### PR TITLE
Rust: Resolve function calls to traits methods

### DIFF
--- a/rust/ql/lib/codeql/rust/elements/internal/MethodCallExprImpl.qll
+++ b/rust/ql/lib/codeql/rust/elements/internal/MethodCallExprImpl.qll
@@ -14,14 +14,6 @@ private import codeql.rust.internal.TypeInference
  * be referenced directly.
  */
 module Impl {
-  private predicate isInherentImplFunction(Function f) {
-    f = any(Impl impl | not impl.hasTrait()).(ImplItemNode).getAnAssocItem()
-  }
-
-  private predicate isTraitImplFunction(Function f) {
-    f = any(Impl impl | impl.hasTrait()).(ImplItemNode).getAnAssocItem()
-  }
-
   // the following QLdoc is generated: if you need to edit it, do it in the schema file
   /**
    * A method call expression. For example:
@@ -31,38 +23,7 @@ module Impl {
    * ```
    */
   class MethodCallExpr extends Generated::MethodCallExpr {
-    private Function getStaticTargetFrom(boolean fromSource) {
-      result = resolveMethodCallExpr(this) and
-      (if result.fromSource() then fromSource = true else fromSource = false) and
-      (
-        // prioritize inherent implementation methods first
-        isInherentImplFunction(result)
-        or
-        not isInherentImplFunction(resolveMethodCallExpr(this)) and
-        (
-          // then trait implementation methods
-          isTraitImplFunction(result)
-          or
-          not isTraitImplFunction(resolveMethodCallExpr(this)) and
-          (
-            // then trait methods with default implementations
-            result.hasBody()
-            or
-            // and finally trait methods without default implementations
-            not resolveMethodCallExpr(this).hasBody()
-          )
-        )
-      )
-    }
-
-    override Function getStaticTarget() {
-      // Functions in source code also gets extracted as library code, due to
-      // this duplication we prioritize functions from source code.
-      result = this.getStaticTargetFrom(true)
-      or
-      not exists(this.getStaticTargetFrom(true)) and
-      result = this.getStaticTargetFrom(false)
-    }
+    override Function getStaticTarget() { result = resolveMethodCallTarget(this) }
 
     private string toStringPart(int index) {
       index = 0 and

--- a/rust/ql/lib/codeql/rust/internal/TypeInference.qll
+++ b/rust/ql/lib/codeql/rust/internal/TypeInference.qll
@@ -678,7 +678,7 @@ private module CallExprBaseMatchingInput implements MatchingInputSig {
     Declaration getTarget() {
       result = CallExprImpl::getResolvedFunction(this)
       or
-      result = resolveMethodCallExpr(this) // mutual recursion; resolving method calls requires resolving types and vice versa
+      result = inferMethodCallTarget(this) // mutual recursion; resolving method calls requires resolving types and vice versa
     }
   }
 
@@ -1000,6 +1000,150 @@ private StructType inferLiteralType(LiteralExpr le) {
   )
 }
 
+private module MethodCall {
+  /** An expression that calls a method. */
+  abstract private class MethodCallImpl extends Expr {
+    /** Gets the name of the method targeted. */
+    abstract string getMethodName();
+
+    /** Gets the number of arguments _excluding_ the `self` argument. */
+    abstract int getArity();
+
+    /** Gets the trait targeted by this method call, if any. */
+    Trait getTrait() { none() }
+
+    /** Gets the type of the receiver of the method call at `path`. */
+    abstract Type getTypeAt(TypePath path);
+  }
+
+  final class MethodCall = MethodCallImpl;
+
+  private class MethodCallExprMethodCall extends MethodCallImpl instanceof MethodCallExpr {
+    override string getMethodName() { result = super.getIdentifier().getText() }
+
+    override int getArity() { result = super.getArgList().getNumberOfArgs() }
+
+    pragma[nomagic]
+    override Type getTypeAt(TypePath path) {
+      exists(TypePath path0 | result = inferType(super.getReceiver(), path0) |
+        path0.isCons(TRefTypeParameter(), path)
+        or
+        not path0.isCons(TRefTypeParameter(), _) and
+        not (path0.isEmpty() and result = TRefType()) and
+        path = path0
+      )
+    }
+  }
+
+  private class CallExprMethodCall extends MethodCallImpl instanceof CallExpr {
+    TraitItemNode trait;
+    string methodName;
+    Expr receiver;
+
+    CallExprMethodCall() {
+      receiver = this.getArgList().getArg(0) and
+      exists(Path path, Function f |
+        path = this.getFunction().(PathExpr).getPath() and
+        f = resolvePath(path) and
+        f.getParamList().hasSelfParam() and
+        trait = resolvePath(path.getQualifier()) and
+        trait.getAnAssocItem() = f and
+        path.getSegment().getIdentifier().getText() = methodName
+      )
+    }
+
+    override string getMethodName() { result = methodName }
+
+    override int getArity() { result = super.getArgList().getNumberOfArgs() - 1 }
+
+    override Trait getTrait() { result = trait }
+
+    pragma[nomagic]
+    override Type getTypeAt(TypePath path) { result = inferType(receiver, path) }
+  }
+}
+
+import MethodCall
+
+/**
+ * Holds if a method for `type` with the name `name` and the arity `arity`
+ * exists in `impl`.
+ */
+private predicate methodCandidate(Type type, string name, int arity, Impl impl) {
+  type = impl.getSelfTy().(TypeMention).resolveType() and
+  exists(Function f |
+    f = impl.(ImplItemNode).getASuccessor(name) and
+    f.getParamList().hasSelfParam() and
+    arity = f.getParamList().getNumberOfParams()
+  )
+}
+
+/**
+ * Holds if a method for `type` for `trait` with the name `name` and the arity
+ * `arity` exists in `impl`.
+ */
+pragma[nomagic]
+private predicate methodCandidateTrait(Type type, Trait trait, string name, int arity, Impl impl) {
+  trait = resolvePath(impl.getTrait().(PathTypeRepr).getPath()) and
+  methodCandidate(type, name, arity, impl)
+}
+
+private module IsInstantiationOfInput implements IsInstantiationOfInputSig<MethodCall> {
+  pragma[nomagic]
+  predicate potentialInstantiationOf(MethodCall mc, TypeAbstraction impl, TypeMention constraint) {
+    exists(Type rootType, string name, int arity |
+      rootType = mc.getTypeAt(TypePath::nil()) and
+      name = mc.getMethodName() and
+      arity = mc.getArity() and
+      constraint = impl.(ImplTypeAbstraction).getSelfTy()
+    |
+      methodCandidateTrait(rootType, mc.getTrait(), name, arity, impl)
+      or
+      not exists(mc.getTrait()) and
+      methodCandidate(rootType, name, arity, impl)
+    )
+  }
+
+  predicate relevantTypeMention(TypeMention constraint) {
+    exists(Impl impl | methodCandidate(_, _, _, impl) and constraint = impl.getSelfTy())
+  }
+}
+
+bindingset[item, name]
+pragma[inline_late]
+private Function getMethodSuccessor(ItemNode item, string name) {
+  result = item.getASuccessor(name)
+}
+
+bindingset[tp, name]
+pragma[inline_late]
+private Function getTypeParameterMethod(TypeParameter tp, string name) {
+  result = getMethodSuccessor(tp.(TypeParamTypeParameter).getTypeParam(), name)
+  or
+  result = getMethodSuccessor(tp.(SelfTypeParameter).getTrait(), name)
+}
+
+/** Gets a method from an `impl` block that matches the method call `mc`. */
+private Function getMethodFromImpl(MethodCall mc) {
+  exists(Impl impl |
+    IsInstantiationOf<MethodCall, IsInstantiationOfInput>::isInstantiationOf(mc, impl, _) and
+    result = getMethodSuccessor(impl, mc.getMethodName())
+  )
+}
+
+/**
+ * Gets a method that the method call `mc` resolves to based on type inference,
+ * if any.
+ */
+private Function inferMethodCallTarget(MethodCall mc) {
+  // The method comes from an `impl` block targeting the type of the receiver.
+  result = getMethodFromImpl(mc)
+  or
+  // The type of the receiver is a type parameter and the method comes from a
+  // trait bound on the type parameter.
+  result = getTypeParameterMethod(mc.getTypeAt(TypePath::nil()), mc.getMethodName())
+}
+
 cached
 private module Cached {
   private import codeql.rust.internal.CachedStages
@@ -1026,90 +1170,47 @@ private module Cached {
     )
   }
 
-  private class ReceiverExpr extends Expr {
-    MethodCallExpr mce;
-
-    ReceiverExpr() { mce.getReceiver() = this }
-
-    string getField() { result = mce.getIdentifier().getText() }
-
-    int getNumberOfArgs() { result = mce.getArgList().getNumberOfArgs() }
-
-    pragma[nomagic]
-    Type getTypeAt(TypePath path) {
-      exists(TypePath path0 | result = inferType(this, path0) |
-        path0.isCons(TRefTypeParameter(), path)
-        or
-        not path0.isCons(TRefTypeParameter(), _) and
-        not (path0.isEmpty() and result = TRefType()) and
-        path = path0
-      )
-    }
+  private predicate isInherentImplFunction(Function f) {
+    f = any(Impl impl | not impl.hasTrait()).(ImplItemNode).getAnAssocItem()
   }
 
-  /** Holds if a method for `type` with the name `name` and the arity `arity` exists in `impl`. */
-  pragma[nomagic]
-  private predicate methodCandidate(Type type, string name, int arity, Impl impl) {
-    type = impl.getSelfTy().(TypeReprMention).resolveType() and
-    exists(Function f |
-      f = impl.(ImplItemNode).getASuccessor(name) and
-      f.getParamList().hasSelfParam() and
-      arity = f.getParamList().getNumberOfParams()
-    )
+  private predicate isTraitImplFunction(Function f) {
+    f = any(Impl impl | impl.hasTrait()).(ImplItemNode).getAnAssocItem()
   }
 
-  private module IsInstantiationOfInput implements IsInstantiationOfInputSig<ReceiverExpr> {
-    pragma[nomagic]
-    predicate potentialInstantiationOf(
-      ReceiverExpr receiver, TypeAbstraction impl, TypeMention constraint
-    ) {
-      methodCandidate(receiver.getTypeAt(TypePath::nil()), receiver.getField(),
-        receiver.getNumberOfArgs(), impl) and
-      constraint = impl.(ImplTypeAbstraction).getSelfTy()
-    }
-
-    predicate relevantTypeMention(TypeMention constraint) {
-      exists(Impl impl | methodCandidate(_, _, _, impl) and constraint = impl.getSelfTy())
-    }
-  }
-
-  bindingset[item, name]
-  pragma[inline_late]
-  private Function getMethodSuccessor(ItemNode item, string name) {
-    result = item.getASuccessor(name)
-  }
-
-  bindingset[tp, name]
-  pragma[inline_late]
-  private Function getTypeParameterMethod(TypeParameter tp, string name) {
-    result = getMethodSuccessor(tp.(TypeParamTypeParameter).getTypeParam(), name)
-    or
-    result = getMethodSuccessor(tp.(SelfTypeParameter).getTrait(), name)
-  }
-
-  /**
-   * Gets the method from an `impl` block with an implementing type that matches
-   * the type of `receiver` and with a name of the method call in which
-   * `receiver` occurs, if any.
-   */
-  private Function getMethodFromImpl(ReceiverExpr receiver) {
-    exists(Impl impl |
-      IsInstantiationOf<ReceiverExpr, IsInstantiationOfInput>::isInstantiationOf(receiver, impl, _) and
-      result = getMethodSuccessor(impl, receiver.getField())
-    )
-  }
-
-  /** Gets a method that the method call `mce` resolves to, if any. */
-  cached
-  Function resolveMethodCallExpr(MethodCallExpr mce) {
-    exists(ReceiverExpr receiver | mce.getReceiver() = receiver |
-      // The method comes from an `impl` block targeting the type of `receiver`.
-      result = getMethodFromImpl(receiver)
+  private Function resolveMethodCallTargetFrom(MethodCall mc, boolean fromSource) {
+    result = inferMethodCallTarget(mc) and
+    (if result.fromSource() then fromSource = true else fromSource = false) and
+    (
+      // prioritize inherent implementation methods first
+      isInherentImplFunction(result)
       or
-      // The type of `receiver` is a type parameter and the method comes from a
-      // trait bound on the type parameter.
-      result = getTypeParameterMethod(receiver.getTypeAt(TypePath::nil()), receiver.getField())
+      not isInherentImplFunction(inferMethodCallTarget(mc)) and
+      (
+        // then trait implementation methods
+        isTraitImplFunction(result)
+        or
+        not isTraitImplFunction(inferMethodCallTarget(mc)) and
+        (
+          // then trait methods with default implementations
+          result.hasBody()
+          or
+          // and finally trait methods without default implementations
+          not inferMethodCallTarget(mc).hasBody()
+        )
+      )
     )
+  }
+
+  /** Gets a method that the method call `mc` resolves to, if any. */
+  cached
+  Function resolveMethodCallTarget(MethodCall mc) {
+    // Functions in source code also gets extracted as library code, due to
+    // this duplication we prioritize functions from source code.
+    result = resolveMethodCallTargetFrom(mc, true)
+    or
+    not exists(resolveMethodCallTargetFrom(mc, true)) and
+    result = resolveMethodCallTargetFrom(mc, false)
   }
 
   pragma[inline]
@@ -1243,6 +1344,6 @@ private module Debug {
 
   Function debugResolveMethodCallExpr(MethodCallExpr mce) {
     mce = getRelevantLocatable() and
-    result = resolveMethodCallExpr(mce)
+    result = resolveMethodCallTarget(mce)
   }
 }

--- a/rust/ql/lib/codeql/rust/internal/TypeInference.qll
+++ b/rust/ql/lib/codeql/rust/internal/TypeInference.qll
@@ -1084,7 +1084,7 @@ private predicate methodCandidate(Type type, string name, int arity, Impl impl) 
  */
 pragma[nomagic]
 private predicate methodCandidateTrait(Type type, Trait trait, string name, int arity, Impl impl) {
-  trait = resolvePath(impl.getTrait().(PathTypeRepr).getPath()) and
+  trait = resolvePath(impl.(ImplItemNode).getTraitPath()) and
   methodCandidate(type, name, arity, impl)
 }
 

--- a/rust/ql/test/library-tests/dataflow/global/inline-flow.expected
+++ b/rust/ql/test/library-tests/dataflow/global/inline-flow.expected
@@ -92,6 +92,24 @@ edges
 | main.rs:188:9:188:9 | d [MyInt] | main.rs:189:10:189:10 | d [MyInt] | provenance |  |
 | main.rs:188:13:188:20 | a.add(...) [MyInt] | main.rs:188:9:188:9 | d [MyInt] | provenance |  |
 | main.rs:189:10:189:10 | d [MyInt] | main.rs:189:10:189:16 | d.value | provenance |  |
+| main.rs:201:18:201:21 | SelfParam [MyInt] | main.rs:201:48:203:5 | { ... } [MyInt] | provenance |  |
+| main.rs:205:26:205:37 | ...: MyInt [MyInt] | main.rs:205:49:207:5 | { ... } [MyInt] | provenance |  |
+| main.rs:211:9:211:9 | a [MyInt] | main.rs:213:49:213:49 | a [MyInt] | provenance |  |
+| main.rs:211:13:211:38 | MyInt {...} [MyInt] | main.rs:211:9:211:9 | a [MyInt] | provenance |  |
+| main.rs:211:28:211:36 | source(...) | main.rs:211:13:211:38 | MyInt {...} [MyInt] | provenance |  |
+| main.rs:213:9:213:26 | MyInt {...} [MyInt] | main.rs:213:24:213:24 | c | provenance |  |
+| main.rs:213:24:213:24 | c | main.rs:214:10:214:10 | c | provenance |  |
+| main.rs:213:30:213:53 | ...::take_self(...) [MyInt] | main.rs:213:9:213:26 | MyInt {...} [MyInt] | provenance |  |
+| main.rs:213:49:213:49 | a [MyInt] | main.rs:201:18:201:21 | SelfParam [MyInt] | provenance |  |
+| main.rs:213:49:213:49 | a [MyInt] | main.rs:213:30:213:53 | ...::take_self(...) [MyInt] | provenance |  |
+| main.rs:217:9:217:9 | b [MyInt] | main.rs:218:54:218:54 | b [MyInt] | provenance |  |
+| main.rs:217:13:217:39 | MyInt {...} [MyInt] | main.rs:217:9:217:9 | b [MyInt] | provenance |  |
+| main.rs:217:28:217:37 | source(...) | main.rs:217:13:217:39 | MyInt {...} [MyInt] | provenance |  |
+| main.rs:218:9:218:26 | MyInt {...} [MyInt] | main.rs:218:24:218:24 | c | provenance |  |
+| main.rs:218:24:218:24 | c | main.rs:219:10:219:10 | c | provenance |  |
+| main.rs:218:30:218:55 | ...::take_second(...) [MyInt] | main.rs:218:9:218:26 | MyInt {...} [MyInt] | provenance |  |
+| main.rs:218:54:218:54 | b [MyInt] | main.rs:205:26:205:37 | ...: MyInt [MyInt] | provenance |  |
+| main.rs:218:54:218:54 | b [MyInt] | main.rs:218:30:218:55 | ...::take_second(...) [MyInt] | provenance |  |
 | main.rs:227:32:231:1 | { ... } | main.rs:246:41:246:54 | async_source(...) | provenance |  |
 | main.rs:228:9:228:9 | a | main.rs:227:32:231:1 | { ... } | provenance |  |
 | main.rs:228:9:228:9 | a | main.rs:229:10:229:10 | a | provenance |  |
@@ -202,6 +220,26 @@ nodes
 | main.rs:188:13:188:20 | a.add(...) [MyInt] | semmle.label | a.add(...) [MyInt] |
 | main.rs:189:10:189:10 | d [MyInt] | semmle.label | d [MyInt] |
 | main.rs:189:10:189:16 | d.value | semmle.label | d.value |
+| main.rs:201:18:201:21 | SelfParam [MyInt] | semmle.label | SelfParam [MyInt] |
+| main.rs:201:48:203:5 | { ... } [MyInt] | semmle.label | { ... } [MyInt] |
+| main.rs:205:26:205:37 | ...: MyInt [MyInt] | semmle.label | ...: MyInt [MyInt] |
+| main.rs:205:49:207:5 | { ... } [MyInt] | semmle.label | { ... } [MyInt] |
+| main.rs:211:9:211:9 | a [MyInt] | semmle.label | a [MyInt] |
+| main.rs:211:13:211:38 | MyInt {...} [MyInt] | semmle.label | MyInt {...} [MyInt] |
+| main.rs:211:28:211:36 | source(...) | semmle.label | source(...) |
+| main.rs:213:9:213:26 | MyInt {...} [MyInt] | semmle.label | MyInt {...} [MyInt] |
+| main.rs:213:24:213:24 | c | semmle.label | c |
+| main.rs:213:30:213:53 | ...::take_self(...) [MyInt] | semmle.label | ...::take_self(...) [MyInt] |
+| main.rs:213:49:213:49 | a [MyInt] | semmle.label | a [MyInt] |
+| main.rs:214:10:214:10 | c | semmle.label | c |
+| main.rs:217:9:217:9 | b [MyInt] | semmle.label | b [MyInt] |
+| main.rs:217:13:217:39 | MyInt {...} [MyInt] | semmle.label | MyInt {...} [MyInt] |
+| main.rs:217:28:217:37 | source(...) | semmle.label | source(...) |
+| main.rs:218:9:218:26 | MyInt {...} [MyInt] | semmle.label | MyInt {...} [MyInt] |
+| main.rs:218:24:218:24 | c | semmle.label | c |
+| main.rs:218:30:218:55 | ...::take_second(...) [MyInt] | semmle.label | ...::take_second(...) [MyInt] |
+| main.rs:218:54:218:54 | b [MyInt] | semmle.label | b [MyInt] |
+| main.rs:219:10:219:10 | c | semmle.label | c |
 | main.rs:227:32:231:1 | { ... } | semmle.label | { ... } |
 | main.rs:228:9:228:9 | a | semmle.label | a |
 | main.rs:228:13:228:21 | source(...) | semmle.label | source(...) |
@@ -225,6 +263,8 @@ subpaths
 | main.rs:143:38:143:38 | a | main.rs:106:27:106:32 | ...: i64 | main.rs:106:42:112:5 | { ... } | main.rs:143:13:143:39 | ...::data_through(...) |
 | main.rs:161:24:161:33 | source(...) | main.rs:155:12:155:17 | ...: i64 | main.rs:155:28:157:5 | { ... } [MyInt] | main.rs:161:13:161:34 | ...::new(...) [MyInt] |
 | main.rs:186:9:186:9 | a [MyInt] | main.rs:169:12:169:15 | SelfParam [MyInt] | main.rs:169:42:172:5 | { ... } [MyInt] | main.rs:188:13:188:20 | a.add(...) [MyInt] |
+| main.rs:213:49:213:49 | a [MyInt] | main.rs:201:18:201:21 | SelfParam [MyInt] | main.rs:201:48:203:5 | { ... } [MyInt] | main.rs:213:30:213:53 | ...::take_self(...) [MyInt] |
+| main.rs:218:54:218:54 | b [MyInt] | main.rs:205:26:205:37 | ...: MyInt [MyInt] | main.rs:205:49:207:5 | { ... } [MyInt] | main.rs:218:30:218:55 | ...::take_second(...) [MyInt] |
 testFailures
 #select
 | main.rs:18:10:18:10 | a | main.rs:13:5:13:13 | source(...) | main.rs:18:10:18:10 | a | $@ | main.rs:13:5:13:13 | source(...) | source(...) |
@@ -241,6 +281,8 @@ testFailures
 | main.rs:144:10:144:10 | b | main.rs:142:13:142:22 | source(...) | main.rs:144:10:144:10 | b | $@ | main.rs:142:13:142:22 | source(...) | source(...) |
 | main.rs:163:10:163:10 | m | main.rs:161:24:161:33 | source(...) | main.rs:163:10:163:10 | m | $@ | main.rs:161:24:161:33 | source(...) | source(...) |
 | main.rs:189:10:189:16 | d.value | main.rs:186:28:186:36 | source(...) | main.rs:189:10:189:16 | d.value | $@ | main.rs:186:28:186:36 | source(...) | source(...) |
+| main.rs:214:10:214:10 | c | main.rs:211:28:211:36 | source(...) | main.rs:214:10:214:10 | c | $@ | main.rs:211:28:211:36 | source(...) | source(...) |
+| main.rs:219:10:219:10 | c | main.rs:217:28:217:37 | source(...) | main.rs:219:10:219:10 | c | $@ | main.rs:217:28:217:37 | source(...) | source(...) |
 | main.rs:229:10:229:10 | a | main.rs:228:13:228:21 | source(...) | main.rs:229:10:229:10 | a | $@ | main.rs:228:13:228:21 | source(...) | source(...) |
 | main.rs:239:14:239:14 | c | main.rs:238:17:238:25 | source(...) | main.rs:239:14:239:14 | c | $@ | main.rs:238:17:238:25 | source(...) | source(...) |
 | main.rs:247:10:247:10 | a | main.rs:228:13:228:21 | source(...) | main.rs:247:10:247:10 | a | $@ | main.rs:228:13:228:21 | source(...) | source(...) |

--- a/rust/ql/test/library-tests/dataflow/global/main.rs
+++ b/rust/ql/test/library-tests/dataflow/global/main.rs
@@ -211,12 +211,12 @@ fn data_through_trait_method_called_as_function() {
     let a = MyInt { value: source(8) };
     let b = MyInt { value: 2 };
     let MyInt { value: c } = MyTrait::take_self(a, b);
-    sink(c); // $ MISSING: hasValueFlow=8
+    sink(c); // $ hasValueFlow=8
 
     let a = MyInt { value: 0 };
     let b = MyInt { value: source(37) };
     let MyInt { value: c } = MyTrait::take_second(a, b);
-    sink(c); // $ MISSING: hasValueFlow=37
+    sink(c); // $ hasValueFlow=37
 
     let a = MyInt { value: 0 };
     let b = MyInt { value: source(38) };

--- a/rust/ql/test/library-tests/dataflow/global/viableCallable.expected
+++ b/rust/ql/test/library-tests/dataflow/global/viableCallable.expected
@@ -48,10 +48,13 @@
 | main.rs:188:13:188:20 | a.add(...) | main.rs:169:5:172:5 | fn add |
 | main.rs:189:5:189:17 | sink(...) | main.rs:5:1:7:1 | fn sink |
 | main.rs:211:28:211:36 | source(...) | main.rs:1:1:3:1 | fn source |
+| main.rs:213:30:213:53 | ...::take_self(...) | main.rs:201:5:203:5 | fn take_self |
 | main.rs:214:5:214:11 | sink(...) | main.rs:5:1:7:1 | fn sink |
 | main.rs:217:28:217:37 | source(...) | main.rs:1:1:3:1 | fn source |
+| main.rs:218:30:218:55 | ...::take_second(...) | main.rs:205:5:207:5 | fn take_second |
 | main.rs:219:5:219:11 | sink(...) | main.rs:5:1:7:1 | fn sink |
 | main.rs:222:28:222:37 | source(...) | main.rs:1:1:3:1 | fn source |
+| main.rs:223:30:223:53 | ...::take_self(...) | main.rs:201:5:203:5 | fn take_self |
 | main.rs:224:5:224:11 | sink(...) | main.rs:5:1:7:1 | fn sink |
 | main.rs:228:13:228:21 | source(...) | main.rs:1:1:3:1 | fn source |
 | main.rs:229:5:229:11 | sink(...) | main.rs:5:1:7:1 | fn sink |

--- a/rust/ql/test/library-tests/type-inference/main.rs
+++ b/rust/ql/test/library-tests/type-inference/main.rs
@@ -90,6 +90,32 @@ mod method_impl {
     }
 }
 
+mod trait_impl {
+    #[derive(Debug)]
+    struct MyThing {
+        field: bool,
+    }
+
+    trait MyTrait<B> {
+        fn trait_method(self) -> B;
+    }
+
+    impl MyTrait<bool> for MyThing {
+        // MyThing::trait_method
+        fn trait_method(self) -> bool {
+            self.field // $ fieldof=MyThing
+        }
+    }
+
+    pub fn f() {
+        let x = MyThing { field: true };
+        let a = x.trait_method(); // $ type=a:bool method=MyThing::trait_method
+
+        let y = MyThing { field: false };
+        let b = MyTrait::trait_method(y); // $ type=b:bool MISSING: method=MyThing::trait_method
+    }
+}
+
 mod method_non_parametric_impl {
     #[derive(Debug)]
     struct MyThing<A> {

--- a/rust/ql/test/library-tests/type-inference/main.rs
+++ b/rust/ql/test/library-tests/type-inference/main.rs
@@ -112,7 +112,7 @@ mod trait_impl {
         let a = x.trait_method(); // $ type=a:bool method=MyThing::trait_method
 
         let y = MyThing { field: false };
-        let b = MyTrait::trait_method(y); // $ type=b:bool MISSING: method=MyThing::trait_method
+        let b = MyTrait::trait_method(y); // $ type=b:bool method=MyThing::trait_method
     }
 }
 

--- a/rust/ql/test/library-tests/type-inference/type-inference.expected
+++ b/rust/ql/test/library-tests/type-inference/type-inference.expected
@@ -88,1520 +88,1537 @@ inferType
 | main.rs:88:9:88:14 | x.m1() |  | main.rs:67:5:67:21 | Foo |
 | main.rs:89:9:89:9 | y |  | main.rs:67:5:67:21 | Foo |
 | main.rs:89:9:89:14 | y.m2() |  | main.rs:67:5:67:21 | Foo |
-| main.rs:106:15:106:18 | SelfParam |  | main.rs:94:5:97:5 | MyThing |
-| main.rs:106:15:106:18 | SelfParam | A | main.rs:99:5:100:14 | S1 |
-| main.rs:106:27:108:9 | { ... } |  | main.rs:99:5:100:14 | S1 |
-| main.rs:107:13:107:16 | self |  | main.rs:94:5:97:5 | MyThing |
-| main.rs:107:13:107:16 | self | A | main.rs:99:5:100:14 | S1 |
-| main.rs:107:13:107:18 | self.a |  | main.rs:99:5:100:14 | S1 |
-| main.rs:113:15:113:18 | SelfParam |  | main.rs:94:5:97:5 | MyThing |
-| main.rs:113:15:113:18 | SelfParam | A | main.rs:101:5:102:14 | S2 |
-| main.rs:113:29:115:9 | { ... } |  | main.rs:94:5:97:5 | MyThing |
-| main.rs:113:29:115:9 | { ... } | A | main.rs:101:5:102:14 | S2 |
-| main.rs:114:13:114:30 | Self {...} |  | main.rs:94:5:97:5 | MyThing |
-| main.rs:114:13:114:30 | Self {...} | A | main.rs:101:5:102:14 | S2 |
-| main.rs:114:23:114:26 | self |  | main.rs:94:5:97:5 | MyThing |
-| main.rs:114:23:114:26 | self | A | main.rs:101:5:102:14 | S2 |
-| main.rs:114:23:114:28 | self.a |  | main.rs:101:5:102:14 | S2 |
-| main.rs:119:15:119:18 | SelfParam |  | main.rs:94:5:97:5 | MyThing |
-| main.rs:119:15:119:18 | SelfParam | A | main.rs:118:10:118:10 | T |
-| main.rs:119:26:121:9 | { ... } |  | main.rs:118:10:118:10 | T |
-| main.rs:120:13:120:16 | self |  | main.rs:94:5:97:5 | MyThing |
-| main.rs:120:13:120:16 | self | A | main.rs:118:10:118:10 | T |
-| main.rs:120:13:120:18 | self.a |  | main.rs:118:10:118:10 | T |
-| main.rs:125:13:125:13 | x |  | main.rs:94:5:97:5 | MyThing |
-| main.rs:125:13:125:13 | x | A | main.rs:99:5:100:14 | S1 |
-| main.rs:125:17:125:33 | MyThing {...} |  | main.rs:94:5:97:5 | MyThing |
-| main.rs:125:17:125:33 | MyThing {...} | A | main.rs:99:5:100:14 | S1 |
-| main.rs:125:30:125:31 | S1 |  | main.rs:99:5:100:14 | S1 |
-| main.rs:126:13:126:13 | y |  | main.rs:94:5:97:5 | MyThing |
-| main.rs:126:13:126:13 | y | A | main.rs:101:5:102:14 | S2 |
-| main.rs:126:17:126:33 | MyThing {...} |  | main.rs:94:5:97:5 | MyThing |
-| main.rs:126:17:126:33 | MyThing {...} | A | main.rs:101:5:102:14 | S2 |
-| main.rs:126:30:126:31 | S2 |  | main.rs:101:5:102:14 | S2 |
-| main.rs:129:18:129:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:129:26:129:26 | x |  | main.rs:94:5:97:5 | MyThing |
-| main.rs:129:26:129:26 | x | A | main.rs:99:5:100:14 | S1 |
-| main.rs:129:26:129:28 | x.a |  | main.rs:99:5:100:14 | S1 |
-| main.rs:130:18:130:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:130:26:130:26 | y |  | main.rs:94:5:97:5 | MyThing |
-| main.rs:130:26:130:26 | y | A | main.rs:101:5:102:14 | S2 |
-| main.rs:130:26:130:28 | y.a |  | main.rs:101:5:102:14 | S2 |
-| main.rs:132:18:132:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:132:26:132:26 | x |  | main.rs:94:5:97:5 | MyThing |
-| main.rs:132:26:132:26 | x | A | main.rs:99:5:100:14 | S1 |
-| main.rs:132:26:132:31 | x.m1() |  | main.rs:99:5:100:14 | S1 |
-| main.rs:133:18:133:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:133:26:133:26 | y |  | main.rs:94:5:97:5 | MyThing |
-| main.rs:133:26:133:26 | y | A | main.rs:101:5:102:14 | S2 |
-| main.rs:133:26:133:31 | y.m1() |  | main.rs:94:5:97:5 | MyThing |
-| main.rs:133:26:133:31 | y.m1() | A | main.rs:101:5:102:14 | S2 |
-| main.rs:133:26:133:33 | ... .a |  | main.rs:101:5:102:14 | S2 |
-| main.rs:135:13:135:13 | x |  | main.rs:94:5:97:5 | MyThing |
-| main.rs:135:13:135:13 | x | A | main.rs:99:5:100:14 | S1 |
-| main.rs:135:17:135:33 | MyThing {...} |  | main.rs:94:5:97:5 | MyThing |
-| main.rs:135:17:135:33 | MyThing {...} | A | main.rs:99:5:100:14 | S1 |
-| main.rs:135:30:135:31 | S1 |  | main.rs:99:5:100:14 | S1 |
-| main.rs:136:13:136:13 | y |  | main.rs:94:5:97:5 | MyThing |
-| main.rs:136:13:136:13 | y | A | main.rs:101:5:102:14 | S2 |
-| main.rs:136:17:136:33 | MyThing {...} |  | main.rs:94:5:97:5 | MyThing |
-| main.rs:136:17:136:33 | MyThing {...} | A | main.rs:101:5:102:14 | S2 |
-| main.rs:136:30:136:31 | S2 |  | main.rs:101:5:102:14 | S2 |
-| main.rs:138:18:138:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:138:26:138:26 | x |  | main.rs:94:5:97:5 | MyThing |
-| main.rs:138:26:138:26 | x | A | main.rs:99:5:100:14 | S1 |
-| main.rs:138:26:138:31 | x.m2() |  | main.rs:99:5:100:14 | S1 |
-| main.rs:139:18:139:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:139:26:139:26 | y |  | main.rs:94:5:97:5 | MyThing |
-| main.rs:139:26:139:26 | y | A | main.rs:101:5:102:14 | S2 |
-| main.rs:139:26:139:31 | y.m2() |  | main.rs:101:5:102:14 | S2 |
-| main.rs:163:15:163:18 | SelfParam |  | main.rs:162:5:171:5 | Self [trait MyTrait] |
-| main.rs:165:15:165:18 | SelfParam |  | main.rs:162:5:171:5 | Self [trait MyTrait] |
-| main.rs:168:9:170:9 | { ... } |  | main.rs:162:5:171:5 | Self [trait MyTrait] |
-| main.rs:169:13:169:16 | self |  | main.rs:162:5:171:5 | Self [trait MyTrait] |
-| main.rs:175:16:175:19 | SelfParam |  | main.rs:173:5:178:5 | Self [trait MyProduct] |
-| main.rs:177:16:177:19 | SelfParam |  | main.rs:173:5:178:5 | Self [trait MyProduct] |
-| main.rs:180:43:180:43 | x |  | main.rs:180:26:180:40 | T2 |
-| main.rs:180:56:182:5 | { ... } |  | main.rs:180:22:180:23 | T1 |
-| main.rs:181:9:181:9 | x |  | main.rs:180:26:180:40 | T2 |
-| main.rs:181:9:181:14 | x.m1() |  | main.rs:180:22:180:23 | T1 |
-| main.rs:186:15:186:18 | SelfParam |  | main.rs:144:5:147:5 | MyThing |
-| main.rs:186:15:186:18 | SelfParam | A | main.rs:155:5:156:14 | S1 |
-| main.rs:186:27:188:9 | { ... } |  | main.rs:155:5:156:14 | S1 |
-| main.rs:187:13:187:16 | self |  | main.rs:144:5:147:5 | MyThing |
-| main.rs:187:13:187:16 | self | A | main.rs:155:5:156:14 | S1 |
-| main.rs:187:13:187:18 | self.a |  | main.rs:155:5:156:14 | S1 |
-| main.rs:193:15:193:18 | SelfParam |  | main.rs:144:5:147:5 | MyThing |
-| main.rs:193:15:193:18 | SelfParam | A | main.rs:157:5:158:14 | S2 |
-| main.rs:193:29:195:9 | { ... } |  | main.rs:144:5:147:5 | MyThing |
-| main.rs:193:29:195:9 | { ... } | A | main.rs:157:5:158:14 | S2 |
-| main.rs:194:13:194:30 | Self {...} |  | main.rs:144:5:147:5 | MyThing |
-| main.rs:194:13:194:30 | Self {...} | A | main.rs:157:5:158:14 | S2 |
-| main.rs:194:23:194:26 | self |  | main.rs:144:5:147:5 | MyThing |
-| main.rs:194:23:194:26 | self | A | main.rs:157:5:158:14 | S2 |
-| main.rs:194:23:194:28 | self.a |  | main.rs:157:5:158:14 | S2 |
-| main.rs:205:15:205:18 | SelfParam |  | main.rs:144:5:147:5 | MyThing |
-| main.rs:205:15:205:18 | SelfParam | A | main.rs:159:5:160:14 | S3 |
-| main.rs:205:27:207:9 | { ... } |  | main.rs:200:10:200:11 | TD |
-| main.rs:206:13:206:25 | ...::default(...) |  | main.rs:200:10:200:11 | TD |
-| main.rs:212:15:212:18 | SelfParam |  | main.rs:149:5:153:5 | MyPair |
-| main.rs:212:15:212:18 | SelfParam | P1 | main.rs:210:10:210:10 | I |
-| main.rs:212:15:212:18 | SelfParam | P2 | main.rs:155:5:156:14 | S1 |
-| main.rs:212:26:214:9 | { ... } |  | main.rs:210:10:210:10 | I |
-| main.rs:213:13:213:16 | self |  | main.rs:149:5:153:5 | MyPair |
-| main.rs:213:13:213:16 | self | P1 | main.rs:210:10:210:10 | I |
-| main.rs:213:13:213:16 | self | P2 | main.rs:155:5:156:14 | S1 |
-| main.rs:213:13:213:19 | self.p1 |  | main.rs:210:10:210:10 | I |
-| main.rs:219:15:219:18 | SelfParam |  | main.rs:149:5:153:5 | MyPair |
-| main.rs:219:15:219:18 | SelfParam | P1 | main.rs:155:5:156:14 | S1 |
-| main.rs:219:15:219:18 | SelfParam | P2 | main.rs:157:5:158:14 | S2 |
-| main.rs:219:27:221:9 | { ... } |  | main.rs:159:5:160:14 | S3 |
-| main.rs:220:13:220:14 | S3 |  | main.rs:159:5:160:14 | S3 |
-| main.rs:226:15:226:18 | SelfParam |  | main.rs:149:5:153:5 | MyPair |
-| main.rs:226:15:226:18 | SelfParam | P1 | main.rs:144:5:147:5 | MyThing |
-| main.rs:226:15:226:18 | SelfParam | P1.A | main.rs:224:10:224:11 | TT |
-| main.rs:226:15:226:18 | SelfParam | P2 | main.rs:159:5:160:14 | S3 |
-| main.rs:226:27:229:9 | { ... } |  | main.rs:224:10:224:11 | TT |
-| main.rs:227:17:227:21 | alpha |  | main.rs:144:5:147:5 | MyThing |
-| main.rs:227:17:227:21 | alpha | A | main.rs:224:10:224:11 | TT |
-| main.rs:227:25:227:28 | self |  | main.rs:149:5:153:5 | MyPair |
-| main.rs:227:25:227:28 | self | P1 | main.rs:144:5:147:5 | MyThing |
-| main.rs:227:25:227:28 | self | P1.A | main.rs:224:10:224:11 | TT |
-| main.rs:227:25:227:28 | self | P2 | main.rs:159:5:160:14 | S3 |
-| main.rs:227:25:227:31 | self.p1 |  | main.rs:144:5:147:5 | MyThing |
-| main.rs:227:25:227:31 | self.p1 | A | main.rs:224:10:224:11 | TT |
-| main.rs:228:13:228:17 | alpha |  | main.rs:144:5:147:5 | MyThing |
-| main.rs:228:13:228:17 | alpha | A | main.rs:224:10:224:11 | TT |
-| main.rs:228:13:228:19 | alpha.a |  | main.rs:224:10:224:11 | TT |
-| main.rs:235:16:235:19 | SelfParam |  | main.rs:149:5:153:5 | MyPair |
-| main.rs:235:16:235:19 | SelfParam | P1 | main.rs:233:10:233:10 | A |
-| main.rs:235:16:235:19 | SelfParam | P2 | main.rs:233:10:233:10 | A |
-| main.rs:235:27:237:9 | { ... } |  | main.rs:233:10:233:10 | A |
-| main.rs:236:13:236:16 | self |  | main.rs:149:5:153:5 | MyPair |
-| main.rs:236:13:236:16 | self | P1 | main.rs:233:10:233:10 | A |
-| main.rs:236:13:236:16 | self | P2 | main.rs:233:10:233:10 | A |
-| main.rs:236:13:236:19 | self.p1 |  | main.rs:233:10:233:10 | A |
-| main.rs:240:16:240:19 | SelfParam |  | main.rs:149:5:153:5 | MyPair |
-| main.rs:240:16:240:19 | SelfParam | P1 | main.rs:233:10:233:10 | A |
-| main.rs:240:16:240:19 | SelfParam | P2 | main.rs:233:10:233:10 | A |
-| main.rs:240:27:242:9 | { ... } |  | main.rs:233:10:233:10 | A |
-| main.rs:241:13:241:16 | self |  | main.rs:149:5:153:5 | MyPair |
-| main.rs:241:13:241:16 | self | P1 | main.rs:233:10:233:10 | A |
-| main.rs:241:13:241:16 | self | P2 | main.rs:233:10:233:10 | A |
-| main.rs:241:13:241:19 | self.p2 |  | main.rs:233:10:233:10 | A |
-| main.rs:248:16:248:19 | SelfParam |  | main.rs:149:5:153:5 | MyPair |
-| main.rs:248:16:248:19 | SelfParam | P1 | main.rs:157:5:158:14 | S2 |
-| main.rs:248:16:248:19 | SelfParam | P2 | main.rs:155:5:156:14 | S1 |
-| main.rs:248:28:250:9 | { ... } |  | main.rs:155:5:156:14 | S1 |
-| main.rs:249:13:249:16 | self |  | main.rs:149:5:153:5 | MyPair |
-| main.rs:249:13:249:16 | self | P1 | main.rs:157:5:158:14 | S2 |
-| main.rs:249:13:249:16 | self | P2 | main.rs:155:5:156:14 | S1 |
-| main.rs:249:13:249:19 | self.p2 |  | main.rs:155:5:156:14 | S1 |
-| main.rs:253:16:253:19 | SelfParam |  | main.rs:149:5:153:5 | MyPair |
-| main.rs:253:16:253:19 | SelfParam | P1 | main.rs:157:5:158:14 | S2 |
-| main.rs:253:16:253:19 | SelfParam | P2 | main.rs:155:5:156:14 | S1 |
-| main.rs:253:28:255:9 | { ... } |  | main.rs:157:5:158:14 | S2 |
-| main.rs:254:13:254:16 | self |  | main.rs:149:5:153:5 | MyPair |
-| main.rs:254:13:254:16 | self | P1 | main.rs:157:5:158:14 | S2 |
-| main.rs:254:13:254:16 | self | P2 | main.rs:155:5:156:14 | S1 |
-| main.rs:254:13:254:19 | self.p1 |  | main.rs:157:5:158:14 | S2 |
-| main.rs:258:46:258:46 | p |  | main.rs:258:24:258:43 | P |
-| main.rs:258:58:260:5 | { ... } |  | main.rs:258:16:258:17 | V1 |
-| main.rs:259:9:259:9 | p |  | main.rs:258:24:258:43 | P |
-| main.rs:259:9:259:15 | p.fst() |  | main.rs:258:16:258:17 | V1 |
-| main.rs:262:46:262:46 | p |  | main.rs:262:24:262:43 | P |
-| main.rs:262:58:264:5 | { ... } |  | main.rs:262:20:262:21 | V2 |
-| main.rs:263:9:263:9 | p |  | main.rs:262:24:262:43 | P |
-| main.rs:263:9:263:15 | p.snd() |  | main.rs:262:20:262:21 | V2 |
-| main.rs:266:54:266:54 | p |  | main.rs:149:5:153:5 | MyPair |
-| main.rs:266:54:266:54 | p | P1 | main.rs:266:20:266:21 | V0 |
-| main.rs:266:54:266:54 | p | P2 | main.rs:266:32:266:51 | P |
-| main.rs:266:78:268:5 | { ... } |  | main.rs:266:24:266:25 | V1 |
-| main.rs:267:9:267:9 | p |  | main.rs:149:5:153:5 | MyPair |
-| main.rs:267:9:267:9 | p | P1 | main.rs:266:20:266:21 | V0 |
-| main.rs:267:9:267:9 | p | P2 | main.rs:266:32:266:51 | P |
-| main.rs:267:9:267:12 | p.p2 |  | main.rs:266:32:266:51 | P |
-| main.rs:267:9:267:18 | ... .fst() |  | main.rs:266:24:266:25 | V1 |
-| main.rs:272:23:272:26 | SelfParam |  | main.rs:270:5:273:5 | Self [trait ConvertTo] |
-| main.rs:277:23:277:26 | SelfParam |  | main.rs:275:10:275:23 | T |
-| main.rs:277:35:279:9 | { ... } |  | main.rs:155:5:156:14 | S1 |
-| main.rs:278:13:278:16 | self |  | main.rs:275:10:275:23 | T |
-| main.rs:278:13:278:21 | self.m1() |  | main.rs:155:5:156:14 | S1 |
-| main.rs:282:41:282:45 | thing |  | main.rs:282:23:282:38 | T |
-| main.rs:282:57:284:5 | { ... } |  | main.rs:282:19:282:20 | TS |
-| main.rs:283:9:283:13 | thing |  | main.rs:282:23:282:38 | T |
-| main.rs:283:9:283:26 | thing.convert_to() |  | main.rs:282:19:282:20 | TS |
-| main.rs:286:56:286:60 | thing |  | main.rs:286:39:286:53 | TP |
-| main.rs:286:73:289:5 | { ... } |  | main.rs:155:5:156:14 | S1 |
-| main.rs:288:9:288:13 | thing |  | main.rs:286:39:286:53 | TP |
-| main.rs:288:9:288:26 | thing.convert_to() |  | main.rs:155:5:156:14 | S1 |
-| main.rs:292:13:292:20 | thing_s1 |  | main.rs:144:5:147:5 | MyThing |
-| main.rs:292:13:292:20 | thing_s1 | A | main.rs:155:5:156:14 | S1 |
-| main.rs:292:24:292:40 | MyThing {...} |  | main.rs:144:5:147:5 | MyThing |
-| main.rs:292:24:292:40 | MyThing {...} | A | main.rs:155:5:156:14 | S1 |
-| main.rs:292:37:292:38 | S1 |  | main.rs:155:5:156:14 | S1 |
-| main.rs:293:13:293:20 | thing_s2 |  | main.rs:144:5:147:5 | MyThing |
-| main.rs:293:13:293:20 | thing_s2 | A | main.rs:157:5:158:14 | S2 |
-| main.rs:293:24:293:40 | MyThing {...} |  | main.rs:144:5:147:5 | MyThing |
-| main.rs:293:24:293:40 | MyThing {...} | A | main.rs:157:5:158:14 | S2 |
-| main.rs:293:37:293:38 | S2 |  | main.rs:157:5:158:14 | S2 |
-| main.rs:294:13:294:20 | thing_s3 |  | main.rs:144:5:147:5 | MyThing |
-| main.rs:294:13:294:20 | thing_s3 | A | main.rs:159:5:160:14 | S3 |
-| main.rs:294:24:294:40 | MyThing {...} |  | main.rs:144:5:147:5 | MyThing |
-| main.rs:294:24:294:40 | MyThing {...} | A | main.rs:159:5:160:14 | S3 |
-| main.rs:294:37:294:38 | S3 |  | main.rs:159:5:160:14 | S3 |
-| main.rs:298:18:298:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:298:26:298:33 | thing_s1 |  | main.rs:144:5:147:5 | MyThing |
-| main.rs:298:26:298:33 | thing_s1 | A | main.rs:155:5:156:14 | S1 |
-| main.rs:298:26:298:38 | thing_s1.m1() |  | main.rs:155:5:156:14 | S1 |
-| main.rs:299:18:299:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:299:26:299:33 | thing_s2 |  | main.rs:144:5:147:5 | MyThing |
-| main.rs:299:26:299:33 | thing_s2 | A | main.rs:157:5:158:14 | S2 |
-| main.rs:299:26:299:38 | thing_s2.m1() |  | main.rs:144:5:147:5 | MyThing |
-| main.rs:299:26:299:38 | thing_s2.m1() | A | main.rs:157:5:158:14 | S2 |
-| main.rs:299:26:299:40 | ... .a |  | main.rs:157:5:158:14 | S2 |
-| main.rs:300:13:300:14 | s3 |  | main.rs:159:5:160:14 | S3 |
-| main.rs:300:22:300:29 | thing_s3 |  | main.rs:144:5:147:5 | MyThing |
-| main.rs:300:22:300:29 | thing_s3 | A | main.rs:159:5:160:14 | S3 |
-| main.rs:300:22:300:34 | thing_s3.m1() |  | main.rs:159:5:160:14 | S3 |
-| main.rs:301:18:301:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:301:26:301:27 | s3 |  | main.rs:159:5:160:14 | S3 |
-| main.rs:303:13:303:14 | p1 |  | main.rs:149:5:153:5 | MyPair |
-| main.rs:303:13:303:14 | p1 | P1 | main.rs:155:5:156:14 | S1 |
-| main.rs:303:13:303:14 | p1 | P2 | main.rs:155:5:156:14 | S1 |
-| main.rs:303:18:303:42 | MyPair {...} |  | main.rs:149:5:153:5 | MyPair |
-| main.rs:303:18:303:42 | MyPair {...} | P1 | main.rs:155:5:156:14 | S1 |
-| main.rs:303:18:303:42 | MyPair {...} | P2 | main.rs:155:5:156:14 | S1 |
-| main.rs:303:31:303:32 | S1 |  | main.rs:155:5:156:14 | S1 |
-| main.rs:303:39:303:40 | S1 |  | main.rs:155:5:156:14 | S1 |
-| main.rs:304:18:304:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:304:26:304:27 | p1 |  | main.rs:149:5:153:5 | MyPair |
-| main.rs:304:26:304:27 | p1 | P1 | main.rs:155:5:156:14 | S1 |
-| main.rs:304:26:304:27 | p1 | P2 | main.rs:155:5:156:14 | S1 |
-| main.rs:304:26:304:32 | p1.m1() |  | main.rs:155:5:156:14 | S1 |
-| main.rs:306:13:306:14 | p2 |  | main.rs:149:5:153:5 | MyPair |
-| main.rs:306:13:306:14 | p2 | P1 | main.rs:155:5:156:14 | S1 |
-| main.rs:306:13:306:14 | p2 | P2 | main.rs:157:5:158:14 | S2 |
-| main.rs:306:18:306:42 | MyPair {...} |  | main.rs:149:5:153:5 | MyPair |
-| main.rs:306:18:306:42 | MyPair {...} | P1 | main.rs:155:5:156:14 | S1 |
-| main.rs:306:18:306:42 | MyPair {...} | P2 | main.rs:157:5:158:14 | S2 |
-| main.rs:306:31:306:32 | S1 |  | main.rs:155:5:156:14 | S1 |
-| main.rs:306:39:306:40 | S2 |  | main.rs:157:5:158:14 | S2 |
-| main.rs:307:18:307:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:307:26:307:27 | p2 |  | main.rs:149:5:153:5 | MyPair |
-| main.rs:307:26:307:27 | p2 | P1 | main.rs:155:5:156:14 | S1 |
-| main.rs:307:26:307:27 | p2 | P2 | main.rs:157:5:158:14 | S2 |
-| main.rs:307:26:307:32 | p2.m1() |  | main.rs:159:5:160:14 | S3 |
-| main.rs:309:13:309:14 | p3 |  | main.rs:149:5:153:5 | MyPair |
-| main.rs:309:13:309:14 | p3 | P1 | main.rs:144:5:147:5 | MyThing |
-| main.rs:309:13:309:14 | p3 | P1.A | main.rs:155:5:156:14 | S1 |
-| main.rs:309:13:309:14 | p3 | P2 | main.rs:159:5:160:14 | S3 |
-| main.rs:309:18:312:9 | MyPair {...} |  | main.rs:149:5:153:5 | MyPair |
-| main.rs:309:18:312:9 | MyPair {...} | P1 | main.rs:144:5:147:5 | MyThing |
-| main.rs:309:18:312:9 | MyPair {...} | P1.A | main.rs:155:5:156:14 | S1 |
-| main.rs:309:18:312:9 | MyPair {...} | P2 | main.rs:159:5:160:14 | S3 |
-| main.rs:310:17:310:33 | MyThing {...} |  | main.rs:144:5:147:5 | MyThing |
-| main.rs:310:17:310:33 | MyThing {...} | A | main.rs:155:5:156:14 | S1 |
-| main.rs:310:30:310:31 | S1 |  | main.rs:155:5:156:14 | S1 |
-| main.rs:311:17:311:18 | S3 |  | main.rs:159:5:160:14 | S3 |
-| main.rs:313:18:313:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:313:26:313:27 | p3 |  | main.rs:149:5:153:5 | MyPair |
-| main.rs:313:26:313:27 | p3 | P1 | main.rs:144:5:147:5 | MyThing |
-| main.rs:313:26:313:27 | p3 | P1.A | main.rs:155:5:156:14 | S1 |
-| main.rs:313:26:313:27 | p3 | P2 | main.rs:159:5:160:14 | S3 |
-| main.rs:313:26:313:32 | p3.m1() |  | main.rs:155:5:156:14 | S1 |
-| main.rs:316:13:316:13 | a |  | main.rs:149:5:153:5 | MyPair |
-| main.rs:316:13:316:13 | a | P1 | main.rs:155:5:156:14 | S1 |
-| main.rs:316:13:316:13 | a | P2 | main.rs:155:5:156:14 | S1 |
-| main.rs:316:17:316:41 | MyPair {...} |  | main.rs:149:5:153:5 | MyPair |
-| main.rs:316:17:316:41 | MyPair {...} | P1 | main.rs:155:5:156:14 | S1 |
-| main.rs:316:17:316:41 | MyPair {...} | P2 | main.rs:155:5:156:14 | S1 |
-| main.rs:316:30:316:31 | S1 |  | main.rs:155:5:156:14 | S1 |
-| main.rs:316:38:316:39 | S1 |  | main.rs:155:5:156:14 | S1 |
-| main.rs:317:13:317:13 | x |  | main.rs:155:5:156:14 | S1 |
-| main.rs:317:17:317:17 | a |  | main.rs:149:5:153:5 | MyPair |
-| main.rs:317:17:317:17 | a | P1 | main.rs:155:5:156:14 | S1 |
-| main.rs:317:17:317:17 | a | P2 | main.rs:155:5:156:14 | S1 |
-| main.rs:317:17:317:23 | a.fst() |  | main.rs:155:5:156:14 | S1 |
-| main.rs:318:18:318:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:318:26:318:26 | x |  | main.rs:155:5:156:14 | S1 |
-| main.rs:319:13:319:13 | y |  | main.rs:155:5:156:14 | S1 |
-| main.rs:319:17:319:17 | a |  | main.rs:149:5:153:5 | MyPair |
-| main.rs:319:17:319:17 | a | P1 | main.rs:155:5:156:14 | S1 |
-| main.rs:319:17:319:17 | a | P2 | main.rs:155:5:156:14 | S1 |
-| main.rs:319:17:319:23 | a.snd() |  | main.rs:155:5:156:14 | S1 |
-| main.rs:320:18:320:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:320:26:320:26 | y |  | main.rs:155:5:156:14 | S1 |
-| main.rs:326:13:326:13 | b |  | main.rs:149:5:153:5 | MyPair |
-| main.rs:326:13:326:13 | b | P1 | main.rs:157:5:158:14 | S2 |
-| main.rs:326:13:326:13 | b | P2 | main.rs:155:5:156:14 | S1 |
-| main.rs:326:17:326:41 | MyPair {...} |  | main.rs:149:5:153:5 | MyPair |
-| main.rs:326:17:326:41 | MyPair {...} | P1 | main.rs:157:5:158:14 | S2 |
-| main.rs:326:17:326:41 | MyPair {...} | P2 | main.rs:155:5:156:14 | S1 |
-| main.rs:326:30:326:31 | S2 |  | main.rs:157:5:158:14 | S2 |
-| main.rs:326:38:326:39 | S1 |  | main.rs:155:5:156:14 | S1 |
-| main.rs:327:13:327:13 | x |  | main.rs:155:5:156:14 | S1 |
-| main.rs:327:17:327:17 | b |  | main.rs:149:5:153:5 | MyPair |
-| main.rs:327:17:327:17 | b | P1 | main.rs:157:5:158:14 | S2 |
-| main.rs:327:17:327:17 | b | P2 | main.rs:155:5:156:14 | S1 |
-| main.rs:327:17:327:23 | b.fst() |  | main.rs:155:5:156:14 | S1 |
-| main.rs:328:18:328:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:328:26:328:26 | x |  | main.rs:155:5:156:14 | S1 |
-| main.rs:329:13:329:13 | y |  | main.rs:157:5:158:14 | S2 |
-| main.rs:329:17:329:17 | b |  | main.rs:149:5:153:5 | MyPair |
-| main.rs:329:17:329:17 | b | P1 | main.rs:157:5:158:14 | S2 |
-| main.rs:329:17:329:17 | b | P2 | main.rs:155:5:156:14 | S1 |
-| main.rs:329:17:329:23 | b.snd() |  | main.rs:157:5:158:14 | S2 |
+| main.rs:100:25:100:28 | SelfParam |  | main.rs:99:5:101:5 | Self [trait MyTrait] |
+| main.rs:105:25:105:28 | SelfParam |  | main.rs:94:5:97:5 | MyThing |
+| main.rs:105:39:107:9 | { ... } |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:106:13:106:16 | self |  | main.rs:94:5:97:5 | MyThing |
+| main.rs:106:13:106:22 | self.field |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:111:13:111:13 | x |  | main.rs:94:5:97:5 | MyThing |
+| main.rs:111:17:111:39 | MyThing {...} |  | main.rs:94:5:97:5 | MyThing |
+| main.rs:111:34:111:37 | true |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:112:13:112:13 | a |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:112:17:112:17 | x |  | main.rs:94:5:97:5 | MyThing |
+| main.rs:112:17:112:32 | x.trait_method() |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:114:13:114:13 | y |  | main.rs:94:5:97:5 | MyThing |
+| main.rs:114:17:114:40 | MyThing {...} |  | main.rs:94:5:97:5 | MyThing |
+| main.rs:114:34:114:38 | false |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:115:13:115:13 | b |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:115:17:115:40 | ...::trait_method(...) |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:115:39:115:39 | y |  | main.rs:94:5:97:5 | MyThing |
+| main.rs:132:15:132:18 | SelfParam |  | main.rs:120:5:123:5 | MyThing |
+| main.rs:132:15:132:18 | SelfParam | A | main.rs:125:5:126:14 | S1 |
+| main.rs:132:27:134:9 | { ... } |  | main.rs:125:5:126:14 | S1 |
+| main.rs:133:13:133:16 | self |  | main.rs:120:5:123:5 | MyThing |
+| main.rs:133:13:133:16 | self | A | main.rs:125:5:126:14 | S1 |
+| main.rs:133:13:133:18 | self.a |  | main.rs:125:5:126:14 | S1 |
+| main.rs:139:15:139:18 | SelfParam |  | main.rs:120:5:123:5 | MyThing |
+| main.rs:139:15:139:18 | SelfParam | A | main.rs:127:5:128:14 | S2 |
+| main.rs:139:29:141:9 | { ... } |  | main.rs:120:5:123:5 | MyThing |
+| main.rs:139:29:141:9 | { ... } | A | main.rs:127:5:128:14 | S2 |
+| main.rs:140:13:140:30 | Self {...} |  | main.rs:120:5:123:5 | MyThing |
+| main.rs:140:13:140:30 | Self {...} | A | main.rs:127:5:128:14 | S2 |
+| main.rs:140:23:140:26 | self |  | main.rs:120:5:123:5 | MyThing |
+| main.rs:140:23:140:26 | self | A | main.rs:127:5:128:14 | S2 |
+| main.rs:140:23:140:28 | self.a |  | main.rs:127:5:128:14 | S2 |
+| main.rs:145:15:145:18 | SelfParam |  | main.rs:120:5:123:5 | MyThing |
+| main.rs:145:15:145:18 | SelfParam | A | main.rs:144:10:144:10 | T |
+| main.rs:145:26:147:9 | { ... } |  | main.rs:144:10:144:10 | T |
+| main.rs:146:13:146:16 | self |  | main.rs:120:5:123:5 | MyThing |
+| main.rs:146:13:146:16 | self | A | main.rs:144:10:144:10 | T |
+| main.rs:146:13:146:18 | self.a |  | main.rs:144:10:144:10 | T |
+| main.rs:151:13:151:13 | x |  | main.rs:120:5:123:5 | MyThing |
+| main.rs:151:13:151:13 | x | A | main.rs:125:5:126:14 | S1 |
+| main.rs:151:17:151:33 | MyThing {...} |  | main.rs:120:5:123:5 | MyThing |
+| main.rs:151:17:151:33 | MyThing {...} | A | main.rs:125:5:126:14 | S1 |
+| main.rs:151:30:151:31 | S1 |  | main.rs:125:5:126:14 | S1 |
+| main.rs:152:13:152:13 | y |  | main.rs:120:5:123:5 | MyThing |
+| main.rs:152:13:152:13 | y | A | main.rs:127:5:128:14 | S2 |
+| main.rs:152:17:152:33 | MyThing {...} |  | main.rs:120:5:123:5 | MyThing |
+| main.rs:152:17:152:33 | MyThing {...} | A | main.rs:127:5:128:14 | S2 |
+| main.rs:152:30:152:31 | S2 |  | main.rs:127:5:128:14 | S2 |
+| main.rs:155:18:155:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:155:26:155:26 | x |  | main.rs:120:5:123:5 | MyThing |
+| main.rs:155:26:155:26 | x | A | main.rs:125:5:126:14 | S1 |
+| main.rs:155:26:155:28 | x.a |  | main.rs:125:5:126:14 | S1 |
+| main.rs:156:18:156:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:156:26:156:26 | y |  | main.rs:120:5:123:5 | MyThing |
+| main.rs:156:26:156:26 | y | A | main.rs:127:5:128:14 | S2 |
+| main.rs:156:26:156:28 | y.a |  | main.rs:127:5:128:14 | S2 |
+| main.rs:158:18:158:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:158:26:158:26 | x |  | main.rs:120:5:123:5 | MyThing |
+| main.rs:158:26:158:26 | x | A | main.rs:125:5:126:14 | S1 |
+| main.rs:158:26:158:31 | x.m1() |  | main.rs:125:5:126:14 | S1 |
+| main.rs:159:18:159:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:159:26:159:26 | y |  | main.rs:120:5:123:5 | MyThing |
+| main.rs:159:26:159:26 | y | A | main.rs:127:5:128:14 | S2 |
+| main.rs:159:26:159:31 | y.m1() |  | main.rs:120:5:123:5 | MyThing |
+| main.rs:159:26:159:31 | y.m1() | A | main.rs:127:5:128:14 | S2 |
+| main.rs:159:26:159:33 | ... .a |  | main.rs:127:5:128:14 | S2 |
+| main.rs:161:13:161:13 | x |  | main.rs:120:5:123:5 | MyThing |
+| main.rs:161:13:161:13 | x | A | main.rs:125:5:126:14 | S1 |
+| main.rs:161:17:161:33 | MyThing {...} |  | main.rs:120:5:123:5 | MyThing |
+| main.rs:161:17:161:33 | MyThing {...} | A | main.rs:125:5:126:14 | S1 |
+| main.rs:161:30:161:31 | S1 |  | main.rs:125:5:126:14 | S1 |
+| main.rs:162:13:162:13 | y |  | main.rs:120:5:123:5 | MyThing |
+| main.rs:162:13:162:13 | y | A | main.rs:127:5:128:14 | S2 |
+| main.rs:162:17:162:33 | MyThing {...} |  | main.rs:120:5:123:5 | MyThing |
+| main.rs:162:17:162:33 | MyThing {...} | A | main.rs:127:5:128:14 | S2 |
+| main.rs:162:30:162:31 | S2 |  | main.rs:127:5:128:14 | S2 |
+| main.rs:164:18:164:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:164:26:164:26 | x |  | main.rs:120:5:123:5 | MyThing |
+| main.rs:164:26:164:26 | x | A | main.rs:125:5:126:14 | S1 |
+| main.rs:164:26:164:31 | x.m2() |  | main.rs:125:5:126:14 | S1 |
+| main.rs:165:18:165:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:165:26:165:26 | y |  | main.rs:120:5:123:5 | MyThing |
+| main.rs:165:26:165:26 | y | A | main.rs:127:5:128:14 | S2 |
+| main.rs:165:26:165:31 | y.m2() |  | main.rs:127:5:128:14 | S2 |
+| main.rs:189:15:189:18 | SelfParam |  | main.rs:188:5:197:5 | Self [trait MyTrait] |
+| main.rs:191:15:191:18 | SelfParam |  | main.rs:188:5:197:5 | Self [trait MyTrait] |
+| main.rs:194:9:196:9 | { ... } |  | main.rs:188:5:197:5 | Self [trait MyTrait] |
+| main.rs:195:13:195:16 | self |  | main.rs:188:5:197:5 | Self [trait MyTrait] |
+| main.rs:201:16:201:19 | SelfParam |  | main.rs:199:5:204:5 | Self [trait MyProduct] |
+| main.rs:203:16:203:19 | SelfParam |  | main.rs:199:5:204:5 | Self [trait MyProduct] |
+| main.rs:206:43:206:43 | x |  | main.rs:206:26:206:40 | T2 |
+| main.rs:206:56:208:5 | { ... } |  | main.rs:206:22:206:23 | T1 |
+| main.rs:207:9:207:9 | x |  | main.rs:206:26:206:40 | T2 |
+| main.rs:207:9:207:14 | x.m1() |  | main.rs:206:22:206:23 | T1 |
+| main.rs:212:15:212:18 | SelfParam |  | main.rs:170:5:173:5 | MyThing |
+| main.rs:212:15:212:18 | SelfParam | A | main.rs:181:5:182:14 | S1 |
+| main.rs:212:27:214:9 | { ... } |  | main.rs:181:5:182:14 | S1 |
+| main.rs:213:13:213:16 | self |  | main.rs:170:5:173:5 | MyThing |
+| main.rs:213:13:213:16 | self | A | main.rs:181:5:182:14 | S1 |
+| main.rs:213:13:213:18 | self.a |  | main.rs:181:5:182:14 | S1 |
+| main.rs:219:15:219:18 | SelfParam |  | main.rs:170:5:173:5 | MyThing |
+| main.rs:219:15:219:18 | SelfParam | A | main.rs:183:5:184:14 | S2 |
+| main.rs:219:29:221:9 | { ... } |  | main.rs:170:5:173:5 | MyThing |
+| main.rs:219:29:221:9 | { ... } | A | main.rs:183:5:184:14 | S2 |
+| main.rs:220:13:220:30 | Self {...} |  | main.rs:170:5:173:5 | MyThing |
+| main.rs:220:13:220:30 | Self {...} | A | main.rs:183:5:184:14 | S2 |
+| main.rs:220:23:220:26 | self |  | main.rs:170:5:173:5 | MyThing |
+| main.rs:220:23:220:26 | self | A | main.rs:183:5:184:14 | S2 |
+| main.rs:220:23:220:28 | self.a |  | main.rs:183:5:184:14 | S2 |
+| main.rs:231:15:231:18 | SelfParam |  | main.rs:170:5:173:5 | MyThing |
+| main.rs:231:15:231:18 | SelfParam | A | main.rs:185:5:186:14 | S3 |
+| main.rs:231:27:233:9 | { ... } |  | main.rs:226:10:226:11 | TD |
+| main.rs:232:13:232:25 | ...::default(...) |  | main.rs:226:10:226:11 | TD |
+| main.rs:238:15:238:18 | SelfParam |  | main.rs:175:5:179:5 | MyPair |
+| main.rs:238:15:238:18 | SelfParam | P1 | main.rs:236:10:236:10 | I |
+| main.rs:238:15:238:18 | SelfParam | P2 | main.rs:181:5:182:14 | S1 |
+| main.rs:238:26:240:9 | { ... } |  | main.rs:236:10:236:10 | I |
+| main.rs:239:13:239:16 | self |  | main.rs:175:5:179:5 | MyPair |
+| main.rs:239:13:239:16 | self | P1 | main.rs:236:10:236:10 | I |
+| main.rs:239:13:239:16 | self | P2 | main.rs:181:5:182:14 | S1 |
+| main.rs:239:13:239:19 | self.p1 |  | main.rs:236:10:236:10 | I |
+| main.rs:245:15:245:18 | SelfParam |  | main.rs:175:5:179:5 | MyPair |
+| main.rs:245:15:245:18 | SelfParam | P1 | main.rs:181:5:182:14 | S1 |
+| main.rs:245:15:245:18 | SelfParam | P2 | main.rs:183:5:184:14 | S2 |
+| main.rs:245:27:247:9 | { ... } |  | main.rs:185:5:186:14 | S3 |
+| main.rs:246:13:246:14 | S3 |  | main.rs:185:5:186:14 | S3 |
+| main.rs:252:15:252:18 | SelfParam |  | main.rs:175:5:179:5 | MyPair |
+| main.rs:252:15:252:18 | SelfParam | P1 | main.rs:170:5:173:5 | MyThing |
+| main.rs:252:15:252:18 | SelfParam | P1.A | main.rs:250:10:250:11 | TT |
+| main.rs:252:15:252:18 | SelfParam | P2 | main.rs:185:5:186:14 | S3 |
+| main.rs:252:27:255:9 | { ... } |  | main.rs:250:10:250:11 | TT |
+| main.rs:253:17:253:21 | alpha |  | main.rs:170:5:173:5 | MyThing |
+| main.rs:253:17:253:21 | alpha | A | main.rs:250:10:250:11 | TT |
+| main.rs:253:25:253:28 | self |  | main.rs:175:5:179:5 | MyPair |
+| main.rs:253:25:253:28 | self | P1 | main.rs:170:5:173:5 | MyThing |
+| main.rs:253:25:253:28 | self | P1.A | main.rs:250:10:250:11 | TT |
+| main.rs:253:25:253:28 | self | P2 | main.rs:185:5:186:14 | S3 |
+| main.rs:253:25:253:31 | self.p1 |  | main.rs:170:5:173:5 | MyThing |
+| main.rs:253:25:253:31 | self.p1 | A | main.rs:250:10:250:11 | TT |
+| main.rs:254:13:254:17 | alpha |  | main.rs:170:5:173:5 | MyThing |
+| main.rs:254:13:254:17 | alpha | A | main.rs:250:10:250:11 | TT |
+| main.rs:254:13:254:19 | alpha.a |  | main.rs:250:10:250:11 | TT |
+| main.rs:261:16:261:19 | SelfParam |  | main.rs:175:5:179:5 | MyPair |
+| main.rs:261:16:261:19 | SelfParam | P1 | main.rs:259:10:259:10 | A |
+| main.rs:261:16:261:19 | SelfParam | P2 | main.rs:259:10:259:10 | A |
+| main.rs:261:27:263:9 | { ... } |  | main.rs:259:10:259:10 | A |
+| main.rs:262:13:262:16 | self |  | main.rs:175:5:179:5 | MyPair |
+| main.rs:262:13:262:16 | self | P1 | main.rs:259:10:259:10 | A |
+| main.rs:262:13:262:16 | self | P2 | main.rs:259:10:259:10 | A |
+| main.rs:262:13:262:19 | self.p1 |  | main.rs:259:10:259:10 | A |
+| main.rs:266:16:266:19 | SelfParam |  | main.rs:175:5:179:5 | MyPair |
+| main.rs:266:16:266:19 | SelfParam | P1 | main.rs:259:10:259:10 | A |
+| main.rs:266:16:266:19 | SelfParam | P2 | main.rs:259:10:259:10 | A |
+| main.rs:266:27:268:9 | { ... } |  | main.rs:259:10:259:10 | A |
+| main.rs:267:13:267:16 | self |  | main.rs:175:5:179:5 | MyPair |
+| main.rs:267:13:267:16 | self | P1 | main.rs:259:10:259:10 | A |
+| main.rs:267:13:267:16 | self | P2 | main.rs:259:10:259:10 | A |
+| main.rs:267:13:267:19 | self.p2 |  | main.rs:259:10:259:10 | A |
+| main.rs:274:16:274:19 | SelfParam |  | main.rs:175:5:179:5 | MyPair |
+| main.rs:274:16:274:19 | SelfParam | P1 | main.rs:183:5:184:14 | S2 |
+| main.rs:274:16:274:19 | SelfParam | P2 | main.rs:181:5:182:14 | S1 |
+| main.rs:274:28:276:9 | { ... } |  | main.rs:181:5:182:14 | S1 |
+| main.rs:275:13:275:16 | self |  | main.rs:175:5:179:5 | MyPair |
+| main.rs:275:13:275:16 | self | P1 | main.rs:183:5:184:14 | S2 |
+| main.rs:275:13:275:16 | self | P2 | main.rs:181:5:182:14 | S1 |
+| main.rs:275:13:275:19 | self.p2 |  | main.rs:181:5:182:14 | S1 |
+| main.rs:279:16:279:19 | SelfParam |  | main.rs:175:5:179:5 | MyPair |
+| main.rs:279:16:279:19 | SelfParam | P1 | main.rs:183:5:184:14 | S2 |
+| main.rs:279:16:279:19 | SelfParam | P2 | main.rs:181:5:182:14 | S1 |
+| main.rs:279:28:281:9 | { ... } |  | main.rs:183:5:184:14 | S2 |
+| main.rs:280:13:280:16 | self |  | main.rs:175:5:179:5 | MyPair |
+| main.rs:280:13:280:16 | self | P1 | main.rs:183:5:184:14 | S2 |
+| main.rs:280:13:280:16 | self | P2 | main.rs:181:5:182:14 | S1 |
+| main.rs:280:13:280:19 | self.p1 |  | main.rs:183:5:184:14 | S2 |
+| main.rs:284:46:284:46 | p |  | main.rs:284:24:284:43 | P |
+| main.rs:284:58:286:5 | { ... } |  | main.rs:284:16:284:17 | V1 |
+| main.rs:285:9:285:9 | p |  | main.rs:284:24:284:43 | P |
+| main.rs:285:9:285:15 | p.fst() |  | main.rs:284:16:284:17 | V1 |
+| main.rs:288:46:288:46 | p |  | main.rs:288:24:288:43 | P |
+| main.rs:288:58:290:5 | { ... } |  | main.rs:288:20:288:21 | V2 |
+| main.rs:289:9:289:9 | p |  | main.rs:288:24:288:43 | P |
+| main.rs:289:9:289:15 | p.snd() |  | main.rs:288:20:288:21 | V2 |
+| main.rs:292:54:292:54 | p |  | main.rs:175:5:179:5 | MyPair |
+| main.rs:292:54:292:54 | p | P1 | main.rs:292:20:292:21 | V0 |
+| main.rs:292:54:292:54 | p | P2 | main.rs:292:32:292:51 | P |
+| main.rs:292:78:294:5 | { ... } |  | main.rs:292:24:292:25 | V1 |
+| main.rs:293:9:293:9 | p |  | main.rs:175:5:179:5 | MyPair |
+| main.rs:293:9:293:9 | p | P1 | main.rs:292:20:292:21 | V0 |
+| main.rs:293:9:293:9 | p | P2 | main.rs:292:32:292:51 | P |
+| main.rs:293:9:293:12 | p.p2 |  | main.rs:292:32:292:51 | P |
+| main.rs:293:9:293:18 | ... .fst() |  | main.rs:292:24:292:25 | V1 |
+| main.rs:298:23:298:26 | SelfParam |  | main.rs:296:5:299:5 | Self [trait ConvertTo] |
+| main.rs:303:23:303:26 | SelfParam |  | main.rs:301:10:301:23 | T |
+| main.rs:303:35:305:9 | { ... } |  | main.rs:181:5:182:14 | S1 |
+| main.rs:304:13:304:16 | self |  | main.rs:301:10:301:23 | T |
+| main.rs:304:13:304:21 | self.m1() |  | main.rs:181:5:182:14 | S1 |
+| main.rs:308:41:308:45 | thing |  | main.rs:308:23:308:38 | T |
+| main.rs:308:57:310:5 | { ... } |  | main.rs:308:19:308:20 | TS |
+| main.rs:309:9:309:13 | thing |  | main.rs:308:23:308:38 | T |
+| main.rs:309:9:309:26 | thing.convert_to() |  | main.rs:308:19:308:20 | TS |
+| main.rs:312:56:312:60 | thing |  | main.rs:312:39:312:53 | TP |
+| main.rs:312:73:315:5 | { ... } |  | main.rs:181:5:182:14 | S1 |
+| main.rs:314:9:314:13 | thing |  | main.rs:312:39:312:53 | TP |
+| main.rs:314:9:314:26 | thing.convert_to() |  | main.rs:181:5:182:14 | S1 |
+| main.rs:318:13:318:20 | thing_s1 |  | main.rs:170:5:173:5 | MyThing |
+| main.rs:318:13:318:20 | thing_s1 | A | main.rs:181:5:182:14 | S1 |
+| main.rs:318:24:318:40 | MyThing {...} |  | main.rs:170:5:173:5 | MyThing |
+| main.rs:318:24:318:40 | MyThing {...} | A | main.rs:181:5:182:14 | S1 |
+| main.rs:318:37:318:38 | S1 |  | main.rs:181:5:182:14 | S1 |
+| main.rs:319:13:319:20 | thing_s2 |  | main.rs:170:5:173:5 | MyThing |
+| main.rs:319:13:319:20 | thing_s2 | A | main.rs:183:5:184:14 | S2 |
+| main.rs:319:24:319:40 | MyThing {...} |  | main.rs:170:5:173:5 | MyThing |
+| main.rs:319:24:319:40 | MyThing {...} | A | main.rs:183:5:184:14 | S2 |
+| main.rs:319:37:319:38 | S2 |  | main.rs:183:5:184:14 | S2 |
+| main.rs:320:13:320:20 | thing_s3 |  | main.rs:170:5:173:5 | MyThing |
+| main.rs:320:13:320:20 | thing_s3 | A | main.rs:185:5:186:14 | S3 |
+| main.rs:320:24:320:40 | MyThing {...} |  | main.rs:170:5:173:5 | MyThing |
+| main.rs:320:24:320:40 | MyThing {...} | A | main.rs:185:5:186:14 | S3 |
+| main.rs:320:37:320:38 | S3 |  | main.rs:185:5:186:14 | S3 |
+| main.rs:324:18:324:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:324:26:324:33 | thing_s1 |  | main.rs:170:5:173:5 | MyThing |
+| main.rs:324:26:324:33 | thing_s1 | A | main.rs:181:5:182:14 | S1 |
+| main.rs:324:26:324:38 | thing_s1.m1() |  | main.rs:181:5:182:14 | S1 |
+| main.rs:325:18:325:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:325:26:325:33 | thing_s2 |  | main.rs:170:5:173:5 | MyThing |
+| main.rs:325:26:325:33 | thing_s2 | A | main.rs:183:5:184:14 | S2 |
+| main.rs:325:26:325:38 | thing_s2.m1() |  | main.rs:170:5:173:5 | MyThing |
+| main.rs:325:26:325:38 | thing_s2.m1() | A | main.rs:183:5:184:14 | S2 |
+| main.rs:325:26:325:40 | ... .a |  | main.rs:183:5:184:14 | S2 |
+| main.rs:326:13:326:14 | s3 |  | main.rs:185:5:186:14 | S3 |
+| main.rs:326:22:326:29 | thing_s3 |  | main.rs:170:5:173:5 | MyThing |
+| main.rs:326:22:326:29 | thing_s3 | A | main.rs:185:5:186:14 | S3 |
+| main.rs:326:22:326:34 | thing_s3.m1() |  | main.rs:185:5:186:14 | S3 |
+| main.rs:327:18:327:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:327:26:327:27 | s3 |  | main.rs:185:5:186:14 | S3 |
+| main.rs:329:13:329:14 | p1 |  | main.rs:175:5:179:5 | MyPair |
+| main.rs:329:13:329:14 | p1 | P1 | main.rs:181:5:182:14 | S1 |
+| main.rs:329:13:329:14 | p1 | P2 | main.rs:181:5:182:14 | S1 |
+| main.rs:329:18:329:42 | MyPair {...} |  | main.rs:175:5:179:5 | MyPair |
+| main.rs:329:18:329:42 | MyPair {...} | P1 | main.rs:181:5:182:14 | S1 |
+| main.rs:329:18:329:42 | MyPair {...} | P2 | main.rs:181:5:182:14 | S1 |
+| main.rs:329:31:329:32 | S1 |  | main.rs:181:5:182:14 | S1 |
+| main.rs:329:39:329:40 | S1 |  | main.rs:181:5:182:14 | S1 |
 | main.rs:330:18:330:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:330:26:330:26 | y |  | main.rs:157:5:158:14 | S2 |
-| main.rs:334:13:334:13 | x |  | main.rs:155:5:156:14 | S1 |
-| main.rs:334:17:334:39 | call_trait_m1(...) |  | main.rs:155:5:156:14 | S1 |
-| main.rs:334:31:334:38 | thing_s1 |  | main.rs:144:5:147:5 | MyThing |
-| main.rs:334:31:334:38 | thing_s1 | A | main.rs:155:5:156:14 | S1 |
-| main.rs:335:18:335:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:335:26:335:26 | x |  | main.rs:155:5:156:14 | S1 |
-| main.rs:336:13:336:13 | y |  | main.rs:144:5:147:5 | MyThing |
-| main.rs:336:13:336:13 | y | A | main.rs:157:5:158:14 | S2 |
-| main.rs:336:17:336:39 | call_trait_m1(...) |  | main.rs:144:5:147:5 | MyThing |
-| main.rs:336:17:336:39 | call_trait_m1(...) | A | main.rs:157:5:158:14 | S2 |
-| main.rs:336:31:336:38 | thing_s2 |  | main.rs:144:5:147:5 | MyThing |
-| main.rs:336:31:336:38 | thing_s2 | A | main.rs:157:5:158:14 | S2 |
-| main.rs:337:18:337:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:337:26:337:26 | y |  | main.rs:144:5:147:5 | MyThing |
-| main.rs:337:26:337:26 | y | A | main.rs:157:5:158:14 | S2 |
-| main.rs:337:26:337:28 | y.a |  | main.rs:157:5:158:14 | S2 |
-| main.rs:340:13:340:13 | a |  | main.rs:149:5:153:5 | MyPair |
-| main.rs:340:13:340:13 | a | P1 | main.rs:155:5:156:14 | S1 |
-| main.rs:340:13:340:13 | a | P2 | main.rs:155:5:156:14 | S1 |
-| main.rs:340:17:340:41 | MyPair {...} |  | main.rs:149:5:153:5 | MyPair |
-| main.rs:340:17:340:41 | MyPair {...} | P1 | main.rs:155:5:156:14 | S1 |
-| main.rs:340:17:340:41 | MyPair {...} | P2 | main.rs:155:5:156:14 | S1 |
-| main.rs:340:30:340:31 | S1 |  | main.rs:155:5:156:14 | S1 |
-| main.rs:340:38:340:39 | S1 |  | main.rs:155:5:156:14 | S1 |
-| main.rs:341:13:341:13 | x |  | main.rs:155:5:156:14 | S1 |
-| main.rs:341:17:341:26 | get_fst(...) |  | main.rs:155:5:156:14 | S1 |
-| main.rs:341:25:341:25 | a |  | main.rs:149:5:153:5 | MyPair |
-| main.rs:341:25:341:25 | a | P1 | main.rs:155:5:156:14 | S1 |
-| main.rs:341:25:341:25 | a | P2 | main.rs:155:5:156:14 | S1 |
-| main.rs:342:18:342:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:342:26:342:26 | x |  | main.rs:155:5:156:14 | S1 |
-| main.rs:343:13:343:13 | y |  | main.rs:155:5:156:14 | S1 |
-| main.rs:343:17:343:26 | get_snd(...) |  | main.rs:155:5:156:14 | S1 |
-| main.rs:343:25:343:25 | a |  | main.rs:149:5:153:5 | MyPair |
-| main.rs:343:25:343:25 | a | P1 | main.rs:155:5:156:14 | S1 |
-| main.rs:343:25:343:25 | a | P2 | main.rs:155:5:156:14 | S1 |
+| main.rs:330:26:330:27 | p1 |  | main.rs:175:5:179:5 | MyPair |
+| main.rs:330:26:330:27 | p1 | P1 | main.rs:181:5:182:14 | S1 |
+| main.rs:330:26:330:27 | p1 | P2 | main.rs:181:5:182:14 | S1 |
+| main.rs:330:26:330:32 | p1.m1() |  | main.rs:181:5:182:14 | S1 |
+| main.rs:332:13:332:14 | p2 |  | main.rs:175:5:179:5 | MyPair |
+| main.rs:332:13:332:14 | p2 | P1 | main.rs:181:5:182:14 | S1 |
+| main.rs:332:13:332:14 | p2 | P2 | main.rs:183:5:184:14 | S2 |
+| main.rs:332:18:332:42 | MyPair {...} |  | main.rs:175:5:179:5 | MyPair |
+| main.rs:332:18:332:42 | MyPair {...} | P1 | main.rs:181:5:182:14 | S1 |
+| main.rs:332:18:332:42 | MyPair {...} | P2 | main.rs:183:5:184:14 | S2 |
+| main.rs:332:31:332:32 | S1 |  | main.rs:181:5:182:14 | S1 |
+| main.rs:332:39:332:40 | S2 |  | main.rs:183:5:184:14 | S2 |
+| main.rs:333:18:333:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:333:26:333:27 | p2 |  | main.rs:175:5:179:5 | MyPair |
+| main.rs:333:26:333:27 | p2 | P1 | main.rs:181:5:182:14 | S1 |
+| main.rs:333:26:333:27 | p2 | P2 | main.rs:183:5:184:14 | S2 |
+| main.rs:333:26:333:32 | p2.m1() |  | main.rs:185:5:186:14 | S3 |
+| main.rs:335:13:335:14 | p3 |  | main.rs:175:5:179:5 | MyPair |
+| main.rs:335:13:335:14 | p3 | P1 | main.rs:170:5:173:5 | MyThing |
+| main.rs:335:13:335:14 | p3 | P1.A | main.rs:181:5:182:14 | S1 |
+| main.rs:335:13:335:14 | p3 | P2 | main.rs:185:5:186:14 | S3 |
+| main.rs:335:18:338:9 | MyPair {...} |  | main.rs:175:5:179:5 | MyPair |
+| main.rs:335:18:338:9 | MyPair {...} | P1 | main.rs:170:5:173:5 | MyThing |
+| main.rs:335:18:338:9 | MyPair {...} | P1.A | main.rs:181:5:182:14 | S1 |
+| main.rs:335:18:338:9 | MyPair {...} | P2 | main.rs:185:5:186:14 | S3 |
+| main.rs:336:17:336:33 | MyThing {...} |  | main.rs:170:5:173:5 | MyThing |
+| main.rs:336:17:336:33 | MyThing {...} | A | main.rs:181:5:182:14 | S1 |
+| main.rs:336:30:336:31 | S1 |  | main.rs:181:5:182:14 | S1 |
+| main.rs:337:17:337:18 | S3 |  | main.rs:185:5:186:14 | S3 |
+| main.rs:339:18:339:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:339:26:339:27 | p3 |  | main.rs:175:5:179:5 | MyPair |
+| main.rs:339:26:339:27 | p3 | P1 | main.rs:170:5:173:5 | MyThing |
+| main.rs:339:26:339:27 | p3 | P1.A | main.rs:181:5:182:14 | S1 |
+| main.rs:339:26:339:27 | p3 | P2 | main.rs:185:5:186:14 | S3 |
+| main.rs:339:26:339:32 | p3.m1() |  | main.rs:181:5:182:14 | S1 |
+| main.rs:342:13:342:13 | a |  | main.rs:175:5:179:5 | MyPair |
+| main.rs:342:13:342:13 | a | P1 | main.rs:181:5:182:14 | S1 |
+| main.rs:342:13:342:13 | a | P2 | main.rs:181:5:182:14 | S1 |
+| main.rs:342:17:342:41 | MyPair {...} |  | main.rs:175:5:179:5 | MyPair |
+| main.rs:342:17:342:41 | MyPair {...} | P1 | main.rs:181:5:182:14 | S1 |
+| main.rs:342:17:342:41 | MyPair {...} | P2 | main.rs:181:5:182:14 | S1 |
+| main.rs:342:30:342:31 | S1 |  | main.rs:181:5:182:14 | S1 |
+| main.rs:342:38:342:39 | S1 |  | main.rs:181:5:182:14 | S1 |
+| main.rs:343:13:343:13 | x |  | main.rs:181:5:182:14 | S1 |
+| main.rs:343:17:343:17 | a |  | main.rs:175:5:179:5 | MyPair |
+| main.rs:343:17:343:17 | a | P1 | main.rs:181:5:182:14 | S1 |
+| main.rs:343:17:343:17 | a | P2 | main.rs:181:5:182:14 | S1 |
+| main.rs:343:17:343:23 | a.fst() |  | main.rs:181:5:182:14 | S1 |
 | main.rs:344:18:344:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:344:26:344:26 | y |  | main.rs:155:5:156:14 | S1 |
-| main.rs:347:13:347:13 | b |  | main.rs:149:5:153:5 | MyPair |
-| main.rs:347:13:347:13 | b | P1 | main.rs:157:5:158:14 | S2 |
-| main.rs:347:13:347:13 | b | P2 | main.rs:155:5:156:14 | S1 |
-| main.rs:347:17:347:41 | MyPair {...} |  | main.rs:149:5:153:5 | MyPair |
-| main.rs:347:17:347:41 | MyPair {...} | P1 | main.rs:157:5:158:14 | S2 |
-| main.rs:347:17:347:41 | MyPair {...} | P2 | main.rs:155:5:156:14 | S1 |
-| main.rs:347:30:347:31 | S2 |  | main.rs:157:5:158:14 | S2 |
-| main.rs:347:38:347:39 | S1 |  | main.rs:155:5:156:14 | S1 |
-| main.rs:348:13:348:13 | x |  | main.rs:155:5:156:14 | S1 |
-| main.rs:348:17:348:26 | get_fst(...) |  | main.rs:155:5:156:14 | S1 |
-| main.rs:348:25:348:25 | b |  | main.rs:149:5:153:5 | MyPair |
-| main.rs:348:25:348:25 | b | P1 | main.rs:157:5:158:14 | S2 |
-| main.rs:348:25:348:25 | b | P2 | main.rs:155:5:156:14 | S1 |
-| main.rs:349:18:349:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:349:26:349:26 | x |  | main.rs:155:5:156:14 | S1 |
-| main.rs:350:13:350:13 | y |  | main.rs:157:5:158:14 | S2 |
-| main.rs:350:17:350:26 | get_snd(...) |  | main.rs:157:5:158:14 | S2 |
-| main.rs:350:25:350:25 | b |  | main.rs:149:5:153:5 | MyPair |
-| main.rs:350:25:350:25 | b | P1 | main.rs:157:5:158:14 | S2 |
-| main.rs:350:25:350:25 | b | P2 | main.rs:155:5:156:14 | S1 |
-| main.rs:351:18:351:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:351:26:351:26 | y |  | main.rs:157:5:158:14 | S2 |
-| main.rs:353:13:353:13 | c |  | main.rs:149:5:153:5 | MyPair |
-| main.rs:353:13:353:13 | c | P1 | main.rs:159:5:160:14 | S3 |
-| main.rs:353:13:353:13 | c | P2 | main.rs:149:5:153:5 | MyPair |
-| main.rs:353:13:353:13 | c | P2.P1 | main.rs:157:5:158:14 | S2 |
-| main.rs:353:13:353:13 | c | P2.P2 | main.rs:155:5:156:14 | S1 |
-| main.rs:353:17:356:9 | MyPair {...} |  | main.rs:149:5:153:5 | MyPair |
-| main.rs:353:17:356:9 | MyPair {...} | P1 | main.rs:159:5:160:14 | S3 |
-| main.rs:353:17:356:9 | MyPair {...} | P2 | main.rs:149:5:153:5 | MyPair |
-| main.rs:353:17:356:9 | MyPair {...} | P2.P1 | main.rs:157:5:158:14 | S2 |
-| main.rs:353:17:356:9 | MyPair {...} | P2.P2 | main.rs:155:5:156:14 | S1 |
-| main.rs:354:17:354:18 | S3 |  | main.rs:159:5:160:14 | S3 |
-| main.rs:355:17:355:41 | MyPair {...} |  | main.rs:149:5:153:5 | MyPair |
-| main.rs:355:17:355:41 | MyPair {...} | P1 | main.rs:157:5:158:14 | S2 |
-| main.rs:355:17:355:41 | MyPair {...} | P2 | main.rs:155:5:156:14 | S1 |
-| main.rs:355:30:355:31 | S2 |  | main.rs:157:5:158:14 | S2 |
-| main.rs:355:38:355:39 | S1 |  | main.rs:155:5:156:14 | S1 |
-| main.rs:357:13:357:13 | x |  | main.rs:155:5:156:14 | S1 |
-| main.rs:357:17:357:30 | get_snd_fst(...) |  | main.rs:155:5:156:14 | S1 |
-| main.rs:357:29:357:29 | c |  | main.rs:149:5:153:5 | MyPair |
-| main.rs:357:29:357:29 | c | P1 | main.rs:159:5:160:14 | S3 |
-| main.rs:357:29:357:29 | c | P2 | main.rs:149:5:153:5 | MyPair |
-| main.rs:357:29:357:29 | c | P2.P1 | main.rs:157:5:158:14 | S2 |
-| main.rs:357:29:357:29 | c | P2.P2 | main.rs:155:5:156:14 | S1 |
-| main.rs:359:13:359:17 | thing |  | main.rs:144:5:147:5 | MyThing |
-| main.rs:359:13:359:17 | thing | A | main.rs:155:5:156:14 | S1 |
-| main.rs:359:21:359:37 | MyThing {...} |  | main.rs:144:5:147:5 | MyThing |
-| main.rs:359:21:359:37 | MyThing {...} | A | main.rs:155:5:156:14 | S1 |
-| main.rs:359:34:359:35 | S1 |  | main.rs:155:5:156:14 | S1 |
-| main.rs:360:17:360:21 | thing |  | main.rs:144:5:147:5 | MyThing |
-| main.rs:360:17:360:21 | thing | A | main.rs:155:5:156:14 | S1 |
-| main.rs:361:13:361:13 | j |  | main.rs:155:5:156:14 | S1 |
-| main.rs:361:17:361:33 | convert_to(...) |  | main.rs:155:5:156:14 | S1 |
-| main.rs:361:28:361:32 | thing |  | main.rs:144:5:147:5 | MyThing |
-| main.rs:361:28:361:32 | thing | A | main.rs:155:5:156:14 | S1 |
-| main.rs:370:26:370:29 | SelfParam |  | main.rs:369:5:373:5 | Self [trait OverlappingTrait] |
-| main.rs:372:28:372:31 | SelfParam |  | main.rs:369:5:373:5 | Self [trait OverlappingTrait] |
-| main.rs:372:34:372:35 | s1 |  | main.rs:366:5:367:14 | S1 |
-| main.rs:377:26:377:29 | SelfParam |  | main.rs:366:5:367:14 | S1 |
-| main.rs:377:38:379:9 | { ... } |  | main.rs:366:5:367:14 | S1 |
-| main.rs:378:20:378:31 | "not called" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:382:28:382:31 | SelfParam |  | main.rs:366:5:367:14 | S1 |
-| main.rs:382:34:382:35 | s1 |  | main.rs:366:5:367:14 | S1 |
-| main.rs:382:48:384:9 | { ... } |  | main.rs:366:5:367:14 | S1 |
-| main.rs:383:20:383:31 | "not called" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:389:26:389:29 | SelfParam |  | main.rs:366:5:367:14 | S1 |
-| main.rs:389:38:391:9 | { ... } |  | main.rs:366:5:367:14 | S1 |
-| main.rs:390:13:390:16 | self |  | main.rs:366:5:367:14 | S1 |
-| main.rs:394:28:394:31 | SelfParam |  | main.rs:366:5:367:14 | S1 |
-| main.rs:394:40:396:9 | { ... } |  | main.rs:366:5:367:14 | S1 |
-| main.rs:395:13:395:16 | self |  | main.rs:366:5:367:14 | S1 |
-| main.rs:400:13:400:13 | x |  | main.rs:366:5:367:14 | S1 |
-| main.rs:400:17:400:18 | S1 |  | main.rs:366:5:367:14 | S1 |
-| main.rs:401:18:401:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:401:26:401:26 | x |  | main.rs:366:5:367:14 | S1 |
-| main.rs:401:26:401:42 | x.common_method() |  | main.rs:366:5:367:14 | S1 |
-| main.rs:402:18:402:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:402:26:402:26 | x |  | main.rs:366:5:367:14 | S1 |
-| main.rs:402:26:402:44 | x.common_method_2() |  | main.rs:366:5:367:14 | S1 |
-| main.rs:419:19:419:22 | SelfParam |  | main.rs:417:5:420:5 | Self [trait FirstTrait] |
-| main.rs:424:19:424:22 | SelfParam |  | main.rs:422:5:425:5 | Self [trait SecondTrait] |
-| main.rs:427:64:427:64 | x |  | main.rs:427:45:427:61 | T |
-| main.rs:429:13:429:14 | s1 |  | main.rs:427:35:427:42 | I |
-| main.rs:429:18:429:18 | x |  | main.rs:427:45:427:61 | T |
-| main.rs:429:18:429:27 | x.method() |  | main.rs:427:35:427:42 | I |
-| main.rs:430:18:430:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:430:26:430:27 | s1 |  | main.rs:427:35:427:42 | I |
-| main.rs:433:65:433:65 | x |  | main.rs:433:46:433:62 | T |
-| main.rs:435:13:435:14 | s2 |  | main.rs:433:36:433:43 | I |
-| main.rs:435:18:435:18 | x |  | main.rs:433:46:433:62 | T |
-| main.rs:435:18:435:27 | x.method() |  | main.rs:433:36:433:43 | I |
-| main.rs:436:18:436:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:436:26:436:27 | s2 |  | main.rs:433:36:433:43 | I |
-| main.rs:439:49:439:49 | x |  | main.rs:439:30:439:46 | T |
-| main.rs:440:13:440:13 | s |  | main.rs:409:5:410:14 | S1 |
-| main.rs:440:17:440:17 | x |  | main.rs:439:30:439:46 | T |
-| main.rs:440:17:440:26 | x.method() |  | main.rs:409:5:410:14 | S1 |
-| main.rs:441:18:441:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:441:26:441:26 | s |  | main.rs:409:5:410:14 | S1 |
-| main.rs:444:53:444:53 | x |  | main.rs:444:34:444:50 | T |
-| main.rs:445:13:445:13 | s |  | main.rs:409:5:410:14 | S1 |
-| main.rs:445:17:445:17 | x |  | main.rs:444:34:444:50 | T |
-| main.rs:445:17:445:26 | x.method() |  | main.rs:409:5:410:14 | S1 |
-| main.rs:446:18:446:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:446:26:446:26 | s |  | main.rs:409:5:410:14 | S1 |
-| main.rs:450:16:450:19 | SelfParam |  | main.rs:449:5:453:5 | Self [trait Pair] |
-| main.rs:452:16:452:19 | SelfParam |  | main.rs:449:5:453:5 | Self [trait Pair] |
-| main.rs:455:58:455:58 | x |  | main.rs:455:41:455:55 | T |
-| main.rs:455:64:455:64 | y |  | main.rs:455:41:455:55 | T |
-| main.rs:457:13:457:14 | s1 |  | main.rs:409:5:410:14 | S1 |
-| main.rs:457:18:457:18 | x |  | main.rs:455:41:455:55 | T |
-| main.rs:457:18:457:24 | x.fst() |  | main.rs:409:5:410:14 | S1 |
-| main.rs:458:13:458:14 | s2 |  | main.rs:412:5:413:14 | S2 |
-| main.rs:458:18:458:18 | y |  | main.rs:455:41:455:55 | T |
-| main.rs:458:18:458:24 | y.snd() |  | main.rs:412:5:413:14 | S2 |
-| main.rs:459:18:459:29 | "{:?}, {:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:459:32:459:33 | s1 |  | main.rs:409:5:410:14 | S1 |
-| main.rs:459:36:459:37 | s2 |  | main.rs:412:5:413:14 | S2 |
-| main.rs:462:69:462:69 | x |  | main.rs:462:52:462:66 | T |
-| main.rs:462:75:462:75 | y |  | main.rs:462:52:462:66 | T |
-| main.rs:464:13:464:14 | s1 |  | main.rs:409:5:410:14 | S1 |
-| main.rs:464:18:464:18 | x |  | main.rs:462:52:462:66 | T |
-| main.rs:464:18:464:24 | x.fst() |  | main.rs:409:5:410:14 | S1 |
-| main.rs:465:13:465:14 | s2 |  | main.rs:462:41:462:49 | T2 |
-| main.rs:465:18:465:18 | y |  | main.rs:462:52:462:66 | T |
-| main.rs:465:18:465:24 | y.snd() |  | main.rs:462:41:462:49 | T2 |
-| main.rs:466:18:466:29 | "{:?}, {:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:466:32:466:33 | s1 |  | main.rs:409:5:410:14 | S1 |
-| main.rs:466:36:466:37 | s2 |  | main.rs:462:41:462:49 | T2 |
-| main.rs:482:15:482:18 | SelfParam |  | main.rs:481:5:490:5 | Self [trait MyTrait] |
-| main.rs:484:15:484:18 | SelfParam |  | main.rs:481:5:490:5 | Self [trait MyTrait] |
-| main.rs:487:9:489:9 | { ... } |  | main.rs:481:19:481:19 | A |
-| main.rs:488:13:488:16 | self |  | main.rs:481:5:490:5 | Self [trait MyTrait] |
-| main.rs:488:13:488:21 | self.m1() |  | main.rs:481:19:481:19 | A |
-| main.rs:493:43:493:43 | x |  | main.rs:493:26:493:40 | T2 |
-| main.rs:493:56:495:5 | { ... } |  | main.rs:493:22:493:23 | T1 |
-| main.rs:494:9:494:9 | x |  | main.rs:493:26:493:40 | T2 |
-| main.rs:494:9:494:14 | x.m1() |  | main.rs:493:22:493:23 | T1 |
-| main.rs:498:49:498:49 | x |  | main.rs:471:5:474:5 | MyThing |
-| main.rs:498:49:498:49 | x | T | main.rs:498:32:498:46 | T2 |
-| main.rs:498:71:500:5 | { ... } |  | main.rs:498:28:498:29 | T1 |
-| main.rs:499:9:499:9 | x |  | main.rs:471:5:474:5 | MyThing |
-| main.rs:499:9:499:9 | x | T | main.rs:498:32:498:46 | T2 |
-| main.rs:499:9:499:11 | x.a |  | main.rs:498:32:498:46 | T2 |
-| main.rs:499:9:499:16 | ... .m1() |  | main.rs:498:28:498:29 | T1 |
-| main.rs:503:15:503:18 | SelfParam |  | main.rs:471:5:474:5 | MyThing |
-| main.rs:503:15:503:18 | SelfParam | T | main.rs:502:10:502:10 | T |
-| main.rs:503:26:505:9 | { ... } |  | main.rs:502:10:502:10 | T |
-| main.rs:504:13:504:16 | self |  | main.rs:471:5:474:5 | MyThing |
-| main.rs:504:13:504:16 | self | T | main.rs:502:10:502:10 | T |
-| main.rs:504:13:504:18 | self.a |  | main.rs:502:10:502:10 | T |
-| main.rs:509:13:509:13 | x |  | main.rs:471:5:474:5 | MyThing |
-| main.rs:509:13:509:13 | x | T | main.rs:476:5:477:14 | S1 |
-| main.rs:509:17:509:33 | MyThing {...} |  | main.rs:471:5:474:5 | MyThing |
-| main.rs:509:17:509:33 | MyThing {...} | T | main.rs:476:5:477:14 | S1 |
-| main.rs:509:30:509:31 | S1 |  | main.rs:476:5:477:14 | S1 |
-| main.rs:510:13:510:13 | y |  | main.rs:471:5:474:5 | MyThing |
-| main.rs:510:13:510:13 | y | T | main.rs:478:5:479:14 | S2 |
-| main.rs:510:17:510:33 | MyThing {...} |  | main.rs:471:5:474:5 | MyThing |
-| main.rs:510:17:510:33 | MyThing {...} | T | main.rs:478:5:479:14 | S2 |
-| main.rs:510:30:510:31 | S2 |  | main.rs:478:5:479:14 | S2 |
-| main.rs:512:18:512:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:512:26:512:26 | x |  | main.rs:471:5:474:5 | MyThing |
-| main.rs:512:26:512:26 | x | T | main.rs:476:5:477:14 | S1 |
-| main.rs:512:26:512:31 | x.m1() |  | main.rs:476:5:477:14 | S1 |
-| main.rs:513:18:513:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:513:26:513:26 | y |  | main.rs:471:5:474:5 | MyThing |
-| main.rs:513:26:513:26 | y | T | main.rs:478:5:479:14 | S2 |
-| main.rs:513:26:513:31 | y.m1() |  | main.rs:478:5:479:14 | S2 |
-| main.rs:515:13:515:13 | x |  | main.rs:471:5:474:5 | MyThing |
-| main.rs:515:13:515:13 | x | T | main.rs:476:5:477:14 | S1 |
-| main.rs:515:17:515:33 | MyThing {...} |  | main.rs:471:5:474:5 | MyThing |
-| main.rs:515:17:515:33 | MyThing {...} | T | main.rs:476:5:477:14 | S1 |
-| main.rs:515:30:515:31 | S1 |  | main.rs:476:5:477:14 | S1 |
-| main.rs:516:13:516:13 | y |  | main.rs:471:5:474:5 | MyThing |
-| main.rs:516:13:516:13 | y | T | main.rs:478:5:479:14 | S2 |
-| main.rs:516:17:516:33 | MyThing {...} |  | main.rs:471:5:474:5 | MyThing |
-| main.rs:516:17:516:33 | MyThing {...} | T | main.rs:478:5:479:14 | S2 |
-| main.rs:516:30:516:31 | S2 |  | main.rs:478:5:479:14 | S2 |
-| main.rs:518:18:518:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:518:26:518:26 | x |  | main.rs:471:5:474:5 | MyThing |
-| main.rs:518:26:518:26 | x | T | main.rs:476:5:477:14 | S1 |
-| main.rs:518:26:518:31 | x.m2() |  | main.rs:476:5:477:14 | S1 |
-| main.rs:519:18:519:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:519:26:519:26 | y |  | main.rs:471:5:474:5 | MyThing |
-| main.rs:519:26:519:26 | y | T | main.rs:478:5:479:14 | S2 |
-| main.rs:519:26:519:31 | y.m2() |  | main.rs:478:5:479:14 | S2 |
-| main.rs:521:13:521:14 | x2 |  | main.rs:471:5:474:5 | MyThing |
-| main.rs:521:13:521:14 | x2 | T | main.rs:476:5:477:14 | S1 |
-| main.rs:521:18:521:34 | MyThing {...} |  | main.rs:471:5:474:5 | MyThing |
-| main.rs:521:18:521:34 | MyThing {...} | T | main.rs:476:5:477:14 | S1 |
-| main.rs:521:31:521:32 | S1 |  | main.rs:476:5:477:14 | S1 |
-| main.rs:522:13:522:14 | y2 |  | main.rs:471:5:474:5 | MyThing |
-| main.rs:522:13:522:14 | y2 | T | main.rs:478:5:479:14 | S2 |
-| main.rs:522:18:522:34 | MyThing {...} |  | main.rs:471:5:474:5 | MyThing |
-| main.rs:522:18:522:34 | MyThing {...} | T | main.rs:478:5:479:14 | S2 |
-| main.rs:522:31:522:32 | S2 |  | main.rs:478:5:479:14 | S2 |
-| main.rs:524:18:524:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:524:26:524:42 | call_trait_m1(...) |  | main.rs:476:5:477:14 | S1 |
-| main.rs:524:40:524:41 | x2 |  | main.rs:471:5:474:5 | MyThing |
-| main.rs:524:40:524:41 | x2 | T | main.rs:476:5:477:14 | S1 |
-| main.rs:525:18:525:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:525:26:525:42 | call_trait_m1(...) |  | main.rs:478:5:479:14 | S2 |
-| main.rs:525:40:525:41 | y2 |  | main.rs:471:5:474:5 | MyThing |
-| main.rs:525:40:525:41 | y2 | T | main.rs:478:5:479:14 | S2 |
-| main.rs:527:13:527:14 | x3 |  | main.rs:471:5:474:5 | MyThing |
-| main.rs:527:13:527:14 | x3 | T | main.rs:471:5:474:5 | MyThing |
-| main.rs:527:13:527:14 | x3 | T.T | main.rs:476:5:477:14 | S1 |
-| main.rs:527:18:529:9 | MyThing {...} |  | main.rs:471:5:474:5 | MyThing |
-| main.rs:527:18:529:9 | MyThing {...} | T | main.rs:471:5:474:5 | MyThing |
-| main.rs:527:18:529:9 | MyThing {...} | T.T | main.rs:476:5:477:14 | S1 |
-| main.rs:528:16:528:32 | MyThing {...} |  | main.rs:471:5:474:5 | MyThing |
-| main.rs:528:16:528:32 | MyThing {...} | T | main.rs:476:5:477:14 | S1 |
-| main.rs:528:29:528:30 | S1 |  | main.rs:476:5:477:14 | S1 |
-| main.rs:530:13:530:14 | y3 |  | main.rs:471:5:474:5 | MyThing |
-| main.rs:530:13:530:14 | y3 | T | main.rs:471:5:474:5 | MyThing |
-| main.rs:530:13:530:14 | y3 | T.T | main.rs:478:5:479:14 | S2 |
-| main.rs:530:18:532:9 | MyThing {...} |  | main.rs:471:5:474:5 | MyThing |
-| main.rs:530:18:532:9 | MyThing {...} | T | main.rs:471:5:474:5 | MyThing |
-| main.rs:530:18:532:9 | MyThing {...} | T.T | main.rs:478:5:479:14 | S2 |
-| main.rs:531:16:531:32 | MyThing {...} |  | main.rs:471:5:474:5 | MyThing |
-| main.rs:531:16:531:32 | MyThing {...} | T | main.rs:478:5:479:14 | S2 |
-| main.rs:531:29:531:30 | S2 |  | main.rs:478:5:479:14 | S2 |
-| main.rs:534:13:534:13 | a |  | main.rs:476:5:477:14 | S1 |
-| main.rs:534:17:534:39 | call_trait_thing_m1(...) |  | main.rs:476:5:477:14 | S1 |
-| main.rs:534:37:534:38 | x3 |  | main.rs:471:5:474:5 | MyThing |
-| main.rs:534:37:534:38 | x3 | T | main.rs:471:5:474:5 | MyThing |
-| main.rs:534:37:534:38 | x3 | T.T | main.rs:476:5:477:14 | S1 |
-| main.rs:535:18:535:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:535:26:535:26 | a |  | main.rs:476:5:477:14 | S1 |
-| main.rs:536:13:536:13 | b |  | main.rs:478:5:479:14 | S2 |
-| main.rs:536:17:536:39 | call_trait_thing_m1(...) |  | main.rs:478:5:479:14 | S2 |
-| main.rs:536:37:536:38 | y3 |  | main.rs:471:5:474:5 | MyThing |
-| main.rs:536:37:536:38 | y3 | T | main.rs:471:5:474:5 | MyThing |
-| main.rs:536:37:536:38 | y3 | T.T | main.rs:478:5:479:14 | S2 |
-| main.rs:537:18:537:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:537:26:537:26 | b |  | main.rs:478:5:479:14 | S2 |
-| main.rs:548:19:548:22 | SelfParam |  | main.rs:542:5:545:5 | Wrapper |
-| main.rs:548:19:548:22 | SelfParam | A | main.rs:547:10:547:10 | A |
-| main.rs:548:30:550:9 | { ... } |  | main.rs:547:10:547:10 | A |
-| main.rs:549:13:549:16 | self |  | main.rs:542:5:545:5 | Wrapper |
-| main.rs:549:13:549:16 | self | A | main.rs:547:10:547:10 | A |
-| main.rs:549:13:549:22 | self.field |  | main.rs:547:10:547:10 | A |
-| main.rs:557:15:557:18 | SelfParam |  | main.rs:553:5:567:5 | Self [trait MyTrait] |
-| main.rs:559:15:559:18 | SelfParam |  | main.rs:553:5:567:5 | Self [trait MyTrait] |
-| main.rs:563:9:566:9 | { ... } |  | main.rs:554:9:554:28 | AssociatedType |
-| main.rs:564:13:564:16 | self |  | main.rs:553:5:567:5 | Self [trait MyTrait] |
-| main.rs:564:13:564:21 | self.m1() |  | main.rs:554:9:554:28 | AssociatedType |
-| main.rs:565:13:565:43 | ...::default(...) |  | main.rs:554:9:554:28 | AssociatedType |
-| main.rs:573:19:573:23 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:573:19:573:23 | SelfParam | &T | main.rs:569:5:579:5 | Self [trait MyTraitAssoc2] |
-| main.rs:573:26:573:26 | a |  | main.rs:573:16:573:16 | A |
-| main.rs:575:22:575:26 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:575:22:575:26 | SelfParam | &T | main.rs:569:5:579:5 | Self [trait MyTraitAssoc2] |
-| main.rs:575:29:575:29 | a |  | main.rs:575:19:575:19 | A |
-| main.rs:575:35:575:35 | b |  | main.rs:575:19:575:19 | A |
-| main.rs:575:75:578:9 | { ... } |  | main.rs:570:9:570:52 | GenericAssociatedType |
-| main.rs:576:13:576:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:576:13:576:16 | self | &T | main.rs:569:5:579:5 | Self [trait MyTraitAssoc2] |
-| main.rs:576:13:576:23 | self.put(...) |  | main.rs:570:9:570:52 | GenericAssociatedType |
-| main.rs:576:22:576:22 | a |  | main.rs:575:19:575:19 | A |
-| main.rs:577:13:577:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:577:13:577:16 | self | &T | main.rs:569:5:579:5 | Self [trait MyTraitAssoc2] |
-| main.rs:577:13:577:23 | self.put(...) |  | main.rs:570:9:570:52 | GenericAssociatedType |
-| main.rs:577:22:577:22 | b |  | main.rs:575:19:575:19 | A |
-| main.rs:586:21:586:25 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:586:21:586:25 | SelfParam | &T | main.rs:581:5:591:5 | Self [trait TraitMultipleAssoc] |
-| main.rs:588:20:588:24 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:588:20:588:24 | SelfParam | &T | main.rs:581:5:591:5 | Self [trait TraitMultipleAssoc] |
-| main.rs:590:20:590:24 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:590:20:590:24 | SelfParam | &T | main.rs:581:5:591:5 | Self [trait TraitMultipleAssoc] |
-| main.rs:606:15:606:18 | SelfParam |  | main.rs:593:5:594:13 | S |
-| main.rs:606:45:608:9 | { ... } |  | main.rs:599:5:600:14 | AT |
-| main.rs:607:13:607:14 | AT |  | main.rs:599:5:600:14 | AT |
-| main.rs:616:19:616:23 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:616:19:616:23 | SelfParam | &T | main.rs:593:5:594:13 | S |
-| main.rs:616:26:616:26 | a |  | main.rs:616:16:616:16 | A |
-| main.rs:616:46:618:9 | { ... } |  | main.rs:542:5:545:5 | Wrapper |
-| main.rs:616:46:618:9 | { ... } | A | main.rs:616:16:616:16 | A |
-| main.rs:617:13:617:32 | Wrapper {...} |  | main.rs:542:5:545:5 | Wrapper |
-| main.rs:617:13:617:32 | Wrapper {...} | A | main.rs:616:16:616:16 | A |
-| main.rs:617:30:617:30 | a |  | main.rs:616:16:616:16 | A |
-| main.rs:625:15:625:18 | SelfParam |  | main.rs:596:5:597:14 | S2 |
-| main.rs:625:45:627:9 | { ... } |  | main.rs:542:5:545:5 | Wrapper |
-| main.rs:625:45:627:9 | { ... } | A | main.rs:596:5:597:14 | S2 |
-| main.rs:626:13:626:35 | Wrapper {...} |  | main.rs:542:5:545:5 | Wrapper |
-| main.rs:626:13:626:35 | Wrapper {...} | A | main.rs:596:5:597:14 | S2 |
-| main.rs:626:30:626:33 | self |  | main.rs:596:5:597:14 | S2 |
-| main.rs:632:30:634:9 | { ... } |  | main.rs:542:5:545:5 | Wrapper |
-| main.rs:632:30:634:9 | { ... } | A | main.rs:596:5:597:14 | S2 |
-| main.rs:633:13:633:33 | Wrapper {...} |  | main.rs:542:5:545:5 | Wrapper |
-| main.rs:633:13:633:33 | Wrapper {...} | A | main.rs:596:5:597:14 | S2 |
-| main.rs:633:30:633:31 | S2 |  | main.rs:596:5:597:14 | S2 |
-| main.rs:638:22:638:26 | thing |  | main.rs:638:10:638:19 | T |
-| main.rs:639:9:639:13 | thing |  | main.rs:638:10:638:19 | T |
-| main.rs:646:21:646:25 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:646:21:646:25 | SelfParam | &T | main.rs:599:5:600:14 | AT |
-| main.rs:646:34:648:9 | { ... } |  | main.rs:599:5:600:14 | AT |
-| main.rs:647:13:647:14 | AT |  | main.rs:599:5:600:14 | AT |
-| main.rs:650:20:650:24 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:650:20:650:24 | SelfParam | &T | main.rs:599:5:600:14 | AT |
-| main.rs:650:43:652:9 | { ... } |  | main.rs:593:5:594:13 | S |
-| main.rs:651:13:651:13 | S |  | main.rs:593:5:594:13 | S |
-| main.rs:654:20:654:24 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:654:20:654:24 | SelfParam | &T | main.rs:599:5:600:14 | AT |
-| main.rs:654:43:656:9 | { ... } |  | main.rs:596:5:597:14 | S2 |
-| main.rs:655:13:655:14 | S2 |  | main.rs:596:5:597:14 | S2 |
-| main.rs:660:13:660:14 | x1 |  | main.rs:593:5:594:13 | S |
-| main.rs:660:18:660:18 | S |  | main.rs:593:5:594:13 | S |
-| main.rs:662:18:662:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:662:26:662:27 | x1 |  | main.rs:593:5:594:13 | S |
-| main.rs:662:26:662:32 | x1.m1() |  | main.rs:599:5:600:14 | AT |
-| main.rs:664:13:664:14 | x2 |  | main.rs:593:5:594:13 | S |
-| main.rs:664:18:664:18 | S |  | main.rs:593:5:594:13 | S |
-| main.rs:666:13:666:13 | y |  | main.rs:599:5:600:14 | AT |
-| main.rs:666:17:666:18 | x2 |  | main.rs:593:5:594:13 | S |
-| main.rs:666:17:666:23 | x2.m2() |  | main.rs:599:5:600:14 | AT |
-| main.rs:667:18:667:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:667:26:667:26 | y |  | main.rs:599:5:600:14 | AT |
-| main.rs:669:13:669:14 | x3 |  | main.rs:593:5:594:13 | S |
-| main.rs:669:18:669:18 | S |  | main.rs:593:5:594:13 | S |
-| main.rs:671:18:671:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:671:26:671:27 | x3 |  | main.rs:593:5:594:13 | S |
-| main.rs:671:26:671:34 | x3.put(...) |  | main.rs:542:5:545:5 | Wrapper |
-| main.rs:671:26:671:34 | x3.put(...) | A | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:671:26:671:43 | ... .unwrap() |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:671:33:671:33 | 1 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:674:18:674:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:674:26:674:27 | x3 |  | main.rs:593:5:594:13 | S |
-| main.rs:674:36:674:36 | 2 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:674:39:674:39 | 3 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:676:20:676:20 | S |  | main.rs:593:5:594:13 | S |
-| main.rs:677:18:677:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:679:13:679:14 | x5 |  | main.rs:596:5:597:14 | S2 |
-| main.rs:679:18:679:19 | S2 |  | main.rs:596:5:597:14 | S2 |
-| main.rs:680:18:680:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:680:26:680:27 | x5 |  | main.rs:596:5:597:14 | S2 |
-| main.rs:680:26:680:32 | x5.m1() |  | main.rs:542:5:545:5 | Wrapper |
-| main.rs:680:26:680:32 | x5.m1() | A | main.rs:596:5:597:14 | S2 |
-| main.rs:681:13:681:14 | x6 |  | main.rs:596:5:597:14 | S2 |
-| main.rs:681:18:681:19 | S2 |  | main.rs:596:5:597:14 | S2 |
-| main.rs:682:18:682:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:682:26:682:27 | x6 |  | main.rs:596:5:597:14 | S2 |
-| main.rs:682:26:682:32 | x6.m2() |  | main.rs:542:5:545:5 | Wrapper |
-| main.rs:682:26:682:32 | x6.m2() | A | main.rs:596:5:597:14 | S2 |
-| main.rs:684:13:684:22 | assoc_zero |  | main.rs:599:5:600:14 | AT |
-| main.rs:684:26:684:27 | AT |  | main.rs:599:5:600:14 | AT |
-| main.rs:684:26:684:38 | AT.get_zero() |  | main.rs:599:5:600:14 | AT |
-| main.rs:685:13:685:21 | assoc_one |  | main.rs:593:5:594:13 | S |
-| main.rs:685:25:685:26 | AT |  | main.rs:599:5:600:14 | AT |
-| main.rs:685:25:685:36 | AT.get_one() |  | main.rs:593:5:594:13 | S |
-| main.rs:686:13:686:21 | assoc_two |  | main.rs:596:5:597:14 | S2 |
-| main.rs:686:25:686:26 | AT |  | main.rs:599:5:600:14 | AT |
-| main.rs:686:25:686:36 | AT.get_two() |  | main.rs:596:5:597:14 | S2 |
-| main.rs:703:15:703:18 | SelfParam |  | main.rs:691:5:695:5 | MyEnum |
-| main.rs:703:15:703:18 | SelfParam | A | main.rs:702:10:702:10 | T |
-| main.rs:703:26:708:9 | { ... } |  | main.rs:702:10:702:10 | T |
-| main.rs:704:13:707:13 | match self { ... } |  | main.rs:702:10:702:10 | T |
-| main.rs:704:19:704:22 | self |  | main.rs:691:5:695:5 | MyEnum |
-| main.rs:704:19:704:22 | self | A | main.rs:702:10:702:10 | T |
-| main.rs:705:28:705:28 | a |  | main.rs:702:10:702:10 | T |
-| main.rs:705:34:705:34 | a |  | main.rs:702:10:702:10 | T |
-| main.rs:706:30:706:30 | a |  | main.rs:702:10:702:10 | T |
-| main.rs:706:37:706:37 | a |  | main.rs:702:10:702:10 | T |
-| main.rs:712:13:712:13 | x |  | main.rs:691:5:695:5 | MyEnum |
-| main.rs:712:13:712:13 | x | A | main.rs:697:5:698:14 | S1 |
-| main.rs:712:17:712:30 | ...::C1(...) |  | main.rs:691:5:695:5 | MyEnum |
-| main.rs:712:17:712:30 | ...::C1(...) | A | main.rs:697:5:698:14 | S1 |
-| main.rs:712:28:712:29 | S1 |  | main.rs:697:5:698:14 | S1 |
-| main.rs:713:13:713:13 | y |  | main.rs:691:5:695:5 | MyEnum |
-| main.rs:713:13:713:13 | y | A | main.rs:699:5:700:14 | S2 |
-| main.rs:713:17:713:36 | ...::C2 {...} |  | main.rs:691:5:695:5 | MyEnum |
-| main.rs:713:17:713:36 | ...::C2 {...} | A | main.rs:699:5:700:14 | S2 |
-| main.rs:713:33:713:34 | S2 |  | main.rs:699:5:700:14 | S2 |
-| main.rs:715:18:715:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:715:26:715:26 | x |  | main.rs:691:5:695:5 | MyEnum |
-| main.rs:715:26:715:26 | x | A | main.rs:697:5:698:14 | S1 |
-| main.rs:715:26:715:31 | x.m1() |  | main.rs:697:5:698:14 | S1 |
-| main.rs:716:18:716:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:716:26:716:26 | y |  | main.rs:691:5:695:5 | MyEnum |
-| main.rs:716:26:716:26 | y | A | main.rs:699:5:700:14 | S2 |
-| main.rs:716:26:716:31 | y.m1() |  | main.rs:699:5:700:14 | S2 |
-| main.rs:738:15:738:18 | SelfParam |  | main.rs:736:5:739:5 | Self [trait MyTrait1] |
-| main.rs:742:15:742:18 | SelfParam |  | main.rs:741:5:752:5 | Self [trait MyTrait2] |
-| main.rs:745:9:751:9 | { ... } |  | main.rs:741:20:741:22 | Tr2 |
-| main.rs:746:13:750:13 | if ... {...} else {...} |  | main.rs:741:20:741:22 | Tr2 |
-| main.rs:746:16:746:16 | 1 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:746:20:746:20 | 1 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:746:24:746:24 | 2 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:746:26:748:13 | { ... } |  | main.rs:741:20:741:22 | Tr2 |
-| main.rs:747:17:747:20 | self |  | main.rs:741:5:752:5 | Self [trait MyTrait2] |
-| main.rs:747:17:747:25 | self.m1() |  | main.rs:741:20:741:22 | Tr2 |
-| main.rs:748:20:750:13 | { ... } |  | main.rs:741:20:741:22 | Tr2 |
-| main.rs:749:17:749:30 | ...::m1(...) |  | main.rs:741:20:741:22 | Tr2 |
-| main.rs:749:26:749:29 | self |  | main.rs:741:5:752:5 | Self [trait MyTrait2] |
-| main.rs:755:15:755:18 | SelfParam |  | main.rs:754:5:765:5 | Self [trait MyTrait3] |
-| main.rs:758:9:764:9 | { ... } |  | main.rs:754:20:754:22 | Tr3 |
-| main.rs:759:13:763:13 | if ... {...} else {...} |  | main.rs:754:20:754:22 | Tr3 |
-| main.rs:759:16:759:16 | 1 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:759:20:759:20 | 1 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:759:24:759:24 | 2 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:759:26:761:13 | { ... } |  | main.rs:754:20:754:22 | Tr3 |
-| main.rs:760:17:760:20 | self |  | main.rs:754:5:765:5 | Self [trait MyTrait3] |
-| main.rs:760:17:760:25 | self.m2() |  | main.rs:721:5:724:5 | MyThing |
-| main.rs:760:17:760:25 | self.m2() | A | main.rs:754:20:754:22 | Tr3 |
-| main.rs:760:17:760:27 | ... .a |  | main.rs:754:20:754:22 | Tr3 |
-| main.rs:761:20:763:13 | { ... } |  | main.rs:754:20:754:22 | Tr3 |
-| main.rs:762:17:762:30 | ...::m2(...) |  | main.rs:721:5:724:5 | MyThing |
-| main.rs:762:17:762:30 | ...::m2(...) | A | main.rs:754:20:754:22 | Tr3 |
-| main.rs:762:17:762:32 | ... .a |  | main.rs:754:20:754:22 | Tr3 |
-| main.rs:762:26:762:29 | self |  | main.rs:754:5:765:5 | Self [trait MyTrait3] |
-| main.rs:769:15:769:18 | SelfParam |  | main.rs:721:5:724:5 | MyThing |
-| main.rs:769:15:769:18 | SelfParam | A | main.rs:767:10:767:10 | T |
-| main.rs:769:26:771:9 | { ... } |  | main.rs:767:10:767:10 | T |
-| main.rs:770:13:770:16 | self |  | main.rs:721:5:724:5 | MyThing |
-| main.rs:770:13:770:16 | self | A | main.rs:767:10:767:10 | T |
-| main.rs:770:13:770:18 | self.a |  | main.rs:767:10:767:10 | T |
-| main.rs:778:15:778:18 | SelfParam |  | main.rs:726:5:729:5 | MyThing2 |
-| main.rs:778:15:778:18 | SelfParam | A | main.rs:776:10:776:10 | T |
-| main.rs:778:35:780:9 | { ... } |  | main.rs:721:5:724:5 | MyThing |
-| main.rs:778:35:780:9 | { ... } | A | main.rs:776:10:776:10 | T |
-| main.rs:779:13:779:33 | MyThing {...} |  | main.rs:721:5:724:5 | MyThing |
-| main.rs:779:13:779:33 | MyThing {...} | A | main.rs:776:10:776:10 | T |
-| main.rs:779:26:779:29 | self |  | main.rs:726:5:729:5 | MyThing2 |
-| main.rs:779:26:779:29 | self | A | main.rs:776:10:776:10 | T |
-| main.rs:779:26:779:31 | self.a |  | main.rs:776:10:776:10 | T |
-| main.rs:787:44:787:44 | x |  | main.rs:787:26:787:41 | T2 |
-| main.rs:787:57:789:5 | { ... } |  | main.rs:787:22:787:23 | T1 |
-| main.rs:788:9:788:9 | x |  | main.rs:787:26:787:41 | T2 |
-| main.rs:788:9:788:14 | x.m1() |  | main.rs:787:22:787:23 | T1 |
-| main.rs:791:56:791:56 | x |  | main.rs:791:39:791:53 | T |
-| main.rs:793:13:793:13 | a |  | main.rs:721:5:724:5 | MyThing |
-| main.rs:793:13:793:13 | a | A | main.rs:731:5:732:14 | S1 |
-| main.rs:793:17:793:17 | x |  | main.rs:791:39:791:53 | T |
-| main.rs:793:17:793:22 | x.m1() |  | main.rs:721:5:724:5 | MyThing |
-| main.rs:793:17:793:22 | x.m1() | A | main.rs:731:5:732:14 | S1 |
-| main.rs:794:18:794:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:794:26:794:26 | a |  | main.rs:721:5:724:5 | MyThing |
-| main.rs:794:26:794:26 | a | A | main.rs:731:5:732:14 | S1 |
-| main.rs:798:13:798:13 | x |  | main.rs:721:5:724:5 | MyThing |
-| main.rs:798:13:798:13 | x | A | main.rs:731:5:732:14 | S1 |
-| main.rs:798:17:798:33 | MyThing {...} |  | main.rs:721:5:724:5 | MyThing |
-| main.rs:798:17:798:33 | MyThing {...} | A | main.rs:731:5:732:14 | S1 |
-| main.rs:798:30:798:31 | S1 |  | main.rs:731:5:732:14 | S1 |
-| main.rs:799:13:799:13 | y |  | main.rs:721:5:724:5 | MyThing |
-| main.rs:799:13:799:13 | y | A | main.rs:733:5:734:14 | S2 |
-| main.rs:799:17:799:33 | MyThing {...} |  | main.rs:721:5:724:5 | MyThing |
-| main.rs:799:17:799:33 | MyThing {...} | A | main.rs:733:5:734:14 | S2 |
-| main.rs:799:30:799:31 | S2 |  | main.rs:733:5:734:14 | S2 |
-| main.rs:801:18:801:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:801:26:801:26 | x |  | main.rs:721:5:724:5 | MyThing |
-| main.rs:801:26:801:26 | x | A | main.rs:731:5:732:14 | S1 |
-| main.rs:801:26:801:31 | x.m1() |  | main.rs:731:5:732:14 | S1 |
-| main.rs:802:18:802:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:802:26:802:26 | y |  | main.rs:721:5:724:5 | MyThing |
-| main.rs:802:26:802:26 | y | A | main.rs:733:5:734:14 | S2 |
-| main.rs:802:26:802:31 | y.m1() |  | main.rs:733:5:734:14 | S2 |
-| main.rs:804:13:804:13 | x |  | main.rs:721:5:724:5 | MyThing |
-| main.rs:804:13:804:13 | x | A | main.rs:731:5:732:14 | S1 |
-| main.rs:804:17:804:33 | MyThing {...} |  | main.rs:721:5:724:5 | MyThing |
-| main.rs:804:17:804:33 | MyThing {...} | A | main.rs:731:5:732:14 | S1 |
-| main.rs:804:30:804:31 | S1 |  | main.rs:731:5:732:14 | S1 |
-| main.rs:805:13:805:13 | y |  | main.rs:721:5:724:5 | MyThing |
-| main.rs:805:13:805:13 | y | A | main.rs:733:5:734:14 | S2 |
-| main.rs:805:17:805:33 | MyThing {...} |  | main.rs:721:5:724:5 | MyThing |
-| main.rs:805:17:805:33 | MyThing {...} | A | main.rs:733:5:734:14 | S2 |
-| main.rs:805:30:805:31 | S2 |  | main.rs:733:5:734:14 | S2 |
-| main.rs:807:18:807:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:807:26:807:26 | x |  | main.rs:721:5:724:5 | MyThing |
-| main.rs:807:26:807:26 | x | A | main.rs:731:5:732:14 | S1 |
-| main.rs:807:26:807:31 | x.m2() |  | main.rs:731:5:732:14 | S1 |
-| main.rs:808:18:808:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:808:26:808:26 | y |  | main.rs:721:5:724:5 | MyThing |
-| main.rs:808:26:808:26 | y | A | main.rs:733:5:734:14 | S2 |
-| main.rs:808:26:808:31 | y.m2() |  | main.rs:733:5:734:14 | S2 |
-| main.rs:810:13:810:13 | x |  | main.rs:726:5:729:5 | MyThing2 |
-| main.rs:810:13:810:13 | x | A | main.rs:731:5:732:14 | S1 |
-| main.rs:810:17:810:34 | MyThing2 {...} |  | main.rs:726:5:729:5 | MyThing2 |
-| main.rs:810:17:810:34 | MyThing2 {...} | A | main.rs:731:5:732:14 | S1 |
-| main.rs:810:31:810:32 | S1 |  | main.rs:731:5:732:14 | S1 |
-| main.rs:811:13:811:13 | y |  | main.rs:726:5:729:5 | MyThing2 |
-| main.rs:811:13:811:13 | y | A | main.rs:733:5:734:14 | S2 |
-| main.rs:811:17:811:34 | MyThing2 {...} |  | main.rs:726:5:729:5 | MyThing2 |
-| main.rs:811:17:811:34 | MyThing2 {...} | A | main.rs:733:5:734:14 | S2 |
-| main.rs:811:31:811:32 | S2 |  | main.rs:733:5:734:14 | S2 |
-| main.rs:813:18:813:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:813:26:813:26 | x |  | main.rs:726:5:729:5 | MyThing2 |
-| main.rs:813:26:813:26 | x | A | main.rs:731:5:732:14 | S1 |
-| main.rs:813:26:813:31 | x.m3() |  | main.rs:731:5:732:14 | S1 |
-| main.rs:814:18:814:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:814:26:814:26 | y |  | main.rs:726:5:729:5 | MyThing2 |
-| main.rs:814:26:814:26 | y | A | main.rs:733:5:734:14 | S2 |
-| main.rs:814:26:814:31 | y.m3() |  | main.rs:733:5:734:14 | S2 |
-| main.rs:816:13:816:13 | x |  | main.rs:721:5:724:5 | MyThing |
-| main.rs:816:13:816:13 | x | A | main.rs:731:5:732:14 | S1 |
-| main.rs:816:17:816:33 | MyThing {...} |  | main.rs:721:5:724:5 | MyThing |
-| main.rs:816:17:816:33 | MyThing {...} | A | main.rs:731:5:732:14 | S1 |
-| main.rs:816:30:816:31 | S1 |  | main.rs:731:5:732:14 | S1 |
-| main.rs:817:13:817:13 | s |  | main.rs:731:5:732:14 | S1 |
-| main.rs:817:17:817:32 | call_trait_m1(...) |  | main.rs:731:5:732:14 | S1 |
-| main.rs:817:31:817:31 | x |  | main.rs:721:5:724:5 | MyThing |
-| main.rs:817:31:817:31 | x | A | main.rs:731:5:732:14 | S1 |
-| main.rs:819:13:819:13 | x |  | main.rs:726:5:729:5 | MyThing2 |
-| main.rs:819:13:819:13 | x | A | main.rs:733:5:734:14 | S2 |
-| main.rs:819:17:819:34 | MyThing2 {...} |  | main.rs:726:5:729:5 | MyThing2 |
-| main.rs:819:17:819:34 | MyThing2 {...} | A | main.rs:733:5:734:14 | S2 |
-| main.rs:819:31:819:32 | S2 |  | main.rs:733:5:734:14 | S2 |
-| main.rs:820:13:820:13 | s |  | main.rs:721:5:724:5 | MyThing |
-| main.rs:820:13:820:13 | s | A | main.rs:733:5:734:14 | S2 |
-| main.rs:820:17:820:32 | call_trait_m1(...) |  | main.rs:721:5:724:5 | MyThing |
-| main.rs:820:17:820:32 | call_trait_m1(...) | A | main.rs:733:5:734:14 | S2 |
-| main.rs:820:31:820:31 | x |  | main.rs:726:5:729:5 | MyThing2 |
-| main.rs:820:31:820:31 | x | A | main.rs:733:5:734:14 | S2 |
-| main.rs:838:22:838:22 | x |  | file://:0:0:0:0 | & |
-| main.rs:838:22:838:22 | x | &T | main.rs:838:11:838:19 | T |
-| main.rs:838:35:840:5 | { ... } |  | file://:0:0:0:0 | & |
-| main.rs:838:35:840:5 | { ... } | &T | main.rs:838:11:838:19 | T |
-| main.rs:839:9:839:9 | x |  | file://:0:0:0:0 | & |
-| main.rs:839:9:839:9 | x | &T | main.rs:838:11:838:19 | T |
-| main.rs:843:17:843:20 | SelfParam |  | main.rs:828:5:829:14 | S1 |
-| main.rs:843:29:845:9 | { ... } |  | main.rs:831:5:832:14 | S2 |
-| main.rs:844:13:844:14 | S2 |  | main.rs:831:5:832:14 | S2 |
-| main.rs:848:21:848:21 | x |  | main.rs:848:13:848:14 | T1 |
-| main.rs:851:5:853:5 | { ... } |  | main.rs:848:17:848:18 | T2 |
-| main.rs:852:9:852:9 | x |  | main.rs:848:13:848:14 | T1 |
-| main.rs:852:9:852:16 | x.into() |  | main.rs:848:17:848:18 | T2 |
-| main.rs:856:13:856:13 | x |  | main.rs:828:5:829:14 | S1 |
-| main.rs:856:17:856:18 | S1 |  | main.rs:828:5:829:14 | S1 |
-| main.rs:857:18:857:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:857:26:857:31 | id(...) |  | file://:0:0:0:0 | & |
-| main.rs:857:26:857:31 | id(...) | &T | main.rs:828:5:829:14 | S1 |
-| main.rs:857:29:857:30 | &x |  | file://:0:0:0:0 | & |
-| main.rs:857:29:857:30 | &x | &T | main.rs:828:5:829:14 | S1 |
-| main.rs:857:30:857:30 | x |  | main.rs:828:5:829:14 | S1 |
-| main.rs:859:13:859:13 | x |  | main.rs:828:5:829:14 | S1 |
-| main.rs:859:17:859:18 | S1 |  | main.rs:828:5:829:14 | S1 |
-| main.rs:860:18:860:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:860:26:860:37 | id::<...>(...) |  | file://:0:0:0:0 | & |
-| main.rs:860:26:860:37 | id::<...>(...) | &T | main.rs:828:5:829:14 | S1 |
-| main.rs:860:35:860:36 | &x |  | file://:0:0:0:0 | & |
-| main.rs:860:35:860:36 | &x | &T | main.rs:828:5:829:14 | S1 |
-| main.rs:860:36:860:36 | x |  | main.rs:828:5:829:14 | S1 |
-| main.rs:862:13:862:13 | x |  | main.rs:828:5:829:14 | S1 |
-| main.rs:862:17:862:18 | S1 |  | main.rs:828:5:829:14 | S1 |
-| main.rs:863:18:863:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:863:26:863:44 | id::<...>(...) |  | file://:0:0:0:0 | & |
-| main.rs:863:26:863:44 | id::<...>(...) | &T | main.rs:828:5:829:14 | S1 |
-| main.rs:863:42:863:43 | &x |  | file://:0:0:0:0 | & |
-| main.rs:863:42:863:43 | &x | &T | main.rs:828:5:829:14 | S1 |
-| main.rs:863:43:863:43 | x |  | main.rs:828:5:829:14 | S1 |
-| main.rs:865:13:865:13 | x |  | main.rs:828:5:829:14 | S1 |
-| main.rs:865:17:865:18 | S1 |  | main.rs:828:5:829:14 | S1 |
-| main.rs:866:9:866:25 | into::<...>(...) |  | main.rs:831:5:832:14 | S2 |
-| main.rs:866:24:866:24 | x |  | main.rs:828:5:829:14 | S1 |
-| main.rs:868:13:868:13 | x |  | main.rs:828:5:829:14 | S1 |
-| main.rs:868:17:868:18 | S1 |  | main.rs:828:5:829:14 | S1 |
-| main.rs:869:13:869:13 | y |  | main.rs:831:5:832:14 | S2 |
-| main.rs:869:21:869:27 | into(...) |  | main.rs:831:5:832:14 | S2 |
-| main.rs:869:26:869:26 | x |  | main.rs:828:5:829:14 | S1 |
-| main.rs:883:22:883:25 | SelfParam |  | main.rs:874:5:880:5 | PairOption |
-| main.rs:883:22:883:25 | SelfParam | Fst | main.rs:882:10:882:12 | Fst |
-| main.rs:883:22:883:25 | SelfParam | Snd | main.rs:882:15:882:17 | Snd |
-| main.rs:883:35:890:9 | { ... } |  | main.rs:882:15:882:17 | Snd |
-| main.rs:884:13:889:13 | match self { ... } |  | main.rs:882:15:882:17 | Snd |
-| main.rs:884:19:884:22 | self |  | main.rs:874:5:880:5 | PairOption |
-| main.rs:884:19:884:22 | self | Fst | main.rs:882:10:882:12 | Fst |
-| main.rs:884:19:884:22 | self | Snd | main.rs:882:15:882:17 | Snd |
-| main.rs:885:43:885:82 | MacroExpr |  | main.rs:882:15:882:17 | Snd |
-| main.rs:885:50:885:81 | "PairNone has no second elemen... |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:886:43:886:81 | MacroExpr |  | main.rs:882:15:882:17 | Snd |
-| main.rs:886:50:886:80 | "PairFst has no second element... |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:887:37:887:39 | snd |  | main.rs:882:15:882:17 | Snd |
-| main.rs:887:45:887:47 | snd |  | main.rs:882:15:882:17 | Snd |
-| main.rs:888:41:888:43 | snd |  | main.rs:882:15:882:17 | Snd |
-| main.rs:888:49:888:51 | snd |  | main.rs:882:15:882:17 | Snd |
-| main.rs:914:10:914:10 | t |  | main.rs:874:5:880:5 | PairOption |
-| main.rs:914:10:914:10 | t | Fst | main.rs:896:5:897:14 | S2 |
-| main.rs:914:10:914:10 | t | Snd | main.rs:874:5:880:5 | PairOption |
-| main.rs:914:10:914:10 | t | Snd.Fst | main.rs:896:5:897:14 | S2 |
-| main.rs:914:10:914:10 | t | Snd.Snd | main.rs:899:5:900:14 | S3 |
-| main.rs:915:13:915:13 | x |  | main.rs:899:5:900:14 | S3 |
-| main.rs:915:17:915:17 | t |  | main.rs:874:5:880:5 | PairOption |
-| main.rs:915:17:915:17 | t | Fst | main.rs:896:5:897:14 | S2 |
-| main.rs:915:17:915:17 | t | Snd | main.rs:874:5:880:5 | PairOption |
-| main.rs:915:17:915:17 | t | Snd.Fst | main.rs:896:5:897:14 | S2 |
-| main.rs:915:17:915:17 | t | Snd.Snd | main.rs:899:5:900:14 | S3 |
-| main.rs:915:17:915:29 | t.unwrapSnd() |  | main.rs:874:5:880:5 | PairOption |
-| main.rs:915:17:915:29 | t.unwrapSnd() | Fst | main.rs:896:5:897:14 | S2 |
-| main.rs:915:17:915:29 | t.unwrapSnd() | Snd | main.rs:899:5:900:14 | S3 |
-| main.rs:915:17:915:41 | ... .unwrapSnd() |  | main.rs:899:5:900:14 | S3 |
-| main.rs:916:18:916:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:916:26:916:26 | x |  | main.rs:899:5:900:14 | S3 |
-| main.rs:921:13:921:14 | p1 |  | main.rs:874:5:880:5 | PairOption |
-| main.rs:921:13:921:14 | p1 | Fst | main.rs:893:5:894:14 | S1 |
-| main.rs:921:13:921:14 | p1 | Snd | main.rs:896:5:897:14 | S2 |
-| main.rs:921:26:921:53 | ...::PairBoth(...) |  | main.rs:874:5:880:5 | PairOption |
-| main.rs:921:26:921:53 | ...::PairBoth(...) | Fst | main.rs:893:5:894:14 | S1 |
-| main.rs:921:26:921:53 | ...::PairBoth(...) | Snd | main.rs:896:5:897:14 | S2 |
-| main.rs:921:47:921:48 | S1 |  | main.rs:893:5:894:14 | S1 |
-| main.rs:921:51:921:52 | S2 |  | main.rs:896:5:897:14 | S2 |
-| main.rs:922:18:922:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:922:26:922:27 | p1 |  | main.rs:874:5:880:5 | PairOption |
-| main.rs:922:26:922:27 | p1 | Fst | main.rs:893:5:894:14 | S1 |
-| main.rs:922:26:922:27 | p1 | Snd | main.rs:896:5:897:14 | S2 |
-| main.rs:925:13:925:14 | p2 |  | main.rs:874:5:880:5 | PairOption |
-| main.rs:925:13:925:14 | p2 | Fst | main.rs:893:5:894:14 | S1 |
-| main.rs:925:13:925:14 | p2 | Snd | main.rs:896:5:897:14 | S2 |
-| main.rs:925:26:925:47 | ...::PairNone(...) |  | main.rs:874:5:880:5 | PairOption |
-| main.rs:925:26:925:47 | ...::PairNone(...) | Fst | main.rs:893:5:894:14 | S1 |
-| main.rs:925:26:925:47 | ...::PairNone(...) | Snd | main.rs:896:5:897:14 | S2 |
-| main.rs:926:18:926:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:926:26:926:27 | p2 |  | main.rs:874:5:880:5 | PairOption |
-| main.rs:926:26:926:27 | p2 | Fst | main.rs:893:5:894:14 | S1 |
-| main.rs:926:26:926:27 | p2 | Snd | main.rs:896:5:897:14 | S2 |
-| main.rs:929:13:929:14 | p3 |  | main.rs:874:5:880:5 | PairOption |
-| main.rs:929:13:929:14 | p3 | Fst | main.rs:896:5:897:14 | S2 |
-| main.rs:929:13:929:14 | p3 | Snd | main.rs:899:5:900:14 | S3 |
-| main.rs:929:34:929:56 | ...::PairSnd(...) |  | main.rs:874:5:880:5 | PairOption |
-| main.rs:929:34:929:56 | ...::PairSnd(...) | Fst | main.rs:896:5:897:14 | S2 |
-| main.rs:929:34:929:56 | ...::PairSnd(...) | Snd | main.rs:899:5:900:14 | S3 |
-| main.rs:929:54:929:55 | S3 |  | main.rs:899:5:900:14 | S3 |
-| main.rs:930:18:930:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:930:26:930:27 | p3 |  | main.rs:874:5:880:5 | PairOption |
-| main.rs:930:26:930:27 | p3 | Fst | main.rs:896:5:897:14 | S2 |
-| main.rs:930:26:930:27 | p3 | Snd | main.rs:899:5:900:14 | S3 |
-| main.rs:933:13:933:14 | p3 |  | main.rs:874:5:880:5 | PairOption |
-| main.rs:933:13:933:14 | p3 | Fst | main.rs:896:5:897:14 | S2 |
-| main.rs:933:13:933:14 | p3 | Snd | main.rs:899:5:900:14 | S3 |
-| main.rs:933:35:933:56 | ...::PairNone(...) |  | main.rs:874:5:880:5 | PairOption |
-| main.rs:933:35:933:56 | ...::PairNone(...) | Fst | main.rs:896:5:897:14 | S2 |
-| main.rs:933:35:933:56 | ...::PairNone(...) | Snd | main.rs:899:5:900:14 | S3 |
-| main.rs:934:18:934:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:934:26:934:27 | p3 |  | main.rs:874:5:880:5 | PairOption |
-| main.rs:934:26:934:27 | p3 | Fst | main.rs:896:5:897:14 | S2 |
-| main.rs:934:26:934:27 | p3 | Snd | main.rs:899:5:900:14 | S3 |
-| main.rs:936:11:936:54 | ...::PairSnd(...) |  | main.rs:874:5:880:5 | PairOption |
-| main.rs:936:11:936:54 | ...::PairSnd(...) | Fst | main.rs:896:5:897:14 | S2 |
-| main.rs:936:11:936:54 | ...::PairSnd(...) | Snd | main.rs:874:5:880:5 | PairOption |
-| main.rs:936:11:936:54 | ...::PairSnd(...) | Snd.Fst | main.rs:896:5:897:14 | S2 |
-| main.rs:936:11:936:54 | ...::PairSnd(...) | Snd.Snd | main.rs:899:5:900:14 | S3 |
-| main.rs:936:31:936:53 | ...::PairSnd(...) |  | main.rs:874:5:880:5 | PairOption |
-| main.rs:936:31:936:53 | ...::PairSnd(...) | Fst | main.rs:896:5:897:14 | S2 |
-| main.rs:936:31:936:53 | ...::PairSnd(...) | Snd | main.rs:899:5:900:14 | S3 |
-| main.rs:936:51:936:52 | S3 |  | main.rs:899:5:900:14 | S3 |
-| main.rs:949:16:949:24 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:949:16:949:24 | SelfParam | &T | main.rs:947:5:954:5 | Self [trait MyTrait] |
-| main.rs:949:27:949:31 | value |  | main.rs:947:19:947:19 | S |
-| main.rs:951:21:951:29 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:951:21:951:29 | SelfParam | &T | main.rs:947:5:954:5 | Self [trait MyTrait] |
-| main.rs:951:32:951:36 | value |  | main.rs:947:19:947:19 | S |
-| main.rs:952:13:952:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:952:13:952:16 | self | &T | main.rs:947:5:954:5 | Self [trait MyTrait] |
-| main.rs:952:22:952:26 | value |  | main.rs:947:19:947:19 | S |
-| main.rs:958:16:958:24 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:958:16:958:24 | SelfParam | &T | main.rs:941:5:945:5 | MyOption |
-| main.rs:958:16:958:24 | SelfParam | &T.T | main.rs:956:10:956:10 | T |
-| main.rs:958:27:958:31 | value |  | main.rs:956:10:956:10 | T |
-| main.rs:962:26:964:9 | { ... } |  | main.rs:941:5:945:5 | MyOption |
-| main.rs:962:26:964:9 | { ... } | T | main.rs:961:10:961:10 | T |
-| main.rs:963:13:963:30 | ...::MyNone(...) |  | main.rs:941:5:945:5 | MyOption |
-| main.rs:963:13:963:30 | ...::MyNone(...) | T | main.rs:961:10:961:10 | T |
-| main.rs:968:20:968:23 | SelfParam |  | main.rs:941:5:945:5 | MyOption |
-| main.rs:968:20:968:23 | SelfParam | T | main.rs:941:5:945:5 | MyOption |
-| main.rs:968:20:968:23 | SelfParam | T.T | main.rs:967:10:967:10 | T |
-| main.rs:968:41:973:9 | { ... } |  | main.rs:941:5:945:5 | MyOption |
-| main.rs:968:41:973:9 | { ... } | T | main.rs:967:10:967:10 | T |
-| main.rs:969:13:972:13 | match self { ... } |  | main.rs:941:5:945:5 | MyOption |
-| main.rs:969:13:972:13 | match self { ... } | T | main.rs:967:10:967:10 | T |
-| main.rs:969:19:969:22 | self |  | main.rs:941:5:945:5 | MyOption |
-| main.rs:969:19:969:22 | self | T | main.rs:941:5:945:5 | MyOption |
-| main.rs:969:19:969:22 | self | T.T | main.rs:967:10:967:10 | T |
-| main.rs:970:39:970:56 | ...::MyNone(...) |  | main.rs:941:5:945:5 | MyOption |
-| main.rs:970:39:970:56 | ...::MyNone(...) | T | main.rs:967:10:967:10 | T |
-| main.rs:971:34:971:34 | x |  | main.rs:941:5:945:5 | MyOption |
-| main.rs:971:34:971:34 | x | T | main.rs:967:10:967:10 | T |
-| main.rs:971:40:971:40 | x |  | main.rs:941:5:945:5 | MyOption |
-| main.rs:971:40:971:40 | x | T | main.rs:967:10:967:10 | T |
-| main.rs:980:13:980:14 | x1 |  | main.rs:941:5:945:5 | MyOption |
-| main.rs:980:18:980:37 | ...::new(...) |  | main.rs:941:5:945:5 | MyOption |
-| main.rs:981:18:981:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:981:26:981:27 | x1 |  | main.rs:941:5:945:5 | MyOption |
-| main.rs:983:13:983:18 | mut x2 |  | main.rs:941:5:945:5 | MyOption |
-| main.rs:983:13:983:18 | mut x2 | T | main.rs:976:5:977:13 | S |
-| main.rs:983:22:983:36 | ...::new(...) |  | main.rs:941:5:945:5 | MyOption |
-| main.rs:983:22:983:36 | ...::new(...) | T | main.rs:976:5:977:13 | S |
-| main.rs:984:9:984:10 | x2 |  | main.rs:941:5:945:5 | MyOption |
-| main.rs:984:9:984:10 | x2 | T | main.rs:976:5:977:13 | S |
-| main.rs:984:16:984:16 | S |  | main.rs:976:5:977:13 | S |
-| main.rs:985:18:985:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:985:26:985:27 | x2 |  | main.rs:941:5:945:5 | MyOption |
-| main.rs:985:26:985:27 | x2 | T | main.rs:976:5:977:13 | S |
-| main.rs:987:13:987:18 | mut x3 |  | main.rs:941:5:945:5 | MyOption |
-| main.rs:987:22:987:36 | ...::new(...) |  | main.rs:941:5:945:5 | MyOption |
-| main.rs:988:9:988:10 | x3 |  | main.rs:941:5:945:5 | MyOption |
-| main.rs:988:21:988:21 | S |  | main.rs:976:5:977:13 | S |
-| main.rs:989:18:989:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:989:26:989:27 | x3 |  | main.rs:941:5:945:5 | MyOption |
-| main.rs:991:13:991:18 | mut x4 |  | main.rs:941:5:945:5 | MyOption |
-| main.rs:991:13:991:18 | mut x4 | T | main.rs:976:5:977:13 | S |
-| main.rs:991:22:991:36 | ...::new(...) |  | main.rs:941:5:945:5 | MyOption |
-| main.rs:991:22:991:36 | ...::new(...) | T | main.rs:976:5:977:13 | S |
-| main.rs:992:23:992:29 | &mut x4 |  | file://:0:0:0:0 | & |
-| main.rs:992:23:992:29 | &mut x4 | &T | main.rs:941:5:945:5 | MyOption |
-| main.rs:992:23:992:29 | &mut x4 | &T.T | main.rs:976:5:977:13 | S |
-| main.rs:992:28:992:29 | x4 |  | main.rs:941:5:945:5 | MyOption |
-| main.rs:992:28:992:29 | x4 | T | main.rs:976:5:977:13 | S |
-| main.rs:992:32:992:32 | S |  | main.rs:976:5:977:13 | S |
-| main.rs:993:18:993:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:993:26:993:27 | x4 |  | main.rs:941:5:945:5 | MyOption |
-| main.rs:993:26:993:27 | x4 | T | main.rs:976:5:977:13 | S |
-| main.rs:995:13:995:14 | x5 |  | main.rs:941:5:945:5 | MyOption |
-| main.rs:995:13:995:14 | x5 | T | main.rs:941:5:945:5 | MyOption |
-| main.rs:995:13:995:14 | x5 | T.T | main.rs:976:5:977:13 | S |
-| main.rs:995:18:995:58 | ...::MySome(...) |  | main.rs:941:5:945:5 | MyOption |
-| main.rs:995:18:995:58 | ...::MySome(...) | T | main.rs:941:5:945:5 | MyOption |
-| main.rs:995:18:995:58 | ...::MySome(...) | T.T | main.rs:976:5:977:13 | S |
-| main.rs:995:35:995:57 | ...::MyNone(...) |  | main.rs:941:5:945:5 | MyOption |
-| main.rs:995:35:995:57 | ...::MyNone(...) | T | main.rs:976:5:977:13 | S |
-| main.rs:996:18:996:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:996:26:996:27 | x5 |  | main.rs:941:5:945:5 | MyOption |
-| main.rs:996:26:996:27 | x5 | T | main.rs:941:5:945:5 | MyOption |
-| main.rs:996:26:996:27 | x5 | T.T | main.rs:976:5:977:13 | S |
-| main.rs:996:26:996:37 | x5.flatten() |  | main.rs:941:5:945:5 | MyOption |
-| main.rs:996:26:996:37 | x5.flatten() | T | main.rs:976:5:977:13 | S |
-| main.rs:998:13:998:14 | x6 |  | main.rs:941:5:945:5 | MyOption |
-| main.rs:998:13:998:14 | x6 | T | main.rs:941:5:945:5 | MyOption |
-| main.rs:998:13:998:14 | x6 | T.T | main.rs:976:5:977:13 | S |
-| main.rs:998:18:998:58 | ...::MySome(...) |  | main.rs:941:5:945:5 | MyOption |
-| main.rs:998:18:998:58 | ...::MySome(...) | T | main.rs:941:5:945:5 | MyOption |
-| main.rs:998:18:998:58 | ...::MySome(...) | T.T | main.rs:976:5:977:13 | S |
-| main.rs:998:35:998:57 | ...::MyNone(...) |  | main.rs:941:5:945:5 | MyOption |
-| main.rs:998:35:998:57 | ...::MyNone(...) | T | main.rs:976:5:977:13 | S |
-| main.rs:999:18:999:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:999:26:999:61 | ...::flatten(...) |  | main.rs:941:5:945:5 | MyOption |
-| main.rs:999:26:999:61 | ...::flatten(...) | T | main.rs:976:5:977:13 | S |
-| main.rs:999:59:999:60 | x6 |  | main.rs:941:5:945:5 | MyOption |
-| main.rs:999:59:999:60 | x6 | T | main.rs:941:5:945:5 | MyOption |
-| main.rs:999:59:999:60 | x6 | T.T | main.rs:976:5:977:13 | S |
-| main.rs:1001:13:1001:19 | from_if |  | main.rs:941:5:945:5 | MyOption |
-| main.rs:1001:13:1001:19 | from_if | T | main.rs:976:5:977:13 | S |
-| main.rs:1001:23:1005:9 | if ... {...} else {...} |  | main.rs:941:5:945:5 | MyOption |
-| main.rs:1001:23:1005:9 | if ... {...} else {...} | T | main.rs:976:5:977:13 | S |
-| main.rs:1001:26:1001:26 | 1 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:1001:30:1001:30 | 1 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:1001:34:1001:34 | 2 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:1001:36:1003:9 | { ... } |  | main.rs:941:5:945:5 | MyOption |
-| main.rs:1001:36:1003:9 | { ... } | T | main.rs:976:5:977:13 | S |
-| main.rs:1002:13:1002:30 | ...::MyNone(...) |  | main.rs:941:5:945:5 | MyOption |
-| main.rs:1002:13:1002:30 | ...::MyNone(...) | T | main.rs:976:5:977:13 | S |
-| main.rs:1003:16:1005:9 | { ... } |  | main.rs:941:5:945:5 | MyOption |
-| main.rs:1003:16:1005:9 | { ... } | T | main.rs:976:5:977:13 | S |
-| main.rs:1004:13:1004:31 | ...::MySome(...) |  | main.rs:941:5:945:5 | MyOption |
-| main.rs:1004:13:1004:31 | ...::MySome(...) | T | main.rs:976:5:977:13 | S |
-| main.rs:1004:30:1004:30 | S |  | main.rs:976:5:977:13 | S |
-| main.rs:1006:18:1006:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:1006:26:1006:32 | from_if |  | main.rs:941:5:945:5 | MyOption |
-| main.rs:1006:26:1006:32 | from_if | T | main.rs:976:5:977:13 | S |
-| main.rs:1008:13:1008:22 | from_match |  | main.rs:941:5:945:5 | MyOption |
-| main.rs:1008:13:1008:22 | from_match | T | main.rs:976:5:977:13 | S |
-| main.rs:1008:26:1011:9 | match ... { ... } |  | main.rs:941:5:945:5 | MyOption |
-| main.rs:1008:26:1011:9 | match ... { ... } | T | main.rs:976:5:977:13 | S |
-| main.rs:1008:32:1008:32 | 1 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:1008:36:1008:36 | 1 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:1008:40:1008:40 | 2 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:1009:13:1009:16 | true |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
-| main.rs:1009:21:1009:38 | ...::MyNone(...) |  | main.rs:941:5:945:5 | MyOption |
-| main.rs:1009:21:1009:38 | ...::MyNone(...) | T | main.rs:976:5:977:13 | S |
-| main.rs:1010:13:1010:17 | false |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
-| main.rs:1010:22:1010:40 | ...::MySome(...) |  | main.rs:941:5:945:5 | MyOption |
-| main.rs:1010:22:1010:40 | ...::MySome(...) | T | main.rs:976:5:977:13 | S |
-| main.rs:1010:39:1010:39 | S |  | main.rs:976:5:977:13 | S |
-| main.rs:1012:18:1012:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:1012:26:1012:35 | from_match |  | main.rs:941:5:945:5 | MyOption |
-| main.rs:1012:26:1012:35 | from_match | T | main.rs:976:5:977:13 | S |
-| main.rs:1014:13:1014:21 | from_loop |  | main.rs:941:5:945:5 | MyOption |
-| main.rs:1014:13:1014:21 | from_loop | T | main.rs:976:5:977:13 | S |
-| main.rs:1014:25:1019:9 | loop { ... } |  | main.rs:941:5:945:5 | MyOption |
-| main.rs:1014:25:1019:9 | loop { ... } | T | main.rs:976:5:977:13 | S |
-| main.rs:1015:16:1015:16 | 1 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:1015:20:1015:20 | 1 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:1015:24:1015:24 | 2 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:1016:23:1016:40 | ...::MyNone(...) |  | main.rs:941:5:945:5 | MyOption |
-| main.rs:1016:23:1016:40 | ...::MyNone(...) | T | main.rs:976:5:977:13 | S |
-| main.rs:1018:19:1018:37 | ...::MySome(...) |  | main.rs:941:5:945:5 | MyOption |
-| main.rs:1018:19:1018:37 | ...::MySome(...) | T | main.rs:976:5:977:13 | S |
-| main.rs:1018:36:1018:36 | S |  | main.rs:976:5:977:13 | S |
-| main.rs:1020:18:1020:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:1020:26:1020:34 | from_loop |  | main.rs:941:5:945:5 | MyOption |
-| main.rs:1020:26:1020:34 | from_loop | T | main.rs:976:5:977:13 | S |
-| main.rs:1033:15:1033:18 | SelfParam |  | main.rs:1026:5:1027:19 | S |
-| main.rs:1033:15:1033:18 | SelfParam | T | main.rs:1032:10:1032:10 | T |
-| main.rs:1033:26:1035:9 | { ... } |  | main.rs:1032:10:1032:10 | T |
-| main.rs:1034:13:1034:16 | self |  | main.rs:1026:5:1027:19 | S |
-| main.rs:1034:13:1034:16 | self | T | main.rs:1032:10:1032:10 | T |
-| main.rs:1034:13:1034:18 | self.0 |  | main.rs:1032:10:1032:10 | T |
-| main.rs:1037:15:1037:19 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:1037:15:1037:19 | SelfParam | &T | main.rs:1026:5:1027:19 | S |
-| main.rs:1037:15:1037:19 | SelfParam | &T.T | main.rs:1032:10:1032:10 | T |
-| main.rs:1037:28:1039:9 | { ... } |  | file://:0:0:0:0 | & |
-| main.rs:1037:28:1039:9 | { ... } | &T | main.rs:1032:10:1032:10 | T |
-| main.rs:1038:13:1038:19 | &... |  | file://:0:0:0:0 | & |
-| main.rs:1038:13:1038:19 | &... | &T | main.rs:1032:10:1032:10 | T |
-| main.rs:1038:14:1038:17 | self |  | file://:0:0:0:0 | & |
-| main.rs:1038:14:1038:17 | self | &T | main.rs:1026:5:1027:19 | S |
-| main.rs:1038:14:1038:17 | self | &T.T | main.rs:1032:10:1032:10 | T |
-| main.rs:1038:14:1038:19 | self.0 |  | main.rs:1032:10:1032:10 | T |
-| main.rs:1041:15:1041:25 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:1041:15:1041:25 | SelfParam | &T | main.rs:1026:5:1027:19 | S |
-| main.rs:1041:15:1041:25 | SelfParam | &T.T | main.rs:1032:10:1032:10 | T |
-| main.rs:1041:34:1043:9 | { ... } |  | file://:0:0:0:0 | & |
-| main.rs:1041:34:1043:9 | { ... } | &T | main.rs:1032:10:1032:10 | T |
-| main.rs:1042:13:1042:19 | &... |  | file://:0:0:0:0 | & |
-| main.rs:1042:13:1042:19 | &... | &T | main.rs:1032:10:1032:10 | T |
-| main.rs:1042:14:1042:17 | self |  | file://:0:0:0:0 | & |
-| main.rs:1042:14:1042:17 | self | &T | main.rs:1026:5:1027:19 | S |
-| main.rs:1042:14:1042:17 | self | &T.T | main.rs:1032:10:1032:10 | T |
-| main.rs:1042:14:1042:19 | self.0 |  | main.rs:1032:10:1032:10 | T |
-| main.rs:1047:13:1047:14 | x1 |  | main.rs:1026:5:1027:19 | S |
-| main.rs:1047:13:1047:14 | x1 | T | main.rs:1029:5:1030:14 | S2 |
-| main.rs:1047:18:1047:22 | S(...) |  | main.rs:1026:5:1027:19 | S |
-| main.rs:1047:18:1047:22 | S(...) | T | main.rs:1029:5:1030:14 | S2 |
-| main.rs:1047:20:1047:21 | S2 |  | main.rs:1029:5:1030:14 | S2 |
-| main.rs:1048:18:1048:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:1048:26:1048:27 | x1 |  | main.rs:1026:5:1027:19 | S |
-| main.rs:1048:26:1048:27 | x1 | T | main.rs:1029:5:1030:14 | S2 |
-| main.rs:1048:26:1048:32 | x1.m1() |  | main.rs:1029:5:1030:14 | S2 |
-| main.rs:1050:13:1050:14 | x2 |  | main.rs:1026:5:1027:19 | S |
-| main.rs:1050:13:1050:14 | x2 | T | main.rs:1029:5:1030:14 | S2 |
-| main.rs:1050:18:1050:22 | S(...) |  | main.rs:1026:5:1027:19 | S |
-| main.rs:1050:18:1050:22 | S(...) | T | main.rs:1029:5:1030:14 | S2 |
-| main.rs:1050:20:1050:21 | S2 |  | main.rs:1029:5:1030:14 | S2 |
-| main.rs:1052:18:1052:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:1052:26:1052:27 | x2 |  | main.rs:1026:5:1027:19 | S |
-| main.rs:1052:26:1052:27 | x2 | T | main.rs:1029:5:1030:14 | S2 |
-| main.rs:1052:26:1052:32 | x2.m2() |  | file://:0:0:0:0 | & |
-| main.rs:1052:26:1052:32 | x2.m2() | &T | main.rs:1029:5:1030:14 | S2 |
-| main.rs:1053:18:1053:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:1053:26:1053:27 | x2 |  | main.rs:1026:5:1027:19 | S |
-| main.rs:1053:26:1053:27 | x2 | T | main.rs:1029:5:1030:14 | S2 |
-| main.rs:1053:26:1053:32 | x2.m3() |  | file://:0:0:0:0 | & |
-| main.rs:1053:26:1053:32 | x2.m3() | &T | main.rs:1029:5:1030:14 | S2 |
-| main.rs:1055:13:1055:14 | x3 |  | main.rs:1026:5:1027:19 | S |
-| main.rs:1055:13:1055:14 | x3 | T | main.rs:1029:5:1030:14 | S2 |
-| main.rs:1055:18:1055:22 | S(...) |  | main.rs:1026:5:1027:19 | S |
-| main.rs:1055:18:1055:22 | S(...) | T | main.rs:1029:5:1030:14 | S2 |
-| main.rs:1055:20:1055:21 | S2 |  | main.rs:1029:5:1030:14 | S2 |
-| main.rs:1057:18:1057:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:1057:26:1057:41 | ...::m2(...) |  | file://:0:0:0:0 | & |
-| main.rs:1057:26:1057:41 | ...::m2(...) | &T | main.rs:1029:5:1030:14 | S2 |
-| main.rs:1057:38:1057:40 | &x3 |  | file://:0:0:0:0 | & |
-| main.rs:1057:38:1057:40 | &x3 | &T | main.rs:1026:5:1027:19 | S |
-| main.rs:1057:38:1057:40 | &x3 | &T.T | main.rs:1029:5:1030:14 | S2 |
-| main.rs:1057:39:1057:40 | x3 |  | main.rs:1026:5:1027:19 | S |
-| main.rs:1057:39:1057:40 | x3 | T | main.rs:1029:5:1030:14 | S2 |
-| main.rs:1058:18:1058:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:1058:26:1058:41 | ...::m3(...) |  | file://:0:0:0:0 | & |
-| main.rs:1058:26:1058:41 | ...::m3(...) | &T | main.rs:1029:5:1030:14 | S2 |
-| main.rs:1058:38:1058:40 | &x3 |  | file://:0:0:0:0 | & |
-| main.rs:1058:38:1058:40 | &x3 | &T | main.rs:1026:5:1027:19 | S |
-| main.rs:1058:38:1058:40 | &x3 | &T.T | main.rs:1029:5:1030:14 | S2 |
-| main.rs:1058:39:1058:40 | x3 |  | main.rs:1026:5:1027:19 | S |
-| main.rs:1058:39:1058:40 | x3 | T | main.rs:1029:5:1030:14 | S2 |
-| main.rs:1060:13:1060:14 | x4 |  | file://:0:0:0:0 | & |
-| main.rs:1060:13:1060:14 | x4 | &T | main.rs:1026:5:1027:19 | S |
-| main.rs:1060:13:1060:14 | x4 | &T.T | main.rs:1029:5:1030:14 | S2 |
-| main.rs:1060:18:1060:23 | &... |  | file://:0:0:0:0 | & |
-| main.rs:1060:18:1060:23 | &... | &T | main.rs:1026:5:1027:19 | S |
-| main.rs:1060:18:1060:23 | &... | &T.T | main.rs:1029:5:1030:14 | S2 |
-| main.rs:1060:19:1060:23 | S(...) |  | main.rs:1026:5:1027:19 | S |
-| main.rs:1060:19:1060:23 | S(...) | T | main.rs:1029:5:1030:14 | S2 |
-| main.rs:1060:21:1060:22 | S2 |  | main.rs:1029:5:1030:14 | S2 |
-| main.rs:1062:18:1062:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:1062:26:1062:27 | x4 |  | file://:0:0:0:0 | & |
-| main.rs:1062:26:1062:27 | x4 | &T | main.rs:1026:5:1027:19 | S |
-| main.rs:1062:26:1062:27 | x4 | &T.T | main.rs:1029:5:1030:14 | S2 |
-| main.rs:1062:26:1062:32 | x4.m2() |  | file://:0:0:0:0 | & |
-| main.rs:1062:26:1062:32 | x4.m2() | &T | main.rs:1029:5:1030:14 | S2 |
-| main.rs:1063:18:1063:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:1063:26:1063:27 | x4 |  | file://:0:0:0:0 | & |
-| main.rs:1063:26:1063:27 | x4 | &T | main.rs:1026:5:1027:19 | S |
-| main.rs:1063:26:1063:27 | x4 | &T.T | main.rs:1029:5:1030:14 | S2 |
-| main.rs:1063:26:1063:32 | x4.m3() |  | file://:0:0:0:0 | & |
-| main.rs:1063:26:1063:32 | x4.m3() | &T | main.rs:1029:5:1030:14 | S2 |
-| main.rs:1065:13:1065:14 | x5 |  | file://:0:0:0:0 | & |
-| main.rs:1065:13:1065:14 | x5 | &T | main.rs:1026:5:1027:19 | S |
-| main.rs:1065:13:1065:14 | x5 | &T.T | main.rs:1029:5:1030:14 | S2 |
-| main.rs:1065:18:1065:23 | &... |  | file://:0:0:0:0 | & |
-| main.rs:1065:18:1065:23 | &... | &T | main.rs:1026:5:1027:19 | S |
-| main.rs:1065:18:1065:23 | &... | &T.T | main.rs:1029:5:1030:14 | S2 |
-| main.rs:1065:19:1065:23 | S(...) |  | main.rs:1026:5:1027:19 | S |
-| main.rs:1065:19:1065:23 | S(...) | T | main.rs:1029:5:1030:14 | S2 |
-| main.rs:1065:21:1065:22 | S2 |  | main.rs:1029:5:1030:14 | S2 |
-| main.rs:1067:18:1067:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:1067:26:1067:27 | x5 |  | file://:0:0:0:0 | & |
-| main.rs:1067:26:1067:27 | x5 | &T | main.rs:1026:5:1027:19 | S |
-| main.rs:1067:26:1067:27 | x5 | &T.T | main.rs:1029:5:1030:14 | S2 |
-| main.rs:1067:26:1067:32 | x5.m1() |  | main.rs:1029:5:1030:14 | S2 |
-| main.rs:1068:18:1068:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:1068:26:1068:27 | x5 |  | file://:0:0:0:0 | & |
-| main.rs:1068:26:1068:27 | x5 | &T | main.rs:1026:5:1027:19 | S |
-| main.rs:1068:26:1068:27 | x5 | &T.T | main.rs:1029:5:1030:14 | S2 |
-| main.rs:1068:26:1068:29 | x5.0 |  | main.rs:1029:5:1030:14 | S2 |
-| main.rs:1070:13:1070:14 | x6 |  | file://:0:0:0:0 | & |
-| main.rs:1070:13:1070:14 | x6 | &T | main.rs:1026:5:1027:19 | S |
-| main.rs:1070:13:1070:14 | x6 | &T.T | main.rs:1029:5:1030:14 | S2 |
-| main.rs:1070:18:1070:23 | &... |  | file://:0:0:0:0 | & |
-| main.rs:1070:18:1070:23 | &... | &T | main.rs:1026:5:1027:19 | S |
-| main.rs:1070:18:1070:23 | &... | &T.T | main.rs:1029:5:1030:14 | S2 |
-| main.rs:1070:19:1070:23 | S(...) |  | main.rs:1026:5:1027:19 | S |
-| main.rs:1070:19:1070:23 | S(...) | T | main.rs:1029:5:1030:14 | S2 |
-| main.rs:1070:21:1070:22 | S2 |  | main.rs:1029:5:1030:14 | S2 |
-| main.rs:1072:18:1072:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:1072:26:1072:30 | (...) |  | main.rs:1026:5:1027:19 | S |
-| main.rs:1072:26:1072:30 | (...) | T | main.rs:1029:5:1030:14 | S2 |
-| main.rs:1072:26:1072:35 | ... .m1() |  | main.rs:1029:5:1030:14 | S2 |
-| main.rs:1072:27:1072:29 | * ... |  | main.rs:1026:5:1027:19 | S |
-| main.rs:1072:27:1072:29 | * ... | T | main.rs:1029:5:1030:14 | S2 |
-| main.rs:1072:28:1072:29 | x6 |  | file://:0:0:0:0 | & |
-| main.rs:1072:28:1072:29 | x6 | &T | main.rs:1026:5:1027:19 | S |
-| main.rs:1072:28:1072:29 | x6 | &T.T | main.rs:1029:5:1030:14 | S2 |
-| main.rs:1074:13:1074:14 | x7 |  | main.rs:1026:5:1027:19 | S |
-| main.rs:1074:13:1074:14 | x7 | T | file://:0:0:0:0 | & |
-| main.rs:1074:13:1074:14 | x7 | T.&T | main.rs:1029:5:1030:14 | S2 |
-| main.rs:1074:18:1074:23 | S(...) |  | main.rs:1026:5:1027:19 | S |
-| main.rs:1074:18:1074:23 | S(...) | T | file://:0:0:0:0 | & |
-| main.rs:1074:18:1074:23 | S(...) | T.&T | main.rs:1029:5:1030:14 | S2 |
-| main.rs:1074:20:1074:22 | &S2 |  | file://:0:0:0:0 | & |
-| main.rs:1074:20:1074:22 | &S2 | &T | main.rs:1029:5:1030:14 | S2 |
-| main.rs:1074:21:1074:22 | S2 |  | main.rs:1029:5:1030:14 | S2 |
-| main.rs:1077:13:1077:13 | t |  | file://:0:0:0:0 | & |
-| main.rs:1077:13:1077:13 | t | &T | main.rs:1029:5:1030:14 | S2 |
-| main.rs:1077:17:1077:18 | x7 |  | main.rs:1026:5:1027:19 | S |
-| main.rs:1077:17:1077:18 | x7 | T | file://:0:0:0:0 | & |
-| main.rs:1077:17:1077:18 | x7 | T.&T | main.rs:1029:5:1030:14 | S2 |
-| main.rs:1077:17:1077:23 | x7.m1() |  | file://:0:0:0:0 | & |
-| main.rs:1077:17:1077:23 | x7.m1() | &T | main.rs:1029:5:1030:14 | S2 |
+| main.rs:344:26:344:26 | x |  | main.rs:181:5:182:14 | S1 |
+| main.rs:345:13:345:13 | y |  | main.rs:181:5:182:14 | S1 |
+| main.rs:345:17:345:17 | a |  | main.rs:175:5:179:5 | MyPair |
+| main.rs:345:17:345:17 | a | P1 | main.rs:181:5:182:14 | S1 |
+| main.rs:345:17:345:17 | a | P2 | main.rs:181:5:182:14 | S1 |
+| main.rs:345:17:345:23 | a.snd() |  | main.rs:181:5:182:14 | S1 |
+| main.rs:346:18:346:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:346:26:346:26 | y |  | main.rs:181:5:182:14 | S1 |
+| main.rs:352:13:352:13 | b |  | main.rs:175:5:179:5 | MyPair |
+| main.rs:352:13:352:13 | b | P1 | main.rs:183:5:184:14 | S2 |
+| main.rs:352:13:352:13 | b | P2 | main.rs:181:5:182:14 | S1 |
+| main.rs:352:17:352:41 | MyPair {...} |  | main.rs:175:5:179:5 | MyPair |
+| main.rs:352:17:352:41 | MyPair {...} | P1 | main.rs:183:5:184:14 | S2 |
+| main.rs:352:17:352:41 | MyPair {...} | P2 | main.rs:181:5:182:14 | S1 |
+| main.rs:352:30:352:31 | S2 |  | main.rs:183:5:184:14 | S2 |
+| main.rs:352:38:352:39 | S1 |  | main.rs:181:5:182:14 | S1 |
+| main.rs:353:13:353:13 | x |  | main.rs:181:5:182:14 | S1 |
+| main.rs:353:17:353:17 | b |  | main.rs:175:5:179:5 | MyPair |
+| main.rs:353:17:353:17 | b | P1 | main.rs:183:5:184:14 | S2 |
+| main.rs:353:17:353:17 | b | P2 | main.rs:181:5:182:14 | S1 |
+| main.rs:353:17:353:23 | b.fst() |  | main.rs:181:5:182:14 | S1 |
+| main.rs:354:18:354:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:354:26:354:26 | x |  | main.rs:181:5:182:14 | S1 |
+| main.rs:355:13:355:13 | y |  | main.rs:183:5:184:14 | S2 |
+| main.rs:355:17:355:17 | b |  | main.rs:175:5:179:5 | MyPair |
+| main.rs:355:17:355:17 | b | P1 | main.rs:183:5:184:14 | S2 |
+| main.rs:355:17:355:17 | b | P2 | main.rs:181:5:182:14 | S1 |
+| main.rs:355:17:355:23 | b.snd() |  | main.rs:183:5:184:14 | S2 |
+| main.rs:356:18:356:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:356:26:356:26 | y |  | main.rs:183:5:184:14 | S2 |
+| main.rs:360:13:360:13 | x |  | main.rs:181:5:182:14 | S1 |
+| main.rs:360:17:360:39 | call_trait_m1(...) |  | main.rs:181:5:182:14 | S1 |
+| main.rs:360:31:360:38 | thing_s1 |  | main.rs:170:5:173:5 | MyThing |
+| main.rs:360:31:360:38 | thing_s1 | A | main.rs:181:5:182:14 | S1 |
+| main.rs:361:18:361:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:361:26:361:26 | x |  | main.rs:181:5:182:14 | S1 |
+| main.rs:362:13:362:13 | y |  | main.rs:170:5:173:5 | MyThing |
+| main.rs:362:13:362:13 | y | A | main.rs:183:5:184:14 | S2 |
+| main.rs:362:17:362:39 | call_trait_m1(...) |  | main.rs:170:5:173:5 | MyThing |
+| main.rs:362:17:362:39 | call_trait_m1(...) | A | main.rs:183:5:184:14 | S2 |
+| main.rs:362:31:362:38 | thing_s2 |  | main.rs:170:5:173:5 | MyThing |
+| main.rs:362:31:362:38 | thing_s2 | A | main.rs:183:5:184:14 | S2 |
+| main.rs:363:18:363:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:363:26:363:26 | y |  | main.rs:170:5:173:5 | MyThing |
+| main.rs:363:26:363:26 | y | A | main.rs:183:5:184:14 | S2 |
+| main.rs:363:26:363:28 | y.a |  | main.rs:183:5:184:14 | S2 |
+| main.rs:366:13:366:13 | a |  | main.rs:175:5:179:5 | MyPair |
+| main.rs:366:13:366:13 | a | P1 | main.rs:181:5:182:14 | S1 |
+| main.rs:366:13:366:13 | a | P2 | main.rs:181:5:182:14 | S1 |
+| main.rs:366:17:366:41 | MyPair {...} |  | main.rs:175:5:179:5 | MyPair |
+| main.rs:366:17:366:41 | MyPair {...} | P1 | main.rs:181:5:182:14 | S1 |
+| main.rs:366:17:366:41 | MyPair {...} | P2 | main.rs:181:5:182:14 | S1 |
+| main.rs:366:30:366:31 | S1 |  | main.rs:181:5:182:14 | S1 |
+| main.rs:366:38:366:39 | S1 |  | main.rs:181:5:182:14 | S1 |
+| main.rs:367:13:367:13 | x |  | main.rs:181:5:182:14 | S1 |
+| main.rs:367:17:367:26 | get_fst(...) |  | main.rs:181:5:182:14 | S1 |
+| main.rs:367:25:367:25 | a |  | main.rs:175:5:179:5 | MyPair |
+| main.rs:367:25:367:25 | a | P1 | main.rs:181:5:182:14 | S1 |
+| main.rs:367:25:367:25 | a | P2 | main.rs:181:5:182:14 | S1 |
+| main.rs:368:18:368:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:368:26:368:26 | x |  | main.rs:181:5:182:14 | S1 |
+| main.rs:369:13:369:13 | y |  | main.rs:181:5:182:14 | S1 |
+| main.rs:369:17:369:26 | get_snd(...) |  | main.rs:181:5:182:14 | S1 |
+| main.rs:369:25:369:25 | a |  | main.rs:175:5:179:5 | MyPair |
+| main.rs:369:25:369:25 | a | P1 | main.rs:181:5:182:14 | S1 |
+| main.rs:369:25:369:25 | a | P2 | main.rs:181:5:182:14 | S1 |
+| main.rs:370:18:370:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:370:26:370:26 | y |  | main.rs:181:5:182:14 | S1 |
+| main.rs:373:13:373:13 | b |  | main.rs:175:5:179:5 | MyPair |
+| main.rs:373:13:373:13 | b | P1 | main.rs:183:5:184:14 | S2 |
+| main.rs:373:13:373:13 | b | P2 | main.rs:181:5:182:14 | S1 |
+| main.rs:373:17:373:41 | MyPair {...} |  | main.rs:175:5:179:5 | MyPair |
+| main.rs:373:17:373:41 | MyPair {...} | P1 | main.rs:183:5:184:14 | S2 |
+| main.rs:373:17:373:41 | MyPair {...} | P2 | main.rs:181:5:182:14 | S1 |
+| main.rs:373:30:373:31 | S2 |  | main.rs:183:5:184:14 | S2 |
+| main.rs:373:38:373:39 | S1 |  | main.rs:181:5:182:14 | S1 |
+| main.rs:374:13:374:13 | x |  | main.rs:181:5:182:14 | S1 |
+| main.rs:374:17:374:26 | get_fst(...) |  | main.rs:181:5:182:14 | S1 |
+| main.rs:374:25:374:25 | b |  | main.rs:175:5:179:5 | MyPair |
+| main.rs:374:25:374:25 | b | P1 | main.rs:183:5:184:14 | S2 |
+| main.rs:374:25:374:25 | b | P2 | main.rs:181:5:182:14 | S1 |
+| main.rs:375:18:375:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:375:26:375:26 | x |  | main.rs:181:5:182:14 | S1 |
+| main.rs:376:13:376:13 | y |  | main.rs:183:5:184:14 | S2 |
+| main.rs:376:17:376:26 | get_snd(...) |  | main.rs:183:5:184:14 | S2 |
+| main.rs:376:25:376:25 | b |  | main.rs:175:5:179:5 | MyPair |
+| main.rs:376:25:376:25 | b | P1 | main.rs:183:5:184:14 | S2 |
+| main.rs:376:25:376:25 | b | P2 | main.rs:181:5:182:14 | S1 |
+| main.rs:377:18:377:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:377:26:377:26 | y |  | main.rs:183:5:184:14 | S2 |
+| main.rs:379:13:379:13 | c |  | main.rs:175:5:179:5 | MyPair |
+| main.rs:379:13:379:13 | c | P1 | main.rs:185:5:186:14 | S3 |
+| main.rs:379:13:379:13 | c | P2 | main.rs:175:5:179:5 | MyPair |
+| main.rs:379:13:379:13 | c | P2.P1 | main.rs:183:5:184:14 | S2 |
+| main.rs:379:13:379:13 | c | P2.P2 | main.rs:181:5:182:14 | S1 |
+| main.rs:379:17:382:9 | MyPair {...} |  | main.rs:175:5:179:5 | MyPair |
+| main.rs:379:17:382:9 | MyPair {...} | P1 | main.rs:185:5:186:14 | S3 |
+| main.rs:379:17:382:9 | MyPair {...} | P2 | main.rs:175:5:179:5 | MyPair |
+| main.rs:379:17:382:9 | MyPair {...} | P2.P1 | main.rs:183:5:184:14 | S2 |
+| main.rs:379:17:382:9 | MyPair {...} | P2.P2 | main.rs:181:5:182:14 | S1 |
+| main.rs:380:17:380:18 | S3 |  | main.rs:185:5:186:14 | S3 |
+| main.rs:381:17:381:41 | MyPair {...} |  | main.rs:175:5:179:5 | MyPair |
+| main.rs:381:17:381:41 | MyPair {...} | P1 | main.rs:183:5:184:14 | S2 |
+| main.rs:381:17:381:41 | MyPair {...} | P2 | main.rs:181:5:182:14 | S1 |
+| main.rs:381:30:381:31 | S2 |  | main.rs:183:5:184:14 | S2 |
+| main.rs:381:38:381:39 | S1 |  | main.rs:181:5:182:14 | S1 |
+| main.rs:383:13:383:13 | x |  | main.rs:181:5:182:14 | S1 |
+| main.rs:383:17:383:30 | get_snd_fst(...) |  | main.rs:181:5:182:14 | S1 |
+| main.rs:383:29:383:29 | c |  | main.rs:175:5:179:5 | MyPair |
+| main.rs:383:29:383:29 | c | P1 | main.rs:185:5:186:14 | S3 |
+| main.rs:383:29:383:29 | c | P2 | main.rs:175:5:179:5 | MyPair |
+| main.rs:383:29:383:29 | c | P2.P1 | main.rs:183:5:184:14 | S2 |
+| main.rs:383:29:383:29 | c | P2.P2 | main.rs:181:5:182:14 | S1 |
+| main.rs:385:13:385:17 | thing |  | main.rs:170:5:173:5 | MyThing |
+| main.rs:385:13:385:17 | thing | A | main.rs:181:5:182:14 | S1 |
+| main.rs:385:21:385:37 | MyThing {...} |  | main.rs:170:5:173:5 | MyThing |
+| main.rs:385:21:385:37 | MyThing {...} | A | main.rs:181:5:182:14 | S1 |
+| main.rs:385:34:385:35 | S1 |  | main.rs:181:5:182:14 | S1 |
+| main.rs:386:17:386:21 | thing |  | main.rs:170:5:173:5 | MyThing |
+| main.rs:386:17:386:21 | thing | A | main.rs:181:5:182:14 | S1 |
+| main.rs:387:13:387:13 | j |  | main.rs:181:5:182:14 | S1 |
+| main.rs:387:17:387:33 | convert_to(...) |  | main.rs:181:5:182:14 | S1 |
+| main.rs:387:28:387:32 | thing |  | main.rs:170:5:173:5 | MyThing |
+| main.rs:387:28:387:32 | thing | A | main.rs:181:5:182:14 | S1 |
+| main.rs:396:26:396:29 | SelfParam |  | main.rs:395:5:399:5 | Self [trait OverlappingTrait] |
+| main.rs:398:28:398:31 | SelfParam |  | main.rs:395:5:399:5 | Self [trait OverlappingTrait] |
+| main.rs:398:34:398:35 | s1 |  | main.rs:392:5:393:14 | S1 |
+| main.rs:403:26:403:29 | SelfParam |  | main.rs:392:5:393:14 | S1 |
+| main.rs:403:38:405:9 | { ... } |  | main.rs:392:5:393:14 | S1 |
+| main.rs:404:20:404:31 | "not called" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:408:28:408:31 | SelfParam |  | main.rs:392:5:393:14 | S1 |
+| main.rs:408:34:408:35 | s1 |  | main.rs:392:5:393:14 | S1 |
+| main.rs:408:48:410:9 | { ... } |  | main.rs:392:5:393:14 | S1 |
+| main.rs:409:20:409:31 | "not called" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:415:26:415:29 | SelfParam |  | main.rs:392:5:393:14 | S1 |
+| main.rs:415:38:417:9 | { ... } |  | main.rs:392:5:393:14 | S1 |
+| main.rs:416:13:416:16 | self |  | main.rs:392:5:393:14 | S1 |
+| main.rs:420:28:420:31 | SelfParam |  | main.rs:392:5:393:14 | S1 |
+| main.rs:420:40:422:9 | { ... } |  | main.rs:392:5:393:14 | S1 |
+| main.rs:421:13:421:16 | self |  | main.rs:392:5:393:14 | S1 |
+| main.rs:426:13:426:13 | x |  | main.rs:392:5:393:14 | S1 |
+| main.rs:426:17:426:18 | S1 |  | main.rs:392:5:393:14 | S1 |
+| main.rs:427:18:427:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:427:26:427:26 | x |  | main.rs:392:5:393:14 | S1 |
+| main.rs:427:26:427:42 | x.common_method() |  | main.rs:392:5:393:14 | S1 |
+| main.rs:428:18:428:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:428:26:428:26 | x |  | main.rs:392:5:393:14 | S1 |
+| main.rs:428:26:428:44 | x.common_method_2() |  | main.rs:392:5:393:14 | S1 |
+| main.rs:445:19:445:22 | SelfParam |  | main.rs:443:5:446:5 | Self [trait FirstTrait] |
+| main.rs:450:19:450:22 | SelfParam |  | main.rs:448:5:451:5 | Self [trait SecondTrait] |
+| main.rs:453:64:453:64 | x |  | main.rs:453:45:453:61 | T |
+| main.rs:455:13:455:14 | s1 |  | main.rs:453:35:453:42 | I |
+| main.rs:455:18:455:18 | x |  | main.rs:453:45:453:61 | T |
+| main.rs:455:18:455:27 | x.method() |  | main.rs:453:35:453:42 | I |
+| main.rs:456:18:456:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:456:26:456:27 | s1 |  | main.rs:453:35:453:42 | I |
+| main.rs:459:65:459:65 | x |  | main.rs:459:46:459:62 | T |
+| main.rs:461:13:461:14 | s2 |  | main.rs:459:36:459:43 | I |
+| main.rs:461:18:461:18 | x |  | main.rs:459:46:459:62 | T |
+| main.rs:461:18:461:27 | x.method() |  | main.rs:459:36:459:43 | I |
+| main.rs:462:18:462:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:462:26:462:27 | s2 |  | main.rs:459:36:459:43 | I |
+| main.rs:465:49:465:49 | x |  | main.rs:465:30:465:46 | T |
+| main.rs:466:13:466:13 | s |  | main.rs:435:5:436:14 | S1 |
+| main.rs:466:17:466:17 | x |  | main.rs:465:30:465:46 | T |
+| main.rs:466:17:466:26 | x.method() |  | main.rs:435:5:436:14 | S1 |
+| main.rs:467:18:467:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:467:26:467:26 | s |  | main.rs:435:5:436:14 | S1 |
+| main.rs:470:53:470:53 | x |  | main.rs:470:34:470:50 | T |
+| main.rs:471:13:471:13 | s |  | main.rs:435:5:436:14 | S1 |
+| main.rs:471:17:471:17 | x |  | main.rs:470:34:470:50 | T |
+| main.rs:471:17:471:26 | x.method() |  | main.rs:435:5:436:14 | S1 |
+| main.rs:472:18:472:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:472:26:472:26 | s |  | main.rs:435:5:436:14 | S1 |
+| main.rs:476:16:476:19 | SelfParam |  | main.rs:475:5:479:5 | Self [trait Pair] |
+| main.rs:478:16:478:19 | SelfParam |  | main.rs:475:5:479:5 | Self [trait Pair] |
+| main.rs:481:58:481:58 | x |  | main.rs:481:41:481:55 | T |
+| main.rs:481:64:481:64 | y |  | main.rs:481:41:481:55 | T |
+| main.rs:483:13:483:14 | s1 |  | main.rs:435:5:436:14 | S1 |
+| main.rs:483:18:483:18 | x |  | main.rs:481:41:481:55 | T |
+| main.rs:483:18:483:24 | x.fst() |  | main.rs:435:5:436:14 | S1 |
+| main.rs:484:13:484:14 | s2 |  | main.rs:438:5:439:14 | S2 |
+| main.rs:484:18:484:18 | y |  | main.rs:481:41:481:55 | T |
+| main.rs:484:18:484:24 | y.snd() |  | main.rs:438:5:439:14 | S2 |
+| main.rs:485:18:485:29 | "{:?}, {:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:485:32:485:33 | s1 |  | main.rs:435:5:436:14 | S1 |
+| main.rs:485:36:485:37 | s2 |  | main.rs:438:5:439:14 | S2 |
+| main.rs:488:69:488:69 | x |  | main.rs:488:52:488:66 | T |
+| main.rs:488:75:488:75 | y |  | main.rs:488:52:488:66 | T |
+| main.rs:490:13:490:14 | s1 |  | main.rs:435:5:436:14 | S1 |
+| main.rs:490:18:490:18 | x |  | main.rs:488:52:488:66 | T |
+| main.rs:490:18:490:24 | x.fst() |  | main.rs:435:5:436:14 | S1 |
+| main.rs:491:13:491:14 | s2 |  | main.rs:488:41:488:49 | T2 |
+| main.rs:491:18:491:18 | y |  | main.rs:488:52:488:66 | T |
+| main.rs:491:18:491:24 | y.snd() |  | main.rs:488:41:488:49 | T2 |
+| main.rs:492:18:492:29 | "{:?}, {:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:492:32:492:33 | s1 |  | main.rs:435:5:436:14 | S1 |
+| main.rs:492:36:492:37 | s2 |  | main.rs:488:41:488:49 | T2 |
+| main.rs:508:15:508:18 | SelfParam |  | main.rs:507:5:516:5 | Self [trait MyTrait] |
+| main.rs:510:15:510:18 | SelfParam |  | main.rs:507:5:516:5 | Self [trait MyTrait] |
+| main.rs:513:9:515:9 | { ... } |  | main.rs:507:19:507:19 | A |
+| main.rs:514:13:514:16 | self |  | main.rs:507:5:516:5 | Self [trait MyTrait] |
+| main.rs:514:13:514:21 | self.m1() |  | main.rs:507:19:507:19 | A |
+| main.rs:519:43:519:43 | x |  | main.rs:519:26:519:40 | T2 |
+| main.rs:519:56:521:5 | { ... } |  | main.rs:519:22:519:23 | T1 |
+| main.rs:520:9:520:9 | x |  | main.rs:519:26:519:40 | T2 |
+| main.rs:520:9:520:14 | x.m1() |  | main.rs:519:22:519:23 | T1 |
+| main.rs:524:49:524:49 | x |  | main.rs:497:5:500:5 | MyThing |
+| main.rs:524:49:524:49 | x | T | main.rs:524:32:524:46 | T2 |
+| main.rs:524:71:526:5 | { ... } |  | main.rs:524:28:524:29 | T1 |
+| main.rs:525:9:525:9 | x |  | main.rs:497:5:500:5 | MyThing |
+| main.rs:525:9:525:9 | x | T | main.rs:524:32:524:46 | T2 |
+| main.rs:525:9:525:11 | x.a |  | main.rs:524:32:524:46 | T2 |
+| main.rs:525:9:525:16 | ... .m1() |  | main.rs:524:28:524:29 | T1 |
+| main.rs:529:15:529:18 | SelfParam |  | main.rs:497:5:500:5 | MyThing |
+| main.rs:529:15:529:18 | SelfParam | T | main.rs:528:10:528:10 | T |
+| main.rs:529:26:531:9 | { ... } |  | main.rs:528:10:528:10 | T |
+| main.rs:530:13:530:16 | self |  | main.rs:497:5:500:5 | MyThing |
+| main.rs:530:13:530:16 | self | T | main.rs:528:10:528:10 | T |
+| main.rs:530:13:530:18 | self.a |  | main.rs:528:10:528:10 | T |
+| main.rs:535:13:535:13 | x |  | main.rs:497:5:500:5 | MyThing |
+| main.rs:535:13:535:13 | x | T | main.rs:502:5:503:14 | S1 |
+| main.rs:535:17:535:33 | MyThing {...} |  | main.rs:497:5:500:5 | MyThing |
+| main.rs:535:17:535:33 | MyThing {...} | T | main.rs:502:5:503:14 | S1 |
+| main.rs:535:30:535:31 | S1 |  | main.rs:502:5:503:14 | S1 |
+| main.rs:536:13:536:13 | y |  | main.rs:497:5:500:5 | MyThing |
+| main.rs:536:13:536:13 | y | T | main.rs:504:5:505:14 | S2 |
+| main.rs:536:17:536:33 | MyThing {...} |  | main.rs:497:5:500:5 | MyThing |
+| main.rs:536:17:536:33 | MyThing {...} | T | main.rs:504:5:505:14 | S2 |
+| main.rs:536:30:536:31 | S2 |  | main.rs:504:5:505:14 | S2 |
+| main.rs:538:18:538:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:538:26:538:26 | x |  | main.rs:497:5:500:5 | MyThing |
+| main.rs:538:26:538:26 | x | T | main.rs:502:5:503:14 | S1 |
+| main.rs:538:26:538:31 | x.m1() |  | main.rs:502:5:503:14 | S1 |
+| main.rs:539:18:539:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:539:26:539:26 | y |  | main.rs:497:5:500:5 | MyThing |
+| main.rs:539:26:539:26 | y | T | main.rs:504:5:505:14 | S2 |
+| main.rs:539:26:539:31 | y.m1() |  | main.rs:504:5:505:14 | S2 |
+| main.rs:541:13:541:13 | x |  | main.rs:497:5:500:5 | MyThing |
+| main.rs:541:13:541:13 | x | T | main.rs:502:5:503:14 | S1 |
+| main.rs:541:17:541:33 | MyThing {...} |  | main.rs:497:5:500:5 | MyThing |
+| main.rs:541:17:541:33 | MyThing {...} | T | main.rs:502:5:503:14 | S1 |
+| main.rs:541:30:541:31 | S1 |  | main.rs:502:5:503:14 | S1 |
+| main.rs:542:13:542:13 | y |  | main.rs:497:5:500:5 | MyThing |
+| main.rs:542:13:542:13 | y | T | main.rs:504:5:505:14 | S2 |
+| main.rs:542:17:542:33 | MyThing {...} |  | main.rs:497:5:500:5 | MyThing |
+| main.rs:542:17:542:33 | MyThing {...} | T | main.rs:504:5:505:14 | S2 |
+| main.rs:542:30:542:31 | S2 |  | main.rs:504:5:505:14 | S2 |
+| main.rs:544:18:544:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:544:26:544:26 | x |  | main.rs:497:5:500:5 | MyThing |
+| main.rs:544:26:544:26 | x | T | main.rs:502:5:503:14 | S1 |
+| main.rs:544:26:544:31 | x.m2() |  | main.rs:502:5:503:14 | S1 |
+| main.rs:545:18:545:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:545:26:545:26 | y |  | main.rs:497:5:500:5 | MyThing |
+| main.rs:545:26:545:26 | y | T | main.rs:504:5:505:14 | S2 |
+| main.rs:545:26:545:31 | y.m2() |  | main.rs:504:5:505:14 | S2 |
+| main.rs:547:13:547:14 | x2 |  | main.rs:497:5:500:5 | MyThing |
+| main.rs:547:13:547:14 | x2 | T | main.rs:502:5:503:14 | S1 |
+| main.rs:547:18:547:34 | MyThing {...} |  | main.rs:497:5:500:5 | MyThing |
+| main.rs:547:18:547:34 | MyThing {...} | T | main.rs:502:5:503:14 | S1 |
+| main.rs:547:31:547:32 | S1 |  | main.rs:502:5:503:14 | S1 |
+| main.rs:548:13:548:14 | y2 |  | main.rs:497:5:500:5 | MyThing |
+| main.rs:548:13:548:14 | y2 | T | main.rs:504:5:505:14 | S2 |
+| main.rs:548:18:548:34 | MyThing {...} |  | main.rs:497:5:500:5 | MyThing |
+| main.rs:548:18:548:34 | MyThing {...} | T | main.rs:504:5:505:14 | S2 |
+| main.rs:548:31:548:32 | S2 |  | main.rs:504:5:505:14 | S2 |
+| main.rs:550:18:550:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:550:26:550:42 | call_trait_m1(...) |  | main.rs:502:5:503:14 | S1 |
+| main.rs:550:40:550:41 | x2 |  | main.rs:497:5:500:5 | MyThing |
+| main.rs:550:40:550:41 | x2 | T | main.rs:502:5:503:14 | S1 |
+| main.rs:551:18:551:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:551:26:551:42 | call_trait_m1(...) |  | main.rs:504:5:505:14 | S2 |
+| main.rs:551:40:551:41 | y2 |  | main.rs:497:5:500:5 | MyThing |
+| main.rs:551:40:551:41 | y2 | T | main.rs:504:5:505:14 | S2 |
+| main.rs:553:13:553:14 | x3 |  | main.rs:497:5:500:5 | MyThing |
+| main.rs:553:13:553:14 | x3 | T | main.rs:497:5:500:5 | MyThing |
+| main.rs:553:13:553:14 | x3 | T.T | main.rs:502:5:503:14 | S1 |
+| main.rs:553:18:555:9 | MyThing {...} |  | main.rs:497:5:500:5 | MyThing |
+| main.rs:553:18:555:9 | MyThing {...} | T | main.rs:497:5:500:5 | MyThing |
+| main.rs:553:18:555:9 | MyThing {...} | T.T | main.rs:502:5:503:14 | S1 |
+| main.rs:554:16:554:32 | MyThing {...} |  | main.rs:497:5:500:5 | MyThing |
+| main.rs:554:16:554:32 | MyThing {...} | T | main.rs:502:5:503:14 | S1 |
+| main.rs:554:29:554:30 | S1 |  | main.rs:502:5:503:14 | S1 |
+| main.rs:556:13:556:14 | y3 |  | main.rs:497:5:500:5 | MyThing |
+| main.rs:556:13:556:14 | y3 | T | main.rs:497:5:500:5 | MyThing |
+| main.rs:556:13:556:14 | y3 | T.T | main.rs:504:5:505:14 | S2 |
+| main.rs:556:18:558:9 | MyThing {...} |  | main.rs:497:5:500:5 | MyThing |
+| main.rs:556:18:558:9 | MyThing {...} | T | main.rs:497:5:500:5 | MyThing |
+| main.rs:556:18:558:9 | MyThing {...} | T.T | main.rs:504:5:505:14 | S2 |
+| main.rs:557:16:557:32 | MyThing {...} |  | main.rs:497:5:500:5 | MyThing |
+| main.rs:557:16:557:32 | MyThing {...} | T | main.rs:504:5:505:14 | S2 |
+| main.rs:557:29:557:30 | S2 |  | main.rs:504:5:505:14 | S2 |
+| main.rs:560:13:560:13 | a |  | main.rs:502:5:503:14 | S1 |
+| main.rs:560:17:560:39 | call_trait_thing_m1(...) |  | main.rs:502:5:503:14 | S1 |
+| main.rs:560:37:560:38 | x3 |  | main.rs:497:5:500:5 | MyThing |
+| main.rs:560:37:560:38 | x3 | T | main.rs:497:5:500:5 | MyThing |
+| main.rs:560:37:560:38 | x3 | T.T | main.rs:502:5:503:14 | S1 |
+| main.rs:561:18:561:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:561:26:561:26 | a |  | main.rs:502:5:503:14 | S1 |
+| main.rs:562:13:562:13 | b |  | main.rs:504:5:505:14 | S2 |
+| main.rs:562:17:562:39 | call_trait_thing_m1(...) |  | main.rs:504:5:505:14 | S2 |
+| main.rs:562:37:562:38 | y3 |  | main.rs:497:5:500:5 | MyThing |
+| main.rs:562:37:562:38 | y3 | T | main.rs:497:5:500:5 | MyThing |
+| main.rs:562:37:562:38 | y3 | T.T | main.rs:504:5:505:14 | S2 |
+| main.rs:563:18:563:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:563:26:563:26 | b |  | main.rs:504:5:505:14 | S2 |
+| main.rs:574:19:574:22 | SelfParam |  | main.rs:568:5:571:5 | Wrapper |
+| main.rs:574:19:574:22 | SelfParam | A | main.rs:573:10:573:10 | A |
+| main.rs:574:30:576:9 | { ... } |  | main.rs:573:10:573:10 | A |
+| main.rs:575:13:575:16 | self |  | main.rs:568:5:571:5 | Wrapper |
+| main.rs:575:13:575:16 | self | A | main.rs:573:10:573:10 | A |
+| main.rs:575:13:575:22 | self.field |  | main.rs:573:10:573:10 | A |
+| main.rs:583:15:583:18 | SelfParam |  | main.rs:579:5:593:5 | Self [trait MyTrait] |
+| main.rs:585:15:585:18 | SelfParam |  | main.rs:579:5:593:5 | Self [trait MyTrait] |
+| main.rs:589:9:592:9 | { ... } |  | main.rs:580:9:580:28 | AssociatedType |
+| main.rs:590:13:590:16 | self |  | main.rs:579:5:593:5 | Self [trait MyTrait] |
+| main.rs:590:13:590:21 | self.m1() |  | main.rs:580:9:580:28 | AssociatedType |
+| main.rs:591:13:591:43 | ...::default(...) |  | main.rs:580:9:580:28 | AssociatedType |
+| main.rs:599:19:599:23 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:599:19:599:23 | SelfParam | &T | main.rs:595:5:605:5 | Self [trait MyTraitAssoc2] |
+| main.rs:599:26:599:26 | a |  | main.rs:599:16:599:16 | A |
+| main.rs:601:22:601:26 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:601:22:601:26 | SelfParam | &T | main.rs:595:5:605:5 | Self [trait MyTraitAssoc2] |
+| main.rs:601:29:601:29 | a |  | main.rs:601:19:601:19 | A |
+| main.rs:601:35:601:35 | b |  | main.rs:601:19:601:19 | A |
+| main.rs:601:75:604:9 | { ... } |  | main.rs:596:9:596:52 | GenericAssociatedType |
+| main.rs:602:13:602:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:602:13:602:16 | self | &T | main.rs:595:5:605:5 | Self [trait MyTraitAssoc2] |
+| main.rs:602:13:602:23 | self.put(...) |  | main.rs:596:9:596:52 | GenericAssociatedType |
+| main.rs:602:22:602:22 | a |  | main.rs:601:19:601:19 | A |
+| main.rs:603:13:603:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:603:13:603:16 | self | &T | main.rs:595:5:605:5 | Self [trait MyTraitAssoc2] |
+| main.rs:603:13:603:23 | self.put(...) |  | main.rs:596:9:596:52 | GenericAssociatedType |
+| main.rs:603:22:603:22 | b |  | main.rs:601:19:601:19 | A |
+| main.rs:612:21:612:25 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:612:21:612:25 | SelfParam | &T | main.rs:607:5:617:5 | Self [trait TraitMultipleAssoc] |
+| main.rs:614:20:614:24 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:614:20:614:24 | SelfParam | &T | main.rs:607:5:617:5 | Self [trait TraitMultipleAssoc] |
+| main.rs:616:20:616:24 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:616:20:616:24 | SelfParam | &T | main.rs:607:5:617:5 | Self [trait TraitMultipleAssoc] |
+| main.rs:632:15:632:18 | SelfParam |  | main.rs:619:5:620:13 | S |
+| main.rs:632:45:634:9 | { ... } |  | main.rs:625:5:626:14 | AT |
+| main.rs:633:13:633:14 | AT |  | main.rs:625:5:626:14 | AT |
+| main.rs:642:19:642:23 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:642:19:642:23 | SelfParam | &T | main.rs:619:5:620:13 | S |
+| main.rs:642:26:642:26 | a |  | main.rs:642:16:642:16 | A |
+| main.rs:642:46:644:9 | { ... } |  | main.rs:568:5:571:5 | Wrapper |
+| main.rs:642:46:644:9 | { ... } | A | main.rs:642:16:642:16 | A |
+| main.rs:643:13:643:32 | Wrapper {...} |  | main.rs:568:5:571:5 | Wrapper |
+| main.rs:643:13:643:32 | Wrapper {...} | A | main.rs:642:16:642:16 | A |
+| main.rs:643:30:643:30 | a |  | main.rs:642:16:642:16 | A |
+| main.rs:651:15:651:18 | SelfParam |  | main.rs:622:5:623:14 | S2 |
+| main.rs:651:45:653:9 | { ... } |  | main.rs:568:5:571:5 | Wrapper |
+| main.rs:651:45:653:9 | { ... } | A | main.rs:622:5:623:14 | S2 |
+| main.rs:652:13:652:35 | Wrapper {...} |  | main.rs:568:5:571:5 | Wrapper |
+| main.rs:652:13:652:35 | Wrapper {...} | A | main.rs:622:5:623:14 | S2 |
+| main.rs:652:30:652:33 | self |  | main.rs:622:5:623:14 | S2 |
+| main.rs:658:30:660:9 | { ... } |  | main.rs:568:5:571:5 | Wrapper |
+| main.rs:658:30:660:9 | { ... } | A | main.rs:622:5:623:14 | S2 |
+| main.rs:659:13:659:33 | Wrapper {...} |  | main.rs:568:5:571:5 | Wrapper |
+| main.rs:659:13:659:33 | Wrapper {...} | A | main.rs:622:5:623:14 | S2 |
+| main.rs:659:30:659:31 | S2 |  | main.rs:622:5:623:14 | S2 |
+| main.rs:664:22:664:26 | thing |  | main.rs:664:10:664:19 | T |
+| main.rs:665:9:665:13 | thing |  | main.rs:664:10:664:19 | T |
+| main.rs:672:21:672:25 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:672:21:672:25 | SelfParam | &T | main.rs:625:5:626:14 | AT |
+| main.rs:672:34:674:9 | { ... } |  | main.rs:625:5:626:14 | AT |
+| main.rs:673:13:673:14 | AT |  | main.rs:625:5:626:14 | AT |
+| main.rs:676:20:676:24 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:676:20:676:24 | SelfParam | &T | main.rs:625:5:626:14 | AT |
+| main.rs:676:43:678:9 | { ... } |  | main.rs:619:5:620:13 | S |
+| main.rs:677:13:677:13 | S |  | main.rs:619:5:620:13 | S |
+| main.rs:680:20:680:24 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:680:20:680:24 | SelfParam | &T | main.rs:625:5:626:14 | AT |
+| main.rs:680:43:682:9 | { ... } |  | main.rs:622:5:623:14 | S2 |
+| main.rs:681:13:681:14 | S2 |  | main.rs:622:5:623:14 | S2 |
+| main.rs:686:13:686:14 | x1 |  | main.rs:619:5:620:13 | S |
+| main.rs:686:18:686:18 | S |  | main.rs:619:5:620:13 | S |
+| main.rs:688:18:688:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:688:26:688:27 | x1 |  | main.rs:619:5:620:13 | S |
+| main.rs:688:26:688:32 | x1.m1() |  | main.rs:625:5:626:14 | AT |
+| main.rs:690:13:690:14 | x2 |  | main.rs:619:5:620:13 | S |
+| main.rs:690:18:690:18 | S |  | main.rs:619:5:620:13 | S |
+| main.rs:692:13:692:13 | y |  | main.rs:625:5:626:14 | AT |
+| main.rs:692:17:692:18 | x2 |  | main.rs:619:5:620:13 | S |
+| main.rs:692:17:692:23 | x2.m2() |  | main.rs:625:5:626:14 | AT |
+| main.rs:693:18:693:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:693:26:693:26 | y |  | main.rs:625:5:626:14 | AT |
+| main.rs:695:13:695:14 | x3 |  | main.rs:619:5:620:13 | S |
+| main.rs:695:18:695:18 | S |  | main.rs:619:5:620:13 | S |
+| main.rs:697:18:697:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:697:26:697:27 | x3 |  | main.rs:619:5:620:13 | S |
+| main.rs:697:26:697:34 | x3.put(...) |  | main.rs:568:5:571:5 | Wrapper |
+| main.rs:697:26:697:34 | x3.put(...) | A | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:697:26:697:43 | ... .unwrap() |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:697:33:697:33 | 1 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:700:18:700:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:700:26:700:27 | x3 |  | main.rs:619:5:620:13 | S |
+| main.rs:700:36:700:36 | 2 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:700:39:700:39 | 3 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:702:20:702:20 | S |  | main.rs:619:5:620:13 | S |
+| main.rs:703:18:703:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:705:13:705:14 | x5 |  | main.rs:622:5:623:14 | S2 |
+| main.rs:705:18:705:19 | S2 |  | main.rs:622:5:623:14 | S2 |
+| main.rs:706:18:706:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:706:26:706:27 | x5 |  | main.rs:622:5:623:14 | S2 |
+| main.rs:706:26:706:32 | x5.m1() |  | main.rs:568:5:571:5 | Wrapper |
+| main.rs:706:26:706:32 | x5.m1() | A | main.rs:622:5:623:14 | S2 |
+| main.rs:707:13:707:14 | x6 |  | main.rs:622:5:623:14 | S2 |
+| main.rs:707:18:707:19 | S2 |  | main.rs:622:5:623:14 | S2 |
+| main.rs:708:18:708:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:708:26:708:27 | x6 |  | main.rs:622:5:623:14 | S2 |
+| main.rs:708:26:708:32 | x6.m2() |  | main.rs:568:5:571:5 | Wrapper |
+| main.rs:708:26:708:32 | x6.m2() | A | main.rs:622:5:623:14 | S2 |
+| main.rs:710:13:710:22 | assoc_zero |  | main.rs:625:5:626:14 | AT |
+| main.rs:710:26:710:27 | AT |  | main.rs:625:5:626:14 | AT |
+| main.rs:710:26:710:38 | AT.get_zero() |  | main.rs:625:5:626:14 | AT |
+| main.rs:711:13:711:21 | assoc_one |  | main.rs:619:5:620:13 | S |
+| main.rs:711:25:711:26 | AT |  | main.rs:625:5:626:14 | AT |
+| main.rs:711:25:711:36 | AT.get_one() |  | main.rs:619:5:620:13 | S |
+| main.rs:712:13:712:21 | assoc_two |  | main.rs:622:5:623:14 | S2 |
+| main.rs:712:25:712:26 | AT |  | main.rs:625:5:626:14 | AT |
+| main.rs:712:25:712:36 | AT.get_two() |  | main.rs:622:5:623:14 | S2 |
+| main.rs:729:15:729:18 | SelfParam |  | main.rs:717:5:721:5 | MyEnum |
+| main.rs:729:15:729:18 | SelfParam | A | main.rs:728:10:728:10 | T |
+| main.rs:729:26:734:9 | { ... } |  | main.rs:728:10:728:10 | T |
+| main.rs:730:13:733:13 | match self { ... } |  | main.rs:728:10:728:10 | T |
+| main.rs:730:19:730:22 | self |  | main.rs:717:5:721:5 | MyEnum |
+| main.rs:730:19:730:22 | self | A | main.rs:728:10:728:10 | T |
+| main.rs:731:28:731:28 | a |  | main.rs:728:10:728:10 | T |
+| main.rs:731:34:731:34 | a |  | main.rs:728:10:728:10 | T |
+| main.rs:732:30:732:30 | a |  | main.rs:728:10:728:10 | T |
+| main.rs:732:37:732:37 | a |  | main.rs:728:10:728:10 | T |
+| main.rs:738:13:738:13 | x |  | main.rs:717:5:721:5 | MyEnum |
+| main.rs:738:13:738:13 | x | A | main.rs:723:5:724:14 | S1 |
+| main.rs:738:17:738:30 | ...::C1(...) |  | main.rs:717:5:721:5 | MyEnum |
+| main.rs:738:17:738:30 | ...::C1(...) | A | main.rs:723:5:724:14 | S1 |
+| main.rs:738:28:738:29 | S1 |  | main.rs:723:5:724:14 | S1 |
+| main.rs:739:13:739:13 | y |  | main.rs:717:5:721:5 | MyEnum |
+| main.rs:739:13:739:13 | y | A | main.rs:725:5:726:14 | S2 |
+| main.rs:739:17:739:36 | ...::C2 {...} |  | main.rs:717:5:721:5 | MyEnum |
+| main.rs:739:17:739:36 | ...::C2 {...} | A | main.rs:725:5:726:14 | S2 |
+| main.rs:739:33:739:34 | S2 |  | main.rs:725:5:726:14 | S2 |
+| main.rs:741:18:741:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:741:26:741:26 | x |  | main.rs:717:5:721:5 | MyEnum |
+| main.rs:741:26:741:26 | x | A | main.rs:723:5:724:14 | S1 |
+| main.rs:741:26:741:31 | x.m1() |  | main.rs:723:5:724:14 | S1 |
+| main.rs:742:18:742:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:742:26:742:26 | y |  | main.rs:717:5:721:5 | MyEnum |
+| main.rs:742:26:742:26 | y | A | main.rs:725:5:726:14 | S2 |
+| main.rs:742:26:742:31 | y.m1() |  | main.rs:725:5:726:14 | S2 |
+| main.rs:764:15:764:18 | SelfParam |  | main.rs:762:5:765:5 | Self [trait MyTrait1] |
+| main.rs:768:15:768:18 | SelfParam |  | main.rs:767:5:778:5 | Self [trait MyTrait2] |
+| main.rs:771:9:777:9 | { ... } |  | main.rs:767:20:767:22 | Tr2 |
+| main.rs:772:13:776:13 | if ... {...} else {...} |  | main.rs:767:20:767:22 | Tr2 |
+| main.rs:772:16:772:16 | 1 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:772:20:772:20 | 1 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:772:24:772:24 | 2 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:772:26:774:13 | { ... } |  | main.rs:767:20:767:22 | Tr2 |
+| main.rs:773:17:773:20 | self |  | main.rs:767:5:778:5 | Self [trait MyTrait2] |
+| main.rs:773:17:773:25 | self.m1() |  | main.rs:767:20:767:22 | Tr2 |
+| main.rs:774:20:776:13 | { ... } |  | main.rs:767:20:767:22 | Tr2 |
+| main.rs:775:17:775:30 | ...::m1(...) |  | main.rs:767:20:767:22 | Tr2 |
+| main.rs:775:26:775:29 | self |  | main.rs:767:5:778:5 | Self [trait MyTrait2] |
+| main.rs:781:15:781:18 | SelfParam |  | main.rs:780:5:791:5 | Self [trait MyTrait3] |
+| main.rs:784:9:790:9 | { ... } |  | main.rs:780:20:780:22 | Tr3 |
+| main.rs:785:13:789:13 | if ... {...} else {...} |  | main.rs:780:20:780:22 | Tr3 |
+| main.rs:785:16:785:16 | 1 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:785:20:785:20 | 1 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:785:24:785:24 | 2 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:785:26:787:13 | { ... } |  | main.rs:780:20:780:22 | Tr3 |
+| main.rs:786:17:786:20 | self |  | main.rs:780:5:791:5 | Self [trait MyTrait3] |
+| main.rs:786:17:786:25 | self.m2() |  | main.rs:747:5:750:5 | MyThing |
+| main.rs:786:17:786:25 | self.m2() | A | main.rs:780:20:780:22 | Tr3 |
+| main.rs:786:17:786:27 | ... .a |  | main.rs:780:20:780:22 | Tr3 |
+| main.rs:787:20:789:13 | { ... } |  | main.rs:780:20:780:22 | Tr3 |
+| main.rs:788:17:788:30 | ...::m2(...) |  | main.rs:747:5:750:5 | MyThing |
+| main.rs:788:17:788:30 | ...::m2(...) | A | main.rs:780:20:780:22 | Tr3 |
+| main.rs:788:17:788:32 | ... .a |  | main.rs:780:20:780:22 | Tr3 |
+| main.rs:788:26:788:29 | self |  | main.rs:780:5:791:5 | Self [trait MyTrait3] |
+| main.rs:795:15:795:18 | SelfParam |  | main.rs:747:5:750:5 | MyThing |
+| main.rs:795:15:795:18 | SelfParam | A | main.rs:793:10:793:10 | T |
+| main.rs:795:26:797:9 | { ... } |  | main.rs:793:10:793:10 | T |
+| main.rs:796:13:796:16 | self |  | main.rs:747:5:750:5 | MyThing |
+| main.rs:796:13:796:16 | self | A | main.rs:793:10:793:10 | T |
+| main.rs:796:13:796:18 | self.a |  | main.rs:793:10:793:10 | T |
+| main.rs:804:15:804:18 | SelfParam |  | main.rs:752:5:755:5 | MyThing2 |
+| main.rs:804:15:804:18 | SelfParam | A | main.rs:802:10:802:10 | T |
+| main.rs:804:35:806:9 | { ... } |  | main.rs:747:5:750:5 | MyThing |
+| main.rs:804:35:806:9 | { ... } | A | main.rs:802:10:802:10 | T |
+| main.rs:805:13:805:33 | MyThing {...} |  | main.rs:747:5:750:5 | MyThing |
+| main.rs:805:13:805:33 | MyThing {...} | A | main.rs:802:10:802:10 | T |
+| main.rs:805:26:805:29 | self |  | main.rs:752:5:755:5 | MyThing2 |
+| main.rs:805:26:805:29 | self | A | main.rs:802:10:802:10 | T |
+| main.rs:805:26:805:31 | self.a |  | main.rs:802:10:802:10 | T |
+| main.rs:813:44:813:44 | x |  | main.rs:813:26:813:41 | T2 |
+| main.rs:813:57:815:5 | { ... } |  | main.rs:813:22:813:23 | T1 |
+| main.rs:814:9:814:9 | x |  | main.rs:813:26:813:41 | T2 |
+| main.rs:814:9:814:14 | x.m1() |  | main.rs:813:22:813:23 | T1 |
+| main.rs:817:56:817:56 | x |  | main.rs:817:39:817:53 | T |
+| main.rs:819:13:819:13 | a |  | main.rs:747:5:750:5 | MyThing |
+| main.rs:819:13:819:13 | a | A | main.rs:757:5:758:14 | S1 |
+| main.rs:819:17:819:17 | x |  | main.rs:817:39:817:53 | T |
+| main.rs:819:17:819:22 | x.m1() |  | main.rs:747:5:750:5 | MyThing |
+| main.rs:819:17:819:22 | x.m1() | A | main.rs:757:5:758:14 | S1 |
+| main.rs:820:18:820:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:820:26:820:26 | a |  | main.rs:747:5:750:5 | MyThing |
+| main.rs:820:26:820:26 | a | A | main.rs:757:5:758:14 | S1 |
+| main.rs:824:13:824:13 | x |  | main.rs:747:5:750:5 | MyThing |
+| main.rs:824:13:824:13 | x | A | main.rs:757:5:758:14 | S1 |
+| main.rs:824:17:824:33 | MyThing {...} |  | main.rs:747:5:750:5 | MyThing |
+| main.rs:824:17:824:33 | MyThing {...} | A | main.rs:757:5:758:14 | S1 |
+| main.rs:824:30:824:31 | S1 |  | main.rs:757:5:758:14 | S1 |
+| main.rs:825:13:825:13 | y |  | main.rs:747:5:750:5 | MyThing |
+| main.rs:825:13:825:13 | y | A | main.rs:759:5:760:14 | S2 |
+| main.rs:825:17:825:33 | MyThing {...} |  | main.rs:747:5:750:5 | MyThing |
+| main.rs:825:17:825:33 | MyThing {...} | A | main.rs:759:5:760:14 | S2 |
+| main.rs:825:30:825:31 | S2 |  | main.rs:759:5:760:14 | S2 |
+| main.rs:827:18:827:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:827:26:827:26 | x |  | main.rs:747:5:750:5 | MyThing |
+| main.rs:827:26:827:26 | x | A | main.rs:757:5:758:14 | S1 |
+| main.rs:827:26:827:31 | x.m1() |  | main.rs:757:5:758:14 | S1 |
+| main.rs:828:18:828:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:828:26:828:26 | y |  | main.rs:747:5:750:5 | MyThing |
+| main.rs:828:26:828:26 | y | A | main.rs:759:5:760:14 | S2 |
+| main.rs:828:26:828:31 | y.m1() |  | main.rs:759:5:760:14 | S2 |
+| main.rs:830:13:830:13 | x |  | main.rs:747:5:750:5 | MyThing |
+| main.rs:830:13:830:13 | x | A | main.rs:757:5:758:14 | S1 |
+| main.rs:830:17:830:33 | MyThing {...} |  | main.rs:747:5:750:5 | MyThing |
+| main.rs:830:17:830:33 | MyThing {...} | A | main.rs:757:5:758:14 | S1 |
+| main.rs:830:30:830:31 | S1 |  | main.rs:757:5:758:14 | S1 |
+| main.rs:831:13:831:13 | y |  | main.rs:747:5:750:5 | MyThing |
+| main.rs:831:13:831:13 | y | A | main.rs:759:5:760:14 | S2 |
+| main.rs:831:17:831:33 | MyThing {...} |  | main.rs:747:5:750:5 | MyThing |
+| main.rs:831:17:831:33 | MyThing {...} | A | main.rs:759:5:760:14 | S2 |
+| main.rs:831:30:831:31 | S2 |  | main.rs:759:5:760:14 | S2 |
+| main.rs:833:18:833:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:833:26:833:26 | x |  | main.rs:747:5:750:5 | MyThing |
+| main.rs:833:26:833:26 | x | A | main.rs:757:5:758:14 | S1 |
+| main.rs:833:26:833:31 | x.m2() |  | main.rs:757:5:758:14 | S1 |
+| main.rs:834:18:834:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:834:26:834:26 | y |  | main.rs:747:5:750:5 | MyThing |
+| main.rs:834:26:834:26 | y | A | main.rs:759:5:760:14 | S2 |
+| main.rs:834:26:834:31 | y.m2() |  | main.rs:759:5:760:14 | S2 |
+| main.rs:836:13:836:13 | x |  | main.rs:752:5:755:5 | MyThing2 |
+| main.rs:836:13:836:13 | x | A | main.rs:757:5:758:14 | S1 |
+| main.rs:836:17:836:34 | MyThing2 {...} |  | main.rs:752:5:755:5 | MyThing2 |
+| main.rs:836:17:836:34 | MyThing2 {...} | A | main.rs:757:5:758:14 | S1 |
+| main.rs:836:31:836:32 | S1 |  | main.rs:757:5:758:14 | S1 |
+| main.rs:837:13:837:13 | y |  | main.rs:752:5:755:5 | MyThing2 |
+| main.rs:837:13:837:13 | y | A | main.rs:759:5:760:14 | S2 |
+| main.rs:837:17:837:34 | MyThing2 {...} |  | main.rs:752:5:755:5 | MyThing2 |
+| main.rs:837:17:837:34 | MyThing2 {...} | A | main.rs:759:5:760:14 | S2 |
+| main.rs:837:31:837:32 | S2 |  | main.rs:759:5:760:14 | S2 |
+| main.rs:839:18:839:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:839:26:839:26 | x |  | main.rs:752:5:755:5 | MyThing2 |
+| main.rs:839:26:839:26 | x | A | main.rs:757:5:758:14 | S1 |
+| main.rs:839:26:839:31 | x.m3() |  | main.rs:757:5:758:14 | S1 |
+| main.rs:840:18:840:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:840:26:840:26 | y |  | main.rs:752:5:755:5 | MyThing2 |
+| main.rs:840:26:840:26 | y | A | main.rs:759:5:760:14 | S2 |
+| main.rs:840:26:840:31 | y.m3() |  | main.rs:759:5:760:14 | S2 |
+| main.rs:842:13:842:13 | x |  | main.rs:747:5:750:5 | MyThing |
+| main.rs:842:13:842:13 | x | A | main.rs:757:5:758:14 | S1 |
+| main.rs:842:17:842:33 | MyThing {...} |  | main.rs:747:5:750:5 | MyThing |
+| main.rs:842:17:842:33 | MyThing {...} | A | main.rs:757:5:758:14 | S1 |
+| main.rs:842:30:842:31 | S1 |  | main.rs:757:5:758:14 | S1 |
+| main.rs:843:13:843:13 | s |  | main.rs:757:5:758:14 | S1 |
+| main.rs:843:17:843:32 | call_trait_m1(...) |  | main.rs:757:5:758:14 | S1 |
+| main.rs:843:31:843:31 | x |  | main.rs:747:5:750:5 | MyThing |
+| main.rs:843:31:843:31 | x | A | main.rs:757:5:758:14 | S1 |
+| main.rs:845:13:845:13 | x |  | main.rs:752:5:755:5 | MyThing2 |
+| main.rs:845:13:845:13 | x | A | main.rs:759:5:760:14 | S2 |
+| main.rs:845:17:845:34 | MyThing2 {...} |  | main.rs:752:5:755:5 | MyThing2 |
+| main.rs:845:17:845:34 | MyThing2 {...} | A | main.rs:759:5:760:14 | S2 |
+| main.rs:845:31:845:32 | S2 |  | main.rs:759:5:760:14 | S2 |
+| main.rs:846:13:846:13 | s |  | main.rs:747:5:750:5 | MyThing |
+| main.rs:846:13:846:13 | s | A | main.rs:759:5:760:14 | S2 |
+| main.rs:846:17:846:32 | call_trait_m1(...) |  | main.rs:747:5:750:5 | MyThing |
+| main.rs:846:17:846:32 | call_trait_m1(...) | A | main.rs:759:5:760:14 | S2 |
+| main.rs:846:31:846:31 | x |  | main.rs:752:5:755:5 | MyThing2 |
+| main.rs:846:31:846:31 | x | A | main.rs:759:5:760:14 | S2 |
+| main.rs:864:22:864:22 | x |  | file://:0:0:0:0 | & |
+| main.rs:864:22:864:22 | x | &T | main.rs:864:11:864:19 | T |
+| main.rs:864:35:866:5 | { ... } |  | file://:0:0:0:0 | & |
+| main.rs:864:35:866:5 | { ... } | &T | main.rs:864:11:864:19 | T |
+| main.rs:865:9:865:9 | x |  | file://:0:0:0:0 | & |
+| main.rs:865:9:865:9 | x | &T | main.rs:864:11:864:19 | T |
+| main.rs:869:17:869:20 | SelfParam |  | main.rs:854:5:855:14 | S1 |
+| main.rs:869:29:871:9 | { ... } |  | main.rs:857:5:858:14 | S2 |
+| main.rs:870:13:870:14 | S2 |  | main.rs:857:5:858:14 | S2 |
+| main.rs:874:21:874:21 | x |  | main.rs:874:13:874:14 | T1 |
+| main.rs:877:5:879:5 | { ... } |  | main.rs:874:17:874:18 | T2 |
+| main.rs:878:9:878:9 | x |  | main.rs:874:13:874:14 | T1 |
+| main.rs:878:9:878:16 | x.into() |  | main.rs:874:17:874:18 | T2 |
+| main.rs:882:13:882:13 | x |  | main.rs:854:5:855:14 | S1 |
+| main.rs:882:17:882:18 | S1 |  | main.rs:854:5:855:14 | S1 |
+| main.rs:883:18:883:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:883:26:883:31 | id(...) |  | file://:0:0:0:0 | & |
+| main.rs:883:26:883:31 | id(...) | &T | main.rs:854:5:855:14 | S1 |
+| main.rs:883:29:883:30 | &x |  | file://:0:0:0:0 | & |
+| main.rs:883:29:883:30 | &x | &T | main.rs:854:5:855:14 | S1 |
+| main.rs:883:30:883:30 | x |  | main.rs:854:5:855:14 | S1 |
+| main.rs:885:13:885:13 | x |  | main.rs:854:5:855:14 | S1 |
+| main.rs:885:17:885:18 | S1 |  | main.rs:854:5:855:14 | S1 |
+| main.rs:886:18:886:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:886:26:886:37 | id::<...>(...) |  | file://:0:0:0:0 | & |
+| main.rs:886:26:886:37 | id::<...>(...) | &T | main.rs:854:5:855:14 | S1 |
+| main.rs:886:35:886:36 | &x |  | file://:0:0:0:0 | & |
+| main.rs:886:35:886:36 | &x | &T | main.rs:854:5:855:14 | S1 |
+| main.rs:886:36:886:36 | x |  | main.rs:854:5:855:14 | S1 |
+| main.rs:888:13:888:13 | x |  | main.rs:854:5:855:14 | S1 |
+| main.rs:888:17:888:18 | S1 |  | main.rs:854:5:855:14 | S1 |
+| main.rs:889:18:889:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:889:26:889:44 | id::<...>(...) |  | file://:0:0:0:0 | & |
+| main.rs:889:26:889:44 | id::<...>(...) | &T | main.rs:854:5:855:14 | S1 |
+| main.rs:889:42:889:43 | &x |  | file://:0:0:0:0 | & |
+| main.rs:889:42:889:43 | &x | &T | main.rs:854:5:855:14 | S1 |
+| main.rs:889:43:889:43 | x |  | main.rs:854:5:855:14 | S1 |
+| main.rs:891:13:891:13 | x |  | main.rs:854:5:855:14 | S1 |
+| main.rs:891:17:891:18 | S1 |  | main.rs:854:5:855:14 | S1 |
+| main.rs:892:9:892:25 | into::<...>(...) |  | main.rs:857:5:858:14 | S2 |
+| main.rs:892:24:892:24 | x |  | main.rs:854:5:855:14 | S1 |
+| main.rs:894:13:894:13 | x |  | main.rs:854:5:855:14 | S1 |
+| main.rs:894:17:894:18 | S1 |  | main.rs:854:5:855:14 | S1 |
+| main.rs:895:13:895:13 | y |  | main.rs:857:5:858:14 | S2 |
+| main.rs:895:21:895:27 | into(...) |  | main.rs:857:5:858:14 | S2 |
+| main.rs:895:26:895:26 | x |  | main.rs:854:5:855:14 | S1 |
+| main.rs:909:22:909:25 | SelfParam |  | main.rs:900:5:906:5 | PairOption |
+| main.rs:909:22:909:25 | SelfParam | Fst | main.rs:908:10:908:12 | Fst |
+| main.rs:909:22:909:25 | SelfParam | Snd | main.rs:908:15:908:17 | Snd |
+| main.rs:909:35:916:9 | { ... } |  | main.rs:908:15:908:17 | Snd |
+| main.rs:910:13:915:13 | match self { ... } |  | main.rs:908:15:908:17 | Snd |
+| main.rs:910:19:910:22 | self |  | main.rs:900:5:906:5 | PairOption |
+| main.rs:910:19:910:22 | self | Fst | main.rs:908:10:908:12 | Fst |
+| main.rs:910:19:910:22 | self | Snd | main.rs:908:15:908:17 | Snd |
+| main.rs:911:43:911:82 | MacroExpr |  | main.rs:908:15:908:17 | Snd |
+| main.rs:911:50:911:81 | "PairNone has no second elemen... |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:912:43:912:81 | MacroExpr |  | main.rs:908:15:908:17 | Snd |
+| main.rs:912:50:912:80 | "PairFst has no second element... |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:913:37:913:39 | snd |  | main.rs:908:15:908:17 | Snd |
+| main.rs:913:45:913:47 | snd |  | main.rs:908:15:908:17 | Snd |
+| main.rs:914:41:914:43 | snd |  | main.rs:908:15:908:17 | Snd |
+| main.rs:914:49:914:51 | snd |  | main.rs:908:15:908:17 | Snd |
+| main.rs:940:10:940:10 | t |  | main.rs:900:5:906:5 | PairOption |
+| main.rs:940:10:940:10 | t | Fst | main.rs:922:5:923:14 | S2 |
+| main.rs:940:10:940:10 | t | Snd | main.rs:900:5:906:5 | PairOption |
+| main.rs:940:10:940:10 | t | Snd.Fst | main.rs:922:5:923:14 | S2 |
+| main.rs:940:10:940:10 | t | Snd.Snd | main.rs:925:5:926:14 | S3 |
+| main.rs:941:13:941:13 | x |  | main.rs:925:5:926:14 | S3 |
+| main.rs:941:17:941:17 | t |  | main.rs:900:5:906:5 | PairOption |
+| main.rs:941:17:941:17 | t | Fst | main.rs:922:5:923:14 | S2 |
+| main.rs:941:17:941:17 | t | Snd | main.rs:900:5:906:5 | PairOption |
+| main.rs:941:17:941:17 | t | Snd.Fst | main.rs:922:5:923:14 | S2 |
+| main.rs:941:17:941:17 | t | Snd.Snd | main.rs:925:5:926:14 | S3 |
+| main.rs:941:17:941:29 | t.unwrapSnd() |  | main.rs:900:5:906:5 | PairOption |
+| main.rs:941:17:941:29 | t.unwrapSnd() | Fst | main.rs:922:5:923:14 | S2 |
+| main.rs:941:17:941:29 | t.unwrapSnd() | Snd | main.rs:925:5:926:14 | S3 |
+| main.rs:941:17:941:41 | ... .unwrapSnd() |  | main.rs:925:5:926:14 | S3 |
+| main.rs:942:18:942:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:942:26:942:26 | x |  | main.rs:925:5:926:14 | S3 |
+| main.rs:947:13:947:14 | p1 |  | main.rs:900:5:906:5 | PairOption |
+| main.rs:947:13:947:14 | p1 | Fst | main.rs:919:5:920:14 | S1 |
+| main.rs:947:13:947:14 | p1 | Snd | main.rs:922:5:923:14 | S2 |
+| main.rs:947:26:947:53 | ...::PairBoth(...) |  | main.rs:900:5:906:5 | PairOption |
+| main.rs:947:26:947:53 | ...::PairBoth(...) | Fst | main.rs:919:5:920:14 | S1 |
+| main.rs:947:26:947:53 | ...::PairBoth(...) | Snd | main.rs:922:5:923:14 | S2 |
+| main.rs:947:47:947:48 | S1 |  | main.rs:919:5:920:14 | S1 |
+| main.rs:947:51:947:52 | S2 |  | main.rs:922:5:923:14 | S2 |
+| main.rs:948:18:948:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:948:26:948:27 | p1 |  | main.rs:900:5:906:5 | PairOption |
+| main.rs:948:26:948:27 | p1 | Fst | main.rs:919:5:920:14 | S1 |
+| main.rs:948:26:948:27 | p1 | Snd | main.rs:922:5:923:14 | S2 |
+| main.rs:951:13:951:14 | p2 |  | main.rs:900:5:906:5 | PairOption |
+| main.rs:951:13:951:14 | p2 | Fst | main.rs:919:5:920:14 | S1 |
+| main.rs:951:13:951:14 | p2 | Snd | main.rs:922:5:923:14 | S2 |
+| main.rs:951:26:951:47 | ...::PairNone(...) |  | main.rs:900:5:906:5 | PairOption |
+| main.rs:951:26:951:47 | ...::PairNone(...) | Fst | main.rs:919:5:920:14 | S1 |
+| main.rs:951:26:951:47 | ...::PairNone(...) | Snd | main.rs:922:5:923:14 | S2 |
+| main.rs:952:18:952:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:952:26:952:27 | p2 |  | main.rs:900:5:906:5 | PairOption |
+| main.rs:952:26:952:27 | p2 | Fst | main.rs:919:5:920:14 | S1 |
+| main.rs:952:26:952:27 | p2 | Snd | main.rs:922:5:923:14 | S2 |
+| main.rs:955:13:955:14 | p3 |  | main.rs:900:5:906:5 | PairOption |
+| main.rs:955:13:955:14 | p3 | Fst | main.rs:922:5:923:14 | S2 |
+| main.rs:955:13:955:14 | p3 | Snd | main.rs:925:5:926:14 | S3 |
+| main.rs:955:34:955:56 | ...::PairSnd(...) |  | main.rs:900:5:906:5 | PairOption |
+| main.rs:955:34:955:56 | ...::PairSnd(...) | Fst | main.rs:922:5:923:14 | S2 |
+| main.rs:955:34:955:56 | ...::PairSnd(...) | Snd | main.rs:925:5:926:14 | S3 |
+| main.rs:955:54:955:55 | S3 |  | main.rs:925:5:926:14 | S3 |
+| main.rs:956:18:956:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:956:26:956:27 | p3 |  | main.rs:900:5:906:5 | PairOption |
+| main.rs:956:26:956:27 | p3 | Fst | main.rs:922:5:923:14 | S2 |
+| main.rs:956:26:956:27 | p3 | Snd | main.rs:925:5:926:14 | S3 |
+| main.rs:959:13:959:14 | p3 |  | main.rs:900:5:906:5 | PairOption |
+| main.rs:959:13:959:14 | p3 | Fst | main.rs:922:5:923:14 | S2 |
+| main.rs:959:13:959:14 | p3 | Snd | main.rs:925:5:926:14 | S3 |
+| main.rs:959:35:959:56 | ...::PairNone(...) |  | main.rs:900:5:906:5 | PairOption |
+| main.rs:959:35:959:56 | ...::PairNone(...) | Fst | main.rs:922:5:923:14 | S2 |
+| main.rs:959:35:959:56 | ...::PairNone(...) | Snd | main.rs:925:5:926:14 | S3 |
+| main.rs:960:18:960:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:960:26:960:27 | p3 |  | main.rs:900:5:906:5 | PairOption |
+| main.rs:960:26:960:27 | p3 | Fst | main.rs:922:5:923:14 | S2 |
+| main.rs:960:26:960:27 | p3 | Snd | main.rs:925:5:926:14 | S3 |
+| main.rs:962:11:962:54 | ...::PairSnd(...) |  | main.rs:900:5:906:5 | PairOption |
+| main.rs:962:11:962:54 | ...::PairSnd(...) | Fst | main.rs:922:5:923:14 | S2 |
+| main.rs:962:11:962:54 | ...::PairSnd(...) | Snd | main.rs:900:5:906:5 | PairOption |
+| main.rs:962:11:962:54 | ...::PairSnd(...) | Snd.Fst | main.rs:922:5:923:14 | S2 |
+| main.rs:962:11:962:54 | ...::PairSnd(...) | Snd.Snd | main.rs:925:5:926:14 | S3 |
+| main.rs:962:31:962:53 | ...::PairSnd(...) |  | main.rs:900:5:906:5 | PairOption |
+| main.rs:962:31:962:53 | ...::PairSnd(...) | Fst | main.rs:922:5:923:14 | S2 |
+| main.rs:962:31:962:53 | ...::PairSnd(...) | Snd | main.rs:925:5:926:14 | S3 |
+| main.rs:962:51:962:52 | S3 |  | main.rs:925:5:926:14 | S3 |
+| main.rs:975:16:975:24 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:975:16:975:24 | SelfParam | &T | main.rs:973:5:980:5 | Self [trait MyTrait] |
+| main.rs:975:27:975:31 | value |  | main.rs:973:19:973:19 | S |
+| main.rs:977:21:977:29 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:977:21:977:29 | SelfParam | &T | main.rs:973:5:980:5 | Self [trait MyTrait] |
+| main.rs:977:32:977:36 | value |  | main.rs:973:19:973:19 | S |
+| main.rs:978:13:978:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:978:13:978:16 | self | &T | main.rs:973:5:980:5 | Self [trait MyTrait] |
+| main.rs:978:22:978:26 | value |  | main.rs:973:19:973:19 | S |
+| main.rs:984:16:984:24 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:984:16:984:24 | SelfParam | &T | main.rs:967:5:971:5 | MyOption |
+| main.rs:984:16:984:24 | SelfParam | &T.T | main.rs:982:10:982:10 | T |
+| main.rs:984:27:984:31 | value |  | main.rs:982:10:982:10 | T |
+| main.rs:988:26:990:9 | { ... } |  | main.rs:967:5:971:5 | MyOption |
+| main.rs:988:26:990:9 | { ... } | T | main.rs:987:10:987:10 | T |
+| main.rs:989:13:989:30 | ...::MyNone(...) |  | main.rs:967:5:971:5 | MyOption |
+| main.rs:989:13:989:30 | ...::MyNone(...) | T | main.rs:987:10:987:10 | T |
+| main.rs:994:20:994:23 | SelfParam |  | main.rs:967:5:971:5 | MyOption |
+| main.rs:994:20:994:23 | SelfParam | T | main.rs:967:5:971:5 | MyOption |
+| main.rs:994:20:994:23 | SelfParam | T.T | main.rs:993:10:993:10 | T |
+| main.rs:994:41:999:9 | { ... } |  | main.rs:967:5:971:5 | MyOption |
+| main.rs:994:41:999:9 | { ... } | T | main.rs:993:10:993:10 | T |
+| main.rs:995:13:998:13 | match self { ... } |  | main.rs:967:5:971:5 | MyOption |
+| main.rs:995:13:998:13 | match self { ... } | T | main.rs:993:10:993:10 | T |
+| main.rs:995:19:995:22 | self |  | main.rs:967:5:971:5 | MyOption |
+| main.rs:995:19:995:22 | self | T | main.rs:967:5:971:5 | MyOption |
+| main.rs:995:19:995:22 | self | T.T | main.rs:993:10:993:10 | T |
+| main.rs:996:39:996:56 | ...::MyNone(...) |  | main.rs:967:5:971:5 | MyOption |
+| main.rs:996:39:996:56 | ...::MyNone(...) | T | main.rs:993:10:993:10 | T |
+| main.rs:997:34:997:34 | x |  | main.rs:967:5:971:5 | MyOption |
+| main.rs:997:34:997:34 | x | T | main.rs:993:10:993:10 | T |
+| main.rs:997:40:997:40 | x |  | main.rs:967:5:971:5 | MyOption |
+| main.rs:997:40:997:40 | x | T | main.rs:993:10:993:10 | T |
+| main.rs:1006:13:1006:14 | x1 |  | main.rs:967:5:971:5 | MyOption |
+| main.rs:1006:18:1006:37 | ...::new(...) |  | main.rs:967:5:971:5 | MyOption |
+| main.rs:1007:18:1007:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:1007:26:1007:27 | x1 |  | main.rs:967:5:971:5 | MyOption |
+| main.rs:1009:13:1009:18 | mut x2 |  | main.rs:967:5:971:5 | MyOption |
+| main.rs:1009:13:1009:18 | mut x2 | T | main.rs:1002:5:1003:13 | S |
+| main.rs:1009:22:1009:36 | ...::new(...) |  | main.rs:967:5:971:5 | MyOption |
+| main.rs:1009:22:1009:36 | ...::new(...) | T | main.rs:1002:5:1003:13 | S |
+| main.rs:1010:9:1010:10 | x2 |  | main.rs:967:5:971:5 | MyOption |
+| main.rs:1010:9:1010:10 | x2 | T | main.rs:1002:5:1003:13 | S |
+| main.rs:1010:16:1010:16 | S |  | main.rs:1002:5:1003:13 | S |
+| main.rs:1011:18:1011:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:1011:26:1011:27 | x2 |  | main.rs:967:5:971:5 | MyOption |
+| main.rs:1011:26:1011:27 | x2 | T | main.rs:1002:5:1003:13 | S |
+| main.rs:1013:13:1013:18 | mut x3 |  | main.rs:967:5:971:5 | MyOption |
+| main.rs:1013:22:1013:36 | ...::new(...) |  | main.rs:967:5:971:5 | MyOption |
+| main.rs:1014:9:1014:10 | x3 |  | main.rs:967:5:971:5 | MyOption |
+| main.rs:1014:21:1014:21 | S |  | main.rs:1002:5:1003:13 | S |
+| main.rs:1015:18:1015:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:1015:26:1015:27 | x3 |  | main.rs:967:5:971:5 | MyOption |
+| main.rs:1017:13:1017:18 | mut x4 |  | main.rs:967:5:971:5 | MyOption |
+| main.rs:1017:13:1017:18 | mut x4 | T | main.rs:1002:5:1003:13 | S |
+| main.rs:1017:22:1017:36 | ...::new(...) |  | main.rs:967:5:971:5 | MyOption |
+| main.rs:1017:22:1017:36 | ...::new(...) | T | main.rs:1002:5:1003:13 | S |
+| main.rs:1018:23:1018:29 | &mut x4 |  | file://:0:0:0:0 | & |
+| main.rs:1018:23:1018:29 | &mut x4 | &T | main.rs:967:5:971:5 | MyOption |
+| main.rs:1018:23:1018:29 | &mut x4 | &T.T | main.rs:1002:5:1003:13 | S |
+| main.rs:1018:28:1018:29 | x4 |  | main.rs:967:5:971:5 | MyOption |
+| main.rs:1018:28:1018:29 | x4 | T | main.rs:1002:5:1003:13 | S |
+| main.rs:1018:32:1018:32 | S |  | main.rs:1002:5:1003:13 | S |
+| main.rs:1019:18:1019:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:1019:26:1019:27 | x4 |  | main.rs:967:5:971:5 | MyOption |
+| main.rs:1019:26:1019:27 | x4 | T | main.rs:1002:5:1003:13 | S |
+| main.rs:1021:13:1021:14 | x5 |  | main.rs:967:5:971:5 | MyOption |
+| main.rs:1021:13:1021:14 | x5 | T | main.rs:967:5:971:5 | MyOption |
+| main.rs:1021:13:1021:14 | x5 | T.T | main.rs:1002:5:1003:13 | S |
+| main.rs:1021:18:1021:58 | ...::MySome(...) |  | main.rs:967:5:971:5 | MyOption |
+| main.rs:1021:18:1021:58 | ...::MySome(...) | T | main.rs:967:5:971:5 | MyOption |
+| main.rs:1021:18:1021:58 | ...::MySome(...) | T.T | main.rs:1002:5:1003:13 | S |
+| main.rs:1021:35:1021:57 | ...::MyNone(...) |  | main.rs:967:5:971:5 | MyOption |
+| main.rs:1021:35:1021:57 | ...::MyNone(...) | T | main.rs:1002:5:1003:13 | S |
+| main.rs:1022:18:1022:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:1022:26:1022:27 | x5 |  | main.rs:967:5:971:5 | MyOption |
+| main.rs:1022:26:1022:27 | x5 | T | main.rs:967:5:971:5 | MyOption |
+| main.rs:1022:26:1022:27 | x5 | T.T | main.rs:1002:5:1003:13 | S |
+| main.rs:1022:26:1022:37 | x5.flatten() |  | main.rs:967:5:971:5 | MyOption |
+| main.rs:1022:26:1022:37 | x5.flatten() | T | main.rs:1002:5:1003:13 | S |
+| main.rs:1024:13:1024:14 | x6 |  | main.rs:967:5:971:5 | MyOption |
+| main.rs:1024:13:1024:14 | x6 | T | main.rs:967:5:971:5 | MyOption |
+| main.rs:1024:13:1024:14 | x6 | T.T | main.rs:1002:5:1003:13 | S |
+| main.rs:1024:18:1024:58 | ...::MySome(...) |  | main.rs:967:5:971:5 | MyOption |
+| main.rs:1024:18:1024:58 | ...::MySome(...) | T | main.rs:967:5:971:5 | MyOption |
+| main.rs:1024:18:1024:58 | ...::MySome(...) | T.T | main.rs:1002:5:1003:13 | S |
+| main.rs:1024:35:1024:57 | ...::MyNone(...) |  | main.rs:967:5:971:5 | MyOption |
+| main.rs:1024:35:1024:57 | ...::MyNone(...) | T | main.rs:1002:5:1003:13 | S |
+| main.rs:1025:18:1025:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:1025:26:1025:61 | ...::flatten(...) |  | main.rs:967:5:971:5 | MyOption |
+| main.rs:1025:26:1025:61 | ...::flatten(...) | T | main.rs:1002:5:1003:13 | S |
+| main.rs:1025:59:1025:60 | x6 |  | main.rs:967:5:971:5 | MyOption |
+| main.rs:1025:59:1025:60 | x6 | T | main.rs:967:5:971:5 | MyOption |
+| main.rs:1025:59:1025:60 | x6 | T.T | main.rs:1002:5:1003:13 | S |
+| main.rs:1027:13:1027:19 | from_if |  | main.rs:967:5:971:5 | MyOption |
+| main.rs:1027:13:1027:19 | from_if | T | main.rs:1002:5:1003:13 | S |
+| main.rs:1027:23:1031:9 | if ... {...} else {...} |  | main.rs:967:5:971:5 | MyOption |
+| main.rs:1027:23:1031:9 | if ... {...} else {...} | T | main.rs:1002:5:1003:13 | S |
+| main.rs:1027:26:1027:26 | 1 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1027:30:1027:30 | 1 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1027:34:1027:34 | 2 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1027:36:1029:9 | { ... } |  | main.rs:967:5:971:5 | MyOption |
+| main.rs:1027:36:1029:9 | { ... } | T | main.rs:1002:5:1003:13 | S |
+| main.rs:1028:13:1028:30 | ...::MyNone(...) |  | main.rs:967:5:971:5 | MyOption |
+| main.rs:1028:13:1028:30 | ...::MyNone(...) | T | main.rs:1002:5:1003:13 | S |
+| main.rs:1029:16:1031:9 | { ... } |  | main.rs:967:5:971:5 | MyOption |
+| main.rs:1029:16:1031:9 | { ... } | T | main.rs:1002:5:1003:13 | S |
+| main.rs:1030:13:1030:31 | ...::MySome(...) |  | main.rs:967:5:971:5 | MyOption |
+| main.rs:1030:13:1030:31 | ...::MySome(...) | T | main.rs:1002:5:1003:13 | S |
+| main.rs:1030:30:1030:30 | S |  | main.rs:1002:5:1003:13 | S |
+| main.rs:1032:18:1032:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:1032:26:1032:32 | from_if |  | main.rs:967:5:971:5 | MyOption |
+| main.rs:1032:26:1032:32 | from_if | T | main.rs:1002:5:1003:13 | S |
+| main.rs:1034:13:1034:22 | from_match |  | main.rs:967:5:971:5 | MyOption |
+| main.rs:1034:13:1034:22 | from_match | T | main.rs:1002:5:1003:13 | S |
+| main.rs:1034:26:1037:9 | match ... { ... } |  | main.rs:967:5:971:5 | MyOption |
+| main.rs:1034:26:1037:9 | match ... { ... } | T | main.rs:1002:5:1003:13 | S |
+| main.rs:1034:32:1034:32 | 1 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1034:36:1034:36 | 1 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1034:40:1034:40 | 2 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1035:13:1035:16 | true |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1035:21:1035:38 | ...::MyNone(...) |  | main.rs:967:5:971:5 | MyOption |
+| main.rs:1035:21:1035:38 | ...::MyNone(...) | T | main.rs:1002:5:1003:13 | S |
+| main.rs:1036:13:1036:17 | false |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1036:22:1036:40 | ...::MySome(...) |  | main.rs:967:5:971:5 | MyOption |
+| main.rs:1036:22:1036:40 | ...::MySome(...) | T | main.rs:1002:5:1003:13 | S |
+| main.rs:1036:39:1036:39 | S |  | main.rs:1002:5:1003:13 | S |
+| main.rs:1038:18:1038:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:1038:26:1038:35 | from_match |  | main.rs:967:5:971:5 | MyOption |
+| main.rs:1038:26:1038:35 | from_match | T | main.rs:1002:5:1003:13 | S |
+| main.rs:1040:13:1040:21 | from_loop |  | main.rs:967:5:971:5 | MyOption |
+| main.rs:1040:13:1040:21 | from_loop | T | main.rs:1002:5:1003:13 | S |
+| main.rs:1040:25:1045:9 | loop { ... } |  | main.rs:967:5:971:5 | MyOption |
+| main.rs:1040:25:1045:9 | loop { ... } | T | main.rs:1002:5:1003:13 | S |
+| main.rs:1041:16:1041:16 | 1 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1041:20:1041:20 | 1 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1041:24:1041:24 | 2 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1042:23:1042:40 | ...::MyNone(...) |  | main.rs:967:5:971:5 | MyOption |
+| main.rs:1042:23:1042:40 | ...::MyNone(...) | T | main.rs:1002:5:1003:13 | S |
+| main.rs:1044:19:1044:37 | ...::MySome(...) |  | main.rs:967:5:971:5 | MyOption |
+| main.rs:1044:19:1044:37 | ...::MySome(...) | T | main.rs:1002:5:1003:13 | S |
+| main.rs:1044:36:1044:36 | S |  | main.rs:1002:5:1003:13 | S |
+| main.rs:1046:18:1046:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:1046:26:1046:34 | from_loop |  | main.rs:967:5:971:5 | MyOption |
+| main.rs:1046:26:1046:34 | from_loop | T | main.rs:1002:5:1003:13 | S |
+| main.rs:1059:15:1059:18 | SelfParam |  | main.rs:1052:5:1053:19 | S |
+| main.rs:1059:15:1059:18 | SelfParam | T | main.rs:1058:10:1058:10 | T |
+| main.rs:1059:26:1061:9 | { ... } |  | main.rs:1058:10:1058:10 | T |
+| main.rs:1060:13:1060:16 | self |  | main.rs:1052:5:1053:19 | S |
+| main.rs:1060:13:1060:16 | self | T | main.rs:1058:10:1058:10 | T |
+| main.rs:1060:13:1060:18 | self.0 |  | main.rs:1058:10:1058:10 | T |
+| main.rs:1063:15:1063:19 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1063:15:1063:19 | SelfParam | &T | main.rs:1052:5:1053:19 | S |
+| main.rs:1063:15:1063:19 | SelfParam | &T.T | main.rs:1058:10:1058:10 | T |
+| main.rs:1063:28:1065:9 | { ... } |  | file://:0:0:0:0 | & |
+| main.rs:1063:28:1065:9 | { ... } | &T | main.rs:1058:10:1058:10 | T |
+| main.rs:1064:13:1064:19 | &... |  | file://:0:0:0:0 | & |
+| main.rs:1064:13:1064:19 | &... | &T | main.rs:1058:10:1058:10 | T |
+| main.rs:1064:14:1064:17 | self |  | file://:0:0:0:0 | & |
+| main.rs:1064:14:1064:17 | self | &T | main.rs:1052:5:1053:19 | S |
+| main.rs:1064:14:1064:17 | self | &T.T | main.rs:1058:10:1058:10 | T |
+| main.rs:1064:14:1064:19 | self.0 |  | main.rs:1058:10:1058:10 | T |
+| main.rs:1067:15:1067:25 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1067:15:1067:25 | SelfParam | &T | main.rs:1052:5:1053:19 | S |
+| main.rs:1067:15:1067:25 | SelfParam | &T.T | main.rs:1058:10:1058:10 | T |
+| main.rs:1067:34:1069:9 | { ... } |  | file://:0:0:0:0 | & |
+| main.rs:1067:34:1069:9 | { ... } | &T | main.rs:1058:10:1058:10 | T |
+| main.rs:1068:13:1068:19 | &... |  | file://:0:0:0:0 | & |
+| main.rs:1068:13:1068:19 | &... | &T | main.rs:1058:10:1058:10 | T |
+| main.rs:1068:14:1068:17 | self |  | file://:0:0:0:0 | & |
+| main.rs:1068:14:1068:17 | self | &T | main.rs:1052:5:1053:19 | S |
+| main.rs:1068:14:1068:17 | self | &T.T | main.rs:1058:10:1058:10 | T |
+| main.rs:1068:14:1068:19 | self.0 |  | main.rs:1058:10:1058:10 | T |
+| main.rs:1073:13:1073:14 | x1 |  | main.rs:1052:5:1053:19 | S |
+| main.rs:1073:13:1073:14 | x1 | T | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1073:18:1073:22 | S(...) |  | main.rs:1052:5:1053:19 | S |
+| main.rs:1073:18:1073:22 | S(...) | T | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1073:20:1073:21 | S2 |  | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1074:18:1074:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:1074:26:1074:27 | x1 |  | main.rs:1052:5:1053:19 | S |
+| main.rs:1074:26:1074:27 | x1 | T | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1074:26:1074:32 | x1.m1() |  | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1076:13:1076:14 | x2 |  | main.rs:1052:5:1053:19 | S |
+| main.rs:1076:13:1076:14 | x2 | T | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1076:18:1076:22 | S(...) |  | main.rs:1052:5:1053:19 | S |
+| main.rs:1076:18:1076:22 | S(...) | T | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1076:20:1076:21 | S2 |  | main.rs:1055:5:1056:14 | S2 |
 | main.rs:1078:18:1078:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:1078:26:1078:27 | x7 |  | main.rs:1026:5:1027:19 | S |
-| main.rs:1078:26:1078:27 | x7 | T | file://:0:0:0:0 | & |
-| main.rs:1078:26:1078:27 | x7 | T.&T | main.rs:1029:5:1030:14 | S2 |
-| main.rs:1085:16:1085:20 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:1085:16:1085:20 | SelfParam | &T | main.rs:1083:5:1091:5 | Self [trait MyTrait] |
-| main.rs:1088:16:1088:20 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:1088:16:1088:20 | SelfParam | &T | main.rs:1083:5:1091:5 | Self [trait MyTrait] |
-| main.rs:1088:32:1090:9 | { ... } |  | file://:0:0:0:0 | & |
-| main.rs:1088:32:1090:9 | { ... } | &T | main.rs:1083:5:1091:5 | Self [trait MyTrait] |
-| main.rs:1089:13:1089:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:1089:13:1089:16 | self | &T | main.rs:1083:5:1091:5 | Self [trait MyTrait] |
-| main.rs:1089:13:1089:22 | self.foo() |  | file://:0:0:0:0 | & |
-| main.rs:1089:13:1089:22 | self.foo() | &T | main.rs:1083:5:1091:5 | Self [trait MyTrait] |
-| main.rs:1097:16:1097:20 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:1097:16:1097:20 | SelfParam | &T | main.rs:1093:5:1093:20 | MyStruct |
-| main.rs:1097:36:1099:9 | { ... } |  | file://:0:0:0:0 | & |
-| main.rs:1097:36:1099:9 | { ... } | &T | main.rs:1093:5:1093:20 | MyStruct |
-| main.rs:1098:13:1098:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:1098:13:1098:16 | self | &T | main.rs:1093:5:1093:20 | MyStruct |
-| main.rs:1103:13:1103:13 | x |  | main.rs:1093:5:1093:20 | MyStruct |
-| main.rs:1103:17:1103:24 | MyStruct |  | main.rs:1093:5:1093:20 | MyStruct |
-| main.rs:1104:9:1104:9 | x |  | main.rs:1093:5:1093:20 | MyStruct |
-| main.rs:1104:9:1104:15 | x.bar() |  | file://:0:0:0:0 | & |
-| main.rs:1104:9:1104:15 | x.bar() | &T | main.rs:1093:5:1093:20 | MyStruct |
+| main.rs:1078:26:1078:27 | x2 |  | main.rs:1052:5:1053:19 | S |
+| main.rs:1078:26:1078:27 | x2 | T | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1078:26:1078:32 | x2.m2() |  | file://:0:0:0:0 | & |
+| main.rs:1078:26:1078:32 | x2.m2() | &T | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1079:18:1079:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:1079:26:1079:27 | x2 |  | main.rs:1052:5:1053:19 | S |
+| main.rs:1079:26:1079:27 | x2 | T | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1079:26:1079:32 | x2.m3() |  | file://:0:0:0:0 | & |
+| main.rs:1079:26:1079:32 | x2.m3() | &T | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1081:13:1081:14 | x3 |  | main.rs:1052:5:1053:19 | S |
+| main.rs:1081:13:1081:14 | x3 | T | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1081:18:1081:22 | S(...) |  | main.rs:1052:5:1053:19 | S |
+| main.rs:1081:18:1081:22 | S(...) | T | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1081:20:1081:21 | S2 |  | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1083:18:1083:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:1083:26:1083:41 | ...::m2(...) |  | file://:0:0:0:0 | & |
+| main.rs:1083:26:1083:41 | ...::m2(...) | &T | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1083:38:1083:40 | &x3 |  | file://:0:0:0:0 | & |
+| main.rs:1083:38:1083:40 | &x3 | &T | main.rs:1052:5:1053:19 | S |
+| main.rs:1083:38:1083:40 | &x3 | &T.T | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1083:39:1083:40 | x3 |  | main.rs:1052:5:1053:19 | S |
+| main.rs:1083:39:1083:40 | x3 | T | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1084:18:1084:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:1084:26:1084:41 | ...::m3(...) |  | file://:0:0:0:0 | & |
+| main.rs:1084:26:1084:41 | ...::m3(...) | &T | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1084:38:1084:40 | &x3 |  | file://:0:0:0:0 | & |
+| main.rs:1084:38:1084:40 | &x3 | &T | main.rs:1052:5:1053:19 | S |
+| main.rs:1084:38:1084:40 | &x3 | &T.T | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1084:39:1084:40 | x3 |  | main.rs:1052:5:1053:19 | S |
+| main.rs:1084:39:1084:40 | x3 | T | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1086:13:1086:14 | x4 |  | file://:0:0:0:0 | & |
+| main.rs:1086:13:1086:14 | x4 | &T | main.rs:1052:5:1053:19 | S |
+| main.rs:1086:13:1086:14 | x4 | &T.T | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1086:18:1086:23 | &... |  | file://:0:0:0:0 | & |
+| main.rs:1086:18:1086:23 | &... | &T | main.rs:1052:5:1053:19 | S |
+| main.rs:1086:18:1086:23 | &... | &T.T | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1086:19:1086:23 | S(...) |  | main.rs:1052:5:1053:19 | S |
+| main.rs:1086:19:1086:23 | S(...) | T | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1086:21:1086:22 | S2 |  | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1088:18:1088:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:1088:26:1088:27 | x4 |  | file://:0:0:0:0 | & |
+| main.rs:1088:26:1088:27 | x4 | &T | main.rs:1052:5:1053:19 | S |
+| main.rs:1088:26:1088:27 | x4 | &T.T | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1088:26:1088:32 | x4.m2() |  | file://:0:0:0:0 | & |
+| main.rs:1088:26:1088:32 | x4.m2() | &T | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1089:18:1089:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:1089:26:1089:27 | x4 |  | file://:0:0:0:0 | & |
+| main.rs:1089:26:1089:27 | x4 | &T | main.rs:1052:5:1053:19 | S |
+| main.rs:1089:26:1089:27 | x4 | &T.T | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1089:26:1089:32 | x4.m3() |  | file://:0:0:0:0 | & |
+| main.rs:1089:26:1089:32 | x4.m3() | &T | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1091:13:1091:14 | x5 |  | file://:0:0:0:0 | & |
+| main.rs:1091:13:1091:14 | x5 | &T | main.rs:1052:5:1053:19 | S |
+| main.rs:1091:13:1091:14 | x5 | &T.T | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1091:18:1091:23 | &... |  | file://:0:0:0:0 | & |
+| main.rs:1091:18:1091:23 | &... | &T | main.rs:1052:5:1053:19 | S |
+| main.rs:1091:18:1091:23 | &... | &T.T | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1091:19:1091:23 | S(...) |  | main.rs:1052:5:1053:19 | S |
+| main.rs:1091:19:1091:23 | S(...) | T | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1091:21:1091:22 | S2 |  | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1093:18:1093:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:1093:26:1093:27 | x5 |  | file://:0:0:0:0 | & |
+| main.rs:1093:26:1093:27 | x5 | &T | main.rs:1052:5:1053:19 | S |
+| main.rs:1093:26:1093:27 | x5 | &T.T | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1093:26:1093:32 | x5.m1() |  | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1094:18:1094:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:1094:26:1094:27 | x5 |  | file://:0:0:0:0 | & |
+| main.rs:1094:26:1094:27 | x5 | &T | main.rs:1052:5:1053:19 | S |
+| main.rs:1094:26:1094:27 | x5 | &T.T | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1094:26:1094:29 | x5.0 |  | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1096:13:1096:14 | x6 |  | file://:0:0:0:0 | & |
+| main.rs:1096:13:1096:14 | x6 | &T | main.rs:1052:5:1053:19 | S |
+| main.rs:1096:13:1096:14 | x6 | &T.T | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1096:18:1096:23 | &... |  | file://:0:0:0:0 | & |
+| main.rs:1096:18:1096:23 | &... | &T | main.rs:1052:5:1053:19 | S |
+| main.rs:1096:18:1096:23 | &... | &T.T | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1096:19:1096:23 | S(...) |  | main.rs:1052:5:1053:19 | S |
+| main.rs:1096:19:1096:23 | S(...) | T | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1096:21:1096:22 | S2 |  | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1098:18:1098:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:1098:26:1098:30 | (...) |  | main.rs:1052:5:1053:19 | S |
+| main.rs:1098:26:1098:30 | (...) | T | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1098:26:1098:35 | ... .m1() |  | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1098:27:1098:29 | * ... |  | main.rs:1052:5:1053:19 | S |
+| main.rs:1098:27:1098:29 | * ... | T | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1098:28:1098:29 | x6 |  | file://:0:0:0:0 | & |
+| main.rs:1098:28:1098:29 | x6 | &T | main.rs:1052:5:1053:19 | S |
+| main.rs:1098:28:1098:29 | x6 | &T.T | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1100:13:1100:14 | x7 |  | main.rs:1052:5:1053:19 | S |
+| main.rs:1100:13:1100:14 | x7 | T | file://:0:0:0:0 | & |
+| main.rs:1100:13:1100:14 | x7 | T.&T | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1100:18:1100:23 | S(...) |  | main.rs:1052:5:1053:19 | S |
+| main.rs:1100:18:1100:23 | S(...) | T | file://:0:0:0:0 | & |
+| main.rs:1100:18:1100:23 | S(...) | T.&T | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1100:20:1100:22 | &S2 |  | file://:0:0:0:0 | & |
+| main.rs:1100:20:1100:22 | &S2 | &T | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1100:21:1100:22 | S2 |  | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1103:13:1103:13 | t |  | file://:0:0:0:0 | & |
+| main.rs:1103:13:1103:13 | t | &T | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1103:17:1103:18 | x7 |  | main.rs:1052:5:1053:19 | S |
+| main.rs:1103:17:1103:18 | x7 | T | file://:0:0:0:0 | & |
+| main.rs:1103:17:1103:18 | x7 | T.&T | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1103:17:1103:23 | x7.m1() |  | file://:0:0:0:0 | & |
+| main.rs:1103:17:1103:23 | x7.m1() | &T | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1104:18:1104:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:1104:26:1104:27 | x7 |  | main.rs:1052:5:1053:19 | S |
+| main.rs:1104:26:1104:27 | x7 | T | file://:0:0:0:0 | & |
+| main.rs:1104:26:1104:27 | x7 | T.&T | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1111:16:1111:20 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1111:16:1111:20 | SelfParam | &T | main.rs:1109:5:1117:5 | Self [trait MyTrait] |
 | main.rs:1114:16:1114:20 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:1114:16:1114:20 | SelfParam | &T | main.rs:1111:5:1111:26 | MyStruct |
-| main.rs:1114:16:1114:20 | SelfParam | &T.T | main.rs:1113:10:1113:10 | T |
+| main.rs:1114:16:1114:20 | SelfParam | &T | main.rs:1109:5:1117:5 | Self [trait MyTrait] |
 | main.rs:1114:32:1116:9 | { ... } |  | file://:0:0:0:0 | & |
-| main.rs:1114:32:1116:9 | { ... } | &T | main.rs:1111:5:1111:26 | MyStruct |
-| main.rs:1114:32:1116:9 | { ... } | &T.T | main.rs:1113:10:1113:10 | T |
+| main.rs:1114:32:1116:9 | { ... } | &T | main.rs:1109:5:1117:5 | Self [trait MyTrait] |
 | main.rs:1115:13:1115:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:1115:13:1115:16 | self | &T | main.rs:1111:5:1111:26 | MyStruct |
-| main.rs:1115:13:1115:16 | self | &T.T | main.rs:1113:10:1113:10 | T |
-| main.rs:1120:13:1120:13 | x |  | main.rs:1111:5:1111:26 | MyStruct |
-| main.rs:1120:13:1120:13 | x | T | main.rs:1109:5:1109:13 | S |
-| main.rs:1120:17:1120:27 | MyStruct(...) |  | main.rs:1111:5:1111:26 | MyStruct |
-| main.rs:1120:17:1120:27 | MyStruct(...) | T | main.rs:1109:5:1109:13 | S |
-| main.rs:1120:26:1120:26 | S |  | main.rs:1109:5:1109:13 | S |
-| main.rs:1121:9:1121:9 | x |  | main.rs:1111:5:1111:26 | MyStruct |
-| main.rs:1121:9:1121:9 | x | T | main.rs:1109:5:1109:13 | S |
-| main.rs:1121:9:1121:15 | x.foo() |  | file://:0:0:0:0 | & |
-| main.rs:1121:9:1121:15 | x.foo() | &T | main.rs:1111:5:1111:26 | MyStruct |
-| main.rs:1121:9:1121:15 | x.foo() | &T.T | main.rs:1109:5:1109:13 | S |
-| main.rs:1129:15:1129:19 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:1129:15:1129:19 | SelfParam | &T | main.rs:1126:5:1126:13 | S |
-| main.rs:1129:31:1131:9 | { ... } |  | file://:0:0:0:0 | & |
-| main.rs:1129:31:1131:9 | { ... } | &T | main.rs:1126:5:1126:13 | S |
-| main.rs:1130:13:1130:19 | &... |  | file://:0:0:0:0 | & |
-| main.rs:1130:13:1130:19 | &... | &T | main.rs:1126:5:1126:13 | S |
-| main.rs:1130:14:1130:19 | &... |  | file://:0:0:0:0 | & |
-| main.rs:1130:14:1130:19 | &... | &T | main.rs:1126:5:1126:13 | S |
-| main.rs:1130:15:1130:19 | &self |  | file://:0:0:0:0 | & |
-| main.rs:1130:15:1130:19 | &self | &T | main.rs:1126:5:1126:13 | S |
-| main.rs:1130:16:1130:19 | self |  | file://:0:0:0:0 | & |
-| main.rs:1130:16:1130:19 | self | &T | main.rs:1126:5:1126:13 | S |
-| main.rs:1133:15:1133:25 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:1133:15:1133:25 | SelfParam | &T | main.rs:1126:5:1126:13 | S |
-| main.rs:1133:37:1135:9 | { ... } |  | file://:0:0:0:0 | & |
-| main.rs:1133:37:1135:9 | { ... } | &T | main.rs:1126:5:1126:13 | S |
-| main.rs:1134:13:1134:19 | &... |  | file://:0:0:0:0 | & |
-| main.rs:1134:13:1134:19 | &... | &T | main.rs:1126:5:1126:13 | S |
-| main.rs:1134:14:1134:19 | &... |  | file://:0:0:0:0 | & |
-| main.rs:1134:14:1134:19 | &... | &T | main.rs:1126:5:1126:13 | S |
-| main.rs:1134:15:1134:19 | &self |  | file://:0:0:0:0 | & |
-| main.rs:1134:15:1134:19 | &self | &T | main.rs:1126:5:1126:13 | S |
-| main.rs:1134:16:1134:19 | self |  | file://:0:0:0:0 | & |
-| main.rs:1134:16:1134:19 | self | &T | main.rs:1126:5:1126:13 | S |
-| main.rs:1137:15:1137:15 | x |  | file://:0:0:0:0 | & |
-| main.rs:1137:15:1137:15 | x | &T | main.rs:1126:5:1126:13 | S |
-| main.rs:1137:34:1139:9 | { ... } |  | file://:0:0:0:0 | & |
-| main.rs:1137:34:1139:9 | { ... } | &T | main.rs:1126:5:1126:13 | S |
-| main.rs:1138:13:1138:13 | x |  | file://:0:0:0:0 | & |
-| main.rs:1138:13:1138:13 | x | &T | main.rs:1126:5:1126:13 | S |
-| main.rs:1141:15:1141:15 | x |  | file://:0:0:0:0 | & |
-| main.rs:1141:15:1141:15 | x | &T | main.rs:1126:5:1126:13 | S |
-| main.rs:1141:34:1143:9 | { ... } |  | file://:0:0:0:0 | & |
-| main.rs:1141:34:1143:9 | { ... } | &T | main.rs:1126:5:1126:13 | S |
-| main.rs:1142:13:1142:16 | &... |  | file://:0:0:0:0 | & |
-| main.rs:1142:13:1142:16 | &... | &T | main.rs:1126:5:1126:13 | S |
-| main.rs:1142:14:1142:16 | &... |  | file://:0:0:0:0 | & |
-| main.rs:1142:14:1142:16 | &... | &T | main.rs:1126:5:1126:13 | S |
-| main.rs:1142:15:1142:16 | &x |  | file://:0:0:0:0 | & |
-| main.rs:1142:15:1142:16 | &x | &T | main.rs:1126:5:1126:13 | S |
-| main.rs:1142:16:1142:16 | x |  | file://:0:0:0:0 | & |
-| main.rs:1142:16:1142:16 | x | &T | main.rs:1126:5:1126:13 | S |
-| main.rs:1147:13:1147:13 | x |  | main.rs:1126:5:1126:13 | S |
-| main.rs:1147:17:1147:20 | S {...} |  | main.rs:1126:5:1126:13 | S |
-| main.rs:1148:9:1148:9 | x |  | main.rs:1126:5:1126:13 | S |
-| main.rs:1148:9:1148:14 | x.f1() |  | file://:0:0:0:0 | & |
-| main.rs:1148:9:1148:14 | x.f1() | &T | main.rs:1126:5:1126:13 | S |
-| main.rs:1149:9:1149:9 | x |  | main.rs:1126:5:1126:13 | S |
-| main.rs:1149:9:1149:14 | x.f2() |  | file://:0:0:0:0 | & |
-| main.rs:1149:9:1149:14 | x.f2() | &T | main.rs:1126:5:1126:13 | S |
-| main.rs:1150:9:1150:17 | ...::f3(...) |  | file://:0:0:0:0 | & |
-| main.rs:1150:9:1150:17 | ...::f3(...) | &T | main.rs:1126:5:1126:13 | S |
-| main.rs:1150:15:1150:16 | &x |  | file://:0:0:0:0 | & |
-| main.rs:1150:15:1150:16 | &x | &T | main.rs:1126:5:1126:13 | S |
-| main.rs:1150:16:1150:16 | x |  | main.rs:1126:5:1126:13 | S |
-| main.rs:1164:43:1167:5 | { ... } |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1164:43:1167:5 | { ... } | E | main.rs:1157:5:1158:14 | S1 |
-| main.rs:1164:43:1167:5 | { ... } | T | main.rs:1157:5:1158:14 | S1 |
-| main.rs:1165:13:1165:13 | x |  | main.rs:1157:5:1158:14 | S1 |
-| main.rs:1165:17:1165:30 | ...::Ok(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1165:17:1165:30 | ...::Ok(...) | T | main.rs:1157:5:1158:14 | S1 |
-| main.rs:1165:17:1165:31 | TryExpr |  | main.rs:1157:5:1158:14 | S1 |
-| main.rs:1165:28:1165:29 | S1 |  | main.rs:1157:5:1158:14 | S1 |
-| main.rs:1166:9:1166:22 | ...::Ok(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1166:9:1166:22 | ...::Ok(...) | E | main.rs:1157:5:1158:14 | S1 |
-| main.rs:1166:9:1166:22 | ...::Ok(...) | T | main.rs:1157:5:1158:14 | S1 |
-| main.rs:1166:20:1166:21 | S1 |  | main.rs:1157:5:1158:14 | S1 |
-| main.rs:1170:46:1174:5 | { ... } |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1170:46:1174:5 | { ... } | E | main.rs:1160:5:1161:14 | S2 |
-| main.rs:1170:46:1174:5 | { ... } | T | main.rs:1157:5:1158:14 | S1 |
-| main.rs:1171:13:1171:13 | x |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1171:13:1171:13 | x | T | main.rs:1157:5:1158:14 | S1 |
-| main.rs:1171:17:1171:30 | ...::Ok(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1171:17:1171:30 | ...::Ok(...) | T | main.rs:1157:5:1158:14 | S1 |
-| main.rs:1171:28:1171:29 | S1 |  | main.rs:1157:5:1158:14 | S1 |
-| main.rs:1172:13:1172:13 | y |  | main.rs:1157:5:1158:14 | S1 |
-| main.rs:1172:17:1172:17 | x |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1172:17:1172:17 | x | T | main.rs:1157:5:1158:14 | S1 |
-| main.rs:1172:17:1172:18 | TryExpr |  | main.rs:1157:5:1158:14 | S1 |
-| main.rs:1173:9:1173:22 | ...::Ok(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1173:9:1173:22 | ...::Ok(...) | E | main.rs:1160:5:1161:14 | S2 |
-| main.rs:1173:9:1173:22 | ...::Ok(...) | T | main.rs:1157:5:1158:14 | S1 |
-| main.rs:1173:20:1173:21 | S1 |  | main.rs:1157:5:1158:14 | S1 |
-| main.rs:1177:40:1182:5 | { ... } |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1177:40:1182:5 | { ... } | E | main.rs:1160:5:1161:14 | S2 |
-| main.rs:1177:40:1182:5 | { ... } | T | main.rs:1157:5:1158:14 | S1 |
-| main.rs:1178:13:1178:13 | x |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1178:13:1178:13 | x | T | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1178:13:1178:13 | x | T.T | main.rs:1157:5:1158:14 | S1 |
-| main.rs:1178:17:1178:42 | ...::Ok(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1178:17:1178:42 | ...::Ok(...) | T | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1178:17:1178:42 | ...::Ok(...) | T.T | main.rs:1157:5:1158:14 | S1 |
-| main.rs:1178:28:1178:41 | ...::Ok(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1178:28:1178:41 | ...::Ok(...) | T | main.rs:1157:5:1158:14 | S1 |
-| main.rs:1178:39:1178:40 | S1 |  | main.rs:1157:5:1158:14 | S1 |
-| main.rs:1180:17:1180:17 | x |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1180:17:1180:17 | x | T | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1180:17:1180:17 | x | T.T | main.rs:1157:5:1158:14 | S1 |
-| main.rs:1180:17:1180:18 | TryExpr |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1180:17:1180:18 | TryExpr | T | main.rs:1157:5:1158:14 | S1 |
-| main.rs:1180:17:1180:29 | ... .map(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1181:9:1181:22 | ...::Ok(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1181:9:1181:22 | ...::Ok(...) | E | main.rs:1160:5:1161:14 | S2 |
-| main.rs:1181:9:1181:22 | ...::Ok(...) | T | main.rs:1157:5:1158:14 | S1 |
-| main.rs:1181:20:1181:21 | S1 |  | main.rs:1157:5:1158:14 | S1 |
-| main.rs:1185:30:1185:34 | input |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1185:30:1185:34 | input | E | main.rs:1157:5:1158:14 | S1 |
-| main.rs:1185:30:1185:34 | input | T | main.rs:1185:20:1185:27 | T |
-| main.rs:1185:69:1192:5 | { ... } |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1185:69:1192:5 | { ... } | E | main.rs:1157:5:1158:14 | S1 |
-| main.rs:1185:69:1192:5 | { ... } | T | main.rs:1185:20:1185:27 | T |
-| main.rs:1186:13:1186:17 | value |  | main.rs:1185:20:1185:27 | T |
-| main.rs:1186:21:1186:25 | input |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1186:21:1186:25 | input | E | main.rs:1157:5:1158:14 | S1 |
-| main.rs:1186:21:1186:25 | input | T | main.rs:1185:20:1185:27 | T |
-| main.rs:1186:21:1186:26 | TryExpr |  | main.rs:1185:20:1185:27 | T |
-| main.rs:1187:22:1187:38 | ...::Ok(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1187:22:1187:38 | ...::Ok(...) | T | main.rs:1185:20:1185:27 | T |
-| main.rs:1187:22:1190:10 | ... .and_then(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1187:33:1187:37 | value |  | main.rs:1185:20:1185:27 | T |
-| main.rs:1187:53:1190:9 | { ... } |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1187:53:1190:9 | { ... } | E | main.rs:1157:5:1158:14 | S1 |
-| main.rs:1188:22:1188:27 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:1189:13:1189:34 | ...::Ok::<...>(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1189:13:1189:34 | ...::Ok::<...>(...) | E | main.rs:1157:5:1158:14 | S1 |
-| main.rs:1191:9:1191:23 | ...::Err(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1191:9:1191:23 | ...::Err(...) | E | main.rs:1157:5:1158:14 | S1 |
-| main.rs:1191:9:1191:23 | ...::Err(...) | T | main.rs:1185:20:1185:27 | T |
-| main.rs:1191:21:1191:22 | S1 |  | main.rs:1157:5:1158:14 | S1 |
-| main.rs:1195:37:1195:52 | try_same_error(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1195:37:1195:52 | try_same_error(...) | E | main.rs:1157:5:1158:14 | S1 |
-| main.rs:1195:37:1195:52 | try_same_error(...) | T | main.rs:1157:5:1158:14 | S1 |
-| main.rs:1196:22:1196:27 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:1199:37:1199:55 | try_convert_error(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1199:37:1199:55 | try_convert_error(...) | E | main.rs:1160:5:1161:14 | S2 |
-| main.rs:1199:37:1199:55 | try_convert_error(...) | T | main.rs:1157:5:1158:14 | S1 |
-| main.rs:1200:22:1200:27 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:1203:37:1203:49 | try_chained(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1203:37:1203:49 | try_chained(...) | E | main.rs:1160:5:1161:14 | S2 |
-| main.rs:1203:37:1203:49 | try_chained(...) | T | main.rs:1157:5:1158:14 | S1 |
-| main.rs:1204:22:1204:27 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:1207:37:1207:63 | try_complex(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1207:37:1207:63 | try_complex(...) | E | main.rs:1157:5:1158:14 | S1 |
-| main.rs:1207:37:1207:63 | try_complex(...) | T | main.rs:1157:5:1158:14 | S1 |
-| main.rs:1207:49:1207:62 | ...::Ok(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1207:49:1207:62 | ...::Ok(...) | E | main.rs:1157:5:1158:14 | S1 |
-| main.rs:1207:49:1207:62 | ...::Ok(...) | T | main.rs:1157:5:1158:14 | S1 |
-| main.rs:1207:60:1207:61 | S1 |  | main.rs:1157:5:1158:14 | S1 |
-| main.rs:1208:22:1208:27 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:1215:13:1215:13 | x |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:1215:22:1215:22 | 1 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:1216:13:1216:13 | y |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:1216:17:1216:17 | 2 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:1217:17:1217:17 | x |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:1217:21:1217:21 | y |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:1218:13:1218:13 | z |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:1218:17:1218:17 | x |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:1218:17:1218:23 | x.abs() |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:1219:13:1219:13 | c |  | file:///BUILTINS/types.rs:6:1:7:16 | char |
-| main.rs:1219:17:1219:19 | 'c' |  | file:///BUILTINS/types.rs:6:1:7:16 | char |
-| main.rs:1220:13:1220:17 | hello |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:1220:21:1220:27 | "Hello" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:1221:13:1221:13 | f |  | file:///BUILTINS/types.rs:25:1:25:15 | f64 |
-| main.rs:1221:17:1221:24 | 123.0f64 |  | file:///BUILTINS/types.rs:25:1:25:15 | f64 |
-| main.rs:1222:13:1222:13 | t |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
-| main.rs:1222:17:1222:20 | true |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
-| main.rs:1223:13:1223:13 | f |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
-| main.rs:1223:17:1223:21 | false |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
-| main.rs:1229:13:1229:13 | x |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
-| main.rs:1229:17:1229:20 | true |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
-| main.rs:1229:17:1229:29 | ... && ... |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
-| main.rs:1229:25:1229:29 | false |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
-| main.rs:1230:13:1230:13 | y |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
-| main.rs:1230:17:1230:20 | true |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
-| main.rs:1230:17:1230:29 | ... \|\| ... |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
-| main.rs:1230:25:1230:29 | false |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
-| main.rs:1232:13:1232:17 | mut a |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:1233:12:1233:13 | 34 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:1233:18:1233:19 | 33 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:1234:17:1234:17 | z |  | file://:0:0:0:0 | () |
-| main.rs:1234:21:1234:27 | (...) |  | file://:0:0:0:0 | () |
-| main.rs:1234:22:1234:22 | a |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:1234:22:1234:26 | ... = ... |  | file://:0:0:0:0 | () |
-| main.rs:1234:26:1234:26 | 1 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:1236:13:1236:13 | a |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:1236:13:1236:17 | ... = ... |  | file://:0:0:0:0 | () |
-| main.rs:1236:17:1236:17 | 2 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:1238:9:1238:9 | a |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:1244:5:1244:20 | ...::f(...) |  | main.rs:67:5:67:21 | Foo |
-| main.rs:1245:5:1245:60 | ...::g(...) |  | main.rs:67:5:67:21 | Foo |
-| main.rs:1245:20:1245:38 | ...::Foo {...} |  | main.rs:67:5:67:21 | Foo |
-| main.rs:1245:41:1245:59 | ...::Foo {...} |  | main.rs:67:5:67:21 | Foo |
+| main.rs:1115:13:1115:16 | self | &T | main.rs:1109:5:1117:5 | Self [trait MyTrait] |
+| main.rs:1115:13:1115:22 | self.foo() |  | file://:0:0:0:0 | & |
+| main.rs:1115:13:1115:22 | self.foo() | &T | main.rs:1109:5:1117:5 | Self [trait MyTrait] |
+| main.rs:1123:16:1123:20 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1123:16:1123:20 | SelfParam | &T | main.rs:1119:5:1119:20 | MyStruct |
+| main.rs:1123:36:1125:9 | { ... } |  | file://:0:0:0:0 | & |
+| main.rs:1123:36:1125:9 | { ... } | &T | main.rs:1119:5:1119:20 | MyStruct |
+| main.rs:1124:13:1124:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1124:13:1124:16 | self | &T | main.rs:1119:5:1119:20 | MyStruct |
+| main.rs:1129:13:1129:13 | x |  | main.rs:1119:5:1119:20 | MyStruct |
+| main.rs:1129:17:1129:24 | MyStruct |  | main.rs:1119:5:1119:20 | MyStruct |
+| main.rs:1130:9:1130:9 | x |  | main.rs:1119:5:1119:20 | MyStruct |
+| main.rs:1130:9:1130:15 | x.bar() |  | file://:0:0:0:0 | & |
+| main.rs:1130:9:1130:15 | x.bar() | &T | main.rs:1119:5:1119:20 | MyStruct |
+| main.rs:1140:16:1140:20 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1140:16:1140:20 | SelfParam | &T | main.rs:1137:5:1137:26 | MyStruct |
+| main.rs:1140:16:1140:20 | SelfParam | &T.T | main.rs:1139:10:1139:10 | T |
+| main.rs:1140:32:1142:9 | { ... } |  | file://:0:0:0:0 | & |
+| main.rs:1140:32:1142:9 | { ... } | &T | main.rs:1137:5:1137:26 | MyStruct |
+| main.rs:1140:32:1142:9 | { ... } | &T.T | main.rs:1139:10:1139:10 | T |
+| main.rs:1141:13:1141:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1141:13:1141:16 | self | &T | main.rs:1137:5:1137:26 | MyStruct |
+| main.rs:1141:13:1141:16 | self | &T.T | main.rs:1139:10:1139:10 | T |
+| main.rs:1146:13:1146:13 | x |  | main.rs:1137:5:1137:26 | MyStruct |
+| main.rs:1146:13:1146:13 | x | T | main.rs:1135:5:1135:13 | S |
+| main.rs:1146:17:1146:27 | MyStruct(...) |  | main.rs:1137:5:1137:26 | MyStruct |
+| main.rs:1146:17:1146:27 | MyStruct(...) | T | main.rs:1135:5:1135:13 | S |
+| main.rs:1146:26:1146:26 | S |  | main.rs:1135:5:1135:13 | S |
+| main.rs:1147:9:1147:9 | x |  | main.rs:1137:5:1137:26 | MyStruct |
+| main.rs:1147:9:1147:9 | x | T | main.rs:1135:5:1135:13 | S |
+| main.rs:1147:9:1147:15 | x.foo() |  | file://:0:0:0:0 | & |
+| main.rs:1147:9:1147:15 | x.foo() | &T | main.rs:1137:5:1137:26 | MyStruct |
+| main.rs:1147:9:1147:15 | x.foo() | &T.T | main.rs:1135:5:1135:13 | S |
+| main.rs:1155:15:1155:19 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1155:15:1155:19 | SelfParam | &T | main.rs:1152:5:1152:13 | S |
+| main.rs:1155:31:1157:9 | { ... } |  | file://:0:0:0:0 | & |
+| main.rs:1155:31:1157:9 | { ... } | &T | main.rs:1152:5:1152:13 | S |
+| main.rs:1156:13:1156:19 | &... |  | file://:0:0:0:0 | & |
+| main.rs:1156:13:1156:19 | &... | &T | main.rs:1152:5:1152:13 | S |
+| main.rs:1156:14:1156:19 | &... |  | file://:0:0:0:0 | & |
+| main.rs:1156:14:1156:19 | &... | &T | main.rs:1152:5:1152:13 | S |
+| main.rs:1156:15:1156:19 | &self |  | file://:0:0:0:0 | & |
+| main.rs:1156:15:1156:19 | &self | &T | main.rs:1152:5:1152:13 | S |
+| main.rs:1156:16:1156:19 | self |  | file://:0:0:0:0 | & |
+| main.rs:1156:16:1156:19 | self | &T | main.rs:1152:5:1152:13 | S |
+| main.rs:1159:15:1159:25 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1159:15:1159:25 | SelfParam | &T | main.rs:1152:5:1152:13 | S |
+| main.rs:1159:37:1161:9 | { ... } |  | file://:0:0:0:0 | & |
+| main.rs:1159:37:1161:9 | { ... } | &T | main.rs:1152:5:1152:13 | S |
+| main.rs:1160:13:1160:19 | &... |  | file://:0:0:0:0 | & |
+| main.rs:1160:13:1160:19 | &... | &T | main.rs:1152:5:1152:13 | S |
+| main.rs:1160:14:1160:19 | &... |  | file://:0:0:0:0 | & |
+| main.rs:1160:14:1160:19 | &... | &T | main.rs:1152:5:1152:13 | S |
+| main.rs:1160:15:1160:19 | &self |  | file://:0:0:0:0 | & |
+| main.rs:1160:15:1160:19 | &self | &T | main.rs:1152:5:1152:13 | S |
+| main.rs:1160:16:1160:19 | self |  | file://:0:0:0:0 | & |
+| main.rs:1160:16:1160:19 | self | &T | main.rs:1152:5:1152:13 | S |
+| main.rs:1163:15:1163:15 | x |  | file://:0:0:0:0 | & |
+| main.rs:1163:15:1163:15 | x | &T | main.rs:1152:5:1152:13 | S |
+| main.rs:1163:34:1165:9 | { ... } |  | file://:0:0:0:0 | & |
+| main.rs:1163:34:1165:9 | { ... } | &T | main.rs:1152:5:1152:13 | S |
+| main.rs:1164:13:1164:13 | x |  | file://:0:0:0:0 | & |
+| main.rs:1164:13:1164:13 | x | &T | main.rs:1152:5:1152:13 | S |
+| main.rs:1167:15:1167:15 | x |  | file://:0:0:0:0 | & |
+| main.rs:1167:15:1167:15 | x | &T | main.rs:1152:5:1152:13 | S |
+| main.rs:1167:34:1169:9 | { ... } |  | file://:0:0:0:0 | & |
+| main.rs:1167:34:1169:9 | { ... } | &T | main.rs:1152:5:1152:13 | S |
+| main.rs:1168:13:1168:16 | &... |  | file://:0:0:0:0 | & |
+| main.rs:1168:13:1168:16 | &... | &T | main.rs:1152:5:1152:13 | S |
+| main.rs:1168:14:1168:16 | &... |  | file://:0:0:0:0 | & |
+| main.rs:1168:14:1168:16 | &... | &T | main.rs:1152:5:1152:13 | S |
+| main.rs:1168:15:1168:16 | &x |  | file://:0:0:0:0 | & |
+| main.rs:1168:15:1168:16 | &x | &T | main.rs:1152:5:1152:13 | S |
+| main.rs:1168:16:1168:16 | x |  | file://:0:0:0:0 | & |
+| main.rs:1168:16:1168:16 | x | &T | main.rs:1152:5:1152:13 | S |
+| main.rs:1173:13:1173:13 | x |  | main.rs:1152:5:1152:13 | S |
+| main.rs:1173:17:1173:20 | S {...} |  | main.rs:1152:5:1152:13 | S |
+| main.rs:1174:9:1174:9 | x |  | main.rs:1152:5:1152:13 | S |
+| main.rs:1174:9:1174:14 | x.f1() |  | file://:0:0:0:0 | & |
+| main.rs:1174:9:1174:14 | x.f1() | &T | main.rs:1152:5:1152:13 | S |
+| main.rs:1175:9:1175:9 | x |  | main.rs:1152:5:1152:13 | S |
+| main.rs:1175:9:1175:14 | x.f2() |  | file://:0:0:0:0 | & |
+| main.rs:1175:9:1175:14 | x.f2() | &T | main.rs:1152:5:1152:13 | S |
+| main.rs:1176:9:1176:17 | ...::f3(...) |  | file://:0:0:0:0 | & |
+| main.rs:1176:9:1176:17 | ...::f3(...) | &T | main.rs:1152:5:1152:13 | S |
+| main.rs:1176:15:1176:16 | &x |  | file://:0:0:0:0 | & |
+| main.rs:1176:15:1176:16 | &x | &T | main.rs:1152:5:1152:13 | S |
+| main.rs:1176:16:1176:16 | x |  | main.rs:1152:5:1152:13 | S |
+| main.rs:1190:43:1193:5 | { ... } |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1190:43:1193:5 | { ... } | E | main.rs:1183:5:1184:14 | S1 |
+| main.rs:1190:43:1193:5 | { ... } | T | main.rs:1183:5:1184:14 | S1 |
+| main.rs:1191:13:1191:13 | x |  | main.rs:1183:5:1184:14 | S1 |
+| main.rs:1191:17:1191:30 | ...::Ok(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1191:17:1191:30 | ...::Ok(...) | T | main.rs:1183:5:1184:14 | S1 |
+| main.rs:1191:17:1191:31 | TryExpr |  | main.rs:1183:5:1184:14 | S1 |
+| main.rs:1191:28:1191:29 | S1 |  | main.rs:1183:5:1184:14 | S1 |
+| main.rs:1192:9:1192:22 | ...::Ok(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1192:9:1192:22 | ...::Ok(...) | E | main.rs:1183:5:1184:14 | S1 |
+| main.rs:1192:9:1192:22 | ...::Ok(...) | T | main.rs:1183:5:1184:14 | S1 |
+| main.rs:1192:20:1192:21 | S1 |  | main.rs:1183:5:1184:14 | S1 |
+| main.rs:1196:46:1200:5 | { ... } |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1196:46:1200:5 | { ... } | E | main.rs:1186:5:1187:14 | S2 |
+| main.rs:1196:46:1200:5 | { ... } | T | main.rs:1183:5:1184:14 | S1 |
+| main.rs:1197:13:1197:13 | x |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1197:13:1197:13 | x | T | main.rs:1183:5:1184:14 | S1 |
+| main.rs:1197:17:1197:30 | ...::Ok(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1197:17:1197:30 | ...::Ok(...) | T | main.rs:1183:5:1184:14 | S1 |
+| main.rs:1197:28:1197:29 | S1 |  | main.rs:1183:5:1184:14 | S1 |
+| main.rs:1198:13:1198:13 | y |  | main.rs:1183:5:1184:14 | S1 |
+| main.rs:1198:17:1198:17 | x |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1198:17:1198:17 | x | T | main.rs:1183:5:1184:14 | S1 |
+| main.rs:1198:17:1198:18 | TryExpr |  | main.rs:1183:5:1184:14 | S1 |
+| main.rs:1199:9:1199:22 | ...::Ok(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1199:9:1199:22 | ...::Ok(...) | E | main.rs:1186:5:1187:14 | S2 |
+| main.rs:1199:9:1199:22 | ...::Ok(...) | T | main.rs:1183:5:1184:14 | S1 |
+| main.rs:1199:20:1199:21 | S1 |  | main.rs:1183:5:1184:14 | S1 |
+| main.rs:1203:40:1208:5 | { ... } |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1203:40:1208:5 | { ... } | E | main.rs:1186:5:1187:14 | S2 |
+| main.rs:1203:40:1208:5 | { ... } | T | main.rs:1183:5:1184:14 | S1 |
+| main.rs:1204:13:1204:13 | x |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1204:13:1204:13 | x | T | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1204:13:1204:13 | x | T.T | main.rs:1183:5:1184:14 | S1 |
+| main.rs:1204:17:1204:42 | ...::Ok(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1204:17:1204:42 | ...::Ok(...) | T | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1204:17:1204:42 | ...::Ok(...) | T.T | main.rs:1183:5:1184:14 | S1 |
+| main.rs:1204:28:1204:41 | ...::Ok(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1204:28:1204:41 | ...::Ok(...) | T | main.rs:1183:5:1184:14 | S1 |
+| main.rs:1204:39:1204:40 | S1 |  | main.rs:1183:5:1184:14 | S1 |
+| main.rs:1206:17:1206:17 | x |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1206:17:1206:17 | x | T | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1206:17:1206:17 | x | T.T | main.rs:1183:5:1184:14 | S1 |
+| main.rs:1206:17:1206:18 | TryExpr |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1206:17:1206:18 | TryExpr | T | main.rs:1183:5:1184:14 | S1 |
+| main.rs:1206:17:1206:29 | ... .map(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1207:9:1207:22 | ...::Ok(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1207:9:1207:22 | ...::Ok(...) | E | main.rs:1186:5:1187:14 | S2 |
+| main.rs:1207:9:1207:22 | ...::Ok(...) | T | main.rs:1183:5:1184:14 | S1 |
+| main.rs:1207:20:1207:21 | S1 |  | main.rs:1183:5:1184:14 | S1 |
+| main.rs:1211:30:1211:34 | input |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1211:30:1211:34 | input | E | main.rs:1183:5:1184:14 | S1 |
+| main.rs:1211:30:1211:34 | input | T | main.rs:1211:20:1211:27 | T |
+| main.rs:1211:69:1218:5 | { ... } |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1211:69:1218:5 | { ... } | E | main.rs:1183:5:1184:14 | S1 |
+| main.rs:1211:69:1218:5 | { ... } | T | main.rs:1211:20:1211:27 | T |
+| main.rs:1212:13:1212:17 | value |  | main.rs:1211:20:1211:27 | T |
+| main.rs:1212:21:1212:25 | input |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1212:21:1212:25 | input | E | main.rs:1183:5:1184:14 | S1 |
+| main.rs:1212:21:1212:25 | input | T | main.rs:1211:20:1211:27 | T |
+| main.rs:1212:21:1212:26 | TryExpr |  | main.rs:1211:20:1211:27 | T |
+| main.rs:1213:22:1213:38 | ...::Ok(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1213:22:1213:38 | ...::Ok(...) | T | main.rs:1211:20:1211:27 | T |
+| main.rs:1213:22:1216:10 | ... .and_then(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1213:33:1213:37 | value |  | main.rs:1211:20:1211:27 | T |
+| main.rs:1213:53:1216:9 | { ... } |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1213:53:1216:9 | { ... } | E | main.rs:1183:5:1184:14 | S1 |
+| main.rs:1214:22:1214:27 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:1215:13:1215:34 | ...::Ok::<...>(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1215:13:1215:34 | ...::Ok::<...>(...) | E | main.rs:1183:5:1184:14 | S1 |
+| main.rs:1217:9:1217:23 | ...::Err(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1217:9:1217:23 | ...::Err(...) | E | main.rs:1183:5:1184:14 | S1 |
+| main.rs:1217:9:1217:23 | ...::Err(...) | T | main.rs:1211:20:1211:27 | T |
+| main.rs:1217:21:1217:22 | S1 |  | main.rs:1183:5:1184:14 | S1 |
+| main.rs:1221:37:1221:52 | try_same_error(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1221:37:1221:52 | try_same_error(...) | E | main.rs:1183:5:1184:14 | S1 |
+| main.rs:1221:37:1221:52 | try_same_error(...) | T | main.rs:1183:5:1184:14 | S1 |
+| main.rs:1222:22:1222:27 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:1225:37:1225:55 | try_convert_error(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1225:37:1225:55 | try_convert_error(...) | E | main.rs:1186:5:1187:14 | S2 |
+| main.rs:1225:37:1225:55 | try_convert_error(...) | T | main.rs:1183:5:1184:14 | S1 |
+| main.rs:1226:22:1226:27 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:1229:37:1229:49 | try_chained(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1229:37:1229:49 | try_chained(...) | E | main.rs:1186:5:1187:14 | S2 |
+| main.rs:1229:37:1229:49 | try_chained(...) | T | main.rs:1183:5:1184:14 | S1 |
+| main.rs:1230:22:1230:27 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:1233:37:1233:63 | try_complex(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1233:37:1233:63 | try_complex(...) | E | main.rs:1183:5:1184:14 | S1 |
+| main.rs:1233:37:1233:63 | try_complex(...) | T | main.rs:1183:5:1184:14 | S1 |
+| main.rs:1233:49:1233:62 | ...::Ok(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1233:49:1233:62 | ...::Ok(...) | E | main.rs:1183:5:1184:14 | S1 |
+| main.rs:1233:49:1233:62 | ...::Ok(...) | T | main.rs:1183:5:1184:14 | S1 |
+| main.rs:1233:60:1233:61 | S1 |  | main.rs:1183:5:1184:14 | S1 |
+| main.rs:1234:22:1234:27 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:1241:13:1241:13 | x |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1241:22:1241:22 | 1 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1242:13:1242:13 | y |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1242:17:1242:17 | 2 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1243:17:1243:17 | x |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1243:21:1243:21 | y |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1244:13:1244:13 | z |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1244:17:1244:17 | x |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1244:17:1244:23 | x.abs() |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1245:13:1245:13 | c |  | file:///BUILTINS/types.rs:6:1:7:16 | char |
+| main.rs:1245:17:1245:19 | 'c' |  | file:///BUILTINS/types.rs:6:1:7:16 | char |
+| main.rs:1246:13:1246:17 | hello |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:1246:21:1246:27 | "Hello" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:1247:13:1247:13 | f |  | file:///BUILTINS/types.rs:25:1:25:15 | f64 |
+| main.rs:1247:17:1247:24 | 123.0f64 |  | file:///BUILTINS/types.rs:25:1:25:15 | f64 |
+| main.rs:1248:13:1248:13 | t |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1248:17:1248:20 | true |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1249:13:1249:13 | f |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1249:17:1249:21 | false |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1255:13:1255:13 | x |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1255:17:1255:20 | true |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1255:17:1255:29 | ... && ... |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1255:25:1255:29 | false |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1256:13:1256:13 | y |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1256:17:1256:20 | true |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1256:17:1256:29 | ... \|\| ... |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1256:25:1256:29 | false |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1258:13:1258:17 | mut a |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1259:12:1259:13 | 34 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1259:18:1259:19 | 33 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1260:17:1260:17 | z |  | file://:0:0:0:0 | () |
+| main.rs:1260:21:1260:27 | (...) |  | file://:0:0:0:0 | () |
+| main.rs:1260:22:1260:22 | a |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1260:22:1260:26 | ... = ... |  | file://:0:0:0:0 | () |
+| main.rs:1260:26:1260:26 | 1 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1262:13:1262:13 | a |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1262:13:1262:17 | ... = ... |  | file://:0:0:0:0 | () |
+| main.rs:1262:17:1262:17 | 2 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1264:9:1264:9 | a |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1270:5:1270:20 | ...::f(...) |  | main.rs:67:5:67:21 | Foo |
+| main.rs:1271:5:1271:60 | ...::g(...) |  | main.rs:67:5:67:21 | Foo |
+| main.rs:1271:20:1271:38 | ...::Foo {...} |  | main.rs:67:5:67:21 | Foo |
+| main.rs:1271:41:1271:59 | ...::Foo {...} |  | main.rs:67:5:67:21 | Foo |

--- a/rust/ql/test/library-tests/type-inference/type-inference.ql
+++ b/rust/ql/test/library-tests/type-inference/type-inference.ql
@@ -43,7 +43,7 @@ module ResolveTest implements TestSig {
       source.fromSource() and
       not source.isFromMacroExpansion()
     |
-      target = source.(MethodCallExpr).getStaticTarget() and
+      target = resolveMethodCallTarget(source) and
       functionHasValue(target, value) and
       tag = "method"
       or


### PR DESCRIPTION
This PR adds resolution for function calls to trait methods `ATrait::some_method(obj, ...)`.

Key changes:
- Introduce an abstract `MethodCall` abstract class that is extended by the different types of expressions that can lead to method calls. Later this class can also be extended by overloaded operators that perform method calls.
- Added a `methodCandidateTrait` predicate, which is similar to the existing `methodCandidate` predicate but which also takes a trait that the method should come from. `potentialInstantiationOf` now accounts both for method calls that target a specific trait.