### PR TITLE
Rust: Remove unnecessary predicate.

### DIFF
--- a/rust/ql/test/library-tests/dataflow/local/DataFlowStep.ql
+++ b/rust/ql/test/library-tests/dataflow/local/DataFlowStep.ql
@@ -2,10 +2,6 @@ import codeql.rust.dataflow.DataFlow
 import codeql.rust.dataflow.internal.DataFlowImpl
 import utils.test.TranslateModels
 
-private predicate provenance(string model) { RustDataFlow::simpleLocalFlowStep(_, _, model) }
-
-private module Tm = TranslateModels<provenance/1>;
-
 query predicate localStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
   // Local flow steps that don't originate from a flow summary.
   RustDataFlow::simpleLocalFlowStep(nodeFrom, nodeTo, "")


### PR DESCRIPTION
Should've ben done in https://github.com/github/codeql/pull/19305/files .