### PR TITLE
C++: Fix `VariableAddress` instruction association for unnamed parameters

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/TranslatedFunction.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/TranslatedFunction.qll
@@ -857,7 +857,12 @@ class TranslatedParameterReadEffect extends TranslatedReadEffect, TTranslatedPar
   }
 
   final override IRVariable getInstructionVariable(InstructionTag tag) {
-    tag = OnlyInstructionTag() and
+    (
+      tag = OnlyInstructionTag() or
+      tag = InitializerStoreTag() or
+      tag = InitializerVariableAddressTag() or
+      tag = InitializerIndirectStoreTag()
+    ) and
     result = getIRUserVariable(this.getFunction(), param)
   }
 }


### PR DESCRIPTION
`TranslatedParameterReadEffect.getInstructionVariable()` now handles all parameter-related instruction tags, not just `OnlyInstructionTag()`.

Took inspiration from base class `TranslatedParameter`. 

