### PR TITLE
Add `cs/string-concatenation-in-loop` to the quality suite

### DIFF
--- a/csharp/ql/integration-tests/posix/query-suite/csharp-code-quality.qls.expected
+++ b/csharp/ql/integration-tests/posix/query-suite/csharp-code-quality.qls.expected
@@ -11,6 +11,7 @@ ql/csharp/ql/src/Likely Bugs/EqualityCheckOnFloats.ql
 ql/csharp/ql/src/Likely Bugs/ReferenceEqualsOnValueTypes.ql
 ql/csharp/ql/src/Likely Bugs/SelfAssignment.ql
 ql/csharp/ql/src/Likely Bugs/UncheckedCastInEquals.ql
+ql/csharp/ql/src/Performance/StringConcatenationInLoop.ql
 ql/csharp/ql/src/Performance/UseTryGetValue.ql
 ql/csharp/ql/src/Useless code/DefaultToString.ql
 ql/csharp/ql/src/Useless code/IntGetHashCode.ql

--- a/csharp/ql/src/Performance/StringConcatenationInLoop.ql
+++ b/csharp/ql/src/Performance/StringConcatenationInLoop.ql
@@ -7,6 +7,7 @@
  * @id cs/string-concatenation-in-loop
  * @tags efficiency
  *       maintainability
+ *       quality
  */
 
 import csharp


### PR DESCRIPTION
This PR is adding the `cs/string-concatenation-in-loop` query to the code-quality suite. I've ran the query on MRVA and then manually checked autofix suggestions. The results and the fixes are sensible.

- [x] MRVA looks good
- [x] need to check autofix (might need more compliant/non-compliant samples)