### PR TITLE
Rust: Add tests for web frameworks as taint sources

### DIFF
--- a/rust/ql/test/library-tests/dataflow/sources/TaintSources.expected
+++ b/rust/ql/test/library-tests/dataflow/sources/TaintSources.expected
@@ -47,3 +47,8 @@
 | test.rs:369:25:369:43 | ...::open | Flow source 'FileSource' of type file (DEFAULT). |
 | test.rs:377:22:377:35 | ...::stdin | Flow source 'StdInSource' of type stdin (DEFAULT). |
 | test.rs:386:16:386:29 | ...::args | Flow source 'CommandLineArgs' of type commandargs (DEFAULT). |
+| web_frameworks.rs:13:31:13:31 | a | Flow source 'RemoteSource' of type remote (DEFAULT). |
+| web_frameworks.rs:22:31:22:36 | TuplePat | Flow source 'RemoteSource' of type remote (DEFAULT). |
+| web_frameworks.rs:44:31:44:45 | MyStruct {...} | Flow source 'RemoteSource' of type remote (DEFAULT). |
+| web_frameworks.rs:52:31:52:32 | ms | Flow source 'RemoteSource' of type remote (DEFAULT). |
+| web_frameworks.rs:61:15:61:15 | a | Flow source 'RemoteSource' of type remote (DEFAULT). |

--- a/rust/ql/test/library-tests/dataflow/sources/options.yml
+++ b/rust/ql/test/library-tests/dataflow/sources/options.yml
@@ -7,3 +7,5 @@ qltest_dependencies:
     - http = { version = "1.2.0" }
     - tokio = { version = "1.43.0", features = ["full"] }
     - futures = { version = "0.3" }
+    - poem = { version = "3.1.10" }
+    - serde = { version = "1.0.219" }

--- a/rust/ql/test/library-tests/dataflow/sources/options.yml
+++ b/rust/ql/test/library-tests/dataflow/sources/options.yml
@@ -10,3 +10,5 @@ qltest_dependencies:
     - poem = { version = "3.1.10" }
     - serde = { version = "1.0.219" }
     - actix-web = { version = "4.10.2" }
+    - axum = { version = "0.8.4" }
+    - serde_json = { version = "1.0.140" }

--- a/rust/ql/test/library-tests/dataflow/sources/options.yml
+++ b/rust/ql/test/library-tests/dataflow/sources/options.yml
@@ -9,3 +9,4 @@ qltest_dependencies:
     - futures = { version = "0.3" }
     - poem = { version = "3.1.10" }
     - serde = { version = "1.0.219" }
+    - actix-web = { version = "4.10.2" }

--- a/rust/ql/test/library-tests/dataflow/sources/web_frameworks.rs
+++ b/rust/ql/test/library-tests/dataflow/sources/web_frameworks.rs
@@ -1,0 +1,81 @@
+#![allow(deprecated)]
+
+fn sink<T>(_: T) { }
+
+// --- tests ---
+
+mod poem_test {
+    use poem::{get, handler, web::Path, web::Query, Route, Server, listener::TcpListener};
+    use serde::Deserialize;
+    use crate::web_frameworks::sink;
+
+    #[handler]
+    fn my_poem_handler_1(Path(a): Path<String>) -> String { // $ Alert[rust/summary/taint-sources]
+        sink(a.as_str()); // $ MISSING: hasTaintFlow
+        sink(a.as_bytes()); // $ MISSING: hasTaintFlow
+        sink(a); // $ MISSING: hasTaintFlow
+
+        "".to_string()
+    }
+
+    #[handler]
+    fn my_poem_handler_2(Path((a, b)): Path<(String, String)>) -> String { // $ Alert[rust/summary/taint-sources]
+        sink(a); // $ MISSING: hasTaintFlow
+        sink(b); // $ MISSING: hasTaintFlow
+
+        "".to_string()
+    }
+
+    #[handler]
+    fn my_poem_handler_3(path: Path<(String, String)>) -> String { // $ MISSING: Alert[rust/summary/taint-sources]
+        sink(&path.0); // $ MISSING: hasTaintFlow
+        sink(&path.1); // $ MISSING: hasTaintFlow
+
+        "".to_string()
+    }
+
+    #[derive(Deserialize)]
+    struct MyStruct {
+        a: String,
+        b: String,
+    }
+
+    #[handler]
+    fn my_poem_handler_4(Path(MyStruct {a, b}): Path<MyStruct>) -> String { // $ Alert[rust/summary/taint-sources]
+        sink(a); // $ MISSING: hasTaintFlow
+        sink(b); // $ MISSING: hasTaintFlow
+
+        "".to_string()
+    }
+
+    #[handler]
+    fn my_poem_handler_5(Path(ms): Path<MyStruct>) -> String { // $ Alert[rust/summary/taint-sources]
+        sink(ms.a); // $ MISSING: hasTaintFlow
+        sink(ms.b); // $ MISSING: hasTaintFlow
+
+        "".to_string()
+    }
+
+    #[handler]
+    fn my_poem_handler_6(
+        Query(a): Query<String>, // $ Alert[rust/summary/taint-sources]
+    ) -> String {
+        sink(a); // $ MISSING: hasTaintFlow
+
+        "".to_string()
+    }
+
+    async fn test_poem() {
+        let app = Route::new()
+            .at("/1/:a", get(my_poem_handler_1))
+            .at("/2/:a/:b", get(my_poem_handler_2))
+            .at("/3/:a/:b", get(my_poem_handler_3))
+            .at("/4/:a/:b", get(my_poem_handler_4))
+            .at("/4/:a/:b", get(my_poem_handler_5))
+            .at("/5/:a/", get(my_poem_handler_6));
+
+        _ = Server::new(TcpListener::bind("0.0.0.0:3000")).run(app).await.unwrap();
+
+        // ...
+    }
+}


### PR DESCRIPTION
Add tests for web frameworks as taint sources:
- [`Poem`](https://docs.rs/poem/latest/poem/) (which we have simple models for, but only a narrow query test).
- [`Actix`](https://docs.rs/actix-web/latest/actix_web/) (which we have a proposed model for, but no tests at all).
- [`Axum`](https://docs.rs/axum/latest/axum/) (which also appears to be popular).

I think these are valuable libraries to model and improve our models for.  Alternatively, we might develop a robust heuristic model that covers all three (and potentially others) in one go.

@coadaflorin the tests in `mod actix_test` below are relevant for https://github.com/github/codeql/pull/19461 .  We could move forward by merging this PR, then merging main into your PR, then reviewing and accepting any difference in test results, then finally merging your PR.