### PR TITLE
Rust: fix parallel execution of tests using the nightly toolchain

### DIFF
--- a/rust/extractor/BUILD.bazel
+++ b/rust/extractor/BUILD.bazel
@@ -7,7 +7,10 @@ codeql_rust_binary(
     name = "extractor",
     srcs = glob(["src/**/*.rs"]),
     aliases = aliases(),
-    compile_data = ["src/qltest_cargo.mustache"],
+    compile_data = [
+        "src/qltest_cargo.mustache",
+        "src/nightly-toolchain/rust-toolchain.toml",
+    ],
     proc_macro_deps = all_crate_deps(
         proc_macro = True,
     ) + [

--- a/rust/extractor/src/nightly-toolchain/rust-toolchain.toml
+++ b/rust/extractor/src/nightly-toolchain/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2025-06-01"
+components = [ "rust-src" ]

--- a/rust/extractor/src/qltest.rs
+++ b/rust/extractor/src/qltest.rs
@@ -9,7 +9,6 @@ use std::process::Command;
 use tracing::info;
 
 const EDITION: &str = "2021";
-const NIGHTLY: &str = "nightly-2025-06-01";
 
 fn dump_lib() -> anyhow::Result<()> {
     let path_iterator = glob("*.rs").context("globbing test sources")?;
@@ -76,7 +75,7 @@ fn dump_cargo_manifest(dependencies: &[String]) -> anyhow::Result<()> {
 fn dump_nightly_toolchain() -> anyhow::Result<()> {
     fs::write(
         "rust-toolchain.toml",
-        format!("[toolchain]\nchannel = \"{NIGHTLY}\"\n"),
+        include_str!("nightly-toolchain/rust-toolchain.toml"),
     )
     .context("writing rust-toolchain.toml")?;
     Ok(())

--- a/rust/ql/test/setup.sh
+++ b/rust/ql/test/setup.sh
@@ -5,14 +5,11 @@ set -euo pipefail
 # This script is run by the CI to set up the test environment for the Rust QL tests
 # We run this as rustup is not meant to be run in parallel, and will this setup will be run by rust-analyzer in the
 # parallel QL tests unless we do the setup prior to launching the tests.
-# We do this for each `rust-toolchain.toml` we use in the tests (and the root one in `rust` last, so it becomes the
-# default).
 
+# no need to install rust-src explicitly, it's listed in both toolchains
 cd "$(dirname "$0")"
-
-find . -name rust-toolchain.toml \
-  -execdir rustup install \; \
-  -execdir rustup component add rust-src \;
-
-# no to install rust-src explicitly, it's listed in ql/rust/rust-toolchain.toml
+pushd ../../extractor/src/nightly-toolchain
+rustup install
+popd
+# this needs to be last to set the default toolchain
 rustup install


### PR DESCRIPTION
Since we dropped checked in toolchain files for tests requiring nightly, the `setup.sh` script was not doing its job of setting up the toolchains and the `rust-src` component, occasionally leading to test failures.