### PR TITLE
Fix user-facing casing of NuGet

### DIFF
--- a/csharp/autobuilder/Semmle.Autobuild.CSharp/CSharpAutobuilder.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.CSharp/CSharpAutobuilder.cs
@@ -113,7 +113,7 @@ namespace Semmle.Autobuild.CSharp
                     "buildless/mode-active",
                     "C# was extracted with build-mode set to 'none'",
                     visibility: new DiagnosticMessage.TspVisibility(statusPage: true, cliSummaryTable: true, telemetry: true),
-                    markdownMessage: "C# was extracted with build-mode set to 'none'. This means that all C# source in the working directory will be scanned, with build tools, such as Nuget and Dotnet CLIs, only contributing information about external dependencies.",
+                    markdownMessage: "C# was extracted with build-mode set to 'none'. This means that all C# source in the working directory will be scanned, with build tools, such as NuGet and dotnet CLIs, only contributing information about external dependencies.",
                     severity: DiagnosticMessage.TspSeverity.Note
                 ));
 

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DotNet.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DotNet.cs
@@ -127,13 +127,13 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
 
         public IList<string> GetNugetFeeds(string nugetConfig)
         {
-            logger.LogInfo($"Getting Nuget feeds from '{nugetConfig}'...");
+            logger.LogInfo($"Getting NuGet feeds from '{nugetConfig}'...");
             return GetResultList($"{nugetListSourceCommand} --configfile \"{nugetConfig}\"");
         }
 
         public IList<string> GetNugetFeedsFromFolder(string folderPath)
         {
-            logger.LogInfo($"Getting Nuget feeds in folder '{folderPath}'...");
+            logger.LogInfo($"Getting NuGet feeds in folder '{folderPath}'...");
             return GetResultList(nugetListSourceCommand, folderPath);
         }
 

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/EnvironmentVariableNames.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/EnvironmentVariableNames.cs
@@ -55,7 +55,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         internal const string NugetFeedResponsivenessRequestCountForFallback = "CODEQL_EXTRACTOR_CSHARP_BUILDLESS_NUGET_FEEDS_CHECK_FALLBACK_LIMIT";
 
         /// <summary>
-        /// Specifies the NuGet feeds to use for fallback Nuget dependency fetching. The value is a space-separated list of feed URLs.
+        /// Specifies the NuGet feeds to use for fallback NuGet dependency fetching. The value is a space-separated list of feed URLs.
         /// The default value is `https://api.nuget.org/v3/index.json`.
         /// </summary>
         public const string FallbackNugetFeeds = "CODEQL_EXTRACTOR_CSHARP_BUILDLESS_NUGET_FEEDS_FALLBACK";

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/NugetPackageRestorer.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/NugetPackageRestorer.cs
@@ -135,16 +135,16 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
 
                 if (nugetPackageDllPaths.Count > 0)
                 {
-                    logger.LogInfo($"Restored {nugetPackageDllPaths.Count} Nuget DLLs.");
+                    logger.LogInfo($"Restored {nugetPackageDllPaths.Count} NuGet DLLs.");
                 }
                 if (excludedPaths.Count > 0)
                 {
-                    logger.LogInfo($"Excluding {excludedPaths.Count} Nuget DLLs.");
+                    logger.LogInfo($"Excluding {excludedPaths.Count} NuGet DLLs.");
                 }
 
                 foreach (var excludedPath in excludedPaths)
                 {
-                    logger.LogInfo($"Excluded Nuget DLL: {excludedPath}");
+                    logger.LogInfo($"Excluded NuGet DLL: {excludedPath}");
                 }
 
                 nugetPackageDllPaths.ExceptWith(excludedPaths);
@@ -152,7 +152,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             }
             catch (Exception exc)
             {
-                logger.LogError($"Failed to restore Nuget packages with nuget.exe: {exc.Message}");
+                logger.LogError($"Failed to restore NuGet packages with nuget.exe: {exc.Message}");
             }
 
             var restoredProjects = RestoreSolutions(out var container);
@@ -186,7 +186,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             if (fallbackFeeds.Count == 0)
             {
                 fallbackFeeds.Add(PublicNugetOrgFeed);
-                logger.LogInfo($"No fallback Nuget feeds specified. Adding default feed: {PublicNugetOrgFeed}");
+                logger.LogInfo($"No fallback NuGet feeds specified. Adding default feed: {PublicNugetOrgFeed}");
 
                 var shouldAddNugetConfigFeeds = EnvironmentVariables.GetBooleanOptOut(EnvironmentVariableNames.AddNugetConfigFeedsToFallback);
                 logger.LogInfo($"Adding feeds from nuget.config to fallback restore: {shouldAddNugetConfigFeeds}");
@@ -196,23 +196,23 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                     // There are some feeds in `feedsFromNugetConfigs` that have already been checked for reachability, we could skip those.
                     // But we might use different responsiveness testing settings when we try them in the fallback logic, so checking them again is safer.
                     fallbackFeeds.UnionWith(feedsFromNugetConfigs);
-                    logger.LogInfo($"Using Nuget feeds from nuget.config files as fallback feeds: {string.Join(", ", feedsFromNugetConfigs.OrderBy(f => f))}");
+                    logger.LogInfo($"Using NuGet feeds from nuget.config files as fallback feeds: {string.Join(", ", feedsFromNugetConfigs.OrderBy(f => f))}");
                 }
             }
 
-            logger.LogInfo($"Checking fallback Nuget feed reachability on feeds: {string.Join(", ", fallbackFeeds.OrderBy(f => f))}");
+            logger.LogInfo($"Checking fallback NuGet feed reachability on feeds: {string.Join(", ", fallbackFeeds.OrderBy(f => f))}");
             var (initialTimeout, tryCount) = GetFeedRequestSettings(isFallback: true);
             var reachableFallbackFeeds = fallbackFeeds.Where(feed => IsFeedReachable(feed, initialTimeout, tryCount, allowExceptions: false)).ToList();
             if (reachableFallbackFeeds.Count == 0)
             {
-                logger.LogWarning("No fallback Nuget feeds are reachable.");
+                logger.LogWarning("No fallback NuGet feeds are reachable.");
             }
             else
             {
-                logger.LogInfo($"Reachable fallback Nuget feeds: {string.Join(", ", reachableFallbackFeeds.OrderBy(f => f))}");
+                logger.LogInfo($"Reachable fallback NuGet feeds: {string.Join(", ", reachableFallbackFeeds.OrderBy(f => f))}");
             }
 
-            compilationInfoContainer.CompilationInfos.Add(("Reachable fallback Nuget feed count", reachableFallbackFeeds.Count.ToString()));
+            compilationInfoContainer.CompilationInfos.Add(("Reachable fallback NuGet feed count", reachableFallbackFeeds.Count.ToString()));
 
             return reachableFallbackFeeds;
         }
@@ -331,7 +331,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                 return DownloadMissingPackages(usedPackageNames, fallbackNugetFeeds: reachableFallbackFeeds);
             }
 
-            logger.LogWarning("Skipping download of missing packages from specific feeds as no fallback Nuget feeds are reachable.");
+            logger.LogWarning("Skipping download of missing packages from specific feeds as no fallback NuGet feeds are reachable.");
             return null;
         }
 
@@ -624,7 +624,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
 
         private bool IsFeedReachable(string feed, int timeoutMilliSeconds, int tryCount, bool allowExceptions = true)
         {
-            logger.LogInfo($"Checking if Nuget feed '{feed}' is reachable...");
+            logger.LogInfo($"Checking if NuGet feed '{feed}' is reachable...");
 
             // Configure the HttpClient to be aware of the Dependabot Proxy, if used.
             HttpClientHandler httpClientHandler = new();
@@ -662,7 +662,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                 try
                 {
                     ExecuteGetRequest(feed, client, cts.Token).GetAwaiter().GetResult();
-                    logger.LogInfo($"Querying Nuget feed '{feed}' succeeded.");
+                    logger.LogInfo($"Querying NuGet feed '{feed}' succeeded.");
                     return true;
                 }
                 catch (Exception exc)
@@ -671,19 +671,19 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                         tce.CancellationToken == cts.Token &&
                         cts.Token.IsCancellationRequested)
                     {
-                        logger.LogInfo($"Didn't receive answer from Nuget feed '{feed}' in {timeoutMilliSeconds}ms.");
+                        logger.LogInfo($"Didn't receive answer from NuGet feed '{feed}' in {timeoutMilliSeconds}ms.");
                         timeoutMilliSeconds *= 2;
                         continue;
                     }
 
                     // We're only interested in timeouts.
                     var start = allowExceptions ? "Considering" : "Not considering";
-                    logger.LogInfo($"Querying Nuget feed '{feed}' failed in a timely manner. {start} the feed for use. The reason for the failure: {exc.Message}");
+                    logger.LogInfo($"Querying NuGet feed '{feed}' failed in a timely manner. {start} the feed for use. The reason for the failure: {exc.Message}");
                     return allowExceptions;
                 }
             }
 
-            logger.LogWarning($"Didn't receive answer from Nuget feed '{feed}'. Tried it {tryCount} times.");
+            logger.LogWarning($"Didn't receive answer from NuGet feed '{feed}'. Tried it {tryCount} times.");
             return false;
         }
 
@@ -694,20 +694,20 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                 : int.TryParse(Environment.GetEnvironmentVariable(EnvironmentVariableNames.NugetFeedResponsivenessInitialTimeout), out timeoutMilliSeconds)
                     ? timeoutMilliSeconds
                     : 1000;
-            logger.LogDebug($"Initial timeout for Nuget feed reachability check is {timeoutMilliSeconds}ms.");
+            logger.LogDebug($"Initial timeout for NuGet feed reachability check is {timeoutMilliSeconds}ms.");
 
             int tryCount = isFallback && int.TryParse(Environment.GetEnvironmentVariable(EnvironmentVariableNames.NugetFeedResponsivenessRequestCountForFallback), out tryCount)
                 ? tryCount
                 : int.TryParse(Environment.GetEnvironmentVariable(EnvironmentVariableNames.NugetFeedResponsivenessRequestCount), out tryCount)
                     ? tryCount
                     : 4;
-            logger.LogDebug($"Number of tries for Nuget feed reachability check is {tryCount}.");
+            logger.LogDebug($"Number of tries for NuGet feed reachability check is {tryCount}.");
 
             return (timeoutMilliSeconds, tryCount);
         }
 
         /// <summary>
-        /// Checks that we can connect to all Nuget feeds that are explicitly configured in configuration files
+        /// Checks that we can connect to all NuGet feeds that are explicitly configured in configuration files
         /// as well as any private package registry feeds that are configured.
         /// </summary>
         /// <param name="explicitFeeds">Outputs the set of explicit feeds.</param>
@@ -727,28 +727,28 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             var inheritedFeeds = allFeeds.Except(explicitFeeds).ToHashSet();
             if (inheritedFeeds.Count > 0)
             {
-                logger.LogInfo($"Inherited Nuget feeds (not checked for reachability): {string.Join(", ", inheritedFeeds.OrderBy(f => f))}");
-                compilationInfoContainer.CompilationInfos.Add(("Inherited Nuget feed count", inheritedFeeds.Count.ToString()));
+                logger.LogInfo($"Inherited NuGet feeds (not checked for reachability): {string.Join(", ", inheritedFeeds.OrderBy(f => f))}");
+                compilationInfoContainer.CompilationInfos.Add(("Inherited NuGet feed count", inheritedFeeds.Count.ToString()));
             }
 
             return allFeedsReachable;
         }
 
         /// <summary>
-        /// Checks that we can connect to the specified Nuget feeds.
+        /// Checks that we can connect to the specified NuGet feeds.
         /// </summary>
         /// <param name="feeds">The set of package feeds to check.</param>
         /// <returns>True if all feeds are reachable or false otherwise.</returns>
         private bool CheckSpecifiedFeeds(HashSet<string> feeds)
         {
-            logger.LogInfo("Checking that Nuget feeds are reachable...");
+            logger.LogInfo("Checking that NuGet feeds are reachable...");
 
             var excludedFeeds = EnvironmentVariables.GetURLs(EnvironmentVariableNames.ExcludedNugetFeedsFromResponsivenessCheck)
                 .ToHashSet();
 
             if (excludedFeeds.Count > 0)
             {
-                logger.LogInfo($"Excluded Nuget feeds from responsiveness check: {string.Join(", ", excludedFeeds.OrderBy(f => f))}");
+                logger.LogInfo($"Excluded NuGet feeds from responsiveness check: {string.Join(", ", excludedFeeds.OrderBy(f => f))}");
             }
 
             var (initialTimeout, tryCount) = GetFeedRequestSettings(isFallback: false);
@@ -756,17 +756,17 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             var allFeedsReachable = feeds.All(feed => excludedFeeds.Contains(feed) || IsFeedReachable(feed, initialTimeout, tryCount));
             if (!allFeedsReachable)
             {
-                logger.LogWarning("Found unreachable Nuget feed in C# analysis with build-mode 'none'. This may cause missing dependencies in the analysis.");
+                logger.LogWarning("Found unreachable NuGet feed in C# analysis with build-mode 'none'. This may cause missing dependencies in the analysis.");
                 diagnosticsWriter.AddEntry(new DiagnosticMessage(
                     Language.CSharp,
                     "buildless/unreachable-feed",
-                    "Found unreachable Nuget feed in C# analysis with build-mode 'none'",
+                    "Found unreachable NuGet feed in C# analysis with build-mode 'none'",
                     visibility: new DiagnosticMessage.TspVisibility(statusPage: true, cliSummaryTable: true, telemetry: true),
-                    markdownMessage: "Found unreachable Nuget feed in C# analysis with build-mode 'none'. This may cause missing dependencies in the analysis.",
+                    markdownMessage: "Found unreachable NuGet feed in C# analysis with build-mode 'none'. This may cause missing dependencies in the analysis.",
                     severity: DiagnosticMessage.TspSeverity.Note
                 ));
             }
-            compilationInfoContainer.CompilationInfos.Add(("All Nuget feeds reachable", allFeedsReachable ? "1" : "0"));
+            compilationInfoContainer.CompilationInfos.Add(("All NuGet feeds reachable", allFeedsReachable ? "1" : "0"));
 
             return allFeedsReachable;
         }
@@ -808,11 +808,11 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
 
             if (explicitFeeds.Count > 0)
             {
-                logger.LogInfo($"Found {explicitFeeds.Count} Nuget feeds in nuget.config files: {string.Join(", ", explicitFeeds.OrderBy(f => f))}");
+                logger.LogInfo($"Found {explicitFeeds.Count} NuGet feeds in nuget.config files: {string.Join(", ", explicitFeeds.OrderBy(f => f))}");
             }
             else
             {
-                logger.LogDebug("No Nuget feeds found in nuget.config files.");
+                logger.LogDebug("No NuGet feeds found in nuget.config files.");
             }
 
             // todo: this could be improved.
@@ -844,7 +844,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                 allFeeds = GetFeeds(() => dotnet.GetNugetFeedsFromFolder(this.fileProvider.SourceDir.FullName)).ToHashSet();
             }
 
-            logger.LogInfo($"Found {allFeeds.Count} Nuget feeds (with inherited ones) in nuget.config files: {string.Join(", ", allFeeds.OrderBy(f => f))}");
+            logger.LogInfo($"Found {allFeeds.Count} NuGet feeds (with inherited ones) in nuget.config files: {string.Join(", ", allFeeds.OrderBy(f => f))}");
 
             return (explicitFeeds, allFeeds);
         }

--- a/csharp/ql/integration-tests/all-platforms/binlog/diagnostics.expected
+++ b/csharp/ql/integration-tests/all-platforms/binlog/diagnostics.expected
@@ -13,7 +13,7 @@
   }
 }
 {
-  "markdownMessage": "C# was extracted with build-mode set to 'none'. This means that all C# source in the working directory will be scanned, with build tools, such as Nuget and Dotnet CLIs, only contributing information about external dependencies.",
+  "markdownMessage": "C# was extracted with build-mode set to 'none'. This means that all C# source in the working directory will be scanned, with build tools, such as NuGet and dotnet CLIs, only contributing information about external dependencies.",
   "severity": "note",
   "source": {
     "extractorName": "csharp",

--- a/csharp/ql/integration-tests/all-platforms/binlog_multiple/diagnostics.expected
+++ b/csharp/ql/integration-tests/all-platforms/binlog_multiple/diagnostics.expected
@@ -13,7 +13,7 @@
   }
 }
 {
-  "markdownMessage": "C# was extracted with build-mode set to 'none'. This means that all C# source in the working directory will be scanned, with build tools, such as Nuget and Dotnet CLIs, only contributing information about external dependencies.",
+  "markdownMessage": "C# was extracted with build-mode set to 'none'. This means that all C# source in the working directory will be scanned, with build tools, such as NuGet and dotnet CLIs, only contributing information about external dependencies.",
   "severity": "note",
   "source": {
     "extractorName": "csharp",

--- a/csharp/ql/integration-tests/all-platforms/standalone/diagnostics.expected
+++ b/csharp/ql/integration-tests/all-platforms/standalone/diagnostics.expected
@@ -13,7 +13,7 @@
   }
 }
 {
-  "markdownMessage": "C# was extracted with build-mode set to 'none'. This means that all C# source in the working directory will be scanned, with build tools, such as Nuget and Dotnet CLIs, only contributing information about external dependencies.",
+  "markdownMessage": "C# was extracted with build-mode set to 'none'. This means that all C# source in the working directory will be scanned, with build tools, such as NuGet and dotnet CLIs, only contributing information about external dependencies.",
   "severity": "note",
   "source": {
     "extractorName": "csharp",

--- a/csharp/ql/integration-tests/all-platforms/standalone_buildless_option/diagnostics.expected
+++ b/csharp/ql/integration-tests/all-platforms/standalone_buildless_option/diagnostics.expected
@@ -13,7 +13,7 @@
   }
 }
 {
-  "markdownMessage": "C# was extracted with build-mode set to 'none'. This means that all C# source in the working directory will be scanned, with build tools, such as Nuget and Dotnet CLIs, only contributing information about external dependencies.",
+  "markdownMessage": "C# was extracted with build-mode set to 'none'. This means that all C# source in the working directory will be scanned, with build tools, such as NuGet and dotnet CLIs, only contributing information about external dependencies.",
   "severity": "note",
   "source": {
     "extractorName": "csharp",

--- a/csharp/ql/integration-tests/all-platforms/standalone_failed/diagnostics.expected
+++ b/csharp/ql/integration-tests/all-platforms/standalone_failed/diagnostics.expected
@@ -13,7 +13,7 @@
   }
 }
 {
-  "markdownMessage": "C# was extracted with build-mode set to 'none'. This means that all C# source in the working directory will be scanned, with build tools, such as Nuget and Dotnet CLIs, only contributing information about external dependencies.",
+  "markdownMessage": "C# was extracted with build-mode set to 'none'. This means that all C# source in the working directory will be scanned, with build tools, such as NuGet and dotnet CLIs, only contributing information about external dependencies.",
   "severity": "note",
   "source": {
     "extractorName": "csharp",

--- a/csharp/ql/integration-tests/all-platforms/standalone_resx/CompilationInfo.expected
+++ b/csharp/ql/integration-tests/all-platforms/standalone_resx/CompilationInfo.expected
@@ -1,10 +1,10 @@
-| All Nuget feeds reachable | 1.0 |
+| All NuGet feeds reachable | 1.0 |
 | Failed project restore with package source error | 0.0 |
 | Failed solution restore with package source error | 0.0 |
-| Inherited Nuget feed count | 1.0 |
+| Inherited NuGet feed count | 1.0 |
 | NuGet feed responsiveness checked | 1.0 |
 | Project files on filesystem | 1.0 |
-| Reachable fallback Nuget feed count | 1.0 |
+| Reachable fallback NuGet feed count | 1.0 |
 | Resource extraction enabled | 1.0 |
 | Restored .NET framework variants | 1.0 |
 | Restored projects through solution files | 0.0 |

--- a/csharp/ql/integration-tests/all-platforms/standalone_winforms/CompilationInfo.expected
+++ b/csharp/ql/integration-tests/all-platforms/standalone_winforms/CompilationInfo.expected
@@ -1,10 +1,10 @@
-| All Nuget feeds reachable | 1.0 |
+| All NuGet feeds reachable | 1.0 |
 | Failed project restore with package source error | 0.0 |
 | Failed solution restore with package source error | 0.0 |
-| Inherited Nuget feed count | 1.0 |
+| Inherited NuGet feed count | 1.0 |
 | NuGet feed responsiveness checked | 1.0 |
 | Project files on filesystem | 1.0 |
-| Reachable fallback Nuget feed count | 1.0 |
+| Reachable fallback NuGet feed count | 1.0 |
 | Resource extraction enabled | 0.0 |
 | Restored .NET framework variants | 1.0 |
 | Restored projects through solution files | 0.0 |

--- a/csharp/ql/integration-tests/posix/standalone_dependencies_nuget_config_error/CompilationInfo.expected
+++ b/csharp/ql/integration-tests/posix/standalone_dependencies_nuget_config_error/CompilationInfo.expected
@@ -1,10 +1,10 @@
-| All Nuget feeds reachable | 1.0 |
+| All NuGet feeds reachable | 1.0 |
 | Failed project restore with package source error | 1.0 |
 | Failed solution restore with package source error | 0.0 |
 | Fallback nuget restore | 1.0 |
 | NuGet feed responsiveness checked | 1.0 |
 | Project files on filesystem | 1.0 |
-| Reachable fallback Nuget feed count | 1.0 |
+| Reachable fallback NuGet feed count | 1.0 |
 | Resolved assembly conflicts | 7.0 |
 | Resource extraction enabled | 0.0 |
 | Restored .NET framework variants | 0.0 |

--- a/csharp/ql/integration-tests/posix/standalone_dependencies_nuget_config_error_timeout/CompilationInfo.expected
+++ b/csharp/ql/integration-tests/posix/standalone_dependencies_nuget_config_error_timeout/CompilationInfo.expected
@@ -1,9 +1,9 @@
-| All Nuget feeds reachable | 0.0 |
+| All NuGet feeds reachable | 0.0 |
 | Fallback nuget restore | 1.0 |
-| Inherited Nuget feed count | 1.0 |
+| Inherited NuGet feed count | 1.0 |
 | NuGet feed responsiveness checked | 1.0 |
 | Project files on filesystem | 1.0 |
-| Reachable fallback Nuget feed count | 1.0 |
+| Reachable fallback NuGet feed count | 1.0 |
 | Resolved assembly conflicts | 7.0 |
 | Resource extraction enabled | 0.0 |
 | Restored .NET framework variants | 0.0 |

--- a/csharp/ql/integration-tests/posix/standalone_dependencies_nuget_config_error_timeout/diagnostics.expected
+++ b/csharp/ql/integration-tests/posix/standalone_dependencies_nuget_config_error_timeout/diagnostics.expected
@@ -13,7 +13,7 @@
   }
 }
 {
-  "markdownMessage": "C# was extracted with build-mode set to 'none'. This means that all C# source in the working directory will be scanned, with build tools, such as Nuget and Dotnet CLIs, only contributing information about external dependencies.",
+  "markdownMessage": "C# was extracted with build-mode set to 'none'. This means that all C# source in the working directory will be scanned, with build tools, such as NuGet and dotnet CLIs, only contributing information about external dependencies.",
   "severity": "note",
   "source": {
     "extractorName": "csharp",
@@ -27,12 +27,12 @@
   }
 }
 {
-  "markdownMessage": "Found unreachable Nuget feed in C# analysis with build-mode 'none'. This may cause missing dependencies in the analysis.",
+  "markdownMessage": "Found unreachable NuGet feed in C# analysis with build-mode 'none'. This may cause missing dependencies in the analysis.",
   "severity": "note",
   "source": {
     "extractorName": "csharp",
     "id": "csharp/autobuilder/buildless/unreachable-feed",
-    "name": "Found unreachable Nuget feed in C# analysis with build-mode 'none'"
+    "name": "Found unreachable NuGet feed in C# analysis with build-mode 'none'"
   },
   "visibility": {
     "cliSummaryTable": true,

--- a/csharp/ql/integration-tests/posix/standalone_dependencies_nuget_config_error_timeout/test.py
+++ b/csharp/ql/integration-tests/posix/standalone_dependencies_nuget_config_error_timeout/test.py
@@ -4,7 +4,7 @@ import runs_on
 
 @runs_on.posix
 def test(codeql, csharp):
-    # os.environ["CODEQL_EXTRACTOR_CSHARP_BUILDLESS_NUGET_FEEDS_CHECK"] = "true"        # Nuget feed check is enabled by default
+    # os.environ["CODEQL_EXTRACTOR_CSHARP_BUILDLESS_NUGET_FEEDS_CHECK"] = "true"        # NuGet feed check is enabled by default
     os.environ["CODEQL_EXTRACTOR_CSHARP_BUILDLESS_NUGET_FEEDS_CHECK_TIMEOUT"] = (
         "1"  # 1ms, the GET request should fail with such short timeout
     )

--- a/csharp/ql/integration-tests/posix/standalone_dependencies_nuget_config_fallback/CompilationInfo.expected
+++ b/csharp/ql/integration-tests/posix/standalone_dependencies_nuget_config_fallback/CompilationInfo.expected
@@ -1,8 +1,8 @@
-| All Nuget feeds reachable | 0.0 |
+| All NuGet feeds reachable | 0.0 |
 | Fallback nuget restore | 1.0 |
 | NuGet feed responsiveness checked | 1.0 |
 | Project files on filesystem | 1.0 |
-| Reachable fallback Nuget feed count | 2.0 |
+| Reachable fallback NuGet feed count | 2.0 |
 | Resolved assembly conflicts | 7.0 |
 | Resource extraction enabled | 0.0 |
 | Restored .NET framework variants | 0.0 |

--- a/csharp/ql/integration-tests/posix/standalone_dependencies_nuget_config_fallback/diagnostics.expected
+++ b/csharp/ql/integration-tests/posix/standalone_dependencies_nuget_config_fallback/diagnostics.expected
@@ -13,7 +13,7 @@
   }
 }
 {
-  "markdownMessage": "C# was extracted with build-mode set to 'none'. This means that all C# source in the working directory will be scanned, with build tools, such as Nuget and Dotnet CLIs, only contributing information about external dependencies.",
+  "markdownMessage": "C# was extracted with build-mode set to 'none'. This means that all C# source in the working directory will be scanned, with build tools, such as NuGet and dotnet CLIs, only contributing information about external dependencies.",
   "severity": "note",
   "source": {
     "extractorName": "csharp",
@@ -27,12 +27,12 @@
   }
 }
 {
-  "markdownMessage": "Found unreachable Nuget feed in C# analysis with build-mode 'none'. This may cause missing dependencies in the analysis.",
+  "markdownMessage": "Found unreachable NuGet feed in C# analysis with build-mode 'none'. This may cause missing dependencies in the analysis.",
   "severity": "note",
   "source": {
     "extractorName": "csharp",
     "id": "csharp/autobuilder/buildless/unreachable-feed",
-    "name": "Found unreachable Nuget feed in C# analysis with build-mode 'none'"
+    "name": "Found unreachable NuGet feed in C# analysis with build-mode 'none'"
   },
   "visibility": {
     "cliSummaryTable": true,

--- a/csharp/ql/integration-tests/posix/standalone_dependencies_nuget_config_fallback/test.py
+++ b/csharp/ql/integration-tests/posix/standalone_dependencies_nuget_config_fallback/test.py
@@ -5,7 +5,7 @@ import runs_on
 @runs_on.posix
 def test(codeql, csharp):
 
-    # os.environ["CODEQL_EXTRACTOR_CSHARP_BUILDLESS_NUGET_FEEDS_CHECK"] = "true"        # Nuget feed check is enabled by default
+    # os.environ["CODEQL_EXTRACTOR_CSHARP_BUILDLESS_NUGET_FEEDS_CHECK"] = "true"        # NuGet feed check is enabled by default
     os.environ["CODEQL_EXTRACTOR_CSHARP_BUILDLESS_NUGET_FEEDS_CHECK_TIMEOUT"] = (
         "1"  # 1ms, the GET request should fail with such short timeout
     )

--- a/csharp/scripts/stubs/README.md
+++ b/csharp/scripts/stubs/README.md
@@ -1,6 +1,6 @@
 # Generate stubs for a single NuGet package
 
-Stubs can be generated from Nuget packages with the `make_stubs_nuget.py` script.
+Stubs can be generated from NuGet packages with the `make_stubs_nuget.py` script.
 
 The following calls generate stubs for `Newtonsoft.Json`:
 
@@ -13,7 +13,7 @@ python3 make_stubs_nuget.py classlib Newtonsoft.Json 13.0.1 /Users/tmp/working-d
 
 The output stubs are found in the `[DIR]/output/stubs` folder and can be copied over to `csharp/ql/test/resources/stubs`.
 
-In some more involved cases the output files need to be edited. For example `ServiceStack` has Nuget dependencies, which
+In some more involved cases the output files need to be edited. For example `ServiceStack` has NuGet dependencies, which
 are included in the `Microsoft.NETCore.App` framework stub. These dependencies generate empty packages, which can be
 removed. The `ProjectReference` entries referencing these removed empty packages also need to be deleted from the
 `.csproj` files.


### PR DESCRIPTION
Fix user-facing strings to use _"NuGet"_ instead of _"Nuget"_ and _"dotnet"_ instead of _"Dotnet"_.
