### PR TITLE
actions: Fix spelling error in UnmaskedSecretExposure.md

### DIFF
--- a/actions/ql/src/Security/CWE-312/UnmaskedSecretExposure.md
+++ b/actions/ql/src/Security/CWE-312/UnmaskedSecretExposure.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-Secrets derived from other secrets are not know to the workflow runner and therefore not masked unless explicitly registered.
+Secrets derived from other secrets are not known to the workflow runner and therefore not masked unless explicitly registered.
 
 ## Recommendations
 


### PR DESCRIPTION
Corrects "know" to "known" in the description of the UnmaskedSecretExposure document.