### PR TITLE
C#: Freeze quality queries in the security-and-quality suite.

### DIFF
--- a/csharp/ql/src/codeql-suites/csharp-security-and-quality.qls
+++ b/csharp/ql/src/codeql-suites/csharp-security-and-quality.qls
@@ -1,4 +1,143 @@
 - description: Security-and-quality queries for C#
 - queries: .
-- apply: security-and-quality-selectors.yml
-  from: codeql/suite-helpers
+- include:
+    kind:
+    - problem
+    - path-problem
+    precision:
+    - high
+    - very-high
+    tags contain:
+    - security
+- include:
+    kind:
+    - problem
+    - path-problem
+    precision: medium
+    problem.severity:
+    - error
+    - warning
+    tags contain:
+    - security
+- include:
+    id:
+      - cs/asp/response-write
+      - cs/call-to-gc
+      - cs/call-to-object-tostring
+      - cs/call-to-obsolete-method
+      - cs/call-to-unmanaged-code
+      - cs/cast-from-abstract-to-concrete-collection
+      - cs/cast-of-this-to-type-parameter
+      - cs/catch-nullreferenceexception
+      - cs/catch-of-all-exceptions
+      - cs/chained-type-tests
+      - cs/class-implements-icloneable
+      - cs/class-missing-equals
+      - cs/class-name-comparison
+      - cs/class-name-matches-base-class
+      - cs/coalesce-of-identical-expressions
+      - cs/comparison-of-identical-expressions
+      - cs/complex-block
+      - cs/complex-condition
+      - cs/constant-comparison
+      - cs/constant-condition
+      - cs/coupled-types
+      - cs/dereferenced-value-is-always-null
+      - cs/dereferenced-value-may-be-null
+      - cs/dispose-not-called-on-throw
+      - cs/downcast-of-this
+      - cs/empty-block
+      - cs/empty-catch-block
+      - cs/empty-collection
+      - cs/empty-lock-statement
+      - cs/equality-on-floats
+      - cs/equals-on-arrays
+      - cs/equals-on-unrelated-types
+      - cs/equals-uses-as
+      - cs/equals-uses-is
+      - cs/expose-implementation
+      - cs/field-masks-base-field
+      - cs/gethashcode-is-not-defined
+      - cs/impossible-array-cast
+      - cs/inconsistent-compareto-and-equals
+      - cs/inconsistent-equals-and-gethashcode
+      - cs/inconsistent-lock-sequence
+      - cs/index-out-of-bounds
+      - cs/inefficient-containskey
+      - cs/invalid-dynamic-call
+      - cs/invalid-string-formatting
+      - cs/linq/inconsistent-enumeration
+      - cs/linq/missed-all
+      - cs/linq/missed-cast
+      - cs/linq/missed-oftype
+      - cs/linq/missed-select
+      - cs/linq/missed-where
+      - cs/linq/useless-select
+      - cs/local-not-disposed
+      - cs/local-shadows-member
+      - cs/lock-this
+      - cs/locked-wait
+      - cs/loss-of-precision
+      - cs/mishandling-japanese-era
+      - cs/misleading-indentation
+      - cs/missed-readonly-modifier
+      - cs/missed-ternary-operator
+      - cs/missed-using-statement
+      - cs/nested-if-statements
+      - cs/nested-loops-with-same-variable
+      - cs/non-short-circuit
+      - cs/null-argument-to-equals
+      - cs/path-combine
+      - cs/recursive-equals-call
+      - cs/recursive-operator-equals-call
+      - cs/reference-equality-on-valuetypes
+      - cs/reference-equality-with-object
+      - cs/rethrown-exception-variable
+      - cs/self-assignment
+      - cs/simplifiable-boolean-expression
+      - cs/static-field-written-by-instance
+      - cs/string-concatenation-in-loop
+      - cs/stringbuilder-creation-in-loop
+      - cs/stringbuilder-initialized-with-character
+      - cs/test-for-negative-container-size
+      - cs/too-many-ref-parameters
+      - cs/type-test-of-this
+      - cs/unchecked-cast-in-equals
+      - cs/unmanaged-code
+      - cs/unsafe-double-checked-lock
+      - cs/unsafe-sync-on-field
+      - cs/unsafe-year-construction
+      - cs/unsynchronized-getter
+      - cs/unsynchronized-static-access
+      - cs/unused-collection
+      - cs/unused-label
+      - cs/unused-property-value
+      - cs/useless-assignment-to-local
+      - cs/useless-cast-to-self
+      - cs/useless-gethashcode-call
+      - cs/useless-if-statement
+      - cs/useless-tostring-call
+      - cs/useless-type-test
+      - cs/useless-upcast
+      - cs/virtual-call-in-constructor
+      - cs/wrong-compareto-signature
+      - cs/wrong-equals-signature
+      - cs/xmldoc/missing-summary
+- include:
+    kind:
+    - diagnostic
+- include:
+    kind:
+    - metric
+    tags contain:
+    - summary
+- exclude:
+    deprecated: //
+- exclude:
+    query path:
+      - /^experimental\/.*/
+      - Metrics/Summaries/FrameworkCoverage.ql
+- exclude:
+    tags contain:
+      - modeleditor
+      - modelgenerator


### PR DESCRIPTION
Freeze the quality queries in `security-and-quality` for C# (to avoid accidentally adding new quality queries to this suite).