### PR TITLE
.qll Contribution for Sink Detection

### DIFF
--- a/python/ql/lib/semmle/python/Frameworks.qll
+++ b/python/ql/lib/semmle/python/Frameworks.qll
@@ -91,3 +91,4 @@ private import semmle.python.frameworks.Urllib3
 private import semmle.python.frameworks.Xmltodict
 private import semmle.python.frameworks.Yaml
 private import semmle.python.frameworks.Yarl
+private import semmle.python.frameworks.Markup

--- a/python/ql/lib/semmle/python/frameworks/Markup.qll
+++ b/python/ql/lib/semmle/python/frameworks/Markup.qll
@@ -1,0 +1,58 @@
+/**
+ * Provides classes modeling security-relevant aspects of the hypothetical `markup` PyPI package
+ * (imported as `markup`)
+ *
+ * This models parsing functions that may process untrusted input.
+ */
+
+ private import python
+ private import semmle.python.dataflow.new.DataFlow
+ private import semmle.python.Concepts
+ private import semmle.python.ApiGraphs
+ 
+ private module Markup {
+   /**
+    * A call to any of the parsing functions in `markup` (`parse`, `parse_document`,
+    * `unsafe_parse`, `unsafe_parse_document`, `safe_parse`, `safe_parse_document`)
+    *
+    * These functions may be unsafe if they parse untrusted markup content.
+    */
+   private class MarkupParseCall extends Decoding::Range, DataFlow::CallCfgNode {
+     override CallNode node;
+     string func_name;
+ 
+     MarkupParseCall() {
+       func_name in [
+           "parse", "parse_document", "unsafe_parse", "unsafe_parse_document",
+           "safe_parse", "safe_parse_document", "div", "page"
+         ] and
+       this = API::moduleImport("markup").getMember(func_name).getACall()
+     }
+ 
+     /**
+      * Determine whether this function call may unsafely execute input data.
+      *
+      * `unsafe_parse`, `unsafe_parse_document`, and `parse`, `parse_document` without secure settings
+      * are considered unsafe.
+      */
+     override predicate mayExecuteInput() {
+       func_name in ["unsafe_parse", "unsafe_parse_document"]
+       or
+       func_name in ["parse", "parse_document"] and
+       // If no safe mode argument is set, assume unsafe
+       not exists(DataFlow::Node mode_arg |
+         mode_arg in [this.getArg(1), this.getArgByName("mode")] |
+           mode_arg =
+             API::moduleImport("markup")
+                 .getMember(["SafeMode", "StrictMode"])
+                 .getAValueReachableFromSource()
+       )
+     }
+ 
+     override DataFlow::Node getAnInput() { result in [this.getArg(0), this.getArgByName("input")] }
+ 
+     override DataFlow::Node getOutput() { result = this }
+ 
+     override string getFormat() { result = "Markup" }
+   }
+ }


### PR DESCRIPTION
Hello,

After reviewing the Python CodeQL queries, I found that only frameworks defined with `.qll` files under the `python/ql/lib/semmle/python/frameworks/` directory are recognized as sinks.

For example, `MarkupSafe` is correctly detected because it is defined in that location, whereas `MarkUp` is currently not recognized as a sink due to the absence of a `.qll` definition.

Therefore, I would like to create a new `.qll` file for `MarkUp`, add the corresponding unit tests, and submit a Pull Request.

The Taint Tracking query used for this test was as follows:

```ql
/**
 * @kind path-problem
 * @id python/taint-tracking
 */

import python
import semmle.python.dataflow.new.DataFlow
import semmle.python.dataflow.new.TaintTracking
import semmle.python.dataflow.new.RemoteFlowSources

module Config implements DataFlow::ConfigSig {
  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }

  predicate isSink(DataFlow::Node sink) { any() }
}

module Flow = TaintTracking::Global<Config>;

import Flow::PathGraph

from Flow::PathNode source, Flow::PathNode sink
where Flow::flowPath(source, sink)
select sink.getNode(), source, sink,
"sink function: " + sink.getNode().asExpr().getScope().(Function).getName()
```

The target code tested was as follows:

```python
from flask import Flask, request
import markupsafe
import markup
import yaml

app = Flask(__name__)

@app.route('/markupsafe', methods=['POST'])
def markupsafe_sink():
    user_input = request.form.get('input', '')
    result = markupsafe.Markup(user_input)
    return f"Rendered using markupsafe: {result}"

@app.route('/markup', methods=['POST'])
def markup_sink():
    user_input = request.form.get('input', '')
    page = markup.page()
    page += markup.div(user_input)
    return str(page)

@app.route('/pyyaml', methods=['POST'])
def pyyaml_sink():
    user_input = request.form.get('input', '')
    yaml_data = "---\n" + user_input
    loaded = yaml.load(yaml_data, Loader=yaml.Loader)
    return f"YAML loaded: {loaded}"

if __name__ == '__main__':
    app.run(debug=True)
```

As you can see, `markupsafe.Markup` is successfully recognized as a sink, but `markup.page()` and `markup.div()` are not detected, due to the missing `.qll` definition for the `markup` library.

I have summarized the detailed information in the Notion document linked below for your reference:

- [CodeQL QLL Contribution Summary](https://tossbank.notion.site/CodeQL-qll-Contribution-1e0557175d2e808883a5d8c6f991340c)

Thank you very much for your time and consideration.

Best regards,  
SooHyun Kim
