### PR TITLE
Python: mass enable diff-informed data flow `none()` location overrides

### DIFF
--- a/python/ql/src/experimental/Security/CWE-327/Azure/UnsafeUsageOfClientSideEncryptionVersion.ql
+++ b/python/ql/src/experimental/Security/CWE-327/Azure/UnsafeUsageOfClientSideEncryptionVersion.ql
@@ -147,6 +147,8 @@ private module AzureBlobClientConfig implements DataFlow::StateConfigSig {
   }
 
   predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSourceLocation(DataFlow::Node sink) { none() }
 }
 
 module AzureBlobClientFlow = DataFlow::GlobalWithState<AzureBlobClientConfig>;

--- a/python/ql/src/experimental/Security/CWE-346/CorsBypass.ql
+++ b/python/ql/src/experimental/Security/CWE-346/CorsBypass.ql
@@ -81,6 +81,8 @@ module CorsBypassConfig implements DataFlow::ConfigSig {
   }
 
   predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSourceLocation(DataFlow::Node sink) { none() }
 }
 
 module CorsFlow = TaintTracking::Global<CorsBypassConfig>;

--- a/python/ql/src/experimental/Security/UnsafeUnpackQuery.qll
+++ b/python/ql/src/experimental/Security/UnsafeUnpackQuery.qll
@@ -210,6 +210,8 @@ module UnsafeUnpackConfig implements DataFlow::ConfigSig {
   }
 
   predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSourceLocation(DataFlow::Node sink) { none() }
 }
 
 /** Global taint-tracking for detecting "UnsafeUnpacking" vulnerabilities. */

--- a/python/ql/src/experimental/semmle/python/security/LdapInsecureAuth.qll
+++ b/python/ql/src/experimental/semmle/python/security/LdapInsecureAuth.qll
@@ -103,6 +103,8 @@ private module LdapInsecureAuthConfig implements DataFlow::ConfigSig {
   }
 
   predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSourceLocation(DataFlow::Node sink) { none() }
 }
 
 /** Global taint-tracking for detecting "LDAP insecure authentications" vulnerabilities. */


### PR DESCRIPTION
An auto-generated patch that enables diff-informed data flow in the obvious cases.

Builds on github#18346 and github/codeql-patch#88

Adds `getASelected{Source,Sink}Location() { none() }` override to a query that select a dataflow source or sink as a location, but not both.
