### PR TITLE
Swift: Update SSA to reference the new use-use predicates.

### DIFF
--- a/swift/ql/lib/codeql/swift/dataflow/Ssa.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/Ssa.qll
@@ -151,10 +151,9 @@ module Ssa {
 
     cached
     ControlFlowNode getAFirstRead() {
-      exists(SsaInput::BasicBlock bb1, int i1, SsaInput::BasicBlock bb2, int i2 |
-        this.definesAt(_, bb1, i1) and
-        SsaImpl::adjacentDefRead(this, bb1, i1, bb2, i2) and
-        result = bb2.getNode(i2)
+      exists(SsaInput::BasicBlock bb, int i |
+        SsaImpl::firstUse(this, bb, i, true) and
+        result = bb.getNode(i)
       )
     }
 
@@ -162,14 +161,13 @@ module Ssa {
     predicate adjacentReadPair(ControlFlowNode read1, ControlFlowNode read2) {
       exists(SsaInput::BasicBlock bb1, int i1, SsaInput::BasicBlock bb2, int i2 |
         read1 = bb1.getNode(i1) and
-        SsaInput::variableRead(bb1, i1, _, true) and
-        SsaImpl::adjacentDefRead(this, bb1, i1, bb2, i2) and
+        SsaImpl::adjacentUseUse(bb1, i1, bb2, i2, _, true) and
         read2 = bb2.getNode(i2)
       )
     }
 
     cached
-    predicate lastRefRedef(SsaInput::BasicBlock bb, int i, Definition next) {
+    deprecated predicate lastRefRedef(SsaInput::BasicBlock bb, int i, Definition next) {
       SsaImpl::lastRefRedef(this, bb, i, next)
     }
   }

--- a/swift/ql/lib/codeql/swift/dataflow/Ssa.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/Ssa.qll
@@ -159,6 +159,7 @@ module Ssa {
 
     cached
     predicate adjacentReadPair(ControlFlowNode read1, ControlFlowNode read2) {
+      read1 = this.getARead() and
       exists(SsaInput::BasicBlock bb1, int i1, SsaInput::BasicBlock bb2, int i2 |
         read1 = bb1.getNode(i1) and
         SsaImpl::adjacentUseUse(bb1, i1, bb2, i2, _, true) and

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPrivate.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPrivate.qll
@@ -111,10 +111,8 @@ private class CaptureNodeImpl extends CaptureNode, NodeImpl {
 }
 
 private predicate localFlowSsaInput(Node nodeFrom, Ssa::Definition def, Ssa::Definition next) {
-  exists(BasicBlock bb, int i | def.lastRefRedef(bb, i, next) |
-    def.definesAt(_, bb, i) and
-    def = nodeFrom.asDefinition()
-  )
+  next.(Ssa::PhiDefinition).getAPhiInput() = def and
+  def = nodeFrom.asDefinition()
 }
 
 /** A collection of cached types and predicates to be evaluated in the same stage. */

--- a/swift/ql/test/library-tests/dataflow/dataflow/DataFlow.expected
+++ b/swift/ql/test/library-tests/dataflow/dataflow/DataFlow.expected
@@ -172,6 +172,7 @@ edges
 | test.swift:6:19:6:26 | call to source() | test.swift:7:15:7:15 | t1 | provenance |  |
 | test.swift:6:19:6:26 | call to source() | test.swift:9:15:9:15 | t1 | provenance |  |
 | test.swift:6:19:6:26 | call to source() | test.swift:10:15:10:15 | t2 | provenance |  |
+| test.swift:6:19:6:26 | call to source() | test.swift:15:15:15:15 | t2 | provenance |  |
 | test.swift:25:20:25:27 | call to source() | test.swift:29:18:29:21 | x | provenance |  |
 | test.swift:26:26:26:33 | call to source() | test.swift:29:26:29:29 | y | provenance |  |
 | test.swift:29:18:29:21 | x | test.swift:30:15:30:15 | x | provenance |  |
@@ -964,6 +965,7 @@ nodes
 | test.swift:7:15:7:15 | t1 | semmle.label | t1 |
 | test.swift:9:15:9:15 | t1 | semmle.label | t1 |
 | test.swift:10:15:10:15 | t2 | semmle.label | t2 |
+| test.swift:15:15:15:15 | t2 | semmle.label | t2 |
 | test.swift:25:20:25:27 | call to source() | semmle.label | call to source() |
 | test.swift:26:26:26:33 | call to source() | semmle.label | call to source() |
 | test.swift:29:18:29:21 | x | semmle.label | x |
@@ -1706,6 +1708,7 @@ subpaths
 | test.swift:7:15:7:15 | t1 | test.swift:6:19:6:26 | call to source() | test.swift:7:15:7:15 | t1 | result |
 | test.swift:9:15:9:15 | t1 | test.swift:6:19:6:26 | call to source() | test.swift:9:15:9:15 | t1 | result |
 | test.swift:10:15:10:15 | t2 | test.swift:6:19:6:26 | call to source() | test.swift:10:15:10:15 | t2 | result |
+| test.swift:15:15:15:15 | t2 | test.swift:6:19:6:26 | call to source() | test.swift:15:15:15:15 | t2 | result |
 | test.swift:30:15:30:15 | x | test.swift:25:20:25:27 | call to source() | test.swift:30:15:30:15 | x | result |
 | test.swift:31:15:31:15 | y | test.swift:26:26:26:33 | call to source() | test.swift:31:15:31:15 | y | result |
 | test.swift:39:15:39:29 | call to callee_source() | test.swift:35:12:35:19 | call to source() | test.swift:39:15:39:29 | call to callee_source() | result |

--- a/swift/ql/test/library-tests/dataflow/dataflow/LocalFlow.expected
+++ b/swift/ql/test/library-tests/dataflow/dataflow/LocalFlow.expected
@@ -250,11 +250,13 @@
 | test.swift:7:15:7:15 | [post] t1 | test.swift:8:10:8:10 | t1 |
 | test.swift:7:15:7:15 | t1 | test.swift:8:10:8:10 | t1 |
 | test.swift:8:5:8:10 | SSA def(t2) | test.swift:10:15:10:15 | t2 |
+| test.swift:8:5:8:10 | SSA def(t2) | test.swift:15:5:15:5 | SSA phi(t2) |
 | test.swift:8:10:8:10 | t1 | test.swift:8:5:8:10 | SSA def(t2) |
 | test.swift:8:10:8:10 | t1 | test.swift:9:15:9:15 | t1 |
 | test.swift:9:15:9:15 | [post] t1 | test.swift:11:8:11:8 | t1 |
 | test.swift:9:15:9:15 | t1 | test.swift:11:8:11:8 | t1 |
 | test.swift:12:9:12:14 | SSA def(t2) | test.swift:13:19:13:19 | t2 |
+| test.swift:12:9:12:14 | SSA def(t2) | test.swift:15:5:15:5 | SSA phi(t2) |
 | test.swift:12:14:12:14 | 0 | test.swift:12:9:12:14 | SSA def(t2) |
 | test.swift:15:5:15:5 | SSA phi(t2) | test.swift:15:15:15:15 | t2 |
 | test.swift:17:5:17:10 | SSA def(t1) | test.swift:21:15:21:15 | t1 |

--- a/swift/ql/test/library-tests/dataflow/dataflow/test.swift
+++ b/swift/ql/test/library-tests/dataflow/dataflow/test.swift
@@ -12,7 +12,7 @@ func intraprocedural_with_local_flow() -> Void {
         t2 = 0
         sink(arg: t2)
     }
-    sink(arg: t2) // $ MISSING: flow=6
+    sink(arg: t2) // $ flow=6
 
     t1 = 0;
     while(false) {


### PR DESCRIPTION
Something about the use-use steps in data flow looks buggy, but I'm not going to fix that here. This is just aiming for a one-for-one semantically equivalent switch to the new use-use predicates.