### PR TITLE
Rust: Assume prelude is always available in path resolution

### DIFF
--- a/rust/ql/lib/codeql/rust/internal/PathResolution.qll
+++ b/rust/ql/lib/codeql/rust/internal/PathResolution.qll
@@ -194,7 +194,7 @@ abstract class ItemNode extends Locatable {
     Stages::PathResolutionStage::ref() and
     result = this.getASuccessorRec(name)
     or
-    preludeEdge(this, name, result) and not declares(this, _, name)
+    preludeEdge(this, name, result)
     or
     this instanceof SourceFile and
     builtin(name, result)
@@ -1505,12 +1505,8 @@ private predicate externCrateEdge(ExternCrateItemNode ec, string name, CrateItem
  */
 pragma[nomagic]
 private predicate preludeEdge(SourceFile f, string name, ItemNode i) {
+  not declares(f, _, name) and
   exists(Crate stdOrCore, ModuleLikeNode mod, ModuleItemNode prelude, ModuleItemNode rust |
-    f = any(Crate c0 | stdOrCore = c0.getDependency(_) or stdOrCore = c0).getASourceFile()
-    or
-    // Give builtin files access to the prelude
-    f instanceof BuiltinSourceFile
-  |
     stdOrCore.getName() = ["std", "core"] and
     mod = stdOrCore.getSourceFile() and
     prelude = mod.getASuccessorRec("prelude") and

--- a/rust/ql/test/library-tests/variables/CONSISTENCY/PathResolutionConsistency.expected
+++ b/rust/ql/test/library-tests/variables/CONSISTENCY/PathResolutionConsistency.expected
@@ -1,5 +1,3 @@
 multipleCallTargets
 | main.rs:85:19:85:40 | ...::from(...) |
 | main.rs:102:19:102:40 | ...::from(...) |
-| main.rs:374:5:374:27 | ... .add_assign(...) |
-| main.rs:459:9:459:23 | z.add_assign(...) |


### PR DESCRIPTION
It should be safe to assume that the prelude is always available, since shadowing definitions will be prioritized anyway, so this PR removes the crate-dependency restriction.

[DCA](https://github.com/github/codeql-dca-main/issues/29936) looks great: `windows-rs`, in particular, has a high increase in resolvable calls (from 11 % to 33 %).