### PR TITLE
Rust: Path resolution for `crate::{self as foo}`

### DIFF
--- a/rust/ql/lib/codeql/rust/internal/PathResolution.qll
+++ b/rust/ql/lib/codeql/rust/internal/PathResolution.qll
@@ -205,7 +205,11 @@ abstract class ItemNode extends Locatable {
     else result = this.getImmediateParentModule().getImmediateParentModule()
     or
     name = "self" and
-    if this instanceof Module or this instanceof Enum or this instanceof Struct
+    if
+      this instanceof Module or
+      this instanceof Enum or
+      this instanceof Struct or
+      this instanceof Crate
     then result = this
     else result = this.getImmediateParentModule()
     or

--- a/rust/ql/test/library-tests/path-resolution/CONSISTENCY/PathResolutionConsistency.expected
+++ b/rust/ql/test/library-tests/path-resolution/CONSISTENCY/PathResolutionConsistency.expected
@@ -3,7 +3,7 @@ multiplePathResolutions
 | main.rs:118:9:118:9 | f | main.rs:110:5:112:5 | fn f |
 | main.rs:626:3:626:12 | proc_macro | file://:0:0:0:0 | Crate(proc_macro@0.0.0) |
 | main.rs:626:3:626:12 | proc_macro | proc_macro.rs:0:0:0:0 | Crate(proc_macro@0.0.1) |
-| main.rs:631:7:631:16 | proc_macro | file://:0:0:0:0 | Crate(proc_macro@0.0.0) |
-| main.rs:631:7:631:16 | proc_macro | proc_macro.rs:0:0:0:0 | Crate(proc_macro@0.0.1) |
-| main.rs:634:7:634:16 | proc_macro | file://:0:0:0:0 | Crate(proc_macro@0.0.0) |
-| main.rs:634:7:634:16 | proc_macro | proc_macro.rs:0:0:0:0 | Crate(proc_macro@0.0.1) |
+| main.rs:632:7:632:16 | proc_macro | file://:0:0:0:0 | Crate(proc_macro@0.0.0) |
+| main.rs:632:7:632:16 | proc_macro | proc_macro.rs:0:0:0:0 | Crate(proc_macro@0.0.1) |
+| main.rs:635:7:635:16 | proc_macro | file://:0:0:0:0 | Crate(proc_macro@0.0.0) |
+| main.rs:635:7:635:16 | proc_macro | proc_macro.rs:0:0:0:0 | Crate(proc_macro@0.0.1) |

--- a/rust/ql/test/library-tests/path-resolution/main.rs
+++ b/rust/ql/test/library-tests/path-resolution/main.rs
@@ -638,7 +638,7 @@ impl AStruct // $ item=I123
 
 use std::{self as ztd}; // $ item=std
 
-fn use_ztd(x: ztd::string::String) {} // $ MISSING: item=String
+fn use_ztd(x: ztd::string::String) {} // $ item=String
 
 fn main() {
     my::nested::nested1::nested2::f(); // $ item=I4

--- a/rust/ql/test/library-tests/path-resolution/main.rs
+++ b/rust/ql/test/library-tests/path-resolution/main.rs
@@ -627,13 +627,18 @@ extern crate self as zelf;
 fn z() {} // I122
 
 struct AStruct {} //I123
-impl AStruct { // $ item=I123
+impl AStruct // $ item=I123
+{
     #[proc_macro::add_suffix("on_type")] // $ item=add_suffix
     pub fn z() {} // I124
 
     #[proc_macro::add_suffix("on_instance")] // $ item=add_suffix
     pub fn z(&self) {} // I125
 }
+
+use std::{self as ztd}; // $ item=std
+
+fn use_ztd(x: ztd::string::String) {} // $ MISSING: item=String
 
 fn main() {
     my::nested::nested1::nested2::f(); // $ item=I4
@@ -667,6 +672,6 @@ fn main() {
     zelf::h(); // $ item=I25
     z_changed(); // $ MISSING: item=I122
     AStruct::z_on_type(); // $ MISSING: item=I124
-    AStruct{} // $ item=I123
+    AStruct {} // $ item=I123
         .z_on_instance(); // MISSING: item=I125
 }

--- a/rust/ql/test/library-tests/path-resolution/path-resolution.expected
+++ b/rust/ql/test/library-tests/path-resolution/path-resolution.expected
@@ -277,6 +277,10 @@ resolvePath
 | main.rs:635:7:635:16 | proc_macro | proc_macro.rs:0:0:0:0 | Crate(proc_macro@0.0.1) |
 | main.rs:635:7:635:28 | ...::add_suffix | proc_macro.rs:4:1:12:1 | fn add_suffix |
 | main.rs:639:5:639:7 | std | {EXTERNAL LOCATION} | Crate(std@0.0.0) |
+| main.rs:639:11:639:14 | self | {EXTERNAL LOCATION} | Crate(std@0.0.0) |
+| main.rs:641:15:641:17 | ztd | {EXTERNAL LOCATION} | Crate(std@0.0.0) |
+| main.rs:641:15:641:25 | ...::string | {EXTERNAL LOCATION} | mod string |
+| main.rs:641:15:641:33 | ...::String | {EXTERNAL LOCATION} | struct String |
 | main.rs:644:5:644:6 | my | main.rs:1:1:1:7 | mod my |
 | main.rs:644:5:644:14 | ...::nested | my.rs:1:1:1:15 | mod nested |
 | main.rs:644:5:644:23 | ...::nested1 | my/nested.rs:1:1:17:1 | mod nested1 |

--- a/rust/ql/test/library-tests/path-resolution/path-resolution.expected
+++ b/rust/ql/test/library-tests/path-resolution/path-resolution.expected
@@ -61,7 +61,7 @@ resolvePath
 | main.rs:30:17:30:21 | super | main.rs:18:5:36:5 | mod m2 |
 | main.rs:30:17:30:24 | ...::f | main.rs:19:9:21:9 | fn f |
 | main.rs:33:17:33:17 | f | main.rs:19:9:21:9 | fn f |
-| main.rs:40:9:40:13 | super | main.rs:1:1:672:2 | SourceFile |
+| main.rs:40:9:40:13 | super | main.rs:1:1:677:2 | SourceFile |
 | main.rs:40:9:40:17 | ...::m1 | main.rs:13:1:37:1 | mod m1 |
 | main.rs:40:9:40:21 | ...::m2 | main.rs:18:5:36:5 | mod m2 |
 | main.rs:40:9:40:24 | ...::g | main.rs:23:9:27:9 | fn g |
@@ -73,7 +73,7 @@ resolvePath
 | main.rs:61:17:61:19 | Foo | main.rs:59:9:59:21 | struct Foo |
 | main.rs:64:13:64:15 | Foo | main.rs:53:5:53:17 | struct Foo |
 | main.rs:66:5:66:5 | f | main.rs:55:5:62:5 | fn f |
-| main.rs:68:5:68:8 | self | main.rs:1:1:672:2 | SourceFile |
+| main.rs:68:5:68:8 | self | main.rs:1:1:677:2 | SourceFile |
 | main.rs:68:5:68:11 | ...::i | main.rs:71:1:83:1 | fn i |
 | main.rs:74:13:74:15 | Foo | main.rs:48:1:48:13 | struct Foo |
 | main.rs:78:16:78:18 | i32 | {EXTERNAL LOCATION} | struct i32 |
@@ -88,7 +88,7 @@ resolvePath
 | main.rs:87:57:87:66 | ...::g | my2/nested2.rs:7:9:9:9 | fn g |
 | main.rs:87:80:87:86 | nested4 | my2/nested2.rs:2:5:10:5 | mod nested4 |
 | main.rs:100:5:100:22 | f_defined_in_macro | main.rs:99:18:99:42 | fn f_defined_in_macro |
-| main.rs:117:13:117:17 | super | main.rs:1:1:672:2 | SourceFile |
+| main.rs:117:13:117:17 | super | main.rs:1:1:677:2 | SourceFile |
 | main.rs:117:13:117:21 | ...::m5 | main.rs:103:1:107:1 | mod m5 |
 | main.rs:118:9:118:9 | f | main.rs:104:5:106:5 | fn f |
 | main.rs:118:9:118:9 | f | main.rs:110:5:112:5 | fn f |
@@ -270,75 +270,76 @@ resolvePath
 | main.rs:626:3:626:12 | proc_macro | proc_macro.rs:0:0:0:0 | Crate(proc_macro@0.0.1) |
 | main.rs:626:3:626:24 | ...::add_suffix | proc_macro.rs:4:1:12:1 | fn add_suffix |
 | main.rs:630:6:630:12 | AStruct | main.rs:629:1:629:17 | struct AStruct |
-| main.rs:631:7:631:16 | proc_macro | {EXTERNAL LOCATION} | Crate(proc_macro@0.0.0) |
-| main.rs:631:7:631:16 | proc_macro | proc_macro.rs:0:0:0:0 | Crate(proc_macro@0.0.1) |
-| main.rs:631:7:631:28 | ...::add_suffix | proc_macro.rs:4:1:12:1 | fn add_suffix |
-| main.rs:634:7:634:16 | proc_macro | {EXTERNAL LOCATION} | Crate(proc_macro@0.0.0) |
-| main.rs:634:7:634:16 | proc_macro | proc_macro.rs:0:0:0:0 | Crate(proc_macro@0.0.1) |
-| main.rs:634:7:634:28 | ...::add_suffix | proc_macro.rs:4:1:12:1 | fn add_suffix |
-| main.rs:639:5:639:6 | my | main.rs:1:1:1:7 | mod my |
-| main.rs:639:5:639:14 | ...::nested | my.rs:1:1:1:15 | mod nested |
-| main.rs:639:5:639:23 | ...::nested1 | my/nested.rs:1:1:17:1 | mod nested1 |
-| main.rs:639:5:639:32 | ...::nested2 | my/nested.rs:2:5:11:5 | mod nested2 |
-| main.rs:639:5:639:35 | ...::f | my/nested.rs:3:9:5:9 | fn f |
-| main.rs:640:5:640:6 | my | main.rs:1:1:1:7 | mod my |
-| main.rs:640:5:640:9 | ...::f | my.rs:5:1:7:1 | fn f |
-| main.rs:641:5:641:11 | nested2 | my2/mod.rs:1:1:1:16 | mod nested2 |
-| main.rs:641:5:641:20 | ...::nested3 | my2/nested2.rs:1:1:11:1 | mod nested3 |
-| main.rs:641:5:641:29 | ...::nested4 | my2/nested2.rs:2:5:10:5 | mod nested4 |
-| main.rs:641:5:641:32 | ...::f | my2/nested2.rs:3:9:5:9 | fn f |
-| main.rs:642:5:642:5 | f | my2/nested2.rs:3:9:5:9 | fn f |
-| main.rs:643:5:643:5 | g | my2/nested2.rs:7:9:9:9 | fn g |
-| main.rs:644:5:644:9 | crate | main.rs:0:0:0:0 | Crate(main@0.0.1) |
-| main.rs:644:5:644:12 | ...::h | main.rs:50:1:69:1 | fn h |
-| main.rs:645:5:645:6 | m1 | main.rs:13:1:37:1 | mod m1 |
-| main.rs:645:5:645:10 | ...::m2 | main.rs:18:5:36:5 | mod m2 |
-| main.rs:645:5:645:13 | ...::g | main.rs:23:9:27:9 | fn g |
-| main.rs:646:5:646:6 | m1 | main.rs:13:1:37:1 | mod m1 |
-| main.rs:646:5:646:10 | ...::m2 | main.rs:18:5:36:5 | mod m2 |
-| main.rs:646:5:646:14 | ...::m3 | main.rs:29:9:35:9 | mod m3 |
-| main.rs:646:5:646:17 | ...::h | main.rs:30:27:34:13 | fn h |
-| main.rs:647:5:647:6 | m4 | main.rs:39:1:46:1 | mod m4 |
-| main.rs:647:5:647:9 | ...::i | main.rs:42:5:45:5 | fn i |
-| main.rs:648:5:648:5 | h | main.rs:50:1:69:1 | fn h |
-| main.rs:649:5:649:11 | f_alias | my2/nested2.rs:3:9:5:9 | fn f |
-| main.rs:650:5:650:11 | g_alias | my2/nested2.rs:7:9:9:9 | fn g |
-| main.rs:651:5:651:5 | j | main.rs:97:1:101:1 | fn j |
-| main.rs:652:5:652:6 | m6 | main.rs:109:1:120:1 | mod m6 |
-| main.rs:652:5:652:9 | ...::g | main.rs:114:5:119:5 | fn g |
-| main.rs:653:5:653:6 | m7 | main.rs:122:1:141:1 | mod m7 |
-| main.rs:653:5:653:9 | ...::f | main.rs:133:5:140:5 | fn f |
-| main.rs:654:5:654:6 | m8 | main.rs:143:1:197:1 | mod m8 |
-| main.rs:654:5:654:9 | ...::g | main.rs:181:5:196:5 | fn g |
-| main.rs:655:5:655:6 | m9 | main.rs:199:1:207:1 | mod m9 |
-| main.rs:655:5:655:9 | ...::f | main.rs:202:5:206:5 | fn f |
-| main.rs:656:5:656:7 | m11 | main.rs:230:1:267:1 | mod m11 |
-| main.rs:656:5:656:10 | ...::f | main.rs:235:5:238:5 | fn f |
-| main.rs:657:5:657:7 | m15 | main.rs:298:1:352:1 | mod m15 |
-| main.rs:657:5:657:10 | ...::f | main.rs:339:5:351:5 | fn f |
-| main.rs:658:5:658:7 | m16 | main.rs:354:1:446:1 | mod m16 |
-| main.rs:658:5:658:10 | ...::f | main.rs:421:5:445:5 | fn f |
-| main.rs:659:5:659:7 | m17 | main.rs:448:1:478:1 | mod m17 |
-| main.rs:659:5:659:10 | ...::f | main.rs:472:5:477:5 | fn f |
-| main.rs:660:5:660:11 | nested6 | my2/nested2.rs:14:5:18:5 | mod nested6 |
-| main.rs:660:5:660:14 | ...::f | my2/nested2.rs:15:9:17:9 | fn f |
-| main.rs:661:5:661:11 | nested8 | my2/nested2.rs:22:5:26:5 | mod nested8 |
-| main.rs:661:5:661:14 | ...::f | my2/nested2.rs:23:9:25:9 | fn f |
-| main.rs:662:5:662:7 | my3 | my2/mod.rs:12:1:12:12 | mod my3 |
-| main.rs:662:5:662:10 | ...::f | my2/my3/mod.rs:1:1:5:1 | fn f |
-| main.rs:663:5:663:12 | nested_f | my/my4/my5/mod.rs:1:1:3:1 | fn f |
-| main.rs:664:5:664:7 | m18 | main.rs:480:1:498:1 | mod m18 |
-| main.rs:664:5:664:12 | ...::m19 | main.rs:485:5:497:5 | mod m19 |
-| main.rs:664:5:664:17 | ...::m20 | main.rs:490:9:496:9 | mod m20 |
-| main.rs:664:5:664:20 | ...::g | main.rs:491:13:495:13 | fn g |
-| main.rs:665:5:665:7 | m23 | main.rs:527:1:552:1 | mod m23 |
-| main.rs:665:5:665:10 | ...::f | main.rs:547:5:551:5 | fn f |
-| main.rs:666:5:666:7 | m24 | main.rs:554:1:622:1 | mod m24 |
-| main.rs:666:5:666:10 | ...::f | main.rs:608:5:621:5 | fn f |
-| main.rs:667:5:667:8 | zelf | main.rs:0:0:0:0 | Crate(main@0.0.1) |
-| main.rs:667:5:667:11 | ...::h | main.rs:50:1:69:1 | fn h |
-| main.rs:669:5:669:11 | AStruct | main.rs:629:1:629:17 | struct AStruct |
-| main.rs:670:5:670:11 | AStruct | main.rs:629:1:629:17 | struct AStruct |
+| main.rs:632:7:632:16 | proc_macro | {EXTERNAL LOCATION} | Crate(proc_macro@0.0.0) |
+| main.rs:632:7:632:16 | proc_macro | proc_macro.rs:0:0:0:0 | Crate(proc_macro@0.0.1) |
+| main.rs:632:7:632:28 | ...::add_suffix | proc_macro.rs:4:1:12:1 | fn add_suffix |
+| main.rs:635:7:635:16 | proc_macro | {EXTERNAL LOCATION} | Crate(proc_macro@0.0.0) |
+| main.rs:635:7:635:16 | proc_macro | proc_macro.rs:0:0:0:0 | Crate(proc_macro@0.0.1) |
+| main.rs:635:7:635:28 | ...::add_suffix | proc_macro.rs:4:1:12:1 | fn add_suffix |
+| main.rs:639:5:639:7 | std | {EXTERNAL LOCATION} | Crate(std@0.0.0) |
+| main.rs:644:5:644:6 | my | main.rs:1:1:1:7 | mod my |
+| main.rs:644:5:644:14 | ...::nested | my.rs:1:1:1:15 | mod nested |
+| main.rs:644:5:644:23 | ...::nested1 | my/nested.rs:1:1:17:1 | mod nested1 |
+| main.rs:644:5:644:32 | ...::nested2 | my/nested.rs:2:5:11:5 | mod nested2 |
+| main.rs:644:5:644:35 | ...::f | my/nested.rs:3:9:5:9 | fn f |
+| main.rs:645:5:645:6 | my | main.rs:1:1:1:7 | mod my |
+| main.rs:645:5:645:9 | ...::f | my.rs:5:1:7:1 | fn f |
+| main.rs:646:5:646:11 | nested2 | my2/mod.rs:1:1:1:16 | mod nested2 |
+| main.rs:646:5:646:20 | ...::nested3 | my2/nested2.rs:1:1:11:1 | mod nested3 |
+| main.rs:646:5:646:29 | ...::nested4 | my2/nested2.rs:2:5:10:5 | mod nested4 |
+| main.rs:646:5:646:32 | ...::f | my2/nested2.rs:3:9:5:9 | fn f |
+| main.rs:647:5:647:5 | f | my2/nested2.rs:3:9:5:9 | fn f |
+| main.rs:648:5:648:5 | g | my2/nested2.rs:7:9:9:9 | fn g |
+| main.rs:649:5:649:9 | crate | main.rs:0:0:0:0 | Crate(main@0.0.1) |
+| main.rs:649:5:649:12 | ...::h | main.rs:50:1:69:1 | fn h |
+| main.rs:650:5:650:6 | m1 | main.rs:13:1:37:1 | mod m1 |
+| main.rs:650:5:650:10 | ...::m2 | main.rs:18:5:36:5 | mod m2 |
+| main.rs:650:5:650:13 | ...::g | main.rs:23:9:27:9 | fn g |
+| main.rs:651:5:651:6 | m1 | main.rs:13:1:37:1 | mod m1 |
+| main.rs:651:5:651:10 | ...::m2 | main.rs:18:5:36:5 | mod m2 |
+| main.rs:651:5:651:14 | ...::m3 | main.rs:29:9:35:9 | mod m3 |
+| main.rs:651:5:651:17 | ...::h | main.rs:30:27:34:13 | fn h |
+| main.rs:652:5:652:6 | m4 | main.rs:39:1:46:1 | mod m4 |
+| main.rs:652:5:652:9 | ...::i | main.rs:42:5:45:5 | fn i |
+| main.rs:653:5:653:5 | h | main.rs:50:1:69:1 | fn h |
+| main.rs:654:5:654:11 | f_alias | my2/nested2.rs:3:9:5:9 | fn f |
+| main.rs:655:5:655:11 | g_alias | my2/nested2.rs:7:9:9:9 | fn g |
+| main.rs:656:5:656:5 | j | main.rs:97:1:101:1 | fn j |
+| main.rs:657:5:657:6 | m6 | main.rs:109:1:120:1 | mod m6 |
+| main.rs:657:5:657:9 | ...::g | main.rs:114:5:119:5 | fn g |
+| main.rs:658:5:658:6 | m7 | main.rs:122:1:141:1 | mod m7 |
+| main.rs:658:5:658:9 | ...::f | main.rs:133:5:140:5 | fn f |
+| main.rs:659:5:659:6 | m8 | main.rs:143:1:197:1 | mod m8 |
+| main.rs:659:5:659:9 | ...::g | main.rs:181:5:196:5 | fn g |
+| main.rs:660:5:660:6 | m9 | main.rs:199:1:207:1 | mod m9 |
+| main.rs:660:5:660:9 | ...::f | main.rs:202:5:206:5 | fn f |
+| main.rs:661:5:661:7 | m11 | main.rs:230:1:267:1 | mod m11 |
+| main.rs:661:5:661:10 | ...::f | main.rs:235:5:238:5 | fn f |
+| main.rs:662:5:662:7 | m15 | main.rs:298:1:352:1 | mod m15 |
+| main.rs:662:5:662:10 | ...::f | main.rs:339:5:351:5 | fn f |
+| main.rs:663:5:663:7 | m16 | main.rs:354:1:446:1 | mod m16 |
+| main.rs:663:5:663:10 | ...::f | main.rs:421:5:445:5 | fn f |
+| main.rs:664:5:664:7 | m17 | main.rs:448:1:478:1 | mod m17 |
+| main.rs:664:5:664:10 | ...::f | main.rs:472:5:477:5 | fn f |
+| main.rs:665:5:665:11 | nested6 | my2/nested2.rs:14:5:18:5 | mod nested6 |
+| main.rs:665:5:665:14 | ...::f | my2/nested2.rs:15:9:17:9 | fn f |
+| main.rs:666:5:666:11 | nested8 | my2/nested2.rs:22:5:26:5 | mod nested8 |
+| main.rs:666:5:666:14 | ...::f | my2/nested2.rs:23:9:25:9 | fn f |
+| main.rs:667:5:667:7 | my3 | my2/mod.rs:12:1:12:12 | mod my3 |
+| main.rs:667:5:667:10 | ...::f | my2/my3/mod.rs:1:1:5:1 | fn f |
+| main.rs:668:5:668:12 | nested_f | my/my4/my5/mod.rs:1:1:3:1 | fn f |
+| main.rs:669:5:669:7 | m18 | main.rs:480:1:498:1 | mod m18 |
+| main.rs:669:5:669:12 | ...::m19 | main.rs:485:5:497:5 | mod m19 |
+| main.rs:669:5:669:17 | ...::m20 | main.rs:490:9:496:9 | mod m20 |
+| main.rs:669:5:669:20 | ...::g | main.rs:491:13:495:13 | fn g |
+| main.rs:670:5:670:7 | m23 | main.rs:527:1:552:1 | mod m23 |
+| main.rs:670:5:670:10 | ...::f | main.rs:547:5:551:5 | fn f |
+| main.rs:671:5:671:7 | m24 | main.rs:554:1:622:1 | mod m24 |
+| main.rs:671:5:671:10 | ...::f | main.rs:608:5:621:5 | fn f |
+| main.rs:672:5:672:8 | zelf | main.rs:0:0:0:0 | Crate(main@0.0.1) |
+| main.rs:672:5:672:11 | ...::h | main.rs:50:1:69:1 | fn h |
+| main.rs:674:5:674:11 | AStruct | main.rs:629:1:629:17 | struct AStruct |
+| main.rs:675:5:675:11 | AStruct | main.rs:629:1:629:17 | struct AStruct |
 | my2/mod.rs:5:5:5:11 | nested2 | my2/mod.rs:1:1:1:16 | mod nested2 |
 | my2/mod.rs:5:5:5:20 | ...::nested3 | my2/nested2.rs:1:1:11:1 | mod nested3 |
 | my2/mod.rs:5:5:5:29 | ...::nested4 | my2/nested2.rs:2:5:10:5 | mod nested4 |
@@ -354,7 +355,7 @@ resolvePath
 | my2/my3/mod.rs:3:5:3:5 | g | my2/mod.rs:3:1:6:1 | fn g |
 | my2/my3/mod.rs:4:5:4:5 | h | main.rs:50:1:69:1 | fn h |
 | my2/my3/mod.rs:7:5:7:9 | super | my2/mod.rs:1:1:17:30 | SourceFile |
-| my2/my3/mod.rs:7:5:7:16 | ...::super | main.rs:1:1:672:2 | SourceFile |
+| my2/my3/mod.rs:7:5:7:16 | ...::super | main.rs:1:1:677:2 | SourceFile |
 | my2/my3/mod.rs:7:5:7:19 | ...::h | main.rs:50:1:69:1 | fn h |
 | my2/my3/mod.rs:8:5:8:9 | super | my2/mod.rs:1:1:17:30 | SourceFile |
 | my2/my3/mod.rs:8:5:8:12 | ...::g | my2/mod.rs:3:1:6:1 | fn g |


### PR DESCRIPTION
For example, `use std::{self as ztd}` introduces `ztd` as an alias for `std`.