### PR TITLE
Add lodash GroupBy as taint step

### DIFF
--- a/javascript/ql/lib/semmle/javascript/frameworks/LodashUnderscore.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/LodashUnderscore.qll
@@ -341,6 +341,18 @@ module LodashUnderscore {
       preservesValue = true
     }
   }
+
+  private class LodashGroupBy extends DataFlow::SummarizedCallable {
+    LodashGroupBy() { this = "_.groupBy" }
+
+    override DataFlow::CallNode getACall() { result = member("groupBy").getACall() }
+
+    override predicate propagatesFlow(string input, string output, boolean preservesValue) {
+      input = "Argument[0]" and
+      output = ["Argument[1].Parameter[0]", "ReturnValue"] and
+      preservesValue = false
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
Adds [`_.groupBy`](https://lodash.com/docs/4.17.15#groupBy) as a taint step.

This is analogous to the `GroupByTaintStep` class, which does the same for `Object` and `Map`.

https://github.com/github/codeql/blob/d83cbde1cb1263fb476a55ea5fd7972307138905/javascript/ql/lib/semmle/javascript/Collections.qll#L158C1-L166C4