### PR TITLE
Rust: Add inline expectations test for type inference

### DIFF
--- a/rust/ql/lib/codeql/rust/elements/internal/FunctionImpl.qll
+++ b/rust/ql/lib/codeql/rust/elements/internal/FunctionImpl.qll
@@ -4,6 +4,7 @@
  * INTERNAL: Do not use.
  */
 
+private import codeql.files.FileSystem
 private import codeql.rust.elements.internal.generated.Function
 private import codeql.rust.elements.Comment
 
@@ -27,6 +28,30 @@ module Impl {
    */
   class Function extends Generated::Function {
     override string toStringImpl() { result = "fn " + this.getName().getText() }
+
+    pragma[nomagic]
+    private predicate hasPotentialCommentAt(File f, int line) {
+      f = this.getLocation().getFile() and
+      // When a function is preceded by comments its start line is the line of
+      // the first comment. Hence all relevant comments are found by including
+      // comments from the start line and up to the line with the function
+      // name.
+      line in [this.getLocation().getStartLine() .. this.getName().getLocation().getStartLine()]
+    }
+
+    /**
+     * Gets a comment preceding this function.
+     *
+     * A comment is considered preceding if it occurs immediately before this
+     * function or if only other comments occur between the comment and this
+     * function.
+     */
+    Comment getAPrecedingComment() {
+      exists(File f, int line |
+        this.hasPotentialCommentAt(f, line) and
+        result.getLocation().hasLocationFileInfo(f, line, _, _, _)
+      )
+    }
 
     /**
      * Gets a comment preceding this function.

--- a/rust/ql/lib/codeql/rust/elements/internal/FunctionImpl.qll
+++ b/rust/ql/lib/codeql/rust/elements/internal/FunctionImpl.qll
@@ -5,6 +5,7 @@
  */
 
 private import codeql.rust.elements.internal.generated.Function
+private import codeql.rust.elements.Comment
 
 /**
  * INTERNAL: This module contains the customizable definition of `Function` and should not
@@ -26,5 +27,22 @@ module Impl {
    */
   class Function extends Generated::Function {
     override string toStringImpl() { result = "fn " + this.getName().getText() }
+
+    /**
+     * Gets a comment preceding this function.
+     *
+     * A comment is considered preceding if it occurs immediately before this
+     * function or if only other comments occur between the comment and this
+     * function.
+     */
+    Comment getPrecedingComment() {
+      result.getLocation().getFile() = this.getLocation().getFile() and
+      // When a function is preceded by comments its start line is the line of
+      // the first comment. Hence all relevant comments are found by including
+      // comments from the start line and up to the line with the function
+      // name.
+      this.getLocation().getStartLine() <= result.getLocation().getStartLine() and
+      result.getLocation().getStartLine() <= this.getName().getLocation().getStartLine()
+    }
   }
 }

--- a/rust/ql/lib/codeql/rust/elements/internal/MethodCallExprImpl.qll
+++ b/rust/ql/lib/codeql/rust/elements/internal/MethodCallExprImpl.qll
@@ -42,12 +42,22 @@ module Impl {
       )
     }
 
+    private string toStringPart(int index) {
+      index = 0 and
+      result = this.getReceiver().toAbbreviatedString()
+      or
+      index = 1 and
+      (if this.getReceiver().toAbbreviatedString() = "..." then result = " ." else result = ".")
+      or
+      index = 2 and
+      result = this.getIdentifier().toStringImpl()
+      or
+      index = 3 and
+      if this.getArgList().getNumberOfArgs() = 0 then result = "()" else result = "(...)"
+    }
+
     override string toStringImpl() {
-      exists(string base, string separator |
-        base = this.getReceiver().toAbbreviatedString() and
-        (if base = "..." then separator = " ." else separator = ".") and
-        result = base + separator + this.getIdentifier().toStringImpl() + "(...)"
-      )
+      result = strictconcat(int i | | this.toStringPart(i) order by i)
     }
   }
 }

--- a/rust/ql/lib/codeql/rust/internal/Type.qll
+++ b/rust/ql/lib/codeql/rust/internal/Type.qll
@@ -104,7 +104,7 @@ class StructType extends StructOrEnumType, TStruct {
     result = TTypeParamTypeParameter(struct.getGenericParamList().getTypeParam(i))
   }
 
-  override string toString() { result = struct.toString() }
+  override string toString() { result = struct.getName().getText() }
 
   override Location getLocation() { result = struct.getLocation() }
 }
@@ -125,7 +125,7 @@ class EnumType extends StructOrEnumType, TEnum {
     result = TTypeParamTypeParameter(enum.getGenericParamList().getTypeParam(i))
   }
 
-  override string toString() { result = enum.toString() }
+  override string toString() { result = enum.getName().getText() }
 
   override Location getLocation() { result = enum.getLocation() }
 }

--- a/rust/ql/lib/utils/test/InlineMadTest.qll
+++ b/rust/ql/lib/utils/test/InlineMadTest.qll
@@ -5,16 +5,7 @@ private module InlineMadTestLang implements InlineMadTestLangSig {
   class Callable = R::Function;
 
   string getComment(R::Function callable) {
-    exists(R::Comment comment |
-      result = comment.getCommentText() and
-      comment.getLocation().getFile() = callable.getLocation().getFile() and
-      // When a function is preceded by comments its start line is the line of
-      // the first comment. Hence all relevant comments are found by including
-      // comments from the start line and up to the line with the function
-      // name.
-      callable.getLocation().getStartLine() <= comment.getLocation().getStartLine() and
-      comment.getLocation().getStartLine() <= callable.getName().getLocation().getStartLine()
-    )
+    result = callable.getPrecedingComment().getCommentText()
   }
 }
 

--- a/rust/ql/lib/utils/test/InlineMadTest.qll
+++ b/rust/ql/lib/utils/test/InlineMadTest.qll
@@ -5,7 +5,7 @@ private module InlineMadTestLang implements InlineMadTestLangSig {
   class Callable = R::Function;
 
   string getComment(R::Function callable) {
-    result = callable.getPrecedingComment().getCommentText()
+    result = callable.getAPrecedingComment().getCommentText()
   }
 }
 

--- a/rust/ql/test/extractor-tests/canonical_path/CONSISTENCY/PathResolutionConsistency.expected
+++ b/rust/ql/test/extractor-tests/canonical_path/CONSISTENCY/PathResolutionConsistency.expected
@@ -1,3 +1,3 @@
 multipleStaticCallTargets
-| regular.rs:29:5:29:9 | s.g(...) | anonymous.rs:15:9:15:22 | fn g |
-| regular.rs:29:5:29:9 | s.g(...) | regular.rs:13:5:13:18 | fn g |
+| regular.rs:29:5:29:9 | s.g() | anonymous.rs:15:9:15:22 | fn g |
+| regular.rs:29:5:29:9 | s.g() | regular.rs:13:5:13:18 | fn g |

--- a/rust/ql/test/extractor-tests/canonical_path/canonical_paths.expected
+++ b/rust/ql/test/extractor-tests/canonical_path/canonical_paths.expected
@@ -38,17 +38,17 @@ canonicalPaths
 resolvedPaths
 | anonymous.rs:27:17:27:30 | OtherStruct {...} | None | None |
 | anonymous.rs:28:9:28:9 | s | None | None |
-| anonymous.rs:28:9:28:13 | s.f(...) | None | None |
+| anonymous.rs:28:9:28:13 | s.f() | None | None |
 | anonymous.rs:29:9:29:9 | s | None | None |
-| anonymous.rs:29:9:29:13 | s.g(...) | None | None |
+| anonymous.rs:29:9:29:13 | s.g() | None | None |
 | anonymous.rs:30:9:30:14 | nested | None | None |
 | regular.rs:27:13:27:21 | Struct {...} | repo::test | crate::regular::Struct |
 | regular.rs:28:5:28:5 | s | None | None |
-| regular.rs:28:5:28:9 | s.f(...) | repo::test | <crate::regular::Struct as crate::regular::Trait>::f |
+| regular.rs:28:5:28:9 | s.f() | repo::test | <crate::regular::Struct as crate::regular::Trait>::f |
 | regular.rs:29:5:29:5 | s | None | None |
-| regular.rs:29:5:29:9 | s.g(...) | repo::test | <crate::regular::Struct>::g |
+| regular.rs:29:5:29:9 | s.g() | repo::test | <crate::regular::Struct>::g |
 | regular.rs:30:5:30:5 | s | None | None |
-| regular.rs:30:5:30:9 | s.h(...) | repo::test | <_ as crate::regular::TraitWithBlanketImpl>::h |
+| regular.rs:30:5:30:9 | s.h() | repo::test | <_ as crate::regular::TraitWithBlanketImpl>::h |
 | regular.rs:31:5:31:8 | free | repo::test | crate::regular::free |
 | regular.rs:41:9:41:26 | ...::None::<...> | lang:core | crate::option::Option::None |
 | regular.rs:42:9:42:20 | ...::Some | lang:core | crate::option::Option::Some |

--- a/rust/ql/test/extractor-tests/canonical_path_disabled/CONSISTENCY/PathResolutionConsistency.expected
+++ b/rust/ql/test/extractor-tests/canonical_path_disabled/CONSISTENCY/PathResolutionConsistency.expected
@@ -1,3 +1,3 @@
 multipleStaticCallTargets
-| regular.rs:32:5:32:9 | s.g(...) | anonymous.rs:18:9:18:22 | fn g |
-| regular.rs:32:5:32:9 | s.g(...) | regular.rs:16:5:16:18 | fn g |
+| regular.rs:32:5:32:9 | s.g() | anonymous.rs:18:9:18:22 | fn g |
+| regular.rs:32:5:32:9 | s.g() | regular.rs:16:5:16:18 | fn g |

--- a/rust/ql/test/extractor-tests/canonical_path_disabled/canonical_paths.expected
+++ b/rust/ql/test/extractor-tests/canonical_path_disabled/canonical_paths.expected
@@ -38,17 +38,17 @@ canonicalPaths
 resolvedPaths
 | anonymous.rs:30:17:30:30 | OtherStruct {...} | None | None |
 | anonymous.rs:31:9:31:9 | s | None | None |
-| anonymous.rs:31:9:31:13 | s.f(...) | None | None |
+| anonymous.rs:31:9:31:13 | s.f() | None | None |
 | anonymous.rs:32:9:32:9 | s | None | None |
-| anonymous.rs:32:9:32:13 | s.g(...) | None | None |
+| anonymous.rs:32:9:32:13 | s.g() | None | None |
 | anonymous.rs:33:9:33:14 | nested | None | None |
 | regular.rs:30:13:30:21 | Struct {...} | None | None |
 | regular.rs:31:5:31:5 | s | None | None |
-| regular.rs:31:5:31:9 | s.f(...) | None | None |
+| regular.rs:31:5:31:9 | s.f() | None | None |
 | regular.rs:32:5:32:5 | s | None | None |
-| regular.rs:32:5:32:9 | s.g(...) | None | None |
+| regular.rs:32:5:32:9 | s.g() | None | None |
 | regular.rs:33:5:33:5 | s | None | None |
-| regular.rs:33:5:33:9 | s.h(...) | None | None |
+| regular.rs:33:5:33:9 | s.h() | None | None |
 | regular.rs:34:5:34:8 | free | None | None |
 | regular.rs:44:9:44:26 | ...::None::<...> | None | None |
 | regular.rs:45:9:45:20 | ...::Some | None | None |

--- a/rust/ql/test/extractor-tests/generated/MacroItems/CONSISTENCY/AstConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/MacroItems/CONSISTENCY/AstConsistency.expected
@@ -1,5 +1,5 @@
 noLocation
-| file://:0:0:0:0 | ... .unwrap(...) |
+| file://:0:0:0:0 | ... .unwrap() |
 | file://:0:0:0:0 | ...: ... |
 | file://:0:0:0:0 | ...::Path |
 | file://:0:0:0:0 | ...::Path |
@@ -32,7 +32,7 @@ noLocation
 | file://:0:0:0:0 | path |
 | file://:0:0:0:0 | path |
 | file://:0:0:0:0 | path |
-| file://:0:0:0:0 | path.parent(...) |
+| file://:0:0:0:0 | path.parent() |
 | file://:0:0:0:0 | std |
 | file://:0:0:0:0 | std |
 | file://:0:0:0:0 | std |

--- a/rust/ql/test/library-tests/controlflow/Cfg.expected
+++ b/rust/ql/test/library-tests/controlflow/Cfg.expected
@@ -205,8 +205,8 @@ edges
 | test.rs:99:19:99:25 | Some(...) | test.rs:99:24:99:24 | x | match |
 | test.rs:99:24:99:24 | x | test.rs:99:24:99:24 | x |  |
 | test.rs:99:24:99:24 | x | test.rs:100:17:100:17 | x | match |
-| test.rs:99:29:99:32 | iter | test.rs:99:29:99:39 | iter.next(...) |  |
-| test.rs:99:29:99:39 | iter.next(...) | test.rs:99:19:99:25 | Some(...) |  |
+| test.rs:99:29:99:32 | iter | test.rs:99:29:99:39 | iter.next() |  |
+| test.rs:99:29:99:39 | iter.next() | test.rs:99:19:99:25 | Some(...) |  |
 | test.rs:99:41:103:9 | { ... } | test.rs:99:15:99:39 | let ... = ... |  |
 | test.rs:100:13:102:13 | if ... {...} | test.rs:99:41:103:9 | { ... } |  |
 | test.rs:100:17:100:17 | x | test.rs:100:22:100:22 | 5 |  |
@@ -760,8 +760,8 @@ edges
 | test.rs:311:87:313:5 | { ... } | test.rs:311:5:313:5 | exit fn test_question_mark_operator_1 (normal) |  |
 | test.rs:312:9:312:10 | Ok | test.rs:312:12:312:12 | s |  |
 | test.rs:312:9:312:33 | Ok(...) | test.rs:311:87:313:5 | { ... } |  |
-| test.rs:312:12:312:12 | s | test.rs:312:12:312:27 | s.parse(...) |  |
-| test.rs:312:12:312:27 | s.parse(...) | test.rs:312:12:312:28 | TryExpr |  |
+| test.rs:312:12:312:12 | s | test.rs:312:12:312:27 | s.parse() |  |
+| test.rs:312:12:312:27 | s.parse() | test.rs:312:12:312:28 | TryExpr |  |
 | test.rs:312:12:312:28 | TryExpr | test.rs:311:5:313:5 | exit fn test_question_mark_operator_1 (normal) | return |
 | test.rs:312:12:312:28 | TryExpr | test.rs:312:32:312:32 | 4 | match |
 | test.rs:312:12:312:32 | ... + ... | test.rs:312:9:312:33 | Ok(...) |  |

--- a/rust/ql/test/library-tests/dataflow/global/inline-flow.expected
+++ b/rust/ql/test/library-tests/dataflow/global/inline-flow.expected
@@ -17,13 +17,13 @@ edges
 | main.rs:38:23:38:31 | source(...) | main.rs:26:28:26:33 | ...: i64 | provenance |  |
 | main.rs:38:23:38:31 | source(...) | main.rs:38:6:38:11 | [post] &mut a [&ref, MyStruct] | provenance |  |
 | main.rs:39:10:39:10 | a [MyStruct] | main.rs:30:17:30:21 | SelfParam [&ref, MyStruct] | provenance |  |
-| main.rs:39:10:39:10 | a [MyStruct] | main.rs:39:10:39:21 | a.get_data(...) | provenance |  |
+| main.rs:39:10:39:10 | a [MyStruct] | main.rs:39:10:39:21 | a.get_data() | provenance |  |
 | main.rs:44:12:44:17 | [post] &mut a [&ref, MyStruct] | main.rs:44:17:44:17 | [post] a [MyStruct] | provenance |  |
 | main.rs:44:17:44:17 | [post] a [MyStruct] | main.rs:45:10:45:10 | a [MyStruct] | provenance |  |
 | main.rs:44:30:44:38 | source(...) | main.rs:26:28:26:33 | ...: i64 | provenance |  |
 | main.rs:44:30:44:38 | source(...) | main.rs:44:12:44:17 | [post] &mut a [&ref, MyStruct] | provenance |  |
 | main.rs:45:10:45:10 | a [MyStruct] | main.rs:30:17:30:21 | SelfParam [&ref, MyStruct] | provenance |  |
-| main.rs:45:10:45:10 | a [MyStruct] | main.rs:45:10:45:21 | a.get_data(...) | provenance |  |
+| main.rs:45:10:45:10 | a [MyStruct] | main.rs:45:10:45:21 | a.get_data() | provenance |  |
 | main.rs:48:12:48:17 | ...: i64 | main.rs:49:10:49:10 | n | provenance |  |
 | main.rs:53:9:53:9 | a | main.rs:54:13:54:13 | a | provenance |  |
 | main.rs:53:13:53:21 | source(...) | main.rs:53:9:53:9 | a | provenance |  |
@@ -48,11 +48,11 @@ edges
 | main.rs:82:26:82:26 | a | main.rs:78:21:78:26 | ...: i64 | provenance |  |
 | main.rs:82:26:82:26 | a | main.rs:82:13:82:27 | pass_through(...) | provenance |  |
 | main.rs:94:22:94:27 | ...: i64 | main.rs:95:14:95:14 | n | provenance |  |
-| main.rs:98:30:104:5 | { ... } | main.rs:117:13:117:25 | mn.get_data(...) | provenance |  |
+| main.rs:98:30:104:5 | { ... } | main.rs:117:13:117:25 | mn.get_data() | provenance |  |
 | main.rs:102:13:102:21 | source(...) | main.rs:98:30:104:5 | { ... } | provenance |  |
 | main.rs:106:27:106:32 | ...: i64 | main.rs:106:42:112:5 | { ... } | provenance |  |
 | main.rs:117:9:117:9 | a | main.rs:118:10:118:10 | a | provenance |  |
-| main.rs:117:13:117:25 | mn.get_data(...) | main.rs:117:9:117:9 | a | provenance |  |
+| main.rs:117:13:117:25 | mn.get_data() | main.rs:117:9:117:9 | a | provenance |  |
 | main.rs:123:9:123:9 | a | main.rs:124:16:124:16 | a | provenance |  |
 | main.rs:123:13:123:21 | source(...) | main.rs:123:9:123:9 | a | provenance |  |
 | main.rs:124:16:124:16 | a | main.rs:94:22:94:27 | ...: i64 | provenance |  |
@@ -115,12 +115,12 @@ nodes
 | main.rs:38:11:38:11 | [post] a [MyStruct] | semmle.label | [post] a [MyStruct] |
 | main.rs:38:23:38:31 | source(...) | semmle.label | source(...) |
 | main.rs:39:10:39:10 | a [MyStruct] | semmle.label | a [MyStruct] |
-| main.rs:39:10:39:21 | a.get_data(...) | semmle.label | a.get_data(...) |
+| main.rs:39:10:39:21 | a.get_data() | semmle.label | a.get_data() |
 | main.rs:44:12:44:17 | [post] &mut a [&ref, MyStruct] | semmle.label | [post] &mut a [&ref, MyStruct] |
 | main.rs:44:17:44:17 | [post] a [MyStruct] | semmle.label | [post] a [MyStruct] |
 | main.rs:44:30:44:38 | source(...) | semmle.label | source(...) |
 | main.rs:45:10:45:10 | a [MyStruct] | semmle.label | a [MyStruct] |
-| main.rs:45:10:45:21 | a.get_data(...) | semmle.label | a.get_data(...) |
+| main.rs:45:10:45:21 | a.get_data() | semmle.label | a.get_data() |
 | main.rs:48:12:48:17 | ...: i64 | semmle.label | ...: i64 |
 | main.rs:49:10:49:10 | n | semmle.label | n |
 | main.rs:53:9:53:9 | a | semmle.label | a |
@@ -154,7 +154,7 @@ nodes
 | main.rs:106:27:106:32 | ...: i64 | semmle.label | ...: i64 |
 | main.rs:106:42:112:5 | { ... } | semmle.label | { ... } |
 | main.rs:117:9:117:9 | a | semmle.label | a |
-| main.rs:117:13:117:25 | mn.get_data(...) | semmle.label | mn.get_data(...) |
+| main.rs:117:13:117:25 | mn.get_data() | semmle.label | mn.get_data() |
 | main.rs:118:10:118:10 | a | semmle.label | a |
 | main.rs:123:9:123:9 | a | semmle.label | a |
 | main.rs:123:13:123:21 | source(...) | semmle.label | source(...) |
@@ -204,9 +204,9 @@ nodes
 | main.rs:239:14:239:14 | c | semmle.label | c |
 subpaths
 | main.rs:38:23:38:31 | source(...) | main.rs:26:28:26:33 | ...: i64 | main.rs:26:17:26:25 | SelfParam [Return] [&ref, MyStruct] | main.rs:38:6:38:11 | [post] &mut a [&ref, MyStruct] |
-| main.rs:39:10:39:10 | a [MyStruct] | main.rs:30:17:30:21 | SelfParam [&ref, MyStruct] | main.rs:30:31:32:5 | { ... } | main.rs:39:10:39:21 | a.get_data(...) |
+| main.rs:39:10:39:10 | a [MyStruct] | main.rs:30:17:30:21 | SelfParam [&ref, MyStruct] | main.rs:30:31:32:5 | { ... } | main.rs:39:10:39:21 | a.get_data() |
 | main.rs:44:30:44:38 | source(...) | main.rs:26:28:26:33 | ...: i64 | main.rs:26:17:26:25 | SelfParam [Return] [&ref, MyStruct] | main.rs:44:12:44:17 | [post] &mut a [&ref, MyStruct] |
-| main.rs:45:10:45:10 | a [MyStruct] | main.rs:30:17:30:21 | SelfParam [&ref, MyStruct] | main.rs:30:31:32:5 | { ... } | main.rs:45:10:45:21 | a.get_data(...) |
+| main.rs:45:10:45:10 | a [MyStruct] | main.rs:30:17:30:21 | SelfParam [&ref, MyStruct] | main.rs:30:31:32:5 | { ... } | main.rs:45:10:45:21 | a.get_data() |
 | main.rs:63:26:63:26 | a | main.rs:57:17:57:22 | ...: i64 | main.rs:57:32:59:1 | { ... } | main.rs:63:13:63:27 | pass_through(...) |
 | main.rs:68:26:71:5 | { ... } | main.rs:57:17:57:22 | ...: i64 | main.rs:57:32:59:1 | { ... } | main.rs:68:13:71:6 | pass_through(...) |
 | main.rs:82:26:82:26 | a | main.rs:78:21:78:26 | ...: i64 | main.rs:78:36:80:5 | { ... } | main.rs:82:13:82:27 | pass_through(...) |
@@ -217,8 +217,8 @@ subpaths
 testFailures
 #select
 | main.rs:18:10:18:10 | a | main.rs:13:5:13:13 | source(...) | main.rs:18:10:18:10 | a | $@ | main.rs:13:5:13:13 | source(...) | source(...) |
-| main.rs:39:10:39:21 | a.get_data(...) | main.rs:38:23:38:31 | source(...) | main.rs:39:10:39:21 | a.get_data(...) | $@ | main.rs:38:23:38:31 | source(...) | source(...) |
-| main.rs:45:10:45:21 | a.get_data(...) | main.rs:44:30:44:38 | source(...) | main.rs:45:10:45:21 | a.get_data(...) | $@ | main.rs:44:30:44:38 | source(...) | source(...) |
+| main.rs:39:10:39:21 | a.get_data() | main.rs:38:23:38:31 | source(...) | main.rs:39:10:39:21 | a.get_data() | $@ | main.rs:38:23:38:31 | source(...) | source(...) |
+| main.rs:45:10:45:21 | a.get_data() | main.rs:44:30:44:38 | source(...) | main.rs:45:10:45:21 | a.get_data() | $@ | main.rs:44:30:44:38 | source(...) | source(...) |
 | main.rs:49:10:49:10 | n | main.rs:53:13:53:21 | source(...) | main.rs:49:10:49:10 | n | $@ | main.rs:53:13:53:21 | source(...) | source(...) |
 | main.rs:64:10:64:10 | b | main.rs:62:13:62:21 | source(...) | main.rs:64:10:64:10 | b | $@ | main.rs:62:13:62:21 | source(...) | source(...) |
 | main.rs:72:10:72:10 | a | main.rs:70:9:70:18 | source(...) | main.rs:72:10:72:10 | a | $@ | main.rs:70:9:70:18 | source(...) | source(...) |

--- a/rust/ql/test/library-tests/dataflow/global/viableCallable.expected
+++ b/rust/ql/test/library-tests/dataflow/global/viableCallable.expected
@@ -2,15 +2,15 @@
 | main.rs:17:13:17:23 | get_data(...) | main.rs:12:1:14:1 | fn get_data |
 | main.rs:18:5:18:11 | sink(...) | main.rs:5:1:7:1 | fn sink |
 | main.rs:37:5:37:22 | sink(...) | main.rs:5:1:7:1 | fn sink |
-| main.rs:37:10:37:21 | a.get_data(...) | main.rs:30:5:32:5 | fn get_data |
+| main.rs:37:10:37:21 | a.get_data() | main.rs:30:5:32:5 | fn get_data |
 | main.rs:38:5:38:32 | ... .set_data(...) | main.rs:26:5:28:5 | fn set_data |
 | main.rs:38:23:38:31 | source(...) | main.rs:1:1:3:1 | fn source |
 | main.rs:39:5:39:22 | sink(...) | main.rs:5:1:7:1 | fn sink |
-| main.rs:39:10:39:21 | a.get_data(...) | main.rs:30:5:32:5 | fn get_data |
+| main.rs:39:10:39:21 | a.get_data() | main.rs:30:5:32:5 | fn get_data |
 | main.rs:44:5:44:39 | ... .set_data(...) | main.rs:26:5:28:5 | fn set_data |
 | main.rs:44:30:44:38 | source(...) | main.rs:1:1:3:1 | fn source |
 | main.rs:45:5:45:22 | sink(...) | main.rs:5:1:7:1 | fn sink |
-| main.rs:45:10:45:21 | a.get_data(...) | main.rs:30:5:32:5 | fn get_data |
+| main.rs:45:10:45:21 | a.get_data() | main.rs:30:5:32:5 | fn get_data |
 | main.rs:49:5:49:11 | sink(...) | main.rs:5:1:7:1 | fn sink |
 | main.rs:53:13:53:21 | source(...) | main.rs:1:1:3:1 | fn source |
 | main.rs:54:5:54:14 | data_in(...) | main.rs:48:1:50:1 | fn data_in |
@@ -25,7 +25,7 @@
 | main.rs:83:5:83:11 | sink(...) | main.rs:5:1:7:1 | fn sink |
 | main.rs:95:9:95:15 | sink(...) | main.rs:5:1:7:1 | fn sink |
 | main.rs:102:13:102:21 | source(...) | main.rs:1:1:3:1 | fn source |
-| main.rs:117:13:117:25 | mn.get_data(...) | main.rs:98:5:104:5 | fn get_data |
+| main.rs:117:13:117:25 | mn.get_data() | main.rs:98:5:104:5 | fn get_data |
 | main.rs:118:5:118:11 | sink(...) | main.rs:5:1:7:1 | fn sink |
 | main.rs:123:13:123:21 | source(...) | main.rs:1:1:3:1 | fn source |
 | main.rs:124:5:124:17 | mn.data_in(...) | main.rs:94:5:96:5 | fn data_in |

--- a/rust/ql/test/library-tests/dataflow/local/DataFlowStep.expected
+++ b/rust/ql/test/library-tests/dataflow/local/DataFlowStep.expected
@@ -330,13 +330,13 @@ localStep
 | main.rs:271:29:271:30 | [post] receiver for r1 | main.rs:271:29:271:30 | [post] r1 |
 | main.rs:271:29:271:30 | r1 | main.rs:271:29:271:30 | receiver for r1 |
 | main.rs:271:29:271:30 | r1 | main.rs:272:29:272:30 | r1 |
-| main.rs:271:29:271:35 | r1.ok(...) | main.rs:271:9:271:11 | o1a |
+| main.rs:271:29:271:35 | r1.ok() | main.rs:271:9:271:11 | o1a |
 | main.rs:272:9:272:11 | [SSA] o1b | main.rs:274:10:274:12 | o1b |
 | main.rs:272:9:272:11 | o1b | main.rs:272:9:272:11 | [SSA] o1b |
 | main.rs:272:9:272:11 | o1b | main.rs:272:9:272:11 | o1b |
 | main.rs:272:29:272:30 | [post] receiver for r1 | main.rs:272:29:272:30 | [post] r1 |
 | main.rs:272:29:272:30 | r1 | main.rs:272:29:272:30 | receiver for r1 |
-| main.rs:272:29:272:36 | r1.err(...) | main.rs:272:9:272:11 | o1b |
+| main.rs:272:29:272:36 | r1.err() | main.rs:272:9:272:11 | o1b |
 | main.rs:273:10:273:12 | [post] receiver for o1a | main.rs:273:10:273:12 | [post] o1a |
 | main.rs:273:10:273:12 | o1a | main.rs:273:10:273:12 | receiver for o1a |
 | main.rs:274:10:274:12 | [post] receiver for o1b | main.rs:274:10:274:12 | [post] o1b |
@@ -352,13 +352,13 @@ localStep
 | main.rs:277:29:277:30 | [post] receiver for r2 | main.rs:277:29:277:30 | [post] r2 |
 | main.rs:277:29:277:30 | r2 | main.rs:277:29:277:30 | receiver for r2 |
 | main.rs:277:29:277:30 | r2 | main.rs:278:29:278:30 | r2 |
-| main.rs:277:29:277:35 | r2.ok(...) | main.rs:277:9:277:11 | o2a |
+| main.rs:277:29:277:35 | r2.ok() | main.rs:277:9:277:11 | o2a |
 | main.rs:278:9:278:11 | [SSA] o2b | main.rs:280:10:280:12 | o2b |
 | main.rs:278:9:278:11 | o2b | main.rs:278:9:278:11 | [SSA] o2b |
 | main.rs:278:9:278:11 | o2b | main.rs:278:9:278:11 | o2b |
 | main.rs:278:29:278:30 | [post] receiver for r2 | main.rs:278:29:278:30 | [post] r2 |
 | main.rs:278:29:278:30 | r2 | main.rs:278:29:278:30 | receiver for r2 |
-| main.rs:278:29:278:36 | r2.err(...) | main.rs:278:9:278:11 | o2b |
+| main.rs:278:29:278:36 | r2.err() | main.rs:278:9:278:11 | o2b |
 | main.rs:279:10:279:12 | [post] receiver for o2a | main.rs:279:10:279:12 | [post] o2a |
 | main.rs:279:10:279:12 | o2a | main.rs:279:10:279:12 | receiver for o2a |
 | main.rs:280:10:280:12 | [post] receiver for o2b | main.rs:280:10:280:12 | [post] o2b |
@@ -646,8 +646,8 @@ localStep
 | main.rs:441:9:441:20 | default_name | main.rs:441:9:441:20 | default_name |
 | main.rs:441:24:441:33 | [post] receiver for source(...) | main.rs:441:24:441:33 | [post] source(...) |
 | main.rs:441:24:441:33 | source(...) | main.rs:441:24:441:33 | receiver for source(...) |
-| main.rs:441:24:441:45 | ... .to_string(...) | main.rs:441:9:441:20 | default_name |
-| main.rs:441:24:441:45 | ... .to_string(...) | main.rs:442:9:442:20 | SSA phi read(default_name) |
+| main.rs:441:24:441:45 | ... .to_string() | main.rs:441:9:441:20 | default_name |
+| main.rs:441:24:441:45 | ... .to_string() | main.rs:442:9:442:20 | SSA phi read(default_name) |
 | main.rs:442:5:448:5 | for ... in ... { ... } | main.rs:440:75:449:1 | { ... } |
 | main.rs:442:9:442:20 | SSA phi read(default_name) | main.rs:444:41:444:67 | default_name |
 | main.rs:442:10:442:13 | [SSA] cond | main.rs:443:12:443:15 | cond |
@@ -692,7 +692,7 @@ localStep
 | main.rs:468:13:468:13 | [post] receiver for a | main.rs:468:13:468:13 | [post] a |
 | main.rs:468:13:468:13 | a | main.rs:468:13:468:13 | receiver for a |
 | main.rs:468:13:468:13 | a | main.rs:472:10:472:10 | a |
-| main.rs:468:13:468:25 | a.to_string(...) | main.rs:468:9:468:9 | b |
+| main.rs:468:13:468:25 | a.to_string() | main.rs:468:9:468:9 | b |
 | main.rs:469:9:469:9 | [SSA] c | main.rs:474:10:474:10 | c |
 | main.rs:469:9:469:9 | c | main.rs:469:9:469:9 | [SSA] c |
 | main.rs:469:9:469:9 | c | main.rs:469:9:469:9 | c |
@@ -700,9 +700,9 @@ localStep
 | main.rs:469:13:469:13 | [post] receiver for b | main.rs:469:13:469:13 | [post] b |
 | main.rs:469:13:469:13 | b | main.rs:469:13:469:13 | receiver for b |
 | main.rs:469:13:469:13 | b | main.rs:470:19:470:19 | b |
-| main.rs:469:13:469:28 | [post] receiver for b.parse(...) | main.rs:469:13:469:28 | [post] b.parse(...) |
-| main.rs:469:13:469:28 | b.parse(...) | main.rs:469:13:469:28 | receiver for b.parse(...) |
-| main.rs:469:13:469:37 | ... .unwrap(...) | main.rs:469:9:469:9 | c |
+| main.rs:469:13:469:28 | [post] receiver for b.parse() | main.rs:469:13:469:28 | [post] b.parse() |
+| main.rs:469:13:469:28 | b.parse() | main.rs:469:13:469:28 | receiver for b.parse() |
+| main.rs:469:13:469:37 | ... .unwrap() | main.rs:469:9:469:9 | c |
 | main.rs:470:9:470:9 | [SSA] d | main.rs:475:10:475:10 | d |
 | main.rs:470:9:470:9 | d | main.rs:470:9:470:9 | [SSA] d |
 | main.rs:470:9:470:9 | d | main.rs:470:9:470:9 | d |
@@ -710,9 +710,9 @@ localStep
 | main.rs:470:19:470:19 | [post] receiver for b | main.rs:470:19:470:19 | [post] b |
 | main.rs:470:19:470:19 | b | main.rs:470:19:470:19 | receiver for b |
 | main.rs:470:19:470:19 | b | main.rs:473:17:473:17 | b |
-| main.rs:470:19:470:27 | [post] receiver for b.parse(...) | main.rs:470:19:470:27 | [post] b.parse(...) |
-| main.rs:470:19:470:27 | b.parse(...) | main.rs:470:19:470:27 | receiver for b.parse(...) |
-| main.rs:470:19:470:36 | ... .unwrap(...) | main.rs:470:9:470:9 | d |
+| main.rs:470:19:470:27 | [post] receiver for b.parse() | main.rs:470:19:470:27 | [post] b.parse() |
+| main.rs:470:19:470:27 | b.parse() | main.rs:470:19:470:27 | receiver for b.parse() |
+| main.rs:470:19:470:36 | ... .unwrap() | main.rs:470:9:470:9 | d |
 | main.rs:479:9:479:10 | [SSA] vs | main.rs:481:10:481:11 | vs |
 | main.rs:479:9:479:10 | vs | main.rs:479:9:479:10 | [SSA] vs |
 | main.rs:479:9:479:10 | vs | main.rs:479:9:479:10 | vs |
@@ -723,16 +723,16 @@ localStep
 | main.rs:482:11:482:12 | [post] vs | main.rs:483:11:483:12 | vs |
 | main.rs:482:11:482:12 | vs | main.rs:482:11:482:12 | receiver for vs |
 | main.rs:482:11:482:12 | vs | main.rs:483:11:483:12 | vs |
-| main.rs:482:11:482:19 | [post] receiver for vs.iter(...) | main.rs:482:11:482:19 | [post] vs.iter(...) |
-| main.rs:482:11:482:19 | vs.iter(...) | main.rs:482:11:482:19 | receiver for vs.iter(...) |
-| main.rs:482:11:482:26 | ... .next(...) | main.rs:482:11:482:26 | receiver for ... .next(...) |
-| main.rs:482:11:482:26 | [post] receiver for ... .next(...) | main.rs:482:11:482:26 | [post] ... .next(...) |
+| main.rs:482:11:482:19 | [post] receiver for vs.iter() | main.rs:482:11:482:19 | [post] vs.iter() |
+| main.rs:482:11:482:19 | vs.iter() | main.rs:482:11:482:19 | receiver for vs.iter() |
+| main.rs:482:11:482:26 | ... .next() | main.rs:482:11:482:26 | receiver for ... .next() |
+| main.rs:482:11:482:26 | [post] receiver for ... .next() | main.rs:482:11:482:26 | [post] ... .next() |
 | main.rs:483:11:483:12 | [post] receiver for vs | main.rs:483:11:483:12 | [post] vs |
 | main.rs:483:11:483:12 | [post] vs | main.rs:485:14:485:15 | vs |
 | main.rs:483:11:483:12 | vs | main.rs:483:11:483:12 | receiver for vs |
 | main.rs:483:11:483:12 | vs | main.rs:485:14:485:15 | vs |
-| main.rs:483:11:483:19 | [post] receiver for vs.iter(...) | main.rs:483:11:483:19 | [post] vs.iter(...) |
-| main.rs:483:11:483:19 | vs.iter(...) | main.rs:483:11:483:19 | receiver for vs.iter(...) |
+| main.rs:483:11:483:19 | [post] receiver for vs.iter() | main.rs:483:11:483:19 | [post] vs.iter() |
+| main.rs:483:11:483:19 | vs.iter() | main.rs:483:11:483:19 | receiver for vs.iter() |
 | main.rs:483:11:483:26 | ... .nth(...) | main.rs:483:11:483:26 | receiver for ... .nth(...) |
 | main.rs:483:11:483:26 | [post] receiver for ... .nth(...) | main.rs:483:11:483:26 | [post] ... .nth(...) |
 | main.rs:485:9:485:9 | [SSA] v | main.rs:486:14:486:14 | v |
@@ -753,9 +753,9 @@ localStep
 | main.rs:492:27:492:28 | [post] vs | main.rs:497:5:497:6 | vs |
 | main.rs:492:27:492:28 | vs | main.rs:492:27:492:28 | receiver for vs |
 | main.rs:492:27:492:28 | vs | main.rs:497:5:497:6 | vs |
-| main.rs:492:27:492:35 | [post] receiver for vs.iter(...) | main.rs:492:27:492:35 | [post] vs.iter(...) |
-| main.rs:492:27:492:35 | vs.iter(...) | main.rs:492:27:492:35 | receiver for vs.iter(...) |
-| main.rs:492:27:492:45 | ... .collect(...) | main.rs:492:9:492:11 | vs2 |
+| main.rs:492:27:492:35 | [post] receiver for vs.iter() | main.rs:492:27:492:35 | [post] vs.iter() |
+| main.rs:492:27:492:35 | vs.iter() | main.rs:492:27:492:35 | receiver for vs.iter() |
+| main.rs:492:27:492:45 | ... .collect() | main.rs:492:9:492:11 | vs2 |
 | main.rs:493:10:493:10 | [SSA] v | main.rs:494:14:494:14 | v |
 | main.rs:493:10:493:10 | v | main.rs:493:10:493:10 | [SSA] v |
 | main.rs:493:10:493:10 | v | main.rs:493:10:493:10 | v |
@@ -763,8 +763,8 @@ localStep
 | main.rs:497:5:497:6 | [post] vs | main.rs:498:5:498:6 | vs |
 | main.rs:497:5:497:6 | vs | main.rs:497:5:497:6 | receiver for vs |
 | main.rs:497:5:497:6 | vs | main.rs:498:5:498:6 | vs |
-| main.rs:497:5:497:13 | [post] receiver for vs.iter(...) | main.rs:497:5:497:13 | [post] vs.iter(...) |
-| main.rs:497:5:497:13 | vs.iter(...) | main.rs:497:5:497:13 | receiver for vs.iter(...) |
+| main.rs:497:5:497:13 | [post] receiver for vs.iter() | main.rs:497:5:497:13 | [post] vs.iter() |
+| main.rs:497:5:497:13 | vs.iter() | main.rs:497:5:497:13 | receiver for vs.iter() |
 | main.rs:497:20:497:20 | ... | main.rs:497:20:497:20 | x |
 | main.rs:497:20:497:20 | [SSA] x | main.rs:497:29:497:29 | x |
 | main.rs:497:20:497:20 | x | main.rs:497:20:497:20 | [SSA] x |
@@ -773,8 +773,8 @@ localStep
 | main.rs:498:5:498:6 | [post] vs | main.rs:500:14:500:15 | vs |
 | main.rs:498:5:498:6 | vs | main.rs:498:5:498:6 | receiver for vs |
 | main.rs:498:5:498:6 | vs | main.rs:500:14:500:15 | vs |
-| main.rs:498:5:498:13 | [post] receiver for vs.iter(...) | main.rs:498:5:498:13 | [post] vs.iter(...) |
-| main.rs:498:5:498:13 | vs.iter(...) | main.rs:498:5:498:13 | receiver for vs.iter(...) |
+| main.rs:498:5:498:13 | [post] receiver for vs.iter() | main.rs:498:5:498:13 | [post] vs.iter() |
+| main.rs:498:5:498:13 | vs.iter() | main.rs:498:5:498:13 | receiver for vs.iter() |
 | main.rs:498:25:498:25 | ... | main.rs:498:25:498:25 | x |
 | main.rs:498:25:498:25 | [SSA] x | main.rs:498:34:498:34 | x |
 | main.rs:498:25:498:25 | x | main.rs:498:25:498:25 | [SSA] x |
@@ -800,17 +800,17 @@ localStep
 | main.rs:507:11:507:16 | vs_mut | main.rs:507:11:507:16 | receiver for vs_mut |
 | main.rs:507:11:507:16 | vs_mut | main.rs:508:11:508:16 | [SSA] vs_mut |
 | main.rs:507:11:507:16 | vs_mut | main.rs:508:11:508:16 | vs_mut |
-| main.rs:507:11:507:23 | [post] receiver for vs_mut.iter(...) | main.rs:507:11:507:23 | [post] vs_mut.iter(...) |
-| main.rs:507:11:507:23 | vs_mut.iter(...) | main.rs:507:11:507:23 | receiver for vs_mut.iter(...) |
-| main.rs:507:11:507:30 | ... .next(...) | main.rs:507:11:507:30 | receiver for ... .next(...) |
-| main.rs:507:11:507:30 | [post] receiver for ... .next(...) | main.rs:507:11:507:30 | [post] ... .next(...) |
+| main.rs:507:11:507:23 | [post] receiver for vs_mut.iter() | main.rs:507:11:507:23 | [post] vs_mut.iter() |
+| main.rs:507:11:507:23 | vs_mut.iter() | main.rs:507:11:507:23 | receiver for vs_mut.iter() |
+| main.rs:507:11:507:30 | ... .next() | main.rs:507:11:507:30 | receiver for ... .next() |
+| main.rs:507:11:507:30 | [post] receiver for ... .next() | main.rs:507:11:507:30 | [post] ... .next() |
 | main.rs:508:11:508:16 | [SSA] vs_mut | main.rs:510:19:510:24 | vs_mut |
 | main.rs:508:11:508:16 | [post] receiver for vs_mut | main.rs:508:11:508:16 | [post] vs_mut |
 | main.rs:508:11:508:16 | [post] vs_mut | main.rs:510:19:510:24 | vs_mut |
 | main.rs:508:11:508:16 | vs_mut | main.rs:508:11:508:16 | receiver for vs_mut |
 | main.rs:508:11:508:16 | vs_mut | main.rs:510:19:510:24 | vs_mut |
-| main.rs:508:11:508:23 | [post] receiver for vs_mut.iter(...) | main.rs:508:11:508:23 | [post] vs_mut.iter(...) |
-| main.rs:508:11:508:23 | vs_mut.iter(...) | main.rs:508:11:508:23 | receiver for vs_mut.iter(...) |
+| main.rs:508:11:508:23 | [post] receiver for vs_mut.iter() | main.rs:508:11:508:23 | [post] vs_mut.iter() |
+| main.rs:508:11:508:23 | vs_mut.iter() | main.rs:508:11:508:23 | receiver for vs_mut.iter() |
 | main.rs:508:11:508:30 | ... .nth(...) | main.rs:508:11:508:30 | receiver for ... .nth(...) |
 | main.rs:508:11:508:30 | [post] receiver for ... .nth(...) | main.rs:508:11:508:30 | [post] ... .nth(...) |
 | main.rs:510:5:512:5 | for ... in ... { ... } | main.rs:478:16:513:1 | { ... } |
@@ -3037,13 +3037,13 @@ readStep
 | main.rs:470:19:470:19 | b | &ref | main.rs:470:19:470:19 | receiver for b |
 | main.rs:481:10:481:11 | vs | element | main.rs:481:10:481:14 | vs[0] |
 | main.rs:482:11:482:12 | vs | &ref | main.rs:482:11:482:12 | receiver for vs |
-| main.rs:482:11:482:35 | ... .unwrap(...) | &ref | main.rs:482:10:482:35 | * ... |
+| main.rs:482:11:482:35 | ... .unwrap() | &ref | main.rs:482:10:482:35 | * ... |
 | main.rs:483:11:483:12 | vs | &ref | main.rs:483:11:483:12 | receiver for vs |
-| main.rs:483:11:483:35 | ... .unwrap(...) | &ref | main.rs:483:10:483:35 | * ... |
+| main.rs:483:11:483:35 | ... .unwrap() | &ref | main.rs:483:10:483:35 | * ... |
 | main.rs:485:14:485:15 | vs | element | main.rs:485:9:485:9 | v |
 | main.rs:488:9:488:10 | &... | &ref | main.rs:488:10:488:10 | v |
 | main.rs:488:15:488:16 | vs | &ref | main.rs:488:15:488:16 | receiver for vs |
-| main.rs:488:15:488:23 | vs.iter(...) | element | main.rs:488:9:488:10 | &... |
+| main.rs:488:15:488:23 | vs.iter() | element | main.rs:488:9:488:10 | &... |
 | main.rs:492:27:492:28 | vs | &ref | main.rs:492:27:492:28 | receiver for vs |
 | main.rs:493:9:493:10 | &... | &ref | main.rs:493:10:493:10 | v |
 | main.rs:493:15:493:17 | vs2 | element | main.rs:493:9:493:10 | &... |
@@ -3052,15 +3052,15 @@ readStep
 | main.rs:498:5:498:6 | vs | &ref | main.rs:498:5:498:6 | receiver for vs |
 | main.rs:498:34:498:34 | x | &ref | main.rs:498:33:498:34 | * ... |
 | main.rs:500:14:500:15 | vs | &ref | main.rs:500:14:500:15 | receiver for vs |
-| main.rs:500:14:500:27 | vs.into_iter(...) | element | main.rs:500:9:500:9 | v |
+| main.rs:500:14:500:27 | vs.into_iter() | element | main.rs:500:9:500:9 | v |
 | main.rs:506:10:506:15 | vs_mut | element | main.rs:506:10:506:18 | vs_mut[0] |
 | main.rs:507:11:507:16 | vs_mut | &ref | main.rs:507:11:507:16 | receiver for vs_mut |
-| main.rs:507:11:507:39 | ... .unwrap(...) | &ref | main.rs:507:10:507:39 | * ... |
+| main.rs:507:11:507:39 | ... .unwrap() | &ref | main.rs:507:10:507:39 | * ... |
 | main.rs:508:11:508:16 | vs_mut | &ref | main.rs:508:11:508:16 | receiver for vs_mut |
-| main.rs:508:11:508:39 | ... .unwrap(...) | &ref | main.rs:508:10:508:39 | * ... |
+| main.rs:508:11:508:39 | ... .unwrap() | &ref | main.rs:508:10:508:39 | * ... |
 | main.rs:510:9:510:14 | &mut ... | &ref | main.rs:510:14:510:14 | v |
 | main.rs:510:19:510:24 | vs_mut | &ref | main.rs:510:19:510:24 | receiver for vs_mut |
-| main.rs:510:19:510:35 | vs_mut.iter_mut(...) | element | main.rs:510:9:510:14 | &mut ... |
+| main.rs:510:19:510:35 | vs_mut.iter_mut() | element | main.rs:510:9:510:14 | &mut ... |
 | main.rs:524:11:524:15 | c_ref | &ref | main.rs:524:10:524:15 | * ... |
 | main.rs:531:10:531:10 | a | &ref | main.rs:531:10:531:10 | receiver for a |
 | main.rs:537:10:537:10 | b | &ref | main.rs:537:10:537:10 | receiver for b |

--- a/rust/ql/test/library-tests/dataflow/local/inline-flow.expected
+++ b/rust/ql/test/library-tests/dataflow/local/inline-flow.expected
@@ -95,7 +95,7 @@ edges
 | main.rs:229:11:229:12 | s1 [Some] | main.rs:230:9:230:15 | Some(...) [Some] | provenance |  |
 | main.rs:230:9:230:15 | Some(...) [Some] | main.rs:230:14:230:14 | n | provenance |  |
 | main.rs:230:14:230:14 | n | main.rs:230:25:230:25 | n | provenance |  |
-| main.rs:240:9:240:10 | s1 [Some] | main.rs:241:10:241:20 | s1.unwrap(...) | provenance | MaD:2 |
+| main.rs:240:9:240:10 | s1 [Some] | main.rs:241:10:241:20 | s1.unwrap() | provenance | MaD:2 |
 | main.rs:240:14:240:29 | Some(...) [Some] | main.rs:240:9:240:10 | s1 [Some] | provenance |  |
 | main.rs:240:19:240:28 | source(...) | main.rs:240:14:240:29 | Some(...) [Some] | provenance |  |
 | main.rs:245:9:245:10 | s1 [Some] | main.rs:246:10:246:24 | s1.unwrap_or(...) | provenance | MaD:4 |
@@ -112,16 +112,16 @@ edges
 | main.rs:263:9:263:10 | i1 | main.rs:264:10:264:11 | i1 | provenance |  |
 | main.rs:263:14:263:15 | s1 [Some] | main.rs:263:14:263:16 | TryExpr | provenance |  |
 | main.rs:263:14:263:16 | TryExpr | main.rs:263:9:263:10 | i1 | provenance |  |
-| main.rs:270:9:270:10 | r1 [Ok] | main.rs:271:29:271:35 | r1.ok(...) [Some] | provenance | MaD:10 |
+| main.rs:270:9:270:10 | r1 [Ok] | main.rs:271:29:271:35 | r1.ok() [Some] | provenance | MaD:10 |
 | main.rs:270:33:270:46 | Ok(...) [Ok] | main.rs:270:9:270:10 | r1 [Ok] | provenance |  |
 | main.rs:270:36:270:45 | source(...) | main.rs:270:33:270:46 | Ok(...) [Ok] | provenance |  |
-| main.rs:271:9:271:11 | o1a [Some] | main.rs:273:10:273:21 | o1a.unwrap(...) | provenance | MaD:2 |
-| main.rs:271:29:271:35 | r1.ok(...) [Some] | main.rs:271:9:271:11 | o1a [Some] | provenance |  |
-| main.rs:276:9:276:10 | r2 [Err] | main.rs:278:29:278:36 | r2.err(...) [Some] | provenance | MaD:7 |
+| main.rs:271:9:271:11 | o1a [Some] | main.rs:273:10:273:21 | o1a.unwrap() | provenance | MaD:2 |
+| main.rs:271:29:271:35 | r1.ok() [Some] | main.rs:271:9:271:11 | o1a [Some] | provenance |  |
+| main.rs:276:9:276:10 | r2 [Err] | main.rs:278:29:278:36 | r2.err() [Some] | provenance | MaD:7 |
 | main.rs:276:33:276:47 | Err(...) [Err] | main.rs:276:9:276:10 | r2 [Err] | provenance |  |
 | main.rs:276:37:276:46 | source(...) | main.rs:276:33:276:47 | Err(...) [Err] | provenance |  |
-| main.rs:278:9:278:11 | o2b [Some] | main.rs:280:10:280:21 | o2b.unwrap(...) | provenance | MaD:2 |
-| main.rs:278:29:278:36 | r2.err(...) [Some] | main.rs:278:9:278:11 | o2b [Some] | provenance |  |
+| main.rs:278:9:278:11 | o2b [Some] | main.rs:280:10:280:21 | o2b.unwrap() | provenance | MaD:2 |
+| main.rs:278:29:278:36 | r2.err() [Some] | main.rs:278:9:278:11 | o2b [Some] | provenance |  |
 | main.rs:284:9:284:10 | s1 [Ok] | main.rs:287:14:287:15 | s1 [Ok] | provenance |  |
 | main.rs:284:32:284:45 | Ok(...) [Ok] | main.rs:284:9:284:10 | s1 [Ok] | provenance |  |
 | main.rs:284:35:284:44 | source(...) | main.rs:284:32:284:45 | Ok(...) [Ok] | provenance |  |
@@ -342,7 +342,7 @@ nodes
 | main.rs:240:9:240:10 | s1 [Some] | semmle.label | s1 [Some] |
 | main.rs:240:14:240:29 | Some(...) [Some] | semmle.label | Some(...) [Some] |
 | main.rs:240:19:240:28 | source(...) | semmle.label | source(...) |
-| main.rs:241:10:241:20 | s1.unwrap(...) | semmle.label | s1.unwrap(...) |
+| main.rs:241:10:241:20 | s1.unwrap() | semmle.label | s1.unwrap() |
 | main.rs:245:9:245:10 | s1 [Some] | semmle.label | s1 [Some] |
 | main.rs:245:14:245:29 | Some(...) [Some] | semmle.label | Some(...) [Some] |
 | main.rs:245:19:245:28 | source(...) | semmle.label | source(...) |
@@ -366,14 +366,14 @@ nodes
 | main.rs:270:33:270:46 | Ok(...) [Ok] | semmle.label | Ok(...) [Ok] |
 | main.rs:270:36:270:45 | source(...) | semmle.label | source(...) |
 | main.rs:271:9:271:11 | o1a [Some] | semmle.label | o1a [Some] |
-| main.rs:271:29:271:35 | r1.ok(...) [Some] | semmle.label | r1.ok(...) [Some] |
-| main.rs:273:10:273:21 | o1a.unwrap(...) | semmle.label | o1a.unwrap(...) |
+| main.rs:271:29:271:35 | r1.ok() [Some] | semmle.label | r1.ok() [Some] |
+| main.rs:273:10:273:21 | o1a.unwrap() | semmle.label | o1a.unwrap() |
 | main.rs:276:9:276:10 | r2 [Err] | semmle.label | r2 [Err] |
 | main.rs:276:33:276:47 | Err(...) [Err] | semmle.label | Err(...) [Err] |
 | main.rs:276:37:276:46 | source(...) | semmle.label | source(...) |
 | main.rs:278:9:278:11 | o2b [Some] | semmle.label | o2b [Some] |
-| main.rs:278:29:278:36 | r2.err(...) [Some] | semmle.label | r2.err(...) [Some] |
-| main.rs:280:10:280:21 | o2b.unwrap(...) | semmle.label | o2b.unwrap(...) |
+| main.rs:278:29:278:36 | r2.err() [Some] | semmle.label | r2.err() [Some] |
+| main.rs:280:10:280:21 | o2b.unwrap() | semmle.label | o2b.unwrap() |
 | main.rs:284:9:284:10 | s1 [Ok] | semmle.label | s1 [Ok] |
 | main.rs:284:32:284:45 | Ok(...) [Ok] | semmle.label | Ok(...) [Ok] |
 | main.rs:284:35:284:44 | source(...) | semmle.label | source(...) |
@@ -528,14 +528,14 @@ testFailures
 | main.rs:204:18:204:18 | x | main.rs:198:27:198:36 | source(...) | main.rs:204:18:204:18 | x | $@ | main.rs:198:27:198:36 | source(...) | source(...) |
 | main.rs:217:33:217:33 | n | main.rs:214:27:214:36 | source(...) | main.rs:217:33:217:33 | n | $@ | main.rs:214:27:214:36 | source(...) | source(...) |
 | main.rs:230:25:230:25 | n | main.rs:227:19:227:28 | source(...) | main.rs:230:25:230:25 | n | $@ | main.rs:227:19:227:28 | source(...) | source(...) |
-| main.rs:241:10:241:20 | s1.unwrap(...) | main.rs:240:19:240:28 | source(...) | main.rs:241:10:241:20 | s1.unwrap(...) | $@ | main.rs:240:19:240:28 | source(...) | source(...) |
+| main.rs:241:10:241:20 | s1.unwrap() | main.rs:240:19:240:28 | source(...) | main.rs:241:10:241:20 | s1.unwrap() | $@ | main.rs:240:19:240:28 | source(...) | source(...) |
 | main.rs:246:10:246:24 | s1.unwrap_or(...) | main.rs:245:19:245:28 | source(...) | main.rs:246:10:246:24 | s1.unwrap_or(...) | $@ | main.rs:245:19:245:28 | source(...) | source(...) |
 | main.rs:249:10:249:33 | s2.unwrap_or(...) | main.rs:249:23:249:32 | source(...) | main.rs:249:10:249:33 | s2.unwrap_or(...) | $@ | main.rs:249:23:249:32 | source(...) | source(...) |
 | main.rs:254:10:254:32 | s1.unwrap_or_else(...) | main.rs:253:19:253:28 | source(...) | main.rs:254:10:254:32 | s1.unwrap_or_else(...) | $@ | main.rs:253:19:253:28 | source(...) | source(...) |
 | main.rs:257:10:257:41 | s2.unwrap_or_else(...) | main.rs:257:31:257:40 | source(...) | main.rs:257:10:257:41 | s2.unwrap_or_else(...) | $@ | main.rs:257:31:257:40 | source(...) | source(...) |
 | main.rs:264:10:264:11 | i1 | main.rs:261:19:261:28 | source(...) | main.rs:264:10:264:11 | i1 | $@ | main.rs:261:19:261:28 | source(...) | source(...) |
-| main.rs:273:10:273:21 | o1a.unwrap(...) | main.rs:270:36:270:45 | source(...) | main.rs:273:10:273:21 | o1a.unwrap(...) | $@ | main.rs:270:36:270:45 | source(...) | source(...) |
-| main.rs:280:10:280:21 | o2b.unwrap(...) | main.rs:276:37:276:46 | source(...) | main.rs:280:10:280:21 | o2b.unwrap(...) | $@ | main.rs:276:37:276:46 | source(...) | source(...) |
+| main.rs:273:10:273:21 | o1a.unwrap() | main.rs:270:36:270:45 | source(...) | main.rs:273:10:273:21 | o1a.unwrap() | $@ | main.rs:270:36:270:45 | source(...) | source(...) |
+| main.rs:280:10:280:21 | o2b.unwrap() | main.rs:276:37:276:46 | source(...) | main.rs:280:10:280:21 | o2b.unwrap() | $@ | main.rs:276:37:276:46 | source(...) | source(...) |
 | main.rs:289:10:289:11 | i1 | main.rs:284:35:284:44 | source(...) | main.rs:289:10:289:11 | i1 | $@ | main.rs:284:35:284:44 | source(...) | source(...) |
 | main.rs:298:10:298:22 | s1.expect(...) | main.rs:297:35:297:44 | source(...) | main.rs:298:10:298:22 | s1.expect(...) | $@ | main.rs:297:35:297:44 | source(...) | source(...) |
 | main.rs:303:10:303:26 | s2.expect_err(...) | main.rs:301:36:301:45 | source(...) | main.rs:303:10:303:26 | s2.expect_err(...) | $@ | main.rs:301:36:301:45 | source(...) | source(...) |

--- a/rust/ql/test/library-tests/dataflow/modeled/inline-flow.expected
+++ b/rust/ql/test/library-tests/dataflow/modeled/inline-flow.expected
@@ -7,34 +7,34 @@ models
 | 6 | Summary: lang:core; crate::ptr::read; Argument[0].Reference; ReturnValue; value |
 | 7 | Summary: lang:core; crate::ptr::write; Argument[1]; Argument[0].Reference; value |
 edges
-| main.rs:12:9:12:9 | a [Some] | main.rs:13:10:13:19 | a.unwrap(...) | provenance | MaD:2 |
-| main.rs:12:9:12:9 | a [Some] | main.rs:14:13:14:21 | a.clone(...) [Some] | provenance | MaD:1 |
-| main.rs:12:9:12:9 | a [Some] | main.rs:14:13:14:21 | a.clone(...) [Some] | provenance | generated |
+| main.rs:12:9:12:9 | a [Some] | main.rs:13:10:13:19 | a.unwrap() | provenance | MaD:2 |
+| main.rs:12:9:12:9 | a [Some] | main.rs:14:13:14:21 | a.clone() [Some] | provenance | MaD:1 |
+| main.rs:12:9:12:9 | a [Some] | main.rs:14:13:14:21 | a.clone() [Some] | provenance | generated |
 | main.rs:12:13:12:28 | Some(...) [Some] | main.rs:12:9:12:9 | a [Some] | provenance |  |
 | main.rs:12:18:12:27 | source(...) | main.rs:12:13:12:28 | Some(...) [Some] | provenance |  |
-| main.rs:14:9:14:9 | b [Some] | main.rs:15:10:15:19 | b.unwrap(...) | provenance | MaD:2 |
-| main.rs:14:13:14:21 | a.clone(...) [Some] | main.rs:14:9:14:9 | b [Some] | provenance |  |
-| main.rs:19:9:19:9 | a [Ok] | main.rs:20:10:20:19 | a.unwrap(...) | provenance | MaD:5 |
-| main.rs:19:9:19:9 | a [Ok] | main.rs:21:13:21:21 | a.clone(...) [Ok] | provenance | MaD:4 |
-| main.rs:19:9:19:9 | a [Ok] | main.rs:21:13:21:21 | a.clone(...) [Ok] | provenance | generated |
+| main.rs:14:9:14:9 | b [Some] | main.rs:15:10:15:19 | b.unwrap() | provenance | MaD:2 |
+| main.rs:14:13:14:21 | a.clone() [Some] | main.rs:14:9:14:9 | b [Some] | provenance |  |
+| main.rs:19:9:19:9 | a [Ok] | main.rs:20:10:20:19 | a.unwrap() | provenance | MaD:5 |
+| main.rs:19:9:19:9 | a [Ok] | main.rs:21:13:21:21 | a.clone() [Ok] | provenance | MaD:4 |
+| main.rs:19:9:19:9 | a [Ok] | main.rs:21:13:21:21 | a.clone() [Ok] | provenance | generated |
 | main.rs:19:31:19:44 | Ok(...) [Ok] | main.rs:19:9:19:9 | a [Ok] | provenance |  |
 | main.rs:19:34:19:43 | source(...) | main.rs:19:31:19:44 | Ok(...) [Ok] | provenance |  |
-| main.rs:21:9:21:9 | b [Ok] | main.rs:22:10:22:19 | b.unwrap(...) | provenance | MaD:5 |
-| main.rs:21:13:21:21 | a.clone(...) [Ok] | main.rs:21:9:21:9 | b [Ok] | provenance |  |
+| main.rs:21:9:21:9 | b [Ok] | main.rs:22:10:22:19 | b.unwrap() | provenance | MaD:5 |
+| main.rs:21:13:21:21 | a.clone() [Ok] | main.rs:21:9:21:9 | b [Ok] | provenance |  |
 | main.rs:26:9:26:9 | a | main.rs:27:10:27:10 | a | provenance |  |
-| main.rs:26:9:26:9 | a | main.rs:28:13:28:21 | a.clone(...) | provenance | generated |
+| main.rs:26:9:26:9 | a | main.rs:28:13:28:21 | a.clone() | provenance | generated |
 | main.rs:26:13:26:22 | source(...) | main.rs:26:9:26:9 | a | provenance |  |
 | main.rs:28:9:28:9 | b | main.rs:29:10:29:10 | b | provenance |  |
-| main.rs:28:13:28:21 | a.clone(...) | main.rs:28:9:28:9 | b | provenance |  |
+| main.rs:28:13:28:21 | a.clone() | main.rs:28:9:28:9 | b | provenance |  |
 | main.rs:41:13:41:13 | w [Wrapper] | main.rs:42:15:42:15 | w [Wrapper] | provenance |  |
 | main.rs:41:17:41:41 | Wrapper {...} [Wrapper] | main.rs:41:13:41:13 | w [Wrapper] | provenance |  |
 | main.rs:41:30:41:39 | source(...) | main.rs:41:17:41:41 | Wrapper {...} [Wrapper] | provenance |  |
 | main.rs:42:15:42:15 | w [Wrapper] | main.rs:43:13:43:28 | Wrapper {...} [Wrapper] | provenance |  |
-| main.rs:42:15:42:15 | w [Wrapper] | main.rs:45:17:45:25 | w.clone(...) [Wrapper] | provenance | generated |
+| main.rs:42:15:42:15 | w [Wrapper] | main.rs:45:17:45:25 | w.clone() [Wrapper] | provenance | generated |
 | main.rs:43:13:43:28 | Wrapper {...} [Wrapper] | main.rs:43:26:43:26 | n | provenance |  |
 | main.rs:43:26:43:26 | n | main.rs:43:38:43:38 | n | provenance |  |
 | main.rs:45:13:45:13 | u [Wrapper] | main.rs:46:15:46:15 | u [Wrapper] | provenance |  |
-| main.rs:45:17:45:25 | w.clone(...) [Wrapper] | main.rs:45:13:45:13 | u [Wrapper] | provenance |  |
+| main.rs:45:17:45:25 | w.clone() [Wrapper] | main.rs:45:13:45:13 | u [Wrapper] | provenance |  |
 | main.rs:46:15:46:15 | u [Wrapper] | main.rs:47:13:47:28 | Wrapper {...} [Wrapper] | provenance |  |
 | main.rs:47:13:47:28 | Wrapper {...} [Wrapper] | main.rs:47:26:47:26 | n | provenance |  |
 | main.rs:47:26:47:26 | n | main.rs:47:38:47:38 | n | provenance |  |
@@ -55,22 +55,22 @@ nodes
 | main.rs:12:9:12:9 | a [Some] | semmle.label | a [Some] |
 | main.rs:12:13:12:28 | Some(...) [Some] | semmle.label | Some(...) [Some] |
 | main.rs:12:18:12:27 | source(...) | semmle.label | source(...) |
-| main.rs:13:10:13:19 | a.unwrap(...) | semmle.label | a.unwrap(...) |
+| main.rs:13:10:13:19 | a.unwrap() | semmle.label | a.unwrap() |
 | main.rs:14:9:14:9 | b [Some] | semmle.label | b [Some] |
-| main.rs:14:13:14:21 | a.clone(...) [Some] | semmle.label | a.clone(...) [Some] |
-| main.rs:15:10:15:19 | b.unwrap(...) | semmle.label | b.unwrap(...) |
+| main.rs:14:13:14:21 | a.clone() [Some] | semmle.label | a.clone() [Some] |
+| main.rs:15:10:15:19 | b.unwrap() | semmle.label | b.unwrap() |
 | main.rs:19:9:19:9 | a [Ok] | semmle.label | a [Ok] |
 | main.rs:19:31:19:44 | Ok(...) [Ok] | semmle.label | Ok(...) [Ok] |
 | main.rs:19:34:19:43 | source(...) | semmle.label | source(...) |
-| main.rs:20:10:20:19 | a.unwrap(...) | semmle.label | a.unwrap(...) |
+| main.rs:20:10:20:19 | a.unwrap() | semmle.label | a.unwrap() |
 | main.rs:21:9:21:9 | b [Ok] | semmle.label | b [Ok] |
-| main.rs:21:13:21:21 | a.clone(...) [Ok] | semmle.label | a.clone(...) [Ok] |
-| main.rs:22:10:22:19 | b.unwrap(...) | semmle.label | b.unwrap(...) |
+| main.rs:21:13:21:21 | a.clone() [Ok] | semmle.label | a.clone() [Ok] |
+| main.rs:22:10:22:19 | b.unwrap() | semmle.label | b.unwrap() |
 | main.rs:26:9:26:9 | a | semmle.label | a |
 | main.rs:26:13:26:22 | source(...) | semmle.label | source(...) |
 | main.rs:27:10:27:10 | a | semmle.label | a |
 | main.rs:28:9:28:9 | b | semmle.label | b |
-| main.rs:28:13:28:21 | a.clone(...) | semmle.label | a.clone(...) |
+| main.rs:28:13:28:21 | a.clone() | semmle.label | a.clone() |
 | main.rs:29:10:29:10 | b | semmle.label | b |
 | main.rs:41:13:41:13 | w [Wrapper] | semmle.label | w [Wrapper] |
 | main.rs:41:17:41:41 | Wrapper {...} [Wrapper] | semmle.label | Wrapper {...} [Wrapper] |
@@ -80,7 +80,7 @@ nodes
 | main.rs:43:26:43:26 | n | semmle.label | n |
 | main.rs:43:38:43:38 | n | semmle.label | n |
 | main.rs:45:13:45:13 | u [Wrapper] | semmle.label | u [Wrapper] |
-| main.rs:45:17:45:25 | w.clone(...) [Wrapper] | semmle.label | w.clone(...) [Wrapper] |
+| main.rs:45:17:45:25 | w.clone() [Wrapper] | semmle.label | w.clone() [Wrapper] |
 | main.rs:46:15:46:15 | u [Wrapper] | semmle.label | u [Wrapper] |
 | main.rs:47:13:47:28 | Wrapper {...} [Wrapper] | semmle.label | Wrapper {...} [Wrapper] |
 | main.rs:47:26:47:26 | n | semmle.label | n |
@@ -103,10 +103,10 @@ nodes
 subpaths
 testFailures
 #select
-| main.rs:13:10:13:19 | a.unwrap(...) | main.rs:12:18:12:27 | source(...) | main.rs:13:10:13:19 | a.unwrap(...) | $@ | main.rs:12:18:12:27 | source(...) | source(...) |
-| main.rs:15:10:15:19 | b.unwrap(...) | main.rs:12:18:12:27 | source(...) | main.rs:15:10:15:19 | b.unwrap(...) | $@ | main.rs:12:18:12:27 | source(...) | source(...) |
-| main.rs:20:10:20:19 | a.unwrap(...) | main.rs:19:34:19:43 | source(...) | main.rs:20:10:20:19 | a.unwrap(...) | $@ | main.rs:19:34:19:43 | source(...) | source(...) |
-| main.rs:22:10:22:19 | b.unwrap(...) | main.rs:19:34:19:43 | source(...) | main.rs:22:10:22:19 | b.unwrap(...) | $@ | main.rs:19:34:19:43 | source(...) | source(...) |
+| main.rs:13:10:13:19 | a.unwrap() | main.rs:12:18:12:27 | source(...) | main.rs:13:10:13:19 | a.unwrap() | $@ | main.rs:12:18:12:27 | source(...) | source(...) |
+| main.rs:15:10:15:19 | b.unwrap() | main.rs:12:18:12:27 | source(...) | main.rs:15:10:15:19 | b.unwrap() | $@ | main.rs:12:18:12:27 | source(...) | source(...) |
+| main.rs:20:10:20:19 | a.unwrap() | main.rs:19:34:19:43 | source(...) | main.rs:20:10:20:19 | a.unwrap() | $@ | main.rs:19:34:19:43 | source(...) | source(...) |
+| main.rs:22:10:22:19 | b.unwrap() | main.rs:19:34:19:43 | source(...) | main.rs:22:10:22:19 | b.unwrap() | $@ | main.rs:19:34:19:43 | source(...) | source(...) |
 | main.rs:27:10:27:10 | a | main.rs:26:13:26:22 | source(...) | main.rs:27:10:27:10 | a | $@ | main.rs:26:13:26:22 | source(...) | source(...) |
 | main.rs:29:10:29:10 | b | main.rs:26:13:26:22 | source(...) | main.rs:29:10:29:10 | b | $@ | main.rs:26:13:26:22 | source(...) | source(...) |
 | main.rs:43:38:43:38 | n | main.rs:41:30:41:39 | source(...) | main.rs:43:38:43:38 | n | $@ | main.rs:41:30:41:39 | source(...) | source(...) |

--- a/rust/ql/test/library-tests/dataflow/pointers/inline-flow.expected
+++ b/rust/ql/test/library-tests/dataflow/pointers/inline-flow.expected
@@ -61,26 +61,26 @@ edges
 | main.rs:164:14:164:39 | ...::MyNumber(...) [MyNumber] | main.rs:164:33:164:38 | number | provenance |  |
 | main.rs:164:33:164:38 | number | main.rs:162:26:166:5 | { ... } | provenance |  |
 | main.rs:174:13:174:21 | my_number [MyNumber] | main.rs:156:18:156:21 | SelfParam [MyNumber] | provenance |  |
-| main.rs:174:13:174:21 | my_number [MyNumber] | main.rs:175:14:175:34 | my_number.to_number(...) | provenance |  |
+| main.rs:174:13:174:21 | my_number [MyNumber] | main.rs:175:14:175:34 | my_number.to_number() | provenance |  |
 | main.rs:174:25:174:54 | ...::MyNumber(...) [MyNumber] | main.rs:174:13:174:21 | my_number [MyNumber] | provenance |  |
 | main.rs:174:44:174:53 | source(...) | main.rs:174:25:174:54 | ...::MyNumber(...) [MyNumber] | provenance |  |
 | main.rs:179:13:179:21 | my_number [MyNumber] | main.rs:180:16:180:24 | my_number [MyNumber] | provenance |  |
 | main.rs:179:25:179:54 | ...::MyNumber(...) [MyNumber] | main.rs:179:13:179:21 | my_number [MyNumber] | provenance |  |
 | main.rs:179:44:179:53 | source(...) | main.rs:179:25:179:54 | ...::MyNumber(...) [MyNumber] | provenance |  |
 | main.rs:180:15:180:24 | &my_number [&ref, MyNumber] | main.rs:162:12:162:16 | SelfParam [&ref, MyNumber] | provenance |  |
-| main.rs:180:15:180:24 | &my_number [&ref, MyNumber] | main.rs:180:14:180:31 | ... .get(...) | provenance |  |
+| main.rs:180:15:180:24 | &my_number [&ref, MyNumber] | main.rs:180:14:180:31 | ... .get() | provenance |  |
 | main.rs:180:16:180:24 | my_number [MyNumber] | main.rs:180:15:180:24 | &my_number [&ref, MyNumber] | provenance |  |
 | main.rs:184:13:184:21 | my_number [MyNumber] | main.rs:186:14:186:22 | my_number [MyNumber] | provenance |  |
 | main.rs:184:25:184:54 | ...::MyNumber(...) [MyNumber] | main.rs:184:13:184:21 | my_number [MyNumber] | provenance |  |
 | main.rs:184:44:184:53 | source(...) | main.rs:184:25:184:54 | ...::MyNumber(...) [MyNumber] | provenance |  |
 | main.rs:186:14:186:22 | my_number [MyNumber] | main.rs:162:12:162:16 | SelfParam [&ref, MyNumber] | provenance |  |
-| main.rs:186:14:186:22 | my_number [MyNumber] | main.rs:186:14:186:28 | my_number.get(...) | provenance |  |
+| main.rs:186:14:186:22 | my_number [MyNumber] | main.rs:186:14:186:28 | my_number.get() | provenance |  |
 | main.rs:190:13:190:21 | my_number [&ref, MyNumber] | main.rs:192:14:192:22 | my_number [&ref, MyNumber] | provenance |  |
 | main.rs:190:25:190:55 | &... [&ref, MyNumber] | main.rs:190:13:190:21 | my_number [&ref, MyNumber] | provenance |  |
 | main.rs:190:26:190:55 | ...::MyNumber(...) [MyNumber] | main.rs:190:25:190:55 | &... [&ref, MyNumber] | provenance |  |
 | main.rs:190:45:190:54 | source(...) | main.rs:190:26:190:55 | ...::MyNumber(...) [MyNumber] | provenance |  |
 | main.rs:192:14:192:22 | my_number [&ref, MyNumber] | main.rs:156:18:156:21 | SelfParam [MyNumber] | provenance |  |
-| main.rs:192:14:192:22 | my_number [&ref, MyNumber] | main.rs:192:14:192:34 | my_number.to_number(...) | provenance |  |
+| main.rs:192:14:192:22 | my_number [&ref, MyNumber] | main.rs:192:14:192:34 | my_number.to_number() | provenance |  |
 | main.rs:200:29:200:38 | ...: i64 | main.rs:201:14:201:18 | value | provenance |  |
 | main.rs:201:10:201:10 | [post] n [&ref] | main.rs:200:16:200:26 | ...: ... [Return] [&ref] | provenance |  |
 | main.rs:201:14:201:18 | value | main.rs:201:10:201:10 | [post] n [&ref] | provenance |  |
@@ -106,9 +106,9 @@ edges
 | main.rs:234:36:234:45 | source(...) | main.rs:228:37:228:47 | ...: i64 | provenance |  |
 | main.rs:234:36:234:45 | source(...) | main.rs:234:20:234:33 | [post] &mut my_number [&ref, MyNumber] | provenance |  |
 | main.rs:235:14:235:22 | my_number [MyNumber] | main.rs:162:12:162:16 | SelfParam [&ref, MyNumber] | provenance |  |
-| main.rs:235:14:235:22 | my_number [MyNumber] | main.rs:235:14:235:28 | my_number.get(...) | provenance |  |
+| main.rs:235:14:235:22 | my_number [MyNumber] | main.rs:235:14:235:28 | my_number.get() | provenance |  |
 | main.rs:237:14:237:22 | my_number [MyNumber] | main.rs:162:12:162:16 | SelfParam [&ref, MyNumber] | provenance |  |
-| main.rs:237:14:237:22 | my_number [MyNumber] | main.rs:237:14:237:28 | my_number.get(...) | provenance |  |
+| main.rs:237:14:237:22 | my_number [MyNumber] | main.rs:237:14:237:28 | my_number.get() | provenance |  |
 | main.rs:243:9:243:17 | [post] my_number [MyNumber] | main.rs:244:24:244:32 | my_number [MyNumber] | provenance |  |
 | main.rs:243:9:243:17 | [post] my_number [MyNumber] | main.rs:246:24:246:32 | my_number [MyNumber] | provenance |  |
 | main.rs:243:23:243:32 | source(...) | main.rs:223:27:223:37 | ...: i64 | provenance |  |
@@ -201,24 +201,24 @@ nodes
 | main.rs:174:13:174:21 | my_number [MyNumber] | semmle.label | my_number [MyNumber] |
 | main.rs:174:25:174:54 | ...::MyNumber(...) [MyNumber] | semmle.label | ...::MyNumber(...) [MyNumber] |
 | main.rs:174:44:174:53 | source(...) | semmle.label | source(...) |
-| main.rs:175:14:175:34 | my_number.to_number(...) | semmle.label | my_number.to_number(...) |
+| main.rs:175:14:175:34 | my_number.to_number() | semmle.label | my_number.to_number() |
 | main.rs:179:13:179:21 | my_number [MyNumber] | semmle.label | my_number [MyNumber] |
 | main.rs:179:25:179:54 | ...::MyNumber(...) [MyNumber] | semmle.label | ...::MyNumber(...) [MyNumber] |
 | main.rs:179:44:179:53 | source(...) | semmle.label | source(...) |
-| main.rs:180:14:180:31 | ... .get(...) | semmle.label | ... .get(...) |
+| main.rs:180:14:180:31 | ... .get() | semmle.label | ... .get() |
 | main.rs:180:15:180:24 | &my_number [&ref, MyNumber] | semmle.label | &my_number [&ref, MyNumber] |
 | main.rs:180:16:180:24 | my_number [MyNumber] | semmle.label | my_number [MyNumber] |
 | main.rs:184:13:184:21 | my_number [MyNumber] | semmle.label | my_number [MyNumber] |
 | main.rs:184:25:184:54 | ...::MyNumber(...) [MyNumber] | semmle.label | ...::MyNumber(...) [MyNumber] |
 | main.rs:184:44:184:53 | source(...) | semmle.label | source(...) |
 | main.rs:186:14:186:22 | my_number [MyNumber] | semmle.label | my_number [MyNumber] |
-| main.rs:186:14:186:28 | my_number.get(...) | semmle.label | my_number.get(...) |
+| main.rs:186:14:186:28 | my_number.get() | semmle.label | my_number.get() |
 | main.rs:190:13:190:21 | my_number [&ref, MyNumber] | semmle.label | my_number [&ref, MyNumber] |
 | main.rs:190:25:190:55 | &... [&ref, MyNumber] | semmle.label | &... [&ref, MyNumber] |
 | main.rs:190:26:190:55 | ...::MyNumber(...) [MyNumber] | semmle.label | ...::MyNumber(...) [MyNumber] |
 | main.rs:190:45:190:54 | source(...) | semmle.label | source(...) |
 | main.rs:192:14:192:22 | my_number [&ref, MyNumber] | semmle.label | my_number [&ref, MyNumber] |
-| main.rs:192:14:192:34 | my_number.to_number(...) | semmle.label | my_number.to_number(...) |
+| main.rs:192:14:192:34 | my_number.to_number() | semmle.label | my_number.to_number() |
 | main.rs:200:16:200:26 | ...: ... [Return] [&ref] | semmle.label | ...: ... [Return] [&ref] |
 | main.rs:200:29:200:38 | ...: i64 | semmle.label | ...: i64 |
 | main.rs:201:10:201:10 | [post] n [&ref] | semmle.label | [post] n [&ref] |
@@ -245,9 +245,9 @@ nodes
 | main.rs:234:25:234:33 | [post] my_number [MyNumber] | semmle.label | [post] my_number [MyNumber] |
 | main.rs:234:36:234:45 | source(...) | semmle.label | source(...) |
 | main.rs:235:14:235:22 | my_number [MyNumber] | semmle.label | my_number [MyNumber] |
-| main.rs:235:14:235:28 | my_number.get(...) | semmle.label | my_number.get(...) |
+| main.rs:235:14:235:28 | my_number.get() | semmle.label | my_number.get() |
 | main.rs:237:14:237:22 | my_number [MyNumber] | semmle.label | my_number [MyNumber] |
-| main.rs:237:14:237:28 | my_number.get(...) | semmle.label | my_number.get(...) |
+| main.rs:237:14:237:28 | my_number.get() | semmle.label | my_number.get() |
 | main.rs:243:9:243:17 | [post] my_number [MyNumber] | semmle.label | [post] my_number [MyNumber] |
 | main.rs:243:23:243:32 | source(...) | semmle.label | source(...) |
 | main.rs:244:14:244:33 | to_number(...) | semmle.label | to_number(...) |
@@ -262,15 +262,15 @@ nodes
 | main.rs:255:14:255:33 | to_number(...) | semmle.label | to_number(...) |
 | main.rs:255:24:255:32 | my_number [MyNumber] | semmle.label | my_number [MyNumber] |
 subpaths
-| main.rs:174:13:174:21 | my_number [MyNumber] | main.rs:156:18:156:21 | SelfParam [MyNumber] | main.rs:156:31:160:5 | { ... } | main.rs:175:14:175:34 | my_number.to_number(...) |
-| main.rs:180:15:180:24 | &my_number [&ref, MyNumber] | main.rs:162:12:162:16 | SelfParam [&ref, MyNumber] | main.rs:162:26:166:5 | { ... } | main.rs:180:14:180:31 | ... .get(...) |
-| main.rs:186:14:186:22 | my_number [MyNumber] | main.rs:162:12:162:16 | SelfParam [&ref, MyNumber] | main.rs:162:26:166:5 | { ... } | main.rs:186:14:186:28 | my_number.get(...) |
-| main.rs:192:14:192:22 | my_number [&ref, MyNumber] | main.rs:156:18:156:21 | SelfParam [MyNumber] | main.rs:156:31:160:5 | { ... } | main.rs:192:14:192:34 | my_number.to_number(...) |
+| main.rs:174:13:174:21 | my_number [MyNumber] | main.rs:156:18:156:21 | SelfParam [MyNumber] | main.rs:156:31:160:5 | { ... } | main.rs:175:14:175:34 | my_number.to_number() |
+| main.rs:180:15:180:24 | &my_number [&ref, MyNumber] | main.rs:162:12:162:16 | SelfParam [&ref, MyNumber] | main.rs:162:26:166:5 | { ... } | main.rs:180:14:180:31 | ... .get() |
+| main.rs:186:14:186:22 | my_number [MyNumber] | main.rs:162:12:162:16 | SelfParam [&ref, MyNumber] | main.rs:162:26:166:5 | { ... } | main.rs:186:14:186:28 | my_number.get() |
+| main.rs:192:14:192:22 | my_number [&ref, MyNumber] | main.rs:156:18:156:21 | SelfParam [MyNumber] | main.rs:156:31:160:5 | { ... } | main.rs:192:14:192:34 | my_number.to_number() |
 | main.rs:210:20:210:29 | source(...) | main.rs:200:29:200:38 | ...: i64 | main.rs:200:16:200:26 | ...: ... [Return] [&ref] | main.rs:210:17:210:17 | [post] p [&ref] |
 | main.rs:218:25:218:34 | source(...) | main.rs:200:29:200:38 | ...: i64 | main.rs:200:16:200:26 | ...: ... [Return] [&ref] | main.rs:218:17:218:22 | [post] &mut n [&ref] |
 | main.rs:234:36:234:45 | source(...) | main.rs:228:37:228:47 | ...: i64 | main.rs:228:19:228:34 | ...: ... [Return] [&ref, MyNumber] | main.rs:234:20:234:33 | [post] &mut my_number [&ref, MyNumber] |
-| main.rs:235:14:235:22 | my_number [MyNumber] | main.rs:162:12:162:16 | SelfParam [&ref, MyNumber] | main.rs:162:26:166:5 | { ... } | main.rs:235:14:235:28 | my_number.get(...) |
-| main.rs:237:14:237:22 | my_number [MyNumber] | main.rs:162:12:162:16 | SelfParam [&ref, MyNumber] | main.rs:162:26:166:5 | { ... } | main.rs:237:14:237:28 | my_number.get(...) |
+| main.rs:235:14:235:22 | my_number [MyNumber] | main.rs:162:12:162:16 | SelfParam [&ref, MyNumber] | main.rs:162:26:166:5 | { ... } | main.rs:235:14:235:28 | my_number.get() |
+| main.rs:237:14:237:22 | my_number [MyNumber] | main.rs:162:12:162:16 | SelfParam [&ref, MyNumber] | main.rs:162:26:166:5 | { ... } | main.rs:237:14:237:28 | my_number.get() |
 | main.rs:243:23:243:32 | source(...) | main.rs:223:27:223:37 | ...: i64 | main.rs:223:16:223:24 | SelfParam [Return] [&ref, MyNumber] | main.rs:243:9:243:17 | [post] my_number [MyNumber] |
 | main.rs:244:24:244:32 | my_number [MyNumber] | main.rs:149:14:149:24 | ...: MyNumber [MyNumber] | main.rs:149:34:153:1 | { ... } | main.rs:244:14:244:33 | to_number(...) |
 | main.rs:246:24:246:32 | my_number [MyNumber] | main.rs:149:14:149:24 | ...: MyNumber [MyNumber] | main.rs:149:34:153:1 | { ... } | main.rs:246:14:246:33 | to_number(...) |
@@ -287,14 +287,14 @@ testFailures
 | main.rs:74:14:74:15 | * ... | main.rs:73:14:73:23 | source(...) | main.rs:74:14:74:15 | * ... | $@ | main.rs:73:14:73:23 | source(...) | source(...) |
 | main.rs:106:14:106:15 | * ... | main.rs:105:14:105:23 | source(...) | main.rs:106:14:106:15 | * ... | $@ | main.rs:105:14:105:23 | source(...) | source(...) |
 | main.rs:113:14:113:15 | * ... | main.rs:112:25:112:34 | source(...) | main.rs:113:14:113:15 | * ... | $@ | main.rs:112:25:112:34 | source(...) | source(...) |
-| main.rs:175:14:175:34 | my_number.to_number(...) | main.rs:174:44:174:53 | source(...) | main.rs:175:14:175:34 | my_number.to_number(...) | $@ | main.rs:174:44:174:53 | source(...) | source(...) |
-| main.rs:180:14:180:31 | ... .get(...) | main.rs:179:44:179:53 | source(...) | main.rs:180:14:180:31 | ... .get(...) | $@ | main.rs:179:44:179:53 | source(...) | source(...) |
-| main.rs:186:14:186:28 | my_number.get(...) | main.rs:184:44:184:53 | source(...) | main.rs:186:14:186:28 | my_number.get(...) | $@ | main.rs:184:44:184:53 | source(...) | source(...) |
-| main.rs:192:14:192:34 | my_number.to_number(...) | main.rs:190:45:190:54 | source(...) | main.rs:192:14:192:34 | my_number.to_number(...) | $@ | main.rs:190:45:190:54 | source(...) | source(...) |
+| main.rs:175:14:175:34 | my_number.to_number() | main.rs:174:44:174:53 | source(...) | main.rs:175:14:175:34 | my_number.to_number() | $@ | main.rs:174:44:174:53 | source(...) | source(...) |
+| main.rs:180:14:180:31 | ... .get() | main.rs:179:44:179:53 | source(...) | main.rs:180:14:180:31 | ... .get() | $@ | main.rs:179:44:179:53 | source(...) | source(...) |
+| main.rs:186:14:186:28 | my_number.get() | main.rs:184:44:184:53 | source(...) | main.rs:186:14:186:28 | my_number.get() | $@ | main.rs:184:44:184:53 | source(...) | source(...) |
+| main.rs:192:14:192:34 | my_number.to_number() | main.rs:190:45:190:54 | source(...) | main.rs:192:14:192:34 | my_number.to_number() | $@ | main.rs:190:45:190:54 | source(...) | source(...) |
 | main.rs:211:14:211:15 | * ... | main.rs:210:20:210:29 | source(...) | main.rs:211:14:211:15 | * ... | $@ | main.rs:210:20:210:29 | source(...) | source(...) |
 | main.rs:219:14:219:14 | n | main.rs:218:25:218:34 | source(...) | main.rs:219:14:219:14 | n | $@ | main.rs:218:25:218:34 | source(...) | source(...) |
-| main.rs:235:14:235:28 | my_number.get(...) | main.rs:234:36:234:45 | source(...) | main.rs:235:14:235:28 | my_number.get(...) | $@ | main.rs:234:36:234:45 | source(...) | source(...) |
-| main.rs:237:14:237:28 | my_number.get(...) | main.rs:234:36:234:45 | source(...) | main.rs:237:14:237:28 | my_number.get(...) | $@ | main.rs:234:36:234:45 | source(...) | source(...) |
+| main.rs:235:14:235:28 | my_number.get() | main.rs:234:36:234:45 | source(...) | main.rs:235:14:235:28 | my_number.get() | $@ | main.rs:234:36:234:45 | source(...) | source(...) |
+| main.rs:237:14:237:28 | my_number.get() | main.rs:234:36:234:45 | source(...) | main.rs:237:14:237:28 | my_number.get() | $@ | main.rs:234:36:234:45 | source(...) | source(...) |
 | main.rs:244:14:244:33 | to_number(...) | main.rs:243:23:243:32 | source(...) | main.rs:244:14:244:33 | to_number(...) | $@ | main.rs:243:23:243:32 | source(...) | source(...) |
 | main.rs:246:14:246:33 | to_number(...) | main.rs:243:23:243:32 | source(...) | main.rs:246:14:246:33 | to_number(...) | $@ | main.rs:243:23:243:32 | source(...) | source(...) |
 | main.rs:253:14:253:33 | to_number(...) | main.rs:252:30:252:39 | source(...) | main.rs:253:14:253:33 | to_number(...) | $@ | main.rs:252:30:252:39 | source(...) | source(...) |

--- a/rust/ql/test/library-tests/dataflow/strings/inline-taint-flow.expected
+++ b/rust/ql/test/library-tests/dataflow/strings/inline-taint-flow.expected
@@ -18,11 +18,11 @@ edges
 | main.rs:52:6:52:7 | s2 | main.rs:53:7:53:8 | s2 | provenance |  |
 | main.rs:52:11:52:26 | ...::from(...) | main.rs:52:6:52:7 | s2 | provenance |  |
 | main.rs:52:24:52:25 | s1 | main.rs:52:11:52:26 | ...::from(...) | provenance | MaD:2 |
-| main.rs:57:6:57:7 | s1 | main.rs:58:11:58:24 | s1.to_string(...) | provenance | MaD:1 |
+| main.rs:57:6:57:7 | s1 | main.rs:58:11:58:24 | s1.to_string() | provenance | MaD:1 |
 | main.rs:57:11:57:26 | source_slice(...) | main.rs:57:6:57:7 | s1 | provenance |  |
 | main.rs:58:6:58:7 | s2 | main.rs:59:7:59:8 | s2 | provenance |  |
-| main.rs:58:11:58:24 | s1.to_string(...) | main.rs:58:6:58:7 | s2 | provenance |  |
-| main.rs:63:9:63:9 | s | main.rs:64:16:64:25 | s.as_str(...) | provenance | MaD:3 |
+| main.rs:58:11:58:24 | s1.to_string() | main.rs:58:6:58:7 | s2 | provenance |  |
+| main.rs:63:9:63:9 | s | main.rs:64:16:64:25 | s.as_str() | provenance | MaD:3 |
 | main.rs:63:13:63:22 | source(...) | main.rs:63:9:63:9 | s | provenance |  |
 | main.rs:68:9:68:9 | s | main.rs:70:34:70:61 | MacroExpr | provenance |  |
 | main.rs:68:9:68:9 | s | main.rs:73:34:73:59 | MacroExpr | provenance |  |
@@ -71,11 +71,11 @@ nodes
 | main.rs:57:6:57:7 | s1 | semmle.label | s1 |
 | main.rs:57:11:57:26 | source_slice(...) | semmle.label | source_slice(...) |
 | main.rs:58:6:58:7 | s2 | semmle.label | s2 |
-| main.rs:58:11:58:24 | s1.to_string(...) | semmle.label | s1.to_string(...) |
+| main.rs:58:11:58:24 | s1.to_string() | semmle.label | s1.to_string() |
 | main.rs:59:7:59:8 | s2 | semmle.label | s2 |
 | main.rs:63:9:63:9 | s | semmle.label | s |
 | main.rs:63:13:63:22 | source(...) | semmle.label | source(...) |
-| main.rs:64:16:64:25 | s.as_str(...) | semmle.label | s.as_str(...) |
+| main.rs:64:16:64:25 | s.as_str() | semmle.label | s.as_str() |
 | main.rs:68:9:68:9 | s | semmle.label | s |
 | main.rs:68:13:68:22 | source(...) | semmle.label | source(...) |
 | main.rs:70:9:70:18 | formatted1 | semmle.label | formatted1 |
@@ -113,7 +113,7 @@ testFailures
 | main.rs:38:10:38:11 | s4 | main.rs:32:14:32:23 | source(...) | main.rs:38:10:38:11 | s4 | $@ | main.rs:32:14:32:23 | source(...) | source(...) |
 | main.rs:53:7:53:8 | s2 | main.rs:51:11:51:26 | source_slice(...) | main.rs:53:7:53:8 | s2 | $@ | main.rs:51:11:51:26 | source_slice(...) | source_slice(...) |
 | main.rs:59:7:59:8 | s2 | main.rs:57:11:57:26 | source_slice(...) | main.rs:59:7:59:8 | s2 | $@ | main.rs:57:11:57:26 | source_slice(...) | source_slice(...) |
-| main.rs:64:16:64:25 | s.as_str(...) | main.rs:63:13:63:22 | source(...) | main.rs:64:16:64:25 | s.as_str(...) | $@ | main.rs:63:13:63:22 | source(...) | source(...) |
+| main.rs:64:16:64:25 | s.as_str() | main.rs:63:13:63:22 | source(...) | main.rs:64:16:64:25 | s.as_str() | $@ | main.rs:63:13:63:22 | source(...) | source(...) |
 | main.rs:71:10:71:19 | formatted1 | main.rs:68:13:68:22 | source(...) | main.rs:71:10:71:19 | formatted1 | $@ | main.rs:68:13:68:22 | source(...) | source(...) |
 | main.rs:74:10:74:19 | formatted2 | main.rs:68:13:68:22 | source(...) | main.rs:74:10:74:19 | formatted2 | $@ | main.rs:68:13:68:22 | source(...) | source(...) |
 | main.rs:78:10:78:19 | formatted3 | main.rs:76:17:76:32 | source_usize(...) | main.rs:78:10:78:19 | formatted3 | $@ | main.rs:76:17:76:32 | source_usize(...) | source_usize(...) |

--- a/rust/ql/test/library-tests/type-inference/loop/main.rs
+++ b/rust/ql/test/library-tests/type-inference/loop/main.rs
@@ -9,6 +9,6 @@ trait T1<T>: T2<S<T>> {
 
 trait T2<T>: T1<S<T>> {
     fn bar(self) {
-        self.foo()
+        self.foo() // $ method=foo
     }
 }

--- a/rust/ql/test/library-tests/type-inference/main.rs
+++ b/rust/ql/test/library-tests/type-inference/main.rs
@@ -24,36 +24,36 @@ mod field_access {
 
     fn simple_field_access() {
         let x = MyThing { a: S };
-        println!("{:?}", x.a);
+        println!("{:?}", x.a); // $ fieldof=MyThing
     }
 
     fn generic_field_access() {
         // Explicit type argument
-        let x = GenericThing::<S> { a: S };
-        println!("{:?}", x.a);
+        let x = GenericThing::<S> { a: S }; // $ type=x:A.S
+        println!("{:?}", x.a); // $ fieldof=GenericThing
 
         // Implicit type argument
         let y = GenericThing { a: S };
-        println!("{:?}", x.a);
+        println!("{:?}", x.a); // $ fieldof=GenericThing
 
         // The type of the field `a` can only be inferred from the concrete type
         // in the struct declaration.
         let x = OptionS {
             a: MyOption::MyNone(),
         };
-        println!("{:?}", x.a);
+        println!("{:?}", x.a); // $ fieldof=OptionS
 
         // The type of the field `a` can only be inferred from the type argument
         let x = GenericThing::<MyOption<S>> {
             a: MyOption::MyNone(),
         };
-        println!("{:?}", x.a);
+        println!("{:?}", x.a); // $ fieldof=GenericThing
 
         let mut x = GenericThing {
             a: MyOption::MyNone(),
         };
         // Only after this access can we infer the type parameter of `x`
-        let a: MyOption<S> = x.a;
+        let a: MyOption<S> = x.a; // $ fieldof=GenericThing
         println!("{:?}", a);
     }
 
@@ -85,8 +85,8 @@ mod method_impl {
 
     pub fn g(x: Foo, y: Foo) -> Foo {
         println!("main.rs::m1::g");
-        x.m1();
-        y.m2()
+        x.m1(); // $ method=m1
+        y.m2() // $ method=m2
     }
 }
 
@@ -102,20 +102,22 @@ mod method_non_parametric_impl {
     struct S2;
 
     impl MyThing<S1> {
+        // MyThing<S1>::m1
         fn m1(self) -> S1 {
-            self.a
+            self.a // $ fieldof=MyThing
         }
     }
 
     impl MyThing<S2> {
+        // MyThing<S2>::m1
         fn m1(self) -> Self {
-            Self { a: self.a }
+            Self { a: self.a } // $ fieldof=MyThing
         }
     }
 
     impl<T> MyThing<T> {
         fn m2(self) -> T {
-            self.a
+            self.a // $ fieldof=MyThing
         }
     }
 
@@ -124,17 +126,17 @@ mod method_non_parametric_impl {
         let y = MyThing { a: S2 };
 
         // simple field access
-        println!("{:?}", x.a);
-        println!("{:?}", y.a);
+        println!("{:?}", x.a); // $ fieldof=MyThing
+        println!("{:?}", y.a); // $ fieldof=MyThing
 
-        println!("{:?}", x.m1()); // missing call target
-        println!("{:?}", y.m1().a); // missing call target
+        println!("{:?}", x.m1()); // $ MISSING: method=MyThing<S1>::m1
+        println!("{:?}", y.m1().a); // $ MISSING: method=MyThing<S2>::m1, field=MyThing
 
         let x = MyThing { a: S1 };
         let y = MyThing { a: S2 };
 
-        println!("{:?}", x.m2());
-        println!("{:?}", y.m2());
+        println!("{:?}", x.m2()); // $ method=m2
+        println!("{:?}", y.m2()); // $ method=m2
     }
 }
 
@@ -161,18 +163,20 @@ mod method_non_parametric_trait_impl {
     }
 
     fn call_trait_m1<T1, T2: MyTrait<T1>>(x: T2) -> T1 {
-        x.m1()
+        x.m1() // $ method=m1
     }
 
     impl MyTrait<S1> for MyThing<S1> {
+        // MyThing<S1>::m1
         fn m1(self) -> S1 {
-            self.a
+            self.a // $ fieldof=MyThing
         }
     }
 
     impl MyTrait<Self> for MyThing<S2> {
+        // MyThing<S2>::m1
         fn m1(self) -> Self {
-            Self { a: self.a }
+            Self { a: self.a } // $ fieldof=MyThing
         }
     }
 
@@ -180,14 +184,14 @@ mod method_non_parametric_trait_impl {
         let x = MyThing { a: S1 };
         let y = MyThing { a: S2 };
 
-        println!("{:?}", x.m1()); // missing call target
-        println!("{:?}", y.m1().a); // missing call target
+        println!("{:?}", x.m1()); // $ MISSING: method=MyThing<S1>::m1
+        println!("{:?}", y.m1().a); // $ MISSING: method=MyThing<S2>::m1, field=MyThing
 
         let x = MyThing { a: S1 };
         let y = MyThing { a: S2 };
 
-        println!("{:?}", call_trait_m1(x)); // missing
-        println!("{:?}", call_trait_m1(y).a); // missing
+        println!("{:?}", call_trait_m1(x)); // MISSING: type=call_trait_m1(...):S1
+        println!("{:?}", call_trait_m1(y).a); // MISSING: field=MyThing
     }
 }
 
@@ -203,32 +207,34 @@ mod type_parameter_bounds {
     // Two traits with the same method name.
 
     trait FirstTrait<FT> {
+        // FirstTrait::method
         fn method(self) -> FT;
     }
 
     trait SecondTrait<ST> {
+        // SecondTrait::method
         fn method(self) -> ST;
     }
 
     fn call_first_trait_per_bound<I: Debug, T: SecondTrait<I>>(x: T) {
         // The type parameter bound determines which method this call is resolved to.
-        let s1 = x.method();
+        let s1 = x.method(); // $ method=SecondTrait::method
         println!("{:?}", s1);
     }
 
     fn call_second_trait_per_bound<I: Debug, T: SecondTrait<I>>(x: T) {
         // The type parameter bound determines which method this call is resolved to.
-        let s2 = x.method();
+        let s2 = x.method(); // $ method=SecondTrait::method
         println!("{:?}", s2);
     }
 
     fn trait_bound_with_type<T: FirstTrait<S1>>(x: T) {
-        let s = x.method();
-        println!("{:?}", s);
+        let s = x.method(); // $ method=FirstTrait::method
+        println!("{:?}", s); // $ type=s:S1
     }
 
     fn trait_per_bound_with_type<T: FirstTrait<S1>>(x: T) {
-        let s = x.method();
+        let s = x.method(); // $ method=FirstTrait::method
         println!("{:?}", s);
     }
 
@@ -240,15 +246,15 @@ mod type_parameter_bounds {
 
     fn call_trait_per_bound_with_type_1<T: Pair<S1, S2>>(x: T, y: T) {
         // The type in the type parameter bound determines the return type.
-        let s1 = x.fst();
-        let s2 = y.snd();
+        let s1 = x.fst(); // $ method=fst
+        let s2 = y.snd(); // $ method=snd
         println!("{:?}, {:?}", s1, s2);
     }
 
     fn call_trait_per_bound_with_type_2<T2: Debug, T: Pair<S1, T2>>(x: T, y: T) {
         // The type in the type parameter bound determines the return type.
-        let s1 = x.fst();
-        let s2 = y.snd();
+        let s1 = x.fst(); // $ method=fst
+        let s2 = y.snd(); // $ method=snd
         println!("{:?}, {:?}", s1, s2);
     }
 }
@@ -271,23 +277,23 @@ mod function_trait_bounds {
         where
             Self: Sized,
         {
-            self.m1()
+            self.m1() // $ method=m1
         }
     }
 
     // Type parameter with bound occurs in the root of a parameter type.
     fn call_trait_m1<T1, T2: MyTrait<T1>>(x: T2) -> T1 {
-        x.m1()
+        x.m1() // $ method=m1 type=x.m1():T1
     }
 
     // Type parameter with bound occurs nested within another type.
     fn call_trait_thing_m1<T1, T2: MyTrait<T1>>(x: MyThing<T2>) -> T1 {
-        x.a.m1()
+        x.a.m1() // $ fieldof=MyThing method=m1
     }
 
     impl<T> MyTrait<T> for MyThing<T> {
         fn m1(self) -> T {
-            self.a
+            self.a // $ fieldof=MyThing
         }
     }
 
@@ -295,14 +301,14 @@ mod function_trait_bounds {
         let x = MyThing { a: S1 };
         let y = MyThing { a: S2 };
 
-        println!("{:?}", x.m1());
-        println!("{:?}", y.m1());
+        println!("{:?}", x.m1()); // $ method=m1
+        println!("{:?}", y.m1()); // $ method=m1
 
         let x = MyThing { a: S1 };
         let y = MyThing { a: S2 };
 
-        println!("{:?}", x.m2());
-        println!("{:?}", y.m2());
+        println!("{:?}", x.m2()); // $ method=m2
+        println!("{:?}", y.m2()); // $ method=m2
 
         let x2 = MyThing { a: S1 };
         let y2 = MyThing { a: S2 };
@@ -343,6 +349,7 @@ mod trait_associated_type {
     impl MyTrait for S {
         type AssociatedType = S;
 
+        // S::m1
         fn m1(self) -> Self::AssociatedType {
             S
         }
@@ -350,10 +357,10 @@ mod trait_associated_type {
 
     pub fn f() {
         let x = S;
-        println!("{:?}", x.m1());
+        println!("{:?}", x.m1()); // $ method=S::m1
 
         let x = S;
-        println!("{:?}", x.m2()); // missing
+        println!("{:?}", x.m2()); // $ method=m2
     }
 }
 
@@ -382,8 +389,8 @@ mod generic_enum {
         let x = MyEnum::C1(S1);
         let y = MyEnum::C2 { a: S2 };
 
-        println!("{:?}", x.m1());
-        println!("{:?}", y.m1());
+        println!("{:?}", x.m1()); // $ method=m1
+        println!("{:?}", y.m1()); // $ method=m1
     }
 }
 
@@ -404,6 +411,7 @@ mod method_supertraits {
     struct S2;
 
     trait MyTrait1<Tr1> {
+        // MyTrait1::m1
         fn m1(self) -> Tr1;
     }
 
@@ -413,7 +421,7 @@ mod method_supertraits {
             Self: Sized,
         {
             if 1 + 1 > 2 {
-                self.m1()
+                self.m1() // $ method=MyTrait1::m1
             } else {
                 Self::m1(self)
             }
@@ -426,24 +434,26 @@ mod method_supertraits {
             Self: Sized,
         {
             if 1 + 1 > 2 {
-                self.m2().a
+                self.m2().a // $ method=m2 $ fieldof=MyThing
             } else {
-                Self::m2(self).a
+                Self::m2(self).a // $ fieldof=MyThing
             }
         }
     }
 
     impl<T> MyTrait1<T> for MyThing<T> {
+        // MyThing::m1
         fn m1(self) -> T {
-            self.a
+            self.a // $ fieldof=MyThing
         }
     }
 
     impl<T> MyTrait2<T> for MyThing<T> {}
 
     impl<T> MyTrait1<MyThing<T>> for MyThing2<T> {
+        // MyThing2::m1
         fn m1(self) -> MyThing<T> {
-            MyThing { a: self.a }
+            MyThing { a: self.a } // $ fieldof=MyThing2
         }
     }
 
@@ -455,20 +465,20 @@ mod method_supertraits {
         let x = MyThing { a: S1 };
         let y = MyThing { a: S2 };
 
-        println!("{:?}", x.m1());
-        println!("{:?}", y.m1());
+        println!("{:?}", x.m1()); // $ method=MyThing::m1
+        println!("{:?}", y.m1()); // $ method=MyThing::m1
 
         let x = MyThing { a: S1 };
         let y = MyThing { a: S2 };
 
-        println!("{:?}", x.m2());
-        println!("{:?}", y.m2());
+        println!("{:?}", x.m2()); // $ method=m2
+        println!("{:?}", y.m2()); // $ method=m2
 
         let x = MyThing2 { a: S1 };
         let y = MyThing2 { a: S2 };
 
-        println!("{:?}", x.m3());
-        println!("{:?}", y.m3());
+        println!("{:?}", x.m3()); // $ method=m3
+        println!("{:?}", y.m3()); // $ method=m3
     }
 }
 
@@ -572,14 +582,16 @@ mod option_methods {
     }
 
     trait MyTrait<S> {
+        // MyTrait::set
         fn set(&mut self, value: S);
 
         fn call_set(&mut self, value: S) {
-            self.set(value);
+            self.set(value); // $ method=MyTrait::set
         }
     }
 
     impl<T> MyTrait<T> for MyOption<T> {
+        // MyOption::set
         fn set(&mut self, value: T) {}
     }
 
@@ -602,15 +614,15 @@ mod option_methods {
     struct S;
 
     pub fn f() {
-        let x1 = MyOption::<S>::new(); // `::new` missing type `S`
+        let x1 = MyOption::<S>::new(); // $ MISSING: type=x1:T.S
         println!("{:?}", x1);
 
         let mut x2 = MyOption::new();
-        x2.set(S);
+        x2.set(S); // $ method=MyOption::set
         println!("{:?}", x2);
 
         let mut x3 = MyOption::new(); // missing type `S` from `MyOption<S>` (but can resolve `MyTrait<S>`)
-        x3.call_set(S);
+        x3.call_set(S); // $ method=call_set
         println!("{:?}", x3);
 
         let mut x4 = MyOption::new();
@@ -618,7 +630,7 @@ mod option_methods {
         println!("{:?}", x4);
 
         let x5 = MyOption::MySome(MyOption::<S>::MyNone());
-        println!("{:?}", x5.flatten()); // missing call target
+        println!("{:?}", x5.flatten()); // MISSING: method=flatten
 
         let x6 = MyOption::MySome(MyOption::<S>::MyNone());
         println!("{:?}", MyOption::<MyOption<S>>::flatten(x6));
@@ -656,26 +668,26 @@ mod method_call_type_conversion {
 
     impl<T> S<T> {
         fn m1(self) -> T {
-            self.0
+            self.0 // $ fieldof=S
         }
 
         fn m2(&self) -> &T {
-            &self.0
+            &self.0 // $ fieldof=S
         }
 
         fn m3(self: &S<T>) -> &T {
-            &self.0
+            &self.0 // $ fieldof=S
         }
     }
 
     pub fn f() {
         let x1 = S(S2);
-        println!("{:?}", x1.m1());
+        println!("{:?}", x1.m1()); // $ method=m1
 
         let x2 = S(S2);
         // implicit borrow
-        println!("{:?}", x2.m2());
-        println!("{:?}", x2.m3());
+        println!("{:?}", x2.m2()); // $ method=m2
+        println!("{:?}", x2.m3()); // $ method=m3
 
         let x3 = S(S2);
         // explicit borrow
@@ -684,32 +696,35 @@ mod method_call_type_conversion {
 
         let x4 = &S(S2);
         // explicit borrow
-        println!("{:?}", x4.m2());
-        println!("{:?}", x4.m3());
+        println!("{:?}", x4.m2()); // $ method=m2
+        println!("{:?}", x4.m3()); // $ method=m3
 
         let x5 = &S(S2);
         // implicit dereference
-        println!("{:?}", x5.m1());
-        println!("{:?}", x5.0);
+        println!("{:?}", x5.m1()); // $ method=m1
+        println!("{:?}", x5.0); // $ fieldof=S
 
         let x6 = &S(S2);
         // explicit dereference
-        println!("{:?}", (*x6).m1());
+        println!("{:?}", (*x6).m1()); // $ method=m1
     }
 }
 
 mod trait_implicit_self_borrow {
     trait MyTrait {
+        // MyTrait::foo
         fn foo(&self) -> &Self;
 
+        // MyTrait::bar
         fn bar(&self) -> &Self {
-            self.foo()
+            self.foo() // $ method=MyTrait::foo
         }
     }
 
     struct MyStruct;
 
     impl MyTrait for MyStruct {
+        // MyStruct::foo
         fn foo(&self) -> &MyStruct {
             self
         }
@@ -717,7 +732,7 @@ mod trait_implicit_self_borrow {
 
     pub fn f() {
         let x = MyStruct;
-        x.bar();
+        x.bar(); // $ method=MyTrait::bar
     }
 }
 
@@ -734,7 +749,7 @@ mod implicit_self_borrow {
 
     pub fn f() {
         let x = MyStruct(S);
-        x.foo();
+        x.foo(); // $ method=foo
     }
 }
 
@@ -761,8 +776,8 @@ mod borrowed_typed {
 
     pub fn f() {
         let x = S {};
-        x.f1();
-        x.f2();
+        x.f1(); // $ method=f1
+        x.f2(); // $ method=f2
         S::f3(&x);
     }
 }

--- a/rust/ql/test/library-tests/type-inference/type-inference.expected
+++ b/rust/ql/test/library-tests/type-inference/type-inference.expected
@@ -2,140 +2,140 @@ inferType
 | loop/main.rs:7:12:7:15 | SelfParam |  | loop/main.rs:6:1:8:1 | Self [trait T1] |
 | loop/main.rs:11:12:11:15 | SelfParam |  | loop/main.rs:10:1:14:1 | Self [trait T2] |
 | loop/main.rs:12:9:12:12 | self |  | loop/main.rs:10:1:14:1 | Self [trait T2] |
-| main.rs:26:13:26:13 | x |  | main.rs:5:5:8:5 | struct MyThing |
-| main.rs:26:17:26:32 | MyThing {...} |  | main.rs:5:5:8:5 | struct MyThing |
-| main.rs:26:30:26:30 | S |  | main.rs:2:5:3:13 | struct S |
-| main.rs:27:26:27:26 | x |  | main.rs:5:5:8:5 | struct MyThing |
-| main.rs:27:26:27:28 | x.a |  | main.rs:2:5:3:13 | struct S |
-| main.rs:32:13:32:13 | x |  | main.rs:16:5:19:5 | struct GenericThing |
-| main.rs:32:13:32:13 | x | A | main.rs:2:5:3:13 | struct S |
-| main.rs:32:17:32:42 | GenericThing::<...> {...} |  | main.rs:16:5:19:5 | struct GenericThing |
-| main.rs:32:17:32:42 | GenericThing::<...> {...} | A | main.rs:2:5:3:13 | struct S |
-| main.rs:32:40:32:40 | S |  | main.rs:2:5:3:13 | struct S |
-| main.rs:33:26:33:26 | x |  | main.rs:16:5:19:5 | struct GenericThing |
-| main.rs:33:26:33:26 | x | A | main.rs:2:5:3:13 | struct S |
-| main.rs:33:26:33:28 | x.a |  | main.rs:2:5:3:13 | struct S |
-| main.rs:36:13:36:13 | y |  | main.rs:16:5:19:5 | struct GenericThing |
-| main.rs:36:13:36:13 | y | A | main.rs:2:5:3:13 | struct S |
-| main.rs:36:17:36:37 | GenericThing {...} |  | main.rs:16:5:19:5 | struct GenericThing |
-| main.rs:36:17:36:37 | GenericThing {...} | A | main.rs:2:5:3:13 | struct S |
-| main.rs:36:35:36:35 | S |  | main.rs:2:5:3:13 | struct S |
-| main.rs:37:26:37:26 | x |  | main.rs:16:5:19:5 | struct GenericThing |
-| main.rs:37:26:37:26 | x | A | main.rs:2:5:3:13 | struct S |
-| main.rs:37:26:37:28 | x.a |  | main.rs:2:5:3:13 | struct S |
-| main.rs:41:13:41:13 | x |  | main.rs:21:5:23:5 | struct OptionS |
-| main.rs:41:17:43:9 | OptionS {...} |  | main.rs:21:5:23:5 | struct OptionS |
-| main.rs:42:16:42:33 | ...::MyNone(...) |  | main.rs:10:5:14:5 | enum MyOption |
-| main.rs:42:16:42:33 | ...::MyNone(...) | T | main.rs:2:5:3:13 | struct S |
-| main.rs:44:26:44:26 | x |  | main.rs:21:5:23:5 | struct OptionS |
-| main.rs:44:26:44:28 | x.a |  | main.rs:10:5:14:5 | enum MyOption |
-| main.rs:44:26:44:28 | x.a | T | main.rs:2:5:3:13 | struct S |
-| main.rs:47:13:47:13 | x |  | main.rs:16:5:19:5 | struct GenericThing |
-| main.rs:47:13:47:13 | x | A | main.rs:10:5:14:5 | enum MyOption |
-| main.rs:47:13:47:13 | x | A.T | main.rs:2:5:3:13 | struct S |
-| main.rs:47:17:49:9 | GenericThing::<...> {...} |  | main.rs:16:5:19:5 | struct GenericThing |
-| main.rs:47:17:49:9 | GenericThing::<...> {...} | A | main.rs:10:5:14:5 | enum MyOption |
-| main.rs:47:17:49:9 | GenericThing::<...> {...} | A.T | main.rs:2:5:3:13 | struct S |
-| main.rs:48:16:48:33 | ...::MyNone(...) |  | main.rs:10:5:14:5 | enum MyOption |
-| main.rs:48:16:48:33 | ...::MyNone(...) | T | main.rs:2:5:3:13 | struct S |
-| main.rs:50:26:50:26 | x |  | main.rs:16:5:19:5 | struct GenericThing |
-| main.rs:50:26:50:26 | x | A | main.rs:10:5:14:5 | enum MyOption |
-| main.rs:50:26:50:26 | x | A.T | main.rs:2:5:3:13 | struct S |
-| main.rs:50:26:50:28 | x.a |  | main.rs:10:5:14:5 | enum MyOption |
-| main.rs:50:26:50:28 | x.a | T | main.rs:2:5:3:13 | struct S |
-| main.rs:52:13:52:17 | mut x |  | main.rs:16:5:19:5 | struct GenericThing |
-| main.rs:52:13:52:17 | mut x | A | main.rs:10:5:14:5 | enum MyOption |
-| main.rs:52:13:52:17 | mut x | A.T | main.rs:2:5:3:13 | struct S |
-| main.rs:52:21:54:9 | GenericThing {...} |  | main.rs:16:5:19:5 | struct GenericThing |
-| main.rs:52:21:54:9 | GenericThing {...} | A | main.rs:10:5:14:5 | enum MyOption |
-| main.rs:52:21:54:9 | GenericThing {...} | A.T | main.rs:2:5:3:13 | struct S |
-| main.rs:53:16:53:33 | ...::MyNone(...) |  | main.rs:10:5:14:5 | enum MyOption |
-| main.rs:53:16:53:33 | ...::MyNone(...) | T | main.rs:2:5:3:13 | struct S |
-| main.rs:56:13:56:13 | a |  | main.rs:10:5:14:5 | enum MyOption |
-| main.rs:56:13:56:13 | a | T | main.rs:2:5:3:13 | struct S |
-| main.rs:56:30:56:30 | x |  | main.rs:16:5:19:5 | struct GenericThing |
-| main.rs:56:30:56:30 | x | A | main.rs:10:5:14:5 | enum MyOption |
-| main.rs:56:30:56:30 | x | A.T | main.rs:2:5:3:13 | struct S |
-| main.rs:56:30:56:32 | x.a |  | main.rs:10:5:14:5 | enum MyOption |
-| main.rs:56:30:56:32 | x.a | T | main.rs:2:5:3:13 | struct S |
-| main.rs:57:26:57:26 | a |  | main.rs:10:5:14:5 | enum MyOption |
-| main.rs:57:26:57:26 | a | T | main.rs:2:5:3:13 | struct S |
-| main.rs:70:19:70:22 | SelfParam |  | main.rs:67:5:67:21 | struct Foo |
-| main.rs:70:33:72:9 | { ... } |  | main.rs:67:5:67:21 | struct Foo |
-| main.rs:71:13:71:16 | self |  | main.rs:67:5:67:21 | struct Foo |
-| main.rs:74:19:74:22 | SelfParam |  | main.rs:67:5:67:21 | struct Foo |
-| main.rs:74:32:76:9 | { ... } |  | main.rs:67:5:67:21 | struct Foo |
-| main.rs:75:13:75:16 | self |  | main.rs:67:5:67:21 | struct Foo |
-| main.rs:79:23:84:5 | { ... } |  | main.rs:67:5:67:21 | struct Foo |
-| main.rs:81:13:81:13 | x |  | main.rs:67:5:67:21 | struct Foo |
-| main.rs:81:17:81:22 | Foo {...} |  | main.rs:67:5:67:21 | struct Foo |
-| main.rs:82:13:82:13 | y |  | main.rs:67:5:67:21 | struct Foo |
-| main.rs:82:20:82:25 | Foo {...} |  | main.rs:67:5:67:21 | struct Foo |
-| main.rs:83:9:83:9 | x |  | main.rs:67:5:67:21 | struct Foo |
-| main.rs:86:14:86:14 | x |  | main.rs:67:5:67:21 | struct Foo |
-| main.rs:86:22:86:22 | y |  | main.rs:67:5:67:21 | struct Foo |
-| main.rs:86:37:90:5 | { ... } |  | main.rs:67:5:67:21 | struct Foo |
-| main.rs:88:9:88:9 | x |  | main.rs:67:5:67:21 | struct Foo |
-| main.rs:88:9:88:14 | x.m1(...) |  | main.rs:67:5:67:21 | struct Foo |
-| main.rs:89:9:89:9 | y |  | main.rs:67:5:67:21 | struct Foo |
-| main.rs:89:9:89:14 | y.m2(...) |  | main.rs:67:5:67:21 | struct Foo |
-| main.rs:105:15:105:18 | SelfParam |  | main.rs:94:5:97:5 | struct MyThing |
-| main.rs:105:15:105:18 | SelfParam | A | main.rs:99:5:100:14 | struct S1 |
-| main.rs:105:27:107:9 | { ... } |  | main.rs:99:5:100:14 | struct S1 |
-| main.rs:106:13:106:16 | self |  | main.rs:94:5:97:5 | struct MyThing |
-| main.rs:106:13:106:16 | self | A | main.rs:99:5:100:14 | struct S1 |
-| main.rs:106:13:106:18 | self.a |  | main.rs:99:5:100:14 | struct S1 |
-| main.rs:111:15:111:18 | SelfParam |  | main.rs:94:5:97:5 | struct MyThing |
-| main.rs:111:15:111:18 | SelfParam | A | main.rs:101:5:102:14 | struct S2 |
-| main.rs:111:29:113:9 | { ... } |  | main.rs:94:5:97:5 | struct MyThing |
-| main.rs:111:29:113:9 | { ... } | A | main.rs:101:5:102:14 | struct S2 |
-| main.rs:112:13:112:30 | Self {...} |  | main.rs:94:5:97:5 | struct MyThing |
-| main.rs:112:13:112:30 | Self {...} | A | main.rs:101:5:102:14 | struct S2 |
-| main.rs:112:23:112:26 | self |  | main.rs:94:5:97:5 | struct MyThing |
-| main.rs:112:23:112:26 | self | A | main.rs:101:5:102:14 | struct S2 |
-| main.rs:112:23:112:28 | self.a |  | main.rs:101:5:102:14 | struct S2 |
-| main.rs:117:15:117:18 | SelfParam |  | main.rs:94:5:97:5 | struct MyThing |
+| main.rs:26:13:26:13 | x |  | main.rs:5:5:8:5 | MyThing |
+| main.rs:26:17:26:32 | MyThing {...} |  | main.rs:5:5:8:5 | MyThing |
+| main.rs:26:30:26:30 | S |  | main.rs:2:5:3:13 | S |
+| main.rs:27:26:27:26 | x |  | main.rs:5:5:8:5 | MyThing |
+| main.rs:27:26:27:28 | x.a |  | main.rs:2:5:3:13 | S |
+| main.rs:32:13:32:13 | x |  | main.rs:16:5:19:5 | GenericThing |
+| main.rs:32:13:32:13 | x | A | main.rs:2:5:3:13 | S |
+| main.rs:32:17:32:42 | GenericThing::<...> {...} |  | main.rs:16:5:19:5 | GenericThing |
+| main.rs:32:17:32:42 | GenericThing::<...> {...} | A | main.rs:2:5:3:13 | S |
+| main.rs:32:40:32:40 | S |  | main.rs:2:5:3:13 | S |
+| main.rs:33:26:33:26 | x |  | main.rs:16:5:19:5 | GenericThing |
+| main.rs:33:26:33:26 | x | A | main.rs:2:5:3:13 | S |
+| main.rs:33:26:33:28 | x.a |  | main.rs:2:5:3:13 | S |
+| main.rs:36:13:36:13 | y |  | main.rs:16:5:19:5 | GenericThing |
+| main.rs:36:13:36:13 | y | A | main.rs:2:5:3:13 | S |
+| main.rs:36:17:36:37 | GenericThing {...} |  | main.rs:16:5:19:5 | GenericThing |
+| main.rs:36:17:36:37 | GenericThing {...} | A | main.rs:2:5:3:13 | S |
+| main.rs:36:35:36:35 | S |  | main.rs:2:5:3:13 | S |
+| main.rs:37:26:37:26 | x |  | main.rs:16:5:19:5 | GenericThing |
+| main.rs:37:26:37:26 | x | A | main.rs:2:5:3:13 | S |
+| main.rs:37:26:37:28 | x.a |  | main.rs:2:5:3:13 | S |
+| main.rs:41:13:41:13 | x |  | main.rs:21:5:23:5 | OptionS |
+| main.rs:41:17:43:9 | OptionS {...} |  | main.rs:21:5:23:5 | OptionS |
+| main.rs:42:16:42:33 | ...::MyNone(...) |  | main.rs:10:5:14:5 | MyOption |
+| main.rs:42:16:42:33 | ...::MyNone(...) | T | main.rs:2:5:3:13 | S |
+| main.rs:44:26:44:26 | x |  | main.rs:21:5:23:5 | OptionS |
+| main.rs:44:26:44:28 | x.a |  | main.rs:10:5:14:5 | MyOption |
+| main.rs:44:26:44:28 | x.a | T | main.rs:2:5:3:13 | S |
+| main.rs:47:13:47:13 | x |  | main.rs:16:5:19:5 | GenericThing |
+| main.rs:47:13:47:13 | x | A | main.rs:10:5:14:5 | MyOption |
+| main.rs:47:13:47:13 | x | A.T | main.rs:2:5:3:13 | S |
+| main.rs:47:17:49:9 | GenericThing::<...> {...} |  | main.rs:16:5:19:5 | GenericThing |
+| main.rs:47:17:49:9 | GenericThing::<...> {...} | A | main.rs:10:5:14:5 | MyOption |
+| main.rs:47:17:49:9 | GenericThing::<...> {...} | A.T | main.rs:2:5:3:13 | S |
+| main.rs:48:16:48:33 | ...::MyNone(...) |  | main.rs:10:5:14:5 | MyOption |
+| main.rs:48:16:48:33 | ...::MyNone(...) | T | main.rs:2:5:3:13 | S |
+| main.rs:50:26:50:26 | x |  | main.rs:16:5:19:5 | GenericThing |
+| main.rs:50:26:50:26 | x | A | main.rs:10:5:14:5 | MyOption |
+| main.rs:50:26:50:26 | x | A.T | main.rs:2:5:3:13 | S |
+| main.rs:50:26:50:28 | x.a |  | main.rs:10:5:14:5 | MyOption |
+| main.rs:50:26:50:28 | x.a | T | main.rs:2:5:3:13 | S |
+| main.rs:52:13:52:17 | mut x |  | main.rs:16:5:19:5 | GenericThing |
+| main.rs:52:13:52:17 | mut x | A | main.rs:10:5:14:5 | MyOption |
+| main.rs:52:13:52:17 | mut x | A.T | main.rs:2:5:3:13 | S |
+| main.rs:52:21:54:9 | GenericThing {...} |  | main.rs:16:5:19:5 | GenericThing |
+| main.rs:52:21:54:9 | GenericThing {...} | A | main.rs:10:5:14:5 | MyOption |
+| main.rs:52:21:54:9 | GenericThing {...} | A.T | main.rs:2:5:3:13 | S |
+| main.rs:53:16:53:33 | ...::MyNone(...) |  | main.rs:10:5:14:5 | MyOption |
+| main.rs:53:16:53:33 | ...::MyNone(...) | T | main.rs:2:5:3:13 | S |
+| main.rs:56:13:56:13 | a |  | main.rs:10:5:14:5 | MyOption |
+| main.rs:56:13:56:13 | a | T | main.rs:2:5:3:13 | S |
+| main.rs:56:30:56:30 | x |  | main.rs:16:5:19:5 | GenericThing |
+| main.rs:56:30:56:30 | x | A | main.rs:10:5:14:5 | MyOption |
+| main.rs:56:30:56:30 | x | A.T | main.rs:2:5:3:13 | S |
+| main.rs:56:30:56:32 | x.a |  | main.rs:10:5:14:5 | MyOption |
+| main.rs:56:30:56:32 | x.a | T | main.rs:2:5:3:13 | S |
+| main.rs:57:26:57:26 | a |  | main.rs:10:5:14:5 | MyOption |
+| main.rs:57:26:57:26 | a | T | main.rs:2:5:3:13 | S |
+| main.rs:70:19:70:22 | SelfParam |  | main.rs:67:5:67:21 | Foo |
+| main.rs:70:33:72:9 | { ... } |  | main.rs:67:5:67:21 | Foo |
+| main.rs:71:13:71:16 | self |  | main.rs:67:5:67:21 | Foo |
+| main.rs:74:19:74:22 | SelfParam |  | main.rs:67:5:67:21 | Foo |
+| main.rs:74:32:76:9 | { ... } |  | main.rs:67:5:67:21 | Foo |
+| main.rs:75:13:75:16 | self |  | main.rs:67:5:67:21 | Foo |
+| main.rs:79:23:84:5 | { ... } |  | main.rs:67:5:67:21 | Foo |
+| main.rs:81:13:81:13 | x |  | main.rs:67:5:67:21 | Foo |
+| main.rs:81:17:81:22 | Foo {...} |  | main.rs:67:5:67:21 | Foo |
+| main.rs:82:13:82:13 | y |  | main.rs:67:5:67:21 | Foo |
+| main.rs:82:20:82:25 | Foo {...} |  | main.rs:67:5:67:21 | Foo |
+| main.rs:83:9:83:9 | x |  | main.rs:67:5:67:21 | Foo |
+| main.rs:86:14:86:14 | x |  | main.rs:67:5:67:21 | Foo |
+| main.rs:86:22:86:22 | y |  | main.rs:67:5:67:21 | Foo |
+| main.rs:86:37:90:5 | { ... } |  | main.rs:67:5:67:21 | Foo |
+| main.rs:88:9:88:9 | x |  | main.rs:67:5:67:21 | Foo |
+| main.rs:88:9:88:14 | x.m1() |  | main.rs:67:5:67:21 | Foo |
+| main.rs:89:9:89:9 | y |  | main.rs:67:5:67:21 | Foo |
+| main.rs:89:9:89:14 | y.m2() |  | main.rs:67:5:67:21 | Foo |
+| main.rs:105:15:105:18 | SelfParam |  | main.rs:94:5:97:5 | MyThing |
+| main.rs:105:15:105:18 | SelfParam | A | main.rs:99:5:100:14 | S1 |
+| main.rs:105:27:107:9 | { ... } |  | main.rs:99:5:100:14 | S1 |
+| main.rs:106:13:106:16 | self |  | main.rs:94:5:97:5 | MyThing |
+| main.rs:106:13:106:16 | self | A | main.rs:99:5:100:14 | S1 |
+| main.rs:106:13:106:18 | self.a |  | main.rs:99:5:100:14 | S1 |
+| main.rs:111:15:111:18 | SelfParam |  | main.rs:94:5:97:5 | MyThing |
+| main.rs:111:15:111:18 | SelfParam | A | main.rs:101:5:102:14 | S2 |
+| main.rs:111:29:113:9 | { ... } |  | main.rs:94:5:97:5 | MyThing |
+| main.rs:111:29:113:9 | { ... } | A | main.rs:101:5:102:14 | S2 |
+| main.rs:112:13:112:30 | Self {...} |  | main.rs:94:5:97:5 | MyThing |
+| main.rs:112:13:112:30 | Self {...} | A | main.rs:101:5:102:14 | S2 |
+| main.rs:112:23:112:26 | self |  | main.rs:94:5:97:5 | MyThing |
+| main.rs:112:23:112:26 | self | A | main.rs:101:5:102:14 | S2 |
+| main.rs:112:23:112:28 | self.a |  | main.rs:101:5:102:14 | S2 |
+| main.rs:117:15:117:18 | SelfParam |  | main.rs:94:5:97:5 | MyThing |
 | main.rs:117:15:117:18 | SelfParam | A | main.rs:116:10:116:10 | T |
 | main.rs:117:26:119:9 | { ... } |  | main.rs:116:10:116:10 | T |
-| main.rs:118:13:118:16 | self |  | main.rs:94:5:97:5 | struct MyThing |
+| main.rs:118:13:118:16 | self |  | main.rs:94:5:97:5 | MyThing |
 | main.rs:118:13:118:16 | self | A | main.rs:116:10:116:10 | T |
 | main.rs:118:13:118:18 | self.a |  | main.rs:116:10:116:10 | T |
-| main.rs:123:13:123:13 | x |  | main.rs:94:5:97:5 | struct MyThing |
-| main.rs:123:13:123:13 | x | A | main.rs:99:5:100:14 | struct S1 |
-| main.rs:123:17:123:33 | MyThing {...} |  | main.rs:94:5:97:5 | struct MyThing |
-| main.rs:123:17:123:33 | MyThing {...} | A | main.rs:99:5:100:14 | struct S1 |
-| main.rs:123:30:123:31 | S1 |  | main.rs:99:5:100:14 | struct S1 |
-| main.rs:124:13:124:13 | y |  | main.rs:94:5:97:5 | struct MyThing |
-| main.rs:124:13:124:13 | y | A | main.rs:101:5:102:14 | struct S2 |
-| main.rs:124:17:124:33 | MyThing {...} |  | main.rs:94:5:97:5 | struct MyThing |
-| main.rs:124:17:124:33 | MyThing {...} | A | main.rs:101:5:102:14 | struct S2 |
-| main.rs:124:30:124:31 | S2 |  | main.rs:101:5:102:14 | struct S2 |
-| main.rs:127:26:127:26 | x |  | main.rs:94:5:97:5 | struct MyThing |
-| main.rs:127:26:127:26 | x | A | main.rs:99:5:100:14 | struct S1 |
-| main.rs:127:26:127:28 | x.a |  | main.rs:99:5:100:14 | struct S1 |
-| main.rs:128:26:128:26 | y |  | main.rs:94:5:97:5 | struct MyThing |
-| main.rs:128:26:128:26 | y | A | main.rs:101:5:102:14 | struct S2 |
-| main.rs:128:26:128:28 | y.a |  | main.rs:101:5:102:14 | struct S2 |
-| main.rs:130:26:130:26 | x |  | main.rs:94:5:97:5 | struct MyThing |
-| main.rs:130:26:130:26 | x | A | main.rs:99:5:100:14 | struct S1 |
-| main.rs:131:26:131:26 | y |  | main.rs:94:5:97:5 | struct MyThing |
-| main.rs:131:26:131:26 | y | A | main.rs:101:5:102:14 | struct S2 |
-| main.rs:133:13:133:13 | x |  | main.rs:94:5:97:5 | struct MyThing |
-| main.rs:133:13:133:13 | x | A | main.rs:99:5:100:14 | struct S1 |
-| main.rs:133:17:133:33 | MyThing {...} |  | main.rs:94:5:97:5 | struct MyThing |
-| main.rs:133:17:133:33 | MyThing {...} | A | main.rs:99:5:100:14 | struct S1 |
-| main.rs:133:30:133:31 | S1 |  | main.rs:99:5:100:14 | struct S1 |
-| main.rs:134:13:134:13 | y |  | main.rs:94:5:97:5 | struct MyThing |
-| main.rs:134:13:134:13 | y | A | main.rs:101:5:102:14 | struct S2 |
-| main.rs:134:17:134:33 | MyThing {...} |  | main.rs:94:5:97:5 | struct MyThing |
-| main.rs:134:17:134:33 | MyThing {...} | A | main.rs:101:5:102:14 | struct S2 |
-| main.rs:134:30:134:31 | S2 |  | main.rs:101:5:102:14 | struct S2 |
-| main.rs:136:26:136:26 | x |  | main.rs:94:5:97:5 | struct MyThing |
-| main.rs:136:26:136:26 | x | A | main.rs:99:5:100:14 | struct S1 |
-| main.rs:136:26:136:31 | x.m2(...) |  | main.rs:99:5:100:14 | struct S1 |
-| main.rs:137:26:137:26 | y |  | main.rs:94:5:97:5 | struct MyThing |
-| main.rs:137:26:137:26 | y | A | main.rs:101:5:102:14 | struct S2 |
-| main.rs:137:26:137:31 | y.m2(...) |  | main.rs:101:5:102:14 | struct S2 |
+| main.rs:123:13:123:13 | x |  | main.rs:94:5:97:5 | MyThing |
+| main.rs:123:13:123:13 | x | A | main.rs:99:5:100:14 | S1 |
+| main.rs:123:17:123:33 | MyThing {...} |  | main.rs:94:5:97:5 | MyThing |
+| main.rs:123:17:123:33 | MyThing {...} | A | main.rs:99:5:100:14 | S1 |
+| main.rs:123:30:123:31 | S1 |  | main.rs:99:5:100:14 | S1 |
+| main.rs:124:13:124:13 | y |  | main.rs:94:5:97:5 | MyThing |
+| main.rs:124:13:124:13 | y | A | main.rs:101:5:102:14 | S2 |
+| main.rs:124:17:124:33 | MyThing {...} |  | main.rs:94:5:97:5 | MyThing |
+| main.rs:124:17:124:33 | MyThing {...} | A | main.rs:101:5:102:14 | S2 |
+| main.rs:124:30:124:31 | S2 |  | main.rs:101:5:102:14 | S2 |
+| main.rs:127:26:127:26 | x |  | main.rs:94:5:97:5 | MyThing |
+| main.rs:127:26:127:26 | x | A | main.rs:99:5:100:14 | S1 |
+| main.rs:127:26:127:28 | x.a |  | main.rs:99:5:100:14 | S1 |
+| main.rs:128:26:128:26 | y |  | main.rs:94:5:97:5 | MyThing |
+| main.rs:128:26:128:26 | y | A | main.rs:101:5:102:14 | S2 |
+| main.rs:128:26:128:28 | y.a |  | main.rs:101:5:102:14 | S2 |
+| main.rs:130:26:130:26 | x |  | main.rs:94:5:97:5 | MyThing |
+| main.rs:130:26:130:26 | x | A | main.rs:99:5:100:14 | S1 |
+| main.rs:131:26:131:26 | y |  | main.rs:94:5:97:5 | MyThing |
+| main.rs:131:26:131:26 | y | A | main.rs:101:5:102:14 | S2 |
+| main.rs:133:13:133:13 | x |  | main.rs:94:5:97:5 | MyThing |
+| main.rs:133:13:133:13 | x | A | main.rs:99:5:100:14 | S1 |
+| main.rs:133:17:133:33 | MyThing {...} |  | main.rs:94:5:97:5 | MyThing |
+| main.rs:133:17:133:33 | MyThing {...} | A | main.rs:99:5:100:14 | S1 |
+| main.rs:133:30:133:31 | S1 |  | main.rs:99:5:100:14 | S1 |
+| main.rs:134:13:134:13 | y |  | main.rs:94:5:97:5 | MyThing |
+| main.rs:134:13:134:13 | y | A | main.rs:101:5:102:14 | S2 |
+| main.rs:134:17:134:33 | MyThing {...} |  | main.rs:94:5:97:5 | MyThing |
+| main.rs:134:17:134:33 | MyThing {...} | A | main.rs:101:5:102:14 | S2 |
+| main.rs:134:30:134:31 | S2 |  | main.rs:101:5:102:14 | S2 |
+| main.rs:136:26:136:26 | x |  | main.rs:94:5:97:5 | MyThing |
+| main.rs:136:26:136:26 | x | A | main.rs:99:5:100:14 | S1 |
+| main.rs:136:26:136:31 | x.m2() |  | main.rs:99:5:100:14 | S1 |
+| main.rs:137:26:137:26 | y |  | main.rs:94:5:97:5 | MyThing |
+| main.rs:137:26:137:26 | y | A | main.rs:101:5:102:14 | S2 |
+| main.rs:137:26:137:31 | y.m2() |  | main.rs:101:5:102:14 | S2 |
 | main.rs:153:15:153:18 | SelfParam |  | main.rs:152:5:161:5 | Self [trait MyTrait] |
 | main.rs:155:15:155:18 | SelfParam |  | main.rs:152:5:161:5 | Self [trait MyTrait] |
 | main.rs:158:9:160:9 | { ... } |  | main.rs:152:5:161:5 | Self [trait MyTrait] |
@@ -143,235 +143,235 @@ inferType
 | main.rs:163:43:163:43 | x |  | main.rs:163:26:163:40 | T2 |
 | main.rs:163:56:165:5 | { ... } |  | main.rs:163:22:163:23 | T1 |
 | main.rs:164:9:164:9 | x |  | main.rs:163:26:163:40 | T2 |
-| main.rs:164:9:164:14 | x.m1(...) |  | main.rs:163:22:163:23 | T1 |
-| main.rs:168:15:168:18 | SelfParam |  | main.rs:142:5:145:5 | struct MyThing |
-| main.rs:168:15:168:18 | SelfParam | A | main.rs:147:5:148:14 | struct S1 |
-| main.rs:168:27:170:9 | { ... } |  | main.rs:147:5:148:14 | struct S1 |
-| main.rs:169:13:169:16 | self |  | main.rs:142:5:145:5 | struct MyThing |
-| main.rs:169:13:169:16 | self | A | main.rs:147:5:148:14 | struct S1 |
-| main.rs:169:13:169:18 | self.a |  | main.rs:147:5:148:14 | struct S1 |
-| main.rs:174:15:174:18 | SelfParam |  | main.rs:142:5:145:5 | struct MyThing |
-| main.rs:174:15:174:18 | SelfParam | A | main.rs:149:5:150:14 | struct S2 |
-| main.rs:174:29:176:9 | { ... } |  | main.rs:142:5:145:5 | struct MyThing |
-| main.rs:174:29:176:9 | { ... } | A | main.rs:149:5:150:14 | struct S2 |
-| main.rs:175:13:175:30 | Self {...} |  | main.rs:142:5:145:5 | struct MyThing |
-| main.rs:175:13:175:30 | Self {...} | A | main.rs:149:5:150:14 | struct S2 |
-| main.rs:175:23:175:26 | self |  | main.rs:142:5:145:5 | struct MyThing |
-| main.rs:175:23:175:26 | self | A | main.rs:149:5:150:14 | struct S2 |
-| main.rs:175:23:175:28 | self.a |  | main.rs:149:5:150:14 | struct S2 |
-| main.rs:180:13:180:13 | x |  | main.rs:142:5:145:5 | struct MyThing |
-| main.rs:180:13:180:13 | x | A | main.rs:147:5:148:14 | struct S1 |
-| main.rs:180:17:180:33 | MyThing {...} |  | main.rs:142:5:145:5 | struct MyThing |
-| main.rs:180:17:180:33 | MyThing {...} | A | main.rs:147:5:148:14 | struct S1 |
-| main.rs:180:30:180:31 | S1 |  | main.rs:147:5:148:14 | struct S1 |
-| main.rs:181:13:181:13 | y |  | main.rs:142:5:145:5 | struct MyThing |
-| main.rs:181:13:181:13 | y | A | main.rs:149:5:150:14 | struct S2 |
-| main.rs:181:17:181:33 | MyThing {...} |  | main.rs:142:5:145:5 | struct MyThing |
-| main.rs:181:17:181:33 | MyThing {...} | A | main.rs:149:5:150:14 | struct S2 |
-| main.rs:181:30:181:31 | S2 |  | main.rs:149:5:150:14 | struct S2 |
-| main.rs:183:26:183:26 | x |  | main.rs:142:5:145:5 | struct MyThing |
-| main.rs:183:26:183:26 | x | A | main.rs:147:5:148:14 | struct S1 |
-| main.rs:184:26:184:26 | y |  | main.rs:142:5:145:5 | struct MyThing |
-| main.rs:184:26:184:26 | y | A | main.rs:149:5:150:14 | struct S2 |
-| main.rs:186:13:186:13 | x |  | main.rs:142:5:145:5 | struct MyThing |
-| main.rs:186:13:186:13 | x | A | main.rs:147:5:148:14 | struct S1 |
-| main.rs:186:17:186:33 | MyThing {...} |  | main.rs:142:5:145:5 | struct MyThing |
-| main.rs:186:17:186:33 | MyThing {...} | A | main.rs:147:5:148:14 | struct S1 |
-| main.rs:186:30:186:31 | S1 |  | main.rs:147:5:148:14 | struct S1 |
-| main.rs:187:13:187:13 | y |  | main.rs:142:5:145:5 | struct MyThing |
-| main.rs:187:13:187:13 | y | A | main.rs:149:5:150:14 | struct S2 |
-| main.rs:187:17:187:33 | MyThing {...} |  | main.rs:142:5:145:5 | struct MyThing |
-| main.rs:187:17:187:33 | MyThing {...} | A | main.rs:149:5:150:14 | struct S2 |
-| main.rs:187:30:187:31 | S2 |  | main.rs:149:5:150:14 | struct S2 |
-| main.rs:189:40:189:40 | x |  | main.rs:142:5:145:5 | struct MyThing |
-| main.rs:189:40:189:40 | x | A | main.rs:147:5:148:14 | struct S1 |
-| main.rs:190:40:190:40 | y |  | main.rs:142:5:145:5 | struct MyThing |
-| main.rs:190:40:190:40 | y | A | main.rs:149:5:150:14 | struct S2 |
+| main.rs:164:9:164:14 | x.m1() |  | main.rs:163:22:163:23 | T1 |
+| main.rs:168:15:168:18 | SelfParam |  | main.rs:142:5:145:5 | MyThing |
+| main.rs:168:15:168:18 | SelfParam | A | main.rs:147:5:148:14 | S1 |
+| main.rs:168:27:170:9 | { ... } |  | main.rs:147:5:148:14 | S1 |
+| main.rs:169:13:169:16 | self |  | main.rs:142:5:145:5 | MyThing |
+| main.rs:169:13:169:16 | self | A | main.rs:147:5:148:14 | S1 |
+| main.rs:169:13:169:18 | self.a |  | main.rs:147:5:148:14 | S1 |
+| main.rs:174:15:174:18 | SelfParam |  | main.rs:142:5:145:5 | MyThing |
+| main.rs:174:15:174:18 | SelfParam | A | main.rs:149:5:150:14 | S2 |
+| main.rs:174:29:176:9 | { ... } |  | main.rs:142:5:145:5 | MyThing |
+| main.rs:174:29:176:9 | { ... } | A | main.rs:149:5:150:14 | S2 |
+| main.rs:175:13:175:30 | Self {...} |  | main.rs:142:5:145:5 | MyThing |
+| main.rs:175:13:175:30 | Self {...} | A | main.rs:149:5:150:14 | S2 |
+| main.rs:175:23:175:26 | self |  | main.rs:142:5:145:5 | MyThing |
+| main.rs:175:23:175:26 | self | A | main.rs:149:5:150:14 | S2 |
+| main.rs:175:23:175:28 | self.a |  | main.rs:149:5:150:14 | S2 |
+| main.rs:180:13:180:13 | x |  | main.rs:142:5:145:5 | MyThing |
+| main.rs:180:13:180:13 | x | A | main.rs:147:5:148:14 | S1 |
+| main.rs:180:17:180:33 | MyThing {...} |  | main.rs:142:5:145:5 | MyThing |
+| main.rs:180:17:180:33 | MyThing {...} | A | main.rs:147:5:148:14 | S1 |
+| main.rs:180:30:180:31 | S1 |  | main.rs:147:5:148:14 | S1 |
+| main.rs:181:13:181:13 | y |  | main.rs:142:5:145:5 | MyThing |
+| main.rs:181:13:181:13 | y | A | main.rs:149:5:150:14 | S2 |
+| main.rs:181:17:181:33 | MyThing {...} |  | main.rs:142:5:145:5 | MyThing |
+| main.rs:181:17:181:33 | MyThing {...} | A | main.rs:149:5:150:14 | S2 |
+| main.rs:181:30:181:31 | S2 |  | main.rs:149:5:150:14 | S2 |
+| main.rs:183:26:183:26 | x |  | main.rs:142:5:145:5 | MyThing |
+| main.rs:183:26:183:26 | x | A | main.rs:147:5:148:14 | S1 |
+| main.rs:184:26:184:26 | y |  | main.rs:142:5:145:5 | MyThing |
+| main.rs:184:26:184:26 | y | A | main.rs:149:5:150:14 | S2 |
+| main.rs:186:13:186:13 | x |  | main.rs:142:5:145:5 | MyThing |
+| main.rs:186:13:186:13 | x | A | main.rs:147:5:148:14 | S1 |
+| main.rs:186:17:186:33 | MyThing {...} |  | main.rs:142:5:145:5 | MyThing |
+| main.rs:186:17:186:33 | MyThing {...} | A | main.rs:147:5:148:14 | S1 |
+| main.rs:186:30:186:31 | S1 |  | main.rs:147:5:148:14 | S1 |
+| main.rs:187:13:187:13 | y |  | main.rs:142:5:145:5 | MyThing |
+| main.rs:187:13:187:13 | y | A | main.rs:149:5:150:14 | S2 |
+| main.rs:187:17:187:33 | MyThing {...} |  | main.rs:142:5:145:5 | MyThing |
+| main.rs:187:17:187:33 | MyThing {...} | A | main.rs:149:5:150:14 | S2 |
+| main.rs:187:30:187:31 | S2 |  | main.rs:149:5:150:14 | S2 |
+| main.rs:189:40:189:40 | x |  | main.rs:142:5:145:5 | MyThing |
+| main.rs:189:40:189:40 | x | A | main.rs:147:5:148:14 | S1 |
+| main.rs:190:40:190:40 | y |  | main.rs:142:5:145:5 | MyThing |
+| main.rs:190:40:190:40 | y | A | main.rs:149:5:150:14 | S2 |
 | main.rs:206:19:206:22 | SelfParam |  | main.rs:205:5:207:5 | Self [trait FirstTrait] |
 | main.rs:210:19:210:22 | SelfParam |  | main.rs:209:5:211:5 | Self [trait SecondTrait] |
 | main.rs:213:64:213:64 | x |  | main.rs:213:45:213:61 | T |
 | main.rs:215:13:215:14 | s1 |  | main.rs:213:35:213:42 | I |
 | main.rs:215:18:215:18 | x |  | main.rs:213:45:213:61 | T |
-| main.rs:215:18:215:27 | x.method(...) |  | main.rs:213:35:213:42 | I |
+| main.rs:215:18:215:27 | x.method() |  | main.rs:213:35:213:42 | I |
 | main.rs:216:26:216:27 | s1 |  | main.rs:213:35:213:42 | I |
 | main.rs:219:65:219:65 | x |  | main.rs:219:46:219:62 | T |
 | main.rs:221:13:221:14 | s2 |  | main.rs:219:36:219:43 | I |
 | main.rs:221:18:221:18 | x |  | main.rs:219:46:219:62 | T |
-| main.rs:221:18:221:27 | x.method(...) |  | main.rs:219:36:219:43 | I |
+| main.rs:221:18:221:27 | x.method() |  | main.rs:219:36:219:43 | I |
 | main.rs:222:26:222:27 | s2 |  | main.rs:219:36:219:43 | I |
 | main.rs:225:49:225:49 | x |  | main.rs:225:30:225:46 | T |
-| main.rs:226:13:226:13 | s |  | main.rs:197:5:198:14 | struct S1 |
+| main.rs:226:13:226:13 | s |  | main.rs:197:5:198:14 | S1 |
 | main.rs:226:17:226:17 | x |  | main.rs:225:30:225:46 | T |
-| main.rs:226:17:226:26 | x.method(...) |  | main.rs:197:5:198:14 | struct S1 |
-| main.rs:227:26:227:26 | s |  | main.rs:197:5:198:14 | struct S1 |
+| main.rs:226:17:226:26 | x.method() |  | main.rs:197:5:198:14 | S1 |
+| main.rs:227:26:227:26 | s |  | main.rs:197:5:198:14 | S1 |
 | main.rs:230:53:230:53 | x |  | main.rs:230:34:230:50 | T |
-| main.rs:231:13:231:13 | s |  | main.rs:197:5:198:14 | struct S1 |
+| main.rs:231:13:231:13 | s |  | main.rs:197:5:198:14 | S1 |
 | main.rs:231:17:231:17 | x |  | main.rs:230:34:230:50 | T |
-| main.rs:231:17:231:26 | x.method(...) |  | main.rs:197:5:198:14 | struct S1 |
-| main.rs:232:26:232:26 | s |  | main.rs:197:5:198:14 | struct S1 |
+| main.rs:231:17:231:26 | x.method() |  | main.rs:197:5:198:14 | S1 |
+| main.rs:232:26:232:26 | s |  | main.rs:197:5:198:14 | S1 |
 | main.rs:236:16:236:19 | SelfParam |  | main.rs:235:5:239:5 | Self [trait Pair] |
 | main.rs:238:16:238:19 | SelfParam |  | main.rs:235:5:239:5 | Self [trait Pair] |
 | main.rs:241:58:241:58 | x |  | main.rs:241:41:241:55 | T |
 | main.rs:241:64:241:64 | y |  | main.rs:241:41:241:55 | T |
-| main.rs:243:13:243:14 | s1 |  | main.rs:197:5:198:14 | struct S1 |
+| main.rs:243:13:243:14 | s1 |  | main.rs:197:5:198:14 | S1 |
 | main.rs:243:18:243:18 | x |  | main.rs:241:41:241:55 | T |
-| main.rs:243:18:243:24 | x.fst(...) |  | main.rs:197:5:198:14 | struct S1 |
-| main.rs:244:13:244:14 | s2 |  | main.rs:200:5:201:14 | struct S2 |
+| main.rs:243:18:243:24 | x.fst() |  | main.rs:197:5:198:14 | S1 |
+| main.rs:244:13:244:14 | s2 |  | main.rs:200:5:201:14 | S2 |
 | main.rs:244:18:244:18 | y |  | main.rs:241:41:241:55 | T |
-| main.rs:244:18:244:24 | y.snd(...) |  | main.rs:200:5:201:14 | struct S2 |
-| main.rs:245:32:245:33 | s1 |  | main.rs:197:5:198:14 | struct S1 |
-| main.rs:245:36:245:37 | s2 |  | main.rs:200:5:201:14 | struct S2 |
+| main.rs:244:18:244:24 | y.snd() |  | main.rs:200:5:201:14 | S2 |
+| main.rs:245:32:245:33 | s1 |  | main.rs:197:5:198:14 | S1 |
+| main.rs:245:36:245:37 | s2 |  | main.rs:200:5:201:14 | S2 |
 | main.rs:248:69:248:69 | x |  | main.rs:248:52:248:66 | T |
 | main.rs:248:75:248:75 | y |  | main.rs:248:52:248:66 | T |
-| main.rs:250:13:250:14 | s1 |  | main.rs:197:5:198:14 | struct S1 |
+| main.rs:250:13:250:14 | s1 |  | main.rs:197:5:198:14 | S1 |
 | main.rs:250:18:250:18 | x |  | main.rs:248:52:248:66 | T |
-| main.rs:250:18:250:24 | x.fst(...) |  | main.rs:197:5:198:14 | struct S1 |
+| main.rs:250:18:250:24 | x.fst() |  | main.rs:197:5:198:14 | S1 |
 | main.rs:251:13:251:14 | s2 |  | main.rs:248:41:248:49 | T2 |
 | main.rs:251:18:251:18 | y |  | main.rs:248:52:248:66 | T |
-| main.rs:251:18:251:24 | y.snd(...) |  | main.rs:248:41:248:49 | T2 |
-| main.rs:252:32:252:33 | s1 |  | main.rs:197:5:198:14 | struct S1 |
+| main.rs:251:18:251:24 | y.snd() |  | main.rs:248:41:248:49 | T2 |
+| main.rs:252:32:252:33 | s1 |  | main.rs:197:5:198:14 | S1 |
 | main.rs:252:36:252:37 | s2 |  | main.rs:248:41:248:49 | T2 |
 | main.rs:268:15:268:18 | SelfParam |  | main.rs:267:5:276:5 | Self [trait MyTrait] |
 | main.rs:270:15:270:18 | SelfParam |  | main.rs:267:5:276:5 | Self [trait MyTrait] |
 | main.rs:273:9:275:9 | { ... } |  | main.rs:267:19:267:19 | A |
 | main.rs:274:13:274:16 | self |  | main.rs:267:5:276:5 | Self [trait MyTrait] |
-| main.rs:274:13:274:21 | self.m1(...) |  | main.rs:267:19:267:19 | A |
+| main.rs:274:13:274:21 | self.m1() |  | main.rs:267:19:267:19 | A |
 | main.rs:279:43:279:43 | x |  | main.rs:279:26:279:40 | T2 |
 | main.rs:279:56:281:5 | { ... } |  | main.rs:279:22:279:23 | T1 |
 | main.rs:280:9:280:9 | x |  | main.rs:279:26:279:40 | T2 |
-| main.rs:280:9:280:14 | x.m1(...) |  | main.rs:279:22:279:23 | T1 |
-| main.rs:284:49:284:49 | x |  | main.rs:257:5:260:5 | struct MyThing |
+| main.rs:280:9:280:14 | x.m1() |  | main.rs:279:22:279:23 | T1 |
+| main.rs:284:49:284:49 | x |  | main.rs:257:5:260:5 | MyThing |
 | main.rs:284:49:284:49 | x | T | main.rs:284:32:284:46 | T2 |
 | main.rs:284:71:286:5 | { ... } |  | main.rs:284:28:284:29 | T1 |
-| main.rs:285:9:285:9 | x |  | main.rs:257:5:260:5 | struct MyThing |
+| main.rs:285:9:285:9 | x |  | main.rs:257:5:260:5 | MyThing |
 | main.rs:285:9:285:9 | x | T | main.rs:284:32:284:46 | T2 |
 | main.rs:285:9:285:11 | x.a |  | main.rs:284:32:284:46 | T2 |
-| main.rs:285:9:285:16 | ... .m1(...) |  | main.rs:284:28:284:29 | T1 |
-| main.rs:289:15:289:18 | SelfParam |  | main.rs:257:5:260:5 | struct MyThing |
+| main.rs:285:9:285:16 | ... .m1() |  | main.rs:284:28:284:29 | T1 |
+| main.rs:289:15:289:18 | SelfParam |  | main.rs:257:5:260:5 | MyThing |
 | main.rs:289:15:289:18 | SelfParam | T | main.rs:288:10:288:10 | T |
 | main.rs:289:26:291:9 | { ... } |  | main.rs:288:10:288:10 | T |
-| main.rs:290:13:290:16 | self |  | main.rs:257:5:260:5 | struct MyThing |
+| main.rs:290:13:290:16 | self |  | main.rs:257:5:260:5 | MyThing |
 | main.rs:290:13:290:16 | self | T | main.rs:288:10:288:10 | T |
 | main.rs:290:13:290:18 | self.a |  | main.rs:288:10:288:10 | T |
-| main.rs:295:13:295:13 | x |  | main.rs:257:5:260:5 | struct MyThing |
-| main.rs:295:13:295:13 | x | T | main.rs:262:5:263:14 | struct S1 |
-| main.rs:295:17:295:33 | MyThing {...} |  | main.rs:257:5:260:5 | struct MyThing |
-| main.rs:295:17:295:33 | MyThing {...} | T | main.rs:262:5:263:14 | struct S1 |
-| main.rs:295:30:295:31 | S1 |  | main.rs:262:5:263:14 | struct S1 |
-| main.rs:296:13:296:13 | y |  | main.rs:257:5:260:5 | struct MyThing |
-| main.rs:296:13:296:13 | y | T | main.rs:264:5:265:14 | struct S2 |
-| main.rs:296:17:296:33 | MyThing {...} |  | main.rs:257:5:260:5 | struct MyThing |
-| main.rs:296:17:296:33 | MyThing {...} | T | main.rs:264:5:265:14 | struct S2 |
-| main.rs:296:30:296:31 | S2 |  | main.rs:264:5:265:14 | struct S2 |
-| main.rs:298:26:298:26 | x |  | main.rs:257:5:260:5 | struct MyThing |
-| main.rs:298:26:298:26 | x | T | main.rs:262:5:263:14 | struct S1 |
-| main.rs:298:26:298:31 | x.m1(...) |  | main.rs:262:5:263:14 | struct S1 |
-| main.rs:299:26:299:26 | y |  | main.rs:257:5:260:5 | struct MyThing |
-| main.rs:299:26:299:26 | y | T | main.rs:264:5:265:14 | struct S2 |
-| main.rs:299:26:299:31 | y.m1(...) |  | main.rs:264:5:265:14 | struct S2 |
-| main.rs:301:13:301:13 | x |  | main.rs:257:5:260:5 | struct MyThing |
-| main.rs:301:13:301:13 | x | T | main.rs:262:5:263:14 | struct S1 |
-| main.rs:301:17:301:33 | MyThing {...} |  | main.rs:257:5:260:5 | struct MyThing |
-| main.rs:301:17:301:33 | MyThing {...} | T | main.rs:262:5:263:14 | struct S1 |
-| main.rs:301:30:301:31 | S1 |  | main.rs:262:5:263:14 | struct S1 |
-| main.rs:302:13:302:13 | y |  | main.rs:257:5:260:5 | struct MyThing |
-| main.rs:302:13:302:13 | y | T | main.rs:264:5:265:14 | struct S2 |
-| main.rs:302:17:302:33 | MyThing {...} |  | main.rs:257:5:260:5 | struct MyThing |
-| main.rs:302:17:302:33 | MyThing {...} | T | main.rs:264:5:265:14 | struct S2 |
-| main.rs:302:30:302:31 | S2 |  | main.rs:264:5:265:14 | struct S2 |
-| main.rs:304:26:304:26 | x |  | main.rs:257:5:260:5 | struct MyThing |
-| main.rs:304:26:304:26 | x | T | main.rs:262:5:263:14 | struct S1 |
-| main.rs:304:26:304:31 | x.m2(...) |  | main.rs:262:5:263:14 | struct S1 |
-| main.rs:305:26:305:26 | y |  | main.rs:257:5:260:5 | struct MyThing |
-| main.rs:305:26:305:26 | y | T | main.rs:264:5:265:14 | struct S2 |
-| main.rs:305:26:305:31 | y.m2(...) |  | main.rs:264:5:265:14 | struct S2 |
-| main.rs:307:13:307:14 | x2 |  | main.rs:257:5:260:5 | struct MyThing |
-| main.rs:307:13:307:14 | x2 | T | main.rs:262:5:263:14 | struct S1 |
-| main.rs:307:18:307:34 | MyThing {...} |  | main.rs:257:5:260:5 | struct MyThing |
-| main.rs:307:18:307:34 | MyThing {...} | T | main.rs:262:5:263:14 | struct S1 |
-| main.rs:307:31:307:32 | S1 |  | main.rs:262:5:263:14 | struct S1 |
-| main.rs:308:13:308:14 | y2 |  | main.rs:257:5:260:5 | struct MyThing |
-| main.rs:308:13:308:14 | y2 | T | main.rs:264:5:265:14 | struct S2 |
-| main.rs:308:18:308:34 | MyThing {...} |  | main.rs:257:5:260:5 | struct MyThing |
-| main.rs:308:18:308:34 | MyThing {...} | T | main.rs:264:5:265:14 | struct S2 |
-| main.rs:308:31:308:32 | S2 |  | main.rs:264:5:265:14 | struct S2 |
-| main.rs:310:26:310:42 | call_trait_m1(...) |  | main.rs:262:5:263:14 | struct S1 |
-| main.rs:310:40:310:41 | x2 |  | main.rs:257:5:260:5 | struct MyThing |
-| main.rs:310:40:310:41 | x2 | T | main.rs:262:5:263:14 | struct S1 |
-| main.rs:311:26:311:42 | call_trait_m1(...) |  | main.rs:264:5:265:14 | struct S2 |
-| main.rs:311:40:311:41 | y2 |  | main.rs:257:5:260:5 | struct MyThing |
-| main.rs:311:40:311:41 | y2 | T | main.rs:264:5:265:14 | struct S2 |
-| main.rs:313:13:313:14 | x3 |  | main.rs:257:5:260:5 | struct MyThing |
-| main.rs:313:13:313:14 | x3 | T | main.rs:257:5:260:5 | struct MyThing |
-| main.rs:313:13:313:14 | x3 | T.T | main.rs:262:5:263:14 | struct S1 |
-| main.rs:313:18:315:9 | MyThing {...} |  | main.rs:257:5:260:5 | struct MyThing |
-| main.rs:313:18:315:9 | MyThing {...} | T | main.rs:257:5:260:5 | struct MyThing |
-| main.rs:313:18:315:9 | MyThing {...} | T.T | main.rs:262:5:263:14 | struct S1 |
-| main.rs:314:16:314:32 | MyThing {...} |  | main.rs:257:5:260:5 | struct MyThing |
-| main.rs:314:16:314:32 | MyThing {...} | T | main.rs:262:5:263:14 | struct S1 |
-| main.rs:314:29:314:30 | S1 |  | main.rs:262:5:263:14 | struct S1 |
-| main.rs:316:13:316:14 | y3 |  | main.rs:257:5:260:5 | struct MyThing |
-| main.rs:316:13:316:14 | y3 | T | main.rs:257:5:260:5 | struct MyThing |
-| main.rs:316:13:316:14 | y3 | T.T | main.rs:264:5:265:14 | struct S2 |
-| main.rs:316:18:318:9 | MyThing {...} |  | main.rs:257:5:260:5 | struct MyThing |
-| main.rs:316:18:318:9 | MyThing {...} | T | main.rs:257:5:260:5 | struct MyThing |
-| main.rs:316:18:318:9 | MyThing {...} | T.T | main.rs:264:5:265:14 | struct S2 |
-| main.rs:317:16:317:32 | MyThing {...} |  | main.rs:257:5:260:5 | struct MyThing |
-| main.rs:317:16:317:32 | MyThing {...} | T | main.rs:264:5:265:14 | struct S2 |
-| main.rs:317:29:317:30 | S2 |  | main.rs:264:5:265:14 | struct S2 |
-| main.rs:320:26:320:48 | call_trait_thing_m1(...) |  | main.rs:262:5:263:14 | struct S1 |
-| main.rs:320:46:320:47 | x3 |  | main.rs:257:5:260:5 | struct MyThing |
-| main.rs:320:46:320:47 | x3 | T | main.rs:257:5:260:5 | struct MyThing |
-| main.rs:320:46:320:47 | x3 | T.T | main.rs:262:5:263:14 | struct S1 |
-| main.rs:321:26:321:48 | call_trait_thing_m1(...) |  | main.rs:264:5:265:14 | struct S2 |
-| main.rs:321:46:321:47 | y3 |  | main.rs:257:5:260:5 | struct MyThing |
-| main.rs:321:46:321:47 | y3 | T | main.rs:257:5:260:5 | struct MyThing |
-| main.rs:321:46:321:47 | y3 | T.T | main.rs:264:5:265:14 | struct S2 |
+| main.rs:295:13:295:13 | x |  | main.rs:257:5:260:5 | MyThing |
+| main.rs:295:13:295:13 | x | T | main.rs:262:5:263:14 | S1 |
+| main.rs:295:17:295:33 | MyThing {...} |  | main.rs:257:5:260:5 | MyThing |
+| main.rs:295:17:295:33 | MyThing {...} | T | main.rs:262:5:263:14 | S1 |
+| main.rs:295:30:295:31 | S1 |  | main.rs:262:5:263:14 | S1 |
+| main.rs:296:13:296:13 | y |  | main.rs:257:5:260:5 | MyThing |
+| main.rs:296:13:296:13 | y | T | main.rs:264:5:265:14 | S2 |
+| main.rs:296:17:296:33 | MyThing {...} |  | main.rs:257:5:260:5 | MyThing |
+| main.rs:296:17:296:33 | MyThing {...} | T | main.rs:264:5:265:14 | S2 |
+| main.rs:296:30:296:31 | S2 |  | main.rs:264:5:265:14 | S2 |
+| main.rs:298:26:298:26 | x |  | main.rs:257:5:260:5 | MyThing |
+| main.rs:298:26:298:26 | x | T | main.rs:262:5:263:14 | S1 |
+| main.rs:298:26:298:31 | x.m1() |  | main.rs:262:5:263:14 | S1 |
+| main.rs:299:26:299:26 | y |  | main.rs:257:5:260:5 | MyThing |
+| main.rs:299:26:299:26 | y | T | main.rs:264:5:265:14 | S2 |
+| main.rs:299:26:299:31 | y.m1() |  | main.rs:264:5:265:14 | S2 |
+| main.rs:301:13:301:13 | x |  | main.rs:257:5:260:5 | MyThing |
+| main.rs:301:13:301:13 | x | T | main.rs:262:5:263:14 | S1 |
+| main.rs:301:17:301:33 | MyThing {...} |  | main.rs:257:5:260:5 | MyThing |
+| main.rs:301:17:301:33 | MyThing {...} | T | main.rs:262:5:263:14 | S1 |
+| main.rs:301:30:301:31 | S1 |  | main.rs:262:5:263:14 | S1 |
+| main.rs:302:13:302:13 | y |  | main.rs:257:5:260:5 | MyThing |
+| main.rs:302:13:302:13 | y | T | main.rs:264:5:265:14 | S2 |
+| main.rs:302:17:302:33 | MyThing {...} |  | main.rs:257:5:260:5 | MyThing |
+| main.rs:302:17:302:33 | MyThing {...} | T | main.rs:264:5:265:14 | S2 |
+| main.rs:302:30:302:31 | S2 |  | main.rs:264:5:265:14 | S2 |
+| main.rs:304:26:304:26 | x |  | main.rs:257:5:260:5 | MyThing |
+| main.rs:304:26:304:26 | x | T | main.rs:262:5:263:14 | S1 |
+| main.rs:304:26:304:31 | x.m2() |  | main.rs:262:5:263:14 | S1 |
+| main.rs:305:26:305:26 | y |  | main.rs:257:5:260:5 | MyThing |
+| main.rs:305:26:305:26 | y | T | main.rs:264:5:265:14 | S2 |
+| main.rs:305:26:305:31 | y.m2() |  | main.rs:264:5:265:14 | S2 |
+| main.rs:307:13:307:14 | x2 |  | main.rs:257:5:260:5 | MyThing |
+| main.rs:307:13:307:14 | x2 | T | main.rs:262:5:263:14 | S1 |
+| main.rs:307:18:307:34 | MyThing {...} |  | main.rs:257:5:260:5 | MyThing |
+| main.rs:307:18:307:34 | MyThing {...} | T | main.rs:262:5:263:14 | S1 |
+| main.rs:307:31:307:32 | S1 |  | main.rs:262:5:263:14 | S1 |
+| main.rs:308:13:308:14 | y2 |  | main.rs:257:5:260:5 | MyThing |
+| main.rs:308:13:308:14 | y2 | T | main.rs:264:5:265:14 | S2 |
+| main.rs:308:18:308:34 | MyThing {...} |  | main.rs:257:5:260:5 | MyThing |
+| main.rs:308:18:308:34 | MyThing {...} | T | main.rs:264:5:265:14 | S2 |
+| main.rs:308:31:308:32 | S2 |  | main.rs:264:5:265:14 | S2 |
+| main.rs:310:26:310:42 | call_trait_m1(...) |  | main.rs:262:5:263:14 | S1 |
+| main.rs:310:40:310:41 | x2 |  | main.rs:257:5:260:5 | MyThing |
+| main.rs:310:40:310:41 | x2 | T | main.rs:262:5:263:14 | S1 |
+| main.rs:311:26:311:42 | call_trait_m1(...) |  | main.rs:264:5:265:14 | S2 |
+| main.rs:311:40:311:41 | y2 |  | main.rs:257:5:260:5 | MyThing |
+| main.rs:311:40:311:41 | y2 | T | main.rs:264:5:265:14 | S2 |
+| main.rs:313:13:313:14 | x3 |  | main.rs:257:5:260:5 | MyThing |
+| main.rs:313:13:313:14 | x3 | T | main.rs:257:5:260:5 | MyThing |
+| main.rs:313:13:313:14 | x3 | T.T | main.rs:262:5:263:14 | S1 |
+| main.rs:313:18:315:9 | MyThing {...} |  | main.rs:257:5:260:5 | MyThing |
+| main.rs:313:18:315:9 | MyThing {...} | T | main.rs:257:5:260:5 | MyThing |
+| main.rs:313:18:315:9 | MyThing {...} | T.T | main.rs:262:5:263:14 | S1 |
+| main.rs:314:16:314:32 | MyThing {...} |  | main.rs:257:5:260:5 | MyThing |
+| main.rs:314:16:314:32 | MyThing {...} | T | main.rs:262:5:263:14 | S1 |
+| main.rs:314:29:314:30 | S1 |  | main.rs:262:5:263:14 | S1 |
+| main.rs:316:13:316:14 | y3 |  | main.rs:257:5:260:5 | MyThing |
+| main.rs:316:13:316:14 | y3 | T | main.rs:257:5:260:5 | MyThing |
+| main.rs:316:13:316:14 | y3 | T.T | main.rs:264:5:265:14 | S2 |
+| main.rs:316:18:318:9 | MyThing {...} |  | main.rs:257:5:260:5 | MyThing |
+| main.rs:316:18:318:9 | MyThing {...} | T | main.rs:257:5:260:5 | MyThing |
+| main.rs:316:18:318:9 | MyThing {...} | T.T | main.rs:264:5:265:14 | S2 |
+| main.rs:317:16:317:32 | MyThing {...} |  | main.rs:257:5:260:5 | MyThing |
+| main.rs:317:16:317:32 | MyThing {...} | T | main.rs:264:5:265:14 | S2 |
+| main.rs:317:29:317:30 | S2 |  | main.rs:264:5:265:14 | S2 |
+| main.rs:320:26:320:48 | call_trait_thing_m1(...) |  | main.rs:262:5:263:14 | S1 |
+| main.rs:320:46:320:47 | x3 |  | main.rs:257:5:260:5 | MyThing |
+| main.rs:320:46:320:47 | x3 | T | main.rs:257:5:260:5 | MyThing |
+| main.rs:320:46:320:47 | x3 | T.T | main.rs:262:5:263:14 | S1 |
+| main.rs:321:26:321:48 | call_trait_thing_m1(...) |  | main.rs:264:5:265:14 | S2 |
+| main.rs:321:46:321:47 | y3 |  | main.rs:257:5:260:5 | MyThing |
+| main.rs:321:46:321:47 | y3 | T | main.rs:257:5:260:5 | MyThing |
+| main.rs:321:46:321:47 | y3 | T.T | main.rs:264:5:265:14 | S2 |
 | main.rs:329:15:329:18 | SelfParam |  | main.rs:326:5:338:5 | Self [trait MyTrait] |
 | main.rs:331:15:331:18 | SelfParam |  | main.rs:326:5:338:5 | Self [trait MyTrait] |
-| main.rs:346:15:346:18 | SelfParam |  | main.rs:340:5:341:13 | struct S |
-| main.rs:346:45:348:9 | { ... } |  | main.rs:340:5:341:13 | struct S |
-| main.rs:347:13:347:13 | S |  | main.rs:340:5:341:13 | struct S |
-| main.rs:352:13:352:13 | x |  | main.rs:340:5:341:13 | struct S |
-| main.rs:352:17:352:17 | S |  | main.rs:340:5:341:13 | struct S |
-| main.rs:353:26:353:26 | x |  | main.rs:340:5:341:13 | struct S |
-| main.rs:353:26:353:31 | x.m1(...) |  | main.rs:340:5:341:13 | struct S |
-| main.rs:355:13:355:13 | x |  | main.rs:340:5:341:13 | struct S |
-| main.rs:355:17:355:17 | S |  | main.rs:340:5:341:13 | struct S |
-| main.rs:356:26:356:26 | x |  | main.rs:340:5:341:13 | struct S |
-| main.rs:373:15:373:18 | SelfParam |  | main.rs:361:5:365:5 | enum MyEnum |
+| main.rs:346:15:346:18 | SelfParam |  | main.rs:340:5:341:13 | S |
+| main.rs:346:45:348:9 | { ... } |  | main.rs:340:5:341:13 | S |
+| main.rs:347:13:347:13 | S |  | main.rs:340:5:341:13 | S |
+| main.rs:352:13:352:13 | x |  | main.rs:340:5:341:13 | S |
+| main.rs:352:17:352:17 | S |  | main.rs:340:5:341:13 | S |
+| main.rs:353:26:353:26 | x |  | main.rs:340:5:341:13 | S |
+| main.rs:353:26:353:31 | x.m1() |  | main.rs:340:5:341:13 | S |
+| main.rs:355:13:355:13 | x |  | main.rs:340:5:341:13 | S |
+| main.rs:355:17:355:17 | S |  | main.rs:340:5:341:13 | S |
+| main.rs:356:26:356:26 | x |  | main.rs:340:5:341:13 | S |
+| main.rs:373:15:373:18 | SelfParam |  | main.rs:361:5:365:5 | MyEnum |
 | main.rs:373:15:373:18 | SelfParam | A | main.rs:372:10:372:10 | T |
 | main.rs:373:26:378:9 | { ... } |  | main.rs:372:10:372:10 | T |
 | main.rs:374:13:377:13 | match self { ... } |  | main.rs:372:10:372:10 | T |
-| main.rs:374:19:374:22 | self |  | main.rs:361:5:365:5 | enum MyEnum |
+| main.rs:374:19:374:22 | self |  | main.rs:361:5:365:5 | MyEnum |
 | main.rs:374:19:374:22 | self | A | main.rs:372:10:372:10 | T |
 | main.rs:375:28:375:28 | a |  | main.rs:372:10:372:10 | T |
 | main.rs:375:34:375:34 | a |  | main.rs:372:10:372:10 | T |
 | main.rs:376:30:376:30 | a |  | main.rs:372:10:372:10 | T |
 | main.rs:376:37:376:37 | a |  | main.rs:372:10:372:10 | T |
-| main.rs:382:13:382:13 | x |  | main.rs:361:5:365:5 | enum MyEnum |
-| main.rs:382:13:382:13 | x | A | main.rs:367:5:368:14 | struct S1 |
-| main.rs:382:17:382:30 | ...::C1(...) |  | main.rs:361:5:365:5 | enum MyEnum |
-| main.rs:382:17:382:30 | ...::C1(...) | A | main.rs:367:5:368:14 | struct S1 |
-| main.rs:382:28:382:29 | S1 |  | main.rs:367:5:368:14 | struct S1 |
-| main.rs:383:13:383:13 | y |  | main.rs:361:5:365:5 | enum MyEnum |
-| main.rs:383:13:383:13 | y | A | main.rs:369:5:370:14 | struct S2 |
-| main.rs:383:17:383:36 | ...::C2 {...} |  | main.rs:361:5:365:5 | enum MyEnum |
-| main.rs:383:17:383:36 | ...::C2 {...} | A | main.rs:369:5:370:14 | struct S2 |
-| main.rs:383:33:383:34 | S2 |  | main.rs:369:5:370:14 | struct S2 |
-| main.rs:385:26:385:26 | x |  | main.rs:361:5:365:5 | enum MyEnum |
-| main.rs:385:26:385:26 | x | A | main.rs:367:5:368:14 | struct S1 |
-| main.rs:385:26:385:31 | x.m1(...) |  | main.rs:367:5:368:14 | struct S1 |
-| main.rs:386:26:386:26 | y |  | main.rs:361:5:365:5 | enum MyEnum |
-| main.rs:386:26:386:26 | y | A | main.rs:369:5:370:14 | struct S2 |
-| main.rs:386:26:386:31 | y.m1(...) |  | main.rs:369:5:370:14 | struct S2 |
+| main.rs:382:13:382:13 | x |  | main.rs:361:5:365:5 | MyEnum |
+| main.rs:382:13:382:13 | x | A | main.rs:367:5:368:14 | S1 |
+| main.rs:382:17:382:30 | ...::C1(...) |  | main.rs:361:5:365:5 | MyEnum |
+| main.rs:382:17:382:30 | ...::C1(...) | A | main.rs:367:5:368:14 | S1 |
+| main.rs:382:28:382:29 | S1 |  | main.rs:367:5:368:14 | S1 |
+| main.rs:383:13:383:13 | y |  | main.rs:361:5:365:5 | MyEnum |
+| main.rs:383:13:383:13 | y | A | main.rs:369:5:370:14 | S2 |
+| main.rs:383:17:383:36 | ...::C2 {...} |  | main.rs:361:5:365:5 | MyEnum |
+| main.rs:383:17:383:36 | ...::C2 {...} | A | main.rs:369:5:370:14 | S2 |
+| main.rs:383:33:383:34 | S2 |  | main.rs:369:5:370:14 | S2 |
+| main.rs:385:26:385:26 | x |  | main.rs:361:5:365:5 | MyEnum |
+| main.rs:385:26:385:26 | x | A | main.rs:367:5:368:14 | S1 |
+| main.rs:385:26:385:31 | x.m1() |  | main.rs:367:5:368:14 | S1 |
+| main.rs:386:26:386:26 | y |  | main.rs:361:5:365:5 | MyEnum |
+| main.rs:386:26:386:26 | y | A | main.rs:369:5:370:14 | S2 |
+| main.rs:386:26:386:31 | y.m1() |  | main.rs:369:5:370:14 | S2 |
 | main.rs:407:15:407:18 | SelfParam |  | main.rs:406:5:408:5 | Self [trait MyTrait1] |
 | main.rs:411:15:411:18 | SelfParam |  | main.rs:410:5:421:5 | Self [trait MyTrait2] |
 | main.rs:414:9:420:9 | { ... } |  | main.rs:410:20:410:22 | Tr2 |
 | main.rs:415:13:419:13 | if ... {...} else {...} |  | main.rs:410:20:410:22 | Tr2 |
 | main.rs:415:26:417:13 | { ... } |  | main.rs:410:20:410:22 | Tr2 |
 | main.rs:416:17:416:20 | self |  | main.rs:410:5:421:5 | Self [trait MyTrait2] |
-| main.rs:416:17:416:25 | self.m1(...) |  | main.rs:410:20:410:22 | Tr2 |
+| main.rs:416:17:416:25 | self.m1() |  | main.rs:410:20:410:22 | Tr2 |
 | main.rs:417:20:419:13 | { ... } |  | main.rs:410:20:410:22 | Tr2 |
 | main.rs:418:17:418:30 | ...::m1(...) |  | main.rs:410:20:410:22 | Tr2 |
 | main.rs:418:26:418:29 | self |  | main.rs:410:5:421:5 | Self [trait MyTrait2] |
@@ -380,147 +380,147 @@ inferType
 | main.rs:428:13:432:13 | if ... {...} else {...} |  | main.rs:423:20:423:22 | Tr3 |
 | main.rs:428:26:430:13 | { ... } |  | main.rs:423:20:423:22 | Tr3 |
 | main.rs:429:17:429:20 | self |  | main.rs:423:5:434:5 | Self [trait MyTrait3] |
-| main.rs:429:17:429:25 | self.m2(...) |  | main.rs:391:5:394:5 | struct MyThing |
-| main.rs:429:17:429:25 | self.m2(...) | A | main.rs:423:20:423:22 | Tr3 |
+| main.rs:429:17:429:25 | self.m2() |  | main.rs:391:5:394:5 | MyThing |
+| main.rs:429:17:429:25 | self.m2() | A | main.rs:423:20:423:22 | Tr3 |
 | main.rs:429:17:429:27 | ... .a |  | main.rs:423:20:423:22 | Tr3 |
 | main.rs:430:20:432:13 | { ... } |  | main.rs:423:20:423:22 | Tr3 |
-| main.rs:431:17:431:30 | ...::m2(...) |  | main.rs:391:5:394:5 | struct MyThing |
+| main.rs:431:17:431:30 | ...::m2(...) |  | main.rs:391:5:394:5 | MyThing |
 | main.rs:431:17:431:30 | ...::m2(...) | A | main.rs:423:20:423:22 | Tr3 |
 | main.rs:431:17:431:32 | ... .a |  | main.rs:423:20:423:22 | Tr3 |
 | main.rs:431:26:431:29 | self |  | main.rs:423:5:434:5 | Self [trait MyTrait3] |
-| main.rs:437:15:437:18 | SelfParam |  | main.rs:391:5:394:5 | struct MyThing |
+| main.rs:437:15:437:18 | SelfParam |  | main.rs:391:5:394:5 | MyThing |
 | main.rs:437:15:437:18 | SelfParam | A | main.rs:436:10:436:10 | T |
 | main.rs:437:26:439:9 | { ... } |  | main.rs:436:10:436:10 | T |
-| main.rs:438:13:438:16 | self |  | main.rs:391:5:394:5 | struct MyThing |
+| main.rs:438:13:438:16 | self |  | main.rs:391:5:394:5 | MyThing |
 | main.rs:438:13:438:16 | self | A | main.rs:436:10:436:10 | T |
 | main.rs:438:13:438:18 | self.a |  | main.rs:436:10:436:10 | T |
-| main.rs:445:15:445:18 | SelfParam |  | main.rs:396:5:399:5 | struct MyThing2 |
+| main.rs:445:15:445:18 | SelfParam |  | main.rs:396:5:399:5 | MyThing2 |
 | main.rs:445:15:445:18 | SelfParam | A | main.rs:444:10:444:10 | T |
-| main.rs:445:35:447:9 | { ... } |  | main.rs:391:5:394:5 | struct MyThing |
+| main.rs:445:35:447:9 | { ... } |  | main.rs:391:5:394:5 | MyThing |
 | main.rs:445:35:447:9 | { ... } | A | main.rs:444:10:444:10 | T |
-| main.rs:446:13:446:33 | MyThing {...} |  | main.rs:391:5:394:5 | struct MyThing |
+| main.rs:446:13:446:33 | MyThing {...} |  | main.rs:391:5:394:5 | MyThing |
 | main.rs:446:13:446:33 | MyThing {...} | A | main.rs:444:10:444:10 | T |
-| main.rs:446:26:446:29 | self |  | main.rs:396:5:399:5 | struct MyThing2 |
+| main.rs:446:26:446:29 | self |  | main.rs:396:5:399:5 | MyThing2 |
 | main.rs:446:26:446:29 | self | A | main.rs:444:10:444:10 | T |
 | main.rs:446:26:446:31 | self.a |  | main.rs:444:10:444:10 | T |
-| main.rs:455:13:455:13 | x |  | main.rs:391:5:394:5 | struct MyThing |
-| main.rs:455:13:455:13 | x | A | main.rs:401:5:402:14 | struct S1 |
-| main.rs:455:17:455:33 | MyThing {...} |  | main.rs:391:5:394:5 | struct MyThing |
-| main.rs:455:17:455:33 | MyThing {...} | A | main.rs:401:5:402:14 | struct S1 |
-| main.rs:455:30:455:31 | S1 |  | main.rs:401:5:402:14 | struct S1 |
-| main.rs:456:13:456:13 | y |  | main.rs:391:5:394:5 | struct MyThing |
-| main.rs:456:13:456:13 | y | A | main.rs:403:5:404:14 | struct S2 |
-| main.rs:456:17:456:33 | MyThing {...} |  | main.rs:391:5:394:5 | struct MyThing |
-| main.rs:456:17:456:33 | MyThing {...} | A | main.rs:403:5:404:14 | struct S2 |
-| main.rs:456:30:456:31 | S2 |  | main.rs:403:5:404:14 | struct S2 |
-| main.rs:458:26:458:26 | x |  | main.rs:391:5:394:5 | struct MyThing |
-| main.rs:458:26:458:26 | x | A | main.rs:401:5:402:14 | struct S1 |
-| main.rs:458:26:458:31 | x.m1(...) |  | main.rs:401:5:402:14 | struct S1 |
-| main.rs:459:26:459:26 | y |  | main.rs:391:5:394:5 | struct MyThing |
-| main.rs:459:26:459:26 | y | A | main.rs:403:5:404:14 | struct S2 |
-| main.rs:459:26:459:31 | y.m1(...) |  | main.rs:403:5:404:14 | struct S2 |
-| main.rs:461:13:461:13 | x |  | main.rs:391:5:394:5 | struct MyThing |
-| main.rs:461:13:461:13 | x | A | main.rs:401:5:402:14 | struct S1 |
-| main.rs:461:17:461:33 | MyThing {...} |  | main.rs:391:5:394:5 | struct MyThing |
-| main.rs:461:17:461:33 | MyThing {...} | A | main.rs:401:5:402:14 | struct S1 |
-| main.rs:461:30:461:31 | S1 |  | main.rs:401:5:402:14 | struct S1 |
-| main.rs:462:13:462:13 | y |  | main.rs:391:5:394:5 | struct MyThing |
-| main.rs:462:13:462:13 | y | A | main.rs:403:5:404:14 | struct S2 |
-| main.rs:462:17:462:33 | MyThing {...} |  | main.rs:391:5:394:5 | struct MyThing |
-| main.rs:462:17:462:33 | MyThing {...} | A | main.rs:403:5:404:14 | struct S2 |
-| main.rs:462:30:462:31 | S2 |  | main.rs:403:5:404:14 | struct S2 |
-| main.rs:464:26:464:26 | x |  | main.rs:391:5:394:5 | struct MyThing |
-| main.rs:464:26:464:26 | x | A | main.rs:401:5:402:14 | struct S1 |
-| main.rs:464:26:464:31 | x.m2(...) |  | main.rs:401:5:402:14 | struct S1 |
-| main.rs:465:26:465:26 | y |  | main.rs:391:5:394:5 | struct MyThing |
-| main.rs:465:26:465:26 | y | A | main.rs:403:5:404:14 | struct S2 |
-| main.rs:465:26:465:31 | y.m2(...) |  | main.rs:403:5:404:14 | struct S2 |
-| main.rs:467:13:467:13 | x |  | main.rs:396:5:399:5 | struct MyThing2 |
-| main.rs:467:13:467:13 | x | A | main.rs:401:5:402:14 | struct S1 |
-| main.rs:467:17:467:34 | MyThing2 {...} |  | main.rs:396:5:399:5 | struct MyThing2 |
-| main.rs:467:17:467:34 | MyThing2 {...} | A | main.rs:401:5:402:14 | struct S1 |
-| main.rs:467:31:467:32 | S1 |  | main.rs:401:5:402:14 | struct S1 |
-| main.rs:468:13:468:13 | y |  | main.rs:396:5:399:5 | struct MyThing2 |
-| main.rs:468:13:468:13 | y | A | main.rs:403:5:404:14 | struct S2 |
-| main.rs:468:17:468:34 | MyThing2 {...} |  | main.rs:396:5:399:5 | struct MyThing2 |
-| main.rs:468:17:468:34 | MyThing2 {...} | A | main.rs:403:5:404:14 | struct S2 |
-| main.rs:468:31:468:32 | S2 |  | main.rs:403:5:404:14 | struct S2 |
-| main.rs:470:26:470:26 | x |  | main.rs:396:5:399:5 | struct MyThing2 |
-| main.rs:470:26:470:26 | x | A | main.rs:401:5:402:14 | struct S1 |
-| main.rs:470:26:470:31 | x.m3(...) |  | main.rs:401:5:402:14 | struct S1 |
-| main.rs:471:26:471:26 | y |  | main.rs:396:5:399:5 | struct MyThing2 |
-| main.rs:471:26:471:26 | y | A | main.rs:403:5:404:14 | struct S2 |
-| main.rs:471:26:471:31 | y.m3(...) |  | main.rs:403:5:404:14 | struct S2 |
+| main.rs:455:13:455:13 | x |  | main.rs:391:5:394:5 | MyThing |
+| main.rs:455:13:455:13 | x | A | main.rs:401:5:402:14 | S1 |
+| main.rs:455:17:455:33 | MyThing {...} |  | main.rs:391:5:394:5 | MyThing |
+| main.rs:455:17:455:33 | MyThing {...} | A | main.rs:401:5:402:14 | S1 |
+| main.rs:455:30:455:31 | S1 |  | main.rs:401:5:402:14 | S1 |
+| main.rs:456:13:456:13 | y |  | main.rs:391:5:394:5 | MyThing |
+| main.rs:456:13:456:13 | y | A | main.rs:403:5:404:14 | S2 |
+| main.rs:456:17:456:33 | MyThing {...} |  | main.rs:391:5:394:5 | MyThing |
+| main.rs:456:17:456:33 | MyThing {...} | A | main.rs:403:5:404:14 | S2 |
+| main.rs:456:30:456:31 | S2 |  | main.rs:403:5:404:14 | S2 |
+| main.rs:458:26:458:26 | x |  | main.rs:391:5:394:5 | MyThing |
+| main.rs:458:26:458:26 | x | A | main.rs:401:5:402:14 | S1 |
+| main.rs:458:26:458:31 | x.m1() |  | main.rs:401:5:402:14 | S1 |
+| main.rs:459:26:459:26 | y |  | main.rs:391:5:394:5 | MyThing |
+| main.rs:459:26:459:26 | y | A | main.rs:403:5:404:14 | S2 |
+| main.rs:459:26:459:31 | y.m1() |  | main.rs:403:5:404:14 | S2 |
+| main.rs:461:13:461:13 | x |  | main.rs:391:5:394:5 | MyThing |
+| main.rs:461:13:461:13 | x | A | main.rs:401:5:402:14 | S1 |
+| main.rs:461:17:461:33 | MyThing {...} |  | main.rs:391:5:394:5 | MyThing |
+| main.rs:461:17:461:33 | MyThing {...} | A | main.rs:401:5:402:14 | S1 |
+| main.rs:461:30:461:31 | S1 |  | main.rs:401:5:402:14 | S1 |
+| main.rs:462:13:462:13 | y |  | main.rs:391:5:394:5 | MyThing |
+| main.rs:462:13:462:13 | y | A | main.rs:403:5:404:14 | S2 |
+| main.rs:462:17:462:33 | MyThing {...} |  | main.rs:391:5:394:5 | MyThing |
+| main.rs:462:17:462:33 | MyThing {...} | A | main.rs:403:5:404:14 | S2 |
+| main.rs:462:30:462:31 | S2 |  | main.rs:403:5:404:14 | S2 |
+| main.rs:464:26:464:26 | x |  | main.rs:391:5:394:5 | MyThing |
+| main.rs:464:26:464:26 | x | A | main.rs:401:5:402:14 | S1 |
+| main.rs:464:26:464:31 | x.m2() |  | main.rs:401:5:402:14 | S1 |
+| main.rs:465:26:465:26 | y |  | main.rs:391:5:394:5 | MyThing |
+| main.rs:465:26:465:26 | y | A | main.rs:403:5:404:14 | S2 |
+| main.rs:465:26:465:31 | y.m2() |  | main.rs:403:5:404:14 | S2 |
+| main.rs:467:13:467:13 | x |  | main.rs:396:5:399:5 | MyThing2 |
+| main.rs:467:13:467:13 | x | A | main.rs:401:5:402:14 | S1 |
+| main.rs:467:17:467:34 | MyThing2 {...} |  | main.rs:396:5:399:5 | MyThing2 |
+| main.rs:467:17:467:34 | MyThing2 {...} | A | main.rs:401:5:402:14 | S1 |
+| main.rs:467:31:467:32 | S1 |  | main.rs:401:5:402:14 | S1 |
+| main.rs:468:13:468:13 | y |  | main.rs:396:5:399:5 | MyThing2 |
+| main.rs:468:13:468:13 | y | A | main.rs:403:5:404:14 | S2 |
+| main.rs:468:17:468:34 | MyThing2 {...} |  | main.rs:396:5:399:5 | MyThing2 |
+| main.rs:468:17:468:34 | MyThing2 {...} | A | main.rs:403:5:404:14 | S2 |
+| main.rs:468:31:468:32 | S2 |  | main.rs:403:5:404:14 | S2 |
+| main.rs:470:26:470:26 | x |  | main.rs:396:5:399:5 | MyThing2 |
+| main.rs:470:26:470:26 | x | A | main.rs:401:5:402:14 | S1 |
+| main.rs:470:26:470:31 | x.m3() |  | main.rs:401:5:402:14 | S1 |
+| main.rs:471:26:471:26 | y |  | main.rs:396:5:399:5 | MyThing2 |
+| main.rs:471:26:471:26 | y | A | main.rs:403:5:404:14 | S2 |
+| main.rs:471:26:471:31 | y.m3() |  | main.rs:403:5:404:14 | S2 |
 | main.rs:489:22:489:22 | x |  | file://:0:0:0:0 | & |
 | main.rs:489:22:489:22 | x | &T | main.rs:489:11:489:19 | T |
 | main.rs:489:35:491:5 | { ... } |  | file://:0:0:0:0 | & |
 | main.rs:489:35:491:5 | { ... } | &T | main.rs:489:11:489:19 | T |
 | main.rs:490:9:490:9 | x |  | file://:0:0:0:0 | & |
 | main.rs:490:9:490:9 | x | &T | main.rs:489:11:489:19 | T |
-| main.rs:494:17:494:20 | SelfParam |  | main.rs:479:5:480:14 | struct S1 |
-| main.rs:494:29:496:9 | { ... } |  | main.rs:482:5:483:14 | struct S2 |
-| main.rs:495:13:495:14 | S2 |  | main.rs:482:5:483:14 | struct S2 |
+| main.rs:494:17:494:20 | SelfParam |  | main.rs:479:5:480:14 | S1 |
+| main.rs:494:29:496:9 | { ... } |  | main.rs:482:5:483:14 | S2 |
+| main.rs:495:13:495:14 | S2 |  | main.rs:482:5:483:14 | S2 |
 | main.rs:499:21:499:21 | x |  | main.rs:499:13:499:14 | T1 |
 | main.rs:502:5:504:5 | { ... } |  | main.rs:499:17:499:18 | T2 |
 | main.rs:503:9:503:9 | x |  | main.rs:499:13:499:14 | T1 |
-| main.rs:503:9:503:16 | x.into(...) |  | main.rs:499:17:499:18 | T2 |
-| main.rs:507:13:507:13 | x |  | main.rs:479:5:480:14 | struct S1 |
-| main.rs:507:17:507:18 | S1 |  | main.rs:479:5:480:14 | struct S1 |
+| main.rs:503:9:503:16 | x.into() |  | main.rs:499:17:499:18 | T2 |
+| main.rs:507:13:507:13 | x |  | main.rs:479:5:480:14 | S1 |
+| main.rs:507:17:507:18 | S1 |  | main.rs:479:5:480:14 | S1 |
 | main.rs:508:26:508:31 | id(...) |  | file://:0:0:0:0 | & |
-| main.rs:508:26:508:31 | id(...) | &T | main.rs:479:5:480:14 | struct S1 |
+| main.rs:508:26:508:31 | id(...) | &T | main.rs:479:5:480:14 | S1 |
 | main.rs:508:29:508:30 | &x |  | file://:0:0:0:0 | & |
-| main.rs:508:29:508:30 | &x | &T | main.rs:479:5:480:14 | struct S1 |
-| main.rs:508:30:508:30 | x |  | main.rs:479:5:480:14 | struct S1 |
-| main.rs:510:13:510:13 | x |  | main.rs:479:5:480:14 | struct S1 |
-| main.rs:510:17:510:18 | S1 |  | main.rs:479:5:480:14 | struct S1 |
+| main.rs:508:29:508:30 | &x | &T | main.rs:479:5:480:14 | S1 |
+| main.rs:508:30:508:30 | x |  | main.rs:479:5:480:14 | S1 |
+| main.rs:510:13:510:13 | x |  | main.rs:479:5:480:14 | S1 |
+| main.rs:510:17:510:18 | S1 |  | main.rs:479:5:480:14 | S1 |
 | main.rs:511:26:511:37 | id::<...>(...) |  | file://:0:0:0:0 | & |
-| main.rs:511:26:511:37 | id::<...>(...) | &T | main.rs:479:5:480:14 | struct S1 |
+| main.rs:511:26:511:37 | id::<...>(...) | &T | main.rs:479:5:480:14 | S1 |
 | main.rs:511:35:511:36 | &x |  | file://:0:0:0:0 | & |
-| main.rs:511:35:511:36 | &x | &T | main.rs:479:5:480:14 | struct S1 |
-| main.rs:511:36:511:36 | x |  | main.rs:479:5:480:14 | struct S1 |
-| main.rs:513:13:513:13 | x |  | main.rs:479:5:480:14 | struct S1 |
-| main.rs:513:17:513:18 | S1 |  | main.rs:479:5:480:14 | struct S1 |
+| main.rs:511:35:511:36 | &x | &T | main.rs:479:5:480:14 | S1 |
+| main.rs:511:36:511:36 | x |  | main.rs:479:5:480:14 | S1 |
+| main.rs:513:13:513:13 | x |  | main.rs:479:5:480:14 | S1 |
+| main.rs:513:17:513:18 | S1 |  | main.rs:479:5:480:14 | S1 |
 | main.rs:514:26:514:44 | id::<...>(...) |  | file://:0:0:0:0 | & |
-| main.rs:514:26:514:44 | id::<...>(...) | &T | main.rs:479:5:480:14 | struct S1 |
+| main.rs:514:26:514:44 | id::<...>(...) | &T | main.rs:479:5:480:14 | S1 |
 | main.rs:514:42:514:43 | &x |  | file://:0:0:0:0 | & |
-| main.rs:514:42:514:43 | &x | &T | main.rs:479:5:480:14 | struct S1 |
-| main.rs:514:43:514:43 | x |  | main.rs:479:5:480:14 | struct S1 |
-| main.rs:516:13:516:13 | x |  | main.rs:479:5:480:14 | struct S1 |
-| main.rs:516:17:516:18 | S1 |  | main.rs:479:5:480:14 | struct S1 |
-| main.rs:517:9:517:25 | into::<...>(...) |  | main.rs:482:5:483:14 | struct S2 |
-| main.rs:517:24:517:24 | x |  | main.rs:479:5:480:14 | struct S1 |
-| main.rs:519:13:519:13 | x |  | main.rs:479:5:480:14 | struct S1 |
-| main.rs:519:17:519:18 | S1 |  | main.rs:479:5:480:14 | struct S1 |
-| main.rs:520:13:520:13 | y |  | main.rs:482:5:483:14 | struct S2 |
-| main.rs:520:21:520:27 | into(...) |  | main.rs:482:5:483:14 | struct S2 |
-| main.rs:520:26:520:26 | x |  | main.rs:479:5:480:14 | struct S1 |
-| main.rs:550:13:550:14 | p1 |  | main.rs:525:5:531:5 | enum PairOption |
-| main.rs:550:13:550:14 | p1 | Fst | main.rs:533:5:534:14 | struct S1 |
-| main.rs:550:13:550:14 | p1 | Snd | main.rs:536:5:537:14 | struct S2 |
-| main.rs:550:26:550:53 | ...::PairBoth(...) |  | main.rs:525:5:531:5 | enum PairOption |
-| main.rs:550:26:550:53 | ...::PairBoth(...) | Fst | main.rs:533:5:534:14 | struct S1 |
-| main.rs:550:26:550:53 | ...::PairBoth(...) | Snd | main.rs:536:5:537:14 | struct S2 |
-| main.rs:550:47:550:48 | S1 |  | main.rs:533:5:534:14 | struct S1 |
-| main.rs:550:51:550:52 | S2 |  | main.rs:536:5:537:14 | struct S2 |
-| main.rs:551:26:551:27 | p1 |  | main.rs:525:5:531:5 | enum PairOption |
-| main.rs:551:26:551:27 | p1 | Fst | main.rs:533:5:534:14 | struct S1 |
-| main.rs:551:26:551:27 | p1 | Snd | main.rs:536:5:537:14 | struct S2 |
-| main.rs:554:13:554:14 | p2 |  | main.rs:525:5:531:5 | enum PairOption |
-| main.rs:554:26:554:47 | ...::PairNone(...) |  | main.rs:525:5:531:5 | enum PairOption |
-| main.rs:555:26:555:27 | p2 |  | main.rs:525:5:531:5 | enum PairOption |
-| main.rs:558:13:558:14 | p3 |  | main.rs:525:5:531:5 | enum PairOption |
-| main.rs:558:13:558:14 | p3 | Snd | main.rs:539:5:540:14 | struct S3 |
-| main.rs:558:34:558:56 | ...::PairSnd(...) |  | main.rs:525:5:531:5 | enum PairOption |
-| main.rs:558:34:558:56 | ...::PairSnd(...) | Snd | main.rs:539:5:540:14 | struct S3 |
-| main.rs:558:54:558:55 | S3 |  | main.rs:539:5:540:14 | struct S3 |
-| main.rs:559:26:559:27 | p3 |  | main.rs:525:5:531:5 | enum PairOption |
-| main.rs:559:26:559:27 | p3 | Snd | main.rs:539:5:540:14 | struct S3 |
-| main.rs:562:13:562:14 | p3 |  | main.rs:525:5:531:5 | enum PairOption |
-| main.rs:562:13:562:14 | p3 | Fst | main.rs:539:5:540:14 | struct S3 |
-| main.rs:562:35:562:56 | ...::PairNone(...) |  | main.rs:525:5:531:5 | enum PairOption |
-| main.rs:562:35:562:56 | ...::PairNone(...) | Fst | main.rs:539:5:540:14 | struct S3 |
-| main.rs:563:26:563:27 | p3 |  | main.rs:525:5:531:5 | enum PairOption |
-| main.rs:563:26:563:27 | p3 | Fst | main.rs:539:5:540:14 | struct S3 |
+| main.rs:514:42:514:43 | &x | &T | main.rs:479:5:480:14 | S1 |
+| main.rs:514:43:514:43 | x |  | main.rs:479:5:480:14 | S1 |
+| main.rs:516:13:516:13 | x |  | main.rs:479:5:480:14 | S1 |
+| main.rs:516:17:516:18 | S1 |  | main.rs:479:5:480:14 | S1 |
+| main.rs:517:9:517:25 | into::<...>(...) |  | main.rs:482:5:483:14 | S2 |
+| main.rs:517:24:517:24 | x |  | main.rs:479:5:480:14 | S1 |
+| main.rs:519:13:519:13 | x |  | main.rs:479:5:480:14 | S1 |
+| main.rs:519:17:519:18 | S1 |  | main.rs:479:5:480:14 | S1 |
+| main.rs:520:13:520:13 | y |  | main.rs:482:5:483:14 | S2 |
+| main.rs:520:21:520:27 | into(...) |  | main.rs:482:5:483:14 | S2 |
+| main.rs:520:26:520:26 | x |  | main.rs:479:5:480:14 | S1 |
+| main.rs:550:13:550:14 | p1 |  | main.rs:525:5:531:5 | PairOption |
+| main.rs:550:13:550:14 | p1 | Fst | main.rs:533:5:534:14 | S1 |
+| main.rs:550:13:550:14 | p1 | Snd | main.rs:536:5:537:14 | S2 |
+| main.rs:550:26:550:53 | ...::PairBoth(...) |  | main.rs:525:5:531:5 | PairOption |
+| main.rs:550:26:550:53 | ...::PairBoth(...) | Fst | main.rs:533:5:534:14 | S1 |
+| main.rs:550:26:550:53 | ...::PairBoth(...) | Snd | main.rs:536:5:537:14 | S2 |
+| main.rs:550:47:550:48 | S1 |  | main.rs:533:5:534:14 | S1 |
+| main.rs:550:51:550:52 | S2 |  | main.rs:536:5:537:14 | S2 |
+| main.rs:551:26:551:27 | p1 |  | main.rs:525:5:531:5 | PairOption |
+| main.rs:551:26:551:27 | p1 | Fst | main.rs:533:5:534:14 | S1 |
+| main.rs:551:26:551:27 | p1 | Snd | main.rs:536:5:537:14 | S2 |
+| main.rs:554:13:554:14 | p2 |  | main.rs:525:5:531:5 | PairOption |
+| main.rs:554:26:554:47 | ...::PairNone(...) |  | main.rs:525:5:531:5 | PairOption |
+| main.rs:555:26:555:27 | p2 |  | main.rs:525:5:531:5 | PairOption |
+| main.rs:558:13:558:14 | p3 |  | main.rs:525:5:531:5 | PairOption |
+| main.rs:558:13:558:14 | p3 | Snd | main.rs:539:5:540:14 | S3 |
+| main.rs:558:34:558:56 | ...::PairSnd(...) |  | main.rs:525:5:531:5 | PairOption |
+| main.rs:558:34:558:56 | ...::PairSnd(...) | Snd | main.rs:539:5:540:14 | S3 |
+| main.rs:558:54:558:55 | S3 |  | main.rs:539:5:540:14 | S3 |
+| main.rs:559:26:559:27 | p3 |  | main.rs:525:5:531:5 | PairOption |
+| main.rs:559:26:559:27 | p3 | Snd | main.rs:539:5:540:14 | S3 |
+| main.rs:562:13:562:14 | p3 |  | main.rs:525:5:531:5 | PairOption |
+| main.rs:562:13:562:14 | p3 | Fst | main.rs:539:5:540:14 | S3 |
+| main.rs:562:35:562:56 | ...::PairNone(...) |  | main.rs:525:5:531:5 | PairOption |
+| main.rs:562:35:562:56 | ...::PairNone(...) | Fst | main.rs:539:5:540:14 | S3 |
+| main.rs:563:26:563:27 | p3 |  | main.rs:525:5:531:5 | PairOption |
+| main.rs:563:26:563:27 | p3 | Fst | main.rs:539:5:540:14 | S3 |
 | main.rs:575:16:575:24 | SelfParam |  | file://:0:0:0:0 | & |
 | main.rs:575:16:575:24 | SelfParam | &T | main.rs:574:5:580:5 | Self [trait MyTrait] |
 | main.rs:575:27:575:31 | value |  | main.rs:574:19:574:19 | S |
@@ -531,240 +531,240 @@ inferType
 | main.rs:578:13:578:16 | self | &T | main.rs:574:5:580:5 | Self [trait MyTrait] |
 | main.rs:578:22:578:26 | value |  | main.rs:574:19:574:19 | S |
 | main.rs:583:16:583:24 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:583:16:583:24 | SelfParam | &T | main.rs:568:5:572:5 | enum MyOption |
+| main.rs:583:16:583:24 | SelfParam | &T | main.rs:568:5:572:5 | MyOption |
 | main.rs:583:16:583:24 | SelfParam | &T.T | main.rs:582:10:582:10 | T |
 | main.rs:583:27:583:31 | value |  | main.rs:582:10:582:10 | T |
-| main.rs:587:26:589:9 | { ... } |  | main.rs:568:5:572:5 | enum MyOption |
+| main.rs:587:26:589:9 | { ... } |  | main.rs:568:5:572:5 | MyOption |
 | main.rs:587:26:589:9 | { ... } | T | main.rs:586:10:586:10 | T |
-| main.rs:588:13:588:30 | ...::MyNone(...) |  | main.rs:568:5:572:5 | enum MyOption |
+| main.rs:588:13:588:30 | ...::MyNone(...) |  | main.rs:568:5:572:5 | MyOption |
 | main.rs:588:13:588:30 | ...::MyNone(...) | T | main.rs:586:10:586:10 | T |
-| main.rs:593:20:593:23 | SelfParam |  | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:593:20:593:23 | SelfParam | T | main.rs:568:5:572:5 | enum MyOption |
+| main.rs:593:20:593:23 | SelfParam |  | main.rs:568:5:572:5 | MyOption |
+| main.rs:593:20:593:23 | SelfParam | T | main.rs:568:5:572:5 | MyOption |
 | main.rs:593:20:593:23 | SelfParam | T.T | main.rs:592:10:592:10 | T |
-| main.rs:593:41:598:9 | { ... } |  | main.rs:568:5:572:5 | enum MyOption |
+| main.rs:593:41:598:9 | { ... } |  | main.rs:568:5:572:5 | MyOption |
 | main.rs:593:41:598:9 | { ... } | T | main.rs:592:10:592:10 | T |
-| main.rs:594:13:597:13 | match self { ... } |  | main.rs:568:5:572:5 | enum MyOption |
+| main.rs:594:13:597:13 | match self { ... } |  | main.rs:568:5:572:5 | MyOption |
 | main.rs:594:13:597:13 | match self { ... } | T | main.rs:592:10:592:10 | T |
-| main.rs:594:19:594:22 | self |  | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:594:19:594:22 | self | T | main.rs:568:5:572:5 | enum MyOption |
+| main.rs:594:19:594:22 | self |  | main.rs:568:5:572:5 | MyOption |
+| main.rs:594:19:594:22 | self | T | main.rs:568:5:572:5 | MyOption |
 | main.rs:594:19:594:22 | self | T.T | main.rs:592:10:592:10 | T |
-| main.rs:595:39:595:56 | ...::MyNone(...) |  | main.rs:568:5:572:5 | enum MyOption |
+| main.rs:595:39:595:56 | ...::MyNone(...) |  | main.rs:568:5:572:5 | MyOption |
 | main.rs:595:39:595:56 | ...::MyNone(...) | T | main.rs:592:10:592:10 | T |
-| main.rs:596:34:596:34 | x |  | main.rs:568:5:572:5 | enum MyOption |
+| main.rs:596:34:596:34 | x |  | main.rs:568:5:572:5 | MyOption |
 | main.rs:596:34:596:34 | x | T | main.rs:592:10:592:10 | T |
-| main.rs:596:40:596:40 | x |  | main.rs:568:5:572:5 | enum MyOption |
+| main.rs:596:40:596:40 | x |  | main.rs:568:5:572:5 | MyOption |
 | main.rs:596:40:596:40 | x | T | main.rs:592:10:592:10 | T |
-| main.rs:605:13:605:14 | x1 |  | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:605:18:605:37 | ...::new(...) |  | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:606:26:606:27 | x1 |  | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:608:13:608:18 | mut x2 |  | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:608:13:608:18 | mut x2 | T | main.rs:601:5:602:13 | struct S |
-| main.rs:608:22:608:36 | ...::new(...) |  | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:608:22:608:36 | ...::new(...) | T | main.rs:601:5:602:13 | struct S |
-| main.rs:609:9:609:10 | x2 |  | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:609:9:609:10 | x2 | T | main.rs:601:5:602:13 | struct S |
-| main.rs:609:16:609:16 | S |  | main.rs:601:5:602:13 | struct S |
-| main.rs:610:26:610:27 | x2 |  | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:610:26:610:27 | x2 | T | main.rs:601:5:602:13 | struct S |
-| main.rs:612:13:612:18 | mut x3 |  | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:612:22:612:36 | ...::new(...) |  | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:613:9:613:10 | x3 |  | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:613:21:613:21 | S |  | main.rs:601:5:602:13 | struct S |
-| main.rs:614:26:614:27 | x3 |  | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:616:13:616:18 | mut x4 |  | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:616:13:616:18 | mut x4 | T | main.rs:601:5:602:13 | struct S |
-| main.rs:616:22:616:36 | ...::new(...) |  | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:616:22:616:36 | ...::new(...) | T | main.rs:601:5:602:13 | struct S |
+| main.rs:605:13:605:14 | x1 |  | main.rs:568:5:572:5 | MyOption |
+| main.rs:605:18:605:37 | ...::new(...) |  | main.rs:568:5:572:5 | MyOption |
+| main.rs:606:26:606:27 | x1 |  | main.rs:568:5:572:5 | MyOption |
+| main.rs:608:13:608:18 | mut x2 |  | main.rs:568:5:572:5 | MyOption |
+| main.rs:608:13:608:18 | mut x2 | T | main.rs:601:5:602:13 | S |
+| main.rs:608:22:608:36 | ...::new(...) |  | main.rs:568:5:572:5 | MyOption |
+| main.rs:608:22:608:36 | ...::new(...) | T | main.rs:601:5:602:13 | S |
+| main.rs:609:9:609:10 | x2 |  | main.rs:568:5:572:5 | MyOption |
+| main.rs:609:9:609:10 | x2 | T | main.rs:601:5:602:13 | S |
+| main.rs:609:16:609:16 | S |  | main.rs:601:5:602:13 | S |
+| main.rs:610:26:610:27 | x2 |  | main.rs:568:5:572:5 | MyOption |
+| main.rs:610:26:610:27 | x2 | T | main.rs:601:5:602:13 | S |
+| main.rs:612:13:612:18 | mut x3 |  | main.rs:568:5:572:5 | MyOption |
+| main.rs:612:22:612:36 | ...::new(...) |  | main.rs:568:5:572:5 | MyOption |
+| main.rs:613:9:613:10 | x3 |  | main.rs:568:5:572:5 | MyOption |
+| main.rs:613:21:613:21 | S |  | main.rs:601:5:602:13 | S |
+| main.rs:614:26:614:27 | x3 |  | main.rs:568:5:572:5 | MyOption |
+| main.rs:616:13:616:18 | mut x4 |  | main.rs:568:5:572:5 | MyOption |
+| main.rs:616:13:616:18 | mut x4 | T | main.rs:601:5:602:13 | S |
+| main.rs:616:22:616:36 | ...::new(...) |  | main.rs:568:5:572:5 | MyOption |
+| main.rs:616:22:616:36 | ...::new(...) | T | main.rs:601:5:602:13 | S |
 | main.rs:617:23:617:29 | &mut x4 |  | file://:0:0:0:0 | & |
-| main.rs:617:23:617:29 | &mut x4 | &T | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:617:23:617:29 | &mut x4 | &T.T | main.rs:601:5:602:13 | struct S |
-| main.rs:617:28:617:29 | x4 |  | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:617:28:617:29 | x4 | T | main.rs:601:5:602:13 | struct S |
-| main.rs:617:32:617:32 | S |  | main.rs:601:5:602:13 | struct S |
-| main.rs:618:26:618:27 | x4 |  | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:618:26:618:27 | x4 | T | main.rs:601:5:602:13 | struct S |
-| main.rs:620:13:620:14 | x5 |  | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:620:13:620:14 | x5 | T | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:620:13:620:14 | x5 | T.T | main.rs:601:5:602:13 | struct S |
-| main.rs:620:18:620:58 | ...::MySome(...) |  | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:620:18:620:58 | ...::MySome(...) | T | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:620:18:620:58 | ...::MySome(...) | T.T | main.rs:601:5:602:13 | struct S |
-| main.rs:620:35:620:57 | ...::MyNone(...) |  | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:620:35:620:57 | ...::MyNone(...) | T | main.rs:601:5:602:13 | struct S |
-| main.rs:621:26:621:27 | x5 |  | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:621:26:621:27 | x5 | T | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:621:26:621:27 | x5 | T.T | main.rs:601:5:602:13 | struct S |
-| main.rs:623:13:623:14 | x6 |  | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:623:13:623:14 | x6 | T | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:623:13:623:14 | x6 | T.T | main.rs:601:5:602:13 | struct S |
-| main.rs:623:18:623:58 | ...::MySome(...) |  | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:623:18:623:58 | ...::MySome(...) | T | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:623:18:623:58 | ...::MySome(...) | T.T | main.rs:601:5:602:13 | struct S |
-| main.rs:623:35:623:57 | ...::MyNone(...) |  | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:623:35:623:57 | ...::MyNone(...) | T | main.rs:601:5:602:13 | struct S |
-| main.rs:624:26:624:61 | ...::flatten(...) |  | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:624:26:624:61 | ...::flatten(...) | T | main.rs:601:5:602:13 | struct S |
-| main.rs:624:59:624:60 | x6 |  | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:624:59:624:60 | x6 | T | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:624:59:624:60 | x6 | T.T | main.rs:601:5:602:13 | struct S |
-| main.rs:626:13:626:19 | from_if |  | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:626:13:626:19 | from_if | T | main.rs:601:5:602:13 | struct S |
-| main.rs:626:23:630:9 | if ... {...} else {...} |  | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:626:23:630:9 | if ... {...} else {...} | T | main.rs:601:5:602:13 | struct S |
-| main.rs:626:36:628:9 | { ... } |  | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:626:36:628:9 | { ... } | T | main.rs:601:5:602:13 | struct S |
-| main.rs:627:13:627:30 | ...::MyNone(...) |  | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:627:13:627:30 | ...::MyNone(...) | T | main.rs:601:5:602:13 | struct S |
-| main.rs:628:16:630:9 | { ... } |  | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:628:16:630:9 | { ... } | T | main.rs:601:5:602:13 | struct S |
-| main.rs:629:13:629:31 | ...::MySome(...) |  | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:629:13:629:31 | ...::MySome(...) | T | main.rs:601:5:602:13 | struct S |
-| main.rs:629:30:629:30 | S |  | main.rs:601:5:602:13 | struct S |
-| main.rs:631:26:631:32 | from_if |  | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:631:26:631:32 | from_if | T | main.rs:601:5:602:13 | struct S |
-| main.rs:633:13:633:22 | from_match |  | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:633:13:633:22 | from_match | T | main.rs:601:5:602:13 | struct S |
-| main.rs:633:26:636:9 | match ... { ... } |  | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:633:26:636:9 | match ... { ... } | T | main.rs:601:5:602:13 | struct S |
-| main.rs:634:21:634:38 | ...::MyNone(...) |  | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:634:21:634:38 | ...::MyNone(...) | T | main.rs:601:5:602:13 | struct S |
-| main.rs:635:22:635:40 | ...::MySome(...) |  | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:635:22:635:40 | ...::MySome(...) | T | main.rs:601:5:602:13 | struct S |
-| main.rs:635:39:635:39 | S |  | main.rs:601:5:602:13 | struct S |
-| main.rs:637:26:637:35 | from_match |  | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:637:26:637:35 | from_match | T | main.rs:601:5:602:13 | struct S |
-| main.rs:639:13:639:21 | from_loop |  | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:639:13:639:21 | from_loop | T | main.rs:601:5:602:13 | struct S |
-| main.rs:639:25:644:9 | loop { ... } |  | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:639:25:644:9 | loop { ... } | T | main.rs:601:5:602:13 | struct S |
-| main.rs:641:23:641:40 | ...::MyNone(...) |  | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:641:23:641:40 | ...::MyNone(...) | T | main.rs:601:5:602:13 | struct S |
-| main.rs:643:19:643:37 | ...::MySome(...) |  | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:643:19:643:37 | ...::MySome(...) | T | main.rs:601:5:602:13 | struct S |
-| main.rs:643:36:643:36 | S |  | main.rs:601:5:602:13 | struct S |
-| main.rs:645:26:645:34 | from_loop |  | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:645:26:645:34 | from_loop | T | main.rs:601:5:602:13 | struct S |
-| main.rs:658:15:658:18 | SelfParam |  | main.rs:651:5:652:19 | struct S |
+| main.rs:617:23:617:29 | &mut x4 | &T | main.rs:568:5:572:5 | MyOption |
+| main.rs:617:23:617:29 | &mut x4 | &T.T | main.rs:601:5:602:13 | S |
+| main.rs:617:28:617:29 | x4 |  | main.rs:568:5:572:5 | MyOption |
+| main.rs:617:28:617:29 | x4 | T | main.rs:601:5:602:13 | S |
+| main.rs:617:32:617:32 | S |  | main.rs:601:5:602:13 | S |
+| main.rs:618:26:618:27 | x4 |  | main.rs:568:5:572:5 | MyOption |
+| main.rs:618:26:618:27 | x4 | T | main.rs:601:5:602:13 | S |
+| main.rs:620:13:620:14 | x5 |  | main.rs:568:5:572:5 | MyOption |
+| main.rs:620:13:620:14 | x5 | T | main.rs:568:5:572:5 | MyOption |
+| main.rs:620:13:620:14 | x5 | T.T | main.rs:601:5:602:13 | S |
+| main.rs:620:18:620:58 | ...::MySome(...) |  | main.rs:568:5:572:5 | MyOption |
+| main.rs:620:18:620:58 | ...::MySome(...) | T | main.rs:568:5:572:5 | MyOption |
+| main.rs:620:18:620:58 | ...::MySome(...) | T.T | main.rs:601:5:602:13 | S |
+| main.rs:620:35:620:57 | ...::MyNone(...) |  | main.rs:568:5:572:5 | MyOption |
+| main.rs:620:35:620:57 | ...::MyNone(...) | T | main.rs:601:5:602:13 | S |
+| main.rs:621:26:621:27 | x5 |  | main.rs:568:5:572:5 | MyOption |
+| main.rs:621:26:621:27 | x5 | T | main.rs:568:5:572:5 | MyOption |
+| main.rs:621:26:621:27 | x5 | T.T | main.rs:601:5:602:13 | S |
+| main.rs:623:13:623:14 | x6 |  | main.rs:568:5:572:5 | MyOption |
+| main.rs:623:13:623:14 | x6 | T | main.rs:568:5:572:5 | MyOption |
+| main.rs:623:13:623:14 | x6 | T.T | main.rs:601:5:602:13 | S |
+| main.rs:623:18:623:58 | ...::MySome(...) |  | main.rs:568:5:572:5 | MyOption |
+| main.rs:623:18:623:58 | ...::MySome(...) | T | main.rs:568:5:572:5 | MyOption |
+| main.rs:623:18:623:58 | ...::MySome(...) | T.T | main.rs:601:5:602:13 | S |
+| main.rs:623:35:623:57 | ...::MyNone(...) |  | main.rs:568:5:572:5 | MyOption |
+| main.rs:623:35:623:57 | ...::MyNone(...) | T | main.rs:601:5:602:13 | S |
+| main.rs:624:26:624:61 | ...::flatten(...) |  | main.rs:568:5:572:5 | MyOption |
+| main.rs:624:26:624:61 | ...::flatten(...) | T | main.rs:601:5:602:13 | S |
+| main.rs:624:59:624:60 | x6 |  | main.rs:568:5:572:5 | MyOption |
+| main.rs:624:59:624:60 | x6 | T | main.rs:568:5:572:5 | MyOption |
+| main.rs:624:59:624:60 | x6 | T.T | main.rs:601:5:602:13 | S |
+| main.rs:626:13:626:19 | from_if |  | main.rs:568:5:572:5 | MyOption |
+| main.rs:626:13:626:19 | from_if | T | main.rs:601:5:602:13 | S |
+| main.rs:626:23:630:9 | if ... {...} else {...} |  | main.rs:568:5:572:5 | MyOption |
+| main.rs:626:23:630:9 | if ... {...} else {...} | T | main.rs:601:5:602:13 | S |
+| main.rs:626:36:628:9 | { ... } |  | main.rs:568:5:572:5 | MyOption |
+| main.rs:626:36:628:9 | { ... } | T | main.rs:601:5:602:13 | S |
+| main.rs:627:13:627:30 | ...::MyNone(...) |  | main.rs:568:5:572:5 | MyOption |
+| main.rs:627:13:627:30 | ...::MyNone(...) | T | main.rs:601:5:602:13 | S |
+| main.rs:628:16:630:9 | { ... } |  | main.rs:568:5:572:5 | MyOption |
+| main.rs:628:16:630:9 | { ... } | T | main.rs:601:5:602:13 | S |
+| main.rs:629:13:629:31 | ...::MySome(...) |  | main.rs:568:5:572:5 | MyOption |
+| main.rs:629:13:629:31 | ...::MySome(...) | T | main.rs:601:5:602:13 | S |
+| main.rs:629:30:629:30 | S |  | main.rs:601:5:602:13 | S |
+| main.rs:631:26:631:32 | from_if |  | main.rs:568:5:572:5 | MyOption |
+| main.rs:631:26:631:32 | from_if | T | main.rs:601:5:602:13 | S |
+| main.rs:633:13:633:22 | from_match |  | main.rs:568:5:572:5 | MyOption |
+| main.rs:633:13:633:22 | from_match | T | main.rs:601:5:602:13 | S |
+| main.rs:633:26:636:9 | match ... { ... } |  | main.rs:568:5:572:5 | MyOption |
+| main.rs:633:26:636:9 | match ... { ... } | T | main.rs:601:5:602:13 | S |
+| main.rs:634:21:634:38 | ...::MyNone(...) |  | main.rs:568:5:572:5 | MyOption |
+| main.rs:634:21:634:38 | ...::MyNone(...) | T | main.rs:601:5:602:13 | S |
+| main.rs:635:22:635:40 | ...::MySome(...) |  | main.rs:568:5:572:5 | MyOption |
+| main.rs:635:22:635:40 | ...::MySome(...) | T | main.rs:601:5:602:13 | S |
+| main.rs:635:39:635:39 | S |  | main.rs:601:5:602:13 | S |
+| main.rs:637:26:637:35 | from_match |  | main.rs:568:5:572:5 | MyOption |
+| main.rs:637:26:637:35 | from_match | T | main.rs:601:5:602:13 | S |
+| main.rs:639:13:639:21 | from_loop |  | main.rs:568:5:572:5 | MyOption |
+| main.rs:639:13:639:21 | from_loop | T | main.rs:601:5:602:13 | S |
+| main.rs:639:25:644:9 | loop { ... } |  | main.rs:568:5:572:5 | MyOption |
+| main.rs:639:25:644:9 | loop { ... } | T | main.rs:601:5:602:13 | S |
+| main.rs:641:23:641:40 | ...::MyNone(...) |  | main.rs:568:5:572:5 | MyOption |
+| main.rs:641:23:641:40 | ...::MyNone(...) | T | main.rs:601:5:602:13 | S |
+| main.rs:643:19:643:37 | ...::MySome(...) |  | main.rs:568:5:572:5 | MyOption |
+| main.rs:643:19:643:37 | ...::MySome(...) | T | main.rs:601:5:602:13 | S |
+| main.rs:643:36:643:36 | S |  | main.rs:601:5:602:13 | S |
+| main.rs:645:26:645:34 | from_loop |  | main.rs:568:5:572:5 | MyOption |
+| main.rs:645:26:645:34 | from_loop | T | main.rs:601:5:602:13 | S |
+| main.rs:658:15:658:18 | SelfParam |  | main.rs:651:5:652:19 | S |
 | main.rs:658:15:658:18 | SelfParam | T | main.rs:657:10:657:10 | T |
 | main.rs:658:26:660:9 | { ... } |  | main.rs:657:10:657:10 | T |
-| main.rs:659:13:659:16 | self |  | main.rs:651:5:652:19 | struct S |
+| main.rs:659:13:659:16 | self |  | main.rs:651:5:652:19 | S |
 | main.rs:659:13:659:16 | self | T | main.rs:657:10:657:10 | T |
 | main.rs:659:13:659:18 | self.0 |  | main.rs:657:10:657:10 | T |
 | main.rs:662:15:662:19 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:662:15:662:19 | SelfParam | &T | main.rs:651:5:652:19 | struct S |
+| main.rs:662:15:662:19 | SelfParam | &T | main.rs:651:5:652:19 | S |
 | main.rs:662:15:662:19 | SelfParam | &T.T | main.rs:657:10:657:10 | T |
 | main.rs:662:28:664:9 | { ... } |  | file://:0:0:0:0 | & |
 | main.rs:662:28:664:9 | { ... } | &T | main.rs:657:10:657:10 | T |
 | main.rs:663:13:663:19 | &... |  | file://:0:0:0:0 | & |
 | main.rs:663:13:663:19 | &... | &T | main.rs:657:10:657:10 | T |
 | main.rs:663:14:663:17 | self |  | file://:0:0:0:0 | & |
-| main.rs:663:14:663:17 | self | &T | main.rs:651:5:652:19 | struct S |
+| main.rs:663:14:663:17 | self | &T | main.rs:651:5:652:19 | S |
 | main.rs:663:14:663:17 | self | &T.T | main.rs:657:10:657:10 | T |
 | main.rs:663:14:663:19 | self.0 |  | main.rs:657:10:657:10 | T |
 | main.rs:666:15:666:25 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:666:15:666:25 | SelfParam | &T | main.rs:651:5:652:19 | struct S |
+| main.rs:666:15:666:25 | SelfParam | &T | main.rs:651:5:652:19 | S |
 | main.rs:666:15:666:25 | SelfParam | &T.T | main.rs:657:10:657:10 | T |
 | main.rs:666:34:668:9 | { ... } |  | file://:0:0:0:0 | & |
 | main.rs:666:34:668:9 | { ... } | &T | main.rs:657:10:657:10 | T |
 | main.rs:667:13:667:19 | &... |  | file://:0:0:0:0 | & |
 | main.rs:667:13:667:19 | &... | &T | main.rs:657:10:657:10 | T |
 | main.rs:667:14:667:17 | self |  | file://:0:0:0:0 | & |
-| main.rs:667:14:667:17 | self | &T | main.rs:651:5:652:19 | struct S |
+| main.rs:667:14:667:17 | self | &T | main.rs:651:5:652:19 | S |
 | main.rs:667:14:667:17 | self | &T.T | main.rs:657:10:657:10 | T |
 | main.rs:667:14:667:19 | self.0 |  | main.rs:657:10:657:10 | T |
-| main.rs:672:13:672:14 | x1 |  | main.rs:651:5:652:19 | struct S |
-| main.rs:672:13:672:14 | x1 | T | main.rs:654:5:655:14 | struct S2 |
-| main.rs:672:18:672:22 | S(...) |  | main.rs:651:5:652:19 | struct S |
-| main.rs:672:18:672:22 | S(...) | T | main.rs:654:5:655:14 | struct S2 |
-| main.rs:672:20:672:21 | S2 |  | main.rs:654:5:655:14 | struct S2 |
-| main.rs:673:26:673:27 | x1 |  | main.rs:651:5:652:19 | struct S |
-| main.rs:673:26:673:27 | x1 | T | main.rs:654:5:655:14 | struct S2 |
-| main.rs:673:26:673:32 | x1.m1(...) |  | main.rs:654:5:655:14 | struct S2 |
-| main.rs:675:13:675:14 | x2 |  | main.rs:651:5:652:19 | struct S |
-| main.rs:675:13:675:14 | x2 | T | main.rs:654:5:655:14 | struct S2 |
-| main.rs:675:18:675:22 | S(...) |  | main.rs:651:5:652:19 | struct S |
-| main.rs:675:18:675:22 | S(...) | T | main.rs:654:5:655:14 | struct S2 |
-| main.rs:675:20:675:21 | S2 |  | main.rs:654:5:655:14 | struct S2 |
-| main.rs:677:26:677:27 | x2 |  | main.rs:651:5:652:19 | struct S |
-| main.rs:677:26:677:27 | x2 | T | main.rs:654:5:655:14 | struct S2 |
-| main.rs:677:26:677:32 | x2.m2(...) |  | file://:0:0:0:0 | & |
-| main.rs:677:26:677:32 | x2.m2(...) | &T | main.rs:654:5:655:14 | struct S2 |
-| main.rs:678:26:678:27 | x2 |  | main.rs:651:5:652:19 | struct S |
-| main.rs:678:26:678:27 | x2 | T | main.rs:654:5:655:14 | struct S2 |
-| main.rs:678:26:678:32 | x2.m3(...) |  | file://:0:0:0:0 | & |
-| main.rs:678:26:678:32 | x2.m3(...) | &T | main.rs:654:5:655:14 | struct S2 |
-| main.rs:680:13:680:14 | x3 |  | main.rs:651:5:652:19 | struct S |
-| main.rs:680:13:680:14 | x3 | T | main.rs:654:5:655:14 | struct S2 |
-| main.rs:680:18:680:22 | S(...) |  | main.rs:651:5:652:19 | struct S |
-| main.rs:680:18:680:22 | S(...) | T | main.rs:654:5:655:14 | struct S2 |
-| main.rs:680:20:680:21 | S2 |  | main.rs:654:5:655:14 | struct S2 |
+| main.rs:672:13:672:14 | x1 |  | main.rs:651:5:652:19 | S |
+| main.rs:672:13:672:14 | x1 | T | main.rs:654:5:655:14 | S2 |
+| main.rs:672:18:672:22 | S(...) |  | main.rs:651:5:652:19 | S |
+| main.rs:672:18:672:22 | S(...) | T | main.rs:654:5:655:14 | S2 |
+| main.rs:672:20:672:21 | S2 |  | main.rs:654:5:655:14 | S2 |
+| main.rs:673:26:673:27 | x1 |  | main.rs:651:5:652:19 | S |
+| main.rs:673:26:673:27 | x1 | T | main.rs:654:5:655:14 | S2 |
+| main.rs:673:26:673:32 | x1.m1() |  | main.rs:654:5:655:14 | S2 |
+| main.rs:675:13:675:14 | x2 |  | main.rs:651:5:652:19 | S |
+| main.rs:675:13:675:14 | x2 | T | main.rs:654:5:655:14 | S2 |
+| main.rs:675:18:675:22 | S(...) |  | main.rs:651:5:652:19 | S |
+| main.rs:675:18:675:22 | S(...) | T | main.rs:654:5:655:14 | S2 |
+| main.rs:675:20:675:21 | S2 |  | main.rs:654:5:655:14 | S2 |
+| main.rs:677:26:677:27 | x2 |  | main.rs:651:5:652:19 | S |
+| main.rs:677:26:677:27 | x2 | T | main.rs:654:5:655:14 | S2 |
+| main.rs:677:26:677:32 | x2.m2() |  | file://:0:0:0:0 | & |
+| main.rs:677:26:677:32 | x2.m2() | &T | main.rs:654:5:655:14 | S2 |
+| main.rs:678:26:678:27 | x2 |  | main.rs:651:5:652:19 | S |
+| main.rs:678:26:678:27 | x2 | T | main.rs:654:5:655:14 | S2 |
+| main.rs:678:26:678:32 | x2.m3() |  | file://:0:0:0:0 | & |
+| main.rs:678:26:678:32 | x2.m3() | &T | main.rs:654:5:655:14 | S2 |
+| main.rs:680:13:680:14 | x3 |  | main.rs:651:5:652:19 | S |
+| main.rs:680:13:680:14 | x3 | T | main.rs:654:5:655:14 | S2 |
+| main.rs:680:18:680:22 | S(...) |  | main.rs:651:5:652:19 | S |
+| main.rs:680:18:680:22 | S(...) | T | main.rs:654:5:655:14 | S2 |
+| main.rs:680:20:680:21 | S2 |  | main.rs:654:5:655:14 | S2 |
 | main.rs:682:26:682:41 | ...::m2(...) |  | file://:0:0:0:0 | & |
-| main.rs:682:26:682:41 | ...::m2(...) | &T | main.rs:654:5:655:14 | struct S2 |
+| main.rs:682:26:682:41 | ...::m2(...) | &T | main.rs:654:5:655:14 | S2 |
 | main.rs:682:38:682:40 | &x3 |  | file://:0:0:0:0 | & |
-| main.rs:682:38:682:40 | &x3 | &T | main.rs:651:5:652:19 | struct S |
-| main.rs:682:38:682:40 | &x3 | &T.T | main.rs:654:5:655:14 | struct S2 |
-| main.rs:682:39:682:40 | x3 |  | main.rs:651:5:652:19 | struct S |
-| main.rs:682:39:682:40 | x3 | T | main.rs:654:5:655:14 | struct S2 |
+| main.rs:682:38:682:40 | &x3 | &T | main.rs:651:5:652:19 | S |
+| main.rs:682:38:682:40 | &x3 | &T.T | main.rs:654:5:655:14 | S2 |
+| main.rs:682:39:682:40 | x3 |  | main.rs:651:5:652:19 | S |
+| main.rs:682:39:682:40 | x3 | T | main.rs:654:5:655:14 | S2 |
 | main.rs:683:26:683:41 | ...::m3(...) |  | file://:0:0:0:0 | & |
-| main.rs:683:26:683:41 | ...::m3(...) | &T | main.rs:654:5:655:14 | struct S2 |
+| main.rs:683:26:683:41 | ...::m3(...) | &T | main.rs:654:5:655:14 | S2 |
 | main.rs:683:38:683:40 | &x3 |  | file://:0:0:0:0 | & |
-| main.rs:683:38:683:40 | &x3 | &T | main.rs:651:5:652:19 | struct S |
-| main.rs:683:38:683:40 | &x3 | &T.T | main.rs:654:5:655:14 | struct S2 |
-| main.rs:683:39:683:40 | x3 |  | main.rs:651:5:652:19 | struct S |
-| main.rs:683:39:683:40 | x3 | T | main.rs:654:5:655:14 | struct S2 |
+| main.rs:683:38:683:40 | &x3 | &T | main.rs:651:5:652:19 | S |
+| main.rs:683:38:683:40 | &x3 | &T.T | main.rs:654:5:655:14 | S2 |
+| main.rs:683:39:683:40 | x3 |  | main.rs:651:5:652:19 | S |
+| main.rs:683:39:683:40 | x3 | T | main.rs:654:5:655:14 | S2 |
 | main.rs:685:13:685:14 | x4 |  | file://:0:0:0:0 | & |
-| main.rs:685:13:685:14 | x4 | &T | main.rs:651:5:652:19 | struct S |
-| main.rs:685:13:685:14 | x4 | &T.T | main.rs:654:5:655:14 | struct S2 |
+| main.rs:685:13:685:14 | x4 | &T | main.rs:651:5:652:19 | S |
+| main.rs:685:13:685:14 | x4 | &T.T | main.rs:654:5:655:14 | S2 |
 | main.rs:685:18:685:23 | &... |  | file://:0:0:0:0 | & |
-| main.rs:685:18:685:23 | &... | &T | main.rs:651:5:652:19 | struct S |
-| main.rs:685:18:685:23 | &... | &T.T | main.rs:654:5:655:14 | struct S2 |
-| main.rs:685:19:685:23 | S(...) |  | main.rs:651:5:652:19 | struct S |
-| main.rs:685:19:685:23 | S(...) | T | main.rs:654:5:655:14 | struct S2 |
-| main.rs:685:21:685:22 | S2 |  | main.rs:654:5:655:14 | struct S2 |
+| main.rs:685:18:685:23 | &... | &T | main.rs:651:5:652:19 | S |
+| main.rs:685:18:685:23 | &... | &T.T | main.rs:654:5:655:14 | S2 |
+| main.rs:685:19:685:23 | S(...) |  | main.rs:651:5:652:19 | S |
+| main.rs:685:19:685:23 | S(...) | T | main.rs:654:5:655:14 | S2 |
+| main.rs:685:21:685:22 | S2 |  | main.rs:654:5:655:14 | S2 |
 | main.rs:687:26:687:27 | x4 |  | file://:0:0:0:0 | & |
-| main.rs:687:26:687:27 | x4 | &T | main.rs:651:5:652:19 | struct S |
-| main.rs:687:26:687:27 | x4 | &T.T | main.rs:654:5:655:14 | struct S2 |
-| main.rs:687:26:687:32 | x4.m2(...) |  | file://:0:0:0:0 | & |
-| main.rs:687:26:687:32 | x4.m2(...) | &T | main.rs:654:5:655:14 | struct S2 |
+| main.rs:687:26:687:27 | x4 | &T | main.rs:651:5:652:19 | S |
+| main.rs:687:26:687:27 | x4 | &T.T | main.rs:654:5:655:14 | S2 |
+| main.rs:687:26:687:32 | x4.m2() |  | file://:0:0:0:0 | & |
+| main.rs:687:26:687:32 | x4.m2() | &T | main.rs:654:5:655:14 | S2 |
 | main.rs:688:26:688:27 | x4 |  | file://:0:0:0:0 | & |
-| main.rs:688:26:688:27 | x4 | &T | main.rs:651:5:652:19 | struct S |
-| main.rs:688:26:688:27 | x4 | &T.T | main.rs:654:5:655:14 | struct S2 |
-| main.rs:688:26:688:32 | x4.m3(...) |  | file://:0:0:0:0 | & |
-| main.rs:688:26:688:32 | x4.m3(...) | &T | main.rs:654:5:655:14 | struct S2 |
+| main.rs:688:26:688:27 | x4 | &T | main.rs:651:5:652:19 | S |
+| main.rs:688:26:688:27 | x4 | &T.T | main.rs:654:5:655:14 | S2 |
+| main.rs:688:26:688:32 | x4.m3() |  | file://:0:0:0:0 | & |
+| main.rs:688:26:688:32 | x4.m3() | &T | main.rs:654:5:655:14 | S2 |
 | main.rs:690:13:690:14 | x5 |  | file://:0:0:0:0 | & |
-| main.rs:690:13:690:14 | x5 | &T | main.rs:651:5:652:19 | struct S |
-| main.rs:690:13:690:14 | x5 | &T.T | main.rs:654:5:655:14 | struct S2 |
+| main.rs:690:13:690:14 | x5 | &T | main.rs:651:5:652:19 | S |
+| main.rs:690:13:690:14 | x5 | &T.T | main.rs:654:5:655:14 | S2 |
 | main.rs:690:18:690:23 | &... |  | file://:0:0:0:0 | & |
-| main.rs:690:18:690:23 | &... | &T | main.rs:651:5:652:19 | struct S |
-| main.rs:690:18:690:23 | &... | &T.T | main.rs:654:5:655:14 | struct S2 |
-| main.rs:690:19:690:23 | S(...) |  | main.rs:651:5:652:19 | struct S |
-| main.rs:690:19:690:23 | S(...) | T | main.rs:654:5:655:14 | struct S2 |
-| main.rs:690:21:690:22 | S2 |  | main.rs:654:5:655:14 | struct S2 |
+| main.rs:690:18:690:23 | &... | &T | main.rs:651:5:652:19 | S |
+| main.rs:690:18:690:23 | &... | &T.T | main.rs:654:5:655:14 | S2 |
+| main.rs:690:19:690:23 | S(...) |  | main.rs:651:5:652:19 | S |
+| main.rs:690:19:690:23 | S(...) | T | main.rs:654:5:655:14 | S2 |
+| main.rs:690:21:690:22 | S2 |  | main.rs:654:5:655:14 | S2 |
 | main.rs:692:26:692:27 | x5 |  | file://:0:0:0:0 | & |
-| main.rs:692:26:692:27 | x5 | &T | main.rs:651:5:652:19 | struct S |
-| main.rs:692:26:692:27 | x5 | &T.T | main.rs:654:5:655:14 | struct S2 |
-| main.rs:692:26:692:32 | x5.m1(...) |  | main.rs:654:5:655:14 | struct S2 |
+| main.rs:692:26:692:27 | x5 | &T | main.rs:651:5:652:19 | S |
+| main.rs:692:26:692:27 | x5 | &T.T | main.rs:654:5:655:14 | S2 |
+| main.rs:692:26:692:32 | x5.m1() |  | main.rs:654:5:655:14 | S2 |
 | main.rs:693:26:693:27 | x5 |  | file://:0:0:0:0 | & |
-| main.rs:693:26:693:27 | x5 | &T | main.rs:651:5:652:19 | struct S |
-| main.rs:693:26:693:27 | x5 | &T.T | main.rs:654:5:655:14 | struct S2 |
-| main.rs:693:26:693:29 | x5.0 |  | main.rs:654:5:655:14 | struct S2 |
+| main.rs:693:26:693:27 | x5 | &T | main.rs:651:5:652:19 | S |
+| main.rs:693:26:693:27 | x5 | &T.T | main.rs:654:5:655:14 | S2 |
+| main.rs:693:26:693:29 | x5.0 |  | main.rs:654:5:655:14 | S2 |
 | main.rs:695:13:695:14 | x6 |  | file://:0:0:0:0 | & |
-| main.rs:695:13:695:14 | x6 | &T | main.rs:651:5:652:19 | struct S |
-| main.rs:695:13:695:14 | x6 | &T.T | main.rs:654:5:655:14 | struct S2 |
+| main.rs:695:13:695:14 | x6 | &T | main.rs:651:5:652:19 | S |
+| main.rs:695:13:695:14 | x6 | &T.T | main.rs:654:5:655:14 | S2 |
 | main.rs:695:18:695:23 | &... |  | file://:0:0:0:0 | & |
-| main.rs:695:18:695:23 | &... | &T | main.rs:651:5:652:19 | struct S |
-| main.rs:695:18:695:23 | &... | &T.T | main.rs:654:5:655:14 | struct S2 |
-| main.rs:695:19:695:23 | S(...) |  | main.rs:651:5:652:19 | struct S |
-| main.rs:695:19:695:23 | S(...) | T | main.rs:654:5:655:14 | struct S2 |
-| main.rs:695:21:695:22 | S2 |  | main.rs:654:5:655:14 | struct S2 |
-| main.rs:697:26:697:30 | (...) |  | main.rs:651:5:652:19 | struct S |
-| main.rs:697:26:697:30 | (...) | T | main.rs:654:5:655:14 | struct S2 |
-| main.rs:697:26:697:35 | ... .m1(...) |  | main.rs:654:5:655:14 | struct S2 |
-| main.rs:697:27:697:29 | * ... |  | main.rs:651:5:652:19 | struct S |
-| main.rs:697:27:697:29 | * ... | T | main.rs:654:5:655:14 | struct S2 |
+| main.rs:695:18:695:23 | &... | &T | main.rs:651:5:652:19 | S |
+| main.rs:695:18:695:23 | &... | &T.T | main.rs:654:5:655:14 | S2 |
+| main.rs:695:19:695:23 | S(...) |  | main.rs:651:5:652:19 | S |
+| main.rs:695:19:695:23 | S(...) | T | main.rs:654:5:655:14 | S2 |
+| main.rs:695:21:695:22 | S2 |  | main.rs:654:5:655:14 | S2 |
+| main.rs:697:26:697:30 | (...) |  | main.rs:651:5:652:19 | S |
+| main.rs:697:26:697:30 | (...) | T | main.rs:654:5:655:14 | S2 |
+| main.rs:697:26:697:35 | ... .m1() |  | main.rs:654:5:655:14 | S2 |
+| main.rs:697:27:697:29 | * ... |  | main.rs:651:5:652:19 | S |
+| main.rs:697:27:697:29 | * ... | T | main.rs:654:5:655:14 | S2 |
 | main.rs:697:28:697:29 | x6 |  | file://:0:0:0:0 | & |
-| main.rs:697:28:697:29 | x6 | &T | main.rs:651:5:652:19 | struct S |
-| main.rs:697:28:697:29 | x6 | &T.T | main.rs:654:5:655:14 | struct S2 |
+| main.rs:697:28:697:29 | x6 | &T | main.rs:651:5:652:19 | S |
+| main.rs:697:28:697:29 | x6 | &T.T | main.rs:654:5:655:14 | S2 |
 | main.rs:703:16:703:20 | SelfParam |  | file://:0:0:0:0 | & |
 | main.rs:703:16:703:20 | SelfParam | &T | main.rs:702:5:708:5 | Self [trait MyTrait] |
 | main.rs:705:16:705:20 | SelfParam |  | file://:0:0:0:0 | & |
@@ -773,146 +773,146 @@ inferType
 | main.rs:705:32:707:9 | { ... } | &T | main.rs:702:5:708:5 | Self [trait MyTrait] |
 | main.rs:706:13:706:16 | self |  | file://:0:0:0:0 | & |
 | main.rs:706:13:706:16 | self | &T | main.rs:702:5:708:5 | Self [trait MyTrait] |
-| main.rs:706:13:706:22 | self.foo(...) |  | file://:0:0:0:0 | & |
-| main.rs:706:13:706:22 | self.foo(...) | &T | main.rs:702:5:708:5 | Self [trait MyTrait] |
+| main.rs:706:13:706:22 | self.foo() |  | file://:0:0:0:0 | & |
+| main.rs:706:13:706:22 | self.foo() | &T | main.rs:702:5:708:5 | Self [trait MyTrait] |
 | main.rs:713:16:713:20 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:713:16:713:20 | SelfParam | &T | main.rs:710:5:710:20 | struct MyStruct |
+| main.rs:713:16:713:20 | SelfParam | &T | main.rs:710:5:710:20 | MyStruct |
 | main.rs:713:36:715:9 | { ... } |  | file://:0:0:0:0 | & |
-| main.rs:713:36:715:9 | { ... } | &T | main.rs:710:5:710:20 | struct MyStruct |
+| main.rs:713:36:715:9 | { ... } | &T | main.rs:710:5:710:20 | MyStruct |
 | main.rs:714:13:714:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:714:13:714:16 | self | &T | main.rs:710:5:710:20 | struct MyStruct |
-| main.rs:719:13:719:13 | x |  | main.rs:710:5:710:20 | struct MyStruct |
-| main.rs:719:17:719:24 | MyStruct |  | main.rs:710:5:710:20 | struct MyStruct |
-| main.rs:720:9:720:9 | x |  | main.rs:710:5:710:20 | struct MyStruct |
-| main.rs:720:9:720:15 | x.bar(...) |  | file://:0:0:0:0 | & |
-| main.rs:720:9:720:15 | x.bar(...) | &T | main.rs:710:5:710:20 | struct MyStruct |
+| main.rs:714:13:714:16 | self | &T | main.rs:710:5:710:20 | MyStruct |
+| main.rs:719:13:719:13 | x |  | main.rs:710:5:710:20 | MyStruct |
+| main.rs:719:17:719:24 | MyStruct |  | main.rs:710:5:710:20 | MyStruct |
+| main.rs:720:9:720:9 | x |  | main.rs:710:5:710:20 | MyStruct |
+| main.rs:720:9:720:15 | x.bar() |  | file://:0:0:0:0 | & |
+| main.rs:720:9:720:15 | x.bar() | &T | main.rs:710:5:710:20 | MyStruct |
 | main.rs:730:16:730:20 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:730:16:730:20 | SelfParam | &T | main.rs:727:5:727:26 | struct MyStruct |
+| main.rs:730:16:730:20 | SelfParam | &T | main.rs:727:5:727:26 | MyStruct |
 | main.rs:730:16:730:20 | SelfParam | &T.T | main.rs:729:10:729:10 | T |
 | main.rs:730:32:732:9 | { ... } |  | file://:0:0:0:0 | & |
-| main.rs:730:32:732:9 | { ... } | &T | main.rs:727:5:727:26 | struct MyStruct |
+| main.rs:730:32:732:9 | { ... } | &T | main.rs:727:5:727:26 | MyStruct |
 | main.rs:730:32:732:9 | { ... } | &T.T | main.rs:729:10:729:10 | T |
 | main.rs:731:13:731:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:731:13:731:16 | self | &T | main.rs:727:5:727:26 | struct MyStruct |
+| main.rs:731:13:731:16 | self | &T | main.rs:727:5:727:26 | MyStruct |
 | main.rs:731:13:731:16 | self | &T.T | main.rs:729:10:729:10 | T |
-| main.rs:736:13:736:13 | x |  | main.rs:727:5:727:26 | struct MyStruct |
-| main.rs:736:13:736:13 | x | T | main.rs:725:5:725:13 | struct S |
-| main.rs:736:17:736:27 | MyStruct(...) |  | main.rs:727:5:727:26 | struct MyStruct |
-| main.rs:736:17:736:27 | MyStruct(...) | T | main.rs:725:5:725:13 | struct S |
-| main.rs:736:26:736:26 | S |  | main.rs:725:5:725:13 | struct S |
-| main.rs:737:9:737:9 | x |  | main.rs:727:5:727:26 | struct MyStruct |
-| main.rs:737:9:737:9 | x | T | main.rs:725:5:725:13 | struct S |
-| main.rs:737:9:737:15 | x.foo(...) |  | file://:0:0:0:0 | & |
-| main.rs:737:9:737:15 | x.foo(...) | &T | main.rs:727:5:727:26 | struct MyStruct |
-| main.rs:737:9:737:15 | x.foo(...) | &T.T | main.rs:725:5:725:13 | struct S |
+| main.rs:736:13:736:13 | x |  | main.rs:727:5:727:26 | MyStruct |
+| main.rs:736:13:736:13 | x | T | main.rs:725:5:725:13 | S |
+| main.rs:736:17:736:27 | MyStruct(...) |  | main.rs:727:5:727:26 | MyStruct |
+| main.rs:736:17:736:27 | MyStruct(...) | T | main.rs:725:5:725:13 | S |
+| main.rs:736:26:736:26 | S |  | main.rs:725:5:725:13 | S |
+| main.rs:737:9:737:9 | x |  | main.rs:727:5:727:26 | MyStruct |
+| main.rs:737:9:737:9 | x | T | main.rs:725:5:725:13 | S |
+| main.rs:737:9:737:15 | x.foo() |  | file://:0:0:0:0 | & |
+| main.rs:737:9:737:15 | x.foo() | &T | main.rs:727:5:727:26 | MyStruct |
+| main.rs:737:9:737:15 | x.foo() | &T.T | main.rs:725:5:725:13 | S |
 | main.rs:745:15:745:19 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:745:15:745:19 | SelfParam | &T | main.rs:742:5:742:13 | struct S |
+| main.rs:745:15:745:19 | SelfParam | &T | main.rs:742:5:742:13 | S |
 | main.rs:745:31:747:9 | { ... } |  | file://:0:0:0:0 | & |
-| main.rs:745:31:747:9 | { ... } | &T | main.rs:742:5:742:13 | struct S |
+| main.rs:745:31:747:9 | { ... } | &T | main.rs:742:5:742:13 | S |
 | main.rs:746:13:746:19 | &... |  | file://:0:0:0:0 | & |
-| main.rs:746:13:746:19 | &... | &T | main.rs:742:5:742:13 | struct S |
+| main.rs:746:13:746:19 | &... | &T | main.rs:742:5:742:13 | S |
 | main.rs:746:14:746:19 | &... |  | file://:0:0:0:0 | & |
-| main.rs:746:14:746:19 | &... | &T | main.rs:742:5:742:13 | struct S |
+| main.rs:746:14:746:19 | &... | &T | main.rs:742:5:742:13 | S |
 | main.rs:746:15:746:19 | &self |  | file://:0:0:0:0 | & |
-| main.rs:746:15:746:19 | &self | &T | main.rs:742:5:742:13 | struct S |
+| main.rs:746:15:746:19 | &self | &T | main.rs:742:5:742:13 | S |
 | main.rs:746:16:746:19 | self |  | file://:0:0:0:0 | & |
-| main.rs:746:16:746:19 | self | &T | main.rs:742:5:742:13 | struct S |
+| main.rs:746:16:746:19 | self | &T | main.rs:742:5:742:13 | S |
 | main.rs:749:15:749:25 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:749:15:749:25 | SelfParam | &T | main.rs:742:5:742:13 | struct S |
+| main.rs:749:15:749:25 | SelfParam | &T | main.rs:742:5:742:13 | S |
 | main.rs:749:37:751:9 | { ... } |  | file://:0:0:0:0 | & |
-| main.rs:749:37:751:9 | { ... } | &T | main.rs:742:5:742:13 | struct S |
+| main.rs:749:37:751:9 | { ... } | &T | main.rs:742:5:742:13 | S |
 | main.rs:750:13:750:19 | &... |  | file://:0:0:0:0 | & |
-| main.rs:750:13:750:19 | &... | &T | main.rs:742:5:742:13 | struct S |
+| main.rs:750:13:750:19 | &... | &T | main.rs:742:5:742:13 | S |
 | main.rs:750:14:750:19 | &... |  | file://:0:0:0:0 | & |
-| main.rs:750:14:750:19 | &... | &T | main.rs:742:5:742:13 | struct S |
+| main.rs:750:14:750:19 | &... | &T | main.rs:742:5:742:13 | S |
 | main.rs:750:15:750:19 | &self |  | file://:0:0:0:0 | & |
-| main.rs:750:15:750:19 | &self | &T | main.rs:742:5:742:13 | struct S |
+| main.rs:750:15:750:19 | &self | &T | main.rs:742:5:742:13 | S |
 | main.rs:750:16:750:19 | self |  | file://:0:0:0:0 | & |
-| main.rs:750:16:750:19 | self | &T | main.rs:742:5:742:13 | struct S |
+| main.rs:750:16:750:19 | self | &T | main.rs:742:5:742:13 | S |
 | main.rs:753:15:753:15 | x |  | file://:0:0:0:0 | & |
-| main.rs:753:15:753:15 | x | &T | main.rs:742:5:742:13 | struct S |
+| main.rs:753:15:753:15 | x | &T | main.rs:742:5:742:13 | S |
 | main.rs:753:34:755:9 | { ... } |  | file://:0:0:0:0 | & |
-| main.rs:753:34:755:9 | { ... } | &T | main.rs:742:5:742:13 | struct S |
+| main.rs:753:34:755:9 | { ... } | &T | main.rs:742:5:742:13 | S |
 | main.rs:754:13:754:13 | x |  | file://:0:0:0:0 | & |
-| main.rs:754:13:754:13 | x | &T | main.rs:742:5:742:13 | struct S |
+| main.rs:754:13:754:13 | x | &T | main.rs:742:5:742:13 | S |
 | main.rs:757:15:757:15 | x |  | file://:0:0:0:0 | & |
-| main.rs:757:15:757:15 | x | &T | main.rs:742:5:742:13 | struct S |
+| main.rs:757:15:757:15 | x | &T | main.rs:742:5:742:13 | S |
 | main.rs:757:34:759:9 | { ... } |  | file://:0:0:0:0 | & |
-| main.rs:757:34:759:9 | { ... } | &T | main.rs:742:5:742:13 | struct S |
+| main.rs:757:34:759:9 | { ... } | &T | main.rs:742:5:742:13 | S |
 | main.rs:758:13:758:16 | &... |  | file://:0:0:0:0 | & |
-| main.rs:758:13:758:16 | &... | &T | main.rs:742:5:742:13 | struct S |
+| main.rs:758:13:758:16 | &... | &T | main.rs:742:5:742:13 | S |
 | main.rs:758:14:758:16 | &... |  | file://:0:0:0:0 | & |
-| main.rs:758:14:758:16 | &... | &T | main.rs:742:5:742:13 | struct S |
+| main.rs:758:14:758:16 | &... | &T | main.rs:742:5:742:13 | S |
 | main.rs:758:15:758:16 | &x |  | file://:0:0:0:0 | & |
-| main.rs:758:15:758:16 | &x | &T | main.rs:742:5:742:13 | struct S |
+| main.rs:758:15:758:16 | &x | &T | main.rs:742:5:742:13 | S |
 | main.rs:758:16:758:16 | x |  | file://:0:0:0:0 | & |
-| main.rs:758:16:758:16 | x | &T | main.rs:742:5:742:13 | struct S |
-| main.rs:763:13:763:13 | x |  | main.rs:742:5:742:13 | struct S |
-| main.rs:763:17:763:20 | S {...} |  | main.rs:742:5:742:13 | struct S |
-| main.rs:764:9:764:9 | x |  | main.rs:742:5:742:13 | struct S |
-| main.rs:764:9:764:14 | x.f1(...) |  | file://:0:0:0:0 | & |
-| main.rs:764:9:764:14 | x.f1(...) | &T | main.rs:742:5:742:13 | struct S |
-| main.rs:765:9:765:9 | x |  | main.rs:742:5:742:13 | struct S |
-| main.rs:765:9:765:14 | x.f2(...) |  | file://:0:0:0:0 | & |
-| main.rs:765:9:765:14 | x.f2(...) | &T | main.rs:742:5:742:13 | struct S |
+| main.rs:758:16:758:16 | x | &T | main.rs:742:5:742:13 | S |
+| main.rs:763:13:763:13 | x |  | main.rs:742:5:742:13 | S |
+| main.rs:763:17:763:20 | S {...} |  | main.rs:742:5:742:13 | S |
+| main.rs:764:9:764:9 | x |  | main.rs:742:5:742:13 | S |
+| main.rs:764:9:764:14 | x.f1() |  | file://:0:0:0:0 | & |
+| main.rs:764:9:764:14 | x.f1() | &T | main.rs:742:5:742:13 | S |
+| main.rs:765:9:765:9 | x |  | main.rs:742:5:742:13 | S |
+| main.rs:765:9:765:14 | x.f2() |  | file://:0:0:0:0 | & |
+| main.rs:765:9:765:14 | x.f2() | &T | main.rs:742:5:742:13 | S |
 | main.rs:766:9:766:17 | ...::f3(...) |  | file://:0:0:0:0 | & |
-| main.rs:766:9:766:17 | ...::f3(...) | &T | main.rs:742:5:742:13 | struct S |
+| main.rs:766:9:766:17 | ...::f3(...) | &T | main.rs:742:5:742:13 | S |
 | main.rs:766:15:766:16 | &x |  | file://:0:0:0:0 | & |
-| main.rs:766:15:766:16 | &x | &T | main.rs:742:5:742:13 | struct S |
-| main.rs:766:16:766:16 | x |  | main.rs:742:5:742:13 | struct S |
-| main.rs:772:5:772:20 | ...::f(...) |  | main.rs:67:5:67:21 | struct Foo |
-| main.rs:773:5:773:60 | ...::g(...) |  | main.rs:67:5:67:21 | struct Foo |
-| main.rs:773:20:773:38 | ...::Foo {...} |  | main.rs:67:5:67:21 | struct Foo |
-| main.rs:773:41:773:59 | ...::Foo {...} |  | main.rs:67:5:67:21 | struct Foo |
+| main.rs:766:15:766:16 | &x | &T | main.rs:742:5:742:13 | S |
+| main.rs:766:16:766:16 | x |  | main.rs:742:5:742:13 | S |
+| main.rs:772:5:772:20 | ...::f(...) |  | main.rs:67:5:67:21 | Foo |
+| main.rs:773:5:773:60 | ...::g(...) |  | main.rs:67:5:67:21 | Foo |
+| main.rs:773:20:773:38 | ...::Foo {...} |  | main.rs:67:5:67:21 | Foo |
+| main.rs:773:41:773:59 | ...::Foo {...} |  | main.rs:67:5:67:21 | Foo |
 resolveMethodCallExpr
-| loop/main.rs:12:9:12:18 | self.foo(...) | loop/main.rs:7:5:7:19 | fn foo |
-| main.rs:88:9:88:14 | x.m1(...) | main.rs:70:9:72:9 | fn m1 |
-| main.rs:89:9:89:14 | y.m2(...) | main.rs:74:9:76:9 | fn m2 |
-| main.rs:136:26:136:31 | x.m2(...) | main.rs:117:9:119:9 | fn m2 |
-| main.rs:137:26:137:31 | y.m2(...) | main.rs:117:9:119:9 | fn m2 |
-| main.rs:164:9:164:14 | x.m1(...) | main.rs:153:9:153:25 | fn m1 |
-| main.rs:215:18:215:27 | x.method(...) | main.rs:210:9:210:30 | fn method |
-| main.rs:221:18:221:27 | x.method(...) | main.rs:210:9:210:30 | fn method |
-| main.rs:226:17:226:26 | x.method(...) | main.rs:206:9:206:30 | fn method |
-| main.rs:231:17:231:26 | x.method(...) | main.rs:206:9:206:30 | fn method |
-| main.rs:243:18:243:24 | x.fst(...) | main.rs:236:9:236:27 | fn fst |
-| main.rs:244:18:244:24 | y.snd(...) | main.rs:238:9:238:27 | fn snd |
-| main.rs:250:18:250:24 | x.fst(...) | main.rs:236:9:236:27 | fn fst |
-| main.rs:251:18:251:24 | y.snd(...) | main.rs:238:9:238:27 | fn snd |
-| main.rs:274:13:274:21 | self.m1(...) | main.rs:268:9:268:25 | fn m1 |
-| main.rs:280:9:280:14 | x.m1(...) | main.rs:268:9:268:25 | fn m1 |
-| main.rs:285:9:285:16 | ... .m1(...) | main.rs:268:9:268:25 | fn m1 |
-| main.rs:298:26:298:31 | x.m1(...) | main.rs:289:9:291:9 | fn m1 |
-| main.rs:299:26:299:31 | y.m1(...) | main.rs:289:9:291:9 | fn m1 |
-| main.rs:304:26:304:31 | x.m2(...) | main.rs:270:9:275:9 | fn m2 |
-| main.rs:305:26:305:31 | y.m2(...) | main.rs:270:9:275:9 | fn m2 |
-| main.rs:353:26:353:31 | x.m1(...) | main.rs:346:9:348:9 | fn m1 |
-| main.rs:356:26:356:31 | x.m2(...) | main.rs:331:9:337:9 | fn m2 |
-| main.rs:385:26:385:31 | x.m1(...) | main.rs:373:9:378:9 | fn m1 |
-| main.rs:386:26:386:31 | y.m1(...) | main.rs:373:9:378:9 | fn m1 |
-| main.rs:416:17:416:25 | self.m1(...) | main.rs:407:9:407:27 | fn m1 |
-| main.rs:429:17:429:25 | self.m2(...) | main.rs:411:9:420:9 | fn m2 |
-| main.rs:458:26:458:31 | x.m1(...) | main.rs:437:9:439:9 | fn m1 |
-| main.rs:459:26:459:31 | y.m1(...) | main.rs:437:9:439:9 | fn m1 |
-| main.rs:464:26:464:31 | x.m2(...) | main.rs:411:9:420:9 | fn m2 |
-| main.rs:465:26:465:31 | y.m2(...) | main.rs:411:9:420:9 | fn m2 |
-| main.rs:470:26:470:31 | x.m3(...) | main.rs:424:9:433:9 | fn m3 |
-| main.rs:471:26:471:31 | y.m3(...) | main.rs:424:9:433:9 | fn m3 |
+| loop/main.rs:12:9:12:18 | self.foo() | loop/main.rs:7:5:7:19 | fn foo |
+| main.rs:88:9:88:14 | x.m1() | main.rs:70:9:72:9 | fn m1 |
+| main.rs:89:9:89:14 | y.m2() | main.rs:74:9:76:9 | fn m2 |
+| main.rs:136:26:136:31 | x.m2() | main.rs:117:9:119:9 | fn m2 |
+| main.rs:137:26:137:31 | y.m2() | main.rs:117:9:119:9 | fn m2 |
+| main.rs:164:9:164:14 | x.m1() | main.rs:153:9:153:25 | fn m1 |
+| main.rs:215:18:215:27 | x.method() | main.rs:210:9:210:30 | fn method |
+| main.rs:221:18:221:27 | x.method() | main.rs:210:9:210:30 | fn method |
+| main.rs:226:17:226:26 | x.method() | main.rs:206:9:206:30 | fn method |
+| main.rs:231:17:231:26 | x.method() | main.rs:206:9:206:30 | fn method |
+| main.rs:243:18:243:24 | x.fst() | main.rs:236:9:236:27 | fn fst |
+| main.rs:244:18:244:24 | y.snd() | main.rs:238:9:238:27 | fn snd |
+| main.rs:250:18:250:24 | x.fst() | main.rs:236:9:236:27 | fn fst |
+| main.rs:251:18:251:24 | y.snd() | main.rs:238:9:238:27 | fn snd |
+| main.rs:274:13:274:21 | self.m1() | main.rs:268:9:268:25 | fn m1 |
+| main.rs:280:9:280:14 | x.m1() | main.rs:268:9:268:25 | fn m1 |
+| main.rs:285:9:285:16 | ... .m1() | main.rs:268:9:268:25 | fn m1 |
+| main.rs:298:26:298:31 | x.m1() | main.rs:289:9:291:9 | fn m1 |
+| main.rs:299:26:299:31 | y.m1() | main.rs:289:9:291:9 | fn m1 |
+| main.rs:304:26:304:31 | x.m2() | main.rs:270:9:275:9 | fn m2 |
+| main.rs:305:26:305:31 | y.m2() | main.rs:270:9:275:9 | fn m2 |
+| main.rs:353:26:353:31 | x.m1() | main.rs:346:9:348:9 | fn m1 |
+| main.rs:356:26:356:31 | x.m2() | main.rs:331:9:337:9 | fn m2 |
+| main.rs:385:26:385:31 | x.m1() | main.rs:373:9:378:9 | fn m1 |
+| main.rs:386:26:386:31 | y.m1() | main.rs:373:9:378:9 | fn m1 |
+| main.rs:416:17:416:25 | self.m1() | main.rs:407:9:407:27 | fn m1 |
+| main.rs:429:17:429:25 | self.m2() | main.rs:411:9:420:9 | fn m2 |
+| main.rs:458:26:458:31 | x.m1() | main.rs:437:9:439:9 | fn m1 |
+| main.rs:459:26:459:31 | y.m1() | main.rs:437:9:439:9 | fn m1 |
+| main.rs:464:26:464:31 | x.m2() | main.rs:411:9:420:9 | fn m2 |
+| main.rs:465:26:465:31 | y.m2() | main.rs:411:9:420:9 | fn m2 |
+| main.rs:470:26:470:31 | x.m3() | main.rs:424:9:433:9 | fn m3 |
+| main.rs:471:26:471:31 | y.m3() | main.rs:424:9:433:9 | fn m3 |
 | main.rs:578:13:578:27 | self.set(...) | main.rs:575:9:575:36 | fn set |
 | main.rs:609:9:609:17 | x2.set(...) | main.rs:583:9:583:38 | fn set |
 | main.rs:613:9:613:22 | x3.call_set(...) | main.rs:577:9:579:9 | fn call_set |
-| main.rs:673:26:673:32 | x1.m1(...) | main.rs:658:9:660:9 | fn m1 |
-| main.rs:677:26:677:32 | x2.m2(...) | main.rs:662:9:664:9 | fn m2 |
-| main.rs:678:26:678:32 | x2.m3(...) | main.rs:666:9:668:9 | fn m3 |
-| main.rs:687:26:687:32 | x4.m2(...) | main.rs:662:9:664:9 | fn m2 |
-| main.rs:688:26:688:32 | x4.m3(...) | main.rs:666:9:668:9 | fn m3 |
-| main.rs:692:26:692:32 | x5.m1(...) | main.rs:658:9:660:9 | fn m1 |
-| main.rs:697:26:697:35 | ... .m1(...) | main.rs:658:9:660:9 | fn m1 |
-| main.rs:706:13:706:22 | self.foo(...) | main.rs:703:9:703:31 | fn foo |
-| main.rs:720:9:720:15 | x.bar(...) | main.rs:705:9:707:9 | fn bar |
-| main.rs:737:9:737:15 | x.foo(...) | main.rs:730:9:732:9 | fn foo |
-| main.rs:764:9:764:14 | x.f1(...) | main.rs:745:9:747:9 | fn f1 |
-| main.rs:765:9:765:14 | x.f2(...) | main.rs:749:9:751:9 | fn f2 |
+| main.rs:673:26:673:32 | x1.m1() | main.rs:658:9:660:9 | fn m1 |
+| main.rs:677:26:677:32 | x2.m2() | main.rs:662:9:664:9 | fn m2 |
+| main.rs:678:26:678:32 | x2.m3() | main.rs:666:9:668:9 | fn m3 |
+| main.rs:687:26:687:32 | x4.m2() | main.rs:662:9:664:9 | fn m2 |
+| main.rs:688:26:688:32 | x4.m3() | main.rs:666:9:668:9 | fn m3 |
+| main.rs:692:26:692:32 | x5.m1() | main.rs:658:9:660:9 | fn m1 |
+| main.rs:697:26:697:35 | ... .m1() | main.rs:658:9:660:9 | fn m1 |
+| main.rs:706:13:706:22 | self.foo() | main.rs:703:9:703:31 | fn foo |
+| main.rs:720:9:720:15 | x.bar() | main.rs:705:9:707:9 | fn bar |
+| main.rs:737:9:737:15 | x.foo() | main.rs:730:9:732:9 | fn foo |
+| main.rs:764:9:764:14 | x.f1() | main.rs:745:9:747:9 | fn f1 |
+| main.rs:765:9:765:14 | x.f2() | main.rs:749:9:751:9 | fn f2 |
 resolveFieldExpr
 | main.rs:27:26:27:28 | x.a | main.rs:7:9:7:12 | StructField |
 | main.rs:33:26:33:28 | x.a | main.rs:18:9:18:12 | StructField |

--- a/rust/ql/test/library-tests/type-inference/type-inference.expected
+++ b/rust/ql/test/library-tests/type-inference/type-inference.expected
@@ -1,3 +1,4 @@
+testFailures
 inferType
 | loop/main.rs:7:12:7:15 | SelfParam |  | loop/main.rs:6:1:8:1 | Self [trait T1] |
 | loop/main.rs:11:12:11:15 | SelfParam |  | loop/main.rs:10:1:14:1 | Self [trait T2] |
@@ -79,861 +80,788 @@ inferType
 | main.rs:88:9:88:14 | x.m1() |  | main.rs:67:5:67:21 | Foo |
 | main.rs:89:9:89:9 | y |  | main.rs:67:5:67:21 | Foo |
 | main.rs:89:9:89:14 | y.m2() |  | main.rs:67:5:67:21 | Foo |
-| main.rs:105:15:105:18 | SelfParam |  | main.rs:94:5:97:5 | MyThing |
-| main.rs:105:15:105:18 | SelfParam | A | main.rs:99:5:100:14 | S1 |
-| main.rs:105:27:107:9 | { ... } |  | main.rs:99:5:100:14 | S1 |
-| main.rs:106:13:106:16 | self |  | main.rs:94:5:97:5 | MyThing |
-| main.rs:106:13:106:16 | self | A | main.rs:99:5:100:14 | S1 |
-| main.rs:106:13:106:18 | self.a |  | main.rs:99:5:100:14 | S1 |
-| main.rs:111:15:111:18 | SelfParam |  | main.rs:94:5:97:5 | MyThing |
-| main.rs:111:15:111:18 | SelfParam | A | main.rs:101:5:102:14 | S2 |
-| main.rs:111:29:113:9 | { ... } |  | main.rs:94:5:97:5 | MyThing |
-| main.rs:111:29:113:9 | { ... } | A | main.rs:101:5:102:14 | S2 |
-| main.rs:112:13:112:30 | Self {...} |  | main.rs:94:5:97:5 | MyThing |
-| main.rs:112:13:112:30 | Self {...} | A | main.rs:101:5:102:14 | S2 |
-| main.rs:112:23:112:26 | self |  | main.rs:94:5:97:5 | MyThing |
-| main.rs:112:23:112:26 | self | A | main.rs:101:5:102:14 | S2 |
-| main.rs:112:23:112:28 | self.a |  | main.rs:101:5:102:14 | S2 |
-| main.rs:117:15:117:18 | SelfParam |  | main.rs:94:5:97:5 | MyThing |
-| main.rs:117:15:117:18 | SelfParam | A | main.rs:116:10:116:10 | T |
-| main.rs:117:26:119:9 | { ... } |  | main.rs:116:10:116:10 | T |
-| main.rs:118:13:118:16 | self |  | main.rs:94:5:97:5 | MyThing |
-| main.rs:118:13:118:16 | self | A | main.rs:116:10:116:10 | T |
-| main.rs:118:13:118:18 | self.a |  | main.rs:116:10:116:10 | T |
-| main.rs:123:13:123:13 | x |  | main.rs:94:5:97:5 | MyThing |
-| main.rs:123:13:123:13 | x | A | main.rs:99:5:100:14 | S1 |
-| main.rs:123:17:123:33 | MyThing {...} |  | main.rs:94:5:97:5 | MyThing |
-| main.rs:123:17:123:33 | MyThing {...} | A | main.rs:99:5:100:14 | S1 |
-| main.rs:123:30:123:31 | S1 |  | main.rs:99:5:100:14 | S1 |
-| main.rs:124:13:124:13 | y |  | main.rs:94:5:97:5 | MyThing |
-| main.rs:124:13:124:13 | y | A | main.rs:101:5:102:14 | S2 |
-| main.rs:124:17:124:33 | MyThing {...} |  | main.rs:94:5:97:5 | MyThing |
-| main.rs:124:17:124:33 | MyThing {...} | A | main.rs:101:5:102:14 | S2 |
-| main.rs:124:30:124:31 | S2 |  | main.rs:101:5:102:14 | S2 |
-| main.rs:127:26:127:26 | x |  | main.rs:94:5:97:5 | MyThing |
-| main.rs:127:26:127:26 | x | A | main.rs:99:5:100:14 | S1 |
-| main.rs:127:26:127:28 | x.a |  | main.rs:99:5:100:14 | S1 |
-| main.rs:128:26:128:26 | y |  | main.rs:94:5:97:5 | MyThing |
-| main.rs:128:26:128:26 | y | A | main.rs:101:5:102:14 | S2 |
-| main.rs:128:26:128:28 | y.a |  | main.rs:101:5:102:14 | S2 |
-| main.rs:130:26:130:26 | x |  | main.rs:94:5:97:5 | MyThing |
-| main.rs:130:26:130:26 | x | A | main.rs:99:5:100:14 | S1 |
-| main.rs:131:26:131:26 | y |  | main.rs:94:5:97:5 | MyThing |
-| main.rs:131:26:131:26 | y | A | main.rs:101:5:102:14 | S2 |
-| main.rs:133:13:133:13 | x |  | main.rs:94:5:97:5 | MyThing |
-| main.rs:133:13:133:13 | x | A | main.rs:99:5:100:14 | S1 |
-| main.rs:133:17:133:33 | MyThing {...} |  | main.rs:94:5:97:5 | MyThing |
-| main.rs:133:17:133:33 | MyThing {...} | A | main.rs:99:5:100:14 | S1 |
-| main.rs:133:30:133:31 | S1 |  | main.rs:99:5:100:14 | S1 |
-| main.rs:134:13:134:13 | y |  | main.rs:94:5:97:5 | MyThing |
-| main.rs:134:13:134:13 | y | A | main.rs:101:5:102:14 | S2 |
-| main.rs:134:17:134:33 | MyThing {...} |  | main.rs:94:5:97:5 | MyThing |
-| main.rs:134:17:134:33 | MyThing {...} | A | main.rs:101:5:102:14 | S2 |
-| main.rs:134:30:134:31 | S2 |  | main.rs:101:5:102:14 | S2 |
-| main.rs:136:26:136:26 | x |  | main.rs:94:5:97:5 | MyThing |
-| main.rs:136:26:136:26 | x | A | main.rs:99:5:100:14 | S1 |
-| main.rs:136:26:136:31 | x.m2() |  | main.rs:99:5:100:14 | S1 |
-| main.rs:137:26:137:26 | y |  | main.rs:94:5:97:5 | MyThing |
-| main.rs:137:26:137:26 | y | A | main.rs:101:5:102:14 | S2 |
-| main.rs:137:26:137:31 | y.m2() |  | main.rs:101:5:102:14 | S2 |
-| main.rs:153:15:153:18 | SelfParam |  | main.rs:152:5:161:5 | Self [trait MyTrait] |
-| main.rs:155:15:155:18 | SelfParam |  | main.rs:152:5:161:5 | Self [trait MyTrait] |
-| main.rs:158:9:160:9 | { ... } |  | main.rs:152:5:161:5 | Self [trait MyTrait] |
-| main.rs:159:13:159:16 | self |  | main.rs:152:5:161:5 | Self [trait MyTrait] |
-| main.rs:163:43:163:43 | x |  | main.rs:163:26:163:40 | T2 |
-| main.rs:163:56:165:5 | { ... } |  | main.rs:163:22:163:23 | T1 |
-| main.rs:164:9:164:9 | x |  | main.rs:163:26:163:40 | T2 |
-| main.rs:164:9:164:14 | x.m1() |  | main.rs:163:22:163:23 | T1 |
-| main.rs:168:15:168:18 | SelfParam |  | main.rs:142:5:145:5 | MyThing |
-| main.rs:168:15:168:18 | SelfParam | A | main.rs:147:5:148:14 | S1 |
-| main.rs:168:27:170:9 | { ... } |  | main.rs:147:5:148:14 | S1 |
-| main.rs:169:13:169:16 | self |  | main.rs:142:5:145:5 | MyThing |
-| main.rs:169:13:169:16 | self | A | main.rs:147:5:148:14 | S1 |
-| main.rs:169:13:169:18 | self.a |  | main.rs:147:5:148:14 | S1 |
-| main.rs:174:15:174:18 | SelfParam |  | main.rs:142:5:145:5 | MyThing |
-| main.rs:174:15:174:18 | SelfParam | A | main.rs:149:5:150:14 | S2 |
-| main.rs:174:29:176:9 | { ... } |  | main.rs:142:5:145:5 | MyThing |
-| main.rs:174:29:176:9 | { ... } | A | main.rs:149:5:150:14 | S2 |
-| main.rs:175:13:175:30 | Self {...} |  | main.rs:142:5:145:5 | MyThing |
-| main.rs:175:13:175:30 | Self {...} | A | main.rs:149:5:150:14 | S2 |
-| main.rs:175:23:175:26 | self |  | main.rs:142:5:145:5 | MyThing |
-| main.rs:175:23:175:26 | self | A | main.rs:149:5:150:14 | S2 |
-| main.rs:175:23:175:28 | self.a |  | main.rs:149:5:150:14 | S2 |
-| main.rs:180:13:180:13 | x |  | main.rs:142:5:145:5 | MyThing |
-| main.rs:180:13:180:13 | x | A | main.rs:147:5:148:14 | S1 |
-| main.rs:180:17:180:33 | MyThing {...} |  | main.rs:142:5:145:5 | MyThing |
-| main.rs:180:17:180:33 | MyThing {...} | A | main.rs:147:5:148:14 | S1 |
-| main.rs:180:30:180:31 | S1 |  | main.rs:147:5:148:14 | S1 |
-| main.rs:181:13:181:13 | y |  | main.rs:142:5:145:5 | MyThing |
-| main.rs:181:13:181:13 | y | A | main.rs:149:5:150:14 | S2 |
-| main.rs:181:17:181:33 | MyThing {...} |  | main.rs:142:5:145:5 | MyThing |
-| main.rs:181:17:181:33 | MyThing {...} | A | main.rs:149:5:150:14 | S2 |
-| main.rs:181:30:181:31 | S2 |  | main.rs:149:5:150:14 | S2 |
-| main.rs:183:26:183:26 | x |  | main.rs:142:5:145:5 | MyThing |
-| main.rs:183:26:183:26 | x | A | main.rs:147:5:148:14 | S1 |
-| main.rs:184:26:184:26 | y |  | main.rs:142:5:145:5 | MyThing |
-| main.rs:184:26:184:26 | y | A | main.rs:149:5:150:14 | S2 |
-| main.rs:186:13:186:13 | x |  | main.rs:142:5:145:5 | MyThing |
-| main.rs:186:13:186:13 | x | A | main.rs:147:5:148:14 | S1 |
-| main.rs:186:17:186:33 | MyThing {...} |  | main.rs:142:5:145:5 | MyThing |
-| main.rs:186:17:186:33 | MyThing {...} | A | main.rs:147:5:148:14 | S1 |
-| main.rs:186:30:186:31 | S1 |  | main.rs:147:5:148:14 | S1 |
-| main.rs:187:13:187:13 | y |  | main.rs:142:5:145:5 | MyThing |
-| main.rs:187:13:187:13 | y | A | main.rs:149:5:150:14 | S2 |
-| main.rs:187:17:187:33 | MyThing {...} |  | main.rs:142:5:145:5 | MyThing |
-| main.rs:187:17:187:33 | MyThing {...} | A | main.rs:149:5:150:14 | S2 |
-| main.rs:187:30:187:31 | S2 |  | main.rs:149:5:150:14 | S2 |
-| main.rs:189:40:189:40 | x |  | main.rs:142:5:145:5 | MyThing |
-| main.rs:189:40:189:40 | x | A | main.rs:147:5:148:14 | S1 |
-| main.rs:190:40:190:40 | y |  | main.rs:142:5:145:5 | MyThing |
-| main.rs:190:40:190:40 | y | A | main.rs:149:5:150:14 | S2 |
-| main.rs:206:19:206:22 | SelfParam |  | main.rs:205:5:207:5 | Self [trait FirstTrait] |
-| main.rs:210:19:210:22 | SelfParam |  | main.rs:209:5:211:5 | Self [trait SecondTrait] |
-| main.rs:213:64:213:64 | x |  | main.rs:213:45:213:61 | T |
-| main.rs:215:13:215:14 | s1 |  | main.rs:213:35:213:42 | I |
-| main.rs:215:18:215:18 | x |  | main.rs:213:45:213:61 | T |
-| main.rs:215:18:215:27 | x.method() |  | main.rs:213:35:213:42 | I |
-| main.rs:216:26:216:27 | s1 |  | main.rs:213:35:213:42 | I |
-| main.rs:219:65:219:65 | x |  | main.rs:219:46:219:62 | T |
-| main.rs:221:13:221:14 | s2 |  | main.rs:219:36:219:43 | I |
-| main.rs:221:18:221:18 | x |  | main.rs:219:46:219:62 | T |
-| main.rs:221:18:221:27 | x.method() |  | main.rs:219:36:219:43 | I |
-| main.rs:222:26:222:27 | s2 |  | main.rs:219:36:219:43 | I |
-| main.rs:225:49:225:49 | x |  | main.rs:225:30:225:46 | T |
-| main.rs:226:13:226:13 | s |  | main.rs:197:5:198:14 | S1 |
-| main.rs:226:17:226:17 | x |  | main.rs:225:30:225:46 | T |
-| main.rs:226:17:226:26 | x.method() |  | main.rs:197:5:198:14 | S1 |
-| main.rs:227:26:227:26 | s |  | main.rs:197:5:198:14 | S1 |
-| main.rs:230:53:230:53 | x |  | main.rs:230:34:230:50 | T |
-| main.rs:231:13:231:13 | s |  | main.rs:197:5:198:14 | S1 |
-| main.rs:231:17:231:17 | x |  | main.rs:230:34:230:50 | T |
-| main.rs:231:17:231:26 | x.method() |  | main.rs:197:5:198:14 | S1 |
-| main.rs:232:26:232:26 | s |  | main.rs:197:5:198:14 | S1 |
-| main.rs:236:16:236:19 | SelfParam |  | main.rs:235:5:239:5 | Self [trait Pair] |
-| main.rs:238:16:238:19 | SelfParam |  | main.rs:235:5:239:5 | Self [trait Pair] |
-| main.rs:241:58:241:58 | x |  | main.rs:241:41:241:55 | T |
-| main.rs:241:64:241:64 | y |  | main.rs:241:41:241:55 | T |
-| main.rs:243:13:243:14 | s1 |  | main.rs:197:5:198:14 | S1 |
-| main.rs:243:18:243:18 | x |  | main.rs:241:41:241:55 | T |
-| main.rs:243:18:243:24 | x.fst() |  | main.rs:197:5:198:14 | S1 |
-| main.rs:244:13:244:14 | s2 |  | main.rs:200:5:201:14 | S2 |
-| main.rs:244:18:244:18 | y |  | main.rs:241:41:241:55 | T |
-| main.rs:244:18:244:24 | y.snd() |  | main.rs:200:5:201:14 | S2 |
-| main.rs:245:32:245:33 | s1 |  | main.rs:197:5:198:14 | S1 |
-| main.rs:245:36:245:37 | s2 |  | main.rs:200:5:201:14 | S2 |
-| main.rs:248:69:248:69 | x |  | main.rs:248:52:248:66 | T |
-| main.rs:248:75:248:75 | y |  | main.rs:248:52:248:66 | T |
-| main.rs:250:13:250:14 | s1 |  | main.rs:197:5:198:14 | S1 |
-| main.rs:250:18:250:18 | x |  | main.rs:248:52:248:66 | T |
-| main.rs:250:18:250:24 | x.fst() |  | main.rs:197:5:198:14 | S1 |
-| main.rs:251:13:251:14 | s2 |  | main.rs:248:41:248:49 | T2 |
-| main.rs:251:18:251:18 | y |  | main.rs:248:52:248:66 | T |
-| main.rs:251:18:251:24 | y.snd() |  | main.rs:248:41:248:49 | T2 |
-| main.rs:252:32:252:33 | s1 |  | main.rs:197:5:198:14 | S1 |
-| main.rs:252:36:252:37 | s2 |  | main.rs:248:41:248:49 | T2 |
-| main.rs:268:15:268:18 | SelfParam |  | main.rs:267:5:276:5 | Self [trait MyTrait] |
-| main.rs:270:15:270:18 | SelfParam |  | main.rs:267:5:276:5 | Self [trait MyTrait] |
-| main.rs:273:9:275:9 | { ... } |  | main.rs:267:19:267:19 | A |
-| main.rs:274:13:274:16 | self |  | main.rs:267:5:276:5 | Self [trait MyTrait] |
-| main.rs:274:13:274:21 | self.m1() |  | main.rs:267:19:267:19 | A |
-| main.rs:279:43:279:43 | x |  | main.rs:279:26:279:40 | T2 |
-| main.rs:279:56:281:5 | { ... } |  | main.rs:279:22:279:23 | T1 |
-| main.rs:280:9:280:9 | x |  | main.rs:279:26:279:40 | T2 |
-| main.rs:280:9:280:14 | x.m1() |  | main.rs:279:22:279:23 | T1 |
-| main.rs:284:49:284:49 | x |  | main.rs:257:5:260:5 | MyThing |
-| main.rs:284:49:284:49 | x | T | main.rs:284:32:284:46 | T2 |
-| main.rs:284:71:286:5 | { ... } |  | main.rs:284:28:284:29 | T1 |
-| main.rs:285:9:285:9 | x |  | main.rs:257:5:260:5 | MyThing |
-| main.rs:285:9:285:9 | x | T | main.rs:284:32:284:46 | T2 |
-| main.rs:285:9:285:11 | x.a |  | main.rs:284:32:284:46 | T2 |
-| main.rs:285:9:285:16 | ... .m1() |  | main.rs:284:28:284:29 | T1 |
-| main.rs:289:15:289:18 | SelfParam |  | main.rs:257:5:260:5 | MyThing |
-| main.rs:289:15:289:18 | SelfParam | T | main.rs:288:10:288:10 | T |
-| main.rs:289:26:291:9 | { ... } |  | main.rs:288:10:288:10 | T |
-| main.rs:290:13:290:16 | self |  | main.rs:257:5:260:5 | MyThing |
-| main.rs:290:13:290:16 | self | T | main.rs:288:10:288:10 | T |
-| main.rs:290:13:290:18 | self.a |  | main.rs:288:10:288:10 | T |
-| main.rs:295:13:295:13 | x |  | main.rs:257:5:260:5 | MyThing |
-| main.rs:295:13:295:13 | x | T | main.rs:262:5:263:14 | S1 |
-| main.rs:295:17:295:33 | MyThing {...} |  | main.rs:257:5:260:5 | MyThing |
-| main.rs:295:17:295:33 | MyThing {...} | T | main.rs:262:5:263:14 | S1 |
-| main.rs:295:30:295:31 | S1 |  | main.rs:262:5:263:14 | S1 |
-| main.rs:296:13:296:13 | y |  | main.rs:257:5:260:5 | MyThing |
-| main.rs:296:13:296:13 | y | T | main.rs:264:5:265:14 | S2 |
-| main.rs:296:17:296:33 | MyThing {...} |  | main.rs:257:5:260:5 | MyThing |
-| main.rs:296:17:296:33 | MyThing {...} | T | main.rs:264:5:265:14 | S2 |
-| main.rs:296:30:296:31 | S2 |  | main.rs:264:5:265:14 | S2 |
-| main.rs:298:26:298:26 | x |  | main.rs:257:5:260:5 | MyThing |
-| main.rs:298:26:298:26 | x | T | main.rs:262:5:263:14 | S1 |
-| main.rs:298:26:298:31 | x.m1() |  | main.rs:262:5:263:14 | S1 |
-| main.rs:299:26:299:26 | y |  | main.rs:257:5:260:5 | MyThing |
-| main.rs:299:26:299:26 | y | T | main.rs:264:5:265:14 | S2 |
-| main.rs:299:26:299:31 | y.m1() |  | main.rs:264:5:265:14 | S2 |
-| main.rs:301:13:301:13 | x |  | main.rs:257:5:260:5 | MyThing |
-| main.rs:301:13:301:13 | x | T | main.rs:262:5:263:14 | S1 |
-| main.rs:301:17:301:33 | MyThing {...} |  | main.rs:257:5:260:5 | MyThing |
-| main.rs:301:17:301:33 | MyThing {...} | T | main.rs:262:5:263:14 | S1 |
-| main.rs:301:30:301:31 | S1 |  | main.rs:262:5:263:14 | S1 |
-| main.rs:302:13:302:13 | y |  | main.rs:257:5:260:5 | MyThing |
-| main.rs:302:13:302:13 | y | T | main.rs:264:5:265:14 | S2 |
-| main.rs:302:17:302:33 | MyThing {...} |  | main.rs:257:5:260:5 | MyThing |
-| main.rs:302:17:302:33 | MyThing {...} | T | main.rs:264:5:265:14 | S2 |
-| main.rs:302:30:302:31 | S2 |  | main.rs:264:5:265:14 | S2 |
-| main.rs:304:26:304:26 | x |  | main.rs:257:5:260:5 | MyThing |
-| main.rs:304:26:304:26 | x | T | main.rs:262:5:263:14 | S1 |
-| main.rs:304:26:304:31 | x.m2() |  | main.rs:262:5:263:14 | S1 |
-| main.rs:305:26:305:26 | y |  | main.rs:257:5:260:5 | MyThing |
-| main.rs:305:26:305:26 | y | T | main.rs:264:5:265:14 | S2 |
-| main.rs:305:26:305:31 | y.m2() |  | main.rs:264:5:265:14 | S2 |
-| main.rs:307:13:307:14 | x2 |  | main.rs:257:5:260:5 | MyThing |
-| main.rs:307:13:307:14 | x2 | T | main.rs:262:5:263:14 | S1 |
-| main.rs:307:18:307:34 | MyThing {...} |  | main.rs:257:5:260:5 | MyThing |
-| main.rs:307:18:307:34 | MyThing {...} | T | main.rs:262:5:263:14 | S1 |
-| main.rs:307:31:307:32 | S1 |  | main.rs:262:5:263:14 | S1 |
-| main.rs:308:13:308:14 | y2 |  | main.rs:257:5:260:5 | MyThing |
-| main.rs:308:13:308:14 | y2 | T | main.rs:264:5:265:14 | S2 |
-| main.rs:308:18:308:34 | MyThing {...} |  | main.rs:257:5:260:5 | MyThing |
-| main.rs:308:18:308:34 | MyThing {...} | T | main.rs:264:5:265:14 | S2 |
-| main.rs:308:31:308:32 | S2 |  | main.rs:264:5:265:14 | S2 |
-| main.rs:310:26:310:42 | call_trait_m1(...) |  | main.rs:262:5:263:14 | S1 |
-| main.rs:310:40:310:41 | x2 |  | main.rs:257:5:260:5 | MyThing |
-| main.rs:310:40:310:41 | x2 | T | main.rs:262:5:263:14 | S1 |
-| main.rs:311:26:311:42 | call_trait_m1(...) |  | main.rs:264:5:265:14 | S2 |
-| main.rs:311:40:311:41 | y2 |  | main.rs:257:5:260:5 | MyThing |
-| main.rs:311:40:311:41 | y2 | T | main.rs:264:5:265:14 | S2 |
-| main.rs:313:13:313:14 | x3 |  | main.rs:257:5:260:5 | MyThing |
-| main.rs:313:13:313:14 | x3 | T | main.rs:257:5:260:5 | MyThing |
-| main.rs:313:13:313:14 | x3 | T.T | main.rs:262:5:263:14 | S1 |
-| main.rs:313:18:315:9 | MyThing {...} |  | main.rs:257:5:260:5 | MyThing |
-| main.rs:313:18:315:9 | MyThing {...} | T | main.rs:257:5:260:5 | MyThing |
-| main.rs:313:18:315:9 | MyThing {...} | T.T | main.rs:262:5:263:14 | S1 |
-| main.rs:314:16:314:32 | MyThing {...} |  | main.rs:257:5:260:5 | MyThing |
-| main.rs:314:16:314:32 | MyThing {...} | T | main.rs:262:5:263:14 | S1 |
-| main.rs:314:29:314:30 | S1 |  | main.rs:262:5:263:14 | S1 |
-| main.rs:316:13:316:14 | y3 |  | main.rs:257:5:260:5 | MyThing |
-| main.rs:316:13:316:14 | y3 | T | main.rs:257:5:260:5 | MyThing |
-| main.rs:316:13:316:14 | y3 | T.T | main.rs:264:5:265:14 | S2 |
-| main.rs:316:18:318:9 | MyThing {...} |  | main.rs:257:5:260:5 | MyThing |
-| main.rs:316:18:318:9 | MyThing {...} | T | main.rs:257:5:260:5 | MyThing |
-| main.rs:316:18:318:9 | MyThing {...} | T.T | main.rs:264:5:265:14 | S2 |
-| main.rs:317:16:317:32 | MyThing {...} |  | main.rs:257:5:260:5 | MyThing |
-| main.rs:317:16:317:32 | MyThing {...} | T | main.rs:264:5:265:14 | S2 |
-| main.rs:317:29:317:30 | S2 |  | main.rs:264:5:265:14 | S2 |
-| main.rs:320:26:320:48 | call_trait_thing_m1(...) |  | main.rs:262:5:263:14 | S1 |
-| main.rs:320:46:320:47 | x3 |  | main.rs:257:5:260:5 | MyThing |
-| main.rs:320:46:320:47 | x3 | T | main.rs:257:5:260:5 | MyThing |
-| main.rs:320:46:320:47 | x3 | T.T | main.rs:262:5:263:14 | S1 |
-| main.rs:321:26:321:48 | call_trait_thing_m1(...) |  | main.rs:264:5:265:14 | S2 |
-| main.rs:321:46:321:47 | y3 |  | main.rs:257:5:260:5 | MyThing |
-| main.rs:321:46:321:47 | y3 | T | main.rs:257:5:260:5 | MyThing |
-| main.rs:321:46:321:47 | y3 | T.T | main.rs:264:5:265:14 | S2 |
-| main.rs:329:15:329:18 | SelfParam |  | main.rs:326:5:338:5 | Self [trait MyTrait] |
-| main.rs:331:15:331:18 | SelfParam |  | main.rs:326:5:338:5 | Self [trait MyTrait] |
-| main.rs:346:15:346:18 | SelfParam |  | main.rs:340:5:341:13 | S |
-| main.rs:346:45:348:9 | { ... } |  | main.rs:340:5:341:13 | S |
-| main.rs:347:13:347:13 | S |  | main.rs:340:5:341:13 | S |
-| main.rs:352:13:352:13 | x |  | main.rs:340:5:341:13 | S |
-| main.rs:352:17:352:17 | S |  | main.rs:340:5:341:13 | S |
-| main.rs:353:26:353:26 | x |  | main.rs:340:5:341:13 | S |
-| main.rs:353:26:353:31 | x.m1() |  | main.rs:340:5:341:13 | S |
-| main.rs:355:13:355:13 | x |  | main.rs:340:5:341:13 | S |
-| main.rs:355:17:355:17 | S |  | main.rs:340:5:341:13 | S |
-| main.rs:356:26:356:26 | x |  | main.rs:340:5:341:13 | S |
-| main.rs:373:15:373:18 | SelfParam |  | main.rs:361:5:365:5 | MyEnum |
-| main.rs:373:15:373:18 | SelfParam | A | main.rs:372:10:372:10 | T |
-| main.rs:373:26:378:9 | { ... } |  | main.rs:372:10:372:10 | T |
-| main.rs:374:13:377:13 | match self { ... } |  | main.rs:372:10:372:10 | T |
-| main.rs:374:19:374:22 | self |  | main.rs:361:5:365:5 | MyEnum |
-| main.rs:374:19:374:22 | self | A | main.rs:372:10:372:10 | T |
-| main.rs:375:28:375:28 | a |  | main.rs:372:10:372:10 | T |
-| main.rs:375:34:375:34 | a |  | main.rs:372:10:372:10 | T |
-| main.rs:376:30:376:30 | a |  | main.rs:372:10:372:10 | T |
-| main.rs:376:37:376:37 | a |  | main.rs:372:10:372:10 | T |
-| main.rs:382:13:382:13 | x |  | main.rs:361:5:365:5 | MyEnum |
-| main.rs:382:13:382:13 | x | A | main.rs:367:5:368:14 | S1 |
-| main.rs:382:17:382:30 | ...::C1(...) |  | main.rs:361:5:365:5 | MyEnum |
-| main.rs:382:17:382:30 | ...::C1(...) | A | main.rs:367:5:368:14 | S1 |
-| main.rs:382:28:382:29 | S1 |  | main.rs:367:5:368:14 | S1 |
-| main.rs:383:13:383:13 | y |  | main.rs:361:5:365:5 | MyEnum |
-| main.rs:383:13:383:13 | y | A | main.rs:369:5:370:14 | S2 |
-| main.rs:383:17:383:36 | ...::C2 {...} |  | main.rs:361:5:365:5 | MyEnum |
-| main.rs:383:17:383:36 | ...::C2 {...} | A | main.rs:369:5:370:14 | S2 |
-| main.rs:383:33:383:34 | S2 |  | main.rs:369:5:370:14 | S2 |
-| main.rs:385:26:385:26 | x |  | main.rs:361:5:365:5 | MyEnum |
-| main.rs:385:26:385:26 | x | A | main.rs:367:5:368:14 | S1 |
-| main.rs:385:26:385:31 | x.m1() |  | main.rs:367:5:368:14 | S1 |
-| main.rs:386:26:386:26 | y |  | main.rs:361:5:365:5 | MyEnum |
-| main.rs:386:26:386:26 | y | A | main.rs:369:5:370:14 | S2 |
-| main.rs:386:26:386:31 | y.m1() |  | main.rs:369:5:370:14 | S2 |
-| main.rs:407:15:407:18 | SelfParam |  | main.rs:406:5:408:5 | Self [trait MyTrait1] |
-| main.rs:411:15:411:18 | SelfParam |  | main.rs:410:5:421:5 | Self [trait MyTrait2] |
-| main.rs:414:9:420:9 | { ... } |  | main.rs:410:20:410:22 | Tr2 |
-| main.rs:415:13:419:13 | if ... {...} else {...} |  | main.rs:410:20:410:22 | Tr2 |
-| main.rs:415:26:417:13 | { ... } |  | main.rs:410:20:410:22 | Tr2 |
-| main.rs:416:17:416:20 | self |  | main.rs:410:5:421:5 | Self [trait MyTrait2] |
-| main.rs:416:17:416:25 | self.m1() |  | main.rs:410:20:410:22 | Tr2 |
-| main.rs:417:20:419:13 | { ... } |  | main.rs:410:20:410:22 | Tr2 |
-| main.rs:418:17:418:30 | ...::m1(...) |  | main.rs:410:20:410:22 | Tr2 |
-| main.rs:418:26:418:29 | self |  | main.rs:410:5:421:5 | Self [trait MyTrait2] |
-| main.rs:424:15:424:18 | SelfParam |  | main.rs:423:5:434:5 | Self [trait MyTrait3] |
-| main.rs:427:9:433:9 | { ... } |  | main.rs:423:20:423:22 | Tr3 |
-| main.rs:428:13:432:13 | if ... {...} else {...} |  | main.rs:423:20:423:22 | Tr3 |
-| main.rs:428:26:430:13 | { ... } |  | main.rs:423:20:423:22 | Tr3 |
-| main.rs:429:17:429:20 | self |  | main.rs:423:5:434:5 | Self [trait MyTrait3] |
-| main.rs:429:17:429:25 | self.m2() |  | main.rs:391:5:394:5 | MyThing |
-| main.rs:429:17:429:25 | self.m2() | A | main.rs:423:20:423:22 | Tr3 |
-| main.rs:429:17:429:27 | ... .a |  | main.rs:423:20:423:22 | Tr3 |
-| main.rs:430:20:432:13 | { ... } |  | main.rs:423:20:423:22 | Tr3 |
-| main.rs:431:17:431:30 | ...::m2(...) |  | main.rs:391:5:394:5 | MyThing |
-| main.rs:431:17:431:30 | ...::m2(...) | A | main.rs:423:20:423:22 | Tr3 |
-| main.rs:431:17:431:32 | ... .a |  | main.rs:423:20:423:22 | Tr3 |
-| main.rs:431:26:431:29 | self |  | main.rs:423:5:434:5 | Self [trait MyTrait3] |
-| main.rs:437:15:437:18 | SelfParam |  | main.rs:391:5:394:5 | MyThing |
-| main.rs:437:15:437:18 | SelfParam | A | main.rs:436:10:436:10 | T |
-| main.rs:437:26:439:9 | { ... } |  | main.rs:436:10:436:10 | T |
-| main.rs:438:13:438:16 | self |  | main.rs:391:5:394:5 | MyThing |
-| main.rs:438:13:438:16 | self | A | main.rs:436:10:436:10 | T |
-| main.rs:438:13:438:18 | self.a |  | main.rs:436:10:436:10 | T |
-| main.rs:445:15:445:18 | SelfParam |  | main.rs:396:5:399:5 | MyThing2 |
-| main.rs:445:15:445:18 | SelfParam | A | main.rs:444:10:444:10 | T |
-| main.rs:445:35:447:9 | { ... } |  | main.rs:391:5:394:5 | MyThing |
-| main.rs:445:35:447:9 | { ... } | A | main.rs:444:10:444:10 | T |
-| main.rs:446:13:446:33 | MyThing {...} |  | main.rs:391:5:394:5 | MyThing |
-| main.rs:446:13:446:33 | MyThing {...} | A | main.rs:444:10:444:10 | T |
-| main.rs:446:26:446:29 | self |  | main.rs:396:5:399:5 | MyThing2 |
-| main.rs:446:26:446:29 | self | A | main.rs:444:10:444:10 | T |
-| main.rs:446:26:446:31 | self.a |  | main.rs:444:10:444:10 | T |
-| main.rs:455:13:455:13 | x |  | main.rs:391:5:394:5 | MyThing |
-| main.rs:455:13:455:13 | x | A | main.rs:401:5:402:14 | S1 |
-| main.rs:455:17:455:33 | MyThing {...} |  | main.rs:391:5:394:5 | MyThing |
-| main.rs:455:17:455:33 | MyThing {...} | A | main.rs:401:5:402:14 | S1 |
-| main.rs:455:30:455:31 | S1 |  | main.rs:401:5:402:14 | S1 |
-| main.rs:456:13:456:13 | y |  | main.rs:391:5:394:5 | MyThing |
-| main.rs:456:13:456:13 | y | A | main.rs:403:5:404:14 | S2 |
-| main.rs:456:17:456:33 | MyThing {...} |  | main.rs:391:5:394:5 | MyThing |
-| main.rs:456:17:456:33 | MyThing {...} | A | main.rs:403:5:404:14 | S2 |
-| main.rs:456:30:456:31 | S2 |  | main.rs:403:5:404:14 | S2 |
-| main.rs:458:26:458:26 | x |  | main.rs:391:5:394:5 | MyThing |
-| main.rs:458:26:458:26 | x | A | main.rs:401:5:402:14 | S1 |
-| main.rs:458:26:458:31 | x.m1() |  | main.rs:401:5:402:14 | S1 |
-| main.rs:459:26:459:26 | y |  | main.rs:391:5:394:5 | MyThing |
-| main.rs:459:26:459:26 | y | A | main.rs:403:5:404:14 | S2 |
-| main.rs:459:26:459:31 | y.m1() |  | main.rs:403:5:404:14 | S2 |
-| main.rs:461:13:461:13 | x |  | main.rs:391:5:394:5 | MyThing |
-| main.rs:461:13:461:13 | x | A | main.rs:401:5:402:14 | S1 |
-| main.rs:461:17:461:33 | MyThing {...} |  | main.rs:391:5:394:5 | MyThing |
-| main.rs:461:17:461:33 | MyThing {...} | A | main.rs:401:5:402:14 | S1 |
-| main.rs:461:30:461:31 | S1 |  | main.rs:401:5:402:14 | S1 |
-| main.rs:462:13:462:13 | y |  | main.rs:391:5:394:5 | MyThing |
-| main.rs:462:13:462:13 | y | A | main.rs:403:5:404:14 | S2 |
-| main.rs:462:17:462:33 | MyThing {...} |  | main.rs:391:5:394:5 | MyThing |
-| main.rs:462:17:462:33 | MyThing {...} | A | main.rs:403:5:404:14 | S2 |
-| main.rs:462:30:462:31 | S2 |  | main.rs:403:5:404:14 | S2 |
-| main.rs:464:26:464:26 | x |  | main.rs:391:5:394:5 | MyThing |
-| main.rs:464:26:464:26 | x | A | main.rs:401:5:402:14 | S1 |
-| main.rs:464:26:464:31 | x.m2() |  | main.rs:401:5:402:14 | S1 |
-| main.rs:465:26:465:26 | y |  | main.rs:391:5:394:5 | MyThing |
-| main.rs:465:26:465:26 | y | A | main.rs:403:5:404:14 | S2 |
-| main.rs:465:26:465:31 | y.m2() |  | main.rs:403:5:404:14 | S2 |
-| main.rs:467:13:467:13 | x |  | main.rs:396:5:399:5 | MyThing2 |
-| main.rs:467:13:467:13 | x | A | main.rs:401:5:402:14 | S1 |
-| main.rs:467:17:467:34 | MyThing2 {...} |  | main.rs:396:5:399:5 | MyThing2 |
-| main.rs:467:17:467:34 | MyThing2 {...} | A | main.rs:401:5:402:14 | S1 |
-| main.rs:467:31:467:32 | S1 |  | main.rs:401:5:402:14 | S1 |
-| main.rs:468:13:468:13 | y |  | main.rs:396:5:399:5 | MyThing2 |
-| main.rs:468:13:468:13 | y | A | main.rs:403:5:404:14 | S2 |
-| main.rs:468:17:468:34 | MyThing2 {...} |  | main.rs:396:5:399:5 | MyThing2 |
-| main.rs:468:17:468:34 | MyThing2 {...} | A | main.rs:403:5:404:14 | S2 |
-| main.rs:468:31:468:32 | S2 |  | main.rs:403:5:404:14 | S2 |
-| main.rs:470:26:470:26 | x |  | main.rs:396:5:399:5 | MyThing2 |
-| main.rs:470:26:470:26 | x | A | main.rs:401:5:402:14 | S1 |
-| main.rs:470:26:470:31 | x.m3() |  | main.rs:401:5:402:14 | S1 |
-| main.rs:471:26:471:26 | y |  | main.rs:396:5:399:5 | MyThing2 |
-| main.rs:471:26:471:26 | y | A | main.rs:403:5:404:14 | S2 |
-| main.rs:471:26:471:31 | y.m3() |  | main.rs:403:5:404:14 | S2 |
-| main.rs:489:22:489:22 | x |  | file://:0:0:0:0 | & |
-| main.rs:489:22:489:22 | x | &T | main.rs:489:11:489:19 | T |
-| main.rs:489:35:491:5 | { ... } |  | file://:0:0:0:0 | & |
-| main.rs:489:35:491:5 | { ... } | &T | main.rs:489:11:489:19 | T |
-| main.rs:490:9:490:9 | x |  | file://:0:0:0:0 | & |
-| main.rs:490:9:490:9 | x | &T | main.rs:489:11:489:19 | T |
-| main.rs:494:17:494:20 | SelfParam |  | main.rs:479:5:480:14 | S1 |
-| main.rs:494:29:496:9 | { ... } |  | main.rs:482:5:483:14 | S2 |
-| main.rs:495:13:495:14 | S2 |  | main.rs:482:5:483:14 | S2 |
-| main.rs:499:21:499:21 | x |  | main.rs:499:13:499:14 | T1 |
-| main.rs:502:5:504:5 | { ... } |  | main.rs:499:17:499:18 | T2 |
-| main.rs:503:9:503:9 | x |  | main.rs:499:13:499:14 | T1 |
-| main.rs:503:9:503:16 | x.into() |  | main.rs:499:17:499:18 | T2 |
-| main.rs:507:13:507:13 | x |  | main.rs:479:5:480:14 | S1 |
-| main.rs:507:17:507:18 | S1 |  | main.rs:479:5:480:14 | S1 |
-| main.rs:508:26:508:31 | id(...) |  | file://:0:0:0:0 | & |
-| main.rs:508:26:508:31 | id(...) | &T | main.rs:479:5:480:14 | S1 |
-| main.rs:508:29:508:30 | &x |  | file://:0:0:0:0 | & |
-| main.rs:508:29:508:30 | &x | &T | main.rs:479:5:480:14 | S1 |
-| main.rs:508:30:508:30 | x |  | main.rs:479:5:480:14 | S1 |
-| main.rs:510:13:510:13 | x |  | main.rs:479:5:480:14 | S1 |
-| main.rs:510:17:510:18 | S1 |  | main.rs:479:5:480:14 | S1 |
-| main.rs:511:26:511:37 | id::<...>(...) |  | file://:0:0:0:0 | & |
-| main.rs:511:26:511:37 | id::<...>(...) | &T | main.rs:479:5:480:14 | S1 |
-| main.rs:511:35:511:36 | &x |  | file://:0:0:0:0 | & |
-| main.rs:511:35:511:36 | &x | &T | main.rs:479:5:480:14 | S1 |
-| main.rs:511:36:511:36 | x |  | main.rs:479:5:480:14 | S1 |
-| main.rs:513:13:513:13 | x |  | main.rs:479:5:480:14 | S1 |
-| main.rs:513:17:513:18 | S1 |  | main.rs:479:5:480:14 | S1 |
-| main.rs:514:26:514:44 | id::<...>(...) |  | file://:0:0:0:0 | & |
-| main.rs:514:26:514:44 | id::<...>(...) | &T | main.rs:479:5:480:14 | S1 |
-| main.rs:514:42:514:43 | &x |  | file://:0:0:0:0 | & |
-| main.rs:514:42:514:43 | &x | &T | main.rs:479:5:480:14 | S1 |
-| main.rs:514:43:514:43 | x |  | main.rs:479:5:480:14 | S1 |
-| main.rs:516:13:516:13 | x |  | main.rs:479:5:480:14 | S1 |
-| main.rs:516:17:516:18 | S1 |  | main.rs:479:5:480:14 | S1 |
-| main.rs:517:9:517:25 | into::<...>(...) |  | main.rs:482:5:483:14 | S2 |
-| main.rs:517:24:517:24 | x |  | main.rs:479:5:480:14 | S1 |
-| main.rs:519:13:519:13 | x |  | main.rs:479:5:480:14 | S1 |
-| main.rs:519:17:519:18 | S1 |  | main.rs:479:5:480:14 | S1 |
-| main.rs:520:13:520:13 | y |  | main.rs:482:5:483:14 | S2 |
-| main.rs:520:21:520:27 | into(...) |  | main.rs:482:5:483:14 | S2 |
-| main.rs:520:26:520:26 | x |  | main.rs:479:5:480:14 | S1 |
-| main.rs:550:13:550:14 | p1 |  | main.rs:525:5:531:5 | PairOption |
-| main.rs:550:13:550:14 | p1 | Fst | main.rs:533:5:534:14 | S1 |
-| main.rs:550:13:550:14 | p1 | Snd | main.rs:536:5:537:14 | S2 |
-| main.rs:550:26:550:53 | ...::PairBoth(...) |  | main.rs:525:5:531:5 | PairOption |
-| main.rs:550:26:550:53 | ...::PairBoth(...) | Fst | main.rs:533:5:534:14 | S1 |
-| main.rs:550:26:550:53 | ...::PairBoth(...) | Snd | main.rs:536:5:537:14 | S2 |
-| main.rs:550:47:550:48 | S1 |  | main.rs:533:5:534:14 | S1 |
-| main.rs:550:51:550:52 | S2 |  | main.rs:536:5:537:14 | S2 |
-| main.rs:551:26:551:27 | p1 |  | main.rs:525:5:531:5 | PairOption |
-| main.rs:551:26:551:27 | p1 | Fst | main.rs:533:5:534:14 | S1 |
-| main.rs:551:26:551:27 | p1 | Snd | main.rs:536:5:537:14 | S2 |
-| main.rs:554:13:554:14 | p2 |  | main.rs:525:5:531:5 | PairOption |
-| main.rs:554:26:554:47 | ...::PairNone(...) |  | main.rs:525:5:531:5 | PairOption |
-| main.rs:555:26:555:27 | p2 |  | main.rs:525:5:531:5 | PairOption |
-| main.rs:558:13:558:14 | p3 |  | main.rs:525:5:531:5 | PairOption |
-| main.rs:558:13:558:14 | p3 | Snd | main.rs:539:5:540:14 | S3 |
-| main.rs:558:34:558:56 | ...::PairSnd(...) |  | main.rs:525:5:531:5 | PairOption |
-| main.rs:558:34:558:56 | ...::PairSnd(...) | Snd | main.rs:539:5:540:14 | S3 |
-| main.rs:558:54:558:55 | S3 |  | main.rs:539:5:540:14 | S3 |
-| main.rs:559:26:559:27 | p3 |  | main.rs:525:5:531:5 | PairOption |
-| main.rs:559:26:559:27 | p3 | Snd | main.rs:539:5:540:14 | S3 |
-| main.rs:562:13:562:14 | p3 |  | main.rs:525:5:531:5 | PairOption |
-| main.rs:562:13:562:14 | p3 | Fst | main.rs:539:5:540:14 | S3 |
-| main.rs:562:35:562:56 | ...::PairNone(...) |  | main.rs:525:5:531:5 | PairOption |
-| main.rs:562:35:562:56 | ...::PairNone(...) | Fst | main.rs:539:5:540:14 | S3 |
-| main.rs:563:26:563:27 | p3 |  | main.rs:525:5:531:5 | PairOption |
-| main.rs:563:26:563:27 | p3 | Fst | main.rs:539:5:540:14 | S3 |
-| main.rs:575:16:575:24 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:575:16:575:24 | SelfParam | &T | main.rs:574:5:580:5 | Self [trait MyTrait] |
-| main.rs:575:27:575:31 | value |  | main.rs:574:19:574:19 | S |
-| main.rs:577:21:577:29 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:577:21:577:29 | SelfParam | &T | main.rs:574:5:580:5 | Self [trait MyTrait] |
-| main.rs:577:32:577:36 | value |  | main.rs:574:19:574:19 | S |
-| main.rs:578:13:578:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:578:13:578:16 | self | &T | main.rs:574:5:580:5 | Self [trait MyTrait] |
-| main.rs:578:22:578:26 | value |  | main.rs:574:19:574:19 | S |
-| main.rs:583:16:583:24 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:583:16:583:24 | SelfParam | &T | main.rs:568:5:572:5 | MyOption |
-| main.rs:583:16:583:24 | SelfParam | &T.T | main.rs:582:10:582:10 | T |
-| main.rs:583:27:583:31 | value |  | main.rs:582:10:582:10 | T |
-| main.rs:587:26:589:9 | { ... } |  | main.rs:568:5:572:5 | MyOption |
-| main.rs:587:26:589:9 | { ... } | T | main.rs:586:10:586:10 | T |
-| main.rs:588:13:588:30 | ...::MyNone(...) |  | main.rs:568:5:572:5 | MyOption |
-| main.rs:588:13:588:30 | ...::MyNone(...) | T | main.rs:586:10:586:10 | T |
-| main.rs:593:20:593:23 | SelfParam |  | main.rs:568:5:572:5 | MyOption |
-| main.rs:593:20:593:23 | SelfParam | T | main.rs:568:5:572:5 | MyOption |
-| main.rs:593:20:593:23 | SelfParam | T.T | main.rs:592:10:592:10 | T |
-| main.rs:593:41:598:9 | { ... } |  | main.rs:568:5:572:5 | MyOption |
-| main.rs:593:41:598:9 | { ... } | T | main.rs:592:10:592:10 | T |
-| main.rs:594:13:597:13 | match self { ... } |  | main.rs:568:5:572:5 | MyOption |
-| main.rs:594:13:597:13 | match self { ... } | T | main.rs:592:10:592:10 | T |
-| main.rs:594:19:594:22 | self |  | main.rs:568:5:572:5 | MyOption |
-| main.rs:594:19:594:22 | self | T | main.rs:568:5:572:5 | MyOption |
-| main.rs:594:19:594:22 | self | T.T | main.rs:592:10:592:10 | T |
-| main.rs:595:39:595:56 | ...::MyNone(...) |  | main.rs:568:5:572:5 | MyOption |
-| main.rs:595:39:595:56 | ...::MyNone(...) | T | main.rs:592:10:592:10 | T |
-| main.rs:596:34:596:34 | x |  | main.rs:568:5:572:5 | MyOption |
-| main.rs:596:34:596:34 | x | T | main.rs:592:10:592:10 | T |
-| main.rs:596:40:596:40 | x |  | main.rs:568:5:572:5 | MyOption |
-| main.rs:596:40:596:40 | x | T | main.rs:592:10:592:10 | T |
-| main.rs:605:13:605:14 | x1 |  | main.rs:568:5:572:5 | MyOption |
-| main.rs:605:18:605:37 | ...::new(...) |  | main.rs:568:5:572:5 | MyOption |
-| main.rs:606:26:606:27 | x1 |  | main.rs:568:5:572:5 | MyOption |
-| main.rs:608:13:608:18 | mut x2 |  | main.rs:568:5:572:5 | MyOption |
-| main.rs:608:13:608:18 | mut x2 | T | main.rs:601:5:602:13 | S |
-| main.rs:608:22:608:36 | ...::new(...) |  | main.rs:568:5:572:5 | MyOption |
-| main.rs:608:22:608:36 | ...::new(...) | T | main.rs:601:5:602:13 | S |
-| main.rs:609:9:609:10 | x2 |  | main.rs:568:5:572:5 | MyOption |
-| main.rs:609:9:609:10 | x2 | T | main.rs:601:5:602:13 | S |
-| main.rs:609:16:609:16 | S |  | main.rs:601:5:602:13 | S |
-| main.rs:610:26:610:27 | x2 |  | main.rs:568:5:572:5 | MyOption |
-| main.rs:610:26:610:27 | x2 | T | main.rs:601:5:602:13 | S |
-| main.rs:612:13:612:18 | mut x3 |  | main.rs:568:5:572:5 | MyOption |
-| main.rs:612:22:612:36 | ...::new(...) |  | main.rs:568:5:572:5 | MyOption |
-| main.rs:613:9:613:10 | x3 |  | main.rs:568:5:572:5 | MyOption |
-| main.rs:613:21:613:21 | S |  | main.rs:601:5:602:13 | S |
-| main.rs:614:26:614:27 | x3 |  | main.rs:568:5:572:5 | MyOption |
-| main.rs:616:13:616:18 | mut x4 |  | main.rs:568:5:572:5 | MyOption |
-| main.rs:616:13:616:18 | mut x4 | T | main.rs:601:5:602:13 | S |
-| main.rs:616:22:616:36 | ...::new(...) |  | main.rs:568:5:572:5 | MyOption |
-| main.rs:616:22:616:36 | ...::new(...) | T | main.rs:601:5:602:13 | S |
-| main.rs:617:23:617:29 | &mut x4 |  | file://:0:0:0:0 | & |
-| main.rs:617:23:617:29 | &mut x4 | &T | main.rs:568:5:572:5 | MyOption |
-| main.rs:617:23:617:29 | &mut x4 | &T.T | main.rs:601:5:602:13 | S |
-| main.rs:617:28:617:29 | x4 |  | main.rs:568:5:572:5 | MyOption |
-| main.rs:617:28:617:29 | x4 | T | main.rs:601:5:602:13 | S |
-| main.rs:617:32:617:32 | S |  | main.rs:601:5:602:13 | S |
-| main.rs:618:26:618:27 | x4 |  | main.rs:568:5:572:5 | MyOption |
-| main.rs:618:26:618:27 | x4 | T | main.rs:601:5:602:13 | S |
-| main.rs:620:13:620:14 | x5 |  | main.rs:568:5:572:5 | MyOption |
-| main.rs:620:13:620:14 | x5 | T | main.rs:568:5:572:5 | MyOption |
-| main.rs:620:13:620:14 | x5 | T.T | main.rs:601:5:602:13 | S |
-| main.rs:620:18:620:58 | ...::MySome(...) |  | main.rs:568:5:572:5 | MyOption |
-| main.rs:620:18:620:58 | ...::MySome(...) | T | main.rs:568:5:572:5 | MyOption |
-| main.rs:620:18:620:58 | ...::MySome(...) | T.T | main.rs:601:5:602:13 | S |
-| main.rs:620:35:620:57 | ...::MyNone(...) |  | main.rs:568:5:572:5 | MyOption |
-| main.rs:620:35:620:57 | ...::MyNone(...) | T | main.rs:601:5:602:13 | S |
-| main.rs:621:26:621:27 | x5 |  | main.rs:568:5:572:5 | MyOption |
-| main.rs:621:26:621:27 | x5 | T | main.rs:568:5:572:5 | MyOption |
-| main.rs:621:26:621:27 | x5 | T.T | main.rs:601:5:602:13 | S |
-| main.rs:623:13:623:14 | x6 |  | main.rs:568:5:572:5 | MyOption |
-| main.rs:623:13:623:14 | x6 | T | main.rs:568:5:572:5 | MyOption |
-| main.rs:623:13:623:14 | x6 | T.T | main.rs:601:5:602:13 | S |
-| main.rs:623:18:623:58 | ...::MySome(...) |  | main.rs:568:5:572:5 | MyOption |
-| main.rs:623:18:623:58 | ...::MySome(...) | T | main.rs:568:5:572:5 | MyOption |
-| main.rs:623:18:623:58 | ...::MySome(...) | T.T | main.rs:601:5:602:13 | S |
-| main.rs:623:35:623:57 | ...::MyNone(...) |  | main.rs:568:5:572:5 | MyOption |
-| main.rs:623:35:623:57 | ...::MyNone(...) | T | main.rs:601:5:602:13 | S |
-| main.rs:624:26:624:61 | ...::flatten(...) |  | main.rs:568:5:572:5 | MyOption |
-| main.rs:624:26:624:61 | ...::flatten(...) | T | main.rs:601:5:602:13 | S |
-| main.rs:624:59:624:60 | x6 |  | main.rs:568:5:572:5 | MyOption |
-| main.rs:624:59:624:60 | x6 | T | main.rs:568:5:572:5 | MyOption |
-| main.rs:624:59:624:60 | x6 | T.T | main.rs:601:5:602:13 | S |
-| main.rs:626:13:626:19 | from_if |  | main.rs:568:5:572:5 | MyOption |
-| main.rs:626:13:626:19 | from_if | T | main.rs:601:5:602:13 | S |
-| main.rs:626:23:630:9 | if ... {...} else {...} |  | main.rs:568:5:572:5 | MyOption |
-| main.rs:626:23:630:9 | if ... {...} else {...} | T | main.rs:601:5:602:13 | S |
-| main.rs:626:36:628:9 | { ... } |  | main.rs:568:5:572:5 | MyOption |
-| main.rs:626:36:628:9 | { ... } | T | main.rs:601:5:602:13 | S |
-| main.rs:627:13:627:30 | ...::MyNone(...) |  | main.rs:568:5:572:5 | MyOption |
-| main.rs:627:13:627:30 | ...::MyNone(...) | T | main.rs:601:5:602:13 | S |
-| main.rs:628:16:630:9 | { ... } |  | main.rs:568:5:572:5 | MyOption |
-| main.rs:628:16:630:9 | { ... } | T | main.rs:601:5:602:13 | S |
-| main.rs:629:13:629:31 | ...::MySome(...) |  | main.rs:568:5:572:5 | MyOption |
-| main.rs:629:13:629:31 | ...::MySome(...) | T | main.rs:601:5:602:13 | S |
-| main.rs:629:30:629:30 | S |  | main.rs:601:5:602:13 | S |
-| main.rs:631:26:631:32 | from_if |  | main.rs:568:5:572:5 | MyOption |
-| main.rs:631:26:631:32 | from_if | T | main.rs:601:5:602:13 | S |
-| main.rs:633:13:633:22 | from_match |  | main.rs:568:5:572:5 | MyOption |
-| main.rs:633:13:633:22 | from_match | T | main.rs:601:5:602:13 | S |
-| main.rs:633:26:636:9 | match ... { ... } |  | main.rs:568:5:572:5 | MyOption |
-| main.rs:633:26:636:9 | match ... { ... } | T | main.rs:601:5:602:13 | S |
-| main.rs:634:21:634:38 | ...::MyNone(...) |  | main.rs:568:5:572:5 | MyOption |
-| main.rs:634:21:634:38 | ...::MyNone(...) | T | main.rs:601:5:602:13 | S |
-| main.rs:635:22:635:40 | ...::MySome(...) |  | main.rs:568:5:572:5 | MyOption |
-| main.rs:635:22:635:40 | ...::MySome(...) | T | main.rs:601:5:602:13 | S |
-| main.rs:635:39:635:39 | S |  | main.rs:601:5:602:13 | S |
-| main.rs:637:26:637:35 | from_match |  | main.rs:568:5:572:5 | MyOption |
-| main.rs:637:26:637:35 | from_match | T | main.rs:601:5:602:13 | S |
-| main.rs:639:13:639:21 | from_loop |  | main.rs:568:5:572:5 | MyOption |
-| main.rs:639:13:639:21 | from_loop | T | main.rs:601:5:602:13 | S |
-| main.rs:639:25:644:9 | loop { ... } |  | main.rs:568:5:572:5 | MyOption |
-| main.rs:639:25:644:9 | loop { ... } | T | main.rs:601:5:602:13 | S |
-| main.rs:641:23:641:40 | ...::MyNone(...) |  | main.rs:568:5:572:5 | MyOption |
-| main.rs:641:23:641:40 | ...::MyNone(...) | T | main.rs:601:5:602:13 | S |
-| main.rs:643:19:643:37 | ...::MySome(...) |  | main.rs:568:5:572:5 | MyOption |
-| main.rs:643:19:643:37 | ...::MySome(...) | T | main.rs:601:5:602:13 | S |
-| main.rs:643:36:643:36 | S |  | main.rs:601:5:602:13 | S |
-| main.rs:645:26:645:34 | from_loop |  | main.rs:568:5:572:5 | MyOption |
-| main.rs:645:26:645:34 | from_loop | T | main.rs:601:5:602:13 | S |
-| main.rs:658:15:658:18 | SelfParam |  | main.rs:651:5:652:19 | S |
-| main.rs:658:15:658:18 | SelfParam | T | main.rs:657:10:657:10 | T |
-| main.rs:658:26:660:9 | { ... } |  | main.rs:657:10:657:10 | T |
-| main.rs:659:13:659:16 | self |  | main.rs:651:5:652:19 | S |
-| main.rs:659:13:659:16 | self | T | main.rs:657:10:657:10 | T |
-| main.rs:659:13:659:18 | self.0 |  | main.rs:657:10:657:10 | T |
-| main.rs:662:15:662:19 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:662:15:662:19 | SelfParam | &T | main.rs:651:5:652:19 | S |
-| main.rs:662:15:662:19 | SelfParam | &T.T | main.rs:657:10:657:10 | T |
-| main.rs:662:28:664:9 | { ... } |  | file://:0:0:0:0 | & |
-| main.rs:662:28:664:9 | { ... } | &T | main.rs:657:10:657:10 | T |
-| main.rs:663:13:663:19 | &... |  | file://:0:0:0:0 | & |
-| main.rs:663:13:663:19 | &... | &T | main.rs:657:10:657:10 | T |
-| main.rs:663:14:663:17 | self |  | file://:0:0:0:0 | & |
-| main.rs:663:14:663:17 | self | &T | main.rs:651:5:652:19 | S |
-| main.rs:663:14:663:17 | self | &T.T | main.rs:657:10:657:10 | T |
-| main.rs:663:14:663:19 | self.0 |  | main.rs:657:10:657:10 | T |
-| main.rs:666:15:666:25 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:666:15:666:25 | SelfParam | &T | main.rs:651:5:652:19 | S |
-| main.rs:666:15:666:25 | SelfParam | &T.T | main.rs:657:10:657:10 | T |
-| main.rs:666:34:668:9 | { ... } |  | file://:0:0:0:0 | & |
-| main.rs:666:34:668:9 | { ... } | &T | main.rs:657:10:657:10 | T |
-| main.rs:667:13:667:19 | &... |  | file://:0:0:0:0 | & |
-| main.rs:667:13:667:19 | &... | &T | main.rs:657:10:657:10 | T |
-| main.rs:667:14:667:17 | self |  | file://:0:0:0:0 | & |
-| main.rs:667:14:667:17 | self | &T | main.rs:651:5:652:19 | S |
-| main.rs:667:14:667:17 | self | &T.T | main.rs:657:10:657:10 | T |
-| main.rs:667:14:667:19 | self.0 |  | main.rs:657:10:657:10 | T |
-| main.rs:672:13:672:14 | x1 |  | main.rs:651:5:652:19 | S |
-| main.rs:672:13:672:14 | x1 | T | main.rs:654:5:655:14 | S2 |
-| main.rs:672:18:672:22 | S(...) |  | main.rs:651:5:652:19 | S |
-| main.rs:672:18:672:22 | S(...) | T | main.rs:654:5:655:14 | S2 |
-| main.rs:672:20:672:21 | S2 |  | main.rs:654:5:655:14 | S2 |
-| main.rs:673:26:673:27 | x1 |  | main.rs:651:5:652:19 | S |
-| main.rs:673:26:673:27 | x1 | T | main.rs:654:5:655:14 | S2 |
-| main.rs:673:26:673:32 | x1.m1() |  | main.rs:654:5:655:14 | S2 |
-| main.rs:675:13:675:14 | x2 |  | main.rs:651:5:652:19 | S |
-| main.rs:675:13:675:14 | x2 | T | main.rs:654:5:655:14 | S2 |
-| main.rs:675:18:675:22 | S(...) |  | main.rs:651:5:652:19 | S |
-| main.rs:675:18:675:22 | S(...) | T | main.rs:654:5:655:14 | S2 |
-| main.rs:675:20:675:21 | S2 |  | main.rs:654:5:655:14 | S2 |
-| main.rs:677:26:677:27 | x2 |  | main.rs:651:5:652:19 | S |
-| main.rs:677:26:677:27 | x2 | T | main.rs:654:5:655:14 | S2 |
-| main.rs:677:26:677:32 | x2.m2() |  | file://:0:0:0:0 | & |
-| main.rs:677:26:677:32 | x2.m2() | &T | main.rs:654:5:655:14 | S2 |
-| main.rs:678:26:678:27 | x2 |  | main.rs:651:5:652:19 | S |
-| main.rs:678:26:678:27 | x2 | T | main.rs:654:5:655:14 | S2 |
-| main.rs:678:26:678:32 | x2.m3() |  | file://:0:0:0:0 | & |
-| main.rs:678:26:678:32 | x2.m3() | &T | main.rs:654:5:655:14 | S2 |
-| main.rs:680:13:680:14 | x3 |  | main.rs:651:5:652:19 | S |
-| main.rs:680:13:680:14 | x3 | T | main.rs:654:5:655:14 | S2 |
-| main.rs:680:18:680:22 | S(...) |  | main.rs:651:5:652:19 | S |
-| main.rs:680:18:680:22 | S(...) | T | main.rs:654:5:655:14 | S2 |
-| main.rs:680:20:680:21 | S2 |  | main.rs:654:5:655:14 | S2 |
-| main.rs:682:26:682:41 | ...::m2(...) |  | file://:0:0:0:0 | & |
-| main.rs:682:26:682:41 | ...::m2(...) | &T | main.rs:654:5:655:14 | S2 |
-| main.rs:682:38:682:40 | &x3 |  | file://:0:0:0:0 | & |
-| main.rs:682:38:682:40 | &x3 | &T | main.rs:651:5:652:19 | S |
-| main.rs:682:38:682:40 | &x3 | &T.T | main.rs:654:5:655:14 | S2 |
-| main.rs:682:39:682:40 | x3 |  | main.rs:651:5:652:19 | S |
-| main.rs:682:39:682:40 | x3 | T | main.rs:654:5:655:14 | S2 |
-| main.rs:683:26:683:41 | ...::m3(...) |  | file://:0:0:0:0 | & |
-| main.rs:683:26:683:41 | ...::m3(...) | &T | main.rs:654:5:655:14 | S2 |
-| main.rs:683:38:683:40 | &x3 |  | file://:0:0:0:0 | & |
-| main.rs:683:38:683:40 | &x3 | &T | main.rs:651:5:652:19 | S |
-| main.rs:683:38:683:40 | &x3 | &T.T | main.rs:654:5:655:14 | S2 |
-| main.rs:683:39:683:40 | x3 |  | main.rs:651:5:652:19 | S |
-| main.rs:683:39:683:40 | x3 | T | main.rs:654:5:655:14 | S2 |
-| main.rs:685:13:685:14 | x4 |  | file://:0:0:0:0 | & |
-| main.rs:685:13:685:14 | x4 | &T | main.rs:651:5:652:19 | S |
-| main.rs:685:13:685:14 | x4 | &T.T | main.rs:654:5:655:14 | S2 |
-| main.rs:685:18:685:23 | &... |  | file://:0:0:0:0 | & |
-| main.rs:685:18:685:23 | &... | &T | main.rs:651:5:652:19 | S |
-| main.rs:685:18:685:23 | &... | &T.T | main.rs:654:5:655:14 | S2 |
-| main.rs:685:19:685:23 | S(...) |  | main.rs:651:5:652:19 | S |
-| main.rs:685:19:685:23 | S(...) | T | main.rs:654:5:655:14 | S2 |
-| main.rs:685:21:685:22 | S2 |  | main.rs:654:5:655:14 | S2 |
-| main.rs:687:26:687:27 | x4 |  | file://:0:0:0:0 | & |
-| main.rs:687:26:687:27 | x4 | &T | main.rs:651:5:652:19 | S |
-| main.rs:687:26:687:27 | x4 | &T.T | main.rs:654:5:655:14 | S2 |
-| main.rs:687:26:687:32 | x4.m2() |  | file://:0:0:0:0 | & |
-| main.rs:687:26:687:32 | x4.m2() | &T | main.rs:654:5:655:14 | S2 |
-| main.rs:688:26:688:27 | x4 |  | file://:0:0:0:0 | & |
-| main.rs:688:26:688:27 | x4 | &T | main.rs:651:5:652:19 | S |
-| main.rs:688:26:688:27 | x4 | &T.T | main.rs:654:5:655:14 | S2 |
-| main.rs:688:26:688:32 | x4.m3() |  | file://:0:0:0:0 | & |
-| main.rs:688:26:688:32 | x4.m3() | &T | main.rs:654:5:655:14 | S2 |
-| main.rs:690:13:690:14 | x5 |  | file://:0:0:0:0 | & |
-| main.rs:690:13:690:14 | x5 | &T | main.rs:651:5:652:19 | S |
-| main.rs:690:13:690:14 | x5 | &T.T | main.rs:654:5:655:14 | S2 |
-| main.rs:690:18:690:23 | &... |  | file://:0:0:0:0 | & |
-| main.rs:690:18:690:23 | &... | &T | main.rs:651:5:652:19 | S |
-| main.rs:690:18:690:23 | &... | &T.T | main.rs:654:5:655:14 | S2 |
-| main.rs:690:19:690:23 | S(...) |  | main.rs:651:5:652:19 | S |
-| main.rs:690:19:690:23 | S(...) | T | main.rs:654:5:655:14 | S2 |
-| main.rs:690:21:690:22 | S2 |  | main.rs:654:5:655:14 | S2 |
-| main.rs:692:26:692:27 | x5 |  | file://:0:0:0:0 | & |
-| main.rs:692:26:692:27 | x5 | &T | main.rs:651:5:652:19 | S |
-| main.rs:692:26:692:27 | x5 | &T.T | main.rs:654:5:655:14 | S2 |
-| main.rs:692:26:692:32 | x5.m1() |  | main.rs:654:5:655:14 | S2 |
-| main.rs:693:26:693:27 | x5 |  | file://:0:0:0:0 | & |
-| main.rs:693:26:693:27 | x5 | &T | main.rs:651:5:652:19 | S |
-| main.rs:693:26:693:27 | x5 | &T.T | main.rs:654:5:655:14 | S2 |
-| main.rs:693:26:693:29 | x5.0 |  | main.rs:654:5:655:14 | S2 |
-| main.rs:695:13:695:14 | x6 |  | file://:0:0:0:0 | & |
-| main.rs:695:13:695:14 | x6 | &T | main.rs:651:5:652:19 | S |
-| main.rs:695:13:695:14 | x6 | &T.T | main.rs:654:5:655:14 | S2 |
-| main.rs:695:18:695:23 | &... |  | file://:0:0:0:0 | & |
-| main.rs:695:18:695:23 | &... | &T | main.rs:651:5:652:19 | S |
-| main.rs:695:18:695:23 | &... | &T.T | main.rs:654:5:655:14 | S2 |
-| main.rs:695:19:695:23 | S(...) |  | main.rs:651:5:652:19 | S |
-| main.rs:695:19:695:23 | S(...) | T | main.rs:654:5:655:14 | S2 |
-| main.rs:695:21:695:22 | S2 |  | main.rs:654:5:655:14 | S2 |
-| main.rs:697:26:697:30 | (...) |  | main.rs:651:5:652:19 | S |
-| main.rs:697:26:697:30 | (...) | T | main.rs:654:5:655:14 | S2 |
-| main.rs:697:26:697:35 | ... .m1() |  | main.rs:654:5:655:14 | S2 |
-| main.rs:697:27:697:29 | * ... |  | main.rs:651:5:652:19 | S |
-| main.rs:697:27:697:29 | * ... | T | main.rs:654:5:655:14 | S2 |
-| main.rs:697:28:697:29 | x6 |  | file://:0:0:0:0 | & |
-| main.rs:697:28:697:29 | x6 | &T | main.rs:651:5:652:19 | S |
-| main.rs:697:28:697:29 | x6 | &T.T | main.rs:654:5:655:14 | S2 |
-| main.rs:703:16:703:20 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:703:16:703:20 | SelfParam | &T | main.rs:702:5:708:5 | Self [trait MyTrait] |
-| main.rs:705:16:705:20 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:705:16:705:20 | SelfParam | &T | main.rs:702:5:708:5 | Self [trait MyTrait] |
-| main.rs:705:32:707:9 | { ... } |  | file://:0:0:0:0 | & |
-| main.rs:705:32:707:9 | { ... } | &T | main.rs:702:5:708:5 | Self [trait MyTrait] |
-| main.rs:706:13:706:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:706:13:706:16 | self | &T | main.rs:702:5:708:5 | Self [trait MyTrait] |
-| main.rs:706:13:706:22 | self.foo() |  | file://:0:0:0:0 | & |
-| main.rs:706:13:706:22 | self.foo() | &T | main.rs:702:5:708:5 | Self [trait MyTrait] |
-| main.rs:713:16:713:20 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:713:16:713:20 | SelfParam | &T | main.rs:710:5:710:20 | MyStruct |
-| main.rs:713:36:715:9 | { ... } |  | file://:0:0:0:0 | & |
-| main.rs:713:36:715:9 | { ... } | &T | main.rs:710:5:710:20 | MyStruct |
-| main.rs:714:13:714:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:714:13:714:16 | self | &T | main.rs:710:5:710:20 | MyStruct |
-| main.rs:719:13:719:13 | x |  | main.rs:710:5:710:20 | MyStruct |
-| main.rs:719:17:719:24 | MyStruct |  | main.rs:710:5:710:20 | MyStruct |
-| main.rs:720:9:720:9 | x |  | main.rs:710:5:710:20 | MyStruct |
-| main.rs:720:9:720:15 | x.bar() |  | file://:0:0:0:0 | & |
-| main.rs:720:9:720:15 | x.bar() | &T | main.rs:710:5:710:20 | MyStruct |
-| main.rs:730:16:730:20 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:730:16:730:20 | SelfParam | &T | main.rs:727:5:727:26 | MyStruct |
-| main.rs:730:16:730:20 | SelfParam | &T.T | main.rs:729:10:729:10 | T |
-| main.rs:730:32:732:9 | { ... } |  | file://:0:0:0:0 | & |
-| main.rs:730:32:732:9 | { ... } | &T | main.rs:727:5:727:26 | MyStruct |
-| main.rs:730:32:732:9 | { ... } | &T.T | main.rs:729:10:729:10 | T |
-| main.rs:731:13:731:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:731:13:731:16 | self | &T | main.rs:727:5:727:26 | MyStruct |
-| main.rs:731:13:731:16 | self | &T.T | main.rs:729:10:729:10 | T |
-| main.rs:736:13:736:13 | x |  | main.rs:727:5:727:26 | MyStruct |
-| main.rs:736:13:736:13 | x | T | main.rs:725:5:725:13 | S |
-| main.rs:736:17:736:27 | MyStruct(...) |  | main.rs:727:5:727:26 | MyStruct |
-| main.rs:736:17:736:27 | MyStruct(...) | T | main.rs:725:5:725:13 | S |
-| main.rs:736:26:736:26 | S |  | main.rs:725:5:725:13 | S |
-| main.rs:737:9:737:9 | x |  | main.rs:727:5:727:26 | MyStruct |
-| main.rs:737:9:737:9 | x | T | main.rs:725:5:725:13 | S |
-| main.rs:737:9:737:15 | x.foo() |  | file://:0:0:0:0 | & |
-| main.rs:737:9:737:15 | x.foo() | &T | main.rs:727:5:727:26 | MyStruct |
-| main.rs:737:9:737:15 | x.foo() | &T.T | main.rs:725:5:725:13 | S |
-| main.rs:745:15:745:19 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:745:15:745:19 | SelfParam | &T | main.rs:742:5:742:13 | S |
-| main.rs:745:31:747:9 | { ... } |  | file://:0:0:0:0 | & |
-| main.rs:745:31:747:9 | { ... } | &T | main.rs:742:5:742:13 | S |
-| main.rs:746:13:746:19 | &... |  | file://:0:0:0:0 | & |
-| main.rs:746:13:746:19 | &... | &T | main.rs:742:5:742:13 | S |
-| main.rs:746:14:746:19 | &... |  | file://:0:0:0:0 | & |
-| main.rs:746:14:746:19 | &... | &T | main.rs:742:5:742:13 | S |
-| main.rs:746:15:746:19 | &self |  | file://:0:0:0:0 | & |
-| main.rs:746:15:746:19 | &self | &T | main.rs:742:5:742:13 | S |
-| main.rs:746:16:746:19 | self |  | file://:0:0:0:0 | & |
-| main.rs:746:16:746:19 | self | &T | main.rs:742:5:742:13 | S |
-| main.rs:749:15:749:25 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:749:15:749:25 | SelfParam | &T | main.rs:742:5:742:13 | S |
-| main.rs:749:37:751:9 | { ... } |  | file://:0:0:0:0 | & |
-| main.rs:749:37:751:9 | { ... } | &T | main.rs:742:5:742:13 | S |
-| main.rs:750:13:750:19 | &... |  | file://:0:0:0:0 | & |
-| main.rs:750:13:750:19 | &... | &T | main.rs:742:5:742:13 | S |
-| main.rs:750:14:750:19 | &... |  | file://:0:0:0:0 | & |
-| main.rs:750:14:750:19 | &... | &T | main.rs:742:5:742:13 | S |
-| main.rs:750:15:750:19 | &self |  | file://:0:0:0:0 | & |
-| main.rs:750:15:750:19 | &self | &T | main.rs:742:5:742:13 | S |
-| main.rs:750:16:750:19 | self |  | file://:0:0:0:0 | & |
-| main.rs:750:16:750:19 | self | &T | main.rs:742:5:742:13 | S |
-| main.rs:753:15:753:15 | x |  | file://:0:0:0:0 | & |
-| main.rs:753:15:753:15 | x | &T | main.rs:742:5:742:13 | S |
-| main.rs:753:34:755:9 | { ... } |  | file://:0:0:0:0 | & |
-| main.rs:753:34:755:9 | { ... } | &T | main.rs:742:5:742:13 | S |
-| main.rs:754:13:754:13 | x |  | file://:0:0:0:0 | & |
-| main.rs:754:13:754:13 | x | &T | main.rs:742:5:742:13 | S |
-| main.rs:757:15:757:15 | x |  | file://:0:0:0:0 | & |
-| main.rs:757:15:757:15 | x | &T | main.rs:742:5:742:13 | S |
-| main.rs:757:34:759:9 | { ... } |  | file://:0:0:0:0 | & |
-| main.rs:757:34:759:9 | { ... } | &T | main.rs:742:5:742:13 | S |
-| main.rs:758:13:758:16 | &... |  | file://:0:0:0:0 | & |
-| main.rs:758:13:758:16 | &... | &T | main.rs:742:5:742:13 | S |
-| main.rs:758:14:758:16 | &... |  | file://:0:0:0:0 | & |
-| main.rs:758:14:758:16 | &... | &T | main.rs:742:5:742:13 | S |
-| main.rs:758:15:758:16 | &x |  | file://:0:0:0:0 | & |
-| main.rs:758:15:758:16 | &x | &T | main.rs:742:5:742:13 | S |
-| main.rs:758:16:758:16 | x |  | file://:0:0:0:0 | & |
-| main.rs:758:16:758:16 | x | &T | main.rs:742:5:742:13 | S |
-| main.rs:763:13:763:13 | x |  | main.rs:742:5:742:13 | S |
-| main.rs:763:17:763:20 | S {...} |  | main.rs:742:5:742:13 | S |
-| main.rs:764:9:764:9 | x |  | main.rs:742:5:742:13 | S |
-| main.rs:764:9:764:14 | x.f1() |  | file://:0:0:0:0 | & |
-| main.rs:764:9:764:14 | x.f1() | &T | main.rs:742:5:742:13 | S |
-| main.rs:765:9:765:9 | x |  | main.rs:742:5:742:13 | S |
-| main.rs:765:9:765:14 | x.f2() |  | file://:0:0:0:0 | & |
-| main.rs:765:9:765:14 | x.f2() | &T | main.rs:742:5:742:13 | S |
-| main.rs:766:9:766:17 | ...::f3(...) |  | file://:0:0:0:0 | & |
-| main.rs:766:9:766:17 | ...::f3(...) | &T | main.rs:742:5:742:13 | S |
-| main.rs:766:15:766:16 | &x |  | file://:0:0:0:0 | & |
-| main.rs:766:15:766:16 | &x | &T | main.rs:742:5:742:13 | S |
-| main.rs:766:16:766:16 | x |  | main.rs:742:5:742:13 | S |
-| main.rs:772:5:772:20 | ...::f(...) |  | main.rs:67:5:67:21 | Foo |
-| main.rs:773:5:773:60 | ...::g(...) |  | main.rs:67:5:67:21 | Foo |
-| main.rs:773:20:773:38 | ...::Foo {...} |  | main.rs:67:5:67:21 | Foo |
-| main.rs:773:41:773:59 | ...::Foo {...} |  | main.rs:67:5:67:21 | Foo |
-resolveMethodCallExpr
-| loop/main.rs:12:9:12:18 | self.foo() | loop/main.rs:7:5:7:19 | fn foo |
-| main.rs:88:9:88:14 | x.m1() | main.rs:70:9:72:9 | fn m1 |
-| main.rs:89:9:89:14 | y.m2() | main.rs:74:9:76:9 | fn m2 |
-| main.rs:136:26:136:31 | x.m2() | main.rs:117:9:119:9 | fn m2 |
-| main.rs:137:26:137:31 | y.m2() | main.rs:117:9:119:9 | fn m2 |
-| main.rs:164:9:164:14 | x.m1() | main.rs:153:9:153:25 | fn m1 |
-| main.rs:215:18:215:27 | x.method() | main.rs:210:9:210:30 | fn method |
-| main.rs:221:18:221:27 | x.method() | main.rs:210:9:210:30 | fn method |
-| main.rs:226:17:226:26 | x.method() | main.rs:206:9:206:30 | fn method |
-| main.rs:231:17:231:26 | x.method() | main.rs:206:9:206:30 | fn method |
-| main.rs:243:18:243:24 | x.fst() | main.rs:236:9:236:27 | fn fst |
-| main.rs:244:18:244:24 | y.snd() | main.rs:238:9:238:27 | fn snd |
-| main.rs:250:18:250:24 | x.fst() | main.rs:236:9:236:27 | fn fst |
-| main.rs:251:18:251:24 | y.snd() | main.rs:238:9:238:27 | fn snd |
-| main.rs:274:13:274:21 | self.m1() | main.rs:268:9:268:25 | fn m1 |
-| main.rs:280:9:280:14 | x.m1() | main.rs:268:9:268:25 | fn m1 |
-| main.rs:285:9:285:16 | ... .m1() | main.rs:268:9:268:25 | fn m1 |
-| main.rs:298:26:298:31 | x.m1() | main.rs:289:9:291:9 | fn m1 |
-| main.rs:299:26:299:31 | y.m1() | main.rs:289:9:291:9 | fn m1 |
-| main.rs:304:26:304:31 | x.m2() | main.rs:270:9:275:9 | fn m2 |
-| main.rs:305:26:305:31 | y.m2() | main.rs:270:9:275:9 | fn m2 |
-| main.rs:353:26:353:31 | x.m1() | main.rs:346:9:348:9 | fn m1 |
-| main.rs:356:26:356:31 | x.m2() | main.rs:331:9:337:9 | fn m2 |
-| main.rs:385:26:385:31 | x.m1() | main.rs:373:9:378:9 | fn m1 |
-| main.rs:386:26:386:31 | y.m1() | main.rs:373:9:378:9 | fn m1 |
-| main.rs:416:17:416:25 | self.m1() | main.rs:407:9:407:27 | fn m1 |
-| main.rs:429:17:429:25 | self.m2() | main.rs:411:9:420:9 | fn m2 |
-| main.rs:458:26:458:31 | x.m1() | main.rs:437:9:439:9 | fn m1 |
-| main.rs:459:26:459:31 | y.m1() | main.rs:437:9:439:9 | fn m1 |
-| main.rs:464:26:464:31 | x.m2() | main.rs:411:9:420:9 | fn m2 |
-| main.rs:465:26:465:31 | y.m2() | main.rs:411:9:420:9 | fn m2 |
-| main.rs:470:26:470:31 | x.m3() | main.rs:424:9:433:9 | fn m3 |
-| main.rs:471:26:471:31 | y.m3() | main.rs:424:9:433:9 | fn m3 |
-| main.rs:578:13:578:27 | self.set(...) | main.rs:575:9:575:36 | fn set |
-| main.rs:609:9:609:17 | x2.set(...) | main.rs:583:9:583:38 | fn set |
-| main.rs:613:9:613:22 | x3.call_set(...) | main.rs:577:9:579:9 | fn call_set |
-| main.rs:673:26:673:32 | x1.m1() | main.rs:658:9:660:9 | fn m1 |
-| main.rs:677:26:677:32 | x2.m2() | main.rs:662:9:664:9 | fn m2 |
-| main.rs:678:26:678:32 | x2.m3() | main.rs:666:9:668:9 | fn m3 |
-| main.rs:687:26:687:32 | x4.m2() | main.rs:662:9:664:9 | fn m2 |
-| main.rs:688:26:688:32 | x4.m3() | main.rs:666:9:668:9 | fn m3 |
-| main.rs:692:26:692:32 | x5.m1() | main.rs:658:9:660:9 | fn m1 |
-| main.rs:697:26:697:35 | ... .m1() | main.rs:658:9:660:9 | fn m1 |
-| main.rs:706:13:706:22 | self.foo() | main.rs:703:9:703:31 | fn foo |
-| main.rs:720:9:720:15 | x.bar() | main.rs:705:9:707:9 | fn bar |
-| main.rs:737:9:737:15 | x.foo() | main.rs:730:9:732:9 | fn foo |
-| main.rs:764:9:764:14 | x.f1() | main.rs:745:9:747:9 | fn f1 |
-| main.rs:765:9:765:14 | x.f2() | main.rs:749:9:751:9 | fn f2 |
-resolveFieldExpr
-| main.rs:27:26:27:28 | x.a | main.rs:7:9:7:12 | StructField |
-| main.rs:33:26:33:28 | x.a | main.rs:18:9:18:12 | StructField |
-| main.rs:37:26:37:28 | x.a | main.rs:18:9:18:12 | StructField |
-| main.rs:44:26:44:28 | x.a | main.rs:22:9:22:22 | StructField |
-| main.rs:50:26:50:28 | x.a | main.rs:18:9:18:12 | StructField |
-| main.rs:56:30:56:32 | x.a | main.rs:18:9:18:12 | StructField |
-| main.rs:106:13:106:18 | self.a | main.rs:96:9:96:12 | StructField |
-| main.rs:112:23:112:28 | self.a | main.rs:96:9:96:12 | StructField |
-| main.rs:118:13:118:18 | self.a | main.rs:96:9:96:12 | StructField |
-| main.rs:127:26:127:28 | x.a | main.rs:96:9:96:12 | StructField |
-| main.rs:128:26:128:28 | y.a | main.rs:96:9:96:12 | StructField |
-| main.rs:169:13:169:18 | self.a | main.rs:144:9:144:12 | StructField |
-| main.rs:175:23:175:28 | self.a | main.rs:144:9:144:12 | StructField |
-| main.rs:285:9:285:11 | x.a | main.rs:259:9:259:12 | StructField |
-| main.rs:290:13:290:18 | self.a | main.rs:259:9:259:12 | StructField |
-| main.rs:429:17:429:27 | ... .a | main.rs:393:9:393:12 | StructField |
-| main.rs:431:17:431:32 | ... .a | main.rs:393:9:393:12 | StructField |
-| main.rs:438:13:438:18 | self.a | main.rs:393:9:393:12 | StructField |
-| main.rs:446:26:446:31 | self.a | main.rs:398:9:398:12 | StructField |
-| main.rs:659:13:659:18 | self.0 | main.rs:652:17:652:17 | TupleField |
-| main.rs:663:14:663:19 | self.0 | main.rs:652:17:652:17 | TupleField |
-| main.rs:667:14:667:19 | self.0 | main.rs:652:17:652:17 | TupleField |
-| main.rs:693:26:693:29 | x5.0 | main.rs:652:17:652:17 | TupleField |
+| main.rs:106:15:106:18 | SelfParam |  | main.rs:94:5:97:5 | MyThing |
+| main.rs:106:15:106:18 | SelfParam | A | main.rs:99:5:100:14 | S1 |
+| main.rs:106:27:108:9 | { ... } |  | main.rs:99:5:100:14 | S1 |
+| main.rs:107:13:107:16 | self |  | main.rs:94:5:97:5 | MyThing |
+| main.rs:107:13:107:16 | self | A | main.rs:99:5:100:14 | S1 |
+| main.rs:107:13:107:18 | self.a |  | main.rs:99:5:100:14 | S1 |
+| main.rs:113:15:113:18 | SelfParam |  | main.rs:94:5:97:5 | MyThing |
+| main.rs:113:15:113:18 | SelfParam | A | main.rs:101:5:102:14 | S2 |
+| main.rs:113:29:115:9 | { ... } |  | main.rs:94:5:97:5 | MyThing |
+| main.rs:113:29:115:9 | { ... } | A | main.rs:101:5:102:14 | S2 |
+| main.rs:114:13:114:30 | Self {...} |  | main.rs:94:5:97:5 | MyThing |
+| main.rs:114:13:114:30 | Self {...} | A | main.rs:101:5:102:14 | S2 |
+| main.rs:114:23:114:26 | self |  | main.rs:94:5:97:5 | MyThing |
+| main.rs:114:23:114:26 | self | A | main.rs:101:5:102:14 | S2 |
+| main.rs:114:23:114:28 | self.a |  | main.rs:101:5:102:14 | S2 |
+| main.rs:119:15:119:18 | SelfParam |  | main.rs:94:5:97:5 | MyThing |
+| main.rs:119:15:119:18 | SelfParam | A | main.rs:118:10:118:10 | T |
+| main.rs:119:26:121:9 | { ... } |  | main.rs:118:10:118:10 | T |
+| main.rs:120:13:120:16 | self |  | main.rs:94:5:97:5 | MyThing |
+| main.rs:120:13:120:16 | self | A | main.rs:118:10:118:10 | T |
+| main.rs:120:13:120:18 | self.a |  | main.rs:118:10:118:10 | T |
+| main.rs:125:13:125:13 | x |  | main.rs:94:5:97:5 | MyThing |
+| main.rs:125:13:125:13 | x | A | main.rs:99:5:100:14 | S1 |
+| main.rs:125:17:125:33 | MyThing {...} |  | main.rs:94:5:97:5 | MyThing |
+| main.rs:125:17:125:33 | MyThing {...} | A | main.rs:99:5:100:14 | S1 |
+| main.rs:125:30:125:31 | S1 |  | main.rs:99:5:100:14 | S1 |
+| main.rs:126:13:126:13 | y |  | main.rs:94:5:97:5 | MyThing |
+| main.rs:126:13:126:13 | y | A | main.rs:101:5:102:14 | S2 |
+| main.rs:126:17:126:33 | MyThing {...} |  | main.rs:94:5:97:5 | MyThing |
+| main.rs:126:17:126:33 | MyThing {...} | A | main.rs:101:5:102:14 | S2 |
+| main.rs:126:30:126:31 | S2 |  | main.rs:101:5:102:14 | S2 |
+| main.rs:129:26:129:26 | x |  | main.rs:94:5:97:5 | MyThing |
+| main.rs:129:26:129:26 | x | A | main.rs:99:5:100:14 | S1 |
+| main.rs:129:26:129:28 | x.a |  | main.rs:99:5:100:14 | S1 |
+| main.rs:130:26:130:26 | y |  | main.rs:94:5:97:5 | MyThing |
+| main.rs:130:26:130:26 | y | A | main.rs:101:5:102:14 | S2 |
+| main.rs:130:26:130:28 | y.a |  | main.rs:101:5:102:14 | S2 |
+| main.rs:132:26:132:26 | x |  | main.rs:94:5:97:5 | MyThing |
+| main.rs:132:26:132:26 | x | A | main.rs:99:5:100:14 | S1 |
+| main.rs:133:26:133:26 | y |  | main.rs:94:5:97:5 | MyThing |
+| main.rs:133:26:133:26 | y | A | main.rs:101:5:102:14 | S2 |
+| main.rs:135:13:135:13 | x |  | main.rs:94:5:97:5 | MyThing |
+| main.rs:135:13:135:13 | x | A | main.rs:99:5:100:14 | S1 |
+| main.rs:135:17:135:33 | MyThing {...} |  | main.rs:94:5:97:5 | MyThing |
+| main.rs:135:17:135:33 | MyThing {...} | A | main.rs:99:5:100:14 | S1 |
+| main.rs:135:30:135:31 | S1 |  | main.rs:99:5:100:14 | S1 |
+| main.rs:136:13:136:13 | y |  | main.rs:94:5:97:5 | MyThing |
+| main.rs:136:13:136:13 | y | A | main.rs:101:5:102:14 | S2 |
+| main.rs:136:17:136:33 | MyThing {...} |  | main.rs:94:5:97:5 | MyThing |
+| main.rs:136:17:136:33 | MyThing {...} | A | main.rs:101:5:102:14 | S2 |
+| main.rs:136:30:136:31 | S2 |  | main.rs:101:5:102:14 | S2 |
+| main.rs:138:26:138:26 | x |  | main.rs:94:5:97:5 | MyThing |
+| main.rs:138:26:138:26 | x | A | main.rs:99:5:100:14 | S1 |
+| main.rs:138:26:138:31 | x.m2() |  | main.rs:99:5:100:14 | S1 |
+| main.rs:139:26:139:26 | y |  | main.rs:94:5:97:5 | MyThing |
+| main.rs:139:26:139:26 | y | A | main.rs:101:5:102:14 | S2 |
+| main.rs:139:26:139:31 | y.m2() |  | main.rs:101:5:102:14 | S2 |
+| main.rs:155:15:155:18 | SelfParam |  | main.rs:154:5:163:5 | Self [trait MyTrait] |
+| main.rs:157:15:157:18 | SelfParam |  | main.rs:154:5:163:5 | Self [trait MyTrait] |
+| main.rs:160:9:162:9 | { ... } |  | main.rs:154:5:163:5 | Self [trait MyTrait] |
+| main.rs:161:13:161:16 | self |  | main.rs:154:5:163:5 | Self [trait MyTrait] |
+| main.rs:165:43:165:43 | x |  | main.rs:165:26:165:40 | T2 |
+| main.rs:165:56:167:5 | { ... } |  | main.rs:165:22:165:23 | T1 |
+| main.rs:166:9:166:9 | x |  | main.rs:165:26:165:40 | T2 |
+| main.rs:166:9:166:14 | x.m1() |  | main.rs:165:22:165:23 | T1 |
+| main.rs:171:15:171:18 | SelfParam |  | main.rs:144:5:147:5 | MyThing |
+| main.rs:171:15:171:18 | SelfParam | A | main.rs:149:5:150:14 | S1 |
+| main.rs:171:27:173:9 | { ... } |  | main.rs:149:5:150:14 | S1 |
+| main.rs:172:13:172:16 | self |  | main.rs:144:5:147:5 | MyThing |
+| main.rs:172:13:172:16 | self | A | main.rs:149:5:150:14 | S1 |
+| main.rs:172:13:172:18 | self.a |  | main.rs:149:5:150:14 | S1 |
+| main.rs:178:15:178:18 | SelfParam |  | main.rs:144:5:147:5 | MyThing |
+| main.rs:178:15:178:18 | SelfParam | A | main.rs:151:5:152:14 | S2 |
+| main.rs:178:29:180:9 | { ... } |  | main.rs:144:5:147:5 | MyThing |
+| main.rs:178:29:180:9 | { ... } | A | main.rs:151:5:152:14 | S2 |
+| main.rs:179:13:179:30 | Self {...} |  | main.rs:144:5:147:5 | MyThing |
+| main.rs:179:13:179:30 | Self {...} | A | main.rs:151:5:152:14 | S2 |
+| main.rs:179:23:179:26 | self |  | main.rs:144:5:147:5 | MyThing |
+| main.rs:179:23:179:26 | self | A | main.rs:151:5:152:14 | S2 |
+| main.rs:179:23:179:28 | self.a |  | main.rs:151:5:152:14 | S2 |
+| main.rs:184:13:184:13 | x |  | main.rs:144:5:147:5 | MyThing |
+| main.rs:184:13:184:13 | x | A | main.rs:149:5:150:14 | S1 |
+| main.rs:184:17:184:33 | MyThing {...} |  | main.rs:144:5:147:5 | MyThing |
+| main.rs:184:17:184:33 | MyThing {...} | A | main.rs:149:5:150:14 | S1 |
+| main.rs:184:30:184:31 | S1 |  | main.rs:149:5:150:14 | S1 |
+| main.rs:185:13:185:13 | y |  | main.rs:144:5:147:5 | MyThing |
+| main.rs:185:13:185:13 | y | A | main.rs:151:5:152:14 | S2 |
+| main.rs:185:17:185:33 | MyThing {...} |  | main.rs:144:5:147:5 | MyThing |
+| main.rs:185:17:185:33 | MyThing {...} | A | main.rs:151:5:152:14 | S2 |
+| main.rs:185:30:185:31 | S2 |  | main.rs:151:5:152:14 | S2 |
+| main.rs:187:26:187:26 | x |  | main.rs:144:5:147:5 | MyThing |
+| main.rs:187:26:187:26 | x | A | main.rs:149:5:150:14 | S1 |
+| main.rs:188:26:188:26 | y |  | main.rs:144:5:147:5 | MyThing |
+| main.rs:188:26:188:26 | y | A | main.rs:151:5:152:14 | S2 |
+| main.rs:190:13:190:13 | x |  | main.rs:144:5:147:5 | MyThing |
+| main.rs:190:13:190:13 | x | A | main.rs:149:5:150:14 | S1 |
+| main.rs:190:17:190:33 | MyThing {...} |  | main.rs:144:5:147:5 | MyThing |
+| main.rs:190:17:190:33 | MyThing {...} | A | main.rs:149:5:150:14 | S1 |
+| main.rs:190:30:190:31 | S1 |  | main.rs:149:5:150:14 | S1 |
+| main.rs:191:13:191:13 | y |  | main.rs:144:5:147:5 | MyThing |
+| main.rs:191:13:191:13 | y | A | main.rs:151:5:152:14 | S2 |
+| main.rs:191:17:191:33 | MyThing {...} |  | main.rs:144:5:147:5 | MyThing |
+| main.rs:191:17:191:33 | MyThing {...} | A | main.rs:151:5:152:14 | S2 |
+| main.rs:191:30:191:31 | S2 |  | main.rs:151:5:152:14 | S2 |
+| main.rs:193:40:193:40 | x |  | main.rs:144:5:147:5 | MyThing |
+| main.rs:193:40:193:40 | x | A | main.rs:149:5:150:14 | S1 |
+| main.rs:194:40:194:40 | y |  | main.rs:144:5:147:5 | MyThing |
+| main.rs:194:40:194:40 | y | A | main.rs:151:5:152:14 | S2 |
+| main.rs:211:19:211:22 | SelfParam |  | main.rs:209:5:212:5 | Self [trait FirstTrait] |
+| main.rs:216:19:216:22 | SelfParam |  | main.rs:214:5:217:5 | Self [trait SecondTrait] |
+| main.rs:219:64:219:64 | x |  | main.rs:219:45:219:61 | T |
+| main.rs:221:13:221:14 | s1 |  | main.rs:219:35:219:42 | I |
+| main.rs:221:18:221:18 | x |  | main.rs:219:45:219:61 | T |
+| main.rs:221:18:221:27 | x.method() |  | main.rs:219:35:219:42 | I |
+| main.rs:222:26:222:27 | s1 |  | main.rs:219:35:219:42 | I |
+| main.rs:225:65:225:65 | x |  | main.rs:225:46:225:62 | T |
+| main.rs:227:13:227:14 | s2 |  | main.rs:225:36:225:43 | I |
+| main.rs:227:18:227:18 | x |  | main.rs:225:46:225:62 | T |
+| main.rs:227:18:227:27 | x.method() |  | main.rs:225:36:225:43 | I |
+| main.rs:228:26:228:27 | s2 |  | main.rs:225:36:225:43 | I |
+| main.rs:231:49:231:49 | x |  | main.rs:231:30:231:46 | T |
+| main.rs:232:13:232:13 | s |  | main.rs:201:5:202:14 | S1 |
+| main.rs:232:17:232:17 | x |  | main.rs:231:30:231:46 | T |
+| main.rs:232:17:232:26 | x.method() |  | main.rs:201:5:202:14 | S1 |
+| main.rs:233:26:233:26 | s |  | main.rs:201:5:202:14 | S1 |
+| main.rs:236:53:236:53 | x |  | main.rs:236:34:236:50 | T |
+| main.rs:237:13:237:13 | s |  | main.rs:201:5:202:14 | S1 |
+| main.rs:237:17:237:17 | x |  | main.rs:236:34:236:50 | T |
+| main.rs:237:17:237:26 | x.method() |  | main.rs:201:5:202:14 | S1 |
+| main.rs:238:26:238:26 | s |  | main.rs:201:5:202:14 | S1 |
+| main.rs:242:16:242:19 | SelfParam |  | main.rs:241:5:245:5 | Self [trait Pair] |
+| main.rs:244:16:244:19 | SelfParam |  | main.rs:241:5:245:5 | Self [trait Pair] |
+| main.rs:247:58:247:58 | x |  | main.rs:247:41:247:55 | T |
+| main.rs:247:64:247:64 | y |  | main.rs:247:41:247:55 | T |
+| main.rs:249:13:249:14 | s1 |  | main.rs:201:5:202:14 | S1 |
+| main.rs:249:18:249:18 | x |  | main.rs:247:41:247:55 | T |
+| main.rs:249:18:249:24 | x.fst() |  | main.rs:201:5:202:14 | S1 |
+| main.rs:250:13:250:14 | s2 |  | main.rs:204:5:205:14 | S2 |
+| main.rs:250:18:250:18 | y |  | main.rs:247:41:247:55 | T |
+| main.rs:250:18:250:24 | y.snd() |  | main.rs:204:5:205:14 | S2 |
+| main.rs:251:32:251:33 | s1 |  | main.rs:201:5:202:14 | S1 |
+| main.rs:251:36:251:37 | s2 |  | main.rs:204:5:205:14 | S2 |
+| main.rs:254:69:254:69 | x |  | main.rs:254:52:254:66 | T |
+| main.rs:254:75:254:75 | y |  | main.rs:254:52:254:66 | T |
+| main.rs:256:13:256:14 | s1 |  | main.rs:201:5:202:14 | S1 |
+| main.rs:256:18:256:18 | x |  | main.rs:254:52:254:66 | T |
+| main.rs:256:18:256:24 | x.fst() |  | main.rs:201:5:202:14 | S1 |
+| main.rs:257:13:257:14 | s2 |  | main.rs:254:41:254:49 | T2 |
+| main.rs:257:18:257:18 | y |  | main.rs:254:52:254:66 | T |
+| main.rs:257:18:257:24 | y.snd() |  | main.rs:254:41:254:49 | T2 |
+| main.rs:258:32:258:33 | s1 |  | main.rs:201:5:202:14 | S1 |
+| main.rs:258:36:258:37 | s2 |  | main.rs:254:41:254:49 | T2 |
+| main.rs:274:15:274:18 | SelfParam |  | main.rs:273:5:282:5 | Self [trait MyTrait] |
+| main.rs:276:15:276:18 | SelfParam |  | main.rs:273:5:282:5 | Self [trait MyTrait] |
+| main.rs:279:9:281:9 | { ... } |  | main.rs:273:19:273:19 | A |
+| main.rs:280:13:280:16 | self |  | main.rs:273:5:282:5 | Self [trait MyTrait] |
+| main.rs:280:13:280:21 | self.m1() |  | main.rs:273:19:273:19 | A |
+| main.rs:285:43:285:43 | x |  | main.rs:285:26:285:40 | T2 |
+| main.rs:285:56:287:5 | { ... } |  | main.rs:285:22:285:23 | T1 |
+| main.rs:286:9:286:9 | x |  | main.rs:285:26:285:40 | T2 |
+| main.rs:286:9:286:14 | x.m1() |  | main.rs:285:22:285:23 | T1 |
+| main.rs:290:49:290:49 | x |  | main.rs:263:5:266:5 | MyThing |
+| main.rs:290:49:290:49 | x | T | main.rs:290:32:290:46 | T2 |
+| main.rs:290:71:292:5 | { ... } |  | main.rs:290:28:290:29 | T1 |
+| main.rs:291:9:291:9 | x |  | main.rs:263:5:266:5 | MyThing |
+| main.rs:291:9:291:9 | x | T | main.rs:290:32:290:46 | T2 |
+| main.rs:291:9:291:11 | x.a |  | main.rs:290:32:290:46 | T2 |
+| main.rs:291:9:291:16 | ... .m1() |  | main.rs:290:28:290:29 | T1 |
+| main.rs:295:15:295:18 | SelfParam |  | main.rs:263:5:266:5 | MyThing |
+| main.rs:295:15:295:18 | SelfParam | T | main.rs:294:10:294:10 | T |
+| main.rs:295:26:297:9 | { ... } |  | main.rs:294:10:294:10 | T |
+| main.rs:296:13:296:16 | self |  | main.rs:263:5:266:5 | MyThing |
+| main.rs:296:13:296:16 | self | T | main.rs:294:10:294:10 | T |
+| main.rs:296:13:296:18 | self.a |  | main.rs:294:10:294:10 | T |
+| main.rs:301:13:301:13 | x |  | main.rs:263:5:266:5 | MyThing |
+| main.rs:301:13:301:13 | x | T | main.rs:268:5:269:14 | S1 |
+| main.rs:301:17:301:33 | MyThing {...} |  | main.rs:263:5:266:5 | MyThing |
+| main.rs:301:17:301:33 | MyThing {...} | T | main.rs:268:5:269:14 | S1 |
+| main.rs:301:30:301:31 | S1 |  | main.rs:268:5:269:14 | S1 |
+| main.rs:302:13:302:13 | y |  | main.rs:263:5:266:5 | MyThing |
+| main.rs:302:13:302:13 | y | T | main.rs:270:5:271:14 | S2 |
+| main.rs:302:17:302:33 | MyThing {...} |  | main.rs:263:5:266:5 | MyThing |
+| main.rs:302:17:302:33 | MyThing {...} | T | main.rs:270:5:271:14 | S2 |
+| main.rs:302:30:302:31 | S2 |  | main.rs:270:5:271:14 | S2 |
+| main.rs:304:26:304:26 | x |  | main.rs:263:5:266:5 | MyThing |
+| main.rs:304:26:304:26 | x | T | main.rs:268:5:269:14 | S1 |
+| main.rs:304:26:304:31 | x.m1() |  | main.rs:268:5:269:14 | S1 |
+| main.rs:305:26:305:26 | y |  | main.rs:263:5:266:5 | MyThing |
+| main.rs:305:26:305:26 | y | T | main.rs:270:5:271:14 | S2 |
+| main.rs:305:26:305:31 | y.m1() |  | main.rs:270:5:271:14 | S2 |
+| main.rs:307:13:307:13 | x |  | main.rs:263:5:266:5 | MyThing |
+| main.rs:307:13:307:13 | x | T | main.rs:268:5:269:14 | S1 |
+| main.rs:307:17:307:33 | MyThing {...} |  | main.rs:263:5:266:5 | MyThing |
+| main.rs:307:17:307:33 | MyThing {...} | T | main.rs:268:5:269:14 | S1 |
+| main.rs:307:30:307:31 | S1 |  | main.rs:268:5:269:14 | S1 |
+| main.rs:308:13:308:13 | y |  | main.rs:263:5:266:5 | MyThing |
+| main.rs:308:13:308:13 | y | T | main.rs:270:5:271:14 | S2 |
+| main.rs:308:17:308:33 | MyThing {...} |  | main.rs:263:5:266:5 | MyThing |
+| main.rs:308:17:308:33 | MyThing {...} | T | main.rs:270:5:271:14 | S2 |
+| main.rs:308:30:308:31 | S2 |  | main.rs:270:5:271:14 | S2 |
+| main.rs:310:26:310:26 | x |  | main.rs:263:5:266:5 | MyThing |
+| main.rs:310:26:310:26 | x | T | main.rs:268:5:269:14 | S1 |
+| main.rs:310:26:310:31 | x.m2() |  | main.rs:268:5:269:14 | S1 |
+| main.rs:311:26:311:26 | y |  | main.rs:263:5:266:5 | MyThing |
+| main.rs:311:26:311:26 | y | T | main.rs:270:5:271:14 | S2 |
+| main.rs:311:26:311:31 | y.m2() |  | main.rs:270:5:271:14 | S2 |
+| main.rs:313:13:313:14 | x2 |  | main.rs:263:5:266:5 | MyThing |
+| main.rs:313:13:313:14 | x2 | T | main.rs:268:5:269:14 | S1 |
+| main.rs:313:18:313:34 | MyThing {...} |  | main.rs:263:5:266:5 | MyThing |
+| main.rs:313:18:313:34 | MyThing {...} | T | main.rs:268:5:269:14 | S1 |
+| main.rs:313:31:313:32 | S1 |  | main.rs:268:5:269:14 | S1 |
+| main.rs:314:13:314:14 | y2 |  | main.rs:263:5:266:5 | MyThing |
+| main.rs:314:13:314:14 | y2 | T | main.rs:270:5:271:14 | S2 |
+| main.rs:314:18:314:34 | MyThing {...} |  | main.rs:263:5:266:5 | MyThing |
+| main.rs:314:18:314:34 | MyThing {...} | T | main.rs:270:5:271:14 | S2 |
+| main.rs:314:31:314:32 | S2 |  | main.rs:270:5:271:14 | S2 |
+| main.rs:316:26:316:42 | call_trait_m1(...) |  | main.rs:268:5:269:14 | S1 |
+| main.rs:316:40:316:41 | x2 |  | main.rs:263:5:266:5 | MyThing |
+| main.rs:316:40:316:41 | x2 | T | main.rs:268:5:269:14 | S1 |
+| main.rs:317:26:317:42 | call_trait_m1(...) |  | main.rs:270:5:271:14 | S2 |
+| main.rs:317:40:317:41 | y2 |  | main.rs:263:5:266:5 | MyThing |
+| main.rs:317:40:317:41 | y2 | T | main.rs:270:5:271:14 | S2 |
+| main.rs:319:13:319:14 | x3 |  | main.rs:263:5:266:5 | MyThing |
+| main.rs:319:13:319:14 | x3 | T | main.rs:263:5:266:5 | MyThing |
+| main.rs:319:13:319:14 | x3 | T.T | main.rs:268:5:269:14 | S1 |
+| main.rs:319:18:321:9 | MyThing {...} |  | main.rs:263:5:266:5 | MyThing |
+| main.rs:319:18:321:9 | MyThing {...} | T | main.rs:263:5:266:5 | MyThing |
+| main.rs:319:18:321:9 | MyThing {...} | T.T | main.rs:268:5:269:14 | S1 |
+| main.rs:320:16:320:32 | MyThing {...} |  | main.rs:263:5:266:5 | MyThing |
+| main.rs:320:16:320:32 | MyThing {...} | T | main.rs:268:5:269:14 | S1 |
+| main.rs:320:29:320:30 | S1 |  | main.rs:268:5:269:14 | S1 |
+| main.rs:322:13:322:14 | y3 |  | main.rs:263:5:266:5 | MyThing |
+| main.rs:322:13:322:14 | y3 | T | main.rs:263:5:266:5 | MyThing |
+| main.rs:322:13:322:14 | y3 | T.T | main.rs:270:5:271:14 | S2 |
+| main.rs:322:18:324:9 | MyThing {...} |  | main.rs:263:5:266:5 | MyThing |
+| main.rs:322:18:324:9 | MyThing {...} | T | main.rs:263:5:266:5 | MyThing |
+| main.rs:322:18:324:9 | MyThing {...} | T.T | main.rs:270:5:271:14 | S2 |
+| main.rs:323:16:323:32 | MyThing {...} |  | main.rs:263:5:266:5 | MyThing |
+| main.rs:323:16:323:32 | MyThing {...} | T | main.rs:270:5:271:14 | S2 |
+| main.rs:323:29:323:30 | S2 |  | main.rs:270:5:271:14 | S2 |
+| main.rs:326:26:326:48 | call_trait_thing_m1(...) |  | main.rs:268:5:269:14 | S1 |
+| main.rs:326:46:326:47 | x3 |  | main.rs:263:5:266:5 | MyThing |
+| main.rs:326:46:326:47 | x3 | T | main.rs:263:5:266:5 | MyThing |
+| main.rs:326:46:326:47 | x3 | T.T | main.rs:268:5:269:14 | S1 |
+| main.rs:327:26:327:48 | call_trait_thing_m1(...) |  | main.rs:270:5:271:14 | S2 |
+| main.rs:327:46:327:47 | y3 |  | main.rs:263:5:266:5 | MyThing |
+| main.rs:327:46:327:47 | y3 | T | main.rs:263:5:266:5 | MyThing |
+| main.rs:327:46:327:47 | y3 | T.T | main.rs:270:5:271:14 | S2 |
+| main.rs:335:15:335:18 | SelfParam |  | main.rs:332:5:344:5 | Self [trait MyTrait] |
+| main.rs:337:15:337:18 | SelfParam |  | main.rs:332:5:344:5 | Self [trait MyTrait] |
+| main.rs:353:15:353:18 | SelfParam |  | main.rs:346:5:347:13 | S |
+| main.rs:353:45:355:9 | { ... } |  | main.rs:346:5:347:13 | S |
+| main.rs:354:13:354:13 | S |  | main.rs:346:5:347:13 | S |
+| main.rs:359:13:359:13 | x |  | main.rs:346:5:347:13 | S |
+| main.rs:359:17:359:17 | S |  | main.rs:346:5:347:13 | S |
+| main.rs:360:26:360:26 | x |  | main.rs:346:5:347:13 | S |
+| main.rs:360:26:360:31 | x.m1() |  | main.rs:346:5:347:13 | S |
+| main.rs:362:13:362:13 | x |  | main.rs:346:5:347:13 | S |
+| main.rs:362:17:362:17 | S |  | main.rs:346:5:347:13 | S |
+| main.rs:363:26:363:26 | x |  | main.rs:346:5:347:13 | S |
+| main.rs:380:15:380:18 | SelfParam |  | main.rs:368:5:372:5 | MyEnum |
+| main.rs:380:15:380:18 | SelfParam | A | main.rs:379:10:379:10 | T |
+| main.rs:380:26:385:9 | { ... } |  | main.rs:379:10:379:10 | T |
+| main.rs:381:13:384:13 | match self { ... } |  | main.rs:379:10:379:10 | T |
+| main.rs:381:19:381:22 | self |  | main.rs:368:5:372:5 | MyEnum |
+| main.rs:381:19:381:22 | self | A | main.rs:379:10:379:10 | T |
+| main.rs:382:28:382:28 | a |  | main.rs:379:10:379:10 | T |
+| main.rs:382:34:382:34 | a |  | main.rs:379:10:379:10 | T |
+| main.rs:383:30:383:30 | a |  | main.rs:379:10:379:10 | T |
+| main.rs:383:37:383:37 | a |  | main.rs:379:10:379:10 | T |
+| main.rs:389:13:389:13 | x |  | main.rs:368:5:372:5 | MyEnum |
+| main.rs:389:13:389:13 | x | A | main.rs:374:5:375:14 | S1 |
+| main.rs:389:17:389:30 | ...::C1(...) |  | main.rs:368:5:372:5 | MyEnum |
+| main.rs:389:17:389:30 | ...::C1(...) | A | main.rs:374:5:375:14 | S1 |
+| main.rs:389:28:389:29 | S1 |  | main.rs:374:5:375:14 | S1 |
+| main.rs:390:13:390:13 | y |  | main.rs:368:5:372:5 | MyEnum |
+| main.rs:390:13:390:13 | y | A | main.rs:376:5:377:14 | S2 |
+| main.rs:390:17:390:36 | ...::C2 {...} |  | main.rs:368:5:372:5 | MyEnum |
+| main.rs:390:17:390:36 | ...::C2 {...} | A | main.rs:376:5:377:14 | S2 |
+| main.rs:390:33:390:34 | S2 |  | main.rs:376:5:377:14 | S2 |
+| main.rs:392:26:392:26 | x |  | main.rs:368:5:372:5 | MyEnum |
+| main.rs:392:26:392:26 | x | A | main.rs:374:5:375:14 | S1 |
+| main.rs:392:26:392:31 | x.m1() |  | main.rs:374:5:375:14 | S1 |
+| main.rs:393:26:393:26 | y |  | main.rs:368:5:372:5 | MyEnum |
+| main.rs:393:26:393:26 | y | A | main.rs:376:5:377:14 | S2 |
+| main.rs:393:26:393:31 | y.m1() |  | main.rs:376:5:377:14 | S2 |
+| main.rs:415:15:415:18 | SelfParam |  | main.rs:413:5:416:5 | Self [trait MyTrait1] |
+| main.rs:419:15:419:18 | SelfParam |  | main.rs:418:5:429:5 | Self [trait MyTrait2] |
+| main.rs:422:9:428:9 | { ... } |  | main.rs:418:20:418:22 | Tr2 |
+| main.rs:423:13:427:13 | if ... {...} else {...} |  | main.rs:418:20:418:22 | Tr2 |
+| main.rs:423:26:425:13 | { ... } |  | main.rs:418:20:418:22 | Tr2 |
+| main.rs:424:17:424:20 | self |  | main.rs:418:5:429:5 | Self [trait MyTrait2] |
+| main.rs:424:17:424:25 | self.m1() |  | main.rs:418:20:418:22 | Tr2 |
+| main.rs:425:20:427:13 | { ... } |  | main.rs:418:20:418:22 | Tr2 |
+| main.rs:426:17:426:30 | ...::m1(...) |  | main.rs:418:20:418:22 | Tr2 |
+| main.rs:426:26:426:29 | self |  | main.rs:418:5:429:5 | Self [trait MyTrait2] |
+| main.rs:432:15:432:18 | SelfParam |  | main.rs:431:5:442:5 | Self [trait MyTrait3] |
+| main.rs:435:9:441:9 | { ... } |  | main.rs:431:20:431:22 | Tr3 |
+| main.rs:436:13:440:13 | if ... {...} else {...} |  | main.rs:431:20:431:22 | Tr3 |
+| main.rs:436:26:438:13 | { ... } |  | main.rs:431:20:431:22 | Tr3 |
+| main.rs:437:17:437:20 | self |  | main.rs:431:5:442:5 | Self [trait MyTrait3] |
+| main.rs:437:17:437:25 | self.m2() |  | main.rs:398:5:401:5 | MyThing |
+| main.rs:437:17:437:25 | self.m2() | A | main.rs:431:20:431:22 | Tr3 |
+| main.rs:437:17:437:27 | ... .a |  | main.rs:431:20:431:22 | Tr3 |
+| main.rs:438:20:440:13 | { ... } |  | main.rs:431:20:431:22 | Tr3 |
+| main.rs:439:17:439:30 | ...::m2(...) |  | main.rs:398:5:401:5 | MyThing |
+| main.rs:439:17:439:30 | ...::m2(...) | A | main.rs:431:20:431:22 | Tr3 |
+| main.rs:439:17:439:32 | ... .a |  | main.rs:431:20:431:22 | Tr3 |
+| main.rs:439:26:439:29 | self |  | main.rs:431:5:442:5 | Self [trait MyTrait3] |
+| main.rs:446:15:446:18 | SelfParam |  | main.rs:398:5:401:5 | MyThing |
+| main.rs:446:15:446:18 | SelfParam | A | main.rs:444:10:444:10 | T |
+| main.rs:446:26:448:9 | { ... } |  | main.rs:444:10:444:10 | T |
+| main.rs:447:13:447:16 | self |  | main.rs:398:5:401:5 | MyThing |
+| main.rs:447:13:447:16 | self | A | main.rs:444:10:444:10 | T |
+| main.rs:447:13:447:18 | self.a |  | main.rs:444:10:444:10 | T |
+| main.rs:455:15:455:18 | SelfParam |  | main.rs:403:5:406:5 | MyThing2 |
+| main.rs:455:15:455:18 | SelfParam | A | main.rs:453:10:453:10 | T |
+| main.rs:455:35:457:9 | { ... } |  | main.rs:398:5:401:5 | MyThing |
+| main.rs:455:35:457:9 | { ... } | A | main.rs:453:10:453:10 | T |
+| main.rs:456:13:456:33 | MyThing {...} |  | main.rs:398:5:401:5 | MyThing |
+| main.rs:456:13:456:33 | MyThing {...} | A | main.rs:453:10:453:10 | T |
+| main.rs:456:26:456:29 | self |  | main.rs:403:5:406:5 | MyThing2 |
+| main.rs:456:26:456:29 | self | A | main.rs:453:10:453:10 | T |
+| main.rs:456:26:456:31 | self.a |  | main.rs:453:10:453:10 | T |
+| main.rs:465:13:465:13 | x |  | main.rs:398:5:401:5 | MyThing |
+| main.rs:465:13:465:13 | x | A | main.rs:408:5:409:14 | S1 |
+| main.rs:465:17:465:33 | MyThing {...} |  | main.rs:398:5:401:5 | MyThing |
+| main.rs:465:17:465:33 | MyThing {...} | A | main.rs:408:5:409:14 | S1 |
+| main.rs:465:30:465:31 | S1 |  | main.rs:408:5:409:14 | S1 |
+| main.rs:466:13:466:13 | y |  | main.rs:398:5:401:5 | MyThing |
+| main.rs:466:13:466:13 | y | A | main.rs:410:5:411:14 | S2 |
+| main.rs:466:17:466:33 | MyThing {...} |  | main.rs:398:5:401:5 | MyThing |
+| main.rs:466:17:466:33 | MyThing {...} | A | main.rs:410:5:411:14 | S2 |
+| main.rs:466:30:466:31 | S2 |  | main.rs:410:5:411:14 | S2 |
+| main.rs:468:26:468:26 | x |  | main.rs:398:5:401:5 | MyThing |
+| main.rs:468:26:468:26 | x | A | main.rs:408:5:409:14 | S1 |
+| main.rs:468:26:468:31 | x.m1() |  | main.rs:408:5:409:14 | S1 |
+| main.rs:469:26:469:26 | y |  | main.rs:398:5:401:5 | MyThing |
+| main.rs:469:26:469:26 | y | A | main.rs:410:5:411:14 | S2 |
+| main.rs:469:26:469:31 | y.m1() |  | main.rs:410:5:411:14 | S2 |
+| main.rs:471:13:471:13 | x |  | main.rs:398:5:401:5 | MyThing |
+| main.rs:471:13:471:13 | x | A | main.rs:408:5:409:14 | S1 |
+| main.rs:471:17:471:33 | MyThing {...} |  | main.rs:398:5:401:5 | MyThing |
+| main.rs:471:17:471:33 | MyThing {...} | A | main.rs:408:5:409:14 | S1 |
+| main.rs:471:30:471:31 | S1 |  | main.rs:408:5:409:14 | S1 |
+| main.rs:472:13:472:13 | y |  | main.rs:398:5:401:5 | MyThing |
+| main.rs:472:13:472:13 | y | A | main.rs:410:5:411:14 | S2 |
+| main.rs:472:17:472:33 | MyThing {...} |  | main.rs:398:5:401:5 | MyThing |
+| main.rs:472:17:472:33 | MyThing {...} | A | main.rs:410:5:411:14 | S2 |
+| main.rs:472:30:472:31 | S2 |  | main.rs:410:5:411:14 | S2 |
+| main.rs:474:26:474:26 | x |  | main.rs:398:5:401:5 | MyThing |
+| main.rs:474:26:474:26 | x | A | main.rs:408:5:409:14 | S1 |
+| main.rs:474:26:474:31 | x.m2() |  | main.rs:408:5:409:14 | S1 |
+| main.rs:475:26:475:26 | y |  | main.rs:398:5:401:5 | MyThing |
+| main.rs:475:26:475:26 | y | A | main.rs:410:5:411:14 | S2 |
+| main.rs:475:26:475:31 | y.m2() |  | main.rs:410:5:411:14 | S2 |
+| main.rs:477:13:477:13 | x |  | main.rs:403:5:406:5 | MyThing2 |
+| main.rs:477:13:477:13 | x | A | main.rs:408:5:409:14 | S1 |
+| main.rs:477:17:477:34 | MyThing2 {...} |  | main.rs:403:5:406:5 | MyThing2 |
+| main.rs:477:17:477:34 | MyThing2 {...} | A | main.rs:408:5:409:14 | S1 |
+| main.rs:477:31:477:32 | S1 |  | main.rs:408:5:409:14 | S1 |
+| main.rs:478:13:478:13 | y |  | main.rs:403:5:406:5 | MyThing2 |
+| main.rs:478:13:478:13 | y | A | main.rs:410:5:411:14 | S2 |
+| main.rs:478:17:478:34 | MyThing2 {...} |  | main.rs:403:5:406:5 | MyThing2 |
+| main.rs:478:17:478:34 | MyThing2 {...} | A | main.rs:410:5:411:14 | S2 |
+| main.rs:478:31:478:32 | S2 |  | main.rs:410:5:411:14 | S2 |
+| main.rs:480:26:480:26 | x |  | main.rs:403:5:406:5 | MyThing2 |
+| main.rs:480:26:480:26 | x | A | main.rs:408:5:409:14 | S1 |
+| main.rs:480:26:480:31 | x.m3() |  | main.rs:408:5:409:14 | S1 |
+| main.rs:481:26:481:26 | y |  | main.rs:403:5:406:5 | MyThing2 |
+| main.rs:481:26:481:26 | y | A | main.rs:410:5:411:14 | S2 |
+| main.rs:481:26:481:31 | y.m3() |  | main.rs:410:5:411:14 | S2 |
+| main.rs:499:22:499:22 | x |  | file://:0:0:0:0 | & |
+| main.rs:499:22:499:22 | x | &T | main.rs:499:11:499:19 | T |
+| main.rs:499:35:501:5 | { ... } |  | file://:0:0:0:0 | & |
+| main.rs:499:35:501:5 | { ... } | &T | main.rs:499:11:499:19 | T |
+| main.rs:500:9:500:9 | x |  | file://:0:0:0:0 | & |
+| main.rs:500:9:500:9 | x | &T | main.rs:499:11:499:19 | T |
+| main.rs:504:17:504:20 | SelfParam |  | main.rs:489:5:490:14 | S1 |
+| main.rs:504:29:506:9 | { ... } |  | main.rs:492:5:493:14 | S2 |
+| main.rs:505:13:505:14 | S2 |  | main.rs:492:5:493:14 | S2 |
+| main.rs:509:21:509:21 | x |  | main.rs:509:13:509:14 | T1 |
+| main.rs:512:5:514:5 | { ... } |  | main.rs:509:17:509:18 | T2 |
+| main.rs:513:9:513:9 | x |  | main.rs:509:13:509:14 | T1 |
+| main.rs:513:9:513:16 | x.into() |  | main.rs:509:17:509:18 | T2 |
+| main.rs:517:13:517:13 | x |  | main.rs:489:5:490:14 | S1 |
+| main.rs:517:17:517:18 | S1 |  | main.rs:489:5:490:14 | S1 |
+| main.rs:518:26:518:31 | id(...) |  | file://:0:0:0:0 | & |
+| main.rs:518:26:518:31 | id(...) | &T | main.rs:489:5:490:14 | S1 |
+| main.rs:518:29:518:30 | &x |  | file://:0:0:0:0 | & |
+| main.rs:518:29:518:30 | &x | &T | main.rs:489:5:490:14 | S1 |
+| main.rs:518:30:518:30 | x |  | main.rs:489:5:490:14 | S1 |
+| main.rs:520:13:520:13 | x |  | main.rs:489:5:490:14 | S1 |
+| main.rs:520:17:520:18 | S1 |  | main.rs:489:5:490:14 | S1 |
+| main.rs:521:26:521:37 | id::<...>(...) |  | file://:0:0:0:0 | & |
+| main.rs:521:26:521:37 | id::<...>(...) | &T | main.rs:489:5:490:14 | S1 |
+| main.rs:521:35:521:36 | &x |  | file://:0:0:0:0 | & |
+| main.rs:521:35:521:36 | &x | &T | main.rs:489:5:490:14 | S1 |
+| main.rs:521:36:521:36 | x |  | main.rs:489:5:490:14 | S1 |
+| main.rs:523:13:523:13 | x |  | main.rs:489:5:490:14 | S1 |
+| main.rs:523:17:523:18 | S1 |  | main.rs:489:5:490:14 | S1 |
+| main.rs:524:26:524:44 | id::<...>(...) |  | file://:0:0:0:0 | & |
+| main.rs:524:26:524:44 | id::<...>(...) | &T | main.rs:489:5:490:14 | S1 |
+| main.rs:524:42:524:43 | &x |  | file://:0:0:0:0 | & |
+| main.rs:524:42:524:43 | &x | &T | main.rs:489:5:490:14 | S1 |
+| main.rs:524:43:524:43 | x |  | main.rs:489:5:490:14 | S1 |
+| main.rs:526:13:526:13 | x |  | main.rs:489:5:490:14 | S1 |
+| main.rs:526:17:526:18 | S1 |  | main.rs:489:5:490:14 | S1 |
+| main.rs:527:9:527:25 | into::<...>(...) |  | main.rs:492:5:493:14 | S2 |
+| main.rs:527:24:527:24 | x |  | main.rs:489:5:490:14 | S1 |
+| main.rs:529:13:529:13 | x |  | main.rs:489:5:490:14 | S1 |
+| main.rs:529:17:529:18 | S1 |  | main.rs:489:5:490:14 | S1 |
+| main.rs:530:13:530:13 | y |  | main.rs:492:5:493:14 | S2 |
+| main.rs:530:21:530:27 | into(...) |  | main.rs:492:5:493:14 | S2 |
+| main.rs:530:26:530:26 | x |  | main.rs:489:5:490:14 | S1 |
+| main.rs:560:13:560:14 | p1 |  | main.rs:535:5:541:5 | PairOption |
+| main.rs:560:13:560:14 | p1 | Fst | main.rs:543:5:544:14 | S1 |
+| main.rs:560:13:560:14 | p1 | Snd | main.rs:546:5:547:14 | S2 |
+| main.rs:560:26:560:53 | ...::PairBoth(...) |  | main.rs:535:5:541:5 | PairOption |
+| main.rs:560:26:560:53 | ...::PairBoth(...) | Fst | main.rs:543:5:544:14 | S1 |
+| main.rs:560:26:560:53 | ...::PairBoth(...) | Snd | main.rs:546:5:547:14 | S2 |
+| main.rs:560:47:560:48 | S1 |  | main.rs:543:5:544:14 | S1 |
+| main.rs:560:51:560:52 | S2 |  | main.rs:546:5:547:14 | S2 |
+| main.rs:561:26:561:27 | p1 |  | main.rs:535:5:541:5 | PairOption |
+| main.rs:561:26:561:27 | p1 | Fst | main.rs:543:5:544:14 | S1 |
+| main.rs:561:26:561:27 | p1 | Snd | main.rs:546:5:547:14 | S2 |
+| main.rs:564:13:564:14 | p2 |  | main.rs:535:5:541:5 | PairOption |
+| main.rs:564:26:564:47 | ...::PairNone(...) |  | main.rs:535:5:541:5 | PairOption |
+| main.rs:565:26:565:27 | p2 |  | main.rs:535:5:541:5 | PairOption |
+| main.rs:568:13:568:14 | p3 |  | main.rs:535:5:541:5 | PairOption |
+| main.rs:568:13:568:14 | p3 | Snd | main.rs:549:5:550:14 | S3 |
+| main.rs:568:34:568:56 | ...::PairSnd(...) |  | main.rs:535:5:541:5 | PairOption |
+| main.rs:568:34:568:56 | ...::PairSnd(...) | Snd | main.rs:549:5:550:14 | S3 |
+| main.rs:568:54:568:55 | S3 |  | main.rs:549:5:550:14 | S3 |
+| main.rs:569:26:569:27 | p3 |  | main.rs:535:5:541:5 | PairOption |
+| main.rs:569:26:569:27 | p3 | Snd | main.rs:549:5:550:14 | S3 |
+| main.rs:572:13:572:14 | p3 |  | main.rs:535:5:541:5 | PairOption |
+| main.rs:572:13:572:14 | p3 | Fst | main.rs:549:5:550:14 | S3 |
+| main.rs:572:35:572:56 | ...::PairNone(...) |  | main.rs:535:5:541:5 | PairOption |
+| main.rs:572:35:572:56 | ...::PairNone(...) | Fst | main.rs:549:5:550:14 | S3 |
+| main.rs:573:26:573:27 | p3 |  | main.rs:535:5:541:5 | PairOption |
+| main.rs:573:26:573:27 | p3 | Fst | main.rs:549:5:550:14 | S3 |
+| main.rs:586:16:586:24 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:586:16:586:24 | SelfParam | &T | main.rs:584:5:591:5 | Self [trait MyTrait] |
+| main.rs:586:27:586:31 | value |  | main.rs:584:19:584:19 | S |
+| main.rs:588:21:588:29 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:588:21:588:29 | SelfParam | &T | main.rs:584:5:591:5 | Self [trait MyTrait] |
+| main.rs:588:32:588:36 | value |  | main.rs:584:19:584:19 | S |
+| main.rs:589:13:589:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:589:13:589:16 | self | &T | main.rs:584:5:591:5 | Self [trait MyTrait] |
+| main.rs:589:22:589:26 | value |  | main.rs:584:19:584:19 | S |
+| main.rs:595:16:595:24 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:595:16:595:24 | SelfParam | &T | main.rs:578:5:582:5 | MyOption |
+| main.rs:595:16:595:24 | SelfParam | &T.T | main.rs:593:10:593:10 | T |
+| main.rs:595:27:595:31 | value |  | main.rs:593:10:593:10 | T |
+| main.rs:599:26:601:9 | { ... } |  | main.rs:578:5:582:5 | MyOption |
+| main.rs:599:26:601:9 | { ... } | T | main.rs:598:10:598:10 | T |
+| main.rs:600:13:600:30 | ...::MyNone(...) |  | main.rs:578:5:582:5 | MyOption |
+| main.rs:600:13:600:30 | ...::MyNone(...) | T | main.rs:598:10:598:10 | T |
+| main.rs:605:20:605:23 | SelfParam |  | main.rs:578:5:582:5 | MyOption |
+| main.rs:605:20:605:23 | SelfParam | T | main.rs:578:5:582:5 | MyOption |
+| main.rs:605:20:605:23 | SelfParam | T.T | main.rs:604:10:604:10 | T |
+| main.rs:605:41:610:9 | { ... } |  | main.rs:578:5:582:5 | MyOption |
+| main.rs:605:41:610:9 | { ... } | T | main.rs:604:10:604:10 | T |
+| main.rs:606:13:609:13 | match self { ... } |  | main.rs:578:5:582:5 | MyOption |
+| main.rs:606:13:609:13 | match self { ... } | T | main.rs:604:10:604:10 | T |
+| main.rs:606:19:606:22 | self |  | main.rs:578:5:582:5 | MyOption |
+| main.rs:606:19:606:22 | self | T | main.rs:578:5:582:5 | MyOption |
+| main.rs:606:19:606:22 | self | T.T | main.rs:604:10:604:10 | T |
+| main.rs:607:39:607:56 | ...::MyNone(...) |  | main.rs:578:5:582:5 | MyOption |
+| main.rs:607:39:607:56 | ...::MyNone(...) | T | main.rs:604:10:604:10 | T |
+| main.rs:608:34:608:34 | x |  | main.rs:578:5:582:5 | MyOption |
+| main.rs:608:34:608:34 | x | T | main.rs:604:10:604:10 | T |
+| main.rs:608:40:608:40 | x |  | main.rs:578:5:582:5 | MyOption |
+| main.rs:608:40:608:40 | x | T | main.rs:604:10:604:10 | T |
+| main.rs:617:13:617:14 | x1 |  | main.rs:578:5:582:5 | MyOption |
+| main.rs:617:18:617:37 | ...::new(...) |  | main.rs:578:5:582:5 | MyOption |
+| main.rs:618:26:618:27 | x1 |  | main.rs:578:5:582:5 | MyOption |
+| main.rs:620:13:620:18 | mut x2 |  | main.rs:578:5:582:5 | MyOption |
+| main.rs:620:13:620:18 | mut x2 | T | main.rs:613:5:614:13 | S |
+| main.rs:620:22:620:36 | ...::new(...) |  | main.rs:578:5:582:5 | MyOption |
+| main.rs:620:22:620:36 | ...::new(...) | T | main.rs:613:5:614:13 | S |
+| main.rs:621:9:621:10 | x2 |  | main.rs:578:5:582:5 | MyOption |
+| main.rs:621:9:621:10 | x2 | T | main.rs:613:5:614:13 | S |
+| main.rs:621:16:621:16 | S |  | main.rs:613:5:614:13 | S |
+| main.rs:622:26:622:27 | x2 |  | main.rs:578:5:582:5 | MyOption |
+| main.rs:622:26:622:27 | x2 | T | main.rs:613:5:614:13 | S |
+| main.rs:624:13:624:18 | mut x3 |  | main.rs:578:5:582:5 | MyOption |
+| main.rs:624:22:624:36 | ...::new(...) |  | main.rs:578:5:582:5 | MyOption |
+| main.rs:625:9:625:10 | x3 |  | main.rs:578:5:582:5 | MyOption |
+| main.rs:625:21:625:21 | S |  | main.rs:613:5:614:13 | S |
+| main.rs:626:26:626:27 | x3 |  | main.rs:578:5:582:5 | MyOption |
+| main.rs:628:13:628:18 | mut x4 |  | main.rs:578:5:582:5 | MyOption |
+| main.rs:628:13:628:18 | mut x4 | T | main.rs:613:5:614:13 | S |
+| main.rs:628:22:628:36 | ...::new(...) |  | main.rs:578:5:582:5 | MyOption |
+| main.rs:628:22:628:36 | ...::new(...) | T | main.rs:613:5:614:13 | S |
+| main.rs:629:23:629:29 | &mut x4 |  | file://:0:0:0:0 | & |
+| main.rs:629:23:629:29 | &mut x4 | &T | main.rs:578:5:582:5 | MyOption |
+| main.rs:629:23:629:29 | &mut x4 | &T.T | main.rs:613:5:614:13 | S |
+| main.rs:629:28:629:29 | x4 |  | main.rs:578:5:582:5 | MyOption |
+| main.rs:629:28:629:29 | x4 | T | main.rs:613:5:614:13 | S |
+| main.rs:629:32:629:32 | S |  | main.rs:613:5:614:13 | S |
+| main.rs:630:26:630:27 | x4 |  | main.rs:578:5:582:5 | MyOption |
+| main.rs:630:26:630:27 | x4 | T | main.rs:613:5:614:13 | S |
+| main.rs:632:13:632:14 | x5 |  | main.rs:578:5:582:5 | MyOption |
+| main.rs:632:13:632:14 | x5 | T | main.rs:578:5:582:5 | MyOption |
+| main.rs:632:13:632:14 | x5 | T.T | main.rs:613:5:614:13 | S |
+| main.rs:632:18:632:58 | ...::MySome(...) |  | main.rs:578:5:582:5 | MyOption |
+| main.rs:632:18:632:58 | ...::MySome(...) | T | main.rs:578:5:582:5 | MyOption |
+| main.rs:632:18:632:58 | ...::MySome(...) | T.T | main.rs:613:5:614:13 | S |
+| main.rs:632:35:632:57 | ...::MyNone(...) |  | main.rs:578:5:582:5 | MyOption |
+| main.rs:632:35:632:57 | ...::MyNone(...) | T | main.rs:613:5:614:13 | S |
+| main.rs:633:26:633:27 | x5 |  | main.rs:578:5:582:5 | MyOption |
+| main.rs:633:26:633:27 | x5 | T | main.rs:578:5:582:5 | MyOption |
+| main.rs:633:26:633:27 | x5 | T.T | main.rs:613:5:614:13 | S |
+| main.rs:635:13:635:14 | x6 |  | main.rs:578:5:582:5 | MyOption |
+| main.rs:635:13:635:14 | x6 | T | main.rs:578:5:582:5 | MyOption |
+| main.rs:635:13:635:14 | x6 | T.T | main.rs:613:5:614:13 | S |
+| main.rs:635:18:635:58 | ...::MySome(...) |  | main.rs:578:5:582:5 | MyOption |
+| main.rs:635:18:635:58 | ...::MySome(...) | T | main.rs:578:5:582:5 | MyOption |
+| main.rs:635:18:635:58 | ...::MySome(...) | T.T | main.rs:613:5:614:13 | S |
+| main.rs:635:35:635:57 | ...::MyNone(...) |  | main.rs:578:5:582:5 | MyOption |
+| main.rs:635:35:635:57 | ...::MyNone(...) | T | main.rs:613:5:614:13 | S |
+| main.rs:636:26:636:61 | ...::flatten(...) |  | main.rs:578:5:582:5 | MyOption |
+| main.rs:636:26:636:61 | ...::flatten(...) | T | main.rs:613:5:614:13 | S |
+| main.rs:636:59:636:60 | x6 |  | main.rs:578:5:582:5 | MyOption |
+| main.rs:636:59:636:60 | x6 | T | main.rs:578:5:582:5 | MyOption |
+| main.rs:636:59:636:60 | x6 | T.T | main.rs:613:5:614:13 | S |
+| main.rs:638:13:638:19 | from_if |  | main.rs:578:5:582:5 | MyOption |
+| main.rs:638:13:638:19 | from_if | T | main.rs:613:5:614:13 | S |
+| main.rs:638:23:642:9 | if ... {...} else {...} |  | main.rs:578:5:582:5 | MyOption |
+| main.rs:638:23:642:9 | if ... {...} else {...} | T | main.rs:613:5:614:13 | S |
+| main.rs:638:36:640:9 | { ... } |  | main.rs:578:5:582:5 | MyOption |
+| main.rs:638:36:640:9 | { ... } | T | main.rs:613:5:614:13 | S |
+| main.rs:639:13:639:30 | ...::MyNone(...) |  | main.rs:578:5:582:5 | MyOption |
+| main.rs:639:13:639:30 | ...::MyNone(...) | T | main.rs:613:5:614:13 | S |
+| main.rs:640:16:642:9 | { ... } |  | main.rs:578:5:582:5 | MyOption |
+| main.rs:640:16:642:9 | { ... } | T | main.rs:613:5:614:13 | S |
+| main.rs:641:13:641:31 | ...::MySome(...) |  | main.rs:578:5:582:5 | MyOption |
+| main.rs:641:13:641:31 | ...::MySome(...) | T | main.rs:613:5:614:13 | S |
+| main.rs:641:30:641:30 | S |  | main.rs:613:5:614:13 | S |
+| main.rs:643:26:643:32 | from_if |  | main.rs:578:5:582:5 | MyOption |
+| main.rs:643:26:643:32 | from_if | T | main.rs:613:5:614:13 | S |
+| main.rs:645:13:645:22 | from_match |  | main.rs:578:5:582:5 | MyOption |
+| main.rs:645:13:645:22 | from_match | T | main.rs:613:5:614:13 | S |
+| main.rs:645:26:648:9 | match ... { ... } |  | main.rs:578:5:582:5 | MyOption |
+| main.rs:645:26:648:9 | match ... { ... } | T | main.rs:613:5:614:13 | S |
+| main.rs:646:21:646:38 | ...::MyNone(...) |  | main.rs:578:5:582:5 | MyOption |
+| main.rs:646:21:646:38 | ...::MyNone(...) | T | main.rs:613:5:614:13 | S |
+| main.rs:647:22:647:40 | ...::MySome(...) |  | main.rs:578:5:582:5 | MyOption |
+| main.rs:647:22:647:40 | ...::MySome(...) | T | main.rs:613:5:614:13 | S |
+| main.rs:647:39:647:39 | S |  | main.rs:613:5:614:13 | S |
+| main.rs:649:26:649:35 | from_match |  | main.rs:578:5:582:5 | MyOption |
+| main.rs:649:26:649:35 | from_match | T | main.rs:613:5:614:13 | S |
+| main.rs:651:13:651:21 | from_loop |  | main.rs:578:5:582:5 | MyOption |
+| main.rs:651:13:651:21 | from_loop | T | main.rs:613:5:614:13 | S |
+| main.rs:651:25:656:9 | loop { ... } |  | main.rs:578:5:582:5 | MyOption |
+| main.rs:651:25:656:9 | loop { ... } | T | main.rs:613:5:614:13 | S |
+| main.rs:653:23:653:40 | ...::MyNone(...) |  | main.rs:578:5:582:5 | MyOption |
+| main.rs:653:23:653:40 | ...::MyNone(...) | T | main.rs:613:5:614:13 | S |
+| main.rs:655:19:655:37 | ...::MySome(...) |  | main.rs:578:5:582:5 | MyOption |
+| main.rs:655:19:655:37 | ...::MySome(...) | T | main.rs:613:5:614:13 | S |
+| main.rs:655:36:655:36 | S |  | main.rs:613:5:614:13 | S |
+| main.rs:657:26:657:34 | from_loop |  | main.rs:578:5:582:5 | MyOption |
+| main.rs:657:26:657:34 | from_loop | T | main.rs:613:5:614:13 | S |
+| main.rs:670:15:670:18 | SelfParam |  | main.rs:663:5:664:19 | S |
+| main.rs:670:15:670:18 | SelfParam | T | main.rs:669:10:669:10 | T |
+| main.rs:670:26:672:9 | { ... } |  | main.rs:669:10:669:10 | T |
+| main.rs:671:13:671:16 | self |  | main.rs:663:5:664:19 | S |
+| main.rs:671:13:671:16 | self | T | main.rs:669:10:669:10 | T |
+| main.rs:671:13:671:18 | self.0 |  | main.rs:669:10:669:10 | T |
+| main.rs:674:15:674:19 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:674:15:674:19 | SelfParam | &T | main.rs:663:5:664:19 | S |
+| main.rs:674:15:674:19 | SelfParam | &T.T | main.rs:669:10:669:10 | T |
+| main.rs:674:28:676:9 | { ... } |  | file://:0:0:0:0 | & |
+| main.rs:674:28:676:9 | { ... } | &T | main.rs:669:10:669:10 | T |
+| main.rs:675:13:675:19 | &... |  | file://:0:0:0:0 | & |
+| main.rs:675:13:675:19 | &... | &T | main.rs:669:10:669:10 | T |
+| main.rs:675:14:675:17 | self |  | file://:0:0:0:0 | & |
+| main.rs:675:14:675:17 | self | &T | main.rs:663:5:664:19 | S |
+| main.rs:675:14:675:17 | self | &T.T | main.rs:669:10:669:10 | T |
+| main.rs:675:14:675:19 | self.0 |  | main.rs:669:10:669:10 | T |
+| main.rs:678:15:678:25 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:678:15:678:25 | SelfParam | &T | main.rs:663:5:664:19 | S |
+| main.rs:678:15:678:25 | SelfParam | &T.T | main.rs:669:10:669:10 | T |
+| main.rs:678:34:680:9 | { ... } |  | file://:0:0:0:0 | & |
+| main.rs:678:34:680:9 | { ... } | &T | main.rs:669:10:669:10 | T |
+| main.rs:679:13:679:19 | &... |  | file://:0:0:0:0 | & |
+| main.rs:679:13:679:19 | &... | &T | main.rs:669:10:669:10 | T |
+| main.rs:679:14:679:17 | self |  | file://:0:0:0:0 | & |
+| main.rs:679:14:679:17 | self | &T | main.rs:663:5:664:19 | S |
+| main.rs:679:14:679:17 | self | &T.T | main.rs:669:10:669:10 | T |
+| main.rs:679:14:679:19 | self.0 |  | main.rs:669:10:669:10 | T |
+| main.rs:684:13:684:14 | x1 |  | main.rs:663:5:664:19 | S |
+| main.rs:684:13:684:14 | x1 | T | main.rs:666:5:667:14 | S2 |
+| main.rs:684:18:684:22 | S(...) |  | main.rs:663:5:664:19 | S |
+| main.rs:684:18:684:22 | S(...) | T | main.rs:666:5:667:14 | S2 |
+| main.rs:684:20:684:21 | S2 |  | main.rs:666:5:667:14 | S2 |
+| main.rs:685:26:685:27 | x1 |  | main.rs:663:5:664:19 | S |
+| main.rs:685:26:685:27 | x1 | T | main.rs:666:5:667:14 | S2 |
+| main.rs:685:26:685:32 | x1.m1() |  | main.rs:666:5:667:14 | S2 |
+| main.rs:687:13:687:14 | x2 |  | main.rs:663:5:664:19 | S |
+| main.rs:687:13:687:14 | x2 | T | main.rs:666:5:667:14 | S2 |
+| main.rs:687:18:687:22 | S(...) |  | main.rs:663:5:664:19 | S |
+| main.rs:687:18:687:22 | S(...) | T | main.rs:666:5:667:14 | S2 |
+| main.rs:687:20:687:21 | S2 |  | main.rs:666:5:667:14 | S2 |
+| main.rs:689:26:689:27 | x2 |  | main.rs:663:5:664:19 | S |
+| main.rs:689:26:689:27 | x2 | T | main.rs:666:5:667:14 | S2 |
+| main.rs:689:26:689:32 | x2.m2() |  | file://:0:0:0:0 | & |
+| main.rs:689:26:689:32 | x2.m2() | &T | main.rs:666:5:667:14 | S2 |
+| main.rs:690:26:690:27 | x2 |  | main.rs:663:5:664:19 | S |
+| main.rs:690:26:690:27 | x2 | T | main.rs:666:5:667:14 | S2 |
+| main.rs:690:26:690:32 | x2.m3() |  | file://:0:0:0:0 | & |
+| main.rs:690:26:690:32 | x2.m3() | &T | main.rs:666:5:667:14 | S2 |
+| main.rs:692:13:692:14 | x3 |  | main.rs:663:5:664:19 | S |
+| main.rs:692:13:692:14 | x3 | T | main.rs:666:5:667:14 | S2 |
+| main.rs:692:18:692:22 | S(...) |  | main.rs:663:5:664:19 | S |
+| main.rs:692:18:692:22 | S(...) | T | main.rs:666:5:667:14 | S2 |
+| main.rs:692:20:692:21 | S2 |  | main.rs:666:5:667:14 | S2 |
+| main.rs:694:26:694:41 | ...::m2(...) |  | file://:0:0:0:0 | & |
+| main.rs:694:26:694:41 | ...::m2(...) | &T | main.rs:666:5:667:14 | S2 |
+| main.rs:694:38:694:40 | &x3 |  | file://:0:0:0:0 | & |
+| main.rs:694:38:694:40 | &x3 | &T | main.rs:663:5:664:19 | S |
+| main.rs:694:38:694:40 | &x3 | &T.T | main.rs:666:5:667:14 | S2 |
+| main.rs:694:39:694:40 | x3 |  | main.rs:663:5:664:19 | S |
+| main.rs:694:39:694:40 | x3 | T | main.rs:666:5:667:14 | S2 |
+| main.rs:695:26:695:41 | ...::m3(...) |  | file://:0:0:0:0 | & |
+| main.rs:695:26:695:41 | ...::m3(...) | &T | main.rs:666:5:667:14 | S2 |
+| main.rs:695:38:695:40 | &x3 |  | file://:0:0:0:0 | & |
+| main.rs:695:38:695:40 | &x3 | &T | main.rs:663:5:664:19 | S |
+| main.rs:695:38:695:40 | &x3 | &T.T | main.rs:666:5:667:14 | S2 |
+| main.rs:695:39:695:40 | x3 |  | main.rs:663:5:664:19 | S |
+| main.rs:695:39:695:40 | x3 | T | main.rs:666:5:667:14 | S2 |
+| main.rs:697:13:697:14 | x4 |  | file://:0:0:0:0 | & |
+| main.rs:697:13:697:14 | x4 | &T | main.rs:663:5:664:19 | S |
+| main.rs:697:13:697:14 | x4 | &T.T | main.rs:666:5:667:14 | S2 |
+| main.rs:697:18:697:23 | &... |  | file://:0:0:0:0 | & |
+| main.rs:697:18:697:23 | &... | &T | main.rs:663:5:664:19 | S |
+| main.rs:697:18:697:23 | &... | &T.T | main.rs:666:5:667:14 | S2 |
+| main.rs:697:19:697:23 | S(...) |  | main.rs:663:5:664:19 | S |
+| main.rs:697:19:697:23 | S(...) | T | main.rs:666:5:667:14 | S2 |
+| main.rs:697:21:697:22 | S2 |  | main.rs:666:5:667:14 | S2 |
+| main.rs:699:26:699:27 | x4 |  | file://:0:0:0:0 | & |
+| main.rs:699:26:699:27 | x4 | &T | main.rs:663:5:664:19 | S |
+| main.rs:699:26:699:27 | x4 | &T.T | main.rs:666:5:667:14 | S2 |
+| main.rs:699:26:699:32 | x4.m2() |  | file://:0:0:0:0 | & |
+| main.rs:699:26:699:32 | x4.m2() | &T | main.rs:666:5:667:14 | S2 |
+| main.rs:700:26:700:27 | x4 |  | file://:0:0:0:0 | & |
+| main.rs:700:26:700:27 | x4 | &T | main.rs:663:5:664:19 | S |
+| main.rs:700:26:700:27 | x4 | &T.T | main.rs:666:5:667:14 | S2 |
+| main.rs:700:26:700:32 | x4.m3() |  | file://:0:0:0:0 | & |
+| main.rs:700:26:700:32 | x4.m3() | &T | main.rs:666:5:667:14 | S2 |
+| main.rs:702:13:702:14 | x5 |  | file://:0:0:0:0 | & |
+| main.rs:702:13:702:14 | x5 | &T | main.rs:663:5:664:19 | S |
+| main.rs:702:13:702:14 | x5 | &T.T | main.rs:666:5:667:14 | S2 |
+| main.rs:702:18:702:23 | &... |  | file://:0:0:0:0 | & |
+| main.rs:702:18:702:23 | &... | &T | main.rs:663:5:664:19 | S |
+| main.rs:702:18:702:23 | &... | &T.T | main.rs:666:5:667:14 | S2 |
+| main.rs:702:19:702:23 | S(...) |  | main.rs:663:5:664:19 | S |
+| main.rs:702:19:702:23 | S(...) | T | main.rs:666:5:667:14 | S2 |
+| main.rs:702:21:702:22 | S2 |  | main.rs:666:5:667:14 | S2 |
+| main.rs:704:26:704:27 | x5 |  | file://:0:0:0:0 | & |
+| main.rs:704:26:704:27 | x5 | &T | main.rs:663:5:664:19 | S |
+| main.rs:704:26:704:27 | x5 | &T.T | main.rs:666:5:667:14 | S2 |
+| main.rs:704:26:704:32 | x5.m1() |  | main.rs:666:5:667:14 | S2 |
+| main.rs:705:26:705:27 | x5 |  | file://:0:0:0:0 | & |
+| main.rs:705:26:705:27 | x5 | &T | main.rs:663:5:664:19 | S |
+| main.rs:705:26:705:27 | x5 | &T.T | main.rs:666:5:667:14 | S2 |
+| main.rs:705:26:705:29 | x5.0 |  | main.rs:666:5:667:14 | S2 |
+| main.rs:707:13:707:14 | x6 |  | file://:0:0:0:0 | & |
+| main.rs:707:13:707:14 | x6 | &T | main.rs:663:5:664:19 | S |
+| main.rs:707:13:707:14 | x6 | &T.T | main.rs:666:5:667:14 | S2 |
+| main.rs:707:18:707:23 | &... |  | file://:0:0:0:0 | & |
+| main.rs:707:18:707:23 | &... | &T | main.rs:663:5:664:19 | S |
+| main.rs:707:18:707:23 | &... | &T.T | main.rs:666:5:667:14 | S2 |
+| main.rs:707:19:707:23 | S(...) |  | main.rs:663:5:664:19 | S |
+| main.rs:707:19:707:23 | S(...) | T | main.rs:666:5:667:14 | S2 |
+| main.rs:707:21:707:22 | S2 |  | main.rs:666:5:667:14 | S2 |
+| main.rs:709:26:709:30 | (...) |  | main.rs:663:5:664:19 | S |
+| main.rs:709:26:709:30 | (...) | T | main.rs:666:5:667:14 | S2 |
+| main.rs:709:26:709:35 | ... .m1() |  | main.rs:666:5:667:14 | S2 |
+| main.rs:709:27:709:29 | * ... |  | main.rs:663:5:664:19 | S |
+| main.rs:709:27:709:29 | * ... | T | main.rs:666:5:667:14 | S2 |
+| main.rs:709:28:709:29 | x6 |  | file://:0:0:0:0 | & |
+| main.rs:709:28:709:29 | x6 | &T | main.rs:663:5:664:19 | S |
+| main.rs:709:28:709:29 | x6 | &T.T | main.rs:666:5:667:14 | S2 |
+| main.rs:716:16:716:20 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:716:16:716:20 | SelfParam | &T | main.rs:714:5:722:5 | Self [trait MyTrait] |
+| main.rs:719:16:719:20 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:719:16:719:20 | SelfParam | &T | main.rs:714:5:722:5 | Self [trait MyTrait] |
+| main.rs:719:32:721:9 | { ... } |  | file://:0:0:0:0 | & |
+| main.rs:719:32:721:9 | { ... } | &T | main.rs:714:5:722:5 | Self [trait MyTrait] |
+| main.rs:720:13:720:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:720:13:720:16 | self | &T | main.rs:714:5:722:5 | Self [trait MyTrait] |
+| main.rs:720:13:720:22 | self.foo() |  | file://:0:0:0:0 | & |
+| main.rs:720:13:720:22 | self.foo() | &T | main.rs:714:5:722:5 | Self [trait MyTrait] |
+| main.rs:728:16:728:20 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:728:16:728:20 | SelfParam | &T | main.rs:724:5:724:20 | MyStruct |
+| main.rs:728:36:730:9 | { ... } |  | file://:0:0:0:0 | & |
+| main.rs:728:36:730:9 | { ... } | &T | main.rs:724:5:724:20 | MyStruct |
+| main.rs:729:13:729:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:729:13:729:16 | self | &T | main.rs:724:5:724:20 | MyStruct |
+| main.rs:734:13:734:13 | x |  | main.rs:724:5:724:20 | MyStruct |
+| main.rs:734:17:734:24 | MyStruct |  | main.rs:724:5:724:20 | MyStruct |
+| main.rs:735:9:735:9 | x |  | main.rs:724:5:724:20 | MyStruct |
+| main.rs:735:9:735:15 | x.bar() |  | file://:0:0:0:0 | & |
+| main.rs:735:9:735:15 | x.bar() | &T | main.rs:724:5:724:20 | MyStruct |
+| main.rs:745:16:745:20 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:745:16:745:20 | SelfParam | &T | main.rs:742:5:742:26 | MyStruct |
+| main.rs:745:16:745:20 | SelfParam | &T.T | main.rs:744:10:744:10 | T |
+| main.rs:745:32:747:9 | { ... } |  | file://:0:0:0:0 | & |
+| main.rs:745:32:747:9 | { ... } | &T | main.rs:742:5:742:26 | MyStruct |
+| main.rs:745:32:747:9 | { ... } | &T.T | main.rs:744:10:744:10 | T |
+| main.rs:746:13:746:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:746:13:746:16 | self | &T | main.rs:742:5:742:26 | MyStruct |
+| main.rs:746:13:746:16 | self | &T.T | main.rs:744:10:744:10 | T |
+| main.rs:751:13:751:13 | x |  | main.rs:742:5:742:26 | MyStruct |
+| main.rs:751:13:751:13 | x | T | main.rs:740:5:740:13 | S |
+| main.rs:751:17:751:27 | MyStruct(...) |  | main.rs:742:5:742:26 | MyStruct |
+| main.rs:751:17:751:27 | MyStruct(...) | T | main.rs:740:5:740:13 | S |
+| main.rs:751:26:751:26 | S |  | main.rs:740:5:740:13 | S |
+| main.rs:752:9:752:9 | x |  | main.rs:742:5:742:26 | MyStruct |
+| main.rs:752:9:752:9 | x | T | main.rs:740:5:740:13 | S |
+| main.rs:752:9:752:15 | x.foo() |  | file://:0:0:0:0 | & |
+| main.rs:752:9:752:15 | x.foo() | &T | main.rs:742:5:742:26 | MyStruct |
+| main.rs:752:9:752:15 | x.foo() | &T.T | main.rs:740:5:740:13 | S |
+| main.rs:760:15:760:19 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:760:15:760:19 | SelfParam | &T | main.rs:757:5:757:13 | S |
+| main.rs:760:31:762:9 | { ... } |  | file://:0:0:0:0 | & |
+| main.rs:760:31:762:9 | { ... } | &T | main.rs:757:5:757:13 | S |
+| main.rs:761:13:761:19 | &... |  | file://:0:0:0:0 | & |
+| main.rs:761:13:761:19 | &... | &T | main.rs:757:5:757:13 | S |
+| main.rs:761:14:761:19 | &... |  | file://:0:0:0:0 | & |
+| main.rs:761:14:761:19 | &... | &T | main.rs:757:5:757:13 | S |
+| main.rs:761:15:761:19 | &self |  | file://:0:0:0:0 | & |
+| main.rs:761:15:761:19 | &self | &T | main.rs:757:5:757:13 | S |
+| main.rs:761:16:761:19 | self |  | file://:0:0:0:0 | & |
+| main.rs:761:16:761:19 | self | &T | main.rs:757:5:757:13 | S |
+| main.rs:764:15:764:25 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:764:15:764:25 | SelfParam | &T | main.rs:757:5:757:13 | S |
+| main.rs:764:37:766:9 | { ... } |  | file://:0:0:0:0 | & |
+| main.rs:764:37:766:9 | { ... } | &T | main.rs:757:5:757:13 | S |
+| main.rs:765:13:765:19 | &... |  | file://:0:0:0:0 | & |
+| main.rs:765:13:765:19 | &... | &T | main.rs:757:5:757:13 | S |
+| main.rs:765:14:765:19 | &... |  | file://:0:0:0:0 | & |
+| main.rs:765:14:765:19 | &... | &T | main.rs:757:5:757:13 | S |
+| main.rs:765:15:765:19 | &self |  | file://:0:0:0:0 | & |
+| main.rs:765:15:765:19 | &self | &T | main.rs:757:5:757:13 | S |
+| main.rs:765:16:765:19 | self |  | file://:0:0:0:0 | & |
+| main.rs:765:16:765:19 | self | &T | main.rs:757:5:757:13 | S |
+| main.rs:768:15:768:15 | x |  | file://:0:0:0:0 | & |
+| main.rs:768:15:768:15 | x | &T | main.rs:757:5:757:13 | S |
+| main.rs:768:34:770:9 | { ... } |  | file://:0:0:0:0 | & |
+| main.rs:768:34:770:9 | { ... } | &T | main.rs:757:5:757:13 | S |
+| main.rs:769:13:769:13 | x |  | file://:0:0:0:0 | & |
+| main.rs:769:13:769:13 | x | &T | main.rs:757:5:757:13 | S |
+| main.rs:772:15:772:15 | x |  | file://:0:0:0:0 | & |
+| main.rs:772:15:772:15 | x | &T | main.rs:757:5:757:13 | S |
+| main.rs:772:34:774:9 | { ... } |  | file://:0:0:0:0 | & |
+| main.rs:772:34:774:9 | { ... } | &T | main.rs:757:5:757:13 | S |
+| main.rs:773:13:773:16 | &... |  | file://:0:0:0:0 | & |
+| main.rs:773:13:773:16 | &... | &T | main.rs:757:5:757:13 | S |
+| main.rs:773:14:773:16 | &... |  | file://:0:0:0:0 | & |
+| main.rs:773:14:773:16 | &... | &T | main.rs:757:5:757:13 | S |
+| main.rs:773:15:773:16 | &x |  | file://:0:0:0:0 | & |
+| main.rs:773:15:773:16 | &x | &T | main.rs:757:5:757:13 | S |
+| main.rs:773:16:773:16 | x |  | file://:0:0:0:0 | & |
+| main.rs:773:16:773:16 | x | &T | main.rs:757:5:757:13 | S |
+| main.rs:778:13:778:13 | x |  | main.rs:757:5:757:13 | S |
+| main.rs:778:17:778:20 | S {...} |  | main.rs:757:5:757:13 | S |
+| main.rs:779:9:779:9 | x |  | main.rs:757:5:757:13 | S |
+| main.rs:779:9:779:14 | x.f1() |  | file://:0:0:0:0 | & |
+| main.rs:779:9:779:14 | x.f1() | &T | main.rs:757:5:757:13 | S |
+| main.rs:780:9:780:9 | x |  | main.rs:757:5:757:13 | S |
+| main.rs:780:9:780:14 | x.f2() |  | file://:0:0:0:0 | & |
+| main.rs:780:9:780:14 | x.f2() | &T | main.rs:757:5:757:13 | S |
+| main.rs:781:9:781:17 | ...::f3(...) |  | file://:0:0:0:0 | & |
+| main.rs:781:9:781:17 | ...::f3(...) | &T | main.rs:757:5:757:13 | S |
+| main.rs:781:15:781:16 | &x |  | file://:0:0:0:0 | & |
+| main.rs:781:15:781:16 | &x | &T | main.rs:757:5:757:13 | S |
+| main.rs:781:16:781:16 | x |  | main.rs:757:5:757:13 | S |
+| main.rs:787:5:787:20 | ...::f(...) |  | main.rs:67:5:67:21 | Foo |
+| main.rs:788:5:788:60 | ...::g(...) |  | main.rs:67:5:67:21 | Foo |
+| main.rs:788:20:788:38 | ...::Foo {...} |  | main.rs:67:5:67:21 | Foo |
+| main.rs:788:41:788:59 | ...::Foo {...} |  | main.rs:67:5:67:21 | Foo |

--- a/rust/ql/test/library-tests/type-inference/type-inference.ql
+++ b/rust/ql/test/library-tests/type-inference/type-inference.ql
@@ -11,9 +11,9 @@ module ResolveTest implements TestSig {
   string getARelevantTag() { result = ["method", "fieldof"] }
 
   private predicate functionHasValue(Function f, string value) {
-    f.getPrecedingComment().getCommentText() = value
+    f.getAPrecedingComment().getCommentText() = value
     or
-    not exists(f.getPrecedingComment()) and
+    not exists(f.getAPrecedingComment()) and
     value = f.getName().getText()
   }
 

--- a/rust/ql/test/library-tests/type-inference/type-inference.ql
+++ b/rust/ql/test/library-tests/type-inference/type-inference.ql
@@ -14,6 +14,7 @@ module ResolveTest implements TestSig {
     f.getAPrecedingComment().getCommentText() = value
     or
     not exists(f.getAPrecedingComment()) and
+    // TODO: Default to canonical path once that is available
     value = f.getName().getText()
   }
 

--- a/rust/ql/test/library-tests/type-inference/type-inference.ql
+++ b/rust/ql/test/library-tests/type-inference/type-inference.ql
@@ -1,18 +1,60 @@
 import rust
+import utils.test.InlineExpectationsTest
 import codeql.rust.internal.TypeInference as TypeInference
 import TypeInference
-import utils.test.InlineExpectationsTest
 
 query predicate inferType(AstNode n, TypePath path, Type t) {
   t = TypeInference::inferType(n, path)
 }
 
-query predicate resolveMethodCallExpr(MethodCallExpr mce, Function f) {
-  f = resolveMethodCallExpr(mce)
+module ResolveTest implements TestSig {
+  string getARelevantTag() { result = ["method", "fieldof"] }
+
+  private predicate functionHasValue(Function f, string value) {
+    f.getPrecedingComment().getCommentText() = value
+    or
+    not exists(f.getPrecedingComment()) and
+    value = f.getName().getText()
+  }
+
+  predicate hasActualResult(Location location, string element, string tag, string value) {
+    exists(AstNode source, AstNode target |
+      location = source.getLocation() and
+      element = source.toString()
+    |
+      target = resolveMethodCallExpr(source) and
+      functionHasValue(target, value) and
+      tag = "method"
+      or
+      target = resolveStructFieldExpr(source) and
+      any(Struct s | s.getStructField(_) = target).getName().getText() = value and
+      tag = "fieldof"
+      or
+      target = resolveTupleFieldExpr(source) and
+      any(Struct s | s.getTupleField(_) = target).getName().getText() = value and
+      tag = "fieldof"
+    )
+  }
 }
 
-query predicate resolveFieldExpr(FieldExpr fe, AstNode target) {
-  target = resolveStructFieldExpr(fe)
-  or
-  target = resolveTupleFieldExpr(fe)
+module TypeTest implements TestSig {
+  string getARelevantTag() { result = "type" }
+
+  predicate tagIsOptional(string expectedTag) { expectedTag = "type" }
+
+  predicate hasActualResult(Location location, string element, string tag, string value) { none() }
+
+  predicate hasOptionalResult(Location location, string element, string tag, string value) {
+    tag = "type" and
+    exists(AstNode n, TypePath path, Type t |
+      t = TypeInference::inferType(n, path) and
+      location = n.getLocation() and
+      element = n.toString() and
+      if path.isEmpty()
+      then value = element + ":" + t
+      else value = element + ":" + path.toString() + "." + t.toString()
+    )
+  }
 }
+
+import MakeTest<MergeTests<ResolveTest, TypeTest>>

--- a/rust/ql/test/library-tests/variables/Cfg.expected
+++ b/rust/ql/test/library-tests/variables/Cfg.expected
@@ -1312,8 +1312,8 @@ edges
 | main.rs:532:5:532:13 | print_i64 | main.rs:532:15:532:15 | a |  |
 | main.rs:532:5:532:25 | print_i64(...) | main.rs:533:5:533:14 | ExprStmt |  |
 | main.rs:532:5:532:26 | ExprStmt | main.rs:532:5:532:13 | print_i64 |  |
-| main.rs:532:15:532:15 | a | main.rs:532:15:532:24 | a.my_get(...) |  |
-| main.rs:532:15:532:24 | a.my_get(...) | main.rs:532:5:532:25 | print_i64(...) |  |
+| main.rs:532:15:532:15 | a | main.rs:532:15:532:24 | a.my_get() |  |
+| main.rs:532:15:532:24 | a.my_get() | main.rs:532:5:532:25 | print_i64(...) |  |
 | main.rs:533:5:533:5 | a | main.rs:533:5:533:9 | a.val |  |
 | main.rs:533:5:533:9 | a.val | main.rs:533:13:533:13 | 5 |  |
 | main.rs:533:5:533:13 | ... = ... | main.rs:534:5:534:26 | ExprStmt |  |
@@ -1322,8 +1322,8 @@ edges
 | main.rs:534:5:534:13 | print_i64 | main.rs:534:15:534:15 | a |  |
 | main.rs:534:5:534:25 | print_i64(...) | main.rs:535:5:535:28 | ExprStmt |  |
 | main.rs:534:5:534:26 | ExprStmt | main.rs:534:5:534:13 | print_i64 |  |
-| main.rs:534:15:534:15 | a | main.rs:534:15:534:24 | a.my_get(...) |  |
-| main.rs:534:15:534:24 | a.my_get(...) | main.rs:534:5:534:25 | print_i64(...) |  |
+| main.rs:534:15:534:15 | a | main.rs:534:15:534:24 | a.my_get() |  |
+| main.rs:534:15:534:24 | a.my_get() | main.rs:534:5:534:25 | print_i64(...) |  |
 | main.rs:535:5:535:5 | a | main.rs:535:25:535:25 | 2 |  |
 | main.rs:535:5:535:27 | ... = ... | main.rs:536:5:536:26 | ExprStmt |  |
 | main.rs:535:5:535:28 | ExprStmt | main.rs:535:5:535:5 | a |  |
@@ -1332,8 +1332,8 @@ edges
 | main.rs:536:5:536:13 | print_i64 | main.rs:536:15:536:15 | a |  |
 | main.rs:536:5:536:25 | print_i64(...) | main.rs:530:14:537:1 | { ... } |  |
 | main.rs:536:5:536:26 | ExprStmt | main.rs:536:5:536:13 | print_i64 |  |
-| main.rs:536:15:536:15 | a | main.rs:536:15:536:24 | a.my_get(...) |  |
-| main.rs:536:15:536:24 | a.my_get(...) | main.rs:536:5:536:25 | print_i64(...) |  |
+| main.rs:536:15:536:15 | a | main.rs:536:15:536:24 | a.my_get() |  |
+| main.rs:536:15:536:24 | a.my_get() | main.rs:536:5:536:25 | print_i64(...) |  |
 | main.rs:539:1:546:1 | enter fn arrays | main.rs:540:5:540:26 | let ... = ... |  |
 | main.rs:539:1:546:1 | exit fn arrays (normal) | main.rs:539:1:546:1 | exit fn arrays |  |
 | main.rs:539:13:546:1 | { ... } | main.rs:539:1:546:1 | exit fn arrays (normal) |  |
@@ -1419,8 +1419,8 @@ edges
 | main.rs:568:11:568:11 | a | main.rs:568:7:568:11 | mut a |  |
 | main.rs:568:15:568:33 | MyStruct {...} | main.rs:568:11:568:11 | a |  |
 | main.rs:568:31:568:31 | 1 | main.rs:568:15:568:33 | MyStruct {...} |  |
-| main.rs:569:3:569:3 | a | main.rs:569:3:569:9 | a.bar(...) |  |
-| main.rs:569:3:569:9 | a.bar(...) | main.rs:571:3:571:19 | ExprStmt |  |
+| main.rs:569:3:569:3 | a | main.rs:569:3:569:9 | a.bar() |  |
+| main.rs:569:3:569:9 | a.bar() | main.rs:571:3:571:19 | ExprStmt |  |
 | main.rs:569:3:569:10 | ExprStmt | main.rs:569:3:569:3 | a |  |
 | main.rs:571:3:571:11 | print_i64 | main.rs:571:13:571:13 | a |  |
 | main.rs:571:3:571:18 | print_i64(...) | main.rs:567:30:572:1 | { ... } |  |

--- a/rust/ql/test/query-tests/security/CWE-022/TaintedPath.expected
+++ b/rust/ql/test/query-tests/security/CWE-022/TaintedPath.expected
@@ -15,13 +15,13 @@ edges
 | src/main.rs:40:52:40:60 | file_path | src/main.rs:40:38:40:61 | ...::from(...) | provenance | MaD:4 |
 | src/main.rs:45:24:45:32 | file_path | src/main.rs:45:5:45:22 | ...::read_to_string | provenance | MaD:1 Sink:MaD:1 |
 | src/main.rs:50:11:50:19 | file_path | src/main.rs:53:52:53:60 | file_path | provenance |  |
-| src/main.rs:53:9:53:17 | file_path | src/main.rs:54:21:54:44 | file_path.canonicalize(...) [Ok] | provenance | Config |
+| src/main.rs:53:9:53:17 | file_path | src/main.rs:54:21:54:44 | file_path.canonicalize() [Ok] | provenance | Config |
 | src/main.rs:53:21:53:62 | public_path.join(...) | src/main.rs:53:9:53:17 | file_path | provenance |  |
 | src/main.rs:53:38:53:61 | ...::from(...) | src/main.rs:53:21:53:62 | public_path.join(...) | provenance | MaD:3 |
 | src/main.rs:53:52:53:60 | file_path | src/main.rs:53:38:53:61 | ...::from(...) | provenance | MaD:4 |
 | src/main.rs:54:9:54:17 | file_path | src/main.rs:59:24:59:32 | file_path | provenance |  |
-| src/main.rs:54:21:54:44 | file_path.canonicalize(...) [Ok] | src/main.rs:54:21:54:53 | ... .unwrap(...) | provenance | MaD:2 |
-| src/main.rs:54:21:54:53 | ... .unwrap(...) | src/main.rs:54:9:54:17 | file_path | provenance |  |
+| src/main.rs:54:21:54:44 | file_path.canonicalize() [Ok] | src/main.rs:54:21:54:53 | ... .unwrap() | provenance | MaD:2 |
+| src/main.rs:54:21:54:53 | ... .unwrap() | src/main.rs:54:9:54:17 | file_path | provenance |  |
 | src/main.rs:59:24:59:32 | file_path | src/main.rs:59:5:59:22 | ...::read_to_string | provenance | MaD:1 Sink:MaD:1 |
 models
 | 1 | Sink: lang:std; crate::fs::read_to_string; path-injection; Argument[0] |
@@ -48,8 +48,8 @@ nodes
 | src/main.rs:53:38:53:61 | ...::from(...) | semmle.label | ...::from(...) |
 | src/main.rs:53:52:53:60 | file_path | semmle.label | file_path |
 | src/main.rs:54:9:54:17 | file_path | semmle.label | file_path |
-| src/main.rs:54:21:54:44 | file_path.canonicalize(...) [Ok] | semmle.label | file_path.canonicalize(...) [Ok] |
-| src/main.rs:54:21:54:53 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
+| src/main.rs:54:21:54:44 | file_path.canonicalize() [Ok] | semmle.label | file_path.canonicalize() [Ok] |
+| src/main.rs:54:21:54:53 | ... .unwrap() | semmle.label | ... .unwrap() |
 | src/main.rs:59:5:59:22 | ...::read_to_string | semmle.label | ...::read_to_string |
 | src/main.rs:59:24:59:32 | file_path | semmle.label | file_path |
 subpaths

--- a/rust/ql/test/query-tests/security/CWE-089/SqlInjection.expected
+++ b/rust/ql/test/query-tests/security/CWE-089/SqlInjection.expected
@@ -1,31 +1,31 @@
 #select
-| sqlx.rs:62:26:62:46 | safe_query_3.as_str(...) | sqlx.rs:48:25:48:46 | ...::get | sqlx.rs:62:26:62:46 | safe_query_3.as_str(...) | This query depends on a $@. | sqlx.rs:48:25:48:46 | ...::get | user-provided value |
-| sqlx.rs:63:26:63:48 | unsafe_query_1.as_str(...) | sqlx.rs:47:22:47:35 | ...::args | sqlx.rs:63:26:63:48 | unsafe_query_1.as_str(...) | This query depends on a $@. | sqlx.rs:47:22:47:35 | ...::args | user-provided value |
-| sqlx.rs:65:30:65:52 | unsafe_query_2.as_str(...) | sqlx.rs:48:25:48:46 | ...::get | sqlx.rs:65:30:65:52 | unsafe_query_2.as_str(...) | This query depends on a $@. | sqlx.rs:48:25:48:46 | ...::get | user-provided value |
-| sqlx.rs:67:30:67:52 | unsafe_query_4.as_str(...) | sqlx.rs:48:25:48:46 | ...::get | sqlx.rs:67:30:67:52 | unsafe_query_4.as_str(...) | This query depends on a $@. | sqlx.rs:48:25:48:46 | ...::get | user-provided value |
-| sqlx.rs:73:25:73:45 | safe_query_3.as_str(...) | sqlx.rs:48:25:48:46 | ...::get | sqlx.rs:73:25:73:45 | safe_query_3.as_str(...) | This query depends on a $@. | sqlx.rs:48:25:48:46 | ...::get | user-provided value |
-| sqlx.rs:74:25:74:47 | unsafe_query_1.as_str(...) | sqlx.rs:47:22:47:35 | ...::args | sqlx.rs:74:25:74:47 | unsafe_query_1.as_str(...) | This query depends on a $@. | sqlx.rs:47:22:47:35 | ...::args | user-provided value |
-| sqlx.rs:76:29:76:51 | unsafe_query_2.as_str(...) | sqlx.rs:48:25:48:46 | ...::get | sqlx.rs:76:29:76:51 | unsafe_query_2.as_str(...) | This query depends on a $@. | sqlx.rs:48:25:48:46 | ...::get | user-provided value |
-| sqlx.rs:78:29:78:51 | unsafe_query_4.as_str(...) | sqlx.rs:48:25:48:46 | ...::get | sqlx.rs:78:29:78:51 | unsafe_query_4.as_str(...) | This query depends on a $@. | sqlx.rs:48:25:48:46 | ...::get | user-provided value |
+| sqlx.rs:62:26:62:46 | safe_query_3.as_str() | sqlx.rs:48:25:48:46 | ...::get | sqlx.rs:62:26:62:46 | safe_query_3.as_str() | This query depends on a $@. | sqlx.rs:48:25:48:46 | ...::get | user-provided value |
+| sqlx.rs:63:26:63:48 | unsafe_query_1.as_str() | sqlx.rs:47:22:47:35 | ...::args | sqlx.rs:63:26:63:48 | unsafe_query_1.as_str() | This query depends on a $@. | sqlx.rs:47:22:47:35 | ...::args | user-provided value |
+| sqlx.rs:65:30:65:52 | unsafe_query_2.as_str() | sqlx.rs:48:25:48:46 | ...::get | sqlx.rs:65:30:65:52 | unsafe_query_2.as_str() | This query depends on a $@. | sqlx.rs:48:25:48:46 | ...::get | user-provided value |
+| sqlx.rs:67:30:67:52 | unsafe_query_4.as_str() | sqlx.rs:48:25:48:46 | ...::get | sqlx.rs:67:30:67:52 | unsafe_query_4.as_str() | This query depends on a $@. | sqlx.rs:48:25:48:46 | ...::get | user-provided value |
+| sqlx.rs:73:25:73:45 | safe_query_3.as_str() | sqlx.rs:48:25:48:46 | ...::get | sqlx.rs:73:25:73:45 | safe_query_3.as_str() | This query depends on a $@. | sqlx.rs:48:25:48:46 | ...::get | user-provided value |
+| sqlx.rs:74:25:74:47 | unsafe_query_1.as_str() | sqlx.rs:47:22:47:35 | ...::args | sqlx.rs:74:25:74:47 | unsafe_query_1.as_str() | This query depends on a $@. | sqlx.rs:47:22:47:35 | ...::args | user-provided value |
+| sqlx.rs:76:29:76:51 | unsafe_query_2.as_str() | sqlx.rs:48:25:48:46 | ...::get | sqlx.rs:76:29:76:51 | unsafe_query_2.as_str() | This query depends on a $@. | sqlx.rs:48:25:48:46 | ...::get | user-provided value |
+| sqlx.rs:78:29:78:51 | unsafe_query_4.as_str() | sqlx.rs:48:25:48:46 | ...::get | sqlx.rs:78:29:78:51 | unsafe_query_4.as_str() | This query depends on a $@. | sqlx.rs:48:25:48:46 | ...::get | user-provided value |
 edges
 | sqlx.rs:47:9:47:18 | arg_string | sqlx.rs:53:27:53:36 | arg_string | provenance |  |
 | sqlx.rs:47:22:47:35 | ...::args | sqlx.rs:47:22:47:37 | ...::args(...) [element] | provenance | Src:MaD:1  |
 | sqlx.rs:47:22:47:37 | ...::args(...) [element] | sqlx.rs:47:22:47:44 | ... .nth(...) [Some] | provenance | MaD:10 |
 | sqlx.rs:47:22:47:44 | ... .nth(...) [Some] | sqlx.rs:47:22:47:77 | ... .unwrap_or(...) | provenance | MaD:5 |
 | sqlx.rs:47:22:47:77 | ... .unwrap_or(...) | sqlx.rs:47:9:47:18 | arg_string | provenance |  |
-| sqlx.rs:48:9:48:21 | remote_string | sqlx.rs:49:25:49:52 | remote_string.parse(...) [Ok] | provenance | MaD:8 |
+| sqlx.rs:48:9:48:21 | remote_string | sqlx.rs:49:25:49:52 | remote_string.parse() [Ok] | provenance | MaD:8 |
 | sqlx.rs:48:9:48:21 | remote_string | sqlx.rs:54:27:54:39 | remote_string | provenance |  |
 | sqlx.rs:48:9:48:21 | remote_string | sqlx.rs:56:34:56:89 | MacroExpr | provenance |  |
 | sqlx.rs:48:25:48:46 | ...::get | sqlx.rs:48:25:48:69 | ...::get(...) [Ok] | provenance | Src:MaD:2  |
-| sqlx.rs:48:25:48:69 | ...::get(...) [Ok] | sqlx.rs:48:25:48:78 | ... .unwrap(...) | provenance | MaD:6 |
-| sqlx.rs:48:25:48:78 | ... .unwrap(...) | sqlx.rs:48:25:48:85 | ... .text(...) [Ok] | provenance | MaD:11 |
-| sqlx.rs:48:25:48:85 | ... .text(...) [Ok] | sqlx.rs:48:25:48:118 | ... .unwrap_or(...) | provenance | MaD:7 |
+| sqlx.rs:48:25:48:69 | ...::get(...) [Ok] | sqlx.rs:48:25:48:78 | ... .unwrap() | provenance | MaD:6 |
+| sqlx.rs:48:25:48:78 | ... .unwrap() | sqlx.rs:48:25:48:85 | ... .text() [Ok] | provenance | MaD:11 |
+| sqlx.rs:48:25:48:85 | ... .text() [Ok] | sqlx.rs:48:25:48:118 | ... .unwrap_or(...) | provenance | MaD:7 |
 | sqlx.rs:48:25:48:118 | ... .unwrap_or(...) | sqlx.rs:48:9:48:21 | remote_string | provenance |  |
 | sqlx.rs:49:9:49:21 | remote_number | sqlx.rs:52:32:52:87 | MacroExpr | provenance |  |
-| sqlx.rs:49:25:49:52 | remote_string.parse(...) [Ok] | sqlx.rs:49:25:49:65 | ... .unwrap_or(...) | provenance | MaD:7 |
+| sqlx.rs:49:25:49:52 | remote_string.parse() [Ok] | sqlx.rs:49:25:49:65 | ... .unwrap_or(...) | provenance | MaD:7 |
 | sqlx.rs:49:25:49:65 | ... .unwrap_or(...) | sqlx.rs:49:9:49:21 | remote_number | provenance |  |
-| sqlx.rs:52:9:52:20 | safe_query_3 | sqlx.rs:62:26:62:46 | safe_query_3.as_str(...) | provenance | MaD:3 |
-| sqlx.rs:52:9:52:20 | safe_query_3 | sqlx.rs:73:25:73:45 | safe_query_3.as_str(...) | provenance | MaD:3 |
+| sqlx.rs:52:9:52:20 | safe_query_3 | sqlx.rs:62:26:62:46 | safe_query_3.as_str() | provenance | MaD:3 |
+| sqlx.rs:52:9:52:20 | safe_query_3 | sqlx.rs:73:25:73:45 | safe_query_3.as_str() | provenance | MaD:3 |
 | sqlx.rs:52:24:52:88 | res | sqlx.rs:52:32:52:87 | { ... } | provenance |  |
 | sqlx.rs:52:32:52:87 | ...::format(...) | sqlx.rs:52:24:52:88 | res | provenance |  |
 | sqlx.rs:52:32:52:87 | ...::must_use(...) | sqlx.rs:52:9:52:20 | safe_query_3 | provenance |  |
@@ -39,17 +39,17 @@ edges
 | sqlx.rs:54:9:54:22 | unsafe_query_2 [&ref] | sqlx.rs:76:29:76:42 | unsafe_query_2 [&ref] | provenance |  |
 | sqlx.rs:54:26:54:39 | &remote_string [&ref] | sqlx.rs:54:9:54:22 | unsafe_query_2 [&ref] | provenance |  |
 | sqlx.rs:54:27:54:39 | remote_string | sqlx.rs:54:26:54:39 | &remote_string [&ref] | provenance |  |
-| sqlx.rs:56:9:56:22 | unsafe_query_4 | sqlx.rs:67:30:67:52 | unsafe_query_4.as_str(...) | provenance | MaD:3 |
-| sqlx.rs:56:9:56:22 | unsafe_query_4 | sqlx.rs:78:29:78:51 | unsafe_query_4.as_str(...) | provenance | MaD:3 |
+| sqlx.rs:56:9:56:22 | unsafe_query_4 | sqlx.rs:67:30:67:52 | unsafe_query_4.as_str() | provenance | MaD:3 |
+| sqlx.rs:56:9:56:22 | unsafe_query_4 | sqlx.rs:78:29:78:51 | unsafe_query_4.as_str() | provenance | MaD:3 |
 | sqlx.rs:56:26:56:90 | res | sqlx.rs:56:34:56:89 | { ... } | provenance |  |
 | sqlx.rs:56:34:56:89 | ...::format(...) | sqlx.rs:56:26:56:90 | res | provenance |  |
 | sqlx.rs:56:34:56:89 | ...::must_use(...) | sqlx.rs:56:9:56:22 | unsafe_query_4 | provenance |  |
 | sqlx.rs:56:34:56:89 | MacroExpr | sqlx.rs:56:34:56:89 | ...::format(...) | provenance | MaD:4 |
 | sqlx.rs:56:34:56:89 | { ... } | sqlx.rs:56:34:56:89 | ...::must_use(...) | provenance | MaD:9 |
-| sqlx.rs:63:26:63:39 | unsafe_query_1 [&ref] | sqlx.rs:63:26:63:48 | unsafe_query_1.as_str(...) | provenance | MaD:3 |
-| sqlx.rs:65:30:65:43 | unsafe_query_2 [&ref] | sqlx.rs:65:30:65:52 | unsafe_query_2.as_str(...) | provenance | MaD:3 |
-| sqlx.rs:74:25:74:38 | unsafe_query_1 [&ref] | sqlx.rs:74:25:74:47 | unsafe_query_1.as_str(...) | provenance | MaD:3 |
-| sqlx.rs:76:29:76:42 | unsafe_query_2 [&ref] | sqlx.rs:76:29:76:51 | unsafe_query_2.as_str(...) | provenance | MaD:3 |
+| sqlx.rs:63:26:63:39 | unsafe_query_1 [&ref] | sqlx.rs:63:26:63:48 | unsafe_query_1.as_str() | provenance | MaD:3 |
+| sqlx.rs:65:30:65:43 | unsafe_query_2 [&ref] | sqlx.rs:65:30:65:52 | unsafe_query_2.as_str() | provenance | MaD:3 |
+| sqlx.rs:74:25:74:38 | unsafe_query_1 [&ref] | sqlx.rs:74:25:74:47 | unsafe_query_1.as_str() | provenance | MaD:3 |
+| sqlx.rs:76:29:76:42 | unsafe_query_2 [&ref] | sqlx.rs:76:29:76:51 | unsafe_query_2.as_str() | provenance | MaD:3 |
 models
 | 1 | Source: lang:std; crate::env::args; command-line-source; ReturnValue.Element |
 | 2 | Source: repo:https://github.com/seanmonstar/reqwest:reqwest; crate::blocking::get; remote; ReturnValue.Field[crate::result::Result::Ok(0)] |
@@ -71,11 +71,11 @@ nodes
 | sqlx.rs:48:9:48:21 | remote_string | semmle.label | remote_string |
 | sqlx.rs:48:25:48:46 | ...::get | semmle.label | ...::get |
 | sqlx.rs:48:25:48:69 | ...::get(...) [Ok] | semmle.label | ...::get(...) [Ok] |
-| sqlx.rs:48:25:48:78 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
-| sqlx.rs:48:25:48:85 | ... .text(...) [Ok] | semmle.label | ... .text(...) [Ok] |
+| sqlx.rs:48:25:48:78 | ... .unwrap() | semmle.label | ... .unwrap() |
+| sqlx.rs:48:25:48:85 | ... .text() [Ok] | semmle.label | ... .text() [Ok] |
 | sqlx.rs:48:25:48:118 | ... .unwrap_or(...) | semmle.label | ... .unwrap_or(...) |
 | sqlx.rs:49:9:49:21 | remote_number | semmle.label | remote_number |
-| sqlx.rs:49:25:49:52 | remote_string.parse(...) [Ok] | semmle.label | remote_string.parse(...) [Ok] |
+| sqlx.rs:49:25:49:52 | remote_string.parse() [Ok] | semmle.label | remote_string.parse() [Ok] |
 | sqlx.rs:49:25:49:65 | ... .unwrap_or(...) | semmle.label | ... .unwrap_or(...) |
 | sqlx.rs:52:9:52:20 | safe_query_3 | semmle.label | safe_query_3 |
 | sqlx.rs:52:24:52:88 | res | semmle.label | res |
@@ -95,16 +95,16 @@ nodes
 | sqlx.rs:56:34:56:89 | ...::must_use(...) | semmle.label | ...::must_use(...) |
 | sqlx.rs:56:34:56:89 | MacroExpr | semmle.label | MacroExpr |
 | sqlx.rs:56:34:56:89 | { ... } | semmle.label | { ... } |
-| sqlx.rs:62:26:62:46 | safe_query_3.as_str(...) | semmle.label | safe_query_3.as_str(...) |
+| sqlx.rs:62:26:62:46 | safe_query_3.as_str() | semmle.label | safe_query_3.as_str() |
 | sqlx.rs:63:26:63:39 | unsafe_query_1 [&ref] | semmle.label | unsafe_query_1 [&ref] |
-| sqlx.rs:63:26:63:48 | unsafe_query_1.as_str(...) | semmle.label | unsafe_query_1.as_str(...) |
+| sqlx.rs:63:26:63:48 | unsafe_query_1.as_str() | semmle.label | unsafe_query_1.as_str() |
 | sqlx.rs:65:30:65:43 | unsafe_query_2 [&ref] | semmle.label | unsafe_query_2 [&ref] |
-| sqlx.rs:65:30:65:52 | unsafe_query_2.as_str(...) | semmle.label | unsafe_query_2.as_str(...) |
-| sqlx.rs:67:30:67:52 | unsafe_query_4.as_str(...) | semmle.label | unsafe_query_4.as_str(...) |
-| sqlx.rs:73:25:73:45 | safe_query_3.as_str(...) | semmle.label | safe_query_3.as_str(...) |
+| sqlx.rs:65:30:65:52 | unsafe_query_2.as_str() | semmle.label | unsafe_query_2.as_str() |
+| sqlx.rs:67:30:67:52 | unsafe_query_4.as_str() | semmle.label | unsafe_query_4.as_str() |
+| sqlx.rs:73:25:73:45 | safe_query_3.as_str() | semmle.label | safe_query_3.as_str() |
 | sqlx.rs:74:25:74:38 | unsafe_query_1 [&ref] | semmle.label | unsafe_query_1 [&ref] |
-| sqlx.rs:74:25:74:47 | unsafe_query_1.as_str(...) | semmle.label | unsafe_query_1.as_str(...) |
+| sqlx.rs:74:25:74:47 | unsafe_query_1.as_str() | semmle.label | unsafe_query_1.as_str() |
 | sqlx.rs:76:29:76:42 | unsafe_query_2 [&ref] | semmle.label | unsafe_query_2 [&ref] |
-| sqlx.rs:76:29:76:51 | unsafe_query_2.as_str(...) | semmle.label | unsafe_query_2.as_str(...) |
-| sqlx.rs:78:29:78:51 | unsafe_query_4.as_str(...) | semmle.label | unsafe_query_4.as_str(...) |
+| sqlx.rs:76:29:76:51 | unsafe_query_2.as_str() | semmle.label | unsafe_query_2.as_str() |
+| sqlx.rs:78:29:78:51 | unsafe_query_4.as_str() | semmle.label | unsafe_query_4.as_str() |
 subpaths

--- a/rust/ql/test/query-tests/security/CWE-311/CleartextTransmission.expected
+++ b/rust/ql/test/query-tests/security/CWE-311/CleartextTransmission.expected
@@ -21,8 +21,8 @@ edges
 | main.rs:12:27:12:59 | { ... } | main.rs:12:27:12:59 | ...::must_use(...) | provenance | MaD:7 |
 | main.rs:12:50:12:57 | password | main.rs:12:27:12:59 | MacroExpr | provenance |  |
 | main.rs:13:9:13:11 | url | main.rs:14:28:14:30 | url | provenance |  |
-| main.rs:13:15:13:34 | ...::parse(...) [Ok] | main.rs:13:15:13:43 | ... .unwrap(...) | provenance | MaD:6 |
-| main.rs:13:15:13:43 | ... .unwrap(...) | main.rs:13:9:13:11 | url | provenance |  |
+| main.rs:13:15:13:34 | ...::parse(...) [Ok] | main.rs:13:15:13:43 | ... .unwrap() | provenance | MaD:6 |
+| main.rs:13:15:13:43 | ... .unwrap() | main.rs:13:9:13:11 | url | provenance |  |
 | main.rs:13:26:13:33 | &address [&ref] | main.rs:13:15:13:34 | ...::parse(...) [Ok] | provenance | MaD:8 |
 | main.rs:13:27:13:33 | address | main.rs:13:26:13:33 | &address [&ref] | provenance |  |
 | main.rs:14:28:14:30 | url | main.rs:14:5:14:26 | ...::get | provenance | MaD:4 Sink:MaD:4 |
@@ -78,7 +78,7 @@ nodes
 | main.rs:12:50:12:57 | password | semmle.label | password |
 | main.rs:13:9:13:11 | url | semmle.label | url |
 | main.rs:13:15:13:34 | ...::parse(...) [Ok] | semmle.label | ...::parse(...) [Ok] |
-| main.rs:13:15:13:43 | ... .unwrap(...) | semmle.label | ... .unwrap(...) |
+| main.rs:13:15:13:43 | ... .unwrap() | semmle.label | ... .unwrap() |
 | main.rs:13:26:13:33 | &address [&ref] | semmle.label | &address [&ref] |
 | main.rs:13:27:13:33 | address | semmle.label | address |
 | main.rs:14:5:14:26 | ...::get | semmle.label | ...::get |

--- a/rust/ql/test/query-tests/security/CWE-312/CleartextLogging.expected
+++ b/rust/ql/test/query-tests/security/CWE-312/CleartextLogging.expected
@@ -181,37 +181,37 @@ edges
 | test_logging.rs:167:40:167:63 | MacroExpr | test_logging.rs:167:40:167:63 | ...::Some(...) [Some] | provenance |  |
 | test_logging.rs:167:56:167:63 | password | test_logging.rs:167:40:167:63 | MacroExpr | provenance |  |
 | test_logging.rs:168:34:168:66 | res | test_logging.rs:168:42:168:65 | { ... } | provenance |  |
-| test_logging.rs:168:34:168:75 | ... .as_str(...) | test_logging.rs:168:27:168:32 | expect | provenance | MaD:1 Sink:MaD:1 |
+| test_logging.rs:168:34:168:75 | ... .as_str() | test_logging.rs:168:27:168:32 | expect | provenance | MaD:1 Sink:MaD:1 |
 | test_logging.rs:168:42:168:65 | ...::format(...) | test_logging.rs:168:34:168:66 | res | provenance |  |
-| test_logging.rs:168:42:168:65 | ...::must_use(...) | test_logging.rs:168:34:168:75 | ... .as_str(...) | provenance | MaD:12 |
+| test_logging.rs:168:42:168:65 | ...::must_use(...) | test_logging.rs:168:34:168:75 | ... .as_str() | provenance | MaD:12 |
 | test_logging.rs:168:42:168:65 | MacroExpr | test_logging.rs:168:42:168:65 | ...::format(...) | provenance | MaD:13 |
 | test_logging.rs:168:42:168:65 | { ... } | test_logging.rs:168:42:168:65 | ...::must_use(...) | provenance | MaD:14 |
 | test_logging.rs:168:58:168:65 | password | test_logging.rs:168:42:168:65 | MacroExpr | provenance |  |
 | test_logging.rs:174:36:174:70 | res | test_logging.rs:174:44:174:69 | { ... } | provenance |  |
-| test_logging.rs:174:36:174:81 | ... .as_bytes(...) | test_logging.rs:174:30:174:34 | write | provenance | MaD:5 Sink:MaD:5 |
+| test_logging.rs:174:36:174:81 | ... .as_bytes() | test_logging.rs:174:30:174:34 | write | provenance | MaD:5 Sink:MaD:5 |
 | test_logging.rs:174:44:174:69 | ...::format(...) | test_logging.rs:174:36:174:70 | res | provenance |  |
-| test_logging.rs:174:44:174:69 | ...::must_use(...) | test_logging.rs:174:36:174:81 | ... .as_bytes(...) | provenance | MaD:11 |
+| test_logging.rs:174:44:174:69 | ...::must_use(...) | test_logging.rs:174:36:174:81 | ... .as_bytes() | provenance | MaD:11 |
 | test_logging.rs:174:44:174:69 | MacroExpr | test_logging.rs:174:44:174:69 | ...::format(...) | provenance | MaD:13 |
 | test_logging.rs:174:44:174:69 | { ... } | test_logging.rs:174:44:174:69 | ...::must_use(...) | provenance | MaD:14 |
 | test_logging.rs:174:62:174:69 | password | test_logging.rs:174:44:174:69 | MacroExpr | provenance |  |
 | test_logging.rs:175:40:175:74 | res | test_logging.rs:175:48:175:73 | { ... } | provenance |  |
-| test_logging.rs:175:40:175:85 | ... .as_bytes(...) | test_logging.rs:175:30:175:38 | write_all | provenance | MaD:6 Sink:MaD:6 |
+| test_logging.rs:175:40:175:85 | ... .as_bytes() | test_logging.rs:175:30:175:38 | write_all | provenance | MaD:6 Sink:MaD:6 |
 | test_logging.rs:175:48:175:73 | ...::format(...) | test_logging.rs:175:40:175:74 | res | provenance |  |
-| test_logging.rs:175:48:175:73 | ...::must_use(...) | test_logging.rs:175:40:175:85 | ... .as_bytes(...) | provenance | MaD:11 |
+| test_logging.rs:175:48:175:73 | ...::must_use(...) | test_logging.rs:175:40:175:85 | ... .as_bytes() | provenance | MaD:11 |
 | test_logging.rs:175:48:175:73 | MacroExpr | test_logging.rs:175:48:175:73 | ...::format(...) | provenance | MaD:13 |
 | test_logging.rs:175:48:175:73 | { ... } | test_logging.rs:175:48:175:73 | ...::must_use(...) | provenance | MaD:14 |
 | test_logging.rs:175:66:175:73 | password | test_logging.rs:175:48:175:73 | MacroExpr | provenance |  |
 | test_logging.rs:178:15:178:49 | res | test_logging.rs:178:23:178:48 | { ... } | provenance |  |
-| test_logging.rs:178:15:178:60 | ... .as_bytes(...) | test_logging.rs:178:9:178:13 | write | provenance | MaD:5 Sink:MaD:5 |
+| test_logging.rs:178:15:178:60 | ... .as_bytes() | test_logging.rs:178:9:178:13 | write | provenance | MaD:5 Sink:MaD:5 |
 | test_logging.rs:178:23:178:48 | ...::format(...) | test_logging.rs:178:15:178:49 | res | provenance |  |
-| test_logging.rs:178:23:178:48 | ...::must_use(...) | test_logging.rs:178:15:178:60 | ... .as_bytes(...) | provenance | MaD:11 |
+| test_logging.rs:178:23:178:48 | ...::must_use(...) | test_logging.rs:178:15:178:60 | ... .as_bytes() | provenance | MaD:11 |
 | test_logging.rs:178:23:178:48 | MacroExpr | test_logging.rs:178:23:178:48 | ...::format(...) | provenance | MaD:13 |
 | test_logging.rs:178:23:178:48 | { ... } | test_logging.rs:178:23:178:48 | ...::must_use(...) | provenance | MaD:14 |
 | test_logging.rs:178:41:178:48 | password | test_logging.rs:178:23:178:48 | MacroExpr | provenance |  |
 | test_logging.rs:181:15:181:49 | res | test_logging.rs:181:23:181:48 | { ... } | provenance |  |
-| test_logging.rs:181:15:181:60 | ... .as_bytes(...) | test_logging.rs:181:9:181:13 | write | provenance | MaD:4 Sink:MaD:4 |
+| test_logging.rs:181:15:181:60 | ... .as_bytes() | test_logging.rs:181:9:181:13 | write | provenance | MaD:4 Sink:MaD:4 |
 | test_logging.rs:181:23:181:48 | ...::format(...) | test_logging.rs:181:15:181:49 | res | provenance |  |
-| test_logging.rs:181:23:181:48 | ...::must_use(...) | test_logging.rs:181:15:181:60 | ... .as_bytes(...) | provenance | MaD:11 |
+| test_logging.rs:181:23:181:48 | ...::must_use(...) | test_logging.rs:181:15:181:60 | ... .as_bytes() | provenance | MaD:11 |
 | test_logging.rs:181:23:181:48 | MacroExpr | test_logging.rs:181:23:181:48 | ...::format(...) | provenance | MaD:13 |
 | test_logging.rs:181:23:181:48 | { ... } | test_logging.rs:181:23:181:48 | ...::must_use(...) | provenance | MaD:14 |
 | test_logging.rs:181:41:181:48 | password | test_logging.rs:181:23:181:48 | MacroExpr | provenance |  |
@@ -400,7 +400,7 @@ nodes
 | test_logging.rs:167:56:167:63 | password | semmle.label | password |
 | test_logging.rs:168:27:168:32 | expect | semmle.label | expect |
 | test_logging.rs:168:34:168:66 | res | semmle.label | res |
-| test_logging.rs:168:34:168:75 | ... .as_str(...) | semmle.label | ... .as_str(...) |
+| test_logging.rs:168:34:168:75 | ... .as_str() | semmle.label | ... .as_str() |
 | test_logging.rs:168:42:168:65 | ...::format(...) | semmle.label | ...::format(...) |
 | test_logging.rs:168:42:168:65 | ...::must_use(...) | semmle.label | ...::must_use(...) |
 | test_logging.rs:168:42:168:65 | MacroExpr | semmle.label | MacroExpr |
@@ -408,7 +408,7 @@ nodes
 | test_logging.rs:168:58:168:65 | password | semmle.label | password |
 | test_logging.rs:174:30:174:34 | write | semmle.label | write |
 | test_logging.rs:174:36:174:70 | res | semmle.label | res |
-| test_logging.rs:174:36:174:81 | ... .as_bytes(...) | semmle.label | ... .as_bytes(...) |
+| test_logging.rs:174:36:174:81 | ... .as_bytes() | semmle.label | ... .as_bytes() |
 | test_logging.rs:174:44:174:69 | ...::format(...) | semmle.label | ...::format(...) |
 | test_logging.rs:174:44:174:69 | ...::must_use(...) | semmle.label | ...::must_use(...) |
 | test_logging.rs:174:44:174:69 | MacroExpr | semmle.label | MacroExpr |
@@ -416,7 +416,7 @@ nodes
 | test_logging.rs:174:62:174:69 | password | semmle.label | password |
 | test_logging.rs:175:30:175:38 | write_all | semmle.label | write_all |
 | test_logging.rs:175:40:175:74 | res | semmle.label | res |
-| test_logging.rs:175:40:175:85 | ... .as_bytes(...) | semmle.label | ... .as_bytes(...) |
+| test_logging.rs:175:40:175:85 | ... .as_bytes() | semmle.label | ... .as_bytes() |
 | test_logging.rs:175:48:175:73 | ...::format(...) | semmle.label | ...::format(...) |
 | test_logging.rs:175:48:175:73 | ...::must_use(...) | semmle.label | ...::must_use(...) |
 | test_logging.rs:175:48:175:73 | MacroExpr | semmle.label | MacroExpr |
@@ -424,7 +424,7 @@ nodes
 | test_logging.rs:175:66:175:73 | password | semmle.label | password |
 | test_logging.rs:178:9:178:13 | write | semmle.label | write |
 | test_logging.rs:178:15:178:49 | res | semmle.label | res |
-| test_logging.rs:178:15:178:60 | ... .as_bytes(...) | semmle.label | ... .as_bytes(...) |
+| test_logging.rs:178:15:178:60 | ... .as_bytes() | semmle.label | ... .as_bytes() |
 | test_logging.rs:178:23:178:48 | ...::format(...) | semmle.label | ...::format(...) |
 | test_logging.rs:178:23:178:48 | ...::must_use(...) | semmle.label | ...::must_use(...) |
 | test_logging.rs:178:23:178:48 | MacroExpr | semmle.label | MacroExpr |
@@ -432,7 +432,7 @@ nodes
 | test_logging.rs:178:41:178:48 | password | semmle.label | password |
 | test_logging.rs:181:9:181:13 | write | semmle.label | write |
 | test_logging.rs:181:15:181:49 | res | semmle.label | res |
-| test_logging.rs:181:15:181:60 | ... .as_bytes(...) | semmle.label | ... .as_bytes(...) |
+| test_logging.rs:181:15:181:60 | ... .as_bytes() | semmle.label | ... .as_bytes() |
 | test_logging.rs:181:23:181:48 | ...::format(...) | semmle.label | ...::format(...) |
 | test_logging.rs:181:23:181:48 | ...::must_use(...) | semmle.label | ...::must_use(...) |
 | test_logging.rs:181:23:181:48 | MacroExpr | semmle.label | MacroExpr |


### PR DESCRIPTION
Adds inline expectations tests for type inference.

The annotations for resolved method calls and field expressions are pretty straightforward and the annotations now subsume what we had in the expected file before.

I've also added annotations for inferred types. We obviously don't want to annotate every single expression, so these annotations are optional and can be used in important places only. These annotations depend on stringifying AST nodes which can be a bit annoying, but I don't think it's too bad is we only use them sparingly and can write the tests with that in mind.

Let's merge at least #19146 before this.