### PR TITLE
Overlay: Add QL for QL query to warn about possible non-inlining across overlay frontier

### DIFF
--- a/ql/ql/src/codeql_ql/ast/Ast.qll
+++ b/ql/ql/src/codeql_ql/ast/Ast.qll
@@ -2613,21 +2613,21 @@ class NoOpt extends Annotation {
 class OverlayCaller extends Annotation {
   OverlayCaller() { this.getName() = "overlay" and this.getArgs(0) instanceof CallerArg }
 
-  override string toString() { result = "caller" }
+  override string toString() { result = "overlay[caller]" }
 }
 
 /** An `overlay[local]` annotation. */
 class OverlayLocal extends Annotation {
   OverlayLocal() { this.getName() = "overlay" and this.getArgs(0) instanceof LocalArg }
 
-  override string toString() { result = "local" }
+  override string toString() { result = "overlay[local]" }
 }
 
 /** An `overlay[local?]` annotation. */
 class OverlayLocalQ extends Annotation {
   OverlayLocalQ() { this.getName() = "overlay" and this.getArgs(0) instanceof LocalQArg }
 
-  override string toString() { result = "local?" }
+  override string toString() { result = "overlay[local?]" }
 }
 
 /** A `language[monotonicAggregates]` annotation. */

--- a/ql/ql/src/codeql_ql/ast/Ast.qll
+++ b/ql/ql/src/codeql_ql/ast/Ast.qll
@@ -2538,6 +2538,18 @@ private class NoOptArg extends AnnotationArg {
   NoOptArg() { this.getValue() = "noopt" }
 }
 
+private class CallerArg extends AnnotationArg {
+  CallerArg() { this.getValue() = "caller" }
+}
+
+private class LocalArg extends AnnotationArg {
+  LocalArg() { this.getValue() = "local" }
+}
+
+private class LocalQArg extends AnnotationArg {
+  LocalQArg() { this.getValue() = "local?" }
+}
+
 private class MonotonicAggregatesArg extends AnnotationArg {
   MonotonicAggregatesArg() { this.getValue() = "monotonicAggregates" }
 }
@@ -2595,6 +2607,27 @@ class NoOpt extends Annotation {
   NoOpt() { this.getArgs(0) instanceof NoOptArg }
 
   override string toString() { result = "noopt" }
+}
+
+/** An `overlay[caller]` annotation. */
+class OverlayCaller extends Annotation {
+  OverlayCaller() { this.getName() = "overlay" and this.getArgs(0) instanceof CallerArg }
+
+  override string toString() { result = "caller" }
+}
+
+/** An `overlay[local]` annotation. */
+class OverlayLocal extends Annotation {
+  OverlayLocal() { this.getName() = "overlay" and this.getArgs(0) instanceof LocalArg }
+
+  override string toString() { result = "local" }
+}
+
+/** An `overlay[local?]` annotation. */
+class OverlayLocalQ extends Annotation {
+  OverlayLocalQ() { this.getName() = "overlay" and this.getArgs(0) instanceof LocalQArg }
+
+  override string toString() { result = "local?" }
 }
 
 /** A `language[monotonicAggregates]` annotation. */

--- a/ql/ql/src/queries/overlay/InlineOverlayCaller.ql
+++ b/ql/ql/src/queries/overlay/InlineOverlayCaller.ql
@@ -1,0 +1,41 @@
+/**
+ * @name Cannot inline predicate across overlay frontier
+ * @description Local inline predicates that are not annotated with `overlay[caller]` are
+ *              not inlined across the overlay frontier. This may negatively affect performance.
+ * @kind problem
+ * @problem.severity warning
+ * @id ql/inline-overlay-caller
+ * @tags performance
+ * @precision high
+ */
+
+import ql
+
+predicate mayBeLocal(AstNode n) {
+  n.getAnAnnotation() instanceof OverlayLocal
+  or
+  n.getAnAnnotation() instanceof OverlayLocalQ
+  or
+  // The tree-sitter-ql grammar doesn't handle annotations on file-level
+  // module declarations correctly. To work around that, we consider any
+  // node in a file that contains an overlay[local] or overlay[local?]
+  // annotation to be potentially local.
+  exists(AstNode m |
+    n.getLocation().getFile() = m.getLocation().getFile() and
+    mayBeLocal(m)
+  )
+}
+
+from Predicate p
+where
+  mayBeLocal(p) and
+  p.getAnAnnotation() instanceof Inline and
+  not p.getAnAnnotation() instanceof OverlayCaller and
+  not p.isPrivate()
+select p,
+  "This possibly local non-private inline predicate will not " +
+    "be inlined across the overlay frontier. This may negatively " +
+    "affect evaluation performance. Consider adding an " +
+    "`overlay[caller]` annotation to allow inlining across the " +
+    "overlay frontier. Note that adding an `overlay[caller]` " +
+    "annotation affects semantics under overlay evaluation."


### PR DESCRIPTION
This PR adds a QL-for-QL query to warn about possible non-inlining across the overlay frontier for possibly local non-private inline predicates. It will be used in tandem with [a script](https://github.com/github/codeql/pull/19631) to automatically add overlay annotations to files without existing overlay annotations. Once locality annotations have been added to a file, this query takes over responsibility for warning about possible non-inlining.

Due to a limitation of the tree-sitter-ql grammar with respect to annotations on file-level module declarations (i.e., `module;`), the heuristic for determining whether an inline predicate might be local is very crude: if the file contains any `overlay[local]` or `overlay[local?]` annotations. 

For https://github.com/github/codeql-core/issues/4951.