### PR TITLE
JS: More efficient nested package naming

### DIFF
--- a/javascript/ql/src/NodeJS/UnresolvableImport.ql
+++ b/javascript/ql/src/NodeJS/UnresolvableImport.ql
@@ -36,7 +36,7 @@ where
   not exists(r.getImportedModule()) and
   // no enclosing NPM package declares a dependency on `mod`
   forex(NpmPackage pkg, PackageJson pkgJson |
-    pkg.getAModule() = r.getTopLevel() and pkgJson = pkg.getPackageJson()
+    pkg.getAModule() = r.getTopLevel() and pkgJson = pkg.getPackageJson().getEnclosingPackage*()
   |
     not pkgJson.declaresDependency(mod, _) and
     not pkgJson.getPeerDependencies().getADependency(mod, _) and

--- a/javascript/ql/test/library-tests/NPM/tests.expected
+++ b/javascript/ql/test/library-tests/NPM/tests.expected
@@ -39,7 +39,6 @@ modules
 | src/node_modules/nested | nested | src/node_modules/nested/tst3.js:1:1:2:13 | <toplevel> |
 | src/node_modules/nested/node_modules/a | a | src/node_modules/nested/node_modules/a/index.js:1:1:1:25 | <toplevel> |
 | src/node_modules/parent-module | parent-module | src/node_modules/parent-module/main.js:1:1:2:0 | <toplevel> |
-| src/node_modules/parent-module | parent-module | src/node_modules/parent-module/sub-module/main.js:1:1:2:0 | <toplevel> |
 | src/node_modules/parent-module/sub-module | parent-module/sub-module | src/node_modules/parent-module/sub-module/main.js:1:1:2:0 | <toplevel> |
 | src/node_modules/third-party-module | third-party-module | src/node_modules/third-party-module/fancy.js:1:1:4:0 | <toplevel> |
 npm


### PR DESCRIPTION
Fixes a bad join order in `PackageJson.getPackageName()` for the case where a package is nested within another package.

Also `NpmPackage.getAFile()` had a discrepancy between its documentation, which states that files are only associated with their nearest enclosing package, but it actually associated files with all their enclosing packages. It now does what it says in the QLDoc. One of the queries that depended on the old behaviour has been updated accordingly.