### PR TITLE
Actions: Exclude model-generator queries from query suites

### DIFF
--- a/misc/suite-helpers/security-and-quality-selectors.yml
+++ b/misc/suite-helpers/security-and-quality-selectors.yml
@@ -33,3 +33,4 @@
     tags contain:
       - modeleditor
       - modelgenerator
+      - 'model-generator'


### PR DESCRIPTION
This change removes the model generator queries for Actions sources/sinks/summaries from being run as part of the `actions-security-and-quality.qls` query suite, where they were accidentally included.

All languages will now exclude both `modelgenerator` and `model-generator` tagged queries from their suites.