### PR TITLE
Swift: Make file checking in tests more strict

### DIFF
--- a/swift/ql/test/library-tests/elements/location/location.ql
+++ b/swift/ql/test/library-tests/elements/location/location.ql
@@ -1,4 +1,5 @@
 import swift
 
 from Location l
+where exists(l.getFile().getRelativePath()) or l instanceof UnknownLocation
 select l


### PR DESCRIPTION
With Swift 6.1 the extractor will start to extract files outside of the test directory. These files and their elements we do not want to see in our tests.

Test forgotten in https://github.com/github/codeql/pull/19344