### PR TITLE
CodeQL docs: Fix ordering in side navigation bar for Query help

### DIFF
--- a/docs/codeql/query-help/index.rst
+++ b/docs/codeql/query-help/index.rst
@@ -29,9 +29,9 @@ For a full list of the CWEs covered by these queries, see ":doc:`CodeQL CWE cove
    :hidden:
    :titlesonly:
 
-   actions
    cpp
    csharp
+   actions
    go
    java
    javascript


### PR DESCRIPTION
This list would currently be incorrectly published as shown in the screenshot below. This PR corrects the order to alphabetic. So "GitHub Actions" should appear after C/C++ and C#.
 
<img width="345" alt="Screenshot showing 'GitHub Actions' appearing at the top of the list instead of correct alphabetic order." src="https://github.com/user-attachments/assets/add86065-2e0b-49bc-b97b-0804bfd51607" />