### PR TITLE
C#: Relax condition for authorize attributes on `cs/web/missing-function-level-access-control`.

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/security/auth/MissingFunctionLevelAccessControlQuery.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/auth/MissingFunctionLevelAccessControlQuery.qll
@@ -81,7 +81,7 @@ predicate hasAuthViaXml(ActionMethod m) {
 
 /** Holds if the given action has an attribute that indications authorization. */
 predicate hasAuthViaAttribute(ActionMethod m) {
-  exists(Attribute attr | attr.getType().getName().toLowerCase().matches("%auth%") |
+  exists(Attribute attr | attr.getType().getABaseType*().getName().toLowerCase().matches("%auth%") |
     attr = m.getOverridee*().getAnAttribute() or
     attr = getAnUnboundBaseType*(m.getDeclaringType()).getAnAttribute()
   )

--- a/csharp/ql/src/change-notes/2025-04-15-missing-function-level-access-control.md
+++ b/csharp/ql/src/change-notes/2025-04-15-missing-function-level-access-control.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Improved detection of authorization checks in the `cs/web/missing-function-level-access-control` query. The query now recognizes authorization attributes inherited from base classes and interfaces.

--- a/csharp/ql/test/query-tests/Security Features/CWE-285/MissingAccessControl/MVCTests/MissingAccessControl.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-285/MissingAccessControl/MVCTests/MissingAccessControl.expected
@@ -1,1 +1,1 @@
-| ProfileController.cs:9:25:9:31 | Delete1 | This action is missing an authorization check. |
+| ProfileController.cs:10:25:10:31 | Delete1 | This action is missing an authorization check. |

--- a/csharp/ql/test/query-tests/Security Features/CWE-285/MissingAccessControl/MVCTests/MissingAccessControl.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-285/MissingAccessControl/MVCTests/MissingAccessControl.expected
@@ -1,1 +1,5 @@
-| ProfileController.cs:10:25:10:31 | Delete1 | This action is missing an authorization check. |
+#select
+| ProfileController.cs:12:25:12:31 | Delete1 | This action is missing an authorization check. |
+| ProfileController.cs:39:25:39:31 | Delete4 | This action is missing an authorization check. |
+testFailures
+| ProfileController.cs:39:25:39:31 | This action is missing an authorization check. | Unexpected result: Alert |

--- a/csharp/ql/test/query-tests/Security Features/CWE-285/MissingAccessControl/MVCTests/MissingAccessControl.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-285/MissingAccessControl/MVCTests/MissingAccessControl.expected
@@ -1,5 +1,1 @@
-#select
 | ProfileController.cs:12:25:12:31 | Delete1 | This action is missing an authorization check. |
-| ProfileController.cs:39:25:39:31 | Delete4 | This action is missing an authorization check. |
-testFailures
-| ProfileController.cs:39:25:39:31 | This action is missing an authorization check. | Unexpected result: Alert |

--- a/csharp/ql/test/query-tests/Security Features/CWE-285/MissingAccessControl/MVCTests/MissingAccessControl.qlref
+++ b/csharp/ql/test/query-tests/Security Features/CWE-285/MissingAccessControl/MVCTests/MissingAccessControl.qlref
@@ -1,1 +1,4 @@
-Security Features/CWE-285/MissingAccessControl.ql
+query: Security Features/CWE-285/MissingAccessControl.ql
+postprocess:
+  - utils/test/PrettyPrintModels.ql
+  - utils/test/InlineExpectationsTestQuery.ql

--- a/csharp/ql/test/query-tests/Security Features/CWE-285/MissingAccessControl/MVCTests/ProfileController.cs
+++ b/csharp/ql/test/query-tests/Security Features/CWE-285/MissingAccessControl/MVCTests/ProfileController.cs
@@ -1,19 +1,23 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Authorization;
 
-public class ProfileController : Controller {
+public class ProfileController : Controller
+{
     private void doThings() { }
     private bool isAuthorized() { return false; }
 
     // BAD: This is a Delete method, but no auth is specified.
-    public ActionResult Delete1(int id) {
+    public ActionResult Delete1(int id) // $ Alert
+    {
         doThings();
         return View();
     }
 
     // GOOD: isAuthorized is checked.
-    public ActionResult Delete2(int id) {
-        if (!isAuthorized()) {
+    public ActionResult Delete2(int id)
+    {
+        if (!isAuthorized())
+        {
             return null;
         }
         doThings();
@@ -22,7 +26,8 @@ public class ProfileController : Controller {
 
     // GOOD: The Authorize attribute is used.
     [Authorize]
-    public ActionResult Delete3(int id) {
+    public ActionResult Delete3(int id)
+    {
         doThings();
         return View();
     }
@@ -30,26 +35,32 @@ public class ProfileController : Controller {
 }
 
 [Authorize]
-public class AuthBaseController : Controller {
+public class AuthBaseController : Controller
+{
     protected void doThings() { }
 }
 
-public class SubController : AuthBaseController {
+public class SubController : AuthBaseController
+{
     // GOOD: The Authorize attribute is used on the base class.
-    public ActionResult Delete4(int id) {
+    public ActionResult Delete4(int id)
+    {
         doThings();
         return View();
     }
 }
 
 [Authorize]
-public class AuthBaseGenericController<T> : Controller {
+public class AuthBaseGenericController<T> : Controller
+{
     protected void doThings() { }
 }
 
-public class SubGenericController : AuthBaseGenericController<string> {
+public class SubGenericController : AuthBaseGenericController<string>
+{
     // GOOD: The Authorize attribute is used on the base class.
-    public ActionResult Delete5(int id) {
+    public ActionResult Delete5(int id)
+    {
         doThings();
         return View();
     }

--- a/csharp/ql/test/query-tests/Security Features/CWE-285/MissingAccessControl/MVCTests/ProfileController.cs
+++ b/csharp/ql/test/query-tests/Security Features/CWE-285/MissingAccessControl/MVCTests/ProfileController.cs
@@ -1,6 +1,8 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Authorization;
 
+public class RequirePermissionAttribute : AuthorizeAttribute { }
+
 public class ProfileController : Controller
 {
     private void doThings() { }
@@ -32,6 +34,13 @@ public class ProfileController : Controller
         return View();
     }
 
+    // GOOD: The RequirePermission attribute is used (which extends AuthorizeAttribute).
+    [RequirePermission]
+    public ActionResult Delete4(int id)
+    {
+        doThings();
+        return View();
+    }
 }
 
 [Authorize]


### PR DESCRIPTION
The change note was made mostly using CoPilot chat.
With the right context (the query, query module and another change note) it produced reasonable output.

DCA is uneventful.