### PR TITLE
C#: Join order fix

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/ExternalFlow.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/ExternalFlow.qll
@@ -408,7 +408,8 @@ Declaration interpretBaseDeclaration(string namespace, string type, string name,
   )
 }
 
-pragma[inline]
+bindingset[d, ext]
+pragma[inline_late]
 private Declaration interpretExt(Declaration d, ExtPath ext) {
   ext = "" and result = d
   or


### PR DESCRIPTION
Fix join order in `ExternalFlow::interpretElement/6`, which was causing a huge slowdown in RTJO mode.