### PR TITLE
Ruby: disable diff-informed mode on regex queries

### DIFF
--- a/ruby/ql/lib/codeql/ruby/security/regexp/MissingFullAnchorQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/regexp/MissingFullAnchorQuery.qll
@@ -17,16 +17,6 @@ private module MissingFullAnchorConfig implements DataFlow::ConfigSig {
   predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
 
   predicate isBarrier(DataFlow::Node node) { node instanceof Sanitizer }
-
-  predicate observeDiffInformedIncrementalMode() { any() }
-
-  Location getASelectedSinkLocation(DataFlow::Node sink) {
-    result = sink.(Sink).getLocation()
-    or
-    result = sink.(Sink).getCallNode().getLocation()
-    or
-    result = sink.(Sink).getRegex().getLocation()
-  }
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/security/regexp/PolynomialReDoSQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/regexp/PolynomialReDoSQuery.qll
@@ -18,16 +18,6 @@ private module PolynomialReDoSConfig implements DataFlow::ConfigSig {
   predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
 
   predicate isBarrier(DataFlow::Node node) { node instanceof Sanitizer }
-
-  predicate observeDiffInformedIncrementalMode() { any() }
-
-  Location getASelectedSinkLocation(DataFlow::Node sink) {
-    result = sink.(Sink).getLocation()
-    or
-    result = sink.(Sink).getHighlight().getLocation()
-    or
-    result = sink.(Sink).getRegExp().getLocation()
-  }
 }
 
 /**


### PR DESCRIPTION
These queries were failing in `codeql test run --check-diff-informed` because they can select locations inside the regex. Until that can be fixed, diff-informed mode is disabled for these queries.

I didn't add a code comment with details about the problem because I didn't investigate it in full detail, but I presume it's overall the same story as in #19379.

Cc @d10c @cklin @asgerf 