### PR TITLE
Docs: Fix escaping in 2.21.0 changelog

### DIFF
--- a/docs/codeql/codeql-overview/codeql-changelog/codeql-cli-2.21.0.rst
+++ b/docs/codeql/codeql-overview/codeql-changelog/codeql-cli-2.21.0.rst
@@ -165,7 +165,7 @@ Java/Kotlin
 """""""""""
 
 *   Java extraction is now able to download Maven 3.9.x if a Maven Enforcer Plugin configuration indicates it is necessary. Maven 3.8.x is still preferred if the enforcer-plugin configuration (if any) permits it.
-*   Added a path injection sanitizer for calls to :code:`java.lang.String.matches`, :code:`java.lang.String.replace`, and :code:`java.lang.String.replaceAll` that make sure '/', '\', '..' are not in the path.
+*   Added a path injection sanitizer for calls to :code:`java.lang.String.matches`, :code:`java.lang.String.replace`, and :code:`java.lang.String.replaceAll` that make sure :code:`/`, :code:`\\`, :code:`..` are not in the path.
 
 JavaScript/TypeScript
 """""""""""""""""""""
@@ -207,5 +207,5 @@ JavaScript/TypeScript
 
     *   Intersection :code:`&&`
     *   Subtraction :code:`--`
-    *   :code:`\q` quoted string
+    *   :code:`\\q` quoted string
     


### PR DESCRIPTION
These break when the RST is processed.
Escape the backslashes and consistently add inline code blocks.