### PR TITLE
C++: Parameters can have a static specifier but are not static

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/Parameter.qll
+++ b/cpp/ql/lib/semmle/code/cpp/Parameter.qll
@@ -157,6 +157,8 @@ class Parameter extends LocalScopeVariable, @parameter {
       vde.isDefinition() or not this.getAnEffectiveDeclarationEntry().isDefinition()
     )
   }
+
+  override predicate isStatic() { none() }
 }
 
 /**

--- a/cpp/ql/test/library-tests/ir/ir/PrintAST.expected
+++ b/cpp/ql/test/library-tests/ir/ir/PrintAST.expected
@@ -236,6 +236,202 @@ bad_stmts.cpp:
 #    8|             Type = [ErroneousType] error
 #    8|             ValueCategory = prvalue(load)
 #    9|     getStmt(3): [ReturnStmt] return ...
+c11.c:
+#    1| [TopLevelFunction] void c11_generic_test_with_load(unsigned int, int)
+#    1|   <params>: 
+#    1|     getParameter(0): [Parameter] x
+#    1|         Type = [IntType] unsigned int
+#    1|     getParameter(1): [Parameter] y
+#    1|         Type = [IntType] int
+#    1|   getEntryPoint(): [BlockStmt] { ... }
+#    2|     getStmt(0): [DeclStmt] declaration
+#    2|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of r
+#    2|           Type = [IntType] unsigned int
+#    3|     getStmt(1): [ExprStmt] ExprStmt
+#    3|       getExpr(): [AssignExpr] ... = ...
+#    3|           Type = [IntType] unsigned int
+#    3|           ValueCategory = prvalue
+#    3|         getLValue(): [VariableAccess] r
+#    3|             Type = [IntType] unsigned int
+#    3|             ValueCategory = lvalue
+#    3|         getRValue(): [AddExpr] ... + ...
+#    3|             Type = [IntType] unsigned int
+#    3|             ValueCategory = prvalue
+#    3|           getLeftOperand(): [VariableAccess] x
+#    3|               Type = [IntType] unsigned int
+#    3|               ValueCategory = prvalue(load)
+#    3|           getRightOperand(): [Literal] 1
+#    3|               Type = [IntType] int
+#    3|               Value = [Literal] 1
+#    3|               ValueCategory = prvalue
+#    3|           getLeftOperand().getFullyConverted(): [C11GenericExpr] _Generic
+#    3|               Type = [IntType] unsigned int
+#    3|               ValueCategory = prvalue(load)
+#    3|             getControllingExpr(): [VariableAccess] r
+#    3|                 Type = [IntType] unsigned int
+#    3|                 ValueCategory = prvalue(load)
+#    3|             getAssociationType(0): [TypeName] unsigned int
+#    3|                 Type = [IntType] unsigned int
+#    3|                 ValueCategory = prvalue
+#    3|             getAssociationExpr(0): [ReuseExpr] reuse of x
+#    3|                 Type = [IntType] unsigned int
+#    3|                 ValueCategory = lvalue
+#    3|             getAssociationType(1): [TypeName] int
+#    3|                 Type = [IntType] int
+#    3|                 ValueCategory = prvalue
+#    3|             getAssociationExpr(1): [VariableAccess] y
+#    3|                 Type = [IntType] int
+#    3|                 ValueCategory = lvalue
+#    3|           getRightOperand().getFullyConverted(): [CStyleCast] (unsigned int)...
+#    3|               Conversion = [IntegralConversion] integral conversion
+#    3|               Type = [IntType] unsigned int
+#    3|               Value = [CStyleCast] 1
+#    3|               ValueCategory = prvalue
+#    4|     getStmt(2): [ReturnStmt] return ...
+#   12| [TopLevelFunction] char const* c11_generic_test_with_constant_and_macro()
+#   12|   <params>: 
+#   13|   getEntryPoint(): [BlockStmt] { ... }
+#   14|     getStmt(0): [DeclStmt] declaration
+#   14|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of i
+#   14|           Type = [IntType] int
+#   16|     getStmt(1): [ReturnStmt] return ...
+#   16|       getExpr(): int
+#   16|           Type = [ArrayType] char[4]
+#   16|           Value = [StringLiteral] "int"
+#   16|           ValueCategory = lvalue
+#   16|       getExpr().getFullyConverted(): [CStyleCast] (const char *)...
+#   16|           Conversion = [PointerConversion] pointer conversion
+#   16|           Type = [PointerType] const char *
+#   16|           ValueCategory = prvalue
+#   16|         getExpr(): [ArrayToPointerConversion] array to pointer conversion
+#   16|             Type = [CharPointerType] char *
+#   16|             ValueCategory = prvalue
+#   16|           getExpr(): [C11GenericExpr] _Generic
+#   16|               Type = [ArrayType] char[4]
+#   16|               Value = [C11GenericExpr] int
+#   16|               ValueCategory = lvalue
+#   16|             getControllingExpr(): [VariableAccess] i
+#   16|                 Type = [IntType] int
+#   16|                 ValueCategory = prvalue(load)
+#   16|             getAssociationType(0): [TypeName] int
+#   16|                 Type = [IntType] int
+#   16|                 ValueCategory = prvalue
+#   16|             getAssociationExpr(0): [ReuseExpr] reuse of int
+#   16|                 Type = [ArrayType] char[4]
+#   16|                 ValueCategory = lvalue
+#   16|             getAssociationType(1): [TypeName] void
+#   16|                 Type = [VoidType] void
+#   16|                 ValueCategory = prvalue
+#   16|             getAssociationExpr(1): unknown
+#   16|                 Type = [ArrayType] char[8]
+#   16|                 Value = [StringLiteral] "unknown"
+#   16|                 ValueCategory = lvalue
+#   16|             getControllingExpr().getFullyConverted(): [ParenthesisExpr] (...)
+#   16|                 Type = [IntType] int
+#   16|                 ValueCategory = prvalue(load)
+#   19| [TopLevelFunction] char const* c11_generic_test_with_constant_and_no_macro()
+#   19|   <params>: 
+#   20|   getEntryPoint(): [BlockStmt] { ... }
+#   21|     getStmt(0): [DeclStmt] declaration
+#   21|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of i
+#   21|           Type = [IntType] int
+#   23|     getStmt(1): [ReturnStmt] return ...
+#   23|       getExpr(): int
+#   23|           Type = [ArrayType] char[4]
+#   23|           Value = [StringLiteral] "int"
+#   23|           ValueCategory = lvalue
+#   23|       getExpr().getFullyConverted(): [CStyleCast] (const char *)...
+#   23|           Conversion = [PointerConversion] pointer conversion
+#   23|           Type = [PointerType] const char *
+#   23|           ValueCategory = prvalue
+#   23|         getExpr(): [ArrayToPointerConversion] array to pointer conversion
+#   23|             Type = [CharPointerType] char *
+#   23|             ValueCategory = prvalue
+#   23|           getExpr(): [C11GenericExpr] _Generic
+#   23|               Type = [ArrayType] char[4]
+#   23|               Value = [C11GenericExpr] int
+#   23|               ValueCategory = lvalue
+#   23|             getControllingExpr(): [VariableAccess] i
+#   23|                 Type = [IntType] int
+#   23|                 ValueCategory = prvalue(load)
+#   23|             getAssociationType(0): [TypeName] int
+#   23|                 Type = [IntType] int
+#   23|                 ValueCategory = prvalue
+#   23|             getAssociationExpr(0): [ReuseExpr] reuse of int
+#   23|                 Type = [ArrayType] char[4]
+#   23|                 ValueCategory = lvalue
+#   23|             getAssociationType(1): [TypeName] void
+#   23|                 Type = [VoidType] void
+#   23|                 ValueCategory = prvalue
+#   23|             getAssociationExpr(1): unknown
+#   23|                 Type = [ArrayType] char[8]
+#   23|                 Value = [StringLiteral] "unknown"
+#   23|                 ValueCategory = lvalue
+#   26| [TopLevelFunction] void c11_generic_test_test_with_cast(int)
+#   26|   <params>: 
+#   26|     getParameter(0): [Parameter] y
+#   26|         Type = [IntType] int
+#   26|   getEntryPoint(): [BlockStmt] { ... }
+#   27|     getStmt(0): [DeclStmt] declaration
+#   27|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of r
+#   27|           Type = [IntType] unsigned int
+#   28|     getStmt(1): [ExprStmt] ExprStmt
+#   28|       getExpr(): [AssignExpr] ... = ...
+#   28|           Type = [IntType] unsigned int
+#   28|           ValueCategory = prvalue
+#   28|         getLValue(): [VariableAccess] r
+#   28|             Type = [IntType] unsigned int
+#   28|             ValueCategory = lvalue
+#   28|         getRValue(): [VariableAccess] y
+#   28|             Type = [IntType] int
+#   28|             ValueCategory = prvalue(load)
+#   28|         getRValue().getFullyConverted(): [C11GenericExpr] _Generic
+#   28|             Type = [IntType] unsigned int
+#   28|             ValueCategory = prvalue
+#   28|           getControllingExpr(): [VariableAccess] r
+#   28|               Type = [IntType] unsigned int
+#   28|               ValueCategory = prvalue(load)
+#   28|           getAssociationType(0): [TypeName] unsigned int
+#   28|               Type = [IntType] unsigned int
+#   28|               ValueCategory = prvalue
+#   28|           getAssociationExpr(0): [ReuseExpr] reuse of y
+#   28|               Type = [IntType] int
+#   28|               ValueCategory = prvalue
+#   28|           getAssociationType(1): [TypeName] int
+#   28|               Type = [IntType] int
+#   28|               ValueCategory = prvalue
+#   28|           getAssociationExpr(1): [VariableAccess] y
+#   28|               Type = [IntType] int
+#   28|               ValueCategory = lvalue
+#   28|           getExpr(): [CStyleCast] (unsigned int)...
+#   28|               Conversion = [IntegralConversion] integral conversion
+#   28|               Type = [IntType] unsigned int
+#   28|               ValueCategory = prvalue
+#   29|     getStmt(2): [ReturnStmt] return ...
+#   32| [TopLevelFunction] void static_array_param(int[3])
+#   32|   <params>: 
+#   32|     getParameter(0): [Parameter] a
+#   32|         Type = [ArrayType] int[3]
+#   32|   getEntryPoint(): [BlockStmt] { ... }
+#   33|     getStmt(0): [ExprStmt] ExprStmt
+#   33|       getExpr(): [AssignExpr] ... = ...
+#   33|           Type = [IntType] int
+#   33|           ValueCategory = prvalue
+#   33|         getLValue(): [ArrayExpr] access to array
+#   33|             Type = [IntType] int
+#   33|             ValueCategory = lvalue
+#   33|           getArrayBase(): [VariableAccess] a
+#   33|               Type = [IntPointerType] int *
+#   33|               ValueCategory = prvalue(load)
+#   33|           getArrayOffset(): [Literal] 0
+#   33|               Type = [IntType] int
+#   33|               Value = [Literal] 0
+#   33|               ValueCategory = prvalue
+#   33|         getRValue(): [Literal] 1
+#   33|             Type = [IntType] int
+#   33|             Value = [Literal] 1
+#   33|             ValueCategory = prvalue
+#   34|     getStmt(1): [ReturnStmt] return ...
 clang.cpp:
 #    5| [TopLevelFunction] int* globalIntAddress()
 #    5|   <params>: 
@@ -4179,178 +4375,6 @@ destructors_for_temps.cpp:
 #  103|             Type = [IntType] int
 #  103|             ValueCategory = prvalue
 #  104|     getStmt(1): [ReturnStmt] return ...
-generic.c:
-#    1| [TopLevelFunction] void c11_generic_test_with_load(unsigned int, int)
-#    1|   <params>: 
-#    1|     getParameter(0): [Parameter] x
-#    1|         Type = [IntType] unsigned int
-#    1|     getParameter(1): [Parameter] y
-#    1|         Type = [IntType] int
-#    1|   getEntryPoint(): [BlockStmt] { ... }
-#    2|     getStmt(0): [DeclStmt] declaration
-#    2|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of r
-#    2|           Type = [IntType] unsigned int
-#    3|     getStmt(1): [ExprStmt] ExprStmt
-#    3|       getExpr(): [AssignExpr] ... = ...
-#    3|           Type = [IntType] unsigned int
-#    3|           ValueCategory = prvalue
-#    3|         getLValue(): [VariableAccess] r
-#    3|             Type = [IntType] unsigned int
-#    3|             ValueCategory = lvalue
-#    3|         getRValue(): [AddExpr] ... + ...
-#    3|             Type = [IntType] unsigned int
-#    3|             ValueCategory = prvalue
-#    3|           getLeftOperand(): [VariableAccess] x
-#    3|               Type = [IntType] unsigned int
-#    3|               ValueCategory = prvalue(load)
-#    3|           getRightOperand(): [Literal] 1
-#    3|               Type = [IntType] int
-#    3|               Value = [Literal] 1
-#    3|               ValueCategory = prvalue
-#    3|           getLeftOperand().getFullyConverted(): [C11GenericExpr] _Generic
-#    3|               Type = [IntType] unsigned int
-#    3|               ValueCategory = prvalue(load)
-#    3|             getControllingExpr(): [VariableAccess] r
-#    3|                 Type = [IntType] unsigned int
-#    3|                 ValueCategory = prvalue(load)
-#    3|             getAssociationType(0): [TypeName] unsigned int
-#    3|                 Type = [IntType] unsigned int
-#    3|                 ValueCategory = prvalue
-#    3|             getAssociationExpr(0): [ReuseExpr] reuse of x
-#    3|                 Type = [IntType] unsigned int
-#    3|                 ValueCategory = lvalue
-#    3|             getAssociationType(1): [TypeName] int
-#    3|                 Type = [IntType] int
-#    3|                 ValueCategory = prvalue
-#    3|             getAssociationExpr(1): [VariableAccess] y
-#    3|                 Type = [IntType] int
-#    3|                 ValueCategory = lvalue
-#    3|           getRightOperand().getFullyConverted(): [CStyleCast] (unsigned int)...
-#    3|               Conversion = [IntegralConversion] integral conversion
-#    3|               Type = [IntType] unsigned int
-#    3|               Value = [CStyleCast] 1
-#    3|               ValueCategory = prvalue
-#    4|     getStmt(2): [ReturnStmt] return ...
-#   12| [TopLevelFunction] char const* c11_generic_test_with_constant_and_macro()
-#   12|   <params>: 
-#   13|   getEntryPoint(): [BlockStmt] { ... }
-#   14|     getStmt(0): [DeclStmt] declaration
-#   14|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of i
-#   14|           Type = [IntType] int
-#   16|     getStmt(1): [ReturnStmt] return ...
-#   16|       getExpr(): int
-#   16|           Type = [ArrayType] char[4]
-#   16|           Value = [StringLiteral] "int"
-#   16|           ValueCategory = lvalue
-#   16|       getExpr().getFullyConverted(): [CStyleCast] (const char *)...
-#   16|           Conversion = [PointerConversion] pointer conversion
-#   16|           Type = [PointerType] const char *
-#   16|           ValueCategory = prvalue
-#   16|         getExpr(): [ArrayToPointerConversion] array to pointer conversion
-#   16|             Type = [CharPointerType] char *
-#   16|             ValueCategory = prvalue
-#   16|           getExpr(): [C11GenericExpr] _Generic
-#   16|               Type = [ArrayType] char[4]
-#   16|               Value = [C11GenericExpr] int
-#   16|               ValueCategory = lvalue
-#   16|             getControllingExpr(): [VariableAccess] i
-#   16|                 Type = [IntType] int
-#   16|                 ValueCategory = prvalue(load)
-#   16|             getAssociationType(0): [TypeName] int
-#   16|                 Type = [IntType] int
-#   16|                 ValueCategory = prvalue
-#   16|             getAssociationExpr(0): [ReuseExpr] reuse of int
-#   16|                 Type = [ArrayType] char[4]
-#   16|                 ValueCategory = lvalue
-#   16|             getAssociationType(1): [TypeName] void
-#   16|                 Type = [VoidType] void
-#   16|                 ValueCategory = prvalue
-#   16|             getAssociationExpr(1): unknown
-#   16|                 Type = [ArrayType] char[8]
-#   16|                 Value = [StringLiteral] "unknown"
-#   16|                 ValueCategory = lvalue
-#   16|             getControllingExpr().getFullyConverted(): [ParenthesisExpr] (...)
-#   16|                 Type = [IntType] int
-#   16|                 ValueCategory = prvalue(load)
-#   19| [TopLevelFunction] char const* c11_generic_test_with_constant_and_no_macro()
-#   19|   <params>: 
-#   20|   getEntryPoint(): [BlockStmt] { ... }
-#   21|     getStmt(0): [DeclStmt] declaration
-#   21|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of i
-#   21|           Type = [IntType] int
-#   23|     getStmt(1): [ReturnStmt] return ...
-#   23|       getExpr(): int
-#   23|           Type = [ArrayType] char[4]
-#   23|           Value = [StringLiteral] "int"
-#   23|           ValueCategory = lvalue
-#   23|       getExpr().getFullyConverted(): [CStyleCast] (const char *)...
-#   23|           Conversion = [PointerConversion] pointer conversion
-#   23|           Type = [PointerType] const char *
-#   23|           ValueCategory = prvalue
-#   23|         getExpr(): [ArrayToPointerConversion] array to pointer conversion
-#   23|             Type = [CharPointerType] char *
-#   23|             ValueCategory = prvalue
-#   23|           getExpr(): [C11GenericExpr] _Generic
-#   23|               Type = [ArrayType] char[4]
-#   23|               Value = [C11GenericExpr] int
-#   23|               ValueCategory = lvalue
-#   23|             getControllingExpr(): [VariableAccess] i
-#   23|                 Type = [IntType] int
-#   23|                 ValueCategory = prvalue(load)
-#   23|             getAssociationType(0): [TypeName] int
-#   23|                 Type = [IntType] int
-#   23|                 ValueCategory = prvalue
-#   23|             getAssociationExpr(0): [ReuseExpr] reuse of int
-#   23|                 Type = [ArrayType] char[4]
-#   23|                 ValueCategory = lvalue
-#   23|             getAssociationType(1): [TypeName] void
-#   23|                 Type = [VoidType] void
-#   23|                 ValueCategory = prvalue
-#   23|             getAssociationExpr(1): unknown
-#   23|                 Type = [ArrayType] char[8]
-#   23|                 Value = [StringLiteral] "unknown"
-#   23|                 ValueCategory = lvalue
-#   26| [TopLevelFunction] void c11_generic_test_test_with_cast(int)
-#   26|   <params>: 
-#   26|     getParameter(0): [Parameter] y
-#   26|         Type = [IntType] int
-#   26|   getEntryPoint(): [BlockStmt] { ... }
-#   27|     getStmt(0): [DeclStmt] declaration
-#   27|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of r
-#   27|           Type = [IntType] unsigned int
-#   28|     getStmt(1): [ExprStmt] ExprStmt
-#   28|       getExpr(): [AssignExpr] ... = ...
-#   28|           Type = [IntType] unsigned int
-#   28|           ValueCategory = prvalue
-#   28|         getLValue(): [VariableAccess] r
-#   28|             Type = [IntType] unsigned int
-#   28|             ValueCategory = lvalue
-#   28|         getRValue(): [VariableAccess] y
-#   28|             Type = [IntType] int
-#   28|             ValueCategory = prvalue(load)
-#   28|         getRValue().getFullyConverted(): [C11GenericExpr] _Generic
-#   28|             Type = [IntType] unsigned int
-#   28|             ValueCategory = prvalue
-#   28|           getControllingExpr(): [VariableAccess] r
-#   28|               Type = [IntType] unsigned int
-#   28|               ValueCategory = prvalue(load)
-#   28|           getAssociationType(0): [TypeName] unsigned int
-#   28|               Type = [IntType] unsigned int
-#   28|               ValueCategory = prvalue
-#   28|           getAssociationExpr(0): [ReuseExpr] reuse of y
-#   28|               Type = [IntType] int
-#   28|               ValueCategory = prvalue
-#   28|           getAssociationType(1): [TypeName] int
-#   28|               Type = [IntType] int
-#   28|               ValueCategory = prvalue
-#   28|           getAssociationExpr(1): [VariableAccess] y
-#   28|               Type = [IntType] int
-#   28|               ValueCategory = lvalue
-#   28|           getExpr(): [CStyleCast] (unsigned int)...
-#   28|               Conversion = [IntegralConversion] integral conversion
-#   28|               Type = [IntType] unsigned int
-#   28|               ValueCategory = prvalue
-#   29|     getStmt(2): [ReturnStmt] return ...
 ir-not-microsoft.c:
 #    1| [TopLevelFunction] void gnuConditionalOmittedOperand()
 #    1|   <params>: 

--- a/cpp/ql/test/library-tests/ir/ir/aliased_ir.expected
+++ b/cpp/ql/test/library-tests/ir/ir/aliased_ir.expected
@@ -151,6 +151,109 @@ bad_stmts.cpp:
 #    5|     v5_6(void)         = AliasedUse              : m5_3
 #    5|     v5_7(void)         = ExitFunction            : 
 
+c11.c:
+#    1| void c11_generic_test_with_load(unsigned int, int)
+#    1|   Block 0
+#    1|     v1_1(void)                = EnterFunction          : 
+#    1|     m1_2(unknown)             = AliasedDefinition      : 
+#    1|     m1_3(unknown)             = InitializeNonLocal     : 
+#    1|     m1_4(unknown)             = Chi                    : total:m1_2, partial:m1_3
+#    1|     r1_5(glval<unsigned int>) = VariableAddress[x]     : 
+#    1|     m1_6(unsigned int)        = InitializeParameter[x] : &:r1_5
+#    1|     r1_7(glval<int>)          = VariableAddress[y]     : 
+#    1|     m1_8(int)                 = InitializeParameter[y] : &:r1_7
+#    2|     r2_1(glval<unsigned int>) = VariableAddress[r]     : 
+#    2|     m2_2(unsigned int)        = Uninitialized[r]       : &:r2_1
+#    3|     r3_1(glval<unsigned int>) = VariableAddress[x]     : 
+#    3|     r3_2(unsigned int)        = Load[x]                : &:r3_1, m1_6
+#    3|     r3_3(unsigned int)        = Constant[1]            : 
+#    3|     r3_4(unsigned int)        = Add                    : r3_2, r3_3
+#    3|     r3_5(glval<unsigned int>) = VariableAddress[r]     : 
+#    3|     m3_6(unsigned int)        = Store[r]               : &:r3_5, r3_4
+#    4|     v4_1(void)                = NoOp                   : 
+#    1|     v1_9(void)                = ReturnVoid             : 
+#    1|     v1_10(void)               = AliasedUse             : m1_3
+#    1|     v1_11(void)               = ExitFunction           : 
+
+#   12| char const* c11_generic_test_with_constant_and_macro()
+#   12|   Block 0
+#   12|     v12_1(void)           = EnterFunction            : 
+#   12|     m12_2(unknown)        = AliasedDefinition        : 
+#   12|     m12_3(unknown)        = InitializeNonLocal       : 
+#   12|     m12_4(unknown)        = Chi                      : total:m12_2, partial:m12_3
+#   14|     r14_1(glval<int>)     = VariableAddress[i]       : 
+#   14|     m14_2(int)            = Uninitialized[i]         : &:r14_1
+#   16|     r16_1(glval<char *>)  = VariableAddress[#return] : 
+#   16|     r16_2(glval<char[4]>) = Constant[int]            : 
+#   16|     r16_3(char *)         = Convert                  : r16_2
+#   16|     r16_4(char *)         = Convert                  : r16_3
+#   16|     m16_5(char *)         = Store[#return]           : &:r16_1, r16_4
+#   12|     r12_5(glval<char *>)  = VariableAddress[#return] : 
+#   12|     v12_6(void)           = ReturnValue              : &:r12_5, m16_5
+#   12|     v12_7(void)           = AliasedUse               : m12_3
+#   12|     v12_8(void)           = ExitFunction             : 
+
+#   19| char const* c11_generic_test_with_constant_and_no_macro()
+#   19|   Block 0
+#   19|     v19_1(void)           = EnterFunction            : 
+#   19|     m19_2(unknown)        = AliasedDefinition        : 
+#   19|     m19_3(unknown)        = InitializeNonLocal       : 
+#   19|     m19_4(unknown)        = Chi                      : total:m19_2, partial:m19_3
+#   21|     r21_1(glval<int>)     = VariableAddress[i]       : 
+#   21|     m21_2(int)            = Uninitialized[i]         : &:r21_1
+#   23|     r23_1(glval<char *>)  = VariableAddress[#return] : 
+#   23|     r23_2(glval<char[4]>) = Constant[int]            : 
+#   23|     r23_3(char *)         = Convert                  : r23_2
+#   23|     r23_4(char *)         = Convert                  : r23_3
+#   23|     m23_5(char *)         = Store[#return]           : &:r23_1, r23_4
+#   19|     r19_5(glval<char *>)  = VariableAddress[#return] : 
+#   19|     v19_6(void)           = ReturnValue              : &:r19_5, m23_5
+#   19|     v19_7(void)           = AliasedUse               : m19_3
+#   19|     v19_8(void)           = ExitFunction             : 
+
+#   26| void c11_generic_test_test_with_cast(int)
+#   26|   Block 0
+#   26|     v26_1(void)                = EnterFunction          : 
+#   26|     m26_2(unknown)             = AliasedDefinition      : 
+#   26|     m26_3(unknown)             = InitializeNonLocal     : 
+#   26|     m26_4(unknown)             = Chi                    : total:m26_2, partial:m26_3
+#   26|     r26_5(glval<int>)          = VariableAddress[y]     : 
+#   26|     m26_6(int)                 = InitializeParameter[y] : &:r26_5
+#   27|     r27_1(glval<unsigned int>) = VariableAddress[r]     : 
+#   27|     m27_2(unsigned int)        = Uninitialized[r]       : &:r27_1
+#   28|     r28_1(glval<int>)          = VariableAddress[y]     : 
+#   28|     r28_2(int)                 = Load[y]                : &:r28_1, m26_6
+#   28|     r28_3(unsigned int)        = Convert                : r28_2
+#   28|     r28_4(glval<unsigned int>) = VariableAddress[r]     : 
+#   28|     m28_5(unsigned int)        = Store[r]               : &:r28_4, r28_3
+#   29|     v29_1(void)                = NoOp                   : 
+#   26|     v26_7(void)                = ReturnVoid             : 
+#   26|     v26_8(void)                = AliasedUse             : m26_3
+#   26|     v26_9(void)                = ExitFunction           : 
+
+#   32| void static_array_param(int[3])
+#   32|   Block 0
+#   32|     v32_1(void)         = EnterFunction            : 
+#   32|     m32_2(unknown)      = AliasedDefinition        : 
+#   32|     m32_3(unknown)      = InitializeNonLocal       : 
+#   32|     m32_4(unknown)      = Chi                      : total:m32_2, partial:m32_3
+#   32|     r32_5(glval<int *>) = VariableAddress[a]       : 
+#   32|     m32_6(int *)        = InitializeParameter[a]   : &:r32_5
+#   32|     r32_7(int *)        = Load[a]                  : &:r32_5, m32_6
+#   32|     m32_8(unknown)      = InitializeIndirection[a] : &:r32_7
+#   33|     r33_1(int)          = Constant[1]              : 
+#   33|     r33_2(glval<int *>) = VariableAddress[a]       : 
+#   33|     r33_3(int *)        = Load[a]                  : &:r33_2, m32_6
+#   33|     r33_4(int)          = Constant[0]              : 
+#   33|     r33_5(glval<int>)   = PointerAdd[4]            : r33_3, r33_4
+#   33|     m33_6(int)          = Store[?]                 : &:r33_5, r33_1
+#   33|     m33_7(unknown)      = Chi                      : total:m32_8, partial:m33_6
+#   34|     v34_1(void)         = NoOp                     : 
+#   32|     v32_9(void)         = ReturnIndirection[a]     : &:r32_7, m33_7
+#   32|     v32_10(void)        = ReturnVoid               : 
+#   32|     v32_11(void)        = AliasedUse               : m32_3
+#   32|     v32_12(void)        = ExitFunction             : 
+
 clang.cpp:
 #    5| int* globalIntAddress()
 #    5|   Block 0
@@ -2951,86 +3054,6 @@ destructors_for_temps.cpp:
 #  102|     v102_8(void)                         = ReturnVoid                               : 
 #  102|     v102_9(void)                         = AliasedUse                               : ~m103_26
 #  102|     v102_10(void)                        = ExitFunction                             : 
-
-generic.c:
-#    1| void c11_generic_test_with_load(unsigned int, int)
-#    1|   Block 0
-#    1|     v1_1(void)                = EnterFunction          : 
-#    1|     m1_2(unknown)             = AliasedDefinition      : 
-#    1|     m1_3(unknown)             = InitializeNonLocal     : 
-#    1|     m1_4(unknown)             = Chi                    : total:m1_2, partial:m1_3
-#    1|     r1_5(glval<unsigned int>) = VariableAddress[x]     : 
-#    1|     m1_6(unsigned int)        = InitializeParameter[x] : &:r1_5
-#    1|     r1_7(glval<int>)          = VariableAddress[y]     : 
-#    1|     m1_8(int)                 = InitializeParameter[y] : &:r1_7
-#    2|     r2_1(glval<unsigned int>) = VariableAddress[r]     : 
-#    2|     m2_2(unsigned int)        = Uninitialized[r]       : &:r2_1
-#    3|     r3_1(glval<unsigned int>) = VariableAddress[x]     : 
-#    3|     r3_2(unsigned int)        = Load[x]                : &:r3_1, m1_6
-#    3|     r3_3(unsigned int)        = Constant[1]            : 
-#    3|     r3_4(unsigned int)        = Add                    : r3_2, r3_3
-#    3|     r3_5(glval<unsigned int>) = VariableAddress[r]     : 
-#    3|     m3_6(unsigned int)        = Store[r]               : &:r3_5, r3_4
-#    4|     v4_1(void)                = NoOp                   : 
-#    1|     v1_9(void)                = ReturnVoid             : 
-#    1|     v1_10(void)               = AliasedUse             : m1_3
-#    1|     v1_11(void)               = ExitFunction           : 
-
-#   12| char const* c11_generic_test_with_constant_and_macro()
-#   12|   Block 0
-#   12|     v12_1(void)           = EnterFunction            : 
-#   12|     m12_2(unknown)        = AliasedDefinition        : 
-#   12|     m12_3(unknown)        = InitializeNonLocal       : 
-#   12|     m12_4(unknown)        = Chi                      : total:m12_2, partial:m12_3
-#   14|     r14_1(glval<int>)     = VariableAddress[i]       : 
-#   14|     m14_2(int)            = Uninitialized[i]         : &:r14_1
-#   16|     r16_1(glval<char *>)  = VariableAddress[#return] : 
-#   16|     r16_2(glval<char[4]>) = Constant[int]            : 
-#   16|     r16_3(char *)         = Convert                  : r16_2
-#   16|     r16_4(char *)         = Convert                  : r16_3
-#   16|     m16_5(char *)         = Store[#return]           : &:r16_1, r16_4
-#   12|     r12_5(glval<char *>)  = VariableAddress[#return] : 
-#   12|     v12_6(void)           = ReturnValue              : &:r12_5, m16_5
-#   12|     v12_7(void)           = AliasedUse               : m12_3
-#   12|     v12_8(void)           = ExitFunction             : 
-
-#   19| char const* c11_generic_test_with_constant_and_no_macro()
-#   19|   Block 0
-#   19|     v19_1(void)           = EnterFunction            : 
-#   19|     m19_2(unknown)        = AliasedDefinition        : 
-#   19|     m19_3(unknown)        = InitializeNonLocal       : 
-#   19|     m19_4(unknown)        = Chi                      : total:m19_2, partial:m19_3
-#   21|     r21_1(glval<int>)     = VariableAddress[i]       : 
-#   21|     m21_2(int)            = Uninitialized[i]         : &:r21_1
-#   23|     r23_1(glval<char *>)  = VariableAddress[#return] : 
-#   23|     r23_2(glval<char[4]>) = Constant[int]            : 
-#   23|     r23_3(char *)         = Convert                  : r23_2
-#   23|     r23_4(char *)         = Convert                  : r23_3
-#   23|     m23_5(char *)         = Store[#return]           : &:r23_1, r23_4
-#   19|     r19_5(glval<char *>)  = VariableAddress[#return] : 
-#   19|     v19_6(void)           = ReturnValue              : &:r19_5, m23_5
-#   19|     v19_7(void)           = AliasedUse               : m19_3
-#   19|     v19_8(void)           = ExitFunction             : 
-
-#   26| void c11_generic_test_test_with_cast(int)
-#   26|   Block 0
-#   26|     v26_1(void)                = EnterFunction          : 
-#   26|     m26_2(unknown)             = AliasedDefinition      : 
-#   26|     m26_3(unknown)             = InitializeNonLocal     : 
-#   26|     m26_4(unknown)             = Chi                    : total:m26_2, partial:m26_3
-#   26|     r26_5(glval<int>)          = VariableAddress[y]     : 
-#   26|     m26_6(int)                 = InitializeParameter[y] : &:r26_5
-#   27|     r27_1(glval<unsigned int>) = VariableAddress[r]     : 
-#   27|     m27_2(unsigned int)        = Uninitialized[r]       : &:r27_1
-#   28|     r28_1(glval<int>)          = VariableAddress[y]     : 
-#   28|     r28_2(int)                 = Load[y]                : &:r28_1, m26_6
-#   28|     r28_3(unsigned int)        = Convert                : r28_2
-#   28|     r28_4(glval<unsigned int>) = VariableAddress[r]     : 
-#   28|     m28_5(unsigned int)        = Store[r]               : &:r28_4, r28_3
-#   29|     v29_1(void)                = NoOp                   : 
-#   26|     v26_7(void)                = ReturnVoid             : 
-#   26|     v26_8(void)                = AliasedUse             : m26_3
-#   26|     v26_9(void)                = ExitFunction           : 
 
 ir-not-microsoft.c:
 #    1| void gnuConditionalOmittedOperand()

--- a/cpp/ql/test/library-tests/ir/ir/c11.c
+++ b/cpp/ql/test/library-tests/ir/ir/c11.c
@@ -28,4 +28,9 @@ void c11_generic_test_test_with_cast(int y) {
   r = _Generic(r, unsigned int: (unsigned int)y, int: y);
 }
 
+
+void static_array_param(int a[static 3]) {
+  a[0] = 1;
+}
+
 // semmle-extractor-options: -std=c11

--- a/cpp/ql/test/library-tests/ir/ir/raw_ir.expected
+++ b/cpp/ql/test/library-tests/ir/ir/raw_ir.expected
@@ -141,6 +141,103 @@ bad_stmts.cpp:
 #    5|     v5_5(void)         = AliasedUse              : ~m?
 #    5|     v5_6(void)         = ExitFunction            : 
 
+c11.c:
+#    1| void c11_generic_test_with_load(unsigned int, int)
+#    1|   Block 0
+#    1|     v1_1(void)                = EnterFunction          : 
+#    1|     mu1_2(unknown)            = AliasedDefinition      : 
+#    1|     mu1_3(unknown)            = InitializeNonLocal     : 
+#    1|     r1_4(glval<unsigned int>) = VariableAddress[x]     : 
+#    1|     mu1_5(unsigned int)       = InitializeParameter[x] : &:r1_4
+#    1|     r1_6(glval<int>)          = VariableAddress[y]     : 
+#    1|     mu1_7(int)                = InitializeParameter[y] : &:r1_6
+#    2|     r2_1(glval<unsigned int>) = VariableAddress[r]     : 
+#    2|     mu2_2(unsigned int)       = Uninitialized[r]       : &:r2_1
+#    3|     r3_1(glval<unsigned int>) = VariableAddress[x]     : 
+#    3|     r3_2(unsigned int)        = Load[x]                : &:r3_1, ~m?
+#    3|     r3_3(unsigned int)        = Constant[1]            : 
+#    3|     r3_4(unsigned int)        = Add                    : r3_2, r3_3
+#    3|     r3_5(glval<unsigned int>) = VariableAddress[r]     : 
+#    3|     mu3_6(unsigned int)       = Store[r]               : &:r3_5, r3_4
+#    4|     v4_1(void)                = NoOp                   : 
+#    1|     v1_8(void)                = ReturnVoid             : 
+#    1|     v1_9(void)                = AliasedUse             : ~m?
+#    1|     v1_10(void)               = ExitFunction           : 
+
+#   12| char const* c11_generic_test_with_constant_and_macro()
+#   12|   Block 0
+#   12|     v12_1(void)           = EnterFunction            : 
+#   12|     mu12_2(unknown)       = AliasedDefinition        : 
+#   12|     mu12_3(unknown)       = InitializeNonLocal       : 
+#   14|     r14_1(glval<int>)     = VariableAddress[i]       : 
+#   14|     mu14_2(int)           = Uninitialized[i]         : &:r14_1
+#   16|     r16_1(glval<char *>)  = VariableAddress[#return] : 
+#   16|     r16_2(glval<char[4]>) = Constant[int]            : 
+#   16|     r16_3(char *)         = Convert                  : r16_2
+#   16|     r16_4(char *)         = Convert                  : r16_3
+#   16|     mu16_5(char *)        = Store[#return]           : &:r16_1, r16_4
+#   12|     r12_4(glval<char *>)  = VariableAddress[#return] : 
+#   12|     v12_5(void)           = ReturnValue              : &:r12_4, ~m?
+#   12|     v12_6(void)           = AliasedUse               : ~m?
+#   12|     v12_7(void)           = ExitFunction             : 
+
+#   19| char const* c11_generic_test_with_constant_and_no_macro()
+#   19|   Block 0
+#   19|     v19_1(void)           = EnterFunction            : 
+#   19|     mu19_2(unknown)       = AliasedDefinition        : 
+#   19|     mu19_3(unknown)       = InitializeNonLocal       : 
+#   21|     r21_1(glval<int>)     = VariableAddress[i]       : 
+#   21|     mu21_2(int)           = Uninitialized[i]         : &:r21_1
+#   23|     r23_1(glval<char *>)  = VariableAddress[#return] : 
+#   23|     r23_2(glval<char[4]>) = Constant[int]            : 
+#   23|     r23_3(char *)         = Convert                  : r23_2
+#   23|     r23_4(char *)         = Convert                  : r23_3
+#   23|     mu23_5(char *)        = Store[#return]           : &:r23_1, r23_4
+#   19|     r19_4(glval<char *>)  = VariableAddress[#return] : 
+#   19|     v19_5(void)           = ReturnValue              : &:r19_4, ~m?
+#   19|     v19_6(void)           = AliasedUse               : ~m?
+#   19|     v19_7(void)           = ExitFunction             : 
+
+#   26| void c11_generic_test_test_with_cast(int)
+#   26|   Block 0
+#   26|     v26_1(void)                = EnterFunction          : 
+#   26|     mu26_2(unknown)            = AliasedDefinition      : 
+#   26|     mu26_3(unknown)            = InitializeNonLocal     : 
+#   26|     r26_4(glval<int>)          = VariableAddress[y]     : 
+#   26|     mu26_5(int)                = InitializeParameter[y] : &:r26_4
+#   27|     r27_1(glval<unsigned int>) = VariableAddress[r]     : 
+#   27|     mu27_2(unsigned int)       = Uninitialized[r]       : &:r27_1
+#   28|     r28_1(glval<int>)          = VariableAddress[y]     : 
+#   28|     r28_2(int)                 = Load[y]                : &:r28_1, ~m?
+#   28|     r28_3(unsigned int)        = Convert                : r28_2
+#   28|     r28_4(glval<unsigned int>) = VariableAddress[r]     : 
+#   28|     mu28_5(unsigned int)       = Store[r]               : &:r28_4, r28_3
+#   29|     v29_1(void)                = NoOp                   : 
+#   26|     v26_6(void)                = ReturnVoid             : 
+#   26|     v26_7(void)                = AliasedUse             : ~m?
+#   26|     v26_8(void)                = ExitFunction           : 
+
+#   32| void static_array_param(int[3])
+#   32|   Block 0
+#   32|     v32_1(void)         = EnterFunction            : 
+#   32|     mu32_2(unknown)     = AliasedDefinition        : 
+#   32|     mu32_3(unknown)     = InitializeNonLocal       : 
+#   32|     r32_4(glval<int *>) = VariableAddress[a]       : 
+#   32|     mu32_5(int *)       = InitializeParameter[a]   : &:r32_4
+#   32|     r32_6(int *)        = Load[a]                  : &:r32_4, ~m?
+#   32|     mu32_7(unknown)     = InitializeIndirection[a] : &:r32_6
+#   33|     r33_1(int)          = Constant[1]              : 
+#   33|     r33_2(glval<int *>) = VariableAddress[a]       : 
+#   33|     r33_3(int *)        = Load[a]                  : &:r33_2, ~m?
+#   33|     r33_4(int)          = Constant[0]              : 
+#   33|     r33_5(glval<int>)   = PointerAdd[4]            : r33_3, r33_4
+#   33|     mu33_6(int)         = Store[?]                 : &:r33_5, r33_1
+#   34|     v34_1(void)         = NoOp                     : 
+#   32|     v32_8(void)         = ReturnIndirection[a]     : &:r32_6, ~m?
+#   32|     v32_9(void)         = ReturnVoid               : 
+#   32|     v32_10(void)        = AliasedUse               : ~m?
+#   32|     v32_11(void)        = ExitFunction             : 
+
 clang.cpp:
 #    5| int* globalIntAddress()
 #    5|   Block 0
@@ -2731,82 +2828,6 @@ destructors_for_temps.cpp:
 #  102|     v102_6(void)                         = ReturnVoid                               : 
 #  102|     v102_7(void)                         = AliasedUse                               : ~m?
 #  102|     v102_8(void)                         = ExitFunction                             : 
-
-generic.c:
-#    1| void c11_generic_test_with_load(unsigned int, int)
-#    1|   Block 0
-#    1|     v1_1(void)                = EnterFunction          : 
-#    1|     mu1_2(unknown)            = AliasedDefinition      : 
-#    1|     mu1_3(unknown)            = InitializeNonLocal     : 
-#    1|     r1_4(glval<unsigned int>) = VariableAddress[x]     : 
-#    1|     mu1_5(unsigned int)       = InitializeParameter[x] : &:r1_4
-#    1|     r1_6(glval<int>)          = VariableAddress[y]     : 
-#    1|     mu1_7(int)                = InitializeParameter[y] : &:r1_6
-#    2|     r2_1(glval<unsigned int>) = VariableAddress[r]     : 
-#    2|     mu2_2(unsigned int)       = Uninitialized[r]       : &:r2_1
-#    3|     r3_1(glval<unsigned int>) = VariableAddress[x]     : 
-#    3|     r3_2(unsigned int)        = Load[x]                : &:r3_1, ~m?
-#    3|     r3_3(unsigned int)        = Constant[1]            : 
-#    3|     r3_4(unsigned int)        = Add                    : r3_2, r3_3
-#    3|     r3_5(glval<unsigned int>) = VariableAddress[r]     : 
-#    3|     mu3_6(unsigned int)       = Store[r]               : &:r3_5, r3_4
-#    4|     v4_1(void)                = NoOp                   : 
-#    1|     v1_8(void)                = ReturnVoid             : 
-#    1|     v1_9(void)                = AliasedUse             : ~m?
-#    1|     v1_10(void)               = ExitFunction           : 
-
-#   12| char const* c11_generic_test_with_constant_and_macro()
-#   12|   Block 0
-#   12|     v12_1(void)           = EnterFunction            : 
-#   12|     mu12_2(unknown)       = AliasedDefinition        : 
-#   12|     mu12_3(unknown)       = InitializeNonLocal       : 
-#   14|     r14_1(glval<int>)     = VariableAddress[i]       : 
-#   14|     mu14_2(int)           = Uninitialized[i]         : &:r14_1
-#   16|     r16_1(glval<char *>)  = VariableAddress[#return] : 
-#   16|     r16_2(glval<char[4]>) = Constant[int]            : 
-#   16|     r16_3(char *)         = Convert                  : r16_2
-#   16|     r16_4(char *)         = Convert                  : r16_3
-#   16|     mu16_5(char *)        = Store[#return]           : &:r16_1, r16_4
-#   12|     r12_4(glval<char *>)  = VariableAddress[#return] : 
-#   12|     v12_5(void)           = ReturnValue              : &:r12_4, ~m?
-#   12|     v12_6(void)           = AliasedUse               : ~m?
-#   12|     v12_7(void)           = ExitFunction             : 
-
-#   19| char const* c11_generic_test_with_constant_and_no_macro()
-#   19|   Block 0
-#   19|     v19_1(void)           = EnterFunction            : 
-#   19|     mu19_2(unknown)       = AliasedDefinition        : 
-#   19|     mu19_3(unknown)       = InitializeNonLocal       : 
-#   21|     r21_1(glval<int>)     = VariableAddress[i]       : 
-#   21|     mu21_2(int)           = Uninitialized[i]         : &:r21_1
-#   23|     r23_1(glval<char *>)  = VariableAddress[#return] : 
-#   23|     r23_2(glval<char[4]>) = Constant[int]            : 
-#   23|     r23_3(char *)         = Convert                  : r23_2
-#   23|     r23_4(char *)         = Convert                  : r23_3
-#   23|     mu23_5(char *)        = Store[#return]           : &:r23_1, r23_4
-#   19|     r19_4(glval<char *>)  = VariableAddress[#return] : 
-#   19|     v19_5(void)           = ReturnValue              : &:r19_4, ~m?
-#   19|     v19_6(void)           = AliasedUse               : ~m?
-#   19|     v19_7(void)           = ExitFunction             : 
-
-#   26| void c11_generic_test_test_with_cast(int)
-#   26|   Block 0
-#   26|     v26_1(void)                = EnterFunction          : 
-#   26|     mu26_2(unknown)            = AliasedDefinition      : 
-#   26|     mu26_3(unknown)            = InitializeNonLocal     : 
-#   26|     r26_4(glval<int>)          = VariableAddress[y]     : 
-#   26|     mu26_5(int)                = InitializeParameter[y] : &:r26_4
-#   27|     r27_1(glval<unsigned int>) = VariableAddress[r]     : 
-#   27|     mu27_2(unsigned int)       = Uninitialized[r]       : &:r27_1
-#   28|     r28_1(glval<int>)          = VariableAddress[y]     : 
-#   28|     r28_2(int)                 = Load[y]                : &:r28_1, ~m?
-#   28|     r28_3(unsigned int)        = Convert                : r28_2
-#   28|     r28_4(glval<unsigned int>) = VariableAddress[r]     : 
-#   28|     mu28_5(unsigned int)       = Store[r]               : &:r28_4, r28_3
-#   29|     v29_1(void)                = NoOp                   : 
-#   26|     v26_6(void)                = ReturnVoid             : 
-#   26|     v26_7(void)                = AliasedUse             : ~m?
-#   26|     v26_8(void)                = ExitFunction           : 
 
 ir-not-microsoft.c:
 #    1| void gnuConditionalOmittedOperand()


### PR DESCRIPTION
This will be a problem once we output those specifiers in the extractor.

Also add a test with such a static specifier.