### PR TITLE
C#: Improve auto-builder to better detect SDK references.

### DIFF
--- a/csharp/autobuilder/Semmle.Autobuild.CSharp.Tests/BuildScripts.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.CSharp.Tests/BuildScripts.cs
@@ -424,8 +424,7 @@ namespace Semmle.Autobuild.CSharp.Tests
             return new CSharpAutobuilder(actions, options);
         }
 
-        [Fact]
-        public void TestDefaultCSharpAutoBuilder()
+        private void SetupActionForDotnet()
         {
             actions.RunProcess["cmd.exe /C dotnet --info"] = 0;
             actions.RunProcess[@"cmd.exe /C dotnet clean C:\Project\test.csproj"] = 0;
@@ -438,18 +437,78 @@ namespace Semmle.Autobuild.CSharp.Tests
             actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_SCRATCH_DIR"] = "scratch";
             actions.EnumerateFiles[@"C:\Project"] = "foo.cs\nbar.cs\ntest.csproj";
             actions.EnumerateDirectories[@"C:\Project"] = "";
-            var xml = new XmlDocument();
-            xml.LoadXml(@"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
+        }
 
-</Project>");
+        private void CreateAndVerifyDotnetScript(XmlDocument xml)
+        {
             actions.LoadXml[@"C:\Project\test.csproj"] = xml;
 
             var autobuilder = CreateAutoBuilder(true);
             TestAutobuilderScript(autobuilder, 0, 4);
+        }
+
+        [Fact]
+        public void TestDefaultCSharpAutoBuilder1()
+        {
+            SetupActionForDotnet();
+            var xml = new XmlDocument();
+            xml.LoadXml(
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <OutputType>Exe</OutputType>
+                <TargetFramework>netcoreapp2.1</TargetFramework>
+              </PropertyGroup>
+            </Project>
+            """);
+            CreateAndVerifyDotnetScript(xml);
+        }
+
+        [Fact]
+        public void TestDefaultCSharpAutoBuilder2()
+        {
+            SetupActionForDotnet();
+            var xml = new XmlDocument();
+
+            xml.LoadXml(
+            """
+            <Project>
+              <Sdk Name="Microsoft.NET.Sdk" />
+
+              <PropertyGroup>
+                <OutputType>Exe</OutputType>
+                <TargetFramework>net9.0</TargetFramework>
+                <ImplicitUsings>enable</ImplicitUsings>
+                <Nullable>enable</Nullable>
+              </PropertyGroup>
+            </Project>
+            """
+            );
+            CreateAndVerifyDotnetScript(xml);
+        }
+
+        [Fact]
+        public void TestDefaultCSharpAutoBuilder3()
+        {
+            SetupActionForDotnet();
+            var xml = new XmlDocument();
+
+            xml.LoadXml(
+            """
+            <Project>
+              <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+
+              <PropertyGroup>
+                <OutputType>Exe</OutputType>
+                <TargetFramework>net9.0</TargetFramework>
+                <ImplicitUsings>enable</ImplicitUsings>
+                <Nullable>enable</Nullable>
+              </PropertyGroup>
+              <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+            </Project>
+            """
+            );
+            CreateAndVerifyDotnetScript(xml);
         }
 
         [Fact]

--- a/csharp/autobuilder/Semmle.Autobuild.Shared/Project.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.Shared/Project.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Xml;
-using Semmle.Util.Logging;
 
 namespace Semmle.Autobuild.Shared
 {
@@ -25,6 +24,26 @@ namespace Semmle.Autobuild.Shared
 
         private readonly Lazy<List<Project<TAutobuildOptions>>> includedProjectsLazy;
         public override IEnumerable<IProjectOrSolution> IncludedProjects => includedProjectsLazy.Value;
+
+        private static bool HasSdkAttribute(XmlElement xml) =>
+            xml.HasAttribute("Sdk");
+
+        private static bool AnyElement(XmlNodeList l, Func<XmlElement, bool> f) =>
+            l.OfType<XmlElement>().Any(f);
+
+        /// <summary>
+        /// According to https://learn.microsoft.com/en-us/visualstudio/msbuild/how-to-use-project-sdk?view=vs-2022#reference-a-project-sdk
+        /// there are three ways to reference a project SDK:
+        ///  1. As an attribute on the <Project/>.
+        ///  2. As a top level element of <Project>.
+        ///  3. As an attribute on an <Import> element.
+        ///
+        /// Returns true, if the Sdk attribute is used, otherwise false.
+        /// </summary>
+        private static bool ReferencesSdk(XmlElement xml) =>
+            HasSdkAttribute(xml) || // Case 1
+            AnyElement(xml.ChildNodes, e => e.Name == "Sdk") || // Case 2
+            AnyElement(xml.GetElementsByTagName("Import"), HasSdkAttribute); // Case 3
 
         public Project(Autobuilder<TAutobuildOptions> builder, string path) : base(builder, path)
         {
@@ -49,7 +68,7 @@ namespace Semmle.Autobuild.Shared
 
             if (root?.Name == "Project")
             {
-                if (root.HasAttribute("Sdk"))
+                if (ReferencesSdk(root))
                 {
                     DotNetProject = true;
                     return;

--- a/csharp/ql/lib/change-notes/2025-04-11-auto-builder-sdk.md
+++ b/csharp/ql/lib/change-notes/2025-04-11-auto-builder-sdk.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Improved autobuilder logic for detecting whether a project references a SDK (and should be built using `dotnet`).


### PR DESCRIPTION
In this PR we extend the auto builder heuristic detection logic for when to use `dotnet` to build a project.
There are tree ways to reference an `Sdk`, which is described [here](https://learn.microsoft.com/en-us/visualstudio/msbuild/how-to-use-project-sdk?view=vs-2022#reference-a-project-sdk).

DCA doesn't show any changes to performance, build capabilities or alerts for the projects in our autobuild suite.