### PR TITLE
Exclude some queries from query suites by lowering their precision.

### DIFF
--- a/csharp/ql/integration-tests/posix/query-suite/csharp-security-and-quality.qls.expected
+++ b/csharp/ql/integration-tests/posix/query-suite/csharp-security-and-quality.qls.expected
@@ -38,7 +38,6 @@ ql/csharp/ql/src/Concurrency/SynchSetUnsynchGet.ql
 ql/csharp/ql/src/Concurrency/UnsafeLazyInitialization.ql
 ql/csharp/ql/src/Concurrency/UnsynchronizedStaticAccess.ql
 ql/csharp/ql/src/Configuration/EmptyPasswordInConfigurationFile.ql
-ql/csharp/ql/src/Configuration/PasswordInConfigurationFile.ql
 ql/csharp/ql/src/Dead Code/DeadStoreOfLocal.ql
 ql/csharp/ql/src/Diagnostics/CompilerError.ql
 ql/csharp/ql/src/Diagnostics/CompilerMessage.ql
@@ -146,8 +145,6 @@ ql/csharp/ql/src/Security Features/CWE-639/InsecureDirectObjectReference.ql
 ql/csharp/ql/src/Security Features/CWE-643/XPathInjection.ql
 ql/csharp/ql/src/Security Features/CWE-730/ReDoS.ql
 ql/csharp/ql/src/Security Features/CWE-730/RegexInjection.ql
-ql/csharp/ql/src/Security Features/CWE-798/HardcodedConnectionString.ql
-ql/csharp/ql/src/Security Features/CWE-798/HardcodedCredentials.ql
 ql/csharp/ql/src/Security Features/CWE-807/ConditionalBypass.ql
 ql/csharp/ql/src/Security Features/CookieWithOverlyBroadDomain.ql
 ql/csharp/ql/src/Security Features/CookieWithOverlyBroadPath.ql

--- a/csharp/ql/integration-tests/posix/query-suite/csharp-security-extended.qls.expected
+++ b/csharp/ql/integration-tests/posix/query-suite/csharp-security-extended.qls.expected
@@ -1,5 +1,4 @@
 ql/csharp/ql/src/Configuration/EmptyPasswordInConfigurationFile.ql
-ql/csharp/ql/src/Configuration/PasswordInConfigurationFile.ql
 ql/csharp/ql/src/Diagnostics/CompilerError.ql
 ql/csharp/ql/src/Diagnostics/CompilerMessage.ql
 ql/csharp/ql/src/Diagnostics/DiagnosticExtractionErrors.ql
@@ -49,8 +48,6 @@ ql/csharp/ql/src/Security Features/CWE-639/InsecureDirectObjectReference.ql
 ql/csharp/ql/src/Security Features/CWE-643/XPathInjection.ql
 ql/csharp/ql/src/Security Features/CWE-730/ReDoS.ql
 ql/csharp/ql/src/Security Features/CWE-730/RegexInjection.ql
-ql/csharp/ql/src/Security Features/CWE-798/HardcodedConnectionString.ql
-ql/csharp/ql/src/Security Features/CWE-798/HardcodedCredentials.ql
 ql/csharp/ql/src/Security Features/CWE-807/ConditionalBypass.ql
 ql/csharp/ql/src/Security Features/CookieWithOverlyBroadDomain.ql
 ql/csharp/ql/src/Security Features/CookieWithOverlyBroadPath.ql

--- a/csharp/ql/integration-tests/posix/query-suite/not_included_in_qls.expected
+++ b/csharp/ql/integration-tests/posix/query-suite/not_included_in_qls.expected
@@ -26,6 +26,7 @@ ql/csharp/ql/src/Bad Practices/Naming Conventions/DefaultControlNames.ql
 ql/csharp/ql/src/Bad Practices/Naming Conventions/VariableNameTooShort.ql
 ql/csharp/ql/src/Bad Practices/UseOfHtmlInputHidden.ql
 ql/csharp/ql/src/Bad Practices/UseOfSystemOutputStream.ql
+ql/csharp/ql/src/Configuration/PasswordInConfigurationFile.ql
 ql/csharp/ql/src/Dead Code/DeadRefTypes.ql
 ql/csharp/ql/src/Dead Code/NonAssignedFields.ql
 ql/csharp/ql/src/Dead Code/UnusedField.ql
@@ -89,6 +90,8 @@ ql/csharp/ql/src/Security Features/CWE-321/HardcodedSymmetricEncryptionKey.ql
 ql/csharp/ql/src/Security Features/CWE-327/DontInstallRootCert.ql
 ql/csharp/ql/src/Security Features/CWE-502/UnsafeDeserialization.ql
 ql/csharp/ql/src/Security Features/CWE-611/UseXmlSecureResolver.ql
+ql/csharp/ql/src/Security Features/CWE-798/HardcodedConnectionString.ql
+ql/csharp/ql/src/Security Features/CWE-798/HardcodedCredentials.ql
 ql/csharp/ql/src/Security Features/CWE-838/InappropriateEncoding.ql
 ql/csharp/ql/src/Useless code/PointlessForwardingMethod.ql
 ql/csharp/ql/src/definitions.ql

--- a/csharp/ql/src/Configuration/PasswordInConfigurationFile.ql
+++ b/csharp/ql/src/Configuration/PasswordInConfigurationFile.ql
@@ -4,7 +4,7 @@
  * @kind problem
  * @problem.severity warning
  * @security-severity 7.5
- * @precision medium
+ * @precision low
  * @id cs/password-in-configuration
  * @tags security
  *       external/cwe/cwe-013

--- a/csharp/ql/src/Security Features/CWE-798/HardcodedConnectionString.ql
+++ b/csharp/ql/src/Security Features/CWE-798/HardcodedConnectionString.ql
@@ -4,7 +4,7 @@
  * @kind path-problem
  * @problem.severity error
  * @security-severity 9.8
- * @precision medium
+ * @precision low
  * @id cs/hardcoded-connection-string-credentials
  * @tags security
  *       external/cwe/cwe-259

--- a/csharp/ql/src/Security Features/CWE-798/HardcodedCredentials.ql
+++ b/csharp/ql/src/Security Features/CWE-798/HardcodedCredentials.ql
@@ -4,7 +4,7 @@
  * @kind path-problem
  * @problem.severity error
  * @security-severity 9.8
- * @precision medium
+ * @precision low
  * @id cs/hardcoded-credentials
  * @tags security
  *       external/cwe/cwe-259

--- a/csharp/ql/src/change-notes/2025-05-16-hardcoded-credentials.md
+++ b/csharp/ql/src/change-notes/2025-05-16-hardcoded-credentials.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The queries `cs/password-in-configuration`, `cs/hardcoded-credentials` and `cs/hardcoded-connection-string-credentials` have been removed from all query suites.

--- a/go/ql/integration-tests/query-suite/go-security-and-quality.qls.expected
+++ b/go/ql/integration-tests/query-suite/go-security-and-quality.qls.expected
@@ -50,6 +50,5 @@ ql/go/ql/src/Security/CWE-640/EmailInjection.ql
 ql/go/ql/src/Security/CWE-643/XPathInjection.ql
 ql/go/ql/src/Security/CWE-681/IncorrectIntegerConversionQuery.ql
 ql/go/ql/src/Security/CWE-770/UncontrolledAllocationSize.ql
-ql/go/ql/src/Security/CWE-798/HardcodedCredentials.ql
 ql/go/ql/src/Security/CWE-918/RequestForgery.ql
 ql/go/ql/src/Summary/LinesOfCode.ql

--- a/go/ql/integration-tests/query-suite/go-security-extended.qls.expected
+++ b/go/ql/integration-tests/query-suite/go-security-extended.qls.expected
@@ -28,6 +28,5 @@ ql/go/ql/src/Security/CWE-640/EmailInjection.ql
 ql/go/ql/src/Security/CWE-643/XPathInjection.ql
 ql/go/ql/src/Security/CWE-681/IncorrectIntegerConversionQuery.ql
 ql/go/ql/src/Security/CWE-770/UncontrolledAllocationSize.ql
-ql/go/ql/src/Security/CWE-798/HardcodedCredentials.ql
 ql/go/ql/src/Security/CWE-918/RequestForgery.ql
 ql/go/ql/src/Summary/LinesOfCode.ql

--- a/go/ql/integration-tests/query-suite/not_included_in_qls.expected
+++ b/go/ql/integration-tests/query-suite/not_included_in_qls.expected
@@ -6,6 +6,7 @@ ql/go/ql/src/Security/CWE-020/UntrustedDataToExternalAPI.ql
 ql/go/ql/src/Security/CWE-020/UntrustedDataToUnknownExternalAPI.ql
 ql/go/ql/src/Security/CWE-078/StoredCommand.ql
 ql/go/ql/src/Security/CWE-079/StoredXss.ql
+ql/go/ql/src/Security/CWE-798/HardcodedCredentials.ql
 ql/go/ql/src/definitions.ql
 ql/go/ql/src/experimental/CWE-090/LDAPInjection.ql
 ql/go/ql/src/experimental/CWE-1004/CookieWithoutHttpOnly.ql

--- a/go/ql/src/Security/CWE-798/HardcodedCredentials.ql
+++ b/go/ql/src/Security/CWE-798/HardcodedCredentials.ql
@@ -5,7 +5,7 @@
  * @kind problem
  * @problem.severity warning
  * @security-severity 9.8
- * @precision medium
+ * @precision low
  * @id go/hardcoded-credentials
  * @tags security
  *       external/cwe/cwe-259

--- a/go/ql/src/change-notes/2025-05-16-hardcoded-credentials.md
+++ b/go/ql/src/change-notes/2025-05-16-hardcoded-credentials.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The query `go/hardcoded-credentials` has been removed from all query suites.

--- a/java/ql/integration-tests/java/query-suite/java-security-and-quality.qls.expected
+++ b/java/ql/integration-tests/java/query-suite/java-security-and-quality.qls.expected
@@ -196,7 +196,6 @@ ql/java/ql/src/Security/CWE/CWE-730/RegexInjection.ql
 ql/java/ql/src/Security/CWE/CWE-732/ReadingFromWorldWritableFile.ql
 ql/java/ql/src/Security/CWE/CWE-749/UnsafeAndroidAccess.ql
 ql/java/ql/src/Security/CWE/CWE-780/RsaWithoutOaep.ql
-ql/java/ql/src/Security/CWE/CWE-798/HardcodedCredentialsApiCall.ql
 ql/java/ql/src/Security/CWE/CWE-807/ConditionalBypass.ql
 ql/java/ql/src/Security/CWE/CWE-807/TaintedPermissionsCheck.ql
 ql/java/ql/src/Security/CWE/CWE-829/InsecureDependencyResolution.ql

--- a/java/ql/integration-tests/java/query-suite/java-security-extended.qls.expected
+++ b/java/ql/integration-tests/java/query-suite/java-security-extended.qls.expected
@@ -99,7 +99,6 @@ ql/java/ql/src/Security/CWE/CWE-730/RegexInjection.ql
 ql/java/ql/src/Security/CWE/CWE-732/ReadingFromWorldWritableFile.ql
 ql/java/ql/src/Security/CWE/CWE-749/UnsafeAndroidAccess.ql
 ql/java/ql/src/Security/CWE/CWE-780/RsaWithoutOaep.ql
-ql/java/ql/src/Security/CWE/CWE-798/HardcodedCredentialsApiCall.ql
 ql/java/ql/src/Security/CWE/CWE-807/ConditionalBypass.ql
 ql/java/ql/src/Security/CWE/CWE-807/TaintedPermissionsCheck.ql
 ql/java/ql/src/Security/CWE/CWE-829/InsecureDependencyResolution.ql

--- a/java/ql/integration-tests/java/query-suite/not_included_in_qls.expected
+++ b/java/ql/integration-tests/java/query-suite/not_included_in_qls.expected
@@ -158,6 +158,7 @@ ql/java/ql/src/Security/CWE/CWE-312/CleartextStorageClass.ql
 ql/java/ql/src/Security/CWE/CWE-319/HttpsUrls.ql
 ql/java/ql/src/Security/CWE/CWE-319/UseSSL.ql
 ql/java/ql/src/Security/CWE/CWE-319/UseSSLSocketFactories.ql
+ql/java/ql/src/Security/CWE/CWE-798/HardcodedCredentialsApiCall.ql
 ql/java/ql/src/Security/CWE/CWE-798/HardcodedCredentialsComparison.ql
 ql/java/ql/src/Security/CWE/CWE-798/HardcodedCredentialsSourceCall.ql
 ql/java/ql/src/Security/CWE/CWE-798/HardcodedPasswordField.ql

--- a/java/ql/src/Security/CWE/CWE-798/HardcodedCredentialsApiCall.ql
+++ b/java/ql/src/Security/CWE/CWE-798/HardcodedCredentialsApiCall.ql
@@ -4,7 +4,7 @@
  * @kind path-problem
  * @problem.severity error
  * @security-severity 9.8
- * @precision medium
+ * @precision low
  * @id java/hardcoded-credential-api-call
  * @tags security
  *       external/cwe/cwe-798

--- a/java/ql/src/change-notes/2025-05-16-hardcoded-credentials.md
+++ b/java/ql/src/change-notes/2025-05-16-hardcoded-credentials.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The query `java/hardcoded-credential-api-call` has been removed from all query suites.

--- a/javascript/ql/integration-tests/query-suite/javascript-code-scanning.qls.expected
+++ b/javascript/ql/integration-tests/query-suite/javascript-code-scanning.qls.expected
@@ -75,7 +75,6 @@ ql/javascript/ql/src/Security/CWE-754/UnvalidatedDynamicMethodCall.ql
 ql/javascript/ql/src/Security/CWE-770/MissingRateLimiting.ql
 ql/javascript/ql/src/Security/CWE-770/ResourceExhaustion.ql
 ql/javascript/ql/src/Security/CWE-776/XmlBomb.ql
-ql/javascript/ql/src/Security/CWE-798/HardcodedCredentials.ql
 ql/javascript/ql/src/Security/CWE-829/InsecureDownload.ql
 ql/javascript/ql/src/Security/CWE-830/FunctionalityFromUntrustedDomain.ql
 ql/javascript/ql/src/Security/CWE-830/FunctionalityFromUntrustedSource.ql

--- a/javascript/ql/integration-tests/query-suite/javascript-security-and-quality.qls.expected
+++ b/javascript/ql/integration-tests/query-suite/javascript-security-and-quality.qls.expected
@@ -144,7 +144,6 @@ ql/javascript/ql/src/Security/CWE-312/ActionsArtifactLeak.ql
 ql/javascript/ql/src/Security/CWE-312/BuildArtifactLeak.ql
 ql/javascript/ql/src/Security/CWE-312/CleartextLogging.ql
 ql/javascript/ql/src/Security/CWE-312/CleartextStorage.ql
-ql/javascript/ql/src/Security/CWE-313/PasswordInConfigurationFile.ql
 ql/javascript/ql/src/Security/CWE-326/InsufficientKeySize.ql
 ql/javascript/ql/src/Security/CWE-327/BadRandomness.ql
 ql/javascript/ql/src/Security/CWE-327/BrokenCryptoAlgorithm.ql
@@ -173,7 +172,6 @@ ql/javascript/ql/src/Security/CWE-754/UnvalidatedDynamicMethodCall.ql
 ql/javascript/ql/src/Security/CWE-770/MissingRateLimiting.ql
 ql/javascript/ql/src/Security/CWE-770/ResourceExhaustion.ql
 ql/javascript/ql/src/Security/CWE-776/XmlBomb.ql
-ql/javascript/ql/src/Security/CWE-798/HardcodedCredentials.ql
 ql/javascript/ql/src/Security/CWE-807/ConditionalBypass.ql
 ql/javascript/ql/src/Security/CWE-829/InsecureDownload.ql
 ql/javascript/ql/src/Security/CWE-830/FunctionalityFromUntrustedDomain.ql

--- a/javascript/ql/integration-tests/query-suite/javascript-security-extended.qls.expected
+++ b/javascript/ql/integration-tests/query-suite/javascript-security-extended.qls.expected
@@ -59,7 +59,6 @@ ql/javascript/ql/src/Security/CWE-312/ActionsArtifactLeak.ql
 ql/javascript/ql/src/Security/CWE-312/BuildArtifactLeak.ql
 ql/javascript/ql/src/Security/CWE-312/CleartextLogging.ql
 ql/javascript/ql/src/Security/CWE-312/CleartextStorage.ql
-ql/javascript/ql/src/Security/CWE-313/PasswordInConfigurationFile.ql
 ql/javascript/ql/src/Security/CWE-326/InsufficientKeySize.ql
 ql/javascript/ql/src/Security/CWE-327/BadRandomness.ql
 ql/javascript/ql/src/Security/CWE-327/BrokenCryptoAlgorithm.ql
@@ -88,7 +87,6 @@ ql/javascript/ql/src/Security/CWE-754/UnvalidatedDynamicMethodCall.ql
 ql/javascript/ql/src/Security/CWE-770/MissingRateLimiting.ql
 ql/javascript/ql/src/Security/CWE-770/ResourceExhaustion.ql
 ql/javascript/ql/src/Security/CWE-776/XmlBomb.ql
-ql/javascript/ql/src/Security/CWE-798/HardcodedCredentials.ql
 ql/javascript/ql/src/Security/CWE-807/ConditionalBypass.ql
 ql/javascript/ql/src/Security/CWE-829/InsecureDownload.ql
 ql/javascript/ql/src/Security/CWE-830/FunctionalityFromUntrustedDomain.ql

--- a/javascript/ql/integration-tests/query-suite/not_included_in_qls.expected
+++ b/javascript/ql/integration-tests/query-suite/not_included_in_qls.expected
@@ -53,7 +53,9 @@ ql/javascript/ql/src/RegExp/BackspaceEscape.ql
 ql/javascript/ql/src/RegExp/MalformedRegExp.ql
 ql/javascript/ql/src/Security/CWE-020/ExternalAPIsUsedWithUntrustedData.ql
 ql/javascript/ql/src/Security/CWE-020/UntrustedDataToExternalAPI.ql
+ql/javascript/ql/src/Security/CWE-313/PasswordInConfigurationFile.ql
 ql/javascript/ql/src/Security/CWE-451/MissingXFrameOptions.ql
+ql/javascript/ql/src/Security/CWE-798/HardcodedCredentials.ql
 ql/javascript/ql/src/Security/CWE-807/DifferentKindsComparisonBypass.ql
 ql/javascript/ql/src/Security/trest/test.ql
 ql/javascript/ql/src/Statements/EphemeralLoop.ql

--- a/javascript/ql/src/Security/CWE-313/PasswordInConfigurationFile.ql
+++ b/javascript/ql/src/Security/CWE-313/PasswordInConfigurationFile.ql
@@ -4,7 +4,7 @@
  * @kind problem
  * @problem.severity warning
  * @security-severity 7.5
- * @precision medium
+ * @precision low
  * @id js/password-in-configuration-file
  * @tags security
  *       external/cwe/cwe-256

--- a/javascript/ql/src/Security/CWE-798/HardcodedCredentials.ql
+++ b/javascript/ql/src/Security/CWE-798/HardcodedCredentials.ql
@@ -5,7 +5,7 @@
  * @kind path-problem
  * @problem.severity warning
  * @security-severity 9.8
- * @precision high
+ * @precision low
  * @id js/hardcoded-credentials
  * @tags security
  *       external/cwe/cwe-259

--- a/javascript/ql/src/change-notes/2025-05-16-hardcoded-credentials.md
+++ b/javascript/ql/src/change-notes/2025-05-16-hardcoded-credentials.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The queries `js/hardcoded-credentials` and `js/password-in-configuration-file` have been removed from all query suites.

--- a/python/ql/integration-tests/query-suite/not_included_in_qls.expected
+++ b/python/ql/integration-tests/query-suite/not_included_in_qls.expected
@@ -58,6 +58,7 @@ ql/python/ql/src/Metrics/NumberOfStatements.ql
 ql/python/ql/src/Metrics/TransitiveImports.ql
 ql/python/ql/src/Security/CWE-020-ExternalAPIs/ExternalAPIsUsedWithUntrustedData.ql
 ql/python/ql/src/Security/CWE-020-ExternalAPIs/UntrustedDataToExternalAPI.ql
+ql/python/ql/src/Security/CWE-798/HardcodedCredentials.ql
 ql/python/ql/src/Statements/AssertLiteralConstant.ql
 ql/python/ql/src/Statements/C_StyleParentheses.ql
 ql/python/ql/src/Statements/DocStrings.ql

--- a/python/ql/integration-tests/query-suite/python-security-and-quality.qls.expected
+++ b/python/ql/integration-tests/query-suite/python-security-and-quality.qls.expected
@@ -133,7 +133,6 @@ ql/python/ql/src/Security/CWE-730/ReDoS.ql
 ql/python/ql/src/Security/CWE-730/RegexInjection.ql
 ql/python/ql/src/Security/CWE-732/WeakFilePermissions.ql
 ql/python/ql/src/Security/CWE-776/XmlBomb.ql
-ql/python/ql/src/Security/CWE-798/HardcodedCredentials.ql
 ql/python/ql/src/Security/CWE-918/FullServerSideRequestForgery.ql
 ql/python/ql/src/Security/CWE-918/PartialServerSideRequestForgery.ql
 ql/python/ql/src/Security/CWE-943/NoSqlInjection.ql

--- a/python/ql/integration-tests/query-suite/python-security-extended.qls.expected
+++ b/python/ql/integration-tests/query-suite/python-security-extended.qls.expected
@@ -43,7 +43,6 @@ ql/python/ql/src/Security/CWE-730/ReDoS.ql
 ql/python/ql/src/Security/CWE-730/RegexInjection.ql
 ql/python/ql/src/Security/CWE-732/WeakFilePermissions.ql
 ql/python/ql/src/Security/CWE-776/XmlBomb.ql
-ql/python/ql/src/Security/CWE-798/HardcodedCredentials.ql
 ql/python/ql/src/Security/CWE-918/FullServerSideRequestForgery.ql
 ql/python/ql/src/Security/CWE-918/PartialServerSideRequestForgery.ql
 ql/python/ql/src/Security/CWE-943/NoSqlInjection.ql

--- a/python/ql/src/Security/CWE-798/HardcodedCredentials.ql
+++ b/python/ql/src/Security/CWE-798/HardcodedCredentials.ql
@@ -4,7 +4,7 @@
  * @kind path-problem
  * @problem.severity error
  * @security-severity 9.8
- * @precision medium
+ * @precision low
  * @id py/hardcoded-credentials
  * @tags security
  *       external/cwe/cwe-259

--- a/python/ql/src/change-notes/2025-05-16-hardcoded-credentials.md
+++ b/python/ql/src/change-notes/2025-05-16-hardcoded-credentials.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The query `py/hardcoded-credentials` has been removed from all query suites.

--- a/ruby/ql/integration-tests/query-suite/not_included_in_qls.expected
+++ b/ruby/ql/integration-tests/query-suite/not_included_in_qls.expected
@@ -30,6 +30,7 @@ ql/ruby/ql/src/queries/metrics/FLinesOfCode.ql
 ql/ruby/ql/src/queries/metrics/FLinesOfComments.ql
 ql/ruby/ql/src/queries/modeling/GenerateModel.ql
 ql/ruby/ql/src/queries/security/cwe-732/WeakFilePermissions.ql
+ql/ruby/ql/src/queries/security/cwe-798/HardcodedCredentials.ql
 ql/ruby/ql/src/queries/variables/UnusedParameter.ql
 ql/ruby/ql/src/utils/modeleditor/ApplicationModeEndpoints.ql
 ql/ruby/ql/src/utils/modeleditor/FrameworkModeAccessPaths.ql

--- a/ruby/ql/integration-tests/query-suite/ruby-security-and-quality.qls.expected
+++ b/ruby/ql/integration-tests/query-suite/ruby-security-and-quality.qls.expected
@@ -41,7 +41,6 @@ ql/ruby/ql/src/queries/security/cwe-598/SensitiveGetQuery.ql
 ql/ruby/ql/src/queries/security/cwe-601/UrlRedirect.ql
 ql/ruby/ql/src/queries/security/cwe-611/Xxe.ql
 ql/ruby/ql/src/queries/security/cwe-732/WeakCookieConfiguration.ql
-ql/ruby/ql/src/queries/security/cwe-798/HardcodedCredentials.ql
 ql/ruby/ql/src/queries/security/cwe-829/InsecureDownload.ql
 ql/ruby/ql/src/queries/security/cwe-912/HttpToFileAccess.ql
 ql/ruby/ql/src/queries/security/cwe-915/MassAssignment.ql

--- a/ruby/ql/integration-tests/query-suite/ruby-security-extended.qls.expected
+++ b/ruby/ql/integration-tests/query-suite/ruby-security-extended.qls.expected
@@ -40,7 +40,6 @@ ql/ruby/ql/src/queries/security/cwe-598/SensitiveGetQuery.ql
 ql/ruby/ql/src/queries/security/cwe-601/UrlRedirect.ql
 ql/ruby/ql/src/queries/security/cwe-611/Xxe.ql
 ql/ruby/ql/src/queries/security/cwe-732/WeakCookieConfiguration.ql
-ql/ruby/ql/src/queries/security/cwe-798/HardcodedCredentials.ql
 ql/ruby/ql/src/queries/security/cwe-829/InsecureDownload.ql
 ql/ruby/ql/src/queries/security/cwe-912/HttpToFileAccess.ql
 ql/ruby/ql/src/queries/security/cwe-915/MassAssignment.ql

--- a/ruby/ql/src/change-notes/2025-05-16-hardcoded-credentials.md
+++ b/ruby/ql/src/change-notes/2025-05-16-hardcoded-credentials.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The query `rb/hardcoded-credentials` has been removed from all query suites.

--- a/ruby/ql/src/queries/security/cwe-798/HardcodedCredentials.ql
+++ b/ruby/ql/src/queries/security/cwe-798/HardcodedCredentials.ql
@@ -4,7 +4,7 @@
  * @kind path-problem
  * @problem.severity error
  * @security-severity 9.8
- * @precision medium
+ * @precision low
  * @id rb/hardcoded-credentials
  * @tags security
  *       external/cwe/cwe-259

--- a/swift/ql/integration-tests/posix/query-suite/not_included_in_qls.expected
+++ b/swift/ql/integration-tests/posix/query-suite/not_included_in_qls.expected
@@ -1,5 +1,7 @@
 ql/swift/ql/src/AlertSuppression.ql
 ql/swift/ql/src/experimental/Security/CWE-022/UnsafeUnpack.ql
+ql/swift/ql/src/queries/Security/CWE-259/ConstantPassword.ql
+ql/swift/ql/src/queries/Security/CWE-321/HardcodedEncryptionKey.ql
 ql/swift/ql/src/queries/Summary/FlowSources.ql
 ql/swift/ql/src/queries/Summary/QuerySinks.ql
 ql/swift/ql/src/queries/Summary/RegexEvals.ql

--- a/swift/ql/integration-tests/posix/query-suite/swift-code-scanning.qls.expected
+++ b/swift/ql/integration-tests/posix/query-suite/swift-code-scanning.qls.expected
@@ -14,12 +14,10 @@ ql/swift/ql/src/queries/Security/CWE-1204/StaticInitializationVector.ql
 ql/swift/ql/src/queries/Security/CWE-1333/ReDoS.ql
 ql/swift/ql/src/queries/Security/CWE-134/UncontrolledFormatString.ql
 ql/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
-ql/swift/ql/src/queries/Security/CWE-259/ConstantPassword.ql
 ql/swift/ql/src/queries/Security/CWE-311/CleartextStorageDatabase.ql
 ql/swift/ql/src/queries/Security/CWE-311/CleartextTransmission.ql
 ql/swift/ql/src/queries/Security/CWE-312/CleartextLogging.ql
 ql/swift/ql/src/queries/Security/CWE-312/CleartextStoragePreferences.ql
-ql/swift/ql/src/queries/Security/CWE-321/HardcodedEncryptionKey.ql
 ql/swift/ql/src/queries/Security/CWE-327/ECBEncryption.ql
 ql/swift/ql/src/queries/Security/CWE-328/WeakPasswordHashing.ql
 ql/swift/ql/src/queries/Security/CWE-328/WeakSensitiveDataHashing.ql

--- a/swift/ql/integration-tests/posix/query-suite/swift-security-and-quality.qls.expected
+++ b/swift/ql/integration-tests/posix/query-suite/swift-security-and-quality.qls.expected
@@ -15,12 +15,10 @@ ql/swift/ql/src/queries/Security/CWE-1204/StaticInitializationVector.ql
 ql/swift/ql/src/queries/Security/CWE-1333/ReDoS.ql
 ql/swift/ql/src/queries/Security/CWE-134/UncontrolledFormatString.ql
 ql/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
-ql/swift/ql/src/queries/Security/CWE-259/ConstantPassword.ql
 ql/swift/ql/src/queries/Security/CWE-311/CleartextStorageDatabase.ql
 ql/swift/ql/src/queries/Security/CWE-311/CleartextTransmission.ql
 ql/swift/ql/src/queries/Security/CWE-312/CleartextLogging.ql
 ql/swift/ql/src/queries/Security/CWE-312/CleartextStoragePreferences.ql
-ql/swift/ql/src/queries/Security/CWE-321/HardcodedEncryptionKey.ql
 ql/swift/ql/src/queries/Security/CWE-327/ECBEncryption.ql
 ql/swift/ql/src/queries/Security/CWE-328/WeakPasswordHashing.ql
 ql/swift/ql/src/queries/Security/CWE-328/WeakSensitiveDataHashing.ql

--- a/swift/ql/integration-tests/posix/query-suite/swift-security-extended.qls.expected
+++ b/swift/ql/integration-tests/posix/query-suite/swift-security-extended.qls.expected
@@ -15,12 +15,10 @@ ql/swift/ql/src/queries/Security/CWE-1204/StaticInitializationVector.ql
 ql/swift/ql/src/queries/Security/CWE-1333/ReDoS.ql
 ql/swift/ql/src/queries/Security/CWE-134/UncontrolledFormatString.ql
 ql/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
-ql/swift/ql/src/queries/Security/CWE-259/ConstantPassword.ql
 ql/swift/ql/src/queries/Security/CWE-311/CleartextStorageDatabase.ql
 ql/swift/ql/src/queries/Security/CWE-311/CleartextTransmission.ql
 ql/swift/ql/src/queries/Security/CWE-312/CleartextLogging.ql
 ql/swift/ql/src/queries/Security/CWE-312/CleartextStoragePreferences.ql
-ql/swift/ql/src/queries/Security/CWE-321/HardcodedEncryptionKey.ql
 ql/swift/ql/src/queries/Security/CWE-327/ECBEncryption.ql
 ql/swift/ql/src/queries/Security/CWE-328/WeakPasswordHashing.ql
 ql/swift/ql/src/queries/Security/CWE-328/WeakSensitiveDataHashing.ql

--- a/swift/ql/src/change-notes/2025-05-16-hardcoded-credentials.md
+++ b/swift/ql/src/change-notes/2025-05-16-hardcoded-credentials.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The queries `swift/hardcoded-key` and `swift/constant-password` have been removed from all query suites.

--- a/swift/ql/src/queries/Security/CWE-259/ConstantPassword.ql
+++ b/swift/ql/src/queries/Security/CWE-259/ConstantPassword.ql
@@ -4,7 +4,7 @@
  * @kind path-problem
  * @problem.severity error
  * @security-severity 6.8
- * @precision high
+ * @precision low
  * @id swift/constant-password
  * @tags security
  *       external/cwe/cwe-259

--- a/swift/ql/src/queries/Security/CWE-321/HardcodedEncryptionKey.ql
+++ b/swift/ql/src/queries/Security/CWE-321/HardcodedEncryptionKey.ql
@@ -4,7 +4,7 @@
  * @kind path-problem
  * @problem.severity error
  * @security-severity 8.1
- * @precision high
+ * @precision low
  * @id swift/hardcoded-key
  * @tags security
  *       external/cwe/cwe-321


### PR DESCRIPTION
The linked issue describes why the precisions are lowered (and it also includes a list of specific query IDs).