### PR TITLE
Rust: Speed up use of Location.contains

### DIFF
--- a/rust/ql/lib/codeql/rust/elements/internal/LocationImpl.qll
+++ b/rust/ql/lib/codeql/rust/elements/internal/LocationImpl.qll
@@ -133,7 +133,8 @@ module LocationImpl {
      * Holds if this location contains location `that`, meaning that it starts
      * before and ends after it.
      */
-    pragma[inline]
+    bindingset[this, that]
+    pragma[inline_late]
     predicate contains(Location that) { this.startsBefore(that) and this.endsAfter(that) }
 
     /**


### PR DESCRIPTION
This speeds up the computation of `rust/access-after-lifetime-ended`, which was exploding a bit in `isFromMacroExpansion` -> ... ->  `getATokenTreeNode` where `Location.contains` is inlined:
```
[2025-07-02 15:37:13] (45s) Tuple counts for MacroCall::MacroCall.getATokenTreeNode/0#d82faf80/2@6714b0ri after 29.3s:
                      120594     ~2%     {2} r1 = SCAN `MacroCall::Generated::MacroCall.getTokenTree/0#dispred#68c6d175` OUTPUT In.1, In.0 'this'
                      120594     ~0%     {2}    | JOIN WITH `cached_Locatable::Locatable.getLocation/0#dispred#f3f7e2b2` ON FIRST 1 OUTPUT Rhs.1, Lhs.1 'this'
                      120594     ~3%     {5}    | JOIN WITH `Locations::Location.hasLocationInfo/5#dispred#6bc680ca` ON FIRST 1 OUTPUT Lhs.0, Lhs.1 'this', Rhs.1, Rhs.4, Rhs.5
                      120594     ~0%     {7}    | JOIN WITH `Locations::Location.hasLocationInfo/5#dispred#6bc680ca` ON FIRST 1 OUTPUT Lhs.2, Lhs.1 'this', Lhs.3, Lhs.4, Rhs.1, Rhs.2, Rhs.3
                      6648676245 ~3%     {9}    | JOIN WITH `Locations::Location.hasLocationInfo/5#dispred#6bc680ca_102345#join_rhs` ON FIRST 1 OUTPUT Lhs.1 'this', Lhs.2, Lhs.3, Lhs.4, Lhs.5, Lhs.6, Rhs.1, Rhs.4, Rhs.5
                                         {9}    | REWRITE WITH NOT [NOT [TEST InOut.1 > InOut.7], NOT [TEST InOut.1 = InOut.7, TEST InOut.2 >= InOut.8]]
                      2786239339 ~0%     {5}    | SCAN OUTPUT In.6, In.3, In.0 'this', In.4, In.5
                      2786239339 ~1%     {6}    | JOIN WITH `Locations::Location.hasLocationInfo/5#dispred#6bc680ca` ON FIRST 2 OUTPUT Lhs.2 'this', Lhs.3, Lhs.4, Lhs.0, Rhs.2, Rhs.3
                                         {6}    | REWRITE WITH NOT [NOT [TEST InOut.1 < InOut.4], NOT [TEST InOut.1 = InOut.4, TEST InOut.2 <= InOut.5]]
                      1422922    ~3%     {2}    | SCAN OUTPUT In.0 'this', In.3
                      1529741991 ~0%     {3}    | JOIN WITH `MacroCallImpl::Impl::isInMacroExpansion/2#87486c28` ON FIRST 1 OUTPUT Rhs.1 'result', Lhs.1, Lhs.0 'this'
                      2735560    ~0%     {2}    | JOIN WITH `cached_Locatable::Locatable.getLocation/0#dispred#f3f7e2b2` ON FIRST 2 OUTPUT Lhs.2 'this', Lhs.0 'result'
                                         return r1
```
It now looks better:
```
[2025-07-02 21:38:22] (107s) Tuple counts for MacroCall::MacroCall.getATokenTreeNode/0#d82faf80/2@9d04f4r5 after 354ms:
                      8317341 ~0%     {3} r1 = JOIN `MacroCall::Generated::MacroCall.getTokenTree/0#dispred#68c6d175` WITH `MacroCallImpl::Impl::isInMacroExpansion/2#87486c28` ON FIRST 1 OUTPUT Rhs.1 'result', Lhs.0 'this', Lhs.1
                      8317341 ~3%     {4}    | JOIN WITH `cached_Locatable::Locatable.getLocation/0#dispred#f3f7e2b2` ON FIRST 1 OUTPUT Lhs.2, Lhs.1 'this', Lhs.0 'result', Rhs.1
                      8317341 ~1%     {4}    | JOIN WITH `cached_Locatable::Locatable.getLocation/0#dispred#f3f7e2b2` ON FIRST 1 OUTPUT Rhs.1, Lhs.1 'this', Lhs.2 'result', Lhs.3
                      8317341 ~0%     {7}    | JOIN WITH `Locations::Location.hasLocationInfo/5#dispred#6bc680ca` ON FIRST 1 OUTPUT Lhs.3, Rhs.1, Lhs.1 'this', Lhs.2 'result', Lhs.0, Rhs.4, Rhs.5
                      8317341 ~0%     {8}    | JOIN WITH `Locations::Location.hasLocationInfo/5#dispred#6bc680ca` ON FIRST 2 OUTPUT Lhs.2 'this', Lhs.3 'result', Lhs.0, Lhs.4, Lhs.5, Lhs.6, Rhs.4, Rhs.5
                                      {8}    | REWRITE WITH NOT [NOT [TEST InOut.4 > InOut.6], NOT [TEST InOut.4 = InOut.6, TEST InOut.5 >= InOut.7]]
                      4547630 ~0%     {4}    | SCAN OUTPUT In.3, In.0 'this', In.1 'result', In.2
                      4547630 ~0%     {6}    | JOIN WITH `Locations::Location.hasLocationInfo/5#dispred#6bc680ca` ON FIRST 1 OUTPUT Lhs.3, Rhs.1, Lhs.1 'this', Lhs.2 'result', Rhs.2, Rhs.3
                      4547630 ~0%     {6}    | JOIN WITH `Locations::Location.hasLocationInfo/5#dispred#6bc680ca` ON FIRST 2 OUTPUT Lhs.2 'this', Lhs.3 'result', Lhs.4, Lhs.5, Rhs.2, Rhs.3
                                      {6}    | REWRITE WITH NOT [NOT [TEST InOut.2 < InOut.4], NOT [TEST InOut.2 = InOut.4, TEST InOut.3 <= InOut.5]]
                      2735560 ~0%     {2}    | SCAN OUTPUT In.0 'this', In.1 'result'
                                      return r1
```
It's also significantly faster in terms of overall clock time in my local experiments, but lets see what DCA thinks...