### PR TITLE
C#: Add `cs/gethashcode-is-not-defined` to the Code Quality suite.

### DIFF
--- a/csharp/ql/integration-tests/posix/query-suite/csharp-code-quality.qls.expected
+++ b/csharp/ql/integration-tests/posix/query-suite/csharp-code-quality.qls.expected
@@ -8,6 +8,7 @@ ql/csharp/ql/src/Likely Bugs/Collections/ContainerLengthCmpOffByOne.ql
 ql/csharp/ql/src/Likely Bugs/Collections/ContainerSizeCmpZero.ql
 ql/csharp/ql/src/Likely Bugs/DangerousNonShortCircuitLogic.ql
 ql/csharp/ql/src/Likely Bugs/EqualityCheckOnFloats.ql
+ql/csharp/ql/src/Likely Bugs/HashedButNoHash.ql
 ql/csharp/ql/src/Likely Bugs/ReferenceEqualsOnValueTypes.ql
 ql/csharp/ql/src/Likely Bugs/SelfAssignment.ql
 ql/csharp/ql/src/Likely Bugs/UncheckedCastInEquals.ql

--- a/csharp/ql/src/Likely Bugs/HashedButNoHash.ql
+++ b/csharp/ql/src/Likely Bugs/HashedButNoHash.ql
@@ -7,6 +7,7 @@
  * @id cs/gethashcode-is-not-defined
  * @tags reliability
  *       maintainability
+ *       quality
  */
 
 import csharp


### PR DESCRIPTION
In this PR we add the query `cs/gethashcode-is-not-defined` to the Code Quality suite.
It is worth mentioning that
- There is compiler warning [CS0659](https://learn.microsoft.com/en-us/dotnet/csharp/misc/cs0659?f1url=%3FappId%3Droslyn%26k%3Dk(CS0659)) which reports all types where the `Equals` method is overridden, but where the `GetHashCode` is not. Our query is a bit more conservative in its approach by only reporting such types, if they are used in a hashing context.
- Only very few cases found via MRVA, but it looks like they would have been good to fix.
- There wasn't any triage data for this query. Created some examples and ran autofix locally - it provided good fix suggestions (in all cases it correctly applied `HashCode.Combine` to create a decent hash function).

DCA looks good.