### PR TITLE
Overlay: Enable overlay compilation for Java

### DIFF
--- a/java/ql/lib/qlpack.yml
+++ b/java/ql/lib/qlpack.yml
@@ -23,3 +23,4 @@ dataExtensions:
   - ext/generated/*.model.yml
   - ext/experimental/*.model.yml
 warnOnImplicitThis: true
+compileForOverlayEval: true


### PR DESCRIPTION
This PR enables overlay compilation for Java. With overlay compilation enabled, the compiler will model the overlay frontier throughout optimisation passes and generate QLX that supports both non-overlay aware evaluation and overlay aware evaluation. The current non-overlay aware evaluation will remain the default. Enabling overlay compilation will not affect semantics under non-overlay aware evaluation, but may affect performance as some previously valid optimisations are no longer valid under overlay compilation. 

Previous DCA experiments identified two real regressions stemming from TC bounds and magic bounds that were hampered by the overlay frontier. The TC bound regressions both involved use of `DataFlow::localExprFlow` and affected 2 queries. The TC bound regressions were fixed client-side by marking the [callers `overlay[local?]`](https://github.com/github/codeql/pull/19968). The magic bounds issue affected all 11 queries that use `RefType.getAStrictAncestor`. The magic bounds issue was fixed callee-side by [marking `getAStrictAncestor` `overlay[caller?]`](https://github.com/github/codeql/pull/19968), in case any custom queries similarly rely on magic bounds for proper performance of `getAStrictAncestor`. 

With the fixes above, [DCA](https://github.com/github/codeql-dca-main/tree/data/kaspersv/pr-19872-10a678__nightly__nightly/reports#analysis-time-per-source) [experiments](https://github.com/github/codeql-dca-main/tree/data/kaspersv/pr-19872-10a678__nightly__nightly-rev/reports#analysis-time-per-source) shows an overall regression below 0.6%. `apache/commons-*` sources show large variability ranging from 25% regressions to 25% improvements. Note that the two latest DCA experiments are equivalent, except with base and variant swapped for the `-rev` experiment. 

DIL size increases are expected, due to the additional HOPs to model the overlay frontier, discard predicates and helpers that can't get inlined across the overlay frontier. 