### PR TITLE
JS: Remote mention of Element MaD token

### DIFF
--- a/docs/codeql/codeql-language-guides/customizing-library-models-for-javascript.rst
+++ b/docs/codeql/codeql-language-guides/customizing-library-models-for-javascript.rst
@@ -517,7 +517,6 @@ The following components are supported:
 - **Member[**\ `name`\ **]** selects the property with the given name.
 - **AnyMember** selects any property regardless of name.
 - **ArrayElement** selects an element of an array.
-- **Element** selects an element of an array, iterator, or set object.
 - **MapValue** selects a value of a map object.
 - **Awaited** selects the value of a promise.
 - **Instance** selects instances of a class, including instances of its subclasses.


### PR DESCRIPTION
This is not supported in JS. There was once an ambition that all languages should have `Element`, but it was not possible to implement it consistently for maps/dictionaries. I think it's better to just remove the mention from the docs.