### PR TITLE
C#/Java/Rust: Change the tag for the model generator debugging queries.

### DIFF
--- a/csharp/ql/src/utils/modelgenerator/debug/CaptureSummaryModelsPartialPath.ql
+++ b/csharp/ql/src/utils/modelgenerator/debug/CaptureSummaryModelsPartialPath.ql
@@ -5,7 +5,7 @@
  * @precision low
  * @id csharp/utils/modelgenerator/summary-models-partial-path
  * @severity info
- * @tags modelgenerator
+ * @tags debugmodelgenerator
  */
 
 import csharp

--- a/csharp/ql/src/utils/modelgenerator/debug/CaptureSummaryModelsPath.ql
+++ b/csharp/ql/src/utils/modelgenerator/debug/CaptureSummaryModelsPath.ql
@@ -5,7 +5,7 @@
  * @precision low
  * @id csharp/utils/modelgenerator/summary-models-path
  * @severity warning
- * @tags modelgenerator
+ * @tags debugmodelgenerator
  */
 
 import csharp

--- a/java/ql/src/utils/modelgenerator/debug/CaptureSummaryModelsPartialPath.ql
+++ b/java/ql/src/utils/modelgenerator/debug/CaptureSummaryModelsPartialPath.ql
@@ -5,7 +5,7 @@
  * @precision low
  * @id java/utils/modelgenerator/summary-models-partial-path
  * @severity info
- * @tags modelgenerator
+ * @tags debugmodelgenerator
  */
 
 import java

--- a/java/ql/src/utils/modelgenerator/debug/CaptureSummaryModelsPath.ql
+++ b/java/ql/src/utils/modelgenerator/debug/CaptureSummaryModelsPath.ql
@@ -5,7 +5,7 @@
  * @precision low
  * @id java/utils/modelgenerator/summary-models-path
  * @severity warning
- * @tags modelgenerator
+ * @tags debugmodelgenerator
  */
 
 import java

--- a/rust/ql/src/utils/modelgenerator/debug/CaptureSummaryModelsPartialPath.ql
+++ b/rust/ql/src/utils/modelgenerator/debug/CaptureSummaryModelsPartialPath.ql
@@ -5,7 +5,7 @@
  * @precision low
  * @id rust/utils/modelgenerator/summary-models-partial-path
  * @severity info
- * @tags modelgenerator
+ * @tags debugmodelgenerator
  */
 
 private import codeql.rust.dataflow.DataFlow

--- a/rust/ql/src/utils/modelgenerator/debug/CaptureSummaryModelsPath.ql
+++ b/rust/ql/src/utils/modelgenerator/debug/CaptureSummaryModelsPath.ql
@@ -5,7 +5,7 @@
  * @precision low
  * @id rust/utils/modelgenerator/summary-models-path
  * @severity warning
- * @tags modelgenerator
+ * @tags debugmodelgenerator
  */
 
 private import codeql.rust.dataflow.DataFlow


### PR DESCRIPTION
The DCA suites are relying on the `modelgenerator` tag, so we should tag the local debug queries differently.

The failing Java integration test is unrelated.