### PR TITLE
Rust: Improve type inference for `for` loops and range expressions

### DIFF
--- a/rust/ql/lib/change-notes/2025-07-07-type-inference-for-loops.md
+++ b/rust/ql/lib/change-notes/2025-07-07-type-inference-for-loops.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Type inference has been improved for `for` loops and range expressions, which improves call resolution and may ultimately lead to more query results.

--- a/rust/ql/lib/codeql/rust/elements/RangeExprExt.qll
+++ b/rust/ql/lib/codeql/rust/elements/RangeExprExt.qll
@@ -13,6 +13,7 @@ private import rust
 final class RangeFromExpr extends RangeExpr {
   RangeFromExpr() {
     this.getOperatorName() = ".." and
+    this.hasStart() and
     not this.hasEnd()
   }
 }
@@ -26,7 +27,8 @@ final class RangeFromExpr extends RangeExpr {
 final class RangeToExpr extends RangeExpr {
   RangeToExpr() {
     this.getOperatorName() = ".." and
-    not this.hasStart()
+    not this.hasStart() and
+    this.hasEnd()
   }
 }
 

--- a/rust/ql/lib/codeql/rust/elements/RangeExprExt.qll
+++ b/rust/ql/lib/codeql/rust/elements/RangeExprExt.qll
@@ -1,0 +1,73 @@
+/**
+ * This module provides sub classes of the `RangeExpr` class.
+ */
+
+private import rust
+
+/**
+ * A range-from expression. For example:
+ * ```rust
+ * let x = 10..;
+ * ```
+ */
+final class RangeFromExpr extends RangeExpr {
+  RangeFromExpr() {
+    this.getOperatorName() = ".." and
+    not this.hasEnd()
+  }
+}
+
+/**
+ * A range-to expression. For example:
+ * ```rust
+ * let x = ..10;
+ * ```
+ */
+final class RangeToExpr extends RangeExpr {
+  RangeToExpr() {
+    this.getOperatorName() = ".." and
+    not this.hasStart()
+  }
+}
+
+/**
+ * A range-from-to expression. For example:
+ * ```rust
+ * let x = 10..20;
+ * ```
+ */
+final class RangeFromToExpr extends RangeExpr {
+  RangeFromToExpr() {
+    this.getOperatorName() = ".." and
+    this.hasStart() and
+    this.hasEnd()
+  }
+}
+
+/**
+ * A range-inclusive expression. For example:
+ * ```rust
+ * let x = 1..=10;
+ * ```
+ */
+final class RangeInclusiveExpr extends RangeExpr {
+  RangeInclusiveExpr() {
+    this.getOperatorName() = "..=" and
+    this.hasStart() and
+    this.hasEnd()
+  }
+}
+
+/**
+ * A range-to-inclusive expression. For example:
+ * ```rust
+ * let x = ..=10;
+ * ```
+ */
+final class RangeToInclusiveExpr extends RangeExpr {
+  RangeToInclusiveExpr() {
+    this.getOperatorName() = "..=" and
+    not this.hasStart() and
+    this.hasEnd()
+  }
+}

--- a/rust/ql/lib/codeql/rust/frameworks/stdlib/Stdlib.qll
+++ b/rust/ql/lib/codeql/rust/frameworks/stdlib/Stdlib.qll
@@ -51,6 +51,72 @@ class ResultEnum extends Enum {
 }
 
 /**
+ * The [`Range` struct][1].
+ *
+ * [1]: https://doc.rust-lang.org/core/ops/struct.Range.html
+ */
+class RangeStruct extends Struct {
+  RangeStruct() { this.getCanonicalPath() = "core::ops::range::Range" }
+
+  /** Gets the `start` field. */
+  StructField getStart() { result = this.getStructField("start") }
+
+  /** Gets the `end` field. */
+  StructField getEnd() { result = this.getStructField("end") }
+}
+
+/**
+ * The [`RangeFrom` struct][1].
+ *
+ * [1]: https://doc.rust-lang.org/core/ops/struct.RangeFrom.html
+ */
+class RangeFromStruct extends Struct {
+  RangeFromStruct() { this.getCanonicalPath() = "core::ops::range::RangeFrom" }
+
+  /** Gets the `start` field. */
+  StructField getStart() { result = this.getStructField("start") }
+}
+
+/**
+ * The [`RangeTo` struct][1].
+ *
+ * [1]: https://doc.rust-lang.org/core/ops/struct.RangeTo.html
+ */
+class RangeToStruct extends Struct {
+  RangeToStruct() { this.getCanonicalPath() = "core::ops::range::RangeTo" }
+
+  /** Gets the `end` field. */
+  StructField getEnd() { result = this.getStructField("end") }
+}
+
+/**
+ * The [`RangeInclusive` struct][1].
+ *
+ * [1]: https://doc.rust-lang.org/core/ops/struct.RangeInclusive.html
+ */
+class RangeInclusiveStruct extends Struct {
+  RangeInclusiveStruct() { this.getCanonicalPath() = "core::ops::range::RangeInclusive" }
+
+  /** Gets the `start` field. */
+  StructField getStart() { result = this.getStructField("start") }
+
+  /** Gets the `end` field. */
+  StructField getEnd() { result = this.getStructField("end") }
+}
+
+/**
+ * The [`RangeToInclusive` struct][1].
+ *
+ * [1]: https://doc.rust-lang.org/core/ops/struct.RangeToInclusive.html
+ */
+class RangeToInclusiveStruct extends Struct {
+  RangeToInclusiveStruct() { this.getCanonicalPath() = "core::ops::range::RangeToInclusive" }
+
+  /** Gets the `end` field. */
+  StructField getEnd() { result = this.getStructField("end") }
+}
+
+/**
  * The [`Future` trait][1].
  *
  * [1]: https://doc.rust-lang.org/std/future/trait.Future.html
@@ -63,6 +129,38 @@ class FutureTrait extends Trait {
   TypeAlias getOutputType() {
     result = this.getAssocItemList().getAnAssocItem() and
     result.getName().getText() = "Output"
+  }
+}
+
+/**
+ * The [`Iterator` trait][1].
+ *
+ * [1]: https://doc.rust-lang.org/std/iter/trait.Iterator.html
+ */
+class IteratorTrait extends Trait {
+  IteratorTrait() { this.getCanonicalPath() = "core::iter::traits::iterator::Iterator" }
+
+  /** Gets the `Item` associated type. */
+  pragma[nomagic]
+  TypeAlias getItemType() {
+    result = this.getAssocItemList().getAnAssocItem() and
+    result.getName().getText() = "Item"
+  }
+}
+
+/**
+ * The [`IntoIterator` trait][1].
+ *
+ * [1]: https://doc.rust-lang.org/std/iter/trait.IntoIterator.html
+ */
+class IntoIteratorTrait extends Trait {
+  IntoIteratorTrait() { this.getCanonicalPath() = "core::iter::traits::collect::IntoIterator" }
+
+  /** Gets the `Item` associated type. */
+  pragma[nomagic]
+  TypeAlias getItemType() {
+    result = this.getAssocItemList().getAnAssocItem() and
+    result.getName().getText() = "Item"
   }
 }
 

--- a/rust/ql/lib/codeql/rust/internal/Type.qll
+++ b/rust/ql/lib/codeql/rust/internal/Type.qll
@@ -421,21 +421,25 @@ final class ImplTypeAbstraction extends TypeAbstraction, Impl {
 }
 
 final class TraitTypeAbstraction extends TypeAbstraction, Trait {
-  override TypeParamTypeParameter getATypeParameter() {
-    result.getTypeParam() = this.getGenericParamList().getATypeParam()
+  override TypeParameter getATypeParameter() {
+    result.(TypeParamTypeParameter).getTypeParam() = this.getGenericParamList().getATypeParam()
+    or
+    result.(AssociatedTypeTypeParameter).getTrait() = this
   }
 }
 
 final class TypeBoundTypeAbstraction extends TypeAbstraction, TypeBound {
-  override TypeParamTypeParameter getATypeParameter() { none() }
+  override TypeParameter getATypeParameter() { none() }
 }
 
 final class SelfTypeBoundTypeAbstraction extends TypeAbstraction, Name {
-  SelfTypeBoundTypeAbstraction() { any(Trait trait).getName() = this }
+  private TraitTypeAbstraction trait;
 
-  override TypeParamTypeParameter getATypeParameter() { none() }
+  SelfTypeBoundTypeAbstraction() { trait.getName() = this }
+
+  override TypeParameter getATypeParameter() { none() }
 }
 
 final class ImplTraitTypeReprAbstraction extends TypeAbstraction, ImplTraitTypeRepr {
-  override TypeParamTypeParameter getATypeParameter() { none() }
+  override TypeParameter getATypeParameter() { none() }
 }

--- a/rust/ql/lib/codeql/rust/internal/TypeInference.qll
+++ b/rust/ql/lib/codeql/rust/internal/TypeInference.qll
@@ -231,6 +231,24 @@ private Type inferAssignmentOperationType(AstNode n, TypePath path) {
   result = TUnit()
 }
 
+pragma[nomagic]
+private Struct getRangeType(RangeExpr re) {
+  re instanceof RangeFromExpr and
+  result instanceof RangeFromStruct
+  or
+  re instanceof RangeToExpr and
+  result instanceof RangeToStruct
+  or
+  re instanceof RangeFromToExpr and
+  result instanceof RangeStruct
+  or
+  re instanceof RangeInclusiveExpr and
+  result instanceof RangeInclusiveStruct
+  or
+  re instanceof RangeToInclusiveExpr and
+  result instanceof RangeToInclusiveStruct
+}
+
 /**
  * Holds if the type tree of `n1` at `prefix1` should be equal to the type tree
  * of `n2` at `prefix2` and type information should propagate in both directions
@@ -300,22 +318,8 @@ private predicate typeEquality(AstNode n1, TypePath prefix1, AstNode n2, TypePat
   exists(Struct s |
     n2 = [n1.(RangeExpr).getStart(), n1.(RangeExpr).getEnd()] and
     prefix1 = TypePath::singleton(TTypeParamTypeParameter(s.getGenericParamList().getATypeParam())) and
-    prefix2.isEmpty()
-  |
-    n1 instanceof RangeFromExpr and
-    s instanceof RangeFromStruct
-    or
-    n1 instanceof RangeToExpr and
-    s instanceof RangeToStruct
-    or
-    n1 instanceof RangeFromToExpr and
-    s instanceof RangeStruct
-    or
-    n1 instanceof RangeInclusiveExpr and
-    s instanceof RangeInclusiveStruct
-    or
-    n1 instanceof RangeToInclusiveExpr and
-    s instanceof RangeToInclusiveStruct
+    prefix2.isEmpty() and
+    s = getRangeType(n1)
   )
 }
 
@@ -1123,24 +1127,7 @@ private Type inferArrayExprType(ArrayExpr ae) { exists(ae) and result = TArrayTy
  * Gets the root type of the range expression `re`.
  */
 pragma[nomagic]
-private Type inferRangeExprType(RangeExpr re) {
-  exists(Struct s | result = TStruct(s) |
-    re instanceof RangeFromExpr and
-    s instanceof RangeFromStruct
-    or
-    re instanceof RangeToExpr and
-    s instanceof RangeToStruct
-    or
-    re instanceof RangeFromToExpr and
-    s instanceof RangeStruct
-    or
-    re instanceof RangeInclusiveExpr and
-    s instanceof RangeInclusiveStruct
-    or
-    re instanceof RangeToInclusiveExpr and
-    s instanceof RangeToInclusiveStruct
-  )
-}
+private Type inferRangeExprType(RangeExpr re) { result = TStruct(getRangeType(re)) }
 
 /**
  * According to [the Rust reference][1]: _"array and slice-typed expressions

--- a/rust/ql/lib/rust.qll
+++ b/rust/ql/lib/rust.qll
@@ -15,6 +15,7 @@ import codeql.rust.elements.AsyncBlockExpr
 import codeql.rust.elements.Variable
 import codeql.rust.elements.NamedFormatArgument
 import codeql.rust.elements.PositionalFormatArgument
+import codeql.rust.elements.RangeExprExt
 private import codeql.rust.elements.Call as Call
 
 class Call = Call::Call;

--- a/rust/ql/test/library-tests/dataflow/sources/TaintSources.expected
+++ b/rust/ql/test/library-tests/dataflow/sources/TaintSources.expected
@@ -55,10 +55,16 @@
 | test.rs:412:31:412:38 | ...::read | Flow source 'FileSource' of type file (DEFAULT). |
 | test.rs:417:22:417:39 | ...::read_to_string | Flow source 'FileSource' of type file (DEFAULT). |
 | test.rs:417:22:417:39 | ...::read_to_string | Flow source 'FileSource' of type file (DEFAULT). |
+| test.rs:423:22:423:25 | path | Flow source 'FileSource' of type file (DEFAULT). |
+| test.rs:424:27:424:35 | file_name | Flow source 'FileSource' of type file (DEFAULT). |
 | test.rs:430:22:430:34 | ...::read_link | Flow source 'FileSource' of type file (DEFAULT). |
 | test.rs:439:31:439:45 | ...::read | Flow source 'FileSource' of type file (DEFAULT). |
 | test.rs:444:31:444:45 | ...::read | Flow source 'FileSource' of type file (DEFAULT). |
 | test.rs:449:22:449:46 | ...::read_to_string | Flow source 'FileSource' of type file (DEFAULT). |
+| test.rs:455:26:455:29 | path | Flow source 'FileSource' of type file (DEFAULT). |
+| test.rs:455:26:455:29 | path | Flow source 'FileSource' of type file (DEFAULT). |
+| test.rs:456:31:456:39 | file_name | Flow source 'FileSource' of type file (DEFAULT). |
+| test.rs:456:31:456:39 | file_name | Flow source 'FileSource' of type file (DEFAULT). |
 | test.rs:462:22:462:41 | ...::read_link | Flow source 'FileSource' of type file (DEFAULT). |
 | test.rs:472:20:472:38 | ...::open | Flow source 'FileSource' of type file (DEFAULT). |
 | test.rs:506:21:506:39 | ...::open | Flow source 'FileSource' of type file (DEFAULT). |

--- a/rust/ql/test/library-tests/dataflow/sources/test.rs
+++ b/rust/ql/test/library-tests/dataflow/sources/test.rs
@@ -420,10 +420,10 @@ fn test_fs() -> Result<(), Box<dyn std::error::Error>> {
 
     for entry in fs::read_dir("directory")? {
         let e = entry?;
-        let path = e.path(); // $ MISSING: Alert[rust/summary/taint-sources]
-        let file_name = e.file_name(); // $ MISSING: Alert[rust/summary/taint-sources]
-        sink(path); // $ MISSING: hasTaintFlow
-        sink(file_name); // $ MISSING: hasTaintFlow
+        let path = e.path(); // $ Alert[rust/summary/taint-sources]
+        let file_name = e.file_name(); // $ Alert[rust/summary/taint-sources]
+        sink(path); // $ hasTaintFlow
+        sink(file_name); // $ hasTaintFlow
     }
 
     {
@@ -452,10 +452,10 @@ async fn test_tokio_fs() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut read_dir = tokio::fs::read_dir("directory").await?;
     for entry in read_dir.next_entry().await? {
-        let path = entry.path(); // $ MISSING: Alert[rust/summary/taint-sources]
-        let file_name = entry.file_name(); // $ MISSING: Alert[rust/summary/taint-sources]
-        sink(path); // $ MISSING: hasTaintFlow
-        sink(file_name); // $ MISSING: hasTaintFlow
+        let path = entry.path(); // $ Alert[rust/summary/taint-sources]
+        let file_name = entry.file_name(); // $ Alert[rust/summary/taint-sources]
+        sink(path); // $ hasTaintFlow
+        sink(file_name); // $ hasTaintFlow
     }
 
     {

--- a/rust/ql/test/library-tests/type-inference/main.rs
+++ b/rust/ql/test/library-tests/type-inference/main.rs
@@ -2087,8 +2087,8 @@ mod loops {
         for u in vals4 {} // $ type=u:u64
 
         let mut strings1 = ["foo", "bar", "baz"]; // $ type=strings1:[T;...].str
-        for s in &strings1 {} // $ MISSING: type=s:&T.str
-        for s in &mut strings1 {} // $ MISSING: type=s:&T.str
+        for s in &strings1 {} // $ type=s:&T.str
+        for s in &mut strings1 {} // $ type=s:&T.str
         for s in strings1 {} // $ type=s:str
 
         let strings2 = // $ type=strings2:[T;...].String
@@ -2116,17 +2116,17 @@ mod loops {
 
         // for loops with ranges
 
-        for i in 0..10 {} // $ MISSING: type=i:i32
-        for u in [0u8..10] {} // $ MISSING: type=u:u8
-        let range = 0..10; // $ MISSING: type=range:Range type=range:Idx.i32
-        for i in range {} // $ MISSING: type=i:i32
+        for i in 0..10 {} // $ type=i:i32
+        for u in [0u8..10] {} // $ type=u:Range type=u:Idx.u8
+        let range = 0..10; // $ type=range:Range type=range:Idx.i32
+        for i in range {} // $ type=i:i32
 
         let range1 = // $ type=range1:Range type=range1:Idx.u16
         std::ops::Range {
             start: 0u16,
             end: 10u16,
         };
-        for u in range1 {} // $ MISSING: type=u:u16
+        for u in range1 {} // $ type=u:u16
 
         // for loops with containers
 
@@ -2150,11 +2150,11 @@ mod loops {
         for u in vals7 {} // $ MISSING: type=u:u8
 
         let matrix1 = vec![vec![1, 2], vec![3, 4]]; // $ MISSING: type=matrix1:Vec type=matrix1:T.Vec type=matrix1:T.T.i32
-        for row in matrix1 {
-            // $ MISSING: type=row:Vec type=row:T.i32
+        #[rustfmt::skip]
+        let _ = for row in matrix1 { // $ MISSING: type=row:Vec type=row:T.i32
             for cell in row { // $ MISSING: type=cell:i32
             }
-        }
+        };
 
         let mut map1 = std::collections::HashMap::new(); // $ method=new $ MISSING: type=map1:Hashmap type=map1:K.i32 type=map1:V.Box type1=map1:V.T.&T.str
         map1.insert(1, Box::new("one")); // $ method=insert method=new

--- a/rust/ql/test/library-tests/type-inference/type-inference.expected
+++ b/rust/ql/test/library-tests/type-inference/type-inference.expected
@@ -3157,11 +3157,17 @@ inferType
 | main.rs:2089:29:2089:33 | "foo" |  | {EXTERNAL LOCATION} | str |
 | main.rs:2089:36:2089:40 | "bar" |  | {EXTERNAL LOCATION} | str |
 | main.rs:2089:43:2089:47 | "baz" |  | {EXTERNAL LOCATION} | str |
+| main.rs:2090:13:2090:13 | s |  | {EXTERNAL LOCATION} | Item |
+| main.rs:2090:13:2090:13 | s |  | file://:0:0:0:0 | & |
+| main.rs:2090:13:2090:13 | s | &T | {EXTERNAL LOCATION} | str |
 | main.rs:2090:18:2090:26 | &strings1 |  | file://:0:0:0:0 | & |
 | main.rs:2090:18:2090:26 | &strings1 | &T | file://:0:0:0:0 | [] |
 | main.rs:2090:18:2090:26 | &strings1 | &T.[T;...] | {EXTERNAL LOCATION} | str |
 | main.rs:2090:19:2090:26 | strings1 |  | file://:0:0:0:0 | [] |
 | main.rs:2090:19:2090:26 | strings1 | [T;...] | {EXTERNAL LOCATION} | str |
+| main.rs:2091:13:2091:13 | s |  | {EXTERNAL LOCATION} | Item |
+| main.rs:2091:13:2091:13 | s |  | file://:0:0:0:0 | & |
+| main.rs:2091:13:2091:13 | s | &T | {EXTERNAL LOCATION} | str |
 | main.rs:2091:18:2091:30 | &mut strings1 |  | file://:0:0:0:0 | & |
 | main.rs:2091:18:2091:30 | &mut strings1 | &T | file://:0:0:0:0 | [] |
 | main.rs:2091:18:2091:30 | &mut strings1 | &T.[T;...] | {EXTERNAL LOCATION} | str |
@@ -3197,6 +3203,9 @@ inferType
 | main.rs:2105:26:2105:30 | "bar" |  | {EXTERNAL LOCATION} | str |
 | main.rs:2106:13:2106:31 | ...::from(...) |  | {EXTERNAL LOCATION} | String |
 | main.rs:2106:26:2106:30 | "baz" |  | {EXTERNAL LOCATION} | str |
+| main.rs:2108:13:2108:13 | s |  | {EXTERNAL LOCATION} | Item |
+| main.rs:2108:13:2108:13 | s |  | file://:0:0:0:0 | & |
+| main.rs:2108:13:2108:13 | s | &T | {EXTERNAL LOCATION} | String |
 | main.rs:2108:18:2108:25 | strings3 |  | file://:0:0:0:0 | & |
 | main.rs:2108:18:2108:25 | strings3 | &T | file://:0:0:0:0 | [] |
 | main.rs:2108:18:2108:25 | strings3 | &T.[T;...] | {EXTERNAL LOCATION} | String |
@@ -3213,19 +3222,44 @@ inferType
 | main.rs:2114:17:2114:22 | result |  | {EXTERNAL LOCATION} | i64 |
 | main.rs:2114:26:2114:26 | c |  | main.rs:2058:5:2058:24 | MyCallable |
 | main.rs:2114:26:2114:33 | c.call() |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2119:13:2119:13 | i |  | {EXTERNAL LOCATION} | Item |
+| main.rs:2119:13:2119:13 | i |  | {EXTERNAL LOCATION} | i32 |
 | main.rs:2119:18:2119:18 | 0 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2119:18:2119:22 | 0..10 |  | {EXTERNAL LOCATION} | Range |
+| main.rs:2119:18:2119:22 | 0..10 | Idx | {EXTERNAL LOCATION} | i32 |
 | main.rs:2119:21:2119:22 | 10 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2120:13:2120:13 | u |  | {EXTERNAL LOCATION} | Range |
+| main.rs:2120:13:2120:13 | u | Idx | {EXTERNAL LOCATION} | i32 |
+| main.rs:2120:13:2120:13 | u | Idx | {EXTERNAL LOCATION} | u8 |
 | main.rs:2120:18:2120:26 | [...] |  | file://:0:0:0:0 | [] |
+| main.rs:2120:18:2120:26 | [...] | [T;...] | {EXTERNAL LOCATION} | Range |
+| main.rs:2120:18:2120:26 | [...] | [T;...].Idx | {EXTERNAL LOCATION} | i32 |
+| main.rs:2120:18:2120:26 | [...] | [T;...].Idx | {EXTERNAL LOCATION} | u8 |
+| main.rs:2120:19:2120:21 | 0u8 |  | {EXTERNAL LOCATION} | i32 |
 | main.rs:2120:19:2120:21 | 0u8 |  | {EXTERNAL LOCATION} | u8 |
+| main.rs:2120:19:2120:25 | 0u8..10 |  | {EXTERNAL LOCATION} | Range |
+| main.rs:2120:19:2120:25 | 0u8..10 | Idx | {EXTERNAL LOCATION} | i32 |
+| main.rs:2120:19:2120:25 | 0u8..10 | Idx | {EXTERNAL LOCATION} | u8 |
 | main.rs:2120:24:2120:25 | 10 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2120:24:2120:25 | 10 |  | {EXTERNAL LOCATION} | u8 |
+| main.rs:2121:13:2121:17 | range |  | {EXTERNAL LOCATION} | Range |
+| main.rs:2121:13:2121:17 | range | Idx | {EXTERNAL LOCATION} | i32 |
 | main.rs:2121:21:2121:21 | 0 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2121:21:2121:25 | 0..10 |  | {EXTERNAL LOCATION} | Range |
+| main.rs:2121:21:2121:25 | 0..10 | Idx | {EXTERNAL LOCATION} | i32 |
 | main.rs:2121:24:2121:25 | 10 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2122:13:2122:13 | i |  | {EXTERNAL LOCATION} | Item |
+| main.rs:2122:13:2122:13 | i |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2122:18:2122:22 | range |  | {EXTERNAL LOCATION} | Range |
+| main.rs:2122:18:2122:22 | range | Idx | {EXTERNAL LOCATION} | i32 |
 | main.rs:2124:13:2124:18 | range1 |  | {EXTERNAL LOCATION} | Range |
 | main.rs:2124:13:2124:18 | range1 | Idx | {EXTERNAL LOCATION} | u16 |
 | main.rs:2125:9:2128:9 | ...::Range {...} |  | {EXTERNAL LOCATION} | Range |
 | main.rs:2125:9:2128:9 | ...::Range {...} | Idx | {EXTERNAL LOCATION} | u16 |
 | main.rs:2126:20:2126:23 | 0u16 |  | {EXTERNAL LOCATION} | u16 |
 | main.rs:2127:18:2127:22 | 10u16 |  | {EXTERNAL LOCATION} | u16 |
+| main.rs:2129:13:2129:13 | u |  | {EXTERNAL LOCATION} | Item |
+| main.rs:2129:13:2129:13 | u |  | {EXTERNAL LOCATION} | u16 |
 | main.rs:2129:18:2129:23 | range1 |  | {EXTERNAL LOCATION} | Range |
 | main.rs:2129:18:2129:23 | range1 | Idx | {EXTERNAL LOCATION} | u16 |
 | main.rs:2133:26:2133:26 | 1 |  | {EXTERNAL LOCATION} | i32 |
@@ -3246,7 +3280,11 @@ inferType
 | main.rs:2136:39:2136:39 | 2 |  | {EXTERNAL LOCATION} | u16 |
 | main.rs:2136:42:2136:42 | 3 |  | {EXTERNAL LOCATION} | i32 |
 | main.rs:2136:42:2136:42 | 3 |  | {EXTERNAL LOCATION} | u16 |
+| main.rs:2137:13:2137:13 | u |  | {EXTERNAL LOCATION} | Vec |
 | main.rs:2137:13:2137:13 | u |  | {EXTERNAL LOCATION} | u16 |
+| main.rs:2137:13:2137:13 | u |  | file://:0:0:0:0 | & |
+| main.rs:2137:13:2137:13 | u | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2137:13:2137:13 | u | T | {EXTERNAL LOCATION} | u16 |
 | main.rs:2137:18:2137:23 | vals4a |  | {EXTERNAL LOCATION} | Vec |
 | main.rs:2137:18:2137:23 | vals4a | A | {EXTERNAL LOCATION} | Global |
 | main.rs:2137:18:2137:23 | vals4a | T | {EXTERNAL LOCATION} | u16 |
@@ -3274,7 +3312,11 @@ inferType
 | main.rs:2142:38:2142:38 | 2 |  | {EXTERNAL LOCATION} | u32 |
 | main.rs:2142:41:2142:41 | 3 |  | {EXTERNAL LOCATION} | i32 |
 | main.rs:2142:41:2142:41 | 3 |  | {EXTERNAL LOCATION} | u32 |
+| main.rs:2143:13:2143:13 | u |  | {EXTERNAL LOCATION} | Vec |
 | main.rs:2143:13:2143:13 | u |  | {EXTERNAL LOCATION} | u8 |
+| main.rs:2143:13:2143:13 | u |  | file://:0:0:0:0 | & |
+| main.rs:2143:13:2143:13 | u | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2143:13:2143:13 | u | T | {EXTERNAL LOCATION} | u8 |
 | main.rs:2143:18:2143:22 | vals5 |  | {EXTERNAL LOCATION} | Vec |
 | main.rs:2143:18:2143:22 | vals5 | A | {EXTERNAL LOCATION} | Global |
 | main.rs:2143:18:2143:22 | vals5 | T | {EXTERNAL LOCATION} | u8 |
@@ -3295,8 +3337,12 @@ inferType
 | main.rs:2145:39:2145:39 | 2 |  | {EXTERNAL LOCATION} | u64 |
 | main.rs:2145:42:2145:42 | 3 |  | {EXTERNAL LOCATION} | i32 |
 | main.rs:2145:42:2145:42 | 3 |  | {EXTERNAL LOCATION} | u64 |
+| main.rs:2146:13:2146:13 | u |  | {EXTERNAL LOCATION} | Vec |
 | main.rs:2146:13:2146:13 | u |  | file://:0:0:0:0 | & |
 | main.rs:2146:13:2146:13 | u | &T | {EXTERNAL LOCATION} | u64 |
+| main.rs:2146:13:2146:13 | u | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2146:13:2146:13 | u | T | file://:0:0:0:0 | & |
+| main.rs:2146:13:2146:13 | u | T.&T | {EXTERNAL LOCATION} | u64 |
 | main.rs:2146:18:2146:22 | vals6 |  | {EXTERNAL LOCATION} | Vec |
 | main.rs:2146:18:2146:22 | vals6 | A | {EXTERNAL LOCATION} | Global |
 | main.rs:2146:18:2146:22 | vals6 | T | file://:0:0:0:0 | & |
@@ -3308,6 +3354,9 @@ inferType
 | main.rs:2149:9:2149:13 | vals7 |  | {EXTERNAL LOCATION} | Vec |
 | main.rs:2149:9:2149:13 | vals7 | A | {EXTERNAL LOCATION} | Global |
 | main.rs:2149:20:2149:22 | 1u8 |  | {EXTERNAL LOCATION} | u8 |
+| main.rs:2150:13:2150:13 | u |  | {EXTERNAL LOCATION} | Vec |
+| main.rs:2150:13:2150:13 | u |  | file://:0:0:0:0 | & |
+| main.rs:2150:13:2150:13 | u | A | {EXTERNAL LOCATION} | Global |
 | main.rs:2150:18:2150:22 | vals7 |  | {EXTERNAL LOCATION} | Vec |
 | main.rs:2150:18:2150:22 | vals7 | A | {EXTERNAL LOCATION} | Global |
 | main.rs:2152:33:2152:33 | 1 |  | {EXTERNAL LOCATION} | i32 |
@@ -3332,15 +3381,21 @@ inferType
 | main.rs:2161:24:2161:38 | ...::new(...) |  | {EXTERNAL LOCATION} | Box |
 | main.rs:2161:24:2161:38 | ...::new(...) | A | {EXTERNAL LOCATION} | Global |
 | main.rs:2161:33:2161:37 | "two" |  | {EXTERNAL LOCATION} | str |
+| main.rs:2162:13:2162:15 | key |  | {EXTERNAL LOCATION} | Item |
+| main.rs:2162:13:2162:15 | key |  | file://:0:0:0:0 | & |
 | main.rs:2162:20:2162:23 | map1 |  | {EXTERNAL LOCATION} | HashMap |
 | main.rs:2162:20:2162:23 | map1 | S | {EXTERNAL LOCATION} | RandomState |
 | main.rs:2162:20:2162:30 | map1.keys() |  | {EXTERNAL LOCATION} | Keys |
+| main.rs:2163:13:2163:17 | value |  | {EXTERNAL LOCATION} | Item |
+| main.rs:2163:13:2163:17 | value |  | file://:0:0:0:0 | & |
 | main.rs:2163:22:2163:25 | map1 |  | {EXTERNAL LOCATION} | HashMap |
 | main.rs:2163:22:2163:25 | map1 | S | {EXTERNAL LOCATION} | RandomState |
 | main.rs:2163:22:2163:34 | map1.values() |  | {EXTERNAL LOCATION} | Values |
+| main.rs:2164:13:2164:24 | TuplePat |  | {EXTERNAL LOCATION} | Item |
 | main.rs:2164:29:2164:32 | map1 |  | {EXTERNAL LOCATION} | HashMap |
 | main.rs:2164:29:2164:32 | map1 | S | {EXTERNAL LOCATION} | RandomState |
 | main.rs:2164:29:2164:39 | map1.iter() |  | {EXTERNAL LOCATION} | Iter |
+| main.rs:2165:13:2165:24 | TuplePat |  | {EXTERNAL LOCATION} | Item |
 | main.rs:2165:29:2165:33 | &map1 |  | file://:0:0:0:0 | & |
 | main.rs:2165:29:2165:33 | &map1 | &T | {EXTERNAL LOCATION} | HashMap |
 | main.rs:2165:29:2165:33 | &map1 | &T.S | {EXTERNAL LOCATION} | RandomState |


### PR DESCRIPTION
This PR generalizes the existing logic for inferring types of `for` loops to be based on the `IntoIterator` trait, cf. [how `for` loops are desugared](https://doc.rust-lang.org/reference/expressions/loop-expr.html#r-expr.loop.for.desugar). Additionally, this PR also adds type inference for range expressions like `1..10`.

[DCA](https://github.com/github/codeql-dca-main/issues/30038) looks good; more resolved calls, no significant slowdown.