### PR TITLE
JS: Update Fastify tld

### DIFF
--- a/javascript/ql/lib/semmle/javascript/frameworks/Fastify.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Fastify.qll
@@ -1,12 +1,12 @@
 /**
- * Provides classes for working with [Fastify](https://www.fastify.io/) applications.
+ * Provides classes for working with [Fastify](https://www.fastify.dev/) applications.
  */
 
 import javascript
 import semmle.javascript.frameworks.HTTP
 
 /**
- * Provides classes for working with [Fastify](https://www.fastify.io/) applications.
+ * Provides classes for working with [Fastify](https://www.fastify.dev/) applications.
  */
 module Fastify {
   /**


### PR DESCRIPTION
Fastify moved from fastify.io to fastify.dev at the end of 2023.

fastify.io currently redirects to fastify.dev, but this may change in the future. :)