### PR TITLE
Update precision java concatenated command line

### DIFF
--- a/java/ql/src/Security/CWE/CWE-078/ExecUnescaped.ql
+++ b/java/ql/src/Security/CWE/CWE-078/ExecUnescaped.ql
@@ -5,7 +5,7 @@
  * @kind problem
  * @problem.severity error
  * @security-severity 9.8
- * @precision high
+ * @precision medium
  * @id java/concatenated-command-line
  * @tags security
  *       external/cwe/cwe-078

--- a/java/ql/src/change-notes/2025-06-10-reduce-precision-for-building-cmdline-with-string-concatenation.md
+++ b/java/ql/src/change-notes/2025-06-10-reduce-precision-for-building-cmdline-with-string-concatenation.md
@@ -1,0 +1,3 @@
+category: queryMetadata
+---
+* Adjusts the `@precision` from high to medium for `java/concatenated-command-line` because it is producing false positive alerts when the concatenated strings are harded coded.


### PR DESCRIPTION
Updated precision to medium because this query is producing false positives when hard coded strings are used in the concatenated string of the command line. 