### PR TITLE
Fix cwe tags to include leading zero

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-014/MemsetMayBeDeleted.ql
+++ b/cpp/ql/src/Security/CWE/CWE-014/MemsetMayBeDeleted.ql
@@ -8,7 +8,7 @@
  * @security-severity 7.8
  * @precision high
  * @tags security
- *       external/cwe/cwe-14
+ *       external/cwe/cwe-014
  */
 
 import cpp

--- a/cpp/ql/src/Security/CWE/CWE-020/CountUntrustedDataToExternalAPI.ql
+++ b/cpp/ql/src/Security/CWE/CWE-020/CountUntrustedDataToExternalAPI.ql
@@ -5,7 +5,7 @@
  *              to it.
  * @id cpp/count-untrusted-data-external-api
  * @kind table
- * @tags security external/cwe/cwe-20
+ * @tags security external/cwe/cwe-020
  */
 
 import cpp

--- a/cpp/ql/src/Security/CWE/CWE-020/IRCountUntrustedDataToExternalAPI.ql
+++ b/cpp/ql/src/Security/CWE/CWE-020/IRCountUntrustedDataToExternalAPI.ql
@@ -5,7 +5,7 @@
  *              to it.
  * @id cpp/count-untrusted-data-external-api-ir
  * @kind table
- * @tags security external/cwe/cwe-20
+ * @tags security external/cwe/cwe-020
  */
 
 import cpp

--- a/cpp/ql/src/Security/CWE/CWE-020/IRUntrustedDataToExternalAPI.ql
+++ b/cpp/ql/src/Security/CWE/CWE-020/IRUntrustedDataToExternalAPI.ql
@@ -6,7 +6,7 @@
  * @precision low
  * @problem.severity error
  * @security-severity 7.8
- * @tags security external/cwe/cwe-20
+ * @tags security external/cwe/cwe-020
  */
 
 import cpp

--- a/cpp/ql/src/Security/CWE/CWE-020/UntrustedDataToExternalAPI.ql
+++ b/cpp/ql/src/Security/CWE/CWE-020/UntrustedDataToExternalAPI.ql
@@ -6,7 +6,7 @@
  * @precision low
  * @problem.severity error
  * @security-severity 7.8
- * @tags security external/cwe/cwe-20
+ * @tags security external/cwe/cwe-020
  */
 
 import cpp

--- a/cpp/ql/src/change-notes/2025-05-01-cwe-tag-changed.md
+++ b/cpp/ql/src/change-notes/2025-05-01-cwe-tag-changed.md
@@ -1,0 +1,9 @@
+---
+category: queryMetadata
+---
+* The tag `external/cwe/cwe-14` has been removed from `cpp/memset-may-be-deleted` and the tag `external/cwe/cwe-014` has been added.
+* The tag `external/cwe/cwe-20` has been removed from `cpp/count-untrusted-data-external-api` and the tag `external/cwe/cwe-020` has been added.
+* The tag `external/cwe/cwe-20` has been removed from `cpp/count-untrusted-data-external-api-ir` and the tag `external/cwe/cwe-020` has been added.
+* The tag `external/cwe/cwe-20` has been removed from `cpp/untrusted-data-to-external-api-ir` and the tag `external/cwe/cwe-020` has been added.
+* The tag `external/cwe/cwe-20` has been removed from `cpp/untrusted-data-to-external-api` and the tag `external/cwe/cwe-020` has been added.
+* The tag `external/cwe/cwe-20` has been removed from `cpp/late-check-of-function-argument` and the tag `external/cwe/cwe-020` has been added.

--- a/cpp/ql/src/experimental/Security/CWE/CWE-020/LateCheckOfFunctionArgument.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-020/LateCheckOfFunctionArgument.ql
@@ -10,7 +10,7 @@
  * @tags correctness
  *       security
  *       experimental
- *       external/cwe/cwe-20
+ *       external/cwe/cwe-020
  */
 
 import cpp

--- a/csharp/ql/src/Configuration/PasswordInConfigurationFile.ql
+++ b/csharp/ql/src/Configuration/PasswordInConfigurationFile.ql
@@ -7,7 +7,7 @@
  * @precision medium
  * @id cs/password-in-configuration
  * @tags security
- *       external/cwe/cwe-13
+ *       external/cwe/cwe-013
  *       external/cwe/cwe-256
  *       external/cwe/cwe-313
  */

--- a/csharp/ql/src/Security Features/CWE-011/ASPNetDebug.ql
+++ b/csharp/ql/src/Security Features/CWE-011/ASPNetDebug.ql
@@ -10,7 +10,7 @@
  * @tags security
  *       maintainability
  *       frameworks/asp.net
- *       external/cwe/cwe-11
+ *       external/cwe/cwe-011
  *       external/cwe/cwe-532
  */
 

--- a/csharp/ql/src/Security Features/CWE-016/ASPNetMaxRequestLength.ql
+++ b/csharp/ql/src/Security Features/CWE-016/ASPNetMaxRequestLength.ql
@@ -8,7 +8,7 @@
  * @id cs/web/large-max-request-length
  * @tags security
  *       frameworks/asp.net
- *       external/cwe/cwe-16
+ *       external/cwe/cwe-016
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/CWE-016/ASPNetPagesValidateRequest.ql
+++ b/csharp/ql/src/Security Features/CWE-016/ASPNetPagesValidateRequest.ql
@@ -8,7 +8,7 @@
  * @id cs/web/request-validation-disabled
  * @tags security
  *       frameworks/asp.net
- *       external/cwe/cwe-16
+ *       external/cwe/cwe-016
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/CWE-020/ExternalAPIsUsedWithUntrustedData.ql
+++ b/csharp/ql/src/Security Features/CWE-020/ExternalAPIsUsedWithUntrustedData.ql
@@ -5,7 +5,7 @@
  *              to it.
  * @id cs/count-untrusted-data-external-api
  * @kind table
- * @tags security external/cwe/cwe-20
+ * @tags security external/cwe/cwe-020
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/CWE-020/RuntimeChecksBypass.ql
+++ b/csharp/ql/src/Security Features/CWE-020/RuntimeChecksBypass.ql
@@ -7,7 +7,7 @@
  * @security-severity 7.8
  * @precision medium
  * @tags security
- *       external/cwe/cwe-20
+ *       external/cwe/cwe-020
  */
 
 import semmle.code.csharp.serialization.Serialization

--- a/csharp/ql/src/Security Features/CWE-020/UntrustedDataToExternalAPI.ql
+++ b/csharp/ql/src/Security Features/CWE-020/UntrustedDataToExternalAPI.ql
@@ -6,7 +6,7 @@
  * @precision low
  * @problem.severity error
  * @security-severity 7.8
- * @tags security external/cwe/cwe-20
+ * @tags security external/cwe/cwe-020
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/CWE-248/MissingASPNETGlobalErrorHandler.ql
+++ b/csharp/ql/src/Security Features/CWE-248/MissingASPNETGlobalErrorHandler.ql
@@ -8,7 +8,7 @@
  * @precision high
  * @id cs/web/missing-global-error-handler
  * @tags security
- *       external/cwe/cwe-12
+ *       external/cwe/cwe-012
  *       external/cwe/cwe-248
  */
 

--- a/csharp/ql/src/change-notes/2025-05-01-cwe-tag-changed.md
+++ b/csharp/ql/src/change-notes/2025-05-01-cwe-tag-changed.md
@@ -1,0 +1,12 @@
+---
+category: queryMetadata
+---
+
+* The tag `external/cwe/cwe-13` has been removed from `cs/password-in-configuration` and the tag `external/cwe/cwe-013` has been added.
+* The tag `external/cwe/cwe-11` has been removed from `cs/web/debug-binary` and the tag `external/cwe/cwe-011` has been added.
+* The tag `external/cwe/cwe-16` has been removed from `cs/web/large-max-request-length` and the tag `external/cwe/cwe-016` has been added.
+* The tag `external/cwe/cwe-16` has been removed from `cs/web/request-validation-disabled` and the tag `external/cwe/cwe-016` has been added.
+* The tag `external/cwe/cwe-20` has been removed from `cs/count-untrusted-data-external-api` and the tag `external/cwe/cwe-020` has been added.
+* The tag `external/cwe/cwe-20` has been removed from `cs/serialization-check-bypass` and the tag `external/cwe/cwe-020` has been added.
+* The tag `external/cwe/cwe-20` has been removed from `cs/untrusted-data-to-external-api` and the tag `external/cwe/cwe-020` has been added.
+* The tag `external/cwe/cwe-12` has been removed from `cs/web/missing-global-error-handler` and the tag `external/cwe/cwe-012` has been added.

--- a/go/ql/src/Security/CWE-020/ExternalAPIsUsedWithUntrustedData.ql
+++ b/go/ql/src/Security/CWE-020/ExternalAPIsUsedWithUntrustedData.ql
@@ -5,7 +5,7 @@
  *              to it.
  * @id go/count-untrusted-data-external-api
  * @kind table
- * @tags security external/cwe/cwe-20
+ * @tags security external/cwe/cwe-020
  */
 
 import go

--- a/go/ql/src/Security/CWE-020/IncompleteHostnameRegexp.ql
+++ b/go/ql/src/Security/CWE-020/IncompleteHostnameRegexp.ql
@@ -9,7 +9,7 @@
  * @id go/incomplete-hostname-regexp
  * @tags correctness
  *       security
- *       external/cwe/cwe-20
+ *       external/cwe/cwe-020
  */
 
 import go

--- a/go/ql/src/Security/CWE-020/MissingRegexpAnchor.ql
+++ b/go/ql/src/Security/CWE-020/MissingRegexpAnchor.ql
@@ -8,7 +8,7 @@
  * @id go/regex/missing-regexp-anchor
  * @tags correctness
  *       security
- *       external/cwe/cwe-20
+ *       external/cwe/cwe-020
  */
 
 import go

--- a/go/ql/src/Security/CWE-020/SuspiciousCharacterInRegexp.ql
+++ b/go/ql/src/Security/CWE-020/SuspiciousCharacterInRegexp.ql
@@ -8,7 +8,7 @@
  * @id go/suspicious-character-in-regex
  * @tags correctness
  *       security
- *       external/cwe/cwe-20
+ *       external/cwe/cwe-020
  */
 
 import go

--- a/go/ql/src/Security/CWE-020/UntrustedDataToExternalAPI.ql
+++ b/go/ql/src/Security/CWE-020/UntrustedDataToExternalAPI.ql
@@ -6,7 +6,7 @@
  * @precision low
  * @problem.severity error
  * @security-severity 7.8
- * @tags security external/cwe/cwe-20
+ * @tags security external/cwe/cwe-020
  */
 
 import go

--- a/go/ql/src/Security/CWE-020/UntrustedDataToUnknownExternalAPI.ql
+++ b/go/ql/src/Security/CWE-020/UntrustedDataToUnknownExternalAPI.ql
@@ -6,7 +6,7 @@
  * @precision low
  * @problem.severity error
  * @security-severity 7.8
- * @tags security external/cwe/cwe-20
+ * @tags security external/cwe/cwe-020
  */
 
 import go

--- a/go/ql/src/change-notes/2025-05-01-cwe-tag-changed.md
+++ b/go/ql/src/change-notes/2025-05-01-cwe-tag-changed.md
@@ -1,0 +1,14 @@
+---
+category: queryMetadata
+---
+
+* The tag `external/cwe/cwe-20` has been removed from `go/count-untrusted-data-external-api` and the tag `external/cwe/cwe-020` has been added.
+* The tag `external/cwe/cwe-20` has been removed from `go/incomplete-hostname-regexp` and the tag `external/cwe/cwe-020` has been added.
+* The tag `external/cwe/cwe-20` has been removed from `go/regex/missing-regexp-anchor` and the tag `external/cwe/cwe-020` has been added.
+* The tag `external/cwe/cwe-20` has been removed from `go/suspicious-character-in-regex` and the tag `external/cwe/cwe-020` has been added.
+* The tag `external/cwe/cwe-20` has been removed from `go/untrusted-data-to-external-api` and the tag `external/cwe/cwe-020` has been added.
+* The tag `external/cwe/cwe-20` has been removed from `go/untrusted-data-to-unknown-external-api` and the tag `external/cwe/cwe-020` has been added.
+* The tag `external/cwe/cwe-90` has been removed from `go/ldap-injection` and the tag `external/cwe/cwe-090` has been added.
+* The tag `external/cwe/cwe-74` has been removed from `go/dsn-injection` and the tag `external/cwe/cwe-074` has been added.
+* The tag `external/cwe/cwe-74` has been removed from `go/dsn-injection-local` and the tag `external/cwe/cwe-074` has been added.
+* The tag `external/cwe/cwe-79` has been removed from `go/html-template-escaping-passthrough` and the tag `external/cwe/cwe-079` has been added.

--- a/go/ql/src/experimental/CWE-090/LDAPInjection.ql
+++ b/go/ql/src/experimental/CWE-090/LDAPInjection.ql
@@ -7,7 +7,7 @@
  * @id go/ldap-injection
  * @tags security
  *       experimental
- *       external/cwe/cwe-90
+ *       external/cwe/cwe-090
  */
 
 import go

--- a/go/ql/src/experimental/CWE-74/DsnInjection.ql
+++ b/go/ql/src/experimental/CWE-74/DsnInjection.ql
@@ -6,7 +6,7 @@
  * @id go/dsn-injection
  * @tags security
  *       experimental
- *       external/cwe/cwe-74
+ *       external/cwe/cwe-074
  */
 
 import go

--- a/go/ql/src/experimental/CWE-74/DsnInjectionLocal.ql
+++ b/go/ql/src/experimental/CWE-74/DsnInjectionLocal.ql
@@ -6,7 +6,7 @@
  * @id go/dsn-injection-local
  * @tags security
  *       experimental
- *       external/cwe/cwe-74
+ *       external/cwe/cwe-074
  */
 
 import go

--- a/go/ql/src/experimental/CWE-79/HTMLTemplateEscapingPassthrough.ql
+++ b/go/ql/src/experimental/CWE-79/HTMLTemplateEscapingPassthrough.ql
@@ -7,7 +7,7 @@
  * @id go/html-template-escaping-passthrough
  * @tags security
  *       experimental
- *       external/cwe/cwe-79
+ *       external/cwe/cwe-079
  */
 
 import go

--- a/java/ql/src/Security/CWE/CWE-020/ExternalAPIsUsedWithUntrustedData.ql
+++ b/java/ql/src/Security/CWE/CWE-020/ExternalAPIsUsedWithUntrustedData.ql
@@ -5,7 +5,7 @@
  *              to it.
  * @id java/count-untrusted-data-external-api
  * @kind table
- * @tags security external/cwe/cwe-20
+ * @tags security external/cwe/cwe-020
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-020/UntrustedDataToExternalAPI.ql
+++ b/java/ql/src/Security/CWE/CWE-020/UntrustedDataToExternalAPI.ql
@@ -6,7 +6,7 @@
  * @precision low
  * @problem.severity error
  * @security-severity 7.8
- * @tags security external/cwe/cwe-20
+ * @tags security external/cwe/cwe-020
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-113/NettyResponseSplitting.ql
+++ b/java/ql/src/Security/CWE/CWE-113/NettyResponseSplitting.ql
@@ -9,7 +9,7 @@
  * @precision high
  * @id java/netty-http-request-or-response-splitting
  * @tags security
- *       external/cwe/cwe-93
+ *       external/cwe/cwe-093
  *       external/cwe/cwe-113
  */
 

--- a/java/ql/src/change-notes/2025-05-01-cwe-tag-changed.md
+++ b/java/ql/src/change-notes/2025-05-01-cwe-tag-changed.md
@@ -1,0 +1,7 @@
+---
+category: queryMetadata
+---
+
+* The tag `external/cwe/cwe-20` has been removed from `java/count-untrusted-data-external-api` and the tag `external/cwe/cwe-020` has been added.
+* The tag `external/cwe/cwe-20` has been removed from `java/untrusted-data-to-external-api` and the tag `external/cwe/cwe-020` has been added.
+* The tag `external/cwe/cwe-93` has been removed from `java/netty-http-request-or-response-splitting` and the tag `external/cwe/cwe-093` has been added.

--- a/javascript/ql/src/Electron/DisablingWebSecurity.ql
+++ b/javascript/ql/src/Electron/DisablingWebSecurity.ql
@@ -7,7 +7,7 @@
  * @precision very-high
  * @tags security
  *       frameworks/electron
- *       external/cwe/cwe-79
+ *       external/cwe/cwe-079
  * @id js/disabling-electron-websecurity
  */
 

--- a/javascript/ql/src/Security/CWE-020/ExternalAPIsUsedWithUntrustedData.ql
+++ b/javascript/ql/src/Security/CWE-020/ExternalAPIsUsedWithUntrustedData.ql
@@ -5,7 +5,7 @@
  *              to it.
  * @id js/count-untrusted-data-external-api
  * @kind table
- * @tags security external/cwe/cwe-20
+ * @tags security external/cwe/cwe-020
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-020/UntrustedDataToExternalAPI.ql
+++ b/javascript/ql/src/Security/CWE-020/UntrustedDataToExternalAPI.ql
@@ -6,7 +6,7 @@
  * @precision low
  * @problem.severity error
  * @security-severity 7.8
- * @tags security external/cwe/cwe-20
+ * @tags security external/cwe/cwe-020
  */
 
 import javascript

--- a/javascript/ql/src/change-notes/2025-05-01-cwe-tag-changed.md
+++ b/javascript/ql/src/change-notes/2025-05-01-cwe-tag-changed.md
@@ -1,0 +1,8 @@
+---
+category: queryMetadata
+---
+
+* The tag `external/cwe/cwe-79` has been removed from `js/disabling-electron-websecurity` and the tag `external/cwe/cwe-079` has been added.
+* The tag `external/cwe/cwe-20` has been removed from `js/count-untrusted-data-external-api` and the tag `external/cwe/cwe-020` has been added.
+* The tag `external/cwe/cwe-20` has been removed from `js/untrusted-data-to-external-api` and the tag `external/cwe/cwe-020` has been added.
+* The tag `external/cwe/cwe-20` has been removed from `js/untrusted-data-to-external-api-more-sources` and the tag `external/cwe/cwe-020` has been added.

--- a/javascript/ql/src/experimental/heuristics/ql/src/Security/CWE-020/UntrustedDataToExternalAPI.ql
+++ b/javascript/ql/src/experimental/heuristics/ql/src/Security/CWE-020/UntrustedDataToExternalAPI.ql
@@ -7,7 +7,7 @@
  * @problem.severity error
  * @security-severity 7.8
  * @tags experimental
- *       security external/cwe/cwe-20
+ *       security external/cwe/cwe-020
  */
 
 import javascript

--- a/python/ql/src/Expressions/UseofInput.ql
+++ b/python/ql/src/Expressions/UseofInput.ql
@@ -4,8 +4,8 @@
  * @kind problem
  * @tags security
  *       correctness
- *       security/cwe/cwe-94
- *       security/cwe/cwe-95
+ *       external/cwe/cwe-094
+ *       external/cwe/cwe-095
  * @problem.severity error
  * @security-severity 9.8
  * @sub-severity high

--- a/python/ql/src/Security/CWE-020-ExternalAPIs/ExternalAPIsUsedWithUntrustedData.ql
+++ b/python/ql/src/Security/CWE-020-ExternalAPIs/ExternalAPIsUsedWithUntrustedData.ql
@@ -5,7 +5,7 @@
  *              to it.
  * @id py/count-untrusted-data-external-api
  * @kind table
- * @tags security external/cwe/cwe-20
+ * @tags security external/cwe/cwe-020
  */
 
 import python

--- a/python/ql/src/Security/CWE-020-ExternalAPIs/UntrustedDataToExternalAPI.ql
+++ b/python/ql/src/Security/CWE-020-ExternalAPIs/UntrustedDataToExternalAPI.ql
@@ -6,7 +6,7 @@
  * @precision low
  * @problem.severity error
  * @security-severity 7.8
- * @tags security external/cwe/cwe-20
+ * @tags security external/cwe/cwe-020
  */
 
 import python

--- a/python/ql/src/Security/CWE-020/CookieInjection.ql
+++ b/python/ql/src/Security/CWE-020/CookieInjection.ql
@@ -7,7 +7,7 @@
  * @security-severity 5.0
  * @id py/cookie-injection
  * @tags security
- *       external/cwe/cwe-20
+ *       external/cwe/cwe-020
  */
 
 import python

--- a/python/ql/src/Security/CWE-020/IncompleteUrlSubstringSanitization.ql
+++ b/python/ql/src/Security/CWE-020/IncompleteUrlSubstringSanitization.ql
@@ -8,7 +8,7 @@
  * @id py/incomplete-url-substring-sanitization
  * @tags correctness
  *       security
- *       external/cwe/cwe-20
+ *       external/cwe/cwe-020
  */
 
 import python

--- a/python/ql/src/change-notes/2025-05-01-cwe-tag-changed.md
+++ b/python/ql/src/change-notes/2025-05-01-cwe-tag-changed.md
@@ -1,0 +1,10 @@
+---
+category: queryMetadata
+---
+
+* The tags `security/cwe/cwe-94` and `security/cwe/cwe-95` have been removed from `py/use-of-input` and the tags `external/cwe/cwe-094` and `external/cwe/cwe-095` have been added.
+* The tag `external/cwe/cwe-20` has been removed from `py/count-untrusted-data-external-api` and the tag `external/cwe/cwe-020` has been added.
+* The tag `external/cwe/cwe-20` has been removed from `py/untrusted-data-to-external-api` and the tag `external/cwe/cwe-020` has been added.
+* The tag `external/cwe/cwe-20` has been removed from `py/cookie-injection` and the tag `external/cwe/cwe-020` has been added.
+* The tag `external/cwe/cwe-20` has been removed from `py/incomplete-url-substring-sanitization` and the tag `external/cwe/cwe-020` has been added.
+* The tag `external/cwe/cwe-94` has been removed from `py/js2py-rce` and the tag `external/cwe/cwe-094` has been added.

--- a/python/ql/src/experimental/Security/CWE-094/Js2Py.ql
+++ b/python/ql/src/experimental/Security/CWE-094/Js2Py.ql
@@ -8,7 +8,7 @@
  * @id py/js2py-rce
  * @tags security
  *       experimental
- *       external/cwe/cwe-94
+ *       external/cwe/cwe-094
  */
 
 import python

--- a/ruby/ql/src/change-notes/2025-05-01-cwe-tag-changed.md
+++ b/ruby/ql/src/change-notes/2025-05-01-cwe-tag-changed.md
@@ -1,0 +1,5 @@
+---
+category: queryMetadata
+---
+
+* The tag `external/cwe/cwe-94` has been removed from `rb/server-side-template-injection` and the tag `external/cwe/cwe-094` has been added.

--- a/ruby/ql/src/experimental/template-injection/TemplateInjection.ql
+++ b/ruby/ql/src/experimental/template-injection/TemplateInjection.ql
@@ -8,7 +8,7 @@
  * @precision high
  * @id rb/server-side-template-injection
  * @tags security
- *       external/cwe/cwe-94
+ *       external/cwe/cwe-094
  */
 
 import codeql.ruby.DataFlow


### PR DESCRIPTION
[The query metadata style guide](https://github.com/github/codeql/blob/main/docs/query-metadata-style-guide.md) gives examples where the cwe number has leading zeros to make it three digits, like `external/cwe/cwe-022`. Most queries do this, but some are missing the leading zeros. This PR fixes that, and also one query that I noticed in passing had the wrong form for its CWE tags.

~I hope this doesn't need a change note for each language. Let me know if I'm wrong.~ I got copilot to generate change notes for me :copilot: .