### PR TITLE
Actions: mass enable diff-informed data flow

### DIFF
--- a/actions/ql/lib/codeql/actions/security/OutputClobberingQuery.qll
+++ b/actions/ql/lib/codeql/actions/security/OutputClobberingQuery.qll
@@ -214,6 +214,8 @@ private module OutputClobberingConfig implements DataFlow::ConfigSig {
       )
     )
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /** Tracks flow of unsafe user input that is used to construct and evaluate an environment variable. */

--- a/actions/ql/lib/codeql/actions/security/RequestForgeryQuery.qll
+++ b/actions/ql/lib/codeql/actions/security/RequestForgeryQuery.qll
@@ -16,6 +16,8 @@ private module RequestForgeryConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof RequestForgerySink }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /** Tracks flow of unsafe user input that is used to construct and evaluate a system command. */

--- a/actions/ql/lib/codeql/actions/security/SecretExfiltrationQuery.qll
+++ b/actions/ql/lib/codeql/actions/security/SecretExfiltrationQuery.qll
@@ -15,6 +15,8 @@ private module SecretExfiltrationConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof SecretExfiltrationSink }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /** Tracks flow of unsafe user input that is used in a context where it may lead to a secret exfiltration. */

--- a/actions/ql/src/Models/CompositeActionsSinks.ql
+++ b/actions/ql/src/Models/CompositeActionsSinks.ql
@@ -24,6 +24,8 @@ private module MyConfig implements DataFlow::ConfigSig {
   predicate isSink(DataFlow::Node sink) {
     sink instanceof CodeInjectionSink and not madSink(sink, "code-injection")
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 module MyFlow = TaintTracking::Global<MyConfig>;

--- a/actions/ql/src/Models/CompositeActionsSources.ql
+++ b/actions/ql/src/Models/CompositeActionsSources.ql
@@ -34,6 +34,8 @@ private module MyConfig implements DataFlow::ConfigSig {
     isSink(node) and
     set instanceof DataFlow::FieldContent
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 module MyFlow = TaintTracking::Global<MyConfig>;

--- a/actions/ql/src/Models/CompositeActionsSummaries.ql
+++ b/actions/ql/src/Models/CompositeActionsSummaries.ql
@@ -25,6 +25,8 @@ private module MyConfig implements DataFlow::ConfigSig {
   predicate isSink(DataFlow::Node sink) {
     exists(CompositeAction c | c.getAnOutputExpr() = sink.asExpr())
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 module MyFlow = TaintTracking::Global<MyConfig>;

--- a/actions/ql/src/Models/ReusableWorkflowsSinks.ql
+++ b/actions/ql/src/Models/ReusableWorkflowsSinks.ql
@@ -24,6 +24,8 @@ private module MyConfig implements DataFlow::ConfigSig {
   predicate isSink(DataFlow::Node sink) {
     sink instanceof CodeInjectionSink and not madSink(sink, "code-injection")
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 module MyFlow = TaintTracking::Global<MyConfig>;

--- a/actions/ql/src/Models/ReusableWorkflowsSources.ql
+++ b/actions/ql/src/Models/ReusableWorkflowsSources.ql
@@ -34,6 +34,8 @@ private module MyConfig implements DataFlow::ConfigSig {
     isSink(node) and
     set instanceof DataFlow::FieldContent
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 module MyFlow = TaintTracking::Global<MyConfig>;

--- a/actions/ql/src/Models/ReusableWorkflowsSummaries.ql
+++ b/actions/ql/src/Models/ReusableWorkflowsSummaries.ql
@@ -25,6 +25,8 @@ private module MyConfig implements DataFlow::ConfigSig {
   predicate isSink(DataFlow::Node sink) {
     exists(ReusableWorkflow w | w.getAnOutputExpr() = sink.asExpr())
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 module MyFlow = TaintTracking::Global<MyConfig>;


### PR DESCRIPTION
An auto-generated patch that enables diff-informed data flow in the obvious cases.

Builds on https://github.com/github/codeql/pull/18346 and https://github.com/github/codeql-patch/pull/88
