### PR TITLE
Rust: ignore `target` in `qltest`

### DIFF
--- a/rust/extractor/src/qltest.rs
+++ b/rust/extractor/src/qltest.rs
@@ -54,6 +54,7 @@ path = "main.rs"
 fn set_sources(config: &mut Config) -> anyhow::Result<()> {
     let path_iterator = glob("**/*.rs").context("globbing test sources")?;
     config.inputs = path_iterator
+        .filter(|f| f.is_err() || !f.as_ref().unwrap().starts_with("target"))
         .collect::<Result<Vec<_>, _>>()
         .context("fetching test sources")?;
     Ok(())


### PR DESCRIPTION
The target file created by `cargo check` was causing problems in language tests.

We might want to also ignore `target` by default in the production indexing, but I'll leave that for further discussion.