### PR TITLE
Rust: Fix `capturedCallRead`

### DIFF
--- a/rust/ql/lib/codeql/rust/dataflow/Ssa.qll
+++ b/rust/ql/lib/codeql/rust/dataflow/Ssa.qll
@@ -263,7 +263,7 @@ module Ssa {
         not exists(this.getSplitString()) and
         prefix = ""
       |
-        result = prefix + "phi"
+        result = prefix + SsaImpl::PhiDefinition.super.toString()
       )
     }
 

--- a/rust/ql/lib/codeql/rust/dataflow/internal/SsaImpl.qll
+++ b/rust/ql/lib/codeql/rust/dataflow/internal/SsaImpl.qll
@@ -189,7 +189,7 @@ private predicate capturedCallRead(Expr call, BasicBlock bb, int i, Variable v) 
     hasCapturedRead(pragma[only_bind_into](v), pragma[only_bind_into](scope)) and
     (
       variableWriteInOuterScope(bb, any(int j | j < i), v, scope) or
-      variableWriteInOuterScope(bb.getAPredecessor+(), _, v, scope)
+      variableWriteInOuterScope(bb.getImmediateDominator+(), _, v, scope)
     ) and
     call = bb.getNode(i).getAstNode()
   )

--- a/rust/ql/test/library-tests/variables/Ssa.expected
+++ b/rust/ql/test/library-tests/variables/Ssa.expected
@@ -38,45 +38,45 @@ definition
 | main.rs:173:17:173:27 | id_variable | main.rs:173:17:173:27 | id_variable |
 | main.rs:178:26:178:27 | id | main.rs:178:26:178:27 | id |
 | main.rs:189:9:189:14 | either | main.rs:189:9:189:14 | either |
-| main.rs:191:9:191:44 | phi | main.rs:191:9:191:44 | a3 |
+| main.rs:191:9:191:44 | SSA phi(a3) | main.rs:191:9:191:44 | a3 |
 | main.rs:191:22:191:23 | a3 | main.rs:191:9:191:44 | a3 |
 | main.rs:191:42:191:43 | a3 | main.rs:191:9:191:44 | a3 |
 | main.rs:203:9:203:10 | tv | main.rs:203:9:203:10 | tv |
-| main.rs:205:9:205:81 | phi | main.rs:205:9:205:81 | a4 |
+| main.rs:205:9:205:81 | SSA phi(a4) | main.rs:205:9:205:81 | a4 |
 | main.rs:205:28:205:29 | a4 | main.rs:205:9:205:81 | a4 |
 | main.rs:205:54:205:55 | a4 | main.rs:205:9:205:81 | a4 |
 | main.rs:205:79:205:80 | a4 | main.rs:205:9:205:81 | a4 |
-| main.rs:209:9:209:83 | phi | main.rs:209:9:209:83 | a5 |
-| main.rs:209:10:209:57 | [match(true)] phi | main.rs:209:9:209:83 | a5 |
+| main.rs:209:9:209:83 | SSA phi(a5) | main.rs:209:9:209:83 | a5 |
+| main.rs:209:10:209:57 | [match(true)] SSA phi(a5) | main.rs:209:9:209:83 | a5 |
 | main.rs:209:29:209:30 | a5 | main.rs:209:9:209:83 | a5 |
 | main.rs:209:55:209:56 | a5 | main.rs:209:9:209:83 | a5 |
 | main.rs:209:81:209:82 | a5 | main.rs:209:9:209:83 | a5 |
-| main.rs:213:9:213:83 | phi | main.rs:213:9:213:83 | a6 |
+| main.rs:213:9:213:83 | SSA phi(a6) | main.rs:213:9:213:83 | a6 |
 | main.rs:213:28:213:29 | a6 | main.rs:213:9:213:83 | a6 |
-| main.rs:213:35:213:82 | phi | main.rs:213:9:213:83 | a6 |
+| main.rs:213:35:213:82 | SSA phi(a6) | main.rs:213:9:213:83 | a6 |
 | main.rs:213:55:213:56 | a6 | main.rs:213:9:213:83 | a6 |
 | main.rs:213:80:213:81 | a6 | main.rs:213:9:213:83 | a6 |
 | main.rs:219:9:219:14 | either | main.rs:219:9:219:14 | either |
-| main.rs:221:9:221:44 | [match(true)] phi | main.rs:221:9:221:44 | a7 |
+| main.rs:221:9:221:44 | [match(true)] SSA phi(a7) | main.rs:221:9:221:44 | a7 |
 | main.rs:221:22:221:23 | a7 | main.rs:221:9:221:44 | a7 |
 | main.rs:221:42:221:43 | a7 | main.rs:221:9:221:44 | a7 |
 | main.rs:229:9:229:14 | either | main.rs:229:9:229:14 | either |
 | main.rs:232:13:232:13 | e | main.rs:232:13:232:13 | e |
-| main.rs:233:14:233:51 | [match(true)] phi | main.rs:233:14:233:51 | a11 |
+| main.rs:233:14:233:51 | [match(true)] SSA phi(a11) | main.rs:233:14:233:51 | a11 |
 | main.rs:233:27:233:29 | a11 | main.rs:233:14:233:51 | a11 |
 | main.rs:233:48:233:50 | a11 | main.rs:233:14:233:51 | a11 |
 | main.rs:236:33:236:35 | a12 | main.rs:236:33:236:35 | a12 |
 | main.rs:253:9:253:10 | fv | main.rs:253:9:253:10 | fv |
-| main.rs:255:9:255:109 | phi | main.rs:255:9:255:109 | a13 |
+| main.rs:255:9:255:109 | SSA phi(a13) | main.rs:255:9:255:109 | a13 |
 | main.rs:255:27:255:29 | a13 | main.rs:255:9:255:109 | a13 |
-| main.rs:255:35:255:82 | [match(true)] phi | main.rs:255:9:255:109 | a13 |
+| main.rs:255:35:255:82 | [match(true)] SSA phi(a13) | main.rs:255:9:255:109 | a13 |
 | main.rs:255:54:255:56 | a13 | main.rs:255:9:255:109 | a13 |
 | main.rs:255:79:255:81 | a13 | main.rs:255:9:255:109 | a13 |
 | main.rs:255:106:255:108 | a13 | main.rs:255:9:255:109 | a13 |
 | main.rs:261:5:261:6 | a8 | main.rs:261:5:261:6 | a8 |
 | main.rs:263:9:263:10 | b3 | main.rs:263:9:263:10 | b3 |
 | main.rs:264:9:264:10 | c1 | main.rs:264:9:264:10 | c1 |
-| main.rs:272:6:272:41 | phi | main.rs:272:6:272:41 | a9 |
+| main.rs:272:6:272:41 | SSA phi(a9) | main.rs:272:6:272:41 | a9 |
 | main.rs:272:19:272:20 | a9 | main.rs:272:6:272:41 | a9 |
 | main.rs:272:39:272:40 | a9 | main.rs:272:6:272:41 | a9 |
 | main.rs:279:13:279:15 | a10 | main.rs:279:13:279:15 | a10 |
@@ -138,7 +138,7 @@ definition
 | main.rs:471:5:471:15 | <captured exit> i | main.rs:466:13:466:13 | i |
 | main.rs:475:8:475:8 | b | main.rs:475:8:475:8 | b |
 | main.rs:476:13:476:13 | x | main.rs:476:13:476:13 | x |
-| main.rs:479:5:487:5 | phi | main.rs:476:13:476:13 | x |
+| main.rs:479:5:487:5 | SSA phi(x) | main.rs:476:13:476:13 | x |
 | main.rs:480:9:480:9 | x | main.rs:476:13:476:13 | x |
 | main.rs:484:9:484:9 | x | main.rs:476:13:476:13 | x |
 | main.rs:491:13:491:14 | b1 | main.rs:491:13:491:14 | b1 |
@@ -207,26 +207,26 @@ read
 | main.rs:173:17:173:27 | id_variable | main.rs:173:17:173:27 | id_variable | main.rs:174:24:174:34 | id_variable |
 | main.rs:178:26:178:27 | id | main.rs:178:26:178:27 | id | main.rs:179:23:179:24 | id |
 | main.rs:189:9:189:14 | either | main.rs:189:9:189:14 | either | main.rs:190:11:190:16 | either |
-| main.rs:191:9:191:44 | phi | main.rs:191:9:191:44 | a3 | main.rs:192:26:192:27 | a3 |
+| main.rs:191:9:191:44 | SSA phi(a3) | main.rs:191:9:191:44 | a3 | main.rs:192:26:192:27 | a3 |
 | main.rs:203:9:203:10 | tv | main.rs:203:9:203:10 | tv | main.rs:204:11:204:12 | tv |
 | main.rs:203:9:203:10 | tv | main.rs:203:9:203:10 | tv | main.rs:208:11:208:12 | tv |
 | main.rs:203:9:203:10 | tv | main.rs:203:9:203:10 | tv | main.rs:212:11:212:12 | tv |
-| main.rs:205:9:205:81 | phi | main.rs:205:9:205:81 | a4 | main.rs:206:26:206:27 | a4 |
-| main.rs:209:9:209:83 | phi | main.rs:209:9:209:83 | a5 | main.rs:210:26:210:27 | a5 |
-| main.rs:213:9:213:83 | phi | main.rs:213:9:213:83 | a6 | main.rs:214:26:214:27 | a6 |
+| main.rs:205:9:205:81 | SSA phi(a4) | main.rs:205:9:205:81 | a4 | main.rs:206:26:206:27 | a4 |
+| main.rs:209:9:209:83 | SSA phi(a5) | main.rs:209:9:209:83 | a5 | main.rs:210:26:210:27 | a5 |
+| main.rs:213:9:213:83 | SSA phi(a6) | main.rs:213:9:213:83 | a6 | main.rs:214:26:214:27 | a6 |
 | main.rs:219:9:219:14 | either | main.rs:219:9:219:14 | either | main.rs:220:11:220:16 | either |
-| main.rs:221:9:221:44 | [match(true)] phi | main.rs:221:9:221:44 | a7 | main.rs:222:16:222:17 | a7 |
-| main.rs:221:9:221:44 | [match(true)] phi | main.rs:221:9:221:44 | a7 | main.rs:223:26:223:27 | a7 |
+| main.rs:221:9:221:44 | [match(true)] SSA phi(a7) | main.rs:221:9:221:44 | a7 | main.rs:222:16:222:17 | a7 |
+| main.rs:221:9:221:44 | [match(true)] SSA phi(a7) | main.rs:221:9:221:44 | a7 | main.rs:223:26:223:27 | a7 |
 | main.rs:229:9:229:14 | either | main.rs:229:9:229:14 | either | main.rs:231:11:231:16 | either |
 | main.rs:232:13:232:13 | e | main.rs:232:13:232:13 | e | main.rs:237:15:237:15 | e |
-| main.rs:233:14:233:51 | [match(true)] phi | main.rs:233:14:233:51 | a11 | main.rs:235:23:235:25 | a11 |
+| main.rs:233:14:233:51 | [match(true)] SSA phi(a11) | main.rs:233:14:233:51 | a11 | main.rs:235:23:235:25 | a11 |
 | main.rs:236:33:236:35 | a12 | main.rs:236:33:236:35 | a12 | main.rs:238:28:238:30 | a12 |
 | main.rs:253:9:253:10 | fv | main.rs:253:9:253:10 | fv | main.rs:254:11:254:12 | fv |
-| main.rs:255:9:255:109 | phi | main.rs:255:9:255:109 | a13 | main.rs:256:26:256:28 | a13 |
+| main.rs:255:9:255:109 | SSA phi(a13) | main.rs:255:9:255:109 | a13 | main.rs:256:26:256:28 | a13 |
 | main.rs:261:5:261:6 | a8 | main.rs:261:5:261:6 | a8 | main.rs:266:15:266:16 | a8 |
 | main.rs:263:9:263:10 | b3 | main.rs:263:9:263:10 | b3 | main.rs:267:15:267:16 | b3 |
 | main.rs:264:9:264:10 | c1 | main.rs:264:9:264:10 | c1 | main.rs:268:15:268:16 | c1 |
-| main.rs:272:6:272:41 | phi | main.rs:272:6:272:41 | a9 | main.rs:274:15:274:16 | a9 |
+| main.rs:272:6:272:41 | SSA phi(a9) | main.rs:272:6:272:41 | a9 | main.rs:274:15:274:16 | a9 |
 | main.rs:279:13:279:15 | a10 | main.rs:279:13:279:15 | a10 | main.rs:283:15:283:17 | a10 |
 | main.rs:280:13:280:14 | b4 | main.rs:280:13:280:14 | b4 | main.rs:284:15:284:16 | b4 |
 | main.rs:281:13:281:14 | c2 | main.rs:281:13:281:14 | c2 | main.rs:285:15:285:16 | c2 |
@@ -297,7 +297,7 @@ read
 | main.rs:475:8:475:8 | b | main.rs:475:8:475:8 | b | main.rs:479:8:479:8 | b |
 | main.rs:476:13:476:13 | x | main.rs:476:13:476:13 | x | main.rs:477:15:477:15 | x |
 | main.rs:476:13:476:13 | x | main.rs:476:13:476:13 | x | main.rs:478:15:478:15 | x |
-| main.rs:479:5:487:5 | phi | main.rs:476:13:476:13 | x | main.rs:488:15:488:15 | x |
+| main.rs:479:5:487:5 | SSA phi(x) | main.rs:476:13:476:13 | x | main.rs:488:15:488:15 | x |
 | main.rs:480:9:480:9 | x | main.rs:476:13:476:13 | x | main.rs:481:19:481:19 | x |
 | main.rs:480:9:480:9 | x | main.rs:476:13:476:13 | x | main.rs:482:19:482:19 | x |
 | main.rs:484:9:484:9 | x | main.rs:476:13:476:13 | x | main.rs:485:19:485:19 | x |
@@ -372,23 +372,23 @@ firstRead
 | main.rs:173:17:173:27 | id_variable | main.rs:173:17:173:27 | id_variable | main.rs:174:24:174:34 | id_variable |
 | main.rs:178:26:178:27 | id | main.rs:178:26:178:27 | id | main.rs:179:23:179:24 | id |
 | main.rs:189:9:189:14 | either | main.rs:189:9:189:14 | either | main.rs:190:11:190:16 | either |
-| main.rs:191:9:191:44 | phi | main.rs:191:9:191:44 | a3 | main.rs:192:26:192:27 | a3 |
+| main.rs:191:9:191:44 | SSA phi(a3) | main.rs:191:9:191:44 | a3 | main.rs:192:26:192:27 | a3 |
 | main.rs:203:9:203:10 | tv | main.rs:203:9:203:10 | tv | main.rs:204:11:204:12 | tv |
-| main.rs:205:9:205:81 | phi | main.rs:205:9:205:81 | a4 | main.rs:206:26:206:27 | a4 |
-| main.rs:209:9:209:83 | phi | main.rs:209:9:209:83 | a5 | main.rs:210:26:210:27 | a5 |
-| main.rs:213:9:213:83 | phi | main.rs:213:9:213:83 | a6 | main.rs:214:26:214:27 | a6 |
+| main.rs:205:9:205:81 | SSA phi(a4) | main.rs:205:9:205:81 | a4 | main.rs:206:26:206:27 | a4 |
+| main.rs:209:9:209:83 | SSA phi(a5) | main.rs:209:9:209:83 | a5 | main.rs:210:26:210:27 | a5 |
+| main.rs:213:9:213:83 | SSA phi(a6) | main.rs:213:9:213:83 | a6 | main.rs:214:26:214:27 | a6 |
 | main.rs:219:9:219:14 | either | main.rs:219:9:219:14 | either | main.rs:220:11:220:16 | either |
-| main.rs:221:9:221:44 | [match(true)] phi | main.rs:221:9:221:44 | a7 | main.rs:222:16:222:17 | a7 |
+| main.rs:221:9:221:44 | [match(true)] SSA phi(a7) | main.rs:221:9:221:44 | a7 | main.rs:222:16:222:17 | a7 |
 | main.rs:229:9:229:14 | either | main.rs:229:9:229:14 | either | main.rs:231:11:231:16 | either |
 | main.rs:232:13:232:13 | e | main.rs:232:13:232:13 | e | main.rs:237:15:237:15 | e |
-| main.rs:233:14:233:51 | [match(true)] phi | main.rs:233:14:233:51 | a11 | main.rs:235:23:235:25 | a11 |
+| main.rs:233:14:233:51 | [match(true)] SSA phi(a11) | main.rs:233:14:233:51 | a11 | main.rs:235:23:235:25 | a11 |
 | main.rs:236:33:236:35 | a12 | main.rs:236:33:236:35 | a12 | main.rs:238:28:238:30 | a12 |
 | main.rs:253:9:253:10 | fv | main.rs:253:9:253:10 | fv | main.rs:254:11:254:12 | fv |
-| main.rs:255:9:255:109 | phi | main.rs:255:9:255:109 | a13 | main.rs:256:26:256:28 | a13 |
+| main.rs:255:9:255:109 | SSA phi(a13) | main.rs:255:9:255:109 | a13 | main.rs:256:26:256:28 | a13 |
 | main.rs:261:5:261:6 | a8 | main.rs:261:5:261:6 | a8 | main.rs:266:15:266:16 | a8 |
 | main.rs:263:9:263:10 | b3 | main.rs:263:9:263:10 | b3 | main.rs:267:15:267:16 | b3 |
 | main.rs:264:9:264:10 | c1 | main.rs:264:9:264:10 | c1 | main.rs:268:15:268:16 | c1 |
-| main.rs:272:6:272:41 | phi | main.rs:272:6:272:41 | a9 | main.rs:274:15:274:16 | a9 |
+| main.rs:272:6:272:41 | SSA phi(a9) | main.rs:272:6:272:41 | a9 | main.rs:274:15:274:16 | a9 |
 | main.rs:279:13:279:15 | a10 | main.rs:279:13:279:15 | a10 | main.rs:283:15:283:17 | a10 |
 | main.rs:280:13:280:14 | b4 | main.rs:280:13:280:14 | b4 | main.rs:284:15:284:16 | b4 |
 | main.rs:281:13:281:14 | c2 | main.rs:281:13:281:14 | c2 | main.rs:285:15:285:16 | c2 |
@@ -444,7 +444,7 @@ firstRead
 | main.rs:471:5:471:15 | <captured exit> i | main.rs:466:13:466:13 | i | main.rs:472:15:472:15 | i |
 | main.rs:475:8:475:8 | b | main.rs:475:8:475:8 | b | main.rs:479:8:479:8 | b |
 | main.rs:476:13:476:13 | x | main.rs:476:13:476:13 | x | main.rs:477:15:477:15 | x |
-| main.rs:479:5:487:5 | phi | main.rs:476:13:476:13 | x | main.rs:488:15:488:15 | x |
+| main.rs:479:5:487:5 | SSA phi(x) | main.rs:476:13:476:13 | x | main.rs:488:15:488:15 | x |
 | main.rs:480:9:480:9 | x | main.rs:476:13:476:13 | x | main.rs:481:19:481:19 | x |
 | main.rs:484:9:484:9 | x | main.rs:476:13:476:13 | x | main.rs:485:19:485:19 | x |
 | main.rs:491:13:491:14 | b1 | main.rs:491:13:491:14 | b1 | main.rs:493:8:493:9 | b1 |
@@ -477,7 +477,7 @@ adjacentReads
 | main.rs:128:9:128:15 | numbers | main.rs:128:9:128:15 | numbers | main.rs:130:11:130:17 | numbers | main.rs:142:11:142:17 | numbers |
 | main.rs:203:9:203:10 | tv | main.rs:203:9:203:10 | tv | main.rs:204:11:204:12 | tv | main.rs:208:11:208:12 | tv |
 | main.rs:203:9:203:10 | tv | main.rs:203:9:203:10 | tv | main.rs:208:11:208:12 | tv | main.rs:212:11:212:12 | tv |
-| main.rs:221:9:221:44 | [match(true)] phi | main.rs:221:9:221:44 | a7 | main.rs:222:16:222:17 | a7 | main.rs:223:26:223:27 | a7 |
+| main.rs:221:9:221:44 | [match(true)] SSA phi(a7) | main.rs:221:9:221:44 | a7 | main.rs:222:16:222:17 | a7 | main.rs:223:26:223:27 | a7 |
 | main.rs:288:9:288:10 | c2 | main.rs:281:13:281:14 | c2 | main.rs:294:9:294:10 | c2 | main.rs:298:15:298:16 | c2 |
 | main.rs:289:9:289:10 | b4 | main.rs:280:13:280:14 | b4 | main.rs:293:9:293:10 | b4 | main.rs:297:15:297:16 | b4 |
 | main.rs:289:9:289:10 | b4 | main.rs:280:13:280:14 | b4 | main.rs:297:15:297:16 | b4 | main.rs:311:15:311:16 | b4 |
@@ -506,32 +506,32 @@ adjacentReads
 | main.rs:540:13:540:13 | a | main.rs:540:13:540:13 | a | main.rs:542:5:542:5 | a | main.rs:543:15:543:15 | a |
 | main.rs:549:9:549:9 | x | main.rs:549:9:549:9 | x | main.rs:550:20:550:20 | x | main.rs:551:15:551:15 | x |
 phi
-| main.rs:191:9:191:44 | phi | main.rs:191:9:191:44 | a3 | main.rs:191:22:191:23 | a3 |
-| main.rs:191:9:191:44 | phi | main.rs:191:9:191:44 | a3 | main.rs:191:42:191:43 | a3 |
-| main.rs:205:9:205:81 | phi | main.rs:205:9:205:81 | a4 | main.rs:205:28:205:29 | a4 |
-| main.rs:205:9:205:81 | phi | main.rs:205:9:205:81 | a4 | main.rs:205:54:205:55 | a4 |
-| main.rs:205:9:205:81 | phi | main.rs:205:9:205:81 | a4 | main.rs:205:79:205:80 | a4 |
-| main.rs:209:9:209:83 | phi | main.rs:209:9:209:83 | a5 | main.rs:209:10:209:57 | [match(true)] phi |
-| main.rs:209:9:209:83 | phi | main.rs:209:9:209:83 | a5 | main.rs:209:81:209:82 | a5 |
-| main.rs:209:10:209:57 | [match(true)] phi | main.rs:209:9:209:83 | a5 | main.rs:209:29:209:30 | a5 |
-| main.rs:209:10:209:57 | [match(true)] phi | main.rs:209:9:209:83 | a5 | main.rs:209:55:209:56 | a5 |
-| main.rs:213:9:213:83 | phi | main.rs:213:9:213:83 | a6 | main.rs:213:28:213:29 | a6 |
-| main.rs:213:9:213:83 | phi | main.rs:213:9:213:83 | a6 | main.rs:213:35:213:82 | phi |
-| main.rs:213:35:213:82 | phi | main.rs:213:9:213:83 | a6 | main.rs:213:55:213:56 | a6 |
-| main.rs:213:35:213:82 | phi | main.rs:213:9:213:83 | a6 | main.rs:213:80:213:81 | a6 |
-| main.rs:221:9:221:44 | [match(true)] phi | main.rs:221:9:221:44 | a7 | main.rs:221:22:221:23 | a7 |
-| main.rs:221:9:221:44 | [match(true)] phi | main.rs:221:9:221:44 | a7 | main.rs:221:42:221:43 | a7 |
-| main.rs:233:14:233:51 | [match(true)] phi | main.rs:233:14:233:51 | a11 | main.rs:233:27:233:29 | a11 |
-| main.rs:233:14:233:51 | [match(true)] phi | main.rs:233:14:233:51 | a11 | main.rs:233:48:233:50 | a11 |
-| main.rs:255:9:255:109 | phi | main.rs:255:9:255:109 | a13 | main.rs:255:27:255:29 | a13 |
-| main.rs:255:9:255:109 | phi | main.rs:255:9:255:109 | a13 | main.rs:255:35:255:82 | [match(true)] phi |
-| main.rs:255:9:255:109 | phi | main.rs:255:9:255:109 | a13 | main.rs:255:106:255:108 | a13 |
-| main.rs:255:35:255:82 | [match(true)] phi | main.rs:255:9:255:109 | a13 | main.rs:255:54:255:56 | a13 |
-| main.rs:255:35:255:82 | [match(true)] phi | main.rs:255:9:255:109 | a13 | main.rs:255:79:255:81 | a13 |
-| main.rs:272:6:272:41 | phi | main.rs:272:6:272:41 | a9 | main.rs:272:19:272:20 | a9 |
-| main.rs:272:6:272:41 | phi | main.rs:272:6:272:41 | a9 | main.rs:272:39:272:40 | a9 |
-| main.rs:479:5:487:5 | phi | main.rs:476:13:476:13 | x | main.rs:480:9:480:9 | x |
-| main.rs:479:5:487:5 | phi | main.rs:476:13:476:13 | x | main.rs:484:9:484:9 | x |
+| main.rs:191:9:191:44 | SSA phi(a3) | main.rs:191:9:191:44 | a3 | main.rs:191:22:191:23 | a3 |
+| main.rs:191:9:191:44 | SSA phi(a3) | main.rs:191:9:191:44 | a3 | main.rs:191:42:191:43 | a3 |
+| main.rs:205:9:205:81 | SSA phi(a4) | main.rs:205:9:205:81 | a4 | main.rs:205:28:205:29 | a4 |
+| main.rs:205:9:205:81 | SSA phi(a4) | main.rs:205:9:205:81 | a4 | main.rs:205:54:205:55 | a4 |
+| main.rs:205:9:205:81 | SSA phi(a4) | main.rs:205:9:205:81 | a4 | main.rs:205:79:205:80 | a4 |
+| main.rs:209:9:209:83 | SSA phi(a5) | main.rs:209:9:209:83 | a5 | main.rs:209:10:209:57 | [match(true)] SSA phi(a5) |
+| main.rs:209:9:209:83 | SSA phi(a5) | main.rs:209:9:209:83 | a5 | main.rs:209:81:209:82 | a5 |
+| main.rs:209:10:209:57 | [match(true)] SSA phi(a5) | main.rs:209:9:209:83 | a5 | main.rs:209:29:209:30 | a5 |
+| main.rs:209:10:209:57 | [match(true)] SSA phi(a5) | main.rs:209:9:209:83 | a5 | main.rs:209:55:209:56 | a5 |
+| main.rs:213:9:213:83 | SSA phi(a6) | main.rs:213:9:213:83 | a6 | main.rs:213:28:213:29 | a6 |
+| main.rs:213:9:213:83 | SSA phi(a6) | main.rs:213:9:213:83 | a6 | main.rs:213:35:213:82 | SSA phi(a6) |
+| main.rs:213:35:213:82 | SSA phi(a6) | main.rs:213:9:213:83 | a6 | main.rs:213:55:213:56 | a6 |
+| main.rs:213:35:213:82 | SSA phi(a6) | main.rs:213:9:213:83 | a6 | main.rs:213:80:213:81 | a6 |
+| main.rs:221:9:221:44 | [match(true)] SSA phi(a7) | main.rs:221:9:221:44 | a7 | main.rs:221:22:221:23 | a7 |
+| main.rs:221:9:221:44 | [match(true)] SSA phi(a7) | main.rs:221:9:221:44 | a7 | main.rs:221:42:221:43 | a7 |
+| main.rs:233:14:233:51 | [match(true)] SSA phi(a11) | main.rs:233:14:233:51 | a11 | main.rs:233:27:233:29 | a11 |
+| main.rs:233:14:233:51 | [match(true)] SSA phi(a11) | main.rs:233:14:233:51 | a11 | main.rs:233:48:233:50 | a11 |
+| main.rs:255:9:255:109 | SSA phi(a13) | main.rs:255:9:255:109 | a13 | main.rs:255:27:255:29 | a13 |
+| main.rs:255:9:255:109 | SSA phi(a13) | main.rs:255:9:255:109 | a13 | main.rs:255:35:255:82 | [match(true)] SSA phi(a13) |
+| main.rs:255:9:255:109 | SSA phi(a13) | main.rs:255:9:255:109 | a13 | main.rs:255:106:255:108 | a13 |
+| main.rs:255:35:255:82 | [match(true)] SSA phi(a13) | main.rs:255:9:255:109 | a13 | main.rs:255:54:255:56 | a13 |
+| main.rs:255:35:255:82 | [match(true)] SSA phi(a13) | main.rs:255:9:255:109 | a13 | main.rs:255:79:255:81 | a13 |
+| main.rs:272:6:272:41 | SSA phi(a9) | main.rs:272:6:272:41 | a9 | main.rs:272:19:272:20 | a9 |
+| main.rs:272:6:272:41 | SSA phi(a9) | main.rs:272:6:272:41 | a9 | main.rs:272:39:272:40 | a9 |
+| main.rs:479:5:487:5 | SSA phi(x) | main.rs:476:13:476:13 | x | main.rs:480:9:480:9 | x |
+| main.rs:479:5:487:5 | SSA phi(x) | main.rs:476:13:476:13 | x | main.rs:484:9:484:9 | x |
 phiReadNode
 | main.rs:104:11:105:12 | SSA phi read(s1) | main.rs:102:9:102:10 | s1 |
 | main.rs:493:5:497:5 | SSA phi read(x) | main.rs:492:9:492:9 | x |
@@ -545,35 +545,35 @@ phiReadInput
 | main.rs:493:5:497:5 | SSA phi read(x) | main.rs:494:19:494:19 | SSA read(x) |
 | main.rs:493:5:497:5 | SSA phi read(x) | main.rs:496:19:496:19 | SSA read(x) |
 ultimateDef
-| main.rs:191:9:191:44 | phi | main.rs:191:22:191:23 | a3 |
-| main.rs:191:9:191:44 | phi | main.rs:191:42:191:43 | a3 |
-| main.rs:205:9:205:81 | phi | main.rs:205:28:205:29 | a4 |
-| main.rs:205:9:205:81 | phi | main.rs:205:54:205:55 | a4 |
-| main.rs:205:9:205:81 | phi | main.rs:205:79:205:80 | a4 |
-| main.rs:209:9:209:83 | phi | main.rs:209:29:209:30 | a5 |
-| main.rs:209:9:209:83 | phi | main.rs:209:55:209:56 | a5 |
-| main.rs:209:9:209:83 | phi | main.rs:209:81:209:82 | a5 |
-| main.rs:209:10:209:57 | [match(true)] phi | main.rs:209:29:209:30 | a5 |
-| main.rs:209:10:209:57 | [match(true)] phi | main.rs:209:55:209:56 | a5 |
-| main.rs:213:9:213:83 | phi | main.rs:213:28:213:29 | a6 |
-| main.rs:213:9:213:83 | phi | main.rs:213:55:213:56 | a6 |
-| main.rs:213:9:213:83 | phi | main.rs:213:80:213:81 | a6 |
-| main.rs:213:35:213:82 | phi | main.rs:213:55:213:56 | a6 |
-| main.rs:213:35:213:82 | phi | main.rs:213:80:213:81 | a6 |
-| main.rs:221:9:221:44 | [match(true)] phi | main.rs:221:22:221:23 | a7 |
-| main.rs:221:9:221:44 | [match(true)] phi | main.rs:221:42:221:43 | a7 |
-| main.rs:233:14:233:51 | [match(true)] phi | main.rs:233:27:233:29 | a11 |
-| main.rs:233:14:233:51 | [match(true)] phi | main.rs:233:48:233:50 | a11 |
-| main.rs:255:9:255:109 | phi | main.rs:255:27:255:29 | a13 |
-| main.rs:255:9:255:109 | phi | main.rs:255:54:255:56 | a13 |
-| main.rs:255:9:255:109 | phi | main.rs:255:79:255:81 | a13 |
-| main.rs:255:9:255:109 | phi | main.rs:255:106:255:108 | a13 |
-| main.rs:255:35:255:82 | [match(true)] phi | main.rs:255:54:255:56 | a13 |
-| main.rs:255:35:255:82 | [match(true)] phi | main.rs:255:79:255:81 | a13 |
-| main.rs:272:6:272:41 | phi | main.rs:272:19:272:20 | a9 |
-| main.rs:272:6:272:41 | phi | main.rs:272:39:272:40 | a9 |
-| main.rs:479:5:487:5 | phi | main.rs:480:9:480:9 | x |
-| main.rs:479:5:487:5 | phi | main.rs:484:9:484:9 | x |
+| main.rs:191:9:191:44 | SSA phi(a3) | main.rs:191:22:191:23 | a3 |
+| main.rs:191:9:191:44 | SSA phi(a3) | main.rs:191:42:191:43 | a3 |
+| main.rs:205:9:205:81 | SSA phi(a4) | main.rs:205:28:205:29 | a4 |
+| main.rs:205:9:205:81 | SSA phi(a4) | main.rs:205:54:205:55 | a4 |
+| main.rs:205:9:205:81 | SSA phi(a4) | main.rs:205:79:205:80 | a4 |
+| main.rs:209:9:209:83 | SSA phi(a5) | main.rs:209:29:209:30 | a5 |
+| main.rs:209:9:209:83 | SSA phi(a5) | main.rs:209:55:209:56 | a5 |
+| main.rs:209:9:209:83 | SSA phi(a5) | main.rs:209:81:209:82 | a5 |
+| main.rs:209:10:209:57 | [match(true)] SSA phi(a5) | main.rs:209:29:209:30 | a5 |
+| main.rs:209:10:209:57 | [match(true)] SSA phi(a5) | main.rs:209:55:209:56 | a5 |
+| main.rs:213:9:213:83 | SSA phi(a6) | main.rs:213:28:213:29 | a6 |
+| main.rs:213:9:213:83 | SSA phi(a6) | main.rs:213:55:213:56 | a6 |
+| main.rs:213:9:213:83 | SSA phi(a6) | main.rs:213:80:213:81 | a6 |
+| main.rs:213:35:213:82 | SSA phi(a6) | main.rs:213:55:213:56 | a6 |
+| main.rs:213:35:213:82 | SSA phi(a6) | main.rs:213:80:213:81 | a6 |
+| main.rs:221:9:221:44 | [match(true)] SSA phi(a7) | main.rs:221:22:221:23 | a7 |
+| main.rs:221:9:221:44 | [match(true)] SSA phi(a7) | main.rs:221:42:221:43 | a7 |
+| main.rs:233:14:233:51 | [match(true)] SSA phi(a11) | main.rs:233:27:233:29 | a11 |
+| main.rs:233:14:233:51 | [match(true)] SSA phi(a11) | main.rs:233:48:233:50 | a11 |
+| main.rs:255:9:255:109 | SSA phi(a13) | main.rs:255:27:255:29 | a13 |
+| main.rs:255:9:255:109 | SSA phi(a13) | main.rs:255:54:255:56 | a13 |
+| main.rs:255:9:255:109 | SSA phi(a13) | main.rs:255:79:255:81 | a13 |
+| main.rs:255:9:255:109 | SSA phi(a13) | main.rs:255:106:255:108 | a13 |
+| main.rs:255:35:255:82 | [match(true)] SSA phi(a13) | main.rs:255:54:255:56 | a13 |
+| main.rs:255:35:255:82 | [match(true)] SSA phi(a13) | main.rs:255:79:255:81 | a13 |
+| main.rs:272:6:272:41 | SSA phi(a9) | main.rs:272:19:272:20 | a9 |
+| main.rs:272:6:272:41 | SSA phi(a9) | main.rs:272:39:272:40 | a9 |
+| main.rs:479:5:487:5 | SSA phi(x) | main.rs:480:9:480:9 | x |
+| main.rs:479:5:487:5 | SSA phi(x) | main.rs:484:9:484:9 | x |
 assigns
 | main.rs:16:9:16:10 | x1 | main.rs:16:14:16:16 | "a" |
 | main.rs:21:13:21:14 | x2 | main.rs:21:18:21:18 | 4 |

--- a/rust/ql/test/query-tests/security/CWE-089/CONSISTENCY/SsaConsistency.expected
+++ b/rust/ql/test/query-tests/security/CWE-089/CONSISTENCY/SsaConsistency.expected
@@ -1,4 +1,4 @@
 uselessPhiNode
-| sqlx.rs:155:5:157:5 | phi | 1 |
+| sqlx.rs:155:5:157:5 | SSA phi(arg0) | 1 |
 phiWithoutTwoPriorRefs
-| sqlx.rs:155:5:157:5 | phi | 1 |
+| sqlx.rs:155:5:157:5 | SSA phi(arg0) | sqlx.rs:155:5:157:5 | if enable_remote {...} | sqlx.rs:156:17:156:86 | arg0 | 1 |

--- a/rust/ql/test/query-tests/security/CWE-089/CONSISTENCY/SsaConsistency.expected
+++ b/rust/ql/test/query-tests/security/CWE-089/CONSISTENCY/SsaConsistency.expected
@@ -1,4 +1,0 @@
-uselessPhiNode
-| sqlx.rs:155:5:157:5 | SSA phi(arg0) | 1 |
-phiWithoutTwoPriorRefs
-| sqlx.rs:155:5:157:5 | SSA phi(arg0) | sqlx.rs:155:5:157:5 | if enable_remote {...} | sqlx.rs:156:17:156:86 | arg0 | 1 |

--- a/shared/ssa/codeql/ssa/Ssa.qll
+++ b/shared/ssa/codeql/ssa/Ssa.qll
@@ -1412,13 +1412,12 @@ module Make<LocationSig Location, InputSig<Location> Input> {
     }
 
     /** Holds if `phi` has less than 2 immediately prior references. */
-    query predicate phiWithoutTwoPriorRefs(PhiNode phi, int inputRefs) {
-      exists(BasicBlock bbPhi, SourceVariable v |
-        phi.definesAt(v, bbPhi, _) and
-        inputRefs =
-          count(BasicBlock bb, int i | AdjacentSsaRefs::adjacentRefPhi(bb, i, _, bbPhi, v)) and
-        inputRefs < 2
-      )
+    query predicate phiWithoutTwoPriorRefs(
+      PhiNode phi, BasicBlock bbPhi, SourceVariable v, int inputRefs
+    ) {
+      phi.definesAt(v, bbPhi, _) and
+      inputRefs = count(BasicBlock bb, int i | AdjacentSsaRefs::adjacentRefPhi(bb, i, _, bbPhi, v)) and
+      inputRefs < 2
     }
 
     /**


### PR DESCRIPTION
The consistency check `phiWithoutTwoPriorRefs` revealed that we were creating too many pseudo reads of captured variables at calls. Instead of checking that a call can be reached from _some_ write, in order to be considered relevant, we instead need to check that it is _dominated_ by _some_ write.