### PR TITLE
Rangeanalysis: Simplify Guards integration.

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/SemanticExprSpecific.qll
+++ b/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/SemanticExprSpecific.qll
@@ -264,10 +264,6 @@ module SemanticExprConfig {
 
   Guard comparisonGuard(Expr e) { getSemanticExpr(result) = e }
 
-  predicate implies_v2(Guard g1, boolean b1, Guard g2, boolean b2) {
-    none() // TODO
-  }
-
   /** Gets the expression associated with `instr`. */
   SemExpr getSemanticExpr(IR::Instruction instr) { result = instr }
 }

--- a/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/SemanticGuard.qll
+++ b/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/SemanticGuard.qll
@@ -18,21 +18,17 @@ class SemGuard instanceof Specific::Guard {
     Specific::equalityGuard(this, e1, e2, polarity)
   }
 
-  final predicate directlyControls(SemBasicBlock controlled, boolean branch) {
+  final predicate controls(SemBasicBlock controlled, boolean branch) {
     Specific::guardDirectlyControlsBlock(this, controlled, branch)
   }
 
-  final predicate hasBranchEdge(SemBasicBlock bb1, SemBasicBlock bb2, boolean branch) {
+  final predicate controlsBranchEdge(SemBasicBlock bb1, SemBasicBlock bb2, boolean branch) {
     Specific::guardHasBranchEdge(this, bb1, bb2, branch)
   }
 
   final SemBasicBlock getBasicBlock() { result = block }
 
   final SemExpr asExpr() { result = Specific::getGuardAsExpr(this) }
-}
-
-predicate semImplies_v2(SemGuard g1, boolean b1, SemGuard g2, boolean b2) {
-  Specific::implies_v2(g1, b1, g2, b2)
 }
 
 SemGuard semGetComparisonGuard(SemRelationalExpr e) { result = Specific::comparisonGuard(e) }

--- a/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/analysis/RangeAnalysisImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/analysis/RangeAnalysisImpl.qll
@@ -77,8 +77,6 @@ module Sem implements Semantic<SemLocation> {
 
   class Guard = SemGuard;
 
-  predicate implies_v2 = semImplies_v2/4;
-
   class Type = SemType;
 
   class IntegerType = SemIntegerType;

--- a/java/ql/lib/semmle/code/java/dataflow/ModulusAnalysis.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/ModulusAnalysis.qll
@@ -17,7 +17,7 @@ private predicate valueFlowStepSsa(SsaVariable v, SsaReadPosition pos, Expr e, i
   exists(Guard guard, boolean testIsTrue |
     pos.hasReadOfVar(v) and
     guard = eqFlowCond(v, e, delta, true, testIsTrue) and
-    guardDirectlyControlsSsaRead(guard, pos, testIsTrue)
+    guardControlsSsaRead(guard, pos, testIsTrue)
   )
 }
 

--- a/java/ql/lib/semmle/code/java/dataflow/RangeAnalysis.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/RangeAnalysis.qll
@@ -219,14 +219,8 @@ module Sem implements Semantic<Location> {
 
   int getBlockId1(BasicBlock bb) { idOf(bb, result) }
 
-  final private class FinalGuard = GL::Guard;
-
-  class Guard extends FinalGuard {
+  class Guard extends GL::Guard_v2 {
     Expr asExpr() { result = this }
-  }
-
-  predicate implies_v2(Guard g1, boolean b1, Guard g2, boolean b2) {
-    GL::implies_v2(g1, b1, g2, b2)
   }
 
   class Type = J::Type;

--- a/java/ql/lib/semmle/code/java/dataflow/RangeUtils.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/RangeUtils.qll
@@ -19,8 +19,6 @@ predicate ssaUpdateStep = U::ssaUpdateStep/3;
 
 predicate valueFlowStep = U::valueFlowStep/3;
 
-predicate guardDirectlyControlsSsaRead = U::guardDirectlyControlsSsaRead/3;
-
 predicate guardControlsSsaRead = U::guardControlsSsaRead/3;
 
 predicate eqFlowCond = U::eqFlowCond/5;

--- a/java/ql/lib/semmle/code/java/dataflow/internal/rangeanalysis/ModulusAnalysisSpecific.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/rangeanalysis/ModulusAnalysisSpecific.qll
@@ -4,7 +4,6 @@ module Private {
   private import semmle.code.java.dataflow.RangeUtils as RU
   private import semmle.code.java.controlflow.Guards as G
   private import semmle.code.java.controlflow.BasicBlocks as BB
-  private import semmle.code.java.controlflow.internal.GuardsLogic as GL
   private import SsaReadPositionCommon
 
   class BasicBlock = BB::BasicBlock;
@@ -15,7 +14,7 @@ module Private {
 
   class Expr = J::Expr;
 
-  class Guard = G::Guard;
+  class Guard = G::Guard_v2;
 
   class ConstantIntegerExpr = RU::ConstantIntegerExpr;
 
@@ -102,28 +101,16 @@ module Private {
   }
 
   /**
-   * Holds if `guard` directly controls the position `controlled` with the
-   * value `testIsTrue`.
-   */
-  pragma[nomagic]
-  predicate guardDirectlyControlsSsaRead(Guard guard, SsaReadPosition controlled, boolean testIsTrue) {
-    guard.directlyControls(controlled.(SsaReadPositionBlock).getBlock(), testIsTrue)
-    or
-    exists(SsaReadPositionPhiInputEdge controlledEdge | controlledEdge = controlled |
-      guard.directlyControls(controlledEdge.getOrigBlock(), testIsTrue) or
-      guard.hasBranchEdge(controlledEdge.getOrigBlock(), controlledEdge.getPhiBlock(), testIsTrue)
-    )
-  }
-
-  /**
    * Holds if `guard` controls the position `controlled` with the value `testIsTrue`.
    */
   predicate guardControlsSsaRead(Guard guard, SsaReadPosition controlled, boolean testIsTrue) {
-    guardDirectlyControlsSsaRead(guard, controlled, testIsTrue)
+    guard.controls(controlled.(SsaReadPositionBlock).getBlock(), testIsTrue)
     or
-    exists(Guard guard0, boolean testIsTrue0 |
-      GL::implies_v2(guard0, testIsTrue0, guard, testIsTrue) and
-      guardControlsSsaRead(guard0, controlled, testIsTrue0)
+    exists(SsaReadPositionPhiInputEdge controlledEdge | controlledEdge = controlled |
+      guard.controls(controlledEdge.getOrigBlock(), testIsTrue) or
+      guard
+          .controlsBranchEdge(controlledEdge.getOrigBlock(), controlledEdge.getPhiBlock(),
+            testIsTrue)
     )
   }
 

--- a/java/ql/lib/semmle/code/java/dataflow/internal/rangeanalysis/SignAnalysisSpecific.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/rangeanalysis/SignAnalysisSpecific.qll
@@ -7,13 +7,12 @@ module Private {
   private import semmle.code.java.dataflow.SSA as Ssa
   private import semmle.code.java.controlflow.Guards as G
   private import SsaReadPositionCommon
-  private import semmle.code.java.controlflow.internal.GuardsLogic as GL
   private import Sign
   import Impl
 
   class ConstantIntegerExpr = RU::ConstantIntegerExpr;
 
-  class Guard = G::Guard;
+  class Guard = G::Guard_v2;
 
   class SsaVariable = Ssa::SsaVariable;
 
@@ -171,30 +170,16 @@ module Private {
   predicate ssaRead = RU::ssaRead/2;
 
   /**
-   * Holds if `guard` directly controls the position `controlled` with the
-   * value `testIsTrue`.
-   */
-  pragma[nomagic]
-  private predicate guardDirectlyControlsSsaRead(
-    Guard guard, SsaReadPosition controlled, boolean testIsTrue
-  ) {
-    guard.directlyControls(controlled.(SsaReadPositionBlock).getBlock(), testIsTrue)
-    or
-    exists(SsaReadPositionPhiInputEdge controlledEdge | controlledEdge = controlled |
-      guard.directlyControls(controlledEdge.getOrigBlock(), testIsTrue) or
-      guard.hasBranchEdge(controlledEdge.getOrigBlock(), controlledEdge.getPhiBlock(), testIsTrue)
-    )
-  }
-
-  /**
    * Holds if `guard` controls the position `controlled` with the value `testIsTrue`.
    */
   predicate guardControlsSsaRead(Guard guard, SsaReadPosition controlled, boolean testIsTrue) {
-    guardDirectlyControlsSsaRead(guard, controlled, testIsTrue)
+    guard.controls(controlled.(SsaReadPositionBlock).getBlock(), testIsTrue)
     or
-    exists(Guard guard0, boolean testIsTrue0 |
-      GL::implies_v2(guard0, testIsTrue0, guard, testIsTrue) and
-      guardControlsSsaRead(guard0, controlled, testIsTrue0)
+    exists(SsaReadPositionPhiInputEdge controlledEdge | controlledEdge = controlled |
+      guard.controls(controlledEdge.getOrigBlock(), testIsTrue) or
+      guard
+          .controlsBranchEdge(controlledEdge.getOrigBlock(), controlledEdge.getPhiBlock(),
+            testIsTrue)
     )
   }
 }

--- a/shared/rangeanalysis/codeql/rangeanalysis/ModulusAnalysis.qll
+++ b/shared/rangeanalysis/codeql/rangeanalysis/ModulusAnalysis.qll
@@ -34,7 +34,7 @@ module ModulusAnalysis<
     exists(Sem::Guard guard, boolean testIsTrue |
       hasReadOfVarInlineLate(pos, v) and
       guard = eqFlowCond(v, e, D::fromInt(delta), true, testIsTrue) and
-      guardDirectlyControlsSsaRead(guard, pos, testIsTrue)
+      guardControlsSsaRead(guard, pos, testIsTrue)
     )
   }
 

--- a/shared/rangeanalysis/codeql/rangeanalysis/RangeAnalysis.qll
+++ b/shared/rangeanalysis/codeql/rangeanalysis/RangeAnalysis.qll
@@ -182,21 +182,6 @@ signature module Semantic<LocationSig Location> {
     Expr asExpr();
 
     /**
-     * Holds if the guard directly controls a given basic block. For example in
-     * the following code, the guard `(x > y)` directly controls the block
-     * beneath it:
-     * ```
-     * if (x > y)
-     * {
-     *   Console.WriteLine("x is greater than y");
-     * }
-     * ```
-     * `branch` indicates whether the basic block is entered when the guard
-     * evaluates to `true` or when it evaluates to `false`.
-     */
-    predicate directlyControls(BasicBlock controlled, boolean branch);
-
-    /**
      * Holds if this guard is an equality test between `e1` and `e2`. If the
      * test is negated, that is `!=`, then `polarity` is false, otherwise
      * `polarity` is true.
@@ -204,24 +189,19 @@ signature module Semantic<LocationSig Location> {
     predicate isEquality(Expr e1, Expr e2, boolean polarity);
 
     /**
-     * Holds if there is a branch edge between two basic blocks. For example
-     * in the following C code, there are two branch edges from the basic block
-     * containing the condition `(x > y)` to the beginnings of the true and
-     * false blocks that follow:
-     * ```
-     * if (x > y) {
-     *   printf("x is greater than y\n");
-     * } else {
-     *   printf("x is not greater than y\n");
-     * }
-     * ```
-     * `branch` indicates whether the second basic block is the one entered
-     * when the guard evaluates to `true` or when it evaluates to `false`.
+     * Holds if this guard evaluating to `branch` controls the control-flow
+     * branch edge from `bb1` to `bb2`. That is, following the edge from
+     * `bb1` to `bb2` implies that this guard evaluated to `branch`.
      */
-    predicate hasBranchEdge(BasicBlock bb1, BasicBlock bb2, boolean branch);
-  }
+    predicate controlsBranchEdge(BasicBlock bb1, BasicBlock bb2, boolean branch);
 
-  predicate implies_v2(Guard g1, boolean b1, Guard g2, boolean b2);
+    /**
+     * Holds if this guard evaluating to `branch` directly or indirectly controls
+     * the block `controlled`. That is, the evaluation of `controlled` is
+     * dominated by this guard evaluating to `branch`.
+     */
+    predicate controls(BasicBlock controlled, boolean branch);
+  }
 
   class Type;
 
@@ -670,19 +650,14 @@ module RangeStage<
       delta = D::fromFloat(D::toFloat(d1) + d2 + d3)
     )
     or
-    exists(boolean testIsTrue0 |
-      Sem::implies_v2(result, testIsTrue, boundFlowCond(v, e, delta, upper, testIsTrue0),
-        testIsTrue0)
-    )
-    or
     result = eqFlowCond(v, e, delta, true, testIsTrue) and
     (upper = true or upper = false)
     or
-    // guard that tests whether `v2` is bounded by `e + delta + d1 - d2` and
-    // exists a guard `guardEq` such that `v = v2 - d1 + d2`.
+    // guard that tests whether `v2` is bounded by `e + delta - d` and
+    // exists a guard `guardEq` such that `v = v2 + d`.
     exists(Sem::SsaVariable v2, D::Delta oldDelta, float d |
       // equality needs to control guard
-      result.getBasicBlock() = eqSsaCondDirectlyControls(v, v2, d) and
+      result.getBasicBlock() = eqSsaCondControls(v, v2, d) and
       result = boundFlowCond(v2, e, oldDelta, upper, testIsTrue) and
       delta = D::fromFloat(D::toFloat(oldDelta) + d)
     )
@@ -692,13 +667,11 @@ module RangeStage<
    * Gets a basic block in which `v1` equals `v2 + delta`.
    */
   pragma[nomagic]
-  private Sem::BasicBlock eqSsaCondDirectlyControls(
-    Sem::SsaVariable v1, Sem::SsaVariable v2, float delta
-  ) {
+  private Sem::BasicBlock eqSsaCondControls(Sem::SsaVariable v1, Sem::SsaVariable v2, float delta) {
     exists(Sem::Guard guardEq, D::Delta d1, D::Delta d2, boolean eqIsTrue |
       guardEq = eqFlowCond(v1, ssaRead(v2, d1), d2, true, eqIsTrue) and
       delta = D::toFloat(d2) - D::toFloat(d1) and
-      guardEq.directlyControls(result, eqIsTrue)
+      guardEq.controls(result, eqIsTrue)
     )
   }
 
@@ -749,7 +722,7 @@ module RangeStage<
     exists(Sem::Guard guard, boolean testIsTrue |
       pos.hasReadOfVar(v) and
       guard = boundFlowCond(v, e, delta, upper, testIsTrue) and
-      guardDirectlyControlsSsaRead(guard, pos, testIsTrue) and
+      guardControlsSsaRead(guard, pos, testIsTrue) and
       reason = TSemCondReason(guard)
     )
   }
@@ -762,7 +735,7 @@ module RangeStage<
     exists(Sem::Guard guard, boolean testIsTrue |
       pos.hasReadOfVar(v) and
       guard = eqFlowCond(v, e, delta, false, testIsTrue) and
-      guardDirectlyControlsSsaRead(guard, pos, testIsTrue) and
+      guardControlsSsaRead(guard, pos, testIsTrue) and
       reason = TSemCondReason(guard)
     )
   }

--- a/shared/rangeanalysis/codeql/rangeanalysis/internal/RangeUtils.qll
+++ b/shared/rangeanalysis/codeql/rangeanalysis/internal/RangeUtils.qll
@@ -52,10 +52,6 @@ module MakeUtils<LocationSig Location, Semantic<Location> Lang, DeltaSig D> {
       (testIsTrue = true or testIsTrue = false) and
       eqpolarity.booleanXor(testIsTrue).booleanNot() = isEq
     )
-    or
-    exists(boolean testIsTrue0 |
-      implies_v2(result, testIsTrue, eqFlowCond(v, e, delta, isEq, testIsTrue0), testIsTrue0)
-    )
   }
 
   /**
@@ -174,28 +170,16 @@ module MakeUtils<LocationSig Location, Semantic<Location> Lang, DeltaSig D> {
   }
 
   /**
-   * Holds if `guard` directly controls the position `controlled` with the
-   * value `testIsTrue`.
-   */
-  pragma[nomagic]
-  predicate guardDirectlyControlsSsaRead(Guard guard, SsaReadPosition controlled, boolean testIsTrue) {
-    guard.directlyControls(controlled.(SsaReadPositionBlock).getBlock(), testIsTrue)
-    or
-    exists(SsaReadPositionPhiInputEdge controlledEdge | controlledEdge = controlled |
-      guard.directlyControls(controlledEdge.getOrigBlock(), testIsTrue) or
-      guard.hasBranchEdge(controlledEdge.getOrigBlock(), controlledEdge.getPhiBlock(), testIsTrue)
-    )
-  }
-
-  /**
    * Holds if `guard` controls the position `controlled` with the value `testIsTrue`.
    */
   predicate guardControlsSsaRead(Guard guard, SsaReadPosition controlled, boolean testIsTrue) {
-    guardDirectlyControlsSsaRead(guard, controlled, testIsTrue)
+    guard.controls(controlled.(SsaReadPositionBlock).getBlock(), testIsTrue)
     or
-    exists(Guard guard0, boolean testIsTrue0 |
-      implies_v2(guard0, testIsTrue0, guard, testIsTrue) and
-      guardControlsSsaRead(guard0, controlled, testIsTrue0)
+    exists(SsaReadPositionPhiInputEdge controlledEdge | controlledEdge = controlled |
+      guard.controls(controlledEdge.getOrigBlock(), testIsTrue) or
+      guard
+          .controlsBranchEdge(controlledEdge.getOrigBlock(), controlledEdge.getPhiBlock(),
+            testIsTrue)
     )
   }
 


### PR DESCRIPTION
The Range Analysis library uses the second (`_v2`) Java Guards implication logic layer. This implementation detail is leaking all over, so this PR cleans that up by changing the interface to use the controls predicates that are closed under any suitable implication logic, and Java can then simply instantiate it with the proper guards layer without requiring the range analysis to know about `implies_v2`.
A small semantic effect is that "bound reasons" are now reported as the original comparison rather than the implied guard:
```
b = x < bound; // R1
...
if (b) { // R2
  use(x); // A
}
```
The reason for the bound on `x` at `A` is now reported as `R1` instead of `R2`. I don't expect this to make much difference in practice.