### PR TITLE
Ruby: Fix bad join in `DeadStoreOfLocal.ql`

### DIFF
--- a/ruby/ql/src/queries/variables/DeadStoreOfLocal.ql
+++ b/ruby/ql/src/queries/variables/DeadStoreOfLocal.ql
@@ -11,15 +11,20 @@
  */
 
 import codeql.ruby.AST
+import codeql.ruby.CFG
 import codeql.ruby.dataflow.SSA
 import codeql.ruby.ApiGraphs
+
+pragma[nomagic]
+private predicate hasErbResultCall(CfgScope scope) {
+  scope = API::getTopLevelMember("ERB").getInstance().getAMethodCall("result").asExpr().getScope()
+}
 
 class RelevantLocalVariableWriteAccess extends LocalVariableWriteAccess {
   RelevantLocalVariableWriteAccess() {
     not this.getVariable().getName().charAt(0) = "_" and
     not this = any(Parameter p).getAVariable().getDefiningAccess() and
-    not API::getTopLevelMember("ERB").getInstance().getAMethodCall("result").asExpr().getScope() =
-      this.getCfgScope() and
+    not hasErbResultCall(this.getCfgScope()) and
     not exists(RetryStmt r | r.getCfgScope() = this.getCfgScope()) and
     not exists(MethodCall c |
       c.getReceiver() instanceof SelfVariableAccess and


### PR DESCRIPTION
```
[2025-04-09 09:22:56] (380s) Cancelling evaluation of #11561 evaluator _ApiGraphs::API::Impl::MkMethodAccessNode#4daa063f_ApiGraphs::API::Impl::TApiNode#368fc76d_ApiGraphs__#antijoin_rhs/1@d02e8ckf: Demand has vanished for #11561 evaluator _ApiGraphs::API::Impl::MkMethodAccessNode#4daa063f_ApiGraphs::API::Impl::TApiNode#368fc76d_ApiGraphs__#antijoin_rhs/1@d02e8ckf
[2025-04-09 09:22:56] (380s) Tuple counts for _ApiGraphs::API::Impl::MkMethodAccessNode#4daa063f_ApiGraphs::API::Impl::TApiNode#368fc76d_ApiGraphs__#antijoin_rhs/1@d02e8ckf after 5m17s:
                      12500       ~2341%      {2} r1 = JOIN `__Variable::LocalVariable.getDefiningAccess/0#dispred#316bde3e_10#join_rhs__Variable::LocalVariableW__#shared` WITH `Statement::Stmt.getCfgScope/0#dispred#58b7c05d` ON FIRST 1 OUTPUT Rhs.1, Lhs.0 'arg0'
                      1700171     ~775%       {2}    | JOIN WITH `ControlFlowGraphImpl::NodeImpl.getScope/0#dispred#fd525252_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1 'arg0'
                      1530333     ~722%       {3}    | JOIN WITH cached_DataFlowPrivate::TExprNode#ec061b78 ON FIRST 1 OUTPUT _, Lhs.1 'arg0', Rhs.1
                      1530333     ~699%       {3}    | REWRITE WITH Out.0 := "ERB"
                      258054437   ~741%       {3}    | JOIN WITH `cached_ApiGraphs::API::Impl::topLevelMember/2#ce51cf11` ON FIRST 1 OUTPUT Rhs.1, Lhs.1 'arg0', Lhs.2
                      258054437   ~741%       {3}    | JOIN WITH cached_ApiGraphs::API::Impl::TApiNode#368fc76d ON FIRST 1 OUTPUT Lhs.0, Lhs.1 'arg0', Lhs.2
                      832733500   ~1726%      {3}    | JOIN WITH `cached_fastTC@ApiGraphs::API::Internal::MkShared::Cached::epsilonEdge/2#aec408a8#2` ON FIRST 1 OUTPUT Rhs.1, Lhs.1 'arg0', Lhs.2
                      450751669   ~1518%      {3}    | JOIN WITH `cached_ApiGraphs::API::Impl::instanceEdge/2#f60af161` ON FIRST 1 OUTPUT Rhs.1, Lhs.1 'arg0', Lhs.2
                      36309175000 ~11844%     {4}    | JOIN WITH `cached_fastTC@ApiGraphs::API::Internal::MkShared::Cached::epsilonEdge/2#aec408a8#2` ON FIRST 1 OUTPUT Rhs.1, _, Lhs.1 'arg0', Lhs.2
                      36309173500 ~11194%     {4}    | REWRITE WITH Out.1 := "result"
                      447552127   ~2171%      {3}    | JOIN WITH `cached_ApiGraphs::API::Impl::methodEdge/3#5c5f7602` ON FIRST 2 OUTPUT Lhs.3, Rhs.2, Lhs.2 'arg0'
                      0           ~0%         {1}    | JOIN WITH cached_ApiGraphs::API::Impl::MkMethodAccessNode#4daa063f ON FIRST 2 OUTPUT Lhs.2 'arg0'
                                              return r1
```