### PR TITLE
Swift: add new `TypeValueExpr` to CFG

### DIFF
--- a/swift/ql/lib/change-notes/2025-05-14-type_value_expr_cfg.md
+++ b/swift/ql/lib/change-notes/2025-05-14-type_value_expr_cfg.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* `TypeValueExpr` experimental AST leaf is now implemented in the control flow library

--- a/swift/ql/lib/codeql/swift/controlflow/internal/ControlFlowGraphImpl.qll
+++ b/swift/ql/lib/codeql/swift/controlflow/internal/ControlFlowGraphImpl.qll
@@ -1884,6 +1884,10 @@ module Exprs {
     }
   }
 
+  private class TypeValueTree extends AstLeafTree {
+    override TypeValueExpr ast;
+  }
+
   module Conversions {
     class ConversionOrIdentity =
       Synth::TIdentityExpr or Synth::TExplicitCastExpr or Synth::TImplicitConversionExpr or

--- a/swift/ql/test/library-tests/ast/Errors.expected
+++ b/swift/ql/test/library-tests/ast/Errors.expected
@@ -1,0 +1,2 @@
+| cfg.swift:591:13:591:13 | missing type from TypeRepr | UnspecifiedElement |
+| cfg.swift:595:13:595:13 | missing type from TypeRepr | UnspecifiedElement |

--- a/swift/ql/test/library-tests/ast/Missing.expected
+++ b/swift/ql/test/library-tests/ast/Missing.expected
@@ -1,0 +1,2 @@
+| cfg.swift:591:13:591:13 | missing type from TypeRepr |
+| cfg.swift:595:13:595:13 | missing type from TypeRepr |

--- a/swift/ql/test/library-tests/ast/PrintAst.expected
+++ b/swift/ql/test/library-tests/ast/PrintAst.expected
@@ -521,15 +521,15 @@ cfg.swift:
 #  113|         Type = Int
 #  114|     getVariable(4): [ConcreteVarDecl] n4
 #  114|         Type = Int
-#  116|     getVariable(5): [ConcreteVarDecl] n5
+#  115|     getVariable(5): [ConcreteVarDecl] n5
+#  115|         Type = Int
+#  116|     getVariable(6): [ConcreteVarDecl] n6
 #  116|         Type = Int
-#  117|     getVariable(6): [ConcreteVarDecl] n6
-#  117|         Type = Int
-#  118|     getVariable(7): [ConcreteVarDecl] n7
+#  118|     getVariable(7): [ConcreteVarDecl] n8
 #  118|         Type = Int
-#  119|     getVariable(8): [ConcreteVarDecl] n8
-#  119|         Type = Int
-#  121|     getVariable(9): [ConcreteVarDecl] n9
+#  120|     getVariable(8): [ConcreteVarDecl] n9
+#  120|         Type = Int
+#  121|     getVariable(9): [ConcreteVarDecl] n7
 #  121|         Type = Int
 #  122|     getVariable(10): [ConcreteVarDecl] n10
 #  122|         Type = Int
@@ -584,33 +584,33 @@ cfg.swift:
 #  114|           getBase().getFullyConverted(): [DotSelfExpr] .self
 #  114|           getMethodRef(): [DeclRefExpr] getMyInt()
 #  114|       getPattern(0): [NamedPattern] n4
-#  116|     getElement(5): [PatternBindingDecl] var ... = ...
+#  115|     getElement(5): [PatternBindingDecl] var ... = ...
+#  115|       getInit(0): [MemberRefExpr] .myInt
+#  115|         getBase(): [DeclRefExpr] param
+#  115|       getPattern(0): [NamedPattern] n5
+#  116|     getElement(6): [PatternBindingDecl] var ... = ...
 #  116|       getInit(0): [MemberRefExpr] .myInt
 #  116|         getBase(): [DeclRefExpr] param
-#  116|       getPattern(0): [NamedPattern] n5
-#  117|     getElement(6): [PatternBindingDecl] var ... = ...
-#  117|       getInit(0): [MemberRefExpr] .myInt
-#  117|         getBase(): [DeclRefExpr] param
-#  117|         getBase().getFullyConverted(): [DotSelfExpr] .self
-#  117|       getPattern(0): [NamedPattern] n6
+#  116|         getBase().getFullyConverted(): [DotSelfExpr] .self
+#  116|       getPattern(0): [NamedPattern] n6
 #  118|     getElement(7): [PatternBindingDecl] var ... = ...
 #  118|       getInit(0): [CallExpr] call to getMyInt()
 #  118|         getFunction(): [MethodLookupExpr] .getMyInt()
 #  118|           getBase(): [DeclRefExpr] param
+#  118|           getBase().getFullyConverted(): [DotSelfExpr] .self
 #  118|           getMethodRef(): [DeclRefExpr] getMyInt()
-#  118|       getPattern(0): [NamedPattern] n7
-#  119|     getElement(8): [PatternBindingDecl] var ... = ...
-#  119|       getInit(0): [CallExpr] call to getMyInt()
-#  119|         getFunction(): [MethodLookupExpr] .getMyInt()
-#  119|           getBase(): [DeclRefExpr] param
-#  119|           getBase().getFullyConverted(): [DotSelfExpr] .self
-#  119|           getMethodRef(): [DeclRefExpr] getMyInt()
-#  119|       getPattern(0): [NamedPattern] n8
+#  118|       getPattern(0): [NamedPattern] n8
+#  120|     getElement(8): [PatternBindingDecl] var ... = ...
+#  120|       getInit(0): [MemberRefExpr] .myInt
+#  120|         getBase(): [DeclRefExpr] inoutParam
+#  120|         getBase().getFullyConverted(): [LoadExpr] (C) ...
+#  120|       getPattern(0): [NamedPattern] n9
 #  121|     getElement(9): [PatternBindingDecl] var ... = ...
-#  121|       getInit(0): [MemberRefExpr] .myInt
-#  121|         getBase(): [DeclRefExpr] inoutParam
-#  121|         getBase().getFullyConverted(): [LoadExpr] (C) ...
-#  121|       getPattern(0): [NamedPattern] n9
+#  121|       getInit(0): [CallExpr] call to getMyInt()
+#  121|         getFunction(): [MethodLookupExpr] .getMyInt()
+#  121|           getBase(): [DeclRefExpr] param
+#  121|           getMethodRef(): [DeclRefExpr] getMyInt()
+#  121|       getPattern(0): [NamedPattern] n7
 #  122|     getElement(10): [PatternBindingDecl] var ... = ...
 #  122|       getInit(0): [MemberRefExpr] .myInt
 #  122|         getBase(): [DeclRefExpr] inoutParam
@@ -3307,11 +3307,13 @@ cfg.swift:
 #  533|             getBase().getFullyConverted(): [LoadExpr] (AsyncStream<Int>) ...
 #-----|             getMethodRef(): [DeclRefExpr] makeAsyncIterator()
 #  533|         getPattern(0): [NamedPattern] $i$generator
-#  533|       getNextCall(): [CallExpr] call to next()
-#  533|         getFunction(): [MethodLookupExpr] .next()
+#  533|       getNextCall(): [CallExpr] call to next(isolation:)
+#  533|         getFunction(): [MethodLookupExpr] .next(isolation:)
 #  533|           getBase(): [DeclRefExpr] $i$generator
 #  533|           getBase().getFullyConverted(): [InOutExpr] &...
-#-----|           getMethodRef(): [DeclRefExpr] next()
+#-----|           getMethodRef(): [DeclRefExpr] next(isolation:)
+#  533|         getArgument(0): [Argument] isolation: CurrentContextIsolationExpr
+#  533|           getExpr(): [CurrentContextIsolationExpr] CurrentContextIsolationExpr
 #  533|       getNextCall().getFullyConverted(): [AwaitExpr] await ...
 #  533|       getBody(): [BraceStmt] { ... }
 #  534|         getElement(0): [CallExpr] call to print(_:separator:terminator:)
@@ -3326,6 +3328,7 @@ cfg.swift:
 #  534|           getArgument(2): [Argument] terminator: default terminator
 #  534|             getExpr(): [DefaultArgumentExpr] default terminator
 #  525| [NilLiteralExpr] nil
+#  533| [NilLiteralExpr] nil
 #  538| [NamedFunction] testNilCoalescing(x:)
 #  538|     InterfaceType = (Int?) -> Int
 #  538|   getParam(0): [ParamDecl] x
@@ -3543,6 +3546,85 @@ cfg.swift:
 #  582|     Type = Int
 #  587| [Comment] // ---
 #  587| 
+#  589| [Comment] //codeql-extractor-options: -enable-experimental-feature ValueGenerics -disable-availability-checking
+#  589| 
+#  590| [StructDecl] ValueGenericsStruct
+#  590|   getGenericTypeParam(0): [GenericTypeParamDecl] N
+#  591|   getMember(0): [PatternBindingDecl] var ... = ...
+#  591|     getInit(0): [TypeValueExpr] TypeValueExpr
+#  591|       getTypeRepr(): (no string representation)
+#  591|     getPattern(0): [NamedPattern] x
+#  591|   getMember(1): [ConcreteVarDecl] x
+#  591|       Type = Int
+#  591|     getAccessor(0): [Accessor] get
+#  591|         InterfaceType = <let N : Int> (ValueGenericsStruct<N>) -> () -> Int
+#  591|       getSelfParam(): [ParamDecl] self
+#  591|           Type = ValueGenericsStruct<N>
+#  591|       getBody(): [BraceStmt] { ... }
+#-----|         getElement(0): [ReturnStmt] return ...
+#-----|           getResult(): [MemberRefExpr] .x
+#-----|             getBase(): [DeclRefExpr] self
+#  591|     getAccessor(1): [Accessor] set
+#  591|         InterfaceType = <let N : Int> (inout ValueGenericsStruct<N>) -> (Int) -> ()
+#  591|       getSelfParam(): [ParamDecl] self
+#  591|           Type = ValueGenericsStruct<N>
+#  591|       getParam(0): [ParamDecl] value
+#  591|           Type = Int
+#  591|       getBody(): [BraceStmt] { ... }
+#-----|         getElement(0): [AssignExpr]  ... = ...
+#-----|           getDest(): [MemberRefExpr] .x
+#-----|             getBase(): [DeclRefExpr] self
+#-----|           getSource(): [DeclRefExpr] value
+#  591|     getAccessor(2): [Accessor] _modify
+#  591|         InterfaceType = <let N : Int> (inout ValueGenericsStruct<N>) -> () -> ()
+#  591|       getSelfParam(): [ParamDecl] self
+#  591|           Type = ValueGenericsStruct<N>
+#  591|       getBody(): [BraceStmt] { ... }
+#  591|         getElement(0): [YieldStmt] yield ...
+#-----|           getResult(0): [MemberRefExpr] .x
+#-----|             getBase(): [DeclRefExpr] self
+#-----|           getResult(0).getFullyConverted(): [InOutExpr] &...
+#  590|   getMember(2): [Initializer] ValueGenericsStruct<N>.init(x:)
+#  590|       InterfaceType = <let N : Int> (ValueGenericsStruct<N>.Type) -> (Int) -> ValueGenericsStruct<N>
+#  590|     getSelfParam(): [ParamDecl] self
+#  590|         Type = ValueGenericsStruct<N>
+#  590|     getParam(0): [ParamDecl] x
+#  590|         Type = Int
+#  590|   getMember(3): [Initializer] ValueGenericsStruct<N>.init()
+#  590|       InterfaceType = <let N : Int> (ValueGenericsStruct<N>.Type) -> () -> ValueGenericsStruct<N>
+#  590|     getSelfParam(): [ParamDecl] self
+#  590|         Type = ValueGenericsStruct<N>
+#  590|     getBody(): [BraceStmt] { ... }
+#  590|       getElement(0): [ReturnStmt] return
+#  591| [UnspecifiedElement] missing type from TypeRepr
+#  594| [NamedFunction] valueGenericsFn(_:)
+#  594|     InterfaceType = <let N : Int> (ValueGenericsStruct<N>) -> ()
+#  594|   getGenericTypeParam(0): [GenericTypeParamDecl] N
+#  594|   getParam(0): [ParamDecl] value
+#  594|       Type = ValueGenericsStruct<N>
+#  594|   getBody(): [BraceStmt] { ... }
+#  595|     getVariable(0): [ConcreteVarDecl] x
+#  595|         Type = Int
+#  595|     getElement(0): [PatternBindingDecl] var ... = ...
+#  595|       getInit(0): [TypeValueExpr] TypeValueExpr
+#  595|         getTypeRepr(): (no string representation)
+#  595|       getPattern(0): [NamedPattern] x
+#  596|     getElement(1): [CallExpr] call to print(_:separator:terminator:)
+#  596|       getFunction(): [DeclRefExpr] print(_:separator:terminator:)
+#  596|       getArgument(0): [Argument] : [...]
+#  596|         getExpr(): [VarargExpansionExpr] [...]
+#  596|           getSubExpr(): [ArrayExpr] [...]
+#  596|             getElement(0): [DeclRefExpr] x
+#  596|             getElement(0).getFullyConverted(): [ErasureExpr] (Any) ...
+#  596|               getSubExpr(): [LoadExpr] (Int) ...
+#  596|       getArgument(1): [Argument] separator: default separator
+#  596|         getExpr(): [DefaultArgumentExpr] default separator
+#  596|       getArgument(2): [Argument] terminator: default terminator
+#  596|         getExpr(): [DefaultArgumentExpr] default terminator
+#  597|     getElement(2): [AssignExpr]  ... = ...
+#  597|       getDest(): [DiscardAssignmentExpr] _
+#  597|       getSource(): [DeclRefExpr] value
+#  595| [UnspecifiedElement] missing type from TypeRepr
 declarations.swift:
 #    1| [StructDecl] Foo
 #    2|   getMember(0): [PatternBindingDecl] var ... = ...

--- a/swift/ql/test/library-tests/ast/cfg.swift
+++ b/swift/ql/test/library-tests/ast/cfg.swift
@@ -112,13 +112,13 @@ func testMemberRef(param : C, inoutParam : inout C, opt : C?) {
   let n2 = c.self.myInt
   let n3 = c.getMyInt()
   let n4 = c.self.getMyInt()
-
   let n5 = param.myInt
   let n6 = param.self.myInt
-  let n7 = param.getMyInt()
+
   let n8 = param.self.getMyInt()
 
   let n9 = inoutParam.myInt
+  let n7 = param.getMyInt()
   let n10 = inoutParam.self.myInt
   let n11 = inoutParam.getMyInt()
   let n12 = inoutParam.self.getMyInt()
@@ -585,3 +585,14 @@ func singleStmtExpr(_ x: Int) {
   let b = if (x < 42) { 1 } else { 2 }
 }
 // ---
+
+//codeql-extractor-options: -enable-experimental-feature ValueGenerics -disable-availability-checking
+struct ValueGenericsStruct<let N: Int> {
+    var x = N;
+}
+
+func valueGenericsFn<let N: Int>(_ value: ValueGenericsStruct<N>) {
+    var x = N;
+    print(x);
+    _ = value;
+}

--- a/swift/ql/test/library-tests/controlflow/graph/Cfg.expected
+++ b/swift/ql/test/library-tests/controlflow/graph/Cfg.expected
@@ -354,37 +354,37 @@
 | cfg.swift:113:12:113:12 | c | cfg.swift:113:12:113:23 | call to getMyInt() |  |
 | cfg.swift:113:12:113:14 | .getMyInt() | cfg.swift:113:12:113:12 | c |  |
 | cfg.swift:113:12:113:23 | call to getMyInt() | cfg.swift:113:3:113:23 | var ... = ... |  |
-| cfg.swift:114:3:114:28 | var ... = ... | cfg.swift:116:7:116:7 | n5 |  |
+| cfg.swift:114:3:114:28 | var ... = ... | cfg.swift:115:7:115:7 | n5 |  |
 | cfg.swift:114:7:114:7 | n4 | cfg.swift:114:12:114:19 | .getMyInt() | match |
 | cfg.swift:114:12:114:12 | c | cfg.swift:114:12:114:14 | .self |  |
 | cfg.swift:114:12:114:14 | .self | cfg.swift:114:12:114:28 | call to getMyInt() |  |
 | cfg.swift:114:12:114:19 | .getMyInt() | cfg.swift:114:12:114:12 | c |  |
 | cfg.swift:114:12:114:28 | call to getMyInt() | cfg.swift:114:3:114:28 | var ... = ... |  |
-| cfg.swift:116:3:116:18 | var ... = ... | cfg.swift:117:7:117:7 | n6 |  |
-| cfg.swift:116:7:116:7 | n5 | cfg.swift:116:12:116:12 | param | match |
-| cfg.swift:116:12:116:12 | param | cfg.swift:116:12:116:18 | getter for .myInt |  |
-| cfg.swift:116:12:116:18 | getter for .myInt | cfg.swift:116:3:116:18 | var ... = ... |  |
-| cfg.swift:117:3:117:23 | var ... = ... | cfg.swift:118:7:118:7 | n7 |  |
-| cfg.swift:117:7:117:7 | n6 | cfg.swift:117:12:117:12 | param | match |
-| cfg.swift:117:12:117:12 | param | cfg.swift:117:12:117:18 | .self |  |
-| cfg.swift:117:12:117:18 | .self | cfg.swift:117:12:117:23 | getter for .myInt |  |
-| cfg.swift:117:12:117:23 | getter for .myInt | cfg.swift:117:3:117:23 | var ... = ... |  |
-| cfg.swift:118:3:118:27 | var ... = ... | cfg.swift:119:7:119:7 | n8 |  |
-| cfg.swift:118:7:118:7 | n7 | cfg.swift:118:12:118:18 | .getMyInt() | match |
-| cfg.swift:118:12:118:12 | param | cfg.swift:118:12:118:27 | call to getMyInt() |  |
-| cfg.swift:118:12:118:18 | .getMyInt() | cfg.swift:118:12:118:12 | param |  |
-| cfg.swift:118:12:118:27 | call to getMyInt() | cfg.swift:118:3:118:27 | var ... = ... |  |
-| cfg.swift:119:3:119:32 | var ... = ... | cfg.swift:121:7:121:7 | n9 |  |
-| cfg.swift:119:7:119:7 | n8 | cfg.swift:119:12:119:23 | .getMyInt() | match |
-| cfg.swift:119:12:119:12 | param | cfg.swift:119:12:119:18 | .self |  |
-| cfg.swift:119:12:119:18 | .self | cfg.swift:119:12:119:32 | call to getMyInt() |  |
-| cfg.swift:119:12:119:23 | .getMyInt() | cfg.swift:119:12:119:12 | param |  |
-| cfg.swift:119:12:119:32 | call to getMyInt() | cfg.swift:119:3:119:32 | var ... = ... |  |
-| cfg.swift:121:3:121:23 | var ... = ... | cfg.swift:122:7:122:7 | n10 |  |
-| cfg.swift:121:7:121:7 | n9 | cfg.swift:121:12:121:12 | inoutParam | match |
-| cfg.swift:121:12:121:12 | (C) ... | cfg.swift:121:12:121:23 | getter for .myInt |  |
-| cfg.swift:121:12:121:12 | inoutParam | cfg.swift:121:12:121:12 | (C) ... |  |
-| cfg.swift:121:12:121:23 | getter for .myInt | cfg.swift:121:3:121:23 | var ... = ... |  |
+| cfg.swift:115:3:115:18 | var ... = ... | cfg.swift:116:7:116:7 | n6 |  |
+| cfg.swift:115:7:115:7 | n5 | cfg.swift:115:12:115:12 | param | match |
+| cfg.swift:115:12:115:12 | param | cfg.swift:115:12:115:18 | getter for .myInt |  |
+| cfg.swift:115:12:115:18 | getter for .myInt | cfg.swift:115:3:115:18 | var ... = ... |  |
+| cfg.swift:116:3:116:23 | var ... = ... | cfg.swift:118:7:118:7 | n8 |  |
+| cfg.swift:116:7:116:7 | n6 | cfg.swift:116:12:116:12 | param | match |
+| cfg.swift:116:12:116:12 | param | cfg.swift:116:12:116:18 | .self |  |
+| cfg.swift:116:12:116:18 | .self | cfg.swift:116:12:116:23 | getter for .myInt |  |
+| cfg.swift:116:12:116:23 | getter for .myInt | cfg.swift:116:3:116:23 | var ... = ... |  |
+| cfg.swift:118:3:118:32 | var ... = ... | cfg.swift:120:7:120:7 | n9 |  |
+| cfg.swift:118:7:118:7 | n8 | cfg.swift:118:12:118:23 | .getMyInt() | match |
+| cfg.swift:118:12:118:12 | param | cfg.swift:118:12:118:18 | .self |  |
+| cfg.swift:118:12:118:18 | .self | cfg.swift:118:12:118:32 | call to getMyInt() |  |
+| cfg.swift:118:12:118:23 | .getMyInt() | cfg.swift:118:12:118:12 | param |  |
+| cfg.swift:118:12:118:32 | call to getMyInt() | cfg.swift:118:3:118:32 | var ... = ... |  |
+| cfg.swift:120:3:120:23 | var ... = ... | cfg.swift:121:7:121:7 | n7 |  |
+| cfg.swift:120:7:120:7 | n9 | cfg.swift:120:12:120:12 | inoutParam | match |
+| cfg.swift:120:12:120:12 | (C) ... | cfg.swift:120:12:120:23 | getter for .myInt |  |
+| cfg.swift:120:12:120:12 | inoutParam | cfg.swift:120:12:120:12 | (C) ... |  |
+| cfg.swift:120:12:120:23 | getter for .myInt | cfg.swift:120:3:120:23 | var ... = ... |  |
+| cfg.swift:121:3:121:27 | var ... = ... | cfg.swift:122:7:122:7 | n10 |  |
+| cfg.swift:121:7:121:7 | n7 | cfg.swift:121:12:121:18 | .getMyInt() | match |
+| cfg.swift:121:12:121:12 | param | cfg.swift:121:12:121:27 | call to getMyInt() |  |
+| cfg.swift:121:12:121:18 | .getMyInt() | cfg.swift:121:12:121:12 | param |  |
+| cfg.swift:121:12:121:27 | call to getMyInt() | cfg.swift:121:3:121:27 | var ... = ... |  |
 | cfg.swift:122:3:122:29 | var ... = ... | cfg.swift:123:7:123:7 | n11 |  |
 | cfg.swift:122:7:122:7 | n10 | cfg.swift:122:13:122:13 | inoutParam | match |
 | cfg.swift:122:13:122:13 | inoutParam | cfg.swift:122:13:122:24 | .self |  |
@@ -2035,10 +2035,12 @@
 | cfg.swift:529:17:529:30 | .finish() | cfg.swift:529:17:529:17 | continuation |  |
 | cfg.swift:529:17:529:37 | call to finish() | cfg.swift:525:27:530:13 | exit { ... } (normal) |  |
 | cfg.swift:533:5:533:5 | $i$generator | cfg.swift:533:5:533:5 | &... |  |
-| cfg.swift:533:5:533:5 | &... | cfg.swift:533:5:533:5 | call to next() |  |
-| cfg.swift:533:5:533:5 | .next() | cfg.swift:533:5:533:5 | $i$generator |  |
+| cfg.swift:533:5:533:5 | &... | cfg.swift:533:5:533:5 | nil |  |
+| cfg.swift:533:5:533:5 | .next(isolation:) | cfg.swift:533:5:533:5 | $i$generator |  |
+| cfg.swift:533:5:533:5 | CurrentContextIsolationExpr | cfg.swift:533:5:533:5 | call to next(isolation:) |  |
 | cfg.swift:533:5:533:5 | await ... | cfg.swift:533:5:535:5 | for ... in ... { ... } |  |
-| cfg.swift:533:5:533:5 | call to next() | cfg.swift:533:5:533:5 | await ... |  |
+| cfg.swift:533:5:533:5 | call to next(isolation:) | cfg.swift:533:5:533:5 | await ... |  |
+| cfg.swift:533:5:533:5 | nil | cfg.swift:533:5:533:5 | CurrentContextIsolationExpr |  |
 | cfg.swift:533:5:535:5 | for ... in ... { ... } | cfg.swift:522:1:536:1 | exit testAsyncFor() (normal) | empty |
 | cfg.swift:533:5:535:5 | for ... in ... { ... } | cfg.swift:533:19:533:19 | i | non-empty |
 | cfg.swift:533:19:533:19 | i | cfg.swift:534:9:534:9 | print(_:separator:terminator:) | match |
@@ -2048,7 +2050,7 @@
 | cfg.swift:533:24:533:24 | call to makeAsyncIterator() | file://:0:0:0:0 | var ... = ... |  |
 | cfg.swift:533:24:533:24 | stream | cfg.swift:533:24:533:24 | (AsyncStream<Int>) ... |  |
 | cfg.swift:534:9:534:9 | print(_:separator:terminator:) | cfg.swift:534:15:534:15 | i |  |
-| cfg.swift:534:9:534:16 | call to print(_:separator:terminator:) | cfg.swift:533:5:533:5 | .next() |  |
+| cfg.swift:534:9:534:16 | call to print(_:separator:terminator:) | cfg.swift:533:5:533:5 | .next(isolation:) |  |
 | cfg.swift:534:14:534:14 | default separator | cfg.swift:534:14:534:14 | default terminator |  |
 | cfg.swift:534:14:534:14 | default terminator | cfg.swift:534:9:534:16 | call to print(_:separator:terminator:) |  |
 | cfg.swift:534:15:534:15 | (Any) ... | cfg.swift:534:15:534:15 | [...] |  |
@@ -2220,6 +2222,44 @@
 | cfg.swift:585:25:585:25 | ThenStmt | cfg.swift:585:11:585:38 | SingleValueStmtExpr |  |
 | cfg.swift:585:36:585:36 | 2 | cfg.swift:585:36:585:36 | ThenStmt |  |
 | cfg.swift:585:36:585:36 | ThenStmt | cfg.swift:585:11:585:38 | SingleValueStmtExpr |  |
+| cfg.swift:590:8:590:8 | ValueGenericsStruct<N>.init() | cfg.swift:590:8:590:8 | self |  |
+| cfg.swift:590:8:590:8 | enter ValueGenericsStruct<N>.init() | cfg.swift:590:8:590:8 | ValueGenericsStruct<N>.init() |  |
+| cfg.swift:590:8:590:8 | exit ValueGenericsStruct<N>.init() (normal) | cfg.swift:590:8:590:8 | exit ValueGenericsStruct<N>.init() |  |
+| cfg.swift:590:8:590:8 | return | cfg.swift:590:8:590:8 | exit ValueGenericsStruct<N>.init() (normal) | return |
+| cfg.swift:590:8:590:8 | self | cfg.swift:590:8:590:8 | return |  |
+| cfg.swift:591:9:591:9 | _modify | cfg.swift:591:9:591:9 | self |  |
+| cfg.swift:591:9:591:9 | enter _modify | cfg.swift:591:9:591:9 | _modify |  |
+| cfg.swift:591:9:591:9 | enter get | cfg.swift:591:9:591:9 | get |  |
+| cfg.swift:591:9:591:9 | enter set | cfg.swift:591:9:591:9 | set |  |
+| cfg.swift:591:9:591:9 | exit _modify (normal) | cfg.swift:591:9:591:9 | exit _modify |  |
+| cfg.swift:591:9:591:9 | exit get (normal) | cfg.swift:591:9:591:9 | exit get |  |
+| cfg.swift:591:9:591:9 | exit set (normal) | cfg.swift:591:9:591:9 | exit set |  |
+| cfg.swift:591:9:591:9 | get | cfg.swift:591:9:591:9 | self |  |
+| cfg.swift:591:9:591:9 | self | cfg.swift:591:9:591:9 | value |  |
+| cfg.swift:591:9:591:9 | self | file://:0:0:0:0 | self |  |
+| cfg.swift:591:9:591:9 | self | file://:0:0:0:0 | self |  |
+| cfg.swift:591:9:591:9 | set | cfg.swift:591:9:591:9 | self |  |
+| cfg.swift:591:9:591:9 | value | file://:0:0:0:0 | self |  |
+| cfg.swift:591:9:591:9 | yield ... | cfg.swift:591:9:591:9 | exit _modify (normal) |  |
+| cfg.swift:594:1:598:1 | enter valueGenericsFn(_:) | cfg.swift:594:1:598:1 | valueGenericsFn(_:) |  |
+| cfg.swift:594:1:598:1 | exit valueGenericsFn(_:) (normal) | cfg.swift:594:1:598:1 | exit valueGenericsFn(_:) |  |
+| cfg.swift:594:1:598:1 | valueGenericsFn(_:) | cfg.swift:594:34:594:64 | value |  |
+| cfg.swift:594:34:594:64 | value | cfg.swift:595:9:595:9 | x |  |
+| cfg.swift:595:5:595:13 | var ... = ... | cfg.swift:596:5:596:5 | print(_:separator:terminator:) |  |
+| cfg.swift:595:9:595:9 | x | cfg.swift:595:13:595:13 | TypeValueExpr | match |
+| cfg.swift:595:13:595:13 | TypeValueExpr | cfg.swift:595:5:595:13 | var ... = ... |  |
+| cfg.swift:596:5:596:5 | print(_:separator:terminator:) | cfg.swift:596:11:596:11 | x |  |
+| cfg.swift:596:5:596:12 | call to print(_:separator:terminator:) | cfg.swift:597:5:597:5 | _ |  |
+| cfg.swift:596:10:596:10 | default separator | cfg.swift:596:10:596:10 | default terminator |  |
+| cfg.swift:596:10:596:10 | default terminator | cfg.swift:596:5:596:12 | call to print(_:separator:terminator:) |  |
+| cfg.swift:596:11:596:11 | (Any) ... | cfg.swift:596:11:596:11 | [...] |  |
+| cfg.swift:596:11:596:11 | (Int) ... | cfg.swift:596:11:596:11 | (Any) ... |  |
+| cfg.swift:596:11:596:11 | [...] | cfg.swift:596:10:596:10 | default separator |  |
+| cfg.swift:596:11:596:11 | [...] | cfg.swift:596:11:596:11 | [...] |  |
+| cfg.swift:596:11:596:11 | x | cfg.swift:596:11:596:11 | (Int) ... |  |
+| cfg.swift:597:5:597:5 | _ | cfg.swift:597:9:597:9 | value |  |
+| cfg.swift:597:5:597:9 |  ... = ... | cfg.swift:594:1:598:1 | exit valueGenericsFn(_:) (normal) |  |
+| cfg.swift:597:9:597:9 | value | cfg.swift:597:5:597:9 |  ... = ... |  |
 | file://:0:0:0:0 |  ... = ... | cfg.swift:394:7:394:7 | exit set (normal) |  |
 | file://:0:0:0:0 |  ... = ... | cfg.swift:410:9:410:9 | exit set (normal) |  |
 | file://:0:0:0:0 |  ... = ... | cfg.swift:417:9:417:9 | exit set (normal) |  |
@@ -2227,6 +2267,7 @@
 | file://:0:0:0:0 |  ... = ... | cfg.swift:450:7:450:7 | exit set (normal) |  |
 | file://:0:0:0:0 |  ... = ... | cfg.swift:451:7:451:7 | exit set (normal) |  |
 | file://:0:0:0:0 |  ... = ... | cfg.swift:452:7:452:7 | exit set (normal) |  |
+| file://:0:0:0:0 |  ... = ... | cfg.swift:591:9:591:9 | exit set (normal) |  |
 | file://:0:0:0:0 | &... | cfg.swift:394:7:394:7 | yield ... |  |
 | file://:0:0:0:0 | &... | cfg.swift:410:9:410:9 | yield ... |  |
 | file://:0:0:0:0 | &... | cfg.swift:417:9:417:9 | yield ... |  |
@@ -2234,6 +2275,7 @@
 | file://:0:0:0:0 | &... | cfg.swift:450:7:450:7 | yield ... |  |
 | file://:0:0:0:0 | &... | cfg.swift:451:7:451:7 | yield ... |  |
 | file://:0:0:0:0 | &... | cfg.swift:452:7:452:7 | yield ... |  |
+| file://:0:0:0:0 | &... | cfg.swift:591:9:591:9 | yield ... |  |
 | file://:0:0:0:0 | .b | file://:0:0:0:0 | return ... |  |
 | file://:0:0:0:0 | .b | file://:0:0:0:0 | value |  |
 | file://:0:0:0:0 | .bs | file://:0:0:0:0 | return ... |  |
@@ -2247,6 +2289,8 @@
 | file://:0:0:0:0 | .x | file://:0:0:0:0 | return ... |  |
 | file://:0:0:0:0 | .x | file://:0:0:0:0 | return ... |  |
 | file://:0:0:0:0 | .x | file://:0:0:0:0 | return ... |  |
+| file://:0:0:0:0 | .x | file://:0:0:0:0 | return ... |  |
+| file://:0:0:0:0 | .x | file://:0:0:0:0 | value |  |
 | file://:0:0:0:0 | .x | file://:0:0:0:0 | value |  |
 | file://:0:0:0:0 | .x | file://:0:0:0:0 | value |  |
 | file://:0:0:0:0 | .x | file://:0:0:0:0 | value |  |
@@ -2255,6 +2299,7 @@
 | file://:0:0:0:0 | getter for .bs | file://:0:0:0:0 | &... |  |
 | file://:0:0:0:0 | getter for .field | file://:0:0:0:0 | &... |  |
 | file://:0:0:0:0 | getter for .mayB | file://:0:0:0:0 | &... |  |
+| file://:0:0:0:0 | getter for .x | file://:0:0:0:0 | &... |  |
 | file://:0:0:0:0 | getter for .x | file://:0:0:0:0 | &... |  |
 | file://:0:0:0:0 | getter for .x | file://:0:0:0:0 | &... |  |
 | file://:0:0:0:0 | getter for .x | file://:0:0:0:0 | &... |  |
@@ -2269,6 +2314,7 @@
 | file://:0:0:0:0 | return ... | cfg.swift:450:7:450:7 | exit get (normal) | return |
 | file://:0:0:0:0 | return ... | cfg.swift:451:7:451:7 | exit get (normal) | return |
 | file://:0:0:0:0 | return ... | cfg.swift:452:7:452:7 | exit get (normal) | return |
+| file://:0:0:0:0 | return ... | cfg.swift:591:9:591:9 | exit get (normal) | return |
 | file://:0:0:0:0 | self | file://:0:0:0:0 | .b |  |
 | file://:0:0:0:0 | self | file://:0:0:0:0 | .b |  |
 | file://:0:0:0:0 | self | file://:0:0:0:0 | .bs |  |
@@ -2285,6 +2331,8 @@
 | file://:0:0:0:0 | self | file://:0:0:0:0 | .x |  |
 | file://:0:0:0:0 | self | file://:0:0:0:0 | .x |  |
 | file://:0:0:0:0 | self | file://:0:0:0:0 | .x |  |
+| file://:0:0:0:0 | self | file://:0:0:0:0 | .x |  |
+| file://:0:0:0:0 | self | file://:0:0:0:0 | .x |  |
 | file://:0:0:0:0 | self | file://:0:0:0:0 | getter for .b |  |
 | file://:0:0:0:0 | self | file://:0:0:0:0 | getter for .bs |  |
 | file://:0:0:0:0 | self | file://:0:0:0:0 | getter for .field |  |
@@ -2292,6 +2340,8 @@
 | file://:0:0:0:0 | self | file://:0:0:0:0 | getter for .x |  |
 | file://:0:0:0:0 | self | file://:0:0:0:0 | getter for .x |  |
 | file://:0:0:0:0 | self | file://:0:0:0:0 | getter for .x |  |
+| file://:0:0:0:0 | self | file://:0:0:0:0 | getter for .x |  |
+| file://:0:0:0:0 | value | file://:0:0:0:0 |  ... = ... |  |
 | file://:0:0:0:0 | value | file://:0:0:0:0 |  ... = ... |  |
 | file://:0:0:0:0 | value | file://:0:0:0:0 |  ... = ... |  |
 | file://:0:0:0:0 | value | file://:0:0:0:0 |  ... = ... |  |
@@ -2301,4 +2351,4 @@
 | file://:0:0:0:0 | value | file://:0:0:0:0 |  ... = ... |  |
 | file://:0:0:0:0 | var ... = ... | cfg.swift:138:3:138:3 | .next() |  |
 | file://:0:0:0:0 | var ... = ... | cfg.swift:526:17:526:17 | .next() |  |
-| file://:0:0:0:0 | var ... = ... | cfg.swift:533:5:533:5 | .next() |  |
+| file://:0:0:0:0 | var ... = ... | cfg.swift:533:5:533:5 | .next(isolation:) |  |

--- a/swift/ql/test/library-tests/controlflow/graph/cfg.swift
+++ b/swift/ql/test/library-tests/controlflow/graph/cfg.swift
@@ -112,13 +112,13 @@ func testMemberRef(param : C, inoutParam : inout C, opt : C?) {
   let n2 = c.self.myInt
   let n3 = c.getMyInt()
   let n4 = c.self.getMyInt()
-
   let n5 = param.myInt
   let n6 = param.self.myInt
-  let n7 = param.getMyInt()
+
   let n8 = param.self.getMyInt()
 
   let n9 = inoutParam.myInt
+  let n7 = param.getMyInt()
   let n10 = inoutParam.self.myInt
   let n11 = inoutParam.getMyInt()
   let n12 = inoutParam.self.getMyInt()
@@ -585,3 +585,14 @@ func singleStmtExpr(_ x: Int) {
   let b = if (x < 42) { 1 } else { 2 }
 }
 // ---
+
+//codeql-extractor-options: -enable-experimental-feature ValueGenerics -disable-availability-checking
+struct ValueGenericsStruct<let N: Int> {
+    var x = N;
+}
+
+func valueGenericsFn<let N: Int>(_ value: ValueGenericsStruct<N>) {
+    var x = N;
+    print(x);
+    _ = value;
+}

--- a/swift/tools/qltest.sh
+++ b/swift/tools/qltest.sh
@@ -10,10 +10,10 @@ export CODEQL_EXTRACTOR_SWIFT_LOG_LEVELS=${CODEQL_EXTRACTOR_SWIFT_LOG_LEVELS:-ou
 for src in *.swift; do
   env=()
   opts=(-resource-dir "$RESOURCE_DIR" -c -primary-file "$src")
-  opts+=($(sed -n '1 s=//codeql-extractor-options:==p' $src))
+  opts+=($(sed -n 's=//codeql-extractor-options:==p' $src))
   expected_status=$(sed -n 's=//codeql-extractor-expected-status:[[:space:]]*==p' $src)
   expected_status=${expected_status:-0}
-  env+=($(sed -n '1 s=//codeql-extractor-env:==p' $src))
+  env+=($(sed -n 's=//codeql-extractor-env:==p' $src))
   echo >> $QLTEST_LOG
   env "${env[@]}" "$EXTRACTOR" "${opts[@]}" >> $QLTEST_LOG 2>&1
   actual_status=$?


### PR DESCRIPTION
We do see errors  about missing types from type reprs, which is not ideal. However I propose to postpone looking at that when type value expressions get out from being experimental.

Also, changed `qltest.sh` to be more liberal about the location of special option comments in the test source code.