### PR TITLE
Go: Avoid using deprecated class

### DIFF
--- a/go/ql/lib/semmle/go/Types.qll
+++ b/go/ql/lib/semmle/go/Types.qll
@@ -1044,7 +1044,9 @@ class DefinedType extends @definedtype, CompositeType {
    * Note that this is only defined for types declared in the project being
    * analyzed. It will not be defined for types declared in external packages.
    */
-  Type getBaseType() { result = this.getEntity().(DeclaredType).getSpec().getTypeExpr().getType() }
+  Type getBaseType() {
+    result = this.getEntity().(DeclaredTypeEntity).getSpec().getTypeExpr().getType()
+  }
 
   override Method getMethod(string m) {
     result = CompositeType.super.getMethod(m)


### PR DESCRIPTION
[Go: Improve two class names and add some helper predicates](https://github.com/github/codeql/pull/19677#top) and [Go: fix DefinedType.getBaseType](https://github.com/github/codeql/pull/19654) got merged at the same time. One deprecated a class and the other introduced a new use of it. This PR fixes the issue by avoiding the deprecated class and using the new one instead.