### PR TITLE
pick-kotlin-version.py: tolerate warnings

### DIFF
--- a/java/kotlin-extractor/pick-kotlin-version.py
+++ b/java/kotlin-extractor/pick-kotlin-version.py
@@ -26,7 +26,7 @@ if kotlinc is None:
 res = subprocess.run([kotlinc, "-version"], text=True, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
 if res.returncode != 0:
     raise Exception(f"kotlinc -version failed: {res.stderr}")
-m = re.match(r'.* kotlinc-jvm ([0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z][a-zA-Z0-9]*)?) .*', res.stderr)
+m = re.search(r' kotlinc-jvm ([0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z][a-zA-Z0-9]*)?) ', res.stderr)
 if m is None:
     raise Exception(f'Cannot detect version of kotlinc (got {res.stderr})')
 version = m[1]


### PR DESCRIPTION
This PR changes `pick-kotlin-version.py` to use re.search() instead of re.match(), so that it can better cope with warning messages.

Running `pick-kotlin-version.py` with JRE 24, without this PR:
```
Traceback (most recent call last):
  File "codeql/java/kotlin-extractor/pick-kotlin-version.py", line 31, in <module>
    raise Exception(f'Cannot detect version of kotlinc (got {res.stderr})')
Exception: Cannot detect version of kotlinc (got WARNING: A restricted method in java.lang.System has been called
WARNING: java.lang.System::load has been called by org.fusesource.jansi.internal.JansiLoader in an unnamed module
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
WARNING: Restricted methods will be blocked in a future release unless native access is enabled

info: kotlinc-jvm 2.2.0 (JRE 24.0.1)
WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::objectFieldOffset has been called by com.intellij.util.containers.Unsafe
WARNING: Please consider reporting this to the maintainers of class com.intellij.util.containers.Unsafe
WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release
)
```

Running `pick-kotlin-version.py` with JRE 24, with this PR:
```
2.2.0
```
