### PR TITLE
Rust: Type inference for non-overloadable operators

### DIFF
--- a/rust/ql/lib/codeql/rust/internal/Type.qll
+++ b/rust/ql/lib/codeql/rust/internal/Type.qll
@@ -9,6 +9,7 @@ private import codeql.rust.elements.internal.generated.Synth
 
 cached
 newtype TType =
+  TUnit() or
   TStruct(Struct s) { Stages::TypeInferenceStage::ref() } or
   TEnum(Enum e) or
   TTrait(Trait t) or
@@ -46,6 +47,21 @@ abstract class Type extends TType {
 
   /** Gets the location of this type. */
   abstract Location getLocation();
+}
+
+/** The unit type `()`. */
+class UnitType extends Type, TUnit {
+  UnitType() { this = TUnit() }
+
+  override StructField getStructField(string name) { none() }
+
+  override TupleField getTupleField(int i) { none() }
+
+  override TypeParameter getTypeParameter(int i) { none() }
+
+  override string toString() { result = "()" }
+
+  override Location getLocation() { result instanceof EmptyLocation }
 }
 
 abstract private class StructOrEnumType extends Type {

--- a/rust/ql/test/library-tests/type-inference/main.rs
+++ b/rust/ql/test/library-tests/type-inference/main.rs
@@ -1226,16 +1226,16 @@ mod builtins {
 
 mod operators {
     pub fn f() {
-        let x = true && false; // $ MISSING: type=x:bool
-        let y = true || false; // $ MISSING: type=y:bool
+        let x = true && false; // $ type=x:bool
+        let y = true || false; // $ type=y:bool
 
         let mut a;
         if 34 == 33 {
-            let z = (a = 1); // $ MISSING: type=z:() MISSING: type=a:i32
+            let z = (a = 1); // $ type=z:() type=a:i32
         } else {
-            a = 2; // $ MISSING: type=a:i32
+            a = 2; // $ type=a:i32
         }
-        a; // $ MISSING: type=a:i32
+        a; // $ type=a:i32
     }
 }
 

--- a/rust/ql/test/library-tests/type-inference/main.rs
+++ b/rust/ql/test/library-tests/type-inference/main.rs
@@ -1224,6 +1224,21 @@ mod builtins {
     }
 }
 
+mod operators {
+    pub fn f() {
+        let x = true && false; // $ MISSING: type=x:bool
+        let y = true || false; // $ MISSING: type=y:bool
+
+        let mut a;
+        if 34 == 33 {
+            let z = (a = 1); // $ MISSING: type=z:() MISSING: type=a:i32
+        } else {
+            a = 2; // $ MISSING: type=a:i32
+        }
+        a; // $ MISSING: type=a:i32
+    }
+}
+
 fn main() {
     field_access::f();
     method_impl::f();
@@ -1242,4 +1257,5 @@ fn main() {
     borrowed_typed::f();
     try_expressions::f();
     builtins::f();
+    operators::f();
 }

--- a/rust/ql/test/library-tests/type-inference/type-inference.expected
+++ b/rust/ql/test/library-tests/type-inference/type-inference.expected
@@ -1581,7 +1581,15 @@ inferType
 | main.rs:1222:17:1222:20 | true |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
 | main.rs:1223:13:1223:13 | f |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
 | main.rs:1223:17:1223:21 | false |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
-| main.rs:1229:5:1229:20 | ...::f(...) |  | main.rs:67:5:67:21 | Foo |
-| main.rs:1230:5:1230:60 | ...::g(...) |  | main.rs:67:5:67:21 | Foo |
-| main.rs:1230:20:1230:38 | ...::Foo {...} |  | main.rs:67:5:67:21 | Foo |
-| main.rs:1230:41:1230:59 | ...::Foo {...} |  | main.rs:67:5:67:21 | Foo |
+| main.rs:1229:17:1229:20 | true |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1229:25:1229:29 | false |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1230:17:1230:20 | true |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1230:25:1230:29 | false |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1233:12:1233:13 | 34 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1233:18:1233:19 | 33 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1234:26:1234:26 | 1 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1236:17:1236:17 | 2 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1244:5:1244:20 | ...::f(...) |  | main.rs:67:5:67:21 | Foo |
+| main.rs:1245:5:1245:60 | ...::g(...) |  | main.rs:67:5:67:21 | Foo |
+| main.rs:1245:20:1245:38 | ...::Foo {...} |  | main.rs:67:5:67:21 | Foo |
+| main.rs:1245:41:1245:59 | ...::Foo {...} |  | main.rs:67:5:67:21 | Foo |

--- a/rust/ql/test/library-tests/type-inference/type-inference.expected
+++ b/rust/ql/test/library-tests/type-inference/type-inference.expected
@@ -1581,14 +1581,26 @@ inferType
 | main.rs:1222:17:1222:20 | true |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
 | main.rs:1223:13:1223:13 | f |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
 | main.rs:1223:17:1223:21 | false |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1229:13:1229:13 | x |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
 | main.rs:1229:17:1229:20 | true |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1229:17:1229:29 | ... && ... |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
 | main.rs:1229:25:1229:29 | false |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1230:13:1230:13 | y |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
 | main.rs:1230:17:1230:20 | true |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1230:17:1230:29 | ... \|\| ... |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
 | main.rs:1230:25:1230:29 | false |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1232:13:1232:17 | mut a |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
 | main.rs:1233:12:1233:13 | 34 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
 | main.rs:1233:18:1233:19 | 33 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1234:17:1234:17 | z |  | file://:0:0:0:0 | () |
+| main.rs:1234:21:1234:27 | (...) |  | file://:0:0:0:0 | () |
+| main.rs:1234:22:1234:22 | a |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1234:22:1234:26 | ... = ... |  | file://:0:0:0:0 | () |
 | main.rs:1234:26:1234:26 | 1 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1236:13:1236:13 | a |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1236:13:1236:17 | ... = ... |  | file://:0:0:0:0 | () |
 | main.rs:1236:17:1236:17 | 2 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1238:9:1238:9 | a |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
 | main.rs:1244:5:1244:20 | ...::f(...) |  | main.rs:67:5:67:21 | Foo |
 | main.rs:1245:5:1245:60 | ...::g(...) |  | main.rs:67:5:67:21 | Foo |
 | main.rs:1245:20:1245:38 | ...::Foo {...} |  | main.rs:67:5:67:21 | Foo |


### PR DESCRIPTION
This PR adds type inference for _all_ non-overloadable operators in Rust. It turns out that there are only three such operators. `&&` and `||` (which are not overloadable for short-circuiting reasons) and `=`.

The assignment operator evaluates to unit, and as we didn't have a unit type I added one.