### PR TITLE
Python: Add Pandas SQLi sinks

### DIFF
--- a/python/ql/lib/semmle/python/frameworks/Pandas.qll
+++ b/python/ql/lib/semmle/python/frameworks/Pandas.qll
@@ -151,4 +151,15 @@ private module Pandas {
 
     override DataFlow::Node getCode() { result = this.getParameter(0, "expr").asSink() }
   }
+
+  /**
+   * A Call to `pandas.read_sql` or `pandas.read_sql_query`
+   * which allows for executing raw SQL queries against a database.
+   * See https://pandas.pydata.org/docs/reference/api/pandas.read_sql.html
+   */
+  class ReadSQLCall extends SqlExecution::Range, DataFlow::CallCfgNode {
+    ReadSQLCall() { this = API::moduleImport("pandas").getMember(["read_sql", "read_sql_query"]).getACall() }
+
+    override DataFlow::Node getSql() { result in [this.getArg(0), this.getArgByName("sql")] }
+  }
 }

--- a/python/ql/lib/semmle/python/frameworks/Pandas.qll
+++ b/python/ql/lib/semmle/python/frameworks/Pandas.qll
@@ -158,7 +158,9 @@ private module Pandas {
    * See https://pandas.pydata.org/docs/reference/api/pandas.read_sql.html
    */
   class ReadSqlCall extends SqlExecution::Range, DataFlow::CallCfgNode {
-    ReadSqlCall() { this = API::moduleImport("pandas").getMember(["read_sql", "read_sql_query"]).getACall() }
+    ReadSqlCall() {
+      this = API::moduleImport("pandas").getMember(["read_sql", "read_sql_query"]).getACall()
+    }
 
     override DataFlow::Node getSql() { result in [this.getArg(0), this.getArgByName("sql")] }
   }

--- a/python/ql/lib/semmle/python/frameworks/Pandas.qll
+++ b/python/ql/lib/semmle/python/frameworks/Pandas.qll
@@ -157,8 +157,8 @@ private module Pandas {
    * which allows for executing raw SQL queries against a database.
    * See https://pandas.pydata.org/docs/reference/api/pandas.read_sql.html
    */
-  class ReadSQLCall extends SqlExecution::Range, DataFlow::CallCfgNode {
-    ReadSQLCall() { this = API::moduleImport("pandas").getMember(["read_sql", "read_sql_query"]).getACall() }
+  class ReadSqlCall extends SqlExecution::Range, DataFlow::CallCfgNode {
+    ReadSqlCall() { this = API::moduleImport("pandas").getMember(["read_sql", "read_sql_query"]).getACall() }
 
     override DataFlow::Node getSql() { result in [this.getArg(0), this.getArgByName("sql")] }
   }

--- a/python/ql/src/change-notes/2025-05-26-pandas-sqli-sinks.md
+++ b/python/ql/src/change-notes/2025-05-26-pandas-sqli-sinks.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added SQL injection models from the `pandas` PyPI package.

--- a/python/ql/test/library-tests/frameworks/pandas/dataframe_query.py
+++ b/python/ql/test/library-tests/frameworks/pandas/dataframe_query.py
@@ -60,7 +60,6 @@ df = pd.read_sql_query("sql query", connection) # $getSql="sql query"
 df.query("query")  # $getCode="query"
 df.eval("query")  # $getCode="query"
 
-connection = sqlite3.connect("pets.db")
 df = pd.read_sql("sql query", connection) # $getSql="sql query"
 df.query("query")  # $getCode="query"
 df.eval("query")  # $getCode="query"

--- a/python/ql/test/library-tests/frameworks/pandas/dataframe_query.py
+++ b/python/ql/test/library-tests/frameworks/pandas/dataframe_query.py
@@ -1,5 +1,5 @@
 import pandas as pd
-
+import sqlite3
 
 df = pd.DataFrame({'temp_c': [17.0, 25.0]}, index=['Portland', 'Berkeley'])
 df.sample().query("query")  # $getCode="query"
@@ -55,11 +55,13 @@ df = pd.read_sql_table("filepath", 'postgres:///db_name')
 df.query("query")  # $getCode="query"
 df.eval("query")  # $getCode="query"
 
-df = pd.read_sql_query("filepath", 'postgres:///db_name')
+connection = sqlite3.connect("pets.db")
+df = pd.read_sql_query("sql query", connection) # $getSql="sql query"
 df.query("query")  # $getCode="query"
 df.eval("query")  # $getCode="query"
 
-df = pd.read_sql("filepath", 'postgres:///db_name')
+connection = sqlite3.connect("pets.db")
+df = pd.read_sql("sql query", connection) # $getSql="sql query"
 df.query("query")  # $getCode="query"
 df.eval("query")  # $getCode="query"
 


### PR DESCRIPTION
Pandas has a `read_sql` sink, which allows for executing raw SQL queries with untrusted input. `read_sql` is a convenience method, that dispatches the query either to `read_sql_table` or `read_sql_query`. Please note that `read_sql_table` is not vulnerable to SQLi, but `read_sql_query` is.

Note that instead of adding new tests, I edited the previous tests, because they contained the vulnerable `read_sql` and `read_sql_query` method, which made them show up as failed.