### PR TITLE
Ruby: mass enable diff-informed data flow `none()` location overrides

### DIFF
--- a/ruby/ql/src/experimental/manually-check-http-verb/ManuallyCheckHttpVerb.ql
+++ b/ruby/ql/src/experimental/manually-check-http-verb/ManuallyCheckHttpVerb.ql
@@ -88,6 +88,8 @@ private module HttpVerbConfig implements DataFlow::ConfigSig {
   }
 
   predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSourceLocation(DataFlow::Node source) { none() }
 }
 
 private module HttpVerbFlow = TaintTracking::Global<HttpVerbConfig>;

--- a/ruby/ql/src/experimental/weak-params/WeakParams.ql
+++ b/ruby/ql/src/experimental/weak-params/WeakParams.ql
@@ -48,6 +48,8 @@ private module WeakParamsConfig implements DataFlow::ConfigSig {
   predicate isSink(DataFlow::Node node) { node = any(PersistentWriteAccess a).getValue() }
 
   predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSourceLocation(DataFlow::Node source) { none() }
 }
 
 private module WeakParamsFlow = TaintTracking::Global<WeakParamsConfig>;

--- a/ruby/ql/src/queries/meta/TaintedNodes.ql
+++ b/ruby/ql/src/queries/meta/TaintedNodes.ql
@@ -21,6 +21,8 @@ private module BasicTaintConfig implements DataFlow::ConfigSig {
   }
 
   predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSourceLocation(DataFlow::Node source) { none() }
 }
 
 private module BasicTaintFlow = TaintTracking::Global<BasicTaintConfig>;


### PR DESCRIPTION
An auto-generated patch that enables diff-informed data flow in the obvious cases.

Adds `getASelected{Source,Sink}Location() { none() }` override to queries that select a dataflow source or sink as a location, but not both.
