### PR TITLE
C++: Fix infinite range analysis loop on invalid SSA

### DIFF
--- a/cpp/ql/lib/change-notes/2025-05-13-range-analysis-infinite-loop.md
+++ b/cpp/ql/lib/change-notes/2025-05-13-range-analysis-infinite-loop.md
@@ -1,0 +1,4 @@
+---
+category: fix
+---
+* Fixed an infinite loop in `semmle.code.cpp.rangeanalysis.new.RangeAnalysis` when computing ranges in very large and complex function bodies.

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -1567,7 +1567,7 @@ private int countNumberOfBranchesUsingParameter(SwitchInstruction switch, Parame
         |
           exists(Ssa::UseImpl use | use.hasIndexInBlock(useblock, _, sv))
           or
-          exists(Ssa::DefImpl def | def.hasIndexInBlock(useblock, _, sv))
+          exists(Ssa::DefImpl def | def.hasIndexInBlock(sv, useblock, _))
         )
       )
   )
@@ -1814,7 +1814,7 @@ module IteratorFlow {
      */
     private predicate isIteratorWrite(Instruction write, Operand address) {
       exists(Ssa::DefImpl writeDef, IRBlock bb, int i |
-        writeDef.hasIndexInBlock(bb, i, _) and
+        writeDef.hasIndexInBlock(_, bb, i) and
         bb.getInstruction(i) = write and
         address = writeDef.getAddressOperand()
       )

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
@@ -191,7 +191,7 @@ abstract class DefImpl extends TDefImpl {
    * Holds if this definition (or use) has index `index` in block `block`,
    * and is a definition (or use) of the variable `sv`
    */
-  final predicate hasIndexInBlock(IRBlock block, int index, SourceVariable sv) {
+  final predicate hasIndexInBlock(SourceVariable sv, IRBlock block, int index) {
     this.hasIndexInBlock(block, index) and
     sv = this.getSourceVariable()
   }
@@ -891,12 +891,12 @@ private module SsaInput implements SsaImplCommon::InputSig<Location> {
   predicate variableWrite(BasicBlock bb, int i, SourceVariable v, boolean certain) {
     DataFlowImplCommon::forceCachingInSameStage() and
     (
-      exists(DefImpl def | def.hasIndexInBlock(bb, i, v) |
+      exists(DefImpl def | def.hasIndexInBlock(v, bb, i) |
         if def.isCertain() then certain = true else certain = false
       )
       or
       exists(GlobalDefImpl global |
-        global.hasIndexInBlock(bb, i, v) and
+        global.hasIndexInBlock(v, bb, i) and
         certain = true
       )
     )
@@ -934,10 +934,11 @@ module SsaCached {
 }
 
 /** Gets the `DefImpl` corresponding to `def`. */
+pragma[nomagic]
 private DefImpl getDefImpl(SsaImpl::Definition def) {
   exists(SourceVariable sv, IRBlock bb, int i |
     def.definesAt(sv, bb, i) and
-    result.hasIndexInBlock(bb, i, sv)
+    result.hasIndexInBlock(sv, bb, i)
   )
 }
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/IRFunction.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/IRFunction.qll
@@ -58,4 +58,12 @@ class IRFunction extends IRFunctionBase {
    * Gets all blocks in this function.
    */
   final IRBlock getABlock() { result.getEnclosingIRFunction() = this }
+
+  /**
+   * Holds if this function may have incomplete def-use information.
+   *
+   * Def-use information may be omitted for a function when it is too expensive
+   * to compute.
+   */
+  final predicate hasIncompleteSsa() { Construction::hasIncompleteSsa(this) }
 }

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/internal/AliasedSSA.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/internal/AliasedSSA.qll
@@ -874,7 +874,7 @@ private int numberOfOverlappingUses(MemoryLocation0 def) {
  * Holds if `def` is a busy definition. That is, it has a large number of
  * overlapping uses.
  */
-private predicate isBusyDef(MemoryLocation0 def) { numberOfOverlappingUses(def) > 1024 }
+predicate isBusyDef(MemoryLocation0 def) { numberOfOverlappingUses(def) > 1024 }
 
 /** Holds if `use` is a use that overlaps with a busy definition. */
 private predicate useOverlapWithBusyDef(MemoryLocation0 use) {

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/internal/AliasedSSA.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/internal/AliasedSSA.qll
@@ -235,7 +235,7 @@ private newtype TMemoryLocation =
  *
  * Some of these memory locations will be filtered out for performance reasons before being passed to SSA construction.
  */
-abstract private class MemoryLocation0 extends TMemoryLocation {
+abstract class MemoryLocation0 extends TMemoryLocation {
   final string toString() {
     if this.isMayAccess()
     then result = "?" + this.toStringInternal()

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/internal/SSAConstruction.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/internal/SSAConstruction.qll
@@ -1320,6 +1320,18 @@ predicate canReuseSsaForMemoryResult(Instruction instruction) {
 }
 
 /**
+ * Holds if the def-use information for `f` may have been omitted because it
+ * was too expensive to compute. This happens if one of the memory allocations
+ * in `f` is a busy definition (i.e., it has many different overlapping uses).
+ */
+predicate hasIncompleteSsa(IRFunction f) {
+  exists(Alias::MemoryLocation0 defLocation |
+    Alias::isBusyDef(defLocation) and
+    defLocation.getIRFunction() = f
+  )
+}
+
+/**
  * Expose some of the internal predicates to PrintSSA.qll. We do this by publicly importing those modules in the
  * `DebugSsa` module, which is then imported by PrintSSA.
  */

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/internal/SSAConstruction.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/internal/SSAConstruction.qll
@@ -731,6 +731,20 @@ private module Cached {
     or
     instruction = getChi(result.(UninitializedGroupInstruction))
   }
+
+  /**
+   * Holds if the def-use information for `f` may have been omitted because it
+   * was too expensive to compute. This happens if one of the memory allocations
+   * in `f` is a busy definition (i.e., it has many different overlapping uses).
+   */
+  pragma[nomagic]
+  cached
+  predicate hasIncompleteSsa(IRFunction f) {
+    exists(Alias::MemoryLocation0 defLocation |
+      Alias::isBusyDef(pragma[only_bind_into](defLocation)) and
+      defLocation.getIRFunction() = f
+    )
+  }
 }
 
 private Instruction getNewInstruction(OldInstruction instr) { getOldInstruction(result) = instr }
@@ -1317,18 +1331,6 @@ predicate canReuseSsaForMemoryResult(Instruction instruction) {
     defLocation.canReuseSsa()
   )
   // We don't support reusing SSA for any location that could create a `Chi` instruction.
-}
-
-/**
- * Holds if the def-use information for `f` may have been omitted because it
- * was too expensive to compute. This happens if one of the memory allocations
- * in `f` is a busy definition (i.e., it has many different overlapping uses).
- */
-predicate hasIncompleteSsa(IRFunction f) {
-  exists(Alias::MemoryLocation0 defLocation |
-    Alias::isBusyDef(defLocation) and
-    defLocation.getIRFunction() = f
-  )
 }
 
 /**

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/IRFunction.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/IRFunction.qll
@@ -58,4 +58,12 @@ class IRFunction extends IRFunctionBase {
    * Gets all blocks in this function.
    */
   final IRBlock getABlock() { result.getEnclosingIRFunction() = this }
+
+  /**
+   * Holds if this function may have incomplete def-use information.
+   *
+   * Def-use information may be omitted for a function when it is too expensive
+   * to compute.
+   */
+  final predicate hasIncompleteSsa() { Construction::hasIncompleteSsa(this) }
 }

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/IRConstruction.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/IRConstruction.qll
@@ -220,6 +220,8 @@ Instruction getMemoryOperandDefinition(
   none()
 }
 
+predicate hasIncompleteSsa(IRFunction f) { none() }
+
 /**
  * Holds if the operand totally overlaps with its definition and consumes the
  * bit range `[startBitOffset, endBitOffset)`.

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/IRFunction.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/IRFunction.qll
@@ -58,4 +58,12 @@ class IRFunction extends IRFunctionBase {
    * Gets all blocks in this function.
    */
   final IRBlock getABlock() { result.getEnclosingIRFunction() = this }
+
+  /**
+   * Holds if this function may have incomplete def-use information.
+   *
+   * Def-use information may be omitted for a function when it is too expensive
+   * to compute.
+   */
+  final predicate hasIncompleteSsa() { Construction::hasIncompleteSsa(this) }
 }

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
@@ -1320,6 +1320,18 @@ predicate canReuseSsaForMemoryResult(Instruction instruction) {
 }
 
 /**
+ * Holds if the def-use information for `f` may have been omitted because it
+ * was too expensive to compute. This happens if one of the memory allocations
+ * in `f` is a busy definition (i.e., it has many different overlapping uses).
+ */
+predicate hasIncompleteSsa(IRFunction f) {
+  exists(Alias::MemoryLocation0 defLocation |
+    Alias::isBusyDef(defLocation) and
+    defLocation.getIRFunction() = f
+  )
+}
+
+/**
  * Expose some of the internal predicates to PrintSSA.qll. We do this by publicly importing those modules in the
  * `DebugSsa` module, which is then imported by PrintSSA.
  */

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
@@ -731,6 +731,20 @@ private module Cached {
     or
     instruction = getChi(result.(UninitializedGroupInstruction))
   }
+
+  /**
+   * Holds if the def-use information for `f` may have been omitted because it
+   * was too expensive to compute. This happens if one of the memory allocations
+   * in `f` is a busy definition (i.e., it has many different overlapping uses).
+   */
+  pragma[nomagic]
+  cached
+  predicate hasIncompleteSsa(IRFunction f) {
+    exists(Alias::MemoryLocation0 defLocation |
+      Alias::isBusyDef(pragma[only_bind_into](defLocation)) and
+      defLocation.getIRFunction() = f
+    )
+  }
 }
 
 private Instruction getNewInstruction(OldInstruction instr) { getOldInstruction(result) = instr }
@@ -1317,18 +1331,6 @@ predicate canReuseSsaForMemoryResult(Instruction instruction) {
     defLocation.canReuseSsa()
   )
   // We don't support reusing SSA for any location that could create a `Chi` instruction.
-}
-
-/**
- * Holds if the def-use information for `f` may have been omitted because it
- * was too expensive to compute. This happens if one of the memory allocations
- * in `f` is a busy definition (i.e., it has many different overlapping uses).
- */
-predicate hasIncompleteSsa(IRFunction f) {
-  exists(Alias::MemoryLocation0 defLocation |
-    Alias::isBusyDef(defLocation) and
-    defLocation.getIRFunction() = f
-  )
 }
 
 /**

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SimpleSSA.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SimpleSSA.qll
@@ -73,6 +73,8 @@ class MemoryLocation extends TMemoryLocation {
   final predicate canReuseSsa() { canReuseSsaForVariable(var) }
 }
 
+class MemoryLocation0 = MemoryLocation;
+
 predicate canReuseSsaForOldResult(Instruction instr) { none() }
 
 abstract class VariableGroup extends Unit {

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SimpleSSA.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SimpleSSA.qll
@@ -143,3 +143,9 @@ int getStartBitOffset(MemoryLocation location) { none() }
 
 /** Gets the end bit offset of a `MemoryLocation`, if any. */
 int getEndBitOffset(MemoryLocation location) { none() }
+
+/**
+ * Holds if `def` is a busy definition. That is, it has a large number of
+ * overlapping uses.
+ */
+predicate isBusyDef(MemoryLocation def) { none() }

--- a/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/SemanticExprSpecific.qll
+++ b/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/SemanticExprSpecific.qll
@@ -112,7 +112,14 @@ module SemanticExprConfig {
   }
 
   /** Holds if no range analysis should be performed on the phi edges in `f`. */
-  private predicate excludeFunction(Cpp::Function f) { count(f.getEntryPoint()) > 1 }
+  private predicate excludeFunction(Cpp::Function f) {
+    count(f.getEntryPoint()) > 1
+    or
+    exists(IR::IRFunction irFunction |
+      irFunction.getFunction() = f and
+      irFunction.hasIncompleteSsa()
+    )
+  }
 
   SemType getUnknownExprType(Expr expr) { result = getSemanticType(expr.getResultIRType()) }
 


### PR DESCRIPTION
As part of the IR SSA/alias analysis we compute the which memory allocations overlap. In https://github.com/github/codeql/pull/17062 we mitigated a problem where, in very large function bodies, the set of overlapping memory allocations was basically a cartesian product.

As a result of this, we don't always have proper SSA information on these large function bodies. It's well-known that even one missing SSA edge can cause the shared range analysis to loop infinitely.

This PR excludes the functions with incomplete SSA information from the new range analysis. Ideally, I would like us to move away from using the IR SSA/alias analysis in the new range analysis library, but that seemed like too big of a task to start right now.

On a customer codebase there were 3 functions in the entire database which contained incomplete SSA and this caused the range analysis to loop infinitely in any of these three functions.

I haven't managed to reproduce a test for this. However, I will make sure that we have testing for this in DCA once this PR is merged.