### PR TITLE
Go: Fix `err` instead of `decErr` in `GetPkgsInfo`

### DIFF
--- a/go/extractor/toolchain/toolchain.go
+++ b/go/extractor/toolchain/toolchain.go
@@ -259,7 +259,7 @@ func GetPkgsInfo(patterns []string, includingDeps bool, extractTests bool, flags
 			break
 		}
 		if decErr != nil {
-			log.Printf("Error decoding output of go list -json: %s", err.Error())
+			log.Printf("Error decoding output of go list -json: %s", decErr.Error())
 			return nil, decErr
 		}
 		pkgAbsDir, err := filepath.Abs(pkgInfo.Dir)


### PR DESCRIPTION
Seems like `err` was used incorrectly instead of `decErr` here. The Go compiler alerted me to this, since `err` is `nil` at this point.