### PR TITLE
C++: Do not use deprecated `hasLocationInfo` in `FlowTestCommon`

### DIFF
--- a/cpp/ql/lib/utils/test/dataflow/FlowTestCommon.qll
+++ b/cpp/ql/lib/utils/test/dataflow/FlowTestCommon.qll
@@ -26,7 +26,7 @@ module IRFlowTest<IRDataFlow::GlobalFlowSig Flow> implements TestSig {
       n =
         strictcount(int line, int column |
           Flow::flow(any(IRDataFlow::Node otherSource |
-              otherSource.hasLocationInfo(_, line, column, _, _)
+              otherSource.getLocation().hasLocationInfo(_, line, column, _, _)
             ), sink)
         ) and
       (
@@ -55,7 +55,7 @@ module AstFlowTest<AstDataFlow::GlobalFlowSig Flow> implements TestSig {
       n =
         strictcount(int line, int column |
           Flow::flow(any(AstDataFlow::Node otherSource |
-              otherSource.hasLocationInfo(_, line, column, _, _)
+              otherSource.getLocation().hasLocationInfo(_, line, column, _, _)
             ), sink)
         ) and
       (


### PR DESCRIPTION
`hasLocationInfo` on dataflow nodes has been deprecated for over a year.

Deprecated in https://github.com/github/codeql/pull/15853