### PR TITLE
Java: Add EnumType to SimpleTypeSanitizer

### DIFF
--- a/java/ql/lib/change-notes/2025-04-09-enum-type-exclusion.md
+++ b/java/ql/lib/change-notes/2025-04-09-enum-type-exclusion.md
@@ -1,4 +1,4 @@
 ---
 category: minorAnalysis
 ---
-* Enum-typed values are now assumed to be safe by most queries. This means that queries may return less results where an enum value is used in a sensitive context, e.g. pasted into a query string.
+* Enum-typed values are now assumed to be safe by most queries. This means that queries may return fewer results where an enum value is used in a sensitive context, e.g. pasted into a query string.

--- a/java/ql/lib/change-notes/2025-04-09-enum-type-exclusion.md
+++ b/java/ql/lib/change-notes/2025-04-09-enum-type-exclusion.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Enum-typed values are now assumed to be safe by most queries. This means that queries may return less results where an enum value is used in a sensitive context, e.g. pasted into a query string.

--- a/java/ql/lib/semmle/code/java/security/Sanitizers.qll
+++ b/java/ql/lib/semmle/code/java/security/Sanitizers.qll
@@ -23,6 +23,7 @@ class SimpleTypeSanitizer extends DataFlow::Node {
     this.getType()
         .(RefType)
         .getASourceSupertype*()
-        .hasQualifiedName("java.time.temporal", "TemporalAccessor")
+        .hasQualifiedName("java.time.temporal", "TemporalAccessor") or
+    this.getType() instanceof EnumType
   }
 }


### PR DESCRIPTION
For the same reasons as integers and other simple values, enums are probably not useful injection vectors for most purposes.