### PR TITLE
C#: Improve `cs/dereference-*` queries and add to the Code Quality suite.

### DIFF
--- a/csharp/ql/integration-tests/posix/query-suite/csharp-code-quality.qls.expected
+++ b/csharp/ql/integration-tests/posix/query-suite/csharp-code-quality.qls.expected
@@ -2,6 +2,8 @@ ql/csharp/ql/src/API Abuse/CallToGCCollect.ql
 ql/csharp/ql/src/API Abuse/FormatInvalid.ql
 ql/csharp/ql/src/API Abuse/NoDisposeCallOnLocalIDisposable.ql
 ql/csharp/ql/src/Bad Practices/Control-Flow/ConstantCondition.ql
+ql/csharp/ql/src/CSI/NullAlways.ql
+ql/csharp/ql/src/CSI/NullMaybe.ql
 ql/csharp/ql/src/Dead Code/DeadStoreOfLocal.ql
 ql/csharp/ql/src/Language Abuse/MissedReadonlyOpportunity.ql
 ql/csharp/ql/src/Likely Bugs/Collections/ContainerLengthCmpOffByOne.ql

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/Nullness.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/Nullness.qll
@@ -544,8 +544,13 @@ class Dereference extends G::DereferenceableExpr {
         p.hasExtensionMethodModifier() and
         not emc.isConditional()
       |
-        p.fromSource() // assume all non-source extension methods perform a dereference
-        implies
+        // Assume all non-source extension methods on
+        // (1) nullable types are null-safe
+        // (2) non-nullable types are doing a dereference.
+        p.fromLibrary() and
+        not p.getAnnotatedType().isNullableRefType()
+        or
+        p.fromSource() and
         exists(
           Ssa::ImplicitParameterDefinition def,
           AssignableDefinitions::ImplicitParameterDefinition pdef

--- a/csharp/ql/lib/semmle/code/csharp/frameworks/system/Diagnostics.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/system/Diagnostics.qll
@@ -41,9 +41,7 @@ class SystemDiagnosticsDebugClass extends SystemDiagnosticsClass {
   /** Gets an `Assert(bool, ...)` method. */
   Method getAssertMethod() {
     result.getDeclaringType() = this and
-    result.hasName("Assert") and
-    result.getParameter(0).getType() instanceof BoolType and
-    result.getReturnType() instanceof VoidType
+    result.hasName("Assert")
   }
 }
 

--- a/csharp/ql/src/CSI/NullAlways.ql
+++ b/csharp/ql/src/CSI/NullAlways.ql
@@ -9,6 +9,7 @@
  *       correctness
  *       exceptions
  *       external/cwe/cwe-476
+ *       quality
  */
 
 import csharp

--- a/csharp/ql/src/CSI/NullMaybe.ql
+++ b/csharp/ql/src/CSI/NullMaybe.ql
@@ -10,6 +10,7 @@
  *       correctness
  *       exceptions
  *       external/cwe/cwe-476
+ *       quality
  */
 
 import csharp

--- a/csharp/ql/src/change-notes/2025-06-03-dereferece-extension-method.md
+++ b/csharp/ql/src/change-notes/2025-06-03-dereferece-extension-method.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The queries `cs/dereferenced-value-is-always-null` and `cs/dereferenced-value-may-be-null` have been improved to reduce false positives. The queries no longer assume that expressions are dereferenced when passed as the receiver (`this` parameter) to extension methods where that parameter is a nullable type.

--- a/csharp/ql/test/query-tests/Nullness/A.cs
+++ b/csharp/ql/test/query-tests/Nullness/A.cs
@@ -5,7 +5,7 @@ class A
     public void Lock()
     {
         object synchronizedAlways = null;
-        lock (synchronizedAlways) // BAD (always)
+        lock (synchronizedAlways) // $ Alert[cs/dereferenced-value-is-always-null]
         {
             synchronizedAlways.GetHashCode(); // GOOD
         }
@@ -14,7 +14,7 @@ class A
     public void ArrayAssignTest()
     {
         int[] arrayNull = null;
-        arrayNull[0] = 10; // BAD (always)
+        arrayNull[0] = 10; // $ Alert[cs/dereferenced-value-is-always-null]
 
         int[] arrayOk;
         arrayOk = new int[10];
@@ -28,10 +28,10 @@ class A
         object methodAccess = null;
         object methodCall = null;
 
-        Console.WriteLine(arrayAccess[1]); // BAD (always)
-        Console.WriteLine(fieldAccess.Length); // BAD (always)
-        Func<String> tmp = methodAccess.ToString; // BAD (always)
-        Console.WriteLine(methodCall.ToString()); // BAD (always)
+        Console.WriteLine(arrayAccess[1]); // $ Alert[cs/dereferenced-value-is-always-null]
+        Console.WriteLine(fieldAccess.Length); // $ Alert[cs/dereferenced-value-is-always-null]
+        Func<String> tmp = methodAccess.ToString; // $ Alert[cs/dereferenced-value-is-always-null]
+        Console.WriteLine(methodCall.ToString()); // $ Alert[cs/dereferenced-value-is-always-null]
 
         Console.WriteLine(arrayAccess[1]); // GOOD
         Console.WriteLine(fieldAccess.Length); // GOOD
@@ -47,7 +47,7 @@ class A
 
         object varRef = null;
         TestMethod2(ref varRef);
-        varRef.ToString(); // BAD (always)
+        varRef.ToString(); // $ Alert[cs/dereferenced-value-is-always-null]
 
         varRef = null;
         TestMethod3(ref varRef);

--- a/csharp/ql/test/query-tests/Nullness/Assert.cs
+++ b/csharp/ql/test/query-tests/Nullness/Assert.cs
@@ -12,7 +12,7 @@ class AssertTests
 
         s = b ? null : "";
         Assert.IsNull(s);
-        Console.WriteLine(s.Length); // BAD (always)
+        Console.WriteLine(s.Length); // $ Alert[cs/dereferenced-value-is-always-null]
 
         s = b ? null : "";
         Assert.IsNotNull(s);
@@ -20,7 +20,7 @@ class AssertTests
 
         s = b ? null : "";
         Assert.IsTrue(s == null);
-        Console.WriteLine(s.Length); // BAD (always)
+        Console.WriteLine(s.Length); // $ Alert[cs/dereferenced-value-is-always-null]
 
         s = b ? null : "";
         Assert.IsTrue(s != null);
@@ -28,7 +28,7 @@ class AssertTests
 
         s = b ? null : "";
         Assert.IsFalse(s != null);
-        Console.WriteLine(s.Length); // BAD (always)
+        Console.WriteLine(s.Length); // $ Alert[cs/dereferenced-value-is-always-null]
 
         s = b ? null : "";
         Assert.IsFalse(s == null);
@@ -44,10 +44,10 @@ class AssertTests
 
         s = b ? null : "";
         Assert.IsTrue(s == null && b);
-        Console.WriteLine(s.Length); // BAD (always)
+        Console.WriteLine(s.Length); // $ Alert[cs/dereferenced-value-is-always-null]
 
         s = b ? null : "";
         Assert.IsFalse(s != null || !b);
-        Console.WriteLine(s.Length); // BAD (always)
+        Console.WriteLine(s.Length); // $ Alert[cs/dereferenced-value-is-always-null]
     }
 }

--- a/csharp/ql/test/query-tests/Nullness/B.cs
+++ b/csharp/ql/test/query-tests/Nullness/B.cs
@@ -10,7 +10,7 @@ class B
         B neqCallAlways = null;
 
         if (eqCallAlways == null)
-            eqCallAlways.ToString(); // BAD (always)
+            eqCallAlways.ToString(); // $ Alert[cs/dereferenced-value-is-always-null]
 
         if (b2 != null)
             b2.ToString(); // GOOD
@@ -21,7 +21,7 @@ class B
 
         if (neqCallAlways != null) { }
         else
-            neqCallAlways.ToString(); // BAD (always)
+            neqCallAlways.ToString(); // $ Alert[cs/dereferenced-value-is-always-null]
     }
 
     public static bool operator ==(B b1, B b2)

--- a/csharp/ql/test/query-tests/Nullness/C.cs
+++ b/csharp/ql/test/query-tests/Nullness/C.cs
@@ -59,13 +59,13 @@ public class C
 
     public void AssertNotNullTest()
     {
-        var o1 = Maybe() ? null : new object();
+        var o1 = Maybe() ? null : new object(); // $ Source[cs/dereferenced-value-may-be-null]
         AssertNonNull(o1);
-        o1.ToString(); // GOOD (false positive)
+        o1.ToString(); // $ SPURIOUS (false positive): Alert[cs/dereferenced-value-may-be-null]
 
-        var o2 = Maybe() ? null : new object();
+        var o2 = Maybe() ? null : new object(); // $ Source[cs/dereferenced-value-may-be-null]
         AssertNonNull(o1);
-        o2.ToString(); // BAD (maybe)
+        o2.ToString(); // $ Alert[cs/dereferenced-value-may-be-null]
 
         var o3 = Maybe() ? null : new object();
         Assert.IsNotNull(o3);
@@ -91,16 +91,16 @@ public class C
 
     public void Lock()
     {
-        var o = Maybe() ? null : new object();
-        lock (o) // BAD (maybe)
+        var o = Maybe() ? null : new object(); // $ Source[cs/dereferenced-value-may-be-null]
+        lock (o) // $ Alert[cs/dereferenced-value-may-be-null]
             o.ToString(); // GOOD
     }
 
     public void Foreach(IEnumerable<int> list)
     {
         if (Maybe())
-            list = null;
-        foreach (var x in list) // BAD (maybe)
+            list = null; // $ Source[cs/dereferenced-value-may-be-null]
+        foreach (var x in list) // $ Alert[cs/dereferenced-value-may-be-null]
         {
             x.ToString(); // GOOD
             list.ToString(); // GOOD
@@ -174,8 +174,8 @@ public class C
         s = "";
         do
         {
-            s.ToString(); // BAD (maybe)
-            s = null;
+            s.ToString(); // $ Alert[cs/dereferenced-value-may-be-null]
+            s = null; // $ Source[cs/dereferenced-value-may-be-null]
         }
         while (true);
     }
@@ -200,8 +200,8 @@ public class C
         s = "";
         while (true)
         {
-            s.ToString(); // BAD (maybe)
-            s = null;
+            s.ToString(); // $ Alert[cs/dereferenced-value-may-be-null]
+            s = null; // $ Source[cs/dereferenced-value-may-be-null]
         }
     }
 
@@ -219,8 +219,8 @@ public class C
 
         s = "";
         if (s != null && s.Length % 2 == 0)
-            s = null;
-        s.ToString(); // BAD (maybe)
+            s = null; // $ Source[cs/dereferenced-value-may-be-null]
+        s.ToString(); // $ Alert[cs/dereferenced-value-may-be-null]
     }
 
     public void For()
@@ -237,9 +237,9 @@ public class C
             s.ToString(); // $ Alert[cs/dereferenced-value-is-always-null]
         }
 
-        for (s = ""; ; s = null)
+        for (s = ""; ; s = null) // $ Source[cs/dereferenced-value-may-be-null]
         {
-            s.ToString(); // BAD (maybe)
+            s.ToString(); // $ Alert[cs/dereferenced-value-may-be-null]
         }
     }
 

--- a/csharp/ql/test/query-tests/Nullness/C.cs
+++ b/csharp/ql/test/query-tests/Nullness/C.cs
@@ -15,7 +15,7 @@ public class C
 
         if (!(o != null))
         {
-            o.GetHashCode(); // BAD (always)
+            o.GetHashCode(); // $ Alert[cs/dereferenced-value-is-always-null]
         }
     }
 
@@ -39,7 +39,7 @@ public class C
     {
         var s = Maybe() ? null : "";
         Debug.Assert(s == null);
-        s.ToString(); // BAD (always)
+        s.ToString(); // $ Alert[cs/dereferenced-value-is-always-null]
 
         s = Maybe() ? null : "";
         Debug.Assert(s != null);
@@ -50,11 +50,11 @@ public class C
     {
         var o1 = new object();
         AssertNull(o1);
-        o1.ToString(); // BAD (always) (false negative)
+        o1.ToString(); // $ MISSING: Alert[cs/dereferenced-value-is-always-null]
 
         var o2 = Maybe() ? null : "";
         Assert.IsNull(o2);
-        o2.ToString(); // BAD (always)
+        o2.ToString(); // $ Alert[cs/dereferenced-value-is-always-null]
     }
 
     public void AssertNotNullTest()
@@ -159,7 +159,7 @@ public class C
         s = null;
         do
         {
-            s.ToString(); // BAD (always)
+            s.ToString(); // $ Alert[cs/dereferenced-value-is-always-null]
             s = null;
         }
         while (s != null);
@@ -167,7 +167,7 @@ public class C
         s = null;
         do
         {
-            s.ToString(); // BAD (always)
+            s.ToString(); // $ Alert[cs/dereferenced-value-is-always-null]
         }
         while (s != null);
 
@@ -193,7 +193,7 @@ public class C
         s = null;
         while (b)
         {
-            s.ToString(); // BAD (always)
+            s.ToString(); // $ Alert[cs/dereferenced-value-is-always-null]
             s = null;
         }
 
@@ -215,7 +215,7 @@ public class C
         }
 
         if (s == null)
-            s.ToString(); // BAD (always)
+            s.ToString(); // $ Alert[cs/dereferenced-value-is-always-null]
 
         s = "";
         if (s != null && s.Length % 2 == 0)
@@ -230,11 +230,11 @@ public class C
         {
             s.ToString(); // GOOD
         }
-        s.ToString(); // BAD (always)
+        s.ToString(); // $ Alert[cs/dereferenced-value-is-always-null]
 
         for (s = null; s == null; s = null)
         {
-            s.ToString(); // BAD (always)
+            s.ToString(); // $ Alert[cs/dereferenced-value-is-always-null]
         }
 
         for (s = ""; ; s = null)
@@ -246,7 +246,7 @@ public class C
     public void ArrayAssignTest()
     {
         int[] a = null;
-        a[0] = 10; // BAD (always)
+        a[0] = 10; // $ Alert[cs/dereferenced-value-is-always-null]
 
         a = new int[10];
         a[0] = 42; // GOOD
@@ -257,8 +257,8 @@ public class C
         int[] ia = null;
         string[] sa = null;
 
-        ia[1] = 0; // BAD (always)
-        var temp = sa.Length; // BAD (always)
+        ia[1] = 0; // $ Alert[cs/dereferenced-value-is-always-null]
+        var temp = sa.Length; // $ Alert[cs/dereferenced-value-is-always-null]
 
         ia[1] = 0; // BAD (always), but not first
         temp = sa.Length; // BAD (always), but not first

--- a/csharp/ql/test/query-tests/Nullness/D.cs
+++ b/csharp/ql/test/query-tests/Nullness/D.cs
@@ -117,7 +117,7 @@ public class D
         var x = b ? null : "abc";
         x = x == null ? "" : x;
         if (x == null)
-            x.ToString(); // BAD (always)
+            x.ToString(); // $ Alert[cs/dereferenced-value-is-always-null]
         else
             x.ToString(); // GOOD
     }
@@ -194,7 +194,7 @@ public class D
     {
         var o = new Object();
         if (o == null)
-            o.ToString(); // BAD (always)
+            o.ToString(); // $ Alert[cs/dereferenced-value-is-always-null]
         o.ToString(); // GOOD
 
         try
@@ -204,7 +204,7 @@ public class D
         catch (Exception e)
         {
             if (e == null)
-                e.ToString(); // BAD (always)
+                e.ToString(); // $ Alert[cs/dereferenced-value-is-always-null]
             e.ToString(); // GOOD
         }
 
@@ -214,12 +214,12 @@ public class D
 
         var o3 = "abc";
         if (o3 == null)
-            o3.ToString(); // BAD (always)
+            o3.ToString(); // $ Alert[cs/dereferenced-value-is-always-null]
         o3.ToString(); // GOOD
 
         var o4 = "" + null;
         if (o4 == null)
-            o4.ToString(); // BAD (always)
+            o4.ToString(); // $ Alert[cs/dereferenced-value-is-always-null]
         o4.ToString(); // GOOD
     }
 
@@ -382,7 +382,7 @@ public class D
         if (ioe != null)
             ioe = e;
         else
-            ioe.ToString(); // BAD (always)
+            ioe.ToString(); // $ Alert[cs/dereferenced-value-is-always-null]
     }
 
     public void LengthGuard2(int[] a, int[] b)

--- a/csharp/ql/test/query-tests/Nullness/D.cs
+++ b/csharp/ql/test/query-tests/Nullness/D.cs
@@ -14,22 +14,22 @@ public class D
     public void Caller()
     {
         Callee1(new object());
-        Callee1(null);
+        Callee1(null); // $ Source[cs/dereferenced-value-may-be-null]
         Callee2(new object());
     }
 
     public void Callee1(object param)
     {
-        param.ToString(); // BAD (maybe)
+        param.ToString(); // $ Alert[cs/dereferenced-value-may-be-null]
     }
 
-    public void Callee2(object param)
+    public void Callee2(object param) // $ Source[cs/dereferenced-value-may-be-null]
     {
         if (param != null)
         {
             param.ToString(); // GOOD
         }
-        param.ToString(); // BAD (maybe)
+        param.ToString(); // $ Alert[cs/dereferenced-value-may-be-null]
     }
 
     private static bool CustomIsNull(object x)
@@ -55,54 +55,54 @@ public class D
         if ((2 > 1 && o4 != null) != false)
             o4.ToString(); // GOOD
 
-        var o5 = (o4 != null) ? "" : null;
+        var o5 = (o4 != null) ? "" : null; // $ Source[cs/dereferenced-value-may-be-null]
         if (o5 != null)
             o4.ToString(); // GOOD
         if (o4 != null)
-            o5.ToString(); // GOOD (false positive)
+            o5.ToString(); // $ SPURIOUS (false positive): Alert[cs/dereferenced-value-may-be-null]
 
         var o6 = maybe ? null : "";
         if (!CustomIsNull(o6))
             o6.ToString(); // GOOD
 
-        var o7 = maybe ? null : "";
+        var o7 = maybe ? null : ""; // $ Source[cs/dereferenced-value-may-be-null]
         var ok = o7 != null && 2 > 1;
         if (ok)
             o7.ToString(); // GOOD
         else
-            o7.ToString(); // BAD (maybe)
+            o7.ToString(); // $ Alert[cs/dereferenced-value-may-be-null]
 
-        var o8 = maybe ? null : "";
+        var o8 = maybe ? null : ""; // $ Source[cs/dereferenced-value-may-be-null]
         int track = o8 == null ? 42 : 1 + 1;
         if (track == 2)
             o8.ToString(); // GOOD
         if (track != 42)
             o8.ToString(); // GOOD
         if (track < 42)
-            o8.ToString(); // GOOD (false positive)
+            o8.ToString(); // $ SPURIOUS (false positive): Alert[cs/dereferenced-value-may-be-null]
         if (track <= 41)
-            o8.ToString(); // GOOD (false positive)
+            o8.ToString(); // $ SPURIOUS (false positive): Alert[cs/dereferenced-value-may-be-null]
     }
 
     public void Deref(int i)
     {
-        int[] xs = maybe ? null : new int[2];
+        int[] xs = maybe ? null : new int[2]; // $ Source[cs/dereferenced-value-may-be-null]
         if (i > 1)
-            xs[0] = 5; // BAD (maybe)
+            xs[0] = 5; // $ Alert[cs/dereferenced-value-may-be-null]
 
         if (i > 2)
-            maybe = xs[1] > 5; // BAD (maybe)
+            maybe = xs[1] > 5; // $ Alert[cs/dereferenced-value-may-be-null]
 
         if (i > 3)
         {
-            var l = xs.Length; // BAD (maybe)
+            var l = xs.Length; // $ Alert[cs/dereferenced-value-may-be-null]
         }
 
         if (i > 4)
-            foreach (var _ in xs) ; // BAD (maybe)
+            foreach (var _ in xs) ; // $ Alert[cs/dereferenced-value-may-be-null]
 
         if (i > 5)
-            lock (xs) // BAD (maybe)
+            lock (xs) // $ Alert[cs/dereferenced-value-may-be-null]
                 xs.ToString(); // Not reported - same basic block
 
         if (i > 6)
@@ -122,7 +122,7 @@ public class D
             x.ToString(); // GOOD
     }
 
-    public void LengthGuard(int[] a, int[] b)
+    public void LengthGuard(int[] a, int[] b) // $ Source[cs/dereferenced-value-may-be-null]
     {
         int alen = a == null ? 0 : a.Length; // GOOD
         int blen = b == null ? 0 : b.Length; // GOOD
@@ -131,8 +131,8 @@ public class D
         {
             for (int i = 0; i < alen; i++)
             {
-                sum += a[i]; // GOOD (false positive)
-                sum += b[i]; // GOOD (false positive)
+                sum += a[i]; // $ SPURIOUS (false positive): Alert[cs/dereferenced-value-may-be-null]
+                sum += b[i]; // $ SPURIOUS (false positive): Alert[cs/dereferenced-value-may-be-null]
             }
         }
         int alen2;
@@ -142,13 +142,13 @@ public class D
             alen2 = 0;
         for (int i = 1; i <= alen2; ++i)
         {
-            sum += a[i - 1]; // GOOD (false positive)
+            sum += a[i - 1]; // $ SPURIOUS (false positive): Alert[cs/dereferenced-value-may-be-null]
         }
     }
 
-    public void MissedGuard(object obj)
+    public void MissedGuard(object obj) // $ Source[cs/dereferenced-value-may-be-null]
     {
-        obj.ToString(); // BAD (maybe)
+        obj.ToString(); // $ Alert[cs/dereferenced-value-may-be-null]
         var x = obj != null ? 1 : 0;
     }
 
@@ -160,7 +160,7 @@ public class D
 
     public void Exceptions()
     {
-        object obj = null;
+        object obj = null; // $ Source[cs/dereferenced-value-may-be-null]
         try
         {
             obj = MkMaybe();
@@ -168,7 +168,7 @@ public class D
         catch (Exception e)
         {
         }
-        obj.ToString(); // BAD (maybe)
+        obj.ToString(); // $ Alert[cs/dereferenced-value-may-be-null]
 
         object obj2 = null;
         try
@@ -237,25 +237,25 @@ public class D
         if (flag)
             o.ToString(); // GOOD
 
-        o = null;
+        o = null; // $ Source[cs/dereferenced-value-may-be-null]
         var other = maybe ? null : "";
         if (other == null)
             o = "";
         if (other != null)
-            o.ToString(); // BAD (always) (reported as maybe)
+            o.ToString(); // $ Alert[cs/dereferenced-value-may-be-null] (always - but reported as maybe)
         else
-            o.ToString(); // GOOD (false positive)
+            o.ToString(); // $ SPURIOUS (false positive): Alert[cs/dereferenced-value-may-be-null]
 
-        var o2 = (num < 0) ? null : "";
+        var o2 = (num < 0) ? null : ""; // $ Source[cs/dereferenced-value-may-be-null]
         if (num < 0)
             o2 = "";
         else
-            o2.ToString(); // GOOD (false positive)
+            o2.ToString(); // $ SPURIOUS (false positive): Alert[cs/dereferenced-value-may-be-null]
     }
 
     public void TrackingVariable(int[] a)
     {
-        object o = null;
+        object o = null; // $ Source[cs/dereferenced-value-may-be-null]
         object other = null;
         if (maybe)
         {
@@ -264,9 +264,9 @@ public class D
         }
 
         if (other is string)
-            o.ToString(); // GOOD (false positive)
+            o.ToString(); // $ SPURIOUS (false positive): Alert[cs/dereferenced-value-may-be-null]
 
-        o = null;
+        o = null; // $ Source[cs/dereferenced-value-may-be-null]
         int count = 0;
         var found = false;
         for (var i = 0; i < a.Length; i++)
@@ -280,7 +280,7 @@ public class D
             }
             if (a[i] > 10000)
             {
-                o = null;
+                o = null; // $ Source[cs/dereferenced-value-may-be-null]
                 count = 0;
                 if (2 > i) { }
                 found = false;
@@ -288,20 +288,20 @@ public class D
         }
 
         if (count > 3)
-            o.ToString(); // GOOD (false positive)
+            o.ToString(); // $ SPURIOUS (false positive): Alert[cs/dereferenced-value-may-be-null]
 
         if (found)
-            o.ToString(); // GOOD (false positive)
+            o.ToString(); // $ SPURIOUS (false positive): Alert[cs/dereferenced-value-may-be-null]
 
-        object prev = null;
+        object prev = null; // $ Source[cs/dereferenced-value-may-be-null]
         for (var i = 0; i < a.Length; ++i)
         {
             if (i != 0)
-                prev.ToString(); // GOOD (false positive)
+                prev.ToString(); // $ SPURIOUS (false positive): Alert[cs/dereferenced-value-may-be-null]
             prev = a[i];
         }
 
-        string s = null;
+        string s = null; // $ Source[cs/dereferenced-value-may-be-null]
         {
             var s_null = true;
             foreach (var i in a)
@@ -310,10 +310,10 @@ public class D
                 s = "" + a;
             }
             if (!s_null)
-                s.ToString(); // GOOD (false positive)
+                s.ToString(); // $ SPURIOUS (false positive): Alert[cs/dereferenced-value-may-be-null]
         }
 
-        object r = null;
+        object r = null; // $ Source[cs/dereferenced-value-may-be-null]
         var stat = MyStatus.INIT;
         while (stat == MyStatus.INIT && stat != MyStatus.READY)
         {
@@ -321,7 +321,7 @@ public class D
             if (stat == MyStatus.INIT)
                 stat = MyStatus.READY;
         }
-        r.ToString(); // GOOD (false positive)
+        r.ToString(); // $ SPURIOUS (false positive): Alert[cs/dereferenced-value-may-be-null]
     }
 
     public enum MyStatus
@@ -348,28 +348,28 @@ public class D
 
     public void LoopCorr(int iters)
     {
-        int[] a = null;
+        int[] a = null; // $ Source[cs/dereferenced-value-may-be-null]
         if (iters > 0)
             a = new int[iters];
 
         for (var i = 0; i < iters; ++i)
-            a[i] = 0; // GOOD (false positive)
+            a[i] = 0; // $ SPURIOUS (false positive): Alert[cs/dereferenced-value-may-be-null]
 
         if (iters > 0)
         {
-            string last = null;
+            string last = null; // $ Source[cs/dereferenced-value-may-be-null]
             for (var i = 0; i < iters; i++)
                 last = "abc";
-            last.ToString(); // GOOD (false positive)
+            last.ToString(); // $ SPURIOUS (false positive): Alert[cs/dereferenced-value-may-be-null]
         }
 
-        int[] b = maybe ? null : new int[iters];
+        int[] b = maybe ? null : new int[iters]; // $ Source[cs/dereferenced-value-may-be-null]
         if (iters > 0 && (b == null || b.Length < iters))
             throw new Exception();
 
         for (var i = 0; i < iters; ++i)
         {
-            b[i] = 0; // GOOD (false positive)
+            b[i] = 0; // $ SPURIOUS (false positive): Alert[cs/dereferenced-value-may-be-null]
         }
     }
 
@@ -385,30 +385,30 @@ public class D
             ioe.ToString(); // $ Alert[cs/dereferenced-value-is-always-null]
     }
 
-    public void LengthGuard2(int[] a, int[] b)
+    public void LengthGuard2(int[] a, int[] b) // $ Source[cs/dereferenced-value-may-be-null]
     {
         int alen = a == null ? 0 : a.Length; // GOOD
         int sum = 0;
         int i;
         for (i = 0; i < alen; i++)
         {
-            sum += a[i]; // GOOD (false positive)
+            sum += a[i]; // $ SPURIOUS (false positive): Alert[cs/dereferenced-value-may-be-null]
         }
         int blen = b == null ? 0 : b.Length; // GOOD
         for (i = 0; i < blen; i++)
         {
-            sum += b[i]; // GOOD (false positive)
+            sum += b[i]; // $ SPURIOUS (false positive): Alert[cs/dereferenced-value-may-be-null]
         }
         i = -3;
     }
 
-    public void CorrConds2(object x, object y)
+    public void CorrConds2(object x, object y) // $ Source[cs/dereferenced-value-may-be-null]
     {
         if ((x != null && y == null) || (x == null && y != null))
             return;
         if (x != null)
-            y.ToString(); // GOOD (false positive)
+            y.ToString(); // $ SPURIOUS (false positive): Alert[cs/dereferenced-value-may-be-null]
         if (y != null)
-            x.ToString(); // GOOD (false positive)
+            x.ToString(); // $ SPURIOUS (false positive): Alert[cs/dereferenced-value-may-be-null]
     }
 }

--- a/csharp/ql/test/query-tests/Nullness/E.cs
+++ b/csharp/ql/test/query-tests/Nullness/E.cs
@@ -6,12 +6,12 @@ public class E
 {
     public void Ex1(long[][][] a1, int ix, int len)
     {
-        long[][] a2 = null;
+        long[][] a2 = null; // $ Source[cs/dereferenced-value-may-be-null]
         var haveA2 = ix < len && (a2 = a1[ix]) != null;
-        long[] a3 = null;
-        var haveA3 = haveA2 && (a3 = a2[ix]) != null; // GOOD (FALSE POSITIVE)
+        long[] a3 = null; // $ Source[cs/dereferenced-value-may-be-null]
+        var haveA3 = haveA2 && (a3 = a2[ix]) != null; // $ SPURIOUS (false positive): Alert[cs/dereferenced-value-may-be-null]
         if (haveA3)
-            a3[0] = 0; // GOOD (FALSE POSITIVE)
+            a3[0] = 0; // $ SPURIOUS (false positive): Alert[cs/dereferenced-value-may-be-null]
     }
 
     public void Ex2(bool x, bool y)
@@ -20,11 +20,11 @@ public class E
         var s2 = (s1 == null) ? null : "";
         if (s2 == null)
         {
-            s1 = y ? null : "";
+            s1 = y ? null : ""; // $ Source[cs/dereferenced-value-may-be-null]
             s2 = (s1 == null) ? null : "";
         }
         if (s2 != null)
-            s1.ToString(); // GOOD (FALSE POSITIVE)
+            s1.ToString(); // $ SPURIOUS (false positive): Alert[cs/dereferenced-value-may-be-null]
     }
 
     public void Ex3(IEnumerable<string> ss)
@@ -48,7 +48,7 @@ public class E
     {
         int index = 0;
         var result = new List<List<string>>();
-        List<string> slice = null;
+        List<string> slice = null; // $ Source[cs/dereferenced-value-may-be-null]
         var iter = list.GetEnumerator();
         while (iter.MoveNext())
         {
@@ -58,19 +58,19 @@ public class E
                 slice = new List<string>();
                 result.Add(slice);
             }
-            slice.Add(str); // GOOD (FALSE POSITIVE)
+            slice.Add(str); // $ SPURIOUS (false positive): Alert[cs/dereferenced-value-may-be-null]
             ++index;
         }
     }
 
-    public void Ex5(bool hasArr, int[] arr)
+    public void Ex5(bool hasArr, int[] arr) // $ Source[cs/dereferenced-value-may-be-null]
     {
         int arrLen = 0;
         if (hasArr)
             arrLen = arr == null ? 0 : arr.Length;
 
         if (arrLen > 0)
-            arr[0] = 0; // GOOD (FALSE POSITIVE)
+            arr[0] = 0; // $ SPURIOUS (false positive): Alert[cs/dereferenced-value-may-be-null]
     }
 
     public const int MY_CONST_A = 1;
@@ -104,12 +104,12 @@ public class E
 
     public void Ex7(int[] arr1)
     {
-        int[] arr2 = null;
+        int[] arr2 = null; // $ Source[cs/dereferenced-value-may-be-null]
         if (arr1.Length > 0)
             arr2 = new int[arr1.Length];
 
         for (var i = 0; i < arr1.Length; i++)
-            arr2[i] = arr1[i]; // GOOD (FALSE POSITIVE)
+            arr2[i] = arr1[i]; // $ SPURIOUS (false positive): Alert[cs/dereferenced-value-may-be-null]
     }
 
     public void Ex8(int x, int lim)
@@ -122,7 +122,7 @@ public class E
             int j = 0;
             while (!stop && j < lim)
             {
-                int step = (j * obj.GetHashCode()) % 10; // GOOD (FALSE POSITIVE)
+                int step = (j * obj.GetHashCode()) % 10; // $ SPURIOUS (false positive): Alert[cs/dereferenced-value-may-be-null]
                 if (step == 0)
                 {
                     obj.ToString(); // GOOD
@@ -134,7 +134,7 @@ public class E
                     }
                     else
                     {
-                        obj = null;
+                        obj = null; // $ Source[cs/dereferenced-value-may-be-null]
                     }
                     continue;
                 }
@@ -149,33 +149,33 @@ public class E
         {
             return;
         }
-        object obj2 = obj1;
+        object obj2 = obj1; // $ Source[cs/dereferenced-value-may-be-null]
         if (obj2 != null && obj2.GetHashCode() % 5 > 2)
         {
             obj2.ToString(); // GOOD
             cond = true;
         }
         if (cond)
-            obj2.ToString(); // GOOD (FALSE POSITIVE)
+            obj2.ToString(); // $ SPURIOUS (false positive): Alert[cs/dereferenced-value-may-be-null]
     }
 
-    public void Ex10(int[] a)
+    public void Ex10(int[] a) // $ Source[cs/dereferenced-value-may-be-null]
     {
         int n = a == null ? 0 : a.Length;
         for (var i = 0; i < n; i++)
         {
-            int x = a[i]; // GOOD (FALSE POSITIVE)
+            int x = a[i]; // $ SPURIOUS (false positive): Alert[cs/dereferenced-value-may-be-null]
             if (x > 7)
                 a = new int[n];
         }
     }
 
-    public void Ex11(object obj, bool b1)
+    public void Ex11(object obj, bool b1) // $ Source[cs/dereferenced-value-may-be-null]
     {
         bool b2 = obj == null ? false : b1;
         if (b2 == null)
         {
-            obj.ToString(); // GOOD (FALSE POSITIVE)
+            obj.ToString(); // $ SPURIOUS (false positive): Alert[cs/dereferenced-value-may-be-null]
         }
         if (obj == null)
         {
@@ -183,24 +183,24 @@ public class E
         }
         if (b1 == null)
         {
-            obj.ToString(); // GOOD (FALSE POSITIVE)
+            obj.ToString(); // $ SPURIOUS (false positive): Alert[cs/dereferenced-value-may-be-null]
         }
     }
 
-    public void Ex12(object o)
+    public void Ex12(object o) // $ Source[cs/dereferenced-value-may-be-null]
     {
-        var i = o.GetHashCode(); // BAD (maybe)
+        var i = o.GetHashCode(); // $ Alert[cs/dereferenced-value-may-be-null]
         var s = o?.ToString();
     }
 
     public void Ex13(bool b)
     {
-        var o = b ? null : "";
+        var o = b ? null : ""; // $ Source[cs/dereferenced-value-may-be-null]
         o.M1(); // GOOD
         if (b)
-            o.M2(); // BAD (maybe)
+            o.M2(); // $ Alert[cs/dereferenced-value-may-be-null]
         else
-            o.Select(x => x); // BAD (maybe)
+            o.Select(x => x); // $ Alert[cs/dereferenced-value-may-be-null]
     }
 
     public int Ex14(string s)
@@ -214,8 +214,8 @@ public class E
     {
         var x = "";
         if (b)
-            x = null;
-        x.ToString(); // BAD (maybe)
+            x = null; // $ Source[cs/dereferenced-value-may-be-null]
+        x.ToString(); // $ Alert[cs/dereferenced-value-may-be-null]
         if (b)
             x.ToString(); // $ Alert[cs/dereferenced-value-is-always-null]
     }
@@ -224,20 +224,20 @@ public class E
     {
         var x = "";
         if (b)
-            x = null;
+            x = null; // $ Source[cs/dereferenced-value-may-be-null]
         if (b)
             x.ToString(); // $ Alert[cs/dereferenced-value-is-always-null]
-        x.ToString(); // BAD (maybe)
+        x.ToString(); // $ Alert[cs/dereferenced-value-may-be-null]
     }
 
-    public int Ex17(int? i)
+    public int Ex17(int? i) // $ Source[cs/dereferenced-value-may-be-null]
     {
-        return i.Value; // BAD (maybe)
+        return i.Value; // $ Alert[cs/dereferenced-value-may-be-null]
     }
 
-    public int Ex18(int? i)
+    public int Ex18(int? i) // $ Source[cs/dereferenced-value-may-be-null]
     {
-        return (int)i; // BAD (maybe)
+        return (int)i; // $ Alert[cs/dereferenced-value-may-be-null]
     }
 
     public int Ex19(int? i)
@@ -280,9 +280,9 @@ public class E
     {
         if (b)
             b.ToString();
-        var o = Make();
+        var o = Make(); // $ Source[cs/dereferenced-value-may-be-null]
         o?.ToString();
-        o.ToString(); // BAD (maybe)
+        o.ToString(); // $ Alert[cs/dereferenced-value-may-be-null]
         if (b)
             b.ToString();
     }
@@ -298,8 +298,8 @@ public class E
 
     public void Ex25(object o)
     {
-        var s = o as string;
-        s.ToString(); // BAD (maybe)
+        var s = o as string; // $ Source[cs/dereferenced-value-may-be-null]
+        s.ToString(); // $ Alert[cs/dereferenced-value-may-be-null]
     }
 
     private long? l;
@@ -339,14 +339,14 @@ public class E
 
     static void Ex30(string s, object o)
     {
-        var x = s ?? o as string;
-        x.ToString(); // BAD (maybe)
+        var x = s ?? o as string; // $ Source[cs/dereferenced-value-may-be-null]
+        x.ToString(); // $ Alert[cs/dereferenced-value-may-be-null]
     }
 
     static void Ex31(string s, object o)
     {
-        dynamic x = s ?? o as string;
-        x.ToString(); // BAD (maybe)
+        dynamic x = s ?? o as string; // $ Source[cs/dereferenced-value-may-be-null]
+        x.ToString(); // $ Alert[cs/dereferenced-value-may-be-null]
     }
 
     static void Ex32(string s, object o)
@@ -363,7 +363,7 @@ public class E
             x.ToString(); // GOOD
     }
 
-    static int Ex34(string s = null) => s.Length; // BAD (maybe)
+    static int Ex34(string s = null) => s.Length; // $ Alert[cs/dereferenced-value-may-be-null]
 
     static int Ex35(string s = "null") => s.Length; // GOOD
 
@@ -371,19 +371,19 @@ public class E
     {
         if (o is string)
         {
-            var s = o as string;
-            return s.Length; // GOOD (FALSE POSITIVE)
+            var s = o as string; // $ Source[cs/dereferenced-value-may-be-null]
+            return s.Length; // $ SPURIOUS (false positive): Alert[cs/dereferenced-value-may-be-null]
         }
         return -1;
     }
 
-    static bool Ex37(E e1, E e2)
+    static bool Ex37(E e1, E e2) // $ Source[cs/dereferenced-value-may-be-null]
     {
         if ((e1 == null && e2 != null) || (e1 != null && e2 == null))
             return false;
         if (e1 == null && e2 == null)
             return true;
-        return e1.Long == e2.Long; // GOOD (FALSE POSITIVE)
+        return e1.Long == e2.Long; // $ SPURIOUS (false positive): Alert[cs/dereferenced-value-may-be-null]
     }
 
     int Ex38(int? i)
@@ -414,20 +414,20 @@ public class E
 
     static bool Ex42(int? i, IEnumerable<int> @is)
     {
-        return @is.Any(j => j == i.Value); // BAD (maybe)
+        return @is.Any(j => j == i.Value); // $ Alert[cs/dereferenced-value-may-be-null]
     }
 
     static bool Ex43(int? i, IEnumerable<int> @is)
     {
         if (i.HasValue)
-            return @is.Any(j => j == i.Value); // GOOD (FALSE POSITIVE)
+            return @is.Any(j => j == i.Value); // $ SPURIOUS (false positive): Alert[cs/dereferenced-value-may-be-null]
         return false;
     }
 
     static bool Ex44(int? i, IEnumerable<int> @is)
     {
         if (i.HasValue)
-            @is = @is.Where(j => j == i.Value); // BAD (always)
+            @is = @is.Where(j => j == i.Value); // $ Alert[cs/dereferenced-value-may-be-null]
         i = null;
         return @is.Any();
     }

--- a/csharp/ql/test/query-tests/Nullness/E.cs
+++ b/csharp/ql/test/query-tests/Nullness/E.cs
@@ -207,7 +207,7 @@ public class E
     {
         if (s is string)
             return s.Length;
-        return s.GetHashCode(); // BAD (always)
+        return s.GetHashCode(); // $ Alert[cs/dereferenced-value-is-always-null]
     }
 
     public void Ex15(bool b)
@@ -217,7 +217,7 @@ public class E
             x = null;
         x.ToString(); // BAD (maybe)
         if (b)
-            x.ToString(); // BAD (always)
+            x.ToString(); // $ Alert[cs/dereferenced-value-is-always-null]
     }
 
     public void Ex16(bool b)
@@ -226,7 +226,7 @@ public class E
         if (b)
             x = null;
         if (b)
-            x.ToString(); // BAD (always)
+            x.ToString(); // $ Alert[cs/dereferenced-value-is-always-null]
         x.ToString(); // BAD (maybe)
     }
 
@@ -320,15 +320,15 @@ public class E
     {
         if ((s1 ?? s2) is null)
         {
-            s1.ToString(); // BAD (always)
-            s2.ToString(); // BAD (always)
+            s1.ToString(); // $ Alert[cs/dereferenced-value-is-always-null]
+            s2.ToString(); // $ Alert[cs/dereferenced-value-is-always-null]
         }
     }
 
     static void Ex28()
     {
         var x = (string)null ?? null;
-        x.ToString(); // BAD (always)
+        x.ToString(); // $ Alert[cs/dereferenced-value-is-always-null]
     }
 
     static void Ex29(string s)
@@ -402,7 +402,7 @@ public class E
     {
         int? i = null;
         i ??= null;
-        return i.Value; // BAD (always)
+        return i.Value; // $ Alert[cs/dereferenced-value-is-always-null]
     }
 
     int Ex41()
@@ -436,12 +436,12 @@ public class E
     {
         if (s is null)
         {
-            s.ToString(); // BAD (always)
+            s.ToString(); // $ Alert[cs/dereferenced-value-is-always-null]
         }
 
         if (s is not not null)
         {
-            s.ToString(); // BAD (always) (FALSE NEGATIVE)
+            s.ToString(); // $ MISSING: Alert[cs/dereferenced-value-is-always-null]
         }
 
         if (s is not null)

--- a/csharp/ql/test/query-tests/Nullness/F.cs
+++ b/csharp/ql/test/query-tests/Nullness/F.cs
@@ -1,0 +1,16 @@
+using Library;
+
+public class F
+{
+    public void M1()
+    {
+        object o = null;
+        o.Accept(); // $ Alert[cs/dereferenced-value-is-always-null]
+    }
+
+    public void M2()
+    {
+        object? o = null;
+        o.AcceptNullable();
+    }
+}

--- a/csharp/ql/test/query-tests/Nullness/Forwarding.cs
+++ b/csharp/ql/test/query-tests/Nullness/Forwarding.cs
@@ -33,11 +33,11 @@ class ForwardingTests
 
         if (IsNotNullWrong(s))
         {
-            Console.WriteLine(s.Length); // BAD (always)
+            Console.WriteLine(s.Length); // $ Alert[cs/dereferenced-value-is-always-null]
         }
 
         AssertIsNotNull(s);
-        Console.WriteLine(s.Length); // GOOD (false positive)
+        Console.WriteLine(s.Length); // $ SPURIOUS (false positive): Alert[cs/dereferenced-value-is-always-null]
     }
 
     bool IsNotNull(object o)

--- a/csharp/ql/test/query-tests/Nullness/GuardedString.cs
+++ b/csharp/ql/test/query-tests/Nullness/GuardedString.cs
@@ -4,7 +4,7 @@ class GuardedStringTest
 {
     void Fn(bool b)
     {
-        string s = b ? null : "";
+        string s = b ? null : ""; // $ Source[cs/dereferenced-value-may-be-null]
 
         if (!string.IsNullOrEmpty(s))
         {
@@ -32,7 +32,7 @@ class GuardedStringTest
             Console.WriteLine(s.Length); // GOOD
 
         if (s?.Length != 0)
-            Console.WriteLine(s.Length); // BAD (maybe)
+            Console.WriteLine(s.Length); // $ Alert[cs/dereferenced-value-may-be-null]
         else
             Console.WriteLine(s.Length); // GOOD
     }

--- a/csharp/ql/test/query-tests/Nullness/Implications.expected
+++ b/csharp/ql/test/query-tests/Nullness/Implications.expected
@@ -1305,6 +1305,10 @@
 | E.cs:442:13:442:29 | ... is ... | true | E.cs:442:13:442:13 | access to parameter s | non-null |
 | E.cs:447:13:447:25 | ... is ... | true | E.cs:447:13:447:13 | access to parameter s | non-null |
 | E.cs:452:13:452:23 | ... is ... | true | E.cs:452:13:452:13 | access to parameter s | non-null |
+| F.cs:8:9:8:9 | access to local variable o | non-null | F.cs:7:20:7:23 | null | non-null |
+| F.cs:8:9:8:9 | access to local variable o | null | F.cs:7:20:7:23 | null | null |
+| F.cs:14:9:14:9 | access to local variable o | non-null | F.cs:13:21:13:24 | null | non-null |
+| F.cs:14:9:14:9 | access to local variable o | null | F.cs:13:21:13:24 | null | null |
 | Forwarding.cs:9:13:9:30 | !... | false | Forwarding.cs:9:14:9:30 | call to method IsNullOrEmpty | true |
 | Forwarding.cs:9:13:9:30 | !... | true | Forwarding.cs:9:14:9:30 | call to method IsNullOrEmpty | false |
 | Forwarding.cs:9:14:9:14 | access to local variable s | empty | Forwarding.cs:7:20:7:23 | null | empty |

--- a/csharp/ql/test/query-tests/Nullness/NullAlways.expected
+++ b/csharp/ql/test/query-tests/Nullness/NullAlways.expected
@@ -1,3 +1,4 @@
+#select
 | A.cs:8:15:8:32 | access to local variable synchronizedAlways | Variable $@ is always null at this dereference. | A.cs:7:16:7:33 | synchronizedAlways | synchronizedAlways |
 | A.cs:17:9:17:17 | access to local variable arrayNull | Variable $@ is always null at this dereference. | A.cs:16:15:16:23 | arrayNull | arrayNull |
 | A.cs:31:27:31:37 | access to local variable arrayAccess | Variable $@ is always null at this dereference. | A.cs:26:15:26:25 | arrayAccess | arrayAccess |
@@ -38,6 +39,10 @@
 | E.cs:331:9:331:9 | access to local variable x | Variable $@ is always null at this dereference. | E.cs:330:13:330:13 | x | x |
 | E.cs:405:16:405:16 | access to local variable i | Variable $@ is always null at this dereference. | E.cs:403:14:403:14 | i | i |
 | E.cs:439:13:439:13 | access to parameter s | Variable $@ is always null at this dereference. | E.cs:435:29:435:29 | s | s |
+| F.cs:8:9:8:9 | access to local variable o | Variable $@ is always null at this dereference. | F.cs:7:16:7:16 | o | o |
+| F.cs:14:9:14:9 | access to local variable o | Variable $@ is always null at this dereference. | F.cs:13:17:13:17 | o | o |
 | Forwarding.cs:36:31:36:31 | access to local variable s | Variable $@ is always null at this dereference. | Forwarding.cs:7:16:7:16 | s | s |
 | Forwarding.cs:40:27:40:27 | access to local variable s | Variable $@ is always null at this dereference. | Forwarding.cs:7:16:7:16 | s | s |
 | NullAlwaysBad.cs:9:30:9:30 | access to parameter s | Variable $@ is always null at this dereference. | NullAlwaysBad.cs:7:29:7:29 | s | s |
+testFailures
+| F.cs:14:9:14:9 | Variable $@ is always null at this dereference. | Unexpected result: Alert |

--- a/csharp/ql/test/query-tests/Nullness/NullAlways.expected
+++ b/csharp/ql/test/query-tests/Nullness/NullAlways.expected
@@ -1,4 +1,3 @@
-#select
 | A.cs:8:15:8:32 | access to local variable synchronizedAlways | Variable $@ is always null at this dereference. | A.cs:7:16:7:33 | synchronizedAlways | synchronizedAlways |
 | A.cs:17:9:17:17 | access to local variable arrayNull | Variable $@ is always null at this dereference. | A.cs:16:15:16:23 | arrayNull | arrayNull |
 | A.cs:31:27:31:37 | access to local variable arrayAccess | Variable $@ is always null at this dereference. | A.cs:26:15:26:25 | arrayAccess | arrayAccess |
@@ -40,9 +39,6 @@
 | E.cs:405:16:405:16 | access to local variable i | Variable $@ is always null at this dereference. | E.cs:403:14:403:14 | i | i |
 | E.cs:439:13:439:13 | access to parameter s | Variable $@ is always null at this dereference. | E.cs:435:29:435:29 | s | s |
 | F.cs:8:9:8:9 | access to local variable o | Variable $@ is always null at this dereference. | F.cs:7:16:7:16 | o | o |
-| F.cs:14:9:14:9 | access to local variable o | Variable $@ is always null at this dereference. | F.cs:13:17:13:17 | o | o |
 | Forwarding.cs:36:31:36:31 | access to local variable s | Variable $@ is always null at this dereference. | Forwarding.cs:7:16:7:16 | s | s |
 | Forwarding.cs:40:27:40:27 | access to local variable s | Variable $@ is always null at this dereference. | Forwarding.cs:7:16:7:16 | s | s |
 | NullAlwaysBad.cs:9:30:9:30 | access to parameter s | Variable $@ is always null at this dereference. | NullAlwaysBad.cs:7:29:7:29 | s | s |
-testFailures
-| F.cs:14:9:14:9 | Variable $@ is always null at this dereference. | Unexpected result: Alert |

--- a/csharp/ql/test/query-tests/Nullness/NullAlways.qlref
+++ b/csharp/ql/test/query-tests/Nullness/NullAlways.qlref
@@ -1,1 +1,2 @@
-CSI/NullAlways.ql
+query: CSI/NullAlways.ql
+postprocess: utils/test/InlineExpectationsTestQuery.ql

--- a/csharp/ql/test/query-tests/Nullness/NullAlwaysBad.cs
+++ b/csharp/ql/test/query-tests/Nullness/NullAlwaysBad.cs
@@ -6,7 +6,7 @@ namespace NullAlways
     {
         void DoPrint(string s)
         {
-            if (s != null || s.Length > 0)
+            if (s != null || s.Length > 0) // $ Alert[cs/dereferenced-value-is-always-null]
                 Console.WriteLine(s);
         }
     }

--- a/csharp/ql/test/query-tests/Nullness/NullMaybe.expected
+++ b/csharp/ql/test/query-tests/Nullness/NullMaybe.expected
@@ -447,7 +447,6 @@ edges
 | E.cs:435:29:435:29 | SSA param(s) | E.cs:437:13:437:21 | [true] ... is ... |
 | E.cs:437:13:437:21 | [true] ... is ... | E.cs:439:13:439:13 | access to parameter s |
 | F.cs:7:16:7:23 | SSA def(o) | F.cs:8:9:8:9 | access to local variable o |
-| F.cs:13:17:13:24 | SSA def(o) | F.cs:14:9:14:9 | access to local variable o |
 | Forwarding.cs:7:16:7:23 | SSA def(s) | Forwarding.cs:9:13:9:30 | [false] !... |
 | Forwarding.cs:9:13:9:30 | [false] !... | Forwarding.cs:14:9:17:9 | if (...) ... |
 | Forwarding.cs:14:9:17:9 | if (...) ... | Forwarding.cs:19:9:22:9 | if (...) ... |
@@ -898,8 +897,6 @@ nodes
 | E.cs:439:13:439:13 | access to parameter s |
 | F.cs:7:16:7:23 | SSA def(o) |
 | F.cs:8:9:8:9 | access to local variable o |
-| F.cs:13:17:13:24 | SSA def(o) |
-| F.cs:14:9:14:9 | access to local variable o |
 | Forwarding.cs:7:16:7:23 | SSA def(s) |
 | Forwarding.cs:9:13:9:30 | [false] !... |
 | Forwarding.cs:14:9:17:9 | if (...) ... |

--- a/csharp/ql/test/query-tests/Nullness/NullMaybe.expected
+++ b/csharp/ql/test/query-tests/Nullness/NullMaybe.expected
@@ -1,3 +1,484 @@
+#select
+| C.cs:64:9:64:10 | access to local variable o1 | C.cs:62:13:62:46 | SSA def(o1) | C.cs:64:9:64:10 | access to local variable o1 | Variable $@ may be null at this access because of $@ assignment. | C.cs:62:13:62:14 | o1 | o1 | C.cs:62:13:62:46 | Object o1 = ... | this |
+| C.cs:68:9:68:10 | access to local variable o2 | C.cs:66:13:66:46 | SSA def(o2) | C.cs:68:9:68:10 | access to local variable o2 | Variable $@ may be null at this access because of $@ assignment. | C.cs:66:13:66:14 | o2 | o2 | C.cs:66:13:66:46 | Object o2 = ... | this |
+| C.cs:95:15:95:15 | access to local variable o | C.cs:94:13:94:45 | SSA def(o) | C.cs:95:15:95:15 | access to local variable o | Variable $@ may be null at this access because of $@ assignment. | C.cs:94:13:94:13 | o | o | C.cs:94:13:94:45 | Object o = ... | this |
+| C.cs:103:27:103:30 | access to parameter list | C.cs:102:13:102:23 | SSA def(list) | C.cs:103:27:103:30 | access to parameter list | Variable $@ may be null at this access because of $@ assignment. | C.cs:99:42:99:45 | list | list | C.cs:102:13:102:23 | ... = ... | this |
+| C.cs:177:13:177:13 | access to local variable s | C.cs:178:13:178:20 | SSA def(s) | C.cs:177:13:177:13 | access to local variable s | Variable $@ may be null at this access because of $@ assignment. | C.cs:151:13:151:13 | s | s | C.cs:178:13:178:20 | ... = ... | this |
+| C.cs:203:13:203:13 | access to local variable s | C.cs:204:13:204:20 | SSA def(s) | C.cs:203:13:203:13 | access to local variable s | Variable $@ may be null at this access because of $@ assignment. | C.cs:185:13:185:13 | s | s | C.cs:204:13:204:20 | ... = ... | this |
+| C.cs:223:9:223:9 | access to local variable s | C.cs:222:13:222:20 | SSA def(s) | C.cs:223:9:223:9 | access to local variable s | Variable $@ may be null at this access because of $@ assignment. | C.cs:210:13:210:13 | s | s | C.cs:222:13:222:20 | ... = ... | this |
+| C.cs:242:13:242:13 | access to local variable s | C.cs:240:24:240:31 | SSA def(s) | C.cs:242:13:242:13 | access to local variable s | Variable $@ may be null at this access because of $@ assignment. | C.cs:228:16:228:16 | s | s | C.cs:240:24:240:31 | ... = ... | this |
+| D.cs:23:9:23:13 | access to parameter param | D.cs:17:17:17:20 | null | D.cs:23:9:23:13 | access to parameter param | Variable $@ may be null at this access because of $@ null argument. | D.cs:21:32:21:36 | param | param | D.cs:17:17:17:20 | null | this |
+| D.cs:32:9:32:13 | access to parameter param | D.cs:26:32:26:36 | SSA param(param) | D.cs:32:9:32:13 | access to parameter param | Variable $@ may be null at this access as suggested by $@ null check. | D.cs:26:32:26:36 | param | param | D.cs:28:13:28:25 | ... != ... | this |
+| D.cs:62:13:62:14 | access to local variable o5 | D.cs:58:13:58:41 | SSA def(o5) | D.cs:62:13:62:14 | access to local variable o5 | Variable $@ may be null at this access because of $@ assignment. | D.cs:58:13:58:14 | o5 | o5 | D.cs:58:13:58:41 | String o5 = ... | this |
+| D.cs:73:13:73:14 | access to local variable o7 | D.cs:68:13:68:34 | SSA def(o7) | D.cs:73:13:73:14 | access to local variable o7 | Variable $@ may be null at this access because of $@ assignment. | D.cs:68:13:68:14 | o7 | o7 | D.cs:68:13:68:34 | String o7 = ... | this |
+| D.cs:82:13:82:14 | access to local variable o8 | D.cs:75:13:75:34 | SSA def(o8) | D.cs:82:13:82:14 | access to local variable o8 | Variable $@ may be null at this access because of $@ assignment. | D.cs:75:13:75:14 | o8 | o8 | D.cs:75:13:75:34 | String o8 = ... | this |
+| D.cs:84:13:84:14 | access to local variable o8 | D.cs:75:13:75:34 | SSA def(o8) | D.cs:84:13:84:14 | access to local variable o8 | Variable $@ may be null at this access because of $@ assignment. | D.cs:75:13:75:14 | o8 | o8 | D.cs:75:13:75:34 | String o8 = ... | this |
+| D.cs:91:13:91:14 | access to local variable xs | D.cs:89:15:89:44 | SSA def(xs) | D.cs:91:13:91:14 | access to local variable xs | Variable $@ may be null at this access because of $@ assignment. | D.cs:89:15:89:16 | xs | xs | D.cs:89:15:89:44 | Int32[] xs = ... | this |
+| D.cs:94:21:94:22 | access to local variable xs | D.cs:89:15:89:44 | SSA def(xs) | D.cs:94:21:94:22 | access to local variable xs | Variable $@ may be null at this access because of $@ assignment. | D.cs:89:15:89:16 | xs | xs | D.cs:89:15:89:44 | Int32[] xs = ... | this |
+| D.cs:98:21:98:22 | access to local variable xs | D.cs:89:15:89:44 | SSA def(xs) | D.cs:98:21:98:22 | access to local variable xs | Variable $@ may be null at this access because of $@ assignment. | D.cs:89:15:89:16 | xs | xs | D.cs:89:15:89:44 | Int32[] xs = ... | this |
+| D.cs:102:31:102:32 | access to local variable xs | D.cs:89:15:89:44 | SSA def(xs) | D.cs:102:31:102:32 | access to local variable xs | Variable $@ may be null at this access because of $@ assignment. | D.cs:89:15:89:16 | xs | xs | D.cs:89:15:89:44 | Int32[] xs = ... | this |
+| D.cs:105:19:105:20 | access to local variable xs | D.cs:89:15:89:44 | SSA def(xs) | D.cs:105:19:105:20 | access to local variable xs | Variable $@ may be null at this access because of $@ assignment. | D.cs:89:15:89:16 | xs | xs | D.cs:89:15:89:44 | Int32[] xs = ... | this |
+| D.cs:134:24:134:24 | access to parameter a | D.cs:125:35:125:35 | SSA param(a) | D.cs:134:24:134:24 | access to parameter a | Variable $@ may be null at this access as suggested by $@ null check. | D.cs:125:35:125:35 | a | a | D.cs:127:20:127:28 | ... == ... | this |
+| D.cs:134:24:134:24 | access to parameter a | D.cs:125:35:125:35 | SSA param(a) | D.cs:134:24:134:24 | access to parameter a | Variable $@ may be null at this access as suggested by $@ null check. | D.cs:125:35:125:35 | a | a | D.cs:139:13:139:21 | ... != ... | this |
+| D.cs:135:24:135:24 | access to parameter b | D.cs:125:44:125:44 | SSA param(b) | D.cs:135:24:135:24 | access to parameter b | Variable $@ may be null at this access as suggested by $@ null check. | D.cs:125:44:125:44 | b | b | D.cs:128:20:128:28 | ... == ... | this |
+| D.cs:145:20:145:20 | access to parameter a | D.cs:125:35:125:35 | SSA param(a) | D.cs:145:20:145:20 | access to parameter a | Variable $@ may be null at this access as suggested by $@ null check. | D.cs:125:35:125:35 | a | a | D.cs:127:20:127:28 | ... == ... | this |
+| D.cs:145:20:145:20 | access to parameter a | D.cs:125:35:125:35 | SSA param(a) | D.cs:145:20:145:20 | access to parameter a | Variable $@ may be null at this access as suggested by $@ null check. | D.cs:125:35:125:35 | a | a | D.cs:139:13:139:21 | ... != ... | this |
+| D.cs:151:9:151:11 | access to parameter obj | D.cs:149:36:149:38 | SSA param(obj) | D.cs:151:9:151:11 | access to parameter obj | Variable $@ may be null at this access as suggested by $@ null check. | D.cs:149:36:149:38 | obj | obj | D.cs:152:17:152:27 | ... != ... | this |
+| D.cs:171:9:171:11 | access to local variable obj | D.cs:163:16:163:25 | SSA def(obj) | D.cs:171:9:171:11 | access to local variable obj | Variable $@ may be null at this access because of $@ assignment. | D.cs:163:16:163:18 | obj | obj | D.cs:163:16:163:25 | Object obj = ... | this |
+| D.cs:245:13:245:13 | access to local variable o | D.cs:240:9:240:16 | SSA def(o) | D.cs:245:13:245:13 | access to local variable o | Variable $@ may be null at this access because of $@ assignment. | D.cs:228:16:228:16 | o | o | D.cs:240:9:240:16 | ... = ... | this |
+| D.cs:247:13:247:13 | access to local variable o | D.cs:240:9:240:16 | SSA def(o) | D.cs:247:13:247:13 | access to local variable o | Variable $@ may be null at this access because of $@ assignment. | D.cs:228:16:228:16 | o | o | D.cs:240:9:240:16 | ... = ... | this |
+| D.cs:253:13:253:14 | access to local variable o2 | D.cs:249:13:249:38 | SSA def(o2) | D.cs:253:13:253:14 | access to local variable o2 | Variable $@ may be null at this access because of $@ assignment. | D.cs:249:13:249:14 | o2 | o2 | D.cs:249:13:249:38 | String o2 = ... | this |
+| D.cs:267:13:267:13 | access to local variable o | D.cs:258:16:258:23 | SSA def(o) | D.cs:267:13:267:13 | access to local variable o | Variable $@ may be null at this access because of $@ assignment. | D.cs:258:16:258:16 | o | o | D.cs:258:16:258:23 | Object o = ... | this |
+| D.cs:291:13:291:13 | access to local variable o | D.cs:269:9:269:16 | SSA def(o) | D.cs:291:13:291:13 | access to local variable o | Variable $@ may be null at this access because of $@ assignment. | D.cs:258:16:258:16 | o | o | D.cs:269:9:269:16 | ... = ... | this |
+| D.cs:291:13:291:13 | access to local variable o | D.cs:283:17:283:24 | SSA def(o) | D.cs:291:13:291:13 | access to local variable o | Variable $@ may be null at this access because of $@ assignment. | D.cs:258:16:258:16 | o | o | D.cs:283:17:283:24 | ... = ... | this |
+| D.cs:294:13:294:13 | access to local variable o | D.cs:269:9:269:16 | SSA def(o) | D.cs:294:13:294:13 | access to local variable o | Variable $@ may be null at this access because of $@ assignment. | D.cs:258:16:258:16 | o | o | D.cs:269:9:269:16 | ... = ... | this |
+| D.cs:294:13:294:13 | access to local variable o | D.cs:283:17:283:24 | SSA def(o) | D.cs:294:13:294:13 | access to local variable o | Variable $@ may be null at this access because of $@ assignment. | D.cs:258:16:258:16 | o | o | D.cs:283:17:283:24 | ... = ... | this |
+| D.cs:300:17:300:20 | access to local variable prev | D.cs:296:16:296:26 | SSA def(prev) | D.cs:300:17:300:20 | access to local variable prev | Variable $@ may be null at this access because of $@ assignment. | D.cs:296:16:296:19 | prev | prev | D.cs:296:16:296:26 | Object prev = ... | this |
+| D.cs:313:17:313:17 | access to local variable s | D.cs:304:16:304:23 | SSA def(s) | D.cs:313:17:313:17 | access to local variable s | Variable $@ may be null at this access because of $@ assignment. | D.cs:304:16:304:16 | s | s | D.cs:304:16:304:23 | String s = ... | this |
+| D.cs:324:9:324:9 | access to local variable r | D.cs:316:16:316:23 | SSA def(r) | D.cs:324:9:324:9 | access to local variable r | Variable $@ may be null at this access because of $@ assignment. | D.cs:316:16:316:16 | r | r | D.cs:316:16:316:23 | Object r = ... | this |
+| D.cs:356:13:356:13 | access to local variable a | D.cs:351:15:351:22 | SSA def(a) | D.cs:356:13:356:13 | access to local variable a | Variable $@ may be null at this access because of $@ assignment. | D.cs:351:15:351:15 | a | a | D.cs:351:15:351:22 | Int32[] a = ... | this |
+| D.cs:363:13:363:16 | access to local variable last | D.cs:360:20:360:30 | SSA def(last) | D.cs:363:13:363:16 | access to local variable last | Variable $@ may be null at this access because of $@ assignment. | D.cs:360:20:360:23 | last | last | D.cs:360:20:360:30 | String last = ... | this |
+| D.cs:372:13:372:13 | access to local variable b | D.cs:366:15:366:47 | SSA def(b) | D.cs:372:13:372:13 | access to local variable b | Variable $@ may be null at this access because of $@ assignment. | D.cs:366:15:366:15 | b | b | D.cs:366:15:366:47 | Int32[] b = ... | this |
+| D.cs:395:20:395:20 | access to parameter a | D.cs:388:36:388:36 | SSA param(a) | D.cs:395:20:395:20 | access to parameter a | Variable $@ may be null at this access as suggested by $@ null check. | D.cs:388:36:388:36 | a | a | D.cs:390:20:390:28 | ... == ... | this |
+| D.cs:400:20:400:20 | access to parameter b | D.cs:388:45:388:45 | SSA param(b) | D.cs:400:20:400:20 | access to parameter b | Variable $@ may be null at this access as suggested by $@ null check. | D.cs:388:45:388:45 | b | b | D.cs:397:20:397:28 | ... == ... | this |
+| D.cs:410:13:410:13 | access to parameter y | D.cs:405:45:405:45 | SSA param(y) | D.cs:410:13:410:13 | access to parameter y | Variable $@ may be null at this access as suggested by $@ null check. | D.cs:405:45:405:45 | y | y | D.cs:407:27:407:35 | ... == ... | this |
+| D.cs:410:13:410:13 | access to parameter y | D.cs:405:45:405:45 | SSA param(y) | D.cs:410:13:410:13 | access to parameter y | Variable $@ may be null at this access as suggested by $@ null check. | D.cs:405:45:405:45 | y | y | D.cs:407:55:407:63 | ... != ... | this |
+| D.cs:410:13:410:13 | access to parameter y | D.cs:405:45:405:45 | SSA param(y) | D.cs:410:13:410:13 | access to parameter y | Variable $@ may be null at this access as suggested by $@ null check. | D.cs:405:45:405:45 | y | y | D.cs:411:13:411:21 | ... != ... | this |
+| D.cs:412:13:412:13 | access to parameter x | D.cs:405:35:405:35 | SSA param(x) | D.cs:412:13:412:13 | access to parameter x | Variable $@ may be null at this access as suggested by $@ null check. | D.cs:405:35:405:35 | x | x | D.cs:407:14:407:22 | ... != ... | this |
+| D.cs:412:13:412:13 | access to parameter x | D.cs:405:35:405:35 | SSA param(x) | D.cs:412:13:412:13 | access to parameter x | Variable $@ may be null at this access as suggested by $@ null check. | D.cs:405:35:405:35 | x | x | D.cs:407:42:407:50 | ... == ... | this |
+| D.cs:412:13:412:13 | access to parameter x | D.cs:405:35:405:35 | SSA param(x) | D.cs:412:13:412:13 | access to parameter x | Variable $@ may be null at this access as suggested by $@ null check. | D.cs:405:35:405:35 | x | x | D.cs:409:13:409:21 | ... != ... | this |
+| E.cs:12:38:12:39 | access to local variable a2 | E.cs:9:18:9:26 | SSA def(a2) | E.cs:12:38:12:39 | access to local variable a2 | Variable $@ may be null at this access because of $@ assignment. | E.cs:9:18:9:19 | a2 | a2 | E.cs:9:18:9:26 | Int64[][] a2 = ... | this |
+| E.cs:14:13:14:14 | access to local variable a3 | E.cs:11:16:11:24 | SSA def(a3) | E.cs:14:13:14:14 | access to local variable a3 | Variable $@ may be null at this access because of $@ assignment. | E.cs:11:16:11:17 | a3 | a3 | E.cs:11:16:11:24 | Int64[] a3 = ... | this |
+| E.cs:27:13:27:14 | access to local variable s1 | E.cs:23:13:23:30 | SSA def(s1) | E.cs:27:13:27:14 | access to local variable s1 | Variable $@ may be null at this access because of $@ assignment. | E.cs:19:13:19:14 | s1 | s1 | E.cs:23:13:23:30 | ... = ... | this |
+| E.cs:61:13:61:17 | access to local variable slice | E.cs:51:22:51:33 | SSA def(slice) | E.cs:61:13:61:17 | access to local variable slice | Variable $@ may be null at this access because of $@ assignment. | E.cs:51:22:51:26 | slice | slice | E.cs:51:22:51:33 | List<String> slice = ... | this |
+| E.cs:73:13:73:15 | access to parameter arr | E.cs:66:40:66:42 | SSA param(arr) | E.cs:73:13:73:15 | access to parameter arr | Variable $@ may be null at this access as suggested by $@ null check. | E.cs:66:40:66:42 | arr | arr | E.cs:70:22:70:32 | ... == ... | this |
+| E.cs:112:13:112:16 | access to local variable arr2 | E.cs:107:15:107:25 | SSA def(arr2) | E.cs:112:13:112:16 | access to local variable arr2 | Variable $@ may be null at this access because of $@ assignment. | E.cs:107:15:107:18 | arr2 | arr2 | E.cs:107:15:107:25 | Int32[] arr2 = ... | this |
+| E.cs:125:33:125:35 | access to local variable obj | E.cs:137:25:137:34 | SSA def(obj) | E.cs:125:33:125:35 | access to local variable obj | Variable $@ may be null at this access because of $@ assignment. | E.cs:119:13:119:15 | obj | obj | E.cs:137:25:137:34 | ... = ... | this |
+| E.cs:159:13:159:16 | access to local variable obj2 | E.cs:152:16:152:26 | SSA def(obj2) | E.cs:159:13:159:16 | access to local variable obj2 | Variable $@ may be null at this access as suggested by $@ null check. | E.cs:152:16:152:19 | obj2 | obj2 | E.cs:153:13:153:24 | ... != ... | this |
+| E.cs:167:21:167:21 | access to parameter a | E.cs:162:28:162:28 | SSA param(a) | E.cs:167:21:167:21 | access to parameter a | Variable $@ may be null at this access as suggested by $@ null check. | E.cs:162:28:162:28 | a | a | E.cs:164:17:164:25 | ... == ... | this |
+| E.cs:178:13:178:15 | access to parameter obj | E.cs:173:29:173:31 | SSA param(obj) | E.cs:178:13:178:15 | access to parameter obj | Variable $@ may be null at this access as suggested by $@ null check. | E.cs:173:29:173:31 | obj | obj | E.cs:175:19:175:29 | ... == ... | this |
+| E.cs:178:13:178:15 | access to parameter obj | E.cs:173:29:173:31 | SSA param(obj) | E.cs:178:13:178:15 | access to parameter obj | Variable $@ may be null at this access as suggested by $@ null check. | E.cs:173:29:173:31 | obj | obj | E.cs:180:13:180:23 | ... == ... | this |
+| E.cs:186:13:186:15 | access to parameter obj | E.cs:173:29:173:31 | SSA param(obj) | E.cs:186:13:186:15 | access to parameter obj | Variable $@ may be null at this access as suggested by $@ null check. | E.cs:173:29:173:31 | obj | obj | E.cs:175:19:175:29 | ... == ... | this |
+| E.cs:186:13:186:15 | access to parameter obj | E.cs:173:29:173:31 | SSA param(obj) | E.cs:186:13:186:15 | access to parameter obj | Variable $@ may be null at this access as suggested by $@ null check. | E.cs:173:29:173:31 | obj | obj | E.cs:180:13:180:23 | ... == ... | this |
+| E.cs:192:17:192:17 | access to parameter o | E.cs:190:29:190:29 | SSA param(o) | E.cs:192:17:192:17 | access to parameter o | Variable $@ may be null at this access as suggested by $@ null check. | E.cs:190:29:190:29 | o | o | E.cs:193:17:193:17 | access to parameter o | this |
+| E.cs:201:13:201:13 | access to local variable o | E.cs:198:13:198:29 | [b (line 196): true] SSA def(o) | E.cs:201:13:201:13 | access to local variable o | Variable $@ may be null at this access because of $@ assignment. | E.cs:198:13:198:13 | o | o | E.cs:198:13:198:29 | String o = ... | this |
+| E.cs:203:13:203:13 | access to local variable o | E.cs:198:13:198:29 | [b (line 196): false] SSA def(o) | E.cs:203:13:203:13 | access to local variable o | Variable $@ may be null at this access because of $@ assignment. | E.cs:198:13:198:13 | o | o | E.cs:198:13:198:29 | String o = ... | this |
+| E.cs:218:9:218:9 | access to local variable x | E.cs:217:13:217:20 | [b (line 213): true] SSA def(x) | E.cs:218:9:218:9 | access to local variable x | Variable $@ may be null at this access because of $@ assignment. | E.cs:215:13:215:13 | x | x | E.cs:217:13:217:20 | ... = ... | this |
+| E.cs:230:9:230:9 | access to local variable x | E.cs:227:13:227:20 | [b (line 223): true] SSA def(x) | E.cs:230:9:230:9 | access to local variable x | Variable $@ may be null at this access because of $@ assignment. | E.cs:225:13:225:13 | x | x | E.cs:227:13:227:20 | ... = ... | this |
+| E.cs:235:16:235:16 | access to parameter i | E.cs:233:26:233:26 | SSA param(i) | E.cs:235:16:235:16 | access to parameter i | Variable $@ may be null at this access because it has a nullable type. | E.cs:233:26:233:26 | i | i | E.cs:233:26:233:26 | i | this |
+| E.cs:240:21:240:21 | access to parameter i | E.cs:238:26:238:26 | SSA param(i) | E.cs:240:21:240:21 | access to parameter i | Variable $@ may be null at this access because it has a nullable type. | E.cs:238:26:238:26 | i | i | E.cs:238:26:238:26 | i | this |
+| E.cs:285:9:285:9 | access to local variable o | E.cs:283:13:283:22 | [b (line 279): false] SSA def(o) | E.cs:285:9:285:9 | access to local variable o | Variable $@ may be null at this access as suggested by $@ null check. | E.cs:283:13:283:13 | o | o | E.cs:284:9:284:9 | access to local variable o | this |
+| E.cs:285:9:285:9 | access to local variable o | E.cs:283:13:283:22 | [b (line 279): true] SSA def(o) | E.cs:285:9:285:9 | access to local variable o | Variable $@ may be null at this access as suggested by $@ null check. | E.cs:283:13:283:13 | o | o | E.cs:284:9:284:9 | access to local variable o | this |
+| E.cs:302:9:302:9 | access to local variable s | E.cs:301:13:301:27 | SSA def(s) | E.cs:302:9:302:9 | access to local variable s | Variable $@ may be null at this access because of $@ assignment. | E.cs:301:13:301:13 | s | s | E.cs:301:13:301:27 | String s = ... | this |
+| E.cs:343:9:343:9 | access to local variable x | E.cs:342:13:342:32 | SSA def(x) | E.cs:343:9:343:9 | access to local variable x | Variable $@ may be null at this access because of $@ assignment. | E.cs:342:13:342:13 | x | x | E.cs:342:13:342:32 | String x = ... | this |
+| E.cs:349:9:349:9 | access to local variable x | E.cs:348:17:348:36 | SSA def(x) | E.cs:349:9:349:9 | access to local variable x | Variable $@ may be null at this access because of $@ assignment. | E.cs:348:17:348:17 | x | x | E.cs:348:17:348:36 | dynamic x = ... | this |
+| E.cs:366:41:366:41 | access to parameter s | E.cs:366:28:366:28 | SSA param(s) | E.cs:366:41:366:41 | access to parameter s | Variable $@ may be null at this access because the parameter has a null default value. | E.cs:366:28:366:28 | s | s | E.cs:366:32:366:35 | null | this |
+| E.cs:375:20:375:20 | access to local variable s | E.cs:374:17:374:31 | SSA def(s) | E.cs:375:20:375:20 | access to local variable s | Variable $@ may be null at this access because of $@ assignment. | E.cs:374:17:374:17 | s | s | E.cs:374:17:374:31 | String s = ... | this |
+| E.cs:386:16:386:17 | access to parameter e1 | E.cs:380:24:380:25 | SSA param(e1) | E.cs:386:16:386:17 | access to parameter e1 | Variable $@ may be null at this access as suggested by $@ null check. | E.cs:380:24:380:25 | e1 | e1 | E.cs:382:14:382:23 | ... == ... | this |
+| E.cs:386:16:386:17 | access to parameter e1 | E.cs:380:24:380:25 | SSA param(e1) | E.cs:386:16:386:17 | access to parameter e1 | Variable $@ may be null at this access as suggested by $@ null check. | E.cs:380:24:380:25 | e1 | e1 | E.cs:382:44:382:53 | ... != ... | this |
+| E.cs:386:16:386:17 | access to parameter e1 | E.cs:380:24:380:25 | SSA param(e1) | E.cs:386:16:386:17 | access to parameter e1 | Variable $@ may be null at this access as suggested by $@ null check. | E.cs:380:24:380:25 | e1 | e1 | E.cs:384:13:384:22 | ... == ... | this |
+| E.cs:386:27:386:28 | access to parameter e2 | E.cs:380:30:380:31 | SSA param(e2) | E.cs:386:27:386:28 | access to parameter e2 | Variable $@ may be null at this access as suggested by $@ null check. | E.cs:380:30:380:31 | e2 | e2 | E.cs:382:28:382:37 | ... != ... | this |
+| E.cs:386:27:386:28 | access to parameter e2 | E.cs:380:30:380:31 | SSA param(e2) | E.cs:386:27:386:28 | access to parameter e2 | Variable $@ may be null at this access as suggested by $@ null check. | E.cs:380:30:380:31 | e2 | e2 | E.cs:382:58:382:67 | ... == ... | this |
+| E.cs:386:27:386:28 | access to parameter e2 | E.cs:380:30:380:31 | SSA param(e2) | E.cs:386:27:386:28 | access to parameter e2 | Variable $@ may be null at this access as suggested by $@ null check. | E.cs:380:30:380:31 | e2 | e2 | E.cs:384:27:384:36 | ... == ... | this |
+| E.cs:417:34:417:34 | access to parameter i | E.cs:417:24:417:40 | SSA capture def(i) | E.cs:417:34:417:34 | access to parameter i | Variable $@ may be null at this access because it has a nullable type. | E.cs:415:27:415:27 | i | i | E.cs:415:27:415:27 | i | this |
+| E.cs:423:38:423:38 | access to parameter i | E.cs:423:28:423:44 | SSA capture def(i) | E.cs:423:38:423:38 | access to parameter i | Variable $@ may be null at this access because it has a nullable type. | E.cs:420:27:420:27 | i | i | E.cs:420:27:420:27 | i | this |
+| E.cs:430:39:430:39 | access to parameter i | E.cs:430:29:430:45 | SSA capture def(i) | E.cs:430:39:430:39 | access to parameter i | Variable $@ may be null at this access because it has a nullable type. | E.cs:427:27:427:27 | i | i | E.cs:427:27:427:27 | i | this |
+| GuardedString.cs:35:31:35:31 | access to local variable s | GuardedString.cs:7:16:7:32 | SSA def(s) | GuardedString.cs:35:31:35:31 | access to local variable s | Variable $@ may be null at this access because of $@ assignment. | GuardedString.cs:7:16:7:16 | s | s | GuardedString.cs:7:16:7:32 | String s = ... | this |
+| NullMaybeBad.cs:7:27:7:27 | access to parameter o | NullMaybeBad.cs:13:17:13:20 | null | NullMaybeBad.cs:7:27:7:27 | access to parameter o | Variable $@ may be null at this access because of $@ null argument. | NullMaybeBad.cs:5:25:5:25 | o | o | NullMaybeBad.cs:13:17:13:20 | null | this |
+| Params.cs:14:17:14:20 | access to parameter args | Params.cs:20:12:20:15 | null | Params.cs:14:17:14:20 | access to parameter args | Variable $@ may be null at this access because of $@ null argument. | Params.cs:12:36:12:39 | args | args | Params.cs:20:12:20:15 | null | this |
+| StringConcatenation.cs:16:17:16:17 | access to local variable s | StringConcatenation.cs:14:16:14:23 | SSA def(s) | StringConcatenation.cs:16:17:16:17 | access to local variable s | Variable $@ may be null at this access because of $@ assignment. | StringConcatenation.cs:14:16:14:16 | s | s | StringConcatenation.cs:14:16:14:23 | String s = ... | this |
+edges
+| A.cs:7:16:7:40 | SSA def(synchronizedAlways) | A.cs:8:15:8:32 | access to local variable synchronizedAlways |
+| A.cs:7:16:7:40 | SSA def(synchronizedAlways) | A.cs:10:13:10:30 | access to local variable synchronizedAlways |
+| A.cs:16:15:16:30 | SSA def(arrayNull) | A.cs:17:9:17:17 | access to local variable arrayNull |
+| A.cs:26:15:26:32 | SSA def(arrayAccess) | A.cs:31:27:31:37 | access to local variable arrayAccess |
+| A.cs:26:15:26:32 | SSA def(arrayAccess) | A.cs:36:27:36:37 | access to local variable arrayAccess |
+| A.cs:27:18:27:35 | SSA def(fieldAccess) | A.cs:32:27:32:37 | access to local variable fieldAccess |
+| A.cs:27:18:27:35 | SSA def(fieldAccess) | A.cs:37:27:37:37 | access to local variable fieldAccess |
+| A.cs:28:16:28:34 | SSA def(methodAccess) | A.cs:33:28:33:39 | access to local variable methodAccess |
+| A.cs:28:16:28:34 | SSA def(methodAccess) | A.cs:38:15:38:26 | access to local variable methodAccess |
+| A.cs:29:16:29:32 | SSA def(methodCall) | A.cs:34:27:34:36 | access to local variable methodCall |
+| A.cs:29:16:29:32 | SSA def(methodCall) | A.cs:39:27:39:36 | access to local variable methodCall |
+| A.cs:48:16:48:28 | SSA def(varRef) | A.cs:50:9:50:14 | access to local variable varRef |
+| Assert.cs:13:9:13:25 | [b (line 7): false] SSA def(s) | Assert.cs:15:27:15:27 | access to local variable s |
+| Assert.cs:13:9:13:25 | [b (line 7): true] SSA def(s) | Assert.cs:15:27:15:27 | access to local variable s |
+| Assert.cs:21:9:21:25 | [b (line 7): false] SSA def(s) | Assert.cs:23:27:23:27 | access to local variable s |
+| Assert.cs:21:9:21:25 | [b (line 7): true] SSA def(s) | Assert.cs:23:27:23:27 | access to local variable s |
+| Assert.cs:29:9:29:25 | [b (line 7): false] SSA def(s) | Assert.cs:31:27:31:27 | access to local variable s |
+| Assert.cs:29:9:29:25 | [b (line 7): true] SSA def(s) | Assert.cs:31:27:31:27 | access to local variable s |
+| Assert.cs:45:9:45:25 | [b (line 7): true] SSA def(s) | Assert.cs:46:36:46:36 | [b (line 7): true] access to parameter b |
+| Assert.cs:46:23:46:36 | [true, b (line 7): true] ... && ... | Assert.cs:47:27:47:27 | access to local variable s |
+| Assert.cs:46:36:46:36 | [b (line 7): true] access to parameter b | Assert.cs:46:23:46:36 | [true, b (line 7): true] ... && ... |
+| Assert.cs:49:9:49:25 | [b (line 7): true] SSA def(s) | Assert.cs:50:38:50:38 | [b (line 7): true] access to parameter b |
+| Assert.cs:50:24:50:38 | [false] ... \|\| ... | Assert.cs:51:27:51:27 | access to local variable s |
+| Assert.cs:50:37:50:38 | [false] !... | Assert.cs:50:24:50:38 | [false] ... \|\| ... |
+| Assert.cs:50:38:50:38 | [b (line 7): true] access to parameter b | Assert.cs:50:37:50:38 | [false] !... |
+| B.cs:7:11:7:29 | SSA def(eqCallAlways) | B.cs:13:13:13:24 | access to local variable eqCallAlways |
+| B.cs:10:11:10:30 | SSA def(neqCallAlways) | B.cs:13:13:13:36 | ...; |
+| B.cs:10:11:10:30 | SSA def(neqCallAlways) | B.cs:15:9:16:26 | if (...) ... |
+| B.cs:13:13:13:36 | ...; | B.cs:15:9:16:26 | if (...) ... |
+| B.cs:15:9:16:26 | if (...) ... | B.cs:16:13:16:26 | ...; |
+| B.cs:15:9:16:26 | if (...) ... | B.cs:18:9:20:26 | if (...) ... |
+| B.cs:16:13:16:26 | ...; | B.cs:18:9:20:26 | if (...) ... |
+| B.cs:18:9:20:26 | if (...) ... | B.cs:18:25:18:27 | {...} |
+| B.cs:18:9:20:26 | if (...) ... | B.cs:20:13:20:26 | ...; |
+| B.cs:18:25:18:27 | {...} | B.cs:22:9:24:37 | if (...) ... |
+| B.cs:20:13:20:26 | ...; | B.cs:22:9:24:37 | if (...) ... |
+| B.cs:22:9:24:37 | if (...) ... | B.cs:24:13:24:25 | access to local variable neqCallAlways |
+| C.cs:10:16:10:23 | SSA def(o) | C.cs:11:17:11:28 | [false] !... |
+| C.cs:11:13:11:30 | [false] !... | C.cs:16:9:19:9 | if (...) ... |
+| C.cs:11:15:11:29 | [true] !... | C.cs:11:13:11:30 | [false] !... |
+| C.cs:11:17:11:28 | [false] !... | C.cs:11:15:11:29 | [true] !... |
+| C.cs:16:9:19:9 | if (...) ... | C.cs:16:13:16:24 | [true] !... |
+| C.cs:16:13:16:24 | [true] !... | C.cs:18:13:18:13 | access to local variable o |
+| C.cs:40:13:40:35 | SSA def(s) | C.cs:42:9:42:9 | access to local variable s |
+| C.cs:55:13:55:36 | SSA def(o2) | C.cs:57:9:57:10 | access to local variable o2 |
+| C.cs:62:13:62:46 | SSA def(o1) | C.cs:64:9:64:10 | access to local variable o1 |
+| C.cs:66:13:66:46 | SSA def(o2) | C.cs:68:9:68:10 | access to local variable o2 |
+| C.cs:94:13:94:45 | SSA def(o) | C.cs:95:15:95:15 | access to local variable o |
+| C.cs:94:13:94:45 | SSA def(o) | C.cs:96:13:96:13 | access to local variable o |
+| C.cs:102:13:102:23 | SSA def(list) | C.cs:103:27:103:30 | access to parameter list |
+| C.cs:102:13:102:23 | SSA def(list) | C.cs:103:27:103:30 | access to parameter list |
+| C.cs:103:9:107:9 | foreach (... ... in ...) ... | C.cs:103:22:103:22 | Int32 x |
+| C.cs:103:9:107:9 | foreach (... ... in ...) ... | C.cs:106:13:106:16 | access to parameter list |
+| C.cs:103:22:103:22 | Int32 x | C.cs:103:9:107:9 | foreach (... ... in ...) ... |
+| C.cs:103:27:103:30 | access to parameter list | C.cs:103:9:107:9 | foreach (... ... in ...) ... |
+| C.cs:159:9:159:16 | SSA def(s) | C.cs:162:13:162:13 | access to local variable s |
+| C.cs:167:9:167:16 | SSA def(s) | C.cs:170:13:170:13 | access to local variable s |
+| C.cs:178:13:178:20 | SSA def(s) | C.cs:177:13:177:13 | access to local variable s |
+| C.cs:193:9:193:16 | SSA def(s) | C.cs:196:13:196:13 | access to local variable s |
+| C.cs:197:13:197:20 | [b (line 192): true] SSA def(s) | C.cs:196:13:196:13 | access to local variable s |
+| C.cs:201:16:201:19 | true | C.cs:203:13:203:13 | access to local variable s |
+| C.cs:204:13:204:20 | SSA def(s) | C.cs:201:16:201:19 | true |
+| C.cs:210:13:210:35 | SSA def(s) | C.cs:217:9:218:25 | if (...) ... |
+| C.cs:214:13:214:20 | SSA def(s) | C.cs:217:9:218:25 | if (...) ... |
+| C.cs:217:9:218:25 | if (...) ... | C.cs:218:13:218:13 | access to local variable s |
+| C.cs:222:13:222:20 | SSA def(s) | C.cs:223:9:223:9 | access to local variable s |
+| C.cs:229:22:229:22 | access to local variable s | C.cs:233:9:233:9 | access to local variable s |
+| C.cs:229:33:229:40 | SSA def(s) | C.cs:229:22:229:22 | access to local variable s |
+| C.cs:235:14:235:21 | SSA def(s) | C.cs:235:24:235:24 | access to local variable s |
+| C.cs:235:24:235:24 | access to local variable s | C.cs:237:13:237:13 | access to local variable s |
+| C.cs:235:35:235:42 | SSA def(s) | C.cs:235:24:235:24 | access to local variable s |
+| C.cs:240:24:240:31 | SSA def(s) | C.cs:242:13:242:13 | access to local variable s |
+| C.cs:248:15:248:22 | SSA def(a) | C.cs:249:9:249:9 | access to local variable a |
+| C.cs:257:15:257:23 | SSA def(ia) | C.cs:260:9:260:10 | access to local variable ia |
+| C.cs:257:15:257:23 | SSA def(ia) | C.cs:263:9:263:10 | access to local variable ia |
+| C.cs:258:18:258:26 | SSA def(sa) | C.cs:261:20:261:21 | access to local variable sa |
+| C.cs:258:18:258:26 | SSA def(sa) | C.cs:264:16:264:17 | access to local variable sa |
+| D.cs:17:17:17:20 | null | D.cs:23:9:23:13 | access to parameter param |
+| D.cs:26:32:26:36 | SSA param(param) | D.cs:32:9:32:13 | access to parameter param |
+| D.cs:58:13:58:41 | SSA def(o5) | D.cs:61:9:62:26 | if (...) ... |
+| D.cs:61:9:62:26 | if (...) ... | D.cs:62:13:62:14 | access to local variable o5 |
+| D.cs:68:13:68:34 | SSA def(o7) | D.cs:69:18:69:36 | ... && ... |
+| D.cs:69:18:69:36 | ... && ... | D.cs:73:13:73:14 | access to local variable o7 |
+| D.cs:75:13:75:34 | SSA def(o8) | D.cs:76:34:76:35 | 42 |
+| D.cs:76:21:76:43 | ... ? ... : ... | D.cs:79:9:80:26 | if (...) ... |
+| D.cs:76:34:76:35 | 42 | D.cs:76:21:76:43 | ... ? ... : ... |
+| D.cs:79:9:80:26 | if (...) ... | D.cs:81:9:82:26 | if (...) ... |
+| D.cs:81:9:82:26 | if (...) ... | D.cs:82:13:82:14 | access to local variable o8 |
+| D.cs:81:9:82:26 | if (...) ... | D.cs:82:13:82:26 | ...; |
+| D.cs:81:9:82:26 | if (...) ... | D.cs:83:9:84:26 | if (...) ... |
+| D.cs:82:13:82:26 | ...; | D.cs:83:9:84:26 | if (...) ... |
+| D.cs:83:9:84:26 | if (...) ... | D.cs:84:13:84:14 | access to local variable o8 |
+| D.cs:89:15:89:44 | SSA def(xs) | D.cs:91:13:91:14 | access to local variable xs |
+| D.cs:89:15:89:44 | SSA def(xs) | D.cs:91:13:91:22 | ...; |
+| D.cs:89:15:89:44 | SSA def(xs) | D.cs:93:9:94:30 | if (...) ... |
+| D.cs:91:13:91:22 | ...; | D.cs:93:9:94:30 | if (...) ... |
+| D.cs:93:9:94:30 | if (...) ... | D.cs:94:13:94:30 | ...; |
+| D.cs:93:9:94:30 | if (...) ... | D.cs:94:21:94:22 | access to local variable xs |
+| D.cs:93:9:94:30 | if (...) ... | D.cs:96:9:99:9 | if (...) ... |
+| D.cs:94:13:94:30 | ...; | D.cs:96:9:99:9 | if (...) ... |
+| D.cs:96:9:99:9 | if (...) ... | D.cs:97:9:99:9 | {...} |
+| D.cs:96:9:99:9 | if (...) ... | D.cs:98:21:98:22 | access to local variable xs |
+| D.cs:96:9:99:9 | if (...) ... | D.cs:101:9:102:35 | if (...) ... |
+| D.cs:97:9:99:9 | {...} | D.cs:101:9:102:35 | if (...) ... |
+| D.cs:101:9:102:35 | if (...) ... | D.cs:102:31:102:32 | access to local variable xs |
+| D.cs:101:9:102:35 | if (...) ... | D.cs:102:31:102:32 | access to local variable xs |
+| D.cs:101:9:102:35 | if (...) ... | D.cs:104:9:106:30 | if (...) ... |
+| D.cs:102:13:102:35 | foreach (... ... in ...) ... | D.cs:102:26:102:26 | Int32 _ |
+| D.cs:102:13:102:35 | foreach (... ... in ...) ... | D.cs:104:9:106:30 | if (...) ... |
+| D.cs:102:26:102:26 | Int32 _ | D.cs:102:13:102:35 | foreach (... ... in ...) ... |
+| D.cs:102:31:102:32 | access to local variable xs | D.cs:102:13:102:35 | foreach (... ... in ...) ... |
+| D.cs:104:9:106:30 | if (...) ... | D.cs:105:19:105:20 | access to local variable xs |
+| D.cs:104:9:106:30 | if (...) ... | D.cs:106:17:106:18 | access to local variable xs |
+| D.cs:118:9:118:30 | SSA def(x) | D.cs:120:13:120:13 | access to local variable x |
+| D.cs:125:35:125:35 | SSA param(a) | D.cs:127:32:127:32 | 0 |
+| D.cs:125:35:125:35 | SSA param(a) | D.cs:127:32:127:32 | 0 |
+| D.cs:125:44:125:44 | SSA param(b) | D.cs:127:32:127:32 | 0 |
+| D.cs:125:44:125:44 | SSA param(b) | D.cs:127:36:127:36 | access to parameter a |
+| D.cs:127:20:127:43 | ... ? ... : ... | D.cs:128:32:128:32 | 0 |
+| D.cs:127:20:127:43 | ... ? ... : ... | D.cs:128:32:128:32 | 0 |
+| D.cs:127:20:127:43 | ... ? ... : ... | D.cs:128:36:128:36 | access to parameter b |
+| D.cs:127:32:127:32 | 0 | D.cs:127:20:127:43 | ... ? ... : ... |
+| D.cs:127:32:127:32 | 0 | D.cs:127:20:127:43 | ... ? ... : ... |
+| D.cs:127:36:127:36 | access to parameter a | D.cs:127:20:127:43 | ... ? ... : ... |
+| D.cs:128:20:128:43 | ... ? ... : ... | D.cs:131:9:137:9 | {...} |
+| D.cs:128:20:128:43 | ... ? ... : ... | D.cs:131:9:137:9 | {...} |
+| D.cs:128:20:128:43 | ... ? ... : ... | D.cs:138:9:138:18 | ... ...; |
+| D.cs:128:32:128:32 | 0 | D.cs:128:20:128:43 | ... ? ... : ... |
+| D.cs:128:32:128:32 | 0 | D.cs:128:20:128:43 | ... ? ... : ... |
+| D.cs:128:36:128:36 | access to parameter b | D.cs:128:20:128:43 | ... ? ... : ... |
+| D.cs:131:9:137:9 | {...} | D.cs:132:29:132:29 | access to local variable i |
+| D.cs:131:9:137:9 | {...} | D.cs:132:29:132:29 | access to local variable i |
+| D.cs:132:29:132:29 | access to local variable i | D.cs:133:13:136:13 | {...} |
+| D.cs:132:29:132:29 | access to local variable i | D.cs:133:13:136:13 | {...} |
+| D.cs:132:29:132:29 | access to local variable i | D.cs:134:24:134:24 | access to parameter a |
+| D.cs:132:29:132:29 | access to local variable i | D.cs:135:24:135:24 | access to parameter b |
+| D.cs:132:29:132:29 | access to local variable i | D.cs:138:9:138:18 | ... ...; |
+| D.cs:133:13:136:13 | {...} | D.cs:132:29:132:29 | access to local variable i |
+| D.cs:133:13:136:13 | {...} | D.cs:132:29:132:29 | access to local variable i |
+| D.cs:138:9:138:18 | ... ...; | D.cs:142:13:142:22 | ...; |
+| D.cs:142:13:142:22 | ...; | D.cs:143:9:146:9 | for (...;...;...) ... |
+| D.cs:143:9:146:9 | for (...;...;...) ... | D.cs:143:25:143:25 | access to local variable i |
+| D.cs:143:25:143:25 | access to local variable i | D.cs:144:9:146:9 | {...} |
+| D.cs:143:25:143:25 | access to local variable i | D.cs:145:20:145:20 | access to parameter a |
+| D.cs:144:9:146:9 | {...} | D.cs:143:25:143:25 | access to local variable i |
+| D.cs:149:36:149:38 | SSA param(obj) | D.cs:151:9:151:11 | access to parameter obj |
+| D.cs:163:16:163:25 | SSA def(obj) | D.cs:168:9:170:9 | [exception: Exception] catch (...) {...} |
+| D.cs:168:9:170:9 | [exception: Exception] catch (...) {...} | D.cs:168:26:168:26 | [exception: Exception] Exception e |
+| D.cs:168:26:168:26 | [exception: Exception] Exception e | D.cs:171:9:171:11 | access to local variable obj |
+| D.cs:240:9:240:16 | SSA def(o) | D.cs:241:29:241:32 | null |
+| D.cs:240:9:240:16 | SSA def(o) | D.cs:241:36:241:37 | "" |
+| D.cs:241:21:241:37 | ... ? ... : ... | D.cs:244:9:247:25 | if (...) ... |
+| D.cs:241:29:241:32 | null | D.cs:241:21:241:37 | ... ? ... : ... |
+| D.cs:241:36:241:37 | "" | D.cs:241:21:241:37 | ... ? ... : ... |
+| D.cs:244:9:247:25 | if (...) ... | D.cs:245:13:245:13 | access to local variable o |
+| D.cs:244:9:247:25 | if (...) ... | D.cs:247:13:247:13 | access to local variable o |
+| D.cs:249:13:249:38 | SSA def(o2) | D.cs:253:13:253:14 | access to local variable o2 |
+| D.cs:258:16:258:23 | SSA def(o) | D.cs:266:9:267:25 | if (...) ... |
+| D.cs:266:9:267:25 | if (...) ... | D.cs:266:13:266:27 | [true] ... is ... |
+| D.cs:266:13:266:27 | [true] ... is ... | D.cs:267:13:267:13 | access to local variable o |
+| D.cs:269:9:269:16 | SSA def(o) | D.cs:272:25:272:25 | access to local variable i |
+| D.cs:272:25:272:25 | access to local variable i | D.cs:273:9:288:9 | {...} |
+| D.cs:272:25:272:25 | access to local variable i | D.cs:290:9:291:25 | if (...) ... |
+| D.cs:272:39:272:39 | access to local variable i | D.cs:272:25:272:25 | access to local variable i |
+| D.cs:273:9:288:9 | {...} | D.cs:281:13:287:13 | if (...) ... |
+| D.cs:281:13:287:13 | if (...) ... | D.cs:272:39:272:39 | access to local variable i |
+| D.cs:283:17:283:24 | SSA def(o) | D.cs:285:28:285:30 | {...} |
+| D.cs:283:17:283:24 | SSA def(o) | D.cs:286:17:286:30 | ...; |
+| D.cs:285:28:285:30 | {...} | D.cs:286:17:286:30 | ...; |
+| D.cs:286:17:286:30 | ...; | D.cs:272:39:272:39 | access to local variable i |
+| D.cs:290:9:291:25 | if (...) ... | D.cs:291:13:291:13 | access to local variable o |
+| D.cs:290:9:291:25 | if (...) ... | D.cs:291:13:291:25 | ...; |
+| D.cs:290:9:291:25 | if (...) ... | D.cs:293:9:294:25 | if (...) ... |
+| D.cs:291:13:291:25 | ...; | D.cs:293:9:294:25 | if (...) ... |
+| D.cs:293:9:294:25 | if (...) ... | D.cs:294:13:294:13 | access to local variable o |
+| D.cs:296:16:296:26 | SSA def(prev) | D.cs:297:25:297:25 | access to local variable i |
+| D.cs:297:25:297:25 | access to local variable i | D.cs:298:9:302:9 | {...} |
+| D.cs:298:9:302:9 | {...} | D.cs:300:17:300:20 | access to local variable prev |
+| D.cs:304:16:304:23 | SSA def(s) | D.cs:307:13:311:13 | foreach (... ... in ...) ... |
+| D.cs:307:13:311:13 | foreach (... ... in ...) ... | D.cs:312:13:313:29 | if (...) ... |
+| D.cs:312:13:313:29 | if (...) ... | D.cs:312:17:312:23 | [true] !... |
+| D.cs:312:17:312:23 | [true] !... | D.cs:313:17:313:17 | access to local variable s |
+| D.cs:316:16:316:23 | SSA def(r) | D.cs:318:16:318:19 | access to local variable stat |
+| D.cs:318:16:318:19 | access to local variable stat | D.cs:318:16:318:62 | [false] ... && ... |
+| D.cs:318:16:318:19 | access to local variable stat | D.cs:318:41:318:44 | access to local variable stat |
+| D.cs:318:16:318:62 | [false] ... && ... | D.cs:324:9:324:9 | access to local variable r |
+| D.cs:318:41:318:44 | access to local variable stat | D.cs:318:16:318:62 | [false] ... && ... |
+| D.cs:351:15:351:22 | SSA def(a) | D.cs:355:9:356:21 | for (...;...;...) ... |
+| D.cs:355:9:356:21 | for (...;...;...) ... | D.cs:355:25:355:25 | access to local variable i |
+| D.cs:355:25:355:25 | access to local variable i | D.cs:356:13:356:13 | access to local variable a |
+| D.cs:355:25:355:25 | access to local variable i | D.cs:356:13:356:21 | ...; |
+| D.cs:356:13:356:21 | ...; | D.cs:355:25:355:25 | access to local variable i |
+| D.cs:360:20:360:30 | SSA def(last) | D.cs:361:29:361:29 | access to local variable i |
+| D.cs:361:29:361:29 | access to local variable i | D.cs:363:13:363:16 | access to local variable last |
+| D.cs:366:15:366:47 | SSA def(b) | D.cs:367:13:367:56 | [false] ... && ... |
+| D.cs:367:13:367:56 | [false] ... && ... | D.cs:370:9:373:9 | for (...;...;...) ... |
+| D.cs:370:9:373:9 | for (...;...;...) ... | D.cs:370:25:370:25 | access to local variable i |
+| D.cs:370:25:370:25 | access to local variable i | D.cs:371:9:373:9 | {...} |
+| D.cs:370:25:370:25 | access to local variable i | D.cs:372:13:372:13 | access to local variable b |
+| D.cs:371:9:373:9 | {...} | D.cs:370:25:370:25 | access to local variable i |
+| D.cs:378:19:378:28 | SSA def(ioe) | D.cs:382:9:385:27 | if (...) ... |
+| D.cs:382:9:385:27 | if (...) ... | D.cs:385:13:385:15 | access to local variable ioe |
+| D.cs:388:36:388:36 | SSA param(a) | D.cs:390:32:390:32 | 0 |
+| D.cs:388:45:388:45 | SSA param(b) | D.cs:390:32:390:32 | 0 |
+| D.cs:388:45:388:45 | SSA param(b) | D.cs:390:36:390:36 | access to parameter a |
+| D.cs:390:20:390:43 | ... ? ... : ... | D.cs:393:21:393:21 | access to local variable i |
+| D.cs:390:20:390:43 | ... ? ... : ... | D.cs:393:21:393:21 | access to local variable i |
+| D.cs:390:32:390:32 | 0 | D.cs:390:20:390:43 | ... ? ... : ... |
+| D.cs:390:32:390:32 | 0 | D.cs:390:20:390:43 | ... ? ... : ... |
+| D.cs:390:36:390:36 | access to parameter a | D.cs:390:20:390:43 | ... ? ... : ... |
+| D.cs:393:21:393:21 | access to local variable i | D.cs:394:9:396:9 | {...} |
+| D.cs:393:21:393:21 | access to local variable i | D.cs:394:9:396:9 | {...} |
+| D.cs:393:21:393:21 | access to local variable i | D.cs:395:20:395:20 | access to parameter a |
+| D.cs:393:21:393:21 | access to local variable i | D.cs:397:9:397:44 | ... ...; |
+| D.cs:394:9:396:9 | {...} | D.cs:393:21:393:21 | access to local variable i |
+| D.cs:394:9:396:9 | {...} | D.cs:393:21:393:21 | access to local variable i |
+| D.cs:397:9:397:44 | ... ...; | D.cs:397:32:397:32 | 0 |
+| D.cs:397:20:397:43 | ... ? ... : ... | D.cs:398:21:398:21 | access to local variable i |
+| D.cs:397:32:397:32 | 0 | D.cs:397:20:397:43 | ... ? ... : ... |
+| D.cs:398:21:398:21 | access to local variable i | D.cs:399:9:401:9 | {...} |
+| D.cs:398:21:398:21 | access to local variable i | D.cs:400:20:400:20 | access to parameter b |
+| D.cs:399:9:401:9 | {...} | D.cs:398:21:398:21 | access to local variable i |
+| D.cs:405:35:405:35 | SSA param(x) | D.cs:407:14:407:35 | [false] ... && ... |
+| D.cs:405:35:405:35 | SSA param(x) | D.cs:407:14:407:35 | [false] ... && ... |
+| D.cs:405:35:405:35 | SSA param(x) | D.cs:407:14:407:35 | [false] ... && ... |
+| D.cs:405:45:405:45 | SSA param(y) | D.cs:407:14:407:35 | [false] ... && ... |
+| D.cs:405:45:405:45 | SSA param(y) | D.cs:407:14:407:35 | [false] ... && ... |
+| D.cs:405:45:405:45 | SSA param(y) | D.cs:407:14:407:35 | [false] ... && ... |
+| D.cs:407:13:407:64 | [false] ... \|\| ... | D.cs:409:9:410:25 | if (...) ... |
+| D.cs:407:13:407:64 | [false] ... \|\| ... | D.cs:409:9:410:25 | if (...) ... |
+| D.cs:407:14:407:35 | [false] ... && ... | D.cs:407:42:407:42 | access to parameter x |
+| D.cs:407:14:407:35 | [false] ... && ... | D.cs:407:42:407:42 | access to parameter x |
+| D.cs:407:42:407:42 | access to parameter x | D.cs:407:42:407:63 | [false] ... && ... |
+| D.cs:407:42:407:42 | access to parameter x | D.cs:407:55:407:55 | access to parameter y |
+| D.cs:407:42:407:42 | access to parameter x | D.cs:407:55:407:55 | access to parameter y |
+| D.cs:407:42:407:63 | [false] ... && ... | D.cs:407:13:407:64 | [false] ... \|\| ... |
+| D.cs:407:42:407:63 | [false] ... && ... | D.cs:407:13:407:64 | [false] ... \|\| ... |
+| D.cs:407:55:407:55 | access to parameter y | D.cs:407:42:407:63 | [false] ... && ... |
+| D.cs:407:55:407:55 | access to parameter y | D.cs:407:42:407:63 | [false] ... && ... |
+| D.cs:409:9:410:25 | if (...) ... | D.cs:410:13:410:13 | access to parameter y |
+| D.cs:409:9:410:25 | if (...) ... | D.cs:411:9:412:25 | if (...) ... |
+| D.cs:411:9:412:25 | if (...) ... | D.cs:412:13:412:13 | access to parameter x |
+| E.cs:9:18:9:26 | SSA def(a2) | E.cs:10:22:10:54 | ... && ... |
+| E.cs:10:22:10:54 | ... && ... | E.cs:12:38:12:39 | access to local variable a2 |
+| E.cs:11:16:11:24 | SSA def(a3) | E.cs:12:22:12:52 | ... && ... |
+| E.cs:12:22:12:52 | ... && ... | E.cs:14:13:14:14 | access to local variable a3 |
+| E.cs:23:13:23:30 | SSA def(s1) | E.cs:24:33:24:36 | null |
+| E.cs:24:18:24:41 | ... ? ... : ... | E.cs:26:9:27:26 | if (...) ... |
+| E.cs:24:33:24:36 | null | E.cs:24:18:24:41 | ... ? ... : ... |
+| E.cs:26:9:27:26 | if (...) ... | E.cs:27:13:27:14 | access to local variable s1 |
+| E.cs:51:22:51:33 | SSA def(slice) | E.cs:53:16:53:19 | access to local variable iter |
+| E.cs:53:16:53:19 | access to local variable iter | E.cs:54:9:63:9 | {...} |
+| E.cs:54:9:63:9 | {...} | E.cs:61:13:61:17 | access to local variable slice |
+| E.cs:54:9:63:9 | {...} | E.cs:61:13:61:27 | ...; |
+| E.cs:61:13:61:27 | ...; | E.cs:53:16:53:19 | access to local variable iter |
+| E.cs:66:40:66:42 | SSA param(arr) | E.cs:70:13:70:50 | ...; |
+| E.cs:66:40:66:42 | SSA param(arr) | E.cs:72:9:73:23 | if (...) ... |
+| E.cs:70:13:70:50 | ...; | E.cs:70:36:70:36 | 0 |
+| E.cs:70:22:70:49 | ... ? ... : ... | E.cs:72:9:73:23 | if (...) ... |
+| E.cs:70:36:70:36 | 0 | E.cs:70:22:70:49 | ... ? ... : ... |
+| E.cs:72:9:73:23 | if (...) ... | E.cs:73:13:73:15 | access to parameter arr |
+| E.cs:107:15:107:25 | SSA def(arr2) | E.cs:111:9:112:30 | for (...;...;...) ... |
+| E.cs:111:9:112:30 | for (...;...;...) ... | E.cs:111:25:111:25 | access to local variable i |
+| E.cs:111:25:111:25 | access to local variable i | E.cs:112:13:112:16 | access to local variable arr2 |
+| E.cs:111:25:111:25 | access to local variable i | E.cs:112:13:112:30 | ...; |
+| E.cs:112:13:112:30 | ...; | E.cs:111:25:111:25 | access to local variable i |
+| E.cs:120:16:120:20 | [true] !... | E.cs:121:9:143:9 | {...} |
+| E.cs:120:17:120:20 | access to local variable stop | E.cs:120:16:120:20 | [true] !... |
+| E.cs:121:9:143:9 | {...} | E.cs:123:21:123:24 | access to local variable stop |
+| E.cs:123:20:123:24 | [false] !... | E.cs:123:20:123:35 | [false] ... && ... |
+| E.cs:123:20:123:24 | [true] !... | E.cs:123:29:123:29 | access to local variable j |
+| E.cs:123:20:123:35 | [false] ... && ... | E.cs:120:17:120:20 | access to local variable stop |
+| E.cs:123:20:123:35 | [true] ... && ... | E.cs:124:13:142:13 | {...} |
+| E.cs:123:20:123:35 | [true] ... && ... | E.cs:125:33:125:35 | access to local variable obj |
+| E.cs:123:21:123:24 | access to local variable stop | E.cs:123:20:123:24 | [false] !... |
+| E.cs:123:21:123:24 | access to local variable stop | E.cs:123:20:123:24 | [true] !... |
+| E.cs:123:29:123:29 | access to local variable j | E.cs:123:20:123:35 | [false] ... && ... |
+| E.cs:123:29:123:29 | access to local variable j | E.cs:123:20:123:35 | [true] ... && ... |
+| E.cs:124:13:142:13 | {...} | E.cs:128:21:128:23 | access to local variable obj |
+| E.cs:124:13:142:13 | {...} | E.cs:141:17:141:26 | ...; |
+| E.cs:137:25:137:34 | SSA def(obj) | E.cs:139:21:139:29 | continue; |
+| E.cs:139:21:139:29 | continue; | E.cs:123:21:123:24 | access to local variable stop |
+| E.cs:141:17:141:26 | ...; | E.cs:123:21:123:24 | access to local variable stop |
+| E.cs:152:16:152:26 | SSA def(obj2) | E.cs:153:13:153:54 | [false] ... && ... |
+| E.cs:153:13:153:54 | [false] ... && ... | E.cs:158:9:159:28 | if (...) ... |
+| E.cs:158:9:159:28 | if (...) ... | E.cs:159:13:159:16 | access to local variable obj2 |
+| E.cs:162:28:162:28 | SSA param(a) | E.cs:164:29:164:29 | 0 |
+| E.cs:164:17:164:40 | ... ? ... : ... | E.cs:165:25:165:25 | access to local variable i |
+| E.cs:164:29:164:29 | 0 | E.cs:164:17:164:40 | ... ? ... : ... |
+| E.cs:165:25:165:25 | access to local variable i | E.cs:166:9:170:9 | {...} |
+| E.cs:165:25:165:25 | access to local variable i | E.cs:167:21:167:21 | access to parameter a |
+| E.cs:165:32:165:32 | access to local variable i | E.cs:165:25:165:25 | access to local variable i |
+| E.cs:166:9:170:9 | {...} | E.cs:165:32:165:32 | access to local variable i |
+| E.cs:173:29:173:31 | SSA param(obj) | E.cs:175:33:175:37 | false |
+| E.cs:173:29:173:31 | SSA param(obj) | E.cs:175:33:175:37 | false |
+| E.cs:175:19:175:42 | ... ? ... : ... | E.cs:177:9:179:9 | {...} |
+| E.cs:175:19:175:42 | ... ? ... : ... | E.cs:178:13:178:15 | access to parameter obj |
+| E.cs:175:19:175:42 | ... ? ... : ... | E.cs:180:9:183:9 | if (...) ... |
+| E.cs:175:33:175:37 | false | E.cs:175:19:175:42 | ... ? ... : ... |
+| E.cs:177:9:179:9 | {...} | E.cs:180:9:183:9 | if (...) ... |
+| E.cs:180:9:183:9 | if (...) ... | E.cs:181:9:183:9 | {...} |
+| E.cs:181:9:183:9 | {...} | E.cs:184:9:187:9 | if (...) ... |
+| E.cs:184:9:187:9 | if (...) ... | E.cs:186:13:186:15 | access to parameter obj |
+| E.cs:190:29:190:29 | SSA param(o) | E.cs:192:17:192:17 | access to parameter o |
+| E.cs:198:13:198:29 | [b (line 196): false] SSA def(o) | E.cs:203:13:203:13 | access to local variable o |
+| E.cs:198:13:198:29 | [b (line 196): true] SSA def(o) | E.cs:201:13:201:13 | access to local variable o |
+| E.cs:206:28:206:28 | SSA param(s) | E.cs:208:13:208:23 | [false] ... is ... |
+| E.cs:208:13:208:23 | [false] ... is ... | E.cs:210:16:210:16 | access to parameter s |
+| E.cs:217:13:217:20 | [b (line 213): true] SSA def(x) | E.cs:218:9:218:9 | access to local variable x |
+| E.cs:217:13:217:20 | [b (line 213): true] SSA def(x) | E.cs:220:13:220:13 | access to local variable x |
+| E.cs:227:13:227:20 | [b (line 223): true] SSA def(x) | E.cs:229:13:229:13 | access to local variable x |
+| E.cs:227:13:227:20 | [b (line 223): true] SSA def(x) | E.cs:229:13:229:25 | ...; |
+| E.cs:229:13:229:25 | ...; | E.cs:230:9:230:9 | access to local variable x |
+| E.cs:233:26:233:26 | SSA param(i) | E.cs:235:16:235:16 | access to parameter i |
+| E.cs:238:26:238:26 | SSA param(i) | E.cs:240:21:240:21 | access to parameter i |
+| E.cs:283:13:283:22 | [b (line 279): false] SSA def(o) | E.cs:285:9:285:9 | access to local variable o |
+| E.cs:283:13:283:22 | [b (line 279): true] SSA def(o) | E.cs:285:9:285:9 | access to local variable o |
+| E.cs:301:13:301:27 | SSA def(s) | E.cs:302:9:302:9 | access to local variable s |
+| E.cs:319:29:319:30 | SSA param(s1) | E.cs:321:20:321:21 | access to parameter s2 |
+| E.cs:321:13:321:30 | [true] ... is ... | E.cs:323:13:323:14 | access to parameter s1 |
+| E.cs:321:14:321:21 | ... ?? ... | E.cs:321:13:321:30 | [true] ... is ... |
+| E.cs:321:20:321:21 | access to parameter s2 | E.cs:321:14:321:21 | ... ?? ... |
+| E.cs:330:13:330:36 | SSA def(x) | E.cs:331:9:331:9 | access to local variable x |
+| E.cs:342:13:342:32 | SSA def(x) | E.cs:343:9:343:9 | access to local variable x |
+| E.cs:348:17:348:36 | SSA def(x) | E.cs:349:9:349:9 | access to local variable x |
+| E.cs:366:28:366:28 | SSA param(s) | E.cs:366:41:366:41 | access to parameter s |
+| E.cs:374:17:374:31 | SSA def(s) | E.cs:375:20:375:20 | access to local variable s |
+| E.cs:380:24:380:25 | SSA param(e1) | E.cs:382:28:382:29 | access to parameter e2 |
+| E.cs:380:24:380:25 | SSA param(e1) | E.cs:382:28:382:29 | access to parameter e2 |
+| E.cs:380:24:380:25 | SSA param(e1) | E.cs:382:28:382:29 | access to parameter e2 |
+| E.cs:380:30:380:31 | SSA param(e2) | E.cs:382:14:382:37 | [false] ... && ... |
+| E.cs:380:30:380:31 | SSA param(e2) | E.cs:382:14:382:37 | [false] ... && ... |
+| E.cs:380:30:380:31 | SSA param(e2) | E.cs:382:14:382:37 | [false] ... && ... |
+| E.cs:380:30:380:31 | SSA param(e2) | E.cs:382:28:382:29 | access to parameter e2 |
+| E.cs:380:30:380:31 | SSA param(e2) | E.cs:382:28:382:29 | access to parameter e2 |
+| E.cs:380:30:380:31 | SSA param(e2) | E.cs:382:28:382:29 | access to parameter e2 |
+| E.cs:382:13:382:68 | [false] ... \|\| ... | E.cs:384:9:385:24 | if (...) ... |
+| E.cs:382:13:382:68 | [false] ... \|\| ... | E.cs:384:9:385:24 | if (...) ... |
+| E.cs:382:14:382:37 | [false] ... && ... | E.cs:382:44:382:45 | access to parameter e1 |
+| E.cs:382:14:382:37 | [false] ... && ... | E.cs:382:44:382:45 | access to parameter e1 |
+| E.cs:382:28:382:29 | access to parameter e2 | E.cs:382:14:382:37 | [false] ... && ... |
+| E.cs:382:28:382:29 | access to parameter e2 | E.cs:382:14:382:37 | [false] ... && ... |
+| E.cs:382:44:382:45 | access to parameter e1 | E.cs:382:44:382:67 | [false] ... && ... |
+| E.cs:382:44:382:45 | access to parameter e1 | E.cs:382:44:382:67 | [false] ... && ... |
+| E.cs:382:44:382:67 | [false] ... && ... | E.cs:382:13:382:68 | [false] ... \|\| ... |
+| E.cs:382:44:382:67 | [false] ... && ... | E.cs:382:13:382:68 | [false] ... \|\| ... |
+| E.cs:384:9:385:24 | if (...) ... | E.cs:384:13:384:36 | [false] ... && ... |
+| E.cs:384:9:385:24 | if (...) ... | E.cs:384:27:384:28 | access to parameter e2 |
+| E.cs:384:13:384:36 | [false] ... && ... | E.cs:386:16:386:17 | access to parameter e1 |
+| E.cs:384:13:384:36 | [false] ... && ... | E.cs:386:27:386:28 | access to parameter e2 |
+| E.cs:384:27:384:28 | access to parameter e2 | E.cs:384:13:384:36 | [false] ... && ... |
+| E.cs:404:9:404:18 | SSA def(i) | E.cs:405:16:405:16 | access to local variable i |
+| E.cs:404:9:404:18 | SSA def(i) | E.cs:405:16:405:16 | access to local variable i |
+| E.cs:417:24:417:40 | SSA capture def(i) | E.cs:417:34:417:34 | access to parameter i |
+| E.cs:423:28:423:44 | SSA capture def(i) | E.cs:423:38:423:38 | access to parameter i |
+| E.cs:430:29:430:45 | SSA capture def(i) | E.cs:430:39:430:39 | access to parameter i |
+| E.cs:435:29:435:29 | SSA param(s) | E.cs:437:13:437:21 | [true] ... is ... |
+| E.cs:437:13:437:21 | [true] ... is ... | E.cs:439:13:439:13 | access to parameter s |
+| F.cs:7:16:7:23 | SSA def(o) | F.cs:8:9:8:9 | access to local variable o |
+| F.cs:13:17:13:24 | SSA def(o) | F.cs:14:9:14:9 | access to local variable o |
+| Forwarding.cs:7:16:7:23 | SSA def(s) | Forwarding.cs:9:13:9:30 | [false] !... |
+| Forwarding.cs:9:13:9:30 | [false] !... | Forwarding.cs:14:9:17:9 | if (...) ... |
+| Forwarding.cs:14:9:17:9 | if (...) ... | Forwarding.cs:19:9:22:9 | if (...) ... |
+| Forwarding.cs:19:9:22:9 | if (...) ... | Forwarding.cs:19:13:19:23 | [false] !... |
+| Forwarding.cs:19:13:19:23 | [false] !... | Forwarding.cs:24:9:27:9 | if (...) ... |
+| Forwarding.cs:24:9:27:9 | if (...) ... | Forwarding.cs:29:9:32:9 | if (...) ... |
+| Forwarding.cs:29:9:32:9 | if (...) ... | Forwarding.cs:34:9:37:9 | if (...) ... |
+| Forwarding.cs:34:9:37:9 | if (...) ... | Forwarding.cs:35:9:37:9 | {...} |
+| Forwarding.cs:34:9:37:9 | if (...) ... | Forwarding.cs:36:31:36:31 | access to local variable s |
+| Forwarding.cs:35:9:37:9 | {...} | Forwarding.cs:40:27:40:27 | access to local variable s |
+| GuardedString.cs:7:16:7:32 | SSA def(s) | GuardedString.cs:9:13:9:36 | [false] !... |
+| GuardedString.cs:9:13:9:36 | [false] !... | GuardedString.cs:14:9:17:9 | if (...) ... |
+| GuardedString.cs:14:9:17:9 | if (...) ... | GuardedString.cs:14:13:14:41 | [false] !... |
+| GuardedString.cs:14:13:14:41 | [false] !... | GuardedString.cs:19:9:20:40 | if (...) ... |
+| GuardedString.cs:19:9:20:40 | if (...) ... | GuardedString.cs:19:26:19:26 | 0 |
+| GuardedString.cs:19:26:19:26 | 0 | GuardedString.cs:22:9:23:40 | if (...) ... |
+| GuardedString.cs:22:9:23:40 | if (...) ... | GuardedString.cs:22:25:22:25 | 0 |
+| GuardedString.cs:22:25:22:25 | 0 | GuardedString.cs:25:9:26:40 | if (...) ... |
+| GuardedString.cs:25:9:26:40 | if (...) ... | GuardedString.cs:25:26:25:26 | 0 |
+| GuardedString.cs:25:26:25:26 | 0 | GuardedString.cs:28:9:29:40 | if (...) ... |
+| GuardedString.cs:28:9:29:40 | if (...) ... | GuardedString.cs:28:25:28:26 | 10 |
+| GuardedString.cs:28:25:28:26 | 10 | GuardedString.cs:31:9:32:40 | if (...) ... |
+| GuardedString.cs:31:9:32:40 | if (...) ... | GuardedString.cs:31:26:31:27 | 10 |
+| GuardedString.cs:31:26:31:27 | 10 | GuardedString.cs:34:9:37:40 | if (...) ... |
+| GuardedString.cs:34:9:37:40 | if (...) ... | GuardedString.cs:34:26:34:26 | 0 |
+| GuardedString.cs:34:26:34:26 | 0 | GuardedString.cs:35:31:35:31 | access to local variable s |
+| NullAlwaysBad.cs:7:29:7:29 | SSA param(s) | NullAlwaysBad.cs:9:30:9:30 | access to parameter s |
+| NullMaybeBad.cs:13:17:13:20 | null | NullMaybeBad.cs:7:27:7:27 | access to parameter o |
+| Params.cs:20:12:20:15 | null | Params.cs:14:17:14:20 | access to parameter args |
+| StringConcatenation.cs:14:16:14:23 | SSA def(s) | StringConcatenation.cs:15:16:15:16 | access to local variable s |
+| StringConcatenation.cs:15:16:15:16 | access to local variable s | StringConcatenation.cs:16:17:16:17 | access to local variable s |
 nodes
 | A.cs:7:16:7:40 | SSA def(synchronizedAlways) |
 | A.cs:8:15:8:32 | access to local variable synchronizedAlways |
@@ -415,6 +896,10 @@ nodes
 | E.cs:435:29:435:29 | SSA param(s) |
 | E.cs:437:13:437:21 | [true] ... is ... |
 | E.cs:439:13:439:13 | access to parameter s |
+| F.cs:7:16:7:23 | SSA def(o) |
+| F.cs:8:9:8:9 | access to local variable o |
+| F.cs:13:17:13:24 | SSA def(o) |
+| F.cs:14:9:14:9 | access to local variable o |
 | Forwarding.cs:7:16:7:23 | SSA def(s) |
 | Forwarding.cs:9:13:9:30 | [false] !... |
 | Forwarding.cs:14:9:17:9 | if (...) ... |
@@ -452,482 +937,3 @@ nodes
 | StringConcatenation.cs:14:16:14:23 | SSA def(s) |
 | StringConcatenation.cs:15:16:15:16 | access to local variable s |
 | StringConcatenation.cs:16:17:16:17 | access to local variable s |
-edges
-| A.cs:7:16:7:40 | SSA def(synchronizedAlways) | A.cs:8:15:8:32 | access to local variable synchronizedAlways |
-| A.cs:7:16:7:40 | SSA def(synchronizedAlways) | A.cs:10:13:10:30 | access to local variable synchronizedAlways |
-| A.cs:16:15:16:30 | SSA def(arrayNull) | A.cs:17:9:17:17 | access to local variable arrayNull |
-| A.cs:26:15:26:32 | SSA def(arrayAccess) | A.cs:31:27:31:37 | access to local variable arrayAccess |
-| A.cs:26:15:26:32 | SSA def(arrayAccess) | A.cs:36:27:36:37 | access to local variable arrayAccess |
-| A.cs:27:18:27:35 | SSA def(fieldAccess) | A.cs:32:27:32:37 | access to local variable fieldAccess |
-| A.cs:27:18:27:35 | SSA def(fieldAccess) | A.cs:37:27:37:37 | access to local variable fieldAccess |
-| A.cs:28:16:28:34 | SSA def(methodAccess) | A.cs:33:28:33:39 | access to local variable methodAccess |
-| A.cs:28:16:28:34 | SSA def(methodAccess) | A.cs:38:15:38:26 | access to local variable methodAccess |
-| A.cs:29:16:29:32 | SSA def(methodCall) | A.cs:34:27:34:36 | access to local variable methodCall |
-| A.cs:29:16:29:32 | SSA def(methodCall) | A.cs:39:27:39:36 | access to local variable methodCall |
-| A.cs:48:16:48:28 | SSA def(varRef) | A.cs:50:9:50:14 | access to local variable varRef |
-| Assert.cs:13:9:13:25 | [b (line 7): false] SSA def(s) | Assert.cs:15:27:15:27 | access to local variable s |
-| Assert.cs:13:9:13:25 | [b (line 7): true] SSA def(s) | Assert.cs:15:27:15:27 | access to local variable s |
-| Assert.cs:21:9:21:25 | [b (line 7): false] SSA def(s) | Assert.cs:23:27:23:27 | access to local variable s |
-| Assert.cs:21:9:21:25 | [b (line 7): true] SSA def(s) | Assert.cs:23:27:23:27 | access to local variable s |
-| Assert.cs:29:9:29:25 | [b (line 7): false] SSA def(s) | Assert.cs:31:27:31:27 | access to local variable s |
-| Assert.cs:29:9:29:25 | [b (line 7): true] SSA def(s) | Assert.cs:31:27:31:27 | access to local variable s |
-| Assert.cs:45:9:45:25 | [b (line 7): true] SSA def(s) | Assert.cs:46:36:46:36 | [b (line 7): true] access to parameter b |
-| Assert.cs:46:23:46:36 | [true, b (line 7): true] ... && ... | Assert.cs:47:27:47:27 | access to local variable s |
-| Assert.cs:46:36:46:36 | [b (line 7): true] access to parameter b | Assert.cs:46:23:46:36 | [true, b (line 7): true] ... && ... |
-| Assert.cs:49:9:49:25 | [b (line 7): true] SSA def(s) | Assert.cs:50:38:50:38 | [b (line 7): true] access to parameter b |
-| Assert.cs:50:24:50:38 | [false] ... \|\| ... | Assert.cs:51:27:51:27 | access to local variable s |
-| Assert.cs:50:37:50:38 | [false] !... | Assert.cs:50:24:50:38 | [false] ... \|\| ... |
-| Assert.cs:50:38:50:38 | [b (line 7): true] access to parameter b | Assert.cs:50:37:50:38 | [false] !... |
-| B.cs:7:11:7:29 | SSA def(eqCallAlways) | B.cs:13:13:13:24 | access to local variable eqCallAlways |
-| B.cs:10:11:10:30 | SSA def(neqCallAlways) | B.cs:13:13:13:36 | ...; |
-| B.cs:10:11:10:30 | SSA def(neqCallAlways) | B.cs:15:9:16:26 | if (...) ... |
-| B.cs:13:13:13:36 | ...; | B.cs:15:9:16:26 | if (...) ... |
-| B.cs:15:9:16:26 | if (...) ... | B.cs:16:13:16:26 | ...; |
-| B.cs:15:9:16:26 | if (...) ... | B.cs:18:9:20:26 | if (...) ... |
-| B.cs:16:13:16:26 | ...; | B.cs:18:9:20:26 | if (...) ... |
-| B.cs:18:9:20:26 | if (...) ... | B.cs:18:25:18:27 | {...} |
-| B.cs:18:9:20:26 | if (...) ... | B.cs:20:13:20:26 | ...; |
-| B.cs:18:25:18:27 | {...} | B.cs:22:9:24:37 | if (...) ... |
-| B.cs:20:13:20:26 | ...; | B.cs:22:9:24:37 | if (...) ... |
-| B.cs:22:9:24:37 | if (...) ... | B.cs:24:13:24:25 | access to local variable neqCallAlways |
-| C.cs:10:16:10:23 | SSA def(o) | C.cs:11:17:11:28 | [false] !... |
-| C.cs:11:13:11:30 | [false] !... | C.cs:16:9:19:9 | if (...) ... |
-| C.cs:11:15:11:29 | [true] !... | C.cs:11:13:11:30 | [false] !... |
-| C.cs:11:17:11:28 | [false] !... | C.cs:11:15:11:29 | [true] !... |
-| C.cs:16:9:19:9 | if (...) ... | C.cs:16:13:16:24 | [true] !... |
-| C.cs:16:13:16:24 | [true] !... | C.cs:18:13:18:13 | access to local variable o |
-| C.cs:40:13:40:35 | SSA def(s) | C.cs:42:9:42:9 | access to local variable s |
-| C.cs:55:13:55:36 | SSA def(o2) | C.cs:57:9:57:10 | access to local variable o2 |
-| C.cs:62:13:62:46 | SSA def(o1) | C.cs:64:9:64:10 | access to local variable o1 |
-| C.cs:66:13:66:46 | SSA def(o2) | C.cs:68:9:68:10 | access to local variable o2 |
-| C.cs:94:13:94:45 | SSA def(o) | C.cs:95:15:95:15 | access to local variable o |
-| C.cs:94:13:94:45 | SSA def(o) | C.cs:96:13:96:13 | access to local variable o |
-| C.cs:102:13:102:23 | SSA def(list) | C.cs:103:27:103:30 | access to parameter list |
-| C.cs:102:13:102:23 | SSA def(list) | C.cs:103:27:103:30 | access to parameter list |
-| C.cs:103:9:107:9 | foreach (... ... in ...) ... | C.cs:103:22:103:22 | Int32 x |
-| C.cs:103:9:107:9 | foreach (... ... in ...) ... | C.cs:106:13:106:16 | access to parameter list |
-| C.cs:103:22:103:22 | Int32 x | C.cs:103:9:107:9 | foreach (... ... in ...) ... |
-| C.cs:103:27:103:30 | access to parameter list | C.cs:103:9:107:9 | foreach (... ... in ...) ... |
-| C.cs:159:9:159:16 | SSA def(s) | C.cs:162:13:162:13 | access to local variable s |
-| C.cs:167:9:167:16 | SSA def(s) | C.cs:170:13:170:13 | access to local variable s |
-| C.cs:178:13:178:20 | SSA def(s) | C.cs:177:13:177:13 | access to local variable s |
-| C.cs:193:9:193:16 | SSA def(s) | C.cs:196:13:196:13 | access to local variable s |
-| C.cs:197:13:197:20 | [b (line 192): true] SSA def(s) | C.cs:196:13:196:13 | access to local variable s |
-| C.cs:201:16:201:19 | true | C.cs:203:13:203:13 | access to local variable s |
-| C.cs:204:13:204:20 | SSA def(s) | C.cs:201:16:201:19 | true |
-| C.cs:210:13:210:35 | SSA def(s) | C.cs:217:9:218:25 | if (...) ... |
-| C.cs:214:13:214:20 | SSA def(s) | C.cs:217:9:218:25 | if (...) ... |
-| C.cs:217:9:218:25 | if (...) ... | C.cs:218:13:218:13 | access to local variable s |
-| C.cs:222:13:222:20 | SSA def(s) | C.cs:223:9:223:9 | access to local variable s |
-| C.cs:229:22:229:22 | access to local variable s | C.cs:233:9:233:9 | access to local variable s |
-| C.cs:229:33:229:40 | SSA def(s) | C.cs:229:22:229:22 | access to local variable s |
-| C.cs:235:14:235:21 | SSA def(s) | C.cs:235:24:235:24 | access to local variable s |
-| C.cs:235:24:235:24 | access to local variable s | C.cs:237:13:237:13 | access to local variable s |
-| C.cs:235:35:235:42 | SSA def(s) | C.cs:235:24:235:24 | access to local variable s |
-| C.cs:240:24:240:31 | SSA def(s) | C.cs:242:13:242:13 | access to local variable s |
-| C.cs:248:15:248:22 | SSA def(a) | C.cs:249:9:249:9 | access to local variable a |
-| C.cs:257:15:257:23 | SSA def(ia) | C.cs:260:9:260:10 | access to local variable ia |
-| C.cs:257:15:257:23 | SSA def(ia) | C.cs:263:9:263:10 | access to local variable ia |
-| C.cs:258:18:258:26 | SSA def(sa) | C.cs:261:20:261:21 | access to local variable sa |
-| C.cs:258:18:258:26 | SSA def(sa) | C.cs:264:16:264:17 | access to local variable sa |
-| D.cs:17:17:17:20 | null | D.cs:23:9:23:13 | access to parameter param |
-| D.cs:26:32:26:36 | SSA param(param) | D.cs:32:9:32:13 | access to parameter param |
-| D.cs:58:13:58:41 | SSA def(o5) | D.cs:61:9:62:26 | if (...) ... |
-| D.cs:61:9:62:26 | if (...) ... | D.cs:62:13:62:14 | access to local variable o5 |
-| D.cs:68:13:68:34 | SSA def(o7) | D.cs:69:18:69:36 | ... && ... |
-| D.cs:69:18:69:36 | ... && ... | D.cs:73:13:73:14 | access to local variable o7 |
-| D.cs:75:13:75:34 | SSA def(o8) | D.cs:76:34:76:35 | 42 |
-| D.cs:76:21:76:43 | ... ? ... : ... | D.cs:79:9:80:26 | if (...) ... |
-| D.cs:76:34:76:35 | 42 | D.cs:76:21:76:43 | ... ? ... : ... |
-| D.cs:79:9:80:26 | if (...) ... | D.cs:81:9:82:26 | if (...) ... |
-| D.cs:81:9:82:26 | if (...) ... | D.cs:82:13:82:14 | access to local variable o8 |
-| D.cs:81:9:82:26 | if (...) ... | D.cs:82:13:82:26 | ...; |
-| D.cs:81:9:82:26 | if (...) ... | D.cs:83:9:84:26 | if (...) ... |
-| D.cs:82:13:82:26 | ...; | D.cs:83:9:84:26 | if (...) ... |
-| D.cs:83:9:84:26 | if (...) ... | D.cs:84:13:84:14 | access to local variable o8 |
-| D.cs:89:15:89:44 | SSA def(xs) | D.cs:91:13:91:14 | access to local variable xs |
-| D.cs:89:15:89:44 | SSA def(xs) | D.cs:91:13:91:22 | ...; |
-| D.cs:89:15:89:44 | SSA def(xs) | D.cs:93:9:94:30 | if (...) ... |
-| D.cs:91:13:91:22 | ...; | D.cs:93:9:94:30 | if (...) ... |
-| D.cs:93:9:94:30 | if (...) ... | D.cs:94:13:94:30 | ...; |
-| D.cs:93:9:94:30 | if (...) ... | D.cs:94:21:94:22 | access to local variable xs |
-| D.cs:93:9:94:30 | if (...) ... | D.cs:96:9:99:9 | if (...) ... |
-| D.cs:94:13:94:30 | ...; | D.cs:96:9:99:9 | if (...) ... |
-| D.cs:96:9:99:9 | if (...) ... | D.cs:97:9:99:9 | {...} |
-| D.cs:96:9:99:9 | if (...) ... | D.cs:98:21:98:22 | access to local variable xs |
-| D.cs:96:9:99:9 | if (...) ... | D.cs:101:9:102:35 | if (...) ... |
-| D.cs:97:9:99:9 | {...} | D.cs:101:9:102:35 | if (...) ... |
-| D.cs:101:9:102:35 | if (...) ... | D.cs:102:31:102:32 | access to local variable xs |
-| D.cs:101:9:102:35 | if (...) ... | D.cs:102:31:102:32 | access to local variable xs |
-| D.cs:101:9:102:35 | if (...) ... | D.cs:104:9:106:30 | if (...) ... |
-| D.cs:102:13:102:35 | foreach (... ... in ...) ... | D.cs:102:26:102:26 | Int32 _ |
-| D.cs:102:13:102:35 | foreach (... ... in ...) ... | D.cs:104:9:106:30 | if (...) ... |
-| D.cs:102:26:102:26 | Int32 _ | D.cs:102:13:102:35 | foreach (... ... in ...) ... |
-| D.cs:102:31:102:32 | access to local variable xs | D.cs:102:13:102:35 | foreach (... ... in ...) ... |
-| D.cs:104:9:106:30 | if (...) ... | D.cs:105:19:105:20 | access to local variable xs |
-| D.cs:104:9:106:30 | if (...) ... | D.cs:106:17:106:18 | access to local variable xs |
-| D.cs:118:9:118:30 | SSA def(x) | D.cs:120:13:120:13 | access to local variable x |
-| D.cs:125:35:125:35 | SSA param(a) | D.cs:127:32:127:32 | 0 |
-| D.cs:125:35:125:35 | SSA param(a) | D.cs:127:32:127:32 | 0 |
-| D.cs:125:44:125:44 | SSA param(b) | D.cs:127:32:127:32 | 0 |
-| D.cs:125:44:125:44 | SSA param(b) | D.cs:127:36:127:36 | access to parameter a |
-| D.cs:127:20:127:43 | ... ? ... : ... | D.cs:128:32:128:32 | 0 |
-| D.cs:127:20:127:43 | ... ? ... : ... | D.cs:128:32:128:32 | 0 |
-| D.cs:127:20:127:43 | ... ? ... : ... | D.cs:128:36:128:36 | access to parameter b |
-| D.cs:127:32:127:32 | 0 | D.cs:127:20:127:43 | ... ? ... : ... |
-| D.cs:127:32:127:32 | 0 | D.cs:127:20:127:43 | ... ? ... : ... |
-| D.cs:127:36:127:36 | access to parameter a | D.cs:127:20:127:43 | ... ? ... : ... |
-| D.cs:128:20:128:43 | ... ? ... : ... | D.cs:131:9:137:9 | {...} |
-| D.cs:128:20:128:43 | ... ? ... : ... | D.cs:131:9:137:9 | {...} |
-| D.cs:128:20:128:43 | ... ? ... : ... | D.cs:138:9:138:18 | ... ...; |
-| D.cs:128:32:128:32 | 0 | D.cs:128:20:128:43 | ... ? ... : ... |
-| D.cs:128:32:128:32 | 0 | D.cs:128:20:128:43 | ... ? ... : ... |
-| D.cs:128:36:128:36 | access to parameter b | D.cs:128:20:128:43 | ... ? ... : ... |
-| D.cs:131:9:137:9 | {...} | D.cs:132:29:132:29 | access to local variable i |
-| D.cs:131:9:137:9 | {...} | D.cs:132:29:132:29 | access to local variable i |
-| D.cs:132:29:132:29 | access to local variable i | D.cs:133:13:136:13 | {...} |
-| D.cs:132:29:132:29 | access to local variable i | D.cs:133:13:136:13 | {...} |
-| D.cs:132:29:132:29 | access to local variable i | D.cs:134:24:134:24 | access to parameter a |
-| D.cs:132:29:132:29 | access to local variable i | D.cs:135:24:135:24 | access to parameter b |
-| D.cs:132:29:132:29 | access to local variable i | D.cs:138:9:138:18 | ... ...; |
-| D.cs:133:13:136:13 | {...} | D.cs:132:29:132:29 | access to local variable i |
-| D.cs:133:13:136:13 | {...} | D.cs:132:29:132:29 | access to local variable i |
-| D.cs:138:9:138:18 | ... ...; | D.cs:142:13:142:22 | ...; |
-| D.cs:142:13:142:22 | ...; | D.cs:143:9:146:9 | for (...;...;...) ... |
-| D.cs:143:9:146:9 | for (...;...;...) ... | D.cs:143:25:143:25 | access to local variable i |
-| D.cs:143:25:143:25 | access to local variable i | D.cs:144:9:146:9 | {...} |
-| D.cs:143:25:143:25 | access to local variable i | D.cs:145:20:145:20 | access to parameter a |
-| D.cs:144:9:146:9 | {...} | D.cs:143:25:143:25 | access to local variable i |
-| D.cs:149:36:149:38 | SSA param(obj) | D.cs:151:9:151:11 | access to parameter obj |
-| D.cs:163:16:163:25 | SSA def(obj) | D.cs:168:9:170:9 | [exception: Exception] catch (...) {...} |
-| D.cs:168:9:170:9 | [exception: Exception] catch (...) {...} | D.cs:168:26:168:26 | [exception: Exception] Exception e |
-| D.cs:168:26:168:26 | [exception: Exception] Exception e | D.cs:171:9:171:11 | access to local variable obj |
-| D.cs:240:9:240:16 | SSA def(o) | D.cs:241:29:241:32 | null |
-| D.cs:240:9:240:16 | SSA def(o) | D.cs:241:36:241:37 | "" |
-| D.cs:241:21:241:37 | ... ? ... : ... | D.cs:244:9:247:25 | if (...) ... |
-| D.cs:241:29:241:32 | null | D.cs:241:21:241:37 | ... ? ... : ... |
-| D.cs:241:36:241:37 | "" | D.cs:241:21:241:37 | ... ? ... : ... |
-| D.cs:244:9:247:25 | if (...) ... | D.cs:245:13:245:13 | access to local variable o |
-| D.cs:244:9:247:25 | if (...) ... | D.cs:247:13:247:13 | access to local variable o |
-| D.cs:249:13:249:38 | SSA def(o2) | D.cs:253:13:253:14 | access to local variable o2 |
-| D.cs:258:16:258:23 | SSA def(o) | D.cs:266:9:267:25 | if (...) ... |
-| D.cs:266:9:267:25 | if (...) ... | D.cs:266:13:266:27 | [true] ... is ... |
-| D.cs:266:13:266:27 | [true] ... is ... | D.cs:267:13:267:13 | access to local variable o |
-| D.cs:269:9:269:16 | SSA def(o) | D.cs:272:25:272:25 | access to local variable i |
-| D.cs:272:25:272:25 | access to local variable i | D.cs:273:9:288:9 | {...} |
-| D.cs:272:25:272:25 | access to local variable i | D.cs:290:9:291:25 | if (...) ... |
-| D.cs:272:39:272:39 | access to local variable i | D.cs:272:25:272:25 | access to local variable i |
-| D.cs:273:9:288:9 | {...} | D.cs:281:13:287:13 | if (...) ... |
-| D.cs:281:13:287:13 | if (...) ... | D.cs:272:39:272:39 | access to local variable i |
-| D.cs:283:17:283:24 | SSA def(o) | D.cs:285:28:285:30 | {...} |
-| D.cs:283:17:283:24 | SSA def(o) | D.cs:286:17:286:30 | ...; |
-| D.cs:285:28:285:30 | {...} | D.cs:286:17:286:30 | ...; |
-| D.cs:286:17:286:30 | ...; | D.cs:272:39:272:39 | access to local variable i |
-| D.cs:290:9:291:25 | if (...) ... | D.cs:291:13:291:13 | access to local variable o |
-| D.cs:290:9:291:25 | if (...) ... | D.cs:291:13:291:25 | ...; |
-| D.cs:290:9:291:25 | if (...) ... | D.cs:293:9:294:25 | if (...) ... |
-| D.cs:291:13:291:25 | ...; | D.cs:293:9:294:25 | if (...) ... |
-| D.cs:293:9:294:25 | if (...) ... | D.cs:294:13:294:13 | access to local variable o |
-| D.cs:296:16:296:26 | SSA def(prev) | D.cs:297:25:297:25 | access to local variable i |
-| D.cs:297:25:297:25 | access to local variable i | D.cs:298:9:302:9 | {...} |
-| D.cs:298:9:302:9 | {...} | D.cs:300:17:300:20 | access to local variable prev |
-| D.cs:304:16:304:23 | SSA def(s) | D.cs:307:13:311:13 | foreach (... ... in ...) ... |
-| D.cs:307:13:311:13 | foreach (... ... in ...) ... | D.cs:312:13:313:29 | if (...) ... |
-| D.cs:312:13:313:29 | if (...) ... | D.cs:312:17:312:23 | [true] !... |
-| D.cs:312:17:312:23 | [true] !... | D.cs:313:17:313:17 | access to local variable s |
-| D.cs:316:16:316:23 | SSA def(r) | D.cs:318:16:318:19 | access to local variable stat |
-| D.cs:318:16:318:19 | access to local variable stat | D.cs:318:16:318:62 | [false] ... && ... |
-| D.cs:318:16:318:19 | access to local variable stat | D.cs:318:41:318:44 | access to local variable stat |
-| D.cs:318:16:318:62 | [false] ... && ... | D.cs:324:9:324:9 | access to local variable r |
-| D.cs:318:41:318:44 | access to local variable stat | D.cs:318:16:318:62 | [false] ... && ... |
-| D.cs:351:15:351:22 | SSA def(a) | D.cs:355:9:356:21 | for (...;...;...) ... |
-| D.cs:355:9:356:21 | for (...;...;...) ... | D.cs:355:25:355:25 | access to local variable i |
-| D.cs:355:25:355:25 | access to local variable i | D.cs:356:13:356:13 | access to local variable a |
-| D.cs:355:25:355:25 | access to local variable i | D.cs:356:13:356:21 | ...; |
-| D.cs:356:13:356:21 | ...; | D.cs:355:25:355:25 | access to local variable i |
-| D.cs:360:20:360:30 | SSA def(last) | D.cs:361:29:361:29 | access to local variable i |
-| D.cs:361:29:361:29 | access to local variable i | D.cs:363:13:363:16 | access to local variable last |
-| D.cs:366:15:366:47 | SSA def(b) | D.cs:367:13:367:56 | [false] ... && ... |
-| D.cs:367:13:367:56 | [false] ... && ... | D.cs:370:9:373:9 | for (...;...;...) ... |
-| D.cs:370:9:373:9 | for (...;...;...) ... | D.cs:370:25:370:25 | access to local variable i |
-| D.cs:370:25:370:25 | access to local variable i | D.cs:371:9:373:9 | {...} |
-| D.cs:370:25:370:25 | access to local variable i | D.cs:372:13:372:13 | access to local variable b |
-| D.cs:371:9:373:9 | {...} | D.cs:370:25:370:25 | access to local variable i |
-| D.cs:378:19:378:28 | SSA def(ioe) | D.cs:382:9:385:27 | if (...) ... |
-| D.cs:382:9:385:27 | if (...) ... | D.cs:385:13:385:15 | access to local variable ioe |
-| D.cs:388:36:388:36 | SSA param(a) | D.cs:390:32:390:32 | 0 |
-| D.cs:388:45:388:45 | SSA param(b) | D.cs:390:32:390:32 | 0 |
-| D.cs:388:45:388:45 | SSA param(b) | D.cs:390:36:390:36 | access to parameter a |
-| D.cs:390:20:390:43 | ... ? ... : ... | D.cs:393:21:393:21 | access to local variable i |
-| D.cs:390:20:390:43 | ... ? ... : ... | D.cs:393:21:393:21 | access to local variable i |
-| D.cs:390:32:390:32 | 0 | D.cs:390:20:390:43 | ... ? ... : ... |
-| D.cs:390:32:390:32 | 0 | D.cs:390:20:390:43 | ... ? ... : ... |
-| D.cs:390:36:390:36 | access to parameter a | D.cs:390:20:390:43 | ... ? ... : ... |
-| D.cs:393:21:393:21 | access to local variable i | D.cs:394:9:396:9 | {...} |
-| D.cs:393:21:393:21 | access to local variable i | D.cs:394:9:396:9 | {...} |
-| D.cs:393:21:393:21 | access to local variable i | D.cs:395:20:395:20 | access to parameter a |
-| D.cs:393:21:393:21 | access to local variable i | D.cs:397:9:397:44 | ... ...; |
-| D.cs:394:9:396:9 | {...} | D.cs:393:21:393:21 | access to local variable i |
-| D.cs:394:9:396:9 | {...} | D.cs:393:21:393:21 | access to local variable i |
-| D.cs:397:9:397:44 | ... ...; | D.cs:397:32:397:32 | 0 |
-| D.cs:397:20:397:43 | ... ? ... : ... | D.cs:398:21:398:21 | access to local variable i |
-| D.cs:397:32:397:32 | 0 | D.cs:397:20:397:43 | ... ? ... : ... |
-| D.cs:398:21:398:21 | access to local variable i | D.cs:399:9:401:9 | {...} |
-| D.cs:398:21:398:21 | access to local variable i | D.cs:400:20:400:20 | access to parameter b |
-| D.cs:399:9:401:9 | {...} | D.cs:398:21:398:21 | access to local variable i |
-| D.cs:405:35:405:35 | SSA param(x) | D.cs:407:14:407:35 | [false] ... && ... |
-| D.cs:405:35:405:35 | SSA param(x) | D.cs:407:14:407:35 | [false] ... && ... |
-| D.cs:405:35:405:35 | SSA param(x) | D.cs:407:14:407:35 | [false] ... && ... |
-| D.cs:405:45:405:45 | SSA param(y) | D.cs:407:14:407:35 | [false] ... && ... |
-| D.cs:405:45:405:45 | SSA param(y) | D.cs:407:14:407:35 | [false] ... && ... |
-| D.cs:405:45:405:45 | SSA param(y) | D.cs:407:14:407:35 | [false] ... && ... |
-| D.cs:407:13:407:64 | [false] ... \|\| ... | D.cs:409:9:410:25 | if (...) ... |
-| D.cs:407:13:407:64 | [false] ... \|\| ... | D.cs:409:9:410:25 | if (...) ... |
-| D.cs:407:14:407:35 | [false] ... && ... | D.cs:407:42:407:42 | access to parameter x |
-| D.cs:407:14:407:35 | [false] ... && ... | D.cs:407:42:407:42 | access to parameter x |
-| D.cs:407:42:407:42 | access to parameter x | D.cs:407:42:407:63 | [false] ... && ... |
-| D.cs:407:42:407:42 | access to parameter x | D.cs:407:55:407:55 | access to parameter y |
-| D.cs:407:42:407:42 | access to parameter x | D.cs:407:55:407:55 | access to parameter y |
-| D.cs:407:42:407:63 | [false] ... && ... | D.cs:407:13:407:64 | [false] ... \|\| ... |
-| D.cs:407:42:407:63 | [false] ... && ... | D.cs:407:13:407:64 | [false] ... \|\| ... |
-| D.cs:407:55:407:55 | access to parameter y | D.cs:407:42:407:63 | [false] ... && ... |
-| D.cs:407:55:407:55 | access to parameter y | D.cs:407:42:407:63 | [false] ... && ... |
-| D.cs:409:9:410:25 | if (...) ... | D.cs:410:13:410:13 | access to parameter y |
-| D.cs:409:9:410:25 | if (...) ... | D.cs:411:9:412:25 | if (...) ... |
-| D.cs:411:9:412:25 | if (...) ... | D.cs:412:13:412:13 | access to parameter x |
-| E.cs:9:18:9:26 | SSA def(a2) | E.cs:10:22:10:54 | ... && ... |
-| E.cs:10:22:10:54 | ... && ... | E.cs:12:38:12:39 | access to local variable a2 |
-| E.cs:11:16:11:24 | SSA def(a3) | E.cs:12:22:12:52 | ... && ... |
-| E.cs:12:22:12:52 | ... && ... | E.cs:14:13:14:14 | access to local variable a3 |
-| E.cs:23:13:23:30 | SSA def(s1) | E.cs:24:33:24:36 | null |
-| E.cs:24:18:24:41 | ... ? ... : ... | E.cs:26:9:27:26 | if (...) ... |
-| E.cs:24:33:24:36 | null | E.cs:24:18:24:41 | ... ? ... : ... |
-| E.cs:26:9:27:26 | if (...) ... | E.cs:27:13:27:14 | access to local variable s1 |
-| E.cs:51:22:51:33 | SSA def(slice) | E.cs:53:16:53:19 | access to local variable iter |
-| E.cs:53:16:53:19 | access to local variable iter | E.cs:54:9:63:9 | {...} |
-| E.cs:54:9:63:9 | {...} | E.cs:61:13:61:17 | access to local variable slice |
-| E.cs:54:9:63:9 | {...} | E.cs:61:13:61:27 | ...; |
-| E.cs:61:13:61:27 | ...; | E.cs:53:16:53:19 | access to local variable iter |
-| E.cs:66:40:66:42 | SSA param(arr) | E.cs:70:13:70:50 | ...; |
-| E.cs:66:40:66:42 | SSA param(arr) | E.cs:72:9:73:23 | if (...) ... |
-| E.cs:70:13:70:50 | ...; | E.cs:70:36:70:36 | 0 |
-| E.cs:70:22:70:49 | ... ? ... : ... | E.cs:72:9:73:23 | if (...) ... |
-| E.cs:70:36:70:36 | 0 | E.cs:70:22:70:49 | ... ? ... : ... |
-| E.cs:72:9:73:23 | if (...) ... | E.cs:73:13:73:15 | access to parameter arr |
-| E.cs:107:15:107:25 | SSA def(arr2) | E.cs:111:9:112:30 | for (...;...;...) ... |
-| E.cs:111:9:112:30 | for (...;...;...) ... | E.cs:111:25:111:25 | access to local variable i |
-| E.cs:111:25:111:25 | access to local variable i | E.cs:112:13:112:16 | access to local variable arr2 |
-| E.cs:111:25:111:25 | access to local variable i | E.cs:112:13:112:30 | ...; |
-| E.cs:112:13:112:30 | ...; | E.cs:111:25:111:25 | access to local variable i |
-| E.cs:120:16:120:20 | [true] !... | E.cs:121:9:143:9 | {...} |
-| E.cs:120:17:120:20 | access to local variable stop | E.cs:120:16:120:20 | [true] !... |
-| E.cs:121:9:143:9 | {...} | E.cs:123:21:123:24 | access to local variable stop |
-| E.cs:123:20:123:24 | [false] !... | E.cs:123:20:123:35 | [false] ... && ... |
-| E.cs:123:20:123:24 | [true] !... | E.cs:123:29:123:29 | access to local variable j |
-| E.cs:123:20:123:35 | [false] ... && ... | E.cs:120:17:120:20 | access to local variable stop |
-| E.cs:123:20:123:35 | [true] ... && ... | E.cs:124:13:142:13 | {...} |
-| E.cs:123:20:123:35 | [true] ... && ... | E.cs:125:33:125:35 | access to local variable obj |
-| E.cs:123:21:123:24 | access to local variable stop | E.cs:123:20:123:24 | [false] !... |
-| E.cs:123:21:123:24 | access to local variable stop | E.cs:123:20:123:24 | [true] !... |
-| E.cs:123:29:123:29 | access to local variable j | E.cs:123:20:123:35 | [false] ... && ... |
-| E.cs:123:29:123:29 | access to local variable j | E.cs:123:20:123:35 | [true] ... && ... |
-| E.cs:124:13:142:13 | {...} | E.cs:128:21:128:23 | access to local variable obj |
-| E.cs:124:13:142:13 | {...} | E.cs:141:17:141:26 | ...; |
-| E.cs:137:25:137:34 | SSA def(obj) | E.cs:139:21:139:29 | continue; |
-| E.cs:139:21:139:29 | continue; | E.cs:123:21:123:24 | access to local variable stop |
-| E.cs:141:17:141:26 | ...; | E.cs:123:21:123:24 | access to local variable stop |
-| E.cs:152:16:152:26 | SSA def(obj2) | E.cs:153:13:153:54 | [false] ... && ... |
-| E.cs:153:13:153:54 | [false] ... && ... | E.cs:158:9:159:28 | if (...) ... |
-| E.cs:158:9:159:28 | if (...) ... | E.cs:159:13:159:16 | access to local variable obj2 |
-| E.cs:162:28:162:28 | SSA param(a) | E.cs:164:29:164:29 | 0 |
-| E.cs:164:17:164:40 | ... ? ... : ... | E.cs:165:25:165:25 | access to local variable i |
-| E.cs:164:29:164:29 | 0 | E.cs:164:17:164:40 | ... ? ... : ... |
-| E.cs:165:25:165:25 | access to local variable i | E.cs:166:9:170:9 | {...} |
-| E.cs:165:25:165:25 | access to local variable i | E.cs:167:21:167:21 | access to parameter a |
-| E.cs:165:32:165:32 | access to local variable i | E.cs:165:25:165:25 | access to local variable i |
-| E.cs:166:9:170:9 | {...} | E.cs:165:32:165:32 | access to local variable i |
-| E.cs:173:29:173:31 | SSA param(obj) | E.cs:175:33:175:37 | false |
-| E.cs:173:29:173:31 | SSA param(obj) | E.cs:175:33:175:37 | false |
-| E.cs:175:19:175:42 | ... ? ... : ... | E.cs:177:9:179:9 | {...} |
-| E.cs:175:19:175:42 | ... ? ... : ... | E.cs:178:13:178:15 | access to parameter obj |
-| E.cs:175:19:175:42 | ... ? ... : ... | E.cs:180:9:183:9 | if (...) ... |
-| E.cs:175:33:175:37 | false | E.cs:175:19:175:42 | ... ? ... : ... |
-| E.cs:177:9:179:9 | {...} | E.cs:180:9:183:9 | if (...) ... |
-| E.cs:180:9:183:9 | if (...) ... | E.cs:181:9:183:9 | {...} |
-| E.cs:181:9:183:9 | {...} | E.cs:184:9:187:9 | if (...) ... |
-| E.cs:184:9:187:9 | if (...) ... | E.cs:186:13:186:15 | access to parameter obj |
-| E.cs:190:29:190:29 | SSA param(o) | E.cs:192:17:192:17 | access to parameter o |
-| E.cs:198:13:198:29 | [b (line 196): false] SSA def(o) | E.cs:203:13:203:13 | access to local variable o |
-| E.cs:198:13:198:29 | [b (line 196): true] SSA def(o) | E.cs:201:13:201:13 | access to local variable o |
-| E.cs:206:28:206:28 | SSA param(s) | E.cs:208:13:208:23 | [false] ... is ... |
-| E.cs:208:13:208:23 | [false] ... is ... | E.cs:210:16:210:16 | access to parameter s |
-| E.cs:217:13:217:20 | [b (line 213): true] SSA def(x) | E.cs:218:9:218:9 | access to local variable x |
-| E.cs:217:13:217:20 | [b (line 213): true] SSA def(x) | E.cs:220:13:220:13 | access to local variable x |
-| E.cs:227:13:227:20 | [b (line 223): true] SSA def(x) | E.cs:229:13:229:13 | access to local variable x |
-| E.cs:227:13:227:20 | [b (line 223): true] SSA def(x) | E.cs:229:13:229:25 | ...; |
-| E.cs:229:13:229:25 | ...; | E.cs:230:9:230:9 | access to local variable x |
-| E.cs:233:26:233:26 | SSA param(i) | E.cs:235:16:235:16 | access to parameter i |
-| E.cs:238:26:238:26 | SSA param(i) | E.cs:240:21:240:21 | access to parameter i |
-| E.cs:283:13:283:22 | [b (line 279): false] SSA def(o) | E.cs:285:9:285:9 | access to local variable o |
-| E.cs:283:13:283:22 | [b (line 279): true] SSA def(o) | E.cs:285:9:285:9 | access to local variable o |
-| E.cs:301:13:301:27 | SSA def(s) | E.cs:302:9:302:9 | access to local variable s |
-| E.cs:319:29:319:30 | SSA param(s1) | E.cs:321:20:321:21 | access to parameter s2 |
-| E.cs:321:13:321:30 | [true] ... is ... | E.cs:323:13:323:14 | access to parameter s1 |
-| E.cs:321:14:321:21 | ... ?? ... | E.cs:321:13:321:30 | [true] ... is ... |
-| E.cs:321:20:321:21 | access to parameter s2 | E.cs:321:14:321:21 | ... ?? ... |
-| E.cs:330:13:330:36 | SSA def(x) | E.cs:331:9:331:9 | access to local variable x |
-| E.cs:342:13:342:32 | SSA def(x) | E.cs:343:9:343:9 | access to local variable x |
-| E.cs:348:17:348:36 | SSA def(x) | E.cs:349:9:349:9 | access to local variable x |
-| E.cs:366:28:366:28 | SSA param(s) | E.cs:366:41:366:41 | access to parameter s |
-| E.cs:374:17:374:31 | SSA def(s) | E.cs:375:20:375:20 | access to local variable s |
-| E.cs:380:24:380:25 | SSA param(e1) | E.cs:382:28:382:29 | access to parameter e2 |
-| E.cs:380:24:380:25 | SSA param(e1) | E.cs:382:28:382:29 | access to parameter e2 |
-| E.cs:380:24:380:25 | SSA param(e1) | E.cs:382:28:382:29 | access to parameter e2 |
-| E.cs:380:30:380:31 | SSA param(e2) | E.cs:382:14:382:37 | [false] ... && ... |
-| E.cs:380:30:380:31 | SSA param(e2) | E.cs:382:14:382:37 | [false] ... && ... |
-| E.cs:380:30:380:31 | SSA param(e2) | E.cs:382:14:382:37 | [false] ... && ... |
-| E.cs:380:30:380:31 | SSA param(e2) | E.cs:382:28:382:29 | access to parameter e2 |
-| E.cs:380:30:380:31 | SSA param(e2) | E.cs:382:28:382:29 | access to parameter e2 |
-| E.cs:380:30:380:31 | SSA param(e2) | E.cs:382:28:382:29 | access to parameter e2 |
-| E.cs:382:13:382:68 | [false] ... \|\| ... | E.cs:384:9:385:24 | if (...) ... |
-| E.cs:382:13:382:68 | [false] ... \|\| ... | E.cs:384:9:385:24 | if (...) ... |
-| E.cs:382:14:382:37 | [false] ... && ... | E.cs:382:44:382:45 | access to parameter e1 |
-| E.cs:382:14:382:37 | [false] ... && ... | E.cs:382:44:382:45 | access to parameter e1 |
-| E.cs:382:28:382:29 | access to parameter e2 | E.cs:382:14:382:37 | [false] ... && ... |
-| E.cs:382:28:382:29 | access to parameter e2 | E.cs:382:14:382:37 | [false] ... && ... |
-| E.cs:382:44:382:45 | access to parameter e1 | E.cs:382:44:382:67 | [false] ... && ... |
-| E.cs:382:44:382:45 | access to parameter e1 | E.cs:382:44:382:67 | [false] ... && ... |
-| E.cs:382:44:382:67 | [false] ... && ... | E.cs:382:13:382:68 | [false] ... \|\| ... |
-| E.cs:382:44:382:67 | [false] ... && ... | E.cs:382:13:382:68 | [false] ... \|\| ... |
-| E.cs:384:9:385:24 | if (...) ... | E.cs:384:13:384:36 | [false] ... && ... |
-| E.cs:384:9:385:24 | if (...) ... | E.cs:384:27:384:28 | access to parameter e2 |
-| E.cs:384:13:384:36 | [false] ... && ... | E.cs:386:16:386:17 | access to parameter e1 |
-| E.cs:384:13:384:36 | [false] ... && ... | E.cs:386:27:386:28 | access to parameter e2 |
-| E.cs:384:27:384:28 | access to parameter e2 | E.cs:384:13:384:36 | [false] ... && ... |
-| E.cs:404:9:404:18 | SSA def(i) | E.cs:405:16:405:16 | access to local variable i |
-| E.cs:404:9:404:18 | SSA def(i) | E.cs:405:16:405:16 | access to local variable i |
-| E.cs:417:24:417:40 | SSA capture def(i) | E.cs:417:34:417:34 | access to parameter i |
-| E.cs:423:28:423:44 | SSA capture def(i) | E.cs:423:38:423:38 | access to parameter i |
-| E.cs:430:29:430:45 | SSA capture def(i) | E.cs:430:39:430:39 | access to parameter i |
-| E.cs:435:29:435:29 | SSA param(s) | E.cs:437:13:437:21 | [true] ... is ... |
-| E.cs:437:13:437:21 | [true] ... is ... | E.cs:439:13:439:13 | access to parameter s |
-| Forwarding.cs:7:16:7:23 | SSA def(s) | Forwarding.cs:9:13:9:30 | [false] !... |
-| Forwarding.cs:9:13:9:30 | [false] !... | Forwarding.cs:14:9:17:9 | if (...) ... |
-| Forwarding.cs:14:9:17:9 | if (...) ... | Forwarding.cs:19:9:22:9 | if (...) ... |
-| Forwarding.cs:19:9:22:9 | if (...) ... | Forwarding.cs:19:13:19:23 | [false] !... |
-| Forwarding.cs:19:13:19:23 | [false] !... | Forwarding.cs:24:9:27:9 | if (...) ... |
-| Forwarding.cs:24:9:27:9 | if (...) ... | Forwarding.cs:29:9:32:9 | if (...) ... |
-| Forwarding.cs:29:9:32:9 | if (...) ... | Forwarding.cs:34:9:37:9 | if (...) ... |
-| Forwarding.cs:34:9:37:9 | if (...) ... | Forwarding.cs:35:9:37:9 | {...} |
-| Forwarding.cs:34:9:37:9 | if (...) ... | Forwarding.cs:36:31:36:31 | access to local variable s |
-| Forwarding.cs:35:9:37:9 | {...} | Forwarding.cs:40:27:40:27 | access to local variable s |
-| GuardedString.cs:7:16:7:32 | SSA def(s) | GuardedString.cs:9:13:9:36 | [false] !... |
-| GuardedString.cs:9:13:9:36 | [false] !... | GuardedString.cs:14:9:17:9 | if (...) ... |
-| GuardedString.cs:14:9:17:9 | if (...) ... | GuardedString.cs:14:13:14:41 | [false] !... |
-| GuardedString.cs:14:13:14:41 | [false] !... | GuardedString.cs:19:9:20:40 | if (...) ... |
-| GuardedString.cs:19:9:20:40 | if (...) ... | GuardedString.cs:19:26:19:26 | 0 |
-| GuardedString.cs:19:26:19:26 | 0 | GuardedString.cs:22:9:23:40 | if (...) ... |
-| GuardedString.cs:22:9:23:40 | if (...) ... | GuardedString.cs:22:25:22:25 | 0 |
-| GuardedString.cs:22:25:22:25 | 0 | GuardedString.cs:25:9:26:40 | if (...) ... |
-| GuardedString.cs:25:9:26:40 | if (...) ... | GuardedString.cs:25:26:25:26 | 0 |
-| GuardedString.cs:25:26:25:26 | 0 | GuardedString.cs:28:9:29:40 | if (...) ... |
-| GuardedString.cs:28:9:29:40 | if (...) ... | GuardedString.cs:28:25:28:26 | 10 |
-| GuardedString.cs:28:25:28:26 | 10 | GuardedString.cs:31:9:32:40 | if (...) ... |
-| GuardedString.cs:31:9:32:40 | if (...) ... | GuardedString.cs:31:26:31:27 | 10 |
-| GuardedString.cs:31:26:31:27 | 10 | GuardedString.cs:34:9:37:40 | if (...) ... |
-| GuardedString.cs:34:9:37:40 | if (...) ... | GuardedString.cs:34:26:34:26 | 0 |
-| GuardedString.cs:34:26:34:26 | 0 | GuardedString.cs:35:31:35:31 | access to local variable s |
-| NullAlwaysBad.cs:7:29:7:29 | SSA param(s) | NullAlwaysBad.cs:9:30:9:30 | access to parameter s |
-| NullMaybeBad.cs:13:17:13:20 | null | NullMaybeBad.cs:7:27:7:27 | access to parameter o |
-| Params.cs:20:12:20:15 | null | Params.cs:14:17:14:20 | access to parameter args |
-| StringConcatenation.cs:14:16:14:23 | SSA def(s) | StringConcatenation.cs:15:16:15:16 | access to local variable s |
-| StringConcatenation.cs:15:16:15:16 | access to local variable s | StringConcatenation.cs:16:17:16:17 | access to local variable s |
-#select
-| C.cs:64:9:64:10 | access to local variable o1 | C.cs:62:13:62:46 | SSA def(o1) | C.cs:64:9:64:10 | access to local variable o1 | Variable $@ may be null at this access because of $@ assignment. | C.cs:62:13:62:14 | o1 | o1 | C.cs:62:13:62:46 | Object o1 = ... | this |
-| C.cs:68:9:68:10 | access to local variable o2 | C.cs:66:13:66:46 | SSA def(o2) | C.cs:68:9:68:10 | access to local variable o2 | Variable $@ may be null at this access because of $@ assignment. | C.cs:66:13:66:14 | o2 | o2 | C.cs:66:13:66:46 | Object o2 = ... | this |
-| C.cs:95:15:95:15 | access to local variable o | C.cs:94:13:94:45 | SSA def(o) | C.cs:95:15:95:15 | access to local variable o | Variable $@ may be null at this access because of $@ assignment. | C.cs:94:13:94:13 | o | o | C.cs:94:13:94:45 | Object o = ... | this |
-| C.cs:103:27:103:30 | access to parameter list | C.cs:102:13:102:23 | SSA def(list) | C.cs:103:27:103:30 | access to parameter list | Variable $@ may be null at this access because of $@ assignment. | C.cs:99:42:99:45 | list | list | C.cs:102:13:102:23 | ... = ... | this |
-| C.cs:177:13:177:13 | access to local variable s | C.cs:178:13:178:20 | SSA def(s) | C.cs:177:13:177:13 | access to local variable s | Variable $@ may be null at this access because of $@ assignment. | C.cs:151:13:151:13 | s | s | C.cs:178:13:178:20 | ... = ... | this |
-| C.cs:203:13:203:13 | access to local variable s | C.cs:204:13:204:20 | SSA def(s) | C.cs:203:13:203:13 | access to local variable s | Variable $@ may be null at this access because of $@ assignment. | C.cs:185:13:185:13 | s | s | C.cs:204:13:204:20 | ... = ... | this |
-| C.cs:223:9:223:9 | access to local variable s | C.cs:222:13:222:20 | SSA def(s) | C.cs:223:9:223:9 | access to local variable s | Variable $@ may be null at this access because of $@ assignment. | C.cs:210:13:210:13 | s | s | C.cs:222:13:222:20 | ... = ... | this |
-| C.cs:242:13:242:13 | access to local variable s | C.cs:240:24:240:31 | SSA def(s) | C.cs:242:13:242:13 | access to local variable s | Variable $@ may be null at this access because of $@ assignment. | C.cs:228:16:228:16 | s | s | C.cs:240:24:240:31 | ... = ... | this |
-| D.cs:23:9:23:13 | access to parameter param | D.cs:17:17:17:20 | null | D.cs:23:9:23:13 | access to parameter param | Variable $@ may be null at this access because of $@ null argument. | D.cs:21:32:21:36 | param | param | D.cs:17:17:17:20 | null | this |
-| D.cs:32:9:32:13 | access to parameter param | D.cs:26:32:26:36 | SSA param(param) | D.cs:32:9:32:13 | access to parameter param | Variable $@ may be null at this access as suggested by $@ null check. | D.cs:26:32:26:36 | param | param | D.cs:28:13:28:25 | ... != ... | this |
-| D.cs:62:13:62:14 | access to local variable o5 | D.cs:58:13:58:41 | SSA def(o5) | D.cs:62:13:62:14 | access to local variable o5 | Variable $@ may be null at this access because of $@ assignment. | D.cs:58:13:58:14 | o5 | o5 | D.cs:58:13:58:41 | String o5 = ... | this |
-| D.cs:73:13:73:14 | access to local variable o7 | D.cs:68:13:68:34 | SSA def(o7) | D.cs:73:13:73:14 | access to local variable o7 | Variable $@ may be null at this access because of $@ assignment. | D.cs:68:13:68:14 | o7 | o7 | D.cs:68:13:68:34 | String o7 = ... | this |
-| D.cs:82:13:82:14 | access to local variable o8 | D.cs:75:13:75:34 | SSA def(o8) | D.cs:82:13:82:14 | access to local variable o8 | Variable $@ may be null at this access because of $@ assignment. | D.cs:75:13:75:14 | o8 | o8 | D.cs:75:13:75:34 | String o8 = ... | this |
-| D.cs:84:13:84:14 | access to local variable o8 | D.cs:75:13:75:34 | SSA def(o8) | D.cs:84:13:84:14 | access to local variable o8 | Variable $@ may be null at this access because of $@ assignment. | D.cs:75:13:75:14 | o8 | o8 | D.cs:75:13:75:34 | String o8 = ... | this |
-| D.cs:91:13:91:14 | access to local variable xs | D.cs:89:15:89:44 | SSA def(xs) | D.cs:91:13:91:14 | access to local variable xs | Variable $@ may be null at this access because of $@ assignment. | D.cs:89:15:89:16 | xs | xs | D.cs:89:15:89:44 | Int32[] xs = ... | this |
-| D.cs:94:21:94:22 | access to local variable xs | D.cs:89:15:89:44 | SSA def(xs) | D.cs:94:21:94:22 | access to local variable xs | Variable $@ may be null at this access because of $@ assignment. | D.cs:89:15:89:16 | xs | xs | D.cs:89:15:89:44 | Int32[] xs = ... | this |
-| D.cs:98:21:98:22 | access to local variable xs | D.cs:89:15:89:44 | SSA def(xs) | D.cs:98:21:98:22 | access to local variable xs | Variable $@ may be null at this access because of $@ assignment. | D.cs:89:15:89:16 | xs | xs | D.cs:89:15:89:44 | Int32[] xs = ... | this |
-| D.cs:102:31:102:32 | access to local variable xs | D.cs:89:15:89:44 | SSA def(xs) | D.cs:102:31:102:32 | access to local variable xs | Variable $@ may be null at this access because of $@ assignment. | D.cs:89:15:89:16 | xs | xs | D.cs:89:15:89:44 | Int32[] xs = ... | this |
-| D.cs:105:19:105:20 | access to local variable xs | D.cs:89:15:89:44 | SSA def(xs) | D.cs:105:19:105:20 | access to local variable xs | Variable $@ may be null at this access because of $@ assignment. | D.cs:89:15:89:16 | xs | xs | D.cs:89:15:89:44 | Int32[] xs = ... | this |
-| D.cs:134:24:134:24 | access to parameter a | D.cs:125:35:125:35 | SSA param(a) | D.cs:134:24:134:24 | access to parameter a | Variable $@ may be null at this access as suggested by $@ null check. | D.cs:125:35:125:35 | a | a | D.cs:127:20:127:28 | ... == ... | this |
-| D.cs:134:24:134:24 | access to parameter a | D.cs:125:35:125:35 | SSA param(a) | D.cs:134:24:134:24 | access to parameter a | Variable $@ may be null at this access as suggested by $@ null check. | D.cs:125:35:125:35 | a | a | D.cs:139:13:139:21 | ... != ... | this |
-| D.cs:135:24:135:24 | access to parameter b | D.cs:125:44:125:44 | SSA param(b) | D.cs:135:24:135:24 | access to parameter b | Variable $@ may be null at this access as suggested by $@ null check. | D.cs:125:44:125:44 | b | b | D.cs:128:20:128:28 | ... == ... | this |
-| D.cs:145:20:145:20 | access to parameter a | D.cs:125:35:125:35 | SSA param(a) | D.cs:145:20:145:20 | access to parameter a | Variable $@ may be null at this access as suggested by $@ null check. | D.cs:125:35:125:35 | a | a | D.cs:127:20:127:28 | ... == ... | this |
-| D.cs:145:20:145:20 | access to parameter a | D.cs:125:35:125:35 | SSA param(a) | D.cs:145:20:145:20 | access to parameter a | Variable $@ may be null at this access as suggested by $@ null check. | D.cs:125:35:125:35 | a | a | D.cs:139:13:139:21 | ... != ... | this |
-| D.cs:151:9:151:11 | access to parameter obj | D.cs:149:36:149:38 | SSA param(obj) | D.cs:151:9:151:11 | access to parameter obj | Variable $@ may be null at this access as suggested by $@ null check. | D.cs:149:36:149:38 | obj | obj | D.cs:152:17:152:27 | ... != ... | this |
-| D.cs:171:9:171:11 | access to local variable obj | D.cs:163:16:163:25 | SSA def(obj) | D.cs:171:9:171:11 | access to local variable obj | Variable $@ may be null at this access because of $@ assignment. | D.cs:163:16:163:18 | obj | obj | D.cs:163:16:163:25 | Object obj = ... | this |
-| D.cs:245:13:245:13 | access to local variable o | D.cs:240:9:240:16 | SSA def(o) | D.cs:245:13:245:13 | access to local variable o | Variable $@ may be null at this access because of $@ assignment. | D.cs:228:16:228:16 | o | o | D.cs:240:9:240:16 | ... = ... | this |
-| D.cs:247:13:247:13 | access to local variable o | D.cs:240:9:240:16 | SSA def(o) | D.cs:247:13:247:13 | access to local variable o | Variable $@ may be null at this access because of $@ assignment. | D.cs:228:16:228:16 | o | o | D.cs:240:9:240:16 | ... = ... | this |
-| D.cs:253:13:253:14 | access to local variable o2 | D.cs:249:13:249:38 | SSA def(o2) | D.cs:253:13:253:14 | access to local variable o2 | Variable $@ may be null at this access because of $@ assignment. | D.cs:249:13:249:14 | o2 | o2 | D.cs:249:13:249:38 | String o2 = ... | this |
-| D.cs:267:13:267:13 | access to local variable o | D.cs:258:16:258:23 | SSA def(o) | D.cs:267:13:267:13 | access to local variable o | Variable $@ may be null at this access because of $@ assignment. | D.cs:258:16:258:16 | o | o | D.cs:258:16:258:23 | Object o = ... | this |
-| D.cs:291:13:291:13 | access to local variable o | D.cs:269:9:269:16 | SSA def(o) | D.cs:291:13:291:13 | access to local variable o | Variable $@ may be null at this access because of $@ assignment. | D.cs:258:16:258:16 | o | o | D.cs:269:9:269:16 | ... = ... | this |
-| D.cs:291:13:291:13 | access to local variable o | D.cs:283:17:283:24 | SSA def(o) | D.cs:291:13:291:13 | access to local variable o | Variable $@ may be null at this access because of $@ assignment. | D.cs:258:16:258:16 | o | o | D.cs:283:17:283:24 | ... = ... | this |
-| D.cs:294:13:294:13 | access to local variable o | D.cs:269:9:269:16 | SSA def(o) | D.cs:294:13:294:13 | access to local variable o | Variable $@ may be null at this access because of $@ assignment. | D.cs:258:16:258:16 | o | o | D.cs:269:9:269:16 | ... = ... | this |
-| D.cs:294:13:294:13 | access to local variable o | D.cs:283:17:283:24 | SSA def(o) | D.cs:294:13:294:13 | access to local variable o | Variable $@ may be null at this access because of $@ assignment. | D.cs:258:16:258:16 | o | o | D.cs:283:17:283:24 | ... = ... | this |
-| D.cs:300:17:300:20 | access to local variable prev | D.cs:296:16:296:26 | SSA def(prev) | D.cs:300:17:300:20 | access to local variable prev | Variable $@ may be null at this access because of $@ assignment. | D.cs:296:16:296:19 | prev | prev | D.cs:296:16:296:26 | Object prev = ... | this |
-| D.cs:313:17:313:17 | access to local variable s | D.cs:304:16:304:23 | SSA def(s) | D.cs:313:17:313:17 | access to local variable s | Variable $@ may be null at this access because of $@ assignment. | D.cs:304:16:304:16 | s | s | D.cs:304:16:304:23 | String s = ... | this |
-| D.cs:324:9:324:9 | access to local variable r | D.cs:316:16:316:23 | SSA def(r) | D.cs:324:9:324:9 | access to local variable r | Variable $@ may be null at this access because of $@ assignment. | D.cs:316:16:316:16 | r | r | D.cs:316:16:316:23 | Object r = ... | this |
-| D.cs:356:13:356:13 | access to local variable a | D.cs:351:15:351:22 | SSA def(a) | D.cs:356:13:356:13 | access to local variable a | Variable $@ may be null at this access because of $@ assignment. | D.cs:351:15:351:15 | a | a | D.cs:351:15:351:22 | Int32[] a = ... | this |
-| D.cs:363:13:363:16 | access to local variable last | D.cs:360:20:360:30 | SSA def(last) | D.cs:363:13:363:16 | access to local variable last | Variable $@ may be null at this access because of $@ assignment. | D.cs:360:20:360:23 | last | last | D.cs:360:20:360:30 | String last = ... | this |
-| D.cs:372:13:372:13 | access to local variable b | D.cs:366:15:366:47 | SSA def(b) | D.cs:372:13:372:13 | access to local variable b | Variable $@ may be null at this access because of $@ assignment. | D.cs:366:15:366:15 | b | b | D.cs:366:15:366:47 | Int32[] b = ... | this |
-| D.cs:395:20:395:20 | access to parameter a | D.cs:388:36:388:36 | SSA param(a) | D.cs:395:20:395:20 | access to parameter a | Variable $@ may be null at this access as suggested by $@ null check. | D.cs:388:36:388:36 | a | a | D.cs:390:20:390:28 | ... == ... | this |
-| D.cs:400:20:400:20 | access to parameter b | D.cs:388:45:388:45 | SSA param(b) | D.cs:400:20:400:20 | access to parameter b | Variable $@ may be null at this access as suggested by $@ null check. | D.cs:388:45:388:45 | b | b | D.cs:397:20:397:28 | ... == ... | this |
-| D.cs:410:13:410:13 | access to parameter y | D.cs:405:45:405:45 | SSA param(y) | D.cs:410:13:410:13 | access to parameter y | Variable $@ may be null at this access as suggested by $@ null check. | D.cs:405:45:405:45 | y | y | D.cs:407:27:407:35 | ... == ... | this |
-| D.cs:410:13:410:13 | access to parameter y | D.cs:405:45:405:45 | SSA param(y) | D.cs:410:13:410:13 | access to parameter y | Variable $@ may be null at this access as suggested by $@ null check. | D.cs:405:45:405:45 | y | y | D.cs:407:55:407:63 | ... != ... | this |
-| D.cs:410:13:410:13 | access to parameter y | D.cs:405:45:405:45 | SSA param(y) | D.cs:410:13:410:13 | access to parameter y | Variable $@ may be null at this access as suggested by $@ null check. | D.cs:405:45:405:45 | y | y | D.cs:411:13:411:21 | ... != ... | this |
-| D.cs:412:13:412:13 | access to parameter x | D.cs:405:35:405:35 | SSA param(x) | D.cs:412:13:412:13 | access to parameter x | Variable $@ may be null at this access as suggested by $@ null check. | D.cs:405:35:405:35 | x | x | D.cs:407:14:407:22 | ... != ... | this |
-| D.cs:412:13:412:13 | access to parameter x | D.cs:405:35:405:35 | SSA param(x) | D.cs:412:13:412:13 | access to parameter x | Variable $@ may be null at this access as suggested by $@ null check. | D.cs:405:35:405:35 | x | x | D.cs:407:42:407:50 | ... == ... | this |
-| D.cs:412:13:412:13 | access to parameter x | D.cs:405:35:405:35 | SSA param(x) | D.cs:412:13:412:13 | access to parameter x | Variable $@ may be null at this access as suggested by $@ null check. | D.cs:405:35:405:35 | x | x | D.cs:409:13:409:21 | ... != ... | this |
-| E.cs:12:38:12:39 | access to local variable a2 | E.cs:9:18:9:26 | SSA def(a2) | E.cs:12:38:12:39 | access to local variable a2 | Variable $@ may be null at this access because of $@ assignment. | E.cs:9:18:9:19 | a2 | a2 | E.cs:9:18:9:26 | Int64[][] a2 = ... | this |
-| E.cs:14:13:14:14 | access to local variable a3 | E.cs:11:16:11:24 | SSA def(a3) | E.cs:14:13:14:14 | access to local variable a3 | Variable $@ may be null at this access because of $@ assignment. | E.cs:11:16:11:17 | a3 | a3 | E.cs:11:16:11:24 | Int64[] a3 = ... | this |
-| E.cs:27:13:27:14 | access to local variable s1 | E.cs:23:13:23:30 | SSA def(s1) | E.cs:27:13:27:14 | access to local variable s1 | Variable $@ may be null at this access because of $@ assignment. | E.cs:19:13:19:14 | s1 | s1 | E.cs:23:13:23:30 | ... = ... | this |
-| E.cs:61:13:61:17 | access to local variable slice | E.cs:51:22:51:33 | SSA def(slice) | E.cs:61:13:61:17 | access to local variable slice | Variable $@ may be null at this access because of $@ assignment. | E.cs:51:22:51:26 | slice | slice | E.cs:51:22:51:33 | List<String> slice = ... | this |
-| E.cs:73:13:73:15 | access to parameter arr | E.cs:66:40:66:42 | SSA param(arr) | E.cs:73:13:73:15 | access to parameter arr | Variable $@ may be null at this access as suggested by $@ null check. | E.cs:66:40:66:42 | arr | arr | E.cs:70:22:70:32 | ... == ... | this |
-| E.cs:112:13:112:16 | access to local variable arr2 | E.cs:107:15:107:25 | SSA def(arr2) | E.cs:112:13:112:16 | access to local variable arr2 | Variable $@ may be null at this access because of $@ assignment. | E.cs:107:15:107:18 | arr2 | arr2 | E.cs:107:15:107:25 | Int32[] arr2 = ... | this |
-| E.cs:125:33:125:35 | access to local variable obj | E.cs:137:25:137:34 | SSA def(obj) | E.cs:125:33:125:35 | access to local variable obj | Variable $@ may be null at this access because of $@ assignment. | E.cs:119:13:119:15 | obj | obj | E.cs:137:25:137:34 | ... = ... | this |
-| E.cs:159:13:159:16 | access to local variable obj2 | E.cs:152:16:152:26 | SSA def(obj2) | E.cs:159:13:159:16 | access to local variable obj2 | Variable $@ may be null at this access as suggested by $@ null check. | E.cs:152:16:152:19 | obj2 | obj2 | E.cs:153:13:153:24 | ... != ... | this |
-| E.cs:167:21:167:21 | access to parameter a | E.cs:162:28:162:28 | SSA param(a) | E.cs:167:21:167:21 | access to parameter a | Variable $@ may be null at this access as suggested by $@ null check. | E.cs:162:28:162:28 | a | a | E.cs:164:17:164:25 | ... == ... | this |
-| E.cs:178:13:178:15 | access to parameter obj | E.cs:173:29:173:31 | SSA param(obj) | E.cs:178:13:178:15 | access to parameter obj | Variable $@ may be null at this access as suggested by $@ null check. | E.cs:173:29:173:31 | obj | obj | E.cs:175:19:175:29 | ... == ... | this |
-| E.cs:178:13:178:15 | access to parameter obj | E.cs:173:29:173:31 | SSA param(obj) | E.cs:178:13:178:15 | access to parameter obj | Variable $@ may be null at this access as suggested by $@ null check. | E.cs:173:29:173:31 | obj | obj | E.cs:180:13:180:23 | ... == ... | this |
-| E.cs:186:13:186:15 | access to parameter obj | E.cs:173:29:173:31 | SSA param(obj) | E.cs:186:13:186:15 | access to parameter obj | Variable $@ may be null at this access as suggested by $@ null check. | E.cs:173:29:173:31 | obj | obj | E.cs:175:19:175:29 | ... == ... | this |
-| E.cs:186:13:186:15 | access to parameter obj | E.cs:173:29:173:31 | SSA param(obj) | E.cs:186:13:186:15 | access to parameter obj | Variable $@ may be null at this access as suggested by $@ null check. | E.cs:173:29:173:31 | obj | obj | E.cs:180:13:180:23 | ... == ... | this |
-| E.cs:192:17:192:17 | access to parameter o | E.cs:190:29:190:29 | SSA param(o) | E.cs:192:17:192:17 | access to parameter o | Variable $@ may be null at this access as suggested by $@ null check. | E.cs:190:29:190:29 | o | o | E.cs:193:17:193:17 | access to parameter o | this |
-| E.cs:201:13:201:13 | access to local variable o | E.cs:198:13:198:29 | [b (line 196): true] SSA def(o) | E.cs:201:13:201:13 | access to local variable o | Variable $@ may be null at this access because of $@ assignment. | E.cs:198:13:198:13 | o | o | E.cs:198:13:198:29 | String o = ... | this |
-| E.cs:203:13:203:13 | access to local variable o | E.cs:198:13:198:29 | [b (line 196): false] SSA def(o) | E.cs:203:13:203:13 | access to local variable o | Variable $@ may be null at this access because of $@ assignment. | E.cs:198:13:198:13 | o | o | E.cs:198:13:198:29 | String o = ... | this |
-| E.cs:218:9:218:9 | access to local variable x | E.cs:217:13:217:20 | [b (line 213): true] SSA def(x) | E.cs:218:9:218:9 | access to local variable x | Variable $@ may be null at this access because of $@ assignment. | E.cs:215:13:215:13 | x | x | E.cs:217:13:217:20 | ... = ... | this |
-| E.cs:230:9:230:9 | access to local variable x | E.cs:227:13:227:20 | [b (line 223): true] SSA def(x) | E.cs:230:9:230:9 | access to local variable x | Variable $@ may be null at this access because of $@ assignment. | E.cs:225:13:225:13 | x | x | E.cs:227:13:227:20 | ... = ... | this |
-| E.cs:235:16:235:16 | access to parameter i | E.cs:233:26:233:26 | SSA param(i) | E.cs:235:16:235:16 | access to parameter i | Variable $@ may be null at this access because it has a nullable type. | E.cs:233:26:233:26 | i | i | E.cs:233:26:233:26 | i | this |
-| E.cs:240:21:240:21 | access to parameter i | E.cs:238:26:238:26 | SSA param(i) | E.cs:240:21:240:21 | access to parameter i | Variable $@ may be null at this access because it has a nullable type. | E.cs:238:26:238:26 | i | i | E.cs:238:26:238:26 | i | this |
-| E.cs:285:9:285:9 | access to local variable o | E.cs:283:13:283:22 | [b (line 279): false] SSA def(o) | E.cs:285:9:285:9 | access to local variable o | Variable $@ may be null at this access as suggested by $@ null check. | E.cs:283:13:283:13 | o | o | E.cs:284:9:284:9 | access to local variable o | this |
-| E.cs:285:9:285:9 | access to local variable o | E.cs:283:13:283:22 | [b (line 279): true] SSA def(o) | E.cs:285:9:285:9 | access to local variable o | Variable $@ may be null at this access as suggested by $@ null check. | E.cs:283:13:283:13 | o | o | E.cs:284:9:284:9 | access to local variable o | this |
-| E.cs:302:9:302:9 | access to local variable s | E.cs:301:13:301:27 | SSA def(s) | E.cs:302:9:302:9 | access to local variable s | Variable $@ may be null at this access because of $@ assignment. | E.cs:301:13:301:13 | s | s | E.cs:301:13:301:27 | String s = ... | this |
-| E.cs:343:9:343:9 | access to local variable x | E.cs:342:13:342:32 | SSA def(x) | E.cs:343:9:343:9 | access to local variable x | Variable $@ may be null at this access because of $@ assignment. | E.cs:342:13:342:13 | x | x | E.cs:342:13:342:32 | String x = ... | this |
-| E.cs:349:9:349:9 | access to local variable x | E.cs:348:17:348:36 | SSA def(x) | E.cs:349:9:349:9 | access to local variable x | Variable $@ may be null at this access because of $@ assignment. | E.cs:348:17:348:17 | x | x | E.cs:348:17:348:36 | dynamic x = ... | this |
-| E.cs:366:41:366:41 | access to parameter s | E.cs:366:28:366:28 | SSA param(s) | E.cs:366:41:366:41 | access to parameter s | Variable $@ may be null at this access because the parameter has a null default value. | E.cs:366:28:366:28 | s | s | E.cs:366:32:366:35 | null | this |
-| E.cs:375:20:375:20 | access to local variable s | E.cs:374:17:374:31 | SSA def(s) | E.cs:375:20:375:20 | access to local variable s | Variable $@ may be null at this access because of $@ assignment. | E.cs:374:17:374:17 | s | s | E.cs:374:17:374:31 | String s = ... | this |
-| E.cs:386:16:386:17 | access to parameter e1 | E.cs:380:24:380:25 | SSA param(e1) | E.cs:386:16:386:17 | access to parameter e1 | Variable $@ may be null at this access as suggested by $@ null check. | E.cs:380:24:380:25 | e1 | e1 | E.cs:382:14:382:23 | ... == ... | this |
-| E.cs:386:16:386:17 | access to parameter e1 | E.cs:380:24:380:25 | SSA param(e1) | E.cs:386:16:386:17 | access to parameter e1 | Variable $@ may be null at this access as suggested by $@ null check. | E.cs:380:24:380:25 | e1 | e1 | E.cs:382:44:382:53 | ... != ... | this |
-| E.cs:386:16:386:17 | access to parameter e1 | E.cs:380:24:380:25 | SSA param(e1) | E.cs:386:16:386:17 | access to parameter e1 | Variable $@ may be null at this access as suggested by $@ null check. | E.cs:380:24:380:25 | e1 | e1 | E.cs:384:13:384:22 | ... == ... | this |
-| E.cs:386:27:386:28 | access to parameter e2 | E.cs:380:30:380:31 | SSA param(e2) | E.cs:386:27:386:28 | access to parameter e2 | Variable $@ may be null at this access as suggested by $@ null check. | E.cs:380:30:380:31 | e2 | e2 | E.cs:382:28:382:37 | ... != ... | this |
-| E.cs:386:27:386:28 | access to parameter e2 | E.cs:380:30:380:31 | SSA param(e2) | E.cs:386:27:386:28 | access to parameter e2 | Variable $@ may be null at this access as suggested by $@ null check. | E.cs:380:30:380:31 | e2 | e2 | E.cs:382:58:382:67 | ... == ... | this |
-| E.cs:386:27:386:28 | access to parameter e2 | E.cs:380:30:380:31 | SSA param(e2) | E.cs:386:27:386:28 | access to parameter e2 | Variable $@ may be null at this access as suggested by $@ null check. | E.cs:380:30:380:31 | e2 | e2 | E.cs:384:27:384:36 | ... == ... | this |
-| E.cs:417:34:417:34 | access to parameter i | E.cs:417:24:417:40 | SSA capture def(i) | E.cs:417:34:417:34 | access to parameter i | Variable $@ may be null at this access because it has a nullable type. | E.cs:415:27:415:27 | i | i | E.cs:415:27:415:27 | i | this |
-| E.cs:423:38:423:38 | access to parameter i | E.cs:423:28:423:44 | SSA capture def(i) | E.cs:423:38:423:38 | access to parameter i | Variable $@ may be null at this access because it has a nullable type. | E.cs:420:27:420:27 | i | i | E.cs:420:27:420:27 | i | this |
-| E.cs:430:39:430:39 | access to parameter i | E.cs:430:29:430:45 | SSA capture def(i) | E.cs:430:39:430:39 | access to parameter i | Variable $@ may be null at this access because it has a nullable type. | E.cs:427:27:427:27 | i | i | E.cs:427:27:427:27 | i | this |
-| GuardedString.cs:35:31:35:31 | access to local variable s | GuardedString.cs:7:16:7:32 | SSA def(s) | GuardedString.cs:35:31:35:31 | access to local variable s | Variable $@ may be null at this access because of $@ assignment. | GuardedString.cs:7:16:7:16 | s | s | GuardedString.cs:7:16:7:32 | String s = ... | this |
-| NullMaybeBad.cs:7:27:7:27 | access to parameter o | NullMaybeBad.cs:13:17:13:20 | null | NullMaybeBad.cs:7:27:7:27 | access to parameter o | Variable $@ may be null at this access because of $@ null argument. | NullMaybeBad.cs:5:25:5:25 | o | o | NullMaybeBad.cs:13:17:13:20 | null | this |
-| Params.cs:14:17:14:20 | access to parameter args | Params.cs:20:12:20:15 | null | Params.cs:14:17:14:20 | access to parameter args | Variable $@ may be null at this access because of $@ null argument. | Params.cs:12:36:12:39 | args | args | Params.cs:20:12:20:15 | null | this |
-| StringConcatenation.cs:16:17:16:17 | access to local variable s | StringConcatenation.cs:14:16:14:23 | SSA def(s) | StringConcatenation.cs:16:17:16:17 | access to local variable s | Variable $@ may be null at this access because of $@ assignment. | StringConcatenation.cs:14:16:14:16 | s | s | StringConcatenation.cs:14:16:14:23 | String s = ... | this |

--- a/csharp/ql/test/query-tests/Nullness/NullMaybe.qlref
+++ b/csharp/ql/test/query-tests/Nullness/NullMaybe.qlref
@@ -1,1 +1,2 @@
-CSI/NullMaybe.ql
+query: CSI/NullMaybe.ql
+postprocess: utils/test/InlineExpectationsTestQuery.ql

--- a/csharp/ql/test/query-tests/Nullness/NullMaybeBad.cs
+++ b/csharp/ql/test/query-tests/Nullness/NullMaybeBad.cs
@@ -4,12 +4,12 @@ class Bad
 {
     void DoPrint(object o)
     {
-        Console.WriteLine(o.ToString());
+        Console.WriteLine(o.ToString()); // $ Alert[cs/dereferenced-value-may-be-null]
     }
 
     void M()
     {
         DoPrint("Hello");
-        DoPrint(null);
+        DoPrint(null); // $ Source[cs/dereferenced-value-may-be-null]
     }
 }

--- a/csharp/ql/test/query-tests/Nullness/Params.cs
+++ b/csharp/ql/test/query-tests/Nullness/Params.cs
@@ -11,12 +11,12 @@ public class Params
 
     public void M2(params string[] args)
     {
-        var l = args.Length; // Good
+        var l = args.Length; // $ SPURIOUS (false positive): Alert[cs/dereferenced-value-may-be-null]
     }
 
     public void M()
     {
         M1("a", "b", "c", null);
-        M2(null);
+        M2(null); // $ Source[cs/dereferenced-value-may-be-null]
     }
 }

--- a/csharp/ql/test/query-tests/Nullness/StringConcatenation.cs
+++ b/csharp/ql/test/query-tests/Nullness/StringConcatenation.cs
@@ -11,9 +11,9 @@ class StringsTest
 
     void StringMaybeNull()
     {
-        string s = null;
+        string s = null; // $ Source[cs/dereferenced-value-may-be-null]
         while (s != "")
-            s = s.Trim(); // BAD (maybe)
+            s = s.Trim(); // $ Alert[cs/dereferenced-value-may-be-null]
     }
 
     void StringNotNull()

--- a/csharp/ql/test/query-tests/Nullness/options
+++ b/csharp/ql/test/query-tests/Nullness/options
@@ -1,3 +1,4 @@
 semmle-extractor-options: /nostdlib /noconfig
 semmle-extractor-options: --load-sources-from-project:${testdir}/../../resources/stubs/_frameworks/Microsoft.NETCore.App/Microsoft.NETCore.App.csproj
 semmle-extractor-options: ${testdir}/../../resources/stubs/Microsoft.VisualStudio.TestTools.UnitTesting.cs
+semmle-extractor-options: ${testdir}/../../resources/stubs/Library.cs

--- a/csharp/ql/test/resources/stubs/Library.cs
+++ b/csharp/ql/test/resources/stubs/Library.cs
@@ -1,0 +1,13 @@
+﻿namespace Library;
+
+/*
+ * This file is for making stubs for library methods used for testing purposes.
+ * The file is located in the stubs folder, because then the code is not
+ * recognized as being from source.
+ */
+public static class MyExtensions
+{
+    public static void Accept(this object o) { }
+
+    public static void AcceptNullable(this object? o) { }
+}


### PR DESCRIPTION
In this PR we do the following for `cs/dereferenced-value-is-always-null` and `cs/dereferenced-value-may-be-null`.
- Change the class of de-referenced expressions: When calling a library extension method where the `this` parameter is a nullable type, we now assume that the null may happen in the extension method itself (this is at least common for the usage of testing frameworks, which reports a high amount of false positives related to the use of such extension methods).
- Remove the explicit type requirements on Debug.Assert methods (they are trivially true). They cause issues when extraction have broken types - and the change doesn't affect the methods that match the predicate when types are healthy.
- Add the queries of the Code Quality suite.
- Convert the tests to use inline expectations tests.

DCA looks good.