### PR TITLE
ruby: add `rb/useless-assignment-to-local` to the code-quality suite

### DIFF
--- a/ruby/ql/src/codeql-suites/ruby-code-quality.qls
+++ b/ruby/ql/src/codeql-suites/ruby-code-quality.qls
@@ -2,3 +2,4 @@
 - include:
     id:
       - rb/database-query-in-loop
+      - rb/useless-assignment-to-local


### PR DESCRIPTION
This PR adds the query `rb/useless-assignment-to-local` to the code-quality suite.
The query was improved in https://github.com/github/codeql/pull/19164 to the point of increasing its precision.
It has been triaged locally and both results and fixes were found to be reasonable.