### PR TITLE
Go: fix database inconsistency when receiver has alias type

### DIFF
--- a/go/extractor/extractor.go
+++ b/go/extractor/extractor.go
@@ -1582,18 +1582,10 @@ func isAlias(tp types.Type) bool {
 	return ok
 }
 
-// If the given type is a type alias, this function resolves it to its underlying type.
-func resolveTypeAlias(tp types.Type) types.Type {
-	if isAlias(tp) {
-		return types.Unalias(tp) // tp.Underlying()
-	}
-	return tp
-}
-
 // extractType extracts type information for `tp` and returns its associated label;
 // types are only extracted once, so the second time `extractType` is invoked it simply returns the label
 func extractType(tw *trap.Writer, tp types.Type) trap.Label {
-	tp = resolveTypeAlias(tp)
+	tp = types.Unalias(tp)
 	lbl, exists := getTypeLabel(tw, tp)
 	if !exists {
 		var kind int
@@ -1771,7 +1763,7 @@ func extractType(tw *trap.Writer, tp types.Type) trap.Label {
 // is constructed from their globally unique ID. This prevents cyclic type keys
 // since type recursion in Go always goes through defined types.
 func getTypeLabel(tw *trap.Writer, tp types.Type) (trap.Label, bool) {
-	tp = resolveTypeAlias(tp)
+	tp = types.Unalias(tp)
 	lbl, exists := tw.Labeler.TypeLabels[tp]
 	if !exists {
 		switch tp := tp.(type) {

--- a/go/extractor/trap/labels.go
+++ b/go/extractor/trap/labels.go
@@ -169,11 +169,12 @@ func (l *Labeler) ScopedObjectID(object types.Object, getTypeLabel func() Label)
 
 // findMethodWithGivenReceiver finds a method with `object` as its receiver, if one exists
 func findMethodWithGivenReceiver(object types.Object) *types.Func {
-	meth := findMethodOnTypeWithGivenReceiver(object.Type(), object)
+	unaliasedType := types.Unalias(object.Type())
+	meth := findMethodOnTypeWithGivenReceiver(unaliasedType, object)
 	if meth != nil {
 		return meth
 	}
-	if pointerType, ok := object.Type().(*types.Pointer); ok {
+	if pointerType, ok := unaliasedType.(*types.Pointer); ok {
 		meth = findMethodOnTypeWithGivenReceiver(pointerType.Elem(), object)
 	}
 	return meth


### PR DESCRIPTION
It was reported that `codeql/go/ql/test/library-tests/semmle/go/aliases/InterfaceImpls` fails `DB-CHECK` if you add `--check-databases` to the test target of `codeql/go/Makefile`. This turns out to be because that test has a method defined on a receiver which is an alias `Impl6Alias` of the type `Impl6`. This is equivalent to defining the method on `Impl6` directly. There is some code in the extractor which makes sure that objects which are receiver variables get a special label which is the same when seen from different files. That code was not unaliasing the type of the receiver. This PR fixes that, which fixes the db inconsistency.

I do not think this needs any tests. I also don't think it needs a change note.

I also included a minor drive-by refactor. We were defining our own wrapper around `types.Unalias` when we don't need to (because it already has the property we want, i.e. being idempotent for non-alias types).