### PR TITLE
Overlay: Add missing `overlay[caller?]` annotation

### DIFF
--- a/java/ql/lib/semmle/code/java/controlflow/Guards.qll
+++ b/java/ql/lib/semmle/code/java/controlflow/Guards.qll
@@ -440,6 +440,7 @@ private module CustomGuardInput implements Guards_v2::CustomGuardInputSig {
   }
 
   /** Holds if arguments at position `apos` match parameters at position `ppos`. */
+  overlay[caller?]
   pragma[inline]
   predicate parameterMatch(ParameterPosition ppos, ArgumentPosition apos) { ppos = apos }
 


### PR DESCRIPTION
This PR adds a missing `overlay[caller?]` annotation [detected](https://github.com/github/codeql/security/code-scanning/96818) by QL4QL. Overlay compilation is currently disabled for Java and the annotation therefore has no effect on compilation or evaluation.