### PR TITLE
Actions: Remove preview notice, minor help and metadata fixes

### DIFF
--- a/actions/ql/src/Security/CWE-077/EnvVarInjectionMedium.md
+++ b/actions/ql/src/Security/CWE-077/EnvVarInjectionMedium.md
@@ -109,7 +109,7 @@ An attacker could craft a malicious artifact that writes dangerous environment v
 
 ### Exploitation
 
-An attacker is be able to run arbitrary code by injecting environment variables such as `LD_PRELOAD`, `BASH_ENV`, etc.
+An attacker would be able to run arbitrary code by injecting environment variables such as `LD_PRELOAD`, `BASH_ENV`, etc.
 
 ## References
 

--- a/actions/ql/src/Security/CWE-275/MissingActionsPermissions.ql
+++ b/actions/ql/src/Security/CWE-275/MissingActionsPermissions.ql
@@ -1,6 +1,6 @@
 /**
  * @name Workflow does not contain permissions
- * @description Workflows should contain permissions to provide a clear understanding has permissions to run the workflow.
+ * @description Workflows should contain explicit permissions to restrict the scope of the default GITHUB_TOKEN.
  * @kind problem
  * @security-severity 5.0
  * @problem.severity warning

--- a/actions/ql/src/Security/CWE-312/ExcessiveSecretsExposure.ql
+++ b/actions/ql/src/Security/CWE-312/ExcessiveSecretsExposure.ql
@@ -3,6 +3,7 @@
  * @description All organization and repository secrets are passed to the workflow runner.
  * @kind problem
  * @precision high
+ * @security-severity 5.0
  * @problem.severity warning
  * @id actions/excessive-secrets-exposure
  * @tags actions

--- a/actions/ql/src/Security/CWE-312/UnmaskedSecretExposure.md
+++ b/actions/ql/src/Security/CWE-312/UnmaskedSecretExposure.md
@@ -2,11 +2,11 @@
 
 ## Description
 
-Secrets derived from other secrets are not know to the workflow runner and therefore not masked unless explicitly registered.
+Secrets derived from other secrets are not known to the workflow runner, and therefore are not masked unless explicitly registered.
 
 ## Recommendations
 
-Avoid defining non-plain secrets. For example, do not define a new secret containing a JSON object and then read properties out of it from the workflow since these read values will not be masked by the workflow runner.
+Avoid defining non-plain secrets. For example, do not define a new secret containing a JSON object and then read properties out of it from the workflow, since these read values will not be masked by the workflow runner.
 
 ## Examples
 

--- a/actions/ql/src/change-notes/2025-04-14-excessive-secrets-exposure-security-severity.md
+++ b/actions/ql/src/change-notes/2025-04-14-excessive-secrets-exposure-security-severity.md
@@ -1,0 +1,5 @@
+---
+category: fix
+---
+* Assigned a `security-severity` to the query `actions
+  excessive-secrets-exposure`.

--- a/actions/ql/src/change-notes/2025-04-14-excessive-secrets-exposure-security-severity.md
+++ b/actions/ql/src/change-notes/2025-04-14-excessive-secrets-exposure-security-severity.md
@@ -1,5 +1,4 @@
 ---
 category: fix
 ---
-* Assigned a `security-severity` to the query `actions
-  excessive-secrets-exposure`.
+* Assigned a `security-severity` to the query `actions/excessive-secrets-exposure`.

--- a/docs/codeql/reusables/supported-versions-compilers.rst
+++ b/docs/codeql/reusables/supported-versions-compilers.rst
@@ -16,7 +16,7 @@
    .NET Core up to 3.1
 
    .NET 5, .NET 6, .NET 7, .NET 8, .NET 9","``.sln``, ``.csproj``, ``.cs``, ``.cshtml``, ``.xaml``"
-   GitHub Actions [12]_,"Not applicable",Not applicable,"``.github/workflows/*.yml``, ``.github/workflows/*.yaml``, ``**/action.yml``, ``**/action.yaml``"
+   GitHub Actions,"Not applicable",Not applicable,"``.github/workflows/*.yml``, ``.github/workflows/*.yaml``, ``**/action.yml``, ``**/action.yaml``"
    Go (aka Golang), "Go up to 1.24", "Go 1.11 or more recent", ``.go``
    Java,"Java 7 to 24 [5]_","javac (OpenJDK and Oracle JDK),
 
@@ -41,4 +41,3 @@
     .. [9] Requires glibc 2.17.
     .. [10] Support for the analysis of Swift requires macOS.
     .. [11] TypeScript analysis is performed by running the JavaScript extractor with TypeScript enabled. This is the default.
-    .. [12] Support for GitHub Actions is in public preview.


### PR DESCRIPTION
Remove the public preview notice for the next publish.
Various corrections to query help.
Add missing `security-severity` for the excessive secrets exposure query.