### PR TITLE
Python: Tweak LoopVariableCapture for performance

### DIFF
--- a/python/ql/src/Variables/LoopVariableCapture/LoopVariableCaptureQuery.qll
+++ b/python/ql/src/Variables/LoopVariableCapture/LoopVariableCaptureQuery.qll
@@ -59,7 +59,7 @@ module EscapingCaptureFlowConfig implements DataFlow::ConfigSig {
   predicate allowImplicitRead(DataFlow::Node node, DataFlow::ContentSet cs) {
     isSink(node) and
     (
-      cs instanceof DataFlow::TupleElementContent or
+      cs.(DataFlow::TupleElementContent).getIndex() in [0 .. 10] or
       cs instanceof DataFlow::ListElementContent or
       cs instanceof DataFlow::SetElementContent or
       cs instanceof DataFlow::DictionaryElementAnyContent


### PR DESCRIPTION
Limits the size of the `allowImplicitRead` predicate to improve performance on databases with a large number of `TupleElementContent`s. 