### PR TITLE
CI: remove deprecated `windows-2019` usage

### DIFF
--- a/.github/workflows/build-ripunzip.yml
+++ b/.github/workflows/build-ripunzip.yml
@@ -6,11 +6,11 @@ on:
       ripunzip-version:
         description: "what reference to checktout from google/runzip"
         required: false
-        default: v1.2.1
+        default: v2.0.2
       openssl-version:
         description: "what reference to checkout from openssl/openssl for Linux"
         required: false
-        default: openssl-3.3.0
+        default: openssl-3.5.0
 
 jobs:
   build:

--- a/.github/workflows/build-ripunzip.yml
+++ b/.github/workflows/build-ripunzip.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-13, windows-2019]
+        os: [ubuntu-22.04, macos-13, windows-2022]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/csharp-qltest.yml
+++ b/.github/workflows/csharp-qltest.yml
@@ -36,7 +36,7 @@ jobs:
   unit-tests:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-2019]
+        os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The rip-unzip build workflow is using slightly older runners to ensure being runnable on supported platforms, though admittedly I don't know whether that can be an issue on windows.