### PR TITLE
Improve data flow in the `async` package

### DIFF
--- a/javascript/ql/lib/semmle/javascript/dataflow/internal/FlowSummaryPrivate.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/internal/FlowSummaryPrivate.qll
@@ -94,6 +94,8 @@ private string encodeContentAux(ContentSet cs, string arg) {
     cs = ContentSet::iteratorElement() and result = "IteratorElement"
     or
     cs = ContentSet::iteratorError() and result = "IteratorError"
+    or
+    cs = ContentSet::anyProperty() and result = "AnyMember"
   )
   or
   cs = getPromiseContent(arg) and

--- a/javascript/ql/test/library-tests/frameworks/AsyncPackage/AsyncTaintTracking.expected
+++ b/javascript/ql/test/library-tests/frameworks/AsyncPackage/AsyncTaintTracking.expected
@@ -1,12 +1,24 @@
 legacyDataFlowDifference
-| each.js:11:9:11:16 | source() | each.js:13:12:13:15 | item | only flow with OLD data flow library |
-| map.js:10:13:10:20 | source() | map.js:12:14:12:17 | item | only flow with OLD data flow library |
-| map.js:26:13:26:20 | source() | map.js:28:27:28:32 | result | only flow with OLD data flow library |
-| sortBy.js:10:22:10:29 | source() | sortBy.js:12:27:12:32 | result | only flow with OLD data flow library |
+| each.js:11:9:11:16 | source() | each.js:13:12:13:15 | item | only flow with NEW data flow library |
+| map.js:14:13:14:20 | source() | map.js:16:14:16:17 | item | only flow with NEW data flow library |
+| map.js:30:13:30:20 | source() | map.js:32:27:32:32 | result | only flow with NEW data flow library |
+| map.js:40:13:40:20 | source() | map.js:11:10:11:10 | x | only flow with NEW data flow library |
+| map.js:42:12:42:19 | source() | map.js:11:10:11:10 | x | only flow with NEW data flow library |
+| map.js:44:16:44:23 | source() | map.js:11:10:11:10 | x | only flow with NEW data flow library |
+| map.js:46:18:46:25 | source() | map.js:11:10:11:10 | x | only flow with NEW data flow library |
+| sortBy.js:10:22:10:29 | source() | sortBy.js:12:27:12:32 | result | only flow with NEW data flow library |
 #select
-| map.js:20:19:20:26 | source() | map.js:23:27:23:32 | result |
-| waterfall.js:8:30:8:37 | source() | waterfall.js:11:12:11:16 | taint |
-| waterfall.js:8:30:8:37 | source() | waterfall.js:20:10:20:14 | taint |
-| waterfall.js:28:18:28:25 | source() | waterfall.js:39:10:39:12 | err |
-| waterfall.js:46:22:46:29 | source() | waterfall.js:49:12:49:16 | taint |
-| waterfall.js:46:22:46:29 | source() | waterfall.js:55:10:55:14 | taint |
+| each.js:11:9:11:16 | source() | each.js:13:12:13:15 | item |
+| map.js:14:13:14:20 | source() | map.js:16:14:16:17 | item |
+| map.js:24:19:24:26 | source() | map.js:27:27:27:32 | result |
+| map.js:30:13:30:20 | source() | map.js:32:27:32:32 | result |
+| map.js:40:13:40:20 | source() | map.js:11:10:11:10 | x |
+| map.js:42:12:42:19 | source() | map.js:11:10:11:10 | x |
+| map.js:44:16:44:23 | source() | map.js:11:10:11:10 | x |
+| map.js:46:18:46:25 | source() | map.js:11:10:11:10 | x |
+| sortBy.js:10:22:10:29 | source() | sortBy.js:12:27:12:32 | result |
+| waterfall.js:16:30:16:37 | source() | waterfall.js:19:12:19:16 | taint |
+| waterfall.js:16:30:16:37 | source() | waterfall.js:28:10:28:14 | taint |
+| waterfall.js:36:18:36:25 | source() | waterfall.js:47:10:47:12 | err |
+| waterfall.js:54:22:54:29 | source() | waterfall.js:57:12:57:16 | taint |
+| waterfall.js:54:22:54:29 | source() | waterfall.js:63:10:63:14 | taint |

--- a/javascript/ql/test/library-tests/frameworks/AsyncPackage/map.js
+++ b/javascript/ql/test/library-tests/frameworks/AsyncPackage/map.js
@@ -7,6 +7,10 @@ function sink(x) {
     console.log(x)
 }
 
+function call_sink(x) {
+    sink(x)
+}
+
 async_.map([source()],
     (item, cb) => {
         sink(item), // NOT OK
@@ -32,3 +36,12 @@ async_.map(['safe'],
     (item, cb) => cb(null, item),
     (err, result) => sink(result) // OK
 );
+
+async_.map([source()], call_sink) // NOT OK
+
+async_.map(source().prop, call_sink) // NOT OK
+
+async_.map({a: source()}, call_sink) // NOT OK
+
+async_.mapLimit([source()], 1, call_sink) // NOT OK
+

--- a/javascript/ql/test/library-tests/frameworks/AsyncPackage/waterfall.js
+++ b/javascript/ql/test/library-tests/frameworks/AsyncPackage/waterfall.js
@@ -1,7 +1,15 @@
 let async_ = require('async');
 let waterfall = require('a-sync-waterfall');
 
-var source, sink, somethingWrong;
+function source() {
+    return 'TAINT'
+}
+
+function sink(x) {
+    console.log(x)
+}
+
+var somethingWrong;
 
 async_.waterfall([
     function(callback) {


### PR DESCRIPTION
This PR makes these changes: 
 1. In `FlowSummaryPrivate.qll`: Added support for `anyProperty` content set in flow summaries:
      - Please confirm this is the correct way to support this. I needed this to find the `async_.map({a: source()}, call_sink)` case. Let me know if there's a better way to do it
      - As a note, I was also unable to use `Element`, which, according to the [documentation](https://codeql.github.com/docs/codeql-language-guides/customizing-library-models-for-javascript/#access-paths), should select "an element of an array, iterator, or set object."
  2. In `AsyncPackage.qll`: Improve taint tracking through functions from the `async` package:
      - Improve tracking of the callback arguments
      - Implemented flow summaries for more robust taint tracking
      - Updated tests
