### PR TITLE
Add code quality suite selector and use that in the code quality suites

### DIFF
--- a/actions/ql/src/codeql-suites/actions-code-quality.qls
+++ b/actions/ql/src/codeql-suites/actions-code-quality.qls
@@ -1,1 +1,3 @@
-[]
+- queries: .
+- apply: code-quality-selectors.yml
+  from: codeql/suite-helpers

--- a/cpp/ql/src/codeql-suites/cpp-code-quality.qls
+++ b/cpp/ql/src/codeql-suites/cpp-code-quality.qls
@@ -1,1 +1,3 @@
-[]
+- queries: .
+- apply: code-quality-selectors.yml
+  from: codeql/suite-helpers

--- a/csharp/ql/src/API Abuse/FormatInvalid.ql
+++ b/csharp/ql/src/API Abuse/FormatInvalid.ql
@@ -8,6 +8,7 @@
  * @id cs/invalid-string-formatting
  * @tags reliability
  *       maintainability
+ *       quality
  */
 
 import csharp

--- a/csharp/ql/src/API Abuse/NoDisposeCallOnLocalIDisposable.ql
+++ b/csharp/ql/src/API Abuse/NoDisposeCallOnLocalIDisposable.ql
@@ -8,6 +8,7 @@
  * @id cs/local-not-disposed
  * @tags efficiency
  *       maintainability
+ *       quality
  *       external/cwe/cwe-404
  *       external/cwe/cwe-459
  *       external/cwe/cwe-460

--- a/csharp/ql/src/Bad Practices/Control-Flow/ConstantCondition.ql
+++ b/csharp/ql/src/Bad Practices/Control-Flow/ConstantCondition.ql
@@ -9,6 +9,7 @@
  * @id cs/constant-condition
  * @tags maintainability
  *       readability
+ *       quality
  *       external/cwe/cwe-835
  */
 

--- a/csharp/ql/src/Dead Code/DeadStoreOfLocal.ql
+++ b/csharp/ql/src/Dead Code/DeadStoreOfLocal.ql
@@ -6,6 +6,7 @@
  * @problem.severity warning
  * @id cs/useless-assignment-to-local
  * @tags maintainability
+ *       quality
  *       external/cwe/cwe-563
  * @precision very-high
  */

--- a/csharp/ql/src/Likely Bugs/Collections/ContainerLengthCmpOffByOne.ql
+++ b/csharp/ql/src/Likely Bugs/Collections/ContainerLengthCmpOffByOne.ql
@@ -9,6 +9,7 @@
  * @tags reliability
  *       correctness
  *       logic
+ *       quality
  *      external/cwe/cwe-193
  */
 

--- a/csharp/ql/src/Likely Bugs/Collections/ContainerSizeCmpZero.ql
+++ b/csharp/ql/src/Likely Bugs/Collections/ContainerSizeCmpZero.ql
@@ -8,6 +8,7 @@
  * @tags reliability
  *       correctness
  *       logic
+ *       quality
  */
 
 import csharp

--- a/csharp/ql/src/Likely Bugs/DangerousNonShortCircuitLogic.ql
+++ b/csharp/ql/src/Likely Bugs/DangerousNonShortCircuitLogic.ql
@@ -9,6 +9,7 @@
  * @tags reliability
  *       correctness
  *       logic
+ *       quality
  *       external/cwe/cwe-480
  *       external/cwe/cwe-691
  */

--- a/csharp/ql/src/Likely Bugs/EqualityCheckOnFloats.ql
+++ b/csharp/ql/src/Likely Bugs/EqualityCheckOnFloats.ql
@@ -9,6 +9,7 @@
  * @id cs/equality-on-floats
  * @tags reliability
  *       correctness
+ *       quality
  */
 
 import csharp

--- a/csharp/ql/src/Likely Bugs/ReferenceEqualsOnValueTypes.ql
+++ b/csharp/ql/src/Likely Bugs/ReferenceEqualsOnValueTypes.ql
@@ -7,6 +7,7 @@
  * @id cs/reference-equality-on-valuetypes
  * @tags reliability
  *       correctness
+ *       quality
  *       external/cwe/cwe-595
  */
 

--- a/csharp/ql/src/Likely Bugs/SelfAssignment.ql
+++ b/csharp/ql/src/Likely Bugs/SelfAssignment.ql
@@ -8,6 +8,7 @@
  * @tags reliability
  *       correctness
  *       logic
+ *       quality
  */
 
 import csharp

--- a/csharp/ql/src/Likely Bugs/UncheckedCastInEquals.ql
+++ b/csharp/ql/src/Likely Bugs/UncheckedCastInEquals.ql
@@ -7,6 +7,7 @@
  * @id cs/unchecked-cast-in-equals
  * @tags reliability
  *       maintainability
+ *       quality
  */
 
 import csharp

--- a/csharp/ql/src/Performance/UseTryGetValue.ql
+++ b/csharp/ql/src/Performance/UseTryGetValue.ql
@@ -6,7 +6,9 @@
  * @problem.severity recommendation
  * @precision high
  * @id cs/inefficient-containskey
- * @tags maintainability efficiency
+ * @tags maintainability
+ *       efficiency
+ *       quality
  */
 
 import csharp

--- a/csharp/ql/src/Useless code/DefaultToString.ql
+++ b/csharp/ql/src/Useless code/DefaultToString.ql
@@ -8,6 +8,7 @@
  * @id cs/call-to-object-tostring
  * @tags reliability
  *       maintainability
+ *       quality
  */
 
 import DefaultToStringQuery

--- a/csharp/ql/src/Useless code/IntGetHashCode.ql
+++ b/csharp/ql/src/Useless code/IntGetHashCode.ql
@@ -8,6 +8,7 @@
  * @id cs/useless-gethashcode-call
  * @tags readability
  *       useless-code
+ *       quality
  */
 
 import csharp

--- a/csharp/ql/src/codeql-suites/csharp-code-quality.qls
+++ b/csharp/ql/src/codeql-suites/csharp-code-quality.qls
@@ -1,17 +1,3 @@
 - queries: .
-- include:
-    id:
-      - cs/index-out-of-bounds
-      - cs/test-for-negative-container-size
-      - cs/unchecked-cast-in-equals
-      - cs/reference-equality-on-valuetypes
-      - cs/self-assignment
-      - cs/inefficient-containskey
-      - cs/call-to-object-tostring
-      - cs/local-not-disposed
-      - cs/constant-condition
-      - cs/useless-gethashcode-call
-      - cs/non-short-circuit
-      - cs/useless-assignment-to-local
-      - cs/invalid-string-formatting
-      - cs/equality-on-floats
+- apply: code-quality-selectors.yml
+  from: codeql/suite-helpers

--- a/go/ql/src/InconsistentCode/LengthComparisonOffByOne.ql
+++ b/go/ql/src/InconsistentCode/LengthComparisonOffByOne.ql
@@ -8,6 +8,7 @@
  * @tags reliability
  *       correctness
  *       logic
+ *       quality
  *       external/cwe/cwe-193
  * @precision high
  */

--- a/go/ql/src/InconsistentCode/MissingErrorCheck.ql
+++ b/go/ql/src/InconsistentCode/MissingErrorCheck.ql
@@ -8,6 +8,7 @@
  * @tags reliability
  *       correctness
  *       logic
+ *       quality
  * @precision high
  */
 

--- a/go/ql/src/InconsistentCode/UnhandledCloseWritableHandle.ql
+++ b/go/ql/src/InconsistentCode/UnhandledCloseWritableHandle.ql
@@ -11,6 +11,7 @@
  *  correctness
  *  call
  *  defer
+ *  quality
  */
 
 import go

--- a/go/ql/src/InconsistentCode/WrappedErrorAlwaysNil.ql
+++ b/go/ql/src/InconsistentCode/WrappedErrorAlwaysNil.ql
@@ -7,6 +7,7 @@
  * @tags reliability
  *       correctness
  *       logic
+ *       quality
  * @precision high
  */
 

--- a/go/ql/src/RedundantCode/NegativeLengthCheck.ql
+++ b/go/ql/src/RedundantCode/NegativeLengthCheck.ql
@@ -9,6 +9,7 @@
  * @precision very-high
  * @id go/negative-length-check
  * @tags correctness
+ *       quality
  */
 
 import go

--- a/go/ql/src/RedundantCode/RedundantRecover.ql
+++ b/go/ql/src/RedundantCode/RedundantRecover.ql
@@ -8,6 +8,7 @@
  * @id go/redundant-recover
  * @tags maintainability
  *       correctness
+ *       quality
  * @precision high
  */
 

--- a/go/ql/src/codeql-suites/go-code-quality.qls
+++ b/go/ql/src/codeql-suites/go-code-quality.qls
@@ -1,9 +1,3 @@
 - queries: .
-- include:
-    id:
-      - go/unhandled-writable-file-close
-      - go/unexpected-nil-value
-      - go/negative-length-check
-      - go/redundant-recover
-      - go/missing-error-check
-      - go/index-out-of-bounds
+- apply: code-quality-selectors.yml
+  from: codeql/suite-helpers

--- a/java/ql/integration-tests/java/query-suite/java-code-quality.qls.expected
+++ b/java/ql/integration-tests/java/query-suite/java-code-quality.qls.expected
@@ -1,4 +1,3 @@
-ql/java/ql/src/Language Abuse/TypeVariableHidesType.ql
 ql/java/ql/src/Likely Bugs/Arithmetic/IntMultToLong.ql
 ql/java/ql/src/Likely Bugs/Collections/WriteOnlyContainer.ql
 ql/java/ql/src/Likely Bugs/Comparison/IncomparableEquals.ql

--- a/java/ql/src/Language Abuse/TypeVariableHidesType.ql
+++ b/java/ql/src/Language Abuse/TypeVariableHidesType.ql
@@ -9,6 +9,7 @@
  * @tags reliability
  *       readability
  *       types
+ *       quality
  */
 
 import java

--- a/java/ql/src/Likely Bugs/Arithmetic/IntMultToLong.ql
+++ b/java/ql/src/Likely Bugs/Arithmetic/IntMultToLong.ql
@@ -9,6 +9,7 @@
  * @tags reliability
  *       correctness
  *       types
+ *       quality
  *       external/cwe/cwe-190
  *       external/cwe/cwe-192
  *       external/cwe/cwe-197

--- a/java/ql/src/Likely Bugs/Collections/WriteOnlyContainer.ql
+++ b/java/ql/src/Likely Bugs/Collections/WriteOnlyContainer.ql
@@ -7,6 +7,7 @@
  * @id java/unused-container
  * @tags maintainability
  *       useless-code
+ *       quality
  *       external/cwe/cwe-561
  */
 

--- a/java/ql/src/Likely Bugs/Comparison/IncomparableEquals.ql
+++ b/java/ql/src/Likely Bugs/Comparison/IncomparableEquals.ql
@@ -8,6 +8,7 @@
  * @id java/equals-on-unrelated-types
  * @tags reliability
  *       correctness
+ *       quality
  */
 
 import java

--- a/java/ql/src/Likely Bugs/Comparison/InconsistentEqualsHashCode.ql
+++ b/java/ql/src/Likely Bugs/Comparison/InconsistentEqualsHashCode.ql
@@ -8,6 +8,7 @@
  * @id java/inconsistent-equals-and-hashcode
  * @tags reliability
  *       correctness
+ *       quality
  *       external/cwe/cwe-581
  */
 

--- a/java/ql/src/Likely Bugs/Comparison/MissingInstanceofInEquals.ql
+++ b/java/ql/src/Likely Bugs/Comparison/MissingInstanceofInEquals.ql
@@ -8,6 +8,7 @@
  * @id java/unchecked-cast-in-equals
  * @tags reliability
  *       correctness
+ *       quality
  */
 
 import java

--- a/java/ql/src/Likely Bugs/Comparison/RefEqBoxed.ql
+++ b/java/ql/src/Likely Bugs/Comparison/RefEqBoxed.ql
@@ -8,6 +8,7 @@
  * @id java/reference-equality-of-boxed-types
  * @tags reliability
  *       correctness
+ *       quality
  *       external/cwe/cwe-595
  */
 

--- a/java/ql/src/Likely Bugs/Likely Typos/ContradictoryTypeChecks.ql
+++ b/java/ql/src/Likely Bugs/Likely Typos/ContradictoryTypeChecks.ql
@@ -9,6 +9,7 @@
  * @id java/contradictory-type-checks
  * @tags correctness
  *       logic
+ *       quality
  */
 
 import java

--- a/java/ql/src/Likely Bugs/Likely Typos/SuspiciousDateFormat.ql
+++ b/java/ql/src/Likely Bugs/Likely Typos/SuspiciousDateFormat.ql
@@ -6,6 +6,7 @@
  * @precision high
  * @id java/suspicious-date-format
  * @tags correctness
+ *       quality
  */
 
 import java

--- a/java/ql/src/Likely Bugs/Resource Leaks/CloseReader.ql
+++ b/java/ql/src/Likely Bugs/Resource Leaks/CloseReader.ql
@@ -9,6 +9,7 @@
  * @tags efficiency
  *       correctness
  *       resources
+ *       quality
  *       external/cwe/cwe-404
  *       external/cwe/cwe-772
  */

--- a/java/ql/src/Likely Bugs/Resource Leaks/CloseWriter.ql
+++ b/java/ql/src/Likely Bugs/Resource Leaks/CloseWriter.ql
@@ -9,6 +9,7 @@
  * @tags efficiency
  *       correctness
  *       resources
+ *       quality
  *       external/cwe/cwe-404
  *       external/cwe/cwe-772
  */

--- a/java/ql/src/codeql-suites/java-code-quality.qls
+++ b/java/ql/src/codeql-suites/java-code-quality.qls
@@ -1,17 +1,3 @@
 - queries: .
-- include:
-    id:
-      - java/contradictory-type-checks
-      - java/do-not-call-finalize
-      - java/equals-on-unrelated-types
-      - java/inconsistent-equals-and-hashcode
-      - java/input-resource-leak
-      - java/integer-multiplication-cast-to-long
-      - java/junit5-missing-nested-annotation
-      - java/output-resource-leak
-      - java/reference-equality-of-boxed-types
-      - java/string-replace-all-with-non-regex
-      - java/suspicious-date-format
-      - java/type-variable-hides-type
-      - java/unchecked-cast-in-equals
-      - java/unused-container
+- apply: code-quality-selectors.yml
+  from: codeql/suite-helpers

--- a/javascript/ql/src/Declarations/IneffectiveParameterType.ql
+++ b/javascript/ql/src/Declarations/IneffectiveParameterType.ql
@@ -7,6 +7,7 @@
  * @precision high
  * @tags correctness
  *       typescript
+ *       quality
  */
 
 import javascript

--- a/javascript/ql/src/Expressions/MissingAwait.ql
+++ b/javascript/ql/src/Expressions/MissingAwait.ql
@@ -5,6 +5,7 @@
  * @problem.severity warning
  * @id js/missing-await
  * @tags correctness
+ *       quality
  * @precision high
  */
 

--- a/javascript/ql/src/LanguageFeatures/SpuriousArguments.ql
+++ b/javascript/ql/src/LanguageFeatures/SpuriousArguments.ql
@@ -7,6 +7,7 @@
  * @tags maintainability
  *       correctness
  *       language-features
+ *       quality
  *       external/cwe/cwe-685
  * @precision very-high
  */

--- a/javascript/ql/src/RegExp/RegExpAlwaysMatches.ql
+++ b/javascript/ql/src/RegExp/RegExpAlwaysMatches.ql
@@ -6,6 +6,7 @@
  * @id js/regex/always-matches
  * @tags correctness
  *       regular-expressions
+ *       quality
  * @precision high
  */
 

--- a/javascript/ql/src/codeql-suites/javascript-code-quality.qls
+++ b/javascript/ql/src/codeql-suites/javascript-code-quality.qls
@@ -1,8 +1,3 @@
 - queries: .
-- include:
-    id:
-      - js/missing-await
-      - js/regex/always-matches
-      - js/superfluous-trailing-arguments
-      - js/useless-expression
-      - js/ineffective-parameter-type
+- apply: code-quality-selectors.yml
+  from: codeql/suite-helpers

--- a/misc/suite-helpers/code-quality-selectors.yml
+++ b/misc/suite-helpers/code-quality-selectors.yml
@@ -1,0 +1,10 @@
+- description: Selectors for selecting the Code-Quality-relevant queries for a language
+- include:
+    kind:
+    - problem
+    - path-problem
+    precision:
+    - high
+    - very-high
+    tags contain:
+    - quality

--- a/python/ql/integration-tests/query-suite/python-code-quality.qls.expected
+++ b/python/ql/integration-tests/query-suite/python-code-quality.qls.expected
@@ -1,4 +1,6 @@
 ql/python/ql/src/Functions/NonCls.ql
 ql/python/ql/src/Functions/NonSelf.ql
+ql/python/ql/src/Functions/ReturnConsistentTupleSizes.ql
 ql/python/ql/src/Functions/SignatureSpecialMethods.ql
 ql/python/ql/src/Resources/FileNotAlwaysClosed.ql
+ql/python/ql/src/Variables/LoopVariableCapture/LoopVariableCapture.ql

--- a/python/ql/src/Functions/NonCls.ql
+++ b/python/ql/src/Functions/NonCls.ql
@@ -5,6 +5,7 @@
  * @tags maintainability
  *       readability
  *       convention
+ *       quality
  * @problem.severity recommendation
  * @sub-severity high
  * @precision high

--- a/python/ql/src/Functions/NonSelf.ql
+++ b/python/ql/src/Functions/NonSelf.ql
@@ -5,6 +5,7 @@
  * @tags maintainability
  *       readability
  *       convention
+ *       quality
  * @problem.severity recommendation
  * @sub-severity high
  * @precision very-high

--- a/python/ql/src/codeql-suites/python-code-quality.qls
+++ b/python/ql/src/codeql-suites/python-code-quality.qls
@@ -1,7 +1,3 @@
 - queries: .
-- include:
-    id:
-      - py/not-named-self
-      - py/not-named-cls
-      - py/file-not-closed
-      - py/special-method-wrong-signature
+- apply: code-quality-selectors.yml
+  from: codeql/suite-helpers

--- a/ruby/ql/integration-tests/query-suite/ruby-code-quality.qls.expected
+++ b/ruby/ql/integration-tests/query-suite/ruby-code-quality.qls.expected
@@ -1,3 +1,2 @@
 ql/ruby/ql/src/queries/performance/DatabaseQueryInLoop.ql
-ql/ruby/ql/src/queries/variables/DeadStoreOfLocal.ql
 ql/ruby/ql/src/queries/variables/UninitializedLocal.ql

--- a/ruby/ql/src/codeql-suites/ruby-code-quality.qls
+++ b/ruby/ql/src/codeql-suites/ruby-code-quality.qls
@@ -1,6 +1,3 @@
 - queries: .
-- include:
-    id:
-      - rb/database-query-in-loop
-      - rb/useless-assignment-to-local
-      - rb/uninitialized-local-variable
+- apply: code-quality-selectors.yml
+  from: codeql/suite-helpers

--- a/ruby/ql/src/queries/performance/DatabaseQueryInLoop.ql
+++ b/ruby/ql/src/queries/performance/DatabaseQueryInLoop.ql
@@ -6,6 +6,7 @@
  * @precision high
  * @id rb/database-query-in-loop
  * @tags performance
+ *       quality
  */
 
 import ruby

--- a/ruby/ql/src/queries/variables/DeadStoreOfLocal.ql
+++ b/ruby/ql/src/queries/variables/DeadStoreOfLocal.ql
@@ -6,6 +6,7 @@
  * @problem.severity warning
  * @id rb/useless-assignment-to-local
  * @tags maintainability
+ *       quality
  *       external/cwe/cwe-563
  * @precision medium
  */

--- a/rust/ql/src/codeql-suites/rust-code-quality.qls
+++ b/rust/ql/src/codeql-suites/rust-code-quality.qls
@@ -1,1 +1,3 @@
-[]
+- queries: .
+- apply: code-quality-selectors.yml
+  from: codeql/suite-helpers

--- a/swift/ql/src/codeql-suites/swift-code-quality.qls
+++ b/swift/ql/src/codeql-suites/swift-code-quality.qls
@@ -1,1 +1,3 @@
-[]
+- queries: .
+- apply: code-quality-selectors.yml
+  from: codeql/suite-helpers


### PR DESCRIPTION
This PR is changing the code-quality query suites to not list individual query IDs, but instead use a shared selector.

Note that the modification results in changes in the following suites: Java, Python, Ruby.