### PR TITLE
Dataflow: Make default field flow branch limit configurable per language

### DIFF
--- a/shared/dataflow/codeql/dataflow/DataFlow.qll
+++ b/shared/dataflow/codeql/dataflow/DataFlow.qll
@@ -342,6 +342,9 @@ signature module InputSig<LocationSig Location> {
     any()
   }
 
+  /** Gets the default value for the `fieldFlowBranchLimit` */
+  default int defaultFieldFlowBranchLimit() { result = 2 }
+
   /** Holds if `fieldFlowBranchLimit` should be ignored for flow going into/out of `c`. */
   default predicate ignoreFieldFlowBranchLimit(DataFlowCallable c) { none() }
 }
@@ -399,7 +402,7 @@ module Configs<LocationSig Location, InputSig<Location> Lang> {
      * This can be overridden to a smaller value to improve performance (a
      * value of 0 disables field flow), or a larger value to get more results.
      */
-    default int fieldFlowBranchLimit() { result = 2 }
+    default int fieldFlowBranchLimit() { result = Lang::defaultFieldFlowBranchLimit() }
 
     /** Gets the access path limit. */
     default int accessPathLimit() { result = Lang::accessPathLimit() }
@@ -548,7 +551,7 @@ module Configs<LocationSig Location, InputSig<Location> Lang> {
      * This can be overridden to a smaller value to improve performance (a
      * value of 0 disables field flow), or a larger value to get more results.
      */
-    default int fieldFlowBranchLimit() { result = 2 }
+    default int fieldFlowBranchLimit() { result = Lang::defaultFieldFlowBranchLimit() }
 
     /** Gets the access path limit. */
     default int accessPathLimit() { result = Lang::accessPathLimit() }


### PR DESCRIPTION
The context for this is that we might want to raise it to 3 for C++ in combination with some other changes.