### PR TITLE
Swift: mass-enable diff-informed queries phase 2 - `getASelected{Source,Sink}Location() { none() }`

### DIFF
--- a/swift/ql/lib/codeql/swift/security/ConstantPasswordQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/ConstantPasswordQuery.qll
@@ -40,6 +40,8 @@ module ConstantPasswordConfig implements DataFlow::ConfigSig {
   }
 
   predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSourceLocation(DataFlow::Node sink) { none() }
 }
 
 module ConstantPasswordFlow = TaintTracking::Global<ConstantPasswordConfig>;

--- a/swift/ql/lib/codeql/swift/security/InsufficientHashIterationsQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/InsufficientHashIterationsQuery.qll
@@ -36,6 +36,8 @@ module InsufficientHashIterationsConfig implements DataFlow::ConfigSig {
   }
 
   predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSourceLocation(DataFlow::Node sink) { none() }
 }
 
 module InsufficientHashIterationsFlow = TaintTracking::Global<InsufficientHashIterationsConfig>;

--- a/swift/ql/lib/codeql/swift/security/StaticInitializationVectorQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/StaticInitializationVectorQuery.qll
@@ -42,6 +42,8 @@ module StaticInitializationVectorConfig implements DataFlow::ConfigSig {
   }
 
   predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSourceLocation(DataFlow::Node sink) { none() }
 }
 
 module StaticInitializationVectorFlow = TaintTracking::Global<StaticInitializationVectorConfig>;

--- a/swift/ql/lib/codeql/swift/security/StringLengthConflationQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/StringLengthConflationQuery.qll
@@ -41,6 +41,8 @@ module StringLengthConflationConfig implements DataFlow::StateConfigSig {
   }
 
   predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSourceLocation(DataFlow::Node sink) { none() }
 }
 
 /**

--- a/swift/ql/lib/codeql/swift/security/UnsafeJsEvalQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/UnsafeJsEvalQuery.qll
@@ -24,6 +24,8 @@ module UnsafeJsEvalConfig implements DataFlow::ConfigSig {
   }
 
   predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSourceLocation(DataFlow::Node sink) { none() }
 }
 
 /**

--- a/swift/ql/lib/codeql/swift/security/UnsafeUnpackQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/UnsafeUnpackQuery.qll
@@ -26,6 +26,8 @@ module UnsafeUnpackConfig implements DataFlow::ConfigSig {
   }
 
   predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSourceLocation(DataFlow::Node sink) { none() }
 }
 
 /**


### PR DESCRIPTION
Stacks on top of earlier PR: https://github.com/github/codeql/pull/19659
Uses patch from: https://github.com/github/codeql-patch/pull/88/commits/ec5681e740c18c792443099fb3e413446616a0ee 

Adds `getASelected{Source,Sink}Location() { none() }` override to queries that select a dataflow source or sink as a location, but not both.