### PR TITLE
Actions: Fix Critical Artifact poisoning False Positive

### DIFF
--- a/actions/ql/lib/codeql/actions/security/ArtifactPoisoningQuery.qll
+++ b/actions/ql/lib/codeql/actions/security/ArtifactPoisoningQuery.qll
@@ -264,7 +264,7 @@ class ArtifactPoisoningSink extends DataFlow::Node {
     download.getAFollowingStep() = poisonable and
     // excluding artifacts downloaded to /tmp and runner.tmp
     not download.getPath().regexpMatch("^/tmp.*") and
-    not download.getPath().regexpMatch("^\${{\s?runner.temp\s?}}.*") and
+    not download.getPath().regexpMatch("^\\${{\\s?runner.temp\\s?}}.*") and
     (
       poisonable.(Run).getScript() = this.asExpr() and
       (

--- a/actions/ql/lib/codeql/actions/security/ArtifactPoisoningQuery.qll
+++ b/actions/ql/lib/codeql/actions/security/ArtifactPoisoningQuery.qll
@@ -262,8 +262,9 @@ class ArtifactPoisoningSink extends DataFlow::Node {
 
   ArtifactPoisoningSink() {
     download.getAFollowingStep() = poisonable and
-    // excluding artifacts downloaded to /tmp
+    // excluding artifacts downloaded to /tmp and runner.tmp
     not download.getPath().regexpMatch("^/tmp.*") and
+    not download.getPath().regexpMatch("^\${{\s?runner.temp\s?}}.*") and
     (
       poisonable.(Run).getScript() = this.asExpr() and
       (


### PR DESCRIPTION
The artifact poisoning CodeQL query creates a Critical false-positive under the following scenario:

* Download Artifact with path set to start with `${{ runner.temp }}`
* Use of a [PoisonableCommandStep](https://github.com/github/codeql/blob/987af4ce1df3d3225e5af63b1b3b1606644c3e61/actions/ql/lib/ext/config/poisonable_steps.yml#L20-L62)

I believe this PR will fix it because it unless the path extraction functionality in CodeQL resolves/sanitizes the context values in some way.

Below is an example that reproduces the false positive:

```
name: Test False Positive
on:
  workflow_run:
    workflows:
      - Benchmark
    types:
      - completed

permissions:
  contents: read

jobs:
  benchmark:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - name: Download From PR
        uses: actions/download-artifact@v4
        with:
          github-token: ${{ secrets.GITHUB_TOKEN }}
          run-id: ${{ github.event.workflow_run.id }}
          path: ${{ runner.temp }}/artifacts/
      - run: npm install
```


This is particularly a problem because the examples for a secure workflow specifically calls out this fix.

```
name: Secure Workflow

on:
  workflow_run:
    workflows: ["Prev"]
    types:
      - completed

jobs:
  Download:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v2
      - run: mkdir -p ${{ runner.temp }}/artifacts/
      - uses: dawidd6/action-download-artifact@v2
        with:
          name: pr_number
          path: ${{ runner.temp }}/artifacts/

      - name: Run command
        run: |
          sh cmd.sh
```