### PR TITLE
C++/Swift: delete outdated deprecations

### DIFF
--- a/cpp/ql/lib/change-notes/2025-05-18-2025-May-outdated-deprecations.md
+++ b/cpp/ql/lib/change-notes/2025-05-18-2025-May-outdated-deprecations.md
@@ -1,0 +1,9 @@
+---
+category: breaking
+---
+* Deleted the deprecated `userInputArgument` predicate and its convenience accessor from the `Security.qll`.
+* Deleted the deprecated `userInputReturned` predicate and its convenience accessor from the `Security.qll`.
+* Deleted the deprecated `userInputReturn` predicate from the `Security.qll`.
+* Deleted the deprecated `isUserInput` predicate and its convenience accessor from the `Security.qll`.
+* Deleted the deprecated `userInputArgument` predicate from the `SecurityOptions.qll`.
+* Deleted the deprecated `userInputReturned` predicate from the `SecurityOptions.qll`.

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowUtil.qll
@@ -99,19 +99,6 @@ class Node extends TNode {
   Location getLocation() { none() } // overridden by subclasses
 
   /**
-   * Holds if this element is at the specified location.
-   * The location spans column `startcolumn` of line `startline` to
-   * column `endcolumn` of line `endline` in file `filepath`.
-   * For more information, see
-   * [Locations](https://codeql.github.com/docs/writing-codeql-queries/providing-locations-in-codeql-queries/).
-   */
-  deprecated predicate hasLocationInfo(
-    string filepath, int startline, int startcolumn, int endline, int endcolumn
-  ) {
-    this.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
-  }
-
-  /**
    * Gets an upper bound on the type of this node.
    */
   Type getTypeBound() { result = this.getType() }

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -538,19 +538,6 @@ class Node extends TIRDataFlowNode {
     none() // overridden by subclasses
   }
 
-  /**
-   * Holds if this element is at the specified location.
-   * The location spans column `startcolumn` of line `startline` to
-   * column `endcolumn` of line `endline` in file `filepath`.
-   * For more information, see
-   * [Locations](https://codeql.github.com/docs/writing-codeql-queries/providing-locations-in-codeql-queries/).
-   */
-  deprecated predicate hasLocationInfo(
-    string filepath, int startline, int startcolumn, int endline, int endcolumn
-  ) {
-    this.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
-  }
-
   /** Gets a textual representation of this element. */
   cached
   final string toString() {

--- a/cpp/ql/lib/semmle/code/cpp/security/Security.qll
+++ b/cpp/ql/lib/semmle/code/cpp/security/Security.qll
@@ -77,16 +77,6 @@ class SecurityOptions extends string {
   }
 }
 
-/**
- * An access to the argv argument to main().
- */
-private predicate commandLineArg(Expr e) {
-  exists(Parameter argv |
-    argv(argv) and
-    argv.getAnAccess() = e
-  )
-}
-
 /** The argv parameter to the main function */
 predicate argv(Parameter argv) {
   exists(Function f |

--- a/cpp/ql/lib/semmle/code/cpp/security/Security.qll
+++ b/cpp/ql/lib/semmle/code/cpp/security/Security.qll
@@ -43,58 +43,6 @@ class SecurityOptions extends string {
   }
 
   /**
-   * The argument of the given function is filled in from user input.
-   */
-  deprecated predicate userInputArgument(FunctionCall functionCall, int arg) {
-    exists(string fname |
-      functionCall.getTarget().hasGlobalOrStdName(fname) and
-      exists(functionCall.getArgument(arg)) and
-      (
-        fname = ["fread", "fgets", "fgetws", "gets"] and arg = 0
-        or
-        fname = "scanf" and arg >= 1
-        or
-        fname = "fscanf" and arg >= 2
-      )
-      or
-      functionCall.getTarget().hasGlobalName(fname) and
-      exists(functionCall.getArgument(arg)) and
-      fname = "getaddrinfo" and
-      arg = 3
-    )
-    or
-    exists(RemoteFlowSourceFunction remote, FunctionOutput output |
-      functionCall.getTarget() = remote and
-      output.isParameterDerefOrQualifierObject(arg) and
-      remote.hasRemoteFlowSource(output, _)
-    )
-  }
-
-  /**
-   * The return value of the given function is filled in from user input.
-   */
-  deprecated predicate userInputReturned(FunctionCall functionCall) {
-    exists(string fname |
-      functionCall.getTarget().getName() = fname and
-      (
-        fname = ["fgets", "gets"] or
-        this.userInputReturn(fname)
-      )
-    )
-    or
-    exists(RemoteFlowSourceFunction remote, FunctionOutput output |
-      functionCall.getTarget() = remote and
-      (output.isReturnValue() or output.isReturnValueDeref()) and
-      remote.hasRemoteFlowSource(output, _)
-    )
-  }
-
-  /**
-   * DEPRECATED: Users should override `userInputReturned()` instead.
-   */
-  deprecated predicate userInputReturn(string function) { none() }
-
-  /**
    * The argument of the given function is used for running a process or loading
    * a library.
    */
@@ -106,29 +54,6 @@ class SecurityOptions extends string {
     or
     // Windows
     function = ["LoadLibrary", "LoadLibraryA", "LoadLibraryW"] and arg = 0
-  }
-
-  /**
-   * This predicate should hold if the expression is directly
-   * computed from user input. Such expressions are treated as
-   * sources of taint.
-   */
-  deprecated predicate isUserInput(Expr expr, string cause) {
-    exists(FunctionCall fc, int i |
-      this.userInputArgument(fc, i) and
-      expr = fc.getArgument(i) and
-      cause = fc.getTarget().getName()
-    )
-    or
-    exists(FunctionCall fc |
-      this.userInputReturned(fc) and
-      expr = fc and
-      cause = fc.getTarget().getName()
-    )
-    or
-    commandLineArg(expr) and cause = "argv"
-    or
-    expr.(EnvironmentRead).getSourceDescription() = cause
   }
 
   /**
@@ -172,21 +97,6 @@ predicate argv(Parameter argv) {
 
 /** Convenience accessor for SecurityOptions.isPureFunction */
 predicate isPureFunction(string name) { exists(SecurityOptions opts | opts.isPureFunction(name)) }
-
-/** Convenience accessor for SecurityOptions.userInputArgument */
-deprecated predicate userInputArgument(FunctionCall functionCall, int arg) {
-  exists(SecurityOptions opts | opts.userInputArgument(functionCall, arg))
-}
-
-/** Convenience accessor for SecurityOptions.userInputReturn */
-deprecated predicate userInputReturned(FunctionCall functionCall) {
-  exists(SecurityOptions opts | opts.userInputReturned(functionCall))
-}
-
-/** Convenience accessor for SecurityOptions.isUserInput */
-deprecated predicate isUserInput(Expr expr, string cause) {
-  exists(SecurityOptions opts | opts.isUserInput(expr, cause))
-}
 
 /** Convenience accessor for SecurityOptions.isProcessOperationArgument */
 predicate isProcessOperationArgument(string function, int arg) {

--- a/cpp/ql/lib/semmle/code/cpp/security/SecurityOptions.qll
+++ b/cpp/ql/lib/semmle/code/cpp/security/SecurityOptions.qll
@@ -22,28 +22,4 @@ class CustomSecurityOptions extends SecurityOptions {
     // for example: (function = "MySpecialSqlFunction" and arg = 0)
     none() // rules to match custom functions replace this line
   }
-
-  deprecated override predicate userInputArgument(FunctionCall functionCall, int arg) {
-    SecurityOptions.super.userInputArgument(functionCall, arg)
-    or
-    exists(string fname |
-      functionCall.getTarget().hasGlobalName(fname) and
-      exists(functionCall.getArgument(arg)) and
-      // --- custom functions that return user input via one of their arguments:
-      // 'arg' is the 0-based index of the argument that is used to return user input
-      // for example: (fname = "readXmlInto" and arg = 1)
-      none() // rules to match custom functions replace this line
-    )
-  }
-
-  deprecated override predicate userInputReturned(FunctionCall functionCall) {
-    SecurityOptions.super.userInputReturned(functionCall)
-    or
-    exists(string fname |
-      functionCall.getTarget().hasGlobalName(fname) and
-      // --- custom functions that return user input via their return value:
-      // for example: fname = "xmlReadAttribute"
-      none() // rules to match custom functions replace this line
-    )
-  }
 }

--- a/swift/ql/lib/change-notes/2025-05-18-2025-May-outdated-deprecations.md
+++ b/swift/ql/lib/change-notes/2025-05-18-2025-May-outdated-deprecations.md
@@ -1,0 +1,10 @@
+---
+category: breaking
+---
+* Deleted the deprecated `parseContent` predicate from the `ExternalFlow.qll`.
+* Deleted the deprecated `hasLocationInfo` predicate from the `DataFlowPublic.qll`.
+* Deleted the deprecated `SummaryComponent` class from the `FlowSummary.qll`.
+* Deleted the deprecated `SummaryComponentStack` class from the `FlowSummary.qll`.
+* Deleted the deprecated `SummaryComponent` module from the `FlowSummary.qll`.
+* Deleted the deprecated `SummaryComponentStack` module from the `FlowSummary.qll`.
+* Deleted the deprecated `RequiredSummaryComponentStack` class from the `FlowSummary.qll`.

--- a/swift/ql/lib/codeql/swift/dataflow/ExternalFlow.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/ExternalFlow.qll
@@ -446,44 +446,6 @@ Element interpretElement(
   )
 }
 
-deprecated private predicate parseField(AccessPathToken c, Content::FieldContent f) {
-  exists(string fieldRegex, string name |
-    c.getName() = "Field" and
-    fieldRegex = "^([^.]+)$" and
-    name = c.getAnArgument().regexpCapture(fieldRegex, 1) and
-    f.getField().getName() = name
-  )
-}
-
-deprecated private predicate parseTuple(AccessPathToken c, Content::TupleContent t) {
-  c.getName() = "TupleElement" and
-  t.getIndex() = c.getAnArgument().toInt()
-}
-
-deprecated private predicate parseEnum(AccessPathToken c, Content::EnumContent e) {
-  c.getName() = "EnumElement" and
-  c.getAnArgument() = e.getSignature()
-  or
-  c.getName() = "OptionalSome" and
-  e.getSignature() = "some:0"
-}
-
-/** Holds if the specification component parses as a `Content`. */
-deprecated predicate parseContent(AccessPathToken component, Content content) {
-  parseField(component, content)
-  or
-  parseTuple(component, content)
-  or
-  parseEnum(component, content)
-  or
-  // map legacy "ArrayElement" specification components to `CollectionContent`
-  component.getName() = "ArrayElement" and
-  content instanceof Content::CollectionContent
-  or
-  component.getName() = "CollectionElement" and
-  content instanceof Content::CollectionContent
-}
-
 cached
 private module Cached {
   /**

--- a/swift/ql/lib/codeql/swift/dataflow/FlowSummary.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/FlowSummary.qll
@@ -13,14 +13,4 @@ private module Summaries {
   private import codeql.swift.frameworks.Frameworks
 }
 
-deprecated class SummaryComponent = Impl::Private::SummaryComponent;
-
-deprecated module SummaryComponent = Impl::Private::SummaryComponent;
-
-deprecated class SummaryComponentStack = Impl::Private::SummaryComponentStack;
-
-deprecated module SummaryComponentStack = Impl::Private::SummaryComponentStack;
-
 class SummarizedCallable = Impl::Public::SummarizedCallable;
-
-deprecated class RequiredSummaryComponentStack = Impl::Private::RequiredSummaryComponentStack;

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPublic.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPublic.qll
@@ -20,19 +20,6 @@ class Node extends TNode {
   final Location getLocation() { result = this.(NodeImpl).getLocationImpl() }
 
   /**
-   * Holds if this element is at the specified location.
-   * The location spans column `startcolumn` of line `startline` to
-   * column `endcolumn` of line `endline` in file `filepath`.
-   * For more information, see
-   * [Locations](https://codeql.github.com/docs/writing-codeql-queries/providing-locations-in-codeql-queries/).
-   */
-  deprecated predicate hasLocationInfo(
-    string filepath, int startline, int startcolumn, int endline, int endcolumn
-  ) {
-    this.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
-  }
-
-  /**
    * Gets the expression that corresponds to this node, if any.
    */
   Expr asExpr() { none() }

--- a/swift/ql/lib/codeql/swift/security/WeakSensitiveDataHashingQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/WeakSensitiveDataHashingQuery.qll
@@ -40,8 +40,4 @@ module WeakSensitiveDataHashingConfig implements DataFlow::ConfigSig {
   }
 }
 
-deprecated module WeakHashingConfig = WeakSensitiveDataHashingConfig;
-
 module WeakSensitiveDataHashingFlow = TaintTracking::Global<WeakSensitiveDataHashingConfig>;
-
-deprecated module WeakHashingFlow = WeakSensitiveDataHashingFlow;


### PR DESCRIPTION
Cherry-picked from https://github.com/github/codeql/pull/19504. Mostly because the related internal C++ tests did get removed, so I don't want the keep the C++ deprecations around for too long without test coverage. 