### PR TITLE
Support post-procesed inline expectations for query predicates in unit tests

### DIFF
--- a/javascript/ql/test/library-tests/SensitiveActions/tests.expected
+++ b/javascript/ql/test/library-tests/SensitiveActions/tests.expected
@@ -31,14 +31,14 @@ sensitiveAction
 | tst.js:23:1:23:25 | require ... .exit() |
 | tst.js:24:1:24:21 | global. ... .exit() |
 sensitiveExpr
-| tst.js:1:1:1:8 | password |
-| tst.js:2:1:2:8 | PassWord |
-| tst.js:3:1:3:21 | myPassw ... eartext |
-| tst.js:4:1:4:10 | x.password |
-| tst.js:5:1:5:11 | getPassword |
-| tst.js:5:1:5:13 | getPassword() |
-| tst.js:6:1:6:13 | x.getPassword |
-| tst.js:6:1:6:15 | x.getPassword() |
-| tst.js:7:1:7:15 | get("password") |
-| tst.js:8:1:8:17 | x.get("password") |
-| tst.js:21:1:21:6 | secret |
+| tst.js:1:1:1:8 | password | password |
+| tst.js:2:1:2:8 | PassWord | password |
+| tst.js:3:1:3:21 | myPassw ... eartext | password |
+| tst.js:4:1:4:10 | x.password | password |
+| tst.js:5:1:5:11 | getPassword | password |
+| tst.js:5:1:5:13 | getPassword() | password |
+| tst.js:6:1:6:13 | x.getPassword | password |
+| tst.js:6:1:6:15 | x.getPassword() | password |
+| tst.js:7:1:7:15 | get("password") | password |
+| tst.js:8:1:8:17 | x.get("password") | password |
+| tst.js:21:1:21:6 | secret | secret |

--- a/javascript/ql/test/library-tests/SensitiveActions/tests.ql
+++ b/javascript/ql/test/library-tests/SensitiveActions/tests.ql
@@ -20,4 +20,4 @@ query predicate processTermination(NodeJSLib::ProcessTermination term) { any() }
 
 query predicate sensitiveAction(SensitiveAction ac) { any() }
 
-query predicate sensitiveExpr(SensitiveNode e) { any() }
+query predicate sensitiveExpr(SensitiveNode e, string kind) { kind = e.getClassification() }

--- a/javascript/ql/test/library-tests/SensitiveActions/tests.qlref
+++ b/javascript/ql/test/library-tests/SensitiveActions/tests.qlref
@@ -1,0 +1,2 @@
+query: tests.ql
+postprocess: utils/test/InlineExpectationsTestQuery.ql

--- a/javascript/ql/test/library-tests/SensitiveActions/tst.js
+++ b/javascript/ql/test/library-tests/SensitiveActions/tst.js
@@ -1,11 +1,11 @@
-password;
-PassWord;
-myPasswordInCleartext;
-x.password;
-getPassword();
-x.getPassword();
-get("password");
-x.get("password");
+password; // $ cleartextPasswordExpr sensitiveExpr=password
+PassWord; // $ cleartextPasswordExpr sensitiveExpr=password
+myPasswordInCleartext; // $ cleartextPasswordExpr sensitiveExpr=password
+x.password; // $ cleartextPasswordExpr sensitiveExpr=password
+getPassword(); // $ cleartextPasswordExpr sensitiveExpr=password
+x.getPassword(); // $ cleartextPasswordExpr sensitiveExpr=password
+get("password"); // $ cleartextPasswordExpr sensitiveExpr=password
+x.get("password"); // $ cleartextPasswordExpr sensitiveExpr=password
 
 hashed_password;
 password_hashed;
@@ -15,13 +15,13 @@ hashedPassword;
 
 var exit = require('exit');
 var e = process.exit;
-e();
-exit();
+e(); // $ processTermination sensitiveAction
+exit(); // $ processTermination sensitiveAction
 
-secret;
+secret; // $ sensitiveExpr=secret
 
-require("process").exit();
-global.process.exit();
+require("process").exit(); // $ processTermination sensitiveAction
+global.process.exit(); // $ processTermination sensitiveAction
 
 get("https://example.com/news?password=true")
 get("https://username:password@example.com")


### PR DESCRIPTION
This adds a low-friction way to add inline expectations to a unit test.

Any `.ql` file in a test folder can now use inline expectations without doing the dance of importing and instantiating a parameterised module.

## Example
Suppose we have a file `test.ql` with this content:
```codeql
import javascript
import semmle.javascript.security.SensitiveActions

query predicate sensitiveExpr(SensitiveNode e, string kind) { kind = e.getClassification() }

query predicate processTermination(NodeJSLib::ProcessTermination term) { any() }
```
We can now add a `test.qlref` in the same folder with the contents:
```yml
query: tests.ql
postprocess: utils/test/InlineExpectationsTestQuery.ql
```
And now the test will run with inline expectation checking. For example the test file might look like this:
```js
x.get("password"); // $ sensitiveExpr=password
process.exit(); // $ processTermination
```
That is, the query predicate name becomes the tag, its first column the location, and the second column, if present, is the value.

## Details
- The name of a query predicate becomes the tag.
- The first column, which should be an entity type, becomes the location.
- The second column, which should be a primitive type like `string`, becomes the value. This column may be omitted.
- Predicates with the wrong number of columns are simply ignored.
- The query must have no query kind for this to take effect. Queries of kind `problem` or `path-problem` are already supported in their own way.

This PR ports a single test to use this in order to keep the PR small while ensuring the behaviour is exercised.