### PR TITLE
Fix typo in ReusableWorkflowsSinks.ql identifier

### DIFF
--- a/actions/ql/src/Models/ReusableWorkflowsSinks.ql
+++ b/actions/ql/src/Models/ReusableWorkflowsSinks.ql
@@ -5,7 +5,7 @@
  * @problem.severity warning
  * @security-severity 9.3
  * @precision high
- * @id actions/reusable-wokflow-sinks
+ * @id actions/reusable-workflow-sinks
  * @tags actions
  *       model-generator
  *       external/cwe/cwe-020


### PR DESCRIPTION
Copilot spotted this when reviewing a PR in the CodeQL docs publication repository.

Will fixing this break anything else, or is safe to correct here?