### PR TITLE
Actions: Fix invocation of autobuild PowerShell script

### DIFF
--- a/actions/extractor/tools/autobuild.cmd
+++ b/actions/extractor/tools/autobuild.cmd
@@ -1,3 +1,4 @@
 @echo off
 rem All of the work is done in the PowerShell script
-powershell.exe "%~dp0autobuild-impl.ps1"
+echo "Running PowerShell script at '%~dp0autobuild-impl.ps1'"
+powershell.exe -File "%~dp0autobuild-impl.ps1"


### PR DESCRIPTION
Pass the quoted script path to PowerShell using `-File`. This ensures the path is treated as a string rather than a command, and correctly handles file paths that contain spaces, unblocking integration tests.

Add logging to autobuild.cmd for easier debugging.