### PR TITLE
C#: Fix CFG for fall-through switch statements

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/Stmt.qll
+++ b/csharp/ql/lib/semmle/code/csharp/Stmt.qll
@@ -278,9 +278,14 @@ class CaseStmt extends Case, @case_stmt {
   override PatternExpr getPattern() { result = this.getChild(0) }
 
   override Stmt getBody() {
-    exists(int i |
+    exists(int i, Stmt next |
       this = this.getParent().getChild(i) and
-      result = this.getParent().getChild(i + 1)
+      next = this.getParent().getChild(i + 1)
+    |
+      result = next and
+      not result instanceof CaseStmt
+      or
+      result = next.(CaseStmt).getBody()
     )
   }
 

--- a/csharp/ql/lib/semmle/code/csharp/controlflow/internal/ControlFlowGraphImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/controlflow/internal/ControlFlowGraphImpl.qll
@@ -1153,7 +1153,13 @@ module Statements {
       )
       or
       // Flow from last element of `case` statement `i` to first element of statement `i+1`
-      exists(int i | last(super.getStmt(i).(CaseStmt).getBody(), pred, c) |
+      exists(int i, Stmt body |
+        body = super.getStmt(i).(CaseStmt).getBody() and
+        // in case of fall-through cases, make sure to not jump from their shared body back
+        // to one of the fall-through cases
+        not body = super.getStmt(i + 1).(CaseStmt).getBody() and
+        last(body, pred, c)
+      |
         c instanceof NormalCompletion and
         first(super.getStmt(i + 1), succ)
       )

--- a/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
@@ -1078,6 +1078,14 @@
 | Switch.cs:156:50:156:52 | "b" | Switch.cs:156:41:156:52 | ... => ... | 2 |
 | Switch.cs:158:13:158:49 | ...; | Switch.cs:158:13:158:48 | call to method WriteLine | 6 |
 | Switch.cs:160:13:160:49 | ...; | Switch.cs:160:13:160:48 | call to method WriteLine | 6 |
+| Switch.cs:163:10:163:12 | enter M16 | Switch.cs:167:18:167:18 | 1 | 6 |
+| Switch.cs:163:10:163:12 | exit M16 (normal) | Switch.cs:163:10:163:12 | exit M16 | 2 |
+| Switch.cs:168:13:168:19 | case ...: | Switch.cs:168:18:168:18 | 2 | 2 |
+| Switch.cs:169:17:169:51 | ...; | Switch.cs:169:17:169:50 | call to method WriteLine | 3 |
+| Switch.cs:170:17:170:22 | break; | Switch.cs:170:17:170:22 | break; | 1 |
+| Switch.cs:171:13:171:19 | case ...: | Switch.cs:171:18:171:18 | 3 | 2 |
+| Switch.cs:172:17:172:46 | ...; | Switch.cs:173:17:173:22 | break; | 4 |
+| Switch.cs:174:13:174:20 | default: | Switch.cs:176:17:176:22 | break; | 5 |
 | TypeAccesses.cs:1:7:1:18 | enter TypeAccesses | TypeAccesses.cs:1:7:1:18 | exit TypeAccesses | 5 |
 | TypeAccesses.cs:3:10:3:10 | enter M | TypeAccesses.cs:7:18:7:22 | Int32 j | 13 |
 | TypeAccesses.cs:7:13:7:22 | [false] ... is ... | TypeAccesses.cs:7:13:7:22 | [false] ... is ... | 1 |

--- a/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
@@ -1081,8 +1081,7 @@
 | Switch.cs:163:10:163:12 | enter M16 | Switch.cs:167:18:167:18 | 1 | 6 |
 | Switch.cs:163:10:163:12 | exit M16 (normal) | Switch.cs:163:10:163:12 | exit M16 | 2 |
 | Switch.cs:168:13:168:19 | case ...: | Switch.cs:168:18:168:18 | 2 | 2 |
-| Switch.cs:169:17:169:51 | ...; | Switch.cs:169:17:169:50 | call to method WriteLine | 3 |
-| Switch.cs:170:17:170:22 | break; | Switch.cs:170:17:170:22 | break; | 1 |
+| Switch.cs:169:17:169:51 | ...; | Switch.cs:170:17:170:22 | break; | 4 |
 | Switch.cs:171:13:171:19 | case ...: | Switch.cs:171:18:171:18 | 3 | 2 |
 | Switch.cs:172:17:172:46 | ...; | Switch.cs:173:17:173:22 | break; | 4 |
 | Switch.cs:174:13:174:20 | default: | Switch.cs:176:17:176:22 | break; | 5 |

--- a/csharp/ql/test/library-tests/controlflow/graph/Condition.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Condition.expected
@@ -2140,21 +2140,10 @@ conditionBlock
 | Switch.cs:156:17:156:54 | ... switch { ... } | Switch.cs:158:13:158:49 | ...; | true |
 | Switch.cs:156:17:156:54 | ... switch { ... } | Switch.cs:160:13:160:49 | ...; | false |
 | Switch.cs:156:41:156:45 | false | Switch.cs:156:50:156:52 | "b" | true |
-| Switch.cs:163:10:163:12 | enter M16 | Switch.cs:163:10:163:12 | exit M16 (normal) | false |
-| Switch.cs:163:10:163:12 | enter M16 | Switch.cs:163:10:163:12 | exit M16 (normal) | true |
 | Switch.cs:163:10:163:12 | enter M16 | Switch.cs:168:13:168:19 | case ...: | false |
-| Switch.cs:163:10:163:12 | enter M16 | Switch.cs:168:13:168:19 | case ...: | true |
-| Switch.cs:163:10:163:12 | enter M16 | Switch.cs:169:17:169:51 | ...; | false |
-| Switch.cs:163:10:163:12 | enter M16 | Switch.cs:169:17:169:51 | ...; | true |
-| Switch.cs:163:10:163:12 | enter M16 | Switch.cs:170:17:170:22 | break; | false |
-| Switch.cs:163:10:163:12 | enter M16 | Switch.cs:170:17:170:22 | break; | true |
 | Switch.cs:163:10:163:12 | enter M16 | Switch.cs:171:13:171:19 | case ...: | false |
-| Switch.cs:163:10:163:12 | enter M16 | Switch.cs:171:13:171:19 | case ...: | true |
 | Switch.cs:163:10:163:12 | enter M16 | Switch.cs:172:17:172:46 | ...; | false |
-| Switch.cs:163:10:163:12 | enter M16 | Switch.cs:172:17:172:46 | ...; | true |
 | Switch.cs:163:10:163:12 | enter M16 | Switch.cs:174:13:174:20 | default: | false |
-| Switch.cs:163:10:163:12 | enter M16 | Switch.cs:174:13:174:20 | default: | true |
-| Switch.cs:168:13:168:19 | case ...: | Switch.cs:169:17:169:51 | ...; | true |
 | Switch.cs:168:13:168:19 | case ...: | Switch.cs:171:13:171:19 | case ...: | false |
 | Switch.cs:168:13:168:19 | case ...: | Switch.cs:172:17:172:46 | ...; | false |
 | Switch.cs:168:13:168:19 | case ...: | Switch.cs:174:13:174:20 | default: | false |

--- a/csharp/ql/test/library-tests/controlflow/graph/Condition.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Condition.expected
@@ -2140,6 +2140,26 @@ conditionBlock
 | Switch.cs:156:17:156:54 | ... switch { ... } | Switch.cs:158:13:158:49 | ...; | true |
 | Switch.cs:156:17:156:54 | ... switch { ... } | Switch.cs:160:13:160:49 | ...; | false |
 | Switch.cs:156:41:156:45 | false | Switch.cs:156:50:156:52 | "b" | true |
+| Switch.cs:163:10:163:12 | enter M16 | Switch.cs:163:10:163:12 | exit M16 (normal) | false |
+| Switch.cs:163:10:163:12 | enter M16 | Switch.cs:163:10:163:12 | exit M16 (normal) | true |
+| Switch.cs:163:10:163:12 | enter M16 | Switch.cs:168:13:168:19 | case ...: | false |
+| Switch.cs:163:10:163:12 | enter M16 | Switch.cs:168:13:168:19 | case ...: | true |
+| Switch.cs:163:10:163:12 | enter M16 | Switch.cs:169:17:169:51 | ...; | false |
+| Switch.cs:163:10:163:12 | enter M16 | Switch.cs:169:17:169:51 | ...; | true |
+| Switch.cs:163:10:163:12 | enter M16 | Switch.cs:170:17:170:22 | break; | false |
+| Switch.cs:163:10:163:12 | enter M16 | Switch.cs:170:17:170:22 | break; | true |
+| Switch.cs:163:10:163:12 | enter M16 | Switch.cs:171:13:171:19 | case ...: | false |
+| Switch.cs:163:10:163:12 | enter M16 | Switch.cs:171:13:171:19 | case ...: | true |
+| Switch.cs:163:10:163:12 | enter M16 | Switch.cs:172:17:172:46 | ...; | false |
+| Switch.cs:163:10:163:12 | enter M16 | Switch.cs:172:17:172:46 | ...; | true |
+| Switch.cs:163:10:163:12 | enter M16 | Switch.cs:174:13:174:20 | default: | false |
+| Switch.cs:163:10:163:12 | enter M16 | Switch.cs:174:13:174:20 | default: | true |
+| Switch.cs:168:13:168:19 | case ...: | Switch.cs:169:17:169:51 | ...; | true |
+| Switch.cs:168:13:168:19 | case ...: | Switch.cs:171:13:171:19 | case ...: | false |
+| Switch.cs:168:13:168:19 | case ...: | Switch.cs:172:17:172:46 | ...; | false |
+| Switch.cs:168:13:168:19 | case ...: | Switch.cs:174:13:174:20 | default: | false |
+| Switch.cs:171:13:171:19 | case ...: | Switch.cs:172:17:172:46 | ...; | true |
+| Switch.cs:171:13:171:19 | case ...: | Switch.cs:174:13:174:20 | default: | false |
 | TypeAccesses.cs:3:10:3:10 | enter M | TypeAccesses.cs:7:13:7:22 | [false] ... is ... | false |
 | TypeAccesses.cs:3:10:3:10 | enter M | TypeAccesses.cs:7:13:7:22 | [true] ... is ... | true |
 | TypeAccesses.cs:3:10:3:10 | enter M | TypeAccesses.cs:7:25:7:25 | ; | true |

--- a/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
@@ -3678,6 +3678,29 @@ dominance
 | Switch.cs:160:40:160:43 | "b = " | Switch.cs:160:45:160:45 | access to local variable s |
 | Switch.cs:160:44:160:46 | {...} | Switch.cs:160:38:160:47 | $"..." |
 | Switch.cs:160:45:160:45 | access to local variable s | Switch.cs:160:44:160:46 | {...} |
+| Switch.cs:163:10:163:12 | enter M16 | Switch.cs:164:5:178:5 | {...} |
+| Switch.cs:163:10:163:12 | exit M16 (normal) | Switch.cs:163:10:163:12 | exit M16 |
+| Switch.cs:164:5:178:5 | {...} | Switch.cs:165:9:177:9 | switch (...) {...} |
+| Switch.cs:165:9:177:9 | switch (...) {...} | Switch.cs:165:17:165:17 | access to parameter i |
+| Switch.cs:165:17:165:17 | access to parameter i | Switch.cs:167:13:167:19 | case ...: |
+| Switch.cs:167:13:167:19 | case ...: | Switch.cs:167:18:167:18 | 1 |
+| Switch.cs:167:18:167:18 | 1 | Switch.cs:168:13:168:19 | case ...: |
+| Switch.cs:168:13:168:19 | case ...: | Switch.cs:168:18:168:18 | 2 |
+| Switch.cs:168:18:168:18 | 2 | Switch.cs:169:17:169:51 | ...; |
+| Switch.cs:168:18:168:18 | 2 | Switch.cs:170:17:170:22 | break; |
+| Switch.cs:168:18:168:18 | 2 | Switch.cs:171:13:171:19 | case ...: |
+| Switch.cs:169:17:169:51 | ...; | Switch.cs:169:42:169:49 | "1 or 2" |
+| Switch.cs:169:42:169:49 | "1 or 2" | Switch.cs:169:17:169:50 | call to method WriteLine |
+| Switch.cs:171:13:171:19 | case ...: | Switch.cs:171:18:171:18 | 3 |
+| Switch.cs:171:18:171:18 | 3 | Switch.cs:172:17:172:46 | ...; |
+| Switch.cs:171:18:171:18 | 3 | Switch.cs:174:13:174:20 | default: |
+| Switch.cs:172:17:172:45 | call to method WriteLine | Switch.cs:173:17:173:22 | break; |
+| Switch.cs:172:17:172:46 | ...; | Switch.cs:172:42:172:44 | "3" |
+| Switch.cs:172:42:172:44 | "3" | Switch.cs:172:17:172:45 | call to method WriteLine |
+| Switch.cs:174:13:174:20 | default: | Switch.cs:175:17:175:48 | ...; |
+| Switch.cs:175:17:175:47 | call to method WriteLine | Switch.cs:176:17:176:22 | break; |
+| Switch.cs:175:17:175:48 | ...; | Switch.cs:175:42:175:46 | "def" |
+| Switch.cs:175:42:175:46 | "def" | Switch.cs:175:17:175:47 | call to method WriteLine |
 | TypeAccesses.cs:1:7:1:18 | call to constructor Object | TypeAccesses.cs:1:7:1:18 | {...} |
 | TypeAccesses.cs:1:7:1:18 | enter TypeAccesses | TypeAccesses.cs:1:7:1:18 | call to constructor Object |
 | TypeAccesses.cs:1:7:1:18 | exit TypeAccesses (normal) | TypeAccesses.cs:1:7:1:18 | exit TypeAccesses |
@@ -7854,6 +7877,28 @@ postDominance
 | Switch.cs:160:40:160:43 | "b = " | Switch.cs:160:13:160:49 | ...; |
 | Switch.cs:160:44:160:46 | {...} | Switch.cs:160:45:160:45 | access to local variable s |
 | Switch.cs:160:45:160:45 | access to local variable s | Switch.cs:160:40:160:43 | "b = " |
+| Switch.cs:163:10:163:12 | exit M16 | Switch.cs:163:10:163:12 | exit M16 (normal) |
+| Switch.cs:163:10:163:12 | exit M16 (normal) | Switch.cs:170:17:170:22 | break; |
+| Switch.cs:163:10:163:12 | exit M16 (normal) | Switch.cs:173:17:173:22 | break; |
+| Switch.cs:163:10:163:12 | exit M16 (normal) | Switch.cs:176:17:176:22 | break; |
+| Switch.cs:164:5:178:5 | {...} | Switch.cs:163:10:163:12 | enter M16 |
+| Switch.cs:165:9:177:9 | switch (...) {...} | Switch.cs:164:5:178:5 | {...} |
+| Switch.cs:165:17:165:17 | access to parameter i | Switch.cs:165:9:177:9 | switch (...) {...} |
+| Switch.cs:167:13:167:19 | case ...: | Switch.cs:165:17:165:17 | access to parameter i |
+| Switch.cs:167:18:167:18 | 1 | Switch.cs:167:13:167:19 | case ...: |
+| Switch.cs:168:13:168:19 | case ...: | Switch.cs:167:18:167:18 | 1 |
+| Switch.cs:168:18:168:18 | 2 | Switch.cs:168:13:168:19 | case ...: |
+| Switch.cs:169:17:169:50 | call to method WriteLine | Switch.cs:169:42:169:49 | "1 or 2" |
+| Switch.cs:169:42:169:49 | "1 or 2" | Switch.cs:169:17:169:51 | ...; |
+| Switch.cs:170:17:170:22 | break; | Switch.cs:169:17:169:50 | call to method WriteLine |
+| Switch.cs:171:18:171:18 | 3 | Switch.cs:171:13:171:19 | case ...: |
+| Switch.cs:172:17:172:45 | call to method WriteLine | Switch.cs:172:42:172:44 | "3" |
+| Switch.cs:172:42:172:44 | "3" | Switch.cs:172:17:172:46 | ...; |
+| Switch.cs:173:17:173:22 | break; | Switch.cs:172:17:172:45 | call to method WriteLine |
+| Switch.cs:175:17:175:47 | call to method WriteLine | Switch.cs:175:42:175:46 | "def" |
+| Switch.cs:175:17:175:48 | ...; | Switch.cs:174:13:174:20 | default: |
+| Switch.cs:175:42:175:46 | "def" | Switch.cs:175:17:175:48 | ...; |
+| Switch.cs:176:17:176:22 | break; | Switch.cs:175:17:175:47 | call to method WriteLine |
 | TypeAccesses.cs:1:7:1:18 | call to constructor Object | TypeAccesses.cs:1:7:1:18 | enter TypeAccesses |
 | TypeAccesses.cs:1:7:1:18 | exit TypeAccesses | TypeAccesses.cs:1:7:1:18 | exit TypeAccesses (normal) |
 | TypeAccesses.cs:1:7:1:18 | exit TypeAccesses (normal) | TypeAccesses.cs:1:7:1:18 | {...} |
@@ -12467,6 +12512,29 @@ blockDominance
 | Switch.cs:156:50:156:52 | "b" | Switch.cs:156:50:156:52 | "b" |
 | Switch.cs:158:13:158:49 | ...; | Switch.cs:158:13:158:49 | ...; |
 | Switch.cs:160:13:160:49 | ...; | Switch.cs:160:13:160:49 | ...; |
+| Switch.cs:163:10:163:12 | enter M16 | Switch.cs:163:10:163:12 | enter M16 |
+| Switch.cs:163:10:163:12 | enter M16 | Switch.cs:163:10:163:12 | exit M16 (normal) |
+| Switch.cs:163:10:163:12 | enter M16 | Switch.cs:168:13:168:19 | case ...: |
+| Switch.cs:163:10:163:12 | enter M16 | Switch.cs:169:17:169:51 | ...; |
+| Switch.cs:163:10:163:12 | enter M16 | Switch.cs:170:17:170:22 | break; |
+| Switch.cs:163:10:163:12 | enter M16 | Switch.cs:171:13:171:19 | case ...: |
+| Switch.cs:163:10:163:12 | enter M16 | Switch.cs:172:17:172:46 | ...; |
+| Switch.cs:163:10:163:12 | enter M16 | Switch.cs:174:13:174:20 | default: |
+| Switch.cs:163:10:163:12 | exit M16 (normal) | Switch.cs:163:10:163:12 | exit M16 (normal) |
+| Switch.cs:168:13:168:19 | case ...: | Switch.cs:163:10:163:12 | exit M16 (normal) |
+| Switch.cs:168:13:168:19 | case ...: | Switch.cs:168:13:168:19 | case ...: |
+| Switch.cs:168:13:168:19 | case ...: | Switch.cs:169:17:169:51 | ...; |
+| Switch.cs:168:13:168:19 | case ...: | Switch.cs:170:17:170:22 | break; |
+| Switch.cs:168:13:168:19 | case ...: | Switch.cs:171:13:171:19 | case ...: |
+| Switch.cs:168:13:168:19 | case ...: | Switch.cs:172:17:172:46 | ...; |
+| Switch.cs:168:13:168:19 | case ...: | Switch.cs:174:13:174:20 | default: |
+| Switch.cs:169:17:169:51 | ...; | Switch.cs:169:17:169:51 | ...; |
+| Switch.cs:170:17:170:22 | break; | Switch.cs:170:17:170:22 | break; |
+| Switch.cs:171:13:171:19 | case ...: | Switch.cs:171:13:171:19 | case ...: |
+| Switch.cs:171:13:171:19 | case ...: | Switch.cs:172:17:172:46 | ...; |
+| Switch.cs:171:13:171:19 | case ...: | Switch.cs:174:13:174:20 | default: |
+| Switch.cs:172:17:172:46 | ...; | Switch.cs:172:17:172:46 | ...; |
+| Switch.cs:174:13:174:20 | default: | Switch.cs:174:13:174:20 | default: |
 | TypeAccesses.cs:1:7:1:18 | enter TypeAccesses | TypeAccesses.cs:1:7:1:18 | enter TypeAccesses |
 | TypeAccesses.cs:3:10:3:10 | enter M | TypeAccesses.cs:3:10:3:10 | enter M |
 | TypeAccesses.cs:3:10:3:10 | enter M | TypeAccesses.cs:7:13:7:22 | [false] ... is ... |
@@ -15794,6 +15862,23 @@ postBlockDominance
 | Switch.cs:156:50:156:52 | "b" | Switch.cs:156:50:156:52 | "b" |
 | Switch.cs:158:13:158:49 | ...; | Switch.cs:158:13:158:49 | ...; |
 | Switch.cs:160:13:160:49 | ...; | Switch.cs:160:13:160:49 | ...; |
+| Switch.cs:163:10:163:12 | enter M16 | Switch.cs:163:10:163:12 | enter M16 |
+| Switch.cs:163:10:163:12 | exit M16 (normal) | Switch.cs:163:10:163:12 | enter M16 |
+| Switch.cs:163:10:163:12 | exit M16 (normal) | Switch.cs:163:10:163:12 | exit M16 (normal) |
+| Switch.cs:163:10:163:12 | exit M16 (normal) | Switch.cs:168:13:168:19 | case ...: |
+| Switch.cs:163:10:163:12 | exit M16 (normal) | Switch.cs:169:17:169:51 | ...; |
+| Switch.cs:163:10:163:12 | exit M16 (normal) | Switch.cs:170:17:170:22 | break; |
+| Switch.cs:163:10:163:12 | exit M16 (normal) | Switch.cs:171:13:171:19 | case ...: |
+| Switch.cs:163:10:163:12 | exit M16 (normal) | Switch.cs:172:17:172:46 | ...; |
+| Switch.cs:163:10:163:12 | exit M16 (normal) | Switch.cs:174:13:174:20 | default: |
+| Switch.cs:168:13:168:19 | case ...: | Switch.cs:163:10:163:12 | enter M16 |
+| Switch.cs:168:13:168:19 | case ...: | Switch.cs:168:13:168:19 | case ...: |
+| Switch.cs:169:17:169:51 | ...; | Switch.cs:169:17:169:51 | ...; |
+| Switch.cs:170:17:170:22 | break; | Switch.cs:169:17:169:51 | ...; |
+| Switch.cs:170:17:170:22 | break; | Switch.cs:170:17:170:22 | break; |
+| Switch.cs:171:13:171:19 | case ...: | Switch.cs:171:13:171:19 | case ...: |
+| Switch.cs:172:17:172:46 | ...; | Switch.cs:172:17:172:46 | ...; |
+| Switch.cs:174:13:174:20 | default: | Switch.cs:174:13:174:20 | default: |
 | TypeAccesses.cs:1:7:1:18 | enter TypeAccesses | TypeAccesses.cs:1:7:1:18 | enter TypeAccesses |
 | TypeAccesses.cs:3:10:3:10 | enter M | TypeAccesses.cs:3:10:3:10 | enter M |
 | TypeAccesses.cs:7:13:7:22 | [false] ... is ... | TypeAccesses.cs:7:13:7:22 | [false] ... is ... |

--- a/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
@@ -3685,10 +3685,10 @@ dominance
 | Switch.cs:165:17:165:17 | access to parameter i | Switch.cs:167:13:167:19 | case ...: |
 | Switch.cs:167:13:167:19 | case ...: | Switch.cs:167:18:167:18 | 1 |
 | Switch.cs:167:18:167:18 | 1 | Switch.cs:168:13:168:19 | case ...: |
+| Switch.cs:167:18:167:18 | 1 | Switch.cs:169:17:169:51 | ...; |
 | Switch.cs:168:13:168:19 | case ...: | Switch.cs:168:18:168:18 | 2 |
-| Switch.cs:168:18:168:18 | 2 | Switch.cs:169:17:169:51 | ...; |
-| Switch.cs:168:18:168:18 | 2 | Switch.cs:170:17:170:22 | break; |
 | Switch.cs:168:18:168:18 | 2 | Switch.cs:171:13:171:19 | case ...: |
+| Switch.cs:169:17:169:50 | call to method WriteLine | Switch.cs:170:17:170:22 | break; |
 | Switch.cs:169:17:169:51 | ...; | Switch.cs:169:42:169:49 | "1 or 2" |
 | Switch.cs:169:42:169:49 | "1 or 2" | Switch.cs:169:17:169:50 | call to method WriteLine |
 | Switch.cs:171:13:171:19 | case ...: | Switch.cs:171:18:171:18 | 3 |
@@ -7886,7 +7886,6 @@ postDominance
 | Switch.cs:165:17:165:17 | access to parameter i | Switch.cs:165:9:177:9 | switch (...) {...} |
 | Switch.cs:167:13:167:19 | case ...: | Switch.cs:165:17:165:17 | access to parameter i |
 | Switch.cs:167:18:167:18 | 1 | Switch.cs:167:13:167:19 | case ...: |
-| Switch.cs:168:13:168:19 | case ...: | Switch.cs:167:18:167:18 | 1 |
 | Switch.cs:168:18:168:18 | 2 | Switch.cs:168:13:168:19 | case ...: |
 | Switch.cs:169:17:169:50 | call to method WriteLine | Switch.cs:169:42:169:49 | "1 or 2" |
 | Switch.cs:169:42:169:49 | "1 or 2" | Switch.cs:169:17:169:51 | ...; |
@@ -12516,20 +12515,15 @@ blockDominance
 | Switch.cs:163:10:163:12 | enter M16 | Switch.cs:163:10:163:12 | exit M16 (normal) |
 | Switch.cs:163:10:163:12 | enter M16 | Switch.cs:168:13:168:19 | case ...: |
 | Switch.cs:163:10:163:12 | enter M16 | Switch.cs:169:17:169:51 | ...; |
-| Switch.cs:163:10:163:12 | enter M16 | Switch.cs:170:17:170:22 | break; |
 | Switch.cs:163:10:163:12 | enter M16 | Switch.cs:171:13:171:19 | case ...: |
 | Switch.cs:163:10:163:12 | enter M16 | Switch.cs:172:17:172:46 | ...; |
 | Switch.cs:163:10:163:12 | enter M16 | Switch.cs:174:13:174:20 | default: |
 | Switch.cs:163:10:163:12 | exit M16 (normal) | Switch.cs:163:10:163:12 | exit M16 (normal) |
-| Switch.cs:168:13:168:19 | case ...: | Switch.cs:163:10:163:12 | exit M16 (normal) |
 | Switch.cs:168:13:168:19 | case ...: | Switch.cs:168:13:168:19 | case ...: |
-| Switch.cs:168:13:168:19 | case ...: | Switch.cs:169:17:169:51 | ...; |
-| Switch.cs:168:13:168:19 | case ...: | Switch.cs:170:17:170:22 | break; |
 | Switch.cs:168:13:168:19 | case ...: | Switch.cs:171:13:171:19 | case ...: |
 | Switch.cs:168:13:168:19 | case ...: | Switch.cs:172:17:172:46 | ...; |
 | Switch.cs:168:13:168:19 | case ...: | Switch.cs:174:13:174:20 | default: |
 | Switch.cs:169:17:169:51 | ...; | Switch.cs:169:17:169:51 | ...; |
-| Switch.cs:170:17:170:22 | break; | Switch.cs:170:17:170:22 | break; |
 | Switch.cs:171:13:171:19 | case ...: | Switch.cs:171:13:171:19 | case ...: |
 | Switch.cs:171:13:171:19 | case ...: | Switch.cs:172:17:172:46 | ...; |
 | Switch.cs:171:13:171:19 | case ...: | Switch.cs:174:13:174:20 | default: |
@@ -15867,15 +15861,11 @@ postBlockDominance
 | Switch.cs:163:10:163:12 | exit M16 (normal) | Switch.cs:163:10:163:12 | exit M16 (normal) |
 | Switch.cs:163:10:163:12 | exit M16 (normal) | Switch.cs:168:13:168:19 | case ...: |
 | Switch.cs:163:10:163:12 | exit M16 (normal) | Switch.cs:169:17:169:51 | ...; |
-| Switch.cs:163:10:163:12 | exit M16 (normal) | Switch.cs:170:17:170:22 | break; |
 | Switch.cs:163:10:163:12 | exit M16 (normal) | Switch.cs:171:13:171:19 | case ...: |
 | Switch.cs:163:10:163:12 | exit M16 (normal) | Switch.cs:172:17:172:46 | ...; |
 | Switch.cs:163:10:163:12 | exit M16 (normal) | Switch.cs:174:13:174:20 | default: |
-| Switch.cs:168:13:168:19 | case ...: | Switch.cs:163:10:163:12 | enter M16 |
 | Switch.cs:168:13:168:19 | case ...: | Switch.cs:168:13:168:19 | case ...: |
 | Switch.cs:169:17:169:51 | ...; | Switch.cs:169:17:169:51 | ...; |
-| Switch.cs:170:17:170:22 | break; | Switch.cs:169:17:169:51 | ...; |
-| Switch.cs:170:17:170:22 | break; | Switch.cs:170:17:170:22 | break; |
 | Switch.cs:171:13:171:19 | case ...: | Switch.cs:171:13:171:19 | case ...: |
 | Switch.cs:172:17:172:46 | ...; | Switch.cs:172:17:172:46 | ...; |
 | Switch.cs:174:13:174:20 | default: | Switch.cs:174:13:174:20 | default: |

--- a/csharp/ql/test/library-tests/controlflow/graph/EnclosingCallable.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/EnclosingCallable.expected
@@ -5942,7 +5942,6 @@ blockEnclosing
 | Switch.cs:163:10:163:12 | exit M16 (normal) | Switch.cs:163:10:163:12 | M16 |
 | Switch.cs:168:13:168:19 | case ...: | Switch.cs:163:10:163:12 | M16 |
 | Switch.cs:169:17:169:51 | ...; | Switch.cs:163:10:163:12 | M16 |
-| Switch.cs:170:17:170:22 | break; | Switch.cs:163:10:163:12 | M16 |
 | Switch.cs:171:13:171:19 | case ...: | Switch.cs:163:10:163:12 | M16 |
 | Switch.cs:172:17:172:46 | ...; | Switch.cs:163:10:163:12 | M16 |
 | Switch.cs:174:13:174:20 | default: | Switch.cs:163:10:163:12 | M16 |

--- a/csharp/ql/test/library-tests/controlflow/graph/EnclosingCallable.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/EnclosingCallable.expected
@@ -4029,6 +4029,31 @@ nodeEnclosing
 | Switch.cs:160:40:160:43 | "b = " | Switch.cs:154:10:154:12 | M15 |
 | Switch.cs:160:44:160:46 | {...} | Switch.cs:154:10:154:12 | M15 |
 | Switch.cs:160:45:160:45 | access to local variable s | Switch.cs:154:10:154:12 | M15 |
+| Switch.cs:163:10:163:12 | enter M16 | Switch.cs:163:10:163:12 | M16 |
+| Switch.cs:163:10:163:12 | exit M16 | Switch.cs:163:10:163:12 | M16 |
+| Switch.cs:163:10:163:12 | exit M16 (normal) | Switch.cs:163:10:163:12 | M16 |
+| Switch.cs:164:5:178:5 | {...} | Switch.cs:163:10:163:12 | M16 |
+| Switch.cs:165:9:177:9 | switch (...) {...} | Switch.cs:163:10:163:12 | M16 |
+| Switch.cs:165:17:165:17 | access to parameter i | Switch.cs:163:10:163:12 | M16 |
+| Switch.cs:167:13:167:19 | case ...: | Switch.cs:163:10:163:12 | M16 |
+| Switch.cs:167:18:167:18 | 1 | Switch.cs:163:10:163:12 | M16 |
+| Switch.cs:168:13:168:19 | case ...: | Switch.cs:163:10:163:12 | M16 |
+| Switch.cs:168:18:168:18 | 2 | Switch.cs:163:10:163:12 | M16 |
+| Switch.cs:169:17:169:50 | call to method WriteLine | Switch.cs:163:10:163:12 | M16 |
+| Switch.cs:169:17:169:51 | ...; | Switch.cs:163:10:163:12 | M16 |
+| Switch.cs:169:42:169:49 | "1 or 2" | Switch.cs:163:10:163:12 | M16 |
+| Switch.cs:170:17:170:22 | break; | Switch.cs:163:10:163:12 | M16 |
+| Switch.cs:171:13:171:19 | case ...: | Switch.cs:163:10:163:12 | M16 |
+| Switch.cs:171:18:171:18 | 3 | Switch.cs:163:10:163:12 | M16 |
+| Switch.cs:172:17:172:45 | call to method WriteLine | Switch.cs:163:10:163:12 | M16 |
+| Switch.cs:172:17:172:46 | ...; | Switch.cs:163:10:163:12 | M16 |
+| Switch.cs:172:42:172:44 | "3" | Switch.cs:163:10:163:12 | M16 |
+| Switch.cs:173:17:173:22 | break; | Switch.cs:163:10:163:12 | M16 |
+| Switch.cs:174:13:174:20 | default: | Switch.cs:163:10:163:12 | M16 |
+| Switch.cs:175:17:175:47 | call to method WriteLine | Switch.cs:163:10:163:12 | M16 |
+| Switch.cs:175:17:175:48 | ...; | Switch.cs:163:10:163:12 | M16 |
+| Switch.cs:175:42:175:46 | "def" | Switch.cs:163:10:163:12 | M16 |
+| Switch.cs:176:17:176:22 | break; | Switch.cs:163:10:163:12 | M16 |
 | TypeAccesses.cs:1:7:1:18 | call to constructor Object | TypeAccesses.cs:1:7:1:18 | TypeAccesses |
 | TypeAccesses.cs:1:7:1:18 | enter TypeAccesses | TypeAccesses.cs:1:7:1:18 | TypeAccesses |
 | TypeAccesses.cs:1:7:1:18 | exit TypeAccesses | TypeAccesses.cs:1:7:1:18 | TypeAccesses |
@@ -5913,6 +5938,14 @@ blockEnclosing
 | Switch.cs:156:50:156:52 | "b" | Switch.cs:154:10:154:12 | M15 |
 | Switch.cs:158:13:158:49 | ...; | Switch.cs:154:10:154:12 | M15 |
 | Switch.cs:160:13:160:49 | ...; | Switch.cs:154:10:154:12 | M15 |
+| Switch.cs:163:10:163:12 | enter M16 | Switch.cs:163:10:163:12 | M16 |
+| Switch.cs:163:10:163:12 | exit M16 (normal) | Switch.cs:163:10:163:12 | M16 |
+| Switch.cs:168:13:168:19 | case ...: | Switch.cs:163:10:163:12 | M16 |
+| Switch.cs:169:17:169:51 | ...; | Switch.cs:163:10:163:12 | M16 |
+| Switch.cs:170:17:170:22 | break; | Switch.cs:163:10:163:12 | M16 |
+| Switch.cs:171:13:171:19 | case ...: | Switch.cs:163:10:163:12 | M16 |
+| Switch.cs:172:17:172:46 | ...; | Switch.cs:163:10:163:12 | M16 |
+| Switch.cs:174:13:174:20 | default: | Switch.cs:163:10:163:12 | M16 |
 | TypeAccesses.cs:1:7:1:18 | enter TypeAccesses | TypeAccesses.cs:1:7:1:18 | TypeAccesses |
 | TypeAccesses.cs:3:10:3:10 | enter M | TypeAccesses.cs:3:10:3:10 | M |
 | TypeAccesses.cs:7:13:7:22 | [false] ... is ... | TypeAccesses.cs:3:10:3:10 | M |

--- a/csharp/ql/test/library-tests/controlflow/graph/EntryElement.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/EntryElement.expected
@@ -2711,6 +2711,28 @@
 | Switch.cs:160:40:160:43 | "b = " | Switch.cs:160:40:160:43 | "b = " |
 | Switch.cs:160:44:160:46 | {...} | Switch.cs:160:45:160:45 | access to local variable s |
 | Switch.cs:160:45:160:45 | access to local variable s | Switch.cs:160:45:160:45 | access to local variable s |
+| Switch.cs:164:5:178:5 | {...} | Switch.cs:164:5:178:5 | {...} |
+| Switch.cs:165:9:177:9 | switch (...) {...} | Switch.cs:165:9:177:9 | switch (...) {...} |
+| Switch.cs:165:17:165:17 | access to parameter i | Switch.cs:165:17:165:17 | access to parameter i |
+| Switch.cs:167:13:167:19 | case ...: | Switch.cs:167:13:167:19 | case ...: |
+| Switch.cs:167:18:167:18 | 1 | Switch.cs:167:18:167:18 | 1 |
+| Switch.cs:168:13:168:19 | case ...: | Switch.cs:168:13:168:19 | case ...: |
+| Switch.cs:168:18:168:18 | 2 | Switch.cs:168:18:168:18 | 2 |
+| Switch.cs:169:17:169:50 | call to method WriteLine | Switch.cs:169:42:169:49 | "1 or 2" |
+| Switch.cs:169:17:169:51 | ...; | Switch.cs:169:17:169:51 | ...; |
+| Switch.cs:169:42:169:49 | "1 or 2" | Switch.cs:169:42:169:49 | "1 or 2" |
+| Switch.cs:170:17:170:22 | break; | Switch.cs:170:17:170:22 | break; |
+| Switch.cs:171:13:171:19 | case ...: | Switch.cs:171:13:171:19 | case ...: |
+| Switch.cs:171:18:171:18 | 3 | Switch.cs:171:18:171:18 | 3 |
+| Switch.cs:172:17:172:45 | call to method WriteLine | Switch.cs:172:42:172:44 | "3" |
+| Switch.cs:172:17:172:46 | ...; | Switch.cs:172:17:172:46 | ...; |
+| Switch.cs:172:42:172:44 | "3" | Switch.cs:172:42:172:44 | "3" |
+| Switch.cs:173:17:173:22 | break; | Switch.cs:173:17:173:22 | break; |
+| Switch.cs:174:13:174:20 | default: | Switch.cs:174:13:174:20 | default: |
+| Switch.cs:175:17:175:47 | call to method WriteLine | Switch.cs:175:42:175:46 | "def" |
+| Switch.cs:175:17:175:48 | ...; | Switch.cs:175:17:175:48 | ...; |
+| Switch.cs:175:42:175:46 | "def" | Switch.cs:175:42:175:46 | "def" |
+| Switch.cs:176:17:176:22 | break; | Switch.cs:176:17:176:22 | break; |
 | TypeAccesses.cs:1:7:1:18 | call to constructor Object | TypeAccesses.cs:1:7:1:18 | call to constructor Object |
 | TypeAccesses.cs:1:7:1:18 | {...} | TypeAccesses.cs:1:7:1:18 | {...} |
 | TypeAccesses.cs:4:5:9:5 | {...} | TypeAccesses.cs:4:5:9:5 | {...} |

--- a/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
@@ -3581,6 +3581,39 @@
 | Switch.cs:160:40:160:43 | "b = " | Switch.cs:160:40:160:43 | "b = " | normal |
 | Switch.cs:160:44:160:46 | {...} | Switch.cs:160:44:160:46 | {...} | normal |
 | Switch.cs:160:45:160:45 | access to local variable s | Switch.cs:160:45:160:45 | access to local variable s | normal |
+| Switch.cs:164:5:178:5 | {...} | Switch.cs:170:17:170:22 | break; | normal [break] (0) |
+| Switch.cs:164:5:178:5 | {...} | Switch.cs:173:17:173:22 | break; | normal [break] (0) |
+| Switch.cs:164:5:178:5 | {...} | Switch.cs:176:17:176:22 | break; | normal [break] (0) |
+| Switch.cs:165:9:177:9 | switch (...) {...} | Switch.cs:170:17:170:22 | break; | normal [break] (0) |
+| Switch.cs:165:9:177:9 | switch (...) {...} | Switch.cs:173:17:173:22 | break; | normal [break] (0) |
+| Switch.cs:165:9:177:9 | switch (...) {...} | Switch.cs:176:17:176:22 | break; | normal [break] (0) |
+| Switch.cs:165:17:165:17 | access to parameter i | Switch.cs:165:17:165:17 | access to parameter i | normal |
+| Switch.cs:167:13:167:19 | case ...: | Switch.cs:167:18:167:18 | 1 | no-match |
+| Switch.cs:167:13:167:19 | case ...: | Switch.cs:168:18:168:18 | 2 | no-match |
+| Switch.cs:167:13:167:19 | case ...: | Switch.cs:169:17:169:50 | call to method WriteLine | normal |
+| Switch.cs:167:18:167:18 | 1 | Switch.cs:167:18:167:18 | 1 | match |
+| Switch.cs:167:18:167:18 | 1 | Switch.cs:167:18:167:18 | 1 | no-match |
+| Switch.cs:168:13:168:19 | case ...: | Switch.cs:168:18:168:18 | 2 | no-match |
+| Switch.cs:168:13:168:19 | case ...: | Switch.cs:169:17:169:50 | call to method WriteLine | normal |
+| Switch.cs:168:18:168:18 | 2 | Switch.cs:168:18:168:18 | 2 | match |
+| Switch.cs:168:18:168:18 | 2 | Switch.cs:168:18:168:18 | 2 | no-match |
+| Switch.cs:169:17:169:50 | call to method WriteLine | Switch.cs:169:17:169:50 | call to method WriteLine | normal |
+| Switch.cs:169:17:169:51 | ...; | Switch.cs:169:17:169:50 | call to method WriteLine | normal |
+| Switch.cs:169:42:169:49 | "1 or 2" | Switch.cs:169:42:169:49 | "1 or 2" | normal |
+| Switch.cs:170:17:170:22 | break; | Switch.cs:170:17:170:22 | break; | break |
+| Switch.cs:171:13:171:19 | case ...: | Switch.cs:171:18:171:18 | 3 | no-match |
+| Switch.cs:171:13:171:19 | case ...: | Switch.cs:172:17:172:45 | call to method WriteLine | normal |
+| Switch.cs:171:18:171:18 | 3 | Switch.cs:171:18:171:18 | 3 | match |
+| Switch.cs:171:18:171:18 | 3 | Switch.cs:171:18:171:18 | 3 | no-match |
+| Switch.cs:172:17:172:45 | call to method WriteLine | Switch.cs:172:17:172:45 | call to method WriteLine | normal |
+| Switch.cs:172:17:172:46 | ...; | Switch.cs:172:17:172:45 | call to method WriteLine | normal |
+| Switch.cs:172:42:172:44 | "3" | Switch.cs:172:42:172:44 | "3" | normal |
+| Switch.cs:173:17:173:22 | break; | Switch.cs:173:17:173:22 | break; | break |
+| Switch.cs:174:13:174:20 | default: | Switch.cs:175:17:175:47 | call to method WriteLine | normal |
+| Switch.cs:175:17:175:47 | call to method WriteLine | Switch.cs:175:17:175:47 | call to method WriteLine | normal |
+| Switch.cs:175:17:175:48 | ...; | Switch.cs:175:17:175:47 | call to method WriteLine | normal |
+| Switch.cs:175:42:175:46 | "def" | Switch.cs:175:42:175:46 | "def" | normal |
+| Switch.cs:176:17:176:22 | break; | Switch.cs:176:17:176:22 | break; | break |
 | TypeAccesses.cs:1:7:1:18 | call to constructor Object | TypeAccesses.cs:1:7:1:18 | call to constructor Object | normal |
 | TypeAccesses.cs:1:7:1:18 | {...} | TypeAccesses.cs:1:7:1:18 | {...} | normal |
 | TypeAccesses.cs:4:5:9:5 | {...} | TypeAccesses.cs:8:13:8:27 | Type t = ... | normal |

--- a/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
@@ -3589,7 +3589,6 @@
 | Switch.cs:165:9:177:9 | switch (...) {...} | Switch.cs:176:17:176:22 | break; | normal [break] (0) |
 | Switch.cs:165:17:165:17 | access to parameter i | Switch.cs:165:17:165:17 | access to parameter i | normal |
 | Switch.cs:167:13:167:19 | case ...: | Switch.cs:167:18:167:18 | 1 | no-match |
-| Switch.cs:167:13:167:19 | case ...: | Switch.cs:168:18:168:18 | 2 | no-match |
 | Switch.cs:167:13:167:19 | case ...: | Switch.cs:169:17:169:50 | call to method WriteLine | normal |
 | Switch.cs:167:18:167:18 | 1 | Switch.cs:167:18:167:18 | 1 | match |
 | Switch.cs:167:18:167:18 | 1 | Switch.cs:167:18:167:18 | 1 | no-match |

--- a/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
@@ -4151,10 +4151,10 @@
 | Switch.cs:165:9:177:9 | switch (...) {...} | Switch.cs:165:17:165:17 | access to parameter i |  |
 | Switch.cs:165:17:165:17 | access to parameter i | Switch.cs:167:13:167:19 | case ...: |  |
 | Switch.cs:167:13:167:19 | case ...: | Switch.cs:167:18:167:18 | 1 |  |
-| Switch.cs:167:18:167:18 | 1 | Switch.cs:168:13:168:19 | case ...: | match, no-match |
+| Switch.cs:167:18:167:18 | 1 | Switch.cs:168:13:168:19 | case ...: | no-match |
+| Switch.cs:167:18:167:18 | 1 | Switch.cs:169:17:169:51 | ...; | match |
 | Switch.cs:168:13:168:19 | case ...: | Switch.cs:168:18:168:18 | 2 |  |
 | Switch.cs:168:18:168:18 | 2 | Switch.cs:169:17:169:51 | ...; | match |
-| Switch.cs:168:18:168:18 | 2 | Switch.cs:170:17:170:22 | break; | no-match |
 | Switch.cs:168:18:168:18 | 2 | Switch.cs:171:13:171:19 | case ...: | no-match |
 | Switch.cs:169:17:169:50 | call to method WriteLine | Switch.cs:170:17:170:22 | break; |  |
 | Switch.cs:169:17:169:51 | ...; | Switch.cs:169:42:169:49 | "1 or 2" |  |

--- a/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
@@ -4145,6 +4145,33 @@
 | Switch.cs:160:40:160:43 | "b = " | Switch.cs:160:45:160:45 | access to local variable s |  |
 | Switch.cs:160:44:160:46 | {...} | Switch.cs:160:38:160:47 | $"..." |  |
 | Switch.cs:160:45:160:45 | access to local variable s | Switch.cs:160:44:160:46 | {...} |  |
+| Switch.cs:163:10:163:12 | enter M16 | Switch.cs:164:5:178:5 | {...} |  |
+| Switch.cs:163:10:163:12 | exit M16 (normal) | Switch.cs:163:10:163:12 | exit M16 |  |
+| Switch.cs:164:5:178:5 | {...} | Switch.cs:165:9:177:9 | switch (...) {...} |  |
+| Switch.cs:165:9:177:9 | switch (...) {...} | Switch.cs:165:17:165:17 | access to parameter i |  |
+| Switch.cs:165:17:165:17 | access to parameter i | Switch.cs:167:13:167:19 | case ...: |  |
+| Switch.cs:167:13:167:19 | case ...: | Switch.cs:167:18:167:18 | 1 |  |
+| Switch.cs:167:18:167:18 | 1 | Switch.cs:168:13:168:19 | case ...: | match, no-match |
+| Switch.cs:168:13:168:19 | case ...: | Switch.cs:168:18:168:18 | 2 |  |
+| Switch.cs:168:18:168:18 | 2 | Switch.cs:169:17:169:51 | ...; | match |
+| Switch.cs:168:18:168:18 | 2 | Switch.cs:170:17:170:22 | break; | no-match |
+| Switch.cs:168:18:168:18 | 2 | Switch.cs:171:13:171:19 | case ...: | no-match |
+| Switch.cs:169:17:169:50 | call to method WriteLine | Switch.cs:170:17:170:22 | break; |  |
+| Switch.cs:169:17:169:51 | ...; | Switch.cs:169:42:169:49 | "1 or 2" |  |
+| Switch.cs:169:42:169:49 | "1 or 2" | Switch.cs:169:17:169:50 | call to method WriteLine |  |
+| Switch.cs:170:17:170:22 | break; | Switch.cs:163:10:163:12 | exit M16 (normal) | break |
+| Switch.cs:171:13:171:19 | case ...: | Switch.cs:171:18:171:18 | 3 |  |
+| Switch.cs:171:18:171:18 | 3 | Switch.cs:172:17:172:46 | ...; | match |
+| Switch.cs:171:18:171:18 | 3 | Switch.cs:174:13:174:20 | default: | no-match |
+| Switch.cs:172:17:172:45 | call to method WriteLine | Switch.cs:173:17:173:22 | break; |  |
+| Switch.cs:172:17:172:46 | ...; | Switch.cs:172:42:172:44 | "3" |  |
+| Switch.cs:172:42:172:44 | "3" | Switch.cs:172:17:172:45 | call to method WriteLine |  |
+| Switch.cs:173:17:173:22 | break; | Switch.cs:163:10:163:12 | exit M16 (normal) | break |
+| Switch.cs:174:13:174:20 | default: | Switch.cs:175:17:175:48 | ...; |  |
+| Switch.cs:175:17:175:47 | call to method WriteLine | Switch.cs:176:17:176:22 | break; |  |
+| Switch.cs:175:17:175:48 | ...; | Switch.cs:175:42:175:46 | "def" |  |
+| Switch.cs:175:42:175:46 | "def" | Switch.cs:175:17:175:47 | call to method WriteLine |  |
+| Switch.cs:176:17:176:22 | break; | Switch.cs:163:10:163:12 | exit M16 (normal) | break |
 | TypeAccesses.cs:1:7:1:18 | call to constructor Object | TypeAccesses.cs:1:7:1:18 | {...} |  |
 | TypeAccesses.cs:1:7:1:18 | enter TypeAccesses | TypeAccesses.cs:1:7:1:18 | call to constructor Object |  |
 | TypeAccesses.cs:1:7:1:18 | exit TypeAccesses (normal) | TypeAccesses.cs:1:7:1:18 | exit TypeAccesses |  |

--- a/csharp/ql/test/library-tests/controlflow/graph/Nodes.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Nodes.expected
@@ -1256,6 +1256,7 @@ entryPoint
 | Switch.cs:134:9:134:11 | M13 | Switch.cs:135:5:142:5 | {...} |
 | Switch.cs:144:9:144:11 | M14 | Switch.cs:145:5:152:5 | {...} |
 | Switch.cs:154:10:154:12 | M15 | Switch.cs:155:5:161:5 | {...} |
+| Switch.cs:163:10:163:12 | M16 | Switch.cs:164:5:178:5 | {...} |
 | TypeAccesses.cs:1:7:1:18 | TypeAccesses | TypeAccesses.cs:1:7:1:18 | call to constructor Object |
 | TypeAccesses.cs:3:10:3:10 | M | TypeAccesses.cs:4:5:9:5 | {...} |
 | VarDecls.cs:3:7:3:14 | VarDecls | VarDecls.cs:3:7:3:14 | call to constructor Object |

--- a/csharp/ql/test/library-tests/controlflow/graph/Switch.cs
+++ b/csharp/ql/test/library-tests/controlflow/graph/Switch.cs
@@ -159,4 +159,21 @@ class Switch
         else
             System.Console.WriteLine($"b = {s}");
     }
+
+    void M16(int i)
+    {
+        switch (i)
+        {
+            case 1:
+            case 2:
+                System.Console.WriteLine("1 or 2");
+                break;
+            case 3:
+                System.Console.WriteLine("3");
+                break;
+            default:
+                System.Console.WriteLine("def");
+                break;
+        }
+    }
 }


### PR DESCRIPTION
Thanks to @aschackmull for making me aware, and providing the example.

Before
```mermaid
flowchart TD
1["enter M16"]
10["2"]
11["call to method WriteLine"]
12["...;"]
13[""1 or 2""]
14["break;"]
15["case ...:"]
16["3"]
17["call to method WriteLine"]
18["...;"]
19[""3""]
2["exit M16"]
20["break;"]
21["default:"]
22["call to method WriteLine"]
23["...;"]
24[""def""]
25["break;"]
3["exit M16 (normal)"]
4["{...}"]
5["switch (...) {...}"]
6["access to parameter i"]
7["case ...:"]
8["1"]
9["case ...:"]

1 --> 4
3 --> 2
4 --> 5
5 --> 6
6 --> 7
7 --> 8
8 -- match, no-match --> 9
9 --> 10
10 -- match --> 12
10 -- no-match --> 14
10 -- no-match --> 15
11 --> 14
12 --> 13
13 --> 11
14 -- break --> 3
15 --> 16
16 -- match --> 18
16 -- no-match --> 21
17 --> 20
18 --> 19
19 --> 17
20 -- break --> 3
21 --> 23
22 --> 25
23 --> 24
24 --> 22
25 -- break --> 3
```

After
```mermaid
flowchart TD
1["enter M16"]
10["2"]
11["call to method WriteLine"]
12["...;"]
13[""1 or 2""]
14["break;"]
15["case ...:"]
16["3"]
17["call to method WriteLine"]
18["...;"]
19[""3""]
2["exit M16"]
20["break;"]
21["default:"]
22["call to method WriteLine"]
23["...;"]
24[""def""]
25["break;"]
3["exit M16 (normal)"]
4["{...}"]
5["switch (...) {...}"]
6["access to parameter i"]
7["case ...:"]
8["1"]
9["case ...:"]

1 --> 4
3 --> 2
4 --> 5
5 --> 6
6 --> 7
7 --> 8
8 -- match --> 12
8 -- no-match --> 9
9 --> 10
10 -- match --> 12
10 -- no-match --> 15
11 --> 14
12 --> 13
13 --> 11
14 -- break --> 3
15 --> 16
16 -- match --> 18
16 -- no-match --> 21
17 --> 20
18 --> 19
19 --> 17
20 -- break --> 3
21 --> 23
22 --> 25
23 --> 24
24 --> 22
25 -- break --> 3
```