### PR TITLE
Add @ps-codeql to CODEOWNERS for experimental cryptography

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -14,6 +14,9 @@
 /java/ql/test-kotlin1/ @github/codeql-kotlin
 /java/ql/test-kotlin2/ @github/codeql-kotlin
 
+# Experimental CodeQL cryptography
+**/experimental/quantum/ @github/ps-codeql
+
 # CodeQL tools and associated docs
 /docs/codeql/codeql-cli/ @github/codeql-cli-reviewers
 /docs/codeql/codeql-for-visual-studio-code/ @github/codeql-vscode-reviewers


### PR DESCRIPTION
This pull request adds @github/ps-codeql as a code owner of `**/experimental/quantum/` to support the development of post-quantum cryptography-related libraries and queries.

We’ll be committing stable but experimental work to these directories as it becomes ready for public use, with a near-term goal of moving it out of experimental.

To get started, we’d also need write access to `github/codeql`.

cc @adityasharad @lcartey