### PR TITLE
Go: mass-enable diff-informed queries phase 2 - `getASelected{Source,Sink}Location() { none() }`

### DIFF
--- a/go/ql/src/Security/CWE-020/MissingRegexpAnchor.ql
+++ b/go/ql/src/Security/CWE-020/MissingRegexpAnchor.ql
@@ -74,6 +74,8 @@ module Config implements DataFlow::ConfigSig {
   predicate isSink(DataFlow::Node sink) { sink instanceof RegexpPattern }
 
   predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSinkLocation(DataFlow::Node sink) { none() }
 }
 
 module Flow = DataFlow::Global<Config>;

--- a/go/ql/src/Security/CWE-079/HtmlTemplateEscapingBypassXss.ql
+++ b/go/ql/src/Security/CWE-079/HtmlTemplateEscapingBypassXss.ql
@@ -101,6 +101,8 @@ module UntrustedToTemplateExecWithConversionConfig implements DataFlow::StateCon
       conversion.getType().getUnderlyingType*() = unescapedType
     )
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 module UntrustedToTemplateExecWithConversionFlow =

--- a/go/ql/src/Security/CWE-326/InsufficientKeySize.ql
+++ b/go/ql/src/Security/CWE-326/InsufficientKeySize.ql
@@ -27,6 +27,8 @@ module Config implements DataFlow::ConfigSig {
   }
 
   predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSourceLocation(DataFlow::Node sink) { none() }
 }
 
 /**

--- a/go/ql/src/experimental/CWE-285/PamAuthBypass.ql
+++ b/go/ql/src/experimental/CWE-285/PamAuthBypass.ql
@@ -44,6 +44,8 @@ module PamStartToAcctMgmtConfig implements DataFlow::ConfigSig {
   }
 
   predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSinkLocation(DataFlow::Node sink) { none() }
 }
 
 module PamStartToAcctMgmtFlow = TaintTracking::Global<PamStartToAcctMgmtConfig>;
@@ -59,6 +61,8 @@ module PamStartToAuthenticateConfig implements DataFlow::ConfigSig {
   }
 
   predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSinkLocation(DataFlow::Node sink) { none() }
 }
 
 module PamStartToAuthenticateFlow = TaintTracking::Global<PamStartToAuthenticateConfig>;

--- a/go/ql/src/experimental/CWE-369/DivideByZero.ql
+++ b/go/ql/src/experimental/CWE-369/DivideByZero.ql
@@ -47,6 +47,8 @@ module Config implements DataFlow::ConfigSig {
   }
 
   predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSourceLocation(DataFlow::Node sink) { none() }
 }
 
 /**


### PR DESCRIPTION
Stacks on top of earlier PR: https://github.com/github/codeql/pull/19659
Uses patch from: https://github.com/github/codeql-patch/pull/88/commits/ec5681e740c18c792443099fb3e413446616a0ee 

Adds `getASelected{Source,Sink}Location() { none() }` override to queries that select a dataflow source or sink as a location, but not both.