### PR TITLE
C++: Add `glibc` to `bulk_generation_targets.yml`

### DIFF
--- a/cpp/bulk_generation_targets.yml
+++ b/cpp/bulk_generation_targets.yml
@@ -2,6 +2,9 @@ language: cpp
 strategy: dca
 destination: cpp/ql/lib/ext/generated
 targets:
+- name: glibc
+  with-sinks: false
+  with-sources: false
 - name: zlib
   with-sinks: false
   with-sources: false


### PR DESCRIPTION
Now that we have `glibc` in the `mad-generation` suite we can start to generate flow summaries for the project