### PR TITLE
Rust: Fix bad join

### DIFF
--- a/rust/ql/lib/codeql/rust/elements/internal/GenericArgListImpl.qll
+++ b/rust/ql/lib/codeql/rust/elements/internal/GenericArgListImpl.qll
@@ -26,6 +26,7 @@ module Impl {
     override string toAbbreviatedString() { result = "<...>" }
 
     /** Gets the `i`th type argument of this list. */
+    pragma[nomagic]
     TypeRepr getTypeArg(int i) {
       result =
         rank[i + 1](TypeRepr res, int j |

--- a/rust/ql/lib/codeql/rust/internal/TypeMention.qll
+++ b/rust/ql/lib/codeql/rust/internal/TypeMention.qll
@@ -130,6 +130,7 @@ class PathTypeReprMention extends TypeMention instanceof PathTypeRepr {
    * Holds if this path resolved to a type alias with a rhs. that has the
    * resulting type at `typePath`.
    */
+  pragma[nomagic]
   Type aliasResolveTypeAt(TypePath typePath) {
     exists(TypeAlias alias, TypeMention rhs | alias = resolved and rhs = alias.getTypeRepr() |
       result = rhs.resolveTypeAt(typePath) and


### PR DESCRIPTION
https://github.com/github/codeql/pull/19584 follow-up. The bad join appears to only happen when running the `SummaryStats.ql` query.

```
[2025-06-10 15:21:37] (83s) Tuple counts for TypeMention::PathTypeReprMention.aliasResolveTypeAt/1#dispred#ae16f47b#fbf#cpe#13/2@i5#5a5451wi after 57.7s:
                      205999      ~1028%     {3} r1 = JOIN `TypeMention::TypeMention.resolveTypeAt/1#dispred#a125c821#bff#reorder_1_0_2#prev_delta` WITH `_TypeAlias::Generated::TypeAlias.getTypeRepr/0#dispred#5fd7e521_TypeMention::PathTypeReprMention#a35__#join_rhs#1` ON FIRST 2 OUTPUT Rhs.2, Lhs.2 'result', Rhs.3 'this'
                                             {3}    | AND NOT `project#TypeMention::pathGetTypeParameter/2#fd301eed#2`(FIRST 2)
                      204000      ~982%      {2}    | SCAN OUTPUT In.2 'this', In.1 'result'

                      5499        ~448%      {7} r2 = JOIN `TypeMention::TypeMention.resolveTypeAt/1#dispred#a125c821#bff#reorder_0_2_1#prev_delta` WITH `_GenericArgList::GenericArgList.getTypeArg/1#dispred#1c780027_PathSegment::Generated::PathSegment.ge__#join_rhs#1` ON FIRST 1 OUTPUT Rhs.1, Rhs.2 'this', Rhs.3, Lhs.1 'result', _, Lhs.2, _
                                             {5}    | REWRITE WITH Tmp.4 := "", Tmp.6 := "", Out.4 := InverseAppend(Tmp.4,In.5,Tmp.6) KEEPING 5
                      2500        ~398%      {5}    | SCAN OUTPUT In.0, In.2, In.4, In.1 'this', In.3 'result'
                      0           ~0%        {2}    | JOIN WITH `TypeMention::TypeMention.resolveTypeAt/1#dispred#a125c821#bff#reorder_0_2_1#prev` ON FIRST 3 OUTPUT Lhs.3 'this', Lhs.4 'result'

                      9000        ~489%      {7} r3 = JOIN `TypeMention::TypeMention.resolveTypeAt/1#dispred#a125c821#bff#reorder_0_2_1#prev_delta` WITH `_PathSegment::Generated::PathSegment.getGenericArgList/0#dispred#e072653b__Path::Generated::Path.get__#join_rhs#1` ON FIRST 1 OUTPUT Rhs.1, Rhs.2 'this', Rhs.3, Lhs.1, _, Lhs.2, _
                                             {5}    | REWRITE WITH Tmp.4 := "", Tmp.6 := "", Out.4 := InverseAppend(In.5,Tmp.4,Tmp.6) KEEPING 5
                      5000        ~411%      {5}    | SCAN OUTPUT In.4, In.0, In.1 'this', In.2, In.3
                      10461919500 ~610%      {6}    | JOIN WITH `TypeMention::TypeMention.resolveTypeAt/1#dispred#a125c821#bff#reorder_1_0_2#prev` ON FIRST 1 OUTPUT Lhs.3, Rhs.1, Lhs.1, Lhs.2 'this', Lhs.4, Rhs.2 'result'
                      500         ~0%        {5}    | JOIN WITH `GenericArgList::GenericArgList.getTypeArg/1#dispred#1c780027_021#join_rhs` ON FIRST 2 OUTPUT Lhs.2, Rhs.2, Lhs.4, Lhs.3 'this', Lhs.5 'result'
                      0           ~0%        {2}    | JOIN WITH `TypeMention::pathGetTypeParameter/2#fd301eed` ON FIRST 3 OUTPUT Lhs.3 'this', Lhs.4 'result'

                      204000      ~982%      {2} r4 = r1 UNION r2 UNION r3
                      203964      ~982%      {2}    | AND NOT `TypeMention::PathTypeReprMention.aliasResolveTypeAt/1#dispred#ae16f47b#fbf#cpe#13#prev`(FIRST 2)
                                             return r4
```