### PR TITLE
Rust: Make current MaD predicates deprecated

### DIFF
--- a/rust/ql/lib/codeql/rust/dataflow/internal/ModelsAsData.qll
+++ b/rust/ql/lib/codeql/rust/dataflow/internal/ModelsAsData.qll
@@ -58,7 +58,7 @@ private import codeql.rust.dataflow.FlowSink
  * For more information on the `kind` parameter, see
  * https://github.com/github/codeql/blob/main/docs/codeql/reusables/threat-model-description.rst.
  */
-extensible predicate sourceModel(
+extensible predicate sourceModelDeprecated(
   string crate, string path, string output, string kind, string provenance,
   QlBuiltins::ExtensionId madId
 );
@@ -74,7 +74,7 @@ extensible predicate sourceModel(
  *
  * - `sql-injection`: a flow sink for SQL injection.
  */
-extensible predicate sinkModel(
+extensible predicate sinkModelDeprecated(
   string crate, string path, string input, string kind, string provenance,
   QlBuiltins::ExtensionId madId
 );
@@ -87,7 +87,7 @@ extensible predicate sinkModel(
  * `kind` should be either `value` or `taint`, for value-preserving or taint-preserving
  * steps, respectively.
  */
-extensible predicate summaryModel(
+extensible predicate summaryModelDeprecated(
   string crate, string path, string input, string output, string kind, string provenance,
   QlBuiltins::ExtensionId madId
 );
@@ -99,17 +99,17 @@ extensible predicate summaryModel(
  */
 predicate interpretModelForTest(QlBuiltins::ExtensionId madId, string model) {
   exists(string crate, string path, string output, string kind |
-    sourceModel(crate, path, kind, output, _, madId) and
+    sourceModelDeprecated(crate, path, kind, output, _, madId) and
     model = "Source: " + crate + "; " + path + "; " + output + "; " + kind
   )
   or
   exists(string crate, string path, string input, string kind |
-    sinkModel(crate, path, kind, input, _, madId) and
+    sinkModelDeprecated(crate, path, kind, input, _, madId) and
     model = "Sink: " + crate + "; " + path + "; " + input + "; " + kind
   )
   or
   exists(string type, string path, string input, string output, string kind |
-    summaryModel(type, path, input, output, kind, _, madId) and
+    summaryModelDeprecated(type, path, input, output, kind, _, madId) and
     model = "Summary: " + type + "; " + path + "; " + input + "; " + output + "; " + kind
   )
 }
@@ -119,7 +119,7 @@ private class SummarizedCallableFromModel extends SummarizedCallable::Range {
   private string path;
 
   SummarizedCallableFromModel() {
-    summaryModel(crate, path, _, _, _, _, _) and
+    summaryModelDeprecated(crate, path, _, _, _, _, _) and
     this = crate + "::_::" + path
   }
 
@@ -127,7 +127,7 @@ private class SummarizedCallableFromModel extends SummarizedCallable::Range {
     string input, string output, boolean preservesValue, string model
   ) {
     exists(string kind, QlBuiltins::ExtensionId madId |
-      summaryModel(crate, path, input, output, kind, _, madId) and
+      summaryModelDeprecated(crate, path, input, output, kind, _, madId) and
       model = "MaD:" + madId.toString()
     |
       kind = "value" and
@@ -144,13 +144,13 @@ private class FlowSourceFromModel extends FlowSource::Range {
   private string path;
 
   FlowSourceFromModel() {
-    sourceModel(crate, path, _, _, _, _) and
+    sourceModelDeprecated(crate, path, _, _, _, _) and
     this.callResolvesTo(crate, path)
   }
 
   override predicate isSource(string output, string kind, Provenance provenance, string model) {
     exists(QlBuiltins::ExtensionId madId |
-      sourceModel(crate, path, output, kind, provenance, madId) and
+      sourceModelDeprecated(crate, path, output, kind, provenance, madId) and
       model = "MaD:" + madId.toString()
     )
   }
@@ -161,13 +161,13 @@ private class FlowSinkFromModel extends FlowSink::Range {
   private string path;
 
   FlowSinkFromModel() {
-    sinkModel(crate, path, _, _, _, _) and
+    sinkModelDeprecated(crate, path, _, _, _, _) and
     this.callResolvesTo(crate, path)
   }
 
   override predicate isSink(string input, string kind, Provenance provenance, string model) {
     exists(QlBuiltins::ExtensionId madId |
-      sinkModel(crate, path, input, kind, provenance, madId) and
+      sinkModelDeprecated(crate, path, input, kind, provenance, madId) and
       model = "MaD:" + madId.toString()
     )
   }

--- a/rust/ql/lib/codeql/rust/dataflow/internal/ModelsAsData.qll
+++ b/rust/ql/lib/codeql/rust/dataflow/internal/ModelsAsData.qll
@@ -49,6 +49,9 @@ private import codeql.rust.dataflow.FlowSource
 private import codeql.rust.dataflow.FlowSink
 
 /**
+ * DEPRECATED: This predicate will be replaced by an alternative implementation
+ * in the future, which uses a slightly different format.
+ *
  * Holds if in a call to the function with canonical path `path`, defined in the
  * crate `crate`, the value referred to by `output` is a flow source of the given
  * `kind`.
@@ -64,6 +67,9 @@ extensible predicate sourceModelDeprecated(
 );
 
 /**
+ * DEPRECATED: This predicate will be replaced by an alternative implementation
+ * in the future, which uses a slightly different format.
+ *
  * Holds if in a call to the function with canonical path `path`, defined in the
  * crate `crate`, the value referred to by `input` is a flow sink of the given
  * `kind`.
@@ -80,6 +86,9 @@ extensible predicate sinkModelDeprecated(
 );
 
 /**
+ * DEPRECATED: This predicate will be replaced by an alternative implementation
+ * in the future, which uses a slightly different format.
+ *
  * Holds if in a call to the function with canonical path `path`, defined in the
  * crate `crate`, the value referred to by `input` can flow to the value referred
  * to by `output`.

--- a/rust/ql/lib/codeql/rust/dataflow/internal/empty.model.yml
+++ b/rust/ql/lib/codeql/rust/dataflow/internal/empty.model.yml
@@ -3,15 +3,15 @@ extensions:
   # to avoid errors about undefined extensionals.
   - addsTo:
       pack: codeql/rust-all
-      extensible: sourceModel
+      extensible: sourceModelDeprecated
     data: []
 
   - addsTo:
       pack: codeql/rust-all
-      extensible: sinkModel
+      extensible: sinkModelDeprecated
     data: []
 
   - addsTo:
       pack: codeql/rust-all
-      extensible: summaryModel
+      extensible: summaryModelDeprecated
     data: []

--- a/rust/ql/lib/codeql/rust/frameworks/futures.model.yml
+++ b/rust/ql/lib/codeql/rust/frameworks/futures.model.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
       pack: codeql/rust-all
-      extensible: summaryModel
+      extensible: summaryModelDeprecated
     data:
       - ["repo:https://github.com/rust-lang/futures-rs:futures-executor", "crate::local_pool::block_on", "Argument[0]", "ReturnValue", "value", "manual"]

--- a/rust/ql/lib/codeql/rust/frameworks/http.model.yml
+++ b/rust/ql/lib/codeql/rust/frameworks/http.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/rust-all
-      extensible: sourceModel
+      extensible: sourceModelDeprecated
     data:
       - ["repo:https://github.com/hyperium/hyper:hyper", "<crate::client::conn::http1::SendRequest>::send_request", "ReturnValue.Future.Field[crate::result::Result::Ok(0)]", "remote", "manual"]
       - ["repo:https://github.com/hyperium/hyper:hyper", "<crate::client::conn::http2::SendRequest>::send_request", "ReturnValue.Future.Field[crate::result::Result::Ok(0)]", "remote", "manual"]

--- a/rust/ql/lib/codeql/rust/frameworks/libc.model.yml
+++ b/rust/ql/lib/codeql/rust/frameworks/libc.model.yml
@@ -1,12 +1,12 @@
 extensions:
   - addsTo:
       pack: codeql/rust-all
-      extensible: sourceModel
+      extensible: sourceModelDeprecated
     data:
       - ["repo:https://github.com/rust-lang/libc:libc", "::free", "Argument[0]", "pointer-invalidate", "manual"]
   - addsTo:
       pack: codeql/rust-all
-      extensible: sinkModel
+      extensible: sinkModelDeprecated
     data:
       - ["repo:https://github.com/rust-lang/libc:libc", "::malloc", "Argument[0]", "alloc-size", "manual"]
       - ["repo:https://github.com/rust-lang/libc:libc", "::aligned_alloc", "Argument[1]", "alloc-size", "manual"]

--- a/rust/ql/lib/codeql/rust/frameworks/log.model.yml
+++ b/rust/ql/lib/codeql/rust/frameworks/log.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/rust-all
-      extensible: sinkModel
+      extensible: sinkModelDeprecated
     data:
       - ["repo:https://github.com/rust-lang/log:log", "crate::__private_api::log", "Argument[0]", "log-injection", "manual"] # logger / args (pre v0.4.27)
       - ["repo:https://github.com/rust-lang/log:log", "crate::__private_api::log", "Argument[1]", "log-injection", "manual"] # args / level (pre v0.4.27)

--- a/rust/ql/lib/codeql/rust/frameworks/postgres.model.yml
+++ b/rust/ql/lib/codeql/rust/frameworks/postgres.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/rust-all
-      extensible: sinkModel
+      extensible: sinkModelDeprecated
     data:
       - ["repo:https://github.com/sfackler/rust-postgres:postgres", "<crate::client::Client>::execute", "Argument[0]", "sql-injection", "manual"]
       - ["repo:https://github.com/sfackler/rust-postgres:postgres", "<crate::client::Client>::batch_execute", "Argument[0]", "sql-injection", "manual"]

--- a/rust/ql/lib/codeql/rust/frameworks/regex.model.yml
+++ b/rust/ql/lib/codeql/rust/frameworks/regex.model.yml
@@ -2,6 +2,6 @@
 extensions:
   - addsTo:
       pack: codeql/rust-all
-      extensible: summaryModel
+      extensible: summaryModelDeprecated
     data:
       - ["repo:https://github.com/rust-lang/regex:regex", "crate::escape", "Argument[0].Reference", "ReturnValue", "taint", "manual"]

--- a/rust/ql/lib/codeql/rust/frameworks/reqwest.model.yml
+++ b/rust/ql/lib/codeql/rust/frameworks/reqwest.model.yml
@@ -1,19 +1,19 @@
 extensions:
   - addsTo:
       pack: codeql/rust-all
-      extensible: sourceModel
+      extensible: sourceModelDeprecated
     data:
       - ["repo:https://github.com/seanmonstar/reqwest:reqwest", "crate::get", "ReturnValue.Field[crate::result::Result::Ok(0)]", "remote", "manual"]
       - ["repo:https://github.com/seanmonstar/reqwest:reqwest", "crate::blocking::get", "ReturnValue.Field[crate::result::Result::Ok(0)]", "remote", "manual"]
   - addsTo:
       pack: codeql/rust-all
-      extensible: sinkModel
+      extensible: sinkModelDeprecated
     data:
       - ["repo:https://github.com/seanmonstar/reqwest:reqwest", "<crate::async_impl::client::Client>::request", "Argument[1]", "transmission", "manual"]
       - ["repo:https://github.com/seanmonstar/reqwest:reqwest", "<crate::blocking::client::Client>::request", "Argument[1]", "transmission", "manual"]
   - addsTo:
       pack: codeql/rust-all
-      extensible: summaryModel
+      extensible: summaryModelDeprecated
     data:
       - ["repo:https://github.com/seanmonstar/reqwest:reqwest", "<crate::response::Response>::text", "Argument[self]", "ReturnValue.Field[crate::result::Result::Ok(0)]", "taint", "manual"]
       - ["repo:https://github.com/seanmonstar/reqwest:reqwest", "<crate::response::Response>::text_with_charset", "Argument[self]", "ReturnValue.Field[crate::result::Result::Ok(0)]", "taint", "manual"]

--- a/rust/ql/lib/codeql/rust/frameworks/rusqlite.model.yml
+++ b/rust/ql/lib/codeql/rust/frameworks/rusqlite.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/rust-all
-      extensible: sinkModel
+      extensible: sinkModelDeprecated
     data:
       - ["repo:https://github.com/rusqlite/rusqlite:rusqlite", "<crate::Connection>::execute", "Argument[0]", "sql-injection", "manual"]
       - ["repo:https://github.com/rusqlite/rusqlite:rusqlite", "<crate::Connection>::execute_batch", "Argument[0]", "sql-injection", "manual"]
@@ -12,7 +12,7 @@ extensions:
 
   - addsTo:
       pack: codeql/rust-all
-      extensible: sourceModel
+      extensible: sourceModelDeprecated
     data:
       - ["repo:https://github.com/rusqlite/rusqlite:rusqlite", "<crate::row::Row>::get", "ReturnValue.Field[crate::result::Result::Ok(0)]", "database", "manual"]
       - ["repo:https://github.com/rusqlite/rusqlite:rusqlite", "<crate::row::Row>::get_unwrap", "ReturnValue", "database", "manual"]

--- a/rust/ql/lib/codeql/rust/frameworks/rustcrypto/rustcrypto.model.yml
+++ b/rust/ql/lib/codeql/rust/frameworks/rustcrypto/rustcrypto.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/rust-all
-      extensible: sinkModel
+      extensible: sinkModelDeprecated
     data:
       - ["repo:https://github.com/RustCrypto/traits:digest", "<_ as crate::digest::Digest>::new_with_prefix", "Argument[0]", "hasher-input", "manual"]
       - ["repo:https://github.com/RustCrypto/traits:digest", "<_ as crate::digest::Digest>::update", "Argument[0]", "hasher-input", "manual"]

--- a/rust/ql/lib/codeql/rust/frameworks/stdlib/env.model.yml
+++ b/rust/ql/lib/codeql/rust/frameworks/stdlib/env.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/rust-all
-      extensible: sourceModel
+      extensible: sourceModelDeprecated
     data:
       - ["lang:std", "crate::env::args", "ReturnValue.Element", "commandargs", "manual"]
       - ["lang:std", "crate::env::args_os", "ReturnValue.Element", "commandargs", "manual"]

--- a/rust/ql/lib/codeql/rust/frameworks/stdlib/fs.model.yml
+++ b/rust/ql/lib/codeql/rust/frameworks/stdlib/fs.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/rust-all
-      extensible: sourceModel
+      extensible: sourceModelDeprecated
     data:
       - ["lang:std", "crate::fs::read", "ReturnValue.Field[crate::result::Result::Ok(0)]", "file", "manual"]
       - ["lang:std", "crate::fs::read_to_string", "ReturnValue.Field[crate::result::Result::Ok(0)]", "file", "manual"]
@@ -12,7 +12,7 @@ extensions:
       - ["lang:std", "<crate::fs::File>::open_buffered", "ReturnValue.Field[crate::result::Result::Ok(0)]", "file", "manual"]
   - addsTo:
       pack: codeql/rust-all
-      extensible: sinkModel
+      extensible: sinkModelDeprecated
     data:
       - ["lang:std", "crate::fs::copy", "Argument[0]", "path-injection", "manual"]
       - ["lang:std", "crate::fs::copy", "Argument[1]", "path-injection", "manual"]
@@ -43,7 +43,7 @@ extensions:
       - ["lang:std", "<crate::fs::File>::open_buffered", "Argument[0]", "path-injection", "manual"]
   - addsTo:
       pack: codeql/rust-all
-      extensible: summaryModel
+      extensible: summaryModelDeprecated
     data:
       - ["lang:std", "<crate::path::PathBuf as crate::convert::From>::from", "Argument[0]", "ReturnValue", "taint", "manual"]
       - ["lang:std", "<crate::path::Path>::join", "Argument[self]", "ReturnValue", "taint", "manual"]

--- a/rust/ql/lib/codeql/rust/frameworks/stdlib/io.model.yml
+++ b/rust/ql/lib/codeql/rust/frameworks/stdlib/io.model.yml
@@ -1,12 +1,12 @@
 extensions:
   - addsTo:
       pack: codeql/rust-all
-      extensible: sourceModel
+      extensible: sourceModelDeprecated
     data:
       - ["lang:std", "crate::io::stdio::stdin", "ReturnValue", "stdin", "manual"]
   - addsTo:
       pack: codeql/rust-all
-      extensible: summaryModel
+      extensible: summaryModelDeprecated
     data:
       - ["lang:std", "<crate::io::buffered::bufreader::BufReader>::new", "Argument[0]", "ReturnValue", "taint", "manual"]
       - ["lang:std", "<crate::io::buffered::bufreader::BufReader as crate::io::BufRead>::fill_buf", "Argument[self]", "ReturnValue.Field[crate::result::Result::Ok(0)]", "taint", "manual"]

--- a/rust/ql/lib/codeql/rust/frameworks/stdlib/lang-alloc.model.yml
+++ b/rust/ql/lib/codeql/rust/frameworks/stdlib/lang-alloc.model.yml
@@ -1,13 +1,13 @@
 extensions:
   - addsTo:
       pack: codeql/rust-all
-      extensible: sourceModel
+      extensible: sourceModelDeprecated
     data:
       # Alloc
       - ["lang:alloc", "crate::alloc::dealloc", "Argument[0]", "pointer-invalidate", "manual"]
   - addsTo:
       pack: codeql/rust-all
-      extensible: sinkModel
+      extensible: sinkModelDeprecated
     data:
       # Alloc
       - ["lang:alloc", "crate::alloc::alloc", "Argument[0]", "alloc-layout", "manual"]
@@ -27,7 +27,7 @@ extensions:
       - ["lang:alloc", "<crate::alloc::Global as crate::alloc::Allocator>::grow_zeroed", "Argument[2]", "alloc-layout", "manual"]
   - addsTo:
       pack: codeql/rust-all
-      extensible: summaryModel
+      extensible: summaryModelDeprecated
     data:
       # Fmt
       - ["lang:alloc", "crate::fmt::format", "Argument[0]", "ReturnValue", "taint", "manual"]

--- a/rust/ql/lib/codeql/rust/frameworks/stdlib/lang-core.model.yml
+++ b/rust/ql/lib/codeql/rust/frameworks/stdlib/lang-core.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/rust-all
-      extensible: summaryModel
+      extensible: summaryModelDeprecated
     data:
       # Iterator
       - ["lang:core", "<[_]>::iter", "Argument[Self].Element", "ReturnValue.Element", "value", "manual"]
@@ -47,7 +47,7 @@ extensions:
       - ["lang:core", "<str>::trim", "Argument[self]", "ReturnValue.Reference", "taint", "manual"]
   - addsTo:
       pack: codeql/rust-all
-      extensible: sourceModel
+      extensible: sourceModelDeprecated
     data:
       # Ptr
       - ["lang:core", "crate::ptr::drop_in_place", "Argument[0]", "pointer-invalidate", "manual"]
@@ -56,7 +56,7 @@ extensions:
       - ["lang:core", "crate::ptr::null", "ReturnValue", "pointer-invalidate", "manual"]
   - addsTo:
       pack: codeql/rust-all
-      extensible: sinkModel
+      extensible: sinkModelDeprecated
     data:
       # Ptr
       - ["lang:core", "crate::ptr::read", "Argument[0]", "pointer-access", "manual"]

--- a/rust/ql/lib/codeql/rust/frameworks/tokio-postgres.model.yml
+++ b/rust/ql/lib/codeql/rust/frameworks/tokio-postgres.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/rust-all
-      extensible: sinkModel
+      extensible: sinkModelDeprecated
     data:
       - ["repo:https://github.com/sfackler/rust-postgres:tokio-postgres", "<crate::client::Client>::execute", "Argument[0]", "sql-injection", "manual"]
       - ["repo:https://github.com/sfackler/rust-postgres:tokio-postgres", "<crate::client::Client>::batch_execute", "Argument[0]", "sql-injection", "manual"]
@@ -18,7 +18,7 @@ extensions:
 
   - addsTo:
       pack: codeql/rust-all
-      extensible: sourceModel
+      extensible: sourceModelDeprecated
     data:
       - ["repo:https://github.com/sfackler/rust-postgres:tokio-postgres", "<crate::row::Row>::get", "ReturnValue", "database", "manual"]
       - ["repo:https://github.com/sfackler/rust-postgres:tokio-postgres", "<crate::row::Row>::try_get", "ReturnValue.Field[crate::result::Result::Ok(0)]", "database", "manual"]

--- a/rust/ql/lib/codeql/rust/frameworks/url.model.yml
+++ b/rust/ql/lib/codeql/rust/frameworks/url.model.yml
@@ -2,6 +2,6 @@
 extensions:
   - addsTo:
       pack: codeql/rust-all
-      extensible: summaryModel
+      extensible: summaryModelDeprecated
     data:
       - ["repo:https://github.com/servo/rust-url:url", "<crate::Url>::parse", "Argument[0].Reference", "ReturnValue.Field[crate::result::Result::Ok(0)]", "taint", "manual"]

--- a/rust/ql/lib/ext/generated/reqwest/repo-https-github.com-seanmonstar-reqwest-reqwest.model.yml
+++ b/rust/ql/lib/ext/generated/reqwest/repo-https-github.com-seanmonstar-reqwest-reqwest.model.yml
@@ -2,7 +2,7 @@
 extensions:
   - addsTo:
       pack: codeql/rust-all
-      extensible: sinkModel
+      extensible: sinkModelDeprecated
     data:
       - ["repo:https://github.com/seanmonstar/reqwest:reqwest", "<crate::async_impl::client::Client>::delete", "Argument[0]", "transmission", "df-generated"]
       - ["repo:https://github.com/seanmonstar/reqwest:reqwest", "<crate::async_impl::client::Client>::get", "Argument[0]", "transmission", "df-generated"]

--- a/rust/ql/lib/ext/generated/rust/lang-alloc.model.yml
+++ b/rust/ql/lib/ext/generated/rust/lang-alloc.model.yml
@@ -2,7 +2,7 @@
 extensions:
   - addsTo:
       pack: codeql/rust-all
-      extensible: summaryModel
+      extensible: summaryModelDeprecated
     data:
       - ["lang:alloc", "<&&str as crate::string::SpecToString>::spec_to_string", "Argument[self].Reference.Reference", "ReturnValue", "value", "dfc-generated"]
       - ["lang:alloc", "<&crate::string::String as crate::str::pattern::Pattern>::as_utf8_pattern", "Argument[self]", "ReturnValue.Field[crate::option::Option::Some(0)].Field[crate::str::pattern::Utf8Pattern::StringPattern(0)]", "value", "dfc-generated"]

--- a/rust/ql/lib/ext/generated/rust/lang-core.model.yml
+++ b/rust/ql/lib/ext/generated/rust/lang-core.model.yml
@@ -2,7 +2,7 @@
 extensions:
   - addsTo:
       pack: codeql/rust-all
-      extensible: summaryModel
+      extensible: summaryModelDeprecated
     data:
       - ["lang:core", "<&_ as crate::borrow::Borrow>::borrow", "Argument[self].Reference.Reference", "ReturnValue.Reference", "value", "dfc-generated"]
       - ["lang:core", "<&_ as crate::clone::Clone>::clone", "Argument[self].Reference", "ReturnValue", "value", "dfc-generated"]

--- a/rust/ql/lib/ext/generated/rust/lang-proc_macro.model.yml
+++ b/rust/ql/lib/ext/generated/rust/lang-proc_macro.model.yml
@@ -2,7 +2,7 @@
 extensions:
   - addsTo:
       pack: codeql/rust-all
-      extensible: summaryModel
+      extensible: summaryModelDeprecated
     data:
       - ["lang:proc_macro", "<&[u8] as crate::bridge::Mark>::mark", "Argument[0]", "ReturnValue", "value", "dfc-generated"]
       - ["lang:proc_macro", "<&[u8] as crate::bridge::Unmark>::unmark", "Argument[self]", "ReturnValue", "value", "dfc-generated"]

--- a/rust/ql/lib/ext/generated/rust/lang-std.model.yml
+++ b/rust/ql/lib/ext/generated/rust/lang-std.model.yml
@@ -2,7 +2,7 @@
 extensions:
   - addsTo:
       pack: codeql/rust-all
-      extensible: summaryModel
+      extensible: summaryModelDeprecated
     data:
       - ["lang:std", "<&[u8] as crate::io::BufRead>::consume", "Argument[self].Element", "Argument[self].Reference.Reference", "value", "dfc-generated"]
       - ["lang:std", "<&[u8] as crate::io::BufRead>::fill_buf", "Argument[self].Reference", "ReturnValue.Field[crate::result::Result::Ok(0)]", "value", "dfc-generated"]

--- a/rust/ql/test/library-tests/dataflow/models/models.ext.yml
+++ b/rust/ql/test/library-tests/dataflow/models/models.ext.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/rust-all
-      extensible: sourceModel
+      extensible: sourceModelDeprecated
     data:
       - ["repo::test", "crate::simple_source", "ReturnValue", "test-source", "manual"]
       - ["repo::test", "crate::enum_source", "ReturnValue.Field[crate::MyFieldEnum::D::field_d]", "test-source", "manual"]
@@ -9,14 +9,14 @@ extensions:
       - ["repo::test", "crate::arg_source", "Argument[0]", "test-source", "manual"]
   - addsTo:
       pack: codeql/rust-all
-      extensible: sinkModel
+      extensible: sinkModelDeprecated
     data:
       - ["repo::test", "crate::simple_sink", "Argument[0]", "test-sink", "manual"]
       - ["repo::test", "crate::enum_sink", "Argument[0].Field[crate::MyFieldEnum::C::field_c]", "test-sink", "manual"]
       - ["repo::test", "<crate::MyFieldEnum>::sink", "Argument[self].Field[crate::MyFieldEnum::D::field_d]", "test-sink", "manual"]
   - addsTo:
       pack: codeql/rust-all
-      extensible: summaryModel
+      extensible: summaryModelDeprecated
     data:
       - ["repo::test", "crate::coerce", "Argument[0]", "ReturnValue", "taint", "manual"]
       - ["repo::test", "crate::get_var_pos", "Argument[0].Field[crate::MyPosEnum::A(0)]", "ReturnValue", "value", "manual"]

--- a/rust/ql/test/utils-tests/modelgenerator/CaptureSinkModels.ext.yml
+++ b/rust/ql/test/utils-tests/modelgenerator/CaptureSinkModels.ext.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
       pack: codeql/rust-all
-      extensible: sinkModel
+      extensible: sinkModelDeprecated
     data:
       - ["repo::test", "crate::sinks::known_sink", "Argument[0]", "test-sink", "manual"]

--- a/rust/ql/test/utils-tests/modelgenerator/CaptureSourceModels.ext.yml
+++ b/rust/ql/test/utils-tests/modelgenerator/CaptureSourceModels.ext.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
       pack: codeql/rust-all
-      extensible: sourceModel
+      extensible: sourceModelDeprecated
     data:
       - ["repo::test", "crate::sources::known_source", "ReturnValue", "test-source", "manual"]


### PR DESCRIPTION
In preparation for a transition period where we will allow for MaD definitions using extractor-provided canonical paths as well as the future QL-provided canonical paths.