### PR TITLE
Disable csharp tests that use nuget on macos-15

### DIFF
--- a/csharp/ql/integration-tests/all-platforms/diag_missing_project_files/test.py
+++ b/csharp/ql/integration-tests/all-platforms/diag_missing_project_files/test.py
@@ -1,2 +1,8 @@
+import pytest
+import runs_on
+
+
+# Skipping the test on macos-15, as we're running into trouble.
+@pytest.mark.only_if(not runs_on.macos_15)
 def test(codeql, csharp):
     codeql.database.create(_assert_failure=True)

--- a/csharp/ql/integration-tests/posix/standalone_dependencies_no_framework/test.py
+++ b/csharp/ql/integration-tests/posix/standalone_dependencies_no_framework/test.py
@@ -3,8 +3,11 @@ import pytest
 import os
 
 
-# Skipping the test on the ARM runners, as we're running into trouble with Mono and nuget.
-@pytest.mark.only_if(runs_on.linux or (runs_on.macos and runs_on.x86_64))
+# Skipping the test on the ARM runners and macos-15, as we're running into trouble with Mono and nuget.
+@pytest.mark.only_if(
+    runs_on.linux
+    or (runs_on.macos and runs_on.x86_64 and not runs_on.macos_15)
+)
 def test(codeql, csharp):
     os.environ["CODEQL_EXTRACTOR_CSHARP_BUILDLESS_DOTNET_FRAMEWORK_REFERENCES"] = (
         "/non-existent-path"

--- a/csharp/ql/integration-tests/posix/standalone_dependencies_nuget with_space/test.py
+++ b/csharp/ql/integration-tests/posix/standalone_dependencies_nuget with_space/test.py
@@ -3,8 +3,11 @@ import runs_on
 import pytest
 
 
-# Skipping the test on the ARM runners, as we're running into trouble with Mono and nuget.
-@pytest.mark.only_if(runs_on.linux or (runs_on.macos and runs_on.x86_64))
+# Skipping the test on the ARM runners and macos-15, as we're running into trouble with Mono and nuget.
+@pytest.mark.only_if(
+    runs_on.linux
+    or (runs_on.macos and runs_on.x86_64 and not runs_on.macos_15)
+)
 def test(codeql, csharp):
     # making sure we're not doing any fallback restore:
     os.environ["CODEQL_EXTRACTOR_CSHARP_BUILDLESS_NUGET_FEEDS_CHECK_FALLBACK_TIMEOUT"] = "1"

--- a/csharp/ql/integration-tests/posix/standalone_dependencies_nuget/test.py
+++ b/csharp/ql/integration-tests/posix/standalone_dependencies_nuget/test.py
@@ -2,7 +2,10 @@ import runs_on
 import pytest
 
 
-# Skipping the test on the ARM runners, as we're running into trouble with Mono and nuget.
-@pytest.mark.only_if(runs_on.linux or (runs_on.macos and runs_on.x86_64))
+# Skipping the test on the ARM runners and macos-15, as we're running into trouble with Mono and nuget.
+@pytest.mark.only_if(
+    runs_on.linux
+    or (runs_on.macos and runs_on.x86_64 and not runs_on.macos_15)
+)
 def test(codeql, csharp):
     codeql.database.create(build_mode="none")

--- a/csharp/ql/integration-tests/posix/standalone_dependencies_nuget_no_sources/test.py
+++ b/csharp/ql/integration-tests/posix/standalone_dependencies_nuget_no_sources/test.py
@@ -3,6 +3,9 @@ import pytest
 
 
 # Skipping the test on the ARM runners, as we're running into trouble with Mono and nuget.
-@pytest.mark.only_if(runs_on.linux or (runs_on.macos and runs_on.x86_64))
+@pytest.mark.only_if(
+    runs_on.linux
+    or (runs_on.macos and runs_on.x86_64 and not runs_on.macos_15)
+)
 def test(codeql, csharp):
     codeql.database.create(source_root="proj", build_mode="none")


### PR DESCRIPTION
`csharp` tests that use `nuget` don't seem to be working, possibly due to issues with provisioning of `Mono` and `nuget` on those runners: https://github.com/actions/runner-images/blob/macos-15/20250120.591/images/macos/macos-15-Readme.md 

Disabling the tests on that platform for now.