### PR TITLE
Run test servers with `sudo` when running on `macos-15`

### DIFF
--- a/java/ql/integration-tests/java/buildless-inherit-trust-store/test.py
+++ b/java/ql/integration-tests/java/buildless-inherit-trust-store/test.py
@@ -7,7 +7,8 @@ def test(codeql, java, cwd):
     # This serves the "repo" directory on https://locahost:4443
     command = ["python3", "../server.py"]
     if runs_on.github_actions and runs_on.posix:
-        # On GitHub Actions, we try to run the server with higher priority
+        # On GitHub Actions, we saw the server timing out while running in parallel with other tests
+        # we work around that by running it with higher permissions
         command = ["sudo"] + command
     repo_server_process = subprocess.Popen(command, cwd="repo")
     certspath = cwd / "jdk8_shipped_cacerts_plus_cert_pem"

--- a/java/ql/integration-tests/java/buildless-inherit-trust-store/test.py
+++ b/java/ql/integration-tests/java/buildless-inherit-trust-store/test.py
@@ -1,10 +1,15 @@
 import subprocess
 import os
+import runs_on
 
 
 def test(codeql, java, cwd):
     # This serves the "repo" directory on https://locahost:4443
-    repo_server_process = subprocess.Popen(["python3", "../server.py"], cwd="repo")
+    command = ["python3", "../server.py"]
+    if runs_on.github_actions and runs_on.posix:
+        # On GitHub Actions, we try to run the server with higher priority
+        command = ["sudo", "nice", "-n", "10"] + command
+    repo_server_process = subprocess.Popen(command, cwd="repo")
     certspath = cwd / "jdk8_shipped_cacerts_plus_cert_pem"
     # If we override MAVEN_OPTS, we'll break cross-test maven isolation, so we need to append to it instead
     maven_opts = os.environ["MAVEN_OPTS"] + f" -Djavax.net.ssl.trustStore={certspath}"

--- a/java/ql/integration-tests/java/buildless-inherit-trust-store/test.py
+++ b/java/ql/integration-tests/java/buildless-inherit-trust-store/test.py
@@ -8,7 +8,7 @@ def test(codeql, java, cwd):
     command = ["python3", "../server.py"]
     if runs_on.github_actions and runs_on.posix:
         # On GitHub Actions, we try to run the server with higher priority
-        command = ["sudo", "nice", "-n", "10"] + command
+        command = ["sudo"] + command
     repo_server_process = subprocess.Popen(command, cwd="repo")
     certspath = cwd / "jdk8_shipped_cacerts_plus_cert_pem"
     # If we override MAVEN_OPTS, we'll break cross-test maven isolation, so we need to append to it instead

--- a/java/ql/integration-tests/java/buildless-snapshot-repository/test.py
+++ b/java/ql/integration-tests/java/buildless-snapshot-repository/test.py
@@ -7,7 +7,7 @@ def test(codeql, java):
     command = ["python3", "-m", "http.server", "9427", "-b", "localhost"]
     if runs_on.github_actions and runs_on.posix:
         # On GitHub Actions, we try to run the server with higher priority
-        command = ["sudo", "nice", "-n", "10"] + command
+        command = ["sudo"] + command
     repo_server_process = subprocess.Popen(
         command, cwd="repo"
     )

--- a/java/ql/integration-tests/java/buildless-snapshot-repository/test.py
+++ b/java/ql/integration-tests/java/buildless-snapshot-repository/test.py
@@ -6,7 +6,8 @@ def test(codeql, java):
     # This serves the "repo" directory on http://localhost:9427
     command = ["python3", "-m", "http.server", "9427", "-b", "localhost"]
     if runs_on.github_actions and runs_on.posix:
-        # On GitHub Actions, we try to run the server with higher priority
+        # On GitHub Actions, we saw the server timing out while running in parallel with other tests
+        # we work around that by running it with higher permissions
         command = ["sudo"] + command
     repo_server_process = subprocess.Popen(
         command, cwd="repo"


### PR DESCRIPTION
`macos-15` has issues with test maven servers, that causes timeouts. Running those servers with `sudo` fixes the problem.
Same fix that https://github.com/github/codeql/pull/19204 