### PR TITLE
Actions: Retroactively add GA changenote

### DIFF
--- a/actions/ql/lib/CHANGELOG.md
+++ b/actions/ql/lib/CHANGELOG.md
@@ -4,7 +4,9 @@ No user-facing changes.
 
 ## 0.4.7
 
-No user-facing changes.
+### New Features
+
+* CodeQL and Copilot Autofix support for GitHub Actions is now Generally Available.
 
 ## 0.4.6
 

--- a/actions/ql/lib/change-notes/released/0.4.7.md
+++ b/actions/ql/lib/change-notes/released/0.4.7.md
@@ -1,3 +1,5 @@
 ## 0.4.7
 
-No user-facing changes.
+### New Features
+
+* CodeQL and Copilot Autofix support for GitHub Actions is now Generally Available.

--- a/actions/ql/src/CHANGELOG.md
+++ b/actions/ql/src/CHANGELOG.md
@@ -20,6 +20,10 @@
 
 ## 0.5.4
 
+### New Features
+
+* CodeQL and Copilot Autofix support for GitHub Actions is now Generally Available.
+
 ### Bug Fixes
 
 * Alerts produced by the query `actions/missing-workflow-permissions` now include a minimal set of recommended permissions in the alert message, based on well-known actions seen within the workflow file.

--- a/actions/ql/src/change-notes/released/0.5.4.md
+++ b/actions/ql/src/change-notes/released/0.5.4.md
@@ -1,5 +1,9 @@
 ## 0.5.4
 
+### New Features
+
+* CodeQL and Copilot Autofix support for GitHub Actions is now Generally Available.
+
 ### Bug Fixes
 
 * Alerts produced by the query `actions/missing-workflow-permissions` now include a minimal set of recommended permissions in the alert message, based on well-known actions seen within the workflow file.

--- a/docs/codeql/codeql-overview/codeql-changelog/codeql-cli-2.21.1.rst
+++ b/docs/codeql/codeql-overview/codeql-changelog/codeql-cli-2.21.1.rst
@@ -37,6 +37,14 @@ Bug Fixes
 Query Packs
 -----------
 
+New Features
+~~~~~~~~~~~~
+
+GitHub Actions
+""""""""""""""
+
+*   CodeQL and Copilot Autofix support for GitHub Actions is now Generally Available.
+
 Bug Fixes
 ~~~~~~~~~
 
@@ -122,6 +130,11 @@ Ruby
 
 New Features
 ~~~~~~~~~~~~
+
+GitHub Actions
+""""""""""""""
+
+*   CodeQL and Copilot Autofix support for GitHub Actions is now Generally Available.
 
 C/C++
 """""


### PR DESCRIPTION
This was manually added in the docs site at the time of 2.21.1 release and GA. Include the change note in the relevant places so it remains in future docs updates:
- codeql/actions-queries@0.5.4
- codeql/actions-all@0.4.7
- 2.21.1 changelog

Targeting `codeql-cli-2.21.2`, but should also merge cleanly into `main`.