### PR TITLE
C++: Exclude tests in model generation

### DIFF
--- a/cpp/ql/src/utils/modelgenerator/internal/CaptureModels.qll
+++ b/cpp/ql/src/utils/modelgenerator/internal/CaptureModels.qll
@@ -45,6 +45,13 @@ private predicate isUninterestingForModels(Callable api) {
   api = any(Cpp::LambdaExpression lambda).getLambdaFunction()
   or
   api.isFromUninstantiatedTemplate(_)
+  or
+  // Exclude functions in test directories (but not the ones in the CodeQL test directory)
+  exists(Cpp::File f |
+    f = api.getFile() and
+    f.getAbsolutePath().matches("%test%") and
+    not f.getAbsolutePath().matches("%test/library-tests/dataflow/modelgenerator/dataflow/%")
+  )
 }
 
 private predicate relevant(Callable api) {


### PR DESCRIPTION
@jketema noticed that there are a few summaries (for OpenSSL specifically) in https://github.com/github/codeql/pull/19492 that are from test functions. This PR excludes model generation for functions inside folders that match `%test%`.

Care is needed to not exclude our own tests, though, as the summary tests are located in `cpp/ql/test/library-tests/dataflow/modelgenerator/dataflow`. So we explicitly allow that directory.

I tried to regenerate the OpenSSL models with these changes on top of https://github.com/github/codeql/pull/19492 and compare the changes: https://www.diffchecker.com/z6iyKLAU/ (this isn't super readable, but I've manually checked most of the excludes functions and they do indeed belong to tests)