### PR TITLE
Rust: Query for uncontrolled allocation size

### DIFF
--- a/rust/ql/lib/codeql/rust/frameworks/libc.model.yml
+++ b/rust/ql/lib/codeql/rust/frameworks/libc.model.yml
@@ -1,0 +1,9 @@
+extensions:
+  - addsTo:
+      pack: codeql/rust-all
+      extensible: sinkModel
+    data:
+      - ["repo:https://github.com/rust-lang/libc:libc", "::malloc", "Argument[0]", "alloc-size", "manual"]
+      - ["repo:https://github.com/rust-lang/libc:libc", "::aligned_alloc", "Argument[1]", "alloc-size", "manual"]
+      - ["repo:https://github.com/rust-lang/libc:libc", "::calloc", "Argument[0,1]", "alloc-size", "manual"]
+      - ["repo:https://github.com/rust-lang/libc:libc", "::realloc", "Argument[1]", "alloc-size", "manual"]

--- a/rust/ql/lib/codeql/rust/frameworks/stdlib/lang-alloc.model.yml
+++ b/rust/ql/lib/codeql/rust/frameworks/stdlib/lang-alloc.model.yml
@@ -19,7 +19,3 @@ extensions:
       - ["lang:alloc", "<crate::alloc::Global as crate::alloc::Allocator>::allocate_zeroed", "Argument[0]", "alloc-layout", "manual"]
       - ["lang:alloc", "<crate::alloc::Global as crate::alloc::Allocator>::grow", "Argument[2]", "alloc-layout", "manual"]
       - ["lang:alloc", "<crate::alloc::Global as crate::alloc::Allocator>::grow_zeroed", "Argument[2]", "alloc-layout", "manual"]
-      - ["repo:https://github.com/rust-lang/libc:libc", "::malloc", "Argument[0]", "alloc-size", "manual"]
-      - ["repo:https://github.com/rust-lang/libc:libc", "::aligned_alloc", "Argument[1]", "alloc-size", "manual"]
-      - ["repo:https://github.com/rust-lang/libc:libc", "::calloc", "Argument[0,1]", "alloc-size", "manual"]
-      - ["repo:https://github.com/rust-lang/libc:libc", "::realloc", "Argument[1]", "alloc-size", "manual"]

--- a/rust/ql/lib/codeql/rust/frameworks/stdlib/lang-alloc.model.yml
+++ b/rust/ql/lib/codeql/rust/frameworks/stdlib/lang-alloc.model.yml
@@ -1,0 +1,25 @@
+extensions:
+  - addsTo:
+      pack: codeql/rust-all
+      extensible: sinkModel
+    data:
+      # Alloc
+      - ["lang:alloc", "crate::alloc::alloc", "Argument[0]", "alloc-layout", "manual"]
+      - ["lang:alloc", "crate::alloc::alloc_zeroed", "Argument[0]", "alloc-layout", "manual"]
+      - ["lang:alloc", "crate::alloc::realloc", "Argument[2]", "alloc-size", "manual"]
+      - ["lang:std", "<crate::alloc::System as crate::alloc::global::GlobalAlloc>::alloc", "Argument[0]", "alloc-layout", "manual"]
+      - ["lang:std", "<crate::alloc::System as crate::alloc::global::GlobalAlloc>::alloc_zeroed", "Argument[0]", "alloc-layout", "manual"]
+      - ["lang:std", "<crate::alloc::System as crate::alloc::Allocator>::allocate", "Argument[0]", "alloc-layout", "manual"]
+      - ["lang:std", "<crate::alloc::System as crate::alloc::Allocator>::allocate_zeroed", "Argument[0]", "alloc-layout", "manual"]
+      - ["lang:std", "<crate::alloc::System as crate::alloc::Allocator>::grow", "Argument[2]", "alloc-layout", "manual"]
+      - ["lang:std", "<crate::alloc::System as crate::alloc::Allocator>::grow_zeroed", "Argument[2]", "alloc-layout", "manual"]
+      - ["lang:alloc", "<crate::alloc::Global as crate::alloc::global::GlobalAlloc>::alloc", "Argument[0]", "alloc-layout", "manual"]
+      - ["lang:alloc", "<crate::alloc::Global as crate::alloc::global::GlobalAlloc>::alloc_zeroed", "Argument[0]", "alloc-layout", "manual"]
+      - ["lang:alloc", "<crate::alloc::Global as crate::alloc::Allocator>::allocate", "Argument[0]", "alloc-layout", "manual"]
+      - ["lang:alloc", "<crate::alloc::Global as crate::alloc::Allocator>::allocate_zeroed", "Argument[0]", "alloc-layout", "manual"]
+      - ["lang:alloc", "<crate::alloc::Global as crate::alloc::Allocator>::grow", "Argument[2]", "alloc-layout", "manual"]
+      - ["lang:alloc", "<crate::alloc::Global as crate::alloc::Allocator>::grow_zeroed", "Argument[2]", "alloc-layout", "manual"]
+      - ["repo:https://github.com/rust-lang/libc:libc", "::malloc", "Argument[0]", "alloc-size", "manual"]
+      - ["repo:https://github.com/rust-lang/libc:libc", "::aligned_alloc", "Argument[1]", "alloc-size", "manual"]
+      - ["repo:https://github.com/rust-lang/libc:libc", "::calloc", "Argument[0,1]", "alloc-size", "manual"]
+      - ["repo:https://github.com/rust-lang/libc:libc", "::realloc", "Argument[1]", "alloc-size", "manual"]

--- a/rust/ql/lib/codeql/rust/frameworks/stdlib/lang-core.model.yml
+++ b/rust/ql/lib/codeql/rust/frameworks/stdlib/lang-core.model.yml
@@ -31,6 +31,9 @@ extensions:
       - ["lang:core", "<crate::alloc::layout::Layout>::extend", "Argument[0]", "ReturnValue.Field[crate::result::Result::Ok(0)].Field[0]", "taint", "manual"]
       - ["lang:core", "<crate::alloc::layout::Layout>::extend_packed", "Argument[self]", "ReturnValue.Field[crate::result::Result::Ok(0)]", "taint", "manual"]
       - ["lang:core", "<crate::alloc::layout::Layout>::extend_packed", "Argument[0]", "ReturnValue.Field[crate::result::Result::Ok(0)]", "taint", "manual"]
+      - ["lang:core", "<crate::alloc::layout::Layout>::align_to", "Argument[self]", "ReturnValue.Field[crate::result::Result::Ok(0)]", "taint", "manual"]
+      - ["lang:core", "<crate::alloc::layout::Layout>::pad_to_align", "Argument[self]", "ReturnValue", "taint", "manual"]
+      - ["lang:core", "<crate::alloc::layout::Layout>::size", "Argument[self]", "ReturnValue", "taint", "manual"]
       # Ptr
       - ["lang:core", "crate::ptr::read", "Argument[0].Reference", "ReturnValue", "value", "manual"]
       - ["lang:core", "crate::ptr::read_unaligned", "Argument[0].Reference", "ReturnValue", "value", "manual"]

--- a/rust/ql/lib/codeql/rust/frameworks/stdlib/lang-core.model.yml
+++ b/rust/ql/lib/codeql/rust/frameworks/stdlib/lang-core.model.yml
@@ -19,7 +19,19 @@ extensions:
       - ["lang:core", "<crate::slice::iter::Iter as crate::iter::traits::iterator::Iterator>::collect", "Argument[self].Element", "ReturnValue.Element", "value", "manual"]
       - ["lang:core", "<crate::slice::iter::Iter as crate::iter::traits::iterator::Iterator>::map", "Argument[self].Element", "Argument[0].Parameter[0]", "value", "manual"]
       - ["lang:core", "<crate::slice::iter::Iter as crate::iter::traits::iterator::Iterator>::for_each", "Argument[self].Element", "Argument[0].Parameter[0]", "value", "manual"]
-      # ptr
+      # Layout
+      - ["lang:core", "<crate::alloc::layout::Layout>::from_size_align", "Argument[0]", "ReturnValue.Field[crate::result::Result::Ok(0)]", "taint", "manual"]
+      - ["lang:core", "<crate::alloc::layout::Layout>::from_size_align_unchecked", "Argument[0]", "ReturnValue", "taint", "manual"]
+      - ["lang:core", "<crate::alloc::layout::Layout>::array", "Argument[0]", "ReturnValue.Field[crate::result::Result::Ok(0)]", "taint", "manual"]
+      - ["lang:core", "<crate::alloc::layout::Layout>::repeat", "Argument[self]", "ReturnValue.Field[crate::result::Result::Ok(0)].Field[0]", "taint", "manual"]
+      - ["lang:core", "<crate::alloc::layout::Layout>::repeat", "Argument[0]", "ReturnValue.Field[crate::result::Result::Ok(0)].Field[0]", "taint", "manual"]
+      - ["lang:core", "<crate::alloc::layout::Layout>::repeat_packed", "Argument[self]", "ReturnValue.Field[crate::result::Result::Ok(0)]", "taint", "manual"]
+      - ["lang:core", "<crate::alloc::layout::Layout>::repeat_packed", "Argument[0]", "ReturnValue.Field[crate::result::Result::Ok(0)]", "taint", "manual"]
+      - ["lang:core", "<crate::alloc::layout::Layout>::extend", "Argument[self]", "ReturnValue.Field[crate::result::Result::Ok(0)].Field[0]", "taint", "manual"]
+      - ["lang:core", "<crate::alloc::layout::Layout>::extend", "Argument[0]", "ReturnValue.Field[crate::result::Result::Ok(0)].Field[0]", "taint", "manual"]
+      - ["lang:core", "<crate::alloc::layout::Layout>::extend_packed", "Argument[self]", "ReturnValue.Field[crate::result::Result::Ok(0)]", "taint", "manual"]
+      - ["lang:core", "<crate::alloc::layout::Layout>::extend_packed", "Argument[0]", "ReturnValue.Field[crate::result::Result::Ok(0)]", "taint", "manual"]
+      # Ptr
       - ["lang:core", "crate::ptr::read", "Argument[0].Reference", "ReturnValue", "value", "manual"]
       - ["lang:core", "crate::ptr::read_unaligned", "Argument[0].Reference", "ReturnValue", "value", "manual"]
       - ["lang:core", "crate::ptr::read_volatile", "Argument[0].Reference", "ReturnValue", "value", "manual"]

--- a/rust/ql/lib/codeql/rust/security/UncontrolledAllocationSizeExtensions.qll
+++ b/rust/ql/lib/codeql/rust/security/UncontrolledAllocationSizeExtensions.qll
@@ -1,0 +1,34 @@
+/**
+ * Provides classes and predicates for reasoning about uncontrolled allocation
+ * size vulnerabilities.
+ */
+
+import rust
+private import codeql.rust.Concepts
+private import codeql.rust.dataflow.DataFlow
+private import codeql.rust.dataflow.FlowSink
+
+/**
+ * Provides default sources, sinks and barriers for detecting uncontrolled
+ * allocation size vulnerabilities, as well as extension points for adding your own.
+ */
+module UncontrolledAllocationSize {
+  /**
+   * A data flow sink for uncontrolled allocation size vulnerabilities.
+   */
+  abstract class Sink extends QuerySink::Range {
+    override string getSinkType() { result = "UncontrolledAllocationSize" }
+  }
+
+  /**
+   * A barrier for uncontrolled allocation size vulnerabilities.
+   */
+  abstract class Barrier extends DataFlow::Node { }
+
+  /**
+   *  sink for uncontrolled allocation size from model data.
+   */
+  private class ModelsAsDataSink extends Sink {
+    ModelsAsDataSink() { sinkNode(this, ["alloc-size", "alloc-layout"]) }
+  }
+}

--- a/rust/ql/lib/codeql/rust/security/UncontrolledAllocationSizeExtensions.qll
+++ b/rust/ql/lib/codeql/rust/security/UncontrolledAllocationSizeExtensions.qll
@@ -7,6 +7,8 @@ import rust
 private import codeql.rust.Concepts
 private import codeql.rust.dataflow.DataFlow
 private import codeql.rust.dataflow.FlowSink
+private import codeql.rust.controlflow.ControlFlowGraph as Cfg
+private import codeql.rust.controlflow.CfgNodes as CfgNodes
 
 /**
  * Provides default sources, sinks and barriers for detecting uncontrolled
@@ -26,9 +28,25 @@ module UncontrolledAllocationSize {
   abstract class Barrier extends DataFlow::Node { }
 
   /**
-   *  sink for uncontrolled allocation size from model data.
+   * A sink for uncontrolled allocation size from model data.
    */
   private class ModelsAsDataSink extends Sink {
     ModelsAsDataSink() { sinkNode(this, ["alloc-size", "alloc-layout"]) }
+  }
+
+  /**
+   * A barrier for uncontrolled allocation size that is an guard / bound check.
+   */
+  private class BoundCheckBarrier extends Barrier {
+    BoundCheckBarrier() { this = DataFlow::BarrierGuard<isBoundCheck/3>::getABarrierNode() }
+  }
+
+  private predicate isBoundCheck(CfgNodes::AstCfgNode g, Cfg::CfgNode node, boolean branch) {
+    // any comparison (`g` / `cmp`) guards the expression on either side (`node`)
+    exists(BinaryExpr cmp |
+      g = cmp.getACfgNode() and
+      [cmp.getLhs(), cmp.getRhs()].getACfgNode() = node and
+      branch = [true, false]
+    )
   }
 }

--- a/rust/ql/src/queries/security/CWE-770/UncontrolledAllocationSize.qhelp
+++ b/rust/ql/src/queries/security/CWE-770/UncontrolledAllocationSize.qhelp
@@ -1,0 +1,41 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+<overview>
+
+<p>Allocating memory with a size based on user input may allow arbitrary amounts of memory to be
+allocated, leading to a crash or denial of service incident.</p>
+
+<p>If the user input is multiplied by a constant, such as the size of a type, the result may
+overflow. In a build with the <code>--release</code> flag Rust performs two's complement wrapping,
+with the result that less memory may be allocated than expected. This can lead to buffer overflow
+incidents.</p>
+
+</overview>
+<recommendation>
+
+<p>Implement a guard to limit the amount of memory that is allocated, and reject the request if
+the guard is not met. Ensure that any multiplications in the calculation cannot overflow, either
+by guarding their inputs, or using a multiplication routine such as <code>checked_mul</code> that
+does not wrap around.</p>
+
+</recommendation>
+<example>
+
+<p>In the following example, an arbitrary amount of memory is allocated based on user input. In
+addition, due to the multiplication operation the result may overflow if a very large value is
+provided, leading to less memory being allocated than other parts of the program expect.</p>
+<sample src="UncontrolledAllocationSizeBad.rs" />
+
+<p>In the fixed example, the user input is checked against a maximum value. If the check fails an
+error is returned, and both the multiplication and alloaction do not take place.</p>
+<sample src="UncontrolledAllocationSizeGood.rs" />
+
+</example>
+<references>
+
+<li>The Rust Programming Language: <a href="https://doc.rust-lang.org/book/ch03-02-data-types.html#integer-overflow">Data Types - Integer Overflow</a>.</li>
+
+</references>
+</qhelp>

--- a/rust/ql/src/queries/security/CWE-770/UncontrolledAllocationSize.ql
+++ b/rust/ql/src/queries/security/CWE-770/UncontrolledAllocationSize.ql
@@ -1,0 +1,44 @@
+/**
+ * @name Uncontrolled allocation size
+ * @description Allocating memory with a size controlled by an external user can result in
+ *              arbitrary amounts of memory being allocated.
+ * @kind path-problem
+ * @problem.severity recommendation
+ * @security-severity 7.5
+ * @precision high
+ * @id rust/uncontrolled-allocation-size
+ * @tags reliability
+ *       security
+ *       external/cwe/cwe-770
+ *       external/cwe/cwe-789
+ */
+
+import rust
+import codeql.rust.Concepts
+import codeql.rust.dataflow.DataFlow
+import codeql.rust.dataflow.TaintTracking
+import codeql.rust.dataflow.internal.DataFlowImpl
+import codeql.rust.security.UncontrolledAllocationSizeExtensions
+
+/**
+ * A taint-tracking configuration for uncontrolled allocation size vulnerabilities.
+ */
+module UncontrolledAllocationConfig implements DataFlow::ConfigSig {
+  import UncontrolledAllocationSize
+
+  predicate isSource(DataFlow::Node source) { source instanceof ActiveThreatModelSource }
+
+  predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
+
+  predicate isBarrier(DataFlow::Node barrier) { barrier instanceof Barrier }
+}
+
+module UncontrolledAllocationFlow = TaintTracking::Global<UncontrolledAllocationConfig>;
+
+import UncontrolledAllocationFlow::PathGraph
+
+from UncontrolledAllocationFlow::PathNode source, UncontrolledAllocationFlow::PathNode sink
+where UncontrolledAllocationFlow::flowPath(source, sink)
+select sink.getNode(), source, sink,
+  "This allocation size is derived from a $@ and could allocate arbitrary amounts of memory.",
+  source.getNode(), "user-provided value"

--- a/rust/ql/src/queries/security/CWE-770/UncontrolledAllocationSizeBad.rs
+++ b/rust/ql/src/queries/security/CWE-770/UncontrolledAllocationSizeBad.rs
@@ -1,0 +1,11 @@
+
+fn allocate_buffer(user_input: String) -> Result<*mut u8, Error> {
+    let num_bytes = user_input.parse::<usize>()? * std::mem::size_of::<u64>();
+
+    let layout = std::alloc::Layout::from_size_align(num_bytes, 1).unwrap();
+    unsafe {
+        let buffer = std::alloc::alloc(layout); // BAD: uncontrolled allocation size
+
+        Ok(buffer)
+    }
+}

--- a/rust/ql/src/queries/security/CWE-770/UncontrolledAllocationSizeGood.rs
+++ b/rust/ql/src/queries/security/CWE-770/UncontrolledAllocationSizeGood.rs
@@ -1,0 +1,17 @@
+
+const BUFFER_LIMIT: usize = 10 * 1024;
+
+fn allocate_buffer(user_input: String) -> Result<*mut u8, Error> {
+    let size = user_input.parse::<usize>()?;
+    if (size > BUFFER_LIMIT) {
+        return Err("Size exceeds limit".into());
+    }
+    let num_bytes = size * std::mem::size_of::<u64>();
+
+    let layout = std::alloc::Layout::from_size_align(num_bytes, 1).unwrap();
+    unsafe {
+        let buffer = std::alloc::alloc(layout); // GOOD
+
+        Ok(buffer)
+    }
+}

--- a/rust/ql/src/queries/summary/Stats.qll
+++ b/rust/ql/src/queries/summary/Stats.qll
@@ -15,6 +15,7 @@ private import codeql.rust.Concepts
 private import codeql.rust.security.CleartextLoggingExtensions
 private import codeql.rust.security.SqlInjectionExtensions
 private import codeql.rust.security.WeakSensitiveDataHashingExtensions
+private import codeql.rust.security.UncontrolledAllocationSizeExtensions
 private import codeql.rust.security.regex.RegexInjectionExtensions
 
 /**

--- a/rust/ql/test/query-tests/diagnostics/SummaryStats.expected
+++ b/rust/ql/test/query-tests/diagnostics/SummaryStats.expected
@@ -15,7 +15,7 @@
 | Macro calls - resolved | 8 |
 | Macro calls - total | 9 |
 | Macro calls - unresolved | 1 |
-| Taint edges - number of edges | 1674 |
+| Taint edges - number of edges | 1675 |
 | Taint reach - nodes tainted | 0 |
 | Taint reach - per million nodes | 0 |
 | Taint sinks - cryptographic operations | 0 |

--- a/rust/ql/test/query-tests/diagnostics/SummaryStats.expected
+++ b/rust/ql/test/query-tests/diagnostics/SummaryStats.expected
@@ -15,7 +15,7 @@
 | Macro calls - resolved | 8 |
 | Macro calls - total | 9 |
 | Macro calls - unresolved | 1 |
-| Taint edges - number of edges | 1675 |
+| Taint edges - number of edges | 1677 |
 | Taint reach - nodes tainted | 0 |
 | Taint reach - per million nodes | 0 |
 | Taint sinks - cryptographic operations | 0 |

--- a/rust/ql/test/query-tests/security/CWE-770/UncontrolledAllocationSize.expected
+++ b/rust/ql/test/query-tests/security/CWE-770/UncontrolledAllocationSize.expected
@@ -1,54 +1,66 @@
 #select
-| main.rs:18:13:18:31 | ...::realloc | main.rs:262:13:262:26 | ...::args | main.rs:18:13:18:31 | ...::realloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
-| main.rs:21:13:21:29 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:21:13:21:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
-| main.rs:22:13:22:29 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:22:13:22:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
-| main.rs:23:13:23:29 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:23:13:23:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
-| main.rs:24:13:24:36 | ...::alloc_zeroed | main.rs:262:13:262:26 | ...::args | main.rs:24:13:24:36 | ...::alloc_zeroed | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
-| main.rs:30:13:30:29 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:30:13:30:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
-| main.rs:33:13:33:29 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:33:13:33:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
-| main.rs:37:13:37:29 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:37:13:37:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
-| main.rs:40:13:40:29 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:40:13:40:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
-| main.rs:50:13:50:29 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:50:13:50:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
-| main.rs:51:13:51:29 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:51:13:51:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
-| main.rs:53:13:53:29 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:53:13:53:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
-| main.rs:54:13:54:29 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:54:13:54:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
-| main.rs:59:13:59:29 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:59:13:59:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
-| main.rs:61:13:61:29 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:61:13:61:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
-| main.rs:63:13:63:29 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:63:13:63:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
-| main.rs:64:13:64:29 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:64:13:64:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
-| main.rs:65:13:65:29 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:65:13:65:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
-| main.rs:68:13:68:29 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:68:13:68:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
-| main.rs:85:17:85:33 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:85:17:85:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
-| main.rs:87:17:87:33 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:87:17:87:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
-| main.rs:91:17:91:33 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:91:17:91:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
-| main.rs:93:17:93:33 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:93:17:93:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
-| main.rs:104:17:104:33 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:104:17:104:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
-| main.rs:107:17:107:33 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:107:17:107:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
-| main.rs:111:13:111:29 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:111:13:111:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
-| main.rs:114:13:114:29 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:114:13:114:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
-| main.rs:117:13:117:29 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:117:13:117:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
-| main.rs:119:13:119:29 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:119:13:119:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
-| main.rs:123:13:123:29 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:123:13:123:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
-| main.rs:138:32:138:36 | alloc | main.rs:262:13:262:26 | ...::args | main.rs:138:32:138:36 | alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
-| main.rs:139:32:139:43 | alloc_zeroed | main.rs:262:13:262:26 | ...::args | main.rs:139:32:139:43 | alloc_zeroed | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
-| main.rs:140:32:140:39 | allocate | main.rs:262:13:262:26 | ...::args | main.rs:140:32:140:39 | allocate | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
-| main.rs:141:32:141:46 | allocate_zeroed | main.rs:262:13:262:26 | ...::args | main.rs:141:32:141:46 | allocate_zeroed | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
-| main.rs:142:32:142:39 | allocate | main.rs:262:13:262:26 | ...::args | main.rs:142:32:142:39 | allocate | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
-| main.rs:143:32:143:46 | allocate_zeroed | main.rs:262:13:262:26 | ...::args | main.rs:143:32:143:46 | allocate_zeroed | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
-| main.rs:153:40:153:43 | grow | main.rs:262:13:262:26 | ...::args | main.rs:153:40:153:43 | grow | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
-| main.rs:155:40:155:50 | grow_zeroed | main.rs:262:13:262:26 | ...::args | main.rs:155:40:155:50 | grow_zeroed | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
-| main.rs:164:13:164:24 | ...::malloc | main.rs:262:13:262:26 | ...::args | main.rs:164:13:164:24 | ...::malloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
-| main.rs:164:13:164:24 | ...::malloc | main.rs:262:13:262:26 | ...::args | main.rs:164:13:164:24 | ...::malloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
-| main.rs:165:13:165:31 | ...::aligned_alloc | main.rs:262:13:262:26 | ...::args | main.rs:165:13:165:31 | ...::aligned_alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
-| main.rs:165:13:165:31 | ...::aligned_alloc | main.rs:262:13:262:26 | ...::args | main.rs:165:13:165:31 | ...::aligned_alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
-| main.rs:167:13:167:24 | ...::calloc | main.rs:262:13:262:26 | ...::args | main.rs:167:13:167:24 | ...::calloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
-| main.rs:167:13:167:24 | ...::calloc | main.rs:262:13:262:26 | ...::args | main.rs:167:13:167:24 | ...::calloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
-| main.rs:168:13:168:24 | ...::calloc | main.rs:262:13:262:26 | ...::args | main.rs:168:13:168:24 | ...::calloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
-| main.rs:168:13:168:24 | ...::calloc | main.rs:262:13:262:26 | ...::args | main.rs:168:13:168:24 | ...::calloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
-| main.rs:169:13:169:25 | ...::realloc | main.rs:262:13:262:26 | ...::args | main.rs:169:13:169:25 | ...::realloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
-| main.rs:169:13:169:25 | ...::realloc | main.rs:262:13:262:26 | ...::args | main.rs:169:13:169:25 | ...::realloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
-| main.rs:229:22:229:38 | ...::alloc | main.rs:253:25:253:38 | ...::args | main.rs:229:22:229:38 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:253:25:253:38 | ...::args | user-provided value |
-| main.rs:246:22:246:38 | ...::alloc | main.rs:254:26:254:39 | ...::args | main.rs:246:22:246:38 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:254:26:254:39 | ...::args | user-provided value |
+| main.rs:18:13:18:31 | ...::realloc | main.rs:317:13:317:26 | ...::args | main.rs:18:13:18:31 | ...::realloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:21:13:21:29 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:21:13:21:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:22:13:22:29 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:22:13:22:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:23:13:23:29 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:23:13:23:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:24:13:24:36 | ...::alloc_zeroed | main.rs:317:13:317:26 | ...::args | main.rs:24:13:24:36 | ...::alloc_zeroed | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:30:13:30:29 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:30:13:30:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:33:13:33:29 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:33:13:33:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:37:13:37:29 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:37:13:37:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:40:13:40:29 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:40:13:40:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:50:13:50:29 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:50:13:50:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:51:13:51:29 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:51:13:51:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:53:13:53:29 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:53:13:53:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:54:13:54:29 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:54:13:54:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:59:13:59:29 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:59:13:59:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:61:13:61:29 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:61:13:61:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:63:13:63:29 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:63:13:63:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:64:13:64:29 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:64:13:64:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:65:13:65:29 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:65:13:65:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:68:13:68:29 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:68:13:68:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:83:13:83:29 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:83:13:83:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:88:13:88:29 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:88:13:88:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:96:17:96:33 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:96:17:96:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:97:17:97:33 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:97:17:97:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:102:17:102:33 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:102:17:102:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:103:17:103:33 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:103:17:103:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:109:17:109:33 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:109:17:109:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:111:17:111:33 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:111:17:111:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:116:17:116:33 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:116:17:116:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:121:17:121:33 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:121:17:121:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:126:17:126:33 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:126:17:126:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:135:13:135:29 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:135:13:135:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:146:17:146:33 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:146:17:146:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:147:17:147:33 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:147:17:147:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:148:17:148:33 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:148:17:148:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:152:13:152:29 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:152:13:152:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:155:13:155:29 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:155:13:155:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:158:13:158:29 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:158:13:158:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:162:17:162:33 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:162:17:162:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:169:17:169:33 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:169:17:169:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:170:17:170:33 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:170:17:170:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:177:13:177:29 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:177:13:177:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:178:13:178:29 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:178:13:178:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:193:32:193:36 | alloc | main.rs:317:13:317:26 | ...::args | main.rs:193:32:193:36 | alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:194:32:194:43 | alloc_zeroed | main.rs:317:13:317:26 | ...::args | main.rs:194:32:194:43 | alloc_zeroed | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:195:32:195:39 | allocate | main.rs:317:13:317:26 | ...::args | main.rs:195:32:195:39 | allocate | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:196:32:196:46 | allocate_zeroed | main.rs:317:13:317:26 | ...::args | main.rs:196:32:196:46 | allocate_zeroed | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:197:32:197:39 | allocate | main.rs:317:13:317:26 | ...::args | main.rs:197:32:197:39 | allocate | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:198:32:198:46 | allocate_zeroed | main.rs:317:13:317:26 | ...::args | main.rs:198:32:198:46 | allocate_zeroed | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:208:40:208:43 | grow | main.rs:317:13:317:26 | ...::args | main.rs:208:40:208:43 | grow | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:210:40:210:50 | grow_zeroed | main.rs:317:13:317:26 | ...::args | main.rs:210:40:210:50 | grow_zeroed | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:219:13:219:24 | ...::malloc | main.rs:317:13:317:26 | ...::args | main.rs:219:13:219:24 | ...::malloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:219:13:219:24 | ...::malloc | main.rs:317:13:317:26 | ...::args | main.rs:219:13:219:24 | ...::malloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:220:13:220:31 | ...::aligned_alloc | main.rs:317:13:317:26 | ...::args | main.rs:220:13:220:31 | ...::aligned_alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:220:13:220:31 | ...::aligned_alloc | main.rs:317:13:317:26 | ...::args | main.rs:220:13:220:31 | ...::aligned_alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:222:13:222:24 | ...::calloc | main.rs:317:13:317:26 | ...::args | main.rs:222:13:222:24 | ...::calloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:222:13:222:24 | ...::calloc | main.rs:317:13:317:26 | ...::args | main.rs:222:13:222:24 | ...::calloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:223:13:223:24 | ...::calloc | main.rs:317:13:317:26 | ...::args | main.rs:223:13:223:24 | ...::calloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:223:13:223:24 | ...::calloc | main.rs:317:13:317:26 | ...::args | main.rs:223:13:223:24 | ...::calloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:224:13:224:25 | ...::realloc | main.rs:317:13:317:26 | ...::args | main.rs:224:13:224:25 | ...::realloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:224:13:224:25 | ...::realloc | main.rs:317:13:317:26 | ...::args | main.rs:224:13:224:25 | ...::realloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:284:22:284:38 | ...::alloc | main.rs:308:25:308:38 | ...::args | main.rs:284:22:284:38 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:308:25:308:38 | ...::args | user-provided value |
+| main.rs:301:22:301:38 | ...::alloc | main.rs:309:26:309:39 | ...::args | main.rs:301:22:301:38 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:309:26:309:39 | ...::args | user-provided value |
 edges
 | main.rs:12:36:12:43 | ...: usize | main.rs:18:41:18:41 | v | provenance |  |
 | main.rs:18:41:18:41 | v | main.rs:18:13:18:31 | ...::realloc | provenance | MaD:5 Sink:MaD:5 |
@@ -140,138 +152,210 @@ edges
 | main.rs:67:46:67:46 | v | main.rs:67:14:67:47 | ...::array::<...>(...) [Ok] | provenance | MaD:18 |
 | main.rs:68:31:68:32 | l4 | main.rs:68:13:68:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
 | main.rs:71:35:71:38 | ...: T | main.rs:77:9:77:16 | return v | provenance |  |
-| main.rs:81:38:81:45 | ...: usize | main.rs:82:47:82:47 | v | provenance |  |
-| main.rs:81:38:81:45 | ...: usize | main.rs:97:13:97:21 | mut v_mut | provenance |  |
-| main.rs:81:38:81:45 | ...: usize | main.rs:106:51:106:51 | v | provenance |  |
-| main.rs:81:38:81:45 | ...: usize | main.rs:110:61:110:61 | v | provenance |  |
-| main.rs:81:38:81:45 | ...: usize | main.rs:113:61:113:61 | v | provenance |  |
-| main.rs:81:38:81:45 | ...: usize | main.rs:116:53:116:53 | v | provenance |  |
-| main.rs:82:9:82:10 | l1 | main.rs:85:35:85:36 | l1 | provenance |  |
-| main.rs:82:9:82:10 | l1 | main.rs:87:35:87:36 | l1 | provenance |  |
-| main.rs:82:14:82:48 | ...::array::<...>(...) [Ok] | main.rs:82:14:82:57 | ... .unwrap(...) | provenance | MaD:31 |
-| main.rs:82:14:82:57 | ... .unwrap(...) | main.rs:82:9:82:10 | l1 | provenance |  |
-| main.rs:82:47:82:47 | v | main.rs:82:14:82:48 | ...::array::<...>(...) [Ok] | provenance | MaD:18 |
-| main.rs:85:35:85:36 | l1 | main.rs:85:17:85:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
-| main.rs:85:35:85:36 | l1 | main.rs:91:35:91:36 | l1 | provenance |  |
-| main.rs:85:35:85:36 | l1 | main.rs:93:35:93:36 | l1 | provenance |  |
-| main.rs:87:35:87:36 | l1 | main.rs:87:17:87:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
-| main.rs:87:35:87:36 | l1 | main.rs:91:35:91:36 | l1 | provenance |  |
-| main.rs:87:35:87:36 | l1 | main.rs:93:35:93:36 | l1 | provenance |  |
-| main.rs:91:35:91:36 | l1 | main.rs:91:17:91:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
-| main.rs:91:35:91:36 | l1 | main.rs:119:31:119:32 | l1 | provenance |  |
-| main.rs:93:35:93:36 | l1 | main.rs:93:17:93:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
-| main.rs:93:35:93:36 | l1 | main.rs:119:31:119:32 | l1 | provenance |  |
-| main.rs:97:13:97:21 | mut v_mut | main.rs:103:51:103:55 | v_mut | provenance |  |
-| main.rs:103:13:103:14 | l2 | main.rs:104:35:104:36 | l2 | provenance |  |
-| main.rs:103:18:103:56 | ...::array::<...>(...) [Ok] | main.rs:103:18:103:65 | ... .unwrap(...) | provenance | MaD:31 |
-| main.rs:103:18:103:65 | ... .unwrap(...) | main.rs:103:13:103:14 | l2 | provenance |  |
-| main.rs:103:51:103:55 | v_mut | main.rs:103:18:103:56 | ...::array::<...>(...) [Ok] | provenance | MaD:18 |
-| main.rs:104:35:104:36 | l2 | main.rs:104:17:104:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
-| main.rs:106:13:106:14 | l3 | main.rs:107:35:107:36 | l3 | provenance |  |
-| main.rs:106:18:106:52 | ...::array::<...>(...) [Ok] | main.rs:106:18:106:61 | ... .unwrap(...) | provenance | MaD:31 |
-| main.rs:106:18:106:61 | ... .unwrap(...) | main.rs:106:13:106:14 | l3 | provenance |  |
-| main.rs:106:51:106:51 | v | main.rs:106:18:106:52 | ...::array::<...>(...) [Ok] | provenance | MaD:18 |
-| main.rs:107:35:107:36 | l3 | main.rs:107:17:107:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
-| main.rs:110:9:110:10 | l4 | main.rs:111:31:111:32 | l4 | provenance |  |
-| main.rs:110:14:110:68 | ...::array::<...>(...) [Ok] | main.rs:110:14:110:77 | ... .unwrap(...) | provenance | MaD:31 |
-| main.rs:110:14:110:77 | ... .unwrap(...) | main.rs:110:9:110:10 | l4 | provenance |  |
-| main.rs:110:47:110:67 | ...::min(...) | main.rs:110:14:110:68 | ...::array::<...>(...) [Ok] | provenance | MaD:18 |
-| main.rs:110:61:110:61 | v | main.rs:110:47:110:67 | ...::min(...) | provenance | MaD:34 |
-| main.rs:111:31:111:32 | l4 | main.rs:111:13:111:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
-| main.rs:113:9:113:10 | l5 | main.rs:114:31:114:32 | l5 | provenance |  |
-| main.rs:113:14:113:68 | ...::array::<...>(...) [Ok] | main.rs:113:14:113:77 | ... .unwrap(...) | provenance | MaD:31 |
-| main.rs:113:14:113:77 | ... .unwrap(...) | main.rs:113:9:113:10 | l5 | provenance |  |
-| main.rs:113:47:113:67 | ...::max(...) | main.rs:113:14:113:68 | ...::array::<...>(...) [Ok] | provenance | MaD:18 |
-| main.rs:113:61:113:61 | v | main.rs:113:47:113:67 | ...::max(...) | provenance | MaD:33 |
-| main.rs:114:31:114:32 | l5 | main.rs:114:13:114:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
-| main.rs:116:9:116:10 | l6 | main.rs:117:31:117:32 | l6 | provenance |  |
-| main.rs:116:14:116:63 | ...::array::<...>(...) [Ok] | main.rs:116:14:116:72 | ... .unwrap(...) | provenance | MaD:31 |
-| main.rs:116:14:116:72 | ... .unwrap(...) | main.rs:116:9:116:10 | l6 | provenance |  |
-| main.rs:116:47:116:62 | clamp(...) | main.rs:116:14:116:63 | ...::array::<...>(...) [Ok] | provenance | MaD:18 |
-| main.rs:116:53:116:53 | v | main.rs:71:35:71:38 | ...: T | provenance |  |
-| main.rs:116:53:116:53 | v | main.rs:116:47:116:62 | clamp(...) | provenance |  |
-| main.rs:117:31:117:32 | l6 | main.rs:117:13:117:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
-| main.rs:119:31:119:32 | l1 | main.rs:119:13:119:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
-| main.rs:119:31:119:32 | l1 | main.rs:123:31:123:32 | l1 | provenance |  |
-| main.rs:123:31:123:32 | l1 | main.rs:123:13:123:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
-| main.rs:128:29:128:36 | ...: usize | main.rs:137:46:137:46 | v | provenance |  |
-| main.rs:137:9:137:10 | l2 | main.rs:138:38:138:39 | l2 | provenance |  |
-| main.rs:137:14:137:47 | ...::array::<...>(...) [Ok] | main.rs:137:14:137:56 | ... .unwrap(...) | provenance | MaD:31 |
-| main.rs:137:14:137:56 | ... .unwrap(...) | main.rs:137:9:137:10 | l2 | provenance |  |
-| main.rs:137:46:137:46 | v | main.rs:137:14:137:47 | ...::array::<...>(...) [Ok] | provenance | MaD:18 |
-| main.rs:138:38:138:39 | l2 | main.rs:138:32:138:36 | alloc | provenance | MaD:10 Sink:MaD:10 |
-| main.rs:138:38:138:39 | l2 | main.rs:139:45:139:46 | l2 | provenance |  |
-| main.rs:139:45:139:46 | l2 | main.rs:139:32:139:43 | alloc_zeroed | provenance | MaD:11 Sink:MaD:11 |
-| main.rs:139:45:139:46 | l2 | main.rs:140:41:140:42 | l2 | provenance |  |
-| main.rs:140:41:140:42 | l2 | main.rs:140:32:140:39 | allocate | provenance | MaD:6 Sink:MaD:6 |
-| main.rs:140:41:140:42 | l2 | main.rs:141:48:141:49 | l2 | provenance |  |
-| main.rs:141:48:141:49 | l2 | main.rs:141:32:141:46 | allocate_zeroed | provenance | MaD:7 Sink:MaD:7 |
-| main.rs:141:48:141:49 | l2 | main.rs:142:41:142:42 | l2 | provenance |  |
-| main.rs:142:41:142:42 | l2 | main.rs:142:32:142:39 | allocate | provenance | MaD:1 Sink:MaD:1 |
-| main.rs:142:41:142:42 | l2 | main.rs:143:48:143:49 | l2 | provenance |  |
-| main.rs:143:48:143:49 | l2 | main.rs:143:32:143:46 | allocate_zeroed | provenance | MaD:2 Sink:MaD:2 |
-| main.rs:143:48:143:49 | l2 | main.rs:153:53:153:54 | l2 | provenance |  |
-| main.rs:143:48:143:49 | l2 | main.rs:155:60:155:61 | l2 | provenance |  |
-| main.rs:153:53:153:54 | l2 | main.rs:153:40:153:43 | grow | provenance | MaD:8 Sink:MaD:8 |
-| main.rs:155:60:155:61 | l2 | main.rs:155:40:155:50 | grow_zeroed | provenance | MaD:9 Sink:MaD:9 |
-| main.rs:162:27:162:34 | ...: usize | main.rs:164:26:164:26 | v | provenance |  |
-| main.rs:164:26:164:26 | v | main.rs:164:13:164:24 | ...::malloc | provenance | MaD:14 Sink:MaD:14 |
-| main.rs:164:26:164:26 | v | main.rs:164:13:164:24 | ...::malloc | provenance | MaD:14 Sink:MaD:14 |
-| main.rs:164:26:164:26 | v | main.rs:165:36:165:36 | v | provenance |  |
-| main.rs:165:36:165:36 | v | main.rs:165:13:165:31 | ...::aligned_alloc | provenance | MaD:12 Sink:MaD:12 |
-| main.rs:165:36:165:36 | v | main.rs:165:13:165:31 | ...::aligned_alloc | provenance | MaD:12 Sink:MaD:12 |
-| main.rs:165:36:165:36 | v | main.rs:167:30:167:30 | v | provenance |  |
-| main.rs:167:30:167:30 | v | main.rs:167:13:167:24 | ...::calloc | provenance | MaD:13 Sink:MaD:13 |
-| main.rs:167:30:167:30 | v | main.rs:167:13:167:24 | ...::calloc | provenance | MaD:13 Sink:MaD:13 |
-| main.rs:167:30:167:30 | v | main.rs:168:26:168:26 | v | provenance |  |
-| main.rs:168:26:168:26 | v | main.rs:168:13:168:24 | ...::calloc | provenance | MaD:13 Sink:MaD:13 |
-| main.rs:168:26:168:26 | v | main.rs:168:13:168:24 | ...::calloc | provenance | MaD:13 Sink:MaD:13 |
-| main.rs:168:26:168:26 | v | main.rs:169:31:169:31 | v | provenance |  |
-| main.rs:169:31:169:31 | v | main.rs:169:13:169:25 | ...::realloc | provenance | MaD:15 Sink:MaD:15 |
-| main.rs:169:31:169:31 | v | main.rs:169:13:169:25 | ...::realloc | provenance | MaD:15 Sink:MaD:15 |
-| main.rs:224:24:224:41 | ...: String | main.rs:225:21:225:47 | user_input.parse(...) [Ok] | provenance | MaD:32 |
-| main.rs:225:9:225:17 | num_bytes | main.rs:227:54:227:62 | num_bytes | provenance |  |
-| main.rs:225:21:225:47 | user_input.parse(...) [Ok] | main.rs:225:21:225:48 | TryExpr | provenance |  |
-| main.rs:225:21:225:48 | TryExpr | main.rs:225:9:225:17 | num_bytes | provenance |  |
-| main.rs:227:9:227:14 | layout | main.rs:229:40:229:45 | layout | provenance |  |
-| main.rs:227:18:227:66 | ...::from_size_align(...) [Ok] | main.rs:227:18:227:75 | ... .unwrap(...) | provenance | MaD:31 |
-| main.rs:227:18:227:75 | ... .unwrap(...) | main.rs:227:9:227:14 | layout | provenance |  |
-| main.rs:227:54:227:62 | num_bytes | main.rs:227:18:227:66 | ...::from_size_align(...) [Ok] | provenance | MaD:23 |
-| main.rs:229:40:229:45 | layout | main.rs:229:22:229:38 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
-| main.rs:237:25:237:42 | ...: String | main.rs:238:16:238:42 | user_input.parse(...) [Ok] | provenance | MaD:32 |
-| main.rs:238:9:238:12 | size | main.rs:242:9:242:17 | num_bytes | provenance |  |
-| main.rs:238:16:238:42 | user_input.parse(...) [Ok] | main.rs:238:16:238:43 | TryExpr | provenance |  |
-| main.rs:238:16:238:43 | TryExpr | main.rs:238:9:238:12 | size | provenance |  |
-| main.rs:242:9:242:17 | num_bytes | main.rs:244:54:244:62 | num_bytes | provenance |  |
-| main.rs:244:9:244:14 | layout | main.rs:246:40:246:45 | layout | provenance |  |
-| main.rs:244:18:244:66 | ...::from_size_align(...) [Ok] | main.rs:244:18:244:75 | ... .unwrap(...) | provenance | MaD:31 |
-| main.rs:244:18:244:75 | ... .unwrap(...) | main.rs:244:9:244:14 | layout | provenance |  |
-| main.rs:244:54:244:62 | num_bytes | main.rs:244:18:244:66 | ...::from_size_align(...) [Ok] | provenance | MaD:23 |
-| main.rs:246:40:246:45 | layout | main.rs:246:22:246:38 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
-| main.rs:253:25:253:38 | ...::args | main.rs:253:25:253:40 | ...::args(...) [element] | provenance | Src:MaD:16  |
-| main.rs:253:25:253:40 | ...::args(...) [element] | main.rs:253:25:253:47 | ... .nth(...) [Some] | provenance | MaD:35 |
-| main.rs:253:25:253:47 | ... .nth(...) [Some] | main.rs:253:25:253:74 | ... .unwrap_or(...) | provenance | MaD:29 |
-| main.rs:253:25:253:74 | ... .unwrap_or(...) | main.rs:224:24:224:41 | ...: String | provenance |  |
-| main.rs:254:26:254:39 | ...::args | main.rs:254:26:254:41 | ...::args(...) [element] | provenance | Src:MaD:16  |
-| main.rs:254:26:254:41 | ...::args(...) [element] | main.rs:254:26:254:48 | ... .nth(...) [Some] | provenance | MaD:35 |
-| main.rs:254:26:254:48 | ... .nth(...) [Some] | main.rs:254:26:254:75 | ... .unwrap_or(...) | provenance | MaD:29 |
-| main.rs:254:26:254:75 | ... .unwrap_or(...) | main.rs:237:25:237:42 | ...: String | provenance |  |
-| main.rs:262:9:262:9 | v | main.rs:265:34:265:34 | v | provenance |  |
-| main.rs:262:9:262:9 | v | main.rs:266:42:266:42 | v | provenance |  |
-| main.rs:262:9:262:9 | v | main.rs:267:36:267:36 | v | provenance |  |
-| main.rs:262:9:262:9 | v | main.rs:268:27:268:27 | v | provenance |  |
-| main.rs:262:9:262:9 | v | main.rs:269:25:269:25 | v | provenance |  |
-| main.rs:262:13:262:26 | ...::args | main.rs:262:13:262:28 | ...::args(...) [element] | provenance | Src:MaD:16  |
-| main.rs:262:13:262:28 | ...::args(...) [element] | main.rs:262:13:262:35 | ... .nth(...) [Some] | provenance | MaD:35 |
-| main.rs:262:13:262:35 | ... .nth(...) [Some] | main.rs:262:13:262:65 | ... .unwrap_or(...) | provenance | MaD:29 |
-| main.rs:262:13:262:65 | ... .unwrap_or(...) | main.rs:262:13:262:82 | ... .parse(...) [Ok] | provenance | MaD:32 |
-| main.rs:262:13:262:82 | ... .parse(...) [Ok] | main.rs:262:13:262:91 | ... .unwrap(...) | provenance | MaD:31 |
-| main.rs:262:13:262:91 | ... .unwrap(...) | main.rs:262:9:262:9 | v | provenance |  |
-| main.rs:265:34:265:34 | v | main.rs:12:36:12:43 | ...: usize | provenance |  |
-| main.rs:266:42:266:42 | v | main.rs:43:44:43:51 | ...: usize | provenance |  |
-| main.rs:267:36:267:36 | v | main.rs:81:38:81:45 | ...: usize | provenance |  |
-| main.rs:268:27:268:27 | v | main.rs:128:29:128:36 | ...: usize | provenance |  |
-| main.rs:269:25:269:25 | v | main.rs:162:27:162:34 | ...: usize | provenance |  |
+| main.rs:81:33:81:40 | ...: usize | main.rs:82:54:82:54 | v | provenance |  |
+| main.rs:82:9:82:14 | layout | main.rs:83:31:83:36 | layout | provenance |  |
+| main.rs:82:18:82:58 | ...::from_size_align(...) [Ok] | main.rs:82:18:82:67 | ... .unwrap(...) | provenance | MaD:31 |
+| main.rs:82:18:82:67 | ... .unwrap(...) | main.rs:82:9:82:14 | layout | provenance |  |
+| main.rs:82:54:82:54 | v | main.rs:82:18:82:58 | ...::from_size_align(...) [Ok] | provenance | MaD:23 |
+| main.rs:83:31:83:36 | layout | main.rs:83:13:83:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:86:35:86:42 | ...: usize | main.rs:87:54:87:54 | v | provenance |  |
+| main.rs:87:9:87:14 | layout | main.rs:88:31:88:36 | layout | provenance |  |
+| main.rs:87:18:87:58 | ...::from_size_align(...) [Ok] | main.rs:87:18:87:67 | ... .unwrap(...) | provenance | MaD:31 |
+| main.rs:87:18:87:67 | ... .unwrap(...) | main.rs:87:9:87:14 | layout | provenance |  |
+| main.rs:87:54:87:54 | v | main.rs:87:18:87:58 | ...::from_size_align(...) [Ok] | provenance | MaD:23 |
+| main.rs:88:31:88:36 | layout | main.rs:88:13:88:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:91:38:91:45 | ...: usize | main.rs:92:47:92:47 | v | provenance |  |
+| main.rs:91:38:91:45 | ...: usize | main.rs:95:51:95:51 | v | provenance |  |
+| main.rs:91:38:91:45 | ...: usize | main.rs:99:31:99:31 | v | provenance |  |
+| main.rs:91:38:91:45 | ...: usize | main.rs:101:51:101:51 | v | provenance |  |
+| main.rs:91:38:91:45 | ...: usize | main.rs:105:33:105:33 | v | provenance |  |
+| main.rs:91:38:91:45 | ...: usize | main.rs:115:54:115:54 | v | provenance |  |
+| main.rs:91:38:91:45 | ...: usize | main.rs:120:54:120:54 | v | provenance |  |
+| main.rs:91:38:91:45 | ...: usize | main.rs:125:54:125:54 | v | provenance |  |
+| main.rs:91:38:91:45 | ...: usize | main.rs:131:50:131:50 | v | provenance |  |
+| main.rs:91:38:91:45 | ...: usize | main.rs:138:13:138:21 | mut v_mut | provenance |  |
+| main.rs:91:38:91:45 | ...: usize | main.rs:145:51:145:51 | v | provenance |  |
+| main.rs:91:38:91:45 | ...: usize | main.rs:151:62:151:62 | v | provenance |  |
+| main.rs:91:38:91:45 | ...: usize | main.rs:154:62:154:62 | v | provenance |  |
+| main.rs:91:38:91:45 | ...: usize | main.rs:157:54:157:54 | v | provenance |  |
+| main.rs:91:38:91:45 | ...: usize | main.rs:161:55:161:55 | v | provenance |  |
+| main.rs:91:38:91:45 | ...: usize | main.rs:168:55:168:55 | v | provenance |  |
+| main.rs:91:38:91:45 | ...: usize | main.rs:176:51:176:51 | v | provenance |  |
+| main.rs:92:9:92:10 | l1 | main.rs:96:35:96:36 | l1 | provenance |  |
+| main.rs:92:9:92:10 | l1 | main.rs:102:35:102:36 | l1 | provenance |  |
+| main.rs:92:14:92:48 | ...::array::<...>(...) [Ok] | main.rs:92:14:92:57 | ... .unwrap(...) | provenance | MaD:31 |
+| main.rs:92:14:92:57 | ... .unwrap(...) | main.rs:92:9:92:10 | l1 | provenance |  |
+| main.rs:92:47:92:47 | v | main.rs:92:14:92:48 | ...::array::<...>(...) [Ok] | provenance | MaD:18 |
+| main.rs:95:13:95:14 | l2 | main.rs:97:35:97:36 | l2 | provenance |  |
+| main.rs:95:18:95:52 | ...::array::<...>(...) [Ok] | main.rs:95:18:95:61 | ... .unwrap(...) | provenance | MaD:31 |
+| main.rs:95:18:95:61 | ... .unwrap(...) | main.rs:95:13:95:14 | l2 | provenance |  |
+| main.rs:95:51:95:51 | v | main.rs:95:18:95:52 | ...::array::<...>(...) [Ok] | provenance | MaD:18 |
+| main.rs:96:35:96:36 | l1 | main.rs:96:17:96:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:96:35:96:36 | l1 | main.rs:109:35:109:36 | l1 | provenance |  |
+| main.rs:96:35:96:36 | l1 | main.rs:111:35:111:36 | l1 | provenance |  |
+| main.rs:97:35:97:36 | l2 | main.rs:97:17:97:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:99:31:99:31 | v | main.rs:81:33:81:40 | ...: usize | provenance |  |
+| main.rs:101:13:101:14 | l3 | main.rs:103:35:103:36 | l3 | provenance |  |
+| main.rs:101:18:101:52 | ...::array::<...>(...) [Ok] | main.rs:101:18:101:61 | ... .unwrap(...) | provenance | MaD:31 |
+| main.rs:101:18:101:61 | ... .unwrap(...) | main.rs:101:13:101:14 | l3 | provenance |  |
+| main.rs:101:51:101:51 | v | main.rs:101:18:101:52 | ...::array::<...>(...) [Ok] | provenance | MaD:18 |
+| main.rs:102:35:102:36 | l1 | main.rs:102:17:102:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:102:35:102:36 | l1 | main.rs:109:35:109:36 | l1 | provenance |  |
+| main.rs:102:35:102:36 | l1 | main.rs:111:35:111:36 | l1 | provenance |  |
+| main.rs:103:35:103:36 | l3 | main.rs:103:17:103:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:105:33:105:33 | v | main.rs:86:35:86:42 | ...: usize | provenance |  |
+| main.rs:109:35:109:36 | l1 | main.rs:109:17:109:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:109:35:109:36 | l1 | main.rs:146:35:146:36 | l1 | provenance |  |
+| main.rs:111:35:111:36 | l1 | main.rs:111:17:111:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:111:35:111:36 | l1 | main.rs:146:35:146:36 | l1 | provenance |  |
+| main.rs:115:13:115:14 | l4 | main.rs:116:35:116:36 | l4 | provenance |  |
+| main.rs:115:18:115:58 | ...::from_size_align(...) [Ok] | main.rs:115:18:115:67 | ... .unwrap(...) | provenance | MaD:31 |
+| main.rs:115:18:115:67 | ... .unwrap(...) | main.rs:115:13:115:14 | l4 | provenance |  |
+| main.rs:115:54:115:54 | v | main.rs:115:18:115:58 | ...::from_size_align(...) [Ok] | provenance | MaD:23 |
+| main.rs:116:35:116:36 | l4 | main.rs:116:17:116:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:120:13:120:14 | l5 | main.rs:121:35:121:36 | l5 | provenance |  |
+| main.rs:120:18:120:58 | ...::from_size_align(...) [Ok] | main.rs:120:18:120:67 | ... .unwrap(...) | provenance | MaD:31 |
+| main.rs:120:18:120:67 | ... .unwrap(...) | main.rs:120:13:120:14 | l5 | provenance |  |
+| main.rs:120:54:120:54 | v | main.rs:120:18:120:58 | ...::from_size_align(...) [Ok] | provenance | MaD:23 |
+| main.rs:121:35:121:36 | l5 | main.rs:121:17:121:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:125:13:125:14 | l6 | main.rs:126:35:126:36 | l6 | provenance |  |
+| main.rs:125:18:125:58 | ...::from_size_align(...) [Ok] | main.rs:125:18:125:67 | ... .unwrap(...) | provenance | MaD:31 |
+| main.rs:125:18:125:67 | ... .unwrap(...) | main.rs:125:13:125:14 | l6 | provenance |  |
+| main.rs:125:54:125:54 | v | main.rs:125:18:125:58 | ...::from_size_align(...) [Ok] | provenance | MaD:23 |
+| main.rs:126:35:126:36 | l6 | main.rs:126:17:126:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:131:9:131:10 | l7 | main.rs:135:31:135:32 | l7 | provenance |  |
+| main.rs:131:14:131:54 | ...::from_size_align(...) [Ok] | main.rs:131:14:131:63 | ... .unwrap(...) | provenance | MaD:31 |
+| main.rs:131:14:131:63 | ... .unwrap(...) | main.rs:131:9:131:10 | l7 | provenance |  |
+| main.rs:131:50:131:50 | v | main.rs:131:14:131:54 | ...::from_size_align(...) [Ok] | provenance | MaD:23 |
+| main.rs:135:31:135:32 | l7 | main.rs:135:13:135:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:138:13:138:21 | mut v_mut | main.rs:144:51:144:55 | v_mut | provenance |  |
+| main.rs:144:13:144:14 | l8 | main.rs:147:35:147:36 | l8 | provenance |  |
+| main.rs:144:18:144:56 | ...::array::<...>(...) [Ok] | main.rs:144:18:144:65 | ... .unwrap(...) | provenance | MaD:31 |
+| main.rs:144:18:144:65 | ... .unwrap(...) | main.rs:144:13:144:14 | l8 | provenance |  |
+| main.rs:144:51:144:55 | v_mut | main.rs:144:18:144:56 | ...::array::<...>(...) [Ok] | provenance | MaD:18 |
+| main.rs:145:13:145:14 | l9 | main.rs:148:35:148:36 | l9 | provenance |  |
+| main.rs:145:18:145:52 | ...::array::<...>(...) [Ok] | main.rs:145:18:145:61 | ... .unwrap(...) | provenance | MaD:31 |
+| main.rs:145:18:145:61 | ... .unwrap(...) | main.rs:145:13:145:14 | l9 | provenance |  |
+| main.rs:145:51:145:51 | v | main.rs:145:18:145:52 | ...::array::<...>(...) [Ok] | provenance | MaD:18 |
+| main.rs:146:35:146:36 | l1 | main.rs:146:17:146:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:146:35:146:36 | l1 | main.rs:177:31:177:32 | l1 | provenance |  |
+| main.rs:147:35:147:36 | l8 | main.rs:147:17:147:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:148:35:148:36 | l9 | main.rs:148:17:148:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:151:9:151:11 | l10 | main.rs:152:31:152:33 | l10 | provenance |  |
+| main.rs:151:15:151:69 | ...::array::<...>(...) [Ok] | main.rs:151:15:151:78 | ... .unwrap(...) | provenance | MaD:31 |
+| main.rs:151:15:151:78 | ... .unwrap(...) | main.rs:151:9:151:11 | l10 | provenance |  |
+| main.rs:151:48:151:68 | ...::min(...) | main.rs:151:15:151:69 | ...::array::<...>(...) [Ok] | provenance | MaD:18 |
+| main.rs:151:62:151:62 | v | main.rs:151:48:151:68 | ...::min(...) | provenance | MaD:34 |
+| main.rs:152:31:152:33 | l10 | main.rs:152:13:152:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:154:9:154:11 | l11 | main.rs:155:31:155:33 | l11 | provenance |  |
+| main.rs:154:15:154:69 | ...::array::<...>(...) [Ok] | main.rs:154:15:154:78 | ... .unwrap(...) | provenance | MaD:31 |
+| main.rs:154:15:154:78 | ... .unwrap(...) | main.rs:154:9:154:11 | l11 | provenance |  |
+| main.rs:154:48:154:68 | ...::max(...) | main.rs:154:15:154:69 | ...::array::<...>(...) [Ok] | provenance | MaD:18 |
+| main.rs:154:62:154:62 | v | main.rs:154:48:154:68 | ...::max(...) | provenance | MaD:33 |
+| main.rs:155:31:155:33 | l11 | main.rs:155:13:155:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:157:9:157:11 | l12 | main.rs:158:31:158:33 | l12 | provenance |  |
+| main.rs:157:15:157:64 | ...::array::<...>(...) [Ok] | main.rs:157:15:157:73 | ... .unwrap(...) | provenance | MaD:31 |
+| main.rs:157:15:157:73 | ... .unwrap(...) | main.rs:157:9:157:11 | l12 | provenance |  |
+| main.rs:157:48:157:63 | clamp(...) | main.rs:157:15:157:64 | ...::array::<...>(...) [Ok] | provenance | MaD:18 |
+| main.rs:157:54:157:54 | v | main.rs:71:35:71:38 | ...: T | provenance |  |
+| main.rs:157:54:157:54 | v | main.rs:157:48:157:63 | clamp(...) | provenance |  |
+| main.rs:158:31:158:33 | l12 | main.rs:158:13:158:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:161:13:161:15 | l13 | main.rs:162:35:162:37 | l13 | provenance |  |
+| main.rs:161:19:161:59 | ...::from_size_align(...) [Ok] | main.rs:161:19:161:68 | ... .unwrap(...) | provenance | MaD:31 |
+| main.rs:161:19:161:68 | ... .unwrap(...) | main.rs:161:13:161:15 | l13 | provenance |  |
+| main.rs:161:55:161:55 | v | main.rs:161:19:161:59 | ...::from_size_align(...) [Ok] | provenance | MaD:23 |
+| main.rs:162:35:162:37 | l13 | main.rs:162:17:162:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:162:35:162:37 | l13 | main.rs:169:35:169:37 | l13 | provenance |  |
+| main.rs:168:13:168:15 | l14 | main.rs:170:35:170:37 | l14 | provenance |  |
+| main.rs:168:19:168:59 | ...::from_size_align(...) [Ok] | main.rs:168:19:168:68 | ... .unwrap(...) | provenance | MaD:31 |
+| main.rs:168:19:168:68 | ... .unwrap(...) | main.rs:168:13:168:15 | l14 | provenance |  |
+| main.rs:168:55:168:55 | v | main.rs:168:19:168:59 | ...::from_size_align(...) [Ok] | provenance | MaD:23 |
+| main.rs:169:35:169:37 | l13 | main.rs:169:17:169:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:170:35:170:37 | l14 | main.rs:170:17:170:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:176:9:176:11 | l15 | main.rs:178:31:178:33 | l15 | provenance |  |
+| main.rs:176:15:176:55 | ...::from_size_align(...) [Ok] | main.rs:176:15:176:64 | ... .unwrap(...) | provenance | MaD:31 |
+| main.rs:176:15:176:64 | ... .unwrap(...) | main.rs:176:9:176:11 | l15 | provenance |  |
+| main.rs:176:51:176:51 | v | main.rs:176:15:176:55 | ...::from_size_align(...) [Ok] | provenance | MaD:23 |
+| main.rs:177:31:177:32 | l1 | main.rs:177:13:177:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:178:31:178:33 | l15 | main.rs:178:13:178:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:183:29:183:36 | ...: usize | main.rs:192:46:192:46 | v | provenance |  |
+| main.rs:192:9:192:10 | l2 | main.rs:193:38:193:39 | l2 | provenance |  |
+| main.rs:192:14:192:47 | ...::array::<...>(...) [Ok] | main.rs:192:14:192:56 | ... .unwrap(...) | provenance | MaD:31 |
+| main.rs:192:14:192:56 | ... .unwrap(...) | main.rs:192:9:192:10 | l2 | provenance |  |
+| main.rs:192:46:192:46 | v | main.rs:192:14:192:47 | ...::array::<...>(...) [Ok] | provenance | MaD:18 |
+| main.rs:193:38:193:39 | l2 | main.rs:193:32:193:36 | alloc | provenance | MaD:10 Sink:MaD:10 |
+| main.rs:193:38:193:39 | l2 | main.rs:194:45:194:46 | l2 | provenance |  |
+| main.rs:194:45:194:46 | l2 | main.rs:194:32:194:43 | alloc_zeroed | provenance | MaD:11 Sink:MaD:11 |
+| main.rs:194:45:194:46 | l2 | main.rs:195:41:195:42 | l2 | provenance |  |
+| main.rs:195:41:195:42 | l2 | main.rs:195:32:195:39 | allocate | provenance | MaD:6 Sink:MaD:6 |
+| main.rs:195:41:195:42 | l2 | main.rs:196:48:196:49 | l2 | provenance |  |
+| main.rs:196:48:196:49 | l2 | main.rs:196:32:196:46 | allocate_zeroed | provenance | MaD:7 Sink:MaD:7 |
+| main.rs:196:48:196:49 | l2 | main.rs:197:41:197:42 | l2 | provenance |  |
+| main.rs:197:41:197:42 | l2 | main.rs:197:32:197:39 | allocate | provenance | MaD:1 Sink:MaD:1 |
+| main.rs:197:41:197:42 | l2 | main.rs:198:48:198:49 | l2 | provenance |  |
+| main.rs:198:48:198:49 | l2 | main.rs:198:32:198:46 | allocate_zeroed | provenance | MaD:2 Sink:MaD:2 |
+| main.rs:198:48:198:49 | l2 | main.rs:208:53:208:54 | l2 | provenance |  |
+| main.rs:198:48:198:49 | l2 | main.rs:210:60:210:61 | l2 | provenance |  |
+| main.rs:208:53:208:54 | l2 | main.rs:208:40:208:43 | grow | provenance | MaD:8 Sink:MaD:8 |
+| main.rs:210:60:210:61 | l2 | main.rs:210:40:210:50 | grow_zeroed | provenance | MaD:9 Sink:MaD:9 |
+| main.rs:217:27:217:34 | ...: usize | main.rs:219:26:219:26 | v | provenance |  |
+| main.rs:219:26:219:26 | v | main.rs:219:13:219:24 | ...::malloc | provenance | MaD:14 Sink:MaD:14 |
+| main.rs:219:26:219:26 | v | main.rs:219:13:219:24 | ...::malloc | provenance | MaD:14 Sink:MaD:14 |
+| main.rs:219:26:219:26 | v | main.rs:220:36:220:36 | v | provenance |  |
+| main.rs:220:36:220:36 | v | main.rs:220:13:220:31 | ...::aligned_alloc | provenance | MaD:12 Sink:MaD:12 |
+| main.rs:220:36:220:36 | v | main.rs:220:13:220:31 | ...::aligned_alloc | provenance | MaD:12 Sink:MaD:12 |
+| main.rs:220:36:220:36 | v | main.rs:222:30:222:30 | v | provenance |  |
+| main.rs:222:30:222:30 | v | main.rs:222:13:222:24 | ...::calloc | provenance | MaD:13 Sink:MaD:13 |
+| main.rs:222:30:222:30 | v | main.rs:222:13:222:24 | ...::calloc | provenance | MaD:13 Sink:MaD:13 |
+| main.rs:222:30:222:30 | v | main.rs:223:26:223:26 | v | provenance |  |
+| main.rs:223:26:223:26 | v | main.rs:223:13:223:24 | ...::calloc | provenance | MaD:13 Sink:MaD:13 |
+| main.rs:223:26:223:26 | v | main.rs:223:13:223:24 | ...::calloc | provenance | MaD:13 Sink:MaD:13 |
+| main.rs:223:26:223:26 | v | main.rs:224:31:224:31 | v | provenance |  |
+| main.rs:224:31:224:31 | v | main.rs:224:13:224:25 | ...::realloc | provenance | MaD:15 Sink:MaD:15 |
+| main.rs:224:31:224:31 | v | main.rs:224:13:224:25 | ...::realloc | provenance | MaD:15 Sink:MaD:15 |
+| main.rs:279:24:279:41 | ...: String | main.rs:280:21:280:47 | user_input.parse(...) [Ok] | provenance | MaD:32 |
+| main.rs:280:9:280:17 | num_bytes | main.rs:282:54:282:62 | num_bytes | provenance |  |
+| main.rs:280:21:280:47 | user_input.parse(...) [Ok] | main.rs:280:21:280:48 | TryExpr | provenance |  |
+| main.rs:280:21:280:48 | TryExpr | main.rs:280:9:280:17 | num_bytes | provenance |  |
+| main.rs:282:9:282:14 | layout | main.rs:284:40:284:45 | layout | provenance |  |
+| main.rs:282:18:282:66 | ...::from_size_align(...) [Ok] | main.rs:282:18:282:75 | ... .unwrap(...) | provenance | MaD:31 |
+| main.rs:282:18:282:75 | ... .unwrap(...) | main.rs:282:9:282:14 | layout | provenance |  |
+| main.rs:282:54:282:62 | num_bytes | main.rs:282:18:282:66 | ...::from_size_align(...) [Ok] | provenance | MaD:23 |
+| main.rs:284:40:284:45 | layout | main.rs:284:22:284:38 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:292:25:292:42 | ...: String | main.rs:293:16:293:42 | user_input.parse(...) [Ok] | provenance | MaD:32 |
+| main.rs:293:9:293:12 | size | main.rs:297:9:297:17 | num_bytes | provenance |  |
+| main.rs:293:16:293:42 | user_input.parse(...) [Ok] | main.rs:293:16:293:43 | TryExpr | provenance |  |
+| main.rs:293:16:293:43 | TryExpr | main.rs:293:9:293:12 | size | provenance |  |
+| main.rs:297:9:297:17 | num_bytes | main.rs:299:54:299:62 | num_bytes | provenance |  |
+| main.rs:299:9:299:14 | layout | main.rs:301:40:301:45 | layout | provenance |  |
+| main.rs:299:18:299:66 | ...::from_size_align(...) [Ok] | main.rs:299:18:299:75 | ... .unwrap(...) | provenance | MaD:31 |
+| main.rs:299:18:299:75 | ... .unwrap(...) | main.rs:299:9:299:14 | layout | provenance |  |
+| main.rs:299:54:299:62 | num_bytes | main.rs:299:18:299:66 | ...::from_size_align(...) [Ok] | provenance | MaD:23 |
+| main.rs:301:40:301:45 | layout | main.rs:301:22:301:38 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:308:25:308:38 | ...::args | main.rs:308:25:308:40 | ...::args(...) [element] | provenance | Src:MaD:16  |
+| main.rs:308:25:308:40 | ...::args(...) [element] | main.rs:308:25:308:47 | ... .nth(...) [Some] | provenance | MaD:35 |
+| main.rs:308:25:308:47 | ... .nth(...) [Some] | main.rs:308:25:308:74 | ... .unwrap_or(...) | provenance | MaD:29 |
+| main.rs:308:25:308:74 | ... .unwrap_or(...) | main.rs:279:24:279:41 | ...: String | provenance |  |
+| main.rs:309:26:309:39 | ...::args | main.rs:309:26:309:41 | ...::args(...) [element] | provenance | Src:MaD:16  |
+| main.rs:309:26:309:41 | ...::args(...) [element] | main.rs:309:26:309:48 | ... .nth(...) [Some] | provenance | MaD:35 |
+| main.rs:309:26:309:48 | ... .nth(...) [Some] | main.rs:309:26:309:75 | ... .unwrap_or(...) | provenance | MaD:29 |
+| main.rs:309:26:309:75 | ... .unwrap_or(...) | main.rs:292:25:292:42 | ...: String | provenance |  |
+| main.rs:317:9:317:9 | v | main.rs:320:34:320:34 | v | provenance |  |
+| main.rs:317:9:317:9 | v | main.rs:321:42:321:42 | v | provenance |  |
+| main.rs:317:9:317:9 | v | main.rs:322:36:322:36 | v | provenance |  |
+| main.rs:317:9:317:9 | v | main.rs:323:27:323:27 | v | provenance |  |
+| main.rs:317:9:317:9 | v | main.rs:324:25:324:25 | v | provenance |  |
+| main.rs:317:13:317:26 | ...::args | main.rs:317:13:317:28 | ...::args(...) [element] | provenance | Src:MaD:16  |
+| main.rs:317:13:317:28 | ...::args(...) [element] | main.rs:317:13:317:35 | ... .nth(...) [Some] | provenance | MaD:35 |
+| main.rs:317:13:317:35 | ... .nth(...) [Some] | main.rs:317:13:317:65 | ... .unwrap_or(...) | provenance | MaD:29 |
+| main.rs:317:13:317:65 | ... .unwrap_or(...) | main.rs:317:13:317:82 | ... .parse(...) [Ok] | provenance | MaD:32 |
+| main.rs:317:13:317:82 | ... .parse(...) [Ok] | main.rs:317:13:317:91 | ... .unwrap(...) | provenance | MaD:31 |
+| main.rs:317:13:317:91 | ... .unwrap(...) | main.rs:317:9:317:9 | v | provenance |  |
+| main.rs:320:34:320:34 | v | main.rs:12:36:12:43 | ...: usize | provenance |  |
+| main.rs:321:42:321:42 | v | main.rs:43:44:43:51 | ...: usize | provenance |  |
+| main.rs:322:36:322:36 | v | main.rs:91:38:91:45 | ...: usize | provenance |  |
+| main.rs:323:27:323:27 | v | main.rs:183:29:183:36 | ...: usize | provenance |  |
+| main.rs:324:25:324:25 | v | main.rs:217:27:217:34 | ...: usize | provenance |  |
 models
 | 1 | Sink: lang:alloc; <crate::alloc::Global as crate::alloc::Allocator>::allocate; alloc-layout; Argument[0] |
 | 2 | Sink: lang:alloc; <crate::alloc::Global as crate::alloc::Allocator>::allocate_zeroed; alloc-layout; Argument[0] |
@@ -402,134 +486,206 @@ nodes
 | main.rs:68:31:68:32 | l4 | semmle.label | l4 |
 | main.rs:71:35:71:38 | ...: T | semmle.label | ...: T |
 | main.rs:77:9:77:16 | return v | semmle.label | return v |
-| main.rs:81:38:81:45 | ...: usize | semmle.label | ...: usize |
-| main.rs:82:9:82:10 | l1 | semmle.label | l1 |
-| main.rs:82:14:82:48 | ...::array::<...>(...) [Ok] | semmle.label | ...::array::<...>(...) [Ok] |
-| main.rs:82:14:82:57 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
-| main.rs:82:47:82:47 | v | semmle.label | v |
-| main.rs:85:17:85:33 | ...::alloc | semmle.label | ...::alloc |
-| main.rs:85:35:85:36 | l1 | semmle.label | l1 |
-| main.rs:87:17:87:33 | ...::alloc | semmle.label | ...::alloc |
-| main.rs:87:35:87:36 | l1 | semmle.label | l1 |
-| main.rs:91:17:91:33 | ...::alloc | semmle.label | ...::alloc |
-| main.rs:91:35:91:36 | l1 | semmle.label | l1 |
-| main.rs:93:17:93:33 | ...::alloc | semmle.label | ...::alloc |
-| main.rs:93:35:93:36 | l1 | semmle.label | l1 |
-| main.rs:97:13:97:21 | mut v_mut | semmle.label | mut v_mut |
-| main.rs:103:13:103:14 | l2 | semmle.label | l2 |
-| main.rs:103:18:103:56 | ...::array::<...>(...) [Ok] | semmle.label | ...::array::<...>(...) [Ok] |
-| main.rs:103:18:103:65 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
-| main.rs:103:51:103:55 | v_mut | semmle.label | v_mut |
-| main.rs:104:17:104:33 | ...::alloc | semmle.label | ...::alloc |
-| main.rs:104:35:104:36 | l2 | semmle.label | l2 |
-| main.rs:106:13:106:14 | l3 | semmle.label | l3 |
-| main.rs:106:18:106:52 | ...::array::<...>(...) [Ok] | semmle.label | ...::array::<...>(...) [Ok] |
-| main.rs:106:18:106:61 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
-| main.rs:106:51:106:51 | v | semmle.label | v |
-| main.rs:107:17:107:33 | ...::alloc | semmle.label | ...::alloc |
-| main.rs:107:35:107:36 | l3 | semmle.label | l3 |
-| main.rs:110:9:110:10 | l4 | semmle.label | l4 |
-| main.rs:110:14:110:68 | ...::array::<...>(...) [Ok] | semmle.label | ...::array::<...>(...) [Ok] |
-| main.rs:110:14:110:77 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
-| main.rs:110:47:110:67 | ...::min(...) | semmle.label | ...::min(...) |
-| main.rs:110:61:110:61 | v | semmle.label | v |
-| main.rs:111:13:111:29 | ...::alloc | semmle.label | ...::alloc |
-| main.rs:111:31:111:32 | l4 | semmle.label | l4 |
-| main.rs:113:9:113:10 | l5 | semmle.label | l5 |
-| main.rs:113:14:113:68 | ...::array::<...>(...) [Ok] | semmle.label | ...::array::<...>(...) [Ok] |
-| main.rs:113:14:113:77 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
-| main.rs:113:47:113:67 | ...::max(...) | semmle.label | ...::max(...) |
-| main.rs:113:61:113:61 | v | semmle.label | v |
-| main.rs:114:13:114:29 | ...::alloc | semmle.label | ...::alloc |
-| main.rs:114:31:114:32 | l5 | semmle.label | l5 |
-| main.rs:116:9:116:10 | l6 | semmle.label | l6 |
-| main.rs:116:14:116:63 | ...::array::<...>(...) [Ok] | semmle.label | ...::array::<...>(...) [Ok] |
-| main.rs:116:14:116:72 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
-| main.rs:116:47:116:62 | clamp(...) | semmle.label | clamp(...) |
-| main.rs:116:53:116:53 | v | semmle.label | v |
-| main.rs:117:13:117:29 | ...::alloc | semmle.label | ...::alloc |
-| main.rs:117:31:117:32 | l6 | semmle.label | l6 |
-| main.rs:119:13:119:29 | ...::alloc | semmle.label | ...::alloc |
-| main.rs:119:31:119:32 | l1 | semmle.label | l1 |
-| main.rs:123:13:123:29 | ...::alloc | semmle.label | ...::alloc |
-| main.rs:123:31:123:32 | l1 | semmle.label | l1 |
-| main.rs:128:29:128:36 | ...: usize | semmle.label | ...: usize |
-| main.rs:137:9:137:10 | l2 | semmle.label | l2 |
-| main.rs:137:14:137:47 | ...::array::<...>(...) [Ok] | semmle.label | ...::array::<...>(...) [Ok] |
-| main.rs:137:14:137:56 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
-| main.rs:137:46:137:46 | v | semmle.label | v |
-| main.rs:138:32:138:36 | alloc | semmle.label | alloc |
-| main.rs:138:38:138:39 | l2 | semmle.label | l2 |
-| main.rs:139:32:139:43 | alloc_zeroed | semmle.label | alloc_zeroed |
-| main.rs:139:45:139:46 | l2 | semmle.label | l2 |
-| main.rs:140:32:140:39 | allocate | semmle.label | allocate |
-| main.rs:140:41:140:42 | l2 | semmle.label | l2 |
-| main.rs:141:32:141:46 | allocate_zeroed | semmle.label | allocate_zeroed |
-| main.rs:141:48:141:49 | l2 | semmle.label | l2 |
-| main.rs:142:32:142:39 | allocate | semmle.label | allocate |
-| main.rs:142:41:142:42 | l2 | semmle.label | l2 |
-| main.rs:143:32:143:46 | allocate_zeroed | semmle.label | allocate_zeroed |
-| main.rs:143:48:143:49 | l2 | semmle.label | l2 |
-| main.rs:153:40:153:43 | grow | semmle.label | grow |
-| main.rs:153:53:153:54 | l2 | semmle.label | l2 |
-| main.rs:155:40:155:50 | grow_zeroed | semmle.label | grow_zeroed |
-| main.rs:155:60:155:61 | l2 | semmle.label | l2 |
-| main.rs:162:27:162:34 | ...: usize | semmle.label | ...: usize |
-| main.rs:164:13:164:24 | ...::malloc | semmle.label | ...::malloc |
-| main.rs:164:13:164:24 | ...::malloc | semmle.label | ...::malloc |
-| main.rs:164:26:164:26 | v | semmle.label | v |
-| main.rs:165:13:165:31 | ...::aligned_alloc | semmle.label | ...::aligned_alloc |
-| main.rs:165:13:165:31 | ...::aligned_alloc | semmle.label | ...::aligned_alloc |
-| main.rs:165:36:165:36 | v | semmle.label | v |
-| main.rs:167:13:167:24 | ...::calloc | semmle.label | ...::calloc |
-| main.rs:167:13:167:24 | ...::calloc | semmle.label | ...::calloc |
-| main.rs:167:30:167:30 | v | semmle.label | v |
-| main.rs:168:13:168:24 | ...::calloc | semmle.label | ...::calloc |
-| main.rs:168:13:168:24 | ...::calloc | semmle.label | ...::calloc |
-| main.rs:168:26:168:26 | v | semmle.label | v |
-| main.rs:169:13:169:25 | ...::realloc | semmle.label | ...::realloc |
-| main.rs:169:13:169:25 | ...::realloc | semmle.label | ...::realloc |
-| main.rs:169:31:169:31 | v | semmle.label | v |
-| main.rs:224:24:224:41 | ...: String | semmle.label | ...: String |
-| main.rs:225:9:225:17 | num_bytes | semmle.label | num_bytes |
-| main.rs:225:21:225:47 | user_input.parse(...) [Ok] | semmle.label | user_input.parse(...) [Ok] |
-| main.rs:225:21:225:48 | TryExpr | semmle.label | TryExpr |
-| main.rs:227:9:227:14 | layout | semmle.label | layout |
-| main.rs:227:18:227:66 | ...::from_size_align(...) [Ok] | semmle.label | ...::from_size_align(...) [Ok] |
-| main.rs:227:18:227:75 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
-| main.rs:227:54:227:62 | num_bytes | semmle.label | num_bytes |
-| main.rs:229:22:229:38 | ...::alloc | semmle.label | ...::alloc |
-| main.rs:229:40:229:45 | layout | semmle.label | layout |
-| main.rs:237:25:237:42 | ...: String | semmle.label | ...: String |
-| main.rs:238:9:238:12 | size | semmle.label | size |
-| main.rs:238:16:238:42 | user_input.parse(...) [Ok] | semmle.label | user_input.parse(...) [Ok] |
-| main.rs:238:16:238:43 | TryExpr | semmle.label | TryExpr |
-| main.rs:242:9:242:17 | num_bytes | semmle.label | num_bytes |
-| main.rs:244:9:244:14 | layout | semmle.label | layout |
-| main.rs:244:18:244:66 | ...::from_size_align(...) [Ok] | semmle.label | ...::from_size_align(...) [Ok] |
-| main.rs:244:18:244:75 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
-| main.rs:244:54:244:62 | num_bytes | semmle.label | num_bytes |
-| main.rs:246:22:246:38 | ...::alloc | semmle.label | ...::alloc |
-| main.rs:246:40:246:45 | layout | semmle.label | layout |
-| main.rs:253:25:253:38 | ...::args | semmle.label | ...::args |
-| main.rs:253:25:253:40 | ...::args(...) [element] | semmle.label | ...::args(...) [element] |
-| main.rs:253:25:253:47 | ... .nth(...) [Some] | semmle.label | ... .nth(...) [Some] |
-| main.rs:253:25:253:74 | ... .unwrap_or(...) | semmle.label | ... .unwrap_or(...) |
-| main.rs:254:26:254:39 | ...::args | semmle.label | ...::args |
-| main.rs:254:26:254:41 | ...::args(...) [element] | semmle.label | ...::args(...) [element] |
-| main.rs:254:26:254:48 | ... .nth(...) [Some] | semmle.label | ... .nth(...) [Some] |
-| main.rs:254:26:254:75 | ... .unwrap_or(...) | semmle.label | ... .unwrap_or(...) |
-| main.rs:262:9:262:9 | v | semmle.label | v |
-| main.rs:262:13:262:26 | ...::args | semmle.label | ...::args |
-| main.rs:262:13:262:28 | ...::args(...) [element] | semmle.label | ...::args(...) [element] |
-| main.rs:262:13:262:35 | ... .nth(...) [Some] | semmle.label | ... .nth(...) [Some] |
-| main.rs:262:13:262:65 | ... .unwrap_or(...) | semmle.label | ... .unwrap_or(...) |
-| main.rs:262:13:262:82 | ... .parse(...) [Ok] | semmle.label | ... .parse(...) [Ok] |
-| main.rs:262:13:262:91 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
-| main.rs:265:34:265:34 | v | semmle.label | v |
-| main.rs:266:42:266:42 | v | semmle.label | v |
-| main.rs:267:36:267:36 | v | semmle.label | v |
-| main.rs:268:27:268:27 | v | semmle.label | v |
-| main.rs:269:25:269:25 | v | semmle.label | v |
+| main.rs:81:33:81:40 | ...: usize | semmle.label | ...: usize |
+| main.rs:82:9:82:14 | layout | semmle.label | layout |
+| main.rs:82:18:82:58 | ...::from_size_align(...) [Ok] | semmle.label | ...::from_size_align(...) [Ok] |
+| main.rs:82:18:82:67 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
+| main.rs:82:54:82:54 | v | semmle.label | v |
+| main.rs:83:13:83:29 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:83:31:83:36 | layout | semmle.label | layout |
+| main.rs:86:35:86:42 | ...: usize | semmle.label | ...: usize |
+| main.rs:87:9:87:14 | layout | semmle.label | layout |
+| main.rs:87:18:87:58 | ...::from_size_align(...) [Ok] | semmle.label | ...::from_size_align(...) [Ok] |
+| main.rs:87:18:87:67 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
+| main.rs:87:54:87:54 | v | semmle.label | v |
+| main.rs:88:13:88:29 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:88:31:88:36 | layout | semmle.label | layout |
+| main.rs:91:38:91:45 | ...: usize | semmle.label | ...: usize |
+| main.rs:92:9:92:10 | l1 | semmle.label | l1 |
+| main.rs:92:14:92:48 | ...::array::<...>(...) [Ok] | semmle.label | ...::array::<...>(...) [Ok] |
+| main.rs:92:14:92:57 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
+| main.rs:92:47:92:47 | v | semmle.label | v |
+| main.rs:95:13:95:14 | l2 | semmle.label | l2 |
+| main.rs:95:18:95:52 | ...::array::<...>(...) [Ok] | semmle.label | ...::array::<...>(...) [Ok] |
+| main.rs:95:18:95:61 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
+| main.rs:95:51:95:51 | v | semmle.label | v |
+| main.rs:96:17:96:33 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:96:35:96:36 | l1 | semmle.label | l1 |
+| main.rs:97:17:97:33 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:97:35:97:36 | l2 | semmle.label | l2 |
+| main.rs:99:31:99:31 | v | semmle.label | v |
+| main.rs:101:13:101:14 | l3 | semmle.label | l3 |
+| main.rs:101:18:101:52 | ...::array::<...>(...) [Ok] | semmle.label | ...::array::<...>(...) [Ok] |
+| main.rs:101:18:101:61 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
+| main.rs:101:51:101:51 | v | semmle.label | v |
+| main.rs:102:17:102:33 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:102:35:102:36 | l1 | semmle.label | l1 |
+| main.rs:103:17:103:33 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:103:35:103:36 | l3 | semmle.label | l3 |
+| main.rs:105:33:105:33 | v | semmle.label | v |
+| main.rs:109:17:109:33 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:109:35:109:36 | l1 | semmle.label | l1 |
+| main.rs:111:17:111:33 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:111:35:111:36 | l1 | semmle.label | l1 |
+| main.rs:115:13:115:14 | l4 | semmle.label | l4 |
+| main.rs:115:18:115:58 | ...::from_size_align(...) [Ok] | semmle.label | ...::from_size_align(...) [Ok] |
+| main.rs:115:18:115:67 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
+| main.rs:115:54:115:54 | v | semmle.label | v |
+| main.rs:116:17:116:33 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:116:35:116:36 | l4 | semmle.label | l4 |
+| main.rs:120:13:120:14 | l5 | semmle.label | l5 |
+| main.rs:120:18:120:58 | ...::from_size_align(...) [Ok] | semmle.label | ...::from_size_align(...) [Ok] |
+| main.rs:120:18:120:67 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
+| main.rs:120:54:120:54 | v | semmle.label | v |
+| main.rs:121:17:121:33 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:121:35:121:36 | l5 | semmle.label | l5 |
+| main.rs:125:13:125:14 | l6 | semmle.label | l6 |
+| main.rs:125:18:125:58 | ...::from_size_align(...) [Ok] | semmle.label | ...::from_size_align(...) [Ok] |
+| main.rs:125:18:125:67 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
+| main.rs:125:54:125:54 | v | semmle.label | v |
+| main.rs:126:17:126:33 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:126:35:126:36 | l6 | semmle.label | l6 |
+| main.rs:131:9:131:10 | l7 | semmle.label | l7 |
+| main.rs:131:14:131:54 | ...::from_size_align(...) [Ok] | semmle.label | ...::from_size_align(...) [Ok] |
+| main.rs:131:14:131:63 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
+| main.rs:131:50:131:50 | v | semmle.label | v |
+| main.rs:135:13:135:29 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:135:31:135:32 | l7 | semmle.label | l7 |
+| main.rs:138:13:138:21 | mut v_mut | semmle.label | mut v_mut |
+| main.rs:144:13:144:14 | l8 | semmle.label | l8 |
+| main.rs:144:18:144:56 | ...::array::<...>(...) [Ok] | semmle.label | ...::array::<...>(...) [Ok] |
+| main.rs:144:18:144:65 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
+| main.rs:144:51:144:55 | v_mut | semmle.label | v_mut |
+| main.rs:145:13:145:14 | l9 | semmle.label | l9 |
+| main.rs:145:18:145:52 | ...::array::<...>(...) [Ok] | semmle.label | ...::array::<...>(...) [Ok] |
+| main.rs:145:18:145:61 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
+| main.rs:145:51:145:51 | v | semmle.label | v |
+| main.rs:146:17:146:33 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:146:35:146:36 | l1 | semmle.label | l1 |
+| main.rs:147:17:147:33 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:147:35:147:36 | l8 | semmle.label | l8 |
+| main.rs:148:17:148:33 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:148:35:148:36 | l9 | semmle.label | l9 |
+| main.rs:151:9:151:11 | l10 | semmle.label | l10 |
+| main.rs:151:15:151:69 | ...::array::<...>(...) [Ok] | semmle.label | ...::array::<...>(...) [Ok] |
+| main.rs:151:15:151:78 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
+| main.rs:151:48:151:68 | ...::min(...) | semmle.label | ...::min(...) |
+| main.rs:151:62:151:62 | v | semmle.label | v |
+| main.rs:152:13:152:29 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:152:31:152:33 | l10 | semmle.label | l10 |
+| main.rs:154:9:154:11 | l11 | semmle.label | l11 |
+| main.rs:154:15:154:69 | ...::array::<...>(...) [Ok] | semmle.label | ...::array::<...>(...) [Ok] |
+| main.rs:154:15:154:78 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
+| main.rs:154:48:154:68 | ...::max(...) | semmle.label | ...::max(...) |
+| main.rs:154:62:154:62 | v | semmle.label | v |
+| main.rs:155:13:155:29 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:155:31:155:33 | l11 | semmle.label | l11 |
+| main.rs:157:9:157:11 | l12 | semmle.label | l12 |
+| main.rs:157:15:157:64 | ...::array::<...>(...) [Ok] | semmle.label | ...::array::<...>(...) [Ok] |
+| main.rs:157:15:157:73 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
+| main.rs:157:48:157:63 | clamp(...) | semmle.label | clamp(...) |
+| main.rs:157:54:157:54 | v | semmle.label | v |
+| main.rs:158:13:158:29 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:158:31:158:33 | l12 | semmle.label | l12 |
+| main.rs:161:13:161:15 | l13 | semmle.label | l13 |
+| main.rs:161:19:161:59 | ...::from_size_align(...) [Ok] | semmle.label | ...::from_size_align(...) [Ok] |
+| main.rs:161:19:161:68 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
+| main.rs:161:55:161:55 | v | semmle.label | v |
+| main.rs:162:17:162:33 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:162:35:162:37 | l13 | semmle.label | l13 |
+| main.rs:168:13:168:15 | l14 | semmle.label | l14 |
+| main.rs:168:19:168:59 | ...::from_size_align(...) [Ok] | semmle.label | ...::from_size_align(...) [Ok] |
+| main.rs:168:19:168:68 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
+| main.rs:168:55:168:55 | v | semmle.label | v |
+| main.rs:169:17:169:33 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:169:35:169:37 | l13 | semmle.label | l13 |
+| main.rs:170:17:170:33 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:170:35:170:37 | l14 | semmle.label | l14 |
+| main.rs:176:9:176:11 | l15 | semmle.label | l15 |
+| main.rs:176:15:176:55 | ...::from_size_align(...) [Ok] | semmle.label | ...::from_size_align(...) [Ok] |
+| main.rs:176:15:176:64 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
+| main.rs:176:51:176:51 | v | semmle.label | v |
+| main.rs:177:13:177:29 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:177:31:177:32 | l1 | semmle.label | l1 |
+| main.rs:178:13:178:29 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:178:31:178:33 | l15 | semmle.label | l15 |
+| main.rs:183:29:183:36 | ...: usize | semmle.label | ...: usize |
+| main.rs:192:9:192:10 | l2 | semmle.label | l2 |
+| main.rs:192:14:192:47 | ...::array::<...>(...) [Ok] | semmle.label | ...::array::<...>(...) [Ok] |
+| main.rs:192:14:192:56 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
+| main.rs:192:46:192:46 | v | semmle.label | v |
+| main.rs:193:32:193:36 | alloc | semmle.label | alloc |
+| main.rs:193:38:193:39 | l2 | semmle.label | l2 |
+| main.rs:194:32:194:43 | alloc_zeroed | semmle.label | alloc_zeroed |
+| main.rs:194:45:194:46 | l2 | semmle.label | l2 |
+| main.rs:195:32:195:39 | allocate | semmle.label | allocate |
+| main.rs:195:41:195:42 | l2 | semmle.label | l2 |
+| main.rs:196:32:196:46 | allocate_zeroed | semmle.label | allocate_zeroed |
+| main.rs:196:48:196:49 | l2 | semmle.label | l2 |
+| main.rs:197:32:197:39 | allocate | semmle.label | allocate |
+| main.rs:197:41:197:42 | l2 | semmle.label | l2 |
+| main.rs:198:32:198:46 | allocate_zeroed | semmle.label | allocate_zeroed |
+| main.rs:198:48:198:49 | l2 | semmle.label | l2 |
+| main.rs:208:40:208:43 | grow | semmle.label | grow |
+| main.rs:208:53:208:54 | l2 | semmle.label | l2 |
+| main.rs:210:40:210:50 | grow_zeroed | semmle.label | grow_zeroed |
+| main.rs:210:60:210:61 | l2 | semmle.label | l2 |
+| main.rs:217:27:217:34 | ...: usize | semmle.label | ...: usize |
+| main.rs:219:13:219:24 | ...::malloc | semmle.label | ...::malloc |
+| main.rs:219:13:219:24 | ...::malloc | semmle.label | ...::malloc |
+| main.rs:219:26:219:26 | v | semmle.label | v |
+| main.rs:220:13:220:31 | ...::aligned_alloc | semmle.label | ...::aligned_alloc |
+| main.rs:220:13:220:31 | ...::aligned_alloc | semmle.label | ...::aligned_alloc |
+| main.rs:220:36:220:36 | v | semmle.label | v |
+| main.rs:222:13:222:24 | ...::calloc | semmle.label | ...::calloc |
+| main.rs:222:13:222:24 | ...::calloc | semmle.label | ...::calloc |
+| main.rs:222:30:222:30 | v | semmle.label | v |
+| main.rs:223:13:223:24 | ...::calloc | semmle.label | ...::calloc |
+| main.rs:223:13:223:24 | ...::calloc | semmle.label | ...::calloc |
+| main.rs:223:26:223:26 | v | semmle.label | v |
+| main.rs:224:13:224:25 | ...::realloc | semmle.label | ...::realloc |
+| main.rs:224:13:224:25 | ...::realloc | semmle.label | ...::realloc |
+| main.rs:224:31:224:31 | v | semmle.label | v |
+| main.rs:279:24:279:41 | ...: String | semmle.label | ...: String |
+| main.rs:280:9:280:17 | num_bytes | semmle.label | num_bytes |
+| main.rs:280:21:280:47 | user_input.parse(...) [Ok] | semmle.label | user_input.parse(...) [Ok] |
+| main.rs:280:21:280:48 | TryExpr | semmle.label | TryExpr |
+| main.rs:282:9:282:14 | layout | semmle.label | layout |
+| main.rs:282:18:282:66 | ...::from_size_align(...) [Ok] | semmle.label | ...::from_size_align(...) [Ok] |
+| main.rs:282:18:282:75 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
+| main.rs:282:54:282:62 | num_bytes | semmle.label | num_bytes |
+| main.rs:284:22:284:38 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:284:40:284:45 | layout | semmle.label | layout |
+| main.rs:292:25:292:42 | ...: String | semmle.label | ...: String |
+| main.rs:293:9:293:12 | size | semmle.label | size |
+| main.rs:293:16:293:42 | user_input.parse(...) [Ok] | semmle.label | user_input.parse(...) [Ok] |
+| main.rs:293:16:293:43 | TryExpr | semmle.label | TryExpr |
+| main.rs:297:9:297:17 | num_bytes | semmle.label | num_bytes |
+| main.rs:299:9:299:14 | layout | semmle.label | layout |
+| main.rs:299:18:299:66 | ...::from_size_align(...) [Ok] | semmle.label | ...::from_size_align(...) [Ok] |
+| main.rs:299:18:299:75 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
+| main.rs:299:54:299:62 | num_bytes | semmle.label | num_bytes |
+| main.rs:301:22:301:38 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:301:40:301:45 | layout | semmle.label | layout |
+| main.rs:308:25:308:38 | ...::args | semmle.label | ...::args |
+| main.rs:308:25:308:40 | ...::args(...) [element] | semmle.label | ...::args(...) [element] |
+| main.rs:308:25:308:47 | ... .nth(...) [Some] | semmle.label | ... .nth(...) [Some] |
+| main.rs:308:25:308:74 | ... .unwrap_or(...) | semmle.label | ... .unwrap_or(...) |
+| main.rs:309:26:309:39 | ...::args | semmle.label | ...::args |
+| main.rs:309:26:309:41 | ...::args(...) [element] | semmle.label | ...::args(...) [element] |
+| main.rs:309:26:309:48 | ... .nth(...) [Some] | semmle.label | ... .nth(...) [Some] |
+| main.rs:309:26:309:75 | ... .unwrap_or(...) | semmle.label | ... .unwrap_or(...) |
+| main.rs:317:9:317:9 | v | semmle.label | v |
+| main.rs:317:13:317:26 | ...::args | semmle.label | ...::args |
+| main.rs:317:13:317:28 | ...::args(...) [element] | semmle.label | ...::args(...) [element] |
+| main.rs:317:13:317:35 | ... .nth(...) [Some] | semmle.label | ... .nth(...) [Some] |
+| main.rs:317:13:317:65 | ... .unwrap_or(...) | semmle.label | ... .unwrap_or(...) |
+| main.rs:317:13:317:82 | ... .parse(...) [Ok] | semmle.label | ... .parse(...) [Ok] |
+| main.rs:317:13:317:91 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
+| main.rs:320:34:320:34 | v | semmle.label | v |
+| main.rs:321:42:321:42 | v | semmle.label | v |
+| main.rs:322:36:322:36 | v | semmle.label | v |
+| main.rs:323:27:323:27 | v | semmle.label | v |
+| main.rs:324:25:324:25 | v | semmle.label | v |
 subpaths
-| main.rs:116:53:116:53 | v | main.rs:71:35:71:38 | ...: T | main.rs:77:9:77:16 | return v | main.rs:116:47:116:62 | clamp(...) |
+| main.rs:157:54:157:54 | v | main.rs:71:35:71:38 | ...: T | main.rs:77:9:77:16 | return v | main.rs:157:48:157:63 | clamp(...) |

--- a/rust/ql/test/query-tests/security/CWE-770/UncontrolledAllocationSize.expected
+++ b/rust/ql/test/query-tests/security/CWE-770/UncontrolledAllocationSize.expected
@@ -1,52 +1,54 @@
 #select
-| main.rs:18:13:18:31 | ...::realloc | main.rs:211:13:211:26 | ...::args | main.rs:18:13:18:31 | ...::realloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
-| main.rs:21:13:21:29 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:21:13:21:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
-| main.rs:22:13:22:29 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:22:13:22:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
-| main.rs:23:13:23:29 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:23:13:23:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
-| main.rs:24:13:24:36 | ...::alloc_zeroed | main.rs:211:13:211:26 | ...::args | main.rs:24:13:24:36 | ...::alloc_zeroed | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
-| main.rs:30:13:30:29 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:30:13:30:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
-| main.rs:33:13:33:29 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:33:13:33:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
-| main.rs:37:13:37:29 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:37:13:37:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
-| main.rs:40:13:40:29 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:40:13:40:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
-| main.rs:50:13:50:29 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:50:13:50:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
-| main.rs:51:13:51:29 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:51:13:51:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
-| main.rs:53:13:53:29 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:53:13:53:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
-| main.rs:54:13:54:29 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:54:13:54:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
-| main.rs:59:13:59:29 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:59:13:59:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
-| main.rs:61:13:61:29 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:61:13:61:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
-| main.rs:63:13:63:29 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:63:13:63:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
-| main.rs:64:13:64:29 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:64:13:64:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
-| main.rs:65:13:65:29 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:65:13:65:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
-| main.rs:68:13:68:29 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:68:13:68:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
-| main.rs:85:17:85:33 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:85:17:85:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
-| main.rs:87:17:87:33 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:87:17:87:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
-| main.rs:91:17:91:33 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:91:17:91:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
-| main.rs:93:17:93:33 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:93:17:93:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
-| main.rs:104:17:104:33 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:104:17:104:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
-| main.rs:107:17:107:33 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:107:17:107:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
-| main.rs:111:13:111:29 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:111:13:111:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
-| main.rs:114:13:114:29 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:114:13:114:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
-| main.rs:117:13:117:29 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:117:13:117:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
-| main.rs:119:13:119:29 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:119:13:119:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
-| main.rs:123:13:123:29 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:123:13:123:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
-| main.rs:138:32:138:36 | alloc | main.rs:211:13:211:26 | ...::args | main.rs:138:32:138:36 | alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
-| main.rs:139:32:139:43 | alloc_zeroed | main.rs:211:13:211:26 | ...::args | main.rs:139:32:139:43 | alloc_zeroed | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
-| main.rs:140:32:140:39 | allocate | main.rs:211:13:211:26 | ...::args | main.rs:140:32:140:39 | allocate | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
-| main.rs:141:32:141:46 | allocate_zeroed | main.rs:211:13:211:26 | ...::args | main.rs:141:32:141:46 | allocate_zeroed | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
-| main.rs:142:32:142:39 | allocate | main.rs:211:13:211:26 | ...::args | main.rs:142:32:142:39 | allocate | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
-| main.rs:143:32:143:46 | allocate_zeroed | main.rs:211:13:211:26 | ...::args | main.rs:143:32:143:46 | allocate_zeroed | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
-| main.rs:153:40:153:43 | grow | main.rs:211:13:211:26 | ...::args | main.rs:153:40:153:43 | grow | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
-| main.rs:155:40:155:50 | grow_zeroed | main.rs:211:13:211:26 | ...::args | main.rs:155:40:155:50 | grow_zeroed | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
-| main.rs:164:13:164:24 | ...::malloc | main.rs:211:13:211:26 | ...::args | main.rs:164:13:164:24 | ...::malloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
-| main.rs:164:13:164:24 | ...::malloc | main.rs:211:13:211:26 | ...::args | main.rs:164:13:164:24 | ...::malloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
-| main.rs:165:13:165:31 | ...::aligned_alloc | main.rs:211:13:211:26 | ...::args | main.rs:165:13:165:31 | ...::aligned_alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
-| main.rs:165:13:165:31 | ...::aligned_alloc | main.rs:211:13:211:26 | ...::args | main.rs:165:13:165:31 | ...::aligned_alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
-| main.rs:167:13:167:24 | ...::calloc | main.rs:211:13:211:26 | ...::args | main.rs:167:13:167:24 | ...::calloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
-| main.rs:167:13:167:24 | ...::calloc | main.rs:211:13:211:26 | ...::args | main.rs:167:13:167:24 | ...::calloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
-| main.rs:168:13:168:24 | ...::calloc | main.rs:211:13:211:26 | ...::args | main.rs:168:13:168:24 | ...::calloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
-| main.rs:168:13:168:24 | ...::calloc | main.rs:211:13:211:26 | ...::args | main.rs:168:13:168:24 | ...::calloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
-| main.rs:169:13:169:25 | ...::realloc | main.rs:211:13:211:26 | ...::args | main.rs:169:13:169:25 | ...::realloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
-| main.rs:169:13:169:25 | ...::realloc | main.rs:211:13:211:26 | ...::args | main.rs:169:13:169:25 | ...::realloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
+| main.rs:18:13:18:31 | ...::realloc | main.rs:262:13:262:26 | ...::args | main.rs:18:13:18:31 | ...::realloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
+| main.rs:21:13:21:29 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:21:13:21:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
+| main.rs:22:13:22:29 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:22:13:22:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
+| main.rs:23:13:23:29 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:23:13:23:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
+| main.rs:24:13:24:36 | ...::alloc_zeroed | main.rs:262:13:262:26 | ...::args | main.rs:24:13:24:36 | ...::alloc_zeroed | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
+| main.rs:30:13:30:29 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:30:13:30:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
+| main.rs:33:13:33:29 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:33:13:33:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
+| main.rs:37:13:37:29 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:37:13:37:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
+| main.rs:40:13:40:29 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:40:13:40:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
+| main.rs:50:13:50:29 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:50:13:50:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
+| main.rs:51:13:51:29 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:51:13:51:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
+| main.rs:53:13:53:29 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:53:13:53:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
+| main.rs:54:13:54:29 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:54:13:54:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
+| main.rs:59:13:59:29 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:59:13:59:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
+| main.rs:61:13:61:29 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:61:13:61:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
+| main.rs:63:13:63:29 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:63:13:63:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
+| main.rs:64:13:64:29 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:64:13:64:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
+| main.rs:65:13:65:29 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:65:13:65:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
+| main.rs:68:13:68:29 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:68:13:68:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
+| main.rs:85:17:85:33 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:85:17:85:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
+| main.rs:87:17:87:33 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:87:17:87:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
+| main.rs:91:17:91:33 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:91:17:91:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
+| main.rs:93:17:93:33 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:93:17:93:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
+| main.rs:104:17:104:33 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:104:17:104:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
+| main.rs:107:17:107:33 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:107:17:107:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
+| main.rs:111:13:111:29 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:111:13:111:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
+| main.rs:114:13:114:29 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:114:13:114:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
+| main.rs:117:13:117:29 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:117:13:117:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
+| main.rs:119:13:119:29 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:119:13:119:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
+| main.rs:123:13:123:29 | ...::alloc | main.rs:262:13:262:26 | ...::args | main.rs:123:13:123:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
+| main.rs:138:32:138:36 | alloc | main.rs:262:13:262:26 | ...::args | main.rs:138:32:138:36 | alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
+| main.rs:139:32:139:43 | alloc_zeroed | main.rs:262:13:262:26 | ...::args | main.rs:139:32:139:43 | alloc_zeroed | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
+| main.rs:140:32:140:39 | allocate | main.rs:262:13:262:26 | ...::args | main.rs:140:32:140:39 | allocate | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
+| main.rs:141:32:141:46 | allocate_zeroed | main.rs:262:13:262:26 | ...::args | main.rs:141:32:141:46 | allocate_zeroed | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
+| main.rs:142:32:142:39 | allocate | main.rs:262:13:262:26 | ...::args | main.rs:142:32:142:39 | allocate | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
+| main.rs:143:32:143:46 | allocate_zeroed | main.rs:262:13:262:26 | ...::args | main.rs:143:32:143:46 | allocate_zeroed | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
+| main.rs:153:40:153:43 | grow | main.rs:262:13:262:26 | ...::args | main.rs:153:40:153:43 | grow | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
+| main.rs:155:40:155:50 | grow_zeroed | main.rs:262:13:262:26 | ...::args | main.rs:155:40:155:50 | grow_zeroed | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
+| main.rs:164:13:164:24 | ...::malloc | main.rs:262:13:262:26 | ...::args | main.rs:164:13:164:24 | ...::malloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
+| main.rs:164:13:164:24 | ...::malloc | main.rs:262:13:262:26 | ...::args | main.rs:164:13:164:24 | ...::malloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
+| main.rs:165:13:165:31 | ...::aligned_alloc | main.rs:262:13:262:26 | ...::args | main.rs:165:13:165:31 | ...::aligned_alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
+| main.rs:165:13:165:31 | ...::aligned_alloc | main.rs:262:13:262:26 | ...::args | main.rs:165:13:165:31 | ...::aligned_alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
+| main.rs:167:13:167:24 | ...::calloc | main.rs:262:13:262:26 | ...::args | main.rs:167:13:167:24 | ...::calloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
+| main.rs:167:13:167:24 | ...::calloc | main.rs:262:13:262:26 | ...::args | main.rs:167:13:167:24 | ...::calloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
+| main.rs:168:13:168:24 | ...::calloc | main.rs:262:13:262:26 | ...::args | main.rs:168:13:168:24 | ...::calloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
+| main.rs:168:13:168:24 | ...::calloc | main.rs:262:13:262:26 | ...::args | main.rs:168:13:168:24 | ...::calloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
+| main.rs:169:13:169:25 | ...::realloc | main.rs:262:13:262:26 | ...::args | main.rs:169:13:169:25 | ...::realloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
+| main.rs:169:13:169:25 | ...::realloc | main.rs:262:13:262:26 | ...::args | main.rs:169:13:169:25 | ...::realloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:262:13:262:26 | ...::args | user-provided value |
+| main.rs:229:22:229:38 | ...::alloc | main.rs:253:25:253:38 | ...::args | main.rs:229:22:229:38 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:253:25:253:38 | ...::args | user-provided value |
+| main.rs:246:22:246:38 | ...::alloc | main.rs:254:26:254:39 | ...::args | main.rs:246:22:246:38 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:254:26:254:39 | ...::args | user-provided value |
 edges
 | main.rs:12:36:12:43 | ...: usize | main.rs:18:41:18:41 | v | provenance |  |
 | main.rs:18:41:18:41 | v | main.rs:18:13:18:31 | ...::realloc | provenance | MaD:5 Sink:MaD:5 |
@@ -227,22 +229,49 @@ edges
 | main.rs:168:26:168:26 | v | main.rs:169:31:169:31 | v | provenance |  |
 | main.rs:169:31:169:31 | v | main.rs:169:13:169:25 | ...::realloc | provenance | MaD:15 Sink:MaD:15 |
 | main.rs:169:31:169:31 | v | main.rs:169:13:169:25 | ...::realloc | provenance | MaD:15 Sink:MaD:15 |
-| main.rs:211:9:211:9 | v | main.rs:214:34:214:34 | v | provenance |  |
-| main.rs:211:9:211:9 | v | main.rs:215:42:215:42 | v | provenance |  |
-| main.rs:211:9:211:9 | v | main.rs:216:36:216:36 | v | provenance |  |
-| main.rs:211:9:211:9 | v | main.rs:217:27:217:27 | v | provenance |  |
-| main.rs:211:9:211:9 | v | main.rs:218:25:218:25 | v | provenance |  |
-| main.rs:211:13:211:26 | ...::args | main.rs:211:13:211:28 | ...::args(...) [element] | provenance | Src:MaD:16  |
-| main.rs:211:13:211:28 | ...::args(...) [element] | main.rs:211:13:211:35 | ... .nth(...) [Some] | provenance | MaD:35 |
-| main.rs:211:13:211:35 | ... .nth(...) [Some] | main.rs:211:13:211:65 | ... .unwrap_or(...) | provenance | MaD:29 |
-| main.rs:211:13:211:65 | ... .unwrap_or(...) | main.rs:211:13:211:82 | ... .parse(...) [Ok] | provenance | MaD:32 |
-| main.rs:211:13:211:82 | ... .parse(...) [Ok] | main.rs:211:13:211:91 | ... .unwrap(...) | provenance | MaD:31 |
-| main.rs:211:13:211:91 | ... .unwrap(...) | main.rs:211:9:211:9 | v | provenance |  |
-| main.rs:214:34:214:34 | v | main.rs:12:36:12:43 | ...: usize | provenance |  |
-| main.rs:215:42:215:42 | v | main.rs:43:44:43:51 | ...: usize | provenance |  |
-| main.rs:216:36:216:36 | v | main.rs:81:38:81:45 | ...: usize | provenance |  |
-| main.rs:217:27:217:27 | v | main.rs:128:29:128:36 | ...: usize | provenance |  |
-| main.rs:218:25:218:25 | v | main.rs:162:27:162:34 | ...: usize | provenance |  |
+| main.rs:224:24:224:41 | ...: String | main.rs:225:21:225:47 | user_input.parse(...) [Ok] | provenance | MaD:32 |
+| main.rs:225:9:225:17 | num_bytes | main.rs:227:54:227:62 | num_bytes | provenance |  |
+| main.rs:225:21:225:47 | user_input.parse(...) [Ok] | main.rs:225:21:225:48 | TryExpr | provenance |  |
+| main.rs:225:21:225:48 | TryExpr | main.rs:225:9:225:17 | num_bytes | provenance |  |
+| main.rs:227:9:227:14 | layout | main.rs:229:40:229:45 | layout | provenance |  |
+| main.rs:227:18:227:66 | ...::from_size_align(...) [Ok] | main.rs:227:18:227:75 | ... .unwrap(...) | provenance | MaD:31 |
+| main.rs:227:18:227:75 | ... .unwrap(...) | main.rs:227:9:227:14 | layout | provenance |  |
+| main.rs:227:54:227:62 | num_bytes | main.rs:227:18:227:66 | ...::from_size_align(...) [Ok] | provenance | MaD:23 |
+| main.rs:229:40:229:45 | layout | main.rs:229:22:229:38 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:237:25:237:42 | ...: String | main.rs:238:16:238:42 | user_input.parse(...) [Ok] | provenance | MaD:32 |
+| main.rs:238:9:238:12 | size | main.rs:242:9:242:17 | num_bytes | provenance |  |
+| main.rs:238:16:238:42 | user_input.parse(...) [Ok] | main.rs:238:16:238:43 | TryExpr | provenance |  |
+| main.rs:238:16:238:43 | TryExpr | main.rs:238:9:238:12 | size | provenance |  |
+| main.rs:242:9:242:17 | num_bytes | main.rs:244:54:244:62 | num_bytes | provenance |  |
+| main.rs:244:9:244:14 | layout | main.rs:246:40:246:45 | layout | provenance |  |
+| main.rs:244:18:244:66 | ...::from_size_align(...) [Ok] | main.rs:244:18:244:75 | ... .unwrap(...) | provenance | MaD:31 |
+| main.rs:244:18:244:75 | ... .unwrap(...) | main.rs:244:9:244:14 | layout | provenance |  |
+| main.rs:244:54:244:62 | num_bytes | main.rs:244:18:244:66 | ...::from_size_align(...) [Ok] | provenance | MaD:23 |
+| main.rs:246:40:246:45 | layout | main.rs:246:22:246:38 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:253:25:253:38 | ...::args | main.rs:253:25:253:40 | ...::args(...) [element] | provenance | Src:MaD:16  |
+| main.rs:253:25:253:40 | ...::args(...) [element] | main.rs:253:25:253:47 | ... .nth(...) [Some] | provenance | MaD:35 |
+| main.rs:253:25:253:47 | ... .nth(...) [Some] | main.rs:253:25:253:74 | ... .unwrap_or(...) | provenance | MaD:29 |
+| main.rs:253:25:253:74 | ... .unwrap_or(...) | main.rs:224:24:224:41 | ...: String | provenance |  |
+| main.rs:254:26:254:39 | ...::args | main.rs:254:26:254:41 | ...::args(...) [element] | provenance | Src:MaD:16  |
+| main.rs:254:26:254:41 | ...::args(...) [element] | main.rs:254:26:254:48 | ... .nth(...) [Some] | provenance | MaD:35 |
+| main.rs:254:26:254:48 | ... .nth(...) [Some] | main.rs:254:26:254:75 | ... .unwrap_or(...) | provenance | MaD:29 |
+| main.rs:254:26:254:75 | ... .unwrap_or(...) | main.rs:237:25:237:42 | ...: String | provenance |  |
+| main.rs:262:9:262:9 | v | main.rs:265:34:265:34 | v | provenance |  |
+| main.rs:262:9:262:9 | v | main.rs:266:42:266:42 | v | provenance |  |
+| main.rs:262:9:262:9 | v | main.rs:267:36:267:36 | v | provenance |  |
+| main.rs:262:9:262:9 | v | main.rs:268:27:268:27 | v | provenance |  |
+| main.rs:262:9:262:9 | v | main.rs:269:25:269:25 | v | provenance |  |
+| main.rs:262:13:262:26 | ...::args | main.rs:262:13:262:28 | ...::args(...) [element] | provenance | Src:MaD:16  |
+| main.rs:262:13:262:28 | ...::args(...) [element] | main.rs:262:13:262:35 | ... .nth(...) [Some] | provenance | MaD:35 |
+| main.rs:262:13:262:35 | ... .nth(...) [Some] | main.rs:262:13:262:65 | ... .unwrap_or(...) | provenance | MaD:29 |
+| main.rs:262:13:262:65 | ... .unwrap_or(...) | main.rs:262:13:262:82 | ... .parse(...) [Ok] | provenance | MaD:32 |
+| main.rs:262:13:262:82 | ... .parse(...) [Ok] | main.rs:262:13:262:91 | ... .unwrap(...) | provenance | MaD:31 |
+| main.rs:262:13:262:91 | ... .unwrap(...) | main.rs:262:9:262:9 | v | provenance |  |
+| main.rs:265:34:265:34 | v | main.rs:12:36:12:43 | ...: usize | provenance |  |
+| main.rs:266:42:266:42 | v | main.rs:43:44:43:51 | ...: usize | provenance |  |
+| main.rs:267:36:267:36 | v | main.rs:81:38:81:45 | ...: usize | provenance |  |
+| main.rs:268:27:268:27 | v | main.rs:128:29:128:36 | ...: usize | provenance |  |
+| main.rs:269:25:269:25 | v | main.rs:162:27:162:34 | ...: usize | provenance |  |
 models
 | 1 | Sink: lang:alloc; <crate::alloc::Global as crate::alloc::Allocator>::allocate; alloc-layout; Argument[0] |
 | 2 | Sink: lang:alloc; <crate::alloc::Global as crate::alloc::Allocator>::allocate_zeroed; alloc-layout; Argument[0] |
@@ -461,17 +490,46 @@ nodes
 | main.rs:169:13:169:25 | ...::realloc | semmle.label | ...::realloc |
 | main.rs:169:13:169:25 | ...::realloc | semmle.label | ...::realloc |
 | main.rs:169:31:169:31 | v | semmle.label | v |
-| main.rs:211:9:211:9 | v | semmle.label | v |
-| main.rs:211:13:211:26 | ...::args | semmle.label | ...::args |
-| main.rs:211:13:211:28 | ...::args(...) [element] | semmle.label | ...::args(...) [element] |
-| main.rs:211:13:211:35 | ... .nth(...) [Some] | semmle.label | ... .nth(...) [Some] |
-| main.rs:211:13:211:65 | ... .unwrap_or(...) | semmle.label | ... .unwrap_or(...) |
-| main.rs:211:13:211:82 | ... .parse(...) [Ok] | semmle.label | ... .parse(...) [Ok] |
-| main.rs:211:13:211:91 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
-| main.rs:214:34:214:34 | v | semmle.label | v |
-| main.rs:215:42:215:42 | v | semmle.label | v |
-| main.rs:216:36:216:36 | v | semmle.label | v |
-| main.rs:217:27:217:27 | v | semmle.label | v |
-| main.rs:218:25:218:25 | v | semmle.label | v |
+| main.rs:224:24:224:41 | ...: String | semmle.label | ...: String |
+| main.rs:225:9:225:17 | num_bytes | semmle.label | num_bytes |
+| main.rs:225:21:225:47 | user_input.parse(...) [Ok] | semmle.label | user_input.parse(...) [Ok] |
+| main.rs:225:21:225:48 | TryExpr | semmle.label | TryExpr |
+| main.rs:227:9:227:14 | layout | semmle.label | layout |
+| main.rs:227:18:227:66 | ...::from_size_align(...) [Ok] | semmle.label | ...::from_size_align(...) [Ok] |
+| main.rs:227:18:227:75 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
+| main.rs:227:54:227:62 | num_bytes | semmle.label | num_bytes |
+| main.rs:229:22:229:38 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:229:40:229:45 | layout | semmle.label | layout |
+| main.rs:237:25:237:42 | ...: String | semmle.label | ...: String |
+| main.rs:238:9:238:12 | size | semmle.label | size |
+| main.rs:238:16:238:42 | user_input.parse(...) [Ok] | semmle.label | user_input.parse(...) [Ok] |
+| main.rs:238:16:238:43 | TryExpr | semmle.label | TryExpr |
+| main.rs:242:9:242:17 | num_bytes | semmle.label | num_bytes |
+| main.rs:244:9:244:14 | layout | semmle.label | layout |
+| main.rs:244:18:244:66 | ...::from_size_align(...) [Ok] | semmle.label | ...::from_size_align(...) [Ok] |
+| main.rs:244:18:244:75 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
+| main.rs:244:54:244:62 | num_bytes | semmle.label | num_bytes |
+| main.rs:246:22:246:38 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:246:40:246:45 | layout | semmle.label | layout |
+| main.rs:253:25:253:38 | ...::args | semmle.label | ...::args |
+| main.rs:253:25:253:40 | ...::args(...) [element] | semmle.label | ...::args(...) [element] |
+| main.rs:253:25:253:47 | ... .nth(...) [Some] | semmle.label | ... .nth(...) [Some] |
+| main.rs:253:25:253:74 | ... .unwrap_or(...) | semmle.label | ... .unwrap_or(...) |
+| main.rs:254:26:254:39 | ...::args | semmle.label | ...::args |
+| main.rs:254:26:254:41 | ...::args(...) [element] | semmle.label | ...::args(...) [element] |
+| main.rs:254:26:254:48 | ... .nth(...) [Some] | semmle.label | ... .nth(...) [Some] |
+| main.rs:254:26:254:75 | ... .unwrap_or(...) | semmle.label | ... .unwrap_or(...) |
+| main.rs:262:9:262:9 | v | semmle.label | v |
+| main.rs:262:13:262:26 | ...::args | semmle.label | ...::args |
+| main.rs:262:13:262:28 | ...::args(...) [element] | semmle.label | ...::args(...) [element] |
+| main.rs:262:13:262:35 | ... .nth(...) [Some] | semmle.label | ... .nth(...) [Some] |
+| main.rs:262:13:262:65 | ... .unwrap_or(...) | semmle.label | ... .unwrap_or(...) |
+| main.rs:262:13:262:82 | ... .parse(...) [Ok] | semmle.label | ... .parse(...) [Ok] |
+| main.rs:262:13:262:91 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
+| main.rs:265:34:265:34 | v | semmle.label | v |
+| main.rs:266:42:266:42 | v | semmle.label | v |
+| main.rs:267:36:267:36 | v | semmle.label | v |
+| main.rs:268:27:268:27 | v | semmle.label | v |
+| main.rs:269:25:269:25 | v | semmle.label | v |
 subpaths
 | main.rs:116:53:116:53 | v | main.rs:71:35:71:38 | ...: T | main.rs:77:9:77:16 | return v | main.rs:116:47:116:62 | clamp(...) |

--- a/rust/ql/test/query-tests/security/CWE-770/UncontrolledAllocationSize.expected
+++ b/rust/ql/test/query-tests/security/CWE-770/UncontrolledAllocationSize.expected
@@ -18,11 +18,18 @@
 | main.rs:64:13:64:29 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:64:13:64:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
 | main.rs:65:13:65:29 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:65:13:65:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
 | main.rs:68:13:68:29 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:68:13:68:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:88:13:88:29 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:88:13:88:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
 | main.rs:96:17:96:33 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:96:17:96:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
 | main.rs:102:17:102:33 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:102:17:102:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:103:17:103:33 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:103:17:103:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
 | main.rs:109:17:109:33 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:109:17:109:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
 | main.rs:111:17:111:33 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:111:17:111:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
 | main.rs:146:17:146:33 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:146:17:146:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:148:17:148:33 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:148:17:148:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:152:13:152:29 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:152:13:152:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:155:13:155:29 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:155:13:155:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:162:17:162:33 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:162:17:162:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
+| main.rs:169:17:169:33 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:169:17:169:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
 | main.rs:177:13:177:29 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:177:13:177:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
 | main.rs:193:32:193:36 | alloc | main.rs:317:13:317:26 | ...::args | main.rs:193:32:193:36 | alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
 | main.rs:194:32:194:43 | alloc_zeroed | main.rs:317:13:317:26 | ...::args | main.rs:194:32:194:43 | alloc_zeroed | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
@@ -133,7 +140,19 @@ edges
 | main.rs:67:14:67:56 | ... .unwrap(...) | main.rs:67:9:67:10 | l4 | provenance |  |
 | main.rs:67:46:67:46 | v | main.rs:67:14:67:47 | ...::array::<...>(...) [Ok] | provenance | MaD:18 |
 | main.rs:68:31:68:32 | l4 | main.rs:68:13:68:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:86:35:86:42 | ...: usize | main.rs:87:54:87:54 | v | provenance |  |
+| main.rs:87:9:87:14 | layout | main.rs:88:31:88:36 | layout | provenance |  |
+| main.rs:87:18:87:58 | ...::from_size_align(...) [Ok] | main.rs:87:18:87:67 | ... .unwrap(...) | provenance | MaD:31 |
+| main.rs:87:18:87:67 | ... .unwrap(...) | main.rs:87:9:87:14 | layout | provenance |  |
+| main.rs:87:54:87:54 | v | main.rs:87:18:87:58 | ...::from_size_align(...) [Ok] | provenance | MaD:23 |
+| main.rs:88:31:88:36 | layout | main.rs:88:13:88:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
 | main.rs:91:38:91:45 | ...: usize | main.rs:92:47:92:47 | v | provenance |  |
+| main.rs:91:38:91:45 | ...: usize | main.rs:101:51:101:51 | v | provenance |  |
+| main.rs:91:38:91:45 | ...: usize | main.rs:105:33:105:33 | v | provenance |  |
+| main.rs:91:38:91:45 | ...: usize | main.rs:145:51:145:51 | v | provenance |  |
+| main.rs:91:38:91:45 | ...: usize | main.rs:151:62:151:62 | v | provenance |  |
+| main.rs:91:38:91:45 | ...: usize | main.rs:154:62:154:62 | v | provenance |  |
+| main.rs:91:38:91:45 | ...: usize | main.rs:161:55:161:55 | v | provenance |  |
 | main.rs:92:9:92:10 | l1 | main.rs:96:35:96:36 | l1 | provenance |  |
 | main.rs:92:9:92:10 | l1 | main.rs:102:35:102:36 | l1 | provenance |  |
 | main.rs:92:14:92:48 | ...::array::<...>(...) [Ok] | main.rs:92:14:92:57 | ... .unwrap(...) | provenance | MaD:31 |
@@ -142,15 +161,45 @@ edges
 | main.rs:96:35:96:36 | l1 | main.rs:96:17:96:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
 | main.rs:96:35:96:36 | l1 | main.rs:109:35:109:36 | l1 | provenance |  |
 | main.rs:96:35:96:36 | l1 | main.rs:111:35:111:36 | l1 | provenance |  |
+| main.rs:101:13:101:14 | l3 | main.rs:103:35:103:36 | l3 | provenance |  |
+| main.rs:101:18:101:52 | ...::array::<...>(...) [Ok] | main.rs:101:18:101:61 | ... .unwrap(...) | provenance | MaD:31 |
+| main.rs:101:18:101:61 | ... .unwrap(...) | main.rs:101:13:101:14 | l3 | provenance |  |
+| main.rs:101:51:101:51 | v | main.rs:101:18:101:52 | ...::array::<...>(...) [Ok] | provenance | MaD:18 |
 | main.rs:102:35:102:36 | l1 | main.rs:102:17:102:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
 | main.rs:102:35:102:36 | l1 | main.rs:109:35:109:36 | l1 | provenance |  |
 | main.rs:102:35:102:36 | l1 | main.rs:111:35:111:36 | l1 | provenance |  |
+| main.rs:103:35:103:36 | l3 | main.rs:103:17:103:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:105:33:105:33 | v | main.rs:86:35:86:42 | ...: usize | provenance |  |
 | main.rs:109:35:109:36 | l1 | main.rs:109:17:109:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
 | main.rs:109:35:109:36 | l1 | main.rs:146:35:146:36 | l1 | provenance |  |
 | main.rs:111:35:111:36 | l1 | main.rs:111:17:111:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
 | main.rs:111:35:111:36 | l1 | main.rs:146:35:146:36 | l1 | provenance |  |
+| main.rs:145:13:145:14 | l9 | main.rs:148:35:148:36 | l9 | provenance |  |
+| main.rs:145:18:145:52 | ...::array::<...>(...) [Ok] | main.rs:145:18:145:61 | ... .unwrap(...) | provenance | MaD:31 |
+| main.rs:145:18:145:61 | ... .unwrap(...) | main.rs:145:13:145:14 | l9 | provenance |  |
+| main.rs:145:51:145:51 | v | main.rs:145:18:145:52 | ...::array::<...>(...) [Ok] | provenance | MaD:18 |
 | main.rs:146:35:146:36 | l1 | main.rs:146:17:146:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
 | main.rs:146:35:146:36 | l1 | main.rs:177:31:177:32 | l1 | provenance |  |
+| main.rs:148:35:148:36 | l9 | main.rs:148:17:148:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:151:9:151:11 | l10 | main.rs:152:31:152:33 | l10 | provenance |  |
+| main.rs:151:15:151:69 | ...::array::<...>(...) [Ok] | main.rs:151:15:151:78 | ... .unwrap(...) | provenance | MaD:31 |
+| main.rs:151:15:151:78 | ... .unwrap(...) | main.rs:151:9:151:11 | l10 | provenance |  |
+| main.rs:151:48:151:68 | ...::min(...) | main.rs:151:15:151:69 | ...::array::<...>(...) [Ok] | provenance | MaD:18 |
+| main.rs:151:62:151:62 | v | main.rs:151:48:151:68 | ...::min(...) | provenance | MaD:34 |
+| main.rs:152:31:152:33 | l10 | main.rs:152:13:152:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:154:9:154:11 | l11 | main.rs:155:31:155:33 | l11 | provenance |  |
+| main.rs:154:15:154:69 | ...::array::<...>(...) [Ok] | main.rs:154:15:154:78 | ... .unwrap(...) | provenance | MaD:31 |
+| main.rs:154:15:154:78 | ... .unwrap(...) | main.rs:154:9:154:11 | l11 | provenance |  |
+| main.rs:154:48:154:68 | ...::max(...) | main.rs:154:15:154:69 | ...::array::<...>(...) [Ok] | provenance | MaD:18 |
+| main.rs:154:62:154:62 | v | main.rs:154:48:154:68 | ...::max(...) | provenance | MaD:33 |
+| main.rs:155:31:155:33 | l11 | main.rs:155:13:155:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:161:13:161:15 | l13 | main.rs:162:35:162:37 | l13 | provenance |  |
+| main.rs:161:19:161:59 | ...::from_size_align(...) [Ok] | main.rs:161:19:161:68 | ... .unwrap(...) | provenance | MaD:31 |
+| main.rs:161:19:161:68 | ... .unwrap(...) | main.rs:161:13:161:15 | l13 | provenance |  |
+| main.rs:161:55:161:55 | v | main.rs:161:19:161:59 | ...::from_size_align(...) [Ok] | provenance | MaD:23 |
+| main.rs:162:35:162:37 | l13 | main.rs:162:17:162:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:162:35:162:37 | l13 | main.rs:169:35:169:37 | l13 | provenance |  |
+| main.rs:169:35:169:37 | l13 | main.rs:169:17:169:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
 | main.rs:177:31:177:32 | l1 | main.rs:177:13:177:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
 | main.rs:183:29:183:36 | ...: usize | main.rs:192:46:192:46 | v | provenance |  |
 | main.rs:192:9:192:10 | l2 | main.rs:193:38:193:39 | l2 | provenance |  |
@@ -197,7 +246,7 @@ edges
 | main.rs:282:54:282:62 | num_bytes | main.rs:282:18:282:66 | ...::from_size_align(...) [Ok] | provenance | MaD:23 |
 | main.rs:284:40:284:45 | layout | main.rs:284:22:284:38 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
 | main.rs:308:25:308:38 | ...::args | main.rs:308:25:308:40 | ...::args(...) [element] | provenance | Src:MaD:16  |
-| main.rs:308:25:308:40 | ...::args(...) [element] | main.rs:308:25:308:47 | ... .nth(...) [Some] | provenance | MaD:33 |
+| main.rs:308:25:308:40 | ...::args(...) [element] | main.rs:308:25:308:47 | ... .nth(...) [Some] | provenance | MaD:35 |
 | main.rs:308:25:308:47 | ... .nth(...) [Some] | main.rs:308:25:308:74 | ... .unwrap_or(...) | provenance | MaD:29 |
 | main.rs:308:25:308:74 | ... .unwrap_or(...) | main.rs:279:24:279:41 | ...: String | provenance |  |
 | main.rs:317:9:317:9 | v | main.rs:320:34:320:34 | v | provenance |  |
@@ -206,7 +255,7 @@ edges
 | main.rs:317:9:317:9 | v | main.rs:323:27:323:27 | v | provenance |  |
 | main.rs:317:9:317:9 | v | main.rs:324:25:324:25 | v | provenance |  |
 | main.rs:317:13:317:26 | ...::args | main.rs:317:13:317:28 | ...::args(...) [element] | provenance | Src:MaD:16  |
-| main.rs:317:13:317:28 | ...::args(...) [element] | main.rs:317:13:317:35 | ... .nth(...) [Some] | provenance | MaD:33 |
+| main.rs:317:13:317:28 | ...::args(...) [element] | main.rs:317:13:317:35 | ... .nth(...) [Some] | provenance | MaD:35 |
 | main.rs:317:13:317:35 | ... .nth(...) [Some] | main.rs:317:13:317:65 | ... .unwrap_or(...) | provenance | MaD:29 |
 | main.rs:317:13:317:65 | ... .unwrap_or(...) | main.rs:317:13:317:82 | ... .parse(...) [Ok] | provenance | MaD:32 |
 | main.rs:317:13:317:82 | ... .parse(...) [Ok] | main.rs:317:13:317:91 | ... .unwrap(...) | provenance | MaD:31 |
@@ -249,7 +298,9 @@ models
 | 30 | Summary: lang:core; <crate::result::Result>::expect; Argument[self].Field[crate::result::Result::Ok(0)]; ReturnValue; value |
 | 31 | Summary: lang:core; <crate::result::Result>::unwrap; Argument[self].Field[crate::result::Result::Ok(0)]; ReturnValue; value |
 | 32 | Summary: lang:core; <str>::parse; Argument[self]; ReturnValue.Field[crate::result::Result::Ok(0)]; taint |
-| 33 | Summary: lang:core; crate::iter::traits::iterator::Iterator::nth; Argument[self].Element; ReturnValue.Field[crate::option::Option::Some(0)]; value |
+| 33 | Summary: lang:core; crate::cmp::max; Argument[0]; ReturnValue; value |
+| 34 | Summary: lang:core; crate::cmp::min; Argument[0]; ReturnValue; value |
+| 35 | Summary: lang:core; crate::iter::traits::iterator::Iterator::nth; Argument[self].Element; ReturnValue.Field[crate::option::Option::Some(0)]; value |
 nodes
 | main.rs:12:36:12:43 | ...: usize | semmle.label | ...: usize |
 | main.rs:18:13:18:31 | ...::realloc | semmle.label | ...::realloc |
@@ -342,6 +393,13 @@ nodes
 | main.rs:67:46:67:46 | v | semmle.label | v |
 | main.rs:68:13:68:29 | ...::alloc | semmle.label | ...::alloc |
 | main.rs:68:31:68:32 | l4 | semmle.label | l4 |
+| main.rs:86:35:86:42 | ...: usize | semmle.label | ...: usize |
+| main.rs:87:9:87:14 | layout | semmle.label | layout |
+| main.rs:87:18:87:58 | ...::from_size_align(...) [Ok] | semmle.label | ...::from_size_align(...) [Ok] |
+| main.rs:87:18:87:67 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
+| main.rs:87:54:87:54 | v | semmle.label | v |
+| main.rs:88:13:88:29 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:88:31:88:36 | layout | semmle.label | layout |
 | main.rs:91:38:91:45 | ...: usize | semmle.label | ...: usize |
 | main.rs:92:9:92:10 | l1 | semmle.label | l1 |
 | main.rs:92:14:92:48 | ...::array::<...>(...) [Ok] | semmle.label | ...::array::<...>(...) [Ok] |
@@ -349,14 +407,49 @@ nodes
 | main.rs:92:47:92:47 | v | semmle.label | v |
 | main.rs:96:17:96:33 | ...::alloc | semmle.label | ...::alloc |
 | main.rs:96:35:96:36 | l1 | semmle.label | l1 |
+| main.rs:101:13:101:14 | l3 | semmle.label | l3 |
+| main.rs:101:18:101:52 | ...::array::<...>(...) [Ok] | semmle.label | ...::array::<...>(...) [Ok] |
+| main.rs:101:18:101:61 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
+| main.rs:101:51:101:51 | v | semmle.label | v |
 | main.rs:102:17:102:33 | ...::alloc | semmle.label | ...::alloc |
 | main.rs:102:35:102:36 | l1 | semmle.label | l1 |
+| main.rs:103:17:103:33 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:103:35:103:36 | l3 | semmle.label | l3 |
+| main.rs:105:33:105:33 | v | semmle.label | v |
 | main.rs:109:17:109:33 | ...::alloc | semmle.label | ...::alloc |
 | main.rs:109:35:109:36 | l1 | semmle.label | l1 |
 | main.rs:111:17:111:33 | ...::alloc | semmle.label | ...::alloc |
 | main.rs:111:35:111:36 | l1 | semmle.label | l1 |
+| main.rs:145:13:145:14 | l9 | semmle.label | l9 |
+| main.rs:145:18:145:52 | ...::array::<...>(...) [Ok] | semmle.label | ...::array::<...>(...) [Ok] |
+| main.rs:145:18:145:61 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
+| main.rs:145:51:145:51 | v | semmle.label | v |
 | main.rs:146:17:146:33 | ...::alloc | semmle.label | ...::alloc |
 | main.rs:146:35:146:36 | l1 | semmle.label | l1 |
+| main.rs:148:17:148:33 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:148:35:148:36 | l9 | semmle.label | l9 |
+| main.rs:151:9:151:11 | l10 | semmle.label | l10 |
+| main.rs:151:15:151:69 | ...::array::<...>(...) [Ok] | semmle.label | ...::array::<...>(...) [Ok] |
+| main.rs:151:15:151:78 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
+| main.rs:151:48:151:68 | ...::min(...) | semmle.label | ...::min(...) |
+| main.rs:151:62:151:62 | v | semmle.label | v |
+| main.rs:152:13:152:29 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:152:31:152:33 | l10 | semmle.label | l10 |
+| main.rs:154:9:154:11 | l11 | semmle.label | l11 |
+| main.rs:154:15:154:69 | ...::array::<...>(...) [Ok] | semmle.label | ...::array::<...>(...) [Ok] |
+| main.rs:154:15:154:78 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
+| main.rs:154:48:154:68 | ...::max(...) | semmle.label | ...::max(...) |
+| main.rs:154:62:154:62 | v | semmle.label | v |
+| main.rs:155:13:155:29 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:155:31:155:33 | l11 | semmle.label | l11 |
+| main.rs:161:13:161:15 | l13 | semmle.label | l13 |
+| main.rs:161:19:161:59 | ...::from_size_align(...) [Ok] | semmle.label | ...::from_size_align(...) [Ok] |
+| main.rs:161:19:161:68 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
+| main.rs:161:55:161:55 | v | semmle.label | v |
+| main.rs:162:17:162:33 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:162:35:162:37 | l13 | semmle.label | l13 |
+| main.rs:169:17:169:33 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:169:35:169:37 | l13 | semmle.label | l13 |
 | main.rs:177:13:177:29 | ...::alloc | semmle.label | ...::alloc |
 | main.rs:177:31:177:32 | l1 | semmle.label | l1 |
 | main.rs:183:29:183:36 | ...: usize | semmle.label | ...: usize |

--- a/rust/ql/test/query-tests/security/CWE-770/UncontrolledAllocationSize.expected
+++ b/rust/ql/test/query-tests/security/CWE-770/UncontrolledAllocationSize.expected
@@ -1,0 +1,4 @@
+#select
+edges
+nodes
+subpaths

--- a/rust/ql/test/query-tests/security/CWE-770/UncontrolledAllocationSize.expected
+++ b/rust/ql/test/query-tests/security/CWE-770/UncontrolledAllocationSize.expected
@@ -40,14 +40,9 @@
 | main.rs:208:40:208:43 | grow | main.rs:317:13:317:26 | ...::args | main.rs:208:40:208:43 | grow | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
 | main.rs:210:40:210:50 | grow_zeroed | main.rs:317:13:317:26 | ...::args | main.rs:210:40:210:50 | grow_zeroed | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
 | main.rs:219:13:219:24 | ...::malloc | main.rs:317:13:317:26 | ...::args | main.rs:219:13:219:24 | ...::malloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
-| main.rs:219:13:219:24 | ...::malloc | main.rs:317:13:317:26 | ...::args | main.rs:219:13:219:24 | ...::malloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
-| main.rs:220:13:220:31 | ...::aligned_alloc | main.rs:317:13:317:26 | ...::args | main.rs:220:13:220:31 | ...::aligned_alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
 | main.rs:220:13:220:31 | ...::aligned_alloc | main.rs:317:13:317:26 | ...::args | main.rs:220:13:220:31 | ...::aligned_alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
 | main.rs:222:13:222:24 | ...::calloc | main.rs:317:13:317:26 | ...::args | main.rs:222:13:222:24 | ...::calloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
-| main.rs:222:13:222:24 | ...::calloc | main.rs:317:13:317:26 | ...::args | main.rs:222:13:222:24 | ...::calloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
 | main.rs:223:13:223:24 | ...::calloc | main.rs:317:13:317:26 | ...::args | main.rs:223:13:223:24 | ...::calloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
-| main.rs:223:13:223:24 | ...::calloc | main.rs:317:13:317:26 | ...::args | main.rs:223:13:223:24 | ...::calloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
-| main.rs:224:13:224:25 | ...::realloc | main.rs:317:13:317:26 | ...::args | main.rs:224:13:224:25 | ...::realloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
 | main.rs:224:13:224:25 | ...::realloc | main.rs:317:13:317:26 | ...::args | main.rs:224:13:224:25 | ...::realloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
 | main.rs:284:22:284:38 | ...::alloc | main.rs:308:25:308:38 | ...::args | main.rs:284:22:284:38 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:308:25:308:38 | ...::args | user-provided value |
 edges
@@ -223,18 +218,13 @@ edges
 | main.rs:210:60:210:61 | l2 | main.rs:210:40:210:50 | grow_zeroed | provenance | MaD:9 Sink:MaD:9 |
 | main.rs:217:27:217:34 | ...: usize | main.rs:219:26:219:26 | v | provenance |  |
 | main.rs:219:26:219:26 | v | main.rs:219:13:219:24 | ...::malloc | provenance | MaD:14 Sink:MaD:14 |
-| main.rs:219:26:219:26 | v | main.rs:219:13:219:24 | ...::malloc | provenance | MaD:14 Sink:MaD:14 |
 | main.rs:219:26:219:26 | v | main.rs:220:36:220:36 | v | provenance |  |
-| main.rs:220:36:220:36 | v | main.rs:220:13:220:31 | ...::aligned_alloc | provenance | MaD:12 Sink:MaD:12 |
 | main.rs:220:36:220:36 | v | main.rs:220:13:220:31 | ...::aligned_alloc | provenance | MaD:12 Sink:MaD:12 |
 | main.rs:220:36:220:36 | v | main.rs:222:30:222:30 | v | provenance |  |
 | main.rs:222:30:222:30 | v | main.rs:222:13:222:24 | ...::calloc | provenance | MaD:13 Sink:MaD:13 |
-| main.rs:222:30:222:30 | v | main.rs:222:13:222:24 | ...::calloc | provenance | MaD:13 Sink:MaD:13 |
 | main.rs:222:30:222:30 | v | main.rs:223:26:223:26 | v | provenance |  |
 | main.rs:223:26:223:26 | v | main.rs:223:13:223:24 | ...::calloc | provenance | MaD:13 Sink:MaD:13 |
-| main.rs:223:26:223:26 | v | main.rs:223:13:223:24 | ...::calloc | provenance | MaD:13 Sink:MaD:13 |
 | main.rs:223:26:223:26 | v | main.rs:224:31:224:31 | v | provenance |  |
-| main.rs:224:31:224:31 | v | main.rs:224:13:224:25 | ...::realloc | provenance | MaD:15 Sink:MaD:15 |
 | main.rs:224:31:224:31 | v | main.rs:224:13:224:25 | ...::realloc | provenance | MaD:15 Sink:MaD:15 |
 | main.rs:279:24:279:41 | ...: String | main.rs:280:21:280:47 | user_input.parse(...) [Ok] | provenance | MaD:32 |
 | main.rs:280:9:280:17 | num_bytes | main.rs:282:54:282:62 | num_bytes | provenance |  |
@@ -475,18 +465,13 @@ nodes
 | main.rs:210:60:210:61 | l2 | semmle.label | l2 |
 | main.rs:217:27:217:34 | ...: usize | semmle.label | ...: usize |
 | main.rs:219:13:219:24 | ...::malloc | semmle.label | ...::malloc |
-| main.rs:219:13:219:24 | ...::malloc | semmle.label | ...::malloc |
 | main.rs:219:26:219:26 | v | semmle.label | v |
-| main.rs:220:13:220:31 | ...::aligned_alloc | semmle.label | ...::aligned_alloc |
 | main.rs:220:13:220:31 | ...::aligned_alloc | semmle.label | ...::aligned_alloc |
 | main.rs:220:36:220:36 | v | semmle.label | v |
 | main.rs:222:13:222:24 | ...::calloc | semmle.label | ...::calloc |
-| main.rs:222:13:222:24 | ...::calloc | semmle.label | ...::calloc |
 | main.rs:222:30:222:30 | v | semmle.label | v |
 | main.rs:223:13:223:24 | ...::calloc | semmle.label | ...::calloc |
-| main.rs:223:13:223:24 | ...::calloc | semmle.label | ...::calloc |
 | main.rs:223:26:223:26 | v | semmle.label | v |
-| main.rs:224:13:224:25 | ...::realloc | semmle.label | ...::realloc |
 | main.rs:224:13:224:25 | ...::realloc | semmle.label | ...::realloc |
 | main.rs:224:31:224:31 | v | semmle.label | v |
 | main.rs:279:24:279:41 | ...: String | semmle.label | ...: String |

--- a/rust/ql/test/query-tests/security/CWE-770/UncontrolledAllocationSize.expected
+++ b/rust/ql/test/query-tests/security/CWE-770/UncontrolledAllocationSize.expected
@@ -1,4 +1,447 @@
 #select
+| main.rs:18:13:18:31 | ...::realloc | main.rs:211:13:211:26 | ...::args | main.rs:18:13:18:31 | ...::realloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
+| main.rs:21:13:21:29 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:21:13:21:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
+| main.rs:24:13:24:36 | ...::alloc_zeroed | main.rs:211:13:211:26 | ...::args | main.rs:24:13:24:36 | ...::alloc_zeroed | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
+| main.rs:30:13:30:29 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:30:13:30:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
+| main.rs:33:13:33:29 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:33:13:33:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
+| main.rs:37:13:37:29 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:37:13:37:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
+| main.rs:50:13:50:29 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:50:13:50:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
+| main.rs:51:13:51:29 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:51:13:51:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
+| main.rs:53:13:53:29 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:53:13:53:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
+| main.rs:54:13:54:29 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:54:13:54:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
+| main.rs:59:13:59:29 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:59:13:59:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
+| main.rs:61:13:61:29 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:61:13:61:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
+| main.rs:63:13:63:29 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:63:13:63:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
+| main.rs:64:13:64:29 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:64:13:64:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
+| main.rs:65:13:65:29 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:65:13:65:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
+| main.rs:68:13:68:29 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:68:13:68:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
+| main.rs:85:17:85:33 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:85:17:85:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
+| main.rs:87:17:87:33 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:87:17:87:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
+| main.rs:91:17:91:33 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:91:17:91:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
+| main.rs:93:17:93:33 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:93:17:93:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
+| main.rs:104:17:104:33 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:104:17:104:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
+| main.rs:107:17:107:33 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:107:17:107:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
+| main.rs:111:13:111:29 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:111:13:111:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
+| main.rs:114:13:114:29 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:114:13:114:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
+| main.rs:117:13:117:29 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:117:13:117:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
+| main.rs:119:13:119:29 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:119:13:119:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
+| main.rs:123:13:123:29 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:123:13:123:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
+| main.rs:138:32:138:36 | alloc | main.rs:211:13:211:26 | ...::args | main.rs:138:32:138:36 | alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
+| main.rs:139:32:139:43 | alloc_zeroed | main.rs:211:13:211:26 | ...::args | main.rs:139:32:139:43 | alloc_zeroed | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
+| main.rs:140:32:140:39 | allocate | main.rs:211:13:211:26 | ...::args | main.rs:140:32:140:39 | allocate | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
+| main.rs:141:32:141:46 | allocate_zeroed | main.rs:211:13:211:26 | ...::args | main.rs:141:32:141:46 | allocate_zeroed | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
+| main.rs:142:32:142:39 | allocate | main.rs:211:13:211:26 | ...::args | main.rs:142:32:142:39 | allocate | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
+| main.rs:143:32:143:46 | allocate_zeroed | main.rs:211:13:211:26 | ...::args | main.rs:143:32:143:46 | allocate_zeroed | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
+| main.rs:153:40:153:43 | grow | main.rs:211:13:211:26 | ...::args | main.rs:153:40:153:43 | grow | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
+| main.rs:155:40:155:50 | grow_zeroed | main.rs:211:13:211:26 | ...::args | main.rs:155:40:155:50 | grow_zeroed | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
+| main.rs:164:13:164:24 | ...::malloc | main.rs:211:13:211:26 | ...::args | main.rs:164:13:164:24 | ...::malloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
+| main.rs:164:13:164:24 | ...::malloc | main.rs:211:13:211:26 | ...::args | main.rs:164:13:164:24 | ...::malloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
+| main.rs:165:13:165:31 | ...::aligned_alloc | main.rs:211:13:211:26 | ...::args | main.rs:165:13:165:31 | ...::aligned_alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
+| main.rs:165:13:165:31 | ...::aligned_alloc | main.rs:211:13:211:26 | ...::args | main.rs:165:13:165:31 | ...::aligned_alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
+| main.rs:167:13:167:24 | ...::calloc | main.rs:211:13:211:26 | ...::args | main.rs:167:13:167:24 | ...::calloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
+| main.rs:167:13:167:24 | ...::calloc | main.rs:211:13:211:26 | ...::args | main.rs:167:13:167:24 | ...::calloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
+| main.rs:168:13:168:24 | ...::calloc | main.rs:211:13:211:26 | ...::args | main.rs:168:13:168:24 | ...::calloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
+| main.rs:168:13:168:24 | ...::calloc | main.rs:211:13:211:26 | ...::args | main.rs:168:13:168:24 | ...::calloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
+| main.rs:169:13:169:25 | ...::realloc | main.rs:211:13:211:26 | ...::args | main.rs:169:13:169:25 | ...::realloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
+| main.rs:169:13:169:25 | ...::realloc | main.rs:211:13:211:26 | ...::args | main.rs:169:13:169:25 | ...::realloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
 edges
+| main.rs:12:36:12:43 | ...: usize | main.rs:18:41:18:41 | v | provenance |  |
+| main.rs:18:41:18:41 | v | main.rs:18:13:18:31 | ...::realloc | provenance | MaD:5 Sink:MaD:5 |
+| main.rs:18:41:18:41 | v | main.rs:20:50:20:50 | v | provenance |  |
+| main.rs:18:41:18:41 | v | main.rs:29:60:29:60 | v | provenance |  |
+| main.rs:18:41:18:41 | v | main.rs:32:60:32:89 | ... * ... | provenance |  |
+| main.rs:18:41:18:41 | v | main.rs:35:9:35:10 | s6 | provenance |  |
+| main.rs:20:9:20:10 | l2 | main.rs:21:31:21:32 | l2 | provenance |  |
+| main.rs:20:14:20:54 | ...::from_size_align(...) [Ok] | main.rs:20:14:20:63 | ... .unwrap(...) | provenance | MaD:28 |
+| main.rs:20:14:20:63 | ... .unwrap(...) | main.rs:20:9:20:10 | l2 | provenance |  |
+| main.rs:20:50:20:50 | v | main.rs:20:14:20:54 | ...::from_size_align(...) [Ok] | provenance | MaD:22 |
+| main.rs:21:31:21:32 | l2 | main.rs:21:13:21:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:21:31:21:32 | l2 | main.rs:24:38:24:39 | l2 | provenance |  |
+| main.rs:24:38:24:39 | l2 | main.rs:24:13:24:36 | ...::alloc_zeroed | provenance | MaD:4 Sink:MaD:4 |
+| main.rs:29:9:29:10 | l4 | main.rs:30:31:30:32 | l4 | provenance |  |
+| main.rs:29:14:29:64 | ...::from_size_align_unchecked(...) | main.rs:29:9:29:10 | l4 | provenance |  |
+| main.rs:29:60:29:60 | v | main.rs:29:14:29:64 | ...::from_size_align_unchecked(...) | provenance | MaD:23 |
+| main.rs:30:31:30:32 | l4 | main.rs:30:13:30:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:32:9:32:10 | l5 | main.rs:33:31:33:32 | l5 | provenance |  |
+| main.rs:32:14:32:118 | ...::from_size_align_unchecked(...) | main.rs:32:9:32:10 | l5 | provenance |  |
+| main.rs:32:60:32:89 | ... * ... | main.rs:32:14:32:118 | ...::from_size_align_unchecked(...) | provenance | MaD:23 |
+| main.rs:33:31:33:32 | l5 | main.rs:33:13:33:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:35:9:35:10 | s6 | main.rs:36:60:36:61 | s6 | provenance |  |
+| main.rs:36:9:36:10 | l6 | main.rs:37:31:37:32 | l6 | provenance |  |
+| main.rs:36:14:36:65 | ...::from_size_align_unchecked(...) | main.rs:36:9:36:10 | l6 | provenance |  |
+| main.rs:36:60:36:61 | s6 | main.rs:36:14:36:65 | ...::from_size_align_unchecked(...) | provenance | MaD:23 |
+| main.rs:37:31:37:32 | l6 | main.rs:37:13:37:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:43:44:43:51 | ...: usize | main.rs:50:41:50:41 | v | provenance |  |
+| main.rs:43:44:43:51 | ...: usize | main.rs:51:41:51:45 | ... + ... | provenance |  |
+| main.rs:43:44:43:51 | ...: usize | main.rs:53:48:53:48 | v | provenance |  |
+| main.rs:43:44:43:51 | ...: usize | main.rs:54:48:54:53 | ... * ... | provenance |  |
+| main.rs:43:44:43:51 | ...: usize | main.rs:58:34:58:34 | v | provenance |  |
+| main.rs:43:44:43:51 | ...: usize | main.rs:67:46:67:46 | v | provenance |  |
+| main.rs:50:31:50:42 | l2.repeat(...) [Ok, tuple.0] | main.rs:50:31:50:51 | ... .unwrap(...) [tuple.0] | provenance | MaD:28 |
+| main.rs:50:31:50:51 | ... .unwrap(...) [tuple.0] | main.rs:50:31:50:53 | ... .0 | provenance |  |
+| main.rs:50:31:50:53 | ... .0 | main.rs:50:13:50:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:50:41:50:41 | v | main.rs:50:31:50:42 | l2.repeat(...) [Ok, tuple.0] | provenance | MaD:24 |
+| main.rs:51:31:51:46 | l2.repeat(...) [Ok, tuple.0] | main.rs:51:31:51:55 | ... .unwrap(...) [tuple.0] | provenance | MaD:28 |
+| main.rs:51:31:51:55 | ... .unwrap(...) [tuple.0] | main.rs:51:31:51:57 | ... .0 | provenance |  |
+| main.rs:51:31:51:57 | ... .0 | main.rs:51:13:51:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:51:41:51:45 | ... + ... | main.rs:51:31:51:46 | l2.repeat(...) [Ok, tuple.0] | provenance | MaD:24 |
+| main.rs:53:31:53:49 | l2.repeat_packed(...) [Ok] | main.rs:53:31:53:58 | ... .unwrap(...) | provenance | MaD:28 |
+| main.rs:53:31:53:58 | ... .unwrap(...) | main.rs:53:13:53:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:53:48:53:48 | v | main.rs:53:31:53:49 | l2.repeat_packed(...) [Ok] | provenance | MaD:25 |
+| main.rs:54:31:54:54 | l2.repeat_packed(...) [Ok] | main.rs:54:31:54:63 | ... .unwrap(...) | provenance | MaD:28 |
+| main.rs:54:31:54:63 | ... .unwrap(...) | main.rs:54:13:54:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:54:48:54:53 | ... * ... | main.rs:54:31:54:54 | l2.repeat_packed(...) [Ok] | provenance | MaD:25 |
+| main.rs:58:9:58:20 | TuplePat [tuple.0] | main.rs:58:10:58:11 | k1 | provenance |  |
+| main.rs:58:10:58:11 | k1 | main.rs:59:31:59:32 | k1 | provenance |  |
+| main.rs:58:24:58:35 | l3.repeat(...) [Ok, tuple.0] | main.rs:58:24:58:66 | ... .expect(...) [tuple.0] | provenance | MaD:27 |
+| main.rs:58:24:58:66 | ... .expect(...) [tuple.0] | main.rs:58:9:58:20 | TuplePat [tuple.0] | provenance |  |
+| main.rs:58:34:58:34 | v | main.rs:58:24:58:35 | l3.repeat(...) [Ok, tuple.0] | provenance | MaD:24 |
+| main.rs:59:31:59:32 | k1 | main.rs:59:13:59:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:59:31:59:32 | k1 | main.rs:60:34:60:35 | k1 | provenance |  |
+| main.rs:59:31:59:32 | k1 | main.rs:62:24:62:36 | k1.extend(...) [Ok, tuple.0] | provenance | MaD:19 |
+| main.rs:59:31:59:32 | k1 | main.rs:64:48:64:49 | k1 | provenance |  |
+| main.rs:59:31:59:32 | k1 | main.rs:65:31:65:50 | k1.extend_packed(...) [Ok] | provenance | MaD:21 |
+| main.rs:60:9:60:20 | TuplePat [tuple.0] | main.rs:60:10:60:11 | k2 | provenance |  |
+| main.rs:60:10:60:11 | k2 | main.rs:61:31:61:32 | k2 | provenance |  |
+| main.rs:60:24:60:36 | l3.extend(...) [Ok, tuple.0] | main.rs:60:24:60:45 | ... .unwrap(...) [tuple.0] | provenance | MaD:28 |
+| main.rs:60:24:60:45 | ... .unwrap(...) [tuple.0] | main.rs:60:9:60:20 | TuplePat [tuple.0] | provenance |  |
+| main.rs:60:34:60:35 | k1 | main.rs:60:24:60:36 | l3.extend(...) [Ok, tuple.0] | provenance | MaD:18 |
+| main.rs:61:31:61:32 | k2 | main.rs:61:13:61:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:62:9:62:20 | TuplePat [tuple.0] | main.rs:62:10:62:11 | k3 | provenance |  |
+| main.rs:62:10:62:11 | k3 | main.rs:63:31:63:32 | k3 | provenance |  |
+| main.rs:62:24:62:36 | k1.extend(...) [Ok, tuple.0] | main.rs:62:24:62:45 | ... .unwrap(...) [tuple.0] | provenance | MaD:28 |
+| main.rs:62:24:62:45 | ... .unwrap(...) [tuple.0] | main.rs:62:9:62:20 | TuplePat [tuple.0] | provenance |  |
+| main.rs:63:31:63:32 | k3 | main.rs:63:13:63:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:64:31:64:50 | l3.extend_packed(...) [Ok] | main.rs:64:31:64:59 | ... .unwrap(...) | provenance | MaD:28 |
+| main.rs:64:31:64:59 | ... .unwrap(...) | main.rs:64:13:64:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:64:48:64:49 | k1 | main.rs:64:31:64:50 | l3.extend_packed(...) [Ok] | provenance | MaD:20 |
+| main.rs:65:31:65:50 | k1.extend_packed(...) [Ok] | main.rs:65:31:65:59 | ... .unwrap(...) | provenance | MaD:28 |
+| main.rs:65:31:65:59 | ... .unwrap(...) | main.rs:65:13:65:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:67:9:67:10 | l4 | main.rs:68:31:68:32 | l4 | provenance |  |
+| main.rs:67:14:67:47 | ...::array::<...>(...) [Ok] | main.rs:67:14:67:56 | ... .unwrap(...) | provenance | MaD:28 |
+| main.rs:67:14:67:56 | ... .unwrap(...) | main.rs:67:9:67:10 | l4 | provenance |  |
+| main.rs:67:46:67:46 | v | main.rs:67:14:67:47 | ...::array::<...>(...) [Ok] | provenance | MaD:17 |
+| main.rs:68:31:68:32 | l4 | main.rs:68:13:68:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:71:35:71:38 | ...: T | main.rs:77:9:77:16 | return v | provenance |  |
+| main.rs:81:38:81:45 | ...: usize | main.rs:82:47:82:47 | v | provenance |  |
+| main.rs:81:38:81:45 | ...: usize | main.rs:97:13:97:21 | mut v_mut | provenance |  |
+| main.rs:81:38:81:45 | ...: usize | main.rs:106:51:106:51 | v | provenance |  |
+| main.rs:81:38:81:45 | ...: usize | main.rs:110:61:110:61 | v | provenance |  |
+| main.rs:81:38:81:45 | ...: usize | main.rs:113:61:113:61 | v | provenance |  |
+| main.rs:81:38:81:45 | ...: usize | main.rs:116:53:116:53 | v | provenance |  |
+| main.rs:82:9:82:10 | l1 | main.rs:85:35:85:36 | l1 | provenance |  |
+| main.rs:82:9:82:10 | l1 | main.rs:87:35:87:36 | l1 | provenance |  |
+| main.rs:82:14:82:48 | ...::array::<...>(...) [Ok] | main.rs:82:14:82:57 | ... .unwrap(...) | provenance | MaD:28 |
+| main.rs:82:14:82:57 | ... .unwrap(...) | main.rs:82:9:82:10 | l1 | provenance |  |
+| main.rs:82:47:82:47 | v | main.rs:82:14:82:48 | ...::array::<...>(...) [Ok] | provenance | MaD:17 |
+| main.rs:85:35:85:36 | l1 | main.rs:85:17:85:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:85:35:85:36 | l1 | main.rs:91:35:91:36 | l1 | provenance |  |
+| main.rs:85:35:85:36 | l1 | main.rs:93:35:93:36 | l1 | provenance |  |
+| main.rs:87:35:87:36 | l1 | main.rs:87:17:87:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:87:35:87:36 | l1 | main.rs:91:35:91:36 | l1 | provenance |  |
+| main.rs:87:35:87:36 | l1 | main.rs:93:35:93:36 | l1 | provenance |  |
+| main.rs:91:35:91:36 | l1 | main.rs:91:17:91:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:91:35:91:36 | l1 | main.rs:119:31:119:32 | l1 | provenance |  |
+| main.rs:93:35:93:36 | l1 | main.rs:93:17:93:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:93:35:93:36 | l1 | main.rs:119:31:119:32 | l1 | provenance |  |
+| main.rs:97:13:97:21 | mut v_mut | main.rs:103:51:103:55 | v_mut | provenance |  |
+| main.rs:103:13:103:14 | l2 | main.rs:104:35:104:36 | l2 | provenance |  |
+| main.rs:103:18:103:56 | ...::array::<...>(...) [Ok] | main.rs:103:18:103:65 | ... .unwrap(...) | provenance | MaD:28 |
+| main.rs:103:18:103:65 | ... .unwrap(...) | main.rs:103:13:103:14 | l2 | provenance |  |
+| main.rs:103:51:103:55 | v_mut | main.rs:103:18:103:56 | ...::array::<...>(...) [Ok] | provenance | MaD:17 |
+| main.rs:104:35:104:36 | l2 | main.rs:104:17:104:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:106:13:106:14 | l3 | main.rs:107:35:107:36 | l3 | provenance |  |
+| main.rs:106:18:106:52 | ...::array::<...>(...) [Ok] | main.rs:106:18:106:61 | ... .unwrap(...) | provenance | MaD:28 |
+| main.rs:106:18:106:61 | ... .unwrap(...) | main.rs:106:13:106:14 | l3 | provenance |  |
+| main.rs:106:51:106:51 | v | main.rs:106:18:106:52 | ...::array::<...>(...) [Ok] | provenance | MaD:17 |
+| main.rs:107:35:107:36 | l3 | main.rs:107:17:107:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:110:9:110:10 | l4 | main.rs:111:31:111:32 | l4 | provenance |  |
+| main.rs:110:14:110:68 | ...::array::<...>(...) [Ok] | main.rs:110:14:110:77 | ... .unwrap(...) | provenance | MaD:28 |
+| main.rs:110:14:110:77 | ... .unwrap(...) | main.rs:110:9:110:10 | l4 | provenance |  |
+| main.rs:110:47:110:67 | ...::min(...) | main.rs:110:14:110:68 | ...::array::<...>(...) [Ok] | provenance | MaD:17 |
+| main.rs:110:61:110:61 | v | main.rs:110:47:110:67 | ...::min(...) | provenance | MaD:31 |
+| main.rs:111:31:111:32 | l4 | main.rs:111:13:111:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:113:9:113:10 | l5 | main.rs:114:31:114:32 | l5 | provenance |  |
+| main.rs:113:14:113:68 | ...::array::<...>(...) [Ok] | main.rs:113:14:113:77 | ... .unwrap(...) | provenance | MaD:28 |
+| main.rs:113:14:113:77 | ... .unwrap(...) | main.rs:113:9:113:10 | l5 | provenance |  |
+| main.rs:113:47:113:67 | ...::max(...) | main.rs:113:14:113:68 | ...::array::<...>(...) [Ok] | provenance | MaD:17 |
+| main.rs:113:61:113:61 | v | main.rs:113:47:113:67 | ...::max(...) | provenance | MaD:30 |
+| main.rs:114:31:114:32 | l5 | main.rs:114:13:114:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:116:9:116:10 | l6 | main.rs:117:31:117:32 | l6 | provenance |  |
+| main.rs:116:14:116:63 | ...::array::<...>(...) [Ok] | main.rs:116:14:116:72 | ... .unwrap(...) | provenance | MaD:28 |
+| main.rs:116:14:116:72 | ... .unwrap(...) | main.rs:116:9:116:10 | l6 | provenance |  |
+| main.rs:116:47:116:62 | clamp(...) | main.rs:116:14:116:63 | ...::array::<...>(...) [Ok] | provenance | MaD:17 |
+| main.rs:116:53:116:53 | v | main.rs:71:35:71:38 | ...: T | provenance |  |
+| main.rs:116:53:116:53 | v | main.rs:116:47:116:62 | clamp(...) | provenance |  |
+| main.rs:117:31:117:32 | l6 | main.rs:117:13:117:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:119:31:119:32 | l1 | main.rs:119:13:119:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:119:31:119:32 | l1 | main.rs:123:31:123:32 | l1 | provenance |  |
+| main.rs:123:31:123:32 | l1 | main.rs:123:13:123:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:128:29:128:36 | ...: usize | main.rs:137:46:137:46 | v | provenance |  |
+| main.rs:137:9:137:10 | l2 | main.rs:138:38:138:39 | l2 | provenance |  |
+| main.rs:137:14:137:47 | ...::array::<...>(...) [Ok] | main.rs:137:14:137:56 | ... .unwrap(...) | provenance | MaD:28 |
+| main.rs:137:14:137:56 | ... .unwrap(...) | main.rs:137:9:137:10 | l2 | provenance |  |
+| main.rs:137:46:137:46 | v | main.rs:137:14:137:47 | ...::array::<...>(...) [Ok] | provenance | MaD:17 |
+| main.rs:138:38:138:39 | l2 | main.rs:138:32:138:36 | alloc | provenance | MaD:10 Sink:MaD:10 |
+| main.rs:138:38:138:39 | l2 | main.rs:139:45:139:46 | l2 | provenance |  |
+| main.rs:139:45:139:46 | l2 | main.rs:139:32:139:43 | alloc_zeroed | provenance | MaD:11 Sink:MaD:11 |
+| main.rs:139:45:139:46 | l2 | main.rs:140:41:140:42 | l2 | provenance |  |
+| main.rs:140:41:140:42 | l2 | main.rs:140:32:140:39 | allocate | provenance | MaD:6 Sink:MaD:6 |
+| main.rs:140:41:140:42 | l2 | main.rs:141:48:141:49 | l2 | provenance |  |
+| main.rs:141:48:141:49 | l2 | main.rs:141:32:141:46 | allocate_zeroed | provenance | MaD:7 Sink:MaD:7 |
+| main.rs:141:48:141:49 | l2 | main.rs:142:41:142:42 | l2 | provenance |  |
+| main.rs:142:41:142:42 | l2 | main.rs:142:32:142:39 | allocate | provenance | MaD:1 Sink:MaD:1 |
+| main.rs:142:41:142:42 | l2 | main.rs:143:48:143:49 | l2 | provenance |  |
+| main.rs:143:48:143:49 | l2 | main.rs:143:32:143:46 | allocate_zeroed | provenance | MaD:2 Sink:MaD:2 |
+| main.rs:143:48:143:49 | l2 | main.rs:153:53:153:54 | l2 | provenance |  |
+| main.rs:143:48:143:49 | l2 | main.rs:155:60:155:61 | l2 | provenance |  |
+| main.rs:153:53:153:54 | l2 | main.rs:153:40:153:43 | grow | provenance | MaD:8 Sink:MaD:8 |
+| main.rs:155:60:155:61 | l2 | main.rs:155:40:155:50 | grow_zeroed | provenance | MaD:9 Sink:MaD:9 |
+| main.rs:162:27:162:34 | ...: usize | main.rs:164:26:164:26 | v | provenance |  |
+| main.rs:164:26:164:26 | v | main.rs:164:13:164:24 | ...::malloc | provenance | MaD:14 Sink:MaD:14 |
+| main.rs:164:26:164:26 | v | main.rs:164:13:164:24 | ...::malloc | provenance | MaD:14 Sink:MaD:14 |
+| main.rs:164:26:164:26 | v | main.rs:165:36:165:36 | v | provenance |  |
+| main.rs:165:36:165:36 | v | main.rs:165:13:165:31 | ...::aligned_alloc | provenance | MaD:12 Sink:MaD:12 |
+| main.rs:165:36:165:36 | v | main.rs:165:13:165:31 | ...::aligned_alloc | provenance | MaD:12 Sink:MaD:12 |
+| main.rs:165:36:165:36 | v | main.rs:167:30:167:30 | v | provenance |  |
+| main.rs:167:30:167:30 | v | main.rs:167:13:167:24 | ...::calloc | provenance | MaD:13 Sink:MaD:13 |
+| main.rs:167:30:167:30 | v | main.rs:167:13:167:24 | ...::calloc | provenance | MaD:13 Sink:MaD:13 |
+| main.rs:167:30:167:30 | v | main.rs:168:26:168:26 | v | provenance |  |
+| main.rs:168:26:168:26 | v | main.rs:168:13:168:24 | ...::calloc | provenance | MaD:13 Sink:MaD:13 |
+| main.rs:168:26:168:26 | v | main.rs:168:13:168:24 | ...::calloc | provenance | MaD:13 Sink:MaD:13 |
+| main.rs:168:26:168:26 | v | main.rs:169:31:169:31 | v | provenance |  |
+| main.rs:169:31:169:31 | v | main.rs:169:13:169:25 | ...::realloc | provenance | MaD:15 Sink:MaD:15 |
+| main.rs:169:31:169:31 | v | main.rs:169:13:169:25 | ...::realloc | provenance | MaD:15 Sink:MaD:15 |
+| main.rs:211:9:211:9 | v | main.rs:214:34:214:34 | v | provenance |  |
+| main.rs:211:9:211:9 | v | main.rs:215:42:215:42 | v | provenance |  |
+| main.rs:211:9:211:9 | v | main.rs:216:36:216:36 | v | provenance |  |
+| main.rs:211:9:211:9 | v | main.rs:217:27:217:27 | v | provenance |  |
+| main.rs:211:9:211:9 | v | main.rs:218:25:218:25 | v | provenance |  |
+| main.rs:211:13:211:26 | ...::args | main.rs:211:13:211:28 | ...::args(...) [element] | provenance | Src:MaD:16  |
+| main.rs:211:13:211:28 | ...::args(...) [element] | main.rs:211:13:211:35 | ... .nth(...) [Some] | provenance | MaD:32 |
+| main.rs:211:13:211:35 | ... .nth(...) [Some] | main.rs:211:13:211:65 | ... .unwrap_or(...) | provenance | MaD:26 |
+| main.rs:211:13:211:65 | ... .unwrap_or(...) | main.rs:211:13:211:82 | ... .parse(...) [Ok] | provenance | MaD:29 |
+| main.rs:211:13:211:82 | ... .parse(...) [Ok] | main.rs:211:13:211:91 | ... .unwrap(...) | provenance | MaD:28 |
+| main.rs:211:13:211:91 | ... .unwrap(...) | main.rs:211:9:211:9 | v | provenance |  |
+| main.rs:214:34:214:34 | v | main.rs:12:36:12:43 | ...: usize | provenance |  |
+| main.rs:215:42:215:42 | v | main.rs:43:44:43:51 | ...: usize | provenance |  |
+| main.rs:216:36:216:36 | v | main.rs:81:38:81:45 | ...: usize | provenance |  |
+| main.rs:217:27:217:27 | v | main.rs:128:29:128:36 | ...: usize | provenance |  |
+| main.rs:218:25:218:25 | v | main.rs:162:27:162:34 | ...: usize | provenance |  |
+models
+| 1 | Sink: lang:alloc; <crate::alloc::Global as crate::alloc::Allocator>::allocate; alloc-layout; Argument[0] |
+| 2 | Sink: lang:alloc; <crate::alloc::Global as crate::alloc::Allocator>::allocate_zeroed; alloc-layout; Argument[0] |
+| 3 | Sink: lang:alloc; crate::alloc::alloc; alloc-layout; Argument[0] |
+| 4 | Sink: lang:alloc; crate::alloc::alloc_zeroed; alloc-layout; Argument[0] |
+| 5 | Sink: lang:alloc; crate::alloc::realloc; alloc-size; Argument[2] |
+| 6 | Sink: lang:std; <crate::alloc::System as crate::alloc::Allocator>::allocate; alloc-layout; Argument[0] |
+| 7 | Sink: lang:std; <crate::alloc::System as crate::alloc::Allocator>::allocate_zeroed; alloc-layout; Argument[0] |
+| 8 | Sink: lang:std; <crate::alloc::System as crate::alloc::Allocator>::grow; alloc-layout; Argument[2] |
+| 9 | Sink: lang:std; <crate::alloc::System as crate::alloc::Allocator>::grow_zeroed; alloc-layout; Argument[2] |
+| 10 | Sink: lang:std; <crate::alloc::System as crate::alloc::global::GlobalAlloc>::alloc; alloc-layout; Argument[0] |
+| 11 | Sink: lang:std; <crate::alloc::System as crate::alloc::global::GlobalAlloc>::alloc_zeroed; alloc-layout; Argument[0] |
+| 12 | Sink: repo:https://github.com/rust-lang/libc:libc; ::aligned_alloc; alloc-size; Argument[1] |
+| 13 | Sink: repo:https://github.com/rust-lang/libc:libc; ::calloc; alloc-size; Argument[0,1] |
+| 14 | Sink: repo:https://github.com/rust-lang/libc:libc; ::malloc; alloc-size; Argument[0] |
+| 15 | Sink: repo:https://github.com/rust-lang/libc:libc; ::realloc; alloc-size; Argument[1] |
+| 16 | Source: lang:std; crate::env::args; command-line-source; ReturnValue.Element |
+| 17 | Summary: lang:core; <crate::alloc::layout::Layout>::array; Argument[0]; ReturnValue.Field[crate::result::Result::Ok(0)]; taint |
+| 18 | Summary: lang:core; <crate::alloc::layout::Layout>::extend; Argument[0]; ReturnValue.Field[crate::result::Result::Ok(0)].Field[0]; taint |
+| 19 | Summary: lang:core; <crate::alloc::layout::Layout>::extend; Argument[self]; ReturnValue.Field[crate::result::Result::Ok(0)].Field[0]; taint |
+| 20 | Summary: lang:core; <crate::alloc::layout::Layout>::extend_packed; Argument[0]; ReturnValue.Field[crate::result::Result::Ok(0)]; taint |
+| 21 | Summary: lang:core; <crate::alloc::layout::Layout>::extend_packed; Argument[self]; ReturnValue.Field[crate::result::Result::Ok(0)]; taint |
+| 22 | Summary: lang:core; <crate::alloc::layout::Layout>::from_size_align; Argument[0]; ReturnValue.Field[crate::result::Result::Ok(0)]; taint |
+| 23 | Summary: lang:core; <crate::alloc::layout::Layout>::from_size_align_unchecked; Argument[0]; ReturnValue; taint |
+| 24 | Summary: lang:core; <crate::alloc::layout::Layout>::repeat; Argument[0]; ReturnValue.Field[crate::result::Result::Ok(0)].Field[0]; taint |
+| 25 | Summary: lang:core; <crate::alloc::layout::Layout>::repeat_packed; Argument[0]; ReturnValue.Field[crate::result::Result::Ok(0)]; taint |
+| 26 | Summary: lang:core; <crate::option::Option>::unwrap_or; Argument[self].Field[crate::option::Option::Some(0)]; ReturnValue; value |
+| 27 | Summary: lang:core; <crate::result::Result>::expect; Argument[self].Field[crate::result::Result::Ok(0)]; ReturnValue; value |
+| 28 | Summary: lang:core; <crate::result::Result>::unwrap; Argument[self].Field[crate::result::Result::Ok(0)]; ReturnValue; value |
+| 29 | Summary: lang:core; <str>::parse; Argument[self]; ReturnValue.Field[crate::result::Result::Ok(0)]; taint |
+| 30 | Summary: lang:core; crate::cmp::max; Argument[0]; ReturnValue; value |
+| 31 | Summary: lang:core; crate::cmp::min; Argument[0]; ReturnValue; value |
+| 32 | Summary: lang:core; crate::iter::traits::iterator::Iterator::nth; Argument[self].Element; ReturnValue.Field[crate::option::Option::Some(0)]; value |
 nodes
+| main.rs:12:36:12:43 | ...: usize | semmle.label | ...: usize |
+| main.rs:18:13:18:31 | ...::realloc | semmle.label | ...::realloc |
+| main.rs:18:41:18:41 | v | semmle.label | v |
+| main.rs:20:9:20:10 | l2 | semmle.label | l2 |
+| main.rs:20:14:20:54 | ...::from_size_align(...) [Ok] | semmle.label | ...::from_size_align(...) [Ok] |
+| main.rs:20:14:20:63 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
+| main.rs:20:50:20:50 | v | semmle.label | v |
+| main.rs:21:13:21:29 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:21:31:21:32 | l2 | semmle.label | l2 |
+| main.rs:24:13:24:36 | ...::alloc_zeroed | semmle.label | ...::alloc_zeroed |
+| main.rs:24:38:24:39 | l2 | semmle.label | l2 |
+| main.rs:29:9:29:10 | l4 | semmle.label | l4 |
+| main.rs:29:14:29:64 | ...::from_size_align_unchecked(...) | semmle.label | ...::from_size_align_unchecked(...) |
+| main.rs:29:60:29:60 | v | semmle.label | v |
+| main.rs:30:13:30:29 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:30:31:30:32 | l4 | semmle.label | l4 |
+| main.rs:32:9:32:10 | l5 | semmle.label | l5 |
+| main.rs:32:14:32:118 | ...::from_size_align_unchecked(...) | semmle.label | ...::from_size_align_unchecked(...) |
+| main.rs:32:60:32:89 | ... * ... | semmle.label | ... * ... |
+| main.rs:33:13:33:29 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:33:31:33:32 | l5 | semmle.label | l5 |
+| main.rs:35:9:35:10 | s6 | semmle.label | s6 |
+| main.rs:36:9:36:10 | l6 | semmle.label | l6 |
+| main.rs:36:14:36:65 | ...::from_size_align_unchecked(...) | semmle.label | ...::from_size_align_unchecked(...) |
+| main.rs:36:60:36:61 | s6 | semmle.label | s6 |
+| main.rs:37:13:37:29 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:37:31:37:32 | l6 | semmle.label | l6 |
+| main.rs:43:44:43:51 | ...: usize | semmle.label | ...: usize |
+| main.rs:50:13:50:29 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:50:31:50:42 | l2.repeat(...) [Ok, tuple.0] | semmle.label | l2.repeat(...) [Ok, tuple.0] |
+| main.rs:50:31:50:51 | ... .unwrap(...) [tuple.0] | semmle.label | ... .unwrap(...) [tuple.0] |
+| main.rs:50:31:50:53 | ... .0 | semmle.label | ... .0 |
+| main.rs:50:41:50:41 | v | semmle.label | v |
+| main.rs:51:13:51:29 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:51:31:51:46 | l2.repeat(...) [Ok, tuple.0] | semmle.label | l2.repeat(...) [Ok, tuple.0] |
+| main.rs:51:31:51:55 | ... .unwrap(...) [tuple.0] | semmle.label | ... .unwrap(...) [tuple.0] |
+| main.rs:51:31:51:57 | ... .0 | semmle.label | ... .0 |
+| main.rs:51:41:51:45 | ... + ... | semmle.label | ... + ... |
+| main.rs:53:13:53:29 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:53:31:53:49 | l2.repeat_packed(...) [Ok] | semmle.label | l2.repeat_packed(...) [Ok] |
+| main.rs:53:31:53:58 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
+| main.rs:53:48:53:48 | v | semmle.label | v |
+| main.rs:54:13:54:29 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:54:31:54:54 | l2.repeat_packed(...) [Ok] | semmle.label | l2.repeat_packed(...) [Ok] |
+| main.rs:54:31:54:63 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
+| main.rs:54:48:54:53 | ... * ... | semmle.label | ... * ... |
+| main.rs:58:9:58:20 | TuplePat [tuple.0] | semmle.label | TuplePat [tuple.0] |
+| main.rs:58:10:58:11 | k1 | semmle.label | k1 |
+| main.rs:58:24:58:35 | l3.repeat(...) [Ok, tuple.0] | semmle.label | l3.repeat(...) [Ok, tuple.0] |
+| main.rs:58:24:58:66 | ... .expect(...) [tuple.0] | semmle.label | ... .expect(...) [tuple.0] |
+| main.rs:58:34:58:34 | v | semmle.label | v |
+| main.rs:59:13:59:29 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:59:31:59:32 | k1 | semmle.label | k1 |
+| main.rs:60:9:60:20 | TuplePat [tuple.0] | semmle.label | TuplePat [tuple.0] |
+| main.rs:60:10:60:11 | k2 | semmle.label | k2 |
+| main.rs:60:24:60:36 | l3.extend(...) [Ok, tuple.0] | semmle.label | l3.extend(...) [Ok, tuple.0] |
+| main.rs:60:24:60:45 | ... .unwrap(...) [tuple.0] | semmle.label | ... .unwrap(...) [tuple.0] |
+| main.rs:60:34:60:35 | k1 | semmle.label | k1 |
+| main.rs:61:13:61:29 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:61:31:61:32 | k2 | semmle.label | k2 |
+| main.rs:62:9:62:20 | TuplePat [tuple.0] | semmle.label | TuplePat [tuple.0] |
+| main.rs:62:10:62:11 | k3 | semmle.label | k3 |
+| main.rs:62:24:62:36 | k1.extend(...) [Ok, tuple.0] | semmle.label | k1.extend(...) [Ok, tuple.0] |
+| main.rs:62:24:62:45 | ... .unwrap(...) [tuple.0] | semmle.label | ... .unwrap(...) [tuple.0] |
+| main.rs:63:13:63:29 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:63:31:63:32 | k3 | semmle.label | k3 |
+| main.rs:64:13:64:29 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:64:31:64:50 | l3.extend_packed(...) [Ok] | semmle.label | l3.extend_packed(...) [Ok] |
+| main.rs:64:31:64:59 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
+| main.rs:64:48:64:49 | k1 | semmle.label | k1 |
+| main.rs:65:13:65:29 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:65:31:65:50 | k1.extend_packed(...) [Ok] | semmle.label | k1.extend_packed(...) [Ok] |
+| main.rs:65:31:65:59 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
+| main.rs:67:9:67:10 | l4 | semmle.label | l4 |
+| main.rs:67:14:67:47 | ...::array::<...>(...) [Ok] | semmle.label | ...::array::<...>(...) [Ok] |
+| main.rs:67:14:67:56 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
+| main.rs:67:46:67:46 | v | semmle.label | v |
+| main.rs:68:13:68:29 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:68:31:68:32 | l4 | semmle.label | l4 |
+| main.rs:71:35:71:38 | ...: T | semmle.label | ...: T |
+| main.rs:77:9:77:16 | return v | semmle.label | return v |
+| main.rs:81:38:81:45 | ...: usize | semmle.label | ...: usize |
+| main.rs:82:9:82:10 | l1 | semmle.label | l1 |
+| main.rs:82:14:82:48 | ...::array::<...>(...) [Ok] | semmle.label | ...::array::<...>(...) [Ok] |
+| main.rs:82:14:82:57 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
+| main.rs:82:47:82:47 | v | semmle.label | v |
+| main.rs:85:17:85:33 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:85:35:85:36 | l1 | semmle.label | l1 |
+| main.rs:87:17:87:33 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:87:35:87:36 | l1 | semmle.label | l1 |
+| main.rs:91:17:91:33 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:91:35:91:36 | l1 | semmle.label | l1 |
+| main.rs:93:17:93:33 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:93:35:93:36 | l1 | semmle.label | l1 |
+| main.rs:97:13:97:21 | mut v_mut | semmle.label | mut v_mut |
+| main.rs:103:13:103:14 | l2 | semmle.label | l2 |
+| main.rs:103:18:103:56 | ...::array::<...>(...) [Ok] | semmle.label | ...::array::<...>(...) [Ok] |
+| main.rs:103:18:103:65 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
+| main.rs:103:51:103:55 | v_mut | semmle.label | v_mut |
+| main.rs:104:17:104:33 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:104:35:104:36 | l2 | semmle.label | l2 |
+| main.rs:106:13:106:14 | l3 | semmle.label | l3 |
+| main.rs:106:18:106:52 | ...::array::<...>(...) [Ok] | semmle.label | ...::array::<...>(...) [Ok] |
+| main.rs:106:18:106:61 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
+| main.rs:106:51:106:51 | v | semmle.label | v |
+| main.rs:107:17:107:33 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:107:35:107:36 | l3 | semmle.label | l3 |
+| main.rs:110:9:110:10 | l4 | semmle.label | l4 |
+| main.rs:110:14:110:68 | ...::array::<...>(...) [Ok] | semmle.label | ...::array::<...>(...) [Ok] |
+| main.rs:110:14:110:77 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
+| main.rs:110:47:110:67 | ...::min(...) | semmle.label | ...::min(...) |
+| main.rs:110:61:110:61 | v | semmle.label | v |
+| main.rs:111:13:111:29 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:111:31:111:32 | l4 | semmle.label | l4 |
+| main.rs:113:9:113:10 | l5 | semmle.label | l5 |
+| main.rs:113:14:113:68 | ...::array::<...>(...) [Ok] | semmle.label | ...::array::<...>(...) [Ok] |
+| main.rs:113:14:113:77 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
+| main.rs:113:47:113:67 | ...::max(...) | semmle.label | ...::max(...) |
+| main.rs:113:61:113:61 | v | semmle.label | v |
+| main.rs:114:13:114:29 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:114:31:114:32 | l5 | semmle.label | l5 |
+| main.rs:116:9:116:10 | l6 | semmle.label | l6 |
+| main.rs:116:14:116:63 | ...::array::<...>(...) [Ok] | semmle.label | ...::array::<...>(...) [Ok] |
+| main.rs:116:14:116:72 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
+| main.rs:116:47:116:62 | clamp(...) | semmle.label | clamp(...) |
+| main.rs:116:53:116:53 | v | semmle.label | v |
+| main.rs:117:13:117:29 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:117:31:117:32 | l6 | semmle.label | l6 |
+| main.rs:119:13:119:29 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:119:31:119:32 | l1 | semmle.label | l1 |
+| main.rs:123:13:123:29 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:123:31:123:32 | l1 | semmle.label | l1 |
+| main.rs:128:29:128:36 | ...: usize | semmle.label | ...: usize |
+| main.rs:137:9:137:10 | l2 | semmle.label | l2 |
+| main.rs:137:14:137:47 | ...::array::<...>(...) [Ok] | semmle.label | ...::array::<...>(...) [Ok] |
+| main.rs:137:14:137:56 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
+| main.rs:137:46:137:46 | v | semmle.label | v |
+| main.rs:138:32:138:36 | alloc | semmle.label | alloc |
+| main.rs:138:38:138:39 | l2 | semmle.label | l2 |
+| main.rs:139:32:139:43 | alloc_zeroed | semmle.label | alloc_zeroed |
+| main.rs:139:45:139:46 | l2 | semmle.label | l2 |
+| main.rs:140:32:140:39 | allocate | semmle.label | allocate |
+| main.rs:140:41:140:42 | l2 | semmle.label | l2 |
+| main.rs:141:32:141:46 | allocate_zeroed | semmle.label | allocate_zeroed |
+| main.rs:141:48:141:49 | l2 | semmle.label | l2 |
+| main.rs:142:32:142:39 | allocate | semmle.label | allocate |
+| main.rs:142:41:142:42 | l2 | semmle.label | l2 |
+| main.rs:143:32:143:46 | allocate_zeroed | semmle.label | allocate_zeroed |
+| main.rs:143:48:143:49 | l2 | semmle.label | l2 |
+| main.rs:153:40:153:43 | grow | semmle.label | grow |
+| main.rs:153:53:153:54 | l2 | semmle.label | l2 |
+| main.rs:155:40:155:50 | grow_zeroed | semmle.label | grow_zeroed |
+| main.rs:155:60:155:61 | l2 | semmle.label | l2 |
+| main.rs:162:27:162:34 | ...: usize | semmle.label | ...: usize |
+| main.rs:164:13:164:24 | ...::malloc | semmle.label | ...::malloc |
+| main.rs:164:13:164:24 | ...::malloc | semmle.label | ...::malloc |
+| main.rs:164:26:164:26 | v | semmle.label | v |
+| main.rs:165:13:165:31 | ...::aligned_alloc | semmle.label | ...::aligned_alloc |
+| main.rs:165:13:165:31 | ...::aligned_alloc | semmle.label | ...::aligned_alloc |
+| main.rs:165:36:165:36 | v | semmle.label | v |
+| main.rs:167:13:167:24 | ...::calloc | semmle.label | ...::calloc |
+| main.rs:167:13:167:24 | ...::calloc | semmle.label | ...::calloc |
+| main.rs:167:30:167:30 | v | semmle.label | v |
+| main.rs:168:13:168:24 | ...::calloc | semmle.label | ...::calloc |
+| main.rs:168:13:168:24 | ...::calloc | semmle.label | ...::calloc |
+| main.rs:168:26:168:26 | v | semmle.label | v |
+| main.rs:169:13:169:25 | ...::realloc | semmle.label | ...::realloc |
+| main.rs:169:13:169:25 | ...::realloc | semmle.label | ...::realloc |
+| main.rs:169:31:169:31 | v | semmle.label | v |
+| main.rs:211:9:211:9 | v | semmle.label | v |
+| main.rs:211:13:211:26 | ...::args | semmle.label | ...::args |
+| main.rs:211:13:211:28 | ...::args(...) [element] | semmle.label | ...::args(...) [element] |
+| main.rs:211:13:211:35 | ... .nth(...) [Some] | semmle.label | ... .nth(...) [Some] |
+| main.rs:211:13:211:65 | ... .unwrap_or(...) | semmle.label | ... .unwrap_or(...) |
+| main.rs:211:13:211:82 | ... .parse(...) [Ok] | semmle.label | ... .parse(...) [Ok] |
+| main.rs:211:13:211:91 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
+| main.rs:214:34:214:34 | v | semmle.label | v |
+| main.rs:215:42:215:42 | v | semmle.label | v |
+| main.rs:216:36:216:36 | v | semmle.label | v |
+| main.rs:217:27:217:27 | v | semmle.label | v |
+| main.rs:218:25:218:25 | v | semmle.label | v |
 subpaths
+| main.rs:116:53:116:53 | v | main.rs:71:35:71:38 | ...: T | main.rs:77:9:77:16 | return v | main.rs:116:47:116:62 | clamp(...) |

--- a/rust/ql/test/query-tests/security/CWE-770/UncontrolledAllocationSize.expected
+++ b/rust/ql/test/query-tests/security/CWE-770/UncontrolledAllocationSize.expected
@@ -1,10 +1,13 @@
 #select
 | main.rs:18:13:18:31 | ...::realloc | main.rs:211:13:211:26 | ...::args | main.rs:18:13:18:31 | ...::realloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
 | main.rs:21:13:21:29 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:21:13:21:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
+| main.rs:22:13:22:29 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:22:13:22:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
+| main.rs:23:13:23:29 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:23:13:23:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
 | main.rs:24:13:24:36 | ...::alloc_zeroed | main.rs:211:13:211:26 | ...::args | main.rs:24:13:24:36 | ...::alloc_zeroed | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
 | main.rs:30:13:30:29 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:30:13:30:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
 | main.rs:33:13:33:29 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:33:13:33:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
 | main.rs:37:13:37:29 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:37:13:37:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
+| main.rs:40:13:40:29 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:40:13:40:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
 | main.rs:50:13:50:29 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:50:13:50:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
 | main.rs:51:13:51:29 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:51:13:51:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
 | main.rs:53:13:53:29 | ...::alloc | main.rs:211:13:211:26 | ...::args | main.rs:53:13:53:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:211:13:211:26 | ...::args | user-provided value |
@@ -52,75 +55,87 @@ edges
 | main.rs:18:41:18:41 | v | main.rs:32:60:32:89 | ... * ... | provenance |  |
 | main.rs:18:41:18:41 | v | main.rs:35:9:35:10 | s6 | provenance |  |
 | main.rs:20:9:20:10 | l2 | main.rs:21:31:21:32 | l2 | provenance |  |
-| main.rs:20:14:20:54 | ...::from_size_align(...) [Ok] | main.rs:20:14:20:63 | ... .unwrap(...) | provenance | MaD:28 |
+| main.rs:20:14:20:54 | ...::from_size_align(...) [Ok] | main.rs:20:14:20:63 | ... .unwrap(...) | provenance | MaD:31 |
 | main.rs:20:14:20:63 | ... .unwrap(...) | main.rs:20:9:20:10 | l2 | provenance |  |
-| main.rs:20:50:20:50 | v | main.rs:20:14:20:54 | ...::from_size_align(...) [Ok] | provenance | MaD:22 |
+| main.rs:20:50:20:50 | v | main.rs:20:14:20:54 | ...::from_size_align(...) [Ok] | provenance | MaD:23 |
 | main.rs:21:31:21:32 | l2 | main.rs:21:13:21:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:21:31:21:32 | l2 | main.rs:22:31:22:44 | l2.align_to(...) [Ok] | provenance | MaD:17 |
+| main.rs:21:31:21:32 | l2 | main.rs:23:31:23:44 | l2.align_to(...) [Ok] | provenance | MaD:17 |
 | main.rs:21:31:21:32 | l2 | main.rs:24:38:24:39 | l2 | provenance |  |
+| main.rs:22:31:22:44 | l2.align_to(...) [Ok] | main.rs:22:31:22:53 | ... .unwrap(...) | provenance | MaD:31 |
+| main.rs:22:31:22:53 | ... .unwrap(...) | main.rs:22:13:22:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:23:31:23:44 | l2.align_to(...) [Ok] | main.rs:23:31:23:53 | ... .unwrap(...) | provenance | MaD:31 |
+| main.rs:23:31:23:53 | ... .unwrap(...) | main.rs:23:31:23:68 | ... .pad_to_align(...) | provenance | MaD:25 |
+| main.rs:23:31:23:68 | ... .pad_to_align(...) | main.rs:23:13:23:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
 | main.rs:24:38:24:39 | l2 | main.rs:24:13:24:36 | ...::alloc_zeroed | provenance | MaD:4 Sink:MaD:4 |
 | main.rs:29:9:29:10 | l4 | main.rs:30:31:30:32 | l4 | provenance |  |
 | main.rs:29:14:29:64 | ...::from_size_align_unchecked(...) | main.rs:29:9:29:10 | l4 | provenance |  |
-| main.rs:29:60:29:60 | v | main.rs:29:14:29:64 | ...::from_size_align_unchecked(...) | provenance | MaD:23 |
+| main.rs:29:60:29:60 | v | main.rs:29:14:29:64 | ...::from_size_align_unchecked(...) | provenance | MaD:24 |
 | main.rs:30:31:30:32 | l4 | main.rs:30:13:30:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
 | main.rs:32:9:32:10 | l5 | main.rs:33:31:33:32 | l5 | provenance |  |
 | main.rs:32:14:32:118 | ...::from_size_align_unchecked(...) | main.rs:32:9:32:10 | l5 | provenance |  |
-| main.rs:32:60:32:89 | ... * ... | main.rs:32:14:32:118 | ...::from_size_align_unchecked(...) | provenance | MaD:23 |
+| main.rs:32:60:32:89 | ... * ... | main.rs:32:14:32:118 | ...::from_size_align_unchecked(...) | provenance | MaD:24 |
 | main.rs:33:31:33:32 | l5 | main.rs:33:13:33:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
 | main.rs:35:9:35:10 | s6 | main.rs:36:60:36:61 | s6 | provenance |  |
 | main.rs:36:9:36:10 | l6 | main.rs:37:31:37:32 | l6 | provenance |  |
 | main.rs:36:14:36:65 | ...::from_size_align_unchecked(...) | main.rs:36:9:36:10 | l6 | provenance |  |
-| main.rs:36:60:36:61 | s6 | main.rs:36:14:36:65 | ...::from_size_align_unchecked(...) | provenance | MaD:23 |
+| main.rs:36:60:36:61 | s6 | main.rs:36:14:36:65 | ...::from_size_align_unchecked(...) | provenance | MaD:24 |
 | main.rs:37:31:37:32 | l6 | main.rs:37:13:37:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:37:31:37:32 | l6 | main.rs:39:60:39:68 | l6.size(...) | provenance | MaD:28 |
+| main.rs:39:9:39:10 | l7 | main.rs:40:31:40:32 | l7 | provenance |  |
+| main.rs:39:14:39:72 | ...::from_size_align_unchecked(...) | main.rs:39:9:39:10 | l7 | provenance |  |
+| main.rs:39:60:39:68 | l6.size(...) | main.rs:39:14:39:72 | ...::from_size_align_unchecked(...) | provenance | MaD:24 |
+| main.rs:40:31:40:32 | l7 | main.rs:40:13:40:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
 | main.rs:43:44:43:51 | ...: usize | main.rs:50:41:50:41 | v | provenance |  |
 | main.rs:43:44:43:51 | ...: usize | main.rs:51:41:51:45 | ... + ... | provenance |  |
 | main.rs:43:44:43:51 | ...: usize | main.rs:53:48:53:48 | v | provenance |  |
 | main.rs:43:44:43:51 | ...: usize | main.rs:54:48:54:53 | ... * ... | provenance |  |
 | main.rs:43:44:43:51 | ...: usize | main.rs:58:34:58:34 | v | provenance |  |
 | main.rs:43:44:43:51 | ...: usize | main.rs:67:46:67:46 | v | provenance |  |
-| main.rs:50:31:50:42 | l2.repeat(...) [Ok, tuple.0] | main.rs:50:31:50:51 | ... .unwrap(...) [tuple.0] | provenance | MaD:28 |
+| main.rs:50:31:50:42 | l2.repeat(...) [Ok, tuple.0] | main.rs:50:31:50:51 | ... .unwrap(...) [tuple.0] | provenance | MaD:31 |
 | main.rs:50:31:50:51 | ... .unwrap(...) [tuple.0] | main.rs:50:31:50:53 | ... .0 | provenance |  |
 | main.rs:50:31:50:53 | ... .0 | main.rs:50:13:50:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
-| main.rs:50:41:50:41 | v | main.rs:50:31:50:42 | l2.repeat(...) [Ok, tuple.0] | provenance | MaD:24 |
-| main.rs:51:31:51:46 | l2.repeat(...) [Ok, tuple.0] | main.rs:51:31:51:55 | ... .unwrap(...) [tuple.0] | provenance | MaD:28 |
+| main.rs:50:41:50:41 | v | main.rs:50:31:50:42 | l2.repeat(...) [Ok, tuple.0] | provenance | MaD:26 |
+| main.rs:51:31:51:46 | l2.repeat(...) [Ok, tuple.0] | main.rs:51:31:51:55 | ... .unwrap(...) [tuple.0] | provenance | MaD:31 |
 | main.rs:51:31:51:55 | ... .unwrap(...) [tuple.0] | main.rs:51:31:51:57 | ... .0 | provenance |  |
 | main.rs:51:31:51:57 | ... .0 | main.rs:51:13:51:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
-| main.rs:51:41:51:45 | ... + ... | main.rs:51:31:51:46 | l2.repeat(...) [Ok, tuple.0] | provenance | MaD:24 |
-| main.rs:53:31:53:49 | l2.repeat_packed(...) [Ok] | main.rs:53:31:53:58 | ... .unwrap(...) | provenance | MaD:28 |
+| main.rs:51:41:51:45 | ... + ... | main.rs:51:31:51:46 | l2.repeat(...) [Ok, tuple.0] | provenance | MaD:26 |
+| main.rs:53:31:53:49 | l2.repeat_packed(...) [Ok] | main.rs:53:31:53:58 | ... .unwrap(...) | provenance | MaD:31 |
 | main.rs:53:31:53:58 | ... .unwrap(...) | main.rs:53:13:53:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
-| main.rs:53:48:53:48 | v | main.rs:53:31:53:49 | l2.repeat_packed(...) [Ok] | provenance | MaD:25 |
-| main.rs:54:31:54:54 | l2.repeat_packed(...) [Ok] | main.rs:54:31:54:63 | ... .unwrap(...) | provenance | MaD:28 |
+| main.rs:53:48:53:48 | v | main.rs:53:31:53:49 | l2.repeat_packed(...) [Ok] | provenance | MaD:27 |
+| main.rs:54:31:54:54 | l2.repeat_packed(...) [Ok] | main.rs:54:31:54:63 | ... .unwrap(...) | provenance | MaD:31 |
 | main.rs:54:31:54:63 | ... .unwrap(...) | main.rs:54:13:54:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
-| main.rs:54:48:54:53 | ... * ... | main.rs:54:31:54:54 | l2.repeat_packed(...) [Ok] | provenance | MaD:25 |
+| main.rs:54:48:54:53 | ... * ... | main.rs:54:31:54:54 | l2.repeat_packed(...) [Ok] | provenance | MaD:27 |
 | main.rs:58:9:58:20 | TuplePat [tuple.0] | main.rs:58:10:58:11 | k1 | provenance |  |
 | main.rs:58:10:58:11 | k1 | main.rs:59:31:59:32 | k1 | provenance |  |
-| main.rs:58:24:58:35 | l3.repeat(...) [Ok, tuple.0] | main.rs:58:24:58:66 | ... .expect(...) [tuple.0] | provenance | MaD:27 |
+| main.rs:58:24:58:35 | l3.repeat(...) [Ok, tuple.0] | main.rs:58:24:58:66 | ... .expect(...) [tuple.0] | provenance | MaD:30 |
 | main.rs:58:24:58:66 | ... .expect(...) [tuple.0] | main.rs:58:9:58:20 | TuplePat [tuple.0] | provenance |  |
-| main.rs:58:34:58:34 | v | main.rs:58:24:58:35 | l3.repeat(...) [Ok, tuple.0] | provenance | MaD:24 |
+| main.rs:58:34:58:34 | v | main.rs:58:24:58:35 | l3.repeat(...) [Ok, tuple.0] | provenance | MaD:26 |
 | main.rs:59:31:59:32 | k1 | main.rs:59:13:59:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
 | main.rs:59:31:59:32 | k1 | main.rs:60:34:60:35 | k1 | provenance |  |
-| main.rs:59:31:59:32 | k1 | main.rs:62:24:62:36 | k1.extend(...) [Ok, tuple.0] | provenance | MaD:19 |
+| main.rs:59:31:59:32 | k1 | main.rs:62:24:62:36 | k1.extend(...) [Ok, tuple.0] | provenance | MaD:20 |
 | main.rs:59:31:59:32 | k1 | main.rs:64:48:64:49 | k1 | provenance |  |
-| main.rs:59:31:59:32 | k1 | main.rs:65:31:65:50 | k1.extend_packed(...) [Ok] | provenance | MaD:21 |
+| main.rs:59:31:59:32 | k1 | main.rs:65:31:65:50 | k1.extend_packed(...) [Ok] | provenance | MaD:22 |
 | main.rs:60:9:60:20 | TuplePat [tuple.0] | main.rs:60:10:60:11 | k2 | provenance |  |
 | main.rs:60:10:60:11 | k2 | main.rs:61:31:61:32 | k2 | provenance |  |
-| main.rs:60:24:60:36 | l3.extend(...) [Ok, tuple.0] | main.rs:60:24:60:45 | ... .unwrap(...) [tuple.0] | provenance | MaD:28 |
+| main.rs:60:24:60:36 | l3.extend(...) [Ok, tuple.0] | main.rs:60:24:60:45 | ... .unwrap(...) [tuple.0] | provenance | MaD:31 |
 | main.rs:60:24:60:45 | ... .unwrap(...) [tuple.0] | main.rs:60:9:60:20 | TuplePat [tuple.0] | provenance |  |
-| main.rs:60:34:60:35 | k1 | main.rs:60:24:60:36 | l3.extend(...) [Ok, tuple.0] | provenance | MaD:18 |
+| main.rs:60:34:60:35 | k1 | main.rs:60:24:60:36 | l3.extend(...) [Ok, tuple.0] | provenance | MaD:19 |
 | main.rs:61:31:61:32 | k2 | main.rs:61:13:61:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
 | main.rs:62:9:62:20 | TuplePat [tuple.0] | main.rs:62:10:62:11 | k3 | provenance |  |
 | main.rs:62:10:62:11 | k3 | main.rs:63:31:63:32 | k3 | provenance |  |
-| main.rs:62:24:62:36 | k1.extend(...) [Ok, tuple.0] | main.rs:62:24:62:45 | ... .unwrap(...) [tuple.0] | provenance | MaD:28 |
+| main.rs:62:24:62:36 | k1.extend(...) [Ok, tuple.0] | main.rs:62:24:62:45 | ... .unwrap(...) [tuple.0] | provenance | MaD:31 |
 | main.rs:62:24:62:45 | ... .unwrap(...) [tuple.0] | main.rs:62:9:62:20 | TuplePat [tuple.0] | provenance |  |
 | main.rs:63:31:63:32 | k3 | main.rs:63:13:63:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
-| main.rs:64:31:64:50 | l3.extend_packed(...) [Ok] | main.rs:64:31:64:59 | ... .unwrap(...) | provenance | MaD:28 |
+| main.rs:64:31:64:50 | l3.extend_packed(...) [Ok] | main.rs:64:31:64:59 | ... .unwrap(...) | provenance | MaD:31 |
 | main.rs:64:31:64:59 | ... .unwrap(...) | main.rs:64:13:64:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
-| main.rs:64:48:64:49 | k1 | main.rs:64:31:64:50 | l3.extend_packed(...) [Ok] | provenance | MaD:20 |
-| main.rs:65:31:65:50 | k1.extend_packed(...) [Ok] | main.rs:65:31:65:59 | ... .unwrap(...) | provenance | MaD:28 |
+| main.rs:64:48:64:49 | k1 | main.rs:64:31:64:50 | l3.extend_packed(...) [Ok] | provenance | MaD:21 |
+| main.rs:65:31:65:50 | k1.extend_packed(...) [Ok] | main.rs:65:31:65:59 | ... .unwrap(...) | provenance | MaD:31 |
 | main.rs:65:31:65:59 | ... .unwrap(...) | main.rs:65:13:65:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
 | main.rs:67:9:67:10 | l4 | main.rs:68:31:68:32 | l4 | provenance |  |
-| main.rs:67:14:67:47 | ...::array::<...>(...) [Ok] | main.rs:67:14:67:56 | ... .unwrap(...) | provenance | MaD:28 |
+| main.rs:67:14:67:47 | ...::array::<...>(...) [Ok] | main.rs:67:14:67:56 | ... .unwrap(...) | provenance | MaD:31 |
 | main.rs:67:14:67:56 | ... .unwrap(...) | main.rs:67:9:67:10 | l4 | provenance |  |
-| main.rs:67:46:67:46 | v | main.rs:67:14:67:47 | ...::array::<...>(...) [Ok] | provenance | MaD:17 |
+| main.rs:67:46:67:46 | v | main.rs:67:14:67:47 | ...::array::<...>(...) [Ok] | provenance | MaD:18 |
 | main.rs:68:31:68:32 | l4 | main.rs:68:13:68:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
 | main.rs:71:35:71:38 | ...: T | main.rs:77:9:77:16 | return v | provenance |  |
 | main.rs:81:38:81:45 | ...: usize | main.rs:82:47:82:47 | v | provenance |  |
@@ -131,9 +146,9 @@ edges
 | main.rs:81:38:81:45 | ...: usize | main.rs:116:53:116:53 | v | provenance |  |
 | main.rs:82:9:82:10 | l1 | main.rs:85:35:85:36 | l1 | provenance |  |
 | main.rs:82:9:82:10 | l1 | main.rs:87:35:87:36 | l1 | provenance |  |
-| main.rs:82:14:82:48 | ...::array::<...>(...) [Ok] | main.rs:82:14:82:57 | ... .unwrap(...) | provenance | MaD:28 |
+| main.rs:82:14:82:48 | ...::array::<...>(...) [Ok] | main.rs:82:14:82:57 | ... .unwrap(...) | provenance | MaD:31 |
 | main.rs:82:14:82:57 | ... .unwrap(...) | main.rs:82:9:82:10 | l1 | provenance |  |
-| main.rs:82:47:82:47 | v | main.rs:82:14:82:48 | ...::array::<...>(...) [Ok] | provenance | MaD:17 |
+| main.rs:82:47:82:47 | v | main.rs:82:14:82:48 | ...::array::<...>(...) [Ok] | provenance | MaD:18 |
 | main.rs:85:35:85:36 | l1 | main.rs:85:17:85:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
 | main.rs:85:35:85:36 | l1 | main.rs:91:35:91:36 | l1 | provenance |  |
 | main.rs:85:35:85:36 | l1 | main.rs:93:35:93:36 | l1 | provenance |  |
@@ -146,31 +161,31 @@ edges
 | main.rs:93:35:93:36 | l1 | main.rs:119:31:119:32 | l1 | provenance |  |
 | main.rs:97:13:97:21 | mut v_mut | main.rs:103:51:103:55 | v_mut | provenance |  |
 | main.rs:103:13:103:14 | l2 | main.rs:104:35:104:36 | l2 | provenance |  |
-| main.rs:103:18:103:56 | ...::array::<...>(...) [Ok] | main.rs:103:18:103:65 | ... .unwrap(...) | provenance | MaD:28 |
+| main.rs:103:18:103:56 | ...::array::<...>(...) [Ok] | main.rs:103:18:103:65 | ... .unwrap(...) | provenance | MaD:31 |
 | main.rs:103:18:103:65 | ... .unwrap(...) | main.rs:103:13:103:14 | l2 | provenance |  |
-| main.rs:103:51:103:55 | v_mut | main.rs:103:18:103:56 | ...::array::<...>(...) [Ok] | provenance | MaD:17 |
+| main.rs:103:51:103:55 | v_mut | main.rs:103:18:103:56 | ...::array::<...>(...) [Ok] | provenance | MaD:18 |
 | main.rs:104:35:104:36 | l2 | main.rs:104:17:104:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
 | main.rs:106:13:106:14 | l3 | main.rs:107:35:107:36 | l3 | provenance |  |
-| main.rs:106:18:106:52 | ...::array::<...>(...) [Ok] | main.rs:106:18:106:61 | ... .unwrap(...) | provenance | MaD:28 |
+| main.rs:106:18:106:52 | ...::array::<...>(...) [Ok] | main.rs:106:18:106:61 | ... .unwrap(...) | provenance | MaD:31 |
 | main.rs:106:18:106:61 | ... .unwrap(...) | main.rs:106:13:106:14 | l3 | provenance |  |
-| main.rs:106:51:106:51 | v | main.rs:106:18:106:52 | ...::array::<...>(...) [Ok] | provenance | MaD:17 |
+| main.rs:106:51:106:51 | v | main.rs:106:18:106:52 | ...::array::<...>(...) [Ok] | provenance | MaD:18 |
 | main.rs:107:35:107:36 | l3 | main.rs:107:17:107:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
 | main.rs:110:9:110:10 | l4 | main.rs:111:31:111:32 | l4 | provenance |  |
-| main.rs:110:14:110:68 | ...::array::<...>(...) [Ok] | main.rs:110:14:110:77 | ... .unwrap(...) | provenance | MaD:28 |
+| main.rs:110:14:110:68 | ...::array::<...>(...) [Ok] | main.rs:110:14:110:77 | ... .unwrap(...) | provenance | MaD:31 |
 | main.rs:110:14:110:77 | ... .unwrap(...) | main.rs:110:9:110:10 | l4 | provenance |  |
-| main.rs:110:47:110:67 | ...::min(...) | main.rs:110:14:110:68 | ...::array::<...>(...) [Ok] | provenance | MaD:17 |
-| main.rs:110:61:110:61 | v | main.rs:110:47:110:67 | ...::min(...) | provenance | MaD:31 |
+| main.rs:110:47:110:67 | ...::min(...) | main.rs:110:14:110:68 | ...::array::<...>(...) [Ok] | provenance | MaD:18 |
+| main.rs:110:61:110:61 | v | main.rs:110:47:110:67 | ...::min(...) | provenance | MaD:34 |
 | main.rs:111:31:111:32 | l4 | main.rs:111:13:111:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
 | main.rs:113:9:113:10 | l5 | main.rs:114:31:114:32 | l5 | provenance |  |
-| main.rs:113:14:113:68 | ...::array::<...>(...) [Ok] | main.rs:113:14:113:77 | ... .unwrap(...) | provenance | MaD:28 |
+| main.rs:113:14:113:68 | ...::array::<...>(...) [Ok] | main.rs:113:14:113:77 | ... .unwrap(...) | provenance | MaD:31 |
 | main.rs:113:14:113:77 | ... .unwrap(...) | main.rs:113:9:113:10 | l5 | provenance |  |
-| main.rs:113:47:113:67 | ...::max(...) | main.rs:113:14:113:68 | ...::array::<...>(...) [Ok] | provenance | MaD:17 |
-| main.rs:113:61:113:61 | v | main.rs:113:47:113:67 | ...::max(...) | provenance | MaD:30 |
+| main.rs:113:47:113:67 | ...::max(...) | main.rs:113:14:113:68 | ...::array::<...>(...) [Ok] | provenance | MaD:18 |
+| main.rs:113:61:113:61 | v | main.rs:113:47:113:67 | ...::max(...) | provenance | MaD:33 |
 | main.rs:114:31:114:32 | l5 | main.rs:114:13:114:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
 | main.rs:116:9:116:10 | l6 | main.rs:117:31:117:32 | l6 | provenance |  |
-| main.rs:116:14:116:63 | ...::array::<...>(...) [Ok] | main.rs:116:14:116:72 | ... .unwrap(...) | provenance | MaD:28 |
+| main.rs:116:14:116:63 | ...::array::<...>(...) [Ok] | main.rs:116:14:116:72 | ... .unwrap(...) | provenance | MaD:31 |
 | main.rs:116:14:116:72 | ... .unwrap(...) | main.rs:116:9:116:10 | l6 | provenance |  |
-| main.rs:116:47:116:62 | clamp(...) | main.rs:116:14:116:63 | ...::array::<...>(...) [Ok] | provenance | MaD:17 |
+| main.rs:116:47:116:62 | clamp(...) | main.rs:116:14:116:63 | ...::array::<...>(...) [Ok] | provenance | MaD:18 |
 | main.rs:116:53:116:53 | v | main.rs:71:35:71:38 | ...: T | provenance |  |
 | main.rs:116:53:116:53 | v | main.rs:116:47:116:62 | clamp(...) | provenance |  |
 | main.rs:117:31:117:32 | l6 | main.rs:117:13:117:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
@@ -179,9 +194,9 @@ edges
 | main.rs:123:31:123:32 | l1 | main.rs:123:13:123:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
 | main.rs:128:29:128:36 | ...: usize | main.rs:137:46:137:46 | v | provenance |  |
 | main.rs:137:9:137:10 | l2 | main.rs:138:38:138:39 | l2 | provenance |  |
-| main.rs:137:14:137:47 | ...::array::<...>(...) [Ok] | main.rs:137:14:137:56 | ... .unwrap(...) | provenance | MaD:28 |
+| main.rs:137:14:137:47 | ...::array::<...>(...) [Ok] | main.rs:137:14:137:56 | ... .unwrap(...) | provenance | MaD:31 |
 | main.rs:137:14:137:56 | ... .unwrap(...) | main.rs:137:9:137:10 | l2 | provenance |  |
-| main.rs:137:46:137:46 | v | main.rs:137:14:137:47 | ...::array::<...>(...) [Ok] | provenance | MaD:17 |
+| main.rs:137:46:137:46 | v | main.rs:137:14:137:47 | ...::array::<...>(...) [Ok] | provenance | MaD:18 |
 | main.rs:138:38:138:39 | l2 | main.rs:138:32:138:36 | alloc | provenance | MaD:10 Sink:MaD:10 |
 | main.rs:138:38:138:39 | l2 | main.rs:139:45:139:46 | l2 | provenance |  |
 | main.rs:139:45:139:46 | l2 | main.rs:139:32:139:43 | alloc_zeroed | provenance | MaD:11 Sink:MaD:11 |
@@ -218,10 +233,10 @@ edges
 | main.rs:211:9:211:9 | v | main.rs:217:27:217:27 | v | provenance |  |
 | main.rs:211:9:211:9 | v | main.rs:218:25:218:25 | v | provenance |  |
 | main.rs:211:13:211:26 | ...::args | main.rs:211:13:211:28 | ...::args(...) [element] | provenance | Src:MaD:16  |
-| main.rs:211:13:211:28 | ...::args(...) [element] | main.rs:211:13:211:35 | ... .nth(...) [Some] | provenance | MaD:32 |
-| main.rs:211:13:211:35 | ... .nth(...) [Some] | main.rs:211:13:211:65 | ... .unwrap_or(...) | provenance | MaD:26 |
-| main.rs:211:13:211:65 | ... .unwrap_or(...) | main.rs:211:13:211:82 | ... .parse(...) [Ok] | provenance | MaD:29 |
-| main.rs:211:13:211:82 | ... .parse(...) [Ok] | main.rs:211:13:211:91 | ... .unwrap(...) | provenance | MaD:28 |
+| main.rs:211:13:211:28 | ...::args(...) [element] | main.rs:211:13:211:35 | ... .nth(...) [Some] | provenance | MaD:35 |
+| main.rs:211:13:211:35 | ... .nth(...) [Some] | main.rs:211:13:211:65 | ... .unwrap_or(...) | provenance | MaD:29 |
+| main.rs:211:13:211:65 | ... .unwrap_or(...) | main.rs:211:13:211:82 | ... .parse(...) [Ok] | provenance | MaD:32 |
+| main.rs:211:13:211:82 | ... .parse(...) [Ok] | main.rs:211:13:211:91 | ... .unwrap(...) | provenance | MaD:31 |
 | main.rs:211:13:211:91 | ... .unwrap(...) | main.rs:211:9:211:9 | v | provenance |  |
 | main.rs:214:34:214:34 | v | main.rs:12:36:12:43 | ...: usize | provenance |  |
 | main.rs:215:42:215:42 | v | main.rs:43:44:43:51 | ...: usize | provenance |  |
@@ -245,22 +260,25 @@ models
 | 14 | Sink: repo:https://github.com/rust-lang/libc:libc; ::malloc; alloc-size; Argument[0] |
 | 15 | Sink: repo:https://github.com/rust-lang/libc:libc; ::realloc; alloc-size; Argument[1] |
 | 16 | Source: lang:std; crate::env::args; command-line-source; ReturnValue.Element |
-| 17 | Summary: lang:core; <crate::alloc::layout::Layout>::array; Argument[0]; ReturnValue.Field[crate::result::Result::Ok(0)]; taint |
-| 18 | Summary: lang:core; <crate::alloc::layout::Layout>::extend; Argument[0]; ReturnValue.Field[crate::result::Result::Ok(0)].Field[0]; taint |
-| 19 | Summary: lang:core; <crate::alloc::layout::Layout>::extend; Argument[self]; ReturnValue.Field[crate::result::Result::Ok(0)].Field[0]; taint |
-| 20 | Summary: lang:core; <crate::alloc::layout::Layout>::extend_packed; Argument[0]; ReturnValue.Field[crate::result::Result::Ok(0)]; taint |
-| 21 | Summary: lang:core; <crate::alloc::layout::Layout>::extend_packed; Argument[self]; ReturnValue.Field[crate::result::Result::Ok(0)]; taint |
-| 22 | Summary: lang:core; <crate::alloc::layout::Layout>::from_size_align; Argument[0]; ReturnValue.Field[crate::result::Result::Ok(0)]; taint |
-| 23 | Summary: lang:core; <crate::alloc::layout::Layout>::from_size_align_unchecked; Argument[0]; ReturnValue; taint |
-| 24 | Summary: lang:core; <crate::alloc::layout::Layout>::repeat; Argument[0]; ReturnValue.Field[crate::result::Result::Ok(0)].Field[0]; taint |
-| 25 | Summary: lang:core; <crate::alloc::layout::Layout>::repeat_packed; Argument[0]; ReturnValue.Field[crate::result::Result::Ok(0)]; taint |
-| 26 | Summary: lang:core; <crate::option::Option>::unwrap_or; Argument[self].Field[crate::option::Option::Some(0)]; ReturnValue; value |
-| 27 | Summary: lang:core; <crate::result::Result>::expect; Argument[self].Field[crate::result::Result::Ok(0)]; ReturnValue; value |
-| 28 | Summary: lang:core; <crate::result::Result>::unwrap; Argument[self].Field[crate::result::Result::Ok(0)]; ReturnValue; value |
-| 29 | Summary: lang:core; <str>::parse; Argument[self]; ReturnValue.Field[crate::result::Result::Ok(0)]; taint |
-| 30 | Summary: lang:core; crate::cmp::max; Argument[0]; ReturnValue; value |
-| 31 | Summary: lang:core; crate::cmp::min; Argument[0]; ReturnValue; value |
-| 32 | Summary: lang:core; crate::iter::traits::iterator::Iterator::nth; Argument[self].Element; ReturnValue.Field[crate::option::Option::Some(0)]; value |
+| 17 | Summary: lang:core; <crate::alloc::layout::Layout>::align_to; Argument[self]; ReturnValue.Field[crate::result::Result::Ok(0)]; taint |
+| 18 | Summary: lang:core; <crate::alloc::layout::Layout>::array; Argument[0]; ReturnValue.Field[crate::result::Result::Ok(0)]; taint |
+| 19 | Summary: lang:core; <crate::alloc::layout::Layout>::extend; Argument[0]; ReturnValue.Field[crate::result::Result::Ok(0)].Field[0]; taint |
+| 20 | Summary: lang:core; <crate::alloc::layout::Layout>::extend; Argument[self]; ReturnValue.Field[crate::result::Result::Ok(0)].Field[0]; taint |
+| 21 | Summary: lang:core; <crate::alloc::layout::Layout>::extend_packed; Argument[0]; ReturnValue.Field[crate::result::Result::Ok(0)]; taint |
+| 22 | Summary: lang:core; <crate::alloc::layout::Layout>::extend_packed; Argument[self]; ReturnValue.Field[crate::result::Result::Ok(0)]; taint |
+| 23 | Summary: lang:core; <crate::alloc::layout::Layout>::from_size_align; Argument[0]; ReturnValue.Field[crate::result::Result::Ok(0)]; taint |
+| 24 | Summary: lang:core; <crate::alloc::layout::Layout>::from_size_align_unchecked; Argument[0]; ReturnValue; taint |
+| 25 | Summary: lang:core; <crate::alloc::layout::Layout>::pad_to_align; Argument[self]; ReturnValue; taint |
+| 26 | Summary: lang:core; <crate::alloc::layout::Layout>::repeat; Argument[0]; ReturnValue.Field[crate::result::Result::Ok(0)].Field[0]; taint |
+| 27 | Summary: lang:core; <crate::alloc::layout::Layout>::repeat_packed; Argument[0]; ReturnValue.Field[crate::result::Result::Ok(0)]; taint |
+| 28 | Summary: lang:core; <crate::alloc::layout::Layout>::size; Argument[self]; ReturnValue; taint |
+| 29 | Summary: lang:core; <crate::option::Option>::unwrap_or; Argument[self].Field[crate::option::Option::Some(0)]; ReturnValue; value |
+| 30 | Summary: lang:core; <crate::result::Result>::expect; Argument[self].Field[crate::result::Result::Ok(0)]; ReturnValue; value |
+| 31 | Summary: lang:core; <crate::result::Result>::unwrap; Argument[self].Field[crate::result::Result::Ok(0)]; ReturnValue; value |
+| 32 | Summary: lang:core; <str>::parse; Argument[self]; ReturnValue.Field[crate::result::Result::Ok(0)]; taint |
+| 33 | Summary: lang:core; crate::cmp::max; Argument[0]; ReturnValue; value |
+| 34 | Summary: lang:core; crate::cmp::min; Argument[0]; ReturnValue; value |
+| 35 | Summary: lang:core; crate::iter::traits::iterator::Iterator::nth; Argument[self].Element; ReturnValue.Field[crate::option::Option::Some(0)]; value |
 nodes
 | main.rs:12:36:12:43 | ...: usize | semmle.label | ...: usize |
 | main.rs:18:13:18:31 | ...::realloc | semmle.label | ...::realloc |
@@ -271,6 +289,13 @@ nodes
 | main.rs:20:50:20:50 | v | semmle.label | v |
 | main.rs:21:13:21:29 | ...::alloc | semmle.label | ...::alloc |
 | main.rs:21:31:21:32 | l2 | semmle.label | l2 |
+| main.rs:22:13:22:29 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:22:31:22:44 | l2.align_to(...) [Ok] | semmle.label | l2.align_to(...) [Ok] |
+| main.rs:22:31:22:53 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
+| main.rs:23:13:23:29 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:23:31:23:44 | l2.align_to(...) [Ok] | semmle.label | l2.align_to(...) [Ok] |
+| main.rs:23:31:23:53 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
+| main.rs:23:31:23:68 | ... .pad_to_align(...) | semmle.label | ... .pad_to_align(...) |
 | main.rs:24:13:24:36 | ...::alloc_zeroed | semmle.label | ...::alloc_zeroed |
 | main.rs:24:38:24:39 | l2 | semmle.label | l2 |
 | main.rs:29:9:29:10 | l4 | semmle.label | l4 |
@@ -289,6 +314,11 @@ nodes
 | main.rs:36:60:36:61 | s6 | semmle.label | s6 |
 | main.rs:37:13:37:29 | ...::alloc | semmle.label | ...::alloc |
 | main.rs:37:31:37:32 | l6 | semmle.label | l6 |
+| main.rs:39:9:39:10 | l7 | semmle.label | l7 |
+| main.rs:39:14:39:72 | ...::from_size_align_unchecked(...) | semmle.label | ...::from_size_align_unchecked(...) |
+| main.rs:39:60:39:68 | l6.size(...) | semmle.label | l6.size(...) |
+| main.rs:40:13:40:29 | ...::alloc | semmle.label | ...::alloc |
+| main.rs:40:31:40:32 | l7 | semmle.label | l7 |
 | main.rs:43:44:43:51 | ...: usize | semmle.label | ...: usize |
 | main.rs:50:13:50:29 | ...::alloc | semmle.label | ...::alloc |
 | main.rs:50:31:50:42 | l2.repeat(...) [Ok, tuple.0] | semmle.label | l2.repeat(...) [Ok, tuple.0] |

--- a/rust/ql/test/query-tests/security/CWE-770/UncontrolledAllocationSize.expected
+++ b/rust/ql/test/query-tests/security/CWE-770/UncontrolledAllocationSize.expected
@@ -18,29 +18,12 @@
 | main.rs:64:13:64:29 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:64:13:64:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
 | main.rs:65:13:65:29 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:65:13:65:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
 | main.rs:68:13:68:29 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:68:13:68:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
-| main.rs:83:13:83:29 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:83:13:83:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
-| main.rs:88:13:88:29 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:88:13:88:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
 | main.rs:96:17:96:33 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:96:17:96:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
-| main.rs:97:17:97:33 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:97:17:97:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
 | main.rs:102:17:102:33 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:102:17:102:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
-| main.rs:103:17:103:33 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:103:17:103:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
 | main.rs:109:17:109:33 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:109:17:109:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
 | main.rs:111:17:111:33 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:111:17:111:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
-| main.rs:116:17:116:33 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:116:17:116:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
-| main.rs:121:17:121:33 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:121:17:121:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
-| main.rs:126:17:126:33 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:126:17:126:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
-| main.rs:135:13:135:29 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:135:13:135:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
 | main.rs:146:17:146:33 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:146:17:146:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
-| main.rs:147:17:147:33 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:147:17:147:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
-| main.rs:148:17:148:33 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:148:17:148:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
-| main.rs:152:13:152:29 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:152:13:152:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
-| main.rs:155:13:155:29 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:155:13:155:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
-| main.rs:158:13:158:29 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:158:13:158:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
-| main.rs:162:17:162:33 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:162:17:162:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
-| main.rs:169:17:169:33 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:169:17:169:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
-| main.rs:170:17:170:33 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:170:17:170:33 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
 | main.rs:177:13:177:29 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:177:13:177:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
-| main.rs:178:13:178:29 | ...::alloc | main.rs:317:13:317:26 | ...::args | main.rs:178:13:178:29 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
 | main.rs:193:32:193:36 | alloc | main.rs:317:13:317:26 | ...::args | main.rs:193:32:193:36 | alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
 | main.rs:194:32:194:43 | alloc_zeroed | main.rs:317:13:317:26 | ...::args | main.rs:194:32:194:43 | alloc_zeroed | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
 | main.rs:195:32:195:39 | allocate | main.rs:317:13:317:26 | ...::args | main.rs:195:32:195:39 | allocate | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
@@ -60,7 +43,6 @@
 | main.rs:224:13:224:25 | ...::realloc | main.rs:317:13:317:26 | ...::args | main.rs:224:13:224:25 | ...::realloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
 | main.rs:224:13:224:25 | ...::realloc | main.rs:317:13:317:26 | ...::args | main.rs:224:13:224:25 | ...::realloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:317:13:317:26 | ...::args | user-provided value |
 | main.rs:284:22:284:38 | ...::alloc | main.rs:308:25:308:38 | ...::args | main.rs:284:22:284:38 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:308:25:308:38 | ...::args | user-provided value |
-| main.rs:301:22:301:38 | ...::alloc | main.rs:309:26:309:39 | ...::args | main.rs:301:22:301:38 | ...::alloc | This allocation size is derived from a $@ and could allocate arbitrary amounts of memory. | main.rs:309:26:309:39 | ...::args | user-provided value |
 edges
 | main.rs:12:36:12:43 | ...: usize | main.rs:18:41:18:41 | v | provenance |  |
 | main.rs:18:41:18:41 | v | main.rs:18:13:18:31 | ...::realloc | provenance | MaD:5 Sink:MaD:5 |
@@ -151,133 +133,25 @@ edges
 | main.rs:67:14:67:56 | ... .unwrap(...) | main.rs:67:9:67:10 | l4 | provenance |  |
 | main.rs:67:46:67:46 | v | main.rs:67:14:67:47 | ...::array::<...>(...) [Ok] | provenance | MaD:18 |
 | main.rs:68:31:68:32 | l4 | main.rs:68:13:68:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
-| main.rs:71:35:71:38 | ...: T | main.rs:77:9:77:16 | return v | provenance |  |
-| main.rs:81:33:81:40 | ...: usize | main.rs:82:54:82:54 | v | provenance |  |
-| main.rs:82:9:82:14 | layout | main.rs:83:31:83:36 | layout | provenance |  |
-| main.rs:82:18:82:58 | ...::from_size_align(...) [Ok] | main.rs:82:18:82:67 | ... .unwrap(...) | provenance | MaD:31 |
-| main.rs:82:18:82:67 | ... .unwrap(...) | main.rs:82:9:82:14 | layout | provenance |  |
-| main.rs:82:54:82:54 | v | main.rs:82:18:82:58 | ...::from_size_align(...) [Ok] | provenance | MaD:23 |
-| main.rs:83:31:83:36 | layout | main.rs:83:13:83:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
-| main.rs:86:35:86:42 | ...: usize | main.rs:87:54:87:54 | v | provenance |  |
-| main.rs:87:9:87:14 | layout | main.rs:88:31:88:36 | layout | provenance |  |
-| main.rs:87:18:87:58 | ...::from_size_align(...) [Ok] | main.rs:87:18:87:67 | ... .unwrap(...) | provenance | MaD:31 |
-| main.rs:87:18:87:67 | ... .unwrap(...) | main.rs:87:9:87:14 | layout | provenance |  |
-| main.rs:87:54:87:54 | v | main.rs:87:18:87:58 | ...::from_size_align(...) [Ok] | provenance | MaD:23 |
-| main.rs:88:31:88:36 | layout | main.rs:88:13:88:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
 | main.rs:91:38:91:45 | ...: usize | main.rs:92:47:92:47 | v | provenance |  |
-| main.rs:91:38:91:45 | ...: usize | main.rs:95:51:95:51 | v | provenance |  |
-| main.rs:91:38:91:45 | ...: usize | main.rs:99:31:99:31 | v | provenance |  |
-| main.rs:91:38:91:45 | ...: usize | main.rs:101:51:101:51 | v | provenance |  |
-| main.rs:91:38:91:45 | ...: usize | main.rs:105:33:105:33 | v | provenance |  |
-| main.rs:91:38:91:45 | ...: usize | main.rs:115:54:115:54 | v | provenance |  |
-| main.rs:91:38:91:45 | ...: usize | main.rs:120:54:120:54 | v | provenance |  |
-| main.rs:91:38:91:45 | ...: usize | main.rs:125:54:125:54 | v | provenance |  |
-| main.rs:91:38:91:45 | ...: usize | main.rs:131:50:131:50 | v | provenance |  |
-| main.rs:91:38:91:45 | ...: usize | main.rs:138:13:138:21 | mut v_mut | provenance |  |
-| main.rs:91:38:91:45 | ...: usize | main.rs:145:51:145:51 | v | provenance |  |
-| main.rs:91:38:91:45 | ...: usize | main.rs:151:62:151:62 | v | provenance |  |
-| main.rs:91:38:91:45 | ...: usize | main.rs:154:62:154:62 | v | provenance |  |
-| main.rs:91:38:91:45 | ...: usize | main.rs:157:54:157:54 | v | provenance |  |
-| main.rs:91:38:91:45 | ...: usize | main.rs:161:55:161:55 | v | provenance |  |
-| main.rs:91:38:91:45 | ...: usize | main.rs:168:55:168:55 | v | provenance |  |
-| main.rs:91:38:91:45 | ...: usize | main.rs:176:51:176:51 | v | provenance |  |
 | main.rs:92:9:92:10 | l1 | main.rs:96:35:96:36 | l1 | provenance |  |
 | main.rs:92:9:92:10 | l1 | main.rs:102:35:102:36 | l1 | provenance |  |
 | main.rs:92:14:92:48 | ...::array::<...>(...) [Ok] | main.rs:92:14:92:57 | ... .unwrap(...) | provenance | MaD:31 |
 | main.rs:92:14:92:57 | ... .unwrap(...) | main.rs:92:9:92:10 | l1 | provenance |  |
 | main.rs:92:47:92:47 | v | main.rs:92:14:92:48 | ...::array::<...>(...) [Ok] | provenance | MaD:18 |
-| main.rs:95:13:95:14 | l2 | main.rs:97:35:97:36 | l2 | provenance |  |
-| main.rs:95:18:95:52 | ...::array::<...>(...) [Ok] | main.rs:95:18:95:61 | ... .unwrap(...) | provenance | MaD:31 |
-| main.rs:95:18:95:61 | ... .unwrap(...) | main.rs:95:13:95:14 | l2 | provenance |  |
-| main.rs:95:51:95:51 | v | main.rs:95:18:95:52 | ...::array::<...>(...) [Ok] | provenance | MaD:18 |
 | main.rs:96:35:96:36 | l1 | main.rs:96:17:96:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
 | main.rs:96:35:96:36 | l1 | main.rs:109:35:109:36 | l1 | provenance |  |
 | main.rs:96:35:96:36 | l1 | main.rs:111:35:111:36 | l1 | provenance |  |
-| main.rs:97:35:97:36 | l2 | main.rs:97:17:97:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
-| main.rs:99:31:99:31 | v | main.rs:81:33:81:40 | ...: usize | provenance |  |
-| main.rs:101:13:101:14 | l3 | main.rs:103:35:103:36 | l3 | provenance |  |
-| main.rs:101:18:101:52 | ...::array::<...>(...) [Ok] | main.rs:101:18:101:61 | ... .unwrap(...) | provenance | MaD:31 |
-| main.rs:101:18:101:61 | ... .unwrap(...) | main.rs:101:13:101:14 | l3 | provenance |  |
-| main.rs:101:51:101:51 | v | main.rs:101:18:101:52 | ...::array::<...>(...) [Ok] | provenance | MaD:18 |
 | main.rs:102:35:102:36 | l1 | main.rs:102:17:102:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
 | main.rs:102:35:102:36 | l1 | main.rs:109:35:109:36 | l1 | provenance |  |
 | main.rs:102:35:102:36 | l1 | main.rs:111:35:111:36 | l1 | provenance |  |
-| main.rs:103:35:103:36 | l3 | main.rs:103:17:103:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
-| main.rs:105:33:105:33 | v | main.rs:86:35:86:42 | ...: usize | provenance |  |
 | main.rs:109:35:109:36 | l1 | main.rs:109:17:109:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
 | main.rs:109:35:109:36 | l1 | main.rs:146:35:146:36 | l1 | provenance |  |
 | main.rs:111:35:111:36 | l1 | main.rs:111:17:111:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
 | main.rs:111:35:111:36 | l1 | main.rs:146:35:146:36 | l1 | provenance |  |
-| main.rs:115:13:115:14 | l4 | main.rs:116:35:116:36 | l4 | provenance |  |
-| main.rs:115:18:115:58 | ...::from_size_align(...) [Ok] | main.rs:115:18:115:67 | ... .unwrap(...) | provenance | MaD:31 |
-| main.rs:115:18:115:67 | ... .unwrap(...) | main.rs:115:13:115:14 | l4 | provenance |  |
-| main.rs:115:54:115:54 | v | main.rs:115:18:115:58 | ...::from_size_align(...) [Ok] | provenance | MaD:23 |
-| main.rs:116:35:116:36 | l4 | main.rs:116:17:116:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
-| main.rs:120:13:120:14 | l5 | main.rs:121:35:121:36 | l5 | provenance |  |
-| main.rs:120:18:120:58 | ...::from_size_align(...) [Ok] | main.rs:120:18:120:67 | ... .unwrap(...) | provenance | MaD:31 |
-| main.rs:120:18:120:67 | ... .unwrap(...) | main.rs:120:13:120:14 | l5 | provenance |  |
-| main.rs:120:54:120:54 | v | main.rs:120:18:120:58 | ...::from_size_align(...) [Ok] | provenance | MaD:23 |
-| main.rs:121:35:121:36 | l5 | main.rs:121:17:121:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
-| main.rs:125:13:125:14 | l6 | main.rs:126:35:126:36 | l6 | provenance |  |
-| main.rs:125:18:125:58 | ...::from_size_align(...) [Ok] | main.rs:125:18:125:67 | ... .unwrap(...) | provenance | MaD:31 |
-| main.rs:125:18:125:67 | ... .unwrap(...) | main.rs:125:13:125:14 | l6 | provenance |  |
-| main.rs:125:54:125:54 | v | main.rs:125:18:125:58 | ...::from_size_align(...) [Ok] | provenance | MaD:23 |
-| main.rs:126:35:126:36 | l6 | main.rs:126:17:126:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
-| main.rs:131:9:131:10 | l7 | main.rs:135:31:135:32 | l7 | provenance |  |
-| main.rs:131:14:131:54 | ...::from_size_align(...) [Ok] | main.rs:131:14:131:63 | ... .unwrap(...) | provenance | MaD:31 |
-| main.rs:131:14:131:63 | ... .unwrap(...) | main.rs:131:9:131:10 | l7 | provenance |  |
-| main.rs:131:50:131:50 | v | main.rs:131:14:131:54 | ...::from_size_align(...) [Ok] | provenance | MaD:23 |
-| main.rs:135:31:135:32 | l7 | main.rs:135:13:135:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
-| main.rs:138:13:138:21 | mut v_mut | main.rs:144:51:144:55 | v_mut | provenance |  |
-| main.rs:144:13:144:14 | l8 | main.rs:147:35:147:36 | l8 | provenance |  |
-| main.rs:144:18:144:56 | ...::array::<...>(...) [Ok] | main.rs:144:18:144:65 | ... .unwrap(...) | provenance | MaD:31 |
-| main.rs:144:18:144:65 | ... .unwrap(...) | main.rs:144:13:144:14 | l8 | provenance |  |
-| main.rs:144:51:144:55 | v_mut | main.rs:144:18:144:56 | ...::array::<...>(...) [Ok] | provenance | MaD:18 |
-| main.rs:145:13:145:14 | l9 | main.rs:148:35:148:36 | l9 | provenance |  |
-| main.rs:145:18:145:52 | ...::array::<...>(...) [Ok] | main.rs:145:18:145:61 | ... .unwrap(...) | provenance | MaD:31 |
-| main.rs:145:18:145:61 | ... .unwrap(...) | main.rs:145:13:145:14 | l9 | provenance |  |
-| main.rs:145:51:145:51 | v | main.rs:145:18:145:52 | ...::array::<...>(...) [Ok] | provenance | MaD:18 |
 | main.rs:146:35:146:36 | l1 | main.rs:146:17:146:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
 | main.rs:146:35:146:36 | l1 | main.rs:177:31:177:32 | l1 | provenance |  |
-| main.rs:147:35:147:36 | l8 | main.rs:147:17:147:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
-| main.rs:148:35:148:36 | l9 | main.rs:148:17:148:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
-| main.rs:151:9:151:11 | l10 | main.rs:152:31:152:33 | l10 | provenance |  |
-| main.rs:151:15:151:69 | ...::array::<...>(...) [Ok] | main.rs:151:15:151:78 | ... .unwrap(...) | provenance | MaD:31 |
-| main.rs:151:15:151:78 | ... .unwrap(...) | main.rs:151:9:151:11 | l10 | provenance |  |
-| main.rs:151:48:151:68 | ...::min(...) | main.rs:151:15:151:69 | ...::array::<...>(...) [Ok] | provenance | MaD:18 |
-| main.rs:151:62:151:62 | v | main.rs:151:48:151:68 | ...::min(...) | provenance | MaD:34 |
-| main.rs:152:31:152:33 | l10 | main.rs:152:13:152:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
-| main.rs:154:9:154:11 | l11 | main.rs:155:31:155:33 | l11 | provenance |  |
-| main.rs:154:15:154:69 | ...::array::<...>(...) [Ok] | main.rs:154:15:154:78 | ... .unwrap(...) | provenance | MaD:31 |
-| main.rs:154:15:154:78 | ... .unwrap(...) | main.rs:154:9:154:11 | l11 | provenance |  |
-| main.rs:154:48:154:68 | ...::max(...) | main.rs:154:15:154:69 | ...::array::<...>(...) [Ok] | provenance | MaD:18 |
-| main.rs:154:62:154:62 | v | main.rs:154:48:154:68 | ...::max(...) | provenance | MaD:33 |
-| main.rs:155:31:155:33 | l11 | main.rs:155:13:155:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
-| main.rs:157:9:157:11 | l12 | main.rs:158:31:158:33 | l12 | provenance |  |
-| main.rs:157:15:157:64 | ...::array::<...>(...) [Ok] | main.rs:157:15:157:73 | ... .unwrap(...) | provenance | MaD:31 |
-| main.rs:157:15:157:73 | ... .unwrap(...) | main.rs:157:9:157:11 | l12 | provenance |  |
-| main.rs:157:48:157:63 | clamp(...) | main.rs:157:15:157:64 | ...::array::<...>(...) [Ok] | provenance | MaD:18 |
-| main.rs:157:54:157:54 | v | main.rs:71:35:71:38 | ...: T | provenance |  |
-| main.rs:157:54:157:54 | v | main.rs:157:48:157:63 | clamp(...) | provenance |  |
-| main.rs:158:31:158:33 | l12 | main.rs:158:13:158:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
-| main.rs:161:13:161:15 | l13 | main.rs:162:35:162:37 | l13 | provenance |  |
-| main.rs:161:19:161:59 | ...::from_size_align(...) [Ok] | main.rs:161:19:161:68 | ... .unwrap(...) | provenance | MaD:31 |
-| main.rs:161:19:161:68 | ... .unwrap(...) | main.rs:161:13:161:15 | l13 | provenance |  |
-| main.rs:161:55:161:55 | v | main.rs:161:19:161:59 | ...::from_size_align(...) [Ok] | provenance | MaD:23 |
-| main.rs:162:35:162:37 | l13 | main.rs:162:17:162:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
-| main.rs:162:35:162:37 | l13 | main.rs:169:35:169:37 | l13 | provenance |  |
-| main.rs:168:13:168:15 | l14 | main.rs:170:35:170:37 | l14 | provenance |  |
-| main.rs:168:19:168:59 | ...::from_size_align(...) [Ok] | main.rs:168:19:168:68 | ... .unwrap(...) | provenance | MaD:31 |
-| main.rs:168:19:168:68 | ... .unwrap(...) | main.rs:168:13:168:15 | l14 | provenance |  |
-| main.rs:168:55:168:55 | v | main.rs:168:19:168:59 | ...::from_size_align(...) [Ok] | provenance | MaD:23 |
-| main.rs:169:35:169:37 | l13 | main.rs:169:17:169:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
-| main.rs:170:35:170:37 | l14 | main.rs:170:17:170:33 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
-| main.rs:176:9:176:11 | l15 | main.rs:178:31:178:33 | l15 | provenance |  |
-| main.rs:176:15:176:55 | ...::from_size_align(...) [Ok] | main.rs:176:15:176:64 | ... .unwrap(...) | provenance | MaD:31 |
-| main.rs:176:15:176:64 | ... .unwrap(...) | main.rs:176:9:176:11 | l15 | provenance |  |
-| main.rs:176:51:176:51 | v | main.rs:176:15:176:55 | ...::from_size_align(...) [Ok] | provenance | MaD:23 |
 | main.rs:177:31:177:32 | l1 | main.rs:177:13:177:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
-| main.rs:178:31:178:33 | l15 | main.rs:178:13:178:29 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
 | main.rs:183:29:183:36 | ...: usize | main.rs:192:46:192:46 | v | provenance |  |
 | main.rs:192:9:192:10 | l2 | main.rs:193:38:193:39 | l2 | provenance |  |
 | main.rs:192:14:192:47 | ...::array::<...>(...) [Ok] | main.rs:192:14:192:56 | ... .unwrap(...) | provenance | MaD:31 |
@@ -322,31 +196,17 @@ edges
 | main.rs:282:18:282:75 | ... .unwrap(...) | main.rs:282:9:282:14 | layout | provenance |  |
 | main.rs:282:54:282:62 | num_bytes | main.rs:282:18:282:66 | ...::from_size_align(...) [Ok] | provenance | MaD:23 |
 | main.rs:284:40:284:45 | layout | main.rs:284:22:284:38 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
-| main.rs:292:25:292:42 | ...: String | main.rs:293:16:293:42 | user_input.parse(...) [Ok] | provenance | MaD:32 |
-| main.rs:293:9:293:12 | size | main.rs:297:9:297:17 | num_bytes | provenance |  |
-| main.rs:293:16:293:42 | user_input.parse(...) [Ok] | main.rs:293:16:293:43 | TryExpr | provenance |  |
-| main.rs:293:16:293:43 | TryExpr | main.rs:293:9:293:12 | size | provenance |  |
-| main.rs:297:9:297:17 | num_bytes | main.rs:299:54:299:62 | num_bytes | provenance |  |
-| main.rs:299:9:299:14 | layout | main.rs:301:40:301:45 | layout | provenance |  |
-| main.rs:299:18:299:66 | ...::from_size_align(...) [Ok] | main.rs:299:18:299:75 | ... .unwrap(...) | provenance | MaD:31 |
-| main.rs:299:18:299:75 | ... .unwrap(...) | main.rs:299:9:299:14 | layout | provenance |  |
-| main.rs:299:54:299:62 | num_bytes | main.rs:299:18:299:66 | ...::from_size_align(...) [Ok] | provenance | MaD:23 |
-| main.rs:301:40:301:45 | layout | main.rs:301:22:301:38 | ...::alloc | provenance | MaD:3 Sink:MaD:3 |
 | main.rs:308:25:308:38 | ...::args | main.rs:308:25:308:40 | ...::args(...) [element] | provenance | Src:MaD:16  |
-| main.rs:308:25:308:40 | ...::args(...) [element] | main.rs:308:25:308:47 | ... .nth(...) [Some] | provenance | MaD:35 |
+| main.rs:308:25:308:40 | ...::args(...) [element] | main.rs:308:25:308:47 | ... .nth(...) [Some] | provenance | MaD:33 |
 | main.rs:308:25:308:47 | ... .nth(...) [Some] | main.rs:308:25:308:74 | ... .unwrap_or(...) | provenance | MaD:29 |
 | main.rs:308:25:308:74 | ... .unwrap_or(...) | main.rs:279:24:279:41 | ...: String | provenance |  |
-| main.rs:309:26:309:39 | ...::args | main.rs:309:26:309:41 | ...::args(...) [element] | provenance | Src:MaD:16  |
-| main.rs:309:26:309:41 | ...::args(...) [element] | main.rs:309:26:309:48 | ... .nth(...) [Some] | provenance | MaD:35 |
-| main.rs:309:26:309:48 | ... .nth(...) [Some] | main.rs:309:26:309:75 | ... .unwrap_or(...) | provenance | MaD:29 |
-| main.rs:309:26:309:75 | ... .unwrap_or(...) | main.rs:292:25:292:42 | ...: String | provenance |  |
 | main.rs:317:9:317:9 | v | main.rs:320:34:320:34 | v | provenance |  |
 | main.rs:317:9:317:9 | v | main.rs:321:42:321:42 | v | provenance |  |
 | main.rs:317:9:317:9 | v | main.rs:322:36:322:36 | v | provenance |  |
 | main.rs:317:9:317:9 | v | main.rs:323:27:323:27 | v | provenance |  |
 | main.rs:317:9:317:9 | v | main.rs:324:25:324:25 | v | provenance |  |
 | main.rs:317:13:317:26 | ...::args | main.rs:317:13:317:28 | ...::args(...) [element] | provenance | Src:MaD:16  |
-| main.rs:317:13:317:28 | ...::args(...) [element] | main.rs:317:13:317:35 | ... .nth(...) [Some] | provenance | MaD:35 |
+| main.rs:317:13:317:28 | ...::args(...) [element] | main.rs:317:13:317:35 | ... .nth(...) [Some] | provenance | MaD:33 |
 | main.rs:317:13:317:35 | ... .nth(...) [Some] | main.rs:317:13:317:65 | ... .unwrap_or(...) | provenance | MaD:29 |
 | main.rs:317:13:317:65 | ... .unwrap_or(...) | main.rs:317:13:317:82 | ... .parse(...) [Ok] | provenance | MaD:32 |
 | main.rs:317:13:317:82 | ... .parse(...) [Ok] | main.rs:317:13:317:91 | ... .unwrap(...) | provenance | MaD:31 |
@@ -389,9 +249,7 @@ models
 | 30 | Summary: lang:core; <crate::result::Result>::expect; Argument[self].Field[crate::result::Result::Ok(0)]; ReturnValue; value |
 | 31 | Summary: lang:core; <crate::result::Result>::unwrap; Argument[self].Field[crate::result::Result::Ok(0)]; ReturnValue; value |
 | 32 | Summary: lang:core; <str>::parse; Argument[self]; ReturnValue.Field[crate::result::Result::Ok(0)]; taint |
-| 33 | Summary: lang:core; crate::cmp::max; Argument[0]; ReturnValue; value |
-| 34 | Summary: lang:core; crate::cmp::min; Argument[0]; ReturnValue; value |
-| 35 | Summary: lang:core; crate::iter::traits::iterator::Iterator::nth; Argument[self].Element; ReturnValue.Field[crate::option::Option::Some(0)]; value |
+| 33 | Summary: lang:core; crate::iter::traits::iterator::Iterator::nth; Argument[self].Element; ReturnValue.Field[crate::option::Option::Some(0)]; value |
 nodes
 | main.rs:12:36:12:43 | ...: usize | semmle.label | ...: usize |
 | main.rs:18:13:18:31 | ...::realloc | semmle.label | ...::realloc |
@@ -484,131 +342,23 @@ nodes
 | main.rs:67:46:67:46 | v | semmle.label | v |
 | main.rs:68:13:68:29 | ...::alloc | semmle.label | ...::alloc |
 | main.rs:68:31:68:32 | l4 | semmle.label | l4 |
-| main.rs:71:35:71:38 | ...: T | semmle.label | ...: T |
-| main.rs:77:9:77:16 | return v | semmle.label | return v |
-| main.rs:81:33:81:40 | ...: usize | semmle.label | ...: usize |
-| main.rs:82:9:82:14 | layout | semmle.label | layout |
-| main.rs:82:18:82:58 | ...::from_size_align(...) [Ok] | semmle.label | ...::from_size_align(...) [Ok] |
-| main.rs:82:18:82:67 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
-| main.rs:82:54:82:54 | v | semmle.label | v |
-| main.rs:83:13:83:29 | ...::alloc | semmle.label | ...::alloc |
-| main.rs:83:31:83:36 | layout | semmle.label | layout |
-| main.rs:86:35:86:42 | ...: usize | semmle.label | ...: usize |
-| main.rs:87:9:87:14 | layout | semmle.label | layout |
-| main.rs:87:18:87:58 | ...::from_size_align(...) [Ok] | semmle.label | ...::from_size_align(...) [Ok] |
-| main.rs:87:18:87:67 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
-| main.rs:87:54:87:54 | v | semmle.label | v |
-| main.rs:88:13:88:29 | ...::alloc | semmle.label | ...::alloc |
-| main.rs:88:31:88:36 | layout | semmle.label | layout |
 | main.rs:91:38:91:45 | ...: usize | semmle.label | ...: usize |
 | main.rs:92:9:92:10 | l1 | semmle.label | l1 |
 | main.rs:92:14:92:48 | ...::array::<...>(...) [Ok] | semmle.label | ...::array::<...>(...) [Ok] |
 | main.rs:92:14:92:57 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
 | main.rs:92:47:92:47 | v | semmle.label | v |
-| main.rs:95:13:95:14 | l2 | semmle.label | l2 |
-| main.rs:95:18:95:52 | ...::array::<...>(...) [Ok] | semmle.label | ...::array::<...>(...) [Ok] |
-| main.rs:95:18:95:61 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
-| main.rs:95:51:95:51 | v | semmle.label | v |
 | main.rs:96:17:96:33 | ...::alloc | semmle.label | ...::alloc |
 | main.rs:96:35:96:36 | l1 | semmle.label | l1 |
-| main.rs:97:17:97:33 | ...::alloc | semmle.label | ...::alloc |
-| main.rs:97:35:97:36 | l2 | semmle.label | l2 |
-| main.rs:99:31:99:31 | v | semmle.label | v |
-| main.rs:101:13:101:14 | l3 | semmle.label | l3 |
-| main.rs:101:18:101:52 | ...::array::<...>(...) [Ok] | semmle.label | ...::array::<...>(...) [Ok] |
-| main.rs:101:18:101:61 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
-| main.rs:101:51:101:51 | v | semmle.label | v |
 | main.rs:102:17:102:33 | ...::alloc | semmle.label | ...::alloc |
 | main.rs:102:35:102:36 | l1 | semmle.label | l1 |
-| main.rs:103:17:103:33 | ...::alloc | semmle.label | ...::alloc |
-| main.rs:103:35:103:36 | l3 | semmle.label | l3 |
-| main.rs:105:33:105:33 | v | semmle.label | v |
 | main.rs:109:17:109:33 | ...::alloc | semmle.label | ...::alloc |
 | main.rs:109:35:109:36 | l1 | semmle.label | l1 |
 | main.rs:111:17:111:33 | ...::alloc | semmle.label | ...::alloc |
 | main.rs:111:35:111:36 | l1 | semmle.label | l1 |
-| main.rs:115:13:115:14 | l4 | semmle.label | l4 |
-| main.rs:115:18:115:58 | ...::from_size_align(...) [Ok] | semmle.label | ...::from_size_align(...) [Ok] |
-| main.rs:115:18:115:67 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
-| main.rs:115:54:115:54 | v | semmle.label | v |
-| main.rs:116:17:116:33 | ...::alloc | semmle.label | ...::alloc |
-| main.rs:116:35:116:36 | l4 | semmle.label | l4 |
-| main.rs:120:13:120:14 | l5 | semmle.label | l5 |
-| main.rs:120:18:120:58 | ...::from_size_align(...) [Ok] | semmle.label | ...::from_size_align(...) [Ok] |
-| main.rs:120:18:120:67 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
-| main.rs:120:54:120:54 | v | semmle.label | v |
-| main.rs:121:17:121:33 | ...::alloc | semmle.label | ...::alloc |
-| main.rs:121:35:121:36 | l5 | semmle.label | l5 |
-| main.rs:125:13:125:14 | l6 | semmle.label | l6 |
-| main.rs:125:18:125:58 | ...::from_size_align(...) [Ok] | semmle.label | ...::from_size_align(...) [Ok] |
-| main.rs:125:18:125:67 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
-| main.rs:125:54:125:54 | v | semmle.label | v |
-| main.rs:126:17:126:33 | ...::alloc | semmle.label | ...::alloc |
-| main.rs:126:35:126:36 | l6 | semmle.label | l6 |
-| main.rs:131:9:131:10 | l7 | semmle.label | l7 |
-| main.rs:131:14:131:54 | ...::from_size_align(...) [Ok] | semmle.label | ...::from_size_align(...) [Ok] |
-| main.rs:131:14:131:63 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
-| main.rs:131:50:131:50 | v | semmle.label | v |
-| main.rs:135:13:135:29 | ...::alloc | semmle.label | ...::alloc |
-| main.rs:135:31:135:32 | l7 | semmle.label | l7 |
-| main.rs:138:13:138:21 | mut v_mut | semmle.label | mut v_mut |
-| main.rs:144:13:144:14 | l8 | semmle.label | l8 |
-| main.rs:144:18:144:56 | ...::array::<...>(...) [Ok] | semmle.label | ...::array::<...>(...) [Ok] |
-| main.rs:144:18:144:65 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
-| main.rs:144:51:144:55 | v_mut | semmle.label | v_mut |
-| main.rs:145:13:145:14 | l9 | semmle.label | l9 |
-| main.rs:145:18:145:52 | ...::array::<...>(...) [Ok] | semmle.label | ...::array::<...>(...) [Ok] |
-| main.rs:145:18:145:61 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
-| main.rs:145:51:145:51 | v | semmle.label | v |
 | main.rs:146:17:146:33 | ...::alloc | semmle.label | ...::alloc |
 | main.rs:146:35:146:36 | l1 | semmle.label | l1 |
-| main.rs:147:17:147:33 | ...::alloc | semmle.label | ...::alloc |
-| main.rs:147:35:147:36 | l8 | semmle.label | l8 |
-| main.rs:148:17:148:33 | ...::alloc | semmle.label | ...::alloc |
-| main.rs:148:35:148:36 | l9 | semmle.label | l9 |
-| main.rs:151:9:151:11 | l10 | semmle.label | l10 |
-| main.rs:151:15:151:69 | ...::array::<...>(...) [Ok] | semmle.label | ...::array::<...>(...) [Ok] |
-| main.rs:151:15:151:78 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
-| main.rs:151:48:151:68 | ...::min(...) | semmle.label | ...::min(...) |
-| main.rs:151:62:151:62 | v | semmle.label | v |
-| main.rs:152:13:152:29 | ...::alloc | semmle.label | ...::alloc |
-| main.rs:152:31:152:33 | l10 | semmle.label | l10 |
-| main.rs:154:9:154:11 | l11 | semmle.label | l11 |
-| main.rs:154:15:154:69 | ...::array::<...>(...) [Ok] | semmle.label | ...::array::<...>(...) [Ok] |
-| main.rs:154:15:154:78 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
-| main.rs:154:48:154:68 | ...::max(...) | semmle.label | ...::max(...) |
-| main.rs:154:62:154:62 | v | semmle.label | v |
-| main.rs:155:13:155:29 | ...::alloc | semmle.label | ...::alloc |
-| main.rs:155:31:155:33 | l11 | semmle.label | l11 |
-| main.rs:157:9:157:11 | l12 | semmle.label | l12 |
-| main.rs:157:15:157:64 | ...::array::<...>(...) [Ok] | semmle.label | ...::array::<...>(...) [Ok] |
-| main.rs:157:15:157:73 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
-| main.rs:157:48:157:63 | clamp(...) | semmle.label | clamp(...) |
-| main.rs:157:54:157:54 | v | semmle.label | v |
-| main.rs:158:13:158:29 | ...::alloc | semmle.label | ...::alloc |
-| main.rs:158:31:158:33 | l12 | semmle.label | l12 |
-| main.rs:161:13:161:15 | l13 | semmle.label | l13 |
-| main.rs:161:19:161:59 | ...::from_size_align(...) [Ok] | semmle.label | ...::from_size_align(...) [Ok] |
-| main.rs:161:19:161:68 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
-| main.rs:161:55:161:55 | v | semmle.label | v |
-| main.rs:162:17:162:33 | ...::alloc | semmle.label | ...::alloc |
-| main.rs:162:35:162:37 | l13 | semmle.label | l13 |
-| main.rs:168:13:168:15 | l14 | semmle.label | l14 |
-| main.rs:168:19:168:59 | ...::from_size_align(...) [Ok] | semmle.label | ...::from_size_align(...) [Ok] |
-| main.rs:168:19:168:68 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
-| main.rs:168:55:168:55 | v | semmle.label | v |
-| main.rs:169:17:169:33 | ...::alloc | semmle.label | ...::alloc |
-| main.rs:169:35:169:37 | l13 | semmle.label | l13 |
-| main.rs:170:17:170:33 | ...::alloc | semmle.label | ...::alloc |
-| main.rs:170:35:170:37 | l14 | semmle.label | l14 |
-| main.rs:176:9:176:11 | l15 | semmle.label | l15 |
-| main.rs:176:15:176:55 | ...::from_size_align(...) [Ok] | semmle.label | ...::from_size_align(...) [Ok] |
-| main.rs:176:15:176:64 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
-| main.rs:176:51:176:51 | v | semmle.label | v |
 | main.rs:177:13:177:29 | ...::alloc | semmle.label | ...::alloc |
 | main.rs:177:31:177:32 | l1 | semmle.label | l1 |
-| main.rs:178:13:178:29 | ...::alloc | semmle.label | ...::alloc |
-| main.rs:178:31:178:33 | l15 | semmle.label | l15 |
 | main.rs:183:29:183:36 | ...: usize | semmle.label | ...: usize |
 | main.rs:192:9:192:10 | l2 | semmle.label | l2 |
 | main.rs:192:14:192:47 | ...::array::<...>(...) [Ok] | semmle.label | ...::array::<...>(...) [Ok] |
@@ -656,25 +406,10 @@ nodes
 | main.rs:282:54:282:62 | num_bytes | semmle.label | num_bytes |
 | main.rs:284:22:284:38 | ...::alloc | semmle.label | ...::alloc |
 | main.rs:284:40:284:45 | layout | semmle.label | layout |
-| main.rs:292:25:292:42 | ...: String | semmle.label | ...: String |
-| main.rs:293:9:293:12 | size | semmle.label | size |
-| main.rs:293:16:293:42 | user_input.parse(...) [Ok] | semmle.label | user_input.parse(...) [Ok] |
-| main.rs:293:16:293:43 | TryExpr | semmle.label | TryExpr |
-| main.rs:297:9:297:17 | num_bytes | semmle.label | num_bytes |
-| main.rs:299:9:299:14 | layout | semmle.label | layout |
-| main.rs:299:18:299:66 | ...::from_size_align(...) [Ok] | semmle.label | ...::from_size_align(...) [Ok] |
-| main.rs:299:18:299:75 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
-| main.rs:299:54:299:62 | num_bytes | semmle.label | num_bytes |
-| main.rs:301:22:301:38 | ...::alloc | semmle.label | ...::alloc |
-| main.rs:301:40:301:45 | layout | semmle.label | layout |
 | main.rs:308:25:308:38 | ...::args | semmle.label | ...::args |
 | main.rs:308:25:308:40 | ...::args(...) [element] | semmle.label | ...::args(...) [element] |
 | main.rs:308:25:308:47 | ... .nth(...) [Some] | semmle.label | ... .nth(...) [Some] |
 | main.rs:308:25:308:74 | ... .unwrap_or(...) | semmle.label | ... .unwrap_or(...) |
-| main.rs:309:26:309:39 | ...::args | semmle.label | ...::args |
-| main.rs:309:26:309:41 | ...::args(...) [element] | semmle.label | ...::args(...) [element] |
-| main.rs:309:26:309:48 | ... .nth(...) [Some] | semmle.label | ... .nth(...) [Some] |
-| main.rs:309:26:309:75 | ... .unwrap_or(...) | semmle.label | ... .unwrap_or(...) |
 | main.rs:317:9:317:9 | v | semmle.label | v |
 | main.rs:317:13:317:26 | ...::args | semmle.label | ...::args |
 | main.rs:317:13:317:28 | ...::args(...) [element] | semmle.label | ...::args(...) [element] |
@@ -688,4 +423,3 @@ nodes
 | main.rs:323:27:323:27 | v | semmle.label | v |
 | main.rs:324:25:324:25 | v | semmle.label | v |
 subpaths
-| main.rs:157:54:157:54 | v | main.rs:71:35:71:38 | ...: T | main.rs:77:9:77:16 | return v | main.rs:157:48:157:63 | clamp(...) |

--- a/rust/ql/test/query-tests/security/CWE-770/UncontrolledAllocationSize.qlref
+++ b/rust/ql/test/query-tests/security/CWE-770/UncontrolledAllocationSize.qlref
@@ -1,0 +1,4 @@
+query: queries/security/CWE-770/UncontrolledAllocationSize.ql
+postprocess:
+ - utils/test/InlineExpectationsTestQuery.ql
+ - utils/test/PrettyPrintModels.ql

--- a/rust/ql/test/query-tests/security/CWE-770/main.rs
+++ b/rust/ql/test/query-tests/security/CWE-770/main.rs
@@ -1,0 +1,223 @@
+#![feature(alloc_layout_extra)]
+#![feature(allocator_api)]
+#![feature(try_with_capacity)]
+#![feature(box_vec_non_null)]
+#![feature(non_null_from_ref)]
+
+struct MyStruct {
+    _a: usize,
+    _b: i64,
+}
+
+unsafe fn test_std_alloc_from_size(v: usize) {
+    let l1 = std::alloc::Layout::from_size_align(16, 1).unwrap();
+    let m1 = std::alloc::alloc(l1);
+    let _ = std::alloc::alloc(l1.align_to(8).unwrap());
+    let _ = std::alloc::alloc(l1.align_to(8).unwrap().pad_to_align());
+    let _ = std::alloc::alloc_zeroed(l1);
+    let _ = std::alloc::realloc(m1, l1, v); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+
+    let l2 = std::alloc::Layout::from_size_align(v, 1).unwrap();
+    let _ = std::alloc::alloc(l2); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+    let _ = std::alloc::alloc(l2.align_to(8).unwrap()); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+    let _ = std::alloc::alloc(l2.align_to(8).unwrap().pad_to_align()); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+    let _ = std::alloc::alloc_zeroed(l2); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+
+    let l3 = std::alloc::Layout::from_size_align(1, v).unwrap(); // not obviously dangerous?
+    let _ = std::alloc::alloc(l3);
+
+    let l4 = std::alloc::Layout::from_size_align_unchecked(v, 1);
+    let _ = std::alloc::alloc(l4); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+
+    let l5 = std::alloc::Layout::from_size_align_unchecked(v * std::mem::size_of::<i64>(), std::mem::size_of::<i64>());
+    let _ = std::alloc::alloc(l5); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+
+    let s6 = (std::mem::size_of::<MyStruct>() * v) + 1;
+    let l6 = std::alloc::Layout::from_size_align_unchecked(s6, 4);
+    let _ = std::alloc::alloc(l6); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+
+    let l7 = std::alloc::Layout::from_size_align_unchecked(l6.size(), 8);
+    let _ = std::alloc::alloc(l7); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+}
+
+unsafe fn test_std_alloc_new_repeat_extend(v: usize) {
+    let l1 = std::alloc::Layout::new::<[u8; 10]>();
+    let _ = std::alloc::alloc(l1);
+
+    let l2 = std::alloc::Layout::new::<MyStruct>();
+    let _ = std::alloc::alloc(l2);
+    let _ = std::alloc::alloc(l2.repeat(10).unwrap().0);
+    let _ = std::alloc::alloc(l2.repeat(v).unwrap().0); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+    let _ = std::alloc::alloc(l2.repeat(v + 1).unwrap().0); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+    let _ = std::alloc::alloc(l2.repeat_packed(10).unwrap());
+    let _ = std::alloc::alloc(l2.repeat_packed(v).unwrap()); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+    let _ = std::alloc::alloc(l2.repeat_packed(v * 10).unwrap()); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+
+    let l3 = std::alloc::Layout::array::<u8>(10).unwrap();
+    let _ = std::alloc::alloc(l3);
+    let (k1, _offs1) = l3.repeat(v).expect("arithmetic overflow?");
+    let _ = std::alloc::alloc(k1); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+    let (k2, _offs2) = l3.extend(k1).unwrap();
+    let _ = std::alloc::alloc(k2); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+    let (k3, _offs3) = k1.extend(l3).unwrap();
+    let _ = std::alloc::alloc(k3); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+    let _ = std::alloc::alloc(l3.extend_packed(k1).unwrap()); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+    let _ = std::alloc::alloc(k1.extend_packed(l3).unwrap()); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+
+    let l4 = std::alloc::Layout::array::<u8>(v).unwrap();
+    let _ = std::alloc::alloc(l4); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+}
+
+fn clamp<T: std::cmp::PartialOrd>(v: T, min: T, max: T) -> T {
+    if v < min {
+        return min;
+    } else if v > max {
+        return max;
+    } else {
+        return v;
+    }
+}
+
+unsafe fn test_std_alloc_with_bounds(v: usize) {
+    let l1 = std::alloc::Layout::array::<u32>(v).unwrap();
+
+    if v < 100 {
+        let _ = std::alloc::alloc(l1);
+    } else {
+        let _ = std::alloc::alloc(l1); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+    }
+
+    if v == 100 {
+        let _ = std::alloc::alloc(l1);
+    } else {
+        let _ = std::alloc::alloc(l1); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+    }
+
+    {
+        let mut v_mut = v;
+
+        if v_mut > 100 {
+            v_mut = 100;
+        }
+
+        let l2 = std::alloc::Layout::array::<u32>(v_mut).unwrap();
+        let _ = std::alloc::alloc(l2);
+
+        let l3 = std::alloc::Layout::array::<u32>(v).unwrap();
+        let _ = std::alloc::alloc(l3); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+    }
+
+    let l4 = std::alloc::Layout::array::<u32>(std::cmp::min(v, 100)).unwrap();
+    let _ = std::alloc::alloc(l4);
+
+    let l5 = std::alloc::Layout::array::<u32>(std::cmp::max(v, 100)).unwrap();
+    let _ = std::alloc::alloc(l5); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+
+    let l6 = std::alloc::Layout::array::<u32>(clamp(v, 1, 100)).unwrap();
+    let _ = std::alloc::alloc(l6);
+
+    let _ = std::alloc::alloc(l1); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+    if v > 100 {
+        return;
+    }
+    let _ = std::alloc::alloc(l1);
+}
+
+use std::alloc::{GlobalAlloc, Allocator};
+
+unsafe fn test_system_alloc(v: usize) {
+    let l1 = std::alloc::Layout::array::<u8>(10).unwrap();
+    let _ = std::alloc::System.alloc(l1);
+    let _ = std::alloc::System.alloc_zeroed(l1);
+    let _ = std::alloc::System.allocate(l1).unwrap();
+    let _ = std::alloc::System.allocate_zeroed(l1).unwrap();
+    let _ = std::alloc::Global.allocate(l1).unwrap();
+    let _ = std::alloc::Global.allocate_zeroed(l1).unwrap();
+
+    let l2 = std::alloc::Layout::array::<u8>(v).unwrap();
+    let _ = std::alloc::System.alloc(l2); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+    let _ = std::alloc::System.alloc_zeroed(l2); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+    let _ = std::alloc::System.allocate(l2).unwrap(); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+    let _ = std::alloc::System.allocate_zeroed(l2).unwrap(); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+    let _ = std::alloc::Global.allocate(l2).unwrap(); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+    let _ = std::alloc::Global.allocate_zeroed(l2).unwrap(); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+
+    let l3 = std::alloc::Layout::array::<u8>(10).unwrap();
+    let m3 = std::alloc::System.alloc(l3);
+    let _ = std::alloc::System.realloc(m3, l3, v); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+
+    let l4 = std::alloc::Layout::array::<u8>(10).unwrap();
+    let m4 = std::ptr::NonNull::<u8>::new(std::alloc::alloc(l4)).unwrap();
+    if v > 10 {
+        if v % 2 == 0 {
+            let _ = std::alloc::System.grow(m4, l4, l2).unwrap(); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+        } else {
+            let _ = std::alloc::System.grow_zeroed(m4, l4, l2).unwrap(); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+        }
+    } else {
+        let _ = std::alloc::System.shrink(m4, l4, l2).unwrap();
+    }
+}
+
+unsafe fn test_libc_alloc(v: usize) {
+    let m1 = libc::malloc(256);
+    let _ = libc::malloc(v); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+    let _ = libc::aligned_alloc(8, v); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+    let _ = libc::aligned_alloc(v, 8);
+    let _ = libc::calloc(64, v); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+    let _ = libc::calloc(v, std::mem::size_of::<i64>()); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+    let _ = libc::realloc(m1, v); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+}
+
+unsafe fn test_vectors(v: usize) {
+    let _ = Vec::<u64>::try_with_capacity(v).unwrap(); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+    let _ = Vec::<u64>::with_capacity(v); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+    let _ = Vec::<u64>::try_with_capacity_in(v, std::alloc::Global).unwrap(); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+    let _ = Vec::<u64>::with_capacity_in(v, std::alloc::Global); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+
+    let mut v1 = Vec::<u64>::with_capacity(100);
+    v1.reserve(v); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+    v1.reserve_exact(v); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+    let _ = v1.try_reserve(v).unwrap(); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+    let _ = v1.try_reserve_exact(v).unwrap(); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+    v1.resize(v, 1); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+    v1.set_len(v); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+
+    let l2 = std::alloc::Layout::new::<[u64; 200]>();
+    let m2 = std::ptr::NonNull::<u64>::new(std::alloc::alloc(l2).cast::<u64>()).unwrap();
+    let _ = Vec::<u64>::from_parts(m2, v, 200); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+
+    let m3 = std::ptr::NonNull::<u64>::new(std::alloc::alloc(l2).cast::<u64>()).unwrap();
+    let _ = Vec::<u64>::from_parts(m3, 100, v); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+
+    let m4 = std::ptr::NonNull::<u64>::new(std::alloc::alloc(l2).cast::<u64>()).unwrap();
+    let _ = Vec::<u64>::from_parts_in(m4, 100, v, std::alloc::Global); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+
+    let m5 = std::alloc::alloc(l2).cast::<u64>();
+    let _ = Vec::<u64>::from_raw_parts(m5, v, 200); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+
+    let m6 = std::alloc::alloc(l2).cast::<u64>();
+    let _ = Vec::<u64>::from_raw_parts(m6, 100, v); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+
+    let m7 = std::alloc::alloc(l2).cast::<u64>();
+    let _ = Vec::<u64>::from_raw_parts_in(m7, 100, v, std::alloc::Global); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+}
+
+// --- main ---
+
+fn main() {
+    println!("--- begin ---");
+
+    let v = std::env::args().nth(1).unwrap_or("1024".to_string()).parse::<usize>().unwrap(); // $ Source=arg1
+
+    unsafe {
+        test_std_alloc_from_size(v);
+        test_std_alloc_new_repeat_extend(v);
+        test_std_alloc_with_bounds(v);
+        test_system_alloc(v);
+        test_libc_alloc(v);
+        test_vectors(v);
+    }
+
+    println!("--- end ---");
+}

--- a/rust/ql/test/query-tests/security/CWE-770/main.rs
+++ b/rust/ql/test/query-tests/security/CWE-770/main.rs
@@ -78,13 +78,31 @@ fn clamp<T: std::cmp::PartialOrd>(v: T, min: T, max: T) -> T {
     }
 }
 
-unsafe fn test_std_alloc_with_bounds(v: usize) {
+unsafe fn test_fn_alloc_bounded(v: usize) {
+    let layout = std::alloc::Layout::from_size_align(v, 1).unwrap();
+    let _ = std::alloc::alloc(layout); // $ SPURIOUS: Alert[rust/uncontrolled-allocation-size]=arg1
+}
+
+unsafe fn test_fn_alloc_unbounded(v: usize) {
+    let layout = std::alloc::Layout::from_size_align(v, 1).unwrap();
+    let _ = std::alloc::alloc(layout); // $ Alert[rust/uncontrolled-allocation-size]=arg1
+}
+
+unsafe fn test_std_alloc_with_bounds(v: usize, limit: usize) {
     let l1 = std::alloc::Layout::array::<u32>(v).unwrap();
 
     if v < 100 {
+        let l2 = std::alloc::Layout::array::<u32>(v).unwrap();
         let _ = std::alloc::alloc(l1); // $ SPURIOUS: Alert[rust/uncontrolled-allocation-size]=arg1
+        let _ = std::alloc::alloc(l2); // $ SPURIOUS: Alert[rust/uncontrolled-allocation-size]=arg1
+
+        test_fn_alloc_bounded(v);
     } else {
+        let l3 = std::alloc::Layout::array::<u32>(v).unwrap();
         let _ = std::alloc::alloc(l1); // $ Alert[rust/uncontrolled-allocation-size]=arg1
+        let _ = std::alloc::alloc(l3); // $ Alert[rust/uncontrolled-allocation-size]=arg1
+
+        test_fn_alloc_unbounded(v);
     }
 
     if v == 100 {
@@ -93,6 +111,29 @@ unsafe fn test_std_alloc_with_bounds(v: usize) {
         let _ = std::alloc::alloc(l1); // $ Alert[rust/uncontrolled-allocation-size]=arg1
     }
 
+    if (v < limit) {
+        let l4 = std::alloc::Layout::from_size_align(v, 1).unwrap();
+        let _ = std::alloc::alloc(l4); // $ SPURIOUS: Alert[rust/uncontrolled-allocation-size]=arg1
+    }
+
+    if (v < 2 * v) { // not a good bound
+        let l5 = std::alloc::Layout::from_size_align(v, 1).unwrap();
+        let _ = std::alloc::alloc(l5); // $ Alert[rust/uncontrolled-allocation-size]=arg1
+    }
+
+    if (true && v < limit && true) {
+        let l6 = std::alloc::Layout::from_size_align(v, 1).unwrap();
+        let _ = std::alloc::alloc(l6); // $ SPURIOUS: Alert[rust/uncontrolled-allocation-size]=arg1
+    }
+
+    let mut l7;
+    if (v < 100) {
+        l7 = std::alloc::Layout::from_size_align(v, 1).unwrap();
+    } else {
+        l7 = std::alloc::Layout::from_size_align(100, 1).unwrap();
+    }
+    let _ = std::alloc::alloc(l7); // $ SPURIOUS: Alert[rust/uncontrolled-allocation-size]=arg1
+
     {
         let mut v_mut = v;
 
@@ -100,27 +141,41 @@ unsafe fn test_std_alloc_with_bounds(v: usize) {
             v_mut = 100;
         }
 
-        let l2 = std::alloc::Layout::array::<u32>(v_mut).unwrap();
-        let _ = std::alloc::alloc(l2); // $ SPURIOUS: Alert[rust/uncontrolled-allocation-size]=arg1
-
-        let l3 = std::alloc::Layout::array::<u32>(v).unwrap();
-        let _ = std::alloc::alloc(l3); // $ Alert[rust/uncontrolled-allocation-size]=arg1
+        let l8 = std::alloc::Layout::array::<u32>(v_mut).unwrap();
+        let l9 = std::alloc::Layout::array::<u32>(v).unwrap();
+        let _ = std::alloc::alloc(l1); // $ Alert[rust/uncontrolled-allocation-size]=arg1
+        let _ = std::alloc::alloc(l8); // $ SPURIOUS: Alert[rust/uncontrolled-allocation-size]=arg1
+        let _ = std::alloc::alloc(l9); // $ Alert[rust/uncontrolled-allocation-size]=arg1
     }
 
-    let l4 = std::alloc::Layout::array::<u32>(std::cmp::min(v, 100)).unwrap();
-    let _ = std::alloc::alloc(l4); // $ SPURIOUS: Alert[rust/uncontrolled-allocation-size]=arg1
+    let l10 = std::alloc::Layout::array::<u32>(std::cmp::min(v, 100)).unwrap();
+    let _ = std::alloc::alloc(l10); // $ SPURIOUS: Alert[rust/uncontrolled-allocation-size]=arg1
 
-    let l5 = std::alloc::Layout::array::<u32>(std::cmp::max(v, 100)).unwrap();
-    let _ = std::alloc::alloc(l5); // $ Alert[rust/uncontrolled-allocation-size]=arg1
+    let l11 = std::alloc::Layout::array::<u32>(std::cmp::max(v, 100)).unwrap();
+    let _ = std::alloc::alloc(l11); // $ Alert[rust/uncontrolled-allocation-size]=arg1
 
-    let l6 = std::alloc::Layout::array::<u32>(clamp(v, 1, 100)).unwrap();
-    let _ = std::alloc::alloc(l6); // $ SPURIOUS: Alert[rust/uncontrolled-allocation-size]=arg1
+    let l12 = std::alloc::Layout::array::<u32>(clamp(v, 1, 100)).unwrap();
+    let _ = std::alloc::alloc(l12); // $ SPURIOUS: Alert[rust/uncontrolled-allocation-size]=arg1
 
-    let _ = std::alloc::alloc(l1); // $ Alert[rust/uncontrolled-allocation-size]=arg1
+    for i in 0..10 {
+        let l13 = std::alloc::Layout::from_size_align(v, 1).unwrap();
+        let _ = std::alloc::alloc(l13); // $ Alert[rust/uncontrolled-allocation-size]=arg1
+
+        if (v > 1000) {
+            continue;
+        }
+
+        let l14 = std::alloc::Layout::from_size_align(v, 1).unwrap();
+        let _ = std::alloc::alloc(l13); // $ SPURIOUS: Alert[rust/uncontrolled-allocation-size]=arg1
+        let _ = std::alloc::alloc(l14); // $ SPURIOUS: Alert[rust/uncontrolled-allocation-size]=arg1
+    }
+
     if v > 100 {
         return;
     }
+    let l15 = std::alloc::Layout::from_size_align(v, 1).unwrap();
     let _ = std::alloc::alloc(l1); // $ SPURIOUS: Alert[rust/uncontrolled-allocation-size]=arg1
+    let _ = std::alloc::alloc(l15); // $ SPURIOUS: Alert[rust/uncontrolled-allocation-size]=arg1
 }
 
 use std::alloc::{GlobalAlloc, Allocator};
@@ -264,7 +319,7 @@ fn main() {
     unsafe {
         test_std_alloc_from_size(v);
         test_std_alloc_new_repeat_extend(v);
-        test_std_alloc_with_bounds(v);
+        test_std_alloc_with_bounds(v, 1000);
         test_system_alloc(v);
         test_libc_alloc(v);
         test_vectors(v);

--- a/rust/ql/test/query-tests/security/CWE-770/main.rs
+++ b/rust/ql/test/query-tests/security/CWE-770/main.rs
@@ -85,7 +85,7 @@ unsafe fn test_fn_alloc_bounded(v: usize) {
 
 unsafe fn test_fn_alloc_unbounded(v: usize) {
     let layout = std::alloc::Layout::from_size_align(v, 1).unwrap();
-    let _ = std::alloc::alloc(layout); // $ MISSING: Alert[rust/uncontrolled-allocation-size]=arg1
+    let _ = std::alloc::alloc(layout); // $ Alert[rust/uncontrolled-allocation-size]=arg1
 }
 
 unsafe fn test_std_alloc_with_bounds(v: usize, limit: usize) {
@@ -100,7 +100,7 @@ unsafe fn test_std_alloc_with_bounds(v: usize, limit: usize) {
     } else {
         let l3 = std::alloc::Layout::array::<u32>(v).unwrap();
         let _ = std::alloc::alloc(l1); // $ Alert[rust/uncontrolled-allocation-size]=arg1
-        let _ = std::alloc::alloc(l3); // $ MISSING: Alert[rust/uncontrolled-allocation-size]=arg1
+        let _ = std::alloc::alloc(l3); // $ Alert[rust/uncontrolled-allocation-size]=arg1
 
         test_fn_alloc_unbounded(v);
     }
@@ -145,28 +145,28 @@ unsafe fn test_std_alloc_with_bounds(v: usize, limit: usize) {
         let l9 = std::alloc::Layout::array::<u32>(v).unwrap();
         let _ = std::alloc::alloc(l1); // $ Alert[rust/uncontrolled-allocation-size]=arg1
         let _ = std::alloc::alloc(l8); // $ GOOD (bounded)
-        let _ = std::alloc::alloc(l9); // $ MISSING: Alert[rust/uncontrolled-allocation-size]=arg1
+        let _ = std::alloc::alloc(l9); // $ Alert[rust/uncontrolled-allocation-size]=arg1
     }
 
     let l10 = std::alloc::Layout::array::<u32>(std::cmp::min(v, 100)).unwrap();
-    let _ = std::alloc::alloc(l10); // $ GOOD (bounded)
+    let _ = std::alloc::alloc(l10); // $ SPURIOUS: Alert[rust/uncontrolled-allocation-size]=arg1
 
     let l11 = std::alloc::Layout::array::<u32>(std::cmp::max(v, 100)).unwrap();
-    let _ = std::alloc::alloc(l11); // $ MISSING: Alert[rust/uncontrolled-allocation-size]=arg1
+    let _ = std::alloc::alloc(l11); // $ Alert[rust/uncontrolled-allocation-size]=arg1
 
     let l12 = std::alloc::Layout::array::<u32>(clamp(v, 1, 100)).unwrap();
     let _ = std::alloc::alloc(l12); // $ GOOD (bounded)
 
     for i in 0..10 {
         let l13 = std::alloc::Layout::from_size_align(v, 1).unwrap();
-        let _ = std::alloc::alloc(l13); // $ MISSING: Alert[rust/uncontrolled-allocation-size]=arg1
+        let _ = std::alloc::alloc(l13); // $ Alert[rust/uncontrolled-allocation-size]=arg1
 
         if (v > 1000) {
             continue;
         }
 
         let l14 = std::alloc::Layout::from_size_align(v, 1).unwrap();
-        let _ = std::alloc::alloc(l13); // $ GOOD (bounded)
+        let _ = std::alloc::alloc(l13); // $ SPURIOUS: Alert[rust/uncontrolled-allocation-size]=arg1
         let _ = std::alloc::alloc(l14); // $ GOOD (bounded)
     }
 

--- a/rust/ql/test/query-tests/security/CWE-770/main.rs
+++ b/rust/ql/test/query-tests/security/CWE-770/main.rs
@@ -19,8 +19,8 @@ unsafe fn test_std_alloc_from_size(v: usize) {
 
     let l2 = std::alloc::Layout::from_size_align(v, 1).unwrap();
     let _ = std::alloc::alloc(l2); // $ Alert[rust/uncontrolled-allocation-size]=arg1
-    let _ = std::alloc::alloc(l2.align_to(8).unwrap()); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
-    let _ = std::alloc::alloc(l2.align_to(8).unwrap().pad_to_align()); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+    let _ = std::alloc::alloc(l2.align_to(8).unwrap()); // $ Alert[rust/uncontrolled-allocation-size]=arg1
+    let _ = std::alloc::alloc(l2.align_to(8).unwrap().pad_to_align()); // $ Alert[rust/uncontrolled-allocation-size]=arg1
     let _ = std::alloc::alloc_zeroed(l2); // $ Alert[rust/uncontrolled-allocation-size]=arg1
 
     let l3 = std::alloc::Layout::from_size_align(1, v).unwrap(); // not obviously dangerous?
@@ -37,7 +37,7 @@ unsafe fn test_std_alloc_from_size(v: usize) {
     let _ = std::alloc::alloc(l6); // $ Alert[rust/uncontrolled-allocation-size]=arg1
 
     let l7 = std::alloc::Layout::from_size_align_unchecked(l6.size(), 8);
-    let _ = std::alloc::alloc(l7); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+    let _ = std::alloc::alloc(l7); // $ Alert[rust/uncontrolled-allocation-size]=arg1
 }
 
 unsafe fn test_std_alloc_new_repeat_extend(v: usize) {

--- a/rust/ql/test/query-tests/security/CWE-770/main.rs
+++ b/rust/ql/test/query-tests/security/CWE-770/main.rs
@@ -15,26 +15,26 @@ unsafe fn test_std_alloc_from_size(v: usize) {
     let _ = std::alloc::alloc(l1.align_to(8).unwrap());
     let _ = std::alloc::alloc(l1.align_to(8).unwrap().pad_to_align());
     let _ = std::alloc::alloc_zeroed(l1);
-    let _ = std::alloc::realloc(m1, l1, v); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+    let _ = std::alloc::realloc(m1, l1, v); // $ Alert[rust/uncontrolled-allocation-size]=arg1
 
     let l2 = std::alloc::Layout::from_size_align(v, 1).unwrap();
-    let _ = std::alloc::alloc(l2); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+    let _ = std::alloc::alloc(l2); // $ Alert[rust/uncontrolled-allocation-size]=arg1
     let _ = std::alloc::alloc(l2.align_to(8).unwrap()); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
     let _ = std::alloc::alloc(l2.align_to(8).unwrap().pad_to_align()); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
-    let _ = std::alloc::alloc_zeroed(l2); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+    let _ = std::alloc::alloc_zeroed(l2); // $ Alert[rust/uncontrolled-allocation-size]=arg1
 
     let l3 = std::alloc::Layout::from_size_align(1, v).unwrap(); // not obviously dangerous?
     let _ = std::alloc::alloc(l3);
 
     let l4 = std::alloc::Layout::from_size_align_unchecked(v, 1);
-    let _ = std::alloc::alloc(l4); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+    let _ = std::alloc::alloc(l4); // $ Alert[rust/uncontrolled-allocation-size]=arg1
 
     let l5 = std::alloc::Layout::from_size_align_unchecked(v * std::mem::size_of::<i64>(), std::mem::size_of::<i64>());
-    let _ = std::alloc::alloc(l5); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+    let _ = std::alloc::alloc(l5); // $ Alert[rust/uncontrolled-allocation-size]=arg1
 
     let s6 = (std::mem::size_of::<MyStruct>() * v) + 1;
     let l6 = std::alloc::Layout::from_size_align_unchecked(s6, 4);
-    let _ = std::alloc::alloc(l6); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+    let _ = std::alloc::alloc(l6); // $ Alert[rust/uncontrolled-allocation-size]=arg1
 
     let l7 = std::alloc::Layout::from_size_align_unchecked(l6.size(), 8);
     let _ = std::alloc::alloc(l7); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
@@ -47,25 +47,25 @@ unsafe fn test_std_alloc_new_repeat_extend(v: usize) {
     let l2 = std::alloc::Layout::new::<MyStruct>();
     let _ = std::alloc::alloc(l2);
     let _ = std::alloc::alloc(l2.repeat(10).unwrap().0);
-    let _ = std::alloc::alloc(l2.repeat(v).unwrap().0); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
-    let _ = std::alloc::alloc(l2.repeat(v + 1).unwrap().0); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+    let _ = std::alloc::alloc(l2.repeat(v).unwrap().0); // $ Alert[rust/uncontrolled-allocation-size]=arg1
+    let _ = std::alloc::alloc(l2.repeat(v + 1).unwrap().0); // $ Alert[rust/uncontrolled-allocation-size]=arg1
     let _ = std::alloc::alloc(l2.repeat_packed(10).unwrap());
-    let _ = std::alloc::alloc(l2.repeat_packed(v).unwrap()); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
-    let _ = std::alloc::alloc(l2.repeat_packed(v * 10).unwrap()); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+    let _ = std::alloc::alloc(l2.repeat_packed(v).unwrap()); // $ Alert[rust/uncontrolled-allocation-size]=arg1
+    let _ = std::alloc::alloc(l2.repeat_packed(v * 10).unwrap()); // $ Alert[rust/uncontrolled-allocation-size]=arg1
 
     let l3 = std::alloc::Layout::array::<u8>(10).unwrap();
     let _ = std::alloc::alloc(l3);
     let (k1, _offs1) = l3.repeat(v).expect("arithmetic overflow?");
-    let _ = std::alloc::alloc(k1); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+    let _ = std::alloc::alloc(k1); // $ Alert[rust/uncontrolled-allocation-size]=arg1
     let (k2, _offs2) = l3.extend(k1).unwrap();
-    let _ = std::alloc::alloc(k2); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+    let _ = std::alloc::alloc(k2); // $ Alert[rust/uncontrolled-allocation-size]=arg1
     let (k3, _offs3) = k1.extend(l3).unwrap();
-    let _ = std::alloc::alloc(k3); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
-    let _ = std::alloc::alloc(l3.extend_packed(k1).unwrap()); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
-    let _ = std::alloc::alloc(k1.extend_packed(l3).unwrap()); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+    let _ = std::alloc::alloc(k3); // $ Alert[rust/uncontrolled-allocation-size]=arg1
+    let _ = std::alloc::alloc(l3.extend_packed(k1).unwrap()); // $ Alert[rust/uncontrolled-allocation-size]=arg1
+    let _ = std::alloc::alloc(k1.extend_packed(l3).unwrap()); // $ Alert[rust/uncontrolled-allocation-size]=arg1
 
     let l4 = std::alloc::Layout::array::<u8>(v).unwrap();
-    let _ = std::alloc::alloc(l4); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+    let _ = std::alloc::alloc(l4); // $ Alert[rust/uncontrolled-allocation-size]=arg1
 }
 
 fn clamp<T: std::cmp::PartialOrd>(v: T, min: T, max: T) -> T {
@@ -82,15 +82,15 @@ unsafe fn test_std_alloc_with_bounds(v: usize) {
     let l1 = std::alloc::Layout::array::<u32>(v).unwrap();
 
     if v < 100 {
-        let _ = std::alloc::alloc(l1);
+        let _ = std::alloc::alloc(l1); // $ SPURIOUS: Alert[rust/uncontrolled-allocation-size]=arg1
     } else {
-        let _ = std::alloc::alloc(l1); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+        let _ = std::alloc::alloc(l1); // $ Alert[rust/uncontrolled-allocation-size]=arg1
     }
 
     if v == 100 {
-        let _ = std::alloc::alloc(l1);
+        let _ = std::alloc::alloc(l1); // $ SPURIOUS: Alert[rust/uncontrolled-allocation-size]=arg1
     } else {
-        let _ = std::alloc::alloc(l1); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+        let _ = std::alloc::alloc(l1); // $ Alert[rust/uncontrolled-allocation-size]=arg1
     }
 
     {
@@ -101,26 +101,26 @@ unsafe fn test_std_alloc_with_bounds(v: usize) {
         }
 
         let l2 = std::alloc::Layout::array::<u32>(v_mut).unwrap();
-        let _ = std::alloc::alloc(l2);
+        let _ = std::alloc::alloc(l2); // $ SPURIOUS: Alert[rust/uncontrolled-allocation-size]=arg1
 
         let l3 = std::alloc::Layout::array::<u32>(v).unwrap();
-        let _ = std::alloc::alloc(l3); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+        let _ = std::alloc::alloc(l3); // $ Alert[rust/uncontrolled-allocation-size]=arg1
     }
 
     let l4 = std::alloc::Layout::array::<u32>(std::cmp::min(v, 100)).unwrap();
-    let _ = std::alloc::alloc(l4);
+    let _ = std::alloc::alloc(l4); // $ SPURIOUS: Alert[rust/uncontrolled-allocation-size]=arg1
 
     let l5 = std::alloc::Layout::array::<u32>(std::cmp::max(v, 100)).unwrap();
-    let _ = std::alloc::alloc(l5); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+    let _ = std::alloc::alloc(l5); // $ Alert[rust/uncontrolled-allocation-size]=arg1
 
     let l6 = std::alloc::Layout::array::<u32>(clamp(v, 1, 100)).unwrap();
-    let _ = std::alloc::alloc(l6);
+    let _ = std::alloc::alloc(l6); // $ SPURIOUS: Alert[rust/uncontrolled-allocation-size]=arg1
 
-    let _ = std::alloc::alloc(l1); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+    let _ = std::alloc::alloc(l1); // $ Alert[rust/uncontrolled-allocation-size]=arg1
     if v > 100 {
         return;
     }
-    let _ = std::alloc::alloc(l1);
+    let _ = std::alloc::alloc(l1); // $ SPURIOUS: Alert[rust/uncontrolled-allocation-size]=arg1
 }
 
 use std::alloc::{GlobalAlloc, Allocator};
@@ -135,12 +135,12 @@ unsafe fn test_system_alloc(v: usize) {
     let _ = std::alloc::Global.allocate_zeroed(l1).unwrap();
 
     let l2 = std::alloc::Layout::array::<u8>(v).unwrap();
-    let _ = std::alloc::System.alloc(l2); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
-    let _ = std::alloc::System.alloc_zeroed(l2); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
-    let _ = std::alloc::System.allocate(l2).unwrap(); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
-    let _ = std::alloc::System.allocate_zeroed(l2).unwrap(); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
-    let _ = std::alloc::Global.allocate(l2).unwrap(); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
-    let _ = std::alloc::Global.allocate_zeroed(l2).unwrap(); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+    let _ = std::alloc::System.alloc(l2); // $ Alert[rust/uncontrolled-allocation-size]=arg1
+    let _ = std::alloc::System.alloc_zeroed(l2); // $ Alert[rust/uncontrolled-allocation-size]=arg1
+    let _ = std::alloc::System.allocate(l2).unwrap(); // $ Alert[rust/uncontrolled-allocation-size]=arg1
+    let _ = std::alloc::System.allocate_zeroed(l2).unwrap(); // $ Alert[rust/uncontrolled-allocation-size]=arg1
+    let _ = std::alloc::Global.allocate(l2).unwrap(); // $ Alert[rust/uncontrolled-allocation-size]=arg1
+    let _ = std::alloc::Global.allocate_zeroed(l2).unwrap(); // $ Alert[rust/uncontrolled-allocation-size]=arg1
 
     let l3 = std::alloc::Layout::array::<u8>(10).unwrap();
     let m3 = std::alloc::System.alloc(l3);
@@ -150,9 +150,9 @@ unsafe fn test_system_alloc(v: usize) {
     let m4 = std::ptr::NonNull::<u8>::new(std::alloc::alloc(l4)).unwrap();
     if v > 10 {
         if v % 2 == 0 {
-            let _ = std::alloc::System.grow(m4, l4, l2).unwrap(); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+            let _ = std::alloc::System.grow(m4, l4, l2).unwrap(); // $ Alert[rust/uncontrolled-allocation-size]=arg1
         } else {
-            let _ = std::alloc::System.grow_zeroed(m4, l4, l2).unwrap(); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+            let _ = std::alloc::System.grow_zeroed(m4, l4, l2).unwrap(); // $ Alert[rust/uncontrolled-allocation-size]=arg1
         }
     } else {
         let _ = std::alloc::System.shrink(m4, l4, l2).unwrap();
@@ -161,12 +161,12 @@ unsafe fn test_system_alloc(v: usize) {
 
 unsafe fn test_libc_alloc(v: usize) {
     let m1 = libc::malloc(256);
-    let _ = libc::malloc(v); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
-    let _ = libc::aligned_alloc(8, v); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+    let _ = libc::malloc(v); // $ Alert[rust/uncontrolled-allocation-size]=arg1
+    let _ = libc::aligned_alloc(8, v); // $ Alert[rust/uncontrolled-allocation-size]=arg1
     let _ = libc::aligned_alloc(v, 8);
-    let _ = libc::calloc(64, v); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
-    let _ = libc::calloc(v, std::mem::size_of::<i64>()); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
-    let _ = libc::realloc(m1, v); // $ MISSING: Alert[rust/uncontrolled-allocation-size]
+    let _ = libc::calloc(64, v); // $ Alert[rust/uncontrolled-allocation-size]=arg1
+    let _ = libc::calloc(v, std::mem::size_of::<i64>()); // $ Alert[rust/uncontrolled-allocation-size]=arg1
+    let _ = libc::realloc(m1, v); // $ Alert[rust/uncontrolled-allocation-size]=arg1
 }
 
 unsafe fn test_vectors(v: usize) {

--- a/rust/ql/test/query-tests/security/CWE-770/options.yml
+++ b/rust/ql/test/query-tests/security/CWE-770/options.yml
@@ -1,0 +1,3 @@
+qltest_cargo_check: true
+qltest_dependencies:
+    - libc = { version = "0.2.11" }

--- a/rust/ql/test/query-tests/security/CWE-770/rust-toolchain.toml
+++ b/rust/ql/test/query-tests/security/CWE-770/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly-2025-03-17"


### PR DESCRIPTION
New query `rust/uncontrolled-allocation-size` for uncontrolled allocations, that is, where user input is allowed to control the size of a memory allocation with no guard.

Note that there's a related issue when a size calculation can overflow, possibly leading to an under-allocation and consequent buffer overrun.  The worst (but not uncommon) case is when these two issues coincide, giving an attacker the ability to control the buffer overrun.  We probably want another query for overflowing arithmetic at some point to get good overall coverage.

TODO:
- [ ] code review
- [ ] docs review
- [ ] DCA run