### PR TITLE
Swift: mass enable diff-informed data flow

### DIFF
--- a/swift/ql/lib/codeql/swift/security/CleartextLoggingQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/CleartextLoggingQuery.qll
@@ -25,6 +25,8 @@ module CleartextLoggingConfig implements DataFlow::ConfigSig {
   predicate isAdditionalFlowStep(DataFlow::Node n1, DataFlow::Node n2) {
     any(CleartextLoggingAdditionalFlowStep s).step(n1, n2)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/swift/ql/lib/codeql/swift/security/CleartextTransmissionQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/CleartextTransmissionQuery.qll
@@ -28,6 +28,8 @@ module CleartextTransmissionConfig implements DataFlow::ConfigSig {
     // make sources barriers so that we only report the closest instance
     isSource(node)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/swift/ql/lib/codeql/swift/security/CommandInjectionQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/CommandInjectionQuery.qll
@@ -23,6 +23,8 @@ module CommandInjectionConfig implements DataFlow::ConfigSig {
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
     any(CommandInjectionAdditionalFlowStep s).step(nodeFrom, nodeTo)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/swift/ql/lib/codeql/swift/security/ConstantPasswordQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/ConstantPasswordQuery.qll
@@ -38,6 +38,8 @@ module ConstantPasswordConfig implements DataFlow::ConfigSig {
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
     any(ConstantPasswordAdditionalFlowStep s).step(nodeFrom, nodeTo)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 module ConstantPasswordFlow = TaintTracking::Global<ConstantPasswordConfig>;

--- a/swift/ql/lib/codeql/swift/security/ConstantSaltQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/ConstantSaltQuery.qll
@@ -39,6 +39,8 @@ module ConstantSaltConfig implements DataFlow::ConfigSig {
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
     any(ConstantSaltAdditionalFlowStep s).step(nodeFrom, nodeTo)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 module ConstantSaltFlow = TaintTracking::Global<ConstantSaltConfig>;

--- a/swift/ql/lib/codeql/swift/security/ECBEncryptionQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/ECBEncryptionQuery.qll
@@ -22,6 +22,8 @@ module EcbEncryptionConfig implements DataFlow::ConfigSig {
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
     any(EcbEncryptionAdditionalFlowStep s).step(nodeFrom, nodeTo)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 module EcbEncryptionFlow = DataFlow::Global<EcbEncryptionConfig>;

--- a/swift/ql/lib/codeql/swift/security/HardcodedEncryptionKeyQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/HardcodedEncryptionKeyQuery.qll
@@ -46,6 +46,8 @@ module HardcodedKeyConfig implements DataFlow::ConfigSig {
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
     any(HardcodedEncryptionKeyAdditionalFlowStep s).step(nodeFrom, nodeTo)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 module HardcodedKeyFlow = TaintTracking::Global<HardcodedKeyConfig>;

--- a/swift/ql/lib/codeql/swift/security/InsecureTLSQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/InsecureTLSQuery.qll
@@ -21,6 +21,8 @@ module InsecureTlsConfig implements DataFlow::ConfigSig {
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
     any(InsecureTlsExtensionsAdditionalFlowStep s).step(nodeFrom, nodeTo)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 module InsecureTlsFlow = TaintTracking::Global<InsecureTlsConfig>;

--- a/swift/ql/lib/codeql/swift/security/InsecureTLSQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/InsecureTLSQuery.qll
@@ -21,8 +21,6 @@ module InsecureTlsConfig implements DataFlow::ConfigSig {
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
     any(InsecureTlsExtensionsAdditionalFlowStep s).step(nodeFrom, nodeTo)
   }
-
-  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 module InsecureTlsFlow = TaintTracking::Global<InsecureTlsConfig>;

--- a/swift/ql/lib/codeql/swift/security/InsufficientHashIterationsQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/InsufficientHashIterationsQuery.qll
@@ -34,6 +34,8 @@ module InsufficientHashIterationsConfig implements DataFlow::ConfigSig {
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
     any(InsufficientHashIterationsAdditionalFlowStep s).step(nodeFrom, nodeTo)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 module InsufficientHashIterationsFlow = TaintTracking::Global<InsufficientHashIterationsConfig>;

--- a/swift/ql/lib/codeql/swift/security/PathInjectionQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/PathInjectionQuery.qll
@@ -23,6 +23,8 @@ module PathInjectionConfig implements DataFlow::ConfigSig {
   predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
     any(PathInjectionAdditionalFlowStep s).step(node1, node2)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/swift/ql/lib/codeql/swift/security/PredicateInjectionQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/PredicateInjectionQuery.qll
@@ -22,6 +22,8 @@ module PredicateInjectionConfig implements DataFlow::ConfigSig {
   predicate isAdditionalFlowStep(DataFlow::Node n1, DataFlow::Node n2) {
     any(PredicateInjectionAdditionalFlowStep s).step(n1, n2)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/swift/ql/lib/codeql/swift/security/SqlInjectionQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/SqlInjectionQuery.qll
@@ -23,6 +23,8 @@ module SqlInjectionConfig implements DataFlow::ConfigSig {
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
     any(SqlInjectionAdditionalFlowStep s).step(nodeFrom, nodeTo)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/swift/ql/lib/codeql/swift/security/StaticInitializationVectorQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/StaticInitializationVectorQuery.qll
@@ -40,6 +40,8 @@ module StaticInitializationVectorConfig implements DataFlow::ConfigSig {
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
     any(StaticInitializationVectorAdditionalFlowStep s).step(nodeFrom, nodeTo)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 module StaticInitializationVectorFlow = TaintTracking::Global<StaticInitializationVectorConfig>;

--- a/swift/ql/lib/codeql/swift/security/StringLengthConflationQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/StringLengthConflationQuery.qll
@@ -39,6 +39,8 @@ module StringLengthConflationConfig implements DataFlow::StateConfigSig {
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
     any(StringLengthConflationAdditionalFlowStep s).step(nodeFrom, nodeTo)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/swift/ql/lib/codeql/swift/security/UncontrolledFormatStringQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/UncontrolledFormatStringQuery.qll
@@ -23,6 +23,8 @@ module TaintedFormatConfig implements DataFlow::ConfigSig {
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
     any(UncontrolledFormatStringAdditionalFlowStep s).step(nodeFrom, nodeTo)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/swift/ql/lib/codeql/swift/security/UnsafeJsEvalQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/UnsafeJsEvalQuery.qll
@@ -22,6 +22,8 @@ module UnsafeJsEvalConfig implements DataFlow::ConfigSig {
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
     any(UnsafeJsEvalAdditionalFlowStep s).step(nodeFrom, nodeTo)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/swift/ql/lib/codeql/swift/security/UnsafeUnpackQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/UnsafeUnpackQuery.qll
@@ -24,6 +24,8 @@ module UnsafeUnpackConfig implements DataFlow::ConfigSig {
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
     any(UnsafeUnpackAdditionalFlowStep s).step(nodeFrom, nodeTo)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/swift/ql/lib/codeql/swift/security/WeakPasswordHashingQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/WeakPasswordHashingQuery.qll
@@ -37,6 +37,8 @@ module WeakPasswordHashingConfig implements DataFlow::ConfigSig {
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
     any(WeakPasswordHashingAdditionalFlowStep s).step(nodeFrom, nodeTo)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 module WeakPasswordHashingFlow = TaintTracking::Global<WeakPasswordHashingConfig>;

--- a/swift/ql/lib/codeql/swift/security/WeakSensitiveDataHashingQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/WeakSensitiveDataHashingQuery.qll
@@ -38,6 +38,8 @@ module WeakSensitiveDataHashingConfig implements DataFlow::ConfigSig {
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
     any(WeakSensitiveDataHashingAdditionalFlowStep s).step(nodeFrom, nodeTo)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 module WeakSensitiveDataHashingFlow = TaintTracking::Global<WeakSensitiveDataHashingConfig>;

--- a/swift/ql/lib/codeql/swift/security/XXEQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/XXEQuery.qll
@@ -22,6 +22,8 @@ module XxeConfig implements DataFlow::ConfigSig {
   predicate isAdditionalFlowStep(DataFlow::Node n1, DataFlow::Node n2) {
     any(XxeAdditionalFlowStep s).step(n1, n2)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/swift/ql/lib/codeql/swift/security/regex/RegexInjectionQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/regex/RegexInjectionQuery.qll
@@ -22,6 +22,8 @@ module RegexInjectionConfig implements DataFlow::ConfigSig {
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
     any(RegexInjectionAdditionalFlowStep s).step(nodeFrom, nodeTo)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**


### PR DESCRIPTION
An auto-generated patch that enables diff-informed data flow in the obvious cases.

Builds on https://github.com/github/codeql/pull/18343 and https://github.com/github/codeql-patch/pull/88
