### PR TITLE
Swift: Make file checking in tests more strict

### DIFF
--- a/swift/ql/test/TestUtils.qll
+++ b/swift/ql/test/TestUtils.qll
@@ -6,7 +6,8 @@ import codeql.swift.elements.expr.internal.DotSyntaxCallExpr
 
 cached
 predicate toBeTested(Element e) {
-  e instanceof File
+  e instanceof File and
+  (exists(e.(File).getRelativePath()) or e instanceof UnknownFile)
   or
   e instanceof ParameterizedProtocolType
   or

--- a/swift/ql/test/library-tests/elements/decl/enumdecl/enumdecl.ql
+++ b/swift/ql/test/library-tests/elements/decl/enumdecl/enumdecl.ql
@@ -21,5 +21,5 @@ string describe(Decl d) {
 }
 
 from Decl d
-where d.getLocation().getFile().getName() != ""
+where exists(d.getLocation().getFile().getRelativePath())
 select d, strictconcat(describe(d), ", ")

--- a/swift/ql/test/library-tests/elements/decl/function/function.ql
+++ b/swift/ql/test/library-tests/elements/decl/function/function.ql
@@ -27,6 +27,6 @@ string describe(Function f) {
 
 from Function f
 where
-  not f.getFile() instanceof UnknownFile and
+  exists(f.getFile().getRelativePath()) and
   not f.getName().matches("%init%")
 select f, concat(describe(f), ", ")

--- a/swift/ql/test/library-tests/elements/type/nominaltype/nominaltype.ql
+++ b/swift/ql/test/library-tests/elements/type/nominaltype/nominaltype.ql
@@ -16,7 +16,7 @@ string describe(Type t) {
 
 from VarDecl v, Type t
 where
-  v.getLocation().getFile().getBaseName() != "" and
+  exists(v.getLocation().getFile().getRelativePath()) and
   not v.getName() = "self" and
   t = v.getType()
 select v, t.toString(), concat(describe(t), ", ")

--- a/swift/ql/test/library-tests/elements/type/nominaltype/nominaltypedecl.ql
+++ b/swift/ql/test/library-tests/elements/type/nominaltype/nominaltypedecl.ql
@@ -14,7 +14,7 @@ string describe(TypeDecl td) {
 
 from VarDecl v, TypeDecl td
 where
-  v.getLocation().getFile().getBaseName() != "" and
+  exists(v.getLocation().getFile().getRelativePath()) and
   not v.getName() = "self" and
   (
     td = v.getType().(NominalType).getDeclaration() or

--- a/swift/ql/test/library-tests/elements/type/numerictype/numerictype.ql
+++ b/swift/ql/test/library-tests/elements/type/numerictype/numerictype.ql
@@ -14,6 +14,6 @@ string describe(Type t) {
 
 from VarDecl v, Type t
 where
-  v.getLocation().getFile().getBaseName() != "" and
+  exists(v.getLocation().getFile().getRelativePath()) and
   t = v.getType()
 select v, t.toString(), concat(describe(t), ", ")

--- a/swift/ql/test/library-tests/elements/type/pointertypes/pointertypes.ql
+++ b/swift/ql/test/library-tests/elements/type/pointertypes/pointertypes.ql
@@ -22,6 +22,6 @@ string describe(Type t) {
 
 from VarDecl v, Type t
 where
-  v.getLocation().getFile().getBaseName() != "" and
+  exists(v.getLocation().getFile().getRelativePath()) and
   t = v.getType()
 select v, t.toString(), strictconcat(describe(t), ", ")

--- a/swift/ql/test/query-tests/Diagnostics/Info.ql
+++ b/swift/ql/test/query-tests/Diagnostics/Info.ql
@@ -3,4 +3,5 @@ import swift
 string describe(File f) { (f.isSuccessfullyExtracted() and result = "isSuccessfullyExtracted") }
 
 from File f
+where exists(f.getRelativePath()) or f instanceof UnknownFile
 select f, concat(f.getRelativePath(), ", "), concat(describe(f), ", ")


### PR DESCRIPTION
With Swift 6.1 the extractor will start to extract files outside of the test directory. These files and their elements we do not want to see in our tests.

Targeting `main` with this PR to ensure we do not break something by accident in the upgrade.