### PR TITLE
C#: Fix autobuild on macos without mono

### DIFF
--- a/csharp/autobuilder/Semmle.Autobuild.CSharp.Tests/BuildScripts.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.CSharp.Tests/BuildScripts.cs
@@ -46,11 +46,6 @@ namespace Semmle.Autobuild.CSharp.Tests
 
         public IList<string> RunProcessIn { get; } = new List<string>();
         public IDictionary<string, int> RunProcess { get; } = new Dictionary<string, int>();
-
-        /// <summary>
-        /// (process-exit code) pairs for commands that are executed during the assembly of the autobuild script.
-        /// </summary>
-        public IDictionary<string, int> RunProcessExecuteDuring { get; } = new Dictionary<string, int>();
         public IDictionary<string, string> RunProcessOut { get; } = new Dictionary<string, string>();
         public IDictionary<string, string> RunProcessWorkingDirectory { get; } = new Dictionary<string, string>();
         public HashSet<string> CreateDirectories { get; } = new HashSet<string>();
@@ -71,7 +66,7 @@ namespace Semmle.Autobuild.CSharp.Tests
             if (wd != workingDirectory)
                 throw new ArgumentException($"Unexpected RunProcessWorkingDirectory, got {wd ?? "null"} expected {workingDirectory ?? "null"} in {pattern}");
 
-            if (!RunProcess.TryGetValue(pattern, out var ret) && !RunProcessExecuteDuring.TryGetValue(pattern, out ret))
+            if (!RunProcess.TryGetValue(pattern, out var ret))
                 throw new ArgumentException("Missing RunProcess " + pattern);
 
             return ret;
@@ -86,7 +81,7 @@ namespace Semmle.Autobuild.CSharp.Tests
             if (wd != workingDirectory)
                 throw new ArgumentException($"Unexpected RunProcessWorkingDirectory, got {wd ?? "null"} expected {workingDirectory ?? "null"} in {pattern}");
 
-            if (!RunProcess.TryGetValue(pattern, out var ret) && !RunProcessExecuteDuring.TryGetValue(pattern, out ret))
+            if (!RunProcess.TryGetValue(pattern, out var ret))
                 throw new ArgumentException("Missing RunProcess " + pattern);
 
             return ret;
@@ -166,6 +161,10 @@ namespace Semmle.Autobuild.CSharp.Tests
         public bool IsRunningOnAppleSilicon { get; set; }
 
         bool IBuildActions.IsRunningOnAppleSilicon() => IsRunningOnAppleSilicon;
+
+        public bool IsMonoInstalled { get; set; }
+
+        bool IBuildActions.IsMonoInstalled() => IsMonoInstalled;
 
         public string PathCombine(params string[] parts)
         {
@@ -804,7 +803,7 @@ namespace Semmle.Autobuild.CSharp.Tests
         [Fact]
         public void TestDirsProjLinux_WithMono()
         {
-            actions.RunProcessExecuteDuring[@"mono --version"] = 0;
+            actions.IsMonoInstalled = true;
 
             actions.RunProcess[@"nuget restore C:\Project/dirs.proj -DisableParallelProcessing"] = 1;
             actions.RunProcess[@"mono scratch/.nuget/nuget.exe restore C:\Project/dirs.proj -DisableParallelProcessing"] = 0;
@@ -817,7 +816,7 @@ namespace Semmle.Autobuild.CSharp.Tests
         [Fact]
         public void TestDirsProjLinux_WithoutMono()
         {
-            actions.RunProcessExecuteDuring[@"mono --version"] = 1;
+            actions.IsMonoInstalled = false;
 
             actions.RunProcess[@"dotnet msbuild /t:restore C:\Project/dirs.proj"] = 0;
             actions.RunProcess[@"dotnet msbuild C:\Project/dirs.proj /t:rebuild"] = 0;

--- a/csharp/autobuilder/Semmle.Autobuild.Cpp.Tests/BuildScripts.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.Cpp.Tests/BuildScripts.cs
@@ -150,6 +150,10 @@ namespace Semmle.Autobuild.Cpp.Tests
 
         bool IBuildActions.IsRunningOnAppleSilicon() => IsRunningOnAppleSilicon;
 
+        public bool IsMonoInstalled { get; set; }
+
+        bool IBuildActions.IsMonoInstalled() => IsMonoInstalled;
+
         string IBuildActions.PathCombine(params string[] parts)
         {
             return string.Join(IsWindows ? '\\' : '/', parts.Where(p => !string.IsNullOrWhiteSpace(p)));

--- a/csharp/autobuilder/Semmle.Autobuild.Shared/MsBuildRule.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.Shared/MsBuildRule.cs
@@ -10,15 +10,13 @@ namespace Semmle.Autobuild.Shared
         /// <summary>
         /// Appends a call to msbuild.
         /// </summary>
-        /// <param name="cmdBuilder"></param>
-        /// <param name="builder"></param>
         /// <returns></returns>
-        public static CommandBuilder MsBuildCommand(this CommandBuilder cmdBuilder, IAutobuilder<AutobuildOptionsShared> builder)
+        public static CommandBuilder MsBuildCommand(this CommandBuilder cmdBuilder, IAutobuilder<AutobuildOptionsShared> builder, bool preferDotnet)
         {
             // mono doesn't ship with `msbuild` on Arm-based Macs, but we can fall back to
             // msbuild that ships with `dotnet` which can be invoked with `dotnet msbuild`
             // perhaps we should do this on all platforms?
-            return builder.Actions.IsRunningOnAppleSilicon()
+            return builder.Actions.IsRunningOnAppleSilicon() || preferDotnet
                 ? cmdBuilder.RunCommand("dotnet").Argument("msbuild")
                 : cmdBuilder.RunCommand("msbuild");
         }
@@ -75,13 +73,21 @@ namespace Semmle.Autobuild.Shared
                         QuoteArgument(projectOrSolution.FullPath).
                         Argument("-DisableParallelProcessing").
                         Script;
+
+                BuildScript GetMonoVersionScript() => new CommandBuilder(builder.Actions).
+                    RunCommand("mono").
+                    Argument("--version").
+                    Script;
+
+                var preferDotnet = !builder.Actions.IsWindows() && GetMonoVersionScript().Run(builder.Actions, (_, _) => { }, (_, _, _) => { }) != 0;
+
                 var nugetRestore = GetNugetRestoreScript();
                 var msbuildRestoreCommand = new CommandBuilder(builder.Actions).
-                    MsBuildCommand(builder).
+                    MsBuildCommand(builder, preferDotnet).
                     Argument("/t:restore").
                     QuoteArgument(projectOrSolution.FullPath);
 
-                if (builder.Actions.IsRunningOnAppleSilicon())
+                if (builder.Actions.IsRunningOnAppleSilicon() || preferDotnet)
                 {
                     // On Apple Silicon, only try package restore with `dotnet msbuild /t:restore`
                     ret &= BuildScript.Try(msbuildRestoreCommand.Script);
@@ -119,7 +125,7 @@ namespace Semmle.Autobuild.Shared
                     command.RunCommand("set Platform=&& type NUL", quoteExe: false);
                 }
 
-                command.MsBuildCommand(builder);
+                command.MsBuildCommand(builder, preferDotnet);
                 command.QuoteArgument(projectOrSolution.FullPath);
 
                 var target = "rebuild";

--- a/csharp/autobuilder/Semmle.Autobuild.Shared/MsBuildRule.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.Shared/MsBuildRule.cs
@@ -74,12 +74,7 @@ namespace Semmle.Autobuild.Shared
                         Argument("-DisableParallelProcessing").
                         Script;
 
-                BuildScript GetMonoVersionScript() => new CommandBuilder(builder.Actions).
-                    RunCommand("mono").
-                    Argument("--version").
-                    Script;
-
-                var preferDotnet = !builder.Actions.IsWindows() && GetMonoVersionScript().Run(builder.Actions, (_, _) => { }, (_, _, _) => { }) != 0;
+                var preferDotnet = !builder.Actions.IsWindows() && !builder.Actions.IsMonoInstalled();
 
                 var nugetRestore = GetNugetRestoreScript();
                 var msbuildRestoreCommand = new CommandBuilder(builder.Actions).

--- a/csharp/extractor/Semmle.Util/BuildActions.cs
+++ b/csharp/extractor/Semmle.Util/BuildActions.cs
@@ -126,6 +126,11 @@ namespace Semmle.Util
         bool IsRunningOnAppleSilicon();
 
         /// <summary>
+        /// Checks if Mono is installed.
+        /// </summary>
+        bool IsMonoInstalled();
+
+        /// <summary>
         /// Combine path segments, Path.Combine().
         /// </summary>
         /// <param name="parts">The parts of the path.</param>
@@ -254,6 +259,25 @@ namespace Semmle.Util
             {
                 thisBuildActions.RunProcess("sysctl", "machdep.cpu.brand_string", workingDirectory: null, env: null, out var stdOut);
                 return stdOut?.Any(s => s?.ToLowerInvariant().Contains("apple") == true) ?? false;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+
+        bool IBuildActions.IsMonoInstalled()
+        {
+            var thisBuildActions = (IBuildActions)this;
+
+            if (thisBuildActions.IsWindows())
+            {
+                return false;
+            }
+
+            try
+            {
+                return 0 == thisBuildActions.RunProcess("mono", "--version", workingDirectory: null, env: null);
             }
             catch (Exception)
             {

--- a/csharp/ql/integration-tests/all-platforms/diag_missing_project_files/test.py
+++ b/csharp/ql/integration-tests/all-platforms/diag_missing_project_files/test.py
@@ -1,8 +1,2 @@
-import pytest
-import runs_on
-
-
-# Skipping the test on macos-15, as we're running into trouble.
-@pytest.mark.only_if(not runs_on.macos_15)
 def test(codeql, csharp):
     codeql.database.create(_assert_failure=True)


### PR DESCRIPTION
This pull request includes several changes to improve the handling of the autobuild process, particularly for different operating systems and scenarios where `mono` is or isn't available. The main changes involve updating the process execution logic and adding new test cases for better coverage.