### PR TITLE
Change definition of `getFactoryNodeInternal`

### DIFF
--- a/javascript/ql/lib/semmle/javascript/AMD.qll
+++ b/javascript/ql/lib/semmle/javascript/AMD.qll
@@ -91,7 +91,7 @@ class AmdModuleDefinition extends CallExpr instanceof AmdModuleDefinition::Range
   Function getFactoryFunction() { TValueNode(result) = this.getFactoryNodeInternal() }
 
   private EarlyStageNode getFactoryNodeInternal() {
-    result = TValueNode(this.getLastArgument())
+    result = TValueNode(this.getArgument(1))
     or
     DataFlow::localFlowStep(result, this.getFactoryNodeInternal())
   }

--- a/javascript/ql/lib/semmle/javascript/AMD.qll
+++ b/javascript/ql/lib/semmle/javascript/AMD.qll
@@ -91,7 +91,9 @@ class AmdModuleDefinition extends CallExpr instanceof AmdModuleDefinition::Range
   Function getFactoryFunction() { TValueNode(result) = this.getFactoryNodeInternal() }
 
   private EarlyStageNode getFactoryNodeInternal() {
-    result = TValueNode(this.getArgument(1))
+    exists(Function factoryFunction | factoryFunction = this.getArgument(_) |
+      result = TValueNode(factoryFunction)
+    )
     or
     DataFlow::localFlowStep(result, this.getFactoryNodeInternal())
   }


### PR DESCRIPTION
## What this PR Contributes

Some variants of AMD module such as [sap.ui.define])(https://sdk.openui5.org/api/sap.ui#methods/sap.ui.define) can accept an additional parameter, making it the last parameter in some cases. Therefore, dynamically determine the index of the factory method parameter.