### PR TITLE
Rust: re-enable attribute macro expansion in library mode

### DIFF
--- a/rust/extractor/src/translate/base.rs
+++ b/rust/extractor/src/translate/base.rs
@@ -734,10 +734,6 @@ impl<'a> Translator<'a> {
     }
 
     pub(crate) fn emit_item_expansion(&mut self, node: &ast::Item, label: Label<generated::Item>) {
-        // TODO: remove this after fixing exponential expansion on libraries like funty-2.0.0
-        if self.source_kind == SourceKind::Library {
-            return;
-        }
         (|| {
             let semantics = self.semantics?;
             let file = semantics.hir_file_for(node.syntax());


### PR DESCRIPTION
Now https://github.com/github/codeql/pull/19572 is merged it should be possible to remove the workaround and re-enable attribute macro expansion on library files. Reverts https://github.com/github/codeql/commit/df99e06c816183b01c9cdb56521e20bdaf4cb7b6