### PR TITLE
C++: Add Arm64 change note

### DIFF
--- a/cpp/ql/lib/change-notes/2025-06-24-float16 copy.md
+++ b/cpp/ql/lib/change-notes/2025-06-24-float16 copy.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The analysis of C/C++ code targeting 64-bit Arm platforms has been improved. This includes support for the Arm-specific builtin functions, support for the `arm_neon.h` header and Neon vector types, and support for the `fp8` scalar type. The `arm_sve.h` header and scalable vectors are only partially supported at this point.


### PR DESCRIPTION
Change not summarizing all the Arm64 work that has been done in earlier PRs, and where change notes were omitted.