### PR TITLE
Fix typo from `commited` to `committed`

### DIFF
--- a/java/ql/test/stubs/jabsorb-1.3.2/org/jabsorb/serializer/ObjectMatch.java
+++ b/java/ql/test/stubs/jabsorb-1.3.2/org/jabsorb/serializer/ObjectMatch.java
@@ -42,7 +42,7 @@ public class ObjectMatch
   /**
    * Create a new ObjectMatch object with the given number of mismatches.
    * 
-   * @param mismatch the number of mismatched fields that occured on a
+   * @param mismatch the number of mismatched fields that occurred on a
    *          tryUnmarshall call.
    */
   public ObjectMatch(int mismatch)
@@ -50,9 +50,9 @@ public class ObjectMatch
   }
 
   /**
-   * Get the number of mismatched fields that occured on a tryUnmarshall call.
+   * Get the number of mismatched fields that occurred on a tryUnmarshall call.
    * 
-   * @return the number of mismatched fields that occured on a tryUnmarshall
+   * @return the number of mismatched fields that occurred on a tryUnmarshall
    *         call.
    */
   public int getMismatch()

--- a/javascript/ql/test/query-tests/Security/CWE-912/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-912/tst.js
@@ -27,11 +27,11 @@ try {
     });
     response.on('error', () => 
     { 
-	fs.writeFile("/tmp/test", "error occured"); // OK - static data written to file
+	fs.writeFile("/tmp/test", "error occurred"); // OK - static data written to file
     });
   }).on('error', () => 
   { 
-      let error = "error occured";
+      let error = "error occurred";
       let writeStream = fs.createWriteStream('/usr/good/errorlog.txt');
       writeStream.write(error);  // OK - static data written to file stream
       writeStream.end();

--- a/shared/typos/codeql/typos/TypoDatabase.qll
+++ b/shared/typos/codeql/typos/TypoDatabase.qll
@@ -1825,7 +1825,7 @@ predicate typos(string wrong, string right) {
   or
   wrong = "commisions" and right = "commissions"
   or
-  wrong = "commited" and right = "committed"
+  wrong = "committed" and right = "committed"
   or
   wrong = "commitee" and right = "committee"
   or

--- a/shared/typos/codeql/typos/TypoDatabase.qll
+++ b/shared/typos/codeql/typos/TypoDatabase.qll
@@ -5557,7 +5557,7 @@ predicate typos(string wrong, string right) {
   or
   wrong = "occurances" and right = "occurrences"
   or
-  wrong = "occured" and right = "occurred"
+  wrong = "occurred" and right = "occurred"
   or
   wrong = "occurence" and right = "occurrence"
   or


### PR DESCRIPTION
Fix typo from `commited` to `committed`