### PR TITLE
python: model `send_header` from `http.server`

### DIFF
--- a/python/ql/lib/change-notes/2025-04-30-model-send-header.md
+++ b/python/ql/lib/change-notes/2025-04-30-model-send-header.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added header write model for `send_header` in `http.server`.

--- a/python/ql/lib/semmle/python/frameworks/Stdlib.qll
+++ b/python/ql/lib/semmle/python/frameworks/Stdlib.qll
@@ -1973,7 +1973,6 @@ module StdlibPrivate {
 
       override DataFlow::Node getValueArg() { result = this.getArg(1) }
 
-      // TODO: These checks perhaps could be made more precise.
       override predicate nameAllowsNewline() { any() }
 
       override predicate valueAllowsNewline() { any() }

--- a/python/ql/lib/semmle/python/frameworks/Stdlib.qll
+++ b/python/ql/lib/semmle/python/frameworks/Stdlib.qll
@@ -1963,6 +1963,22 @@ module StdlibPrivate {
     /** Gets a reference to an instance of the `BaseHttpRequestHandler` class or any subclass. */
     DataFlow::Node instance() { instance(DataFlow::TypeTracker::end()).flowsTo(result) }
 
+    /** A call to a method that writes to a response header. */
+    private class HeaderWriteCall extends Http::Server::ResponseHeaderWrite::Range,
+      DataFlow::MethodCallNode
+    {
+      HeaderWriteCall() { this.calls(instance(), "send_header") }
+
+      override DataFlow::Node getNameArg() { result = this.getArg(0) }
+
+      override DataFlow::Node getValueArg() { result = this.getArg(1) }
+
+      // TODO: These checks perhaps could be made more precise.
+      override predicate nameAllowsNewline() { any() }
+
+      override predicate valueAllowsNewline() { any() }
+    }
+
     private class AdditionalTaintStep extends TaintTracking::AdditionalTaintStep {
       override predicate step(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
         nodeFrom = instance() and

--- a/python/ql/test/library-tests/frameworks/stdlib/http_server.py
+++ b/python/ql/test/library-tests/frameworks/stdlib/http_server.py
@@ -83,7 +83,7 @@ class MyHandler(BaseHTTPRequestHandler):
     def do_GET(self): # $ requestHandler
         # send_response will log a line to stderr
         self.send_response(200)
-        self.send_header("Content-type", "text/plain; charset=utf-8")
+        self.send_header("Content-type", "text/plain; charset=utf-8") # $ headerWriteNameUnsanitized="Content-type" headerWriteValueUnsanitized="text/plain; charset=utf-8"
         self.end_headers()
         self.wfile.write(b"Hello BaseHTTPRequestHandler\n")
         self.wfile.writelines([b"1\n", b"2\n", b"3\n"])


### PR DESCRIPTION
Requested [here](https://github.com/github/field-security-codeql/issues/194)