### PR TITLE
Shared: Re-factor summary, source and sink model generators into separate modules.

### DIFF
--- a/cpp/ql/src/utils/modelgenerator/CaptureContentSummaryModels.ql
+++ b/cpp/ql/src/utils/modelgenerator/CaptureContentSummaryModels.ql
@@ -7,6 +7,7 @@
  */
 
 import internal.CaptureModels
+import SummaryModels
 
 from DataFlowSummaryTargetApi api, string flow
 where flow = ContentSensitive::captureFlow(api, _)

--- a/cpp/ql/src/utils/modelgenerator/CaptureNeutralModels.ql
+++ b/cpp/ql/src/utils/modelgenerator/CaptureNeutralModels.ql
@@ -7,6 +7,7 @@
  */
 
 import internal.CaptureModels
+import SummaryModels
 
 from DataFlowSummaryTargetApi api, string noflow
 where noflow = captureNeutral(api)

--- a/cpp/ql/src/utils/modelgenerator/CaptureSinkModels.ql
+++ b/cpp/ql/src/utils/modelgenerator/CaptureSinkModels.ql
@@ -7,8 +7,8 @@
  */
 
 import internal.CaptureModels
-import Heuristic
+import SinkModels
 
 from DataFlowSinkTargetApi api, string sink
-where sink = captureSink(api)
+where sink = Heuristic::captureSink(api)
 select sink order by sink

--- a/cpp/ql/src/utils/modelgenerator/CaptureSourceModels.ql
+++ b/cpp/ql/src/utils/modelgenerator/CaptureSourceModels.ql
@@ -7,8 +7,8 @@
  */
 
 import internal.CaptureModels
-import Heuristic
+import SourceModels
 
 from DataFlowSourceTargetApi api, string source
-where source = captureSource(api)
+where source = Heuristic::captureSource(api)
 select source order by source

--- a/cpp/ql/src/utils/modelgenerator/CaptureSummaryModels.ql
+++ b/cpp/ql/src/utils/modelgenerator/CaptureSummaryModels.ql
@@ -7,6 +7,7 @@
  */
 
 import internal.CaptureModels
+import SummaryModels
 
 from DataFlowSummaryTargetApi api, string flow
 where flow = captureFlow(api, _)

--- a/cpp/ql/src/utils/modelgenerator/internal/CaptureModels.qll
+++ b/cpp/ql/src/utils/modelgenerator/internal/CaptureModels.qll
@@ -360,12 +360,6 @@ private module SummaryModelGeneratorInput implements SummaryModelGeneratorInputS
       result = "Element[" + ec.getIndirectionIndex() + "]"
     )
   }
-
-  predicate isUninterestingForDataFlowModels(Callable api) { none() }
-
-  predicate isUninterestingForHeuristicDataFlowModels(Callable api) {
-    isUninterestingForDataFlowModels(api)
-  }
 }
 
 private module SourceModelGeneratorInput implements SourceModelGeneratorInputSig {
@@ -376,11 +370,6 @@ private module SourceModelGeneratorInput implements SourceModelGeneratorInputSig
   class SourceTargetApi extends Callable {
     SourceTargetApi() { relevant(this) and not hasManualSourceModel(this) }
   }
-
-  predicate irrelevantSourceSinkApi(Callable source, SourceTargetApi api) { none() }
-
-  bindingset[kind]
-  predicate isRelevantSourceKind(string kind) { any() }
 
   predicate sourceNode = ExternalFlow::sourceNode/2;
 }
@@ -395,8 +384,6 @@ private module SinkModelGeneratorInput implements SinkModelGeneratorInputSig {
   class SinkTargetApi extends Callable {
     SinkTargetApi() { relevant(this) and not hasManualSinkModel(this) }
   }
-
-  predicate sinkModelSanitizer(DataFlow::Node node) { none() }
 
   predicate apiSource(DataFlow::Node source) {
     DataFlowPrivate::nodeHasOperand(source, any(DataFlow::FieldAddress fa), 1)
@@ -415,9 +402,6 @@ private module SinkModelGeneratorInput implements SinkModelGeneratorInputSig {
     DataFlowPrivate::nodeHasOperand(source, any(DataFlow::FieldAddress fa), 1) and
     result = qualifierString()
   }
-
-  bindingset[kind]
-  predicate isRelevantSinkKind(string kind) { any() }
 
   predicate sinkNode = ExternalFlow::sinkNode/2;
 }

--- a/cpp/ql/src/utils/modelgenerator/internal/CaptureModels.qll
+++ b/cpp/ql/src/utils/modelgenerator/internal/CaptureModels.qll
@@ -2,7 +2,7 @@
  * Provides predicates related to capturing summary models of the Standard or a 3rd party library.
  */
 
-private import cpp
+private import cpp as Cpp
 private import semmle.code.cpp.ir.IR
 private import semmle.code.cpp.dataflow.ExternalFlow as ExternalFlow
 private import semmle.code.cpp.ir.dataflow.internal.DataFlowImplCommon as DataFlowImplCommon
@@ -10,111 +10,65 @@ private import semmle.code.cpp.ir.dataflow.internal.DataFlowImplSpecific
 private import semmle.code.cpp.ir.dataflow.internal.DataFlowPrivate as DataFlowPrivate
 private import semmle.code.cpp.dataflow.internal.FlowSummaryImpl as FlowSummaryImpl
 private import semmle.code.cpp.ir.dataflow.internal.TaintTrackingImplSpecific
-private import semmle.code.cpp.dataflow.new.TaintTracking
+private import semmle.code.cpp.dataflow.new.TaintTracking as Tt
+private import semmle.code.cpp.dataflow.new.DataFlow as Df
 private import codeql.mad.modelgenerator.internal.ModelGeneratorImpl
 
-module ModelGeneratorInput implements ModelGeneratorInputSig<Location, CppDataFlow> {
+/**
+ * Holds if `f` is a "private" function.
+ *
+ * A "private" function does not contribute any models as it is assumed
+ * to be an implementation detail of some other "public" function for which
+ * we will generate a summary.
+ */
+private predicate isPrivateOrProtected(Cpp::Function f) {
+  f.getNamespace().getParentNamespace*().isAnonymous()
+  or
+  exists(Cpp::MemberFunction mf | mf = f |
+    mf.isPrivate()
+    or
+    mf.isProtected()
+  )
+  or
+  f.isStatic()
+}
+
+private predicate isUninterestingForModels(Callable api) {
+  // Note: This also makes all global/static-local variables
+  // not relevant (which is good!)
+  not api.(Cpp::Function).hasDefinition()
+  or
+  isPrivateOrProtected(api)
+  or
+  api instanceof Cpp::Destructor
+  or
+  api = any(Cpp::LambdaExpression lambda).getLambdaFunction()
+  or
+  api.isFromUninstantiatedTemplate(_)
+}
+
+private predicate relevant(Callable api) {
+  api.fromSource() and
+  not isUninterestingForModels(api)
+}
+
+module ModelGeneratorCommonInput implements ModelGeneratorCommonInputSig<Cpp::Location, CppDataFlow>
+{
+  private module DataFlow = Df::DataFlow;
+
   class Type = DataFlowPrivate::DataFlowType;
 
   // Note: This also includes `this`
   class Parameter = DataFlow::ParameterNode;
 
-  class Callable = Declaration;
+  class Callable = Cpp::Declaration;
 
   class NodeExtended extends DataFlow::Node {
     Callable getAsExprEnclosingCallable() { result = this.asExpr().getEnclosingDeclaration() }
   }
 
-  Parameter asParameter(NodeExtended n) { result = n }
-
   Callable getEnclosingCallable(NodeExtended n) {
     result = n.getEnclosingCallable().asSourceCallable()
-  }
-
-  Callable getAsExprEnclosingCallable(NodeExtended n) {
-    result = n.asExpr().getEnclosingDeclaration()
-  }
-
-  /** Gets `api` if it is relevant. */
-  private Callable liftedImpl(Callable api) { result = api and relevant(api) }
-
-  private predicate hasManualSummaryModel(Callable api) {
-    api = any(FlowSummaryImpl::Public::SummarizedCallable sc | sc.applyManualModel()) or
-    api = any(FlowSummaryImpl::Public::NeutralSummaryCallable sc | sc.hasManualModel())
-  }
-
-  private predicate hasManualSourceModel(Callable api) {
-    api = any(FlowSummaryImpl::Public::NeutralSourceCallable sc | sc.hasManualModel())
-  }
-
-  private predicate hasManualSinkModel(Callable api) {
-    api = any(FlowSummaryImpl::Public::NeutralSinkCallable sc | sc.hasManualModel())
-  }
-
-  /**
-   * Holds if `f` is a "private" function.
-   *
-   * A "private" function does not contribute any models as it is assumed
-   * to be an implementation detail of some other "public" function for which
-   * we will generate a summary.
-   */
-  private predicate isPrivateOrProtected(Function f) {
-    f.getNamespace().getParentNamespace*().isAnonymous()
-    or
-    exists(MemberFunction mf | mf = f |
-      mf.isPrivate()
-      or
-      mf.isProtected()
-    )
-    or
-    f.isStatic()
-  }
-
-  private predicate isUninterestingForModels(Callable api) {
-    // Note: This also makes all global/static-local variables
-    // not relevant (which is good!)
-    not api.(Function).hasDefinition()
-    or
-    isPrivateOrProtected(api)
-    or
-    api instanceof Destructor
-    or
-    api = any(LambdaExpression lambda).getLambdaFunction()
-    or
-    api.isFromUninstantiatedTemplate(_)
-  }
-
-  private predicate relevant(Callable api) {
-    api.fromSource() and
-    not isUninterestingForModels(api)
-  }
-
-  class SummaryTargetApi extends Callable {
-    private Callable lift;
-
-    SummaryTargetApi() {
-      lift = liftedImpl(this) and
-      not hasManualSummaryModel(lift)
-    }
-
-    Callable lift() { result = lift }
-
-    predicate isRelevant() {
-      relevant(this) and
-      not hasManualSummaryModel(this)
-    }
-  }
-
-  class SourceOrSinkTargetApi extends Callable {
-    SourceOrSinkTargetApi() { relevant(this) }
-  }
-
-  class SinkTargetApi extends SourceOrSinkTargetApi {
-    SinkTargetApi() { not hasManualSinkModel(this) }
-  }
-
-  class SourceTargetApi extends SourceOrSinkTargetApi {
-    SourceTargetApi() { not hasManualSourceModel(this) }
   }
 
   class InstanceParameterNode extends DataFlow::ParameterNode {
@@ -124,7 +78,7 @@ module ModelGeneratorInput implements ModelGeneratorInputSig<Location, CppDataFl
     }
   }
 
-  private predicate isFinalMemberFunction(MemberFunction mf) {
+  private predicate isFinalMemberFunction(Cpp::MemberFunction mf) {
     mf.isFinal()
     or
     mf.getDeclaringType().isFinal()
@@ -146,12 +100,12 @@ module ModelGeneratorInput implements ModelGeneratorInputSig<Location, CppDataFl
    * - An uninstantiated template, or
    * - A declaration that is not from a template instantiation.
    */
-  private string templateParams(Declaration template) {
+  private string templateParams(Cpp::Declaration template) {
     exists(string params |
       params =
         concat(int i |
           |
-          template.getTemplateArgument(i).(TypeTemplateParameter).getName(), "," order by i
+          template.getTemplateArgument(i).(Cpp::TypeTemplateParameter).getName(), "," order by i
         )
     |
       if params = "" then result = "" else result = "<" + params + ">"
@@ -166,7 +120,7 @@ module ModelGeneratorInput implements ModelGeneratorInputSig<Location, CppDataFl
    * - An uninstantiated template, or
    * - A declaration that is not from a template instantiation.
    */
-  private string params(Function functionTemplate) {
+  private string params(Cpp::Function functionTemplate) {
     exists(string params |
       params =
         concat(int i |
@@ -193,7 +147,7 @@ module ModelGeneratorInput implements ModelGeneratorInputSig<Location, CppDataFl
     Callable callable, string namespace, string type, string name, string params
   ) {
     exists(
-      Function functionTemplate, string typeWithoutTemplateArgs, string nameWithoutTemplateArgs
+      Cpp::Function functionTemplate, string typeWithoutTemplateArgs, string nameWithoutTemplateArgs
     |
       functionTemplate = ExternalFlow::getFullyTemplatedFunction(callable) and
       functionTemplate.hasQualifiedName(namespace, typeWithoutTemplateArgs, nameWithoutTemplateArgs) and
@@ -201,7 +155,7 @@ module ModelGeneratorInput implements ModelGeneratorInputSig<Location, CppDataFl
       name = nameWithoutTemplateArgs + templateParams(functionTemplate) and
       params = params(functionTemplate)
     |
-      exists(Class classTemplate |
+      exists(Cpp::Class classTemplate |
         classTemplate = functionTemplate.getDeclaringType() and
         type = typeWithoutTemplateArgs + templateParams(classTemplate)
       )
@@ -263,36 +217,16 @@ module ModelGeneratorInput implements ModelGeneratorInputSig<Location, CppDataFl
 
   /** Holds if this instance access is to an enclosing instance of type `t`. */
   pragma[nomagic]
-  private predicate isEnclosingInstanceAccess(DataFlowPrivate::ReturnNode n, Class t) {
+  private predicate isEnclosingInstanceAccess(DataFlowPrivate::ReturnNode n, Cpp::Class t) {
     n.getKind().isIndirectReturn(-1) and
     t = n.getType().stripType() and
-    t != n.getEnclosingCallable().asSourceCallable().(Function).getDeclaringType()
+    t != n.getEnclosingCallable().asSourceCallable().(Cpp::Function).getDeclaringType()
   }
 
   pragma[nomagic]
   predicate isOwnInstanceAccessNode(DataFlowPrivate::ReturnNode node) {
     node.getKind().isIndirectReturn(-1) and
     not isEnclosingInstanceAccess(node, _)
-  }
-
-  predicate sinkModelSanitizer(DataFlow::Node node) { none() }
-
-  predicate apiSource(DataFlow::Node source) {
-    DataFlowPrivate::nodeHasOperand(source, any(DataFlow::FieldAddress fa), 1)
-    or
-    source instanceof DataFlow::ParameterNode
-  }
-
-  string getInputArgument(DataFlow::Node source) {
-    exists(DataFlowPrivate::Position pos, int argumentIndex, int indirectionIndex |
-      source.(DataFlow::ParameterNode).isParameterOf(_, pos) and
-      argumentIndex = pos.getArgumentIndex() and
-      indirectionIndex = pos.getIndirectionIndex() and
-      result = "Argument[" + DataFlow::repeatStars(indirectionIndex) + argumentIndex + "]"
-    )
-    or
-    DataFlowPrivate::nodeHasOperand(source, any(DataFlow::FieldAddress fa), 1) and
-    result = qualifierString()
   }
 
   DataFlowPrivate::ParameterPosition getReturnKindParamPosition(DataFlowPrivate::ReturnKind k) {
@@ -314,18 +248,71 @@ module ModelGeneratorInput implements ModelGeneratorInputSig<Location, CppDataFl
     )
   }
 
-  predicate irrelevantSourceSinkApi(Callable source, SourceTargetApi api) { none() }
-
-  bindingset[kind]
-  predicate isRelevantSourceKind(string kind) { any() }
-
-  bindingset[kind]
-  predicate isRelevantSinkKind(string kind) { any() }
-
   predicate containerContent(DataFlow::ContentSet cs) { cs instanceof DataFlow::ElementContent }
 
+  string partialModelRow(Callable api, int i) {
+    i = 0 and qualifiedName(api, result, _, _, _) // namespace
+    or
+    i = 1 and qualifiedName(api, _, result, _, _) // type
+    or
+    i = 2 and result = isExtensible(api) // extensible
+    or
+    i = 3 and qualifiedName(api, _, _, result, _) // name
+    or
+    i = 4 and qualifiedName(api, _, _, _, result) // parameters
+    or
+    i = 5 and result = "" and exists(api) // ext
+  }
+
+  string partialNeutralModelRow(Callable api, int i) {
+    i = 0 and qualifiedName(api, result, _, _, _) // namespace
+    or
+    i = 1 and qualifiedName(api, _, result, _, _) // type
+    or
+    i = 2 and qualifiedName(api, _, _, result, _) // name
+    or
+    i = 3 and qualifiedName(api, _, _, _, result) // parameters
+  }
+}
+
+private import ModelGeneratorCommonInput
+private import MakeModelGeneratorFactory<Cpp::Location, CppDataFlow, CppTaintTracking, ModelGeneratorCommonInput>
+
+private module SummaryModelGeneratorInput implements SummaryModelGeneratorInputSig {
+  private module DataFlow = Df::DataFlow;
+
+  Parameter asParameter(NodeExtended n) { result = n }
+
+  Callable getAsExprEnclosingCallable(NodeExtended n) {
+    result = n.asExpr().getEnclosingDeclaration()
+  }
+
+  private predicate hasManualSummaryModel(Callable api) {
+    api = any(FlowSummaryImpl::Public::SummarizedCallable sc | sc.applyManualModel()) or
+    api = any(FlowSummaryImpl::Public::NeutralSummaryCallable sc | sc.hasManualModel())
+  }
+
+  /** Gets `api` if it is relevant. */
+  private Callable liftedImpl(Callable api) { result = api and relevant(api) }
+
+  class SummaryTargetApi extends Callable {
+    private Callable lift;
+
+    SummaryTargetApi() {
+      lift = liftedImpl(this) and
+      not hasManualSummaryModel(lift)
+    }
+
+    Callable lift() { result = lift }
+
+    predicate isRelevant() {
+      relevant(this) and
+      not hasManualSummaryModel(this)
+    }
+  }
+
   predicate isAdditionalContentFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
-    TaintTracking::defaultAdditionalTaintStep(node1, node2, _) and
+    Tt::TaintTracking::defaultAdditionalTaintStep(node1, node2, _) and
     not exists(DataFlow::Content f |
       DataFlowPrivate::readStep(node1, f, node2) and containerContent(f)
     )
@@ -341,7 +328,7 @@ module ModelGeneratorInput implements ModelGeneratorInputSig<Location, CppDataFl
   predicate isCallback(DataFlow::ContentSet c) { none() }
 
   string getSyntheticName(DataFlow::ContentSet c) {
-    exists(Field f |
+    exists(Cpp::Field f |
       not f.isPublic() and
       f = c.(DataFlow::FieldContent).getField() and
       result = f.getName()
@@ -379,34 +366,62 @@ module ModelGeneratorInput implements ModelGeneratorInputSig<Location, CppDataFl
   predicate isUninterestingForHeuristicDataFlowModels(Callable api) {
     isUninterestingForDataFlowModels(api)
   }
+}
 
-  string partialModelRow(Callable api, int i) {
-    i = 0 and qualifiedName(api, result, _, _, _) // namespace
-    or
-    i = 1 and qualifiedName(api, _, result, _, _) // type
-    or
-    i = 2 and result = isExtensible(api) // extensible
-    or
-    i = 3 and qualifiedName(api, _, _, result, _) // name
-    or
-    i = 4 and qualifiedName(api, _, _, _, result) // parameters
-    or
-    i = 5 and result = "" and exists(api) // ext
+private module SourceModelGeneratorInput implements SourceModelGeneratorInputSig {
+  private predicate hasManualSourceModel(Callable api) {
+    api = any(FlowSummaryImpl::Public::NeutralSourceCallable sc | sc.hasManualModel())
   }
 
-  string partialNeutralModelRow(Callable api, int i) {
-    i = 0 and qualifiedName(api, result, _, _, _) // namespace
-    or
-    i = 1 and qualifiedName(api, _, result, _, _) // type
-    or
-    i = 2 and qualifiedName(api, _, _, result, _) // name
-    or
-    i = 3 and qualifiedName(api, _, _, _, result) // parameters
+  class SourceTargetApi extends Callable {
+    SourceTargetApi() { relevant(this) and not hasManualSourceModel(this) }
   }
+
+  predicate irrelevantSourceSinkApi(Callable source, SourceTargetApi api) { none() }
+
+  bindingset[kind]
+  predicate isRelevantSourceKind(string kind) { any() }
 
   predicate sourceNode = ExternalFlow::sourceNode/2;
+}
+
+private module SinkModelGeneratorInput implements SinkModelGeneratorInputSig {
+  private module DataFlow = Df::DataFlow;
+
+  private predicate hasManualSinkModel(Callable api) {
+    api = any(FlowSummaryImpl::Public::NeutralSinkCallable sc | sc.hasManualModel())
+  }
+
+  class SinkTargetApi extends Callable {
+    SinkTargetApi() { relevant(this) and not hasManualSinkModel(this) }
+  }
+
+  predicate sinkModelSanitizer(DataFlow::Node node) { none() }
+
+  predicate apiSource(DataFlow::Node source) {
+    DataFlowPrivate::nodeHasOperand(source, any(DataFlow::FieldAddress fa), 1)
+    or
+    source instanceof DataFlow::ParameterNode
+  }
+
+  string getInputArgument(DataFlow::Node source) {
+    exists(DataFlowPrivate::Position pos, int argumentIndex, int indirectionIndex |
+      source.(DataFlow::ParameterNode).isParameterOf(_, pos) and
+      argumentIndex = pos.getArgumentIndex() and
+      indirectionIndex = pos.getIndirectionIndex() and
+      result = "Argument[" + DataFlow::repeatStars(indirectionIndex) + argumentIndex + "]"
+    )
+    or
+    DataFlowPrivate::nodeHasOperand(source, any(DataFlow::FieldAddress fa), 1) and
+    result = qualifierString()
+  }
+
+  bindingset[kind]
+  predicate isRelevantSinkKind(string kind) { any() }
 
   predicate sinkNode = ExternalFlow::sinkNode/2;
 }
 
-import MakeModelGenerator<Location, CppDataFlow, CppTaintTracking, ModelGeneratorInput>
+import MakeSummaryModelGenerator<SummaryModelGeneratorInput> as SummaryModels
+import MakeSourceModelGenerator<SourceModelGeneratorInput> as SourceModels
+import MakeSinkModelGenerator<SinkModelGeneratorInput> as SinkModels

--- a/cpp/ql/src/utils/modelgenerator/internal/CaptureModelsPrinting.qll
+++ b/cpp/ql/src/utils/modelgenerator/internal/CaptureModelsPrinting.qll
@@ -1,6 +1,6 @@
 private import cpp as Cpp
 private import codeql.mad.modelgenerator.internal.ModelPrinting
-private import CaptureModels::ModelGeneratorInput as ModelGeneratorInput
+private import CaptureModels::ModelGeneratorCommonInput as ModelGeneratorInput
 
 private module ModelPrintingLang implements ModelPrintingLangSig {
   class Callable = Cpp::Declaration;

--- a/cpp/ql/test/library-tests/dataflow/modelgenerator/dataflow/CaptureContentSummaryModels.ql
+++ b/cpp/ql/test/library-tests/dataflow/modelgenerator/dataflow/CaptureContentSummaryModels.ql
@@ -1,5 +1,6 @@
 import cpp
 import utils.modelgenerator.internal.CaptureModels
+import SummaryModels
 import InlineModelsAsDataTest
 
 module InlineMadTestConfig implements InlineMadTestConfigSig {

--- a/cpp/ql/test/library-tests/dataflow/modelgenerator/dataflow/CaptureHeuristicSummaryModels.ql
+++ b/cpp/ql/test/library-tests/dataflow/modelgenerator/dataflow/CaptureHeuristicSummaryModels.ql
@@ -1,5 +1,6 @@
 import cpp
 import utils.modelgenerator.internal.CaptureModels
+import SummaryModels
 import InlineModelsAsDataTest
 
 module InlineMadTestConfig implements InlineMadTestConfigSig {

--- a/csharp/ql/src/utils/modelgenerator/CaptureContentSummaryModels.ql
+++ b/csharp/ql/src/utils/modelgenerator/CaptureContentSummaryModels.ql
@@ -7,6 +7,7 @@
  */
 
 import internal.CaptureModels
+import SummaryModels
 
 from DataFlowSummaryTargetApi api, string flow
 where flow = ContentSensitive::captureFlow(api, _)

--- a/csharp/ql/src/utils/modelgenerator/CaptureNeutralModels.ql
+++ b/csharp/ql/src/utils/modelgenerator/CaptureNeutralModels.ql
@@ -7,6 +7,7 @@
  */
 
 import internal.CaptureModels
+import SummaryModels
 
 from DataFlowSummaryTargetApi api, string noflow
 where noflow = captureNeutral(api)

--- a/csharp/ql/src/utils/modelgenerator/CaptureSinkModels.ql
+++ b/csharp/ql/src/utils/modelgenerator/CaptureSinkModels.ql
@@ -7,6 +7,7 @@
  */
 
 import internal.CaptureModels
+import SinkModels
 
 from DataFlowSinkTargetApi api, string sink
 where sink = Heuristic::captureSink(api)

--- a/csharp/ql/src/utils/modelgenerator/CaptureSourceModels.ql
+++ b/csharp/ql/src/utils/modelgenerator/CaptureSourceModels.ql
@@ -7,6 +7,7 @@
  */
 
 import internal.CaptureModels
+import SourceModels
 
 from DataFlowSourceTargetApi api, string source
 where source = Heuristic::captureSource(api)

--- a/csharp/ql/src/utils/modelgenerator/CaptureSummaryModels.ql
+++ b/csharp/ql/src/utils/modelgenerator/CaptureSummaryModels.ql
@@ -7,6 +7,7 @@
  */
 
 import internal.CaptureModels
+import SummaryModels
 
 from DataFlowSummaryTargetApi api, string flow
 where flow = captureFlow(api, _)

--- a/csharp/ql/src/utils/modelgenerator/debug/CaptureSummaryModelsPartialPath.ql
+++ b/csharp/ql/src/utils/modelgenerator/debug/CaptureSummaryModelsPartialPath.ql
@@ -10,6 +10,7 @@
 
 import csharp
 import utils.modelgenerator.internal.CaptureModels
+import SummaryModels
 import PartialFlow::PartialPathGraph
 
 int explorationLimit() { result = 3 }

--- a/csharp/ql/src/utils/modelgenerator/debug/CaptureSummaryModelsPath.ql
+++ b/csharp/ql/src/utils/modelgenerator/debug/CaptureSummaryModelsPath.ql
@@ -10,6 +10,7 @@
 
 import csharp
 import utils.modelgenerator.internal.CaptureModels
+import SummaryModels
 import Heuristic
 import PropagateFlow::PathGraph
 

--- a/csharp/ql/src/utils/modelgenerator/internal/CaptureModels.qll
+++ b/csharp/ql/src/utils/modelgenerator/internal/CaptureModels.qll
@@ -234,8 +234,6 @@ module SummaryModelGeneratorInput implements SummaryModelGeneratorInputSig {
     api = any(FlowSummaryImpl::Public::NeutralSummaryCallable sc | sc.hasManualModel())
   }
 
-  predicate isUninterestingForDataFlowModels(Callable api) { none() }
-
   predicate isUninterestingForHeuristicDataFlowModels(Callable api) { isHigherOrder(api) }
 
   class SummaryTargetApi extends Callable {
@@ -356,9 +354,6 @@ private module SourceModelGeneratorInput implements SourceModelGeneratorInputSig
     )
   }
 
-  bindingset[kind]
-  predicate isRelevantSourceKind(string kind) { any() }
-
   predicate sourceNode = ExternalFlow::sourceNode/2;
 }
 
@@ -371,8 +366,6 @@ private module SinkModelGeneratorInput implements SinkModelGeneratorInputSig {
   class SinkTargetApi extends Callable {
     SinkTargetApi() { relevant(this) and not hasManualSinkModel(this) }
   }
-
-  predicate sinkModelSanitizer(DataFlow::Node node) { none() }
 
   private predicate isRelevantMemberAccess(DataFlow::Node node) {
     exists(CS::MemberAccess access | access = node.asExpr() |
@@ -399,9 +392,6 @@ private module SinkModelGeneratorInput implements SinkModelGeneratorInputSig {
     source.asExpr() instanceof DataFlowPrivate::FieldOrPropertyAccess and
     result = qualifierString()
   }
-
-  bindingset[kind]
-  predicate isRelevantSinkKind(string kind) { any() }
 
   predicate sinkNode = ExternalFlow::sinkNode/2;
 }

--- a/csharp/ql/src/utils/modelgenerator/internal/CaptureModels.qll
+++ b/csharp/ql/src/utils/modelgenerator/internal/CaptureModels.qll
@@ -15,7 +15,41 @@ private import semmle.code.csharp.frameworks.System
 private import semmle.code.csharp.Location
 private import codeql.mad.modelgenerator.internal.ModelGeneratorImpl
 
-module ModelGeneratorInput implements ModelGeneratorInputSig<Location, CsharpDataFlow> {
+private predicate irrelevantAccessor(CS::Accessor a) {
+  a.getDeclaration().(CS::Property).isReadWrite()
+}
+
+private predicate isUninterestingForModels(Callable api) {
+  api.getDeclaringType().getNamespace().getFullName() = ""
+  or
+  api instanceof CS::ConversionOperator
+  or
+  api instanceof Util::MainMethod
+  or
+  api instanceof CS::Destructor
+  or
+  api instanceof CS::AnonymousFunctionExpr
+  or
+  api.(CS::Constructor).isParameterless()
+  or
+  exists(Type decl | decl = api.getDeclaringType() |
+    decl instanceof SystemObjectClass or
+    decl instanceof SystemValueTypeClass
+  )
+  or
+  // Disregard properties that have both a get and a set accessor,
+  // which implicitly means auto implemented properties.
+  irrelevantAccessor(api)
+}
+
+private predicate relevant(Callable api) {
+  [api.(CS::Modifiable), api.(CS::Accessor).getDeclaration()].isEffectivelyPublic() and
+  api.fromSource() and
+  api.isUnboundDeclaration() and
+  not isUninterestingForModels(api)
+}
+
+module ModelGeneratorCommonInput implements ModelGeneratorCommonInputSig<Location, CsharpDataFlow> {
   class Type = CS::Type;
 
   class Parameter = CS::Parameter;
@@ -24,126 +58,7 @@ module ModelGeneratorInput implements ModelGeneratorInputSig<Location, CsharpDat
 
   class NodeExtended = CS::DataFlow::Node;
 
-  Callable getAsExprEnclosingCallable(NodeExtended node) {
-    result = node.asExpr().getEnclosingCallable()
-  }
-
   Callable getEnclosingCallable(NodeExtended node) { result = node.getEnclosingCallable() }
-
-  Parameter asParameter(NodeExtended node) { result = node.asParameter() }
-
-  /**
-   * Holds if any of the parameters of `api` are `System.Func<>`.
-   */
-  private predicate isHigherOrder(Callable api) {
-    exists(Type t | t = api.getAParameter().getType().getUnboundDeclaration() |
-      t instanceof SystemLinqExpressions::DelegateExtType
-    )
-  }
-
-  private predicate irrelevantAccessor(CS::Accessor a) {
-    a.getDeclaration().(CS::Property).isReadWrite()
-  }
-
-  private predicate isUninterestingForModels(Callable api) {
-    api.getDeclaringType().getNamespace().getFullName() = ""
-    or
-    api instanceof CS::ConversionOperator
-    or
-    api instanceof Util::MainMethod
-    or
-    api instanceof CS::Destructor
-    or
-    api instanceof CS::AnonymousFunctionExpr
-    or
-    api.(CS::Constructor).isParameterless()
-    or
-    exists(Type decl | decl = api.getDeclaringType() |
-      decl instanceof SystemObjectClass or
-      decl instanceof SystemValueTypeClass
-    )
-    or
-    // Disregard properties that have both a get and a set accessor,
-    // which implicitly means auto implemented properties.
-    irrelevantAccessor(api)
-  }
-
-  private predicate relevant(Callable api) {
-    [api.(CS::Modifiable), api.(CS::Accessor).getDeclaration()].isEffectivelyPublic() and
-    api.fromSource() and
-    api.isUnboundDeclaration() and
-    not isUninterestingForModels(api)
-  }
-
-  private Callable getARelevantOverrideeOrImplementee(Overridable m) {
-    m.overridesOrImplements(result) and relevant(result)
-  }
-
-  /**
-   * Gets the super implementation of `api` if it is relevant.
-   * If such a super implementation does not exist, returns `api` if it is relevant.
-   */
-  private Callable liftedImpl(Callable api) {
-    (
-      result = getARelevantOverrideeOrImplementee(api)
-      or
-      result = api and relevant(api)
-    ) and
-    not exists(getARelevantOverrideeOrImplementee(result))
-  }
-
-  private predicate hasManualSummaryModel(Callable api) {
-    api = any(FlowSummaryImpl::Public::SummarizedCallable sc | sc.applyManualModel()) or
-    api = any(FlowSummaryImpl::Public::NeutralSummaryCallable sc | sc.hasManualModel())
-  }
-
-  private predicate hasManualSourceModel(Callable api) {
-    api = any(ExternalFlow::SourceCallable sc | sc.hasManualModel()) or
-    api = any(FlowSummaryImpl::Public::NeutralSourceCallable sc | sc.hasManualModel())
-  }
-
-  private predicate hasManualSinkModel(Callable api) {
-    api = any(ExternalFlow::SinkCallable sc | sc.hasManualModel()) or
-    api = any(FlowSummaryImpl::Public::NeutralSinkCallable sc | sc.hasManualModel())
-  }
-
-  predicate isUninterestingForDataFlowModels(Callable api) { none() }
-
-  predicate isUninterestingForHeuristicDataFlowModels(Callable api) { isHigherOrder(api) }
-
-  class SourceOrSinkTargetApi extends Callable {
-    SourceOrSinkTargetApi() { relevant(this) }
-  }
-
-  class SinkTargetApi extends SourceOrSinkTargetApi {
-    SinkTargetApi() { not hasManualSinkModel(this) }
-  }
-
-  class SourceTargetApi extends SourceOrSinkTargetApi {
-    SourceTargetApi() {
-      not hasManualSourceModel(this) and
-      // Do not generate source models for overridable callables
-      // as virtual dispatch implies that too many methods
-      // will be considered sources.
-      not this.(Overridable).overridesOrImplements(_)
-    }
-  }
-
-  class SummaryTargetApi extends Callable {
-    private Callable lift;
-
-    SummaryTargetApi() {
-      lift = liftedImpl(this) and
-      not hasManualSummaryModel(lift)
-    }
-
-    Callable lift() { result = lift }
-
-    predicate isRelevant() {
-      relevant(this) and
-      not hasManualSummaryModel(this)
-    }
-  }
 
   /**
    * Holds if `t` is a type that is generally used for bulk data in collection types.
@@ -205,6 +120,8 @@ module ModelGeneratorInput implements ModelGeneratorInputSig<Location, CsharpDat
     )
   }
 
+  class InstanceParameterNode = DataFlowPrivate::InstanceParameterNode;
+
   string qualifierString() { result = "Argument[this]" }
 
   string parameterAccess(CS::Parameter p) {
@@ -214,8 +131,6 @@ module ModelGeneratorInput implements ModelGeneratorInputSig<Location, CsharpDat
   }
 
   string parameterContentAccess(CS::Parameter p) { result = "Argument[" + p.getPosition() + "]" }
-
-  class InstanceParameterNode = DataFlowPrivate::InstanceParameterNode;
 
   private signature string parameterAccessSig(Parameter p);
 
@@ -251,62 +166,93 @@ module ModelGeneratorInput implements ModelGeneratorInputSig<Location, CsharpDat
     node.asExpr() instanceof CS::ThisAccess
   }
 
-  private predicate isRelevantMemberAccess(DataFlow::Node node) {
-    exists(CS::MemberAccess access | access = node.asExpr() |
-      access.hasThisQualifier() and
-      access.getTarget().isEffectivelyPublic() and
-      (
-        access instanceof CS::FieldAccess
-        or
-        access.getTarget().(CS::Property).getSetter().isPublic()
-      )
-    )
-  }
-
-  predicate sinkModelSanitizer(DataFlow::Node node) { none() }
-
-  predicate apiSource(DataFlow::Node source) {
-    isRelevantMemberAccess(source) or source instanceof DataFlow::ParameterNode
-  }
-
-  private predicate uniquelyCalls(DataFlowCallable dc1, DataFlowCallable dc2) {
-    exists(DataFlowCall call |
-      dc1 = call.getEnclosingCallable() and
-      dc2 = unique(DataFlowCallable dc0 | dc0 = viableCallable(call) | dc0)
-    )
-  }
-
-  bindingset[dc1, dc2]
-  private predicate uniquelyCallsPlus(DataFlowCallable dc1, DataFlowCallable dc2) =
-    fastTC(uniquelyCalls/2)(dc1, dc2)
-
-  bindingset[sourceEnclosing, api]
-  predicate irrelevantSourceSinkApi(Callable sourceEnclosing, SourceTargetApi api) {
-    not exists(DataFlowCallable dc1, DataFlowCallable dc2 |
-      uniquelyCallsPlus(dc1, dc2) or dc1 = dc2
-    |
-      dc1.getUnderlyingCallable() = api and
-      dc2.getUnderlyingCallable() = sourceEnclosing
-    )
-  }
-
-  string getInputArgument(DataFlow::Node source) {
-    exists(int pos |
-      pos = source.(DataFlow::ParameterNode).getParameter().getPosition() and
-      result = "Argument[" + pos + "]"
-    )
-    or
-    source.asExpr() instanceof DataFlowPrivate::FieldOrPropertyAccess and
-    result = qualifierString()
-  }
-
-  bindingset[kind]
-  predicate isRelevantSinkKind(string kind) { any() }
-
-  bindingset[kind]
-  predicate isRelevantSourceKind(string kind) { any() }
-
   predicate containerContent(DataFlow::ContentSet c) { c.isElement() }
+
+  string partialModelRow(Callable api, int i) {
+    i = 0 and ExternalFlow::partialModel(api, result, _, _, _, _) // package
+    or
+    i = 1 and ExternalFlow::partialModel(api, _, result, _, _, _) // type
+    or
+    i = 2 and ExternalFlow::partialModel(api, _, _, result, _, _) // extensible
+    or
+    i = 3 and ExternalFlow::partialModel(api, _, _, _, result, _) // name
+    or
+    i = 4 and ExternalFlow::partialModel(api, _, _, _, _, result) // parameters
+    or
+    i = 5 and result = "" and exists(api) // ext
+  }
+
+  string partialNeutralModelRow(Callable api, int i) {
+    i = 0 and result = partialModelRow(api, 0) // package
+    or
+    i = 1 and result = partialModelRow(api, 1) // type
+    or
+    i = 2 and result = partialModelRow(api, 3) // name
+    or
+    i = 3 and result = partialModelRow(api, 4) // parameters
+  }
+}
+
+private import ModelGeneratorCommonInput
+private import MakeModelGeneratorFactory<Location, CsharpDataFlow, CsharpTaintTracking, ModelGeneratorCommonInput>
+
+module SummaryModelGeneratorInput implements SummaryModelGeneratorInputSig {
+  Callable getAsExprEnclosingCallable(NodeExtended node) {
+    result = node.asExpr().getEnclosingCallable()
+  }
+
+  Parameter asParameter(NodeExtended node) { result = node.asParameter() }
+
+  /**
+   * Holds if any of the parameters of `api` are `System.Func<>`.
+   */
+  private predicate isHigherOrder(Callable api) {
+    exists(Type t | t = api.getAParameter().getType().getUnboundDeclaration() |
+      t instanceof SystemLinqExpressions::DelegateExtType
+    )
+  }
+
+  private Callable getARelevantOverrideeOrImplementee(Overridable m) {
+    m.overridesOrImplements(result) and relevant(result)
+  }
+
+  /**
+   * Gets the super implementation of `api` if it is relevant.
+   * If such a super implementation does not exist, returns `api` if it is relevant.
+   */
+  private Callable liftedImpl(Callable api) {
+    (
+      result = getARelevantOverrideeOrImplementee(api)
+      or
+      result = api and relevant(api)
+    ) and
+    not exists(getARelevantOverrideeOrImplementee(result))
+  }
+
+  private predicate hasManualSummaryModel(Callable api) {
+    api = any(FlowSummaryImpl::Public::SummarizedCallable sc | sc.applyManualModel()) or
+    api = any(FlowSummaryImpl::Public::NeutralSummaryCallable sc | sc.hasManualModel())
+  }
+
+  predicate isUninterestingForDataFlowModels(Callable api) { none() }
+
+  predicate isUninterestingForHeuristicDataFlowModels(Callable api) { isHigherOrder(api) }
+
+  class SummaryTargetApi extends Callable {
+    private Callable lift;
+
+    SummaryTargetApi() {
+      lift = liftedImpl(this) and
+      not hasManualSummaryModel(lift)
+    }
+
+    Callable lift() { result = lift }
+
+    predicate isRelevant() {
+      relevant(this) and
+      not hasManualSummaryModel(this)
+    }
+  }
 
   predicate isAdditionalContentFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
     TaintTrackingPrivate::defaultAdditionalTaintStep(nodeFrom, nodeTo, _) and
@@ -370,34 +316,96 @@ module ModelGeneratorInput implements ModelGeneratorInputSig<Location, CsharpDat
     or
     c.isDelegateCallReturn() and result = "ReturnValue"
   }
+}
 
-  string partialModelRow(Callable api, int i) {
-    i = 0 and ExternalFlow::partialModel(api, result, _, _, _, _) // package
-    or
-    i = 1 and ExternalFlow::partialModel(api, _, result, _, _, _) // type
-    or
-    i = 2 and ExternalFlow::partialModel(api, _, _, result, _, _) // extensible
-    or
-    i = 3 and ExternalFlow::partialModel(api, _, _, _, result, _) // name
-    or
-    i = 4 and ExternalFlow::partialModel(api, _, _, _, _, result) // parameters
-    or
-    i = 5 and result = "" and exists(api) // ext
+private module SourceModelGeneratorInput implements SourceModelGeneratorInputSig {
+  private predicate hasManualSourceModel(Callable api) {
+    api = any(ExternalFlow::SourceCallable sc | sc.hasManualModel()) or
+    api = any(FlowSummaryImpl::Public::NeutralSourceCallable sc | sc.hasManualModel())
   }
 
-  string partialNeutralModelRow(Callable api, int i) {
-    i = 0 and result = partialModelRow(api, 0) // package
-    or
-    i = 1 and result = partialModelRow(api, 1) // type
-    or
-    i = 2 and result = partialModelRow(api, 3) // name
-    or
-    i = 3 and result = partialModelRow(api, 4) // parameters
+  class SourceTargetApi extends Callable {
+    SourceTargetApi() {
+      relevant(this) and
+      not hasManualSourceModel(this) and
+      // Do not generate source models for overridable callables
+      // as virtual dispatch implies that too many methods
+      // will be considered sources.
+      not this.(Overridable).overridesOrImplements(_)
+    }
   }
+
+  private predicate uniquelyCalls(DataFlowCallable dc1, DataFlowCallable dc2) {
+    exists(DataFlowCall call |
+      dc1 = call.getEnclosingCallable() and
+      dc2 = unique(DataFlowCallable dc0 | dc0 = viableCallable(call) | dc0)
+    )
+  }
+
+  bindingset[dc1, dc2]
+  private predicate uniquelyCallsPlus(DataFlowCallable dc1, DataFlowCallable dc2) =
+    fastTC(uniquelyCalls/2)(dc1, dc2)
+
+  bindingset[sourceEnclosing, api]
+  predicate irrelevantSourceSinkApi(Callable sourceEnclosing, SourceTargetApi api) {
+    not exists(DataFlowCallable dc1, DataFlowCallable dc2 |
+      uniquelyCallsPlus(dc1, dc2) or dc1 = dc2
+    |
+      dc1.getUnderlyingCallable() = api and
+      dc2.getUnderlyingCallable() = sourceEnclosing
+    )
+  }
+
+  bindingset[kind]
+  predicate isRelevantSourceKind(string kind) { any() }
 
   predicate sourceNode = ExternalFlow::sourceNode/2;
+}
+
+private module SinkModelGeneratorInput implements SinkModelGeneratorInputSig {
+  private predicate hasManualSinkModel(Callable api) {
+    api = any(ExternalFlow::SinkCallable sc | sc.hasManualModel()) or
+    api = any(FlowSummaryImpl::Public::NeutralSinkCallable sc | sc.hasManualModel())
+  }
+
+  class SinkTargetApi extends Callable {
+    SinkTargetApi() { relevant(this) and not hasManualSinkModel(this) }
+  }
+
+  predicate sinkModelSanitizer(DataFlow::Node node) { none() }
+
+  private predicate isRelevantMemberAccess(DataFlow::Node node) {
+    exists(CS::MemberAccess access | access = node.asExpr() |
+      access.hasThisQualifier() and
+      access.getTarget().isEffectivelyPublic() and
+      (
+        access instanceof CS::FieldAccess
+        or
+        access.getTarget().(CS::Property).getSetter().isPublic()
+      )
+    )
+  }
+
+  predicate apiSource(DataFlow::Node source) {
+    isRelevantMemberAccess(source) or source instanceof DataFlow::ParameterNode
+  }
+
+  string getInputArgument(DataFlow::Node source) {
+    exists(int pos |
+      pos = source.(DataFlow::ParameterNode).getParameter().getPosition() and
+      result = "Argument[" + pos + "]"
+    )
+    or
+    source.asExpr() instanceof DataFlowPrivate::FieldOrPropertyAccess and
+    result = qualifierString()
+  }
+
+  bindingset[kind]
+  predicate isRelevantSinkKind(string kind) { any() }
 
   predicate sinkNode = ExternalFlow::sinkNode/2;
 }
 
-import MakeModelGenerator<Location, CsharpDataFlow, CsharpTaintTracking, ModelGeneratorInput>
+import MakeSummaryModelGenerator<SummaryModelGeneratorInput> as SummaryModels
+import MakeSourceModelGenerator<SourceModelGeneratorInput> as SourceModels
+import MakeSinkModelGenerator<SinkModelGeneratorInput> as SinkModels

--- a/csharp/ql/src/utils/modelgenerator/internal/CaptureModelsPrinting.qll
+++ b/csharp/ql/src/utils/modelgenerator/internal/CaptureModelsPrinting.qll
@@ -1,6 +1,6 @@
 private import csharp as CS
 private import codeql.mad.modelgenerator.internal.ModelPrinting
-private import CaptureModels::ModelGeneratorInput as ModelGeneratorInput
+private import CaptureModels::ModelGeneratorCommonInput as ModelGeneratorInput
 
 private module ModelPrintingLang implements ModelPrintingLangSig {
   class Callable = CS::Callable;

--- a/csharp/ql/src/utils/modelgenerator/internal/CaptureTypeBasedSummaryModels.qll
+++ b/csharp/ql/src/utils/modelgenerator/internal/CaptureTypeBasedSummaryModels.qll
@@ -2,7 +2,8 @@ private import csharp
 private import semmle.code.csharp.frameworks.system.collections.Generic as GenericCollections
 private import semmle.code.csharp.dataflow.internal.DataFlowPrivate
 private import semmle.code.csharp.frameworks.system.linq.Expressions
-private import CaptureModels::ModelGeneratorInput as ModelGeneratorInput
+private import CaptureModels::ModelGeneratorCommonInput as ModelGeneratorInput
+private import CaptureModels::SummaryModelGeneratorInput as SummaryModelGeneratorInput
 private import CaptureModelsPrinting
 
 /**
@@ -189,7 +190,7 @@ private module Printing = ModelPrintingSummary<ModelPrintingInput>;
  * A class of callables that are relevant generating summaries for based
  * on the Theorems for Free approach.
  */
-class TypeBasedFlowTargetApi extends ModelGeneratorInput::SummaryTargetApi {
+class TypeBasedFlowTargetApi extends SummaryModelGeneratorInput::SummaryTargetApi {
   /**
    * Gets the string representation of all type based summaries for `this`
    * inspired by the Theorems for Free approach.

--- a/csharp/ql/src/utils/modelgenerator/internal/CaptureTypeBasedSummaryModels.qll
+++ b/csharp/ql/src/utils/modelgenerator/internal/CaptureTypeBasedSummaryModels.qll
@@ -177,15 +177,13 @@ private predicate output(Callable callable, TypeParameter tp, string output) {
   delegateSink(callable, tp, output)
 }
 
-private module ModelPrintingInput implements ModelPrintingSig {
+private module ModelPrintingInput implements ModelPrintingSummarySig {
   class SummaryApi = TypeBasedFlowTargetApi;
-
-  class SourceOrSinkApi = TypeBasedFlowTargetApi;
 
   string getProvenance() { result = "tb-generated" }
 }
 
-private module Printing = ModelPrinting<ModelPrintingInput>;
+private module Printing = ModelPrintingSummary<ModelPrintingInput>;
 
 /**
  * A class of callables that are relevant generating summaries for based

--- a/csharp/ql/test/utils/modelgenerator/dataflow/CaptureContentSummaryModels.ql
+++ b/csharp/ql/test/utils/modelgenerator/dataflow/CaptureContentSummaryModels.ql
@@ -1,5 +1,6 @@
 import csharp
 import utils.modelgenerator.internal.CaptureModels
+import SummaryModels
 import utils.test.InlineMadTest
 
 module InlineMadTestConfig implements InlineMadTestConfigSig {

--- a/csharp/ql/test/utils/modelgenerator/dataflow/CaptureHeuristicSummaryModels.ql
+++ b/csharp/ql/test/utils/modelgenerator/dataflow/CaptureHeuristicSummaryModels.ql
@@ -1,5 +1,6 @@
 import csharp
 import utils.modelgenerator.internal.CaptureModels
+import SummaryModels
 import utils.test.InlineMadTest
 
 module InlineMadTestConfig implements InlineMadTestConfigSig {

--- a/csharp/ql/test/utils/modelgenerator/dataflow/CaptureNeutralModels.ql
+++ b/csharp/ql/test/utils/modelgenerator/dataflow/CaptureNeutralModels.ql
@@ -1,5 +1,6 @@
 import csharp
 import utils.modelgenerator.internal.CaptureModels
+import SummaryModels
 import utils.test.InlineMadTest
 
 module InlineMadTestConfig implements InlineMadTestConfigSig {

--- a/csharp/ql/test/utils/modelgenerator/dataflow/CaptureSinkModels.ql
+++ b/csharp/ql/test/utils/modelgenerator/dataflow/CaptureSinkModels.ql
@@ -1,5 +1,6 @@
 import csharp
 import utils.modelgenerator.internal.CaptureModels
+import SinkModels
 import utils.test.InlineMadTest
 
 module InlineMadTestConfig implements InlineMadTestConfigSig {

--- a/csharp/ql/test/utils/modelgenerator/dataflow/CaptureSourceModels.ql
+++ b/csharp/ql/test/utils/modelgenerator/dataflow/CaptureSourceModels.ql
@@ -1,5 +1,6 @@
 import csharp
 import utils.modelgenerator.internal.CaptureModels
+import SourceModels
 import utils.test.InlineMadTest
 
 module InlineMadTestConfig implements InlineMadTestConfigSig {

--- a/java/ql/src/utils/modelgenerator/CaptureContentSummaryModels.ql
+++ b/java/ql/src/utils/modelgenerator/CaptureContentSummaryModels.ql
@@ -7,6 +7,7 @@
  */
 
 import internal.CaptureModels
+import SummaryModels
 
 from DataFlowSummaryTargetApi api, string flow
 where flow = ContentSensitive::captureFlow(api, _)

--- a/java/ql/src/utils/modelgenerator/CaptureNeutralModels.ql
+++ b/java/ql/src/utils/modelgenerator/CaptureNeutralModels.ql
@@ -7,6 +7,7 @@
  */
 
 import internal.CaptureModels
+import SummaryModels
 
 from DataFlowSummaryTargetApi api, string noflow
 where noflow = captureNeutral(api)

--- a/java/ql/src/utils/modelgenerator/CaptureSinkModels.ql
+++ b/java/ql/src/utils/modelgenerator/CaptureSinkModels.ql
@@ -7,6 +7,7 @@
  */
 
 import internal.CaptureModels
+import SinkModels
 
 from DataFlowSinkTargetApi api, string sink
 where sink = Heuristic::captureSink(api)

--- a/java/ql/src/utils/modelgenerator/CaptureSourceModels.ql
+++ b/java/ql/src/utils/modelgenerator/CaptureSourceModels.ql
@@ -7,6 +7,7 @@
  */
 
 import internal.CaptureModels
+import SourceModels
 
 from DataFlowSourceTargetApi api, string source
 where source = Heuristic::captureSource(api)

--- a/java/ql/src/utils/modelgenerator/CaptureSummaryModels.ql
+++ b/java/ql/src/utils/modelgenerator/CaptureSummaryModels.ql
@@ -7,6 +7,7 @@
  */
 
 import internal.CaptureModels
+import SummaryModels
 
 from DataFlowSummaryTargetApi api, string flow
 where flow = captureFlow(api, _)

--- a/java/ql/src/utils/modelgenerator/debug/CaptureSummaryModelsPartialPath.ql
+++ b/java/ql/src/utils/modelgenerator/debug/CaptureSummaryModelsPartialPath.ql
@@ -11,6 +11,7 @@
 import java
 import semmle.code.java.dataflow.DataFlow
 import utils.modelgenerator.internal.CaptureModels
+import SummaryModels
 import PartialFlow::PartialPathGraph
 
 int explorationLimit() { result = 3 }

--- a/java/ql/src/utils/modelgenerator/debug/CaptureSummaryModelsPath.ql
+++ b/java/ql/src/utils/modelgenerator/debug/CaptureSummaryModelsPath.ql
@@ -11,6 +11,7 @@
 import java
 import semmle.code.java.dataflow.DataFlow
 import utils.modelgenerator.internal.CaptureModels
+import SummaryModels
 import Heuristic
 import PropagateFlow::PathGraph
 

--- a/java/ql/src/utils/modelgenerator/internal/CaptureModels.qll
+++ b/java/ql/src/utils/modelgenerator/internal/CaptureModels.qll
@@ -211,8 +211,6 @@ module SummaryModelGeneratorInput implements SummaryModelGeneratorInputSig {
     api.getDeclaringType() instanceof J::Interface and not exists(api.getBody())
   }
 
-  predicate isUninterestingForHeuristicDataFlowModels(Callable api) { none() }
-
   predicate isAdditionalContentFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
     TaintTracking::defaultAdditionalTaintStep(node1, node2, _) and
     not exists(DataFlow::Content f |
@@ -263,11 +261,6 @@ private module SourceModelGeneratorInput implements SourceModelGeneratorInputSig
   class SourceTargetApi extends Callable {
     SourceTargetApi() { relevant(this) and not hasManualSourceModel(this) }
   }
-
-  predicate irrelevantSourceSinkApi(Callable source, SourceTargetApi api) { none() }
-
-  bindingset[kind]
-  predicate isRelevantSourceKind(string kind) { any() }
 
   predicate sourceNode = ExternalFlow::sourceNode/2;
 }

--- a/java/ql/src/utils/modelgenerator/internal/CaptureModels.qll
+++ b/java/ql/src/utils/modelgenerator/internal/CaptureModels.qll
@@ -25,7 +25,20 @@ predicate isPrimitiveTypeUsedForBulkData(J::Type t) {
   t.hasName(["byte", "char", "Byte", "Character"])
 }
 
-module ModelGeneratorInput implements ModelGeneratorInputSig<Location, JavaDataFlow> {
+private predicate isInfrequentlyUsed(J::CompilationUnit cu) {
+  cu.getPackage().getName().matches("javax.swing%") or
+  cu.getPackage().getName().matches("java.awt%")
+}
+
+private predicate relevant(Callable api) {
+  api.isPublic() and
+  api.getDeclaringType().isPublic() and
+  api.fromSource() and
+  not isUninterestingForModels(api) and
+  not isInfrequentlyUsed(api.getCompilationUnit())
+}
+
+module ModelGeneratorCommonInput implements ModelGeneratorCommonInputSig<Location, JavaDataFlow> {
   class Type = J::Type;
 
   class Parameter = J::Parameter;
@@ -34,95 +47,7 @@ module ModelGeneratorInput implements ModelGeneratorInputSig<Location, JavaDataF
 
   class NodeExtended = DataFlow::Node;
 
-  Callable getAsExprEnclosingCallable(NodeExtended node) {
-    result = node.asExpr().getEnclosingCallable()
-  }
-
   Callable getEnclosingCallable(NodeExtended node) { result = node.getEnclosingCallable() }
-
-  Parameter asParameter(NodeExtended node) { result = node.asParameter() }
-
-  private predicate isInfrequentlyUsed(J::CompilationUnit cu) {
-    cu.getPackage().getName().matches("javax.swing%") or
-    cu.getPackage().getName().matches("java.awt%")
-  }
-
-  private predicate relevant(Callable api) {
-    api.isPublic() and
-    api.getDeclaringType().isPublic() and
-    api.fromSource() and
-    not isUninterestingForModels(api) and
-    not isInfrequentlyUsed(api.getCompilationUnit())
-  }
-
-  private J::Method getARelevantOverride(J::Method m) {
-    result = m.getAnOverride() and
-    relevant(result) and
-    // Other exclusions for overrides.
-    not m instanceof J::ToStringMethod
-  }
-
-  /**
-   * Gets the super implementation of `m` if it is relevant.
-   * If such a super implementations does not exist, returns `m` if it is relevant.
-   */
-  private J::Callable liftedImpl(J::Callable m) {
-    (
-      result = getARelevantOverride(m)
-      or
-      result = m and relevant(m)
-    ) and
-    not exists(getARelevantOverride(result))
-  }
-
-  private predicate hasManualSummaryModel(Callable api) {
-    api = any(FlowSummaryImpl::Public::SummarizedCallable sc | sc.applyManualModel()).asCallable() or
-    api = any(FlowSummaryImpl::Public::NeutralSummaryCallable sc | sc.hasManualModel()).asCallable()
-  }
-
-  private predicate hasManualSourceModel(Callable api) {
-    api = any(ExternalFlow::SourceCallable sc | sc.hasManualModel()) or
-    api = any(FlowSummaryImpl::Public::NeutralSourceCallable sc | sc.hasManualModel()).asCallable()
-  }
-
-  private predicate hasManualSinkModel(Callable api) {
-    api = any(ExternalFlow::SinkCallable sc | sc.hasManualModel()) or
-    api = any(FlowSummaryImpl::Public::NeutralSinkCallable sc | sc.hasManualModel()).asCallable()
-  }
-
-  predicate isUninterestingForDataFlowModels(Callable api) {
-    api.getDeclaringType() instanceof J::Interface and not exists(api.getBody())
-  }
-
-  predicate isUninterestingForHeuristicDataFlowModels(Callable api) { none() }
-
-  class SourceOrSinkTargetApi extends Callable {
-    SourceOrSinkTargetApi() { relevant(this) }
-  }
-
-  class SinkTargetApi extends SourceOrSinkTargetApi {
-    SinkTargetApi() { not hasManualSinkModel(this) }
-  }
-
-  class SourceTargetApi extends SourceOrSinkTargetApi {
-    SourceTargetApi() { not hasManualSourceModel(this) }
-  }
-
-  class SummaryTargetApi extends Callable {
-    private Callable lift;
-
-    SummaryTargetApi() {
-      lift = liftedImpl(this) and
-      not hasManualSummaryModel(lift)
-    }
-
-    Callable lift() { result = lift }
-
-    predicate isRelevant() {
-      relevant(this) and
-      not hasManualSummaryModel(this)
-    }
-  }
 
   private string isExtensible(Callable c) {
     if c.getDeclaringType().isFinal() then result = "false" else result = "true"
@@ -204,49 +129,89 @@ module ModelGeneratorInput implements ModelGeneratorInputSig<Location, JavaDataF
     node.asExpr().(J::ThisAccess).isOwnInstanceAccess()
   }
 
-  predicate sinkModelSanitizer(DataFlow::Node node) {
-    // exclude variable capture jump steps
-    exists(Ssa::SsaImplicitInit closure |
-      closure.captures(_) and
-      node.asExpr() = closure.getAFirstUse()
-    )
-  }
-
-  predicate apiSource(DataFlow::Node source) {
-    (
-      source.asExpr().(J::FieldAccess).isOwnFieldAccess() or
-      source instanceof DataFlow::ParameterNode
-    ) and
-    exists(J::RefType t |
-      t = source.getEnclosingCallable().getDeclaringType().getAnAncestor() and
-      not t instanceof J::TypeObject and
-      t.isPublic()
-    )
-  }
-
-  predicate irrelevantSourceSinkApi(Callable source, SourceTargetApi api) { none() }
-
-  string getInputArgument(DataFlow::Node source) {
-    exists(int pos |
-      source.(DataFlow::ParameterNode).isParameterOf(_, pos) and
-      if pos >= 0 then result = "Argument[" + pos + "]" else result = qualifierString()
-    )
-    or
-    source.asExpr() instanceof J::FieldAccess and
-    result = qualifierString()
-  }
-
-  bindingset[kind]
-  predicate isRelevantSinkKind(string kind) {
-    not kind = "log-injection" and
-    not kind.matches("regex-use%") and
-    not kind = "file-content-store"
-  }
-
-  bindingset[kind]
-  predicate isRelevantSourceKind(string kind) { any() }
-
   predicate containerContent = DataFlowPrivate::containerContent/1;
+
+  string partialModelRow(Callable api, int i) {
+    i = 0 and qualifiedName(api, result, _) // package
+    or
+    i = 1 and qualifiedName(api, _, result) // type
+    or
+    i = 2 and result = isExtensible(api) // extensible
+    or
+    i = 3 and result = api.getName() // name
+    or
+    i = 4 and result = ExternalFlow::paramsString(api) // parameters
+    or
+    i = 5 and result = "" and exists(api) // ext
+  }
+
+  string partialNeutralModelRow(Callable api, int i) {
+    i = 0 and qualifiedName(api, result, _) // package
+    or
+    i = 1 and qualifiedName(api, _, result) // type
+    or
+    i = 2 and result = api.getName() // name
+    or
+    i = 3 and result = ExternalFlow::paramsString(api) // parameters
+  }
+}
+
+private import ModelGeneratorCommonInput
+private import MakeModelGeneratorFactory<Location, JavaDataFlow, JavaTaintTracking, ModelGeneratorCommonInput>
+
+module SummaryModelGeneratorInput implements SummaryModelGeneratorInputSig {
+  Callable getAsExprEnclosingCallable(NodeExtended node) {
+    result = node.asExpr().getEnclosingCallable()
+  }
+
+  Parameter asParameter(NodeExtended node) { result = node.asParameter() }
+
+  private J::Method getARelevantOverride(J::Method m) {
+    result = m.getAnOverride() and
+    relevant(result) and
+    // Other exclusions for overrides.
+    not m instanceof J::ToStringMethod
+  }
+
+  /**
+   * Gets the super implementation of `m` if it is relevant.
+   * If such a super implementations does not exist, returns `m` if it is relevant.
+   */
+  private J::Callable liftedImpl(J::Callable m) {
+    (
+      result = getARelevantOverride(m)
+      or
+      result = m and relevant(m)
+    ) and
+    not exists(getARelevantOverride(result))
+  }
+
+  private predicate hasManualSummaryModel(Callable api) {
+    api = any(FlowSummaryImpl::Public::SummarizedCallable sc | sc.applyManualModel()).asCallable() or
+    api = any(FlowSummaryImpl::Public::NeutralSummaryCallable sc | sc.hasManualModel()).asCallable()
+  }
+
+  class SummaryTargetApi extends Callable {
+    private Callable lift;
+
+    SummaryTargetApi() {
+      lift = liftedImpl(this) and
+      not hasManualSummaryModel(lift)
+    }
+
+    Callable lift() { result = lift }
+
+    predicate isRelevant() {
+      relevant(this) and
+      not hasManualSummaryModel(this)
+    }
+  }
+
+  predicate isUninterestingForDataFlowModels(Callable api) {
+    api.getDeclaringType() instanceof J::Interface and not exists(api.getBody())
+  }
+
+  predicate isUninterestingForHeuristicDataFlowModels(Callable api) { none() }
 
   predicate isAdditionalContentFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
     TaintTracking::defaultAdditionalTaintStep(node1, node2, _) and
@@ -287,34 +252,76 @@ module ModelGeneratorInput implements ModelGeneratorInputSig<Location, JavaDataF
     or
     c instanceof DataFlowUtil::MapKeyContent and result = "MapKey"
   }
+}
 
-  string partialModelRow(Callable api, int i) {
-    i = 0 and qualifiedName(api, result, _) // package
-    or
-    i = 1 and qualifiedName(api, _, result) // type
-    or
-    i = 2 and result = isExtensible(api) // extensible
-    or
-    i = 3 and result = api.getName() // name
-    or
-    i = 4 and result = ExternalFlow::paramsString(api) // parameters
-    or
-    i = 5 and result = "" and exists(api) // ext
+private module SourceModelGeneratorInput implements SourceModelGeneratorInputSig {
+  private predicate hasManualSourceModel(Callable api) {
+    api = any(ExternalFlow::SourceCallable sc | sc.hasManualModel()) or
+    api = any(FlowSummaryImpl::Public::NeutralSourceCallable sc | sc.hasManualModel()).asCallable()
   }
 
-  string partialNeutralModelRow(Callable api, int i) {
-    i = 0 and qualifiedName(api, result, _) // package
-    or
-    i = 1 and qualifiedName(api, _, result) // type
-    or
-    i = 2 and result = api.getName() // name
-    or
-    i = 3 and result = ExternalFlow::paramsString(api) // parameters
+  class SourceTargetApi extends Callable {
+    SourceTargetApi() { relevant(this) and not hasManualSourceModel(this) }
   }
+
+  predicate irrelevantSourceSinkApi(Callable source, SourceTargetApi api) { none() }
+
+  bindingset[kind]
+  predicate isRelevantSourceKind(string kind) { any() }
 
   predicate sourceNode = ExternalFlow::sourceNode/2;
+}
+
+private module SinkModelGeneratorInput implements SinkModelGeneratorInputSig {
+  private predicate hasManualSinkModel(Callable api) {
+    api = any(ExternalFlow::SinkCallable sc | sc.hasManualModel()) or
+    api = any(FlowSummaryImpl::Public::NeutralSinkCallable sc | sc.hasManualModel()).asCallable()
+  }
+
+  class SinkTargetApi extends Callable {
+    SinkTargetApi() { relevant(this) and not hasManualSinkModel(this) }
+  }
+
+  predicate sinkModelSanitizer(DataFlow::Node node) {
+    // exclude variable capture jump steps
+    exists(Ssa::SsaImplicitInit closure |
+      closure.captures(_) and
+      node.asExpr() = closure.getAFirstUse()
+    )
+  }
+
+  predicate apiSource(DataFlow::Node source) {
+    (
+      source.asExpr().(J::FieldAccess).isOwnFieldAccess() or
+      source instanceof DataFlow::ParameterNode
+    ) and
+    exists(J::RefType t |
+      t = source.getEnclosingCallable().getDeclaringType().getAnAncestor() and
+      not t instanceof J::TypeObject and
+      t.isPublic()
+    )
+  }
+
+  string getInputArgument(DataFlow::Node source) {
+    exists(int pos |
+      source.(DataFlow::ParameterNode).isParameterOf(_, pos) and
+      if pos >= 0 then result = "Argument[" + pos + "]" else result = qualifierString()
+    )
+    or
+    source.asExpr() instanceof J::FieldAccess and
+    result = qualifierString()
+  }
+
+  bindingset[kind]
+  predicate isRelevantSinkKind(string kind) {
+    not kind = "log-injection" and
+    not kind.matches("regex-use%") and
+    not kind = "file-content-store"
+  }
 
   predicate sinkNode = ExternalFlow::sinkNode/2;
 }
 
-import MakeModelGenerator<Location, JavaDataFlow, JavaTaintTracking, ModelGeneratorInput>
+import MakeSummaryModelGenerator<SummaryModelGeneratorInput> as SummaryModels
+import MakeSourceModelGenerator<SourceModelGeneratorInput> as SourceModels
+import MakeSinkModelGenerator<SinkModelGeneratorInput> as SinkModels

--- a/java/ql/src/utils/modelgenerator/internal/CaptureModelsPrinting.qll
+++ b/java/ql/src/utils/modelgenerator/internal/CaptureModelsPrinting.qll
@@ -1,6 +1,6 @@
 private import java as J
 private import codeql.mad.modelgenerator.internal.ModelPrinting
-private import CaptureModels::ModelGeneratorInput as ModelGeneratorInput
+private import CaptureModels::ModelGeneratorCommonInput as ModelGeneratorInput
 
 private module ModelPrintingLang implements ModelPrintingLangSig {
   class Callable = J::Callable;

--- a/java/ql/src/utils/modelgenerator/internal/CaptureTypeBasedSummaryModels.qll
+++ b/java/ql/src/utils/modelgenerator/internal/CaptureTypeBasedSummaryModels.qll
@@ -284,15 +284,13 @@ private predicate output(Callable callable, TypeVariable tv, string output) {
   functionalSink(callable, tv, output)
 }
 
-module ModelPrintingInput implements ModelPrintingSig {
+module ModelPrintingInput implements ModelPrintingSummarySig {
   class SummaryApi = TypeBasedFlowTargetApi;
-
-  class SourceOrSinkApi = ModelGeneratorInput::SourceOrSinkTargetApi;
 
   string getProvenance() { result = "tb-generated" }
 }
 
-private module Printing = ModelPrinting<ModelPrintingInput>;
+private module Printing = ModelPrintingSummary<ModelPrintingInput>;
 
 /**
  * A class of callables that are relevant generating summaries for based

--- a/java/ql/src/utils/modelgenerator/internal/CaptureTypeBasedSummaryModels.qll
+++ b/java/ql/src/utils/modelgenerator/internal/CaptureTypeBasedSummaryModels.qll
@@ -2,7 +2,8 @@ private import java
 private import semmle.code.java.Collections
 private import semmle.code.java.dataflow.internal.ContainerFlow
 private import CaptureModels as CaptureModels
-private import CaptureModels::ModelGeneratorInput as ModelGeneratorInput
+private import CaptureModels::ModelGeneratorCommonInput as ModelGeneratorInput
+private import CaptureModels::SummaryModelGeneratorInput as SummaryModelGeneratorInput
 private import CaptureModelsPrinting
 
 /**
@@ -296,7 +297,7 @@ private module Printing = ModelPrintingSummary<ModelPrintingInput>;
  * A class of callables that are relevant generating summaries for based
  * on the Theorems for Free approach.
  */
-class TypeBasedFlowTargetApi extends ModelGeneratorInput::SummaryTargetApi {
+class TypeBasedFlowTargetApi extends SummaryModelGeneratorInput::SummaryTargetApi {
   /**
    * Gets the string representation of all type based summaries for `this`
    * inspired by the Theorems for Free approach.

--- a/java/ql/test/utils/modelgenerator/dataflow/CaptureContentSummaryModels.ql
+++ b/java/ql/test/utils/modelgenerator/dataflow/CaptureContentSummaryModels.ql
@@ -1,5 +1,6 @@
 import java
 import utils.modelgenerator.internal.CaptureModels
+import SummaryModels
 import utils.test.InlineMadTest
 
 module InlineMadTestConfig implements InlineMadTestConfigSig {

--- a/java/ql/test/utils/modelgenerator/dataflow/CaptureHeuristicSummaryModels.ql
+++ b/java/ql/test/utils/modelgenerator/dataflow/CaptureHeuristicSummaryModels.ql
@@ -1,5 +1,6 @@
 import java
 import utils.modelgenerator.internal.CaptureModels
+import SummaryModels
 import utils.test.InlineMadTest
 
 module InlineMadTestConfig implements InlineMadTestConfigSig {

--- a/java/ql/test/utils/modelgenerator/dataflow/CaptureNeutralModels.ql
+++ b/java/ql/test/utils/modelgenerator/dataflow/CaptureNeutralModels.ql
@@ -1,5 +1,6 @@
 import java
 import utils.modelgenerator.internal.CaptureModels
+import SummaryModels
 import utils.test.InlineMadTest
 
 module InlineMadTestConfig implements InlineMadTestConfigSig {

--- a/java/ql/test/utils/modelgenerator/dataflow/CaptureSinkModels.ql
+++ b/java/ql/test/utils/modelgenerator/dataflow/CaptureSinkModels.ql
@@ -1,5 +1,6 @@
 import java
 import utils.modelgenerator.internal.CaptureModels
+import SinkModels
 import utils.test.InlineMadTest
 
 module InlineMadTestConfig implements InlineMadTestConfigSig {

--- a/java/ql/test/utils/modelgenerator/dataflow/CaptureSourceModels.ql
+++ b/java/ql/test/utils/modelgenerator/dataflow/CaptureSourceModels.ql
@@ -1,5 +1,6 @@
 import java
 import utils.modelgenerator.internal.CaptureModels
+import SourceModels
 import utils.test.InlineMadTest
 
 module InlineMadTestConfig implements InlineMadTestConfigSig {

--- a/rust/ql/src/utils/modelgenerator/CaptureContentSummaryModels.ql
+++ b/rust/ql/src/utils/modelgenerator/CaptureContentSummaryModels.ql
@@ -7,6 +7,7 @@
  */
 
 import internal.CaptureModels
+import SummaryModels
 
 from DataFlowSummaryTargetApi api, string flow
 where flow = ContentSensitive::captureFlow(api, _)

--- a/rust/ql/src/utils/modelgenerator/CaptureNeutralModels.ql
+++ b/rust/ql/src/utils/modelgenerator/CaptureNeutralModels.ql
@@ -7,6 +7,7 @@
  */
 
 import internal.CaptureModels
+import SummaryModels
 
 from DataFlowSummaryTargetApi api, string noflow
 where noflow = Heuristic::captureNoFlow(api)

--- a/rust/ql/src/utils/modelgenerator/CaptureSinkModels.ql
+++ b/rust/ql/src/utils/modelgenerator/CaptureSinkModels.ql
@@ -7,6 +7,7 @@
  */
 
 import internal.CaptureModels
+import SinkModels
 
 from DataFlowSinkTargetApi api, string sink
 where sink = Heuristic::captureSink(api)

--- a/rust/ql/src/utils/modelgenerator/CaptureSourceModels.ql
+++ b/rust/ql/src/utils/modelgenerator/CaptureSourceModels.ql
@@ -7,6 +7,7 @@
  */
 
 import internal.CaptureModels
+import SourceModels
 
 from DataFlowSourceTargetApi api, string source
 where source = Heuristic::captureSource(api)

--- a/rust/ql/src/utils/modelgenerator/CaptureSummaryModels.ql
+++ b/rust/ql/src/utils/modelgenerator/CaptureSummaryModels.ql
@@ -7,6 +7,7 @@
  */
 
 import internal.CaptureModels
+import SummaryModels
 
 from DataFlowSummaryTargetApi api, string flow
 where flow = captureFlow(api, _)

--- a/rust/ql/src/utils/modelgenerator/debug/CaptureSummaryModelsPartialPath.ql
+++ b/rust/ql/src/utils/modelgenerator/debug/CaptureSummaryModelsPartialPath.ql
@@ -10,6 +10,7 @@
 
 private import codeql.rust.dataflow.DataFlow
 import utils.modelgenerator.internal.CaptureModels
+import SummaryModels
 import PartialFlow::PartialPathGraph
 
 int explorationLimit() { result = 3 }

--- a/rust/ql/src/utils/modelgenerator/debug/CaptureSummaryModelsPath.ql
+++ b/rust/ql/src/utils/modelgenerator/debug/CaptureSummaryModelsPath.ql
@@ -10,6 +10,7 @@
 
 private import codeql.rust.dataflow.DataFlow
 import utils.modelgenerator.internal.CaptureModels
+import SummaryModels
 import Heuristic
 import PropagateFlow::PathGraph
 

--- a/rust/ql/src/utils/modelgenerator/internal/CaptureModels.qll
+++ b/rust/ql/src/utils/modelgenerator/internal/CaptureModels.qll
@@ -123,10 +123,6 @@ private module SummaryModelGeneratorInput implements SummaryModelGeneratorInputS
 
   Parameter asParameter(NodeExtended node) { result = node.asParameter() }
 
-  predicate isUninterestingForDataFlowModels(Callable api) { none() }
-
-  predicate isUninterestingForHeuristicDataFlowModels(Callable api) { none() }
-
   predicate isAdditionalContentFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) { none() }
 
   predicate isField(DataFlow::ContentSet c) {
@@ -169,12 +165,6 @@ private module SourceModelGeneratorInput implements SourceModelGeneratorInputSig
     SourceTargetApi() { relevant(this) }
   }
 
-  bindingset[sourceEnclosing, api]
-  predicate irrelevantSourceSinkApi(Callable sourceEnclosing, SourceTargetApi api) { none() }
-
-  bindingset[kind]
-  predicate isRelevantSourceKind(string kind) { any() }
-
   predicate sourceNode(DataFlow::Node node, string kind) { FlowSource::sourceNode(node, kind) }
 }
 
@@ -182,8 +172,6 @@ private module SinkModelGeneratorInput implements SinkModelGeneratorInputSig {
   class SinkTargetApi extends Callable {
     SinkTargetApi() { relevant(this) }
   }
-
-  predicate sinkModelSanitizer(DataFlow::Node node) { none() }
 
   /**
    * Holds if `source` is an API entrypoint, i.e., a source of input where data
@@ -196,9 +184,6 @@ private module SinkModelGeneratorInput implements SinkModelGeneratorInputSig {
   string getInputArgument(DataFlow::Node source) {
     result = "Argument[" + source.(Node::SourceParameterNode).getPosition().toString() + "]"
   }
-
-  bindingset[kind]
-  predicate isRelevantSinkKind(string kind) { any() }
 
   predicate sinkNode(DataFlow::Node node, string kind) { FlowSink::sinkNode(node, kind) }
 }

--- a/rust/ql/src/utils/modelgenerator/internal/CaptureModels.qll
+++ b/rust/ql/src/utils/modelgenerator/internal/CaptureModels.qll
@@ -2,7 +2,7 @@ private import codeql.util.Unit
 private import rust
 private import rust as R
 private import codeql.rust.dataflow.DataFlow
-private import codeql.rust.dataflow.internal.DataFlowImpl
+private import codeql.rust.dataflow.internal.DataFlowImpl as DataFlowImpl
 private import codeql.rust.dataflow.internal.Node as Node
 private import codeql.rust.dataflow.internal.Content
 private import codeql.rust.dataflow.FlowSource as FlowSource
@@ -11,7 +11,25 @@ private import codeql.rust.dataflow.internal.TaintTrackingImpl
 private import codeql.mad.modelgenerator.internal.ModelGeneratorImpl
 private import codeql.rust.dataflow.internal.FlowSummaryImpl as FlowSummary
 
-module ModelGeneratorInput implements ModelGeneratorInputSig<Location, RustDataFlow> {
+private predicate relevant(Function api) {
+  // Only include functions that have a resolved path.
+  api.hasCrateOrigin() and
+  api.hasExtendedCanonicalPath() and
+  (
+    // This excludes closures (these are not exported API endpoints) and
+    // functions without a `pub` visiblity. A function can be `pub` without
+    // ultimately being exported by a crate, so this is an overapproximation.
+    api.hasVisibility()
+    or
+    // If a method implements a public trait it is exposed through the trait.
+    // We overapproximate this by including all trait method implementations.
+    exists(Impl impl | impl.hasTrait() and impl.getAssocItemList().getAssocItem(_) = api)
+  )
+}
+
+module ModelGeneratorCommonInput implements
+  ModelGeneratorCommonInputSig<Location, DataFlowImpl::RustDataFlow>
+{
   // NOTE: We are not using type information for now.
   class Type = Unit;
 
@@ -23,42 +41,71 @@ module ModelGeneratorInput implements ModelGeneratorInputSig<Location, RustDataF
     Type getType() { any() }
   }
 
-  Callable getAsExprEnclosingCallable(NodeExtended node) { result = node.asExpr().getScope() }
-
   Callable getEnclosingCallable(NodeExtended node) {
     result = node.(Node::Node).getEnclosingCallable().asCfgScope()
   }
 
-  Parameter asParameter(NodeExtended node) { result = node.asParameter() }
+  predicate isRelevantType(Type t) { any() }
 
-  private predicate relevant(Function api) {
-    // Only include functions that have a resolved path.
-    api.hasCrateOrigin() and
-    api.hasExtendedCanonicalPath() and
-    (
-      // This excludes closures (these are not exported API endpoints) and
-      // functions without a `pub` visiblity. A function can be `pub` without
-      // ultimately being exported by a crate, so this is an overapproximation.
-      api.hasVisibility()
-      or
-      // If a method implements a public trait it is exposed through the trait.
-      // We overapproximate this by including all trait method implementations.
-      exists(Impl impl | impl.hasTrait() and impl.getAssocItemList().getAssocItem(_) = api)
-    )
+  /**
+   * Gets the underlying type of the content `c`.
+   */
+  Type getUnderlyingContentType(DataFlow::ContentSet c) { result = any(Type t) and exists(c) }
+
+  string qualifierString() { result = "Argument[self]" }
+
+  string parameterAccess(R::ParamBase p) {
+    result =
+      "Argument[" + any(DataFlowImpl::ParameterPosition pos | p = pos.getParameterIn(_)).toString() +
+        "]"
   }
 
-  predicate isUninterestingForDataFlowModels(Callable api) { none() }
+  string parameterContentAccess(R::ParamBase p) { result = parameterAccess(p) }
 
-  predicate isUninterestingForHeuristicDataFlowModels(Callable api) { none() }
-
-  class SourceOrSinkTargetApi extends Callable {
-    SourceOrSinkTargetApi() { relevant(this) }
+  class InstanceParameterNode extends DataFlow::ParameterNode {
+    InstanceParameterNode() { this.asParameter() instanceof SelfParam }
   }
 
-  class SinkTargetApi extends SourceOrSinkTargetApi { }
+  bindingset[c]
+  string paramReturnNodeAsOutput(Callable c, DataFlowImpl::ParameterPosition pos) {
+    result = paramReturnNodeAsContentOutput(c, pos)
+  }
 
-  class SourceTargetApi extends SourceOrSinkTargetApi { }
+  bindingset[c]
+  string paramReturnNodeAsContentOutput(Callable c, DataFlowImpl::ParameterPosition pos) {
+    result = parameterContentAccess(c.getParamList().getParam(pos.getPosition()))
+    or
+    pos.isSelf() and result = qualifierString()
+  }
 
+  Callable returnNodeEnclosingCallable(DataFlow::Node ret) {
+    result = ret.(Node::Node).getEnclosingCallable().asCfgScope()
+  }
+
+  predicate isOwnInstanceAccessNode(DataFlowImpl::RustDataFlow::ReturnNode node) {
+    // This is probably not relevant to implement for Rust, as we only use
+    // `captureMixedFlow` which doesn't explicitly distinguish between
+    // functions that return `self` and those that don't.
+    none()
+  }
+
+  predicate containerContent(DataFlow::ContentSet c) {
+    c.(SingletonContentSet).getContent() instanceof ElementContent
+  }
+
+  string partialModelRow(Callable api, int i) {
+    i = 0 and result = api.(Function).getCrateOrigin() // crate
+    or
+    i = 1 and result = api.(Function).getExtendedCanonicalPath() // name
+  }
+
+  string partialNeutralModelRow(Callable api, int i) { result = partialModelRow(api, i) }
+}
+
+private import ModelGeneratorCommonInput
+private import MakeModelGeneratorFactory<Location, DataFlowImpl::RustDataFlow, RustTaintTracking, ModelGeneratorCommonInput>
+
+private module SummaryModelGeneratorInput implements SummaryModelGeneratorInputSig {
   class SummaryTargetApi extends Callable {
     private Callable lift;
 
@@ -72,74 +119,13 @@ module ModelGeneratorInput implements ModelGeneratorInputSig<Location, RustDataF
     predicate isRelevant() { relevant(this) }
   }
 
-  predicate isRelevantType(Type t) { any() }
+  Callable getAsExprEnclosingCallable(NodeExtended node) { result = node.asExpr().getScope() }
 
-  /**
-   * Gets the underlying type of the content `c`.
-   */
-  Type getUnderlyingContentType(DataFlow::ContentSet c) { result = any(Type t) and exists(c) }
+  Parameter asParameter(NodeExtended node) { result = node.asParameter() }
 
-  string qualifierString() { result = "Argument[self]" }
+  predicate isUninterestingForDataFlowModels(Callable api) { none() }
 
-  string parameterAccess(R::ParamBase p) {
-    result = "Argument[" + any(ParameterPosition pos | p = pos.getParameterIn(_)).toString() + "]"
-  }
-
-  string parameterContentAccess(R::ParamBase p) { result = parameterAccess(p) }
-
-  class InstanceParameterNode extends DataFlow::ParameterNode {
-    InstanceParameterNode() { this.asParameter() instanceof SelfParam }
-  }
-
-  bindingset[c]
-  string paramReturnNodeAsOutput(Callable c, ParameterPosition pos) {
-    result = paramReturnNodeAsContentOutput(c, pos)
-  }
-
-  bindingset[c]
-  string paramReturnNodeAsContentOutput(Callable c, ParameterPosition pos) {
-    result = parameterContentAccess(c.getParamList().getParam(pos.getPosition()))
-    or
-    pos.isSelf() and result = qualifierString()
-  }
-
-  Callable returnNodeEnclosingCallable(DataFlow::Node ret) {
-    result = ret.(Node::Node).getEnclosingCallable().asCfgScope()
-  }
-
-  predicate isOwnInstanceAccessNode(RustDataFlow::ReturnNode node) {
-    // This is probably not relevant to implement for Rust, as we only use
-    // `captureMixedFlow` which doesn't explicitly distinguish between
-    // functions that return `self` and those that don't.
-    none()
-  }
-
-  predicate sinkModelSanitizer(DataFlow::Node node) { none() }
-
-  /**
-   * Holds if `source` is an API entrypoint, i.e., a source of input where data
-   * can flow in to a library. This is used for creating sink models, as we
-   * only want to mark functions as sinks if input to the function can reach
-   * (from an input source) a known sink.
-   */
-  predicate apiSource(DataFlow::Node source) { source instanceof DataFlow::ParameterNode }
-
-  bindingset[sourceEnclosing, api]
-  predicate irrelevantSourceSinkApi(Callable sourceEnclosing, SourceTargetApi api) { none() }
-
-  string getInputArgument(DataFlow::Node source) {
-    result = "Argument[" + source.(Node::SourceParameterNode).getPosition().toString() + "]"
-  }
-
-  bindingset[kind]
-  predicate isRelevantSinkKind(string kind) { any() }
-
-  bindingset[kind]
-  predicate isRelevantSourceKind(string kind) { any() }
-
-  predicate containerContent(DataFlow::ContentSet c) {
-    c.(SingletonContentSet).getContent() instanceof ElementContent
-  }
+  predicate isUninterestingForHeuristicDataFlowModels(Callable api) { none() }
 
   predicate isAdditionalContentFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) { none() }
 
@@ -159,7 +145,7 @@ module ModelGeneratorInput implements ModelGeneratorInputSig<Location, RustDataF
   private string encodeContent(ContentSet cs, string arg) {
     result = FlowSummary::Input::encodeContent(cs, arg)
     or
-    exists(Content c | cs = TSingletonContentSet(c) |
+    exists(Content c | cs = DataFlowImpl::TSingletonContentSet(c) |
       exists(int pos |
         pos = c.(FunctionCallArgumentContent).getPosition() and
         result = "Parameter" and
@@ -176,18 +162,47 @@ module ModelGeneratorInput implements ModelGeneratorInputSig<Location, RustDataF
       if arg = "" then result = name else result = name + "[" + arg + "]"
     )
   }
+}
 
-  string partialModelRow(Callable api, int i) {
-    i = 0 and result = api.(Function).getCrateOrigin() // crate
-    or
-    i = 1 and result = api.(Function).getExtendedCanonicalPath() // name
+private module SourceModelGeneratorInput implements SourceModelGeneratorInputSig {
+  class SourceTargetApi extends Callable {
+    SourceTargetApi() { relevant(this) }
   }
 
-  string partialNeutralModelRow(Callable api, int i) { result = partialModelRow(api, i) }
+  bindingset[sourceEnclosing, api]
+  predicate irrelevantSourceSinkApi(Callable sourceEnclosing, SourceTargetApi api) { none() }
+
+  bindingset[kind]
+  predicate isRelevantSourceKind(string kind) { any() }
 
   predicate sourceNode(DataFlow::Node node, string kind) { FlowSource::sourceNode(node, kind) }
+}
+
+private module SinkModelGeneratorInput implements SinkModelGeneratorInputSig {
+  class SinkTargetApi extends Callable {
+    SinkTargetApi() { relevant(this) }
+  }
+
+  predicate sinkModelSanitizer(DataFlow::Node node) { none() }
+
+  /**
+   * Holds if `source` is an API entrypoint, i.e., a source of input where data
+   * can flow in to a library. This is used for creating sink models, as we
+   * only want to mark functions as sinks if input to the function can reach
+   * (from an input source) a known sink.
+   */
+  predicate apiSource(DataFlow::Node source) { source instanceof DataFlow::ParameterNode }
+
+  string getInputArgument(DataFlow::Node source) {
+    result = "Argument[" + source.(Node::SourceParameterNode).getPosition().toString() + "]"
+  }
+
+  bindingset[kind]
+  predicate isRelevantSinkKind(string kind) { any() }
 
   predicate sinkNode(DataFlow::Node node, string kind) { FlowSink::sinkNode(node, kind) }
 }
 
-import MakeModelGenerator<Location, RustDataFlow, RustTaintTracking, ModelGeneratorInput>
+import MakeSummaryModelGenerator<SummaryModelGeneratorInput> as SummaryModels
+import MakeSourceModelGenerator<SourceModelGeneratorInput> as SourceModels
+import MakeSinkModelGenerator<SinkModelGeneratorInput> as SinkModels

--- a/rust/ql/src/utils/modelgenerator/internal/CaptureModelsPrinting.qll
+++ b/rust/ql/src/utils/modelgenerator/internal/CaptureModelsPrinting.qll
@@ -1,6 +1,6 @@
 private import rust as R
 private import codeql.mad.modelgenerator.internal.ModelPrinting
-private import CaptureModels::ModelGeneratorInput as ModelGeneratorInput
+private import CaptureModels::ModelGeneratorCommonInput as ModelGeneratorInput
 
 private module ModelPrintingLang implements ModelPrintingLangSig {
   class Callable = R::Callable;

--- a/rust/ql/test/utils-tests/modelgenerator/CaptureSinkModels.ql
+++ b/rust/ql/test/utils-tests/modelgenerator/CaptureSinkModels.ql
@@ -1,5 +1,6 @@
 import rust
 import utils.modelgenerator.internal.CaptureModels
+import SinkModels
 import utils.test.InlineMadTest
 
 module InlineMadTestConfig implements InlineMadTestConfigSig {

--- a/rust/ql/test/utils-tests/modelgenerator/CaptureSourceModels.ql
+++ b/rust/ql/test/utils-tests/modelgenerator/CaptureSourceModels.ql
@@ -1,5 +1,6 @@
 import rust
 import utils.modelgenerator.internal.CaptureModels
+import SourceModels
 import utils.test.InlineMadTest
 import codeql.rust.dataflow.internal.ModelsAsData
 

--- a/rust/ql/test/utils-tests/modelgenerator/CaptureSummaryModels.ql
+++ b/rust/ql/test/utils-tests/modelgenerator/CaptureSummaryModels.ql
@@ -1,5 +1,6 @@
 import rust
 import utils.modelgenerator.internal.CaptureModels
+import SummaryModels
 import utils.test.InlineMadTest
 
 module InlineMadTestConfig implements InlineMadTestConfigSig {

--- a/shared/mad/codeql/mad/modelgenerator/internal/ModelGeneratorImpl.qll
+++ b/shared/mad/codeql/mad/modelgenerator/internal/ModelGeneratorImpl.qll
@@ -295,7 +295,7 @@ module MakeModelGeneratorFactory<
      *
      * This serves as an extra filter for the `relevant` predicate.
      */
-    predicate isUninterestingForDataFlowModels(Callable api);
+    default predicate isUninterestingForDataFlowModels(Callable api) { none() }
 
     /**
      * Holds if it is irrelevant to generate models for `api` based on the heuristic
@@ -304,7 +304,7 @@ module MakeModelGeneratorFactory<
      * This serves as an extra filter for the `relevant`
      * and `isUninterestingForDataFlowModels` predicates.
      */
-    predicate isUninterestingForHeuristicDataFlowModels(Callable api);
+    default predicate isUninterestingForHeuristicDataFlowModels(Callable api) { none() }
   }
 
   /**
@@ -941,23 +941,19 @@ module MakeModelGeneratorFactory<
     class SourceTargetApi extends Callable;
 
     /**
-     * Holds if it is not relevant to generate a source model for `api`, even
-     * if flow is detected from a node within `source` to a sink within `api`.
-     */
-    bindingset[sourceEnclosing, api]
-    predicate irrelevantSourceSinkApi(Callable sourceEnclosing, SourceTargetApi api);
-
-    /**
-     * Holds if `kind` is a relevant source kind for creating source models.
-     */
-    bindingset[kind]
-    predicate isRelevantSourceKind(string kind);
-
-    /**
      * Holds if `node` is specified as a source with the given kind in a MaD flow
      * model.
      */
     predicate sourceNode(Lang::Node node, string kind);
+
+    /**
+     * Holds if it is not relevant to generate a source model for `api`, even
+     * if flow is detected from a node within `source` to a sink within `api`.
+     */
+    bindingset[sourceEnclosing, api]
+    default predicate irrelevantSourceSinkApi(Callable sourceEnclosing, SourceTargetApi api) {
+      none()
+    }
   }
 
   /**
@@ -970,14 +966,15 @@ module MakeModelGeneratorFactory<
     class SinkTargetApi extends Callable;
 
     /**
+     * Holds if `node` is specified as a sink with the given kind in a MaD flow
+     * model.
+     */
+    predicate sinkNode(Lang::Node node, string kind);
+
+    /**
      * Gets the MaD input string representation of `source`.
      */
     string getInputArgument(Lang::Node source);
-
-    /**
-     * Holds if `node` is a sanitizer for sink model construction.
-     */
-    predicate sinkModelSanitizer(Lang::Node node);
 
     /**
      * Holds if `source` is an api entrypoint relevant for creating sink models.
@@ -985,16 +982,15 @@ module MakeModelGeneratorFactory<
     predicate apiSource(Lang::Node source);
 
     /**
+     * Holds if `node` is a sanitizer for sink model construction.
+     */
+    default predicate sinkModelSanitizer(Lang::Node node) { none() }
+
+    /**
      * Holds if `kind` is a relevant sink kind for creating sink models.
      */
     bindingset[kind]
-    predicate isRelevantSinkKind(string kind);
-
-    /**
-     * Holds if `node` is specified as a sink with the given kind in a MaD flow
-     * model.
-     */
-    predicate sinkNode(Lang::Node node, string kind);
+    default predicate isRelevantSinkKind(string kind) { any() }
   }
 
   /**
@@ -1029,12 +1025,7 @@ module MakeModelGeneratorFactory<
        * via its return (then the API itself becomes a source).
        */
       module PropagateFromSourceConfig implements DataFlow::ConfigSig {
-        predicate isSource(DataFlow::Node source) {
-          exists(string kind |
-            isRelevantSourceKind(kind) and
-            sourceNode(source, kind)
-          )
-        }
+        predicate isSource(DataFlow::Node source) { sourceNode(source, _) }
 
         predicate isSink(DataFlow::Node sink) {
           sink instanceof ReturnNodeExt and

--- a/shared/mad/codeql/mad/modelgenerator/internal/ModelGeneratorImpl.qll
+++ b/shared/mad/codeql/mad/modelgenerator/internal/ModelGeneratorImpl.qll
@@ -15,7 +15,7 @@ private import ModelPrinting
 /**
  * Provides language-specific model generator parameters.
  */
-signature module ModelGeneratorInputSig<LocationSig Location, InputSig<Location> Lang> {
+signature module ModelGeneratorCommonInputSig<LocationSig Location, InputSig<Location> Lang> {
   /**
    * A Type.
    */
@@ -50,52 +50,6 @@ signature module ModelGeneratorInputSig<LocationSig Location, InputSig<Location>
   Callable getEnclosingCallable(NodeExtended node);
 
   /**
-   * Gets the enclosing callable of `node`, when considered as an expression.
-   */
-  Callable getAsExprEnclosingCallable(NodeExtended node);
-
-  /** Gets the parameter corresponding to this node, if any. */
-  Parameter asParameter(NodeExtended n);
-
-  /**
-   * A class of callables that are potentially relevant for generating summary or
-   * neutral models.
-   *
-   * In the Standard library and 3rd party libraries it is the callables (or callables that have a
-   * super implementation) that can be called from outside the library itself.
-   */
-  class SummaryTargetApi extends Callable {
-    /**
-     * Gets the callable that a model will be lifted to.
-     *
-     * The lifted callable is relevant in terms of model
-     * generation (this is ensured by `liftedImpl`).
-     */
-    Callable lift();
-
-    /**
-     * Holds if `this` is relevant in terms of model generation.
-     */
-    predicate isRelevant();
-  }
-
-  /**
-   * A class of callables that are potentially relevant for generating source or
-   * sink models.
-   */
-  class SourceOrSinkTargetApi extends Callable;
-
-  /**
-   * A class of callables that are potentially relevant for generating source models.
-   */
-  class SourceTargetApi extends SourceOrSinkTargetApi;
-
-  /**
-   * A class of callables that are potentially relevant for generating sink models.
-   */
-  class SinkTargetApi extends SourceOrSinkTargetApi;
-
-  /**
    * An instance parameter node.
    */
   class InstanceParameterNode extends Lang::Node;
@@ -112,22 +66,6 @@ signature module ModelGeneratorInputSig<LocationSig Location, InputSig<Location>
    * Gets the underlying type of the content `c`.
    */
   Type getUnderlyingContentType(Lang::ContentSet c);
-
-  /**
-   * Gets the MaD string representation of the qualifier.
-   */
-  string qualifierString();
-
-  /**
-   * Gets the MaD string representation of the parameter `p`.
-   */
-  string parameterAccess(Parameter p);
-
-  /**
-   * Gets the MaD string representation of the parameter `p`
-   * when used in content flow.
-   */
-  string parameterContentAccess(Parameter p);
 
   /**
    * Gets the MaD string representation of return through parameter at position
@@ -154,68 +92,25 @@ signature module ModelGeneratorInputSig<LocationSig Location, InputSig<Location>
   predicate isOwnInstanceAccessNode(Lang::ReturnNode node);
 
   /**
-   * Holds if `node` is a sanitizer for sink model construction.
+   * Gets the MaD string representation of the parameter `p`.
    */
-  predicate sinkModelSanitizer(Lang::Node node);
+  string parameterAccess(Parameter p);
 
   /**
-   * Holds if `source` is an api entrypoint relevant for creating sink models.
+   * Gets the MaD string representation of the parameter `p`
+   * when used in content flow.
    */
-  predicate apiSource(Lang::Node source);
+  string parameterContentAccess(Parameter p);
 
   /**
-   * Gets the MaD input string representation of `source`.
+   * Gets the MaD string representation of the qualifier.
    */
-  string getInputArgument(Lang::Node source);
-
-  /**
-   * Holds if it is not relevant to generate a source model for `api`, even
-   * if flow is detected from a node within `source` to a sink within `api`.
-   */
-  bindingset[sourceEnclosing, api]
-  predicate irrelevantSourceSinkApi(Callable sourceEnclosing, SourceTargetApi api);
-
-  /**
-   * Holds if `kind` is a relevant sink kind for creating sink models.
-   */
-  bindingset[kind]
-  predicate isRelevantSinkKind(string kind);
-
-  /**
-   * Holds if `kind` is a relevant source kind for creating source models.
-   */
-  bindingset[kind]
-  predicate isRelevantSourceKind(string kind);
+  string qualifierString();
 
   /**
    * Holds if the the content `c` is a container.
    */
   predicate containerContent(Lang::ContentSet c);
-
-  /**
-   * Holds if there is a taint step from `node1` to `node2` in content flow.
-   */
-  predicate isAdditionalContentFlowStep(Lang::Node nodeFrom, Lang::Node nodeTo);
-
-  /**
-   * Holds if the content set `c` is field like.
-   */
-  predicate isField(Lang::ContentSet c);
-
-  /**
-   * Holds if the content set `c` is callback like.
-   */
-  predicate isCallback(Lang::ContentSet c);
-
-  /**
-   * Gets the MaD synthetic name string representation for the content set `c`, if any.
-   */
-  string getSyntheticName(Lang::ContentSet c);
-
-  /**
-   * Gets the MaD string representation of the content set `c`.
-   */
-  string printContent(Lang::ContentSet c);
 
   /**
    * Gets the parameter position of the return kind, if any.
@@ -231,22 +126,6 @@ signature module ModelGeneratorInputSig<LocationSig Location, InputSig<Location>
   default string getReturnValueString(Lang::ReturnKind kind) { result = "ReturnValue" }
 
   /**
-   * Holds if it is irrelevant to generate models for `api` based on data flow analysis.
-   *
-   * This serves as an extra filter for the `relevant` predicate.
-   */
-  predicate isUninterestingForDataFlowModels(Callable api);
-
-  /**
-   * Holds if it is irrelevant to generate models for `api` based on the heuristic
-   * (non-content) flow analysis.
-   *
-   * This serves as an extra filter for the `relevant`
-   * and `isUninterestingForDataFlowModels` predicates.
-   */
-  predicate isUninterestingForHeuristicDataFlowModels(Callable api);
-
-  /**
    * Gets the string representation for the `i`th column in the MaD row for `api`.
    */
   string partialModelRow(Callable api, int i);
@@ -255,23 +134,14 @@ signature module ModelGeneratorInputSig<LocationSig Location, InputSig<Location>
    * Gets the string representation for the `i`th column in the neutral MaD row for `api`.
    */
   string partialNeutralModelRow(Callable api, int i);
-
-  /**
-   * Holds if `node` is specified as a source with the given kind in a MaD flow
-   * model.
-   */
-  predicate sourceNode(Lang::Node node, string kind);
-
-  /**
-   * Holds if `node` is specified as a sink with the given kind in a MaD flow
-   * model.
-   */
-  predicate sinkNode(Lang::Node node, string kind);
 }
 
-module MakeModelGenerator<
+/**
+ * Make a factory for constructing different model generators.
+ */
+module MakeModelGeneratorFactory<
   LocationSig Location, InputSig<Location> Lang, Tt::InputSig<Location, Lang> TaintLang,
-  ModelGeneratorInputSig<Location, Lang> ModelGeneratorInput>
+  ModelGeneratorCommonInputSig<Location, Lang> ModelGeneratorInput>
 {
   private module DataFlow {
     import Lang
@@ -338,16 +208,6 @@ module MakeModelGenerator<
     }
   }
 
-  final private class SummaryTargetApiFinal = SummaryTargetApi;
-
-  class DataFlowSummaryTargetApi extends SummaryTargetApiFinal {
-    DataFlowSummaryTargetApi() { not isUninterestingForDataFlowModels(this) }
-  }
-
-  class DataFlowSourceTargetApi = SourceTargetApi;
-
-  class DataFlowSinkTargetApi = SinkTargetApi;
-
   /**
    * Holds if `c` is a relevant content kind, where the underlying type is relevant.
    */
@@ -365,721 +225,926 @@ module MakeModelGenerator<
     containerContent(c)
   }
 
+  private string getOutput(ReturnNodeExt node) {
+    result = PrintReturnNodeExt<paramReturnNodeAsOutput/2>::getOutput(node)
+  }
+
   /**
-   * Provides classes and predicates related to capturing models
-   * based on heuristic data flow.
+   * Provides language-specific summary model generator parameters.
    */
-  module Heuristic {
-    private module ModelPrintingSummaryInput implements Printing::ModelPrintingSummarySig {
-      class SummaryApi = DataFlowSummaryTargetApi;
-
-      string getProvenance() { result = "df-generated" }
-    }
-
-    module ModelPrintingSummary = Printing::ModelPrintingSummary<ModelPrintingSummaryInput>;
-
-    private module ModelPrintingSourceOrSinkInput implements Printing::ModelPrintingSourceOrSinkSig {
-      class SourceOrSinkApi = SourceOrSinkTargetApi;
-
-      string getProvenance() { result = "df-generated" }
-    }
-
-    private string getOutput(ReturnNodeExt node) {
-      result = PrintReturnNodeExt<paramReturnNodeAsOutput/2>::getOutput(node)
-    }
-
-    private module ModelPrintingSourceOrSink =
-      Printing::ModelPrintingSourceOrSink<ModelPrintingSourceOrSinkInput>;
-
+  signature module SummaryModelGeneratorInputSig {
     /**
-     * Holds if data can flow from `node1` to `node2` either via a read or a write of an intermediate field `f`.
-     */
-    private predicate isRelevantTaintStep(DataFlow::Node node1, DataFlow::Node node2) {
-      exists(DataFlow::ContentSet f |
-        DataFlow::readStep(node1, f, node2) and
-        // Partially restrict the content types used for intermediate steps.
-        (not exists(getUnderlyingContentType(f)) or isRelevantTypeInContent(f))
-      )
-      or
-      exists(DataFlow::ContentSet f | DataFlow::storeStep(node1, f, node2) | containerContent(f))
-    }
-
-    /**
-     * Gets the MaD string representation of the parameter node `p`.
-     */
-    string parameterNodeAsInput(DataFlow::ParameterNode p) {
-      result = parameterAccess(asParameter(p))
-      or
-      result = qualifierString() and p instanceof InstanceParameterNode
-    }
-
-    /**
-     * Gets the MaD input string representation of `source`.
-     */
-    private string asInputArgument(NodeExtended source) { result = getInputArgument(source) }
-
-    /**
-     * Gets the summary model of `api`, if it follows the `fluent` programming pattern (returns `this`).
-     */
-    private string captureQualifierFlow(DataFlowSummaryTargetApi api) {
-      exists(ReturnNodeExt ret |
-        api = returnNodeEnclosingCallable(ret) and
-        isOwnInstanceAccessNode(ret)
-      ) and
-      result = ModelPrintingSummary::asLiftedValueModel(api, qualifierString(), "ReturnValue")
-    }
-
-    private int accessPathLimit0() { result = 2 }
-
-    private newtype TTaintState =
-      TTaintRead(int n) { n in [0 .. accessPathLimit0()] } or
-      TTaintStore(int n) { n in [1 .. accessPathLimit0()] }
-
-    abstract private class TaintState extends TTaintState {
-      abstract string toString();
-    }
-
-    /**
-     * A FlowState representing a tainted read.
-     */
-    private class TaintRead extends TaintState, TTaintRead {
-      private int step;
-
-      TaintRead() { this = TTaintRead(step) }
-
-      /**
-       * Gets the flow state step number.
-       */
-      int getStep() { result = step }
-
-      override string toString() { result = "TaintRead(" + step + ")" }
-    }
-
-    /**
-     * A FlowState representing a tainted write.
-     */
-    private class TaintStore extends TaintState, TTaintStore {
-      private int step;
-
-      TaintStore() { this = TTaintStore(step) }
-
-      /**
-       * Gets the flow state step number.
-       */
-      int getStep() { result = step }
-
-      override string toString() { result = "TaintStore(" + step + ")" }
-    }
-
-    /**
-     * A data flow configuration for tracking flow through APIs.
-     * The sources are the parameters of an API and the sinks are the return values (excluding `this`) and parameters.
+     * A class of callables that are potentially relevant for generating summary or
+     * neutral models.
      *
-     * This can be used to generate Flow summaries for APIs from parameter to return.
+     * In the Standard library and 3rd party libraries it is the callables (or callables that have a
+     * super implementation) that can be called from outside the library itself.
      */
-    private module PropagateFlowConfig implements DataFlow::StateConfigSig {
-      class FlowState = TaintState;
+    class SummaryTargetApi extends Callable {
+      /**
+       * Gets the callable that a model will be lifted to.
+       *
+       * The lifted callable is relevant in terms of model
+       * generation (this is ensured by `liftedImpl`).
+       */
+      Callable lift();
 
-      predicate isSource(DataFlow::Node source, FlowState state) {
-        source instanceof DataFlow::ParameterNode and
-        exists(Callable c |
-          c = getEnclosingCallable(source) and
-          c instanceof DataFlowSummaryTargetApi and
-          not isUninterestingForHeuristicDataFlowModels(c)
+      /**
+       * Holds if `this` is relevant in terms of model generation.
+       */
+      predicate isRelevant();
+    }
+
+    /**
+     * Gets the enclosing callable of `node`, when considered as an expression.
+     */
+    Callable getAsExprEnclosingCallable(NodeExtended node);
+
+    /**
+     * Gets the parameter corresponding to this node, if any.
+     */
+    Parameter asParameter(NodeExtended n);
+
+    /**
+     * Holds if there is a taint step from `node1` to `node2` in content flow.
+     */
+    predicate isAdditionalContentFlowStep(Lang::Node nodeFrom, Lang::Node nodeTo);
+
+    /**
+     * Holds if the content set `c` is field like.
+     */
+    predicate isField(Lang::ContentSet c);
+
+    /**
+     * Holds if the content set `c` is callback like.
+     */
+    predicate isCallback(Lang::ContentSet c);
+
+    /**
+     * Gets the MaD synthetic name string representation for the content set `c`, if any.
+     */
+    string getSyntheticName(Lang::ContentSet c);
+
+    /**
+     * Gets the MaD string representation of the content set `c`.
+     */
+    string printContent(Lang::ContentSet c);
+
+    /**
+     * Holds if it is irrelevant to generate models for `api` based on data flow analysis.
+     *
+     * This serves as an extra filter for the `relevant` predicate.
+     */
+    predicate isUninterestingForDataFlowModels(Callable api);
+
+    /**
+     * Holds if it is irrelevant to generate models for `api` based on the heuristic
+     * (non-content) flow analysis.
+     *
+     * This serves as an extra filter for the `relevant`
+     * and `isUninterestingForDataFlowModels` predicates.
+     */
+    predicate isUninterestingForHeuristicDataFlowModels(Callable api);
+  }
+
+  /**
+   * Make a summary model generator.
+   */
+  module MakeSummaryModelGenerator<SummaryModelGeneratorInputSig SummaryModelGeneratorInput> {
+    private import SummaryModelGeneratorInput
+
+    final private class SummaryTargetApiFinal = SummaryTargetApi;
+
+    class DataFlowSummaryTargetApi extends SummaryTargetApiFinal {
+      DataFlowSummaryTargetApi() { not isUninterestingForDataFlowModels(this) }
+    }
+
+    /**
+     * Provides classes and predicates related to capturing summary models
+     * based on heuristic data flow.
+     */
+    module Heuristic {
+      private module ModelPrintingSummaryInput implements Printing::ModelPrintingSummarySig {
+        class SummaryApi = DataFlowSummaryTargetApi;
+
+        string getProvenance() { result = "df-generated" }
+      }
+
+      module ModelPrintingSummary = Printing::ModelPrintingSummary<ModelPrintingSummaryInput>;
+
+      /**
+       * Gets the MaD string representation of the parameter node `p`.
+       */
+      string parameterNodeAsInput(DataFlow::ParameterNode p) {
+        result = parameterAccess(asParameter(p))
+        or
+        result = qualifierString() and p instanceof InstanceParameterNode
+      }
+
+      /**
+       * Gets the summary model of `api`, if it follows the `fluent` programming pattern (returns `this`).
+       */
+      private string captureQualifierFlow(DataFlowSummaryTargetApi api) {
+        exists(ReturnNodeExt ret |
+          api = returnNodeEnclosingCallable(ret) and
+          isOwnInstanceAccessNode(ret)
         ) and
-        state.(TaintRead).getStep() = 0
+        result = ModelPrintingSummary::asLiftedValueModel(api, qualifierString(), "ReturnValue")
       }
 
-      predicate isSink(DataFlow::Node sink, FlowState state) {
-        // Sinks are provided by `isSink/1`
-        none()
+      private int accessPathLimit0() { result = 2 }
+
+      private newtype TTaintState =
+        TTaintRead(int n) { n in [0 .. accessPathLimit0()] } or
+        TTaintStore(int n) { n in [1 .. accessPathLimit0()] }
+
+      abstract private class TaintState extends TTaintState {
+        abstract string toString();
       }
 
-      predicate isSink(DataFlow::Node sink) {
-        sink instanceof ReturnNodeExt and
-        not isOwnInstanceAccessNode(sink) and
-        not exists(captureQualifierFlow(getAsExprEnclosingCallable(sink)))
+      /**
+       * A FlowState representing a tainted read.
+       */
+      private class TaintRead extends TaintState, TTaintRead {
+        private int step;
+
+        TaintRead() { this = TTaintRead(step) }
+
+        /**
+         * Gets the flow state step number.
+         */
+        int getStep() { result = step }
+
+        override string toString() { result = "TaintRead(" + step + ")" }
       }
 
-      predicate isAdditionalFlowStep(
-        DataFlow::Node node1, FlowState state1, DataFlow::Node node2, FlowState state2
+      /**
+       * A FlowState representing a tainted write.
+       */
+      private class TaintStore extends TaintState, TTaintStore {
+        private int step;
+
+        TaintStore() { this = TTaintStore(step) }
+
+        /**
+         * Gets the flow state step number.
+         */
+        int getStep() { result = step }
+
+        override string toString() { result = "TaintStore(" + step + ")" }
+      }
+
+      /**
+       * A data flow configuration for tracking flow through APIs.
+       * The sources are the parameters of an API and the sinks are the return values (excluding `this`) and parameters.
+       *
+       * This can be used to generate Flow summaries for APIs from parameter to return.
+       */
+      private module PropagateFlowConfig implements DataFlow::StateConfigSig {
+        class FlowState = TaintState;
+
+        predicate isSource(DataFlow::Node source, FlowState state) {
+          source instanceof DataFlow::ParameterNode and
+          exists(Callable c |
+            c = getEnclosingCallable(source) and
+            c instanceof DataFlowSummaryTargetApi and
+            not isUninterestingForHeuristicDataFlowModels(c)
+          ) and
+          state.(TaintRead).getStep() = 0
+        }
+
+        predicate isSink(DataFlow::Node sink, FlowState state) {
+          // Sinks are provided by `isSink/1`
+          none()
+        }
+
+        predicate isSink(DataFlow::Node sink) {
+          sink instanceof ReturnNodeExt and
+          not isOwnInstanceAccessNode(sink) and
+          not exists(captureQualifierFlow(getAsExprEnclosingCallable(sink)))
+        }
+
+        predicate isAdditionalFlowStep(
+          DataFlow::Node node1, FlowState state1, DataFlow::Node node2, FlowState state2
+        ) {
+          exists(DataFlow::NodeEx n1, DataFlow::NodeEx n2, DataFlow::ContentSet c |
+            node1 = n1.asNode() and
+            node2 = n2.asNode() and
+            DataFlow::storeEx(n1, c.getAStoreContent(), n2, _, _) and
+            isRelevantContent0(c) and
+            (
+              state1 instanceof TaintRead and state2.(TaintStore).getStep() = 1
+              or
+              state1.(TaintStore).getStep() + 1 = state2.(TaintStore).getStep()
+            )
+          )
+          or
+          exists(DataFlow::ContentSet c |
+            DataFlow::readStep(node1, c, node2) and
+            isRelevantContent0(c) and
+            state1.(TaintRead).getStep() + 1 = state2.(TaintRead).getStep()
+          )
+        }
+
+        predicate isBarrier(DataFlow::Node n) {
+          exists(Type t | t = n.(NodeExtended).getType() and not isRelevantType(t))
+        }
+
+        DataFlow::FlowFeature getAFeature() {
+          result instanceof DataFlow::FeatureEqualSourceSinkCallContext
+        }
+      }
+
+      module PropagateFlow = TaintTracking::GlobalWithState<PropagateFlowConfig>;
+
+      /**
+       * Gets the summary model(s) of `api`, if there is flow from parameters to return value or parameter.
+       */
+      string captureThroughFlow0(
+        DataFlowSummaryTargetApi api, DataFlow::ParameterNode p, ReturnNodeExt returnNodeExt
       ) {
-        exists(DataFlow::NodeEx n1, DataFlow::NodeEx n2, DataFlow::ContentSet c |
-          node1 = n1.asNode() and
-          node2 = n2.asNode() and
-          DataFlow::storeEx(n1, c.getAStoreContent(), n2, _, _) and
-          isRelevantContent0(c) and
-          (
-            state1 instanceof TaintRead and state2.(TaintStore).getStep() = 1
+        exists(string input, string output |
+          getEnclosingCallable(p) = api and
+          getEnclosingCallable(returnNodeExt) = api and
+          input = parameterNodeAsInput(p) and
+          output = getOutput(returnNodeExt) and
+          input != output and
+          result = ModelPrintingSummary::asLiftedTaintModel(api, input, output)
+        )
+      }
+
+      /**
+       * Gets the summary model(s) of `api`, if there is flow from parameters to return value or parameter.
+       */
+      private string captureThroughFlow(DataFlowSummaryTargetApi api) {
+        exists(DataFlow::ParameterNode p, ReturnNodeExt returnNodeExt |
+          PropagateFlow::flow(p, returnNodeExt) and
+          result = captureThroughFlow0(api, p, returnNodeExt)
+        )
+      }
+
+      /**
+       * Gets the summary model(s) of `api`, if there is flow from parameters to the
+       * return value or parameter or if `api` is a fluent API.
+       */
+      string captureFlow(DataFlowSummaryTargetApi api) {
+        result = captureQualifierFlow(api) or
+        result = captureThroughFlow(api)
+      }
+
+      /**
+       * Gets the neutral summary model for `api`, if any.
+       * A neutral summary model is generated, if we are not generating
+       * a summary model that applies to `api`.
+       */
+      string captureNoFlow(DataFlowSummaryTargetApi api) {
+        not exists(DataFlowSummaryTargetApi api0 |
+          exists(captureFlow(api0)) and api0.lift() = api.lift()
+        ) and
+        api.isRelevant() and
+        result = ModelPrintingSummary::asNeutralSummaryModel(api)
+      }
+    }
+
+    /**
+     * Provides classes and predicates related to capturing summary models
+     * based on content data flow.
+     */
+    module ContentSensitive {
+      private import MakeImplContentDataFlow<Location, Lang> as ContentDataFlow
+
+      private module PropagateContentFlowConfig implements ContentDataFlow::ConfigSig {
+        predicate isSource(DataFlow::Node source) {
+          source instanceof DataFlow::ParameterNode and
+          getEnclosingCallable(source) instanceof DataFlowSummaryTargetApi
+        }
+
+        predicate isSink(DataFlow::Node sink) {
+          sink instanceof ReturnNodeExt and
+          getEnclosingCallable(sink) instanceof DataFlowSummaryTargetApi
+        }
+
+        predicate isAdditionalFlowStep = isAdditionalContentFlowStep/2;
+
+        predicate isBarrier(DataFlow::Node n) {
+          exists(Type t | t = n.(NodeExtended).getType() and not isRelevantType(t))
+        }
+
+        int accessPathLimit() { result = 2 }
+
+        predicate isRelevantContent(DataFlow::ContentSet s) { isRelevantContent0(s) }
+
+        DataFlow::FlowFeature getAFeature() {
+          result instanceof DataFlow::FeatureEqualSourceSinkCallContext
+        }
+      }
+
+      private module PropagateContentFlow = ContentDataFlow::Global<PropagateContentFlowConfig>;
+
+      private module ContentModelPrintingInput implements Printing::ModelPrintingSummarySig {
+        class SummaryApi = DataFlowSummaryTargetApi;
+
+        string getProvenance() { result = "dfc-generated" }
+      }
+
+      private module ContentModelPrinting =
+        Printing::ModelPrintingSummary<ContentModelPrintingInput>;
+
+      private string getContentOutput(ReturnNodeExt node) {
+        result = PrintReturnNodeExt<paramReturnNodeAsContentOutput/2>::getOutput(node)
+      }
+
+      /**
+       * Gets the MaD string representation of the parameter `p`
+       * when used in content flow.
+       */
+      private string parameterNodeAsContentInput(DataFlow::ParameterNode p) {
+        result = parameterContentAccess(asParameter(p))
+        or
+        result = qualifierString() and p instanceof InstanceParameterNode
+      }
+
+      private string getContent(PropagateContentFlow::AccessPath ap, int i) {
+        result = "." + printContent(ap.getAtIndex(i))
+      }
+
+      /**
+       * Gets the MaD string representation of a store step access path.
+       */
+      private string printStoreAccessPath(PropagateContentFlow::AccessPath ap) {
+        result = concat(int i | | getContent(ap, i), "" order by i)
+      }
+
+      /**
+       * Gets the MaD string representation of a read step access path.
+       */
+      private string printReadAccessPath(PropagateContentFlow::AccessPath ap) {
+        result = concat(int i | | getContent(ap, i), "" order by i desc)
+      }
+
+      /**
+       * Holds if the access path `ap` contains a field or synthetic field access.
+       */
+      private predicate mentionsField(PropagateContentFlow::AccessPath ap) {
+        isField(ap.getAtIndex(_))
+      }
+
+      /**
+       * Holds if this access path `ap` mentions a callback.
+       */
+      private predicate mentionsCallback(PropagateContentFlow::AccessPath ap) {
+        isCallback(ap.getAtIndex(_))
+      }
+
+      /**
+       * Holds if the access path `ap` is not a parameter or returnvalue of a callback
+       * stored in a field.
+       *
+       * That is, we currently don't include summaries that rely on parameters or return values
+       * of callbacks stored in fields.
+       */
+      private predicate validateAccessPath(PropagateContentFlow::AccessPath ap) {
+        not (mentionsField(ap) and mentionsCallback(ap))
+      }
+
+      private predicate apiFlow(
+        DataFlowSummaryTargetApi api, DataFlow::ParameterNode p,
+        PropagateContentFlow::AccessPath reads, ReturnNodeExt returnNodeExt,
+        PropagateContentFlow::AccessPath stores, boolean preservesValue
+      ) {
+        PropagateContentFlow::flow(p, reads, returnNodeExt, stores, preservesValue) and
+        getEnclosingCallable(returnNodeExt) = api and
+        getEnclosingCallable(p) = api
+      }
+
+      /**
+       * A class of APIs relevant for modeling using content flow.
+       * The following heuristic is applied:
+       * Content flow is only relevant for an API on a parameter, if
+       *    #content flow from parameter <= 3
+       * If an API produces more content flow on a parameter, it is likely that
+       * 1. Types are not sufficiently constrained on the parameter leading to a combinatorial
+       * explosion in dispatch and thus in the generated summaries.
+       * 2. It is a reasonable approximation to use the heuristic based flow
+       * detection instead, as reads and stores would use a significant
+       * part of an objects internal state.
+       */
+      private class ContentDataFlowSummaryTargetApi extends DataFlowSummaryTargetApi {
+        private DataFlow::ParameterNode parameter;
+
+        ContentDataFlowSummaryTargetApi() {
+          strictcount(string input, string output |
+            exists(
+              PropagateContentFlow::AccessPath reads, ReturnNodeExt returnNodeExt,
+              PropagateContentFlow::AccessPath stores
+            |
+              apiFlow(this, parameter, reads, returnNodeExt, stores, _) and
+              input = parameterNodeAsContentInput(parameter) + printReadAccessPath(reads) and
+              output = getContentOutput(returnNodeExt) + printStoreAccessPath(stores)
+            )
+          ) <= 3
+        }
+
+        /**
+         * Gets a parameter node of `this` api, where there are less than 3 possible models, if any.
+         */
+        DataFlow::ParameterNode getARelevantParameterNode() { result = parameter }
+      }
+
+      pragma[nomagic]
+      private predicate apiContentFlow(
+        ContentDataFlowSummaryTargetApi api, DataFlow::ParameterNode p,
+        PropagateContentFlow::AccessPath reads, ReturnNodeExt returnNodeExt,
+        PropagateContentFlow::AccessPath stores, boolean preservesValue
+      ) {
+        PropagateContentFlow::flow(p, reads, returnNodeExt, stores, preservesValue) and
+        getEnclosingCallable(returnNodeExt) = api and
+        getEnclosingCallable(p) = api and
+        p = api.getARelevantParameterNode()
+      }
+
+      /**
+       * Holds if any of the content sets in `path` translates into a synthetic field.
+       */
+      private predicate hasSyntheticContent(PropagateContentFlow::AccessPath path) {
+        exists(getSyntheticName(path.getAtIndex(_)))
+      }
+
+      private string getHashAtIndex(PropagateContentFlow::AccessPath ap, int i) {
+        result = getSyntheticName(ap.getAtIndex(i))
+      }
+
+      private string getReversedHash(PropagateContentFlow::AccessPath ap) {
+        result = strictconcat(int i | | getHashAtIndex(ap, i), "." order by i desc)
+      }
+
+      private string getHash(PropagateContentFlow::AccessPath ap) {
+        result = strictconcat(int i | | getHashAtIndex(ap, i), "." order by i)
+      }
+
+      /**
+       * Gets all access paths that contain the synthetic fields
+       * from `ap` in reverse order (if `ap` contains at least one synthetic field).
+       * These are the possible candidates for synthetic path continuations.
+       */
+      private PropagateContentFlow::AccessPath getSyntheticPathCandidate(
+        PropagateContentFlow::AccessPath ap
+      ) {
+        getHash(ap) = getReversedHash(result)
+      }
+
+      /**
+       * A module containing predicates for validating access paths containing content sets
+       * that translates into synthetic fields, when used for generated summary models.
+       */
+      private module AccessPathSyntheticValidation {
+        /**
+         * Holds if there exists an API that has content flow from `read` (on type `t1`)
+         * to `store` (on type `t2`).
+         */
+        private predicate step(
+          Type t1, PropagateContentFlow::AccessPath read, Type t2,
+          PropagateContentFlow::AccessPath store
+        ) {
+          exists(DataFlow::ParameterNode p, ReturnNodeExt returnNodeExt |
+            p.(NodeExtended).getType() = t1 and
+            returnNodeExt.getType() = t2 and
+            apiContentFlow(_, p, read, returnNodeExt, store, _)
+          )
+        }
+
+        /**
+         * Holds if there exists an API that has content flow from `read` (on type `t1`)
+         * to `store` (on type `t2`), where `read` does not have synthetic content and `store` does.
+         *
+         * Step A -> Synth.
+         */
+        private predicate synthPathEntry(
+          Type t1, PropagateContentFlow::AccessPath read, Type t2,
+          PropagateContentFlow::AccessPath store
+        ) {
+          not hasSyntheticContent(read) and
+          hasSyntheticContent(store) and
+          step(t1, read, t2, store)
+        }
+
+        /**
+         * Holds if there exists an API that has content flow from `read` (on type `t1`)
+         * to `store` (on type `t2`), where `read` has synthetic content
+         * and `store` does not.
+         *
+         * Step Synth -> A.
+         */
+        private predicate synthPathExit(
+          Type t1, PropagateContentFlow::AccessPath read, Type t2,
+          PropagateContentFlow::AccessPath store
+        ) {
+          hasSyntheticContent(read) and
+          not hasSyntheticContent(store) and
+          step(t1, read, t2, store)
+        }
+
+        /**
+         * Holds if there exists a path of steps from `read` to an exit.
+         *
+         * read ->* Synth -> A
+         */
+        private predicate reachesSynthExit(Type t, PropagateContentFlow::AccessPath read) {
+          synthPathExit(t, read, _, _)
+          or
+          hasSyntheticContent(read) and
+          exists(PropagateContentFlow::AccessPath mid, Type midType |
+            hasSyntheticContent(mid) and
+            step(t, read, midType, mid) and
+            reachesSynthExit(midType, getSyntheticPathCandidate(mid))
+          )
+        }
+
+        /**
+         * Holds if there exists a path of steps from an entry to `store`.
+         *
+         * A -> Synth ->* store
+         */
+        private predicate synthEntryReaches(Type t, PropagateContentFlow::AccessPath store) {
+          synthPathEntry(_, _, t, store)
+          or
+          hasSyntheticContent(store) and
+          exists(PropagateContentFlow::AccessPath mid, Type midType |
+            hasSyntheticContent(mid) and
+            step(midType, mid, t, store) and
+            synthEntryReaches(midType, getSyntheticPathCandidate(mid))
+          )
+        }
+
+        /**
+         * Holds if at least one of the access paths `read` (on type `t1`) and `store` (on type `t2`)
+         * contain content that will be translated into a synthetic field, when being used in
+         * a MaD summary model, and if there is a range of APIs, such that
+         * when chaining their flow access paths, there exists access paths `A` and `B` where
+         * A ->* read -> store ->* B and where `A` and `B` do not contain content that will
+         * be translated into a synthetic field.
+         *
+         * This is needed because we don't want to include summaries that reads from or
+         * stores into an "internal" synthetic field.
+         *
+         * Example:
+         * Assume we have a type `t` (in this case `t1` = `t2`) with methods `getX` and
+         * `setX`, which gets and sets a private field `X` on `t`.
+         * This would lead to the following content flows
+         * getX : Argument[this].SyntheticField[t.X] -> ReturnValue.
+         * setX : Argument[0] -> Argument[this].SyntheticField[t.X]
+         * As the reads and stores are on synthetic fields we should only make summaries
+         * if both of these methods exist.
+         */
+        pragma[nomagic]
+        predicate acceptReadStore(
+          Type t1, PropagateContentFlow::AccessPath read, Type t2,
+          PropagateContentFlow::AccessPath store
+        ) {
+          synthPathEntry(t1, read, t2, store) and
+          reachesSynthExit(t2, getSyntheticPathCandidate(store))
+          or
+          exists(PropagateContentFlow::AccessPath store0 |
+            getSyntheticPathCandidate(store0) = read
+          |
+            synthEntryReaches(t1, store0) and synthPathExit(t1, read, t2, store)
             or
-            state1.(TaintStore).getStep() + 1 = state2.(TaintStore).getStep()
+            synthEntryReaches(t1, store0) and
+            step(t1, read, t2, store) and
+            reachesSynthExit(t2, getSyntheticPathCandidate(store))
+          )
+        }
+      }
+
+      /**
+       * Holds, if the API `api` has relevant flow from `read` on `p` to `store` on `returnNodeExt`.
+       * Flow is considered relevant,
+       * 1. If `read` or `store` do not contain a content set that translates into a synthetic field.
+       * 2. If `read` or `store` contain a content set that translates into a synthetic field, and if
+       * the synthetic content is "live" on the relevant declaring type.
+       */
+      private predicate apiRelevantContentFlow(
+        ContentDataFlowSummaryTargetApi api, DataFlow::ParameterNode p,
+        PropagateContentFlow::AccessPath read, ReturnNodeExt returnNodeExt,
+        PropagateContentFlow::AccessPath store, boolean preservesValue
+      ) {
+        apiContentFlow(api, p, read, returnNodeExt, store, preservesValue) and
+        (
+          not hasSyntheticContent(read) and not hasSyntheticContent(store)
+          or
+          AccessPathSyntheticValidation::acceptReadStore(p.(NodeExtended).getType(), read,
+            returnNodeExt.getType(), store)
+        )
+      }
+
+      pragma[nomagic]
+      private predicate captureFlow0(
+        ContentDataFlowSummaryTargetApi api, string input, string output, boolean preservesValue,
+        boolean lift
+      ) {
+        exists(
+          DataFlow::ParameterNode p, ReturnNodeExt returnNodeExt,
+          PropagateContentFlow::AccessPath reads, PropagateContentFlow::AccessPath stores
+        |
+          apiRelevantContentFlow(api, p, reads, returnNodeExt, stores, preservesValue) and
+          input = parameterNodeAsContentInput(p) + printReadAccessPath(reads) and
+          output = getContentOutput(returnNodeExt) + printStoreAccessPath(stores) and
+          input != output and
+          validateAccessPath(reads) and
+          validateAccessPath(stores) and
+          (
+            if mentionsField(reads) or mentionsField(stores)
+            then lift = false and api.isRelevant()
+            else lift = true
           )
         )
-        or
-        exists(DataFlow::ContentSet c |
-          DataFlow::readStep(node1, c, node2) and
-          isRelevantContent0(c) and
-          state1.(TaintRead).getStep() + 1 = state2.(TaintRead).getStep()
+      }
+
+      /**
+       * Gets the content based summary model(s) of the API `api` (if there is flow from a parameter to
+       * the return value or a parameter). `lift` is true, if the model should be lifted, otherwise false.
+       *
+       * Models are lifted to the best type in case the read and store access paths do not
+       * contain a field or synthetic field access.
+       */
+      string captureFlow(ContentDataFlowSummaryTargetApi api, boolean lift) {
+        exists(string input, string output, boolean preservesValue |
+          captureFlow0(api, input, output, _, lift) and
+          preservesValue = max(boolean p | captureFlow0(api, input, output, p, lift)) and
+          result = ContentModelPrinting::asModel(api, input, output, preservesValue, lift)
         )
       }
-
-      predicate isBarrier(DataFlow::Node n) {
-        exists(Type t | t = n.(NodeExtended).getType() and not isRelevantType(t))
-      }
-
-      DataFlow::FlowFeature getAFeature() {
-        result instanceof DataFlow::FeatureEqualSourceSinkCallContext
-      }
-    }
-
-    module PropagateFlow = TaintTracking::GlobalWithState<PropagateFlowConfig>;
-
-    /**
-     * Gets the summary model(s) of `api`, if there is flow from parameters to return value or parameter.
-     */
-    string captureThroughFlow0(
-      DataFlowSummaryTargetApi api, DataFlow::ParameterNode p, ReturnNodeExt returnNodeExt
-    ) {
-      exists(string input, string output |
-        getEnclosingCallable(p) = api and
-        getEnclosingCallable(returnNodeExt) = api and
-        input = parameterNodeAsInput(p) and
-        output = getOutput(returnNodeExt) and
-        input != output and
-        result = ModelPrintingSummary::asLiftedTaintModel(api, input, output)
-      )
     }
 
     /**
-     * Gets the summary model(s) of `api`, if there is flow from parameters to return value or parameter.
+     * Gets the summary model(s) for `api`, if any. `lift` is true if the model is lifted
+     * otherwise false.
+     * The following heuristic is applied:
+     * 1. If content based flow yields at lease one summary for an API, then we use that.
+     * 2. If content based flow does not yield any summary for an API, then we try and
+     * generate flow summaries using the heuristic based summary generator.
      */
-    private string captureThroughFlow(DataFlowSummaryTargetApi api) {
-      exists(DataFlow::ParameterNode p, ReturnNodeExt returnNodeExt |
-        PropagateFlow::flow(p, returnNodeExt) and
-        result = captureThroughFlow0(api, p, returnNodeExt)
-      )
-    }
-
-    /**
-     * Gets the summary model(s) of `api`, if there is flow from parameters to the
-     * return value or parameter or if `api` is a fluent API.
-     */
-    string captureFlow(DataFlowSummaryTargetApi api) {
-      result = captureQualifierFlow(api) or
-      result = captureThroughFlow(api)
+    string captureFlow(DataFlowSummaryTargetApi api, boolean lift) {
+      result = ContentSensitive::captureFlow(api, lift)
+      or
+      not exists(DataFlowSummaryTargetApi api0 |
+        (api0 = api or api.lift() = api0) and
+        exists(ContentSensitive::captureFlow(api0, false))
+        or
+        api0.lift() = api.lift() and
+        exists(ContentSensitive::captureFlow(api0, true))
+      ) and
+      result = Heuristic::captureFlow(api) and
+      lift = true
     }
 
     /**
      * Gets the neutral summary model for `api`, if any.
      * A neutral summary model is generated, if we are not generating
-     * a summary model that applies to `api`.
+     * a mixed summary model that applies to `api`.
      */
-    string captureNoFlow(DataFlowSummaryTargetApi api) {
-      not exists(DataFlowSummaryTargetApi api0 |
-        exists(captureFlow(api0)) and api0.lift() = api.lift()
+    string captureNeutral(DataFlowSummaryTargetApi api) {
+      not exists(DataFlowSummaryTargetApi api0, boolean lift |
+        exists(captureFlow(api0, lift)) and
+        (
+          lift = false and
+          (api0 = api or api0 = api.lift())
+          or
+          lift = true and api0.lift() = api.lift()
+        )
       ) and
       api.isRelevant() and
-      result = ModelPrintingSummary::asNeutralSummaryModel(api)
-    }
-
-    /**
-     * A data flow configuration used for finding new sources.
-     * The sources are the already known existing sources and the sinks are the API return nodes.
-     *
-     * This can be used to generate Source summaries for an API, if the API expose an already known source
-     * via its return (then the API itself becomes a source).
-     */
-    module PropagateFromSourceConfig implements DataFlow::ConfigSig {
-      predicate isSource(DataFlow::Node source) {
-        exists(string kind |
-          isRelevantSourceKind(kind) and
-          sourceNode(source, kind)
-        )
-      }
-
-      predicate isSink(DataFlow::Node sink) {
-        sink instanceof ReturnNodeExt and
-        getEnclosingCallable(sink) instanceof DataFlowSourceTargetApi
-      }
-
-      DataFlow::FlowFeature getAFeature() { result instanceof DataFlow::FeatureHasSinkCallContext }
-
-      predicate isBarrier(DataFlow::Node n) {
-        exists(Type t | t = n.(NodeExtended).getType() and not isRelevantType(t))
-      }
-
-      predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
-        isRelevantTaintStep(node1, node2)
-      }
-    }
-
-    private module PropagateFromSource = TaintTracking::Global<PropagateFromSourceConfig>;
-
-    /**
-     * Gets the source model(s) of `api`, if there is flow from an existing known source to the return of `api`.
-     */
-    string captureSource(DataFlowSourceTargetApi api) {
-      exists(NodeExtended source, ReturnNodeExt sink, string kind |
-        PropagateFromSource::flow(source, sink) and
-        sourceNode(source, kind) and
-        api = getEnclosingCallable(sink) and
-        not irrelevantSourceSinkApi(getEnclosingCallable(source), api) and
-        result = ModelPrintingSourceOrSink::asSourceModel(api, getOutput(sink), kind)
-      )
-    }
-
-    /**
-     * A data flow configuration used for finding new sinks.
-     * The sources are the parameters of the API and the fields of the enclosing type.
-     *
-     * This can be used to generate Sink summaries for APIs, if the API propagates a parameter (or enclosing type field)
-     * into an existing known sink (then the API itself becomes a sink).
-     */
-    module PropagateToSinkConfig implements DataFlow::ConfigSig {
-      predicate isSource(DataFlow::Node source) {
-        apiSource(source) and
-        getEnclosingCallable(source) instanceof DataFlowSinkTargetApi
-      }
-
-      predicate isSink(DataFlow::Node sink) {
-        exists(string kind | isRelevantSinkKind(kind) and sinkNode(sink, kind))
-      }
-
-      predicate isBarrier(DataFlow::Node node) {
-        exists(Type t | t = node.(NodeExtended).getType() and not isRelevantType(t))
-        or
-        sinkModelSanitizer(node)
-      }
-
-      DataFlow::FlowFeature getAFeature() {
-        result instanceof DataFlow::FeatureHasSourceCallContext
-      }
-
-      predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
-        isRelevantTaintStep(node1, node2)
-      }
-    }
-
-    private module PropagateToSink = TaintTracking::Global<PropagateToSinkConfig>;
-
-    /**
-     * Gets the sink model(s) of `api`, if there is flow from a parameter to an existing known sink.
-     */
-    string captureSink(DataFlowSinkTargetApi api) {
-      exists(NodeExtended src, NodeExtended sink, string kind |
-        PropagateToSink::flow(src, sink) and
-        sinkNode(sink, kind) and
-        api = getEnclosingCallable(src) and
-        result = ModelPrintingSourceOrSink::asSinkModel(api, asInputArgument(src), kind)
-      )
+      result = Heuristic::ModelPrintingSummary::asNeutralSummaryModel(api)
     }
   }
 
   /**
-   * Provides classes and predicates related to capturing summary models
-   * based on content data flow.
+   * Holds if data can flow from `node1` to `node2` either via a read or a write of an intermediate field `f`.
    */
-  module ContentSensitive {
-    private import MakeImplContentDataFlow<Location, Lang> as ContentDataFlow
-
-    private module PropagateContentFlowConfig implements ContentDataFlow::ConfigSig {
-      predicate isSource(DataFlow::Node source) {
-        source instanceof DataFlow::ParameterNode and
-        getEnclosingCallable(source) instanceof DataFlowSummaryTargetApi
-      }
-
-      predicate isSink(DataFlow::Node sink) {
-        sink instanceof ReturnNodeExt and
-        getEnclosingCallable(sink) instanceof DataFlowSummaryTargetApi
-      }
-
-      predicate isAdditionalFlowStep = isAdditionalContentFlowStep/2;
-
-      predicate isBarrier(DataFlow::Node n) {
-        exists(Type t | t = n.(NodeExtended).getType() and not isRelevantType(t))
-      }
-
-      int accessPathLimit() { result = 2 }
-
-      predicate isRelevantContent(DataFlow::ContentSet s) { isRelevantContent0(s) }
-
-      DataFlow::FlowFeature getAFeature() {
-        result instanceof DataFlow::FeatureEqualSourceSinkCallContext
-      }
-    }
-
-    private module PropagateContentFlow = ContentDataFlow::Global<PropagateContentFlowConfig>;
-
-    private module ContentModelPrintingInput implements Printing::ModelPrintingSummarySig {
-      class SummaryApi = DataFlowSummaryTargetApi;
-
-      string getProvenance() { result = "dfc-generated" }
-    }
-
-    private module ContentModelPrinting = Printing::ModelPrintingSummary<ContentModelPrintingInput>;
-
-    private string getContentOutput(ReturnNodeExt node) {
-      result = PrintReturnNodeExt<paramReturnNodeAsContentOutput/2>::getOutput(node)
-    }
-
-    /**
-     * Gets the MaD string representation of the parameter `p`
-     * when used in content flow.
-     */
-    private string parameterNodeAsContentInput(DataFlow::ParameterNode p) {
-      result = parameterContentAccess(asParameter(p))
-      or
-      result = qualifierString() and p instanceof InstanceParameterNode
-    }
-
-    private string getContent(PropagateContentFlow::AccessPath ap, int i) {
-      result = "." + printContent(ap.getAtIndex(i))
-    }
-
-    /**
-     * Gets the MaD string representation of a store step access path.
-     */
-    private string printStoreAccessPath(PropagateContentFlow::AccessPath ap) {
-      result = concat(int i | | getContent(ap, i), "" order by i)
-    }
-
-    /**
-     * Gets the MaD string representation of a read step access path.
-     */
-    private string printReadAccessPath(PropagateContentFlow::AccessPath ap) {
-      result = concat(int i | | getContent(ap, i), "" order by i desc)
-    }
-
-    /**
-     * Holds if the access path `ap` contains a field or synthetic field access.
-     */
-    private predicate mentionsField(PropagateContentFlow::AccessPath ap) {
-      isField(ap.getAtIndex(_))
-    }
-
-    /**
-     * Holds if this access path `ap` mentions a callback.
-     */
-    private predicate mentionsCallback(PropagateContentFlow::AccessPath ap) {
-      isCallback(ap.getAtIndex(_))
-    }
-
-    /**
-     * Holds if the access path `ap` is not a parameter or returnvalue of a callback
-     * stored in a field.
-     *
-     * That is, we currently don't include summaries that rely on parameters or return values
-     * of callbacks stored in fields.
-     */
-    private predicate validateAccessPath(PropagateContentFlow::AccessPath ap) {
-      not (mentionsField(ap) and mentionsCallback(ap))
-    }
-
-    private predicate apiFlow(
-      DataFlowSummaryTargetApi api, DataFlow::ParameterNode p,
-      PropagateContentFlow::AccessPath reads, ReturnNodeExt returnNodeExt,
-      PropagateContentFlow::AccessPath stores, boolean preservesValue
-    ) {
-      PropagateContentFlow::flow(p, reads, returnNodeExt, stores, preservesValue) and
-      getEnclosingCallable(returnNodeExt) = api and
-      getEnclosingCallable(p) = api
-    }
-
-    /**
-     * A class of APIs relevant for modeling using content flow.
-     * The following heuristic is applied:
-     * Content flow is only relevant for an API on a parameter, if
-     *    #content flow from parameter <= 3
-     * If an API produces more content flow on a parameter, it is likely that
-     * 1. Types are not sufficiently constrained on the parameter leading to a combinatorial
-     * explosion in dispatch and thus in the generated summaries.
-     * 2. It is a reasonable approximation to use the heuristic based flow
-     * detection instead, as reads and stores would use a significant
-     * part of an objects internal state.
-     */
-    private class ContentDataFlowSummaryTargetApi extends DataFlowSummaryTargetApi {
-      private DataFlow::ParameterNode parameter;
-
-      ContentDataFlowSummaryTargetApi() {
-        strictcount(string input, string output |
-          exists(
-            PropagateContentFlow::AccessPath reads, ReturnNodeExt returnNodeExt,
-            PropagateContentFlow::AccessPath stores
-          |
-            apiFlow(this, parameter, reads, returnNodeExt, stores, _) and
-            input = parameterNodeAsContentInput(parameter) + printReadAccessPath(reads) and
-            output = getContentOutput(returnNodeExt) + printStoreAccessPath(stores)
-          )
-        ) <= 3
-      }
-
-      /**
-       * Gets a parameter node of `this` api, where there are less than 3 possible models, if any.
-       */
-      DataFlow::ParameterNode getARelevantParameterNode() { result = parameter }
-    }
-
-    pragma[nomagic]
-    private predicate apiContentFlow(
-      ContentDataFlowSummaryTargetApi api, DataFlow::ParameterNode p,
-      PropagateContentFlow::AccessPath reads, ReturnNodeExt returnNodeExt,
-      PropagateContentFlow::AccessPath stores, boolean preservesValue
-    ) {
-      PropagateContentFlow::flow(p, reads, returnNodeExt, stores, preservesValue) and
-      getEnclosingCallable(returnNodeExt) = api and
-      getEnclosingCallable(p) = api and
-      p = api.getARelevantParameterNode()
-    }
-
-    /**
-     * Holds if any of the content sets in `path` translates into a synthetic field.
-     */
-    private predicate hasSyntheticContent(PropagateContentFlow::AccessPath path) {
-      exists(getSyntheticName(path.getAtIndex(_)))
-    }
-
-    private string getHashAtIndex(PropagateContentFlow::AccessPath ap, int i) {
-      result = getSyntheticName(ap.getAtIndex(i))
-    }
-
-    private string getReversedHash(PropagateContentFlow::AccessPath ap) {
-      result = strictconcat(int i | | getHashAtIndex(ap, i), "." order by i desc)
-    }
-
-    private string getHash(PropagateContentFlow::AccessPath ap) {
-      result = strictconcat(int i | | getHashAtIndex(ap, i), "." order by i)
-    }
-
-    /**
-     * Gets all access paths that contain the synthetic fields
-     * from `ap` in reverse order (if `ap` contains at least one synthetic field).
-     * These are the possible candidates for synthetic path continuations.
-     */
-    private PropagateContentFlow::AccessPath getSyntheticPathCandidate(
-      PropagateContentFlow::AccessPath ap
-    ) {
-      getHash(ap) = getReversedHash(result)
-    }
-
-    /**
-     * A module containing predicates for validating access paths containing content sets
-     * that translates into synthetic fields, when used for generated summary models.
-     */
-    private module AccessPathSyntheticValidation {
-      /**
-       * Holds if there exists an API that has content flow from `read` (on type `t1`)
-       * to `store` (on type `t2`).
-       */
-      private predicate step(
-        Type t1, PropagateContentFlow::AccessPath read, Type t2,
-        PropagateContentFlow::AccessPath store
-      ) {
-        exists(DataFlow::ParameterNode p, ReturnNodeExt returnNodeExt |
-          p.(NodeExtended).getType() = t1 and
-          returnNodeExt.getType() = t2 and
-          apiContentFlow(_, p, read, returnNodeExt, store, _)
-        )
-      }
-
-      /**
-       * Holds if there exists an API that has content flow from `read` (on type `t1`)
-       * to `store` (on type `t2`), where `read` does not have synthetic content and `store` does.
-       *
-       * Step A -> Synth.
-       */
-      private predicate synthPathEntry(
-        Type t1, PropagateContentFlow::AccessPath read, Type t2,
-        PropagateContentFlow::AccessPath store
-      ) {
-        not hasSyntheticContent(read) and
-        hasSyntheticContent(store) and
-        step(t1, read, t2, store)
-      }
-
-      /**
-       * Holds if there exists an API that has content flow from `read` (on type `t1`)
-       * to `store` (on type `t2`), where `read` has synthetic content
-       * and `store` does not.
-       *
-       * Step Synth -> A.
-       */
-      private predicate synthPathExit(
-        Type t1, PropagateContentFlow::AccessPath read, Type t2,
-        PropagateContentFlow::AccessPath store
-      ) {
-        hasSyntheticContent(read) and
-        not hasSyntheticContent(store) and
-        step(t1, read, t2, store)
-      }
-
-      /**
-       * Holds if there exists a path of steps from `read` to an exit.
-       *
-       * read ->* Synth -> A
-       */
-      private predicate reachesSynthExit(Type t, PropagateContentFlow::AccessPath read) {
-        synthPathExit(t, read, _, _)
-        or
-        hasSyntheticContent(read) and
-        exists(PropagateContentFlow::AccessPath mid, Type midType |
-          hasSyntheticContent(mid) and
-          step(t, read, midType, mid) and
-          reachesSynthExit(midType, getSyntheticPathCandidate(mid))
-        )
-      }
-
-      /**
-       * Holds if there exists a path of steps from an entry to `store`.
-       *
-       * A -> Synth ->* store
-       */
-      private predicate synthEntryReaches(Type t, PropagateContentFlow::AccessPath store) {
-        synthPathEntry(_, _, t, store)
-        or
-        hasSyntheticContent(store) and
-        exists(PropagateContentFlow::AccessPath mid, Type midType |
-          hasSyntheticContent(mid) and
-          step(midType, mid, t, store) and
-          synthEntryReaches(midType, getSyntheticPathCandidate(mid))
-        )
-      }
-
-      /**
-       * Holds if at least one of the access paths `read` (on type `t1`) and `store` (on type `t2`)
-       * contain content that will be translated into a synthetic field, when being used in
-       * a MaD summary model, and if there is a range of APIs, such that
-       * when chaining their flow access paths, there exists access paths `A` and `B` where
-       * A ->* read -> store ->* B and where `A` and `B` do not contain content that will
-       * be translated into a synthetic field.
-       *
-       * This is needed because we don't want to include summaries that reads from or
-       * stores into an "internal" synthetic field.
-       *
-       * Example:
-       * Assume we have a type `t` (in this case `t1` = `t2`) with methods `getX` and
-       * `setX`, which gets and sets a private field `X` on `t`.
-       * This would lead to the following content flows
-       * getX : Argument[this].SyntheticField[t.X] -> ReturnValue.
-       * setX : Argument[0] -> Argument[this].SyntheticField[t.X]
-       * As the reads and stores are on synthetic fields we should only make summaries
-       * if both of these methods exist.
-       */
-      pragma[nomagic]
-      predicate acceptReadStore(
-        Type t1, PropagateContentFlow::AccessPath read, Type t2,
-        PropagateContentFlow::AccessPath store
-      ) {
-        synthPathEntry(t1, read, t2, store) and
-        reachesSynthExit(t2, getSyntheticPathCandidate(store))
-        or
-        exists(PropagateContentFlow::AccessPath store0 | getSyntheticPathCandidate(store0) = read |
-          synthEntryReaches(t1, store0) and synthPathExit(t1, read, t2, store)
-          or
-          synthEntryReaches(t1, store0) and
-          step(t1, read, t2, store) and
-          reachesSynthExit(t2, getSyntheticPathCandidate(store))
-        )
-      }
-    }
-
-    /**
-     * Holds, if the API `api` has relevant flow from `read` on `p` to `store` on `returnNodeExt`.
-     * Flow is considered relevant,
-     * 1. If `read` or `store` do not contain a content set that translates into a synthetic field.
-     * 2. If `read` or `store` contain a content set that translates into a synthetic field, and if
-     * the synthetic content is "live" on the relevant declaring type.
-     */
-    private predicate apiRelevantContentFlow(
-      ContentDataFlowSummaryTargetApi api, DataFlow::ParameterNode p,
-      PropagateContentFlow::AccessPath read, ReturnNodeExt returnNodeExt,
-      PropagateContentFlow::AccessPath store, boolean preservesValue
-    ) {
-      apiContentFlow(api, p, read, returnNodeExt, store, preservesValue) and
-      (
-        not hasSyntheticContent(read) and not hasSyntheticContent(store)
-        or
-        AccessPathSyntheticValidation::acceptReadStore(p.(NodeExtended).getType(), read,
-          returnNodeExt.getType(), store)
-      )
-    }
-
-    pragma[nomagic]
-    private predicate captureFlow0(
-      ContentDataFlowSummaryTargetApi api, string input, string output, boolean preservesValue,
-      boolean lift
-    ) {
-      exists(
-        DataFlow::ParameterNode p, ReturnNodeExt returnNodeExt,
-        PropagateContentFlow::AccessPath reads, PropagateContentFlow::AccessPath stores
-      |
-        apiRelevantContentFlow(api, p, reads, returnNodeExt, stores, preservesValue) and
-        input = parameterNodeAsContentInput(p) + printReadAccessPath(reads) and
-        output = getContentOutput(returnNodeExt) + printStoreAccessPath(stores) and
-        input != output and
-        validateAccessPath(reads) and
-        validateAccessPath(stores) and
-        (
-          if mentionsField(reads) or mentionsField(stores)
-          then lift = false and api.isRelevant()
-          else lift = true
-        )
-      )
-    }
-
-    /**
-     * Gets the content based summary model(s) of the API `api` (if there is flow from a parameter to
-     * the return value or a parameter). `lift` is true, if the model should be lifted, otherwise false.
-     *
-     * Models are lifted to the best type in case the read and store access paths do not
-     * contain a field or synthetic field access.
-     */
-    string captureFlow(ContentDataFlowSummaryTargetApi api, boolean lift) {
-      exists(string input, string output, boolean preservesValue |
-        captureFlow0(api, input, output, _, lift) and
-        preservesValue = max(boolean p | captureFlow0(api, input, output, p, lift)) and
-        result = ContentModelPrinting::asModel(api, input, output, preservesValue, lift)
-      )
-    }
-  }
-
-  /**
-   * Gets the summary model(s) for `api`, if any. `lift` is true if the model is lifted
-   * otherwise false.
-   * The following heuristic is applied:
-   * 1. If content based flow yields at lease one summary for an API, then we use that.
-   * 2. If content based flow does not yield any summary for an API, then we try and
-   * generate flow summaries using the heuristic based summary generator.
-   */
-  string captureFlow(DataFlowSummaryTargetApi api, boolean lift) {
-    result = ContentSensitive::captureFlow(api, lift)
+  private predicate isRelevantTaintStep(DataFlow::Node node1, DataFlow::Node node2) {
+    exists(DataFlow::ContentSet f |
+      DataFlow::readStep(node1, f, node2) and
+      // Partially restrict the content types used for intermediate steps.
+      (not exists(getUnderlyingContentType(f)) or isRelevantTypeInContent(f))
+    )
     or
-    not exists(DataFlowSummaryTargetApi api0 |
-      (api0 = api or api.lift() = api0) and
-      exists(ContentSensitive::captureFlow(api0, false))
-      or
-      api0.lift() = api.lift() and
-      exists(ContentSensitive::captureFlow(api0, true))
-    ) and
-    result = Heuristic::captureFlow(api) and
-    lift = true
+    exists(DataFlow::ContentSet f | DataFlow::storeStep(node1, f, node2) | containerContent(f))
   }
 
   /**
-   * Gets the neutral summary model for `api`, if any.
-   * A neutral summary model is generated, if we are not generating
-   * a mixed summary model that applies to `api`.
+   * Provides language-specific source model generator parameters.
    */
-  string captureNeutral(DataFlowSummaryTargetApi api) {
-    not exists(DataFlowSummaryTargetApi api0, boolean lift |
-      exists(captureFlow(api0, lift)) and
-      (
-        lift = false and
-        (api0 = api or api0 = api.lift())
-        or
-        lift = true and api0.lift() = api.lift()
-      )
-    ) and
-    api.isRelevant() and
-    result = Heuristic::ModelPrintingSummary::asNeutralSummaryModel(api)
+  signature module SourceModelGeneratorInputSig {
+    /**
+     * A class of callables that are potentially relevant for generating source models.
+     */
+    class SourceTargetApi extends Callable;
+
+    /**
+     * Holds if it is not relevant to generate a source model for `api`, even
+     * if flow is detected from a node within `source` to a sink within `api`.
+     */
+    bindingset[sourceEnclosing, api]
+    predicate irrelevantSourceSinkApi(Callable sourceEnclosing, SourceTargetApi api);
+
+    /**
+     * Holds if `kind` is a relevant source kind for creating source models.
+     */
+    bindingset[kind]
+    predicate isRelevantSourceKind(string kind);
+
+    /**
+     * Holds if `node` is specified as a source with the given kind in a MaD flow
+     * model.
+     */
+    predicate sourceNode(Lang::Node node, string kind);
+  }
+
+  /**
+   * Provides language-specific sink model generator parameters.
+   */
+  signature module SinkModelGeneratorInputSig {
+    /**
+     * A class of callables that are potentially relevant for generating sink models.
+     */
+    class SinkTargetApi extends Callable;
+
+    /**
+     * Gets the MaD input string representation of `source`.
+     */
+    string getInputArgument(Lang::Node source);
+
+    /**
+     * Holds if `node` is a sanitizer for sink model construction.
+     */
+    predicate sinkModelSanitizer(Lang::Node node);
+
+    /**
+     * Holds if `source` is an api entrypoint relevant for creating sink models.
+     */
+    predicate apiSource(Lang::Node source);
+
+    /**
+     * Holds if `kind` is a relevant sink kind for creating sink models.
+     */
+    bindingset[kind]
+    predicate isRelevantSinkKind(string kind);
+
+    /**
+     * Holds if `node` is specified as a sink with the given kind in a MaD flow
+     * model.
+     */
+    predicate sinkNode(Lang::Node node, string kind);
+  }
+
+  /**
+   * Make a source model generator.
+   */
+  module MakeSourceModelGenerator<SourceModelGeneratorInputSig SourceModelGeneratorInput> {
+    private import SourceModelGeneratorInput
+
+    class DataFlowSourceTargetApi = SourceTargetApi;
+
+    /**
+     * Provides classes and predicates related to capturing source models
+     * based on heuristic data flow.
+     */
+    module Heuristic {
+      private module ModelPrintingSourceOrSinkInput implements
+        Printing::ModelPrintingSourceOrSinkSig
+      {
+        class SourceOrSinkApi = DataFlowSourceTargetApi;
+
+        string getProvenance() { result = "df-generated" }
+      }
+
+      private module ModelPrintingSourceOrSink =
+        Printing::ModelPrintingSourceOrSink<ModelPrintingSourceOrSinkInput>;
+
+      /**
+       * A data flow configuration used for finding new sources.
+       * The sources are the already known existing sources and the sinks are the API return nodes.
+       *
+       * This can be used to generate Source summaries for an API, if the API expose an already known source
+       * via its return (then the API itself becomes a source).
+       */
+      module PropagateFromSourceConfig implements DataFlow::ConfigSig {
+        predicate isSource(DataFlow::Node source) {
+          exists(string kind |
+            isRelevantSourceKind(kind) and
+            sourceNode(source, kind)
+          )
+        }
+
+        predicate isSink(DataFlow::Node sink) {
+          sink instanceof ReturnNodeExt and
+          getEnclosingCallable(sink) instanceof DataFlowSourceTargetApi
+        }
+
+        DataFlow::FlowFeature getAFeature() {
+          result instanceof DataFlow::FeatureHasSinkCallContext
+        }
+
+        predicate isBarrier(DataFlow::Node n) {
+          exists(Type t | t = n.(NodeExtended).getType() and not isRelevantType(t))
+        }
+
+        predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
+          isRelevantTaintStep(node1, node2)
+        }
+      }
+
+      private module PropagateFromSource = TaintTracking::Global<PropagateFromSourceConfig>;
+
+      /**
+       * Gets the source model(s) of `api`, if there is flow from an existing known source to the return of `api`.
+       */
+      string captureSource(DataFlowSourceTargetApi api) {
+        exists(NodeExtended source, ReturnNodeExt sink, string kind |
+          PropagateFromSource::flow(source, sink) and
+          sourceNode(source, kind) and
+          api = getEnclosingCallable(sink) and
+          not irrelevantSourceSinkApi(getEnclosingCallable(source), api) and
+          result = ModelPrintingSourceOrSink::asSourceModel(api, getOutput(sink), kind)
+        )
+      }
+    }
+  }
+
+  /**
+   * Make a sink model generator.
+   */
+  module MakeSinkModelGenerator<SinkModelGeneratorInputSig SinkModelGeneratorInput> {
+    private import SinkModelGeneratorInput
+
+    class DataFlowSinkTargetApi = SinkTargetApi;
+
+    /**
+     * Provides classes and predicates related to capturing sink models
+     * based on heuristic data flow.
+     */
+    module Heuristic {
+      private module ModelPrintingSourceOrSinkInput implements
+        Printing::ModelPrintingSourceOrSinkSig
+      {
+        class SourceOrSinkApi = DataFlowSinkTargetApi;
+
+        string getProvenance() { result = "df-generated" }
+      }
+
+      private module ModelPrintingSourceOrSink =
+        Printing::ModelPrintingSourceOrSink<ModelPrintingSourceOrSinkInput>;
+
+      /**
+       * Gets the MaD input string representation of `source`.
+       */
+      private string asInputArgument(NodeExtended source) { result = getInputArgument(source) }
+
+      /**
+       * A data flow configuration used for finding new sinks.
+       * The sources are the parameters of the API and the fields of the enclosing type.
+       *
+       * This can be used to generate Sink summaries for APIs, if the API propagates a parameter (or enclosing type field)
+       * into an existing known sink (then the API itself becomes a sink).
+       */
+      module PropagateToSinkConfig implements DataFlow::ConfigSig {
+        predicate isSource(DataFlow::Node source) {
+          apiSource(source) and
+          getEnclosingCallable(source) instanceof DataFlowSinkTargetApi
+        }
+
+        predicate isSink(DataFlow::Node sink) {
+          exists(string kind | isRelevantSinkKind(kind) and sinkNode(sink, kind))
+        }
+
+        predicate isBarrier(DataFlow::Node node) {
+          exists(Type t | t = node.(NodeExtended).getType() and not isRelevantType(t))
+          or
+          sinkModelSanitizer(node)
+        }
+
+        DataFlow::FlowFeature getAFeature() {
+          result instanceof DataFlow::FeatureHasSourceCallContext
+        }
+
+        predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
+          isRelevantTaintStep(node1, node2)
+        }
+      }
+
+      private module PropagateToSink = TaintTracking::Global<PropagateToSinkConfig>;
+
+      /**
+       * Gets the sink model(s) of `api`, if there is flow from a parameter to an existing known sink.
+       */
+      string captureSink(DataFlowSinkTargetApi api) {
+        exists(NodeExtended src, NodeExtended sink, string kind |
+          PropagateToSink::flow(src, sink) and
+          sinkNode(sink, kind) and
+          api = getEnclosingCallable(src) and
+          result = ModelPrintingSourceOrSink::asSinkModel(api, asInputArgument(src), kind)
+        )
+      }
+    }
   }
 }

--- a/shared/mad/codeql/mad/modelgenerator/internal/ModelPrinting.qll
+++ b/shared/mad/codeql/mad/modelgenerator/internal/ModelPrinting.qll
@@ -16,7 +16,7 @@ signature module ModelPrintingLangSig {
 }
 
 module ModelPrintingImpl<ModelPrintingLangSig Lang> {
-  signature module ModelPrintingSig {
+  signature module ModelPrintingSummarySig {
     /**
      * The class of APIs relevant for model generation.
      */
@@ -24,6 +24,16 @@ module ModelPrintingImpl<ModelPrintingLangSig Lang> {
       Lang::Callable lift();
     }
 
+    /**
+     * Gets the string representation of the provenance of the models.
+     */
+    string getProvenance();
+  }
+
+  signature module ModelPrintingSourceOrSinkSig {
+    /**
+     * The class of APIs relevant for model generation.
+     */
     class SourceOrSinkApi extends Lang::Callable;
 
     /**
@@ -32,14 +42,14 @@ module ModelPrintingImpl<ModelPrintingLangSig Lang> {
     string getProvenance();
   }
 
-  module ModelPrinting<ModelPrintingSig Printing> {
-    /**
-     * Computes the first columns for MaD rows used for summaries, sources and sinks.
-     */
-    private string asPartialModel(Lang::Callable api) {
-      result = strictconcat(int i | | Lang::partialModelRow(api, i), ";" order by i) + ";"
-    }
+  /**
+   * Computes the first columns for MaD rows used for summaries, sources and sinks.
+   */
+  private string asPartialModel(Lang::Callable api) {
+    result = strictconcat(int i | | Lang::partialModelRow(api, i), ";" order by i) + ";"
+  }
 
+  module ModelPrintingSummary<ModelPrintingSummarySig Printing> {
     /**
      * Computes the first columns for neutral MaD rows.
      */
@@ -106,7 +116,9 @@ module ModelPrintingImpl<ModelPrintingLangSig Lang> {
       preservesValue = false and
       result = asSummaryModel(api, input, output, "taint", lift)
     }
+  }
 
+  module ModelPrintingSourceOrSink<ModelPrintingSourceOrSinkSig Printing> {
     /**
      * Gets the sink model for `api` with `input` and `kind`.
      */


### PR DESCRIPTION
In this PR we re-write the model generator into separate (nested) parameterized modules. Prior to this change it was only possible to create a model generator that could create summaries, neutrals, source and sinks. If only summary/neutral models are of interest, one still needed to provide all the source and sink model generation related parameters (as these were included in the input signature for model generator). With this change the model generator is turned into a series of nested parameterized modules.
That is, to create a model generator one now needs to
- Instantiate a model generator *factory* (this is the shared part of the model generation logic between summaries, neutrals, sources and sinks).
- Instantiate a summary/neutral, source or sink model generator using the model generator *factory* from above.

Furthermore, in this PR we sprinkle *sensible* predicate defaults for some of the model generator input predicates. 