### PR TITLE
Overlay: Mark `RefType.getAStrictAncestor`` overlay[caller?]`

### DIFF
--- a/java/ql/lib/semmle/code/java/Type.qll
+++ b/java/ql/lib/semmle/code/java/Type.qll
@@ -422,6 +422,7 @@ class RefType extends Type, Annotatable, Modifiable, @reftype {
    * This does not include itself, unless this type is part of a cycle
    * in the type hierarchy.
    */
+  overlay[caller?]
   RefType getAStrictAncestor() { result = this.getASupertype().getAnAncestor() }
 
   /**


### PR DESCRIPTION
This PR marks `RefType.getAStrictAncestor` `overlay[caller?]` to ensure that queries that rely on magic to bound `getAStrictAncestor` can still execute efficiently with overlay compilation enabled.

Queries that rely on magic to ensure efficient bounding of `getAStrictAncestor` includes `java/useless-type-test`, `java/useless-upcast`, `java/missing-super-finalize`, `java/non-final-call-in-constructor`, `java/incorrect-serial-version-uid`, `java/non-serializable-field`, `java/unreachable-catch-clause`, `java/non-static-nested-class`, `java/lock-order-inconsistency`, `java/magic-string`, `java/confusing-override-name`. Without magic bounds, these queries regress significantly for the `palatable__lambda` DCA test case.

The regressions can also be fixed on the query side by adding suitable `overlay[local?]` annotations, but given the number of affected queries, it seems likely that custom queries that use `getAStrictAncestor` would also regress with a solution based on query-side annotations. 

Overlay compilation is currently disabled for Java and the annotations therefore have no effect on compilation or evaluation at the moment. 