### PR TITLE
ruby: adjust precision of `rb/useless-assignment-to-local`

### DIFF
--- a/ruby/ql/integration-tests/query-suite/ruby-code-quality.qls.expected
+++ b/ruby/ql/integration-tests/query-suite/ruby-code-quality.qls.expected
@@ -1,2 +1,3 @@
 ql/ruby/ql/src/queries/performance/DatabaseQueryInLoop.ql
+ql/ruby/ql/src/queries/variables/DeadStoreOfLocal.ql
 ql/ruby/ql/src/queries/variables/UninitializedLocal.ql

--- a/ruby/ql/src/change-notes/2025-05-12-rb-useless-assignment-to-local-precision-high.md
+++ b/ruby/ql/src/change-notes/2025-05-12-rb-useless-assignment-to-local-precision-high.md
@@ -1,0 +1,5 @@
+---
+category: queryMetadata
+---
+
+* The precision of `rb/useless-assignment-to-local` has been adjusted from `medium` to `high`.

--- a/ruby/ql/src/queries/variables/DeadStoreOfLocal.ql
+++ b/ruby/ql/src/queries/variables/DeadStoreOfLocal.ql
@@ -8,7 +8,7 @@
  * @tags maintainability
  *       quality
  *       external/cwe/cwe-563
- * @precision medium
+ * @precision high
  */
 
 import codeql.ruby.AST


### PR DESCRIPTION
from `medium` to `high`. It was initially set to `medium` due to the number of alerts observed on the Java top 100 via MRVA. However, after triaging a large number of these, it does indeed seem that they are almost all true positives.