### PR TITLE
C++: Add exception edges out of calls inside `try` statements

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/TranslatedCall.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/TranslatedCall.qll
@@ -4,6 +4,7 @@ private import semmle.code.cpp.ir.implementation.internal.OperandTag
 private import semmle.code.cpp.ir.internal.CppType
 private import semmle.code.cpp.models.interfaces.SideEffect
 private import semmle.code.cpp.models.interfaces.Throwing
+private import semmle.code.cpp.models.interfaces.NonThrowing
 private import InstructionTag
 private import SideEffects
 private import TranslatedElement
@@ -366,6 +367,10 @@ class TranslatedFunctionCall extends TranslatedCallExpr, TranslatedDirectCall {
     or
     exists(MicrosoftTryStmt tryStmt | tryStmt.getStmt() = expr.getEnclosingStmt().getParent*()) and
     e instanceof SehExceptionEdge
+    or
+    not expr.getTarget() instanceof NonCppThrowingFunction and
+    exists(TryStmt tryStmt | tryStmt.getStmt() = expr.getEnclosingStmt().getParent*()) and
+    e instanceof CppExceptionEdge
   }
 
   final override predicate mustThrowException(ExceptionEdge e) {

--- a/cpp/ql/test/library-tests/controlflow/guards-ir/tests.expected
+++ b/cpp/ql/test/library-tests/controlflow/guards-ir/tests.expected
@@ -448,7 +448,6 @@ astGuardsControl
 | test.cpp:31:7:31:13 | ... == ... | false | 34 | 34 |
 | test.cpp:31:7:31:13 | ... == ... | true | 30 | 30 |
 | test.cpp:31:7:31:13 | ... == ... | true | 31 | 32 |
-| test.cpp:42:13:42:20 | call to getABool | false | 53 | 53 |
 | test.cpp:42:13:42:20 | call to getABool | true | 43 | 45 |
 astGuardsEnsure
 | test.c:7:9:7:13 | ... > ... | test.c:7:9:7:9 | x | < | test.c:7:13:7:13 | 0 | 1 | 10 | 11 |
@@ -893,8 +892,6 @@ astGuardsEnsure_const
 | test.cpp:31:7:31:13 | ... == ... | test.cpp:31:7:31:13 | ... == ... | == | 1 | 30 | 30 |
 | test.cpp:31:7:31:13 | ... == ... | test.cpp:31:7:31:13 | ... == ... | == | 1 | 31 | 32 |
 | test.cpp:42:13:42:20 | call to getABool | test.cpp:42:13:42:20 | call to getABool | != | 0 | 43 | 45 |
-| test.cpp:42:13:42:20 | call to getABool | test.cpp:42:13:42:20 | call to getABool | != | 1 | 53 | 53 |
-| test.cpp:42:13:42:20 | call to getABool | test.cpp:42:13:42:20 | call to getABool | == | 0 | 53 | 53 |
 | test.cpp:42:13:42:20 | call to getABool | test.cpp:42:13:42:20 | call to getABool | == | 1 | 43 | 45 |
 irGuards
 | test.c:7:9:7:13 | CompareGT: ... > ... |
@@ -1301,8 +1298,8 @@ irGuardsControl
 | test.cpp:31:7:31:13 | CompareEQ: ... == ... | false | 34 | 34 |
 | test.cpp:31:7:31:13 | CompareEQ: ... == ... | true | 30 | 30 |
 | test.cpp:31:7:31:13 | CompareEQ: ... == ... | true | 32 | 32 |
-| test.cpp:42:13:42:20 | Call: call to getABool | false | 53 | 53 |
 | test.cpp:42:13:42:20 | Call: call to getABool | true | 44 | 44 |
+| test.cpp:42:13:42:20 | Call: call to getABool | true | 45 | 45 |
 irGuardsEnsure
 | test.c:7:9:7:13 | CompareGT: ... > ... | test.c:7:9:7:9 | Load: x | < | test.c:7:13:7:13 | Constant: 0 | 1 | 11 | 11 |
 | test.c:7:9:7:13 | CompareGT: ... > ... | test.c:7:9:7:9 | Load: x | >= | test.c:7:13:7:13 | Constant: 0 | 1 | 8 | 8 |
@@ -1781,6 +1778,6 @@ irGuardsEnsure_const
 | test.cpp:31:7:31:13 | CompareEQ: ... == ... | test.cpp:31:7:31:13 | CompareEQ: ... == ... | == | 1 | 30 | 30 |
 | test.cpp:31:7:31:13 | CompareEQ: ... == ... | test.cpp:31:7:31:13 | CompareEQ: ... == ... | == | 1 | 32 | 32 |
 | test.cpp:42:13:42:20 | Call: call to getABool | test.cpp:42:13:42:20 | Call: call to getABool | != | 0 | 44 | 44 |
-| test.cpp:42:13:42:20 | Call: call to getABool | test.cpp:42:13:42:20 | Call: call to getABool | != | 1 | 53 | 53 |
-| test.cpp:42:13:42:20 | Call: call to getABool | test.cpp:42:13:42:20 | Call: call to getABool | == | 0 | 53 | 53 |
+| test.cpp:42:13:42:20 | Call: call to getABool | test.cpp:42:13:42:20 | Call: call to getABool | != | 0 | 45 | 45 |
 | test.cpp:42:13:42:20 | Call: call to getABool | test.cpp:42:13:42:20 | Call: call to getABool | == | 1 | 44 | 44 |
+| test.cpp:42:13:42:20 | Call: call to getABool | test.cpp:42:13:42:20 | Call: call to getABool | == | 1 | 45 | 45 |

--- a/cpp/ql/test/library-tests/controlflow/guards/GuardsControl.expected
+++ b/cpp/ql/test/library-tests/controlflow/guards/GuardsControl.expected
@@ -104,7 +104,6 @@
 | test.cpp:31:7:31:13 | ... == ... | false | 34 | 34 |
 | test.cpp:31:7:31:13 | ... == ... | true | 30 | 30 |
 | test.cpp:31:7:31:13 | ... == ... | true | 31 | 32 |
-| test.cpp:42:13:42:20 | call to getABool | false | 53 | 53 |
 | test.cpp:42:13:42:20 | call to getABool | true | 43 | 45 |
 | test.cpp:61:10:61:10 | i | Case[0] | 62 | 64 |
 | test.cpp:61:10:61:10 | i | Case[1] | 65 | 66 |

--- a/cpp/ql/test/library-tests/controlflow/guards/GuardsEnsure.expected
+++ b/cpp/ql/test/library-tests/controlflow/guards/GuardsEnsure.expected
@@ -635,8 +635,6 @@ unary
 | test.cpp:31:7:31:13 | ... == ... | test.cpp:31:7:31:13 | ... == ... | == | 1 | 30 | 30 |
 | test.cpp:31:7:31:13 | ... == ... | test.cpp:31:7:31:13 | ... == ... | == | 1 | 31 | 32 |
 | test.cpp:42:13:42:20 | call to getABool | test.cpp:42:13:42:20 | call to getABool | != | 0 | 43 | 45 |
-| test.cpp:42:13:42:20 | call to getABool | test.cpp:42:13:42:20 | call to getABool | != | 1 | 53 | 53 |
-| test.cpp:42:13:42:20 | call to getABool | test.cpp:42:13:42:20 | call to getABool | == | 0 | 53 | 53 |
 | test.cpp:42:13:42:20 | call to getABool | test.cpp:42:13:42:20 | call to getABool | == | 1 | 43 | 45 |
 | test.cpp:61:10:61:10 | i | test.cpp:61:10:61:10 | i | == | 0 | 62 | 64 |
 | test.cpp:61:10:61:10 | i | test.cpp:61:10:61:10 | i | == | 1 | 65 | 66 |

--- a/cpp/ql/test/library-tests/ir/ir/aliased_ir.expected
+++ b/cpp/ql/test/library-tests/ir/ir/aliased_ir.expected
@@ -887,14 +887,13 @@ coroutines.cpp:
 #-----|     v0_16(void)                   = ^IndirectReadSideEffect[-1]               : &:r0_11, ~m0_15
 #-----|     m0_17(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r0_11
 #-----|     m0_18(unknown)                = Chi                                       : total:m0_15, partial:m0_17
-#   88|     v88_1(void)                   = NoOp                                      : 
-#-----|     v0_19(void)                   = NoOp                                      : 
-#-----|   Goto (back edge) -> Block 3
+#-----|   C++ Exception -> Block 4
+#-----|   Goto -> Block 3
 
 #   87|   Block 2
 #   87|     r87_42(suspend_always *)                      = CopyValue                                 : r87_27
 #   87|     r87_43(glval<suspend_always>)                 = CopyValue                                 : r87_42
-#-----|     r0_20(glval<suspend_always>)                  = Convert                                   : r87_43
+#-----|     r0_19(glval<suspend_always>)                  = Convert                                   : r87_43
 #   87|     r87_44(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
 #   87|     r87_45(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp87:20]               : 
 #   87|     m87_46(coroutine_handle<promise_type>)        = Uninitialized[#temp87:20]                 : &:r87_45
@@ -910,87 +909,116 @@ coroutines.cpp:
 #   87|     m87_56(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r87_45
 #   87|     m87_57(unknown)                               = Chi                                       : total:m87_54, partial:m87_56
 #   87|     r87_58(coroutine_handle<promise_type>)        = Load[#temp87:20]                          : &:r87_45, ~m87_57
-#   87|     v87_59(void)                                  = Call[await_suspend]                       : func:r87_44, this:r0_20, 0:r87_58
+#   87|     v87_59(void)                                  = Call[await_suspend]                       : func:r87_44, this:r0_19, 0:r87_58
 #   87|     m87_60(unknown)                               = ^CallSideEffect                           : ~m87_57
 #   87|     m87_61(unknown)                               = Chi                                       : total:m87_57, partial:m87_60
-#-----|     v0_21(void)                                   = ^IndirectReadSideEffect[-1]               : &:r0_20, ~m87_61
+#-----|     v0_20(void)                                   = ^IndirectReadSideEffect[-1]               : &:r0_19, ~m87_61
 #-----|   Goto -> Block 1
 
-#-----|   Block 3
-#-----|     v0_22(void)                    = NoOp                                      : 
-#   87|     r87_62(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
-#   87|     r87_63(glval<unknown>)         = FunctionAddress[final_suspend]            : 
-#   87|     r87_64(suspend_always)         = Call[final_suspend]                       : func:r87_63, this:r87_62
-#   87|     m87_65(unknown)                = ^CallSideEffect                           : ~m0_18
-#   87|     m87_66(unknown)                = Chi                                       : total:m0_18, partial:m87_65
-#   87|     v87_67(void)                   = ^IndirectReadSideEffect[-1]               : &:r87_62, ~m87_66
-#   87|     m87_68(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r87_62
-#   87|     m87_69(unknown)                = Chi                                       : total:m87_66, partial:m87_68
-#-----|     r0_23(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
-#   87|     r87_70(glval<suspend_always>)  = VariableAddress[#temp87:20]               : 
-#   87|     r87_71(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
-#   87|     r87_72(glval<unknown>)         = FunctionAddress[final_suspend]            : 
-#   87|     r87_73(suspend_always)         = Call[final_suspend]                       : func:r87_72, this:r87_71
-#   87|     m87_74(unknown)                = ^CallSideEffect                           : ~m87_69
-#   87|     m87_75(unknown)                = Chi                                       : total:m87_69, partial:m87_74
-#   87|     v87_76(void)                   = ^IndirectReadSideEffect[-1]               : &:r87_71, ~m87_75
-#   87|     m87_77(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r87_71
-#   87|     m87_78(unknown)                = Chi                                       : total:m87_75, partial:m87_77
-#   87|     m87_79(suspend_always)         = Store[#temp87:20]                         : &:r87_70, r87_73
-#   87|     m87_80(unknown)                = Chi                                       : total:m87_78, partial:m87_79
-#   87|     r87_81(suspend_always *)       = CopyValue                                 : r87_70
-#   87|     m87_82(suspend_always *)       = Store[#temp0:0]                           : &:r0_23, r87_81
-#-----|     r0_24(suspend_always *)        = Load[#temp0:0]                            : &:r0_23, m87_82
-#   87|     r87_83(glval<suspend_always>)  = CopyValue                                 : r0_24
-#   87|     r87_84(glval<suspend_always>)  = Convert                                   : r87_83
-#   87|     r87_85(glval<unknown>)         = FunctionAddress[await_ready]              : 
-#   87|     r87_86(bool)                   = Call[await_ready]                         : func:r87_85, this:r87_84
-#   87|     m87_87(unknown)                = ^CallSideEffect                           : ~m87_80
-#   87|     m87_88(unknown)                = Chi                                       : total:m87_80, partial:m87_87
-#   87|     v87_89(void)                   = ^IndirectReadSideEffect[-1]               : &:r87_84, ~m87_88
-#-----|     v0_25(void)                    = ConditionalBranch                         : r87_86
-#-----|   False -> Block 5
-#-----|   True -> Block 4
+#   88|   Block 3
+#   88|     v88_1(void) = NoOp : 
+#-----|     v0_21(void) = NoOp : 
+#-----|   Goto (back edge) -> Block 6
 
-#   87|   Block 4
-#   87|     m87_90(unknown)                   = Phi                           : from 3:~m87_88, from 5:~m87_120
-#   87|     r87_91(suspend_always *)          = CopyValue                     : r87_81
-#   87|     r87_92(glval<suspend_always>)     = CopyValue                     : r87_91
-#-----|     r0_26(glval<suspend_always>)      = Convert                       : r87_92
-#   87|     r87_93(glval<unknown>)            = FunctionAddress[await_resume] : 
-#   87|     v87_94(void)                      = Call[await_resume]            : func:r87_93, this:r0_26
-#   87|     m87_95(unknown)                   = ^CallSideEffect               : ~m87_90
-#   87|     m87_96(unknown)                   = Chi                           : total:m87_90, partial:m87_95
-#-----|     v0_27(void)                       = ^IndirectReadSideEffect[-1]   : &:r0_26, ~m87_96
-#   87|     r87_97(glval<co_returnable_void>) = VariableAddress[#return]      : 
-#   87|     v87_98(void)                      = ReturnValue                   : &:r87_97, ~m87_96
-#   87|     v87_99(void)                      = AliasedUse                    : ~m87_96
-#   87|     v87_100(void)                     = ExitFunction                  : 
+#-----|   Block 4
+#-----|     v0_22(void)        = CatchAny                                  : 
+#-----|     r0_23(glval<bool>) = VariableAddress[(unnamed local variable)] : 
+#-----|     r0_24(bool)        = Load[(unnamed local variable)]            : &:r0_23, m0_7
+#-----|     r0_25(bool)        = LogicalNot                                : r0_24
+#-----|     v0_26(void)        = ConditionalBranch                         : r0_25
+#-----|   False -> Block 5
+#-----|   True -> Block 9
 
 #   87|   Block 5
-#   87|     r87_101(suspend_always *)                      = CopyValue                                 : r87_81
-#   87|     r87_102(glval<suspend_always>)                 = CopyValue                                 : r87_101
-#-----|     r0_28(glval<suspend_always>)                   = Convert                                   : r87_102
-#   87|     r87_103(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
-#   87|     r87_104(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp87:20]               : 
-#   87|     m87_105(coroutine_handle<promise_type>)        = Uninitialized[#temp87:20]                 : &:r87_104
-#   87|     m87_106(unknown)                               = Chi                                       : total:m87_88, partial:m87_105
-#   87|     r87_107(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
-#   87|     r87_108(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
-#   87|     r87_109(glval<coroutine_handle<promise_type>>) = Convert                                   : r87_108
-#   87|     r87_110(coroutine_handle<promise_type> &)      = CopyValue                                 : r87_109
-#   87|     v87_111(void)                                  = Call[coroutine_handle]                    : func:r87_107, this:r87_104, 0:r87_110
-#   87|     m87_112(unknown)                               = ^CallSideEffect                           : ~m87_106
-#   87|     m87_113(unknown)                               = Chi                                       : total:m87_106, partial:m87_112
-#   87|     v87_114(void)                                  = ^BufferReadSideEffect[0]                  : &:r87_110, ~m87_113
-#   87|     m87_115(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r87_104
-#   87|     m87_116(unknown)                               = Chi                                       : total:m87_113, partial:m87_115
-#   87|     r87_117(coroutine_handle<promise_type>)        = Load[#temp87:20]                          : &:r87_104, ~m87_116
-#   87|     v87_118(void)                                  = Call[await_suspend]                       : func:r87_103, this:r0_28, 0:r87_117
-#   87|     m87_119(unknown)                               = ^CallSideEffect                           : ~m87_116
-#   87|     m87_120(unknown)                               = Chi                                       : total:m87_116, partial:m87_119
-#-----|     v0_29(void)                                    = ^IndirectReadSideEffect[-1]               : &:r0_28, ~m87_120
-#-----|   Goto -> Block 4
+#   87|     r87_62(glval<promise_type>) = VariableAddress[(unnamed local variable)] : 
+#   87|     r87_63(glval<unknown>)      = FunctionAddress[unhandled_exception]      : 
+#   87|     v87_64(void)                = Call[unhandled_exception]                 : func:r87_63, this:r87_62
+#   87|     m87_65(unknown)             = ^CallSideEffect                           : ~m0_18
+#   87|     m87_66(unknown)             = Chi                                       : total:m0_18, partial:m87_65
+#   87|     v87_67(void)                = ^IndirectReadSideEffect[-1]               : &:r87_62, ~m87_66
+#   87|     m87_68(promise_type)        = ^IndirectMayWriteSideEffect[-1]           : &:r87_62
+#   87|     m87_69(unknown)             = Chi                                       : total:m87_66, partial:m87_68
+#-----|   Goto -> Block 6
+
+#-----|   Block 6
+#-----|     m0_27(unknown)                 = Phi                                       : from 3:~m0_18, from 5:~m87_69
+#-----|     v0_28(void)                    = NoOp                                      : 
+#   87|     r87_70(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
+#   87|     r87_71(glval<unknown>)         = FunctionAddress[final_suspend]            : 
+#   87|     r87_72(suspend_always)         = Call[final_suspend]                       : func:r87_71, this:r87_70
+#   87|     m87_73(unknown)                = ^CallSideEffect                           : ~m0_27
+#   87|     m87_74(unknown)                = Chi                                       : total:m0_27, partial:m87_73
+#   87|     v87_75(void)                   = ^IndirectReadSideEffect[-1]               : &:r87_70, ~m87_74
+#   87|     m87_76(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r87_70
+#   87|     m87_77(unknown)                = Chi                                       : total:m87_74, partial:m87_76
+#-----|     r0_29(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
+#   87|     r87_78(glval<suspend_always>)  = VariableAddress[#temp87:20]               : 
+#   87|     r87_79(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
+#   87|     r87_80(glval<unknown>)         = FunctionAddress[final_suspend]            : 
+#   87|     r87_81(suspend_always)         = Call[final_suspend]                       : func:r87_80, this:r87_79
+#   87|     m87_82(unknown)                = ^CallSideEffect                           : ~m87_77
+#   87|     m87_83(unknown)                = Chi                                       : total:m87_77, partial:m87_82
+#   87|     v87_84(void)                   = ^IndirectReadSideEffect[-1]               : &:r87_79, ~m87_83
+#   87|     m87_85(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r87_79
+#   87|     m87_86(unknown)                = Chi                                       : total:m87_83, partial:m87_85
+#   87|     m87_87(suspend_always)         = Store[#temp87:20]                         : &:r87_78, r87_81
+#   87|     m87_88(unknown)                = Chi                                       : total:m87_86, partial:m87_87
+#   87|     r87_89(suspend_always *)       = CopyValue                                 : r87_78
+#   87|     m87_90(suspend_always *)       = Store[#temp0:0]                           : &:r0_29, r87_89
+#-----|     r0_30(suspend_always *)        = Load[#temp0:0]                            : &:r0_29, m87_90
+#   87|     r87_91(glval<suspend_always>)  = CopyValue                                 : r0_30
+#   87|     r87_92(glval<suspend_always>)  = Convert                                   : r87_91
+#   87|     r87_93(glval<unknown>)         = FunctionAddress[await_ready]              : 
+#   87|     r87_94(bool)                   = Call[await_ready]                         : func:r87_93, this:r87_92
+#   87|     m87_95(unknown)                = ^CallSideEffect                           : ~m87_88
+#   87|     m87_96(unknown)                = Chi                                       : total:m87_88, partial:m87_95
+#   87|     v87_97(void)                   = ^IndirectReadSideEffect[-1]               : &:r87_92, ~m87_96
+#-----|     v0_31(void)                    = ConditionalBranch                         : r87_94
+#-----|   False -> Block 8
+#-----|   True -> Block 7
+
+#   87|   Block 7
+#   87|     m87_98(unknown)                    = Phi                           : from 6:~m87_96, from 8:~m87_128
+#   87|     r87_99(suspend_always *)           = CopyValue                     : r87_89
+#   87|     r87_100(glval<suspend_always>)     = CopyValue                     : r87_99
+#-----|     r0_32(glval<suspend_always>)       = Convert                       : r87_100
+#   87|     r87_101(glval<unknown>)            = FunctionAddress[await_resume] : 
+#   87|     v87_102(void)                      = Call[await_resume]            : func:r87_101, this:r0_32
+#   87|     m87_103(unknown)                   = ^CallSideEffect               : ~m87_98
+#   87|     m87_104(unknown)                   = Chi                           : total:m87_98, partial:m87_103
+#-----|     v0_33(void)                        = ^IndirectReadSideEffect[-1]   : &:r0_32, ~m87_104
+#   87|     r87_105(glval<co_returnable_void>) = VariableAddress[#return]      : 
+#   87|     v87_106(void)                      = ReturnValue                   : &:r87_105, ~m87_104
+#   87|     v87_107(void)                      = AliasedUse                    : ~m87_104
+#   87|     v87_108(void)                      = ExitFunction                  : 
+
+#   87|   Block 8
+#   87|     r87_109(suspend_always *)                      = CopyValue                                 : r87_89
+#   87|     r87_110(glval<suspend_always>)                 = CopyValue                                 : r87_109
+#-----|     r0_34(glval<suspend_always>)                   = Convert                                   : r87_110
+#   87|     r87_111(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
+#   87|     r87_112(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp87:20]               : 
+#   87|     m87_113(coroutine_handle<promise_type>)        = Uninitialized[#temp87:20]                 : &:r87_112
+#   87|     m87_114(unknown)                               = Chi                                       : total:m87_96, partial:m87_113
+#   87|     r87_115(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
+#   87|     r87_116(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
+#   87|     r87_117(glval<coroutine_handle<promise_type>>) = Convert                                   : r87_116
+#   87|     r87_118(coroutine_handle<promise_type> &)      = CopyValue                                 : r87_117
+#   87|     v87_119(void)                                  = Call[coroutine_handle]                    : func:r87_115, this:r87_112, 0:r87_118
+#   87|     m87_120(unknown)                               = ^CallSideEffect                           : ~m87_114
+#   87|     m87_121(unknown)                               = Chi                                       : total:m87_114, partial:m87_120
+#   87|     v87_122(void)                                  = ^BufferReadSideEffect[0]                  : &:r87_118, ~m87_121
+#   87|     m87_123(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r87_112
+#   87|     m87_124(unknown)                               = Chi                                       : total:m87_121, partial:m87_123
+#   87|     r87_125(coroutine_handle<promise_type>)        = Load[#temp87:20]                          : &:r87_112, ~m87_124
+#   87|     v87_126(void)                                  = Call[await_suspend]                       : func:r87_111, this:r0_34, 0:r87_125
+#   87|     m87_127(unknown)                               = ^CallSideEffect                           : ~m87_124
+#   87|     m87_128(unknown)                               = Chi                                       : total:m87_124, partial:m87_127
+#-----|     v0_35(void)                                    = ^IndirectReadSideEffect[-1]               : &:r0_34, ~m87_128
+#-----|   Goto -> Block 7
+
+#   87|   Block 9
+#   87|     v87_129(void) = Unreached : 
 
 #   91| co_returnable_value co_return_int(int)
 #   91|   Block 0
@@ -1065,14 +1093,13 @@ coroutines.cpp:
 #-----|     v0_20(void)                   = ^IndirectReadSideEffect[-1]               : &:r0_15, ~m0_19
 #-----|     m0_21(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r0_15
 #-----|     m0_22(unknown)                = Chi                                       : total:m0_19, partial:m0_21
-#   92|     v92_3(void)                   = NoOp                                      : 
-#-----|     v0_23(void)                   = NoOp                                      : 
-#-----|   Goto (back edge) -> Block 3
+#-----|   C++ Exception -> Block 4
+#-----|   Goto -> Block 3
 
 #   91|   Block 2
 #   91|     r91_44(suspend_always *)                      = CopyValue                                 : r91_29
 #   91|     r91_45(glval<suspend_always>)                 = CopyValue                                 : r91_44
-#-----|     r0_24(glval<suspend_always>)                  = Convert                                   : r91_45
+#-----|     r0_23(glval<suspend_always>)                  = Convert                                   : r91_45
 #   91|     r91_46(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
 #   91|     r91_47(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp91:21]               : 
 #   91|     m91_48(coroutine_handle<promise_type>)        = Uninitialized[#temp91:21]                 : &:r91_47
@@ -1088,87 +1115,116 @@ coroutines.cpp:
 #   91|     m91_58(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r91_47
 #   91|     m91_59(unknown)                               = Chi                                       : total:m91_56, partial:m91_58
 #   91|     r91_60(coroutine_handle<promise_type>)        = Load[#temp91:21]                          : &:r91_47, ~m91_59
-#   91|     v91_61(void)                                  = Call[await_suspend]                       : func:r91_46, this:r0_24, 0:r91_60
+#   91|     v91_61(void)                                  = Call[await_suspend]                       : func:r91_46, this:r0_23, 0:r91_60
 #   91|     m91_62(unknown)                               = ^CallSideEffect                           : ~m91_59
 #   91|     m91_63(unknown)                               = Chi                                       : total:m91_59, partial:m91_62
-#-----|     v0_25(void)                                   = ^IndirectReadSideEffect[-1]               : &:r0_24, ~m91_63
+#-----|     v0_24(void)                                   = ^IndirectReadSideEffect[-1]               : &:r0_23, ~m91_63
 #-----|   Goto -> Block 1
 
-#-----|   Block 3
-#-----|     v0_26(void)                    = NoOp                                      : 
-#   91|     r91_64(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
-#   91|     r91_65(glval<unknown>)         = FunctionAddress[final_suspend]            : 
-#   91|     r91_66(suspend_always)         = Call[final_suspend]                       : func:r91_65, this:r91_64
-#   91|     m91_67(unknown)                = ^CallSideEffect                           : ~m0_22
-#   91|     m91_68(unknown)                = Chi                                       : total:m0_22, partial:m91_67
-#   91|     v91_69(void)                   = ^IndirectReadSideEffect[-1]               : &:r91_64, ~m91_68
-#   91|     m91_70(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r91_64
-#   91|     m91_71(unknown)                = Chi                                       : total:m91_68, partial:m91_70
-#-----|     r0_27(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
-#   91|     r91_72(glval<suspend_always>)  = VariableAddress[#temp91:21]               : 
-#   91|     r91_73(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
-#   91|     r91_74(glval<unknown>)         = FunctionAddress[final_suspend]            : 
-#   91|     r91_75(suspend_always)         = Call[final_suspend]                       : func:r91_74, this:r91_73
-#   91|     m91_76(unknown)                = ^CallSideEffect                           : ~m91_71
-#   91|     m91_77(unknown)                = Chi                                       : total:m91_71, partial:m91_76
-#   91|     v91_78(void)                   = ^IndirectReadSideEffect[-1]               : &:r91_73, ~m91_77
-#   91|     m91_79(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r91_73
-#   91|     m91_80(unknown)                = Chi                                       : total:m91_77, partial:m91_79
-#   91|     m91_81(suspend_always)         = Store[#temp91:21]                         : &:r91_72, r91_75
-#   91|     m91_82(unknown)                = Chi                                       : total:m91_80, partial:m91_81
-#   91|     r91_83(suspend_always *)       = CopyValue                                 : r91_72
-#   91|     m91_84(suspend_always *)       = Store[#temp0:0]                           : &:r0_27, r91_83
-#-----|     r0_28(suspend_always *)        = Load[#temp0:0]                            : &:r0_27, m91_84
-#   91|     r91_85(glval<suspend_always>)  = CopyValue                                 : r0_28
-#   91|     r91_86(glval<suspend_always>)  = Convert                                   : r91_85
-#   91|     r91_87(glval<unknown>)         = FunctionAddress[await_ready]              : 
-#   91|     r91_88(bool)                   = Call[await_ready]                         : func:r91_87, this:r91_86
-#   91|     m91_89(unknown)                = ^CallSideEffect                           : ~m91_82
-#   91|     m91_90(unknown)                = Chi                                       : total:m91_82, partial:m91_89
-#   91|     v91_91(void)                   = ^IndirectReadSideEffect[-1]               : &:r91_86, ~m91_90
-#-----|     v0_29(void)                    = ConditionalBranch                         : r91_88
-#-----|   False -> Block 5
-#-----|   True -> Block 4
+#   92|   Block 3
+#   92|     v92_3(void) = NoOp : 
+#-----|     v0_25(void) = NoOp : 
+#-----|   Goto (back edge) -> Block 6
 
-#   91|   Block 4
-#   91|     m91_92(unknown)                    = Phi                           : from 3:~m91_90, from 5:~m91_122
-#   91|     r91_93(suspend_always *)           = CopyValue                     : r91_83
-#   91|     r91_94(glval<suspend_always>)      = CopyValue                     : r91_93
-#-----|     r0_30(glval<suspend_always>)       = Convert                       : r91_94
-#   91|     r91_95(glval<unknown>)             = FunctionAddress[await_resume] : 
-#   91|     v91_96(void)                       = Call[await_resume]            : func:r91_95, this:r0_30
-#   91|     m91_97(unknown)                    = ^CallSideEffect               : ~m91_92
-#   91|     m91_98(unknown)                    = Chi                           : total:m91_92, partial:m91_97
-#-----|     v0_31(void)                        = ^IndirectReadSideEffect[-1]   : &:r0_30, ~m91_98
-#   91|     r91_99(glval<co_returnable_value>) = VariableAddress[#return]      : 
-#   91|     v91_100(void)                      = ReturnValue                   : &:r91_99, ~m91_98
-#   91|     v91_101(void)                      = AliasedUse                    : ~m91_98
-#   91|     v91_102(void)                      = ExitFunction                  : 
+#-----|   Block 4
+#-----|     v0_26(void)        = CatchAny                                  : 
+#-----|     r0_27(glval<bool>) = VariableAddress[(unnamed local variable)] : 
+#-----|     r0_28(bool)        = Load[(unnamed local variable)]            : &:r0_27, m0_11
+#-----|     r0_29(bool)        = LogicalNot                                : r0_28
+#-----|     v0_30(void)        = ConditionalBranch                         : r0_29
+#-----|   False -> Block 5
+#-----|   True -> Block 9
 
 #   91|   Block 5
-#   91|     r91_103(suspend_always *)                      = CopyValue                                 : r91_83
-#   91|     r91_104(glval<suspend_always>)                 = CopyValue                                 : r91_103
-#-----|     r0_32(glval<suspend_always>)                   = Convert                                   : r91_104
-#   91|     r91_105(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
-#   91|     r91_106(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp91:21]               : 
-#   91|     m91_107(coroutine_handle<promise_type>)        = Uninitialized[#temp91:21]                 : &:r91_106
-#   91|     m91_108(unknown)                               = Chi                                       : total:m91_90, partial:m91_107
-#   91|     r91_109(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
-#   91|     r91_110(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
-#   91|     r91_111(glval<coroutine_handle<promise_type>>) = Convert                                   : r91_110
-#   91|     r91_112(coroutine_handle<promise_type> &)      = CopyValue                                 : r91_111
-#   91|     v91_113(void)                                  = Call[coroutine_handle]                    : func:r91_109, this:r91_106, 0:r91_112
-#   91|     m91_114(unknown)                               = ^CallSideEffect                           : ~m91_108
-#   91|     m91_115(unknown)                               = Chi                                       : total:m91_108, partial:m91_114
-#   91|     v91_116(void)                                  = ^BufferReadSideEffect[0]                  : &:r91_112, ~m91_115
-#   91|     m91_117(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r91_106
-#   91|     m91_118(unknown)                               = Chi                                       : total:m91_115, partial:m91_117
-#   91|     r91_119(coroutine_handle<promise_type>)        = Load[#temp91:21]                          : &:r91_106, ~m91_118
-#   91|     v91_120(void)                                  = Call[await_suspend]                       : func:r91_105, this:r0_32, 0:r91_119
-#   91|     m91_121(unknown)                               = ^CallSideEffect                           : ~m91_118
-#   91|     m91_122(unknown)                               = Chi                                       : total:m91_118, partial:m91_121
-#-----|     v0_33(void)                                    = ^IndirectReadSideEffect[-1]               : &:r0_32, ~m91_122
-#-----|   Goto -> Block 4
+#   91|     r91_64(glval<promise_type>) = VariableAddress[(unnamed local variable)] : 
+#   91|     r91_65(glval<unknown>)      = FunctionAddress[unhandled_exception]      : 
+#   91|     v91_66(void)                = Call[unhandled_exception]                 : func:r91_65, this:r91_64
+#   91|     m91_67(unknown)             = ^CallSideEffect                           : ~m0_22
+#   91|     m91_68(unknown)             = Chi                                       : total:m0_22, partial:m91_67
+#   91|     v91_69(void)                = ^IndirectReadSideEffect[-1]               : &:r91_64, ~m91_68
+#   91|     m91_70(promise_type)        = ^IndirectMayWriteSideEffect[-1]           : &:r91_64
+#   91|     m91_71(unknown)             = Chi                                       : total:m91_68, partial:m91_70
+#-----|   Goto -> Block 6
+
+#-----|   Block 6
+#-----|     m0_31(unknown)                 = Phi                                       : from 3:~m0_22, from 5:~m91_71
+#-----|     v0_32(void)                    = NoOp                                      : 
+#   91|     r91_72(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
+#   91|     r91_73(glval<unknown>)         = FunctionAddress[final_suspend]            : 
+#   91|     r91_74(suspend_always)         = Call[final_suspend]                       : func:r91_73, this:r91_72
+#   91|     m91_75(unknown)                = ^CallSideEffect                           : ~m0_31
+#   91|     m91_76(unknown)                = Chi                                       : total:m0_31, partial:m91_75
+#   91|     v91_77(void)                   = ^IndirectReadSideEffect[-1]               : &:r91_72, ~m91_76
+#   91|     m91_78(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r91_72
+#   91|     m91_79(unknown)                = Chi                                       : total:m91_76, partial:m91_78
+#-----|     r0_33(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
+#   91|     r91_80(glval<suspend_always>)  = VariableAddress[#temp91:21]               : 
+#   91|     r91_81(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
+#   91|     r91_82(glval<unknown>)         = FunctionAddress[final_suspend]            : 
+#   91|     r91_83(suspend_always)         = Call[final_suspend]                       : func:r91_82, this:r91_81
+#   91|     m91_84(unknown)                = ^CallSideEffect                           : ~m91_79
+#   91|     m91_85(unknown)                = Chi                                       : total:m91_79, partial:m91_84
+#   91|     v91_86(void)                   = ^IndirectReadSideEffect[-1]               : &:r91_81, ~m91_85
+#   91|     m91_87(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r91_81
+#   91|     m91_88(unknown)                = Chi                                       : total:m91_85, partial:m91_87
+#   91|     m91_89(suspend_always)         = Store[#temp91:21]                         : &:r91_80, r91_83
+#   91|     m91_90(unknown)                = Chi                                       : total:m91_88, partial:m91_89
+#   91|     r91_91(suspend_always *)       = CopyValue                                 : r91_80
+#   91|     m91_92(suspend_always *)       = Store[#temp0:0]                           : &:r0_33, r91_91
+#-----|     r0_34(suspend_always *)        = Load[#temp0:0]                            : &:r0_33, m91_92
+#   91|     r91_93(glval<suspend_always>)  = CopyValue                                 : r0_34
+#   91|     r91_94(glval<suspend_always>)  = Convert                                   : r91_93
+#   91|     r91_95(glval<unknown>)         = FunctionAddress[await_ready]              : 
+#   91|     r91_96(bool)                   = Call[await_ready]                         : func:r91_95, this:r91_94
+#   91|     m91_97(unknown)                = ^CallSideEffect                           : ~m91_90
+#   91|     m91_98(unknown)                = Chi                                       : total:m91_90, partial:m91_97
+#   91|     v91_99(void)                   = ^IndirectReadSideEffect[-1]               : &:r91_94, ~m91_98
+#-----|     v0_35(void)                    = ConditionalBranch                         : r91_96
+#-----|   False -> Block 8
+#-----|   True -> Block 7
+
+#   91|   Block 7
+#   91|     m91_100(unknown)                    = Phi                           : from 6:~m91_98, from 8:~m91_130
+#   91|     r91_101(suspend_always *)           = CopyValue                     : r91_91
+#   91|     r91_102(glval<suspend_always>)      = CopyValue                     : r91_101
+#-----|     r0_36(glval<suspend_always>)        = Convert                       : r91_102
+#   91|     r91_103(glval<unknown>)             = FunctionAddress[await_resume] : 
+#   91|     v91_104(void)                       = Call[await_resume]            : func:r91_103, this:r0_36
+#   91|     m91_105(unknown)                    = ^CallSideEffect               : ~m91_100
+#   91|     m91_106(unknown)                    = Chi                           : total:m91_100, partial:m91_105
+#-----|     v0_37(void)                         = ^IndirectReadSideEffect[-1]   : &:r0_36, ~m91_106
+#   91|     r91_107(glval<co_returnable_value>) = VariableAddress[#return]      : 
+#   91|     v91_108(void)                       = ReturnValue                   : &:r91_107, ~m91_106
+#   91|     v91_109(void)                       = AliasedUse                    : ~m91_106
+#   91|     v91_110(void)                       = ExitFunction                  : 
+
+#   91|   Block 8
+#   91|     r91_111(suspend_always *)                      = CopyValue                                 : r91_91
+#   91|     r91_112(glval<suspend_always>)                 = CopyValue                                 : r91_111
+#-----|     r0_38(glval<suspend_always>)                   = Convert                                   : r91_112
+#   91|     r91_113(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
+#   91|     r91_114(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp91:21]               : 
+#   91|     m91_115(coroutine_handle<promise_type>)        = Uninitialized[#temp91:21]                 : &:r91_114
+#   91|     m91_116(unknown)                               = Chi                                       : total:m91_98, partial:m91_115
+#   91|     r91_117(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
+#   91|     r91_118(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
+#   91|     r91_119(glval<coroutine_handle<promise_type>>) = Convert                                   : r91_118
+#   91|     r91_120(coroutine_handle<promise_type> &)      = CopyValue                                 : r91_119
+#   91|     v91_121(void)                                  = Call[coroutine_handle]                    : func:r91_117, this:r91_114, 0:r91_120
+#   91|     m91_122(unknown)                               = ^CallSideEffect                           : ~m91_116
+#   91|     m91_123(unknown)                               = Chi                                       : total:m91_116, partial:m91_122
+#   91|     v91_124(void)                                  = ^BufferReadSideEffect[0]                  : &:r91_120, ~m91_123
+#   91|     m91_125(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r91_114
+#   91|     m91_126(unknown)                               = Chi                                       : total:m91_123, partial:m91_125
+#   91|     r91_127(coroutine_handle<promise_type>)        = Load[#temp91:21]                          : &:r91_114, ~m91_126
+#   91|     v91_128(void)                                  = Call[await_suspend]                       : func:r91_113, this:r0_38, 0:r91_127
+#   91|     m91_129(unknown)                               = ^CallSideEffect                           : ~m91_126
+#   91|     m91_130(unknown)                               = Chi                                       : total:m91_126, partial:m91_129
+#-----|     v0_39(void)                                    = ^IndirectReadSideEffect[-1]               : &:r0_38, ~m91_130
+#-----|   Goto -> Block 7
+
+#   91|   Block 9
+#   91|     v91_131(void) = Unreached : 
 
 #   95| co_returnable_void co_yield_value_void(int)
 #   95|   Block 0
@@ -1220,61 +1276,36 @@ coroutines.cpp:
 #-----|   True -> Block 1
 
 #-----|   Block 1
-#-----|     m0_8(unknown)                  = Phi                                       : from 0:~m95_36, from 2:~m95_63
-#-----|     r0_9(bool)                     = Constant[1]                               : 
-#-----|     r0_10(glval<bool>)             = VariableAddress[(unnamed local variable)] : 
-#-----|     m0_11(bool)                    = Store[(unnamed local variable)]           : &:r0_10, r0_9
-#   95|     r95_38(suspend_always *)       = CopyValue                                 : r95_29
-#   95|     r95_39(glval<suspend_always>)  = CopyValue                                 : r95_38
-#-----|     r0_12(glval<suspend_always>)   = Convert                                   : r95_39
-#   95|     r95_40(glval<unknown>)         = FunctionAddress[await_resume]             : 
-#   95|     v95_41(void)                   = Call[await_resume]                        : func:r95_40, this:r0_12
-#   95|     m95_42(unknown)                = ^CallSideEffect                           : ~m0_8
-#   95|     m95_43(unknown)                = Chi                                       : total:m0_8, partial:m95_42
-#-----|     v0_13(void)                    = ^IndirectReadSideEffect[-1]               : &:r0_12, ~m95_43
-#-----|     v0_14(void)                    = CopyValue                                 : v95_41
-#   96|     r96_1(glval<promise_type>)     = VariableAddress[(unnamed local variable)] : 
-#   96|     r96_2(glval<unknown>)          = FunctionAddress[yield_value]              : 
-#   96|     r96_3(glval<int>)              = VariableAddress[i]                        : 
-#   96|     r96_4(int)                     = Load[i]                                   : &:r96_3, m0_4
-#   96|     r96_5(suspend_always)          = Call[yield_value]                         : func:r96_2, this:r96_1, 0:r96_4
-#   96|     m96_6(unknown)                 = ^CallSideEffect                           : ~m95_43
-#   96|     m96_7(unknown)                 = Chi                                       : total:m95_43, partial:m96_6
-#   96|     v96_8(void)                    = ^IndirectReadSideEffect[-1]               : &:r96_1, ~m96_7
-#   96|     m96_9(promise_type)            = ^IndirectMayWriteSideEffect[-1]           : &:r96_1
-#   96|     m96_10(unknown)                = Chi                                       : total:m96_7, partial:m96_9
-#-----|     r0_15(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
-#   96|     r96_11(glval<suspend_always>)  = VariableAddress[#temp96:13]               : 
-#   96|     r96_12(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
-#   96|     r96_13(glval<unknown>)         = FunctionAddress[yield_value]              : 
-#   96|     r96_14(glval<int>)             = VariableAddress[i]                        : 
-#   96|     r96_15(int)                    = Load[i]                                   : &:r96_14, m0_4
-#   96|     r96_16(suspend_always)         = Call[yield_value]                         : func:r96_13, this:r96_12, 0:r96_15
-#   96|     m96_17(unknown)                = ^CallSideEffect                           : ~m96_10
-#   96|     m96_18(unknown)                = Chi                                       : total:m96_10, partial:m96_17
-#   96|     v96_19(void)                   = ^IndirectReadSideEffect[-1]               : &:r96_12, ~m96_18
-#   96|     m96_20(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r96_12
-#   96|     m96_21(unknown)                = Chi                                       : total:m96_18, partial:m96_20
-#   96|     m96_22(suspend_always)         = Store[#temp96:13]                         : &:r96_11, r96_16
-#   96|     m96_23(unknown)                = Chi                                       : total:m96_21, partial:m96_22
-#   96|     r96_24(suspend_always *)       = CopyValue                                 : r96_11
-#   96|     m96_25(suspend_always *)       = Store[#temp0:0]                           : &:r0_15, r96_24
-#-----|     r0_16(suspend_always *)        = Load[#temp0:0]                            : &:r0_15, m96_25
-#   96|     r96_26(glval<suspend_always>)  = CopyValue                                 : r0_16
-#   96|     r96_27(glval<suspend_always>)  = Convert                                   : r96_26
-#   96|     r96_28(glval<unknown>)         = FunctionAddress[await_ready]              : 
-#   96|     r96_29(bool)                   = Call[await_ready]                         : func:r96_28, this:r96_27
-#   96|     m96_30(unknown)                = ^CallSideEffect                           : ~m96_23
-#   96|     m96_31(unknown)                = Chi                                       : total:m96_23, partial:m96_30
-#   96|     v96_32(void)                   = ^IndirectReadSideEffect[-1]               : &:r96_27, ~m96_31
-#   96|     v96_33(void)                   = ConditionalBranch                         : r96_29
-#-----|   False -> Block 4
-#-----|   True -> Block 3
+#-----|     m0_8(unknown)                 = Phi                                       : from 0:~m95_36, from 2:~m95_63
+#-----|     r0_9(bool)                    = Constant[1]                               : 
+#-----|     r0_10(glval<bool>)            = VariableAddress[(unnamed local variable)] : 
+#-----|     m0_11(bool)                   = Store[(unnamed local variable)]           : &:r0_10, r0_9
+#   95|     r95_38(suspend_always *)      = CopyValue                                 : r95_29
+#   95|     r95_39(glval<suspend_always>) = CopyValue                                 : r95_38
+#-----|     r0_12(glval<suspend_always>)  = Convert                                   : r95_39
+#   95|     r95_40(glval<unknown>)        = FunctionAddress[await_resume]             : 
+#   95|     v95_41(void)                  = Call[await_resume]                        : func:r95_40, this:r0_12
+#   95|     m95_42(unknown)               = ^CallSideEffect                           : ~m0_8
+#   95|     m95_43(unknown)               = Chi                                       : total:m0_8, partial:m95_42
+#-----|     v0_13(void)                   = ^IndirectReadSideEffect[-1]               : &:r0_12, ~m95_43
+#-----|     v0_14(void)                   = CopyValue                                 : v95_41
+#   96|     r96_1(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
+#   96|     r96_2(glval<unknown>)         = FunctionAddress[yield_value]              : 
+#   96|     r96_3(glval<int>)             = VariableAddress[i]                        : 
+#   96|     r96_4(int)                    = Load[i]                                   : &:r96_3, m0_4
+#   96|     r96_5(suspend_always)         = Call[yield_value]                         : func:r96_2, this:r96_1, 0:r96_4
+#   96|     m96_6(unknown)                = ^CallSideEffect                           : ~m95_43
+#   96|     m96_7(unknown)                = Chi                                       : total:m95_43, partial:m96_6
+#   96|     v96_8(void)                   = ^IndirectReadSideEffect[-1]               : &:r96_1, ~m96_7
+#   96|     m96_9(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r96_1
+#   96|     m96_10(unknown)               = Chi                                       : total:m96_7, partial:m96_9
+#-----|   C++ Exception -> Block 8
+#-----|   Goto -> Block 3
 
 #   95|   Block 2
 #   95|     r95_44(suspend_always *)                      = CopyValue                                 : r95_29
 #   95|     r95_45(glval<suspend_always>)                 = CopyValue                                 : r95_44
-#-----|     r0_17(glval<suspend_always>)                  = Convert                                   : r95_45
+#-----|     r0_15(glval<suspend_always>)                  = Convert                                   : r95_45
 #   95|     r95_46(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
 #   95|     r95_47(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp95:20]               : 
 #   95|     m95_48(coroutine_handle<promise_type>)        = Uninitialized[#temp95:20]                 : &:r95_47
@@ -1290,14 +1321,47 @@ coroutines.cpp:
 #   95|     m95_58(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r95_47
 #   95|     m95_59(unknown)                               = Chi                                       : total:m95_56, partial:m95_58
 #   95|     r95_60(coroutine_handle<promise_type>)        = Load[#temp95:20]                          : &:r95_47, ~m95_59
-#   95|     v95_61(void)                                  = Call[await_suspend]                       : func:r95_46, this:r0_17, 0:r95_60
+#   95|     v95_61(void)                                  = Call[await_suspend]                       : func:r95_46, this:r0_15, 0:r95_60
 #   95|     m95_62(unknown)                               = ^CallSideEffect                           : ~m95_59
 #   95|     m95_63(unknown)                               = Chi                                       : total:m95_59, partial:m95_62
-#-----|     v0_18(void)                                   = ^IndirectReadSideEffect[-1]               : &:r0_17, ~m95_63
+#-----|     v0_16(void)                                   = ^IndirectReadSideEffect[-1]               : &:r0_15, ~m95_63
 #-----|   Goto -> Block 1
 
-#   96|   Block 3
-#   96|     m96_34(unknown)               = Phi                                       : from 1:~m96_31, from 4:~m96_60
+#-----|   Block 3
+#-----|     r0_17(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
+#   96|     r96_11(glval<suspend_always>)  = VariableAddress[#temp96:13]               : 
+#   96|     r96_12(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
+#   96|     r96_13(glval<unknown>)         = FunctionAddress[yield_value]              : 
+#   96|     r96_14(glval<int>)             = VariableAddress[i]                        : 
+#   96|     r96_15(int)                    = Load[i]                                   : &:r96_14, m0_4
+#   96|     r96_16(suspend_always)         = Call[yield_value]                         : func:r96_13, this:r96_12, 0:r96_15
+#   96|     m96_17(unknown)                = ^CallSideEffect                           : ~m96_10
+#   96|     m96_18(unknown)                = Chi                                       : total:m96_10, partial:m96_17
+#   96|     v96_19(void)                   = ^IndirectReadSideEffect[-1]               : &:r96_12, ~m96_18
+#   96|     m96_20(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r96_12
+#   96|     m96_21(unknown)                = Chi                                       : total:m96_18, partial:m96_20
+#-----|   C++ Exception -> Block 8
+#-----|   Goto -> Block 4
+
+#   96|   Block 4
+#   96|     m96_22(suspend_always)        = Store[#temp96:13]            : &:r96_11, r96_16
+#   96|     m96_23(unknown)               = Chi                          : total:m96_21, partial:m96_22
+#   96|     r96_24(suspend_always *)      = CopyValue                    : r96_11
+#   96|     m96_25(suspend_always *)      = Store[#temp0:0]              : &:r0_17, r96_24
+#-----|     r0_18(suspend_always *)       = Load[#temp0:0]               : &:r0_17, m96_25
+#   96|     r96_26(glval<suspend_always>) = CopyValue                    : r0_18
+#   96|     r96_27(glval<suspend_always>) = Convert                      : r96_26
+#   96|     r96_28(glval<unknown>)        = FunctionAddress[await_ready] : 
+#   96|     r96_29(bool)                  = Call[await_ready]            : func:r96_28, this:r96_27
+#   96|     m96_30(unknown)               = ^CallSideEffect              : ~m96_23
+#   96|     m96_31(unknown)               = Chi                          : total:m96_23, partial:m96_30
+#   96|     v96_32(void)                  = ^IndirectReadSideEffect[-1]  : &:r96_27, ~m96_31
+#   96|     v96_33(void)                  = ConditionalBranch            : r96_29
+#-----|   False -> Block 6
+#-----|   True -> Block 5
+
+#   96|   Block 5
+#   96|     m96_34(unknown)               = Phi                                       : from 4:~m96_31, from 6:~m96_60
 #   96|     r96_35(suspend_always *)      = CopyValue                                 : r96_24
 #   96|     r96_36(glval<suspend_always>) = CopyValue                                 : r96_35
 #-----|     r0_19(glval<suspend_always>)  = Convert                                   : r96_36
@@ -1314,14 +1378,13 @@ coroutines.cpp:
 #-----|     v0_26(void)                   = ^IndirectReadSideEffect[-1]               : &:r0_21, ~m0_25
 #-----|     m0_27(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r0_21
 #-----|     m0_28(unknown)                = Chi                                       : total:m0_25, partial:m0_27
-#   97|     v97_1(void)                   = NoOp                                      : 
-#-----|     v0_29(void)                   = NoOp                                      : 
-#-----|   Goto (back edge) -> Block 5
+#-----|   C++ Exception -> Block 8
+#-----|   Goto -> Block 7
 
-#   96|   Block 4
+#   96|   Block 6
 #   96|     r96_41(suspend_always *)                      = CopyValue                                 : r96_24
 #   96|     r96_42(glval<suspend_always>)                 = CopyValue                                 : r96_41
-#-----|     r0_30(glval<suspend_always>)                  = Convert                                   : r96_42
+#-----|     r0_29(glval<suspend_always>)                  = Convert                                   : r96_42
 #   96|     r96_43(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
 #   96|     r96_44(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp96:3]                : 
 #   96|     m96_45(coroutine_handle<promise_type>)        = Uninitialized[#temp96:3]                  : &:r96_44
@@ -1337,87 +1400,117 @@ coroutines.cpp:
 #   96|     m96_55(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r96_44
 #   96|     m96_56(unknown)                               = Chi                                       : total:m96_53, partial:m96_55
 #   96|     r96_57(coroutine_handle<promise_type>)        = Load[#temp96:3]                           : &:r96_44, ~m96_56
-#   96|     v96_58(void)                                  = Call[await_suspend]                       : func:r96_43, this:r0_30, 0:r96_57
+#   96|     v96_58(void)                                  = Call[await_suspend]                       : func:r96_43, this:r0_29, 0:r96_57
 #   96|     m96_59(unknown)                               = ^CallSideEffect                           : ~m96_56
 #   96|     m96_60(unknown)                               = Chi                                       : total:m96_56, partial:m96_59
-#-----|     v0_31(void)                                   = ^IndirectReadSideEffect[-1]               : &:r0_30, ~m96_60
-#-----|   Goto -> Block 3
+#-----|     v0_30(void)                                   = ^IndirectReadSideEffect[-1]               : &:r0_29, ~m96_60
+#-----|   Goto -> Block 5
 
-#-----|   Block 5
-#-----|     v0_32(void)                    = NoOp                                      : 
-#   95|     r95_64(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
-#   95|     r95_65(glval<unknown>)         = FunctionAddress[final_suspend]            : 
-#   95|     r95_66(suspend_always)         = Call[final_suspend]                       : func:r95_65, this:r95_64
-#   95|     m95_67(unknown)                = ^CallSideEffect                           : ~m0_28
-#   95|     m95_68(unknown)                = Chi                                       : total:m0_28, partial:m95_67
-#   95|     v95_69(void)                   = ^IndirectReadSideEffect[-1]               : &:r95_64, ~m95_68
-#   95|     m95_70(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r95_64
-#   95|     m95_71(unknown)                = Chi                                       : total:m95_68, partial:m95_70
-#-----|     r0_33(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
-#   95|     r95_72(glval<suspend_always>)  = VariableAddress[#temp95:20]               : 
-#   95|     r95_73(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
-#   95|     r95_74(glval<unknown>)         = FunctionAddress[final_suspend]            : 
-#   95|     r95_75(suspend_always)         = Call[final_suspend]                       : func:r95_74, this:r95_73
-#   95|     m95_76(unknown)                = ^CallSideEffect                           : ~m95_71
-#   95|     m95_77(unknown)                = Chi                                       : total:m95_71, partial:m95_76
-#   95|     v95_78(void)                   = ^IndirectReadSideEffect[-1]               : &:r95_73, ~m95_77
-#   95|     m95_79(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r95_73
-#   95|     m95_80(unknown)                = Chi                                       : total:m95_77, partial:m95_79
-#   95|     m95_81(suspend_always)         = Store[#temp95:20]                         : &:r95_72, r95_75
-#   95|     m95_82(unknown)                = Chi                                       : total:m95_80, partial:m95_81
-#   95|     r95_83(suspend_always *)       = CopyValue                                 : r95_72
-#   95|     m95_84(suspend_always *)       = Store[#temp0:0]                           : &:r0_33, r95_83
-#-----|     r0_34(suspend_always *)        = Load[#temp0:0]                            : &:r0_33, m95_84
-#   95|     r95_85(glval<suspend_always>)  = CopyValue                                 : r0_34
-#   95|     r95_86(glval<suspend_always>)  = Convert                                   : r95_85
-#   95|     r95_87(glval<unknown>)         = FunctionAddress[await_ready]              : 
-#   95|     r95_88(bool)                   = Call[await_ready]                         : func:r95_87, this:r95_86
-#   95|     m95_89(unknown)                = ^CallSideEffect                           : ~m95_82
-#   95|     m95_90(unknown)                = Chi                                       : total:m95_82, partial:m95_89
-#   95|     v95_91(void)                   = ^IndirectReadSideEffect[-1]               : &:r95_86, ~m95_90
-#-----|     v0_35(void)                    = ConditionalBranch                         : r95_88
-#-----|   False -> Block 7
-#-----|   True -> Block 6
+#   97|   Block 7
+#   97|     v97_1(void) = NoOp : 
+#-----|     v0_31(void) = NoOp : 
+#-----|   Goto (back edge) -> Block 10
 
-#   95|   Block 6
-#   95|     m95_92(unknown)                   = Phi                           : from 5:~m95_90, from 7:~m95_122
-#   95|     r95_93(suspend_always *)          = CopyValue                     : r95_83
-#   95|     r95_94(glval<suspend_always>)     = CopyValue                     : r95_93
-#-----|     r0_36(glval<suspend_always>)      = Convert                       : r95_94
-#   95|     r95_95(glval<unknown>)            = FunctionAddress[await_resume] : 
-#   95|     v95_96(void)                      = Call[await_resume]            : func:r95_95, this:r0_36
-#   95|     m95_97(unknown)                   = ^CallSideEffect               : ~m95_92
-#   95|     m95_98(unknown)                   = Chi                           : total:m95_92, partial:m95_97
-#-----|     v0_37(void)                       = ^IndirectReadSideEffect[-1]   : &:r0_36, ~m95_98
-#   95|     r95_99(glval<co_returnable_void>) = VariableAddress[#return]      : 
-#   95|     v95_100(void)                     = ReturnValue                   : &:r95_99, ~m95_98
-#   95|     v95_101(void)                     = AliasedUse                    : ~m95_98
-#   95|     v95_102(void)                     = ExitFunction                  : 
+#-----|   Block 8
+#-----|     m0_32(unknown)     = Phi                                       : from 1:~m96_10, from 3:~m96_21, from 5:~m0_28
+#-----|     v0_33(void)        = CatchAny                                  : 
+#-----|     r0_34(glval<bool>) = VariableAddress[(unnamed local variable)] : 
+#-----|     r0_35(bool)        = Load[(unnamed local variable)]            : &:r0_34, m0_11
+#-----|     r0_36(bool)        = LogicalNot                                : r0_35
+#-----|     v0_37(void)        = ConditionalBranch                         : r0_36
+#-----|   False -> Block 9
+#-----|   True -> Block 13
 
-#   95|   Block 7
-#   95|     r95_103(suspend_always *)                      = CopyValue                                 : r95_83
-#   95|     r95_104(glval<suspend_always>)                 = CopyValue                                 : r95_103
-#-----|     r0_38(glval<suspend_always>)                   = Convert                                   : r95_104
-#   95|     r95_105(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
-#   95|     r95_106(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp95:20]               : 
-#   95|     m95_107(coroutine_handle<promise_type>)        = Uninitialized[#temp95:20]                 : &:r95_106
-#   95|     m95_108(unknown)                               = Chi                                       : total:m95_90, partial:m95_107
-#   95|     r95_109(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
-#   95|     r95_110(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
-#   95|     r95_111(glval<coroutine_handle<promise_type>>) = Convert                                   : r95_110
-#   95|     r95_112(coroutine_handle<promise_type> &)      = CopyValue                                 : r95_111
-#   95|     v95_113(void)                                  = Call[coroutine_handle]                    : func:r95_109, this:r95_106, 0:r95_112
-#   95|     m95_114(unknown)                               = ^CallSideEffect                           : ~m95_108
-#   95|     m95_115(unknown)                               = Chi                                       : total:m95_108, partial:m95_114
-#   95|     v95_116(void)                                  = ^BufferReadSideEffect[0]                  : &:r95_112, ~m95_115
-#   95|     m95_117(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r95_106
-#   95|     m95_118(unknown)                               = Chi                                       : total:m95_115, partial:m95_117
-#   95|     r95_119(coroutine_handle<promise_type>)        = Load[#temp95:20]                          : &:r95_106, ~m95_118
-#   95|     v95_120(void)                                  = Call[await_suspend]                       : func:r95_105, this:r0_38, 0:r95_119
-#   95|     m95_121(unknown)                               = ^CallSideEffect                           : ~m95_118
-#   95|     m95_122(unknown)                               = Chi                                       : total:m95_118, partial:m95_121
-#-----|     v0_39(void)                                    = ^IndirectReadSideEffect[-1]               : &:r0_38, ~m95_122
-#-----|   Goto -> Block 6
+#   95|   Block 9
+#   95|     r95_64(glval<promise_type>) = VariableAddress[(unnamed local variable)] : 
+#   95|     r95_65(glval<unknown>)      = FunctionAddress[unhandled_exception]      : 
+#   95|     v95_66(void)                = Call[unhandled_exception]                 : func:r95_65, this:r95_64
+#   95|     m95_67(unknown)             = ^CallSideEffect                           : ~m0_32
+#   95|     m95_68(unknown)             = Chi                                       : total:m0_32, partial:m95_67
+#   95|     v95_69(void)                = ^IndirectReadSideEffect[-1]               : &:r95_64, ~m95_68
+#   95|     m95_70(promise_type)        = ^IndirectMayWriteSideEffect[-1]           : &:r95_64
+#   95|     m95_71(unknown)             = Chi                                       : total:m95_68, partial:m95_70
+#-----|   Goto -> Block 10
+
+#-----|   Block 10
+#-----|     m0_38(unknown)                 = Phi                                       : from 7:~m0_28, from 9:~m95_71
+#-----|     v0_39(void)                    = NoOp                                      : 
+#   95|     r95_72(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
+#   95|     r95_73(glval<unknown>)         = FunctionAddress[final_suspend]            : 
+#   95|     r95_74(suspend_always)         = Call[final_suspend]                       : func:r95_73, this:r95_72
+#   95|     m95_75(unknown)                = ^CallSideEffect                           : ~m0_38
+#   95|     m95_76(unknown)                = Chi                                       : total:m0_38, partial:m95_75
+#   95|     v95_77(void)                   = ^IndirectReadSideEffect[-1]               : &:r95_72, ~m95_76
+#   95|     m95_78(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r95_72
+#   95|     m95_79(unknown)                = Chi                                       : total:m95_76, partial:m95_78
+#-----|     r0_40(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
+#   95|     r95_80(glval<suspend_always>)  = VariableAddress[#temp95:20]               : 
+#   95|     r95_81(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
+#   95|     r95_82(glval<unknown>)         = FunctionAddress[final_suspend]            : 
+#   95|     r95_83(suspend_always)         = Call[final_suspend]                       : func:r95_82, this:r95_81
+#   95|     m95_84(unknown)                = ^CallSideEffect                           : ~m95_79
+#   95|     m95_85(unknown)                = Chi                                       : total:m95_79, partial:m95_84
+#   95|     v95_86(void)                   = ^IndirectReadSideEffect[-1]               : &:r95_81, ~m95_85
+#   95|     m95_87(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r95_81
+#   95|     m95_88(unknown)                = Chi                                       : total:m95_85, partial:m95_87
+#   95|     m95_89(suspend_always)         = Store[#temp95:20]                         : &:r95_80, r95_83
+#   95|     m95_90(unknown)                = Chi                                       : total:m95_88, partial:m95_89
+#   95|     r95_91(suspend_always *)       = CopyValue                                 : r95_80
+#   95|     m95_92(suspend_always *)       = Store[#temp0:0]                           : &:r0_40, r95_91
+#-----|     r0_41(suspend_always *)        = Load[#temp0:0]                            : &:r0_40, m95_92
+#   95|     r95_93(glval<suspend_always>)  = CopyValue                                 : r0_41
+#   95|     r95_94(glval<suspend_always>)  = Convert                                   : r95_93
+#   95|     r95_95(glval<unknown>)         = FunctionAddress[await_ready]              : 
+#   95|     r95_96(bool)                   = Call[await_ready]                         : func:r95_95, this:r95_94
+#   95|     m95_97(unknown)                = ^CallSideEffect                           : ~m95_90
+#   95|     m95_98(unknown)                = Chi                                       : total:m95_90, partial:m95_97
+#   95|     v95_99(void)                   = ^IndirectReadSideEffect[-1]               : &:r95_94, ~m95_98
+#-----|     v0_42(void)                    = ConditionalBranch                         : r95_96
+#-----|   False -> Block 12
+#-----|   True -> Block 11
+
+#   95|   Block 11
+#   95|     m95_100(unknown)                   = Phi                           : from 10:~m95_98, from 12:~m95_130
+#   95|     r95_101(suspend_always *)          = CopyValue                     : r95_91
+#   95|     r95_102(glval<suspend_always>)     = CopyValue                     : r95_101
+#-----|     r0_43(glval<suspend_always>)       = Convert                       : r95_102
+#   95|     r95_103(glval<unknown>)            = FunctionAddress[await_resume] : 
+#   95|     v95_104(void)                      = Call[await_resume]            : func:r95_103, this:r0_43
+#   95|     m95_105(unknown)                   = ^CallSideEffect               : ~m95_100
+#   95|     m95_106(unknown)                   = Chi                           : total:m95_100, partial:m95_105
+#-----|     v0_44(void)                        = ^IndirectReadSideEffect[-1]   : &:r0_43, ~m95_106
+#   95|     r95_107(glval<co_returnable_void>) = VariableAddress[#return]      : 
+#   95|     v95_108(void)                      = ReturnValue                   : &:r95_107, ~m95_106
+#   95|     v95_109(void)                      = AliasedUse                    : ~m95_106
+#   95|     v95_110(void)                      = ExitFunction                  : 
+
+#   95|   Block 12
+#   95|     r95_111(suspend_always *)                      = CopyValue                                 : r95_91
+#   95|     r95_112(glval<suspend_always>)                 = CopyValue                                 : r95_111
+#-----|     r0_45(glval<suspend_always>)                   = Convert                                   : r95_112
+#   95|     r95_113(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
+#   95|     r95_114(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp95:20]               : 
+#   95|     m95_115(coroutine_handle<promise_type>)        = Uninitialized[#temp95:20]                 : &:r95_114
+#   95|     m95_116(unknown)                               = Chi                                       : total:m95_98, partial:m95_115
+#   95|     r95_117(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
+#   95|     r95_118(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
+#   95|     r95_119(glval<coroutine_handle<promise_type>>) = Convert                                   : r95_118
+#   95|     r95_120(coroutine_handle<promise_type> &)      = CopyValue                                 : r95_119
+#   95|     v95_121(void)                                  = Call[coroutine_handle]                    : func:r95_117, this:r95_114, 0:r95_120
+#   95|     m95_122(unknown)                               = ^CallSideEffect                           : ~m95_116
+#   95|     m95_123(unknown)                               = Chi                                       : total:m95_116, partial:m95_122
+#   95|     v95_124(void)                                  = ^BufferReadSideEffect[0]                  : &:r95_120, ~m95_123
+#   95|     m95_125(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r95_114
+#   95|     m95_126(unknown)                               = Chi                                       : total:m95_123, partial:m95_125
+#   95|     r95_127(coroutine_handle<promise_type>)        = Load[#temp95:20]                          : &:r95_114, ~m95_126
+#   95|     v95_128(void)                                  = Call[await_suspend]                       : func:r95_113, this:r0_45, 0:r95_127
+#   95|     m95_129(unknown)                               = ^CallSideEffect                           : ~m95_126
+#   95|     m95_130(unknown)                               = Chi                                       : total:m95_126, partial:m95_129
+#-----|     v0_46(void)                                    = ^IndirectReadSideEffect[-1]               : &:r0_45, ~m95_130
+#-----|   Goto -> Block 11
+
+#   95|   Block 13
+#   95|     v95_131(void) = Unreached : 
 
 #   99| co_returnable_value co_yield_value_value(int)
 #   99|   Block 0
@@ -1469,61 +1562,36 @@ coroutines.cpp:
 #-----|   True -> Block 1
 
 #-----|   Block 1
-#-----|     m0_8(unknown)                  = Phi                                       : from 0:~m99_36, from 2:~m99_63
-#-----|     r0_9(bool)                     = Constant[1]                               : 
-#-----|     r0_10(glval<bool>)             = VariableAddress[(unnamed local variable)] : 
-#-----|     m0_11(bool)                    = Store[(unnamed local variable)]           : &:r0_10, r0_9
-#   99|     r99_38(suspend_always *)       = CopyValue                                 : r99_29
-#   99|     r99_39(glval<suspend_always>)  = CopyValue                                 : r99_38
-#-----|     r0_12(glval<suspend_always>)   = Convert                                   : r99_39
-#   99|     r99_40(glval<unknown>)         = FunctionAddress[await_resume]             : 
-#   99|     v99_41(void)                   = Call[await_resume]                        : func:r99_40, this:r0_12
-#   99|     m99_42(unknown)                = ^CallSideEffect                           : ~m0_8
-#   99|     m99_43(unknown)                = Chi                                       : total:m0_8, partial:m99_42
-#-----|     v0_13(void)                    = ^IndirectReadSideEffect[-1]               : &:r0_12, ~m99_43
-#-----|     v0_14(void)                    = CopyValue                                 : v99_41
-#  100|     r100_1(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
-#  100|     r100_2(glval<unknown>)         = FunctionAddress[yield_value]              : 
-#  100|     r100_3(glval<int>)             = VariableAddress[i]                        : 
-#  100|     r100_4(int)                    = Load[i]                                   : &:r100_3, m0_4
-#  100|     r100_5(suspend_always)         = Call[yield_value]                         : func:r100_2, this:r100_1, 0:r100_4
-#  100|     m100_6(unknown)                = ^CallSideEffect                           : ~m99_43
-#  100|     m100_7(unknown)                = Chi                                       : total:m99_43, partial:m100_6
-#  100|     v100_8(void)                   = ^IndirectReadSideEffect[-1]               : &:r100_1, ~m100_7
-#  100|     m100_9(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r100_1
-#  100|     m100_10(unknown)               = Chi                                       : total:m100_7, partial:m100_9
-#-----|     r0_15(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
-#  100|     r100_11(glval<suspend_always>) = VariableAddress[#temp100:13]              : 
-#  100|     r100_12(glval<promise_type>)   = VariableAddress[(unnamed local variable)] : 
-#  100|     r100_13(glval<unknown>)        = FunctionAddress[yield_value]              : 
-#  100|     r100_14(glval<int>)            = VariableAddress[i]                        : 
-#  100|     r100_15(int)                   = Load[i]                                   : &:r100_14, m0_4
-#  100|     r100_16(suspend_always)        = Call[yield_value]                         : func:r100_13, this:r100_12, 0:r100_15
-#  100|     m100_17(unknown)               = ^CallSideEffect                           : ~m100_10
-#  100|     m100_18(unknown)               = Chi                                       : total:m100_10, partial:m100_17
-#  100|     v100_19(void)                  = ^IndirectReadSideEffect[-1]               : &:r100_12, ~m100_18
-#  100|     m100_20(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r100_12
-#  100|     m100_21(unknown)               = Chi                                       : total:m100_18, partial:m100_20
-#  100|     m100_22(suspend_always)        = Store[#temp100:13]                        : &:r100_11, r100_16
-#  100|     m100_23(unknown)               = Chi                                       : total:m100_21, partial:m100_22
-#  100|     r100_24(suspend_always *)      = CopyValue                                 : r100_11
-#  100|     m100_25(suspend_always *)      = Store[#temp0:0]                           : &:r0_15, r100_24
-#-----|     r0_16(suspend_always *)        = Load[#temp0:0]                            : &:r0_15, m100_25
-#  100|     r100_26(glval<suspend_always>) = CopyValue                                 : r0_16
-#  100|     r100_27(glval<suspend_always>) = Convert                                   : r100_26
-#  100|     r100_28(glval<unknown>)        = FunctionAddress[await_ready]              : 
-#  100|     r100_29(bool)                  = Call[await_ready]                         : func:r100_28, this:r100_27
-#  100|     m100_30(unknown)               = ^CallSideEffect                           : ~m100_23
-#  100|     m100_31(unknown)               = Chi                                       : total:m100_23, partial:m100_30
-#  100|     v100_32(void)                  = ^IndirectReadSideEffect[-1]               : &:r100_27, ~m100_31
-#  100|     v100_33(void)                  = ConditionalBranch                         : r100_29
-#-----|   False -> Block 4
-#-----|   True -> Block 3
+#-----|     m0_8(unknown)                 = Phi                                       : from 0:~m99_36, from 2:~m99_63
+#-----|     r0_9(bool)                    = Constant[1]                               : 
+#-----|     r0_10(glval<bool>)            = VariableAddress[(unnamed local variable)] : 
+#-----|     m0_11(bool)                   = Store[(unnamed local variable)]           : &:r0_10, r0_9
+#   99|     r99_38(suspend_always *)      = CopyValue                                 : r99_29
+#   99|     r99_39(glval<suspend_always>) = CopyValue                                 : r99_38
+#-----|     r0_12(glval<suspend_always>)  = Convert                                   : r99_39
+#   99|     r99_40(glval<unknown>)        = FunctionAddress[await_resume]             : 
+#   99|     v99_41(void)                  = Call[await_resume]                        : func:r99_40, this:r0_12
+#   99|     m99_42(unknown)               = ^CallSideEffect                           : ~m0_8
+#   99|     m99_43(unknown)               = Chi                                       : total:m0_8, partial:m99_42
+#-----|     v0_13(void)                   = ^IndirectReadSideEffect[-1]               : &:r0_12, ~m99_43
+#-----|     v0_14(void)                   = CopyValue                                 : v99_41
+#  100|     r100_1(glval<promise_type>)   = VariableAddress[(unnamed local variable)] : 
+#  100|     r100_2(glval<unknown>)        = FunctionAddress[yield_value]              : 
+#  100|     r100_3(glval<int>)            = VariableAddress[i]                        : 
+#  100|     r100_4(int)                   = Load[i]                                   : &:r100_3, m0_4
+#  100|     r100_5(suspend_always)        = Call[yield_value]                         : func:r100_2, this:r100_1, 0:r100_4
+#  100|     m100_6(unknown)               = ^CallSideEffect                           : ~m99_43
+#  100|     m100_7(unknown)               = Chi                                       : total:m99_43, partial:m100_6
+#  100|     v100_8(void)                  = ^IndirectReadSideEffect[-1]               : &:r100_1, ~m100_7
+#  100|     m100_9(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r100_1
+#  100|     m100_10(unknown)              = Chi                                       : total:m100_7, partial:m100_9
+#-----|   C++ Exception -> Block 7
+#-----|   Goto -> Block 3
 
 #   99|   Block 2
 #   99|     r99_44(suspend_always *)                      = CopyValue                                 : r99_29
 #   99|     r99_45(glval<suspend_always>)                 = CopyValue                                 : r99_44
-#-----|     r0_17(glval<suspend_always>)                  = Convert                                   : r99_45
+#-----|     r0_15(glval<suspend_always>)                  = Convert                                   : r99_45
 #   99|     r99_46(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
 #   99|     r99_47(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp99:21]               : 
 #   99|     m99_48(coroutine_handle<promise_type>)        = Uninitialized[#temp99:21]                 : &:r99_47
@@ -1539,61 +1607,61 @@ coroutines.cpp:
 #   99|     m99_58(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r99_47
 #   99|     m99_59(unknown)                               = Chi                                       : total:m99_56, partial:m99_58
 #   99|     r99_60(coroutine_handle<promise_type>)        = Load[#temp99:21]                          : &:r99_47, ~m99_59
-#   99|     v99_61(void)                                  = Call[await_suspend]                       : func:r99_46, this:r0_17, 0:r99_60
+#   99|     v99_61(void)                                  = Call[await_suspend]                       : func:r99_46, this:r0_15, 0:r99_60
 #   99|     m99_62(unknown)                               = ^CallSideEffect                           : ~m99_59
 #   99|     m99_63(unknown)                               = Chi                                       : total:m99_59, partial:m99_62
-#-----|     v0_18(void)                                   = ^IndirectReadSideEffect[-1]               : &:r0_17, ~m99_63
+#-----|     v0_16(void)                                   = ^IndirectReadSideEffect[-1]               : &:r0_15, ~m99_63
 #-----|   Goto -> Block 1
 
-#  100|   Block 3
-#  100|     m100_34(unknown)               = Phi                                       : from 1:~m100_31, from 4:~m100_60
-#  100|     r100_35(suspend_always *)      = CopyValue                                 : r100_24
-#  100|     r100_36(glval<suspend_always>) = CopyValue                                 : r100_35
-#-----|     r0_19(glval<suspend_always>)   = Convert                                   : r100_36
-#  100|     r100_37(glval<unknown>)        = FunctionAddress[await_resume]             : 
-#  100|     v100_38(void)                  = Call[await_resume]                        : func:r100_37, this:r0_19
-#  100|     m100_39(unknown)               = ^CallSideEffect                           : ~m100_34
-#  100|     m100_40(unknown)               = Chi                                       : total:m100_34, partial:m100_39
-#-----|     v0_20(void)                    = ^IndirectReadSideEffect[-1]               : &:r0_19, ~m100_40
-#-----|     v0_21(void)                    = NoOp                                      : 
-#   99|     r99_64(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
-#   99|     r99_65(glval<unknown>)         = FunctionAddress[final_suspend]            : 
-#   99|     r99_66(suspend_always)         = Call[final_suspend]                       : func:r99_65, this:r99_64
-#   99|     m99_67(unknown)                = ^CallSideEffect                           : ~m100_40
-#   99|     m99_68(unknown)                = Chi                                       : total:m100_40, partial:m99_67
-#   99|     v99_69(void)                   = ^IndirectReadSideEffect[-1]               : &:r99_64, ~m99_68
-#   99|     m99_70(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r99_64
-#   99|     m99_71(unknown)                = Chi                                       : total:m99_68, partial:m99_70
-#-----|     r0_22(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
-#   99|     r99_72(glval<suspend_always>)  = VariableAddress[#temp99:21]               : 
-#   99|     r99_73(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
-#   99|     r99_74(glval<unknown>)         = FunctionAddress[final_suspend]            : 
-#   99|     r99_75(suspend_always)         = Call[final_suspend]                       : func:r99_74, this:r99_73
-#   99|     m99_76(unknown)                = ^CallSideEffect                           : ~m99_71
-#   99|     m99_77(unknown)                = Chi                                       : total:m99_71, partial:m99_76
-#   99|     v99_78(void)                   = ^IndirectReadSideEffect[-1]               : &:r99_73, ~m99_77
-#   99|     m99_79(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r99_73
-#   99|     m99_80(unknown)                = Chi                                       : total:m99_77, partial:m99_79
-#   99|     m99_81(suspend_always)         = Store[#temp99:21]                         : &:r99_72, r99_75
-#   99|     m99_82(unknown)                = Chi                                       : total:m99_80, partial:m99_81
-#   99|     r99_83(suspend_always *)       = CopyValue                                 : r99_72
-#   99|     m99_84(suspend_always *)       = Store[#temp0:0]                           : &:r0_22, r99_83
-#-----|     r0_23(suspend_always *)        = Load[#temp0:0]                            : &:r0_22, m99_84
-#   99|     r99_85(glval<suspend_always>)  = CopyValue                                 : r0_23
-#   99|     r99_86(glval<suspend_always>)  = Convert                                   : r99_85
-#   99|     r99_87(glval<unknown>)         = FunctionAddress[await_ready]              : 
-#   99|     r99_88(bool)                   = Call[await_ready]                         : func:r99_87, this:r99_86
-#   99|     m99_89(unknown)                = ^CallSideEffect                           : ~m99_82
-#   99|     m99_90(unknown)                = Chi                                       : total:m99_82, partial:m99_89
-#   99|     v99_91(void)                   = ^IndirectReadSideEffect[-1]               : &:r99_86, ~m99_90
-#-----|     v0_24(void)                    = ConditionalBranch                         : r99_88
+#-----|   Block 3
+#-----|     r0_17(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
+#  100|     r100_11(glval<suspend_always>) = VariableAddress[#temp100:13]              : 
+#  100|     r100_12(glval<promise_type>)   = VariableAddress[(unnamed local variable)] : 
+#  100|     r100_13(glval<unknown>)        = FunctionAddress[yield_value]              : 
+#  100|     r100_14(glval<int>)            = VariableAddress[i]                        : 
+#  100|     r100_15(int)                   = Load[i]                                   : &:r100_14, m0_4
+#  100|     r100_16(suspend_always)        = Call[yield_value]                         : func:r100_13, this:r100_12, 0:r100_15
+#  100|     m100_17(unknown)               = ^CallSideEffect                           : ~m100_10
+#  100|     m100_18(unknown)               = Chi                                       : total:m100_10, partial:m100_17
+#  100|     v100_19(void)                  = ^IndirectReadSideEffect[-1]               : &:r100_12, ~m100_18
+#  100|     m100_20(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r100_12
+#  100|     m100_21(unknown)               = Chi                                       : total:m100_18, partial:m100_20
+#-----|   C++ Exception -> Block 7
+#-----|   Goto -> Block 4
+
+#  100|   Block 4
+#  100|     m100_22(suspend_always)        = Store[#temp100:13]           : &:r100_11, r100_16
+#  100|     m100_23(unknown)               = Chi                          : total:m100_21, partial:m100_22
+#  100|     r100_24(suspend_always *)      = CopyValue                    : r100_11
+#  100|     m100_25(suspend_always *)      = Store[#temp0:0]              : &:r0_17, r100_24
+#-----|     r0_18(suspend_always *)        = Load[#temp0:0]               : &:r0_17, m100_25
+#  100|     r100_26(glval<suspend_always>) = CopyValue                    : r0_18
+#  100|     r100_27(glval<suspend_always>) = Convert                      : r100_26
+#  100|     r100_28(glval<unknown>)        = FunctionAddress[await_ready] : 
+#  100|     r100_29(bool)                  = Call[await_ready]            : func:r100_28, this:r100_27
+#  100|     m100_30(unknown)               = ^CallSideEffect              : ~m100_23
+#  100|     m100_31(unknown)               = Chi                          : total:m100_23, partial:m100_30
+#  100|     v100_32(void)                  = ^IndirectReadSideEffect[-1]  : &:r100_27, ~m100_31
+#  100|     v100_33(void)                  = ConditionalBranch            : r100_29
 #-----|   False -> Block 6
 #-----|   True -> Block 5
 
-#  100|   Block 4
+#  100|   Block 5
+#  100|     m100_34(unknown)               = Phi                           : from 4:~m100_31, from 6:~m100_60
+#  100|     r100_35(suspend_always *)      = CopyValue                     : r100_24
+#  100|     r100_36(glval<suspend_always>) = CopyValue                     : r100_35
+#-----|     r0_19(glval<suspend_always>)   = Convert                       : r100_36
+#  100|     r100_37(glval<unknown>)        = FunctionAddress[await_resume] : 
+#  100|     v100_38(void)                  = Call[await_resume]            : func:r100_37, this:r0_19
+#  100|     m100_39(unknown)               = ^CallSideEffect               : ~m100_34
+#  100|     m100_40(unknown)               = Chi                           : total:m100_34, partial:m100_39
+#-----|     v0_20(void)                    = ^IndirectReadSideEffect[-1]   : &:r0_19, ~m100_40
+#-----|   Goto -> Block 9
+
+#  100|   Block 6
 #  100|     r100_41(suspend_always *)                      = CopyValue                                 : r100_24
 #  100|     r100_42(glval<suspend_always>)                 = CopyValue                                 : r100_41
-#-----|     r0_25(glval<suspend_always>)                   = Convert                                   : r100_42
+#-----|     r0_21(glval<suspend_always>)                   = Convert                                   : r100_42
 #  100|     r100_43(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
 #  100|     r100_44(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp100:3]               : 
 #  100|     m100_45(coroutine_handle<promise_type>)        = Uninitialized[#temp100:3]                 : &:r100_44
@@ -1609,51 +1677,112 @@ coroutines.cpp:
 #  100|     m100_55(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r100_44
 #  100|     m100_56(unknown)                               = Chi                                       : total:m100_53, partial:m100_55
 #  100|     r100_57(coroutine_handle<promise_type>)        = Load[#temp100:3]                          : &:r100_44, ~m100_56
-#  100|     v100_58(void)                                  = Call[await_suspend]                       : func:r100_43, this:r0_25, 0:r100_57
+#  100|     v100_58(void)                                  = Call[await_suspend]                       : func:r100_43, this:r0_21, 0:r100_57
 #  100|     m100_59(unknown)                               = ^CallSideEffect                           : ~m100_56
 #  100|     m100_60(unknown)                               = Chi                                       : total:m100_56, partial:m100_59
-#-----|     v0_26(void)                                    = ^IndirectReadSideEffect[-1]               : &:r0_25, ~m100_60
-#-----|   Goto -> Block 3
-
-#   99|   Block 5
-#   99|     m99_92(unknown)                    = Phi                           : from 3:~m99_90, from 6:~m99_122
-#   99|     r99_93(suspend_always *)           = CopyValue                     : r99_83
-#   99|     r99_94(glval<suspend_always>)      = CopyValue                     : r99_93
-#-----|     r0_27(glval<suspend_always>)       = Convert                       : r99_94
-#   99|     r99_95(glval<unknown>)             = FunctionAddress[await_resume] : 
-#   99|     v99_96(void)                       = Call[await_resume]            : func:r99_95, this:r0_27
-#   99|     m99_97(unknown)                    = ^CallSideEffect               : ~m99_92
-#   99|     m99_98(unknown)                    = Chi                           : total:m99_92, partial:m99_97
-#-----|     v0_28(void)                        = ^IndirectReadSideEffect[-1]   : &:r0_27, ~m99_98
-#   99|     r99_99(glval<co_returnable_value>) = VariableAddress[#return]      : 
-#   99|     v99_100(void)                      = ReturnValue                   : &:r99_99, ~m99_98
-#   99|     v99_101(void)                      = AliasedUse                    : ~m99_98
-#   99|     v99_102(void)                      = ExitFunction                  : 
-
-#   99|   Block 6
-#   99|     r99_103(suspend_always *)                      = CopyValue                                 : r99_83
-#   99|     r99_104(glval<suspend_always>)                 = CopyValue                                 : r99_103
-#-----|     r0_29(glval<suspend_always>)                   = Convert                                   : r99_104
-#   99|     r99_105(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
-#   99|     r99_106(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp99:21]               : 
-#   99|     m99_107(coroutine_handle<promise_type>)        = Uninitialized[#temp99:21]                 : &:r99_106
-#   99|     m99_108(unknown)                               = Chi                                       : total:m99_90, partial:m99_107
-#   99|     r99_109(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
-#   99|     r99_110(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
-#   99|     r99_111(glval<coroutine_handle<promise_type>>) = Convert                                   : r99_110
-#   99|     r99_112(coroutine_handle<promise_type> &)      = CopyValue                                 : r99_111
-#   99|     v99_113(void)                                  = Call[coroutine_handle]                    : func:r99_109, this:r99_106, 0:r99_112
-#   99|     m99_114(unknown)                               = ^CallSideEffect                           : ~m99_108
-#   99|     m99_115(unknown)                               = Chi                                       : total:m99_108, partial:m99_114
-#   99|     v99_116(void)                                  = ^BufferReadSideEffect[0]                  : &:r99_112, ~m99_115
-#   99|     m99_117(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r99_106
-#   99|     m99_118(unknown)                               = Chi                                       : total:m99_115, partial:m99_117
-#   99|     r99_119(coroutine_handle<promise_type>)        = Load[#temp99:21]                          : &:r99_106, ~m99_118
-#   99|     v99_120(void)                                  = Call[await_suspend]                       : func:r99_105, this:r0_29, 0:r99_119
-#   99|     m99_121(unknown)                               = ^CallSideEffect                           : ~m99_118
-#   99|     m99_122(unknown)                               = Chi                                       : total:m99_118, partial:m99_121
-#-----|     v0_30(void)                                    = ^IndirectReadSideEffect[-1]               : &:r0_29, ~m99_122
+#-----|     v0_22(void)                                    = ^IndirectReadSideEffect[-1]               : &:r0_21, ~m100_60
 #-----|   Goto -> Block 5
+
+#-----|   Block 7
+#-----|     m0_23(unknown)     = Phi                                       : from 1:~m100_10, from 3:~m100_21
+#-----|     v0_24(void)        = CatchAny                                  : 
+#-----|     r0_25(glval<bool>) = VariableAddress[(unnamed local variable)] : 
+#-----|     r0_26(bool)        = Load[(unnamed local variable)]            : &:r0_25, m0_11
+#-----|     r0_27(bool)        = LogicalNot                                : r0_26
+#-----|     v0_28(void)        = ConditionalBranch                         : r0_27
+#-----|   False -> Block 8
+#-----|   True -> Block 12
+
+#   99|   Block 8
+#   99|     r99_64(glval<promise_type>) = VariableAddress[(unnamed local variable)] : 
+#   99|     r99_65(glval<unknown>)      = FunctionAddress[unhandled_exception]      : 
+#   99|     v99_66(void)                = Call[unhandled_exception]                 : func:r99_65, this:r99_64
+#   99|     m99_67(unknown)             = ^CallSideEffect                           : ~m0_23
+#   99|     m99_68(unknown)             = Chi                                       : total:m0_23, partial:m99_67
+#   99|     v99_69(void)                = ^IndirectReadSideEffect[-1]               : &:r99_64, ~m99_68
+#   99|     m99_70(promise_type)        = ^IndirectMayWriteSideEffect[-1]           : &:r99_64
+#   99|     m99_71(unknown)             = Chi                                       : total:m99_68, partial:m99_70
+#-----|   Goto -> Block 9
+
+#-----|   Block 9
+#-----|     m0_29(unknown)                 = Phi                                       : from 5:~m100_40, from 8:~m99_71
+#-----|     v0_30(void)                    = NoOp                                      : 
+#   99|     r99_72(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
+#   99|     r99_73(glval<unknown>)         = FunctionAddress[final_suspend]            : 
+#   99|     r99_74(suspend_always)         = Call[final_suspend]                       : func:r99_73, this:r99_72
+#   99|     m99_75(unknown)                = ^CallSideEffect                           : ~m0_29
+#   99|     m99_76(unknown)                = Chi                                       : total:m0_29, partial:m99_75
+#   99|     v99_77(void)                   = ^IndirectReadSideEffect[-1]               : &:r99_72, ~m99_76
+#   99|     m99_78(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r99_72
+#   99|     m99_79(unknown)                = Chi                                       : total:m99_76, partial:m99_78
+#-----|     r0_31(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
+#   99|     r99_80(glval<suspend_always>)  = VariableAddress[#temp99:21]               : 
+#   99|     r99_81(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
+#   99|     r99_82(glval<unknown>)         = FunctionAddress[final_suspend]            : 
+#   99|     r99_83(suspend_always)         = Call[final_suspend]                       : func:r99_82, this:r99_81
+#   99|     m99_84(unknown)                = ^CallSideEffect                           : ~m99_79
+#   99|     m99_85(unknown)                = Chi                                       : total:m99_79, partial:m99_84
+#   99|     v99_86(void)                   = ^IndirectReadSideEffect[-1]               : &:r99_81, ~m99_85
+#   99|     m99_87(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r99_81
+#   99|     m99_88(unknown)                = Chi                                       : total:m99_85, partial:m99_87
+#   99|     m99_89(suspend_always)         = Store[#temp99:21]                         : &:r99_80, r99_83
+#   99|     m99_90(unknown)                = Chi                                       : total:m99_88, partial:m99_89
+#   99|     r99_91(suspend_always *)       = CopyValue                                 : r99_80
+#   99|     m99_92(suspend_always *)       = Store[#temp0:0]                           : &:r0_31, r99_91
+#-----|     r0_32(suspend_always *)        = Load[#temp0:0]                            : &:r0_31, m99_92
+#   99|     r99_93(glval<suspend_always>)  = CopyValue                                 : r0_32
+#   99|     r99_94(glval<suspend_always>)  = Convert                                   : r99_93
+#   99|     r99_95(glval<unknown>)         = FunctionAddress[await_ready]              : 
+#   99|     r99_96(bool)                   = Call[await_ready]                         : func:r99_95, this:r99_94
+#   99|     m99_97(unknown)                = ^CallSideEffect                           : ~m99_90
+#   99|     m99_98(unknown)                = Chi                                       : total:m99_90, partial:m99_97
+#   99|     v99_99(void)                   = ^IndirectReadSideEffect[-1]               : &:r99_94, ~m99_98
+#-----|     v0_33(void)                    = ConditionalBranch                         : r99_96
+#-----|   False -> Block 11
+#-----|   True -> Block 10
+
+#   99|   Block 10
+#   99|     m99_100(unknown)                    = Phi                           : from 9:~m99_98, from 11:~m99_130
+#   99|     r99_101(suspend_always *)           = CopyValue                     : r99_91
+#   99|     r99_102(glval<suspend_always>)      = CopyValue                     : r99_101
+#-----|     r0_34(glval<suspend_always>)        = Convert                       : r99_102
+#   99|     r99_103(glval<unknown>)             = FunctionAddress[await_resume] : 
+#   99|     v99_104(void)                       = Call[await_resume]            : func:r99_103, this:r0_34
+#   99|     m99_105(unknown)                    = ^CallSideEffect               : ~m99_100
+#   99|     m99_106(unknown)                    = Chi                           : total:m99_100, partial:m99_105
+#-----|     v0_35(void)                         = ^IndirectReadSideEffect[-1]   : &:r0_34, ~m99_106
+#   99|     r99_107(glval<co_returnable_value>) = VariableAddress[#return]      : 
+#   99|     v99_108(void)                       = ReturnValue                   : &:r99_107, ~m99_106
+#   99|     v99_109(void)                       = AliasedUse                    : ~m99_106
+#   99|     v99_110(void)                       = ExitFunction                  : 
+
+#   99|   Block 11
+#   99|     r99_111(suspend_always *)                      = CopyValue                                 : r99_91
+#   99|     r99_112(glval<suspend_always>)                 = CopyValue                                 : r99_111
+#-----|     r0_36(glval<suspend_always>)                   = Convert                                   : r99_112
+#   99|     r99_113(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
+#   99|     r99_114(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp99:21]               : 
+#   99|     m99_115(coroutine_handle<promise_type>)        = Uninitialized[#temp99:21]                 : &:r99_114
+#   99|     m99_116(unknown)                               = Chi                                       : total:m99_98, partial:m99_115
+#   99|     r99_117(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
+#   99|     r99_118(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
+#   99|     r99_119(glval<coroutine_handle<promise_type>>) = Convert                                   : r99_118
+#   99|     r99_120(coroutine_handle<promise_type> &)      = CopyValue                                 : r99_119
+#   99|     v99_121(void)                                  = Call[coroutine_handle]                    : func:r99_117, this:r99_114, 0:r99_120
+#   99|     m99_122(unknown)                               = ^CallSideEffect                           : ~m99_116
+#   99|     m99_123(unknown)                               = Chi                                       : total:m99_116, partial:m99_122
+#   99|     v99_124(void)                                  = ^BufferReadSideEffect[0]                  : &:r99_120, ~m99_123
+#   99|     m99_125(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r99_114
+#   99|     m99_126(unknown)                               = Chi                                       : total:m99_123, partial:m99_125
+#   99|     r99_127(coroutine_handle<promise_type>)        = Load[#temp99:21]                          : &:r99_114, ~m99_126
+#   99|     v99_128(void)                                  = Call[await_suspend]                       : func:r99_113, this:r0_36, 0:r99_127
+#   99|     m99_129(unknown)                               = ^CallSideEffect                           : ~m99_126
+#   99|     m99_130(unknown)                               = Chi                                       : total:m99_126, partial:m99_129
+#-----|     v0_37(void)                                    = ^IndirectReadSideEffect[-1]               : &:r0_36, ~m99_130
+#-----|   Goto -> Block 10
+
+#   99|   Block 12
+#   99|     v99_131(void) = Unreached : 
 
 #  103| co_returnable_void co_yield_and_return_void(int)
 #  103|   Block 0
@@ -1728,38 +1857,13 @@ coroutines.cpp:
 #  104|     v104_8(void)                   = ^IndirectReadSideEffect[-1]               : &:r104_1, ~m104_7
 #  104|     m104_9(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r104_1
 #  104|     m104_10(unknown)               = Chi                                       : total:m104_7, partial:m104_9
-#-----|     r0_15(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
-#  104|     r104_11(glval<suspend_always>) = VariableAddress[#temp104:13]              : 
-#  104|     r104_12(glval<promise_type>)   = VariableAddress[(unnamed local variable)] : 
-#  104|     r104_13(glval<unknown>)        = FunctionAddress[yield_value]              : 
-#  104|     r104_14(glval<int>)            = VariableAddress[i]                        : 
-#  104|     r104_15(int)                   = Load[i]                                   : &:r104_14, m0_4
-#  104|     r104_16(suspend_always)        = Call[yield_value]                         : func:r104_13, this:r104_12, 0:r104_15
-#  104|     m104_17(unknown)               = ^CallSideEffect                           : ~m104_10
-#  104|     m104_18(unknown)               = Chi                                       : total:m104_10, partial:m104_17
-#  104|     v104_19(void)                  = ^IndirectReadSideEffect[-1]               : &:r104_12, ~m104_18
-#  104|     m104_20(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r104_12
-#  104|     m104_21(unknown)               = Chi                                       : total:m104_18, partial:m104_20
-#  104|     m104_22(suspend_always)        = Store[#temp104:13]                        : &:r104_11, r104_16
-#  104|     m104_23(unknown)               = Chi                                       : total:m104_21, partial:m104_22
-#  104|     r104_24(suspend_always *)      = CopyValue                                 : r104_11
-#  104|     m104_25(suspend_always *)      = Store[#temp0:0]                           : &:r0_15, r104_24
-#-----|     r0_16(suspend_always *)        = Load[#temp0:0]                            : &:r0_15, m104_25
-#  104|     r104_26(glval<suspend_always>) = CopyValue                                 : r0_16
-#  104|     r104_27(glval<suspend_always>) = Convert                                   : r104_26
-#  104|     r104_28(glval<unknown>)        = FunctionAddress[await_ready]              : 
-#  104|     r104_29(bool)                  = Call[await_ready]                         : func:r104_28, this:r104_27
-#  104|     m104_30(unknown)               = ^CallSideEffect                           : ~m104_23
-#  104|     m104_31(unknown)               = Chi                                       : total:m104_23, partial:m104_30
-#  104|     v104_32(void)                  = ^IndirectReadSideEffect[-1]               : &:r104_27, ~m104_31
-#  104|     v104_33(void)                  = ConditionalBranch                         : r104_29
-#-----|   False -> Block 4
-#-----|   True -> Block 3
+#-----|   C++ Exception -> Block 8
+#-----|   Goto -> Block 3
 
 #  103|   Block 2
 #  103|     r103_44(suspend_always *)                      = CopyValue                                 : r103_29
 #  103|     r103_45(glval<suspend_always>)                 = CopyValue                                 : r103_44
-#-----|     r0_17(glval<suspend_always>)                   = Convert                                   : r103_45
+#-----|     r0_15(glval<suspend_always>)                   = Convert                                   : r103_45
 #  103|     r103_46(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
 #  103|     r103_47(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp103:20]              : 
 #  103|     m103_48(coroutine_handle<promise_type>)        = Uninitialized[#temp103:20]                : &:r103_47
@@ -1775,14 +1879,47 @@ coroutines.cpp:
 #  103|     m103_58(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r103_47
 #  103|     m103_59(unknown)                               = Chi                                       : total:m103_56, partial:m103_58
 #  103|     r103_60(coroutine_handle<promise_type>)        = Load[#temp103:20]                         : &:r103_47, ~m103_59
-#  103|     v103_61(void)                                  = Call[await_suspend]                       : func:r103_46, this:r0_17, 0:r103_60
+#  103|     v103_61(void)                                  = Call[await_suspend]                       : func:r103_46, this:r0_15, 0:r103_60
 #  103|     m103_62(unknown)                               = ^CallSideEffect                           : ~m103_59
 #  103|     m103_63(unknown)                               = Chi                                       : total:m103_59, partial:m103_62
-#-----|     v0_18(void)                                    = ^IndirectReadSideEffect[-1]               : &:r0_17, ~m103_63
+#-----|     v0_16(void)                                    = ^IndirectReadSideEffect[-1]               : &:r0_15, ~m103_63
 #-----|   Goto -> Block 1
 
-#  104|   Block 3
-#  104|     m104_34(unknown)               = Phi                                       : from 1:~m104_31, from 4:~m104_60
+#-----|   Block 3
+#-----|     r0_17(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
+#  104|     r104_11(glval<suspend_always>) = VariableAddress[#temp104:13]              : 
+#  104|     r104_12(glval<promise_type>)   = VariableAddress[(unnamed local variable)] : 
+#  104|     r104_13(glval<unknown>)        = FunctionAddress[yield_value]              : 
+#  104|     r104_14(glval<int>)            = VariableAddress[i]                        : 
+#  104|     r104_15(int)                   = Load[i]                                   : &:r104_14, m0_4
+#  104|     r104_16(suspend_always)        = Call[yield_value]                         : func:r104_13, this:r104_12, 0:r104_15
+#  104|     m104_17(unknown)               = ^CallSideEffect                           : ~m104_10
+#  104|     m104_18(unknown)               = Chi                                       : total:m104_10, partial:m104_17
+#  104|     v104_19(void)                  = ^IndirectReadSideEffect[-1]               : &:r104_12, ~m104_18
+#  104|     m104_20(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r104_12
+#  104|     m104_21(unknown)               = Chi                                       : total:m104_18, partial:m104_20
+#-----|   C++ Exception -> Block 8
+#-----|   Goto -> Block 4
+
+#  104|   Block 4
+#  104|     m104_22(suspend_always)        = Store[#temp104:13]           : &:r104_11, r104_16
+#  104|     m104_23(unknown)               = Chi                          : total:m104_21, partial:m104_22
+#  104|     r104_24(suspend_always *)      = CopyValue                    : r104_11
+#  104|     m104_25(suspend_always *)      = Store[#temp0:0]              : &:r0_17, r104_24
+#-----|     r0_18(suspend_always *)        = Load[#temp0:0]               : &:r0_17, m104_25
+#  104|     r104_26(glval<suspend_always>) = CopyValue                    : r0_18
+#  104|     r104_27(glval<suspend_always>) = Convert                      : r104_26
+#  104|     r104_28(glval<unknown>)        = FunctionAddress[await_ready] : 
+#  104|     r104_29(bool)                  = Call[await_ready]            : func:r104_28, this:r104_27
+#  104|     m104_30(unknown)               = ^CallSideEffect              : ~m104_23
+#  104|     m104_31(unknown)               = Chi                          : total:m104_23, partial:m104_30
+#  104|     v104_32(void)                  = ^IndirectReadSideEffect[-1]  : &:r104_27, ~m104_31
+#  104|     v104_33(void)                  = ConditionalBranch            : r104_29
+#-----|   False -> Block 6
+#-----|   True -> Block 5
+
+#  104|   Block 5
+#  104|     m104_34(unknown)               = Phi                                       : from 4:~m104_31, from 6:~m104_60
 #  104|     r104_35(suspend_always *)      = CopyValue                                 : r104_24
 #  104|     r104_36(glval<suspend_always>) = CopyValue                                 : r104_35
 #-----|     r0_19(glval<suspend_always>)   = Convert                                   : r104_36
@@ -1799,14 +1936,13 @@ coroutines.cpp:
 #-----|     v0_26(void)                    = ^IndirectReadSideEffect[-1]               : &:r0_21, ~m0_25
 #-----|     m0_27(promise_type)            = ^IndirectMayWriteSideEffect[-1]           : &:r0_21
 #-----|     m0_28(unknown)                 = Chi                                       : total:m0_25, partial:m0_27
-#  105|     v105_1(void)                   = NoOp                                      : 
-#-----|     v0_29(void)                    = NoOp                                      : 
-#-----|   Goto (back edge) -> Block 5
+#-----|   C++ Exception -> Block 8
+#-----|   Goto -> Block 7
 
-#  104|   Block 4
+#  104|   Block 6
 #  104|     r104_41(suspend_always *)                      = CopyValue                                 : r104_24
 #  104|     r104_42(glval<suspend_always>)                 = CopyValue                                 : r104_41
-#-----|     r0_30(glval<suspend_always>)                   = Convert                                   : r104_42
+#-----|     r0_29(glval<suspend_always>)                   = Convert                                   : r104_42
 #  104|     r104_43(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
 #  104|     r104_44(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp104:3]               : 
 #  104|     m104_45(coroutine_handle<promise_type>)        = Uninitialized[#temp104:3]                 : &:r104_44
@@ -1822,87 +1958,117 @@ coroutines.cpp:
 #  104|     m104_55(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r104_44
 #  104|     m104_56(unknown)                               = Chi                                       : total:m104_53, partial:m104_55
 #  104|     r104_57(coroutine_handle<promise_type>)        = Load[#temp104:3]                          : &:r104_44, ~m104_56
-#  104|     v104_58(void)                                  = Call[await_suspend]                       : func:r104_43, this:r0_30, 0:r104_57
+#  104|     v104_58(void)                                  = Call[await_suspend]                       : func:r104_43, this:r0_29, 0:r104_57
 #  104|     m104_59(unknown)                               = ^CallSideEffect                           : ~m104_56
 #  104|     m104_60(unknown)                               = Chi                                       : total:m104_56, partial:m104_59
-#-----|     v0_31(void)                                    = ^IndirectReadSideEffect[-1]               : &:r0_30, ~m104_60
-#-----|   Goto -> Block 3
+#-----|     v0_30(void)                                    = ^IndirectReadSideEffect[-1]               : &:r0_29, ~m104_60
+#-----|   Goto -> Block 5
 
-#-----|   Block 5
-#-----|     v0_32(void)                    = NoOp                                      : 
-#  103|     r103_64(glval<promise_type>)   = VariableAddress[(unnamed local variable)] : 
-#  103|     r103_65(glval<unknown>)        = FunctionAddress[final_suspend]            : 
-#  103|     r103_66(suspend_always)        = Call[final_suspend]                       : func:r103_65, this:r103_64
-#  103|     m103_67(unknown)               = ^CallSideEffect                           : ~m0_28
-#  103|     m103_68(unknown)               = Chi                                       : total:m0_28, partial:m103_67
-#  103|     v103_69(void)                  = ^IndirectReadSideEffect[-1]               : &:r103_64, ~m103_68
-#  103|     m103_70(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r103_64
-#  103|     m103_71(unknown)               = Chi                                       : total:m103_68, partial:m103_70
-#-----|     r0_33(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
-#  103|     r103_72(glval<suspend_always>) = VariableAddress[#temp103:20]              : 
-#  103|     r103_73(glval<promise_type>)   = VariableAddress[(unnamed local variable)] : 
-#  103|     r103_74(glval<unknown>)        = FunctionAddress[final_suspend]            : 
-#  103|     r103_75(suspend_always)        = Call[final_suspend]                       : func:r103_74, this:r103_73
-#  103|     m103_76(unknown)               = ^CallSideEffect                           : ~m103_71
-#  103|     m103_77(unknown)               = Chi                                       : total:m103_71, partial:m103_76
-#  103|     v103_78(void)                  = ^IndirectReadSideEffect[-1]               : &:r103_73, ~m103_77
-#  103|     m103_79(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r103_73
-#  103|     m103_80(unknown)               = Chi                                       : total:m103_77, partial:m103_79
-#  103|     m103_81(suspend_always)        = Store[#temp103:20]                        : &:r103_72, r103_75
-#  103|     m103_82(unknown)               = Chi                                       : total:m103_80, partial:m103_81
-#  103|     r103_83(suspend_always *)      = CopyValue                                 : r103_72
-#  103|     m103_84(suspend_always *)      = Store[#temp0:0]                           : &:r0_33, r103_83
-#-----|     r0_34(suspend_always *)        = Load[#temp0:0]                            : &:r0_33, m103_84
-#  103|     r103_85(glval<suspend_always>) = CopyValue                                 : r0_34
-#  103|     r103_86(glval<suspend_always>) = Convert                                   : r103_85
-#  103|     r103_87(glval<unknown>)        = FunctionAddress[await_ready]              : 
-#  103|     r103_88(bool)                  = Call[await_ready]                         : func:r103_87, this:r103_86
-#  103|     m103_89(unknown)               = ^CallSideEffect                           : ~m103_82
-#  103|     m103_90(unknown)               = Chi                                       : total:m103_82, partial:m103_89
-#  103|     v103_91(void)                  = ^IndirectReadSideEffect[-1]               : &:r103_86, ~m103_90
-#-----|     v0_35(void)                    = ConditionalBranch                         : r103_88
-#-----|   False -> Block 7
-#-----|   True -> Block 6
+#  105|   Block 7
+#  105|     v105_1(void) = NoOp : 
+#-----|     v0_31(void)  = NoOp : 
+#-----|   Goto (back edge) -> Block 10
 
-#  103|   Block 6
-#  103|     m103_92(unknown)                   = Phi                           : from 5:~m103_90, from 7:~m103_122
-#  103|     r103_93(suspend_always *)          = CopyValue                     : r103_83
-#  103|     r103_94(glval<suspend_always>)     = CopyValue                     : r103_93
-#-----|     r0_36(glval<suspend_always>)       = Convert                       : r103_94
-#  103|     r103_95(glval<unknown>)            = FunctionAddress[await_resume] : 
-#  103|     v103_96(void)                      = Call[await_resume]            : func:r103_95, this:r0_36
-#  103|     m103_97(unknown)                   = ^CallSideEffect               : ~m103_92
-#  103|     m103_98(unknown)                   = Chi                           : total:m103_92, partial:m103_97
-#-----|     v0_37(void)                        = ^IndirectReadSideEffect[-1]   : &:r0_36, ~m103_98
-#  103|     r103_99(glval<co_returnable_void>) = VariableAddress[#return]      : 
-#  103|     v103_100(void)                     = ReturnValue                   : &:r103_99, ~m103_98
-#  103|     v103_101(void)                     = AliasedUse                    : ~m103_98
-#  103|     v103_102(void)                     = ExitFunction                  : 
+#-----|   Block 8
+#-----|     m0_32(unknown)     = Phi                                       : from 1:~m104_10, from 3:~m104_21, from 5:~m0_28
+#-----|     v0_33(void)        = CatchAny                                  : 
+#-----|     r0_34(glval<bool>) = VariableAddress[(unnamed local variable)] : 
+#-----|     r0_35(bool)        = Load[(unnamed local variable)]            : &:r0_34, m0_11
+#-----|     r0_36(bool)        = LogicalNot                                : r0_35
+#-----|     v0_37(void)        = ConditionalBranch                         : r0_36
+#-----|   False -> Block 9
+#-----|   True -> Block 13
 
-#  103|   Block 7
-#  103|     r103_103(suspend_always *)                      = CopyValue                                 : r103_83
-#  103|     r103_104(glval<suspend_always>)                 = CopyValue                                 : r103_103
-#-----|     r0_38(glval<suspend_always>)                    = Convert                                   : r103_104
-#  103|     r103_105(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
-#  103|     r103_106(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp103:20]              : 
-#  103|     m103_107(coroutine_handle<promise_type>)        = Uninitialized[#temp103:20]                : &:r103_106
-#  103|     m103_108(unknown)                               = Chi                                       : total:m103_90, partial:m103_107
-#  103|     r103_109(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
-#  103|     r103_110(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
-#  103|     r103_111(glval<coroutine_handle<promise_type>>) = Convert                                   : r103_110
-#  103|     r103_112(coroutine_handle<promise_type> &)      = CopyValue                                 : r103_111
-#  103|     v103_113(void)                                  = Call[coroutine_handle]                    : func:r103_109, this:r103_106, 0:r103_112
-#  103|     m103_114(unknown)                               = ^CallSideEffect                           : ~m103_108
-#  103|     m103_115(unknown)                               = Chi                                       : total:m103_108, partial:m103_114
-#  103|     v103_116(void)                                  = ^BufferReadSideEffect[0]                  : &:r103_112, ~m103_115
-#  103|     m103_117(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r103_106
-#  103|     m103_118(unknown)                               = Chi                                       : total:m103_115, partial:m103_117
-#  103|     r103_119(coroutine_handle<promise_type>)        = Load[#temp103:20]                         : &:r103_106, ~m103_118
-#  103|     v103_120(void)                                  = Call[await_suspend]                       : func:r103_105, this:r0_38, 0:r103_119
-#  103|     m103_121(unknown)                               = ^CallSideEffect                           : ~m103_118
-#  103|     m103_122(unknown)                               = Chi                                       : total:m103_118, partial:m103_121
-#-----|     v0_39(void)                                     = ^IndirectReadSideEffect[-1]               : &:r0_38, ~m103_122
-#-----|   Goto -> Block 6
+#  103|   Block 9
+#  103|     r103_64(glval<promise_type>) = VariableAddress[(unnamed local variable)] : 
+#  103|     r103_65(glval<unknown>)      = FunctionAddress[unhandled_exception]      : 
+#  103|     v103_66(void)                = Call[unhandled_exception]                 : func:r103_65, this:r103_64
+#  103|     m103_67(unknown)             = ^CallSideEffect                           : ~m0_32
+#  103|     m103_68(unknown)             = Chi                                       : total:m0_32, partial:m103_67
+#  103|     v103_69(void)                = ^IndirectReadSideEffect[-1]               : &:r103_64, ~m103_68
+#  103|     m103_70(promise_type)        = ^IndirectMayWriteSideEffect[-1]           : &:r103_64
+#  103|     m103_71(unknown)             = Chi                                       : total:m103_68, partial:m103_70
+#-----|   Goto -> Block 10
+
+#-----|   Block 10
+#-----|     m0_38(unknown)                 = Phi                                       : from 7:~m0_28, from 9:~m103_71
+#-----|     v0_39(void)                    = NoOp                                      : 
+#  103|     r103_72(glval<promise_type>)   = VariableAddress[(unnamed local variable)] : 
+#  103|     r103_73(glval<unknown>)        = FunctionAddress[final_suspend]            : 
+#  103|     r103_74(suspend_always)        = Call[final_suspend]                       : func:r103_73, this:r103_72
+#  103|     m103_75(unknown)               = ^CallSideEffect                           : ~m0_38
+#  103|     m103_76(unknown)               = Chi                                       : total:m0_38, partial:m103_75
+#  103|     v103_77(void)                  = ^IndirectReadSideEffect[-1]               : &:r103_72, ~m103_76
+#  103|     m103_78(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r103_72
+#  103|     m103_79(unknown)               = Chi                                       : total:m103_76, partial:m103_78
+#-----|     r0_40(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
+#  103|     r103_80(glval<suspend_always>) = VariableAddress[#temp103:20]              : 
+#  103|     r103_81(glval<promise_type>)   = VariableAddress[(unnamed local variable)] : 
+#  103|     r103_82(glval<unknown>)        = FunctionAddress[final_suspend]            : 
+#  103|     r103_83(suspend_always)        = Call[final_suspend]                       : func:r103_82, this:r103_81
+#  103|     m103_84(unknown)               = ^CallSideEffect                           : ~m103_79
+#  103|     m103_85(unknown)               = Chi                                       : total:m103_79, partial:m103_84
+#  103|     v103_86(void)                  = ^IndirectReadSideEffect[-1]               : &:r103_81, ~m103_85
+#  103|     m103_87(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r103_81
+#  103|     m103_88(unknown)               = Chi                                       : total:m103_85, partial:m103_87
+#  103|     m103_89(suspend_always)        = Store[#temp103:20]                        : &:r103_80, r103_83
+#  103|     m103_90(unknown)               = Chi                                       : total:m103_88, partial:m103_89
+#  103|     r103_91(suspend_always *)      = CopyValue                                 : r103_80
+#  103|     m103_92(suspend_always *)      = Store[#temp0:0]                           : &:r0_40, r103_91
+#-----|     r0_41(suspend_always *)        = Load[#temp0:0]                            : &:r0_40, m103_92
+#  103|     r103_93(glval<suspend_always>) = CopyValue                                 : r0_41
+#  103|     r103_94(glval<suspend_always>) = Convert                                   : r103_93
+#  103|     r103_95(glval<unknown>)        = FunctionAddress[await_ready]              : 
+#  103|     r103_96(bool)                  = Call[await_ready]                         : func:r103_95, this:r103_94
+#  103|     m103_97(unknown)               = ^CallSideEffect                           : ~m103_90
+#  103|     m103_98(unknown)               = Chi                                       : total:m103_90, partial:m103_97
+#  103|     v103_99(void)                  = ^IndirectReadSideEffect[-1]               : &:r103_94, ~m103_98
+#-----|     v0_42(void)                    = ConditionalBranch                         : r103_96
+#-----|   False -> Block 12
+#-----|   True -> Block 11
+
+#  103|   Block 11
+#  103|     m103_100(unknown)                   = Phi                           : from 10:~m103_98, from 12:~m103_130
+#  103|     r103_101(suspend_always *)          = CopyValue                     : r103_91
+#  103|     r103_102(glval<suspend_always>)     = CopyValue                     : r103_101
+#-----|     r0_43(glval<suspend_always>)        = Convert                       : r103_102
+#  103|     r103_103(glval<unknown>)            = FunctionAddress[await_resume] : 
+#  103|     v103_104(void)                      = Call[await_resume]            : func:r103_103, this:r0_43
+#  103|     m103_105(unknown)                   = ^CallSideEffect               : ~m103_100
+#  103|     m103_106(unknown)                   = Chi                           : total:m103_100, partial:m103_105
+#-----|     v0_44(void)                         = ^IndirectReadSideEffect[-1]   : &:r0_43, ~m103_106
+#  103|     r103_107(glval<co_returnable_void>) = VariableAddress[#return]      : 
+#  103|     v103_108(void)                      = ReturnValue                   : &:r103_107, ~m103_106
+#  103|     v103_109(void)                      = AliasedUse                    : ~m103_106
+#  103|     v103_110(void)                      = ExitFunction                  : 
+
+#  103|   Block 12
+#  103|     r103_111(suspend_always *)                      = CopyValue                                 : r103_91
+#  103|     r103_112(glval<suspend_always>)                 = CopyValue                                 : r103_111
+#-----|     r0_45(glval<suspend_always>)                    = Convert                                   : r103_112
+#  103|     r103_113(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
+#  103|     r103_114(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp103:20]              : 
+#  103|     m103_115(coroutine_handle<promise_type>)        = Uninitialized[#temp103:20]                : &:r103_114
+#  103|     m103_116(unknown)                               = Chi                                       : total:m103_98, partial:m103_115
+#  103|     r103_117(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
+#  103|     r103_118(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
+#  103|     r103_119(glval<coroutine_handle<promise_type>>) = Convert                                   : r103_118
+#  103|     r103_120(coroutine_handle<promise_type> &)      = CopyValue                                 : r103_119
+#  103|     v103_121(void)                                  = Call[coroutine_handle]                    : func:r103_117, this:r103_114, 0:r103_120
+#  103|     m103_122(unknown)                               = ^CallSideEffect                           : ~m103_116
+#  103|     m103_123(unknown)                               = Chi                                       : total:m103_116, partial:m103_122
+#  103|     v103_124(void)                                  = ^BufferReadSideEffect[0]                  : &:r103_120, ~m103_123
+#  103|     m103_125(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r103_114
+#  103|     m103_126(unknown)                               = Chi                                       : total:m103_123, partial:m103_125
+#  103|     r103_127(coroutine_handle<promise_type>)        = Load[#temp103:20]                         : &:r103_114, ~m103_126
+#  103|     v103_128(void)                                  = Call[await_suspend]                       : func:r103_113, this:r0_45, 0:r103_127
+#  103|     m103_129(unknown)                               = ^CallSideEffect                           : ~m103_126
+#  103|     m103_130(unknown)                               = Chi                                       : total:m103_126, partial:m103_129
+#-----|     v0_46(void)                                     = ^IndirectReadSideEffect[-1]               : &:r0_45, ~m103_130
+#-----|   Goto -> Block 11
+
+#  103|   Block 13
+#  103|     v103_131(void) = Unreached : 
 
 #  108| co_returnable_value co_yield_and_return_value(int)
 #  108|   Block 0
@@ -1977,38 +2143,13 @@ coroutines.cpp:
 #  109|     v109_8(void)                   = ^IndirectReadSideEffect[-1]               : &:r109_1, ~m109_7
 #  109|     m109_9(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r109_1
 #  109|     m109_10(unknown)               = Chi                                       : total:m109_7, partial:m109_9
-#-----|     r0_15(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
-#  109|     r109_11(glval<suspend_always>) = VariableAddress[#temp109:13]              : 
-#  109|     r109_12(glval<promise_type>)   = VariableAddress[(unnamed local variable)] : 
-#  109|     r109_13(glval<unknown>)        = FunctionAddress[yield_value]              : 
-#  109|     r109_14(glval<int>)            = VariableAddress[i]                        : 
-#  109|     r109_15(int)                   = Load[i]                                   : &:r109_14, m0_4
-#  109|     r109_16(suspend_always)        = Call[yield_value]                         : func:r109_13, this:r109_12, 0:r109_15
-#  109|     m109_17(unknown)               = ^CallSideEffect                           : ~m109_10
-#  109|     m109_18(unknown)               = Chi                                       : total:m109_10, partial:m109_17
-#  109|     v109_19(void)                  = ^IndirectReadSideEffect[-1]               : &:r109_12, ~m109_18
-#  109|     m109_20(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r109_12
-#  109|     m109_21(unknown)               = Chi                                       : total:m109_18, partial:m109_20
-#  109|     m109_22(suspend_always)        = Store[#temp109:13]                        : &:r109_11, r109_16
-#  109|     m109_23(unknown)               = Chi                                       : total:m109_21, partial:m109_22
-#  109|     r109_24(suspend_always *)      = CopyValue                                 : r109_11
-#  109|     m109_25(suspend_always *)      = Store[#temp0:0]                           : &:r0_15, r109_24
-#-----|     r0_16(suspend_always *)        = Load[#temp0:0]                            : &:r0_15, m109_25
-#  109|     r109_26(glval<suspend_always>) = CopyValue                                 : r0_16
-#  109|     r109_27(glval<suspend_always>) = Convert                                   : r109_26
-#  109|     r109_28(glval<unknown>)        = FunctionAddress[await_ready]              : 
-#  109|     r109_29(bool)                  = Call[await_ready]                         : func:r109_28, this:r109_27
-#  109|     m109_30(unknown)               = ^CallSideEffect                           : ~m109_23
-#  109|     m109_31(unknown)               = Chi                                       : total:m109_23, partial:m109_30
-#  109|     v109_32(void)                  = ^IndirectReadSideEffect[-1]               : &:r109_27, ~m109_31
-#  109|     v109_33(void)                  = ConditionalBranch                         : r109_29
-#-----|   False -> Block 4
-#-----|   True -> Block 3
+#-----|   C++ Exception -> Block 8
+#-----|   Goto -> Block 3
 
 #  108|   Block 2
 #  108|     r108_44(suspend_always *)                      = CopyValue                                 : r108_29
 #  108|     r108_45(glval<suspend_always>)                 = CopyValue                                 : r108_44
-#-----|     r0_17(glval<suspend_always>)                   = Convert                                   : r108_45
+#-----|     r0_15(glval<suspend_always>)                   = Convert                                   : r108_45
 #  108|     r108_46(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
 #  108|     r108_47(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp108:21]              : 
 #  108|     m108_48(coroutine_handle<promise_type>)        = Uninitialized[#temp108:21]                : &:r108_47
@@ -2024,14 +2165,47 @@ coroutines.cpp:
 #  108|     m108_58(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r108_47
 #  108|     m108_59(unknown)                               = Chi                                       : total:m108_56, partial:m108_58
 #  108|     r108_60(coroutine_handle<promise_type>)        = Load[#temp108:21]                         : &:r108_47, ~m108_59
-#  108|     v108_61(void)                                  = Call[await_suspend]                       : func:r108_46, this:r0_17, 0:r108_60
+#  108|     v108_61(void)                                  = Call[await_suspend]                       : func:r108_46, this:r0_15, 0:r108_60
 #  108|     m108_62(unknown)                               = ^CallSideEffect                           : ~m108_59
 #  108|     m108_63(unknown)                               = Chi                                       : total:m108_59, partial:m108_62
-#-----|     v0_18(void)                                    = ^IndirectReadSideEffect[-1]               : &:r0_17, ~m108_63
+#-----|     v0_16(void)                                    = ^IndirectReadSideEffect[-1]               : &:r0_15, ~m108_63
 #-----|   Goto -> Block 1
 
-#  109|   Block 3
-#  109|     m109_34(unknown)               = Phi                                       : from 1:~m109_31, from 4:~m109_60
+#-----|   Block 3
+#-----|     r0_17(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
+#  109|     r109_11(glval<suspend_always>) = VariableAddress[#temp109:13]              : 
+#  109|     r109_12(glval<promise_type>)   = VariableAddress[(unnamed local variable)] : 
+#  109|     r109_13(glval<unknown>)        = FunctionAddress[yield_value]              : 
+#  109|     r109_14(glval<int>)            = VariableAddress[i]                        : 
+#  109|     r109_15(int)                   = Load[i]                                   : &:r109_14, m0_4
+#  109|     r109_16(suspend_always)        = Call[yield_value]                         : func:r109_13, this:r109_12, 0:r109_15
+#  109|     m109_17(unknown)               = ^CallSideEffect                           : ~m109_10
+#  109|     m109_18(unknown)               = Chi                                       : total:m109_10, partial:m109_17
+#  109|     v109_19(void)                  = ^IndirectReadSideEffect[-1]               : &:r109_12, ~m109_18
+#  109|     m109_20(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r109_12
+#  109|     m109_21(unknown)               = Chi                                       : total:m109_18, partial:m109_20
+#-----|   C++ Exception -> Block 8
+#-----|   Goto -> Block 4
+
+#  109|   Block 4
+#  109|     m109_22(suspend_always)        = Store[#temp109:13]           : &:r109_11, r109_16
+#  109|     m109_23(unknown)               = Chi                          : total:m109_21, partial:m109_22
+#  109|     r109_24(suspend_always *)      = CopyValue                    : r109_11
+#  109|     m109_25(suspend_always *)      = Store[#temp0:0]              : &:r0_17, r109_24
+#-----|     r0_18(suspend_always *)        = Load[#temp0:0]               : &:r0_17, m109_25
+#  109|     r109_26(glval<suspend_always>) = CopyValue                    : r0_18
+#  109|     r109_27(glval<suspend_always>) = Convert                      : r109_26
+#  109|     r109_28(glval<unknown>)        = FunctionAddress[await_ready] : 
+#  109|     r109_29(bool)                  = Call[await_ready]            : func:r109_28, this:r109_27
+#  109|     m109_30(unknown)               = ^CallSideEffect              : ~m109_23
+#  109|     m109_31(unknown)               = Chi                          : total:m109_23, partial:m109_30
+#  109|     v109_32(void)                  = ^IndirectReadSideEffect[-1]  : &:r109_27, ~m109_31
+#  109|     v109_33(void)                  = ConditionalBranch            : r109_29
+#-----|   False -> Block 6
+#-----|   True -> Block 5
+
+#  109|   Block 5
+#  109|     m109_34(unknown)               = Phi                                       : from 4:~m109_31, from 6:~m109_60
 #  109|     r109_35(suspend_always *)      = CopyValue                                 : r109_24
 #  109|     r109_36(glval<suspend_always>) = CopyValue                                 : r109_35
 #-----|     r0_19(glval<suspend_always>)   = Convert                                   : r109_36
@@ -2052,14 +2226,13 @@ coroutines.cpp:
 #-----|     v0_26(void)                    = ^IndirectReadSideEffect[-1]               : &:r0_21, ~m0_25
 #-----|     m0_27(promise_type)            = ^IndirectMayWriteSideEffect[-1]           : &:r0_21
 #-----|     m0_28(unknown)                 = Chi                                       : total:m0_25, partial:m0_27
-#  110|     v110_5(void)                   = NoOp                                      : 
-#-----|     v0_29(void)                    = NoOp                                      : 
-#-----|   Goto (back edge) -> Block 5
+#-----|   C++ Exception -> Block 8
+#-----|   Goto -> Block 7
 
-#  109|   Block 4
+#  109|   Block 6
 #  109|     r109_41(suspend_always *)                      = CopyValue                                 : r109_24
 #  109|     r109_42(glval<suspend_always>)                 = CopyValue                                 : r109_41
-#-----|     r0_30(glval<suspend_always>)                   = Convert                                   : r109_42
+#-----|     r0_29(glval<suspend_always>)                   = Convert                                   : r109_42
 #  109|     r109_43(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
 #  109|     r109_44(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp109:3]               : 
 #  109|     m109_45(coroutine_handle<promise_type>)        = Uninitialized[#temp109:3]                 : &:r109_44
@@ -2075,87 +2248,117 @@ coroutines.cpp:
 #  109|     m109_55(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r109_44
 #  109|     m109_56(unknown)                               = Chi                                       : total:m109_53, partial:m109_55
 #  109|     r109_57(coroutine_handle<promise_type>)        = Load[#temp109:3]                          : &:r109_44, ~m109_56
-#  109|     v109_58(void)                                  = Call[await_suspend]                       : func:r109_43, this:r0_30, 0:r109_57
+#  109|     v109_58(void)                                  = Call[await_suspend]                       : func:r109_43, this:r0_29, 0:r109_57
 #  109|     m109_59(unknown)                               = ^CallSideEffect                           : ~m109_56
 #  109|     m109_60(unknown)                               = Chi                                       : total:m109_56, partial:m109_59
-#-----|     v0_31(void)                                    = ^IndirectReadSideEffect[-1]               : &:r0_30, ~m109_60
-#-----|   Goto -> Block 3
+#-----|     v0_30(void)                                    = ^IndirectReadSideEffect[-1]               : &:r0_29, ~m109_60
+#-----|   Goto -> Block 5
 
-#-----|   Block 5
-#-----|     v0_32(void)                    = NoOp                                      : 
-#  108|     r108_64(glval<promise_type>)   = VariableAddress[(unnamed local variable)] : 
-#  108|     r108_65(glval<unknown>)        = FunctionAddress[final_suspend]            : 
-#  108|     r108_66(suspend_always)        = Call[final_suspend]                       : func:r108_65, this:r108_64
-#  108|     m108_67(unknown)               = ^CallSideEffect                           : ~m0_28
-#  108|     m108_68(unknown)               = Chi                                       : total:m0_28, partial:m108_67
-#  108|     v108_69(void)                  = ^IndirectReadSideEffect[-1]               : &:r108_64, ~m108_68
-#  108|     m108_70(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r108_64
-#  108|     m108_71(unknown)               = Chi                                       : total:m108_68, partial:m108_70
-#-----|     r0_33(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
-#  108|     r108_72(glval<suspend_always>) = VariableAddress[#temp108:21]              : 
-#  108|     r108_73(glval<promise_type>)   = VariableAddress[(unnamed local variable)] : 
-#  108|     r108_74(glval<unknown>)        = FunctionAddress[final_suspend]            : 
-#  108|     r108_75(suspend_always)        = Call[final_suspend]                       : func:r108_74, this:r108_73
-#  108|     m108_76(unknown)               = ^CallSideEffect                           : ~m108_71
-#  108|     m108_77(unknown)               = Chi                                       : total:m108_71, partial:m108_76
-#  108|     v108_78(void)                  = ^IndirectReadSideEffect[-1]               : &:r108_73, ~m108_77
-#  108|     m108_79(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r108_73
-#  108|     m108_80(unknown)               = Chi                                       : total:m108_77, partial:m108_79
-#  108|     m108_81(suspend_always)        = Store[#temp108:21]                        : &:r108_72, r108_75
-#  108|     m108_82(unknown)               = Chi                                       : total:m108_80, partial:m108_81
-#  108|     r108_83(suspend_always *)      = CopyValue                                 : r108_72
-#  108|     m108_84(suspend_always *)      = Store[#temp0:0]                           : &:r0_33, r108_83
-#-----|     r0_34(suspend_always *)        = Load[#temp0:0]                            : &:r0_33, m108_84
-#  108|     r108_85(glval<suspend_always>) = CopyValue                                 : r0_34
-#  108|     r108_86(glval<suspend_always>) = Convert                                   : r108_85
-#  108|     r108_87(glval<unknown>)        = FunctionAddress[await_ready]              : 
-#  108|     r108_88(bool)                  = Call[await_ready]                         : func:r108_87, this:r108_86
-#  108|     m108_89(unknown)               = ^CallSideEffect                           : ~m108_82
-#  108|     m108_90(unknown)               = Chi                                       : total:m108_82, partial:m108_89
-#  108|     v108_91(void)                  = ^IndirectReadSideEffect[-1]               : &:r108_86, ~m108_90
-#-----|     v0_35(void)                    = ConditionalBranch                         : r108_88
-#-----|   False -> Block 7
-#-----|   True -> Block 6
+#  110|   Block 7
+#  110|     v110_5(void) = NoOp : 
+#-----|     v0_31(void)  = NoOp : 
+#-----|   Goto (back edge) -> Block 10
 
-#  108|   Block 6
-#  108|     m108_92(unknown)                    = Phi                           : from 5:~m108_90, from 7:~m108_122
-#  108|     r108_93(suspend_always *)           = CopyValue                     : r108_83
-#  108|     r108_94(glval<suspend_always>)      = CopyValue                     : r108_93
-#-----|     r0_36(glval<suspend_always>)        = Convert                       : r108_94
-#  108|     r108_95(glval<unknown>)             = FunctionAddress[await_resume] : 
-#  108|     v108_96(void)                       = Call[await_resume]            : func:r108_95, this:r0_36
-#  108|     m108_97(unknown)                    = ^CallSideEffect               : ~m108_92
-#  108|     m108_98(unknown)                    = Chi                           : total:m108_92, partial:m108_97
-#-----|     v0_37(void)                         = ^IndirectReadSideEffect[-1]   : &:r0_36, ~m108_98
-#  108|     r108_99(glval<co_returnable_value>) = VariableAddress[#return]      : 
-#  108|     v108_100(void)                      = ReturnValue                   : &:r108_99, ~m108_98
-#  108|     v108_101(void)                      = AliasedUse                    : ~m108_98
-#  108|     v108_102(void)                      = ExitFunction                  : 
+#-----|   Block 8
+#-----|     m0_32(unknown)     = Phi                                       : from 1:~m109_10, from 3:~m109_21, from 5:~m0_28
+#-----|     v0_33(void)        = CatchAny                                  : 
+#-----|     r0_34(glval<bool>) = VariableAddress[(unnamed local variable)] : 
+#-----|     r0_35(bool)        = Load[(unnamed local variable)]            : &:r0_34, m0_11
+#-----|     r0_36(bool)        = LogicalNot                                : r0_35
+#-----|     v0_37(void)        = ConditionalBranch                         : r0_36
+#-----|   False -> Block 9
+#-----|   True -> Block 13
 
-#  108|   Block 7
-#  108|     r108_103(suspend_always *)                      = CopyValue                                 : r108_83
-#  108|     r108_104(glval<suspend_always>)                 = CopyValue                                 : r108_103
-#-----|     r0_38(glval<suspend_always>)                    = Convert                                   : r108_104
-#  108|     r108_105(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
-#  108|     r108_106(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp108:21]              : 
-#  108|     m108_107(coroutine_handle<promise_type>)        = Uninitialized[#temp108:21]                : &:r108_106
-#  108|     m108_108(unknown)                               = Chi                                       : total:m108_90, partial:m108_107
-#  108|     r108_109(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
-#  108|     r108_110(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
-#  108|     r108_111(glval<coroutine_handle<promise_type>>) = Convert                                   : r108_110
-#  108|     r108_112(coroutine_handle<promise_type> &)      = CopyValue                                 : r108_111
-#  108|     v108_113(void)                                  = Call[coroutine_handle]                    : func:r108_109, this:r108_106, 0:r108_112
-#  108|     m108_114(unknown)                               = ^CallSideEffect                           : ~m108_108
-#  108|     m108_115(unknown)                               = Chi                                       : total:m108_108, partial:m108_114
-#  108|     v108_116(void)                                  = ^BufferReadSideEffect[0]                  : &:r108_112, ~m108_115
-#  108|     m108_117(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r108_106
-#  108|     m108_118(unknown)                               = Chi                                       : total:m108_115, partial:m108_117
-#  108|     r108_119(coroutine_handle<promise_type>)        = Load[#temp108:21]                         : &:r108_106, ~m108_118
-#  108|     v108_120(void)                                  = Call[await_suspend]                       : func:r108_105, this:r0_38, 0:r108_119
-#  108|     m108_121(unknown)                               = ^CallSideEffect                           : ~m108_118
-#  108|     m108_122(unknown)                               = Chi                                       : total:m108_118, partial:m108_121
-#-----|     v0_39(void)                                     = ^IndirectReadSideEffect[-1]               : &:r0_38, ~m108_122
-#-----|   Goto -> Block 6
+#  108|   Block 9
+#  108|     r108_64(glval<promise_type>) = VariableAddress[(unnamed local variable)] : 
+#  108|     r108_65(glval<unknown>)      = FunctionAddress[unhandled_exception]      : 
+#  108|     v108_66(void)                = Call[unhandled_exception]                 : func:r108_65, this:r108_64
+#  108|     m108_67(unknown)             = ^CallSideEffect                           : ~m0_32
+#  108|     m108_68(unknown)             = Chi                                       : total:m0_32, partial:m108_67
+#  108|     v108_69(void)                = ^IndirectReadSideEffect[-1]               : &:r108_64, ~m108_68
+#  108|     m108_70(promise_type)        = ^IndirectMayWriteSideEffect[-1]           : &:r108_64
+#  108|     m108_71(unknown)             = Chi                                       : total:m108_68, partial:m108_70
+#-----|   Goto -> Block 10
+
+#-----|   Block 10
+#-----|     m0_38(unknown)                 = Phi                                       : from 7:~m0_28, from 9:~m108_71
+#-----|     v0_39(void)                    = NoOp                                      : 
+#  108|     r108_72(glval<promise_type>)   = VariableAddress[(unnamed local variable)] : 
+#  108|     r108_73(glval<unknown>)        = FunctionAddress[final_suspend]            : 
+#  108|     r108_74(suspend_always)        = Call[final_suspend]                       : func:r108_73, this:r108_72
+#  108|     m108_75(unknown)               = ^CallSideEffect                           : ~m0_38
+#  108|     m108_76(unknown)               = Chi                                       : total:m0_38, partial:m108_75
+#  108|     v108_77(void)                  = ^IndirectReadSideEffect[-1]               : &:r108_72, ~m108_76
+#  108|     m108_78(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r108_72
+#  108|     m108_79(unknown)               = Chi                                       : total:m108_76, partial:m108_78
+#-----|     r0_40(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
+#  108|     r108_80(glval<suspend_always>) = VariableAddress[#temp108:21]              : 
+#  108|     r108_81(glval<promise_type>)   = VariableAddress[(unnamed local variable)] : 
+#  108|     r108_82(glval<unknown>)        = FunctionAddress[final_suspend]            : 
+#  108|     r108_83(suspend_always)        = Call[final_suspend]                       : func:r108_82, this:r108_81
+#  108|     m108_84(unknown)               = ^CallSideEffect                           : ~m108_79
+#  108|     m108_85(unknown)               = Chi                                       : total:m108_79, partial:m108_84
+#  108|     v108_86(void)                  = ^IndirectReadSideEffect[-1]               : &:r108_81, ~m108_85
+#  108|     m108_87(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r108_81
+#  108|     m108_88(unknown)               = Chi                                       : total:m108_85, partial:m108_87
+#  108|     m108_89(suspend_always)        = Store[#temp108:21]                        : &:r108_80, r108_83
+#  108|     m108_90(unknown)               = Chi                                       : total:m108_88, partial:m108_89
+#  108|     r108_91(suspend_always *)      = CopyValue                                 : r108_80
+#  108|     m108_92(suspend_always *)      = Store[#temp0:0]                           : &:r0_40, r108_91
+#-----|     r0_41(suspend_always *)        = Load[#temp0:0]                            : &:r0_40, m108_92
+#  108|     r108_93(glval<suspend_always>) = CopyValue                                 : r0_41
+#  108|     r108_94(glval<suspend_always>) = Convert                                   : r108_93
+#  108|     r108_95(glval<unknown>)        = FunctionAddress[await_ready]              : 
+#  108|     r108_96(bool)                  = Call[await_ready]                         : func:r108_95, this:r108_94
+#  108|     m108_97(unknown)               = ^CallSideEffect                           : ~m108_90
+#  108|     m108_98(unknown)               = Chi                                       : total:m108_90, partial:m108_97
+#  108|     v108_99(void)                  = ^IndirectReadSideEffect[-1]               : &:r108_94, ~m108_98
+#-----|     v0_42(void)                    = ConditionalBranch                         : r108_96
+#-----|   False -> Block 12
+#-----|   True -> Block 11
+
+#  108|   Block 11
+#  108|     m108_100(unknown)                    = Phi                           : from 10:~m108_98, from 12:~m108_130
+#  108|     r108_101(suspend_always *)           = CopyValue                     : r108_91
+#  108|     r108_102(glval<suspend_always>)      = CopyValue                     : r108_101
+#-----|     r0_43(glval<suspend_always>)         = Convert                       : r108_102
+#  108|     r108_103(glval<unknown>)             = FunctionAddress[await_resume] : 
+#  108|     v108_104(void)                       = Call[await_resume]            : func:r108_103, this:r0_43
+#  108|     m108_105(unknown)                    = ^CallSideEffect               : ~m108_100
+#  108|     m108_106(unknown)                    = Chi                           : total:m108_100, partial:m108_105
+#-----|     v0_44(void)                          = ^IndirectReadSideEffect[-1]   : &:r0_43, ~m108_106
+#  108|     r108_107(glval<co_returnable_value>) = VariableAddress[#return]      : 
+#  108|     v108_108(void)                       = ReturnValue                   : &:r108_107, ~m108_106
+#  108|     v108_109(void)                       = AliasedUse                    : ~m108_106
+#  108|     v108_110(void)                       = ExitFunction                  : 
+
+#  108|   Block 12
+#  108|     r108_111(suspend_always *)                      = CopyValue                                 : r108_91
+#  108|     r108_112(glval<suspend_always>)                 = CopyValue                                 : r108_111
+#-----|     r0_45(glval<suspend_always>)                    = Convert                                   : r108_112
+#  108|     r108_113(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
+#  108|     r108_114(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp108:21]              : 
+#  108|     m108_115(coroutine_handle<promise_type>)        = Uninitialized[#temp108:21]                : &:r108_114
+#  108|     m108_116(unknown)                               = Chi                                       : total:m108_98, partial:m108_115
+#  108|     r108_117(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
+#  108|     r108_118(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
+#  108|     r108_119(glval<coroutine_handle<promise_type>>) = Convert                                   : r108_118
+#  108|     r108_120(coroutine_handle<promise_type> &)      = CopyValue                                 : r108_119
+#  108|     v108_121(void)                                  = Call[coroutine_handle]                    : func:r108_117, this:r108_114, 0:r108_120
+#  108|     m108_122(unknown)                               = ^CallSideEffect                           : ~m108_116
+#  108|     m108_123(unknown)                               = Chi                                       : total:m108_116, partial:m108_122
+#  108|     v108_124(void)                                  = ^BufferReadSideEffect[0]                  : &:r108_120, ~m108_123
+#  108|     m108_125(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r108_114
+#  108|     m108_126(unknown)                               = Chi                                       : total:m108_123, partial:m108_125
+#  108|     r108_127(coroutine_handle<promise_type>)        = Load[#temp108:21]                         : &:r108_114, ~m108_126
+#  108|     v108_128(void)                                  = Call[await_suspend]                       : func:r108_113, this:r0_45, 0:r108_127
+#  108|     m108_129(unknown)                               = ^CallSideEffect                           : ~m108_126
+#  108|     m108_130(unknown)                               = Chi                                       : total:m108_126, partial:m108_129
+#-----|     v0_46(void)                                     = ^IndirectReadSideEffect[-1]               : &:r0_45, ~m108_130
+#-----|   Goto -> Block 11
+
+#  108|   Block 13
+#  108|     v108_131(void) = Unreached : 
 
 destructors_for_temps.cpp:
 #    9| void ClassWithConstructor::ClassWithConstructor(ClassWithConstructor&&)
@@ -17056,23 +17259,27 @@ ir.cpp:
 # 2276|     m2276_7(unknown)        = Chi                             : total:m2276_3, partial:m2276_6
 # 2276|     m2276_8(String)         = ^IndirectMayWriteSideEffect[-1] : &:r2276_1
 # 2276|     m2276_9(unknown)        = Chi                             : total:m2276_7, partial:m2276_8
-# 2277|     r2277_1(glval<bool>)    = VariableAddress[b]              : 
-# 2277|     r2277_2(bool)           = Load[b]                         : &:r2277_1, m2274_6
-# 2277|     v2277_3(void)           = ConditionalBranch               : r2277_2
-#-----|   False -> Block 4
-#-----|   True -> Block 3
+#-----|   C++ Exception -> Block 7
+#-----|   Goto -> Block 3
 
 # 2274|   Block 1
-# 2274|     m2274_7(unknown) = Phi          : from 2:~m2274_10, from 10:~m2290_1
+# 2274|     m2274_7(unknown) = Phi          : from 2:~m2274_10, from 12:~m2290_1
 # 2274|     v2274_8(void)    = AliasedUse   : ~m2274_7
 # 2274|     v2274_9(void)    = ExitFunction : 
 
 # 2274|   Block 2
-# 2274|     m2274_10(unknown) = Phi    : from 6:~m2283_12, from 9:~m2281_8
+# 2274|     m2274_10(unknown) = Phi    : from 8:~m2283_12, from 11:~m2282_1
 # 2274|     v2274_11(void)    = Unwind : 
 #-----|   Goto -> Block 1
 
-# 2278|   Block 3
+# 2277|   Block 3
+# 2277|     r2277_1(glval<bool>) = VariableAddress[b] : 
+# 2277|     r2277_2(bool)        = Load[b]            : &:r2277_1, m2274_6
+# 2277|     v2277_3(void)        = ConditionalBranch  : r2277_2
+#-----|   False -> Block 5
+#-----|   True -> Block 4
+
+# 2278|   Block 4
 # 2278|     r2278_1(glval<char *>)   = VariableAddress[#throw2278:7]    : 
 # 2278|     r2278_2(glval<char[15]>) = StringConstant["string literal"] : 
 # 2278|     r2278_3(char *)          = Convert                          : r2278_2
@@ -17086,18 +17293,22 @@ ir.cpp:
 # 2281|     v2281_6(void)            = ^IndirectReadSideEffect[-1]      : &:r2281_1, ~m2281_5
 # 2281|     m2281_7(String)          = ^IndirectMayWriteSideEffect[-1]  : &:r2281_1
 # 2281|     m2281_8(unknown)         = Chi                              : total:m2281_5, partial:m2281_7
-#-----|   C++ Exception -> Block 5
+#-----|   C++ Exception -> Block 7
 
-# 2280|   Block 4
-# 2280|     r2280_1(glval<String>)   = VariableAddress[s2]             : 
-# 2280|     m2280_2(String)          = Uninitialized[s2]               : &:r2280_1
-# 2280|     m2280_3(unknown)         = Chi                             : total:m2276_9, partial:m2280_2
-# 2280|     r2280_4(glval<unknown>)  = FunctionAddress[String]         : 
-# 2280|     v2280_5(void)            = Call[String]                    : func:r2280_4, this:r2280_1
-# 2280|     m2280_6(unknown)         = ^CallSideEffect                 : ~m2280_3
-# 2280|     m2280_7(unknown)         = Chi                             : total:m2280_3, partial:m2280_6
-# 2280|     m2280_8(String)          = ^IndirectMayWriteSideEffect[-1] : &:r2280_1
-# 2280|     m2280_9(unknown)         = Chi                             : total:m2280_7, partial:m2280_8
+# 2280|   Block 5
+# 2280|     r2280_1(glval<String>)  = VariableAddress[s2]             : 
+# 2280|     m2280_2(String)         = Uninitialized[s2]               : &:r2280_1
+# 2280|     m2280_3(unknown)        = Chi                             : total:m2276_9, partial:m2280_2
+# 2280|     r2280_4(glval<unknown>) = FunctionAddress[String]         : 
+# 2280|     v2280_5(void)           = Call[String]                    : func:r2280_4, this:r2280_1
+# 2280|     m2280_6(unknown)        = ^CallSideEffect                 : ~m2280_3
+# 2280|     m2280_7(unknown)        = Chi                             : total:m2280_3, partial:m2280_6
+# 2280|     m2280_8(String)         = ^IndirectMayWriteSideEffect[-1] : &:r2280_1
+# 2280|     m2280_9(unknown)        = Chi                             : total:m2280_7, partial:m2280_8
+#-----|   C++ Exception -> Block 7
+#-----|   Goto -> Block 6
+
+# 2281|   Block 6
 # 2281|     r2281_9(glval<String>)   = VariableAddress[s2]             : 
 # 2281|     r2281_10(glval<unknown>) = FunctionAddress[~String]        : 
 # 2281|     v2281_11(void)           = Call[~String]                   : func:r2281_10, this:r2281_9
@@ -17114,25 +17325,26 @@ ir.cpp:
 # 2281|     v2281_22(void)           = ^IndirectReadSideEffect[-1]     : &:r2281_17, ~m2281_21
 # 2281|     m2281_23(String)         = ^IndirectMayWriteSideEffect[-1] : &:r2281_17
 # 2281|     m2281_24(unknown)        = Chi                             : total:m2281_21, partial:m2281_23
-#-----|   Goto -> Block 10
+#-----|   Goto -> Block 12
 
-# 2282|   Block 5
-# 2282|     v2282_1(void) = CatchByType[const char *] : 
-#-----|   C++ Exception -> Block 7
-#-----|   Goto -> Block 6
+# 2282|   Block 7
+# 2282|     m2282_1(unknown) = Phi                       : from 0:~m2276_9, from 4:~m2281_8, from 5:~m2280_9
+# 2282|     v2282_2(void)    = CatchByType[const char *] : 
+#-----|   C++ Exception -> Block 9
+#-----|   Goto -> Block 8
 
-# 2282|   Block 6
-# 2282|     r2282_2(glval<char *>)  = VariableAddress[s]              : 
-# 2282|     m2282_3(char *)         = InitializeParameter[s]          : &:r2282_2
-# 2282|     r2282_4(char *)         = Load[s]                         : &:r2282_2, m2282_3
-# 2282|     m2282_5(unknown)        = InitializeIndirection[s]        : &:r2282_4
-# 2282|     m2282_6(unknown)        = Chi                             : total:m2281_8, partial:m2282_5
+# 2282|   Block 8
+# 2282|     r2282_3(glval<char *>)  = VariableAddress[s]              : 
+# 2282|     m2282_4(char *)         = InitializeParameter[s]          : &:r2282_3
+# 2282|     r2282_5(char *)         = Load[s]                         : &:r2282_3, m2282_4
+# 2282|     m2282_6(unknown)        = InitializeIndirection[s]        : &:r2282_5
+# 2282|     m2282_7(unknown)        = Chi                             : total:m2282_1, partial:m2282_6
 # 2283|     r2283_1(glval<String>)  = VariableAddress[#throw2283:5]   : 
 # 2283|     m2283_2(String)         = Uninitialized[#throw2283:5]     : &:r2283_1
-# 2283|     m2283_3(unknown)        = Chi                             : total:m2282_6, partial:m2283_2
+# 2283|     m2283_3(unknown)        = Chi                             : total:m2282_7, partial:m2283_2
 # 2283|     r2283_4(glval<unknown>) = FunctionAddress[String]         : 
 # 2283|     r2283_5(glval<char *>)  = VariableAddress[s]              : 
-# 2283|     r2283_6(char *)         = Load[s]                         : &:r2283_5, m2282_3
+# 2283|     r2283_6(char *)         = Load[s]                         : &:r2283_5, m2282_4
 # 2283|     v2283_7(void)           = Call[String]                    : func:r2283_4, this:r2283_1, 0:r2283_6
 # 2283|     m2283_8(unknown)        = ^CallSideEffect                 : ~m2283_3
 # 2283|     m2283_9(unknown)        = Chi                             : total:m2283_3, partial:m2283_8
@@ -17142,26 +17354,26 @@ ir.cpp:
 # 2283|     v2283_13(void)          = ThrowValue                      : &:r2283_1, ~m2283_12
 #-----|   C++ Exception -> Block 2
 
-# 2285|   Block 7
+# 2285|   Block 9
 # 2285|     v2285_1(void) = CatchByType[const String &] : 
-#-----|   C++ Exception -> Block 9
-#-----|   Goto -> Block 8
+#-----|   C++ Exception -> Block 11
+#-----|   Goto -> Block 10
 
-# 2285|   Block 8
+# 2285|   Block 10
 # 2285|     r2285_2(glval<String &>) = VariableAddress[e]       : 
 # 2285|     m2285_3(String &)        = InitializeParameter[e]   : &:r2285_2
 # 2285|     r2285_4(String &)        = Load[e]                  : &:r2285_2, m2285_3
 # 2285|     m2285_5(unknown)         = InitializeIndirection[e] : &:r2285_4
 # 2285|     v2285_6(void)            = NoOp                     : 
-#-----|   Goto -> Block 10
+#-----|   Goto -> Block 12
 
-# 2287|   Block 9
+# 2287|   Block 11
 # 2287|     v2287_1(void) = CatchAny : 
 # 2288|     v2288_1(void) = ReThrow  : 
 #-----|   C++ Exception -> Block 2
 
-# 2290|   Block 10
-# 2290|     m2290_1(unknown) = Phi        : from 4:~m2281_24, from 8:~m2281_8
+# 2290|   Block 12
+# 2290|     m2290_1(unknown) = Phi        : from 6:~m2281_24, from 10:~m2282_1
 # 2290|     v2290_2(void)    = NoOp       : 
 # 2274|     v2274_12(void)   = ReturnVoid : 
 #-----|   Goto -> Block 1

--- a/cpp/ql/test/library-tests/ir/ir/raw_ir.expected
+++ b/cpp/ql/test/library-tests/ir/ir/raw_ir.expected
@@ -863,14 +863,13 @@ coroutines.cpp:
 #-----|     mu0_13(unknown)               = ^CallSideEffect                           : ~m?
 #-----|     v0_14(void)                   = ^IndirectReadSideEffect[-1]               : &:r0_10, ~m?
 #-----|     mu0_15(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r0_10
-#   88|     v88_1(void)                   = NoOp                                      : 
-#-----|     v0_16(void)                   = NoOp                                      : 
-#-----|   Goto (back edge) -> Block 8
+#-----|   C++ Exception -> Block 6
+#-----|   Goto -> Block 5
 
 #   87|   Block 4
 #   87|     r87_36(suspend_always *)                      = CopyValue                                 : r87_20
 #   87|     r87_37(glval<suspend_always>)                 = CopyValue                                 : r87_36
-#-----|     r0_17(glval<suspend_always>)                  = Convert                                   : r87_37
+#-----|     r0_16(glval<suspend_always>)                  = Convert                                   : r87_37
 #   87|     r87_38(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
 #   87|     r87_39(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp87:20]               : 
 #   87|     mu87_40(coroutine_handle<promise_type>)       = Uninitialized[#temp87:20]                 : &:r87_39
@@ -883,34 +882,39 @@ coroutines.cpp:
 #   87|     v87_47(void)                                  = ^BufferReadSideEffect[0]                  : &:r87_44, ~m?
 #   87|     mu87_48(coroutine_handle<promise_type>)       = ^IndirectMayWriteSideEffect[-1]           : &:r87_39
 #   87|     r87_49(coroutine_handle<promise_type>)        = Load[#temp87:20]                          : &:r87_39, ~m?
-#   87|     v87_50(void)                                  = Call[await_suspend]                       : func:r87_38, this:r0_17, 0:r87_49
+#   87|     v87_50(void)                                  = Call[await_suspend]                       : func:r87_38, this:r0_16, 0:r87_49
 #   87|     mu87_51(unknown)                              = ^CallSideEffect                           : ~m?
-#-----|     v0_18(void)                                   = ^IndirectReadSideEffect[-1]               : &:r0_17, ~m?
+#-----|     v0_17(void)                                   = ^IndirectReadSideEffect[-1]               : &:r0_16, ~m?
 #-----|   Goto -> Block 3
 
-#-----|   Block 5
+#   88|   Block 5
+#   88|     v88_1(void) = NoOp : 
+#-----|     v0_18(void) = NoOp : 
+#-----|   Goto (back edge) -> Block 9
+
+#-----|   Block 6
 #-----|     v0_19(void)        = CatchAny                                  : 
 #-----|     r0_20(glval<bool>) = VariableAddress[(unnamed local variable)] : 
 #-----|     r0_21(bool)        = Load[(unnamed local variable)]            : &:r0_20, ~m?
 #-----|     r0_22(bool)        = LogicalNot                                : r0_21
 #-----|     v0_23(void)        = ConditionalBranch                         : r0_22
-#-----|   False -> Block 7
-#-----|   True -> Block 6
+#-----|   False -> Block 8
+#-----|   True -> Block 7
 
-#-----|   Block 6
+#-----|   Block 7
 #-----|     v0_24(void) = ReThrow : 
 #-----|   C++ Exception -> Block 2
 
-#   87|   Block 7
+#   87|   Block 8
 #   87|     r87_52(glval<promise_type>) = VariableAddress[(unnamed local variable)] : 
 #   87|     r87_53(glval<unknown>)      = FunctionAddress[unhandled_exception]      : 
 #   87|     v87_54(void)                = Call[unhandled_exception]                 : func:r87_53, this:r87_52
 #   87|     mu87_55(unknown)            = ^CallSideEffect                           : ~m?
 #   87|     v87_56(void)                = ^IndirectReadSideEffect[-1]               : &:r87_52, ~m?
 #   87|     mu87_57(promise_type)       = ^IndirectMayWriteSideEffect[-1]           : &:r87_52
-#-----|   Goto -> Block 8
+#-----|   Goto -> Block 9
 
-#-----|   Block 8
+#-----|   Block 9
 #-----|     v0_25(void)                    = NoOp                                      : 
 #   87|     r87_58(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
 #   87|     r87_59(glval<unknown>)         = FunctionAddress[final_suspend]            : 
@@ -937,10 +941,10 @@ coroutines.cpp:
 #   87|     mu87_78(unknown)               = ^CallSideEffect                           : ~m?
 #   87|     v87_79(void)                   = ^IndirectReadSideEffect[-1]               : &:r87_75, ~m?
 #-----|     v0_28(void)                    = ConditionalBranch                         : r87_77
-#-----|   False -> Block 10
-#-----|   True -> Block 9
+#-----|   False -> Block 11
+#-----|   True -> Block 10
 
-#   87|   Block 9
+#   87|   Block 10
 #   87|     r87_80(suspend_always *)          = CopyValue                     : r87_72
 #   87|     r87_81(glval<suspend_always>)     = CopyValue                     : r87_80
 #-----|     r0_29(glval<suspend_always>)      = Convert                       : r87_81
@@ -952,7 +956,7 @@ coroutines.cpp:
 #   87|     v87_86(void)                      = ReturnValue                   : &:r87_85, ~m?
 #-----|   Goto -> Block 1
 
-#   87|   Block 10
+#   87|   Block 11
 #   87|     r87_87(suspend_always *)                      = CopyValue                                 : r87_72
 #   87|     r87_88(glval<suspend_always>)                 = CopyValue                                 : r87_87
 #-----|     r0_31(glval<suspend_always>)                  = Convert                                   : r87_88
@@ -971,7 +975,7 @@ coroutines.cpp:
 #   87|     v87_101(void)                                 = Call[await_suspend]                       : func:r87_89, this:r0_31, 0:r87_100
 #   87|     mu87_102(unknown)                             = ^CallSideEffect                           : ~m?
 #-----|     v0_32(void)                                   = ^IndirectReadSideEffect[-1]               : &:r0_31, ~m?
-#-----|   Goto -> Block 9
+#-----|   Goto -> Block 10
 
 #   91| co_returnable_value co_return_int(int)
 #   91|   Block 0
@@ -1042,14 +1046,13 @@ coroutines.cpp:
 #-----|     mu0_17(unknown)               = ^CallSideEffect                           : ~m?
 #-----|     v0_18(void)                   = ^IndirectReadSideEffect[-1]               : &:r0_14, ~m?
 #-----|     mu0_19(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r0_14
-#   92|     v92_3(void)                   = NoOp                                      : 
-#-----|     v0_20(void)                   = NoOp                                      : 
-#-----|   Goto (back edge) -> Block 8
+#-----|   C++ Exception -> Block 6
+#-----|   Goto -> Block 5
 
 #   91|   Block 4
 #   91|     r91_38(suspend_always *)                      = CopyValue                                 : r91_22
 #   91|     r91_39(glval<suspend_always>)                 = CopyValue                                 : r91_38
-#-----|     r0_21(glval<suspend_always>)                  = Convert                                   : r91_39
+#-----|     r0_20(glval<suspend_always>)                  = Convert                                   : r91_39
 #   91|     r91_40(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
 #   91|     r91_41(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp91:21]               : 
 #   91|     mu91_42(coroutine_handle<promise_type>)       = Uninitialized[#temp91:21]                 : &:r91_41
@@ -1062,34 +1065,39 @@ coroutines.cpp:
 #   91|     v91_49(void)                                  = ^BufferReadSideEffect[0]                  : &:r91_46, ~m?
 #   91|     mu91_50(coroutine_handle<promise_type>)       = ^IndirectMayWriteSideEffect[-1]           : &:r91_41
 #   91|     r91_51(coroutine_handle<promise_type>)        = Load[#temp91:21]                          : &:r91_41, ~m?
-#   91|     v91_52(void)                                  = Call[await_suspend]                       : func:r91_40, this:r0_21, 0:r91_51
+#   91|     v91_52(void)                                  = Call[await_suspend]                       : func:r91_40, this:r0_20, 0:r91_51
 #   91|     mu91_53(unknown)                              = ^CallSideEffect                           : ~m?
-#-----|     v0_22(void)                                   = ^IndirectReadSideEffect[-1]               : &:r0_21, ~m?
+#-----|     v0_21(void)                                   = ^IndirectReadSideEffect[-1]               : &:r0_20, ~m?
 #-----|   Goto -> Block 3
 
-#-----|   Block 5
+#   92|   Block 5
+#   92|     v92_3(void) = NoOp : 
+#-----|     v0_22(void) = NoOp : 
+#-----|   Goto (back edge) -> Block 9
+
+#-----|   Block 6
 #-----|     v0_23(void)        = CatchAny                                  : 
 #-----|     r0_24(glval<bool>) = VariableAddress[(unnamed local variable)] : 
 #-----|     r0_25(bool)        = Load[(unnamed local variable)]            : &:r0_24, ~m?
 #-----|     r0_26(bool)        = LogicalNot                                : r0_25
 #-----|     v0_27(void)        = ConditionalBranch                         : r0_26
-#-----|   False -> Block 7
-#-----|   True -> Block 6
+#-----|   False -> Block 8
+#-----|   True -> Block 7
 
-#-----|   Block 6
+#-----|   Block 7
 #-----|     v0_28(void) = ReThrow : 
 #-----|   C++ Exception -> Block 2
 
-#   91|   Block 7
+#   91|   Block 8
 #   91|     r91_54(glval<promise_type>) = VariableAddress[(unnamed local variable)] : 
 #   91|     r91_55(glval<unknown>)      = FunctionAddress[unhandled_exception]      : 
 #   91|     v91_56(void)                = Call[unhandled_exception]                 : func:r91_55, this:r91_54
 #   91|     mu91_57(unknown)            = ^CallSideEffect                           : ~m?
 #   91|     v91_58(void)                = ^IndirectReadSideEffect[-1]               : &:r91_54, ~m?
 #   91|     mu91_59(promise_type)       = ^IndirectMayWriteSideEffect[-1]           : &:r91_54
-#-----|   Goto -> Block 8
+#-----|   Goto -> Block 9
 
-#-----|   Block 8
+#-----|   Block 9
 #-----|     v0_29(void)                    = NoOp                                      : 
 #   91|     r91_60(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
 #   91|     r91_61(glval<unknown>)         = FunctionAddress[final_suspend]            : 
@@ -1116,10 +1124,10 @@ coroutines.cpp:
 #   91|     mu91_80(unknown)               = ^CallSideEffect                           : ~m?
 #   91|     v91_81(void)                   = ^IndirectReadSideEffect[-1]               : &:r91_77, ~m?
 #-----|     v0_32(void)                    = ConditionalBranch                         : r91_79
-#-----|   False -> Block 10
-#-----|   True -> Block 9
+#-----|   False -> Block 11
+#-----|   True -> Block 10
 
-#   91|   Block 9
+#   91|   Block 10
 #   91|     r91_82(suspend_always *)           = CopyValue                     : r91_74
 #   91|     r91_83(glval<suspend_always>)      = CopyValue                     : r91_82
 #-----|     r0_33(glval<suspend_always>)       = Convert                       : r91_83
@@ -1131,7 +1139,7 @@ coroutines.cpp:
 #   91|     v91_88(void)                       = ReturnValue                   : &:r91_87, ~m?
 #-----|   Goto -> Block 1
 
-#   91|   Block 10
+#   91|   Block 11
 #   91|     r91_89(suspend_always *)                      = CopyValue                                 : r91_74
 #   91|     r91_90(glval<suspend_always>)                 = CopyValue                                 : r91_89
 #-----|     r0_35(glval<suspend_always>)                  = Convert                                   : r91_90
@@ -1150,7 +1158,7 @@ coroutines.cpp:
 #   91|     v91_103(void)                                 = Call[await_suspend]                       : func:r91_91, this:r0_35, 0:r91_102
 #   91|     mu91_104(unknown)                             = ^CallSideEffect                           : ~m?
 #-----|     v0_36(void)                                   = ^IndirectReadSideEffect[-1]               : &:r0_35, ~m?
-#-----|   Goto -> Block 9
+#-----|   Goto -> Block 10
 
 #   95| co_returnable_void co_yield_value_void(int)
 #   95|   Block 0
@@ -1202,53 +1210,32 @@ coroutines.cpp:
 #-----|   Goto -> Block 1
 
 #-----|   Block 3
-#-----|     r0_8(bool)                     = Constant[1]                               : 
-#-----|     r0_9(glval<bool>)              = VariableAddress[(unnamed local variable)] : 
-#-----|     mu0_10(bool)                   = Store[(unnamed local variable)]           : &:r0_9, r0_8
-#   95|     r95_33(suspend_always *)       = CopyValue                                 : r95_22
-#   95|     r95_34(glval<suspend_always>)  = CopyValue                                 : r95_33
-#-----|     r0_11(glval<suspend_always>)   = Convert                                   : r95_34
-#   95|     r95_35(glval<unknown>)         = FunctionAddress[await_resume]             : 
-#   95|     v95_36(void)                   = Call[await_resume]                        : func:r95_35, this:r0_11
-#   95|     mu95_37(unknown)               = ^CallSideEffect                           : ~m?
-#-----|     v0_12(void)                    = ^IndirectReadSideEffect[-1]               : &:r0_11, ~m?
-#-----|     v0_13(void)                    = CopyValue                                 : v95_36
-#   96|     r96_1(glval<promise_type>)     = VariableAddress[(unnamed local variable)] : 
-#   96|     r96_2(glval<unknown>)          = FunctionAddress[yield_value]              : 
-#   96|     r96_3(glval<int>)              = VariableAddress[i]                        : 
-#   96|     r96_4(int)                     = Load[i]                                   : &:r96_3, ~m?
-#   96|     r96_5(suspend_always)          = Call[yield_value]                         : func:r96_2, this:r96_1, 0:r96_4
-#   96|     mu96_6(unknown)                = ^CallSideEffect                           : ~m?
-#   96|     v96_7(void)                    = ^IndirectReadSideEffect[-1]               : &:r96_1, ~m?
-#   96|     mu96_8(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r96_1
-#-----|     r0_14(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
-#   96|     r96_9(glval<suspend_always>)   = VariableAddress[#temp96:13]               : 
-#   96|     r96_10(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
-#   96|     r96_11(glval<unknown>)         = FunctionAddress[yield_value]              : 
-#   96|     r96_12(glval<int>)             = VariableAddress[i]                        : 
-#   96|     r96_13(int)                    = Load[i]                                   : &:r96_12, ~m?
-#   96|     r96_14(suspend_always)         = Call[yield_value]                         : func:r96_11, this:r96_10, 0:r96_13
-#   96|     mu96_15(unknown)               = ^CallSideEffect                           : ~m?
-#   96|     v96_16(void)                   = ^IndirectReadSideEffect[-1]               : &:r96_10, ~m?
-#   96|     mu96_17(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r96_10
-#   96|     mu96_18(suspend_always)        = Store[#temp96:13]                         : &:r96_9, r96_14
-#   96|     r96_19(suspend_always *)       = CopyValue                                 : r96_9
-#   96|     mu96_20(suspend_always *)      = Store[#temp0:0]                           : &:r0_14, r96_19
-#-----|     r0_15(suspend_always *)        = Load[#temp0:0]                            : &:r0_14, ~m?
-#   96|     r96_21(glval<suspend_always>)  = CopyValue                                 : r0_15
-#   96|     r96_22(glval<suspend_always>)  = Convert                                   : r96_21
-#   96|     r96_23(glval<unknown>)         = FunctionAddress[await_ready]              : 
-#   96|     r96_24(bool)                   = Call[await_ready]                         : func:r96_23, this:r96_22
-#   96|     mu96_25(unknown)               = ^CallSideEffect                           : ~m?
-#   96|     v96_26(void)                   = ^IndirectReadSideEffect[-1]               : &:r96_22, ~m?
-#   96|     v96_27(void)                   = ConditionalBranch                         : r96_24
-#-----|   False -> Block 6
-#-----|   True -> Block 5
+#-----|     r0_8(bool)                    = Constant[1]                               : 
+#-----|     r0_9(glval<bool>)             = VariableAddress[(unnamed local variable)] : 
+#-----|     mu0_10(bool)                  = Store[(unnamed local variable)]           : &:r0_9, r0_8
+#   95|     r95_33(suspend_always *)      = CopyValue                                 : r95_22
+#   95|     r95_34(glval<suspend_always>) = CopyValue                                 : r95_33
+#-----|     r0_11(glval<suspend_always>)  = Convert                                   : r95_34
+#   95|     r95_35(glval<unknown>)        = FunctionAddress[await_resume]             : 
+#   95|     v95_36(void)                  = Call[await_resume]                        : func:r95_35, this:r0_11
+#   95|     mu95_37(unknown)              = ^CallSideEffect                           : ~m?
+#-----|     v0_12(void)                   = ^IndirectReadSideEffect[-1]               : &:r0_11, ~m?
+#-----|     v0_13(void)                   = CopyValue                                 : v95_36
+#   96|     r96_1(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
+#   96|     r96_2(glval<unknown>)         = FunctionAddress[yield_value]              : 
+#   96|     r96_3(glval<int>)             = VariableAddress[i]                        : 
+#   96|     r96_4(int)                    = Load[i]                                   : &:r96_3, ~m?
+#   96|     r96_5(suspend_always)         = Call[yield_value]                         : func:r96_2, this:r96_1, 0:r96_4
+#   96|     mu96_6(unknown)               = ^CallSideEffect                           : ~m?
+#   96|     v96_7(void)                   = ^IndirectReadSideEffect[-1]               : &:r96_1, ~m?
+#   96|     mu96_8(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r96_1
+#-----|   C++ Exception -> Block 10
+#-----|   Goto -> Block 5
 
 #   95|   Block 4
 #   95|     r95_38(suspend_always *)                      = CopyValue                                 : r95_22
 #   95|     r95_39(glval<suspend_always>)                 = CopyValue                                 : r95_38
-#-----|     r0_16(glval<suspend_always>)                  = Convert                                   : r95_39
+#-----|     r0_14(glval<suspend_always>)                  = Convert                                   : r95_39
 #   95|     r95_40(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
 #   95|     r95_41(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp95:20]               : 
 #   95|     mu95_42(coroutine_handle<promise_type>)       = Uninitialized[#temp95:20]                 : &:r95_41
@@ -1261,12 +1248,41 @@ coroutines.cpp:
 #   95|     v95_49(void)                                  = ^BufferReadSideEffect[0]                  : &:r95_46, ~m?
 #   95|     mu95_50(coroutine_handle<promise_type>)       = ^IndirectMayWriteSideEffect[-1]           : &:r95_41
 #   95|     r95_51(coroutine_handle<promise_type>)        = Load[#temp95:20]                          : &:r95_41, ~m?
-#   95|     v95_52(void)                                  = Call[await_suspend]                       : func:r95_40, this:r0_16, 0:r95_51
+#   95|     v95_52(void)                                  = Call[await_suspend]                       : func:r95_40, this:r0_14, 0:r95_51
 #   95|     mu95_53(unknown)                              = ^CallSideEffect                           : ~m?
-#-----|     v0_17(void)                                   = ^IndirectReadSideEffect[-1]               : &:r0_16, ~m?
+#-----|     v0_15(void)                                   = ^IndirectReadSideEffect[-1]               : &:r0_14, ~m?
 #-----|   Goto -> Block 3
 
-#   96|   Block 5
+#-----|   Block 5
+#-----|     r0_16(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
+#   96|     r96_9(glval<suspend_always>)   = VariableAddress[#temp96:13]               : 
+#   96|     r96_10(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
+#   96|     r96_11(glval<unknown>)         = FunctionAddress[yield_value]              : 
+#   96|     r96_12(glval<int>)             = VariableAddress[i]                        : 
+#   96|     r96_13(int)                    = Load[i]                                   : &:r96_12, ~m?
+#   96|     r96_14(suspend_always)         = Call[yield_value]                         : func:r96_11, this:r96_10, 0:r96_13
+#   96|     mu96_15(unknown)               = ^CallSideEffect                           : ~m?
+#   96|     v96_16(void)                   = ^IndirectReadSideEffect[-1]               : &:r96_10, ~m?
+#   96|     mu96_17(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r96_10
+#-----|   C++ Exception -> Block 10
+#-----|   Goto -> Block 6
+
+#   96|   Block 6
+#   96|     mu96_18(suspend_always)       = Store[#temp96:13]            : &:r96_9, r96_14
+#   96|     r96_19(suspend_always *)      = CopyValue                    : r96_9
+#   96|     mu96_20(suspend_always *)     = Store[#temp0:0]              : &:r0_16, r96_19
+#-----|     r0_17(suspend_always *)       = Load[#temp0:0]               : &:r0_16, ~m?
+#   96|     r96_21(glval<suspend_always>) = CopyValue                    : r0_17
+#   96|     r96_22(glval<suspend_always>) = Convert                      : r96_21
+#   96|     r96_23(glval<unknown>)        = FunctionAddress[await_ready] : 
+#   96|     r96_24(bool)                  = Call[await_ready]            : func:r96_23, this:r96_22
+#   96|     mu96_25(unknown)              = ^CallSideEffect              : ~m?
+#   96|     v96_26(void)                  = ^IndirectReadSideEffect[-1]  : &:r96_22, ~m?
+#   96|     v96_27(void)                  = ConditionalBranch            : r96_24
+#-----|   False -> Block 8
+#-----|   True -> Block 7
+
+#   96|   Block 7
 #   96|     r96_28(suspend_always *)      = CopyValue                                 : r96_19
 #   96|     r96_29(glval<suspend_always>) = CopyValue                                 : r96_28
 #-----|     r0_18(glval<suspend_always>)  = Convert                                   : r96_29
@@ -1280,14 +1296,13 @@ coroutines.cpp:
 #-----|     mu0_23(unknown)               = ^CallSideEffect                           : ~m?
 #-----|     v0_24(void)                   = ^IndirectReadSideEffect[-1]               : &:r0_20, ~m?
 #-----|     mu0_25(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r0_20
-#   97|     v97_1(void)                   = NoOp                                      : 
-#-----|     v0_26(void)                   = NoOp                                      : 
-#-----|   Goto (back edge) -> Block 10
+#-----|   C++ Exception -> Block 10
+#-----|   Goto -> Block 9
 
-#   96|   Block 6
+#   96|   Block 8
 #   96|     r96_33(suspend_always *)                      = CopyValue                                 : r96_19
 #   96|     r96_34(glval<suspend_always>)                 = CopyValue                                 : r96_33
-#-----|     r0_27(glval<suspend_always>)                  = Convert                                   : r96_34
+#-----|     r0_26(glval<suspend_always>)                  = Convert                                   : r96_34
 #   96|     r96_35(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
 #   96|     r96_36(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp96:3]                : 
 #   96|     mu96_37(coroutine_handle<promise_type>)       = Uninitialized[#temp96:3]                  : &:r96_36
@@ -1300,34 +1315,39 @@ coroutines.cpp:
 #   96|     v96_44(void)                                  = ^BufferReadSideEffect[0]                  : &:r96_41, ~m?
 #   96|     mu96_45(coroutine_handle<promise_type>)       = ^IndirectMayWriteSideEffect[-1]           : &:r96_36
 #   96|     r96_46(coroutine_handle<promise_type>)        = Load[#temp96:3]                           : &:r96_36, ~m?
-#   96|     v96_47(void)                                  = Call[await_suspend]                       : func:r96_35, this:r0_27, 0:r96_46
+#   96|     v96_47(void)                                  = Call[await_suspend]                       : func:r96_35, this:r0_26, 0:r96_46
 #   96|     mu96_48(unknown)                              = ^CallSideEffect                           : ~m?
-#-----|     v0_28(void)                                   = ^IndirectReadSideEffect[-1]               : &:r0_27, ~m?
-#-----|   Goto -> Block 5
+#-----|     v0_27(void)                                   = ^IndirectReadSideEffect[-1]               : &:r0_26, ~m?
+#-----|   Goto -> Block 7
 
-#-----|   Block 7
+#   97|   Block 9
+#   97|     v97_1(void) = NoOp : 
+#-----|     v0_28(void) = NoOp : 
+#-----|   Goto (back edge) -> Block 13
+
+#-----|   Block 10
 #-----|     v0_29(void)        = CatchAny                                  : 
 #-----|     r0_30(glval<bool>) = VariableAddress[(unnamed local variable)] : 
 #-----|     r0_31(bool)        = Load[(unnamed local variable)]            : &:r0_30, ~m?
 #-----|     r0_32(bool)        = LogicalNot                                : r0_31
 #-----|     v0_33(void)        = ConditionalBranch                         : r0_32
-#-----|   False -> Block 9
-#-----|   True -> Block 8
+#-----|   False -> Block 12
+#-----|   True -> Block 11
 
-#-----|   Block 8
+#-----|   Block 11
 #-----|     v0_34(void) = ReThrow : 
 #-----|   C++ Exception -> Block 2
 
-#   95|   Block 9
+#   95|   Block 12
 #   95|     r95_54(glval<promise_type>) = VariableAddress[(unnamed local variable)] : 
 #   95|     r95_55(glval<unknown>)      = FunctionAddress[unhandled_exception]      : 
 #   95|     v95_56(void)                = Call[unhandled_exception]                 : func:r95_55, this:r95_54
 #   95|     mu95_57(unknown)            = ^CallSideEffect                           : ~m?
 #   95|     v95_58(void)                = ^IndirectReadSideEffect[-1]               : &:r95_54, ~m?
 #   95|     mu95_59(promise_type)       = ^IndirectMayWriteSideEffect[-1]           : &:r95_54
-#-----|   Goto -> Block 10
+#-----|   Goto -> Block 13
 
-#-----|   Block 10
+#-----|   Block 13
 #-----|     v0_35(void)                    = NoOp                                      : 
 #   95|     r95_60(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
 #   95|     r95_61(glval<unknown>)         = FunctionAddress[final_suspend]            : 
@@ -1354,10 +1374,10 @@ coroutines.cpp:
 #   95|     mu95_80(unknown)               = ^CallSideEffect                           : ~m?
 #   95|     v95_81(void)                   = ^IndirectReadSideEffect[-1]               : &:r95_77, ~m?
 #-----|     v0_38(void)                    = ConditionalBranch                         : r95_79
-#-----|   False -> Block 12
-#-----|   True -> Block 11
+#-----|   False -> Block 15
+#-----|   True -> Block 14
 
-#   95|   Block 11
+#   95|   Block 14
 #   95|     r95_82(suspend_always *)          = CopyValue                     : r95_74
 #   95|     r95_83(glval<suspend_always>)     = CopyValue                     : r95_82
 #-----|     r0_39(glval<suspend_always>)      = Convert                       : r95_83
@@ -1369,7 +1389,7 @@ coroutines.cpp:
 #   95|     v95_88(void)                      = ReturnValue                   : &:r95_87, ~m?
 #-----|   Goto -> Block 1
 
-#   95|   Block 12
+#   95|   Block 15
 #   95|     r95_89(suspend_always *)                      = CopyValue                                 : r95_74
 #   95|     r95_90(glval<suspend_always>)                 = CopyValue                                 : r95_89
 #-----|     r0_41(glval<suspend_always>)                  = Convert                                   : r95_90
@@ -1388,7 +1408,7 @@ coroutines.cpp:
 #   95|     v95_103(void)                                 = Call[await_suspend]                       : func:r95_91, this:r0_41, 0:r95_102
 #   95|     mu95_104(unknown)                             = ^CallSideEffect                           : ~m?
 #-----|     v0_42(void)                                   = ^IndirectReadSideEffect[-1]               : &:r0_41, ~m?
-#-----|   Goto -> Block 11
+#-----|   Goto -> Block 14
 
 #   99| co_returnable_value co_yield_value_value(int)
 #   99|   Block 0
@@ -1440,53 +1460,32 @@ coroutines.cpp:
 #-----|   Goto -> Block 1
 
 #-----|   Block 3
-#-----|     r0_8(bool)                     = Constant[1]                               : 
-#-----|     r0_9(glval<bool>)              = VariableAddress[(unnamed local variable)] : 
-#-----|     mu0_10(bool)                   = Store[(unnamed local variable)]           : &:r0_9, r0_8
-#   99|     r99_33(suspend_always *)       = CopyValue                                 : r99_22
-#   99|     r99_34(glval<suspend_always>)  = CopyValue                                 : r99_33
-#-----|     r0_11(glval<suspend_always>)   = Convert                                   : r99_34
-#   99|     r99_35(glval<unknown>)         = FunctionAddress[await_resume]             : 
-#   99|     v99_36(void)                   = Call[await_resume]                        : func:r99_35, this:r0_11
-#   99|     mu99_37(unknown)               = ^CallSideEffect                           : ~m?
-#-----|     v0_12(void)                    = ^IndirectReadSideEffect[-1]               : &:r0_11, ~m?
-#-----|     v0_13(void)                    = CopyValue                                 : v99_36
-#  100|     r100_1(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
-#  100|     r100_2(glval<unknown>)         = FunctionAddress[yield_value]              : 
-#  100|     r100_3(glval<int>)             = VariableAddress[i]                        : 
-#  100|     r100_4(int)                    = Load[i]                                   : &:r100_3, ~m?
-#  100|     r100_5(suspend_always)         = Call[yield_value]                         : func:r100_2, this:r100_1, 0:r100_4
-#  100|     mu100_6(unknown)               = ^CallSideEffect                           : ~m?
-#  100|     v100_7(void)                   = ^IndirectReadSideEffect[-1]               : &:r100_1, ~m?
-#  100|     mu100_8(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r100_1
-#-----|     r0_14(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
-#  100|     r100_9(glval<suspend_always>)  = VariableAddress[#temp100:13]              : 
-#  100|     r100_10(glval<promise_type>)   = VariableAddress[(unnamed local variable)] : 
-#  100|     r100_11(glval<unknown>)        = FunctionAddress[yield_value]              : 
-#  100|     r100_12(glval<int>)            = VariableAddress[i]                        : 
-#  100|     r100_13(int)                   = Load[i]                                   : &:r100_12, ~m?
-#  100|     r100_14(suspend_always)        = Call[yield_value]                         : func:r100_11, this:r100_10, 0:r100_13
-#  100|     mu100_15(unknown)              = ^CallSideEffect                           : ~m?
-#  100|     v100_16(void)                  = ^IndirectReadSideEffect[-1]               : &:r100_10, ~m?
-#  100|     mu100_17(promise_type)         = ^IndirectMayWriteSideEffect[-1]           : &:r100_10
-#  100|     mu100_18(suspend_always)       = Store[#temp100:13]                        : &:r100_9, r100_14
-#  100|     r100_19(suspend_always *)      = CopyValue                                 : r100_9
-#  100|     mu100_20(suspend_always *)     = Store[#temp0:0]                           : &:r0_14, r100_19
-#-----|     r0_15(suspend_always *)        = Load[#temp0:0]                            : &:r0_14, ~m?
-#  100|     r100_21(glval<suspend_always>) = CopyValue                                 : r0_15
-#  100|     r100_22(glval<suspend_always>) = Convert                                   : r100_21
-#  100|     r100_23(glval<unknown>)        = FunctionAddress[await_ready]              : 
-#  100|     r100_24(bool)                  = Call[await_ready]                         : func:r100_23, this:r100_22
-#  100|     mu100_25(unknown)              = ^CallSideEffect                           : ~m?
-#  100|     v100_26(void)                  = ^IndirectReadSideEffect[-1]               : &:r100_22, ~m?
-#  100|     v100_27(void)                  = ConditionalBranch                         : r100_24
-#-----|   False -> Block 6
-#-----|   True -> Block 5
+#-----|     r0_8(bool)                    = Constant[1]                               : 
+#-----|     r0_9(glval<bool>)             = VariableAddress[(unnamed local variable)] : 
+#-----|     mu0_10(bool)                  = Store[(unnamed local variable)]           : &:r0_9, r0_8
+#   99|     r99_33(suspend_always *)      = CopyValue                                 : r99_22
+#   99|     r99_34(glval<suspend_always>) = CopyValue                                 : r99_33
+#-----|     r0_11(glval<suspend_always>)  = Convert                                   : r99_34
+#   99|     r99_35(glval<unknown>)        = FunctionAddress[await_resume]             : 
+#   99|     v99_36(void)                  = Call[await_resume]                        : func:r99_35, this:r0_11
+#   99|     mu99_37(unknown)              = ^CallSideEffect                           : ~m?
+#-----|     v0_12(void)                   = ^IndirectReadSideEffect[-1]               : &:r0_11, ~m?
+#-----|     v0_13(void)                   = CopyValue                                 : v99_36
+#  100|     r100_1(glval<promise_type>)   = VariableAddress[(unnamed local variable)] : 
+#  100|     r100_2(glval<unknown>)        = FunctionAddress[yield_value]              : 
+#  100|     r100_3(glval<int>)            = VariableAddress[i]                        : 
+#  100|     r100_4(int)                   = Load[i]                                   : &:r100_3, ~m?
+#  100|     r100_5(suspend_always)        = Call[yield_value]                         : func:r100_2, this:r100_1, 0:r100_4
+#  100|     mu100_6(unknown)              = ^CallSideEffect                           : ~m?
+#  100|     v100_7(void)                  = ^IndirectReadSideEffect[-1]               : &:r100_1, ~m?
+#  100|     mu100_8(promise_type)         = ^IndirectMayWriteSideEffect[-1]           : &:r100_1
+#-----|   C++ Exception -> Block 9
+#-----|   Goto -> Block 5
 
 #   99|   Block 4
 #   99|     r99_38(suspend_always *)                      = CopyValue                                 : r99_22
 #   99|     r99_39(glval<suspend_always>)                 = CopyValue                                 : r99_38
-#-----|     r0_16(glval<suspend_always>)                  = Convert                                   : r99_39
+#-----|     r0_14(glval<suspend_always>)                  = Convert                                   : r99_39
 #   99|     r99_40(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
 #   99|     r99_41(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp99:21]               : 
 #   99|     mu99_42(coroutine_handle<promise_type>)       = Uninitialized[#temp99:21]                 : &:r99_41
@@ -1499,12 +1498,41 @@ coroutines.cpp:
 #   99|     v99_49(void)                                  = ^BufferReadSideEffect[0]                  : &:r99_46, ~m?
 #   99|     mu99_50(coroutine_handle<promise_type>)       = ^IndirectMayWriteSideEffect[-1]           : &:r99_41
 #   99|     r99_51(coroutine_handle<promise_type>)        = Load[#temp99:21]                          : &:r99_41, ~m?
-#   99|     v99_52(void)                                  = Call[await_suspend]                       : func:r99_40, this:r0_16, 0:r99_51
+#   99|     v99_52(void)                                  = Call[await_suspend]                       : func:r99_40, this:r0_14, 0:r99_51
 #   99|     mu99_53(unknown)                              = ^CallSideEffect                           : ~m?
-#-----|     v0_17(void)                                   = ^IndirectReadSideEffect[-1]               : &:r0_16, ~m?
+#-----|     v0_15(void)                                   = ^IndirectReadSideEffect[-1]               : &:r0_14, ~m?
 #-----|   Goto -> Block 3
 
-#  100|   Block 5
+#-----|   Block 5
+#-----|     r0_16(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
+#  100|     r100_9(glval<suspend_always>)  = VariableAddress[#temp100:13]              : 
+#  100|     r100_10(glval<promise_type>)   = VariableAddress[(unnamed local variable)] : 
+#  100|     r100_11(glval<unknown>)        = FunctionAddress[yield_value]              : 
+#  100|     r100_12(glval<int>)            = VariableAddress[i]                        : 
+#  100|     r100_13(int)                   = Load[i]                                   : &:r100_12, ~m?
+#  100|     r100_14(suspend_always)        = Call[yield_value]                         : func:r100_11, this:r100_10, 0:r100_13
+#  100|     mu100_15(unknown)              = ^CallSideEffect                           : ~m?
+#  100|     v100_16(void)                  = ^IndirectReadSideEffect[-1]               : &:r100_10, ~m?
+#  100|     mu100_17(promise_type)         = ^IndirectMayWriteSideEffect[-1]           : &:r100_10
+#-----|   C++ Exception -> Block 9
+#-----|   Goto -> Block 6
+
+#  100|   Block 6
+#  100|     mu100_18(suspend_always)       = Store[#temp100:13]           : &:r100_9, r100_14
+#  100|     r100_19(suspend_always *)      = CopyValue                    : r100_9
+#  100|     mu100_20(suspend_always *)     = Store[#temp0:0]              : &:r0_16, r100_19
+#-----|     r0_17(suspend_always *)        = Load[#temp0:0]               : &:r0_16, ~m?
+#  100|     r100_21(glval<suspend_always>) = CopyValue                    : r0_17
+#  100|     r100_22(glval<suspend_always>) = Convert                      : r100_21
+#  100|     r100_23(glval<unknown>)        = FunctionAddress[await_ready] : 
+#  100|     r100_24(bool)                  = Call[await_ready]            : func:r100_23, this:r100_22
+#  100|     mu100_25(unknown)              = ^CallSideEffect              : ~m?
+#  100|     v100_26(void)                  = ^IndirectReadSideEffect[-1]  : &:r100_22, ~m?
+#  100|     v100_27(void)                  = ConditionalBranch            : r100_24
+#-----|   False -> Block 8
+#-----|   True -> Block 7
+
+#  100|   Block 7
 #  100|     r100_28(suspend_always *)      = CopyValue                     : r100_19
 #  100|     r100_29(glval<suspend_always>) = CopyValue                     : r100_28
 #-----|     r0_18(glval<suspend_always>)   = Convert                       : r100_29
@@ -1512,9 +1540,9 @@ coroutines.cpp:
 #  100|     v100_31(void)                  = Call[await_resume]            : func:r100_30, this:r0_18
 #  100|     mu100_32(unknown)              = ^CallSideEffect               : ~m?
 #-----|     v0_19(void)                    = ^IndirectReadSideEffect[-1]   : &:r0_18, ~m?
-#-----|   Goto -> Block 10
+#-----|   Goto -> Block 12
 
-#  100|   Block 6
+#  100|   Block 8
 #  100|     r100_33(suspend_always *)                      = CopyValue                                 : r100_19
 #  100|     r100_34(glval<suspend_always>)                 = CopyValue                                 : r100_33
 #-----|     r0_20(glval<suspend_always>)                   = Convert                                   : r100_34
@@ -1533,31 +1561,31 @@ coroutines.cpp:
 #  100|     v100_47(void)                                  = Call[await_suspend]                       : func:r100_35, this:r0_20, 0:r100_46
 #  100|     mu100_48(unknown)                              = ^CallSideEffect                           : ~m?
 #-----|     v0_21(void)                                    = ^IndirectReadSideEffect[-1]               : &:r0_20, ~m?
-#-----|   Goto -> Block 5
+#-----|   Goto -> Block 7
 
-#-----|   Block 7
+#-----|   Block 9
 #-----|     v0_22(void)        = CatchAny                                  : 
 #-----|     r0_23(glval<bool>) = VariableAddress[(unnamed local variable)] : 
 #-----|     r0_24(bool)        = Load[(unnamed local variable)]            : &:r0_23, ~m?
 #-----|     r0_25(bool)        = LogicalNot                                : r0_24
 #-----|     v0_26(void)        = ConditionalBranch                         : r0_25
-#-----|   False -> Block 9
-#-----|   True -> Block 8
+#-----|   False -> Block 11
+#-----|   True -> Block 10
 
-#-----|   Block 8
+#-----|   Block 10
 #-----|     v0_27(void) = ReThrow : 
 #-----|   C++ Exception -> Block 2
 
-#   99|   Block 9
+#   99|   Block 11
 #   99|     r99_54(glval<promise_type>) = VariableAddress[(unnamed local variable)] : 
 #   99|     r99_55(glval<unknown>)      = FunctionAddress[unhandled_exception]      : 
 #   99|     v99_56(void)                = Call[unhandled_exception]                 : func:r99_55, this:r99_54
 #   99|     mu99_57(unknown)            = ^CallSideEffect                           : ~m?
 #   99|     v99_58(void)                = ^IndirectReadSideEffect[-1]               : &:r99_54, ~m?
 #   99|     mu99_59(promise_type)       = ^IndirectMayWriteSideEffect[-1]           : &:r99_54
-#-----|   Goto -> Block 10
+#-----|   Goto -> Block 12
 
-#-----|   Block 10
+#-----|   Block 12
 #-----|     v0_28(void)                    = NoOp                                      : 
 #   99|     r99_60(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
 #   99|     r99_61(glval<unknown>)         = FunctionAddress[final_suspend]            : 
@@ -1584,10 +1612,10 @@ coroutines.cpp:
 #   99|     mu99_80(unknown)               = ^CallSideEffect                           : ~m?
 #   99|     v99_81(void)                   = ^IndirectReadSideEffect[-1]               : &:r99_77, ~m?
 #-----|     v0_31(void)                    = ConditionalBranch                         : r99_79
-#-----|   False -> Block 12
-#-----|   True -> Block 11
+#-----|   False -> Block 14
+#-----|   True -> Block 13
 
-#   99|   Block 11
+#   99|   Block 13
 #   99|     r99_82(suspend_always *)           = CopyValue                     : r99_74
 #   99|     r99_83(glval<suspend_always>)      = CopyValue                     : r99_82
 #-----|     r0_32(glval<suspend_always>)       = Convert                       : r99_83
@@ -1599,7 +1627,7 @@ coroutines.cpp:
 #   99|     v99_88(void)                       = ReturnValue                   : &:r99_87, ~m?
 #-----|   Goto -> Block 1
 
-#   99|   Block 12
+#   99|   Block 14
 #   99|     r99_89(suspend_always *)                      = CopyValue                                 : r99_74
 #   99|     r99_90(glval<suspend_always>)                 = CopyValue                                 : r99_89
 #-----|     r0_34(glval<suspend_always>)                  = Convert                                   : r99_90
@@ -1618,7 +1646,7 @@ coroutines.cpp:
 #   99|     v99_103(void)                                 = Call[await_suspend]                       : func:r99_91, this:r0_34, 0:r99_102
 #   99|     mu99_104(unknown)                             = ^CallSideEffect                           : ~m?
 #-----|     v0_35(void)                                   = ^IndirectReadSideEffect[-1]               : &:r0_34, ~m?
-#-----|   Goto -> Block 11
+#-----|   Goto -> Block 13
 
 #  103| co_returnable_void co_yield_and_return_void(int)
 #  103|   Block 0
@@ -1689,34 +1717,13 @@ coroutines.cpp:
 #  104|     mu104_6(unknown)               = ^CallSideEffect                           : ~m?
 #  104|     v104_7(void)                   = ^IndirectReadSideEffect[-1]               : &:r104_1, ~m?
 #  104|     mu104_8(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r104_1
-#-----|     r0_14(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
-#  104|     r104_9(glval<suspend_always>)  = VariableAddress[#temp104:13]              : 
-#  104|     r104_10(glval<promise_type>)   = VariableAddress[(unnamed local variable)] : 
-#  104|     r104_11(glval<unknown>)        = FunctionAddress[yield_value]              : 
-#  104|     r104_12(glval<int>)            = VariableAddress[i]                        : 
-#  104|     r104_13(int)                   = Load[i]                                   : &:r104_12, ~m?
-#  104|     r104_14(suspend_always)        = Call[yield_value]                         : func:r104_11, this:r104_10, 0:r104_13
-#  104|     mu104_15(unknown)              = ^CallSideEffect                           : ~m?
-#  104|     v104_16(void)                  = ^IndirectReadSideEffect[-1]               : &:r104_10, ~m?
-#  104|     mu104_17(promise_type)         = ^IndirectMayWriteSideEffect[-1]           : &:r104_10
-#  104|     mu104_18(suspend_always)       = Store[#temp104:13]                        : &:r104_9, r104_14
-#  104|     r104_19(suspend_always *)      = CopyValue                                 : r104_9
-#  104|     mu104_20(suspend_always *)     = Store[#temp0:0]                           : &:r0_14, r104_19
-#-----|     r0_15(suspend_always *)        = Load[#temp0:0]                            : &:r0_14, ~m?
-#  104|     r104_21(glval<suspend_always>) = CopyValue                                 : r0_15
-#  104|     r104_22(glval<suspend_always>) = Convert                                   : r104_21
-#  104|     r104_23(glval<unknown>)        = FunctionAddress[await_ready]              : 
-#  104|     r104_24(bool)                  = Call[await_ready]                         : func:r104_23, this:r104_22
-#  104|     mu104_25(unknown)              = ^CallSideEffect                           : ~m?
-#  104|     v104_26(void)                  = ^IndirectReadSideEffect[-1]               : &:r104_22, ~m?
-#  104|     v104_27(void)                  = ConditionalBranch                         : r104_24
-#-----|   False -> Block 6
-#-----|   True -> Block 5
+#-----|   C++ Exception -> Block 10
+#-----|   Goto -> Block 5
 
 #  103|   Block 4
 #  103|     r103_38(suspend_always *)                      = CopyValue                                 : r103_22
 #  103|     r103_39(glval<suspend_always>)                 = CopyValue                                 : r103_38
-#-----|     r0_16(glval<suspend_always>)                   = Convert                                   : r103_39
+#-----|     r0_14(glval<suspend_always>)                   = Convert                                   : r103_39
 #  103|     r103_40(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
 #  103|     r103_41(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp103:20]              : 
 #  103|     mu103_42(coroutine_handle<promise_type>)       = Uninitialized[#temp103:20]                : &:r103_41
@@ -1729,12 +1736,41 @@ coroutines.cpp:
 #  103|     v103_49(void)                                  = ^BufferReadSideEffect[0]                  : &:r103_46, ~m?
 #  103|     mu103_50(coroutine_handle<promise_type>)       = ^IndirectMayWriteSideEffect[-1]           : &:r103_41
 #  103|     r103_51(coroutine_handle<promise_type>)        = Load[#temp103:20]                         : &:r103_41, ~m?
-#  103|     v103_52(void)                                  = Call[await_suspend]                       : func:r103_40, this:r0_16, 0:r103_51
+#  103|     v103_52(void)                                  = Call[await_suspend]                       : func:r103_40, this:r0_14, 0:r103_51
 #  103|     mu103_53(unknown)                              = ^CallSideEffect                           : ~m?
-#-----|     v0_17(void)                                    = ^IndirectReadSideEffect[-1]               : &:r0_16, ~m?
+#-----|     v0_15(void)                                    = ^IndirectReadSideEffect[-1]               : &:r0_14, ~m?
 #-----|   Goto -> Block 3
 
-#  104|   Block 5
+#-----|   Block 5
+#-----|     r0_16(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
+#  104|     r104_9(glval<suspend_always>)  = VariableAddress[#temp104:13]              : 
+#  104|     r104_10(glval<promise_type>)   = VariableAddress[(unnamed local variable)] : 
+#  104|     r104_11(glval<unknown>)        = FunctionAddress[yield_value]              : 
+#  104|     r104_12(glval<int>)            = VariableAddress[i]                        : 
+#  104|     r104_13(int)                   = Load[i]                                   : &:r104_12, ~m?
+#  104|     r104_14(suspend_always)        = Call[yield_value]                         : func:r104_11, this:r104_10, 0:r104_13
+#  104|     mu104_15(unknown)              = ^CallSideEffect                           : ~m?
+#  104|     v104_16(void)                  = ^IndirectReadSideEffect[-1]               : &:r104_10, ~m?
+#  104|     mu104_17(promise_type)         = ^IndirectMayWriteSideEffect[-1]           : &:r104_10
+#-----|   C++ Exception -> Block 10
+#-----|   Goto -> Block 6
+
+#  104|   Block 6
+#  104|     mu104_18(suspend_always)       = Store[#temp104:13]           : &:r104_9, r104_14
+#  104|     r104_19(suspend_always *)      = CopyValue                    : r104_9
+#  104|     mu104_20(suspend_always *)     = Store[#temp0:0]              : &:r0_16, r104_19
+#-----|     r0_17(suspend_always *)        = Load[#temp0:0]               : &:r0_16, ~m?
+#  104|     r104_21(glval<suspend_always>) = CopyValue                    : r0_17
+#  104|     r104_22(glval<suspend_always>) = Convert                      : r104_21
+#  104|     r104_23(glval<unknown>)        = FunctionAddress[await_ready] : 
+#  104|     r104_24(bool)                  = Call[await_ready]            : func:r104_23, this:r104_22
+#  104|     mu104_25(unknown)              = ^CallSideEffect              : ~m?
+#  104|     v104_26(void)                  = ^IndirectReadSideEffect[-1]  : &:r104_22, ~m?
+#  104|     v104_27(void)                  = ConditionalBranch            : r104_24
+#-----|   False -> Block 8
+#-----|   True -> Block 7
+
+#  104|   Block 7
 #  104|     r104_28(suspend_always *)      = CopyValue                                 : r104_19
 #  104|     r104_29(glval<suspend_always>) = CopyValue                                 : r104_28
 #-----|     r0_18(glval<suspend_always>)   = Convert                                   : r104_29
@@ -1748,14 +1784,13 @@ coroutines.cpp:
 #-----|     mu0_23(unknown)                = ^CallSideEffect                           : ~m?
 #-----|     v0_24(void)                    = ^IndirectReadSideEffect[-1]               : &:r0_20, ~m?
 #-----|     mu0_25(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r0_20
-#  105|     v105_1(void)                   = NoOp                                      : 
-#-----|     v0_26(void)                    = NoOp                                      : 
-#-----|   Goto (back edge) -> Block 10
+#-----|   C++ Exception -> Block 10
+#-----|   Goto -> Block 9
 
-#  104|   Block 6
+#  104|   Block 8
 #  104|     r104_33(suspend_always *)                      = CopyValue                                 : r104_19
 #  104|     r104_34(glval<suspend_always>)                 = CopyValue                                 : r104_33
-#-----|     r0_27(glval<suspend_always>)                   = Convert                                   : r104_34
+#-----|     r0_26(glval<suspend_always>)                   = Convert                                   : r104_34
 #  104|     r104_35(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
 #  104|     r104_36(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp104:3]               : 
 #  104|     mu104_37(coroutine_handle<promise_type>)       = Uninitialized[#temp104:3]                 : &:r104_36
@@ -1768,34 +1803,39 @@ coroutines.cpp:
 #  104|     v104_44(void)                                  = ^BufferReadSideEffect[0]                  : &:r104_41, ~m?
 #  104|     mu104_45(coroutine_handle<promise_type>)       = ^IndirectMayWriteSideEffect[-1]           : &:r104_36
 #  104|     r104_46(coroutine_handle<promise_type>)        = Load[#temp104:3]                          : &:r104_36, ~m?
-#  104|     v104_47(void)                                  = Call[await_suspend]                       : func:r104_35, this:r0_27, 0:r104_46
+#  104|     v104_47(void)                                  = Call[await_suspend]                       : func:r104_35, this:r0_26, 0:r104_46
 #  104|     mu104_48(unknown)                              = ^CallSideEffect                           : ~m?
-#-----|     v0_28(void)                                    = ^IndirectReadSideEffect[-1]               : &:r0_27, ~m?
-#-----|   Goto -> Block 5
+#-----|     v0_27(void)                                    = ^IndirectReadSideEffect[-1]               : &:r0_26, ~m?
+#-----|   Goto -> Block 7
 
-#-----|   Block 7
+#  105|   Block 9
+#  105|     v105_1(void) = NoOp : 
+#-----|     v0_28(void)  = NoOp : 
+#-----|   Goto (back edge) -> Block 13
+
+#-----|   Block 10
 #-----|     v0_29(void)        = CatchAny                                  : 
 #-----|     r0_30(glval<bool>) = VariableAddress[(unnamed local variable)] : 
 #-----|     r0_31(bool)        = Load[(unnamed local variable)]            : &:r0_30, ~m?
 #-----|     r0_32(bool)        = LogicalNot                                : r0_31
 #-----|     v0_33(void)        = ConditionalBranch                         : r0_32
-#-----|   False -> Block 9
-#-----|   True -> Block 8
+#-----|   False -> Block 12
+#-----|   True -> Block 11
 
-#-----|   Block 8
+#-----|   Block 11
 #-----|     v0_34(void) = ReThrow : 
 #-----|   C++ Exception -> Block 2
 
-#  103|   Block 9
+#  103|   Block 12
 #  103|     r103_54(glval<promise_type>) = VariableAddress[(unnamed local variable)] : 
 #  103|     r103_55(glval<unknown>)      = FunctionAddress[unhandled_exception]      : 
 #  103|     v103_56(void)                = Call[unhandled_exception]                 : func:r103_55, this:r103_54
 #  103|     mu103_57(unknown)            = ^CallSideEffect                           : ~m?
 #  103|     v103_58(void)                = ^IndirectReadSideEffect[-1]               : &:r103_54, ~m?
 #  103|     mu103_59(promise_type)       = ^IndirectMayWriteSideEffect[-1]           : &:r103_54
-#-----|   Goto -> Block 10
+#-----|   Goto -> Block 13
 
-#-----|   Block 10
+#-----|   Block 13
 #-----|     v0_35(void)                    = NoOp                                      : 
 #  103|     r103_60(glval<promise_type>)   = VariableAddress[(unnamed local variable)] : 
 #  103|     r103_61(glval<unknown>)        = FunctionAddress[final_suspend]            : 
@@ -1822,10 +1862,10 @@ coroutines.cpp:
 #  103|     mu103_80(unknown)              = ^CallSideEffect                           : ~m?
 #  103|     v103_81(void)                  = ^IndirectReadSideEffect[-1]               : &:r103_77, ~m?
 #-----|     v0_38(void)                    = ConditionalBranch                         : r103_79
-#-----|   False -> Block 12
-#-----|   True -> Block 11
+#-----|   False -> Block 15
+#-----|   True -> Block 14
 
-#  103|   Block 11
+#  103|   Block 14
 #  103|     r103_82(suspend_always *)          = CopyValue                     : r103_74
 #  103|     r103_83(glval<suspend_always>)     = CopyValue                     : r103_82
 #-----|     r0_39(glval<suspend_always>)       = Convert                       : r103_83
@@ -1837,7 +1877,7 @@ coroutines.cpp:
 #  103|     v103_88(void)                      = ReturnValue                   : &:r103_87, ~m?
 #-----|   Goto -> Block 1
 
-#  103|   Block 12
+#  103|   Block 15
 #  103|     r103_89(suspend_always *)                      = CopyValue                                 : r103_74
 #  103|     r103_90(glval<suspend_always>)                 = CopyValue                                 : r103_89
 #-----|     r0_41(glval<suspend_always>)                   = Convert                                   : r103_90
@@ -1856,7 +1896,7 @@ coroutines.cpp:
 #  103|     v103_103(void)                                 = Call[await_suspend]                       : func:r103_91, this:r0_41, 0:r103_102
 #  103|     mu103_104(unknown)                             = ^CallSideEffect                           : ~m?
 #-----|     v0_42(void)                                    = ^IndirectReadSideEffect[-1]               : &:r0_41, ~m?
-#-----|   Goto -> Block 11
+#-----|   Goto -> Block 14
 
 #  108| co_returnable_value co_yield_and_return_value(int)
 #  108|   Block 0
@@ -1927,34 +1967,13 @@ coroutines.cpp:
 #  109|     mu109_6(unknown)               = ^CallSideEffect                           : ~m?
 #  109|     v109_7(void)                   = ^IndirectReadSideEffect[-1]               : &:r109_1, ~m?
 #  109|     mu109_8(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r109_1
-#-----|     r0_14(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
-#  109|     r109_9(glval<suspend_always>)  = VariableAddress[#temp109:13]              : 
-#  109|     r109_10(glval<promise_type>)   = VariableAddress[(unnamed local variable)] : 
-#  109|     r109_11(glval<unknown>)        = FunctionAddress[yield_value]              : 
-#  109|     r109_12(glval<int>)            = VariableAddress[i]                        : 
-#  109|     r109_13(int)                   = Load[i]                                   : &:r109_12, ~m?
-#  109|     r109_14(suspend_always)        = Call[yield_value]                         : func:r109_11, this:r109_10, 0:r109_13
-#  109|     mu109_15(unknown)              = ^CallSideEffect                           : ~m?
-#  109|     v109_16(void)                  = ^IndirectReadSideEffect[-1]               : &:r109_10, ~m?
-#  109|     mu109_17(promise_type)         = ^IndirectMayWriteSideEffect[-1]           : &:r109_10
-#  109|     mu109_18(suspend_always)       = Store[#temp109:13]                        : &:r109_9, r109_14
-#  109|     r109_19(suspend_always *)      = CopyValue                                 : r109_9
-#  109|     mu109_20(suspend_always *)     = Store[#temp0:0]                           : &:r0_14, r109_19
-#-----|     r0_15(suspend_always *)        = Load[#temp0:0]                            : &:r0_14, ~m?
-#  109|     r109_21(glval<suspend_always>) = CopyValue                                 : r0_15
-#  109|     r109_22(glval<suspend_always>) = Convert                                   : r109_21
-#  109|     r109_23(glval<unknown>)        = FunctionAddress[await_ready]              : 
-#  109|     r109_24(bool)                  = Call[await_ready]                         : func:r109_23, this:r109_22
-#  109|     mu109_25(unknown)              = ^CallSideEffect                           : ~m?
-#  109|     v109_26(void)                  = ^IndirectReadSideEffect[-1]               : &:r109_22, ~m?
-#  109|     v109_27(void)                  = ConditionalBranch                         : r109_24
-#-----|   False -> Block 6
-#-----|   True -> Block 5
+#-----|   C++ Exception -> Block 10
+#-----|   Goto -> Block 5
 
 #  108|   Block 4
 #  108|     r108_38(suspend_always *)                      = CopyValue                                 : r108_22
 #  108|     r108_39(glval<suspend_always>)                 = CopyValue                                 : r108_38
-#-----|     r0_16(glval<suspend_always>)                   = Convert                                   : r108_39
+#-----|     r0_14(glval<suspend_always>)                   = Convert                                   : r108_39
 #  108|     r108_40(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
 #  108|     r108_41(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp108:21]              : 
 #  108|     mu108_42(coroutine_handle<promise_type>)       = Uninitialized[#temp108:21]                : &:r108_41
@@ -1967,12 +1986,41 @@ coroutines.cpp:
 #  108|     v108_49(void)                                  = ^BufferReadSideEffect[0]                  : &:r108_46, ~m?
 #  108|     mu108_50(coroutine_handle<promise_type>)       = ^IndirectMayWriteSideEffect[-1]           : &:r108_41
 #  108|     r108_51(coroutine_handle<promise_type>)        = Load[#temp108:21]                         : &:r108_41, ~m?
-#  108|     v108_52(void)                                  = Call[await_suspend]                       : func:r108_40, this:r0_16, 0:r108_51
+#  108|     v108_52(void)                                  = Call[await_suspend]                       : func:r108_40, this:r0_14, 0:r108_51
 #  108|     mu108_53(unknown)                              = ^CallSideEffect                           : ~m?
-#-----|     v0_17(void)                                    = ^IndirectReadSideEffect[-1]               : &:r0_16, ~m?
+#-----|     v0_15(void)                                    = ^IndirectReadSideEffect[-1]               : &:r0_14, ~m?
 #-----|   Goto -> Block 3
 
-#  109|   Block 5
+#-----|   Block 5
+#-----|     r0_16(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
+#  109|     r109_9(glval<suspend_always>)  = VariableAddress[#temp109:13]              : 
+#  109|     r109_10(glval<promise_type>)   = VariableAddress[(unnamed local variable)] : 
+#  109|     r109_11(glval<unknown>)        = FunctionAddress[yield_value]              : 
+#  109|     r109_12(glval<int>)            = VariableAddress[i]                        : 
+#  109|     r109_13(int)                   = Load[i]                                   : &:r109_12, ~m?
+#  109|     r109_14(suspend_always)        = Call[yield_value]                         : func:r109_11, this:r109_10, 0:r109_13
+#  109|     mu109_15(unknown)              = ^CallSideEffect                           : ~m?
+#  109|     v109_16(void)                  = ^IndirectReadSideEffect[-1]               : &:r109_10, ~m?
+#  109|     mu109_17(promise_type)         = ^IndirectMayWriteSideEffect[-1]           : &:r109_10
+#-----|   C++ Exception -> Block 10
+#-----|   Goto -> Block 6
+
+#  109|   Block 6
+#  109|     mu109_18(suspend_always)       = Store[#temp109:13]           : &:r109_9, r109_14
+#  109|     r109_19(suspend_always *)      = CopyValue                    : r109_9
+#  109|     mu109_20(suspend_always *)     = Store[#temp0:0]              : &:r0_16, r109_19
+#-----|     r0_17(suspend_always *)        = Load[#temp0:0]               : &:r0_16, ~m?
+#  109|     r109_21(glval<suspend_always>) = CopyValue                    : r0_17
+#  109|     r109_22(glval<suspend_always>) = Convert                      : r109_21
+#  109|     r109_23(glval<unknown>)        = FunctionAddress[await_ready] : 
+#  109|     r109_24(bool)                  = Call[await_ready]            : func:r109_23, this:r109_22
+#  109|     mu109_25(unknown)              = ^CallSideEffect              : ~m?
+#  109|     v109_26(void)                  = ^IndirectReadSideEffect[-1]  : &:r109_22, ~m?
+#  109|     v109_27(void)                  = ConditionalBranch            : r109_24
+#-----|   False -> Block 8
+#-----|   True -> Block 7
+
+#  109|   Block 7
 #  109|     r109_28(suspend_always *)      = CopyValue                                 : r109_19
 #  109|     r109_29(glval<suspend_always>) = CopyValue                                 : r109_28
 #-----|     r0_18(glval<suspend_always>)   = Convert                                   : r109_29
@@ -1990,14 +2038,13 @@ coroutines.cpp:
 #-----|     mu0_23(unknown)                = ^CallSideEffect                           : ~m?
 #-----|     v0_24(void)                    = ^IndirectReadSideEffect[-1]               : &:r0_20, ~m?
 #-----|     mu0_25(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r0_20
-#  110|     v110_5(void)                   = NoOp                                      : 
-#-----|     v0_26(void)                    = NoOp                                      : 
-#-----|   Goto (back edge) -> Block 10
+#-----|   C++ Exception -> Block 10
+#-----|   Goto -> Block 9
 
-#  109|   Block 6
+#  109|   Block 8
 #  109|     r109_33(suspend_always *)                      = CopyValue                                 : r109_19
 #  109|     r109_34(glval<suspend_always>)                 = CopyValue                                 : r109_33
-#-----|     r0_27(glval<suspend_always>)                   = Convert                                   : r109_34
+#-----|     r0_26(glval<suspend_always>)                   = Convert                                   : r109_34
 #  109|     r109_35(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
 #  109|     r109_36(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp109:3]               : 
 #  109|     mu109_37(coroutine_handle<promise_type>)       = Uninitialized[#temp109:3]                 : &:r109_36
@@ -2010,34 +2057,39 @@ coroutines.cpp:
 #  109|     v109_44(void)                                  = ^BufferReadSideEffect[0]                  : &:r109_41, ~m?
 #  109|     mu109_45(coroutine_handle<promise_type>)       = ^IndirectMayWriteSideEffect[-1]           : &:r109_36
 #  109|     r109_46(coroutine_handle<promise_type>)        = Load[#temp109:3]                          : &:r109_36, ~m?
-#  109|     v109_47(void)                                  = Call[await_suspend]                       : func:r109_35, this:r0_27, 0:r109_46
+#  109|     v109_47(void)                                  = Call[await_suspend]                       : func:r109_35, this:r0_26, 0:r109_46
 #  109|     mu109_48(unknown)                              = ^CallSideEffect                           : ~m?
-#-----|     v0_28(void)                                    = ^IndirectReadSideEffect[-1]               : &:r0_27, ~m?
-#-----|   Goto -> Block 5
+#-----|     v0_27(void)                                    = ^IndirectReadSideEffect[-1]               : &:r0_26, ~m?
+#-----|   Goto -> Block 7
 
-#-----|   Block 7
+#  110|   Block 9
+#  110|     v110_5(void) = NoOp : 
+#-----|     v0_28(void)  = NoOp : 
+#-----|   Goto (back edge) -> Block 13
+
+#-----|   Block 10
 #-----|     v0_29(void)        = CatchAny                                  : 
 #-----|     r0_30(glval<bool>) = VariableAddress[(unnamed local variable)] : 
 #-----|     r0_31(bool)        = Load[(unnamed local variable)]            : &:r0_30, ~m?
 #-----|     r0_32(bool)        = LogicalNot                                : r0_31
 #-----|     v0_33(void)        = ConditionalBranch                         : r0_32
-#-----|   False -> Block 9
-#-----|   True -> Block 8
+#-----|   False -> Block 12
+#-----|   True -> Block 11
 
-#-----|   Block 8
+#-----|   Block 11
 #-----|     v0_34(void) = ReThrow : 
 #-----|   C++ Exception -> Block 2
 
-#  108|   Block 9
+#  108|   Block 12
 #  108|     r108_54(glval<promise_type>) = VariableAddress[(unnamed local variable)] : 
 #  108|     r108_55(glval<unknown>)      = FunctionAddress[unhandled_exception]      : 
 #  108|     v108_56(void)                = Call[unhandled_exception]                 : func:r108_55, this:r108_54
 #  108|     mu108_57(unknown)            = ^CallSideEffect                           : ~m?
 #  108|     v108_58(void)                = ^IndirectReadSideEffect[-1]               : &:r108_54, ~m?
 #  108|     mu108_59(promise_type)       = ^IndirectMayWriteSideEffect[-1]           : &:r108_54
-#-----|   Goto -> Block 10
+#-----|   Goto -> Block 13
 
-#-----|   Block 10
+#-----|   Block 13
 #-----|     v0_35(void)                    = NoOp                                      : 
 #  108|     r108_60(glval<promise_type>)   = VariableAddress[(unnamed local variable)] : 
 #  108|     r108_61(glval<unknown>)        = FunctionAddress[final_suspend]            : 
@@ -2064,10 +2116,10 @@ coroutines.cpp:
 #  108|     mu108_80(unknown)              = ^CallSideEffect                           : ~m?
 #  108|     v108_81(void)                  = ^IndirectReadSideEffect[-1]               : &:r108_77, ~m?
 #-----|     v0_38(void)                    = ConditionalBranch                         : r108_79
-#-----|   False -> Block 12
-#-----|   True -> Block 11
+#-----|   False -> Block 15
+#-----|   True -> Block 14
 
-#  108|   Block 11
+#  108|   Block 14
 #  108|     r108_82(suspend_always *)           = CopyValue                     : r108_74
 #  108|     r108_83(glval<suspend_always>)      = CopyValue                     : r108_82
 #-----|     r0_39(glval<suspend_always>)        = Convert                       : r108_83
@@ -2079,7 +2131,7 @@ coroutines.cpp:
 #  108|     v108_88(void)                       = ReturnValue                   : &:r108_87, ~m?
 #-----|   Goto -> Block 1
 
-#  108|   Block 12
+#  108|   Block 15
 #  108|     r108_89(suspend_always *)                      = CopyValue                                 : r108_74
 #  108|     r108_90(glval<suspend_always>)                 = CopyValue                                 : r108_89
 #-----|     r0_41(glval<suspend_always>)                   = Convert                                   : r108_90
@@ -2098,7 +2150,7 @@ coroutines.cpp:
 #  108|     v108_103(void)                                 = Call[await_suspend]                       : func:r108_91, this:r0_41, 0:r108_102
 #  108|     mu108_104(unknown)                             = ^CallSideEffect                           : ~m?
 #-----|     v0_42(void)                                    = ^IndirectReadSideEffect[-1]               : &:r0_41, ~m?
-#-----|   Goto -> Block 11
+#-----|   Goto -> Block 14
 
 destructors_for_temps.cpp:
 #    9| void ClassWithConstructor::ClassWithConstructor(ClassWithConstructor&&)
@@ -6769,7 +6821,7 @@ ir.cpp:
 #  728|     r728_3(char *)          = Convert                          : r728_2
 #  728|     mu728_4(char *)         = Store[#throw728:7]               : &:r728_1, r728_3
 #  728|     v728_5(void)            = ThrowValue                       : &:r728_1, ~m?
-#-----|   C++ Exception -> Block 9
+#-----|   C++ Exception -> Block 10
 
 #  730|   Block 4
 #  730|     r730_1(glval<int>) = VariableAddress[x] : 
@@ -6777,7 +6829,7 @@ ir.cpp:
 #  730|     r730_3(int)        = Constant[2]        : 
 #  730|     r730_4(bool)       = CompareLT          : r730_2, r730_3
 #  730|     v730_5(void)       = ConditionalBranch  : r730_4
-#-----|   False -> Block 8
+#-----|   False -> Block 9
 #-----|   True -> Block 5
 
 #  731|   Block 5
@@ -6795,7 +6847,7 @@ ir.cpp:
 #  731|     r731_8(int)        = Load[#temp731:11]            : &:r731_7, ~m?
 #  731|     r731_9(glval<int>) = VariableAddress[x]           : 
 #  731|     mu731_10(int)      = Store[x]                     : &:r731_9, r731_8
-#-----|   Goto -> Block 8
+#-----|   Goto -> Block 9
 
 #  731|   Block 7
 #  731|     r731_11(glval<String>)   = VariableAddress[#throw731:19]   : 
@@ -6807,21 +6859,25 @@ ir.cpp:
 #  731|     mu731_17(unknown)        = ^CallSideEffect                 : ~m?
 #  731|     v731_18(void)            = ^BufferReadSideEffect[0]        : &:r731_15, ~m?
 #  731|     mu731_19(String)         = ^IndirectMayWriteSideEffect[-1] : &:r731_11
-#  731|     v731_20(void)            = ThrowValue                      : &:r731_11, ~m?
-#-----|   C++ Exception -> Block 9
+#-----|   C++ Exception -> Block 10
+#-----|   Goto -> Block 8
 
-#  733|   Block 8
+#  731|   Block 8
+#  731|     v731_20(void) = ThrowValue : &:r731_11, ~m?
+#-----|   C++ Exception -> Block 10
+
+#  733|   Block 9
 #  733|     r733_1(int)        = Constant[7]        : 
 #  733|     r733_2(glval<int>) = VariableAddress[x] : 
 #  733|     mu733_3(int)       = Store[x]           : &:r733_2, r733_1
-#-----|   Goto -> Block 14
-
-#  735|   Block 9
-#  735|     v735_1(void) = CatchByType[const char *] : 
-#-----|   C++ Exception -> Block 11
-#-----|   Goto -> Block 10
+#-----|   Goto -> Block 15
 
 #  735|   Block 10
+#  735|     v735_1(void) = CatchByType[const char *] : 
+#-----|   C++ Exception -> Block 12
+#-----|   Goto -> Block 11
+
+#  735|   Block 11
 #  735|     r735_2(glval<char *>)  = VariableAddress[s]              : 
 #  735|     mu735_3(char *)        = InitializeParameter[s]          : &:r735_2
 #  735|     r735_4(char *)         = Load[s]                         : &:r735_2, ~m?
@@ -6838,25 +6894,25 @@ ir.cpp:
 #  736|     v736_10(void)          = ThrowValue                      : &:r736_1, ~m?
 #-----|   C++ Exception -> Block 2
 
-#  738|   Block 11
-#  738|     v738_1(void) = CatchByType[const String &] : 
-#-----|   C++ Exception -> Block 13
-#-----|   Goto -> Block 12
-
 #  738|   Block 12
+#  738|     v738_1(void) = CatchByType[const String &] : 
+#-----|   C++ Exception -> Block 14
+#-----|   Goto -> Block 13
+
+#  738|   Block 13
 #  738|     r738_2(glval<String &>) = VariableAddress[e]       : 
 #  738|     mu738_3(String &)       = InitializeParameter[e]   : &:r738_2
 #  738|     r738_4(String &)        = Load[e]                  : &:r738_2, ~m?
 #  738|     mu738_5(unknown)        = InitializeIndirection[e] : &:r738_4
 #  738|     v738_6(void)            = NoOp                     : 
-#-----|   Goto -> Block 14
+#-----|   Goto -> Block 15
 
-#  740|   Block 13
+#  740|   Block 14
 #  740|     v740_1(void) = CatchAny : 
 #  741|     v741_1(void) = ReThrow  : 
 #-----|   C++ Exception -> Block 2
 
-#  743|   Block 14
+#  743|   Block 15
 #  743|     v743_1(void) = NoOp       : 
 #  724|     v724_9(void) = ReturnVoid : 
 #-----|   Goto -> Block 1
@@ -9439,7 +9495,7 @@ ir.cpp:
 # 1195|     r1195_3(char *)          = Convert                          : r1195_2
 # 1195|     mu1195_4(char *)         = Store[#throw1195:7]              : &:r1195_1, r1195_3
 # 1195|     v1195_5(void)            = ThrowValue                       : &:r1195_1, ~m?
-#-----|   C++ Exception -> Block 9
+#-----|   C++ Exception -> Block 10
 
 # 1197|   Block 4
 # 1197|     r1197_1(glval<int>) = VariableAddress[x] : 
@@ -9447,7 +9503,7 @@ ir.cpp:
 # 1197|     r1197_3(int)        = Constant[2]        : 
 # 1197|     r1197_4(bool)       = CompareLT          : r1197_2, r1197_3
 # 1197|     v1197_5(void)       = ConditionalBranch  : r1197_4
-#-----|   False -> Block 8
+#-----|   False -> Block 9
 #-----|   True -> Block 5
 
 # 1198|   Block 5
@@ -9465,7 +9521,7 @@ ir.cpp:
 # 1198|     r1198_8(int)        = Load[#temp1198:11]            : &:r1198_7, ~m?
 # 1198|     r1198_9(glval<int>) = VariableAddress[x]            : 
 # 1198|     mu1198_10(int)      = Store[x]                      : &:r1198_9, r1198_8
-#-----|   Goto -> Block 8
+#-----|   Goto -> Block 9
 
 # 1198|   Block 7
 # 1198|     r1198_11(glval<String>)   = VariableAddress[#throw1198:19]  : 
@@ -9477,21 +9533,25 @@ ir.cpp:
 # 1198|     mu1198_17(unknown)        = ^CallSideEffect                 : ~m?
 # 1198|     v1198_18(void)            = ^BufferReadSideEffect[0]        : &:r1198_15, ~m?
 # 1198|     mu1198_19(String)         = ^IndirectMayWriteSideEffect[-1] : &:r1198_11
-# 1198|     v1198_20(void)            = ThrowValue                      : &:r1198_11, ~m?
-#-----|   C++ Exception -> Block 9
+#-----|   C++ Exception -> Block 10
+#-----|   Goto -> Block 8
 
-# 1200|   Block 8
+# 1198|   Block 8
+# 1198|     v1198_20(void) = ThrowValue : &:r1198_11, ~m?
+#-----|   C++ Exception -> Block 10
+
+# 1200|   Block 9
 # 1200|     r1200_1(int)        = Constant[7]        : 
 # 1200|     r1200_2(glval<int>) = VariableAddress[x] : 
 # 1200|     mu1200_3(int)       = Store[x]           : &:r1200_2, r1200_1
-#-----|   Goto -> Block 13
-
-# 1202|   Block 9
-# 1202|     v1202_1(void) = CatchByType[const char *] : 
-#-----|   C++ Exception -> Block 11
-#-----|   Goto -> Block 10
+#-----|   Goto -> Block 14
 
 # 1202|   Block 10
+# 1202|     v1202_1(void) = CatchByType[const char *] : 
+#-----|   C++ Exception -> Block 12
+#-----|   Goto -> Block 11
+
+# 1202|   Block 11
 # 1202|     r1202_2(glval<char *>)  = VariableAddress[s]              : 
 # 1202|     mu1202_3(char *)        = InitializeParameter[s]          : &:r1202_2
 # 1202|     r1202_4(char *)         = Load[s]                         : &:r1202_2, ~m?
@@ -9508,20 +9568,20 @@ ir.cpp:
 # 1203|     v1203_10(void)          = ThrowValue                      : &:r1203_1, ~m?
 #-----|   C++ Exception -> Block 2
 
-# 1205|   Block 11
+# 1205|   Block 12
 # 1205|     v1205_1(void) = CatchByType[const String &] : 
 #-----|   C++ Exception -> Block 2
-#-----|   Goto -> Block 12
+#-----|   Goto -> Block 13
 
-# 1205|   Block 12
+# 1205|   Block 13
 # 1205|     r1205_2(glval<String &>) = VariableAddress[e]       : 
 # 1205|     mu1205_3(String &)       = InitializeParameter[e]   : &:r1205_2
 # 1205|     r1205_4(String &)        = Load[e]                  : &:r1205_2, ~m?
 # 1205|     mu1205_5(unknown)        = InitializeIndirection[e] : &:r1205_4
 # 1205|     v1205_6(void)            = NoOp                     : 
-#-----|   Goto -> Block 13
+#-----|   Goto -> Block 14
 
-# 1207|   Block 13
+# 1207|   Block 14
 # 1207|     v1207_1(void) = NoOp       : 
 # 1191|     v1191_9(void) = ReturnVoid : 
 #-----|   Goto -> Block 1
@@ -15699,11 +15759,8 @@ ir.cpp:
 # 2276|     v2276_4(void)           = Call[String]                    : func:r2276_3, this:r2276_1
 # 2276|     mu2276_5(unknown)       = ^CallSideEffect                 : ~m?
 # 2276|     mu2276_6(String)        = ^IndirectMayWriteSideEffect[-1] : &:r2276_1
-# 2277|     r2277_1(glval<bool>)    = VariableAddress[b]              : 
-# 2277|     r2277_2(bool)           = Load[b]                         : &:r2277_1, ~m?
-# 2277|     v2277_3(void)           = ConditionalBranch               : r2277_2
-#-----|   False -> Block 4
-#-----|   True -> Block 3
+#-----|   C++ Exception -> Block 7
+#-----|   Goto -> Block 3
 
 # 2274|   Block 1
 # 2274|     v2274_6(void) = AliasedUse   : ~m?
@@ -15713,7 +15770,14 @@ ir.cpp:
 # 2274|     v2274_8(void) = Unwind : 
 #-----|   Goto -> Block 1
 
-# 2278|   Block 3
+# 2277|   Block 3
+# 2277|     r2277_1(glval<bool>) = VariableAddress[b] : 
+# 2277|     r2277_2(bool)        = Load[b]            : &:r2277_1, ~m?
+# 2277|     v2277_3(void)        = ConditionalBranch  : r2277_2
+#-----|   False -> Block 5
+#-----|   True -> Block 4
+
+# 2278|   Block 4
 # 2278|     r2278_1(glval<char *>)   = VariableAddress[#throw2278:7]    : 
 # 2278|     r2278_2(glval<char[15]>) = StringConstant["string literal"] : 
 # 2278|     r2278_3(char *)          = Convert                          : r2278_2
@@ -15725,15 +15789,19 @@ ir.cpp:
 # 2281|     mu2281_4(unknown)        = ^CallSideEffect                  : ~m?
 # 2281|     v2281_5(void)            = ^IndirectReadSideEffect[-1]      : &:r2281_1, ~m?
 # 2281|     mu2281_6(String)         = ^IndirectMayWriteSideEffect[-1]  : &:r2281_1
-#-----|   C++ Exception -> Block 5
+#-----|   C++ Exception -> Block 7
 
-# 2280|   Block 4
-# 2280|     r2280_1(glval<String>)   = VariableAddress[s2]             : 
-# 2280|     mu2280_2(String)         = Uninitialized[s2]               : &:r2280_1
-# 2280|     r2280_3(glval<unknown>)  = FunctionAddress[String]         : 
-# 2280|     v2280_4(void)            = Call[String]                    : func:r2280_3, this:r2280_1
-# 2280|     mu2280_5(unknown)        = ^CallSideEffect                 : ~m?
-# 2280|     mu2280_6(String)         = ^IndirectMayWriteSideEffect[-1] : &:r2280_1
+# 2280|   Block 5
+# 2280|     r2280_1(glval<String>)  = VariableAddress[s2]             : 
+# 2280|     mu2280_2(String)        = Uninitialized[s2]               : &:r2280_1
+# 2280|     r2280_3(glval<unknown>) = FunctionAddress[String]         : 
+# 2280|     v2280_4(void)           = Call[String]                    : func:r2280_3, this:r2280_1
+# 2280|     mu2280_5(unknown)       = ^CallSideEffect                 : ~m?
+# 2280|     mu2280_6(String)        = ^IndirectMayWriteSideEffect[-1] : &:r2280_1
+#-----|   C++ Exception -> Block 7
+#-----|   Goto -> Block 6
+
+# 2281|   Block 6
 # 2281|     r2281_7(glval<String>)   = VariableAddress[s2]             : 
 # 2281|     r2281_8(glval<unknown>)  = FunctionAddress[~String]        : 
 # 2281|     v2281_9(void)            = Call[~String]                   : func:r2281_8, this:r2281_7
@@ -15746,14 +15814,14 @@ ir.cpp:
 # 2281|     mu2281_16(unknown)       = ^CallSideEffect                 : ~m?
 # 2281|     v2281_17(void)           = ^IndirectReadSideEffect[-1]     : &:r2281_13, ~m?
 # 2281|     mu2281_18(String)        = ^IndirectMayWriteSideEffect[-1] : &:r2281_13
-#-----|   Goto -> Block 10
+#-----|   Goto -> Block 12
 
-# 2282|   Block 5
+# 2282|   Block 7
 # 2282|     v2282_1(void) = CatchByType[const char *] : 
-#-----|   C++ Exception -> Block 7
-#-----|   Goto -> Block 6
+#-----|   C++ Exception -> Block 9
+#-----|   Goto -> Block 8
 
-# 2282|   Block 6
+# 2282|   Block 8
 # 2282|     r2282_2(glval<char *>)  = VariableAddress[s]              : 
 # 2282|     mu2282_3(char *)        = InitializeParameter[s]          : &:r2282_2
 # 2282|     r2282_4(char *)         = Load[s]                         : &:r2282_2, ~m?
@@ -15770,25 +15838,25 @@ ir.cpp:
 # 2283|     v2283_10(void)          = ThrowValue                      : &:r2283_1, ~m?
 #-----|   C++ Exception -> Block 2
 
-# 2285|   Block 7
+# 2285|   Block 9
 # 2285|     v2285_1(void) = CatchByType[const String &] : 
-#-----|   C++ Exception -> Block 9
-#-----|   Goto -> Block 8
+#-----|   C++ Exception -> Block 11
+#-----|   Goto -> Block 10
 
-# 2285|   Block 8
+# 2285|   Block 10
 # 2285|     r2285_2(glval<String &>) = VariableAddress[e]       : 
 # 2285|     mu2285_3(String &)       = InitializeParameter[e]   : &:r2285_2
 # 2285|     r2285_4(String &)        = Load[e]                  : &:r2285_2, ~m?
 # 2285|     mu2285_5(unknown)        = InitializeIndirection[e] : &:r2285_4
 # 2285|     v2285_6(void)            = NoOp                     : 
-#-----|   Goto -> Block 10
+#-----|   Goto -> Block 12
 
-# 2287|   Block 9
+# 2287|   Block 11
 # 2287|     v2287_1(void) = CatchAny : 
 # 2288|     v2288_1(void) = ReThrow  : 
 #-----|   C++ Exception -> Block 2
 
-# 2290|   Block 10
+# 2290|   Block 12
 # 2290|     v2290_1(void) = NoOp       : 
 # 2274|     v2274_9(void) = ReturnVoid : 
 #-----|   Goto -> Block 1


### PR DESCRIPTION
Same as https://github.com/github/codeql/pull/19746, but for C++ exceptions (whereas https://github.com/github/codeql/pull/19746 was for SEH exceptions).