### PR TITLE
Python: disable diff-informed PolynomialReDoS.ql

### DIFF
--- a/python/ql/lib/semmle/python/security/dataflow/PolynomialReDoSQuery.qll
+++ b/python/ql/lib/semmle/python/security/dataflow/PolynomialReDoSQuery.qll
@@ -18,7 +18,17 @@ private module PolynomialReDoSConfig implements DataFlow::ConfigSig {
 
   predicate isBarrier(DataFlow::Node node) { node instanceof Sanitizer }
 
-  predicate observeDiffInformedIncrementalMode() { any() }
+  // Diff-informed incremental mode is currently disabled for this query due to
+  // API limitations. The query exposes sink.getABacktrackingTerm() as an alert
+  // location, but there is no way to express that information through
+  // getASelectedSinkLocation() because there is no @location in the CodeQL
+  // database that corresponds to a term inside a regular expression. As a
+  // result, this query could miss alerts in diff-informed incremental mode.
+  //
+  // To address this problem, we need to have a version of
+  // getASelectedSinkLocation() that uses hasLocationInfo() instead of
+  // returning Location objects.
+  predicate observeDiffInformedIncrementalMode() { none() }
 
   Location getASelectedSinkLocation(DataFlow::Node sink) {
     result = sink.(Sink).getHighlight().getLocation()


### PR DESCRIPTION
This commit disabled diff-informed for PolynomialReDoS.ql because it could miss some alerts within diff ranges.