### PR TITLE
Java: Add test showing missing dispatch for incomplete parameterised type

### DIFF
--- a/java/ql/test/library-tests/errortype/Dispatch.expected
+++ b/java/ql/test/library-tests/errortype/Dispatch.expected
@@ -1,0 +1,1 @@
+| Test.java:16:5:16:15 | method(...) | Test.java:11:17:11:22 | method |

--- a/java/ql/test/library-tests/errortype/Dispatch.ql
+++ b/java/ql/test/library-tests/errortype/Dispatch.ql
@@ -1,0 +1,6 @@
+import java
+import semmle.code.java.dispatch.VirtualDispatch
+
+from MethodCall mc, Method m
+where viableImpl(mc) = m
+select mc, m

--- a/java/ql/test/library-tests/errortype/Test.java
+++ b/java/ql/test/library-tests/errortype/Test.java
@@ -7,6 +7,16 @@ public class Test {
     return nsc;
   }
 
+  static class GenericClass<T> {
+    public void method() { }
+  }
+
+  public testDispatch() {
+    GenericClass<String> g1 = new GenericClass<>();
+    g1.method();
+    GenericClass<NoSuchClass> g2 = new GenericClass<>();
+    g2.method();
+  }
 }
 
 // Diagnostic Matches: Unexpected symbol for constructor: new NoSuchClass()


### PR DESCRIPTION
Cf. https://github.com/github/codeql/issues/19538

The test is failing for a couple of reasons. The most important is that `MethodCall.getMethod()` has no results for the call, i.e. the extractor has not populated `callableBinding`. It's unclear what exactly we'd want the target callable to be, but it's clear what its `getSourceDeclaration()` should be and that's what we really need. If we fix that somehow, then we'll also need to allow `ErrorType` in `Unification.qll`, but for now that won't do anything.