### PR TITLE
Rust: Allow for crate self-references in crate graph paths

### DIFF
--- a/rust/ql/lib/codeql/rust/internal/PathResolution.qll
+++ b/rust/ql/lib/codeql/rust/internal/PathResolution.qll
@@ -764,6 +764,10 @@ private predicate crateDependencyEdge(ModuleLikeNode m, string name, CrateItemNo
     // entry/transitive source file
     m = c.getASourceFile()
   )
+  or
+  // paths inside the crate graph use the name of the crate itself as prefix,
+  // although that is not valid in Rust
+  dep = any(Crate c | name = c.getName() and m = c.getModule())
 }
 
 private predicate useTreeDeclares(UseTree tree, string name) {


### PR DESCRIPTION
The extractor produces fully crate-qualified paths for entities extracted from the crate graph, which our path resolution logic handles. However, for entities where the crate-qualifier refers to the defining crate itself, the extractor should have used the special `crate` qualifier instead of the name of the crate.

For example, the `impl<T> Option<T>` block is extracted as `impl<T> core::option::Option<T>` instead of `impl<T> crate::option::Option<T>`.

This PR adjusts our path resolution logic to also handle crate self-references like above, but restricted to entities from the crate graph.

DCA shows that, while we maintain performance, we reduce the number of unresolved call targets by 16 % (down 1,699,468 from 2,012,848), all numbers computed across the entire DCA suite.

cc @aibaars 