### PR TITLE
CI: fix python version

### DIFF
--- a/.github/workflows/python-tooling.yml
+++ b/.github/workflows/python-tooling.yml
@@ -22,6 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
       - uses: pre-commit/action@646c83fcd040023954eafda54b4db0192ce70507
         name: Check that python code is properly formatted
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,7 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
+default_language_version:
+  python: python3.12
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0

--- a/misc/scripts/models-as-data/bulk_generate_mad.py
+++ b/misc/scripts/models-as-data/bulk_generate_mad.py
@@ -116,9 +116,7 @@ def clone_project(project: Project) -> str:
     return target_dir
 
 
-def run_in_parallel[
-    T, U
-](
+def run_in_parallel[T, U](
     func: Callable[[T], U],
     items: List[T],
     *,
@@ -516,7 +514,7 @@ if __name__ == "__main__":
         "--dca",
         type=str,
         help="Name of a DCA run that built all the projects. Can be repeated, with sources taken from all provided runs, "
-             "the last provided ones having priority",
+        "the last provided ones having priority",
         action="append",
     )
     parser.add_argument(


### PR DESCRIPTION
Turns out this is important for the black formatting tool to work correctly. The formatting won't generally change between python versions (it only depends on `black`'s version), but the formatted code needs to be parseable by the system python version. One script uses
```python
def foo[T](x: T) -> T:
```
syntax, which is only supported in Python 3.12 and later.

Running `pre-commit` will now require a python 3.12 installation (which is already what we mandate for internal developer environment setup). The error in case of absence of such a version is pretty clear though.