### PR TITLE
SSA: Distinguish between has and controls branch edge.

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -1903,6 +1903,10 @@ module IteratorFlow {
     predicate allowFlowIntoUncertainDef(IteratorSsa::UncertainWriteDefinition def) { any() }
 
     class Guard extends Void {
+      predicate hasBranchEdge(SsaInput::BasicBlock bb1, SsaInput::BasicBlock bb2, boolean branch) {
+        none()
+      }
+
       predicate controlsBranchEdge(
         SsaInput::BasicBlock bb1, SsaInput::BasicBlock bb2, boolean branch
       ) {

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
@@ -991,12 +991,16 @@ private module DataFlowIntegrationInput implements SsaImpl::DataFlowIntegrationI
   class Guard instanceof IRGuards::IRGuardCondition {
     string toString() { result = super.toString() }
 
-    predicate controlsBranchEdge(SsaInput::BasicBlock bb1, SsaInput::BasicBlock bb2, boolean branch) {
+    predicate hasBranchEdge(SsaInput::BasicBlock bb1, SsaInput::BasicBlock bb2, boolean branch) {
       exists(EdgeKind kind |
         super.getBlock() = bb1 and
         kind = getConditionalEdge(branch) and
         bb1.getSuccessor(kind) = bb2
       )
+    }
+
+    predicate controlsBranchEdge(SsaInput::BasicBlock bb1, SsaInput::BasicBlock bb2, boolean branch) {
+      this.hasBranchEdge(bb1, bb2, branch)
     }
   }
 

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/SsaImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/SsaImpl.qll
@@ -1044,16 +1044,24 @@ private module DataFlowIntegrationInput implements Impl::DataFlowIntegrationInpu
 
   class Guard extends Guards::Guard {
     /**
-     * Holds if the control flow branching from `bb1` is dependent on this guard,
-     * and that the edge from `bb1` to `bb2` corresponds to the evaluation of this
-     * guard to `branch`.
+     * Holds if the evaluation of this guard to `branch` corresponds to the edge
+     * from `bb1` to `bb2`.
      */
-    predicate controlsBranchEdge(BasicBlock bb1, BasicBlock bb2, boolean branch) {
+    predicate hasBranchEdge(BasicBlock bb1, BasicBlock bb2, boolean branch) {
       exists(ControlFlow::SuccessorTypes::ConditionalSuccessor s |
         this.getAControlFlowNode() = bb1.getLastNode() and
         bb2 = bb1.getASuccessorByType(s) and
         s.getValue() = branch
       )
+    }
+
+    /**
+     * Holds if this guard evaluating to `branch` controls the control-flow
+     * branch edge from `bb1` to `bb2`. That is, following the edge from
+     * `bb1` to `bb2` implies that this guard evaluated to `branch`.
+     */
+    predicate controlsBranchEdge(BasicBlock bb1, BasicBlock bb2, boolean branch) {
+      this.hasBranchEdge(bb1, bb2, branch)
     }
   }
 

--- a/java/ql/lib/semmle/code/java/controlflow/Guards.qll
+++ b/java/ql/lib/semmle/code/java/controlflow/Guards.qll
@@ -273,6 +273,15 @@ class Guard extends ExprParent {
   }
 
   /**
+   * Holds if this guard evaluating to `branch` controls the control-flow
+   * branch edge from `bb1` to `bb2`. That is, following the edge from
+   * `bb1` to `bb2` implies that this guard evaluated to `branch`.
+   */
+  predicate controlsBranchEdge(BasicBlock bb1, BasicBlock bb2, boolean branch) {
+    guardControlsBranchEdge_v3(this, bb1, bb2, branch)
+  }
+
+  /**
    * Holds if this guard evaluating to `branch` directly or indirectly controls
    * the block `controlled`. That is, the evaluation of `controlled` is
    * dominated by this guard evaluating to `branch`.
@@ -347,6 +356,18 @@ private predicate guardControls_v3(Guard guard, BasicBlock controlled, boolean b
   or
   exists(Guard g, boolean b |
     guardControls_v3(g, controlled, b) and
+    implies_v3(g, b, guard, branch)
+  )
+}
+
+pragma[nomagic]
+private predicate guardControlsBranchEdge_v3(
+  Guard guard, BasicBlock bb1, BasicBlock bb2, boolean branch
+) {
+  guard.hasBranchEdge(bb1, bb2, branch)
+  or
+  exists(Guard g, boolean b |
+    guardControlsBranchEdge_v3(g, bb1, bb2, b) and
     implies_v3(g, b, guard, branch)
   )
 }

--- a/java/ql/lib/semmle/code/java/dataflow/internal/SsaImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/SsaImpl.qll
@@ -654,16 +654,7 @@ private module DataFlowIntegrationInput implements Impl::DataFlowIntegrationInpu
     def instanceof SsaUncertainImplicitUpdate
   }
 
-  class Guard extends Guards::Guard {
-    /**
-     * Holds if the control flow branching from `bb1` is dependent on this guard,
-     * and that the edge from `bb1` to `bb2` corresponds to the evaluation of this
-     * guard to `branch`.
-     */
-    predicate controlsBranchEdge(BasicBlock bb1, BasicBlock bb2, boolean branch) {
-      super.hasBranchEdge(bb1, bb2, branch)
-    }
-  }
+  class Guard = Guards::Guard;
 
   /** Holds if the guard `guard` directly controls block `bb` upon evaluating to `branch`. */
   predicate guardDirectlyControlsBlock(Guard guard, BasicBlock bb, boolean branch) {

--- a/javascript/ql/lib/semmle/javascript/dataflow/internal/sharedlib/Ssa.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/internal/sharedlib/Ssa.qll
@@ -75,17 +75,25 @@ module SsaDataflowInput implements DataFlowIntegrationInputSig {
     Guard() { this = any(js::ConditionGuardNode g).getTest() }
 
     /**
-     * Holds if the control flow branching from `bb1` is dependent on this guard,
-     * and that the edge from `bb1` to `bb2` corresponds to the evaluation of this
-     * guard to `branch`.
+     * Holds if the evaluation of this guard to `branch` corresponds to the edge
+     * from `bb1` to `bb2`.
      */
-    predicate controlsBranchEdge(js::BasicBlock bb1, js::BasicBlock bb2, boolean branch) {
+    predicate hasBranchEdge(js::BasicBlock bb1, js::BasicBlock bb2, boolean branch) {
       exists(js::ConditionGuardNode g |
         g.getTest() = this and
         bb1 = this.getBasicBlock() and
         bb2 = g.getBasicBlock() and
         branch = g.getOutcome()
       )
+    }
+
+    /**
+     * Holds if this guard evaluating to `branch` controls the control-flow
+     * branch edge from `bb1` to `bb2`. That is, following the edge from
+     * `bb1` to `bb2` implies that this guard evaluated to `branch`.
+     */
+    predicate controlsBranchEdge(js::BasicBlock bb1, js::BasicBlock bb2, boolean branch) {
+      this.hasBranchEdge(bb1, bb2, branch)
     }
   }
 

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/SsaImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/SsaImpl.qll
@@ -484,16 +484,24 @@ private module DataFlowIntegrationInput implements Impl::DataFlowIntegrationInpu
 
   class Guard extends Cfg::CfgNodes::AstCfgNode {
     /**
-     * Holds if the control flow branching from `bb1` is dependent on this guard,
-     * and that the edge from `bb1` to `bb2` corresponds to the evaluation of this
-     * guard to `branch`.
+     * Holds if the evaluation of this guard to `branch` corresponds to the edge
+     * from `bb1` to `bb2`.
      */
-    predicate controlsBranchEdge(SsaInput::BasicBlock bb1, SsaInput::BasicBlock bb2, boolean branch) {
+    predicate hasBranchEdge(SsaInput::BasicBlock bb1, SsaInput::BasicBlock bb2, boolean branch) {
       exists(Cfg::SuccessorTypes::ConditionalSuccessor s |
         this.getBasicBlock() = bb1 and
         bb2 = bb1.getASuccessor(s) and
         s.getValue() = branch
       )
+    }
+
+    /**
+     * Holds if this guard evaluating to `branch` controls the control-flow
+     * branch edge from `bb1` to `bb2`. That is, following the edge from
+     * `bb1` to `bb2` implies that this guard evaluated to `branch`.
+     */
+    predicate controlsBranchEdge(SsaInput::BasicBlock bb1, SsaInput::BasicBlock bb2, boolean branch) {
+      this.hasBranchEdge(bb1, bb2, branch)
     }
   }
 

--- a/rust/ql/lib/codeql/rust/dataflow/internal/SsaImpl.qll
+++ b/rust/ql/lib/codeql/rust/dataflow/internal/SsaImpl.qll
@@ -363,16 +363,24 @@ private module DataFlowIntegrationInput implements Impl::DataFlowIntegrationInpu
 
   class Guard extends CfgNodes::AstCfgNode {
     /**
-     * Holds if the control flow branching from `bb1` is dependent on this guard,
-     * and that the edge from `bb1` to `bb2` corresponds to the evaluation of this
-     * guard to `branch`.
+     * Holds if the evaluation of this guard to `branch` corresponds to the edge
+     * from `bb1` to `bb2`.
      */
-    predicate controlsBranchEdge(SsaInput::BasicBlock bb1, SsaInput::BasicBlock bb2, boolean branch) {
+    predicate hasBranchEdge(SsaInput::BasicBlock bb1, SsaInput::BasicBlock bb2, boolean branch) {
       exists(Cfg::ConditionalSuccessor s |
         this = bb1.getANode() and
         bb2 = bb1.getASuccessor(s) and
         s.getValue() = branch
       )
+    }
+
+    /**
+     * Holds if this guard evaluating to `branch` controls the control-flow
+     * branch edge from `bb1` to `bb2`. That is, following the edge from
+     * `bb1` to `bb2` implies that this guard evaluated to `branch`.
+     */
+    predicate controlsBranchEdge(SsaInput::BasicBlock bb1, SsaInput::BasicBlock bb2, boolean branch) {
+      this.hasBranchEdge(bb1, bb2, branch)
     }
   }
 

--- a/shared/dataflow/codeql/dataflow/VariableCapture.qll
+++ b/shared/dataflow/codeql/dataflow/VariableCapture.qll
@@ -732,6 +732,8 @@ module Flow<LocationSig Location, InputSig<Location> Input> implements OutputSig
     }
 
     class Guard extends Void {
+      predicate hasBranchEdge(BasicBlock bb1, BasicBlock bb2, boolean branch) { none() }
+
       predicate controlsBranchEdge(BasicBlock bb1, BasicBlock bb2, boolean branch) { none() }
     }
 

--- a/shared/ssa/change-notes/2025-05-23-guards-interface.md
+++ b/shared/ssa/change-notes/2025-05-23-guards-interface.md
@@ -1,0 +1,4 @@
+---
+category: breaking
+---
+* Adjusted the Guards interface in the SSA data flow integration to distinguish `hasBranchEdge` from `controlsBranchEdge`. Any breakage can be fixed by implementing one with the other as a reasonable fallback solution.

--- a/shared/ssa/codeql/ssa/Ssa.qll
+++ b/shared/ssa/codeql/ssa/Ssa.qll
@@ -1579,6 +1579,14 @@ module Make<LocationSig Location, InputSig<Location> Input> {
        * Holds if this guard evaluating to `branch` controls the control-flow
        * branch edge from `bb1` to `bb2`. That is, following the edge from
        * `bb1` to `bb2` implies that this guard evaluated to `branch`.
+       *
+       * This predicate differs from `hasBranchEdge` in that it also covers
+       * indirect guards, such as:
+       * ```
+       * b = guard;
+       * ...
+       * if (b) { ... }
+       * ```
        */
       predicate controlsBranchEdge(BasicBlock bb1, BasicBlock bb2, boolean branch);
     }

--- a/shared/ssa/codeql/ssa/Ssa.qll
+++ b/shared/ssa/codeql/ssa/Ssa.qll
@@ -1570,9 +1570,15 @@ module Make<LocationSig Location, InputSig<Location> Input> {
       string toString();
 
       /**
-       * Holds if the control flow branching from `bb1` is dependent on this guard,
-       * and that the edge from `bb1` to `bb2` corresponds to the evaluation of this
-       * guard to `branch`.
+       * Holds if the evaluation of this guard to `branch` corresponds to the edge
+       * from `bb1` to `bb2`.
+       */
+      predicate hasBranchEdge(BasicBlock bb1, BasicBlock bb2, boolean branch);
+
+      /**
+       * Holds if this guard evaluating to `branch` controls the control-flow
+       * branch edge from `bb1` to `bb2`. That is, following the edge from
+       * `bb1` to `bb2` implies that this guard evaluated to `branch`.
        */
       predicate controlsBranchEdge(BasicBlock bb1, BasicBlock bb2, boolean branch);
     }
@@ -1667,7 +1673,7 @@ module Make<LocationSig Location, InputSig<Location> Input> {
       (
         // The input node is relevant either if it sits directly on a branch
         // edge for a guard,
-        exists(DfInput::Guard g | g.controlsBranchEdge(input, phi.getBasicBlock(), _))
+        exists(DfInput::Guard g | g.hasBranchEdge(input, phi.getBasicBlock(), _))
         or
         // or if the unique predecessor is not an equivalent substitute in
         // terms of being controlled by the same guards.


### PR DESCRIPTION
For languages without a guards implication logic, `hasBranchEdge` and `controlsBranchEdge` is the same thing, but libraries like SSA should distinguish between them. This _might_ theoretically improve barrier guards a bit for Java, but more importantly this prepares us a bit for the introduction of a shared Guards library.