### PR TITLE
Rust: SSA inconsistency counts

### DIFF
--- a/rust/ql/consistency-queries/SsaConsistency.ql
+++ b/rust/ql/consistency-queries/SsaConsistency.ql
@@ -1,3 +1,10 @@
-import codeql.rust.dataflow.Ssa
+/**
+ * @name Static single assignment inconsistencies
+ * @description Lists the static single assignment inconsistencies in the database.  This query is intended for internal use.
+ * @kind table
+ * @id rust/diagnostics/ssa-consistency
+ */
+
+ import codeql.rust.dataflow.Ssa
 import codeql.rust.dataflow.internal.SsaImpl
 import Consistency

--- a/rust/ql/consistency-queries/SsaConsistency.ql
+++ b/rust/ql/consistency-queries/SsaConsistency.ql
@@ -5,6 +5,6 @@
  * @id rust/diagnostics/ssa-consistency
  */
 
- import codeql.rust.dataflow.Ssa
+import codeql.rust.dataflow.Ssa
 import codeql.rust.dataflow.internal.SsaImpl
 import Consistency

--- a/rust/ql/integration-tests/hello-project/summary.expected
+++ b/rust/ql/integration-tests/hello-project/summary.expected
@@ -7,6 +7,7 @@
 | Inconsistencies - AST | 0 |
 | Inconsistencies - CFG | 0 |
 | Inconsistencies - Path resolution | 0 |
+| Inconsistencies - SSA | 0 |
 | Inconsistencies - data flow | 0 |
 | Lines of code extracted | 6 |
 | Lines of user code extracted | 6 |

--- a/rust/ql/integration-tests/hello-workspace/summary.cargo.expected
+++ b/rust/ql/integration-tests/hello-workspace/summary.cargo.expected
@@ -7,6 +7,7 @@
 | Inconsistencies - AST | 0 |
 | Inconsistencies - CFG | 0 |
 | Inconsistencies - Path resolution | 0 |
+| Inconsistencies - SSA | 0 |
 | Inconsistencies - data flow | 0 |
 | Lines of code extracted | 9 |
 | Lines of user code extracted | 9 |

--- a/rust/ql/integration-tests/hello-workspace/summary.rust-project.expected
+++ b/rust/ql/integration-tests/hello-workspace/summary.rust-project.expected
@@ -7,6 +7,7 @@
 | Inconsistencies - AST | 0 |
 | Inconsistencies - CFG | 0 |
 | Inconsistencies - Path resolution | 0 |
+| Inconsistencies - SSA | 0 |
 | Inconsistencies - data flow | 0 |
 | Lines of code extracted | 9 |
 | Lines of user code extracted | 9 |

--- a/rust/ql/src/queries/diagnostics/SsaConsistencyCounts.ql
+++ b/rust/ql/src/queries/diagnostics/SsaConsistencyCounts.ql
@@ -5,10 +5,10 @@
  * @id rust/diagnostics/ssa-consistency-counts
  */
 
-private import codeql.rust.dataflow.internal.SsaImpl as SsaImpl
+private import codeql.rust.dataflow.internal.SsaImpl::Consistency as SsaConsistency
 
 // see also `rust/diagnostics/ssa-consistency`, which lists the
 // individual inconsistency results.
 from string type, int num
-where num = SsaImpl::Consistency::getInconsistencyCounts(type)
+where num = SsaConsistency::getInconsistencyCounts(type)
 select type, num

--- a/rust/ql/src/queries/diagnostics/SsaConsistencyCounts.ql
+++ b/rust/ql/src/queries/diagnostics/SsaConsistencyCounts.ql
@@ -1,0 +1,14 @@
+/**
+ * @name Static single assignment inconsistency counts
+ * @description Counts the number of static single assignment inconsistencies of each type.  This query is intended for internal use.
+ * @kind diagnostic
+ * @id rust/diagnostics/ssa-consistency-counts
+ */
+
+ private import codeql.rust.dataflow.internal.SsaImpl as SsaImpl
+
+// see also `rust/diagnostics/ssa-consistency`, which lists the
+// individual inconsistency results.
+from string type, int num
+where num = SsaImpl::Consistency::getInconsistencyCounts(type)
+select type, num

--- a/rust/ql/src/queries/diagnostics/SsaConsistencyCounts.ql
+++ b/rust/ql/src/queries/diagnostics/SsaConsistencyCounts.ql
@@ -5,7 +5,7 @@
  * @id rust/diagnostics/ssa-consistency-counts
  */
 
- private import codeql.rust.dataflow.internal.SsaImpl as SsaImpl
+private import codeql.rust.dataflow.internal.SsaImpl as SsaImpl
 
 // see also `rust/diagnostics/ssa-consistency`, which lists the
 // individual inconsistency results.

--- a/rust/ql/src/queries/summary/Stats.qll
+++ b/rust/ql/src/queries/summary/Stats.qll
@@ -10,6 +10,7 @@ private import codeql.rust.internal.AstConsistency as AstConsistency
 private import codeql.rust.internal.PathResolutionConsistency as PathResolutionConsistency
 private import codeql.rust.controlflow.internal.CfgConsistency as CfgConsistency
 private import codeql.rust.dataflow.internal.DataFlowConsistency as DataFlowConsistency
+private import codeql.rust.dataflow.internal.SsaImpl as SsaImpl
 private import codeql.rust.Concepts
 private import codeql.rust.Diagnostics
 private import codeql.rust.security.SensitiveData
@@ -55,6 +56,13 @@ int getTotalPathResolutionInconsistencies() {
  */
 int getTotalCfgInconsistencies() {
   result = sum(string type | | CfgConsistency::getCfgInconsistencyCounts(type))
+}
+
+/**
+ * Gets a count of the total number of SSA inconsistencies in the database.
+ */
+int getTotalSsaInconsistencies() {
+  result = sum(string type | | SsaImpl::Consistency::getInconsistencyCounts(type))
 }
 
 /**
@@ -141,6 +149,8 @@ predicate inconsistencyStats(string key, int value) {
   key = "Inconsistencies - Path resolution" and value = getTotalPathResolutionInconsistencies()
   or
   key = "Inconsistencies - CFG" and value = getTotalCfgInconsistencies()
+  or
+  key = "Inconsistencies - SSA" and value = getTotalSsaInconsistencies()
   or
   key = "Inconsistencies - data flow" and value = getTotalDataFlowInconsistencies()
 }

--- a/rust/ql/src/queries/summary/Stats.qll
+++ b/rust/ql/src/queries/summary/Stats.qll
@@ -10,7 +10,7 @@ private import codeql.rust.internal.AstConsistency as AstConsistency
 private import codeql.rust.internal.PathResolutionConsistency as PathResolutionConsistency
 private import codeql.rust.controlflow.internal.CfgConsistency as CfgConsistency
 private import codeql.rust.dataflow.internal.DataFlowConsistency as DataFlowConsistency
-private import codeql.rust.dataflow.internal.SsaImpl as SsaImpl
+private import codeql.rust.dataflow.internal.SsaImpl::Consistency as SsaConsistency
 private import codeql.rust.Concepts
 private import codeql.rust.Diagnostics
 private import codeql.rust.security.SensitiveData
@@ -62,7 +62,7 @@ int getTotalCfgInconsistencies() {
  * Gets a count of the total number of SSA inconsistencies in the database.
  */
 int getTotalSsaInconsistencies() {
-  result = sum(string type | | SsaImpl::Consistency::getInconsistencyCounts(type))
+  result = sum(string type | | SsaConsistency::getInconsistencyCounts(type))
 }
 
 /**

--- a/rust/ql/test/query-tests/diagnostics/SsaConsistencyCounts.expected
+++ b/rust/ql/test/query-tests/diagnostics/SsaConsistencyCounts.expected
@@ -1,0 +1,10 @@
+| Definition cannot reach a read | 0 |
+| End of a basic block can be reached by multiple definitions | 0 |
+| Phi has less than 2 immediately prior references | 0 |
+| Phi node has less than two inputs | 0 |
+| Phi read has less than 2 immediately prior references | 0 |
+| Read can be reached from multiple definitions | 0 |
+| Read cannot be reached from a definition | 0 |
+| Read does not have a prior reference | 0 |
+| Read has multiple prior references | 0 |
+| Read is not dominated by a definition | 0 |

--- a/rust/ql/test/query-tests/diagnostics/SsaConsistencyCounts.qlref
+++ b/rust/ql/test/query-tests/diagnostics/SsaConsistencyCounts.qlref
@@ -1,0 +1,1 @@
+queries/diagnostics/SsaConsistencyCounts.ql

--- a/rust/ql/test/query-tests/diagnostics/SummaryStatsReduced.expected
+++ b/rust/ql/test/query-tests/diagnostics/SummaryStatsReduced.expected
@@ -7,6 +7,7 @@
 | Inconsistencies - AST | 0 |
 | Inconsistencies - CFG | 0 |
 | Inconsistencies - Path resolution | 0 |
+| Inconsistencies - SSA | 0 |
 | Inconsistencies - data flow | 0 |
 | Lines of code extracted | 60 |
 | Lines of user code extracted | 60 |

--- a/shared/ssa/codeql/ssa/Ssa.qll
+++ b/shared/ssa/codeql/ssa/Ssa.qll
@@ -1468,6 +1468,13 @@ module Make<LocationSig Location, InputSig<Location> Input> {
       inputRefs = count(BasicBlock bb, int i | AdjacentSsaRefs::adjacentRefPhi(bb, i, _, bbPhi, v)) and
       inputRefs < 2
     }
+
+    /**
+     * Gets counts of inconsistencies of each type.
+     */
+    int getInconsistencyCounts(string type) {
+      type = "" and result = 0
+    }
   }
 
   /** Provides the input to `DataFlowIntegration`. */

--- a/shared/ssa/codeql/ssa/Ssa.qll
+++ b/shared/ssa/codeql/ssa/Ssa.qll
@@ -1473,7 +1473,52 @@ module Make<LocationSig Location, InputSig<Location> Input> {
      * Gets counts of inconsistencies of each type.
      */
     int getInconsistencyCounts(string type) {
-      type = "" and result = 0
+      // total results from all the SSA consistency query predicates.
+      type = "Read can be reached from multiple definitions" and
+      result =
+        count(Definition def, SourceVariable v, BasicBlock bb, int i | nonUniqueDef(def, v, bb, i))
+      or
+      type = "Read cannot be reached from a definition" and
+      result = count(SourceVariable v, BasicBlock bb, int i | readWithoutDef(v, bb, i))
+      or
+      type = "Definition cannot reach a read" and
+      result = count(Definition def, SourceVariable v | deadDef(def, v))
+      or
+      type = "Read is not dominated by a definition" and
+      result =
+        count(Definition def, SourceVariable v, BasicBlock bb, int i |
+          notDominatedByDef(def, v, bb, i)
+        )
+      or
+      type = "End of a basic block can be reached by multiple definitions" and
+      result =
+        count(Definition def, SourceVariable v, BasicBlock bb |
+          nonUniqueDefReachesEndOfBlock(def, v, bb)
+        )
+      or
+      type = "Phi node has less than two inputs" and
+      result = count(PhiNode phi, int inputs | uselessPhiNode(phi, inputs))
+      or
+      type = "Read does not have a prior reference" and
+      result = count(SourceVariable v, BasicBlock bb, int i | readWithoutPriorRef(v, bb, i))
+      or
+      type = "Read has multiple prior references" and
+      result =
+        count(SourceVariable v, BasicBlock bb1, int i1, BasicBlock bb2, int i2 |
+          readWithMultiplePriorRefs(v, bb1, i1, bb2, i2)
+        )
+      or
+      type = "Phi has less than 2 immediately prior references" and
+      result =
+        count(PhiNode phi, BasicBlock bbPhi, SourceVariable v, int inputRefs |
+          phiWithoutTwoPriorRefs(phi, bbPhi, v, inputRefs)
+        )
+      or
+      type = "Phi read has less than 2 immediately prior references" and
+      result =
+        count(BasicBlock bbPhi, SourceVariable v, int inputRefs |
+          phiReadWithoutTwoPriorRefs(bbPhi, v, inputRefs)
+        )
     }
   }
 


### PR DESCRIPTION
Provide SSA inconsistency counts:
- precise data through existing query `rust/diagnostics/ssa-consistency` (which has been given metadata).
- totals per inconsistency type through new query `rust/diagnostics/ssa-consistency-counts`.
- overall totals through `rust/summary/summary-statistics` (via changes in `Stats.qll`).  This data will be used by the DCA report.

This required adding a predicate `getInconsistencyCounts` to the shared `SSA.qll`, similar to the one we already have for data flow.  This shouldn't be controversial as no existing shared behaviour is changed, but I'm open to suggestions / comments representing all interests of course.