### PR TITLE
C++: Remove QLtest related comment from integration test

### DIFF
--- a/cpp/ql/integration-tests/header-variant-tests/clang-pch/b.c
+++ b/cpp/ql/integration-tests/header-variant-tests/clang-pch/b.c
@@ -4,4 +4,3 @@
 int main() {
   return ONE + TWO + THREE + FOUR;
 }
-// semmle-extractor-options: --clang -include-pch ${testdir}/clang-pch.testproj/a.pch -Iextra_dummy_path


### PR DESCRIPTION
I forgot to remove this in https://github.com/github/codeql/pull/19410