### PR TITLE
Rust: Update query severities

### DIFF
--- a/rust/ql/src/queries/security/CWE-312/CleartextLogging.ql
+++ b/rust/ql/src/queries/security/CWE-312/CleartextLogging.ql
@@ -3,7 +3,7 @@
  * @description Logging sensitive information in plaintext can
  *              expose it to an attacker.
  * @kind path-problem
- * @problem.severity error
+ * @problem.severity warning
  * @security-severity 7.5
  * @precision high
  * @id rust/cleartext-logging

--- a/rust/ql/src/queries/security/CWE-770/UncontrolledAllocationSize.ql
+++ b/rust/ql/src/queries/security/CWE-770/UncontrolledAllocationSize.ql
@@ -4,7 +4,7 @@
  *              arbitrary amounts of memory being allocated, leading to a crash or a
  *              denial-of-service (DoS) attack.
  * @kind path-problem
- * @problem.severity recommendation
+ * @problem.severity warning
  * @security-severity 7.5
  * @precision high
  * @id rust/uncontrolled-allocation-size


### PR DESCRIPTION
Update query severities:
- promote `rust/uncontrolled-allocation-size` to `warning` (`recommendation` was unreasonably low; this change will cause the query to appear in the code scanning suite, as originally intended).
- demote `rust/cleartext-logging` to `warning` (the same as `rust/cleartext-transmission`, which I think has this right).