### PR TITLE
Go: mass enable diff-informed data flow

### DIFF
--- a/go/ql/lib/semmle/go/security/CleartextLogging.qll
+++ b/go/ql/lib/semmle/go/security/CleartextLogging.qll
@@ -46,6 +46,8 @@ module CleartextLogging {
       // Also exclude protobuf field fetches, since they amount to single field reads.
       not any(Protobuf::GetMethod gm).taintStep(src, trg)
     }
+
+    predicate observeDiffInformedIncrementalMode() { any() }
   }
 
   /**

--- a/go/ql/lib/semmle/go/security/ExternalAPIs.qll
+++ b/go/ql/lib/semmle/go/security/ExternalAPIs.qll
@@ -197,6 +197,8 @@ private module UntrustedDataToUnknownExternalApiConfig implements DataFlow::Conf
   predicate isSource(DataFlow::Node source) { source instanceof ActiveThreatModelSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof UnknownExternalApiDataNode }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/go/ql/lib/semmle/go/security/LogInjection.qll
+++ b/go/ql/lib/semmle/go/security/LogInjection.qll
@@ -21,6 +21,8 @@ module LogInjection {
     predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
 
     predicate isBarrier(DataFlow::Node sanitizer) { sanitizer instanceof Sanitizer }
+
+    predicate observeDiffInformedIncrementalMode() { any() }
   }
 
   /** Tracks taint flow for reasoning about log injection vulnerabilities. */

--- a/go/ql/lib/semmle/go/security/MissingJwtSignatureCheck.qll
+++ b/go/ql/lib/semmle/go/security/MissingJwtSignatureCheck.qll
@@ -23,6 +23,8 @@ module MissingJwtSignatureCheck {
     predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
       any(AdditionalFlowStep s).step(nodeFrom, nodeTo)
     }
+
+    predicate observeDiffInformedIncrementalMode() { any() }
   }
 
   /** Tracks taint flow for reasoning about JWT vulnerabilities. */

--- a/go/ql/lib/semmle/go/security/OpenUrlRedirect.qll
+++ b/go/ql/lib/semmle/go/security/OpenUrlRedirect.qll
@@ -54,6 +54,8 @@ module OpenUrlRedirect {
       or
       hostnameSanitizingPrefixEdge(node, _)
     }
+
+    predicate observeDiffInformedIncrementalMode() { any() }
   }
 
   /** Tracks taint flow from unvalidated, untrusted data to URL redirections. */

--- a/go/ql/lib/semmle/go/security/SqlInjection.qll
+++ b/go/ql/lib/semmle/go/security/SqlInjection.qll
@@ -23,6 +23,8 @@ module SqlInjection {
     }
 
     predicate isBarrier(DataFlow::Node node) { node instanceof Sanitizer }
+
+    predicate observeDiffInformedIncrementalMode() { any() }
   }
 
   /** Tracks taint flow for reasoning about SQL-injection vulnerabilities. */

--- a/go/ql/lib/semmle/go/security/StoredCommand.qll
+++ b/go/ql/lib/semmle/go/security/StoredCommand.qll
@@ -26,6 +26,8 @@ module StoredCommand {
     predicate isSink(DataFlow::Node sink) { sink instanceof CommandInjection::Sink }
 
     predicate isBarrier(DataFlow::Node node) { node instanceof CommandInjection::Sanitizer }
+
+    predicate observeDiffInformedIncrementalMode() { any() }
   }
 
   /** Tracks taint flow for reasoning about command-injection vulnerabilities. */

--- a/go/ql/lib/semmle/go/security/StoredXss.qll
+++ b/go/ql/lib/semmle/go/security/StoredXss.qll
@@ -22,6 +22,8 @@ module StoredXss {
     predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
 
     predicate isBarrier(DataFlow::Node node) { node instanceof Sanitizer }
+
+    predicate observeDiffInformedIncrementalMode() { any() }
   }
 
   /** Tracks taint flow for reasoning about XSS. */

--- a/go/ql/lib/semmle/go/security/StringBreak.qll
+++ b/go/ql/lib/semmle/go/security/StringBreak.qll
@@ -26,6 +26,8 @@ module StringBreak {
     predicate isBarrier(DataFlow::Node node, FlowState state) {
       state = node.(Sanitizer).getQuote()
     }
+
+    predicate observeDiffInformedIncrementalMode() { any() }
   }
 
   /**

--- a/go/ql/lib/semmle/go/security/TaintedPath.qll
+++ b/go/ql/lib/semmle/go/security/TaintedPath.qll
@@ -17,6 +17,8 @@ module TaintedPath {
     predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
 
     predicate isBarrier(DataFlow::Node node) { node instanceof Sanitizer }
+
+    predicate observeDiffInformedIncrementalMode() { any() }
   }
 
   /** Tracks taint flow for reasoning about path-traversal vulnerabilities. */

--- a/go/ql/lib/semmle/go/security/UncontrolledAllocationSize.qll
+++ b/go/ql/lib/semmle/go/security/UncontrolledAllocationSize.qll
@@ -27,6 +27,8 @@ module UncontrolledAllocationSize {
         node2 = cn.getResult(0)
       )
     }
+
+    predicate observeDiffInformedIncrementalMode() { any() }
   }
 
   /** Tracks taint flow for reasoning about uncontrolled allocation size issues. */

--- a/go/ql/lib/semmle/go/security/UnsafeUnzipSymlink.qll
+++ b/go/ql/lib/semmle/go/security/UnsafeUnzipSymlink.qll
@@ -44,6 +44,8 @@ module UnsafeUnzipSymlink {
     predicate isSink(DataFlow::Node sink) { sink instanceof SymlinkSink }
 
     predicate isBarrier(DataFlow::Node node) { node instanceof SymlinkSanitizer }
+
+    predicate observeDiffInformedIncrementalMode() { any() }
   }
 
   /**

--- a/go/ql/lib/semmle/go/security/XPathInjection.qll
+++ b/go/ql/lib/semmle/go/security/XPathInjection.qll
@@ -19,6 +19,8 @@ module XPathInjection {
     predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
 
     predicate isBarrier(DataFlow::Node node) { node instanceof Sanitizer }
+
+    predicate observeDiffInformedIncrementalMode() { any() }
   }
 
   /**

--- a/go/ql/lib/semmle/go/security/ZipSlip.qll
+++ b/go/ql/lib/semmle/go/security/ZipSlip.qll
@@ -17,6 +17,8 @@ module ZipSlip {
     predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
 
     predicate isBarrier(DataFlow::Node node) { node instanceof Sanitizer }
+
+    predicate observeDiffInformedIncrementalMode() { any() }
   }
 
   /** Tracks taint flow for reasoning about zip-slip vulnerabilities. */

--- a/go/ql/src/Security/CWE-020/IncompleteHostnameRegexp.ql
+++ b/go/ql/src/Security/CWE-020/IncompleteHostnameRegexp.ql
@@ -103,6 +103,8 @@ module IncompleteHostNameRegexpConfig implements DataFlow::ConfigSig {
   predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
     StringOps::Concatenation::taintStep(node1, node2)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 module Flow = DataFlow::Global<IncompleteHostNameRegexpConfig>;

--- a/go/ql/src/Security/CWE-020/MissingRegexpAnchor.ql
+++ b/go/ql/src/Security/CWE-020/MissingRegexpAnchor.ql
@@ -72,6 +72,8 @@ module Config implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) { isSourceString(source, _) }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof RegexpPattern }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 module Flow = DataFlow::Global<Config>;

--- a/go/ql/src/Security/CWE-020/SuspiciousCharacterInRegexp.ql
+++ b/go/ql/src/Security/CWE-020/SuspiciousCharacterInRegexp.ql
@@ -40,6 +40,8 @@ module SuspiciousCharacterInRegexpConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) { isSourceString(source, _) }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof RegexpPattern }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/go/ql/src/Security/CWE-209/StackTraceExposure.ql
+++ b/go/ql/src/Security/CWE-209/StackTraceExposure.ql
@@ -62,6 +62,8 @@ module StackTraceExposureConfig implements DataFlow::ConfigSig {
       cgn.dominates(node.getBasicBlock())
     )
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/go/ql/src/Security/CWE-326/InsufficientKeySize.ql
+++ b/go/ql/src/Security/CWE-326/InsufficientKeySize.ql
@@ -25,6 +25,8 @@ module Config implements DataFlow::ConfigSig {
   predicate isBarrier(DataFlow::Node node) {
     node = DataFlow::BarrierGuard<comparisonBarrierGuard/3>::getABarrierNode()
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/go/ql/src/Security/CWE-352/ConstantOauth2State.ql
+++ b/go/ql/src/Security/CWE-352/ConstantOauth2State.ql
@@ -40,6 +40,8 @@ module ConstantStateFlowConfig implements DataFlow::ConfigSig {
   }
 
   predicate isSink(DataFlow::Node sink) { isSinkCall(sink, _) }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/go/ql/src/Security/CWE-640/EmailInjection.qll
+++ b/go/ql/src/Security/CWE-640/EmailInjection.qll
@@ -20,6 +20,8 @@ module EmailInjection {
     predicate isSource(DataFlow::Node source) { source instanceof Source }
 
     predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
+
+    predicate observeDiffInformedIncrementalMode() { any() }
   }
 
   /** Tracks taint flow for reasoning about email-injection vulnerabilities. */

--- a/go/ql/src/experimental/CWE-090/LDAPInjection.qll
+++ b/go/ql/src/experimental/CWE-090/LDAPInjection.qll
@@ -101,6 +101,8 @@ private module LdapInjectionConfig implements DataFlow::ConfigSig {
   predicate isSink(DataFlow::Node sink) { sink instanceof LdapSink }
 
   predicate isBarrier(DataFlow::Node node) { node instanceof LdapSanitizer }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/go/ql/src/experimental/CWE-203/Timing.ql
+++ b/go/ql/src/experimental/CWE-203/Timing.ql
@@ -102,6 +102,8 @@ module Config implements DataFlow::ConfigSig {
   }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof Sink and not isBadResult(sink) }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 module Flow = TaintTracking::Global<Config>;

--- a/go/ql/src/experimental/CWE-285/PamAuthBypass.ql
+++ b/go/ql/src/experimental/CWE-285/PamAuthBypass.ql
@@ -42,6 +42,8 @@ module PamStartToAcctMgmtConfig implements DataFlow::ConfigSig {
   predicate isSink(DataFlow::Node sink) {
     exists(PamAcctMgmt p | p.getACall().getReceiver() = sink)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 module PamStartToAcctMgmtFlow = TaintTracking::Global<PamStartToAcctMgmtConfig>;
@@ -55,6 +57,8 @@ module PamStartToAuthenticateConfig implements DataFlow::ConfigSig {
   predicate isSink(DataFlow::Node sink) {
     exists(PamAuthenticate p | p.getACall().getReceiver() = sink)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 module PamStartToAuthenticateFlow = TaintTracking::Global<PamStartToAuthenticateConfig>;

--- a/go/ql/src/experimental/CWE-287/ImproperLdapAuthCustomizations.qll
+++ b/go/ql/src/experimental/CWE-287/ImproperLdapAuthCustomizations.qll
@@ -74,6 +74,8 @@ module ImproperLdapAuth {
     predicate isSink(DataFlow::Node sink) { sink instanceof LdapAuthSink }
 
     predicate isBarrier(DataFlow::Node node) { node instanceof LdapSanitizer }
+
+    predicate observeDiffInformedIncrementalMode() { any() }
   }
 
   /**

--- a/go/ql/src/experimental/CWE-321-V2/HardCodedKeys.ql
+++ b/go/ql/src/experimental/CWE-321-V2/HardCodedKeys.ql
@@ -33,6 +33,8 @@ module JwtParseWithConstantKeyConfig implements DataFlow::ConfigSig {
     // second part is the JWT Parsing Functions that get a string or byte as an argument
     sink = any(JwtParse jp).getKeyArg()
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 module GolangJwtKeyFuncConfig implements DataFlow::ConfigSig {

--- a/go/ql/src/experimental/CWE-327/WeakCryptoAlgorithmCustomizations.qll
+++ b/go/ql/src/experimental/CWE-327/WeakCryptoAlgorithmCustomizations.qll
@@ -54,6 +54,8 @@ module WeakCryptoAlgorithm {
     predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
 
     predicate isBarrier(DataFlow::Node node) { node instanceof Sanitizer }
+
+    predicate observeDiffInformedIncrementalMode() { any() }
   }
 
   /**

--- a/go/ql/src/experimental/CWE-369/DivideByZero.ql
+++ b/go/ql/src/experimental/CWE-369/DivideByZero.ql
@@ -45,6 +45,8 @@ module Config implements DataFlow::ConfigSig {
   predicate isSink(DataFlow::Node sink) {
     sink = DataFlow::exprNode(any(QuoExpr e).getRightOperand())
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/go/ql/src/experimental/CWE-74/DsnInjectionCustomizations.qll
+++ b/go/ql/src/experimental/CWE-74/DsnInjectionCustomizations.qll
@@ -19,6 +19,8 @@ private module DsnInjectionConfig implements DataFlow::ConfigSig {
   }
 
   predicate isBarrier(DataFlow::Node node) { node instanceof RegexpCheckBarrier }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/go/ql/src/experimental/frameworks/DecompressionBombs.qll
+++ b/go/ql/src/experimental/frameworks/DecompressionBombs.qll
@@ -56,6 +56,8 @@ module DecompressionBomb {
         addStep.isAdditionalFlowStep(fromNode, fromState, toNode, toState)
       )
     }
+
+    predicate observeDiffInformedIncrementalMode() { any() }
   }
 
   /** Tracks taint flow for reasoning about decompression bomb vulnerabilities. */


### PR DESCRIPTION
An auto-generated patch that enables diff-informed data flow in the obvious cases.

Builds on https://github.com/github/codeql/pull/18345 and https://github.com/github/codeql-patch/pull/88
