### PR TITLE
Rust: Remove unused impl type

### DIFF
--- a/rust/ql/lib/codeql/rust/internal/Type.qll
+++ b/rust/ql/lib/codeql/rust/internal/Type.qll
@@ -13,7 +13,6 @@ newtype TType =
   TStruct(Struct s) { Stages::TypeInferenceStage::ref() } or
   TEnum(Enum e) or
   TTrait(Trait t) or
-  TImpl(Impl i) or
   TArrayType() or // todo: add size?
   TRefType() or // todo: add mut?
   TTypeParamTypeParameter(TypeParam t) or
@@ -130,75 +129,6 @@ class TraitType extends Type, TTrait {
   override string toString() { result = trait.toString() }
 
   override Location getLocation() { result = trait.getLocation() }
-}
-
-/**
- * An `impl` block type.
- *
- * Although `impl` blocks are not really types, we treat them as such in order
- * to be able to match type parameters from structs (or enums) with type
- * parameters from `impl` blocks. For example, in
- *
- * ```rust
- * struct S<T1>(T1);
- *
- * impl<T2> S<T2> {
- *   fn id(self) -> S<T2> { self }
- * }
- *
- * let x : S(i64) = S(42);
- * x.id();
- * ```
- *
- * we pretend that the `impl` block is a base type mention of the struct `S`,
- * with type argument `T1`. This means that from knowing that `x` has type
- * `S(i64)`, we can first match `i64` with `T1`, and then by matching `T1` with
- * `T2`, we can match `i64` with `T2`.
- *
- * `impl` blocks can also have base type mentions, namely the trait that they
- * implement (if any). Example:
- *
- * ```rust
- * struct S<T1>(T1);
- *
- * trait Trait<T2> {
- *   fn f(self) -> T2;
- *
- *   fn g(self) -> T2 { self.f() }
- * }
- *
- * impl<T3> Trait<T3> for S<T3> { // `Trait<T3>` is a base type mention of this `impl` block
- *   fn f(self) -> T3 {
- *     match self {
- *       S(x) => x
- *     }
- *   }
- * }
- *
- * let x : S(i64) = S(42);
- * x.g();
- * ```
- *
- * In this case we can match `i64` with `T1`, `T1` with `T3`, and `T3` with `T2`,
- * allowing us match `i64` with `T2`, and hence infer that the return type of `g`
- * is `i64`.
- */
-class ImplType extends Type, TImpl {
-  private Impl impl;
-
-  ImplType() { this = TImpl(impl) }
-
-  override StructField getStructField(string name) { none() }
-
-  override TupleField getTupleField(int i) { none() }
-
-  override TypeParameter getTypeParameter(int i) {
-    result = TTypeParamTypeParameter(impl.getGenericParamList().getTypeParam(i))
-  }
-
-  override string toString() { result = impl.toString() }
-
-  override Location getLocation() { result = impl.getLocation() }
 }
 
 /**

--- a/rust/ql/lib/codeql/rust/internal/TypeMention.qll
+++ b/rust/ql/lib/codeql/rust/internal/TypeMention.qll
@@ -189,56 +189,6 @@ class TypeAliasMention extends TypeMention, TypeAlias {
   override Type resolveType() { result = t }
 }
 
-/**
- * Holds if the `i`th type argument of `selfPath`, belonging to `impl`, resolves
- * to type parameter `tp`.
- *
- * Example:
- *
- * ```rust
- * impl<T> Foo<T> for Bar<T> { ... }
- * //      ^^^^^^ selfPath
- * //   ^         tp
- * ```
- */
-pragma[nomagic]
-private predicate isImplSelfTypeParam(
-  ImplItemNode impl, PathMention selfPath, int i, TypeParameter tp
-) {
-  exists(PathMention path |
-    selfPath = impl.getSelfPath() and
-    path = selfPath.getSegment().getGenericArgList().getTypeArg(i).(PathTypeRepr).getPath() and
-    tp = path.resolveType()
-  )
-}
-
-class ImplMention extends TypeMention, ImplItemNode {
-  override TypeReprMention getTypeArgument(int i) { none() }
-
-  override Type resolveType() { result = TImpl(this) }
-
-  override Type resolveTypeAt(TypePath path) {
-    result = TImpl(this) and
-    path.isEmpty()
-    or
-    // For example, in
-    //
-    // ```rust
-    // struct S<T1>(T1);
-    //
-    // impl<T2> S<T2> { ... }
-    // ```
-    //
-    // We get that the type path "0" resolves to `T1` for the `impl` block,
-    // which is considered a base type mention of `S`.
-    exists(PathMention selfPath, TypeParameter tp, int i |
-      isImplSelfTypeParam(this, selfPath, pragma[only_bind_into](i), tp) and
-      result = selfPath.resolveType().getTypeParameter(pragma[only_bind_into](i)) and
-      path = TypePath::singleton(tp)
-    )
-  }
-}
-
 class TraitMention extends TypeMention, TraitItemNode {
   override TypeMention getTypeArgument(int i) {
     result = this.getTypeParam(i)


### PR DESCRIPTION
I just realized that the type for `impl` blocks is in fact unused after the recent changes to method resolution.