### PR TITLE
Java: Diff-informed CleartextStorageCookie.ql

### DIFF
--- a/java/ql/lib/semmle/code/java/security/CleartextStorageCookieQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/CleartextStorageCookieQuery.qll
@@ -7,7 +7,17 @@ private import semmle.code.java.dataflow.FlowSinks
 private import semmle.code.java.dataflow.FlowSources
 
 private class CookieCleartextStorageSink extends CleartextStorageSink {
-  CookieCleartextStorageSink() { this.asExpr() = cookieInput(_) }
+  Cookie cookie;
+
+  CookieCleartextStorageSink() { this.asExpr() = cookieInput(cookie) }
+
+  override Location getASelectedLocation() {
+    result = this.getLocation()
+    or
+    result = cookie.getLocation()
+    or
+    result = cookie.getAStore().getLocation()
+  }
 }
 
 /** The instantiation of a cookie, which can act as storage. */


### PR DESCRIPTION
I picked this commit out of #17846 because it doesn't rely on any of the controversial API changes that are holding back that PR. It appears there are no tests for `CleartextStorageCookie.ql`.

> This query shares implementation with several other queries about cleartext storage, but it's the only one of them that's in the code-scanning suite. The sharing mechanism remains the same as before, but now each query has to override `getASelectedLocation` to become diff-informed.
>
> Two other data-flow configurations are used in this query, but they can't easily be made diff-informed.
