### PR TITLE
Go: move to standard windows runner

### DIFF
--- a/.github/workflows/go-tests-other-os.yml
+++ b/.github/workflows/go-tests-other-os.yml
@@ -26,9 +26,8 @@ jobs:
         uses: ./go/actions/test
 
   test-win:
-    if: github.repository_owner == 'github'
     name: Test Windows
-    runs-on: windows-latest-xl
+    runs-on: windows-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v4


### PR DESCRIPTION
Seems like `windows-latest-xl` is not available any more, leading to jobs waiting endlessly (see for example https://github.com/github/codeql/actions/runs/15109425790). This should unblock CI, but longer term we should consider doing what other languages do (i.e. run tests from the internal repo).