### PR TITLE
Rust: delete leftover log statement

### DIFF
--- a/rust/extractor/src/main.rs
+++ b/rust/extractor/src/main.rs
@@ -317,7 +317,6 @@ fn main() -> anyhow::Result<()> {
                             .source_root(db)
                             .is_library
                     {
-                        tracing::info!("file: {}", file.display());
                         extractor.extract_with_semantics(
                             file,
                             &semantics,


### PR DESCRIPTION
I accidentally left a chatty log statement in the code.