### PR TITLE
Java: mass enable diff-informed data flow + `none()` overrides

### DIFF
--- a/java/ql/lib/semmle/code/java/security/ArbitraryApkInstallationQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/ArbitraryApkInstallationQuery.qll
@@ -23,6 +23,10 @@ module ApkInstallationConfig implements DataFlow::ConfigSig {
       )
     )
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSourceLocation(DataFlow::Node sink) { none() }
 }
 
 module ApkInstallationFlow = DataFlow::Global<ApkInstallationConfig>;

--- a/java/ql/lib/semmle/code/java/security/HardcodedCredentialsApiCallQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/HardcodedCredentialsApiCallQuery.qll
@@ -49,6 +49,8 @@ module HardcodedCredentialApiCallConfig implements DataFlow::ConfigSig {
   predicate isBarrier(DataFlow::Node n) {
     n.asExpr().(MethodCall).getMethod() instanceof MethodSystemGetenv
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/java/ql/lib/semmle/code/java/security/HardcodedCredentialsSourceCallQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/HardcodedCredentialsSourceCallQuery.qll
@@ -14,6 +14,8 @@ module HardcodedCredentialSourceCallConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node n) { n.asExpr() instanceof HardcodedExpr }
 
   predicate isSink(DataFlow::Node n) { n.asExpr() instanceof FinalCredentialsSourceSink }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/java/ql/lib/semmle/code/java/security/HttpsUrlsQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/HttpsUrlsQuery.qll
@@ -19,6 +19,8 @@ module HttpStringToUrlOpenMethodFlowConfig implements DataFlow::ConfigSig {
   }
 
   predicate isBarrier(DataFlow::Node node) { node instanceof SimpleTypeSanitizer }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/java/ql/lib/semmle/code/java/security/InsecureBasicAuthQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/InsecureBasicAuthQuery.qll
@@ -17,6 +17,8 @@ module BasicAuthFlowConfig implements DataFlow::ConfigSig {
   predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
     any(HttpUrlsAdditionalTaintStep c).step(node1, node2)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/java/ql/lib/semmle/code/java/security/SensitiveUiQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/SensitiveUiQuery.qll
@@ -19,6 +19,8 @@ private module NotificationTrackingConfig implements DataFlow::ConfigSig {
   }
 
   predicate isBarrierIn(DataFlow::Node node) { isSource(node) }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /** Taint tracking flow for sensitive data flowing to system notifications. */
@@ -75,6 +77,8 @@ private module TextFieldTrackingConfig implements DataFlow::ConfigSig {
   predicate isBarrier(DataFlow::Node node) { node instanceof SimpleTypeSanitizer }
 
   predicate isBarrierIn(DataFlow::Node node) { isSource(node) }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /** A local flow step that also flows through access to fields containing `View`s */

--- a/java/ql/lib/semmle/code/java/security/UnsafeAndroidAccessQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/UnsafeAndroidAccessQuery.qll
@@ -15,6 +15,8 @@ module FetchUntrustedResourceConfig implements DataFlow::ConfigSig {
   predicate isSink(DataFlow::Node sink) { sink instanceof UrlResourceSink }
 
   predicate isBarrier(DataFlow::Node sanitizer) { sanitizer instanceof RequestForgerySanitizer }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**


### PR DESCRIPTION
An auto-generated patch that enables diff-informed data flow in the obvious cases.

- Adds `observeDiffInformedIncrementalMode() { any() }` override to queries that don't select a location other than a dataflow source or sink.
- Adds `getASelected{Source,Sink}Location() { none() }` override to queries that select a dataflow source or sink as a location, but not both.

Java has previously had a round of diff-informed query enablements, but it seems some queries were missed in the first round.
