### PR TITLE
JS: Taint propagation from low-level `ArrayBuffer` to `Strings`

### DIFF
--- a/javascript/ql/lib/change-notes/2025-04-07-typed-arrays.md
+++ b/javascript/ql/lib/change-notes/2025-04-07-typed-arrays.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added taint propagation for `Uint8Array`, `ArrayBuffer`, `SharedArrayBuffer` and `TextDecoder.decode()`.

--- a/javascript/ql/lib/semmle/javascript/internal/flow_summaries/AllFlowSummaries.qll
+++ b/javascript/ql/lib/semmle/javascript/internal/flow_summaries/AllFlowSummaries.qll
@@ -13,3 +13,4 @@ private import Strings
 private import DynamicImportStep
 private import UrlSearchParams
 private import TypedArrays
+private import Decoders

--- a/javascript/ql/lib/semmle/javascript/internal/flow_summaries/AllFlowSummaries.qll
+++ b/javascript/ql/lib/semmle/javascript/internal/flow_summaries/AllFlowSummaries.qll
@@ -12,3 +12,4 @@ private import Sets
 private import Strings
 private import DynamicImportStep
 private import UrlSearchParams
+private import TypedArrays

--- a/javascript/ql/lib/semmle/javascript/internal/flow_summaries/Decoders.qll
+++ b/javascript/ql/lib/semmle/javascript/internal/flow_summaries/Decoders.qll
@@ -1,0 +1,29 @@
+private import javascript
+private import semmle.javascript.dataflow.FlowSummary
+private import semmle.javascript.dataflow.InferredTypes
+private import semmle.javascript.dataflow.internal.DataFlowPrivate as Private
+private import FlowSummaryUtil
+
+private class TextDecoderEntryPoint extends API::EntryPoint {
+  TextDecoderEntryPoint() { this = "global.TextDecoder" }
+
+  override DataFlow::SourceNode getASource() { result = DataFlow::globalVarRef("TextDecoder") }
+}
+
+pragma[nomagic]
+API::Node textDecoderConstructorRef() { result = any(TextDecoderEntryPoint e).getANode() }
+
+class DecodeLike extends SummarizedCallable {
+  DecodeLike() { this = "TextDecoder#decode" }
+
+  override InstanceCall getACall() {
+    result =
+      textDecoderConstructorRef().getAnInstantiation().getReturn().getMember("decode").getACall()
+  }
+
+  override predicate propagatesFlow(string input, string output, boolean preservesValue) {
+    preservesValue = true and
+    input = "Argument[0]" and
+    output = "ReturnValue"
+  }
+}

--- a/javascript/ql/lib/semmle/javascript/internal/flow_summaries/Decoders.qll
+++ b/javascript/ql/lib/semmle/javascript/internal/flow_summaries/Decoders.qll
@@ -17,8 +17,7 @@ class DecodeLike extends SummarizedCallable {
   DecodeLike() { this = "TextDecoder#decode" }
 
   override InstanceCall getACall() {
-    result =
-      textDecoderConstructorRef().getAnInstantiation().getReturn().getMember("decode").getACall()
+    result = textDecoderConstructorRef().getInstance().getMember("decode").getACall()
   }
 
   override predicate propagatesFlow(string input, string output, boolean preservesValue) {

--- a/javascript/ql/lib/semmle/javascript/internal/flow_summaries/Decoders.qll
+++ b/javascript/ql/lib/semmle/javascript/internal/flow_summaries/Decoders.qll
@@ -13,16 +13,16 @@ private class TextDecoderEntryPoint extends API::EntryPoint {
 pragma[nomagic]
 API::Node textDecoderConstructorRef() { result = any(TextDecoderEntryPoint e).getANode() }
 
-class DecodeLike extends SummarizedCallable {
-  DecodeLike() { this = "TextDecoder#decode" }
+class Decode extends SummarizedCallable {
+  Decode() { this = "TextDecoder#decode" }
 
   override InstanceCall getACall() {
     result = textDecoderConstructorRef().getInstance().getMember("decode").getACall()
   }
 
   override predicate propagatesFlow(string input, string output, boolean preservesValue) {
-    preservesValue = true and
-    input = "Argument[0]" and
+    preservesValue = false and
+    input = "Argument[0].ArrayElement" and
     output = "ReturnValue"
   }
 }

--- a/javascript/ql/lib/semmle/javascript/internal/flow_summaries/Strings.qll
+++ b/javascript/ql/lib/semmle/javascript/internal/flow_summaries/Strings.qll
@@ -108,7 +108,7 @@ class StringFromCharCode extends SummarizedCallable {
   }
 
   override predicate propagatesFlow(string input, string output, boolean preservesValue) {
-    preservesValue = true and
+    preservesValue = false and
     (
       input = "Argument[0..]" and
       output = "ReturnValue"

--- a/javascript/ql/lib/semmle/javascript/internal/flow_summaries/Strings.qll
+++ b/javascript/ql/lib/semmle/javascript/internal/flow_summaries/Strings.qll
@@ -99,3 +99,19 @@ class StringSplitHashOrQuestionMark extends SummarizedCallable {
     )
   }
 }
+
+class StringFromCharCode extends SummarizedCallable {
+  StringFromCharCode() { this = "String#fromCharCode" }
+
+  override DataFlow::CallNode getACall() {
+    result = DataFlow::globalVarRef("String").getAPropertyRead("fromCharCode").getACall()
+  }
+
+  override predicate propagatesFlow(string input, string output, boolean preservesValue) {
+    preservesValue = true and
+    (
+      input = "Argument[0..]" and
+      output = "ReturnValue"
+    )
+  }
+}

--- a/javascript/ql/lib/semmle/javascript/internal/flow_summaries/TypedArrays.qll
+++ b/javascript/ql/lib/semmle/javascript/internal/flow_summaries/TypedArrays.qll
@@ -1,0 +1,38 @@
+private import javascript
+private import semmle.javascript.dataflow.FlowSummary
+private import semmle.javascript.dataflow.InferredTypes
+private import semmle.javascript.dataflow.internal.DataFlowPrivate as Private
+private import FlowSummaryUtil
+
+private class TypedArrayEntryPoint extends API::EntryPoint {
+  TypedArrayEntryPoint() { this = "global.Uint8Array" }
+
+  override DataFlow::SourceNode getASource() { result = DataFlow::globalVarRef("Uint8Array") }
+}
+
+pragma[nomagic]
+API::Node typedArrayConstructorRef() { result = any(TypedArrayEntryPoint e).getANode() }
+
+class TypedArrayConstructorSummary extends SummarizedCallable {
+  TypedArrayConstructorSummary() { this = "TypedArray constructor" }
+
+  override DataFlow::InvokeNode getACall() {
+    result = typedArrayConstructorRef().getAnInstantiation()
+  }
+
+  override predicate propagatesFlow(string input, string output, boolean preservesValue) {
+    preservesValue = true and
+    input = "Argument[0].ArrayElement" and
+    output = "ReturnValue.ArrayElement"
+  }
+}
+
+class BufferTypedArray extends DataFlow::AdditionalFlowStep {
+  override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+    exists(DataFlow::PropRead p |
+      p = typedArrayConstructorRef().getInstance().getMember("buffer").asSource() and
+      pred = p.getBase() and
+      succ = p
+    )
+  }
+}

--- a/javascript/ql/lib/semmle/javascript/internal/flow_summaries/TypedArrays.qll
+++ b/javascript/ql/lib/semmle/javascript/internal/flow_summaries/TypedArrays.qll
@@ -65,3 +65,47 @@ class SubArrayLike extends SummarizedCallable {
     output = "ReturnValue.ArrayElement"
   }
 }
+
+private class ArrayBufferEntryPoint extends API::EntryPoint {
+  ArrayBufferEntryPoint() { this = ["global.ArrayBuffer", "global.SharedArrayBuffer"] }
+
+  override DataFlow::SourceNode getASource() {
+    result = DataFlow::globalVarRef(["ArrayBuffer", "SharedArrayBuffer"])
+  }
+}
+
+pragma[nomagic]
+API::Node arrayBufferConstructorRef() { result = any(ArrayBufferEntryPoint a).getANode() }
+
+class ArrayBufferConstructorSummary extends SummarizedCallable {
+  ArrayBufferConstructorSummary() { this = "ArrayBuffer constructor" }
+
+  override DataFlow::InvokeNode getACall() {
+    result = arrayBufferConstructorRef().getAnInstantiation()
+  }
+
+  override predicate propagatesFlow(string input, string output, boolean preservesValue) {
+    preservesValue = true and
+    input = "Argument[0].ArrayElement" and
+    output = "ReturnValue.ArrayElement"
+  }
+}
+
+class TransferLike extends SummarizedCallable {
+  TransferLike() { this = "ArrayBuffer#transfer" }
+
+  override InstanceCall getACall() {
+    result =
+      arrayBufferConstructorRef()
+          .getAnInstantiation()
+          .getReturn()
+          .getMember(["transfer", "transferToFixedLength"])
+          .getACall()
+  }
+
+  override predicate propagatesFlow(string input, string output, boolean preservesValue) {
+    preservesValue = true and
+    input = "Argument[this].ArrayElement" and
+    output = "ReturnValue.ArrayElement"
+  }
+}

--- a/javascript/ql/lib/semmle/javascript/internal/flow_summaries/TypedArrays.qll
+++ b/javascript/ql/lib/semmle/javascript/internal/flow_summaries/TypedArrays.qll
@@ -74,20 +74,6 @@ private class ArrayBufferEntryPoint extends API::EntryPoint {
 pragma[nomagic]
 API::Node arrayBufferConstructorRef() { result = any(ArrayBufferEntryPoint a).getANode() }
 
-class ArrayBufferConstructorSummary extends SummarizedCallable {
-  ArrayBufferConstructorSummary() { this = "ArrayBuffer constructor" }
-
-  override DataFlow::InvokeNode getACall() {
-    result = arrayBufferConstructorRef().getAnInstantiation()
-  }
-
-  override predicate propagatesFlow(string input, string output, boolean preservesValue) {
-    preservesValue = true and
-    input = "Argument[0].ArrayElement" and
-    output = "ReturnValue.ArrayElement"
-  }
-}
-
 class TransferLike extends SummarizedCallable {
   TransferLike() { this = "ArrayBuffer#transfer" }
 

--- a/javascript/ql/lib/semmle/javascript/internal/flow_summaries/TypedArrays.qll
+++ b/javascript/ql/lib/semmle/javascript/internal/flow_summaries/TypedArrays.qll
@@ -36,3 +36,32 @@ class BufferTypedArray extends DataFlow::AdditionalFlowStep {
     )
   }
 }
+
+class SetLike extends SummarizedCallable {
+  SetLike() { this = "TypedArray#set" }
+
+  override InstanceCall getACall() {
+    result = typedArrayConstructorRef().getAnInstantiation().getReturn().getMember("set").getACall()
+  }
+
+  override predicate propagatesFlow(string input, string output, boolean preservesValue) {
+    preservesValue = true and
+    input = "Argument[0].ArrayElement" and
+    output = "Argument[this].ArrayElement"
+  }
+}
+
+class SubArrayLike extends SummarizedCallable {
+  SubArrayLike() { this = "TypedArray#subarray" }
+
+  override InstanceCall getACall() {
+    result =
+      typedArrayConstructorRef().getAnInstantiation().getReturn().getMember("subarray").getACall()
+  }
+
+  override predicate propagatesFlow(string input, string output, boolean preservesValue) {
+    preservesValue = true and
+    input = "Argument[this].ArrayElement" and
+    output = "ReturnValue.ArrayElement"
+  }
+}

--- a/javascript/ql/lib/semmle/javascript/internal/flow_summaries/TypedArrays.qll
+++ b/javascript/ql/lib/semmle/javascript/internal/flow_summaries/TypedArrays.qll
@@ -37,11 +37,11 @@ class BufferTypedArray extends DataFlow::AdditionalFlowStep {
   }
 }
 
-class SetLike extends SummarizedCallable {
-  SetLike() { this = "TypedArray#set" }
+class TypedArraySet extends SummarizedCallable {
+  TypedArraySet() { this = "TypedArray#set" }
 
   override InstanceCall getACall() {
-    result = typedArrayConstructorRef().getAnInstantiation().getReturn().getMember("set").getACall()
+    result = typedArrayConstructorRef().getInstance().getMember("set").getACall()
   }
 
   override predicate propagatesFlow(string input, string output, boolean preservesValue) {
@@ -51,13 +51,10 @@ class SetLike extends SummarizedCallable {
   }
 }
 
-class SubArrayLike extends SummarizedCallable {
-  SubArrayLike() { this = "TypedArray#subarray" }
+class TypedArraySubarray extends SummarizedCallable {
+  TypedArraySubarray() { this = "TypedArray#subarray" }
 
-  override InstanceCall getACall() {
-    result =
-      typedArrayConstructorRef().getAnInstantiation().getReturn().getMember("subarray").getACall()
-  }
+  override InstanceCall getACall() { result.getMethodName() = "subarray" }
 
   override predicate propagatesFlow(string input, string output, boolean preservesValue) {
     preservesValue = true and
@@ -95,12 +92,7 @@ class TransferLike extends SummarizedCallable {
   TransferLike() { this = "ArrayBuffer#transfer" }
 
   override InstanceCall getACall() {
-    result =
-      arrayBufferConstructorRef()
-          .getAnInstantiation()
-          .getReturn()
-          .getMember(["transfer", "transferToFixedLength"])
-          .getACall()
+    result.getMethodName() = ["transfer", "transferToFixedLength"]
   }
 
   override predicate propagatesFlow(string input, string output, boolean preservesValue) {

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -40,15 +40,15 @@ legacyDataFlowDifference
 | typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:11:10:11:12 | arr | only flow with NEW data flow library |
 | typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:15:10:15:10 | z | only flow with NEW data flow library |
 | typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:18:10:18:12 | sub | only flow with NEW data flow library |
+| typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:22:10:22:13 | view | only flow with NEW data flow library |
+| typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:26:10:26:14 | view1 | only flow with NEW data flow library |
+| typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:30:10:30:23 | transferedView | only flow with NEW data flow library |
+| typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:34:10:34:24 | transferedView2 | only flow with NEW data flow library |
 | use-use-after-implicit-read.js:7:17:7:24 | source() | use-use-after-implicit-read.js:15:10:15:10 | x | only flow with NEW data flow library |
 consistencyIssue
 | nested-props.js:20 | expected an alert, but found none | NOT OK - but not found | Consistency |
 | stringification-read-steps.js:17 | expected an alert, but found none | NOT OK | Consistency |
 | stringification-read-steps.js:25 | expected an alert, but found none | NOT OK | Consistency |
-| typed-arrays.js:22 | expected an alert, but found none | NOT OK | Consistency |
-| typed-arrays.js:26 | expected an alert, but found none | NOT OK | Consistency |
-| typed-arrays.js:30 | expected an alert, but found none | NOT OK | Consistency |
-| typed-arrays.js:34 | expected an alert, but found none | NOT OK | Consistency |
 flow
 | access-path-sanitizer.js:2:18:2:25 | source() | access-path-sanitizer.js:4:8:4:12 | obj.x |
 | addexpr.js:4:10:4:17 | source() | addexpr.js:7:8:7:8 | x |
@@ -339,6 +339,10 @@ flow
 | typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:11:10:11:12 | arr |
 | typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:15:10:15:10 | z |
 | typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:18:10:18:12 | sub |
+| typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:22:10:22:13 | view |
+| typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:26:10:26:14 | view1 |
+| typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:30:10:30:23 | transferedView |
+| typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:34:10:34:24 | transferedView2 |
 | use-use-after-implicit-read.js:7:17:7:24 | source() | use-use-after-implicit-read.js:8:10:8:17 | captured |
 | use-use-after-implicit-read.js:7:17:7:24 | source() | use-use-after-implicit-read.js:15:10:15:10 | x |
 | xml.js:5:18:5:25 | source() | xml.js:8:14:8:17 | text |

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -40,6 +40,9 @@ consistencyIssue
 | nested-props.js:20 | expected an alert, but found none | NOT OK - but not found | Consistency |
 | stringification-read-steps.js:17 | expected an alert, but found none | NOT OK | Consistency |
 | stringification-read-steps.js:25 | expected an alert, but found none | NOT OK | Consistency |
+| typed-arrays.js:5 | expected an alert, but found none | NOT OK | Consistency |
+| typed-arrays.js:7 | expected an alert, but found none | NOT OK | Consistency |
+| typed-arrays.js:11 | expected an alert, but found none | NOT OK | Consistency |
 flow
 | access-path-sanitizer.js:2:18:2:25 | source() | access-path-sanitizer.js:4:8:4:12 | obj.x |
 | addexpr.js:4:10:4:17 | source() | addexpr.js:7:8:7:8 | x |

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -45,13 +45,13 @@ legacyDataFlowDifference
 | typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:30:10:30:23 | transferedView | only flow with NEW data flow library |
 | typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:34:10:34:24 | transferedView2 | only flow with NEW data flow library |
 | typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:46:10:46:12 | str | only flow with NEW data flow library |
+| typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:50:10:50:13 | str2 | only flow with NEW data flow library |
 | use-use-after-implicit-read.js:7:17:7:24 | source() | use-use-after-implicit-read.js:15:10:15:10 | x | only flow with NEW data flow library |
 consistencyIssue
 | nested-props.js:20 | expected an alert, but found none | NOT OK - but not found | Consistency |
 | stringification-read-steps.js:17 | expected an alert, but found none | NOT OK | Consistency |
 | stringification-read-steps.js:25 | expected an alert, but found none | NOT OK | Consistency |
 | typed-arrays.js:40 | expected an alert, but found none | NOT OK -- Should be flagged but it is not. | Consistency |
-| typed-arrays.js:50 | expected an alert, but found none | NOT OK | Consistency |
 flow
 | access-path-sanitizer.js:2:18:2:25 | source() | access-path-sanitizer.js:4:8:4:12 | obj.x |
 | addexpr.js:4:10:4:17 | source() | addexpr.js:7:8:7:8 | x |
@@ -347,6 +347,7 @@ flow
 | typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:30:10:30:23 | transferedView |
 | typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:34:10:34:24 | transferedView2 |
 | typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:46:10:46:12 | str |
+| typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:50:10:50:13 | str2 |
 | use-use-after-implicit-read.js:7:17:7:24 | source() | use-use-after-implicit-read.js:8:10:8:17 | captured |
 | use-use-after-implicit-read.js:7:17:7:24 | source() | use-use-after-implicit-read.js:15:10:15:10 | x |
 | xml.js:5:18:5:25 | source() | xml.js:8:14:8:17 | text |

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -40,18 +40,18 @@ legacyDataFlowDifference
 | typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:11:10:11:12 | arr | only flow with NEW data flow library |
 | typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:15:10:15:10 | z | only flow with NEW data flow library |
 | typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:18:10:18:12 | sub | only flow with NEW data flow library |
-| typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:22:10:22:13 | view | only flow with NEW data flow library |
-| typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:26:10:26:14 | view1 | only flow with NEW data flow library |
-| typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:30:10:30:23 | transferedView | only flow with NEW data flow library |
-| typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:34:10:34:24 | transferedView2 | only flow with NEW data flow library |
-| typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:46:10:46:12 | str | only flow with NEW data flow library |
-| typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:50:10:50:13 | str2 | only flow with NEW data flow library |
+| typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:48:10:48:12 | str | only flow with NEW data flow library |
+| typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:52:10:52:13 | str2 | only flow with NEW data flow library |
 | use-use-after-implicit-read.js:7:17:7:24 | source() | use-use-after-implicit-read.js:15:10:15:10 | x | only flow with NEW data flow library |
 consistencyIssue
 | nested-props.js:20 | expected an alert, but found none | NOT OK - but not found | Consistency |
 | stringification-read-steps.js:17 | expected an alert, but found none | NOT OK | Consistency |
 | stringification-read-steps.js:25 | expected an alert, but found none | NOT OK | Consistency |
-| typed-arrays.js:40 | expected an alert, but found none | NOT OK -- Should be flagged but it is not. | Consistency |
+| typed-arrays.js:23 | expected an alert, but found none | NOT OK -- Should be flagged but it is not. | Consistency |
+| typed-arrays.js:28 | expected an alert, but found none | NOT OK -- Should be flagged but it is not. | Consistency |
+| typed-arrays.js:32 | expected an alert, but found none | NOT OK -- Should be flagged but it is not. | Consistency |
+| typed-arrays.js:36 | expected an alert, but found none | NOT OK -- Should be flagged but it is not. | Consistency |
+| typed-arrays.js:42 | expected an alert, but found none | NOT OK -- Should be flagged but it is not. | Consistency |
 flow
 | access-path-sanitizer.js:2:18:2:25 | source() | access-path-sanitizer.js:4:8:4:12 | obj.x |
 | addexpr.js:4:10:4:17 | source() | addexpr.js:7:8:7:8 | x |
@@ -342,12 +342,8 @@ flow
 | typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:11:10:11:12 | arr |
 | typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:15:10:15:10 | z |
 | typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:18:10:18:12 | sub |
-| typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:22:10:22:13 | view |
-| typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:26:10:26:14 | view1 |
-| typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:30:10:30:23 | transferedView |
-| typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:34:10:34:24 | transferedView2 |
-| typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:46:10:46:12 | str |
-| typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:50:10:50:13 | str2 |
+| typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:48:10:48:12 | str |
+| typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:52:10:52:13 | str2 |
 | use-use-after-implicit-read.js:7:17:7:24 | source() | use-use-after-implicit-read.js:8:10:8:17 | captured |
 | use-use-after-implicit-read.js:7:17:7:24 | source() | use-use-after-implicit-read.js:15:10:15:10 | x |
 | xml.js:5:18:5:25 | source() | xml.js:8:14:8:17 | text |

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -45,6 +45,10 @@ consistencyIssue
 | nested-props.js:20 | expected an alert, but found none | NOT OK - but not found | Consistency |
 | stringification-read-steps.js:17 | expected an alert, but found none | NOT OK | Consistency |
 | stringification-read-steps.js:25 | expected an alert, but found none | NOT OK | Consistency |
+| typed-arrays.js:22 | expected an alert, but found none | NOT OK | Consistency |
+| typed-arrays.js:26 | expected an alert, but found none | NOT OK | Consistency |
+| typed-arrays.js:30 | expected an alert, but found none | NOT OK | Consistency |
+| typed-arrays.js:34 | expected an alert, but found none | NOT OK | Consistency |
 flow
 | access-path-sanitizer.js:2:18:2:25 | source() | access-path-sanitizer.js:4:8:4:12 | obj.x |
 | addexpr.js:4:10:4:17 | source() | addexpr.js:7:8:7:8 | x |

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -43,6 +43,9 @@ consistencyIssue
 | nested-props.js:20 | expected an alert, but found none | NOT OK - but not found | Consistency |
 | stringification-read-steps.js:17 | expected an alert, but found none | NOT OK | Consistency |
 | stringification-read-steps.js:25 | expected an alert, but found none | NOT OK | Consistency |
+| typed-arrays.js:15 | expected an alert, but found none | NOT OK | Consistency |
+| typed-arrays.js:18 | expected an alert, but found none | NOT OK | Consistency |
+| typed-arrays.js:22 | expected an alert, but found none | NOT OK | Consistency |
 flow
 | access-path-sanitizer.js:2:18:2:25 | source() | access-path-sanitizer.js:4:8:4:12 | obj.x |
 | addexpr.js:4:10:4:17 | source() | addexpr.js:7:8:7:8 | x |

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -40,6 +40,7 @@ legacyDataFlowDifference
 | typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:11:10:11:12 | arr | only flow with NEW data flow library |
 | typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:15:10:15:10 | z | only flow with NEW data flow library |
 | typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:18:10:18:12 | sub | only flow with NEW data flow library |
+| typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:42:10:42:30 | typedAr ... ring(y) | only flow with NEW data flow library |
 | typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:48:10:48:12 | str | only flow with NEW data flow library |
 | typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:52:10:52:13 | str2 | only flow with NEW data flow library |
 | use-use-after-implicit-read.js:7:17:7:24 | source() | use-use-after-implicit-read.js:15:10:15:10 | x | only flow with NEW data flow library |
@@ -51,7 +52,6 @@ consistencyIssue
 | typed-arrays.js:28 | expected an alert, but found none | NOT OK -- Should be flagged but it is not. | Consistency |
 | typed-arrays.js:32 | expected an alert, but found none | NOT OK -- Should be flagged but it is not. | Consistency |
 | typed-arrays.js:36 | expected an alert, but found none | NOT OK -- Should be flagged but it is not. | Consistency |
-| typed-arrays.js:42 | expected an alert, but found none | NOT OK -- Should be flagged but it is not. | Consistency |
 flow
 | access-path-sanitizer.js:2:18:2:25 | source() | access-path-sanitizer.js:4:8:4:12 | obj.x |
 | addexpr.js:4:10:4:17 | source() | addexpr.js:7:8:7:8 | x |
@@ -342,6 +342,7 @@ flow
 | typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:11:10:11:12 | arr |
 | typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:15:10:15:10 | z |
 | typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:18:10:18:12 | sub |
+| typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:42:10:42:30 | typedAr ... ring(y) |
 | typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:48:10:48:12 | str |
 | typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:52:10:52:13 | str2 |
 | use-use-after-implicit-read.js:7:17:7:24 | source() | use-use-after-implicit-read.js:8:10:8:17 | captured |

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -38,14 +38,13 @@ legacyDataFlowDifference
 | typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:5:10:5:10 | y | only flow with NEW data flow library |
 | typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:7:10:7:17 | y.buffer | only flow with NEW data flow library |
 | typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:11:10:11:12 | arr | only flow with NEW data flow library |
+| typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:15:10:15:10 | z | only flow with NEW data flow library |
+| typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:18:10:18:12 | sub | only flow with NEW data flow library |
 | use-use-after-implicit-read.js:7:17:7:24 | source() | use-use-after-implicit-read.js:15:10:15:10 | x | only flow with NEW data flow library |
 consistencyIssue
 | nested-props.js:20 | expected an alert, but found none | NOT OK - but not found | Consistency |
 | stringification-read-steps.js:17 | expected an alert, but found none | NOT OK | Consistency |
 | stringification-read-steps.js:25 | expected an alert, but found none | NOT OK | Consistency |
-| typed-arrays.js:15 | expected an alert, but found none | NOT OK | Consistency |
-| typed-arrays.js:18 | expected an alert, but found none | NOT OK | Consistency |
-| typed-arrays.js:22 | expected an alert, but found none | NOT OK | Consistency |
 flow
 | access-path-sanitizer.js:2:18:2:25 | source() | access-path-sanitizer.js:4:8:4:12 | obj.x |
 | addexpr.js:4:10:4:17 | source() | addexpr.js:7:8:7:8 | x |
@@ -334,6 +333,8 @@ flow
 | typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:5:10:5:10 | y |
 | typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:7:10:7:17 | y.buffer |
 | typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:11:10:11:12 | arr |
+| typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:15:10:15:10 | z |
+| typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:18:10:18:12 | sub |
 | use-use-after-implicit-read.js:7:17:7:24 | source() | use-use-after-implicit-read.js:8:10:8:17 | captured |
 | use-use-after-implicit-read.js:7:17:7:24 | source() | use-use-after-implicit-read.js:15:10:15:10 | x |
 | xml.js:5:18:5:25 | source() | xml.js:8:14:8:17 | text |

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -44,11 +44,14 @@ legacyDataFlowDifference
 | typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:26:10:26:14 | view1 | only flow with NEW data flow library |
 | typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:30:10:30:23 | transferedView | only flow with NEW data flow library |
 | typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:34:10:34:24 | transferedView2 | only flow with NEW data flow library |
+| typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:46:10:46:12 | str | only flow with NEW data flow library |
 | use-use-after-implicit-read.js:7:17:7:24 | source() | use-use-after-implicit-read.js:15:10:15:10 | x | only flow with NEW data flow library |
 consistencyIssue
 | nested-props.js:20 | expected an alert, but found none | NOT OK - but not found | Consistency |
 | stringification-read-steps.js:17 | expected an alert, but found none | NOT OK | Consistency |
 | stringification-read-steps.js:25 | expected an alert, but found none | NOT OK | Consistency |
+| typed-arrays.js:40 | expected an alert, but found none | NOT OK -- Should be flagged but it is not. | Consistency |
+| typed-arrays.js:50 | expected an alert, but found none | NOT OK | Consistency |
 flow
 | access-path-sanitizer.js:2:18:2:25 | source() | access-path-sanitizer.js:4:8:4:12 | obj.x |
 | addexpr.js:4:10:4:17 | source() | addexpr.js:7:8:7:8 | x |
@@ -343,6 +346,7 @@ flow
 | typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:26:10:26:14 | view1 |
 | typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:30:10:30:23 | transferedView |
 | typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:34:10:34:24 | transferedView2 |
+| typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:46:10:46:12 | str |
 | use-use-after-implicit-read.js:7:17:7:24 | source() | use-use-after-implicit-read.js:8:10:8:17 | captured |
 | use-use-after-implicit-read.js:7:17:7:24 | source() | use-use-after-implicit-read.js:15:10:15:10 | x |
 | xml.js:5:18:5:25 | source() | xml.js:8:14:8:17 | text |

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -35,14 +35,14 @@ legacyDataFlowDifference
 | spread.js:4:15:4:22 | source() | spread.js:18:8:18:8 | y | only flow with NEW data flow library |
 | spread.js:4:15:4:22 | source() | spread.js:24:8:24:8 | y | only flow with NEW data flow library |
 | tst.js:2:13:2:20 | source() | tst.js:17:10:17:10 | a | only flow with OLD data flow library |
+| typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:5:10:5:10 | y | only flow with NEW data flow library |
+| typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:7:10:7:17 | y.buffer | only flow with NEW data flow library |
+| typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:11:10:11:12 | arr | only flow with NEW data flow library |
 | use-use-after-implicit-read.js:7:17:7:24 | source() | use-use-after-implicit-read.js:15:10:15:10 | x | only flow with NEW data flow library |
 consistencyIssue
 | nested-props.js:20 | expected an alert, but found none | NOT OK - but not found | Consistency |
 | stringification-read-steps.js:17 | expected an alert, but found none | NOT OK | Consistency |
 | stringification-read-steps.js:25 | expected an alert, but found none | NOT OK | Consistency |
-| typed-arrays.js:5 | expected an alert, but found none | NOT OK | Consistency |
-| typed-arrays.js:7 | expected an alert, but found none | NOT OK | Consistency |
-| typed-arrays.js:11 | expected an alert, but found none | NOT OK | Consistency |
 flow
 | access-path-sanitizer.js:2:18:2:25 | source() | access-path-sanitizer.js:4:8:4:12 | obj.x |
 | addexpr.js:4:10:4:17 | source() | addexpr.js:7:8:7:8 | x |
@@ -328,6 +328,9 @@ flow
 | tst.js:87:22:87:29 | source() | tst.js:90:14:90:25 | taintedValue |
 | tst.js:93:22:93:29 | source() | tst.js:96:14:96:25 | taintedValue |
 | tst.js:93:22:93:29 | source() | tst.js:97:14:97:26 | map.get(true) |
+| typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:5:10:5:10 | y |
+| typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:7:10:7:17 | y.buffer |
+| typed-arrays.js:2:13:2:20 | source() | typed-arrays.js:11:10:11:12 | arr |
 | use-use-after-implicit-read.js:7:17:7:24 | source() | use-use-after-implicit-read.js:8:10:8:17 | captured |
 | use-use-after-implicit-read.js:7:17:7:24 | source() | use-use-after-implicit-read.js:15:10:15:10 | x |
 | xml.js:5:18:5:25 | source() | xml.js:8:14:8:17 | text |

--- a/javascript/ql/test/library-tests/TaintTracking/typed-arrays.js
+++ b/javascript/ql/test/library-tests/TaintTracking/typed-arrays.js
@@ -1,0 +1,12 @@
+function test() {
+    let x = source();
+
+    let y = new Uint8Array(x);
+    sink(y); // NOT OK
+
+    sink(y.buffer); // NOT OK
+    sink(y.length);
+
+    var arr = new Uint8Array(y.buffer, y.byteOffset, y.byteLength);
+    sink(arr); // NOT OK
+}

--- a/javascript/ql/test/library-tests/TaintTracking/typed-arrays.js
+++ b/javascript/ql/test/library-tests/TaintTracking/typed-arrays.js
@@ -16,4 +16,20 @@ function test() {
 
     const sub = y.subarray(1, 3)
     sink(sub); // NOT OK
+
+    const buffer = new ArrayBuffer(x);
+    const view = new Uint8Array(buffer);
+    sink(view); // NOT OK
+
+    const sharedBuffer = new SharedArrayBuffer(x);
+    const view1 = new Uint8Array(sharedBuffer);
+    sink(view1); // NOT OK
+
+    const transfered = buffer.transfer();
+    const transferedView = new Uint8Array(transfered);
+    sink(transferedView); // NOT OK
+
+    const transfered2 = buffer.transferToFixedLength();
+    const transferedView2 = new Uint8Array(transfered2);
+    sink(transferedView2); // NOT OK
 }

--- a/javascript/ql/test/library-tests/TaintTracking/typed-arrays.js
+++ b/javascript/ql/test/library-tests/TaintTracking/typed-arrays.js
@@ -9,4 +9,15 @@ function test() {
 
     var arr = new Uint8Array(y.buffer, y.byteOffset, y.byteLength);
     sink(arr); // NOT OK
+
+    const z = new Uint8Array([1, 2, 3]);
+    z.set(y, 3);
+    sink(z); // NOT OK
+
+    const sub = y.subarray(1, 3)
+    sink(sub); // NOT OK
+
+    const clone = new y.constructor(y.length);
+    clone.set(y);    
+    sink(clone); // NOT OK
 }

--- a/javascript/ql/test/library-tests/TaintTracking/typed-arrays.js
+++ b/javascript/ql/test/library-tests/TaintTracking/typed-arrays.js
@@ -32,4 +32,20 @@ function test() {
     const transfered2 = buffer.transferToFixedLength();
     const transferedView2 = new Uint8Array(transfered2);
     sink(transferedView2); // NOT OK
+
+    var typedArrayToString = (function () {
+        return function (a) { return String.fromCharCode.apply(null, a); };
+    })();
+
+    sink(typedArrayToString(y)); // NOT OK -- Should be flagged but it is not.
+
+    let str = '';
+    for (let i = 0; i < y.length; i++) 
+        str += String.fromCharCode(y[i]);
+    
+    sink(str); // NOT OK
+
+    const decoder = new TextDecoder('utf-8');
+    const str2 = decoder.decode(y);
+    sink(str2); //  NOT OK
 }

--- a/javascript/ql/test/library-tests/TaintTracking/typed-arrays.js
+++ b/javascript/ql/test/library-tests/TaintTracking/typed-arrays.js
@@ -16,8 +16,4 @@ function test() {
 
     const sub = y.subarray(1, 3)
     sink(sub); // NOT OK
-
-    const clone = new y.constructor(y.length);
-    clone.set(y);    
-    sink(clone); // NOT OK
 }

--- a/javascript/ql/test/library-tests/TaintTracking/typed-arrays.js
+++ b/javascript/ql/test/library-tests/TaintTracking/typed-arrays.js
@@ -17,21 +17,23 @@ function test() {
     const sub = y.subarray(1, 3)
     sink(sub); // NOT OK
 
-    const buffer = new ArrayBuffer(x);
+    const buffer = new ArrayBuffer(8);
     const view = new Uint8Array(buffer);
-    sink(view); // NOT OK
+    view.set(x, 3);
+    sink(buffer); // NOT OK -- Should be flagged but it is not.
 
-    const sharedBuffer = new SharedArrayBuffer(x);
+    const sharedBuffer = new SharedArrayBuffer(8);
     const view1 = new Uint8Array(sharedBuffer);
-    sink(view1); // NOT OK
+    view1.set(x, 3);
+    sink(sharedBuffer); // NOT OK -- Should be flagged but it is not.
 
     const transfered = buffer.transfer();
     const transferedView = new Uint8Array(transfered);
-    sink(transferedView); // NOT OK
+    sink(transferedView); // NOT OK -- Should be flagged but it is not.
 
     const transfered2 = buffer.transferToFixedLength();
     const transferedView2 = new Uint8Array(transfered2);
-    sink(transferedView2); // NOT OK
+    sink(transferedView2); // NOT OK -- Should be flagged but it is not.
 
     var typedArrayToString = (function () {
         return function (a) { return String.fromCharCode.apply(null, a); };

--- a/javascript/ql/test/library-tests/TaintTracking/typed-arrays.js
+++ b/javascript/ql/test/library-tests/TaintTracking/typed-arrays.js
@@ -39,7 +39,7 @@ function test() {
         return function (a) { return String.fromCharCode.apply(null, a); };
     })();
 
-    sink(typedArrayToString(y)); // NOT OK -- Should be flagged but it is not.
+    sink(typedArrayToString(y)); // NOT OK
 
     let str = '';
     for (let i = 0; i < y.length; i++) 

--- a/javascript/ql/test/query-tests/Security/CWE-522-DecompressionBombs/DecompressionBombs.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-522-DecompressionBombs/DecompressionBombs.expected
@@ -81,9 +81,12 @@ edges
 | pako.js:18:48:18:66 | zipFile.data.buffer | pako.js:18:33:18:67 | new Uin ... buffer) | provenance | Config |
 | pako.js:28:19:28:25 | zipFile | pako.js:29:36:29:42 | zipFile | provenance |  |
 | pako.js:29:11:29:62 | myArray | pako.js:32:31:32:37 | myArray | provenance |  |
+| pako.js:29:11:29:62 | myArray [ArrayElement] | pako.js:32:31:32:37 | myArray | provenance |  |
 | pako.js:29:21:29:55 | new Uin ... buffer) | pako.js:29:11:29:62 | myArray | provenance |  |
+| pako.js:29:21:29:55 | new Uin ... buffer) [ArrayElement] | pako.js:29:11:29:62 | myArray [ArrayElement] | provenance |  |
 | pako.js:29:36:29:42 | zipFile | pako.js:29:36:29:54 | zipFile.data.buffer | provenance |  |
 | pako.js:29:36:29:54 | zipFile.data.buffer | pako.js:29:21:29:55 | new Uin ... buffer) | provenance | Config |
+| pako.js:29:36:29:54 | zipFile.data.buffer | pako.js:29:21:29:55 | new Uin ... buffer) [ArrayElement] | provenance |  |
 | unbzip2.js:12:5:12:43 | fs.crea ... lePath) | unbzip2.js:12:50:12:54 | bz2() | provenance | Config |
 | unbzip2.js:12:25:12:42 | req.query.FilePath | unbzip2.js:12:5:12:43 | fs.crea ... lePath) | provenance | Config |
 | unzipper.js:13:26:13:62 | Readabl ... e.data) | unzipper.js:16:23:16:63 | unzippe ... ath' }) | provenance | Config |
@@ -183,7 +186,9 @@ nodes
 | pako.js:21:31:21:37 | myArray | semmle.label | myArray |
 | pako.js:28:19:28:25 | zipFile | semmle.label | zipFile |
 | pako.js:29:11:29:62 | myArray | semmle.label | myArray |
+| pako.js:29:11:29:62 | myArray [ArrayElement] | semmle.label | myArray [ArrayElement] |
 | pako.js:29:21:29:55 | new Uin ... buffer) | semmle.label | new Uin ... buffer) |
+| pako.js:29:21:29:55 | new Uin ... buffer) [ArrayElement] | semmle.label | new Uin ... buffer) [ArrayElement] |
 | pako.js:29:36:29:42 | zipFile | semmle.label | zipFile |
 | pako.js:29:36:29:54 | zipFile.data.buffer | semmle.label | zipFile.data.buffer |
 | pako.js:32:31:32:37 | myArray | semmle.label | myArray |


### PR DESCRIPTION
This pull request introduces taint modeling for the most commonly used `TypedArray`, specifically the [Uint8Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array), which is primarily utilized in byte-to-string operations. It excludes other `TypedArray` types, such as [Int32Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int32Array), as they are generally not associated with taint propagation.

Additionally, this update adds support for `ArrayBuffer` and `SharedArrayBuffer`, which are frequently used in low-level operations and are often passed to `TypedArray` constructors.

Finally, the pull request includes taint propagation for `TextDecoder`, as it plays a key role in converting `ArrayBuffer` or `TypedArray` data into `Strings`.
