### PR TITLE
Rust: fix nightly toolchain version for tests using it

### DIFF
--- a/rust/extractor/src/config.rs
+++ b/rust/extractor/src/config.rs
@@ -62,6 +62,7 @@ pub struct Config {
     pub qltest: bool,
     pub qltest_cargo_check: bool,
     pub qltest_dependencies: Vec<String>,
+    pub qltest_use_nightly: bool,
     pub sysroot: Option<PathBuf>,
     pub sysroot_src: Option<PathBuf>,
     pub rustc_src: Option<PathBuf>,

--- a/rust/extractor/src/qltest.rs
+++ b/rust/extractor/src/qltest.rs
@@ -8,6 +8,9 @@ use std::path::Path;
 use std::process::Command;
 use tracing::info;
 
+const EDITION: &str = "2021";
+const NIGHTLY: &str = "nightly-2025-06-01";
+
 fn dump_lib() -> anyhow::Result<()> {
     let path_iterator = glob("*.rs").context("globbing test sources")?;
     let paths = path_iterator
@@ -29,8 +32,11 @@ enum TestCargoManifest<'a> {
         uses_proc_macro: bool,
         uses_main: bool,
         dependencies: &'a [String],
+        edition: &'a str,
     },
-    Macro {},
+    Macro {
+        edition: &'a str,
+    },
 }
 
 impl TestCargoManifest<'_> {
@@ -56,14 +62,24 @@ fn dump_cargo_manifest(dependencies: &[String]) -> anyhow::Result<()> {
         uses_proc_macro,
         uses_main: fs::exists("main.rs").context("checking existence of main.rs")?,
         dependencies,
+        edition: EDITION,
     };
     if uses_proc_macro {
         TestCargoManifest::Workspace {}.dump("")?;
         lib_manifest.dump(".lib")?;
-        TestCargoManifest::Macro {}.dump(".proc_macro")
+        TestCargoManifest::Macro { edition: EDITION }.dump(".proc_macro")
     } else {
         lib_manifest.dump("")
     }
+}
+
+fn dump_nightly_toolchain() -> anyhow::Result<()> {
+    fs::write(
+        "rust-toolchain.toml",
+        format!("[toolchain]\nchannel = \"{NIGHTLY}\"\n"),
+    )
+    .context("writing rust-toolchain.toml")?;
+    Ok(())
 }
 
 fn set_sources(config: &mut Config) -> anyhow::Result<()> {
@@ -79,6 +95,9 @@ pub(crate) fn prepare(config: &mut Config) -> anyhow::Result<()> {
     dump_lib()?;
     set_sources(config)?;
     dump_cargo_manifest(&config.qltest_dependencies)?;
+    if config.qltest_use_nightly {
+        dump_nightly_toolchain()?;
+    }
     if config.qltest_cargo_check {
         let status = Command::new("cargo")
             .env("RUSTFLAGS", "-Awarnings")

--- a/rust/extractor/src/qltest_cargo.mustache
+++ b/rust/extractor/src/qltest_cargo.mustache
@@ -11,7 +11,7 @@ members = [".lib", ".proc_macro"]
 [package]
 name = "test"
 version = "0.0.1"
-edition = "2021"
+edition = "{{ edition }}"
 [lib]
 path = "{{#uses_proc_macro}}../{{/uses_proc_macro}}lib.rs"
 {{#uses_main}}
@@ -32,7 +32,7 @@ proc_macro = { path = "../.proc_macro" }
 [package]
 name = "proc_macro"
 version = "0.0.1"
-edition = "2021"
+edition = "{{ edition }}"
 [lib]
 path = "../proc_macro.rs"
 proc_macro = true

--- a/rust/ql/test/.gitignore
+++ b/rust/ql/test/.gitignore
@@ -1,6 +1,9 @@
-Cargo.toml
-lib.rs
 target/
+
+# these are all generated, see `rust/extractor/src/qltest.rs` for details
+Cargo.toml
+rust-toolchain.toml
+lib.rs
 .proc_macro/
 .lib/
 

--- a/rust/ql/test/query-tests/security/CWE-022/options.yml
+++ b/rust/ql/test/query-tests/security/CWE-022/options.yml
@@ -1,2 +1,3 @@
+qltest_use_nightly: true
 qltest_dependencies:
     - poem = { version = "3.1.7" }

--- a/rust/ql/test/query-tests/security/CWE-022/rust-toolchain.toml
+++ b/rust/ql/test/query-tests/security/CWE-022/rust-toolchain.toml
@@ -1,8 +1,0 @@
-# This file specifies the Rust version used to develop and test the
-# extractors written in rust. It is set to the lowest version of Rust
-# we want to support.
-
-[toolchain]
-channel = "nightly"
-profile = "minimal"
-components = [ ]

--- a/rust/ql/test/query-tests/security/CWE-770/options.yml
+++ b/rust/ql/test/query-tests/security/CWE-770/options.yml
@@ -1,3 +1,3 @@
-qltest_cargo_check: true
+qltest_use_nightly: true
 qltest_dependencies:
     - libc = { version = "0.2.11" }

--- a/rust/ql/test/query-tests/security/CWE-770/rust-toolchain.toml
+++ b/rust/ql/test/query-tests/security/CWE-770/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "nightly"

--- a/rust/ql/test/query-tests/security/CWE-825/CONSISTENCY/PathResolutionConsistency.expected
+++ b/rust/ql/test/query-tests/security/CWE-825/CONSISTENCY/PathResolutionConsistency.expected
@@ -1,13 +1,13 @@
 multiplePathResolutions
-| deallocation.rs:106:16:106:19 | libc | file://:0:0:0:0 | Crate(libc@0.2.171) |
+| deallocation.rs:106:16:106:19 | libc | file://:0:0:0:0 | Crate(libc@0.2.172) |
 | deallocation.rs:106:16:106:19 | libc | file://:0:0:0:0 | Crate(libc@0.2.173) |
 | deallocation.rs:106:16:106:27 | ...::malloc | file://:0:0:0:0 | fn malloc |
 | deallocation.rs:106:16:106:27 | ...::malloc | file://:0:0:0:0 | fn malloc |
-| deallocation.rs:112:3:112:6 | libc | file://:0:0:0:0 | Crate(libc@0.2.171) |
+| deallocation.rs:112:3:112:6 | libc | file://:0:0:0:0 | Crate(libc@0.2.172) |
 | deallocation.rs:112:3:112:6 | libc | file://:0:0:0:0 | Crate(libc@0.2.173) |
 | deallocation.rs:112:3:112:12 | ...::free | file://:0:0:0:0 | fn free |
 | deallocation.rs:112:3:112:12 | ...::free | file://:0:0:0:0 | fn free |
-| deallocation.rs:112:29:112:32 | libc | file://:0:0:0:0 | Crate(libc@0.2.171) |
+| deallocation.rs:112:29:112:32 | libc | file://:0:0:0:0 | Crate(libc@0.2.172) |
 | deallocation.rs:112:29:112:32 | libc | file://:0:0:0:0 | Crate(libc@0.2.173) |
 | deallocation.rs:260:11:260:22 | ...::from | file://:0:0:0:0 | fn from |
 | deallocation.rs:260:11:260:22 | ...::from | file://:0:0:0:0 | fn from |

--- a/rust/ql/test/query-tests/security/CWE-825/options.yml
+++ b/rust/ql/test/query-tests/security/CWE-825/options.yml
@@ -1,3 +1,3 @@
-qltest_cargo_check: true
+qltest_use_nightly: true
 qltest_dependencies:
     - libc = { version = "0.2.11" }

--- a/rust/ql/test/query-tests/security/CWE-825/rust-toolchain.toml
+++ b/rust/ql/test/query-tests/security/CWE-825/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "nightly-2025-03-17"


### PR DESCRIPTION
Rather than fixing the version separately for each test, we can just request to use a nightly in the `options.yml` file, with the specific version hard-coded in `qltest.rs`. We can update it if we need to.

It's better to have a single nightly version for all tests that require it, in order to avoid downloading more versions than necessary.

Also removed some uneeded cargo check requests, as that flag is true by default on all tests.