### PR TITLE
JS: mass enable diff-informed data flow + none() overrides

### DIFF
--- a/javascript/ql/src/experimental/Security/CWE-918/SSRF.qll
+++ b/javascript/ql/src/experimental/Security/CWE-918/SSRF.qll
@@ -34,6 +34,8 @@ module SsrfConfig implements DataFlow::ConfigSig {
   }
 
   predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSourceLocation(DataFlow::Node sink) { none() }
 }
 
 module SsrfFlow = TaintTracking::Global<SsrfConfig>;


### PR DESCRIPTION
An auto-generated patch that enables diff-informed data flow in the obvious cases.

Adds `getASelected{Source,Sink}Location() { none() }` override to a query that select a dataflow source or sink as a location, but not both.
