### PR TITLE
Rust: Allow implicit reads from reference content in taint reach.

### DIFF
--- a/rust/ql/src/queries/summary/TaintReach.qll
+++ b/rust/ql/src/queries/summary/TaintReach.qll
@@ -15,6 +15,12 @@ private module TaintReachConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node node) { node instanceof ActiveThreatModelSource }
 
   predicate isSink(DataFlow::Node node) { any() }
+
+  predicate allowImplicitRead(DataFlow::Node node, DataFlow::ContentSet c) {
+    // flow out from reference content at the sink.
+    isSink(node) and
+    c.getAReadContent() instanceof DataFlow::ReferenceContent
+  }
 }
 
 private module TaintReachFlow = TaintTracking::Global<TaintReachConfig>;


### PR DESCRIPTION
Allow implicit reads from reference content in the taint reach calculation:
- the metric was designed without content in mind.  As written nodes reached with content on them do not count as reached in the metric, which leads to undercounting.
- however allowing any content produces a huge cartesian product in `allowImplicitRead`.
- as a compromise, allow implicit read for reference content, which I hypothesize may be responsible for a big part of the undercounting (DCA to confirm).