### PR TITLE
Rust: refactor `ast-generator` to have all customization at the start

### DIFF
--- a/rust/ast-generator/src/field_info.rs
+++ b/rust/ast-generator/src/field_info.rs
@@ -1,0 +1,50 @@
+#[derive(Eq, PartialEq)]
+pub enum FieldType {
+    String,
+    Predicate,
+    Optional(String),
+    Body(String),
+    List(String),
+}
+
+pub struct FieldInfo {
+    pub name: String,
+    pub ty: FieldType,
+}
+
+impl FieldInfo {
+    pub fn optional(name: &str, ty: &str) -> FieldInfo {
+        FieldInfo {
+            name: name.to_string(),
+            ty: FieldType::Optional(ty.to_string()),
+        }
+    }
+
+    pub fn body(name: &str, ty: &str) -> FieldInfo {
+        FieldInfo {
+            name: name.to_string(),
+            ty: FieldType::Body(ty.to_string()),
+        }
+    }
+
+    pub fn string(name: &str) -> FieldInfo {
+        FieldInfo {
+            name: name.to_string(),
+            ty: FieldType::String,
+        }
+    }
+
+    pub fn predicate(name: &str) -> FieldInfo {
+        FieldInfo {
+            name: name.to_string(),
+            ty: FieldType::Predicate,
+        }
+    }
+
+    pub fn list(name: &str, ty: &str) -> FieldInfo {
+        FieldInfo {
+            name: name.to_string(),
+            ty: FieldType::List(ty.to_string()),
+        }
+    }
+}


### PR DESCRIPTION
This makes it so that all customization of the `ast-generator` is written down in functions at the very start of `main.rs`. This should make it somewhat easier to maintain and tweak it in the future.