### PR TITLE
Python: modeling of `hdbcli`

### DIFF
--- a/docs/codeql/reusables/supported-frameworks.rst
+++ b/docs/codeql/reusables/supported-frameworks.rst
@@ -254,6 +254,7 @@ and the CodeQL library pack ``codeql/python-all`` (`changelog <https://github.co
    cassandra-driver, Database
    clickhouse-driver, Database
    cx_Oracle, Database
+   hdbcli, Database
    mysql-connector, Database
    mysql-connector-python, Database
    MySQL-python, Database

--- a/python/ql/lib/change-notes/2025-05-01-hdbcli.md
+++ b/python/ql/lib/change-notes/2025-05-01-hdbcli.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added modeling for the `hdbcli` PyPI package as a database library implementing PEP 249.

--- a/python/ql/lib/semmle/python/Frameworks.qll
+++ b/python/ql/lib/semmle/python/Frameworks.qll
@@ -35,6 +35,7 @@ private import semmle.python.frameworks.FlaskAdmin
 private import semmle.python.frameworks.FlaskSqlAlchemy
 private import semmle.python.frameworks.Genshi
 private import semmle.python.frameworks.Gradio
+private import semmle.python.frameworks.Hdbcli
 private import semmle.python.frameworks.Httpx
 private import semmle.python.frameworks.Idna
 private import semmle.python.frameworks.Invoke

--- a/python/ql/lib/semmle/python/frameworks/Hdbcli.qll
+++ b/python/ql/lib/semmle/python/frameworks/Hdbcli.qll
@@ -1,0 +1,24 @@
+/**
+ * Provides classes modeling security-relevant aspects of the `hdbcli` PyPI package.
+ * See https://pypi.org/project/hdbcli/
+ */
+
+private import python
+private import semmle.python.dataflow.new.RemoteFlowSources
+private import semmle.python.Concepts
+private import semmle.python.ApiGraphs
+private import semmle.python.frameworks.PEP249
+
+/**
+ * Provides models for the `hdbcli` PyPI package.
+ * See https://pypi.org/project/hdbcli/
+ */
+private module Hdbcli {
+  /**
+   * A model of `hdbcli` as a module that implements PEP 249, providing ways to execute SQL statements
+   * against a database.
+   */
+  class HdbcliPEP249 extends PEP249::PEP249ModuleApiNode {
+    HdbcliPEP249() { this = API::moduleImport("hdbcli").getMember("dbapi") }
+  }
+}

--- a/python/ql/test/library-tests/frameworks/hdbcli/ConceptsTest.ql
+++ b/python/ql/test/library-tests/frameworks/hdbcli/ConceptsTest.ql
@@ -1,0 +1,2 @@
+import python
+import experimental.meta.ConceptsTest

--- a/python/ql/test/library-tests/frameworks/hdbcli/pep249.py
+++ b/python/ql/test/library-tests/frameworks/hdbcli/pep249.py
@@ -3,7 +3,7 @@ from hdbcli import dbapi
 conn = dbapi.connect(address="hostname", port=300, user="username", password="password")
 cursor = conn.cursor()
 
-cursor.execute("some sql", (42,))  # $ MISSING: getSql="some sql"
-cursor.executemany("some sql", (42,))  # $ MISSING: getSql="some sql"
+cursor.execute("some sql", (42,))  # $ getSql="some sql"
+cursor.executemany("some sql", (42,))  # $ getSql="some sql"
     
 cursor.close()

--- a/python/ql/test/library-tests/frameworks/hdbcli/pep249.py
+++ b/python/ql/test/library-tests/frameworks/hdbcli/pep249.py
@@ -1,0 +1,9 @@
+from hdbcli import dbapi
+
+conn = dbapi.connect(address="hostname", port=300, user="username", password="password")
+cursor = conn.cursor()
+
+cursor.execute("some sql", (42,))  # $ MISSING: getSql="some sql"
+cursor.executemany("some sql", (42,))  # $ MISSING: getSql="some sql"
+    
+cursor.close()


### PR DESCRIPTION
Added support for the `hdbcli` PyPI package (SAP HANA DB connector) as a PEP 249 compliant database module.