### PR TITLE
C#: Improve the query `cs/gethashcode-is-not-defined`.

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/frameworks/system/collections/Generic.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/system/collections/Generic.qll
@@ -159,6 +159,15 @@ class SystemCollectionsGenericIDictionaryInterface extends SystemCollectionsGene
   }
 }
 
+/** The ``System.Collections.Generic.IReadOnlyDictionary`2`` interface. */
+class SystemCollectionsGenericIReadOnlyDictionaryInterface extends SystemCollectionsGenericUnboundGenericInterface
+{
+  SystemCollectionsGenericIReadOnlyDictionaryInterface() {
+    this.hasName("IReadOnlyDictionary`2") and
+    this.getNumberOfTypeParameters() = 2
+  }
+}
+
 /** The ``System.Collections.Generic.IReadOnlyCollection`1`` interface. */
 class SystemCollectionsGenericIReadOnlyCollectionTInterface extends SystemCollectionsGenericUnboundGenericInterface
 {
@@ -173,6 +182,14 @@ class SystemCollectionsGenericIReadOnlyListTInterface extends SystemCollectionsG
 {
   SystemCollectionsGenericIReadOnlyListTInterface() {
     this.hasName("IReadOnlyList`1") and
+    this.getNumberOfTypeParameters() = 1
+  }
+}
+
+/** The ``System.Collections.Generic.HashSet`1`` class. */
+class SystemCollectionsGenericHashSetClass extends SystemCollectionsGenericUnboundGenericClass {
+  SystemCollectionsGenericHashSetClass() {
+    this.hasName("HashSet`1") and
     this.getNumberOfTypeParameters() = 1
   }
 }

--- a/csharp/ql/src/change-notes/2025-05-15-gethashcode-is-not-defined.md
+++ b/csharp/ql/src/change-notes/2025-05-15-gethashcode-is-not-defined.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The precision of the query `cs/gethashcode-is-not-defined` has been improved (false negative reduction). Calls to more methods (and indexers) that rely on the invariant `e1.Equals(e2)` implies `e1.GetHashCode() == e2.GetHashCode()` are taken into account.

--- a/csharp/ql/test/query-tests/Likely Bugs/HashedButNoHash/HashedButNoHash.cs
+++ b/csharp/ql/test/query-tests/Likely Bugs/HashedButNoHash/HashedButNoHash.cs
@@ -6,9 +6,10 @@ public class Test
     public void M()
     {
         var h = new Hashtable();
-        h.Add(this, null); // BAD
+        h.Add(this, null); // $ Alert
+
         var d = new Dictionary<Test, bool>();
-        d.Add(this, false); // BAD
+        d.Add(this, false); // $ Alert
     }
 
     public override bool Equals(object other)

--- a/csharp/ql/test/query-tests/Likely Bugs/HashedButNoHash/HashedButNoHash.cs
+++ b/csharp/ql/test/query-tests/Likely Bugs/HashedButNoHash/HashedButNoHash.cs
@@ -7,9 +7,26 @@ public class Test
     {
         var h = new Hashtable();
         h.Add(this, null); // $ Alert
+        h.Contains(this); // $ Alert
+        h.ContainsKey(this); // $ Alert
+        h[this] = null; // $ Alert
+        h.Remove(this); // $ Alert
+
+        var l = new List<Test>();
+        l.Add(this); // Good
 
         var d = new Dictionary<Test, bool>();
         d.Add(this, false); // $ Alert
+        d.ContainsKey(this); // $ Alert
+        d[this] = false; // $ Alert
+        d.Remove(this); // $ Alert
+        d.TryAdd(this, false); // $ Alert
+        d.TryGetValue(this, out bool _); // $ Alert
+
+        var hs = new HashSet<Test>();
+        hs.Add(this); // $ Alert
+        hs.Contains(this); // $ Alert
+        hs.Remove(this); // $ Alert
     }
 
     public override bool Equals(object other)

--- a/csharp/ql/test/query-tests/Likely Bugs/HashedButNoHash/HashedButNoHash.expected
+++ b/csharp/ql/test/query-tests/Likely Bugs/HashedButNoHash/HashedButNoHash.expected
@@ -1,2 +1,2 @@
 | HashedButNoHash.cs:9:15:9:18 | this access | This expression is hashed, but type 'Test' only defines Equals(...) not GetHashCode(). |
-| HashedButNoHash.cs:11:15:11:18 | this access | This expression is hashed, but type 'Test' only defines Equals(...) not GetHashCode(). |
+| HashedButNoHash.cs:12:15:12:18 | this access | This expression is hashed, but type 'Test' only defines Equals(...) not GetHashCode(). |

--- a/csharp/ql/test/query-tests/Likely Bugs/HashedButNoHash/HashedButNoHash.expected
+++ b/csharp/ql/test/query-tests/Likely Bugs/HashedButNoHash/HashedButNoHash.expected
@@ -1,16 +1,14 @@
-#select
 | HashedButNoHash.cs:9:15:9:18 | this access | This expression is hashed, but type 'Test' only defines Equals(...) not GetHashCode(). |
+| HashedButNoHash.cs:10:20:10:23 | this access | This expression is hashed, but type 'Test' only defines Equals(...) not GetHashCode(). |
 | HashedButNoHash.cs:11:23:11:26 | this access | This expression is hashed, but type 'Test' only defines Equals(...) not GetHashCode(). |
+| HashedButNoHash.cs:12:11:12:14 | this access | This expression is hashed, but type 'Test' only defines Equals(...) not GetHashCode(). |
+| HashedButNoHash.cs:13:18:13:21 | this access | This expression is hashed, but type 'Test' only defines Equals(...) not GetHashCode(). |
 | HashedButNoHash.cs:19:15:19:18 | this access | This expression is hashed, but type 'Test' only defines Equals(...) not GetHashCode(). |
 | HashedButNoHash.cs:20:23:20:26 | this access | This expression is hashed, but type 'Test' only defines Equals(...) not GetHashCode(). |
-testFailures
-| HashedButNoHash.cs:10:27:10:36 | // ... | Missing result: Alert |
-| HashedButNoHash.cs:12:25:12:34 | // ... | Missing result: Alert |
-| HashedButNoHash.cs:13:25:13:34 | // ... | Missing result: Alert |
-| HashedButNoHash.cs:21:26:21:35 | // ... | Missing result: Alert |
-| HashedButNoHash.cs:22:25:22:34 | // ... | Missing result: Alert |
-| HashedButNoHash.cs:23:32:23:41 | // ... | Missing result: Alert |
-| HashedButNoHash.cs:24:42:24:51 | // ... | Missing result: Alert |
-| HashedButNoHash.cs:27:23:27:32 | // ... | Missing result: Alert |
-| HashedButNoHash.cs:28:28:28:37 | // ... | Missing result: Alert |
-| HashedButNoHash.cs:29:26:29:35 | // ... | Missing result: Alert |
+| HashedButNoHash.cs:21:11:21:14 | this access | This expression is hashed, but type 'Test' only defines Equals(...) not GetHashCode(). |
+| HashedButNoHash.cs:22:18:22:21 | this access | This expression is hashed, but type 'Test' only defines Equals(...) not GetHashCode(). |
+| HashedButNoHash.cs:23:18:23:21 | this access | This expression is hashed, but type 'Test' only defines Equals(...) not GetHashCode(). |
+| HashedButNoHash.cs:24:23:24:26 | this access | This expression is hashed, but type 'Test' only defines Equals(...) not GetHashCode(). |
+| HashedButNoHash.cs:27:16:27:19 | this access | This expression is hashed, but type 'Test' only defines Equals(...) not GetHashCode(). |
+| HashedButNoHash.cs:28:21:28:24 | this access | This expression is hashed, but type 'Test' only defines Equals(...) not GetHashCode(). |
+| HashedButNoHash.cs:29:19:29:22 | this access | This expression is hashed, but type 'Test' only defines Equals(...) not GetHashCode(). |

--- a/csharp/ql/test/query-tests/Likely Bugs/HashedButNoHash/HashedButNoHash.expected
+++ b/csharp/ql/test/query-tests/Likely Bugs/HashedButNoHash/HashedButNoHash.expected
@@ -1,2 +1,16 @@
+#select
 | HashedButNoHash.cs:9:15:9:18 | this access | This expression is hashed, but type 'Test' only defines Equals(...) not GetHashCode(). |
-| HashedButNoHash.cs:12:15:12:18 | this access | This expression is hashed, but type 'Test' only defines Equals(...) not GetHashCode(). |
+| HashedButNoHash.cs:11:23:11:26 | this access | This expression is hashed, but type 'Test' only defines Equals(...) not GetHashCode(). |
+| HashedButNoHash.cs:19:15:19:18 | this access | This expression is hashed, but type 'Test' only defines Equals(...) not GetHashCode(). |
+| HashedButNoHash.cs:20:23:20:26 | this access | This expression is hashed, but type 'Test' only defines Equals(...) not GetHashCode(). |
+testFailures
+| HashedButNoHash.cs:10:27:10:36 | // ... | Missing result: Alert |
+| HashedButNoHash.cs:12:25:12:34 | // ... | Missing result: Alert |
+| HashedButNoHash.cs:13:25:13:34 | // ... | Missing result: Alert |
+| HashedButNoHash.cs:21:26:21:35 | // ... | Missing result: Alert |
+| HashedButNoHash.cs:22:25:22:34 | // ... | Missing result: Alert |
+| HashedButNoHash.cs:23:32:23:41 | // ... | Missing result: Alert |
+| HashedButNoHash.cs:24:42:24:51 | // ... | Missing result: Alert |
+| HashedButNoHash.cs:27:23:27:32 | // ... | Missing result: Alert |
+| HashedButNoHash.cs:28:28:28:37 | // ... | Missing result: Alert |
+| HashedButNoHash.cs:29:26:29:35 | // ... | Missing result: Alert |

--- a/csharp/ql/test/query-tests/Likely Bugs/HashedButNoHash/HashedButNoHash.qlref
+++ b/csharp/ql/test/query-tests/Likely Bugs/HashedButNoHash/HashedButNoHash.qlref
@@ -1,1 +1,3 @@
-Likely Bugs/HashedButNoHash.ql
+query: Likely Bugs/HashedButNoHash.ql
+postprocess: utils/test/InlineExpectationsTestQuery.ql
+


### PR DESCRIPTION
Even though there is a general compiler warning [CS0659](https://docs.microsoft.com/en-us/dotnet/csharp/misc/cs0659) for all types overriding `Equals` but not `GetHashCode` - this query only targets expressions of types, where it is more likely to have an impact that `GetHashCode()` is not overridden.