### PR TITLE
C++: fix `(no string representation)` for `ConstructorInit`

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/exprs/Call.qll
+++ b/cpp/ql/lib/semmle/code/cpp/exprs/Call.qll
@@ -504,6 +504,8 @@ class VacuousDestructorCall extends Expr, @vacuous_destructor_call {
  */
 class ConstructorInit extends Expr, @ctorinit {
   override string getAPrimaryQlClass() { result = "ConstructorInit" }
+
+  override string toString() { result = "constructor init" }
 }
 
 /**
@@ -512,6 +514,8 @@ class ConstructorInit extends Expr, @ctorinit {
  */
 class ConstructorBaseInit extends ConstructorInit, ConstructorCall {
   override string getAPrimaryQlClass() { result = "ConstructorBaseInit" }
+
+  override string toString() { result = "call to " + this.getTarget().getName() }
 }
 
 /**

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -4717,7 +4717,7 @@ WARNING: module 'TaintTracking' has been deprecated and may be removed in future
 | stl.h:292:30:292:40 | call to allocator | stl.h:292:21:292:41 | noexcept(...) | TAINT |
 | stl.h:292:30:292:40 | call to allocator | stl.h:292:21:292:41 | noexcept(...) | TAINT |
 | stl.h:292:30:292:40 | call to allocator | stl.h:292:21:292:41 | noexcept(...) | TAINT |
-| stl.h:292:53:292:63 | 0 | stl.h:292:46:292:64 | (no string representation) | TAINT |
+| stl.h:292:53:292:63 | 0 | stl.h:292:46:292:64 | constructor init | TAINT |
 | stl.h:396:3:396:3 | this | stl.h:396:36:396:43 | constructor init of field first [pre-this] |  |
 | stl.h:396:3:396:3 | this | stl.h:396:36:396:43 | constructor init of field first [pre-this] |  |
 | stl.h:396:3:396:3 | this | stl.h:396:36:396:43 | constructor init of field first [pre-this] |  |

--- a/cpp/ql/test/library-tests/ir/ir/PrintAST.expected
+++ b/cpp/ql/test/library-tests/ir/ir/PrintAST.expected
@@ -15134,7 +15134,7 @@ ir.cpp:
 # 1506| [Constructor] void Inheritance_Test_A::Inheritance_Test_A()
 # 1506|   <params>: 
 # 1506|   <initializations>: 
-# 1506|     getInitializer(0): (no string representation)
+# 1506|     getInitializer(0): [ConstructorInit] constructor init
 # 1506|         Type = [Struct] Inheritance_Test_B
 # 1506|         ValueCategory = prvalue
 # 1506|     getInitializer(1): [ConstructorFieldInit] constructor init of field x
@@ -17205,7 +17205,7 @@ ir.cpp:
 # 1785|           getExpr(): [ReferenceDereferenceExpr] (reference dereference)
 # 1785|               Type = [SpecifiedType] const CopyConstructorTestNonVirtualClass
 # 1785|               ValueCategory = lvalue
-# 1785|     getInitializer(1): (no string representation)
+# 1785|     getInitializer(1): [ConstructorInit] constructor init
 # 1785|         Type = [VirtualBaseClass] CopyConstructorWithBitwiseCopyClass
 # 1785|         ValueCategory = prvalue
 # 1785|   getEntryPoint(): [BlockStmt] { ... }
@@ -17254,7 +17254,7 @@ ir.cpp:
 # 1792|           getExpr(): [ReferenceDereferenceExpr] (reference dereference)
 # 1792|               Type = [SpecifiedType] const CopyConstructorTestVirtualClass
 # 1792|               ValueCategory = lvalue
-# 1792|     getInitializer(1): (no string representation)
+# 1792|     getInitializer(1): [ConstructorInit] constructor init
 # 1792|         Type = [VirtualBaseClass] CopyConstructorWithBitwiseCopyClass
 # 1792|         ValueCategory = prvalue
 # 1792|   getEntryPoint(): [BlockStmt] { ... }

--- a/cpp/ql/test/library-tests/ptr_to_member/segfault/exprs.expected
+++ b/cpp/ql/test/library-tests/ptr_to_member/segfault/exprs.expected
@@ -4,6 +4,7 @@
 | file://:0:0:0:0 | uls | file://:0:0:0:0 | unsigned long |
 | segfault.cpp:25:46:25:65 | call to S | file://:0:0:0:0 | void |
 | segfault.cpp:25:46:25:65 | call to S | file://:0:0:0:0 | void |
+| segfault.cpp:25:46:25:65 | constructor init | segfault.cpp:22:8:22:8 | S<T> |
 | segfault.cpp:25:48:25:55 | __second | segfault.cpp:15:7:15:11 | tuple |
 | segfault.cpp:25:48:25:55 | __second | segfault.cpp:15:7:15:11 | tuple |
 | segfault.cpp:25:48:25:55 | __second | segfault.cpp:15:7:15:11 | tuple |


### PR DESCRIPTION
This PR overrides `toString` for `ConstructorInit`, which previously had `no string representation`. It also overrides `toString` for `ConstructorBaseInit` while preserving the existing behavior.

Coding Standards PR: https://github.com/github/codeql-coding-standards/pull/916