### PR TITLE
JS: Promote `js/template-syntax-in-string-literal` to the Code Quality suite.

### DIFF
--- a/javascript/ql/integration-tests/query-suite/javascript-code-quality.qls.expected
+++ b/javascript/ql/integration-tests/query-suite/javascript-code-quality.qls.expected
@@ -2,6 +2,7 @@ ql/javascript/ql/src/Declarations/IneffectiveParameterType.ql
 ql/javascript/ql/src/Expressions/ExprHasNoEffect.ql
 ql/javascript/ql/src/Expressions/MissingAwait.ql
 ql/javascript/ql/src/LanguageFeatures/SpuriousArguments.ql
+ql/javascript/ql/src/LanguageFeatures/TemplateSyntaxInStringLiteral.ql
 ql/javascript/ql/src/Quality/UnhandledErrorInStreamPipeline.ql
 ql/javascript/ql/src/RegExp/DuplicateCharacterInCharacterClass.ql
 ql/javascript/ql/src/RegExp/RegExpAlwaysMatches.ql

--- a/javascript/ql/src/LanguageFeatures/TemplateSyntaxInStringLiteral.ql
+++ b/javascript/ql/src/LanguageFeatures/TemplateSyntaxInStringLiteral.ql
@@ -97,24 +97,26 @@ VarDecl getDeclIn(Variable v, Scope scope, string name, CandidateTopLevel tl) {
 /**
  * Tracks data flow from a string literal that may flow to a replace operation.
  */
-DataFlow::SourceNode trackString(CandidateStringLiteral lit, DataFlow::TypeTracker t) {
-  t.start() and result = lit.flow()
+DataFlow::SourceNode trackStringWithTemplateSyntax(
+  CandidateStringLiteral lit, DataFlow::TypeTracker t
+) {
+  t.start() and result = lit.flow() and exists(lit.getAReferencedVariable())
   or
-  exists(DataFlow::TypeTracker t2 | result = trackString(lit, t2).track(t2, t))
+  exists(DataFlow::TypeTracker t2 | result = trackStringWithTemplateSyntax(lit, t2).track(t2, t))
 }
 
 /**
  * Gets a string literal that flows to a replace operation.
  */
-DataFlow::SourceNode trackString(CandidateStringLiteral lit) {
-  result = trackString(lit, DataFlow::TypeTracker::end())
+DataFlow::SourceNode trackStringWithTemplateSyntax(CandidateStringLiteral lit) {
+  result = trackStringWithTemplateSyntax(lit, DataFlow::TypeTracker::end())
 }
 
 /**
  * Holds if the string literal flows to a replace method call.
  */
 predicate hasReplaceMethodCall(CandidateStringLiteral lit) {
-  trackString(lit).getAMethodCall() instanceof StringReplaceCall
+  trackStringWithTemplateSyntax(lit).getAMethodCall() instanceof StringReplaceCall
 }
 
 from CandidateStringLiteral lit, Variable v, Scope s, string name, VarDecl decl

--- a/javascript/ql/src/LanguageFeatures/TemplateSyntaxInStringLiteral.ql
+++ b/javascript/ql/src/LanguageFeatures/TemplateSyntaxInStringLiteral.ql
@@ -5,7 +5,10 @@
  * @problem.severity warning
  * @id js/template-syntax-in-string-literal
  * @precision high
- * @tags correctness
+ * @tags quality
+ *       reliability
+ *       correctness
+ *       language-features
  */
 
 import javascript

--- a/javascript/ql/src/LanguageFeatures/TemplateSyntaxInStringLiteral.ql
+++ b/javascript/ql/src/LanguageFeatures/TemplateSyntaxInStringLiteral.ql
@@ -76,9 +76,8 @@ class CandidateStringLiteral extends StringLiteral {
  * ```
  */
 predicate hasObjectProvidingTemplateVariables(CandidateStringLiteral lit) {
-  exists(DataFlow::CallNode call, DataFlow::ObjectLiteralNode obj, DataFlow::Node stringArg |
-    stringArg = [StringConcatenation::getRoot(lit.flow()), lit.flow()] and
-    stringArg = call.getAnArgument() and
+  exists(DataFlow::CallNode call, DataFlow::ObjectLiteralNode obj |
+    call.getAnArgument() = [lit.flow(), StringConcatenation::getRoot(lit.flow())] and
     obj.flowsTo(call.getAnArgument()) and
     forex(string name | name = lit.getAReferencedVariable() | exists(obj.getAPropertyWrite(name)))
   )

--- a/javascript/ql/src/LanguageFeatures/TemplateSyntaxInStringLiteral.ql
+++ b/javascript/ql/src/LanguageFeatures/TemplateSyntaxInStringLiteral.ql
@@ -76,9 +76,10 @@ class CandidateStringLiteral extends StringLiteral {
  * ```
  */
 predicate hasObjectProvidingTemplateVariables(CandidateStringLiteral lit) {
-  exists(DataFlow::CallNode call, DataFlow::ObjectLiteralNode obj |
-    call.getAnArgument().getALocalSource() = obj and
-    call.getAnArgument().asExpr() = lit and
+  exists(DataFlow::CallNode call, DataFlow::ObjectLiteralNode obj, DataFlow::Node stringArg |
+    stringArg = [StringConcatenation::getRoot(lit.flow()), lit.flow()] and
+    stringArg = call.getAnArgument() and
+    obj.flowsTo(call.getAnArgument()) and
     forex(string name | name = lit.getAReferencedVariable() | exists(obj.getAPropertyWrite(name)))
   )
 }

--- a/javascript/ql/src/change-notes/2025-06-12-string-interpolation.md
+++ b/javascript/ql/src/change-notes/2025-06-12-string-interpolation.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Fixed false positives in the `js/template-syntax-in-string-literal` query where template syntax in string concatenation and "manual string interpolation" patterns were incorrectly flagged.

--- a/javascript/ql/src/change-notes/2025-06-12-template-syntax-metadata.md
+++ b/javascript/ql/src/change-notes/2025-06-12-template-syntax-metadata.md
@@ -1,0 +1,4 @@
+---
+category: queryMetadata
+---
+* Added `reliability` and `language-features` tags to the `js/template-syntax-in-string-literal` query.

--- a/javascript/ql/test/query-tests/LanguageFeatures/TemplateSyntaxInStringLiteral/TemplateSyntaxInStringLiteral.expected
+++ b/javascript/ql/test/query-tests/LanguageFeatures/TemplateSyntaxInStringLiteral/TemplateSyntaxInStringLiteral.expected
@@ -3,5 +3,3 @@
 | TemplateSyntaxInStringLiteral.js:19:11:19:36 | 'global ... alVar}' | This string is not a template literal, but appears to reference the variable $@. | TemplateSyntaxInStringLiteral.js:14:5:14:13 | globalVar | globalVar |
 | TemplateSyntaxInStringLiteral.js:28:15:28:21 | "${x} " | This string is not a template literal, but appears to reference the variable $@. | TemplateSyntaxInStringLiteral.js:25:14:25:14 | x | x |
 | TemplateSyntaxInStringLiteral.js:42:17:42:57 | "Name:  ... oobar}" | This string is not a template literal, but appears to reference the variable $@. | TemplateSyntaxInStringLiteral.js:37:11:37:16 | foobar | foobar |
-| TemplateSyntaxInStringLiteral.js:62:15:62:29 | "Name: ${name}" | This string is not a template literal, but appears to reference the variable $@. | TemplateSyntaxInStringLiteral.js:61:30:61:33 | name | name |
-| TemplateSyntaxInStringLiteral.js:66:11:66:44 | "Name:  ... {name}" | This string is not a template literal, but appears to reference the variable $@. | TemplateSyntaxInStringLiteral.js:61:30:61:33 | name | name |

--- a/javascript/ql/test/query-tests/LanguageFeatures/TemplateSyntaxInStringLiteral/TemplateSyntaxInStringLiteral.expected
+++ b/javascript/ql/test/query-tests/LanguageFeatures/TemplateSyntaxInStringLiteral/TemplateSyntaxInStringLiteral.expected
@@ -3,7 +3,5 @@
 | TemplateSyntaxInStringLiteral.js:19:11:19:36 | 'global ... alVar}' | This string is not a template literal, but appears to reference the variable $@. | TemplateSyntaxInStringLiteral.js:14:5:14:13 | globalVar | globalVar |
 | TemplateSyntaxInStringLiteral.js:28:15:28:21 | "${x} " | This string is not a template literal, but appears to reference the variable $@. | TemplateSyntaxInStringLiteral.js:25:14:25:14 | x | x |
 | TemplateSyntaxInStringLiteral.js:42:17:42:57 | "Name:  ... oobar}" | This string is not a template literal, but appears to reference the variable $@. | TemplateSyntaxInStringLiteral.js:37:11:37:16 | foobar | foobar |
-| TemplateSyntaxInStringLiteral.js:47:27:47:51 | ") ${ex ...  got (" | This string is not a template literal, but appears to reference the variable $@. | TemplateSyntaxInStringLiteral.js:45:20:45:27 | expected | expected |
-| TemplateSyntaxInStringLiteral.js:47:71:47:83 | ") ${actual}" | This string is not a template literal, but appears to reference the variable $@. | TemplateSyntaxInStringLiteral.js:45:12:45:17 | actual | actual |
 | TemplateSyntaxInStringLiteral.js:62:15:62:29 | "Name: ${name}" | This string is not a template literal, but appears to reference the variable $@. | TemplateSyntaxInStringLiteral.js:61:30:61:33 | name | name |
 | TemplateSyntaxInStringLiteral.js:66:11:66:44 | "Name:  ... {name}" | This string is not a template literal, but appears to reference the variable $@. | TemplateSyntaxInStringLiteral.js:61:30:61:33 | name | name |

--- a/javascript/ql/test/query-tests/LanguageFeatures/TemplateSyntaxInStringLiteral/TemplateSyntaxInStringLiteral.expected
+++ b/javascript/ql/test/query-tests/LanguageFeatures/TemplateSyntaxInStringLiteral/TemplateSyntaxInStringLiteral.expected
@@ -3,3 +3,7 @@
 | TemplateSyntaxInStringLiteral.js:19:11:19:36 | 'global ... alVar}' | This string is not a template literal, but appears to reference the variable $@. | TemplateSyntaxInStringLiteral.js:14:5:14:13 | globalVar | globalVar |
 | TemplateSyntaxInStringLiteral.js:28:15:28:21 | "${x} " | This string is not a template literal, but appears to reference the variable $@. | TemplateSyntaxInStringLiteral.js:25:14:25:14 | x | x |
 | TemplateSyntaxInStringLiteral.js:42:17:42:57 | "Name:  ... oobar}" | This string is not a template literal, but appears to reference the variable $@. | TemplateSyntaxInStringLiteral.js:37:11:37:16 | foobar | foobar |
+| TemplateSyntaxInStringLiteral.js:47:27:47:51 | ") ${ex ...  got (" | This string is not a template literal, but appears to reference the variable $@. | TemplateSyntaxInStringLiteral.js:45:20:45:27 | expected | expected |
+| TemplateSyntaxInStringLiteral.js:47:71:47:83 | ") ${actual}" | This string is not a template literal, but appears to reference the variable $@. | TemplateSyntaxInStringLiteral.js:45:12:45:17 | actual | actual |
+| TemplateSyntaxInStringLiteral.js:62:15:62:29 | "Name: ${name}" | This string is not a template literal, but appears to reference the variable $@. | TemplateSyntaxInStringLiteral.js:61:30:61:33 | name | name |
+| TemplateSyntaxInStringLiteral.js:66:11:66:44 | "Name:  ... {name}" | This string is not a template literal, but appears to reference the variable $@. | TemplateSyntaxInStringLiteral.js:61:30:61:33 | name | name |

--- a/javascript/ql/test/query-tests/LanguageFeatures/TemplateSyntaxInStringLiteral/TemplateSyntaxInStringLiteral.js
+++ b/javascript/ql/test/query-tests/LanguageFeatures/TemplateSyntaxInStringLiteral/TemplateSyntaxInStringLiteral.js
@@ -59,11 +59,11 @@ function replacerAll(str, name) {
 }
 
 function manualInterpolation(name) {
-    let str = "Name: ${name}"; // $SPURIOUS:Alert
+    let str = "Name: ${name}";
     let result1 = replacer(str, name);
     console.log(result1); 
 
-    str = "Name: ${name} and again: ${name}"; // $SPURIOUS:Alert
+    str = "Name: ${name} and again: ${name}";
     let result2 = replacerAll(str, name);
     console.log(result2);
 }

--- a/javascript/ql/test/query-tests/LanguageFeatures/TemplateSyntaxInStringLiteral/TemplateSyntaxInStringLiteral.js
+++ b/javascript/ql/test/query-tests/LanguageFeatures/TemplateSyntaxInStringLiteral/TemplateSyntaxInStringLiteral.js
@@ -41,3 +41,29 @@ function foo1() {
 
     writer.emit("Name: ${name}, Date: ${date}, ${foobar}", data); // $ Alert - `foobar` is not in `data`.
 }
+
+function a(actual, expected, description) {
+    assert(false, "a", description, "expected (" +
+        typeof expected + ") ${expected} but got (" + typeof actual + ") ${actual}", { // $SPURIOUS:Alert
+            expected: expected,
+            actual: actual
+        });
+}
+
+function replacer(str, name) {
+    return str.replace("${name}", name);
+}
+
+function replacerAll(str, name) {
+    return str.replaceAll("${name}", name);
+}
+
+function manualInterpolation(name) {
+    let str = "Name: ${name}"; // $SPURIOUS:Alert
+    let result1 = replacer(str, name);
+    console.log(result1); 
+
+    str = "Name: ${name} and again: ${name}"; // $SPURIOUS:Alert
+    let result2 = replacerAll(str, name);
+    console.log(result2);
+}

--- a/javascript/ql/test/query-tests/LanguageFeatures/TemplateSyntaxInStringLiteral/TemplateSyntaxInStringLiteral.js
+++ b/javascript/ql/test/query-tests/LanguageFeatures/TemplateSyntaxInStringLiteral/TemplateSyntaxInStringLiteral.js
@@ -44,7 +44,7 @@ function foo1() {
 
 function a(actual, expected, description) {
     assert(false, "a", description, "expected (" +
-        typeof expected + ") ${expected} but got (" + typeof actual + ") ${actual}", { // $SPURIOUS:Alert
+        typeof expected + ") ${expected} but got (" + typeof actual + ") ${actual}", {
             expected: expected,
             actual: actual
         });


### PR DESCRIPTION
This pull request adds the query `js/template-syntax-in-string-literal` to the Code Quality suite. The problem that the query aims to highlight is straightforward for `autofix` to fix.

While running MRVA, a few patterns of false positives were observed. Note that all of these cases are rare:

-   Packages like [yup](https://www.npmjs.com/package/yup) may produce false positives. Yup uses special variables such as `${min}`, `${max}`, `${path}`, `${less}`, etc., which are correctly interpolated, even when included inside single (`''`) or double (`""`) quotes and passed to the respective yup methods. These false positives are uncommon, as they only occur when there is a variable with the exact same name in the current scope.
- ~~In certain [test framework code](https://github.com/web-platform-tests/wpt/blob/de3ebde457ce958c2bad68c3e25ed04263ce60a0/resources/testharness.js#L1545), template placeholders like `${expected}` are used to inform users about variable values.~~ Fixed [bafe7e6](https://github.com/github/codeql/pull/19726/commits/bafe7e66ad7d7948517cac60b4f3ea43c5617d7e)
- ~~Some cases involve "manual interpolation", where a placeholder like `${usedAsPlaceHolder}` is later replaced using `replaceAll` or `replace` functions.~~ Fixed 923aff2

`High` accuracy seems appropriate for the following query.


