### PR TITLE
C++: Prepare for model generation adoption

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/dataflow/ExternalFlow.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/ExternalFlow.qll
@@ -465,7 +465,7 @@ private predicate isFunctionConstructedFrom(Function f, Function templateFunc) {
 }
 
 /** Gets the fully templated version of `f`. */
-private Function getFullyTemplatedFunction(Function f) {
+Function getFullyTemplatedFunction(Function f) {
   not f.isFromUninstantiatedTemplate(_) and
   (
     exists(Class c, Class templateClass, int i |
@@ -559,12 +559,15 @@ private string getTypeName(Type t, boolean needsSpace) {
 
 /**
  * Gets a type name for the `n`'th parameter of `f` without any template
- * arguments. The result may be a string representing a type for which the
- * typedefs have been resolved.
+ * arguments.
+ *
+ * If `canonical = false` then the result may be a string representing a type
+ * for which the typedefs have been resolved. If `canonical = true` then the
+ * result will be a string representing a type without resolving `typedefs`.
  */
 bindingset[f]
 pragma[inline_late]
-string getParameterTypeWithoutTemplateArguments(Function f, int n) {
+string getParameterTypeWithoutTemplateArguments(Function f, int n, boolean canonical) {
   exists(string s, string base, string specifiers, Type t |
     t = f.getParameter(n).getType() and
     // The name of the string can either be the possibly typedefed name
@@ -572,14 +575,19 @@ string getParameterTypeWithoutTemplateArguments(Function f, int n) {
     // `getTypeName(t, _)` is almost equal to `t.resolveTypedefs().getName()`,
     // except that `t.resolveTypedefs()` doesn't have a result when the
     // resulting type doesn't appear in the database.
-    s = [t.getName(), getTypeName(t, _)] and
+    (
+      s = t.getName() and canonical = true
+      or
+      s = getTypeName(t, _) and canonical = false
+    ) and
     parseAngles(s, base, _, specifiers) and
     result = base + specifiers
   )
   or
   f.isVarargs() and
   n = f.getNumberOfParameters() and
-  result = "..."
+  result = "..." and
+  canonical = true
 }
 
 /**
@@ -590,7 +598,7 @@ private string getTypeNameWithoutFunctionTemplates(Function f, int n, int remain
   exists(Function templateFunction |
     templateFunction = getFullyTemplatedFunction(f) and
     remaining = templateFunction.getNumberOfTemplateArguments() and
-    result = getParameterTypeWithoutTemplateArguments(templateFunction, n)
+    result = getParameterTypeWithoutTemplateArguments(templateFunction, n, _)
   )
   or
   exists(string mid, TypeTemplateParameter tp, Function templateFunction |
@@ -627,7 +635,7 @@ private string getTypeNameWithoutClassTemplates(Function f, int n, int remaining
 }
 
 /** Gets the string representation of the `i`'th parameter of `c`. */
-private string getParameterTypeName(Function c, int i) {
+string getParameterTypeName(Function c, int i) {
   result = getTypeNameWithoutClassTemplates(c, i, 0)
 }
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -470,7 +470,7 @@ newtype TPosition =
     Ssa::hasIndirectOperand(any(CallInstruction call).getArgumentOperand(argumentIndex),
       indirectionIndex)
     or
-    // Handle the rare case where the is a function definition but no call to
+    // Handle the rare case where there is a function definition but no call to
     // the function.
     exists(Cpp::Function f, Cpp::Parameter p |
       p = f.getParameter(argumentIndex) and

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -462,7 +462,7 @@ newtype TPosition =
   TDirectPosition(int argumentIndex) {
     exists(any(CallInstruction c).getArgument(argumentIndex))
     or
-    // Handle the rare case where the is a function definition but no call to
+    // Handle the rare case where there is a function definition but no call to
     // the function.
     exists(any(Cpp::Function f).getParameter(argumentIndex))
   } or

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -371,7 +371,7 @@ private class PrimaryArgumentNode extends ArgumentNode, OperandNode {
   PrimaryArgumentNode() { exists(CallInstruction call | op = call.getAnArgumentOperand()) }
 
   override predicate argumentOf(DataFlowCall call, ArgumentPosition pos) {
-    op = call.getArgumentOperand(pos.(DirectPosition).getIndex())
+    op = call.getArgumentOperand(pos.(DirectPosition).getArgumentIndex())
   }
 }
 
@@ -410,8 +410,16 @@ class ParameterPosition = Position;
 class ArgumentPosition = Position;
 
 abstract class Position extends TPosition {
+  /** Gets a textual representation of this position. */
   abstract string toString();
 
+  /**
+   * Gets the argument index of this position. The qualifier of a call has
+   * argument index `-1`.
+   */
+  abstract int getArgumentIndex();
+
+  /** Gets the indirection index of this position. */
   abstract int getIndirectionIndex();
 }
 
@@ -428,7 +436,7 @@ class DirectPosition extends Position, TDirectPosition {
     result = index.toString()
   }
 
-  int getIndex() { result = index }
+  override int getArgumentIndex() { result = index }
 
   final override int getIndirectionIndex() { result = 0 }
 }
@@ -445,7 +453,7 @@ class IndirectionPosition extends Position, TIndirectionPosition {
     else result = repeatStars(indirectionIndex) + argumentIndex.toString()
   }
 
-  int getArgumentIndex() { result = argumentIndex }
+  override int getArgumentIndex() { result = argumentIndex }
 
   final override int getIndirectionIndex() { result = indirectionIndex }
 }

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -509,6 +509,15 @@ class ReturnKind extends TReturnKind {
 
   /** Gets a textual representation of this return kind. */
   abstract string toString();
+
+  /** Holds if this `ReturnKind` is generated from a `return` statement. */
+  abstract predicate isNormalReturn();
+
+  /**
+   * Holds if this `ReturnKind` is generated from a write to the parameter with
+   * index `argumentIndex`
+   */
+  abstract predicate isIndirectReturn(int argumentIndex);
 }
 
 /**
@@ -522,6 +531,10 @@ class NormalReturnKind extends ReturnKind, TNormalReturnKind {
   override int getIndirectionIndex() { result = indirectionIndex }
 
   override string toString() { result = "indirect return" }
+
+  override predicate isNormalReturn() { any() }
+
+  override predicate isIndirectReturn(int argumentIndex) { none() }
 }
 
 /**
@@ -536,6 +549,10 @@ private class IndirectReturnKind extends ReturnKind, TIndirectReturnKind {
   override int getIndirectionIndex() { result = indirectionIndex }
 
   override string toString() { result = "indirect outparam[" + argumentIndex.toString() + "]" }
+
+  override predicate isNormalReturn() { none() }
+
+  override predicate isIndirectReturn(int argumentIndex_) { argumentIndex_ = argumentIndex }
 }
 
 /** A data flow node that occurs as the result of a `ReturnStmt`. */

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -1445,7 +1445,7 @@ private class ExplicitParameterInstructionNode extends AbstractExplicitParameter
   ExplicitParameterInstructionNode() { exists(instr.getParameter()) }
 
   override predicate isSourceParameterOf(Function f, ParameterPosition pos) {
-    f.getParameter(pos.(DirectPosition).getIndex()) = instr.getParameter()
+    f.getParameter(pos.(DirectPosition).getArgumentIndex()) = instr.getParameter()
   }
 
   override string toStringImpl() { result = instr.getParameter().toString() }
@@ -1460,7 +1460,7 @@ class ThisParameterInstructionNode extends AbstractExplicitParameterNode,
   ThisParameterInstructionNode() { instr.getIRVariable() instanceof IRThisVariable }
 
   override predicate isSourceParameterOf(Function f, ParameterPosition pos) {
-    pos.(DirectPosition).getIndex() = -1 and
+    pos.(DirectPosition).getArgumentIndex() = -1 and
     instr.getEnclosingFunction() = f
   }
 
@@ -1494,7 +1494,7 @@ private class DirectBodyLessParameterNode extends AbstractExplicitParameterNode,
 
   override predicate isSourceParameterOf(Function f, ParameterPosition pos) {
     this.getFunction() = f and
-    f.getParameter(pos.(DirectPosition).getIndex()) = p
+    f.getParameter(pos.(DirectPosition).getArgumentIndex()) = p
   }
 
   override Parameter getParameter() { result = p }

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/TaintTrackingUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/TaintTrackingUtil.qll
@@ -229,11 +229,11 @@ private module SpeculativeTaintFlow {
       not exists(DataFlowDispatch::viableCallable(call)) and
       src.(DataFlowPrivate::ArgumentNode).argumentOf(call, argpos)
     |
-      not argpos.(DirectPosition).getIndex() = -1 and
+      not argpos.(DirectPosition).getArgumentIndex() = -1 and
       sink.(PostUpdateNode)
           .getPreUpdateNode()
           .(DataFlowPrivate::ArgumentNode)
-          .argumentOf(call, any(DirectPosition qualpos | qualpos.getIndex() = -1))
+          .argumentOf(call, any(DirectPosition qualpos | qualpos.getArgumentIndex() = -1))
       or
       sink.(DataFlowPrivate::OutNode).getCall() = call
     )


### PR DESCRIPTION
This PR does the necessary changes to existing C++ code required for model generation. It should be a no-opt in terms of results and performance.

DCA was uneventful (as expected).