### PR TITLE
Rust: Add more Operation subclasses

### DIFF
--- a/rust/ql/lib/codeql/rust/elements/ArithmeticOperation.qll
+++ b/rust/ql/lib/codeql/rust/elements/ArithmeticOperation.qll
@@ -1,0 +1,41 @@
+/**
+ * Provides classes for arithmetic operations.
+ */
+
+private import codeql.rust.elements.BinaryExpr
+private import codeql.rust.elements.PrefixExpr
+private import codeql.rust.elements.Operation
+
+/**
+ * An arithmetic operation, such as `+`, `*=`, or `-`.
+ */
+abstract private class ArithmeticOperationImpl extends Operation { }
+
+final class ArithmeticOperation = ArithmeticOperationImpl;
+
+/**
+ * A binary arithmetic operation, such as `+` or `*`.
+ */
+final class BinaryArithmeticOperation extends BinaryExpr, ArithmeticOperationImpl {
+  BinaryArithmeticOperation() {
+    this.getOperatorName() = ["+", "-", "*", "/", "%"]
+  }
+}
+
+/**
+ * An arithmetic assignment operation, such as `+=` or `*=`.
+ */
+final class AssignArithmeticOperation extends BinaryExpr, ArithmeticOperationImpl {
+  AssignArithmeticOperation() {
+    this.getOperatorName() = ["+=", "-=", "*=", "/=", "%="]
+  }
+}
+
+/**
+ * A prefix arithmetic operation, such as `-`.
+ */
+final class PrefixArithmeticOperation extends PrefixExpr, ArithmeticOperationImpl {
+  PrefixArithmeticOperation() {
+    this.getOperatorName() = "-"
+  }
+}

--- a/rust/ql/lib/codeql/rust/elements/ArithmeticOperation.qll
+++ b/rust/ql/lib/codeql/rust/elements/ArithmeticOperation.qll
@@ -5,6 +5,7 @@
 private import codeql.rust.elements.BinaryExpr
 private import codeql.rust.elements.PrefixExpr
 private import codeql.rust.elements.Operation
+private import codeql.rust.elements.AssignmentOperation
 
 /**
  * An arithmetic operation, such as `+`, `*=`, or `-`.
@@ -17,25 +18,21 @@ final class ArithmeticOperation = ArithmeticOperationImpl;
  * A binary arithmetic operation, such as `+` or `*`.
  */
 final class BinaryArithmeticOperation extends BinaryExpr, ArithmeticOperationImpl {
-  BinaryArithmeticOperation() {
-    this.getOperatorName() = ["+", "-", "*", "/", "%"]
-  }
+  BinaryArithmeticOperation() { this.getOperatorName() = ["+", "-", "*", "/", "%"] }
 }
 
 /**
  * An arithmetic assignment operation, such as `+=` or `*=`.
  */
-final class AssignArithmeticOperation extends BinaryExpr, ArithmeticOperationImpl {
-  AssignArithmeticOperation() {
-    this.getOperatorName() = ["+=", "-=", "*=", "/=", "%="]
-  }
+final class AssignArithmeticOperation extends BinaryExpr, ArithmeticOperationImpl,
+  AssignmentOperation
+{
+  AssignArithmeticOperation() { this.getOperatorName() = ["+=", "-=", "*=", "/=", "%="] }
 }
 
 /**
  * A prefix arithmetic operation, such as `-`.
  */
 final class PrefixArithmeticOperation extends PrefixExpr, ArithmeticOperationImpl {
-  PrefixArithmeticOperation() {
-    this.getOperatorName() = "-"
-  }
+  PrefixArithmeticOperation() { this.getOperatorName() = "-" }
 }

--- a/rust/ql/lib/codeql/rust/elements/BitwiseOperation.qll
+++ b/rust/ql/lib/codeql/rust/elements/BitwiseOperation.qll
@@ -1,0 +1,27 @@
+/**
+ * Provides classes for bitwise operations.
+ */
+
+private import codeql.rust.elements.BinaryExpr
+private import codeql.rust.elements.Operation
+
+/**
+ * A bitwise operation, such as `&`, `<<`, or `|=`.
+ */
+abstract private class BitwiseOperationImpl extends Operation { }
+
+final class BitwiseOperation = BitwiseOperationImpl;
+
+/**
+ * A binary bitwise operation, such as `&` or `<<`.
+ */
+final class BinaryBitwiseOperation extends BinaryExpr, BitwiseOperationImpl {
+  BinaryBitwiseOperation() { this.getOperatorName() = ["&", "|", "^", "<<", ">>"] }
+}
+
+/**
+ * A bitwise assignment operation, such as `|=` or `<<=`.
+ */
+final class AssignBitwiseOperation extends BinaryExpr, BitwiseOperationImpl {
+  AssignBitwiseOperation() { this.getOperatorName() = ["&=", "|=", "^=", "<<=", ">>="] }
+}

--- a/rust/ql/lib/codeql/rust/elements/BitwiseOperation.qll
+++ b/rust/ql/lib/codeql/rust/elements/BitwiseOperation.qll
@@ -4,6 +4,7 @@
 
 private import codeql.rust.elements.BinaryExpr
 private import codeql.rust.elements.Operation
+private import codeql.rust.elements.AssignmentOperation
 
 /**
  * A bitwise operation, such as `&`, `<<`, or `|=`.
@@ -22,6 +23,6 @@ final class BinaryBitwiseOperation extends BinaryExpr, BitwiseOperationImpl {
 /**
  * A bitwise assignment operation, such as `|=` or `<<=`.
  */
-final class AssignBitwiseOperation extends BinaryExpr, BitwiseOperationImpl {
+final class AssignBitwiseOperation extends BinaryExpr, BitwiseOperationImpl, AssignmentOperation {
   AssignBitwiseOperation() { this.getOperatorName() = ["&=", "|=", "^=", "<<=", ">>="] }
 }

--- a/rust/ql/lib/codeql/rust/elements/DerefExpr.qll
+++ b/rust/ql/lib/codeql/rust/elements/DerefExpr.qll
@@ -1,0 +1,13 @@
+/**
+ * Provides classes for deref expressions (`*`).
+ */
+
+private import codeql.rust.elements.PrefixExpr
+private import codeql.rust.elements.Operation
+
+/**
+ * A dereference expression, `*`.
+ */
+final class DerefExpr extends PrefixExpr, Operation {
+  DerefExpr() { this.getOperatorName() = "*" }
+}

--- a/rust/ql/lib/codeql/rust/elements/internal/RefExprImpl.qll
+++ b/rust/ql/lib/codeql/rust/elements/internal/RefExprImpl.qll
@@ -5,6 +5,7 @@
  */
 
 private import codeql.rust.elements.internal.generated.RefExpr
+private import codeql.rust.elements.internal.OperationImpl::Impl as OperationImpl
 
 /**
  * INTERNAL: This module contains the customizable definition of `RefExpr` and should not
@@ -21,10 +22,14 @@ module Impl {
    *     let raw_mut: &mut i32 = &raw mut foo;
    * ```
    */
-  class RefExpr extends Generated::RefExpr {
+  class RefExpr extends Generated::RefExpr, OperationImpl::Operation {
     override string toStringImpl() {
       result = "&" + concat(int i | | this.getSpecPart(i), " " order by i)
     }
+
+    override string getOperatorName() { result = "&" }
+
+    override Expr getAnOperand() { result = this.getExpr() }
 
     private string getSpecPart(int index) {
       index = 0 and this.isRaw() and result = "raw"

--- a/rust/ql/lib/codeql/rust/elements/internal/VariableImpl.qll
+++ b/rust/ql/lib/codeql/rust/elements/internal/VariableImpl.qll
@@ -610,7 +610,7 @@ module Impl {
     exists(Expr mid |
       assignmentExprDescendant(mid) and
       getImmediateParent(e) = mid and
-      not mid.(PrefixExpr).getOperatorName() = "*" and
+      not mid instanceof DerefExpr and
       not mid instanceof FieldExpr and
       not mid instanceof IndexExpr
     )

--- a/rust/ql/lib/codeql/rust/internal/TypeInference.qll
+++ b/rust/ql/lib/codeql/rust/internal/TypeInference.qll
@@ -259,8 +259,7 @@ private predicate typeEqualityLeft(AstNode n1, TypePath path1, AstNode n2, TypeP
   typeEquality(n1, path1, n2, path2)
   or
   n2 =
-    any(PrefixExpr pe |
-      pe.getOperatorName() = "*" and
+    any(DerefExpr pe |
       pe.getExpr() = n1 and
       path1.isCons(TRefTypeParameter(), path2)
     )
@@ -271,8 +270,7 @@ private predicate typeEqualityRight(AstNode n1, TypePath path1, AstNode n2, Type
   typeEquality(n1, path1, n2, path2)
   or
   n2 =
-    any(PrefixExpr pe |
-      pe.getOperatorName() = "*" and
+    any(DerefExpr pe |
       pe.getExpr() = n1 and
       path1 = TypePath::cons(TRefTypeParameter(), path2)
     )

--- a/rust/ql/lib/codeql/rust/security/AccessInvalidPointerExtensions.qll
+++ b/rust/ql/lib/codeql/rust/security/AccessInvalidPointerExtensions.qll
@@ -50,9 +50,7 @@ module AccessInvalidPointer {
    * A pointer access using the unary `*` operator.
    */
   private class DereferenceSink extends Sink {
-    DereferenceSink() {
-      exists(PrefixExpr p | p.getOperatorName() = "*" and p.getExpr() = this.asExpr().getExpr())
-    }
+    DereferenceSink() { exists(DerefExpr p | p.getExpr() = this.asExpr().getExpr()) }
   }
 
   /**

--- a/rust/ql/lib/rust.qll
+++ b/rust/ql/lib/rust.qll
@@ -6,6 +6,7 @@ import codeql.files.FileSystem
 import codeql.rust.elements.Operation
 import codeql.rust.elements.ArithmeticOperation
 import codeql.rust.elements.AssignmentOperation
+import codeql.rust.elements.BitwiseOperation
 import codeql.rust.elements.ComparisonOperation
 import codeql.rust.elements.LiteralExprExt
 import codeql.rust.elements.LogicalOperation

--- a/rust/ql/lib/rust.qll
+++ b/rust/ql/lib/rust.qll
@@ -8,6 +8,7 @@ import codeql.rust.elements.ArithmeticOperation
 import codeql.rust.elements.AssignmentOperation
 import codeql.rust.elements.BitwiseOperation
 import codeql.rust.elements.ComparisonOperation
+import codeql.rust.elements.DerefExpr
 import codeql.rust.elements.LiteralExprExt
 import codeql.rust.elements.LogicalOperation
 import codeql.rust.elements.AsyncBlockExpr

--- a/rust/ql/lib/rust.qll
+++ b/rust/ql/lib/rust.qll
@@ -4,6 +4,7 @@ import codeql.rust.elements
 import codeql.Locations
 import codeql.files.FileSystem
 import codeql.rust.elements.Operation
+import codeql.rust.elements.ArithmeticOperation
 import codeql.rust.elements.AssignmentOperation
 import codeql.rust.elements.ComparisonOperation
 import codeql.rust.elements.LiteralExprExt

--- a/rust/ql/test/library-tests/operations/Operations.ql
+++ b/rust/ql/test/library-tests/operations/Operations.ql
@@ -39,6 +39,12 @@ string describe(Expr op) {
   op instanceof AssignArithmeticOperation and result = "AssignArithmeticOperation"
   or
   op instanceof PrefixArithmeticOperation and result = "PrefixArithmeticOperation"
+  or
+  op instanceof BitwiseOperation and result = "BitwiseOperation"
+  or
+  op instanceof BinaryBitwiseOperation and result = "BinaryBitwiseOperation"
+  or
+  op instanceof AssignBitwiseOperation and result = "AssignBitwiseOperation"
 }
 
 module OperationsTest implements TestSig {

--- a/rust/ql/test/library-tests/operations/Operations.ql
+++ b/rust/ql/test/library-tests/operations/Operations.ql
@@ -31,6 +31,14 @@ string describe(Expr op) {
   op instanceof LessOrEqualsOperation and result = "LessOrEqualsOperation"
   or
   op instanceof GreaterOrEqualsOperation and result = "GreaterOrEqualsOperation"
+  or
+  op instanceof ArithmeticOperation and result = "ArithmeticOperation"
+  or
+  op instanceof BinaryArithmeticOperation and result = "BinaryArithmeticOperation"
+  or
+  op instanceof AssignArithmeticOperation and result = "AssignArithmeticOperation"
+  or
+  op instanceof PrefixArithmeticOperation and result = "PrefixArithmeticOperation"
 }
 
 module OperationsTest implements TestSig {

--- a/rust/ql/test/library-tests/operations/Operations.ql
+++ b/rust/ql/test/library-tests/operations/Operations.ql
@@ -45,6 +45,8 @@ string describe(Expr op) {
   op instanceof BinaryBitwiseOperation and result = "BinaryBitwiseOperation"
   or
   op instanceof AssignBitwiseOperation and result = "AssignBitwiseOperation"
+  or
+  op instanceof DerefExpr and result = "DerefExpr"
 }
 
 module OperationsTest implements TestSig {

--- a/rust/ql/test/library-tests/operations/test.rs
+++ b/rust/ql/test/library-tests/operations/test.rs
@@ -37,16 +37,16 @@ fn test_operations(
 	!a; // $ Operation Op=! Operands=1 PrefixExpr LogicalOperation
 
 	// bitwise operations
-	x & y; // $ Operation Op=& Operands=2 BinaryExpr
-	x | y; // $ Operation Op=| Operands=2 BinaryExpr
-	x ^ y; // $ Operation Op=^ Operands=2 BinaryExpr
-	x << y; // $ Operation Op=<< Operands=2 BinaryExpr
-	x >> y; // $ Operation Op=>> Operands=2 BinaryExpr
-	x &= y; // $ Operation Op=&= Operands=2 AssignmentOperation BinaryExpr
-	x |= y; // $ Operation Op=|= Operands=2 AssignmentOperation BinaryExpr
-	x ^= y; // $ Operation Op=^= Operands=2 AssignmentOperation BinaryExpr
-	x <<= y; // $ Operation Op=<<= Operands=2 AssignmentOperation BinaryExpr
-	x >>= y; // $ Operation Op=>>= Operands=2 AssignmentOperation BinaryExpr
+	x & y; // $ Operation Op=& Operands=2 BinaryExpr BitwiseOperation BinaryBitwiseOperation
+	x | y; // $ Operation Op=| Operands=2 BinaryExpr BitwiseOperation BinaryBitwiseOperation
+	x ^ y; // $ Operation Op=^ Operands=2 BinaryExpr BitwiseOperation BinaryBitwiseOperation
+	x << y; // $ Operation Op=<< Operands=2 BinaryExpr BitwiseOperation BinaryBitwiseOperation
+	x >> y; // $ Operation Op=>> Operands=2 BinaryExpr BitwiseOperation BinaryBitwiseOperation
+	x &= y; // $ Operation Op=&= Operands=2 AssignmentOperation BinaryExpr BitwiseOperation AssignBitwiseOperation
+	x |= y; // $ Operation Op=|= Operands=2 AssignmentOperation BinaryExpr BitwiseOperation AssignBitwiseOperation
+	x ^= y; // $ Operation Op=^= Operands=2 AssignmentOperation BinaryExpr BitwiseOperation AssignBitwiseOperation
+	x <<= y; // $ Operation Op=<<= Operands=2 AssignmentOperation BinaryExpr BitwiseOperation AssignBitwiseOperation
+	x >>= y; // $ Operation Op=>>= Operands=2 AssignmentOperation BinaryExpr BitwiseOperation AssignBitwiseOperation
 
 	// miscellaneous expressions that might be operations
 	*ptr; // $ Operation Op=* Operands=1 PrefixExpr

--- a/rust/ql/test/library-tests/operations/test.rs
+++ b/rust/ql/test/library-tests/operations/test.rs
@@ -49,7 +49,7 @@ fn test_operations(
 	x >>= y; // $ Operation Op=>>= Operands=2 AssignmentOperation BinaryExpr BitwiseOperation AssignBitwiseOperation
 
 	// miscellaneous expressions that might be operations
-	*ptr; // $ Operation Op=* Operands=1 PrefixExpr
+	*ptr; // $ Operation Op=* Operands=1 PrefixExpr DerefExpr
 	&x; // $ RefExpr
 	res?;
 

--- a/rust/ql/test/library-tests/operations/test.rs
+++ b/rust/ql/test/library-tests/operations/test.rs
@@ -19,17 +19,17 @@ fn test_operations(
 	x >= y; // $ Operation Op=>= Operands=2 BinaryExpr ComparisonOperation RelationalOperation GreaterOrEqualsOperation Greater=x Lesser=y
 
 	// arithmetic operations
-	x + y; // $ Operation Op=+ Operands=2 BinaryExpr
-	x - y; // $ Operation Op=- Operands=2 BinaryExpr
-	x * y; // $ Operation Op=* Operands=2 BinaryExpr
-	x / y; // $ Operation Op=/ Operands=2 BinaryExpr
-	x % y; // $ Operation Op=% Operands=2 BinaryExpr
-	x += y; // $ Operation Op=+= Operands=2 AssignmentOperation BinaryExpr
-	x -= y; // $ Operation Op=-= Operands=2 AssignmentOperation BinaryExpr
-	x *= y; // $ Operation Op=*= Operands=2 AssignmentOperation BinaryExpr
-	x /= y; // $ Operation Op=/= Operands=2 AssignmentOperation BinaryExpr
-	x %= y; // $ Operation Op=%= Operands=2 AssignmentOperation BinaryExpr
-	-x; // $ Operation Op=- Operands=1 PrefixExpr
+	x + y; // $ Operation Op=+ Operands=2 BinaryExpr ArithmeticOperation BinaryArithmeticOperation
+	x - y; // $ Operation Op=- Operands=2 BinaryExpr ArithmeticOperation BinaryArithmeticOperation
+	x * y; // $ Operation Op=* Operands=2 BinaryExpr ArithmeticOperation BinaryArithmeticOperation
+	x / y; // $ Operation Op=/ Operands=2 BinaryExpr ArithmeticOperation BinaryArithmeticOperation
+	x % y; // $ Operation Op=% Operands=2 BinaryExpr ArithmeticOperation BinaryArithmeticOperation
+	x += y; // $ Operation Op=+= Operands=2 AssignmentOperation BinaryExpr ArithmeticOperation AssignArithmeticOperation
+	x -= y; // $ Operation Op=-= Operands=2 AssignmentOperation BinaryExpr ArithmeticOperation AssignArithmeticOperation
+	x *= y; // $ Operation Op=*= Operands=2 AssignmentOperation BinaryExpr ArithmeticOperation AssignArithmeticOperation
+	x /= y; // $ Operation Op=/= Operands=2 AssignmentOperation BinaryExpr ArithmeticOperation AssignArithmeticOperation
+	x %= y; // $ Operation Op=%= Operands=2 AssignmentOperation BinaryExpr ArithmeticOperation AssignArithmeticOperation
+	-x; // $ Operation Op=- Operands=1 PrefixExpr ArithmeticOperation PrefixArithmeticOperation
 
 	// logical operations
 	a && b; // $ Operation Op=&& Operands=2 BinaryExpr LogicalOperation

--- a/rust/ql/test/library-tests/operations/test.rs
+++ b/rust/ql/test/library-tests/operations/test.rs
@@ -50,7 +50,7 @@ fn test_operations(
 
 	// miscellaneous expressions that might be operations
 	*ptr; // $ Operation Op=* Operands=1 PrefixExpr DerefExpr
-	&x; // $ RefExpr
+	&x; // $ Operation Op=& Operands=1 RefExpr MISSING: PrefixExpr
 	res?;
 
 	return Ok(());


### PR DESCRIPTION
Add more Operation subclasses - `ArithmeticOperation`, `BitwiseOperation`, `DerefExpr`.  Follows on from https://github.com/github/codeql/pull/19535, but I've kept these ones a bit simpler as they're not currently used (except for `DerefExpr` which I found several uses for).  I feel we should have these concepts, like other languages we support, rather than conspicuous gaps.