### PR TITLE
Shared: Use `isSink/1` in `PropagateFlowConfig`

### DIFF
--- a/shared/mad/codeql/mad/modelgenerator/internal/ModelGeneratorImpl.qll
+++ b/shared/mad/codeql/mad/modelgenerator/internal/ModelGeneratorImpl.qll
@@ -484,10 +484,14 @@ module MakeModelGenerator<
       }
 
       predicate isSink(DataFlow::Node sink, FlowState state) {
+        // Sinks are provided by `isSink/1`
+        none()
+      }
+
+      predicate isSink(DataFlow::Node sink) {
         sink instanceof ReturnNodeExt and
         not isOwnInstanceAccessNode(sink) and
-        not exists(captureQualifierFlow(getAsExprEnclosingCallable(sink))) and
-        (state instanceof TaintRead or state instanceof TaintStore)
+        not exists(captureQualifierFlow(getAsExprEnclosingCallable(sink)))
       }
 
       predicate isAdditionalFlowStep(


### PR DESCRIPTION
A not-super-widely-known feature from state-based dataflow configurations is that you can omit the state (see [here](https://github.com/github/codeql/pull/13851)) in the `isSink` when you don't want to restrict the state in `isSink`.

It looks like this is exactly what's being done in `PropagateFlowConfig::isSink` so we might as well omit the sink and avoid the small cartesian product.