### PR TITLE
Update list of supported platforms

### DIFF
--- a/docs/codeql/reusables/supported-platforms.rst
+++ b/docs/codeql/reusables/supported-platforms.rst
@@ -4,17 +4,17 @@
    :stub-columns: 1
 
    Operating system,Supported versions,Supported CPU architectures
-   Linux,"Ubuntu 20.04
+   Linux,"Ubuntu 22.04
 
-   Ubuntu 21.04
-
-   Ubuntu 22.04","x86-64"
+   Ubuntu 24.04","x86-64"
    Windows,"Windows 10 / Windows Server 2019
 
    Windows 11 / Windows Server 2022","x86-64"
    macOS,"macOS 13 Ventura
 
-   macOS 14 Sonoma","x86-64, arm64 (Apple Silicon) [1]_"
+   macOS 14 Sonoma
+
+   macOS 15 Sequoia","x86-64, arm64 (Apple Silicon) [1]_"
 
 .. container:: footnote-group
 


### PR DESCRIPTION
I've effectively sync'ed this with the list of runners that are publicly available. I did not yet add Windows 2025, as it is my understanding is that we haven't really done any testing on that yet.