### PR TITLE
C#: Models for Microsoft.Data.SqlClient.

### DIFF
--- a/csharp/ql/lib/ext/Microsoft.Data.SqlClient.model.yml
+++ b/csharp/ql/lib/ext/Microsoft.Data.SqlClient.model.yml
@@ -1,0 +1,20 @@
+extensions:
+  - addsTo:
+      pack: codeql/csharp-all
+      extensible: sinkModel
+    data:
+      - ["Microsoft.Data.SqlClient", "SqlCommand", False, "SqlCommand", "(System.String)", "", "Argument[0]", "sql-injection", "manual"]
+      - ["Microsoft.Data.SqlClient", "SqlCommand", False, "SqlCommand", "(System.String,Microsoft.Data.SqlClient.SqlConnection)", "", "Argument[0]", "sql-injection", "manual"]
+      - ["Microsoft.Data.SqlClient", "SqlCommand", False, "SqlCommand", "(System.String,Microsoft.Data.SqlClient.SqlConnection,Microsoft.Data.SqlClient.SqlTransaction)", "", "Argument[0]", "sql-injection", "manual"]
+      - ["Microsoft.Data.SqlClient", "SqlCommand", False, "SqlCommand", "(System.String,Microsoft.Data.SqlClient.SqlConnection,Microsoft.Data.SqlClient.SqlTransaction,Microsoft.Data.SqlClient.SqlCommandColumnEncryptionSetting)", "", "Argument[0]", "sql-injection", "manual"]
+      - ["Microsoft.Data.SqlClient", "SqlDataAdapter", False, "SqlDataAdapter", "(Microsoft.Data.SqlClient.SqlCommand)", "", "Argument[0]", "sql-injection", "manual"]
+      - ["Microsoft.Data.SqlClient", "SqlDataAdapter", False, "SqlDataAdapter", "(System.String,Microsoft.Data.SqlClient.SqlConnection)", "", "Argument[0]", "sql-injection", "manual"]
+      - ["Microsoft.Data.SqlClient", "SqlDataAdapter", False, "SqlDataAdapter", "(System.String,System.String)", "", "Argument[0]", "sql-injection", "manual"]
+  - addsTo:
+      pack: codeql/csharp-all
+      extensible: summaryModel
+    data:
+      - ["Microsoft.Data.SqlClient", "SqlCommand", False, "SqlCommand", "(System.String)", "", "Argument[0]", "Argument[this]", "taint", "manual"]
+      - ["Microsoft.Data.SqlClient", "SqlCommand", False, "SqlCommand", "(System.String,Microsoft.Data.SqlClient.SqlConnection)", "", "Argument[0]", "Argument[this]", "taint", "manual"]
+      - ["Microsoft.Data.SqlClient", "SqlCommand", False, "SqlCommand", "(System.String,Microsoft.Data.SqlClient.SqlConnection,Microsoft.Data.SqlClient.SqlTransaction)", "", "Argument[0]", "Argument[this]", "taint", "manual"]
+      - ["Microsoft.Data.SqlClient", "SqlCommand", False, "SqlCommand", "(System.String,Microsoft.Data.SqlClient.SqlConnection,Microsoft.Data.SqlClient.SqlTransaction,Microsoft.Data.SqlClient.SqlCommandColumnEncryptionSetting)", "", "Argument[0]", "Argument[this]", "taint", "manual"]

--- a/csharp/ql/lib/semmle/code/csharp/frameworks/Sql.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/Sql.qll
@@ -35,6 +35,7 @@ class IDbCommandConstructionSqlExpr extends SqlExpr, ObjectCreation {
       ic.getParameter(0).getType() instanceof StringType and
       not exists(Type t | t = ic.getDeclaringType() |
         // Known sealed classes:
+        t.hasFullyQualifiedName("Microsoft.Data.SqlClient", "SqlCommand") or
         t.hasFullyQualifiedName("System.Data.SqlClient", "SqlCommand") or
         t.hasFullyQualifiedName("System.Data.Odbc", "OdbcCommand") or
         t.hasFullyQualifiedName("System.Data.OleDb", "OleDbCommand") or

--- a/csharp/ql/src/change-notes/2025-06-25-sqlcommand-models.md
+++ b/csharp/ql/src/change-notes/2025-06-25-sqlcommand-models.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added explicit SQL injection Models as Data models for `Microsoft.Data.SqlClient.SqlCommand` and `Microsoft.Data.SqlClient.SqlDataAdapter`. This reduces false negatives for the query `cs/sql-injection`.

--- a/csharp/ql/test/query-tests/Security Features/CWE-089-2/SqlInjection.cs
+++ b/csharp/ql/test/query-tests/Security Features/CWE-089-2/SqlInjection.cs
@@ -1,0 +1,33 @@
+using System;
+using Microsoft.Data;
+using Microsoft.Data.SqlClient;
+
+namespace Test
+{
+    class SqlInjection
+    {
+        string connectionString;
+        System.Windows.Forms.TextBox box1;
+
+        public void MakeSqlCommand()
+        {
+            // BAD: Text from a local textbox
+            using (var connection = new SqlConnection(connectionString))
+            {
+                var queryString = "SELECT ITEM,PRICE FROM PRODUCT WHERE ITEM_CATEGORY='"
+                  + box1.Text + "' ORDER BY PRICE"; // $ Source[cs/sql-injection]
+                var cmd = new SqlCommand(queryString); // $ Alert[cs/sql-injection]
+                var adapter = new SqlDataAdapter(cmd); // $ Alert[cs/sql-injection]
+            }
+
+            // BAD: Input from the command line.
+            using (var connection = new SqlConnection(connectionString))
+            {
+                var queryString = "SELECT ITEM,PRICE FROM PRODUCT WHERE ITEM_CATEGORY='"
+                  + Console.ReadLine() + "' ORDER BY PRICE"; // $ Source[cs/sql-injection]
+                var cmd = new SqlCommand(queryString); // $ Alert[cs/sql-injection]
+                var adapter = new SqlDataAdapter(cmd); // $ Alert[cs/sql-injection]
+            }
+        }
+    }
+}

--- a/csharp/ql/test/query-tests/Security Features/CWE-089-2/SqlInjection.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-089-2/SqlInjection.expected
@@ -1,0 +1,21 @@
+#select
+| SqlInjection.cs:19:42:19:52 | access to local variable queryString | SqlInjection.cs:18:21:18:29 | access to property Text : String | SqlInjection.cs:19:42:19:52 | access to local variable queryString | This query depends on $@. | SqlInjection.cs:18:21:18:29 | access to property Text : String | this TextBox text |
+| SqlInjection.cs:28:42:28:52 | access to local variable queryString | SqlInjection.cs:27:21:27:38 | call to method ReadLine : String | SqlInjection.cs:28:42:28:52 | access to local variable queryString | This query depends on $@. | SqlInjection.cs:27:21:27:38 | call to method ReadLine : String | this read from stdin |
+edges
+| SqlInjection.cs:17:21:17:31 | access to local variable queryString : String | SqlInjection.cs:19:42:19:52 | access to local variable queryString | provenance |  |
+| SqlInjection.cs:18:21:18:29 | access to property Text : String | SqlInjection.cs:17:21:17:31 | access to local variable queryString : String | provenance |  |
+| SqlInjection.cs:26:21:26:31 | access to local variable queryString : String | SqlInjection.cs:28:42:28:52 | access to local variable queryString | provenance |  |
+| SqlInjection.cs:27:21:27:38 | call to method ReadLine : String | SqlInjection.cs:26:21:26:31 | access to local variable queryString : String | provenance | Src:MaD:1  |
+models
+| 1 | Source: System; Console; false; ReadLine; ; ; ReturnValue; stdin; manual |
+nodes
+| SqlInjection.cs:17:21:17:31 | access to local variable queryString : String | semmle.label | access to local variable queryString : String |
+| SqlInjection.cs:18:21:18:29 | access to property Text : String | semmle.label | access to property Text : String |
+| SqlInjection.cs:19:42:19:52 | access to local variable queryString | semmle.label | access to local variable queryString |
+| SqlInjection.cs:26:21:26:31 | access to local variable queryString : String | semmle.label | access to local variable queryString : String |
+| SqlInjection.cs:27:21:27:38 | call to method ReadLine : String | semmle.label | call to method ReadLine : String |
+| SqlInjection.cs:28:42:28:52 | access to local variable queryString | semmle.label | access to local variable queryString |
+subpaths
+testFailures
+| SqlInjection.cs:20:56:20:83 | // ... | Missing result: Alert[cs/sql-injection] |
+| SqlInjection.cs:29:56:29:83 | // ... | Missing result: Alert[cs/sql-injection] |

--- a/csharp/ql/test/query-tests/Security Features/CWE-089-2/SqlInjection.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-089-2/SqlInjection.expected
@@ -1,11 +1,39 @@
 #select
+| SqlInjection.cs:19:42:19:52 | access to local variable queryString | SqlInjection.cs:18:21:18:29 | access to property Text : String | SqlInjection.cs:19:42:19:52 | access to local variable queryString | This query depends on $@. | SqlInjection.cs:18:21:18:29 | access to property Text : String | this TextBox text |
+| SqlInjection.cs:20:50:20:52 | access to local variable cmd | SqlInjection.cs:18:21:18:29 | access to property Text : String | SqlInjection.cs:20:50:20:52 | access to local variable cmd | This query depends on $@. | SqlInjection.cs:18:21:18:29 | access to property Text : String | this TextBox text |
+| SqlInjection.cs:28:42:28:52 | access to local variable queryString | SqlInjection.cs:27:21:27:38 | call to method ReadLine : String | SqlInjection.cs:28:42:28:52 | access to local variable queryString | This query depends on $@. | SqlInjection.cs:27:21:27:38 | call to method ReadLine : String | this read from stdin |
+| SqlInjection.cs:29:50:29:52 | access to local variable cmd | SqlInjection.cs:27:21:27:38 | call to method ReadLine : String | SqlInjection.cs:29:50:29:52 | access to local variable cmd | This query depends on $@. | SqlInjection.cs:27:21:27:38 | call to method ReadLine : String | this read from stdin |
 edges
+| SqlInjection.cs:17:21:17:31 | access to local variable queryString : String | SqlInjection.cs:19:42:19:52 | access to local variable queryString | provenance | Sink:MaD:1 |
+| SqlInjection.cs:17:21:17:31 | access to local variable queryString : String | SqlInjection.cs:19:42:19:52 | access to local variable queryString : String | provenance |  |
+| SqlInjection.cs:18:21:18:29 | access to property Text : String | SqlInjection.cs:17:21:17:31 | access to local variable queryString : String | provenance |  |
+| SqlInjection.cs:19:21:19:23 | access to local variable cmd : SqlCommand | SqlInjection.cs:20:50:20:52 | access to local variable cmd | provenance | Sink:MaD:2 |
+| SqlInjection.cs:19:27:19:53 | object creation of type SqlCommand : SqlCommand | SqlInjection.cs:19:21:19:23 | access to local variable cmd : SqlCommand | provenance |  |
+| SqlInjection.cs:19:42:19:52 | access to local variable queryString : String | SqlInjection.cs:19:27:19:53 | object creation of type SqlCommand : SqlCommand | provenance | MaD:4 |
+| SqlInjection.cs:26:21:26:31 | access to local variable queryString : String | SqlInjection.cs:28:42:28:52 | access to local variable queryString | provenance | Sink:MaD:1 |
+| SqlInjection.cs:26:21:26:31 | access to local variable queryString : String | SqlInjection.cs:28:42:28:52 | access to local variable queryString : String | provenance |  |
+| SqlInjection.cs:27:21:27:38 | call to method ReadLine : String | SqlInjection.cs:26:21:26:31 | access to local variable queryString : String | provenance | Src:MaD:3  |
+| SqlInjection.cs:28:21:28:23 | access to local variable cmd : SqlCommand | SqlInjection.cs:29:50:29:52 | access to local variable cmd | provenance | Sink:MaD:2 |
+| SqlInjection.cs:28:27:28:53 | object creation of type SqlCommand : SqlCommand | SqlInjection.cs:28:21:28:23 | access to local variable cmd : SqlCommand | provenance |  |
+| SqlInjection.cs:28:42:28:52 | access to local variable queryString : String | SqlInjection.cs:28:27:28:53 | object creation of type SqlCommand : SqlCommand | provenance | MaD:4 |
+models
+| 1 | Sink: Microsoft.Data.SqlClient; SqlCommand; false; SqlCommand; (System.String); ; Argument[0]; sql-injection; manual |
+| 2 | Sink: Microsoft.Data.SqlClient; SqlDataAdapter; false; SqlDataAdapter; (Microsoft.Data.SqlClient.SqlCommand); ; Argument[0]; sql-injection; manual |
+| 3 | Source: System; Console; false; ReadLine; ; ; ReturnValue; stdin; manual |
+| 4 | Summary: Microsoft.Data.SqlClient; SqlCommand; false; SqlCommand; (System.String); ; Argument[0]; Argument[this]; taint; manual |
 nodes
+| SqlInjection.cs:17:21:17:31 | access to local variable queryString : String | semmle.label | access to local variable queryString : String |
+| SqlInjection.cs:18:21:18:29 | access to property Text : String | semmle.label | access to property Text : String |
+| SqlInjection.cs:19:21:19:23 | access to local variable cmd : SqlCommand | semmle.label | access to local variable cmd : SqlCommand |
+| SqlInjection.cs:19:27:19:53 | object creation of type SqlCommand : SqlCommand | semmle.label | object creation of type SqlCommand : SqlCommand |
+| SqlInjection.cs:19:42:19:52 | access to local variable queryString | semmle.label | access to local variable queryString |
+| SqlInjection.cs:19:42:19:52 | access to local variable queryString : String | semmle.label | access to local variable queryString : String |
+| SqlInjection.cs:20:50:20:52 | access to local variable cmd | semmle.label | access to local variable cmd |
+| SqlInjection.cs:26:21:26:31 | access to local variable queryString : String | semmle.label | access to local variable queryString : String |
+| SqlInjection.cs:27:21:27:38 | call to method ReadLine : String | semmle.label | call to method ReadLine : String |
+| SqlInjection.cs:28:21:28:23 | access to local variable cmd : SqlCommand | semmle.label | access to local variable cmd : SqlCommand |
+| SqlInjection.cs:28:27:28:53 | object creation of type SqlCommand : SqlCommand | semmle.label | object creation of type SqlCommand : SqlCommand |
+| SqlInjection.cs:28:42:28:52 | access to local variable queryString | semmle.label | access to local variable queryString |
+| SqlInjection.cs:28:42:28:52 | access to local variable queryString : String | semmle.label | access to local variable queryString : String |
+| SqlInjection.cs:29:50:29:52 | access to local variable cmd | semmle.label | access to local variable cmd |
 subpaths
-testFailures
-| SqlInjection.cs:18:53:18:81 | // ... | Missing result: Source[cs/sql-injection] |
-| SqlInjection.cs:19:56:19:83 | // ... | Missing result: Alert[cs/sql-injection] |
-| SqlInjection.cs:20:56:20:83 | // ... | Missing result: Alert[cs/sql-injection] |
-| SqlInjection.cs:27:62:27:90 | // ... | Missing result: Source[cs/sql-injection] |
-| SqlInjection.cs:28:56:28:83 | // ... | Missing result: Alert[cs/sql-injection] |
-| SqlInjection.cs:29:56:29:83 | // ... | Missing result: Alert[cs/sql-injection] |

--- a/csharp/ql/test/query-tests/Security Features/CWE-089-2/SqlInjection.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-089-2/SqlInjection.expected
@@ -1,21 +1,11 @@
 #select
-| SqlInjection.cs:19:42:19:52 | access to local variable queryString | SqlInjection.cs:18:21:18:29 | access to property Text : String | SqlInjection.cs:19:42:19:52 | access to local variable queryString | This query depends on $@. | SqlInjection.cs:18:21:18:29 | access to property Text : String | this TextBox text |
-| SqlInjection.cs:28:42:28:52 | access to local variable queryString | SqlInjection.cs:27:21:27:38 | call to method ReadLine : String | SqlInjection.cs:28:42:28:52 | access to local variable queryString | This query depends on $@. | SqlInjection.cs:27:21:27:38 | call to method ReadLine : String | this read from stdin |
 edges
-| SqlInjection.cs:17:21:17:31 | access to local variable queryString : String | SqlInjection.cs:19:42:19:52 | access to local variable queryString | provenance |  |
-| SqlInjection.cs:18:21:18:29 | access to property Text : String | SqlInjection.cs:17:21:17:31 | access to local variable queryString : String | provenance |  |
-| SqlInjection.cs:26:21:26:31 | access to local variable queryString : String | SqlInjection.cs:28:42:28:52 | access to local variable queryString | provenance |  |
-| SqlInjection.cs:27:21:27:38 | call to method ReadLine : String | SqlInjection.cs:26:21:26:31 | access to local variable queryString : String | provenance | Src:MaD:1  |
-models
-| 1 | Source: System; Console; false; ReadLine; ; ; ReturnValue; stdin; manual |
 nodes
-| SqlInjection.cs:17:21:17:31 | access to local variable queryString : String | semmle.label | access to local variable queryString : String |
-| SqlInjection.cs:18:21:18:29 | access to property Text : String | semmle.label | access to property Text : String |
-| SqlInjection.cs:19:42:19:52 | access to local variable queryString | semmle.label | access to local variable queryString |
-| SqlInjection.cs:26:21:26:31 | access to local variable queryString : String | semmle.label | access to local variable queryString : String |
-| SqlInjection.cs:27:21:27:38 | call to method ReadLine : String | semmle.label | call to method ReadLine : String |
-| SqlInjection.cs:28:42:28:52 | access to local variable queryString | semmle.label | access to local variable queryString |
 subpaths
 testFailures
+| SqlInjection.cs:18:53:18:81 | // ... | Missing result: Source[cs/sql-injection] |
+| SqlInjection.cs:19:56:19:83 | // ... | Missing result: Alert[cs/sql-injection] |
 | SqlInjection.cs:20:56:20:83 | // ... | Missing result: Alert[cs/sql-injection] |
+| SqlInjection.cs:27:62:27:90 | // ... | Missing result: Source[cs/sql-injection] |
+| SqlInjection.cs:28:56:28:83 | // ... | Missing result: Alert[cs/sql-injection] |
 | SqlInjection.cs:29:56:29:83 | // ... | Missing result: Alert[cs/sql-injection] |

--- a/csharp/ql/test/query-tests/Security Features/CWE-089-2/SqlInjection.ext.yml
+++ b/csharp/ql/test/query-tests/Security Features/CWE-089-2/SqlInjection.ext.yml
@@ -1,0 +1,7 @@
+extensions:
+
+  - addsTo:
+      pack: codeql/threat-models
+      extensible: threatModelConfiguration
+    data:
+      - ["local", true, 0]

--- a/csharp/ql/test/query-tests/Security Features/CWE-089-2/SqlInjection.qlref
+++ b/csharp/ql/test/query-tests/Security Features/CWE-089-2/SqlInjection.qlref
@@ -1,0 +1,4 @@
+query: Security Features/CWE-089/SqlInjection.ql
+postprocess:
+  - utils/test/PrettyPrintModels.ql
+  - utils/test/InlineExpectationsTestQuery.ql

--- a/csharp/ql/test/query-tests/Security Features/CWE-089-2/options
+++ b/csharp/ql/test/query-tests/Security Features/CWE-089-2/options
@@ -1,0 +1,4 @@
+semmle-extractor-options: /nostdlib /noconfig
+semmle-extractor-options: --load-sources-from-project:${testdir}/../../../resources/stubs/Microsoft.Data.SqlClient/6.0.2/Microsoft.Data.SqlClient.csproj
+semmle-extractor-options: ${testdir}/../../../resources/stubs/System.Windows.cs
+semmle-extractor-options: --load-sources-from-project:${testdir}/../../../resources/stubs/_frameworks/Microsoft.AspNetCore.App/Microsoft.AspNetCore.App.csproj

--- a/csharp/ql/test/query-tests/Security Features/CWE-089/SecondOrderSqlInjection.cs
+++ b/csharp/ql/test/query-tests/Security Features/CWE-089/SecondOrderSqlInjection.cs
@@ -17,12 +17,12 @@ namespace Test
             {
                 connection.Open();
                 SqlCommand customerCommand = new SqlCommand("SELECT * FROM customers", connection);
-                SqlDataReader customerReader = customerCommand.ExecuteReader();
+                SqlDataReader customerReader = customerCommand.ExecuteReader(); // $ Source[cs/sql-injection]
 
                 while (customerReader.Read())
                 {
                     // BAD: Read from database, write it straight to another query
-                    SqlCommand secondCustomerCommand = new SqlCommand("SELECT * FROM customers WHERE customerName=" + customerReader.GetString(1), connection);
+                    SqlCommand secondCustomerCommand = new SqlCommand("SELECT * FROM customers WHERE customerName=" + customerReader.GetString(1), connection); // $ Alert[cs/sql-injection]
                 }
                 customerReader.Close();
             }
@@ -30,7 +30,7 @@ namespace Test
 
         public void RunSQLFromFile()
         {
-            using (FileStream fs = new FileStream("myfile.txt", FileMode.Open))
+            using (FileStream fs = new FileStream("myfile.txt", FileMode.Open)) // $ Source[cs/sql-injection]
             {
                 using (StreamReader sr = new StreamReader(fs, Encoding.UTF8))
                 {
@@ -42,7 +42,7 @@ namespace Test
                             continue;
                         using (var connection = new SQLiteConnection(""))
                         {
-                            var cmd = new SQLiteCommand(sql, connection);
+                            var cmd = new SQLiteCommand(sql, connection); // $ Alert[cs/sql-injection]
                             cmd.ExecuteScalar();
                         }
                     }

--- a/csharp/ql/test/query-tests/Security Features/CWE-089/SqlInjection.cs
+++ b/csharp/ql/test/query-tests/Security Features/CWE-089/SqlInjection.cs
@@ -35,8 +35,8 @@ namespace Test
             using (var connection = new SqlConnection(connectionString))
             {
                 var query1 = "SELECT ITEM,PRICE FROM PRODUCT WHERE ITEM_CATEGORY='"
-                  + categoryTextBox.Text + "' ORDER BY PRICE";
-                var adapter = new SqlDataAdapter(query1, connection);
+                  + categoryTextBox.Text + "' ORDER BY PRICE"; // $ Source[cs/sql-injection]
+                var adapter = new SqlDataAdapter(query1, connection); // $ Alert[cs/sql-injection]
                 var result = new DataSet();
                 adapter.Fill(result);
             }
@@ -70,9 +70,9 @@ namespace Test
                 {
                     // BAD: Use EntityFramework direct Sql execution methods
                     var query1 = "SELECT ITEM,PRICE FROM PRODUCT WHERE ITEM_CATEGORY='"
-                              + categoryTextBox.Text + "' ORDER BY PRICE";
-                    context.Database.ExecuteSqlCommand(query1);
-                    context.Database.SqlQuery<string>(query1);
+                              + categoryTextBox.Text + "' ORDER BY PRICE"; // $ Source[cs/sql-injection]
+                    context.Database.ExecuteSqlCommand(query1); // $ Alert[cs/sql-injection]
+                    context.Database.SqlQuery<string>(query1); // $ Alert[cs/sql-injection]
                     // GOOD: Use EntityFramework direct Sql execution methods with parameter
                     var query2 = "SELECT ITEM,PRICE FROM PRODUCT WHERE ITEM_CATEGORY="
                             + "@p0 ORDER BY PRICE";
@@ -84,8 +84,8 @@ namespace Test
             using (var connection = new SqlConnection(connectionString))
             {
                 var query1 = "SELECT ITEM,PRICE FROM PRODUCT WHERE ITEM_CATEGORY='"
-                  + box1.Text + "' ORDER BY PRICE";
-                var adapter = new SqlDataAdapter(query1, connection);
+                  + box1.Text + "' ORDER BY PRICE"; // $ Source[cs/sql-injection]
+                var adapter = new SqlDataAdapter(query1, connection); // $ Alert[cs/sql-injection]
                 var result = new DataSet();
                 adapter.Fill(result);
             }
@@ -94,9 +94,9 @@ namespace Test
             using (var connection = new SqlConnection(connectionString))
             {
                 var queryString = "SELECT ITEM,PRICE FROM PRODUCT WHERE ITEM_CATEGORY='"
-                  + box1.Text + "' ORDER BY PRICE";
-                var cmd = new SqlCommand(queryString);
-                var adapter = new SqlDataAdapter(cmd);
+                  + box1.Text + "' ORDER BY PRICE"; // $ Source[cs/sql-injection]
+                var cmd = new SqlCommand(queryString); // $ Alert[cs/sql-injection]
+                var adapter = new SqlDataAdapter(cmd); // $ Alert[cs/sql-injection]
                 var result = new DataSet();
                 adapter.Fill(result);
             }
@@ -105,9 +105,9 @@ namespace Test
             using (var connection = new SqlConnection(connectionString))
             {
                 var queryString = "SELECT ITEM,PRICE FROM PRODUCT WHERE ITEM_CATEGORY='"
-                  + Console.ReadLine()! + "' ORDER BY PRICE";
-                var cmd = new SqlCommand(queryString);
-                var adapter = new SqlDataAdapter(cmd);
+                  + Console.ReadLine()! + "' ORDER BY PRICE"; // $ Source[cs/sql-injection]
+                var cmd = new SqlCommand(queryString); // $ Alert[cs/sql-injection]
+                var adapter = new SqlDataAdapter(cmd); // $ Alert[cs/sql-injection]
                 var result = new DataSet();
                 adapter.Fill(result);
             }
@@ -119,14 +119,14 @@ namespace Test
     public abstract class MyController : Controller
     {
         [HttpPost("{userId:string}")]
-        public async Task<IActionResult> GetUserById([FromRoute] string userId, CancellationToken cancellationToken)
+        public async Task<IActionResult> GetUserById([FromRoute] string userId, CancellationToken cancellationToken) // $ Source[cs/sql-injection]
         {
             // This is a vulnerable method due to SQL injection
             string query = "SELECT * FROM Users WHERE UserId = '" + userId + "'";
 
             using (SqlConnection connection = new SqlConnection("YourConnectionString"))
             {
-                SqlCommand command = new SqlCommand(query, connection);
+                SqlCommand command = new SqlCommand(query, connection); // $ Alert[cs/sql-injection]
                 connection.Open();
 
                 SqlDataReader reader = command.ExecuteReader();

--- a/csharp/ql/test/query-tests/Security Features/CWE-089/SqlInjection.qlref
+++ b/csharp/ql/test/query-tests/Security Features/CWE-089/SqlInjection.qlref
@@ -1,2 +1,4 @@
 query: Security Features/CWE-089/SqlInjection.ql
-postprocess: utils/test/PrettyPrintModels.ql
+postprocess:
+  - utils/test/PrettyPrintModels.ql
+  - utils/test/InlineExpectationsTestQuery.ql

--- a/csharp/ql/test/query-tests/Security Features/CWE-089/SqlInjectionDapper.cs
+++ b/csharp/ql/test/query-tests/Security Features/CWE-089/SqlInjectionDapper.cs
@@ -17,8 +17,8 @@ namespace Test
         {
             using (var connection = new SqlConnection(connectionString))
             {
-                var query = "SELECT ITEM,PRICE FROM PRODUCT WHERE ITEM_CATEGORY='" + box1.Text + "' ORDER BY PRICE";
-                var result = connection.Query<object>(query);
+                var query = "SELECT ITEM,PRICE FROM PRODUCT WHERE ITEM_CATEGORY='" + box1.Text + "' ORDER BY PRICE"; // $ Source[cs/sql-injection]
+                var result = connection.Query<object>(query); // $ Alert[cs/sql-injection]
             }
         }
 
@@ -26,8 +26,8 @@ namespace Test
         {
             using (var connection = new SqlConnection(connectionString))
             {
-                var query = "SELECT ITEM,PRICE FROM PRODUCT WHERE ITEM_CATEGORY='" + box1.Text + "' ORDER BY PRICE";
-                var result = await connection.QueryAsync<object>(query);
+                var query = "SELECT ITEM,PRICE FROM PRODUCT WHERE ITEM_CATEGORY='" + box1.Text + "' ORDER BY PRICE"; // $ Source[cs/sql-injection]
+                var result = await connection.QueryAsync<object>(query); // $ Alert[cs/sql-injection]
             }
         }
 
@@ -35,8 +35,8 @@ namespace Test
         {
             using (var connection = new SqlConnection(connectionString))
             {
-                var query = "SELECT ITEM,PRICE FROM PRODUCT WHERE ITEM_CATEGORY='" + box1.Text + "' ORDER BY PRICE";
-                var result = await connection.QueryFirstAsync(query);
+                var query = "SELECT ITEM,PRICE FROM PRODUCT WHERE ITEM_CATEGORY='" + box1.Text + "' ORDER BY PRICE"; // $ Source[cs/sql-injection]
+                var result = await connection.QueryFirstAsync(query); // $ Alert[cs/sql-injection]
             }
         }
 
@@ -44,9 +44,9 @@ namespace Test
         {
             using (var connection = new SqlConnection(connectionString))
             {
-                var query = "SELECT ITEM,PRICE FROM PRODUCT WHERE ITEM_CATEGORY='" + box1.Text + "' ORDER BY PRICE";
+                var query = "SELECT ITEM,PRICE FROM PRODUCT WHERE ITEM_CATEGORY='" + box1.Text + "' ORDER BY PRICE"; // $ Source[cs/sql-injection]
 
-                await connection.ExecuteAsync(query);
+                await connection.ExecuteAsync(query); // $ Alert[cs/sql-injection]
             }
         }
 
@@ -54,8 +54,8 @@ namespace Test
         {
             using (var connection = new SqlConnection(connectionString))
             {
-                var query = "SELECT ITEM,PRICE FROM PRODUCT WHERE ITEM_CATEGORY='" + box1.Text + "' ORDER BY PRICE";
-                connection.ExecuteScalar(query);
+                var query = "SELECT ITEM,PRICE FROM PRODUCT WHERE ITEM_CATEGORY='" + box1.Text + "' ORDER BY PRICE"; // $ Source[cs/sql-injection]
+                connection.ExecuteScalar(query); // $ Alert[cs/sql-injection]
             }
         }
 
@@ -63,8 +63,8 @@ namespace Test
         {
             using (var connection = new SqlConnection(connectionString))
             {
-                var query = "SELECT ITEM,PRICE FROM PRODUCT WHERE ITEM_CATEGORY='" + box1.Text + "' ORDER BY PRICE";
-                connection.ExecuteReader(query);
+                var query = "SELECT ITEM,PRICE FROM PRODUCT WHERE ITEM_CATEGORY='" + box1.Text + "' ORDER BY PRICE"; // $ Source[cs/sql-injection]
+                connection.ExecuteReader(query); // $ Alert[cs/sql-injection]
             }
         }
 
@@ -72,9 +72,9 @@ namespace Test
         {
             using (var connection = new SqlConnection(connectionString))
             {
-                var query = "SELECT ITEM,PRICE FROM PRODUCT WHERE ITEM_CATEGORY='" + box1.Text + "' ORDER BY PRICE";
+                var query = "SELECT ITEM,PRICE FROM PRODUCT WHERE ITEM_CATEGORY='" + box1.Text + "' ORDER BY PRICE"; // $ Source[cs/sql-injection]
 
-                var comDef = new CommandDefinition(query);
+                var comDef = new CommandDefinition(query); // $ Alert[cs/sql-injection]
                 var result = await connection.QueryFirstAsync(comDef);
             }
         }

--- a/csharp/ql/test/query-tests/Security Features/CWE-089/SqlInjectionSqlite.cs
+++ b/csharp/ql/test/query-tests/Security Features/CWE-089/SqlInjectionSqlite.cs
@@ -16,12 +16,12 @@ namespace TestSqlite
         public void InjectUntrustedData()
         {
             // BAD: untrusted data is not sanitized.
-            SQLiteCommand cmd = new SQLiteCommand(untrustedData.Text);
+            SQLiteCommand cmd = new SQLiteCommand(untrustedData.Text); // $ Alert[cs/sql-injection]
 
             // BAD: untrusted data is not sanitized.
             using (var connection = new SQLiteConnection(connectionString))
             {
-                cmd = new SQLiteCommand(untrustedData.Text, connection);
+                cmd = new SQLiteCommand(untrustedData.Text, connection); // $ Source[cs/sql-injection] Alert[cs/sql-injection]
             }
 
             SQLiteDataAdapter adapter;
@@ -30,23 +30,23 @@ namespace TestSqlite
             // BAD: untrusted data is not sanitized.
             using (var connection = new SQLiteConnection(connectionString))
             {
-                adapter = new SQLiteDataAdapter(untrustedData.Text, connection);
+                adapter = new SQLiteDataAdapter(untrustedData.Text, connection); // $ Alert[cs/sql-injection]
                 result = new DataSet();
                 adapter.Fill(result);
             }
 
             // BAD: untrusted data is not sanitized.
-            adapter = new SQLiteDataAdapter(untrustedData.Text, connectionString);
+            adapter = new SQLiteDataAdapter(untrustedData.Text, connectionString); // $ Alert[cs/sql-injection]
             result = new DataSet();
             adapter.Fill(result);
 
             // BAD: untrusted data is not sanitized.
-            adapter = new SQLiteDataAdapter(cmd);
+            adapter = new SQLiteDataAdapter(cmd); // $ Alert[cs/sql-injection]
             result = new DataSet();
             adapter.Fill(result);
 
             // BAD: untrusted data as filename is not sanitized.
-            using (FileStream fs = new FileStream(untrustedData.Text, FileMode.Open))
+            using (FileStream fs = new FileStream(untrustedData.Text, FileMode.Open)) // $ Source[cs/sql-injection]
             {
                 using (StreamReader sr = new StreamReader(fs, Encoding.UTF8))
                 {
@@ -58,7 +58,7 @@ namespace TestSqlite
                             continue;
                         using (var connection = new SQLiteConnection(""))
                         {
-                            cmd = new SQLiteCommand(sql, connection);
+                            cmd = new SQLiteCommand(sql, connection); // $ Alert[cs/sql-injection]
                             cmd.ExecuteScalar();
                         }
                     }

--- a/csharp/ql/test/resources/stubs/Azure.Core/1.38.0/Azure.Core.cs
+++ b/csharp/ql/test/resources/stubs/Azure.Core/1.38.0/Azure.Core.cs
@@ -1,0 +1,1104 @@
+// This file contains auto-generated code.
+// Generated from `Azure.Core, Version=1.38.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8`.
+namespace Azure
+{
+    public abstract class AsyncPageable<T> : System.Collections.Generic.IAsyncEnumerable<T>
+    {
+        public abstract System.Collections.Generic.IAsyncEnumerable<Azure.Page<T>> AsPages(string continuationToken = default(string), int? pageSizeHint = default(int?));
+        protected virtual System.Threading.CancellationToken CancellationToken { get => throw null; }
+        protected AsyncPageable() => throw null;
+        protected AsyncPageable(System.Threading.CancellationToken cancellationToken) => throw null;
+        public override bool Equals(object obj) => throw null;
+        public static Azure.AsyncPageable<T> FromPages(System.Collections.Generic.IEnumerable<Azure.Page<T>> pages) => throw null;
+        public virtual System.Collections.Generic.IAsyncEnumerator<T> GetAsyncEnumerator(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+        public override int GetHashCode() => throw null;
+        public override string ToString() => throw null;
+    }
+    public static partial class AzureCoreExtensions
+    {
+        public static dynamic ToDynamicFromJson(this System.BinaryData utf8Json) => throw null;
+        public static dynamic ToDynamicFromJson(this System.BinaryData utf8Json, Azure.Core.Serialization.JsonPropertyNames propertyNameFormat, string dateTimeFormat = default(string)) => throw null;
+        public static T ToObject<T>(this System.BinaryData data, Azure.Core.Serialization.ObjectSerializer serializer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+        public static System.Threading.Tasks.ValueTask<T> ToObjectAsync<T>(this System.BinaryData data, Azure.Core.Serialization.ObjectSerializer serializer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+        public static object ToObjectFromJson(this System.BinaryData data) => throw null;
+    }
+    public class AzureKeyCredential
+    {
+        public AzureKeyCredential(string key) => throw null;
+        public string Key { get => throw null; }
+        public void Update(string key) => throw null;
+    }
+    public class AzureNamedKeyCredential
+    {
+        public AzureNamedKeyCredential(string name, string key) => throw null;
+        public void Deconstruct(out string name, out string key) => throw null;
+        public string Name { get => throw null; }
+        public void Update(string name, string key) => throw null;
+    }
+    public class AzureSasCredential
+    {
+        public AzureSasCredential(string signature) => throw null;
+        public string Signature { get => throw null; }
+        public void Update(string signature) => throw null;
+    }
+    namespace Core
+    {
+        public struct AccessToken
+        {
+            public AccessToken(string accessToken, System.DateTimeOffset expiresOn) => throw null;
+            public override bool Equals(object obj) => throw null;
+            public System.DateTimeOffset ExpiresOn { get => throw null; }
+            public override int GetHashCode() => throw null;
+            public string Token { get => throw null; }
+        }
+        public struct AzureLocation : System.IEquatable<Azure.Core.AzureLocation>
+        {
+            public static Azure.Core.AzureLocation AustraliaCentral { get => throw null; }
+            public static Azure.Core.AzureLocation AustraliaCentral2 { get => throw null; }
+            public static Azure.Core.AzureLocation AustraliaEast { get => throw null; }
+            public static Azure.Core.AzureLocation AustraliaSoutheast { get => throw null; }
+            public static Azure.Core.AzureLocation BrazilSouth { get => throw null; }
+            public static Azure.Core.AzureLocation BrazilSoutheast { get => throw null; }
+            public static Azure.Core.AzureLocation CanadaCentral { get => throw null; }
+            public static Azure.Core.AzureLocation CanadaEast { get => throw null; }
+            public static Azure.Core.AzureLocation CentralIndia { get => throw null; }
+            public static Azure.Core.AzureLocation CentralUS { get => throw null; }
+            public static Azure.Core.AzureLocation ChinaEast { get => throw null; }
+            public static Azure.Core.AzureLocation ChinaEast2 { get => throw null; }
+            public static Azure.Core.AzureLocation ChinaEast3 { get => throw null; }
+            public static Azure.Core.AzureLocation ChinaNorth { get => throw null; }
+            public static Azure.Core.AzureLocation ChinaNorth2 { get => throw null; }
+            public static Azure.Core.AzureLocation ChinaNorth3 { get => throw null; }
+            public AzureLocation(string location) => throw null;
+            public AzureLocation(string name, string displayName) => throw null;
+            public string DisplayName { get => throw null; }
+            public static Azure.Core.AzureLocation EastAsia { get => throw null; }
+            public static Azure.Core.AzureLocation EastUS { get => throw null; }
+            public static Azure.Core.AzureLocation EastUS2 { get => throw null; }
+            public bool Equals(Azure.Core.AzureLocation other) => throw null;
+            public override bool Equals(object obj) => throw null;
+            public static Azure.Core.AzureLocation FranceCentral { get => throw null; }
+            public static Azure.Core.AzureLocation FranceSouth { get => throw null; }
+            public static Azure.Core.AzureLocation GermanyCentral { get => throw null; }
+            public static Azure.Core.AzureLocation GermanyNorth { get => throw null; }
+            public static Azure.Core.AzureLocation GermanyNorthEast { get => throw null; }
+            public static Azure.Core.AzureLocation GermanyWestCentral { get => throw null; }
+            public override int GetHashCode() => throw null;
+            public static Azure.Core.AzureLocation IsraelCentral { get => throw null; }
+            public static Azure.Core.AzureLocation ItalyNorth { get => throw null; }
+            public static Azure.Core.AzureLocation JapanEast { get => throw null; }
+            public static Azure.Core.AzureLocation JapanWest { get => throw null; }
+            public static Azure.Core.AzureLocation KoreaCentral { get => throw null; }
+            public static Azure.Core.AzureLocation KoreaSouth { get => throw null; }
+            public string Name { get => throw null; }
+            public static Azure.Core.AzureLocation NorthCentralUS { get => throw null; }
+            public static Azure.Core.AzureLocation NorthEurope { get => throw null; }
+            public static Azure.Core.AzureLocation NorwayEast { get => throw null; }
+            public static Azure.Core.AzureLocation NorwayWest { get => throw null; }
+            public static bool operator ==(Azure.Core.AzureLocation left, Azure.Core.AzureLocation right) => throw null;
+            public static implicit operator Azure.Core.AzureLocation(string location) => throw null;
+            public static implicit operator string(Azure.Core.AzureLocation location) => throw null;
+            public static bool operator !=(Azure.Core.AzureLocation left, Azure.Core.AzureLocation right) => throw null;
+            public static Azure.Core.AzureLocation PolandCentral { get => throw null; }
+            public static Azure.Core.AzureLocation QatarCentral { get => throw null; }
+            public static Azure.Core.AzureLocation SouthAfricaNorth { get => throw null; }
+            public static Azure.Core.AzureLocation SouthAfricaWest { get => throw null; }
+            public static Azure.Core.AzureLocation SouthCentralUS { get => throw null; }
+            public static Azure.Core.AzureLocation SoutheastAsia { get => throw null; }
+            public static Azure.Core.AzureLocation SouthIndia { get => throw null; }
+            public static Azure.Core.AzureLocation SwedenCentral { get => throw null; }
+            public static Azure.Core.AzureLocation SwedenSouth { get => throw null; }
+            public static Azure.Core.AzureLocation SwitzerlandNorth { get => throw null; }
+            public static Azure.Core.AzureLocation SwitzerlandWest { get => throw null; }
+            public override string ToString() => throw null;
+            public static Azure.Core.AzureLocation UAECentral { get => throw null; }
+            public static Azure.Core.AzureLocation UAENorth { get => throw null; }
+            public static Azure.Core.AzureLocation UKSouth { get => throw null; }
+            public static Azure.Core.AzureLocation UKWest { get => throw null; }
+            public static Azure.Core.AzureLocation USDoDCentral { get => throw null; }
+            public static Azure.Core.AzureLocation USDoDEast { get => throw null; }
+            public static Azure.Core.AzureLocation USGovArizona { get => throw null; }
+            public static Azure.Core.AzureLocation USGovIowa { get => throw null; }
+            public static Azure.Core.AzureLocation USGovTexas { get => throw null; }
+            public static Azure.Core.AzureLocation USGovVirginia { get => throw null; }
+            public static Azure.Core.AzureLocation WestCentralUS { get => throw null; }
+            public static Azure.Core.AzureLocation WestEurope { get => throw null; }
+            public static Azure.Core.AzureLocation WestIndia { get => throw null; }
+            public static Azure.Core.AzureLocation WestUS { get => throw null; }
+            public static Azure.Core.AzureLocation WestUS2 { get => throw null; }
+            public static Azure.Core.AzureLocation WestUS3 { get => throw null; }
+        }
+        public abstract class ClientOptions
+        {
+            public void AddPolicy(Azure.Core.Pipeline.HttpPipelinePolicy policy, Azure.Core.HttpPipelinePosition position) => throw null;
+            protected ClientOptions() => throw null;
+            protected ClientOptions(Azure.Core.DiagnosticsOptions diagnostics) => throw null;
+            public static Azure.Core.ClientOptions Default { get => throw null; }
+            public Azure.Core.DiagnosticsOptions Diagnostics { get => throw null; }
+            public override bool Equals(object obj) => throw null;
+            public override int GetHashCode() => throw null;
+            public Azure.Core.RetryOptions Retry { get => throw null; }
+            public Azure.Core.Pipeline.HttpPipelinePolicy RetryPolicy { get => throw null; set { } }
+            public override string ToString() => throw null;
+            public Azure.Core.Pipeline.HttpPipelineTransport Transport { get => throw null; set { } }
+        }
+        public struct ContentType : System.IEquatable<Azure.Core.ContentType>, System.IEquatable<string>
+        {
+            public static Azure.Core.ContentType ApplicationJson { get => throw null; }
+            public static Azure.Core.ContentType ApplicationOctetStream { get => throw null; }
+            public ContentType(string contentType) => throw null;
+            public bool Equals(Azure.Core.ContentType other) => throw null;
+            public bool Equals(string other) => throw null;
+            public override bool Equals(object obj) => throw null;
+            public override int GetHashCode() => throw null;
+            public static bool operator ==(Azure.Core.ContentType left, Azure.Core.ContentType right) => throw null;
+            public static implicit operator Azure.Core.ContentType(string contentType) => throw null;
+            public static bool operator !=(Azure.Core.ContentType left, Azure.Core.ContentType right) => throw null;
+            public static Azure.Core.ContentType TextPlain { get => throw null; }
+            public override string ToString() => throw null;
+        }
+        namespace Cryptography
+        {
+            public interface IKeyEncryptionKey
+            {
+                string KeyId { get; }
+                byte[] UnwrapKey(string algorithm, System.ReadOnlyMemory<byte> encryptedKey, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+                System.Threading.Tasks.Task<byte[]> UnwrapKeyAsync(string algorithm, System.ReadOnlyMemory<byte> encryptedKey, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+                byte[] WrapKey(string algorithm, System.ReadOnlyMemory<byte> key, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+                System.Threading.Tasks.Task<byte[]> WrapKeyAsync(string algorithm, System.ReadOnlyMemory<byte> key, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+            }
+            public interface IKeyEncryptionKeyResolver
+            {
+                Azure.Core.Cryptography.IKeyEncryptionKey Resolve(string keyId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+                System.Threading.Tasks.Task<Azure.Core.Cryptography.IKeyEncryptionKey> ResolveAsync(string keyId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+            }
+        }
+        public abstract class DelayStrategy
+        {
+            public static Azure.Core.DelayStrategy CreateExponentialDelayStrategy(System.TimeSpan? initialDelay = default(System.TimeSpan?), System.TimeSpan? maxDelay = default(System.TimeSpan?)) => throw null;
+            public static Azure.Core.DelayStrategy CreateFixedDelayStrategy(System.TimeSpan? delay = default(System.TimeSpan?)) => throw null;
+            protected DelayStrategy(System.TimeSpan? maxDelay = default(System.TimeSpan?), double jitterFactor = default(double)) => throw null;
+            public System.TimeSpan GetNextDelay(Azure.Response response, int retryNumber) => throw null;
+            protected abstract System.TimeSpan GetNextDelayCore(Azure.Response response, int retryNumber);
+            protected static System.TimeSpan Max(System.TimeSpan val1, System.TimeSpan val2) => throw null;
+            protected static System.TimeSpan Min(System.TimeSpan val1, System.TimeSpan val2) => throw null;
+        }
+        public static class DelegatedTokenCredential
+        {
+            public static Azure.Core.TokenCredential Create(System.Func<Azure.Core.TokenRequestContext, System.Threading.CancellationToken, Azure.Core.AccessToken> getToken, System.Func<Azure.Core.TokenRequestContext, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<Azure.Core.AccessToken>> getTokenAsync) => throw null;
+            public static Azure.Core.TokenCredential Create(System.Func<Azure.Core.TokenRequestContext, System.Threading.CancellationToken, Azure.Core.AccessToken> getToken) => throw null;
+        }
+        namespace Diagnostics
+        {
+            public class AzureEventSourceListener : System.Diagnostics.Tracing.EventListener
+            {
+                public static Azure.Core.Diagnostics.AzureEventSourceListener CreateConsoleLogger(System.Diagnostics.Tracing.EventLevel level = default(System.Diagnostics.Tracing.EventLevel)) => throw null;
+                public static Azure.Core.Diagnostics.AzureEventSourceListener CreateTraceLogger(System.Diagnostics.Tracing.EventLevel level = default(System.Diagnostics.Tracing.EventLevel)) => throw null;
+                public AzureEventSourceListener(System.Action<System.Diagnostics.Tracing.EventWrittenEventArgs, string> log, System.Diagnostics.Tracing.EventLevel level) => throw null;
+                protected override sealed void OnEventSourceCreated(System.Diagnostics.Tracing.EventSource eventSource) => throw null;
+                protected override sealed void OnEventWritten(System.Diagnostics.Tracing.EventWrittenEventArgs eventData) => throw null;
+                public const string TraitName = default;
+                public const string TraitValue = default;
+            }
+        }
+        public class DiagnosticsOptions
+        {
+            public string ApplicationId { get => throw null; set { } }
+            protected DiagnosticsOptions() => throw null;
+            public static string DefaultApplicationId { get => throw null; set { } }
+            public bool IsDistributedTracingEnabled { get => throw null; set { } }
+            public bool IsLoggingContentEnabled { get => throw null; set { } }
+            public bool IsLoggingEnabled { get => throw null; set { } }
+            public bool IsTelemetryEnabled { get => throw null; set { } }
+            public int LoggedContentSizeLimit { get => throw null; set { } }
+            public System.Collections.Generic.IList<string> LoggedHeaderNames { get => throw null; }
+            public System.Collections.Generic.IList<string> LoggedQueryParameters { get => throw null; }
+        }
+        namespace Extensions
+        {
+            public interface IAzureClientBuilder<TClient, TOptions> where TOptions : class
+            {
+            }
+            public interface IAzureClientFactoryBuilder
+            {
+                Azure.Core.Extensions.IAzureClientBuilder<TClient, TOptions> RegisterClientFactory<TClient, TOptions>(System.Func<TOptions, TClient> clientFactory) where TOptions : class;
+            }
+            public interface IAzureClientFactoryBuilderWithConfiguration<TConfiguration> : Azure.Core.Extensions.IAzureClientFactoryBuilder
+            {
+                Azure.Core.Extensions.IAzureClientBuilder<TClient, TOptions> RegisterClientFactory<TClient, TOptions>(TConfiguration configuration) where TOptions : class;
+            }
+            public interface IAzureClientFactoryBuilderWithCredential
+            {
+                Azure.Core.Extensions.IAzureClientBuilder<TClient, TOptions> RegisterClientFactory<TClient, TOptions>(System.Func<TOptions, Azure.Core.TokenCredential, TClient> clientFactory, bool requiresCredential = default(bool)) where TOptions : class;
+            }
+        }
+        namespace GeoJson
+        {
+            public struct GeoArray<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>
+            {
+                public int Count { get => throw null; }
+                public struct Enumerator : System.IDisposable, System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator
+                {
+                    object System.Collections.IEnumerator.Current { get => throw null; }
+                    public T Current { get => throw null; }
+                    public void Dispose() => throw null;
+                    public bool MoveNext() => throw null;
+                    public void Reset() => throw null;
+                }
+                public Azure.Core.GeoJson.GeoArray<T>.Enumerator GetEnumerator() => throw null;
+                System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null;
+                System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() => throw null;
+                public T this[int index] { get => throw null; }
+            }
+            public sealed class GeoBoundingBox : System.IEquatable<Azure.Core.GeoJson.GeoBoundingBox>
+            {
+                public GeoBoundingBox(double west, double south, double east, double north) => throw null;
+                public GeoBoundingBox(double west, double south, double east, double north, double? minAltitude, double? maxAltitude) => throw null;
+                public double East { get => throw null; }
+                public bool Equals(Azure.Core.GeoJson.GeoBoundingBox other) => throw null;
+                public override bool Equals(object obj) => throw null;
+                public override int GetHashCode() => throw null;
+                public double? MaxAltitude { get => throw null; }
+                public double? MinAltitude { get => throw null; }
+                public double North { get => throw null; }
+                public double South { get => throw null; }
+                public double this[int index] { get => throw null; }
+                public override string ToString() => throw null;
+                public double West { get => throw null; }
+            }
+            public sealed class GeoCollection : Azure.Core.GeoJson.GeoObject, System.Collections.Generic.IEnumerable<Azure.Core.GeoJson.GeoObject>, System.Collections.IEnumerable, System.Collections.Generic.IReadOnlyCollection<Azure.Core.GeoJson.GeoObject>, System.Collections.Generic.IReadOnlyList<Azure.Core.GeoJson.GeoObject>
+            {
+                public int Count { get => throw null; }
+                public GeoCollection(System.Collections.Generic.IEnumerable<Azure.Core.GeoJson.GeoObject> geometries) => throw null;
+                public GeoCollection(System.Collections.Generic.IEnumerable<Azure.Core.GeoJson.GeoObject> geometries, Azure.Core.GeoJson.GeoBoundingBox boundingBox, System.Collections.Generic.IReadOnlyDictionary<string, object> customProperties) => throw null;
+                public System.Collections.Generic.IEnumerator<Azure.Core.GeoJson.GeoObject> GetEnumerator() => throw null;
+                System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null;
+                public Azure.Core.GeoJson.GeoObject this[int index] { get => throw null; }
+                public override Azure.Core.GeoJson.GeoObjectType Type { get => throw null; }
+            }
+            public sealed class GeoLinearRing
+            {
+                public Azure.Core.GeoJson.GeoArray<Azure.Core.GeoJson.GeoPosition> Coordinates { get => throw null; }
+                public GeoLinearRing(System.Collections.Generic.IEnumerable<Azure.Core.GeoJson.GeoPosition> coordinates) => throw null;
+            }
+            public sealed class GeoLineString : Azure.Core.GeoJson.GeoObject
+            {
+                public Azure.Core.GeoJson.GeoArray<Azure.Core.GeoJson.GeoPosition> Coordinates { get => throw null; }
+                public GeoLineString(System.Collections.Generic.IEnumerable<Azure.Core.GeoJson.GeoPosition> coordinates) => throw null;
+                public GeoLineString(System.Collections.Generic.IEnumerable<Azure.Core.GeoJson.GeoPosition> coordinates, Azure.Core.GeoJson.GeoBoundingBox boundingBox, System.Collections.Generic.IReadOnlyDictionary<string, object> customProperties) => throw null;
+                public override Azure.Core.GeoJson.GeoObjectType Type { get => throw null; }
+            }
+            public sealed class GeoLineStringCollection : Azure.Core.GeoJson.GeoObject, System.Collections.Generic.IEnumerable<Azure.Core.GeoJson.GeoLineString>, System.Collections.IEnumerable, System.Collections.Generic.IReadOnlyCollection<Azure.Core.GeoJson.GeoLineString>, System.Collections.Generic.IReadOnlyList<Azure.Core.GeoJson.GeoLineString>
+            {
+                public Azure.Core.GeoJson.GeoArray<Azure.Core.GeoJson.GeoArray<Azure.Core.GeoJson.GeoPosition>> Coordinates { get => throw null; }
+                public int Count { get => throw null; }
+                public GeoLineStringCollection(System.Collections.Generic.IEnumerable<Azure.Core.GeoJson.GeoLineString> lines) => throw null;
+                public GeoLineStringCollection(System.Collections.Generic.IEnumerable<Azure.Core.GeoJson.GeoLineString> lines, Azure.Core.GeoJson.GeoBoundingBox boundingBox, System.Collections.Generic.IReadOnlyDictionary<string, object> customProperties) => throw null;
+                public System.Collections.Generic.IEnumerator<Azure.Core.GeoJson.GeoLineString> GetEnumerator() => throw null;
+                System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null;
+                public Azure.Core.GeoJson.GeoLineString this[int index] { get => throw null; }
+                public override Azure.Core.GeoJson.GeoObjectType Type { get => throw null; }
+            }
+            public abstract class GeoObject
+            {
+                public Azure.Core.GeoJson.GeoBoundingBox BoundingBox { get => throw null; }
+                public static Azure.Core.GeoJson.GeoObject Parse(string json) => throw null;
+                public override string ToString() => throw null;
+                public bool TryGetCustomProperty(string name, out object value) => throw null;
+                public abstract Azure.Core.GeoJson.GeoObjectType Type { get; }
+            }
+            public enum GeoObjectType
+            {
+                Point = 0,
+                MultiPoint = 1,
+                Polygon = 2,
+                MultiPolygon = 3,
+                LineString = 4,
+                MultiLineString = 5,
+                GeometryCollection = 6,
+            }
+            public sealed class GeoPoint : Azure.Core.GeoJson.GeoObject
+            {
+                public Azure.Core.GeoJson.GeoPosition Coordinates { get => throw null; }
+                public GeoPoint(double longitude, double latitude) => throw null;
+                public GeoPoint(double longitude, double latitude, double? altitude) => throw null;
+                public GeoPoint(Azure.Core.GeoJson.GeoPosition position) => throw null;
+                public GeoPoint(Azure.Core.GeoJson.GeoPosition position, Azure.Core.GeoJson.GeoBoundingBox boundingBox, System.Collections.Generic.IReadOnlyDictionary<string, object> customProperties) => throw null;
+                public override Azure.Core.GeoJson.GeoObjectType Type { get => throw null; }
+            }
+            public sealed class GeoPointCollection : Azure.Core.GeoJson.GeoObject, System.Collections.Generic.IEnumerable<Azure.Core.GeoJson.GeoPoint>, System.Collections.IEnumerable, System.Collections.Generic.IReadOnlyCollection<Azure.Core.GeoJson.GeoPoint>, System.Collections.Generic.IReadOnlyList<Azure.Core.GeoJson.GeoPoint>
+            {
+                public Azure.Core.GeoJson.GeoArray<Azure.Core.GeoJson.GeoPosition> Coordinates { get => throw null; }
+                public int Count { get => throw null; }
+                public GeoPointCollection(System.Collections.Generic.IEnumerable<Azure.Core.GeoJson.GeoPoint> points) => throw null;
+                public GeoPointCollection(System.Collections.Generic.IEnumerable<Azure.Core.GeoJson.GeoPoint> points, Azure.Core.GeoJson.GeoBoundingBox boundingBox, System.Collections.Generic.IReadOnlyDictionary<string, object> customProperties) => throw null;
+                public System.Collections.Generic.IEnumerator<Azure.Core.GeoJson.GeoPoint> GetEnumerator() => throw null;
+                System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null;
+                public Azure.Core.GeoJson.GeoPoint this[int index] { get => throw null; }
+                public override Azure.Core.GeoJson.GeoObjectType Type { get => throw null; }
+            }
+            public sealed class GeoPolygon : Azure.Core.GeoJson.GeoObject
+            {
+                public Azure.Core.GeoJson.GeoArray<Azure.Core.GeoJson.GeoArray<Azure.Core.GeoJson.GeoPosition>> Coordinates { get => throw null; }
+                public GeoPolygon(System.Collections.Generic.IEnumerable<Azure.Core.GeoJson.GeoPosition> positions) => throw null;
+                public GeoPolygon(System.Collections.Generic.IEnumerable<Azure.Core.GeoJson.GeoLinearRing> rings) => throw null;
+                public GeoPolygon(System.Collections.Generic.IEnumerable<Azure.Core.GeoJson.GeoLinearRing> rings, Azure.Core.GeoJson.GeoBoundingBox boundingBox, System.Collections.Generic.IReadOnlyDictionary<string, object> customProperties) => throw null;
+                public Azure.Core.GeoJson.GeoLinearRing OuterRing { get => throw null; }
+                public System.Collections.Generic.IReadOnlyList<Azure.Core.GeoJson.GeoLinearRing> Rings { get => throw null; }
+                public override Azure.Core.GeoJson.GeoObjectType Type { get => throw null; }
+            }
+            public sealed class GeoPolygonCollection : Azure.Core.GeoJson.GeoObject, System.Collections.Generic.IEnumerable<Azure.Core.GeoJson.GeoPolygon>, System.Collections.IEnumerable, System.Collections.Generic.IReadOnlyCollection<Azure.Core.GeoJson.GeoPolygon>, System.Collections.Generic.IReadOnlyList<Azure.Core.GeoJson.GeoPolygon>
+            {
+                public Azure.Core.GeoJson.GeoArray<Azure.Core.GeoJson.GeoArray<Azure.Core.GeoJson.GeoArray<Azure.Core.GeoJson.GeoPosition>>> Coordinates { get => throw null; }
+                public int Count { get => throw null; }
+                public GeoPolygonCollection(System.Collections.Generic.IEnumerable<Azure.Core.GeoJson.GeoPolygon> polygons) => throw null;
+                public GeoPolygonCollection(System.Collections.Generic.IEnumerable<Azure.Core.GeoJson.GeoPolygon> polygons, Azure.Core.GeoJson.GeoBoundingBox boundingBox, System.Collections.Generic.IReadOnlyDictionary<string, object> customProperties) => throw null;
+                public System.Collections.Generic.IEnumerator<Azure.Core.GeoJson.GeoPolygon> GetEnumerator() => throw null;
+                System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null;
+                public Azure.Core.GeoJson.GeoPolygon this[int index] { get => throw null; }
+                public override Azure.Core.GeoJson.GeoObjectType Type { get => throw null; }
+            }
+            public struct GeoPosition : System.IEquatable<Azure.Core.GeoJson.GeoPosition>
+            {
+                public double? Altitude { get => throw null; }
+                public int Count { get => throw null; }
+                public GeoPosition(double longitude, double latitude) => throw null;
+                public GeoPosition(double longitude, double latitude, double? altitude) => throw null;
+                public bool Equals(Azure.Core.GeoJson.GeoPosition other) => throw null;
+                public override bool Equals(object obj) => throw null;
+                public override int GetHashCode() => throw null;
+                public double Latitude { get => throw null; }
+                public double Longitude { get => throw null; }
+                public static bool operator ==(Azure.Core.GeoJson.GeoPosition left, Azure.Core.GeoJson.GeoPosition right) => throw null;
+                public static bool operator !=(Azure.Core.GeoJson.GeoPosition left, Azure.Core.GeoJson.GeoPosition right) => throw null;
+                public double this[int index] { get => throw null; }
+                public override string ToString() => throw null;
+            }
+        }
+        public struct HttpHeader : System.IEquatable<Azure.Core.HttpHeader>
+        {
+            public static class Common
+            {
+                public static readonly Azure.Core.HttpHeader FormUrlEncodedContentType;
+                public static readonly Azure.Core.HttpHeader JsonAccept;
+                public static readonly Azure.Core.HttpHeader JsonContentType;
+                public static readonly Azure.Core.HttpHeader OctetStreamContentType;
+            }
+            public HttpHeader(string name, string value) => throw null;
+            public override bool Equals(object obj) => throw null;
+            public bool Equals(Azure.Core.HttpHeader other) => throw null;
+            public override int GetHashCode() => throw null;
+            public string Name { get => throw null; }
+            public static class Names
+            {
+                public static string Accept { get => throw null; }
+                public static string Authorization { get => throw null; }
+                public static string ContentDisposition { get => throw null; }
+                public static string ContentLength { get => throw null; }
+                public static string ContentType { get => throw null; }
+                public static string Date { get => throw null; }
+                public static string ETag { get => throw null; }
+                public static string Host { get => throw null; }
+                public static string IfMatch { get => throw null; }
+                public static string IfModifiedSince { get => throw null; }
+                public static string IfNoneMatch { get => throw null; }
+                public static string IfUnmodifiedSince { get => throw null; }
+                public static string Prefer { get => throw null; }
+                public static string Range { get => throw null; }
+                public static string Referer { get => throw null; }
+                public static string UserAgent { get => throw null; }
+                public static string WwwAuthenticate { get => throw null; }
+                public static string XMsDate { get => throw null; }
+                public static string XMsRange { get => throw null; }
+                public static string XMsRequestId { get => throw null; }
+            }
+            public override string ToString() => throw null;
+            public string Value { get => throw null; }
+        }
+        public sealed class HttpMessage : System.IDisposable
+        {
+            public bool BufferResponse { get => throw null; set { } }
+            public System.Threading.CancellationToken CancellationToken { get => throw null; }
+            public HttpMessage(Azure.Core.Request request, Azure.Core.ResponseClassifier responseClassifier) => throw null;
+            public void Dispose() => throw null;
+            public System.IO.Stream ExtractResponseContent() => throw null;
+            public bool HasResponse { get => throw null; }
+            public System.TimeSpan? NetworkTimeout { get => throw null; set { } }
+            public Azure.Core.MessageProcessingContext ProcessingContext { get => throw null; }
+            public Azure.Core.Request Request { get => throw null; }
+            public Azure.Response Response { get => throw null; set { } }
+            public Azure.Core.ResponseClassifier ResponseClassifier { get => throw null; set { } }
+            public void SetProperty(string name, object value) => throw null;
+            public void SetProperty(System.Type type, object value) => throw null;
+            public bool TryGetProperty(string name, out object value) => throw null;
+            public bool TryGetProperty(System.Type type, out object value) => throw null;
+        }
+        public enum HttpPipelinePosition
+        {
+            PerCall = 0,
+            PerRetry = 1,
+            BeforeTransport = 2,
+        }
+        public struct MessageProcessingContext
+        {
+            public int RetryNumber { get => throw null; set { } }
+            public System.DateTimeOffset StartTime { get => throw null; }
+        }
+        public static class MultipartResponse
+        {
+            public static Azure.Response[] Parse(Azure.Response response, bool expectCrLf, System.Threading.CancellationToken cancellationToken) => throw null;
+            public static System.Threading.Tasks.Task<Azure.Response[]> ParseAsync(Azure.Response response, bool expectCrLf, System.Threading.CancellationToken cancellationToken) => throw null;
+        }
+        namespace Pipeline
+        {
+            public class BearerTokenAuthenticationPolicy : Azure.Core.Pipeline.HttpPipelinePolicy
+            {
+                protected void AuthenticateAndAuthorizeRequest(Azure.Core.HttpMessage message, Azure.Core.TokenRequestContext context) => throw null;
+                protected System.Threading.Tasks.ValueTask AuthenticateAndAuthorizeRequestAsync(Azure.Core.HttpMessage message, Azure.Core.TokenRequestContext context) => throw null;
+                protected virtual void AuthorizeRequest(Azure.Core.HttpMessage message) => throw null;
+                protected virtual System.Threading.Tasks.ValueTask AuthorizeRequestAsync(Azure.Core.HttpMessage message) => throw null;
+                protected virtual bool AuthorizeRequestOnChallenge(Azure.Core.HttpMessage message) => throw null;
+                protected virtual System.Threading.Tasks.ValueTask<bool> AuthorizeRequestOnChallengeAsync(Azure.Core.HttpMessage message) => throw null;
+                public BearerTokenAuthenticationPolicy(Azure.Core.TokenCredential credential, string scope) => throw null;
+                public BearerTokenAuthenticationPolicy(Azure.Core.TokenCredential credential, System.Collections.Generic.IEnumerable<string> scopes) => throw null;
+                public override void Process(Azure.Core.HttpMessage message, System.ReadOnlyMemory<Azure.Core.Pipeline.HttpPipelinePolicy> pipeline) => throw null;
+                public override System.Threading.Tasks.ValueTask ProcessAsync(Azure.Core.HttpMessage message, System.ReadOnlyMemory<Azure.Core.Pipeline.HttpPipelinePolicy> pipeline) => throw null;
+            }
+            public sealed class DisposableHttpPipeline : Azure.Core.Pipeline.HttpPipeline, System.IDisposable
+            {
+                public void Dispose() => throw null;
+                internal DisposableHttpPipeline() : base(default(Azure.Core.Pipeline.HttpPipelineTransport), default(Azure.Core.Pipeline.HttpPipelinePolicy[]), default(Azure.Core.ResponseClassifier)) { }
+            }
+            public class HttpClientTransport : Azure.Core.Pipeline.HttpPipelineTransport, System.IDisposable
+            {
+                public override sealed Azure.Core.Request CreateRequest() => throw null;
+                public HttpClientTransport() => throw null;
+                public HttpClientTransport(System.Net.Http.HttpMessageHandler messageHandler) => throw null;
+                public HttpClientTransport(System.Net.Http.HttpClient client) => throw null;
+                public void Dispose() => throw null;
+                public override void Process(Azure.Core.HttpMessage message) => throw null;
+                public override System.Threading.Tasks.ValueTask ProcessAsync(Azure.Core.HttpMessage message) => throw null;
+                public static readonly Azure.Core.Pipeline.HttpClientTransport Shared;
+            }
+            public class HttpPipeline
+            {
+                public static System.IDisposable CreateClientRequestIdScope(string clientRequestId) => throw null;
+                public static System.IDisposable CreateHttpMessagePropertiesScope(System.Collections.Generic.IDictionary<string, object> messageProperties) => throw null;
+                public Azure.Core.HttpMessage CreateMessage() => throw null;
+                public Azure.Core.HttpMessage CreateMessage(Azure.RequestContext context) => throw null;
+                public Azure.Core.HttpMessage CreateMessage(Azure.RequestContext context, Azure.Core.ResponseClassifier classifier = default(Azure.Core.ResponseClassifier)) => throw null;
+                public Azure.Core.Request CreateRequest() => throw null;
+                public HttpPipeline(Azure.Core.Pipeline.HttpPipelineTransport transport, Azure.Core.Pipeline.HttpPipelinePolicy[] policies = default(Azure.Core.Pipeline.HttpPipelinePolicy[]), Azure.Core.ResponseClassifier responseClassifier = default(Azure.Core.ResponseClassifier)) => throw null;
+                public Azure.Core.ResponseClassifier ResponseClassifier { get => throw null; }
+                public void Send(Azure.Core.HttpMessage message, System.Threading.CancellationToken cancellationToken) => throw null;
+                public System.Threading.Tasks.ValueTask SendAsync(Azure.Core.HttpMessage message, System.Threading.CancellationToken cancellationToken) => throw null;
+                public Azure.Response SendRequest(Azure.Core.Request request, System.Threading.CancellationToken cancellationToken) => throw null;
+                public System.Threading.Tasks.ValueTask<Azure.Response> SendRequestAsync(Azure.Core.Request request, System.Threading.CancellationToken cancellationToken) => throw null;
+            }
+            public static class HttpPipelineBuilder
+            {
+                public static Azure.Core.Pipeline.HttpPipeline Build(Azure.Core.ClientOptions options, params Azure.Core.Pipeline.HttpPipelinePolicy[] perRetryPolicies) => throw null;
+                public static Azure.Core.Pipeline.HttpPipeline Build(Azure.Core.ClientOptions options, Azure.Core.Pipeline.HttpPipelinePolicy[] perCallPolicies, Azure.Core.Pipeline.HttpPipelinePolicy[] perRetryPolicies, Azure.Core.ResponseClassifier responseClassifier) => throw null;
+                public static Azure.Core.Pipeline.DisposableHttpPipeline Build(Azure.Core.ClientOptions options, Azure.Core.Pipeline.HttpPipelinePolicy[] perCallPolicies, Azure.Core.Pipeline.HttpPipelinePolicy[] perRetryPolicies, Azure.Core.Pipeline.HttpPipelineTransportOptions transportOptions, Azure.Core.ResponseClassifier responseClassifier) => throw null;
+                public static Azure.Core.Pipeline.HttpPipeline Build(Azure.Core.Pipeline.HttpPipelineOptions options) => throw null;
+                public static Azure.Core.Pipeline.DisposableHttpPipeline Build(Azure.Core.Pipeline.HttpPipelineOptions options, Azure.Core.Pipeline.HttpPipelineTransportOptions transportOptions) => throw null;
+            }
+            public class HttpPipelineOptions
+            {
+                public Azure.Core.ClientOptions ClientOptions { get => throw null; }
+                public HttpPipelineOptions(Azure.Core.ClientOptions options) => throw null;
+                public System.Collections.Generic.IList<Azure.Core.Pipeline.HttpPipelinePolicy> PerCallPolicies { get => throw null; }
+                public System.Collections.Generic.IList<Azure.Core.Pipeline.HttpPipelinePolicy> PerRetryPolicies { get => throw null; }
+                public Azure.Core.RequestFailedDetailsParser RequestFailedDetailsParser { get => throw null; set { } }
+                public Azure.Core.ResponseClassifier ResponseClassifier { get => throw null; set { } }
+            }
+            public abstract class HttpPipelinePolicy
+            {
+                protected HttpPipelinePolicy() => throw null;
+                public abstract void Process(Azure.Core.HttpMessage message, System.ReadOnlyMemory<Azure.Core.Pipeline.HttpPipelinePolicy> pipeline);
+                public abstract System.Threading.Tasks.ValueTask ProcessAsync(Azure.Core.HttpMessage message, System.ReadOnlyMemory<Azure.Core.Pipeline.HttpPipelinePolicy> pipeline);
+                protected static void ProcessNext(Azure.Core.HttpMessage message, System.ReadOnlyMemory<Azure.Core.Pipeline.HttpPipelinePolicy> pipeline) => throw null;
+                protected static System.Threading.Tasks.ValueTask ProcessNextAsync(Azure.Core.HttpMessage message, System.ReadOnlyMemory<Azure.Core.Pipeline.HttpPipelinePolicy> pipeline) => throw null;
+            }
+            public abstract class HttpPipelineSynchronousPolicy : Azure.Core.Pipeline.HttpPipelinePolicy
+            {
+                protected HttpPipelineSynchronousPolicy() => throw null;
+                public virtual void OnReceivedResponse(Azure.Core.HttpMessage message) => throw null;
+                public virtual void OnSendingRequest(Azure.Core.HttpMessage message) => throw null;
+                public override void Process(Azure.Core.HttpMessage message, System.ReadOnlyMemory<Azure.Core.Pipeline.HttpPipelinePolicy> pipeline) => throw null;
+                public override System.Threading.Tasks.ValueTask ProcessAsync(Azure.Core.HttpMessage message, System.ReadOnlyMemory<Azure.Core.Pipeline.HttpPipelinePolicy> pipeline) => throw null;
+            }
+            public abstract class HttpPipelineTransport
+            {
+                public abstract Azure.Core.Request CreateRequest();
+                protected HttpPipelineTransport() => throw null;
+                public abstract void Process(Azure.Core.HttpMessage message);
+                public abstract System.Threading.Tasks.ValueTask ProcessAsync(Azure.Core.HttpMessage message);
+            }
+            public class HttpPipelineTransportOptions
+            {
+                public System.Collections.Generic.IList<System.Security.Cryptography.X509Certificates.X509Certificate2> ClientCertificates { get => throw null; }
+                public HttpPipelineTransportOptions() => throw null;
+                public bool IsClientRedirectEnabled { get => throw null; set { } }
+                public System.Func<Azure.Core.Pipeline.ServerCertificateCustomValidationArgs, bool> ServerCertificateCustomValidationCallback { get => throw null; set { } }
+            }
+            public sealed class RedirectPolicy : Azure.Core.Pipeline.HttpPipelinePolicy
+            {
+                public override void Process(Azure.Core.HttpMessage message, System.ReadOnlyMemory<Azure.Core.Pipeline.HttpPipelinePolicy> pipeline) => throw null;
+                public override System.Threading.Tasks.ValueTask ProcessAsync(Azure.Core.HttpMessage message, System.ReadOnlyMemory<Azure.Core.Pipeline.HttpPipelinePolicy> pipeline) => throw null;
+                public static void SetAllowAutoRedirect(Azure.Core.HttpMessage message, bool allowAutoRedirect) => throw null;
+            }
+            public class RetryPolicy : Azure.Core.Pipeline.HttpPipelinePolicy
+            {
+                public RetryPolicy(int maxRetries = default(int), Azure.Core.DelayStrategy delayStrategy = default(Azure.Core.DelayStrategy)) => throw null;
+                protected virtual void OnRequestSent(Azure.Core.HttpMessage message) => throw null;
+                protected virtual System.Threading.Tasks.ValueTask OnRequestSentAsync(Azure.Core.HttpMessage message) => throw null;
+                protected virtual void OnSendingRequest(Azure.Core.HttpMessage message) => throw null;
+                protected virtual System.Threading.Tasks.ValueTask OnSendingRequestAsync(Azure.Core.HttpMessage message) => throw null;
+                public override void Process(Azure.Core.HttpMessage message, System.ReadOnlyMemory<Azure.Core.Pipeline.HttpPipelinePolicy> pipeline) => throw null;
+                public override System.Threading.Tasks.ValueTask ProcessAsync(Azure.Core.HttpMessage message, System.ReadOnlyMemory<Azure.Core.Pipeline.HttpPipelinePolicy> pipeline) => throw null;
+                protected virtual bool ShouldRetry(Azure.Core.HttpMessage message, System.Exception exception) => throw null;
+                protected virtual System.Threading.Tasks.ValueTask<bool> ShouldRetryAsync(Azure.Core.HttpMessage message, System.Exception exception) => throw null;
+            }
+            public class ServerCertificateCustomValidationArgs
+            {
+                public System.Security.Cryptography.X509Certificates.X509Certificate2 Certificate { get => throw null; }
+                public System.Security.Cryptography.X509Certificates.X509Chain CertificateAuthorityChain { get => throw null; }
+                public ServerCertificateCustomValidationArgs(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, System.Security.Cryptography.X509Certificates.X509Chain certificateAuthorityChain, System.Net.Security.SslPolicyErrors sslPolicyErrors) => throw null;
+                public System.Net.Security.SslPolicyErrors SslPolicyErrors { get => throw null; }
+            }
+        }
+        public struct RehydrationToken : System.ClientModel.Primitives.IJsonModel<Azure.Core.RehydrationToken>, System.ClientModel.Primitives.IJsonModel<object>, System.ClientModel.Primitives.IPersistableModel<Azure.Core.RehydrationToken>, System.ClientModel.Primitives.IPersistableModel<object>
+        {
+            Azure.Core.RehydrationToken System.ClientModel.Primitives.IJsonModel<Azure.Core.RehydrationToken>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) => throw null;
+            Azure.Core.RehydrationToken System.ClientModel.Primitives.IPersistableModel<Azure.Core.RehydrationToken>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) => throw null;
+            object System.ClientModel.Primitives.IPersistableModel<object>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) => throw null;
+            object System.ClientModel.Primitives.IJsonModel<object>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) => throw null;
+            string System.ClientModel.Primitives.IPersistableModel<Azure.Core.RehydrationToken>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) => throw null;
+            string System.ClientModel.Primitives.IPersistableModel<object>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) => throw null;
+            public string Id { get => throw null; }
+            void System.ClientModel.Primitives.IJsonModel<Azure.Core.RehydrationToken>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) => throw null;
+            System.BinaryData System.ClientModel.Primitives.IPersistableModel<Azure.Core.RehydrationToken>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) => throw null;
+            System.BinaryData System.ClientModel.Primitives.IPersistableModel<object>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) => throw null;
+            void System.ClientModel.Primitives.IJsonModel<object>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) => throw null;
+        }
+        public abstract class Request : System.IDisposable
+        {
+            protected abstract void AddHeader(string name, string value);
+            public abstract string ClientRequestId { get; set; }
+            protected abstract bool ContainsHeader(string name);
+            public virtual Azure.Core.RequestContent Content { get => throw null; set { } }
+            protected Request() => throw null;
+            public abstract void Dispose();
+            protected abstract System.Collections.Generic.IEnumerable<Azure.Core.HttpHeader> EnumerateHeaders();
+            public Azure.Core.RequestHeaders Headers { get => throw null; }
+            public virtual Azure.Core.RequestMethod Method { get => throw null; set { } }
+            protected abstract bool RemoveHeader(string name);
+            protected virtual void SetHeader(string name, string value) => throw null;
+            protected abstract bool TryGetHeader(string name, out string value);
+            protected abstract bool TryGetHeaderValues(string name, out System.Collections.Generic.IEnumerable<string> values);
+            public virtual Azure.Core.RequestUriBuilder Uri { get => throw null; set { } }
+        }
+        public abstract class RequestContent : System.IDisposable
+        {
+            public static Azure.Core.RequestContent Create(System.IO.Stream stream) => throw null;
+            public static Azure.Core.RequestContent Create(byte[] bytes) => throw null;
+            public static Azure.Core.RequestContent Create(byte[] bytes, int index, int length) => throw null;
+            public static Azure.Core.RequestContent Create(System.ReadOnlyMemory<byte> bytes) => throw null;
+            public static Azure.Core.RequestContent Create(System.Buffers.ReadOnlySequence<byte> bytes) => throw null;
+            public static Azure.Core.RequestContent Create(string content) => throw null;
+            public static Azure.Core.RequestContent Create(System.BinaryData content) => throw null;
+            public static Azure.Core.RequestContent Create(Azure.Core.Serialization.DynamicData content) => throw null;
+            public static Azure.Core.RequestContent Create(object serializable) => throw null;
+            public static Azure.Core.RequestContent Create(object serializable, Azure.Core.Serialization.ObjectSerializer serializer) => throw null;
+            public static Azure.Core.RequestContent Create(object serializable, Azure.Core.Serialization.JsonPropertyNames propertyNameFormat, string dateTimeFormat = default(string)) => throw null;
+            protected RequestContent() => throw null;
+            public abstract void Dispose();
+            public static implicit operator Azure.Core.RequestContent(string content) => throw null;
+            public static implicit operator Azure.Core.RequestContent(System.BinaryData content) => throw null;
+            public static implicit operator Azure.Core.RequestContent(Azure.Core.Serialization.DynamicData content) => throw null;
+            public abstract bool TryComputeLength(out long length);
+            public abstract void WriteTo(System.IO.Stream stream, System.Threading.CancellationToken cancellation);
+            public abstract System.Threading.Tasks.Task WriteToAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellation);
+        }
+        public abstract class RequestFailedDetailsParser
+        {
+            protected RequestFailedDetailsParser() => throw null;
+            public abstract bool TryParse(Azure.Response response, out Azure.ResponseError error, out System.Collections.Generic.IDictionary<string, string> data);
+        }
+        public struct RequestHeaders : System.Collections.Generic.IEnumerable<Azure.Core.HttpHeader>, System.Collections.IEnumerable
+        {
+            public void Add(Azure.Core.HttpHeader header) => throw null;
+            public void Add(string name, string value) => throw null;
+            public bool Contains(string name) => throw null;
+            public System.Collections.Generic.IEnumerator<Azure.Core.HttpHeader> GetEnumerator() => throw null;
+            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null;
+            public bool Remove(string name) => throw null;
+            public void SetValue(string name, string value) => throw null;
+            public bool TryGetValue(string name, out string value) => throw null;
+            public bool TryGetValues(string name, out System.Collections.Generic.IEnumerable<string> values) => throw null;
+        }
+        public struct RequestMethod : System.IEquatable<Azure.Core.RequestMethod>
+        {
+            public RequestMethod(string method) => throw null;
+            public static Azure.Core.RequestMethod Delete { get => throw null; }
+            public bool Equals(Azure.Core.RequestMethod other) => throw null;
+            public override bool Equals(object obj) => throw null;
+            public static Azure.Core.RequestMethod Get { get => throw null; }
+            public override int GetHashCode() => throw null;
+            public static Azure.Core.RequestMethod Head { get => throw null; }
+            public string Method { get => throw null; }
+            public static bool operator ==(Azure.Core.RequestMethod left, Azure.Core.RequestMethod right) => throw null;
+            public static bool operator !=(Azure.Core.RequestMethod left, Azure.Core.RequestMethod right) => throw null;
+            public static Azure.Core.RequestMethod Options { get => throw null; }
+            public static Azure.Core.RequestMethod Parse(string method) => throw null;
+            public static Azure.Core.RequestMethod Patch { get => throw null; }
+            public static Azure.Core.RequestMethod Post { get => throw null; }
+            public static Azure.Core.RequestMethod Put { get => throw null; }
+            public override string ToString() => throw null;
+            public static Azure.Core.RequestMethod Trace { get => throw null; }
+        }
+        public class RequestUriBuilder
+        {
+            public void AppendPath(string value) => throw null;
+            public void AppendPath(string value, bool escape) => throw null;
+            public void AppendPath(System.ReadOnlySpan<char> value, bool escape) => throw null;
+            public void AppendQuery(string name, string value) => throw null;
+            public void AppendQuery(string name, string value, bool escapeValue) => throw null;
+            public void AppendQuery(System.ReadOnlySpan<char> name, System.ReadOnlySpan<char> value, bool escapeValue) => throw null;
+            public RequestUriBuilder() => throw null;
+            protected bool HasPath { get => throw null; }
+            protected bool HasQuery { get => throw null; }
+            public string Host { get => throw null; set { } }
+            public string Path { get => throw null; set { } }
+            public string PathAndQuery { get => throw null; }
+            public int Port { get => throw null; set { } }
+            public string Query { get => throw null; set { } }
+            public void Reset(System.Uri value) => throw null;
+            public string Scheme { get => throw null; set { } }
+            public override string ToString() => throw null;
+            public System.Uri ToUri() => throw null;
+        }
+        public sealed class ResourceIdentifier : System.IComparable<Azure.Core.ResourceIdentifier>, System.IEquatable<Azure.Core.ResourceIdentifier>
+        {
+            public Azure.Core.ResourceIdentifier AppendChildResource(string childResourceType, string childResourceName) => throw null;
+            public Azure.Core.ResourceIdentifier AppendProviderResource(string providerNamespace, string resourceType, string resourceName) => throw null;
+            public int CompareTo(Azure.Core.ResourceIdentifier other) => throw null;
+            public ResourceIdentifier(string resourceId) => throw null;
+            public bool Equals(Azure.Core.ResourceIdentifier other) => throw null;
+            public override bool Equals(object obj) => throw null;
+            public override int GetHashCode() => throw null;
+            public Azure.Core.AzureLocation? Location { get => throw null; }
+            public string Name { get => throw null; }
+            public static bool operator ==(Azure.Core.ResourceIdentifier left, Azure.Core.ResourceIdentifier right) => throw null;
+            public static bool operator >(Azure.Core.ResourceIdentifier left, Azure.Core.ResourceIdentifier right) => throw null;
+            public static bool operator >=(Azure.Core.ResourceIdentifier left, Azure.Core.ResourceIdentifier right) => throw null;
+            public static implicit operator string(Azure.Core.ResourceIdentifier id) => throw null;
+            public static bool operator !=(Azure.Core.ResourceIdentifier left, Azure.Core.ResourceIdentifier right) => throw null;
+            public static bool operator <(Azure.Core.ResourceIdentifier left, Azure.Core.ResourceIdentifier right) => throw null;
+            public static bool operator <=(Azure.Core.ResourceIdentifier left, Azure.Core.ResourceIdentifier right) => throw null;
+            public Azure.Core.ResourceIdentifier Parent { get => throw null; }
+            public static Azure.Core.ResourceIdentifier Parse(string input) => throw null;
+            public string Provider { get => throw null; }
+            public string ResourceGroupName { get => throw null; }
+            public Azure.Core.ResourceType ResourceType { get => throw null; }
+            public static readonly Azure.Core.ResourceIdentifier Root;
+            public string SubscriptionId { get => throw null; }
+            public override string ToString() => throw null;
+            public static bool TryParse(string input, out Azure.Core.ResourceIdentifier result) => throw null;
+        }
+        public struct ResourceType : System.IEquatable<Azure.Core.ResourceType>
+        {
+            public ResourceType(string resourceType) => throw null;
+            public bool Equals(Azure.Core.ResourceType other) => throw null;
+            public override bool Equals(object other) => throw null;
+            public override int GetHashCode() => throw null;
+            public string GetLastType() => throw null;
+            public string Namespace { get => throw null; }
+            public static bool operator ==(Azure.Core.ResourceType left, Azure.Core.ResourceType right) => throw null;
+            public static implicit operator Azure.Core.ResourceType(string resourceType) => throw null;
+            public static implicit operator string(Azure.Core.ResourceType resourceType) => throw null;
+            public static bool operator !=(Azure.Core.ResourceType left, Azure.Core.ResourceType right) => throw null;
+            public override string ToString() => throw null;
+            public string Type { get => throw null; }
+        }
+        public abstract class ResponseClassificationHandler
+        {
+            protected ResponseClassificationHandler() => throw null;
+            public abstract bool TryClassify(Azure.Core.HttpMessage message, out bool isError);
+        }
+        public class ResponseClassifier
+        {
+            public ResponseClassifier() => throw null;
+            public virtual bool IsErrorResponse(Azure.Core.HttpMessage message) => throw null;
+            public virtual bool IsRetriable(Azure.Core.HttpMessage message, System.Exception exception) => throw null;
+            public virtual bool IsRetriableException(System.Exception exception) => throw null;
+            public virtual bool IsRetriableResponse(Azure.Core.HttpMessage message) => throw null;
+        }
+        public struct ResponseHeaders : System.Collections.Generic.IEnumerable<Azure.Core.HttpHeader>, System.Collections.IEnumerable
+        {
+            public bool Contains(string name) => throw null;
+            public int? ContentLength { get => throw null; }
+            public long? ContentLengthLong { get => throw null; }
+            public string ContentType { get => throw null; }
+            public System.DateTimeOffset? Date { get => throw null; }
+            public Azure.ETag? ETag { get => throw null; }
+            public System.Collections.Generic.IEnumerator<Azure.Core.HttpHeader> GetEnumerator() => throw null;
+            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null;
+            public string RequestId { get => throw null; }
+            public bool TryGetValue(string name, out string value) => throw null;
+            public bool TryGetValues(string name, out System.Collections.Generic.IEnumerable<string> values) => throw null;
+        }
+        public enum RetryMode
+        {
+            Fixed = 0,
+            Exponential = 1,
+        }
+        public class RetryOptions
+        {
+            public System.TimeSpan Delay { get => throw null; set { } }
+            public System.TimeSpan MaxDelay { get => throw null; set { } }
+            public int MaxRetries { get => throw null; set { } }
+            public Azure.Core.RetryMode Mode { get => throw null; set { } }
+            public System.TimeSpan NetworkTimeout { get => throw null; set { } }
+        }
+        namespace Serialization
+        {
+            public sealed class DynamicData : System.IDisposable, System.Dynamic.IDynamicMetaObjectProvider
+            {
+                public void Dispose() => throw null;
+                public override bool Equals(object obj) => throw null;
+                public override int GetHashCode() => throw null;
+                System.Dynamic.DynamicMetaObject System.Dynamic.IDynamicMetaObjectProvider.GetMetaObject(System.Linq.Expressions.Expression parameter) => throw null;
+                public static bool operator ==(Azure.Core.Serialization.DynamicData left, object right) => throw null;
+                public static explicit operator System.DateTime(Azure.Core.Serialization.DynamicData value) => throw null;
+                public static explicit operator System.DateTimeOffset(Azure.Core.Serialization.DynamicData value) => throw null;
+                public static explicit operator System.Guid(Azure.Core.Serialization.DynamicData value) => throw null;
+                public static implicit operator bool(Azure.Core.Serialization.DynamicData value) => throw null;
+                public static implicit operator string(Azure.Core.Serialization.DynamicData value) => throw null;
+                public static implicit operator byte(Azure.Core.Serialization.DynamicData value) => throw null;
+                public static implicit operator sbyte(Azure.Core.Serialization.DynamicData value) => throw null;
+                public static implicit operator short(Azure.Core.Serialization.DynamicData value) => throw null;
+                public static implicit operator ushort(Azure.Core.Serialization.DynamicData value) => throw null;
+                public static implicit operator int(Azure.Core.Serialization.DynamicData value) => throw null;
+                public static implicit operator uint(Azure.Core.Serialization.DynamicData value) => throw null;
+                public static implicit operator long(Azure.Core.Serialization.DynamicData value) => throw null;
+                public static implicit operator ulong(Azure.Core.Serialization.DynamicData value) => throw null;
+                public static implicit operator float(Azure.Core.Serialization.DynamicData value) => throw null;
+                public static implicit operator double(Azure.Core.Serialization.DynamicData value) => throw null;
+                public static implicit operator decimal(Azure.Core.Serialization.DynamicData value) => throw null;
+                public static bool operator !=(Azure.Core.Serialization.DynamicData left, object right) => throw null;
+                public override string ToString() => throw null;
+            }
+            public interface IMemberNameConverter
+            {
+                string ConvertMemberName(System.Reflection.MemberInfo member);
+            }
+            public class JsonObjectSerializer : Azure.Core.Serialization.ObjectSerializer, Azure.Core.Serialization.IMemberNameConverter
+            {
+                string Azure.Core.Serialization.IMemberNameConverter.ConvertMemberName(System.Reflection.MemberInfo member) => throw null;
+                public JsonObjectSerializer() => throw null;
+                public JsonObjectSerializer(System.Text.Json.JsonSerializerOptions options) => throw null;
+                public static Azure.Core.Serialization.JsonObjectSerializer Default { get => throw null; }
+                public override object Deserialize(System.IO.Stream stream, System.Type returnType, System.Threading.CancellationToken cancellationToken) => throw null;
+                public override System.Threading.Tasks.ValueTask<object> DeserializeAsync(System.IO.Stream stream, System.Type returnType, System.Threading.CancellationToken cancellationToken) => throw null;
+                public override void Serialize(System.IO.Stream stream, object value, System.Type inputType, System.Threading.CancellationToken cancellationToken) => throw null;
+                public override System.BinaryData Serialize(object value, System.Type inputType = default(System.Type), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+                public override System.Threading.Tasks.ValueTask SerializeAsync(System.IO.Stream stream, object value, System.Type inputType, System.Threading.CancellationToken cancellationToken) => throw null;
+                public override System.Threading.Tasks.ValueTask<System.BinaryData> SerializeAsync(object value, System.Type inputType = default(System.Type), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+            }
+            public enum JsonPropertyNames
+            {
+                UseExact = 0,
+                CamelCase = 1,
+            }
+            public abstract class ObjectSerializer
+            {
+                protected ObjectSerializer() => throw null;
+                public abstract object Deserialize(System.IO.Stream stream, System.Type returnType, System.Threading.CancellationToken cancellationToken);
+                public abstract System.Threading.Tasks.ValueTask<object> DeserializeAsync(System.IO.Stream stream, System.Type returnType, System.Threading.CancellationToken cancellationToken);
+                public abstract void Serialize(System.IO.Stream stream, object value, System.Type inputType, System.Threading.CancellationToken cancellationToken);
+                public virtual System.BinaryData Serialize(object value, System.Type inputType = default(System.Type), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+                public abstract System.Threading.Tasks.ValueTask SerializeAsync(System.IO.Stream stream, object value, System.Type inputType, System.Threading.CancellationToken cancellationToken);
+                public virtual System.Threading.Tasks.ValueTask<System.BinaryData> SerializeAsync(object value, System.Type inputType = default(System.Type), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+            }
+        }
+        public class StatusCodeClassifier : Azure.Core.ResponseClassifier
+        {
+            public StatusCodeClassifier(System.ReadOnlySpan<ushort> successStatusCodes) => throw null;
+            public override bool IsErrorResponse(Azure.Core.HttpMessage message) => throw null;
+        }
+        public delegate System.Threading.Tasks.Task SyncAsyncEventHandler<T>(T e) where T : Azure.SyncAsyncEventArgs;
+        public class TelemetryDetails
+        {
+            public string ApplicationId { get => throw null; }
+            public void Apply(Azure.Core.HttpMessage message) => throw null;
+            public System.Reflection.Assembly Assembly { get => throw null; }
+            public TelemetryDetails(System.Reflection.Assembly assembly, string applicationId = default(string)) => throw null;
+            public override string ToString() => throw null;
+        }
+        public abstract class TokenCredential
+        {
+            protected TokenCredential() => throw null;
+            public abstract Azure.Core.AccessToken GetToken(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken);
+            public abstract System.Threading.Tasks.ValueTask<Azure.Core.AccessToken> GetTokenAsync(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken);
+        }
+        public struct TokenRequestContext
+        {
+            public string Claims { get => throw null; }
+            public TokenRequestContext(string[] scopes, string parentRequestId) => throw null;
+            public TokenRequestContext(string[] scopes, string parentRequestId, string claims) => throw null;
+            public TokenRequestContext(string[] scopes, string parentRequestId, string claims, string tenantId) => throw null;
+            public TokenRequestContext(string[] scopes, string parentRequestId = default(string), string claims = default(string), string tenantId = default(string), bool isCaeEnabled = default(bool)) => throw null;
+            public bool IsCaeEnabled { get => throw null; }
+            public string ParentRequestId { get => throw null; }
+            public string[] Scopes { get => throw null; }
+            public string TenantId { get => throw null; }
+        }
+    }
+    [System.Flags]
+    public enum ErrorOptions
+    {
+        Default = 0,
+        NoThrow = 1,
+    }
+    public struct ETag : System.IEquatable<Azure.ETag>
+    {
+        public static readonly Azure.ETag All;
+        public ETag(string etag) => throw null;
+        public bool Equals(Azure.ETag other) => throw null;
+        public bool Equals(string other) => throw null;
+        public override bool Equals(object obj) => throw null;
+        public override int GetHashCode() => throw null;
+        public static bool operator ==(Azure.ETag left, Azure.ETag right) => throw null;
+        public static bool operator !=(Azure.ETag left, Azure.ETag right) => throw null;
+        public override string ToString() => throw null;
+        public string ToString(string format) => throw null;
+    }
+    public class HttpAuthorization
+    {
+        public HttpAuthorization(string scheme, string parameter) => throw null;
+        public string Parameter { get => throw null; }
+        public string Scheme { get => throw null; }
+        public override string ToString() => throw null;
+    }
+    public struct HttpRange : System.IEquatable<Azure.HttpRange>
+    {
+        public HttpRange(long offset = default(long), long? length = default(long?)) => throw null;
+        public bool Equals(Azure.HttpRange other) => throw null;
+        public override bool Equals(object obj) => throw null;
+        public override int GetHashCode() => throw null;
+        public long? Length { get => throw null; }
+        public long Offset { get => throw null; }
+        public static bool operator ==(Azure.HttpRange left, Azure.HttpRange right) => throw null;
+        public static bool operator !=(Azure.HttpRange left, Azure.HttpRange right) => throw null;
+        public override string ToString() => throw null;
+    }
+    public class JsonPatchDocument
+    {
+        public void AppendAdd<T>(string path, T value) => throw null;
+        public void AppendAddRaw(string path, string rawJsonValue) => throw null;
+        public void AppendCopy(string from, string path) => throw null;
+        public void AppendMove(string from, string path) => throw null;
+        public void AppendRemove(string path) => throw null;
+        public void AppendReplace<T>(string path, T value) => throw null;
+        public void AppendReplaceRaw(string path, string rawJsonValue) => throw null;
+        public void AppendTest<T>(string path, T value) => throw null;
+        public void AppendTestRaw(string path, string rawJsonValue) => throw null;
+        public JsonPatchDocument() => throw null;
+        public JsonPatchDocument(Azure.Core.Serialization.ObjectSerializer serializer) => throw null;
+        public JsonPatchDocument(System.ReadOnlyMemory<byte> rawDocument) => throw null;
+        public JsonPatchDocument(System.ReadOnlyMemory<byte> rawDocument, Azure.Core.Serialization.ObjectSerializer serializer) => throw null;
+        public System.ReadOnlyMemory<byte> ToBytes() => throw null;
+        public override string ToString() => throw null;
+    }
+    public class MatchConditions
+    {
+        public MatchConditions() => throw null;
+        public Azure.ETag? IfMatch { get => throw null; set { } }
+        public Azure.ETag? IfNoneMatch { get => throw null; set { } }
+    }
+    namespace Messaging
+    {
+        public class CloudEvent
+        {
+            public CloudEvent(string source, string type, object jsonSerializableData, System.Type dataSerializationType = default(System.Type)) => throw null;
+            public CloudEvent(string source, string type, System.BinaryData data, string dataContentType, Azure.Messaging.CloudEventDataFormat dataFormat = default(Azure.Messaging.CloudEventDataFormat)) => throw null;
+            public System.BinaryData Data { get => throw null; set { } }
+            public string DataContentType { get => throw null; set { } }
+            public string DataSchema { get => throw null; set { } }
+            public System.Collections.Generic.IDictionary<string, object> ExtensionAttributes { get => throw null; }
+            public string Id { get => throw null; set { } }
+            public static Azure.Messaging.CloudEvent Parse(System.BinaryData json, bool skipValidation = default(bool)) => throw null;
+            public static Azure.Messaging.CloudEvent[] ParseMany(System.BinaryData json, bool skipValidation = default(bool)) => throw null;
+            public string Source { get => throw null; set { } }
+            public string Subject { get => throw null; set { } }
+            public System.DateTimeOffset? Time { get => throw null; set { } }
+            public string Type { get => throw null; set { } }
+        }
+        public enum CloudEventDataFormat
+        {
+            Binary = 0,
+            Json = 1,
+        }
+        public class MessageContent
+        {
+            public virtual Azure.Core.ContentType? ContentType { get => throw null; set { } }
+            protected virtual Azure.Core.ContentType? ContentTypeCore { get => throw null; set { } }
+            public MessageContent() => throw null;
+            public virtual System.BinaryData Data { get => throw null; set { } }
+            public virtual bool IsReadOnly { get => throw null; }
+        }
+    }
+    public abstract class NullableResponse<T>
+    {
+        protected NullableResponse() => throw null;
+        public override bool Equals(object obj) => throw null;
+        public override int GetHashCode() => throw null;
+        public abstract Azure.Response GetRawResponse();
+        public abstract bool HasValue { get; }
+        public override string ToString() => throw null;
+        public abstract T Value { get; }
+    }
+    public abstract class Operation
+    {
+        protected Operation() => throw null;
+        public override bool Equals(object obj) => throw null;
+        public override int GetHashCode() => throw null;
+        public abstract Azure.Response GetRawResponse();
+        public virtual Azure.Core.RehydrationToken? GetRehydrationToken() => throw null;
+        public abstract bool HasCompleted { get; }
+        public abstract string Id { get; }
+        public override string ToString() => throw null;
+        public abstract Azure.Response UpdateStatus(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        public abstract System.Threading.Tasks.ValueTask<Azure.Response> UpdateStatusAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        public virtual Azure.Response WaitForCompletionResponse(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+        public virtual Azure.Response WaitForCompletionResponse(System.TimeSpan pollingInterval, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+        public virtual Azure.Response WaitForCompletionResponse(Azure.Core.DelayStrategy delayStrategy, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+        public virtual System.Threading.Tasks.ValueTask<Azure.Response> WaitForCompletionResponseAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+        public virtual System.Threading.Tasks.ValueTask<Azure.Response> WaitForCompletionResponseAsync(System.TimeSpan pollingInterval, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+        public virtual System.Threading.Tasks.ValueTask<Azure.Response> WaitForCompletionResponseAsync(Azure.Core.DelayStrategy delayStrategy, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+    }
+    public abstract class Operation<T> : Azure.Operation
+    {
+        protected Operation() => throw null;
+        public abstract bool HasValue { get; }
+        public abstract T Value { get; }
+        public virtual Azure.Response<T> WaitForCompletion(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+        public virtual Azure.Response<T> WaitForCompletion(System.TimeSpan pollingInterval, System.Threading.CancellationToken cancellationToken) => throw null;
+        public virtual Azure.Response<T> WaitForCompletion(Azure.Core.DelayStrategy delayStrategy, System.Threading.CancellationToken cancellationToken) => throw null;
+        public virtual System.Threading.Tasks.ValueTask<Azure.Response<T>> WaitForCompletionAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+        public virtual System.Threading.Tasks.ValueTask<Azure.Response<T>> WaitForCompletionAsync(System.TimeSpan pollingInterval, System.Threading.CancellationToken cancellationToken) => throw null;
+        public virtual System.Threading.Tasks.ValueTask<Azure.Response<T>> WaitForCompletionAsync(Azure.Core.DelayStrategy delayStrategy, System.Threading.CancellationToken cancellationToken) => throw null;
+        public override System.Threading.Tasks.ValueTask<Azure.Response> WaitForCompletionResponseAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+        public override System.Threading.Tasks.ValueTask<Azure.Response> WaitForCompletionResponseAsync(System.TimeSpan pollingInterval, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+    }
+    public abstract class Page<T>
+    {
+        public abstract string ContinuationToken { get; }
+        protected Page() => throw null;
+        public override bool Equals(object obj) => throw null;
+        public static Azure.Page<T> FromValues(System.Collections.Generic.IReadOnlyList<T> values, string continuationToken, Azure.Response response) => throw null;
+        public override int GetHashCode() => throw null;
+        public abstract Azure.Response GetRawResponse();
+        public override string ToString() => throw null;
+        public abstract System.Collections.Generic.IReadOnlyList<T> Values { get; }
+    }
+    public abstract class Pageable<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable
+    {
+        public abstract System.Collections.Generic.IEnumerable<Azure.Page<T>> AsPages(string continuationToken = default(string), int? pageSizeHint = default(int?));
+        protected virtual System.Threading.CancellationToken CancellationToken { get => throw null; }
+        protected Pageable() => throw null;
+        protected Pageable(System.Threading.CancellationToken cancellationToken) => throw null;
+        public override bool Equals(object obj) => throw null;
+        public static Azure.Pageable<T> FromPages(System.Collections.Generic.IEnumerable<Azure.Page<T>> pages) => throw null;
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null;
+        public virtual System.Collections.Generic.IEnumerator<T> GetEnumerator() => throw null;
+        public override int GetHashCode() => throw null;
+        public override string ToString() => throw null;
+    }
+    public abstract class PageableOperation<T> : Azure.Operation<Azure.AsyncPageable<T>>
+    {
+        protected PageableOperation() => throw null;
+        public abstract Azure.Pageable<T> GetValues(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        public abstract Azure.AsyncPageable<T> GetValuesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        public override Azure.AsyncPageable<T> Value { get => throw null; }
+    }
+    public class RequestConditions : Azure.MatchConditions
+    {
+        public RequestConditions() => throw null;
+        public System.DateTimeOffset? IfModifiedSince { get => throw null; set { } }
+        public System.DateTimeOffset? IfUnmodifiedSince { get => throw null; set { } }
+    }
+    public class RequestContext
+    {
+        public void AddClassifier(int statusCode, bool isError) => throw null;
+        public void AddClassifier(Azure.Core.ResponseClassificationHandler classifier) => throw null;
+        public void AddPolicy(Azure.Core.Pipeline.HttpPipelinePolicy policy, Azure.Core.HttpPipelinePosition position) => throw null;
+        public System.Threading.CancellationToken CancellationToken { get => throw null; set { } }
+        public RequestContext() => throw null;
+        public Azure.ErrorOptions ErrorOptions { get => throw null; set { } }
+        public static implicit operator Azure.RequestContext(Azure.ErrorOptions options) => throw null;
+    }
+    public class RequestFailedException : System.Exception, System.Runtime.Serialization.ISerializable
+    {
+        public RequestFailedException(string message) => throw null;
+        public RequestFailedException(string message, System.Exception innerException) => throw null;
+        public RequestFailedException(int status, string message) => throw null;
+        public RequestFailedException(int status, string message, System.Exception innerException) => throw null;
+        public RequestFailedException(int status, string message, string errorCode, System.Exception innerException) => throw null;
+        public RequestFailedException(Azure.Response response) => throw null;
+        public RequestFailedException(Azure.Response response, System.Exception innerException) => throw null;
+        public RequestFailedException(Azure.Response response, System.Exception innerException, Azure.Core.RequestFailedDetailsParser detailsParser) => throw null;
+        protected RequestFailedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) => throw null;
+        public string ErrorCode { get => throw null; }
+        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) => throw null;
+        public Azure.Response GetRawResponse() => throw null;
+        public int Status { get => throw null; }
+    }
+    public abstract class Response : System.IDisposable
+    {
+        public abstract string ClientRequestId { get; set; }
+        protected abstract bool ContainsHeader(string name);
+        public virtual System.BinaryData Content { get => throw null; }
+        public abstract System.IO.Stream ContentStream { get; set; }
+        protected Response() => throw null;
+        public abstract void Dispose();
+        protected abstract System.Collections.Generic.IEnumerable<Azure.Core.HttpHeader> EnumerateHeaders();
+        public static Azure.Response<T> FromValue<T>(T value, Azure.Response response) => throw null;
+        public virtual Azure.Core.ResponseHeaders Headers { get => throw null; }
+        public virtual bool IsError { get => throw null; set { } }
+        public abstract string ReasonPhrase { get; }
+        public abstract int Status { get; }
+        public override string ToString() => throw null;
+        protected abstract bool TryGetHeader(string name, out string value);
+        protected abstract bool TryGetHeaderValues(string name, out System.Collections.Generic.IEnumerable<string> values);
+    }
+    public abstract class Response<T> : Azure.NullableResponse<T>
+    {
+        protected Response() => throw null;
+        public override bool Equals(object obj) => throw null;
+        public override int GetHashCode() => throw null;
+        public override bool HasValue { get => throw null; }
+        public static implicit operator T(Azure.Response<T> response) => throw null;
+        public override T Value { get => throw null; }
+    }
+    public sealed class ResponseError
+    {
+        public string Code { get => throw null; }
+        public ResponseError(string code, string message) => throw null;
+        public string Message { get => throw null; }
+        public override string ToString() => throw null;
+    }
+    public class SyncAsyncEventArgs : System.EventArgs
+    {
+        public System.Threading.CancellationToken CancellationToken { get => throw null; }
+        public SyncAsyncEventArgs(bool isRunningSynchronously, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+        public bool IsRunningSynchronously { get => throw null; }
+    }
+    public enum WaitUntil
+    {
+        Completed = 0,
+        Started = 1,
+    }
+}

--- a/csharp/ql/test/resources/stubs/Azure.Core/1.38.0/Azure.Core.csproj
+++ b/csharp/ql/test/resources/stubs/Azure.Core/1.38.0/Azure.Core.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputPath>bin\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../Microsoft.Bcl.AsyncInterfaces/1.1.1/Microsoft.Bcl.AsyncInterfaces.csproj" />
+    <ProjectReference Include="../../System.ClientModel/1.0.0/System.ClientModel.csproj" />
+    <ProjectReference Include="../../System.Diagnostics.DiagnosticSource/6.0.1/System.Diagnostics.DiagnosticSource.csproj" />
+    <ProjectReference Include="../../System.Memory.Data/1.0.2/System.Memory.Data.csproj" />
+    <ProjectReference Include="../../System.Numerics.Vectors/4.5.0/System.Numerics.Vectors.csproj" />
+    <ProjectReference Include="../../System.Text.Encodings.Web/4.7.2/System.Text.Encodings.Web.csproj" />
+    <ProjectReference Include="../../System.Text.Json/4.7.2/System.Text.Json.csproj" />
+    <ProjectReference Include="../../System.Threading.Tasks.Extensions/4.5.4/System.Threading.Tasks.Extensions.csproj" />
+    <ProjectReference Include="../../_frameworks/Microsoft.NETCore.App/Microsoft.NETCore.App.csproj" />
+  </ItemGroup>
+</Project>

--- a/csharp/ql/test/resources/stubs/Azure.Identity/1.11.4/Azure.Identity.cs
+++ b/csharp/ql/test/resources/stubs/Azure.Identity/1.11.4/Azure.Identity.cs
@@ -1,0 +1,431 @@
+// This file contains auto-generated code.
+// Generated from `Azure.Identity, Version=1.11.4.0, Culture=neutral, PublicKeyToken=92742159e12e44c8`.
+namespace Azure
+{
+    namespace Identity
+    {
+        public class AuthenticationFailedException : System.Exception
+        {
+            public AuthenticationFailedException(string message) => throw null;
+            public AuthenticationFailedException(string message, System.Exception innerException) => throw null;
+            protected AuthenticationFailedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) => throw null;
+        }
+        public class AuthenticationRecord
+        {
+            public string Authority { get => throw null; }
+            public string ClientId { get => throw null; }
+            public static Azure.Identity.AuthenticationRecord Deserialize(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+            public static System.Threading.Tasks.Task<Azure.Identity.AuthenticationRecord> DeserializeAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+            public string HomeAccountId { get => throw null; }
+            public void Serialize(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+            public System.Threading.Tasks.Task SerializeAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+            public string TenantId { get => throw null; }
+            public string Username { get => throw null; }
+        }
+        public class AuthenticationRequiredException : Azure.Identity.CredentialUnavailableException
+        {
+            public AuthenticationRequiredException(string message, Azure.Core.TokenRequestContext context) : base(default(string)) => throw null;
+            public AuthenticationRequiredException(string message, Azure.Core.TokenRequestContext context, System.Exception innerException) : base(default(string)) => throw null;
+            protected AuthenticationRequiredException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(default(string)) => throw null;
+            public Azure.Core.TokenRequestContext TokenRequestContext { get => throw null; }
+        }
+        public class AuthorizationCodeCredential : Azure.Core.TokenCredential
+        {
+            protected AuthorizationCodeCredential() => throw null;
+            public AuthorizationCodeCredential(string tenantId, string clientId, string clientSecret, string authorizationCode) => throw null;
+            public AuthorizationCodeCredential(string tenantId, string clientId, string clientSecret, string authorizationCode, Azure.Identity.AuthorizationCodeCredentialOptions options) => throw null;
+            public AuthorizationCodeCredential(string tenantId, string clientId, string clientSecret, string authorizationCode, Azure.Identity.TokenCredentialOptions options) => throw null;
+            public override Azure.Core.AccessToken GetToken(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+            public override System.Threading.Tasks.ValueTask<Azure.Core.AccessToken> GetTokenAsync(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+        }
+        public class AuthorizationCodeCredentialOptions : Azure.Identity.TokenCredentialOptions
+        {
+            public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get => throw null; }
+            public AuthorizationCodeCredentialOptions() => throw null;
+            public bool DisableInstanceDiscovery { get => throw null; set { } }
+            public System.Uri RedirectUri { get => throw null; set { } }
+        }
+        public static class AzureAuthorityHosts
+        {
+            public static System.Uri AzureChina { get => throw null; }
+            public static System.Uri AzureGermany { get => throw null; }
+            public static System.Uri AzureGovernment { get => throw null; }
+            public static System.Uri AzurePublicCloud { get => throw null; }
+        }
+        public class AzureCliCredential : Azure.Core.TokenCredential
+        {
+            public AzureCliCredential() => throw null;
+            public AzureCliCredential(Azure.Identity.AzureCliCredentialOptions options) => throw null;
+            public override Azure.Core.AccessToken GetToken(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+            public override System.Threading.Tasks.ValueTask<Azure.Core.AccessToken> GetTokenAsync(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+        }
+        public class AzureCliCredentialOptions : Azure.Identity.TokenCredentialOptions
+        {
+            public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get => throw null; }
+            public AzureCliCredentialOptions() => throw null;
+            public System.TimeSpan? ProcessTimeout { get => throw null; set { } }
+            public string TenantId { get => throw null; set { } }
+        }
+        public class AzureDeveloperCliCredential : Azure.Core.TokenCredential
+        {
+            public AzureDeveloperCliCredential() => throw null;
+            public AzureDeveloperCliCredential(Azure.Identity.AzureDeveloperCliCredentialOptions options) => throw null;
+            public override Azure.Core.AccessToken GetToken(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+            public override System.Threading.Tasks.ValueTask<Azure.Core.AccessToken> GetTokenAsync(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+        }
+        public class AzureDeveloperCliCredentialOptions : Azure.Identity.TokenCredentialOptions
+        {
+            public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get => throw null; }
+            public AzureDeveloperCliCredentialOptions() => throw null;
+            public System.TimeSpan? ProcessTimeout { get => throw null; set { } }
+            public string TenantId { get => throw null; set { } }
+        }
+        public class AzurePowerShellCredential : Azure.Core.TokenCredential
+        {
+            public AzurePowerShellCredential() => throw null;
+            public AzurePowerShellCredential(Azure.Identity.AzurePowerShellCredentialOptions options) => throw null;
+            public override Azure.Core.AccessToken GetToken(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken) => throw null;
+            public override System.Threading.Tasks.ValueTask<Azure.Core.AccessToken> GetTokenAsync(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+        }
+        public class AzurePowerShellCredentialOptions : Azure.Identity.TokenCredentialOptions
+        {
+            public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get => throw null; }
+            public AzurePowerShellCredentialOptions() => throw null;
+            public System.TimeSpan? ProcessTimeout { get => throw null; set { } }
+            public string TenantId { get => throw null; set { } }
+        }
+        public class BrowserCustomizationOptions
+        {
+            public BrowserCustomizationOptions() => throw null;
+            public string ErrorMessage { get => throw null; set { } }
+            public string SuccessMessage { get => throw null; set { } }
+            public bool? UseEmbeddedWebView { get => throw null; set { } }
+        }
+        public class ChainedTokenCredential : Azure.Core.TokenCredential
+        {
+            public ChainedTokenCredential(params Azure.Core.TokenCredential[] sources) => throw null;
+            public override Azure.Core.AccessToken GetToken(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+            public override System.Threading.Tasks.ValueTask<Azure.Core.AccessToken> GetTokenAsync(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+        }
+        public class ClientAssertionCredential : Azure.Core.TokenCredential
+        {
+            protected ClientAssertionCredential() => throw null;
+            public ClientAssertionCredential(string tenantId, string clientId, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<string>> assertionCallback, Azure.Identity.ClientAssertionCredentialOptions options = default(Azure.Identity.ClientAssertionCredentialOptions)) => throw null;
+            public ClientAssertionCredential(string tenantId, string clientId, System.Func<string> assertionCallback, Azure.Identity.ClientAssertionCredentialOptions options = default(Azure.Identity.ClientAssertionCredentialOptions)) => throw null;
+            public override Azure.Core.AccessToken GetToken(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+            public override System.Threading.Tasks.ValueTask<Azure.Core.AccessToken> GetTokenAsync(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+        }
+        public class ClientAssertionCredentialOptions : Azure.Identity.TokenCredentialOptions
+        {
+            public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get => throw null; }
+            public ClientAssertionCredentialOptions() => throw null;
+            public bool DisableInstanceDiscovery { get => throw null; set { } }
+        }
+        public class ClientCertificateCredential : Azure.Core.TokenCredential
+        {
+            protected ClientCertificateCredential() => throw null;
+            public ClientCertificateCredential(string tenantId, string clientId, string clientCertificatePath) => throw null;
+            public ClientCertificateCredential(string tenantId, string clientId, string clientCertificatePath, Azure.Identity.TokenCredentialOptions options) => throw null;
+            public ClientCertificateCredential(string tenantId, string clientId, string clientCertificatePath, Azure.Identity.ClientCertificateCredentialOptions options) => throw null;
+            public ClientCertificateCredential(string tenantId, string clientId, System.Security.Cryptography.X509Certificates.X509Certificate2 clientCertificate) => throw null;
+            public ClientCertificateCredential(string tenantId, string clientId, System.Security.Cryptography.X509Certificates.X509Certificate2 clientCertificate, Azure.Identity.TokenCredentialOptions options) => throw null;
+            public ClientCertificateCredential(string tenantId, string clientId, System.Security.Cryptography.X509Certificates.X509Certificate2 clientCertificate, Azure.Identity.ClientCertificateCredentialOptions options) => throw null;
+            public override Azure.Core.AccessToken GetToken(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+            public override System.Threading.Tasks.ValueTask<Azure.Core.AccessToken> GetTokenAsync(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+        }
+        public class ClientCertificateCredentialOptions : Azure.Identity.TokenCredentialOptions
+        {
+            public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get => throw null; }
+            public ClientCertificateCredentialOptions() => throw null;
+            public bool DisableInstanceDiscovery { get => throw null; set { } }
+            public bool SendCertificateChain { get => throw null; set { } }
+            public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get => throw null; set { } }
+        }
+        public class ClientSecretCredential : Azure.Core.TokenCredential
+        {
+            protected ClientSecretCredential() => throw null;
+            public ClientSecretCredential(string tenantId, string clientId, string clientSecret) => throw null;
+            public ClientSecretCredential(string tenantId, string clientId, string clientSecret, Azure.Identity.ClientSecretCredentialOptions options) => throw null;
+            public ClientSecretCredential(string tenantId, string clientId, string clientSecret, Azure.Identity.TokenCredentialOptions options) => throw null;
+            public override Azure.Core.AccessToken GetToken(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+            public override System.Threading.Tasks.ValueTask<Azure.Core.AccessToken> GetTokenAsync(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+        }
+        public class ClientSecretCredentialOptions : Azure.Identity.TokenCredentialOptions
+        {
+            public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get => throw null; }
+            public ClientSecretCredentialOptions() => throw null;
+            public bool DisableInstanceDiscovery { get => throw null; set { } }
+            public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get => throw null; set { } }
+        }
+        public class CredentialUnavailableException : Azure.Identity.AuthenticationFailedException
+        {
+            public CredentialUnavailableException(string message) : base(default(string)) => throw null;
+            public CredentialUnavailableException(string message, System.Exception innerException) : base(default(string)) => throw null;
+            protected CredentialUnavailableException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(default(string)) => throw null;
+        }
+        public class DefaultAzureCredential : Azure.Core.TokenCredential
+        {
+            public DefaultAzureCredential(bool includeInteractiveCredentials = default(bool)) => throw null;
+            public DefaultAzureCredential(Azure.Identity.DefaultAzureCredentialOptions options) => throw null;
+            public override Azure.Core.AccessToken GetToken(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+            public override System.Threading.Tasks.ValueTask<Azure.Core.AccessToken> GetTokenAsync(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+        }
+        public class DefaultAzureCredentialOptions : Azure.Identity.TokenCredentialOptions
+        {
+            public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get => throw null; }
+            public System.TimeSpan? CredentialProcessTimeout { get => throw null; set { } }
+            public DefaultAzureCredentialOptions() => throw null;
+            public bool DisableInstanceDiscovery { get => throw null; set { } }
+            public bool ExcludeAzureCliCredential { get => throw null; set { } }
+            public bool ExcludeAzureDeveloperCliCredential { get => throw null; set { } }
+            public bool ExcludeAzurePowerShellCredential { get => throw null; set { } }
+            public bool ExcludeEnvironmentCredential { get => throw null; set { } }
+            public bool ExcludeInteractiveBrowserCredential { get => throw null; set { } }
+            public bool ExcludeManagedIdentityCredential { get => throw null; set { } }
+            public bool ExcludeSharedTokenCacheCredential { get => throw null; set { } }
+            public bool ExcludeVisualStudioCodeCredential { get => throw null; set { } }
+            public bool ExcludeVisualStudioCredential { get => throw null; set { } }
+            public bool ExcludeWorkloadIdentityCredential { get => throw null; set { } }
+            public string InteractiveBrowserCredentialClientId { get => throw null; set { } }
+            public string InteractiveBrowserTenantId { get => throw null; set { } }
+            public string ManagedIdentityClientId { get => throw null; set { } }
+            public Azure.Core.ResourceIdentifier ManagedIdentityResourceId { get => throw null; set { } }
+            public string SharedTokenCacheTenantId { get => throw null; set { } }
+            public string SharedTokenCacheUsername { get => throw null; set { } }
+            public string TenantId { get => throw null; set { } }
+            public string VisualStudioCodeTenantId { get => throw null; set { } }
+            public string VisualStudioTenantId { get => throw null; set { } }
+            public string WorkloadIdentityClientId { get => throw null; set { } }
+        }
+        public class DeviceCodeCredential : Azure.Core.TokenCredential
+        {
+            public virtual Azure.Identity.AuthenticationRecord Authenticate(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+            public virtual Azure.Identity.AuthenticationRecord Authenticate(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+            public virtual System.Threading.Tasks.Task<Azure.Identity.AuthenticationRecord> AuthenticateAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+            public virtual System.Threading.Tasks.Task<Azure.Identity.AuthenticationRecord> AuthenticateAsync(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+            public DeviceCodeCredential() => throw null;
+            public DeviceCodeCredential(Azure.Identity.DeviceCodeCredentialOptions options) => throw null;
+            public DeviceCodeCredential(System.Func<Azure.Identity.DeviceCodeInfo, System.Threading.CancellationToken, System.Threading.Tasks.Task> deviceCodeCallback, string clientId, Azure.Identity.TokenCredentialOptions options = default(Azure.Identity.TokenCredentialOptions)) => throw null;
+            public DeviceCodeCredential(System.Func<Azure.Identity.DeviceCodeInfo, System.Threading.CancellationToken, System.Threading.Tasks.Task> deviceCodeCallback, string tenantId, string clientId, Azure.Identity.TokenCredentialOptions options = default(Azure.Identity.TokenCredentialOptions)) => throw null;
+            public override Azure.Core.AccessToken GetToken(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+            public override System.Threading.Tasks.ValueTask<Azure.Core.AccessToken> GetTokenAsync(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+        }
+        public class DeviceCodeCredentialOptions : Azure.Identity.TokenCredentialOptions
+        {
+            public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get => throw null; }
+            public Azure.Identity.AuthenticationRecord AuthenticationRecord { get => throw null; set { } }
+            public string ClientId { get => throw null; set { } }
+            public DeviceCodeCredentialOptions() => throw null;
+            public System.Func<Azure.Identity.DeviceCodeInfo, System.Threading.CancellationToken, System.Threading.Tasks.Task> DeviceCodeCallback { get => throw null; set { } }
+            public bool DisableAutomaticAuthentication { get => throw null; set { } }
+            public bool DisableInstanceDiscovery { get => throw null; set { } }
+            public string TenantId { get => throw null; set { } }
+            public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get => throw null; set { } }
+        }
+        public struct DeviceCodeInfo
+        {
+            public string ClientId { get => throw null; }
+            public string DeviceCode { get => throw null; }
+            public System.DateTimeOffset ExpiresOn { get => throw null; }
+            public string Message { get => throw null; }
+            public System.Collections.Generic.IReadOnlyCollection<string> Scopes { get => throw null; }
+            public string UserCode { get => throw null; }
+            public System.Uri VerificationUri { get => throw null; }
+        }
+        public class EnvironmentCredential : Azure.Core.TokenCredential
+        {
+            public EnvironmentCredential() => throw null;
+            public EnvironmentCredential(Azure.Identity.TokenCredentialOptions options) => throw null;
+            public EnvironmentCredential(Azure.Identity.EnvironmentCredentialOptions options) => throw null;
+            public override Azure.Core.AccessToken GetToken(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+            public override System.Threading.Tasks.ValueTask<Azure.Core.AccessToken> GetTokenAsync(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+        }
+        public class EnvironmentCredentialOptions : Azure.Identity.TokenCredentialOptions
+        {
+            public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get => throw null; }
+            public EnvironmentCredentialOptions() => throw null;
+            public bool DisableInstanceDiscovery { get => throw null; set { } }
+        }
+        public static class IdentityModelFactory
+        {
+            public static Azure.Identity.AuthenticationRecord AuthenticationRecord(string username, string authority, string homeAccountId, string tenantId, string clientId) => throw null;
+            public static Azure.Identity.DeviceCodeInfo DeviceCodeInfo(string userCode, string deviceCode, System.Uri verificationUri, System.DateTimeOffset expiresOn, string message, string clientId, System.Collections.Generic.IReadOnlyCollection<string> scopes) => throw null;
+        }
+        public class InteractiveBrowserCredential : Azure.Core.TokenCredential
+        {
+            public virtual Azure.Identity.AuthenticationRecord Authenticate(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+            public virtual Azure.Identity.AuthenticationRecord Authenticate(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+            public virtual System.Threading.Tasks.Task<Azure.Identity.AuthenticationRecord> AuthenticateAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+            public virtual System.Threading.Tasks.Task<Azure.Identity.AuthenticationRecord> AuthenticateAsync(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+            public InteractiveBrowserCredential() => throw null;
+            public InteractiveBrowserCredential(Azure.Identity.InteractiveBrowserCredentialOptions options) => throw null;
+            public InteractiveBrowserCredential(string clientId) => throw null;
+            public InteractiveBrowserCredential(string tenantId, string clientId, Azure.Identity.TokenCredentialOptions options = default(Azure.Identity.TokenCredentialOptions)) => throw null;
+            public override Azure.Core.AccessToken GetToken(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+            public override System.Threading.Tasks.ValueTask<Azure.Core.AccessToken> GetTokenAsync(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+        }
+        public class InteractiveBrowserCredentialOptions : Azure.Identity.TokenCredentialOptions
+        {
+            public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get => throw null; }
+            public Azure.Identity.AuthenticationRecord AuthenticationRecord { get => throw null; set { } }
+            public Azure.Identity.BrowserCustomizationOptions BrowserCustomization { get => throw null; set { } }
+            public string ClientId { get => throw null; set { } }
+            public InteractiveBrowserCredentialOptions() => throw null;
+            public bool DisableAutomaticAuthentication { get => throw null; set { } }
+            public bool DisableInstanceDiscovery { get => throw null; set { } }
+            public string LoginHint { get => throw null; set { } }
+            public System.Uri RedirectUri { get => throw null; set { } }
+            public string TenantId { get => throw null; set { } }
+            public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get => throw null; set { } }
+        }
+        public class ManagedIdentityCredential : Azure.Core.TokenCredential
+        {
+            protected ManagedIdentityCredential() => throw null;
+            public ManagedIdentityCredential(string clientId = default(string), Azure.Identity.TokenCredentialOptions options = default(Azure.Identity.TokenCredentialOptions)) => throw null;
+            public ManagedIdentityCredential(Azure.Core.ResourceIdentifier resourceId, Azure.Identity.TokenCredentialOptions options = default(Azure.Identity.TokenCredentialOptions)) => throw null;
+            public override Azure.Core.AccessToken GetToken(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+            public override System.Threading.Tasks.ValueTask<Azure.Core.AccessToken> GetTokenAsync(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+        }
+        public class OnBehalfOfCredential : Azure.Core.TokenCredential
+        {
+            protected OnBehalfOfCredential() => throw null;
+            public OnBehalfOfCredential(string tenantId, string clientId, System.Security.Cryptography.X509Certificates.X509Certificate2 clientCertificate, string userAssertion) => throw null;
+            public OnBehalfOfCredential(string tenantId, string clientId, System.Security.Cryptography.X509Certificates.X509Certificate2 clientCertificate, string userAssertion, Azure.Identity.OnBehalfOfCredentialOptions options) => throw null;
+            public OnBehalfOfCredential(string tenantId, string clientId, string clientSecret, string userAssertion) => throw null;
+            public OnBehalfOfCredential(string tenantId, string clientId, string clientSecret, string userAssertion, Azure.Identity.OnBehalfOfCredentialOptions options) => throw null;
+            public override Azure.Core.AccessToken GetToken(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken) => throw null;
+            public override System.Threading.Tasks.ValueTask<Azure.Core.AccessToken> GetTokenAsync(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken) => throw null;
+        }
+        public class OnBehalfOfCredentialOptions : Azure.Identity.TokenCredentialOptions
+        {
+            public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get => throw null; }
+            public OnBehalfOfCredentialOptions() => throw null;
+            public bool DisableInstanceDiscovery { get => throw null; set { } }
+            public bool SendCertificateChain { get => throw null; set { } }
+            public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get => throw null; set { } }
+        }
+        public class SharedTokenCacheCredential : Azure.Core.TokenCredential
+        {
+            public SharedTokenCacheCredential() => throw null;
+            public SharedTokenCacheCredential(Azure.Identity.SharedTokenCacheCredentialOptions options) => throw null;
+            public SharedTokenCacheCredential(string username, Azure.Identity.TokenCredentialOptions options = default(Azure.Identity.TokenCredentialOptions)) => throw null;
+            public override Azure.Core.AccessToken GetToken(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+            public override System.Threading.Tasks.ValueTask<Azure.Core.AccessToken> GetTokenAsync(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+        }
+        public class SharedTokenCacheCredentialOptions : Azure.Identity.TokenCredentialOptions
+        {
+            public Azure.Identity.AuthenticationRecord AuthenticationRecord { get => throw null; set { } }
+            public string ClientId { get => throw null; set { } }
+            public SharedTokenCacheCredentialOptions() => throw null;
+            public SharedTokenCacheCredentialOptions(Azure.Identity.TokenCachePersistenceOptions tokenCacheOptions) => throw null;
+            public bool DisableInstanceDiscovery { get => throw null; set { } }
+            public bool EnableGuestTenantAuthentication { get => throw null; set { } }
+            public string TenantId { get => throw null; set { } }
+            public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get => throw null; set { } }
+            public string Username { get => throw null; set { } }
+        }
+        public struct TokenCacheData
+        {
+            public System.ReadOnlyMemory<byte> CacheBytes { get => throw null; }
+            public TokenCacheData(System.ReadOnlyMemory<byte> cacheBytes) => throw null;
+        }
+        public class TokenCachePersistenceOptions
+        {
+            public TokenCachePersistenceOptions() => throw null;
+            public string Name { get => throw null; set { } }
+            public bool UnsafeAllowUnencryptedStorage { get => throw null; set { } }
+        }
+        public class TokenCacheRefreshArgs
+        {
+            public bool IsCaeEnabled { get => throw null; }
+            public string SuggestedCacheKey { get => throw null; }
+        }
+        public class TokenCacheUpdatedArgs
+        {
+            public bool IsCaeEnabled { get => throw null; }
+            public System.ReadOnlyMemory<byte> UnsafeCacheData { get => throw null; }
+        }
+        public class TokenCredentialDiagnosticsOptions : Azure.Core.DiagnosticsOptions
+        {
+            public TokenCredentialDiagnosticsOptions() => throw null;
+            public bool IsAccountIdentifierLoggingEnabled { get => throw null; set { } }
+        }
+        public class TokenCredentialOptions : Azure.Core.ClientOptions
+        {
+            public System.Uri AuthorityHost { get => throw null; set { } }
+            public TokenCredentialOptions() => throw null;
+            public Azure.Identity.TokenCredentialDiagnosticsOptions Diagnostics { get => throw null; }
+            public bool IsUnsafeSupportLoggingEnabled { get => throw null; set { } }
+        }
+        public abstract class UnsafeTokenCacheOptions : Azure.Identity.TokenCachePersistenceOptions
+        {
+            protected UnsafeTokenCacheOptions() => throw null;
+            protected abstract System.Threading.Tasks.Task<System.ReadOnlyMemory<byte>> RefreshCacheAsync();
+            protected virtual System.Threading.Tasks.Task<Azure.Identity.TokenCacheData> RefreshCacheAsync(Azure.Identity.TokenCacheRefreshArgs args, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+            protected abstract System.Threading.Tasks.Task TokenCacheUpdatedAsync(Azure.Identity.TokenCacheUpdatedArgs tokenCacheUpdatedArgs);
+        }
+        public class UsernamePasswordCredential : Azure.Core.TokenCredential
+        {
+            public virtual Azure.Identity.AuthenticationRecord Authenticate(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+            public virtual Azure.Identity.AuthenticationRecord Authenticate(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+            public virtual System.Threading.Tasks.Task<Azure.Identity.AuthenticationRecord> AuthenticateAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+            public virtual System.Threading.Tasks.Task<Azure.Identity.AuthenticationRecord> AuthenticateAsync(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+            protected UsernamePasswordCredential() => throw null;
+            public UsernamePasswordCredential(string username, string password, string tenantId, string clientId) => throw null;
+            public UsernamePasswordCredential(string username, string password, string tenantId, string clientId, Azure.Identity.TokenCredentialOptions options) => throw null;
+            public UsernamePasswordCredential(string username, string password, string tenantId, string clientId, Azure.Identity.UsernamePasswordCredentialOptions options) => throw null;
+            public override Azure.Core.AccessToken GetToken(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+            public override System.Threading.Tasks.ValueTask<Azure.Core.AccessToken> GetTokenAsync(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+        }
+        public class UsernamePasswordCredentialOptions : Azure.Identity.TokenCredentialOptions
+        {
+            public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get => throw null; }
+            public UsernamePasswordCredentialOptions() => throw null;
+            public bool DisableInstanceDiscovery { get => throw null; set { } }
+            public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get => throw null; set { } }
+        }
+        public class VisualStudioCodeCredential : Azure.Core.TokenCredential
+        {
+            public VisualStudioCodeCredential() => throw null;
+            public VisualStudioCodeCredential(Azure.Identity.VisualStudioCodeCredentialOptions options) => throw null;
+            public override Azure.Core.AccessToken GetToken(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken) => throw null;
+            public override System.Threading.Tasks.ValueTask<Azure.Core.AccessToken> GetTokenAsync(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken) => throw null;
+        }
+        public class VisualStudioCodeCredentialOptions : Azure.Identity.TokenCredentialOptions
+        {
+            public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get => throw null; }
+            public VisualStudioCodeCredentialOptions() => throw null;
+            public string TenantId { get => throw null; set { } }
+        }
+        public class VisualStudioCredential : Azure.Core.TokenCredential
+        {
+            public VisualStudioCredential() => throw null;
+            public VisualStudioCredential(Azure.Identity.VisualStudioCredentialOptions options) => throw null;
+            public override Azure.Core.AccessToken GetToken(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken) => throw null;
+            public override System.Threading.Tasks.ValueTask<Azure.Core.AccessToken> GetTokenAsync(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken) => throw null;
+        }
+        public class VisualStudioCredentialOptions : Azure.Identity.TokenCredentialOptions
+        {
+            public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get => throw null; }
+            public VisualStudioCredentialOptions() => throw null;
+            public System.TimeSpan? ProcessTimeout { get => throw null; set { } }
+            public string TenantId { get => throw null; set { } }
+        }
+        public class WorkloadIdentityCredential : Azure.Core.TokenCredential
+        {
+            public WorkloadIdentityCredential() => throw null;
+            public WorkloadIdentityCredential(Azure.Identity.WorkloadIdentityCredentialOptions options) => throw null;
+            public override Azure.Core.AccessToken GetToken(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+            public override System.Threading.Tasks.ValueTask<Azure.Core.AccessToken> GetTokenAsync(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+        }
+        public class WorkloadIdentityCredentialOptions : Azure.Identity.TokenCredentialOptions
+        {
+            public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get => throw null; }
+            public string ClientId { get => throw null; set { } }
+            public WorkloadIdentityCredentialOptions() => throw null;
+            public bool DisableInstanceDiscovery { get => throw null; set { } }
+            public string TenantId { get => throw null; set { } }
+            public string TokenFilePath { get => throw null; set { } }
+        }
+    }
+}

--- a/csharp/ql/test/resources/stubs/Azure.Identity/1.11.4/Azure.Identity.csproj
+++ b/csharp/ql/test/resources/stubs/Azure.Identity/1.11.4/Azure.Identity.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputPath>bin\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../Azure.Core/1.38.0/Azure.Core.csproj" />
+    <ProjectReference Include="../../Microsoft.Identity.Client/4.61.3/Microsoft.Identity.Client.csproj" />
+    <ProjectReference Include="../../Microsoft.Identity.Client.Extensions.Msal/4.61.3/Microsoft.Identity.Client.Extensions.Msal.csproj" />
+    <ProjectReference Include="../../System.Memory/4.5.4/System.Memory.csproj" />
+    <ProjectReference Include="../../System.Security.Cryptography.ProtectedData/9.0.1/System.Security.Cryptography.ProtectedData.csproj" />
+    <ProjectReference Include="../../System.Text.Json/4.7.2/System.Text.Json.csproj" />
+    <ProjectReference Include="../../System.Threading.Tasks.Extensions/4.5.4/System.Threading.Tasks.Extensions.csproj" />
+    <ProjectReference Include="../../_frameworks/Microsoft.NETCore.App/Microsoft.NETCore.App.csproj" />
+  </ItemGroup>
+</Project>

--- a/csharp/ql/test/resources/stubs/Microsoft.Bcl.AsyncInterfaces/1.1.1/Microsoft.Bcl.AsyncInterfaces.csproj
+++ b/csharp/ql/test/resources/stubs/Microsoft.Bcl.AsyncInterfaces/1.1.1/Microsoft.Bcl.AsyncInterfaces.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputPath>bin\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../_frameworks/Microsoft.NETCore.App/Microsoft.NETCore.App.csproj" />
+  </ItemGroup>
+</Project>

--- a/csharp/ql/test/resources/stubs/Microsoft.Bcl.Cryptography/9.0.4/Microsoft.Bcl.Cryptography.csproj
+++ b/csharp/ql/test/resources/stubs/Microsoft.Bcl.Cryptography/9.0.4/Microsoft.Bcl.Cryptography.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputPath>bin\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../_frameworks/Microsoft.NETCore.App/Microsoft.NETCore.App.csproj" />
+  </ItemGroup>
+</Project>

--- a/csharp/ql/test/resources/stubs/Microsoft.Data.SqlClient.SNI.runtime/6.0.2/Microsoft.Data.SqlClient.SNI.runtime.csproj
+++ b/csharp/ql/test/resources/stubs/Microsoft.Data.SqlClient.SNI.runtime/6.0.2/Microsoft.Data.SqlClient.SNI.runtime.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputPath>bin\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../_frameworks/Microsoft.NETCore.App/Microsoft.NETCore.App.csproj" />
+  </ItemGroup>
+</Project>

--- a/csharp/ql/test/resources/stubs/Microsoft.Data.SqlClient/6.0.2/Microsoft.Data.SqlClient.cs
+++ b/csharp/ql/test/resources/stubs/Microsoft.Data.SqlClient/6.0.2/Microsoft.Data.SqlClient.cs
@@ -1,0 +1,1445 @@
+// This file contains auto-generated code.
+// Generated from `Microsoft.Data.SqlClient, Version=6.0.0.0, Culture=neutral, PublicKeyToken=23ec7fc2d6eaa4a5`.
+namespace Microsoft
+{
+    namespace Data
+    {
+        public sealed class OperationAbortedException : System.SystemException
+        {
+        }
+        namespace Sql
+        {
+            public sealed class SqlDataSourceEnumerator : System.Data.Common.DbDataSourceEnumerator
+            {
+                public SqlDataSourceEnumerator() => throw null;
+                public override System.Data.DataTable GetDataSources() => throw null;
+                public static Microsoft.Data.Sql.SqlDataSourceEnumerator Instance { get => throw null; }
+            }
+            public sealed class SqlNotificationRequest
+            {
+                public SqlNotificationRequest() => throw null;
+                public SqlNotificationRequest(string userData, string options, int timeout) => throw null;
+                public string Options { get => throw null; set { } }
+                public int Timeout { get => throw null; set { } }
+                public string UserData { get => throw null; set { } }
+            }
+        }
+        namespace SqlClient
+        {
+            public sealed class ActiveDirectoryAuthenticationProvider : Microsoft.Data.SqlClient.SqlAuthenticationProvider
+            {
+                public override System.Threading.Tasks.Task<Microsoft.Data.SqlClient.SqlAuthenticationToken> AcquireTokenAsync(Microsoft.Data.SqlClient.SqlAuthenticationParameters parameters) => throw null;
+                public override void BeforeLoad(Microsoft.Data.SqlClient.SqlAuthenticationMethod authentication) => throw null;
+                public override void BeforeUnload(Microsoft.Data.SqlClient.SqlAuthenticationMethod authentication) => throw null;
+                public static void ClearUserTokenCache() => throw null;
+                public ActiveDirectoryAuthenticationProvider() => throw null;
+                public ActiveDirectoryAuthenticationProvider(string applicationClientId) => throw null;
+                public ActiveDirectoryAuthenticationProvider(System.Func<Microsoft.Identity.Client.DeviceCodeResult, System.Threading.Tasks.Task> deviceCodeFlowCallbackMethod, string applicationClientId = default(string)) => throw null;
+                public override bool IsSupported(Microsoft.Data.SqlClient.SqlAuthenticationMethod authentication) => throw null;
+                public void SetAcquireAuthorizationCodeAsyncCallback(System.Func<System.Uri, System.Uri, System.Threading.CancellationToken, System.Threading.Tasks.Task<System.Uri>> acquireAuthorizationCodeAsyncCallback) => throw null;
+                public void SetDeviceCodeFlowCallback(System.Func<Microsoft.Identity.Client.DeviceCodeResult, System.Threading.Tasks.Task> deviceCodeFlowCallbackMethod) => throw null;
+            }
+            public enum ApplicationIntent
+            {
+                ReadOnly = 1,
+                ReadWrite = 0,
+            }
+            namespace DataClassification
+            {
+                public class ColumnSensitivity
+                {
+                    public ColumnSensitivity(System.Collections.Generic.IList<Microsoft.Data.SqlClient.DataClassification.SensitivityProperty> sensitivityProperties) => throw null;
+                    public System.Collections.ObjectModel.ReadOnlyCollection<Microsoft.Data.SqlClient.DataClassification.SensitivityProperty> SensitivityProperties { get => throw null; }
+                }
+                public class InformationType
+                {
+                    public InformationType(string name, string id) => throw null;
+                    public string Id { get => throw null; }
+                    public string Name { get => throw null; }
+                }
+                public class Label
+                {
+                    public Label(string name, string id) => throw null;
+                    public string Id { get => throw null; }
+                    public string Name { get => throw null; }
+                }
+                public class SensitivityClassification
+                {
+                    public System.Collections.ObjectModel.ReadOnlyCollection<Microsoft.Data.SqlClient.DataClassification.ColumnSensitivity> ColumnSensitivities { get => throw null; }
+                    public SensitivityClassification(System.Collections.Generic.IList<Microsoft.Data.SqlClient.DataClassification.Label> labels, System.Collections.Generic.IList<Microsoft.Data.SqlClient.DataClassification.InformationType> informationTypes, System.Collections.Generic.IList<Microsoft.Data.SqlClient.DataClassification.ColumnSensitivity> columnSensitivity, Microsoft.Data.SqlClient.DataClassification.SensitivityRank sensitivityRank) => throw null;
+                    public System.Collections.ObjectModel.ReadOnlyCollection<Microsoft.Data.SqlClient.DataClassification.InformationType> InformationTypes { get => throw null; }
+                    public System.Collections.ObjectModel.ReadOnlyCollection<Microsoft.Data.SqlClient.DataClassification.Label> Labels { get => throw null; }
+                    public Microsoft.Data.SqlClient.DataClassification.SensitivityRank SensitivityRank { get => throw null; }
+                }
+                public class SensitivityProperty
+                {
+                    public SensitivityProperty(Microsoft.Data.SqlClient.DataClassification.Label label, Microsoft.Data.SqlClient.DataClassification.InformationType informationType, Microsoft.Data.SqlClient.DataClassification.SensitivityRank sensitivityRank) => throw null;
+                    public Microsoft.Data.SqlClient.DataClassification.InformationType InformationType { get => throw null; }
+                    public Microsoft.Data.SqlClient.DataClassification.Label Label { get => throw null; }
+                    public Microsoft.Data.SqlClient.DataClassification.SensitivityRank SensitivityRank { get => throw null; }
+                }
+                public enum SensitivityRank
+                {
+                    NOT_DEFINED = -1,
+                    NONE = 0,
+                    LOW = 10,
+                    MEDIUM = 20,
+                    HIGH = 30,
+                    CRITICAL = 40,
+                }
+            }
+            namespace Diagnostics
+            {
+                public sealed class SqlClientCommandAfter : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.IEnumerable, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IReadOnlyList<System.Collections.Generic.KeyValuePair<string, object>>
+                {
+                    public Microsoft.Data.SqlClient.SqlCommand Command { get => throw null; }
+                    public System.Guid? ConnectionId { get => throw null; }
+                    public int Count { get => throw null; }
+                    public SqlClientCommandAfter() => throw null;
+                    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null;
+                    public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, object>> GetEnumerator() => throw null;
+                    public const string Name = default;
+                    public string Operation { get => throw null; }
+                    public System.Guid OperationId { get => throw null; }
+                    public System.Collections.IDictionary Statistics { get => throw null; }
+                    public System.Collections.Generic.KeyValuePair<string, object> this[int index] { get => throw null; }
+                    public long Timestamp { get => throw null; }
+                    public long? TransactionId { get => throw null; }
+                }
+                public sealed class SqlClientCommandBefore : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.IEnumerable, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IReadOnlyList<System.Collections.Generic.KeyValuePair<string, object>>
+                {
+                    public Microsoft.Data.SqlClient.SqlCommand Command { get => throw null; }
+                    public System.Guid? ConnectionId { get => throw null; }
+                    public int Count { get => throw null; }
+                    public SqlClientCommandBefore() => throw null;
+                    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null;
+                    public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, object>> GetEnumerator() => throw null;
+                    public const string Name = default;
+                    public string Operation { get => throw null; }
+                    public System.Guid OperationId { get => throw null; }
+                    public System.Collections.Generic.KeyValuePair<string, object> this[int index] { get => throw null; }
+                    public long Timestamp { get => throw null; }
+                    public long? TransactionId { get => throw null; }
+                }
+                public sealed class SqlClientCommandError : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.IEnumerable, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IReadOnlyList<System.Collections.Generic.KeyValuePair<string, object>>
+                {
+                    public Microsoft.Data.SqlClient.SqlCommand Command { get => throw null; }
+                    public System.Guid? ConnectionId { get => throw null; }
+                    public int Count { get => throw null; }
+                    public SqlClientCommandError() => throw null;
+                    public System.Exception Exception { get => throw null; }
+                    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null;
+                    public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, object>> GetEnumerator() => throw null;
+                    public const string Name = default;
+                    public string Operation { get => throw null; }
+                    public System.Guid OperationId { get => throw null; }
+                    public System.Collections.Generic.KeyValuePair<string, object> this[int index] { get => throw null; }
+                    public long Timestamp { get => throw null; }
+                    public long? TransactionId { get => throw null; }
+                }
+                public sealed class SqlClientConnectionCloseAfter : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.IEnumerable, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IReadOnlyList<System.Collections.Generic.KeyValuePair<string, object>>
+                {
+                    public Microsoft.Data.SqlClient.SqlConnection Connection { get => throw null; }
+                    public System.Guid? ConnectionId { get => throw null; }
+                    public int Count { get => throw null; }
+                    public SqlClientConnectionCloseAfter() => throw null;
+                    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null;
+                    public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, object>> GetEnumerator() => throw null;
+                    public const string Name = default;
+                    public string Operation { get => throw null; }
+                    public System.Guid OperationId { get => throw null; }
+                    public System.Collections.IDictionary Statistics { get => throw null; }
+                    public System.Collections.Generic.KeyValuePair<string, object> this[int index] { get => throw null; }
+                    public long Timestamp { get => throw null; }
+                }
+                public sealed class SqlClientConnectionCloseBefore : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.IEnumerable, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IReadOnlyList<System.Collections.Generic.KeyValuePair<string, object>>
+                {
+                    public Microsoft.Data.SqlClient.SqlConnection Connection { get => throw null; }
+                    public System.Guid? ConnectionId { get => throw null; }
+                    public int Count { get => throw null; }
+                    public SqlClientConnectionCloseBefore() => throw null;
+                    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null;
+                    public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, object>> GetEnumerator() => throw null;
+                    public const string Name = default;
+                    public string Operation { get => throw null; }
+                    public System.Guid OperationId { get => throw null; }
+                    public System.Collections.IDictionary Statistics { get => throw null; }
+                    public System.Collections.Generic.KeyValuePair<string, object> this[int index] { get => throw null; }
+                    public long Timestamp { get => throw null; }
+                }
+                public sealed class SqlClientConnectionCloseError : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.IEnumerable, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IReadOnlyList<System.Collections.Generic.KeyValuePair<string, object>>
+                {
+                    public Microsoft.Data.SqlClient.SqlConnection Connection { get => throw null; }
+                    public System.Guid? ConnectionId { get => throw null; }
+                    public int Count { get => throw null; }
+                    public SqlClientConnectionCloseError() => throw null;
+                    public System.Exception Exception { get => throw null; }
+                    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null;
+                    public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, object>> GetEnumerator() => throw null;
+                    public const string Name = default;
+                    public string Operation { get => throw null; }
+                    public System.Guid OperationId { get => throw null; }
+                    public System.Collections.IDictionary Statistics { get => throw null; }
+                    public System.Collections.Generic.KeyValuePair<string, object> this[int index] { get => throw null; }
+                    public long Timestamp { get => throw null; }
+                }
+                public sealed class SqlClientConnectionOpenAfter : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.IEnumerable, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IReadOnlyList<System.Collections.Generic.KeyValuePair<string, object>>
+                {
+                    public string ClientVersion { get => throw null; }
+                    public Microsoft.Data.SqlClient.SqlConnection Connection { get => throw null; }
+                    public System.Guid ConnectionId { get => throw null; }
+                    public int Count { get => throw null; }
+                    public SqlClientConnectionOpenAfter() => throw null;
+                    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null;
+                    public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, object>> GetEnumerator() => throw null;
+                    public const string Name = default;
+                    public string Operation { get => throw null; }
+                    public System.Guid OperationId { get => throw null; }
+                    public System.Collections.IDictionary Statistics { get => throw null; }
+                    public System.Collections.Generic.KeyValuePair<string, object> this[int index] { get => throw null; }
+                    public long Timestamp { get => throw null; }
+                }
+                public sealed class SqlClientConnectionOpenBefore : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.IEnumerable, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IReadOnlyList<System.Collections.Generic.KeyValuePair<string, object>>
+                {
+                    public string ClientVersion { get => throw null; }
+                    public Microsoft.Data.SqlClient.SqlConnection Connection { get => throw null; }
+                    public int Count { get => throw null; }
+                    public SqlClientConnectionOpenBefore() => throw null;
+                    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null;
+                    public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, object>> GetEnumerator() => throw null;
+                    public const string Name = default;
+                    public string Operation { get => throw null; }
+                    public System.Guid OperationId { get => throw null; }
+                    public System.Collections.Generic.KeyValuePair<string, object> this[int index] { get => throw null; }
+                    public long Timestamp { get => throw null; }
+                }
+                public sealed class SqlClientConnectionOpenError : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.IEnumerable, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IReadOnlyList<System.Collections.Generic.KeyValuePair<string, object>>
+                {
+                    public string ClientVersion { get => throw null; }
+                    public Microsoft.Data.SqlClient.SqlConnection Connection { get => throw null; }
+                    public System.Guid ConnectionId { get => throw null; }
+                    public int Count { get => throw null; }
+                    public SqlClientConnectionOpenError() => throw null;
+                    public System.Exception Exception { get => throw null; }
+                    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null;
+                    public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, object>> GetEnumerator() => throw null;
+                    public const string Name = default;
+                    public string Operation { get => throw null; }
+                    public System.Guid OperationId { get => throw null; }
+                    public System.Collections.Generic.KeyValuePair<string, object> this[int index] { get => throw null; }
+                    public long Timestamp { get => throw null; }
+                }
+                public sealed class SqlClientTransactionCommitAfter : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.IEnumerable, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IReadOnlyList<System.Collections.Generic.KeyValuePair<string, object>>
+                {
+                    public Microsoft.Data.SqlClient.SqlConnection Connection { get => throw null; }
+                    public int Count { get => throw null; }
+                    public SqlClientTransactionCommitAfter() => throw null;
+                    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null;
+                    public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, object>> GetEnumerator() => throw null;
+                    public System.Data.IsolationLevel IsolationLevel { get => throw null; }
+                    public const string Name = default;
+                    public string Operation { get => throw null; }
+                    public System.Guid OperationId { get => throw null; }
+                    public System.Collections.Generic.KeyValuePair<string, object> this[int index] { get => throw null; }
+                    public long Timestamp { get => throw null; }
+                    public long? TransactionId { get => throw null; }
+                }
+                public sealed class SqlClientTransactionCommitBefore : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.IEnumerable, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IReadOnlyList<System.Collections.Generic.KeyValuePair<string, object>>
+                {
+                    public Microsoft.Data.SqlClient.SqlConnection Connection { get => throw null; }
+                    public int Count { get => throw null; }
+                    public SqlClientTransactionCommitBefore() => throw null;
+                    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null;
+                    public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, object>> GetEnumerator() => throw null;
+                    public System.Data.IsolationLevel IsolationLevel { get => throw null; }
+                    public const string Name = default;
+                    public string Operation { get => throw null; }
+                    public System.Guid OperationId { get => throw null; }
+                    public System.Collections.Generic.KeyValuePair<string, object> this[int index] { get => throw null; }
+                    public long Timestamp { get => throw null; }
+                    public long? TransactionId { get => throw null; }
+                }
+                public sealed class SqlClientTransactionCommitError : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.IEnumerable, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IReadOnlyList<System.Collections.Generic.KeyValuePair<string, object>>
+                {
+                    public Microsoft.Data.SqlClient.SqlConnection Connection { get => throw null; }
+                    public int Count { get => throw null; }
+                    public SqlClientTransactionCommitError() => throw null;
+                    public System.Exception Exception { get => throw null; }
+                    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null;
+                    public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, object>> GetEnumerator() => throw null;
+                    public System.Data.IsolationLevel IsolationLevel { get => throw null; }
+                    public const string Name = default;
+                    public string Operation { get => throw null; }
+                    public System.Guid OperationId { get => throw null; }
+                    public System.Collections.Generic.KeyValuePair<string, object> this[int index] { get => throw null; }
+                    public long Timestamp { get => throw null; }
+                    public long? TransactionId { get => throw null; }
+                }
+                public sealed class SqlClientTransactionRollbackAfter : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.IEnumerable, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IReadOnlyList<System.Collections.Generic.KeyValuePair<string, object>>
+                {
+                    public Microsoft.Data.SqlClient.SqlConnection Connection { get => throw null; }
+                    public int Count { get => throw null; }
+                    public SqlClientTransactionRollbackAfter() => throw null;
+                    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null;
+                    public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, object>> GetEnumerator() => throw null;
+                    public System.Data.IsolationLevel IsolationLevel { get => throw null; }
+                    public const string Name = default;
+                    public string Operation { get => throw null; }
+                    public System.Guid OperationId { get => throw null; }
+                    public System.Collections.Generic.KeyValuePair<string, object> this[int index] { get => throw null; }
+                    public long Timestamp { get => throw null; }
+                    public long? TransactionId { get => throw null; }
+                    public string TransactionName { get => throw null; }
+                }
+                public sealed class SqlClientTransactionRollbackBefore : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.IEnumerable, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IReadOnlyList<System.Collections.Generic.KeyValuePair<string, object>>
+                {
+                    public Microsoft.Data.SqlClient.SqlConnection Connection { get => throw null; }
+                    public int Count { get => throw null; }
+                    public SqlClientTransactionRollbackBefore() => throw null;
+                    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null;
+                    public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, object>> GetEnumerator() => throw null;
+                    public System.Data.IsolationLevel IsolationLevel { get => throw null; }
+                    public const string Name = default;
+                    public string Operation { get => throw null; }
+                    public System.Guid OperationId { get => throw null; }
+                    public System.Collections.Generic.KeyValuePair<string, object> this[int index] { get => throw null; }
+                    public long Timestamp { get => throw null; }
+                    public long? TransactionId { get => throw null; }
+                    public string TransactionName { get => throw null; }
+                }
+                public sealed class SqlClientTransactionRollbackError : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.IEnumerable, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IReadOnlyList<System.Collections.Generic.KeyValuePair<string, object>>
+                {
+                    public Microsoft.Data.SqlClient.SqlConnection Connection { get => throw null; }
+                    public int Count { get => throw null; }
+                    public SqlClientTransactionRollbackError() => throw null;
+                    public System.Exception Exception { get => throw null; }
+                    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null;
+                    public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, object>> GetEnumerator() => throw null;
+                    public System.Data.IsolationLevel IsolationLevel { get => throw null; }
+                    public const string Name = default;
+                    public string Operation { get => throw null; }
+                    public System.Guid OperationId { get => throw null; }
+                    public System.Collections.Generic.KeyValuePair<string, object> this[int index] { get => throw null; }
+                    public long Timestamp { get => throw null; }
+                    public long? TransactionId { get => throw null; }
+                    public string TransactionName { get => throw null; }
+                }
+            }
+            public delegate void OnChangeEventHandler(object sender, Microsoft.Data.SqlClient.SqlNotificationEventArgs e);
+            public enum PoolBlockingPeriod
+            {
+                Auto = 0,
+                AlwaysBlock = 1,
+                NeverBlock = 2,
+            }
+            namespace Server
+            {
+                public class SqlDataRecord : System.Data.IDataRecord
+                {
+                    public SqlDataRecord(params Microsoft.Data.SqlClient.Server.SqlMetaData[] metaData) => throw null;
+                    public virtual int FieldCount { get => throw null; }
+                    public virtual bool GetBoolean(int ordinal) => throw null;
+                    public virtual byte GetByte(int ordinal) => throw null;
+                    public virtual long GetBytes(int ordinal, long fieldOffset, byte[] buffer, int bufferOffset, int length) => throw null;
+                    public virtual char GetChar(int ordinal) => throw null;
+                    public virtual long GetChars(int ordinal, long fieldOffset, char[] buffer, int bufferOffset, int length) => throw null;
+                    System.Data.IDataReader System.Data.IDataRecord.GetData(int ordinal) => throw null;
+                    public virtual string GetDataTypeName(int ordinal) => throw null;
+                    public virtual System.DateTime GetDateTime(int ordinal) => throw null;
+                    public virtual System.DateTimeOffset GetDateTimeOffset(int ordinal) => throw null;
+                    public virtual decimal GetDecimal(int ordinal) => throw null;
+                    public virtual double GetDouble(int ordinal) => throw null;
+                    public virtual System.Type GetFieldType(int ordinal) => throw null;
+                    public virtual float GetFloat(int ordinal) => throw null;
+                    public virtual System.Guid GetGuid(int ordinal) => throw null;
+                    public virtual short GetInt16(int ordinal) => throw null;
+                    public virtual int GetInt32(int ordinal) => throw null;
+                    public virtual long GetInt64(int ordinal) => throw null;
+                    public virtual string GetName(int ordinal) => throw null;
+                    public virtual int GetOrdinal(string name) => throw null;
+                    public virtual System.Data.SqlTypes.SqlBinary GetSqlBinary(int ordinal) => throw null;
+                    public virtual System.Data.SqlTypes.SqlBoolean GetSqlBoolean(int ordinal) => throw null;
+                    public virtual System.Data.SqlTypes.SqlByte GetSqlByte(int ordinal) => throw null;
+                    public virtual System.Data.SqlTypes.SqlBytes GetSqlBytes(int ordinal) => throw null;
+                    public virtual System.Data.SqlTypes.SqlChars GetSqlChars(int ordinal) => throw null;
+                    public virtual System.Data.SqlTypes.SqlDateTime GetSqlDateTime(int ordinal) => throw null;
+                    public virtual System.Data.SqlTypes.SqlDecimal GetSqlDecimal(int ordinal) => throw null;
+                    public virtual System.Data.SqlTypes.SqlDouble GetSqlDouble(int ordinal) => throw null;
+                    public virtual System.Type GetSqlFieldType(int ordinal) => throw null;
+                    public virtual System.Data.SqlTypes.SqlGuid GetSqlGuid(int ordinal) => throw null;
+                    public virtual System.Data.SqlTypes.SqlInt16 GetSqlInt16(int ordinal) => throw null;
+                    public virtual System.Data.SqlTypes.SqlInt32 GetSqlInt32(int ordinal) => throw null;
+                    public virtual System.Data.SqlTypes.SqlInt64 GetSqlInt64(int ordinal) => throw null;
+                    public virtual Microsoft.Data.SqlClient.Server.SqlMetaData GetSqlMetaData(int ordinal) => throw null;
+                    public virtual System.Data.SqlTypes.SqlMoney GetSqlMoney(int ordinal) => throw null;
+                    public virtual System.Data.SqlTypes.SqlSingle GetSqlSingle(int ordinal) => throw null;
+                    public virtual System.Data.SqlTypes.SqlString GetSqlString(int ordinal) => throw null;
+                    public virtual object GetSqlValue(int ordinal) => throw null;
+                    public virtual int GetSqlValues(object[] values) => throw null;
+                    public virtual System.Data.SqlTypes.SqlXml GetSqlXml(int ordinal) => throw null;
+                    public virtual string GetString(int ordinal) => throw null;
+                    public virtual System.TimeSpan GetTimeSpan(int ordinal) => throw null;
+                    public virtual object GetValue(int ordinal) => throw null;
+                    public virtual int GetValues(object[] values) => throw null;
+                    public virtual bool IsDBNull(int ordinal) => throw null;
+                    public virtual void SetBoolean(int ordinal, bool value) => throw null;
+                    public virtual void SetByte(int ordinal, byte value) => throw null;
+                    public virtual void SetBytes(int ordinal, long fieldOffset, byte[] buffer, int bufferOffset, int length) => throw null;
+                    public virtual void SetChar(int ordinal, char value) => throw null;
+                    public virtual void SetChars(int ordinal, long fieldOffset, char[] buffer, int bufferOffset, int length) => throw null;
+                    public virtual void SetDateTime(int ordinal, System.DateTime value) => throw null;
+                    public virtual void SetDateTimeOffset(int ordinal, System.DateTimeOffset value) => throw null;
+                    public virtual void SetDBNull(int ordinal) => throw null;
+                    public virtual void SetDecimal(int ordinal, decimal value) => throw null;
+                    public virtual void SetDouble(int ordinal, double value) => throw null;
+                    public virtual void SetFloat(int ordinal, float value) => throw null;
+                    public virtual void SetGuid(int ordinal, System.Guid value) => throw null;
+                    public virtual void SetInt16(int ordinal, short value) => throw null;
+                    public virtual void SetInt32(int ordinal, int value) => throw null;
+                    public virtual void SetInt64(int ordinal, long value) => throw null;
+                    public virtual void SetSqlBinary(int ordinal, System.Data.SqlTypes.SqlBinary value) => throw null;
+                    public virtual void SetSqlBoolean(int ordinal, System.Data.SqlTypes.SqlBoolean value) => throw null;
+                    public virtual void SetSqlByte(int ordinal, System.Data.SqlTypes.SqlByte value) => throw null;
+                    public virtual void SetSqlBytes(int ordinal, System.Data.SqlTypes.SqlBytes value) => throw null;
+                    public virtual void SetSqlChars(int ordinal, System.Data.SqlTypes.SqlChars value) => throw null;
+                    public virtual void SetSqlDateTime(int ordinal, System.Data.SqlTypes.SqlDateTime value) => throw null;
+                    public virtual void SetSqlDecimal(int ordinal, System.Data.SqlTypes.SqlDecimal value) => throw null;
+                    public virtual void SetSqlDouble(int ordinal, System.Data.SqlTypes.SqlDouble value) => throw null;
+                    public virtual void SetSqlGuid(int ordinal, System.Data.SqlTypes.SqlGuid value) => throw null;
+                    public virtual void SetSqlInt16(int ordinal, System.Data.SqlTypes.SqlInt16 value) => throw null;
+                    public virtual void SetSqlInt32(int ordinal, System.Data.SqlTypes.SqlInt32 value) => throw null;
+                    public virtual void SetSqlInt64(int ordinal, System.Data.SqlTypes.SqlInt64 value) => throw null;
+                    public virtual void SetSqlMoney(int ordinal, System.Data.SqlTypes.SqlMoney value) => throw null;
+                    public virtual void SetSqlSingle(int ordinal, System.Data.SqlTypes.SqlSingle value) => throw null;
+                    public virtual void SetSqlString(int ordinal, System.Data.SqlTypes.SqlString value) => throw null;
+                    public virtual void SetSqlXml(int ordinal, System.Data.SqlTypes.SqlXml value) => throw null;
+                    public virtual void SetString(int ordinal, string value) => throw null;
+                    public virtual void SetTimeSpan(int ordinal, System.TimeSpan value) => throw null;
+                    public virtual void SetValue(int ordinal, object value) => throw null;
+                    public virtual int SetValues(params object[] values) => throw null;
+                    public virtual object this[int ordinal] { get => throw null; }
+                    public virtual object this[string name] { get => throw null; }
+                }
+                public sealed class SqlMetaData
+                {
+                    public bool Adjust(bool value) => throw null;
+                    public byte Adjust(byte value) => throw null;
+                    public byte[] Adjust(byte[] value) => throw null;
+                    public char Adjust(char value) => throw null;
+                    public char[] Adjust(char[] value) => throw null;
+                    public System.Data.SqlTypes.SqlBinary Adjust(System.Data.SqlTypes.SqlBinary value) => throw null;
+                    public System.Data.SqlTypes.SqlBoolean Adjust(System.Data.SqlTypes.SqlBoolean value) => throw null;
+                    public System.Data.SqlTypes.SqlByte Adjust(System.Data.SqlTypes.SqlByte value) => throw null;
+                    public System.Data.SqlTypes.SqlBytes Adjust(System.Data.SqlTypes.SqlBytes value) => throw null;
+                    public System.Data.SqlTypes.SqlChars Adjust(System.Data.SqlTypes.SqlChars value) => throw null;
+                    public System.Data.SqlTypes.SqlDateTime Adjust(System.Data.SqlTypes.SqlDateTime value) => throw null;
+                    public System.Data.SqlTypes.SqlDecimal Adjust(System.Data.SqlTypes.SqlDecimal value) => throw null;
+                    public System.Data.SqlTypes.SqlDouble Adjust(System.Data.SqlTypes.SqlDouble value) => throw null;
+                    public System.Data.SqlTypes.SqlGuid Adjust(System.Data.SqlTypes.SqlGuid value) => throw null;
+                    public System.Data.SqlTypes.SqlInt16 Adjust(System.Data.SqlTypes.SqlInt16 value) => throw null;
+                    public System.Data.SqlTypes.SqlInt32 Adjust(System.Data.SqlTypes.SqlInt32 value) => throw null;
+                    public System.Data.SqlTypes.SqlInt64 Adjust(System.Data.SqlTypes.SqlInt64 value) => throw null;
+                    public System.Data.SqlTypes.SqlMoney Adjust(System.Data.SqlTypes.SqlMoney value) => throw null;
+                    public System.Data.SqlTypes.SqlSingle Adjust(System.Data.SqlTypes.SqlSingle value) => throw null;
+                    public System.Data.SqlTypes.SqlString Adjust(System.Data.SqlTypes.SqlString value) => throw null;
+                    public System.Data.SqlTypes.SqlXml Adjust(System.Data.SqlTypes.SqlXml value) => throw null;
+                    public System.DateTime Adjust(System.DateTime value) => throw null;
+                    public System.DateTimeOffset Adjust(System.DateTimeOffset value) => throw null;
+                    public decimal Adjust(decimal value) => throw null;
+                    public double Adjust(double value) => throw null;
+                    public System.Guid Adjust(System.Guid value) => throw null;
+                    public short Adjust(short value) => throw null;
+                    public int Adjust(int value) => throw null;
+                    public long Adjust(long value) => throw null;
+                    public object Adjust(object value) => throw null;
+                    public float Adjust(float value) => throw null;
+                    public string Adjust(string value) => throw null;
+                    public System.TimeSpan Adjust(System.TimeSpan value) => throw null;
+                    public System.Data.SqlTypes.SqlCompareOptions CompareOptions { get => throw null; }
+                    public SqlMetaData(string name, System.Data.SqlDbType dbType) => throw null;
+                    public SqlMetaData(string name, System.Data.SqlDbType dbType, bool useServerDefault, bool isUniqueKey, Microsoft.Data.SqlClient.SortOrder columnSortOrder, int sortOrdinal) => throw null;
+                    public SqlMetaData(string name, System.Data.SqlDbType dbType, byte precision, byte scale) => throw null;
+                    public SqlMetaData(string name, System.Data.SqlDbType dbType, byte precision, byte scale, bool useServerDefault, bool isUniqueKey, Microsoft.Data.SqlClient.SortOrder columnSortOrder, int sortOrdinal) => throw null;
+                    public SqlMetaData(string name, System.Data.SqlDbType dbType, long maxLength) => throw null;
+                    public SqlMetaData(string name, System.Data.SqlDbType dbType, long maxLength, bool useServerDefault, bool isUniqueKey, Microsoft.Data.SqlClient.SortOrder columnSortOrder, int sortOrdinal) => throw null;
+                    public SqlMetaData(string name, System.Data.SqlDbType dbType, long maxLength, byte precision, byte scale, long locale, System.Data.SqlTypes.SqlCompareOptions compareOptions, System.Type userDefinedType) => throw null;
+                    public SqlMetaData(string name, System.Data.SqlDbType dbType, long maxLength, byte precision, byte scale, long localeId, System.Data.SqlTypes.SqlCompareOptions compareOptions, System.Type userDefinedType, bool useServerDefault, bool isUniqueKey, Microsoft.Data.SqlClient.SortOrder columnSortOrder, int sortOrdinal) => throw null;
+                    public SqlMetaData(string name, System.Data.SqlDbType dbType, long maxLength, long locale, System.Data.SqlTypes.SqlCompareOptions compareOptions) => throw null;
+                    public SqlMetaData(string name, System.Data.SqlDbType dbType, long maxLength, long locale, System.Data.SqlTypes.SqlCompareOptions compareOptions, bool useServerDefault, bool isUniqueKey, Microsoft.Data.SqlClient.SortOrder columnSortOrder, int sortOrdinal) => throw null;
+                    public SqlMetaData(string name, System.Data.SqlDbType dbType, string database, string owningSchema, string objectName) => throw null;
+                    public SqlMetaData(string name, System.Data.SqlDbType dbType, string database, string owningSchema, string objectName, bool useServerDefault, bool isUniqueKey, Microsoft.Data.SqlClient.SortOrder columnSortOrder, int sortOrdinal) => throw null;
+                    public SqlMetaData(string name, System.Data.SqlDbType dbType, System.Type userDefinedType) => throw null;
+                    public SqlMetaData(string name, System.Data.SqlDbType dbType, System.Type userDefinedType, string serverTypeName) => throw null;
+                    public SqlMetaData(string name, System.Data.SqlDbType dbType, System.Type userDefinedType, string serverTypeName, bool useServerDefault, bool isUniqueKey, Microsoft.Data.SqlClient.SortOrder columnSortOrder, int sortOrdinal) => throw null;
+                    public System.Data.DbType DbType { get => throw null; }
+                    public static Microsoft.Data.SqlClient.Server.SqlMetaData InferFromValue(object value, string name) => throw null;
+                    public bool IsUniqueKey { get => throw null; }
+                    public long LocaleId { get => throw null; }
+                    public static long Max { get => throw null; }
+                    public long MaxLength { get => throw null; }
+                    public string Name { get => throw null; }
+                    public byte Precision { get => throw null; }
+                    public byte Scale { get => throw null; }
+                    public Microsoft.Data.SqlClient.SortOrder SortOrder { get => throw null; }
+                    public int SortOrdinal { get => throw null; }
+                    public System.Data.SqlDbType SqlDbType { get => throw null; }
+                    public System.Type Type { get => throw null; }
+                    public string TypeName { get => throw null; }
+                    public bool UseServerDefault { get => throw null; }
+                    public string XmlSchemaCollectionDatabase { get => throw null; }
+                    public string XmlSchemaCollectionName { get => throw null; }
+                    public string XmlSchemaCollectionOwningSchema { get => throw null; }
+                }
+            }
+            public enum SortOrder
+            {
+                Unspecified = -1,
+                Ascending = 0,
+                Descending = 1,
+            }
+            public abstract class SqlAuthenticationInitializer
+            {
+                protected SqlAuthenticationInitializer() => throw null;
+                public abstract void Initialize();
+            }
+            public enum SqlAuthenticationMethod
+            {
+                NotSpecified = 0,
+                SqlPassword = 1,
+                ActiveDirectoryPassword = 2,
+                ActiveDirectoryIntegrated = 3,
+                ActiveDirectoryInteractive = 4,
+                ActiveDirectoryServicePrincipal = 5,
+                ActiveDirectoryDeviceCodeFlow = 6,
+                ActiveDirectoryManagedIdentity = 7,
+                ActiveDirectoryMSI = 8,
+                ActiveDirectoryDefault = 9,
+                ActiveDirectoryWorkloadIdentity = 10,
+            }
+            public class SqlAuthenticationParameters
+            {
+                public Microsoft.Data.SqlClient.SqlAuthenticationMethod AuthenticationMethod { get => throw null; }
+                public string Authority { get => throw null; }
+                public System.Guid ConnectionId { get => throw null; }
+                public int ConnectionTimeout { get => throw null; }
+                protected SqlAuthenticationParameters(Microsoft.Data.SqlClient.SqlAuthenticationMethod authenticationMethod, string serverName, string databaseName, string resource, string authority, string userId, string password, System.Guid connectionId, int connectionTimeout) => throw null;
+                public string DatabaseName { get => throw null; }
+                public string Password { get => throw null; }
+                public string Resource { get => throw null; }
+                public string ServerName { get => throw null; }
+                public string UserId { get => throw null; }
+            }
+            public abstract class SqlAuthenticationProvider
+            {
+                public abstract System.Threading.Tasks.Task<Microsoft.Data.SqlClient.SqlAuthenticationToken> AcquireTokenAsync(Microsoft.Data.SqlClient.SqlAuthenticationParameters parameters);
+                public virtual void BeforeLoad(Microsoft.Data.SqlClient.SqlAuthenticationMethod authenticationMethod) => throw null;
+                public virtual void BeforeUnload(Microsoft.Data.SqlClient.SqlAuthenticationMethod authenticationMethod) => throw null;
+                protected SqlAuthenticationProvider() => throw null;
+                public static Microsoft.Data.SqlClient.SqlAuthenticationProvider GetProvider(Microsoft.Data.SqlClient.SqlAuthenticationMethod authenticationMethod) => throw null;
+                public abstract bool IsSupported(Microsoft.Data.SqlClient.SqlAuthenticationMethod authenticationMethod);
+                public static bool SetProvider(Microsoft.Data.SqlClient.SqlAuthenticationMethod authenticationMethod, Microsoft.Data.SqlClient.SqlAuthenticationProvider provider) => throw null;
+            }
+            public class SqlAuthenticationToken
+            {
+                public string AccessToken { get => throw null; }
+                public SqlAuthenticationToken(string accessToken, System.DateTimeOffset expiresOn) => throw null;
+                public System.DateTimeOffset ExpiresOn { get => throw null; }
+            }
+            public class SqlBatch : System.Data.Common.DbBatch
+            {
+                public Microsoft.Data.SqlClient.SqlBatchCommandCollection BatchCommands { get => throw null; }
+                public override void Cancel() => throw null;
+                public System.Collections.Generic.List<Microsoft.Data.SqlClient.SqlBatchCommand> Commands { get => throw null; }
+                public Microsoft.Data.SqlClient.SqlConnection Connection { get => throw null; set { } }
+                protected override System.Data.Common.DbBatchCommand CreateDbBatchCommand() => throw null;
+                public SqlBatch() => throw null;
+                public SqlBatch(Microsoft.Data.SqlClient.SqlConnection connection, Microsoft.Data.SqlClient.SqlTransaction transaction = default(Microsoft.Data.SqlClient.SqlTransaction)) => throw null;
+                protected override System.Data.Common.DbBatchCommandCollection DbBatchCommands { get => throw null; }
+                protected override System.Data.Common.DbConnection DbConnection { get => throw null; set { } }
+                protected override System.Data.Common.DbTransaction DbTransaction { get => throw null; set { } }
+                public override void Dispose() => throw null;
+                protected override System.Data.Common.DbDataReader ExecuteDbDataReader(System.Data.CommandBehavior behavior) => throw null;
+                protected override System.Threading.Tasks.Task<System.Data.Common.DbDataReader> ExecuteDbDataReaderAsync(System.Data.CommandBehavior behavior, System.Threading.CancellationToken cancellationToken) => throw null;
+                public override int ExecuteNonQuery() => throw null;
+                public override System.Threading.Tasks.Task<int> ExecuteNonQueryAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+                public Microsoft.Data.SqlClient.SqlDataReader ExecuteReader() => throw null;
+                public System.Threading.Tasks.Task<Microsoft.Data.SqlClient.SqlDataReader> ExecuteReaderAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+                public override object ExecuteScalar() => throw null;
+                public override System.Threading.Tasks.Task<object> ExecuteScalarAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+                public override void Prepare() => throw null;
+                public override System.Threading.Tasks.Task PrepareAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+                public override int Timeout { get => throw null; set { } }
+                public Microsoft.Data.SqlClient.SqlTransaction Transaction { get => throw null; set { } }
+            }
+            public class SqlBatchCommand : System.Data.Common.DbBatchCommand
+            {
+                public Microsoft.Data.SqlClient.SqlCommandColumnEncryptionSetting ColumnEncryptionSetting { get => throw null; set { } }
+                public System.Data.CommandBehavior CommandBehavior { get => throw null; set { } }
+                public override string CommandText { get => throw null; set { } }
+                public override System.Data.CommandType CommandType { get => throw null; set { } }
+                public SqlBatchCommand() => throw null;
+                public SqlBatchCommand(string commandText, System.Data.CommandType commandType = default(System.Data.CommandType), System.Collections.Generic.IEnumerable<Microsoft.Data.SqlClient.SqlParameter> parameters = default(System.Collections.Generic.IEnumerable<Microsoft.Data.SqlClient.SqlParameter>), Microsoft.Data.SqlClient.SqlCommandColumnEncryptionSetting columnEncryptionSetting = default(Microsoft.Data.SqlClient.SqlCommandColumnEncryptionSetting)) => throw null;
+                protected override System.Data.Common.DbParameterCollection DbParameterCollection { get => throw null; }
+                public Microsoft.Data.SqlClient.SqlParameterCollection Parameters { get => throw null; }
+                public override int RecordsAffected { get => throw null; }
+            }
+            public class SqlBatchCommandCollection : System.Data.Common.DbBatchCommandCollection, System.Collections.Generic.ICollection<Microsoft.Data.SqlClient.SqlBatchCommand>, System.Collections.Generic.IEnumerable<Microsoft.Data.SqlClient.SqlBatchCommand>, System.Collections.IEnumerable, System.Collections.Generic.IList<Microsoft.Data.SqlClient.SqlBatchCommand>
+            {
+                public void Add(Microsoft.Data.SqlClient.SqlBatchCommand item) => throw null;
+                public override void Add(System.Data.Common.DbBatchCommand item) => throw null;
+                public override void Clear() => throw null;
+                public bool Contains(Microsoft.Data.SqlClient.SqlBatchCommand item) => throw null;
+                public override bool Contains(System.Data.Common.DbBatchCommand item) => throw null;
+                public void CopyTo(Microsoft.Data.SqlClient.SqlBatchCommand[] array, int arrayIndex) => throw null;
+                public override void CopyTo(System.Data.Common.DbBatchCommand[] array, int arrayIndex) => throw null;
+                public override int Count { get => throw null; }
+                public SqlBatchCommandCollection() => throw null;
+                protected override System.Data.Common.DbBatchCommand GetBatchCommand(int index) => throw null;
+                System.Collections.Generic.IEnumerator<Microsoft.Data.SqlClient.SqlBatchCommand> System.Collections.Generic.IEnumerable<Microsoft.Data.SqlClient.SqlBatchCommand>.GetEnumerator() => throw null;
+                public override System.Collections.Generic.IEnumerator<System.Data.Common.DbBatchCommand> GetEnumerator() => throw null;
+                System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null;
+                public int IndexOf(Microsoft.Data.SqlClient.SqlBatchCommand item) => throw null;
+                public override int IndexOf(System.Data.Common.DbBatchCommand item) => throw null;
+                public void Insert(int index, Microsoft.Data.SqlClient.SqlBatchCommand item) => throw null;
+                public override void Insert(int index, System.Data.Common.DbBatchCommand item) => throw null;
+                public override bool IsReadOnly { get => throw null; }
+                Microsoft.Data.SqlClient.SqlBatchCommand System.Collections.Generic.IList<Microsoft.Data.SqlClient.SqlBatchCommand>.this[int index] { get => throw null; set { } }
+                public bool Remove(Microsoft.Data.SqlClient.SqlBatchCommand item) => throw null;
+                public override bool Remove(System.Data.Common.DbBatchCommand item) => throw null;
+                public override void RemoveAt(int index) => throw null;
+                protected override void SetBatchCommand(int index, System.Data.Common.DbBatchCommand batchCommand) => throw null;
+                public Microsoft.Data.SqlClient.SqlBatchCommand this[int index] { get => throw null; set { } }
+            }
+            public sealed class SqlBulkCopy : System.IDisposable
+            {
+                public int BatchSize { get => throw null; set { } }
+                public int BulkCopyTimeout { get => throw null; set { } }
+                public void Close() => throw null;
+                public Microsoft.Data.SqlClient.SqlBulkCopyColumnMappingCollection ColumnMappings { get => throw null; }
+                public Microsoft.Data.SqlClient.SqlBulkCopyColumnOrderHintCollection ColumnOrderHints { get => throw null; }
+                public SqlBulkCopy(Microsoft.Data.SqlClient.SqlConnection connection) => throw null;
+                public SqlBulkCopy(Microsoft.Data.SqlClient.SqlConnection connection, Microsoft.Data.SqlClient.SqlBulkCopyOptions copyOptions, Microsoft.Data.SqlClient.SqlTransaction externalTransaction) => throw null;
+                public SqlBulkCopy(string connectionString) => throw null;
+                public SqlBulkCopy(string connectionString, Microsoft.Data.SqlClient.SqlBulkCopyOptions copyOptions) => throw null;
+                public string DestinationTableName { get => throw null; set { } }
+                void System.IDisposable.Dispose() => throw null;
+                public bool EnableStreaming { get => throw null; set { } }
+                public int NotifyAfter { get => throw null; set { } }
+                public int RowsCopied { get => throw null; }
+                public long RowsCopied64 { get => throw null; }
+                public event Microsoft.Data.SqlClient.SqlRowsCopiedEventHandler SqlRowsCopied;
+                public void WriteToServer(System.Data.Common.DbDataReader reader) => throw null;
+                public void WriteToServer(System.Data.DataTable table) => throw null;
+                public void WriteToServer(System.Data.DataTable table, System.Data.DataRowState rowState) => throw null;
+                public void WriteToServer(System.Data.DataRow[] rows) => throw null;
+                public void WriteToServer(System.Data.IDataReader reader) => throw null;
+                public System.Threading.Tasks.Task WriteToServerAsync(System.Data.Common.DbDataReader reader) => throw null;
+                public System.Threading.Tasks.Task WriteToServerAsync(System.Data.Common.DbDataReader reader, System.Threading.CancellationToken cancellationToken) => throw null;
+                public System.Threading.Tasks.Task WriteToServerAsync(System.Data.DataRow[] rows) => throw null;
+                public System.Threading.Tasks.Task WriteToServerAsync(System.Data.DataRow[] rows, System.Threading.CancellationToken cancellationToken) => throw null;
+                public System.Threading.Tasks.Task WriteToServerAsync(System.Data.DataTable table) => throw null;
+                public System.Threading.Tasks.Task WriteToServerAsync(System.Data.DataTable table, System.Data.DataRowState rowState) => throw null;
+                public System.Threading.Tasks.Task WriteToServerAsync(System.Data.DataTable table, System.Data.DataRowState rowState, System.Threading.CancellationToken cancellationToken) => throw null;
+                public System.Threading.Tasks.Task WriteToServerAsync(System.Data.DataTable table, System.Threading.CancellationToken cancellationToken) => throw null;
+                public System.Threading.Tasks.Task WriteToServerAsync(System.Data.IDataReader reader) => throw null;
+                public System.Threading.Tasks.Task WriteToServerAsync(System.Data.IDataReader reader, System.Threading.CancellationToken cancellationToken) => throw null;
+            }
+            public sealed class SqlBulkCopyColumnMapping
+            {
+                public SqlBulkCopyColumnMapping() => throw null;
+                public SqlBulkCopyColumnMapping(int sourceColumnOrdinal, int destinationOrdinal) => throw null;
+                public SqlBulkCopyColumnMapping(int sourceColumnOrdinal, string destinationColumn) => throw null;
+                public SqlBulkCopyColumnMapping(string sourceColumn, int destinationOrdinal) => throw null;
+                public SqlBulkCopyColumnMapping(string sourceColumn, string destinationColumn) => throw null;
+                public string DestinationColumn { get => throw null; set { } }
+                public int DestinationOrdinal { get => throw null; set { } }
+                public string SourceColumn { get => throw null; set { } }
+                public int SourceOrdinal { get => throw null; set { } }
+            }
+            public sealed class SqlBulkCopyColumnMappingCollection : System.Collections.CollectionBase
+            {
+                public Microsoft.Data.SqlClient.SqlBulkCopyColumnMapping Add(Microsoft.Data.SqlClient.SqlBulkCopyColumnMapping bulkCopyColumnMapping) => throw null;
+                public Microsoft.Data.SqlClient.SqlBulkCopyColumnMapping Add(int sourceColumnIndex, int destinationColumnIndex) => throw null;
+                public Microsoft.Data.SqlClient.SqlBulkCopyColumnMapping Add(int sourceColumnIndex, string destinationColumn) => throw null;
+                public Microsoft.Data.SqlClient.SqlBulkCopyColumnMapping Add(string sourceColumn, int destinationColumnIndex) => throw null;
+                public Microsoft.Data.SqlClient.SqlBulkCopyColumnMapping Add(string sourceColumn, string destinationColumn) => throw null;
+                public void Clear() => throw null;
+                public bool Contains(Microsoft.Data.SqlClient.SqlBulkCopyColumnMapping value) => throw null;
+                public void CopyTo(Microsoft.Data.SqlClient.SqlBulkCopyColumnMapping[] array, int index) => throw null;
+                public int IndexOf(Microsoft.Data.SqlClient.SqlBulkCopyColumnMapping value) => throw null;
+                public void Insert(int index, Microsoft.Data.SqlClient.SqlBulkCopyColumnMapping value) => throw null;
+                public void Remove(Microsoft.Data.SqlClient.SqlBulkCopyColumnMapping value) => throw null;
+                public void RemoveAt(int index) => throw null;
+                public Microsoft.Data.SqlClient.SqlBulkCopyColumnMapping this[int index] { get => throw null; }
+            }
+            public sealed class SqlBulkCopyColumnOrderHint
+            {
+                public string Column { get => throw null; set { } }
+                public SqlBulkCopyColumnOrderHint(string column, Microsoft.Data.SqlClient.SortOrder sortOrder) => throw null;
+                public Microsoft.Data.SqlClient.SortOrder SortOrder { get => throw null; set { } }
+            }
+            public sealed class SqlBulkCopyColumnOrderHintCollection : System.Collections.CollectionBase
+            {
+                public Microsoft.Data.SqlClient.SqlBulkCopyColumnOrderHint Add(Microsoft.Data.SqlClient.SqlBulkCopyColumnOrderHint columnOrderHint) => throw null;
+                public Microsoft.Data.SqlClient.SqlBulkCopyColumnOrderHint Add(string column, Microsoft.Data.SqlClient.SortOrder sortOrder) => throw null;
+                public void Clear() => throw null;
+                public bool Contains(Microsoft.Data.SqlClient.SqlBulkCopyColumnOrderHint value) => throw null;
+                public void CopyTo(Microsoft.Data.SqlClient.SqlBulkCopyColumnOrderHint[] array, int index) => throw null;
+                public SqlBulkCopyColumnOrderHintCollection() => throw null;
+                public int IndexOf(Microsoft.Data.SqlClient.SqlBulkCopyColumnOrderHint value) => throw null;
+                public void Insert(int index, Microsoft.Data.SqlClient.SqlBulkCopyColumnOrderHint columnOrderHint) => throw null;
+                public void Remove(Microsoft.Data.SqlClient.SqlBulkCopyColumnOrderHint columnOrderHint) => throw null;
+                public void RemoveAt(int index) => throw null;
+                public Microsoft.Data.SqlClient.SqlBulkCopyColumnOrderHint this[int index] { get => throw null; }
+            }
+            [System.Flags]
+            public enum SqlBulkCopyOptions
+            {
+                AllowEncryptedValueModifications = 64,
+                CheckConstraints = 2,
+                Default = 0,
+                FireTriggers = 16,
+                KeepIdentity = 1,
+                KeepNulls = 8,
+                TableLock = 4,
+                UseInternalTransaction = 32,
+            }
+            public sealed class SqlClientFactory : System.Data.Common.DbProviderFactory
+            {
+                public override bool CanCreateBatch { get => throw null; }
+                public override System.Data.Common.DbBatch CreateBatch() => throw null;
+                public override System.Data.Common.DbBatchCommand CreateBatchCommand() => throw null;
+                public override System.Data.Common.DbCommand CreateCommand() => throw null;
+                public override System.Data.Common.DbCommandBuilder CreateCommandBuilder() => throw null;
+                public override System.Data.Common.DbConnection CreateConnection() => throw null;
+                public override System.Data.Common.DbConnectionStringBuilder CreateConnectionStringBuilder() => throw null;
+                public override System.Data.Common.DbDataAdapter CreateDataAdapter() => throw null;
+                public override System.Data.Common.DbDataSourceEnumerator CreateDataSourceEnumerator() => throw null;
+                public override System.Data.Common.DbParameter CreateParameter() => throw null;
+                public static readonly Microsoft.Data.SqlClient.SqlClientFactory Instance;
+            }
+            public class SqlClientLogger
+            {
+                public SqlClientLogger() => throw null;
+                public bool IsLoggingEnabled { get => throw null; }
+                public bool LogAssert(bool value, string type, string method, string message) => throw null;
+                public void LogError(string type, string method, string message) => throw null;
+                public void LogInfo(string type, string method, string message) => throw null;
+                public void LogWarning(string type, string method, string message) => throw null;
+            }
+            public static class SqlClientMetaDataCollectionNames
+            {
+                public static readonly string AllColumns;
+                public static readonly string Columns;
+                public static readonly string ColumnSetColumns;
+                public static readonly string Databases;
+                public static readonly string ForeignKeys;
+                public static readonly string IndexColumns;
+                public static readonly string Indexes;
+                public static readonly string ProcedureParameters;
+                public static readonly string Procedures;
+                public static readonly string StructuredTypeMembers;
+                public static readonly string Tables;
+                public static readonly string UserDefinedTypes;
+                public static readonly string Users;
+                public static readonly string ViewColumns;
+                public static readonly string Views;
+            }
+            public class SqlColumnEncryptionCertificateStoreProvider : Microsoft.Data.SqlClient.SqlColumnEncryptionKeyStoreProvider
+            {
+                public SqlColumnEncryptionCertificateStoreProvider() => throw null;
+                public override byte[] DecryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm, byte[] encryptedColumnEncryptionKey) => throw null;
+                public override byte[] EncryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm, byte[] columnEncryptionKey) => throw null;
+                public const string ProviderName = default;
+                public override byte[] SignColumnMasterKeyMetadata(string masterKeyPath, bool allowEnclaveComputations) => throw null;
+                public override bool VerifyColumnMasterKeyMetadata(string masterKeyPath, bool allowEnclaveComputations, byte[] signature) => throw null;
+            }
+            public class SqlColumnEncryptionCngProvider : Microsoft.Data.SqlClient.SqlColumnEncryptionKeyStoreProvider
+            {
+                public SqlColumnEncryptionCngProvider() => throw null;
+                public override byte[] DecryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm, byte[] encryptedColumnEncryptionKey) => throw null;
+                public override byte[] EncryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm, byte[] columnEncryptionKey) => throw null;
+                public const string ProviderName = default;
+                public override byte[] SignColumnMasterKeyMetadata(string masterKeyPath, bool allowEnclaveComputations) => throw null;
+                public override bool VerifyColumnMasterKeyMetadata(string masterKeyPath, bool allowEnclaveComputations, byte[] signature) => throw null;
+            }
+            public class SqlColumnEncryptionCspProvider : Microsoft.Data.SqlClient.SqlColumnEncryptionKeyStoreProvider
+            {
+                public SqlColumnEncryptionCspProvider() => throw null;
+                public override byte[] DecryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm, byte[] encryptedColumnEncryptionKey) => throw null;
+                public override byte[] EncryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm, byte[] columnEncryptionKey) => throw null;
+                public const string ProviderName = default;
+                public override byte[] SignColumnMasterKeyMetadata(string masterKeyPath, bool allowEnclaveComputations) => throw null;
+                public override bool VerifyColumnMasterKeyMetadata(string masterKeyPath, bool allowEnclaveComputations, byte[] signature) => throw null;
+            }
+            public abstract class SqlColumnEncryptionKeyStoreProvider
+            {
+                public virtual System.TimeSpan? ColumnEncryptionKeyCacheTtl { get => throw null; set { } }
+                protected SqlColumnEncryptionKeyStoreProvider() => throw null;
+                public abstract byte[] DecryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm, byte[] encryptedColumnEncryptionKey);
+                public abstract byte[] EncryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm, byte[] columnEncryptionKey);
+                public virtual byte[] SignColumnMasterKeyMetadata(string masterKeyPath, bool allowEnclaveComputations) => throw null;
+                public virtual bool VerifyColumnMasterKeyMetadata(string masterKeyPath, bool allowEnclaveComputations, byte[] signature) => throw null;
+            }
+            public sealed class SqlCommand : System.Data.Common.DbCommand, System.ICloneable
+            {
+                public System.IAsyncResult BeginExecuteNonQuery() => throw null;
+                public System.IAsyncResult BeginExecuteNonQuery(System.AsyncCallback callback, object stateObject) => throw null;
+                public System.IAsyncResult BeginExecuteReader() => throw null;
+                public System.IAsyncResult BeginExecuteReader(System.AsyncCallback callback, object stateObject) => throw null;
+                public System.IAsyncResult BeginExecuteReader(System.AsyncCallback callback, object stateObject, System.Data.CommandBehavior behavior) => throw null;
+                public System.IAsyncResult BeginExecuteReader(System.Data.CommandBehavior behavior) => throw null;
+                public System.IAsyncResult BeginExecuteXmlReader() => throw null;
+                public System.IAsyncResult BeginExecuteXmlReader(System.AsyncCallback callback, object stateObject) => throw null;
+                public override void Cancel() => throw null;
+                object System.ICloneable.Clone() => throw null;
+                public Microsoft.Data.SqlClient.SqlCommand Clone() => throw null;
+                public Microsoft.Data.SqlClient.SqlCommandColumnEncryptionSetting ColumnEncryptionSetting { get => throw null; }
+                public override string CommandText { get => throw null; set { } }
+                public override int CommandTimeout { get => throw null; set { } }
+                public override System.Data.CommandType CommandType { get => throw null; set { } }
+                public Microsoft.Data.SqlClient.SqlConnection Connection { get => throw null; set { } }
+                protected override System.Data.Common.DbParameter CreateDbParameter() => throw null;
+                public Microsoft.Data.SqlClient.SqlParameter CreateParameter() => throw null;
+                public SqlCommand() => throw null;
+                public SqlCommand(string cmdText) => throw null;
+                public SqlCommand(string cmdText, Microsoft.Data.SqlClient.SqlConnection connection) => throw null;
+                public SqlCommand(string cmdText, Microsoft.Data.SqlClient.SqlConnection connection, Microsoft.Data.SqlClient.SqlTransaction transaction) => throw null;
+                public SqlCommand(string cmdText, Microsoft.Data.SqlClient.SqlConnection connection, Microsoft.Data.SqlClient.SqlTransaction transaction, Microsoft.Data.SqlClient.SqlCommandColumnEncryptionSetting columnEncryptionSetting) => throw null;
+                protected override System.Data.Common.DbConnection DbConnection { get => throw null; set { } }
+                protected override System.Data.Common.DbParameterCollection DbParameterCollection { get => throw null; }
+                protected override System.Data.Common.DbTransaction DbTransaction { get => throw null; set { } }
+                public override bool DesignTimeVisible { get => throw null; set { } }
+                protected override void Dispose(bool disposing) => throw null;
+                public bool EnableOptimizedParameterBinding { get => throw null; set { } }
+                public int EndExecuteNonQuery(System.IAsyncResult asyncResult) => throw null;
+                public Microsoft.Data.SqlClient.SqlDataReader EndExecuteReader(System.IAsyncResult asyncResult) => throw null;
+                public System.Xml.XmlReader EndExecuteXmlReader(System.IAsyncResult asyncResult) => throw null;
+                protected override System.Data.Common.DbDataReader ExecuteDbDataReader(System.Data.CommandBehavior behavior) => throw null;
+                protected override System.Threading.Tasks.Task<System.Data.Common.DbDataReader> ExecuteDbDataReaderAsync(System.Data.CommandBehavior behavior, System.Threading.CancellationToken cancellationToken) => throw null;
+                public override int ExecuteNonQuery() => throw null;
+                public override System.Threading.Tasks.Task<int> ExecuteNonQueryAsync(System.Threading.CancellationToken cancellationToken) => throw null;
+                public Microsoft.Data.SqlClient.SqlDataReader ExecuteReader() => throw null;
+                public Microsoft.Data.SqlClient.SqlDataReader ExecuteReader(System.Data.CommandBehavior behavior) => throw null;
+                public System.Threading.Tasks.Task<Microsoft.Data.SqlClient.SqlDataReader> ExecuteReaderAsync() => throw null;
+                public System.Threading.Tasks.Task<Microsoft.Data.SqlClient.SqlDataReader> ExecuteReaderAsync(System.Data.CommandBehavior behavior) => throw null;
+                public System.Threading.Tasks.Task<Microsoft.Data.SqlClient.SqlDataReader> ExecuteReaderAsync(System.Data.CommandBehavior behavior, System.Threading.CancellationToken cancellationToken) => throw null;
+                public System.Threading.Tasks.Task<Microsoft.Data.SqlClient.SqlDataReader> ExecuteReaderAsync(System.Threading.CancellationToken cancellationToken) => throw null;
+                public override object ExecuteScalar() => throw null;
+                public override System.Threading.Tasks.Task<object> ExecuteScalarAsync(System.Threading.CancellationToken cancellationToken) => throw null;
+                public System.Xml.XmlReader ExecuteXmlReader() => throw null;
+                public System.Threading.Tasks.Task<System.Xml.XmlReader> ExecuteXmlReaderAsync() => throw null;
+                public System.Threading.Tasks.Task<System.Xml.XmlReader> ExecuteXmlReaderAsync(System.Threading.CancellationToken cancellationToken) => throw null;
+                public Microsoft.Data.Sql.SqlNotificationRequest Notification { get => throw null; set { } }
+                public Microsoft.Data.SqlClient.SqlParameterCollection Parameters { get => throw null; }
+                public override void Prepare() => throw null;
+                public void RegisterColumnEncryptionKeyStoreProvidersOnCommand(System.Collections.Generic.IDictionary<string, Microsoft.Data.SqlClient.SqlColumnEncryptionKeyStoreProvider> customProviders) => throw null;
+                public void ResetCommandTimeout() => throw null;
+                public Microsoft.Data.SqlClient.SqlRetryLogicBaseProvider RetryLogicProvider { get => throw null; set { } }
+                public event System.Data.StatementCompletedEventHandler StatementCompleted;
+                public Microsoft.Data.SqlClient.SqlTransaction Transaction { get => throw null; set { } }
+                public override System.Data.UpdateRowSource UpdatedRowSource { get => throw null; set { } }
+            }
+            public sealed class SqlCommandBuilder : System.Data.Common.DbCommandBuilder
+            {
+                protected override void ApplyParameterInfo(System.Data.Common.DbParameter parameter, System.Data.DataRow datarow, System.Data.StatementType statementType, bool whereClause) => throw null;
+                public override System.Data.Common.CatalogLocation CatalogLocation { get => throw null; set { } }
+                public override string CatalogSeparator { get => throw null; set { } }
+                public SqlCommandBuilder() => throw null;
+                public SqlCommandBuilder(Microsoft.Data.SqlClient.SqlDataAdapter adapter) => throw null;
+                public Microsoft.Data.SqlClient.SqlDataAdapter DataAdapter { get => throw null; set { } }
+                public static void DeriveParameters(Microsoft.Data.SqlClient.SqlCommand command) => throw null;
+                public Microsoft.Data.SqlClient.SqlCommand GetDeleteCommand() => throw null;
+                public Microsoft.Data.SqlClient.SqlCommand GetDeleteCommand(bool useColumnsForParameterNames) => throw null;
+                public Microsoft.Data.SqlClient.SqlCommand GetInsertCommand() => throw null;
+                public Microsoft.Data.SqlClient.SqlCommand GetInsertCommand(bool useColumnsForParameterNames) => throw null;
+                protected override string GetParameterName(int parameterOrdinal) => throw null;
+                protected override string GetParameterName(string parameterName) => throw null;
+                protected override string GetParameterPlaceholder(int parameterOrdinal) => throw null;
+                protected override System.Data.DataTable GetSchemaTable(System.Data.Common.DbCommand srcCommand) => throw null;
+                public Microsoft.Data.SqlClient.SqlCommand GetUpdateCommand() => throw null;
+                public Microsoft.Data.SqlClient.SqlCommand GetUpdateCommand(bool useColumnsForParameterNames) => throw null;
+                protected override System.Data.Common.DbCommand InitializeCommand(System.Data.Common.DbCommand command) => throw null;
+                public override string QuoteIdentifier(string unquotedIdentifier) => throw null;
+                public override string QuotePrefix { get => throw null; set { } }
+                public override string QuoteSuffix { get => throw null; set { } }
+                public override string SchemaSeparator { get => throw null; set { } }
+                protected override void SetRowUpdatingHandler(System.Data.Common.DbDataAdapter adapter) => throw null;
+                public override string UnquoteIdentifier(string quotedIdentifier) => throw null;
+            }
+            public enum SqlCommandColumnEncryptionSetting
+            {
+                Disabled = 3,
+                Enabled = 1,
+                ResultSetOnly = 2,
+                UseConnectionSetting = 0,
+            }
+            public sealed class SqlConfigurableRetryFactory
+            {
+                public static Microsoft.Data.SqlClient.SqlRetryLogicBaseProvider CreateExponentialRetryProvider(Microsoft.Data.SqlClient.SqlRetryLogicOption retryLogicOption) => throw null;
+                public static Microsoft.Data.SqlClient.SqlRetryLogicBaseProvider CreateFixedRetryProvider(Microsoft.Data.SqlClient.SqlRetryLogicOption retryLogicOption) => throw null;
+                public static Microsoft.Data.SqlClient.SqlRetryLogicBaseProvider CreateIncrementalRetryProvider(Microsoft.Data.SqlClient.SqlRetryLogicOption retryLogicOption) => throw null;
+                public static Microsoft.Data.SqlClient.SqlRetryLogicBaseProvider CreateNoneRetryProvider() => throw null;
+                public SqlConfigurableRetryFactory() => throw null;
+            }
+            public sealed class SqlConnection : System.Data.Common.DbConnection, System.ICloneable
+            {
+                public string AccessToken { get => throw null; set { } }
+                public System.Func<Microsoft.Data.SqlClient.SqlAuthenticationParameters, System.Threading.CancellationToken, System.Threading.Tasks.Task<Microsoft.Data.SqlClient.SqlAuthenticationToken>> AccessTokenCallback { get => throw null; set { } }
+                protected override System.Data.Common.DbTransaction BeginDbTransaction(System.Data.IsolationLevel isolationLevel) => throw null;
+                public Microsoft.Data.SqlClient.SqlTransaction BeginTransaction() => throw null;
+                public Microsoft.Data.SqlClient.SqlTransaction BeginTransaction(System.Data.IsolationLevel iso) => throw null;
+                public Microsoft.Data.SqlClient.SqlTransaction BeginTransaction(System.Data.IsolationLevel iso, string transactionName) => throw null;
+                public Microsoft.Data.SqlClient.SqlTransaction BeginTransaction(string transactionName) => throw null;
+                public override bool CanCreateBatch { get => throw null; }
+                public override void ChangeDatabase(string database) => throw null;
+                public static void ChangePassword(string connectionString, Microsoft.Data.SqlClient.SqlCredential credential, System.Security.SecureString newSecurePassword) => throw null;
+                public static void ChangePassword(string connectionString, string newPassword) => throw null;
+                public static void ClearAllPools() => throw null;
+                public static void ClearPool(Microsoft.Data.SqlClient.SqlConnection connection) => throw null;
+                public System.Guid ClientConnectionId { get => throw null; }
+                object System.ICloneable.Clone() => throw null;
+                public override void Close() => throw null;
+                public static System.TimeSpan ColumnEncryptionKeyCacheTtl { get => throw null; set { } }
+                public static bool ColumnEncryptionQueryMetadataCacheEnabled { get => throw null; set { } }
+                public static System.Collections.Generic.IDictionary<string, System.Collections.Generic.IList<string>> ColumnEncryptionTrustedMasterKeyPaths { get => throw null; }
+                public int CommandTimeout { get => throw null; }
+                public override string ConnectionString { get => throw null; set { } }
+                public override int ConnectionTimeout { get => throw null; }
+                public Microsoft.Data.SqlClient.SqlCommand CreateCommand() => throw null;
+                protected override System.Data.Common.DbBatch CreateDbBatch() => throw null;
+                protected override System.Data.Common.DbCommand CreateDbCommand() => throw null;
+                public Microsoft.Data.SqlClient.SqlCredential Credential { get => throw null; set { } }
+                public SqlConnection() => throw null;
+                public SqlConnection(string connectionString) => throw null;
+                public SqlConnection(string connectionString, Microsoft.Data.SqlClient.SqlCredential credential) => throw null;
+                public override string Database { get => throw null; }
+                public override string DataSource { get => throw null; }
+                protected override void Dispose(bool disposing) => throw null;
+                public bool FireInfoMessageEventOnUserErrors { get => throw null; set { } }
+                public override System.Data.DataTable GetSchema() => throw null;
+                public override System.Data.DataTable GetSchema(string collectionName) => throw null;
+                public override System.Data.DataTable GetSchema(string collectionName, string[] restrictionValues) => throw null;
+                public event Microsoft.Data.SqlClient.SqlInfoMessageEventHandler InfoMessage;
+                public override void Open() => throw null;
+                public void Open(Microsoft.Data.SqlClient.SqlConnectionOverrides overrides) => throw null;
+                public override System.Threading.Tasks.Task OpenAsync(System.Threading.CancellationToken cancellationToken) => throw null;
+                public System.Threading.Tasks.Task OpenAsync(Microsoft.Data.SqlClient.SqlConnectionOverrides overrides, System.Threading.CancellationToken cancellationToken) => throw null;
+                public int PacketSize { get => throw null; }
+                public static void RegisterColumnEncryptionKeyStoreProviders(System.Collections.Generic.IDictionary<string, Microsoft.Data.SqlClient.SqlColumnEncryptionKeyStoreProvider> customProviders) => throw null;
+                public void RegisterColumnEncryptionKeyStoreProvidersOnConnection(System.Collections.Generic.IDictionary<string, Microsoft.Data.SqlClient.SqlColumnEncryptionKeyStoreProvider> customProviders) => throw null;
+                public void ResetStatistics() => throw null;
+                public System.Collections.Generic.IDictionary<string, object> RetrieveInternalInfo() => throw null;
+                public System.Collections.IDictionary RetrieveStatistics() => throw null;
+                public Microsoft.Data.SqlClient.SqlRetryLogicBaseProvider RetryLogicProvider { get => throw null; set { } }
+                public int ServerProcessId { get => throw null; }
+                public override string ServerVersion { get => throw null; }
+                public override System.Data.ConnectionState State { get => throw null; }
+                public bool StatisticsEnabled { get => throw null; set { } }
+                public string WorkstationId { get => throw null; }
+            }
+            public enum SqlConnectionAttestationProtocol
+            {
+                NotSpecified = 0,
+                AAS = 1,
+                None = 2,
+                HGS = 3,
+            }
+            public enum SqlConnectionColumnEncryptionSetting
+            {
+                Disabled = 0,
+                Enabled = 1,
+            }
+            public sealed class SqlConnectionEncryptOption
+            {
+                public SqlConnectionEncryptOption() => throw null;
+                public override bool Equals(object obj) => throw null;
+                public override int GetHashCode() => throw null;
+                public static Microsoft.Data.SqlClient.SqlConnectionEncryptOption Mandatory { get => throw null; }
+                public static implicit operator Microsoft.Data.SqlClient.SqlConnectionEncryptOption(bool value) => throw null;
+                public static implicit operator bool(Microsoft.Data.SqlClient.SqlConnectionEncryptOption value) => throw null;
+                public static Microsoft.Data.SqlClient.SqlConnectionEncryptOption Optional { get => throw null; }
+                public static Microsoft.Data.SqlClient.SqlConnectionEncryptOption Parse(string value) => throw null;
+                public static Microsoft.Data.SqlClient.SqlConnectionEncryptOption Strict { get => throw null; }
+                public override string ToString() => throw null;
+                public static bool TryParse(string value, out Microsoft.Data.SqlClient.SqlConnectionEncryptOption result) => throw null;
+            }
+            public enum SqlConnectionIPAddressPreference
+            {
+                IPv4First = 0,
+                IPv6First = 1,
+                UsePlatformDefault = 2,
+            }
+            public enum SqlConnectionOverrides
+            {
+                None = 0,
+                OpenWithoutRetry = 1,
+            }
+            public sealed class SqlConnectionStringBuilder : System.Data.Common.DbConnectionStringBuilder
+            {
+                public Microsoft.Data.SqlClient.ApplicationIntent ApplicationIntent { get => throw null; set { } }
+                public string ApplicationName { get => throw null; set { } }
+                public string AttachDBFilename { get => throw null; set { } }
+                public Microsoft.Data.SqlClient.SqlConnectionAttestationProtocol AttestationProtocol { get => throw null; set { } }
+                public Microsoft.Data.SqlClient.SqlAuthenticationMethod Authentication { get => throw null; set { } }
+                public override void Clear() => throw null;
+                public Microsoft.Data.SqlClient.SqlConnectionColumnEncryptionSetting ColumnEncryptionSetting { get => throw null; set { } }
+                public int CommandTimeout { get => throw null; set { } }
+                public int ConnectRetryCount { get => throw null; set { } }
+                public int ConnectRetryInterval { get => throw null; set { } }
+                public int ConnectTimeout { get => throw null; set { } }
+                public override bool ContainsKey(string keyword) => throw null;
+                public SqlConnectionStringBuilder() => throw null;
+                public SqlConnectionStringBuilder(string connectionString) => throw null;
+                public string CurrentLanguage { get => throw null; set { } }
+                public string DataSource { get => throw null; set { } }
+                public string EnclaveAttestationUrl { get => throw null; set { } }
+                public Microsoft.Data.SqlClient.SqlConnectionEncryptOption Encrypt { get => throw null; set { } }
+                public bool Enlist { get => throw null; set { } }
+                public string FailoverPartner { get => throw null; set { } }
+                public string FailoverPartnerSPN { get => throw null; set { } }
+                public string HostNameInCertificate { get => throw null; set { } }
+                public string InitialCatalog { get => throw null; set { } }
+                public bool IntegratedSecurity { get => throw null; set { } }
+                public Microsoft.Data.SqlClient.SqlConnectionIPAddressPreference IPAddressPreference { get => throw null; set { } }
+                public override bool IsFixedSize { get => throw null; }
+                public override System.Collections.ICollection Keys { get => throw null; }
+                public int LoadBalanceTimeout { get => throw null; set { } }
+                public int MaxPoolSize { get => throw null; set { } }
+                public int MinPoolSize { get => throw null; set { } }
+                public bool MultipleActiveResultSets { get => throw null; set { } }
+                public bool MultiSubnetFailover { get => throw null; set { } }
+                public int PacketSize { get => throw null; set { } }
+                public string Password { get => throw null; set { } }
+                public bool PersistSecurityInfo { get => throw null; set { } }
+                public Microsoft.Data.SqlClient.PoolBlockingPeriod PoolBlockingPeriod { get => throw null; set { } }
+                public bool Pooling { get => throw null; set { } }
+                public override bool Remove(string keyword) => throw null;
+                public bool Replication { get => throw null; set { } }
+                public string ServerCertificate { get => throw null; set { } }
+                public string ServerSPN { get => throw null; set { } }
+                public override bool ShouldSerialize(string keyword) => throw null;
+                public override object this[string keyword] { get => throw null; set { } }
+                public string TransactionBinding { get => throw null; set { } }
+                public bool TrustServerCertificate { get => throw null; set { } }
+                public override bool TryGetValue(string keyword, out object value) => throw null;
+                public string TypeSystemVersion { get => throw null; set { } }
+                public string UserID { get => throw null; set { } }
+                public bool UserInstance { get => throw null; set { } }
+                public override System.Collections.ICollection Values { get => throw null; }
+                public string WorkstationID { get => throw null; set { } }
+            }
+            public sealed class SqlCredential
+            {
+                public SqlCredential(string userId, System.Security.SecureString password) => throw null;
+                public System.Security.SecureString Password { get => throw null; }
+                public string UserId { get => throw null; }
+            }
+            public sealed class SqlDataAdapter : System.Data.Common.DbDataAdapter, System.ICloneable, System.Data.IDataAdapter, System.Data.IDbDataAdapter
+            {
+                object System.ICloneable.Clone() => throw null;
+                public SqlDataAdapter() => throw null;
+                public SqlDataAdapter(Microsoft.Data.SqlClient.SqlCommand selectCommand) => throw null;
+                public SqlDataAdapter(string selectCommandText, Microsoft.Data.SqlClient.SqlConnection selectConnection) => throw null;
+                public SqlDataAdapter(string selectCommandText, string selectConnectionString) => throw null;
+                public Microsoft.Data.SqlClient.SqlCommand DeleteCommand { get => throw null; set { } }
+                System.Data.IDbCommand System.Data.IDbDataAdapter.DeleteCommand { get => throw null; set { } }
+                public Microsoft.Data.SqlClient.SqlCommand InsertCommand { get => throw null; set { } }
+                System.Data.IDbCommand System.Data.IDbDataAdapter.InsertCommand { get => throw null; set { } }
+                protected override void OnRowUpdated(System.Data.Common.RowUpdatedEventArgs value) => throw null;
+                protected override void OnRowUpdating(System.Data.Common.RowUpdatingEventArgs value) => throw null;
+                public event Microsoft.Data.SqlClient.SqlRowUpdatedEventHandler RowUpdated;
+                public event Microsoft.Data.SqlClient.SqlRowUpdatingEventHandler RowUpdating;
+                public Microsoft.Data.SqlClient.SqlCommand SelectCommand { get => throw null; set { } }
+                System.Data.IDbCommand System.Data.IDbDataAdapter.SelectCommand { get => throw null; set { } }
+                public override int UpdateBatchSize { get => throw null; set { } }
+                System.Data.IDbCommand System.Data.IDbDataAdapter.UpdateCommand { get => throw null; set { } }
+                public Microsoft.Data.SqlClient.SqlCommand UpdateCommand { get => throw null; set { } }
+            }
+            public class SqlDataReader : System.Data.Common.DbDataReader, System.Data.IDataReader, System.Data.IDataRecord, System.IDisposable
+            {
+                public override void Close() => throw null;
+                protected Microsoft.Data.SqlClient.SqlConnection Connection { get => throw null; }
+                public override int Depth { get => throw null; }
+                public override int FieldCount { get => throw null; }
+                public override bool GetBoolean(int i) => throw null;
+                public override byte GetByte(int i) => throw null;
+                public override long GetBytes(int i, long dataIndex, byte[] buffer, int bufferIndex, int length) => throw null;
+                public override char GetChar(int i) => throw null;
+                public override long GetChars(int i, long dataIndex, char[] buffer, int bufferIndex, int length) => throw null;
+                public System.Collections.ObjectModel.ReadOnlyCollection<System.Data.Common.DbColumn> GetColumnSchema() => throw null;
+                System.Data.IDataReader System.Data.IDataRecord.GetData(int i) => throw null;
+                public override string GetDataTypeName(int i) => throw null;
+                public override System.DateTime GetDateTime(int i) => throw null;
+                public virtual System.DateTimeOffset GetDateTimeOffset(int i) => throw null;
+                public override decimal GetDecimal(int i) => throw null;
+                public override double GetDouble(int i) => throw null;
+                public override System.Collections.IEnumerator GetEnumerator() => throw null;
+                public override System.Type GetFieldType(int i) => throw null;
+                public override T GetFieldValue<T>(int i) => throw null;
+                public override System.Threading.Tasks.Task<T> GetFieldValueAsync<T>(int i, System.Threading.CancellationToken cancellationToken) => throw null;
+                public override float GetFloat(int i) => throw null;
+                public override System.Guid GetGuid(int i) => throw null;
+                public override short GetInt16(int i) => throw null;
+                public override int GetInt32(int i) => throw null;
+                public override long GetInt64(int i) => throw null;
+                public override string GetName(int i) => throw null;
+                public override int GetOrdinal(string name) => throw null;
+                public override System.Type GetProviderSpecificFieldType(int i) => throw null;
+                public override object GetProviderSpecificValue(int i) => throw null;
+                public override int GetProviderSpecificValues(object[] values) => throw null;
+                public override System.Data.DataTable GetSchemaTable() => throw null;
+                public virtual System.Data.SqlTypes.SqlBinary GetSqlBinary(int i) => throw null;
+                public virtual System.Data.SqlTypes.SqlBoolean GetSqlBoolean(int i) => throw null;
+                public virtual System.Data.SqlTypes.SqlByte GetSqlByte(int i) => throw null;
+                public virtual System.Data.SqlTypes.SqlBytes GetSqlBytes(int i) => throw null;
+                public virtual System.Data.SqlTypes.SqlChars GetSqlChars(int i) => throw null;
+                public virtual System.Data.SqlTypes.SqlDateTime GetSqlDateTime(int i) => throw null;
+                public virtual System.Data.SqlTypes.SqlDecimal GetSqlDecimal(int i) => throw null;
+                public virtual System.Data.SqlTypes.SqlDouble GetSqlDouble(int i) => throw null;
+                public virtual System.Data.SqlTypes.SqlGuid GetSqlGuid(int i) => throw null;
+                public virtual System.Data.SqlTypes.SqlInt16 GetSqlInt16(int i) => throw null;
+                public virtual System.Data.SqlTypes.SqlInt32 GetSqlInt32(int i) => throw null;
+                public virtual System.Data.SqlTypes.SqlInt64 GetSqlInt64(int i) => throw null;
+                public virtual Microsoft.Data.SqlTypes.SqlJson GetSqlJson(int i) => throw null;
+                public virtual System.Data.SqlTypes.SqlMoney GetSqlMoney(int i) => throw null;
+                public virtual System.Data.SqlTypes.SqlSingle GetSqlSingle(int i) => throw null;
+                public virtual System.Data.SqlTypes.SqlString GetSqlString(int i) => throw null;
+                public virtual object GetSqlValue(int i) => throw null;
+                public virtual int GetSqlValues(object[] values) => throw null;
+                public virtual System.Data.SqlTypes.SqlXml GetSqlXml(int i) => throw null;
+                public override System.IO.Stream GetStream(int i) => throw null;
+                public override string GetString(int i) => throw null;
+                public override System.IO.TextReader GetTextReader(int i) => throw null;
+                public virtual System.TimeSpan GetTimeSpan(int i) => throw null;
+                public override object GetValue(int i) => throw null;
+                public override int GetValues(object[] values) => throw null;
+                public virtual System.Xml.XmlReader GetXmlReader(int i) => throw null;
+                public override bool HasRows { get => throw null; }
+                public override bool IsClosed { get => throw null; }
+                protected bool IsCommandBehavior(System.Data.CommandBehavior condition) => throw null;
+                public override bool IsDBNull(int i) => throw null;
+                public override System.Threading.Tasks.Task<bool> IsDBNullAsync(int i, System.Threading.CancellationToken cancellationToken) => throw null;
+                public override bool NextResult() => throw null;
+                public override System.Threading.Tasks.Task<bool> NextResultAsync(System.Threading.CancellationToken cancellationToken) => throw null;
+                public override bool Read() => throw null;
+                public override System.Threading.Tasks.Task<bool> ReadAsync(System.Threading.CancellationToken cancellationToken) => throw null;
+                public override int RecordsAffected { get => throw null; }
+                public Microsoft.Data.SqlClient.DataClassification.SensitivityClassification SensitivityClassification { get => throw null; }
+                public override object this[int i] { get => throw null; }
+                public override object this[string name] { get => throw null; }
+                public override int VisibleFieldCount { get => throw null; }
+            }
+            public sealed class SqlDependency
+            {
+                public void AddCommandDependency(Microsoft.Data.SqlClient.SqlCommand command) => throw null;
+                public SqlDependency() => throw null;
+                public SqlDependency(Microsoft.Data.SqlClient.SqlCommand command) => throw null;
+                public SqlDependency(Microsoft.Data.SqlClient.SqlCommand command, string options, int timeout) => throw null;
+                public bool HasChanges { get => throw null; }
+                public string Id { get => throw null; }
+                public event Microsoft.Data.SqlClient.OnChangeEventHandler OnChange;
+                public static bool Start(string connectionString) => throw null;
+                public static bool Start(string connectionString, string queue) => throw null;
+                public static bool Stop(string connectionString) => throw null;
+                public static bool Stop(string connectionString, string queue) => throw null;
+            }
+            public sealed class SqlError
+            {
+                public byte Class { get => throw null; }
+                public int LineNumber { get => throw null; }
+                public string Message { get => throw null; }
+                public int Number { get => throw null; }
+                public string Procedure { get => throw null; }
+                public string Server { get => throw null; }
+                public string Source { get => throw null; }
+                public byte State { get => throw null; }
+                public override string ToString() => throw null;
+            }
+            public sealed class SqlErrorCollection : System.Collections.ICollection, System.Collections.IEnumerable
+            {
+                public void CopyTo(System.Array array, int index) => throw null;
+                public void CopyTo(Microsoft.Data.SqlClient.SqlError[] array, int index) => throw null;
+                public int Count { get => throw null; }
+                public System.Collections.IEnumerator GetEnumerator() => throw null;
+                bool System.Collections.ICollection.IsSynchronized { get => throw null; }
+                object System.Collections.ICollection.SyncRoot { get => throw null; }
+                public Microsoft.Data.SqlClient.SqlError this[int index] { get => throw null; }
+            }
+            public sealed class SqlException : System.Data.Common.DbException
+            {
+                public Microsoft.Data.SqlClient.SqlBatchCommand BatchCommand { get => throw null; }
+                public byte Class { get => throw null; }
+                public System.Guid ClientConnectionId { get => throw null; }
+                protected override System.Data.Common.DbBatchCommand DbBatchCommand { get => throw null; }
+                public Microsoft.Data.SqlClient.SqlErrorCollection Errors { get => throw null; }
+                public override void GetObjectData(System.Runtime.Serialization.SerializationInfo si, System.Runtime.Serialization.StreamingContext context) => throw null;
+                public int LineNumber { get => throw null; }
+                public int Number { get => throw null; }
+                public string Procedure { get => throw null; }
+                public string Server { get => throw null; }
+                public override string Source { get => throw null; }
+                public byte State { get => throw null; }
+                public override string ToString() => throw null;
+            }
+            public sealed class SqlInfoMessageEventArgs : System.EventArgs
+            {
+                public Microsoft.Data.SqlClient.SqlErrorCollection Errors { get => throw null; }
+                public string Message { get => throw null; }
+                public string Source { get => throw null; }
+                public override string ToString() => throw null;
+            }
+            public delegate void SqlInfoMessageEventHandler(object sender, Microsoft.Data.SqlClient.SqlInfoMessageEventArgs e);
+            public class SqlNotificationEventArgs : System.EventArgs
+            {
+                public SqlNotificationEventArgs(Microsoft.Data.SqlClient.SqlNotificationType type, Microsoft.Data.SqlClient.SqlNotificationInfo info, Microsoft.Data.SqlClient.SqlNotificationSource source) => throw null;
+                public Microsoft.Data.SqlClient.SqlNotificationInfo Info { get => throw null; }
+                public Microsoft.Data.SqlClient.SqlNotificationSource Source { get => throw null; }
+                public Microsoft.Data.SqlClient.SqlNotificationType Type { get => throw null; }
+            }
+            public enum SqlNotificationInfo
+            {
+                AlreadyChanged = -2,
+                Alter = 5,
+                Delete = 3,
+                Drop = 4,
+                Error = 7,
+                Expired = 12,
+                Insert = 1,
+                Invalid = 9,
+                Isolation = 11,
+                Merge = 16,
+                Options = 10,
+                PreviousFire = 14,
+                Query = 8,
+                Resource = 13,
+                Restart = 6,
+                TemplateLimit = 15,
+                Truncate = 0,
+                Unknown = -1,
+                Update = 2,
+            }
+            public enum SqlNotificationSource
+            {
+                Client = -2,
+                Data = 0,
+                Database = 3,
+                Environment = 6,
+                Execution = 7,
+                Object = 2,
+                Owner = 8,
+                Statement = 5,
+                System = 4,
+                Timeout = 1,
+                Unknown = -1,
+            }
+            public enum SqlNotificationType
+            {
+                Change = 0,
+                Subscribe = 1,
+                Unknown = -1,
+            }
+            public sealed class SqlParameter : System.Data.Common.DbParameter, System.ICloneable, System.Data.IDataParameter, System.Data.IDbDataParameter
+            {
+                object System.ICloneable.Clone() => throw null;
+                public System.Data.SqlTypes.SqlCompareOptions CompareInfo { get => throw null; set { } }
+                public SqlParameter() => throw null;
+                public SqlParameter(string parameterName, System.Data.SqlDbType dbType) => throw null;
+                public SqlParameter(string parameterName, System.Data.SqlDbType dbType, int size) => throw null;
+                public SqlParameter(string parameterName, System.Data.SqlDbType dbType, int size, System.Data.ParameterDirection direction, bool isNullable, byte precision, byte scale, string sourceColumn, System.Data.DataRowVersion sourceVersion, object value) => throw null;
+                public SqlParameter(string parameterName, System.Data.SqlDbType dbType, int size, System.Data.ParameterDirection direction, byte precision, byte scale, string sourceColumn, System.Data.DataRowVersion sourceVersion, bool sourceColumnNullMapping, object value, string xmlSchemaCollectionDatabase, string xmlSchemaCollectionOwningSchema, string xmlSchemaCollectionName) => throw null;
+                public SqlParameter(string parameterName, System.Data.SqlDbType dbType, int size, string sourceColumn) => throw null;
+                public SqlParameter(string parameterName, object value) => throw null;
+                public override System.Data.DbType DbType { get => throw null; set { } }
+                public override System.Data.ParameterDirection Direction { get => throw null; set { } }
+                public bool ForceColumnEncryption { get => throw null; set { } }
+                public override bool IsNullable { get => throw null; set { } }
+                public int LocaleId { get => throw null; set { } }
+                public int Offset { get => throw null; set { } }
+                public override string ParameterName { get => throw null; set { } }
+                public byte Precision { get => throw null; set { } }
+                public override void ResetDbType() => throw null;
+                public void ResetSqlDbType() => throw null;
+                public byte Scale { get => throw null; set { } }
+                public override int Size { get => throw null; set { } }
+                public override string SourceColumn { get => throw null; set { } }
+                public override bool SourceColumnNullMapping { get => throw null; set { } }
+                public override System.Data.DataRowVersion SourceVersion { get => throw null; set { } }
+                public System.Data.SqlDbType SqlDbType { get => throw null; set { } }
+                public object SqlValue { get => throw null; set { } }
+                public override string ToString() => throw null;
+                public string TypeName { get => throw null; set { } }
+                public string UdtTypeName { get => throw null; set { } }
+                public override object Value { get => throw null; set { } }
+                public string XmlSchemaCollectionDatabase { get => throw null; set { } }
+                public string XmlSchemaCollectionName { get => throw null; set { } }
+                public string XmlSchemaCollectionOwningSchema { get => throw null; set { } }
+            }
+            public sealed class SqlParameterCollection : System.Data.Common.DbParameterCollection
+            {
+                public Microsoft.Data.SqlClient.SqlParameter Add(Microsoft.Data.SqlClient.SqlParameter value) => throw null;
+                public override int Add(object value) => throw null;
+                public Microsoft.Data.SqlClient.SqlParameter Add(string parameterName, System.Data.SqlDbType sqlDbType) => throw null;
+                public Microsoft.Data.SqlClient.SqlParameter Add(string parameterName, System.Data.SqlDbType sqlDbType, int size) => throw null;
+                public Microsoft.Data.SqlClient.SqlParameter Add(string parameterName, System.Data.SqlDbType sqlDbType, int size, string sourceColumn) => throw null;
+                public void AddRange(Microsoft.Data.SqlClient.SqlParameter[] values) => throw null;
+                public override void AddRange(System.Array values) => throw null;
+                public Microsoft.Data.SqlClient.SqlParameter AddWithValue(string parameterName, object value) => throw null;
+                public override void Clear() => throw null;
+                public bool Contains(Microsoft.Data.SqlClient.SqlParameter value) => throw null;
+                public override bool Contains(object value) => throw null;
+                public override bool Contains(string value) => throw null;
+                public override void CopyTo(System.Array array, int index) => throw null;
+                public void CopyTo(Microsoft.Data.SqlClient.SqlParameter[] array, int index) => throw null;
+                public override int Count { get => throw null; }
+                public override System.Collections.IEnumerator GetEnumerator() => throw null;
+                protected override System.Data.Common.DbParameter GetParameter(int index) => throw null;
+                protected override System.Data.Common.DbParameter GetParameter(string parameterName) => throw null;
+                public int IndexOf(Microsoft.Data.SqlClient.SqlParameter value) => throw null;
+                public override int IndexOf(object value) => throw null;
+                public override int IndexOf(string parameterName) => throw null;
+                public void Insert(int index, Microsoft.Data.SqlClient.SqlParameter value) => throw null;
+                public override void Insert(int index, object value) => throw null;
+                public override bool IsFixedSize { get => throw null; }
+                public override bool IsReadOnly { get => throw null; }
+                public void Remove(Microsoft.Data.SqlClient.SqlParameter value) => throw null;
+                public override void Remove(object value) => throw null;
+                public override void RemoveAt(int index) => throw null;
+                public override void RemoveAt(string parameterName) => throw null;
+                protected override void SetParameter(int index, System.Data.Common.DbParameter value) => throw null;
+                protected override void SetParameter(string parameterName, System.Data.Common.DbParameter value) => throw null;
+                public override object SyncRoot { get => throw null; }
+                public Microsoft.Data.SqlClient.SqlParameter this[int index] { get => throw null; set { } }
+                public Microsoft.Data.SqlClient.SqlParameter this[string parameterName] { get => throw null; set { } }
+            }
+            public sealed class SqlRetryingEventArgs : System.EventArgs
+            {
+                public bool Cancel { get => throw null; set { } }
+                public SqlRetryingEventArgs(int retryCount, System.TimeSpan delay, System.Collections.Generic.IList<System.Exception> exceptions) => throw null;
+                public System.TimeSpan Delay { get => throw null; }
+                public System.Collections.Generic.IList<System.Exception> Exceptions { get => throw null; }
+                public int RetryCount { get => throw null; }
+            }
+            public abstract class SqlRetryIntervalBaseEnumerator : System.ICloneable, System.IDisposable, System.Collections.Generic.IEnumerator<System.TimeSpan>, System.Collections.IEnumerator
+            {
+                public virtual object Clone() => throw null;
+                public SqlRetryIntervalBaseEnumerator() => throw null;
+                public SqlRetryIntervalBaseEnumerator(System.TimeSpan timeInterval, System.TimeSpan maxTime, System.TimeSpan minTime) => throw null;
+                public System.TimeSpan Current { get => throw null; set { } }
+                object System.Collections.IEnumerator.Current { get => throw null; }
+                public virtual void Dispose() => throw null;
+                public System.TimeSpan GapTimeInterval { get => throw null; set { } }
+                protected abstract System.TimeSpan GetNextInterval();
+                public System.TimeSpan MaxTimeInterval { get => throw null; set { } }
+                public System.TimeSpan MinTimeInterval { get => throw null; set { } }
+                public virtual bool MoveNext() => throw null;
+                public virtual void Reset() => throw null;
+                protected virtual void Validate(System.TimeSpan timeInterval, System.TimeSpan maxTimeInterval, System.TimeSpan minTimeInterval) => throw null;
+            }
+            public abstract class SqlRetryLogicBase : System.ICloneable
+            {
+                public virtual object Clone() => throw null;
+                protected SqlRetryLogicBase() => throw null;
+                public int Current { get => throw null; set { } }
+                public int NumberOfTries { get => throw null; set { } }
+                public abstract void Reset();
+                public virtual bool RetryCondition(object sender) => throw null;
+                public Microsoft.Data.SqlClient.SqlRetryIntervalBaseEnumerator RetryIntervalEnumerator { get => throw null; set { } }
+                public System.Predicate<System.Exception> TransientPredicate { get => throw null; set { } }
+                public abstract bool TryNextInterval(out System.TimeSpan intervalTime);
+            }
+            public abstract class SqlRetryLogicBaseProvider
+            {
+                protected SqlRetryLogicBaseProvider() => throw null;
+                public abstract TResult Execute<TResult>(object sender, System.Func<TResult> function);
+                public abstract System.Threading.Tasks.Task<TResult> ExecuteAsync<TResult>(object sender, System.Func<System.Threading.Tasks.Task<TResult>> function, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+                public abstract System.Threading.Tasks.Task ExecuteAsync(object sender, System.Func<System.Threading.Tasks.Task> function, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+                public System.EventHandler<Microsoft.Data.SqlClient.SqlRetryingEventArgs> Retrying { get => throw null; set { } }
+                public Microsoft.Data.SqlClient.SqlRetryLogicBase RetryLogic { get => throw null; set { } }
+            }
+            public sealed class SqlRetryLogicOption
+            {
+                public System.Predicate<string> AuthorizedSqlCondition { get => throw null; set { } }
+                public SqlRetryLogicOption() => throw null;
+                public System.TimeSpan DeltaTime { get => throw null; set { } }
+                public System.TimeSpan MaxTimeInterval { get => throw null; set { } }
+                public System.TimeSpan MinTimeInterval { get => throw null; set { } }
+                public int NumberOfTries { get => throw null; set { } }
+                public System.Collections.Generic.IEnumerable<int> TransientErrors { get => throw null; set { } }
+            }
+            public class SqlRowsCopiedEventArgs : System.EventArgs
+            {
+                public bool Abort { get => throw null; set { } }
+                public SqlRowsCopiedEventArgs(long rowsCopied) => throw null;
+                public long RowsCopied { get => throw null; }
+            }
+            public delegate void SqlRowsCopiedEventHandler(object sender, Microsoft.Data.SqlClient.SqlRowsCopiedEventArgs e);
+            public sealed class SqlRowUpdatedEventArgs : System.Data.Common.RowUpdatedEventArgs
+            {
+                public Microsoft.Data.SqlClient.SqlCommand Command { get => throw null; }
+                public SqlRowUpdatedEventArgs(System.Data.DataRow row, System.Data.IDbCommand command, System.Data.StatementType statementType, System.Data.Common.DataTableMapping tableMapping) : base(default(System.Data.DataRow), default(System.Data.IDbCommand), default(System.Data.StatementType), default(System.Data.Common.DataTableMapping)) => throw null;
+            }
+            public delegate void SqlRowUpdatedEventHandler(object sender, Microsoft.Data.SqlClient.SqlRowUpdatedEventArgs e);
+            public sealed class SqlRowUpdatingEventArgs : System.Data.Common.RowUpdatingEventArgs
+            {
+                protected override System.Data.IDbCommand BaseCommand { get => throw null; set { } }
+                public Microsoft.Data.SqlClient.SqlCommand Command { get => throw null; set { } }
+                public SqlRowUpdatingEventArgs(System.Data.DataRow row, System.Data.IDbCommand command, System.Data.StatementType statementType, System.Data.Common.DataTableMapping tableMapping) : base(default(System.Data.DataRow), default(System.Data.IDbCommand), default(System.Data.StatementType), default(System.Data.Common.DataTableMapping)) => throw null;
+            }
+            public delegate void SqlRowUpdatingEventHandler(object sender, Microsoft.Data.SqlClient.SqlRowUpdatingEventArgs e);
+            public sealed class SqlTransaction : System.Data.Common.DbTransaction
+            {
+                public override void Commit() => throw null;
+                public Microsoft.Data.SqlClient.SqlConnection Connection { get => throw null; }
+                protected override System.Data.Common.DbConnection DbConnection { get => throw null; }
+                protected override void Dispose(bool disposing) => throw null;
+                public override System.Data.IsolationLevel IsolationLevel { get => throw null; }
+                public override void Rollback() => throw null;
+                public override void Rollback(string transactionName) => throw null;
+                public override void Save(string savePointName) => throw null;
+            }
+        }
+        public static partial class SqlDbTypeExtensions
+        {
+            public const System.Data.SqlDbType Json = default;
+        }
+        namespace SqlTypes
+        {
+            public sealed class SqlFileStream : System.IO.Stream
+            {
+                public override System.IAsyncResult BeginRead(byte[] buffer, int offset, int count, System.AsyncCallback callback, object state) => throw null;
+                public override System.IAsyncResult BeginWrite(byte[] buffer, int offset, int count, System.AsyncCallback callback, object state) => throw null;
+                public override bool CanRead { get => throw null; }
+                public override bool CanSeek { get => throw null; }
+                public override bool CanTimeout { get => throw null; }
+                public override bool CanWrite { get => throw null; }
+                public SqlFileStream(string path, byte[] transactionContext, System.IO.FileAccess access) => throw null;
+                public SqlFileStream(string path, byte[] transactionContext, System.IO.FileAccess access, System.IO.FileOptions options, long allocationSize) => throw null;
+                public override int EndRead(System.IAsyncResult asyncResult) => throw null;
+                public override void EndWrite(System.IAsyncResult asyncResult) => throw null;
+                public override void Flush() => throw null;
+                public override long Length { get => throw null; }
+                public string Name { get => throw null; }
+                public override long Position { get => throw null; set { } }
+                public override int Read(byte[] buffer, int offset, int count) => throw null;
+                public override int ReadByte() => throw null;
+                public override int ReadTimeout { get => throw null; }
+                public override long Seek(long offset, System.IO.SeekOrigin origin) => throw null;
+                public override void SetLength(long value) => throw null;
+                public byte[] TransactionContext { get => throw null; }
+                public override void Write(byte[] buffer, int offset, int count) => throw null;
+                public override void WriteByte(byte value) => throw null;
+                public override int WriteTimeout { get => throw null; }
+            }
+            public class SqlJson : System.Data.SqlTypes.INullable
+            {
+                public SqlJson() => throw null;
+                public SqlJson(string jsonString) => throw null;
+                public SqlJson(System.Text.Json.JsonDocument jsonDoc) => throw null;
+                public bool IsNull { get => throw null; }
+                public static Microsoft.Data.SqlTypes.SqlJson Null { get => throw null; }
+                public string Value { get => throw null; }
+            }
+        }
+    }
+}

--- a/csharp/ql/test/resources/stubs/Microsoft.Data.SqlClient/6.0.2/Microsoft.Data.SqlClient.csproj
+++ b/csharp/ql/test/resources/stubs/Microsoft.Data.SqlClient/6.0.2/Microsoft.Data.SqlClient.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputPath>bin\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../Azure.Identity/1.11.4/Azure.Identity.csproj" />
+    <ProjectReference Include="../../Microsoft.Bcl.Cryptography/9.0.4/Microsoft.Bcl.Cryptography.csproj" />
+    <ProjectReference Include="../../Microsoft.Data.SqlClient.SNI.runtime/6.0.2/Microsoft.Data.SqlClient.SNI.runtime.csproj" />
+    <ProjectReference Include="../../Microsoft.Extensions.Caching.Memory/9.0.4/Microsoft.Extensions.Caching.Memory.csproj" />
+    <ProjectReference Include="../../Microsoft.IdentityModel.JsonWebTokens/7.5.0/Microsoft.IdentityModel.JsonWebTokens.csproj" />
+    <ProjectReference Include="../../Microsoft.IdentityModel.Protocols.OpenIdConnect/7.5.0/Microsoft.IdentityModel.Protocols.OpenIdConnect.csproj" />
+    <ProjectReference Include="../../Microsoft.SqlServer.Server/1.0.0/Microsoft.SqlServer.Server.csproj" />
+    <ProjectReference Include="../../System.Configuration.ConfigurationManager/9.0.4/System.Configuration.ConfigurationManager.csproj" />
+    <ProjectReference Include="../../System.Security.Cryptography.Pkcs/9.0.4/System.Security.Cryptography.Pkcs.csproj" />
+    <ProjectReference Include="../../_frameworks/Microsoft.NETCore.App/Microsoft.NETCore.App.csproj" />
+  </ItemGroup>
+</Project>

--- a/csharp/ql/test/resources/stubs/Microsoft.Extensions.Caching.Abstractions/9.0.4/Microsoft.Extensions.Caching.Abstractions.csproj
+++ b/csharp/ql/test/resources/stubs/Microsoft.Extensions.Caching.Abstractions/9.0.4/Microsoft.Extensions.Caching.Abstractions.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputPath>bin\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../Microsoft.Extensions.Primitives/9.0.4/Microsoft.Extensions.Primitives.csproj" />
+    <ProjectReference Include="../../_frameworks/Microsoft.NETCore.App/Microsoft.NETCore.App.csproj" />
+  </ItemGroup>
+</Project>

--- a/csharp/ql/test/resources/stubs/Microsoft.Extensions.Caching.Memory/9.0.4/Microsoft.Extensions.Caching.Memory.csproj
+++ b/csharp/ql/test/resources/stubs/Microsoft.Extensions.Caching.Memory/9.0.4/Microsoft.Extensions.Caching.Memory.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputPath>bin\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../Microsoft.Extensions.Caching.Abstractions/9.0.4/Microsoft.Extensions.Caching.Abstractions.csproj" />
+    <ProjectReference Include="../../Microsoft.Extensions.DependencyInjection.Abstractions/9.0.4/Microsoft.Extensions.DependencyInjection.Abstractions.csproj" />
+    <ProjectReference Include="../../Microsoft.Extensions.Logging.Abstractions/9.0.4/Microsoft.Extensions.Logging.Abstractions.csproj" />
+    <ProjectReference Include="../../Microsoft.Extensions.Options/9.0.4/Microsoft.Extensions.Options.csproj" />
+    <ProjectReference Include="../../Microsoft.Extensions.Primitives/9.0.4/Microsoft.Extensions.Primitives.csproj" />
+    <ProjectReference Include="../../_frameworks/Microsoft.NETCore.App/Microsoft.NETCore.App.csproj" />
+  </ItemGroup>
+</Project>

--- a/csharp/ql/test/resources/stubs/Microsoft.Extensions.DependencyInjection.Abstractions/9.0.4/Microsoft.Extensions.DependencyInjection.Abstractions.csproj
+++ b/csharp/ql/test/resources/stubs/Microsoft.Extensions.DependencyInjection.Abstractions/9.0.4/Microsoft.Extensions.DependencyInjection.Abstractions.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputPath>bin\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../_frameworks/Microsoft.NETCore.App/Microsoft.NETCore.App.csproj" />
+  </ItemGroup>
+</Project>

--- a/csharp/ql/test/resources/stubs/Microsoft.Extensions.Logging.Abstractions/9.0.4/Microsoft.Extensions.Logging.Abstractions.csproj
+++ b/csharp/ql/test/resources/stubs/Microsoft.Extensions.Logging.Abstractions/9.0.4/Microsoft.Extensions.Logging.Abstractions.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputPath>bin\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../Microsoft.Extensions.DependencyInjection.Abstractions/9.0.4/Microsoft.Extensions.DependencyInjection.Abstractions.csproj" />
+    <ProjectReference Include="../../_frameworks/Microsoft.NETCore.App/Microsoft.NETCore.App.csproj" />
+  </ItemGroup>
+</Project>

--- a/csharp/ql/test/resources/stubs/Microsoft.Extensions.Options/9.0.4/Microsoft.Extensions.Options.csproj
+++ b/csharp/ql/test/resources/stubs/Microsoft.Extensions.Options/9.0.4/Microsoft.Extensions.Options.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputPath>bin\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../Microsoft.Extensions.DependencyInjection.Abstractions/9.0.4/Microsoft.Extensions.DependencyInjection.Abstractions.csproj" />
+    <ProjectReference Include="../../Microsoft.Extensions.Primitives/9.0.4/Microsoft.Extensions.Primitives.csproj" />
+    <ProjectReference Include="../../_frameworks/Microsoft.NETCore.App/Microsoft.NETCore.App.csproj" />
+  </ItemGroup>
+</Project>

--- a/csharp/ql/test/resources/stubs/Microsoft.Extensions.Primitives/9.0.4/Microsoft.Extensions.Primitives.csproj
+++ b/csharp/ql/test/resources/stubs/Microsoft.Extensions.Primitives/9.0.4/Microsoft.Extensions.Primitives.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputPath>bin\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../_frameworks/Microsoft.NETCore.App/Microsoft.NETCore.App.csproj" />
+  </ItemGroup>
+</Project>

--- a/csharp/ql/test/resources/stubs/Microsoft.Identity.Client.Extensions.Msal/4.61.3/Microsoft.Identity.Client.Extensions.Msal.cs
+++ b/csharp/ql/test/resources/stubs/Microsoft.Identity.Client.Extensions.Msal/4.61.3/Microsoft.Identity.Client.Extensions.Msal.cs
@@ -1,0 +1,103 @@
+// This file contains auto-generated code.
+// Generated from `Microsoft.Identity.Client.Extensions.Msal, Version=4.61.3.0, Culture=neutral, PublicKeyToken=0a613f4dd989e8ae`.
+namespace Microsoft
+{
+    namespace Identity
+    {
+        namespace Client
+        {
+            namespace Extensions
+            {
+                namespace Msal
+                {
+                    public class CacheChangedEventArgs : System.EventArgs
+                    {
+                        public readonly System.Collections.Generic.IEnumerable<string> AccountsAdded;
+                        public readonly System.Collections.Generic.IEnumerable<string> AccountsRemoved;
+                        public CacheChangedEventArgs(System.Collections.Generic.IEnumerable<string> added, System.Collections.Generic.IEnumerable<string> removed) => throw null;
+                    }
+                    public sealed class CrossPlatLock : System.IDisposable
+                    {
+                        public CrossPlatLock(string lockfilePath, int lockFileRetryDelay = default(int), int lockFileRetryCount = default(int)) => throw null;
+                        public void Dispose() => throw null;
+                    }
+                    public class MsalCacheHelper
+                    {
+                        public event System.EventHandler<Microsoft.Identity.Client.Extensions.Msal.CacheChangedEventArgs> CacheChanged;
+                        public void Clear() => throw null;
+                        public static System.Threading.Tasks.Task<Microsoft.Identity.Client.Extensions.Msal.MsalCacheHelper> CreateAsync(Microsoft.Identity.Client.Extensions.Msal.StorageCreationProperties storageCreationProperties, System.Diagnostics.TraceSource logger = default(System.Diagnostics.TraceSource)) => throw null;
+                        public const string LinuxKeyRingDefaultCollection = default;
+                        public const string LinuxKeyRingSessionCollection = default;
+                        public byte[] LoadUnencryptedTokenCache() => throw null;
+                        public void RegisterCache(Microsoft.Identity.Client.ITokenCache tokenCache) => throw null;
+                        public void SaveUnencryptedTokenCache(byte[] tokenCache) => throw null;
+                        public void UnregisterCache(Microsoft.Identity.Client.ITokenCache tokenCache) => throw null;
+                        public static string UserRootDirectory { get => throw null; }
+                        public void VerifyPersistence() => throw null;
+                    }
+                    public class MsalCachePersistenceException : System.Exception
+                    {
+                        public MsalCachePersistenceException() => throw null;
+                        public MsalCachePersistenceException(string message) => throw null;
+                        public MsalCachePersistenceException(string message, System.Exception innerException) => throw null;
+                        protected MsalCachePersistenceException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) => throw null;
+                    }
+                    public static class SharedUtilities
+                    {
+                        public static string GetUserRootDirectory() => throw null;
+                        public static bool IsLinuxPlatform() => throw null;
+                        public static bool IsMacPlatform() => throw null;
+                        public static bool IsWindowsPlatform() => throw null;
+                    }
+                    public class Storage
+                    {
+                        public void Clear(bool ignoreExceptions = default(bool)) => throw null;
+                        public static Microsoft.Identity.Client.Extensions.Msal.Storage Create(Microsoft.Identity.Client.Extensions.Msal.StorageCreationProperties creationProperties, System.Diagnostics.TraceSource logger = default(System.Diagnostics.TraceSource)) => throw null;
+                        public byte[] ReadData() => throw null;
+                        public void VerifyPersistence() => throw null;
+                        public void WriteData(byte[] data) => throw null;
+                    }
+                    public class StorageCreationProperties
+                    {
+                        public string Authority { get => throw null; }
+                        public readonly string CacheDirectory;
+                        public readonly string CacheFileName;
+                        public string CacheFilePath { get => throw null; }
+                        public string ClientId { get => throw null; }
+                        public readonly System.Collections.Generic.KeyValuePair<string, string> KeyringAttribute1;
+                        public readonly System.Collections.Generic.KeyValuePair<string, string> KeyringAttribute2;
+                        public readonly string KeyringCollection;
+                        public readonly string KeyringSchemaName;
+                        public readonly string KeyringSecretLabel;
+                        public readonly int LockRetryCount;
+                        public readonly int LockRetryDelay;
+                        public readonly string MacKeyChainAccountName;
+                        public readonly string MacKeyChainServiceName;
+                        public readonly bool UseLinuxUnencryptedFallback;
+                        public readonly bool UseUnencryptedFallback;
+                    }
+                    public class StorageCreationPropertiesBuilder
+                    {
+                        public Microsoft.Identity.Client.Extensions.Msal.StorageCreationProperties Build() => throw null;
+                        public StorageCreationPropertiesBuilder(string cacheFileName, string cacheDirectory, string clientId) => throw null;
+                        public StorageCreationPropertiesBuilder(string cacheFileName, string cacheDirectory) => throw null;
+                        public Microsoft.Identity.Client.Extensions.Msal.StorageCreationPropertiesBuilder CustomizeLockRetry(int lockRetryDelay, int lockRetryCount) => throw null;
+                        public Microsoft.Identity.Client.Extensions.Msal.StorageCreationPropertiesBuilder WithCacheChangedEvent(string clientId, string authority = default(string)) => throw null;
+                        public Microsoft.Identity.Client.Extensions.Msal.StorageCreationPropertiesBuilder WithLinuxKeyring(string schemaName, string collection, string secretLabel, System.Collections.Generic.KeyValuePair<string, string> attribute1, System.Collections.Generic.KeyValuePair<string, string> attribute2) => throw null;
+                        public Microsoft.Identity.Client.Extensions.Msal.StorageCreationPropertiesBuilder WithLinuxUnprotectedFile() => throw null;
+                        public Microsoft.Identity.Client.Extensions.Msal.StorageCreationPropertiesBuilder WithMacKeyChain(string serviceName, string accountName) => throw null;
+                        public Microsoft.Identity.Client.Extensions.Msal.StorageCreationPropertiesBuilder WithUnprotectedFile() => throw null;
+                    }
+                    public class TraceSourceLogger
+                    {
+                        public TraceSourceLogger(System.Diagnostics.TraceSource traceSource) => throw null;
+                        public void LogError(string message) => throw null;
+                        public void LogInformation(string message) => throw null;
+                        public void LogWarning(string message) => throw null;
+                        public System.Diagnostics.TraceSource Source { get => throw null; }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/csharp/ql/test/resources/stubs/Microsoft.Identity.Client.Extensions.Msal/4.61.3/Microsoft.Identity.Client.Extensions.Msal.csproj
+++ b/csharp/ql/test/resources/stubs/Microsoft.Identity.Client.Extensions.Msal/4.61.3/Microsoft.Identity.Client.Extensions.Msal.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputPath>bin\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../Microsoft.Identity.Client/4.61.3/Microsoft.Identity.Client.csproj" />
+    <ProjectReference Include="../../System.Security.Cryptography.ProtectedData/9.0.1/System.Security.Cryptography.ProtectedData.csproj" />
+    <ProjectReference Include="../../_frameworks/Microsoft.NETCore.App/Microsoft.NETCore.App.csproj" />
+  </ItemGroup>
+</Project>

--- a/csharp/ql/test/resources/stubs/Microsoft.Identity.Client/4.61.3/Microsoft.Identity.Client.cs
+++ b/csharp/ql/test/resources/stubs/Microsoft.Identity.Client/4.61.3/Microsoft.Identity.Client.cs
@@ -1,0 +1,1350 @@
+// This file contains auto-generated code.
+// Generated from `Microsoft.Identity.Client, Version=4.61.3.0, Culture=neutral, PublicKeyToken=0a613f4dd989e8ae`.
+namespace Microsoft
+{
+    namespace Identity
+    {
+        namespace Client
+        {
+            public enum AadAuthorityAudience
+            {
+                None = 0,
+                AzureAdMyOrg = 1,
+                AzureAdAndPersonalMicrosoftAccount = 2,
+                AzureAdMultipleOrgs = 3,
+                PersonalMicrosoftAccount = 4,
+            }
+            public abstract class AbstractAcquireTokenParameterBuilder<T> : Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T> where T : Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T>
+            {
+                protected AbstractAcquireTokenParameterBuilder() => throw null;
+                public T WithAdfsAuthority(string authorityUri, bool validateAuthority = default(bool)) => throw null;
+                public T WithAuthority(string authorityUri, bool validateAuthority = default(bool)) => throw null;
+                public T WithAuthority(string cloudInstanceUri, System.Guid tenantId, bool validateAuthority = default(bool)) => throw null;
+                public T WithAuthority(string cloudInstanceUri, string tenant, bool validateAuthority = default(bool)) => throw null;
+                public T WithAuthority(Microsoft.Identity.Client.AzureCloudInstance azureCloudInstance, System.Guid tenantId, bool validateAuthority = default(bool)) => throw null;
+                public T WithAuthority(Microsoft.Identity.Client.AzureCloudInstance azureCloudInstance, string tenant, bool validateAuthority = default(bool)) => throw null;
+                public T WithAuthority(Microsoft.Identity.Client.AzureCloudInstance azureCloudInstance, Microsoft.Identity.Client.AadAuthorityAudience authorityAudience, bool validateAuthority = default(bool)) => throw null;
+                public T WithAuthority(Microsoft.Identity.Client.AadAuthorityAudience authorityAudience, bool validateAuthority = default(bool)) => throw null;
+                public T WithB2CAuthority(string authorityUri) => throw null;
+                public T WithClaims(string claims) => throw null;
+                public T WithExtraQueryParameters(System.Collections.Generic.Dictionary<string, string> extraQueryParameters) => throw null;
+                public T WithExtraQueryParameters(string extraQueryParameters) => throw null;
+                protected T WithScopes(System.Collections.Generic.IEnumerable<string> scopes) => throw null;
+                public T WithTenantId(string tenantId) => throw null;
+                public T WithTenantIdFromAuthority(System.Uri authorityUri) => throw null;
+            }
+            public abstract class AbstractApplicationBuilder<T> : Microsoft.Identity.Client.BaseAbstractApplicationBuilder<T> where T : Microsoft.Identity.Client.BaseAbstractApplicationBuilder<T>
+            {
+                public T WithAdfsAuthority(string authorityUri, bool validateAuthority = default(bool)) => throw null;
+                public T WithAuthority(System.Uri authorityUri, bool validateAuthority = default(bool)) => throw null;
+                public T WithAuthority(string authorityUri, bool validateAuthority = default(bool)) => throw null;
+                public T WithAuthority(string cloudInstanceUri, System.Guid tenantId, bool validateAuthority = default(bool)) => throw null;
+                public T WithAuthority(string cloudInstanceUri, string tenant, bool validateAuthority = default(bool)) => throw null;
+                public T WithAuthority(Microsoft.Identity.Client.AzureCloudInstance azureCloudInstance, System.Guid tenantId, bool validateAuthority = default(bool)) => throw null;
+                public T WithAuthority(Microsoft.Identity.Client.AzureCloudInstance azureCloudInstance, string tenant, bool validateAuthority = default(bool)) => throw null;
+                public T WithAuthority(Microsoft.Identity.Client.AzureCloudInstance azureCloudInstance, Microsoft.Identity.Client.AadAuthorityAudience authorityAudience, bool validateAuthority = default(bool)) => throw null;
+                public T WithAuthority(Microsoft.Identity.Client.AadAuthorityAudience authorityAudience, bool validateAuthority = default(bool)) => throw null;
+                public T WithB2CAuthority(string authorityUri) => throw null;
+                public T WithCacheOptions(Microsoft.Identity.Client.CacheOptions options) => throw null;
+                public T WithClientCapabilities(System.Collections.Generic.IEnumerable<string> clientCapabilities) => throw null;
+                public T WithClientId(string clientId) => throw null;
+                public T WithClientName(string clientName) => throw null;
+                public T WithClientVersion(string clientVersion) => throw null;
+                public T WithExtraQueryParameters(System.Collections.Generic.IDictionary<string, string> extraQueryParameters) => throw null;
+                public T WithExtraQueryParameters(string extraQueryParameters) => throw null;
+                public T WithInstanceDicoveryMetadata(string instanceDiscoveryJson) => throw null;
+                public T WithInstanceDicoveryMetadata(System.Uri instanceDiscoveryUri) => throw null;
+                public T WithInstanceDiscovery(bool enableInstanceDiscovery) => throw null;
+                public T WithInstanceDiscoveryMetadata(string instanceDiscoveryJson) => throw null;
+                public T WithInstanceDiscoveryMetadata(System.Uri instanceDiscoveryUri) => throw null;
+                public T WithLegacyCacheCompatibility(bool enableLegacyCacheCompatibility = default(bool)) => throw null;
+                protected T WithOptions(Microsoft.Identity.Client.ApplicationOptions applicationOptions) => throw null;
+                public T WithRedirectUri(string redirectUri) => throw null;
+                public T WithTelemetry(Microsoft.Identity.Client.ITelemetryConfig telemetryConfig) => throw null;
+                public T WithTenantId(string tenantId) => throw null;
+            }
+            public abstract class AbstractClientAppBaseAcquireTokenParameterBuilder<T> : Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> where T : Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>
+            {
+                public override System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> ExecuteAsync(System.Threading.CancellationToken cancellationToken) => throw null;
+            }
+            public abstract class AbstractConfidentialClientAcquireTokenParameterBuilder<T> : Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> where T : Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>
+            {
+                public override System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> ExecuteAsync(System.Threading.CancellationToken cancellationToken) => throw null;
+                protected override void Validate() => throw null;
+                public T WithProofOfPossession(Microsoft.Identity.Client.AppConfig.PoPAuthenticationConfiguration popAuthenticationConfiguration) => throw null;
+            }
+            public abstract class AbstractManagedIdentityAcquireTokenParameterBuilder<T> : Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T> where T : Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T>
+            {
+                protected AbstractManagedIdentityAcquireTokenParameterBuilder() => throw null;
+                public override System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> ExecuteAsync(System.Threading.CancellationToken cancellationToken) => throw null;
+            }
+            public abstract class AbstractPublicClientAcquireTokenParameterBuilder<T> : Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> where T : Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>
+            {
+                public override System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> ExecuteAsync(System.Threading.CancellationToken cancellationToken) => throw null;
+            }
+            public static partial class AccountExtensions
+            {
+                public static System.Collections.Generic.IEnumerable<Microsoft.Identity.Client.TenantProfile> GetTenantProfiles(this Microsoft.Identity.Client.IAccount account) => throw null;
+            }
+            public class AccountId
+            {
+                public AccountId(string identifier, string objectId, string tenantId) => throw null;
+                public AccountId(string adfsIdentifier) => throw null;
+                public override bool Equals(object obj) => throw null;
+                public override int GetHashCode() => throw null;
+                public string Identifier { get => throw null; }
+                public string ObjectId { get => throw null; }
+                public string TenantId { get => throw null; }
+                public override string ToString() => throw null;
+            }
+            public sealed class AcquireTokenByAuthorizationCodeParameterBuilder : Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<Microsoft.Identity.Client.AcquireTokenByAuthorizationCodeParameterBuilder>
+            {
+                protected override void Validate() => throw null;
+                public Microsoft.Identity.Client.AcquireTokenByAuthorizationCodeParameterBuilder WithCcsRoutingHint(string userObjectIdentifier, string tenantIdentifier) => throw null;
+                public Microsoft.Identity.Client.AcquireTokenByAuthorizationCodeParameterBuilder WithCcsRoutingHint(string userName) => throw null;
+                public Microsoft.Identity.Client.AcquireTokenByAuthorizationCodeParameterBuilder WithPkceCodeVerifier(string pkceCodeVerifier) => throw null;
+                public Microsoft.Identity.Client.AcquireTokenByAuthorizationCodeParameterBuilder WithSendX5C(bool withSendX5C) => throw null;
+                public Microsoft.Identity.Client.AcquireTokenByAuthorizationCodeParameterBuilder WithSpaAuthorizationCode(bool requestSpaAuthorizationCode = default(bool)) => throw null;
+            }
+            public sealed class AcquireTokenByIntegratedWindowsAuthParameterBuilder : Microsoft.Identity.Client.AbstractPublicClientAcquireTokenParameterBuilder<Microsoft.Identity.Client.AcquireTokenByIntegratedWindowsAuthParameterBuilder>
+            {
+                public Microsoft.Identity.Client.AcquireTokenByIntegratedWindowsAuthParameterBuilder WithFederationMetadata(string federationMetadata) => throw null;
+                public Microsoft.Identity.Client.AcquireTokenByIntegratedWindowsAuthParameterBuilder WithUsername(string username) => throw null;
+            }
+            public sealed class AcquireTokenByRefreshTokenParameterBuilder : Microsoft.Identity.Client.AbstractClientAppBaseAcquireTokenParameterBuilder<Microsoft.Identity.Client.AcquireTokenByRefreshTokenParameterBuilder>
+            {
+                protected override void Validate() => throw null;
+                public Microsoft.Identity.Client.AcquireTokenByRefreshTokenParameterBuilder WithSendX5C(bool withSendX5C) => throw null;
+            }
+            public sealed class AcquireTokenByUsernamePasswordParameterBuilder : Microsoft.Identity.Client.AbstractPublicClientAcquireTokenParameterBuilder<Microsoft.Identity.Client.AcquireTokenByUsernamePasswordParameterBuilder>
+            {
+                public Microsoft.Identity.Client.AcquireTokenByUsernamePasswordParameterBuilder WithFederationMetadata(string federationMetadata) => throw null;
+                public Microsoft.Identity.Client.AcquireTokenByUsernamePasswordParameterBuilder WithProofOfPossession(string nonce, System.Net.Http.HttpMethod httpMethod, System.Uri requestUri) => throw null;
+            }
+            public sealed class AcquireTokenForClientParameterBuilder : Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder>
+            {
+                protected override void Validate() => throw null;
+                public Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder WithAzureRegion(bool useAzureRegion) => throw null;
+                public Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder WithForceRefresh(bool forceRefresh) => throw null;
+                public Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder WithPreferredAzureRegion(bool useAzureRegion = default(bool), string regionUsedIfAutoDetectFails = default(string), bool fallbackToGlobal = default(bool)) => throw null;
+                public Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder WithSendX5C(bool withSendX5C) => throw null;
+            }
+            public sealed class AcquireTokenForManagedIdentityParameterBuilder : Microsoft.Identity.Client.AbstractManagedIdentityAcquireTokenParameterBuilder<Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder>
+            {
+                public Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder WithForceRefresh(bool forceRefresh) => throw null;
+            }
+            public sealed class AcquireTokenInteractiveParameterBuilder : Microsoft.Identity.Client.AbstractPublicClientAcquireTokenParameterBuilder<Microsoft.Identity.Client.AcquireTokenInteractiveParameterBuilder>
+            {
+                protected override void Validate() => throw null;
+                public Microsoft.Identity.Client.AcquireTokenInteractiveParameterBuilder WithAccount(Microsoft.Identity.Client.IAccount account) => throw null;
+                public Microsoft.Identity.Client.AcquireTokenInteractiveParameterBuilder WithEmbeddedWebViewOptions(Microsoft.Identity.Client.EmbeddedWebViewOptions options) => throw null;
+                public Microsoft.Identity.Client.AcquireTokenInteractiveParameterBuilder WithExtraScopesToConsent(System.Collections.Generic.IEnumerable<string> extraScopesToConsent) => throw null;
+                public Microsoft.Identity.Client.AcquireTokenInteractiveParameterBuilder WithLoginHint(string loginHint) => throw null;
+                public Microsoft.Identity.Client.AcquireTokenInteractiveParameterBuilder WithParentActivityOrWindow(object parent) => throw null;
+                public Microsoft.Identity.Client.AcquireTokenInteractiveParameterBuilder WithParentActivityOrWindow(nint window) => throw null;
+                public Microsoft.Identity.Client.AcquireTokenInteractiveParameterBuilder WithPrompt(Microsoft.Identity.Client.Prompt prompt) => throw null;
+                public Microsoft.Identity.Client.AcquireTokenInteractiveParameterBuilder WithProofOfPossession(string nonce, System.Net.Http.HttpMethod httpMethod, System.Uri requestUri) => throw null;
+                public Microsoft.Identity.Client.AcquireTokenInteractiveParameterBuilder WithSystemWebViewOptions(Microsoft.Identity.Client.SystemWebViewOptions options) => throw null;
+                public Microsoft.Identity.Client.AcquireTokenInteractiveParameterBuilder WithUseEmbeddedWebView(bool useEmbeddedWebView) => throw null;
+            }
+            public sealed class AcquireTokenOnBehalfOfParameterBuilder : Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<Microsoft.Identity.Client.AcquireTokenOnBehalfOfParameterBuilder>
+            {
+                protected override void Validate() => throw null;
+                public Microsoft.Identity.Client.AcquireTokenOnBehalfOfParameterBuilder WithCcsRoutingHint(string userObjectIdentifier, string tenantIdentifier) => throw null;
+                public Microsoft.Identity.Client.AcquireTokenOnBehalfOfParameterBuilder WithCcsRoutingHint(string userName) => throw null;
+                public Microsoft.Identity.Client.AcquireTokenOnBehalfOfParameterBuilder WithForceRefresh(bool forceRefresh) => throw null;
+                public Microsoft.Identity.Client.AcquireTokenOnBehalfOfParameterBuilder WithSendX5C(bool withSendX5C) => throw null;
+            }
+            public sealed class AcquireTokenSilentParameterBuilder : Microsoft.Identity.Client.AbstractClientAppBaseAcquireTokenParameterBuilder<Microsoft.Identity.Client.AcquireTokenSilentParameterBuilder>
+            {
+                protected override void Validate() => throw null;
+                public Microsoft.Identity.Client.AcquireTokenSilentParameterBuilder WithForceRefresh(bool forceRefresh) => throw null;
+                public Microsoft.Identity.Client.AcquireTokenSilentParameterBuilder WithProofOfPossession(Microsoft.Identity.Client.AppConfig.PoPAuthenticationConfiguration popAuthenticationConfiguration) => throw null;
+                public Microsoft.Identity.Client.AcquireTokenSilentParameterBuilder WithProofOfPossession(string nonce, System.Net.Http.HttpMethod httpMethod, System.Uri requestUri) => throw null;
+                public Microsoft.Identity.Client.AcquireTokenSilentParameterBuilder WithSendX5C(bool withSendX5C) => throw null;
+            }
+            public sealed class AcquireTokenWithDeviceCodeParameterBuilder : Microsoft.Identity.Client.AbstractPublicClientAcquireTokenParameterBuilder<Microsoft.Identity.Client.AcquireTokenWithDeviceCodeParameterBuilder>
+            {
+                protected override void Validate() => throw null;
+                public Microsoft.Identity.Client.AcquireTokenWithDeviceCodeParameterBuilder WithDeviceCodeResultCallback(System.Func<Microsoft.Identity.Client.DeviceCodeResult, System.Threading.Tasks.Task> deviceCodeResultCallback) => throw null;
+            }
+            namespace Advanced
+            {
+                public static partial class AcquireTokenParameterBuilderExtensions
+                {
+                    public static T WithExtraHttpHeaders<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, System.Collections.Generic.IDictionary<string, string> extraHttpHeaders) where T : Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> => throw null;
+                }
+            }
+            namespace AppConfig
+            {
+                public class ManagedIdentityId
+                {
+                    public static Microsoft.Identity.Client.AppConfig.ManagedIdentityId SystemAssigned { get => throw null; }
+                    public static Microsoft.Identity.Client.AppConfig.ManagedIdentityId WithUserAssignedClientId(string clientId) => throw null;
+                    public static Microsoft.Identity.Client.AppConfig.ManagedIdentityId WithUserAssignedObjectId(string objectId) => throw null;
+                    public static Microsoft.Identity.Client.AppConfig.ManagedIdentityId WithUserAssignedResourceId(string resourceId) => throw null;
+                }
+                public class PoPAuthenticationConfiguration
+                {
+                    public PoPAuthenticationConfiguration() => throw null;
+                    public PoPAuthenticationConfiguration(System.Net.Http.HttpRequestMessage httpRequestMessage) => throw null;
+                    public PoPAuthenticationConfiguration(System.Uri requestUri) => throw null;
+                    public string HttpHost { get => throw null; set { } }
+                    public System.Net.Http.HttpMethod HttpMethod { get => throw null; set { } }
+                    public string HttpPath { get => throw null; set { } }
+                    public string Nonce { get => throw null; set { } }
+                    public Microsoft.Identity.Client.AuthScheme.PoP.IPoPCryptoProvider PopCryptoProvider { get => throw null; set { } }
+                    public bool SignHttpRequest { get => throw null; set { } }
+                }
+            }
+            public abstract class ApplicationBase : Microsoft.Identity.Client.IApplicationBase
+            {
+            }
+            public abstract class ApplicationOptions : Microsoft.Identity.Client.BaseApplicationOptions
+            {
+                public Microsoft.Identity.Client.AadAuthorityAudience AadAuthorityAudience { get => throw null; set { } }
+                public Microsoft.Identity.Client.AzureCloudInstance AzureCloudInstance { get => throw null; set { } }
+                public System.Collections.Generic.IEnumerable<string> ClientCapabilities { get => throw null; set { } }
+                public string ClientId { get => throw null; set { } }
+                public string ClientName { get => throw null; set { } }
+                public string ClientVersion { get => throw null; set { } }
+                protected ApplicationOptions() => throw null;
+                public string Instance { get => throw null; set { } }
+                public string KerberosServicePrincipalName { get => throw null; set { } }
+                public bool LegacyCacheCompatibilityEnabled { get => throw null; set { } }
+                public string RedirectUri { get => throw null; set { } }
+                public string TenantId { get => throw null; set { } }
+                public Microsoft.Identity.Client.Kerberos.KerberosTicketContainer TicketContainer { get => throw null; set { } }
+            }
+            public class AssertionRequestOptions
+            {
+                public System.Threading.CancellationToken CancellationToken { get => throw null; set { } }
+                public string ClientID { get => throw null; set { } }
+                public AssertionRequestOptions() => throw null;
+                public string TokenEndpoint { get => throw null; set { } }
+            }
+            public class AuthenticationHeaderParser
+            {
+                public Microsoft.Identity.Client.AuthenticationInfoParameters AuthenticationInfoParameters { get => throw null; }
+                public AuthenticationHeaderParser() => throw null;
+                public static Microsoft.Identity.Client.AuthenticationHeaderParser ParseAuthenticationHeaders(System.Net.Http.Headers.HttpResponseHeaders httpResponseHeaders) => throw null;
+                public static System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationHeaderParser> ParseAuthenticationHeadersAsync(string resourceUri, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+                public static System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationHeaderParser> ParseAuthenticationHeadersAsync(string resourceUri, System.Net.Http.HttpClient httpClient, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+                public string PopNonce { get => throw null; }
+                public System.Collections.Generic.IReadOnlyList<Microsoft.Identity.Client.WwwAuthenticateParameters> WwwAuthenticateParameters { get => throw null; }
+            }
+            public class AuthenticationInfoParameters
+            {
+                public static Microsoft.Identity.Client.AuthenticationInfoParameters CreateFromResponseHeaders(System.Net.Http.Headers.HttpResponseHeaders httpResponseHeaders) => throw null;
+                public AuthenticationInfoParameters() => throw null;
+                public string NextNonce { get => throw null; }
+                public string this[string key] { get => throw null; }
+            }
+            public class AuthenticationResult
+            {
+                public string AccessToken { get => throw null; }
+                public Microsoft.Identity.Client.IAccount Account { get => throw null; }
+                public System.Collections.Generic.IReadOnlyDictionary<string, string> AdditionalResponseParameters { get => throw null; }
+                public Microsoft.Identity.Client.AuthenticationResultMetadata AuthenticationResultMetadata { get => throw null; }
+                public System.Security.Claims.ClaimsPrincipal ClaimsPrincipal { get => throw null; }
+                public System.Guid CorrelationId { get => throw null; }
+                public string CreateAuthorizationHeader() => throw null;
+                public AuthenticationResult(string accessToken, bool isExtendedLifeTimeToken, string uniqueId, System.DateTimeOffset expiresOn, System.DateTimeOffset extendedExpiresOn, string tenantId, Microsoft.Identity.Client.IAccount account, string idToken, System.Collections.Generic.IEnumerable<string> scopes, System.Guid correlationId, string tokenType = default(string), Microsoft.Identity.Client.AuthenticationResultMetadata authenticationResultMetadata = default(Microsoft.Identity.Client.AuthenticationResultMetadata), System.Security.Claims.ClaimsPrincipal claimsPrincipal = default(System.Security.Claims.ClaimsPrincipal), string spaAuthCode = default(string), System.Collections.Generic.IReadOnlyDictionary<string, string> additionalResponseParameters = default(System.Collections.Generic.IReadOnlyDictionary<string, string>)) => throw null;
+                public AuthenticationResult(string accessToken, bool isExtendedLifeTimeToken, string uniqueId, System.DateTimeOffset expiresOn, System.DateTimeOffset extendedExpiresOn, string tenantId, Microsoft.Identity.Client.IAccount account, string idToken, System.Collections.Generic.IEnumerable<string> scopes, System.Guid correlationId, Microsoft.Identity.Client.AuthenticationResultMetadata authenticationResultMetadata, string tokenType = default(string)) => throw null;
+                public System.DateTimeOffset ExpiresOn { get => throw null; }
+                public System.DateTimeOffset ExtendedExpiresOn { get => throw null; }
+                public string IdToken { get => throw null; }
+                public bool IsExtendedLifeTimeToken { get => throw null; }
+                public System.Collections.Generic.IEnumerable<string> Scopes { get => throw null; }
+                public string SpaAuthCode { get => throw null; }
+                public string TenantId { get => throw null; }
+                public string TokenType { get => throw null; }
+                public string UniqueId { get => throw null; }
+                public Microsoft.Identity.Client.IUser User { get => throw null; }
+            }
+            public class AuthenticationResultMetadata
+            {
+                public Microsoft.Identity.Client.Cache.CacheLevel CacheLevel { get => throw null; set { } }
+                public Microsoft.Identity.Client.CacheRefreshReason CacheRefreshReason { get => throw null; set { } }
+                public AuthenticationResultMetadata(Microsoft.Identity.Client.TokenSource tokenSource) => throw null;
+                public long DurationInCacheInMs { get => throw null; set { } }
+                public long DurationInHttpInMs { get => throw null; set { } }
+                public long DurationTotalInMs { get => throw null; set { } }
+                public System.DateTimeOffset? RefreshOn { get => throw null; set { } }
+                public Microsoft.Identity.Client.RegionDetails RegionDetails { get => throw null; set { } }
+                public string Telemetry { get => throw null; set { } }
+                public string TokenEndpoint { get => throw null; set { } }
+                public Microsoft.Identity.Client.TokenSource TokenSource { get => throw null; }
+            }
+            namespace AuthScheme
+            {
+                namespace PoP
+                {
+                    public interface IPoPCryptoProvider
+                    {
+                        string CannonicalPublicKeyJwk { get; }
+                        string CryptographicAlgorithm { get; }
+                        byte[] Sign(byte[] data);
+                    }
+                }
+            }
+            public enum AzureCloudInstance
+            {
+                None = 0,
+                AzurePublic = 1,
+                AzureChina = 2,
+                AzureGermany = 3,
+                AzureUsGovernment = 4,
+            }
+            public abstract class BaseAbstractAcquireTokenParameterBuilder<T> where T : Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T>
+            {
+                protected BaseAbstractAcquireTokenParameterBuilder() => throw null;
+                public abstract System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> ExecuteAsync(System.Threading.CancellationToken cancellationToken);
+                public System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> ExecuteAsync() => throw null;
+                protected virtual void Validate() => throw null;
+                public T WithCorrelationId(System.Guid correlationId) => throw null;
+            }
+            public abstract class BaseAbstractApplicationBuilder<T> where T : Microsoft.Identity.Client.BaseAbstractApplicationBuilder<T>
+            {
+                public T WithDebugLoggingCallback(Microsoft.Identity.Client.LogLevel logLevel = default(Microsoft.Identity.Client.LogLevel), bool enablePiiLogging = default(bool), bool withDefaultPlatformLoggingEnabled = default(bool)) => throw null;
+                public T WithExperimentalFeatures(bool enableExperimentalFeatures = default(bool)) => throw null;
+                public T WithHttpClientFactory(Microsoft.Identity.Client.IMsalHttpClientFactory httpClientFactory) => throw null;
+                public T WithHttpClientFactory(Microsoft.Identity.Client.IMsalHttpClientFactory httpClientFactory, bool retryOnceOn5xx) => throw null;
+                public T WithLogging(Microsoft.Identity.Client.LogCallback loggingCallback, Microsoft.Identity.Client.LogLevel? logLevel = default(Microsoft.Identity.Client.LogLevel?), bool? enablePiiLogging = default(bool?), bool? enableDefaultPlatformLogging = default(bool?)) => throw null;
+                public T WithLogging(Microsoft.IdentityModel.Abstractions.IIdentityLogger identityLogger, bool enablePiiLogging = default(bool)) => throw null;
+                protected T WithOptions(Microsoft.Identity.Client.BaseApplicationOptions applicationOptions) => throw null;
+            }
+            public abstract class BaseApplicationOptions
+            {
+                protected BaseApplicationOptions() => throw null;
+                public bool EnablePiiLogging { get => throw null; set { } }
+                public bool IsDefaultPlatformLoggingEnabled { get => throw null; set { } }
+                public Microsoft.Identity.Client.LogLevel LogLevel { get => throw null; set { } }
+            }
+            public class BrokerOptions
+            {
+                public BrokerOptions(Microsoft.Identity.Client.BrokerOptions.OperatingSystems enabledOn) => throw null;
+                public Microsoft.Identity.Client.BrokerOptions.OperatingSystems EnabledOn { get => throw null; }
+                public bool ListOperatingSystemAccounts { get => throw null; set { } }
+                public bool MsaPassthrough { get => throw null; set { } }
+                [System.Flags]
+                public enum OperatingSystems
+                {
+                    None = 0,
+                    Windows = 1,
+                }
+                public string Title { get => throw null; set { } }
+            }
+            namespace Cache
+            {
+                public class CacheData
+                {
+                    public byte[] AdalV3State { get => throw null; set { } }
+                    public CacheData() => throw null;
+                    public byte[] UnifiedState { get => throw null; set { } }
+                }
+                public enum CacheLevel
+                {
+                    None = 0,
+                    Unknown = 1,
+                    L1Cache = 2,
+                    L2Cache = 3,
+                }
+            }
+            public class CacheOptions
+            {
+                public CacheOptions() => throw null;
+                public CacheOptions(bool useSharedCache) => throw null;
+                public static Microsoft.Identity.Client.CacheOptions EnableSharedCacheOptions { get => throw null; }
+                public bool UseSharedCache { get => throw null; set { } }
+            }
+            public enum CacheRefreshReason
+            {
+                NotApplicable = 0,
+                ForceRefreshOrClaims = 1,
+                NoCachedAccessToken = 2,
+                Expired = 3,
+                ProactivelyRefreshed = 4,
+            }
+            public abstract class ClientApplicationBase : Microsoft.Identity.Client.ApplicationBase, Microsoft.Identity.Client.IApplicationBase, Microsoft.Identity.Client.IClientApplicationBase
+            {
+                public Microsoft.Identity.Client.AcquireTokenSilentParameterBuilder AcquireTokenSilent(System.Collections.Generic.IEnumerable<string> scopes, Microsoft.Identity.Client.IAccount account) => throw null;
+                public Microsoft.Identity.Client.AcquireTokenSilentParameterBuilder AcquireTokenSilent(System.Collections.Generic.IEnumerable<string> scopes, string loginHint) => throw null;
+                public System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenSilentAsync(System.Collections.Generic.IEnumerable<string> scopes, Microsoft.Identity.Client.IAccount account, string authority, bool forceRefresh) => throw null;
+                public System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenSilentAsync(System.Collections.Generic.IEnumerable<string> scopes, Microsoft.Identity.Client.IAccount account) => throw null;
+                public Microsoft.Identity.Client.IAppConfig AppConfig { get => throw null; }
+                public string Authority { get => throw null; }
+                public string ClientId { get => throw null; }
+                public string Component { get => throw null; set { } }
+                public System.Threading.Tasks.Task<Microsoft.Identity.Client.IAccount> GetAccountAsync(string accountId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+                public System.Threading.Tasks.Task<Microsoft.Identity.Client.IAccount> GetAccountAsync(string accountId) => throw null;
+                public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Identity.Client.IAccount>> GetAccountsAsync() => throw null;
+                public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Identity.Client.IAccount>> GetAccountsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+                public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Identity.Client.IAccount>> GetAccountsAsync(string userFlow) => throw null;
+                public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Identity.Client.IAccount>> GetAccountsAsync(string userFlow, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+                public Microsoft.Identity.Client.IUser GetUser(string identifier) => throw null;
+                public string RedirectUri { get => throw null; set { } }
+                public void Remove(Microsoft.Identity.Client.IUser user) => throw null;
+                public System.Threading.Tasks.Task RemoveAsync(Microsoft.Identity.Client.IAccount account) => throw null;
+                public System.Threading.Tasks.Task RemoveAsync(Microsoft.Identity.Client.IAccount account, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+                public string SliceParameters { get => throw null; set { } }
+                public System.Collections.Generic.IEnumerable<Microsoft.Identity.Client.IUser> Users { get => throw null; }
+                public Microsoft.Identity.Client.ITokenCache UserTokenCache { get => throw null; }
+                public bool ValidateAuthority { get => throw null; set { } }
+            }
+            public sealed class ClientAssertionCertificate
+            {
+                public System.Security.Cryptography.X509Certificates.X509Certificate2 Certificate { get => throw null; }
+                public ClientAssertionCertificate(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) => throw null;
+                public static int MinKeySizeInBits { get => throw null; }
+            }
+            public sealed class ClientCredential
+            {
+                public ClientCredential(Microsoft.Identity.Client.ClientAssertionCertificate certificate) => throw null;
+                public ClientCredential(string secret) => throw null;
+            }
+            public sealed class ConfidentialClientApplication : Microsoft.Identity.Client.ClientApplicationBase, Microsoft.Identity.Client.IApplicationBase, Microsoft.Identity.Client.IByRefreshToken, Microsoft.Identity.Client.IClientApplicationBase, Microsoft.Identity.Client.IConfidentialClientApplication, Microsoft.Identity.Client.IConfidentialClientApplicationWithCertificate, Microsoft.Identity.Client.ILongRunningWebApi
+            {
+                public Microsoft.Identity.Client.AcquireTokenByAuthorizationCodeParameterBuilder AcquireTokenByAuthorizationCode(System.Collections.Generic.IEnumerable<string> scopes, string authorizationCode) => throw null;
+                public System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenByAuthorizationCodeAsync(string authorizationCode, System.Collections.Generic.IEnumerable<string> scopes) => throw null;
+                Microsoft.Identity.Client.AcquireTokenByRefreshTokenParameterBuilder Microsoft.Identity.Client.IByRefreshToken.AcquireTokenByRefreshToken(System.Collections.Generic.IEnumerable<string> scopes, string refreshToken) => throw null;
+                System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> Microsoft.Identity.Client.IByRefreshToken.AcquireTokenByRefreshTokenAsync(System.Collections.Generic.IEnumerable<string> scopes, string refreshToken) => throw null;
+                public Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder AcquireTokenForClient(System.Collections.Generic.IEnumerable<string> scopes) => throw null;
+                public System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenForClientAsync(System.Collections.Generic.IEnumerable<string> scopes) => throw null;
+                public System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenForClientAsync(System.Collections.Generic.IEnumerable<string> scopes, bool forceRefresh) => throw null;
+                System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> Microsoft.Identity.Client.IConfidentialClientApplicationWithCertificate.AcquireTokenForClientWithCertificateAsync(System.Collections.Generic.IEnumerable<string> scopes) => throw null;
+                System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> Microsoft.Identity.Client.IConfidentialClientApplicationWithCertificate.AcquireTokenForClientWithCertificateAsync(System.Collections.Generic.IEnumerable<string> scopes, bool forceRefresh) => throw null;
+                public Microsoft.Identity.Client.AcquireTokenOnBehalfOfParameterBuilder AcquireTokenInLongRunningProcess(System.Collections.Generic.IEnumerable<string> scopes, string longRunningProcessSessionKey) => throw null;
+                public Microsoft.Identity.Client.AcquireTokenOnBehalfOfParameterBuilder AcquireTokenOnBehalfOf(System.Collections.Generic.IEnumerable<string> scopes, Microsoft.Identity.Client.UserAssertion userAssertion) => throw null;
+                public System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenOnBehalfOfAsync(System.Collections.Generic.IEnumerable<string> scopes, Microsoft.Identity.Client.UserAssertion userAssertion) => throw null;
+                public System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenOnBehalfOfAsync(System.Collections.Generic.IEnumerable<string> scopes, Microsoft.Identity.Client.UserAssertion userAssertion, string authority) => throw null;
+                System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> Microsoft.Identity.Client.IConfidentialClientApplicationWithCertificate.AcquireTokenOnBehalfOfWithCertificateAsync(System.Collections.Generic.IEnumerable<string> scopes, Microsoft.Identity.Client.UserAssertion userAssertion) => throw null;
+                System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> Microsoft.Identity.Client.IConfidentialClientApplicationWithCertificate.AcquireTokenOnBehalfOfWithCertificateAsync(System.Collections.Generic.IEnumerable<string> scopes, Microsoft.Identity.Client.UserAssertion userAssertion, string authority) => throw null;
+                public Microsoft.Identity.Client.ITokenCache AppTokenCache { get => throw null; }
+                public const string AttemptRegionDiscovery = default;
+                public System.Security.Cryptography.X509Certificates.X509Certificate2 Certificate { get => throw null; }
+                public ConfidentialClientApplication(string clientId, string redirectUri, Microsoft.Identity.Client.ClientCredential clientCredential, Microsoft.Identity.Client.TokenCache userTokenCache, Microsoft.Identity.Client.TokenCache appTokenCache) => throw null;
+                public ConfidentialClientApplication(string clientId, string authority, string redirectUri, Microsoft.Identity.Client.ClientCredential clientCredential, Microsoft.Identity.Client.TokenCache userTokenCache, Microsoft.Identity.Client.TokenCache appTokenCache) => throw null;
+                public Microsoft.Identity.Client.GetAuthorizationRequestUrlParameterBuilder GetAuthorizationRequestUrl(System.Collections.Generic.IEnumerable<string> scopes) => throw null;
+                public System.Threading.Tasks.Task<System.Uri> GetAuthorizationRequestUrlAsync(System.Collections.Generic.IEnumerable<string> scopes, string loginHint, string extraQueryParameters) => throw null;
+                public System.Threading.Tasks.Task<System.Uri> GetAuthorizationRequestUrlAsync(System.Collections.Generic.IEnumerable<string> scopes, string redirectUri, string loginHint, string extraQueryParameters, System.Collections.Generic.IEnumerable<string> extraScopesToConsent, string authority) => throw null;
+                public Microsoft.Identity.Client.AcquireTokenOnBehalfOfParameterBuilder InitiateLongRunningProcessInWebApi(System.Collections.Generic.IEnumerable<string> scopes, string userToken, ref string longRunningProcessSessionKey) => throw null;
+                public System.Threading.Tasks.Task<bool> StopLongRunningProcessInWebApiAsync(string longRunningProcessSessionKey, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+            }
+            public class ConfidentialClientApplicationBuilder : Microsoft.Identity.Client.AbstractApplicationBuilder<Microsoft.Identity.Client.ConfidentialClientApplicationBuilder>
+            {
+                public Microsoft.Identity.Client.IConfidentialClientApplication Build() => throw null;
+                public static Microsoft.Identity.Client.ConfidentialClientApplicationBuilder Create(string clientId) => throw null;
+                public static Microsoft.Identity.Client.ConfidentialClientApplicationBuilder CreateWithApplicationOptions(Microsoft.Identity.Client.ConfidentialClientApplicationOptions options) => throw null;
+                public Microsoft.Identity.Client.ConfidentialClientApplicationBuilder WithAzureRegion(string azureRegion = default(string)) => throw null;
+                public Microsoft.Identity.Client.ConfidentialClientApplicationBuilder WithCacheSynchronization(bool enableCacheSynchronization) => throw null;
+                public Microsoft.Identity.Client.ConfidentialClientApplicationBuilder WithCertificate(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) => throw null;
+                public Microsoft.Identity.Client.ConfidentialClientApplicationBuilder WithCertificate(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, bool sendX5C) => throw null;
+                public Microsoft.Identity.Client.ConfidentialClientApplicationBuilder WithClientAssertion(string signedClientAssertion) => throw null;
+                public Microsoft.Identity.Client.ConfidentialClientApplicationBuilder WithClientAssertion(System.Func<string> clientAssertionDelegate) => throw null;
+                public Microsoft.Identity.Client.ConfidentialClientApplicationBuilder WithClientAssertion(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<string>> clientAssertionAsyncDelegate) => throw null;
+                public Microsoft.Identity.Client.ConfidentialClientApplicationBuilder WithClientAssertion(System.Func<Microsoft.Identity.Client.AssertionRequestOptions, System.Threading.Tasks.Task<string>> clientAssertionAsyncDelegate) => throw null;
+                public Microsoft.Identity.Client.ConfidentialClientApplicationBuilder WithClientClaims(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, System.Collections.Generic.IDictionary<string, string> claimsToSign, bool mergeWithDefaultClaims) => throw null;
+                public Microsoft.Identity.Client.ConfidentialClientApplicationBuilder WithClientClaims(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, System.Collections.Generic.IDictionary<string, string> claimsToSign, bool mergeWithDefaultClaims = default(bool), bool sendX5C = default(bool)) => throw null;
+                public Microsoft.Identity.Client.ConfidentialClientApplicationBuilder WithClientSecret(string clientSecret) => throw null;
+                public Microsoft.Identity.Client.ConfidentialClientApplicationBuilder WithGenericAuthority(string authorityUri) => throw null;
+                public Microsoft.Identity.Client.ConfidentialClientApplicationBuilder WithOidcAuthority(string authorityUri) => throw null;
+                public Microsoft.Identity.Client.ConfidentialClientApplicationBuilder WithTelemetryClient(params Microsoft.IdentityModel.Abstractions.ITelemetryClient[] telemetryClients) => throw null;
+            }
+            public class ConfidentialClientApplicationOptions : Microsoft.Identity.Client.ApplicationOptions
+            {
+                public string AzureRegion { get => throw null; set { } }
+                public string ClientSecret { get => throw null; set { } }
+                public ConfidentialClientApplicationOptions() => throw null;
+                public bool EnableCacheSynchronization { get => throw null; set { } }
+            }
+            public class DeviceCodeResult
+            {
+                public string ClientId { get => throw null; }
+                public string DeviceCode { get => throw null; }
+                public System.DateTimeOffset ExpiresOn { get => throw null; }
+                public long Interval { get => throw null; }
+                public string Message { get => throw null; }
+                public System.Collections.Generic.IReadOnlyCollection<string> Scopes { get => throw null; }
+                public string UserCode { get => throw null; }
+                public string VerificationUrl { get => throw null; }
+            }
+            public class EmbeddedWebViewOptions
+            {
+                public EmbeddedWebViewOptions() => throw null;
+                public string Title { get => throw null; set { } }
+                public string WebView2BrowserExecutableFolder { get => throw null; set { } }
+            }
+            namespace Extensibility
+            {
+                public static class AbstractConfidentialClientAcquireTokenParameterBuilderExtension
+                {
+                    public static Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> OnBeforeTokenRequest<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, System.Func<Microsoft.Identity.Client.Extensibility.OnBeforeTokenRequestData, System.Threading.Tasks.Task> onBeforeTokenRequestHandler) where T : Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> => throw null;
+                    public static Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> WithProofOfPosessionKeyId<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, string keyId, string expectedTokenTypeFromAad = default(string)) where T : Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> => throw null;
+                }
+                public static partial class AcquireTokenForClientBuilderExtensions
+                {
+                    public static Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder WithProofOfPosessionKeyId(this Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder builder, string keyId, string expectedTokenTypeFromAad = default(string)) => throw null;
+                }
+                public static partial class AcquireTokenInteractiveParameterBuilderExtensions
+                {
+                    public static Microsoft.Identity.Client.AcquireTokenInteractiveParameterBuilder WithCustomWebUi(this Microsoft.Identity.Client.AcquireTokenInteractiveParameterBuilder builder, Microsoft.Identity.Client.Extensibility.ICustomWebUi customWebUi) => throw null;
+                }
+                public static partial class AcquireTokenOnBehalfOfParameterBuilderExtensions
+                {
+                    public static Microsoft.Identity.Client.AcquireTokenOnBehalfOfParameterBuilder WithSearchInCacheForLongRunningProcess(this Microsoft.Identity.Client.AcquireTokenOnBehalfOfParameterBuilder builder, bool searchInCache = default(bool)) => throw null;
+                }
+                public class AppTokenProviderParameters
+                {
+                    public System.Threading.CancellationToken CancellationToken { get => throw null; }
+                    public string Claims { get => throw null; }
+                    public string CorrelationId { get => throw null; }
+                    public AppTokenProviderParameters() => throw null;
+                    public System.Collections.Generic.IEnumerable<string> Scopes { get => throw null; }
+                    public string TenantId { get => throw null; }
+                }
+                public class AppTokenProviderResult
+                {
+                    public string AccessToken { get => throw null; set { } }
+                    public AppTokenProviderResult() => throw null;
+                    public long ExpiresInSeconds { get => throw null; set { } }
+                    public long? RefreshInSeconds { get => throw null; set { } }
+                }
+                public static partial class ConfidentialClientApplicationBuilderExtensions
+                {
+                    public static Microsoft.Identity.Client.ConfidentialClientApplicationBuilder WithAppTokenProvider(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Func<Microsoft.Identity.Client.Extensibility.AppTokenProviderParameters, System.Threading.Tasks.Task<Microsoft.Identity.Client.Extensibility.AppTokenProviderResult>> appTokenProvider) => throw null;
+                }
+                public static partial class ConfidentialClientApplicationExtensions
+                {
+                    public static System.Threading.Tasks.Task<bool> StopLongRunningProcessInWebApiAsync(this Microsoft.Identity.Client.ILongRunningWebApi clientApp, string longRunningProcessSessionKey, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+                }
+                public interface ICustomWebUi
+                {
+                    System.Threading.Tasks.Task<System.Uri> AcquireAuthorizationCodeAsync(System.Uri authorizationUri, System.Uri redirectUri, System.Threading.CancellationToken cancellationToken);
+                }
+                public sealed class OnBeforeTokenRequestData
+                {
+                    public System.Collections.Generic.IDictionary<string, string> BodyParameters { get => throw null; }
+                    public System.Threading.CancellationToken CancellationToken { get => throw null; }
+                    public OnBeforeTokenRequestData(System.Collections.Generic.IDictionary<string, string> bodyParameters, System.Collections.Generic.IDictionary<string, string> headers, System.Uri requestUri, System.Threading.CancellationToken cancellationToken) => throw null;
+                    public System.Collections.Generic.IDictionary<string, string> Headers { get => throw null; }
+                    public System.Uri RequestUri { get => throw null; set { } }
+                }
+            }
+            public sealed class GetAuthorizationRequestUrlParameterBuilder : Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<Microsoft.Identity.Client.GetAuthorizationRequestUrlParameterBuilder>
+            {
+                public System.Threading.Tasks.Task<System.Uri> ExecuteAsync(System.Threading.CancellationToken cancellationToken) => throw null;
+                public System.Threading.Tasks.Task<System.Uri> ExecuteAsync() => throw null;
+                public Microsoft.Identity.Client.GetAuthorizationRequestUrlParameterBuilder WithAccount(Microsoft.Identity.Client.IAccount account) => throw null;
+                public Microsoft.Identity.Client.GetAuthorizationRequestUrlParameterBuilder WithCcsRoutingHint(string userObjectIdentifier, string tenantIdentifier) => throw null;
+                public Microsoft.Identity.Client.GetAuthorizationRequestUrlParameterBuilder WithExtraScopesToConsent(System.Collections.Generic.IEnumerable<string> extraScopesToConsent) => throw null;
+                public Microsoft.Identity.Client.GetAuthorizationRequestUrlParameterBuilder WithLoginHint(string loginHint) => throw null;
+                public Microsoft.Identity.Client.GetAuthorizationRequestUrlParameterBuilder WithPkce(out string codeVerifier) => throw null;
+                public Microsoft.Identity.Client.GetAuthorizationRequestUrlParameterBuilder WithPrompt(Microsoft.Identity.Client.Prompt prompt) => throw null;
+                public Microsoft.Identity.Client.GetAuthorizationRequestUrlParameterBuilder WithRedirectUri(string redirectUri) => throw null;
+            }
+            public interface IAccount
+            {
+                string Environment { get; }
+                Microsoft.Identity.Client.AccountId HomeAccountId { get; }
+                string Username { get; }
+            }
+            public interface IAppConfig
+            {
+                System.Collections.Generic.IEnumerable<string> ClientCapabilities { get; }
+                System.Security.Cryptography.X509Certificates.X509Certificate2 ClientCredentialCertificate { get; }
+                string ClientId { get; }
+                string ClientName { get; }
+                string ClientSecret { get; }
+                string ClientVersion { get; }
+                bool EnablePiiLogging { get; }
+                bool ExperimentalFeaturesEnabled { get; }
+                System.Collections.Generic.IDictionary<string, string> ExtraQueryParameters { get; }
+                Microsoft.Identity.Client.IMsalHttpClientFactory HttpClientFactory { get; }
+                bool IsBrokerEnabled { get; }
+                bool IsDefaultPlatformLoggingEnabled { get; }
+                bool LegacyCacheCompatibilityEnabled { get; }
+                Microsoft.Identity.Client.LogCallback LoggingCallback { get; }
+                Microsoft.Identity.Client.LogLevel LogLevel { get; }
+                System.Func<object> ParentActivityOrWindowFunc { get; }
+                string RedirectUri { get; }
+                Microsoft.Identity.Client.ITelemetryConfig TelemetryConfig { get; }
+                string TenantId { get; }
+            }
+            public interface IApplicationBase
+            {
+            }
+            public interface IByRefreshToken
+            {
+                Microsoft.Identity.Client.AcquireTokenByRefreshTokenParameterBuilder AcquireTokenByRefreshToken(System.Collections.Generic.IEnumerable<string> scopes, string refreshToken);
+                System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenByRefreshTokenAsync(System.Collections.Generic.IEnumerable<string> scopes, string refreshToken);
+            }
+            public interface IClientApplicationBase : Microsoft.Identity.Client.IApplicationBase
+            {
+                Microsoft.Identity.Client.AcquireTokenSilentParameterBuilder AcquireTokenSilent(System.Collections.Generic.IEnumerable<string> scopes, Microsoft.Identity.Client.IAccount account);
+                Microsoft.Identity.Client.AcquireTokenSilentParameterBuilder AcquireTokenSilent(System.Collections.Generic.IEnumerable<string> scopes, string loginHint);
+                System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenSilentAsync(System.Collections.Generic.IEnumerable<string> scopes, Microsoft.Identity.Client.IAccount account);
+                System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenSilentAsync(System.Collections.Generic.IEnumerable<string> scopes, Microsoft.Identity.Client.IAccount account, string authority, bool forceRefresh);
+                Microsoft.Identity.Client.IAppConfig AppConfig { get; }
+                string Authority { get; }
+                string ClientId { get; }
+                string Component { get; set; }
+                System.Threading.Tasks.Task<Microsoft.Identity.Client.IAccount> GetAccountAsync(string identifier);
+                System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Identity.Client.IAccount>> GetAccountsAsync();
+                System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Identity.Client.IAccount>> GetAccountsAsync(string userFlow);
+                Microsoft.Identity.Client.IUser GetUser(string identifier);
+                string RedirectUri { get; set; }
+                void Remove(Microsoft.Identity.Client.IUser user);
+                System.Threading.Tasks.Task RemoveAsync(Microsoft.Identity.Client.IAccount account);
+                string SliceParameters { get; set; }
+                System.Collections.Generic.IEnumerable<Microsoft.Identity.Client.IUser> Users { get; }
+                Microsoft.Identity.Client.ITokenCache UserTokenCache { get; }
+                bool ValidateAuthority { get; }
+            }
+            public interface IConfidentialClientApplication : Microsoft.Identity.Client.IApplicationBase, Microsoft.Identity.Client.IClientApplicationBase
+            {
+                Microsoft.Identity.Client.AcquireTokenByAuthorizationCodeParameterBuilder AcquireTokenByAuthorizationCode(System.Collections.Generic.IEnumerable<string> scopes, string authorizationCode);
+                System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenByAuthorizationCodeAsync(string authorizationCode, System.Collections.Generic.IEnumerable<string> scopes);
+                Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder AcquireTokenForClient(System.Collections.Generic.IEnumerable<string> scopes);
+                System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenForClientAsync(System.Collections.Generic.IEnumerable<string> scopes);
+                System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenForClientAsync(System.Collections.Generic.IEnumerable<string> scopes, bool forceRefresh);
+                Microsoft.Identity.Client.AcquireTokenOnBehalfOfParameterBuilder AcquireTokenOnBehalfOf(System.Collections.Generic.IEnumerable<string> scopes, Microsoft.Identity.Client.UserAssertion userAssertion);
+                System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenOnBehalfOfAsync(System.Collections.Generic.IEnumerable<string> scopes, Microsoft.Identity.Client.UserAssertion userAssertion);
+                System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenOnBehalfOfAsync(System.Collections.Generic.IEnumerable<string> scopes, Microsoft.Identity.Client.UserAssertion userAssertion, string authority);
+                Microsoft.Identity.Client.AcquireTokenSilentParameterBuilder AcquireTokenSilent(System.Collections.Generic.IEnumerable<string> scopes, string loginHint);
+                Microsoft.Identity.Client.ITokenCache AppTokenCache { get; }
+                System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Microsoft.Identity.Client.IAccount>> GetAccountsAsync();
+                Microsoft.Identity.Client.GetAuthorizationRequestUrlParameterBuilder GetAuthorizationRequestUrl(System.Collections.Generic.IEnumerable<string> scopes);
+                System.Threading.Tasks.Task<System.Uri> GetAuthorizationRequestUrlAsync(System.Collections.Generic.IEnumerable<string> scopes, string loginHint, string extraQueryParameters);
+                System.Threading.Tasks.Task<System.Uri> GetAuthorizationRequestUrlAsync(System.Collections.Generic.IEnumerable<string> scopes, string redirectUri, string loginHint, string extraQueryParameters, System.Collections.Generic.IEnumerable<string> extraScopesToConsent, string authority);
+            }
+            public interface IConfidentialClientApplicationWithCertificate
+            {
+                System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenForClientWithCertificateAsync(System.Collections.Generic.IEnumerable<string> scopes);
+                System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenForClientWithCertificateAsync(System.Collections.Generic.IEnumerable<string> scopes, bool forceRefresh);
+                System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenOnBehalfOfWithCertificateAsync(System.Collections.Generic.IEnumerable<string> scopes, Microsoft.Identity.Client.UserAssertion userAssertion);
+                System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenOnBehalfOfWithCertificateAsync(System.Collections.Generic.IEnumerable<string> scopes, Microsoft.Identity.Client.UserAssertion userAssertion, string authority);
+            }
+            public interface ILongRunningWebApi
+            {
+                Microsoft.Identity.Client.AcquireTokenOnBehalfOfParameterBuilder AcquireTokenInLongRunningProcess(System.Collections.Generic.IEnumerable<string> scopes, string longRunningProcessSessionKey);
+                Microsoft.Identity.Client.AcquireTokenOnBehalfOfParameterBuilder InitiateLongRunningProcessInWebApi(System.Collections.Generic.IEnumerable<string> scopes, string userToken, ref string longRunningProcessSessionKey);
+            }
+            public interface IManagedIdentityApplication : Microsoft.Identity.Client.IApplicationBase
+            {
+                Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder AcquireTokenForManagedIdentity(string resource);
+            }
+            public interface IMsalHttpClientFactory
+            {
+                System.Net.Http.HttpClient GetHttpClient();
+            }
+            public class IntuneAppProtectionPolicyRequiredException : Microsoft.Identity.Client.MsalServiceException
+            {
+                public string AccountUserId { get => throw null; set { } }
+                public string AuthorityUrl { get => throw null; set { } }
+                public IntuneAppProtectionPolicyRequiredException(string errorCode, string errorMessage) : base(default(string), default(string)) => throw null;
+                public string TenantId { get => throw null; set { } }
+                public string Upn { get => throw null; set { } }
+            }
+            public interface IPublicClientApplication : Microsoft.Identity.Client.IApplicationBase, Microsoft.Identity.Client.IClientApplicationBase
+            {
+                System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenAsync(System.Collections.Generic.IEnumerable<string> scopes);
+                System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenAsync(System.Collections.Generic.IEnumerable<string> scopes, string loginHint);
+                System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenAsync(System.Collections.Generic.IEnumerable<string> scopes, Microsoft.Identity.Client.IAccount account);
+                System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenAsync(System.Collections.Generic.IEnumerable<string> scopes, string loginHint, Microsoft.Identity.Client.Prompt prompt, string extraQueryParameters);
+                System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenAsync(System.Collections.Generic.IEnumerable<string> scopes, Microsoft.Identity.Client.IAccount account, Microsoft.Identity.Client.Prompt prompt, string extraQueryParameters);
+                System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenAsync(System.Collections.Generic.IEnumerable<string> scopes, string loginHint, Microsoft.Identity.Client.Prompt prompt, string extraQueryParameters, System.Collections.Generic.IEnumerable<string> extraScopesToConsent, string authority);
+                System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenAsync(System.Collections.Generic.IEnumerable<string> scopes, Microsoft.Identity.Client.IAccount account, Microsoft.Identity.Client.Prompt prompt, string extraQueryParameters, System.Collections.Generic.IEnumerable<string> extraScopesToConsent, string authority);
+                System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenAsync(System.Collections.Generic.IEnumerable<string> scopes, Microsoft.Identity.Client.UIParent parent);
+                System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenAsync(System.Collections.Generic.IEnumerable<string> scopes, string loginHint, Microsoft.Identity.Client.UIParent parent);
+                System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenAsync(System.Collections.Generic.IEnumerable<string> scopes, Microsoft.Identity.Client.IAccount account, Microsoft.Identity.Client.UIParent parent);
+                System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenAsync(System.Collections.Generic.IEnumerable<string> scopes, string loginHint, Microsoft.Identity.Client.Prompt prompt, string extraQueryParameters, Microsoft.Identity.Client.UIParent parent);
+                System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenAsync(System.Collections.Generic.IEnumerable<string> scopes, Microsoft.Identity.Client.IAccount account, Microsoft.Identity.Client.Prompt prompt, string extraQueryParameters, Microsoft.Identity.Client.UIParent parent);
+                System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenAsync(System.Collections.Generic.IEnumerable<string> scopes, string loginHint, Microsoft.Identity.Client.Prompt prompt, string extraQueryParameters, System.Collections.Generic.IEnumerable<string> extraScopesToConsent, string authority, Microsoft.Identity.Client.UIParent parent);
+                System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenAsync(System.Collections.Generic.IEnumerable<string> scopes, Microsoft.Identity.Client.IAccount account, Microsoft.Identity.Client.Prompt prompt, string extraQueryParameters, System.Collections.Generic.IEnumerable<string> extraScopesToConsent, string authority, Microsoft.Identity.Client.UIParent parent);
+                Microsoft.Identity.Client.AcquireTokenByIntegratedWindowsAuthParameterBuilder AcquireTokenByIntegratedWindowsAuth(System.Collections.Generic.IEnumerable<string> scopes);
+                System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenByIntegratedWindowsAuthAsync(System.Collections.Generic.IEnumerable<string> scopes);
+                System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenByIntegratedWindowsAuthAsync(System.Collections.Generic.IEnumerable<string> scopes, string username);
+                Microsoft.Identity.Client.AcquireTokenByUsernamePasswordParameterBuilder AcquireTokenByUsernamePassword(System.Collections.Generic.IEnumerable<string> scopes, string username, System.Security.SecureString password);
+                Microsoft.Identity.Client.AcquireTokenByUsernamePasswordParameterBuilder AcquireTokenByUsernamePassword(System.Collections.Generic.IEnumerable<string> scopes, string username, string password);
+                System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenByUsernamePasswordAsync(System.Collections.Generic.IEnumerable<string> scopes, string username, System.Security.SecureString securePassword);
+                Microsoft.Identity.Client.AcquireTokenInteractiveParameterBuilder AcquireTokenInteractive(System.Collections.Generic.IEnumerable<string> scopes);
+                Microsoft.Identity.Client.AcquireTokenWithDeviceCodeParameterBuilder AcquireTokenWithDeviceCode(System.Collections.Generic.IEnumerable<string> scopes, System.Func<Microsoft.Identity.Client.DeviceCodeResult, System.Threading.Tasks.Task> deviceCodeResultCallback);
+                System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenWithDeviceCodeAsync(System.Collections.Generic.IEnumerable<string> scopes, System.Func<Microsoft.Identity.Client.DeviceCodeResult, System.Threading.Tasks.Task> deviceCodeResultCallback);
+                System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenWithDeviceCodeAsync(System.Collections.Generic.IEnumerable<string> scopes, string extraQueryParameters, System.Func<Microsoft.Identity.Client.DeviceCodeResult, System.Threading.Tasks.Task> deviceCodeResultCallback);
+                System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenWithDeviceCodeAsync(System.Collections.Generic.IEnumerable<string> scopes, System.Func<Microsoft.Identity.Client.DeviceCodeResult, System.Threading.Tasks.Task> deviceCodeResultCallback, System.Threading.CancellationToken cancellationToken);
+                System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenWithDeviceCodeAsync(System.Collections.Generic.IEnumerable<string> scopes, string extraQueryParameters, System.Func<Microsoft.Identity.Client.DeviceCodeResult, System.Threading.Tasks.Task> deviceCodeResultCallback, System.Threading.CancellationToken cancellationToken);
+                bool IsSystemWebViewAvailable { get; }
+            }
+            public interface ITelemetryConfig
+            {
+                Microsoft.Identity.Client.TelemetryAudienceType AudienceType { get; }
+                System.Action<Microsoft.Identity.Client.ITelemetryEventPayload> DispatchAction { get; }
+                string SessionId { get; }
+            }
+            public interface ITelemetryEventPayload
+            {
+                System.Collections.Generic.IReadOnlyDictionary<string, bool> BoolValues { get; }
+                System.Collections.Generic.IReadOnlyDictionary<string, long> Int64Values { get; }
+                System.Collections.Generic.IReadOnlyDictionary<string, int> IntValues { get; }
+                string Name { get; }
+                System.Collections.Generic.IReadOnlyDictionary<string, string> StringValues { get; }
+                string ToJsonString();
+            }
+            public interface ITokenCache
+            {
+                void Deserialize(byte[] msalV2State);
+                void DeserializeAdalV3(byte[] adalV3State);
+                void DeserializeMsalV2(byte[] msalV2State);
+                void DeserializeMsalV3(byte[] msalV3State, bool shouldClearExistingCache = default(bool));
+                void DeserializeUnifiedAndAdalCache(Microsoft.Identity.Client.Cache.CacheData cacheData);
+                byte[] Serialize();
+                byte[] SerializeAdalV3();
+                byte[] SerializeMsalV2();
+                byte[] SerializeMsalV3();
+                Microsoft.Identity.Client.Cache.CacheData SerializeUnifiedAndAdalCache();
+                void SetAfterAccess(Microsoft.Identity.Client.TokenCacheCallback afterAccess);
+                void SetAfterAccessAsync(System.Func<Microsoft.Identity.Client.TokenCacheNotificationArgs, System.Threading.Tasks.Task> afterAccess);
+                void SetBeforeAccess(Microsoft.Identity.Client.TokenCacheCallback beforeAccess);
+                void SetBeforeAccessAsync(System.Func<Microsoft.Identity.Client.TokenCacheNotificationArgs, System.Threading.Tasks.Task> beforeAccess);
+                void SetBeforeWrite(Microsoft.Identity.Client.TokenCacheCallback beforeWrite);
+                void SetBeforeWriteAsync(System.Func<Microsoft.Identity.Client.TokenCacheNotificationArgs, System.Threading.Tasks.Task> beforeWrite);
+            }
+            public interface ITokenCacheSerializer
+            {
+                void DeserializeAdalV3(byte[] adalV3State);
+                void DeserializeMsalV2(byte[] msalV2State);
+                void DeserializeMsalV3(byte[] msalV3State, bool shouldClearExistingCache = default(bool));
+                byte[] SerializeAdalV3();
+                byte[] SerializeMsalV2();
+                byte[] SerializeMsalV3();
+            }
+            public interface IUser
+            {
+                string DisplayableId { get; }
+                string Identifier { get; }
+                string IdentityProvider { get; }
+                string Name { get; }
+            }
+            namespace Kerberos
+            {
+                public enum KerberosKeyTypes
+                {
+                    None = 0,
+                    DecCbcCrc = 1,
+                    DesCbcMd5 = 3,
+                    Aes128CtsHmacSha196 = 17,
+                    Aes256CtsHmacSha196 = 18,
+                }
+                public class KerberosSupplementalTicket
+                {
+                    public string ClientKey { get => throw null; set { } }
+                    public string ClientName { get => throw null; set { } }
+                    public KerberosSupplementalTicket() => throw null;
+                    public KerberosSupplementalTicket(string errorMessage) => throw null;
+                    public string ErrorMessage { get => throw null; set { } }
+                    public string KerberosMessageBuffer { get => throw null; set { } }
+                    public Microsoft.Identity.Client.Kerberos.KerberosKeyTypes KeyType { get => throw null; set { } }
+                    public string Realm { get => throw null; set { } }
+                    public string ServicePrincipalName { get => throw null; set { } }
+                    public override string ToString() => throw null;
+                }
+                public static class KerberosSupplementalTicketManager
+                {
+                    public static Microsoft.Identity.Client.Kerberos.KerberosSupplementalTicket FromIdToken(string idToken) => throw null;
+                    public static byte[] GetKerberosTicketFromWindowsTicketCache(string servicePrincipalName) => throw null;
+                    public static byte[] GetKerberosTicketFromWindowsTicketCache(string servicePrincipalName, long logonId) => throw null;
+                    public static byte[] GetKrbCred(Microsoft.Identity.Client.Kerberos.KerberosSupplementalTicket ticket) => throw null;
+                    public static void SaveToWindowsTicketCache(Microsoft.Identity.Client.Kerberos.KerberosSupplementalTicket ticket) => throw null;
+                    public static void SaveToWindowsTicketCache(Microsoft.Identity.Client.Kerberos.KerberosSupplementalTicket ticket, long logonId) => throw null;
+                }
+                public enum KerberosTicketContainer
+                {
+                    IdToken = 0,
+                    AccessToken = 1,
+                }
+            }
+            public delegate void LogCallback(Microsoft.Identity.Client.LogLevel level, string message, bool containsPii);
+            public sealed class Logger
+            {
+                public Logger() => throw null;
+                public static bool DefaultLoggingEnabled { get => throw null; set { } }
+                public static Microsoft.Identity.Client.LogLevel Level { get => throw null; set { } }
+                public static Microsoft.Identity.Client.LogCallback LogCallback { set { } }
+                public static bool PiiLoggingEnabled { get => throw null; set { } }
+            }
+            public enum LogLevel
+            {
+                Always = -1,
+                Error = 0,
+                Warning = 1,
+                Info = 2,
+                Verbose = 3,
+            }
+            namespace ManagedIdentity
+            {
+                public enum ManagedIdentitySource
+                {
+                    None = 0,
+                    Imds = 1,
+                    AppService = 2,
+                    AzureArc = 3,
+                    CloudShell = 4,
+                    ServiceFabric = 5,
+                    DefaultToImds = 6,
+                }
+            }
+            public sealed class ManagedIdentityApplication : Microsoft.Identity.Client.ApplicationBase, Microsoft.Identity.Client.IApplicationBase, Microsoft.Identity.Client.IManagedIdentityApplication
+            {
+                public Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder AcquireTokenForManagedIdentity(string resource) => throw null;
+                public static Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource GetManagedIdentitySource() => throw null;
+            }
+            public sealed class ManagedIdentityApplicationBuilder : Microsoft.Identity.Client.BaseAbstractApplicationBuilder<Microsoft.Identity.Client.ManagedIdentityApplicationBuilder>
+            {
+                public Microsoft.Identity.Client.IManagedIdentityApplication Build() => throw null;
+                public static Microsoft.Identity.Client.ManagedIdentityApplicationBuilder Create(Microsoft.Identity.Client.AppConfig.ManagedIdentityId managedIdentityId) => throw null;
+                public Microsoft.Identity.Client.ManagedIdentityApplicationBuilder WithTelemetryClient(params Microsoft.IdentityModel.Abstractions.ITelemetryClient[] telemetryClients) => throw null;
+            }
+            public class Metrics
+            {
+                public static long TotalAccessTokensFromBroker { get => throw null; }
+                public static long TotalAccessTokensFromCache { get => throw null; }
+                public static long TotalAccessTokensFromIdP { get => throw null; }
+                public static long TotalDurationInMs { get => throw null; }
+            }
+            public class MsalClaimsChallengeException : Microsoft.Identity.Client.MsalUiRequiredException
+            {
+                public MsalClaimsChallengeException(string errorCode, string errorMessage) : base(default(string), default(string)) => throw null;
+                public MsalClaimsChallengeException(string errorCode, string errorMessage, System.Exception innerException) : base(default(string), default(string)) => throw null;
+                public MsalClaimsChallengeException(string errorCode, string errorMessage, System.Exception innerException, Microsoft.Identity.Client.UiRequiredExceptionClassification classification) : base(default(string), default(string)) => throw null;
+            }
+            public class MsalClientException : Microsoft.Identity.Client.MsalException
+            {
+                public MsalClientException(string errorCode) => throw null;
+                public MsalClientException(string errorCode, string errorMessage) => throw null;
+                public MsalClientException(string errorCode, string errorMessage, System.Exception innerException) => throw null;
+            }
+            public static class MsalError
+            {
+                public const string AccessDenied = default;
+                public const string AccessingWsMetadataExchangeFailed = default;
+                public const string AccessTokenTypeMissing = default;
+                public const string ActivityRequired = default;
+                public const string AdfsNotSupportedWithBroker = default;
+                public const string AndroidBrokerOperationFailed = default;
+                public const string AndroidBrokerSignatureVerificationFailed = default;
+                public const string AuthenticationCanceledError = default;
+                public const string AuthenticationFailed = default;
+                public const string AuthenticationUiFailed = default;
+                public const string AuthenticationUiFailedError = default;
+                public const string AuthorityHostMismatch = default;
+                public const string AuthorityTenantSpecifiedTwice = default;
+                public const string AuthorityTypeMismatch = default;
+                public const string AuthorityValidationFailed = default;
+                public const string B2CAuthorityHostMismatch = default;
+                public const string BrokerApplicationRequired = default;
+                public const string BrokerDoesNotSupportPop = default;
+                public const string BrokerNonceMismatch = default;
+                public const string BrokerRequiredForPop = default;
+                public const string BrokerResponseHashMismatch = default;
+                public const string BrokerResponseReturnedError = default;
+                public const string CannotAccessUserInformationOrUserNotDomainJoined = default;
+                public const string CannotInvokeBroker = default;
+                public const string CertificateNotRsa = default;
+                public const string CertWithoutPrivateKey = default;
+                public const string ClientCredentialAuthenticationTypeMustBeDefined = default;
+                public const string ClientCredentialAuthenticationTypesAreMutuallyExclusive = default;
+                public const string CodeExpired = default;
+                public const string CombinedUserAppCacheNotSupported = default;
+                public const string CryptographicError = default;
+                public const string CurrentBrokerAccount = default;
+                public const string CustomMetadataInstanceOrUri = default;
+                public const string CustomWebUiRedirectUriMismatch = default;
+                public const string CustomWebUiReturnedInvalidUri = default;
+                public const string DefaultRedirectUriIsInvalid = default;
+                public const string DeviceCertificateNotFound = default;
+                public const string DuplicateQueryParameterError = default;
+                public const string EncodedTokenTooLong = default;
+                public const string ExactlyOneScopeExpected = default;
+                public const string ExperimentalFeature = default;
+                public const string FailedToAcquireTokenSilentlyFromBroker = default;
+                public const string FailedToGetBrokerResponse = default;
+                public const string FailedToRefreshToken = default;
+                public const string FederatedServiceReturnedError = default;
+                public const string GetUserNameFailed = default;
+                public const string HttpListenerError = default;
+                public const string HttpStatusCodeNotOk = default;
+                public const string HttpStatusNotFound = default;
+                public const string InitializeProcessSecurityError = default;
+                public const string IntegratedWindowsAuthenticationFailed = default;
+                public const string IntegratedWindowsAuthNotSupportedForManagedUser = default;
+                public const string InteractionRequired = default;
+                public const string InternalError = default;
+                public const string InvalidAdalCacheMultipleRTs = default;
+                public const string InvalidAuthority = default;
+                public const string InvalidAuthorityType = default;
+                public const string InvalidAuthorizationUri = default;
+                public const string InvalidClient = default;
+                public const string InvalidGrantError = default;
+                public const string InvalidInstance = default;
+                public const string InvalidJsonClaimsFormat = default;
+                public const string InvalidJwtError = default;
+                public const string InvalidManagedIdentityEndpoint = default;
+                public const string InvalidManagedIdentityResponse = default;
+                public const string InvalidOwnerWindowType = default;
+                public const string InvalidRequest = default;
+                public const string InvalidTokenProviderResponseValue = default;
+                public const string InvalidUserInstanceMetadata = default;
+                public const string JsonParseError = default;
+                public const string LinuxXdgOpen = default;
+                public const string LoopbackRedirectUri = default;
+                public const string LoopbackResponseUriMismatch = default;
+                public const string ManagedIdentityRequestFailed = default;
+                public const string ManagedIdentityUnreachableNetwork = default;
+                public const string MissingFederationMetadataUrl = default;
+                public const string MissingPassiveAuthEndpoint = default;
+                public const string MultipleAccountsForLoginHint = default;
+                public const string MultipleTokensMatchedError = default;
+                public const string NetworkNotAvailableError = default;
+                public const string NoAccountForLoginHint = default;
+                public const string NoAndroidBrokerAccountFound = default;
+                public const string NoAndroidBrokerInstalledOnDevice = default;
+                public const string NoClientId = default;
+                public const string NonceRequiredForPopOnPCA = default;
+                public const string NonHttpsRedirectNotSupported = default;
+                public const string NonParsableOAuthError = default;
+                public const string NoPromptFailedError = default;
+                public const string NoRedirectUri = default;
+                public const string NoTokensFoundError = default;
+                public const string NoUsernameOrAccountIDProvidedForSilentAndroidBrokerAuthentication = default;
+                public const string NullIntentReturnedFromAndroidBroker = default;
+                public const string OboCacheKeyNotInCacheError = default;
+                public const string ParsingWsMetadataExchangeFailed = default;
+                public const string ParsingWsTrustResponseFailed = default;
+                public const string PasswordRequiredForManagedUserError = default;
+                public const string PlatformNotSupported = default;
+                public const string RedirectUriValidationFailed = default;
+                public const string RegionalAndAuthorityOverride = default;
+                public const string RegionalAuthorityValidation = default;
+                public const string RegionDiscoveryFailed = default;
+                public const string RegionDiscoveryNotEnabled = default;
+                public const string RegionDiscoveryWithCustomInstanceMetadata = default;
+                public const string RequestThrottled = default;
+                public const string RequestTimeout = default;
+                public const string RopcDoesNotSupportMsaAccounts = default;
+                public const string ScopesRequired = default;
+                public const string ServiceNotAvailable = default;
+                public const string SetCiamAuthorityAtRequestLevelNotSupported = default;
+                public const string SSHCertUsedAsHttpHeader = default;
+                public const string StateMismatchError = default;
+                public const string StaticCacheWithExternalSerialization = default;
+                public const string SystemWebviewOptionsNotApplicable = default;
+                public const string TelemetryConfigOrTelemetryCallback = default;
+                public const string TenantDiscoveryFailedError = default;
+                public const string TenantOverrideNonAad = default;
+                public const string TokenCacheNullError = default;
+                public const string TokenTypeMismatch = default;
+                public const string UapCannotFindDomainUser = default;
+                public const string UapCannotFindUpn = default;
+                public const string UnableToParseAuthenticationHeader = default;
+                public const string UnauthorizedClient = default;
+                public const string UnknownBrokerError = default;
+                public const string UnknownError = default;
+                public const string UnknownManagedIdentityError = default;
+                public const string UnknownUser = default;
+                public const string UnknownUserType = default;
+                public const string UpnRequired = default;
+                public const string UserAssertionNullError = default;
+                public const string UserAssignedManagedIdentityNotConfigurableAtRuntime = default;
+                public const string UserAssignedManagedIdentityNotSupported = default;
+                public const string UserMismatch = default;
+                public const string UserNullError = default;
+                public const string UserRealmDiscoveryFailed = default;
+                public const string ValidateAuthorityOrCustomMetadata = default;
+                public const string WABError = default;
+                public const string WamFailedToSignout = default;
+                public const string WamInteractiveError = default;
+                public const string WamNoB2C = default;
+                public const string WamPickerError = default;
+                public const string WamScopesRequired = default;
+                public const string WamUiThread = default;
+                public const string WebView2LoaderNotFound = default;
+                public const string WebView2NotInstalled = default;
+                public const string WebviewUnavailable = default;
+                public const string WsTrustEndpointNotFoundInMetadataDocument = default;
+            }
+            public class MsalException : System.Exception
+            {
+                public System.Collections.Generic.IReadOnlyDictionary<string, string> AdditionalExceptionData { get => throw null; set { } }
+                public const string BrokerErrorCode = default;
+                public const string BrokerErrorContext = default;
+                public const string BrokerErrorStatus = default;
+                public const string BrokerErrorTag = default;
+                public const string BrokerTelemetry = default;
+                public string CorrelationId { get => throw null; set { } }
+                public MsalException() => throw null;
+                public MsalException(string errorCode) => throw null;
+                public MsalException(string errorCode, string errorMessage) => throw null;
+                public MsalException(string errorCode, string errorMessage, System.Exception innerException) => throw null;
+                public string ErrorCode { get => throw null; }
+                public static Microsoft.Identity.Client.MsalException FromJsonString(string json) => throw null;
+                public bool IsRetryable { get => throw null; set { } }
+                public const string ManagedIdentitySource = default;
+                public string ToJsonString() => throw null;
+                public override string ToString() => throw null;
+            }
+            public class MsalManagedIdentityException : Microsoft.Identity.Client.MsalServiceException
+            {
+                public MsalManagedIdentityException(string errorCode, string errorMessage, Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource source) : base(default(string), default(string)) => throw null;
+                public MsalManagedIdentityException(string errorCode, string errorMessage, Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource source, int statusCode) : base(default(string), default(string)) => throw null;
+                public MsalManagedIdentityException(string errorCode, string errorMessage, System.Exception innerException, Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource source, int statusCode) : base(default(string), default(string)) => throw null;
+                public MsalManagedIdentityException(string errorCode, string errorMessage, System.Exception innerException, Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource source) : base(default(string), default(string)) => throw null;
+                public Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource ManagedIdentitySource { get => throw null; }
+                protected override void UpdateIsRetryable() => throw null;
+            }
+            public class MsalServiceException : Microsoft.Identity.Client.MsalException
+            {
+                public string Claims { get => throw null; }
+                public MsalServiceException(string errorCode, string errorMessage) => throw null;
+                public MsalServiceException(string errorCode, string errorMessage, int statusCode) => throw null;
+                public MsalServiceException(string errorCode, string errorMessage, System.Exception innerException) => throw null;
+                public MsalServiceException(string errorCode, string errorMessage, int statusCode, System.Exception innerException) => throw null;
+                public MsalServiceException(string errorCode, string errorMessage, int statusCode, string claims, System.Exception innerException) => throw null;
+                public System.Net.Http.Headers.HttpResponseHeaders Headers { get => throw null; set { } }
+                public string ResponseBody { get => throw null; set { } }
+                public int StatusCode { get => throw null; }
+                public override string ToString() => throw null;
+                protected virtual void UpdateIsRetryable() => throw null;
+            }
+            public class MsalThrottledServiceException : Microsoft.Identity.Client.MsalServiceException
+            {
+                public MsalThrottledServiceException(Microsoft.Identity.Client.MsalServiceException originalException) : base(default(string), default(string)) => throw null;
+                public Microsoft.Identity.Client.MsalServiceException OriginalServiceException { get => throw null; }
+            }
+            public class MsalThrottledUiRequiredException : Microsoft.Identity.Client.MsalUiRequiredException
+            {
+                public MsalThrottledUiRequiredException(Microsoft.Identity.Client.MsalUiRequiredException originalException) : base(default(string), default(string)) => throw null;
+                public Microsoft.Identity.Client.MsalUiRequiredException OriginalServiceException { get => throw null; }
+            }
+            public class MsalUiRequiredException : Microsoft.Identity.Client.MsalServiceException
+            {
+                public Microsoft.Identity.Client.UiRequiredExceptionClassification Classification { get => throw null; }
+                public MsalUiRequiredException(string errorCode, string errorMessage) : base(default(string), default(string)) => throw null;
+                public MsalUiRequiredException(string errorCode, string errorMessage, System.Exception innerException) : base(default(string), default(string)) => throw null;
+                public MsalUiRequiredException(string errorCode, string errorMessage, System.Exception innerException, Microsoft.Identity.Client.UiRequiredExceptionClassification classification) : base(default(string), default(string)) => throw null;
+            }
+            public static partial class OsCapabilitiesExtensions
+            {
+                public static System.Security.Cryptography.X509Certificates.X509Certificate2 GetCertificate(this Microsoft.Identity.Client.IConfidentialClientApplication confidentialClientApplication) => throw null;
+                public static bool IsEmbeddedWebViewAvailable(this Microsoft.Identity.Client.IPublicClientApplication publicClientApplication) => throw null;
+                public static bool IsSystemWebViewAvailable(this Microsoft.Identity.Client.IPublicClientApplication publicClientApplication) => throw null;
+                public static bool IsUserInteractive(this Microsoft.Identity.Client.IPublicClientApplication publicClientApplication) => throw null;
+            }
+            namespace Platforms
+            {
+                namespace Features
+                {
+                    namespace DesktopOs
+                    {
+                        namespace Kerberos
+                        {
+                            public abstract class Credential
+                            {
+                                protected Credential() => throw null;
+                                public static Microsoft.Identity.Client.Platforms.Features.DesktopOs.Kerberos.Credential Current() => throw null;
+                            }
+                        }
+                    }
+                }
+            }
+            public struct Prompt
+            {
+                public static readonly Microsoft.Identity.Client.Prompt Consent;
+                public static readonly Microsoft.Identity.Client.Prompt Create;
+                public override bool Equals(object obj) => throw null;
+                public static readonly Microsoft.Identity.Client.Prompt ForceLogin;
+                public override int GetHashCode() => throw null;
+                public static readonly Microsoft.Identity.Client.Prompt NoPrompt;
+                public static bool operator ==(Microsoft.Identity.Client.Prompt x, Microsoft.Identity.Client.Prompt y) => throw null;
+                public static bool operator !=(Microsoft.Identity.Client.Prompt x, Microsoft.Identity.Client.Prompt y) => throw null;
+                public static readonly Microsoft.Identity.Client.Prompt SelectAccount;
+            }
+            public sealed class PublicClientApplication : Microsoft.Identity.Client.ClientApplicationBase, Microsoft.Identity.Client.IApplicationBase, Microsoft.Identity.Client.IByRefreshToken, Microsoft.Identity.Client.IClientApplicationBase, Microsoft.Identity.Client.IPublicClientApplication
+            {
+                public System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenAsync(System.Collections.Generic.IEnumerable<string> scopes) => throw null;
+                public System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenAsync(System.Collections.Generic.IEnumerable<string> scopes, string loginHint) => throw null;
+                public System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenAsync(System.Collections.Generic.IEnumerable<string> scopes, Microsoft.Identity.Client.IAccount account) => throw null;
+                public System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenAsync(System.Collections.Generic.IEnumerable<string> scopes, string loginHint, Microsoft.Identity.Client.Prompt prompt, string extraQueryParameters) => throw null;
+                public System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenAsync(System.Collections.Generic.IEnumerable<string> scopes, Microsoft.Identity.Client.IAccount account, Microsoft.Identity.Client.Prompt prompt, string extraQueryParameters) => throw null;
+                public System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenAsync(System.Collections.Generic.IEnumerable<string> scopes, string loginHint, Microsoft.Identity.Client.Prompt prompt, string extraQueryParameters, System.Collections.Generic.IEnumerable<string> extraScopesToConsent, string authority) => throw null;
+                public System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenAsync(System.Collections.Generic.IEnumerable<string> scopes, Microsoft.Identity.Client.IAccount account, Microsoft.Identity.Client.Prompt prompt, string extraQueryParameters, System.Collections.Generic.IEnumerable<string> extraScopesToConsent, string authority) => throw null;
+                public System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenAsync(System.Collections.Generic.IEnumerable<string> scopes, Microsoft.Identity.Client.UIParent parent) => throw null;
+                public System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenAsync(System.Collections.Generic.IEnumerable<string> scopes, string loginHint, Microsoft.Identity.Client.UIParent parent) => throw null;
+                public System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenAsync(System.Collections.Generic.IEnumerable<string> scopes, Microsoft.Identity.Client.IAccount account, Microsoft.Identity.Client.UIParent parent) => throw null;
+                public System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenAsync(System.Collections.Generic.IEnumerable<string> scopes, string loginHint, Microsoft.Identity.Client.Prompt prompt, string extraQueryParameters, Microsoft.Identity.Client.UIParent parent) => throw null;
+                public System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenAsync(System.Collections.Generic.IEnumerable<string> scopes, Microsoft.Identity.Client.IAccount account, Microsoft.Identity.Client.Prompt prompt, string extraQueryParameters, Microsoft.Identity.Client.UIParent parent) => throw null;
+                public System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenAsync(System.Collections.Generic.IEnumerable<string> scopes, string loginHint, Microsoft.Identity.Client.Prompt prompt, string extraQueryParameters, System.Collections.Generic.IEnumerable<string> extraScopesToConsent, string authority, Microsoft.Identity.Client.UIParent parent) => throw null;
+                public System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenAsync(System.Collections.Generic.IEnumerable<string> scopes, Microsoft.Identity.Client.IAccount account, Microsoft.Identity.Client.Prompt prompt, string extraQueryParameters, System.Collections.Generic.IEnumerable<string> extraScopesToConsent, string authority, Microsoft.Identity.Client.UIParent parent) => throw null;
+                public Microsoft.Identity.Client.AcquireTokenByIntegratedWindowsAuthParameterBuilder AcquireTokenByIntegratedWindowsAuth(System.Collections.Generic.IEnumerable<string> scopes) => throw null;
+                public System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenByIntegratedWindowsAuthAsync(System.Collections.Generic.IEnumerable<string> scopes) => throw null;
+                public System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenByIntegratedWindowsAuthAsync(System.Collections.Generic.IEnumerable<string> scopes, string username) => throw null;
+                Microsoft.Identity.Client.AcquireTokenByRefreshTokenParameterBuilder Microsoft.Identity.Client.IByRefreshToken.AcquireTokenByRefreshToken(System.Collections.Generic.IEnumerable<string> scopes, string refreshToken) => throw null;
+                System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> Microsoft.Identity.Client.IByRefreshToken.AcquireTokenByRefreshTokenAsync(System.Collections.Generic.IEnumerable<string> scopes, string refreshToken) => throw null;
+                public Microsoft.Identity.Client.AcquireTokenByUsernamePasswordParameterBuilder AcquireTokenByUsernamePassword(System.Collections.Generic.IEnumerable<string> scopes, string username, System.Security.SecureString password) => throw null;
+                public Microsoft.Identity.Client.AcquireTokenByUsernamePasswordParameterBuilder AcquireTokenByUsernamePassword(System.Collections.Generic.IEnumerable<string> scopes, string username, string password) => throw null;
+                public System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenByUsernamePasswordAsync(System.Collections.Generic.IEnumerable<string> scopes, string username, System.Security.SecureString securePassword) => throw null;
+                public Microsoft.Identity.Client.AcquireTokenInteractiveParameterBuilder AcquireTokenInteractive(System.Collections.Generic.IEnumerable<string> scopes) => throw null;
+                public Microsoft.Identity.Client.AcquireTokenWithDeviceCodeParameterBuilder AcquireTokenWithDeviceCode(System.Collections.Generic.IEnumerable<string> scopes, System.Func<Microsoft.Identity.Client.DeviceCodeResult, System.Threading.Tasks.Task> deviceCodeResultCallback) => throw null;
+                public System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenWithDeviceCodeAsync(System.Collections.Generic.IEnumerable<string> scopes, System.Func<Microsoft.Identity.Client.DeviceCodeResult, System.Threading.Tasks.Task> deviceCodeResultCallback) => throw null;
+                public System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenWithDeviceCodeAsync(System.Collections.Generic.IEnumerable<string> scopes, string extraQueryParameters, System.Func<Microsoft.Identity.Client.DeviceCodeResult, System.Threading.Tasks.Task> deviceCodeResultCallback) => throw null;
+                public System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenWithDeviceCodeAsync(System.Collections.Generic.IEnumerable<string> scopes, System.Func<Microsoft.Identity.Client.DeviceCodeResult, System.Threading.Tasks.Task> deviceCodeResultCallback, System.Threading.CancellationToken cancellationToken) => throw null;
+                public System.Threading.Tasks.Task<Microsoft.Identity.Client.AuthenticationResult> AcquireTokenWithDeviceCodeAsync(System.Collections.Generic.IEnumerable<string> scopes, string extraQueryParameters, System.Func<Microsoft.Identity.Client.DeviceCodeResult, System.Threading.Tasks.Task> deviceCodeResultCallback, System.Threading.CancellationToken cancellationToken) => throw null;
+                public PublicClientApplication(string clientId) => throw null;
+                public PublicClientApplication(string clientId, string authority) => throw null;
+                public PublicClientApplication(string clientId, string authority, Microsoft.Identity.Client.TokenCache userTokenCache) => throw null;
+                public bool IsBrokerAvailable() => throw null;
+                public bool IsEmbeddedWebViewAvailable() => throw null;
+                public bool IsProofOfPossessionSupportedByClient() => throw null;
+                public bool IsSystemWebViewAvailable { get => throw null; }
+                public bool IsUserInteractive() => throw null;
+                public static Microsoft.Identity.Client.IAccount OperatingSystemAccount { get => throw null; }
+            }
+            public sealed class PublicClientApplicationBuilder : Microsoft.Identity.Client.AbstractApplicationBuilder<Microsoft.Identity.Client.PublicClientApplicationBuilder>
+            {
+                public Microsoft.Identity.Client.IPublicClientApplication Build() => throw null;
+                public static Microsoft.Identity.Client.PublicClientApplicationBuilder Create(string clientId) => throw null;
+                public static Microsoft.Identity.Client.PublicClientApplicationBuilder CreateWithApplicationOptions(Microsoft.Identity.Client.PublicClientApplicationOptions options) => throw null;
+                public bool IsBrokerAvailable() => throw null;
+                public Microsoft.Identity.Client.PublicClientApplicationBuilder WithBroker(bool enableBroker = default(bool)) => throw null;
+                public Microsoft.Identity.Client.PublicClientApplicationBuilder WithDefaultRedirectUri() => throw null;
+                public Microsoft.Identity.Client.PublicClientApplicationBuilder WithIosKeychainSecurityGroup(string keychainSecurityGroup) => throw null;
+                public Microsoft.Identity.Client.PublicClientApplicationBuilder WithKerberosTicketClaim(string servicePrincipalName, Microsoft.Identity.Client.Kerberos.KerberosTicketContainer ticketContainer) => throw null;
+                public Microsoft.Identity.Client.PublicClientApplicationBuilder WithMultiCloudSupport(bool enableMultiCloudSupport) => throw null;
+                public Microsoft.Identity.Client.PublicClientApplicationBuilder WithOidcAuthority(string authorityUri) => throw null;
+                public Microsoft.Identity.Client.PublicClientApplicationBuilder WithParentActivityOrWindow(System.Func<object> parentActivityOrWindowFunc) => throw null;
+                public Microsoft.Identity.Client.PublicClientApplicationBuilder WithParentActivityOrWindow(System.Func<nint> windowFunc) => throw null;
+                public Microsoft.Identity.Client.PublicClientApplicationBuilder WithWindowsBrokerOptions(Microsoft.Identity.Client.WindowsBrokerOptions options) => throw null;
+            }
+            public static partial class PublicClientApplicationExtensions
+            {
+                public static bool IsProofOfPossessionSupportedByClient(this Microsoft.Identity.Client.IPublicClientApplication app) => throw null;
+            }
+            public class PublicClientApplicationOptions : Microsoft.Identity.Client.ApplicationOptions
+            {
+                public PublicClientApplicationOptions() => throw null;
+            }
+            namespace Region
+            {
+                public enum RegionOutcome
+                {
+                    None = 0,
+                    UserProvidedValid = 1,
+                    UserProvidedAutodetectionFailed = 2,
+                    UserProvidedInvalid = 3,
+                    AutodetectSuccess = 4,
+                    FallbackToGlobal = 5,
+                }
+            }
+            public class RegionDetails
+            {
+                public string AutoDetectionError { get => throw null; }
+                public RegionDetails(Microsoft.Identity.Client.Region.RegionOutcome regionOutcome, string regionUsed, string autoDetectionError) => throw null;
+                public Microsoft.Identity.Client.Region.RegionOutcome RegionOutcome { get => throw null; }
+                public string RegionUsed { get => throw null; }
+            }
+            namespace SSHCertificates
+            {
+                public static partial class SSHExtensions
+                {
+                    public static Microsoft.Identity.Client.AcquireTokenInteractiveParameterBuilder WithSSHCertificateAuthenticationScheme(this Microsoft.Identity.Client.AcquireTokenInteractiveParameterBuilder builder, string publicKeyJwk, string keyId) => throw null;
+                    public static Microsoft.Identity.Client.AcquireTokenSilentParameterBuilder WithSSHCertificateAuthenticationScheme(this Microsoft.Identity.Client.AcquireTokenSilentParameterBuilder builder, string publicKeyJwk, string keyId) => throw null;
+                }
+            }
+            public class SystemWebViewOptions
+            {
+                public System.Uri BrowserRedirectError { get => throw null; set { } }
+                public System.Uri BrowserRedirectSuccess { get => throw null; set { } }
+                public SystemWebViewOptions() => throw null;
+                public string HtmlMessageError { get => throw null; set { } }
+                public string HtmlMessageSuccess { get => throw null; set { } }
+                public bool iOSHidePrivacyPrompt { get => throw null; set { } }
+                public System.Func<System.Uri, System.Threading.Tasks.Task> OpenBrowserAsync { get => throw null; set { } }
+                public static System.Threading.Tasks.Task OpenWithChromeEdgeBrowserAsync(System.Uri uri) => throw null;
+                public static System.Threading.Tasks.Task OpenWithEdgeBrowserAsync(System.Uri uri) => throw null;
+            }
+            public class Telemetry
+            {
+                public Telemetry() => throw null;
+                public static Microsoft.Identity.Client.Telemetry GetInstance() => throw null;
+                public bool HasRegisteredReceiver() => throw null;
+                public delegate void Receiver(System.Collections.Generic.List<System.Collections.Generic.Dictionary<string, string>> events);
+                public void RegisterReceiver(Microsoft.Identity.Client.Telemetry.Receiver r) => throw null;
+                public bool TelemetryOnFailureOnly { get => throw null; set { } }
+            }
+            public enum TelemetryAudienceType
+            {
+                PreProduction = 0,
+                Production = 1,
+            }
+            namespace TelemetryCore
+            {
+                namespace TelemetryClient
+                {
+                    public class TelemetryData
+                    {
+                        public Microsoft.Identity.Client.Cache.CacheLevel CacheLevel { get => throw null; set { } }
+                        public TelemetryData() => throw null;
+                    }
+                }
+            }
+            public class TenantProfile
+            {
+                public System.Security.Claims.ClaimsPrincipal ClaimsPrincipal { get => throw null; }
+                public bool IsHomeTenant { get => throw null; }
+                public string Oid { get => throw null; }
+                public string TenantId { get => throw null; }
+            }
+            public sealed class TokenCache : Microsoft.Identity.Client.ITokenCache, Microsoft.Identity.Client.ITokenCacheSerializer
+            {
+                public TokenCache() => throw null;
+                public void Deserialize(byte[] msalV2State) => throw null;
+                public void DeserializeAdalV3(byte[] adalV3State) => throw null;
+                void Microsoft.Identity.Client.ITokenCacheSerializer.DeserializeAdalV3(byte[] adalV3State) => throw null;
+                public void DeserializeMsalV2(byte[] msalV2State) => throw null;
+                void Microsoft.Identity.Client.ITokenCacheSerializer.DeserializeMsalV2(byte[] msalV2State) => throw null;
+                public void DeserializeMsalV3(byte[] msalV3State, bool shouldClearExistingCache) => throw null;
+                void Microsoft.Identity.Client.ITokenCacheSerializer.DeserializeMsalV3(byte[] msalV3State, bool shouldClearExistingCache) => throw null;
+                public void DeserializeUnifiedAndAdalCache(Microsoft.Identity.Client.Cache.CacheData cacheData) => throw null;
+                public bool HasStateChanged { get => throw null; set { } }
+                public byte[] Serialize() => throw null;
+                public byte[] SerializeAdalV3() => throw null;
+                byte[] Microsoft.Identity.Client.ITokenCacheSerializer.SerializeAdalV3() => throw null;
+                public byte[] SerializeMsalV2() => throw null;
+                byte[] Microsoft.Identity.Client.ITokenCacheSerializer.SerializeMsalV2() => throw null;
+                public byte[] SerializeMsalV3() => throw null;
+                byte[] Microsoft.Identity.Client.ITokenCacheSerializer.SerializeMsalV3() => throw null;
+                public Microsoft.Identity.Client.Cache.CacheData SerializeUnifiedAndAdalCache() => throw null;
+                public void SetAfterAccess(Microsoft.Identity.Client.TokenCacheCallback afterAccess) => throw null;
+                public void SetAfterAccessAsync(System.Func<Microsoft.Identity.Client.TokenCacheNotificationArgs, System.Threading.Tasks.Task> afterAccess) => throw null;
+                public void SetBeforeAccess(Microsoft.Identity.Client.TokenCacheCallback beforeAccess) => throw null;
+                public void SetBeforeAccessAsync(System.Func<Microsoft.Identity.Client.TokenCacheNotificationArgs, System.Threading.Tasks.Task> beforeAccess) => throw null;
+                public void SetBeforeWrite(Microsoft.Identity.Client.TokenCacheCallback beforeWrite) => throw null;
+                public void SetBeforeWriteAsync(System.Func<Microsoft.Identity.Client.TokenCacheNotificationArgs, System.Threading.Tasks.Task> beforeWrite) => throw null;
+                public void SetIosKeychainSecurityGroup(string securityGroup) => throw null;
+                public delegate void TokenCacheNotification(Microsoft.Identity.Client.TokenCacheNotificationArgs args);
+            }
+            public delegate void TokenCacheCallback(Microsoft.Identity.Client.TokenCacheNotificationArgs args);
+            public static partial class TokenCacheExtensions
+            {
+                public static void SetCacheOptions(this Microsoft.Identity.Client.ITokenCache tokenCache, Microsoft.Identity.Client.CacheOptions options) => throw null;
+            }
+            public sealed class TokenCacheNotificationArgs
+            {
+                public Microsoft.Identity.Client.IAccount Account { get => throw null; }
+                public System.Threading.CancellationToken CancellationToken { get => throw null; }
+                public string ClientId { get => throw null; }
+                public System.Guid CorrelationId { get => throw null; }
+                public TokenCacheNotificationArgs(Microsoft.Identity.Client.ITokenCacheSerializer tokenCache, string clientId, Microsoft.Identity.Client.IAccount account, bool hasStateChanged, bool isApplicationCache, string suggestedCacheKey, bool hasTokens, System.DateTimeOffset? suggestedCacheExpiry, System.Threading.CancellationToken cancellationToken) => throw null;
+                public TokenCacheNotificationArgs(Microsoft.Identity.Client.ITokenCacheSerializer tokenCache, string clientId, Microsoft.Identity.Client.IAccount account, bool hasStateChanged, bool isApplicationCache, string suggestedCacheKey, bool hasTokens, System.DateTimeOffset? suggestedCacheExpiry, System.Threading.CancellationToken cancellationToken, System.Guid correlationId) => throw null;
+                public TokenCacheNotificationArgs(Microsoft.Identity.Client.ITokenCacheSerializer tokenCache, string clientId, Microsoft.Identity.Client.IAccount account, bool hasStateChanged, bool isApplicationCache, string suggestedCacheKey, bool hasTokens, System.DateTimeOffset? suggestedCacheExpiry, System.Threading.CancellationToken cancellationToken, System.Guid correlationId, System.Collections.Generic.IEnumerable<string> requestScopes, string requestTenantId) => throw null;
+                public TokenCacheNotificationArgs(Microsoft.Identity.Client.ITokenCacheSerializer tokenCache, string clientId, Microsoft.Identity.Client.IAccount account, bool hasStateChanged, bool isApplicationCache, string suggestedCacheKey, bool hasTokens, System.DateTimeOffset? suggestedCacheExpiry, System.Threading.CancellationToken cancellationToken, System.Guid correlationId, System.Collections.Generic.IEnumerable<string> requestScopes, string requestTenantId, Microsoft.IdentityModel.Abstractions.IIdentityLogger identityLogger, bool piiLoggingEnabled, Microsoft.Identity.Client.TelemetryCore.TelemetryClient.TelemetryData telemetryData = default(Microsoft.Identity.Client.TelemetryCore.TelemetryClient.TelemetryData)) => throw null;
+                public bool HasStateChanged { get => throw null; }
+                public bool HasTokens { get => throw null; }
+                public Microsoft.IdentityModel.Abstractions.IIdentityLogger IdentityLogger { get => throw null; }
+                public bool IsApplicationCache { get => throw null; }
+                public bool PiiLoggingEnabled { get => throw null; }
+                public System.Collections.Generic.IEnumerable<string> RequestScopes { get => throw null; }
+                public string RequestTenantId { get => throw null; }
+                public System.DateTimeOffset? SuggestedCacheExpiry { get => throw null; }
+                public string SuggestedCacheKey { get => throw null; }
+                public Microsoft.Identity.Client.TelemetryCore.TelemetryClient.TelemetryData TelemetryData { get => throw null; }
+                public Microsoft.Identity.Client.ITokenCacheSerializer TokenCache { get => throw null; }
+                public Microsoft.Identity.Client.IUser User { get => throw null; }
+            }
+            public enum TokenSource
+            {
+                IdentityProvider = 0,
+                Cache = 1,
+                Broker = 2,
+            }
+            public class TraceTelemetryConfig : Microsoft.Identity.Client.ITelemetryConfig
+            {
+                public System.Collections.Generic.IEnumerable<string> AllowedScopes { get => throw null; }
+                public Microsoft.Identity.Client.TelemetryAudienceType AudienceType { get => throw null; }
+                public TraceTelemetryConfig() => throw null;
+                public System.Action<Microsoft.Identity.Client.ITelemetryEventPayload> DispatchAction { get => throw null; }
+                public string SessionId { get => throw null; }
+            }
+            public struct UIBehavior
+            {
+            }
+            public sealed class UIParent
+            {
+                public UIParent() => throw null;
+                public UIParent(object parent, bool useEmbeddedWebView) => throw null;
+                public static bool IsSystemWebviewAvailable() => throw null;
+            }
+            public enum UiRequiredExceptionClassification
+            {
+                None = 0,
+                MessageOnly = 1,
+                BasicAction = 2,
+                AdditionalAction = 3,
+                ConsentRequired = 4,
+                UserPasswordExpired = 5,
+                PromptNeverFailed = 6,
+                AcquireTokenSilentFailed = 7,
+            }
+            public sealed class UserAssertion
+            {
+                public string Assertion { get => throw null; }
+                public string AssertionType { get => throw null; }
+                public UserAssertion(string jwtBearerToken) => throw null;
+                public UserAssertion(string assertion, string assertionType) => throw null;
+            }
+            namespace Utils
+            {
+                namespace Windows
+                {
+                    public static class WindowsNativeUtils
+                    {
+                        public static void InitializeProcessSecurity() => throw null;
+                        public static bool IsElevatedUser() => throw null;
+                    }
+                }
+            }
+            public class WindowsBrokerOptions
+            {
+                public WindowsBrokerOptions() => throw null;
+                public string HeaderText { get => throw null; set { } }
+                public bool ListWindowsWorkAndSchoolAccounts { get => throw null; set { } }
+                public bool MsaPassthrough { get => throw null; set { } }
+            }
+            public class WwwAuthenticateParameters
+            {
+                public string AuthenticationScheme { get => throw null; }
+                public string Authority { get => throw null; set { } }
+                public string Claims { get => throw null; set { } }
+                public static Microsoft.Identity.Client.WwwAuthenticateParameters CreateFromAuthenticationHeaders(System.Net.Http.Headers.HttpResponseHeaders httpResponseHeaders, string scheme) => throw null;
+                public static System.Collections.Generic.IReadOnlyList<Microsoft.Identity.Client.WwwAuthenticateParameters> CreateFromAuthenticationHeaders(System.Net.Http.Headers.HttpResponseHeaders httpResponseHeaders) => throw null;
+                public static System.Threading.Tasks.Task<Microsoft.Identity.Client.WwwAuthenticateParameters> CreateFromAuthenticationResponseAsync(string resourceUri, string scheme, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+                public static System.Threading.Tasks.Task<Microsoft.Identity.Client.WwwAuthenticateParameters> CreateFromAuthenticationResponseAsync(string resourceUri, string scheme, System.Net.Http.HttpClient httpClient, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+                public static System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<Microsoft.Identity.Client.WwwAuthenticateParameters>> CreateFromAuthenticationResponseAsync(string resourceUri, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+                public static System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<Microsoft.Identity.Client.WwwAuthenticateParameters>> CreateFromAuthenticationResponseAsync(string resourceUri, System.Net.Http.HttpClient httpClient, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+                public static System.Threading.Tasks.Task<Microsoft.Identity.Client.WwwAuthenticateParameters> CreateFromResourceResponseAsync(string resourceUri) => throw null;
+                public static System.Threading.Tasks.Task<Microsoft.Identity.Client.WwwAuthenticateParameters> CreateFromResourceResponseAsync(string resourceUri, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+                public static System.Threading.Tasks.Task<Microsoft.Identity.Client.WwwAuthenticateParameters> CreateFromResourceResponseAsync(System.Net.Http.HttpClient httpClient, string resourceUri, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+                public static Microsoft.Identity.Client.WwwAuthenticateParameters CreateFromResponseHeaders(System.Net.Http.Headers.HttpResponseHeaders httpResponseHeaders, string scheme = default(string)) => throw null;
+                public static Microsoft.Identity.Client.WwwAuthenticateParameters CreateFromWwwAuthenticateHeaderValue(string wwwAuthenticateValue) => throw null;
+                public WwwAuthenticateParameters() => throw null;
+                public string Error { get => throw null; set { } }
+                public static string GetClaimChallengeFromResponseHeaders(System.Net.Http.Headers.HttpResponseHeaders httpResponseHeaders, string scheme = default(string)) => throw null;
+                public string GetTenantId() => throw null;
+                public string Nonce { get => throw null; }
+                public string Resource { get => throw null; set { } }
+                public System.Collections.Generic.IEnumerable<string> Scopes { get => throw null; set { } }
+                public string this[string key] { get => throw null; }
+            }
+        }
+    }
+}

--- a/csharp/ql/test/resources/stubs/Microsoft.Identity.Client/4.61.3/Microsoft.Identity.Client.csproj
+++ b/csharp/ql/test/resources/stubs/Microsoft.Identity.Client/4.61.3/Microsoft.Identity.Client.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputPath>bin\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../Microsoft.IdentityModel.Abstractions/7.5.0/Microsoft.IdentityModel.Abstractions.csproj" />
+    <ProjectReference Include="../../System.Diagnostics.DiagnosticSource/6.0.1/System.Diagnostics.DiagnosticSource.csproj" />
+    <ProjectReference Include="../../_frameworks/Microsoft.NETCore.App/Microsoft.NETCore.App.csproj" />
+  </ItemGroup>
+</Project>

--- a/csharp/ql/test/resources/stubs/Microsoft.IdentityModel.Abstractions/7.5.0/Microsoft.IdentityModel.Abstractions.cs
+++ b/csharp/ql/test/resources/stubs/Microsoft.IdentityModel.Abstractions/7.5.0/Microsoft.IdentityModel.Abstractions.cs
@@ -1,0 +1,77 @@
+// This file contains auto-generated code.
+// Generated from `Microsoft.IdentityModel.Abstractions, Version=7.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35`.
+namespace Microsoft
+{
+    namespace IdentityModel
+    {
+        namespace Abstractions
+        {
+            public enum EventLogLevel
+            {
+                LogAlways = 0,
+                Critical = 1,
+                Error = 2,
+                Warning = 3,
+                Informational = 4,
+                Verbose = 5,
+            }
+            public interface IIdentityLogger
+            {
+                bool IsEnabled(Microsoft.IdentityModel.Abstractions.EventLogLevel eventLogLevel);
+                void Log(Microsoft.IdentityModel.Abstractions.LogEntry entry);
+            }
+            public interface ITelemetryClient
+            {
+                string ClientId { get; set; }
+                void Initialize();
+                bool IsEnabled();
+                bool IsEnabled(string eventName);
+                void TrackEvent(Microsoft.IdentityModel.Abstractions.TelemetryEventDetails eventDetails);
+                void TrackEvent(string eventName, System.Collections.Generic.IDictionary<string, string> stringProperties = default(System.Collections.Generic.IDictionary<string, string>), System.Collections.Generic.IDictionary<string, long> longProperties = default(System.Collections.Generic.IDictionary<string, long>), System.Collections.Generic.IDictionary<string, bool> boolProperties = default(System.Collections.Generic.IDictionary<string, bool>), System.Collections.Generic.IDictionary<string, System.DateTime> dateTimeProperties = default(System.Collections.Generic.IDictionary<string, System.DateTime>), System.Collections.Generic.IDictionary<string, double> doubleProperties = default(System.Collections.Generic.IDictionary<string, double>), System.Collections.Generic.IDictionary<string, System.Guid> guidProperties = default(System.Collections.Generic.IDictionary<string, System.Guid>));
+            }
+            public class LogEntry
+            {
+                public string CorrelationId { get => throw null; set { } }
+                public LogEntry() => throw null;
+                public Microsoft.IdentityModel.Abstractions.EventLogLevel EventLogLevel { get => throw null; set { } }
+                public string Message { get => throw null; set { } }
+            }
+            public sealed class NullIdentityModelLogger : Microsoft.IdentityModel.Abstractions.IIdentityLogger
+            {
+                public static Microsoft.IdentityModel.Abstractions.NullIdentityModelLogger Instance { get => throw null; }
+                public bool IsEnabled(Microsoft.IdentityModel.Abstractions.EventLogLevel eventLogLevel) => throw null;
+                public void Log(Microsoft.IdentityModel.Abstractions.LogEntry entry) => throw null;
+            }
+            public class NullTelemetryClient : Microsoft.IdentityModel.Abstractions.ITelemetryClient
+            {
+                public string ClientId { get => throw null; set { } }
+                public void Initialize() => throw null;
+                public static Microsoft.IdentityModel.Abstractions.NullTelemetryClient Instance { get => throw null; }
+                public bool IsEnabled() => throw null;
+                public bool IsEnabled(string eventName) => throw null;
+                public void TrackEvent(Microsoft.IdentityModel.Abstractions.TelemetryEventDetails eventDetails) => throw null;
+                public void TrackEvent(string eventName, System.Collections.Generic.IDictionary<string, string> stringProperties = default(System.Collections.Generic.IDictionary<string, string>), System.Collections.Generic.IDictionary<string, long> longProperties = default(System.Collections.Generic.IDictionary<string, long>), System.Collections.Generic.IDictionary<string, bool> boolProperties = default(System.Collections.Generic.IDictionary<string, bool>), System.Collections.Generic.IDictionary<string, System.DateTime> dateTimeProperties = default(System.Collections.Generic.IDictionary<string, System.DateTime>), System.Collections.Generic.IDictionary<string, double> doubleProperties = default(System.Collections.Generic.IDictionary<string, double>), System.Collections.Generic.IDictionary<string, System.Guid> guidProperties = default(System.Collections.Generic.IDictionary<string, System.Guid>)) => throw null;
+            }
+            public static class ObservabilityConstants
+            {
+                public const string ActivityId = default;
+                public const string ClientId = default;
+                public const string Duration = default;
+                public const string Succeeded = default;
+            }
+            public abstract class TelemetryEventDetails
+            {
+                protected TelemetryEventDetails() => throw null;
+                public virtual string Name { get => throw null; set { } }
+                public virtual System.Collections.Generic.IReadOnlyDictionary<string, object> Properties { get => throw null; }
+                protected System.Collections.Generic.IDictionary<string, object> PropertyValues { get => throw null; }
+                public virtual void SetProperty(string key, string value) => throw null;
+                public virtual void SetProperty(string key, long value) => throw null;
+                public virtual void SetProperty(string key, bool value) => throw null;
+                public virtual void SetProperty(string key, System.DateTime value) => throw null;
+                public virtual void SetProperty(string key, double value) => throw null;
+                public virtual void SetProperty(string key, System.Guid value) => throw null;
+            }
+        }
+    }
+}

--- a/csharp/ql/test/resources/stubs/Microsoft.IdentityModel.Abstractions/7.5.0/Microsoft.IdentityModel.Abstractions.csproj
+++ b/csharp/ql/test/resources/stubs/Microsoft.IdentityModel.Abstractions/7.5.0/Microsoft.IdentityModel.Abstractions.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputPath>bin\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../_frameworks/Microsoft.NETCore.App/Microsoft.NETCore.App.csproj" />
+  </ItemGroup>
+</Project>

--- a/csharp/ql/test/resources/stubs/Microsoft.IdentityModel.JsonWebTokens/7.5.0/Microsoft.IdentityModel.JsonWebTokens.cs
+++ b/csharp/ql/test/resources/stubs/Microsoft.IdentityModel.JsonWebTokens/7.5.0/Microsoft.IdentityModel.JsonWebTokens.cs
@@ -1,0 +1,174 @@
+// This file contains auto-generated code.
+// Generated from `Microsoft.IdentityModel.JsonWebTokens, Version=7.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35`.
+namespace Microsoft
+{
+    namespace IdentityModel
+    {
+        namespace JsonWebTokens
+        {
+            public static class JsonClaimValueTypes
+            {
+                public const string Json = default;
+                public const string JsonArray = default;
+                public const string JsonNull = default;
+            }
+            public class JsonWebToken : Microsoft.IdentityModel.Tokens.SecurityToken
+            {
+                public string Actor { get => throw null; }
+                public string Alg { get => throw null; }
+                public System.Collections.Generic.IEnumerable<string> Audiences { get => throw null; }
+                public string AuthenticationTag { get => throw null; }
+                public string Azp { get => throw null; }
+                public string Ciphertext { get => throw null; }
+                public virtual System.Collections.Generic.IEnumerable<System.Security.Claims.Claim> Claims { get => throw null; }
+                public JsonWebToken(string jwtEncodedString) => throw null;
+                public JsonWebToken(System.ReadOnlyMemory<char> encodedTokenMemory) => throw null;
+                public JsonWebToken(string header, string payload) => throw null;
+                public string Cty { get => throw null; }
+                public string Enc { get => throw null; }
+                public string EncodedHeader { get => throw null; }
+                public string EncodedPayload { get => throw null; }
+                public string EncodedSignature { get => throw null; }
+                public string EncodedToken { get => throw null; }
+                public string EncryptedKey { get => throw null; }
+                public System.Security.Claims.Claim GetClaim(string key) => throw null;
+                public T GetHeaderValue<T>(string key) => throw null;
+                public T GetPayloadValue<T>(string key) => throw null;
+                public override string Id { get => throw null; }
+                public string InitializationVector { get => throw null; }
+                public Microsoft.IdentityModel.JsonWebTokens.JsonWebToken InnerToken { get => throw null; }
+                public bool IsEncrypted { get => throw null; }
+                public bool IsSigned { get => throw null; }
+                public System.DateTime IssuedAt { get => throw null; }
+                public override string Issuer { get => throw null; }
+                public string Kid { get => throw null; }
+                public override Microsoft.IdentityModel.Tokens.SecurityKey SecurityKey { get => throw null; }
+                public override Microsoft.IdentityModel.Tokens.SecurityKey SigningKey { get => throw null; set { } }
+                public string Subject { get => throw null; }
+                public override string ToString() => throw null;
+                public bool TryGetClaim(string key, out System.Security.Claims.Claim value) => throw null;
+                public bool TryGetHeaderValue<T>(string key, out T value) => throw null;
+                public bool TryGetPayloadValue<T>(string key, out T value) => throw null;
+                public bool TryGetValue<T>(string key, out T value) => throw null;
+                public string Typ { get => throw null; }
+                public override string UnsafeToString() => throw null;
+                public override System.DateTime ValidFrom { get => throw null; }
+                public override System.DateTime ValidTo { get => throw null; }
+                public string X5t { get => throw null; }
+                public string Zip { get => throw null; }
+            }
+            public class JsonWebTokenHandler : Microsoft.IdentityModel.Tokens.TokenHandler
+            {
+                public const string Base64UrlEncodedUnsignedJWSHeader = default;
+                public virtual bool CanReadToken(string token) => throw null;
+                public virtual bool CanValidateToken { get => throw null; }
+                protected virtual System.Security.Claims.ClaimsIdentity CreateClaimsIdentity(Microsoft.IdentityModel.JsonWebTokens.JsonWebToken jwtToken, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters) => throw null;
+                protected virtual System.Security.Claims.ClaimsIdentity CreateClaimsIdentity(Microsoft.IdentityModel.JsonWebTokens.JsonWebToken jwtToken, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters, string issuer) => throw null;
+                public virtual string CreateToken(string payload) => throw null;
+                public virtual string CreateToken(string payload, System.Collections.Generic.IDictionary<string, object> additionalHeaderClaims) => throw null;
+                public virtual string CreateToken(string payload, Microsoft.IdentityModel.Tokens.SigningCredentials signingCredentials) => throw null;
+                public virtual string CreateToken(string payload, Microsoft.IdentityModel.Tokens.SigningCredentials signingCredentials, System.Collections.Generic.IDictionary<string, object> additionalHeaderClaims) => throw null;
+                public virtual string CreateToken(Microsoft.IdentityModel.Tokens.SecurityTokenDescriptor tokenDescriptor) => throw null;
+                public virtual string CreateToken(string payload, Microsoft.IdentityModel.Tokens.EncryptingCredentials encryptingCredentials) => throw null;
+                public virtual string CreateToken(string payload, Microsoft.IdentityModel.Tokens.EncryptingCredentials encryptingCredentials, System.Collections.Generic.IDictionary<string, object> additionalHeaderClaims) => throw null;
+                public virtual string CreateToken(string payload, Microsoft.IdentityModel.Tokens.SigningCredentials signingCredentials, Microsoft.IdentityModel.Tokens.EncryptingCredentials encryptingCredentials) => throw null;
+                public virtual string CreateToken(string payload, Microsoft.IdentityModel.Tokens.SigningCredentials signingCredentials, Microsoft.IdentityModel.Tokens.EncryptingCredentials encryptingCredentials, System.Collections.Generic.IDictionary<string, object> additionalHeaderClaims) => throw null;
+                public virtual string CreateToken(string payload, Microsoft.IdentityModel.Tokens.EncryptingCredentials encryptingCredentials, string compressionAlgorithm) => throw null;
+                public virtual string CreateToken(string payload, Microsoft.IdentityModel.Tokens.SigningCredentials signingCredentials, Microsoft.IdentityModel.Tokens.EncryptingCredentials encryptingCredentials, string compressionAlgorithm) => throw null;
+                public virtual string CreateToken(string payload, Microsoft.IdentityModel.Tokens.SigningCredentials signingCredentials, Microsoft.IdentityModel.Tokens.EncryptingCredentials encryptingCredentials, string compressionAlgorithm, System.Collections.Generic.IDictionary<string, object> additionalHeaderClaims, System.Collections.Generic.IDictionary<string, object> additionalInnerHeaderClaims) => throw null;
+                public virtual string CreateToken(string payload, Microsoft.IdentityModel.Tokens.SigningCredentials signingCredentials, Microsoft.IdentityModel.Tokens.EncryptingCredentials encryptingCredentials, string compressionAlgorithm, System.Collections.Generic.IDictionary<string, object> additionalHeaderClaims) => throw null;
+                public JsonWebTokenHandler() => throw null;
+                public string DecryptToken(Microsoft.IdentityModel.JsonWebTokens.JsonWebToken jwtToken, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters) => throw null;
+                public static System.Collections.Generic.IDictionary<string, string> DefaultInboundClaimTypeMap;
+                public static bool DefaultMapInboundClaims;
+                public string EncryptToken(string innerJwt, Microsoft.IdentityModel.Tokens.EncryptingCredentials encryptingCredentials) => throw null;
+                public string EncryptToken(string innerJwt, Microsoft.IdentityModel.Tokens.EncryptingCredentials encryptingCredentials, System.Collections.Generic.IDictionary<string, object> additionalHeaderClaims) => throw null;
+                public string EncryptToken(string innerJwt, Microsoft.IdentityModel.Tokens.EncryptingCredentials encryptingCredentials, string algorithm) => throw null;
+                public string EncryptToken(string innerJwt, Microsoft.IdentityModel.Tokens.EncryptingCredentials encryptingCredentials, string algorithm, System.Collections.Generic.IDictionary<string, object> additionalHeaderClaims) => throw null;
+                public System.Collections.Generic.IDictionary<string, string> InboundClaimTypeMap { get => throw null; set { } }
+                public bool MapInboundClaims { get => throw null; set { } }
+                public virtual Microsoft.IdentityModel.JsonWebTokens.JsonWebToken ReadJsonWebToken(string token) => throw null;
+                public override Microsoft.IdentityModel.Tokens.SecurityToken ReadToken(string token) => throw null;
+                protected virtual Microsoft.IdentityModel.Tokens.SecurityKey ResolveTokenDecryptionKey(string token, Microsoft.IdentityModel.JsonWebTokens.JsonWebToken jwtToken, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters) => throw null;
+                public static string ShortClaimTypeProperty { get => throw null; set { } }
+                public System.Type TokenType { get => throw null; }
+                public virtual Microsoft.IdentityModel.Tokens.TokenValidationResult ValidateToken(string token, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters) => throw null;
+                public override System.Threading.Tasks.Task<Microsoft.IdentityModel.Tokens.TokenValidationResult> ValidateTokenAsync(string token, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters) => throw null;
+                public override System.Threading.Tasks.Task<Microsoft.IdentityModel.Tokens.TokenValidationResult> ValidateTokenAsync(Microsoft.IdentityModel.Tokens.SecurityToken token, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters) => throw null;
+            }
+            public static class JwtConstants
+            {
+                public const string DirectKeyUseAlg = default;
+                public const string HeaderType = default;
+                public const string HeaderTypeAlt = default;
+                public const string JsonCompactSerializationRegex = default;
+                public const string JweCompactSerializationRegex = default;
+                public const int JweSegmentCount = 5;
+                public const int JwsSegmentCount = 3;
+                public const int MaxJwtSegmentCount = 5;
+                public const string TokenType = default;
+                public const string TokenTypeAlt = default;
+            }
+            public struct JwtHeaderParameterNames
+            {
+                public const string Alg = default;
+                public const string Apu = default;
+                public const string Apv = default;
+                public const string Cty = default;
+                public const string Enc = default;
+                public const string Epk = default;
+                public const string IV = default;
+                public const string Jku = default;
+                public const string Jwk = default;
+                public const string Kid = default;
+                public const string Typ = default;
+                public const string X5c = default;
+                public const string X5t = default;
+                public const string X5u = default;
+                public const string Zip = default;
+            }
+            public struct JwtRegisteredClaimNames
+            {
+                public const string Acr = default;
+                public const string Actort = default;
+                public const string Amr = default;
+                public const string AtHash = default;
+                public const string Aud = default;
+                public const string AuthTime = default;
+                public const string Azp = default;
+                public const string Birthdate = default;
+                public const string CHash = default;
+                public const string Email = default;
+                public const string Exp = default;
+                public const string FamilyName = default;
+                public const string Gender = default;
+                public const string GivenName = default;
+                public const string Iat = default;
+                public const string Iss = default;
+                public const string Jti = default;
+                public const string Name = default;
+                public const string NameId = default;
+                public const string Nbf = default;
+                public const string Nonce = default;
+                public const string PhoneNumber = default;
+                public const string PhoneNumberVerified = default;
+                public const string Prn = default;
+                public const string Sid = default;
+                public const string Sub = default;
+                public const string Typ = default;
+                public const string UniqueName = default;
+                public const string Website = default;
+            }
+            public class JwtTokenUtilities
+            {
+                public static string CreateEncodedSignature(string input, Microsoft.IdentityModel.Tokens.SigningCredentials signingCredentials) => throw null;
+                public static string CreateEncodedSignature(string input, Microsoft.IdentityModel.Tokens.SigningCredentials signingCredentials, bool cacheProvider) => throw null;
+                public JwtTokenUtilities() => throw null;
+                public static byte[] GenerateKeyBytes(int sizeInBits) => throw null;
+                public static System.Collections.Generic.IEnumerable<Microsoft.IdentityModel.Tokens.SecurityKey> GetAllDecryptionKeys(Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters) => throw null;
+                public static System.Text.RegularExpressions.Regex RegexJwe;
+                public static System.Text.RegularExpressions.Regex RegexJws;
+            }
+        }
+    }
+}

--- a/csharp/ql/test/resources/stubs/Microsoft.IdentityModel.JsonWebTokens/7.5.0/Microsoft.IdentityModel.JsonWebTokens.csproj
+++ b/csharp/ql/test/resources/stubs/Microsoft.IdentityModel.JsonWebTokens/7.5.0/Microsoft.IdentityModel.JsonWebTokens.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputPath>bin\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../Microsoft.IdentityModel.Tokens/7.5.0/Microsoft.IdentityModel.Tokens.csproj" />
+    <ProjectReference Include="../../_frameworks/Microsoft.NETCore.App/Microsoft.NETCore.App.csproj" />
+  </ItemGroup>
+</Project>

--- a/csharp/ql/test/resources/stubs/Microsoft.IdentityModel.Logging/7.5.0/Microsoft.IdentityModel.Logging.cs
+++ b/csharp/ql/test/resources/stubs/Microsoft.IdentityModel.Logging/7.5.0/Microsoft.IdentityModel.Logging.cs
@@ -1,0 +1,98 @@
+// This file contains auto-generated code.
+// Generated from `Microsoft.IdentityModel.Logging, Version=7.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35`.
+namespace Microsoft
+{
+    namespace IdentityModel
+    {
+        namespace Logging
+        {
+            public class IdentityModelEventSource : System.Diagnostics.Tracing.EventSource
+            {
+                public static bool HeaderWritten { get => throw null; set { } }
+                public static string HiddenPIIString { get => throw null; }
+                public static string HiddenSecurityArtifactString { get => throw null; }
+                public static bool LogCompleteSecurityArtifact { get => throw null; set { } }
+                public static Microsoft.IdentityModel.Logging.IdentityModelEventSource Logger { get => throw null; }
+                public System.Diagnostics.Tracing.EventLevel LogLevel { get => throw null; set { } }
+                public static bool ShowPII { get => throw null; set { } }
+                public void Write(System.Diagnostics.Tracing.EventLevel level, System.Exception innerException, string message) => throw null;
+                public void Write(System.Diagnostics.Tracing.EventLevel level, System.Exception innerException, string message, params object[] args) => throw null;
+                public void WriteAlways(string message) => throw null;
+                public void WriteAlways(string message, params object[] args) => throw null;
+                public void WriteCritical(string message) => throw null;
+                public void WriteCritical(string message, params object[] args) => throw null;
+                public void WriteError(string message) => throw null;
+                public void WriteError(string message, params object[] args) => throw null;
+                public void WriteInformation(string message) => throw null;
+                public void WriteInformation(string message, params object[] args) => throw null;
+                public void WriteVerbose(string message) => throw null;
+                public void WriteVerbose(string message, params object[] args) => throw null;
+                public void WriteWarning(string message) => throw null;
+                public void WriteWarning(string message, params object[] args) => throw null;
+            }
+            public static class IdentityModelTelemetryUtil
+            {
+                public static bool AddTelemetryData(string key, string value) => throw null;
+                public static string ClientSku { get => throw null; }
+                public static string ClientVer { get => throw null; }
+                public static bool RemoveTelemetryData(string key) => throw null;
+            }
+            public interface ISafeLogSecurityArtifact
+            {
+                string UnsafeToString();
+            }
+            public class LoggerContext
+            {
+                public System.Guid ActivityId { get => throw null; set { } }
+                public bool CaptureLogs { get => throw null; set { } }
+                public LoggerContext() => throw null;
+                public LoggerContext(System.Guid activityId) => throw null;
+                public virtual string DebugId { get => throw null; set { } }
+                public System.Collections.Generic.ICollection<string> Logs { get => throw null; }
+                public System.Collections.Generic.IDictionary<string, object> PropertyBag { get => throw null; set { } }
+            }
+            public class LogHelper
+            {
+                public LogHelper() => throw null;
+                public static string FormatInvariant(string format, params object[] args) => throw null;
+                public static bool IsEnabled(Microsoft.IdentityModel.Abstractions.EventLogLevel level) => throw null;
+                public static T LogArgumentException<T>(string argumentName, string message) where T : System.ArgumentException => throw null;
+                public static T LogArgumentException<T>(string argumentName, string format, params object[] args) where T : System.ArgumentException => throw null;
+                public static T LogArgumentException<T>(string argumentName, System.Exception innerException, string message) where T : System.ArgumentException => throw null;
+                public static T LogArgumentException<T>(string argumentName, System.Exception innerException, string format, params object[] args) where T : System.ArgumentException => throw null;
+                public static T LogArgumentException<T>(System.Diagnostics.Tracing.EventLevel eventLevel, string argumentName, string message) where T : System.ArgumentException => throw null;
+                public static T LogArgumentException<T>(System.Diagnostics.Tracing.EventLevel eventLevel, string argumentName, string format, params object[] args) where T : System.ArgumentException => throw null;
+                public static T LogArgumentException<T>(System.Diagnostics.Tracing.EventLevel eventLevel, string argumentName, System.Exception innerException, string message) where T : System.ArgumentException => throw null;
+                public static T LogArgumentException<T>(System.Diagnostics.Tracing.EventLevel eventLevel, string argumentName, System.Exception innerException, string format, params object[] args) where T : System.ArgumentException => throw null;
+                public static System.ArgumentNullException LogArgumentNullException(string argument) => throw null;
+                public static T LogException<T>(string message) where T : System.Exception => throw null;
+                public static T LogException<T>(string format, params object[] args) where T : System.Exception => throw null;
+                public static T LogException<T>(System.Exception innerException, string message) where T : System.Exception => throw null;
+                public static T LogException<T>(System.Exception innerException, string format, params object[] args) where T : System.Exception => throw null;
+                public static T LogException<T>(System.Diagnostics.Tracing.EventLevel eventLevel, string message) where T : System.Exception => throw null;
+                public static T LogException<T>(System.Diagnostics.Tracing.EventLevel eventLevel, string format, params object[] args) where T : System.Exception => throw null;
+                public static T LogException<T>(System.Diagnostics.Tracing.EventLevel eventLevel, System.Exception innerException, string message) where T : System.Exception => throw null;
+                public static T LogException<T>(System.Diagnostics.Tracing.EventLevel eventLevel, System.Exception innerException, string format, params object[] args) where T : System.Exception => throw null;
+                public static System.Exception LogExceptionMessage(System.Exception exception) => throw null;
+                public static System.Exception LogExceptionMessage(System.Diagnostics.Tracing.EventLevel eventLevel, System.Exception exception) => throw null;
+                public static Microsoft.IdentityModel.Abstractions.IIdentityLogger Logger { get => throw null; set { } }
+                public static void LogInformation(string message, params object[] args) => throw null;
+                public static void LogVerbose(string message, params object[] args) => throw null;
+                public static void LogWarning(string message, params object[] args) => throw null;
+                public static object MarkAsNonPII(object arg) => throw null;
+                public static object MarkAsSecurityArtifact(object arg, System.Func<object, string> callback) => throw null;
+                public static object MarkAsSecurityArtifact(object arg, System.Func<object, string> callback, System.Func<object, string> callbackUnsafe) => throw null;
+                public static object MarkAsUnsafeSecurityArtifact(object arg, System.Func<object, string> callbackUnsafe) => throw null;
+            }
+            public class TextWriterEventListener : System.Diagnostics.Tracing.EventListener
+            {
+                public TextWriterEventListener() => throw null;
+                public TextWriterEventListener(string filePath) => throw null;
+                public TextWriterEventListener(System.IO.StreamWriter streamWriter) => throw null;
+                public static readonly string DefaultLogFileName;
+                public override void Dispose() => throw null;
+                protected override void OnEventWritten(System.Diagnostics.Tracing.EventWrittenEventArgs eventData) => throw null;
+            }
+        }
+    }
+}

--- a/csharp/ql/test/resources/stubs/Microsoft.IdentityModel.Logging/7.5.0/Microsoft.IdentityModel.Logging.csproj
+++ b/csharp/ql/test/resources/stubs/Microsoft.IdentityModel.Logging/7.5.0/Microsoft.IdentityModel.Logging.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputPath>bin\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../Microsoft.IdentityModel.Abstractions/7.5.0/Microsoft.IdentityModel.Abstractions.csproj" />
+    <ProjectReference Include="../../_frameworks/Microsoft.NETCore.App/Microsoft.NETCore.App.csproj" />
+  </ItemGroup>
+</Project>

--- a/csharp/ql/test/resources/stubs/Microsoft.IdentityModel.Protocols.OpenIdConnect/7.5.0/Microsoft.IdentityModel.Protocols.OpenIdConnect.cs
+++ b/csharp/ql/test/resources/stubs/Microsoft.IdentityModel.Protocols.OpenIdConnect/7.5.0/Microsoft.IdentityModel.Protocols.OpenIdConnect.cs
@@ -1,0 +1,396 @@
+// This file contains auto-generated code.
+// Generated from `Microsoft.IdentityModel.Protocols.OpenIdConnect, Version=7.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35`.
+namespace Microsoft
+{
+    namespace IdentityModel
+    {
+        namespace Protocols
+        {
+            namespace OpenIdConnect
+            {
+                public static class ActiveDirectoryOpenIdConnectEndpoints
+                {
+                    public const string Authorize = default;
+                    public const string Logout = default;
+                    public const string Token = default;
+                }
+                namespace Configuration
+                {
+                    public class OpenIdConnectConfigurationValidator : Microsoft.IdentityModel.Protocols.IConfigurationValidator<Microsoft.IdentityModel.Protocols.OpenIdConnect.OpenIdConnectConfiguration>
+                    {
+                        public OpenIdConnectConfigurationValidator() => throw null;
+                        public int MinimumNumberOfKeys { get => throw null; set { } }
+                        public Microsoft.IdentityModel.Protocols.ConfigurationValidationResult Validate(Microsoft.IdentityModel.Protocols.OpenIdConnect.OpenIdConnectConfiguration openIdConnectConfiguration) => throw null;
+                    }
+                }
+                public delegate void IdTokenValidator(System.IdentityModel.Tokens.Jwt.JwtSecurityToken idToken, Microsoft.IdentityModel.Protocols.OpenIdConnect.OpenIdConnectProtocolValidationContext context);
+                public class OpenIdConnectConfiguration : Microsoft.IdentityModel.Tokens.BaseConfiguration
+                {
+                    public System.Collections.Generic.ICollection<string> AcrValuesSupported { get => throw null; }
+                    public override string ActiveTokenEndpoint { get => throw null; set { } }
+                    public System.Collections.Generic.IDictionary<string, object> AdditionalData { get => throw null; }
+                    public string AuthorizationEndpoint { get => throw null; set { } }
+                    public string CheckSessionIframe { get => throw null; set { } }
+                    public System.Collections.Generic.ICollection<string> ClaimsLocalesSupported { get => throw null; }
+                    public bool ClaimsParameterSupported { get => throw null; set { } }
+                    public System.Collections.Generic.ICollection<string> ClaimsSupported { get => throw null; }
+                    public System.Collections.Generic.ICollection<string> ClaimTypesSupported { get => throw null; }
+                    public static Microsoft.IdentityModel.Protocols.OpenIdConnect.OpenIdConnectConfiguration Create(string json) => throw null;
+                    public OpenIdConnectConfiguration() => throw null;
+                    public OpenIdConnectConfiguration(string json) => throw null;
+                    public System.Collections.Generic.ICollection<string> DisplayValuesSupported { get => throw null; }
+                    public string EndSessionEndpoint { get => throw null; set { } }
+                    public string FrontchannelLogoutSessionSupported { get => throw null; set { } }
+                    public string FrontchannelLogoutSupported { get => throw null; set { } }
+                    public System.Collections.Generic.ICollection<string> GrantTypesSupported { get => throw null; }
+                    public bool HttpLogoutSupported { get => throw null; set { } }
+                    public System.Collections.Generic.ICollection<string> IdTokenEncryptionAlgValuesSupported { get => throw null; }
+                    public System.Collections.Generic.ICollection<string> IdTokenEncryptionEncValuesSupported { get => throw null; }
+                    public System.Collections.Generic.ICollection<string> IdTokenSigningAlgValuesSupported { get => throw null; }
+                    public string IntrospectionEndpoint { get => throw null; set { } }
+                    public System.Collections.Generic.ICollection<string> IntrospectionEndpointAuthMethodsSupported { get => throw null; }
+                    public System.Collections.Generic.ICollection<string> IntrospectionEndpointAuthSigningAlgValuesSupported { get => throw null; }
+                    public override string Issuer { get => throw null; set { } }
+                    public Microsoft.IdentityModel.Tokens.JsonWebKeySet JsonWebKeySet { get => throw null; set { } }
+                    public string JwksUri { get => throw null; set { } }
+                    public bool LogoutSessionSupported { get => throw null; set { } }
+                    public string OpPolicyUri { get => throw null; set { } }
+                    public string OpTosUri { get => throw null; set { } }
+                    public string RegistrationEndpoint { get => throw null; set { } }
+                    public System.Collections.Generic.ICollection<string> RequestObjectEncryptionAlgValuesSupported { get => throw null; }
+                    public System.Collections.Generic.ICollection<string> RequestObjectEncryptionEncValuesSupported { get => throw null; }
+                    public System.Collections.Generic.ICollection<string> RequestObjectSigningAlgValuesSupported { get => throw null; }
+                    public bool RequestParameterSupported { get => throw null; set { } }
+                    public bool RequestUriParameterSupported { get => throw null; set { } }
+                    public bool RequireRequestUriRegistration { get => throw null; set { } }
+                    public System.Collections.Generic.ICollection<string> ResponseModesSupported { get => throw null; }
+                    public System.Collections.Generic.ICollection<string> ResponseTypesSupported { get => throw null; }
+                    public System.Collections.Generic.ICollection<string> ScopesSupported { get => throw null; }
+                    public string ServiceDocumentation { get => throw null; set { } }
+                    public bool ShouldSerializeAcrValuesSupported() => throw null;
+                    public bool ShouldSerializeClaimsLocalesSupported() => throw null;
+                    public bool ShouldSerializeClaimsSupported() => throw null;
+                    public bool ShouldSerializeClaimTypesSupported() => throw null;
+                    public bool ShouldSerializeDisplayValuesSupported() => throw null;
+                    public bool ShouldSerializeGrantTypesSupported() => throw null;
+                    public bool ShouldSerializeIdTokenEncryptionAlgValuesSupported() => throw null;
+                    public bool ShouldSerializeIdTokenEncryptionEncValuesSupported() => throw null;
+                    public bool ShouldSerializeIdTokenSigningAlgValuesSupported() => throw null;
+                    public bool ShouldSerializeIntrospectionEndpointAuthMethodsSupported() => throw null;
+                    public bool ShouldSerializeIntrospectionEndpointAuthSigningAlgValuesSupported() => throw null;
+                    public bool ShouldSerializeRequestObjectEncryptionAlgValuesSupported() => throw null;
+                    public bool ShouldSerializeRequestObjectEncryptionEncValuesSupported() => throw null;
+                    public bool ShouldSerializeRequestObjectSigningAlgValuesSupported() => throw null;
+                    public bool ShouldSerializeResponseModesSupported() => throw null;
+                    public bool ShouldSerializeResponseTypesSupported() => throw null;
+                    public bool ShouldSerializeScopesSupported() => throw null;
+                    public bool ShouldSerializeSigningKeys() => throw null;
+                    public bool ShouldSerializeSubjectTypesSupported() => throw null;
+                    public bool ShouldSerializeTokenEndpointAuthMethodsSupported() => throw null;
+                    public bool ShouldSerializeTokenEndpointAuthSigningAlgValuesSupported() => throw null;
+                    public bool ShouldSerializeUILocalesSupported() => throw null;
+                    public bool ShouldSerializeUserInfoEndpointEncryptionAlgValuesSupported() => throw null;
+                    public bool ShouldSerializeUserInfoEndpointEncryptionEncValuesSupported() => throw null;
+                    public bool ShouldSerializeUserInfoEndpointSigningAlgValuesSupported() => throw null;
+                    public override System.Collections.Generic.ICollection<Microsoft.IdentityModel.Tokens.SecurityKey> SigningKeys { get => throw null; }
+                    public System.Collections.Generic.ICollection<string> SubjectTypesSupported { get => throw null; }
+                    public override string TokenEndpoint { get => throw null; set { } }
+                    public System.Collections.Generic.ICollection<string> TokenEndpointAuthMethodsSupported { get => throw null; }
+                    public System.Collections.Generic.ICollection<string> TokenEndpointAuthSigningAlgValuesSupported { get => throw null; }
+                    public System.Collections.Generic.ICollection<string> UILocalesSupported { get => throw null; }
+                    public string UserInfoEndpoint { get => throw null; set { } }
+                    public System.Collections.Generic.ICollection<string> UserInfoEndpointEncryptionAlgValuesSupported { get => throw null; }
+                    public System.Collections.Generic.ICollection<string> UserInfoEndpointEncryptionEncValuesSupported { get => throw null; }
+                    public System.Collections.Generic.ICollection<string> UserInfoEndpointSigningAlgValuesSupported { get => throw null; }
+                    public static string Write(Microsoft.IdentityModel.Protocols.OpenIdConnect.OpenIdConnectConfiguration configuration) => throw null;
+                }
+                public class OpenIdConnectConfigurationRetriever : Microsoft.IdentityModel.Protocols.IConfigurationRetriever<Microsoft.IdentityModel.Protocols.OpenIdConnect.OpenIdConnectConfiguration>
+                {
+                    public OpenIdConnectConfigurationRetriever() => throw null;
+                    public static System.Threading.Tasks.Task<Microsoft.IdentityModel.Protocols.OpenIdConnect.OpenIdConnectConfiguration> GetAsync(string address, System.Threading.CancellationToken cancel) => throw null;
+                    public static System.Threading.Tasks.Task<Microsoft.IdentityModel.Protocols.OpenIdConnect.OpenIdConnectConfiguration> GetAsync(string address, System.Net.Http.HttpClient httpClient, System.Threading.CancellationToken cancel) => throw null;
+                    public static System.Threading.Tasks.Task<Microsoft.IdentityModel.Protocols.OpenIdConnect.OpenIdConnectConfiguration> GetAsync(string address, Microsoft.IdentityModel.Protocols.IDocumentRetriever retriever, System.Threading.CancellationToken cancel) => throw null;
+                    System.Threading.Tasks.Task<Microsoft.IdentityModel.Protocols.OpenIdConnect.OpenIdConnectConfiguration> Microsoft.IdentityModel.Protocols.IConfigurationRetriever<Microsoft.IdentityModel.Protocols.OpenIdConnect.OpenIdConnectConfiguration>.GetConfigurationAsync(string address, Microsoft.IdentityModel.Protocols.IDocumentRetriever retriever, System.Threading.CancellationToken cancel) => throw null;
+                }
+                public static class OpenIdConnectGrantTypes
+                {
+                    public const string AuthorizationCode = default;
+                    public const string ClientCredentials = default;
+                    public const string Password = default;
+                    public const string RefreshToken = default;
+                }
+                public class OpenIdConnectMessage : Microsoft.IdentityModel.Protocols.AuthenticationProtocolMessage
+                {
+                    public string AccessToken { get => throw null; set { } }
+                    public string AcrValues { get => throw null; set { } }
+                    public string AuthorizationEndpoint { get => throw null; set { } }
+                    public string ClaimsLocales { get => throw null; set { } }
+                    public string ClientAssertion { get => throw null; set { } }
+                    public string ClientAssertionType { get => throw null; set { } }
+                    public string ClientId { get => throw null; set { } }
+                    public string ClientSecret { get => throw null; set { } }
+                    public virtual Microsoft.IdentityModel.Protocols.OpenIdConnect.OpenIdConnectMessage Clone() => throw null;
+                    public string Code { get => throw null; set { } }
+                    public virtual string CreateAuthenticationRequestUrl() => throw null;
+                    public virtual string CreateLogoutRequestUrl() => throw null;
+                    public OpenIdConnectMessage() => throw null;
+                    public OpenIdConnectMessage(string json) => throw null;
+                    protected OpenIdConnectMessage(Microsoft.IdentityModel.Protocols.OpenIdConnect.OpenIdConnectMessage other) => throw null;
+                    public OpenIdConnectMessage(System.Collections.Specialized.NameValueCollection nameValueCollection) => throw null;
+                    public OpenIdConnectMessage(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string[]>> parameters) => throw null;
+                    public string Display { get => throw null; set { } }
+                    public string DomainHint { get => throw null; set { } }
+                    public bool EnableTelemetryParameters { get => throw null; set { } }
+                    public static bool EnableTelemetryParametersByDefault { get => throw null; set { } }
+                    public string Error { get => throw null; set { } }
+                    public string ErrorDescription { get => throw null; set { } }
+                    public string ErrorUri { get => throw null; set { } }
+                    public string ExpiresIn { get => throw null; set { } }
+                    public string GrantType { get => throw null; set { } }
+                    public string IdentityProvider { get => throw null; set { } }
+                    public string IdToken { get => throw null; set { } }
+                    public string IdTokenHint { get => throw null; set { } }
+                    public string Iss { get => throw null; set { } }
+                    public string LoginHint { get => throw null; set { } }
+                    public string MaxAge { get => throw null; set { } }
+                    public string Nonce { get => throw null; set { } }
+                    public string Password { get => throw null; set { } }
+                    public string PostLogoutRedirectUri { get => throw null; set { } }
+                    public string Prompt { get => throw null; set { } }
+                    public string RedirectUri { get => throw null; set { } }
+                    public string RefreshToken { get => throw null; set { } }
+                    public Microsoft.IdentityModel.Protocols.OpenIdConnect.OpenIdConnectRequestType RequestType { get => throw null; set { } }
+                    public string RequestUri { get => throw null; set { } }
+                    public string Resource { get => throw null; set { } }
+                    public string ResponseMode { get => throw null; set { } }
+                    public string ResponseType { get => throw null; set { } }
+                    public string Scope { get => throw null; set { } }
+                    public string SessionState { get => throw null; set { } }
+                    public string Sid { get => throw null; set { } }
+                    public string SkuTelemetryValue { get => throw null; set { } }
+                    public string State { get => throw null; set { } }
+                    public string TargetLinkUri { get => throw null; set { } }
+                    public string TokenEndpoint { get => throw null; set { } }
+                    public string TokenType { get => throw null; set { } }
+                    public string UiLocales { get => throw null; set { } }
+                    public string UserId { get => throw null; set { } }
+                    public string Username { get => throw null; set { } }
+                }
+                public static class OpenIdConnectParameterNames
+                {
+                    public const string AccessToken = default;
+                    public const string AcrValues = default;
+                    public const string ClaimsLocales = default;
+                    public const string ClientAssertion = default;
+                    public const string ClientAssertionType = default;
+                    public const string ClientId = default;
+                    public const string ClientSecret = default;
+                    public const string Code = default;
+                    public const string Display = default;
+                    public const string DomainHint = default;
+                    public const string Error = default;
+                    public const string ErrorDescription = default;
+                    public const string ErrorUri = default;
+                    public const string ExpiresIn = default;
+                    public const string GrantType = default;
+                    public const string IdentityProvider = default;
+                    public const string IdToken = default;
+                    public const string IdTokenHint = default;
+                    public const string Iss = default;
+                    public const string LoginHint = default;
+                    public const string MaxAge = default;
+                    public const string Nonce = default;
+                    public const string Password = default;
+                    public const string PostLogoutRedirectUri = default;
+                    public const string Prompt = default;
+                    public const string RedirectUri = default;
+                    public const string RefreshToken = default;
+                    public const string RequestUri = default;
+                    public const string Resource = default;
+                    public const string ResponseMode = default;
+                    public const string ResponseType = default;
+                    public const string Scope = default;
+                    public const string SessionState = default;
+                    public const string Sid = default;
+                    public const string SkuTelemetry = default;
+                    public const string State = default;
+                    public const string TargetLinkUri = default;
+                    public const string TokenType = default;
+                    public const string UiLocales = default;
+                    public const string UserId = default;
+                    public const string Username = default;
+                    public const string VersionTelemetry = default;
+                }
+                public static class OpenIdConnectPrompt
+                {
+                    public const string Consent = default;
+                    public const string Login = default;
+                    public const string None = default;
+                    public const string SelectAccount = default;
+                }
+                public class OpenIdConnectProtocolException : System.Exception
+                {
+                    public OpenIdConnectProtocolException() => throw null;
+                    public OpenIdConnectProtocolException(string message) => throw null;
+                    public OpenIdConnectProtocolException(string message, System.Exception innerException) => throw null;
+                    protected OpenIdConnectProtocolException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) => throw null;
+                }
+                public class OpenIdConnectProtocolInvalidAtHashException : Microsoft.IdentityModel.Protocols.OpenIdConnect.OpenIdConnectProtocolException
+                {
+                    public OpenIdConnectProtocolInvalidAtHashException() => throw null;
+                    public OpenIdConnectProtocolInvalidAtHashException(string message) => throw null;
+                    public OpenIdConnectProtocolInvalidAtHashException(string message, System.Exception innerException) => throw null;
+                    protected OpenIdConnectProtocolInvalidAtHashException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) => throw null;
+                }
+                public class OpenIdConnectProtocolInvalidCHashException : Microsoft.IdentityModel.Protocols.OpenIdConnect.OpenIdConnectProtocolException
+                {
+                    public OpenIdConnectProtocolInvalidCHashException() => throw null;
+                    public OpenIdConnectProtocolInvalidCHashException(string message) => throw null;
+                    public OpenIdConnectProtocolInvalidCHashException(string message, System.Exception innerException) => throw null;
+                    protected OpenIdConnectProtocolInvalidCHashException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) => throw null;
+                }
+                public class OpenIdConnectProtocolInvalidNonceException : Microsoft.IdentityModel.Protocols.OpenIdConnect.OpenIdConnectProtocolException
+                {
+                    public OpenIdConnectProtocolInvalidNonceException() => throw null;
+                    public OpenIdConnectProtocolInvalidNonceException(string message) => throw null;
+                    public OpenIdConnectProtocolInvalidNonceException(string message, System.Exception innerException) => throw null;
+                    protected OpenIdConnectProtocolInvalidNonceException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) => throw null;
+                }
+                public class OpenIdConnectProtocolInvalidStateException : Microsoft.IdentityModel.Protocols.OpenIdConnect.OpenIdConnectProtocolException
+                {
+                    public OpenIdConnectProtocolInvalidStateException() => throw null;
+                    public OpenIdConnectProtocolInvalidStateException(string message) => throw null;
+                    public OpenIdConnectProtocolInvalidStateException(string message, System.Exception innerException) => throw null;
+                    protected OpenIdConnectProtocolInvalidStateException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) => throw null;
+                }
+                public class OpenIdConnectProtocolValidationContext
+                {
+                    public string ClientId { get => throw null; set { } }
+                    public OpenIdConnectProtocolValidationContext() => throw null;
+                    public string Nonce { get => throw null; set { } }
+                    public Microsoft.IdentityModel.Protocols.OpenIdConnect.OpenIdConnectMessage ProtocolMessage { get => throw null; set { } }
+                    public string State { get => throw null; set { } }
+                    public string UserInfoEndpointResponse { get => throw null; set { } }
+                    public System.IdentityModel.Tokens.Jwt.JwtSecurityToken ValidatedIdToken { get => throw null; set { } }
+                }
+                public class OpenIdConnectProtocolValidator
+                {
+                    public Microsoft.IdentityModel.Tokens.CryptoProviderFactory CryptoProviderFactory { get => throw null; set { } }
+                    public OpenIdConnectProtocolValidator() => throw null;
+                    public static readonly System.TimeSpan DefaultNonceLifetime;
+                    public virtual string GenerateNonce() => throw null;
+                    public virtual System.Security.Cryptography.HashAlgorithm GetHashAlgorithm(string algorithm) => throw null;
+                    public System.Collections.Generic.IDictionary<string, string> HashAlgorithmMap { get => throw null; }
+                    public Microsoft.IdentityModel.Protocols.OpenIdConnect.IdTokenValidator IdTokenValidator { get => throw null; set { } }
+                    public System.TimeSpan NonceLifetime { get => throw null; set { } }
+                    public bool RequireAcr { get => throw null; set { } }
+                    public bool RequireAmr { get => throw null; set { } }
+                    public bool RequireAuthTime { get => throw null; set { } }
+                    public bool RequireAzp { get => throw null; set { } }
+                    public bool RequireNonce { get => throw null; set { } }
+                    public bool RequireState { get => throw null; set { } }
+                    public bool RequireStateValidation { get => throw null; set { } }
+                    public bool RequireSub { get => throw null; set { } }
+                    public static bool RequireSubByDefault { get => throw null; set { } }
+                    public bool RequireTimeStampInNonce { get => throw null; set { } }
+                    protected virtual void ValidateAtHash(Microsoft.IdentityModel.Protocols.OpenIdConnect.OpenIdConnectProtocolValidationContext validationContext) => throw null;
+                    public virtual void ValidateAuthenticationResponse(Microsoft.IdentityModel.Protocols.OpenIdConnect.OpenIdConnectProtocolValidationContext validationContext) => throw null;
+                    protected virtual void ValidateCHash(Microsoft.IdentityModel.Protocols.OpenIdConnect.OpenIdConnectProtocolValidationContext validationContext) => throw null;
+                    protected virtual void ValidateIdToken(Microsoft.IdentityModel.Protocols.OpenIdConnect.OpenIdConnectProtocolValidationContext validationContext) => throw null;
+                    protected virtual void ValidateNonce(Microsoft.IdentityModel.Protocols.OpenIdConnect.OpenIdConnectProtocolValidationContext validationContext) => throw null;
+                    protected virtual void ValidateState(Microsoft.IdentityModel.Protocols.OpenIdConnect.OpenIdConnectProtocolValidationContext validationContext) => throw null;
+                    public virtual void ValidateTokenResponse(Microsoft.IdentityModel.Protocols.OpenIdConnect.OpenIdConnectProtocolValidationContext validationContext) => throw null;
+                    public virtual void ValidateUserInfoResponse(Microsoft.IdentityModel.Protocols.OpenIdConnect.OpenIdConnectProtocolValidationContext validationContext) => throw null;
+                }
+                public enum OpenIdConnectRequestType
+                {
+                    Authentication = 0,
+                    Logout = 1,
+                    Token = 2,
+                }
+                public static class OpenIdConnectResponseMode
+                {
+                    public const string FormPost = default;
+                    public const string Fragment = default;
+                    public const string Query = default;
+                }
+                public static class OpenIdConnectResponseType
+                {
+                    public const string Code = default;
+                    public const string CodeIdToken = default;
+                    public const string CodeIdTokenToken = default;
+                    public const string CodeToken = default;
+                    public const string IdToken = default;
+                    public const string IdTokenToken = default;
+                    public const string None = default;
+                    public const string Token = default;
+                }
+                public static class OpenIdConnectScope
+                {
+                    public const string Address = default;
+                    public const string Email = default;
+                    public const string OfflineAccess = default;
+                    public const string OpenId = default;
+                    public const string OpenIdProfile = default;
+                    public const string Phone = default;
+                    public const string UserImpersonation = default;
+                }
+                public static class OpenIdConnectSessionProperties
+                {
+                    public const string CheckSessionIFrame = default;
+                    public const string RedirectUri = default;
+                    public const string SessionState = default;
+                }
+                public static class OpenIdProviderMetadataNames
+                {
+                    public const string AcrValuesSupported = default;
+                    public const string AuthorizationEndpoint = default;
+                    public const string CheckSessionIframe = default;
+                    public const string ClaimsLocalesSupported = default;
+                    public const string ClaimsParameterSupported = default;
+                    public const string ClaimsSupported = default;
+                    public const string ClaimTypesSupported = default;
+                    public const string Discovery = default;
+                    public const string DisplayValuesSupported = default;
+                    public const string EndSessionEndpoint = default;
+                    public const string FrontchannelLogoutSessionSupported = default;
+                    public const string FrontchannelLogoutSupported = default;
+                    public const string GrantTypesSupported = default;
+                    public const string HttpLogoutSupported = default;
+                    public const string IdTokenEncryptionAlgValuesSupported = default;
+                    public const string IdTokenEncryptionEncValuesSupported = default;
+                    public const string IdTokenSigningAlgValuesSupported = default;
+                    public const string IntrospectionEndpoint = default;
+                    public const string IntrospectionEndpointAuthMethodsSupported = default;
+                    public const string IntrospectionEndpointAuthSigningAlgValuesSupported = default;
+                    public const string Issuer = default;
+                    public const string JwksUri = default;
+                    public const string LogoutSessionSupported = default;
+                    public const string MicrosoftMultiRefreshToken = default;
+                    public const string OpPolicyUri = default;
+                    public const string OpTosUri = default;
+                    public const string RegistrationEndpoint = default;
+                    public const string RequestObjectEncryptionAlgValuesSupported = default;
+                    public const string RequestObjectEncryptionEncValuesSupported = default;
+                    public const string RequestObjectSigningAlgValuesSupported = default;
+                    public const string RequestParameterSupported = default;
+                    public const string RequestUriParameterSupported = default;
+                    public const string RequireRequestUriRegistration = default;
+                    public const string ResponseModesSupported = default;
+                    public const string ResponseTypesSupported = default;
+                    public const string ScopesSupported = default;
+                    public const string ServiceDocumentation = default;
+                    public const string SubjectTypesSupported = default;
+                    public const string TokenEndpoint = default;
+                    public const string TokenEndpointAuthMethodsSupported = default;
+                    public const string TokenEndpointAuthSigningAlgValuesSupported = default;
+                    public const string UILocalesSupported = default;
+                    public const string UserInfoEncryptionAlgValuesSupported = default;
+                    public const string UserInfoEncryptionEncValuesSupported = default;
+                    public const string UserInfoEndpoint = default;
+                    public const string UserInfoSigningAlgValuesSupported = default;
+                }
+            }
+        }
+    }
+}

--- a/csharp/ql/test/resources/stubs/Microsoft.IdentityModel.Protocols.OpenIdConnect/7.5.0/Microsoft.IdentityModel.Protocols.OpenIdConnect.csproj
+++ b/csharp/ql/test/resources/stubs/Microsoft.IdentityModel.Protocols.OpenIdConnect/7.5.0/Microsoft.IdentityModel.Protocols.OpenIdConnect.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputPath>bin\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../Microsoft.IdentityModel.Protocols/7.5.0/Microsoft.IdentityModel.Protocols.csproj" />
+    <ProjectReference Include="../../System.IdentityModel.Tokens.Jwt/7.5.0/System.IdentityModel.Tokens.Jwt.csproj" />
+    <ProjectReference Include="../../_frameworks/Microsoft.NETCore.App/Microsoft.NETCore.App.csproj" />
+  </ItemGroup>
+</Project>

--- a/csharp/ql/test/resources/stubs/Microsoft.IdentityModel.Protocols/7.5.0/Microsoft.IdentityModel.Protocols.cs
+++ b/csharp/ql/test/resources/stubs/Microsoft.IdentityModel.Protocols/7.5.0/Microsoft.IdentityModel.Protocols.cs
@@ -1,0 +1,120 @@
+// This file contains auto-generated code.
+// Generated from `Microsoft.IdentityModel.Protocols, Version=7.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35`.
+namespace Microsoft
+{
+    namespace IdentityModel
+    {
+        namespace Protocols
+        {
+            public abstract class AuthenticationProtocolMessage
+            {
+                public virtual string BuildFormPost() => throw null;
+                public virtual string BuildRedirectUrl() => throw null;
+                protected AuthenticationProtocolMessage() => throw null;
+                public virtual string GetParameter(string parameter) => throw null;
+                public string IssuerAddress { get => throw null; set { } }
+                public System.Collections.Generic.IDictionary<string, string> Parameters { get => throw null; }
+                public string PostTitle { get => throw null; set { } }
+                public virtual void RemoveParameter(string parameter) => throw null;
+                public string Script { get => throw null; set { } }
+                public string ScriptButtonText { get => throw null; set { } }
+                public string ScriptDisabledText { get => throw null; set { } }
+                public void SetParameter(string parameter, string value) => throw null;
+                public virtual void SetParameters(System.Collections.Specialized.NameValueCollection nameValueCollection) => throw null;
+            }
+            namespace Configuration
+            {
+                public class InvalidConfigurationException : System.Exception
+                {
+                    public InvalidConfigurationException() => throw null;
+                    public InvalidConfigurationException(string message) => throw null;
+                    public InvalidConfigurationException(string message, System.Exception innerException) => throw null;
+                    protected InvalidConfigurationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) => throw null;
+                }
+                public class LastKnownGoodConfigurationCacheOptions : Microsoft.IdentityModel.Tokens.Configuration.LKGConfigurationCacheOptions
+                {
+                    public LastKnownGoodConfigurationCacheOptions() => throw null;
+                    public static readonly int DefaultLastKnownGoodConfigurationSizeLimit;
+                }
+            }
+            public class ConfigurationManager<T> : Microsoft.IdentityModel.Tokens.BaseConfigurationManager, Microsoft.IdentityModel.Protocols.IConfigurationManager<T> where T : class
+            {
+                public ConfigurationManager(string metadataAddress, Microsoft.IdentityModel.Protocols.IConfigurationRetriever<T> configRetriever) => throw null;
+                public ConfigurationManager(string metadataAddress, Microsoft.IdentityModel.Protocols.IConfigurationRetriever<T> configRetriever, System.Net.Http.HttpClient httpClient) => throw null;
+                public ConfigurationManager(string metadataAddress, Microsoft.IdentityModel.Protocols.IConfigurationRetriever<T> configRetriever, Microsoft.IdentityModel.Protocols.IDocumentRetriever docRetriever) => throw null;
+                public ConfigurationManager(string metadataAddress, Microsoft.IdentityModel.Protocols.IConfigurationRetriever<T> configRetriever, Microsoft.IdentityModel.Protocols.IDocumentRetriever docRetriever, Microsoft.IdentityModel.Protocols.Configuration.LastKnownGoodConfigurationCacheOptions lkgCacheOptions) => throw null;
+                public ConfigurationManager(string metadataAddress, Microsoft.IdentityModel.Protocols.IConfigurationRetriever<T> configRetriever, Microsoft.IdentityModel.Protocols.IDocumentRetriever docRetriever, Microsoft.IdentityModel.Protocols.IConfigurationValidator<T> configValidator) => throw null;
+                public ConfigurationManager(string metadataAddress, Microsoft.IdentityModel.Protocols.IConfigurationRetriever<T> configRetriever, Microsoft.IdentityModel.Protocols.IDocumentRetriever docRetriever, Microsoft.IdentityModel.Protocols.IConfigurationValidator<T> configValidator, Microsoft.IdentityModel.Protocols.Configuration.LastKnownGoodConfigurationCacheOptions lkgCacheOptions) => throw null;
+                public static readonly System.TimeSpan DefaultAutomaticRefreshInterval;
+                public static readonly System.TimeSpan DefaultRefreshInterval;
+                public override System.Threading.Tasks.Task<Microsoft.IdentityModel.Tokens.BaseConfiguration> GetBaseConfigurationAsync(System.Threading.CancellationToken cancel) => throw null;
+                public System.Threading.Tasks.Task<T> GetConfigurationAsync() => throw null;
+                public System.Threading.Tasks.Task<T> GetConfigurationAsync(System.Threading.CancellationToken cancel) => throw null;
+                public static readonly System.TimeSpan MinimumAutomaticRefreshInterval;
+                public static readonly System.TimeSpan MinimumRefreshInterval;
+                public override void RequestRefresh() => throw null;
+            }
+            public class ConfigurationValidationResult
+            {
+                public ConfigurationValidationResult() => throw null;
+                public string ErrorMessage { get => throw null; set { } }
+                public bool Succeeded { get => throw null; set { } }
+            }
+            public class FileDocumentRetriever : Microsoft.IdentityModel.Protocols.IDocumentRetriever
+            {
+                public FileDocumentRetriever() => throw null;
+                public System.Threading.Tasks.Task<string> GetDocumentAsync(string address, System.Threading.CancellationToken cancel) => throw null;
+            }
+            public class HttpDocumentRetriever : Microsoft.IdentityModel.Protocols.IDocumentRetriever
+            {
+                public HttpDocumentRetriever() => throw null;
+                public HttpDocumentRetriever(System.Net.Http.HttpClient httpClient) => throw null;
+                public static bool DefaultSendAdditionalHeaderData { get => throw null; set { } }
+                public System.Threading.Tasks.Task<string> GetDocumentAsync(string address, System.Threading.CancellationToken cancel) => throw null;
+                public bool RequireHttps { get => throw null; set { } }
+                public const string ResponseContent = default;
+                public bool SendAdditionalHeaderData { get => throw null; set { } }
+                public const string StatusCode = default;
+            }
+            public class HttpRequestData
+            {
+                public void AppendHeaders(System.Net.Http.Headers.HttpHeaders headers) => throw null;
+                public byte[] Body { get => throw null; set { } }
+                public System.Security.Cryptography.X509Certificates.X509Certificate2Collection ClientCertificates { get => throw null; }
+                public HttpRequestData() => throw null;
+                public System.Collections.Generic.IDictionary<string, System.Collections.Generic.IEnumerable<string>> Headers { get => throw null; set { } }
+                public string Method { get => throw null; set { } }
+                public System.Collections.Generic.IDictionary<string, object> PropertyBag { get => throw null; set { } }
+                public System.Uri Uri { get => throw null; set { } }
+            }
+            public interface IConfigurationManager<T> where T : class
+            {
+                System.Threading.Tasks.Task<T> GetConfigurationAsync(System.Threading.CancellationToken cancel);
+                void RequestRefresh();
+            }
+            public interface IConfigurationRetriever<T>
+            {
+                System.Threading.Tasks.Task<T> GetConfigurationAsync(string address, Microsoft.IdentityModel.Protocols.IDocumentRetriever retriever, System.Threading.CancellationToken cancel);
+            }
+            public interface IConfigurationValidator<T>
+            {
+                Microsoft.IdentityModel.Protocols.ConfigurationValidationResult Validate(T configuration);
+            }
+            public interface IDocumentRetriever
+            {
+                System.Threading.Tasks.Task<string> GetDocumentAsync(string address, System.Threading.CancellationToken cancel);
+            }
+            public class StaticConfigurationManager<T> : Microsoft.IdentityModel.Tokens.BaseConfigurationManager, Microsoft.IdentityModel.Protocols.IConfigurationManager<T> where T : class
+            {
+                public StaticConfigurationManager(T configuration) => throw null;
+                public override System.Threading.Tasks.Task<Microsoft.IdentityModel.Tokens.BaseConfiguration> GetBaseConfigurationAsync(System.Threading.CancellationToken cancel) => throw null;
+                public System.Threading.Tasks.Task<T> GetConfigurationAsync(System.Threading.CancellationToken cancel) => throw null;
+                public override void RequestRefresh() => throw null;
+            }
+            public class X509CertificateValidationMode
+            {
+                public X509CertificateValidationMode() => throw null;
+            }
+        }
+    }
+}

--- a/csharp/ql/test/resources/stubs/Microsoft.IdentityModel.Protocols/7.5.0/Microsoft.IdentityModel.Protocols.csproj
+++ b/csharp/ql/test/resources/stubs/Microsoft.IdentityModel.Protocols/7.5.0/Microsoft.IdentityModel.Protocols.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputPath>bin\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../Microsoft.IdentityModel.Tokens/7.5.0/Microsoft.IdentityModel.Tokens.csproj" />
+    <ProjectReference Include="../../_frameworks/Microsoft.NETCore.App/Microsoft.NETCore.App.csproj" />
+  </ItemGroup>
+</Project>

--- a/csharp/ql/test/resources/stubs/Microsoft.IdentityModel.Tokens/7.5.0/Microsoft.IdentityModel.Tokens.cs
+++ b/csharp/ql/test/resources/stubs/Microsoft.IdentityModel.Tokens/7.5.0/Microsoft.IdentityModel.Tokens.cs
@@ -1,0 +1,959 @@
+// This file contains auto-generated code.
+// Generated from `Microsoft.IdentityModel.Tokens, Version=7.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35`.
+namespace Microsoft
+{
+    namespace IdentityModel
+    {
+        namespace Tokens
+        {
+            public delegate bool AlgorithmValidator(string algorithm, Microsoft.IdentityModel.Tokens.SecurityKey securityKey, Microsoft.IdentityModel.Tokens.SecurityToken securityToken, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters);
+            public abstract class AsymmetricSecurityKey : Microsoft.IdentityModel.Tokens.SecurityKey
+            {
+                public AsymmetricSecurityKey() => throw null;
+                public abstract bool HasPrivateKey { get; }
+                public abstract Microsoft.IdentityModel.Tokens.PrivateKeyStatus PrivateKeyStatus { get; }
+            }
+            public class AsymmetricSignatureProvider : Microsoft.IdentityModel.Tokens.SignatureProvider
+            {
+                public AsymmetricSignatureProvider(Microsoft.IdentityModel.Tokens.SecurityKey key, string algorithm) : base(default(Microsoft.IdentityModel.Tokens.SecurityKey), default(string)) => throw null;
+                public AsymmetricSignatureProvider(Microsoft.IdentityModel.Tokens.SecurityKey key, string algorithm, bool willCreateSignatures) : base(default(Microsoft.IdentityModel.Tokens.SecurityKey), default(string)) => throw null;
+                public static readonly System.Collections.Generic.Dictionary<string, int> DefaultMinimumAsymmetricKeySizeInBitsForSigningMap;
+                public static readonly System.Collections.Generic.Dictionary<string, int> DefaultMinimumAsymmetricKeySizeInBitsForVerifyingMap;
+                protected override void Dispose(bool disposing) => throw null;
+                protected virtual System.Security.Cryptography.HashAlgorithmName GetHashAlgorithmName(string algorithm) => throw null;
+                public System.Collections.Generic.IReadOnlyDictionary<string, int> MinimumAsymmetricKeySizeInBitsForSigningMap { get => throw null; }
+                public System.Collections.Generic.IReadOnlyDictionary<string, int> MinimumAsymmetricKeySizeInBitsForVerifyingMap { get => throw null; }
+                public override bool Sign(System.ReadOnlySpan<byte> input, System.Span<byte> signature, out int bytesWritten) => throw null;
+                public override byte[] Sign(byte[] input) => throw null;
+                public override byte[] Sign(byte[] input, int offset, int count) => throw null;
+                public virtual void ValidateAsymmetricSecurityKeySize(Microsoft.IdentityModel.Tokens.SecurityKey key, string algorithm, bool willCreateSignatures) => throw null;
+                public override bool Verify(byte[] input, byte[] signature) => throw null;
+                public override bool Verify(byte[] input, int inputOffset, int inputLength, byte[] signature, int signatureOffset, int signatureLength) => throw null;
+            }
+            public delegate bool AudienceValidator(System.Collections.Generic.IEnumerable<string> audiences, Microsoft.IdentityModel.Tokens.SecurityToken securityToken, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters);
+            public class AuthenticatedEncryptionProvider : System.IDisposable
+            {
+                public string Algorithm { get => throw null; }
+                public string Context { get => throw null; set { } }
+                public AuthenticatedEncryptionProvider(Microsoft.IdentityModel.Tokens.SecurityKey key, string algorithm) => throw null;
+                public virtual byte[] Decrypt(byte[] ciphertext, byte[] authenticatedData, byte[] iv, byte[] authenticationTag) => throw null;
+                public void Dispose() => throw null;
+                protected virtual void Dispose(bool disposing) => throw null;
+                public virtual Microsoft.IdentityModel.Tokens.AuthenticatedEncryptionResult Encrypt(byte[] plaintext, byte[] authenticatedData) => throw null;
+                public virtual Microsoft.IdentityModel.Tokens.AuthenticatedEncryptionResult Encrypt(byte[] plaintext, byte[] authenticatedData, byte[] iv) => throw null;
+                protected virtual byte[] GetKeyBytes(Microsoft.IdentityModel.Tokens.SecurityKey key) => throw null;
+                protected virtual bool IsSupportedAlgorithm(Microsoft.IdentityModel.Tokens.SecurityKey key, string algorithm) => throw null;
+                public Microsoft.IdentityModel.Tokens.SecurityKey Key { get => throw null; }
+                protected virtual void ValidateKeySize(Microsoft.IdentityModel.Tokens.SecurityKey key, string algorithm) => throw null;
+            }
+            public class AuthenticatedEncryptionResult
+            {
+                public byte[] AuthenticationTag { get => throw null; }
+                public byte[] Ciphertext { get => throw null; }
+                public AuthenticatedEncryptionResult(Microsoft.IdentityModel.Tokens.SecurityKey key, byte[] ciphertext, byte[] iv, byte[] authenticationTag) => throw null;
+                public byte[] IV { get => throw null; }
+                public Microsoft.IdentityModel.Tokens.SecurityKey Key { get => throw null; }
+            }
+            public static class Base64UrlEncoder
+            {
+                public static string Decode(string arg) => throw null;
+                public static byte[] DecodeBytes(string str) => throw null;
+                public static string Encode(string arg) => throw null;
+                public static string Encode(byte[] inArray) => throw null;
+                public static string Encode(byte[] inArray, int offset, int length) => throw null;
+                public static int Encode(System.ReadOnlySpan<byte> inArray, System.Span<char> output) => throw null;
+            }
+            public abstract class BaseConfiguration
+            {
+                public virtual string ActiveTokenEndpoint { get => throw null; set { } }
+                protected BaseConfiguration() => throw null;
+                public virtual string Issuer { get => throw null; set { } }
+                public virtual System.Collections.Generic.ICollection<Microsoft.IdentityModel.Tokens.SecurityKey> SigningKeys { get => throw null; }
+                public virtual System.Collections.Generic.ICollection<Microsoft.IdentityModel.Tokens.SecurityKey> TokenDecryptionKeys { get => throw null; }
+                public virtual string TokenEndpoint { get => throw null; set { } }
+            }
+            public abstract class BaseConfigurationManager
+            {
+                public System.TimeSpan AutomaticRefreshInterval { get => throw null; set { } }
+                public BaseConfigurationManager() => throw null;
+                public BaseConfigurationManager(Microsoft.IdentityModel.Tokens.Configuration.LKGConfigurationCacheOptions options) => throw null;
+                public static readonly System.TimeSpan DefaultAutomaticRefreshInterval;
+                public static readonly System.TimeSpan DefaultLastKnownGoodConfigurationLifetime;
+                public static readonly System.TimeSpan DefaultRefreshInterval;
+                public virtual System.Threading.Tasks.Task<Microsoft.IdentityModel.Tokens.BaseConfiguration> GetBaseConfigurationAsync(System.Threading.CancellationToken cancel) => throw null;
+                public bool IsLastKnownGoodValid { get => throw null; }
+                public Microsoft.IdentityModel.Tokens.BaseConfiguration LastKnownGoodConfiguration { get => throw null; set { } }
+                public System.TimeSpan LastKnownGoodLifetime { get => throw null; set { } }
+                public string MetadataAddress { get => throw null; set { } }
+                public static readonly System.TimeSpan MinimumAutomaticRefreshInterval;
+                public static readonly System.TimeSpan MinimumRefreshInterval;
+                public System.TimeSpan RefreshInterval { get => throw null; set { } }
+                public abstract void RequestRefresh();
+                public bool UseLastKnownGoodConfiguration { get => throw null; set { } }
+            }
+            public class CallContext : Microsoft.IdentityModel.Logging.LoggerContext
+            {
+                public CallContext() => throw null;
+                public CallContext(System.Guid activityId) => throw null;
+            }
+            public static class CollectionUtilities
+            {
+                public static bool IsNullOrEmpty<T>(this System.Collections.Generic.IEnumerable<T> enumerable) => throw null;
+            }
+            public class CompressionAlgorithms
+            {
+                public CompressionAlgorithms() => throw null;
+                public const string Deflate = default;
+            }
+            public class CompressionProviderFactory
+            {
+                public Microsoft.IdentityModel.Tokens.ICompressionProvider CreateCompressionProvider(string algorithm) => throw null;
+                public Microsoft.IdentityModel.Tokens.ICompressionProvider CreateCompressionProvider(string algorithm, int maximumDeflateSize) => throw null;
+                public CompressionProviderFactory() => throw null;
+                public CompressionProviderFactory(Microsoft.IdentityModel.Tokens.CompressionProviderFactory other) => throw null;
+                public Microsoft.IdentityModel.Tokens.ICompressionProvider CustomCompressionProvider { get => throw null; set { } }
+                public static Microsoft.IdentityModel.Tokens.CompressionProviderFactory Default { get => throw null; set { } }
+                public virtual bool IsSupportedAlgorithm(string algorithm) => throw null;
+            }
+            namespace Configuration
+            {
+                public class LKGConfigurationCacheOptions
+                {
+                    public System.Collections.Generic.IEqualityComparer<Microsoft.IdentityModel.Tokens.BaseConfiguration> BaseConfigurationComparer { get => throw null; set { } }
+                    public LKGConfigurationCacheOptions() => throw null;
+                    public static readonly int DefaultLKGConfigurationSizeLimit;
+                    public int LastKnownGoodConfigurationSizeLimit { get => throw null; set { } }
+                    public bool RemoveExpiredValues { get => throw null; set { } }
+                    public System.Threading.Tasks.TaskCreationOptions TaskCreationOptions { get => throw null; set { } }
+                }
+            }
+            public abstract class CryptoProviderCache
+            {
+                protected CryptoProviderCache() => throw null;
+                protected abstract string GetCacheKey(Microsoft.IdentityModel.Tokens.SignatureProvider signatureProvider);
+                protected abstract string GetCacheKey(Microsoft.IdentityModel.Tokens.SecurityKey securityKey, string algorithm, string typeofProvider);
+                public abstract bool TryAdd(Microsoft.IdentityModel.Tokens.SignatureProvider signatureProvider);
+                public abstract bool TryGetSignatureProvider(Microsoft.IdentityModel.Tokens.SecurityKey securityKey, string algorithm, string typeofProvider, bool willCreateSignatures, out Microsoft.IdentityModel.Tokens.SignatureProvider signatureProvider);
+                public abstract bool TryRemove(Microsoft.IdentityModel.Tokens.SignatureProvider signatureProvider);
+            }
+            public class CryptoProviderCacheOptions
+            {
+                public CryptoProviderCacheOptions() => throw null;
+                public static readonly int DefaultSizeLimit;
+                public int SizeLimit { get => throw null; set { } }
+            }
+            public class CryptoProviderFactory
+            {
+                public bool CacheSignatureProviders { get => throw null; set { } }
+                public virtual Microsoft.IdentityModel.Tokens.AuthenticatedEncryptionProvider CreateAuthenticatedEncryptionProvider(Microsoft.IdentityModel.Tokens.SecurityKey key, string algorithm) => throw null;
+                public virtual Microsoft.IdentityModel.Tokens.SignatureProvider CreateForSigning(Microsoft.IdentityModel.Tokens.SecurityKey key, string algorithm) => throw null;
+                public virtual Microsoft.IdentityModel.Tokens.SignatureProvider CreateForSigning(Microsoft.IdentityModel.Tokens.SecurityKey key, string algorithm, bool cacheProvider) => throw null;
+                public virtual Microsoft.IdentityModel.Tokens.SignatureProvider CreateForVerifying(Microsoft.IdentityModel.Tokens.SecurityKey key, string algorithm) => throw null;
+                public virtual Microsoft.IdentityModel.Tokens.SignatureProvider CreateForVerifying(Microsoft.IdentityModel.Tokens.SecurityKey key, string algorithm, bool cacheProvider) => throw null;
+                public virtual System.Security.Cryptography.HashAlgorithm CreateHashAlgorithm(System.Security.Cryptography.HashAlgorithmName algorithm) => throw null;
+                public virtual System.Security.Cryptography.HashAlgorithm CreateHashAlgorithm(string algorithm) => throw null;
+                public virtual System.Security.Cryptography.KeyedHashAlgorithm CreateKeyedHashAlgorithm(byte[] keyBytes, string algorithm) => throw null;
+                public virtual Microsoft.IdentityModel.Tokens.KeyWrapProvider CreateKeyWrapProvider(Microsoft.IdentityModel.Tokens.SecurityKey key, string algorithm) => throw null;
+                public virtual Microsoft.IdentityModel.Tokens.KeyWrapProvider CreateKeyWrapProviderForUnwrap(Microsoft.IdentityModel.Tokens.SecurityKey key, string algorithm) => throw null;
+                public Microsoft.IdentityModel.Tokens.CryptoProviderCache CryptoProviderCache { get => throw null; }
+                public CryptoProviderFactory() => throw null;
+                public CryptoProviderFactory(Microsoft.IdentityModel.Tokens.CryptoProviderCache cache) => throw null;
+                public CryptoProviderFactory(Microsoft.IdentityModel.Tokens.CryptoProviderFactory other) => throw null;
+                public Microsoft.IdentityModel.Tokens.ICryptoProvider CustomCryptoProvider { get => throw null; set { } }
+                public static Microsoft.IdentityModel.Tokens.CryptoProviderFactory Default { get => throw null; set { } }
+                public static bool DefaultCacheSignatureProviders { get => throw null; set { } }
+                public static int DefaultSignatureProviderObjectPoolCacheSize { get => throw null; set { } }
+                public virtual bool IsSupportedAlgorithm(string algorithm) => throw null;
+                public virtual bool IsSupportedAlgorithm(string algorithm, Microsoft.IdentityModel.Tokens.SecurityKey key) => throw null;
+                public virtual void ReleaseHashAlgorithm(System.Security.Cryptography.HashAlgorithm hashAlgorithm) => throw null;
+                public virtual void ReleaseKeyWrapProvider(Microsoft.IdentityModel.Tokens.KeyWrapProvider provider) => throw null;
+                public virtual void ReleaseRsaKeyWrapProvider(Microsoft.IdentityModel.Tokens.RsaKeyWrapProvider provider) => throw null;
+                public virtual void ReleaseSignatureProvider(Microsoft.IdentityModel.Tokens.SignatureProvider signatureProvider) => throw null;
+                public int SignatureProviderObjectPoolCacheSize { get => throw null; set { } }
+            }
+            public static class DateTimeUtil
+            {
+                public static System.DateTime Add(System.DateTime time, System.TimeSpan timespan) => throw null;
+                public static System.DateTime GetMaxValue(System.DateTimeKind kind) => throw null;
+                public static System.DateTime GetMinValue(System.DateTimeKind kind) => throw null;
+                public static System.DateTime? ToUniversalTime(System.DateTime? value) => throw null;
+                public static System.DateTime ToUniversalTime(System.DateTime value) => throw null;
+            }
+            public class DeflateCompressionProvider : Microsoft.IdentityModel.Tokens.ICompressionProvider
+            {
+                public string Algorithm { get => throw null; }
+                public byte[] Compress(byte[] value) => throw null;
+                public System.IO.Compression.CompressionLevel CompressionLevel { get => throw null; }
+                public DeflateCompressionProvider() => throw null;
+                public DeflateCompressionProvider(System.IO.Compression.CompressionLevel compressionLevel) => throw null;
+                public byte[] Decompress(byte[] value) => throw null;
+                public bool IsSupportedAlgorithm(string algorithm) => throw null;
+                public int MaximumDeflateSize { get => throw null; set { } }
+            }
+            public class EcdhKeyExchangeProvider
+            {
+                public EcdhKeyExchangeProvider(Microsoft.IdentityModel.Tokens.SecurityKey privateKey, Microsoft.IdentityModel.Tokens.SecurityKey publicKey, string alg, string enc) => throw null;
+                public Microsoft.IdentityModel.Tokens.SecurityKey GenerateKdf(string apu = default(string), string apv = default(string)) => throw null;
+                public int KeyDataLen { get => throw null; set { } }
+            }
+            public class ECDsaSecurityKey : Microsoft.IdentityModel.Tokens.AsymmetricSecurityKey
+            {
+                public override bool CanComputeJwkThumbprint() => throw null;
+                public override byte[] ComputeJwkThumbprint() => throw null;
+                public ECDsaSecurityKey(System.Security.Cryptography.ECDsa ecdsa) => throw null;
+                public System.Security.Cryptography.ECDsa ECDsa { get => throw null; }
+                public override bool HasPrivateKey { get => throw null; }
+                public override int KeySize { get => throw null; }
+                public override Microsoft.IdentityModel.Tokens.PrivateKeyStatus PrivateKeyStatus { get => throw null; }
+            }
+            public class EncryptingCredentials
+            {
+                public string Alg { get => throw null; }
+                public Microsoft.IdentityModel.Tokens.CryptoProviderFactory CryptoProviderFactory { get => throw null; set { } }
+                protected EncryptingCredentials(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, string alg, string enc) => throw null;
+                public EncryptingCredentials(Microsoft.IdentityModel.Tokens.SecurityKey key, string alg, string enc) => throw null;
+                public EncryptingCredentials(Microsoft.IdentityModel.Tokens.SymmetricSecurityKey key, string enc) => throw null;
+                public string Enc { get => throw null; }
+                public Microsoft.IdentityModel.Tokens.SecurityKey Key { get => throw null; }
+                public Microsoft.IdentityModel.Tokens.SecurityKey KeyExchangePublicKey { get => throw null; set { } }
+                public bool SetDefaultCtyClaim { get => throw null; set { } }
+            }
+            public static class EpochTime
+            {
+                public static System.DateTime DateTime(long secondsSinceUnixEpoch) => throw null;
+                public static long GetIntDate(System.DateTime datetime) => throw null;
+                public static readonly System.DateTime UnixEpoch;
+            }
+            public interface ICompressionProvider
+            {
+                string Algorithm { get; }
+                byte[] Compress(byte[] value);
+                byte[] Decompress(byte[] value);
+                bool IsSupportedAlgorithm(string algorithm);
+            }
+            public interface ICryptoProvider
+            {
+                object Create(string algorithm, params object[] args);
+                bool IsSupportedAlgorithm(string algorithm, params object[] args);
+                void Release(object cryptoInstance);
+            }
+            public class InMemoryCryptoProviderCache : Microsoft.IdentityModel.Tokens.CryptoProviderCache, System.IDisposable
+            {
+                public InMemoryCryptoProviderCache() => throw null;
+                public InMemoryCryptoProviderCache(Microsoft.IdentityModel.Tokens.CryptoProviderCacheOptions cryptoProviderCacheOptions) => throw null;
+                public void Dispose() => throw null;
+                protected virtual void Dispose(bool disposing) => throw null;
+                protected override string GetCacheKey(Microsoft.IdentityModel.Tokens.SignatureProvider signatureProvider) => throw null;
+                protected override string GetCacheKey(Microsoft.IdentityModel.Tokens.SecurityKey securityKey, string algorithm, string typeofProvider) => throw null;
+                public override bool TryAdd(Microsoft.IdentityModel.Tokens.SignatureProvider signatureProvider) => throw null;
+                public override bool TryGetSignatureProvider(Microsoft.IdentityModel.Tokens.SecurityKey securityKey, string algorithm, string typeofProvider, bool willCreateSignatures, out Microsoft.IdentityModel.Tokens.SignatureProvider signatureProvider) => throw null;
+                public override bool TryRemove(Microsoft.IdentityModel.Tokens.SignatureProvider signatureProvider) => throw null;
+            }
+            public interface ISecurityTokenValidator
+            {
+                bool CanReadToken(string securityToken);
+                bool CanValidateToken { get; }
+                int MaximumTokenSizeInBytes { get; set; }
+                System.Security.Claims.ClaimsPrincipal ValidateToken(string securityToken, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters, out Microsoft.IdentityModel.Tokens.SecurityToken validatedToken);
+            }
+            public delegate System.Collections.Generic.IEnumerable<Microsoft.IdentityModel.Tokens.SecurityKey> IssuerSigningKeyResolver(string token, Microsoft.IdentityModel.Tokens.SecurityToken securityToken, string kid, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters);
+            public delegate System.Collections.Generic.IEnumerable<Microsoft.IdentityModel.Tokens.SecurityKey> IssuerSigningKeyResolverUsingConfiguration(string token, Microsoft.IdentityModel.Tokens.SecurityToken securityToken, string kid, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters, Microsoft.IdentityModel.Tokens.BaseConfiguration configuration);
+            public delegate bool IssuerSigningKeyValidator(Microsoft.IdentityModel.Tokens.SecurityKey securityKey, Microsoft.IdentityModel.Tokens.SecurityToken securityToken, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters);
+            public delegate bool IssuerSigningKeyValidatorUsingConfiguration(Microsoft.IdentityModel.Tokens.SecurityKey securityKey, Microsoft.IdentityModel.Tokens.SecurityToken securityToken, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters, Microsoft.IdentityModel.Tokens.BaseConfiguration configuration);
+            public delegate string IssuerValidator(string issuer, Microsoft.IdentityModel.Tokens.SecurityToken securityToken, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters);
+            public delegate string IssuerValidatorUsingConfiguration(string issuer, Microsoft.IdentityModel.Tokens.SecurityToken securityToken, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters, Microsoft.IdentityModel.Tokens.BaseConfiguration configuration);
+            public interface ITokenReplayCache
+            {
+                bool TryAdd(string securityToken, System.DateTime expiresOn);
+                bool TryFind(string securityToken);
+            }
+            public static class JsonWebAlgorithmsKeyTypes
+            {
+                public const string EllipticCurve = default;
+                public const string Octet = default;
+                public const string RSA = default;
+            }
+            public class JsonWebKey : Microsoft.IdentityModel.Tokens.SecurityKey
+            {
+                public System.Collections.Generic.IDictionary<string, object> AdditionalData { get => throw null; }
+                public string Alg { get => throw null; set { } }
+                public override bool CanComputeJwkThumbprint() => throw null;
+                public override byte[] ComputeJwkThumbprint() => throw null;
+                public static Microsoft.IdentityModel.Tokens.JsonWebKey Create(string json) => throw null;
+                public string Crv { get => throw null; set { } }
+                public JsonWebKey() => throw null;
+                public JsonWebKey(string json) => throw null;
+                public string D { get => throw null; set { } }
+                public string DP { get => throw null; set { } }
+                public string DQ { get => throw null; set { } }
+                public string E { get => throw null; set { } }
+                public bool HasPrivateKey { get => throw null; }
+                public string K { get => throw null; set { } }
+                public override string KeyId { get => throw null; set { } }
+                public System.Collections.Generic.IList<string> KeyOps { get => throw null; }
+                public override int KeySize { get => throw null; }
+                public string Kid { get => throw null; set { } }
+                public string Kty { get => throw null; set { } }
+                public string N { get => throw null; set { } }
+                public System.Collections.Generic.IList<string> Oth { get => throw null; }
+                public string P { get => throw null; set { } }
+                public string Q { get => throw null; set { } }
+                public string QI { get => throw null; set { } }
+                public override string ToString() => throw null;
+                public string Use { get => throw null; set { } }
+                public string X { get => throw null; set { } }
+                public System.Collections.Generic.IList<string> X5c { get => throw null; }
+                public string X5t { get => throw null; set { } }
+                public string X5tS256 { get => throw null; set { } }
+                public string X5u { get => throw null; set { } }
+                public string Y { get => throw null; set { } }
+            }
+            public class JsonWebKeyConverter
+            {
+                public static Microsoft.IdentityModel.Tokens.JsonWebKey ConvertFromECDsaSecurityKey(Microsoft.IdentityModel.Tokens.ECDsaSecurityKey key) => throw null;
+                public static Microsoft.IdentityModel.Tokens.JsonWebKey ConvertFromRSASecurityKey(Microsoft.IdentityModel.Tokens.RsaSecurityKey key) => throw null;
+                public static Microsoft.IdentityModel.Tokens.JsonWebKey ConvertFromSecurityKey(Microsoft.IdentityModel.Tokens.SecurityKey key) => throw null;
+                public static Microsoft.IdentityModel.Tokens.JsonWebKey ConvertFromSymmetricSecurityKey(Microsoft.IdentityModel.Tokens.SymmetricSecurityKey key) => throw null;
+                public static Microsoft.IdentityModel.Tokens.JsonWebKey ConvertFromX509SecurityKey(Microsoft.IdentityModel.Tokens.X509SecurityKey key) => throw null;
+                public static Microsoft.IdentityModel.Tokens.JsonWebKey ConvertFromX509SecurityKey(Microsoft.IdentityModel.Tokens.X509SecurityKey key, bool representAsRsaKey) => throw null;
+                public JsonWebKeyConverter() => throw null;
+            }
+            public static class JsonWebKeyECTypes
+            {
+                public const string P256 = default;
+                public const string P384 = default;
+                public const string P512 = default;
+                public const string P521 = default;
+            }
+            public static class JsonWebKeyParameterNames
+            {
+                public const string Alg = default;
+                public const string Crv = default;
+                public const string D = default;
+                public const string DP = default;
+                public const string DQ = default;
+                public const string E = default;
+                public const string K = default;
+                public const string KeyOps = default;
+                public const string Keys = default;
+                public const string Kid = default;
+                public const string Kty = default;
+                public const string N = default;
+                public const string Oth = default;
+                public const string P = default;
+                public const string Q = default;
+                public const string QI = default;
+                public const string Use = default;
+                public const string X = default;
+                public const string X5c = default;
+                public const string X5t = default;
+                public const string X5tS256 = default;
+                public const string X5u = default;
+                public const string Y = default;
+            }
+            public class JsonWebKeySet
+            {
+                public System.Collections.Generic.IDictionary<string, object> AdditionalData { get => throw null; }
+                public static Microsoft.IdentityModel.Tokens.JsonWebKeySet Create(string json) => throw null;
+                public JsonWebKeySet() => throw null;
+                public JsonWebKeySet(string json) => throw null;
+                public static bool DefaultSkipUnresolvedJsonWebKeys;
+                public System.Collections.Generic.IList<Microsoft.IdentityModel.Tokens.SecurityKey> GetSigningKeys() => throw null;
+                public System.Collections.Generic.IList<Microsoft.IdentityModel.Tokens.JsonWebKey> Keys { get => throw null; }
+                public bool SkipUnresolvedJsonWebKeys { get => throw null; set { } }
+            }
+            public static class JsonWebKeySetParameterNames
+            {
+                public const string Keys = default;
+            }
+            public static class JsonWebKeyUseNames
+            {
+                public const string Enc = default;
+                public const string Sig = default;
+            }
+            public abstract class KeyWrapProvider : System.IDisposable
+            {
+                public abstract string Algorithm { get; }
+                public abstract string Context { get; set; }
+                protected KeyWrapProvider() => throw null;
+                public void Dispose() => throw null;
+                protected abstract void Dispose(bool disposing);
+                public abstract Microsoft.IdentityModel.Tokens.SecurityKey Key { get; }
+                public abstract byte[] UnwrapKey(byte[] keyBytes);
+                public abstract byte[] WrapKey(byte[] keyBytes);
+            }
+            public delegate bool LifetimeValidator(System.DateTime? notBefore, System.DateTime? expires, Microsoft.IdentityModel.Tokens.SecurityToken securityToken, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters);
+            public enum PrivateKeyStatus
+            {
+                Exists = 0,
+                DoesNotExist = 1,
+                Unknown = 2,
+            }
+            public class RsaKeyWrapProvider : Microsoft.IdentityModel.Tokens.KeyWrapProvider
+            {
+                public override string Algorithm { get => throw null; }
+                public override string Context { get => throw null; set { } }
+                public RsaKeyWrapProvider(Microsoft.IdentityModel.Tokens.SecurityKey key, string algorithm, bool willUnwrap) => throw null;
+                protected override void Dispose(bool disposing) => throw null;
+                protected virtual bool IsSupportedAlgorithm(Microsoft.IdentityModel.Tokens.SecurityKey key, string algorithm) => throw null;
+                public override Microsoft.IdentityModel.Tokens.SecurityKey Key { get => throw null; }
+                public override byte[] UnwrapKey(byte[] keyBytes) => throw null;
+                public override byte[] WrapKey(byte[] keyBytes) => throw null;
+            }
+            public class RsaSecurityKey : Microsoft.IdentityModel.Tokens.AsymmetricSecurityKey
+            {
+                public override bool CanComputeJwkThumbprint() => throw null;
+                public override byte[] ComputeJwkThumbprint() => throw null;
+                public RsaSecurityKey(System.Security.Cryptography.RSAParameters rsaParameters) => throw null;
+                public RsaSecurityKey(System.Security.Cryptography.RSA rsa) => throw null;
+                public override bool HasPrivateKey { get => throw null; }
+                public override int KeySize { get => throw null; }
+                public System.Security.Cryptography.RSAParameters Parameters { get => throw null; }
+                public override Microsoft.IdentityModel.Tokens.PrivateKeyStatus PrivateKeyStatus { get => throw null; }
+                public System.Security.Cryptography.RSA Rsa { get => throw null; }
+            }
+            public static class SecurityAlgorithms
+            {
+                public const string Aes128CbcHmacSha256 = default;
+                public const string Aes128Encryption = default;
+                public const string Aes128Gcm = default;
+                public const string Aes128KeyWrap = default;
+                public const string Aes128KW = default;
+                public const string Aes192CbcHmacSha384 = default;
+                public const string Aes192Encryption = default;
+                public const string Aes192Gcm = default;
+                public const string Aes192KeyWrap = default;
+                public const string Aes192KW = default;
+                public const string Aes256CbcHmacSha512 = default;
+                public const string Aes256Encryption = default;
+                public const string Aes256Gcm = default;
+                public const string Aes256KeyWrap = default;
+                public const string Aes256KW = default;
+                public const string DesEncryption = default;
+                public const string EcdhEs = default;
+                public const string EcdhEsA128kw = default;
+                public const string EcdhEsA192kw = default;
+                public const string EcdhEsA256kw = default;
+                public const string EcdsaSha256 = default;
+                public const string EcdsaSha256Signature = default;
+                public const string EcdsaSha384 = default;
+                public const string EcdsaSha384Signature = default;
+                public const string EcdsaSha512 = default;
+                public const string EcdsaSha512Signature = default;
+                public const string EnvelopedSignature = default;
+                public const string ExclusiveC14n = default;
+                public const string ExclusiveC14nWithComments = default;
+                public const string HmacSha256 = default;
+                public const string HmacSha256Signature = default;
+                public const string HmacSha384 = default;
+                public const string HmacSha384Signature = default;
+                public const string HmacSha512 = default;
+                public const string HmacSha512Signature = default;
+                public const string None = default;
+                public const string Ripemd160Digest = default;
+                public const string RsaOAEP = default;
+                public const string RsaOaepKeyWrap = default;
+                public const string RsaPKCS1 = default;
+                public const string RsaSha256 = default;
+                public const string RsaSha256Signature = default;
+                public const string RsaSha384 = default;
+                public const string RsaSha384Signature = default;
+                public const string RsaSha512 = default;
+                public const string RsaSha512Signature = default;
+                public const string RsaSsaPssSha256 = default;
+                public const string RsaSsaPssSha256Signature = default;
+                public const string RsaSsaPssSha384 = default;
+                public const string RsaSsaPssSha384Signature = default;
+                public const string RsaSsaPssSha512 = default;
+                public const string RsaSsaPssSha512Signature = default;
+                public const string RsaV15KeyWrap = default;
+                public const string Sha256 = default;
+                public const string Sha256Digest = default;
+                public const string Sha384 = default;
+                public const string Sha384Digest = default;
+                public const string Sha512 = default;
+                public const string Sha512Digest = default;
+            }
+            public abstract class SecurityKey
+            {
+                public virtual bool CanComputeJwkThumbprint() => throw null;
+                public virtual byte[] ComputeJwkThumbprint() => throw null;
+                public Microsoft.IdentityModel.Tokens.CryptoProviderFactory CryptoProviderFactory { get => throw null; set { } }
+                public SecurityKey() => throw null;
+                public virtual bool IsSupportedAlgorithm(string algorithm) => throw null;
+                public virtual string KeyId { get => throw null; set { } }
+                public abstract int KeySize { get; }
+                public override string ToString() => throw null;
+            }
+            public class SecurityKeyIdentifierClause
+            {
+                public SecurityKeyIdentifierClause() => throw null;
+            }
+            public abstract class SecurityToken : Microsoft.IdentityModel.Logging.ISafeLogSecurityArtifact
+            {
+                protected SecurityToken() => throw null;
+                public abstract string Id { get; }
+                public abstract string Issuer { get; }
+                public abstract Microsoft.IdentityModel.Tokens.SecurityKey SecurityKey { get; }
+                public abstract Microsoft.IdentityModel.Tokens.SecurityKey SigningKey { get; set; }
+                public virtual string UnsafeToString() => throw null;
+                public abstract System.DateTime ValidFrom { get; }
+                public abstract System.DateTime ValidTo { get; }
+            }
+            public class SecurityTokenArgumentException : System.ArgumentException
+            {
+                public SecurityTokenArgumentException() => throw null;
+                public SecurityTokenArgumentException(string message) => throw null;
+                public SecurityTokenArgumentException(string message, System.Exception innerException) => throw null;
+                protected SecurityTokenArgumentException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) => throw null;
+            }
+            public class SecurityTokenCompressionFailedException : Microsoft.IdentityModel.Tokens.SecurityTokenException
+            {
+                public SecurityTokenCompressionFailedException() => throw null;
+                public SecurityTokenCompressionFailedException(string message) => throw null;
+                public SecurityTokenCompressionFailedException(string message, System.Exception inner) => throw null;
+                protected SecurityTokenCompressionFailedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) => throw null;
+            }
+            public class SecurityTokenDecompressionFailedException : Microsoft.IdentityModel.Tokens.SecurityTokenException
+            {
+                public SecurityTokenDecompressionFailedException() => throw null;
+                public SecurityTokenDecompressionFailedException(string message) => throw null;
+                public SecurityTokenDecompressionFailedException(string message, System.Exception inner) => throw null;
+                protected SecurityTokenDecompressionFailedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) => throw null;
+            }
+            public class SecurityTokenDecryptionFailedException : Microsoft.IdentityModel.Tokens.SecurityTokenException
+            {
+                public SecurityTokenDecryptionFailedException() => throw null;
+                public SecurityTokenDecryptionFailedException(string message) => throw null;
+                public SecurityTokenDecryptionFailedException(string message, System.Exception innerException) => throw null;
+                protected SecurityTokenDecryptionFailedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) => throw null;
+            }
+            public class SecurityTokenDescriptor
+            {
+                public System.Collections.Generic.IDictionary<string, object> AdditionalHeaderClaims { get => throw null; set { } }
+                public System.Collections.Generic.IDictionary<string, object> AdditionalInnerHeaderClaims { get => throw null; set { } }
+                public string Audience { get => throw null; set { } }
+                public System.Collections.Generic.IDictionary<string, object> Claims { get => throw null; set { } }
+                public string CompressionAlgorithm { get => throw null; set { } }
+                public SecurityTokenDescriptor() => throw null;
+                public Microsoft.IdentityModel.Tokens.EncryptingCredentials EncryptingCredentials { get => throw null; set { } }
+                public System.DateTime? Expires { get => throw null; set { } }
+                public System.DateTime? IssuedAt { get => throw null; set { } }
+                public string Issuer { get => throw null; set { } }
+                public System.DateTime? NotBefore { get => throw null; set { } }
+                public Microsoft.IdentityModel.Tokens.SigningCredentials SigningCredentials { get => throw null; set { } }
+                public System.Security.Claims.ClaimsIdentity Subject { get => throw null; set { } }
+                public string TokenType { get => throw null; set { } }
+            }
+            public class SecurityTokenEncryptionFailedException : Microsoft.IdentityModel.Tokens.SecurityTokenException
+            {
+                public SecurityTokenEncryptionFailedException() => throw null;
+                public SecurityTokenEncryptionFailedException(string message) => throw null;
+                public SecurityTokenEncryptionFailedException(string message, System.Exception innerException) => throw null;
+                protected SecurityTokenEncryptionFailedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) => throw null;
+            }
+            public class SecurityTokenEncryptionKeyNotFoundException : Microsoft.IdentityModel.Tokens.SecurityTokenDecryptionFailedException
+            {
+                public SecurityTokenEncryptionKeyNotFoundException() => throw null;
+                public SecurityTokenEncryptionKeyNotFoundException(string message) => throw null;
+                public SecurityTokenEncryptionKeyNotFoundException(string message, System.Exception innerException) => throw null;
+                protected SecurityTokenEncryptionKeyNotFoundException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) => throw null;
+            }
+            public class SecurityTokenException : System.Exception
+            {
+                public SecurityTokenException() => throw null;
+                public SecurityTokenException(string message) => throw null;
+                public SecurityTokenException(string message, System.Exception innerException) => throw null;
+                protected SecurityTokenException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) => throw null;
+                public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) => throw null;
+            }
+            public class SecurityTokenExpiredException : Microsoft.IdentityModel.Tokens.SecurityTokenValidationException
+            {
+                public SecurityTokenExpiredException() => throw null;
+                public SecurityTokenExpiredException(string message) => throw null;
+                public SecurityTokenExpiredException(string message, System.Exception inner) => throw null;
+                protected SecurityTokenExpiredException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) => throw null;
+                public System.DateTime Expires { get => throw null; set { } }
+                public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) => throw null;
+            }
+            public abstract class SecurityTokenHandler : Microsoft.IdentityModel.Tokens.TokenHandler, Microsoft.IdentityModel.Tokens.ISecurityTokenValidator
+            {
+                public virtual bool CanReadToken(System.Xml.XmlReader reader) => throw null;
+                public virtual bool CanReadToken(string tokenString) => throw null;
+                public virtual bool CanValidateToken { get => throw null; }
+                public virtual bool CanWriteToken { get => throw null; }
+                public virtual Microsoft.IdentityModel.Tokens.SecurityKeyIdentifierClause CreateSecurityTokenReference(Microsoft.IdentityModel.Tokens.SecurityToken token, bool attached) => throw null;
+                public virtual Microsoft.IdentityModel.Tokens.SecurityToken CreateToken(Microsoft.IdentityModel.Tokens.SecurityTokenDescriptor tokenDescriptor) => throw null;
+                protected SecurityTokenHandler() => throw null;
+                public virtual Microsoft.IdentityModel.Tokens.SecurityToken ReadToken(System.Xml.XmlReader reader) => throw null;
+                public abstract Microsoft.IdentityModel.Tokens.SecurityToken ReadToken(System.Xml.XmlReader reader, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters);
+                public abstract System.Type TokenType { get; }
+                public virtual System.Security.Claims.ClaimsPrincipal ValidateToken(string securityToken, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters, out Microsoft.IdentityModel.Tokens.SecurityToken validatedToken) => throw null;
+                public virtual System.Security.Claims.ClaimsPrincipal ValidateToken(System.Xml.XmlReader reader, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters, out Microsoft.IdentityModel.Tokens.SecurityToken validatedToken) => throw null;
+                public virtual string WriteToken(Microsoft.IdentityModel.Tokens.SecurityToken token) => throw null;
+                public abstract void WriteToken(System.Xml.XmlWriter writer, Microsoft.IdentityModel.Tokens.SecurityToken token);
+            }
+            public class SecurityTokenInvalidAlgorithmException : Microsoft.IdentityModel.Tokens.SecurityTokenValidationException
+            {
+                public SecurityTokenInvalidAlgorithmException() => throw null;
+                public SecurityTokenInvalidAlgorithmException(string message) => throw null;
+                public SecurityTokenInvalidAlgorithmException(string message, System.Exception innerException) => throw null;
+                protected SecurityTokenInvalidAlgorithmException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) => throw null;
+                public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) => throw null;
+                public string InvalidAlgorithm { get => throw null; set { } }
+            }
+            public class SecurityTokenInvalidAudienceException : Microsoft.IdentityModel.Tokens.SecurityTokenValidationException
+            {
+                public SecurityTokenInvalidAudienceException() => throw null;
+                public SecurityTokenInvalidAudienceException(string message) => throw null;
+                public SecurityTokenInvalidAudienceException(string message, System.Exception innerException) => throw null;
+                protected SecurityTokenInvalidAudienceException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) => throw null;
+                public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) => throw null;
+                public string InvalidAudience { get => throw null; set { } }
+            }
+            public class SecurityTokenInvalidIssuerException : Microsoft.IdentityModel.Tokens.SecurityTokenValidationException
+            {
+                public SecurityTokenInvalidIssuerException() => throw null;
+                public SecurityTokenInvalidIssuerException(string message) => throw null;
+                public SecurityTokenInvalidIssuerException(string message, System.Exception innerException) => throw null;
+                protected SecurityTokenInvalidIssuerException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) => throw null;
+                public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) => throw null;
+                public string InvalidIssuer { get => throw null; set { } }
+            }
+            public class SecurityTokenInvalidLifetimeException : Microsoft.IdentityModel.Tokens.SecurityTokenValidationException
+            {
+                public SecurityTokenInvalidLifetimeException() => throw null;
+                public SecurityTokenInvalidLifetimeException(string message) => throw null;
+                public SecurityTokenInvalidLifetimeException(string message, System.Exception innerException) => throw null;
+                protected SecurityTokenInvalidLifetimeException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) => throw null;
+                public System.DateTime? Expires { get => throw null; set { } }
+                public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) => throw null;
+                public System.DateTime? NotBefore { get => throw null; set { } }
+            }
+            public class SecurityTokenInvalidSignatureException : Microsoft.IdentityModel.Tokens.SecurityTokenValidationException
+            {
+                public SecurityTokenInvalidSignatureException() => throw null;
+                public SecurityTokenInvalidSignatureException(string message) => throw null;
+                public SecurityTokenInvalidSignatureException(string message, System.Exception innerException) => throw null;
+                protected SecurityTokenInvalidSignatureException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) => throw null;
+            }
+            public class SecurityTokenInvalidSigningKeyException : Microsoft.IdentityModel.Tokens.SecurityTokenValidationException
+            {
+                public SecurityTokenInvalidSigningKeyException() => throw null;
+                public SecurityTokenInvalidSigningKeyException(string message) => throw null;
+                public SecurityTokenInvalidSigningKeyException(string message, System.Exception inner) => throw null;
+                protected SecurityTokenInvalidSigningKeyException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) => throw null;
+                public Microsoft.IdentityModel.Tokens.SecurityKey SigningKey { get => throw null; set { } }
+            }
+            public class SecurityTokenInvalidTypeException : Microsoft.IdentityModel.Tokens.SecurityTokenValidationException
+            {
+                public SecurityTokenInvalidTypeException() => throw null;
+                public SecurityTokenInvalidTypeException(string message) => throw null;
+                public SecurityTokenInvalidTypeException(string message, System.Exception innerException) => throw null;
+                protected SecurityTokenInvalidTypeException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) => throw null;
+                public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) => throw null;
+                public string InvalidType { get => throw null; set { } }
+            }
+            public class SecurityTokenKeyWrapException : Microsoft.IdentityModel.Tokens.SecurityTokenException
+            {
+                public SecurityTokenKeyWrapException() => throw null;
+                public SecurityTokenKeyWrapException(string message) => throw null;
+                public SecurityTokenKeyWrapException(string message, System.Exception innerException) => throw null;
+                protected SecurityTokenKeyWrapException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) => throw null;
+            }
+            public class SecurityTokenMalformedException : Microsoft.IdentityModel.Tokens.SecurityTokenArgumentException
+            {
+                public SecurityTokenMalformedException() => throw null;
+                public SecurityTokenMalformedException(string message) => throw null;
+                public SecurityTokenMalformedException(string message, System.Exception innerException) => throw null;
+                protected SecurityTokenMalformedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) => throw null;
+            }
+            public class SecurityTokenNoExpirationException : Microsoft.IdentityModel.Tokens.SecurityTokenValidationException
+            {
+                public SecurityTokenNoExpirationException() => throw null;
+                public SecurityTokenNoExpirationException(string message) => throw null;
+                public SecurityTokenNoExpirationException(string message, System.Exception innerException) => throw null;
+                protected SecurityTokenNoExpirationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) => throw null;
+            }
+            public class SecurityTokenNotYetValidException : Microsoft.IdentityModel.Tokens.SecurityTokenValidationException
+            {
+                public SecurityTokenNotYetValidException() => throw null;
+                public SecurityTokenNotYetValidException(string message) => throw null;
+                public SecurityTokenNotYetValidException(string message, System.Exception inner) => throw null;
+                protected SecurityTokenNotYetValidException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) => throw null;
+                public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) => throw null;
+                public System.DateTime NotBefore { get => throw null; set { } }
+            }
+            public class SecurityTokenReplayAddFailedException : Microsoft.IdentityModel.Tokens.SecurityTokenValidationException
+            {
+                public SecurityTokenReplayAddFailedException() => throw null;
+                public SecurityTokenReplayAddFailedException(string message) => throw null;
+                public SecurityTokenReplayAddFailedException(string message, System.Exception innerException) => throw null;
+                protected SecurityTokenReplayAddFailedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) => throw null;
+            }
+            public class SecurityTokenReplayDetectedException : Microsoft.IdentityModel.Tokens.SecurityTokenValidationException
+            {
+                public SecurityTokenReplayDetectedException() => throw null;
+                public SecurityTokenReplayDetectedException(string message) => throw null;
+                public SecurityTokenReplayDetectedException(string message, System.Exception inner) => throw null;
+                protected SecurityTokenReplayDetectedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) => throw null;
+            }
+            public class SecurityTokenSignatureKeyNotFoundException : Microsoft.IdentityModel.Tokens.SecurityTokenInvalidSignatureException
+            {
+                public SecurityTokenSignatureKeyNotFoundException() => throw null;
+                public SecurityTokenSignatureKeyNotFoundException(string message) => throw null;
+                public SecurityTokenSignatureKeyNotFoundException(string message, System.Exception innerException) => throw null;
+                protected SecurityTokenSignatureKeyNotFoundException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) => throw null;
+            }
+            public class SecurityTokenUnableToValidateException : Microsoft.IdentityModel.Tokens.SecurityTokenInvalidSignatureException
+            {
+                public SecurityTokenUnableToValidateException() => throw null;
+                public SecurityTokenUnableToValidateException(Microsoft.IdentityModel.Tokens.ValidationFailure validationFailure, string message) => throw null;
+                public SecurityTokenUnableToValidateException(string message) => throw null;
+                public SecurityTokenUnableToValidateException(string message, System.Exception innerException) => throw null;
+                protected SecurityTokenUnableToValidateException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) => throw null;
+                public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) => throw null;
+                public Microsoft.IdentityModel.Tokens.ValidationFailure ValidationFailure { get => throw null; set { } }
+            }
+            public class SecurityTokenValidationException : Microsoft.IdentityModel.Tokens.SecurityTokenException
+            {
+                public SecurityTokenValidationException() => throw null;
+                public SecurityTokenValidationException(string message) => throw null;
+                public SecurityTokenValidationException(string message, System.Exception innerException) => throw null;
+                protected SecurityTokenValidationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) => throw null;
+            }
+            public abstract class SignatureProvider : System.IDisposable
+            {
+                public string Algorithm { get => throw null; }
+                public string Context { get => throw null; set { } }
+                public Microsoft.IdentityModel.Tokens.CryptoProviderCache CryptoProviderCache { get => throw null; set { } }
+                protected SignatureProvider(Microsoft.IdentityModel.Tokens.SecurityKey key, string algorithm) => throw null;
+                public void Dispose() => throw null;
+                protected abstract void Dispose(bool disposing);
+                public Microsoft.IdentityModel.Tokens.SecurityKey Key { get => throw null; }
+                public abstract byte[] Sign(byte[] input);
+                public virtual byte[] Sign(byte[] input, int offset, int count) => throw null;
+                public virtual bool Sign(System.ReadOnlySpan<byte> data, System.Span<byte> destination, out int bytesWritten) => throw null;
+                public abstract bool Verify(byte[] input, byte[] signature);
+                public virtual bool Verify(byte[] input, int inputOffset, int inputLength, byte[] signature, int signatureOffset, int signatureLength) => throw null;
+                public bool WillCreateSignatures { get => throw null; set { } }
+            }
+            public delegate Microsoft.IdentityModel.Tokens.SecurityToken SignatureValidator(string token, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters);
+            public delegate Microsoft.IdentityModel.Tokens.SecurityToken SignatureValidatorUsingConfiguration(string token, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters, Microsoft.IdentityModel.Tokens.BaseConfiguration configuration);
+            public class SigningCredentials
+            {
+                public string Algorithm { get => throw null; }
+                public Microsoft.IdentityModel.Tokens.CryptoProviderFactory CryptoProviderFactory { get => throw null; set { } }
+                protected SigningCredentials(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) => throw null;
+                protected SigningCredentials(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, string algorithm) => throw null;
+                public SigningCredentials(Microsoft.IdentityModel.Tokens.SecurityKey key, string algorithm) => throw null;
+                public SigningCredentials(Microsoft.IdentityModel.Tokens.SecurityKey key, string algorithm, string digest) => throw null;
+                public string Digest { get => throw null; }
+                public Microsoft.IdentityModel.Tokens.SecurityKey Key { get => throw null; }
+                public string Kid { get => throw null; }
+            }
+            public class SymmetricKeyWrapProvider : Microsoft.IdentityModel.Tokens.KeyWrapProvider
+            {
+                public override string Algorithm { get => throw null; }
+                public override string Context { get => throw null; set { } }
+                public SymmetricKeyWrapProvider(Microsoft.IdentityModel.Tokens.SecurityKey key, string algorithm) => throw null;
+                protected override void Dispose(bool disposing) => throw null;
+                protected virtual System.Security.Cryptography.SymmetricAlgorithm GetSymmetricAlgorithm(Microsoft.IdentityModel.Tokens.SecurityKey key, string algorithm) => throw null;
+                protected virtual bool IsSupportedAlgorithm(Microsoft.IdentityModel.Tokens.SecurityKey key, string algorithm) => throw null;
+                public override Microsoft.IdentityModel.Tokens.SecurityKey Key { get => throw null; }
+                public override byte[] UnwrapKey(byte[] keyBytes) => throw null;
+                public override byte[] WrapKey(byte[] keyBytes) => throw null;
+            }
+            public class SymmetricSecurityKey : Microsoft.IdentityModel.Tokens.SecurityKey
+            {
+                public override bool CanComputeJwkThumbprint() => throw null;
+                public override byte[] ComputeJwkThumbprint() => throw null;
+                public SymmetricSecurityKey(byte[] key) => throw null;
+                public virtual byte[] Key { get => throw null; }
+                public override int KeySize { get => throw null; }
+            }
+            public class SymmetricSignatureProvider : Microsoft.IdentityModel.Tokens.SignatureProvider
+            {
+                public SymmetricSignatureProvider(Microsoft.IdentityModel.Tokens.SecurityKey key, string algorithm) : base(default(Microsoft.IdentityModel.Tokens.SecurityKey), default(string)) => throw null;
+                public SymmetricSignatureProvider(Microsoft.IdentityModel.Tokens.SecurityKey key, string algorithm, bool willCreateSignatures) : base(default(Microsoft.IdentityModel.Tokens.SecurityKey), default(string)) => throw null;
+                public static readonly int DefaultMinimumSymmetricKeySizeInBits;
+                protected override void Dispose(bool disposing) => throw null;
+                protected virtual byte[] GetKeyBytes(Microsoft.IdentityModel.Tokens.SecurityKey key) => throw null;
+                protected virtual System.Security.Cryptography.KeyedHashAlgorithm GetKeyedHashAlgorithm(byte[] keyBytes, string algorithm) => throw null;
+                public int MinimumSymmetricKeySizeInBits { get => throw null; set { } }
+                protected virtual void ReleaseKeyedHashAlgorithm(System.Security.Cryptography.KeyedHashAlgorithm keyedHashAlgorithm) => throw null;
+                public override byte[] Sign(byte[] input) => throw null;
+                public override bool Sign(System.ReadOnlySpan<byte> input, System.Span<byte> signature, out int bytesWritten) => throw null;
+                public override byte[] Sign(byte[] input, int offset, int count) => throw null;
+                public override bool Verify(byte[] input, byte[] signature) => throw null;
+                public bool Verify(byte[] input, byte[] signature, int length) => throw null;
+                public override bool Verify(byte[] input, int inputOffset, int inputLength, byte[] signature, int signatureOffset, int signatureLength) => throw null;
+            }
+            public class TokenContext : Microsoft.IdentityModel.Tokens.CallContext
+            {
+                public TokenContext() => throw null;
+                public TokenContext(System.Guid activityId) => throw null;
+            }
+            public delegate System.Collections.Generic.IEnumerable<Microsoft.IdentityModel.Tokens.SecurityKey> TokenDecryptionKeyResolver(string token, Microsoft.IdentityModel.Tokens.SecurityToken securityToken, string kid, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters);
+            public abstract class TokenHandler
+            {
+                protected TokenHandler() => throw null;
+                public static readonly int DefaultTokenLifetimeInMinutes;
+                public virtual int MaximumTokenSizeInBytes { get => throw null; set { } }
+                public virtual Microsoft.IdentityModel.Tokens.SecurityToken ReadToken(string token) => throw null;
+                public bool SetDefaultTimesOnTokenCreation { get => throw null; set { } }
+                public int TokenLifetimeInMinutes { get => throw null; set { } }
+                public virtual System.Threading.Tasks.Task<Microsoft.IdentityModel.Tokens.TokenValidationResult> ValidateTokenAsync(string token, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters) => throw null;
+                public virtual System.Threading.Tasks.Task<Microsoft.IdentityModel.Tokens.TokenValidationResult> ValidateTokenAsync(Microsoft.IdentityModel.Tokens.SecurityToken token, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters) => throw null;
+            }
+            public delegate Microsoft.IdentityModel.Tokens.SecurityToken TokenReader(string token, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters);
+            public delegate bool TokenReplayValidator(System.DateTime? expirationTime, string securityToken, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters);
+            public class TokenValidationParameters
+            {
+                public Microsoft.IdentityModel.Tokens.TokenValidationParameters ActorValidationParameters { get => throw null; set { } }
+                public Microsoft.IdentityModel.Tokens.AlgorithmValidator AlgorithmValidator { get => throw null; set { } }
+                public Microsoft.IdentityModel.Tokens.AudienceValidator AudienceValidator { get => throw null; set { } }
+                public string AuthenticationType { get => throw null; set { } }
+                public System.TimeSpan ClockSkew { get => throw null; set { } }
+                public virtual Microsoft.IdentityModel.Tokens.TokenValidationParameters Clone() => throw null;
+                public Microsoft.IdentityModel.Tokens.BaseConfigurationManager ConfigurationManager { get => throw null; set { } }
+                public virtual System.Security.Claims.ClaimsIdentity CreateClaimsIdentity(Microsoft.IdentityModel.Tokens.SecurityToken securityToken, string issuer) => throw null;
+                public Microsoft.IdentityModel.Tokens.CryptoProviderFactory CryptoProviderFactory { get => throw null; set { } }
+                protected TokenValidationParameters(Microsoft.IdentityModel.Tokens.TokenValidationParameters other) => throw null;
+                public TokenValidationParameters() => throw null;
+                public string DebugId { get => throw null; set { } }
+                public static readonly string DefaultAuthenticationType;
+                public static readonly System.TimeSpan DefaultClockSkew;
+                public const int DefaultMaximumTokenSizeInBytes = 256000;
+                public bool IgnoreTrailingSlashWhenValidatingAudience { get => throw null; set { } }
+                public bool IncludeTokenOnFailedValidation { get => throw null; set { } }
+                public System.Collections.Generic.IDictionary<string, object> InstancePropertyBag { get => throw null; }
+                public bool IsClone { get => throw null; set { } }
+                public Microsoft.IdentityModel.Tokens.SecurityKey IssuerSigningKey { get => throw null; set { } }
+                public Microsoft.IdentityModel.Tokens.IssuerSigningKeyResolver IssuerSigningKeyResolver { get => throw null; set { } }
+                public Microsoft.IdentityModel.Tokens.IssuerSigningKeyResolverUsingConfiguration IssuerSigningKeyResolverUsingConfiguration { get => throw null; set { } }
+                public System.Collections.Generic.IEnumerable<Microsoft.IdentityModel.Tokens.SecurityKey> IssuerSigningKeys { get => throw null; set { } }
+                public Microsoft.IdentityModel.Tokens.IssuerSigningKeyValidator IssuerSigningKeyValidator { get => throw null; set { } }
+                public Microsoft.IdentityModel.Tokens.IssuerSigningKeyValidatorUsingConfiguration IssuerSigningKeyValidatorUsingConfiguration { get => throw null; set { } }
+                public Microsoft.IdentityModel.Tokens.IssuerValidator IssuerValidator { get => throw null; set { } }
+                public Microsoft.IdentityModel.Tokens.IssuerValidatorUsingConfiguration IssuerValidatorUsingConfiguration { get => throw null; set { } }
+                public Microsoft.IdentityModel.Tokens.LifetimeValidator LifetimeValidator { get => throw null; set { } }
+                public bool LogTokenId { get => throw null; set { } }
+                public bool LogValidationExceptions { get => throw null; set { } }
+                public string NameClaimType { get => throw null; set { } }
+                public System.Func<Microsoft.IdentityModel.Tokens.SecurityToken, string, string> NameClaimTypeRetriever { get => throw null; set { } }
+                public System.Collections.Generic.IDictionary<string, object> PropertyBag { get => throw null; set { } }
+                public bool RefreshBeforeValidation { get => throw null; set { } }
+                public bool RequireAudience { get => throw null; set { } }
+                public bool RequireExpirationTime { get => throw null; set { } }
+                public bool RequireSignedTokens { get => throw null; set { } }
+                public string RoleClaimType { get => throw null; set { } }
+                public System.Func<Microsoft.IdentityModel.Tokens.SecurityToken, string, string> RoleClaimTypeRetriever { get => throw null; set { } }
+                public bool SaveSigninToken { get => throw null; set { } }
+                public Microsoft.IdentityModel.Tokens.SignatureValidator SignatureValidator { get => throw null; set { } }
+                public Microsoft.IdentityModel.Tokens.SignatureValidatorUsingConfiguration SignatureValidatorUsingConfiguration { get => throw null; set { } }
+                public Microsoft.IdentityModel.Tokens.SecurityKey TokenDecryptionKey { get => throw null; set { } }
+                public Microsoft.IdentityModel.Tokens.TokenDecryptionKeyResolver TokenDecryptionKeyResolver { get => throw null; set { } }
+                public System.Collections.Generic.IEnumerable<Microsoft.IdentityModel.Tokens.SecurityKey> TokenDecryptionKeys { get => throw null; set { } }
+                public Microsoft.IdentityModel.Tokens.TokenReader TokenReader { get => throw null; set { } }
+                public Microsoft.IdentityModel.Tokens.ITokenReplayCache TokenReplayCache { get => throw null; set { } }
+                public Microsoft.IdentityModel.Tokens.TokenReplayValidator TokenReplayValidator { get => throw null; set { } }
+                public Microsoft.IdentityModel.Tokens.TransformBeforeSignatureValidation TransformBeforeSignatureValidation { get => throw null; set { } }
+                public bool TryAllIssuerSigningKeys { get => throw null; set { } }
+                public Microsoft.IdentityModel.Tokens.TypeValidator TypeValidator { get => throw null; set { } }
+                public System.Collections.Generic.IEnumerable<string> ValidAlgorithms { get => throw null; set { } }
+                public bool ValidateActor { get => throw null; set { } }
+                public bool ValidateAudience { get => throw null; set { } }
+                public bool ValidateIssuer { get => throw null; set { } }
+                public bool ValidateIssuerSigningKey { get => throw null; set { } }
+                public bool ValidateLifetime { get => throw null; set { } }
+                public bool ValidateSignatureLast { get => throw null; set { } }
+                public bool ValidateTokenReplay { get => throw null; set { } }
+                public bool ValidateWithLKG { get => throw null; set { } }
+                public string ValidAudience { get => throw null; set { } }
+                public System.Collections.Generic.IEnumerable<string> ValidAudiences { get => throw null; set { } }
+                public string ValidIssuer { get => throw null; set { } }
+                public System.Collections.Generic.IEnumerable<string> ValidIssuers { get => throw null; set { } }
+                public System.Collections.Generic.IEnumerable<string> ValidTypes { get => throw null; set { } }
+            }
+            public class TokenValidationResult
+            {
+                public System.Collections.Generic.IDictionary<string, object> Claims { get => throw null; }
+                public System.Security.Claims.ClaimsIdentity ClaimsIdentity { get => throw null; set { } }
+                public TokenValidationResult() => throw null;
+                public System.Exception Exception { get => throw null; set { } }
+                public string Issuer { get => throw null; set { } }
+                public bool IsValid { get => throw null; set { } }
+                public System.Collections.Generic.IDictionary<string, object> PropertyBag { get => throw null; }
+                public Microsoft.IdentityModel.Tokens.SecurityToken SecurityToken { get => throw null; set { } }
+                public Microsoft.IdentityModel.Tokens.CallContext TokenContext { get => throw null; set { } }
+                public Microsoft.IdentityModel.Tokens.SecurityToken TokenOnFailedValidation { get => throw null; }
+                public string TokenType { get => throw null; set { } }
+            }
+            public delegate Microsoft.IdentityModel.Tokens.SecurityToken TransformBeforeSignatureValidation(Microsoft.IdentityModel.Tokens.SecurityToken token, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters);
+            public delegate string TypeValidator(string type, Microsoft.IdentityModel.Tokens.SecurityToken securityToken, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters);
+            public static class UniqueId
+            {
+                public static string CreateRandomId() => throw null;
+                public static string CreateRandomId(string prefix) => throw null;
+                public static System.Uri CreateRandomUri() => throw null;
+                public static string CreateUniqueId() => throw null;
+                public static string CreateUniqueId(string prefix) => throw null;
+            }
+            public static class Utility
+            {
+                public static bool AreEqual(byte[] a, byte[] b) => throw null;
+                public static byte[] CloneByteArray(this byte[] src) => throw null;
+                public const string Empty = default;
+                public static bool IsHttps(string address) => throw null;
+                public static bool IsHttps(System.Uri uri) => throw null;
+                public const string Null = default;
+            }
+            public enum ValidationFailure
+            {
+                None = 0,
+                InvalidLifetime = 1,
+                InvalidIssuer = 2,
+            }
+            public static class Validators
+            {
+                public static void ValidateAlgorithm(string algorithm, Microsoft.IdentityModel.Tokens.SecurityKey securityKey, Microsoft.IdentityModel.Tokens.SecurityToken securityToken, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters) => throw null;
+                public static void ValidateAudience(System.Collections.Generic.IEnumerable<string> audiences, Microsoft.IdentityModel.Tokens.SecurityToken securityToken, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters) => throw null;
+                public static string ValidateIssuer(string issuer, Microsoft.IdentityModel.Tokens.SecurityToken securityToken, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters) => throw null;
+                public static void ValidateIssuerSecurityKey(Microsoft.IdentityModel.Tokens.SecurityKey securityKey, Microsoft.IdentityModel.Tokens.SecurityToken securityToken, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters) => throw null;
+                public static void ValidateLifetime(System.DateTime? notBefore, System.DateTime? expires, Microsoft.IdentityModel.Tokens.SecurityToken securityToken, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters) => throw null;
+                public static void ValidateTokenReplay(System.DateTime? expirationTime, string securityToken, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters) => throw null;
+                public static void ValidateTokenReplay(string securityToken, System.DateTime? expirationTime, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters) => throw null;
+                public static string ValidateTokenType(string type, Microsoft.IdentityModel.Tokens.SecurityToken securityToken, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters) => throw null;
+            }
+            public class X509EncryptingCredentials : Microsoft.IdentityModel.Tokens.EncryptingCredentials
+            {
+                public System.Security.Cryptography.X509Certificates.X509Certificate2 Certificate { get => throw null; }
+                public X509EncryptingCredentials(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) : base(default(Microsoft.IdentityModel.Tokens.SymmetricSecurityKey), default(string)) => throw null;
+                public X509EncryptingCredentials(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, string keyWrapAlgorithm, string dataEncryptionAlgorithm) : base(default(Microsoft.IdentityModel.Tokens.SymmetricSecurityKey), default(string)) => throw null;
+            }
+            public class X509SecurityKey : Microsoft.IdentityModel.Tokens.AsymmetricSecurityKey
+            {
+                public override bool CanComputeJwkThumbprint() => throw null;
+                public System.Security.Cryptography.X509Certificates.X509Certificate2 Certificate { get => throw null; }
+                public override byte[] ComputeJwkThumbprint() => throw null;
+                public X509SecurityKey(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) => throw null;
+                public X509SecurityKey(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, string keyId) => throw null;
+                public override bool Equals(object obj) => throw null;
+                public override int GetHashCode() => throw null;
+                public override bool HasPrivateKey { get => throw null; }
+                public override int KeySize { get => throw null; }
+                public System.Security.Cryptography.AsymmetricAlgorithm PrivateKey { get => throw null; }
+                public override Microsoft.IdentityModel.Tokens.PrivateKeyStatus PrivateKeyStatus { get => throw null; }
+                public System.Security.Cryptography.AsymmetricAlgorithm PublicKey { get => throw null; }
+                public string X5t { get => throw null; }
+            }
+            public class X509SigningCredentials : Microsoft.IdentityModel.Tokens.SigningCredentials
+            {
+                public System.Security.Cryptography.X509Certificates.X509Certificate2 Certificate { get => throw null; }
+                public X509SigningCredentials(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) : base(default(System.Security.Cryptography.X509Certificates.X509Certificate2)) => throw null;
+                public X509SigningCredentials(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, string algorithm) : base(default(System.Security.Cryptography.X509Certificates.X509Certificate2)) => throw null;
+            }
+        }
+    }
+}

--- a/csharp/ql/test/resources/stubs/Microsoft.IdentityModel.Tokens/7.5.0/Microsoft.IdentityModel.Tokens.csproj
+++ b/csharp/ql/test/resources/stubs/Microsoft.IdentityModel.Tokens/7.5.0/Microsoft.IdentityModel.Tokens.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputPath>bin\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../Microsoft.IdentityModel.Logging/7.5.0/Microsoft.IdentityModel.Logging.csproj" />
+    <ProjectReference Include="../../_frameworks/Microsoft.NETCore.App/Microsoft.NETCore.App.csproj" />
+  </ItemGroup>
+</Project>

--- a/csharp/ql/test/resources/stubs/Microsoft.SqlServer.Server/1.0.0/Microsoft.SqlServer.Server.cs
+++ b/csharp/ql/test/resources/stubs/Microsoft.SqlServer.Server/1.0.0/Microsoft.SqlServer.Server.cs
@@ -1,0 +1,91 @@
+// This file contains auto-generated code.
+// Generated from `Microsoft.SqlServer.Server, Version=1.0.0.0, Culture=neutral, PublicKeyToken=23ec7fc2d6eaa4a5`.
+namespace Microsoft
+{
+    namespace SqlServer
+    {
+        namespace Server
+        {
+            public enum DataAccessKind
+            {
+                None = 0,
+                Read = 1,
+            }
+            public enum Format
+            {
+                Unknown = 0,
+                Native = 1,
+                UserDefined = 2,
+            }
+            public interface IBinarySerialize
+            {
+                void Read(System.IO.BinaryReader r);
+                void Write(System.IO.BinaryWriter w);
+            }
+            public sealed class InvalidUdtException : System.SystemException
+            {
+                public static Microsoft.SqlServer.Server.InvalidUdtException Create(System.Type udtType, string resourceReason = default(string)) => throw null;
+                public override void GetObjectData(System.Runtime.Serialization.SerializationInfo si, System.Runtime.Serialization.StreamingContext context) => throw null;
+            }
+            [System.AttributeUsage((System.AttributeTargets)10624, AllowMultiple = false, Inherited = false)]
+            public class SqlFacetAttribute : System.Attribute
+            {
+                public SqlFacetAttribute() => throw null;
+                public bool IsFixedLength { get => throw null; set { } }
+                public bool IsNullable { get => throw null; set { } }
+                public int MaxSize { get => throw null; set { } }
+                public int Precision { get => throw null; set { } }
+                public int Scale { get => throw null; set { } }
+            }
+            [System.AttributeUsage((System.AttributeTargets)64, AllowMultiple = false, Inherited = false)]
+            public class SqlFunctionAttribute : System.Attribute
+            {
+                public SqlFunctionAttribute() => throw null;
+                public Microsoft.SqlServer.Server.DataAccessKind DataAccess { get => throw null; set { } }
+                public string FillRowMethodName { get => throw null; set { } }
+                public bool IsDeterministic { get => throw null; set { } }
+                public bool IsPrecise { get => throw null; set { } }
+                public string Name { get => throw null; set { } }
+                public Microsoft.SqlServer.Server.SystemDataAccessKind SystemDataAccess { get => throw null; set { } }
+                public string TableDefinition { get => throw null; set { } }
+            }
+            [System.AttributeUsage((System.AttributeTargets)64, AllowMultiple = false, Inherited = false)]
+            public sealed class SqlMethodAttribute : Microsoft.SqlServer.Server.SqlFunctionAttribute
+            {
+                public SqlMethodAttribute() => throw null;
+                public bool InvokeIfReceiverIsNull { get => throw null; set { } }
+                public bool IsMutator { get => throw null; set { } }
+                public bool OnNullCall { get => throw null; set { } }
+            }
+            [System.AttributeUsage((System.AttributeTargets)12, AllowMultiple = false, Inherited = false)]
+            public sealed class SqlUserDefinedAggregateAttribute : System.Attribute
+            {
+                public SqlUserDefinedAggregateAttribute(Microsoft.SqlServer.Server.Format format) => throw null;
+                public Microsoft.SqlServer.Server.Format Format { get => throw null; }
+                public bool IsInvariantToDuplicates { get => throw null; set { } }
+                public bool IsInvariantToNulls { get => throw null; set { } }
+                public bool IsInvariantToOrder { get => throw null; set { } }
+                public bool IsNullIfEmpty { get => throw null; set { } }
+                public int MaxByteSize { get => throw null; set { } }
+                public const int MaxByteSizeValue = 8000;
+                public string Name { get => throw null; set { } }
+            }
+            [System.AttributeUsage((System.AttributeTargets)12, AllowMultiple = false, Inherited = true)]
+            public sealed class SqlUserDefinedTypeAttribute : System.Attribute
+            {
+                public SqlUserDefinedTypeAttribute(Microsoft.SqlServer.Server.Format format) => throw null;
+                public Microsoft.SqlServer.Server.Format Format { get => throw null; }
+                public bool IsByteOrdered { get => throw null; set { } }
+                public bool IsFixedLength { get => throw null; set { } }
+                public int MaxByteSize { get => throw null; set { } }
+                public string Name { get => throw null; set { } }
+                public string ValidationMethodName { get => throw null; set { } }
+            }
+            public enum SystemDataAccessKind
+            {
+                None = 0,
+                Read = 1,
+            }
+        }
+    }
+}

--- a/csharp/ql/test/resources/stubs/Microsoft.SqlServer.Server/1.0.0/Microsoft.SqlServer.Server.csproj
+++ b/csharp/ql/test/resources/stubs/Microsoft.SqlServer.Server/1.0.0/Microsoft.SqlServer.Server.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputPath>bin\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../_frameworks/Microsoft.NETCore.App/Microsoft.NETCore.App.csproj" />
+  </ItemGroup>
+</Project>

--- a/csharp/ql/test/resources/stubs/System.ClientModel/1.0.0/System.ClientModel.cs
+++ b/csharp/ql/test/resources/stubs/System.ClientModel/1.0.0/System.ClientModel.cs
@@ -1,0 +1,42 @@
+// This file contains auto-generated code.
+// Generated from `System.ClientModel, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8`.
+namespace System
+{
+    namespace ClientModel
+    {
+        namespace Primitives
+        {
+            public interface IJsonModel<T> : System.ClientModel.Primitives.IPersistableModel<T>
+            {
+                T Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options);
+                void Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options);
+            }
+            public interface IPersistableModel<T>
+            {
+                T Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options);
+                string GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options);
+                System.BinaryData Write(System.ClientModel.Primitives.ModelReaderWriterOptions options);
+            }
+            public static class ModelReaderWriter
+            {
+                public static T Read<T>(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options = default(System.ClientModel.Primitives.ModelReaderWriterOptions)) where T : System.ClientModel.Primitives.IPersistableModel<T> => throw null;
+                public static object Read(System.BinaryData data, System.Type returnType, System.ClientModel.Primitives.ModelReaderWriterOptions options = default(System.ClientModel.Primitives.ModelReaderWriterOptions)) => throw null;
+                public static System.BinaryData Write<T>(T model, System.ClientModel.Primitives.ModelReaderWriterOptions options = default(System.ClientModel.Primitives.ModelReaderWriterOptions)) where T : System.ClientModel.Primitives.IPersistableModel<T> => throw null;
+                public static System.BinaryData Write(object model, System.ClientModel.Primitives.ModelReaderWriterOptions options = default(System.ClientModel.Primitives.ModelReaderWriterOptions)) => throw null;
+            }
+            public class ModelReaderWriterOptions
+            {
+                public ModelReaderWriterOptions(string format) => throw null;
+                public string Format { get => throw null; }
+                public static System.ClientModel.Primitives.ModelReaderWriterOptions Json { get => throw null; }
+                public static System.ClientModel.Primitives.ModelReaderWriterOptions Xml { get => throw null; }
+            }
+            [System.AttributeUsage((System.AttributeTargets)4)]
+            public sealed class PersistableModelProxyAttribute : System.Attribute
+            {
+                public PersistableModelProxyAttribute(System.Type proxyType) => throw null;
+                public System.Type ProxyType { get => throw null; }
+            }
+        }
+    }
+}

--- a/csharp/ql/test/resources/stubs/System.ClientModel/1.0.0/System.ClientModel.csproj
+++ b/csharp/ql/test/resources/stubs/System.ClientModel/1.0.0/System.ClientModel.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputPath>bin\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../System.Memory.Data/1.0.2/System.Memory.Data.csproj" />
+    <ProjectReference Include="../../System.Text.Json/4.7.2/System.Text.Json.csproj" />
+    <ProjectReference Include="../../_frameworks/Microsoft.NETCore.App/Microsoft.NETCore.App.csproj" />
+  </ItemGroup>
+</Project>

--- a/csharp/ql/test/resources/stubs/System.Configuration.ConfigurationManager/9.0.4/System.Configuration.ConfigurationManager.csproj
+++ b/csharp/ql/test/resources/stubs/System.Configuration.ConfigurationManager/9.0.4/System.Configuration.ConfigurationManager.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputPath>bin\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../System.Diagnostics.EventLog/9.0.1/System.Diagnostics.EventLog.csproj" />
+    <ProjectReference Include="../../System.Security.Cryptography.ProtectedData/9.0.1/System.Security.Cryptography.ProtectedData.csproj" />
+    <ProjectReference Include="../../_frameworks/Microsoft.NETCore.App/Microsoft.NETCore.App.csproj" />
+  </ItemGroup>
+</Project>

--- a/csharp/ql/test/resources/stubs/System.Diagnostics.DiagnosticSource/6.0.1/System.Diagnostics.DiagnosticSource.csproj
+++ b/csharp/ql/test/resources/stubs/System.Diagnostics.DiagnosticSource/6.0.1/System.Diagnostics.DiagnosticSource.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputPath>bin\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../System.Runtime.CompilerServices.Unsafe/6.0.0/System.Runtime.CompilerServices.Unsafe.csproj" />
+    <ProjectReference Include="../../_frameworks/Microsoft.NETCore.App/Microsoft.NETCore.App.csproj" />
+  </ItemGroup>
+</Project>

--- a/csharp/ql/test/resources/stubs/System.Diagnostics.EventLog/9.0.4/System.Diagnostics.EventLog.csproj
+++ b/csharp/ql/test/resources/stubs/System.Diagnostics.EventLog/9.0.4/System.Diagnostics.EventLog.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputPath>bin\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../_frameworks/Microsoft.NETCore.App/Microsoft.NETCore.App.csproj" />
+  </ItemGroup>
+</Project>

--- a/csharp/ql/test/resources/stubs/System.IdentityModel.Tokens.Jwt/7.5.0/System.IdentityModel.Tokens.Jwt.cs
+++ b/csharp/ql/test/resources/stubs/System.IdentityModel.Tokens.Jwt/7.5.0/System.IdentityModel.Tokens.Jwt.cs
@@ -1,0 +1,227 @@
+// This file contains auto-generated code.
+// Generated from `System.IdentityModel.Tokens.Jwt, Version=7.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35`.
+namespace System
+{
+    namespace IdentityModel
+    {
+        namespace Tokens
+        {
+            namespace Jwt
+            {
+                public static class JsonClaimValueTypes
+                {
+                    public const string Json = default;
+                    public const string JsonArray = default;
+                    public const string JsonNull = default;
+                }
+                public static class JwtConstants
+                {
+                    public const string DirectKeyUseAlg = default;
+                    public const string HeaderType = default;
+                    public const string HeaderTypeAlt = default;
+                    public const string JsonCompactSerializationRegex = default;
+                    public const string JweCompactSerializationRegex = default;
+                    public const string TokenType = default;
+                    public const string TokenTypeAlt = default;
+                }
+                public class JwtHeader : System.Collections.Generic.Dictionary<string, object>
+                {
+                    public string Alg { get => throw null; }
+                    public static System.IdentityModel.Tokens.Jwt.JwtHeader Base64UrlDeserialize(string base64UrlEncodedJsonString) => throw null;
+                    public virtual string Base64UrlEncode() => throw null;
+                    public JwtHeader() => throw null;
+                    public JwtHeader(Microsoft.IdentityModel.Tokens.SigningCredentials signingCredentials) => throw null;
+                    public JwtHeader(Microsoft.IdentityModel.Tokens.EncryptingCredentials encryptingCredentials) => throw null;
+                    public JwtHeader(Microsoft.IdentityModel.Tokens.SigningCredentials signingCredentials, System.Collections.Generic.IDictionary<string, string> outboundAlgorithmMap) => throw null;
+                    public JwtHeader(Microsoft.IdentityModel.Tokens.SigningCredentials signingCredentials, System.Collections.Generic.IDictionary<string, string> outboundAlgorithmMap, string tokenType) => throw null;
+                    public JwtHeader(Microsoft.IdentityModel.Tokens.SigningCredentials signingCredentials, System.Collections.Generic.IDictionary<string, string> outboundAlgorithmMap, string tokenType, System.Collections.Generic.IDictionary<string, object> additionalInnerHeaderClaims) => throw null;
+                    public JwtHeader(Microsoft.IdentityModel.Tokens.EncryptingCredentials encryptingCredentials, System.Collections.Generic.IDictionary<string, string> outboundAlgorithmMap) => throw null;
+                    public JwtHeader(Microsoft.IdentityModel.Tokens.EncryptingCredentials encryptingCredentials, System.Collections.Generic.IDictionary<string, string> outboundAlgorithmMap, string tokenType) => throw null;
+                    public JwtHeader(Microsoft.IdentityModel.Tokens.EncryptingCredentials encryptingCredentials, System.Collections.Generic.IDictionary<string, string> outboundAlgorithmMap, string tokenType, System.Collections.Generic.IDictionary<string, object> additionalHeaderClaims) => throw null;
+                    public string Cty { get => throw null; }
+                    public string Enc { get => throw null; }
+                    public Microsoft.IdentityModel.Tokens.EncryptingCredentials EncryptingCredentials { get => throw null; }
+                    public string IV { get => throw null; }
+                    public string Kid { get => throw null; }
+                    public virtual string SerializeToJson() => throw null;
+                    public Microsoft.IdentityModel.Tokens.SigningCredentials SigningCredentials { get => throw null; }
+                    public string Typ { get => throw null; }
+                    public string X5c { get => throw null; }
+                    public string X5t { get => throw null; }
+                    public string Zip { get => throw null; }
+                }
+                public struct JwtHeaderParameterNames
+                {
+                    public const string Alg = default;
+                    public const string Apu = default;
+                    public const string Apv = default;
+                    public const string Cty = default;
+                    public const string Enc = default;
+                    public const string Epk = default;
+                    public const string IV = default;
+                    public const string Jku = default;
+                    public const string Jwk = default;
+                    public const string Kid = default;
+                    public const string Typ = default;
+                    public const string X5c = default;
+                    public const string X5t = default;
+                    public const string X5u = default;
+                    public const string Zip = default;
+                }
+                public class JwtPayload : System.Collections.Generic.Dictionary<string, object>
+                {
+                    public string Acr { get => throw null; }
+                    public string Actort { get => throw null; }
+                    public void AddClaim(System.Security.Claims.Claim claim) => throw null;
+                    public void AddClaims(System.Collections.Generic.IEnumerable<System.Security.Claims.Claim> claims) => throw null;
+                    public System.Collections.Generic.IList<string> Amr { get => throw null; }
+                    public System.Collections.Generic.IList<string> Aud { get => throw null; }
+                    public int? AuthTime { get => throw null; }
+                    public string Azp { get => throw null; }
+                    public static System.IdentityModel.Tokens.Jwt.JwtPayload Base64UrlDeserialize(string base64UrlEncodedJsonString) => throw null;
+                    public virtual string Base64UrlEncode() => throw null;
+                    public string CHash { get => throw null; }
+                    public virtual System.Collections.Generic.IEnumerable<System.Security.Claims.Claim> Claims { get => throw null; }
+                    public JwtPayload() => throw null;
+                    public JwtPayload(System.Collections.Generic.IEnumerable<System.Security.Claims.Claim> claims) => throw null;
+                    public JwtPayload(string issuer, string audience, System.Collections.Generic.IEnumerable<System.Security.Claims.Claim> claims, System.DateTime? notBefore, System.DateTime? expires) => throw null;
+                    public JwtPayload(string issuer, string audience, System.Collections.Generic.IEnumerable<System.Security.Claims.Claim> claims, System.DateTime? notBefore, System.DateTime? expires, System.DateTime? issuedAt) => throw null;
+                    public JwtPayload(string issuer, string audience, System.Collections.Generic.IEnumerable<System.Security.Claims.Claim> claims, System.Collections.Generic.IDictionary<string, object> claimsCollection, System.DateTime? notBefore, System.DateTime? expires, System.DateTime? issuedAt) => throw null;
+                    public static System.IdentityModel.Tokens.Jwt.JwtPayload Deserialize(string jsonString) => throw null;
+                    public int? Exp { get => throw null; }
+                    public long? Expiration { get => throw null; }
+                    public int? Iat { get => throw null; }
+                    public string Iss { get => throw null; }
+                    public System.DateTime IssuedAt { get => throw null; }
+                    public string Jti { get => throw null; }
+                    public int? Nbf { get => throw null; }
+                    public string Nonce { get => throw null; }
+                    public long? NotBefore { get => throw null; }
+                    public virtual string SerializeToJson() => throw null;
+                    public string Sub { get => throw null; }
+                    public System.DateTime ValidFrom { get => throw null; }
+                    public System.DateTime ValidTo { get => throw null; }
+                }
+                public struct JwtRegisteredClaimNames
+                {
+                    public const string Acr = default;
+                    public const string Actort = default;
+                    public const string Amr = default;
+                    public const string AtHash = default;
+                    public const string Aud = default;
+                    public const string AuthTime = default;
+                    public const string Azp = default;
+                    public const string Birthdate = default;
+                    public const string CHash = default;
+                    public const string Email = default;
+                    public const string Exp = default;
+                    public const string FamilyName = default;
+                    public const string Gender = default;
+                    public const string GivenName = default;
+                    public const string Iat = default;
+                    public const string Iss = default;
+                    public const string Jti = default;
+                    public const string Name = default;
+                    public const string NameId = default;
+                    public const string Nbf = default;
+                    public const string Nonce = default;
+                    public const string Prn = default;
+                    public const string Sid = default;
+                    public const string Sub = default;
+                    public const string Typ = default;
+                    public const string UniqueName = default;
+                    public const string Website = default;
+                }
+                public class JwtSecurityToken : Microsoft.IdentityModel.Tokens.SecurityToken
+                {
+                    public string Actor { get => throw null; }
+                    public System.Collections.Generic.IEnumerable<string> Audiences { get => throw null; }
+                    public System.Collections.Generic.IEnumerable<System.Security.Claims.Claim> Claims { get => throw null; }
+                    public JwtSecurityToken(string jwtEncodedString) => throw null;
+                    public JwtSecurityToken(System.IdentityModel.Tokens.Jwt.JwtHeader header, System.IdentityModel.Tokens.Jwt.JwtPayload payload, string rawHeader, string rawPayload, string rawSignature) => throw null;
+                    public JwtSecurityToken(System.IdentityModel.Tokens.Jwt.JwtHeader header, System.IdentityModel.Tokens.Jwt.JwtSecurityToken innerToken, string rawHeader, string rawEncryptedKey, string rawInitializationVector, string rawCiphertext, string rawAuthenticationTag) => throw null;
+                    public JwtSecurityToken(System.IdentityModel.Tokens.Jwt.JwtHeader header, System.IdentityModel.Tokens.Jwt.JwtPayload payload) => throw null;
+                    public JwtSecurityToken(string issuer = default(string), string audience = default(string), System.Collections.Generic.IEnumerable<System.Security.Claims.Claim> claims = default(System.Collections.Generic.IEnumerable<System.Security.Claims.Claim>), System.DateTime? notBefore = default(System.DateTime?), System.DateTime? expires = default(System.DateTime?), Microsoft.IdentityModel.Tokens.SigningCredentials signingCredentials = default(Microsoft.IdentityModel.Tokens.SigningCredentials)) => throw null;
+                    public virtual string EncodedHeader { get => throw null; }
+                    public virtual string EncodedPayload { get => throw null; }
+                    public Microsoft.IdentityModel.Tokens.EncryptingCredentials EncryptingCredentials { get => throw null; }
+                    public System.IdentityModel.Tokens.Jwt.JwtHeader Header { get => throw null; }
+                    public override string Id { get => throw null; }
+                    public System.IdentityModel.Tokens.Jwt.JwtSecurityToken InnerToken { get => throw null; }
+                    public virtual System.DateTime IssuedAt { get => throw null; }
+                    public override string Issuer { get => throw null; }
+                    public System.IdentityModel.Tokens.Jwt.JwtPayload Payload { get => throw null; }
+                    public string RawAuthenticationTag { get => throw null; }
+                    public string RawCiphertext { get => throw null; }
+                    public string RawData { get => throw null; }
+                    public string RawEncryptedKey { get => throw null; }
+                    public string RawHeader { get => throw null; }
+                    public string RawInitializationVector { get => throw null; }
+                    public string RawPayload { get => throw null; }
+                    public string RawSignature { get => throw null; }
+                    public override Microsoft.IdentityModel.Tokens.SecurityKey SecurityKey { get => throw null; }
+                    public string SignatureAlgorithm { get => throw null; }
+                    public Microsoft.IdentityModel.Tokens.SigningCredentials SigningCredentials { get => throw null; }
+                    public override Microsoft.IdentityModel.Tokens.SecurityKey SigningKey { get => throw null; set { } }
+                    public string Subject { get => throw null; }
+                    public override string ToString() => throw null;
+                    public override string UnsafeToString() => throw null;
+                    public override System.DateTime ValidFrom { get => throw null; }
+                    public override System.DateTime ValidTo { get => throw null; }
+                }
+                public static class JwtSecurityTokenConverter
+                {
+                    public static System.IdentityModel.Tokens.Jwt.JwtSecurityToken Convert(Microsoft.IdentityModel.JsonWebTokens.JsonWebToken token) => throw null;
+                }
+                public class JwtSecurityTokenHandler : Microsoft.IdentityModel.Tokens.SecurityTokenHandler
+                {
+                    public override bool CanReadToken(string token) => throw null;
+                    public override bool CanValidateToken { get => throw null; }
+                    public override bool CanWriteToken { get => throw null; }
+                    protected virtual string CreateActorValue(System.Security.Claims.ClaimsIdentity actor) => throw null;
+                    protected virtual System.Security.Claims.ClaimsIdentity CreateClaimsIdentity(System.IdentityModel.Tokens.Jwt.JwtSecurityToken jwtToken, string issuer, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters) => throw null;
+                    public virtual string CreateEncodedJwt(Microsoft.IdentityModel.Tokens.SecurityTokenDescriptor tokenDescriptor) => throw null;
+                    public virtual string CreateEncodedJwt(string issuer, string audience, System.Security.Claims.ClaimsIdentity subject, System.DateTime? notBefore, System.DateTime? expires, System.DateTime? issuedAt, Microsoft.IdentityModel.Tokens.SigningCredentials signingCredentials) => throw null;
+                    public virtual string CreateEncodedJwt(string issuer, string audience, System.Security.Claims.ClaimsIdentity subject, System.DateTime? notBefore, System.DateTime? expires, System.DateTime? issuedAt, Microsoft.IdentityModel.Tokens.SigningCredentials signingCredentials, Microsoft.IdentityModel.Tokens.EncryptingCredentials encryptingCredentials) => throw null;
+                    public virtual string CreateEncodedJwt(string issuer, string audience, System.Security.Claims.ClaimsIdentity subject, System.DateTime? notBefore, System.DateTime? expires, System.DateTime? issuedAt, Microsoft.IdentityModel.Tokens.SigningCredentials signingCredentials, Microsoft.IdentityModel.Tokens.EncryptingCredentials encryptingCredentials, System.Collections.Generic.IDictionary<string, object> claimCollection) => throw null;
+                    public virtual System.IdentityModel.Tokens.Jwt.JwtSecurityToken CreateJwtSecurityToken(Microsoft.IdentityModel.Tokens.SecurityTokenDescriptor tokenDescriptor) => throw null;
+                    public virtual System.IdentityModel.Tokens.Jwt.JwtSecurityToken CreateJwtSecurityToken(string issuer, string audience, System.Security.Claims.ClaimsIdentity subject, System.DateTime? notBefore, System.DateTime? expires, System.DateTime? issuedAt, Microsoft.IdentityModel.Tokens.SigningCredentials signingCredentials, Microsoft.IdentityModel.Tokens.EncryptingCredentials encryptingCredentials) => throw null;
+                    public virtual System.IdentityModel.Tokens.Jwt.JwtSecurityToken CreateJwtSecurityToken(string issuer, string audience, System.Security.Claims.ClaimsIdentity subject, System.DateTime? notBefore, System.DateTime? expires, System.DateTime? issuedAt, Microsoft.IdentityModel.Tokens.SigningCredentials signingCredentials, Microsoft.IdentityModel.Tokens.EncryptingCredentials encryptingCredentials, System.Collections.Generic.IDictionary<string, object> claimCollection) => throw null;
+                    public virtual System.IdentityModel.Tokens.Jwt.JwtSecurityToken CreateJwtSecurityToken(string issuer = default(string), string audience = default(string), System.Security.Claims.ClaimsIdentity subject = default(System.Security.Claims.ClaimsIdentity), System.DateTime? notBefore = default(System.DateTime?), System.DateTime? expires = default(System.DateTime?), System.DateTime? issuedAt = default(System.DateTime?), Microsoft.IdentityModel.Tokens.SigningCredentials signingCredentials = default(Microsoft.IdentityModel.Tokens.SigningCredentials)) => throw null;
+                    public override Microsoft.IdentityModel.Tokens.SecurityToken CreateToken(Microsoft.IdentityModel.Tokens.SecurityTokenDescriptor tokenDescriptor) => throw null;
+                    public JwtSecurityTokenHandler() => throw null;
+                    protected string DecryptToken(System.IdentityModel.Tokens.Jwt.JwtSecurityToken jwtToken, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters) => throw null;
+                    public static System.Collections.Generic.ISet<string> DefaultInboundClaimFilter;
+                    public static System.Collections.Generic.IDictionary<string, string> DefaultInboundClaimTypeMap;
+                    public static bool DefaultMapInboundClaims;
+                    public static System.Collections.Generic.IDictionary<string, string> DefaultOutboundAlgorithmMap;
+                    public static System.Collections.Generic.IDictionary<string, string> DefaultOutboundClaimTypeMap;
+                    public System.Collections.Generic.ISet<string> InboundClaimFilter { get => throw null; set { } }
+                    public System.Collections.Generic.IDictionary<string, string> InboundClaimTypeMap { get => throw null; set { } }
+                    public static string JsonClaimTypeProperty { get => throw null; set { } }
+                    public bool MapInboundClaims { get => throw null; set { } }
+                    public System.Collections.Generic.IDictionary<string, string> OutboundAlgorithmMap { get => throw null; }
+                    public System.Collections.Generic.IDictionary<string, string> OutboundClaimTypeMap { get => throw null; set { } }
+                    public System.IdentityModel.Tokens.Jwt.JwtSecurityToken ReadJwtToken(string token) => throw null;
+                    public override Microsoft.IdentityModel.Tokens.SecurityToken ReadToken(string token) => throw null;
+                    public override Microsoft.IdentityModel.Tokens.SecurityToken ReadToken(System.Xml.XmlReader reader, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters) => throw null;
+                    protected virtual Microsoft.IdentityModel.Tokens.SecurityKey ResolveIssuerSigningKey(string token, System.IdentityModel.Tokens.Jwt.JwtSecurityToken jwtToken, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters) => throw null;
+                    protected virtual Microsoft.IdentityModel.Tokens.SecurityKey ResolveTokenDecryptionKey(string token, System.IdentityModel.Tokens.Jwt.JwtSecurityToken jwtToken, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters) => throw null;
+                    public static string ShortClaimTypeProperty { get => throw null; set { } }
+                    public override System.Type TokenType { get => throw null; }
+                    protected virtual void ValidateAudience(System.Collections.Generic.IEnumerable<string> audiences, System.IdentityModel.Tokens.Jwt.JwtSecurityToken jwtToken, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters) => throw null;
+                    protected virtual string ValidateIssuer(string issuer, System.IdentityModel.Tokens.Jwt.JwtSecurityToken jwtToken, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters) => throw null;
+                    protected virtual void ValidateIssuerSecurityKey(Microsoft.IdentityModel.Tokens.SecurityKey key, System.IdentityModel.Tokens.Jwt.JwtSecurityToken securityToken, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters) => throw null;
+                    protected virtual void ValidateLifetime(System.DateTime? notBefore, System.DateTime? expires, System.IdentityModel.Tokens.Jwt.JwtSecurityToken jwtToken, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters) => throw null;
+                    protected virtual System.IdentityModel.Tokens.Jwt.JwtSecurityToken ValidateSignature(string token, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters) => throw null;
+                    public override System.Security.Claims.ClaimsPrincipal ValidateToken(string token, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters, out Microsoft.IdentityModel.Tokens.SecurityToken validatedToken) => throw null;
+                    public override System.Threading.Tasks.Task<Microsoft.IdentityModel.Tokens.TokenValidationResult> ValidateTokenAsync(string token, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters) => throw null;
+                    protected System.Security.Claims.ClaimsPrincipal ValidateTokenPayload(System.IdentityModel.Tokens.Jwt.JwtSecurityToken jwtToken, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters) => throw null;
+                    protected virtual void ValidateTokenReplay(System.DateTime? expires, string securityToken, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters) => throw null;
+                    public override string WriteToken(Microsoft.IdentityModel.Tokens.SecurityToken token) => throw null;
+                    public override void WriteToken(System.Xml.XmlWriter writer, Microsoft.IdentityModel.Tokens.SecurityToken token) => throw null;
+                }
+            }
+        }
+    }
+}

--- a/csharp/ql/test/resources/stubs/System.IdentityModel.Tokens.Jwt/7.5.0/System.IdentityModel.Tokens.Jwt.csproj
+++ b/csharp/ql/test/resources/stubs/System.IdentityModel.Tokens.Jwt/7.5.0/System.IdentityModel.Tokens.Jwt.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputPath>bin\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../Microsoft.IdentityModel.JsonWebTokens/7.5.0/Microsoft.IdentityModel.JsonWebTokens.csproj" />
+    <ProjectReference Include="../../Microsoft.IdentityModel.Tokens/7.5.0/Microsoft.IdentityModel.Tokens.csproj" />
+    <ProjectReference Include="../../_frameworks/Microsoft.NETCore.App/Microsoft.NETCore.App.csproj" />
+  </ItemGroup>
+</Project>

--- a/csharp/ql/test/resources/stubs/System.Memory.Data/1.0.2/System.Memory.Data.cs
+++ b/csharp/ql/test/resources/stubs/System.Memory.Data/1.0.2/System.Memory.Data.cs
@@ -1,0 +1,27 @@
+// This file contains auto-generated code.
+// Generated from `System.Memory.Data, Version=1.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51`.
+namespace System
+{
+    public class BinaryData
+    {
+        public BinaryData(byte[] data) => throw null;
+        public BinaryData(object jsonSerializable, System.Text.Json.JsonSerializerOptions options = default(System.Text.Json.JsonSerializerOptions), System.Type type = default(System.Type)) => throw null;
+        public BinaryData(System.ReadOnlyMemory<byte> data) => throw null;
+        public BinaryData(string data) => throw null;
+        public override bool Equals(object obj) => throw null;
+        public static System.BinaryData FromBytes(System.ReadOnlyMemory<byte> data) => throw null;
+        public static System.BinaryData FromBytes(byte[] data) => throw null;
+        public static System.BinaryData FromObjectAsJson<T>(T jsonSerializable, System.Text.Json.JsonSerializerOptions options = default(System.Text.Json.JsonSerializerOptions)) => throw null;
+        public static System.BinaryData FromStream(System.IO.Stream stream) => throw null;
+        public static System.Threading.Tasks.Task<System.BinaryData> FromStreamAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) => throw null;
+        public static System.BinaryData FromString(string data) => throw null;
+        public override int GetHashCode() => throw null;
+        public static implicit operator System.ReadOnlyMemory<byte>(System.BinaryData data) => throw null;
+        public static implicit operator System.ReadOnlySpan<byte>(System.BinaryData data) => throw null;
+        public byte[] ToArray() => throw null;
+        public System.ReadOnlyMemory<byte> ToMemory() => throw null;
+        public T ToObjectFromJson<T>(System.Text.Json.JsonSerializerOptions options = default(System.Text.Json.JsonSerializerOptions)) => throw null;
+        public System.IO.Stream ToStream() => throw null;
+        public override string ToString() => throw null;
+    }
+}

--- a/csharp/ql/test/resources/stubs/System.Memory.Data/1.0.2/System.Memory.Data.csproj
+++ b/csharp/ql/test/resources/stubs/System.Memory.Data/1.0.2/System.Memory.Data.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputPath>bin\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../System.Text.Encodings.Web/4.7.2/System.Text.Encodings.Web.csproj" />
+    <ProjectReference Include="../../System.Text.Json/4.7.2/System.Text.Json.csproj" />
+    <ProjectReference Include="../../_frameworks/Microsoft.NETCore.App/Microsoft.NETCore.App.csproj" />
+  </ItemGroup>
+</Project>

--- a/csharp/ql/test/resources/stubs/System.Memory/4.5.4/System.Memory.csproj
+++ b/csharp/ql/test/resources/stubs/System.Memory/4.5.4/System.Memory.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputPath>bin\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../_frameworks/Microsoft.NETCore.App/Microsoft.NETCore.App.csproj" />
+  </ItemGroup>
+</Project>

--- a/csharp/ql/test/resources/stubs/System.Numerics.Vectors/4.5.0/System.Numerics.Vectors.csproj
+++ b/csharp/ql/test/resources/stubs/System.Numerics.Vectors/4.5.0/System.Numerics.Vectors.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputPath>bin\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../_frameworks/Microsoft.NETCore.App/Microsoft.NETCore.App.csproj" />
+  </ItemGroup>
+</Project>

--- a/csharp/ql/test/resources/stubs/System.Runtime.CompilerServices.Unsafe/6.0.0/System.Runtime.CompilerServices.Unsafe.csproj
+++ b/csharp/ql/test/resources/stubs/System.Runtime.CompilerServices.Unsafe/6.0.0/System.Runtime.CompilerServices.Unsafe.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputPath>bin\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../_frameworks/Microsoft.NETCore.App/Microsoft.NETCore.App.csproj" />
+  </ItemGroup>
+</Project>

--- a/csharp/ql/test/resources/stubs/System.Security.Cryptography.Pkcs/9.0.4/System.Security.Cryptography.Pkcs.cs
+++ b/csharp/ql/test/resources/stubs/System.Security.Cryptography.Pkcs/9.0.4/System.Security.Cryptography.Pkcs.cs
@@ -1,0 +1,503 @@
+// This file contains auto-generated code.
+// Generated from `System.Security.Cryptography.Pkcs, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a`.
+namespace System
+{
+    namespace Security
+    {
+        namespace Cryptography
+        {
+            public sealed class CryptographicAttributeObject
+            {
+                public CryptographicAttributeObject(System.Security.Cryptography.Oid oid) => throw null;
+                public CryptographicAttributeObject(System.Security.Cryptography.Oid oid, System.Security.Cryptography.AsnEncodedDataCollection values) => throw null;
+                public System.Security.Cryptography.Oid Oid { get => throw null; }
+                public System.Security.Cryptography.AsnEncodedDataCollection Values { get => throw null; }
+            }
+            public sealed class CryptographicAttributeObjectCollection : System.Collections.ICollection, System.Collections.IEnumerable
+            {
+                public int Add(System.Security.Cryptography.AsnEncodedData asnEncodedData) => throw null;
+                public int Add(System.Security.Cryptography.CryptographicAttributeObject attribute) => throw null;
+                void System.Collections.ICollection.CopyTo(System.Array array, int index) => throw null;
+                public void CopyTo(System.Security.Cryptography.CryptographicAttributeObject[] array, int index) => throw null;
+                public int Count { get => throw null; }
+                public CryptographicAttributeObjectCollection() => throw null;
+                public CryptographicAttributeObjectCollection(System.Security.Cryptography.CryptographicAttributeObject attribute) => throw null;
+                public System.Security.Cryptography.CryptographicAttributeObjectEnumerator GetEnumerator() => throw null;
+                System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null;
+                public bool IsSynchronized { get => throw null; }
+                public void Remove(System.Security.Cryptography.CryptographicAttributeObject attribute) => throw null;
+                public object SyncRoot { get => throw null; }
+                public System.Security.Cryptography.CryptographicAttributeObject this[int index] { get => throw null; }
+            }
+            public sealed class CryptographicAttributeObjectEnumerator : System.Collections.IEnumerator
+            {
+                public System.Security.Cryptography.CryptographicAttributeObject Current { get => throw null; }
+                object System.Collections.IEnumerator.Current { get => throw null; }
+                public bool MoveNext() => throw null;
+                public void Reset() => throw null;
+            }
+            namespace Pkcs
+            {
+                public sealed class AlgorithmIdentifier
+                {
+                    public AlgorithmIdentifier() => throw null;
+                    public AlgorithmIdentifier(System.Security.Cryptography.Oid oid) => throw null;
+                    public AlgorithmIdentifier(System.Security.Cryptography.Oid oid, int keyLength) => throw null;
+                    public int KeyLength { get => throw null; set { } }
+                    public System.Security.Cryptography.Oid Oid { get => throw null; set { } }
+                    public byte[] Parameters { get => throw null; set { } }
+                }
+                public sealed class CmsRecipient
+                {
+                    public System.Security.Cryptography.X509Certificates.X509Certificate2 Certificate { get => throw null; }
+                    public CmsRecipient(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) => throw null;
+                    public CmsRecipient(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, System.Security.Cryptography.RSAEncryptionPadding rsaEncryptionPadding) => throw null;
+                    public CmsRecipient(System.Security.Cryptography.Pkcs.SubjectIdentifierType recipientIdentifierType, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, System.Security.Cryptography.RSAEncryptionPadding rsaEncryptionPadding) => throw null;
+                    public CmsRecipient(System.Security.Cryptography.Pkcs.SubjectIdentifierType recipientIdentifierType, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) => throw null;
+                    public System.Security.Cryptography.Pkcs.SubjectIdentifierType RecipientIdentifierType { get => throw null; }
+                    public System.Security.Cryptography.RSAEncryptionPadding RSAEncryptionPadding { get => throw null; }
+                }
+                public sealed class CmsRecipientCollection : System.Collections.ICollection, System.Collections.IEnumerable
+                {
+                    public int Add(System.Security.Cryptography.Pkcs.CmsRecipient recipient) => throw null;
+                    public void CopyTo(System.Array array, int index) => throw null;
+                    public void CopyTo(System.Security.Cryptography.Pkcs.CmsRecipient[] array, int index) => throw null;
+                    public int Count { get => throw null; }
+                    public CmsRecipientCollection() => throw null;
+                    public CmsRecipientCollection(System.Security.Cryptography.Pkcs.CmsRecipient recipient) => throw null;
+                    public CmsRecipientCollection(System.Security.Cryptography.Pkcs.SubjectIdentifierType recipientIdentifierType, System.Security.Cryptography.X509Certificates.X509Certificate2Collection certificates) => throw null;
+                    public System.Security.Cryptography.Pkcs.CmsRecipientEnumerator GetEnumerator() => throw null;
+                    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null;
+                    public bool IsSynchronized { get => throw null; }
+                    public void Remove(System.Security.Cryptography.Pkcs.CmsRecipient recipient) => throw null;
+                    public object SyncRoot { get => throw null; }
+                    public System.Security.Cryptography.Pkcs.CmsRecipient this[int index] { get => throw null; }
+                }
+                public sealed class CmsRecipientEnumerator : System.Collections.IEnumerator
+                {
+                    public System.Security.Cryptography.Pkcs.CmsRecipient Current { get => throw null; }
+                    object System.Collections.IEnumerator.Current { get => throw null; }
+                    public bool MoveNext() => throw null;
+                    public void Reset() => throw null;
+                }
+                public sealed class CmsSigner
+                {
+                    public System.Security.Cryptography.X509Certificates.X509Certificate2 Certificate { get => throw null; set { } }
+                    public System.Security.Cryptography.X509Certificates.X509Certificate2Collection Certificates { get => throw null; }
+                    public CmsSigner() => throw null;
+                    public CmsSigner(System.Security.Cryptography.Pkcs.SubjectIdentifierType signerIdentifierType) => throw null;
+                    public CmsSigner(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) => throw null;
+                    public CmsSigner(System.Security.Cryptography.CspParameters parameters) => throw null;
+                    public CmsSigner(System.Security.Cryptography.Pkcs.SubjectIdentifierType signerIdentifierType, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) => throw null;
+                    public CmsSigner(System.Security.Cryptography.Pkcs.SubjectIdentifierType signerIdentifierType, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, System.Security.Cryptography.AsymmetricAlgorithm privateKey) => throw null;
+                    public CmsSigner(System.Security.Cryptography.Pkcs.SubjectIdentifierType signerIdentifierType, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, System.Security.Cryptography.RSA privateKey, System.Security.Cryptography.RSASignaturePadding signaturePadding) => throw null;
+                    public System.Security.Cryptography.Oid DigestAlgorithm { get => throw null; set { } }
+                    public System.Security.Cryptography.X509Certificates.X509IncludeOption IncludeOption { get => throw null; set { } }
+                    public System.Security.Cryptography.AsymmetricAlgorithm PrivateKey { get => throw null; set { } }
+                    public System.Security.Cryptography.RSASignaturePadding SignaturePadding { get => throw null; set { } }
+                    public System.Security.Cryptography.CryptographicAttributeObjectCollection SignedAttributes { get => throw null; }
+                    public System.Security.Cryptography.Pkcs.SubjectIdentifierType SignerIdentifierType { get => throw null; set { } }
+                    public System.Security.Cryptography.CryptographicAttributeObjectCollection UnsignedAttributes { get => throw null; }
+                }
+                public sealed class ContentInfo
+                {
+                    public byte[] Content { get => throw null; }
+                    public System.Security.Cryptography.Oid ContentType { get => throw null; }
+                    public ContentInfo(byte[] content) => throw null;
+                    public ContentInfo(System.Security.Cryptography.Oid contentType, byte[] content) => throw null;
+                    public static System.Security.Cryptography.Oid GetContentType(byte[] encodedMessage) => throw null;
+                    public static System.Security.Cryptography.Oid GetContentType(System.ReadOnlySpan<byte> encodedMessage) => throw null;
+                }
+                public sealed class EnvelopedCms
+                {
+                    public System.Security.Cryptography.X509Certificates.X509Certificate2Collection Certificates { get => throw null; }
+                    public System.Security.Cryptography.Pkcs.AlgorithmIdentifier ContentEncryptionAlgorithm { get => throw null; }
+                    public System.Security.Cryptography.Pkcs.ContentInfo ContentInfo { get => throw null; }
+                    public EnvelopedCms() => throw null;
+                    public EnvelopedCms(System.Security.Cryptography.Pkcs.ContentInfo contentInfo) => throw null;
+                    public EnvelopedCms(System.Security.Cryptography.Pkcs.ContentInfo contentInfo, System.Security.Cryptography.Pkcs.AlgorithmIdentifier encryptionAlgorithm) => throw null;
+                    public void Decode(byte[] encodedMessage) => throw null;
+                    public void Decode(System.ReadOnlySpan<byte> encodedMessage) => throw null;
+                    public void Decrypt() => throw null;
+                    public void Decrypt(System.Security.Cryptography.Pkcs.RecipientInfo recipientInfo) => throw null;
+                    public void Decrypt(System.Security.Cryptography.Pkcs.RecipientInfo recipientInfo, System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraStore) => throw null;
+                    public void Decrypt(System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraStore) => throw null;
+                    public void Decrypt(System.Security.Cryptography.Pkcs.RecipientInfo recipientInfo, System.Security.Cryptography.AsymmetricAlgorithm privateKey) => throw null;
+                    public byte[] Encode() => throw null;
+                    public void Encrypt(System.Security.Cryptography.Pkcs.CmsRecipient recipient) => throw null;
+                    public void Encrypt(System.Security.Cryptography.Pkcs.CmsRecipientCollection recipients) => throw null;
+                    public System.Security.Cryptography.Pkcs.RecipientInfoCollection RecipientInfos { get => throw null; }
+                    public System.Security.Cryptography.CryptographicAttributeObjectCollection UnprotectedAttributes { get => throw null; }
+                    public int Version { get => throw null; }
+                }
+                public sealed class KeyAgreeRecipientInfo : System.Security.Cryptography.Pkcs.RecipientInfo
+                {
+                    public System.DateTime Date { get => throw null; }
+                    public override byte[] EncryptedKey { get => throw null; }
+                    public override System.Security.Cryptography.Pkcs.AlgorithmIdentifier KeyEncryptionAlgorithm { get => throw null; }
+                    public System.Security.Cryptography.Pkcs.SubjectIdentifierOrKey OriginatorIdentifierOrKey { get => throw null; }
+                    public System.Security.Cryptography.CryptographicAttributeObject OtherKeyAttribute { get => throw null; }
+                    public override System.Security.Cryptography.Pkcs.SubjectIdentifier RecipientIdentifier { get => throw null; }
+                    public override int Version { get => throw null; }
+                }
+                public sealed class KeyTransRecipientInfo : System.Security.Cryptography.Pkcs.RecipientInfo
+                {
+                    public override byte[] EncryptedKey { get => throw null; }
+                    public override System.Security.Cryptography.Pkcs.AlgorithmIdentifier KeyEncryptionAlgorithm { get => throw null; }
+                    public override System.Security.Cryptography.Pkcs.SubjectIdentifier RecipientIdentifier { get => throw null; }
+                    public override int Version { get => throw null; }
+                }
+                public sealed class Pkcs12Builder
+                {
+                    public void AddSafeContentsEncrypted(System.Security.Cryptography.Pkcs.Pkcs12SafeContents safeContents, byte[] passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters) => throw null;
+                    public void AddSafeContentsEncrypted(System.Security.Cryptography.Pkcs.Pkcs12SafeContents safeContents, System.ReadOnlySpan<byte> passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters) => throw null;
+                    public void AddSafeContentsEncrypted(System.Security.Cryptography.Pkcs.Pkcs12SafeContents safeContents, string password, System.Security.Cryptography.PbeParameters pbeParameters) => throw null;
+                    public void AddSafeContentsEncrypted(System.Security.Cryptography.Pkcs.Pkcs12SafeContents safeContents, System.ReadOnlySpan<char> password, System.Security.Cryptography.PbeParameters pbeParameters) => throw null;
+                    public void AddSafeContentsUnencrypted(System.Security.Cryptography.Pkcs.Pkcs12SafeContents safeContents) => throw null;
+                    public Pkcs12Builder() => throw null;
+                    public byte[] Encode() => throw null;
+                    public bool IsSealed { get => throw null; }
+                    public void SealWithMac(string password, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, int iterationCount) => throw null;
+                    public void SealWithMac(System.ReadOnlySpan<char> password, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, int iterationCount) => throw null;
+                    public void SealWithoutIntegrity() => throw null;
+                    public bool TryEncode(System.Span<byte> destination, out int bytesWritten) => throw null;
+                }
+                public sealed class Pkcs12CertBag : System.Security.Cryptography.Pkcs.Pkcs12SafeBag
+                {
+                    public Pkcs12CertBag(System.Security.Cryptography.Oid certificateType, System.ReadOnlyMemory<byte> encodedCertificate) : base(default(string), default(System.ReadOnlyMemory<byte>), default(bool)) => throw null;
+                    public System.ReadOnlyMemory<byte> EncodedCertificate { get => throw null; }
+                    public System.Security.Cryptography.X509Certificates.X509Certificate2 GetCertificate() => throw null;
+                    public System.Security.Cryptography.Oid GetCertificateType() => throw null;
+                    public bool IsX509Certificate { get => throw null; }
+                }
+                public enum Pkcs12ConfidentialityMode
+                {
+                    Unknown = 0,
+                    None = 1,
+                    Password = 2,
+                    PublicKey = 3,
+                }
+                public sealed class Pkcs12Info
+                {
+                    public System.Collections.ObjectModel.ReadOnlyCollection<System.Security.Cryptography.Pkcs.Pkcs12SafeContents> AuthenticatedSafe { get => throw null; }
+                    public static System.Security.Cryptography.Pkcs.Pkcs12Info Decode(System.ReadOnlyMemory<byte> encodedBytes, out int bytesConsumed, bool skipCopy = default(bool)) => throw null;
+                    public System.Security.Cryptography.Pkcs.Pkcs12IntegrityMode IntegrityMode { get => throw null; }
+                    public bool VerifyMac(string password) => throw null;
+                    public bool VerifyMac(System.ReadOnlySpan<char> password) => throw null;
+                }
+                public enum Pkcs12IntegrityMode
+                {
+                    Unknown = 0,
+                    None = 1,
+                    Password = 2,
+                    PublicKey = 3,
+                }
+                public sealed class Pkcs12KeyBag : System.Security.Cryptography.Pkcs.Pkcs12SafeBag
+                {
+                    public Pkcs12KeyBag(System.ReadOnlyMemory<byte> pkcs8PrivateKey, bool skipCopy = default(bool)) : base(default(string), default(System.ReadOnlyMemory<byte>), default(bool)) => throw null;
+                    public System.ReadOnlyMemory<byte> Pkcs8PrivateKey { get => throw null; }
+                }
+                public abstract class Pkcs12SafeBag
+                {
+                    public System.Security.Cryptography.CryptographicAttributeObjectCollection Attributes { get => throw null; }
+                    protected Pkcs12SafeBag(string bagIdValue, System.ReadOnlyMemory<byte> encodedBagValue, bool skipCopy = default(bool)) => throw null;
+                    public byte[] Encode() => throw null;
+                    public System.ReadOnlyMemory<byte> EncodedBagValue { get => throw null; }
+                    public System.Security.Cryptography.Oid GetBagId() => throw null;
+                    public bool TryEncode(System.Span<byte> destination, out int bytesWritten) => throw null;
+                }
+                public sealed class Pkcs12SafeContents
+                {
+                    public System.Security.Cryptography.Pkcs.Pkcs12CertBag AddCertificate(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) => throw null;
+                    public System.Security.Cryptography.Pkcs.Pkcs12KeyBag AddKeyUnencrypted(System.Security.Cryptography.AsymmetricAlgorithm key) => throw null;
+                    public System.Security.Cryptography.Pkcs.Pkcs12SafeContentsBag AddNestedContents(System.Security.Cryptography.Pkcs.Pkcs12SafeContents safeContents) => throw null;
+                    public void AddSafeBag(System.Security.Cryptography.Pkcs.Pkcs12SafeBag safeBag) => throw null;
+                    public System.Security.Cryptography.Pkcs.Pkcs12SecretBag AddSecret(System.Security.Cryptography.Oid secretType, System.ReadOnlyMemory<byte> secretValue) => throw null;
+                    public System.Security.Cryptography.Pkcs.Pkcs12ShroudedKeyBag AddShroudedKey(System.Security.Cryptography.AsymmetricAlgorithm key, byte[] passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters) => throw null;
+                    public System.Security.Cryptography.Pkcs.Pkcs12ShroudedKeyBag AddShroudedKey(System.Security.Cryptography.AsymmetricAlgorithm key, System.ReadOnlySpan<byte> passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters) => throw null;
+                    public System.Security.Cryptography.Pkcs.Pkcs12ShroudedKeyBag AddShroudedKey(System.Security.Cryptography.AsymmetricAlgorithm key, string password, System.Security.Cryptography.PbeParameters pbeParameters) => throw null;
+                    public System.Security.Cryptography.Pkcs.Pkcs12ShroudedKeyBag AddShroudedKey(System.Security.Cryptography.AsymmetricAlgorithm key, System.ReadOnlySpan<char> password, System.Security.Cryptography.PbeParameters pbeParameters) => throw null;
+                    public System.Security.Cryptography.Pkcs.Pkcs12ConfidentialityMode ConfidentialityMode { get => throw null; }
+                    public Pkcs12SafeContents() => throw null;
+                    public void Decrypt(byte[] passwordBytes) => throw null;
+                    public void Decrypt(System.ReadOnlySpan<byte> passwordBytes) => throw null;
+                    public void Decrypt(string password) => throw null;
+                    public void Decrypt(System.ReadOnlySpan<char> password) => throw null;
+                    public System.Collections.Generic.IEnumerable<System.Security.Cryptography.Pkcs.Pkcs12SafeBag> GetBags() => throw null;
+                    public bool IsReadOnly { get => throw null; }
+                }
+                public sealed class Pkcs12SafeContentsBag : System.Security.Cryptography.Pkcs.Pkcs12SafeBag
+                {
+                    public System.Security.Cryptography.Pkcs.Pkcs12SafeContents SafeContents { get => throw null; }
+                    internal Pkcs12SafeContentsBag() : base(default(string), default(System.ReadOnlyMemory<byte>), default(bool)) { }
+                }
+                public sealed class Pkcs12SecretBag : System.Security.Cryptography.Pkcs.Pkcs12SafeBag
+                {
+                    public System.Security.Cryptography.Oid GetSecretType() => throw null;
+                    public System.ReadOnlyMemory<byte> SecretValue { get => throw null; }
+                    internal Pkcs12SecretBag() : base(default(string), default(System.ReadOnlyMemory<byte>), default(bool)) { }
+                }
+                public sealed class Pkcs12ShroudedKeyBag : System.Security.Cryptography.Pkcs.Pkcs12SafeBag
+                {
+                    public Pkcs12ShroudedKeyBag(System.ReadOnlyMemory<byte> encryptedPkcs8PrivateKey, bool skipCopy = default(bool)) : base(default(string), default(System.ReadOnlyMemory<byte>), default(bool)) => throw null;
+                    public System.ReadOnlyMemory<byte> EncryptedPkcs8PrivateKey { get => throw null; }
+                }
+                public sealed class Pkcs8PrivateKeyInfo
+                {
+                    public System.Security.Cryptography.Oid AlgorithmId { get => throw null; }
+                    public System.ReadOnlyMemory<byte>? AlgorithmParameters { get => throw null; }
+                    public System.Security.Cryptography.CryptographicAttributeObjectCollection Attributes { get => throw null; }
+                    public static System.Security.Cryptography.Pkcs.Pkcs8PrivateKeyInfo Create(System.Security.Cryptography.AsymmetricAlgorithm privateKey) => throw null;
+                    public Pkcs8PrivateKeyInfo(System.Security.Cryptography.Oid algorithmId, System.ReadOnlyMemory<byte>? algorithmParameters, System.ReadOnlyMemory<byte> privateKey, bool skipCopies = default(bool)) => throw null;
+                    public static System.Security.Cryptography.Pkcs.Pkcs8PrivateKeyInfo Decode(System.ReadOnlyMemory<byte> source, out int bytesRead, bool skipCopy = default(bool)) => throw null;
+                    public static System.Security.Cryptography.Pkcs.Pkcs8PrivateKeyInfo DecryptAndDecode(System.ReadOnlySpan<char> password, System.ReadOnlyMemory<byte> source, out int bytesRead) => throw null;
+                    public static System.Security.Cryptography.Pkcs.Pkcs8PrivateKeyInfo DecryptAndDecode(System.ReadOnlySpan<byte> passwordBytes, System.ReadOnlyMemory<byte> source, out int bytesRead) => throw null;
+                    public byte[] Encode() => throw null;
+                    public byte[] Encrypt(System.ReadOnlySpan<char> password, System.Security.Cryptography.PbeParameters pbeParameters) => throw null;
+                    public byte[] Encrypt(System.ReadOnlySpan<byte> passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters) => throw null;
+                    public System.ReadOnlyMemory<byte> PrivateKeyBytes { get => throw null; }
+                    public bool TryEncode(System.Span<byte> destination, out int bytesWritten) => throw null;
+                    public bool TryEncrypt(System.ReadOnlySpan<char> password, System.Security.Cryptography.PbeParameters pbeParameters, System.Span<byte> destination, out int bytesWritten) => throw null;
+                    public bool TryEncrypt(System.ReadOnlySpan<byte> passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters, System.Span<byte> destination, out int bytesWritten) => throw null;
+                }
+                public class Pkcs9AttributeObject : System.Security.Cryptography.AsnEncodedData
+                {
+                    public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) => throw null;
+                    public Pkcs9AttributeObject() => throw null;
+                    public Pkcs9AttributeObject(string oid, byte[] encodedData) => throw null;
+                    public Pkcs9AttributeObject(System.Security.Cryptography.Oid oid, byte[] encodedData) => throw null;
+                    public Pkcs9AttributeObject(System.Security.Cryptography.AsnEncodedData asnEncodedData) => throw null;
+                    public System.Security.Cryptography.Oid Oid { get => throw null; }
+                }
+                public sealed class Pkcs9ContentType : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+                {
+                    public System.Security.Cryptography.Oid ContentType { get => throw null; }
+                    public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) => throw null;
+                    public Pkcs9ContentType() => throw null;
+                }
+                public sealed class Pkcs9DocumentDescription : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+                {
+                    public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) => throw null;
+                    public Pkcs9DocumentDescription() => throw null;
+                    public Pkcs9DocumentDescription(string documentDescription) => throw null;
+                    public Pkcs9DocumentDescription(byte[] encodedDocumentDescription) => throw null;
+                    public string DocumentDescription { get => throw null; }
+                }
+                public sealed class Pkcs9DocumentName : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+                {
+                    public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) => throw null;
+                    public Pkcs9DocumentName() => throw null;
+                    public Pkcs9DocumentName(string documentName) => throw null;
+                    public Pkcs9DocumentName(byte[] encodedDocumentName) => throw null;
+                    public string DocumentName { get => throw null; }
+                }
+                public sealed class Pkcs9LocalKeyId : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+                {
+                    public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) => throw null;
+                    public Pkcs9LocalKeyId() => throw null;
+                    public Pkcs9LocalKeyId(byte[] keyId) => throw null;
+                    public Pkcs9LocalKeyId(System.ReadOnlySpan<byte> keyId) => throw null;
+                    public System.ReadOnlyMemory<byte> KeyId { get => throw null; }
+                }
+                public sealed class Pkcs9MessageDigest : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+                {
+                    public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) => throw null;
+                    public Pkcs9MessageDigest() => throw null;
+                    public byte[] MessageDigest { get => throw null; }
+                }
+                public sealed class Pkcs9SigningTime : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+                {
+                    public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) => throw null;
+                    public Pkcs9SigningTime() => throw null;
+                    public Pkcs9SigningTime(System.DateTime signingTime) => throw null;
+                    public Pkcs9SigningTime(byte[] encodedSigningTime) => throw null;
+                    public System.DateTime SigningTime { get => throw null; }
+                }
+                public sealed class PublicKeyInfo
+                {
+                    public System.Security.Cryptography.Pkcs.AlgorithmIdentifier Algorithm { get => throw null; }
+                    public byte[] KeyValue { get => throw null; }
+                }
+                public abstract class RecipientInfo
+                {
+                    public abstract byte[] EncryptedKey { get; }
+                    public abstract System.Security.Cryptography.Pkcs.AlgorithmIdentifier KeyEncryptionAlgorithm { get; }
+                    public abstract System.Security.Cryptography.Pkcs.SubjectIdentifier RecipientIdentifier { get; }
+                    public System.Security.Cryptography.Pkcs.RecipientInfoType Type { get => throw null; }
+                    public abstract int Version { get; }
+                }
+                public sealed class RecipientInfoCollection : System.Collections.ICollection, System.Collections.IEnumerable
+                {
+                    public void CopyTo(System.Array array, int index) => throw null;
+                    public void CopyTo(System.Security.Cryptography.Pkcs.RecipientInfo[] array, int index) => throw null;
+                    public int Count { get => throw null; }
+                    public System.Security.Cryptography.Pkcs.RecipientInfoEnumerator GetEnumerator() => throw null;
+                    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null;
+                    public bool IsSynchronized { get => throw null; }
+                    public object SyncRoot { get => throw null; }
+                    public System.Security.Cryptography.Pkcs.RecipientInfo this[int index] { get => throw null; }
+                }
+                public sealed class RecipientInfoEnumerator : System.Collections.IEnumerator
+                {
+                    public System.Security.Cryptography.Pkcs.RecipientInfo Current { get => throw null; }
+                    object System.Collections.IEnumerator.Current { get => throw null; }
+                    public bool MoveNext() => throw null;
+                    public void Reset() => throw null;
+                }
+                public enum RecipientInfoType
+                {
+                    Unknown = 0,
+                    KeyTransport = 1,
+                    KeyAgreement = 2,
+                }
+                public sealed class Rfc3161TimestampRequest
+                {
+                    public static System.Security.Cryptography.Pkcs.Rfc3161TimestampRequest CreateFromData(System.ReadOnlySpan<byte> data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.Oid requestedPolicyId = default(System.Security.Cryptography.Oid), System.ReadOnlyMemory<byte>? nonce = default(System.ReadOnlyMemory<byte>?), bool requestSignerCertificates = default(bool), System.Security.Cryptography.X509Certificates.X509ExtensionCollection extensions = default(System.Security.Cryptography.X509Certificates.X509ExtensionCollection)) => throw null;
+                    public static System.Security.Cryptography.Pkcs.Rfc3161TimestampRequest CreateFromHash(System.ReadOnlyMemory<byte> hash, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.Oid requestedPolicyId = default(System.Security.Cryptography.Oid), System.ReadOnlyMemory<byte>? nonce = default(System.ReadOnlyMemory<byte>?), bool requestSignerCertificates = default(bool), System.Security.Cryptography.X509Certificates.X509ExtensionCollection extensions = default(System.Security.Cryptography.X509Certificates.X509ExtensionCollection)) => throw null;
+                    public static System.Security.Cryptography.Pkcs.Rfc3161TimestampRequest CreateFromHash(System.ReadOnlyMemory<byte> hash, System.Security.Cryptography.Oid hashAlgorithmId, System.Security.Cryptography.Oid requestedPolicyId = default(System.Security.Cryptography.Oid), System.ReadOnlyMemory<byte>? nonce = default(System.ReadOnlyMemory<byte>?), bool requestSignerCertificates = default(bool), System.Security.Cryptography.X509Certificates.X509ExtensionCollection extensions = default(System.Security.Cryptography.X509Certificates.X509ExtensionCollection)) => throw null;
+                    public static System.Security.Cryptography.Pkcs.Rfc3161TimestampRequest CreateFromSignerInfo(System.Security.Cryptography.Pkcs.SignerInfo signerInfo, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.Oid requestedPolicyId = default(System.Security.Cryptography.Oid), System.ReadOnlyMemory<byte>? nonce = default(System.ReadOnlyMemory<byte>?), bool requestSignerCertificates = default(bool), System.Security.Cryptography.X509Certificates.X509ExtensionCollection extensions = default(System.Security.Cryptography.X509Certificates.X509ExtensionCollection)) => throw null;
+                    public byte[] Encode() => throw null;
+                    public System.Security.Cryptography.X509Certificates.X509ExtensionCollection GetExtensions() => throw null;
+                    public System.ReadOnlyMemory<byte> GetMessageHash() => throw null;
+                    public System.ReadOnlyMemory<byte>? GetNonce() => throw null;
+                    public bool HasExtensions { get => throw null; }
+                    public System.Security.Cryptography.Oid HashAlgorithmId { get => throw null; }
+                    public System.Security.Cryptography.Pkcs.Rfc3161TimestampToken ProcessResponse(System.ReadOnlyMemory<byte> responseBytes, out int bytesConsumed) => throw null;
+                    public System.Security.Cryptography.Oid RequestedPolicyId { get => throw null; }
+                    public bool RequestSignerCertificate { get => throw null; }
+                    public static bool TryDecode(System.ReadOnlyMemory<byte> encodedBytes, out System.Security.Cryptography.Pkcs.Rfc3161TimestampRequest request, out int bytesConsumed) => throw null;
+                    public bool TryEncode(System.Span<byte> destination, out int bytesWritten) => throw null;
+                    public int Version { get => throw null; }
+                }
+                public sealed class Rfc3161TimestampToken
+                {
+                    public System.Security.Cryptography.Pkcs.SignedCms AsSignedCms() => throw null;
+                    public System.Security.Cryptography.Pkcs.Rfc3161TimestampTokenInfo TokenInfo { get => throw null; }
+                    public static bool TryDecode(System.ReadOnlyMemory<byte> encodedBytes, out System.Security.Cryptography.Pkcs.Rfc3161TimestampToken token, out int bytesConsumed) => throw null;
+                    public bool VerifySignatureForData(System.ReadOnlySpan<byte> data, out System.Security.Cryptography.X509Certificates.X509Certificate2 signerCertificate, System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraCandidates = default(System.Security.Cryptography.X509Certificates.X509Certificate2Collection)) => throw null;
+                    public bool VerifySignatureForHash(System.ReadOnlySpan<byte> hash, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, out System.Security.Cryptography.X509Certificates.X509Certificate2 signerCertificate, System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraCandidates = default(System.Security.Cryptography.X509Certificates.X509Certificate2Collection)) => throw null;
+                    public bool VerifySignatureForHash(System.ReadOnlySpan<byte> hash, System.Security.Cryptography.Oid hashAlgorithmId, out System.Security.Cryptography.X509Certificates.X509Certificate2 signerCertificate, System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraCandidates = default(System.Security.Cryptography.X509Certificates.X509Certificate2Collection)) => throw null;
+                    public bool VerifySignatureForSignerInfo(System.Security.Cryptography.Pkcs.SignerInfo signerInfo, out System.Security.Cryptography.X509Certificates.X509Certificate2 signerCertificate, System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraCandidates = default(System.Security.Cryptography.X509Certificates.X509Certificate2Collection)) => throw null;
+                }
+                public sealed class Rfc3161TimestampTokenInfo
+                {
+                    public long? AccuracyInMicroseconds { get => throw null; }
+                    public Rfc3161TimestampTokenInfo(System.Security.Cryptography.Oid policyId, System.Security.Cryptography.Oid hashAlgorithmId, System.ReadOnlyMemory<byte> messageHash, System.ReadOnlyMemory<byte> serialNumber, System.DateTimeOffset timestamp, long? accuracyInMicroseconds = default(long?), bool isOrdering = default(bool), System.ReadOnlyMemory<byte>? nonce = default(System.ReadOnlyMemory<byte>?), System.ReadOnlyMemory<byte>? timestampAuthorityName = default(System.ReadOnlyMemory<byte>?), System.Security.Cryptography.X509Certificates.X509ExtensionCollection extensions = default(System.Security.Cryptography.X509Certificates.X509ExtensionCollection)) => throw null;
+                    public byte[] Encode() => throw null;
+                    public System.Security.Cryptography.X509Certificates.X509ExtensionCollection GetExtensions() => throw null;
+                    public System.ReadOnlyMemory<byte> GetMessageHash() => throw null;
+                    public System.ReadOnlyMemory<byte>? GetNonce() => throw null;
+                    public System.ReadOnlyMemory<byte> GetSerialNumber() => throw null;
+                    public System.ReadOnlyMemory<byte>? GetTimestampAuthorityName() => throw null;
+                    public bool HasExtensions { get => throw null; }
+                    public System.Security.Cryptography.Oid HashAlgorithmId { get => throw null; }
+                    public bool IsOrdering { get => throw null; }
+                    public System.Security.Cryptography.Oid PolicyId { get => throw null; }
+                    public System.DateTimeOffset Timestamp { get => throw null; }
+                    public static bool TryDecode(System.ReadOnlyMemory<byte> encodedBytes, out System.Security.Cryptography.Pkcs.Rfc3161TimestampTokenInfo timestampTokenInfo, out int bytesConsumed) => throw null;
+                    public bool TryEncode(System.Span<byte> destination, out int bytesWritten) => throw null;
+                    public int Version { get => throw null; }
+                }
+                public sealed class SignedCms
+                {
+                    public void AddCertificate(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) => throw null;
+                    public System.Security.Cryptography.X509Certificates.X509Certificate2Collection Certificates { get => throw null; }
+                    public void CheckHash() => throw null;
+                    public void CheckSignature(bool verifySignatureOnly) => throw null;
+                    public void CheckSignature(System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraStore, bool verifySignatureOnly) => throw null;
+                    public void ComputeSignature() => throw null;
+                    public void ComputeSignature(System.Security.Cryptography.Pkcs.CmsSigner signer) => throw null;
+                    public void ComputeSignature(System.Security.Cryptography.Pkcs.CmsSigner signer, bool silent) => throw null;
+                    public System.Security.Cryptography.Pkcs.ContentInfo ContentInfo { get => throw null; }
+                    public SignedCms(System.Security.Cryptography.Pkcs.SubjectIdentifierType signerIdentifierType, System.Security.Cryptography.Pkcs.ContentInfo contentInfo, bool detached) => throw null;
+                    public SignedCms() => throw null;
+                    public SignedCms(System.Security.Cryptography.Pkcs.SubjectIdentifierType signerIdentifierType) => throw null;
+                    public SignedCms(System.Security.Cryptography.Pkcs.ContentInfo contentInfo) => throw null;
+                    public SignedCms(System.Security.Cryptography.Pkcs.SubjectIdentifierType signerIdentifierType, System.Security.Cryptography.Pkcs.ContentInfo contentInfo) => throw null;
+                    public SignedCms(System.Security.Cryptography.Pkcs.ContentInfo contentInfo, bool detached) => throw null;
+                    public void Decode(byte[] encodedMessage) => throw null;
+                    public void Decode(System.ReadOnlySpan<byte> encodedMessage) => throw null;
+                    public bool Detached { get => throw null; }
+                    public byte[] Encode() => throw null;
+                    public void RemoveCertificate(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) => throw null;
+                    public void RemoveSignature(int index) => throw null;
+                    public void RemoveSignature(System.Security.Cryptography.Pkcs.SignerInfo signerInfo) => throw null;
+                    public System.Security.Cryptography.Pkcs.SignerInfoCollection SignerInfos { get => throw null; }
+                    public int Version { get => throw null; }
+                }
+                public sealed class SignerInfo
+                {
+                    public void AddUnsignedAttribute(System.Security.Cryptography.AsnEncodedData unsignedAttribute) => throw null;
+                    public System.Security.Cryptography.X509Certificates.X509Certificate2 Certificate { get => throw null; }
+                    public void CheckHash() => throw null;
+                    public void CheckSignature(bool verifySignatureOnly) => throw null;
+                    public void CheckSignature(System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraStore, bool verifySignatureOnly) => throw null;
+                    public void ComputeCounterSignature() => throw null;
+                    public void ComputeCounterSignature(System.Security.Cryptography.Pkcs.CmsSigner signer) => throw null;
+                    public System.Security.Cryptography.Pkcs.SignerInfoCollection CounterSignerInfos { get => throw null; }
+                    public System.Security.Cryptography.Oid DigestAlgorithm { get => throw null; }
+                    public byte[] GetSignature() => throw null;
+                    public void RemoveCounterSignature(int index) => throw null;
+                    public void RemoveCounterSignature(System.Security.Cryptography.Pkcs.SignerInfo counterSignerInfo) => throw null;
+                    public void RemoveUnsignedAttribute(System.Security.Cryptography.AsnEncodedData unsignedAttribute) => throw null;
+                    public System.Security.Cryptography.Oid SignatureAlgorithm { get => throw null; }
+                    public System.Security.Cryptography.CryptographicAttributeObjectCollection SignedAttributes { get => throw null; }
+                    public System.Security.Cryptography.Pkcs.SubjectIdentifier SignerIdentifier { get => throw null; }
+                    public System.Security.Cryptography.CryptographicAttributeObjectCollection UnsignedAttributes { get => throw null; }
+                    public int Version { get => throw null; }
+                }
+                public sealed class SignerInfoCollection : System.Collections.ICollection, System.Collections.IEnumerable
+                {
+                    public void CopyTo(System.Array array, int index) => throw null;
+                    public void CopyTo(System.Security.Cryptography.Pkcs.SignerInfo[] array, int index) => throw null;
+                    public int Count { get => throw null; }
+                    public System.Security.Cryptography.Pkcs.SignerInfoEnumerator GetEnumerator() => throw null;
+                    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null;
+                    public bool IsSynchronized { get => throw null; }
+                    public object SyncRoot { get => throw null; }
+                    public System.Security.Cryptography.Pkcs.SignerInfo this[int index] { get => throw null; }
+                }
+                public sealed class SignerInfoEnumerator : System.Collections.IEnumerator
+                {
+                    public System.Security.Cryptography.Pkcs.SignerInfo Current { get => throw null; }
+                    object System.Collections.IEnumerator.Current { get => throw null; }
+                    public bool MoveNext() => throw null;
+                    public void Reset() => throw null;
+                }
+                public sealed class SubjectIdentifier
+                {
+                    public bool MatchesCertificate(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) => throw null;
+                    public System.Security.Cryptography.Pkcs.SubjectIdentifierType Type { get => throw null; }
+                    public object Value { get => throw null; }
+                }
+                public sealed class SubjectIdentifierOrKey
+                {
+                    public System.Security.Cryptography.Pkcs.SubjectIdentifierOrKeyType Type { get => throw null; }
+                    public object Value { get => throw null; }
+                }
+                public enum SubjectIdentifierOrKeyType
+                {
+                    Unknown = 0,
+                    IssuerAndSerialNumber = 1,
+                    SubjectKeyIdentifier = 2,
+                    PublicKeyInfo = 3,
+                }
+                public enum SubjectIdentifierType
+                {
+                    Unknown = 0,
+                    IssuerAndSerialNumber = 1,
+                    SubjectKeyIdentifier = 2,
+                    NoSignature = 3,
+                }
+            }
+            namespace Xml
+            {
+                public struct X509IssuerSerial
+                {
+                    public string IssuerName { get => throw null; set { } }
+                    public string SerialNumber { get => throw null; set { } }
+                }
+            }
+        }
+    }
+}

--- a/csharp/ql/test/resources/stubs/System.Security.Cryptography.Pkcs/9.0.4/System.Security.Cryptography.Pkcs.csproj
+++ b/csharp/ql/test/resources/stubs/System.Security.Cryptography.Pkcs/9.0.4/System.Security.Cryptography.Pkcs.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputPath>bin\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../_frameworks/Microsoft.NETCore.App/Microsoft.NETCore.App.csproj" />
+  </ItemGroup>
+</Project>

--- a/csharp/ql/test/resources/stubs/System.Security.Cryptography.ProtectedData/9.0.4/System.Security.Cryptography.ProtectedData.cs
+++ b/csharp/ql/test/resources/stubs/System.Security.Cryptography.ProtectedData/9.0.4/System.Security.Cryptography.ProtectedData.cs
@@ -1,0 +1,21 @@
+// This file contains auto-generated code.
+// Generated from `System.Security.Cryptography.ProtectedData, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a`.
+namespace System
+{
+    namespace Security
+    {
+        namespace Cryptography
+        {
+            public enum DataProtectionScope
+            {
+                CurrentUser = 0,
+                LocalMachine = 1,
+            }
+            public static class ProtectedData
+            {
+                public static byte[] Protect(byte[] userData, byte[] optionalEntropy, System.Security.Cryptography.DataProtectionScope scope) => throw null;
+                public static byte[] Unprotect(byte[] encryptedData, byte[] optionalEntropy, System.Security.Cryptography.DataProtectionScope scope) => throw null;
+            }
+        }
+    }
+}

--- a/csharp/ql/test/resources/stubs/System.Security.Cryptography.ProtectedData/9.0.4/System.Security.Cryptography.ProtectedData.csproj
+++ b/csharp/ql/test/resources/stubs/System.Security.Cryptography.ProtectedData/9.0.4/System.Security.Cryptography.ProtectedData.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputPath>bin\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../_frameworks/Microsoft.NETCore.App/Microsoft.NETCore.App.csproj" />
+  </ItemGroup>
+</Project>

--- a/csharp/ql/test/resources/stubs/System.Text.Encodings.Web/4.7.2/System.Text.Encodings.Web.csproj
+++ b/csharp/ql/test/resources/stubs/System.Text.Encodings.Web/4.7.2/System.Text.Encodings.Web.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputPath>bin\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../_frameworks/Microsoft.NETCore.App/Microsoft.NETCore.App.csproj" />
+  </ItemGroup>
+</Project>

--- a/csharp/ql/test/resources/stubs/System.Text.Json/4.7.2/System.Text.Json.csproj
+++ b/csharp/ql/test/resources/stubs/System.Text.Json/4.7.2/System.Text.Json.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputPath>bin\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../_frameworks/Microsoft.NETCore.App/Microsoft.NETCore.App.csproj" />
+  </ItemGroup>
+</Project>

--- a/csharp/ql/test/resources/stubs/System.Threading.Tasks.Extensions/4.5.4/System.Threading.Tasks.Extensions.csproj
+++ b/csharp/ql/test/resources/stubs/System.Threading.Tasks.Extensions/4.5.4/System.Threading.Tasks.Extensions.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputPath>bin\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../_frameworks/Microsoft.NETCore.App/Microsoft.NETCore.App.csproj" />
+  </ItemGroup>
+</Project>

--- a/csharp/scripts/stubs/make_stubs_all.py
+++ b/csharp/scripts/stubs/make_stubs_all.py
@@ -14,6 +14,7 @@ packages = [
     "Amazon.Lambda.APIGatewayEvents",
     "Dapper",
     "EntityFramework",
+    "Microsoft.Data.SqlClient",
     "Newtonsoft.Json",
     "NHibernate",
     "System.Data.OleDb",


### PR DESCRIPTION
In this PR we
- Add explicit Models as Data models for `Microsoft.Data.SqlClient.[SqlCommand|SqlDataAdapter]`.
- Add stubs for `Microsoft.Data.SqlClient` using the stub generator.
- Convert tests for `cs/sql-injection` to inline expectations tests.

Note that prior to this change `Microsoft.Data.SqlClient.SqlCommand` was identified as a sink since it is declared in type that implements the `System.Data.IDbCommand` interface. Furthermore, `Microsoft.Data.SqlClient.SqlDataAdapter` was not modelled as a sink.