### PR TITLE
Rust: Use the new 'quality' tag.

### DIFF
--- a/rust/ql/src/queries/unusedentities/UnreachableCode.ql
+++ b/rust/ql/src/queries/unusedentities/UnreachableCode.ql
@@ -6,6 +6,7 @@
  * @precision medium
  * @id rust/dead-code
  * @tags maintainability
+ *       quality
  */
 
 import rust

--- a/rust/ql/src/queries/unusedentities/UnusedValue.ql
+++ b/rust/ql/src/queries/unusedentities/UnusedValue.ql
@@ -6,6 +6,7 @@
  * @precision medium
  * @id rust/unused-value
  * @tags maintainability
+ *       quality
  */
 
 import rust

--- a/rust/ql/src/queries/unusedentities/UnusedVariable.ql
+++ b/rust/ql/src/queries/unusedentities/UnusedVariable.ql
@@ -6,6 +6,7 @@
  * @precision high
  * @id rust/unused-variable
  * @tags maintainability
+ *       quality
  */
 
 import rust


### PR DESCRIPTION
Use the new 'quality' tag in Rust queries.

@tamasvajk are these the sorts of queries we want this tag on?  Our other Rust queries for the time being are very much security focussed.