### PR TITLE
Swift: Make file checking in integration tests more strict

### DIFF
--- a/swift/ql/integration-tests/autobuilder/xcode-fails-spm-works/Files.ql
+++ b/swift/ql/integration-tests/autobuilder/xcode-fails-spm-works/Files.ql
@@ -1,4 +1,5 @@
 import swift
 
 from File f
+where exists(f.getRelativePath()) or f instanceof UnknownFile
 select f

--- a/swift/ql/integration-tests/osx/canonical-case/Files.ql
+++ b/swift/ql/integration-tests/osx/canonical-case/Files.ql
@@ -1,4 +1,5 @@
 import swift
 
 from File f
+where exists(f.getRelativePath()) or f instanceof UnknownFile
 select f

--- a/swift/ql/integration-tests/osx/hello-ios/Files.ql
+++ b/swift/ql/integration-tests/osx/hello-ios/Files.ql
@@ -1,4 +1,5 @@
 import swift
 
 from File f
+where exists(f.getRelativePath()) or f instanceof UnknownFile
 select f

--- a/swift/ql/integration-tests/osx/hello-xcode/Files.ql
+++ b/swift/ql/integration-tests/osx/hello-xcode/Files.ql
@@ -1,4 +1,5 @@
 import swift
 
 from File f
+where exists(f.getRelativePath()) or f instanceof UnknownFile
 select f

--- a/swift/ql/integration-tests/posix/cross-references/Classes.ql
+++ b/swift/ql/integration-tests/posix/cross-references/Classes.ql
@@ -1,5 +1,7 @@
 import swift
 
 from ClassDecl d
-where d.getLocation().getFile().getBaseName() != "Package.swift"
+where
+  d.getLocation().getFile().getBaseName() != "Package.swift" and
+  exists(d.getLocation().getFile().getRelativePath())
 select d

--- a/swift/ql/integration-tests/posix/cross-references/Deinitializers.ql
+++ b/swift/ql/integration-tests/posix/cross-references/Deinitializers.ql
@@ -1,5 +1,7 @@
 import swift
 
 from Deinitializer d
-where d.getLocation().getFile().getBaseName() != "Package.swift"
+where
+  d.getLocation().getFile().getBaseName() != "Package.swift" and
+  exists(d.getLocation().getFile().getRelativePath())
 select d

--- a/swift/ql/integration-tests/posix/cross-references/Enums.ql
+++ b/swift/ql/integration-tests/posix/cross-references/Enums.ql
@@ -1,5 +1,7 @@
 import swift
 
 from EnumDecl d
-where d.getLocation().getFile().getBaseName() != "Package.swift"
+where
+  d.getLocation().getFile().getBaseName() != "Package.swift" and
+  exists(d.getLocation().getFile().getRelativePath())
 select d

--- a/swift/ql/integration-tests/posix/cross-references/Functions.ql
+++ b/swift/ql/integration-tests/posix/cross-references/Functions.ql
@@ -1,5 +1,7 @@
 import codeql.swift.elements.decl.internal.AccessorOrNamedFunction
 
 from AccessorOrNamedFunction f
-where f.getLocation().getFile().getBaseName() != "Package.swift"
+where
+  f.getLocation().getFile().getBaseName() != "Package.swift" and
+  exists(f.getLocation().getFile().getRelativePath())
 select f

--- a/swift/ql/integration-tests/posix/cross-references/Initializers.ql
+++ b/swift/ql/integration-tests/posix/cross-references/Initializers.ql
@@ -1,5 +1,7 @@
 import swift
 
 from Initializer d
-where d.getLocation().getFile().getBaseName() != "Package.swift"
+where
+  d.getLocation().getFile().getBaseName() != "Package.swift" and
+  exists(d.getLocation().getFile().getRelativePath())
 select d

--- a/swift/ql/integration-tests/posix/cross-references/Protocols.ql
+++ b/swift/ql/integration-tests/posix/cross-references/Protocols.ql
@@ -1,5 +1,7 @@
 import swift
 
 from ProtocolDecl d
-where d.getLocation().getFile().getBaseName() != "Package.swift"
+where
+  d.getLocation().getFile().getBaseName() != "Package.swift" and
+  exists(d.getLocation().getFile().getRelativePath())
 select d

--- a/swift/ql/integration-tests/posix/cross-references/Structs.ql
+++ b/swift/ql/integration-tests/posix/cross-references/Structs.ql
@@ -1,5 +1,7 @@
 import swift
 
 from StructDecl d
-where d.getLocation().getFile().getBaseName() != "Package.swift"
+where
+  d.getLocation().getFile().getBaseName() != "Package.swift" and
+  exists(d.getLocation().getFile().getRelativePath())
 select d

--- a/swift/ql/integration-tests/posix/cross-references/VarDecls.ql
+++ b/swift/ql/integration-tests/posix/cross-references/VarDecls.ql
@@ -1,5 +1,7 @@
 import swift
 
 from VarDecl d
-where d.getLocation().getFile().getBaseName() != "Package.swift"
+where
+  d.getLocation().getFile().getBaseName() != "Package.swift" and
+  exists(d.getLocation().getFile().getRelativePath())
 select d

--- a/swift/ql/integration-tests/posix/frontend-invocations/Files.ql
+++ b/swift/ql/integration-tests/posix/frontend-invocations/Files.ql
@@ -1,4 +1,5 @@
 import swift
 
 from File f
+where exists(f.getRelativePath()) or f instanceof UnknownFile
 select f

--- a/swift/ql/integration-tests/posix/hello-world/test.ql
+++ b/swift/ql/integration-tests/posix/hello-world/test.ql
@@ -1,4 +1,5 @@
 import swift
 
 from File f
+where exists(f.getRelativePath()) or f instanceof UnknownFile
 select f

--- a/swift/ql/integration-tests/posix/symlinks/Files.ql
+++ b/swift/ql/integration-tests/posix/symlinks/Files.ql
@@ -1,4 +1,5 @@
 import swift
 
 from File f
+where exists(f.getRelativePath()) or f instanceof UnknownFile
 select f


### PR DESCRIPTION
With Swift 6.1 the extractor will start to extract files outside of the test directory. These files and their elements we do not want to see in our tests.

Targeting `main` with this PR to ensure we do not break something by accident in the upgrade.

Integration test counterpart to https://github.com/github/codeql/pull/19344