### PR TITLE
Add `client-response` Threat Model and update JS ClientsRequests

### DIFF
--- a/javascript/ql/lib/change-notes/2025-06-03-client-response-threatmodel.md
+++ b/javascript/ql/lib/change-notes/2025-06-03-client-response-threatmodel.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added support for ClientRequest being part of the `client-response` threat model versus part of `response` threat model.

--- a/javascript/ql/lib/semmle/javascript/frameworks/ClientRequests.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/ClientRequests.qll
@@ -947,7 +947,7 @@ module ClientRequest {
   private class ClientRequestThreatModel extends ThreatModelSource::Range {
     ClientRequestThreatModel() { this = any(ClientRequest r).getAResponseDataNode() }
 
-    override string getThreatModel() { result = "response" }
+    override string getThreatModel() { result = "client-response" }
 
     override string getSourceType() { result = "HTTP response data" }
   }

--- a/shared/threat-models/change-notes/2025-06-03-client-response-threatmodel.md
+++ b/shared/threat-models/change-notes/2025-06-03-client-response-threatmodel.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Add support for `client-response` threat model.

--- a/shared/threat-models/ext/threat-model-grouping.model.yml
+++ b/shared/threat-models/ext/threat-model-grouping.model.yml
@@ -18,6 +18,8 @@ extensions:
       - ["stdin", "local"]
       - ["file", "local"]
       - ["windows-registry", "local"]
+      # Client-side threat models for request responses.
+      - ["client-response", "local"]
 
       # Android threat models
       - ["android-external-storage-dir", "android"]


### PR DESCRIPTION
I've added the `client-response` threat model to the Threat Modelling shared library. This is a new local threat model that includes the sources of client libraries (mainly focuses at JavaScript / Typescript).

This is needed to discover XSS or other types of security issues when the source of untrusted data in the response content of REST, GraphQL, Soap, etc. clients.