### PR TITLE
Rust: Type inference for operator overloading

### DIFF
--- a/rust/ql/lib/codeql/rust/elements/internal/BinaryExprImpl.qll
+++ b/rust/ql/lib/codeql/rust/elements/internal/BinaryExprImpl.qll
@@ -28,6 +28,12 @@ module Impl {
 
     override string getOperatorName() { result = Generated::BinaryExpr.super.getOperatorName() }
 
-    override Expr getAnOperand() { result = [this.getLhs(), this.getRhs()] }
+    override int getNumberOfOperands() { result = 2 }
+
+    override Expr getOperand(int n) {
+      n = 0 and result = this.getLhs()
+      or
+      n = 1 and result = this.getRhs()
+    }
   }
 }

--- a/rust/ql/lib/codeql/rust/elements/internal/BinaryExprImpl.qll
+++ b/rust/ql/lib/codeql/rust/elements/internal/BinaryExprImpl.qll
@@ -28,8 +28,6 @@ module Impl {
 
     override string getOperatorName() { result = Generated::BinaryExpr.super.getOperatorName() }
 
-    override int getNumberOfOperands() { result = 2 }
-
     override Expr getOperand(int n) {
       n = 0 and result = this.getLhs()
       or

--- a/rust/ql/lib/codeql/rust/elements/internal/OperationImpl.qll
+++ b/rust/ql/lib/codeql/rust/elements/internal/OperationImpl.qll
@@ -8,6 +8,78 @@ private import rust
 private import codeql.rust.elements.internal.ExprImpl::Impl as ExprImpl
 
 /**
+ * Holds if the operator `op` is overloaded to a trait with the canonical path
+ * `path` and the method name `method`.
+ */
+private predicate isOverloaded(string op, string path, string method) {
+  // Negation
+  op = "-" and path = "core::ops::arith::Neg" and method = "neg"
+  or
+  // Not
+  op = "!" and path = "core::ops::bit::Not" and method = "not"
+  or
+  // Dereference
+  op = "*" and path = "core::ops::Deref" and method = "deref"
+  or
+  // Comparison operators
+  op = "==" and path = "core::cmp::PartialEq" and method = "eq"
+  or
+  op = "!=" and path = "core::cmp::PartialEq" and method = "ne"
+  or
+  op = "<" and path = "core::cmp::PartialOrd" and method = "lt"
+  or
+  op = "<=" and path = "core::cmp::PartialOrd" and method = "le"
+  or
+  op = ">" and path = "core::cmp::PartialOrd" and method = "gt"
+  or
+  op = ">=" and path = "core::cmp::PartialOrd" and method = "ge"
+  or
+  // Arithmetic operators
+  op = "+" and path = "core::ops::arith::Add" and method = "add"
+  or
+  op = "-" and path = "core::ops::arith::Sub" and method = "sub"
+  or
+  op = "*" and path = "core::ops::arith::Mul" and method = "mul"
+  or
+  op = "/" and path = "core::ops::arith::Div" and method = "div"
+  or
+  op = "%" and path = "core::ops::arith::Rem" and method = "rem"
+  or
+  // Arithmetic assignment expressions
+  op = "+=" and path = "core::ops::arith::AddAssign" and method = "add_assign"
+  or
+  op = "-=" and path = "core::ops::arith::SubAssign" and method = "sub_assign"
+  or
+  op = "*=" and path = "core::ops::arith::MulAssign" and method = "mul_assign"
+  or
+  op = "/=" and path = "core::ops::arith::DivAssign" and method = "div_assign"
+  or
+  op = "%=" and path = "core::ops::arith::RemAssign" and method = "rem_assign"
+  or
+  // Bitwise operators
+  op = "&" and path = "core::ops::bit::BitAnd" and method = "bitand"
+  or
+  op = "|" and path = "core::ops::bit::BitOr" and method = "bitor"
+  or
+  op = "^" and path = "core::ops::bit::BitXor" and method = "bitxor"
+  or
+  op = "<<" and path = "core::ops::bit::Shl" and method = "shl"
+  or
+  op = ">>" and path = "core::ops::bit::Shr" and method = "shr"
+  or
+  // Bitwise assignment operators
+  op = "&=" and path = "core::ops::bit::BitAndAssign" and method = "bitand_assign"
+  or
+  op = "|=" and path = "core::ops::bit::BitOrAssign" and method = "bitor_assign"
+  or
+  op = "^=" and path = "core::ops::bit::BitXorAssign" and method = "bitxor_assign"
+  or
+  op = "<<=" and path = "core::ops::bit::ShlAssign" and method = "shl_assign"
+  or
+  op = ">>=" and path = "core::ops::bit::ShrAssign" and method = "shr_assign"
+}
+
+/**
  * INTERNAL: This module contains the customizable definition of `Operation` and should not
  * be referenced directly.
  */
@@ -16,14 +88,28 @@ module Impl {
    * An operation, for example `&&`, `+=`, `!` or `*`.
    */
   abstract class Operation extends ExprImpl::Expr {
-    /**
-     * Gets the operator name of this operation, if it exists.
-     */
+    /** Gets the operator name of this operation, if it exists. */
     abstract string getOperatorName();
 
+    /** Gets the `n`th operand of this operation, if any. */
+    abstract Expr getOperand(int n);
+
     /**
-     * Gets an operand of this operation.
+     * Gets the number of operands of this operation.
+     *
+     * This is either 1 for prefix operations, or 2 for binary operations.
      */
-    abstract Expr getAnOperand();
+    abstract int getNumberOfOperands();
+
+    /** Gets an operand of this operation. */
+    Expr getAnOperand() { result = this.getOperand(_) }
+
+    /**
+     * Holds if this operation is overloaded to the method `methodName` of the
+     * trait `trait`.
+     */
+    predicate isOverloaded(Trait trait, string methodName) {
+      isOverloaded(this.getOperatorName(), trait.getCanonicalPath(), methodName)
+    }
   }
 }

--- a/rust/ql/lib/codeql/rust/elements/internal/OperationImpl.qll
+++ b/rust/ql/lib/codeql/rust/elements/internal/OperationImpl.qll
@@ -99,7 +99,7 @@ module Impl {
      *
      * This is either 1 for prefix operations, or 2 for binary operations.
      */
-    final int getNumberOfOperands() { result = count(this.getAnOperand()) }
+    final int getNumberOfOperands() { result = strictcount(this.getAnOperand()) }
 
     /** Gets an operand of this operation. */
     Expr getAnOperand() { result = this.getOperand(_) }

--- a/rust/ql/lib/codeql/rust/elements/internal/OperationImpl.qll
+++ b/rust/ql/lib/codeql/rust/elements/internal/OperationImpl.qll
@@ -99,7 +99,7 @@ module Impl {
      *
      * This is either 1 for prefix operations, or 2 for binary operations.
      */
-    abstract int getNumberOfOperands();
+    final int getNumberOfOperands() { result = count(this.getAnOperand()) }
 
     /** Gets an operand of this operation. */
     Expr getAnOperand() { result = this.getOperand(_) }

--- a/rust/ql/lib/codeql/rust/elements/internal/PrefixExprImpl.qll
+++ b/rust/ql/lib/codeql/rust/elements/internal/PrefixExprImpl.qll
@@ -26,8 +26,6 @@ module Impl {
 
     override string getOperatorName() { result = Generated::PrefixExpr.super.getOperatorName() }
 
-    override int getNumberOfOperands() { result = 1 }
-
     override Expr getOperand(int n) { n = 0 and result = this.getExpr() }
   }
 }

--- a/rust/ql/lib/codeql/rust/elements/internal/PrefixExprImpl.qll
+++ b/rust/ql/lib/codeql/rust/elements/internal/PrefixExprImpl.qll
@@ -26,6 +26,8 @@ module Impl {
 
     override string getOperatorName() { result = Generated::PrefixExpr.super.getOperatorName() }
 
-    override Expr getAnOperand() { result = this.getExpr() }
+    override int getNumberOfOperands() { result = 1 }
+
+    override Expr getOperand(int n) { n = 0 and result = this.getExpr() }
   }
 }

--- a/rust/ql/lib/codeql/rust/elements/internal/RefExprImpl.qll
+++ b/rust/ql/lib/codeql/rust/elements/internal/RefExprImpl.qll
@@ -29,8 +29,6 @@ module Impl {
 
     override string getOperatorName() { result = "&" }
 
-    override int getNumberOfOperands() { result = 1 }
-
     override Expr getOperand(int n) { n = 0 and result = this.getExpr() }
 
     private string getSpecPart(int index) {

--- a/rust/ql/lib/codeql/rust/elements/internal/RefExprImpl.qll
+++ b/rust/ql/lib/codeql/rust/elements/internal/RefExprImpl.qll
@@ -29,7 +29,9 @@ module Impl {
 
     override string getOperatorName() { result = "&" }
 
-    override Expr getAnOperand() { result = this.getExpr() }
+    override int getNumberOfOperands() { result = 1 }
+
+    override Expr getOperand(int n) { n = 0 and result = this.getExpr() }
 
     private string getSpecPart(int index) {
       index = 0 and this.isRaw() and result = "raw"

--- a/rust/ql/lib/codeql/rust/internal/TypeInference.qll
+++ b/rust/ql/lib/codeql/rust/internal/TypeInference.qll
@@ -691,6 +691,8 @@ private module CallExprBaseMatchingInput implements MatchingInputSig {
   }
 
   private class OperationAccess extends Access instanceof Operation {
+    OperationAccess() { super.isOverloaded(_, _) }
+
     override Type getTypeArgument(TypeArgumentPosition apos, TypePath path) {
       // The syntax for operators does not allow type arguments.
       none()

--- a/rust/ql/lib/codeql/rust/internal/TypeInference.qll
+++ b/rust/ql/lib/codeql/rust/internal/TypeInference.qll
@@ -643,12 +643,22 @@ private module CallExprBaseMatchingInput implements MatchingInputSig {
 
   private import codeql.rust.elements.internal.CallExprImpl::Impl as CallExprImpl
 
-  class Access extends CallExprBase {
+  abstract class Access extends Expr {
+    abstract Type getTypeArgument(TypeArgumentPosition apos, TypePath path);
+
+    abstract AstNode getNodeAt(AccessPosition apos);
+
+    abstract Type getInferredType(AccessPosition apos, TypePath path);
+
+    abstract Declaration getTarget();
+  }
+
+  private class CallExprBaseAccess extends Access instanceof CallExprBase {
     private TypeMention getMethodTypeArg(int i) {
       result = this.(MethodCallExpr).getGenericArgList().getTypeArg(i)
     }
 
-    Type getTypeArgument(TypeArgumentPosition apos, TypePath path) {
+    override Type getTypeArgument(TypeArgumentPosition apos, TypePath path) {
       exists(TypeMention arg | result = arg.resolveTypeAt(path) |
         arg = getExplicitTypeArgMention(CallExprImpl::getFunctionPath(this), apos.asTypeParam())
         or
@@ -656,7 +666,7 @@ private module CallExprBaseMatchingInput implements MatchingInputSig {
       )
     }
 
-    AstNode getNodeAt(AccessPosition apos) {
+    override AstNode getNodeAt(AccessPosition apos) {
       exists(int p, boolean isMethodCall |
         argPos(this, result, p, isMethodCall) and
         apos = TPositionalAccessPosition(p, isMethodCall)
@@ -669,13 +679,36 @@ private module CallExprBaseMatchingInput implements MatchingInputSig {
       apos = TReturnAccessPosition()
     }
 
-    Type getInferredType(AccessPosition apos, TypePath path) {
+    override Type getInferredType(AccessPosition apos, TypePath path) {
       result = inferType(this.getNodeAt(apos), path)
     }
 
-    Declaration getTarget() {
+    override Declaration getTarget() {
       result = CallExprImpl::getResolvedFunction(this)
       or
+      result = inferMethodCallTarget(this) // mutual recursion; resolving method calls requires resolving types and vice versa
+    }
+  }
+
+  private class OperationAccess extends Access instanceof Operation {
+    override Type getTypeArgument(TypeArgumentPosition apos, TypePath path) {
+      // The syntax for operators does not allow type arguments.
+      none()
+    }
+
+    override AstNode getNodeAt(AccessPosition apos) {
+      result = super.getOperand(0) and apos = TSelfAccessPosition()
+      or
+      result = super.getOperand(1) and apos = TPositionalAccessPosition(0, true)
+      or
+      result = this and apos = TReturnAccessPosition()
+    }
+
+    override Type getInferredType(AccessPosition apos, TypePath path) {
+      result = inferType(this.getNodeAt(apos), path)
+    }
+
+    override Declaration getTarget() {
       result = inferMethodCallTarget(this) // mutual recursion; resolving method calls requires resolving types and vice versa
     }
   }
@@ -1058,6 +1091,26 @@ private module MethodCall {
 
     pragma[nomagic]
     override Type getTypeAt(TypePath path) { result = inferType(receiver, path) }
+  }
+
+  private class OperationMethodCall extends MethodCallImpl instanceof Operation {
+    TraitItemNode trait;
+    string methodName;
+
+    OperationMethodCall() { super.isOverloaded(trait, methodName) }
+
+    override string getMethodName() { result = methodName }
+
+    override int getArity() { result = this.(Operation).getNumberOfOperands() - 1 }
+
+    override Trait getTrait() { result = trait }
+
+    pragma[nomagic]
+    override Type getTypeAt(TypePath path) {
+      result = inferType(this.(BinaryExpr).getLhs(), path)
+      or
+      result = inferType(this.(PrefixExpr).getExpr(), path)
+    }
   }
 }
 

--- a/rust/ql/test/library-tests/type-inference/main.rs
+++ b/rust/ql/test/library-tests/type-inference/main.rs
@@ -770,7 +770,7 @@ mod method_supertraits {
         where
             Self: Sized,
         {
-            if 3 > 2 { // $ MISSING: method=gt
+            if 3 > 2 { // $ method=gt
                 self.m1() // $ method=MyTrait1::m1
             } else {
                 Self::m1(self)
@@ -784,7 +784,7 @@ mod method_supertraits {
         where
             Self: Sized,
         {
-            if 3 > 2 { // $ MISSING: method=gt
+            if 3 > 2 { // $ method=gt
                 self.m2().a // $ method=m2 $ fieldof=MyThing
             } else {
                 Self::m2(self).a // $ fieldof=MyThing
@@ -1027,7 +1027,7 @@ mod option_methods {
         println!("{:?}", MyOption::<MyOption<S>>::flatten(x6));
 
         #[rustfmt::skip]
-        let from_if = if 3 > 2 { // $ MISSING: method=gt
+        let from_if = if 3 > 2 { // $ method=gt
             MyOption::MyNone()
         } else {
             MyOption::MySome(S)
@@ -1035,7 +1035,7 @@ mod option_methods {
         println!("{:?}", from_if);
 
         #[rustfmt::skip]
-        let from_match = match 3 > 2 { // $ MISSING: method=gt
+        let from_match = match 3 > 2 { // $ method=gt
             true => MyOption::MyNone(),
             false => MyOption::MySome(S),
         };
@@ -1043,7 +1043,7 @@ mod option_methods {
 
         #[rustfmt::skip]
         let from_loop = loop {
-            if 3 > 2 { // $ MISSING: method=gt
+            if 3 > 2 { // $ method=gt
                 break MyOption::MyNone();
             }
             break MyOption::MySome(S);
@@ -1245,7 +1245,7 @@ mod builtins {
     pub fn f() {
         let x: i32 = 1; // $ type=x:i32
         let y = 2; // $ type=y:i32
-        let z = x + y; // $ MISSING: type=z:i32 method=add
+        let z = x + y; // $ type=z:i32 method=add
         let z = x.abs(); // $ method=abs $ type=z:i32
         let c = 'c'; // $ type=c:char
         let hello = "Hello"; // $ type=hello:str
@@ -1262,7 +1262,7 @@ mod operators {
         let y = true || false; // $ type=y:bool
 
         let mut a;
-        let cond = 34 == 33; // $ MISSING: method=eq
+        let cond = 34 == 33; // $ method=eq
         if cond {
             let z = (a = 1); // $ type=z:() type=a:i32
         } else {
@@ -1287,8 +1287,8 @@ mod overloadable_operators {
         // Vec2::add
         fn add(self, rhs: Self) -> Self {
             Vec2 {
-                x: self.x + rhs.x, // $ fieldof=Vec2 MISSING: method=add
-                y: self.y + rhs.y, // $ fieldof=Vec2 MISSING: method=add
+                x: self.x + rhs.x, // $ fieldof=Vec2 method=add
+                y: self.y + rhs.y, // $ fieldof=Vec2 method=add
             }
         }
     }
@@ -1296,8 +1296,8 @@ mod overloadable_operators {
         // Vec2::add_assign
         #[rustfmt::skip]
         fn add_assign(&mut self, rhs: Self) {
-            self.x += rhs.x; // $ fieldof=Vec2 MISSING: method=add_assign
-            self.y += rhs.y; // $ fieldof=Vec2 MISSING: method=add_assign
+            self.x += rhs.x; // $ fieldof=Vec2 method=add_assign
+            self.y += rhs.y; // $ fieldof=Vec2 method=add_assign
         }
     }
     impl Sub for Vec2 {
@@ -1305,8 +1305,8 @@ mod overloadable_operators {
         // Vec2::sub
         fn sub(self, rhs: Self) -> Self {
             Vec2 {
-                x: self.x - rhs.x, // $ fieldof=Vec2 MISSING: method=sub
-                y: self.y - rhs.y, // $ fieldof=Vec2 MISSING: method=sub
+                x: self.x - rhs.x, // $ fieldof=Vec2 method=sub
+                y: self.y - rhs.y, // $ fieldof=Vec2 method=sub
             }
         }
     }
@@ -1314,8 +1314,8 @@ mod overloadable_operators {
         // Vec2::sub_assign
         #[rustfmt::skip]
         fn sub_assign(&mut self, rhs: Self) {
-            self.x -= rhs.x; // $ fieldof=Vec2 MISSING: method=sub_assign
-            self.y -= rhs.y; // $ fieldof=Vec2 MISSING: method=sub_assign
+            self.x -= rhs.x; // $ fieldof=Vec2 method=sub_assign
+            self.y -= rhs.y; // $ fieldof=Vec2 method=sub_assign
         }
     }
     impl Mul for Vec2 {
@@ -1323,16 +1323,16 @@ mod overloadable_operators {
         // Vec2::mul
         fn mul(self, rhs: Self) -> Self {
             Vec2 {
-                x: self.x * rhs.x, // $ fieldof=Vec2 MISSING: method=mul
-                y: self.y * rhs.y, // $ fieldof=Vec2 MISSING: method=mul
+                x: self.x * rhs.x, // $ fieldof=Vec2 method=mul
+                y: self.y * rhs.y, // $ fieldof=Vec2 method=mul
             }
         }
     }
     impl MulAssign for Vec2 {
         // Vec2::mul_assign
         fn mul_assign(&mut self, rhs: Self) {
-            self.x *= rhs.x; // $ fieldof=Vec2 MISSING: method=mul_assign
-            self.y *= rhs.y; // $ fieldof=Vec2 MISSING: method=mul_assign
+            self.x *= rhs.x; // $ fieldof=Vec2 method=mul_assign
+            self.y *= rhs.y; // $ fieldof=Vec2 method=mul_assign
         }
     }
     impl Div for Vec2 {
@@ -1340,16 +1340,16 @@ mod overloadable_operators {
         // Vec2::div
         fn div(self, rhs: Self) -> Self {
             Vec2 {
-                x: self.x / rhs.x, // $ fieldof=Vec2 MISSING: method=div
-                y: self.y / rhs.y, // $ fieldof=Vec2 MISSING: method=div
+                x: self.x / rhs.x, // $ fieldof=Vec2 method=div
+                y: self.y / rhs.y, // $ fieldof=Vec2 method=div
             }
         }
     }
     impl DivAssign for Vec2 {
         // Vec2::div_assign
         fn div_assign(&mut self, rhs: Self) {
-            self.x /= rhs.x; // $ fieldof=Vec2 MISSING: method=div_assign
-            self.y /= rhs.y; // $ fieldof=Vec2 MISSING: method=div_assign
+            self.x /= rhs.x; // $ fieldof=Vec2 method=div_assign
+            self.y /= rhs.y; // $ fieldof=Vec2 method=div_assign
         }
     }
     impl Rem for Vec2 {
@@ -1357,16 +1357,16 @@ mod overloadable_operators {
         // Vec2::rem
         fn rem(self, rhs: Self) -> Self {
             Vec2 {
-                x: self.x % rhs.x, // $ fieldof=Vec2 MISSING: method=rem
-                y: self.y % rhs.y, // $ fieldof=Vec2 MISSING: method=rem
+                x: self.x % rhs.x, // $ fieldof=Vec2 method=rem
+                y: self.y % rhs.y, // $ fieldof=Vec2 method=rem
             }
         }
     }
     impl RemAssign for Vec2 {
         // Vec2::rem_assign
         fn rem_assign(&mut self, rhs: Self) {
-            self.x %= rhs.x; // $ fieldof=Vec2 MISSING: method=rem_assign
-            self.y %= rhs.y; // $ fieldof=Vec2 MISSING: method=rem_assign
+            self.x %= rhs.x; // $ fieldof=Vec2 method=rem_assign
+            self.y %= rhs.y; // $ fieldof=Vec2 method=rem_assign
         }
     }
     impl BitAnd for Vec2 {
@@ -1374,16 +1374,16 @@ mod overloadable_operators {
         // Vec2::bitand
         fn bitand(self, rhs: Self) -> Self {
             Vec2 {
-                x: self.x & rhs.x, // $ fieldof=Vec2 MISSING: method=bitand
-                y: self.y & rhs.y, // $ fieldof=Vec2 MISSING: method=bitand
+                x: self.x & rhs.x, // $ fieldof=Vec2 method=bitand
+                y: self.y & rhs.y, // $ fieldof=Vec2 method=bitand
             }
         }
     }
     impl BitAndAssign for Vec2 {
         // Vec2::bitand_assign
         fn bitand_assign(&mut self, rhs: Self) {
-            self.x &= rhs.x; // $ fieldof=Vec2 MISSING: method=bitand_assign
-            self.y &= rhs.y; // $ fieldof=Vec2 MISSING: method=bitand_assign
+            self.x &= rhs.x; // $ fieldof=Vec2 method=bitand_assign
+            self.y &= rhs.y; // $ fieldof=Vec2 method=bitand_assign
         }
     }
     impl BitOr for Vec2 {
@@ -1391,16 +1391,16 @@ mod overloadable_operators {
         // Vec2::bitor
         fn bitor(self, rhs: Self) -> Self {
             Vec2 {
-                x: self.x | rhs.x, // $ fieldof=Vec2 MISSING: method=bitor
-                y: self.y | rhs.y, // $ fieldof=Vec2 MISSING: method=bitor
+                x: self.x | rhs.x, // $ fieldof=Vec2 method=bitor
+                y: self.y | rhs.y, // $ fieldof=Vec2 method=bitor
             }
         }
     }
     impl BitOrAssign for Vec2 {
         // Vec2::bitor_assign
         fn bitor_assign(&mut self, rhs: Self) {
-            self.x |= rhs.x; // $ fieldof=Vec2 MISSING: method=bitor_assign
-            self.y |= rhs.y; // $ fieldof=Vec2 MISSING: method=bitor_assign
+            self.x |= rhs.x; // $ fieldof=Vec2 method=bitor_assign
+            self.y |= rhs.y; // $ fieldof=Vec2 method=bitor_assign
         }
     }
     impl BitXor for Vec2 {
@@ -1408,16 +1408,16 @@ mod overloadable_operators {
         // Vec2::bitxor
         fn bitxor(self, rhs: Self) -> Self {
             Vec2 {
-                x: self.x ^ rhs.x, // $ fieldof=Vec2 MISSING: method=bitxor
-                y: self.y ^ rhs.y, // $ fieldof=Vec2 MISSING: method=bitxor
+                x: self.x ^ rhs.x, // $ fieldof=Vec2 method=bitxor
+                y: self.y ^ rhs.y, // $ fieldof=Vec2 method=bitxor
             }
         }
     }
     impl BitXorAssign for Vec2 {
         // Vec2::bitxor_assign
         fn bitxor_assign(&mut self, rhs: Self) {
-            self.x ^= rhs.x; // $ fieldof=Vec2 MISSING: method=bitxor_assign
-            self.y ^= rhs.y; // $ fieldof=Vec2 MISSING: method=bitxor_assign
+            self.x ^= rhs.x; // $ fieldof=Vec2 method=bitxor_assign
+            self.y ^= rhs.y; // $ fieldof=Vec2 method=bitxor_assign
         }
     }
     impl Shl<u32> for Vec2 {
@@ -1425,16 +1425,16 @@ mod overloadable_operators {
         // Vec2::shl
         fn shl(self, rhs: u32) -> Self {
             Vec2 {
-                x: self.x << rhs, // $ fieldof=Vec2 MISSING: method=shl
-                y: self.y << rhs, // $ fieldof=Vec2 MISSING: method=shl
+                x: self.x << rhs, // $ fieldof=Vec2 method=shl
+                y: self.y << rhs, // $ fieldof=Vec2 method=shl
             }
         }
     }
     impl ShlAssign<u32> for Vec2 {
         // Vec2::shl_assign
         fn shl_assign(&mut self, rhs: u32) {
-            self.x <<= rhs; // $ fieldof=Vec2 MISSING: method=shl_assign
-            self.y <<= rhs; // $ fieldof=Vec2 MISSING: method=shl_assign
+            self.x <<= rhs; // $ fieldof=Vec2 method=shl_assign
+            self.y <<= rhs; // $ fieldof=Vec2 method=shl_assign
         }
     }
     impl Shr<u32> for Vec2 {
@@ -1442,16 +1442,16 @@ mod overloadable_operators {
         // Vec2::shr
         fn shr(self, rhs: u32) -> Self {
             Vec2 {
-                x: self.x >> rhs, // $ fieldof=Vec2 MISSING: method=shr
-                y: self.y >> rhs, // $ fieldof=Vec2 MISSING: method=shr
+                x: self.x >> rhs, // $ fieldof=Vec2 method=shr
+                y: self.y >> rhs, // $ fieldof=Vec2 method=shr
             }
         }
     }
     impl ShrAssign<u32> for Vec2 {
         // Vec2::shr_assign
         fn shr_assign(&mut self, rhs: u32) {
-            self.x >>= rhs; // $ fieldof=Vec2 MISSING: method=shr_assign
-            self.y >>= rhs; // $ fieldof=Vec2 MISSING: method=shr_assign
+            self.x >>= rhs; // $ fieldof=Vec2 method=shr_assign
+            self.y >>= rhs; // $ fieldof=Vec2 method=shr_assign
         }
     }
     impl Neg for Vec2 {
@@ -1459,8 +1459,8 @@ mod overloadable_operators {
         // Vec2::neg
         fn neg(self) -> Self {
             Vec2 {
-                x: -self.x, // $ fieldof=Vec2 MISSING: method=neg
-                y: -self.y, // $ fieldof=Vec2 MISSING: method=neg
+                x: -self.x, // $ fieldof=Vec2 method=neg
+                y: -self.y, // $ fieldof=Vec2 method=neg
             }
         }
     }
@@ -1469,164 +1469,164 @@ mod overloadable_operators {
         // Vec2::not
         fn not(self) -> Self {
             Vec2 {
-                x: !self.x, // $ fieldof=Vec2 MISSING: method=not
-                y: !self.y, // $ fieldof=Vec2 MISSING: method=not
+                x: !self.x, // $ fieldof=Vec2 method=not
+                y: !self.y, // $ fieldof=Vec2 method=not
             }
         }
     }
     impl PartialEq for Vec2 {
         // Vec2::eq
         fn eq(&self, other: &Self) -> bool {
-            self.x == other.x && self.y == other.y // $ fieldof=Vec2 fieldof=Vec2 MISSING: method=eq
+            self.x == other.x && self.y == other.y // $ fieldof=Vec2 method=eq
         }
         // Vec2::ne
         fn ne(&self, other: &Self) -> bool {
-            self.x != other.x || self.y != other.y // $ fieldof=Vec2 fieldof=Vec2 MISSING: method=ne
+            self.x != other.x || self.y != other.y // $ fieldof=Vec2 method=ne
         }
     }
     impl PartialOrd for Vec2 {
         // Vec2::partial_cmp
         fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-            (self.x + self.y).partial_cmp(&(other.x + other.y)) // $ fieldof=Vec2 fieldof=Vec2 MISSING: method=partial_cmp method=add
+            (self.x + self.y).partial_cmp(&(other.x + other.y)) // $ fieldof=Vec2 method=partial_cmp method=add
         }
         // Vec2::lt
         fn lt(&self, other: &Self) -> bool {
-            self.x < other.x && self.y < other.y // $ fieldof=Vec2 fieldof=Vec2 MISSING: method=lt
+            self.x < other.x && self.y < other.y // $ fieldof=Vec2 method=lt
         }
         // Vec2::le
         fn le(&self, other: &Self) -> bool {
-            self.x <= other.x && self.y <= other.y // $ fieldof=Vec2 fieldof=Vec2 MISSING: method=le
+            self.x <= other.x && self.y <= other.y // $ fieldof=Vec2 method=le
         }
         // Vec2::gt
         fn gt(&self, other: &Self) -> bool {
-            self.x > other.x && self.y > other.y // $ fieldof=Vec2 fieldof=Vec2 MISSING: method=gt
+            self.x > other.x && self.y > other.y // $ fieldof=Vec2 method=gt
         }
         // Vec2::ge
         fn ge(&self, other: &Self) -> bool {
-            self.x >= other.x && self.y >= other.y // $ fieldof=Vec2 fieldof=Vec2 MISSING: method=ge
+            self.x >= other.x && self.y >= other.y // $ fieldof=Vec2 method=ge
         }
     }
     pub fn f() {
         // Test for all overloadable operators on `i64`
 
         // Comparison operators
-        let i64_eq = (1i64 == 2i64); // $ MISSING: type=i64_eq:bool method=eq
-        let i64_ne = (3i64 != 4i64); // $ MISSING: type=i64_ne:bool method=ne
-        let i64_lt = (5i64 < 6i64); // $ MISSING: type=i64_lt:bool method=lt
-        let i64_le = (7i64 <= 8i64); // $ MISSING: type=i64_le:bool method=le
-        let i64_gt = (9i64 > 10i64); // $ MISSING: type=i64_gt:bool method=gt
-        let i64_ge = (11i64 >= 12i64); // $ MISSING: type=i64_ge:bool method=ge
+        let i64_eq = (1i64 == 2i64); // $ type=i64_eq:bool method=eq
+        let i64_ne = (3i64 != 4i64); // $ type=i64_ne:bool method=ne
+        let i64_lt = (5i64 < 6i64); // $ type=i64_lt:bool method=lt
+        let i64_le = (7i64 <= 8i64); // $ type=i64_le:bool method=le
+        let i64_gt = (9i64 > 10i64); // $ type=i64_gt:bool method=gt
+        let i64_ge = (11i64 >= 12i64); // $ type=i64_ge:bool method=ge
 
         // Arithmetic operators
-        let i64_add = 13i64 + 14i64; // $ MISSING: type=i64_add:i64 method=add
-        let i64_sub = 15i64 - 16i64; // $ MISSING: type=i64_sub:i64 method=sub
-        let i64_mul = 17i64 * 18i64; // $ MISSING: type=i64_mul:i64 method=mul
-        let i64_div = 19i64 / 20i64; // $ MISSING: type=i64_div:i64 method=div
-        let i64_rem = 21i64 % 22i64; // $ MISSING: type=i64_rem:i64 method=rem
+        let i64_add = 13i64 + 14i64; // $ type=i64_add:i64 method=add
+        let i64_sub = 15i64 - 16i64; // $ type=i64_sub:i64 method=sub
+        let i64_mul = 17i64 * 18i64; // $ type=i64_mul:i64 method=mul
+        let i64_div = 19i64 / 20i64; // $ type=i64_div:i64 method=div
+        let i64_rem = 21i64 % 22i64; // $ type=i64_rem:i64 method=rem
 
         // Arithmetic assignment operators
         let mut i64_add_assign = 23i64;
-        i64_add_assign += 24i64; // $ MISSING: method=add_assign
+        i64_add_assign += 24i64; // $ method=add_assign
 
         let mut i64_sub_assign = 25i64;
-        i64_sub_assign -= 26i64; // $ MISSING: method=sub_assign
+        i64_sub_assign -= 26i64; // $ method=sub_assign
 
         let mut i64_mul_assign = 27i64;
-        i64_mul_assign *= 28i64; // $ MISSING: method=mul_assign
+        i64_mul_assign *= 28i64; // $ method=mul_assign
 
         let mut i64_div_assign = 29i64;
-        i64_div_assign /= 30i64; // $ MISSING: method=div_assign
+        i64_div_assign /= 30i64; // $ method=div_assign
 
         let mut i64_rem_assign = 31i64;
-        i64_rem_assign %= 32i64; // $ MISSING: method=rem_assign
+        i64_rem_assign %= 32i64; // $ method=rem_assign
 
         // Bitwise operators
-        let i64_bitand = 33i64 & 34i64; // $ MISSING: type=i64_bitand:i64 method=bitand
-        let i64_bitor = 35i64 | 36i64; // $ MISSING: type=i64_bitor:i64 method=bitor
-        let i64_bitxor = 37i64 ^ 38i64; // $ MISSING: type=i64_bitxor:i64 method=bitxor
-        let i64_shl = 39i64 << 40i64; // $ MISSING: type=i64_shl:i64 method=shl
-        let i64_shr = 41i64 >> 42i64; // $ MISSING: type=i64_shr:i64 method=shr
+        let i64_bitand = 33i64 & 34i64; // $ type=i64_bitand:i64 method=bitand
+        let i64_bitor = 35i64 | 36i64; // $ type=i64_bitor:i64 method=bitor
+        let i64_bitxor = 37i64 ^ 38i64; // $ type=i64_bitxor:i64 method=bitxor
+        let i64_shl = 39i64 << 40i64; // $ type=i64_shl:i64 method=shl
+        let i64_shr = 41i64 >> 42i64; // $ type=i64_shr:i64 method=shr
 
         // Bitwise assignment operators
         let mut i64_bitand_assign = 43i64;
-        i64_bitand_assign &= 44i64; // $ MISSING: method=bitand_assign
+        i64_bitand_assign &= 44i64; // $ method=bitand_assign
 
         let mut i64_bitor_assign = 45i64;
-        i64_bitor_assign |= 46i64; // $ MISSING: method=bitor_assign
+        i64_bitor_assign |= 46i64; // $ method=bitor_assign
 
         let mut i64_bitxor_assign = 47i64;
-        i64_bitxor_assign ^= 48i64; // $ MISSING: method=bitxor_assign
+        i64_bitxor_assign ^= 48i64; // $ method=bitxor_assign
 
         let mut i64_shl_assign = 49i64;
-        i64_shl_assign <<= 50i64; // $ MISSING: method=shl_assign
+        i64_shl_assign <<= 50i64; // $ method=shl_assign
 
         let mut i64_shr_assign = 51i64;
-        i64_shr_assign >>= 52i64; // $ MISSING: method=shr_assign
+        i64_shr_assign >>= 52i64; // $ method=shr_assign
 
-        let i64_neg = -53i64; // $ MISSING: type=i64_neg:i64 method=neg
-        let i64_not = !54i64; // $ MISSING: type=i64_not:i64 method=not
+        let i64_neg = -53i64; // $ type=i64_neg:i64 method=neg
+        let i64_not = !54i64; // $ type=i64_not:i64 method=not
 
         // Test for all overloadable operators on Vec2
         let v1 = Vec2 { x: 1, y: 2 };
         let v2 = Vec2 { x: 3, y: 4 };
 
         // Comparison operators
-        let vec2_eq = v1 == v2; // $ MISSING: type=vec2_eq:bool method=Vec2::eq
-        let vec2_ne = v1 != v2; // $ MISSING: type=vec2_ne:bool method=Vec2::ne
-        let vec2_lt = v1 < v2; // $ MISSING: type=vec2_lt:bool method=Vec2::lt
-        let vec2_le = v1 <= v2; // $ MISSING: type=vec2_le:bool method=Vec2::le
-        let vec2_gt = v1 > v2; // $ MISSING: type=vec2_gt:bool method=Vec2::gt
-        let vec2_ge = v1 >= v2; // $ MISSING: type=vec2_ge:bool method=Vec2::ge
+        let vec2_eq = v1 == v2; // $ type=vec2_eq:bool method=Vec2::eq
+        let vec2_ne = v1 != v2; // $ type=vec2_ne:bool method=Vec2::ne
+        let vec2_lt = v1 < v2; // $ type=vec2_lt:bool method=Vec2::lt
+        let vec2_le = v1 <= v2; // $ type=vec2_le:bool method=Vec2::le
+        let vec2_gt = v1 > v2; // $ type=vec2_gt:bool method=Vec2::gt
+        let vec2_ge = v1 >= v2; // $ type=vec2_ge:bool method=Vec2::ge
 
         // Arithmetic operators
-        let vec2_add = v1 + v2; // $ MISSING: type=vec2_add:Vec2 method=Vec2::add
-        let vec2_sub = v1 - v2; // $ MISSING: type=vec2_sub:Vec2 method=Vec2::sub
-        let vec2_mul = v1 * v2; // $ MISSING: type=vec2_mul:Vec2 method=Vec2::mul
-        let vec2_div = v1 / v2; // $ MISSING: type=vec2_div:Vec2 method=Vec2::div
-        let vec2_rem = v1 % v2; // $ MISSING: type=vec2_rem:Vec2 method=Vec2::rem
+        let vec2_add = v1 + v2; // $ type=vec2_add:Vec2 method=Vec2::add
+        let vec2_sub = v1 - v2; // $ type=vec2_sub:Vec2 method=Vec2::sub
+        let vec2_mul = v1 * v2; // $ type=vec2_mul:Vec2 method=Vec2::mul
+        let vec2_div = v1 / v2; // $ type=vec2_div:Vec2 method=Vec2::div
+        let vec2_rem = v1 % v2; // $ type=vec2_rem:Vec2 method=Vec2::rem
 
         // Arithmetic assignment operators
         let mut vec2_add_assign = v1;
-        vec2_add_assign += v2; // $ MISSING: method=Vec2::add_assign
+        vec2_add_assign += v2; // $ method=Vec2::add_assign
 
         let mut vec2_sub_assign = v1;
-        vec2_sub_assign -= v2; // $ MISSING: method=Vec2::sub_assign
+        vec2_sub_assign -= v2; // $ method=Vec2::sub_assign
 
         let mut vec2_mul_assign = v1;
-        vec2_mul_assign *= v2; // $ MISSING: method=Vec2::mul_assign
+        vec2_mul_assign *= v2; // $ method=Vec2::mul_assign
 
         let mut vec2_div_assign = v1;
-        vec2_div_assign /= v2; // $ MISSING: method=Vec2::div_assign
+        vec2_div_assign /= v2; // $ method=Vec2::div_assign
 
         let mut vec2_rem_assign = v1;
-        vec2_rem_assign %= v2; // $ MISSING: method=Vec2::rem_assign
+        vec2_rem_assign %= v2; // $ method=Vec2::rem_assign
 
         // Bitwise operators
-        let vec2_bitand = v1 & v2; // $ MISSING: type=vec2_bitand:Vec2 method=Vec2::bitand
-        let vec2_bitor = v1 | v2; // $ MISSING: type=vec2_bitor:Vec2 method=Vec2::bitor
-        let vec2_bitxor = v1 ^ v2; // $ MISSING: type=vec2_bitxor:Vec2 method=Vec2::bitxor
-        let vec2_shl = v1 << 1u32; // $ MISSING: type=vec2_shl:Vec2 method=Vec2::shl
-        let vec2_shr = v1 >> 1u32; // $ MISSING: type=vec2_shr:Vec2 method=Vec2::shr
+        let vec2_bitand = v1 & v2; // $ type=vec2_bitand:Vec2 method=Vec2::bitand
+        let vec2_bitor = v1 | v2; // $ type=vec2_bitor:Vec2 method=Vec2::bitor
+        let vec2_bitxor = v1 ^ v2; // $ type=vec2_bitxor:Vec2 method=Vec2::bitxor
+        let vec2_shl = v1 << 1u32; // $ type=vec2_shl:Vec2 method=Vec2::shl
+        let vec2_shr = v1 >> 1u32; // $ type=vec2_shr:Vec2 method=Vec2::shr
 
         // Bitwise assignment operators
         let mut vec2_bitand_assign = v1;
-        vec2_bitand_assign &= v2; // $ MISSING: method=Vec2::bitand_assign
+        vec2_bitand_assign &= v2; // $ method=Vec2::bitand_assign
 
         let mut vec2_bitor_assign = v1;
-        vec2_bitor_assign |= v2; // $ MISSING: method=Vec2::bitor_assign
+        vec2_bitor_assign |= v2; // $ method=Vec2::bitor_assign
 
         let mut vec2_bitxor_assign = v1;
-        vec2_bitxor_assign ^= v2; // $ MISSING: method=Vec2::bitxor_assign
+        vec2_bitxor_assign ^= v2; // $ method=Vec2::bitxor_assign
 
         let mut vec2_shl_assign = v1;
-        vec2_shl_assign <<= 1u32; // $ MISSING: method=Vec2::shl_assign
+        vec2_shl_assign <<= 1u32; // $ method=Vec2::shl_assign
 
         let mut vec2_shr_assign = v1;
-        vec2_shr_assign >>= 1u32; // $ MISSING: method=Vec2::shr_assign
+        vec2_shr_assign >>= 1u32; // $ method=Vec2::shr_assign
 
         // Prefix operators
-        let vec2_neg = -v1; // $ MISSING: type=vec2_neg:Vec2 method=Vec2::neg
-        let vec2_not = !v1; // $ MISSING: type=vec2_not:Vec2 method=Vec2::not
+        let vec2_neg = -v1; // $ type=vec2_neg:Vec2 method=Vec2::neg
+        let vec2_not = !v1; // $ type=vec2_not:Vec2 method=Vec2::not
     }
 }
 

--- a/rust/ql/test/library-tests/type-inference/main.rs
+++ b/rust/ql/test/library-tests/type-inference/main.rs
@@ -765,11 +765,12 @@ mod method_supertraits {
     }
 
     trait MyTrait2<Tr2>: MyTrait1<Tr2> {
+        #[rustfmt::skip]
         fn m2(self) -> Tr2
         where
             Self: Sized,
         {
-            if 1 + 1 > 2 {
+            if 3 > 2 { // $ MISSING: method=gt
                 self.m1() // $ method=MyTrait1::m1
             } else {
                 Self::m1(self)
@@ -778,11 +779,12 @@ mod method_supertraits {
     }
 
     trait MyTrait3<Tr3>: MyTrait2<MyThing<Tr3>> {
+        #[rustfmt::skip]
         fn m3(self) -> Tr3
         where
             Self: Sized,
         {
-            if 1 + 1 > 2 {
+            if 3 > 2 { // $ MISSING: method=gt
                 self.m2().a // $ method=m2 $ fieldof=MyThing
             } else {
                 Self::m2(self).a // $ fieldof=MyThing
@@ -1024,21 +1026,24 @@ mod option_methods {
         let x6 = MyOption::MySome(MyOption::<S>::MyNone());
         println!("{:?}", MyOption::<MyOption<S>>::flatten(x6));
 
-        let from_if = if 1 + 1 > 2 {
+        #[rustfmt::skip]
+        let from_if = if 3 > 2 { // $ MISSING: method=gt
             MyOption::MyNone()
         } else {
             MyOption::MySome(S)
         };
         println!("{:?}", from_if);
 
-        let from_match = match 1 + 1 > 2 {
+        #[rustfmt::skip]
+        let from_match = match 3 > 2 { // $ MISSING: method=gt
             true => MyOption::MyNone(),
             false => MyOption::MySome(S),
         };
         println!("{:?}", from_match);
 
+        #[rustfmt::skip]
         let from_loop = loop {
-            if 1 + 1 > 2 {
+            if 3 > 2 { // $ MISSING: method=gt
                 break MyOption::MyNone();
             }
             break MyOption::MySome(S);
@@ -1240,7 +1245,7 @@ mod builtins {
     pub fn f() {
         let x: i32 = 1; // $ type=x:i32
         let y = 2; // $ type=y:i32
-        let z = x + y; // $ MISSING: type=z:i32
+        let z = x + y; // $ MISSING: type=z:i32 method=add
         let z = x.abs(); // $ method=abs $ type=z:i32
         let c = 'c'; // $ type=c:char
         let hello = "Hello"; // $ type=hello:str
@@ -1250,18 +1255,378 @@ mod builtins {
     }
 }
 
+// Tests for non-overloaded operators.
 mod operators {
     pub fn f() {
         let x = true && false; // $ type=x:bool
         let y = true || false; // $ type=y:bool
 
         let mut a;
-        if 34 == 33 {
+        let cond = 34 == 33; // $ MISSING: method=eq
+        if cond {
             let z = (a = 1); // $ type=z:() type=a:i32
         } else {
             a = 2; // $ type=a:i32
         }
         a; // $ type=a:i32
+    }
+}
+
+// Tests for overloaded operators.
+mod overloadable_operators {
+    use std::ops::*;
+    // A vector type with overloaded operators.
+    #[derive(Debug, Copy, Clone)]
+    struct Vec2 {
+        x: i64,
+        y: i64,
+    }
+    // Implement all overloadable operators for Vec2
+    impl Add for Vec2 {
+        type Output = Self;
+        // Vec2::add
+        fn add(self, rhs: Self) -> Self {
+            Vec2 {
+                x: self.x + rhs.x, // $ fieldof=Vec2 MISSING: method=add
+                y: self.y + rhs.y, // $ fieldof=Vec2 MISSING: method=add
+            }
+        }
+    }
+    impl AddAssign for Vec2 {
+        // Vec2::add_assign
+        #[rustfmt::skip]
+        fn add_assign(&mut self, rhs: Self) {
+            self.x += rhs.x; // $ fieldof=Vec2 MISSING: method=add_assign
+            self.y += rhs.y; // $ fieldof=Vec2 MISSING: method=add_assign
+        }
+    }
+    impl Sub for Vec2 {
+        type Output = Self;
+        // Vec2::sub
+        fn sub(self, rhs: Self) -> Self {
+            Vec2 {
+                x: self.x - rhs.x, // $ fieldof=Vec2 MISSING: method=sub
+                y: self.y - rhs.y, // $ fieldof=Vec2 MISSING: method=sub
+            }
+        }
+    }
+    impl SubAssign for Vec2 {
+        // Vec2::sub_assign
+        #[rustfmt::skip]
+        fn sub_assign(&mut self, rhs: Self) {
+            self.x -= rhs.x; // $ fieldof=Vec2 MISSING: method=sub_assign
+            self.y -= rhs.y; // $ fieldof=Vec2 MISSING: method=sub_assign
+        }
+    }
+    impl Mul for Vec2 {
+        type Output = Self;
+        // Vec2::mul
+        fn mul(self, rhs: Self) -> Self {
+            Vec2 {
+                x: self.x * rhs.x, // $ fieldof=Vec2 MISSING: method=mul
+                y: self.y * rhs.y, // $ fieldof=Vec2 MISSING: method=mul
+            }
+        }
+    }
+    impl MulAssign for Vec2 {
+        // Vec2::mul_assign
+        fn mul_assign(&mut self, rhs: Self) {
+            self.x *= rhs.x; // $ fieldof=Vec2 MISSING: method=mul_assign
+            self.y *= rhs.y; // $ fieldof=Vec2 MISSING: method=mul_assign
+        }
+    }
+    impl Div for Vec2 {
+        type Output = Self;
+        // Vec2::div
+        fn div(self, rhs: Self) -> Self {
+            Vec2 {
+                x: self.x / rhs.x, // $ fieldof=Vec2 MISSING: method=div
+                y: self.y / rhs.y, // $ fieldof=Vec2 MISSING: method=div
+            }
+        }
+    }
+    impl DivAssign for Vec2 {
+        // Vec2::div_assign
+        fn div_assign(&mut self, rhs: Self) {
+            self.x /= rhs.x; // $ fieldof=Vec2 MISSING: method=div_assign
+            self.y /= rhs.y; // $ fieldof=Vec2 MISSING: method=div_assign
+        }
+    }
+    impl Rem for Vec2 {
+        type Output = Self;
+        // Vec2::rem
+        fn rem(self, rhs: Self) -> Self {
+            Vec2 {
+                x: self.x % rhs.x, // $ fieldof=Vec2 MISSING: method=rem
+                y: self.y % rhs.y, // $ fieldof=Vec2 MISSING: method=rem
+            }
+        }
+    }
+    impl RemAssign for Vec2 {
+        // Vec2::rem_assign
+        fn rem_assign(&mut self, rhs: Self) {
+            self.x %= rhs.x; // $ fieldof=Vec2 MISSING: method=rem_assign
+            self.y %= rhs.y; // $ fieldof=Vec2 MISSING: method=rem_assign
+        }
+    }
+    impl BitAnd for Vec2 {
+        type Output = Self;
+        // Vec2::bitand
+        fn bitand(self, rhs: Self) -> Self {
+            Vec2 {
+                x: self.x & rhs.x, // $ fieldof=Vec2 MISSING: method=bitand
+                y: self.y & rhs.y, // $ fieldof=Vec2 MISSING: method=bitand
+            }
+        }
+    }
+    impl BitAndAssign for Vec2 {
+        // Vec2::bitand_assign
+        fn bitand_assign(&mut self, rhs: Self) {
+            self.x &= rhs.x; // $ fieldof=Vec2 MISSING: method=bitand_assign
+            self.y &= rhs.y; // $ fieldof=Vec2 MISSING: method=bitand_assign
+        }
+    }
+    impl BitOr for Vec2 {
+        type Output = Self;
+        // Vec2::bitor
+        fn bitor(self, rhs: Self) -> Self {
+            Vec2 {
+                x: self.x | rhs.x, // $ fieldof=Vec2 MISSING: method=bitor
+                y: self.y | rhs.y, // $ fieldof=Vec2 MISSING: method=bitor
+            }
+        }
+    }
+    impl BitOrAssign for Vec2 {
+        // Vec2::bitor_assign
+        fn bitor_assign(&mut self, rhs: Self) {
+            self.x |= rhs.x; // $ fieldof=Vec2 MISSING: method=bitor_assign
+            self.y |= rhs.y; // $ fieldof=Vec2 MISSING: method=bitor_assign
+        }
+    }
+    impl BitXor for Vec2 {
+        type Output = Self;
+        // Vec2::bitxor
+        fn bitxor(self, rhs: Self) -> Self {
+            Vec2 {
+                x: self.x ^ rhs.x, // $ fieldof=Vec2 MISSING: method=bitxor
+                y: self.y ^ rhs.y, // $ fieldof=Vec2 MISSING: method=bitxor
+            }
+        }
+    }
+    impl BitXorAssign for Vec2 {
+        // Vec2::bitxor_assign
+        fn bitxor_assign(&mut self, rhs: Self) {
+            self.x ^= rhs.x; // $ fieldof=Vec2 MISSING: method=bitxor_assign
+            self.y ^= rhs.y; // $ fieldof=Vec2 MISSING: method=bitxor_assign
+        }
+    }
+    impl Shl<u32> for Vec2 {
+        type Output = Self;
+        // Vec2::shl
+        fn shl(self, rhs: u32) -> Self {
+            Vec2 {
+                x: self.x << rhs, // $ fieldof=Vec2 MISSING: method=shl
+                y: self.y << rhs, // $ fieldof=Vec2 MISSING: method=shl
+            }
+        }
+    }
+    impl ShlAssign<u32> for Vec2 {
+        // Vec2::shl_assign
+        fn shl_assign(&mut self, rhs: u32) {
+            self.x <<= rhs; // $ fieldof=Vec2 MISSING: method=shl_assign
+            self.y <<= rhs; // $ fieldof=Vec2 MISSING: method=shl_assign
+        }
+    }
+    impl Shr<u32> for Vec2 {
+        type Output = Self;
+        // Vec2::shr
+        fn shr(self, rhs: u32) -> Self {
+            Vec2 {
+                x: self.x >> rhs, // $ fieldof=Vec2 MISSING: method=shr
+                y: self.y >> rhs, // $ fieldof=Vec2 MISSING: method=shr
+            }
+        }
+    }
+    impl ShrAssign<u32> for Vec2 {
+        // Vec2::shr_assign
+        fn shr_assign(&mut self, rhs: u32) {
+            self.x >>= rhs; // $ fieldof=Vec2 MISSING: method=shr_assign
+            self.y >>= rhs; // $ fieldof=Vec2 MISSING: method=shr_assign
+        }
+    }
+    impl Neg for Vec2 {
+        type Output = Self;
+        // Vec2::neg
+        fn neg(self) -> Self {
+            Vec2 {
+                x: -self.x, // $ fieldof=Vec2 MISSING: method=neg
+                y: -self.y, // $ fieldof=Vec2 MISSING: method=neg
+            }
+        }
+    }
+    impl Not for Vec2 {
+        type Output = Self;
+        // Vec2::not
+        fn not(self) -> Self {
+            Vec2 {
+                x: !self.x, // $ fieldof=Vec2 MISSING: method=not
+                y: !self.y, // $ fieldof=Vec2 MISSING: method=not
+            }
+        }
+    }
+    impl PartialEq for Vec2 {
+        // Vec2::eq
+        fn eq(&self, other: &Self) -> bool {
+            self.x == other.x && self.y == other.y // $ fieldof=Vec2 fieldof=Vec2 MISSING: method=eq
+        }
+        // Vec2::ne
+        fn ne(&self, other: &Self) -> bool {
+            self.x != other.x || self.y != other.y // $ fieldof=Vec2 fieldof=Vec2 MISSING: method=ne
+        }
+    }
+    impl PartialOrd for Vec2 {
+        // Vec2::partial_cmp
+        fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+            (self.x + self.y).partial_cmp(&(other.x + other.y)) // $ fieldof=Vec2 fieldof=Vec2 MISSING: method=partial_cmp method=add
+        }
+        // Vec2::lt
+        fn lt(&self, other: &Self) -> bool {
+            self.x < other.x && self.y < other.y // $ fieldof=Vec2 fieldof=Vec2 MISSING: method=lt
+        }
+        // Vec2::le
+        fn le(&self, other: &Self) -> bool {
+            self.x <= other.x && self.y <= other.y // $ fieldof=Vec2 fieldof=Vec2 MISSING: method=le
+        }
+        // Vec2::gt
+        fn gt(&self, other: &Self) -> bool {
+            self.x > other.x && self.y > other.y // $ fieldof=Vec2 fieldof=Vec2 MISSING: method=gt
+        }
+        // Vec2::ge
+        fn ge(&self, other: &Self) -> bool {
+            self.x >= other.x && self.y >= other.y // $ fieldof=Vec2 fieldof=Vec2 MISSING: method=ge
+        }
+    }
+    pub fn f() {
+        // Test for all overloadable operators on `i64`
+
+        // Comparison operators
+        let i64_eq = (1i64 == 2i64); // $ MISSING: type=i64_eq:bool method=eq
+        let i64_ne = (3i64 != 4i64); // $ MISSING: type=i64_ne:bool method=ne
+        let i64_lt = (5i64 < 6i64); // $ MISSING: type=i64_lt:bool method=lt
+        let i64_le = (7i64 <= 8i64); // $ MISSING: type=i64_le:bool method=le
+        let i64_gt = (9i64 > 10i64); // $ MISSING: type=i64_gt:bool method=gt
+        let i64_ge = (11i64 >= 12i64); // $ MISSING: type=i64_ge:bool method=ge
+
+        // Arithmetic operators
+        let i64_add = 13i64 + 14i64; // $ MISSING: type=i64_add:i64 method=add
+        let i64_sub = 15i64 - 16i64; // $ MISSING: type=i64_sub:i64 method=sub
+        let i64_mul = 17i64 * 18i64; // $ MISSING: type=i64_mul:i64 method=mul
+        let i64_div = 19i64 / 20i64; // $ MISSING: type=i64_div:i64 method=div
+        let i64_rem = 21i64 % 22i64; // $ MISSING: type=i64_rem:i64 method=rem
+
+        // Arithmetic assignment operators
+        let mut i64_add_assign = 23i64;
+        i64_add_assign += 24i64; // $ MISSING: method=add_assign
+
+        let mut i64_sub_assign = 25i64;
+        i64_sub_assign -= 26i64; // $ MISSING: method=sub_assign
+
+        let mut i64_mul_assign = 27i64;
+        i64_mul_assign *= 28i64; // $ MISSING: method=mul_assign
+
+        let mut i64_div_assign = 29i64;
+        i64_div_assign /= 30i64; // $ MISSING: method=div_assign
+
+        let mut i64_rem_assign = 31i64;
+        i64_rem_assign %= 32i64; // $ MISSING: method=rem_assign
+
+        // Bitwise operators
+        let i64_bitand = 33i64 & 34i64; // $ MISSING: type=i64_bitand:i64 method=bitand
+        let i64_bitor = 35i64 | 36i64; // $ MISSING: type=i64_bitor:i64 method=bitor
+        let i64_bitxor = 37i64 ^ 38i64; // $ MISSING: type=i64_bitxor:i64 method=bitxor
+        let i64_shl = 39i64 << 40i64; // $ MISSING: type=i64_shl:i64 method=shl
+        let i64_shr = 41i64 >> 42i64; // $ MISSING: type=i64_shr:i64 method=shr
+
+        // Bitwise assignment operators
+        let mut i64_bitand_assign = 43i64;
+        i64_bitand_assign &= 44i64; // $ MISSING: method=bitand_assign
+
+        let mut i64_bitor_assign = 45i64;
+        i64_bitor_assign |= 46i64; // $ MISSING: method=bitor_assign
+
+        let mut i64_bitxor_assign = 47i64;
+        i64_bitxor_assign ^= 48i64; // $ MISSING: method=bitxor_assign
+
+        let mut i64_shl_assign = 49i64;
+        i64_shl_assign <<= 50i64; // $ MISSING: method=shl_assign
+
+        let mut i64_shr_assign = 51i64;
+        i64_shr_assign >>= 52i64; // $ MISSING: method=shr_assign
+
+        let i64_neg = -53i64; // $ MISSING: type=i64_neg:i64 method=neg
+        let i64_not = !54i64; // $ MISSING: type=i64_not:i64 method=not
+
+        // Test for all overloadable operators on Vec2
+        let v1 = Vec2 { x: 1, y: 2 };
+        let v2 = Vec2 { x: 3, y: 4 };
+
+        // Comparison operators
+        let vec2_eq = v1 == v2; // $ MISSING: type=vec2_eq:bool method=Vec2::eq
+        let vec2_ne = v1 != v2; // $ MISSING: type=vec2_ne:bool method=Vec2::ne
+        let vec2_lt = v1 < v2; // $ MISSING: type=vec2_lt:bool method=Vec2::lt
+        let vec2_le = v1 <= v2; // $ MISSING: type=vec2_le:bool method=Vec2::le
+        let vec2_gt = v1 > v2; // $ MISSING: type=vec2_gt:bool method=Vec2::gt
+        let vec2_ge = v1 >= v2; // $ MISSING: type=vec2_ge:bool method=Vec2::ge
+
+        // Arithmetic operators
+        let vec2_add = v1 + v2; // $ MISSING: type=vec2_add:Vec2 method=Vec2::add
+        let vec2_sub = v1 - v2; // $ MISSING: type=vec2_sub:Vec2 method=Vec2::sub
+        let vec2_mul = v1 * v2; // $ MISSING: type=vec2_mul:Vec2 method=Vec2::mul
+        let vec2_div = v1 / v2; // $ MISSING: type=vec2_div:Vec2 method=Vec2::div
+        let vec2_rem = v1 % v2; // $ MISSING: type=vec2_rem:Vec2 method=Vec2::rem
+
+        // Arithmetic assignment operators
+        let mut vec2_add_assign = v1;
+        vec2_add_assign += v2; // $ MISSING: method=Vec2::add_assign
+
+        let mut vec2_sub_assign = v1;
+        vec2_sub_assign -= v2; // $ MISSING: method=Vec2::sub_assign
+
+        let mut vec2_mul_assign = v1;
+        vec2_mul_assign *= v2; // $ MISSING: method=Vec2::mul_assign
+
+        let mut vec2_div_assign = v1;
+        vec2_div_assign /= v2; // $ MISSING: method=Vec2::div_assign
+
+        let mut vec2_rem_assign = v1;
+        vec2_rem_assign %= v2; // $ MISSING: method=Vec2::rem_assign
+
+        // Bitwise operators
+        let vec2_bitand = v1 & v2; // $ MISSING: type=vec2_bitand:Vec2 method=Vec2::bitand
+        let vec2_bitor = v1 | v2; // $ MISSING: type=vec2_bitor:Vec2 method=Vec2::bitor
+        let vec2_bitxor = v1 ^ v2; // $ MISSING: type=vec2_bitxor:Vec2 method=Vec2::bitxor
+        let vec2_shl = v1 << 1u32; // $ MISSING: type=vec2_shl:Vec2 method=Vec2::shl
+        let vec2_shr = v1 >> 1u32; // $ MISSING: type=vec2_shr:Vec2 method=Vec2::shr
+
+        // Bitwise assignment operators
+        let mut vec2_bitand_assign = v1;
+        vec2_bitand_assign &= v2; // $ MISSING: method=Vec2::bitand_assign
+
+        let mut vec2_bitor_assign = v1;
+        vec2_bitor_assign |= v2; // $ MISSING: method=Vec2::bitor_assign
+
+        let mut vec2_bitxor_assign = v1;
+        vec2_bitxor_assign ^= v2; // $ MISSING: method=Vec2::bitxor_assign
+
+        let mut vec2_shl_assign = v1;
+        vec2_shl_assign <<= 1u32; // $ MISSING: method=Vec2::shl_assign
+
+        let mut vec2_shr_assign = v1;
+        vec2_shr_assign >>= 1u32; // $ MISSING: method=Vec2::shr_assign
+
+        // Prefix operators
+        let vec2_neg = -v1; // $ MISSING: type=vec2_neg:Vec2 method=Vec2::neg
+        let vec2_not = !v1; // $ MISSING: type=vec2_not:Vec2 method=Vec2::not
     }
 }
 

--- a/rust/ql/test/library-tests/type-inference/type-inference.expected
+++ b/rust/ql/test/library-tests/type-inference/type-inference.expected
@@ -837,6 +837,7 @@ inferType
 | main.rs:772:9:778:9 | { ... } |  | main.rs:767:20:767:22 | Tr2 |
 | main.rs:773:13:777:13 | if ... {...} else {...} |  | main.rs:767:20:767:22 | Tr2 |
 | main.rs:773:16:773:16 | 3 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:773:16:773:20 | ... > ... |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
 | main.rs:773:20:773:20 | 2 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
 | main.rs:773:22:775:13 | { ... } |  | main.rs:767:20:767:22 | Tr2 |
 | main.rs:774:17:774:20 | self |  | main.rs:767:5:779:5 | Self [trait MyTrait2] |
@@ -848,6 +849,7 @@ inferType
 | main.rs:786:9:792:9 | { ... } |  | main.rs:781:20:781:22 | Tr3 |
 | main.rs:787:13:791:13 | if ... {...} else {...} |  | main.rs:781:20:781:22 | Tr3 |
 | main.rs:787:16:787:16 | 3 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:787:16:787:20 | ... > ... |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
 | main.rs:787:20:787:20 | 2 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
 | main.rs:787:22:789:13 | { ... } |  | main.rs:781:20:781:22 | Tr3 |
 | main.rs:788:17:788:20 | self |  | main.rs:781:5:793:5 | Self [trait MyTrait3] |
@@ -1191,6 +1193,7 @@ inferType
 | main.rs:1030:23:1034:9 | if ... {...} else {...} |  | main.rs:969:5:973:5 | MyOption |
 | main.rs:1030:23:1034:9 | if ... {...} else {...} | T | main.rs:1004:5:1005:13 | S |
 | main.rs:1030:26:1030:26 | 3 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1030:26:1030:30 | ... > ... |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
 | main.rs:1030:30:1030:30 | 2 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
 | main.rs:1030:32:1032:9 | { ... } |  | main.rs:969:5:973:5 | MyOption |
 | main.rs:1030:32:1032:9 | { ... } | T | main.rs:1004:5:1005:13 | S |
@@ -1209,6 +1212,7 @@ inferType
 | main.rs:1038:26:1041:9 | match ... { ... } |  | main.rs:969:5:973:5 | MyOption |
 | main.rs:1038:26:1041:9 | match ... { ... } | T | main.rs:1004:5:1005:13 | S |
 | main.rs:1038:32:1038:32 | 3 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1038:32:1038:36 | ... > ... |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
 | main.rs:1038:36:1038:36 | 2 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
 | main.rs:1039:13:1039:16 | true |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
 | main.rs:1039:21:1039:38 | ...::MyNone(...) |  | main.rs:969:5:973:5 | MyOption |
@@ -1225,6 +1229,7 @@ inferType
 | main.rs:1045:25:1050:9 | loop { ... } |  | main.rs:969:5:973:5 | MyOption |
 | main.rs:1045:25:1050:9 | loop { ... } | T | main.rs:1004:5:1005:13 | S |
 | main.rs:1046:16:1046:16 | 3 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1046:16:1046:20 | ... > ... |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
 | main.rs:1046:20:1046:20 | 2 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
 | main.rs:1047:23:1047:40 | ...::MyNone(...) |  | main.rs:969:5:973:5 | MyOption |
 | main.rs:1047:23:1047:40 | ...::MyNone(...) | T | main.rs:1004:5:1005:13 | S |
@@ -1578,7 +1583,9 @@ inferType
 | main.rs:1246:22:1246:22 | 1 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
 | main.rs:1247:13:1247:13 | y |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
 | main.rs:1247:17:1247:17 | 2 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1248:13:1248:13 | z |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
 | main.rs:1248:17:1248:17 | x |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1248:17:1248:21 | ... + ... |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
 | main.rs:1248:21:1248:21 | y |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
 | main.rs:1249:13:1249:13 | z |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
 | main.rs:1249:17:1249:17 | x |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
@@ -1602,8 +1609,11 @@ inferType
 | main.rs:1262:17:1262:29 | ... \|\| ... |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
 | main.rs:1262:25:1262:29 | false |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
 | main.rs:1264:13:1264:17 | mut a |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1265:13:1265:16 | cond |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
 | main.rs:1265:20:1265:21 | 34 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1265:20:1265:27 | ... == ... |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
 | main.rs:1265:26:1265:27 | 33 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1266:12:1266:15 | cond |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
 | main.rs:1267:17:1267:17 | z |  | file://:0:0:0:0 | () |
 | main.rs:1267:21:1267:27 | (...) |  | file://:0:0:0:0 | () |
 | main.rs:1267:22:1267:22 | a |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
@@ -1959,18 +1969,23 @@ inferType
 | main.rs:1489:31:1489:35 | other | &T | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1489:75:1491:9 | { ... } |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/option.rs:565:1:581:1 | Option |
 | main.rs:1489:75:1491:9 | { ... } | T | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/cmp.rs:367:1:397:1 | Ordering |
+| main.rs:1490:13:1490:29 | (...) |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
 | main.rs:1490:13:1490:63 | ... .partial_cmp(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/option.rs:565:1:581:1 | Option |
 | main.rs:1490:13:1490:63 | ... .partial_cmp(...) | T | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/cmp.rs:367:1:397:1 | Ordering |
 | main.rs:1490:14:1490:17 | self |  | file://:0:0:0:0 | & |
 | main.rs:1490:14:1490:17 | self | &T | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1490:14:1490:19 | self.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1490:14:1490:28 | ... + ... |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
 | main.rs:1490:23:1490:26 | self |  | file://:0:0:0:0 | & |
 | main.rs:1490:23:1490:26 | self | &T | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1490:23:1490:28 | self.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
 | main.rs:1490:43:1490:62 | &... |  | file://:0:0:0:0 | & |
+| main.rs:1490:43:1490:62 | &... | &T | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1490:44:1490:62 | (...) |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
 | main.rs:1490:45:1490:49 | other |  | file://:0:0:0:0 | & |
 | main.rs:1490:45:1490:49 | other | &T | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1490:45:1490:51 | other.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1490:45:1490:61 | ... + ... |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
 | main.rs:1490:55:1490:59 | other |  | file://:0:0:0:0 | & |
 | main.rs:1490:55:1490:59 | other | &T | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1490:55:1490:61 | other.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
@@ -2054,27 +2069,55 @@ inferType
 | main.rs:1506:44:1506:48 | other |  | file://:0:0:0:0 | & |
 | main.rs:1506:44:1506:48 | other | &T | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1506:44:1506:50 | other.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1513:13:1513:18 | i64_eq |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1513:22:1513:35 | (...) |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
 | main.rs:1513:23:1513:26 | 1i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1513:23:1513:34 | ... == ... |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
 | main.rs:1513:31:1513:34 | 2i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1514:13:1514:18 | i64_ne |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1514:22:1514:35 | (...) |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
 | main.rs:1514:23:1514:26 | 3i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1514:23:1514:34 | ... != ... |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
 | main.rs:1514:31:1514:34 | 4i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1515:13:1515:18 | i64_lt |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1515:22:1515:34 | (...) |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
 | main.rs:1515:23:1515:26 | 5i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1515:23:1515:33 | ... < ... |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
 | main.rs:1515:30:1515:33 | 6i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1516:13:1516:18 | i64_le |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1516:22:1516:35 | (...) |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
 | main.rs:1516:23:1516:26 | 7i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1516:23:1516:34 | ... <= ... |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
 | main.rs:1516:31:1516:34 | 8i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1517:13:1517:18 | i64_gt |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1517:22:1517:35 | (...) |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
 | main.rs:1517:23:1517:26 | 9i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1517:23:1517:34 | ... > ... |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
 | main.rs:1517:30:1517:34 | 10i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1518:13:1518:18 | i64_ge |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1518:22:1518:37 | (...) |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
 | main.rs:1518:23:1518:27 | 11i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1518:23:1518:36 | ... >= ... |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
 | main.rs:1518:32:1518:36 | 12i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1521:13:1521:19 | i64_add |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
 | main.rs:1521:23:1521:27 | 13i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1521:23:1521:35 | ... + ... |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
 | main.rs:1521:31:1521:35 | 14i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1522:13:1522:19 | i64_sub |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
 | main.rs:1522:23:1522:27 | 15i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1522:23:1522:35 | ... - ... |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
 | main.rs:1522:31:1522:35 | 16i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1523:13:1523:19 | i64_mul |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
 | main.rs:1523:23:1523:27 | 17i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1523:23:1523:35 | ... * ... |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
 | main.rs:1523:31:1523:35 | 18i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1524:13:1524:19 | i64_div |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
 | main.rs:1524:23:1524:27 | 19i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1524:23:1524:35 | ... / ... |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
 | main.rs:1524:31:1524:35 | 20i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1525:13:1525:19 | i64_rem |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
 | main.rs:1525:23:1525:27 | 21i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1525:23:1525:35 | ... % ... |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
 | main.rs:1525:31:1525:35 | 22i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
 | main.rs:1528:13:1528:30 | mut i64_add_assign |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
 | main.rs:1528:34:1528:38 | 23i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
@@ -2101,15 +2144,25 @@ inferType
 | main.rs:1541:9:1541:22 | i64_rem_assign |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
 | main.rs:1541:9:1541:31 | ... %= ... |  | file://:0:0:0:0 | () |
 | main.rs:1541:27:1541:31 | 32i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1544:13:1544:22 | i64_bitand |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
 | main.rs:1544:26:1544:30 | 33i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1544:26:1544:38 | ... & ... |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
 | main.rs:1544:34:1544:38 | 34i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1545:13:1545:21 | i64_bitor |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
 | main.rs:1545:25:1545:29 | 35i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1545:25:1545:37 | ... \| ... |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
 | main.rs:1545:33:1545:37 | 36i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1546:13:1546:22 | i64_bitxor |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
 | main.rs:1546:26:1546:30 | 37i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1546:26:1546:38 | ... ^ ... |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
 | main.rs:1546:34:1546:38 | 38i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1547:13:1547:19 | i64_shl |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
 | main.rs:1547:23:1547:27 | 39i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1547:23:1547:36 | ... << ... |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
 | main.rs:1547:32:1547:36 | 40i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1548:13:1548:19 | i64_shr |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
 | main.rs:1548:23:1548:27 | 41i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1548:23:1548:36 | ... >> ... |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
 | main.rs:1548:32:1548:36 | 42i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
 | main.rs:1551:13:1551:33 | mut i64_bitand_assign |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
 | main.rs:1551:37:1551:41 | 43i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
@@ -2136,7 +2189,11 @@ inferType
 | main.rs:1564:9:1564:22 | i64_shr_assign |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
 | main.rs:1564:9:1564:32 | ... >>= ... |  | file://:0:0:0:0 | () |
 | main.rs:1564:28:1564:32 | 52i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1566:13:1566:19 | i64_neg |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1566:23:1566:28 | - ... |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
 | main.rs:1566:24:1566:28 | 53i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1567:13:1567:19 | i64_not |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1567:23:1567:28 | ! ... |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
 | main.rs:1567:24:1567:28 | 54i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
 | main.rs:1570:13:1570:14 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1570:18:1570:36 | Vec2 {...} |  | main.rs:1278:5:1283:5 | Vec2 |
@@ -2144,84 +2201,164 @@ inferType
 | main.rs:1570:28:1570:28 | 1 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
 | main.rs:1570:34:1570:34 | 2 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
 | main.rs:1570:34:1570:34 | 2 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1571:13:1571:14 | v2 |  | file://:0:0:0:0 | & |
 | main.rs:1571:13:1571:14 | v2 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1571:13:1571:14 | v2 | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1571:18:1571:36 | Vec2 {...} |  | file://:0:0:0:0 | & |
 | main.rs:1571:18:1571:36 | Vec2 {...} |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1571:18:1571:36 | Vec2 {...} | &T | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1571:28:1571:28 | 3 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
 | main.rs:1571:28:1571:28 | 3 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
 | main.rs:1571:34:1571:34 | 4 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
 | main.rs:1571:34:1571:34 | 4 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1574:13:1574:19 | vec2_eq |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
 | main.rs:1574:23:1574:24 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1574:23:1574:30 | ... == ... |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1574:29:1574:30 | v2 |  | file://:0:0:0:0 | & |
 | main.rs:1574:29:1574:30 | v2 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1574:29:1574:30 | v2 | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1575:13:1575:19 | vec2_ne |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
 | main.rs:1575:23:1575:24 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1575:23:1575:30 | ... != ... |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1575:29:1575:30 | v2 |  | file://:0:0:0:0 | & |
 | main.rs:1575:29:1575:30 | v2 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1575:29:1575:30 | v2 | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1576:13:1576:19 | vec2_lt |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
 | main.rs:1576:23:1576:24 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1576:23:1576:29 | ... < ... |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1576:28:1576:29 | v2 |  | file://:0:0:0:0 | & |
 | main.rs:1576:28:1576:29 | v2 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1576:28:1576:29 | v2 | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1577:13:1577:19 | vec2_le |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
 | main.rs:1577:23:1577:24 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1577:23:1577:30 | ... <= ... |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1577:29:1577:30 | v2 |  | file://:0:0:0:0 | & |
 | main.rs:1577:29:1577:30 | v2 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1577:29:1577:30 | v2 | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1578:13:1578:19 | vec2_gt |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
 | main.rs:1578:23:1578:24 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1578:23:1578:29 | ... > ... |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1578:28:1578:29 | v2 |  | file://:0:0:0:0 | & |
 | main.rs:1578:28:1578:29 | v2 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1578:28:1578:29 | v2 | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1579:13:1579:19 | vec2_ge |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
 | main.rs:1579:23:1579:24 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1579:23:1579:30 | ... >= ... |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1579:29:1579:30 | v2 |  | file://:0:0:0:0 | & |
 | main.rs:1579:29:1579:30 | v2 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1579:29:1579:30 | v2 | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1582:13:1582:20 | vec2_add |  | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1582:24:1582:25 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1582:24:1582:30 | ... + ... |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1582:29:1582:30 | v2 |  | file://:0:0:0:0 | & |
 | main.rs:1582:29:1582:30 | v2 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1582:29:1582:30 | v2 | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1583:13:1583:20 | vec2_sub |  | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1583:24:1583:25 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1583:24:1583:30 | ... - ... |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1583:29:1583:30 | v2 |  | file://:0:0:0:0 | & |
 | main.rs:1583:29:1583:30 | v2 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1583:29:1583:30 | v2 | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1584:13:1584:20 | vec2_mul |  | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1584:24:1584:25 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1584:24:1584:30 | ... * ... |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1584:29:1584:30 | v2 |  | file://:0:0:0:0 | & |
 | main.rs:1584:29:1584:30 | v2 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1584:29:1584:30 | v2 | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1585:13:1585:20 | vec2_div |  | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1585:24:1585:25 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1585:24:1585:30 | ... / ... |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1585:29:1585:30 | v2 |  | file://:0:0:0:0 | & |
 | main.rs:1585:29:1585:30 | v2 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1585:29:1585:30 | v2 | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1586:13:1586:20 | vec2_rem |  | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1586:24:1586:25 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1586:24:1586:30 | ... % ... |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1586:29:1586:30 | v2 |  | file://:0:0:0:0 | & |
 | main.rs:1586:29:1586:30 | v2 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1586:29:1586:30 | v2 | &T | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1589:13:1589:31 | mut vec2_add_assign |  | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1589:35:1589:36 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1590:9:1590:23 | vec2_add_assign |  | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1590:9:1590:29 | ... += ... |  | file://:0:0:0:0 | () |
+| main.rs:1590:28:1590:29 | v2 |  | file://:0:0:0:0 | & |
 | main.rs:1590:28:1590:29 | v2 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1590:28:1590:29 | v2 | &T | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1592:13:1592:31 | mut vec2_sub_assign |  | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1592:35:1592:36 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1593:9:1593:23 | vec2_sub_assign |  | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1593:9:1593:29 | ... -= ... |  | file://:0:0:0:0 | () |
+| main.rs:1593:28:1593:29 | v2 |  | file://:0:0:0:0 | & |
 | main.rs:1593:28:1593:29 | v2 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1593:28:1593:29 | v2 | &T | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1595:13:1595:31 | mut vec2_mul_assign |  | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1595:35:1595:36 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1596:9:1596:23 | vec2_mul_assign |  | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1596:9:1596:29 | ... *= ... |  | file://:0:0:0:0 | () |
+| main.rs:1596:28:1596:29 | v2 |  | file://:0:0:0:0 | & |
 | main.rs:1596:28:1596:29 | v2 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1596:28:1596:29 | v2 | &T | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1598:13:1598:31 | mut vec2_div_assign |  | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1598:35:1598:36 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1599:9:1599:23 | vec2_div_assign |  | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1599:9:1599:29 | ... /= ... |  | file://:0:0:0:0 | () |
+| main.rs:1599:28:1599:29 | v2 |  | file://:0:0:0:0 | & |
 | main.rs:1599:28:1599:29 | v2 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1599:28:1599:29 | v2 | &T | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1601:13:1601:31 | mut vec2_rem_assign |  | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1601:35:1601:36 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1602:9:1602:23 | vec2_rem_assign |  | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1602:9:1602:29 | ... %= ... |  | file://:0:0:0:0 | () |
+| main.rs:1602:28:1602:29 | v2 |  | file://:0:0:0:0 | & |
 | main.rs:1602:28:1602:29 | v2 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1602:28:1602:29 | v2 | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1605:13:1605:23 | vec2_bitand |  | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1605:27:1605:28 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1605:27:1605:33 | ... & ... |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1605:32:1605:33 | v2 |  | file://:0:0:0:0 | & |
 | main.rs:1605:32:1605:33 | v2 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1605:32:1605:33 | v2 | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1606:13:1606:22 | vec2_bitor |  | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1606:26:1606:27 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1606:26:1606:32 | ... \| ... |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1606:31:1606:32 | v2 |  | file://:0:0:0:0 | & |
 | main.rs:1606:31:1606:32 | v2 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1606:31:1606:32 | v2 | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1607:13:1607:23 | vec2_bitxor |  | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1607:27:1607:28 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1607:27:1607:33 | ... ^ ... |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1607:32:1607:33 | v2 |  | file://:0:0:0:0 | & |
 | main.rs:1607:32:1607:33 | v2 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1607:32:1607:33 | v2 | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1608:13:1608:20 | vec2_shl |  | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1608:24:1608:25 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1608:24:1608:33 | ... << ... |  | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1608:30:1608:33 | 1u32 |  | file:///BUILTINS/types.rs:17:1:17:15 | u32 |
+| main.rs:1609:13:1609:20 | vec2_shr |  | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1609:24:1609:25 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1609:24:1609:33 | ... >> ... |  | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1609:30:1609:33 | 1u32 |  | file:///BUILTINS/types.rs:17:1:17:15 | u32 |
 | main.rs:1612:13:1612:34 | mut vec2_bitand_assign |  | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1612:38:1612:39 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1613:9:1613:26 | vec2_bitand_assign |  | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1613:9:1613:32 | ... &= ... |  | file://:0:0:0:0 | () |
+| main.rs:1613:31:1613:32 | v2 |  | file://:0:0:0:0 | & |
 | main.rs:1613:31:1613:32 | v2 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1613:31:1613:32 | v2 | &T | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1615:13:1615:33 | mut vec2_bitor_assign |  | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1615:37:1615:38 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1616:9:1616:25 | vec2_bitor_assign |  | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1616:9:1616:31 | ... \|= ... |  | file://:0:0:0:0 | () |
+| main.rs:1616:30:1616:31 | v2 |  | file://:0:0:0:0 | & |
 | main.rs:1616:30:1616:31 | v2 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1616:30:1616:31 | v2 | &T | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1618:13:1618:34 | mut vec2_bitxor_assign |  | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1618:38:1618:39 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1619:9:1619:26 | vec2_bitxor_assign |  | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1619:9:1619:32 | ... ^= ... |  | file://:0:0:0:0 | () |
+| main.rs:1619:31:1619:32 | v2 |  | file://:0:0:0:0 | & |
 | main.rs:1619:31:1619:32 | v2 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1619:31:1619:32 | v2 | &T | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1621:13:1621:31 | mut vec2_shl_assign |  | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1621:35:1621:36 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1622:9:1622:23 | vec2_shl_assign |  | main.rs:1278:5:1283:5 | Vec2 |
@@ -2232,7 +2369,11 @@ inferType
 | main.rs:1625:9:1625:23 | vec2_shr_assign |  | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1625:9:1625:32 | ... >>= ... |  | file://:0:0:0:0 | () |
 | main.rs:1625:29:1625:32 | 1u32 |  | file:///BUILTINS/types.rs:17:1:17:15 | u32 |
+| main.rs:1628:13:1628:20 | vec2_neg |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1628:24:1628:26 | - ... |  | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1628:25:1628:26 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1629:13:1629:20 | vec2_not |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1629:24:1629:26 | ! ... |  | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1629:25:1629:26 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
 | main.rs:1635:5:1635:20 | ...::f(...) |  | main.rs:67:5:67:21 | Foo |
 | main.rs:1636:5:1636:60 | ...::g(...) |  | main.rs:67:5:67:21 | Foo |

--- a/rust/ql/test/library-tests/type-inference/type-inference.expected
+++ b/rust/ql/test/library-tests/type-inference/type-inference.expected
@@ -833,792 +833,1408 @@ inferType
 | main.rs:742:26:742:26 | y | A | main.rs:725:5:726:14 | S2 |
 | main.rs:742:26:742:31 | y.m1() |  | main.rs:725:5:726:14 | S2 |
 | main.rs:764:15:764:18 | SelfParam |  | main.rs:762:5:765:5 | Self [trait MyTrait1] |
-| main.rs:768:15:768:18 | SelfParam |  | main.rs:767:5:778:5 | Self [trait MyTrait2] |
-| main.rs:771:9:777:9 | { ... } |  | main.rs:767:20:767:22 | Tr2 |
-| main.rs:772:13:776:13 | if ... {...} else {...} |  | main.rs:767:20:767:22 | Tr2 |
-| main.rs:772:16:772:16 | 1 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:772:20:772:20 | 1 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:772:24:772:24 | 2 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:772:26:774:13 | { ... } |  | main.rs:767:20:767:22 | Tr2 |
-| main.rs:773:17:773:20 | self |  | main.rs:767:5:778:5 | Self [trait MyTrait2] |
-| main.rs:773:17:773:25 | self.m1() |  | main.rs:767:20:767:22 | Tr2 |
-| main.rs:774:20:776:13 | { ... } |  | main.rs:767:20:767:22 | Tr2 |
-| main.rs:775:17:775:30 | ...::m1(...) |  | main.rs:767:20:767:22 | Tr2 |
-| main.rs:775:26:775:29 | self |  | main.rs:767:5:778:5 | Self [trait MyTrait2] |
-| main.rs:781:15:781:18 | SelfParam |  | main.rs:780:5:791:5 | Self [trait MyTrait3] |
-| main.rs:784:9:790:9 | { ... } |  | main.rs:780:20:780:22 | Tr3 |
-| main.rs:785:13:789:13 | if ... {...} else {...} |  | main.rs:780:20:780:22 | Tr3 |
-| main.rs:785:16:785:16 | 1 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:785:20:785:20 | 1 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:785:24:785:24 | 2 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:785:26:787:13 | { ... } |  | main.rs:780:20:780:22 | Tr3 |
-| main.rs:786:17:786:20 | self |  | main.rs:780:5:791:5 | Self [trait MyTrait3] |
-| main.rs:786:17:786:25 | self.m2() |  | main.rs:747:5:750:5 | MyThing |
-| main.rs:786:17:786:25 | self.m2() | A | main.rs:780:20:780:22 | Tr3 |
-| main.rs:786:17:786:27 | ... .a |  | main.rs:780:20:780:22 | Tr3 |
-| main.rs:787:20:789:13 | { ... } |  | main.rs:780:20:780:22 | Tr3 |
-| main.rs:788:17:788:30 | ...::m2(...) |  | main.rs:747:5:750:5 | MyThing |
-| main.rs:788:17:788:30 | ...::m2(...) | A | main.rs:780:20:780:22 | Tr3 |
-| main.rs:788:17:788:32 | ... .a |  | main.rs:780:20:780:22 | Tr3 |
-| main.rs:788:26:788:29 | self |  | main.rs:780:5:791:5 | Self [trait MyTrait3] |
-| main.rs:795:15:795:18 | SelfParam |  | main.rs:747:5:750:5 | MyThing |
-| main.rs:795:15:795:18 | SelfParam | A | main.rs:793:10:793:10 | T |
-| main.rs:795:26:797:9 | { ... } |  | main.rs:793:10:793:10 | T |
-| main.rs:796:13:796:16 | self |  | main.rs:747:5:750:5 | MyThing |
-| main.rs:796:13:796:16 | self | A | main.rs:793:10:793:10 | T |
-| main.rs:796:13:796:18 | self.a |  | main.rs:793:10:793:10 | T |
-| main.rs:804:15:804:18 | SelfParam |  | main.rs:752:5:755:5 | MyThing2 |
-| main.rs:804:15:804:18 | SelfParam | A | main.rs:802:10:802:10 | T |
-| main.rs:804:35:806:9 | { ... } |  | main.rs:747:5:750:5 | MyThing |
-| main.rs:804:35:806:9 | { ... } | A | main.rs:802:10:802:10 | T |
-| main.rs:805:13:805:33 | MyThing {...} |  | main.rs:747:5:750:5 | MyThing |
-| main.rs:805:13:805:33 | MyThing {...} | A | main.rs:802:10:802:10 | T |
-| main.rs:805:26:805:29 | self |  | main.rs:752:5:755:5 | MyThing2 |
-| main.rs:805:26:805:29 | self | A | main.rs:802:10:802:10 | T |
-| main.rs:805:26:805:31 | self.a |  | main.rs:802:10:802:10 | T |
-| main.rs:813:44:813:44 | x |  | main.rs:813:26:813:41 | T2 |
-| main.rs:813:57:815:5 | { ... } |  | main.rs:813:22:813:23 | T1 |
-| main.rs:814:9:814:9 | x |  | main.rs:813:26:813:41 | T2 |
-| main.rs:814:9:814:14 | x.m1() |  | main.rs:813:22:813:23 | T1 |
-| main.rs:817:56:817:56 | x |  | main.rs:817:39:817:53 | T |
-| main.rs:819:13:819:13 | a |  | main.rs:747:5:750:5 | MyThing |
-| main.rs:819:13:819:13 | a | A | main.rs:757:5:758:14 | S1 |
-| main.rs:819:17:819:17 | x |  | main.rs:817:39:817:53 | T |
-| main.rs:819:17:819:22 | x.m1() |  | main.rs:747:5:750:5 | MyThing |
-| main.rs:819:17:819:22 | x.m1() | A | main.rs:757:5:758:14 | S1 |
-| main.rs:820:18:820:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:820:26:820:26 | a |  | main.rs:747:5:750:5 | MyThing |
-| main.rs:820:26:820:26 | a | A | main.rs:757:5:758:14 | S1 |
-| main.rs:824:13:824:13 | x |  | main.rs:747:5:750:5 | MyThing |
-| main.rs:824:13:824:13 | x | A | main.rs:757:5:758:14 | S1 |
-| main.rs:824:17:824:33 | MyThing {...} |  | main.rs:747:5:750:5 | MyThing |
-| main.rs:824:17:824:33 | MyThing {...} | A | main.rs:757:5:758:14 | S1 |
-| main.rs:824:30:824:31 | S1 |  | main.rs:757:5:758:14 | S1 |
-| main.rs:825:13:825:13 | y |  | main.rs:747:5:750:5 | MyThing |
-| main.rs:825:13:825:13 | y | A | main.rs:759:5:760:14 | S2 |
-| main.rs:825:17:825:33 | MyThing {...} |  | main.rs:747:5:750:5 | MyThing |
-| main.rs:825:17:825:33 | MyThing {...} | A | main.rs:759:5:760:14 | S2 |
-| main.rs:825:30:825:31 | S2 |  | main.rs:759:5:760:14 | S2 |
-| main.rs:827:18:827:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:827:26:827:26 | x |  | main.rs:747:5:750:5 | MyThing |
-| main.rs:827:26:827:26 | x | A | main.rs:757:5:758:14 | S1 |
-| main.rs:827:26:827:31 | x.m1() |  | main.rs:757:5:758:14 | S1 |
-| main.rs:828:18:828:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:828:26:828:26 | y |  | main.rs:747:5:750:5 | MyThing |
-| main.rs:828:26:828:26 | y | A | main.rs:759:5:760:14 | S2 |
-| main.rs:828:26:828:31 | y.m1() |  | main.rs:759:5:760:14 | S2 |
-| main.rs:830:13:830:13 | x |  | main.rs:747:5:750:5 | MyThing |
-| main.rs:830:13:830:13 | x | A | main.rs:757:5:758:14 | S1 |
-| main.rs:830:17:830:33 | MyThing {...} |  | main.rs:747:5:750:5 | MyThing |
-| main.rs:830:17:830:33 | MyThing {...} | A | main.rs:757:5:758:14 | S1 |
-| main.rs:830:30:830:31 | S1 |  | main.rs:757:5:758:14 | S1 |
-| main.rs:831:13:831:13 | y |  | main.rs:747:5:750:5 | MyThing |
-| main.rs:831:13:831:13 | y | A | main.rs:759:5:760:14 | S2 |
-| main.rs:831:17:831:33 | MyThing {...} |  | main.rs:747:5:750:5 | MyThing |
-| main.rs:831:17:831:33 | MyThing {...} | A | main.rs:759:5:760:14 | S2 |
-| main.rs:831:30:831:31 | S2 |  | main.rs:759:5:760:14 | S2 |
-| main.rs:833:18:833:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:833:26:833:26 | x |  | main.rs:747:5:750:5 | MyThing |
-| main.rs:833:26:833:26 | x | A | main.rs:757:5:758:14 | S1 |
-| main.rs:833:26:833:31 | x.m2() |  | main.rs:757:5:758:14 | S1 |
-| main.rs:834:18:834:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:834:26:834:26 | y |  | main.rs:747:5:750:5 | MyThing |
-| main.rs:834:26:834:26 | y | A | main.rs:759:5:760:14 | S2 |
-| main.rs:834:26:834:31 | y.m2() |  | main.rs:759:5:760:14 | S2 |
-| main.rs:836:13:836:13 | x |  | main.rs:752:5:755:5 | MyThing2 |
-| main.rs:836:13:836:13 | x | A | main.rs:757:5:758:14 | S1 |
-| main.rs:836:17:836:34 | MyThing2 {...} |  | main.rs:752:5:755:5 | MyThing2 |
-| main.rs:836:17:836:34 | MyThing2 {...} | A | main.rs:757:5:758:14 | S1 |
-| main.rs:836:31:836:32 | S1 |  | main.rs:757:5:758:14 | S1 |
-| main.rs:837:13:837:13 | y |  | main.rs:752:5:755:5 | MyThing2 |
-| main.rs:837:13:837:13 | y | A | main.rs:759:5:760:14 | S2 |
-| main.rs:837:17:837:34 | MyThing2 {...} |  | main.rs:752:5:755:5 | MyThing2 |
-| main.rs:837:17:837:34 | MyThing2 {...} | A | main.rs:759:5:760:14 | S2 |
-| main.rs:837:31:837:32 | S2 |  | main.rs:759:5:760:14 | S2 |
-| main.rs:839:18:839:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:839:26:839:26 | x |  | main.rs:752:5:755:5 | MyThing2 |
-| main.rs:839:26:839:26 | x | A | main.rs:757:5:758:14 | S1 |
-| main.rs:839:26:839:31 | x.m3() |  | main.rs:757:5:758:14 | S1 |
-| main.rs:840:18:840:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:840:26:840:26 | y |  | main.rs:752:5:755:5 | MyThing2 |
-| main.rs:840:26:840:26 | y | A | main.rs:759:5:760:14 | S2 |
-| main.rs:840:26:840:31 | y.m3() |  | main.rs:759:5:760:14 | S2 |
-| main.rs:842:13:842:13 | x |  | main.rs:747:5:750:5 | MyThing |
-| main.rs:842:13:842:13 | x | A | main.rs:757:5:758:14 | S1 |
-| main.rs:842:17:842:33 | MyThing {...} |  | main.rs:747:5:750:5 | MyThing |
-| main.rs:842:17:842:33 | MyThing {...} | A | main.rs:757:5:758:14 | S1 |
-| main.rs:842:30:842:31 | S1 |  | main.rs:757:5:758:14 | S1 |
-| main.rs:843:13:843:13 | s |  | main.rs:757:5:758:14 | S1 |
-| main.rs:843:17:843:32 | call_trait_m1(...) |  | main.rs:757:5:758:14 | S1 |
-| main.rs:843:31:843:31 | x |  | main.rs:747:5:750:5 | MyThing |
-| main.rs:843:31:843:31 | x | A | main.rs:757:5:758:14 | S1 |
-| main.rs:845:13:845:13 | x |  | main.rs:752:5:755:5 | MyThing2 |
-| main.rs:845:13:845:13 | x | A | main.rs:759:5:760:14 | S2 |
-| main.rs:845:17:845:34 | MyThing2 {...} |  | main.rs:752:5:755:5 | MyThing2 |
-| main.rs:845:17:845:34 | MyThing2 {...} | A | main.rs:759:5:760:14 | S2 |
-| main.rs:845:31:845:32 | S2 |  | main.rs:759:5:760:14 | S2 |
-| main.rs:846:13:846:13 | s |  | main.rs:747:5:750:5 | MyThing |
-| main.rs:846:13:846:13 | s | A | main.rs:759:5:760:14 | S2 |
-| main.rs:846:17:846:32 | call_trait_m1(...) |  | main.rs:747:5:750:5 | MyThing |
-| main.rs:846:17:846:32 | call_trait_m1(...) | A | main.rs:759:5:760:14 | S2 |
-| main.rs:846:31:846:31 | x |  | main.rs:752:5:755:5 | MyThing2 |
-| main.rs:846:31:846:31 | x | A | main.rs:759:5:760:14 | S2 |
-| main.rs:864:22:864:22 | x |  | file://:0:0:0:0 | & |
-| main.rs:864:22:864:22 | x | &T | main.rs:864:11:864:19 | T |
-| main.rs:864:35:866:5 | { ... } |  | file://:0:0:0:0 | & |
-| main.rs:864:35:866:5 | { ... } | &T | main.rs:864:11:864:19 | T |
-| main.rs:865:9:865:9 | x |  | file://:0:0:0:0 | & |
-| main.rs:865:9:865:9 | x | &T | main.rs:864:11:864:19 | T |
-| main.rs:869:17:869:20 | SelfParam |  | main.rs:854:5:855:14 | S1 |
-| main.rs:869:29:871:9 | { ... } |  | main.rs:857:5:858:14 | S2 |
-| main.rs:870:13:870:14 | S2 |  | main.rs:857:5:858:14 | S2 |
-| main.rs:874:21:874:21 | x |  | main.rs:874:13:874:14 | T1 |
-| main.rs:877:5:879:5 | { ... } |  | main.rs:874:17:874:18 | T2 |
-| main.rs:878:9:878:9 | x |  | main.rs:874:13:874:14 | T1 |
-| main.rs:878:9:878:16 | x.into() |  | main.rs:874:17:874:18 | T2 |
-| main.rs:882:13:882:13 | x |  | main.rs:854:5:855:14 | S1 |
-| main.rs:882:17:882:18 | S1 |  | main.rs:854:5:855:14 | S1 |
-| main.rs:883:18:883:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:883:26:883:31 | id(...) |  | file://:0:0:0:0 | & |
-| main.rs:883:26:883:31 | id(...) | &T | main.rs:854:5:855:14 | S1 |
-| main.rs:883:29:883:30 | &x |  | file://:0:0:0:0 | & |
-| main.rs:883:29:883:30 | &x | &T | main.rs:854:5:855:14 | S1 |
-| main.rs:883:30:883:30 | x |  | main.rs:854:5:855:14 | S1 |
-| main.rs:885:13:885:13 | x |  | main.rs:854:5:855:14 | S1 |
-| main.rs:885:17:885:18 | S1 |  | main.rs:854:5:855:14 | S1 |
-| main.rs:886:18:886:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:886:26:886:37 | id::<...>(...) |  | file://:0:0:0:0 | & |
-| main.rs:886:26:886:37 | id::<...>(...) | &T | main.rs:854:5:855:14 | S1 |
-| main.rs:886:35:886:36 | &x |  | file://:0:0:0:0 | & |
-| main.rs:886:35:886:36 | &x | &T | main.rs:854:5:855:14 | S1 |
-| main.rs:886:36:886:36 | x |  | main.rs:854:5:855:14 | S1 |
-| main.rs:888:13:888:13 | x |  | main.rs:854:5:855:14 | S1 |
-| main.rs:888:17:888:18 | S1 |  | main.rs:854:5:855:14 | S1 |
-| main.rs:889:18:889:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:889:26:889:44 | id::<...>(...) |  | file://:0:0:0:0 | & |
-| main.rs:889:26:889:44 | id::<...>(...) | &T | main.rs:854:5:855:14 | S1 |
-| main.rs:889:42:889:43 | &x |  | file://:0:0:0:0 | & |
-| main.rs:889:42:889:43 | &x | &T | main.rs:854:5:855:14 | S1 |
-| main.rs:889:43:889:43 | x |  | main.rs:854:5:855:14 | S1 |
-| main.rs:891:13:891:13 | x |  | main.rs:854:5:855:14 | S1 |
-| main.rs:891:17:891:18 | S1 |  | main.rs:854:5:855:14 | S1 |
-| main.rs:892:9:892:25 | into::<...>(...) |  | main.rs:857:5:858:14 | S2 |
-| main.rs:892:24:892:24 | x |  | main.rs:854:5:855:14 | S1 |
-| main.rs:894:13:894:13 | x |  | main.rs:854:5:855:14 | S1 |
-| main.rs:894:17:894:18 | S1 |  | main.rs:854:5:855:14 | S1 |
-| main.rs:895:13:895:13 | y |  | main.rs:857:5:858:14 | S2 |
-| main.rs:895:21:895:27 | into(...) |  | main.rs:857:5:858:14 | S2 |
-| main.rs:895:26:895:26 | x |  | main.rs:854:5:855:14 | S1 |
-| main.rs:909:22:909:25 | SelfParam |  | main.rs:900:5:906:5 | PairOption |
-| main.rs:909:22:909:25 | SelfParam | Fst | main.rs:908:10:908:12 | Fst |
-| main.rs:909:22:909:25 | SelfParam | Snd | main.rs:908:15:908:17 | Snd |
-| main.rs:909:35:916:9 | { ... } |  | main.rs:908:15:908:17 | Snd |
-| main.rs:910:13:915:13 | match self { ... } |  | main.rs:908:15:908:17 | Snd |
-| main.rs:910:19:910:22 | self |  | main.rs:900:5:906:5 | PairOption |
-| main.rs:910:19:910:22 | self | Fst | main.rs:908:10:908:12 | Fst |
-| main.rs:910:19:910:22 | self | Snd | main.rs:908:15:908:17 | Snd |
-| main.rs:911:43:911:82 | MacroExpr |  | main.rs:908:15:908:17 | Snd |
-| main.rs:911:50:911:81 | "PairNone has no second elemen... |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:912:43:912:81 | MacroExpr |  | main.rs:908:15:908:17 | Snd |
-| main.rs:912:50:912:80 | "PairFst has no second element... |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:913:37:913:39 | snd |  | main.rs:908:15:908:17 | Snd |
-| main.rs:913:45:913:47 | snd |  | main.rs:908:15:908:17 | Snd |
-| main.rs:914:41:914:43 | snd |  | main.rs:908:15:908:17 | Snd |
-| main.rs:914:49:914:51 | snd |  | main.rs:908:15:908:17 | Snd |
-| main.rs:940:10:940:10 | t |  | main.rs:900:5:906:5 | PairOption |
-| main.rs:940:10:940:10 | t | Fst | main.rs:922:5:923:14 | S2 |
-| main.rs:940:10:940:10 | t | Snd | main.rs:900:5:906:5 | PairOption |
-| main.rs:940:10:940:10 | t | Snd.Fst | main.rs:922:5:923:14 | S2 |
-| main.rs:940:10:940:10 | t | Snd.Snd | main.rs:925:5:926:14 | S3 |
-| main.rs:941:13:941:13 | x |  | main.rs:925:5:926:14 | S3 |
-| main.rs:941:17:941:17 | t |  | main.rs:900:5:906:5 | PairOption |
-| main.rs:941:17:941:17 | t | Fst | main.rs:922:5:923:14 | S2 |
-| main.rs:941:17:941:17 | t | Snd | main.rs:900:5:906:5 | PairOption |
-| main.rs:941:17:941:17 | t | Snd.Fst | main.rs:922:5:923:14 | S2 |
-| main.rs:941:17:941:17 | t | Snd.Snd | main.rs:925:5:926:14 | S3 |
-| main.rs:941:17:941:29 | t.unwrapSnd() |  | main.rs:900:5:906:5 | PairOption |
-| main.rs:941:17:941:29 | t.unwrapSnd() | Fst | main.rs:922:5:923:14 | S2 |
-| main.rs:941:17:941:29 | t.unwrapSnd() | Snd | main.rs:925:5:926:14 | S3 |
-| main.rs:941:17:941:41 | ... .unwrapSnd() |  | main.rs:925:5:926:14 | S3 |
-| main.rs:942:18:942:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:942:26:942:26 | x |  | main.rs:925:5:926:14 | S3 |
-| main.rs:947:13:947:14 | p1 |  | main.rs:900:5:906:5 | PairOption |
-| main.rs:947:13:947:14 | p1 | Fst | main.rs:919:5:920:14 | S1 |
-| main.rs:947:13:947:14 | p1 | Snd | main.rs:922:5:923:14 | S2 |
-| main.rs:947:26:947:53 | ...::PairBoth(...) |  | main.rs:900:5:906:5 | PairOption |
-| main.rs:947:26:947:53 | ...::PairBoth(...) | Fst | main.rs:919:5:920:14 | S1 |
-| main.rs:947:26:947:53 | ...::PairBoth(...) | Snd | main.rs:922:5:923:14 | S2 |
-| main.rs:947:47:947:48 | S1 |  | main.rs:919:5:920:14 | S1 |
-| main.rs:947:51:947:52 | S2 |  | main.rs:922:5:923:14 | S2 |
-| main.rs:948:18:948:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:948:26:948:27 | p1 |  | main.rs:900:5:906:5 | PairOption |
-| main.rs:948:26:948:27 | p1 | Fst | main.rs:919:5:920:14 | S1 |
-| main.rs:948:26:948:27 | p1 | Snd | main.rs:922:5:923:14 | S2 |
-| main.rs:951:13:951:14 | p2 |  | main.rs:900:5:906:5 | PairOption |
-| main.rs:951:13:951:14 | p2 | Fst | main.rs:919:5:920:14 | S1 |
-| main.rs:951:13:951:14 | p2 | Snd | main.rs:922:5:923:14 | S2 |
-| main.rs:951:26:951:47 | ...::PairNone(...) |  | main.rs:900:5:906:5 | PairOption |
-| main.rs:951:26:951:47 | ...::PairNone(...) | Fst | main.rs:919:5:920:14 | S1 |
-| main.rs:951:26:951:47 | ...::PairNone(...) | Snd | main.rs:922:5:923:14 | S2 |
-| main.rs:952:18:952:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:952:26:952:27 | p2 |  | main.rs:900:5:906:5 | PairOption |
-| main.rs:952:26:952:27 | p2 | Fst | main.rs:919:5:920:14 | S1 |
-| main.rs:952:26:952:27 | p2 | Snd | main.rs:922:5:923:14 | S2 |
-| main.rs:955:13:955:14 | p3 |  | main.rs:900:5:906:5 | PairOption |
-| main.rs:955:13:955:14 | p3 | Fst | main.rs:922:5:923:14 | S2 |
-| main.rs:955:13:955:14 | p3 | Snd | main.rs:925:5:926:14 | S3 |
-| main.rs:955:34:955:56 | ...::PairSnd(...) |  | main.rs:900:5:906:5 | PairOption |
-| main.rs:955:34:955:56 | ...::PairSnd(...) | Fst | main.rs:922:5:923:14 | S2 |
-| main.rs:955:34:955:56 | ...::PairSnd(...) | Snd | main.rs:925:5:926:14 | S3 |
-| main.rs:955:54:955:55 | S3 |  | main.rs:925:5:926:14 | S3 |
-| main.rs:956:18:956:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:956:26:956:27 | p3 |  | main.rs:900:5:906:5 | PairOption |
-| main.rs:956:26:956:27 | p3 | Fst | main.rs:922:5:923:14 | S2 |
-| main.rs:956:26:956:27 | p3 | Snd | main.rs:925:5:926:14 | S3 |
-| main.rs:959:13:959:14 | p3 |  | main.rs:900:5:906:5 | PairOption |
-| main.rs:959:13:959:14 | p3 | Fst | main.rs:922:5:923:14 | S2 |
-| main.rs:959:13:959:14 | p3 | Snd | main.rs:925:5:926:14 | S3 |
-| main.rs:959:35:959:56 | ...::PairNone(...) |  | main.rs:900:5:906:5 | PairOption |
-| main.rs:959:35:959:56 | ...::PairNone(...) | Fst | main.rs:922:5:923:14 | S2 |
-| main.rs:959:35:959:56 | ...::PairNone(...) | Snd | main.rs:925:5:926:14 | S3 |
-| main.rs:960:18:960:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:960:26:960:27 | p3 |  | main.rs:900:5:906:5 | PairOption |
-| main.rs:960:26:960:27 | p3 | Fst | main.rs:922:5:923:14 | S2 |
-| main.rs:960:26:960:27 | p3 | Snd | main.rs:925:5:926:14 | S3 |
-| main.rs:962:11:962:54 | ...::PairSnd(...) |  | main.rs:900:5:906:5 | PairOption |
-| main.rs:962:11:962:54 | ...::PairSnd(...) | Fst | main.rs:922:5:923:14 | S2 |
-| main.rs:962:11:962:54 | ...::PairSnd(...) | Snd | main.rs:900:5:906:5 | PairOption |
-| main.rs:962:11:962:54 | ...::PairSnd(...) | Snd.Fst | main.rs:922:5:923:14 | S2 |
-| main.rs:962:11:962:54 | ...::PairSnd(...) | Snd.Snd | main.rs:925:5:926:14 | S3 |
-| main.rs:962:31:962:53 | ...::PairSnd(...) |  | main.rs:900:5:906:5 | PairOption |
-| main.rs:962:31:962:53 | ...::PairSnd(...) | Fst | main.rs:922:5:923:14 | S2 |
-| main.rs:962:31:962:53 | ...::PairSnd(...) | Snd | main.rs:925:5:926:14 | S3 |
-| main.rs:962:51:962:52 | S3 |  | main.rs:925:5:926:14 | S3 |
-| main.rs:975:16:975:24 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:975:16:975:24 | SelfParam | &T | main.rs:973:5:980:5 | Self [trait MyTrait] |
-| main.rs:975:27:975:31 | value |  | main.rs:973:19:973:19 | S |
-| main.rs:977:21:977:29 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:977:21:977:29 | SelfParam | &T | main.rs:973:5:980:5 | Self [trait MyTrait] |
-| main.rs:977:32:977:36 | value |  | main.rs:973:19:973:19 | S |
-| main.rs:978:13:978:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:978:13:978:16 | self | &T | main.rs:973:5:980:5 | Self [trait MyTrait] |
-| main.rs:978:22:978:26 | value |  | main.rs:973:19:973:19 | S |
-| main.rs:984:16:984:24 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:984:16:984:24 | SelfParam | &T | main.rs:967:5:971:5 | MyOption |
-| main.rs:984:16:984:24 | SelfParam | &T.T | main.rs:982:10:982:10 | T |
-| main.rs:984:27:984:31 | value |  | main.rs:982:10:982:10 | T |
-| main.rs:988:26:990:9 | { ... } |  | main.rs:967:5:971:5 | MyOption |
-| main.rs:988:26:990:9 | { ... } | T | main.rs:987:10:987:10 | T |
-| main.rs:989:13:989:30 | ...::MyNone(...) |  | main.rs:967:5:971:5 | MyOption |
-| main.rs:989:13:989:30 | ...::MyNone(...) | T | main.rs:987:10:987:10 | T |
-| main.rs:994:20:994:23 | SelfParam |  | main.rs:967:5:971:5 | MyOption |
-| main.rs:994:20:994:23 | SelfParam | T | main.rs:967:5:971:5 | MyOption |
-| main.rs:994:20:994:23 | SelfParam | T.T | main.rs:993:10:993:10 | T |
-| main.rs:994:41:999:9 | { ... } |  | main.rs:967:5:971:5 | MyOption |
-| main.rs:994:41:999:9 | { ... } | T | main.rs:993:10:993:10 | T |
-| main.rs:995:13:998:13 | match self { ... } |  | main.rs:967:5:971:5 | MyOption |
-| main.rs:995:13:998:13 | match self { ... } | T | main.rs:993:10:993:10 | T |
-| main.rs:995:19:995:22 | self |  | main.rs:967:5:971:5 | MyOption |
-| main.rs:995:19:995:22 | self | T | main.rs:967:5:971:5 | MyOption |
-| main.rs:995:19:995:22 | self | T.T | main.rs:993:10:993:10 | T |
-| main.rs:996:39:996:56 | ...::MyNone(...) |  | main.rs:967:5:971:5 | MyOption |
-| main.rs:996:39:996:56 | ...::MyNone(...) | T | main.rs:993:10:993:10 | T |
-| main.rs:997:34:997:34 | x |  | main.rs:967:5:971:5 | MyOption |
-| main.rs:997:34:997:34 | x | T | main.rs:993:10:993:10 | T |
-| main.rs:997:40:997:40 | x |  | main.rs:967:5:971:5 | MyOption |
-| main.rs:997:40:997:40 | x | T | main.rs:993:10:993:10 | T |
-| main.rs:1006:13:1006:14 | x1 |  | main.rs:967:5:971:5 | MyOption |
-| main.rs:1006:18:1006:37 | ...::new(...) |  | main.rs:967:5:971:5 | MyOption |
-| main.rs:1007:18:1007:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:1007:26:1007:27 | x1 |  | main.rs:967:5:971:5 | MyOption |
-| main.rs:1009:13:1009:18 | mut x2 |  | main.rs:967:5:971:5 | MyOption |
-| main.rs:1009:13:1009:18 | mut x2 | T | main.rs:1002:5:1003:13 | S |
-| main.rs:1009:22:1009:36 | ...::new(...) |  | main.rs:967:5:971:5 | MyOption |
-| main.rs:1009:22:1009:36 | ...::new(...) | T | main.rs:1002:5:1003:13 | S |
-| main.rs:1010:9:1010:10 | x2 |  | main.rs:967:5:971:5 | MyOption |
-| main.rs:1010:9:1010:10 | x2 | T | main.rs:1002:5:1003:13 | S |
-| main.rs:1010:16:1010:16 | S |  | main.rs:1002:5:1003:13 | S |
-| main.rs:1011:18:1011:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:1011:26:1011:27 | x2 |  | main.rs:967:5:971:5 | MyOption |
-| main.rs:1011:26:1011:27 | x2 | T | main.rs:1002:5:1003:13 | S |
-| main.rs:1013:13:1013:18 | mut x3 |  | main.rs:967:5:971:5 | MyOption |
-| main.rs:1013:22:1013:36 | ...::new(...) |  | main.rs:967:5:971:5 | MyOption |
-| main.rs:1014:9:1014:10 | x3 |  | main.rs:967:5:971:5 | MyOption |
-| main.rs:1014:21:1014:21 | S |  | main.rs:1002:5:1003:13 | S |
-| main.rs:1015:18:1015:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:1015:26:1015:27 | x3 |  | main.rs:967:5:971:5 | MyOption |
-| main.rs:1017:13:1017:18 | mut x4 |  | main.rs:967:5:971:5 | MyOption |
-| main.rs:1017:13:1017:18 | mut x4 | T | main.rs:1002:5:1003:13 | S |
-| main.rs:1017:22:1017:36 | ...::new(...) |  | main.rs:967:5:971:5 | MyOption |
-| main.rs:1017:22:1017:36 | ...::new(...) | T | main.rs:1002:5:1003:13 | S |
-| main.rs:1018:23:1018:29 | &mut x4 |  | file://:0:0:0:0 | & |
-| main.rs:1018:23:1018:29 | &mut x4 | &T | main.rs:967:5:971:5 | MyOption |
-| main.rs:1018:23:1018:29 | &mut x4 | &T.T | main.rs:1002:5:1003:13 | S |
-| main.rs:1018:28:1018:29 | x4 |  | main.rs:967:5:971:5 | MyOption |
-| main.rs:1018:28:1018:29 | x4 | T | main.rs:1002:5:1003:13 | S |
-| main.rs:1018:32:1018:32 | S |  | main.rs:1002:5:1003:13 | S |
-| main.rs:1019:18:1019:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:1019:26:1019:27 | x4 |  | main.rs:967:5:971:5 | MyOption |
-| main.rs:1019:26:1019:27 | x4 | T | main.rs:1002:5:1003:13 | S |
-| main.rs:1021:13:1021:14 | x5 |  | main.rs:967:5:971:5 | MyOption |
-| main.rs:1021:13:1021:14 | x5 | T | main.rs:967:5:971:5 | MyOption |
-| main.rs:1021:13:1021:14 | x5 | T.T | main.rs:1002:5:1003:13 | S |
-| main.rs:1021:18:1021:58 | ...::MySome(...) |  | main.rs:967:5:971:5 | MyOption |
-| main.rs:1021:18:1021:58 | ...::MySome(...) | T | main.rs:967:5:971:5 | MyOption |
-| main.rs:1021:18:1021:58 | ...::MySome(...) | T.T | main.rs:1002:5:1003:13 | S |
-| main.rs:1021:35:1021:57 | ...::MyNone(...) |  | main.rs:967:5:971:5 | MyOption |
-| main.rs:1021:35:1021:57 | ...::MyNone(...) | T | main.rs:1002:5:1003:13 | S |
-| main.rs:1022:18:1022:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:1022:26:1022:27 | x5 |  | main.rs:967:5:971:5 | MyOption |
-| main.rs:1022:26:1022:27 | x5 | T | main.rs:967:5:971:5 | MyOption |
-| main.rs:1022:26:1022:27 | x5 | T.T | main.rs:1002:5:1003:13 | S |
-| main.rs:1022:26:1022:37 | x5.flatten() |  | main.rs:967:5:971:5 | MyOption |
-| main.rs:1022:26:1022:37 | x5.flatten() | T | main.rs:1002:5:1003:13 | S |
-| main.rs:1024:13:1024:14 | x6 |  | main.rs:967:5:971:5 | MyOption |
-| main.rs:1024:13:1024:14 | x6 | T | main.rs:967:5:971:5 | MyOption |
-| main.rs:1024:13:1024:14 | x6 | T.T | main.rs:1002:5:1003:13 | S |
-| main.rs:1024:18:1024:58 | ...::MySome(...) |  | main.rs:967:5:971:5 | MyOption |
-| main.rs:1024:18:1024:58 | ...::MySome(...) | T | main.rs:967:5:971:5 | MyOption |
-| main.rs:1024:18:1024:58 | ...::MySome(...) | T.T | main.rs:1002:5:1003:13 | S |
-| main.rs:1024:35:1024:57 | ...::MyNone(...) |  | main.rs:967:5:971:5 | MyOption |
-| main.rs:1024:35:1024:57 | ...::MyNone(...) | T | main.rs:1002:5:1003:13 | S |
-| main.rs:1025:18:1025:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:1025:26:1025:61 | ...::flatten(...) |  | main.rs:967:5:971:5 | MyOption |
-| main.rs:1025:26:1025:61 | ...::flatten(...) | T | main.rs:1002:5:1003:13 | S |
-| main.rs:1025:59:1025:60 | x6 |  | main.rs:967:5:971:5 | MyOption |
-| main.rs:1025:59:1025:60 | x6 | T | main.rs:967:5:971:5 | MyOption |
-| main.rs:1025:59:1025:60 | x6 | T.T | main.rs:1002:5:1003:13 | S |
-| main.rs:1027:13:1027:19 | from_if |  | main.rs:967:5:971:5 | MyOption |
-| main.rs:1027:13:1027:19 | from_if | T | main.rs:1002:5:1003:13 | S |
-| main.rs:1027:23:1031:9 | if ... {...} else {...} |  | main.rs:967:5:971:5 | MyOption |
-| main.rs:1027:23:1031:9 | if ... {...} else {...} | T | main.rs:1002:5:1003:13 | S |
-| main.rs:1027:26:1027:26 | 1 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:1027:30:1027:30 | 1 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:1027:34:1027:34 | 2 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:1027:36:1029:9 | { ... } |  | main.rs:967:5:971:5 | MyOption |
-| main.rs:1027:36:1029:9 | { ... } | T | main.rs:1002:5:1003:13 | S |
-| main.rs:1028:13:1028:30 | ...::MyNone(...) |  | main.rs:967:5:971:5 | MyOption |
-| main.rs:1028:13:1028:30 | ...::MyNone(...) | T | main.rs:1002:5:1003:13 | S |
-| main.rs:1029:16:1031:9 | { ... } |  | main.rs:967:5:971:5 | MyOption |
-| main.rs:1029:16:1031:9 | { ... } | T | main.rs:1002:5:1003:13 | S |
-| main.rs:1030:13:1030:31 | ...::MySome(...) |  | main.rs:967:5:971:5 | MyOption |
-| main.rs:1030:13:1030:31 | ...::MySome(...) | T | main.rs:1002:5:1003:13 | S |
-| main.rs:1030:30:1030:30 | S |  | main.rs:1002:5:1003:13 | S |
-| main.rs:1032:18:1032:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:1032:26:1032:32 | from_if |  | main.rs:967:5:971:5 | MyOption |
-| main.rs:1032:26:1032:32 | from_if | T | main.rs:1002:5:1003:13 | S |
-| main.rs:1034:13:1034:22 | from_match |  | main.rs:967:5:971:5 | MyOption |
-| main.rs:1034:13:1034:22 | from_match | T | main.rs:1002:5:1003:13 | S |
-| main.rs:1034:26:1037:9 | match ... { ... } |  | main.rs:967:5:971:5 | MyOption |
-| main.rs:1034:26:1037:9 | match ... { ... } | T | main.rs:1002:5:1003:13 | S |
-| main.rs:1034:32:1034:32 | 1 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:1034:36:1034:36 | 1 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:1034:40:1034:40 | 2 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:1035:13:1035:16 | true |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
-| main.rs:1035:21:1035:38 | ...::MyNone(...) |  | main.rs:967:5:971:5 | MyOption |
-| main.rs:1035:21:1035:38 | ...::MyNone(...) | T | main.rs:1002:5:1003:13 | S |
-| main.rs:1036:13:1036:17 | false |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
-| main.rs:1036:22:1036:40 | ...::MySome(...) |  | main.rs:967:5:971:5 | MyOption |
-| main.rs:1036:22:1036:40 | ...::MySome(...) | T | main.rs:1002:5:1003:13 | S |
-| main.rs:1036:39:1036:39 | S |  | main.rs:1002:5:1003:13 | S |
-| main.rs:1038:18:1038:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:1038:26:1038:35 | from_match |  | main.rs:967:5:971:5 | MyOption |
-| main.rs:1038:26:1038:35 | from_match | T | main.rs:1002:5:1003:13 | S |
-| main.rs:1040:13:1040:21 | from_loop |  | main.rs:967:5:971:5 | MyOption |
-| main.rs:1040:13:1040:21 | from_loop | T | main.rs:1002:5:1003:13 | S |
-| main.rs:1040:25:1045:9 | loop { ... } |  | main.rs:967:5:971:5 | MyOption |
-| main.rs:1040:25:1045:9 | loop { ... } | T | main.rs:1002:5:1003:13 | S |
-| main.rs:1041:16:1041:16 | 1 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:1041:20:1041:20 | 1 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:1041:24:1041:24 | 2 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:1042:23:1042:40 | ...::MyNone(...) |  | main.rs:967:5:971:5 | MyOption |
-| main.rs:1042:23:1042:40 | ...::MyNone(...) | T | main.rs:1002:5:1003:13 | S |
-| main.rs:1044:19:1044:37 | ...::MySome(...) |  | main.rs:967:5:971:5 | MyOption |
-| main.rs:1044:19:1044:37 | ...::MySome(...) | T | main.rs:1002:5:1003:13 | S |
-| main.rs:1044:36:1044:36 | S |  | main.rs:1002:5:1003:13 | S |
-| main.rs:1046:18:1046:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:1046:26:1046:34 | from_loop |  | main.rs:967:5:971:5 | MyOption |
-| main.rs:1046:26:1046:34 | from_loop | T | main.rs:1002:5:1003:13 | S |
-| main.rs:1059:15:1059:18 | SelfParam |  | main.rs:1052:5:1053:19 | S |
-| main.rs:1059:15:1059:18 | SelfParam | T | main.rs:1058:10:1058:10 | T |
-| main.rs:1059:26:1061:9 | { ... } |  | main.rs:1058:10:1058:10 | T |
-| main.rs:1060:13:1060:16 | self |  | main.rs:1052:5:1053:19 | S |
-| main.rs:1060:13:1060:16 | self | T | main.rs:1058:10:1058:10 | T |
-| main.rs:1060:13:1060:18 | self.0 |  | main.rs:1058:10:1058:10 | T |
-| main.rs:1063:15:1063:19 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:1063:15:1063:19 | SelfParam | &T | main.rs:1052:5:1053:19 | S |
-| main.rs:1063:15:1063:19 | SelfParam | &T.T | main.rs:1058:10:1058:10 | T |
-| main.rs:1063:28:1065:9 | { ... } |  | file://:0:0:0:0 | & |
-| main.rs:1063:28:1065:9 | { ... } | &T | main.rs:1058:10:1058:10 | T |
-| main.rs:1064:13:1064:19 | &... |  | file://:0:0:0:0 | & |
-| main.rs:1064:13:1064:19 | &... | &T | main.rs:1058:10:1058:10 | T |
-| main.rs:1064:14:1064:17 | self |  | file://:0:0:0:0 | & |
-| main.rs:1064:14:1064:17 | self | &T | main.rs:1052:5:1053:19 | S |
-| main.rs:1064:14:1064:17 | self | &T.T | main.rs:1058:10:1058:10 | T |
-| main.rs:1064:14:1064:19 | self.0 |  | main.rs:1058:10:1058:10 | T |
-| main.rs:1067:15:1067:25 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:1067:15:1067:25 | SelfParam | &T | main.rs:1052:5:1053:19 | S |
-| main.rs:1067:15:1067:25 | SelfParam | &T.T | main.rs:1058:10:1058:10 | T |
-| main.rs:1067:34:1069:9 | { ... } |  | file://:0:0:0:0 | & |
-| main.rs:1067:34:1069:9 | { ... } | &T | main.rs:1058:10:1058:10 | T |
-| main.rs:1068:13:1068:19 | &... |  | file://:0:0:0:0 | & |
-| main.rs:1068:13:1068:19 | &... | &T | main.rs:1058:10:1058:10 | T |
-| main.rs:1068:14:1068:17 | self |  | file://:0:0:0:0 | & |
-| main.rs:1068:14:1068:17 | self | &T | main.rs:1052:5:1053:19 | S |
-| main.rs:1068:14:1068:17 | self | &T.T | main.rs:1058:10:1058:10 | T |
-| main.rs:1068:14:1068:19 | self.0 |  | main.rs:1058:10:1058:10 | T |
-| main.rs:1073:13:1073:14 | x1 |  | main.rs:1052:5:1053:19 | S |
-| main.rs:1073:13:1073:14 | x1 | T | main.rs:1055:5:1056:14 | S2 |
-| main.rs:1073:18:1073:22 | S(...) |  | main.rs:1052:5:1053:19 | S |
-| main.rs:1073:18:1073:22 | S(...) | T | main.rs:1055:5:1056:14 | S2 |
-| main.rs:1073:20:1073:21 | S2 |  | main.rs:1055:5:1056:14 | S2 |
-| main.rs:1074:18:1074:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:1074:26:1074:27 | x1 |  | main.rs:1052:5:1053:19 | S |
-| main.rs:1074:26:1074:27 | x1 | T | main.rs:1055:5:1056:14 | S2 |
-| main.rs:1074:26:1074:32 | x1.m1() |  | main.rs:1055:5:1056:14 | S2 |
-| main.rs:1076:13:1076:14 | x2 |  | main.rs:1052:5:1053:19 | S |
-| main.rs:1076:13:1076:14 | x2 | T | main.rs:1055:5:1056:14 | S2 |
-| main.rs:1076:18:1076:22 | S(...) |  | main.rs:1052:5:1053:19 | S |
-| main.rs:1076:18:1076:22 | S(...) | T | main.rs:1055:5:1056:14 | S2 |
-| main.rs:1076:20:1076:21 | S2 |  | main.rs:1055:5:1056:14 | S2 |
-| main.rs:1078:18:1078:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:1078:26:1078:27 | x2 |  | main.rs:1052:5:1053:19 | S |
-| main.rs:1078:26:1078:27 | x2 | T | main.rs:1055:5:1056:14 | S2 |
-| main.rs:1078:26:1078:32 | x2.m2() |  | file://:0:0:0:0 | & |
-| main.rs:1078:26:1078:32 | x2.m2() | &T | main.rs:1055:5:1056:14 | S2 |
+| main.rs:769:15:769:18 | SelfParam |  | main.rs:767:5:779:5 | Self [trait MyTrait2] |
+| main.rs:772:9:778:9 | { ... } |  | main.rs:767:20:767:22 | Tr2 |
+| main.rs:773:13:777:13 | if ... {...} else {...} |  | main.rs:767:20:767:22 | Tr2 |
+| main.rs:773:16:773:16 | 3 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:773:20:773:20 | 2 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:773:22:775:13 | { ... } |  | main.rs:767:20:767:22 | Tr2 |
+| main.rs:774:17:774:20 | self |  | main.rs:767:5:779:5 | Self [trait MyTrait2] |
+| main.rs:774:17:774:25 | self.m1() |  | main.rs:767:20:767:22 | Tr2 |
+| main.rs:775:20:777:13 | { ... } |  | main.rs:767:20:767:22 | Tr2 |
+| main.rs:776:17:776:30 | ...::m1(...) |  | main.rs:767:20:767:22 | Tr2 |
+| main.rs:776:26:776:29 | self |  | main.rs:767:5:779:5 | Self [trait MyTrait2] |
+| main.rs:783:15:783:18 | SelfParam |  | main.rs:781:5:793:5 | Self [trait MyTrait3] |
+| main.rs:786:9:792:9 | { ... } |  | main.rs:781:20:781:22 | Tr3 |
+| main.rs:787:13:791:13 | if ... {...} else {...} |  | main.rs:781:20:781:22 | Tr3 |
+| main.rs:787:16:787:16 | 3 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:787:20:787:20 | 2 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:787:22:789:13 | { ... } |  | main.rs:781:20:781:22 | Tr3 |
+| main.rs:788:17:788:20 | self |  | main.rs:781:5:793:5 | Self [trait MyTrait3] |
+| main.rs:788:17:788:25 | self.m2() |  | main.rs:747:5:750:5 | MyThing |
+| main.rs:788:17:788:25 | self.m2() | A | main.rs:781:20:781:22 | Tr3 |
+| main.rs:788:17:788:27 | ... .a |  | main.rs:781:20:781:22 | Tr3 |
+| main.rs:789:20:791:13 | { ... } |  | main.rs:781:20:781:22 | Tr3 |
+| main.rs:790:17:790:30 | ...::m2(...) |  | main.rs:747:5:750:5 | MyThing |
+| main.rs:790:17:790:30 | ...::m2(...) | A | main.rs:781:20:781:22 | Tr3 |
+| main.rs:790:17:790:32 | ... .a |  | main.rs:781:20:781:22 | Tr3 |
+| main.rs:790:26:790:29 | self |  | main.rs:781:5:793:5 | Self [trait MyTrait3] |
+| main.rs:797:15:797:18 | SelfParam |  | main.rs:747:5:750:5 | MyThing |
+| main.rs:797:15:797:18 | SelfParam | A | main.rs:795:10:795:10 | T |
+| main.rs:797:26:799:9 | { ... } |  | main.rs:795:10:795:10 | T |
+| main.rs:798:13:798:16 | self |  | main.rs:747:5:750:5 | MyThing |
+| main.rs:798:13:798:16 | self | A | main.rs:795:10:795:10 | T |
+| main.rs:798:13:798:18 | self.a |  | main.rs:795:10:795:10 | T |
+| main.rs:806:15:806:18 | SelfParam |  | main.rs:752:5:755:5 | MyThing2 |
+| main.rs:806:15:806:18 | SelfParam | A | main.rs:804:10:804:10 | T |
+| main.rs:806:35:808:9 | { ... } |  | main.rs:747:5:750:5 | MyThing |
+| main.rs:806:35:808:9 | { ... } | A | main.rs:804:10:804:10 | T |
+| main.rs:807:13:807:33 | MyThing {...} |  | main.rs:747:5:750:5 | MyThing |
+| main.rs:807:13:807:33 | MyThing {...} | A | main.rs:804:10:804:10 | T |
+| main.rs:807:26:807:29 | self |  | main.rs:752:5:755:5 | MyThing2 |
+| main.rs:807:26:807:29 | self | A | main.rs:804:10:804:10 | T |
+| main.rs:807:26:807:31 | self.a |  | main.rs:804:10:804:10 | T |
+| main.rs:815:44:815:44 | x |  | main.rs:815:26:815:41 | T2 |
+| main.rs:815:57:817:5 | { ... } |  | main.rs:815:22:815:23 | T1 |
+| main.rs:816:9:816:9 | x |  | main.rs:815:26:815:41 | T2 |
+| main.rs:816:9:816:14 | x.m1() |  | main.rs:815:22:815:23 | T1 |
+| main.rs:819:56:819:56 | x |  | main.rs:819:39:819:53 | T |
+| main.rs:821:13:821:13 | a |  | main.rs:747:5:750:5 | MyThing |
+| main.rs:821:13:821:13 | a | A | main.rs:757:5:758:14 | S1 |
+| main.rs:821:17:821:17 | x |  | main.rs:819:39:819:53 | T |
+| main.rs:821:17:821:22 | x.m1() |  | main.rs:747:5:750:5 | MyThing |
+| main.rs:821:17:821:22 | x.m1() | A | main.rs:757:5:758:14 | S1 |
+| main.rs:822:18:822:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:822:26:822:26 | a |  | main.rs:747:5:750:5 | MyThing |
+| main.rs:822:26:822:26 | a | A | main.rs:757:5:758:14 | S1 |
+| main.rs:826:13:826:13 | x |  | main.rs:747:5:750:5 | MyThing |
+| main.rs:826:13:826:13 | x | A | main.rs:757:5:758:14 | S1 |
+| main.rs:826:17:826:33 | MyThing {...} |  | main.rs:747:5:750:5 | MyThing |
+| main.rs:826:17:826:33 | MyThing {...} | A | main.rs:757:5:758:14 | S1 |
+| main.rs:826:30:826:31 | S1 |  | main.rs:757:5:758:14 | S1 |
+| main.rs:827:13:827:13 | y |  | main.rs:747:5:750:5 | MyThing |
+| main.rs:827:13:827:13 | y | A | main.rs:759:5:760:14 | S2 |
+| main.rs:827:17:827:33 | MyThing {...} |  | main.rs:747:5:750:5 | MyThing |
+| main.rs:827:17:827:33 | MyThing {...} | A | main.rs:759:5:760:14 | S2 |
+| main.rs:827:30:827:31 | S2 |  | main.rs:759:5:760:14 | S2 |
+| main.rs:829:18:829:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:829:26:829:26 | x |  | main.rs:747:5:750:5 | MyThing |
+| main.rs:829:26:829:26 | x | A | main.rs:757:5:758:14 | S1 |
+| main.rs:829:26:829:31 | x.m1() |  | main.rs:757:5:758:14 | S1 |
+| main.rs:830:18:830:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:830:26:830:26 | y |  | main.rs:747:5:750:5 | MyThing |
+| main.rs:830:26:830:26 | y | A | main.rs:759:5:760:14 | S2 |
+| main.rs:830:26:830:31 | y.m1() |  | main.rs:759:5:760:14 | S2 |
+| main.rs:832:13:832:13 | x |  | main.rs:747:5:750:5 | MyThing |
+| main.rs:832:13:832:13 | x | A | main.rs:757:5:758:14 | S1 |
+| main.rs:832:17:832:33 | MyThing {...} |  | main.rs:747:5:750:5 | MyThing |
+| main.rs:832:17:832:33 | MyThing {...} | A | main.rs:757:5:758:14 | S1 |
+| main.rs:832:30:832:31 | S1 |  | main.rs:757:5:758:14 | S1 |
+| main.rs:833:13:833:13 | y |  | main.rs:747:5:750:5 | MyThing |
+| main.rs:833:13:833:13 | y | A | main.rs:759:5:760:14 | S2 |
+| main.rs:833:17:833:33 | MyThing {...} |  | main.rs:747:5:750:5 | MyThing |
+| main.rs:833:17:833:33 | MyThing {...} | A | main.rs:759:5:760:14 | S2 |
+| main.rs:833:30:833:31 | S2 |  | main.rs:759:5:760:14 | S2 |
+| main.rs:835:18:835:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:835:26:835:26 | x |  | main.rs:747:5:750:5 | MyThing |
+| main.rs:835:26:835:26 | x | A | main.rs:757:5:758:14 | S1 |
+| main.rs:835:26:835:31 | x.m2() |  | main.rs:757:5:758:14 | S1 |
+| main.rs:836:18:836:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:836:26:836:26 | y |  | main.rs:747:5:750:5 | MyThing |
+| main.rs:836:26:836:26 | y | A | main.rs:759:5:760:14 | S2 |
+| main.rs:836:26:836:31 | y.m2() |  | main.rs:759:5:760:14 | S2 |
+| main.rs:838:13:838:13 | x |  | main.rs:752:5:755:5 | MyThing2 |
+| main.rs:838:13:838:13 | x | A | main.rs:757:5:758:14 | S1 |
+| main.rs:838:17:838:34 | MyThing2 {...} |  | main.rs:752:5:755:5 | MyThing2 |
+| main.rs:838:17:838:34 | MyThing2 {...} | A | main.rs:757:5:758:14 | S1 |
+| main.rs:838:31:838:32 | S1 |  | main.rs:757:5:758:14 | S1 |
+| main.rs:839:13:839:13 | y |  | main.rs:752:5:755:5 | MyThing2 |
+| main.rs:839:13:839:13 | y | A | main.rs:759:5:760:14 | S2 |
+| main.rs:839:17:839:34 | MyThing2 {...} |  | main.rs:752:5:755:5 | MyThing2 |
+| main.rs:839:17:839:34 | MyThing2 {...} | A | main.rs:759:5:760:14 | S2 |
+| main.rs:839:31:839:32 | S2 |  | main.rs:759:5:760:14 | S2 |
+| main.rs:841:18:841:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:841:26:841:26 | x |  | main.rs:752:5:755:5 | MyThing2 |
+| main.rs:841:26:841:26 | x | A | main.rs:757:5:758:14 | S1 |
+| main.rs:841:26:841:31 | x.m3() |  | main.rs:757:5:758:14 | S1 |
+| main.rs:842:18:842:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:842:26:842:26 | y |  | main.rs:752:5:755:5 | MyThing2 |
+| main.rs:842:26:842:26 | y | A | main.rs:759:5:760:14 | S2 |
+| main.rs:842:26:842:31 | y.m3() |  | main.rs:759:5:760:14 | S2 |
+| main.rs:844:13:844:13 | x |  | main.rs:747:5:750:5 | MyThing |
+| main.rs:844:13:844:13 | x | A | main.rs:757:5:758:14 | S1 |
+| main.rs:844:17:844:33 | MyThing {...} |  | main.rs:747:5:750:5 | MyThing |
+| main.rs:844:17:844:33 | MyThing {...} | A | main.rs:757:5:758:14 | S1 |
+| main.rs:844:30:844:31 | S1 |  | main.rs:757:5:758:14 | S1 |
+| main.rs:845:13:845:13 | s |  | main.rs:757:5:758:14 | S1 |
+| main.rs:845:17:845:32 | call_trait_m1(...) |  | main.rs:757:5:758:14 | S1 |
+| main.rs:845:31:845:31 | x |  | main.rs:747:5:750:5 | MyThing |
+| main.rs:845:31:845:31 | x | A | main.rs:757:5:758:14 | S1 |
+| main.rs:847:13:847:13 | x |  | main.rs:752:5:755:5 | MyThing2 |
+| main.rs:847:13:847:13 | x | A | main.rs:759:5:760:14 | S2 |
+| main.rs:847:17:847:34 | MyThing2 {...} |  | main.rs:752:5:755:5 | MyThing2 |
+| main.rs:847:17:847:34 | MyThing2 {...} | A | main.rs:759:5:760:14 | S2 |
+| main.rs:847:31:847:32 | S2 |  | main.rs:759:5:760:14 | S2 |
+| main.rs:848:13:848:13 | s |  | main.rs:747:5:750:5 | MyThing |
+| main.rs:848:13:848:13 | s | A | main.rs:759:5:760:14 | S2 |
+| main.rs:848:17:848:32 | call_trait_m1(...) |  | main.rs:747:5:750:5 | MyThing |
+| main.rs:848:17:848:32 | call_trait_m1(...) | A | main.rs:759:5:760:14 | S2 |
+| main.rs:848:31:848:31 | x |  | main.rs:752:5:755:5 | MyThing2 |
+| main.rs:848:31:848:31 | x | A | main.rs:759:5:760:14 | S2 |
+| main.rs:866:22:866:22 | x |  | file://:0:0:0:0 | & |
+| main.rs:866:22:866:22 | x | &T | main.rs:866:11:866:19 | T |
+| main.rs:866:35:868:5 | { ... } |  | file://:0:0:0:0 | & |
+| main.rs:866:35:868:5 | { ... } | &T | main.rs:866:11:866:19 | T |
+| main.rs:867:9:867:9 | x |  | file://:0:0:0:0 | & |
+| main.rs:867:9:867:9 | x | &T | main.rs:866:11:866:19 | T |
+| main.rs:871:17:871:20 | SelfParam |  | main.rs:856:5:857:14 | S1 |
+| main.rs:871:29:873:9 | { ... } |  | main.rs:859:5:860:14 | S2 |
+| main.rs:872:13:872:14 | S2 |  | main.rs:859:5:860:14 | S2 |
+| main.rs:876:21:876:21 | x |  | main.rs:876:13:876:14 | T1 |
+| main.rs:879:5:881:5 | { ... } |  | main.rs:876:17:876:18 | T2 |
+| main.rs:880:9:880:9 | x |  | main.rs:876:13:876:14 | T1 |
+| main.rs:880:9:880:16 | x.into() |  | main.rs:876:17:876:18 | T2 |
+| main.rs:884:13:884:13 | x |  | main.rs:856:5:857:14 | S1 |
+| main.rs:884:17:884:18 | S1 |  | main.rs:856:5:857:14 | S1 |
+| main.rs:885:18:885:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:885:26:885:31 | id(...) |  | file://:0:0:0:0 | & |
+| main.rs:885:26:885:31 | id(...) | &T | main.rs:856:5:857:14 | S1 |
+| main.rs:885:29:885:30 | &x |  | file://:0:0:0:0 | & |
+| main.rs:885:29:885:30 | &x | &T | main.rs:856:5:857:14 | S1 |
+| main.rs:885:30:885:30 | x |  | main.rs:856:5:857:14 | S1 |
+| main.rs:887:13:887:13 | x |  | main.rs:856:5:857:14 | S1 |
+| main.rs:887:17:887:18 | S1 |  | main.rs:856:5:857:14 | S1 |
+| main.rs:888:18:888:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:888:26:888:37 | id::<...>(...) |  | file://:0:0:0:0 | & |
+| main.rs:888:26:888:37 | id::<...>(...) | &T | main.rs:856:5:857:14 | S1 |
+| main.rs:888:35:888:36 | &x |  | file://:0:0:0:0 | & |
+| main.rs:888:35:888:36 | &x | &T | main.rs:856:5:857:14 | S1 |
+| main.rs:888:36:888:36 | x |  | main.rs:856:5:857:14 | S1 |
+| main.rs:890:13:890:13 | x |  | main.rs:856:5:857:14 | S1 |
+| main.rs:890:17:890:18 | S1 |  | main.rs:856:5:857:14 | S1 |
+| main.rs:891:18:891:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:891:26:891:44 | id::<...>(...) |  | file://:0:0:0:0 | & |
+| main.rs:891:26:891:44 | id::<...>(...) | &T | main.rs:856:5:857:14 | S1 |
+| main.rs:891:42:891:43 | &x |  | file://:0:0:0:0 | & |
+| main.rs:891:42:891:43 | &x | &T | main.rs:856:5:857:14 | S1 |
+| main.rs:891:43:891:43 | x |  | main.rs:856:5:857:14 | S1 |
+| main.rs:893:13:893:13 | x |  | main.rs:856:5:857:14 | S1 |
+| main.rs:893:17:893:18 | S1 |  | main.rs:856:5:857:14 | S1 |
+| main.rs:894:9:894:25 | into::<...>(...) |  | main.rs:859:5:860:14 | S2 |
+| main.rs:894:24:894:24 | x |  | main.rs:856:5:857:14 | S1 |
+| main.rs:896:13:896:13 | x |  | main.rs:856:5:857:14 | S1 |
+| main.rs:896:17:896:18 | S1 |  | main.rs:856:5:857:14 | S1 |
+| main.rs:897:13:897:13 | y |  | main.rs:859:5:860:14 | S2 |
+| main.rs:897:21:897:27 | into(...) |  | main.rs:859:5:860:14 | S2 |
+| main.rs:897:26:897:26 | x |  | main.rs:856:5:857:14 | S1 |
+| main.rs:911:22:911:25 | SelfParam |  | main.rs:902:5:908:5 | PairOption |
+| main.rs:911:22:911:25 | SelfParam | Fst | main.rs:910:10:910:12 | Fst |
+| main.rs:911:22:911:25 | SelfParam | Snd | main.rs:910:15:910:17 | Snd |
+| main.rs:911:35:918:9 | { ... } |  | main.rs:910:15:910:17 | Snd |
+| main.rs:912:13:917:13 | match self { ... } |  | main.rs:910:15:910:17 | Snd |
+| main.rs:912:19:912:22 | self |  | main.rs:902:5:908:5 | PairOption |
+| main.rs:912:19:912:22 | self | Fst | main.rs:910:10:910:12 | Fst |
+| main.rs:912:19:912:22 | self | Snd | main.rs:910:15:910:17 | Snd |
+| main.rs:913:43:913:82 | MacroExpr |  | main.rs:910:15:910:17 | Snd |
+| main.rs:913:50:913:81 | "PairNone has no second elemen... |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:914:43:914:81 | MacroExpr |  | main.rs:910:15:910:17 | Snd |
+| main.rs:914:50:914:80 | "PairFst has no second element... |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:915:37:915:39 | snd |  | main.rs:910:15:910:17 | Snd |
+| main.rs:915:45:915:47 | snd |  | main.rs:910:15:910:17 | Snd |
+| main.rs:916:41:916:43 | snd |  | main.rs:910:15:910:17 | Snd |
+| main.rs:916:49:916:51 | snd |  | main.rs:910:15:910:17 | Snd |
+| main.rs:942:10:942:10 | t |  | main.rs:902:5:908:5 | PairOption |
+| main.rs:942:10:942:10 | t | Fst | main.rs:924:5:925:14 | S2 |
+| main.rs:942:10:942:10 | t | Snd | main.rs:902:5:908:5 | PairOption |
+| main.rs:942:10:942:10 | t | Snd.Fst | main.rs:924:5:925:14 | S2 |
+| main.rs:942:10:942:10 | t | Snd.Snd | main.rs:927:5:928:14 | S3 |
+| main.rs:943:13:943:13 | x |  | main.rs:927:5:928:14 | S3 |
+| main.rs:943:17:943:17 | t |  | main.rs:902:5:908:5 | PairOption |
+| main.rs:943:17:943:17 | t | Fst | main.rs:924:5:925:14 | S2 |
+| main.rs:943:17:943:17 | t | Snd | main.rs:902:5:908:5 | PairOption |
+| main.rs:943:17:943:17 | t | Snd.Fst | main.rs:924:5:925:14 | S2 |
+| main.rs:943:17:943:17 | t | Snd.Snd | main.rs:927:5:928:14 | S3 |
+| main.rs:943:17:943:29 | t.unwrapSnd() |  | main.rs:902:5:908:5 | PairOption |
+| main.rs:943:17:943:29 | t.unwrapSnd() | Fst | main.rs:924:5:925:14 | S2 |
+| main.rs:943:17:943:29 | t.unwrapSnd() | Snd | main.rs:927:5:928:14 | S3 |
+| main.rs:943:17:943:41 | ... .unwrapSnd() |  | main.rs:927:5:928:14 | S3 |
+| main.rs:944:18:944:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:944:26:944:26 | x |  | main.rs:927:5:928:14 | S3 |
+| main.rs:949:13:949:14 | p1 |  | main.rs:902:5:908:5 | PairOption |
+| main.rs:949:13:949:14 | p1 | Fst | main.rs:921:5:922:14 | S1 |
+| main.rs:949:13:949:14 | p1 | Snd | main.rs:924:5:925:14 | S2 |
+| main.rs:949:26:949:53 | ...::PairBoth(...) |  | main.rs:902:5:908:5 | PairOption |
+| main.rs:949:26:949:53 | ...::PairBoth(...) | Fst | main.rs:921:5:922:14 | S1 |
+| main.rs:949:26:949:53 | ...::PairBoth(...) | Snd | main.rs:924:5:925:14 | S2 |
+| main.rs:949:47:949:48 | S1 |  | main.rs:921:5:922:14 | S1 |
+| main.rs:949:51:949:52 | S2 |  | main.rs:924:5:925:14 | S2 |
+| main.rs:950:18:950:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:950:26:950:27 | p1 |  | main.rs:902:5:908:5 | PairOption |
+| main.rs:950:26:950:27 | p1 | Fst | main.rs:921:5:922:14 | S1 |
+| main.rs:950:26:950:27 | p1 | Snd | main.rs:924:5:925:14 | S2 |
+| main.rs:953:13:953:14 | p2 |  | main.rs:902:5:908:5 | PairOption |
+| main.rs:953:13:953:14 | p2 | Fst | main.rs:921:5:922:14 | S1 |
+| main.rs:953:13:953:14 | p2 | Snd | main.rs:924:5:925:14 | S2 |
+| main.rs:953:26:953:47 | ...::PairNone(...) |  | main.rs:902:5:908:5 | PairOption |
+| main.rs:953:26:953:47 | ...::PairNone(...) | Fst | main.rs:921:5:922:14 | S1 |
+| main.rs:953:26:953:47 | ...::PairNone(...) | Snd | main.rs:924:5:925:14 | S2 |
+| main.rs:954:18:954:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:954:26:954:27 | p2 |  | main.rs:902:5:908:5 | PairOption |
+| main.rs:954:26:954:27 | p2 | Fst | main.rs:921:5:922:14 | S1 |
+| main.rs:954:26:954:27 | p2 | Snd | main.rs:924:5:925:14 | S2 |
+| main.rs:957:13:957:14 | p3 |  | main.rs:902:5:908:5 | PairOption |
+| main.rs:957:13:957:14 | p3 | Fst | main.rs:924:5:925:14 | S2 |
+| main.rs:957:13:957:14 | p3 | Snd | main.rs:927:5:928:14 | S3 |
+| main.rs:957:34:957:56 | ...::PairSnd(...) |  | main.rs:902:5:908:5 | PairOption |
+| main.rs:957:34:957:56 | ...::PairSnd(...) | Fst | main.rs:924:5:925:14 | S2 |
+| main.rs:957:34:957:56 | ...::PairSnd(...) | Snd | main.rs:927:5:928:14 | S3 |
+| main.rs:957:54:957:55 | S3 |  | main.rs:927:5:928:14 | S3 |
+| main.rs:958:18:958:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:958:26:958:27 | p3 |  | main.rs:902:5:908:5 | PairOption |
+| main.rs:958:26:958:27 | p3 | Fst | main.rs:924:5:925:14 | S2 |
+| main.rs:958:26:958:27 | p3 | Snd | main.rs:927:5:928:14 | S3 |
+| main.rs:961:13:961:14 | p3 |  | main.rs:902:5:908:5 | PairOption |
+| main.rs:961:13:961:14 | p3 | Fst | main.rs:924:5:925:14 | S2 |
+| main.rs:961:13:961:14 | p3 | Snd | main.rs:927:5:928:14 | S3 |
+| main.rs:961:35:961:56 | ...::PairNone(...) |  | main.rs:902:5:908:5 | PairOption |
+| main.rs:961:35:961:56 | ...::PairNone(...) | Fst | main.rs:924:5:925:14 | S2 |
+| main.rs:961:35:961:56 | ...::PairNone(...) | Snd | main.rs:927:5:928:14 | S3 |
+| main.rs:962:18:962:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:962:26:962:27 | p3 |  | main.rs:902:5:908:5 | PairOption |
+| main.rs:962:26:962:27 | p3 | Fst | main.rs:924:5:925:14 | S2 |
+| main.rs:962:26:962:27 | p3 | Snd | main.rs:927:5:928:14 | S3 |
+| main.rs:964:11:964:54 | ...::PairSnd(...) |  | main.rs:902:5:908:5 | PairOption |
+| main.rs:964:11:964:54 | ...::PairSnd(...) | Fst | main.rs:924:5:925:14 | S2 |
+| main.rs:964:11:964:54 | ...::PairSnd(...) | Snd | main.rs:902:5:908:5 | PairOption |
+| main.rs:964:11:964:54 | ...::PairSnd(...) | Snd.Fst | main.rs:924:5:925:14 | S2 |
+| main.rs:964:11:964:54 | ...::PairSnd(...) | Snd.Snd | main.rs:927:5:928:14 | S3 |
+| main.rs:964:31:964:53 | ...::PairSnd(...) |  | main.rs:902:5:908:5 | PairOption |
+| main.rs:964:31:964:53 | ...::PairSnd(...) | Fst | main.rs:924:5:925:14 | S2 |
+| main.rs:964:31:964:53 | ...::PairSnd(...) | Snd | main.rs:927:5:928:14 | S3 |
+| main.rs:964:51:964:52 | S3 |  | main.rs:927:5:928:14 | S3 |
+| main.rs:977:16:977:24 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:977:16:977:24 | SelfParam | &T | main.rs:975:5:982:5 | Self [trait MyTrait] |
+| main.rs:977:27:977:31 | value |  | main.rs:975:19:975:19 | S |
+| main.rs:979:21:979:29 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:979:21:979:29 | SelfParam | &T | main.rs:975:5:982:5 | Self [trait MyTrait] |
+| main.rs:979:32:979:36 | value |  | main.rs:975:19:975:19 | S |
+| main.rs:980:13:980:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:980:13:980:16 | self | &T | main.rs:975:5:982:5 | Self [trait MyTrait] |
+| main.rs:980:22:980:26 | value |  | main.rs:975:19:975:19 | S |
+| main.rs:986:16:986:24 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:986:16:986:24 | SelfParam | &T | main.rs:969:5:973:5 | MyOption |
+| main.rs:986:16:986:24 | SelfParam | &T.T | main.rs:984:10:984:10 | T |
+| main.rs:986:27:986:31 | value |  | main.rs:984:10:984:10 | T |
+| main.rs:990:26:992:9 | { ... } |  | main.rs:969:5:973:5 | MyOption |
+| main.rs:990:26:992:9 | { ... } | T | main.rs:989:10:989:10 | T |
+| main.rs:991:13:991:30 | ...::MyNone(...) |  | main.rs:969:5:973:5 | MyOption |
+| main.rs:991:13:991:30 | ...::MyNone(...) | T | main.rs:989:10:989:10 | T |
+| main.rs:996:20:996:23 | SelfParam |  | main.rs:969:5:973:5 | MyOption |
+| main.rs:996:20:996:23 | SelfParam | T | main.rs:969:5:973:5 | MyOption |
+| main.rs:996:20:996:23 | SelfParam | T.T | main.rs:995:10:995:10 | T |
+| main.rs:996:41:1001:9 | { ... } |  | main.rs:969:5:973:5 | MyOption |
+| main.rs:996:41:1001:9 | { ... } | T | main.rs:995:10:995:10 | T |
+| main.rs:997:13:1000:13 | match self { ... } |  | main.rs:969:5:973:5 | MyOption |
+| main.rs:997:13:1000:13 | match self { ... } | T | main.rs:995:10:995:10 | T |
+| main.rs:997:19:997:22 | self |  | main.rs:969:5:973:5 | MyOption |
+| main.rs:997:19:997:22 | self | T | main.rs:969:5:973:5 | MyOption |
+| main.rs:997:19:997:22 | self | T.T | main.rs:995:10:995:10 | T |
+| main.rs:998:39:998:56 | ...::MyNone(...) |  | main.rs:969:5:973:5 | MyOption |
+| main.rs:998:39:998:56 | ...::MyNone(...) | T | main.rs:995:10:995:10 | T |
+| main.rs:999:34:999:34 | x |  | main.rs:969:5:973:5 | MyOption |
+| main.rs:999:34:999:34 | x | T | main.rs:995:10:995:10 | T |
+| main.rs:999:40:999:40 | x |  | main.rs:969:5:973:5 | MyOption |
+| main.rs:999:40:999:40 | x | T | main.rs:995:10:995:10 | T |
+| main.rs:1008:13:1008:14 | x1 |  | main.rs:969:5:973:5 | MyOption |
+| main.rs:1008:18:1008:37 | ...::new(...) |  | main.rs:969:5:973:5 | MyOption |
+| main.rs:1009:18:1009:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:1009:26:1009:27 | x1 |  | main.rs:969:5:973:5 | MyOption |
+| main.rs:1011:13:1011:18 | mut x2 |  | main.rs:969:5:973:5 | MyOption |
+| main.rs:1011:13:1011:18 | mut x2 | T | main.rs:1004:5:1005:13 | S |
+| main.rs:1011:22:1011:36 | ...::new(...) |  | main.rs:969:5:973:5 | MyOption |
+| main.rs:1011:22:1011:36 | ...::new(...) | T | main.rs:1004:5:1005:13 | S |
+| main.rs:1012:9:1012:10 | x2 |  | main.rs:969:5:973:5 | MyOption |
+| main.rs:1012:9:1012:10 | x2 | T | main.rs:1004:5:1005:13 | S |
+| main.rs:1012:16:1012:16 | S |  | main.rs:1004:5:1005:13 | S |
+| main.rs:1013:18:1013:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:1013:26:1013:27 | x2 |  | main.rs:969:5:973:5 | MyOption |
+| main.rs:1013:26:1013:27 | x2 | T | main.rs:1004:5:1005:13 | S |
+| main.rs:1015:13:1015:18 | mut x3 |  | main.rs:969:5:973:5 | MyOption |
+| main.rs:1015:22:1015:36 | ...::new(...) |  | main.rs:969:5:973:5 | MyOption |
+| main.rs:1016:9:1016:10 | x3 |  | main.rs:969:5:973:5 | MyOption |
+| main.rs:1016:21:1016:21 | S |  | main.rs:1004:5:1005:13 | S |
+| main.rs:1017:18:1017:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:1017:26:1017:27 | x3 |  | main.rs:969:5:973:5 | MyOption |
+| main.rs:1019:13:1019:18 | mut x4 |  | main.rs:969:5:973:5 | MyOption |
+| main.rs:1019:13:1019:18 | mut x4 | T | main.rs:1004:5:1005:13 | S |
+| main.rs:1019:22:1019:36 | ...::new(...) |  | main.rs:969:5:973:5 | MyOption |
+| main.rs:1019:22:1019:36 | ...::new(...) | T | main.rs:1004:5:1005:13 | S |
+| main.rs:1020:23:1020:29 | &mut x4 |  | file://:0:0:0:0 | & |
+| main.rs:1020:23:1020:29 | &mut x4 | &T | main.rs:969:5:973:5 | MyOption |
+| main.rs:1020:23:1020:29 | &mut x4 | &T.T | main.rs:1004:5:1005:13 | S |
+| main.rs:1020:28:1020:29 | x4 |  | main.rs:969:5:973:5 | MyOption |
+| main.rs:1020:28:1020:29 | x4 | T | main.rs:1004:5:1005:13 | S |
+| main.rs:1020:32:1020:32 | S |  | main.rs:1004:5:1005:13 | S |
+| main.rs:1021:18:1021:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:1021:26:1021:27 | x4 |  | main.rs:969:5:973:5 | MyOption |
+| main.rs:1021:26:1021:27 | x4 | T | main.rs:1004:5:1005:13 | S |
+| main.rs:1023:13:1023:14 | x5 |  | main.rs:969:5:973:5 | MyOption |
+| main.rs:1023:13:1023:14 | x5 | T | main.rs:969:5:973:5 | MyOption |
+| main.rs:1023:13:1023:14 | x5 | T.T | main.rs:1004:5:1005:13 | S |
+| main.rs:1023:18:1023:58 | ...::MySome(...) |  | main.rs:969:5:973:5 | MyOption |
+| main.rs:1023:18:1023:58 | ...::MySome(...) | T | main.rs:969:5:973:5 | MyOption |
+| main.rs:1023:18:1023:58 | ...::MySome(...) | T.T | main.rs:1004:5:1005:13 | S |
+| main.rs:1023:35:1023:57 | ...::MyNone(...) |  | main.rs:969:5:973:5 | MyOption |
+| main.rs:1023:35:1023:57 | ...::MyNone(...) | T | main.rs:1004:5:1005:13 | S |
+| main.rs:1024:18:1024:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:1024:26:1024:27 | x5 |  | main.rs:969:5:973:5 | MyOption |
+| main.rs:1024:26:1024:27 | x5 | T | main.rs:969:5:973:5 | MyOption |
+| main.rs:1024:26:1024:27 | x5 | T.T | main.rs:1004:5:1005:13 | S |
+| main.rs:1024:26:1024:37 | x5.flatten() |  | main.rs:969:5:973:5 | MyOption |
+| main.rs:1024:26:1024:37 | x5.flatten() | T | main.rs:1004:5:1005:13 | S |
+| main.rs:1026:13:1026:14 | x6 |  | main.rs:969:5:973:5 | MyOption |
+| main.rs:1026:13:1026:14 | x6 | T | main.rs:969:5:973:5 | MyOption |
+| main.rs:1026:13:1026:14 | x6 | T.T | main.rs:1004:5:1005:13 | S |
+| main.rs:1026:18:1026:58 | ...::MySome(...) |  | main.rs:969:5:973:5 | MyOption |
+| main.rs:1026:18:1026:58 | ...::MySome(...) | T | main.rs:969:5:973:5 | MyOption |
+| main.rs:1026:18:1026:58 | ...::MySome(...) | T.T | main.rs:1004:5:1005:13 | S |
+| main.rs:1026:35:1026:57 | ...::MyNone(...) |  | main.rs:969:5:973:5 | MyOption |
+| main.rs:1026:35:1026:57 | ...::MyNone(...) | T | main.rs:1004:5:1005:13 | S |
+| main.rs:1027:18:1027:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:1027:26:1027:61 | ...::flatten(...) |  | main.rs:969:5:973:5 | MyOption |
+| main.rs:1027:26:1027:61 | ...::flatten(...) | T | main.rs:1004:5:1005:13 | S |
+| main.rs:1027:59:1027:60 | x6 |  | main.rs:969:5:973:5 | MyOption |
+| main.rs:1027:59:1027:60 | x6 | T | main.rs:969:5:973:5 | MyOption |
+| main.rs:1027:59:1027:60 | x6 | T.T | main.rs:1004:5:1005:13 | S |
+| main.rs:1030:13:1030:19 | from_if |  | main.rs:969:5:973:5 | MyOption |
+| main.rs:1030:13:1030:19 | from_if | T | main.rs:1004:5:1005:13 | S |
+| main.rs:1030:23:1034:9 | if ... {...} else {...} |  | main.rs:969:5:973:5 | MyOption |
+| main.rs:1030:23:1034:9 | if ... {...} else {...} | T | main.rs:1004:5:1005:13 | S |
+| main.rs:1030:26:1030:26 | 3 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1030:30:1030:30 | 2 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1030:32:1032:9 | { ... } |  | main.rs:969:5:973:5 | MyOption |
+| main.rs:1030:32:1032:9 | { ... } | T | main.rs:1004:5:1005:13 | S |
+| main.rs:1031:13:1031:30 | ...::MyNone(...) |  | main.rs:969:5:973:5 | MyOption |
+| main.rs:1031:13:1031:30 | ...::MyNone(...) | T | main.rs:1004:5:1005:13 | S |
+| main.rs:1032:16:1034:9 | { ... } |  | main.rs:969:5:973:5 | MyOption |
+| main.rs:1032:16:1034:9 | { ... } | T | main.rs:1004:5:1005:13 | S |
+| main.rs:1033:13:1033:31 | ...::MySome(...) |  | main.rs:969:5:973:5 | MyOption |
+| main.rs:1033:13:1033:31 | ...::MySome(...) | T | main.rs:1004:5:1005:13 | S |
+| main.rs:1033:30:1033:30 | S |  | main.rs:1004:5:1005:13 | S |
+| main.rs:1035:18:1035:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:1035:26:1035:32 | from_if |  | main.rs:969:5:973:5 | MyOption |
+| main.rs:1035:26:1035:32 | from_if | T | main.rs:1004:5:1005:13 | S |
+| main.rs:1038:13:1038:22 | from_match |  | main.rs:969:5:973:5 | MyOption |
+| main.rs:1038:13:1038:22 | from_match | T | main.rs:1004:5:1005:13 | S |
+| main.rs:1038:26:1041:9 | match ... { ... } |  | main.rs:969:5:973:5 | MyOption |
+| main.rs:1038:26:1041:9 | match ... { ... } | T | main.rs:1004:5:1005:13 | S |
+| main.rs:1038:32:1038:32 | 3 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1038:36:1038:36 | 2 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1039:13:1039:16 | true |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1039:21:1039:38 | ...::MyNone(...) |  | main.rs:969:5:973:5 | MyOption |
+| main.rs:1039:21:1039:38 | ...::MyNone(...) | T | main.rs:1004:5:1005:13 | S |
+| main.rs:1040:13:1040:17 | false |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1040:22:1040:40 | ...::MySome(...) |  | main.rs:969:5:973:5 | MyOption |
+| main.rs:1040:22:1040:40 | ...::MySome(...) | T | main.rs:1004:5:1005:13 | S |
+| main.rs:1040:39:1040:39 | S |  | main.rs:1004:5:1005:13 | S |
+| main.rs:1042:18:1042:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:1042:26:1042:35 | from_match |  | main.rs:969:5:973:5 | MyOption |
+| main.rs:1042:26:1042:35 | from_match | T | main.rs:1004:5:1005:13 | S |
+| main.rs:1045:13:1045:21 | from_loop |  | main.rs:969:5:973:5 | MyOption |
+| main.rs:1045:13:1045:21 | from_loop | T | main.rs:1004:5:1005:13 | S |
+| main.rs:1045:25:1050:9 | loop { ... } |  | main.rs:969:5:973:5 | MyOption |
+| main.rs:1045:25:1050:9 | loop { ... } | T | main.rs:1004:5:1005:13 | S |
+| main.rs:1046:16:1046:16 | 3 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1046:20:1046:20 | 2 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1047:23:1047:40 | ...::MyNone(...) |  | main.rs:969:5:973:5 | MyOption |
+| main.rs:1047:23:1047:40 | ...::MyNone(...) | T | main.rs:1004:5:1005:13 | S |
+| main.rs:1049:19:1049:37 | ...::MySome(...) |  | main.rs:969:5:973:5 | MyOption |
+| main.rs:1049:19:1049:37 | ...::MySome(...) | T | main.rs:1004:5:1005:13 | S |
+| main.rs:1049:36:1049:36 | S |  | main.rs:1004:5:1005:13 | S |
+| main.rs:1051:18:1051:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:1051:26:1051:34 | from_loop |  | main.rs:969:5:973:5 | MyOption |
+| main.rs:1051:26:1051:34 | from_loop | T | main.rs:1004:5:1005:13 | S |
+| main.rs:1064:15:1064:18 | SelfParam |  | main.rs:1057:5:1058:19 | S |
+| main.rs:1064:15:1064:18 | SelfParam | T | main.rs:1063:10:1063:10 | T |
+| main.rs:1064:26:1066:9 | { ... } |  | main.rs:1063:10:1063:10 | T |
+| main.rs:1065:13:1065:16 | self |  | main.rs:1057:5:1058:19 | S |
+| main.rs:1065:13:1065:16 | self | T | main.rs:1063:10:1063:10 | T |
+| main.rs:1065:13:1065:18 | self.0 |  | main.rs:1063:10:1063:10 | T |
+| main.rs:1068:15:1068:19 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1068:15:1068:19 | SelfParam | &T | main.rs:1057:5:1058:19 | S |
+| main.rs:1068:15:1068:19 | SelfParam | &T.T | main.rs:1063:10:1063:10 | T |
+| main.rs:1068:28:1070:9 | { ... } |  | file://:0:0:0:0 | & |
+| main.rs:1068:28:1070:9 | { ... } | &T | main.rs:1063:10:1063:10 | T |
+| main.rs:1069:13:1069:19 | &... |  | file://:0:0:0:0 | & |
+| main.rs:1069:13:1069:19 | &... | &T | main.rs:1063:10:1063:10 | T |
+| main.rs:1069:14:1069:17 | self |  | file://:0:0:0:0 | & |
+| main.rs:1069:14:1069:17 | self | &T | main.rs:1057:5:1058:19 | S |
+| main.rs:1069:14:1069:17 | self | &T.T | main.rs:1063:10:1063:10 | T |
+| main.rs:1069:14:1069:19 | self.0 |  | main.rs:1063:10:1063:10 | T |
+| main.rs:1072:15:1072:25 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1072:15:1072:25 | SelfParam | &T | main.rs:1057:5:1058:19 | S |
+| main.rs:1072:15:1072:25 | SelfParam | &T.T | main.rs:1063:10:1063:10 | T |
+| main.rs:1072:34:1074:9 | { ... } |  | file://:0:0:0:0 | & |
+| main.rs:1072:34:1074:9 | { ... } | &T | main.rs:1063:10:1063:10 | T |
+| main.rs:1073:13:1073:19 | &... |  | file://:0:0:0:0 | & |
+| main.rs:1073:13:1073:19 | &... | &T | main.rs:1063:10:1063:10 | T |
+| main.rs:1073:14:1073:17 | self |  | file://:0:0:0:0 | & |
+| main.rs:1073:14:1073:17 | self | &T | main.rs:1057:5:1058:19 | S |
+| main.rs:1073:14:1073:17 | self | &T.T | main.rs:1063:10:1063:10 | T |
+| main.rs:1073:14:1073:19 | self.0 |  | main.rs:1063:10:1063:10 | T |
+| main.rs:1078:13:1078:14 | x1 |  | main.rs:1057:5:1058:19 | S |
+| main.rs:1078:13:1078:14 | x1 | T | main.rs:1060:5:1061:14 | S2 |
+| main.rs:1078:18:1078:22 | S(...) |  | main.rs:1057:5:1058:19 | S |
+| main.rs:1078:18:1078:22 | S(...) | T | main.rs:1060:5:1061:14 | S2 |
+| main.rs:1078:20:1078:21 | S2 |  | main.rs:1060:5:1061:14 | S2 |
 | main.rs:1079:18:1079:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:1079:26:1079:27 | x2 |  | main.rs:1052:5:1053:19 | S |
-| main.rs:1079:26:1079:27 | x2 | T | main.rs:1055:5:1056:14 | S2 |
-| main.rs:1079:26:1079:32 | x2.m3() |  | file://:0:0:0:0 | & |
-| main.rs:1079:26:1079:32 | x2.m3() | &T | main.rs:1055:5:1056:14 | S2 |
-| main.rs:1081:13:1081:14 | x3 |  | main.rs:1052:5:1053:19 | S |
-| main.rs:1081:13:1081:14 | x3 | T | main.rs:1055:5:1056:14 | S2 |
-| main.rs:1081:18:1081:22 | S(...) |  | main.rs:1052:5:1053:19 | S |
-| main.rs:1081:18:1081:22 | S(...) | T | main.rs:1055:5:1056:14 | S2 |
-| main.rs:1081:20:1081:21 | S2 |  | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1079:26:1079:27 | x1 |  | main.rs:1057:5:1058:19 | S |
+| main.rs:1079:26:1079:27 | x1 | T | main.rs:1060:5:1061:14 | S2 |
+| main.rs:1079:26:1079:32 | x1.m1() |  | main.rs:1060:5:1061:14 | S2 |
+| main.rs:1081:13:1081:14 | x2 |  | main.rs:1057:5:1058:19 | S |
+| main.rs:1081:13:1081:14 | x2 | T | main.rs:1060:5:1061:14 | S2 |
+| main.rs:1081:18:1081:22 | S(...) |  | main.rs:1057:5:1058:19 | S |
+| main.rs:1081:18:1081:22 | S(...) | T | main.rs:1060:5:1061:14 | S2 |
+| main.rs:1081:20:1081:21 | S2 |  | main.rs:1060:5:1061:14 | S2 |
 | main.rs:1083:18:1083:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:1083:26:1083:41 | ...::m2(...) |  | file://:0:0:0:0 | & |
-| main.rs:1083:26:1083:41 | ...::m2(...) | &T | main.rs:1055:5:1056:14 | S2 |
-| main.rs:1083:38:1083:40 | &x3 |  | file://:0:0:0:0 | & |
-| main.rs:1083:38:1083:40 | &x3 | &T | main.rs:1052:5:1053:19 | S |
-| main.rs:1083:38:1083:40 | &x3 | &T.T | main.rs:1055:5:1056:14 | S2 |
-| main.rs:1083:39:1083:40 | x3 |  | main.rs:1052:5:1053:19 | S |
-| main.rs:1083:39:1083:40 | x3 | T | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1083:26:1083:27 | x2 |  | main.rs:1057:5:1058:19 | S |
+| main.rs:1083:26:1083:27 | x2 | T | main.rs:1060:5:1061:14 | S2 |
+| main.rs:1083:26:1083:32 | x2.m2() |  | file://:0:0:0:0 | & |
+| main.rs:1083:26:1083:32 | x2.m2() | &T | main.rs:1060:5:1061:14 | S2 |
 | main.rs:1084:18:1084:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:1084:26:1084:41 | ...::m3(...) |  | file://:0:0:0:0 | & |
-| main.rs:1084:26:1084:41 | ...::m3(...) | &T | main.rs:1055:5:1056:14 | S2 |
-| main.rs:1084:38:1084:40 | &x3 |  | file://:0:0:0:0 | & |
-| main.rs:1084:38:1084:40 | &x3 | &T | main.rs:1052:5:1053:19 | S |
-| main.rs:1084:38:1084:40 | &x3 | &T.T | main.rs:1055:5:1056:14 | S2 |
-| main.rs:1084:39:1084:40 | x3 |  | main.rs:1052:5:1053:19 | S |
-| main.rs:1084:39:1084:40 | x3 | T | main.rs:1055:5:1056:14 | S2 |
-| main.rs:1086:13:1086:14 | x4 |  | file://:0:0:0:0 | & |
-| main.rs:1086:13:1086:14 | x4 | &T | main.rs:1052:5:1053:19 | S |
-| main.rs:1086:13:1086:14 | x4 | &T.T | main.rs:1055:5:1056:14 | S2 |
-| main.rs:1086:18:1086:23 | &... |  | file://:0:0:0:0 | & |
-| main.rs:1086:18:1086:23 | &... | &T | main.rs:1052:5:1053:19 | S |
-| main.rs:1086:18:1086:23 | &... | &T.T | main.rs:1055:5:1056:14 | S2 |
-| main.rs:1086:19:1086:23 | S(...) |  | main.rs:1052:5:1053:19 | S |
-| main.rs:1086:19:1086:23 | S(...) | T | main.rs:1055:5:1056:14 | S2 |
-| main.rs:1086:21:1086:22 | S2 |  | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1084:26:1084:27 | x2 |  | main.rs:1057:5:1058:19 | S |
+| main.rs:1084:26:1084:27 | x2 | T | main.rs:1060:5:1061:14 | S2 |
+| main.rs:1084:26:1084:32 | x2.m3() |  | file://:0:0:0:0 | & |
+| main.rs:1084:26:1084:32 | x2.m3() | &T | main.rs:1060:5:1061:14 | S2 |
+| main.rs:1086:13:1086:14 | x3 |  | main.rs:1057:5:1058:19 | S |
+| main.rs:1086:13:1086:14 | x3 | T | main.rs:1060:5:1061:14 | S2 |
+| main.rs:1086:18:1086:22 | S(...) |  | main.rs:1057:5:1058:19 | S |
+| main.rs:1086:18:1086:22 | S(...) | T | main.rs:1060:5:1061:14 | S2 |
+| main.rs:1086:20:1086:21 | S2 |  | main.rs:1060:5:1061:14 | S2 |
 | main.rs:1088:18:1088:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:1088:26:1088:27 | x4 |  | file://:0:0:0:0 | & |
-| main.rs:1088:26:1088:27 | x4 | &T | main.rs:1052:5:1053:19 | S |
-| main.rs:1088:26:1088:27 | x4 | &T.T | main.rs:1055:5:1056:14 | S2 |
-| main.rs:1088:26:1088:32 | x4.m2() |  | file://:0:0:0:0 | & |
-| main.rs:1088:26:1088:32 | x4.m2() | &T | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1088:26:1088:41 | ...::m2(...) |  | file://:0:0:0:0 | & |
+| main.rs:1088:26:1088:41 | ...::m2(...) | &T | main.rs:1060:5:1061:14 | S2 |
+| main.rs:1088:38:1088:40 | &x3 |  | file://:0:0:0:0 | & |
+| main.rs:1088:38:1088:40 | &x3 | &T | main.rs:1057:5:1058:19 | S |
+| main.rs:1088:38:1088:40 | &x3 | &T.T | main.rs:1060:5:1061:14 | S2 |
+| main.rs:1088:39:1088:40 | x3 |  | main.rs:1057:5:1058:19 | S |
+| main.rs:1088:39:1088:40 | x3 | T | main.rs:1060:5:1061:14 | S2 |
 | main.rs:1089:18:1089:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:1089:26:1089:27 | x4 |  | file://:0:0:0:0 | & |
-| main.rs:1089:26:1089:27 | x4 | &T | main.rs:1052:5:1053:19 | S |
-| main.rs:1089:26:1089:27 | x4 | &T.T | main.rs:1055:5:1056:14 | S2 |
-| main.rs:1089:26:1089:32 | x4.m3() |  | file://:0:0:0:0 | & |
-| main.rs:1089:26:1089:32 | x4.m3() | &T | main.rs:1055:5:1056:14 | S2 |
-| main.rs:1091:13:1091:14 | x5 |  | file://:0:0:0:0 | & |
-| main.rs:1091:13:1091:14 | x5 | &T | main.rs:1052:5:1053:19 | S |
-| main.rs:1091:13:1091:14 | x5 | &T.T | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1089:26:1089:41 | ...::m3(...) |  | file://:0:0:0:0 | & |
+| main.rs:1089:26:1089:41 | ...::m3(...) | &T | main.rs:1060:5:1061:14 | S2 |
+| main.rs:1089:38:1089:40 | &x3 |  | file://:0:0:0:0 | & |
+| main.rs:1089:38:1089:40 | &x3 | &T | main.rs:1057:5:1058:19 | S |
+| main.rs:1089:38:1089:40 | &x3 | &T.T | main.rs:1060:5:1061:14 | S2 |
+| main.rs:1089:39:1089:40 | x3 |  | main.rs:1057:5:1058:19 | S |
+| main.rs:1089:39:1089:40 | x3 | T | main.rs:1060:5:1061:14 | S2 |
+| main.rs:1091:13:1091:14 | x4 |  | file://:0:0:0:0 | & |
+| main.rs:1091:13:1091:14 | x4 | &T | main.rs:1057:5:1058:19 | S |
+| main.rs:1091:13:1091:14 | x4 | &T.T | main.rs:1060:5:1061:14 | S2 |
 | main.rs:1091:18:1091:23 | &... |  | file://:0:0:0:0 | & |
-| main.rs:1091:18:1091:23 | &... | &T | main.rs:1052:5:1053:19 | S |
-| main.rs:1091:18:1091:23 | &... | &T.T | main.rs:1055:5:1056:14 | S2 |
-| main.rs:1091:19:1091:23 | S(...) |  | main.rs:1052:5:1053:19 | S |
-| main.rs:1091:19:1091:23 | S(...) | T | main.rs:1055:5:1056:14 | S2 |
-| main.rs:1091:21:1091:22 | S2 |  | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1091:18:1091:23 | &... | &T | main.rs:1057:5:1058:19 | S |
+| main.rs:1091:18:1091:23 | &... | &T.T | main.rs:1060:5:1061:14 | S2 |
+| main.rs:1091:19:1091:23 | S(...) |  | main.rs:1057:5:1058:19 | S |
+| main.rs:1091:19:1091:23 | S(...) | T | main.rs:1060:5:1061:14 | S2 |
+| main.rs:1091:21:1091:22 | S2 |  | main.rs:1060:5:1061:14 | S2 |
 | main.rs:1093:18:1093:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:1093:26:1093:27 | x5 |  | file://:0:0:0:0 | & |
-| main.rs:1093:26:1093:27 | x5 | &T | main.rs:1052:5:1053:19 | S |
-| main.rs:1093:26:1093:27 | x5 | &T.T | main.rs:1055:5:1056:14 | S2 |
-| main.rs:1093:26:1093:32 | x5.m1() |  | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1093:26:1093:27 | x4 |  | file://:0:0:0:0 | & |
+| main.rs:1093:26:1093:27 | x4 | &T | main.rs:1057:5:1058:19 | S |
+| main.rs:1093:26:1093:27 | x4 | &T.T | main.rs:1060:5:1061:14 | S2 |
+| main.rs:1093:26:1093:32 | x4.m2() |  | file://:0:0:0:0 | & |
+| main.rs:1093:26:1093:32 | x4.m2() | &T | main.rs:1060:5:1061:14 | S2 |
 | main.rs:1094:18:1094:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:1094:26:1094:27 | x5 |  | file://:0:0:0:0 | & |
-| main.rs:1094:26:1094:27 | x5 | &T | main.rs:1052:5:1053:19 | S |
-| main.rs:1094:26:1094:27 | x5 | &T.T | main.rs:1055:5:1056:14 | S2 |
-| main.rs:1094:26:1094:29 | x5.0 |  | main.rs:1055:5:1056:14 | S2 |
-| main.rs:1096:13:1096:14 | x6 |  | file://:0:0:0:0 | & |
-| main.rs:1096:13:1096:14 | x6 | &T | main.rs:1052:5:1053:19 | S |
-| main.rs:1096:13:1096:14 | x6 | &T.T | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1094:26:1094:27 | x4 |  | file://:0:0:0:0 | & |
+| main.rs:1094:26:1094:27 | x4 | &T | main.rs:1057:5:1058:19 | S |
+| main.rs:1094:26:1094:27 | x4 | &T.T | main.rs:1060:5:1061:14 | S2 |
+| main.rs:1094:26:1094:32 | x4.m3() |  | file://:0:0:0:0 | & |
+| main.rs:1094:26:1094:32 | x4.m3() | &T | main.rs:1060:5:1061:14 | S2 |
+| main.rs:1096:13:1096:14 | x5 |  | file://:0:0:0:0 | & |
+| main.rs:1096:13:1096:14 | x5 | &T | main.rs:1057:5:1058:19 | S |
+| main.rs:1096:13:1096:14 | x5 | &T.T | main.rs:1060:5:1061:14 | S2 |
 | main.rs:1096:18:1096:23 | &... |  | file://:0:0:0:0 | & |
-| main.rs:1096:18:1096:23 | &... | &T | main.rs:1052:5:1053:19 | S |
-| main.rs:1096:18:1096:23 | &... | &T.T | main.rs:1055:5:1056:14 | S2 |
-| main.rs:1096:19:1096:23 | S(...) |  | main.rs:1052:5:1053:19 | S |
-| main.rs:1096:19:1096:23 | S(...) | T | main.rs:1055:5:1056:14 | S2 |
-| main.rs:1096:21:1096:22 | S2 |  | main.rs:1055:5:1056:14 | S2 |
+| main.rs:1096:18:1096:23 | &... | &T | main.rs:1057:5:1058:19 | S |
+| main.rs:1096:18:1096:23 | &... | &T.T | main.rs:1060:5:1061:14 | S2 |
+| main.rs:1096:19:1096:23 | S(...) |  | main.rs:1057:5:1058:19 | S |
+| main.rs:1096:19:1096:23 | S(...) | T | main.rs:1060:5:1061:14 | S2 |
+| main.rs:1096:21:1096:22 | S2 |  | main.rs:1060:5:1061:14 | S2 |
 | main.rs:1098:18:1098:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:1098:26:1098:30 | (...) |  | main.rs:1052:5:1053:19 | S |
-| main.rs:1098:26:1098:30 | (...) | T | main.rs:1055:5:1056:14 | S2 |
-| main.rs:1098:26:1098:35 | ... .m1() |  | main.rs:1055:5:1056:14 | S2 |
-| main.rs:1098:27:1098:29 | * ... |  | main.rs:1052:5:1053:19 | S |
-| main.rs:1098:27:1098:29 | * ... | T | main.rs:1055:5:1056:14 | S2 |
-| main.rs:1098:28:1098:29 | x6 |  | file://:0:0:0:0 | & |
-| main.rs:1098:28:1098:29 | x6 | &T | main.rs:1052:5:1053:19 | S |
-| main.rs:1098:28:1098:29 | x6 | &T.T | main.rs:1055:5:1056:14 | S2 |
-| main.rs:1100:13:1100:14 | x7 |  | main.rs:1052:5:1053:19 | S |
-| main.rs:1100:13:1100:14 | x7 | T | file://:0:0:0:0 | & |
-| main.rs:1100:13:1100:14 | x7 | T.&T | main.rs:1055:5:1056:14 | S2 |
-| main.rs:1100:18:1100:23 | S(...) |  | main.rs:1052:5:1053:19 | S |
-| main.rs:1100:18:1100:23 | S(...) | T | file://:0:0:0:0 | & |
-| main.rs:1100:18:1100:23 | S(...) | T.&T | main.rs:1055:5:1056:14 | S2 |
-| main.rs:1100:20:1100:22 | &S2 |  | file://:0:0:0:0 | & |
-| main.rs:1100:20:1100:22 | &S2 | &T | main.rs:1055:5:1056:14 | S2 |
-| main.rs:1100:21:1100:22 | S2 |  | main.rs:1055:5:1056:14 | S2 |
-| main.rs:1103:13:1103:13 | t |  | file://:0:0:0:0 | & |
-| main.rs:1103:13:1103:13 | t | &T | main.rs:1055:5:1056:14 | S2 |
-| main.rs:1103:17:1103:18 | x7 |  | main.rs:1052:5:1053:19 | S |
-| main.rs:1103:17:1103:18 | x7 | T | file://:0:0:0:0 | & |
-| main.rs:1103:17:1103:18 | x7 | T.&T | main.rs:1055:5:1056:14 | S2 |
-| main.rs:1103:17:1103:23 | x7.m1() |  | file://:0:0:0:0 | & |
-| main.rs:1103:17:1103:23 | x7.m1() | &T | main.rs:1055:5:1056:14 | S2 |
-| main.rs:1104:18:1104:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:1104:26:1104:27 | x7 |  | main.rs:1052:5:1053:19 | S |
-| main.rs:1104:26:1104:27 | x7 | T | file://:0:0:0:0 | & |
-| main.rs:1104:26:1104:27 | x7 | T.&T | main.rs:1055:5:1056:14 | S2 |
-| main.rs:1111:16:1111:20 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:1111:16:1111:20 | SelfParam | &T | main.rs:1109:5:1117:5 | Self [trait MyTrait] |
-| main.rs:1114:16:1114:20 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:1114:16:1114:20 | SelfParam | &T | main.rs:1109:5:1117:5 | Self [trait MyTrait] |
-| main.rs:1114:32:1116:9 | { ... } |  | file://:0:0:0:0 | & |
-| main.rs:1114:32:1116:9 | { ... } | &T | main.rs:1109:5:1117:5 | Self [trait MyTrait] |
-| main.rs:1115:13:1115:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:1115:13:1115:16 | self | &T | main.rs:1109:5:1117:5 | Self [trait MyTrait] |
-| main.rs:1115:13:1115:22 | self.foo() |  | file://:0:0:0:0 | & |
-| main.rs:1115:13:1115:22 | self.foo() | &T | main.rs:1109:5:1117:5 | Self [trait MyTrait] |
-| main.rs:1123:16:1123:20 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:1123:16:1123:20 | SelfParam | &T | main.rs:1119:5:1119:20 | MyStruct |
-| main.rs:1123:36:1125:9 | { ... } |  | file://:0:0:0:0 | & |
-| main.rs:1123:36:1125:9 | { ... } | &T | main.rs:1119:5:1119:20 | MyStruct |
-| main.rs:1124:13:1124:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:1124:13:1124:16 | self | &T | main.rs:1119:5:1119:20 | MyStruct |
-| main.rs:1129:13:1129:13 | x |  | main.rs:1119:5:1119:20 | MyStruct |
-| main.rs:1129:17:1129:24 | MyStruct |  | main.rs:1119:5:1119:20 | MyStruct |
-| main.rs:1130:9:1130:9 | x |  | main.rs:1119:5:1119:20 | MyStruct |
-| main.rs:1130:9:1130:15 | x.bar() |  | file://:0:0:0:0 | & |
-| main.rs:1130:9:1130:15 | x.bar() | &T | main.rs:1119:5:1119:20 | MyStruct |
-| main.rs:1140:16:1140:20 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:1140:16:1140:20 | SelfParam | &T | main.rs:1137:5:1137:26 | MyStruct |
-| main.rs:1140:16:1140:20 | SelfParam | &T.T | main.rs:1139:10:1139:10 | T |
-| main.rs:1140:32:1142:9 | { ... } |  | file://:0:0:0:0 | & |
-| main.rs:1140:32:1142:9 | { ... } | &T | main.rs:1137:5:1137:26 | MyStruct |
-| main.rs:1140:32:1142:9 | { ... } | &T.T | main.rs:1139:10:1139:10 | T |
-| main.rs:1141:13:1141:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:1141:13:1141:16 | self | &T | main.rs:1137:5:1137:26 | MyStruct |
-| main.rs:1141:13:1141:16 | self | &T.T | main.rs:1139:10:1139:10 | T |
-| main.rs:1146:13:1146:13 | x |  | main.rs:1137:5:1137:26 | MyStruct |
-| main.rs:1146:13:1146:13 | x | T | main.rs:1135:5:1135:13 | S |
-| main.rs:1146:17:1146:27 | MyStruct(...) |  | main.rs:1137:5:1137:26 | MyStruct |
-| main.rs:1146:17:1146:27 | MyStruct(...) | T | main.rs:1135:5:1135:13 | S |
-| main.rs:1146:26:1146:26 | S |  | main.rs:1135:5:1135:13 | S |
-| main.rs:1147:9:1147:9 | x |  | main.rs:1137:5:1137:26 | MyStruct |
-| main.rs:1147:9:1147:9 | x | T | main.rs:1135:5:1135:13 | S |
-| main.rs:1147:9:1147:15 | x.foo() |  | file://:0:0:0:0 | & |
-| main.rs:1147:9:1147:15 | x.foo() | &T | main.rs:1137:5:1137:26 | MyStruct |
-| main.rs:1147:9:1147:15 | x.foo() | &T.T | main.rs:1135:5:1135:13 | S |
-| main.rs:1155:15:1155:19 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:1155:15:1155:19 | SelfParam | &T | main.rs:1152:5:1152:13 | S |
-| main.rs:1155:31:1157:9 | { ... } |  | file://:0:0:0:0 | & |
-| main.rs:1155:31:1157:9 | { ... } | &T | main.rs:1152:5:1152:13 | S |
-| main.rs:1156:13:1156:19 | &... |  | file://:0:0:0:0 | & |
-| main.rs:1156:13:1156:19 | &... | &T | main.rs:1152:5:1152:13 | S |
-| main.rs:1156:14:1156:19 | &... |  | file://:0:0:0:0 | & |
-| main.rs:1156:14:1156:19 | &... | &T | main.rs:1152:5:1152:13 | S |
-| main.rs:1156:15:1156:19 | &self |  | file://:0:0:0:0 | & |
-| main.rs:1156:15:1156:19 | &self | &T | main.rs:1152:5:1152:13 | S |
-| main.rs:1156:16:1156:19 | self |  | file://:0:0:0:0 | & |
-| main.rs:1156:16:1156:19 | self | &T | main.rs:1152:5:1152:13 | S |
-| main.rs:1159:15:1159:25 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:1159:15:1159:25 | SelfParam | &T | main.rs:1152:5:1152:13 | S |
-| main.rs:1159:37:1161:9 | { ... } |  | file://:0:0:0:0 | & |
-| main.rs:1159:37:1161:9 | { ... } | &T | main.rs:1152:5:1152:13 | S |
-| main.rs:1160:13:1160:19 | &... |  | file://:0:0:0:0 | & |
-| main.rs:1160:13:1160:19 | &... | &T | main.rs:1152:5:1152:13 | S |
-| main.rs:1160:14:1160:19 | &... |  | file://:0:0:0:0 | & |
-| main.rs:1160:14:1160:19 | &... | &T | main.rs:1152:5:1152:13 | S |
-| main.rs:1160:15:1160:19 | &self |  | file://:0:0:0:0 | & |
-| main.rs:1160:15:1160:19 | &self | &T | main.rs:1152:5:1152:13 | S |
-| main.rs:1160:16:1160:19 | self |  | file://:0:0:0:0 | & |
-| main.rs:1160:16:1160:19 | self | &T | main.rs:1152:5:1152:13 | S |
-| main.rs:1163:15:1163:15 | x |  | file://:0:0:0:0 | & |
-| main.rs:1163:15:1163:15 | x | &T | main.rs:1152:5:1152:13 | S |
-| main.rs:1163:34:1165:9 | { ... } |  | file://:0:0:0:0 | & |
-| main.rs:1163:34:1165:9 | { ... } | &T | main.rs:1152:5:1152:13 | S |
-| main.rs:1164:13:1164:13 | x |  | file://:0:0:0:0 | & |
-| main.rs:1164:13:1164:13 | x | &T | main.rs:1152:5:1152:13 | S |
-| main.rs:1167:15:1167:15 | x |  | file://:0:0:0:0 | & |
-| main.rs:1167:15:1167:15 | x | &T | main.rs:1152:5:1152:13 | S |
-| main.rs:1167:34:1169:9 | { ... } |  | file://:0:0:0:0 | & |
-| main.rs:1167:34:1169:9 | { ... } | &T | main.rs:1152:5:1152:13 | S |
-| main.rs:1168:13:1168:16 | &... |  | file://:0:0:0:0 | & |
-| main.rs:1168:13:1168:16 | &... | &T | main.rs:1152:5:1152:13 | S |
-| main.rs:1168:14:1168:16 | &... |  | file://:0:0:0:0 | & |
-| main.rs:1168:14:1168:16 | &... | &T | main.rs:1152:5:1152:13 | S |
-| main.rs:1168:15:1168:16 | &x |  | file://:0:0:0:0 | & |
-| main.rs:1168:15:1168:16 | &x | &T | main.rs:1152:5:1152:13 | S |
-| main.rs:1168:16:1168:16 | x |  | file://:0:0:0:0 | & |
-| main.rs:1168:16:1168:16 | x | &T | main.rs:1152:5:1152:13 | S |
-| main.rs:1173:13:1173:13 | x |  | main.rs:1152:5:1152:13 | S |
-| main.rs:1173:17:1173:20 | S {...} |  | main.rs:1152:5:1152:13 | S |
-| main.rs:1174:9:1174:9 | x |  | main.rs:1152:5:1152:13 | S |
-| main.rs:1174:9:1174:14 | x.f1() |  | file://:0:0:0:0 | & |
-| main.rs:1174:9:1174:14 | x.f1() | &T | main.rs:1152:5:1152:13 | S |
-| main.rs:1175:9:1175:9 | x |  | main.rs:1152:5:1152:13 | S |
-| main.rs:1175:9:1175:14 | x.f2() |  | file://:0:0:0:0 | & |
-| main.rs:1175:9:1175:14 | x.f2() | &T | main.rs:1152:5:1152:13 | S |
-| main.rs:1176:9:1176:17 | ...::f3(...) |  | file://:0:0:0:0 | & |
-| main.rs:1176:9:1176:17 | ...::f3(...) | &T | main.rs:1152:5:1152:13 | S |
-| main.rs:1176:15:1176:16 | &x |  | file://:0:0:0:0 | & |
-| main.rs:1176:15:1176:16 | &x | &T | main.rs:1152:5:1152:13 | S |
-| main.rs:1176:16:1176:16 | x |  | main.rs:1152:5:1152:13 | S |
-| main.rs:1190:43:1193:5 | { ... } |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1190:43:1193:5 | { ... } | E | main.rs:1183:5:1184:14 | S1 |
-| main.rs:1190:43:1193:5 | { ... } | T | main.rs:1183:5:1184:14 | S1 |
-| main.rs:1191:13:1191:13 | x |  | main.rs:1183:5:1184:14 | S1 |
-| main.rs:1191:17:1191:30 | ...::Ok(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1191:17:1191:30 | ...::Ok(...) | T | main.rs:1183:5:1184:14 | S1 |
-| main.rs:1191:17:1191:31 | TryExpr |  | main.rs:1183:5:1184:14 | S1 |
-| main.rs:1191:28:1191:29 | S1 |  | main.rs:1183:5:1184:14 | S1 |
-| main.rs:1192:9:1192:22 | ...::Ok(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1192:9:1192:22 | ...::Ok(...) | E | main.rs:1183:5:1184:14 | S1 |
-| main.rs:1192:9:1192:22 | ...::Ok(...) | T | main.rs:1183:5:1184:14 | S1 |
-| main.rs:1192:20:1192:21 | S1 |  | main.rs:1183:5:1184:14 | S1 |
-| main.rs:1196:46:1200:5 | { ... } |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1196:46:1200:5 | { ... } | E | main.rs:1186:5:1187:14 | S2 |
-| main.rs:1196:46:1200:5 | { ... } | T | main.rs:1183:5:1184:14 | S1 |
-| main.rs:1197:13:1197:13 | x |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1197:13:1197:13 | x | T | main.rs:1183:5:1184:14 | S1 |
-| main.rs:1197:17:1197:30 | ...::Ok(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1197:17:1197:30 | ...::Ok(...) | T | main.rs:1183:5:1184:14 | S1 |
-| main.rs:1197:28:1197:29 | S1 |  | main.rs:1183:5:1184:14 | S1 |
-| main.rs:1198:13:1198:13 | y |  | main.rs:1183:5:1184:14 | S1 |
-| main.rs:1198:17:1198:17 | x |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1198:17:1198:17 | x | T | main.rs:1183:5:1184:14 | S1 |
-| main.rs:1198:17:1198:18 | TryExpr |  | main.rs:1183:5:1184:14 | S1 |
-| main.rs:1199:9:1199:22 | ...::Ok(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1199:9:1199:22 | ...::Ok(...) | E | main.rs:1186:5:1187:14 | S2 |
-| main.rs:1199:9:1199:22 | ...::Ok(...) | T | main.rs:1183:5:1184:14 | S1 |
-| main.rs:1199:20:1199:21 | S1 |  | main.rs:1183:5:1184:14 | S1 |
-| main.rs:1203:40:1208:5 | { ... } |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1203:40:1208:5 | { ... } | E | main.rs:1186:5:1187:14 | S2 |
-| main.rs:1203:40:1208:5 | { ... } | T | main.rs:1183:5:1184:14 | S1 |
-| main.rs:1204:13:1204:13 | x |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1204:13:1204:13 | x | T | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1204:13:1204:13 | x | T.T | main.rs:1183:5:1184:14 | S1 |
-| main.rs:1204:17:1204:42 | ...::Ok(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1204:17:1204:42 | ...::Ok(...) | T | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1204:17:1204:42 | ...::Ok(...) | T.T | main.rs:1183:5:1184:14 | S1 |
-| main.rs:1204:28:1204:41 | ...::Ok(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1204:28:1204:41 | ...::Ok(...) | T | main.rs:1183:5:1184:14 | S1 |
-| main.rs:1204:39:1204:40 | S1 |  | main.rs:1183:5:1184:14 | S1 |
-| main.rs:1206:17:1206:17 | x |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1206:17:1206:17 | x | T | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1206:17:1206:17 | x | T.T | main.rs:1183:5:1184:14 | S1 |
-| main.rs:1206:17:1206:18 | TryExpr |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1206:17:1206:18 | TryExpr | T | main.rs:1183:5:1184:14 | S1 |
-| main.rs:1206:17:1206:29 | ... .map(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1207:9:1207:22 | ...::Ok(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1207:9:1207:22 | ...::Ok(...) | E | main.rs:1186:5:1187:14 | S2 |
-| main.rs:1207:9:1207:22 | ...::Ok(...) | T | main.rs:1183:5:1184:14 | S1 |
-| main.rs:1207:20:1207:21 | S1 |  | main.rs:1183:5:1184:14 | S1 |
-| main.rs:1211:30:1211:34 | input |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1211:30:1211:34 | input | E | main.rs:1183:5:1184:14 | S1 |
-| main.rs:1211:30:1211:34 | input | T | main.rs:1211:20:1211:27 | T |
-| main.rs:1211:69:1218:5 | { ... } |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1211:69:1218:5 | { ... } | E | main.rs:1183:5:1184:14 | S1 |
-| main.rs:1211:69:1218:5 | { ... } | T | main.rs:1211:20:1211:27 | T |
-| main.rs:1212:13:1212:17 | value |  | main.rs:1211:20:1211:27 | T |
-| main.rs:1212:21:1212:25 | input |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1212:21:1212:25 | input | E | main.rs:1183:5:1184:14 | S1 |
-| main.rs:1212:21:1212:25 | input | T | main.rs:1211:20:1211:27 | T |
-| main.rs:1212:21:1212:26 | TryExpr |  | main.rs:1211:20:1211:27 | T |
-| main.rs:1213:22:1213:38 | ...::Ok(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1213:22:1213:38 | ...::Ok(...) | T | main.rs:1211:20:1211:27 | T |
-| main.rs:1213:22:1216:10 | ... .and_then(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1213:33:1213:37 | value |  | main.rs:1211:20:1211:27 | T |
-| main.rs:1213:53:1216:9 | { ... } |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1213:53:1216:9 | { ... } | E | main.rs:1183:5:1184:14 | S1 |
-| main.rs:1214:22:1214:27 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:1215:13:1215:34 | ...::Ok::<...>(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1215:13:1215:34 | ...::Ok::<...>(...) | E | main.rs:1183:5:1184:14 | S1 |
-| main.rs:1217:9:1217:23 | ...::Err(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1217:9:1217:23 | ...::Err(...) | E | main.rs:1183:5:1184:14 | S1 |
-| main.rs:1217:9:1217:23 | ...::Err(...) | T | main.rs:1211:20:1211:27 | T |
-| main.rs:1217:21:1217:22 | S1 |  | main.rs:1183:5:1184:14 | S1 |
-| main.rs:1221:37:1221:52 | try_same_error(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1221:37:1221:52 | try_same_error(...) | E | main.rs:1183:5:1184:14 | S1 |
-| main.rs:1221:37:1221:52 | try_same_error(...) | T | main.rs:1183:5:1184:14 | S1 |
-| main.rs:1222:22:1222:27 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:1225:37:1225:55 | try_convert_error(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1225:37:1225:55 | try_convert_error(...) | E | main.rs:1186:5:1187:14 | S2 |
-| main.rs:1225:37:1225:55 | try_convert_error(...) | T | main.rs:1183:5:1184:14 | S1 |
-| main.rs:1226:22:1226:27 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:1229:37:1229:49 | try_chained(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1229:37:1229:49 | try_chained(...) | E | main.rs:1186:5:1187:14 | S2 |
-| main.rs:1229:37:1229:49 | try_chained(...) | T | main.rs:1183:5:1184:14 | S1 |
-| main.rs:1230:22:1230:27 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:1233:37:1233:63 | try_complex(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1233:37:1233:63 | try_complex(...) | E | main.rs:1183:5:1184:14 | S1 |
-| main.rs:1233:37:1233:63 | try_complex(...) | T | main.rs:1183:5:1184:14 | S1 |
-| main.rs:1233:49:1233:62 | ...::Ok(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
-| main.rs:1233:49:1233:62 | ...::Ok(...) | E | main.rs:1183:5:1184:14 | S1 |
-| main.rs:1233:49:1233:62 | ...::Ok(...) | T | main.rs:1183:5:1184:14 | S1 |
-| main.rs:1233:60:1233:61 | S1 |  | main.rs:1183:5:1184:14 | S1 |
-| main.rs:1234:22:1234:27 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:1241:13:1241:13 | x |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:1241:22:1241:22 | 1 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:1242:13:1242:13 | y |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:1242:17:1242:17 | 2 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:1243:17:1243:17 | x |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:1243:21:1243:21 | y |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:1244:13:1244:13 | z |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:1244:17:1244:17 | x |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:1244:17:1244:23 | x.abs() |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:1245:13:1245:13 | c |  | file:///BUILTINS/types.rs:6:1:7:16 | char |
-| main.rs:1245:17:1245:19 | 'c' |  | file:///BUILTINS/types.rs:6:1:7:16 | char |
-| main.rs:1246:13:1246:17 | hello |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:1246:21:1246:27 | "Hello" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
-| main.rs:1247:13:1247:13 | f |  | file:///BUILTINS/types.rs:25:1:25:15 | f64 |
-| main.rs:1247:17:1247:24 | 123.0f64 |  | file:///BUILTINS/types.rs:25:1:25:15 | f64 |
-| main.rs:1248:13:1248:13 | t |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
-| main.rs:1248:17:1248:20 | true |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
-| main.rs:1249:13:1249:13 | f |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
-| main.rs:1249:17:1249:21 | false |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
-| main.rs:1255:13:1255:13 | x |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
-| main.rs:1255:17:1255:20 | true |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
-| main.rs:1255:17:1255:29 | ... && ... |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
-| main.rs:1255:25:1255:29 | false |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
-| main.rs:1256:13:1256:13 | y |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
-| main.rs:1256:17:1256:20 | true |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
-| main.rs:1256:17:1256:29 | ... \|\| ... |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
-| main.rs:1256:25:1256:29 | false |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
-| main.rs:1258:13:1258:17 | mut a |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:1259:12:1259:13 | 34 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:1259:18:1259:19 | 33 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:1260:17:1260:17 | z |  | file://:0:0:0:0 | () |
-| main.rs:1260:21:1260:27 | (...) |  | file://:0:0:0:0 | () |
-| main.rs:1260:22:1260:22 | a |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:1260:22:1260:26 | ... = ... |  | file://:0:0:0:0 | () |
-| main.rs:1260:26:1260:26 | 1 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:1262:13:1262:13 | a |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:1262:13:1262:17 | ... = ... |  | file://:0:0:0:0 | () |
-| main.rs:1262:17:1262:17 | 2 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:1264:9:1264:9 | a |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
-| main.rs:1270:5:1270:20 | ...::f(...) |  | main.rs:67:5:67:21 | Foo |
-| main.rs:1271:5:1271:60 | ...::g(...) |  | main.rs:67:5:67:21 | Foo |
-| main.rs:1271:20:1271:38 | ...::Foo {...} |  | main.rs:67:5:67:21 | Foo |
-| main.rs:1271:41:1271:59 | ...::Foo {...} |  | main.rs:67:5:67:21 | Foo |
+| main.rs:1098:26:1098:27 | x5 |  | file://:0:0:0:0 | & |
+| main.rs:1098:26:1098:27 | x5 | &T | main.rs:1057:5:1058:19 | S |
+| main.rs:1098:26:1098:27 | x5 | &T.T | main.rs:1060:5:1061:14 | S2 |
+| main.rs:1098:26:1098:32 | x5.m1() |  | main.rs:1060:5:1061:14 | S2 |
+| main.rs:1099:18:1099:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:1099:26:1099:27 | x5 |  | file://:0:0:0:0 | & |
+| main.rs:1099:26:1099:27 | x5 | &T | main.rs:1057:5:1058:19 | S |
+| main.rs:1099:26:1099:27 | x5 | &T.T | main.rs:1060:5:1061:14 | S2 |
+| main.rs:1099:26:1099:29 | x5.0 |  | main.rs:1060:5:1061:14 | S2 |
+| main.rs:1101:13:1101:14 | x6 |  | file://:0:0:0:0 | & |
+| main.rs:1101:13:1101:14 | x6 | &T | main.rs:1057:5:1058:19 | S |
+| main.rs:1101:13:1101:14 | x6 | &T.T | main.rs:1060:5:1061:14 | S2 |
+| main.rs:1101:18:1101:23 | &... |  | file://:0:0:0:0 | & |
+| main.rs:1101:18:1101:23 | &... | &T | main.rs:1057:5:1058:19 | S |
+| main.rs:1101:18:1101:23 | &... | &T.T | main.rs:1060:5:1061:14 | S2 |
+| main.rs:1101:19:1101:23 | S(...) |  | main.rs:1057:5:1058:19 | S |
+| main.rs:1101:19:1101:23 | S(...) | T | main.rs:1060:5:1061:14 | S2 |
+| main.rs:1101:21:1101:22 | S2 |  | main.rs:1060:5:1061:14 | S2 |
+| main.rs:1103:18:1103:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:1103:26:1103:30 | (...) |  | main.rs:1057:5:1058:19 | S |
+| main.rs:1103:26:1103:30 | (...) | T | main.rs:1060:5:1061:14 | S2 |
+| main.rs:1103:26:1103:35 | ... .m1() |  | main.rs:1060:5:1061:14 | S2 |
+| main.rs:1103:27:1103:29 | * ... |  | main.rs:1057:5:1058:19 | S |
+| main.rs:1103:27:1103:29 | * ... | T | main.rs:1060:5:1061:14 | S2 |
+| main.rs:1103:28:1103:29 | x6 |  | file://:0:0:0:0 | & |
+| main.rs:1103:28:1103:29 | x6 | &T | main.rs:1057:5:1058:19 | S |
+| main.rs:1103:28:1103:29 | x6 | &T.T | main.rs:1060:5:1061:14 | S2 |
+| main.rs:1105:13:1105:14 | x7 |  | main.rs:1057:5:1058:19 | S |
+| main.rs:1105:13:1105:14 | x7 | T | file://:0:0:0:0 | & |
+| main.rs:1105:13:1105:14 | x7 | T.&T | main.rs:1060:5:1061:14 | S2 |
+| main.rs:1105:18:1105:23 | S(...) |  | main.rs:1057:5:1058:19 | S |
+| main.rs:1105:18:1105:23 | S(...) | T | file://:0:0:0:0 | & |
+| main.rs:1105:18:1105:23 | S(...) | T.&T | main.rs:1060:5:1061:14 | S2 |
+| main.rs:1105:20:1105:22 | &S2 |  | file://:0:0:0:0 | & |
+| main.rs:1105:20:1105:22 | &S2 | &T | main.rs:1060:5:1061:14 | S2 |
+| main.rs:1105:21:1105:22 | S2 |  | main.rs:1060:5:1061:14 | S2 |
+| main.rs:1108:13:1108:13 | t |  | file://:0:0:0:0 | & |
+| main.rs:1108:13:1108:13 | t | &T | main.rs:1060:5:1061:14 | S2 |
+| main.rs:1108:17:1108:18 | x7 |  | main.rs:1057:5:1058:19 | S |
+| main.rs:1108:17:1108:18 | x7 | T | file://:0:0:0:0 | & |
+| main.rs:1108:17:1108:18 | x7 | T.&T | main.rs:1060:5:1061:14 | S2 |
+| main.rs:1108:17:1108:23 | x7.m1() |  | file://:0:0:0:0 | & |
+| main.rs:1108:17:1108:23 | x7.m1() | &T | main.rs:1060:5:1061:14 | S2 |
+| main.rs:1109:18:1109:23 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:1109:26:1109:27 | x7 |  | main.rs:1057:5:1058:19 | S |
+| main.rs:1109:26:1109:27 | x7 | T | file://:0:0:0:0 | & |
+| main.rs:1109:26:1109:27 | x7 | T.&T | main.rs:1060:5:1061:14 | S2 |
+| main.rs:1116:16:1116:20 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1116:16:1116:20 | SelfParam | &T | main.rs:1114:5:1122:5 | Self [trait MyTrait] |
+| main.rs:1119:16:1119:20 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1119:16:1119:20 | SelfParam | &T | main.rs:1114:5:1122:5 | Self [trait MyTrait] |
+| main.rs:1119:32:1121:9 | { ... } |  | file://:0:0:0:0 | & |
+| main.rs:1119:32:1121:9 | { ... } | &T | main.rs:1114:5:1122:5 | Self [trait MyTrait] |
+| main.rs:1120:13:1120:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1120:13:1120:16 | self | &T | main.rs:1114:5:1122:5 | Self [trait MyTrait] |
+| main.rs:1120:13:1120:22 | self.foo() |  | file://:0:0:0:0 | & |
+| main.rs:1120:13:1120:22 | self.foo() | &T | main.rs:1114:5:1122:5 | Self [trait MyTrait] |
+| main.rs:1128:16:1128:20 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1128:16:1128:20 | SelfParam | &T | main.rs:1124:5:1124:20 | MyStruct |
+| main.rs:1128:36:1130:9 | { ... } |  | file://:0:0:0:0 | & |
+| main.rs:1128:36:1130:9 | { ... } | &T | main.rs:1124:5:1124:20 | MyStruct |
+| main.rs:1129:13:1129:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1129:13:1129:16 | self | &T | main.rs:1124:5:1124:20 | MyStruct |
+| main.rs:1134:13:1134:13 | x |  | main.rs:1124:5:1124:20 | MyStruct |
+| main.rs:1134:17:1134:24 | MyStruct |  | main.rs:1124:5:1124:20 | MyStruct |
+| main.rs:1135:9:1135:9 | x |  | main.rs:1124:5:1124:20 | MyStruct |
+| main.rs:1135:9:1135:15 | x.bar() |  | file://:0:0:0:0 | & |
+| main.rs:1135:9:1135:15 | x.bar() | &T | main.rs:1124:5:1124:20 | MyStruct |
+| main.rs:1145:16:1145:20 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1145:16:1145:20 | SelfParam | &T | main.rs:1142:5:1142:26 | MyStruct |
+| main.rs:1145:16:1145:20 | SelfParam | &T.T | main.rs:1144:10:1144:10 | T |
+| main.rs:1145:32:1147:9 | { ... } |  | file://:0:0:0:0 | & |
+| main.rs:1145:32:1147:9 | { ... } | &T | main.rs:1142:5:1142:26 | MyStruct |
+| main.rs:1145:32:1147:9 | { ... } | &T.T | main.rs:1144:10:1144:10 | T |
+| main.rs:1146:13:1146:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1146:13:1146:16 | self | &T | main.rs:1142:5:1142:26 | MyStruct |
+| main.rs:1146:13:1146:16 | self | &T.T | main.rs:1144:10:1144:10 | T |
+| main.rs:1151:13:1151:13 | x |  | main.rs:1142:5:1142:26 | MyStruct |
+| main.rs:1151:13:1151:13 | x | T | main.rs:1140:5:1140:13 | S |
+| main.rs:1151:17:1151:27 | MyStruct(...) |  | main.rs:1142:5:1142:26 | MyStruct |
+| main.rs:1151:17:1151:27 | MyStruct(...) | T | main.rs:1140:5:1140:13 | S |
+| main.rs:1151:26:1151:26 | S |  | main.rs:1140:5:1140:13 | S |
+| main.rs:1152:9:1152:9 | x |  | main.rs:1142:5:1142:26 | MyStruct |
+| main.rs:1152:9:1152:9 | x | T | main.rs:1140:5:1140:13 | S |
+| main.rs:1152:9:1152:15 | x.foo() |  | file://:0:0:0:0 | & |
+| main.rs:1152:9:1152:15 | x.foo() | &T | main.rs:1142:5:1142:26 | MyStruct |
+| main.rs:1152:9:1152:15 | x.foo() | &T.T | main.rs:1140:5:1140:13 | S |
+| main.rs:1160:15:1160:19 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1160:15:1160:19 | SelfParam | &T | main.rs:1157:5:1157:13 | S |
+| main.rs:1160:31:1162:9 | { ... } |  | file://:0:0:0:0 | & |
+| main.rs:1160:31:1162:9 | { ... } | &T | main.rs:1157:5:1157:13 | S |
+| main.rs:1161:13:1161:19 | &... |  | file://:0:0:0:0 | & |
+| main.rs:1161:13:1161:19 | &... | &T | main.rs:1157:5:1157:13 | S |
+| main.rs:1161:14:1161:19 | &... |  | file://:0:0:0:0 | & |
+| main.rs:1161:14:1161:19 | &... | &T | main.rs:1157:5:1157:13 | S |
+| main.rs:1161:15:1161:19 | &self |  | file://:0:0:0:0 | & |
+| main.rs:1161:15:1161:19 | &self | &T | main.rs:1157:5:1157:13 | S |
+| main.rs:1161:16:1161:19 | self |  | file://:0:0:0:0 | & |
+| main.rs:1161:16:1161:19 | self | &T | main.rs:1157:5:1157:13 | S |
+| main.rs:1164:15:1164:25 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1164:15:1164:25 | SelfParam | &T | main.rs:1157:5:1157:13 | S |
+| main.rs:1164:37:1166:9 | { ... } |  | file://:0:0:0:0 | & |
+| main.rs:1164:37:1166:9 | { ... } | &T | main.rs:1157:5:1157:13 | S |
+| main.rs:1165:13:1165:19 | &... |  | file://:0:0:0:0 | & |
+| main.rs:1165:13:1165:19 | &... | &T | main.rs:1157:5:1157:13 | S |
+| main.rs:1165:14:1165:19 | &... |  | file://:0:0:0:0 | & |
+| main.rs:1165:14:1165:19 | &... | &T | main.rs:1157:5:1157:13 | S |
+| main.rs:1165:15:1165:19 | &self |  | file://:0:0:0:0 | & |
+| main.rs:1165:15:1165:19 | &self | &T | main.rs:1157:5:1157:13 | S |
+| main.rs:1165:16:1165:19 | self |  | file://:0:0:0:0 | & |
+| main.rs:1165:16:1165:19 | self | &T | main.rs:1157:5:1157:13 | S |
+| main.rs:1168:15:1168:15 | x |  | file://:0:0:0:0 | & |
+| main.rs:1168:15:1168:15 | x | &T | main.rs:1157:5:1157:13 | S |
+| main.rs:1168:34:1170:9 | { ... } |  | file://:0:0:0:0 | & |
+| main.rs:1168:34:1170:9 | { ... } | &T | main.rs:1157:5:1157:13 | S |
+| main.rs:1169:13:1169:13 | x |  | file://:0:0:0:0 | & |
+| main.rs:1169:13:1169:13 | x | &T | main.rs:1157:5:1157:13 | S |
+| main.rs:1172:15:1172:15 | x |  | file://:0:0:0:0 | & |
+| main.rs:1172:15:1172:15 | x | &T | main.rs:1157:5:1157:13 | S |
+| main.rs:1172:34:1174:9 | { ... } |  | file://:0:0:0:0 | & |
+| main.rs:1172:34:1174:9 | { ... } | &T | main.rs:1157:5:1157:13 | S |
+| main.rs:1173:13:1173:16 | &... |  | file://:0:0:0:0 | & |
+| main.rs:1173:13:1173:16 | &... | &T | main.rs:1157:5:1157:13 | S |
+| main.rs:1173:14:1173:16 | &... |  | file://:0:0:0:0 | & |
+| main.rs:1173:14:1173:16 | &... | &T | main.rs:1157:5:1157:13 | S |
+| main.rs:1173:15:1173:16 | &x |  | file://:0:0:0:0 | & |
+| main.rs:1173:15:1173:16 | &x | &T | main.rs:1157:5:1157:13 | S |
+| main.rs:1173:16:1173:16 | x |  | file://:0:0:0:0 | & |
+| main.rs:1173:16:1173:16 | x | &T | main.rs:1157:5:1157:13 | S |
+| main.rs:1178:13:1178:13 | x |  | main.rs:1157:5:1157:13 | S |
+| main.rs:1178:17:1178:20 | S {...} |  | main.rs:1157:5:1157:13 | S |
+| main.rs:1179:9:1179:9 | x |  | main.rs:1157:5:1157:13 | S |
+| main.rs:1179:9:1179:14 | x.f1() |  | file://:0:0:0:0 | & |
+| main.rs:1179:9:1179:14 | x.f1() | &T | main.rs:1157:5:1157:13 | S |
+| main.rs:1180:9:1180:9 | x |  | main.rs:1157:5:1157:13 | S |
+| main.rs:1180:9:1180:14 | x.f2() |  | file://:0:0:0:0 | & |
+| main.rs:1180:9:1180:14 | x.f2() | &T | main.rs:1157:5:1157:13 | S |
+| main.rs:1181:9:1181:17 | ...::f3(...) |  | file://:0:0:0:0 | & |
+| main.rs:1181:9:1181:17 | ...::f3(...) | &T | main.rs:1157:5:1157:13 | S |
+| main.rs:1181:15:1181:16 | &x |  | file://:0:0:0:0 | & |
+| main.rs:1181:15:1181:16 | &x | &T | main.rs:1157:5:1157:13 | S |
+| main.rs:1181:16:1181:16 | x |  | main.rs:1157:5:1157:13 | S |
+| main.rs:1195:43:1198:5 | { ... } |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1195:43:1198:5 | { ... } | E | main.rs:1188:5:1189:14 | S1 |
+| main.rs:1195:43:1198:5 | { ... } | T | main.rs:1188:5:1189:14 | S1 |
+| main.rs:1196:13:1196:13 | x |  | main.rs:1188:5:1189:14 | S1 |
+| main.rs:1196:17:1196:30 | ...::Ok(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1196:17:1196:30 | ...::Ok(...) | T | main.rs:1188:5:1189:14 | S1 |
+| main.rs:1196:17:1196:31 | TryExpr |  | main.rs:1188:5:1189:14 | S1 |
+| main.rs:1196:28:1196:29 | S1 |  | main.rs:1188:5:1189:14 | S1 |
+| main.rs:1197:9:1197:22 | ...::Ok(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1197:9:1197:22 | ...::Ok(...) | E | main.rs:1188:5:1189:14 | S1 |
+| main.rs:1197:9:1197:22 | ...::Ok(...) | T | main.rs:1188:5:1189:14 | S1 |
+| main.rs:1197:20:1197:21 | S1 |  | main.rs:1188:5:1189:14 | S1 |
+| main.rs:1201:46:1205:5 | { ... } |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1201:46:1205:5 | { ... } | E | main.rs:1191:5:1192:14 | S2 |
+| main.rs:1201:46:1205:5 | { ... } | T | main.rs:1188:5:1189:14 | S1 |
+| main.rs:1202:13:1202:13 | x |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1202:13:1202:13 | x | T | main.rs:1188:5:1189:14 | S1 |
+| main.rs:1202:17:1202:30 | ...::Ok(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1202:17:1202:30 | ...::Ok(...) | T | main.rs:1188:5:1189:14 | S1 |
+| main.rs:1202:28:1202:29 | S1 |  | main.rs:1188:5:1189:14 | S1 |
+| main.rs:1203:13:1203:13 | y |  | main.rs:1188:5:1189:14 | S1 |
+| main.rs:1203:17:1203:17 | x |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1203:17:1203:17 | x | T | main.rs:1188:5:1189:14 | S1 |
+| main.rs:1203:17:1203:18 | TryExpr |  | main.rs:1188:5:1189:14 | S1 |
+| main.rs:1204:9:1204:22 | ...::Ok(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1204:9:1204:22 | ...::Ok(...) | E | main.rs:1191:5:1192:14 | S2 |
+| main.rs:1204:9:1204:22 | ...::Ok(...) | T | main.rs:1188:5:1189:14 | S1 |
+| main.rs:1204:20:1204:21 | S1 |  | main.rs:1188:5:1189:14 | S1 |
+| main.rs:1208:40:1213:5 | { ... } |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1208:40:1213:5 | { ... } | E | main.rs:1191:5:1192:14 | S2 |
+| main.rs:1208:40:1213:5 | { ... } | T | main.rs:1188:5:1189:14 | S1 |
+| main.rs:1209:13:1209:13 | x |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1209:13:1209:13 | x | T | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1209:13:1209:13 | x | T.T | main.rs:1188:5:1189:14 | S1 |
+| main.rs:1209:17:1209:42 | ...::Ok(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1209:17:1209:42 | ...::Ok(...) | T | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1209:17:1209:42 | ...::Ok(...) | T.T | main.rs:1188:5:1189:14 | S1 |
+| main.rs:1209:28:1209:41 | ...::Ok(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1209:28:1209:41 | ...::Ok(...) | T | main.rs:1188:5:1189:14 | S1 |
+| main.rs:1209:39:1209:40 | S1 |  | main.rs:1188:5:1189:14 | S1 |
+| main.rs:1211:17:1211:17 | x |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1211:17:1211:17 | x | T | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1211:17:1211:17 | x | T.T | main.rs:1188:5:1189:14 | S1 |
+| main.rs:1211:17:1211:18 | TryExpr |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1211:17:1211:18 | TryExpr | T | main.rs:1188:5:1189:14 | S1 |
+| main.rs:1211:17:1211:29 | ... .map(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1212:9:1212:22 | ...::Ok(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1212:9:1212:22 | ...::Ok(...) | E | main.rs:1191:5:1192:14 | S2 |
+| main.rs:1212:9:1212:22 | ...::Ok(...) | T | main.rs:1188:5:1189:14 | S1 |
+| main.rs:1212:20:1212:21 | S1 |  | main.rs:1188:5:1189:14 | S1 |
+| main.rs:1216:30:1216:34 | input |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1216:30:1216:34 | input | E | main.rs:1188:5:1189:14 | S1 |
+| main.rs:1216:30:1216:34 | input | T | main.rs:1216:20:1216:27 | T |
+| main.rs:1216:69:1223:5 | { ... } |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1216:69:1223:5 | { ... } | E | main.rs:1188:5:1189:14 | S1 |
+| main.rs:1216:69:1223:5 | { ... } | T | main.rs:1216:20:1216:27 | T |
+| main.rs:1217:13:1217:17 | value |  | main.rs:1216:20:1216:27 | T |
+| main.rs:1217:21:1217:25 | input |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1217:21:1217:25 | input | E | main.rs:1188:5:1189:14 | S1 |
+| main.rs:1217:21:1217:25 | input | T | main.rs:1216:20:1216:27 | T |
+| main.rs:1217:21:1217:26 | TryExpr |  | main.rs:1216:20:1216:27 | T |
+| main.rs:1218:22:1218:38 | ...::Ok(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1218:22:1218:38 | ...::Ok(...) | T | main.rs:1216:20:1216:27 | T |
+| main.rs:1218:22:1221:10 | ... .and_then(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1218:33:1218:37 | value |  | main.rs:1216:20:1216:27 | T |
+| main.rs:1218:53:1221:9 | { ... } |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1218:53:1221:9 | { ... } | E | main.rs:1188:5:1189:14 | S1 |
+| main.rs:1219:22:1219:27 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:1220:13:1220:34 | ...::Ok::<...>(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1220:13:1220:34 | ...::Ok::<...>(...) | E | main.rs:1188:5:1189:14 | S1 |
+| main.rs:1222:9:1222:23 | ...::Err(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1222:9:1222:23 | ...::Err(...) | E | main.rs:1188:5:1189:14 | S1 |
+| main.rs:1222:9:1222:23 | ...::Err(...) | T | main.rs:1216:20:1216:27 | T |
+| main.rs:1222:21:1222:22 | S1 |  | main.rs:1188:5:1189:14 | S1 |
+| main.rs:1226:37:1226:52 | try_same_error(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1226:37:1226:52 | try_same_error(...) | E | main.rs:1188:5:1189:14 | S1 |
+| main.rs:1226:37:1226:52 | try_same_error(...) | T | main.rs:1188:5:1189:14 | S1 |
+| main.rs:1227:22:1227:27 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:1230:37:1230:55 | try_convert_error(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1230:37:1230:55 | try_convert_error(...) | E | main.rs:1191:5:1192:14 | S2 |
+| main.rs:1230:37:1230:55 | try_convert_error(...) | T | main.rs:1188:5:1189:14 | S1 |
+| main.rs:1231:22:1231:27 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:1234:37:1234:49 | try_chained(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1234:37:1234:49 | try_chained(...) | E | main.rs:1191:5:1192:14 | S2 |
+| main.rs:1234:37:1234:49 | try_chained(...) | T | main.rs:1188:5:1189:14 | S1 |
+| main.rs:1235:22:1235:27 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:1238:37:1238:63 | try_complex(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1238:37:1238:63 | try_complex(...) | E | main.rs:1188:5:1189:14 | S1 |
+| main.rs:1238:37:1238:63 | try_complex(...) | T | main.rs:1188:5:1189:14 | S1 |
+| main.rs:1238:49:1238:62 | ...::Ok(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/result.rs:520:1:538:1 | Result |
+| main.rs:1238:49:1238:62 | ...::Ok(...) | E | main.rs:1188:5:1189:14 | S1 |
+| main.rs:1238:49:1238:62 | ...::Ok(...) | T | main.rs:1188:5:1189:14 | S1 |
+| main.rs:1238:60:1238:61 | S1 |  | main.rs:1188:5:1189:14 | S1 |
+| main.rs:1239:22:1239:27 | "{:?}\\n" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:1246:13:1246:13 | x |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1246:22:1246:22 | 1 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1247:13:1247:13 | y |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1247:17:1247:17 | 2 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1248:17:1248:17 | x |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1248:21:1248:21 | y |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1249:13:1249:13 | z |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1249:17:1249:17 | x |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1249:17:1249:23 | x.abs() |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1250:13:1250:13 | c |  | file:///BUILTINS/types.rs:6:1:7:16 | char |
+| main.rs:1250:17:1250:19 | 'c' |  | file:///BUILTINS/types.rs:6:1:7:16 | char |
+| main.rs:1251:13:1251:17 | hello |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:1251:21:1251:27 | "Hello" |  | file:///BUILTINS/types.rs:8:1:8:15 | str |
+| main.rs:1252:13:1252:13 | f |  | file:///BUILTINS/types.rs:25:1:25:15 | f64 |
+| main.rs:1252:17:1252:24 | 123.0f64 |  | file:///BUILTINS/types.rs:25:1:25:15 | f64 |
+| main.rs:1253:13:1253:13 | t |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1253:17:1253:20 | true |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1254:13:1254:13 | f |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1254:17:1254:21 | false |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1261:13:1261:13 | x |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1261:17:1261:20 | true |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1261:17:1261:29 | ... && ... |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1261:25:1261:29 | false |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1262:13:1262:13 | y |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1262:17:1262:20 | true |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1262:17:1262:29 | ... \|\| ... |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1262:25:1262:29 | false |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1264:13:1264:17 | mut a |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1265:20:1265:21 | 34 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1265:26:1265:27 | 33 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1267:17:1267:17 | z |  | file://:0:0:0:0 | () |
+| main.rs:1267:21:1267:27 | (...) |  | file://:0:0:0:0 | () |
+| main.rs:1267:22:1267:22 | a |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1267:22:1267:26 | ... = ... |  | file://:0:0:0:0 | () |
+| main.rs:1267:26:1267:26 | 1 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1269:13:1269:13 | a |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1269:13:1269:17 | ... = ... |  | file://:0:0:0:0 | () |
+| main.rs:1269:17:1269:17 | 2 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1271:9:1271:9 | a |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1288:16:1288:19 | SelfParam |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1288:22:1288:24 | rhs |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1288:41:1293:9 | { ... } |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1289:13:1292:13 | Vec2 {...} |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1290:20:1290:23 | self |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1290:20:1290:25 | self.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1290:20:1290:33 | ... + ... |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1290:29:1290:31 | rhs |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1290:29:1290:33 | rhs.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1291:20:1291:23 | self |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1291:20:1291:25 | self.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1291:20:1291:33 | ... + ... |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1291:29:1291:31 | rhs |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1291:29:1291:33 | rhs.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1298:23:1298:31 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1298:23:1298:31 | SelfParam | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1298:34:1298:36 | rhs |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1299:13:1299:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1299:13:1299:16 | self | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1299:13:1299:18 | self.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1299:13:1299:27 | ... += ... |  | file://:0:0:0:0 | () |
+| main.rs:1299:23:1299:25 | rhs |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1299:23:1299:27 | rhs.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1300:13:1300:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1300:13:1300:16 | self | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1300:13:1300:18 | self.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1300:13:1300:27 | ... += ... |  | file://:0:0:0:0 | () |
+| main.rs:1300:23:1300:25 | rhs |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1300:23:1300:27 | rhs.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1306:16:1306:19 | SelfParam |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1306:22:1306:24 | rhs |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1306:41:1311:9 | { ... } |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1307:13:1310:13 | Vec2 {...} |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1308:20:1308:23 | self |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1308:20:1308:25 | self.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1308:20:1308:33 | ... - ... |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1308:29:1308:31 | rhs |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1308:29:1308:33 | rhs.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1309:20:1309:23 | self |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1309:20:1309:25 | self.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1309:20:1309:33 | ... - ... |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1309:29:1309:31 | rhs |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1309:29:1309:33 | rhs.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1316:23:1316:31 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1316:23:1316:31 | SelfParam | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1316:34:1316:36 | rhs |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1317:13:1317:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1317:13:1317:16 | self | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1317:13:1317:18 | self.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1317:13:1317:27 | ... -= ... |  | file://:0:0:0:0 | () |
+| main.rs:1317:23:1317:25 | rhs |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1317:23:1317:27 | rhs.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1318:13:1318:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1318:13:1318:16 | self | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1318:13:1318:18 | self.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1318:13:1318:27 | ... -= ... |  | file://:0:0:0:0 | () |
+| main.rs:1318:23:1318:25 | rhs |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1318:23:1318:27 | rhs.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1324:16:1324:19 | SelfParam |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1324:22:1324:24 | rhs |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1324:41:1329:9 | { ... } |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1325:13:1328:13 | Vec2 {...} |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1326:20:1326:23 | self |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1326:20:1326:25 | self.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1326:20:1326:33 | ... * ... |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1326:29:1326:31 | rhs |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1326:29:1326:33 | rhs.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1327:20:1327:23 | self |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1327:20:1327:25 | self.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1327:20:1327:33 | ... * ... |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1327:29:1327:31 | rhs |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1327:29:1327:33 | rhs.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1333:23:1333:31 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1333:23:1333:31 | SelfParam | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1333:34:1333:36 | rhs |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1334:13:1334:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1334:13:1334:16 | self | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1334:13:1334:18 | self.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1334:13:1334:27 | ... *= ... |  | file://:0:0:0:0 | () |
+| main.rs:1334:23:1334:25 | rhs |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1334:23:1334:27 | rhs.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1335:13:1335:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1335:13:1335:16 | self | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1335:13:1335:18 | self.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1335:13:1335:27 | ... *= ... |  | file://:0:0:0:0 | () |
+| main.rs:1335:23:1335:25 | rhs |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1335:23:1335:27 | rhs.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1341:16:1341:19 | SelfParam |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1341:22:1341:24 | rhs |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1341:41:1346:9 | { ... } |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1342:13:1345:13 | Vec2 {...} |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1343:20:1343:23 | self |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1343:20:1343:25 | self.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1343:20:1343:33 | ... / ... |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1343:29:1343:31 | rhs |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1343:29:1343:33 | rhs.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1344:20:1344:23 | self |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1344:20:1344:25 | self.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1344:20:1344:33 | ... / ... |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1344:29:1344:31 | rhs |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1344:29:1344:33 | rhs.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1350:23:1350:31 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1350:23:1350:31 | SelfParam | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1350:34:1350:36 | rhs |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1351:13:1351:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1351:13:1351:16 | self | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1351:13:1351:18 | self.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1351:13:1351:27 | ... /= ... |  | file://:0:0:0:0 | () |
+| main.rs:1351:23:1351:25 | rhs |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1351:23:1351:27 | rhs.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1352:13:1352:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1352:13:1352:16 | self | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1352:13:1352:18 | self.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1352:13:1352:27 | ... /= ... |  | file://:0:0:0:0 | () |
+| main.rs:1352:23:1352:25 | rhs |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1352:23:1352:27 | rhs.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1358:16:1358:19 | SelfParam |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1358:22:1358:24 | rhs |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1358:41:1363:9 | { ... } |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1359:13:1362:13 | Vec2 {...} |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1360:20:1360:23 | self |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1360:20:1360:25 | self.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1360:20:1360:33 | ... % ... |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1360:29:1360:31 | rhs |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1360:29:1360:33 | rhs.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1361:20:1361:23 | self |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1361:20:1361:25 | self.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1361:20:1361:33 | ... % ... |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1361:29:1361:31 | rhs |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1361:29:1361:33 | rhs.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1367:23:1367:31 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1367:23:1367:31 | SelfParam | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1367:34:1367:36 | rhs |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1368:13:1368:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1368:13:1368:16 | self | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1368:13:1368:18 | self.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1368:13:1368:27 | ... %= ... |  | file://:0:0:0:0 | () |
+| main.rs:1368:23:1368:25 | rhs |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1368:23:1368:27 | rhs.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1369:13:1369:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1369:13:1369:16 | self | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1369:13:1369:18 | self.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1369:13:1369:27 | ... %= ... |  | file://:0:0:0:0 | () |
+| main.rs:1369:23:1369:25 | rhs |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1369:23:1369:27 | rhs.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1375:19:1375:22 | SelfParam |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1375:25:1375:27 | rhs |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1375:44:1380:9 | { ... } |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1376:13:1379:13 | Vec2 {...} |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1377:20:1377:23 | self |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1377:20:1377:25 | self.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1377:20:1377:33 | ... & ... |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1377:29:1377:31 | rhs |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1377:29:1377:33 | rhs.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1378:20:1378:23 | self |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1378:20:1378:25 | self.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1378:20:1378:33 | ... & ... |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1378:29:1378:31 | rhs |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1378:29:1378:33 | rhs.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1384:26:1384:34 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1384:26:1384:34 | SelfParam | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1384:37:1384:39 | rhs |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1385:13:1385:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1385:13:1385:16 | self | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1385:13:1385:18 | self.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1385:13:1385:27 | ... &= ... |  | file://:0:0:0:0 | () |
+| main.rs:1385:23:1385:25 | rhs |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1385:23:1385:27 | rhs.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1386:13:1386:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1386:13:1386:16 | self | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1386:13:1386:18 | self.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1386:13:1386:27 | ... &= ... |  | file://:0:0:0:0 | () |
+| main.rs:1386:23:1386:25 | rhs |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1386:23:1386:27 | rhs.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1392:18:1392:21 | SelfParam |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1392:24:1392:26 | rhs |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1392:43:1397:9 | { ... } |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1393:13:1396:13 | Vec2 {...} |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1394:20:1394:23 | self |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1394:20:1394:25 | self.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1394:20:1394:33 | ... \| ... |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1394:29:1394:31 | rhs |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1394:29:1394:33 | rhs.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1395:20:1395:23 | self |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1395:20:1395:25 | self.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1395:20:1395:33 | ... \| ... |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1395:29:1395:31 | rhs |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1395:29:1395:33 | rhs.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1401:25:1401:33 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1401:25:1401:33 | SelfParam | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1401:36:1401:38 | rhs |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1402:13:1402:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1402:13:1402:16 | self | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1402:13:1402:18 | self.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1402:13:1402:27 | ... \|= ... |  | file://:0:0:0:0 | () |
+| main.rs:1402:23:1402:25 | rhs |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1402:23:1402:27 | rhs.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1403:13:1403:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1403:13:1403:16 | self | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1403:13:1403:18 | self.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1403:13:1403:27 | ... \|= ... |  | file://:0:0:0:0 | () |
+| main.rs:1403:23:1403:25 | rhs |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1403:23:1403:27 | rhs.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1409:19:1409:22 | SelfParam |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1409:25:1409:27 | rhs |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1409:44:1414:9 | { ... } |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1410:13:1413:13 | Vec2 {...} |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1411:20:1411:23 | self |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1411:20:1411:25 | self.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1411:20:1411:33 | ... ^ ... |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1411:29:1411:31 | rhs |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1411:29:1411:33 | rhs.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1412:20:1412:23 | self |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1412:20:1412:25 | self.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1412:20:1412:33 | ... ^ ... |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1412:29:1412:31 | rhs |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1412:29:1412:33 | rhs.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1418:26:1418:34 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1418:26:1418:34 | SelfParam | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1418:37:1418:39 | rhs |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1419:13:1419:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1419:13:1419:16 | self | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1419:13:1419:18 | self.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1419:13:1419:27 | ... ^= ... |  | file://:0:0:0:0 | () |
+| main.rs:1419:23:1419:25 | rhs |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1419:23:1419:27 | rhs.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1420:13:1420:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1420:13:1420:16 | self | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1420:13:1420:18 | self.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1420:13:1420:27 | ... ^= ... |  | file://:0:0:0:0 | () |
+| main.rs:1420:23:1420:25 | rhs |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1420:23:1420:27 | rhs.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1426:16:1426:19 | SelfParam |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1426:22:1426:24 | rhs |  | file:///BUILTINS/types.rs:17:1:17:15 | u32 |
+| main.rs:1426:40:1431:9 | { ... } |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1427:13:1430:13 | Vec2 {...} |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1428:20:1428:23 | self |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1428:20:1428:25 | self.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1428:20:1428:32 | ... << ... |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1428:30:1428:32 | rhs |  | file:///BUILTINS/types.rs:17:1:17:15 | u32 |
+| main.rs:1429:20:1429:23 | self |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1429:20:1429:25 | self.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1429:20:1429:32 | ... << ... |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1429:30:1429:32 | rhs |  | file:///BUILTINS/types.rs:17:1:17:15 | u32 |
+| main.rs:1435:23:1435:31 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1435:23:1435:31 | SelfParam | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1435:34:1435:36 | rhs |  | file:///BUILTINS/types.rs:17:1:17:15 | u32 |
+| main.rs:1436:13:1436:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1436:13:1436:16 | self | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1436:13:1436:18 | self.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1436:13:1436:26 | ... <<= ... |  | file://:0:0:0:0 | () |
+| main.rs:1436:24:1436:26 | rhs |  | file:///BUILTINS/types.rs:17:1:17:15 | u32 |
+| main.rs:1437:13:1437:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1437:13:1437:16 | self | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1437:13:1437:18 | self.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1437:13:1437:26 | ... <<= ... |  | file://:0:0:0:0 | () |
+| main.rs:1437:24:1437:26 | rhs |  | file:///BUILTINS/types.rs:17:1:17:15 | u32 |
+| main.rs:1443:16:1443:19 | SelfParam |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1443:22:1443:24 | rhs |  | file:///BUILTINS/types.rs:17:1:17:15 | u32 |
+| main.rs:1443:40:1448:9 | { ... } |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1444:13:1447:13 | Vec2 {...} |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1445:20:1445:23 | self |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1445:20:1445:25 | self.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1445:20:1445:32 | ... >> ... |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1445:30:1445:32 | rhs |  | file:///BUILTINS/types.rs:17:1:17:15 | u32 |
+| main.rs:1446:20:1446:23 | self |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1446:20:1446:25 | self.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1446:20:1446:32 | ... >> ... |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1446:30:1446:32 | rhs |  | file:///BUILTINS/types.rs:17:1:17:15 | u32 |
+| main.rs:1452:23:1452:31 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1452:23:1452:31 | SelfParam | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1452:34:1452:36 | rhs |  | file:///BUILTINS/types.rs:17:1:17:15 | u32 |
+| main.rs:1453:13:1453:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1453:13:1453:16 | self | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1453:13:1453:18 | self.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1453:13:1453:26 | ... >>= ... |  | file://:0:0:0:0 | () |
+| main.rs:1453:24:1453:26 | rhs |  | file:///BUILTINS/types.rs:17:1:17:15 | u32 |
+| main.rs:1454:13:1454:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1454:13:1454:16 | self | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1454:13:1454:18 | self.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1454:13:1454:26 | ... >>= ... |  | file://:0:0:0:0 | () |
+| main.rs:1454:24:1454:26 | rhs |  | file:///BUILTINS/types.rs:17:1:17:15 | u32 |
+| main.rs:1460:16:1460:19 | SelfParam |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1460:30:1465:9 | { ... } |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1461:13:1464:13 | Vec2 {...} |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1462:20:1462:26 | - ... |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1462:21:1462:24 | self |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1462:21:1462:26 | self.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1463:20:1463:26 | - ... |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1463:21:1463:24 | self |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1463:21:1463:26 | self.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1470:16:1470:19 | SelfParam |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1470:30:1475:9 | { ... } |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1471:13:1474:13 | Vec2 {...} |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1472:20:1472:26 | ! ... |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1472:21:1472:24 | self |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1472:21:1472:26 | self.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1473:20:1473:26 | ! ... |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1473:21:1473:24 | self |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1473:21:1473:26 | self.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1479:15:1479:19 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1479:15:1479:19 | SelfParam | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1479:22:1479:26 | other |  | file://:0:0:0:0 | & |
+| main.rs:1479:22:1479:26 | other | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1479:44:1481:9 | { ... } |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1480:13:1480:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1480:13:1480:16 | self | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1480:13:1480:18 | self.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1480:13:1480:29 | ... == ... |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1480:13:1480:50 | ... && ... |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1480:23:1480:27 | other |  | file://:0:0:0:0 | & |
+| main.rs:1480:23:1480:27 | other | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1480:23:1480:29 | other.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1480:34:1480:37 | self |  | file://:0:0:0:0 | & |
+| main.rs:1480:34:1480:37 | self | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1480:34:1480:39 | self.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1480:34:1480:50 | ... == ... |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1480:44:1480:48 | other |  | file://:0:0:0:0 | & |
+| main.rs:1480:44:1480:48 | other | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1480:44:1480:50 | other.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1483:15:1483:19 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1483:15:1483:19 | SelfParam | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1483:22:1483:26 | other |  | file://:0:0:0:0 | & |
+| main.rs:1483:22:1483:26 | other | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1483:44:1485:9 | { ... } |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1484:13:1484:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1484:13:1484:16 | self | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1484:13:1484:18 | self.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1484:13:1484:29 | ... != ... |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1484:13:1484:50 | ... \|\| ... |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1484:23:1484:27 | other |  | file://:0:0:0:0 | & |
+| main.rs:1484:23:1484:27 | other | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1484:23:1484:29 | other.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1484:34:1484:37 | self |  | file://:0:0:0:0 | & |
+| main.rs:1484:34:1484:37 | self | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1484:34:1484:39 | self.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1484:34:1484:50 | ... != ... |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1484:44:1484:48 | other |  | file://:0:0:0:0 | & |
+| main.rs:1484:44:1484:48 | other | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1484:44:1484:50 | other.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1489:24:1489:28 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1489:24:1489:28 | SelfParam | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1489:31:1489:35 | other |  | file://:0:0:0:0 | & |
+| main.rs:1489:31:1489:35 | other | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1489:75:1491:9 | { ... } |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/option.rs:565:1:581:1 | Option |
+| main.rs:1489:75:1491:9 | { ... } | T | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/cmp.rs:367:1:397:1 | Ordering |
+| main.rs:1490:13:1490:63 | ... .partial_cmp(...) |  | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/option.rs:565:1:581:1 | Option |
+| main.rs:1490:13:1490:63 | ... .partial_cmp(...) | T | file:///RUSTUP_HOME/toolchain/lib/rustlib/src/rust/library/core/src/cmp.rs:367:1:397:1 | Ordering |
+| main.rs:1490:14:1490:17 | self |  | file://:0:0:0:0 | & |
+| main.rs:1490:14:1490:17 | self | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1490:14:1490:19 | self.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1490:23:1490:26 | self |  | file://:0:0:0:0 | & |
+| main.rs:1490:23:1490:26 | self | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1490:23:1490:28 | self.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1490:43:1490:62 | &... |  | file://:0:0:0:0 | & |
+| main.rs:1490:45:1490:49 | other |  | file://:0:0:0:0 | & |
+| main.rs:1490:45:1490:49 | other | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1490:45:1490:51 | other.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1490:55:1490:59 | other |  | file://:0:0:0:0 | & |
+| main.rs:1490:55:1490:59 | other | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1490:55:1490:61 | other.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1493:15:1493:19 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1493:15:1493:19 | SelfParam | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1493:22:1493:26 | other |  | file://:0:0:0:0 | & |
+| main.rs:1493:22:1493:26 | other | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1493:44:1495:9 | { ... } |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1494:13:1494:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1494:13:1494:16 | self | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1494:13:1494:18 | self.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1494:13:1494:28 | ... < ... |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1494:13:1494:48 | ... && ... |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1494:22:1494:26 | other |  | file://:0:0:0:0 | & |
+| main.rs:1494:22:1494:26 | other | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1494:22:1494:28 | other.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1494:33:1494:36 | self |  | file://:0:0:0:0 | & |
+| main.rs:1494:33:1494:36 | self | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1494:33:1494:38 | self.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1494:33:1494:48 | ... < ... |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1494:42:1494:46 | other |  | file://:0:0:0:0 | & |
+| main.rs:1494:42:1494:46 | other | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1494:42:1494:48 | other.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1497:15:1497:19 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1497:15:1497:19 | SelfParam | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1497:22:1497:26 | other |  | file://:0:0:0:0 | & |
+| main.rs:1497:22:1497:26 | other | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1497:44:1499:9 | { ... } |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1498:13:1498:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1498:13:1498:16 | self | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1498:13:1498:18 | self.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1498:13:1498:29 | ... <= ... |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1498:13:1498:50 | ... && ... |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1498:23:1498:27 | other |  | file://:0:0:0:0 | & |
+| main.rs:1498:23:1498:27 | other | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1498:23:1498:29 | other.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1498:34:1498:37 | self |  | file://:0:0:0:0 | & |
+| main.rs:1498:34:1498:37 | self | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1498:34:1498:39 | self.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1498:34:1498:50 | ... <= ... |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1498:44:1498:48 | other |  | file://:0:0:0:0 | & |
+| main.rs:1498:44:1498:48 | other | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1498:44:1498:50 | other.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1501:15:1501:19 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1501:15:1501:19 | SelfParam | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1501:22:1501:26 | other |  | file://:0:0:0:0 | & |
+| main.rs:1501:22:1501:26 | other | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1501:44:1503:9 | { ... } |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1502:13:1502:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1502:13:1502:16 | self | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1502:13:1502:18 | self.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1502:13:1502:28 | ... > ... |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1502:13:1502:48 | ... && ... |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1502:22:1502:26 | other |  | file://:0:0:0:0 | & |
+| main.rs:1502:22:1502:26 | other | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1502:22:1502:28 | other.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1502:33:1502:36 | self |  | file://:0:0:0:0 | & |
+| main.rs:1502:33:1502:36 | self | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1502:33:1502:38 | self.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1502:33:1502:48 | ... > ... |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1502:42:1502:46 | other |  | file://:0:0:0:0 | & |
+| main.rs:1502:42:1502:46 | other | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1502:42:1502:48 | other.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1505:15:1505:19 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1505:15:1505:19 | SelfParam | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1505:22:1505:26 | other |  | file://:0:0:0:0 | & |
+| main.rs:1505:22:1505:26 | other | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1505:44:1507:9 | { ... } |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1506:13:1506:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1506:13:1506:16 | self | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1506:13:1506:18 | self.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1506:13:1506:29 | ... >= ... |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1506:13:1506:50 | ... && ... |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1506:23:1506:27 | other |  | file://:0:0:0:0 | & |
+| main.rs:1506:23:1506:27 | other | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1506:23:1506:29 | other.x |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1506:34:1506:37 | self |  | file://:0:0:0:0 | & |
+| main.rs:1506:34:1506:37 | self | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1506:34:1506:39 | self.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1506:34:1506:50 | ... >= ... |  | file:///BUILTINS/types.rs:3:1:5:16 | bool |
+| main.rs:1506:44:1506:48 | other |  | file://:0:0:0:0 | & |
+| main.rs:1506:44:1506:48 | other | &T | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1506:44:1506:50 | other.y |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1513:23:1513:26 | 1i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1513:31:1513:34 | 2i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1514:23:1514:26 | 3i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1514:31:1514:34 | 4i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1515:23:1515:26 | 5i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1515:30:1515:33 | 6i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1516:23:1516:26 | 7i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1516:31:1516:34 | 8i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1517:23:1517:26 | 9i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1517:30:1517:34 | 10i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1518:23:1518:27 | 11i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1518:32:1518:36 | 12i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1521:23:1521:27 | 13i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1521:31:1521:35 | 14i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1522:23:1522:27 | 15i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1522:31:1522:35 | 16i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1523:23:1523:27 | 17i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1523:31:1523:35 | 18i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1524:23:1524:27 | 19i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1524:31:1524:35 | 20i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1525:23:1525:27 | 21i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1525:31:1525:35 | 22i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1528:13:1528:30 | mut i64_add_assign |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1528:34:1528:38 | 23i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1529:9:1529:22 | i64_add_assign |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1529:9:1529:31 | ... += ... |  | file://:0:0:0:0 | () |
+| main.rs:1529:27:1529:31 | 24i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1531:13:1531:30 | mut i64_sub_assign |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1531:34:1531:38 | 25i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1532:9:1532:22 | i64_sub_assign |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1532:9:1532:31 | ... -= ... |  | file://:0:0:0:0 | () |
+| main.rs:1532:27:1532:31 | 26i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1534:13:1534:30 | mut i64_mul_assign |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1534:34:1534:38 | 27i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1535:9:1535:22 | i64_mul_assign |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1535:9:1535:31 | ... *= ... |  | file://:0:0:0:0 | () |
+| main.rs:1535:27:1535:31 | 28i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1537:13:1537:30 | mut i64_div_assign |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1537:34:1537:38 | 29i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1538:9:1538:22 | i64_div_assign |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1538:9:1538:31 | ... /= ... |  | file://:0:0:0:0 | () |
+| main.rs:1538:27:1538:31 | 30i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1540:13:1540:30 | mut i64_rem_assign |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1540:34:1540:38 | 31i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1541:9:1541:22 | i64_rem_assign |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1541:9:1541:31 | ... %= ... |  | file://:0:0:0:0 | () |
+| main.rs:1541:27:1541:31 | 32i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1544:26:1544:30 | 33i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1544:34:1544:38 | 34i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1545:25:1545:29 | 35i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1545:33:1545:37 | 36i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1546:26:1546:30 | 37i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1546:34:1546:38 | 38i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1547:23:1547:27 | 39i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1547:32:1547:36 | 40i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1548:23:1548:27 | 41i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1548:32:1548:36 | 42i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1551:13:1551:33 | mut i64_bitand_assign |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1551:37:1551:41 | 43i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1552:9:1552:25 | i64_bitand_assign |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1552:9:1552:34 | ... &= ... |  | file://:0:0:0:0 | () |
+| main.rs:1552:30:1552:34 | 44i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1554:13:1554:32 | mut i64_bitor_assign |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1554:36:1554:40 | 45i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1555:9:1555:24 | i64_bitor_assign |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1555:9:1555:33 | ... \|= ... |  | file://:0:0:0:0 | () |
+| main.rs:1555:29:1555:33 | 46i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1557:13:1557:33 | mut i64_bitxor_assign |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1557:37:1557:41 | 47i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1558:9:1558:25 | i64_bitxor_assign |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1558:9:1558:34 | ... ^= ... |  | file://:0:0:0:0 | () |
+| main.rs:1558:30:1558:34 | 48i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1560:13:1560:30 | mut i64_shl_assign |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1560:34:1560:38 | 49i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1561:9:1561:22 | i64_shl_assign |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1561:9:1561:32 | ... <<= ... |  | file://:0:0:0:0 | () |
+| main.rs:1561:28:1561:32 | 50i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1563:13:1563:30 | mut i64_shr_assign |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1563:34:1563:38 | 51i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1564:9:1564:22 | i64_shr_assign |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1564:9:1564:32 | ... >>= ... |  | file://:0:0:0:0 | () |
+| main.rs:1564:28:1564:32 | 52i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1566:24:1566:28 | 53i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1567:24:1567:28 | 54i64 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1570:13:1570:14 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1570:18:1570:36 | Vec2 {...} |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1570:28:1570:28 | 1 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1570:28:1570:28 | 1 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1570:34:1570:34 | 2 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1570:34:1570:34 | 2 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1571:13:1571:14 | v2 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1571:18:1571:36 | Vec2 {...} |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1571:28:1571:28 | 3 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1571:28:1571:28 | 3 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1571:34:1571:34 | 4 |  | file:///BUILTINS/types.rs:12:1:12:15 | i32 |
+| main.rs:1571:34:1571:34 | 4 |  | file:///BUILTINS/types.rs:13:1:13:15 | i64 |
+| main.rs:1574:23:1574:24 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1574:29:1574:30 | v2 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1575:23:1575:24 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1575:29:1575:30 | v2 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1576:23:1576:24 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1576:28:1576:29 | v2 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1577:23:1577:24 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1577:29:1577:30 | v2 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1578:23:1578:24 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1578:28:1578:29 | v2 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1579:23:1579:24 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1579:29:1579:30 | v2 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1582:24:1582:25 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1582:29:1582:30 | v2 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1583:24:1583:25 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1583:29:1583:30 | v2 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1584:24:1584:25 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1584:29:1584:30 | v2 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1585:24:1585:25 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1585:29:1585:30 | v2 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1586:24:1586:25 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1586:29:1586:30 | v2 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1589:13:1589:31 | mut vec2_add_assign |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1589:35:1589:36 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1590:9:1590:23 | vec2_add_assign |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1590:9:1590:29 | ... += ... |  | file://:0:0:0:0 | () |
+| main.rs:1590:28:1590:29 | v2 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1592:13:1592:31 | mut vec2_sub_assign |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1592:35:1592:36 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1593:9:1593:23 | vec2_sub_assign |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1593:9:1593:29 | ... -= ... |  | file://:0:0:0:0 | () |
+| main.rs:1593:28:1593:29 | v2 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1595:13:1595:31 | mut vec2_mul_assign |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1595:35:1595:36 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1596:9:1596:23 | vec2_mul_assign |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1596:9:1596:29 | ... *= ... |  | file://:0:0:0:0 | () |
+| main.rs:1596:28:1596:29 | v2 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1598:13:1598:31 | mut vec2_div_assign |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1598:35:1598:36 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1599:9:1599:23 | vec2_div_assign |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1599:9:1599:29 | ... /= ... |  | file://:0:0:0:0 | () |
+| main.rs:1599:28:1599:29 | v2 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1601:13:1601:31 | mut vec2_rem_assign |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1601:35:1601:36 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1602:9:1602:23 | vec2_rem_assign |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1602:9:1602:29 | ... %= ... |  | file://:0:0:0:0 | () |
+| main.rs:1602:28:1602:29 | v2 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1605:27:1605:28 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1605:32:1605:33 | v2 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1606:26:1606:27 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1606:31:1606:32 | v2 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1607:27:1607:28 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1607:32:1607:33 | v2 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1608:24:1608:25 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1608:30:1608:33 | 1u32 |  | file:///BUILTINS/types.rs:17:1:17:15 | u32 |
+| main.rs:1609:24:1609:25 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1609:30:1609:33 | 1u32 |  | file:///BUILTINS/types.rs:17:1:17:15 | u32 |
+| main.rs:1612:13:1612:34 | mut vec2_bitand_assign |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1612:38:1612:39 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1613:9:1613:26 | vec2_bitand_assign |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1613:9:1613:32 | ... &= ... |  | file://:0:0:0:0 | () |
+| main.rs:1613:31:1613:32 | v2 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1615:13:1615:33 | mut vec2_bitor_assign |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1615:37:1615:38 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1616:9:1616:25 | vec2_bitor_assign |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1616:9:1616:31 | ... \|= ... |  | file://:0:0:0:0 | () |
+| main.rs:1616:30:1616:31 | v2 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1618:13:1618:34 | mut vec2_bitxor_assign |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1618:38:1618:39 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1619:9:1619:26 | vec2_bitxor_assign |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1619:9:1619:32 | ... ^= ... |  | file://:0:0:0:0 | () |
+| main.rs:1619:31:1619:32 | v2 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1621:13:1621:31 | mut vec2_shl_assign |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1621:35:1621:36 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1622:9:1622:23 | vec2_shl_assign |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1622:9:1622:32 | ... <<= ... |  | file://:0:0:0:0 | () |
+| main.rs:1622:29:1622:32 | 1u32 |  | file:///BUILTINS/types.rs:17:1:17:15 | u32 |
+| main.rs:1624:13:1624:31 | mut vec2_shr_assign |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1624:35:1624:36 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1625:9:1625:23 | vec2_shr_assign |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1625:9:1625:32 | ... >>= ... |  | file://:0:0:0:0 | () |
+| main.rs:1625:29:1625:32 | 1u32 |  | file:///BUILTINS/types.rs:17:1:17:15 | u32 |
+| main.rs:1628:25:1628:26 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1629:25:1629:26 | v1 |  | main.rs:1278:5:1283:5 | Vec2 |
+| main.rs:1635:5:1635:20 | ...::f(...) |  | main.rs:67:5:67:21 | Foo |
+| main.rs:1636:5:1636:60 | ...::g(...) |  | main.rs:67:5:67:21 | Foo |
+| main.rs:1636:20:1636:38 | ...::Foo {...} |  | main.rs:67:5:67:21 | Foo |
+| main.rs:1636:41:1636:59 | ...::Foo {...} |  | main.rs:67:5:67:21 | Foo |


### PR DESCRIPTION
Implements type inference for overloaded operators in Rust.

Note, that this does _not_ implement the data flow side of things.

Shoutout to Copilot :copilot: for helping out with generating the tests 💪 