### PR TITLE
Java: Add explicit `@suites`-based filtering in query suites 

### DIFF
--- a/java/ql/src/Advisory/Declarations/MissingOverrideAnnotation.ql
+++ b/java/ql/src/Advisory/Declarations/MissingOverrideAnnotation.ql
@@ -6,6 +6,7 @@
  * @problem.severity recommendation
  * @precision high
  * @id java/missing-override-annotation
+ * @suites security-and-quality
  * @tags maintainability
  */
 

--- a/java/ql/src/Advisory/Deprecated Code/AvoidDeprecatedCallableAccess.ql
+++ b/java/ql/src/Advisory/Deprecated Code/AvoidDeprecatedCallableAccess.ql
@@ -6,6 +6,7 @@
  * @problem.severity recommendation
  * @precision high
  * @id java/deprecated-call
+ * @suites security-and-quality
  * @tags maintainability
  *       non-attributable
  *       external/cwe/cwe-477

--- a/java/ql/src/Advisory/Documentation/ImpossibleJavadocThrows.ql
+++ b/java/ql/src/Advisory/Documentation/ImpossibleJavadocThrows.ql
@@ -6,6 +6,7 @@
  * @problem.severity recommendation
  * @precision high
  * @id java/inconsistent-javadoc-throws
+ * @suites security-and-quality
  * @tags maintainability
  */
 

--- a/java/ql/src/Advisory/Documentation/SpuriousJavadocParam.ql
+++ b/java/ql/src/Advisory/Documentation/SpuriousJavadocParam.ql
@@ -6,6 +6,7 @@
  * @problem.severity recommendation
  * @precision very-high
  * @id java/unknown-javadoc-parameter
+ * @suites security-and-quality
  * @tags maintainability
  */
 

--- a/java/ql/src/Compatibility/JDK9/JdkInternalAccess.ql
+++ b/java/ql/src/Compatibility/JDK9/JdkInternalAccess.ql
@@ -6,6 +6,7 @@
  * @problem.severity recommendation
  * @precision high
  * @id java/jdk-internal-api-access
+ * @suites security-and-quality
  * @tags maintainability
  */
 

--- a/java/ql/src/Compatibility/JDK9/UnderscoreIdentifier.ql
+++ b/java/ql/src/Compatibility/JDK9/UnderscoreIdentifier.ql
@@ -6,6 +6,7 @@
  * @problem.severity recommendation
  * @precision high
  * @id java/underscore-identifier
+ * @suites security-and-quality
  * @tags maintainability
  */
 

--- a/java/ql/src/DeadCode/UselessParameter.ql
+++ b/java/ql/src/DeadCode/UselessParameter.ql
@@ -5,6 +5,7 @@
  * @problem.severity recommendation
  * @precision high
  * @id java/unused-parameter
+ * @suites security-and-quality
  * @tags maintainability
  *       useless-code
  *       external/cwe/cwe-561

--- a/java/ql/src/Language Abuse/ChainedInstanceof.ql
+++ b/java/ql/src/Language Abuse/ChainedInstanceof.ql
@@ -5,6 +5,7 @@
  * @problem.severity recommendation
  * @precision high
  * @id java/chained-type-tests
+ * @suites security-and-quality
  * @tags maintainability
  *       language-features
  */

--- a/java/ql/src/Language Abuse/IterableIterator.ql
+++ b/java/ql/src/Language Abuse/IterableIterator.ql
@@ -7,6 +7,7 @@
  * @problem.severity warning
  * @precision very-high
  * @id java/iterator-implements-iterable
+ * @suites security-and-quality
  * @tags correctness
  *       reliability
  */

--- a/java/ql/src/Language Abuse/OverridePackagePrivate.ql
+++ b/java/ql/src/Language Abuse/OverridePackagePrivate.ql
@@ -6,6 +6,7 @@
  * @problem.severity warning
  * @precision medium
  * @id java/non-overriding-package-private
+ * @suites security-and-quality
  * @tags maintainability
  *       readability
  */

--- a/java/ql/src/Language Abuse/TypeVarExtendsFinalType.ql
+++ b/java/ql/src/Language Abuse/TypeVarExtendsFinalType.ql
@@ -7,6 +7,7 @@
  * @problem.severity warning
  * @precision medium
  * @id java/type-bound-extends-final
+ * @suites security-and-quality
  * @tags maintainability
  *       readability
  *       types

--- a/java/ql/src/Language Abuse/TypeVariableHidesType.ql
+++ b/java/ql/src/Language Abuse/TypeVariableHidesType.ql
@@ -6,6 +6,7 @@
  * @problem.severity warning
  * @precision medium
  * @id java/type-variable-hides-type
+ * @suites security-and-quality
  * @tags reliability
  *       readability
  *       types

--- a/java/ql/src/Language Abuse/TypeVariableHidesType.ql
+++ b/java/ql/src/Language Abuse/TypeVariableHidesType.ql
@@ -7,6 +7,7 @@
  * @precision medium
  * @id java/type-variable-hides-type
  * @suites security-and-quality
+ *         quality
  * @tags reliability
  *       readability
  *       types

--- a/java/ql/src/Language Abuse/UselessNullCheck.ql
+++ b/java/ql/src/Language Abuse/UselessNullCheck.ql
@@ -6,6 +6,7 @@
  * @problem.severity warning
  * @precision very-high
  * @id java/useless-null-check
+ * @suites security-and-quality
  * @tags maintainability
  *       useless-code
  *       external/cwe/cwe-561

--- a/java/ql/src/Language Abuse/UselessTypeTest.ql
+++ b/java/ql/src/Language Abuse/UselessTypeTest.ql
@@ -5,6 +5,7 @@
  * @problem.severity warning
  * @precision very-high
  * @id java/useless-type-test
+ * @suites security-and-quality
  * @tags maintainability
  *       language-features
  *       external/cwe/cwe-561

--- a/java/ql/src/Language Abuse/WrappedIterator.ql
+++ b/java/ql/src/Language Abuse/WrappedIterator.ql
@@ -6,6 +6,7 @@
  * @problem.severity warning
  * @precision very-high
  * @id java/iterable-wraps-iterator
+ * @suites security-and-quality
  * @tags correctness
  *       reliability
  */

--- a/java/ql/src/Likely Bugs/Arithmetic/BadAbsOfRandom.ql
+++ b/java/ql/src/Likely Bugs/Arithmetic/BadAbsOfRandom.ql
@@ -6,6 +6,7 @@
  * @problem.severity warning
  * @precision medium
  * @id java/abs-of-random
+ * @suites security-and-quality
  * @tags reliability
  *       maintainability
  */

--- a/java/ql/src/Likely Bugs/Arithmetic/ConstantExpAppearsNonConstant.ql
+++ b/java/ql/src/Likely Bugs/Arithmetic/ConstantExpAppearsNonConstant.ql
@@ -5,6 +5,7 @@
  * @problem.severity warning
  * @precision very-high
  * @id java/evaluation-to-constant
+ * @suites security-and-quality
  * @tags maintainability
  *       useless-code
  */

--- a/java/ql/src/Likely Bugs/Arithmetic/InformationLoss.ql
+++ b/java/ql/src/Likely Bugs/Arithmetic/InformationLoss.ql
@@ -8,6 +8,7 @@
  * @security-severity 8.1
  * @precision very-high
  * @id java/implicit-cast-in-compound-assignment
+ * @suites security-and-quality
  * @tags reliability
  *       security
  *       external/cwe/cwe-190

--- a/java/ql/src/Likely Bugs/Arithmetic/IntMultToLong.ql
+++ b/java/ql/src/Likely Bugs/Arithmetic/IntMultToLong.ql
@@ -6,6 +6,7 @@
  * @problem.severity warning
  * @precision very-high
  * @id java/integer-multiplication-cast-to-long
+ * @suites security-and-quality
  * @tags reliability
  *       correctness
  *       types

--- a/java/ql/src/Likely Bugs/Arithmetic/IntMultToLong.ql
+++ b/java/ql/src/Likely Bugs/Arithmetic/IntMultToLong.ql
@@ -7,6 +7,7 @@
  * @precision very-high
  * @id java/integer-multiplication-cast-to-long
  * @suites security-and-quality
+ *         quality
  * @tags reliability
  *       correctness
  *       types

--- a/java/ql/src/Likely Bugs/Arithmetic/LShiftLargerThanTypeWidth.ql
+++ b/java/ql/src/Likely Bugs/Arithmetic/LShiftLargerThanTypeWidth.ql
@@ -5,6 +5,7 @@
  * @problem.severity warning
  * @precision very-high
  * @id java/lshift-larger-than-type-width
+ * @suites security-and-quality
  * @tags correctness
  */
 

--- a/java/ql/src/Likely Bugs/Arithmetic/MultiplyRemainder.ql
+++ b/java/ql/src/Likely Bugs/Arithmetic/MultiplyRemainder.ql
@@ -6,6 +6,7 @@
  * @problem.severity warning
  * @precision medium
  * @id java/multiplication-of-remainder
+ * @suites security-and-quality
  * @tags maintainability
  *       correctness
  */

--- a/java/ql/src/Likely Bugs/Arithmetic/RandomUsedOnce.ql
+++ b/java/ql/src/Likely Bugs/Arithmetic/RandomUsedOnce.ql
@@ -6,6 +6,7 @@
  * @problem.severity warning
  * @precision medium
  * @id java/random-used-once
+ * @suites security-and-quality
  * @tags reliability
  *       maintainability
  *       external/cwe/cwe-335

--- a/java/ql/src/Likely Bugs/Arithmetic/WhitespaceContradictsPrecedence.ql
+++ b/java/ql/src/Likely Bugs/Arithmetic/WhitespaceContradictsPrecedence.ql
@@ -6,6 +6,7 @@
  * @problem.severity warning
  * @precision very-high
  * @id java/whitespace-contradicts-precedence
+ * @suites security-and-quality
  * @tags maintainability
  *       readability
  *       external/cwe/cwe-783

--- a/java/ql/src/Likely Bugs/Cloning/MissingCallToSuperClone.ql
+++ b/java/ql/src/Likely Bugs/Cloning/MissingCallToSuperClone.ql
@@ -7,6 +7,7 @@
  * @problem.severity error
  * @precision medium
  * @id java/missing-call-to-super-clone
+ * @suites security-and-quality
  * @tags reliability
  *       maintainability
  *       external/cwe/cwe-580

--- a/java/ql/src/Likely Bugs/Cloning/MissingMethodClone.ql
+++ b/java/ql/src/Likely Bugs/Cloning/MissingMethodClone.ql
@@ -6,6 +6,7 @@
  * @problem.severity error
  * @precision medium
  * @id java/missing-clone-method
+ * @suites security-and-quality
  * @tags reliability
  *       maintainability
  */

--- a/java/ql/src/Likely Bugs/Collections/ArrayIndexOutOfBounds.ql
+++ b/java/ql/src/Likely Bugs/Collections/ArrayIndexOutOfBounds.ql
@@ -6,6 +6,7 @@
  * @problem.severity error
  * @precision high
  * @id java/index-out-of-bounds
+ * @suites security-and-quality
  * @tags reliability
  *       correctness
  *       exceptions

--- a/java/ql/src/Likely Bugs/Collections/ContainsTypeMismatch.ql
+++ b/java/ql/src/Likely Bugs/Collections/ContainsTypeMismatch.ql
@@ -7,6 +7,7 @@
  * @problem.severity error
  * @precision very-high
  * @id java/type-mismatch-access
+ * @suites security-and-quality
  * @tags reliability
  *       correctness
  *       logic

--- a/java/ql/src/Likely Bugs/Collections/IteratorRemoveMayFail.ql
+++ b/java/ql/src/Likely Bugs/Collections/IteratorRemoveMayFail.ql
@@ -6,6 +6,7 @@
  * @problem.severity warning
  * @precision medium
  * @id java/iterator-remove-failure
+ * @suites security-and-quality
  * @tags reliability
  *       correctness
  *       logic

--- a/java/ql/src/Likely Bugs/Collections/ReadOnlyContainer.ql
+++ b/java/ql/src/Likely Bugs/Collections/ReadOnlyContainer.ql
@@ -5,6 +5,7 @@
  * @problem.severity error
  * @precision very-high
  * @id java/empty-container
+ * @suites security-and-quality
  * @tags reliability
  *       maintainability
  *       useless-code

--- a/java/ql/src/Likely Bugs/Collections/RemoveTypeMismatch.ql
+++ b/java/ql/src/Likely Bugs/Collections/RemoveTypeMismatch.ql
@@ -7,6 +7,7 @@
  * @problem.severity error
  * @precision very-high
  * @id java/type-mismatch-modification
+ * @suites security-and-quality
  * @tags reliability
  *       correctness
  *       logic

--- a/java/ql/src/Likely Bugs/Collections/WriteOnlyContainer.ql
+++ b/java/ql/src/Likely Bugs/Collections/WriteOnlyContainer.ql
@@ -6,6 +6,7 @@
  * @precision very-high
  * @id java/unused-container
  * @suites security-and-quality
+ *         quality
  * @tags maintainability
  *       useless-code
  *       external/cwe/cwe-561

--- a/java/ql/src/Likely Bugs/Collections/WriteOnlyContainer.ql
+++ b/java/ql/src/Likely Bugs/Collections/WriteOnlyContainer.ql
@@ -5,6 +5,7 @@
  * @problem.severity error
  * @precision very-high
  * @id java/unused-container
+ * @suites security-and-quality
  * @tags maintainability
  *       useless-code
  *       external/cwe/cwe-561

--- a/java/ql/src/Likely Bugs/Comparison/CompareIdenticalValues.ql
+++ b/java/ql/src/Likely Bugs/Comparison/CompareIdenticalValues.ql
@@ -6,6 +6,7 @@
  * @problem.severity error
  * @precision very-high
  * @id java/comparison-of-identical-expressions
+ * @suites security-and-quality
  * @tags reliability
  *       correctness
  *       logic

--- a/java/ql/src/Likely Bugs/Comparison/CovariantCompareTo.ql
+++ b/java/ql/src/Likely Bugs/Comparison/CovariantCompareTo.ql
@@ -6,6 +6,7 @@
  * @problem.severity error
  * @precision medium
  * @id java/wrong-compareto-signature
+ * @suites security-and-quality
  * @tags reliability
  *       correctness
  */

--- a/java/ql/src/Likely Bugs/Comparison/CovariantEquals.ql
+++ b/java/ql/src/Likely Bugs/Comparison/CovariantEquals.ql
@@ -6,6 +6,7 @@
  * @problem.severity error
  * @precision medium
  * @id java/wrong-equals-signature
+ * @suites security-and-quality
  * @tags reliability
  *       correctness
  */

--- a/java/ql/src/Likely Bugs/Comparison/EqualsArray.ql
+++ b/java/ql/src/Likely Bugs/Comparison/EqualsArray.ql
@@ -6,6 +6,7 @@
  * @problem.severity error
  * @precision very-high
  * @id java/equals-on-arrays
+ * @suites security-and-quality
  * @tags reliability
  *       correctness
  */

--- a/java/ql/src/Likely Bugs/Comparison/HashedButNoHash.ql
+++ b/java/ql/src/Likely Bugs/Comparison/HashedButNoHash.ql
@@ -6,6 +6,7 @@
  * @problem.severity error
  * @precision very-high
  * @id java/hashing-without-hashcode
+ * @suites security-and-quality
  * @tags reliability
  *       correctness
  */

--- a/java/ql/src/Likely Bugs/Comparison/IncomparableEquals.ql
+++ b/java/ql/src/Likely Bugs/Comparison/IncomparableEquals.ql
@@ -6,6 +6,7 @@
  * @problem.severity error
  * @precision very-high
  * @id java/equals-on-unrelated-types
+ * @suites security-and-quality
  * @tags reliability
  *       correctness
  */

--- a/java/ql/src/Likely Bugs/Comparison/IncomparableEquals.ql
+++ b/java/ql/src/Likely Bugs/Comparison/IncomparableEquals.ql
@@ -7,6 +7,7 @@
  * @precision very-high
  * @id java/equals-on-unrelated-types
  * @suites security-and-quality
+ *         quality
  * @tags reliability
  *       correctness
  */

--- a/java/ql/src/Likely Bugs/Comparison/InconsistentCompareTo.ql
+++ b/java/ql/src/Likely Bugs/Comparison/InconsistentCompareTo.ql
@@ -6,6 +6,7 @@
  * @problem.severity warning
  * @precision medium
  * @id java/inconsistent-compareto-and-equals
+ * @suites security-and-quality
  * @tags reliability
  *       correctness
  */

--- a/java/ql/src/Likely Bugs/Comparison/InconsistentEqualsHashCode.ql
+++ b/java/ql/src/Likely Bugs/Comparison/InconsistentEqualsHashCode.ql
@@ -7,6 +7,7 @@
  * @precision very-high
  * @id java/inconsistent-equals-and-hashcode
  * @suites security-and-quality
+ *         quality
  * @tags reliability
  *       correctness
  *       external/cwe/cwe-581

--- a/java/ql/src/Likely Bugs/Comparison/InconsistentEqualsHashCode.ql
+++ b/java/ql/src/Likely Bugs/Comparison/InconsistentEqualsHashCode.ql
@@ -6,6 +6,7 @@
  * @problem.severity error
  * @precision very-high
  * @id java/inconsistent-equals-and-hashcode
+ * @suites security-and-quality
  * @tags reliability
  *       correctness
  *       external/cwe/cwe-581

--- a/java/ql/src/Likely Bugs/Comparison/MissingInstanceofInEquals.ql
+++ b/java/ql/src/Likely Bugs/Comparison/MissingInstanceofInEquals.ql
@@ -6,6 +6,7 @@
  * @problem.severity error
  * @precision high
  * @id java/unchecked-cast-in-equals
+ * @suites security-and-quality
  * @tags reliability
  *       correctness
  */

--- a/java/ql/src/Likely Bugs/Comparison/MissingInstanceofInEquals.ql
+++ b/java/ql/src/Likely Bugs/Comparison/MissingInstanceofInEquals.ql
@@ -7,6 +7,7 @@
  * @precision high
  * @id java/unchecked-cast-in-equals
  * @suites security-and-quality
+ *         quality
  * @tags reliability
  *       correctness
  */

--- a/java/ql/src/Likely Bugs/Comparison/RefEqBoxed.ql
+++ b/java/ql/src/Likely Bugs/Comparison/RefEqBoxed.ql
@@ -7,6 +7,7 @@
  * @precision very-high
  * @id java/reference-equality-of-boxed-types
  * @suites security-and-quality
+ *         quality
  * @tags reliability
  *       correctness
  *       external/cwe/cwe-595

--- a/java/ql/src/Likely Bugs/Comparison/RefEqBoxed.ql
+++ b/java/ql/src/Likely Bugs/Comparison/RefEqBoxed.ql
@@ -6,6 +6,7 @@
  * @problem.severity error
  * @precision very-high
  * @id java/reference-equality-of-boxed-types
+ * @suites security-and-quality
  * @tags reliability
  *       correctness
  *       external/cwe/cwe-595

--- a/java/ql/src/Likely Bugs/Comparison/StringComparison.ql
+++ b/java/ql/src/Likely Bugs/Comparison/StringComparison.ql
@@ -6,6 +6,7 @@
  * @problem.severity warning
  * @precision medium
  * @id java/reference-equality-on-strings
+ * @suites security-and-quality
  * @tags reliability
  *       external/cwe/cwe-597
  */

--- a/java/ql/src/Likely Bugs/Comparison/UselessComparisonTest.ql
+++ b/java/ql/src/Likely Bugs/Comparison/UselessComparisonTest.ql
@@ -7,6 +7,7 @@
  * @problem.severity warning
  * @precision very-high
  * @id java/constant-comparison
+ * @suites security-and-quality
  * @tags correctness
  *       logic
  *       external/cwe/cwe-570

--- a/java/ql/src/Likely Bugs/Comparison/WrongNanComparison.ql
+++ b/java/ql/src/Likely Bugs/Comparison/WrongNanComparison.ql
@@ -6,6 +6,7 @@
  * @problem.severity error
  * @precision very-high
  * @id java/comparison-with-nan
+ * @suites security-and-quality
  * @tags correctness
  */
 

--- a/java/ql/src/Likely Bugs/Concurrency/CallsToConditionWait.ql
+++ b/java/ql/src/Likely Bugs/Concurrency/CallsToConditionWait.ql
@@ -6,6 +6,7 @@
  * @problem.severity error
  * @precision medium
  * @id java/wait-on-condition-interface
+ * @suites security-and-quality
  * @tags reliability
  *       correctness
  *       concurrency

--- a/java/ql/src/Likely Bugs/Concurrency/CallsToRunnableRun.ql
+++ b/java/ql/src/Likely Bugs/Concurrency/CallsToRunnableRun.ql
@@ -6,6 +6,7 @@
  * @problem.severity recommendation
  * @precision high
  * @id java/call-to-thread-run
+ * @suites security-and-quality
  * @tags reliability
  *       correctness
  *       concurrency

--- a/java/ql/src/Likely Bugs/Concurrency/DateFormatThreadUnsafe.ql
+++ b/java/ql/src/Likely Bugs/Concurrency/DateFormatThreadUnsafe.ql
@@ -6,6 +6,7 @@
  * @problem.severity warning
  * @precision medium
  * @id java/thread-unsafe-dateformat
+ * @suites security-and-quality
  * @tags reliability
  *       correctness
  *       concurrency

--- a/java/ql/src/Likely Bugs/Concurrency/DoubleCheckedLocking.ql
+++ b/java/ql/src/Likely Bugs/Concurrency/DoubleCheckedLocking.ql
@@ -6,6 +6,7 @@
  * @problem.severity error
  * @precision high
  * @id java/unsafe-double-checked-locking
+ * @suites security-and-quality
  * @tags reliability
  *       correctness
  *       concurrency

--- a/java/ql/src/Likely Bugs/Concurrency/DoubleCheckedLockingWithInitRace.ql
+++ b/java/ql/src/Likely Bugs/Concurrency/DoubleCheckedLockingWithInitRace.ql
@@ -8,6 +8,7 @@
  * @problem.severity warning
  * @precision high
  * @id java/unsafe-double-checked-locking-init-order
+ * @suites security-and-quality
  * @tags reliability
  *       correctness
  *       concurrency

--- a/java/ql/src/Likely Bugs/Concurrency/FutileSynchOnField.ql
+++ b/java/ql/src/Likely Bugs/Concurrency/FutileSynchOnField.ql
@@ -6,6 +6,7 @@
  * @problem.severity error
  * @precision medium
  * @id java/unsafe-sync-on-field
+ * @suites security-and-quality
  * @tags reliability
  *       correctness
  *       concurrency

--- a/java/ql/src/Likely Bugs/Concurrency/NonSynchronizedOverride.ql
+++ b/java/ql/src/Likely Bugs/Concurrency/NonSynchronizedOverride.ql
@@ -6,6 +6,7 @@
  * @problem.severity warning
  * @precision very-high
  * @id java/non-sync-override
+ * @suites security-and-quality
  * @tags reliability
  *       correctness
  *       concurrency

--- a/java/ql/src/Likely Bugs/Concurrency/NotifyNotNotifyAll.ql
+++ b/java/ql/src/Likely Bugs/Concurrency/NotifyNotNotifyAll.ql
@@ -6,6 +6,7 @@
  * @problem.severity warning
  * @precision medium
  * @id java/notify-instead-of-notify-all
+ * @suites security-and-quality
  * @tags reliability
  *       correctness
  *       concurrency

--- a/java/ql/src/Likely Bugs/Concurrency/SleepWithLock.ql
+++ b/java/ql/src/Likely Bugs/Concurrency/SleepWithLock.ql
@@ -6,6 +6,7 @@
  * @problem.severity error
  * @precision medium
  * @id java/sleep-with-lock-held
+ * @suites security-and-quality
  * @tags reliability
  *       correctness
  *       concurrency

--- a/java/ql/src/Likely Bugs/Concurrency/StartInConstructor.ql
+++ b/java/ql/src/Likely Bugs/Concurrency/StartInConstructor.ql
@@ -7,6 +7,7 @@
  * @problem.severity warning
  * @precision medium
  * @id java/thread-start-in-constructor
+ * @suites security-and-quality
  * @tags reliability
  *       correctness
  *       concurrency

--- a/java/ql/src/Likely Bugs/Concurrency/SynchOnBoxedType.ql
+++ b/java/ql/src/Likely Bugs/Concurrency/SynchOnBoxedType.ql
@@ -7,6 +7,7 @@
  * @problem.severity error
  * @precision very-high
  * @id java/sync-on-boxed-types
+ * @suites security-and-quality
  * @tags reliability
  *       correctness
  *       concurrency

--- a/java/ql/src/Likely Bugs/Concurrency/SynchSetUnsynchGet.ql
+++ b/java/ql/src/Likely Bugs/Concurrency/SynchSetUnsynchGet.ql
@@ -7,6 +7,7 @@
  * @problem.severity error
  * @precision very-high
  * @id java/unsynchronized-getter
+ * @suites security-and-quality
  * @tags reliability
  *       correctness
  *       concurrency

--- a/java/ql/src/Likely Bugs/Concurrency/SynchWriteObject.ql
+++ b/java/ql/src/Likely Bugs/Concurrency/SynchWriteObject.ql
@@ -6,6 +6,7 @@
  * @problem.severity warning
  * @precision medium
  * @id java/inconsistent-sync-writeobject
+ * @suites security-and-quality
  * @tags reliability
  *       correctness
  *       concurrency

--- a/java/ql/src/Likely Bugs/Concurrency/UnreleasedLock.ql
+++ b/java/ql/src/Likely Bugs/Concurrency/UnreleasedLock.ql
@@ -7,6 +7,7 @@
  * @security-severity 5.0
  * @precision medium
  * @id java/unreleased-lock
+ * @suites security-and-quality
  * @tags reliability
  *       security
  *       external/cwe/cwe-764

--- a/java/ql/src/Likely Bugs/Finalization/NullifiedSuperFinalize.ql
+++ b/java/ql/src/Likely Bugs/Finalization/NullifiedSuperFinalize.ql
@@ -6,6 +6,7 @@
  * @problem.severity error
  * @precision medium
  * @id java/missing-super-finalize
+ * @suites security-and-quality
  * @tags reliability
  *       maintainability
  *       external/cwe/cwe-568

--- a/java/ql/src/Likely Bugs/Frameworks/JUnit/BadSuiteMethod.ql
+++ b/java/ql/src/Likely Bugs/Frameworks/JUnit/BadSuiteMethod.ql
@@ -6,6 +6,7 @@
  * @problem.severity warning
  * @precision medium
  * @id java/wrong-junit-suite-signature
+ * @suites security-and-quality
  * @tags testability
  *       maintainability
  *       frameworks/junit

--- a/java/ql/src/Likely Bugs/Frameworks/Swing/BadlyOverriddenAdapter.ql
+++ b/java/ql/src/Likely Bugs/Frameworks/Swing/BadlyOverriddenAdapter.ql
@@ -7,6 +7,7 @@
  * @problem.severity warning
  * @precision medium
  * @id java/wrong-swing-event-adapter-signature
+ * @suites security-and-quality
  * @tags reliability
  *       maintainability
  *       frameworks/swing

--- a/java/ql/src/Likely Bugs/Inheritance/NoNonFinalInConstructor.ql
+++ b/java/ql/src/Likely Bugs/Inheritance/NoNonFinalInConstructor.ql
@@ -6,6 +6,7 @@
  * @problem.severity error
  * @precision very-high
  * @id java/non-final-call-in-constructor
+ * @suites security-and-quality
  * @tags reliability
  *       correctness
  *       logic

--- a/java/ql/src/Likely Bugs/Likely Typos/ContainerSizeCmpZero.ql
+++ b/java/ql/src/Likely Bugs/Likely Typos/ContainerSizeCmpZero.ql
@@ -5,6 +5,7 @@
  * @problem.severity warning
  * @precision very-high
  * @id java/test-for-negative-container-size
+ * @suites security-and-quality
  * @tags reliability
  *       correctness
  *       logic

--- a/java/ql/src/Likely Bugs/Likely Typos/ContradictoryTypeChecks.ql
+++ b/java/ql/src/Likely Bugs/Likely Typos/ContradictoryTypeChecks.ql
@@ -7,6 +7,7 @@
  * @problem.severity error
  * @precision very-high
  * @id java/contradictory-type-checks
+ * @suites security-and-quality
  * @tags correctness
  *       logic
  */

--- a/java/ql/src/Likely Bugs/Likely Typos/ContradictoryTypeChecks.ql
+++ b/java/ql/src/Likely Bugs/Likely Typos/ContradictoryTypeChecks.ql
@@ -8,6 +8,7 @@
  * @precision very-high
  * @id java/contradictory-type-checks
  * @suites security-and-quality
+ *         quality
  * @tags correctness
  *       logic
  */

--- a/java/ql/src/Likely Bugs/Likely Typos/DangerousNonCircuitLogic.ql
+++ b/java/ql/src/Likely Bugs/Likely Typos/DangerousNonCircuitLogic.ql
@@ -7,6 +7,7 @@
  * @problem.severity warning
  * @precision medium
  * @id java/non-short-circuit-evaluation
+ * @suites security-and-quality
  * @tags reliability
  *       readability
  *       external/cwe/cwe-691

--- a/java/ql/src/Likely Bugs/Likely Typos/EqualsTypo.ql
+++ b/java/ql/src/Likely Bugs/Likely Typos/EqualsTypo.ql
@@ -5,6 +5,7 @@
  * @problem.severity warning
  * @precision medium
  * @id java/equals-typo
+ * @suites security-and-quality
  * @tags maintainability
  *       readability
  *       naming

--- a/java/ql/src/Likely Bugs/Likely Typos/HashCodeTypo.ql
+++ b/java/ql/src/Likely Bugs/Likely Typos/HashCodeTypo.ql
@@ -5,6 +5,7 @@
  * @problem.severity warning
  * @precision medium
  * @id java/hashcode-typo
+ * @suites security-and-quality
  * @tags maintainability
  *       readability
  *       naming

--- a/java/ql/src/Likely Bugs/Likely Typos/MissingFormatArg.ql
+++ b/java/ql/src/Likely Bugs/Likely Typos/MissingFormatArg.ql
@@ -6,6 +6,7 @@
  * @problem.severity error
  * @precision very-high
  * @id java/missing-format-argument
+ * @suites security-and-quality
  * @tags correctness
  *       external/cwe/cwe-685
  */

--- a/java/ql/src/Likely Bugs/Likely Typos/MissingSpaceTypo.ql
+++ b/java/ql/src/Likely Bugs/Likely Typos/MissingSpaceTypo.ql
@@ -7,6 +7,7 @@
  * @problem.severity recommendation
  * @precision very-high
  * @id java/missing-space-in-concatenation
+ * @suites security-and-quality
  * @tags readability
  */
 

--- a/java/ql/src/Likely Bugs/Likely Typos/SelfAssignment.ql
+++ b/java/ql/src/Likely Bugs/Likely Typos/SelfAssignment.ql
@@ -5,6 +5,7 @@
  * @problem.severity error
  * @precision very-high
  * @id java/redundant-assignment
+ * @suites security-and-quality
  * @tags reliability
  *       correctness
  *       logic

--- a/java/ql/src/Likely Bugs/Likely Typos/StringBufferCharInit.ql
+++ b/java/ql/src/Likely Bugs/Likely Typos/StringBufferCharInit.ql
@@ -6,6 +6,7 @@
  * @problem.severity error
  * @precision very-high
  * @id java/string-buffer-char-init
+ * @suites security-and-quality
  * @tags reliability
  *       maintainability
  */

--- a/java/ql/src/Likely Bugs/Likely Typos/SuspiciousDateFormat.ql
+++ b/java/ql/src/Likely Bugs/Likely Typos/SuspiciousDateFormat.ql
@@ -5,6 +5,7 @@
  * @problem.severity warning
  * @precision high
  * @id java/suspicious-date-format
+ * @suites security-and-quality
  * @tags correctness
  */
 

--- a/java/ql/src/Likely Bugs/Likely Typos/SuspiciousDateFormat.ql
+++ b/java/ql/src/Likely Bugs/Likely Typos/SuspiciousDateFormat.ql
@@ -6,6 +6,7 @@
  * @precision high
  * @id java/suspicious-date-format
  * @suites security-and-quality
+ *         quality
  * @tags correctness
  */
 

--- a/java/ql/src/Likely Bugs/Likely Typos/ToStringTypo.ql
+++ b/java/ql/src/Likely Bugs/Likely Typos/ToStringTypo.ql
@@ -5,6 +5,7 @@
  * @problem.severity warning
  * @precision medium
  * @id java/tostring-typo
+ * @suites security-and-quality
  * @tags maintainability
  *       readability
  *       naming

--- a/java/ql/src/Likely Bugs/Likely Typos/UnusedFormatArg.ql
+++ b/java/ql/src/Likely Bugs/Likely Typos/UnusedFormatArg.ql
@@ -7,6 +7,7 @@
  * @problem.severity warning
  * @precision very-high
  * @id java/unused-format-argument
+ * @suites security-and-quality
  * @tags maintainability
  *       useless-code
  *       external/cwe/cwe-685

--- a/java/ql/src/Likely Bugs/Nullness/NullAlways.ql
+++ b/java/ql/src/Likely Bugs/Nullness/NullAlways.ql
@@ -5,6 +5,7 @@
  * @problem.severity error
  * @precision very-high
  * @id java/dereferenced-value-is-always-null
+ * @suites security-and-quality
  * @tags reliability
  *       correctness
  *       exceptions

--- a/java/ql/src/Likely Bugs/Nullness/NullExprDeref.ql
+++ b/java/ql/src/Likely Bugs/Nullness/NullExprDeref.ql
@@ -6,6 +6,7 @@
  * @problem.severity warning
  * @precision high
  * @id java/dereferenced-expr-may-be-null
+ * @suites security-and-quality
  * @tags reliability
  *       correctness
  *       exceptions

--- a/java/ql/src/Likely Bugs/Nullness/NullMaybe.ql
+++ b/java/ql/src/Likely Bugs/Nullness/NullMaybe.ql
@@ -6,6 +6,7 @@
  * @problem.severity warning
  * @precision high
  * @id java/dereferenced-value-may-be-null
+ * @suites security-and-quality
  * @tags reliability
  *       correctness
  *       exceptions

--- a/java/ql/src/Likely Bugs/Reflection/AnnotationPresentCheck.ql
+++ b/java/ql/src/Likely Bugs/Reflection/AnnotationPresentCheck.ql
@@ -6,6 +6,7 @@
  * @problem.severity error
  * @precision medium
  * @id java/ineffective-annotation-present-check
+ * @suites security-and-quality
  * @tags correctness
  *       logic
  */

--- a/java/ql/src/Likely Bugs/Resource Leaks/CloseReader.ql
+++ b/java/ql/src/Likely Bugs/Resource Leaks/CloseReader.ql
@@ -6,6 +6,7 @@
  * @problem.severity warning
  * @precision high
  * @id java/input-resource-leak
+ * @suites security-and-quality
  * @tags efficiency
  *       correctness
  *       resources

--- a/java/ql/src/Likely Bugs/Resource Leaks/CloseReader.ql
+++ b/java/ql/src/Likely Bugs/Resource Leaks/CloseReader.ql
@@ -7,6 +7,7 @@
  * @precision high
  * @id java/input-resource-leak
  * @suites security-and-quality
+ *         quality
  * @tags efficiency
  *       correctness
  *       resources

--- a/java/ql/src/Likely Bugs/Resource Leaks/CloseSql.ql
+++ b/java/ql/src/Likely Bugs/Resource Leaks/CloseSql.ql
@@ -5,6 +5,7 @@
  * @problem.severity warning
  * @precision high
  * @id java/database-resource-leak
+ * @suites security-and-quality
  * @tags correctness
  *       resources
  *       external/cwe/cwe-404

--- a/java/ql/src/Likely Bugs/Resource Leaks/CloseWriter.ql
+++ b/java/ql/src/Likely Bugs/Resource Leaks/CloseWriter.ql
@@ -7,6 +7,7 @@
  * @precision high
  * @id java/output-resource-leak
  * @suites security-and-quality
+ *         quality
  * @tags efficiency
  *       correctness
  *       resources

--- a/java/ql/src/Likely Bugs/Resource Leaks/CloseWriter.ql
+++ b/java/ql/src/Likely Bugs/Resource Leaks/CloseWriter.ql
@@ -6,6 +6,7 @@
  * @problem.severity warning
  * @precision high
  * @id java/output-resource-leak
+ * @suites security-and-quality
  * @tags efficiency
  *       correctness
  *       resources

--- a/java/ql/src/Likely Bugs/Serialization/IncorrectSerialVersionUID.ql
+++ b/java/ql/src/Likely Bugs/Serialization/IncorrectSerialVersionUID.ql
@@ -6,6 +6,7 @@
  * @problem.severity warning
  * @precision medium
  * @id java/incorrect-serial-version-uid
+ * @suites security-and-quality
  * @tags reliability
  *       maintainability
  *       language-features

--- a/java/ql/src/Likely Bugs/Serialization/IncorrectSerializableMethods.ql
+++ b/java/ql/src/Likely Bugs/Serialization/IncorrectSerializableMethods.ql
@@ -6,6 +6,7 @@
  * @problem.severity warning
  * @precision medium
  * @id java/wrong-object-serialization-signature
+ * @suites security-and-quality
  * @tags reliability
  *       maintainability
  *       language-features

--- a/java/ql/src/Likely Bugs/Serialization/MissingVoidConstructorOnExternalizable.ql
+++ b/java/ql/src/Likely Bugs/Serialization/MissingVoidConstructorOnExternalizable.ql
@@ -6,6 +6,7 @@
  * @problem.severity warning
  * @precision medium
  * @id java/missing-no-arg-constructor-on-externalizable
+ * @suites security-and-quality
  * @tags reliability
  *       maintainability
  *       language-features

--- a/java/ql/src/Likely Bugs/Serialization/MissingVoidConstructorsOnSerializable.ql
+++ b/java/ql/src/Likely Bugs/Serialization/MissingVoidConstructorsOnSerializable.ql
@@ -7,6 +7,7 @@
  * @problem.severity warning
  * @precision medium
  * @id java/missing-no-arg-constructor-on-serializable
+ * @suites security-and-quality
  * @tags reliability
  *       maintainability
  *       language-features

--- a/java/ql/src/Likely Bugs/Serialization/NonSerializableInnerClass.ql
+++ b/java/ql/src/Likely Bugs/Serialization/NonSerializableInnerClass.ql
@@ -6,6 +6,7 @@
  * @problem.severity warning
  * @precision medium
  * @id java/non-serializable-inner-class
+ * @suites security-and-quality
  * @tags reliability
  *       maintainability
  *       language-features

--- a/java/ql/src/Likely Bugs/Serialization/ReadResolveObject.ql
+++ b/java/ql/src/Likely Bugs/Serialization/ReadResolveObject.ql
@@ -7,6 +7,7 @@
  * @problem.severity warning
  * @precision medium
  * @id java/wrong-readresolve-signature
+ * @suites security-and-quality
  * @tags reliability
  *       maintainability
  *       language-features

--- a/java/ql/src/Likely Bugs/Statements/ContinueInFalseLoop.ql
+++ b/java/ql/src/Likely Bugs/Statements/ContinueInFalseLoop.ql
@@ -8,6 +8,7 @@
  * @id java/continue-in-false-loop
  * @problem.severity warning
  * @precision high
+ * @suites security-and-quality
  * @tags correctness
  */
 

--- a/java/ql/src/Likely Bugs/Statements/MissingEnumInSwitch.ql
+++ b/java/ql/src/Likely Bugs/Statements/MissingEnumInSwitch.ql
@@ -6,6 +6,7 @@
  * @problem.severity warning
  * @precision medium
  * @id java/missing-case-in-switch
+ * @suites security-and-quality
  * @tags reliability
  *       readability
  *       external/cwe/cwe-478

--- a/java/ql/src/Likely Bugs/Statements/PartiallyMaskedCatch.ql
+++ b/java/ql/src/Likely Bugs/Statements/PartiallyMaskedCatch.ql
@@ -6,6 +6,7 @@
  * @problem.severity warning
  * @precision high
  * @id java/unreachable-catch-clause
+ * @suites security-and-quality
  * @tags reliability
  *       correctness
  *       exceptions

--- a/java/ql/src/Likely Bugs/Statements/UseBraces.ql
+++ b/java/ql/src/Likely Bugs/Statements/UseBraces.ql
@@ -6,6 +6,7 @@
  * @problem.severity warning
  * @precision very-high
  * @id java/misleading-indentation
+ * @suites security-and-quality
  * @tags maintainability
  *       correctness
  *       logic

--- a/java/ql/src/Likely Bugs/Termination/ConstantLoopCondition.ql
+++ b/java/ql/src/Likely Bugs/Termination/ConstantLoopCondition.ql
@@ -7,6 +7,7 @@
  * @problem.severity warning
  * @precision very-high
  * @id java/constant-loop-condition
+ * @suites security-and-quality
  * @tags correctness
  *       external/cwe/cwe-835
  */

--- a/java/ql/src/Likely Bugs/Termination/SpinOnField.ql
+++ b/java/ql/src/Likely Bugs/Termination/SpinOnField.ql
@@ -6,6 +6,7 @@
  * @problem.severity warning
  * @precision medium
  * @id java/spin-on-field
+ * @suites security-and-quality
  * @tags efficiency
  *       correctness
  *       concurrency

--- a/java/ql/src/Performance/InefficientEmptyStringTest.ql
+++ b/java/ql/src/Performance/InefficientEmptyStringTest.ql
@@ -5,6 +5,7 @@
  * @problem.severity recommendation
  * @precision high
  * @id java/inefficient-empty-string-test
+ * @suites security-and-quality
  * @tags efficiency
  *       maintainability
  */

--- a/java/ql/src/Performance/InefficientKeySetIterator.ql
+++ b/java/ql/src/Performance/InefficientKeySetIterator.ql
@@ -5,6 +5,7 @@
  * @problem.severity recommendation
  * @precision high
  * @id java/inefficient-key-set-iterator
+ * @suites security-and-quality
  * @tags efficiency
  *       maintainability
  */

--- a/java/ql/src/Performance/InefficientOutputStream.ql
+++ b/java/ql/src/Performance/InefficientOutputStream.ql
@@ -6,6 +6,7 @@
  * @problem.severity warning
  * @precision very-high
  * @id java/inefficient-output-stream
+ * @suites security-and-quality
  * @tags efficiency
  */
 

--- a/java/ql/src/Performance/InefficientPrimConstructor.ql
+++ b/java/ql/src/Performance/InefficientPrimConstructor.ql
@@ -5,6 +5,7 @@
  * @problem.severity recommendation
  * @precision high
  * @id java/inefficient-boxed-constructor
+ * @suites security-and-quality
  * @tags efficiency
  *       maintainability
  */

--- a/java/ql/src/Performance/InnerClassCouldBeStatic.ql
+++ b/java/ql/src/Performance/InnerClassCouldBeStatic.ql
@@ -6,6 +6,7 @@
  * @problem.severity recommendation
  * @precision high
  * @id java/non-static-nested-class
+ * @suites security-and-quality
  * @tags efficiency
  *       maintainability
  */

--- a/java/ql/src/Performance/NewStringString.ql
+++ b/java/ql/src/Performance/NewStringString.ql
@@ -6,6 +6,7 @@
  * @problem.severity recommendation
  * @precision high
  * @id java/inefficient-string-constructor
+ * @suites security-and-quality
  * @tags efficiency
  *       maintainability
  */

--- a/java/ql/src/Violations of Best Practice/Boxed Types/BoxedVariable.ql
+++ b/java/ql/src/Violations of Best Practice/Boxed Types/BoxedVariable.ql
@@ -6,6 +6,7 @@
  * @problem.severity warning
  * @precision very-high
  * @id java/non-null-boxed-variable
+ * @suites security-and-quality
  * @tags readability
  *       types
  */

--- a/java/ql/src/Violations of Best Practice/Dead Code/CreatesEmptyZip.ql
+++ b/java/ql/src/Violations of Best Practice/Dead Code/CreatesEmptyZip.ql
@@ -6,6 +6,7 @@
  * @problem.severity warning
  * @precision medium
  * @id java/empty-zip-file-entry
+ * @suites security-and-quality
  * @tags reliability
  *       readability
  */

--- a/java/ql/src/Violations of Best Practice/Dead Code/DeadRefTypes.ql
+++ b/java/ql/src/Violations of Best Practice/Dead Code/DeadRefTypes.ql
@@ -6,6 +6,7 @@
  * @problem.severity recommendation
  * @precision high
  * @id java/unused-reference-type
+ * @suites security-and-quality
  * @tags maintainability
  *       useless-code
  *       external/cwe/cwe-561

--- a/java/ql/src/Violations of Best Practice/Dead Code/InterfaceCannotBeImplemented.ql
+++ b/java/ql/src/Violations of Best Practice/Dead Code/InterfaceCannotBeImplemented.ql
@@ -6,6 +6,7 @@
  * @problem.severity warning
  * @precision very-high
  * @id java/unimplementable-interface
+ * @suites security-and-quality
  * @tags maintainability
  *       useless-code
  */

--- a/java/ql/src/Violations of Best Practice/Dead Code/UnreadLocal.ql
+++ b/java/ql/src/Violations of Best Practice/Dead Code/UnreadLocal.ql
@@ -5,6 +5,7 @@
  * @problem.severity recommendation
  * @precision high
  * @id java/local-variable-is-never-read
+ * @suites security-and-quality
  * @tags maintainability
  *       useless-code
  *       external/cwe/cwe-561

--- a/java/ql/src/Violations of Best Practice/Dead Code/UnusedLabel.ql
+++ b/java/ql/src/Violations of Best Practice/Dead Code/UnusedLabel.ql
@@ -6,6 +6,7 @@
  * @problem.severity recommendation
  * @precision high
  * @id java/unused-label
+ * @suites security-and-quality
  * @tags maintainability
  *       useless-code
  *       external/cwe/cwe-561

--- a/java/ql/src/Violations of Best Practice/Declarations/NoConstantsOnly.ql
+++ b/java/ql/src/Violations of Best Practice/Declarations/NoConstantsOnly.ql
@@ -6,6 +6,7 @@
  * @problem.severity recommendation
  * @precision high
  * @id java/constants-only-interface
+ * @suites security-and-quality
  * @tags maintainability
  *       modularity
  */

--- a/java/ql/src/Violations of Best Practice/Exception Handling/IgnoreExceptionalReturn.ql
+++ b/java/ql/src/Violations of Best Practice/Exception Handling/IgnoreExceptionalReturn.ql
@@ -6,6 +6,7 @@
  * @problem.severity recommendation
  * @precision high
  * @id java/ignored-error-status-of-call
+ * @suites security-and-quality
  * @tags reliability
  *       correctness
  *       external/cwe/cwe-391

--- a/java/ql/src/Violations of Best Practice/Exception Handling/NumberFormatException.ql
+++ b/java/ql/src/Violations of Best Practice/Exception Handling/NumberFormatException.ql
@@ -6,6 +6,7 @@
  * @problem.severity recommendation
  * @precision high
  * @id java/uncaught-number-format-exception
+ * @suites security-and-quality
  * @tags reliability
  *       external/cwe/cwe-248
  */

--- a/java/ql/src/Violations of Best Practice/Implementation Hiding/AbstractToConcreteCollection.ql
+++ b/java/ql/src/Violations of Best Practice/Implementation Hiding/AbstractToConcreteCollection.ql
@@ -6,6 +6,7 @@
  * @problem.severity warning
  * @precision very-high
  * @id java/abstract-to-concrete-cast
+ * @suites security-and-quality
  * @tags reliability
  *       maintainability
  *       modularity

--- a/java/ql/src/Violations of Best Practice/Implementation Hiding/ExposeRepresentation.ql
+++ b/java/ql/src/Violations of Best Practice/Implementation Hiding/ExposeRepresentation.ql
@@ -6,6 +6,7 @@
  * @problem.severity recommendation
  * @precision high
  * @id java/internal-representation-exposure
+ * @suites security-and-quality
  * @tags reliability
  *       maintainability
  *       modularity

--- a/java/ql/src/Violations of Best Practice/Implementation Hiding/GetClassGetResource.ql
+++ b/java/ql/src/Violations of Best Practice/Implementation Hiding/GetClassGetResource.ql
@@ -6,6 +6,7 @@
  * @problem.severity warning
  * @precision medium
  * @id java/unsafe-get-resource
+ * @suites security-and-quality
  * @tags reliability
  *       maintainability
  */

--- a/java/ql/src/Violations of Best Practice/Naming Conventions/AmbiguousOuterSuper.ql
+++ b/java/ql/src/Violations of Best Practice/Naming Conventions/AmbiguousOuterSuper.ql
@@ -6,6 +6,7 @@
  * @problem.severity warning
  * @precision very-high
  * @id java/subtle-inherited-call
+ * @suites security-and-quality
  * @tags reliability
  *       readability
  */

--- a/java/ql/src/Violations of Best Practice/Naming Conventions/ConfusingMethodNames.ql
+++ b/java/ql/src/Violations of Best Practice/Naming Conventions/ConfusingMethodNames.ql
@@ -6,6 +6,7 @@
  * @problem.severity recommendation
  * @precision high
  * @id java/confusing-method-name
+ * @suites security-and-quality
  * @tags maintainability
  *       readability
  *       naming

--- a/java/ql/src/Violations of Best Practice/Naming Conventions/ConfusingOverloading.ql
+++ b/java/ql/src/Violations of Best Practice/Naming Conventions/ConfusingOverloading.ql
@@ -7,6 +7,7 @@
  * @problem.severity recommendation
  * @precision high
  * @id java/confusing-method-signature
+ * @suites security-and-quality
  * @tags maintainability
  *       readability
  *       naming

--- a/java/ql/src/Violations of Best Practice/Naming Conventions/FieldMasksSuperField.ql
+++ b/java/ql/src/Violations of Best Practice/Naming Conventions/FieldMasksSuperField.ql
@@ -7,6 +7,7 @@
  * @problem.severity warning
  * @precision medium
  * @id java/field-masks-super-field
+ * @suites security-and-quality
  * @tags maintainability
  *       readability
  */

--- a/java/ql/src/Violations of Best Practice/Naming Conventions/LocalShadowsFieldConfusing.ql
+++ b/java/ql/src/Violations of Best Practice/Naming Conventions/LocalShadowsFieldConfusing.ql
@@ -6,6 +6,7 @@
  * @problem.severity recommendation
  * @precision high
  * @id java/local-shadows-field
+ * @suites security-and-quality
  * @tags maintainability
  *       readability
  */

--- a/java/ql/src/Violations of Best Practice/Naming Conventions/SameNameAsSuper.ql
+++ b/java/ql/src/Violations of Best Practice/Naming Conventions/SameNameAsSuper.ql
@@ -5,6 +5,7 @@
  * @problem.severity recommendation
  * @precision high
  * @id java/class-name-matches-super-class
+ * @suites security-and-quality
  * @tags maintainability
  *       readability
  *       naming

--- a/java/ql/src/Violations of Best Practice/Undesirable Calls/CallsToRunFinalizersOnExit.ql
+++ b/java/ql/src/Violations of Best Practice/Undesirable Calls/CallsToRunFinalizersOnExit.ql
@@ -7,6 +7,7 @@
  * @problem.severity error
  * @precision medium
  * @id java/run-finalizers-on-exit
+ * @suites security-and-quality
  * @tags reliability
  *       maintainability
  */

--- a/java/ql/src/Violations of Best Practice/Undesirable Calls/CallsToStringToString.ql
+++ b/java/ql/src/Violations of Best Practice/Undesirable Calls/CallsToStringToString.ql
@@ -5,6 +5,7 @@
  * @problem.severity recommendation
  * @precision high
  * @id java/useless-tostring-call
+ * @suites security-and-quality
  * @tags maintainability
  */
 

--- a/java/ql/src/Violations of Best Practice/Undesirable Calls/DefaultToString.ql
+++ b/java/ql/src/Violations of Best Practice/Undesirable Calls/DefaultToString.ql
@@ -6,6 +6,7 @@
  * @problem.severity recommendation
  * @precision high
  * @id java/call-to-object-tostring
+ * @suites security-and-quality
  * @tags reliability
  *       maintainability
  */

--- a/java/ql/src/Violations of Best Practice/Undesirable Calls/NextFromIterator.ql
+++ b/java/ql/src/Violations of Best Practice/Undesirable Calls/NextFromIterator.ql
@@ -6,6 +6,7 @@
  * @problem.severity warning
  * @precision medium
  * @id java/iterator-hasnext-calls-next
+ * @suites security-and-quality
  * @tags reliability
  *       correctness
  */

--- a/java/ql/src/Violations of Best Practice/Undesirable Calls/PrintLnArray.ql
+++ b/java/ql/src/Violations of Best Practice/Undesirable Calls/PrintLnArray.ql
@@ -6,6 +6,7 @@
  * @problem.severity recommendation
  * @precision very-high
  * @id java/print-array
+ * @suites security-and-quality
  * @tags maintainability
  */
 

--- a/java/ql/src/codeql-suites/java-code-quality.qls
+++ b/java/ql/src/codeql-suites/java-code-quality.qls
@@ -1,14 +1,4 @@
 - queries: .
 - include:
-    id:
-      - java/suspicious-date-format
-      - java/integer-multiplication-cast-to-long
-      - java/equals-on-unrelated-types
-      - java/contradictory-type-checks
-      - java/reference-equality-of-boxed-types
-      - java/inconsistent-equals-and-hashcode
-      - java/unchecked-cast-in-equals
-      - java/unused-container
-      - java/input-resource-leak
-      - java/output-resource-leak
-      - java/type-variable-hides-type
+    suites contain:
+    - quality

--- a/java/ql/src/codeql-suites/java-security-and-quality.qls
+++ b/java/ql/src/codeql-suites/java-security-and-quality.qls
@@ -7,14 +7,22 @@
     precision:
     - high
     - very-high
+    tags contain:
+    - security
 - include:
     kind:
     - problem
     - path-problem
-    precision: medium
+    precision:
+    - medium
     problem.severity:
-      - error
-      - warning
+    - error
+    - warning
+    tags contain:
+    - security
+- include:
+    suites contain:
+    - security-and-quality
 - include:
     kind:
     - diagnostic

--- a/java/ql/src/codeql-suites/java-security-and-quality.qls
+++ b/java/ql/src/codeql-suites/java-security-and-quality.qls
@@ -1,4 +1,36 @@
 - description: Security-and-quality queries for Java
 - queries: .
-- apply: security-and-quality-selectors.yml
-  from: codeql/suite-helpers
+- include:
+    kind:
+    - problem
+    - path-problem
+    precision:
+    - high
+    - very-high
+- include:
+    kind:
+    - problem
+    - path-problem
+    precision: medium
+    problem.severity:
+      - error
+      - warning
+- include:
+    kind:
+    - diagnostic
+- include:
+    kind:
+    - metric
+    tags contain:
+    - summary
+- exclude:
+    deprecated: //
+- exclude:
+    query path:
+      - /^experimental\/.*/
+      - Metrics/Summaries/FrameworkCoverage.ql
+      - /Diagnostics/Internal/.*/
+- exclude:
+    tags contain:
+      - modeleditor
+      - modelgenerator


### PR DESCRIPTION
This PR depends on an internal one (linked below) to add the necessary filtering capability based on `@suites`.