### PR TITLE
Rust: Add Operation class

### DIFF
--- a/rust/ql/lib/codeql/rust/elements/AssignmentOperation.qll
+++ b/rust/ql/lib/codeql/rust/elements/AssignmentOperation.qll
@@ -1,16 +1,23 @@
-/** Provides classes for assignment operations. */
+/**
+ * Provides classes for assignment operations.
+ */
 
 private import rust
 private import codeql.rust.elements.internal.BinaryExprImpl
 
-/** An assignment operation. */
+/**
+ * An assignment operation, for example:
+ * ```rust
+ * x = y;
+ * x += y;
+ * ```
+ */
 abstract private class AssignmentOperationImpl extends Impl::BinaryExpr { }
 
 final class AssignmentOperation = AssignmentOperationImpl;
 
 /**
- * An assignment expression, for example
- *
+ * An assignment expression, for example:
  * ```rust
  * x = y;
  * ```
@@ -22,8 +29,7 @@ final class AssignmentExpr extends AssignmentOperationImpl {
 }
 
 /**
- * A compound assignment expression, for example
- *
+ * A compound assignment expression, for example:
  * ```rust
  * x += y;
  * ```

--- a/rust/ql/lib/codeql/rust/elements/LogicalOperation.qll
+++ b/rust/ql/lib/codeql/rust/elements/LogicalOperation.qll
@@ -1,11 +1,12 @@
 private import codeql.rust.elements.Expr
 private import codeql.rust.elements.BinaryExpr
 private import codeql.rust.elements.PrefixExpr
+private import codeql.rust.elements.Operation
 
 /**
  * A logical operation, such as `&&`, `||` or `!`.
  */
-abstract private class LogicalOperationImpl extends Expr {
+abstract private class LogicalOperationImpl extends Operation {
   abstract Expr getAnOperand();
 }
 

--- a/rust/ql/lib/codeql/rust/elements/LogicalOperation.qll
+++ b/rust/ql/lib/codeql/rust/elements/LogicalOperation.qll
@@ -2,30 +2,48 @@ private import codeql.rust.elements.Expr
 private import codeql.rust.elements.BinaryExpr
 private import codeql.rust.elements.PrefixExpr
 
+/**
+ * A logical operation, such as `&&`, `||` or `!`.
+ */
 abstract private class LogicalOperationImpl extends Expr {
   abstract Expr getAnOperand();
 }
 
 final class LogicalOperation = LogicalOperationImpl;
 
+/**
+ * A binary logical operation, such as `&&` or `||`.
+ */
 abstract private class BinaryLogicalOperationImpl extends BinaryExpr, LogicalOperationImpl {
   override Expr getAnOperand() { result = [this.getLhs(), this.getRhs()] }
 }
 
 final class BinaryLogicalOperation = BinaryLogicalOperationImpl;
 
+/**
+ * The logical and operation, `&&`.
+ */
 final class LogicalAndExpr extends BinaryLogicalOperationImpl, BinaryExpr {
   LogicalAndExpr() { this.getOperatorName() = "&&" }
 }
 
+/**
+ * The logical or operation, `||`.
+ */
 final class LogicalOrExpr extends BinaryLogicalOperationImpl {
   LogicalOrExpr() { this.getOperatorName() = "||" }
 }
 
+/**
+ * A unary logical operation, such as `!`.
+ */
 abstract private class UnaryLogicalOperationImpl extends PrefixExpr, LogicalOperationImpl { }
 
 final class UnaryLogicalOperation = UnaryLogicalOperationImpl;
 
+/**
+ * A logical not operation, `!`.
+ */
 final class LogicalNotExpr extends UnaryLogicalOperationImpl {
   LogicalNotExpr() { this.getOperatorName() = "!" }
 

--- a/rust/ql/lib/codeql/rust/elements/LogicalOperation.qll
+++ b/rust/ql/lib/codeql/rust/elements/LogicalOperation.qll
@@ -18,14 +18,14 @@ abstract private class BinaryLogicalOperationImpl extends BinaryExpr, LogicalOpe
 final class BinaryLogicalOperation = BinaryLogicalOperationImpl;
 
 /**
- * The logical and operation, `&&`.
+ * The logical "and" operation, `&&`.
  */
 final class LogicalAndExpr extends BinaryLogicalOperationImpl, BinaryExpr {
   LogicalAndExpr() { this.getOperatorName() = "&&" }
 }
 
 /**
- * The logical or operation, `||`.
+ * The logical "or" operation, `||`.
  */
 final class LogicalOrExpr extends BinaryLogicalOperationImpl {
   LogicalOrExpr() { this.getOperatorName() = "||" }
@@ -39,7 +39,7 @@ abstract private class UnaryLogicalOperationImpl extends PrefixExpr, LogicalOper
 final class UnaryLogicalOperation = UnaryLogicalOperationImpl;
 
 /**
- * A logical not operation, `!`.
+ * A logical "not" operation, `!`.
  */
 final class LogicalNotExpr extends UnaryLogicalOperationImpl {
   LogicalNotExpr() { this.getOperatorName() = "!" }

--- a/rust/ql/lib/codeql/rust/elements/LogicalOperation.qll
+++ b/rust/ql/lib/codeql/rust/elements/LogicalOperation.qll
@@ -6,16 +6,14 @@ private import codeql.rust.elements.Operation
 /**
  * A logical operation, such as `&&`, `||` or `!`.
  */
-abstract private class LogicalOperationImpl extends Operation {
-}
+abstract private class LogicalOperationImpl extends Operation { }
 
 final class LogicalOperation = LogicalOperationImpl;
 
 /**
  * A binary logical operation, such as `&&` or `||`.
  */
-abstract private class BinaryLogicalOperationImpl extends BinaryExpr, LogicalOperationImpl {
-}
+abstract private class BinaryLogicalOperationImpl extends BinaryExpr, LogicalOperationImpl { }
 
 final class BinaryLogicalOperation = BinaryLogicalOperationImpl;
 

--- a/rust/ql/lib/codeql/rust/elements/LogicalOperation.qll
+++ b/rust/ql/lib/codeql/rust/elements/LogicalOperation.qll
@@ -7,7 +7,6 @@ private import codeql.rust.elements.Operation
  * A logical operation, such as `&&`, `||` or `!`.
  */
 abstract private class LogicalOperationImpl extends Operation {
-  abstract Expr getAnOperand();
 }
 
 final class LogicalOperation = LogicalOperationImpl;
@@ -16,7 +15,6 @@ final class LogicalOperation = LogicalOperationImpl;
  * A binary logical operation, such as `&&` or `||`.
  */
 abstract private class BinaryLogicalOperationImpl extends BinaryExpr, LogicalOperationImpl {
-  override Expr getAnOperand() { result = [this.getLhs(), this.getRhs()] }
 }
 
 final class BinaryLogicalOperation = BinaryLogicalOperationImpl;
@@ -47,6 +45,4 @@ final class UnaryLogicalOperation = UnaryLogicalOperationImpl;
  */
 final class LogicalNotExpr extends UnaryLogicalOperationImpl {
   LogicalNotExpr() { this.getOperatorName() = "!" }
-
-  override Expr getAnOperand() { result = this.getExpr() }
 }

--- a/rust/ql/lib/codeql/rust/elements/Operation.qll
+++ b/rust/ql/lib/codeql/rust/elements/Operation.qll
@@ -2,28 +2,7 @@
  * Provides classes for operations.
  */
 
-private import rust
+import internal.OperationImpl
 private import codeql.rust.elements.internal.ExprImpl::Impl as ExprImpl
-
-/**
- * INTERNAL: This module contains the customizable definition of `Operation` and should not
- * be referenced directly.
- */
-module OperationImpl {
-  /**
-   * An operation, for example `&&`, `+=`, `!` or `*`.
-   */
-  abstract class Operation extends ExprImpl::Expr {
-    /**
-     * Gets the operator name of this operation, if it exists.
-     */
-    abstract string getOperatorName();
-
-    /**
-     * Gets an operand of this operation.
-     */
-    abstract Expr getAnOperand();
-  }
-}
 
 final class Operation = OperationImpl::Operation;

--- a/rust/ql/lib/codeql/rust/elements/Operation.qll
+++ b/rust/ql/lib/codeql/rust/elements/Operation.qll
@@ -1,0 +1,19 @@
+/**
+ * Provides classes for operations.
+ */
+
+private import rust
+private import codeql.rust.elements.internal.ExprImpl::Impl as ExprImpl
+
+/**
+ * INTERNAL: This module contains the customizable definition of `Operation` and should not
+ * be referenced directly.
+ */
+module OperationImpl {
+    /**
+     * An operation, for example `&&`, `+=`, `!` or `*`.
+     */
+    abstract class Operation extends ExprImpl::Expr { }
+}
+
+final class Operation = OperationImpl::Operation;

--- a/rust/ql/lib/codeql/rust/elements/Operation.qll
+++ b/rust/ql/lib/codeql/rust/elements/Operation.qll
@@ -2,7 +2,7 @@
  * Provides classes for operations.
  */
 
-import internal.OperationImpl
+import internal.OperationImpl::Impl as OperationImpl
 private import codeql.rust.elements.internal.ExprImpl::Impl as ExprImpl
 
 final class Operation = OperationImpl::Operation;

--- a/rust/ql/lib/codeql/rust/elements/Operation.qll
+++ b/rust/ql/lib/codeql/rust/elements/Operation.qll
@@ -10,10 +10,15 @@ private import codeql.rust.elements.internal.ExprImpl::Impl as ExprImpl
  * be referenced directly.
  */
 module OperationImpl {
+  /**
+   * An operation, for example `&&`, `+=`, `!` or `*`.
+   */
+  abstract class Operation extends ExprImpl::Expr {
     /**
-     * An operation, for example `&&`, `+=`, `!` or `*`.
+     * Gets an operand of this operation.
      */
-    abstract class Operation extends ExprImpl::Expr { }
+    abstract Expr getAnOperand();
+  }
 }
 
 final class Operation = OperationImpl::Operation;

--- a/rust/ql/lib/codeql/rust/elements/Operation.qll
+++ b/rust/ql/lib/codeql/rust/elements/Operation.qll
@@ -15,6 +15,11 @@ module OperationImpl {
    */
   abstract class Operation extends ExprImpl::Expr {
     /**
+     * Gets the operator name of this operation, if it exists.
+     */
+    abstract string getOperatorName();
+
+    /**
      * Gets an operand of this operation.
      */
     abstract Expr getAnOperand();

--- a/rust/ql/lib/codeql/rust/elements/Operation.qll
+++ b/rust/ql/lib/codeql/rust/elements/Operation.qll
@@ -2,7 +2,7 @@
  * Provides classes for operations.
  */
 
-import internal.OperationImpl::Impl as OperationImpl
+private import internal.OperationImpl
 private import codeql.rust.elements.internal.ExprImpl::Impl as ExprImpl
 
-final class Operation = OperationImpl::Operation;
+final class Operation = Impl::Operation;

--- a/rust/ql/lib/codeql/rust/elements/internal/BinaryExprImpl.qll
+++ b/rust/ql/lib/codeql/rust/elements/internal/BinaryExprImpl.qll
@@ -25,5 +25,7 @@ module Impl {
    */
   class BinaryExpr extends Generated::BinaryExpr, OperationImpl::Operation {
     override string toStringImpl() { result = "... " + this.getOperatorName() + " ..." }
+
+    override Expr getAnOperand() { result = [this.getLhs(), this.getRhs()] }
   }
 }

--- a/rust/ql/lib/codeql/rust/elements/internal/BinaryExprImpl.qll
+++ b/rust/ql/lib/codeql/rust/elements/internal/BinaryExprImpl.qll
@@ -5,6 +5,7 @@
  */
 
 private import codeql.rust.elements.internal.generated.BinaryExpr
+private import codeql.rust.elements.Operation::OperationImpl as OperationImpl
 
 /**
  * INTERNAL: This module contains the customizable definition of `BinaryExpr` and should not
@@ -22,7 +23,7 @@ module Impl {
    * x += y;
    * ```
    */
-  class BinaryExpr extends Generated::BinaryExpr {
+  class BinaryExpr extends Generated::BinaryExpr, OperationImpl::Operation {
     override string toStringImpl() { result = "... " + this.getOperatorName() + " ..." }
   }
 }

--- a/rust/ql/lib/codeql/rust/elements/internal/BinaryExprImpl.qll
+++ b/rust/ql/lib/codeql/rust/elements/internal/BinaryExprImpl.qll
@@ -5,7 +5,7 @@
  */
 
 private import codeql.rust.elements.internal.generated.BinaryExpr
-private import codeql.rust.elements.Operation::OperationImpl as OperationImpl
+private import codeql.rust.elements.internal.OperationImpl::Impl as OperationImpl
 
 /**
  * INTERNAL: This module contains the customizable definition of `BinaryExpr` and should not

--- a/rust/ql/lib/codeql/rust/elements/internal/BinaryExprImpl.qll
+++ b/rust/ql/lib/codeql/rust/elements/internal/BinaryExprImpl.qll
@@ -26,6 +26,8 @@ module Impl {
   class BinaryExpr extends Generated::BinaryExpr, OperationImpl::Operation {
     override string toStringImpl() { result = "... " + this.getOperatorName() + " ..." }
 
+    override string getOperatorName() { result = Generated::BinaryExpr.super.getOperatorName() }
+
     override Expr getAnOperand() { result = [this.getLhs(), this.getRhs()] }
   }
 }

--- a/rust/ql/lib/codeql/rust/elements/internal/OperationImpl.qll
+++ b/rust/ql/lib/codeql/rust/elements/internal/OperationImpl.qll
@@ -11,7 +11,7 @@ private import codeql.rust.elements.internal.ExprImpl::Impl as ExprImpl
  * INTERNAL: This module contains the customizable definition of `Operation` and should not
  * be referenced directly.
  */
-module OperationImpl {
+module Impl {
   /**
    * An operation, for example `&&`, `+=`, `!` or `*`.
    */

--- a/rust/ql/lib/codeql/rust/elements/internal/OperationImpl.qll
+++ b/rust/ql/lib/codeql/rust/elements/internal/OperationImpl.qll
@@ -1,0 +1,29 @@
+/**
+ * Provides classes for operations.
+ *
+ * INTERNAL: Do not use.
+ */
+
+private import rust
+private import codeql.rust.elements.internal.ExprImpl::Impl as ExprImpl
+
+/**
+ * INTERNAL: This module contains the customizable definition of `Operation` and should not
+ * be referenced directly.
+ */
+module OperationImpl {
+  /**
+   * An operation, for example `&&`, `+=`, `!` or `*`.
+   */
+  abstract class Operation extends ExprImpl::Expr {
+    /**
+     * Gets the operator name of this operation, if it exists.
+     */
+    abstract string getOperatorName();
+
+    /**
+     * Gets an operand of this operation.
+     */
+    abstract Expr getAnOperand();
+  }
+}

--- a/rust/ql/lib/codeql/rust/elements/internal/PrefixExprImpl.qll
+++ b/rust/ql/lib/codeql/rust/elements/internal/PrefixExprImpl.qll
@@ -5,7 +5,7 @@
  */
 
 private import codeql.rust.elements.internal.generated.PrefixExpr
-private import codeql.rust.elements.Operation::OperationImpl as OperationImpl
+private import codeql.rust.elements.internal.OperationImpl::Impl as OperationImpl
 
 /**
  * INTERNAL: This module contains the customizable definition of `PrefixExpr` and should not

--- a/rust/ql/lib/codeql/rust/elements/internal/PrefixExprImpl.qll
+++ b/rust/ql/lib/codeql/rust/elements/internal/PrefixExprImpl.qll
@@ -23,5 +23,7 @@ module Impl {
    */
   class PrefixExpr extends Generated::PrefixExpr, OperationImpl::Operation {
     override string toStringImpl() { result = this.getOperatorName() + " ..." }
+
+    override Expr getAnOperand() { result = this.getExpr() }
   }
 }

--- a/rust/ql/lib/codeql/rust/elements/internal/PrefixExprImpl.qll
+++ b/rust/ql/lib/codeql/rust/elements/internal/PrefixExprImpl.qll
@@ -5,6 +5,7 @@
  */
 
 private import codeql.rust.elements.internal.generated.PrefixExpr
+private import codeql.rust.elements.Operation::OperationImpl as OperationImpl
 
 /**
  * INTERNAL: This module contains the customizable definition of `PrefixExpr` and should not
@@ -20,7 +21,7 @@ module Impl {
    * let z = *ptr;
    * ```
    */
-  class PrefixExpr extends Generated::PrefixExpr {
+  class PrefixExpr extends Generated::PrefixExpr, OperationImpl::Operation {
     override string toStringImpl() { result = this.getOperatorName() + " ..." }
   }
 }

--- a/rust/ql/lib/codeql/rust/elements/internal/PrefixExprImpl.qll
+++ b/rust/ql/lib/codeql/rust/elements/internal/PrefixExprImpl.qll
@@ -24,6 +24,8 @@ module Impl {
   class PrefixExpr extends Generated::PrefixExpr, OperationImpl::Operation {
     override string toStringImpl() { result = this.getOperatorName() + " ..." }
 
+    override string getOperatorName() { result = Generated::PrefixExpr.super.getOperatorName() }
+
     override Expr getAnOperand() { result = this.getExpr() }
   }
 }

--- a/rust/ql/lib/rust.qll
+++ b/rust/ql/lib/rust.qll
@@ -3,6 +3,7 @@
 import codeql.rust.elements
 import codeql.Locations
 import codeql.files.FileSystem
+import codeql.rust.elements.Operation
 import codeql.rust.elements.AssignmentOperation
 import codeql.rust.elements.LogicalOperation
 import codeql.rust.elements.AsyncBlockExpr

--- a/rust/ql/test/library-tests/operations/Operations.ql
+++ b/rust/ql/test/library-tests/operations/Operations.ql
@@ -2,6 +2,8 @@ import rust
 import utils.test.InlineExpectationsTest
 
 string describe(Expr op) {
+  op instanceof Operation and result = "Operation"
+  or
   op instanceof PrefixExpr and result = "PrefixExpr"
   or
   op instanceof BinaryExpr and result = "BinaryExpr"

--- a/rust/ql/test/library-tests/operations/Operations.ql
+++ b/rust/ql/test/library-tests/operations/Operations.ql
@@ -16,7 +16,7 @@ string describe(Expr op) {
 }
 
 module OperationsTest implements TestSig {
-  string getARelevantTag() { result = describe(_) or result = "Operands" }
+  string getARelevantTag() { result = describe(_) or result = ["Op", "Operands"] }
 
   predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(Expr op |
@@ -26,6 +26,9 @@ module OperationsTest implements TestSig {
       (
         tag = describe(op) and
         value = ""
+        or
+        tag = "Op" and
+        value = op.(Operation).getOperatorName()
         or
         op instanceof Operation and
         tag = "Operands" and

--- a/rust/ql/test/library-tests/operations/Operations.ql
+++ b/rust/ql/test/library-tests/operations/Operations.ql
@@ -16,15 +16,21 @@ string describe(Expr op) {
 }
 
 module OperationsTest implements TestSig {
-  string getARelevantTag() { result = describe(_) }
+  string getARelevantTag() { result = describe(_) or result = "Operands" }
 
   predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(Expr op |
       location = op.getLocation() and
       location.getFile().getBaseName() != "" and
       element = op.toString() and
-      tag = describe(op) and
-      value = ""
+      (
+        tag = describe(op) and
+        value = ""
+        or
+        op instanceof Operation and
+        tag = "Operands" and
+        value = count(op.(Operation).getAnOperand()).toString()
+      )
     )
   }
 }

--- a/rust/ql/test/library-tests/operations/Operations.ql
+++ b/rust/ql/test/library-tests/operations/Operations.ql
@@ -1,0 +1,30 @@
+import rust
+import utils.test.InlineExpectationsTest
+
+string describe(Expr op) {
+  op instanceof PrefixExpr and result = "PrefixExpr"
+  or
+  op instanceof BinaryExpr and result = "BinaryExpr"
+  or
+  op instanceof AssignmentOperation and result = "AssignmentOperation"
+  or
+  op instanceof LogicalOperation and result = "LogicalOperation"
+  or
+  op instanceof RefExpr and result = "RefExpr"
+}
+
+module OperationsTest implements TestSig {
+  string getARelevantTag() { result = describe(_) }
+
+  predicate hasActualResult(Location location, string element, string tag, string value) {
+    exists(Expr op |
+      location = op.getLocation() and
+      location.getFile().getBaseName() != "" and
+      element = op.toString() and
+      tag = describe(op) and
+      value = ""
+    )
+  }
+}
+
+import MakeTest<OperationsTest>

--- a/rust/ql/test/library-tests/operations/test.rs
+++ b/rust/ql/test/library-tests/operations/test.rs
@@ -1,0 +1,57 @@
+
+// --- tests ---
+
+fn test_operations(
+	y: i32, a: bool, b: bool,
+	ptr: &i32, res: Result<i32, ()>) -> Result<(), ()>
+{
+	let mut x: i32;
+
+	// simple assignment
+	x = y; // $ AssignmentOperation BinaryExpr
+
+	// comparison operations
+	x == y; // $ BinaryExpr
+	x != y; // $ BinaryExpr
+	x < y; // $ BinaryExpr
+	x <= y; // $ BinaryExpr
+	x > y; // $ BinaryExpr
+	x >= y; // $ BinaryExpr
+
+	// arithmetic operations
+	x + y; // $ BinaryExpr
+	x - y; // $ BinaryExpr
+	x * y; // $ BinaryExpr
+	x / y; // $ BinaryExpr
+	x % y; // $ BinaryExpr
+	x += y; // $ AssignmentOperation BinaryExpr
+	x -= y; // $ AssignmentOperation BinaryExpr
+	x *= y; // $ AssignmentOperation BinaryExpr
+	x /= y; // $ AssignmentOperation BinaryExpr
+	x %= y; // $ AssignmentOperation BinaryExpr
+	-x; // $ PrefixExpr
+
+	// logical operations
+	a && b; // $ BinaryExpr LogicalOperation
+	a || b; // $ BinaryExpr LogicalOperation
+	!a; // $ PrefixExpr LogicalOperation
+
+	// bitwise operations
+	x & y; // $ BinaryExpr
+	x | y; // $ BinaryExpr
+	x ^ y; // $ BinaryExpr
+	x << y; // $ BinaryExpr
+	x >> y; // $ BinaryExpr
+	x &= y; // $ AssignmentOperation BinaryExpr
+	x |= y; // $ AssignmentOperation BinaryExpr
+	x ^= y; // $ AssignmentOperation BinaryExpr
+	x <<= y; // $ AssignmentOperation BinaryExpr
+	x >>= y; // $ AssignmentOperation BinaryExpr
+
+	// miscellaneous expressions that might be operations
+	*ptr; // $ PrefixExpr
+	&x; // $ RefExpr
+	res?;
+
+	return Ok(());
+}

--- a/rust/ql/test/library-tests/operations/test.rs
+++ b/rust/ql/test/library-tests/operations/test.rs
@@ -8,48 +8,48 @@ fn test_operations(
 	let mut x: i32;
 
 	// simple assignment
-	x = y; // $ Operation Operands=2 AssignmentOperation BinaryExpr
+	x = y; // $ Operation Op== Operands=2 AssignmentOperation BinaryExpr
 
 	// comparison operations
-	x == y; // $ Operation Operands=2 BinaryExpr
-	x != y; // $ Operation Operands=2 BinaryExpr
-	x < y; // $ Operation Operands=2 BinaryExpr
-	x <= y; // $ Operation Operands=2 BinaryExpr
-	x > y; // $ Operation Operands=2 BinaryExpr
-	x >= y; // $ Operation Operands=2 BinaryExpr
+	x == y; // $ Operation Op=== Operands=2 BinaryExpr
+	x != y; // $ Operation Op=!= Operands=2 BinaryExpr
+	x < y; // $ Operation Op=< Operands=2 BinaryExpr
+	x <= y; // $ Operation Op=<= Operands=2 BinaryExpr
+	x > y; // $ Operation Op=> Operands=2 BinaryExpr
+	x >= y; // $ Operation Op=>= Operands=2 BinaryExpr
 
 	// arithmetic operations
-	x + y; // $ Operation Operands=2 BinaryExpr
-	x - y; // $ Operation Operands=2 BinaryExpr
-	x * y; // $ Operation Operands=2 BinaryExpr
-	x / y; // $ Operation Operands=2 BinaryExpr
-	x % y; // $ Operation Operands=2 BinaryExpr
-	x += y; // $ Operation Operands=2 AssignmentOperation BinaryExpr
-	x -= y; // $ Operation Operands=2 AssignmentOperation BinaryExpr
-	x *= y; // $ Operation Operands=2 AssignmentOperation BinaryExpr
-	x /= y; // $ Operation Operands=2 AssignmentOperation BinaryExpr
-	x %= y; // $ Operation Operands=2 AssignmentOperation BinaryExpr
-	-x; // $ Operation Operands=1 PrefixExpr
+	x + y; // $ Operation Op=+ Operands=2 BinaryExpr
+	x - y; // $ Operation Op=- Operands=2 BinaryExpr
+	x * y; // $ Operation Op=* Operands=2 BinaryExpr
+	x / y; // $ Operation Op=/ Operands=2 BinaryExpr
+	x % y; // $ Operation Op=% Operands=2 BinaryExpr
+	x += y; // $ Operation Op=+= Operands=2 AssignmentOperation BinaryExpr
+	x -= y; // $ Operation Op=-= Operands=2 AssignmentOperation BinaryExpr
+	x *= y; // $ Operation Op=*= Operands=2 AssignmentOperation BinaryExpr
+	x /= y; // $ Operation Op=/= Operands=2 AssignmentOperation BinaryExpr
+	x %= y; // $ Operation Op=%= Operands=2 AssignmentOperation BinaryExpr
+	-x; // $ Operation Op=- Operands=1 PrefixExpr
 
 	// logical operations
-	a && b; // $ Operation Operands=2 BinaryExpr LogicalOperation
-	a || b; // $ Operation Operands=2 BinaryExpr LogicalOperation
-	!a; // $ Operation Operands=1 PrefixExpr LogicalOperation
+	a && b; // $ Operation Op=&& Operands=2 BinaryExpr LogicalOperation
+	a || b; // $ Operation Op=|| Operands=2 BinaryExpr LogicalOperation
+	!a; // $ Operation Op=! Operands=1 PrefixExpr LogicalOperation
 
 	// bitwise operations
-	x & y; // $ Operation Operands=2 BinaryExpr
-	x | y; // $ Operation Operands=2 BinaryExpr
-	x ^ y; // $ Operation Operands=2 BinaryExpr
-	x << y; // $ Operation Operands=2 BinaryExpr
-	x >> y; // $ Operation Operands=2 BinaryExpr
-	x &= y; // $ Operation Operands=2 AssignmentOperation BinaryExpr
-	x |= y; // $ Operation Operands=2 AssignmentOperation BinaryExpr
-	x ^= y; // $ Operation Operands=2 AssignmentOperation BinaryExpr
-	x <<= y; // $ Operation Operands=2 AssignmentOperation BinaryExpr
-	x >>= y; // $ Operation Operands=2 AssignmentOperation BinaryExpr
+	x & y; // $ Operation Op=& Operands=2 BinaryExpr
+	x | y; // $ Operation Op=| Operands=2 BinaryExpr
+	x ^ y; // $ Operation Op=^ Operands=2 BinaryExpr
+	x << y; // $ Operation Op=<< Operands=2 BinaryExpr
+	x >> y; // $ Operation Op=>> Operands=2 BinaryExpr
+	x &= y; // $ Operation Op=&= Operands=2 AssignmentOperation BinaryExpr
+	x |= y; // $ Operation Op=|= Operands=2 AssignmentOperation BinaryExpr
+	x ^= y; // $ Operation Op=^= Operands=2 AssignmentOperation BinaryExpr
+	x <<= y; // $ Operation Op=<<= Operands=2 AssignmentOperation BinaryExpr
+	x >>= y; // $ Operation Op=>>= Operands=2 AssignmentOperation BinaryExpr
 
 	// miscellaneous expressions that might be operations
-	*ptr; // $ Operation Operands=1 PrefixExpr
+	*ptr; // $ Operation Op=* Operands=1 PrefixExpr
 	&x; // $ RefExpr
 	res?;
 

--- a/rust/ql/test/library-tests/operations/test.rs
+++ b/rust/ql/test/library-tests/operations/test.rs
@@ -8,48 +8,48 @@ fn test_operations(
 	let mut x: i32;
 
 	// simple assignment
-	x = y; // $ Operation AssignmentOperation BinaryExpr
+	x = y; // $ Operation Operands=2 AssignmentOperation BinaryExpr
 
 	// comparison operations
-	x == y; // $ Operation BinaryExpr
-	x != y; // $ Operation BinaryExpr
-	x < y; // $ Operation BinaryExpr
-	x <= y; // $ Operation BinaryExpr
-	x > y; // $ Operation BinaryExpr
-	x >= y; // $ Operation BinaryExpr
+	x == y; // $ Operation Operands=2 BinaryExpr
+	x != y; // $ Operation Operands=2 BinaryExpr
+	x < y; // $ Operation Operands=2 BinaryExpr
+	x <= y; // $ Operation Operands=2 BinaryExpr
+	x > y; // $ Operation Operands=2 BinaryExpr
+	x >= y; // $ Operation Operands=2 BinaryExpr
 
 	// arithmetic operations
-	x + y; // $ Operation BinaryExpr
-	x - y; // $ Operation BinaryExpr
-	x * y; // $ Operation BinaryExpr
-	x / y; // $ Operation BinaryExpr
-	x % y; // $ Operation BinaryExpr
-	x += y; // $ Operation AssignmentOperation BinaryExpr
-	x -= y; // $ Operation AssignmentOperation BinaryExpr
-	x *= y; // $ Operation AssignmentOperation BinaryExpr
-	x /= y; // $ Operation AssignmentOperation BinaryExpr
-	x %= y; // $ Operation AssignmentOperation BinaryExpr
-	-x; // $ Operation PrefixExpr
+	x + y; // $ Operation Operands=2 BinaryExpr
+	x - y; // $ Operation Operands=2 BinaryExpr
+	x * y; // $ Operation Operands=2 BinaryExpr
+	x / y; // $ Operation Operands=2 BinaryExpr
+	x % y; // $ Operation Operands=2 BinaryExpr
+	x += y; // $ Operation Operands=2 AssignmentOperation BinaryExpr
+	x -= y; // $ Operation Operands=2 AssignmentOperation BinaryExpr
+	x *= y; // $ Operation Operands=2 AssignmentOperation BinaryExpr
+	x /= y; // $ Operation Operands=2 AssignmentOperation BinaryExpr
+	x %= y; // $ Operation Operands=2 AssignmentOperation BinaryExpr
+	-x; // $ Operation Operands=1 PrefixExpr
 
 	// logical operations
-	a && b; // $ Operation BinaryExpr LogicalOperation
-	a || b; // $ Operation BinaryExpr LogicalOperation
-	!a; // $ Operation PrefixExpr LogicalOperation
+	a && b; // $ Operation Operands=2 BinaryExpr LogicalOperation
+	a || b; // $ Operation Operands=2 BinaryExpr LogicalOperation
+	!a; // $ Operation Operands=1 PrefixExpr LogicalOperation
 
 	// bitwise operations
-	x & y; // $ Operation BinaryExpr
-	x | y; // $ Operation BinaryExpr
-	x ^ y; // $ Operation BinaryExpr
-	x << y; // $ Operation BinaryExpr
-	x >> y; // $ Operation BinaryExpr
-	x &= y; // $ Operation AssignmentOperation BinaryExpr
-	x |= y; // $ Operation AssignmentOperation BinaryExpr
-	x ^= y; // $ Operation AssignmentOperation BinaryExpr
-	x <<= y; // $ Operation AssignmentOperation BinaryExpr
-	x >>= y; // $ Operation AssignmentOperation BinaryExpr
+	x & y; // $ Operation Operands=2 BinaryExpr
+	x | y; // $ Operation Operands=2 BinaryExpr
+	x ^ y; // $ Operation Operands=2 BinaryExpr
+	x << y; // $ Operation Operands=2 BinaryExpr
+	x >> y; // $ Operation Operands=2 BinaryExpr
+	x &= y; // $ Operation Operands=2 AssignmentOperation BinaryExpr
+	x |= y; // $ Operation Operands=2 AssignmentOperation BinaryExpr
+	x ^= y; // $ Operation Operands=2 AssignmentOperation BinaryExpr
+	x <<= y; // $ Operation Operands=2 AssignmentOperation BinaryExpr
+	x >>= y; // $ Operation Operands=2 AssignmentOperation BinaryExpr
 
 	// miscellaneous expressions that might be operations
-	*ptr; // $ Operation PrefixExpr
+	*ptr; // $ Operation Operands=1 PrefixExpr
 	&x; // $ RefExpr
 	res?;
 

--- a/rust/ql/test/library-tests/operations/test.rs
+++ b/rust/ql/test/library-tests/operations/test.rs
@@ -8,48 +8,48 @@ fn test_operations(
 	let mut x: i32;
 
 	// simple assignment
-	x = y; // $ AssignmentOperation BinaryExpr
+	x = y; // $ Operation AssignmentOperation BinaryExpr
 
 	// comparison operations
-	x == y; // $ BinaryExpr
-	x != y; // $ BinaryExpr
-	x < y; // $ BinaryExpr
-	x <= y; // $ BinaryExpr
-	x > y; // $ BinaryExpr
-	x >= y; // $ BinaryExpr
+	x == y; // $ Operation BinaryExpr
+	x != y; // $ Operation BinaryExpr
+	x < y; // $ Operation BinaryExpr
+	x <= y; // $ Operation BinaryExpr
+	x > y; // $ Operation BinaryExpr
+	x >= y; // $ Operation BinaryExpr
 
 	// arithmetic operations
-	x + y; // $ BinaryExpr
-	x - y; // $ BinaryExpr
-	x * y; // $ BinaryExpr
-	x / y; // $ BinaryExpr
-	x % y; // $ BinaryExpr
-	x += y; // $ AssignmentOperation BinaryExpr
-	x -= y; // $ AssignmentOperation BinaryExpr
-	x *= y; // $ AssignmentOperation BinaryExpr
-	x /= y; // $ AssignmentOperation BinaryExpr
-	x %= y; // $ AssignmentOperation BinaryExpr
-	-x; // $ PrefixExpr
+	x + y; // $ Operation BinaryExpr
+	x - y; // $ Operation BinaryExpr
+	x * y; // $ Operation BinaryExpr
+	x / y; // $ Operation BinaryExpr
+	x % y; // $ Operation BinaryExpr
+	x += y; // $ Operation AssignmentOperation BinaryExpr
+	x -= y; // $ Operation AssignmentOperation BinaryExpr
+	x *= y; // $ Operation AssignmentOperation BinaryExpr
+	x /= y; // $ Operation AssignmentOperation BinaryExpr
+	x %= y; // $ Operation AssignmentOperation BinaryExpr
+	-x; // $ Operation PrefixExpr
 
 	// logical operations
-	a && b; // $ BinaryExpr LogicalOperation
-	a || b; // $ BinaryExpr LogicalOperation
-	!a; // $ PrefixExpr LogicalOperation
+	a && b; // $ Operation BinaryExpr LogicalOperation
+	a || b; // $ Operation BinaryExpr LogicalOperation
+	!a; // $ Operation PrefixExpr LogicalOperation
 
 	// bitwise operations
-	x & y; // $ BinaryExpr
-	x | y; // $ BinaryExpr
-	x ^ y; // $ BinaryExpr
-	x << y; // $ BinaryExpr
-	x >> y; // $ BinaryExpr
-	x &= y; // $ AssignmentOperation BinaryExpr
-	x |= y; // $ AssignmentOperation BinaryExpr
-	x ^= y; // $ AssignmentOperation BinaryExpr
-	x <<= y; // $ AssignmentOperation BinaryExpr
-	x >>= y; // $ AssignmentOperation BinaryExpr
+	x & y; // $ Operation BinaryExpr
+	x | y; // $ Operation BinaryExpr
+	x ^ y; // $ Operation BinaryExpr
+	x << y; // $ Operation BinaryExpr
+	x >> y; // $ Operation BinaryExpr
+	x &= y; // $ Operation AssignmentOperation BinaryExpr
+	x |= y; // $ Operation AssignmentOperation BinaryExpr
+	x ^= y; // $ Operation AssignmentOperation BinaryExpr
+	x <<= y; // $ Operation AssignmentOperation BinaryExpr
+	x >>= y; // $ Operation AssignmentOperation BinaryExpr
 
 	// miscellaneous expressions that might be operations
-	*ptr; // $ PrefixExpr
+	*ptr; // $ Operation PrefixExpr
 	&x; // $ RefExpr
 	res?;
 


### PR DESCRIPTION
Unify various classes representing operations under a single `Operation` class, providing a single consistent interface (with `getOperatorName()` and `getAnOperand()`) for reasoning about them.

The idea is to get things in order before I follow up with another PR that will add new subclasses, allowing us to find things like the dereference expression (`*`) and comparison operations more easily.