### PR TITLE
C++: mass enable diff-informed data flow

### DIFF
--- a/cpp/ql/lib/experimental/semmle/code/cpp/security/PrivateCleartextWrite.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/security/PrivateCleartextWrite.qll
@@ -42,6 +42,8 @@ module PrivateCleartextWrite {
     predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
 
     predicate isBarrier(DataFlow::Node node) { node instanceof Sanitizer }
+
+    predicate observeDiffInformedIncrementalMode() { any() }
   }
 
   module WriteFlow = TaintTracking::Global<WriteConfig>;

--- a/cpp/ql/src/Likely Bugs/Conversion/CastArrayPointerArithmetic.ql
+++ b/cpp/ql/src/Likely Bugs/Conversion/CastArrayPointerArithmetic.ql
@@ -48,6 +48,8 @@ module CastToPointerArithFlowConfig implements DataFlow::StateConfigSig {
   predicate isBarrierIn(DataFlow::Node node) { isSource(node, _) }
 
   predicate isBarrierOut(DataFlow::Node node) { isSink(node, _) }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/cpp/ql/src/Likely Bugs/Memory Management/NtohlArrayNoBound.qll
+++ b/cpp/ql/src/Likely Bugs/Memory Management/NtohlArrayNoBound.qll
@@ -141,6 +141,8 @@ private module NetworkToBufferSizeConfig implements DataFlow::ConfigSig {
       gc.controls(node.asExpr().getBasicBlock(), _)
     )
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 module NetworkToBufferSizeFlow = DataFlow::Global<NetworkToBufferSizeConfig>;

--- a/cpp/ql/src/Security/CWE/CWE-114/UncontrolledProcessOperation.ql
+++ b/cpp/ql/src/Security/CWE/CWE-114/UncontrolledProcessOperation.ql
@@ -39,6 +39,8 @@ module Config implements DataFlow::ConfigSig {
     or
     node.asCertainDefinition().getUnspecifiedType() instanceof ArithmeticType
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 module Flow = TaintTracking::Global<Config>;

--- a/cpp/ql/src/Security/CWE/CWE-129/ImproperArrayIndexValidation.ql
+++ b/cpp/ql/src/Security/CWE/CWE-129/ImproperArrayIndexValidation.ql
@@ -66,6 +66,8 @@ module ImproperArrayIndexValidationConfig implements DataFlow::ConfigSig {
       not offsetIsAlwaysInBounds(arrayExpr, offsetExpr)
     )
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 module ImproperArrayIndexValidation = TaintTracking::Global<ImproperArrayIndexValidationConfig>;

--- a/cpp/ql/src/Security/CWE/CWE-134/UncontrolledFormatString.ql
+++ b/cpp/ql/src/Security/CWE/CWE-134/UncontrolledFormatString.ql
@@ -44,6 +44,8 @@ module Config implements DataFlow::ConfigSig {
     or
     isArithmeticNonCharType(node.asCertainDefinition().getUnspecifiedType())
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 module Flow = TaintTracking::Global<Config>;

--- a/cpp/ql/src/Security/CWE/CWE-190/IntegerOverflowTainted.ql
+++ b/cpp/ql/src/Security/CWE/CWE-190/IntegerOverflowTainted.ql
@@ -94,6 +94,8 @@ module Config implements DataFlow::ConfigSig {
       not iTo instanceof PointerArithmeticInstruction
     )
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 module Flow = TaintTracking::Global<Config>;

--- a/cpp/ql/src/Security/CWE/CWE-497/ExposedSystemData.ql
+++ b/cpp/ql/src/Security/CWE/CWE-497/ExposedSystemData.ql
@@ -34,6 +34,8 @@ module ExposedSystemDataConfig implements DataFlow::ConfigSig {
   predicate isBarrier(DataFlow::Node node) {
     node.asIndirectArgument() = any(MemsetFunction func).getACallToThisFunction().getAnArgument()
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 module ExposedSystemData = TaintTracking::Global<ExposedSystemDataConfig>;

--- a/cpp/ql/src/Security/CWE/CWE-497/PotentiallyExposedSystemData.ql
+++ b/cpp/ql/src/Security/CWE/CWE-497/PotentiallyExposedSystemData.ql
@@ -54,6 +54,8 @@ module PotentiallyExposedSystemDataConfig implements DataFlow::ConfigSig {
   predicate isBarrier(DataFlow::Node node) {
     node.asIndirectArgument() = any(MemsetFunction func).getACallToThisFunction().getAnArgument()
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 module PotentiallyExposedSystemData = TaintTracking::Global<PotentiallyExposedSystemDataConfig>;

--- a/cpp/ql/src/Security/CWE/CWE-611/XXE.ql
+++ b/cpp/ql/src/Security/CWE/CWE-611/XXE.ql
@@ -45,6 +45,8 @@ module XxeConfig implements DataFlow::StateConfigSig {
   }
 
   predicate neverSkip(DataFlow::Node node) { none() }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 module XxeFlow = DataFlow::GlobalWithState<XxeConfig>;

--- a/cpp/ql/src/experimental/Security/CWE/CWE-078/WordexpTainted.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-078/WordexpTainted.ql
@@ -48,6 +48,8 @@ module WordexpTaintConfig implements DataFlow::ConfigSig {
   predicate isBarrier(DataFlow::Node node) {
     node.asExpr().getUnspecifiedType() instanceof IntegralType
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 module WordexpTaint = TaintTracking::Global<WordexpTaintConfig>;

--- a/cpp/ql/src/experimental/Security/CWE/CWE-190/AllocMultiplicationOverflow.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-190/AllocMultiplicationOverflow.ql
@@ -30,6 +30,8 @@ module MultToAllocConfig implements DataFlow::ConfigSig {
     // something that affects an allocation size
     node.asExpr() = any(HeuristicAllocationExpr ae).getSizeExpr().getAChild*()
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 module MultToAlloc = DataFlow::Global<MultToAllocConfig>;


### PR DESCRIPTION
An auto-generated patch that enables diff-informed data flow in the obvious cases.

Builds on https://github.com/github/codeql/pull/18342 and https://github.com/github/codeql-patch/pull/88
