### PR TITLE
Shared: Prepare model generation for C++ adoption

### DIFF
--- a/csharp/ql/src/utils/modelgenerator/internal/CaptureModels.qll
+++ b/csharp/ql/src/utils/modelgenerator/internal/CaptureModels.qll
@@ -22,9 +22,15 @@ module ModelGeneratorInput implements ModelGeneratorInputSig<Location, CsharpDat
 
   class Callable = CS::Callable;
 
-  class NodeExtended extends CS::DataFlow::Node {
-    Callable getAsExprEnclosingCallable() { result = this.asExpr().getEnclosingCallable() }
+  class NodeExtended = CS::DataFlow::Node;
+
+  Callable getAsExprEnclosingCallable(NodeExtended node) {
+    result = node.asExpr().getEnclosingCallable()
   }
+
+  Callable getEnclosingCallable(NodeExtended node) { result = node.getEnclosingCallable() }
+
+  Parameter asParameter(NodeExtended node) { result = node.asParameter() }
 
   /**
    * Holds if any of the parameters of `api` are `System.Func<>`.

--- a/java/ql/src/utils/modelgenerator/internal/CaptureModels.qll
+++ b/java/ql/src/utils/modelgenerator/internal/CaptureModels.qll
@@ -32,9 +32,15 @@ module ModelGeneratorInput implements ModelGeneratorInputSig<Location, JavaDataF
 
   class Callable = J::Callable;
 
-  class NodeExtended extends DataFlow::Node {
-    Callable getAsExprEnclosingCallable() { result = this.asExpr().getEnclosingCallable() }
+  class NodeExtended = DataFlow::Node;
+
+  Callable getAsExprEnclosingCallable(NodeExtended node) {
+    result = node.asExpr().getEnclosingCallable()
   }
+
+  Callable getEnclosingCallable(NodeExtended node) { result = node.getEnclosingCallable() }
+
+  Parameter asParameter(NodeExtended node) { result = node.asParameter() }
 
   private predicate isInfrequentlyUsed(J::CompilationUnit cu) {
     cu.getPackage().getName().matches("javax.swing%") or

--- a/rust/ql/src/utils/modelgenerator/internal/CaptureModels.qll
+++ b/rust/ql/src/utils/modelgenerator/internal/CaptureModels.qll
@@ -20,14 +20,16 @@ module ModelGeneratorInput implements ModelGeneratorInputSig<Location, RustDataF
   class Callable = R::Callable;
 
   class NodeExtended extends DataFlow::Node {
-    Callable getAsExprEnclosingCallable() { result = this.asExpr().getScope() }
-
     Type getType() { any() }
-
-    Callable getEnclosingCallable() {
-      result = this.(Node::Node).getEnclosingCallable().asCfgScope()
-    }
   }
+
+  Callable getAsExprEnclosingCallable(NodeExtended node) { result = node.asExpr().getScope() }
+
+  Callable getEnclosingCallable(NodeExtended node) {
+    result = node.(Node::Node).getEnclosingCallable().asCfgScope()
+  }
+
+  Parameter asParameter(NodeExtended node) { result = node.asParameter() }
 
   private predicate relevant(Function api) {
     // Only include functions that have a resolved path.

--- a/shared/mad/codeql/mad/modelgenerator/internal/ModelGeneratorImpl.qll
+++ b/shared/mad/codeql/mad/modelgenerator/internal/ModelGeneratorImpl.qll
@@ -55,11 +55,8 @@ signature module ModelGeneratorInputSig<LocationSig Location, InputSig<Location>
      */
     Callable getAsExprEnclosingCallable();
 
-    /**
-     * Gets the parameter corresponding to this node, if any.
-     */
-    Parameter asParameter();
-  }
+  /** Gets the parameter corresponding to this node, if any. */
+  Parameter asParameter(NodeExtended n);
 
   /**
    * A class of callables that are potentially relevant for generating summary or
@@ -390,7 +387,7 @@ module MakeModelGenerator<
    * Gets the MaD string representation of the parameter node `p`.
    */
   string parameterNodeAsInput(DataFlow::ParameterNode p) {
-    result = parameterAccess(p.(NodeExtended).asParameter())
+    result = parameterAccess(asParameter(p))
     or
     result = qualifierString() and p instanceof InstanceParameterNode
   }
@@ -613,7 +610,7 @@ module MakeModelGenerator<
      * when used in content flow.
      */
     private string parameterNodeAsContentInput(DataFlow::ParameterNode p) {
-      result = parameterContentAccess(p.(NodeExtended).asParameter())
+      result = parameterContentAccess(asParameter(p))
       or
       result = qualifierString() and p instanceof InstanceParameterNode
     }

--- a/shared/mad/codeql/mad/modelgenerator/internal/ModelGeneratorImpl.qll
+++ b/shared/mad/codeql/mad/modelgenerator/internal/ModelGeneratorImpl.qll
@@ -687,7 +687,7 @@ module MakeModelGenerator<
       private DataFlow::ParameterNode parameter;
 
       ContentDataFlowSummaryTargetApi() {
-        count(string input, string output |
+        strictcount(string input, string output |
           exists(
             PropagateContentFlow::AccessPath reads, ReturnNodeExt returnNodeExt,
             PropagateContentFlow::AccessPath stores

--- a/shared/mad/codeql/mad/modelgenerator/internal/ModelGeneratorImpl.qll
+++ b/shared/mad/codeql/mad/modelgenerator/internal/ModelGeneratorImpl.qll
@@ -223,6 +223,14 @@ signature module ModelGeneratorInputSig<LocationSig Location, InputSig<Location>
   default Lang::ParameterPosition getReturnKindParamPosition(Lang::ReturnKind node) { none() }
 
   /**
+   * Gets the string that represents the return value corresponding to the
+   * return kind `kind`.
+   *
+   * For most languages this will be the string "ReturnValue".
+   */
+  default string getReturnValueString(Lang::ReturnKind kind) { result = "ReturnValue" }
+
+  /**
    * Holds if it is irrelevant to generate models for `api` based on data flow analysis.
    *
    * This serves as an extra filter for the `relevant` predicate.
@@ -317,9 +325,11 @@ module MakeModelGenerator<
 
   private module PrintReturnNodeExt<printCallableParamSig/2 printCallableParam> {
     string getOutput(ReturnNodeExt node) {
-      node.getKind() instanceof DataFlow::ValueReturnKind and
-      not exists(node.getPosition()) and
-      result = "ReturnValue"
+      exists(DataFlow::ValueReturnKind valueReturnKind |
+        valueReturnKind = node.getKind() and
+        not exists(node.getPosition()) and
+        result = getReturnValueString(valueReturnKind.getKind())
+      )
       or
       exists(DataFlow::ParameterPosition pos |
         pos = node.getPosition() and


### PR DESCRIPTION
This PR slightly generalizes the model generation input signature to allow for a smooth C++ adoption:

- 732fcbf1c908abbe7f6976e7aff17712eca8ab89 moves the `asParameter` out of the `NodeExtended` signature. This is necessary because the return type of C++'s `Node.asParameter` is different from the actual parameter nodes we use inside dataflow.
- Likewise, c484945f395d31e7c6c131ef373baf467ca8b555 moves the `getEnclosingCallable` out of the `NodeExtended` for similar reasons. I also moved `getAsExprEnclosingCallable` for symmetry.
- ea3bb8cf0c2a362c02b1ea586733706e52a1596c adds a hook to customize the `ReturnValue` string for `ValueReturnKind`s. This necessary because C++ has `ReturnValue`, `ReturnValue[*]`, `ReturnValue[**]`, etc, for returning `p`, `*p`, `**p` from a function.

Additionally, I fixed a potential cartesian product in a1dc87496a02c1eeb538630fd867c8a189256fd9 that I was hitting when testing MaD on a large C++ repository internally at Microsoft.

Commit-by-commit review recommended.

@michaelnebel does this need additional testing other than CI? And if so, how do I go about doing that?