### PR TITLE
C#: Add `cs/equality-on-floats` to the Code Quality suite.

### DIFF
--- a/csharp/ql/integration-tests/posix/query-suite/csharp-code-quality.qls.expected
+++ b/csharp/ql/integration-tests/posix/query-suite/csharp-code-quality.qls.expected
@@ -5,6 +5,7 @@ ql/csharp/ql/src/Dead Code/DeadStoreOfLocal.ql
 ql/csharp/ql/src/Likely Bugs/Collections/ContainerLengthCmpOffByOne.ql
 ql/csharp/ql/src/Likely Bugs/Collections/ContainerSizeCmpZero.ql
 ql/csharp/ql/src/Likely Bugs/DangerousNonShortCircuitLogic.ql
+ql/csharp/ql/src/Likely Bugs/EqualityCheckOnFloats.ql
 ql/csharp/ql/src/Likely Bugs/ReferenceEqualsOnValueTypes.ql
 ql/csharp/ql/src/Likely Bugs/SelfAssignment.ql
 ql/csharp/ql/src/Likely Bugs/UncheckedCastInEquals.ql

--- a/csharp/ql/src/Likely Bugs/EqualityCheckOnFloats.ql
+++ b/csharp/ql/src/Likely Bugs/EqualityCheckOnFloats.ql
@@ -5,7 +5,7 @@
  *              computation does not follow the standard rules of algebra.
  * @kind problem
  * @problem.severity warning
- * @precision medium
+ * @precision high
  * @id cs/equality-on-floats
  * @tags reliability
  *       correctness

--- a/csharp/ql/src/change-notes/2025-04-28-equality-on-floats-precision.md
+++ b/csharp/ql/src/change-notes/2025-04-28-equality-on-floats-precision.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Changed the precision of the `cs/equality-on-floats` query from medium to high.

--- a/csharp/ql/src/codeql-suites/csharp-code-quality.qls
+++ b/csharp/ql/src/codeql-suites/csharp-code-quality.qls
@@ -14,3 +14,4 @@
       - cs/non-short-circuit
       - cs/useless-assignment-to-local
       - cs/invalid-string-formatting
+      - cs/equality-on-floats


### PR DESCRIPTION
The precision of the query has been increased to high. Even though comparing floats in many cases yield correct results, it should generally be avoided. If exact comparison is needed, `decimal` should be used instead.