### PR TITLE
JS: Promote `js/loop-iteration-skipped-due-to-shifting` to the Code Quality suite

### DIFF
--- a/javascript/ql/integration-tests/query-suite/javascript-code-quality.qls.expected
+++ b/javascript/ql/integration-tests/query-suite/javascript-code-quality.qls.expected
@@ -5,3 +5,4 @@ ql/javascript/ql/src/LanguageFeatures/SpuriousArguments.ql
 ql/javascript/ql/src/Quality/UnhandledErrorInStreamPipeline.ql
 ql/javascript/ql/src/RegExp/DuplicateCharacterInCharacterClass.ql
 ql/javascript/ql/src/RegExp/RegExpAlwaysMatches.ql
+ql/javascript/ql/src/Statements/LoopIterationSkippedDueToShifting.ql

--- a/javascript/ql/src/Statements/LoopIterationSkippedDueToShifting.ql
+++ b/javascript/ql/src/Statements/LoopIterationSkippedDueToShifting.ql
@@ -146,7 +146,12 @@ class ArrayIterationLoop extends ForStmt {
     or
     this.hasPathThrough(splice, cfg.getAPredecessor()) and
     this.getLoopEntry().dominates(cfg.getBasicBlock()) and
-    not this.hasIndexingManipulation(cfg)
+    not this.hasIndexingManipulation(cfg) and
+    // Don't continue through a branch that tests the splice call's return value
+    not exists(ConditionGuardNode guard | cfg = guard |
+      guard.getTest() = splice.asExpr() and
+      guard.getOutcome() = false
+    )
   }
 }
 

--- a/javascript/ql/src/Statements/LoopIterationSkippedDueToShifting.ql
+++ b/javascript/ql/src/Statements/LoopIterationSkippedDueToShifting.ql
@@ -5,7 +5,9 @@
  * @kind problem
  * @problem.severity warning
  * @id js/loop-iteration-skipped-due-to-shifting
- * @tags correctness
+ * @tags quality
+ *       reliability
+ *       correctness
  * @precision high
  */
 

--- a/javascript/ql/src/change-notes/2025-06-12-loop-iteration-fix.md
+++ b/javascript/ql/src/change-notes/2025-06-12-loop-iteration-fix.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Fixed false positives in the `js/loop-iteration-skipped-due-to-shifting` query when `splice` is used as a condition that adjusts the loop counter.

--- a/javascript/ql/src/change-notes/2025-06-12-loop-iteration.md
+++ b/javascript/ql/src/change-notes/2025-06-12-loop-iteration.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The `js/loop-iteration-skipped-due-to-shifting` query has been updated with `reliability` tag.

--- a/javascript/ql/test/query-tests/Statements/LoopIterationSkippedDueToShifting/LoopIterationSkippedDueToShifting.expected
+++ b/javascript/ql/test/query-tests/Statements/LoopIterationSkippedDueToShifting/LoopIterationSkippedDueToShifting.expected
@@ -2,5 +2,4 @@
 | tst.js:13:29:13:46 | parts.splice(i, 1) | Removing an array item without adjusting the loop index 'i' causes the subsequent array item to be skipped. |
 | tst.js:24:9:24:26 | parts.splice(i, 1) | Removing an array item without adjusting the loop index 'i' causes the subsequent array item to be skipped. |
 | tst.js:128:11:128:33 | pending ... e(i, 1) | Removing an array item without adjusting the loop index 'i' causes the subsequent array item to be skipped. |
-| tst.js:136:32:136:47 | toc.splice(i, 1) | Removing an array item without adjusting the loop index 'i' causes the subsequent array item to be skipped. |
-| tst.js:143:10:143:25 | toc.splice(i, 1) | Removing an array item without adjusting the loop index 'i' causes the subsequent array item to be skipped. |
+| tst.js:153:11:153:26 | toc.splice(i, 1) | Removing an array item without adjusting the loop index 'i' causes the subsequent array item to be skipped. |

--- a/javascript/ql/test/query-tests/Statements/LoopIterationSkippedDueToShifting/LoopIterationSkippedDueToShifting.expected
+++ b/javascript/ql/test/query-tests/Statements/LoopIterationSkippedDueToShifting/LoopIterationSkippedDueToShifting.expected
@@ -1,3 +1,6 @@
 | tst.js:4:27:4:44 | parts.splice(i, 1) | Removing an array item without adjusting the loop index 'i' causes the subsequent array item to be skipped. |
 | tst.js:13:29:13:46 | parts.splice(i, 1) | Removing an array item without adjusting the loop index 'i' causes the subsequent array item to be skipped. |
 | tst.js:24:9:24:26 | parts.splice(i, 1) | Removing an array item without adjusting the loop index 'i' causes the subsequent array item to be skipped. |
+| tst.js:128:11:128:33 | pending ... e(i, 1) | Removing an array item without adjusting the loop index 'i' causes the subsequent array item to be skipped. |
+| tst.js:136:32:136:47 | toc.splice(i, 1) | Removing an array item without adjusting the loop index 'i' causes the subsequent array item to be skipped. |
+| tst.js:143:10:143:25 | toc.splice(i, 1) | Removing an array item without adjusting the loop index 'i' causes the subsequent array item to be skipped. |

--- a/javascript/ql/test/query-tests/Statements/LoopIterationSkippedDueToShifting/tst.js
+++ b/javascript/ql/test/query-tests/Statements/LoopIterationSkippedDueToShifting/tst.js
@@ -133,15 +133,25 @@ function withTryCatch(pendingCSS) {
 
 function andOperand(toc) {
   for (let i = 0; i < toc.length; i++) {
-    toc[i].ignoreSubHeading && toc.splice(i, 1) && i--; // $ SPURIOUS:Alert
+    toc[i].ignoreSubHeading && toc.splice(i, 1) && i--;
   }
 }
 
 function ifStatement(toc) {
   for (let i = 0; i < toc.length; i++) {
     if(toc[i].ignoreSubHeading){
-      if(toc.splice(i, 1)){ // $ SPURIOUS:Alert
+      if(toc.splice(i, 1)){
         i--; 
+      }
+    }
+  }
+}
+
+function ifStatement2(toc) {
+  for (let i = 0; i < toc.length; i++) {
+    if(toc[i].ignoreSubHeading){
+      if(!toc.splice(i, 1)){ // $Alert
+        i--;
       }
     }
   }

--- a/javascript/ql/test/query-tests/Statements/LoopIterationSkippedDueToShifting/tst.js
+++ b/javascript/ql/test/query-tests/Statements/LoopIterationSkippedDueToShifting/tst.js
@@ -121,3 +121,28 @@ function inspectNextElement(string) {
   }
   return parts.join('/');
 }
+
+function withTryCatch(pendingCSS) {
+  for (let i = 0; i < pendingCSS.length; ++i) {
+      try {
+          pendingCSS.splice(i, 1); // $ SPURIOUS:Alert
+          i -= 1;
+      } catch (ex) {}
+  }
+}
+
+function andOperand(toc) {
+  for (let i = 0; i < toc.length; i++) {
+    toc[i].ignoreSubHeading && toc.splice(i, 1) && i--; // $ SPURIOUS:Alert
+  }
+}
+
+function ifStatement(toc) {
+  for (let i = 0; i < toc.length; i++) {
+    if(toc[i].ignoreSubHeading){
+      if(toc.splice(i, 1)){ // $ SPURIOUS:Alert
+        i--; 
+      }
+    }
+  }
+}


### PR DESCRIPTION
The following pull request makes changes to `js/loop-iteration-skipped-due-to-shifting`:

- Promotes it to quality suite.
- Fixed false positives when `splice` is used as a condition that adjusts the loop counter.
- Added a test for a false positive that isn’t worth fixing.

MRVA shows good results (61 out of which most are true positives). `Autofix` seems to be able to do the job 