### PR TITLE
Docs: Fix formatting of GitHub Actions content

### DIFF
--- a/docs/codeql/codeql-language-guides/codeql-for-actions.rst
+++ b/docs/codeql/codeql-language-guides/codeql-for-actions.rst
@@ -12,6 +12,6 @@ Experiment and learn how to write effective and efficient queries for CodeQL dat
    codeql-library-for-actions
    customizing-library-models-for-actions
 
--  :doc:`CodeQL library for GitHub Actions <codeql-library-for-actions>`: When you're analyzing a Ruby program, you can make use of the large collection of classes in the CodeQL library for GitHub Actions.
+-  :doc:`CodeQL library for GitHub Actions <codeql-library-for-actions>`: When you're analyzing GitHub Actions code, you can make use of the large collection of classes in the CodeQL library for GitHub Actions.
 
 -  :doc:`Customizing library models for GitHub Actions <customizing-library-models-for-actions>`: You can model frameworks and libraries that your codebase depends on using data extensions and publish them as CodeQL model packs.

--- a/docs/codeql/codeql-language-guides/codeql-library-for-actions.rst
+++ b/docs/codeql/codeql-language-guides/codeql-library-for-actions.rst
@@ -95,7 +95,7 @@ to all AST classes:
    * - ``getAChildNode()``
      - Gets a child node of this node.
    * - ``getParentNode()``
-     - Gets the parent of this `AstNode`, if this node is not a root node.
+     - Gets the parent of this ``AstNode``, if this node is not a root node.
    * - ``getATriggerEvent()``
      - Gets an Actions trigger event that can start the enclosing Actions workflow, if any.
      
@@ -104,9 +104,9 @@ Workflows
 ~~~~~~~~~
 
 A workflow is a configurable automated process made up of one or more jobs,
-defined in a workflow YAML file in the `.github/workflows` directory of a GitHub repository.
+defined in a workflow YAML file in the ``.github/workflows`` directory of a GitHub repository.
 
-In the CodeQL AST library, a `Workflow` is an `AstNode` representing the mapping at the top level of an Actions YAML workflow file.
+In the CodeQL AST library, a ``Workflow`` is an ``AstNode`` representing the mapping at the top level of an Actions YAML workflow file.
 
 See the GitHub Actions documentation on `workflows <https://docs.github.com/en/actions/writing-workflows/about-workflows>`__ and `workflow syntax <https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions>`__ for more information.
 
@@ -116,16 +116,17 @@ See the GitHub Actions documentation on `workflows <https://docs.github.com/en/a
    * - CodeQL class
      - Description and selected predicates
    * - ``Workflow``
-     -  An Actions workflow, defined as a mapping at the top level of a workflow YAML file in `.github/workflows`. See https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions.
-        - `getAJob()` - Gets a job within the `jobs` mapping of this workflow.
-        - `getEnv()` - Gets an `env` mapping within this workflow declaring workflow-level environment variables, if any.
-        - `getJob(string jobId)` - Gets a job within the `jobs` mapping of this workflow with the given job ID.
-        - `getOn()` - Gets the `on` mapping defining the events that trigger this workflow.
-        - `getPermissions()` - Gets a `permissions` mapping within this workflow declaring workflow-level token permissions, if any.
-        - `getStrategy()` - Gets a `strategy` mapping for the jobs in this workflow, if any.
-        - `getName()` - Gets the name of this workflow, if defined within the workflow.
+     -  An Actions workflow, defined as a mapping at the top level of a workflow YAML file in ``.github/workflows``. See https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions.
 
-The following example lists all jobs in a workflow with the name declaration `name: test`:
+        - ``getAJob()`` - Gets a job within the ``jobs`` mapping of this workflow.
+        - ``getEnv()`` - Gets an ``env`` mapping within this workflow declaring workflow-level environment variables, if any.
+        - ``getJob(string jobId)`` - Gets a job within the ``jobs`` mapping of this workflow with the given job ID.
+        - ``getOn()``` - Gets the ``on`` mapping defining the events that trigger this workflow.
+        - ``getPermissions()`` - Gets a ``permissions`` mapping within this workflow declaring workflow-level token permissions, if any.
+        - ``getStrategy()``` - Gets a ``strategy`` mapping for the jobs in this workflow, if any.
+        - ``getName()`` - Gets the name of this workflow, if defined within the workflow.
+
+The following example lists all jobs in a workflow with the name declaration ``name: test``:
 
 .. code-block:: ql
 

--- a/docs/codeql/codeql-language-guides/customizing-library-models-for-actions.rst
+++ b/docs/codeql/codeql-language-guides/customizing-library-models-for-actions.rst
@@ -1,6 +1,6 @@
 .. _customizing-library-models-for-actions:
 
-Customizing Library Models for GitHub Actions
+Customizing library models for GitHub Actions
 =============================================
 
 .. include:: ../reusables/beta-note-customizing-library-models.rst

--- a/docs/codeql/codeql-language-guides/customizing-library-models-for-ruby.rst
+++ b/docs/codeql/codeql-language-guides/customizing-library-models-for-ruby.rst
@@ -1,7 +1,7 @@
 .. _customizing-library-models-for-ruby:
 
 
-Customizing Library Models for Ruby
+Customizing library models for Ruby
 ===================================
 
 .. include:: ../reusables/beta-note-customizing-library-models.rst

--- a/docs/codeql/codeql-language-guides/index.rst
+++ b/docs/codeql/codeql-language-guides/index.rst
@@ -7,9 +7,9 @@ Experiment and learn how to write effective and efficient queries for CodeQL dat
 
 .. toctree::
 
-   codeql-for-actions
    codeql-for-cpp
    codeql-for-csharp
+   codeql-for-actions
    codeql-for-go
    codeql-for-java
    codeql-for-javascript

--- a/docs/codeql/reusables/supported-frameworks.rst
+++ b/docs/codeql/reusables/supported-frameworks.rst
@@ -54,8 +54,8 @@ and the CodeQL library pack ``codeql/actions-all`` (`changelog <https://github.c
    :align: left
 
    Name, Category
-   `GitHub Actions workflow YAML files <https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions>`, Workflows
-   `GitHub Actions action metadata YAML files <https://docs.github.com/en/actions/sharing-automations/creating-actions/metadata-syntax-for-github-actions>`, Actions
+   `GitHub Actions workflow YAML files <https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions>`__, Workflows
+   `GitHub Actions action metadata YAML files <https://docs.github.com/en/actions/sharing-automations/creating-actions/metadata-syntax-for-github-actions>`__, Actions
 
 Go built-in support
 ================================


### PR DESCRIPTION
Discovered in internal review of docs preview.
Use double backticks to render inline code blocks. Use __ after inline hyperlinks.
Use an extra blank line to format the Actions library predicates table correctly. Fix some rogue references to Ruby and case inconsistency.
Place GitHub Actions link lower in sidebar (order by human-readable language name).