### PR TITLE
Ruby printAst: fix order for synth children of real parents

### DIFF
--- a/ruby/ql/lib/change-notes/2025-05-02-ruby-printast-order-fix.md
+++ b/ruby/ql/lib/change-notes/2025-05-02-ruby-printast-order-fix.md
@@ -1,0 +1,6 @@
+---
+category: fix
+---
+### Bug Fixes
+
+* The Ruby printAst.qll library now orders AST nodes slightly differently: child nodes that do not literally appear in the source code, but whose parent nodes do, are assigned a deterministic order based on a combination of source location and logical order within the parent. This fixes the non-deterministic ordering that sometimes occurred depending on evaluation order. The effect may also be visible in downstream uses of the printAst library, such as the AST view in the VSCode extension.

--- a/ruby/ql/lib/codeql/ruby/printAst.qll
+++ b/ruby/ql/lib/codeql/ruby/printAst.qll
@@ -121,15 +121,17 @@ class PrintRegularAstNode extends PrintAstNode, TPrintRegularAstNode {
   }
 
   private int getSynthAstNodeIndex() {
-    this.parentIsSynthesized() and
-    exists(AstNode parent |
-      shouldPrintAstEdge(parent, _, astNode) and
-      parent.isSynthesized() and
-      synthChild(parent, result, astNode)
-    )
-    or
-    not this.parentIsSynthesized() and
-    result = 0
+    if
+      exists(AstNode parent |
+        shouldPrintAstEdge(parent, _, astNode) and
+        synthChild(parent, _, astNode)
+      )
+    then
+      exists(AstNode parent |
+        shouldPrintAstEdge(parent, _, astNode) and
+        synthChild(parent, result, astNode)
+      )
+    else result = 0
   }
 
   override int getOrder() {

--- a/ruby/ql/lib/codeql/ruby/printAst.qll
+++ b/ruby/ql/lib/codeql/ruby/printAst.qll
@@ -121,17 +121,16 @@ class PrintRegularAstNode extends PrintAstNode, TPrintRegularAstNode {
   }
 
   private int getSynthAstNodeIndex() {
-    if
-      exists(AstNode parent |
-        shouldPrintAstEdge(parent, _, astNode) and
-        synthChild(parent, _, astNode)
-      )
-    then
-      exists(AstNode parent |
-        shouldPrintAstEdge(parent, _, astNode) and
-        synthChild(parent, result, astNode)
-      )
-    else result = 0
+    exists(AstNode parent |
+      shouldPrintAstEdge(parent, _, astNode) and
+      synthChild(parent, result, astNode)
+    )
+    or
+    not exists(AstNode parent |
+      shouldPrintAstEdge(parent, _, astNode) and
+      synthChild(parent, _, astNode)
+    ) and
+    result = 0
   }
 
   private int getSynthAstNodeIndexForSynthParent() {

--- a/ruby/ql/lib/codeql/ruby/printAst.qll
+++ b/ruby/ql/lib/codeql/ruby/printAst.qll
@@ -142,8 +142,8 @@ class PrintRegularAstNode extends PrintAstNode, TPrintRegularAstNode {
       |
         p
         order by
-          f.getBaseName(), f.getAbsolutePath(), l.getStartLine(), p.getSynthAstNodeIndex(),
-          l.getStartColumn(), l.getEndLine(), l.getEndColumn()
+          f.getBaseName(), f.getAbsolutePath(), l.getStartLine(), l.getStartColumn(),
+          p.getSynthAstNodeIndex(), l.getEndLine(), l.getEndColumn()
       )
   }
 

--- a/ruby/ql/lib/codeql/ruby/printAst.qll
+++ b/ruby/ql/lib/codeql/ruby/printAst.qll
@@ -134,6 +134,10 @@ class PrintRegularAstNode extends PrintAstNode, TPrintRegularAstNode {
     else result = 0
   }
 
+  private int getSynthAstNodeIndexForSynthParent() {
+    if this.parentIsSynthesized() then result = this.getSynthAstNodeIndex() else result = 0
+  }
+
   override int getOrder() {
     this =
       rank[result](PrintRegularAstNode p, Location l, File f |
@@ -142,8 +146,9 @@ class PrintRegularAstNode extends PrintAstNode, TPrintRegularAstNode {
       |
         p
         order by
-          f.getBaseName(), f.getAbsolutePath(), l.getStartLine(), l.getStartColumn(),
-          p.getSynthAstNodeIndex(), l.getEndLine(), l.getEndColumn()
+          f.getBaseName(), f.getAbsolutePath(), l.getStartLine(),
+          p.getSynthAstNodeIndexForSynthParent(), l.getStartColumn(), p.getSynthAstNodeIndex(),
+          l.getEndLine(), l.getEndColumn()
       )
   }
 

--- a/ruby/ql/test/library-tests/ast/Ast.expected
+++ b/ruby/ql/test/library-tests/ast/Ast.expected
@@ -915,8 +915,8 @@ control/cases.rb:
 #   56|         getValue: [IntegerLiteral] 5
 #   56|         getKey: [SymbolLiteral] :b
 #   56|           getComponent: [StringTextComponent] b
-#   56|         getRestVariableAccess: [LocalVariableAccess] map
 #   56|         getValue: [LocalVariableAccess] b
+#   56|         getRestVariableAccess: [LocalVariableAccess] map
 #   57|     getBranch: [InClause] in ... then ...
 #   57|       getPattern: [HashPattern] { ..., ** }
 #   57|         getKey: [SymbolLiteral] :a
@@ -1006,8 +1006,8 @@ control/cases.rb:
 #   75|         getValue: [IntegerLiteral] 5
 #   75|         getKey: [SymbolLiteral] :b
 #   75|           getComponent: [StringTextComponent] b
-#   75|         getRestVariableAccess: [LocalVariableAccess] map
 #   75|         getValue: [LocalVariableAccess] b
+#   75|         getRestVariableAccess: [LocalVariableAccess] map
 #   76|     getBranch: [InClause] in ... then ...
 #   76|       getPattern: [HashPattern] { ..., ** }
 #   76|         getKey: [SymbolLiteral] :a
@@ -1209,8 +1209,8 @@ control/cases.rb:
 #  141|         getValue: [IntegerLiteral] 1
 #  141|         getKey: [SymbolLiteral] :a
 #  141|           getComponent: [StringTextComponent] a
-#  141|         getRestVariableAccess: [LocalVariableAccess] rest
 #  141|         getValue: [LocalVariableAccess] a
+#  141|         getRestVariableAccess: [LocalVariableAccess] rest
 #  142|     getBranch: [InClause] in ... then ...
 #  142|       getPattern: [HashPattern] { ..., ** }
 #  142|         getClass: [ConstantReadAccess] Foo

--- a/ruby/ql/test/library-tests/ast/Ast.expected
+++ b/ruby/ql/test/library-tests/ast/Ast.expected
@@ -915,8 +915,8 @@ control/cases.rb:
 #   56|         getValue: [IntegerLiteral] 5
 #   56|         getKey: [SymbolLiteral] :b
 #   56|           getComponent: [StringTextComponent] b
-#   56|         getValue: [LocalVariableAccess] b
 #   56|         getRestVariableAccess: [LocalVariableAccess] map
+#   56|         getValue: [LocalVariableAccess] b
 #   57|     getBranch: [InClause] in ... then ...
 #   57|       getPattern: [HashPattern] { ..., ** }
 #   57|         getKey: [SymbolLiteral] :a
@@ -1006,8 +1006,8 @@ control/cases.rb:
 #   75|         getValue: [IntegerLiteral] 5
 #   75|         getKey: [SymbolLiteral] :b
 #   75|           getComponent: [StringTextComponent] b
-#   75|         getValue: [LocalVariableAccess] b
 #   75|         getRestVariableAccess: [LocalVariableAccess] map
+#   75|         getValue: [LocalVariableAccess] b
 #   76|     getBranch: [InClause] in ... then ...
 #   76|       getPattern: [HashPattern] { ..., ** }
 #   76|         getKey: [SymbolLiteral] :a
@@ -1209,8 +1209,8 @@ control/cases.rb:
 #  141|         getValue: [IntegerLiteral] 1
 #  141|         getKey: [SymbolLiteral] :a
 #  141|           getComponent: [StringTextComponent] a
-#  141|         getValue: [LocalVariableAccess] a
 #  141|         getRestVariableAccess: [LocalVariableAccess] rest
+#  141|         getValue: [LocalVariableAccess] a
 #  142|     getBranch: [InClause] in ... then ...
 #  142|       getPattern: [HashPattern] { ..., ** }
 #  142|         getClass: [ConstantReadAccess] Foo
@@ -3185,14 +3185,14 @@ params/params.rb:
 #  106|       getParameter: [HashSplatParameter] **kwargs
 #  106|         getDefiningAccess: [LocalVariableAccess] kwargs
 #  107|       getStmt: [SuperCall] super call to m
-#  107|         getArgument: [HashSplatExpr] ** ...
-#  107|           getAnOperand/getOperand/getReceiver: [LocalVariableAccess] kwargs
+#  107|         getArgument: [LocalVariableAccess] y
+#  107|         getArgument: [SplatExpr] * ...
+#  107|           getAnOperand/getOperand/getReceiver: [LocalVariableAccess] rest
 #  107|         getArgument: [Pair] Pair
 #  107|           getKey: [SymbolLiteral] k
 #  107|           getValue: [LocalVariableAccess] k
-#  107|         getArgument: [SplatExpr] * ...
-#  107|           getAnOperand/getOperand/getReceiver: [LocalVariableAccess] rest
-#  107|         getArgument: [LocalVariableAccess] y
+#  107|         getArgument: [HashSplatExpr] ** ...
+#  107|           getAnOperand/getOperand/getReceiver: [LocalVariableAccess] kwargs
 #  111|   getStmt: [MethodCall] call to m
 #  111|     getReceiver: [MethodCall] call to new
 #  111|       getReceiver: [ConstantReadAccess] Sub


### PR DESCRIPTION
Real parents can have synthesized children, so always assigning index 0 leads to nondeterminism in graph output.
