### PR TITLE
C#: Handle non-unique type arguments when computing generics strings

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/Generics.qll
+++ b/csharp/ql/lib/semmle/code/csharp/Generics.qll
@@ -110,9 +110,12 @@ private string getTypeArgumentsToString(ConstructedGeneric cg) {
     strictconcat(Type t, int i | t = cg.getTypeArgument(i) | t.toStringWithTypes(), ", " order by i)
 }
 
+language[monotonicAggregates]
 pragma[nomagic]
 private string getTypeArgumentName(ConstructedGeneric cg, int i) {
-  result = cg.getTypeArgument(i).getName()
+  // Normally, `cg.getTypeArgument(i)` will be unique, and in those cases the line below
+  // is simply the same as `result = cg.getTypeArgument(i).getName()`.
+  result = strictconcat(Type t | t = cg.getTypeArgument(i) | t.getName(), "/")
 }
 
 /** Gets the concatenation of the `getName()` of type arguments. */

--- a/csharp/ql/lib/semmle/code/csharp/commons/QualifiedName.qll
+++ b/csharp/ql/lib/semmle/code/csharp/commons/QualifiedName.qll
@@ -48,9 +48,12 @@ module QualifiedName<QualifiedNameInputSig Input> {
     )
   }
 
+  language[monotonicAggregates]
   pragma[nomagic]
   private string getTypeArgumentsQualifiedName(ConstructedGeneric cg, int i) {
-    result = getFullName(cg.getTypeArgument(i))
+    // Normally, `cg.getTypeArgument(i)` will be unique, and in those cases the line below
+    // is simply the same as `result = getFullName(cg.getTypeArgument(i))`.
+    result = strictconcat(Type t | t = cg.getTypeArgument(i) | getFullName(t), "/")
   }
 
   /** Gets the concatenation of the `getFullName` of type arguments. */


### PR DESCRIPTION
Avoids a combinatorial explosion when type arguments are not unique.