### PR TITLE
Rust: Improve performance of type inference

### DIFF
--- a/rust/ql/lib/codeql/rust/internal/TypeInference.qll
+++ b/rust/ql/lib/codeql/rust/internal/TypeInference.qll
@@ -240,7 +240,7 @@ private predicate typeEqualityLeft(AstNode n1, TypePath path1, AstNode n2, TypeP
     any(PrefixExpr pe |
       pe.getOperatorName() = "*" and
       pe.getExpr() = n1 and
-      path1 = TypePath::consInverse(TRefTypeParameter(), path2)
+      path1.isCons(TRefTypeParameter(), path2)
     )
 }
 
@@ -926,7 +926,7 @@ private Type inferRefExprType(Expr e, TypePath path) {
     e = re.getExpr() and
     exists(TypePath exprPath, TypePath refPath, Type exprType |
       result = inferType(re, exprPath) and
-      exprPath = TypePath::consInverse(TRefTypeParameter(), refPath) and
+      exprPath.isCons(TRefTypeParameter(), refPath) and
       exprType = inferType(e)
     |
       if exprType = TRefType()
@@ -940,8 +940,9 @@ private Type inferRefExprType(Expr e, TypePath path) {
 
 pragma[nomagic]
 private Type inferTryExprType(TryExpr te, TypePath path) {
-  exists(TypeParam tp |
-    result = inferType(te.getExpr(), TypePath::consInverse(TTypeParamTypeParameter(tp), path))
+  exists(TypeParam tp, TypePath path0 |
+    result = inferType(te.getExpr(), path0) and
+    path0.isCons(TTypeParamTypeParameter(tp), path)
   |
     tp = any(ResultEnum r).getGenericParamList().getGenericParam(0)
     or
@@ -1017,7 +1018,7 @@ private module Cached {
     pragma[nomagic]
     Type getTypeAt(TypePath path) {
       exists(TypePath path0 | result = inferType(this, path0) |
-        path0 = TypePath::consInverse(TRefTypeParameter(), path)
+        path0.isCons(TRefTypeParameter(), path)
         or
         not path0.isCons(TRefTypeParameter(), _) and
         not (path0.isEmpty() and result = TRefType()) and

--- a/rust/ql/lib/codeql/rust/internal/TypeInference.qll
+++ b/rust/ql/lib/codeql/rust/internal/TypeInference.qll
@@ -213,13 +213,6 @@ private predicate typeEquality(AstNode n1, TypePath path1, AstNode n2, TypePath 
     path1 = path2
   )
   or
-  n2 =
-    any(PrefixExpr pe |
-      pe.getOperatorName() = "*" and
-      pe.getExpr() = n1 and
-      path1 = TypePath::cons(TRefTypeParameter(), path2)
-    )
-  or
   n1 = n2.(ParenExpr).getExpr() and
   path1 = path2
   or
@@ -239,12 +232,36 @@ private predicate typeEquality(AstNode n1, TypePath path1, AstNode n2, TypePath 
   )
 }
 
+bindingset[path1]
+private predicate typeEqualityLeft(AstNode n1, TypePath path1, AstNode n2, TypePath path2) {
+  typeEquality(n1, path1, n2, path2)
+  or
+  n2 =
+    any(PrefixExpr pe |
+      pe.getOperatorName() = "*" and
+      pe.getExpr() = n1 and
+      path1 = TypePath::consInverse(TRefTypeParameter(), path2)
+    )
+}
+
+bindingset[path2]
+private predicate typeEqualityRight(AstNode n1, TypePath path1, AstNode n2, TypePath path2) {
+  typeEquality(n1, path1, n2, path2)
+  or
+  n2 =
+    any(PrefixExpr pe |
+      pe.getOperatorName() = "*" and
+      pe.getExpr() = n1 and
+      path1 = TypePath::cons(TRefTypeParameter(), path2)
+    )
+}
+
 pragma[nomagic]
 private Type inferTypeEquality(AstNode n, TypePath path) {
   exists(AstNode n2, TypePath path2 | result = inferType(n2, path2) |
-    typeEquality(n, path, n2, path2)
+    typeEqualityRight(n, path, n2, path2)
     or
-    typeEquality(n2, path2, n, path)
+    typeEqualityLeft(n2, path2, n, path)
   )
 }
 
@@ -909,7 +926,7 @@ private Type inferRefExprType(Expr e, TypePath path) {
     e = re.getExpr() and
     exists(TypePath exprPath, TypePath refPath, Type exprType |
       result = inferType(re, exprPath) and
-      exprPath = TypePath::cons(TRefTypeParameter(), refPath) and
+      exprPath = TypePath::consInverse(TRefTypeParameter(), refPath) and
       exprType = inferType(e)
     |
       if exprType = TRefType()
@@ -924,7 +941,7 @@ private Type inferRefExprType(Expr e, TypePath path) {
 pragma[nomagic]
 private Type inferTryExprType(TryExpr te, TypePath path) {
   exists(TypeParam tp |
-    result = inferType(te.getExpr(), TypePath::cons(TTypeParamTypeParameter(tp), path))
+    result = inferType(te.getExpr(), TypePath::consInverse(TTypeParamTypeParameter(tp), path))
   |
     tp = any(ResultEnum r).getGenericParamList().getGenericParam(0)
     or
@@ -1000,7 +1017,7 @@ private module Cached {
     pragma[nomagic]
     Type getTypeAt(TypePath path) {
       exists(TypePath path0 | result = inferType(this, path0) |
-        path0 = TypePath::cons(TRefTypeParameter(), path)
+        path0 = TypePath::consInverse(TRefTypeParameter(), path)
         or
         not path0.isCons(TRefTypeParameter(), _) and
         not (path0.isEmpty() and result = TRefType()) and


### PR DESCRIPTION
This PR speeds up type inference by
1. avoiding the `strictcount` aggregate,
2. avoiding a run-time negation that can be done at compile-time, and
3. avoiding checking for type path lengths when deconstructing existing type paths that have already been checked.

[DCA](https://github.com/github/codeql-dca-main/issues/28908) shows an impressive 65 % analysis time speedup on `rust-lang/rust`.