### PR TITLE
Fix SpringRequestMappingMethod URL Extraction: Use getAStringArrayValue Instead of getValue

### DIFF
--- a/java/ql/lib/semmle/code/java/frameworks/spring/SpringController.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/spring/SpringController.qll
@@ -156,6 +156,10 @@ class SpringRequestMappingMethod extends SpringControllerMethod {
   /** Gets the "value" @RequestMapping annotation value, if present. */
   string getValue() { result = requestMappingAnnotation.getStringValue("value") }
 
+
+
+  /** Gets the "value" @RequestMapping annotation array string value, if present. */
+  string getArrayValue() { result = requestMappingAnnotation.getAStringArrayValue("value") }
   /** Gets the "method" @RequestMapping annotation value, if present. */
   string getMethodValue() {
     result = requestMappingAnnotation.getAnEnumConstantArrayValue("method").getName()


### PR DESCRIPTION
Previously, the SpringRequestMappingMethod class in CodeQL used the getValue or getStringValue predicate to extract the "value" attribute from Spring's @RequestMapping and related annotations. However, in Spring, the "value" and "path" attributes are defined as String[] (string arrays), not single strings. This caused issues where URLs could not be extracted if they were specified as arrays.

This PR updates the relevant logic to use getAStringArrayValue, which correctly handles array-typed annotation elements and ensures all specified URLs are extracted, regardless of whether they are provided as single values or arrays. This change improves the accuracy and reliability of Spring controller route extraction in CodeQL queries.

spring-web-5.2.8.RELEASE
`org.springframework.web.bind.annotation.RequestMapping`
![image](https://github.com/user-attachments/assets/a43daf18-5bd3-40c8-beb9-0321903887ca)
or
[https://github.com/spring-projects/spring-framework/blob/main/spring-web/src/main/java/org/springframework/web/bind/annotation/RequestMapping.java](url)
