### PR TITLE
Actions: Make `Env` non-abstract

### DIFF
--- a/actions/ql/lib/codeql/actions/Ast.qll
+++ b/actions/ql/lib/codeql/actions/Ast.qll
@@ -50,8 +50,8 @@ class Expression extends AstNode instanceof ExpressionImpl {
   string getNormalizedExpression() { result = normalizeExpr(expression) }
 }
 
-/** A common class for `env` in workflow, job or step. */
-abstract class Env extends AstNode instanceof EnvImpl {
+/** An `env` in workflow, job or step. */
+class Env extends AstNode instanceof EnvImpl {
   /** Gets an environment variable value given its name. */
   ScalarValueImpl getEnvVarValue(string name) { result = super.getEnvVarValue(name) }
 


### PR DESCRIPTION
`class Env` was previously abstract with no concrete descendants, so user queries like `any(Env e | ...)` would never produce results.

In the JS library the corresponding class derived from `YamlNode` and has concrete descendants representing workflow-, job- and step-level `env` nodes. However these are dubiously useful since you can always just use `any(Step s).getEnv()` to achieve the same result. Since `EnvImpl` already fully characterises an `env` node, I simply make the class concrete.