### PR TITLE
C#: mass-enable diff-informed queries phase 2 - `getASelected{Source,Sink}Location() { none() }`

### DIFF
--- a/csharp/ql/src/Security Features/CWE-327/DontInstallRootCert.ql
+++ b/csharp/ql/src/Security Features/CWE-327/DontInstallRootCert.ql
@@ -39,6 +39,8 @@ module AddCertToRootStoreConfig implements DataFlow::ConfigSig {
   }
 
   predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSourceLocation(DataFlow::Node sink) { none() }
 }
 
 module AddCertToRootStore = DataFlow::Global<AddCertToRootStoreConfig>;


### PR DESCRIPTION
Stacks on top of earlier PR: https://github.com/github/codeql/pull/19659
Uses patch from: https://github.com/github/codeql-patch/pull/88/commits/ec5681e740c18c792443099fb3e413446616a0ee 

Adds `getASelected{Source,Sink}Location() { none() }` override to queries that select a dataflow source or sink as a location, but not both.
