### PR TITLE
C++: mass-enable diff-informed queries phase 2 - `getASelected{Source,Sink}Location() { none() }`

### DIFF
--- a/cpp/ql/src/experimental/Security/CWE/CWE-078/WordexpTainted.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-078/WordexpTainted.ql
@@ -50,6 +50,8 @@ module WordexpTaintConfig implements DataFlow::ConfigSig {
   }
 
   predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSourceLocation(DataFlow::Node source) { none() }
 }
 
 module WordexpTaint = TaintTracking::Global<WordexpTaintConfig>;


### PR DESCRIPTION
Stacks on top of earlier PR: https://github.com/github/codeql/pull/19659
Uses patch from: https://github.com/github/codeql-patch/pull/88/commits/ec5681e740c18c792443099fb3e413446616a0ee 

Adds `getASelected{Source,Sink}Location() { none() }` override to a query that selects a dataflow source or sink as a location, but not both.
