### PR TITLE
Rust: Adjust the taint reach metric for better stability.

### DIFF
--- a/rust/ql/src/queries/summary/Stats.qll
+++ b/rust/ql/src/queries/summary/Stats.qll
@@ -189,6 +189,8 @@ predicate taintStats(string key, int value) {
   or
   key = "Taint reach - nodes tainted" and value = getTaintedNodesCount()
   or
+  key = "Taint reach - total non-summary nodes" and value = getTotalNodesCount()
+  or
   key = "Taint reach - per million nodes" and value = getTaintReach().floor()
   or
   key = "Taint sinks - query sinks" and value = getQuerySinksCount()

--- a/rust/ql/src/queries/summary/TaintReach.qll
+++ b/rust/ql/src/queries/summary/TaintReach.qll
@@ -26,7 +26,17 @@ private module TaintReachFlow = TaintTracking::Global<TaintReachConfig>;
  * We don't include flow summary nodes, as their number is unstable (varies when models
  * are added).
  */
-int getTaintedNodesCount() { result = count(DataFlow::Node n | TaintReachFlow::flowTo(n) and not n instanceof FlowSummaryNode) }
+int getTaintedNodesCount() {
+  result = count(DataFlow::Node n | TaintReachFlow::flowTo(n) and not n instanceof FlowSummaryNode)
+}
+
+/**
+ * Gets the total number of data flow nodes.
+ *
+ * We don't include flow summary nodes, as their number is unstable (varies when models
+ * are added).
+ */
+int getTotalNodesCount() { result = count(DataFlow::Node n | not n instanceof FlowSummaryNode) }
 
 /**
  * Gets the proportion of data flow nodes that taint reaches (from any source),
@@ -35,4 +45,4 @@ int getTaintedNodesCount() { result = count(DataFlow::Node n | TaintReachFlow::f
  * We don't include flow summary nodes, as their number is unstable (varies when models
  * are added).
  */
-float getTaintReach() { result = (getTaintedNodesCount() * 1000000.0) / count(DataFlow::Node n |  not n instanceof FlowSummaryNode) }
+float getTaintReach() { result = (getTaintedNodesCount() * 1000000.0) / getTotalNodesCount() }


### PR DESCRIPTION
Adjust the taint reach metric for better stability.

When models are added the number of flow summary nodes generated often increases, and we've recently found this tends to cause the taint reach metric to wobble (even when the amount of actual flow and regular nodes associated with the database remains constant).  We now exclude flow summary nodes from both the numerator and denominator of the taint reach calculation.  I have locally verified this makes the taint reach number stable under deletion (and therefore also addition) of irrelevant summary models.

I expect to see [hopefully quite small] wobbles in the taint reach calculation in the DCA run for this change.