### PR TITLE
Rust: Minor path resolution fix for `($)crate` paths

### DIFF
--- a/rust/ql/lib/codeql/rust/internal/PathResolution.qll
+++ b/rust/ql/lib/codeql/rust/internal/PathResolution.qll
@@ -194,21 +194,11 @@ abstract class ItemNode extends Locatable {
     this = result.(ImplOrTraitItemNode).getAnItemInSelfScope()
     or
     name = "crate" and
-    result =
-      any(CrateItemNode crate |
-        this = crate.getASourceFile()
-        or
-        this = crate.getModuleNode()
-      )
+    this = result.(CrateItemNode).getARootModuleNode()
     or
     // todo: implement properly
     name = "$crate" and
-    result =
-      any(CrateItemNode crate |
-        this = crate.getASourceFile()
-        or
-        this = crate.getModuleNode()
-      ).(Crate).getADependency*() and
+    result = any(CrateItemNode crate | this = crate.getARootModuleNode()).(Crate).getADependency*() and
     result.(CrateItemNode).isPotentialDollarCrateTarget()
   }
 
@@ -237,7 +227,7 @@ abstract private class ModuleLikeNode extends ItemNode {
   predicate isRoot() {
     this instanceof SourceFileItemNode
     or
-    this = any(CrateItemNode c).getModuleNode()
+    this = any(Crate c).getModule()
   }
 }
 
@@ -292,6 +282,15 @@ class CrateItemNode extends ItemNode instanceof Crate {
       fileImport(mod, result) and
       not result = any(Crate other).getSourceFile()
     )
+  }
+
+  /**
+   * Gets a root module node belonging to this crate.
+   */
+  ModuleLikeNode getARootModuleNode() {
+    result = this.getASourceFile()
+    or
+    result = super.getModule()
   }
 
   pragma[nomagic]


### PR DESCRIPTION
Only matters to `rust-lang/rust`, where the prelude exists in both source code and in the crate graph, so we need to handle both.