### PR TITLE
C++: Add exception for build-mode-none in various queries

### DIFF
--- a/cpp/ql/src/Likely Bugs/Arithmetic/IntMultToLong.ql
+++ b/cpp/ql/src/Likely Bugs/Arithmetic/IntMultToLong.ql
@@ -179,6 +179,7 @@ predicate overflows(MulExpr me, Type t) {
 
 from MulExpr me, Type t1, Type t2
 where
+  not any(Compilation c).buildModeNone() and
   t1 = me.getType().getUnderlyingType() and
   t2 = me.getConversion().getType().getUnderlyingType() and
   t1.getSize() < t2.getSize() and

--- a/cpp/ql/src/Likely Bugs/Format/WrongTypeFormatArguments.ql
+++ b/cpp/ql/src/Likely Bugs/Format/WrongTypeFormatArguments.ql
@@ -154,6 +154,7 @@ int sizeof_IntType() { exists(IntType it | result = it.getSize()) }
 
 from FormattingFunctionCall ffc, int n, Expr arg, Type expected, Type actual
 where
+  not any(Compilation c).buildModeNone() and
   (
     formattingFunctionCallExpectedType(ffc, n, expected) and
     formattingFunctionCallActualType(ffc, n, arg, actual) and

--- a/cpp/ql/src/Likely Bugs/Underspecified Functions/ImplicitFunctionDeclaration.ql
+++ b/cpp/ql/src/Likely Bugs/Underspecified Functions/ImplicitFunctionDeclaration.ql
@@ -38,6 +38,7 @@ predicate isCompiledAsC(File f) {
 
 from FunctionDeclarationEntry fdeIm, FunctionCall fc
 where
+  not any(Compilation c).buildModeNone() and
   isCompiledAsC(fdeIm.getFile()) and
   not isFromMacroDefinition(fc) and
   fdeIm.isImplicit() and

--- a/cpp/ql/src/Security/CWE/CWE-190/ComparisonWithWiderType.ql
+++ b/cpp/ql/src/Security/CWE/CWE-190/ComparisonWithWiderType.ql
@@ -51,6 +51,7 @@ int getComparisonSizeAdjustment(Expr e) {
 
 from Loop l, RelationalOperation rel, VariableAccess small, Expr large
 where
+  not any(Compilation c).buildModeNone() and
   small = rel.getLesserOperand() and
   large = rel.getGreaterOperand() and
   rel = l.getCondition().getAChild*() and

--- a/cpp/ql/src/Security/CWE/CWE-468/SuspiciousAddWithSizeof.ql
+++ b/cpp/ql/src/Security/CWE/CWE-468/SuspiciousAddWithSizeof.ql
@@ -24,6 +24,7 @@ private predicate isCharSzPtrExpr(Expr e) {
 
 from Expr sizeofExpr, Expr e
 where
+  not any(Compilation c).buildModeNone() and
   // If we see an addWithSizeof then we expect the type of
   // the pointer expression to be `char*` or `void*`. Otherwise it
   // is probably a mistake.

--- a/cpp/ql/src/Security/CWE/CWE-468/SuspiciousAddWithSizeof.ql
+++ b/cpp/ql/src/Security/CWE/CWE-468/SuspiciousAddWithSizeof.ql
@@ -28,7 +28,8 @@ where
   // If we see an addWithSizeof then we expect the type of
   // the pointer expression to be `char*` or `void*`. Otherwise it
   // is probably a mistake.
-  addWithSizeof(e, sizeofExpr, _) and not isCharSzPtrExpr(e)
+  addWithSizeof(e, sizeofExpr, _) and
+  not isCharSzPtrExpr(e)
 select sizeofExpr,
   "Suspicious sizeof offset in a pointer arithmetic expression. The type of the pointer is $@.",
   e.getFullyConverted().getType() as t, t.toString()


### PR DESCRIPTION
This PR introduces checks for the absence of build-mode-none in
* cpp/wrong-type-format-argument
* cpp/comparison-with-wider-type
* cpp/integer-multiplication-cast-to-long
* cpp/implicit-function-declaration
* cpp/suspicious-add-sizeof
