### PR TITLE
Rust: Fix SSA inconsistencies

### DIFF
--- a/rust/ql/lib/codeql/rust/dataflow/internal/SsaImpl.qll
+++ b/rust/ql/lib/codeql/rust/dataflow/internal/SsaImpl.qll
@@ -144,12 +144,6 @@ private predicate writesCapturedVariable(BasicBlock bb, Variable v) {
   getACapturedVariableAccess(bb, v) instanceof VariableWriteAccess
 }
 
-/** Holds if `bb` contains a captured read to variable `v`. */
-pragma[nomagic]
-private predicate readsCapturedVariable(BasicBlock bb, Variable v) {
-  variableReadCertain(_, _, getACapturedVariableAccess(bb, v), _)
-}
-
 /**
  * Holds if captured variable `v` is read directly inside `scope`,
  * or inside a (transitively) nested scope of `scope`.
@@ -229,7 +223,7 @@ private module Cached {
    */
   cached
   predicate capturedEntryWrite(EntryBasicBlock bb, int i, Variable v) {
-    readsCapturedVariable(bb.getASuccessor*(), v) and
+    exists(getACapturedVariableAccess(bb.getASuccessor*(), v)) and
     i = -1
   }
 

--- a/rust/ql/test/library-tests/variables/CONSISTENCY/PathResolutionConsistency.expected
+++ b/rust/ql/test/library-tests/variables/CONSISTENCY/PathResolutionConsistency.expected
@@ -1,3 +1,3 @@
 multipleCallTargets
-| main.rs:85:19:85:40 | ...::from(...) |
-| main.rs:102:19:102:40 | ...::from(...) |
+| main.rs:87:19:87:40 | ...::from(...) |
+| main.rs:106:19:106:40 | ...::from(...) |

--- a/rust/ql/test/library-tests/variables/CONSISTENCY/SsaConsistency.expected
+++ b/rust/ql/test/library-tests/variables/CONSISTENCY/SsaConsistency.expected
@@ -1,4 +1,0 @@
-uselessPhiNode
-| main.rs:629:17:631:9 | SSA phi(x) | 1 |
-phiWithoutTwoPriorRefs
-| main.rs:629:17:631:9 | SSA phi(x) | main.rs:629:17:631:9 | if b {...} | main.rs:626:13:626:13 | x | 1 |

--- a/rust/ql/test/library-tests/variables/CONSISTENCY/SsaConsistency.expected
+++ b/rust/ql/test/library-tests/variables/CONSISTENCY/SsaConsistency.expected
@@ -1,0 +1,4 @@
+uselessPhiNode
+| main.rs:629:17:631:9 | SSA phi(x) | 1 |
+phiWithoutTwoPriorRefs
+| main.rs:629:17:631:9 | SSA phi(x) | main.rs:629:17:631:9 | if b {...} | main.rs:626:13:626:13 | x | 1 |

--- a/rust/ql/test/library-tests/variables/Cfg.expected
+++ b/rust/ql/test/library-tests/variables/Cfg.expected
@@ -1,1583 +1,1640 @@
 edges
-| main.rs:3:1:5:1 | enter fn print_str | main.rs:3:14:3:14 | s |  |
-| main.rs:3:1:5:1 | exit fn print_str (normal) | main.rs:3:1:5:1 | exit fn print_str |  |
+| main.rs:3:1:6:1 | enter fn print_str | main.rs:3:14:3:14 | s |  |
+| main.rs:3:1:6:1 | exit fn print_str (normal) | main.rs:3:1:6:1 | exit fn print_str |  |
 | main.rs:3:14:3:14 | s | main.rs:3:14:3:14 | s |  |
 | main.rs:3:14:3:14 | s | main.rs:3:14:3:20 | ...: ... | match |
-| main.rs:3:14:3:20 | ...: ... | main.rs:4:5:4:22 | ExprStmt |  |
-| main.rs:3:23:5:1 | { ... } | main.rs:3:1:5:1 | exit fn print_str (normal) |  |
-| main.rs:4:5:4:21 | ...::_print | main.rs:4:14:4:17 | "{}\\n" |  |
-| main.rs:4:5:4:21 | MacroExpr | main.rs:3:23:5:1 | { ... } |  |
-| main.rs:4:5:4:21 | println!... | main.rs:4:5:4:21 | MacroExpr |  |
-| main.rs:4:5:4:22 | ExprStmt | main.rs:4:14:4:20 | ExprStmt |  |
-| main.rs:4:14:4:17 | "{}\\n" | main.rs:4:20:4:20 | s |  |
-| main.rs:4:14:4:20 | ...::_print(...) | main.rs:4:14:4:20 | { ... } |  |
-| main.rs:4:14:4:20 | ...::format_args_nl!... | main.rs:4:14:4:20 | MacroExpr |  |
-| main.rs:4:14:4:20 | ExprStmt | main.rs:4:5:4:21 | ...::_print |  |
-| main.rs:4:14:4:20 | FormatArgsExpr | main.rs:4:14:4:20 | ...::format_args_nl!... |  |
-| main.rs:4:14:4:20 | MacroBlockExpr | main.rs:4:5:4:21 | println!... |  |
-| main.rs:4:14:4:20 | MacroExpr | main.rs:4:14:4:20 | ...::_print(...) |  |
-| main.rs:4:14:4:20 | { ... } | main.rs:4:14:4:20 | MacroBlockExpr |  |
-| main.rs:4:20:4:20 | s | main.rs:4:14:4:20 | FormatArgsExpr |  |
-| main.rs:7:1:9:1 | enter fn print_i64 | main.rs:7:14:7:14 | i |  |
-| main.rs:7:1:9:1 | exit fn print_i64 (normal) | main.rs:7:1:9:1 | exit fn print_i64 |  |
-| main.rs:7:14:7:14 | i | main.rs:7:14:7:14 | i |  |
-| main.rs:7:14:7:14 | i | main.rs:7:14:7:19 | ...: i64 | match |
-| main.rs:7:14:7:19 | ...: i64 | main.rs:8:5:8:22 | ExprStmt |  |
-| main.rs:7:22:9:1 | { ... } | main.rs:7:1:9:1 | exit fn print_i64 (normal) |  |
-| main.rs:8:5:8:21 | ...::_print | main.rs:8:14:8:17 | "{}\\n" |  |
-| main.rs:8:5:8:21 | MacroExpr | main.rs:7:22:9:1 | { ... } |  |
-| main.rs:8:5:8:21 | println!... | main.rs:8:5:8:21 | MacroExpr |  |
-| main.rs:8:5:8:22 | ExprStmt | main.rs:8:14:8:20 | ExprStmt |  |
-| main.rs:8:14:8:17 | "{}\\n" | main.rs:8:20:8:20 | i |  |
-| main.rs:8:14:8:20 | ...::_print(...) | main.rs:8:14:8:20 | { ... } |  |
-| main.rs:8:14:8:20 | ...::format_args_nl!... | main.rs:8:14:8:20 | MacroExpr |  |
-| main.rs:8:14:8:20 | ExprStmt | main.rs:8:5:8:21 | ...::_print |  |
-| main.rs:8:14:8:20 | FormatArgsExpr | main.rs:8:14:8:20 | ...::format_args_nl!... |  |
-| main.rs:8:14:8:20 | MacroBlockExpr | main.rs:8:5:8:21 | println!... |  |
-| main.rs:8:14:8:20 | MacroExpr | main.rs:8:14:8:20 | ...::_print(...) |  |
-| main.rs:8:14:8:20 | { ... } | main.rs:8:14:8:20 | MacroBlockExpr |  |
-| main.rs:8:20:8:20 | i | main.rs:8:14:8:20 | FormatArgsExpr |  |
-| main.rs:11:1:13:1 | enter fn print_i64_ref | main.rs:11:18:11:18 | i |  |
-| main.rs:11:1:13:1 | exit fn print_i64_ref (normal) | main.rs:11:1:13:1 | exit fn print_i64_ref |  |
-| main.rs:11:18:11:18 | i | main.rs:11:18:11:18 | i |  |
-| main.rs:11:18:11:18 | i | main.rs:11:18:11:24 | ...: ... | match |
-| main.rs:11:18:11:24 | ...: ... | main.rs:12:5:12:13 | print_i64 |  |
-| main.rs:11:27:13:1 | { ... } | main.rs:11:1:13:1 | exit fn print_i64_ref (normal) |  |
-| main.rs:12:5:12:13 | print_i64 | main.rs:12:16:12:16 | i |  |
-| main.rs:12:5:12:17 | print_i64(...) | main.rs:11:27:13:1 | { ... } |  |
-| main.rs:12:15:12:16 | * ... | main.rs:12:5:12:17 | print_i64(...) |  |
-| main.rs:12:16:12:16 | i | main.rs:12:15:12:16 | * ... |  |
-| main.rs:15:1:18:1 | enter fn immutable_variable | main.rs:16:5:16:17 | let ... = "a" |  |
-| main.rs:15:1:18:1 | exit fn immutable_variable (normal) | main.rs:15:1:18:1 | exit fn immutable_variable |  |
-| main.rs:15:25:18:1 | { ... } | main.rs:15:1:18:1 | exit fn immutable_variable (normal) |  |
-| main.rs:16:5:16:17 | let ... = "a" | main.rs:16:14:16:16 | "a" |  |
-| main.rs:16:9:16:10 | x1 | main.rs:16:9:16:10 | x1 |  |
-| main.rs:16:9:16:10 | x1 | main.rs:17:5:17:18 | ExprStmt | match |
-| main.rs:16:14:16:16 | "a" | main.rs:16:9:16:10 | x1 |  |
-| main.rs:17:5:17:13 | print_str | main.rs:17:15:17:16 | x1 |  |
-| main.rs:17:5:17:17 | print_str(...) | main.rs:15:25:18:1 | { ... } |  |
-| main.rs:17:5:17:18 | ExprStmt | main.rs:17:5:17:13 | print_str |  |
-| main.rs:17:15:17:16 | x1 | main.rs:17:5:17:17 | print_str(...) |  |
-| main.rs:20:1:25:1 | enter fn mutable_variable | main.rs:21:5:21:19 | let ... = 4 |  |
-| main.rs:20:1:25:1 | exit fn mutable_variable (normal) | main.rs:20:1:25:1 | exit fn mutable_variable |  |
-| main.rs:20:23:25:1 | { ... } | main.rs:20:1:25:1 | exit fn mutable_variable (normal) |  |
-| main.rs:21:5:21:19 | let ... = 4 | main.rs:21:18:21:18 | 4 |  |
-| main.rs:21:9:21:14 | mut x2 | main.rs:22:5:22:18 | ExprStmt | match |
-| main.rs:21:13:21:14 | x2 | main.rs:21:9:21:14 | mut x2 |  |
-| main.rs:21:18:21:18 | 4 | main.rs:21:13:21:14 | x2 |  |
-| main.rs:22:5:22:13 | print_i64 | main.rs:22:15:22:16 | x2 |  |
-| main.rs:22:5:22:17 | print_i64(...) | main.rs:23:5:23:11 | ExprStmt |  |
-| main.rs:22:5:22:18 | ExprStmt | main.rs:22:5:22:13 | print_i64 |  |
-| main.rs:22:15:22:16 | x2 | main.rs:22:5:22:17 | print_i64(...) |  |
-| main.rs:23:5:23:6 | x2 | main.rs:23:10:23:10 | 5 |  |
-| main.rs:23:5:23:10 | ... = ... | main.rs:24:5:24:18 | ExprStmt |  |
-| main.rs:23:5:23:11 | ExprStmt | main.rs:23:5:23:6 | x2 |  |
-| main.rs:23:10:23:10 | 5 | main.rs:23:5:23:10 | ... = ... |  |
+| main.rs:3:14:3:20 | ...: ... | main.rs:5:5:5:22 | ExprStmt |  |
+| main.rs:4:1:6:1 | { ... } | main.rs:3:1:6:1 | exit fn print_str (normal) |  |
+| main.rs:5:5:5:21 | ...::_print | main.rs:5:14:5:17 | "{}\\n" |  |
+| main.rs:5:5:5:21 | MacroExpr | main.rs:4:1:6:1 | { ... } |  |
+| main.rs:5:5:5:21 | println!... | main.rs:5:5:5:21 | MacroExpr |  |
+| main.rs:5:5:5:22 | ExprStmt | main.rs:5:14:5:20 | ExprStmt |  |
+| main.rs:5:14:5:17 | "{}\\n" | main.rs:5:20:5:20 | s |  |
+| main.rs:5:14:5:20 | ...::_print(...) | main.rs:5:14:5:20 | { ... } |  |
+| main.rs:5:14:5:20 | ...::format_args_nl!... | main.rs:5:14:5:20 | MacroExpr |  |
+| main.rs:5:14:5:20 | ExprStmt | main.rs:5:5:5:21 | ...::_print |  |
+| main.rs:5:14:5:20 | FormatArgsExpr | main.rs:5:14:5:20 | ...::format_args_nl!... |  |
+| main.rs:5:14:5:20 | MacroBlockExpr | main.rs:5:5:5:21 | println!... |  |
+| main.rs:5:14:5:20 | MacroExpr | main.rs:5:14:5:20 | ...::_print(...) |  |
+| main.rs:5:14:5:20 | { ... } | main.rs:5:14:5:20 | MacroBlockExpr |  |
+| main.rs:5:20:5:20 | s | main.rs:5:14:5:20 | FormatArgsExpr |  |
+| main.rs:8:1:11:1 | enter fn print_i64 | main.rs:8:14:8:14 | i |  |
+| main.rs:8:1:11:1 | exit fn print_i64 (normal) | main.rs:8:1:11:1 | exit fn print_i64 |  |
+| main.rs:8:14:8:14 | i | main.rs:8:14:8:14 | i |  |
+| main.rs:8:14:8:14 | i | main.rs:8:14:8:19 | ...: i64 | match |
+| main.rs:8:14:8:19 | ...: i64 | main.rs:10:5:10:22 | ExprStmt |  |
+| main.rs:9:1:11:1 | { ... } | main.rs:8:1:11:1 | exit fn print_i64 (normal) |  |
+| main.rs:10:5:10:21 | ...::_print | main.rs:10:14:10:17 | "{}\\n" |  |
+| main.rs:10:5:10:21 | MacroExpr | main.rs:9:1:11:1 | { ... } |  |
+| main.rs:10:5:10:21 | println!... | main.rs:10:5:10:21 | MacroExpr |  |
+| main.rs:10:5:10:22 | ExprStmt | main.rs:10:14:10:20 | ExprStmt |  |
+| main.rs:10:14:10:17 | "{}\\n" | main.rs:10:20:10:20 | i |  |
+| main.rs:10:14:10:20 | ...::_print(...) | main.rs:10:14:10:20 | { ... } |  |
+| main.rs:10:14:10:20 | ...::format_args_nl!... | main.rs:10:14:10:20 | MacroExpr |  |
+| main.rs:10:14:10:20 | ExprStmt | main.rs:10:5:10:21 | ...::_print |  |
+| main.rs:10:14:10:20 | FormatArgsExpr | main.rs:10:14:10:20 | ...::format_args_nl!... |  |
+| main.rs:10:14:10:20 | MacroBlockExpr | main.rs:10:5:10:21 | println!... |  |
+| main.rs:10:14:10:20 | MacroExpr | main.rs:10:14:10:20 | ...::_print(...) |  |
+| main.rs:10:14:10:20 | { ... } | main.rs:10:14:10:20 | MacroBlockExpr |  |
+| main.rs:10:20:10:20 | i | main.rs:10:14:10:20 | FormatArgsExpr |  |
+| main.rs:13:1:15:1 | enter fn print_i64_ref | main.rs:13:18:13:18 | i |  |
+| main.rs:13:1:15:1 | exit fn print_i64_ref (normal) | main.rs:13:1:15:1 | exit fn print_i64_ref |  |
+| main.rs:13:18:13:18 | i | main.rs:13:18:13:18 | i |  |
+| main.rs:13:18:13:18 | i | main.rs:13:18:13:24 | ...: ... | match |
+| main.rs:13:18:13:24 | ...: ... | main.rs:14:5:14:13 | print_i64 |  |
+| main.rs:13:27:15:1 | { ... } | main.rs:13:1:15:1 | exit fn print_i64_ref (normal) |  |
+| main.rs:14:5:14:13 | print_i64 | main.rs:14:16:14:16 | i |  |
+| main.rs:14:5:14:17 | print_i64(...) | main.rs:13:27:15:1 | { ... } |  |
+| main.rs:14:15:14:16 | * ... | main.rs:14:5:14:17 | print_i64(...) |  |
+| main.rs:14:16:14:16 | i | main.rs:14:15:14:16 | * ... |  |
+| main.rs:17:1:20:1 | enter fn immutable_variable | main.rs:18:5:18:17 | let ... = "a" |  |
+| main.rs:17:1:20:1 | exit fn immutable_variable (normal) | main.rs:17:1:20:1 | exit fn immutable_variable |  |
+| main.rs:17:25:20:1 | { ... } | main.rs:17:1:20:1 | exit fn immutable_variable (normal) |  |
+| main.rs:18:5:18:17 | let ... = "a" | main.rs:18:14:18:16 | "a" |  |
+| main.rs:18:9:18:10 | x1 | main.rs:18:9:18:10 | x1 |  |
+| main.rs:18:9:18:10 | x1 | main.rs:19:5:19:18 | ExprStmt | match |
+| main.rs:18:14:18:16 | "a" | main.rs:18:9:18:10 | x1 |  |
+| main.rs:19:5:19:13 | print_str | main.rs:19:15:19:16 | x1 |  |
+| main.rs:19:5:19:17 | print_str(...) | main.rs:17:25:20:1 | { ... } |  |
+| main.rs:19:5:19:18 | ExprStmt | main.rs:19:5:19:13 | print_str |  |
+| main.rs:19:15:19:16 | x1 | main.rs:19:5:19:17 | print_str(...) |  |
+| main.rs:22:1:27:1 | enter fn mutable_variable | main.rs:23:5:23:19 | let ... = 4 |  |
+| main.rs:22:1:27:1 | exit fn mutable_variable (normal) | main.rs:22:1:27:1 | exit fn mutable_variable |  |
+| main.rs:22:23:27:1 | { ... } | main.rs:22:1:27:1 | exit fn mutable_variable (normal) |  |
+| main.rs:23:5:23:19 | let ... = 4 | main.rs:23:18:23:18 | 4 |  |
+| main.rs:23:9:23:14 | mut x2 | main.rs:24:5:24:18 | ExprStmt | match |
+| main.rs:23:13:23:14 | x2 | main.rs:23:9:23:14 | mut x2 |  |
+| main.rs:23:18:23:18 | 4 | main.rs:23:13:23:14 | x2 |  |
 | main.rs:24:5:24:13 | print_i64 | main.rs:24:15:24:16 | x2 |  |
-| main.rs:24:5:24:17 | print_i64(...) | main.rs:20:23:25:1 | { ... } |  |
+| main.rs:24:5:24:17 | print_i64(...) | main.rs:25:5:25:11 | ExprStmt |  |
 | main.rs:24:5:24:18 | ExprStmt | main.rs:24:5:24:13 | print_i64 |  |
 | main.rs:24:15:24:16 | x2 | main.rs:24:5:24:17 | print_i64(...) |  |
-| main.rs:27:1:32:1 | enter fn mutable_variable_immutable_borrow | main.rs:28:5:28:18 | let ... = 1 |  |
-| main.rs:27:1:32:1 | exit fn mutable_variable_immutable_borrow (normal) | main.rs:27:1:32:1 | exit fn mutable_variable_immutable_borrow |  |
-| main.rs:27:40:32:1 | { ... } | main.rs:27:1:32:1 | exit fn mutable_variable_immutable_borrow (normal) |  |
-| main.rs:28:5:28:18 | let ... = 1 | main.rs:28:17:28:17 | 1 |  |
-| main.rs:28:9:28:13 | mut x | main.rs:29:5:29:22 | ExprStmt | match |
-| main.rs:28:13:28:13 | x | main.rs:28:9:28:13 | mut x |  |
-| main.rs:28:17:28:17 | 1 | main.rs:28:13:28:13 | x |  |
-| main.rs:29:5:29:17 | print_i64_ref | main.rs:29:20:29:20 | x |  |
-| main.rs:29:5:29:21 | print_i64_ref(...) | main.rs:30:5:30:10 | ExprStmt |  |
-| main.rs:29:5:29:22 | ExprStmt | main.rs:29:5:29:17 | print_i64_ref |  |
-| main.rs:29:19:29:20 | &x | main.rs:29:5:29:21 | print_i64_ref(...) |  |
-| main.rs:29:20:29:20 | x | main.rs:29:19:29:20 | &x |  |
-| main.rs:30:5:30:5 | x | main.rs:30:9:30:9 | 2 |  |
-| main.rs:30:5:30:9 | ... = ... | main.rs:31:5:31:22 | ExprStmt |  |
-| main.rs:30:5:30:10 | ExprStmt | main.rs:30:5:30:5 | x |  |
-| main.rs:30:9:30:9 | 2 | main.rs:30:5:30:9 | ... = ... |  |
+| main.rs:25:5:25:6 | x2 | main.rs:25:10:25:10 | 5 |  |
+| main.rs:25:5:25:10 | ... = ... | main.rs:26:5:26:18 | ExprStmt |  |
+| main.rs:25:5:25:11 | ExprStmt | main.rs:25:5:25:6 | x2 |  |
+| main.rs:25:10:25:10 | 5 | main.rs:25:5:25:10 | ... = ... |  |
+| main.rs:26:5:26:13 | print_i64 | main.rs:26:15:26:16 | x2 |  |
+| main.rs:26:5:26:17 | print_i64(...) | main.rs:22:23:27:1 | { ... } |  |
+| main.rs:26:5:26:18 | ExprStmt | main.rs:26:5:26:13 | print_i64 |  |
+| main.rs:26:15:26:16 | x2 | main.rs:26:5:26:17 | print_i64(...) |  |
+| main.rs:29:1:34:1 | enter fn mutable_variable_immutable_borrow | main.rs:30:5:30:18 | let ... = 1 |  |
+| main.rs:29:1:34:1 | exit fn mutable_variable_immutable_borrow (normal) | main.rs:29:1:34:1 | exit fn mutable_variable_immutable_borrow |  |
+| main.rs:29:40:34:1 | { ... } | main.rs:29:1:34:1 | exit fn mutable_variable_immutable_borrow (normal) |  |
+| main.rs:30:5:30:18 | let ... = 1 | main.rs:30:17:30:17 | 1 |  |
+| main.rs:30:9:30:13 | mut x | main.rs:31:5:31:22 | ExprStmt | match |
+| main.rs:30:13:30:13 | x | main.rs:30:9:30:13 | mut x |  |
+| main.rs:30:17:30:17 | 1 | main.rs:30:13:30:13 | x |  |
 | main.rs:31:5:31:17 | print_i64_ref | main.rs:31:20:31:20 | x |  |
-| main.rs:31:5:31:21 | print_i64_ref(...) | main.rs:27:40:32:1 | { ... } |  |
+| main.rs:31:5:31:21 | print_i64_ref(...) | main.rs:32:5:32:10 | ExprStmt |  |
 | main.rs:31:5:31:22 | ExprStmt | main.rs:31:5:31:17 | print_i64_ref |  |
 | main.rs:31:19:31:20 | &x | main.rs:31:5:31:21 | print_i64_ref(...) |  |
 | main.rs:31:20:31:20 | x | main.rs:31:19:31:20 | &x |  |
-| main.rs:34:1:40:1 | enter fn variable_shadow1 | main.rs:35:5:35:15 | let ... = 1 |  |
-| main.rs:34:1:40:1 | exit fn variable_shadow1 (normal) | main.rs:34:1:40:1 | exit fn variable_shadow1 |  |
-| main.rs:34:23:40:1 | { ... } | main.rs:34:1:40:1 | exit fn variable_shadow1 (normal) |  |
-| main.rs:35:5:35:15 | let ... = 1 | main.rs:35:14:35:14 | 1 |  |
-| main.rs:35:9:35:10 | x3 | main.rs:35:9:35:10 | x3 |  |
-| main.rs:35:9:35:10 | x3 | main.rs:36:5:36:18 | ExprStmt | match |
-| main.rs:35:14:35:14 | 1 | main.rs:35:9:35:10 | x3 |  |
-| main.rs:36:5:36:13 | print_i64 | main.rs:36:15:36:16 | x3 |  |
-| main.rs:36:5:36:17 | print_i64(...) | main.rs:37:5:38:15 | let ... = ... |  |
-| main.rs:36:5:36:18 | ExprStmt | main.rs:36:5:36:13 | print_i64 |  |
-| main.rs:36:15:36:16 | x3 | main.rs:36:5:36:17 | print_i64(...) |  |
-| main.rs:37:5:38:15 | let ... = ... | main.rs:38:9:38:10 | x3 |  |
+| main.rs:32:5:32:5 | x | main.rs:32:9:32:9 | 2 |  |
+| main.rs:32:5:32:9 | ... = ... | main.rs:33:5:33:22 | ExprStmt |  |
+| main.rs:32:5:32:10 | ExprStmt | main.rs:32:5:32:5 | x |  |
+| main.rs:32:9:32:9 | 2 | main.rs:32:5:32:9 | ... = ... |  |
+| main.rs:33:5:33:17 | print_i64_ref | main.rs:33:20:33:20 | x |  |
+| main.rs:33:5:33:21 | print_i64_ref(...) | main.rs:29:40:34:1 | { ... } |  |
+| main.rs:33:5:33:22 | ExprStmt | main.rs:33:5:33:17 | print_i64_ref |  |
+| main.rs:33:19:33:20 | &x | main.rs:33:5:33:21 | print_i64_ref(...) |  |
+| main.rs:33:20:33:20 | x | main.rs:33:19:33:20 | &x |  |
+| main.rs:36:1:42:1 | enter fn variable_shadow1 | main.rs:37:5:37:15 | let ... = 1 |  |
+| main.rs:36:1:42:1 | exit fn variable_shadow1 (normal) | main.rs:36:1:42:1 | exit fn variable_shadow1 |  |
+| main.rs:36:23:42:1 | { ... } | main.rs:36:1:42:1 | exit fn variable_shadow1 (normal) |  |
+| main.rs:37:5:37:15 | let ... = 1 | main.rs:37:14:37:14 | 1 |  |
 | main.rs:37:9:37:10 | x3 | main.rs:37:9:37:10 | x3 |  |
-| main.rs:37:9:37:10 | x3 | main.rs:39:5:39:18 | ExprStmt | match |
-| main.rs:38:9:38:10 | x3 | main.rs:38:14:38:14 | 1 |  |
-| main.rs:38:9:38:14 | ... + ... | main.rs:37:9:37:10 | x3 |  |
-| main.rs:38:14:38:14 | 1 | main.rs:38:9:38:14 | ... + ... |  |
-| main.rs:39:5:39:13 | print_i64 | main.rs:39:15:39:16 | x3 |  |
-| main.rs:39:5:39:17 | print_i64(...) | main.rs:34:23:40:1 | { ... } |  |
-| main.rs:39:5:39:18 | ExprStmt | main.rs:39:5:39:13 | print_i64 |  |
-| main.rs:39:15:39:16 | x3 | main.rs:39:5:39:17 | print_i64(...) |  |
-| main.rs:42:1:50:1 | enter fn variable_shadow2 | main.rs:43:5:43:17 | let ... = "a" |  |
-| main.rs:42:1:50:1 | exit fn variable_shadow2 (normal) | main.rs:42:1:50:1 | exit fn variable_shadow2 |  |
-| main.rs:42:23:50:1 | { ... } | main.rs:42:1:50:1 | exit fn variable_shadow2 (normal) |  |
-| main.rs:43:5:43:17 | let ... = "a" | main.rs:43:14:43:16 | "a" |  |
-| main.rs:43:9:43:10 | x4 | main.rs:43:9:43:10 | x4 |  |
-| main.rs:43:9:43:10 | x4 | main.rs:44:5:44:18 | ExprStmt | match |
-| main.rs:43:14:43:16 | "a" | main.rs:43:9:43:10 | x4 |  |
-| main.rs:44:5:44:13 | print_str | main.rs:44:15:44:16 | x4 |  |
-| main.rs:44:5:44:17 | print_str(...) | main.rs:45:5:48:5 | ExprStmt |  |
-| main.rs:44:5:44:18 | ExprStmt | main.rs:44:5:44:13 | print_str |  |
-| main.rs:44:15:44:16 | x4 | main.rs:44:5:44:17 | print_str(...) |  |
-| main.rs:45:5:48:5 | ExprStmt | main.rs:46:9:46:21 | let ... = "b" |  |
-| main.rs:45:5:48:5 | { ... } | main.rs:49:5:49:18 | ExprStmt |  |
-| main.rs:46:9:46:21 | let ... = "b" | main.rs:46:18:46:20 | "b" |  |
-| main.rs:46:13:46:14 | x4 | main.rs:46:13:46:14 | x4 |  |
-| main.rs:46:13:46:14 | x4 | main.rs:47:9:47:22 | ExprStmt | match |
-| main.rs:46:18:46:20 | "b" | main.rs:46:13:46:14 | x4 |  |
-| main.rs:47:9:47:17 | print_str | main.rs:47:19:47:20 | x4 |  |
-| main.rs:47:9:47:21 | print_str(...) | main.rs:45:5:48:5 | { ... } |  |
-| main.rs:47:9:47:22 | ExprStmt | main.rs:47:9:47:17 | print_str |  |
-| main.rs:47:19:47:20 | x4 | main.rs:47:9:47:21 | print_str(...) |  |
-| main.rs:49:5:49:13 | print_str | main.rs:49:15:49:16 | x4 |  |
-| main.rs:49:5:49:17 | print_str(...) | main.rs:42:23:50:1 | { ... } |  |
-| main.rs:49:5:49:18 | ExprStmt | main.rs:49:5:49:13 | print_str |  |
-| main.rs:49:15:49:16 | x4 | main.rs:49:5:49:17 | print_str(...) |  |
-| main.rs:57:1:72:1 | enter fn let_pattern1 | main.rs:58:5:67:47 | let ... = ... |  |
-| main.rs:57:1:72:1 | exit fn let_pattern1 (normal) | main.rs:57:1:72:1 | exit fn let_pattern1 |  |
-| main.rs:57:19:72:1 | { ... } | main.rs:57:1:72:1 | exit fn let_pattern1 (normal) |  |
-| main.rs:58:5:67:47 | let ... = ... | main.rs:67:11:67:13 | "a" |  |
-| main.rs:58:9:67:5 | TuplePat | main.rs:59:9:62:9 | TuplePat | match |
-| main.rs:59:9:62:9 | TuplePat | main.rs:60:13:60:14 | a1 | match |
-| main.rs:60:13:60:14 | a1 | main.rs:60:13:60:14 | a1 |  |
-| main.rs:60:13:60:14 | a1 | main.rs:61:13:61:14 | b1 | match |
-| main.rs:61:13:61:14 | b1 | main.rs:61:13:61:14 | b1 |  |
-| main.rs:61:13:61:14 | b1 | main.rs:63:9:66:9 | Point {...} | match |
-| main.rs:63:9:66:9 | Point {...} | main.rs:64:13:64:13 | x | match |
-| main.rs:64:13:64:13 | x | main.rs:64:13:64:13 | x |  |
-| main.rs:64:13:64:13 | x | main.rs:65:13:65:13 | y | match |
-| main.rs:65:13:65:13 | y | main.rs:65:13:65:13 | y |  |
-| main.rs:65:13:65:13 | y | main.rs:68:5:68:18 | ExprStmt | match |
-| main.rs:67:9:67:46 | TupleExpr | main.rs:58:9:67:5 | TuplePat |  |
-| main.rs:67:10:67:19 | TupleExpr | main.rs:67:33:67:35 | "x" |  |
-| main.rs:67:11:67:13 | "a" | main.rs:67:16:67:18 | "b" |  |
-| main.rs:67:16:67:18 | "b" | main.rs:67:10:67:19 | TupleExpr |  |
-| main.rs:67:22:67:45 | Point {...} | main.rs:67:9:67:46 | TupleExpr |  |
-| main.rs:67:33:67:35 | "x" | main.rs:67:41:67:43 | "y" |  |
-| main.rs:67:41:67:43 | "y" | main.rs:67:22:67:45 | Point {...} |  |
-| main.rs:68:5:68:13 | print_str | main.rs:68:15:68:16 | a1 |  |
-| main.rs:68:5:68:17 | print_str(...) | main.rs:69:5:69:18 | ExprStmt |  |
-| main.rs:68:5:68:18 | ExprStmt | main.rs:68:5:68:13 | print_str |  |
-| main.rs:68:15:68:16 | a1 | main.rs:68:5:68:17 | print_str(...) |  |
-| main.rs:69:5:69:13 | print_str | main.rs:69:15:69:16 | b1 |  |
-| main.rs:69:5:69:17 | print_str(...) | main.rs:70:5:70:17 | ExprStmt |  |
-| main.rs:69:5:69:18 | ExprStmt | main.rs:69:5:69:13 | print_str |  |
-| main.rs:69:15:69:16 | b1 | main.rs:69:5:69:17 | print_str(...) |  |
-| main.rs:70:5:70:13 | print_str | main.rs:70:15:70:15 | x |  |
-| main.rs:70:5:70:16 | print_str(...) | main.rs:71:5:71:17 | ExprStmt |  |
-| main.rs:70:5:70:17 | ExprStmt | main.rs:70:5:70:13 | print_str |  |
-| main.rs:70:15:70:15 | x | main.rs:70:5:70:16 | print_str(...) |  |
-| main.rs:71:5:71:13 | print_str | main.rs:71:15:71:15 | y |  |
-| main.rs:71:5:71:16 | print_str(...) | main.rs:57:19:72:1 | { ... } |  |
-| main.rs:71:5:71:17 | ExprStmt | main.rs:71:5:71:13 | print_str |  |
-| main.rs:71:15:71:15 | y | main.rs:71:5:71:16 | print_str(...) |  |
-| main.rs:74:1:82:1 | enter fn let_pattern2 | main.rs:75:5:75:38 | let ... = ... |  |
-| main.rs:74:1:82:1 | exit fn let_pattern2 (normal) | main.rs:74:1:82:1 | exit fn let_pattern2 |  |
-| main.rs:74:19:82:1 | { ... } | main.rs:74:1:82:1 | exit fn let_pattern2 (normal) |  |
-| main.rs:75:5:75:38 | let ... = ... | main.rs:75:25:75:27 | "a" |  |
-| main.rs:75:9:75:10 | p1 | main.rs:75:9:75:10 | p1 |  |
-| main.rs:75:9:75:10 | p1 | main.rs:76:5:79:11 | let ... = p1 | match |
-| main.rs:75:14:75:37 | Point {...} | main.rs:75:9:75:10 | p1 |  |
-| main.rs:75:25:75:27 | "a" | main.rs:75:33:75:35 | "b" |  |
-| main.rs:75:33:75:35 | "b" | main.rs:75:14:75:37 | Point {...} |  |
-| main.rs:76:5:79:11 | let ... = p1 | main.rs:79:9:79:10 | p1 |  |
-| main.rs:76:9:79:5 | Point {...} | main.rs:77:12:77:13 | a2 | match |
-| main.rs:77:12:77:13 | a2 | main.rs:77:12:77:13 | a2 |  |
-| main.rs:77:12:77:13 | a2 | main.rs:78:12:78:13 | b2 | match |
-| main.rs:78:12:78:13 | b2 | main.rs:78:12:78:13 | b2 |  |
-| main.rs:78:12:78:13 | b2 | main.rs:80:5:80:18 | ExprStmt | match |
-| main.rs:79:9:79:10 | p1 | main.rs:76:9:79:5 | Point {...} |  |
-| main.rs:80:5:80:13 | print_str | main.rs:80:15:80:16 | a2 |  |
-| main.rs:80:5:80:17 | print_str(...) | main.rs:81:5:81:18 | ExprStmt |  |
-| main.rs:80:5:80:18 | ExprStmt | main.rs:80:5:80:13 | print_str |  |
-| main.rs:80:15:80:16 | a2 | main.rs:80:5:80:17 | print_str(...) |  |
-| main.rs:81:5:81:13 | print_str | main.rs:81:15:81:16 | b2 |  |
-| main.rs:81:5:81:17 | print_str(...) | main.rs:74:19:82:1 | { ... } |  |
-| main.rs:81:5:81:18 | ExprStmt | main.rs:81:5:81:13 | print_str |  |
-| main.rs:81:15:81:16 | b2 | main.rs:81:5:81:17 | print_str(...) |  |
-| main.rs:84:1:91:1 | enter fn let_pattern3 | main.rs:85:5:85:42 | let ... = ... |  |
-| main.rs:84:1:91:1 | exit fn let_pattern3 (normal) | main.rs:84:1:91:1 | exit fn let_pattern3 |  |
-| main.rs:84:19:91:1 | { ... } | main.rs:84:1:91:1 | exit fn let_pattern3 (normal) |  |
-| main.rs:85:5:85:42 | let ... = ... | main.rs:85:14:85:17 | Some |  |
-| main.rs:85:9:85:10 | s1 | main.rs:85:9:85:10 | s1 |  |
-| main.rs:85:9:85:10 | s1 | main.rs:87:8:88:12 | let ... = s1 | match |
-| main.rs:85:14:85:17 | Some | main.rs:85:19:85:30 | ...::from |  |
-| main.rs:85:14:85:41 | Some(...) | main.rs:85:9:85:10 | s1 |  |
-| main.rs:85:19:85:30 | ...::from | main.rs:85:32:85:39 | "Hello!" |  |
-| main.rs:85:19:85:40 | ...::from(...) | main.rs:85:14:85:41 | Some(...) |  |
-| main.rs:85:32:85:39 | "Hello!" | main.rs:85:19:85:40 | ...::from(...) |  |
-| main.rs:87:5:90:5 | if ... {...} | main.rs:84:19:91:1 | { ... } |  |
-| main.rs:87:8:88:12 | let ... = s1 | main.rs:88:11:88:12 | s1 |  |
-| main.rs:87:12:87:23 | Some(...) | main.rs:87:5:90:5 | if ... {...} | no-match |
-| main.rs:87:12:87:23 | Some(...) | main.rs:87:21:87:22 | s2 | match |
-| main.rs:87:17:87:22 | ref s2 | main.rs:89:9:89:22 | ExprStmt | match |
-| main.rs:87:21:87:22 | s2 | main.rs:87:17:87:22 | ref s2 |  |
-| main.rs:88:11:88:12 | s1 | main.rs:87:12:87:23 | Some(...) |  |
-| main.rs:88:14:90:5 | { ... } | main.rs:87:5:90:5 | if ... {...} |  |
-| main.rs:89:9:89:17 | print_str | main.rs:89:19:89:20 | s2 |  |
-| main.rs:89:9:89:21 | print_str(...) | main.rs:88:14:90:5 | { ... } |  |
-| main.rs:89:9:89:22 | ExprStmt | main.rs:89:9:89:17 | print_str |  |
-| main.rs:89:19:89:20 | s2 | main.rs:89:9:89:21 | print_str(...) |  |
-| main.rs:93:1:99:1 | enter fn let_pattern4 | main.rs:94:5:97:10 | let ... = ... else {...} |  |
-| main.rs:93:1:99:1 | exit fn let_pattern4 (normal) | main.rs:93:1:99:1 | exit fn let_pattern4 |  |
-| main.rs:93:19:99:1 | { ... } | main.rs:93:1:99:1 | exit fn let_pattern4 (normal) |  |
-| main.rs:94:5:97:10 | let ... = ... else {...} | main.rs:94:34:94:37 | Some |  |
-| main.rs:94:9:94:16 | Some(...) | main.rs:94:14:94:15 | x5 | match |
-| main.rs:94:9:94:16 | Some(...) | main.rs:96:13:96:19 | ...::panic | no-match |
-| main.rs:94:14:94:15 | x5 | main.rs:94:14:94:15 | x5 |  |
-| main.rs:94:14:94:15 | x5 | main.rs:98:5:98:18 | ExprStmt | match |
-| main.rs:94:34:94:37 | Some | main.rs:94:39:94:42 | "x5" |  |
-| main.rs:94:34:94:43 | Some(...) | main.rs:94:9:94:16 | Some(...) |  |
-| main.rs:94:39:94:42 | "x5" | main.rs:94:34:94:43 | Some(...) |  |
-| main.rs:96:13:96:19 | "not yet implemented" | main.rs:96:13:96:19 | ...::panic(...) |  |
-| main.rs:96:13:96:19 | ...::panic | main.rs:96:13:96:19 | "not yet implemented" |  |
-| main.rs:96:13:96:19 | ...::panic(...) | main.rs:96:13:96:19 | MacroBlockExpr |  |
-| main.rs:96:13:96:19 | MacroBlockExpr | main.rs:96:13:96:19 | todo!... |  |
-| main.rs:96:13:96:19 | MacroExpr | main.rs:95:14:97:9 | { ... } |  |
-| main.rs:96:13:96:19 | todo!... | main.rs:96:13:96:19 | MacroExpr |  |
-| main.rs:98:5:98:13 | print_str | main.rs:98:15:98:16 | x5 |  |
-| main.rs:98:5:98:17 | print_str(...) | main.rs:93:19:99:1 | { ... } |  |
-| main.rs:98:5:98:18 | ExprStmt | main.rs:98:5:98:13 | print_str |  |
-| main.rs:98:15:98:16 | x5 | main.rs:98:5:98:17 | print_str(...) |  |
-| main.rs:101:1:108:1 | enter fn let_pattern5 | main.rs:102:5:102:42 | let ... = ... |  |
-| main.rs:101:1:108:1 | exit fn let_pattern5 (normal) | main.rs:101:1:108:1 | exit fn let_pattern5 |  |
-| main.rs:101:19:108:1 | { ... } | main.rs:101:1:108:1 | exit fn let_pattern5 (normal) |  |
-| main.rs:102:5:102:42 | let ... = ... | main.rs:102:14:102:17 | Some |  |
-| main.rs:102:9:102:10 | s1 | main.rs:102:9:102:10 | s1 |  |
-| main.rs:102:9:102:10 | s1 | main.rs:104:11:105:12 | let ... = s1 | match |
-| main.rs:102:14:102:17 | Some | main.rs:102:19:102:30 | ...::from |  |
-| main.rs:102:14:102:41 | Some(...) | main.rs:102:9:102:10 | s1 |  |
-| main.rs:102:19:102:30 | ...::from | main.rs:102:32:102:39 | "Hello!" |  |
-| main.rs:102:19:102:40 | ...::from(...) | main.rs:102:14:102:41 | Some(...) |  |
-| main.rs:102:32:102:39 | "Hello!" | main.rs:102:19:102:40 | ...::from(...) |  |
-| main.rs:104:5:107:5 | while ... { ... } | main.rs:101:19:108:1 | { ... } |  |
-| main.rs:104:11:105:12 | let ... = s1 | main.rs:105:11:105:12 | s1 |  |
-| main.rs:104:15:104:26 | Some(...) | main.rs:104:5:107:5 | while ... { ... } | no-match |
-| main.rs:104:15:104:26 | Some(...) | main.rs:104:24:104:25 | s2 | match |
-| main.rs:104:20:104:25 | ref s2 | main.rs:106:9:106:22 | ExprStmt | match |
-| main.rs:104:24:104:25 | s2 | main.rs:104:20:104:25 | ref s2 |  |
-| main.rs:105:11:105:12 | s1 | main.rs:104:15:104:26 | Some(...) |  |
-| main.rs:105:14:107:5 | { ... } | main.rs:104:11:105:12 | let ... = s1 |  |
-| main.rs:106:9:106:17 | print_str | main.rs:106:19:106:20 | s2 |  |
-| main.rs:106:9:106:21 | print_str(...) | main.rs:105:14:107:5 | { ... } |  |
-| main.rs:106:9:106:22 | ExprStmt | main.rs:106:9:106:17 | print_str |  |
-| main.rs:106:19:106:20 | s2 | main.rs:106:9:106:21 | print_str(...) |  |
-| main.rs:110:1:125:1 | enter fn match_pattern1 | main.rs:111:5:111:21 | let ... = ... |  |
-| main.rs:110:1:125:1 | exit fn match_pattern1 (normal) | main.rs:110:1:125:1 | exit fn match_pattern1 |  |
-| main.rs:110:21:125:1 | { ... } | main.rs:110:1:125:1 | exit fn match_pattern1 (normal) |  |
-| main.rs:111:5:111:21 | let ... = ... | main.rs:111:14:111:17 | Some |  |
-| main.rs:111:9:111:10 | x6 | main.rs:111:9:111:10 | x6 |  |
-| main.rs:111:9:111:10 | x6 | main.rs:112:5:112:16 | let ... = 10 | match |
-| main.rs:111:14:111:17 | Some | main.rs:111:19:111:19 | 5 |  |
-| main.rs:111:14:111:20 | Some(...) | main.rs:111:9:111:10 | x6 |  |
-| main.rs:111:19:111:19 | 5 | main.rs:111:14:111:20 | Some(...) |  |
-| main.rs:112:5:112:16 | let ... = 10 | main.rs:112:14:112:15 | 10 |  |
-| main.rs:112:9:112:10 | y1 | main.rs:112:9:112:10 | y1 |  |
-| main.rs:112:9:112:10 | y1 | main.rs:114:5:122:5 | ExprStmt | match |
-| main.rs:112:14:112:15 | 10 | main.rs:112:9:112:10 | y1 |  |
-| main.rs:114:5:122:5 | ExprStmt | main.rs:114:11:114:12 | x6 |  |
-| main.rs:114:5:122:5 | match x6 { ... } | main.rs:124:5:124:18 | ExprStmt |  |
-| main.rs:114:11:114:12 | x6 | main.rs:115:9:115:16 | Some(...) |  |
-| main.rs:115:9:115:16 | Some(...) | main.rs:115:14:115:15 | 50 | match |
-| main.rs:115:9:115:16 | Some(...) | main.rs:116:9:116:16 | Some(...) | no-match |
-| main.rs:115:14:115:15 | 50 | main.rs:115:14:115:15 | 50 |  |
-| main.rs:115:14:115:15 | 50 | main.rs:115:21:115:29 | print_str | match |
-| main.rs:115:14:115:15 | 50 | main.rs:116:9:116:16 | Some(...) | no-match |
-| main.rs:115:21:115:29 | print_str | main.rs:115:31:115:38 | "Got 50" |  |
-| main.rs:115:21:115:39 | print_str(...) | main.rs:114:5:122:5 | match x6 { ... } |  |
-| main.rs:115:31:115:38 | "Got 50" | main.rs:115:21:115:39 | print_str(...) |  |
-| main.rs:116:9:116:16 | Some(...) | main.rs:116:14:116:15 | y1 | match |
-| main.rs:116:9:116:16 | Some(...) | main.rs:121:9:121:12 | None | no-match |
-| main.rs:116:14:116:15 | y1 | main.rs:116:14:116:15 | y1 |  |
-| main.rs:116:14:116:15 | y1 | main.rs:119:13:119:21 | print_i64 | match |
-| main.rs:118:9:120:9 | { ... } | main.rs:114:5:122:5 | match x6 { ... } |  |
-| main.rs:119:13:119:21 | print_i64 | main.rs:119:23:119:24 | y1 |  |
-| main.rs:119:13:119:25 | print_i64(...) | main.rs:118:9:120:9 | { ... } |  |
-| main.rs:119:23:119:24 | y1 | main.rs:119:13:119:25 | print_i64(...) |  |
-| main.rs:121:9:121:12 | None | main.rs:121:9:121:12 | None |  |
-| main.rs:121:9:121:12 | None | main.rs:121:17:121:25 | print_str | match |
-| main.rs:121:17:121:25 | print_str | main.rs:121:27:121:32 | "NONE" |  |
-| main.rs:121:17:121:33 | print_str(...) | main.rs:114:5:122:5 | match x6 { ... } |  |
-| main.rs:121:27:121:32 | "NONE" | main.rs:121:17:121:33 | print_str(...) |  |
-| main.rs:124:5:124:13 | print_i64 | main.rs:124:15:124:16 | y1 |  |
-| main.rs:124:5:124:17 | print_i64(...) | main.rs:110:21:125:1 | { ... } |  |
-| main.rs:124:5:124:18 | ExprStmt | main.rs:124:5:124:13 | print_i64 |  |
-| main.rs:124:15:124:16 | y1 | main.rs:124:5:124:17 | print_i64(...) |  |
-| main.rs:127:1:152:1 | enter fn match_pattern2 | main.rs:128:5:128:36 | let ... = ... |  |
-| main.rs:127:1:152:1 | exit fn match_pattern2 (normal) | main.rs:127:1:152:1 | exit fn match_pattern2 |  |
-| main.rs:127:21:152:1 | { ... } | main.rs:127:1:152:1 | exit fn match_pattern2 (normal) |  |
-| main.rs:128:5:128:36 | let ... = ... | main.rs:128:20:128:20 | 2 |  |
-| main.rs:128:9:128:15 | numbers | main.rs:128:9:128:15 | numbers |  |
-| main.rs:128:9:128:15 | numbers | main.rs:130:5:140:5 | ExprStmt | match |
-| main.rs:128:19:128:35 | TupleExpr | main.rs:128:9:128:15 | numbers |  |
-| main.rs:128:20:128:20 | 2 | main.rs:128:23:128:23 | 4 |  |
-| main.rs:128:23:128:23 | 4 | main.rs:128:26:128:26 | 8 |  |
-| main.rs:128:26:128:26 | 8 | main.rs:128:29:128:30 | 16 |  |
-| main.rs:128:29:128:30 | 16 | main.rs:128:33:128:34 | 32 |  |
-| main.rs:128:33:128:34 | 32 | main.rs:128:19:128:35 | TupleExpr |  |
-| main.rs:130:5:140:5 | ExprStmt | main.rs:130:11:130:17 | numbers |  |
-| main.rs:130:5:140:5 | match numbers { ... } | main.rs:142:11:142:17 | numbers |  |
-| main.rs:130:11:130:17 | numbers | main.rs:131:9:135:9 | TuplePat |  |
-| main.rs:131:9:135:9 | TuplePat | main.rs:132:13:132:17 | first | match |
-| main.rs:132:13:132:17 | first | main.rs:132:13:132:17 | first |  |
-| main.rs:132:13:132:17 | first | main.rs:132:20:132:20 | _ | match |
-| main.rs:132:20:132:20 | _ | main.rs:133:13:133:17 | third | match |
-| main.rs:133:13:133:17 | third | main.rs:133:13:133:17 | third |  |
-| main.rs:133:13:133:17 | third | main.rs:133:20:133:20 | _ | match |
-| main.rs:133:20:133:20 | _ | main.rs:134:13:134:17 | fifth | match |
-| main.rs:134:13:134:17 | fifth | main.rs:134:13:134:17 | fifth |  |
-| main.rs:134:13:134:17 | fifth | main.rs:136:13:136:29 | ExprStmt | match |
-| main.rs:135:14:139:9 | { ... } | main.rs:130:5:140:5 | match numbers { ... } |  |
-| main.rs:136:13:136:21 | print_i64 | main.rs:136:23:136:27 | first |  |
-| main.rs:136:13:136:28 | print_i64(...) | main.rs:137:13:137:29 | ExprStmt |  |
-| main.rs:136:13:136:29 | ExprStmt | main.rs:136:13:136:21 | print_i64 |  |
-| main.rs:136:23:136:27 | first | main.rs:136:13:136:28 | print_i64(...) |  |
-| main.rs:137:13:137:21 | print_i64 | main.rs:137:23:137:27 | third |  |
-| main.rs:137:13:137:28 | print_i64(...) | main.rs:138:13:138:29 | ExprStmt |  |
-| main.rs:137:13:137:29 | ExprStmt | main.rs:137:13:137:21 | print_i64 |  |
-| main.rs:137:23:137:27 | third | main.rs:137:13:137:28 | print_i64(...) |  |
-| main.rs:138:13:138:21 | print_i64 | main.rs:138:23:138:27 | fifth |  |
-| main.rs:138:13:138:28 | print_i64(...) | main.rs:135:14:139:9 | { ... } |  |
-| main.rs:138:13:138:29 | ExprStmt | main.rs:138:13:138:21 | print_i64 |  |
-| main.rs:138:23:138:27 | fifth | main.rs:138:13:138:28 | print_i64(...) |  |
-| main.rs:142:5:151:5 | match numbers { ... } | main.rs:127:21:152:1 | { ... } |  |
-| main.rs:142:11:142:17 | numbers | main.rs:143:9:147:9 | TuplePat |  |
-| main.rs:143:9:147:9 | TuplePat | main.rs:144:13:144:17 | first | match |
-| main.rs:144:13:144:17 | first | main.rs:144:13:144:17 | first |  |
-| main.rs:144:13:144:17 | first | main.rs:145:13:145:14 | .. | match |
-| main.rs:145:13:145:14 | .. | main.rs:146:13:146:16 | last | match |
-| main.rs:146:13:146:16 | last | main.rs:146:13:146:16 | last |  |
-| main.rs:146:13:146:16 | last | main.rs:148:13:148:29 | ExprStmt | match |
-| main.rs:147:14:150:9 | { ... } | main.rs:142:5:151:5 | match numbers { ... } |  |
-| main.rs:148:13:148:21 | print_i64 | main.rs:148:23:148:27 | first |  |
-| main.rs:148:13:148:28 | print_i64(...) | main.rs:149:13:149:28 | ExprStmt |  |
-| main.rs:148:13:148:29 | ExprStmt | main.rs:148:13:148:21 | print_i64 |  |
-| main.rs:148:23:148:27 | first | main.rs:148:13:148:28 | print_i64(...) |  |
-| main.rs:149:13:149:21 | print_i64 | main.rs:149:23:149:26 | last |  |
-| main.rs:149:13:149:27 | print_i64(...) | main.rs:147:14:150:9 | { ... } |  |
-| main.rs:149:13:149:28 | ExprStmt | main.rs:149:13:149:21 | print_i64 |  |
-| main.rs:149:23:149:26 | last | main.rs:149:13:149:27 | print_i64(...) |  |
-| main.rs:154:1:162:1 | enter fn match_pattern3 | main.rs:155:5:155:38 | let ... = ... |  |
-| main.rs:154:1:162:1 | exit fn match_pattern3 (normal) | main.rs:154:1:162:1 | exit fn match_pattern3 |  |
-| main.rs:154:21:162:1 | { ... } | main.rs:154:1:162:1 | exit fn match_pattern3 (normal) |  |
-| main.rs:155:5:155:38 | let ... = ... | main.rs:155:25:155:27 | "x" |  |
-| main.rs:155:9:155:10 | p2 | main.rs:155:9:155:10 | p2 |  |
-| main.rs:155:9:155:10 | p2 | main.rs:157:11:157:12 | p2 | match |
-| main.rs:155:14:155:37 | Point {...} | main.rs:155:9:155:10 | p2 |  |
-| main.rs:155:25:155:27 | "x" | main.rs:155:33:155:35 | "y" |  |
-| main.rs:155:33:155:35 | "y" | main.rs:155:14:155:37 | Point {...} |  |
-| main.rs:157:5:161:5 | match p2 { ... } | main.rs:154:21:162:1 | { ... } |  |
-| main.rs:157:11:157:12 | p2 | main.rs:158:9:160:9 | Point {...} |  |
-| main.rs:158:9:160:9 | Point {...} | main.rs:159:16:159:17 | x7 | match |
-| main.rs:159:16:159:17 | x7 | main.rs:159:16:159:17 | x7 |  |
-| main.rs:159:16:159:17 | x7 | main.rs:159:20:159:21 | .. | match |
-| main.rs:159:20:159:21 | .. | main.rs:160:14:160:22 | print_str | match |
-| main.rs:160:14:160:22 | print_str | main.rs:160:24:160:25 | x7 |  |
-| main.rs:160:14:160:26 | print_str(...) | main.rs:157:5:161:5 | match p2 { ... } |  |
-| main.rs:160:24:160:25 | x7 | main.rs:160:14:160:26 | print_str(...) |  |
-| main.rs:168:1:181:1 | enter fn match_pattern4 | main.rs:169:5:169:39 | let ... = ... |  |
-| main.rs:168:1:181:1 | exit fn match_pattern4 (normal) | main.rs:168:1:181:1 | exit fn match_pattern4 |  |
-| main.rs:168:21:181:1 | { ... } | main.rs:168:1:181:1 | exit fn match_pattern4 (normal) |  |
-| main.rs:169:5:169:39 | let ... = ... | main.rs:169:36:169:36 | 0 |  |
-| main.rs:169:9:169:11 | msg | main.rs:169:9:169:11 | msg |  |
-| main.rs:169:9:169:11 | msg | main.rs:171:11:171:13 | msg | match |
-| main.rs:169:15:169:38 | ...::Hello {...} | main.rs:169:9:169:11 | msg |  |
-| main.rs:169:36:169:36 | 0 | main.rs:169:15:169:38 | ...::Hello {...} |  |
-| main.rs:171:5:180:5 | match msg { ... } | main.rs:168:21:181:1 | { ... } |  |
-| main.rs:171:11:171:13 | msg | main.rs:172:9:174:9 | ...::Hello {...} |  |
-| main.rs:172:9:174:9 | ...::Hello {...} | main.rs:173:31:173:35 | RangePat | match |
-| main.rs:172:9:174:9 | ...::Hello {...} | main.rs:175:9:175:38 | ...::Hello {...} | no-match |
-| main.rs:173:17:173:27 | id_variable | main.rs:173:17:173:35 | id_variable @ ... |  |
-| main.rs:173:17:173:35 | id_variable @ ... | main.rs:174:14:174:22 | print_i64 | match |
-| main.rs:173:31:173:31 | 3 | main.rs:173:31:173:31 | 3 |  |
-| main.rs:173:31:173:31 | 3 | main.rs:173:35:173:35 | 7 | match |
-| main.rs:173:31:173:31 | 3 | main.rs:175:9:175:38 | ...::Hello {...} | no-match |
-| main.rs:173:31:173:35 | RangePat | main.rs:173:31:173:31 | 3 | match |
-| main.rs:173:35:173:35 | 7 | main.rs:173:17:173:27 | id_variable | match |
-| main.rs:173:35:173:35 | 7 | main.rs:173:35:173:35 | 7 |  |
-| main.rs:173:35:173:35 | 7 | main.rs:175:9:175:38 | ...::Hello {...} | no-match |
-| main.rs:174:14:174:22 | print_i64 | main.rs:174:24:174:34 | id_variable |  |
-| main.rs:174:14:174:35 | print_i64(...) | main.rs:171:5:180:5 | match msg { ... } |  |
-| main.rs:174:24:174:34 | id_variable | main.rs:174:14:174:35 | print_i64(...) |  |
-| main.rs:175:9:175:38 | ...::Hello {...} | main.rs:175:30:175:36 | RangePat | match |
-| main.rs:175:9:175:38 | ...::Hello {...} | main.rs:178:9:178:29 | ...::Hello {...} | no-match |
-| main.rs:175:30:175:31 | 10 | main.rs:175:30:175:31 | 10 |  |
-| main.rs:175:30:175:31 | 10 | main.rs:175:35:175:36 | 12 | match |
-| main.rs:175:30:175:31 | 10 | main.rs:178:9:178:29 | ...::Hello {...} | no-match |
-| main.rs:175:30:175:36 | RangePat | main.rs:175:30:175:31 | 10 | match |
-| main.rs:175:35:175:36 | 12 | main.rs:175:35:175:36 | 12 |  |
-| main.rs:175:35:175:36 | 12 | main.rs:176:22:176:51 | ExprStmt | match |
-| main.rs:175:35:175:36 | 12 | main.rs:178:9:178:29 | ...::Hello {...} | no-match |
-| main.rs:175:43:177:9 | { ... } | main.rs:171:5:180:5 | match msg { ... } |  |
-| main.rs:176:13:176:52 | ...::_print | main.rs:176:22:176:51 | "Found an id in another range\\... |  |
-| main.rs:176:13:176:52 | MacroExpr | main.rs:175:43:177:9 | { ... } |  |
-| main.rs:176:13:176:52 | println!... | main.rs:176:13:176:52 | MacroExpr |  |
-| main.rs:176:22:176:51 | "Found an id in another range\\... | main.rs:176:22:176:51 | FormatArgsExpr |  |
-| main.rs:176:22:176:51 | ...::_print(...) | main.rs:176:22:176:51 | { ... } |  |
-| main.rs:176:22:176:51 | ...::format_args_nl!... | main.rs:176:22:176:51 | MacroExpr |  |
-| main.rs:176:22:176:51 | ExprStmt | main.rs:176:13:176:52 | ...::_print |  |
-| main.rs:176:22:176:51 | FormatArgsExpr | main.rs:176:22:176:51 | ...::format_args_nl!... |  |
-| main.rs:176:22:176:51 | MacroBlockExpr | main.rs:176:13:176:52 | println!... |  |
-| main.rs:176:22:176:51 | MacroExpr | main.rs:176:22:176:51 | ...::_print(...) |  |
-| main.rs:176:22:176:51 | { ... } | main.rs:176:22:176:51 | MacroBlockExpr |  |
-| main.rs:178:9:178:29 | ...::Hello {...} | main.rs:178:26:178:27 | id | match |
-| main.rs:178:26:178:27 | id | main.rs:178:26:178:27 | id |  |
-| main.rs:178:26:178:27 | id | main.rs:179:13:179:21 | print_i64 | match |
-| main.rs:179:13:179:21 | print_i64 | main.rs:179:23:179:24 | id |  |
-| main.rs:179:13:179:25 | print_i64(...) | main.rs:171:5:180:5 | match msg { ... } |  |
-| main.rs:179:23:179:24 | id | main.rs:179:13:179:25 | print_i64(...) |  |
-| main.rs:188:1:194:1 | enter fn match_pattern5 | main.rs:189:5:189:34 | let ... = ... |  |
-| main.rs:188:1:194:1 | exit fn match_pattern5 (normal) | main.rs:188:1:194:1 | exit fn match_pattern5 |  |
-| main.rs:188:21:194:1 | { ... } | main.rs:188:1:194:1 | exit fn match_pattern5 (normal) |  |
-| main.rs:189:5:189:34 | let ... = ... | main.rs:189:18:189:29 | ...::Left |  |
-| main.rs:189:9:189:14 | either | main.rs:189:9:189:14 | either |  |
-| main.rs:189:9:189:14 | either | main.rs:190:11:190:16 | either | match |
-| main.rs:189:18:189:29 | ...::Left | main.rs:189:31:189:32 | 32 |  |
-| main.rs:189:18:189:33 | ...::Left(...) | main.rs:189:9:189:14 | either |  |
-| main.rs:189:31:189:32 | 32 | main.rs:189:18:189:33 | ...::Left(...) |  |
-| main.rs:190:5:193:5 | match either { ... } | main.rs:188:21:194:1 | { ... } |  |
-| main.rs:190:11:190:16 | either | main.rs:191:9:191:24 | ...::Left(...) |  |
-| main.rs:191:9:191:24 | ...::Left(...) | main.rs:191:22:191:23 | a3 | match |
-| main.rs:191:9:191:24 | ...::Left(...) | main.rs:191:28:191:44 | ...::Right(...) | no-match |
-| main.rs:191:9:191:44 | ... \| ... | main.rs:192:16:192:24 | print_i64 | match |
-| main.rs:191:22:191:23 | a3 | main.rs:191:9:191:44 | ... \| ... | match |
-| main.rs:191:22:191:23 | a3 | main.rs:191:22:191:23 | a3 |  |
-| main.rs:191:28:191:44 | ...::Right(...) | main.rs:191:42:191:43 | a3 | match |
-| main.rs:191:42:191:43 | a3 | main.rs:191:9:191:44 | ... \| ... | match |
-| main.rs:191:42:191:43 | a3 | main.rs:191:42:191:43 | a3 |  |
-| main.rs:192:16:192:24 | print_i64 | main.rs:192:26:192:27 | a3 |  |
-| main.rs:192:16:192:28 | print_i64(...) | main.rs:190:5:193:5 | match either { ... } |  |
-| main.rs:192:26:192:27 | a3 | main.rs:192:16:192:28 | print_i64(...) |  |
-| main.rs:202:1:216:1 | enter fn match_pattern6 | main.rs:203:5:203:37 | let ... = ... |  |
-| main.rs:202:1:216:1 | exit fn match_pattern6 (normal) | main.rs:202:1:216:1 | exit fn match_pattern6 |  |
-| main.rs:202:21:216:1 | { ... } | main.rs:202:1:216:1 | exit fn match_pattern6 (normal) |  |
-| main.rs:203:5:203:37 | let ... = ... | main.rs:203:14:203:32 | ...::Second |  |
-| main.rs:203:9:203:10 | tv | main.rs:203:9:203:10 | tv |  |
-| main.rs:203:9:203:10 | tv | main.rs:204:5:207:5 | ExprStmt | match |
-| main.rs:203:14:203:32 | ...::Second | main.rs:203:34:203:35 | 62 |  |
-| main.rs:203:14:203:36 | ...::Second(...) | main.rs:203:9:203:10 | tv |  |
-| main.rs:203:34:203:35 | 62 | main.rs:203:14:203:36 | ...::Second(...) |  |
-| main.rs:204:5:207:5 | ExprStmt | main.rs:204:11:204:12 | tv |  |
-| main.rs:204:5:207:5 | match tv { ... } | main.rs:208:5:211:5 | ExprStmt |  |
-| main.rs:204:11:204:12 | tv | main.rs:205:9:205:30 | ...::First(...) |  |
-| main.rs:205:9:205:30 | ...::First(...) | main.rs:205:28:205:29 | a4 | match |
-| main.rs:205:9:205:30 | ...::First(...) | main.rs:205:34:205:56 | ...::Second(...) | no-match |
-| main.rs:205:9:205:81 | ... \| ... \| ... | main.rs:206:16:206:24 | print_i64 | match |
-| main.rs:205:28:205:29 | a4 | main.rs:205:9:205:81 | ... \| ... \| ... | match |
-| main.rs:205:28:205:29 | a4 | main.rs:205:28:205:29 | a4 |  |
-| main.rs:205:34:205:56 | ...::Second(...) | main.rs:205:54:205:55 | a4 | match |
-| main.rs:205:34:205:56 | ...::Second(...) | main.rs:205:60:205:81 | ...::Third(...) | no-match |
-| main.rs:205:54:205:55 | a4 | main.rs:205:9:205:81 | ... \| ... \| ... | match |
-| main.rs:205:54:205:55 | a4 | main.rs:205:54:205:55 | a4 |  |
-| main.rs:205:60:205:81 | ...::Third(...) | main.rs:205:79:205:80 | a4 | match |
-| main.rs:205:79:205:80 | a4 | main.rs:205:9:205:81 | ... \| ... \| ... | match |
-| main.rs:205:79:205:80 | a4 | main.rs:205:79:205:80 | a4 |  |
-| main.rs:206:16:206:24 | print_i64 | main.rs:206:26:206:27 | a4 |  |
-| main.rs:206:16:206:28 | print_i64(...) | main.rs:204:5:207:5 | match tv { ... } |  |
-| main.rs:206:26:206:27 | a4 | main.rs:206:16:206:28 | print_i64(...) |  |
-| main.rs:208:5:211:5 | ExprStmt | main.rs:208:11:208:12 | tv |  |
-| main.rs:208:5:211:5 | match tv { ... } | main.rs:212:11:212:12 | tv |  |
-| main.rs:208:11:208:12 | tv | main.rs:209:10:209:31 | ...::First(...) |  |
-| main.rs:209:9:209:83 | ... \| ... | main.rs:210:16:210:24 | print_i64 | match |
-| main.rs:209:10:209:31 | ...::First(...) | main.rs:209:29:209:30 | a5 | match |
-| main.rs:209:10:209:31 | ...::First(...) | main.rs:209:35:209:57 | ...::Second(...) | no-match |
-| main.rs:209:10:209:57 | [match(false)] ... \| ... | main.rs:209:62:209:83 | ...::Third(...) | no-match |
-| main.rs:209:10:209:57 | [match(true)] ... \| ... | main.rs:209:9:209:83 | ... \| ... | match |
-| main.rs:209:29:209:30 | a5 | main.rs:209:10:209:57 | [match(true)] ... \| ... | match |
-| main.rs:209:29:209:30 | a5 | main.rs:209:29:209:30 | a5 |  |
-| main.rs:209:35:209:57 | ...::Second(...) | main.rs:209:10:209:57 | [match(false)] ... \| ... | no-match |
-| main.rs:209:35:209:57 | ...::Second(...) | main.rs:209:55:209:56 | a5 | match |
-| main.rs:209:55:209:56 | a5 | main.rs:209:10:209:57 | [match(true)] ... \| ... | match |
-| main.rs:209:55:209:56 | a5 | main.rs:209:55:209:56 | a5 |  |
-| main.rs:209:62:209:83 | ...::Third(...) | main.rs:209:81:209:82 | a5 | match |
-| main.rs:209:81:209:82 | a5 | main.rs:209:9:209:83 | ... \| ... | match |
-| main.rs:209:81:209:82 | a5 | main.rs:209:81:209:82 | a5 |  |
-| main.rs:210:16:210:24 | print_i64 | main.rs:210:26:210:27 | a5 |  |
-| main.rs:210:16:210:28 | print_i64(...) | main.rs:208:5:211:5 | match tv { ... } |  |
-| main.rs:210:26:210:27 | a5 | main.rs:210:16:210:28 | print_i64(...) |  |
-| main.rs:212:5:215:5 | match tv { ... } | main.rs:202:21:216:1 | { ... } |  |
-| main.rs:212:11:212:12 | tv | main.rs:213:9:213:30 | ...::First(...) |  |
-| main.rs:213:9:213:30 | ...::First(...) | main.rs:213:28:213:29 | a6 | match |
-| main.rs:213:9:213:30 | ...::First(...) | main.rs:213:35:213:57 | ...::Second(...) | no-match |
-| main.rs:213:9:213:83 | ... \| ... | main.rs:214:16:214:24 | print_i64 | match |
-| main.rs:213:28:213:29 | a6 | main.rs:213:9:213:83 | ... \| ... | match |
-| main.rs:213:28:213:29 | a6 | main.rs:213:28:213:29 | a6 |  |
-| main.rs:213:35:213:57 | ...::Second(...) | main.rs:213:55:213:56 | a6 | match |
-| main.rs:213:35:213:57 | ...::Second(...) | main.rs:213:61:213:82 | ...::Third(...) | no-match |
-| main.rs:213:35:213:82 | ... \| ... | main.rs:213:9:213:83 | ... \| ... | match |
-| main.rs:213:55:213:56 | a6 | main.rs:213:35:213:82 | ... \| ... | match |
-| main.rs:213:55:213:56 | a6 | main.rs:213:55:213:56 | a6 |  |
-| main.rs:213:61:213:82 | ...::Third(...) | main.rs:213:80:213:81 | a6 | match |
-| main.rs:213:80:213:81 | a6 | main.rs:213:35:213:82 | ... \| ... | match |
-| main.rs:213:80:213:81 | a6 | main.rs:213:80:213:81 | a6 |  |
-| main.rs:214:16:214:24 | print_i64 | main.rs:214:26:214:27 | a6 |  |
-| main.rs:214:16:214:28 | print_i64(...) | main.rs:212:5:215:5 | match tv { ... } |  |
-| main.rs:214:26:214:27 | a6 | main.rs:214:16:214:28 | print_i64(...) |  |
-| main.rs:218:1:226:1 | enter fn match_pattern7 | main.rs:219:5:219:34 | let ... = ... |  |
-| main.rs:218:1:226:1 | exit fn match_pattern7 (normal) | main.rs:218:1:226:1 | exit fn match_pattern7 |  |
-| main.rs:218:21:226:1 | { ... } | main.rs:218:1:226:1 | exit fn match_pattern7 (normal) |  |
-| main.rs:219:5:219:34 | let ... = ... | main.rs:219:18:219:29 | ...::Left |  |
-| main.rs:219:9:219:14 | either | main.rs:219:9:219:14 | either |  |
-| main.rs:219:9:219:14 | either | main.rs:220:11:220:16 | either | match |
-| main.rs:219:18:219:29 | ...::Left | main.rs:219:31:219:32 | 32 |  |
-| main.rs:219:18:219:33 | ...::Left(...) | main.rs:219:9:219:14 | either |  |
-| main.rs:219:31:219:32 | 32 | main.rs:219:18:219:33 | ...::Left(...) |  |
-| main.rs:220:5:225:5 | match either { ... } | main.rs:218:21:226:1 | { ... } |  |
-| main.rs:220:11:220:16 | either | main.rs:221:9:221:24 | ...::Left(...) |  |
-| main.rs:221:9:221:24 | ...::Left(...) | main.rs:221:22:221:23 | a7 | match |
-| main.rs:221:9:221:24 | ...::Left(...) | main.rs:221:28:221:44 | ...::Right(...) | no-match |
-| main.rs:221:9:221:44 | [match(false)] ... \| ... | main.rs:224:9:224:9 | _ | no-match |
-| main.rs:221:9:221:44 | [match(true)] ... \| ... | main.rs:222:16:222:17 | a7 | match |
-| main.rs:221:22:221:23 | a7 | main.rs:221:9:221:44 | [match(true)] ... \| ... | match |
-| main.rs:221:22:221:23 | a7 | main.rs:221:22:221:23 | a7 |  |
-| main.rs:221:28:221:44 | ...::Right(...) | main.rs:221:9:221:44 | [match(false)] ... \| ... | no-match |
-| main.rs:221:28:221:44 | ...::Right(...) | main.rs:221:42:221:43 | a7 | match |
-| main.rs:221:42:221:43 | a7 | main.rs:221:9:221:44 | [match(true)] ... \| ... | match |
-| main.rs:221:42:221:43 | a7 | main.rs:221:42:221:43 | a7 |  |
-| main.rs:222:16:222:17 | a7 | main.rs:222:21:222:21 | 0 |  |
-| main.rs:222:16:222:21 | ... > ... | main.rs:223:16:223:24 | print_i64 | true |
-| main.rs:222:16:222:21 | ... > ... | main.rs:224:9:224:9 | _ | false |
-| main.rs:222:21:222:21 | 0 | main.rs:222:16:222:21 | ... > ... |  |
-| main.rs:223:16:223:24 | print_i64 | main.rs:223:26:223:27 | a7 |  |
-| main.rs:223:16:223:28 | print_i64(...) | main.rs:220:5:225:5 | match either { ... } |  |
-| main.rs:223:26:223:27 | a7 | main.rs:223:16:223:28 | print_i64(...) |  |
-| main.rs:224:9:224:9 | _ | main.rs:224:14:224:15 | TupleExpr | match |
-| main.rs:224:14:224:15 | TupleExpr | main.rs:220:5:225:5 | match either { ... } |  |
-| main.rs:228:1:243:1 | enter fn match_pattern8 | main.rs:229:5:229:34 | let ... = ... |  |
-| main.rs:228:1:243:1 | exit fn match_pattern8 (normal) | main.rs:228:1:243:1 | exit fn match_pattern8 |  |
-| main.rs:228:21:243:1 | { ... } | main.rs:228:1:243:1 | exit fn match_pattern8 (normal) |  |
-| main.rs:229:5:229:34 | let ... = ... | main.rs:229:18:229:29 | ...::Left |  |
-| main.rs:229:9:229:14 | either | main.rs:229:9:229:14 | either |  |
-| main.rs:229:9:229:14 | either | main.rs:231:11:231:16 | either | match |
-| main.rs:229:18:229:29 | ...::Left | main.rs:229:31:229:32 | 32 |  |
-| main.rs:229:18:229:33 | ...::Left(...) | main.rs:229:9:229:14 | either |  |
-| main.rs:229:31:229:32 | 32 | main.rs:229:18:229:33 | ...::Left(...) |  |
-| main.rs:231:5:242:5 | match either { ... } | main.rs:228:21:243:1 | { ... } |  |
-| main.rs:231:11:231:16 | either | main.rs:233:14:233:30 | ...::Left(...) |  |
-| main.rs:232:9:233:52 | ref e @ ... | main.rs:235:13:235:27 | ExprStmt | match |
-| main.rs:232:13:232:13 | e | main.rs:232:9:233:52 | ref e @ ... |  |
-| main.rs:233:14:233:30 | ...::Left(...) | main.rs:233:27:233:29 | a11 | match |
-| main.rs:233:14:233:30 | ...::Left(...) | main.rs:233:34:233:51 | ...::Right(...) | no-match |
-| main.rs:233:14:233:51 | [match(false)] ... \| ... | main.rs:241:9:241:9 | _ | no-match |
-| main.rs:233:14:233:51 | [match(true)] ... \| ... | main.rs:232:13:232:13 | e | match |
-| main.rs:233:27:233:29 | a11 | main.rs:233:14:233:51 | [match(true)] ... \| ... | match |
-| main.rs:233:27:233:29 | a11 | main.rs:233:27:233:29 | a11 |  |
-| main.rs:233:34:233:51 | ...::Right(...) | main.rs:233:14:233:51 | [match(false)] ... \| ... | no-match |
-| main.rs:233:34:233:51 | ...::Right(...) | main.rs:233:48:233:50 | a11 | match |
-| main.rs:233:48:233:50 | a11 | main.rs:233:14:233:51 | [match(true)] ... \| ... | match |
-| main.rs:233:48:233:50 | a11 | main.rs:233:48:233:50 | a11 |  |
-| main.rs:234:12:240:9 | { ... } | main.rs:231:5:242:5 | match either { ... } |  |
-| main.rs:235:13:235:21 | print_i64 | main.rs:235:23:235:25 | a11 |  |
-| main.rs:235:13:235:26 | print_i64(...) | main.rs:236:16:237:15 | let ... = e |  |
-| main.rs:235:13:235:27 | ExprStmt | main.rs:235:13:235:21 | print_i64 |  |
-| main.rs:235:23:235:25 | a11 | main.rs:235:13:235:26 | print_i64(...) |  |
-| main.rs:236:13:239:13 | if ... {...} | main.rs:234:12:240:9 | { ... } |  |
-| main.rs:236:16:237:15 | let ... = e | main.rs:237:15:237:15 | e |  |
-| main.rs:236:20:236:36 | ...::Left(...) | main.rs:236:13:239:13 | if ... {...} | no-match |
-| main.rs:236:20:236:36 | ...::Left(...) | main.rs:236:33:236:35 | a12 | match |
-| main.rs:236:33:236:35 | a12 | main.rs:236:33:236:35 | a12 |  |
-| main.rs:236:33:236:35 | a12 | main.rs:238:17:238:32 | ExprStmt | match |
-| main.rs:237:15:237:15 | e | main.rs:236:20:236:36 | ...::Left(...) |  |
-| main.rs:237:17:239:13 | { ... } | main.rs:236:13:239:13 | if ... {...} |  |
-| main.rs:238:17:238:25 | print_i64 | main.rs:238:28:238:30 | a12 |  |
-| main.rs:238:17:238:31 | print_i64(...) | main.rs:237:17:239:13 | { ... } |  |
-| main.rs:238:17:238:32 | ExprStmt | main.rs:238:17:238:25 | print_i64 |  |
-| main.rs:238:27:238:30 | * ... | main.rs:238:17:238:31 | print_i64(...) |  |
-| main.rs:238:28:238:30 | a12 | main.rs:238:27:238:30 | * ... |  |
-| main.rs:241:9:241:9 | _ | main.rs:241:14:241:15 | TupleExpr | match |
-| main.rs:241:14:241:15 | TupleExpr | main.rs:231:5:242:5 | match either { ... } |  |
-| main.rs:252:1:258:1 | enter fn match_pattern9 | main.rs:253:5:253:36 | let ... = ... |  |
-| main.rs:252:1:258:1 | exit fn match_pattern9 (normal) | main.rs:252:1:258:1 | exit fn match_pattern9 |  |
-| main.rs:252:21:258:1 | { ... } | main.rs:252:1:258:1 | exit fn match_pattern9 (normal) |  |
-| main.rs:253:5:253:36 | let ... = ... | main.rs:253:14:253:31 | ...::Second |  |
-| main.rs:253:9:253:10 | fv | main.rs:253:9:253:10 | fv |  |
-| main.rs:253:9:253:10 | fv | main.rs:254:11:254:12 | fv | match |
-| main.rs:253:14:253:31 | ...::Second | main.rs:253:33:253:34 | 62 |  |
-| main.rs:253:14:253:35 | ...::Second(...) | main.rs:253:9:253:10 | fv |  |
-| main.rs:253:33:253:34 | 62 | main.rs:253:14:253:35 | ...::Second(...) |  |
-| main.rs:254:5:257:5 | match fv { ... } | main.rs:252:21:258:1 | { ... } |  |
-| main.rs:254:11:254:12 | fv | main.rs:255:9:255:30 | ...::First(...) |  |
-| main.rs:255:9:255:30 | ...::First(...) | main.rs:255:27:255:29 | a13 | match |
-| main.rs:255:9:255:30 | ...::First(...) | main.rs:255:35:255:57 | ...::Second(...) | no-match |
-| main.rs:255:9:255:109 | ... \| ... \| ... | main.rs:256:16:256:24 | print_i64 | match |
-| main.rs:255:27:255:29 | a13 | main.rs:255:9:255:109 | ... \| ... \| ... | match |
-| main.rs:255:27:255:29 | a13 | main.rs:255:27:255:29 | a13 |  |
-| main.rs:255:35:255:57 | ...::Second(...) | main.rs:255:54:255:56 | a13 | match |
-| main.rs:255:35:255:57 | ...::Second(...) | main.rs:255:61:255:82 | ...::Third(...) | no-match |
-| main.rs:255:35:255:82 | [match(false)] ... \| ... | main.rs:255:87:255:109 | ...::Fourth(...) | no-match |
-| main.rs:255:35:255:82 | [match(true)] ... \| ... | main.rs:255:9:255:109 | ... \| ... \| ... | match |
-| main.rs:255:54:255:56 | a13 | main.rs:255:35:255:82 | [match(true)] ... \| ... | match |
-| main.rs:255:54:255:56 | a13 | main.rs:255:54:255:56 | a13 |  |
-| main.rs:255:61:255:82 | ...::Third(...) | main.rs:255:35:255:82 | [match(false)] ... \| ... | no-match |
-| main.rs:255:61:255:82 | ...::Third(...) | main.rs:255:79:255:81 | a13 | match |
-| main.rs:255:79:255:81 | a13 | main.rs:255:35:255:82 | [match(true)] ... \| ... | match |
-| main.rs:255:79:255:81 | a13 | main.rs:255:79:255:81 | a13 |  |
-| main.rs:255:87:255:109 | ...::Fourth(...) | main.rs:255:106:255:108 | a13 | match |
-| main.rs:255:106:255:108 | a13 | main.rs:255:9:255:109 | ... \| ... \| ... | match |
-| main.rs:255:106:255:108 | a13 | main.rs:255:106:255:108 | a13 |  |
-| main.rs:256:16:256:24 | print_i64 | main.rs:256:26:256:28 | a13 |  |
-| main.rs:256:16:256:29 | print_i64(...) | main.rs:254:5:257:5 | match fv { ... } |  |
-| main.rs:256:26:256:28 | a13 | main.rs:256:16:256:29 | print_i64(...) |  |
-| main.rs:260:1:269:1 | enter fn param_pattern1 | main.rs:261:5:261:6 | a8 |  |
-| main.rs:260:1:269:1 | exit fn param_pattern1 (normal) | main.rs:260:1:269:1 | exit fn param_pattern1 |  |
-| main.rs:261:5:261:6 | a8 | main.rs:261:5:261:6 | a8 |  |
-| main.rs:261:5:261:6 | a8 | main.rs:261:5:261:12 | ...: ... | match |
-| main.rs:261:5:261:12 | ...: ... | main.rs:262:5:265:5 | TuplePat |  |
-| main.rs:262:5:265:5 | TuplePat | main.rs:263:9:263:10 | b3 | match |
-| main.rs:262:5:265:19 | ...: ... | main.rs:266:5:266:18 | ExprStmt |  |
-| main.rs:263:9:263:10 | b3 | main.rs:263:9:263:10 | b3 |  |
-| main.rs:263:9:263:10 | b3 | main.rs:264:9:264:10 | c1 | match |
-| main.rs:264:9:264:10 | c1 | main.rs:262:5:265:19 | ...: ... | match |
-| main.rs:264:9:264:10 | c1 | main.rs:264:9:264:10 | c1 |  |
-| main.rs:265:28:269:1 | { ... } | main.rs:260:1:269:1 | exit fn param_pattern1 (normal) |  |
-| main.rs:266:5:266:13 | print_str | main.rs:266:15:266:16 | a8 |  |
-| main.rs:266:5:266:17 | print_str(...) | main.rs:267:5:267:18 | ExprStmt |  |
-| main.rs:266:5:266:18 | ExprStmt | main.rs:266:5:266:13 | print_str |  |
-| main.rs:266:15:266:16 | a8 | main.rs:266:5:266:17 | print_str(...) |  |
-| main.rs:267:5:267:13 | print_str | main.rs:267:15:267:16 | b3 |  |
-| main.rs:267:5:267:17 | print_str(...) | main.rs:268:5:268:18 | ExprStmt |  |
-| main.rs:267:5:267:18 | ExprStmt | main.rs:267:5:267:13 | print_str |  |
-| main.rs:267:15:267:16 | b3 | main.rs:267:5:267:17 | print_str(...) |  |
-| main.rs:268:5:268:13 | print_str | main.rs:268:15:268:16 | c1 |  |
-| main.rs:268:5:268:17 | print_str(...) | main.rs:265:28:269:1 | { ... } |  |
-| main.rs:268:5:268:18 | ExprStmt | main.rs:268:5:268:13 | print_str |  |
-| main.rs:268:15:268:16 | c1 | main.rs:268:5:268:17 | print_str(...) |  |
-| main.rs:271:1:275:1 | enter fn param_pattern2 | main.rs:272:6:272:21 | ...::Left(...) |  |
-| main.rs:271:1:275:1 | exit fn param_pattern2 (normal) | main.rs:271:1:275:1 | exit fn param_pattern2 |  |
-| main.rs:272:5:272:50 | ...: Either | main.rs:274:5:274:18 | ExprStmt |  |
-| main.rs:272:6:272:21 | ...::Left(...) | main.rs:272:19:272:20 | a9 | match |
-| main.rs:272:6:272:21 | ...::Left(...) | main.rs:272:25:272:41 | ...::Right(...) | no-match |
-| main.rs:272:6:272:41 | ... \| ... | main.rs:272:5:272:50 | ...: Either | match |
-| main.rs:272:19:272:20 | a9 | main.rs:272:6:272:41 | ... \| ... | match |
-| main.rs:272:19:272:20 | a9 | main.rs:272:19:272:20 | a9 |  |
-| main.rs:272:25:272:41 | ...::Right(...) | main.rs:272:39:272:40 | a9 | match |
-| main.rs:272:39:272:40 | a9 | main.rs:272:6:272:41 | ... \| ... | match |
-| main.rs:272:39:272:40 | a9 | main.rs:272:39:272:40 | a9 |  |
-| main.rs:273:9:275:1 | { ... } | main.rs:271:1:275:1 | exit fn param_pattern2 (normal) |  |
-| main.rs:274:5:274:13 | print_i64 | main.rs:274:15:274:16 | a9 |  |
-| main.rs:274:5:274:17 | print_i64(...) | main.rs:273:9:275:1 | { ... } |  |
-| main.rs:274:5:274:18 | ExprStmt | main.rs:274:5:274:13 | print_i64 |  |
-| main.rs:274:15:274:16 | a9 | main.rs:274:5:274:17 | print_i64(...) |  |
-| main.rs:277:1:312:1 | enter fn destruct_assignment | main.rs:278:5:282:18 | let ... = ... |  |
-| main.rs:277:1:312:1 | exit fn destruct_assignment (normal) | main.rs:277:1:312:1 | exit fn destruct_assignment |  |
-| main.rs:277:26:312:1 | { ... } | main.rs:277:1:312:1 | exit fn destruct_assignment (normal) |  |
-| main.rs:278:5:282:18 | let ... = ... | main.rs:282:10:282:10 | 1 |  |
-| main.rs:278:9:282:5 | TuplePat | main.rs:279:13:279:15 | a10 | match |
-| main.rs:279:9:279:15 | mut a10 | main.rs:280:13:280:14 | b4 | match |
-| main.rs:279:13:279:15 | a10 | main.rs:279:9:279:15 | mut a10 |  |
-| main.rs:280:9:280:14 | mut b4 | main.rs:281:13:281:14 | c2 | match |
-| main.rs:280:13:280:14 | b4 | main.rs:280:9:280:14 | mut b4 |  |
-| main.rs:281:9:281:14 | mut c2 | main.rs:283:5:283:19 | ExprStmt | match |
-| main.rs:281:13:281:14 | c2 | main.rs:281:9:281:14 | mut c2 |  |
-| main.rs:282:9:282:17 | TupleExpr | main.rs:278:9:282:5 | TuplePat |  |
-| main.rs:282:10:282:10 | 1 | main.rs:282:13:282:13 | 2 |  |
-| main.rs:282:13:282:13 | 2 | main.rs:282:16:282:16 | 3 |  |
-| main.rs:282:16:282:16 | 3 | main.rs:282:9:282:17 | TupleExpr |  |
-| main.rs:283:5:283:13 | print_i64 | main.rs:283:15:283:17 | a10 |  |
-| main.rs:283:5:283:18 | print_i64(...) | main.rs:284:5:284:18 | ExprStmt |  |
-| main.rs:283:5:283:19 | ExprStmt | main.rs:283:5:283:13 | print_i64 |  |
-| main.rs:283:15:283:17 | a10 | main.rs:283:5:283:18 | print_i64(...) |  |
-| main.rs:284:5:284:13 | print_i64 | main.rs:284:15:284:16 | b4 |  |
-| main.rs:284:5:284:17 | print_i64(...) | main.rs:285:5:285:18 | ExprStmt |  |
-| main.rs:284:5:284:18 | ExprStmt | main.rs:284:5:284:13 | print_i64 |  |
-| main.rs:284:15:284:16 | b4 | main.rs:284:5:284:17 | print_i64(...) |  |
-| main.rs:285:5:285:13 | print_i64 | main.rs:285:15:285:16 | c2 |  |
-| main.rs:285:5:285:17 | print_i64(...) | main.rs:287:5:295:6 | ExprStmt |  |
-| main.rs:285:5:285:18 | ExprStmt | main.rs:285:5:285:13 | print_i64 |  |
-| main.rs:285:15:285:16 | c2 | main.rs:285:5:285:17 | print_i64(...) |  |
-| main.rs:287:5:291:5 | TupleExpr | main.rs:292:9:292:11 | a10 |  |
-| main.rs:287:5:295:5 | ... = ... | main.rs:296:5:296:19 | ExprStmt |  |
-| main.rs:287:5:295:6 | ExprStmt | main.rs:288:9:288:10 | c2 |  |
-| main.rs:288:9:288:10 | c2 | main.rs:289:9:289:10 | b4 |  |
-| main.rs:289:9:289:10 | b4 | main.rs:290:9:290:11 | a10 |  |
-| main.rs:290:9:290:11 | a10 | main.rs:287:5:291:5 | TupleExpr |  |
-| main.rs:291:9:295:5 | TupleExpr | main.rs:287:5:295:5 | ... = ... |  |
-| main.rs:292:9:292:11 | a10 | main.rs:293:9:293:10 | b4 |  |
-| main.rs:293:9:293:10 | b4 | main.rs:294:9:294:10 | c2 |  |
-| main.rs:294:9:294:10 | c2 | main.rs:291:9:295:5 | TupleExpr |  |
-| main.rs:296:5:296:13 | print_i64 | main.rs:296:15:296:17 | a10 |  |
-| main.rs:296:5:296:18 | print_i64(...) | main.rs:297:5:297:18 | ExprStmt |  |
-| main.rs:296:5:296:19 | ExprStmt | main.rs:296:5:296:13 | print_i64 |  |
-| main.rs:296:15:296:17 | a10 | main.rs:296:5:296:18 | print_i64(...) |  |
-| main.rs:297:5:297:13 | print_i64 | main.rs:297:15:297:16 | b4 |  |
-| main.rs:297:5:297:17 | print_i64(...) | main.rs:298:5:298:18 | ExprStmt |  |
+| main.rs:37:9:37:10 | x3 | main.rs:38:5:38:18 | ExprStmt | match |
+| main.rs:37:14:37:14 | 1 | main.rs:37:9:37:10 | x3 |  |
+| main.rs:38:5:38:13 | print_i64 | main.rs:38:15:38:16 | x3 |  |
+| main.rs:38:5:38:17 | print_i64(...) | main.rs:39:5:40:15 | let ... = ... |  |
+| main.rs:38:5:38:18 | ExprStmt | main.rs:38:5:38:13 | print_i64 |  |
+| main.rs:38:15:38:16 | x3 | main.rs:38:5:38:17 | print_i64(...) |  |
+| main.rs:39:5:40:15 | let ... = ... | main.rs:40:9:40:10 | x3 |  |
+| main.rs:39:9:39:10 | x3 | main.rs:39:9:39:10 | x3 |  |
+| main.rs:39:9:39:10 | x3 | main.rs:41:5:41:18 | ExprStmt | match |
+| main.rs:40:9:40:10 | x3 | main.rs:40:14:40:14 | 1 |  |
+| main.rs:40:9:40:14 | ... + ... | main.rs:39:9:39:10 | x3 |  |
+| main.rs:40:14:40:14 | 1 | main.rs:40:9:40:14 | ... + ... |  |
+| main.rs:41:5:41:13 | print_i64 | main.rs:41:15:41:16 | x3 |  |
+| main.rs:41:5:41:17 | print_i64(...) | main.rs:36:23:42:1 | { ... } |  |
+| main.rs:41:5:41:18 | ExprStmt | main.rs:41:5:41:13 | print_i64 |  |
+| main.rs:41:15:41:16 | x3 | main.rs:41:5:41:17 | print_i64(...) |  |
+| main.rs:44:1:52:1 | enter fn variable_shadow2 | main.rs:45:5:45:17 | let ... = "a" |  |
+| main.rs:44:1:52:1 | exit fn variable_shadow2 (normal) | main.rs:44:1:52:1 | exit fn variable_shadow2 |  |
+| main.rs:44:23:52:1 | { ... } | main.rs:44:1:52:1 | exit fn variable_shadow2 (normal) |  |
+| main.rs:45:5:45:17 | let ... = "a" | main.rs:45:14:45:16 | "a" |  |
+| main.rs:45:9:45:10 | x4 | main.rs:45:9:45:10 | x4 |  |
+| main.rs:45:9:45:10 | x4 | main.rs:46:5:46:18 | ExprStmt | match |
+| main.rs:45:14:45:16 | "a" | main.rs:45:9:45:10 | x4 |  |
+| main.rs:46:5:46:13 | print_str | main.rs:46:15:46:16 | x4 |  |
+| main.rs:46:5:46:17 | print_str(...) | main.rs:47:5:50:5 | ExprStmt |  |
+| main.rs:46:5:46:18 | ExprStmt | main.rs:46:5:46:13 | print_str |  |
+| main.rs:46:15:46:16 | x4 | main.rs:46:5:46:17 | print_str(...) |  |
+| main.rs:47:5:50:5 | ExprStmt | main.rs:48:9:48:21 | let ... = "b" |  |
+| main.rs:47:5:50:5 | { ... } | main.rs:51:5:51:18 | ExprStmt |  |
+| main.rs:48:9:48:21 | let ... = "b" | main.rs:48:18:48:20 | "b" |  |
+| main.rs:48:13:48:14 | x4 | main.rs:48:13:48:14 | x4 |  |
+| main.rs:48:13:48:14 | x4 | main.rs:49:9:49:22 | ExprStmt | match |
+| main.rs:48:18:48:20 | "b" | main.rs:48:13:48:14 | x4 |  |
+| main.rs:49:9:49:17 | print_str | main.rs:49:19:49:20 | x4 |  |
+| main.rs:49:9:49:21 | print_str(...) | main.rs:47:5:50:5 | { ... } |  |
+| main.rs:49:9:49:22 | ExprStmt | main.rs:49:9:49:17 | print_str |  |
+| main.rs:49:19:49:20 | x4 | main.rs:49:9:49:21 | print_str(...) |  |
+| main.rs:51:5:51:13 | print_str | main.rs:51:15:51:16 | x4 |  |
+| main.rs:51:5:51:17 | print_str(...) | main.rs:44:23:52:1 | { ... } |  |
+| main.rs:51:5:51:18 | ExprStmt | main.rs:51:5:51:13 | print_str |  |
+| main.rs:51:15:51:16 | x4 | main.rs:51:5:51:17 | print_str(...) |  |
+| main.rs:59:1:74:1 | enter fn let_pattern1 | main.rs:60:5:69:47 | let ... = ... |  |
+| main.rs:59:1:74:1 | exit fn let_pattern1 (normal) | main.rs:59:1:74:1 | exit fn let_pattern1 |  |
+| main.rs:59:19:74:1 | { ... } | main.rs:59:1:74:1 | exit fn let_pattern1 (normal) |  |
+| main.rs:60:5:69:47 | let ... = ... | main.rs:69:11:69:13 | "a" |  |
+| main.rs:60:9:69:5 | TuplePat | main.rs:61:9:64:9 | TuplePat | match |
+| main.rs:61:9:64:9 | TuplePat | main.rs:62:13:62:14 | a1 | match |
+| main.rs:62:13:62:14 | a1 | main.rs:62:13:62:14 | a1 |  |
+| main.rs:62:13:62:14 | a1 | main.rs:63:13:63:14 | b1 | match |
+| main.rs:63:13:63:14 | b1 | main.rs:63:13:63:14 | b1 |  |
+| main.rs:63:13:63:14 | b1 | main.rs:65:9:68:9 | Point {...} | match |
+| main.rs:65:9:68:9 | Point {...} | main.rs:66:13:66:13 | x | match |
+| main.rs:66:13:66:13 | x | main.rs:66:13:66:13 | x |  |
+| main.rs:66:13:66:13 | x | main.rs:67:13:67:13 | y | match |
+| main.rs:67:13:67:13 | y | main.rs:67:13:67:13 | y |  |
+| main.rs:67:13:67:13 | y | main.rs:70:5:70:18 | ExprStmt | match |
+| main.rs:69:9:69:46 | TupleExpr | main.rs:60:9:69:5 | TuplePat |  |
+| main.rs:69:10:69:19 | TupleExpr | main.rs:69:33:69:35 | "x" |  |
+| main.rs:69:11:69:13 | "a" | main.rs:69:16:69:18 | "b" |  |
+| main.rs:69:16:69:18 | "b" | main.rs:69:10:69:19 | TupleExpr |  |
+| main.rs:69:22:69:45 | Point {...} | main.rs:69:9:69:46 | TupleExpr |  |
+| main.rs:69:33:69:35 | "x" | main.rs:69:41:69:43 | "y" |  |
+| main.rs:69:41:69:43 | "y" | main.rs:69:22:69:45 | Point {...} |  |
+| main.rs:70:5:70:13 | print_str | main.rs:70:15:70:16 | a1 |  |
+| main.rs:70:5:70:17 | print_str(...) | main.rs:71:5:71:18 | ExprStmt |  |
+| main.rs:70:5:70:18 | ExprStmt | main.rs:70:5:70:13 | print_str |  |
+| main.rs:70:15:70:16 | a1 | main.rs:70:5:70:17 | print_str(...) |  |
+| main.rs:71:5:71:13 | print_str | main.rs:71:15:71:16 | b1 |  |
+| main.rs:71:5:71:17 | print_str(...) | main.rs:72:5:72:17 | ExprStmt |  |
+| main.rs:71:5:71:18 | ExprStmt | main.rs:71:5:71:13 | print_str |  |
+| main.rs:71:15:71:16 | b1 | main.rs:71:5:71:17 | print_str(...) |  |
+| main.rs:72:5:72:13 | print_str | main.rs:72:15:72:15 | x |  |
+| main.rs:72:5:72:16 | print_str(...) | main.rs:73:5:73:17 | ExprStmt |  |
+| main.rs:72:5:72:17 | ExprStmt | main.rs:72:5:72:13 | print_str |  |
+| main.rs:72:15:72:15 | x | main.rs:72:5:72:16 | print_str(...) |  |
+| main.rs:73:5:73:13 | print_str | main.rs:73:15:73:15 | y |  |
+| main.rs:73:5:73:16 | print_str(...) | main.rs:59:19:74:1 | { ... } |  |
+| main.rs:73:5:73:17 | ExprStmt | main.rs:73:5:73:13 | print_str |  |
+| main.rs:73:15:73:15 | y | main.rs:73:5:73:16 | print_str(...) |  |
+| main.rs:76:1:84:1 | enter fn let_pattern2 | main.rs:77:5:77:38 | let ... = ... |  |
+| main.rs:76:1:84:1 | exit fn let_pattern2 (normal) | main.rs:76:1:84:1 | exit fn let_pattern2 |  |
+| main.rs:76:19:84:1 | { ... } | main.rs:76:1:84:1 | exit fn let_pattern2 (normal) |  |
+| main.rs:77:5:77:38 | let ... = ... | main.rs:77:25:77:27 | "a" |  |
+| main.rs:77:9:77:10 | p1 | main.rs:77:9:77:10 | p1 |  |
+| main.rs:77:9:77:10 | p1 | main.rs:78:5:81:11 | let ... = p1 | match |
+| main.rs:77:14:77:37 | Point {...} | main.rs:77:9:77:10 | p1 |  |
+| main.rs:77:25:77:27 | "a" | main.rs:77:33:77:35 | "b" |  |
+| main.rs:77:33:77:35 | "b" | main.rs:77:14:77:37 | Point {...} |  |
+| main.rs:78:5:81:11 | let ... = p1 | main.rs:81:9:81:10 | p1 |  |
+| main.rs:78:9:81:5 | Point {...} | main.rs:79:12:79:13 | a2 | match |
+| main.rs:79:12:79:13 | a2 | main.rs:79:12:79:13 | a2 |  |
+| main.rs:79:12:79:13 | a2 | main.rs:80:12:80:13 | b2 | match |
+| main.rs:80:12:80:13 | b2 | main.rs:80:12:80:13 | b2 |  |
+| main.rs:80:12:80:13 | b2 | main.rs:82:5:82:18 | ExprStmt | match |
+| main.rs:81:9:81:10 | p1 | main.rs:78:9:81:5 | Point {...} |  |
+| main.rs:82:5:82:13 | print_str | main.rs:82:15:82:16 | a2 |  |
+| main.rs:82:5:82:17 | print_str(...) | main.rs:83:5:83:18 | ExprStmt |  |
+| main.rs:82:5:82:18 | ExprStmt | main.rs:82:5:82:13 | print_str |  |
+| main.rs:82:15:82:16 | a2 | main.rs:82:5:82:17 | print_str(...) |  |
+| main.rs:83:5:83:13 | print_str | main.rs:83:15:83:16 | b2 |  |
+| main.rs:83:5:83:17 | print_str(...) | main.rs:76:19:84:1 | { ... } |  |
+| main.rs:83:5:83:18 | ExprStmt | main.rs:83:5:83:13 | print_str |  |
+| main.rs:83:15:83:16 | b2 | main.rs:83:5:83:17 | print_str(...) |  |
+| main.rs:86:1:93:1 | enter fn let_pattern3 | main.rs:87:5:87:42 | let ... = ... |  |
+| main.rs:86:1:93:1 | exit fn let_pattern3 (normal) | main.rs:86:1:93:1 | exit fn let_pattern3 |  |
+| main.rs:86:19:93:1 | { ... } | main.rs:86:1:93:1 | exit fn let_pattern3 (normal) |  |
+| main.rs:87:5:87:42 | let ... = ... | main.rs:87:14:87:17 | Some |  |
+| main.rs:87:9:87:10 | s1 | main.rs:87:9:87:10 | s1 |  |
+| main.rs:87:9:87:10 | s1 | main.rs:89:8:90:12 | let ... = s1 | match |
+| main.rs:87:14:87:17 | Some | main.rs:87:19:87:30 | ...::from |  |
+| main.rs:87:14:87:41 | Some(...) | main.rs:87:9:87:10 | s1 |  |
+| main.rs:87:19:87:30 | ...::from | main.rs:87:32:87:39 | "Hello!" |  |
+| main.rs:87:19:87:40 | ...::from(...) | main.rs:87:14:87:41 | Some(...) |  |
+| main.rs:87:32:87:39 | "Hello!" | main.rs:87:19:87:40 | ...::from(...) |  |
+| main.rs:89:5:92:5 | if ... {...} | main.rs:86:19:93:1 | { ... } |  |
+| main.rs:89:8:90:12 | let ... = s1 | main.rs:90:11:90:12 | s1 |  |
+| main.rs:89:12:89:23 | Some(...) | main.rs:89:5:92:5 | if ... {...} | no-match |
+| main.rs:89:12:89:23 | Some(...) | main.rs:89:21:89:22 | s2 | match |
+| main.rs:89:17:89:22 | ref s2 | main.rs:91:9:91:22 | ExprStmt | match |
+| main.rs:89:21:89:22 | s2 | main.rs:89:17:89:22 | ref s2 |  |
+| main.rs:90:11:90:12 | s1 | main.rs:89:12:89:23 | Some(...) |  |
+| main.rs:90:14:92:5 | { ... } | main.rs:89:5:92:5 | if ... {...} |  |
+| main.rs:91:9:91:17 | print_str | main.rs:91:19:91:20 | s2 |  |
+| main.rs:91:9:91:21 | print_str(...) | main.rs:90:14:92:5 | { ... } |  |
+| main.rs:91:9:91:22 | ExprStmt | main.rs:91:9:91:17 | print_str |  |
+| main.rs:91:19:91:20 | s2 | main.rs:91:9:91:21 | print_str(...) |  |
+| main.rs:95:1:103:1 | enter fn let_pattern4 | main.rs:96:5:101:6 | let ... = ... else {...} |  |
+| main.rs:95:1:103:1 | exit fn let_pattern4 (normal) | main.rs:95:1:103:1 | exit fn let_pattern4 |  |
+| main.rs:95:19:103:1 | { ... } | main.rs:95:1:103:1 | exit fn let_pattern4 (normal) |  |
+| main.rs:96:5:101:6 | let ... = ... else {...} | main.rs:97:7:97:10 | Some |  |
+| main.rs:96:9:96:16 | Some(...) | main.rs:96:14:96:15 | x5 | match |
+| main.rs:96:9:96:16 | Some(...) | main.rs:100:9:100:15 | ...::panic | no-match |
+| main.rs:96:14:96:15 | x5 | main.rs:96:14:96:15 | x5 |  |
+| main.rs:96:14:96:15 | x5 | main.rs:102:5:102:18 | ExprStmt | match |
+| main.rs:97:7:97:10 | Some | main.rs:97:12:97:15 | "x5" |  |
+| main.rs:97:7:97:16 | Some(...) | main.rs:96:9:96:16 | Some(...) |  |
+| main.rs:97:12:97:15 | "x5" | main.rs:97:7:97:16 | Some(...) |  |
+| main.rs:100:9:100:15 | "not yet implemented" | main.rs:100:9:100:15 | ...::panic(...) |  |
+| main.rs:100:9:100:15 | ...::panic | main.rs:100:9:100:15 | "not yet implemented" |  |
+| main.rs:100:9:100:15 | ...::panic(...) | main.rs:100:9:100:15 | MacroBlockExpr |  |
+| main.rs:100:9:100:15 | MacroBlockExpr | main.rs:100:9:100:15 | todo!... |  |
+| main.rs:100:9:100:15 | MacroExpr | main.rs:99:10:101:5 | { ... } |  |
+| main.rs:100:9:100:15 | todo!... | main.rs:100:9:100:15 | MacroExpr |  |
+| main.rs:102:5:102:13 | print_str | main.rs:102:15:102:16 | x5 |  |
+| main.rs:102:5:102:17 | print_str(...) | main.rs:95:19:103:1 | { ... } |  |
+| main.rs:102:5:102:18 | ExprStmt | main.rs:102:5:102:13 | print_str |  |
+| main.rs:102:15:102:16 | x5 | main.rs:102:5:102:17 | print_str(...) |  |
+| main.rs:105:1:112:1 | enter fn let_pattern5 | main.rs:106:5:106:42 | let ... = ... |  |
+| main.rs:105:1:112:1 | exit fn let_pattern5 (normal) | main.rs:105:1:112:1 | exit fn let_pattern5 |  |
+| main.rs:105:19:112:1 | { ... } | main.rs:105:1:112:1 | exit fn let_pattern5 (normal) |  |
+| main.rs:106:5:106:42 | let ... = ... | main.rs:106:14:106:17 | Some |  |
+| main.rs:106:9:106:10 | s1 | main.rs:106:9:106:10 | s1 |  |
+| main.rs:106:9:106:10 | s1 | main.rs:108:11:109:12 | let ... = s1 | match |
+| main.rs:106:14:106:17 | Some | main.rs:106:19:106:30 | ...::from |  |
+| main.rs:106:14:106:41 | Some(...) | main.rs:106:9:106:10 | s1 |  |
+| main.rs:106:19:106:30 | ...::from | main.rs:106:32:106:39 | "Hello!" |  |
+| main.rs:106:19:106:40 | ...::from(...) | main.rs:106:14:106:41 | Some(...) |  |
+| main.rs:106:32:106:39 | "Hello!" | main.rs:106:19:106:40 | ...::from(...) |  |
+| main.rs:108:5:111:5 | while ... { ... } | main.rs:105:19:112:1 | { ... } |  |
+| main.rs:108:11:109:12 | let ... = s1 | main.rs:109:11:109:12 | s1 |  |
+| main.rs:108:15:108:26 | Some(...) | main.rs:108:5:111:5 | while ... { ... } | no-match |
+| main.rs:108:15:108:26 | Some(...) | main.rs:108:24:108:25 | s2 | match |
+| main.rs:108:20:108:25 | ref s2 | main.rs:110:9:110:22 | ExprStmt | match |
+| main.rs:108:24:108:25 | s2 | main.rs:108:20:108:25 | ref s2 |  |
+| main.rs:109:11:109:12 | s1 | main.rs:108:15:108:26 | Some(...) |  |
+| main.rs:109:14:111:5 | { ... } | main.rs:108:11:109:12 | let ... = s1 |  |
+| main.rs:110:9:110:17 | print_str | main.rs:110:19:110:20 | s2 |  |
+| main.rs:110:9:110:21 | print_str(...) | main.rs:109:14:111:5 | { ... } |  |
+| main.rs:110:9:110:22 | ExprStmt | main.rs:110:9:110:17 | print_str |  |
+| main.rs:110:19:110:20 | s2 | main.rs:110:9:110:21 | print_str(...) |  |
+| main.rs:114:1:129:1 | enter fn match_pattern1 | main.rs:115:5:115:21 | let ... = ... |  |
+| main.rs:114:1:129:1 | exit fn match_pattern1 (normal) | main.rs:114:1:129:1 | exit fn match_pattern1 |  |
+| main.rs:114:21:129:1 | { ... } | main.rs:114:1:129:1 | exit fn match_pattern1 (normal) |  |
+| main.rs:115:5:115:21 | let ... = ... | main.rs:115:14:115:17 | Some |  |
+| main.rs:115:9:115:10 | x6 | main.rs:115:9:115:10 | x6 |  |
+| main.rs:115:9:115:10 | x6 | main.rs:116:5:116:16 | let ... = 10 | match |
+| main.rs:115:14:115:17 | Some | main.rs:115:19:115:19 | 5 |  |
+| main.rs:115:14:115:20 | Some(...) | main.rs:115:9:115:10 | x6 |  |
+| main.rs:115:19:115:19 | 5 | main.rs:115:14:115:20 | Some(...) |  |
+| main.rs:116:5:116:16 | let ... = 10 | main.rs:116:14:116:15 | 10 |  |
+| main.rs:116:9:116:10 | y1 | main.rs:116:9:116:10 | y1 |  |
+| main.rs:116:9:116:10 | y1 | main.rs:118:5:126:5 | ExprStmt | match |
+| main.rs:116:14:116:15 | 10 | main.rs:116:9:116:10 | y1 |  |
+| main.rs:118:5:126:5 | ExprStmt | main.rs:118:11:118:12 | x6 |  |
+| main.rs:118:5:126:5 | match x6 { ... } | main.rs:128:5:128:18 | ExprStmt |  |
+| main.rs:118:11:118:12 | x6 | main.rs:119:9:119:16 | Some(...) |  |
+| main.rs:119:9:119:16 | Some(...) | main.rs:119:14:119:15 | 50 | match |
+| main.rs:119:9:119:16 | Some(...) | main.rs:120:9:120:16 | Some(...) | no-match |
+| main.rs:119:14:119:15 | 50 | main.rs:119:14:119:15 | 50 |  |
+| main.rs:119:14:119:15 | 50 | main.rs:119:21:119:29 | print_str | match |
+| main.rs:119:14:119:15 | 50 | main.rs:120:9:120:16 | Some(...) | no-match |
+| main.rs:119:21:119:29 | print_str | main.rs:119:31:119:38 | "Got 50" |  |
+| main.rs:119:21:119:39 | print_str(...) | main.rs:118:5:126:5 | match x6 { ... } |  |
+| main.rs:119:31:119:38 | "Got 50" | main.rs:119:21:119:39 | print_str(...) |  |
+| main.rs:120:9:120:16 | Some(...) | main.rs:120:14:120:15 | y1 | match |
+| main.rs:120:9:120:16 | Some(...) | main.rs:125:9:125:12 | None | no-match |
+| main.rs:120:14:120:15 | y1 | main.rs:120:14:120:15 | y1 |  |
+| main.rs:120:14:120:15 | y1 | main.rs:123:13:123:21 | print_i64 | match |
+| main.rs:122:9:124:9 | { ... } | main.rs:118:5:126:5 | match x6 { ... } |  |
+| main.rs:123:13:123:21 | print_i64 | main.rs:123:23:123:24 | y1 |  |
+| main.rs:123:13:123:25 | print_i64(...) | main.rs:122:9:124:9 | { ... } |  |
+| main.rs:123:23:123:24 | y1 | main.rs:123:13:123:25 | print_i64(...) |  |
+| main.rs:125:9:125:12 | None | main.rs:125:9:125:12 | None |  |
+| main.rs:125:9:125:12 | None | main.rs:125:17:125:25 | print_str | match |
+| main.rs:125:17:125:25 | print_str | main.rs:125:27:125:32 | "NONE" |  |
+| main.rs:125:17:125:33 | print_str(...) | main.rs:118:5:126:5 | match x6 { ... } |  |
+| main.rs:125:27:125:32 | "NONE" | main.rs:125:17:125:33 | print_str(...) |  |
+| main.rs:128:5:128:13 | print_i64 | main.rs:128:15:128:16 | y1 |  |
+| main.rs:128:5:128:17 | print_i64(...) | main.rs:114:21:129:1 | { ... } |  |
+| main.rs:128:5:128:18 | ExprStmt | main.rs:128:5:128:13 | print_i64 |  |
+| main.rs:128:15:128:16 | y1 | main.rs:128:5:128:17 | print_i64(...) |  |
+| main.rs:131:1:160:1 | enter fn match_pattern2 | main.rs:132:5:132:36 | let ... = ... |  |
+| main.rs:131:1:160:1 | exit fn match_pattern2 (normal) | main.rs:131:1:160:1 | exit fn match_pattern2 |  |
+| main.rs:131:21:160:1 | { ... } | main.rs:131:1:160:1 | exit fn match_pattern2 (normal) |  |
+| main.rs:132:5:132:36 | let ... = ... | main.rs:132:20:132:20 | 2 |  |
+| main.rs:132:9:132:15 | numbers | main.rs:132:9:132:15 | numbers |  |
+| main.rs:132:9:132:15 | numbers | main.rs:134:5:147:5 | ExprStmt | match |
+| main.rs:132:19:132:35 | TupleExpr | main.rs:132:9:132:15 | numbers |  |
+| main.rs:132:20:132:20 | 2 | main.rs:132:23:132:23 | 4 |  |
+| main.rs:132:23:132:23 | 4 | main.rs:132:26:132:26 | 8 |  |
+| main.rs:132:26:132:26 | 8 | main.rs:132:29:132:30 | 16 |  |
+| main.rs:132:29:132:30 | 16 | main.rs:132:33:132:34 | 32 |  |
+| main.rs:132:33:132:34 | 32 | main.rs:132:19:132:35 | TupleExpr |  |
+| main.rs:134:5:147:5 | ExprStmt | main.rs:134:11:134:17 | numbers |  |
+| main.rs:134:5:147:5 | match numbers { ... } | main.rs:149:11:149:17 | numbers |  |
+| main.rs:134:11:134:17 | numbers | main.rs:136:9:142:9 | TuplePat |  |
+| main.rs:136:9:142:9 | TuplePat | main.rs:137:13:137:17 | first | match |
+| main.rs:137:13:137:17 | first | main.rs:137:13:137:17 | first |  |
+| main.rs:137:13:137:17 | first | main.rs:138:13:138:13 | _ | match |
+| main.rs:138:13:138:13 | _ | main.rs:139:13:139:17 | third | match |
+| main.rs:139:13:139:17 | third | main.rs:139:13:139:17 | third |  |
+| main.rs:139:13:139:17 | third | main.rs:140:13:140:13 | _ | match |
+| main.rs:140:13:140:13 | _ | main.rs:141:13:141:17 | fifth | match |
+| main.rs:141:13:141:17 | fifth | main.rs:141:13:141:17 | fifth |  |
+| main.rs:141:13:141:17 | fifth | main.rs:143:13:143:29 | ExprStmt | match |
+| main.rs:142:14:146:9 | { ... } | main.rs:134:5:147:5 | match numbers { ... } |  |
+| main.rs:143:13:143:21 | print_i64 | main.rs:143:23:143:27 | first |  |
+| main.rs:143:13:143:28 | print_i64(...) | main.rs:144:13:144:29 | ExprStmt |  |
+| main.rs:143:13:143:29 | ExprStmt | main.rs:143:13:143:21 | print_i64 |  |
+| main.rs:143:23:143:27 | first | main.rs:143:13:143:28 | print_i64(...) |  |
+| main.rs:144:13:144:21 | print_i64 | main.rs:144:23:144:27 | third |  |
+| main.rs:144:13:144:28 | print_i64(...) | main.rs:145:13:145:29 | ExprStmt |  |
+| main.rs:144:13:144:29 | ExprStmt | main.rs:144:13:144:21 | print_i64 |  |
+| main.rs:144:23:144:27 | third | main.rs:144:13:144:28 | print_i64(...) |  |
+| main.rs:145:13:145:21 | print_i64 | main.rs:145:23:145:27 | fifth |  |
+| main.rs:145:13:145:28 | print_i64(...) | main.rs:142:14:146:9 | { ... } |  |
+| main.rs:145:13:145:29 | ExprStmt | main.rs:145:13:145:21 | print_i64 |  |
+| main.rs:145:23:145:27 | fifth | main.rs:145:13:145:28 | print_i64(...) |  |
+| main.rs:149:5:159:5 | match numbers { ... } | main.rs:131:21:160:1 | { ... } |  |
+| main.rs:149:11:149:17 | numbers | main.rs:151:9:155:9 | TuplePat |  |
+| main.rs:151:9:155:9 | TuplePat | main.rs:152:13:152:17 | first | match |
+| main.rs:152:13:152:17 | first | main.rs:152:13:152:17 | first |  |
+| main.rs:152:13:152:17 | first | main.rs:153:13:153:14 | .. | match |
+| main.rs:153:13:153:14 | .. | main.rs:154:13:154:16 | last | match |
+| main.rs:154:13:154:16 | last | main.rs:154:13:154:16 | last |  |
+| main.rs:154:13:154:16 | last | main.rs:156:13:156:29 | ExprStmt | match |
+| main.rs:155:14:158:9 | { ... } | main.rs:149:5:159:5 | match numbers { ... } |  |
+| main.rs:156:13:156:21 | print_i64 | main.rs:156:23:156:27 | first |  |
+| main.rs:156:13:156:28 | print_i64(...) | main.rs:157:13:157:28 | ExprStmt |  |
+| main.rs:156:13:156:29 | ExprStmt | main.rs:156:13:156:21 | print_i64 |  |
+| main.rs:156:23:156:27 | first | main.rs:156:13:156:28 | print_i64(...) |  |
+| main.rs:157:13:157:21 | print_i64 | main.rs:157:23:157:26 | last |  |
+| main.rs:157:13:157:27 | print_i64(...) | main.rs:155:14:158:9 | { ... } |  |
+| main.rs:157:13:157:28 | ExprStmt | main.rs:157:13:157:21 | print_i64 |  |
+| main.rs:157:23:157:26 | last | main.rs:157:13:157:27 | print_i64(...) |  |
+| main.rs:162:1:170:1 | enter fn match_pattern3 | main.rs:163:5:163:38 | let ... = ... |  |
+| main.rs:162:1:170:1 | exit fn match_pattern3 (normal) | main.rs:162:1:170:1 | exit fn match_pattern3 |  |
+| main.rs:162:21:170:1 | { ... } | main.rs:162:1:170:1 | exit fn match_pattern3 (normal) |  |
+| main.rs:163:5:163:38 | let ... = ... | main.rs:163:25:163:27 | "x" |  |
+| main.rs:163:9:163:10 | p2 | main.rs:163:9:163:10 | p2 |  |
+| main.rs:163:9:163:10 | p2 | main.rs:165:11:165:12 | p2 | match |
+| main.rs:163:14:163:37 | Point {...} | main.rs:163:9:163:10 | p2 |  |
+| main.rs:163:25:163:27 | "x" | main.rs:163:33:163:35 | "y" |  |
+| main.rs:163:33:163:35 | "y" | main.rs:163:14:163:37 | Point {...} |  |
+| main.rs:165:5:169:5 | match p2 { ... } | main.rs:162:21:170:1 | { ... } |  |
+| main.rs:165:11:165:12 | p2 | main.rs:166:9:168:9 | Point {...} |  |
+| main.rs:166:9:168:9 | Point {...} | main.rs:167:16:167:17 | x7 | match |
+| main.rs:167:16:167:17 | x7 | main.rs:167:16:167:17 | x7 |  |
+| main.rs:167:16:167:17 | x7 | main.rs:167:20:167:21 | .. | match |
+| main.rs:167:20:167:21 | .. | main.rs:168:14:168:22 | print_str | match |
+| main.rs:168:14:168:22 | print_str | main.rs:168:24:168:25 | x7 |  |
+| main.rs:168:14:168:26 | print_str(...) | main.rs:165:5:169:5 | match p2 { ... } |  |
+| main.rs:168:24:168:25 | x7 | main.rs:168:14:168:26 | print_str(...) |  |
+| main.rs:176:1:193:1 | enter fn match_pattern4 | main.rs:177:5:177:39 | let ... = ... |  |
+| main.rs:176:1:193:1 | exit fn match_pattern4 (normal) | main.rs:176:1:193:1 | exit fn match_pattern4 |  |
+| main.rs:176:21:193:1 | { ... } | main.rs:176:1:193:1 | exit fn match_pattern4 (normal) |  |
+| main.rs:177:5:177:39 | let ... = ... | main.rs:177:36:177:36 | 0 |  |
+| main.rs:177:9:177:11 | msg | main.rs:177:9:177:11 | msg |  |
+| main.rs:177:9:177:11 | msg | main.rs:179:11:179:13 | msg | match |
+| main.rs:177:15:177:38 | ...::Hello {...} | main.rs:177:9:177:11 | msg |  |
+| main.rs:177:36:177:36 | 0 | main.rs:177:15:177:38 | ...::Hello {...} |  |
+| main.rs:179:5:192:5 | match msg { ... } | main.rs:176:21:193:1 | { ... } |  |
+| main.rs:179:11:179:13 | msg | main.rs:181:9:183:9 | ...::Hello {...} |  |
+| main.rs:181:9:183:9 | ...::Hello {...} | main.rs:182:31:182:35 | RangePat | match |
+| main.rs:181:9:183:9 | ...::Hello {...} | main.rs:184:9:184:38 | ...::Hello {...} | no-match |
+| main.rs:182:17:182:27 | id_variable | main.rs:182:17:182:35 | id_variable @ ... |  |
+| main.rs:182:17:182:35 | id_variable @ ... | main.rs:183:14:183:22 | print_i64 | match |
+| main.rs:182:31:182:31 | 3 | main.rs:182:31:182:31 | 3 |  |
+| main.rs:182:31:182:31 | 3 | main.rs:182:35:182:35 | 7 | match |
+| main.rs:182:31:182:31 | 3 | main.rs:184:9:184:38 | ...::Hello {...} | no-match |
+| main.rs:182:31:182:35 | RangePat | main.rs:182:31:182:31 | 3 | match |
+| main.rs:182:35:182:35 | 7 | main.rs:182:17:182:27 | id_variable | match |
+| main.rs:182:35:182:35 | 7 | main.rs:182:35:182:35 | 7 |  |
+| main.rs:182:35:182:35 | 7 | main.rs:184:9:184:38 | ...::Hello {...} | no-match |
+| main.rs:183:14:183:22 | print_i64 | main.rs:183:24:183:34 | id_variable |  |
+| main.rs:183:14:183:35 | print_i64(...) | main.rs:179:5:192:5 | match msg { ... } |  |
+| main.rs:183:24:183:34 | id_variable | main.rs:183:14:183:35 | print_i64(...) |  |
+| main.rs:184:9:184:38 | ...::Hello {...} | main.rs:184:30:184:36 | RangePat | match |
+| main.rs:184:9:184:38 | ...::Hello {...} | main.rs:187:9:187:29 | ...::Hello {...} | no-match |
+| main.rs:184:30:184:31 | 10 | main.rs:184:30:184:31 | 10 |  |
+| main.rs:184:30:184:31 | 10 | main.rs:184:35:184:36 | 12 | match |
+| main.rs:184:30:184:31 | 10 | main.rs:187:9:187:29 | ...::Hello {...} | no-match |
+| main.rs:184:30:184:36 | RangePat | main.rs:184:30:184:31 | 10 | match |
+| main.rs:184:35:184:36 | 12 | main.rs:184:35:184:36 | 12 |  |
+| main.rs:184:35:184:36 | 12 | main.rs:185:22:185:51 | ExprStmt | match |
+| main.rs:184:35:184:36 | 12 | main.rs:187:9:187:29 | ...::Hello {...} | no-match |
+| main.rs:184:43:186:9 | { ... } | main.rs:179:5:192:5 | match msg { ... } |  |
+| main.rs:185:13:185:52 | ...::_print | main.rs:185:22:185:51 | "Found an id in another range\\... |  |
+| main.rs:185:13:185:52 | MacroExpr | main.rs:184:43:186:9 | { ... } |  |
+| main.rs:185:13:185:52 | println!... | main.rs:185:13:185:52 | MacroExpr |  |
+| main.rs:185:22:185:51 | "Found an id in another range\\... | main.rs:185:22:185:51 | FormatArgsExpr |  |
+| main.rs:185:22:185:51 | ...::_print(...) | main.rs:185:22:185:51 | { ... } |  |
+| main.rs:185:22:185:51 | ...::format_args_nl!... | main.rs:185:22:185:51 | MacroExpr |  |
+| main.rs:185:22:185:51 | ExprStmt | main.rs:185:13:185:52 | ...::_print |  |
+| main.rs:185:22:185:51 | FormatArgsExpr | main.rs:185:22:185:51 | ...::format_args_nl!... |  |
+| main.rs:185:22:185:51 | MacroBlockExpr | main.rs:185:13:185:52 | println!... |  |
+| main.rs:185:22:185:51 | MacroExpr | main.rs:185:22:185:51 | ...::_print(...) |  |
+| main.rs:185:22:185:51 | { ... } | main.rs:185:22:185:51 | MacroBlockExpr |  |
+| main.rs:187:9:187:29 | ...::Hello {...} | main.rs:187:26:187:27 | id | match |
+| main.rs:187:26:187:27 | id | main.rs:187:26:187:27 | id |  |
+| main.rs:187:26:187:27 | id | main.rs:190:13:190:21 | print_i64 | match |
+| main.rs:189:9:191:9 | { ... } | main.rs:179:5:192:5 | match msg { ... } |  |
+| main.rs:190:13:190:21 | print_i64 | main.rs:190:23:190:24 | id |  |
+| main.rs:190:13:190:25 | print_i64(...) | main.rs:189:9:191:9 | { ... } |  |
+| main.rs:190:23:190:24 | id | main.rs:190:13:190:25 | print_i64(...) |  |
+| main.rs:200:1:206:1 | enter fn match_pattern5 | main.rs:201:5:201:34 | let ... = ... |  |
+| main.rs:200:1:206:1 | exit fn match_pattern5 (normal) | main.rs:200:1:206:1 | exit fn match_pattern5 |  |
+| main.rs:200:21:206:1 | { ... } | main.rs:200:1:206:1 | exit fn match_pattern5 (normal) |  |
+| main.rs:201:5:201:34 | let ... = ... | main.rs:201:18:201:29 | ...::Left |  |
+| main.rs:201:9:201:14 | either | main.rs:201:9:201:14 | either |  |
+| main.rs:201:9:201:14 | either | main.rs:202:11:202:16 | either | match |
+| main.rs:201:18:201:29 | ...::Left | main.rs:201:31:201:32 | 32 |  |
+| main.rs:201:18:201:33 | ...::Left(...) | main.rs:201:9:201:14 | either |  |
+| main.rs:201:31:201:32 | 32 | main.rs:201:18:201:33 | ...::Left(...) |  |
+| main.rs:202:5:205:5 | match either { ... } | main.rs:200:21:206:1 | { ... } |  |
+| main.rs:202:11:202:16 | either | main.rs:203:9:203:24 | ...::Left(...) |  |
+| main.rs:203:9:203:24 | ...::Left(...) | main.rs:203:22:203:23 | a3 | match |
+| main.rs:203:9:203:24 | ...::Left(...) | main.rs:203:28:203:44 | ...::Right(...) | no-match |
+| main.rs:203:9:203:44 | ... \| ... | main.rs:204:16:204:24 | print_i64 | match |
+| main.rs:203:22:203:23 | a3 | main.rs:203:9:203:44 | ... \| ... | match |
+| main.rs:203:22:203:23 | a3 | main.rs:203:22:203:23 | a3 |  |
+| main.rs:203:28:203:44 | ...::Right(...) | main.rs:203:42:203:43 | a3 | match |
+| main.rs:203:42:203:43 | a3 | main.rs:203:9:203:44 | ... \| ... | match |
+| main.rs:203:42:203:43 | a3 | main.rs:203:42:203:43 | a3 |  |
+| main.rs:204:16:204:24 | print_i64 | main.rs:204:26:204:27 | a3 |  |
+| main.rs:204:16:204:28 | print_i64(...) | main.rs:202:5:205:5 | match either { ... } |  |
+| main.rs:204:26:204:27 | a3 | main.rs:204:16:204:28 | print_i64(...) |  |
+| main.rs:214:1:228:1 | enter fn match_pattern6 | main.rs:215:5:215:37 | let ... = ... |  |
+| main.rs:214:1:228:1 | exit fn match_pattern6 (normal) | main.rs:214:1:228:1 | exit fn match_pattern6 |  |
+| main.rs:214:21:228:1 | { ... } | main.rs:214:1:228:1 | exit fn match_pattern6 (normal) |  |
+| main.rs:215:5:215:37 | let ... = ... | main.rs:215:14:215:32 | ...::Second |  |
+| main.rs:215:9:215:10 | tv | main.rs:215:9:215:10 | tv |  |
+| main.rs:215:9:215:10 | tv | main.rs:216:5:219:5 | ExprStmt | match |
+| main.rs:215:14:215:32 | ...::Second | main.rs:215:34:215:35 | 62 |  |
+| main.rs:215:14:215:36 | ...::Second(...) | main.rs:215:9:215:10 | tv |  |
+| main.rs:215:34:215:35 | 62 | main.rs:215:14:215:36 | ...::Second(...) |  |
+| main.rs:216:5:219:5 | ExprStmt | main.rs:216:11:216:12 | tv |  |
+| main.rs:216:5:219:5 | match tv { ... } | main.rs:220:5:223:5 | ExprStmt |  |
+| main.rs:216:11:216:12 | tv | main.rs:217:9:217:30 | ...::First(...) |  |
+| main.rs:217:9:217:30 | ...::First(...) | main.rs:217:28:217:29 | a4 | match |
+| main.rs:217:9:217:30 | ...::First(...) | main.rs:217:34:217:56 | ...::Second(...) | no-match |
+| main.rs:217:9:217:81 | ... \| ... \| ... | main.rs:218:16:218:24 | print_i64 | match |
+| main.rs:217:28:217:29 | a4 | main.rs:217:9:217:81 | ... \| ... \| ... | match |
+| main.rs:217:28:217:29 | a4 | main.rs:217:28:217:29 | a4 |  |
+| main.rs:217:34:217:56 | ...::Second(...) | main.rs:217:54:217:55 | a4 | match |
+| main.rs:217:34:217:56 | ...::Second(...) | main.rs:217:60:217:81 | ...::Third(...) | no-match |
+| main.rs:217:54:217:55 | a4 | main.rs:217:9:217:81 | ... \| ... \| ... | match |
+| main.rs:217:54:217:55 | a4 | main.rs:217:54:217:55 | a4 |  |
+| main.rs:217:60:217:81 | ...::Third(...) | main.rs:217:79:217:80 | a4 | match |
+| main.rs:217:79:217:80 | a4 | main.rs:217:9:217:81 | ... \| ... \| ... | match |
+| main.rs:217:79:217:80 | a4 | main.rs:217:79:217:80 | a4 |  |
+| main.rs:218:16:218:24 | print_i64 | main.rs:218:26:218:27 | a4 |  |
+| main.rs:218:16:218:28 | print_i64(...) | main.rs:216:5:219:5 | match tv { ... } |  |
+| main.rs:218:26:218:27 | a4 | main.rs:218:16:218:28 | print_i64(...) |  |
+| main.rs:220:5:223:5 | ExprStmt | main.rs:220:11:220:12 | tv |  |
+| main.rs:220:5:223:5 | match tv { ... } | main.rs:224:11:224:12 | tv |  |
+| main.rs:220:11:220:12 | tv | main.rs:221:10:221:31 | ...::First(...) |  |
+| main.rs:221:9:221:83 | ... \| ... | main.rs:222:16:222:24 | print_i64 | match |
+| main.rs:221:10:221:31 | ...::First(...) | main.rs:221:29:221:30 | a5 | match |
+| main.rs:221:10:221:31 | ...::First(...) | main.rs:221:35:221:57 | ...::Second(...) | no-match |
+| main.rs:221:10:221:57 | [match(false)] ... \| ... | main.rs:221:62:221:83 | ...::Third(...) | no-match |
+| main.rs:221:10:221:57 | [match(true)] ... \| ... | main.rs:221:9:221:83 | ... \| ... | match |
+| main.rs:221:29:221:30 | a5 | main.rs:221:10:221:57 | [match(true)] ... \| ... | match |
+| main.rs:221:29:221:30 | a5 | main.rs:221:29:221:30 | a5 |  |
+| main.rs:221:35:221:57 | ...::Second(...) | main.rs:221:10:221:57 | [match(false)] ... \| ... | no-match |
+| main.rs:221:35:221:57 | ...::Second(...) | main.rs:221:55:221:56 | a5 | match |
+| main.rs:221:55:221:56 | a5 | main.rs:221:10:221:57 | [match(true)] ... \| ... | match |
+| main.rs:221:55:221:56 | a5 | main.rs:221:55:221:56 | a5 |  |
+| main.rs:221:62:221:83 | ...::Third(...) | main.rs:221:81:221:82 | a5 | match |
+| main.rs:221:81:221:82 | a5 | main.rs:221:9:221:83 | ... \| ... | match |
+| main.rs:221:81:221:82 | a5 | main.rs:221:81:221:82 | a5 |  |
+| main.rs:222:16:222:24 | print_i64 | main.rs:222:26:222:27 | a5 |  |
+| main.rs:222:16:222:28 | print_i64(...) | main.rs:220:5:223:5 | match tv { ... } |  |
+| main.rs:222:26:222:27 | a5 | main.rs:222:16:222:28 | print_i64(...) |  |
+| main.rs:224:5:227:5 | match tv { ... } | main.rs:214:21:228:1 | { ... } |  |
+| main.rs:224:11:224:12 | tv | main.rs:225:9:225:30 | ...::First(...) |  |
+| main.rs:225:9:225:30 | ...::First(...) | main.rs:225:28:225:29 | a6 | match |
+| main.rs:225:9:225:30 | ...::First(...) | main.rs:225:35:225:57 | ...::Second(...) | no-match |
+| main.rs:225:9:225:83 | ... \| ... | main.rs:226:16:226:24 | print_i64 | match |
+| main.rs:225:28:225:29 | a6 | main.rs:225:9:225:83 | ... \| ... | match |
+| main.rs:225:28:225:29 | a6 | main.rs:225:28:225:29 | a6 |  |
+| main.rs:225:35:225:57 | ...::Second(...) | main.rs:225:55:225:56 | a6 | match |
+| main.rs:225:35:225:57 | ...::Second(...) | main.rs:225:61:225:82 | ...::Third(...) | no-match |
+| main.rs:225:35:225:82 | ... \| ... | main.rs:225:9:225:83 | ... \| ... | match |
+| main.rs:225:55:225:56 | a6 | main.rs:225:35:225:82 | ... \| ... | match |
+| main.rs:225:55:225:56 | a6 | main.rs:225:55:225:56 | a6 |  |
+| main.rs:225:61:225:82 | ...::Third(...) | main.rs:225:80:225:81 | a6 | match |
+| main.rs:225:80:225:81 | a6 | main.rs:225:35:225:82 | ... \| ... | match |
+| main.rs:225:80:225:81 | a6 | main.rs:225:80:225:81 | a6 |  |
+| main.rs:226:16:226:24 | print_i64 | main.rs:226:26:226:27 | a6 |  |
+| main.rs:226:16:226:28 | print_i64(...) | main.rs:224:5:227:5 | match tv { ... } |  |
+| main.rs:226:26:226:27 | a6 | main.rs:226:16:226:28 | print_i64(...) |  |
+| main.rs:230:1:238:1 | enter fn match_pattern7 | main.rs:231:5:231:34 | let ... = ... |  |
+| main.rs:230:1:238:1 | exit fn match_pattern7 (normal) | main.rs:230:1:238:1 | exit fn match_pattern7 |  |
+| main.rs:230:21:238:1 | { ... } | main.rs:230:1:238:1 | exit fn match_pattern7 (normal) |  |
+| main.rs:231:5:231:34 | let ... = ... | main.rs:231:18:231:29 | ...::Left |  |
+| main.rs:231:9:231:14 | either | main.rs:231:9:231:14 | either |  |
+| main.rs:231:9:231:14 | either | main.rs:232:11:232:16 | either | match |
+| main.rs:231:18:231:29 | ...::Left | main.rs:231:31:231:32 | 32 |  |
+| main.rs:231:18:231:33 | ...::Left(...) | main.rs:231:9:231:14 | either |  |
+| main.rs:231:31:231:32 | 32 | main.rs:231:18:231:33 | ...::Left(...) |  |
+| main.rs:232:5:237:5 | match either { ... } | main.rs:230:21:238:1 | { ... } |  |
+| main.rs:232:11:232:16 | either | main.rs:233:9:233:24 | ...::Left(...) |  |
+| main.rs:233:9:233:24 | ...::Left(...) | main.rs:233:22:233:23 | a7 | match |
+| main.rs:233:9:233:24 | ...::Left(...) | main.rs:233:28:233:44 | ...::Right(...) | no-match |
+| main.rs:233:9:233:44 | [match(false)] ... \| ... | main.rs:236:9:236:9 | _ | no-match |
+| main.rs:233:9:233:44 | [match(true)] ... \| ... | main.rs:234:16:234:17 | a7 | match |
+| main.rs:233:22:233:23 | a7 | main.rs:233:9:233:44 | [match(true)] ... \| ... | match |
+| main.rs:233:22:233:23 | a7 | main.rs:233:22:233:23 | a7 |  |
+| main.rs:233:28:233:44 | ...::Right(...) | main.rs:233:9:233:44 | [match(false)] ... \| ... | no-match |
+| main.rs:233:28:233:44 | ...::Right(...) | main.rs:233:42:233:43 | a7 | match |
+| main.rs:233:42:233:43 | a7 | main.rs:233:9:233:44 | [match(true)] ... \| ... | match |
+| main.rs:233:42:233:43 | a7 | main.rs:233:42:233:43 | a7 |  |
+| main.rs:234:16:234:17 | a7 | main.rs:234:21:234:21 | 0 |  |
+| main.rs:234:16:234:21 | ... > ... | main.rs:235:16:235:24 | print_i64 | true |
+| main.rs:234:16:234:21 | ... > ... | main.rs:236:9:236:9 | _ | false |
+| main.rs:234:21:234:21 | 0 | main.rs:234:16:234:21 | ... > ... |  |
+| main.rs:235:16:235:24 | print_i64 | main.rs:235:26:235:27 | a7 |  |
+| main.rs:235:16:235:28 | print_i64(...) | main.rs:232:5:237:5 | match either { ... } |  |
+| main.rs:235:26:235:27 | a7 | main.rs:235:16:235:28 | print_i64(...) |  |
+| main.rs:236:9:236:9 | _ | main.rs:236:14:236:15 | TupleExpr | match |
+| main.rs:236:14:236:15 | TupleExpr | main.rs:232:5:237:5 | match either { ... } |  |
+| main.rs:240:1:255:1 | enter fn match_pattern8 | main.rs:241:5:241:34 | let ... = ... |  |
+| main.rs:240:1:255:1 | exit fn match_pattern8 (normal) | main.rs:240:1:255:1 | exit fn match_pattern8 |  |
+| main.rs:240:21:255:1 | { ... } | main.rs:240:1:255:1 | exit fn match_pattern8 (normal) |  |
+| main.rs:241:5:241:34 | let ... = ... | main.rs:241:18:241:29 | ...::Left |  |
+| main.rs:241:9:241:14 | either | main.rs:241:9:241:14 | either |  |
+| main.rs:241:9:241:14 | either | main.rs:243:11:243:16 | either | match |
+| main.rs:241:18:241:29 | ...::Left | main.rs:241:31:241:32 | 32 |  |
+| main.rs:241:18:241:33 | ...::Left(...) | main.rs:241:9:241:14 | either |  |
+| main.rs:241:31:241:32 | 32 | main.rs:241:18:241:33 | ...::Left(...) |  |
+| main.rs:243:5:254:5 | match either { ... } | main.rs:240:21:255:1 | { ... } |  |
+| main.rs:243:11:243:16 | either | main.rs:245:14:245:30 | ...::Left(...) |  |
+| main.rs:244:9:245:52 | ref e @ ... | main.rs:247:13:247:27 | ExprStmt | match |
+| main.rs:244:13:244:13 | e | main.rs:244:9:245:52 | ref e @ ... |  |
+| main.rs:245:14:245:30 | ...::Left(...) | main.rs:245:27:245:29 | a11 | match |
+| main.rs:245:14:245:30 | ...::Left(...) | main.rs:245:34:245:51 | ...::Right(...) | no-match |
+| main.rs:245:14:245:51 | [match(false)] ... \| ... | main.rs:253:9:253:9 | _ | no-match |
+| main.rs:245:14:245:51 | [match(true)] ... \| ... | main.rs:244:13:244:13 | e | match |
+| main.rs:245:27:245:29 | a11 | main.rs:245:14:245:51 | [match(true)] ... \| ... | match |
+| main.rs:245:27:245:29 | a11 | main.rs:245:27:245:29 | a11 |  |
+| main.rs:245:34:245:51 | ...::Right(...) | main.rs:245:14:245:51 | [match(false)] ... \| ... | no-match |
+| main.rs:245:34:245:51 | ...::Right(...) | main.rs:245:48:245:50 | a11 | match |
+| main.rs:245:48:245:50 | a11 | main.rs:245:14:245:51 | [match(true)] ... \| ... | match |
+| main.rs:245:48:245:50 | a11 | main.rs:245:48:245:50 | a11 |  |
+| main.rs:246:12:252:9 | { ... } | main.rs:243:5:254:5 | match either { ... } |  |
+| main.rs:247:13:247:21 | print_i64 | main.rs:247:23:247:25 | a11 |  |
+| main.rs:247:13:247:26 | print_i64(...) | main.rs:248:16:249:15 | let ... = e |  |
+| main.rs:247:13:247:27 | ExprStmt | main.rs:247:13:247:21 | print_i64 |  |
+| main.rs:247:23:247:25 | a11 | main.rs:247:13:247:26 | print_i64(...) |  |
+| main.rs:248:13:251:13 | if ... {...} | main.rs:246:12:252:9 | { ... } |  |
+| main.rs:248:16:249:15 | let ... = e | main.rs:249:15:249:15 | e |  |
+| main.rs:248:20:248:36 | ...::Left(...) | main.rs:248:13:251:13 | if ... {...} | no-match |
+| main.rs:248:20:248:36 | ...::Left(...) | main.rs:248:33:248:35 | a12 | match |
+| main.rs:248:33:248:35 | a12 | main.rs:248:33:248:35 | a12 |  |
+| main.rs:248:33:248:35 | a12 | main.rs:250:17:250:32 | ExprStmt | match |
+| main.rs:249:15:249:15 | e | main.rs:248:20:248:36 | ...::Left(...) |  |
+| main.rs:249:17:251:13 | { ... } | main.rs:248:13:251:13 | if ... {...} |  |
+| main.rs:250:17:250:25 | print_i64 | main.rs:250:28:250:30 | a12 |  |
+| main.rs:250:17:250:31 | print_i64(...) | main.rs:249:17:251:13 | { ... } |  |
+| main.rs:250:17:250:32 | ExprStmt | main.rs:250:17:250:25 | print_i64 |  |
+| main.rs:250:27:250:30 | * ... | main.rs:250:17:250:31 | print_i64(...) |  |
+| main.rs:250:28:250:30 | a12 | main.rs:250:27:250:30 | * ... |  |
+| main.rs:253:9:253:9 | _ | main.rs:253:14:253:15 | TupleExpr | match |
+| main.rs:253:14:253:15 | TupleExpr | main.rs:243:5:254:5 | match either { ... } |  |
+| main.rs:264:1:270:1 | enter fn match_pattern9 | main.rs:265:5:265:36 | let ... = ... |  |
+| main.rs:264:1:270:1 | exit fn match_pattern9 (normal) | main.rs:264:1:270:1 | exit fn match_pattern9 |  |
+| main.rs:264:21:270:1 | { ... } | main.rs:264:1:270:1 | exit fn match_pattern9 (normal) |  |
+| main.rs:265:5:265:36 | let ... = ... | main.rs:265:14:265:31 | ...::Second |  |
+| main.rs:265:9:265:10 | fv | main.rs:265:9:265:10 | fv |  |
+| main.rs:265:9:265:10 | fv | main.rs:266:11:266:12 | fv | match |
+| main.rs:265:14:265:31 | ...::Second | main.rs:265:33:265:34 | 62 |  |
+| main.rs:265:14:265:35 | ...::Second(...) | main.rs:265:9:265:10 | fv |  |
+| main.rs:265:33:265:34 | 62 | main.rs:265:14:265:35 | ...::Second(...) |  |
+| main.rs:266:5:269:5 | match fv { ... } | main.rs:264:21:270:1 | { ... } |  |
+| main.rs:266:11:266:12 | fv | main.rs:267:9:267:30 | ...::First(...) |  |
+| main.rs:267:9:267:30 | ...::First(...) | main.rs:267:27:267:29 | a13 | match |
+| main.rs:267:9:267:30 | ...::First(...) | main.rs:267:35:267:57 | ...::Second(...) | no-match |
+| main.rs:267:9:267:109 | ... \| ... \| ... | main.rs:268:16:268:24 | print_i64 | match |
+| main.rs:267:27:267:29 | a13 | main.rs:267:9:267:109 | ... \| ... \| ... | match |
+| main.rs:267:27:267:29 | a13 | main.rs:267:27:267:29 | a13 |  |
+| main.rs:267:35:267:57 | ...::Second(...) | main.rs:267:54:267:56 | a13 | match |
+| main.rs:267:35:267:57 | ...::Second(...) | main.rs:267:61:267:82 | ...::Third(...) | no-match |
+| main.rs:267:35:267:82 | [match(false)] ... \| ... | main.rs:267:87:267:109 | ...::Fourth(...) | no-match |
+| main.rs:267:35:267:82 | [match(true)] ... \| ... | main.rs:267:9:267:109 | ... \| ... \| ... | match |
+| main.rs:267:54:267:56 | a13 | main.rs:267:35:267:82 | [match(true)] ... \| ... | match |
+| main.rs:267:54:267:56 | a13 | main.rs:267:54:267:56 | a13 |  |
+| main.rs:267:61:267:82 | ...::Third(...) | main.rs:267:35:267:82 | [match(false)] ... \| ... | no-match |
+| main.rs:267:61:267:82 | ...::Third(...) | main.rs:267:79:267:81 | a13 | match |
+| main.rs:267:79:267:81 | a13 | main.rs:267:35:267:82 | [match(true)] ... \| ... | match |
+| main.rs:267:79:267:81 | a13 | main.rs:267:79:267:81 | a13 |  |
+| main.rs:267:87:267:109 | ...::Fourth(...) | main.rs:267:106:267:108 | a13 | match |
+| main.rs:267:106:267:108 | a13 | main.rs:267:9:267:109 | ... \| ... \| ... | match |
+| main.rs:267:106:267:108 | a13 | main.rs:267:106:267:108 | a13 |  |
+| main.rs:268:16:268:24 | print_i64 | main.rs:268:26:268:28 | a13 |  |
+| main.rs:268:16:268:29 | print_i64(...) | main.rs:266:5:269:5 | match fv { ... } |  |
+| main.rs:268:26:268:28 | a13 | main.rs:268:16:268:29 | print_i64(...) |  |
+| main.rs:272:1:282:1 | enter fn param_pattern1 | main.rs:273:5:273:6 | a8 |  |
+| main.rs:272:1:282:1 | exit fn param_pattern1 (normal) | main.rs:272:1:282:1 | exit fn param_pattern1 |  |
+| main.rs:273:5:273:6 | a8 | main.rs:273:5:273:6 | a8 |  |
+| main.rs:273:5:273:6 | a8 | main.rs:273:5:273:12 | ...: ... | match |
+| main.rs:273:5:273:12 | ...: ... | main.rs:274:5:277:5 | TuplePat |  |
+| main.rs:274:5:277:5 | TuplePat | main.rs:275:9:275:10 | b3 | match |
+| main.rs:274:5:277:19 | ...: ... | main.rs:279:5:279:18 | ExprStmt |  |
+| main.rs:275:9:275:10 | b3 | main.rs:275:9:275:10 | b3 |  |
+| main.rs:275:9:275:10 | b3 | main.rs:276:9:276:10 | c1 | match |
+| main.rs:276:9:276:10 | c1 | main.rs:274:5:277:19 | ...: ... | match |
+| main.rs:276:9:276:10 | c1 | main.rs:276:9:276:10 | c1 |  |
+| main.rs:278:9:282:1 | { ... } | main.rs:272:1:282:1 | exit fn param_pattern1 (normal) |  |
+| main.rs:279:5:279:13 | print_str | main.rs:279:15:279:16 | a8 |  |
+| main.rs:279:5:279:17 | print_str(...) | main.rs:280:5:280:18 | ExprStmt |  |
+| main.rs:279:5:279:18 | ExprStmt | main.rs:279:5:279:13 | print_str |  |
+| main.rs:279:15:279:16 | a8 | main.rs:279:5:279:17 | print_str(...) |  |
+| main.rs:280:5:280:13 | print_str | main.rs:280:15:280:16 | b3 |  |
+| main.rs:280:5:280:17 | print_str(...) | main.rs:281:5:281:18 | ExprStmt |  |
+| main.rs:280:5:280:18 | ExprStmt | main.rs:280:5:280:13 | print_str |  |
+| main.rs:280:15:280:16 | b3 | main.rs:280:5:280:17 | print_str(...) |  |
+| main.rs:281:5:281:13 | print_str | main.rs:281:15:281:16 | c1 |  |
+| main.rs:281:5:281:17 | print_str(...) | main.rs:278:9:282:1 | { ... } |  |
+| main.rs:281:5:281:18 | ExprStmt | main.rs:281:5:281:13 | print_str |  |
+| main.rs:281:15:281:16 | c1 | main.rs:281:5:281:17 | print_str(...) |  |
+| main.rs:284:1:287:1 | enter fn param_pattern2 | main.rs:284:20:284:35 | ...::Left(...) |  |
+| main.rs:284:1:287:1 | exit fn param_pattern2 (normal) | main.rs:284:1:287:1 | exit fn param_pattern2 |  |
+| main.rs:284:19:284:64 | ...: Either | main.rs:286:5:286:18 | ExprStmt |  |
+| main.rs:284:20:284:35 | ...::Left(...) | main.rs:284:33:284:34 | a9 | match |
+| main.rs:284:20:284:35 | ...::Left(...) | main.rs:284:39:284:55 | ...::Right(...) | no-match |
+| main.rs:284:20:284:55 | ... \| ... | main.rs:284:19:284:64 | ...: Either | match |
+| main.rs:284:33:284:34 | a9 | main.rs:284:20:284:55 | ... \| ... | match |
+| main.rs:284:33:284:34 | a9 | main.rs:284:33:284:34 | a9 |  |
+| main.rs:284:39:284:55 | ...::Right(...) | main.rs:284:53:284:54 | a9 | match |
+| main.rs:284:53:284:54 | a9 | main.rs:284:20:284:55 | ... \| ... | match |
+| main.rs:284:53:284:54 | a9 | main.rs:284:53:284:54 | a9 |  |
+| main.rs:285:9:287:1 | { ... } | main.rs:284:1:287:1 | exit fn param_pattern2 (normal) |  |
+| main.rs:286:5:286:13 | print_i64 | main.rs:286:15:286:16 | a9 |  |
+| main.rs:286:5:286:17 | print_i64(...) | main.rs:285:9:287:1 | { ... } |  |
+| main.rs:286:5:286:18 | ExprStmt | main.rs:286:5:286:13 | print_i64 |  |
+| main.rs:286:15:286:16 | a9 | main.rs:286:5:286:17 | print_i64(...) |  |
+| main.rs:289:1:324:1 | enter fn destruct_assignment | main.rs:290:5:294:18 | let ... = ... |  |
+| main.rs:289:1:324:1 | exit fn destruct_assignment (normal) | main.rs:289:1:324:1 | exit fn destruct_assignment |  |
+| main.rs:289:26:324:1 | { ... } | main.rs:289:1:324:1 | exit fn destruct_assignment (normal) |  |
+| main.rs:290:5:294:18 | let ... = ... | main.rs:294:10:294:10 | 1 |  |
+| main.rs:290:9:294:5 | TuplePat | main.rs:291:13:291:15 | a10 | match |
+| main.rs:291:9:291:15 | mut a10 | main.rs:292:13:292:14 | b4 | match |
+| main.rs:291:13:291:15 | a10 | main.rs:291:9:291:15 | mut a10 |  |
+| main.rs:292:9:292:14 | mut b4 | main.rs:293:13:293:14 | c2 | match |
+| main.rs:292:13:292:14 | b4 | main.rs:292:9:292:14 | mut b4 |  |
+| main.rs:293:9:293:14 | mut c2 | main.rs:295:5:295:19 | ExprStmt | match |
+| main.rs:293:13:293:14 | c2 | main.rs:293:9:293:14 | mut c2 |  |
+| main.rs:294:9:294:17 | TupleExpr | main.rs:290:9:294:5 | TuplePat |  |
+| main.rs:294:10:294:10 | 1 | main.rs:294:13:294:13 | 2 |  |
+| main.rs:294:13:294:13 | 2 | main.rs:294:16:294:16 | 3 |  |
+| main.rs:294:16:294:16 | 3 | main.rs:294:9:294:17 | TupleExpr |  |
+| main.rs:295:5:295:13 | print_i64 | main.rs:295:15:295:17 | a10 |  |
+| main.rs:295:5:295:18 | print_i64(...) | main.rs:296:5:296:18 | ExprStmt |  |
+| main.rs:295:5:295:19 | ExprStmt | main.rs:295:5:295:13 | print_i64 |  |
+| main.rs:295:15:295:17 | a10 | main.rs:295:5:295:18 | print_i64(...) |  |
+| main.rs:296:5:296:13 | print_i64 | main.rs:296:15:296:16 | b4 |  |
+| main.rs:296:5:296:17 | print_i64(...) | main.rs:297:5:297:18 | ExprStmt |  |
+| main.rs:296:5:296:18 | ExprStmt | main.rs:296:5:296:13 | print_i64 |  |
+| main.rs:296:15:296:16 | b4 | main.rs:296:5:296:17 | print_i64(...) |  |
+| main.rs:297:5:297:13 | print_i64 | main.rs:297:15:297:16 | c2 |  |
+| main.rs:297:5:297:17 | print_i64(...) | main.rs:299:5:307:6 | ExprStmt |  |
 | main.rs:297:5:297:18 | ExprStmt | main.rs:297:5:297:13 | print_i64 |  |
-| main.rs:297:15:297:16 | b4 | main.rs:297:5:297:17 | print_i64(...) |  |
-| main.rs:298:5:298:13 | print_i64 | main.rs:298:15:298:16 | c2 |  |
-| main.rs:298:5:298:17 | print_i64(...) | main.rs:300:5:308:5 | ExprStmt |  |
-| main.rs:298:5:298:18 | ExprStmt | main.rs:298:5:298:13 | print_i64 |  |
-| main.rs:298:15:298:16 | c2 | main.rs:298:5:298:17 | print_i64(...) |  |
-| main.rs:300:5:308:5 | ExprStmt | main.rs:300:12:300:12 | 4 |  |
-| main.rs:300:5:308:5 | match ... { ... } | main.rs:310:5:310:19 | ExprStmt |  |
-| main.rs:300:11:300:16 | TupleExpr | main.rs:301:9:304:9 | TuplePat |  |
-| main.rs:300:12:300:12 | 4 | main.rs:300:15:300:15 | 5 |  |
-| main.rs:300:15:300:15 | 5 | main.rs:300:11:300:16 | TupleExpr |  |
-| main.rs:301:9:304:9 | TuplePat | main.rs:302:13:302:15 | a10 | match |
-| main.rs:302:13:302:15 | a10 | main.rs:302:13:302:15 | a10 |  |
-| main.rs:302:13:302:15 | a10 | main.rs:303:13:303:14 | b4 | match |
-| main.rs:303:13:303:14 | b4 | main.rs:303:13:303:14 | b4 |  |
-| main.rs:303:13:303:14 | b4 | main.rs:305:13:305:27 | ExprStmt | match |
-| main.rs:304:14:307:9 | { ... } | main.rs:300:5:308:5 | match ... { ... } |  |
-| main.rs:305:13:305:21 | print_i64 | main.rs:305:23:305:25 | a10 |  |
-| main.rs:305:13:305:26 | print_i64(...) | main.rs:306:13:306:26 | ExprStmt |  |
-| main.rs:305:13:305:27 | ExprStmt | main.rs:305:13:305:21 | print_i64 |  |
-| main.rs:305:23:305:25 | a10 | main.rs:305:13:305:26 | print_i64(...) |  |
-| main.rs:306:13:306:21 | print_i64 | main.rs:306:23:306:24 | b4 |  |
-| main.rs:306:13:306:25 | print_i64(...) | main.rs:304:14:307:9 | { ... } |  |
-| main.rs:306:13:306:26 | ExprStmt | main.rs:306:13:306:21 | print_i64 |  |
-| main.rs:306:23:306:24 | b4 | main.rs:306:13:306:25 | print_i64(...) |  |
-| main.rs:310:5:310:13 | print_i64 | main.rs:310:15:310:17 | a10 |  |
-| main.rs:310:5:310:18 | print_i64(...) | main.rs:311:5:311:18 | ExprStmt |  |
-| main.rs:310:5:310:19 | ExprStmt | main.rs:310:5:310:13 | print_i64 |  |
-| main.rs:310:15:310:17 | a10 | main.rs:310:5:310:18 | print_i64(...) |  |
-| main.rs:311:5:311:13 | print_i64 | main.rs:311:15:311:16 | b4 |  |
-| main.rs:311:5:311:17 | print_i64(...) | main.rs:277:26:312:1 | { ... } |  |
-| main.rs:311:5:311:18 | ExprStmt | main.rs:311:5:311:13 | print_i64 |  |
-| main.rs:311:15:311:16 | b4 | main.rs:311:5:311:17 | print_i64(...) |  |
-| main.rs:314:1:329:1 | enter fn closure_variable | main.rs:315:5:317:10 | let ... = ... |  |
-| main.rs:314:1:329:1 | exit fn closure_variable (normal) | main.rs:314:1:329:1 | exit fn closure_variable |  |
-| main.rs:314:23:329:1 | { ... } | main.rs:314:1:329:1 | exit fn closure_variable (normal) |  |
-| main.rs:315:5:317:10 | let ... = ... | main.rs:316:9:317:9 | \|...\| x |  |
-| main.rs:315:9:315:23 | example_closure | main.rs:315:9:315:23 | example_closure |  |
-| main.rs:315:9:315:23 | example_closure | main.rs:318:5:319:27 | let ... = ... | match |
-| main.rs:316:9:317:9 | \|...\| x | main.rs:315:9:315:23 | example_closure |  |
-| main.rs:316:9:317:9 | enter \|...\| x | main.rs:316:10:316:10 | x |  |
-| main.rs:316:9:317:9 | exit \|...\| x (normal) | main.rs:316:9:317:9 | exit \|...\| x |  |
-| main.rs:316:10:316:10 | x | main.rs:316:10:316:10 | x |  |
-| main.rs:316:10:316:10 | x | main.rs:316:10:316:15 | ...: i64 | match |
-| main.rs:316:10:316:15 | ...: i64 | main.rs:317:9:317:9 | x |  |
-| main.rs:317:9:317:9 | x | main.rs:316:9:317:9 | exit \|...\| x (normal) |  |
-| main.rs:318:5:319:27 | let ... = ... | main.rs:319:9:319:23 | example_closure |  |
-| main.rs:318:9:318:10 | n1 | main.rs:318:9:318:10 | n1 |  |
-| main.rs:318:9:318:10 | n1 | main.rs:320:5:320:18 | ExprStmt | match |
-| main.rs:319:9:319:23 | example_closure | main.rs:319:25:319:25 | 5 |  |
-| main.rs:319:9:319:26 | example_closure(...) | main.rs:318:9:318:10 | n1 |  |
-| main.rs:319:25:319:25 | 5 | main.rs:319:9:319:26 | example_closure(...) |  |
-| main.rs:320:5:320:13 | print_i64 | main.rs:320:15:320:16 | n1 |  |
-| main.rs:320:5:320:17 | print_i64(...) | main.rs:322:5:322:25 | ExprStmt |  |
-| main.rs:320:5:320:18 | ExprStmt | main.rs:320:5:320:13 | print_i64 |  |
-| main.rs:320:15:320:16 | n1 | main.rs:320:5:320:17 | print_i64(...) |  |
-| main.rs:322:5:322:22 | immutable_variable | main.rs:322:5:322:24 | immutable_variable(...) |  |
-| main.rs:322:5:322:24 | immutable_variable(...) | main.rs:323:5:325:10 | let ... = ... |  |
-| main.rs:322:5:322:25 | ExprStmt | main.rs:322:5:322:22 | immutable_variable |  |
-| main.rs:323:5:325:10 | let ... = ... | main.rs:324:9:325:9 | \|...\| x |  |
-| main.rs:323:9:323:26 | immutable_variable | main.rs:323:9:323:26 | immutable_variable |  |
-| main.rs:323:9:323:26 | immutable_variable | main.rs:326:5:327:30 | let ... = ... | match |
-| main.rs:324:9:325:9 | \|...\| x | main.rs:323:9:323:26 | immutable_variable |  |
-| main.rs:324:9:325:9 | enter \|...\| x | main.rs:324:10:324:10 | x |  |
-| main.rs:324:9:325:9 | exit \|...\| x (normal) | main.rs:324:9:325:9 | exit \|...\| x |  |
-| main.rs:324:10:324:10 | x | main.rs:324:10:324:10 | x |  |
-| main.rs:324:10:324:10 | x | main.rs:324:10:324:15 | ...: i64 | match |
-| main.rs:324:10:324:15 | ...: i64 | main.rs:325:9:325:9 | x |  |
-| main.rs:325:9:325:9 | x | main.rs:324:9:325:9 | exit \|...\| x (normal) |  |
-| main.rs:326:5:327:30 | let ... = ... | main.rs:327:9:327:26 | immutable_variable |  |
-| main.rs:326:9:326:10 | n2 | main.rs:326:9:326:10 | n2 |  |
-| main.rs:326:9:326:10 | n2 | main.rs:328:5:328:18 | ExprStmt | match |
-| main.rs:327:9:327:26 | immutable_variable | main.rs:327:28:327:28 | 6 |  |
-| main.rs:327:9:327:29 | immutable_variable(...) | main.rs:326:9:326:10 | n2 |  |
-| main.rs:327:28:327:28 | 6 | main.rs:327:9:327:29 | immutable_variable(...) |  |
-| main.rs:328:5:328:13 | print_i64 | main.rs:328:15:328:16 | n2 |  |
-| main.rs:328:5:328:17 | print_i64(...) | main.rs:314:23:329:1 | { ... } |  |
-| main.rs:328:5:328:18 | ExprStmt | main.rs:328:5:328:13 | print_i64 |  |
-| main.rs:328:15:328:16 | n2 | main.rs:328:5:328:17 | print_i64(...) |  |
-| main.rs:331:1:359:1 | enter fn nested_function | main.rs:333:5:335:10 | let ... = ... |  |
-| main.rs:331:1:359:1 | exit fn nested_function (normal) | main.rs:331:1:359:1 | exit fn nested_function |  |
-| main.rs:331:22:359:1 | { ... } | main.rs:331:1:359:1 | exit fn nested_function (normal) |  |
-| main.rs:333:5:335:10 | let ... = ... | main.rs:334:9:335:9 | \|...\| x |  |
-| main.rs:333:9:333:9 | f | main.rs:333:9:333:9 | f |  |
-| main.rs:333:9:333:9 | f | main.rs:336:5:336:20 | ExprStmt | match |
-| main.rs:334:9:335:9 | \|...\| x | main.rs:333:9:333:9 | f |  |
-| main.rs:334:9:335:9 | enter \|...\| x | main.rs:334:10:334:10 | x |  |
-| main.rs:334:9:335:9 | exit \|...\| x (normal) | main.rs:334:9:335:9 | exit \|...\| x |  |
-| main.rs:334:10:334:10 | x | main.rs:334:10:334:10 | x |  |
-| main.rs:334:10:334:10 | x | main.rs:334:10:334:15 | ...: i64 | match |
-| main.rs:334:10:334:15 | ...: i64 | main.rs:335:9:335:9 | x |  |
-| main.rs:335:9:335:9 | x | main.rs:334:9:335:9 | exit \|...\| x (normal) |  |
-| main.rs:336:5:336:13 | print_i64 | main.rs:336:15:336:15 | f |  |
-| main.rs:336:5:336:19 | print_i64(...) | main.rs:338:5:340:5 | fn f |  |
-| main.rs:336:5:336:20 | ExprStmt | main.rs:336:5:336:13 | print_i64 |  |
-| main.rs:336:15:336:15 | f | main.rs:336:17:336:17 | 1 |  |
-| main.rs:336:15:336:18 | f(...) | main.rs:336:5:336:19 | print_i64(...) |  |
-| main.rs:336:17:336:17 | 1 | main.rs:336:15:336:18 | f(...) |  |
-| main.rs:338:5:340:5 | enter fn f | main.rs:338:10:338:10 | x |  |
-| main.rs:338:5:340:5 | exit fn f (normal) | main.rs:338:5:340:5 | exit fn f |  |
-| main.rs:338:5:340:5 | fn f | main.rs:342:5:342:20 | ExprStmt |  |
-| main.rs:338:10:338:10 | x | main.rs:338:10:338:10 | x |  |
-| main.rs:338:10:338:10 | x | main.rs:338:10:338:15 | ...: i64 | match |
-| main.rs:338:10:338:15 | ...: i64 | main.rs:339:9:339:9 | x |  |
-| main.rs:338:25:340:5 | { ... } | main.rs:338:5:340:5 | exit fn f (normal) |  |
-| main.rs:339:9:339:9 | x | main.rs:339:13:339:13 | 1 |  |
-| main.rs:339:9:339:13 | ... + ... | main.rs:338:25:340:5 | { ... } |  |
-| main.rs:339:13:339:13 | 1 | main.rs:339:9:339:13 | ... + ... |  |
-| main.rs:342:5:342:13 | print_i64 | main.rs:342:15:342:15 | f |  |
-| main.rs:342:5:342:19 | print_i64(...) | main.rs:345:9:345:24 | ExprStmt |  |
-| main.rs:342:5:342:20 | ExprStmt | main.rs:342:5:342:13 | print_i64 |  |
-| main.rs:342:15:342:15 | f | main.rs:342:17:342:17 | 2 |  |
-| main.rs:342:15:342:18 | f(...) | main.rs:342:5:342:19 | print_i64(...) |  |
-| main.rs:342:17:342:17 | 2 | main.rs:342:15:342:18 | f(...) |  |
-| main.rs:344:5:358:5 | { ... } | main.rs:331:22:359:1 | { ... } |  |
-| main.rs:345:9:345:17 | print_i64 | main.rs:345:19:345:19 | f |  |
-| main.rs:345:9:345:23 | print_i64(...) | main.rs:346:9:348:9 | fn f |  |
-| main.rs:345:9:345:24 | ExprStmt | main.rs:345:9:345:17 | print_i64 |  |
-| main.rs:345:19:345:19 | f | main.rs:345:21:345:21 | 3 |  |
-| main.rs:345:19:345:22 | f(...) | main.rs:345:9:345:23 | print_i64(...) |  |
-| main.rs:345:21:345:21 | 3 | main.rs:345:19:345:22 | f(...) |  |
-| main.rs:346:9:348:9 | enter fn f | main.rs:346:14:346:14 | x |  |
-| main.rs:346:9:348:9 | exit fn f (normal) | main.rs:346:9:348:9 | exit fn f |  |
-| main.rs:346:9:348:9 | fn f | main.rs:350:9:352:9 | ExprStmt |  |
-| main.rs:346:14:346:14 | x | main.rs:346:14:346:14 | x |  |
-| main.rs:346:14:346:14 | x | main.rs:346:14:346:19 | ...: i64 | match |
-| main.rs:346:14:346:19 | ...: i64 | main.rs:347:13:347:13 | 2 |  |
-| main.rs:346:29:348:9 | { ... } | main.rs:346:9:348:9 | exit fn f (normal) |  |
-| main.rs:347:13:347:13 | 2 | main.rs:347:17:347:17 | x |  |
-| main.rs:347:13:347:17 | ... * ... | main.rs:346:29:348:9 | { ... } |  |
-| main.rs:347:17:347:17 | x | main.rs:347:13:347:17 | ... * ... |  |
-| main.rs:350:9:352:9 | ExprStmt | main.rs:351:13:351:28 | ExprStmt |  |
-| main.rs:350:9:352:9 | { ... } | main.rs:354:9:356:14 | let ... = ... |  |
-| main.rs:351:13:351:21 | print_i64 | main.rs:351:23:351:23 | f |  |
-| main.rs:351:13:351:27 | print_i64(...) | main.rs:350:9:352:9 | { ... } |  |
-| main.rs:351:13:351:28 | ExprStmt | main.rs:351:13:351:21 | print_i64 |  |
-| main.rs:351:23:351:23 | f | main.rs:351:25:351:25 | 4 |  |
-| main.rs:351:23:351:26 | f(...) | main.rs:351:13:351:27 | print_i64(...) |  |
-| main.rs:351:25:351:25 | 4 | main.rs:351:23:351:26 | f(...) |  |
-| main.rs:354:9:356:14 | let ... = ... | main.rs:355:13:356:13 | \|...\| x |  |
-| main.rs:354:13:354:13 | f | main.rs:354:13:354:13 | f |  |
-| main.rs:354:13:354:13 | f | main.rs:357:9:357:24 | ExprStmt | match |
-| main.rs:355:13:356:13 | \|...\| x | main.rs:354:13:354:13 | f |  |
-| main.rs:355:13:356:13 | enter \|...\| x | main.rs:355:14:355:14 | x |  |
-| main.rs:355:13:356:13 | exit \|...\| x (normal) | main.rs:355:13:356:13 | exit \|...\| x |  |
-| main.rs:355:14:355:14 | x | main.rs:355:14:355:14 | x |  |
-| main.rs:355:14:355:14 | x | main.rs:355:14:355:19 | ...: i64 | match |
-| main.rs:355:14:355:19 | ...: i64 | main.rs:356:13:356:13 | x |  |
-| main.rs:356:13:356:13 | x | main.rs:355:13:356:13 | exit \|...\| x (normal) |  |
-| main.rs:357:9:357:17 | print_i64 | main.rs:357:19:357:19 | f |  |
-| main.rs:357:9:357:23 | print_i64(...) | main.rs:344:5:358:5 | { ... } |  |
-| main.rs:357:9:357:24 | ExprStmt | main.rs:357:9:357:17 | print_i64 |  |
-| main.rs:357:19:357:19 | f | main.rs:357:21:357:21 | 5 |  |
-| main.rs:357:19:357:22 | f(...) | main.rs:357:9:357:23 | print_i64(...) |  |
-| main.rs:357:21:357:21 | 5 | main.rs:357:19:357:22 | f(...) |  |
-| main.rs:361:1:368:1 | enter fn for_variable | main.rs:362:5:362:42 | let ... = ... |  |
-| main.rs:361:1:368:1 | exit fn for_variable (normal) | main.rs:361:1:368:1 | exit fn for_variable |  |
-| main.rs:361:19:368:1 | { ... } | main.rs:361:1:368:1 | exit fn for_variable (normal) |  |
-| main.rs:362:5:362:42 | let ... = ... | main.rs:362:15:362:22 | "apples" |  |
-| main.rs:362:9:362:9 | v | main.rs:362:9:362:9 | v |  |
-| main.rs:362:9:362:9 | v | main.rs:365:12:365:12 | v | match |
-| main.rs:362:13:362:41 | &... | main.rs:362:9:362:9 | v |  |
-| main.rs:362:14:362:41 | [...] | main.rs:362:13:362:41 | &... |  |
-| main.rs:362:15:362:22 | "apples" | main.rs:362:25:362:30 | "cake" |  |
-| main.rs:362:25:362:30 | "cake" | main.rs:362:33:362:40 | "coffee" |  |
-| main.rs:362:33:362:40 | "coffee" | main.rs:362:14:362:41 | [...] |  |
-| main.rs:364:5:367:5 | for ... in ... { ... } | main.rs:361:19:368:1 | { ... } |  |
-| main.rs:364:9:364:12 | text | main.rs:364:5:367:5 | for ... in ... { ... } | no-match |
-| main.rs:364:9:364:12 | text | main.rs:364:9:364:12 | text |  |
-| main.rs:364:9:364:12 | text | main.rs:366:9:366:24 | ExprStmt | match |
-| main.rs:365:12:365:12 | v | main.rs:364:9:364:12 | text |  |
-| main.rs:365:14:367:5 | { ... } | main.rs:364:9:364:12 | text |  |
-| main.rs:366:9:366:17 | print_str | main.rs:366:19:366:22 | text |  |
-| main.rs:366:9:366:23 | print_str(...) | main.rs:365:14:367:5 | { ... } |  |
-| main.rs:366:9:366:24 | ExprStmt | main.rs:366:9:366:17 | print_str |  |
-| main.rs:366:19:366:22 | text | main.rs:366:9:366:23 | print_str(...) |  |
-| main.rs:370:1:376:1 | enter fn add_assign | main.rs:371:5:371:18 | let ... = 0 |  |
-| main.rs:370:1:376:1 | exit fn add_assign (normal) | main.rs:370:1:376:1 | exit fn add_assign |  |
-| main.rs:370:17:376:1 | { ... } | main.rs:370:1:376:1 | exit fn add_assign (normal) |  |
-| main.rs:371:5:371:18 | let ... = 0 | main.rs:371:17:371:17 | 0 |  |
-| main.rs:371:9:371:13 | mut a | main.rs:372:5:372:11 | ExprStmt | match |
-| main.rs:371:13:371:13 | a | main.rs:371:9:371:13 | mut a |  |
-| main.rs:371:17:371:17 | 0 | main.rs:371:13:371:13 | a |  |
-| main.rs:372:5:372:5 | a | main.rs:372:10:372:10 | 1 |  |
-| main.rs:372:5:372:10 | ... += ... | main.rs:373:5:373:17 | ExprStmt |  |
-| main.rs:372:5:372:11 | ExprStmt | main.rs:372:5:372:5 | a |  |
-| main.rs:372:10:372:10 | 1 | main.rs:372:5:372:10 | ... += ... |  |
-| main.rs:373:5:373:13 | print_i64 | main.rs:373:15:373:15 | a |  |
-| main.rs:373:5:373:16 | print_i64(...) | main.rs:374:5:374:28 | ExprStmt |  |
-| main.rs:373:5:373:17 | ExprStmt | main.rs:373:5:373:13 | print_i64 |  |
-| main.rs:373:15:373:15 | a | main.rs:373:5:373:16 | print_i64(...) |  |
-| main.rs:374:5:374:27 | ... .add_assign(...) | main.rs:375:5:375:17 | ExprStmt |  |
-| main.rs:374:5:374:28 | ExprStmt | main.rs:374:11:374:11 | a |  |
-| main.rs:374:6:374:11 | &mut a | main.rs:374:25:374:26 | 10 |  |
-| main.rs:374:11:374:11 | a | main.rs:374:6:374:11 | &mut a |  |
-| main.rs:374:25:374:26 | 10 | main.rs:374:5:374:27 | ... .add_assign(...) |  |
-| main.rs:375:5:375:13 | print_i64 | main.rs:375:15:375:15 | a |  |
-| main.rs:375:5:375:16 | print_i64(...) | main.rs:370:17:376:1 | { ... } |  |
-| main.rs:375:5:375:17 | ExprStmt | main.rs:375:5:375:13 | print_i64 |  |
-| main.rs:375:15:375:15 | a | main.rs:375:5:375:16 | print_i64(...) |  |
-| main.rs:378:1:384:1 | enter fn mutate | main.rs:379:5:379:18 | let ... = 1 |  |
-| main.rs:378:1:384:1 | exit fn mutate (normal) | main.rs:378:1:384:1 | exit fn mutate |  |
-| main.rs:378:13:384:1 | { ... } | main.rs:378:1:384:1 | exit fn mutate (normal) |  |
-| main.rs:379:5:379:18 | let ... = 1 | main.rs:379:17:379:17 | 1 |  |
-| main.rs:379:9:379:13 | mut i | main.rs:380:5:381:15 | let ... = ... | match |
-| main.rs:379:13:379:13 | i | main.rs:379:9:379:13 | mut i |  |
-| main.rs:379:17:379:17 | 1 | main.rs:379:13:379:13 | i |  |
-| main.rs:380:5:381:15 | let ... = ... | main.rs:381:14:381:14 | i |  |
-| main.rs:380:9:380:13 | ref_i | main.rs:380:9:380:13 | ref_i |  |
-| main.rs:380:9:380:13 | ref_i | main.rs:382:5:382:15 | ExprStmt | match |
-| main.rs:381:9:381:14 | &mut i | main.rs:380:9:380:13 | ref_i |  |
-| main.rs:381:14:381:14 | i | main.rs:381:9:381:14 | &mut i |  |
-| main.rs:382:5:382:10 | * ... | main.rs:382:14:382:14 | 2 |  |
-| main.rs:382:5:382:14 | ... = ... | main.rs:383:5:383:17 | ExprStmt |  |
-| main.rs:382:5:382:15 | ExprStmt | main.rs:382:6:382:10 | ref_i |  |
-| main.rs:382:6:382:10 | ref_i | main.rs:382:5:382:10 | * ... |  |
-| main.rs:382:14:382:14 | 2 | main.rs:382:5:382:14 | ... = ... |  |
-| main.rs:383:5:383:13 | print_i64 | main.rs:383:15:383:15 | i |  |
-| main.rs:383:5:383:16 | print_i64(...) | main.rs:378:13:384:1 | { ... } |  |
-| main.rs:383:5:383:17 | ExprStmt | main.rs:383:5:383:13 | print_i64 |  |
-| main.rs:383:15:383:15 | i | main.rs:383:5:383:16 | print_i64(...) |  |
-| main.rs:386:1:391:1 | enter fn mutate_param | main.rs:386:17:386:17 | x |  |
-| main.rs:386:1:391:1 | exit fn mutate_param (normal) | main.rs:386:1:391:1 | exit fn mutate_param |  |
-| main.rs:386:17:386:17 | x | main.rs:386:17:386:17 | x |  |
-| main.rs:386:17:386:17 | x | main.rs:386:17:386:28 | ...: ... | match |
-| main.rs:386:17:386:28 | ...: ... | main.rs:387:5:389:11 | ExprStmt |  |
-| main.rs:387:5:387:6 | * ... | main.rs:388:10:388:10 | x |  |
-| main.rs:387:5:389:10 | ... = ... | main.rs:390:5:390:13 | ExprStmt |  |
-| main.rs:387:5:389:11 | ExprStmt | main.rs:387:6:387:6 | x |  |
-| main.rs:387:6:387:6 | x | main.rs:387:5:387:6 | * ... |  |
-| main.rs:388:9:388:10 | * ... | main.rs:389:10:389:10 | x |  |
-| main.rs:388:9:389:10 | ... + ... | main.rs:387:5:389:10 | ... = ... |  |
-| main.rs:388:10:388:10 | x | main.rs:388:9:388:10 | * ... |  |
-| main.rs:389:9:389:10 | * ... | main.rs:388:9:389:10 | ... + ... |  |
-| main.rs:389:10:389:10 | x | main.rs:389:9:389:10 | * ... |  |
-| main.rs:390:5:390:12 | return x | main.rs:386:1:391:1 | exit fn mutate_param (normal) | return |
-| main.rs:390:5:390:13 | ExprStmt | main.rs:390:12:390:12 | x |  |
-| main.rs:390:12:390:12 | x | main.rs:390:5:390:12 | return x |  |
-| main.rs:393:1:399:1 | enter fn mutate_param2 | main.rs:393:22:393:22 | x |  |
-| main.rs:393:1:399:1 | exit fn mutate_param2 (normal) | main.rs:393:1:399:1 | exit fn mutate_param2 |  |
-| main.rs:393:22:393:22 | x | main.rs:393:22:393:22 | x |  |
-| main.rs:393:22:393:22 | x | main.rs:393:22:393:36 | ...: ... | match |
-| main.rs:393:22:393:36 | ...: ... | main.rs:393:39:393:39 | y |  |
-| main.rs:393:39:393:39 | y | main.rs:393:39:393:39 | y |  |
-| main.rs:393:39:393:39 | y | main.rs:393:39:393:57 | ...: ... | match |
-| main.rs:393:39:393:57 | ...: ... | main.rs:394:5:396:11 | ExprStmt |  |
-| main.rs:393:60:399:1 | { ... } | main.rs:393:1:399:1 | exit fn mutate_param2 (normal) |  |
-| main.rs:394:5:394:6 | * ... | main.rs:395:10:395:10 | x |  |
-| main.rs:394:5:396:10 | ... = ... | main.rs:397:5:398:10 | ExprStmt |  |
-| main.rs:394:5:396:11 | ExprStmt | main.rs:394:6:394:6 | x |  |
-| main.rs:394:6:394:6 | x | main.rs:394:5:394:6 | * ... |  |
-| main.rs:395:9:395:10 | * ... | main.rs:396:10:396:10 | x |  |
-| main.rs:395:9:396:10 | ... + ... | main.rs:394:5:396:10 | ... = ... |  |
-| main.rs:395:10:395:10 | x | main.rs:395:9:395:10 | * ... |  |
-| main.rs:396:9:396:10 | * ... | main.rs:395:9:396:10 | ... + ... |  |
-| main.rs:396:10:396:10 | x | main.rs:396:9:396:10 | * ... |  |
-| main.rs:397:5:397:6 | * ... | main.rs:398:9:398:9 | x |  |
-| main.rs:397:5:398:9 | ... = ... | main.rs:393:60:399:1 | { ... } |  |
-| main.rs:397:5:398:10 | ExprStmt | main.rs:397:6:397:6 | y |  |
-| main.rs:397:6:397:6 | y | main.rs:397:5:397:6 | * ... |  |
-| main.rs:398:9:398:9 | x | main.rs:397:5:398:9 | ... = ... |  |
-| main.rs:401:1:419:1 | enter fn mutate_arg | main.rs:402:5:402:18 | let ... = 2 |  |
-| main.rs:401:1:419:1 | exit fn mutate_arg (normal) | main.rs:401:1:419:1 | exit fn mutate_arg |  |
-| main.rs:401:17:419:1 | { ... } | main.rs:401:1:419:1 | exit fn mutate_arg (normal) |  |
-| main.rs:402:5:402:18 | let ... = 2 | main.rs:402:17:402:17 | 2 |  |
-| main.rs:402:9:402:13 | mut x | main.rs:403:5:404:29 | let ... = ... | match |
-| main.rs:402:13:402:13 | x | main.rs:402:9:402:13 | mut x |  |
-| main.rs:402:17:402:17 | 2 | main.rs:402:13:402:13 | x |  |
-| main.rs:403:5:404:29 | let ... = ... | main.rs:404:9:404:20 | mutate_param |  |
-| main.rs:403:9:403:9 | y | main.rs:403:9:403:9 | y |  |
-| main.rs:403:9:403:9 | y | main.rs:405:5:405:12 | ExprStmt | match |
-| main.rs:404:9:404:20 | mutate_param | main.rs:404:27:404:27 | x |  |
-| main.rs:404:9:404:28 | mutate_param(...) | main.rs:403:9:403:9 | y |  |
-| main.rs:404:22:404:27 | &mut x | main.rs:404:9:404:28 | mutate_param(...) |  |
-| main.rs:404:27:404:27 | x | main.rs:404:22:404:27 | &mut x |  |
-| main.rs:405:5:405:6 | * ... | main.rs:405:10:405:11 | 10 |  |
-| main.rs:405:5:405:11 | ... = ... | main.rs:407:5:407:17 | ExprStmt |  |
-| main.rs:405:5:405:12 | ExprStmt | main.rs:405:6:405:6 | y |  |
-| main.rs:405:6:405:6 | y | main.rs:405:5:405:6 | * ... |  |
-| main.rs:405:10:405:11 | 10 | main.rs:405:5:405:11 | ... = ... |  |
-| main.rs:407:5:407:13 | print_i64 | main.rs:407:15:407:15 | x |  |
-| main.rs:407:5:407:16 | print_i64(...) | main.rs:409:5:409:18 | let ... = 4 |  |
-| main.rs:407:5:407:17 | ExprStmt | main.rs:407:5:407:13 | print_i64 |  |
-| main.rs:407:15:407:15 | x | main.rs:407:5:407:16 | print_i64(...) |  |
-| main.rs:409:5:409:18 | let ... = 4 | main.rs:409:17:409:17 | 4 |  |
-| main.rs:409:9:409:13 | mut z | main.rs:410:5:411:20 | let ... = ... | match |
-| main.rs:409:13:409:13 | z | main.rs:409:9:409:13 | mut z |  |
-| main.rs:409:17:409:17 | 4 | main.rs:409:13:409:13 | z |  |
-| main.rs:410:5:411:20 | let ... = ... | main.rs:411:19:411:19 | x |  |
-| main.rs:410:9:410:9 | w | main.rs:410:9:410:9 | w |  |
-| main.rs:410:9:410:9 | w | main.rs:412:5:415:6 | ExprStmt | match |
-| main.rs:411:9:411:19 | &mut ... | main.rs:410:9:410:9 | w |  |
-| main.rs:411:14:411:19 | &mut x | main.rs:411:9:411:19 | &mut ... |  |
-| main.rs:411:19:411:19 | x | main.rs:411:14:411:19 | &mut x |  |
-| main.rs:412:5:412:17 | mutate_param2 | main.rs:413:14:413:14 | z |  |
-| main.rs:412:5:415:5 | mutate_param2(...) | main.rs:416:5:416:13 | ExprStmt |  |
-| main.rs:412:5:415:6 | ExprStmt | main.rs:412:5:412:17 | mutate_param2 |  |
-| main.rs:413:9:413:14 | &mut z | main.rs:414:9:414:9 | w |  |
-| main.rs:413:14:413:14 | z | main.rs:413:9:413:14 | &mut z |  |
-| main.rs:414:9:414:9 | w | main.rs:412:5:415:5 | mutate_param2(...) |  |
-| main.rs:416:5:416:7 | * ... | main.rs:416:11:416:12 | 11 |  |
-| main.rs:416:5:416:12 | ... = ... | main.rs:418:5:418:17 | ExprStmt |  |
-| main.rs:416:5:416:13 | ExprStmt | main.rs:416:7:416:7 | w |  |
-| main.rs:416:6:416:7 | * ... | main.rs:416:5:416:7 | * ... |  |
-| main.rs:416:7:416:7 | w | main.rs:416:6:416:7 | * ... |  |
-| main.rs:416:11:416:12 | 11 | main.rs:416:5:416:12 | ... = ... |  |
-| main.rs:418:5:418:13 | print_i64 | main.rs:418:15:418:15 | z |  |
-| main.rs:418:5:418:16 | print_i64(...) | main.rs:401:17:419:1 | { ... } |  |
-| main.rs:418:5:418:17 | ExprStmt | main.rs:418:5:418:13 | print_i64 |  |
-| main.rs:418:15:418:15 | z | main.rs:418:5:418:16 | print_i64(...) |  |
-| main.rs:421:1:427:1 | enter fn alias | main.rs:422:5:422:18 | let ... = 1 |  |
-| main.rs:421:1:427:1 | exit fn alias (normal) | main.rs:421:1:427:1 | exit fn alias |  |
-| main.rs:421:12:427:1 | { ... } | main.rs:421:1:427:1 | exit fn alias (normal) |  |
-| main.rs:422:5:422:18 | let ... = 1 | main.rs:422:17:422:17 | 1 |  |
-| main.rs:422:9:422:13 | mut x | main.rs:423:5:424:15 | let ... = ... | match |
-| main.rs:422:13:422:13 | x | main.rs:422:9:422:13 | mut x |  |
-| main.rs:422:17:422:17 | 1 | main.rs:422:13:422:13 | x |  |
-| main.rs:423:5:424:15 | let ... = ... | main.rs:424:14:424:14 | x |  |
-| main.rs:423:9:423:9 | y | main.rs:423:9:423:9 | y |  |
-| main.rs:423:9:423:9 | y | main.rs:425:5:425:11 | ExprStmt | match |
-| main.rs:424:9:424:14 | &mut x | main.rs:423:9:423:9 | y |  |
-| main.rs:424:14:424:14 | x | main.rs:424:9:424:14 | &mut x |  |
-| main.rs:425:5:425:6 | * ... | main.rs:425:10:425:10 | 2 |  |
-| main.rs:425:5:425:10 | ... = ... | main.rs:426:5:426:17 | ExprStmt |  |
-| main.rs:425:5:425:11 | ExprStmt | main.rs:425:6:425:6 | y |  |
-| main.rs:425:6:425:6 | y | main.rs:425:5:425:6 | * ... |  |
-| main.rs:425:10:425:10 | 2 | main.rs:425:5:425:10 | ... = ... |  |
-| main.rs:426:5:426:13 | print_i64 | main.rs:426:15:426:15 | x |  |
-| main.rs:426:5:426:16 | print_i64(...) | main.rs:421:12:427:1 | { ... } |  |
-| main.rs:426:5:426:17 | ExprStmt | main.rs:426:5:426:13 | print_i64 |  |
-| main.rs:426:15:426:15 | x | main.rs:426:5:426:16 | print_i64(...) |  |
-| main.rs:429:1:437:1 | enter fn capture_immut | main.rs:430:5:430:16 | let ... = 100 |  |
-| main.rs:429:1:437:1 | exit fn capture_immut (normal) | main.rs:429:1:437:1 | exit fn capture_immut |  |
-| main.rs:429:20:437:1 | { ... } | main.rs:429:1:437:1 | exit fn capture_immut (normal) |  |
-| main.rs:430:5:430:16 | let ... = 100 | main.rs:430:13:430:15 | 100 |  |
-| main.rs:430:9:430:9 | x | main.rs:430:9:430:9 | x |  |
-| main.rs:430:9:430:9 | x | main.rs:432:5:434:6 | let ... = ... | match |
-| main.rs:430:13:430:15 | 100 | main.rs:430:9:430:9 | x |  |
-| main.rs:432:5:434:6 | let ... = ... | main.rs:432:15:434:5 | \|...\| ... |  |
-| main.rs:432:9:432:11 | cap | main.rs:432:9:432:11 | cap |  |
-| main.rs:432:9:432:11 | cap | main.rs:435:5:435:10 | ExprStmt | match |
-| main.rs:432:15:434:5 | \|...\| ... | main.rs:432:9:432:11 | cap |  |
-| main.rs:432:15:434:5 | enter \|...\| ... | main.rs:433:9:433:21 | ExprStmt |  |
-| main.rs:432:15:434:5 | exit \|...\| ... (normal) | main.rs:432:15:434:5 | exit \|...\| ... |  |
-| main.rs:432:18:434:5 | { ... } | main.rs:432:15:434:5 | exit \|...\| ... (normal) |  |
-| main.rs:433:9:433:17 | print_i64 | main.rs:433:19:433:19 | x |  |
-| main.rs:433:9:433:20 | print_i64(...) | main.rs:432:18:434:5 | { ... } |  |
-| main.rs:433:9:433:21 | ExprStmt | main.rs:433:9:433:17 | print_i64 |  |
-| main.rs:433:19:433:19 | x | main.rs:433:9:433:20 | print_i64(...) |  |
-| main.rs:435:5:435:7 | cap | main.rs:435:5:435:9 | cap(...) |  |
-| main.rs:435:5:435:9 | cap(...) | main.rs:436:5:436:17 | ExprStmt |  |
-| main.rs:435:5:435:10 | ExprStmt | main.rs:435:5:435:7 | cap |  |
-| main.rs:436:5:436:13 | print_i64 | main.rs:436:15:436:15 | x |  |
-| main.rs:436:5:436:16 | print_i64(...) | main.rs:429:20:437:1 | { ... } |  |
-| main.rs:436:5:436:17 | ExprStmt | main.rs:436:5:436:13 | print_i64 |  |
-| main.rs:436:15:436:15 | x | main.rs:436:5:436:16 | print_i64(...) |  |
-| main.rs:439:1:463:1 | enter fn capture_mut | main.rs:440:5:440:18 | let ... = 1 |  |
-| main.rs:439:1:463:1 | exit fn capture_mut (normal) | main.rs:439:1:463:1 | exit fn capture_mut |  |
-| main.rs:439:18:463:1 | { ... } | main.rs:439:1:463:1 | exit fn capture_mut (normal) |  |
-| main.rs:440:5:440:18 | let ... = 1 | main.rs:440:17:440:17 | 1 |  |
-| main.rs:440:9:440:13 | mut x | main.rs:442:5:444:6 | let ... = ... | match |
-| main.rs:440:13:440:13 | x | main.rs:440:9:440:13 | mut x |  |
-| main.rs:440:17:440:17 | 1 | main.rs:440:13:440:13 | x |  |
-| main.rs:442:5:444:6 | let ... = ... | main.rs:442:20:444:5 | \|...\| ... |  |
-| main.rs:442:9:442:16 | closure1 | main.rs:442:9:442:16 | closure1 |  |
-| main.rs:442:9:442:16 | closure1 | main.rs:445:5:445:15 | ExprStmt | match |
-| main.rs:442:20:444:5 | \|...\| ... | main.rs:442:9:442:16 | closure1 |  |
-| main.rs:442:20:444:5 | enter \|...\| ... | main.rs:443:9:443:21 | ExprStmt |  |
-| main.rs:442:20:444:5 | exit \|...\| ... (normal) | main.rs:442:20:444:5 | exit \|...\| ... |  |
-| main.rs:442:23:444:5 | { ... } | main.rs:442:20:444:5 | exit \|...\| ... (normal) |  |
-| main.rs:443:9:443:17 | print_i64 | main.rs:443:19:443:19 | x |  |
-| main.rs:443:9:443:20 | print_i64(...) | main.rs:442:23:444:5 | { ... } |  |
-| main.rs:443:9:443:21 | ExprStmt | main.rs:443:9:443:17 | print_i64 |  |
-| main.rs:443:19:443:19 | x | main.rs:443:9:443:20 | print_i64(...) |  |
-| main.rs:445:5:445:12 | closure1 | main.rs:445:5:445:14 | closure1(...) |  |
-| main.rs:445:5:445:14 | closure1(...) | main.rs:446:5:446:17 | ExprStmt |  |
-| main.rs:445:5:445:15 | ExprStmt | main.rs:445:5:445:12 | closure1 |  |
-| main.rs:446:5:446:13 | print_i64 | main.rs:446:15:446:15 | x |  |
-| main.rs:446:5:446:16 | print_i64(...) | main.rs:448:5:448:18 | let ... = 2 |  |
-| main.rs:446:5:446:17 | ExprStmt | main.rs:446:5:446:13 | print_i64 |  |
-| main.rs:446:15:446:15 | x | main.rs:446:5:446:16 | print_i64(...) |  |
-| main.rs:448:5:448:18 | let ... = 2 | main.rs:448:17:448:17 | 2 |  |
-| main.rs:448:9:448:13 | mut y | main.rs:450:5:452:6 | let ... = ... | match |
-| main.rs:448:13:448:13 | y | main.rs:448:9:448:13 | mut y |  |
-| main.rs:448:17:448:17 | 2 | main.rs:448:13:448:13 | y |  |
-| main.rs:450:5:452:6 | let ... = ... | main.rs:450:24:452:5 | \|...\| ... |  |
-| main.rs:450:9:450:20 | mut closure2 | main.rs:453:5:453:15 | ExprStmt | match |
-| main.rs:450:13:450:20 | closure2 | main.rs:450:9:450:20 | mut closure2 |  |
-| main.rs:450:24:452:5 | \|...\| ... | main.rs:450:13:450:20 | closure2 |  |
-| main.rs:450:24:452:5 | enter \|...\| ... | main.rs:451:9:451:14 | ExprStmt |  |
-| main.rs:450:24:452:5 | exit \|...\| ... (normal) | main.rs:450:24:452:5 | exit \|...\| ... |  |
-| main.rs:450:27:452:5 | { ... } | main.rs:450:24:452:5 | exit \|...\| ... (normal) |  |
-| main.rs:451:9:451:9 | y | main.rs:451:13:451:13 | 3 |  |
-| main.rs:451:9:451:13 | ... = ... | main.rs:450:27:452:5 | { ... } |  |
-| main.rs:451:9:451:14 | ExprStmt | main.rs:451:9:451:9 | y |  |
-| main.rs:451:13:451:13 | 3 | main.rs:451:9:451:13 | ... = ... |  |
-| main.rs:453:5:453:12 | closure2 | main.rs:453:5:453:14 | closure2(...) |  |
-| main.rs:453:5:453:14 | closure2(...) | main.rs:454:5:454:17 | ExprStmt |  |
-| main.rs:453:5:453:15 | ExprStmt | main.rs:453:5:453:12 | closure2 |  |
-| main.rs:454:5:454:13 | print_i64 | main.rs:454:15:454:15 | y |  |
-| main.rs:454:5:454:16 | print_i64(...) | main.rs:456:5:456:18 | let ... = 2 |  |
-| main.rs:454:5:454:17 | ExprStmt | main.rs:454:5:454:13 | print_i64 |  |
-| main.rs:454:15:454:15 | y | main.rs:454:5:454:16 | print_i64(...) |  |
-| main.rs:456:5:456:18 | let ... = 2 | main.rs:456:17:456:17 | 2 |  |
-| main.rs:456:9:456:13 | mut z | main.rs:458:5:460:6 | let ... = ... | match |
-| main.rs:456:13:456:13 | z | main.rs:456:9:456:13 | mut z |  |
-| main.rs:456:17:456:17 | 2 | main.rs:456:13:456:13 | z |  |
-| main.rs:458:5:460:6 | let ... = ... | main.rs:458:24:460:5 | \|...\| ... |  |
-| main.rs:458:9:458:20 | mut closure3 | main.rs:461:5:461:15 | ExprStmt | match |
-| main.rs:458:13:458:20 | closure3 | main.rs:458:9:458:20 | mut closure3 |  |
-| main.rs:458:24:460:5 | \|...\| ... | main.rs:458:13:458:20 | closure3 |  |
-| main.rs:458:24:460:5 | enter \|...\| ... | main.rs:459:9:459:24 | ExprStmt |  |
-| main.rs:458:24:460:5 | exit \|...\| ... (normal) | main.rs:458:24:460:5 | exit \|...\| ... |  |
-| main.rs:458:27:460:5 | { ... } | main.rs:458:24:460:5 | exit \|...\| ... (normal) |  |
-| main.rs:459:9:459:9 | z | main.rs:459:22:459:22 | 1 |  |
-| main.rs:459:9:459:23 | z.add_assign(...) | main.rs:458:27:460:5 | { ... } |  |
-| main.rs:459:9:459:24 | ExprStmt | main.rs:459:9:459:9 | z |  |
-| main.rs:459:22:459:22 | 1 | main.rs:459:9:459:23 | z.add_assign(...) |  |
-| main.rs:461:5:461:12 | closure3 | main.rs:461:5:461:14 | closure3(...) |  |
-| main.rs:461:5:461:14 | closure3(...) | main.rs:462:5:462:17 | ExprStmt |  |
-| main.rs:461:5:461:15 | ExprStmt | main.rs:461:5:461:12 | closure3 |  |
-| main.rs:462:5:462:13 | print_i64 | main.rs:462:15:462:15 | z |  |
-| main.rs:462:5:462:16 | print_i64(...) | main.rs:439:18:463:1 | { ... } |  |
-| main.rs:462:5:462:17 | ExprStmt | main.rs:462:5:462:13 | print_i64 |  |
-| main.rs:462:15:462:15 | z | main.rs:462:5:462:16 | print_i64(...) |  |
-| main.rs:465:1:473:1 | enter fn async_block_capture | main.rs:466:5:466:23 | let ... = 0 |  |
-| main.rs:465:1:473:1 | exit fn async_block_capture (normal) | main.rs:465:1:473:1 | exit fn async_block_capture |  |
-| main.rs:465:32:473:1 | { ... } | main.rs:465:1:473:1 | exit fn async_block_capture (normal) |  |
-| main.rs:466:5:466:23 | let ... = 0 | main.rs:466:22:466:22 | 0 |  |
-| main.rs:466:9:466:13 | mut i | main.rs:467:5:469:6 | let ... = ... | match |
-| main.rs:466:13:466:13 | i | main.rs:466:9:466:13 | mut i |  |
-| main.rs:466:22:466:22 | 0 | main.rs:466:13:466:13 | i |  |
-| main.rs:467:5:469:6 | let ... = ... | main.rs:467:17:469:5 | { ... } |  |
-| main.rs:467:9:467:13 | block | main.rs:467:9:467:13 | block |  |
-| main.rs:467:9:467:13 | block | main.rs:471:5:471:16 | ExprStmt | match |
-| main.rs:467:17:469:5 | enter { ... } | main.rs:468:9:468:14 | ExprStmt |  |
-| main.rs:467:17:469:5 | exit { ... } (normal) | main.rs:467:17:469:5 | exit { ... } |  |
-| main.rs:467:17:469:5 | { ... } | main.rs:467:9:467:13 | block |  |
-| main.rs:468:9:468:9 | i | main.rs:468:13:468:13 | 1 |  |
-| main.rs:468:9:468:13 | ... = ... | main.rs:467:17:469:5 | exit { ... } (normal) |  |
-| main.rs:468:9:468:14 | ExprStmt | main.rs:468:9:468:9 | i |  |
-| main.rs:468:13:468:13 | 1 | main.rs:468:9:468:13 | ... = ... |  |
-| main.rs:471:5:471:9 | block | main.rs:471:5:471:15 | await block |  |
-| main.rs:471:5:471:15 | await block | main.rs:472:5:472:17 | ExprStmt |  |
-| main.rs:471:5:471:16 | ExprStmt | main.rs:471:5:471:9 | block |  |
-| main.rs:472:5:472:13 | print_i64 | main.rs:472:15:472:15 | i |  |
-| main.rs:472:5:472:16 | print_i64(...) | main.rs:465:32:473:1 | { ... } |  |
-| main.rs:472:5:472:17 | ExprStmt | main.rs:472:5:472:13 | print_i64 |  |
-| main.rs:472:15:472:15 | i | main.rs:472:5:472:16 | print_i64(...) |  |
-| main.rs:475:1:489:1 | enter fn phi | main.rs:475:8:475:8 | b |  |
-| main.rs:475:1:489:1 | exit fn phi (normal) | main.rs:475:1:489:1 | exit fn phi |  |
-| main.rs:475:8:475:8 | b | main.rs:475:8:475:8 | b |  |
-| main.rs:475:8:475:8 | b | main.rs:475:8:475:15 | ...: bool | match |
-| main.rs:475:8:475:15 | ...: bool | main.rs:476:5:476:18 | let ... = 1 |  |
-| main.rs:475:18:489:1 | { ... } | main.rs:475:1:489:1 | exit fn phi (normal) |  |
-| main.rs:476:5:476:18 | let ... = 1 | main.rs:476:17:476:17 | 1 |  |
-| main.rs:476:9:476:13 | mut x | main.rs:477:5:477:17 | ExprStmt | match |
-| main.rs:476:13:476:13 | x | main.rs:476:9:476:13 | mut x |  |
-| main.rs:476:17:476:17 | 1 | main.rs:476:13:476:13 | x |  |
-| main.rs:477:5:477:13 | print_i64 | main.rs:477:15:477:15 | x |  |
-| main.rs:477:5:477:16 | print_i64(...) | main.rs:478:5:478:21 | ExprStmt |  |
-| main.rs:477:5:477:17 | ExprStmt | main.rs:477:5:477:13 | print_i64 |  |
-| main.rs:477:15:477:15 | x | main.rs:477:5:477:16 | print_i64(...) |  |
-| main.rs:478:5:478:13 | print_i64 | main.rs:478:15:478:15 | x |  |
-| main.rs:478:5:478:20 | print_i64(...) | main.rs:479:5:487:5 | ExprStmt |  |
-| main.rs:478:5:478:21 | ExprStmt | main.rs:478:5:478:13 | print_i64 |  |
-| main.rs:478:15:478:15 | x | main.rs:478:19:478:19 | 1 |  |
-| main.rs:478:15:478:19 | ... + ... | main.rs:478:5:478:20 | print_i64(...) |  |
-| main.rs:478:19:478:19 | 1 | main.rs:478:15:478:19 | ... + ... |  |
-| main.rs:479:5:487:5 | ExprStmt | main.rs:479:8:479:8 | b |  |
-| main.rs:479:5:487:5 | if b {...} else {...} | main.rs:488:5:488:17 | ExprStmt |  |
-| main.rs:479:8:479:8 | b | main.rs:480:9:480:14 | ExprStmt | true |
-| main.rs:479:8:479:8 | b | main.rs:484:9:484:14 | ExprStmt | false |
-| main.rs:479:10:483:5 | { ... } | main.rs:479:5:487:5 | if b {...} else {...} |  |
-| main.rs:480:9:480:9 | x | main.rs:480:13:480:13 | 2 |  |
-| main.rs:480:9:480:13 | ... = ... | main.rs:481:9:481:21 | ExprStmt |  |
-| main.rs:480:9:480:14 | ExprStmt | main.rs:480:9:480:9 | x |  |
-| main.rs:480:13:480:13 | 2 | main.rs:480:9:480:13 | ... = ... |  |
-| main.rs:481:9:481:17 | print_i64 | main.rs:481:19:481:19 | x |  |
-| main.rs:481:9:481:20 | print_i64(...) | main.rs:482:9:482:25 | ExprStmt |  |
-| main.rs:481:9:481:21 | ExprStmt | main.rs:481:9:481:17 | print_i64 |  |
-| main.rs:481:19:481:19 | x | main.rs:481:9:481:20 | print_i64(...) |  |
-| main.rs:482:9:482:17 | print_i64 | main.rs:482:19:482:19 | x |  |
-| main.rs:482:9:482:24 | print_i64(...) | main.rs:479:10:483:5 | { ... } |  |
-| main.rs:482:9:482:25 | ExprStmt | main.rs:482:9:482:17 | print_i64 |  |
-| main.rs:482:19:482:19 | x | main.rs:482:23:482:23 | 1 |  |
-| main.rs:482:19:482:23 | ... + ... | main.rs:482:9:482:24 | print_i64(...) |  |
-| main.rs:482:23:482:23 | 1 | main.rs:482:19:482:23 | ... + ... |  |
-| main.rs:483:12:487:5 | { ... } | main.rs:479:5:487:5 | if b {...} else {...} |  |
-| main.rs:484:9:484:9 | x | main.rs:484:13:484:13 | 3 |  |
-| main.rs:484:9:484:13 | ... = ... | main.rs:485:9:485:21 | ExprStmt |  |
-| main.rs:484:9:484:14 | ExprStmt | main.rs:484:9:484:9 | x |  |
-| main.rs:484:13:484:13 | 3 | main.rs:484:9:484:13 | ... = ... |  |
-| main.rs:485:9:485:17 | print_i64 | main.rs:485:19:485:19 | x |  |
-| main.rs:485:9:485:20 | print_i64(...) | main.rs:486:9:486:25 | ExprStmt |  |
-| main.rs:485:9:485:21 | ExprStmt | main.rs:485:9:485:17 | print_i64 |  |
-| main.rs:485:19:485:19 | x | main.rs:485:9:485:20 | print_i64(...) |  |
-| main.rs:486:9:486:17 | print_i64 | main.rs:486:19:486:19 | x |  |
-| main.rs:486:9:486:24 | print_i64(...) | main.rs:483:12:487:5 | { ... } |  |
-| main.rs:486:9:486:25 | ExprStmt | main.rs:486:9:486:17 | print_i64 |  |
-| main.rs:486:19:486:19 | x | main.rs:486:23:486:23 | 1 |  |
-| main.rs:486:19:486:23 | ... + ... | main.rs:486:9:486:24 | print_i64(...) |  |
-| main.rs:486:23:486:23 | 1 | main.rs:486:19:486:23 | ... + ... |  |
-| main.rs:488:5:488:13 | print_i64 | main.rs:488:15:488:15 | x |  |
-| main.rs:488:5:488:16 | print_i64(...) | main.rs:475:18:489:1 | { ... } |  |
-| main.rs:488:5:488:17 | ExprStmt | main.rs:488:5:488:13 | print_i64 |  |
-| main.rs:488:15:488:15 | x | main.rs:488:5:488:16 | print_i64(...) |  |
-| main.rs:491:1:504:1 | enter fn phi_read | main.rs:491:13:491:14 | b1 |  |
-| main.rs:491:1:504:1 | exit fn phi_read (normal) | main.rs:491:1:504:1 | exit fn phi_read |  |
-| main.rs:491:13:491:14 | b1 | main.rs:491:13:491:14 | b1 |  |
-| main.rs:491:13:491:14 | b1 | main.rs:491:13:491:21 | ...: bool | match |
-| main.rs:491:13:491:21 | ...: bool | main.rs:491:24:491:25 | b2 |  |
-| main.rs:491:24:491:25 | b2 | main.rs:491:24:491:25 | b2 |  |
-| main.rs:491:24:491:25 | b2 | main.rs:491:24:491:32 | ...: bool | match |
-| main.rs:491:24:491:32 | ...: bool | main.rs:492:5:492:14 | let ... = 1 |  |
-| main.rs:491:35:504:1 | { ... } | main.rs:491:1:504:1 | exit fn phi_read (normal) |  |
-| main.rs:492:5:492:14 | let ... = 1 | main.rs:492:13:492:13 | 1 |  |
-| main.rs:492:9:492:9 | x | main.rs:492:9:492:9 | x |  |
-| main.rs:492:9:492:9 | x | main.rs:493:5:497:5 | ExprStmt | match |
-| main.rs:492:13:492:13 | 1 | main.rs:492:9:492:9 | x |  |
-| main.rs:493:5:497:5 | ExprStmt | main.rs:493:8:493:9 | b1 |  |
-| main.rs:493:5:497:5 | if b1 {...} else {...} | main.rs:499:8:499:9 | b2 |  |
-| main.rs:493:8:493:9 | b1 | main.rs:494:9:494:21 | ExprStmt | true |
-| main.rs:493:8:493:9 | b1 | main.rs:496:9:496:21 | ExprStmt | false |
-| main.rs:493:11:495:5 | { ... } | main.rs:493:5:497:5 | if b1 {...} else {...} |  |
-| main.rs:494:9:494:17 | print_i64 | main.rs:494:19:494:19 | x |  |
-| main.rs:494:9:494:20 | print_i64(...) | main.rs:493:11:495:5 | { ... } |  |
-| main.rs:494:9:494:21 | ExprStmt | main.rs:494:9:494:17 | print_i64 |  |
-| main.rs:494:19:494:19 | x | main.rs:494:9:494:20 | print_i64(...) |  |
-| main.rs:495:12:497:5 | { ... } | main.rs:493:5:497:5 | if b1 {...} else {...} |  |
-| main.rs:496:9:496:17 | print_i64 | main.rs:496:19:496:19 | x |  |
-| main.rs:496:9:496:20 | print_i64(...) | main.rs:495:12:497:5 | { ... } |  |
-| main.rs:496:9:496:21 | ExprStmt | main.rs:496:9:496:17 | print_i64 |  |
-| main.rs:496:19:496:19 | x | main.rs:496:9:496:20 | print_i64(...) |  |
-| main.rs:499:5:503:5 | if b2 {...} else {...} | main.rs:491:35:504:1 | { ... } |  |
-| main.rs:499:8:499:9 | b2 | main.rs:500:9:500:21 | ExprStmt | true |
-| main.rs:499:8:499:9 | b2 | main.rs:502:9:502:21 | ExprStmt | false |
-| main.rs:499:11:501:5 | { ... } | main.rs:499:5:503:5 | if b2 {...} else {...} |  |
-| main.rs:500:9:500:17 | print_i64 | main.rs:500:19:500:19 | x |  |
-| main.rs:500:9:500:20 | print_i64(...) | main.rs:499:11:501:5 | { ... } |  |
-| main.rs:500:9:500:21 | ExprStmt | main.rs:500:9:500:17 | print_i64 |  |
-| main.rs:500:19:500:19 | x | main.rs:500:9:500:20 | print_i64(...) |  |
-| main.rs:501:12:503:5 | { ... } | main.rs:499:5:503:5 | if b2 {...} else {...} |  |
+| main.rs:297:15:297:16 | c2 | main.rs:297:5:297:17 | print_i64(...) |  |
+| main.rs:299:5:303:5 | TupleExpr | main.rs:304:9:304:11 | a10 |  |
+| main.rs:299:5:307:5 | ... = ... | main.rs:308:5:308:19 | ExprStmt |  |
+| main.rs:299:5:307:6 | ExprStmt | main.rs:300:9:300:10 | c2 |  |
+| main.rs:300:9:300:10 | c2 | main.rs:301:9:301:10 | b4 |  |
+| main.rs:301:9:301:10 | b4 | main.rs:302:9:302:11 | a10 |  |
+| main.rs:302:9:302:11 | a10 | main.rs:299:5:303:5 | TupleExpr |  |
+| main.rs:303:9:307:5 | TupleExpr | main.rs:299:5:307:5 | ... = ... |  |
+| main.rs:304:9:304:11 | a10 | main.rs:305:9:305:10 | b4 |  |
+| main.rs:305:9:305:10 | b4 | main.rs:306:9:306:10 | c2 |  |
+| main.rs:306:9:306:10 | c2 | main.rs:303:9:307:5 | TupleExpr |  |
+| main.rs:308:5:308:13 | print_i64 | main.rs:308:15:308:17 | a10 |  |
+| main.rs:308:5:308:18 | print_i64(...) | main.rs:309:5:309:18 | ExprStmt |  |
+| main.rs:308:5:308:19 | ExprStmt | main.rs:308:5:308:13 | print_i64 |  |
+| main.rs:308:15:308:17 | a10 | main.rs:308:5:308:18 | print_i64(...) |  |
+| main.rs:309:5:309:13 | print_i64 | main.rs:309:15:309:16 | b4 |  |
+| main.rs:309:5:309:17 | print_i64(...) | main.rs:310:5:310:18 | ExprStmt |  |
+| main.rs:309:5:309:18 | ExprStmt | main.rs:309:5:309:13 | print_i64 |  |
+| main.rs:309:15:309:16 | b4 | main.rs:309:5:309:17 | print_i64(...) |  |
+| main.rs:310:5:310:13 | print_i64 | main.rs:310:15:310:16 | c2 |  |
+| main.rs:310:5:310:17 | print_i64(...) | main.rs:312:5:320:5 | ExprStmt |  |
+| main.rs:310:5:310:18 | ExprStmt | main.rs:310:5:310:13 | print_i64 |  |
+| main.rs:310:15:310:16 | c2 | main.rs:310:5:310:17 | print_i64(...) |  |
+| main.rs:312:5:320:5 | ExprStmt | main.rs:312:12:312:12 | 4 |  |
+| main.rs:312:5:320:5 | match ... { ... } | main.rs:322:5:322:19 | ExprStmt |  |
+| main.rs:312:11:312:16 | TupleExpr | main.rs:313:9:316:9 | TuplePat |  |
+| main.rs:312:12:312:12 | 4 | main.rs:312:15:312:15 | 5 |  |
+| main.rs:312:15:312:15 | 5 | main.rs:312:11:312:16 | TupleExpr |  |
+| main.rs:313:9:316:9 | TuplePat | main.rs:314:13:314:15 | a10 | match |
+| main.rs:314:13:314:15 | a10 | main.rs:314:13:314:15 | a10 |  |
+| main.rs:314:13:314:15 | a10 | main.rs:315:13:315:14 | b4 | match |
+| main.rs:315:13:315:14 | b4 | main.rs:315:13:315:14 | b4 |  |
+| main.rs:315:13:315:14 | b4 | main.rs:317:13:317:27 | ExprStmt | match |
+| main.rs:316:14:319:9 | { ... } | main.rs:312:5:320:5 | match ... { ... } |  |
+| main.rs:317:13:317:21 | print_i64 | main.rs:317:23:317:25 | a10 |  |
+| main.rs:317:13:317:26 | print_i64(...) | main.rs:318:13:318:26 | ExprStmt |  |
+| main.rs:317:13:317:27 | ExprStmt | main.rs:317:13:317:21 | print_i64 |  |
+| main.rs:317:23:317:25 | a10 | main.rs:317:13:317:26 | print_i64(...) |  |
+| main.rs:318:13:318:21 | print_i64 | main.rs:318:23:318:24 | b4 |  |
+| main.rs:318:13:318:25 | print_i64(...) | main.rs:316:14:319:9 | { ... } |  |
+| main.rs:318:13:318:26 | ExprStmt | main.rs:318:13:318:21 | print_i64 |  |
+| main.rs:318:23:318:24 | b4 | main.rs:318:13:318:25 | print_i64(...) |  |
+| main.rs:322:5:322:13 | print_i64 | main.rs:322:15:322:17 | a10 |  |
+| main.rs:322:5:322:18 | print_i64(...) | main.rs:323:5:323:18 | ExprStmt |  |
+| main.rs:322:5:322:19 | ExprStmt | main.rs:322:5:322:13 | print_i64 |  |
+| main.rs:322:15:322:17 | a10 | main.rs:322:5:322:18 | print_i64(...) |  |
+| main.rs:323:5:323:13 | print_i64 | main.rs:323:15:323:16 | b4 |  |
+| main.rs:323:5:323:17 | print_i64(...) | main.rs:289:26:324:1 | { ... } |  |
+| main.rs:323:5:323:18 | ExprStmt | main.rs:323:5:323:13 | print_i64 |  |
+| main.rs:323:15:323:16 | b4 | main.rs:323:5:323:17 | print_i64(...) |  |
+| main.rs:326:1:341:1 | enter fn closure_variable | main.rs:327:5:329:10 | let ... = ... |  |
+| main.rs:326:1:341:1 | exit fn closure_variable (normal) | main.rs:326:1:341:1 | exit fn closure_variable |  |
+| main.rs:326:23:341:1 | { ... } | main.rs:326:1:341:1 | exit fn closure_variable (normal) |  |
+| main.rs:327:5:329:10 | let ... = ... | main.rs:328:9:329:9 | \|...\| x |  |
+| main.rs:327:9:327:23 | example_closure | main.rs:327:9:327:23 | example_closure |  |
+| main.rs:327:9:327:23 | example_closure | main.rs:330:5:331:27 | let ... = ... | match |
+| main.rs:328:9:329:9 | \|...\| x | main.rs:327:9:327:23 | example_closure |  |
+| main.rs:328:9:329:9 | enter \|...\| x | main.rs:328:10:328:10 | x |  |
+| main.rs:328:9:329:9 | exit \|...\| x (normal) | main.rs:328:9:329:9 | exit \|...\| x |  |
+| main.rs:328:10:328:10 | x | main.rs:328:10:328:10 | x |  |
+| main.rs:328:10:328:10 | x | main.rs:328:10:328:15 | ...: i64 | match |
+| main.rs:328:10:328:15 | ...: i64 | main.rs:329:9:329:9 | x |  |
+| main.rs:329:9:329:9 | x | main.rs:328:9:329:9 | exit \|...\| x (normal) |  |
+| main.rs:330:5:331:27 | let ... = ... | main.rs:331:9:331:23 | example_closure |  |
+| main.rs:330:9:330:10 | n1 | main.rs:330:9:330:10 | n1 |  |
+| main.rs:330:9:330:10 | n1 | main.rs:332:5:332:18 | ExprStmt | match |
+| main.rs:331:9:331:23 | example_closure | main.rs:331:25:331:25 | 5 |  |
+| main.rs:331:9:331:26 | example_closure(...) | main.rs:330:9:330:10 | n1 |  |
+| main.rs:331:25:331:25 | 5 | main.rs:331:9:331:26 | example_closure(...) |  |
+| main.rs:332:5:332:13 | print_i64 | main.rs:332:15:332:16 | n1 |  |
+| main.rs:332:5:332:17 | print_i64(...) | main.rs:334:5:334:25 | ExprStmt |  |
+| main.rs:332:5:332:18 | ExprStmt | main.rs:332:5:332:13 | print_i64 |  |
+| main.rs:332:15:332:16 | n1 | main.rs:332:5:332:17 | print_i64(...) |  |
+| main.rs:334:5:334:22 | immutable_variable | main.rs:334:5:334:24 | immutable_variable(...) |  |
+| main.rs:334:5:334:24 | immutable_variable(...) | main.rs:335:5:337:10 | let ... = ... |  |
+| main.rs:334:5:334:25 | ExprStmt | main.rs:334:5:334:22 | immutable_variable |  |
+| main.rs:335:5:337:10 | let ... = ... | main.rs:336:5:337:9 | \|...\| x |  |
+| main.rs:335:9:335:26 | immutable_variable | main.rs:335:9:335:26 | immutable_variable |  |
+| main.rs:335:9:335:26 | immutable_variable | main.rs:338:5:339:30 | let ... = ... | match |
+| main.rs:336:5:337:9 | \|...\| x | main.rs:335:9:335:26 | immutable_variable |  |
+| main.rs:336:5:337:9 | enter \|...\| x | main.rs:336:6:336:6 | x |  |
+| main.rs:336:5:337:9 | exit \|...\| x (normal) | main.rs:336:5:337:9 | exit \|...\| x |  |
+| main.rs:336:6:336:6 | x | main.rs:336:6:336:6 | x |  |
+| main.rs:336:6:336:6 | x | main.rs:336:6:336:11 | ...: i64 | match |
+| main.rs:336:6:336:11 | ...: i64 | main.rs:337:9:337:9 | x |  |
+| main.rs:337:9:337:9 | x | main.rs:336:5:337:9 | exit \|...\| x (normal) |  |
+| main.rs:338:5:339:30 | let ... = ... | main.rs:339:9:339:26 | immutable_variable |  |
+| main.rs:338:9:338:10 | n2 | main.rs:338:9:338:10 | n2 |  |
+| main.rs:338:9:338:10 | n2 | main.rs:340:5:340:18 | ExprStmt | match |
+| main.rs:339:9:339:26 | immutable_variable | main.rs:339:28:339:28 | 6 |  |
+| main.rs:339:9:339:29 | immutable_variable(...) | main.rs:338:9:338:10 | n2 |  |
+| main.rs:339:28:339:28 | 6 | main.rs:339:9:339:29 | immutable_variable(...) |  |
+| main.rs:340:5:340:13 | print_i64 | main.rs:340:15:340:16 | n2 |  |
+| main.rs:340:5:340:17 | print_i64(...) | main.rs:326:23:341:1 | { ... } |  |
+| main.rs:340:5:340:18 | ExprStmt | main.rs:340:5:340:13 | print_i64 |  |
+| main.rs:340:15:340:16 | n2 | main.rs:340:5:340:17 | print_i64(...) |  |
+| main.rs:343:1:373:1 | enter fn nested_function | main.rs:345:5:347:10 | let ... = ... |  |
+| main.rs:343:1:373:1 | exit fn nested_function (normal) | main.rs:343:1:373:1 | exit fn nested_function |  |
+| main.rs:343:22:373:1 | { ... } | main.rs:343:1:373:1 | exit fn nested_function (normal) |  |
+| main.rs:345:5:347:10 | let ... = ... | main.rs:346:9:347:9 | \|...\| x |  |
+| main.rs:345:9:345:9 | f | main.rs:345:9:345:9 | f |  |
+| main.rs:345:9:345:9 | f | main.rs:348:5:348:20 | ExprStmt | match |
+| main.rs:346:9:347:9 | \|...\| x | main.rs:345:9:345:9 | f |  |
+| main.rs:346:9:347:9 | enter \|...\| x | main.rs:346:10:346:10 | x |  |
+| main.rs:346:9:347:9 | exit \|...\| x (normal) | main.rs:346:9:347:9 | exit \|...\| x |  |
+| main.rs:346:10:346:10 | x | main.rs:346:10:346:10 | x |  |
+| main.rs:346:10:346:10 | x | main.rs:346:10:346:15 | ...: i64 | match |
+| main.rs:346:10:346:15 | ...: i64 | main.rs:347:9:347:9 | x |  |
+| main.rs:347:9:347:9 | x | main.rs:346:9:347:9 | exit \|...\| x (normal) |  |
+| main.rs:348:5:348:13 | print_i64 | main.rs:348:15:348:15 | f |  |
+| main.rs:348:5:348:19 | print_i64(...) | main.rs:350:5:353:5 | fn f |  |
+| main.rs:348:5:348:20 | ExprStmt | main.rs:348:5:348:13 | print_i64 |  |
+| main.rs:348:15:348:15 | f | main.rs:348:17:348:17 | 1 |  |
+| main.rs:348:15:348:18 | f(...) | main.rs:348:5:348:19 | print_i64(...) |  |
+| main.rs:348:17:348:17 | 1 | main.rs:348:15:348:18 | f(...) |  |
+| main.rs:350:5:353:5 | enter fn f | main.rs:350:10:350:10 | x |  |
+| main.rs:350:5:353:5 | exit fn f (normal) | main.rs:350:5:353:5 | exit fn f |  |
+| main.rs:350:5:353:5 | fn f | main.rs:355:5:355:20 | ExprStmt |  |
+| main.rs:350:10:350:10 | x | main.rs:350:10:350:10 | x |  |
+| main.rs:350:10:350:10 | x | main.rs:350:10:350:15 | ...: i64 | match |
+| main.rs:350:10:350:15 | ...: i64 | main.rs:352:9:352:9 | x |  |
+| main.rs:351:5:353:5 | { ... } | main.rs:350:5:353:5 | exit fn f (normal) |  |
+| main.rs:352:9:352:9 | x | main.rs:352:13:352:13 | 1 |  |
+| main.rs:352:9:352:13 | ... + ... | main.rs:351:5:353:5 | { ... } |  |
+| main.rs:352:13:352:13 | 1 | main.rs:352:9:352:13 | ... + ... |  |
+| main.rs:355:5:355:13 | print_i64 | main.rs:355:15:355:15 | f |  |
+| main.rs:355:5:355:19 | print_i64(...) | main.rs:358:9:358:24 | ExprStmt |  |
+| main.rs:355:5:355:20 | ExprStmt | main.rs:355:5:355:13 | print_i64 |  |
+| main.rs:355:15:355:15 | f | main.rs:355:17:355:17 | 2 |  |
+| main.rs:355:15:355:18 | f(...) | main.rs:355:5:355:19 | print_i64(...) |  |
+| main.rs:355:17:355:17 | 2 | main.rs:355:15:355:18 | f(...) |  |
+| main.rs:357:5:372:5 | { ... } | main.rs:343:22:373:1 | { ... } |  |
+| main.rs:358:9:358:17 | print_i64 | main.rs:358:19:358:19 | f |  |
+| main.rs:358:9:358:23 | print_i64(...) | main.rs:359:9:362:9 | fn f |  |
+| main.rs:358:9:358:24 | ExprStmt | main.rs:358:9:358:17 | print_i64 |  |
+| main.rs:358:19:358:19 | f | main.rs:358:21:358:21 | 3 |  |
+| main.rs:358:19:358:22 | f(...) | main.rs:358:9:358:23 | print_i64(...) |  |
+| main.rs:358:21:358:21 | 3 | main.rs:358:19:358:22 | f(...) |  |
+| main.rs:359:9:362:9 | enter fn f | main.rs:359:14:359:14 | x |  |
+| main.rs:359:9:362:9 | exit fn f (normal) | main.rs:359:9:362:9 | exit fn f |  |
+| main.rs:359:9:362:9 | fn f | main.rs:364:9:366:9 | ExprStmt |  |
+| main.rs:359:14:359:14 | x | main.rs:359:14:359:14 | x |  |
+| main.rs:359:14:359:14 | x | main.rs:359:14:359:19 | ...: i64 | match |
+| main.rs:359:14:359:19 | ...: i64 | main.rs:361:13:361:13 | 2 |  |
+| main.rs:360:9:362:9 | { ... } | main.rs:359:9:362:9 | exit fn f (normal) |  |
+| main.rs:361:13:361:13 | 2 | main.rs:361:17:361:17 | x |  |
+| main.rs:361:13:361:17 | ... * ... | main.rs:360:9:362:9 | { ... } |  |
+| main.rs:361:17:361:17 | x | main.rs:361:13:361:17 | ... * ... |  |
+| main.rs:364:9:366:9 | ExprStmt | main.rs:365:13:365:28 | ExprStmt |  |
+| main.rs:364:9:366:9 | { ... } | main.rs:368:9:370:14 | let ... = ... |  |
+| main.rs:365:13:365:21 | print_i64 | main.rs:365:23:365:23 | f |  |
+| main.rs:365:13:365:27 | print_i64(...) | main.rs:364:9:366:9 | { ... } |  |
+| main.rs:365:13:365:28 | ExprStmt | main.rs:365:13:365:21 | print_i64 |  |
+| main.rs:365:23:365:23 | f | main.rs:365:25:365:25 | 4 |  |
+| main.rs:365:23:365:26 | f(...) | main.rs:365:13:365:27 | print_i64(...) |  |
+| main.rs:365:25:365:25 | 4 | main.rs:365:23:365:26 | f(...) |  |
+| main.rs:368:9:370:14 | let ... = ... | main.rs:369:13:370:13 | \|...\| x |  |
+| main.rs:368:13:368:13 | f | main.rs:368:13:368:13 | f |  |
+| main.rs:368:13:368:13 | f | main.rs:371:9:371:24 | ExprStmt | match |
+| main.rs:369:13:370:13 | \|...\| x | main.rs:368:13:368:13 | f |  |
+| main.rs:369:13:370:13 | enter \|...\| x | main.rs:369:14:369:14 | x |  |
+| main.rs:369:13:370:13 | exit \|...\| x (normal) | main.rs:369:13:370:13 | exit \|...\| x |  |
+| main.rs:369:14:369:14 | x | main.rs:369:14:369:14 | x |  |
+| main.rs:369:14:369:14 | x | main.rs:369:14:369:19 | ...: i64 | match |
+| main.rs:369:14:369:19 | ...: i64 | main.rs:370:13:370:13 | x |  |
+| main.rs:370:13:370:13 | x | main.rs:369:13:370:13 | exit \|...\| x (normal) |  |
+| main.rs:371:9:371:17 | print_i64 | main.rs:371:19:371:19 | f |  |
+| main.rs:371:9:371:23 | print_i64(...) | main.rs:357:5:372:5 | { ... } |  |
+| main.rs:371:9:371:24 | ExprStmt | main.rs:371:9:371:17 | print_i64 |  |
+| main.rs:371:19:371:19 | f | main.rs:371:21:371:21 | 5 |  |
+| main.rs:371:19:371:22 | f(...) | main.rs:371:9:371:23 | print_i64(...) |  |
+| main.rs:371:21:371:21 | 5 | main.rs:371:19:371:22 | f(...) |  |
+| main.rs:375:1:382:1 | enter fn for_variable | main.rs:376:5:376:42 | let ... = ... |  |
+| main.rs:375:1:382:1 | exit fn for_variable (normal) | main.rs:375:1:382:1 | exit fn for_variable |  |
+| main.rs:375:19:382:1 | { ... } | main.rs:375:1:382:1 | exit fn for_variable (normal) |  |
+| main.rs:376:5:376:42 | let ... = ... | main.rs:376:15:376:22 | "apples" |  |
+| main.rs:376:9:376:9 | v | main.rs:376:9:376:9 | v |  |
+| main.rs:376:9:376:9 | v | main.rs:379:12:379:12 | v | match |
+| main.rs:376:13:376:41 | &... | main.rs:376:9:376:9 | v |  |
+| main.rs:376:14:376:41 | [...] | main.rs:376:13:376:41 | &... |  |
+| main.rs:376:15:376:22 | "apples" | main.rs:376:25:376:30 | "cake" |  |
+| main.rs:376:25:376:30 | "cake" | main.rs:376:33:376:40 | "coffee" |  |
+| main.rs:376:33:376:40 | "coffee" | main.rs:376:14:376:41 | [...] |  |
+| main.rs:378:5:381:5 | for ... in ... { ... } | main.rs:375:19:382:1 | { ... } |  |
+| main.rs:378:9:378:12 | text | main.rs:378:5:381:5 | for ... in ... { ... } | no-match |
+| main.rs:378:9:378:12 | text | main.rs:378:9:378:12 | text |  |
+| main.rs:378:9:378:12 | text | main.rs:380:9:380:24 | ExprStmt | match |
+| main.rs:379:12:379:12 | v | main.rs:378:9:378:12 | text |  |
+| main.rs:379:14:381:5 | { ... } | main.rs:378:9:378:12 | text |  |
+| main.rs:380:9:380:17 | print_str | main.rs:380:19:380:22 | text |  |
+| main.rs:380:9:380:23 | print_str(...) | main.rs:379:14:381:5 | { ... } |  |
+| main.rs:380:9:380:24 | ExprStmt | main.rs:380:9:380:17 | print_str |  |
+| main.rs:380:19:380:22 | text | main.rs:380:9:380:23 | print_str(...) |  |
+| main.rs:384:1:390:1 | enter fn add_assign | main.rs:385:5:385:18 | let ... = 0 |  |
+| main.rs:384:1:390:1 | exit fn add_assign (normal) | main.rs:384:1:390:1 | exit fn add_assign |  |
+| main.rs:384:17:390:1 | { ... } | main.rs:384:1:390:1 | exit fn add_assign (normal) |  |
+| main.rs:385:5:385:18 | let ... = 0 | main.rs:385:17:385:17 | 0 |  |
+| main.rs:385:9:385:13 | mut a | main.rs:386:5:386:11 | ExprStmt | match |
+| main.rs:385:13:385:13 | a | main.rs:385:9:385:13 | mut a |  |
+| main.rs:385:17:385:17 | 0 | main.rs:385:13:385:13 | a |  |
+| main.rs:386:5:386:5 | a | main.rs:386:10:386:10 | 1 |  |
+| main.rs:386:5:386:10 | ... += ... | main.rs:387:5:387:17 | ExprStmt |  |
+| main.rs:386:5:386:11 | ExprStmt | main.rs:386:5:386:5 | a |  |
+| main.rs:386:10:386:10 | 1 | main.rs:386:5:386:10 | ... += ... |  |
+| main.rs:387:5:387:13 | print_i64 | main.rs:387:15:387:15 | a |  |
+| main.rs:387:5:387:16 | print_i64(...) | main.rs:388:5:388:28 | ExprStmt |  |
+| main.rs:387:5:387:17 | ExprStmt | main.rs:387:5:387:13 | print_i64 |  |
+| main.rs:387:15:387:15 | a | main.rs:387:5:387:16 | print_i64(...) |  |
+| main.rs:388:5:388:27 | ... .add_assign(...) | main.rs:389:5:389:17 | ExprStmt |  |
+| main.rs:388:5:388:28 | ExprStmt | main.rs:388:11:388:11 | a |  |
+| main.rs:388:6:388:11 | &mut a | main.rs:388:25:388:26 | 10 |  |
+| main.rs:388:11:388:11 | a | main.rs:388:6:388:11 | &mut a |  |
+| main.rs:388:25:388:26 | 10 | main.rs:388:5:388:27 | ... .add_assign(...) |  |
+| main.rs:389:5:389:13 | print_i64 | main.rs:389:15:389:15 | a |  |
+| main.rs:389:5:389:16 | print_i64(...) | main.rs:384:17:390:1 | { ... } |  |
+| main.rs:389:5:389:17 | ExprStmt | main.rs:389:5:389:13 | print_i64 |  |
+| main.rs:389:15:389:15 | a | main.rs:389:5:389:16 | print_i64(...) |  |
+| main.rs:392:1:398:1 | enter fn mutate | main.rs:393:5:393:18 | let ... = 1 |  |
+| main.rs:392:1:398:1 | exit fn mutate (normal) | main.rs:392:1:398:1 | exit fn mutate |  |
+| main.rs:392:13:398:1 | { ... } | main.rs:392:1:398:1 | exit fn mutate (normal) |  |
+| main.rs:393:5:393:18 | let ... = 1 | main.rs:393:17:393:17 | 1 |  |
+| main.rs:393:9:393:13 | mut i | main.rs:394:5:395:15 | let ... = ... | match |
+| main.rs:393:13:393:13 | i | main.rs:393:9:393:13 | mut i |  |
+| main.rs:393:17:393:17 | 1 | main.rs:393:13:393:13 | i |  |
+| main.rs:394:5:395:15 | let ... = ... | main.rs:395:14:395:14 | i |  |
+| main.rs:394:9:394:13 | ref_i | main.rs:394:9:394:13 | ref_i |  |
+| main.rs:394:9:394:13 | ref_i | main.rs:396:5:396:15 | ExprStmt | match |
+| main.rs:395:9:395:14 | &mut i | main.rs:394:9:394:13 | ref_i |  |
+| main.rs:395:14:395:14 | i | main.rs:395:9:395:14 | &mut i |  |
+| main.rs:396:5:396:10 | * ... | main.rs:396:14:396:14 | 2 |  |
+| main.rs:396:5:396:14 | ... = ... | main.rs:397:5:397:17 | ExprStmt |  |
+| main.rs:396:5:396:15 | ExprStmt | main.rs:396:6:396:10 | ref_i |  |
+| main.rs:396:6:396:10 | ref_i | main.rs:396:5:396:10 | * ... |  |
+| main.rs:396:14:396:14 | 2 | main.rs:396:5:396:14 | ... = ... |  |
+| main.rs:397:5:397:13 | print_i64 | main.rs:397:15:397:15 | i |  |
+| main.rs:397:5:397:16 | print_i64(...) | main.rs:392:13:398:1 | { ... } |  |
+| main.rs:397:5:397:17 | ExprStmt | main.rs:397:5:397:13 | print_i64 |  |
+| main.rs:397:15:397:15 | i | main.rs:397:5:397:16 | print_i64(...) |  |
+| main.rs:400:1:405:1 | enter fn mutate_param | main.rs:400:17:400:17 | x |  |
+| main.rs:400:1:405:1 | exit fn mutate_param (normal) | main.rs:400:1:405:1 | exit fn mutate_param |  |
+| main.rs:400:17:400:17 | x | main.rs:400:17:400:17 | x |  |
+| main.rs:400:17:400:17 | x | main.rs:400:17:400:27 | ...: ... | match |
+| main.rs:400:17:400:27 | ...: ... | main.rs:401:5:403:11 | ExprStmt |  |
+| main.rs:401:5:401:6 | * ... | main.rs:402:10:402:10 | x |  |
+| main.rs:401:5:403:10 | ... = ... | main.rs:404:5:404:13 | ExprStmt |  |
+| main.rs:401:5:403:11 | ExprStmt | main.rs:401:6:401:6 | x |  |
+| main.rs:401:6:401:6 | x | main.rs:401:5:401:6 | * ... |  |
+| main.rs:402:9:402:10 | * ... | main.rs:403:10:403:10 | x |  |
+| main.rs:402:9:403:10 | ... + ... | main.rs:401:5:403:10 | ... = ... |  |
+| main.rs:402:10:402:10 | x | main.rs:402:9:402:10 | * ... |  |
+| main.rs:403:9:403:10 | * ... | main.rs:402:9:403:10 | ... + ... |  |
+| main.rs:403:10:403:10 | x | main.rs:403:9:403:10 | * ... |  |
+| main.rs:404:5:404:12 | return x | main.rs:400:1:405:1 | exit fn mutate_param (normal) | return |
+| main.rs:404:5:404:13 | ExprStmt | main.rs:404:12:404:12 | x |  |
+| main.rs:404:12:404:12 | x | main.rs:404:5:404:12 | return x |  |
+| main.rs:407:1:413:1 | enter fn mutate_param2 | main.rs:407:22:407:22 | x |  |
+| main.rs:407:1:413:1 | exit fn mutate_param2 (normal) | main.rs:407:1:413:1 | exit fn mutate_param2 |  |
+| main.rs:407:22:407:22 | x | main.rs:407:22:407:22 | x |  |
+| main.rs:407:22:407:22 | x | main.rs:407:22:407:35 | ...: ... | match |
+| main.rs:407:22:407:35 | ...: ... | main.rs:407:38:407:38 | y |  |
+| main.rs:407:38:407:38 | y | main.rs:407:38:407:38 | y |  |
+| main.rs:407:38:407:38 | y | main.rs:407:38:407:56 | ...: ... | match |
+| main.rs:407:38:407:56 | ...: ... | main.rs:408:5:410:11 | ExprStmt |  |
+| main.rs:407:59:413:1 | { ... } | main.rs:407:1:413:1 | exit fn mutate_param2 (normal) |  |
+| main.rs:408:5:408:6 | * ... | main.rs:409:10:409:10 | x |  |
+| main.rs:408:5:410:10 | ... = ... | main.rs:411:5:412:10 | ExprStmt |  |
+| main.rs:408:5:410:11 | ExprStmt | main.rs:408:6:408:6 | x |  |
+| main.rs:408:6:408:6 | x | main.rs:408:5:408:6 | * ... |  |
+| main.rs:409:9:409:10 | * ... | main.rs:410:10:410:10 | x |  |
+| main.rs:409:9:410:10 | ... + ... | main.rs:408:5:410:10 | ... = ... |  |
+| main.rs:409:10:409:10 | x | main.rs:409:9:409:10 | * ... |  |
+| main.rs:410:9:410:10 | * ... | main.rs:409:9:410:10 | ... + ... |  |
+| main.rs:410:10:410:10 | x | main.rs:410:9:410:10 | * ... |  |
+| main.rs:411:5:411:6 | * ... | main.rs:412:9:412:9 | x |  |
+| main.rs:411:5:412:9 | ... = ... | main.rs:407:59:413:1 | { ... } |  |
+| main.rs:411:5:412:10 | ExprStmt | main.rs:411:6:411:6 | y |  |
+| main.rs:411:6:411:6 | y | main.rs:411:5:411:6 | * ... |  |
+| main.rs:412:9:412:9 | x | main.rs:411:5:412:9 | ... = ... |  |
+| main.rs:415:1:433:1 | enter fn mutate_arg | main.rs:416:5:416:18 | let ... = 2 |  |
+| main.rs:415:1:433:1 | exit fn mutate_arg (normal) | main.rs:415:1:433:1 | exit fn mutate_arg |  |
+| main.rs:415:17:433:1 | { ... } | main.rs:415:1:433:1 | exit fn mutate_arg (normal) |  |
+| main.rs:416:5:416:18 | let ... = 2 | main.rs:416:17:416:17 | 2 |  |
+| main.rs:416:9:416:13 | mut x | main.rs:417:5:418:29 | let ... = ... | match |
+| main.rs:416:13:416:13 | x | main.rs:416:9:416:13 | mut x |  |
+| main.rs:416:17:416:17 | 2 | main.rs:416:13:416:13 | x |  |
+| main.rs:417:5:418:29 | let ... = ... | main.rs:418:9:418:20 | mutate_param |  |
+| main.rs:417:9:417:9 | y | main.rs:417:9:417:9 | y |  |
+| main.rs:417:9:417:9 | y | main.rs:419:5:419:12 | ExprStmt | match |
+| main.rs:418:9:418:20 | mutate_param | main.rs:418:27:418:27 | x |  |
+| main.rs:418:9:418:28 | mutate_param(...) | main.rs:417:9:417:9 | y |  |
+| main.rs:418:22:418:27 | &mut x | main.rs:418:9:418:28 | mutate_param(...) |  |
+| main.rs:418:27:418:27 | x | main.rs:418:22:418:27 | &mut x |  |
+| main.rs:419:5:419:6 | * ... | main.rs:419:10:419:11 | 10 |  |
+| main.rs:419:5:419:11 | ... = ... | main.rs:421:5:421:17 | ExprStmt |  |
+| main.rs:419:5:419:12 | ExprStmt | main.rs:419:6:419:6 | y |  |
+| main.rs:419:6:419:6 | y | main.rs:419:5:419:6 | * ... |  |
+| main.rs:419:10:419:11 | 10 | main.rs:419:5:419:11 | ... = ... |  |
+| main.rs:421:5:421:13 | print_i64 | main.rs:421:15:421:15 | x |  |
+| main.rs:421:5:421:16 | print_i64(...) | main.rs:423:5:423:18 | let ... = 4 |  |
+| main.rs:421:5:421:17 | ExprStmt | main.rs:421:5:421:13 | print_i64 |  |
+| main.rs:421:15:421:15 | x | main.rs:421:5:421:16 | print_i64(...) |  |
+| main.rs:423:5:423:18 | let ... = 4 | main.rs:423:17:423:17 | 4 |  |
+| main.rs:423:9:423:13 | mut z | main.rs:424:5:425:20 | let ... = ... | match |
+| main.rs:423:13:423:13 | z | main.rs:423:9:423:13 | mut z |  |
+| main.rs:423:17:423:17 | 4 | main.rs:423:13:423:13 | z |  |
+| main.rs:424:5:425:20 | let ... = ... | main.rs:425:19:425:19 | x |  |
+| main.rs:424:9:424:9 | w | main.rs:424:9:424:9 | w |  |
+| main.rs:424:9:424:9 | w | main.rs:426:5:429:6 | ExprStmt | match |
+| main.rs:425:9:425:19 | &mut ... | main.rs:424:9:424:9 | w |  |
+| main.rs:425:14:425:19 | &mut x | main.rs:425:9:425:19 | &mut ... |  |
+| main.rs:425:19:425:19 | x | main.rs:425:14:425:19 | &mut x |  |
+| main.rs:426:5:426:17 | mutate_param2 | main.rs:427:14:427:14 | z |  |
+| main.rs:426:5:429:5 | mutate_param2(...) | main.rs:430:5:430:13 | ExprStmt |  |
+| main.rs:426:5:429:6 | ExprStmt | main.rs:426:5:426:17 | mutate_param2 |  |
+| main.rs:427:9:427:14 | &mut z | main.rs:428:9:428:9 | w |  |
+| main.rs:427:14:427:14 | z | main.rs:427:9:427:14 | &mut z |  |
+| main.rs:428:9:428:9 | w | main.rs:426:5:429:5 | mutate_param2(...) |  |
+| main.rs:430:5:430:7 | * ... | main.rs:430:11:430:12 | 11 |  |
+| main.rs:430:5:430:12 | ... = ... | main.rs:432:5:432:17 | ExprStmt |  |
+| main.rs:430:5:430:13 | ExprStmt | main.rs:430:7:430:7 | w |  |
+| main.rs:430:6:430:7 | * ... | main.rs:430:5:430:7 | * ... |  |
+| main.rs:430:7:430:7 | w | main.rs:430:6:430:7 | * ... |  |
+| main.rs:430:11:430:12 | 11 | main.rs:430:5:430:12 | ... = ... |  |
+| main.rs:432:5:432:13 | print_i64 | main.rs:432:15:432:15 | z |  |
+| main.rs:432:5:432:16 | print_i64(...) | main.rs:415:17:433:1 | { ... } |  |
+| main.rs:432:5:432:17 | ExprStmt | main.rs:432:5:432:13 | print_i64 |  |
+| main.rs:432:15:432:15 | z | main.rs:432:5:432:16 | print_i64(...) |  |
+| main.rs:435:1:441:1 | enter fn alias | main.rs:436:5:436:18 | let ... = 1 |  |
+| main.rs:435:1:441:1 | exit fn alias (normal) | main.rs:435:1:441:1 | exit fn alias |  |
+| main.rs:435:12:441:1 | { ... } | main.rs:435:1:441:1 | exit fn alias (normal) |  |
+| main.rs:436:5:436:18 | let ... = 1 | main.rs:436:17:436:17 | 1 |  |
+| main.rs:436:9:436:13 | mut x | main.rs:437:5:438:15 | let ... = ... | match |
+| main.rs:436:13:436:13 | x | main.rs:436:9:436:13 | mut x |  |
+| main.rs:436:17:436:17 | 1 | main.rs:436:13:436:13 | x |  |
+| main.rs:437:5:438:15 | let ... = ... | main.rs:438:14:438:14 | x |  |
+| main.rs:437:9:437:9 | y | main.rs:437:9:437:9 | y |  |
+| main.rs:437:9:437:9 | y | main.rs:439:5:439:11 | ExprStmt | match |
+| main.rs:438:9:438:14 | &mut x | main.rs:437:9:437:9 | y |  |
+| main.rs:438:14:438:14 | x | main.rs:438:9:438:14 | &mut x |  |
+| main.rs:439:5:439:6 | * ... | main.rs:439:10:439:10 | 2 |  |
+| main.rs:439:5:439:10 | ... = ... | main.rs:440:5:440:17 | ExprStmt |  |
+| main.rs:439:5:439:11 | ExprStmt | main.rs:439:6:439:6 | y |  |
+| main.rs:439:6:439:6 | y | main.rs:439:5:439:6 | * ... |  |
+| main.rs:439:10:439:10 | 2 | main.rs:439:5:439:10 | ... = ... |  |
+| main.rs:440:5:440:13 | print_i64 | main.rs:440:15:440:15 | x |  |
+| main.rs:440:5:440:16 | print_i64(...) | main.rs:435:12:441:1 | { ... } |  |
+| main.rs:440:5:440:17 | ExprStmt | main.rs:440:5:440:13 | print_i64 |  |
+| main.rs:440:15:440:15 | x | main.rs:440:5:440:16 | print_i64(...) |  |
+| main.rs:443:1:451:1 | enter fn capture_immut | main.rs:444:5:444:16 | let ... = 100 |  |
+| main.rs:443:1:451:1 | exit fn capture_immut (normal) | main.rs:443:1:451:1 | exit fn capture_immut |  |
+| main.rs:443:20:451:1 | { ... } | main.rs:443:1:451:1 | exit fn capture_immut (normal) |  |
+| main.rs:444:5:444:16 | let ... = 100 | main.rs:444:13:444:15 | 100 |  |
+| main.rs:444:9:444:9 | x | main.rs:444:9:444:9 | x |  |
+| main.rs:444:9:444:9 | x | main.rs:446:5:448:6 | let ... = ... | match |
+| main.rs:444:13:444:15 | 100 | main.rs:444:9:444:9 | x |  |
+| main.rs:446:5:448:6 | let ... = ... | main.rs:446:15:448:5 | \|...\| ... |  |
+| main.rs:446:9:446:11 | cap | main.rs:446:9:446:11 | cap |  |
+| main.rs:446:9:446:11 | cap | main.rs:449:5:449:10 | ExprStmt | match |
+| main.rs:446:15:448:5 | \|...\| ... | main.rs:446:9:446:11 | cap |  |
+| main.rs:446:15:448:5 | enter \|...\| ... | main.rs:447:9:447:21 | ExprStmt |  |
+| main.rs:446:15:448:5 | exit \|...\| ... (normal) | main.rs:446:15:448:5 | exit \|...\| ... |  |
+| main.rs:446:18:448:5 | { ... } | main.rs:446:15:448:5 | exit \|...\| ... (normal) |  |
+| main.rs:447:9:447:17 | print_i64 | main.rs:447:19:447:19 | x |  |
+| main.rs:447:9:447:20 | print_i64(...) | main.rs:446:18:448:5 | { ... } |  |
+| main.rs:447:9:447:21 | ExprStmt | main.rs:447:9:447:17 | print_i64 |  |
+| main.rs:447:19:447:19 | x | main.rs:447:9:447:20 | print_i64(...) |  |
+| main.rs:449:5:449:7 | cap | main.rs:449:5:449:9 | cap(...) |  |
+| main.rs:449:5:449:9 | cap(...) | main.rs:450:5:450:17 | ExprStmt |  |
+| main.rs:449:5:449:10 | ExprStmt | main.rs:449:5:449:7 | cap |  |
+| main.rs:450:5:450:13 | print_i64 | main.rs:450:15:450:15 | x |  |
+| main.rs:450:5:450:16 | print_i64(...) | main.rs:443:20:451:1 | { ... } |  |
+| main.rs:450:5:450:17 | ExprStmt | main.rs:450:5:450:13 | print_i64 |  |
+| main.rs:450:15:450:15 | x | main.rs:450:5:450:16 | print_i64(...) |  |
+| main.rs:453:1:477:1 | enter fn capture_mut | main.rs:454:5:454:18 | let ... = 1 |  |
+| main.rs:453:1:477:1 | exit fn capture_mut (normal) | main.rs:453:1:477:1 | exit fn capture_mut |  |
+| main.rs:453:18:477:1 | { ... } | main.rs:453:1:477:1 | exit fn capture_mut (normal) |  |
+| main.rs:454:5:454:18 | let ... = 1 | main.rs:454:17:454:17 | 1 |  |
+| main.rs:454:9:454:13 | mut x | main.rs:456:5:458:6 | let ... = ... | match |
+| main.rs:454:13:454:13 | x | main.rs:454:9:454:13 | mut x |  |
+| main.rs:454:17:454:17 | 1 | main.rs:454:13:454:13 | x |  |
+| main.rs:456:5:458:6 | let ... = ... | main.rs:456:20:458:5 | \|...\| ... |  |
+| main.rs:456:9:456:16 | closure1 | main.rs:456:9:456:16 | closure1 |  |
+| main.rs:456:9:456:16 | closure1 | main.rs:459:5:459:15 | ExprStmt | match |
+| main.rs:456:20:458:5 | \|...\| ... | main.rs:456:9:456:16 | closure1 |  |
+| main.rs:456:20:458:5 | enter \|...\| ... | main.rs:457:9:457:21 | ExprStmt |  |
+| main.rs:456:20:458:5 | exit \|...\| ... (normal) | main.rs:456:20:458:5 | exit \|...\| ... |  |
+| main.rs:456:23:458:5 | { ... } | main.rs:456:20:458:5 | exit \|...\| ... (normal) |  |
+| main.rs:457:9:457:17 | print_i64 | main.rs:457:19:457:19 | x |  |
+| main.rs:457:9:457:20 | print_i64(...) | main.rs:456:23:458:5 | { ... } |  |
+| main.rs:457:9:457:21 | ExprStmt | main.rs:457:9:457:17 | print_i64 |  |
+| main.rs:457:19:457:19 | x | main.rs:457:9:457:20 | print_i64(...) |  |
+| main.rs:459:5:459:12 | closure1 | main.rs:459:5:459:14 | closure1(...) |  |
+| main.rs:459:5:459:14 | closure1(...) | main.rs:460:5:460:17 | ExprStmt |  |
+| main.rs:459:5:459:15 | ExprStmt | main.rs:459:5:459:12 | closure1 |  |
+| main.rs:460:5:460:13 | print_i64 | main.rs:460:15:460:15 | x |  |
+| main.rs:460:5:460:16 | print_i64(...) | main.rs:462:5:462:18 | let ... = 2 |  |
+| main.rs:460:5:460:17 | ExprStmt | main.rs:460:5:460:13 | print_i64 |  |
+| main.rs:460:15:460:15 | x | main.rs:460:5:460:16 | print_i64(...) |  |
+| main.rs:462:5:462:18 | let ... = 2 | main.rs:462:17:462:17 | 2 |  |
+| main.rs:462:9:462:13 | mut y | main.rs:464:5:466:6 | let ... = ... | match |
+| main.rs:462:13:462:13 | y | main.rs:462:9:462:13 | mut y |  |
+| main.rs:462:17:462:17 | 2 | main.rs:462:13:462:13 | y |  |
+| main.rs:464:5:466:6 | let ... = ... | main.rs:464:24:466:5 | \|...\| ... |  |
+| main.rs:464:9:464:20 | mut closure2 | main.rs:467:5:467:15 | ExprStmt | match |
+| main.rs:464:13:464:20 | closure2 | main.rs:464:9:464:20 | mut closure2 |  |
+| main.rs:464:24:466:5 | \|...\| ... | main.rs:464:13:464:20 | closure2 |  |
+| main.rs:464:24:466:5 | enter \|...\| ... | main.rs:465:9:465:14 | ExprStmt |  |
+| main.rs:464:24:466:5 | exit \|...\| ... (normal) | main.rs:464:24:466:5 | exit \|...\| ... |  |
+| main.rs:464:27:466:5 | { ... } | main.rs:464:24:466:5 | exit \|...\| ... (normal) |  |
+| main.rs:465:9:465:9 | y | main.rs:465:13:465:13 | 3 |  |
+| main.rs:465:9:465:13 | ... = ... | main.rs:464:27:466:5 | { ... } |  |
+| main.rs:465:9:465:14 | ExprStmt | main.rs:465:9:465:9 | y |  |
+| main.rs:465:13:465:13 | 3 | main.rs:465:9:465:13 | ... = ... |  |
+| main.rs:467:5:467:12 | closure2 | main.rs:467:5:467:14 | closure2(...) |  |
+| main.rs:467:5:467:14 | closure2(...) | main.rs:468:5:468:17 | ExprStmt |  |
+| main.rs:467:5:467:15 | ExprStmt | main.rs:467:5:467:12 | closure2 |  |
+| main.rs:468:5:468:13 | print_i64 | main.rs:468:15:468:15 | y |  |
+| main.rs:468:5:468:16 | print_i64(...) | main.rs:470:5:470:18 | let ... = 2 |  |
+| main.rs:468:5:468:17 | ExprStmt | main.rs:468:5:468:13 | print_i64 |  |
+| main.rs:468:15:468:15 | y | main.rs:468:5:468:16 | print_i64(...) |  |
+| main.rs:470:5:470:18 | let ... = 2 | main.rs:470:17:470:17 | 2 |  |
+| main.rs:470:9:470:13 | mut z | main.rs:472:5:474:6 | let ... = ... | match |
+| main.rs:470:13:470:13 | z | main.rs:470:9:470:13 | mut z |  |
+| main.rs:470:17:470:17 | 2 | main.rs:470:13:470:13 | z |  |
+| main.rs:472:5:474:6 | let ... = ... | main.rs:472:24:474:5 | \|...\| ... |  |
+| main.rs:472:9:472:20 | mut closure3 | main.rs:475:5:475:15 | ExprStmt | match |
+| main.rs:472:13:472:20 | closure3 | main.rs:472:9:472:20 | mut closure3 |  |
+| main.rs:472:24:474:5 | \|...\| ... | main.rs:472:13:472:20 | closure3 |  |
+| main.rs:472:24:474:5 | enter \|...\| ... | main.rs:473:9:473:24 | ExprStmt |  |
+| main.rs:472:24:474:5 | exit \|...\| ... (normal) | main.rs:472:24:474:5 | exit \|...\| ... |  |
+| main.rs:472:27:474:5 | { ... } | main.rs:472:24:474:5 | exit \|...\| ... (normal) |  |
+| main.rs:473:9:473:9 | z | main.rs:473:22:473:22 | 1 |  |
+| main.rs:473:9:473:23 | z.add_assign(...) | main.rs:472:27:474:5 | { ... } |  |
+| main.rs:473:9:473:24 | ExprStmt | main.rs:473:9:473:9 | z |  |
+| main.rs:473:22:473:22 | 1 | main.rs:473:9:473:23 | z.add_assign(...) |  |
+| main.rs:475:5:475:12 | closure3 | main.rs:475:5:475:14 | closure3(...) |  |
+| main.rs:475:5:475:14 | closure3(...) | main.rs:476:5:476:17 | ExprStmt |  |
+| main.rs:475:5:475:15 | ExprStmt | main.rs:475:5:475:12 | closure3 |  |
+| main.rs:476:5:476:13 | print_i64 | main.rs:476:15:476:15 | z |  |
+| main.rs:476:5:476:16 | print_i64(...) | main.rs:453:18:477:1 | { ... } |  |
+| main.rs:476:5:476:17 | ExprStmt | main.rs:476:5:476:13 | print_i64 |  |
+| main.rs:476:15:476:15 | z | main.rs:476:5:476:16 | print_i64(...) |  |
+| main.rs:479:1:487:1 | enter fn async_block_capture | main.rs:480:5:480:23 | let ... = 0 |  |
+| main.rs:479:1:487:1 | exit fn async_block_capture (normal) | main.rs:479:1:487:1 | exit fn async_block_capture |  |
+| main.rs:479:32:487:1 | { ... } | main.rs:479:1:487:1 | exit fn async_block_capture (normal) |  |
+| main.rs:480:5:480:23 | let ... = 0 | main.rs:480:22:480:22 | 0 |  |
+| main.rs:480:9:480:13 | mut i | main.rs:481:5:483:6 | let ... = ... | match |
+| main.rs:480:13:480:13 | i | main.rs:480:9:480:13 | mut i |  |
+| main.rs:480:22:480:22 | 0 | main.rs:480:13:480:13 | i |  |
+| main.rs:481:5:483:6 | let ... = ... | main.rs:481:17:483:5 | { ... } |  |
+| main.rs:481:9:481:13 | block | main.rs:481:9:481:13 | block |  |
+| main.rs:481:9:481:13 | block | main.rs:485:5:485:16 | ExprStmt | match |
+| main.rs:481:17:483:5 | enter { ... } | main.rs:482:9:482:14 | ExprStmt |  |
+| main.rs:481:17:483:5 | exit { ... } (normal) | main.rs:481:17:483:5 | exit { ... } |  |
+| main.rs:481:17:483:5 | { ... } | main.rs:481:9:481:13 | block |  |
+| main.rs:482:9:482:9 | i | main.rs:482:13:482:13 | 1 |  |
+| main.rs:482:9:482:13 | ... = ... | main.rs:481:17:483:5 | exit { ... } (normal) |  |
+| main.rs:482:9:482:14 | ExprStmt | main.rs:482:9:482:9 | i |  |
+| main.rs:482:13:482:13 | 1 | main.rs:482:9:482:13 | ... = ... |  |
+| main.rs:485:5:485:9 | block | main.rs:485:5:485:15 | await block |  |
+| main.rs:485:5:485:15 | await block | main.rs:486:5:486:17 | ExprStmt |  |
+| main.rs:485:5:485:16 | ExprStmt | main.rs:485:5:485:9 | block |  |
+| main.rs:486:5:486:13 | print_i64 | main.rs:486:15:486:15 | i |  |
+| main.rs:486:5:486:16 | print_i64(...) | main.rs:479:32:487:1 | { ... } |  |
+| main.rs:486:5:486:17 | ExprStmt | main.rs:486:5:486:13 | print_i64 |  |
+| main.rs:486:15:486:15 | i | main.rs:486:5:486:16 | print_i64(...) |  |
+| main.rs:489:1:505:1 | enter fn phi | main.rs:489:8:489:8 | b |  |
+| main.rs:489:1:505:1 | exit fn phi (normal) | main.rs:489:1:505:1 | exit fn phi |  |
+| main.rs:489:8:489:8 | b | main.rs:489:8:489:8 | b |  |
+| main.rs:489:8:489:8 | b | main.rs:489:8:489:14 | ...: bool | match |
+| main.rs:489:8:489:14 | ...: bool | main.rs:490:5:490:18 | let ... = 1 |  |
+| main.rs:489:17:505:1 | { ... } | main.rs:489:1:505:1 | exit fn phi (normal) |  |
+| main.rs:490:5:490:18 | let ... = 1 | main.rs:490:17:490:17 | 1 |  |
+| main.rs:490:9:490:13 | mut x | main.rs:491:5:491:17 | ExprStmt | match |
+| main.rs:490:13:490:13 | x | main.rs:490:9:490:13 | mut x |  |
+| main.rs:490:17:490:17 | 1 | main.rs:490:13:490:13 | x |  |
+| main.rs:491:5:491:13 | print_i64 | main.rs:491:15:491:15 | x |  |
+| main.rs:491:5:491:16 | print_i64(...) | main.rs:492:5:492:21 | ExprStmt |  |
+| main.rs:491:5:491:17 | ExprStmt | main.rs:491:5:491:13 | print_i64 |  |
+| main.rs:491:15:491:15 | x | main.rs:491:5:491:16 | print_i64(...) |  |
+| main.rs:492:5:492:13 | print_i64 | main.rs:492:15:492:15 | x |  |
+| main.rs:492:5:492:20 | print_i64(...) | main.rs:493:5:503:6 | let _ = ... |  |
+| main.rs:492:5:492:21 | ExprStmt | main.rs:492:5:492:13 | print_i64 |  |
+| main.rs:492:15:492:15 | x | main.rs:492:19:492:19 | 1 |  |
+| main.rs:492:15:492:19 | ... + ... | main.rs:492:5:492:20 | print_i64(...) |  |
+| main.rs:492:19:492:19 | 1 | main.rs:492:15:492:19 | ... + ... |  |
+| main.rs:493:5:503:6 | let _ = ... | main.rs:494:16:494:16 | b |  |
+| main.rs:494:9:494:9 | _ | main.rs:504:5:504:17 | ExprStmt | match |
+| main.rs:494:13:503:5 | if b {...} else {...} | main.rs:494:9:494:9 | _ |  |
+| main.rs:494:16:494:16 | b | main.rs:496:9:496:14 | ExprStmt | true |
+| main.rs:494:16:494:16 | b | main.rs:500:9:500:14 | ExprStmt | false |
+| main.rs:495:5:499:5 | { ... } | main.rs:494:13:503:5 | if b {...} else {...} |  |
+| main.rs:496:9:496:9 | x | main.rs:496:13:496:13 | 2 |  |
+| main.rs:496:9:496:13 | ... = ... | main.rs:497:9:497:21 | ExprStmt |  |
+| main.rs:496:9:496:14 | ExprStmt | main.rs:496:9:496:9 | x |  |
+| main.rs:496:13:496:13 | 2 | main.rs:496:9:496:13 | ... = ... |  |
+| main.rs:497:9:497:17 | print_i64 | main.rs:497:19:497:19 | x |  |
+| main.rs:497:9:497:20 | print_i64(...) | main.rs:498:9:498:25 | ExprStmt |  |
+| main.rs:497:9:497:21 | ExprStmt | main.rs:497:9:497:17 | print_i64 |  |
+| main.rs:497:19:497:19 | x | main.rs:497:9:497:20 | print_i64(...) |  |
+| main.rs:498:9:498:17 | print_i64 | main.rs:498:19:498:19 | x |  |
+| main.rs:498:9:498:24 | print_i64(...) | main.rs:495:5:499:5 | { ... } |  |
+| main.rs:498:9:498:25 | ExprStmt | main.rs:498:9:498:17 | print_i64 |  |
+| main.rs:498:19:498:19 | x | main.rs:498:23:498:23 | 1 |  |
+| main.rs:498:19:498:23 | ... + ... | main.rs:498:9:498:24 | print_i64(...) |  |
+| main.rs:498:23:498:23 | 1 | main.rs:498:19:498:23 | ... + ... |  |
+| main.rs:499:12:503:5 | { ... } | main.rs:494:13:503:5 | if b {...} else {...} |  |
+| main.rs:500:9:500:9 | x | main.rs:500:13:500:13 | 3 |  |
+| main.rs:500:9:500:13 | ... = ... | main.rs:501:9:501:21 | ExprStmt |  |
+| main.rs:500:9:500:14 | ExprStmt | main.rs:500:9:500:9 | x |  |
+| main.rs:500:13:500:13 | 3 | main.rs:500:9:500:13 | ... = ... |  |
+| main.rs:501:9:501:17 | print_i64 | main.rs:501:19:501:19 | x |  |
+| main.rs:501:9:501:20 | print_i64(...) | main.rs:502:9:502:25 | ExprStmt |  |
+| main.rs:501:9:501:21 | ExprStmt | main.rs:501:9:501:17 | print_i64 |  |
+| main.rs:501:19:501:19 | x | main.rs:501:9:501:20 | print_i64(...) |  |
 | main.rs:502:9:502:17 | print_i64 | main.rs:502:19:502:19 | x |  |
-| main.rs:502:9:502:20 | print_i64(...) | main.rs:501:12:503:5 | { ... } |  |
-| main.rs:502:9:502:21 | ExprStmt | main.rs:502:9:502:17 | print_i64 |  |
-| main.rs:502:19:502:19 | x | main.rs:502:9:502:20 | print_i64(...) |  |
-| main.rs:512:5:514:5 | enter fn my_get | main.rs:512:20:512:23 | self |  |
-| main.rs:512:5:514:5 | exit fn my_get (normal) | main.rs:512:5:514:5 | exit fn my_get |  |
-| main.rs:512:15:512:23 | SelfParam | main.rs:513:9:513:24 | ExprStmt |  |
-| main.rs:512:20:512:23 | self | main.rs:512:15:512:23 | SelfParam |  |
-| main.rs:513:9:513:23 | return ... | main.rs:512:5:514:5 | exit fn my_get (normal) | return |
-| main.rs:513:9:513:24 | ExprStmt | main.rs:513:16:513:19 | self |  |
-| main.rs:513:16:513:19 | self | main.rs:513:16:513:23 | self.val |  |
-| main.rs:513:16:513:23 | self.val | main.rs:513:9:513:23 | return ... |  |
-| main.rs:516:5:518:5 | enter fn id | main.rs:516:11:516:14 | self |  |
-| main.rs:516:5:518:5 | exit fn id (normal) | main.rs:516:5:518:5 | exit fn id |  |
-| main.rs:516:11:516:14 | SelfParam | main.rs:517:9:517:12 | self |  |
-| main.rs:516:11:516:14 | self | main.rs:516:11:516:14 | SelfParam |  |
-| main.rs:516:25:518:5 | { ... } | main.rs:516:5:518:5 | exit fn id (normal) |  |
-| main.rs:517:9:517:12 | self | main.rs:516:25:518:5 | { ... } |  |
-| main.rs:520:5:527:5 | enter fn my_method | main.rs:520:23:520:26 | self |  |
-| main.rs:520:5:527:5 | exit fn my_method (normal) | main.rs:520:5:527:5 | exit fn my_method |  |
-| main.rs:520:18:520:26 | SelfParam | main.rs:521:9:524:10 | let ... = ... |  |
-| main.rs:520:23:520:26 | self | main.rs:520:18:520:26 | SelfParam |  |
-| main.rs:520:29:527:5 | { ... } | main.rs:520:5:527:5 | exit fn my_method (normal) |  |
-| main.rs:521:9:524:10 | let ... = ... | main.rs:521:21:524:9 | \|...\| ... |  |
-| main.rs:521:13:521:17 | mut f | main.rs:525:9:525:13 | ExprStmt | match |
-| main.rs:521:17:521:17 | f | main.rs:521:13:521:17 | mut f |  |
-| main.rs:521:21:524:9 | \|...\| ... | main.rs:521:17:521:17 | f |  |
-| main.rs:521:21:524:9 | enter \|...\| ... | main.rs:521:22:521:22 | n |  |
-| main.rs:521:21:524:9 | exit \|...\| ... (normal) | main.rs:521:21:524:9 | exit \|...\| ... |  |
-| main.rs:521:22:521:22 | ... | main.rs:523:13:523:26 | ExprStmt |  |
-| main.rs:521:22:521:22 | n | main.rs:521:22:521:22 | ... | match |
-| main.rs:521:22:521:22 | n | main.rs:521:22:521:22 | n |  |
-| main.rs:521:25:524:9 | { ... } | main.rs:521:21:524:9 | exit \|...\| ... (normal) |  |
-| main.rs:523:13:523:16 | self | main.rs:523:13:523:20 | self.val |  |
-| main.rs:523:13:523:20 | self.val | main.rs:523:25:523:25 | n |  |
-| main.rs:523:13:523:25 | ... += ... | main.rs:521:25:524:9 | { ... } |  |
-| main.rs:523:13:523:26 | ExprStmt | main.rs:523:13:523:16 | self |  |
-| main.rs:523:25:523:25 | n | main.rs:523:13:523:25 | ... += ... |  |
-| main.rs:525:9:525:9 | f | main.rs:525:11:525:11 | 3 |  |
-| main.rs:525:9:525:12 | f(...) | main.rs:526:9:526:13 | ExprStmt |  |
-| main.rs:525:9:525:13 | ExprStmt | main.rs:525:9:525:9 | f |  |
-| main.rs:525:11:525:11 | 3 | main.rs:525:9:525:12 | f(...) |  |
-| main.rs:526:9:526:9 | f | main.rs:526:11:526:11 | 4 |  |
-| main.rs:526:9:526:12 | f(...) | main.rs:520:29:527:5 | { ... } |  |
-| main.rs:526:9:526:13 | ExprStmt | main.rs:526:9:526:9 | f |  |
-| main.rs:526:11:526:11 | 4 | main.rs:526:9:526:12 | f(...) |  |
-| main.rs:530:1:537:1 | enter fn structs | main.rs:531:5:531:36 | let ... = ... |  |
-| main.rs:530:1:537:1 | exit fn structs (normal) | main.rs:530:1:537:1 | exit fn structs |  |
-| main.rs:530:14:537:1 | { ... } | main.rs:530:1:537:1 | exit fn structs (normal) |  |
-| main.rs:531:5:531:36 | let ... = ... | main.rs:531:33:531:33 | 1 |  |
-| main.rs:531:9:531:13 | mut a | main.rs:532:5:532:26 | ExprStmt | match |
-| main.rs:531:13:531:13 | a | main.rs:531:9:531:13 | mut a |  |
-| main.rs:531:17:531:35 | MyStruct {...} | main.rs:531:13:531:13 | a |  |
-| main.rs:531:33:531:33 | 1 | main.rs:531:17:531:35 | MyStruct {...} |  |
-| main.rs:532:5:532:13 | print_i64 | main.rs:532:15:532:15 | a |  |
-| main.rs:532:5:532:25 | print_i64(...) | main.rs:533:5:533:14 | ExprStmt |  |
-| main.rs:532:5:532:26 | ExprStmt | main.rs:532:5:532:13 | print_i64 |  |
-| main.rs:532:15:532:15 | a | main.rs:532:15:532:24 | a.my_get() |  |
-| main.rs:532:15:532:24 | a.my_get() | main.rs:532:5:532:25 | print_i64(...) |  |
-| main.rs:533:5:533:5 | a | main.rs:533:5:533:9 | a.val |  |
-| main.rs:533:5:533:9 | a.val | main.rs:533:13:533:13 | 5 |  |
-| main.rs:533:5:533:13 | ... = ... | main.rs:534:5:534:26 | ExprStmt |  |
-| main.rs:533:5:533:14 | ExprStmt | main.rs:533:5:533:5 | a |  |
-| main.rs:533:13:533:13 | 5 | main.rs:533:5:533:13 | ... = ... |  |
-| main.rs:534:5:534:13 | print_i64 | main.rs:534:15:534:15 | a |  |
-| main.rs:534:5:534:25 | print_i64(...) | main.rs:535:5:535:28 | ExprStmt |  |
-| main.rs:534:5:534:26 | ExprStmt | main.rs:534:5:534:13 | print_i64 |  |
-| main.rs:534:15:534:15 | a | main.rs:534:15:534:24 | a.my_get() |  |
-| main.rs:534:15:534:24 | a.my_get() | main.rs:534:5:534:25 | print_i64(...) |  |
-| main.rs:535:5:535:5 | a | main.rs:535:25:535:25 | 2 |  |
-| main.rs:535:5:535:27 | ... = ... | main.rs:536:5:536:26 | ExprStmt |  |
-| main.rs:535:5:535:28 | ExprStmt | main.rs:535:5:535:5 | a |  |
-| main.rs:535:9:535:27 | MyStruct {...} | main.rs:535:5:535:27 | ... = ... |  |
-| main.rs:535:25:535:25 | 2 | main.rs:535:9:535:27 | MyStruct {...} |  |
-| main.rs:536:5:536:13 | print_i64 | main.rs:536:15:536:15 | a |  |
-| main.rs:536:5:536:25 | print_i64(...) | main.rs:530:14:537:1 | { ... } |  |
-| main.rs:536:5:536:26 | ExprStmt | main.rs:536:5:536:13 | print_i64 |  |
-| main.rs:536:15:536:15 | a | main.rs:536:15:536:24 | a.my_get() |  |
-| main.rs:536:15:536:24 | a.my_get() | main.rs:536:5:536:25 | print_i64(...) |  |
-| main.rs:539:1:546:1 | enter fn arrays | main.rs:540:5:540:26 | let ... = ... |  |
-| main.rs:539:1:546:1 | exit fn arrays (normal) | main.rs:539:1:546:1 | exit fn arrays |  |
-| main.rs:539:13:546:1 | { ... } | main.rs:539:1:546:1 | exit fn arrays (normal) |  |
-| main.rs:540:5:540:26 | let ... = ... | main.rs:540:18:540:18 | 1 |  |
-| main.rs:540:9:540:13 | mut a | main.rs:541:5:541:20 | ExprStmt | match |
-| main.rs:540:13:540:13 | a | main.rs:540:9:540:13 | mut a |  |
-| main.rs:540:17:540:25 | [...] | main.rs:540:13:540:13 | a |  |
-| main.rs:540:18:540:18 | 1 | main.rs:540:21:540:21 | 2 |  |
-| main.rs:540:21:540:21 | 2 | main.rs:540:24:540:24 | 3 |  |
-| main.rs:540:24:540:24 | 3 | main.rs:540:17:540:25 | [...] |  |
-| main.rs:541:5:541:13 | print_i64 | main.rs:541:15:541:15 | a |  |
-| main.rs:541:5:541:19 | print_i64(...) | main.rs:542:5:542:13 | ExprStmt |  |
-| main.rs:541:5:541:20 | ExprStmt | main.rs:541:5:541:13 | print_i64 |  |
-| main.rs:541:15:541:15 | a | main.rs:541:17:541:17 | 0 |  |
-| main.rs:541:15:541:18 | a[0] | main.rs:541:5:541:19 | print_i64(...) |  |
-| main.rs:541:17:541:17 | 0 | main.rs:541:15:541:18 | a[0] |  |
-| main.rs:542:5:542:5 | a | main.rs:542:7:542:7 | 1 |  |
-| main.rs:542:5:542:8 | a[1] | main.rs:542:12:542:12 | 5 |  |
-| main.rs:542:5:542:12 | ... = ... | main.rs:543:5:543:20 | ExprStmt |  |
-| main.rs:542:5:542:13 | ExprStmt | main.rs:542:5:542:5 | a |  |
-| main.rs:542:7:542:7 | 1 | main.rs:542:5:542:8 | a[1] |  |
-| main.rs:542:12:542:12 | 5 | main.rs:542:5:542:12 | ... = ... |  |
-| main.rs:543:5:543:13 | print_i64 | main.rs:543:15:543:15 | a |  |
-| main.rs:543:5:543:19 | print_i64(...) | main.rs:544:5:544:18 | ExprStmt |  |
-| main.rs:543:5:543:20 | ExprStmt | main.rs:543:5:543:13 | print_i64 |  |
-| main.rs:543:15:543:15 | a | main.rs:543:17:543:17 | 1 |  |
-| main.rs:543:15:543:18 | a[1] | main.rs:543:5:543:19 | print_i64(...) |  |
-| main.rs:543:17:543:17 | 1 | main.rs:543:15:543:18 | a[1] |  |
-| main.rs:544:5:544:5 | a | main.rs:544:10:544:10 | 4 |  |
-| main.rs:544:5:544:17 | ... = ... | main.rs:545:5:545:20 | ExprStmt |  |
-| main.rs:544:5:544:18 | ExprStmt | main.rs:544:5:544:5 | a |  |
-| main.rs:544:9:544:17 | [...] | main.rs:544:5:544:17 | ... = ... |  |
-| main.rs:544:10:544:10 | 4 | main.rs:544:13:544:13 | 5 |  |
-| main.rs:544:13:544:13 | 5 | main.rs:544:16:544:16 | 6 |  |
-| main.rs:544:16:544:16 | 6 | main.rs:544:9:544:17 | [...] |  |
-| main.rs:545:5:545:13 | print_i64 | main.rs:545:15:545:15 | a |  |
-| main.rs:545:5:545:19 | print_i64(...) | main.rs:539:13:546:1 | { ... } |  |
-| main.rs:545:5:545:20 | ExprStmt | main.rs:545:5:545:13 | print_i64 |  |
-| main.rs:545:15:545:15 | a | main.rs:545:17:545:17 | 2 |  |
-| main.rs:545:15:545:18 | a[2] | main.rs:545:5:545:19 | print_i64(...) |  |
-| main.rs:545:17:545:17 | 2 | main.rs:545:15:545:18 | a[2] |  |
-| main.rs:548:1:555:1 | enter fn ref_arg | main.rs:549:5:549:15 | let ... = 16 |  |
-| main.rs:548:1:555:1 | exit fn ref_arg (normal) | main.rs:548:1:555:1 | exit fn ref_arg |  |
-| main.rs:548:14:555:1 | { ... } | main.rs:548:1:555:1 | exit fn ref_arg (normal) |  |
-| main.rs:549:5:549:15 | let ... = 16 | main.rs:549:13:549:14 | 16 |  |
-| main.rs:549:9:549:9 | x | main.rs:549:9:549:9 | x |  |
-| main.rs:549:9:549:9 | x | main.rs:550:5:550:22 | ExprStmt | match |
-| main.rs:549:13:549:14 | 16 | main.rs:549:9:549:9 | x |  |
-| main.rs:550:5:550:17 | print_i64_ref | main.rs:550:20:550:20 | x |  |
-| main.rs:550:5:550:21 | print_i64_ref(...) | main.rs:551:5:551:17 | ExprStmt |  |
-| main.rs:550:5:550:22 | ExprStmt | main.rs:550:5:550:17 | print_i64_ref |  |
-| main.rs:550:19:550:20 | &x | main.rs:550:5:550:21 | print_i64_ref(...) |  |
-| main.rs:550:20:550:20 | x | main.rs:550:19:550:20 | &x |  |
-| main.rs:551:5:551:13 | print_i64 | main.rs:551:15:551:15 | x |  |
-| main.rs:551:5:551:16 | print_i64(...) | main.rs:553:5:553:15 | let ... = 17 |  |
-| main.rs:551:5:551:17 | ExprStmt | main.rs:551:5:551:13 | print_i64 |  |
-| main.rs:551:15:551:15 | x | main.rs:551:5:551:16 | print_i64(...) |  |
-| main.rs:553:5:553:15 | let ... = 17 | main.rs:553:13:553:14 | 17 |  |
-| main.rs:553:9:553:9 | z | main.rs:553:9:553:9 | z |  |
-| main.rs:553:9:553:9 | z | main.rs:554:5:554:22 | ExprStmt | match |
-| main.rs:553:13:553:14 | 17 | main.rs:553:9:553:9 | z |  |
-| main.rs:554:5:554:17 | print_i64_ref | main.rs:554:20:554:20 | z |  |
-| main.rs:554:5:554:21 | print_i64_ref(...) | main.rs:548:14:555:1 | { ... } |  |
-| main.rs:554:5:554:22 | ExprStmt | main.rs:554:5:554:17 | print_i64_ref |  |
-| main.rs:554:19:554:20 | &z | main.rs:554:5:554:21 | print_i64_ref(...) |  |
-| main.rs:554:20:554:20 | z | main.rs:554:19:554:20 | &z |  |
-| main.rs:562:3:564:3 | enter fn bar | main.rs:562:15:562:18 | self |  |
-| main.rs:562:3:564:3 | exit fn bar (normal) | main.rs:562:3:564:3 | exit fn bar |  |
-| main.rs:562:10:562:18 | SelfParam | main.rs:563:5:563:32 | ExprStmt |  |
-| main.rs:562:15:562:18 | self | main.rs:562:10:562:18 | SelfParam |  |
-| main.rs:562:21:564:3 | { ... } | main.rs:562:3:564:3 | exit fn bar (normal) |  |
-| main.rs:563:5:563:9 | * ... | main.rs:563:29:563:29 | 3 |  |
-| main.rs:563:5:563:31 | ... = ... | main.rs:562:21:564:3 | { ... } |  |
-| main.rs:563:5:563:32 | ExprStmt | main.rs:563:6:563:9 | self |  |
-| main.rs:563:6:563:9 | self | main.rs:563:5:563:9 | * ... |  |
-| main.rs:563:13:563:31 | MyStruct {...} | main.rs:563:5:563:31 | ... = ... |  |
-| main.rs:563:29:563:29 | 3 | main.rs:563:13:563:31 | MyStruct {...} |  |
-| main.rs:567:1:572:1 | enter fn ref_methodcall_receiver | main.rs:568:3:568:34 | let ... = ... |  |
-| main.rs:567:1:572:1 | exit fn ref_methodcall_receiver (normal) | main.rs:567:1:572:1 | exit fn ref_methodcall_receiver |  |
-| main.rs:567:30:572:1 | { ... } | main.rs:567:1:572:1 | exit fn ref_methodcall_receiver (normal) |  |
-| main.rs:568:3:568:34 | let ... = ... | main.rs:568:31:568:31 | 1 |  |
-| main.rs:568:7:568:11 | mut a | main.rs:569:3:569:10 | ExprStmt | match |
-| main.rs:568:11:568:11 | a | main.rs:568:7:568:11 | mut a |  |
-| main.rs:568:15:568:33 | MyStruct {...} | main.rs:568:11:568:11 | a |  |
-| main.rs:568:31:568:31 | 1 | main.rs:568:15:568:33 | MyStruct {...} |  |
-| main.rs:569:3:569:3 | a | main.rs:569:3:569:9 | a.bar() |  |
-| main.rs:569:3:569:9 | a.bar() | main.rs:571:3:571:19 | ExprStmt |  |
-| main.rs:569:3:569:10 | ExprStmt | main.rs:569:3:569:3 | a |  |
-| main.rs:571:3:571:11 | print_i64 | main.rs:571:13:571:13 | a |  |
-| main.rs:571:3:571:18 | print_i64(...) | main.rs:567:30:572:1 | { ... } |  |
-| main.rs:571:3:571:19 | ExprStmt | main.rs:571:3:571:11 | print_i64 |  |
-| main.rs:571:13:571:13 | a | main.rs:571:13:571:17 | a.val |  |
-| main.rs:571:13:571:17 | a.val | main.rs:571:3:571:18 | print_i64(...) |  |
-| main.rs:592:1:602:1 | enter fn macro_invocation | main.rs:593:5:594:26 | let ... = ... |  |
-| main.rs:592:1:602:1 | exit fn macro_invocation (normal) | main.rs:592:1:602:1 | exit fn macro_invocation |  |
-| main.rs:592:23:602:1 | { ... } | main.rs:592:1:602:1 | exit fn macro_invocation (normal) |  |
-| main.rs:593:5:594:26 | let ... = ... | main.rs:594:23:594:24 | let ... = 37 |  |
-| main.rs:593:9:593:22 | var_from_macro | main.rs:593:9:593:22 | var_from_macro |  |
-| main.rs:593:9:593:22 | var_from_macro | main.rs:595:5:595:30 | ExprStmt | match |
-| main.rs:594:9:594:25 | MacroExpr | main.rs:593:9:593:22 | var_from_macro |  |
-| main.rs:594:9:594:25 | let_in_macro!... | main.rs:594:9:594:25 | MacroExpr |  |
-| main.rs:594:9:594:25 | var_in_macro | main.rs:594:9:594:25 | var_in_macro |  |
-| main.rs:594:9:594:25 | var_in_macro | main.rs:594:9:594:25 | var_in_macro | match |
-| main.rs:594:9:594:25 | var_in_macro | main.rs:594:23:594:24 | { ... } |  |
-| main.rs:594:23:594:24 | 37 | main.rs:594:9:594:25 | var_in_macro |  |
-| main.rs:594:23:594:24 | let ... = 37 | main.rs:594:23:594:24 | 37 |  |
-| main.rs:594:23:594:24 | { ... } | main.rs:594:9:594:25 | let_in_macro!... |  |
-| main.rs:595:5:595:13 | print_i64 | main.rs:595:15:595:28 | var_from_macro |  |
-| main.rs:595:5:595:29 | print_i64(...) | main.rs:596:5:596:26 | let ... = 33 |  |
-| main.rs:595:5:595:30 | ExprStmt | main.rs:595:5:595:13 | print_i64 |  |
-| main.rs:595:15:595:28 | var_from_macro | main.rs:595:5:595:29 | print_i64(...) |  |
-| main.rs:596:5:596:26 | let ... = 33 | main.rs:596:24:596:25 | 33 |  |
-| main.rs:596:9:596:20 | var_in_macro | main.rs:596:9:596:20 | var_in_macro |  |
-| main.rs:596:9:596:20 | var_in_macro | main.rs:600:5:600:44 | ExprStmt | match |
-| main.rs:596:24:596:25 | 33 | main.rs:596:9:596:20 | var_in_macro |  |
-| main.rs:600:5:600:13 | print_i64 | main.rs:600:15:600:42 | let ... = 0 |  |
-| main.rs:600:5:600:43 | print_i64(...) | main.rs:601:5:601:28 | ExprStmt |  |
-| main.rs:600:5:600:44 | ExprStmt | main.rs:600:5:600:13 | print_i64 |  |
-| main.rs:600:15:600:42 | 0 | main.rs:600:15:600:42 | var_in_macro |  |
-| main.rs:600:15:600:42 | MacroExpr | main.rs:600:5:600:43 | print_i64(...) |  |
-| main.rs:600:15:600:42 | let ... = 0 | main.rs:600:15:600:42 | 0 |  |
-| main.rs:600:15:600:42 | let_in_macro2!... | main.rs:600:15:600:42 | MacroExpr |  |
-| main.rs:600:15:600:42 | var_in_macro | main.rs:600:15:600:42 | var_in_macro |  |
-| main.rs:600:15:600:42 | var_in_macro | main.rs:600:30:600:41 | var_in_macro | match |
-| main.rs:600:30:600:41 | var_in_macro | main.rs:600:30:600:41 | { ... } |  |
-| main.rs:600:30:600:41 | { ... } | main.rs:600:15:600:42 | let_in_macro2!... |  |
-| main.rs:601:5:601:13 | print_i64 | main.rs:601:15:601:26 | var_in_macro |  |
-| main.rs:601:5:601:27 | print_i64(...) | main.rs:592:23:602:1 | { ... } |  |
-| main.rs:601:5:601:28 | ExprStmt | main.rs:601:5:601:13 | print_i64 |  |
-| main.rs:601:15:601:26 | var_in_macro | main.rs:601:5:601:27 | print_i64(...) |  |
-| main.rs:604:1:640:1 | enter fn main | main.rs:605:5:605:25 | ExprStmt |  |
-| main.rs:604:1:640:1 | exit fn main (normal) | main.rs:604:1:640:1 | exit fn main |  |
-| main.rs:604:11:640:1 | { ... } | main.rs:604:1:640:1 | exit fn main (normal) |  |
-| main.rs:605:5:605:22 | immutable_variable | main.rs:605:5:605:24 | immutable_variable(...) |  |
-| main.rs:605:5:605:24 | immutable_variable(...) | main.rs:606:5:606:23 | ExprStmt |  |
-| main.rs:605:5:605:25 | ExprStmt | main.rs:605:5:605:22 | immutable_variable |  |
-| main.rs:606:5:606:20 | mutable_variable | main.rs:606:5:606:22 | mutable_variable(...) |  |
-| main.rs:606:5:606:22 | mutable_variable(...) | main.rs:607:5:607:40 | ExprStmt |  |
-| main.rs:606:5:606:23 | ExprStmt | main.rs:606:5:606:20 | mutable_variable |  |
-| main.rs:607:5:607:37 | mutable_variable_immutable_borrow | main.rs:607:5:607:39 | mutable_variable_immutable_borrow(...) |  |
-| main.rs:607:5:607:39 | mutable_variable_immutable_borrow(...) | main.rs:608:5:608:23 | ExprStmt |  |
-| main.rs:607:5:607:40 | ExprStmt | main.rs:607:5:607:37 | mutable_variable_immutable_borrow |  |
-| main.rs:608:5:608:20 | variable_shadow1 | main.rs:608:5:608:22 | variable_shadow1(...) |  |
-| main.rs:608:5:608:22 | variable_shadow1(...) | main.rs:609:5:609:23 | ExprStmt |  |
-| main.rs:608:5:608:23 | ExprStmt | main.rs:608:5:608:20 | variable_shadow1 |  |
-| main.rs:609:5:609:20 | variable_shadow2 | main.rs:609:5:609:22 | variable_shadow2(...) |  |
-| main.rs:609:5:609:22 | variable_shadow2(...) | main.rs:610:5:610:19 | ExprStmt |  |
-| main.rs:609:5:609:23 | ExprStmt | main.rs:609:5:609:20 | variable_shadow2 |  |
-| main.rs:610:5:610:16 | let_pattern1 | main.rs:610:5:610:18 | let_pattern1(...) |  |
-| main.rs:610:5:610:18 | let_pattern1(...) | main.rs:611:5:611:19 | ExprStmt |  |
-| main.rs:610:5:610:19 | ExprStmt | main.rs:610:5:610:16 | let_pattern1 |  |
-| main.rs:611:5:611:16 | let_pattern2 | main.rs:611:5:611:18 | let_pattern2(...) |  |
-| main.rs:611:5:611:18 | let_pattern2(...) | main.rs:612:5:612:19 | ExprStmt |  |
-| main.rs:611:5:611:19 | ExprStmt | main.rs:611:5:611:16 | let_pattern2 |  |
-| main.rs:612:5:612:16 | let_pattern3 | main.rs:612:5:612:18 | let_pattern3(...) |  |
-| main.rs:612:5:612:18 | let_pattern3(...) | main.rs:613:5:613:19 | ExprStmt |  |
-| main.rs:612:5:612:19 | ExprStmt | main.rs:612:5:612:16 | let_pattern3 |  |
-| main.rs:613:5:613:16 | let_pattern4 | main.rs:613:5:613:18 | let_pattern4(...) |  |
-| main.rs:613:5:613:18 | let_pattern4(...) | main.rs:614:5:614:21 | ExprStmt |  |
-| main.rs:613:5:613:19 | ExprStmt | main.rs:613:5:613:16 | let_pattern4 |  |
-| main.rs:614:5:614:18 | match_pattern1 | main.rs:614:5:614:20 | match_pattern1(...) |  |
-| main.rs:614:5:614:20 | match_pattern1(...) | main.rs:615:5:615:21 | ExprStmt |  |
-| main.rs:614:5:614:21 | ExprStmt | main.rs:614:5:614:18 | match_pattern1 |  |
-| main.rs:615:5:615:18 | match_pattern2 | main.rs:615:5:615:20 | match_pattern2(...) |  |
-| main.rs:615:5:615:20 | match_pattern2(...) | main.rs:616:5:616:21 | ExprStmt |  |
-| main.rs:615:5:615:21 | ExprStmt | main.rs:615:5:615:18 | match_pattern2 |  |
-| main.rs:616:5:616:18 | match_pattern3 | main.rs:616:5:616:20 | match_pattern3(...) |  |
-| main.rs:616:5:616:20 | match_pattern3(...) | main.rs:617:5:617:21 | ExprStmt |  |
-| main.rs:616:5:616:21 | ExprStmt | main.rs:616:5:616:18 | match_pattern3 |  |
-| main.rs:617:5:617:18 | match_pattern4 | main.rs:617:5:617:20 | match_pattern4(...) |  |
-| main.rs:617:5:617:20 | match_pattern4(...) | main.rs:618:5:618:21 | ExprStmt |  |
-| main.rs:617:5:617:21 | ExprStmt | main.rs:617:5:617:18 | match_pattern4 |  |
-| main.rs:618:5:618:18 | match_pattern5 | main.rs:618:5:618:20 | match_pattern5(...) |  |
-| main.rs:618:5:618:20 | match_pattern5(...) | main.rs:619:5:619:21 | ExprStmt |  |
-| main.rs:618:5:618:21 | ExprStmt | main.rs:618:5:618:18 | match_pattern5 |  |
-| main.rs:619:5:619:18 | match_pattern6 | main.rs:619:5:619:20 | match_pattern6(...) |  |
-| main.rs:619:5:619:20 | match_pattern6(...) | main.rs:620:5:620:21 | ExprStmt |  |
-| main.rs:619:5:619:21 | ExprStmt | main.rs:619:5:619:18 | match_pattern6 |  |
-| main.rs:620:5:620:18 | match_pattern7 | main.rs:620:5:620:20 | match_pattern7(...) |  |
-| main.rs:620:5:620:20 | match_pattern7(...) | main.rs:621:5:621:21 | ExprStmt |  |
-| main.rs:620:5:620:21 | ExprStmt | main.rs:620:5:620:18 | match_pattern7 |  |
-| main.rs:621:5:621:18 | match_pattern8 | main.rs:621:5:621:20 | match_pattern8(...) |  |
-| main.rs:621:5:621:20 | match_pattern8(...) | main.rs:622:5:622:21 | ExprStmt |  |
-| main.rs:621:5:621:21 | ExprStmt | main.rs:621:5:621:18 | match_pattern8 |  |
-| main.rs:622:5:622:18 | match_pattern9 | main.rs:622:5:622:20 | match_pattern9(...) |  |
-| main.rs:622:5:622:20 | match_pattern9(...) | main.rs:623:5:623:36 | ExprStmt |  |
-| main.rs:622:5:622:21 | ExprStmt | main.rs:622:5:622:18 | match_pattern9 |  |
-| main.rs:623:5:623:18 | param_pattern1 | main.rs:623:20:623:22 | "a" |  |
-| main.rs:623:5:623:35 | param_pattern1(...) | main.rs:624:5:624:37 | ExprStmt |  |
-| main.rs:623:5:623:36 | ExprStmt | main.rs:623:5:623:18 | param_pattern1 |  |
-| main.rs:623:20:623:22 | "a" | main.rs:623:26:623:28 | "b" |  |
-| main.rs:623:25:623:34 | TupleExpr | main.rs:623:5:623:35 | param_pattern1(...) |  |
-| main.rs:623:26:623:28 | "b" | main.rs:623:31:623:33 | "c" |  |
-| main.rs:623:31:623:33 | "c" | main.rs:623:25:623:34 | TupleExpr |  |
-| main.rs:624:5:624:18 | param_pattern2 | main.rs:624:20:624:31 | ...::Left |  |
-| main.rs:624:5:624:36 | param_pattern2(...) | main.rs:625:5:625:26 | ExprStmt |  |
-| main.rs:624:5:624:37 | ExprStmt | main.rs:624:5:624:18 | param_pattern2 |  |
-| main.rs:624:20:624:31 | ...::Left | main.rs:624:33:624:34 | 45 |  |
-| main.rs:624:20:624:35 | ...::Left(...) | main.rs:624:5:624:36 | param_pattern2(...) |  |
-| main.rs:624:33:624:34 | 45 | main.rs:624:20:624:35 | ...::Left(...) |  |
-| main.rs:625:5:625:23 | destruct_assignment | main.rs:625:5:625:25 | destruct_assignment(...) |  |
-| main.rs:625:5:625:25 | destruct_assignment(...) | main.rs:626:5:626:23 | ExprStmt |  |
-| main.rs:625:5:625:26 | ExprStmt | main.rs:625:5:625:23 | destruct_assignment |  |
-| main.rs:626:5:626:20 | closure_variable | main.rs:626:5:626:22 | closure_variable(...) |  |
-| main.rs:626:5:626:22 | closure_variable(...) | main.rs:627:5:627:22 | ExprStmt |  |
-| main.rs:626:5:626:23 | ExprStmt | main.rs:626:5:626:20 | closure_variable |  |
-| main.rs:627:5:627:19 | nested_function | main.rs:627:5:627:21 | nested_function(...) |  |
-| main.rs:627:5:627:21 | nested_function(...) | main.rs:628:5:628:19 | ExprStmt |  |
-| main.rs:627:5:627:22 | ExprStmt | main.rs:627:5:627:19 | nested_function |  |
-| main.rs:628:5:628:16 | for_variable | main.rs:628:5:628:18 | for_variable(...) |  |
-| main.rs:628:5:628:18 | for_variable(...) | main.rs:629:5:629:17 | ExprStmt |  |
-| main.rs:628:5:628:19 | ExprStmt | main.rs:628:5:628:16 | for_variable |  |
-| main.rs:629:5:629:14 | add_assign | main.rs:629:5:629:16 | add_assign(...) |  |
-| main.rs:629:5:629:16 | add_assign(...) | main.rs:630:5:630:13 | ExprStmt |  |
-| main.rs:629:5:629:17 | ExprStmt | main.rs:629:5:629:14 | add_assign |  |
-| main.rs:630:5:630:10 | mutate | main.rs:630:5:630:12 | mutate(...) |  |
-| main.rs:630:5:630:12 | mutate(...) | main.rs:631:5:631:17 | ExprStmt |  |
-| main.rs:630:5:630:13 | ExprStmt | main.rs:630:5:630:10 | mutate |  |
-| main.rs:631:5:631:14 | mutate_arg | main.rs:631:5:631:16 | mutate_arg(...) |  |
-| main.rs:631:5:631:16 | mutate_arg(...) | main.rs:632:5:632:12 | ExprStmt |  |
-| main.rs:631:5:631:17 | ExprStmt | main.rs:631:5:631:14 | mutate_arg |  |
-| main.rs:632:5:632:9 | alias | main.rs:632:5:632:11 | alias(...) |  |
-| main.rs:632:5:632:11 | alias(...) | main.rs:633:5:633:18 | ExprStmt |  |
-| main.rs:632:5:632:12 | ExprStmt | main.rs:632:5:632:9 | alias |  |
-| main.rs:633:5:633:15 | capture_mut | main.rs:633:5:633:17 | capture_mut(...) |  |
-| main.rs:633:5:633:17 | capture_mut(...) | main.rs:634:5:634:20 | ExprStmt |  |
-| main.rs:633:5:633:18 | ExprStmt | main.rs:633:5:633:15 | capture_mut |  |
-| main.rs:634:5:634:17 | capture_immut | main.rs:634:5:634:19 | capture_immut(...) |  |
-| main.rs:634:5:634:19 | capture_immut(...) | main.rs:635:5:635:26 | ExprStmt |  |
-| main.rs:634:5:634:20 | ExprStmt | main.rs:634:5:634:17 | capture_immut |  |
-| main.rs:635:5:635:23 | async_block_capture | main.rs:635:5:635:25 | async_block_capture(...) |  |
-| main.rs:635:5:635:25 | async_block_capture(...) | main.rs:636:5:636:14 | ExprStmt |  |
-| main.rs:635:5:635:26 | ExprStmt | main.rs:635:5:635:23 | async_block_capture |  |
-| main.rs:636:5:636:11 | structs | main.rs:636:5:636:13 | structs(...) |  |
-| main.rs:636:5:636:13 | structs(...) | main.rs:637:5:637:14 | ExprStmt |  |
-| main.rs:636:5:636:14 | ExprStmt | main.rs:636:5:636:11 | structs |  |
-| main.rs:637:5:637:11 | ref_arg | main.rs:637:5:637:13 | ref_arg(...) |  |
-| main.rs:637:5:637:13 | ref_arg(...) | main.rs:638:5:638:30 | ExprStmt |  |
-| main.rs:637:5:637:14 | ExprStmt | main.rs:637:5:637:11 | ref_arg |  |
-| main.rs:638:5:638:27 | ref_methodcall_receiver | main.rs:638:5:638:29 | ref_methodcall_receiver(...) |  |
-| main.rs:638:5:638:29 | ref_methodcall_receiver(...) | main.rs:639:5:639:23 | ExprStmt |  |
-| main.rs:638:5:638:30 | ExprStmt | main.rs:638:5:638:27 | ref_methodcall_receiver |  |
-| main.rs:639:5:639:20 | macro_invocation | main.rs:639:5:639:22 | macro_invocation(...) |  |
-| main.rs:639:5:639:22 | macro_invocation(...) | main.rs:604:11:640:1 | { ... } |  |
-| main.rs:639:5:639:23 | ExprStmt | main.rs:639:5:639:20 | macro_invocation |  |
+| main.rs:502:9:502:24 | print_i64(...) | main.rs:499:12:503:5 | { ... } |  |
+| main.rs:502:9:502:25 | ExprStmt | main.rs:502:9:502:17 | print_i64 |  |
+| main.rs:502:19:502:19 | x | main.rs:502:23:502:23 | 1 |  |
+| main.rs:502:19:502:23 | ... + ... | main.rs:502:9:502:24 | print_i64(...) |  |
+| main.rs:502:23:502:23 | 1 | main.rs:502:19:502:23 | ... + ... |  |
+| main.rs:504:5:504:13 | print_i64 | main.rs:504:15:504:15 | x |  |
+| main.rs:504:5:504:16 | print_i64(...) | main.rs:489:17:505:1 | { ... } |  |
+| main.rs:504:5:504:17 | ExprStmt | main.rs:504:5:504:13 | print_i64 |  |
+| main.rs:504:15:504:15 | x | main.rs:504:5:504:16 | print_i64(...) |  |
+| main.rs:507:1:524:1 | enter fn phi_read | main.rs:507:13:507:14 | b1 |  |
+| main.rs:507:1:524:1 | exit fn phi_read (normal) | main.rs:507:1:524:1 | exit fn phi_read |  |
+| main.rs:507:13:507:14 | b1 | main.rs:507:13:507:14 | b1 |  |
+| main.rs:507:13:507:14 | b1 | main.rs:507:13:507:20 | ...: bool | match |
+| main.rs:507:13:507:20 | ...: bool | main.rs:507:23:507:24 | b2 |  |
+| main.rs:507:23:507:24 | b2 | main.rs:507:23:507:24 | b2 |  |
+| main.rs:507:23:507:24 | b2 | main.rs:507:23:507:30 | ...: bool | match |
+| main.rs:507:23:507:30 | ...: bool | main.rs:508:5:508:14 | let ... = 1 |  |
+| main.rs:507:33:524:1 | { ... } | main.rs:507:1:524:1 | exit fn phi_read (normal) |  |
+| main.rs:508:5:508:14 | let ... = 1 | main.rs:508:13:508:13 | 1 |  |
+| main.rs:508:9:508:9 | x | main.rs:508:9:508:9 | x |  |
+| main.rs:508:9:508:9 | x | main.rs:509:5:515:6 | let _ = ... | match |
+| main.rs:508:13:508:13 | 1 | main.rs:508:9:508:9 | x |  |
+| main.rs:509:5:515:6 | let _ = ... | main.rs:510:16:510:17 | b1 |  |
+| main.rs:510:9:510:9 | _ | main.rs:517:5:523:6 | let _ = ... | match |
+| main.rs:510:13:515:5 | if b1 {...} else {...} | main.rs:510:9:510:9 | _ |  |
+| main.rs:510:16:510:17 | b1 | main.rs:512:9:512:21 | ExprStmt | true |
+| main.rs:510:16:510:17 | b1 | main.rs:514:9:514:21 | ExprStmt | false |
+| main.rs:511:5:513:5 | { ... } | main.rs:510:13:515:5 | if b1 {...} else {...} |  |
+| main.rs:512:9:512:17 | print_i64 | main.rs:512:19:512:19 | x |  |
+| main.rs:512:9:512:20 | print_i64(...) | main.rs:511:5:513:5 | { ... } |  |
+| main.rs:512:9:512:21 | ExprStmt | main.rs:512:9:512:17 | print_i64 |  |
+| main.rs:512:19:512:19 | x | main.rs:512:9:512:20 | print_i64(...) |  |
+| main.rs:513:12:515:5 | { ... } | main.rs:510:13:515:5 | if b1 {...} else {...} |  |
+| main.rs:514:9:514:17 | print_i64 | main.rs:514:19:514:19 | x |  |
+| main.rs:514:9:514:20 | print_i64(...) | main.rs:513:12:515:5 | { ... } |  |
+| main.rs:514:9:514:21 | ExprStmt | main.rs:514:9:514:17 | print_i64 |  |
+| main.rs:514:19:514:19 | x | main.rs:514:9:514:20 | print_i64(...) |  |
+| main.rs:517:5:523:6 | let _ = ... | main.rs:518:16:518:17 | b2 |  |
+| main.rs:518:9:518:9 | _ | main.rs:507:33:524:1 | { ... } | match |
+| main.rs:518:13:523:5 | if b2 {...} else {...} | main.rs:518:9:518:9 | _ |  |
+| main.rs:518:16:518:17 | b2 | main.rs:520:9:520:21 | ExprStmt | true |
+| main.rs:518:16:518:17 | b2 | main.rs:522:9:522:21 | ExprStmt | false |
+| main.rs:519:5:521:5 | { ... } | main.rs:518:13:523:5 | if b2 {...} else {...} |  |
+| main.rs:520:9:520:17 | print_i64 | main.rs:520:19:520:19 | x |  |
+| main.rs:520:9:520:20 | print_i64(...) | main.rs:519:5:521:5 | { ... } |  |
+| main.rs:520:9:520:21 | ExprStmt | main.rs:520:9:520:17 | print_i64 |  |
+| main.rs:520:19:520:19 | x | main.rs:520:9:520:20 | print_i64(...) |  |
+| main.rs:521:12:523:5 | { ... } | main.rs:518:13:523:5 | if b2 {...} else {...} |  |
+| main.rs:522:9:522:17 | print_i64 | main.rs:522:19:522:19 | x |  |
+| main.rs:522:9:522:20 | print_i64(...) | main.rs:521:12:523:5 | { ... } |  |
+| main.rs:522:9:522:21 | ExprStmt | main.rs:522:9:522:17 | print_i64 |  |
+| main.rs:522:19:522:19 | x | main.rs:522:9:522:20 | print_i64(...) |  |
+| main.rs:531:5:533:5 | enter fn my_get | main.rs:531:20:531:23 | self |  |
+| main.rs:531:5:533:5 | exit fn my_get (normal) | main.rs:531:5:533:5 | exit fn my_get |  |
+| main.rs:531:15:531:23 | SelfParam | main.rs:532:9:532:24 | ExprStmt |  |
+| main.rs:531:20:531:23 | self | main.rs:531:15:531:23 | SelfParam |  |
+| main.rs:532:9:532:23 | return ... | main.rs:531:5:533:5 | exit fn my_get (normal) | return |
+| main.rs:532:9:532:24 | ExprStmt | main.rs:532:16:532:19 | self |  |
+| main.rs:532:16:532:19 | self | main.rs:532:16:532:23 | self.val |  |
+| main.rs:532:16:532:23 | self.val | main.rs:532:9:532:23 | return ... |  |
+| main.rs:535:5:537:5 | enter fn id | main.rs:535:11:535:14 | self |  |
+| main.rs:535:5:537:5 | exit fn id (normal) | main.rs:535:5:537:5 | exit fn id |  |
+| main.rs:535:11:535:14 | SelfParam | main.rs:536:9:536:12 | self |  |
+| main.rs:535:11:535:14 | self | main.rs:535:11:535:14 | SelfParam |  |
+| main.rs:535:25:537:5 | { ... } | main.rs:535:5:537:5 | exit fn id (normal) |  |
+| main.rs:536:9:536:12 | self | main.rs:535:25:537:5 | { ... } |  |
+| main.rs:539:5:546:5 | enter fn my_method | main.rs:539:23:539:26 | self |  |
+| main.rs:539:5:546:5 | exit fn my_method (normal) | main.rs:539:5:546:5 | exit fn my_method |  |
+| main.rs:539:18:539:26 | SelfParam | main.rs:540:9:543:10 | let ... = ... |  |
+| main.rs:539:23:539:26 | self | main.rs:539:18:539:26 | SelfParam |  |
+| main.rs:539:29:546:5 | { ... } | main.rs:539:5:546:5 | exit fn my_method (normal) |  |
+| main.rs:540:9:543:10 | let ... = ... | main.rs:540:21:543:9 | \|...\| ... |  |
+| main.rs:540:13:540:17 | mut f | main.rs:544:9:544:13 | ExprStmt | match |
+| main.rs:540:17:540:17 | f | main.rs:540:13:540:17 | mut f |  |
+| main.rs:540:21:543:9 | \|...\| ... | main.rs:540:17:540:17 | f |  |
+| main.rs:540:21:543:9 | enter \|...\| ... | main.rs:540:22:540:22 | n |  |
+| main.rs:540:21:543:9 | exit \|...\| ... (normal) | main.rs:540:21:543:9 | exit \|...\| ... |  |
+| main.rs:540:22:540:22 | ... | main.rs:542:13:542:26 | ExprStmt |  |
+| main.rs:540:22:540:22 | n | main.rs:540:22:540:22 | ... | match |
+| main.rs:540:22:540:22 | n | main.rs:540:22:540:22 | n |  |
+| main.rs:540:25:543:9 | { ... } | main.rs:540:21:543:9 | exit \|...\| ... (normal) |  |
+| main.rs:542:13:542:16 | self | main.rs:542:13:542:20 | self.val |  |
+| main.rs:542:13:542:20 | self.val | main.rs:542:25:542:25 | n |  |
+| main.rs:542:13:542:25 | ... += ... | main.rs:540:25:543:9 | { ... } |  |
+| main.rs:542:13:542:26 | ExprStmt | main.rs:542:13:542:16 | self |  |
+| main.rs:542:25:542:25 | n | main.rs:542:13:542:25 | ... += ... |  |
+| main.rs:544:9:544:9 | f | main.rs:544:11:544:11 | 3 |  |
+| main.rs:544:9:544:12 | f(...) | main.rs:545:9:545:13 | ExprStmt |  |
+| main.rs:544:9:544:13 | ExprStmt | main.rs:544:9:544:9 | f |  |
+| main.rs:544:11:544:11 | 3 | main.rs:544:9:544:12 | f(...) |  |
+| main.rs:545:9:545:9 | f | main.rs:545:11:545:11 | 4 |  |
+| main.rs:545:9:545:12 | f(...) | main.rs:539:29:546:5 | { ... } |  |
+| main.rs:545:9:545:13 | ExprStmt | main.rs:545:9:545:9 | f |  |
+| main.rs:545:11:545:11 | 4 | main.rs:545:9:545:12 | f(...) |  |
+| main.rs:549:1:556:1 | enter fn structs | main.rs:550:5:550:36 | let ... = ... |  |
+| main.rs:549:1:556:1 | exit fn structs (normal) | main.rs:549:1:556:1 | exit fn structs |  |
+| main.rs:549:14:556:1 | { ... } | main.rs:549:1:556:1 | exit fn structs (normal) |  |
+| main.rs:550:5:550:36 | let ... = ... | main.rs:550:33:550:33 | 1 |  |
+| main.rs:550:9:550:13 | mut a | main.rs:551:5:551:26 | ExprStmt | match |
+| main.rs:550:13:550:13 | a | main.rs:550:9:550:13 | mut a |  |
+| main.rs:550:17:550:35 | MyStruct {...} | main.rs:550:13:550:13 | a |  |
+| main.rs:550:33:550:33 | 1 | main.rs:550:17:550:35 | MyStruct {...} |  |
+| main.rs:551:5:551:13 | print_i64 | main.rs:551:15:551:15 | a |  |
+| main.rs:551:5:551:25 | print_i64(...) | main.rs:552:5:552:14 | ExprStmt |  |
+| main.rs:551:5:551:26 | ExprStmt | main.rs:551:5:551:13 | print_i64 |  |
+| main.rs:551:15:551:15 | a | main.rs:551:15:551:24 | a.my_get() |  |
+| main.rs:551:15:551:24 | a.my_get() | main.rs:551:5:551:25 | print_i64(...) |  |
+| main.rs:552:5:552:5 | a | main.rs:552:5:552:9 | a.val |  |
+| main.rs:552:5:552:9 | a.val | main.rs:552:13:552:13 | 5 |  |
+| main.rs:552:5:552:13 | ... = ... | main.rs:553:5:553:26 | ExprStmt |  |
+| main.rs:552:5:552:14 | ExprStmt | main.rs:552:5:552:5 | a |  |
+| main.rs:552:13:552:13 | 5 | main.rs:552:5:552:13 | ... = ... |  |
+| main.rs:553:5:553:13 | print_i64 | main.rs:553:15:553:15 | a |  |
+| main.rs:553:5:553:25 | print_i64(...) | main.rs:554:5:554:28 | ExprStmt |  |
+| main.rs:553:5:553:26 | ExprStmt | main.rs:553:5:553:13 | print_i64 |  |
+| main.rs:553:15:553:15 | a | main.rs:553:15:553:24 | a.my_get() |  |
+| main.rs:553:15:553:24 | a.my_get() | main.rs:553:5:553:25 | print_i64(...) |  |
+| main.rs:554:5:554:5 | a | main.rs:554:25:554:25 | 2 |  |
+| main.rs:554:5:554:27 | ... = ... | main.rs:555:5:555:26 | ExprStmt |  |
+| main.rs:554:5:554:28 | ExprStmt | main.rs:554:5:554:5 | a |  |
+| main.rs:554:9:554:27 | MyStruct {...} | main.rs:554:5:554:27 | ... = ... |  |
+| main.rs:554:25:554:25 | 2 | main.rs:554:9:554:27 | MyStruct {...} |  |
+| main.rs:555:5:555:13 | print_i64 | main.rs:555:15:555:15 | a |  |
+| main.rs:555:5:555:25 | print_i64(...) | main.rs:549:14:556:1 | { ... } |  |
+| main.rs:555:5:555:26 | ExprStmt | main.rs:555:5:555:13 | print_i64 |  |
+| main.rs:555:15:555:15 | a | main.rs:555:15:555:24 | a.my_get() |  |
+| main.rs:555:15:555:24 | a.my_get() | main.rs:555:5:555:25 | print_i64(...) |  |
+| main.rs:558:1:565:1 | enter fn arrays | main.rs:559:5:559:26 | let ... = ... |  |
+| main.rs:558:1:565:1 | exit fn arrays (normal) | main.rs:558:1:565:1 | exit fn arrays |  |
+| main.rs:558:13:565:1 | { ... } | main.rs:558:1:565:1 | exit fn arrays (normal) |  |
+| main.rs:559:5:559:26 | let ... = ... | main.rs:559:18:559:18 | 1 |  |
+| main.rs:559:9:559:13 | mut a | main.rs:560:5:560:20 | ExprStmt | match |
+| main.rs:559:13:559:13 | a | main.rs:559:9:559:13 | mut a |  |
+| main.rs:559:17:559:25 | [...] | main.rs:559:13:559:13 | a |  |
+| main.rs:559:18:559:18 | 1 | main.rs:559:21:559:21 | 2 |  |
+| main.rs:559:21:559:21 | 2 | main.rs:559:24:559:24 | 3 |  |
+| main.rs:559:24:559:24 | 3 | main.rs:559:17:559:25 | [...] |  |
+| main.rs:560:5:560:13 | print_i64 | main.rs:560:15:560:15 | a |  |
+| main.rs:560:5:560:19 | print_i64(...) | main.rs:561:5:561:13 | ExprStmt |  |
+| main.rs:560:5:560:20 | ExprStmt | main.rs:560:5:560:13 | print_i64 |  |
+| main.rs:560:15:560:15 | a | main.rs:560:17:560:17 | 0 |  |
+| main.rs:560:15:560:18 | a[0] | main.rs:560:5:560:19 | print_i64(...) |  |
+| main.rs:560:17:560:17 | 0 | main.rs:560:15:560:18 | a[0] |  |
+| main.rs:561:5:561:5 | a | main.rs:561:7:561:7 | 1 |  |
+| main.rs:561:5:561:8 | a[1] | main.rs:561:12:561:12 | 5 |  |
+| main.rs:561:5:561:12 | ... = ... | main.rs:562:5:562:20 | ExprStmt |  |
+| main.rs:561:5:561:13 | ExprStmt | main.rs:561:5:561:5 | a |  |
+| main.rs:561:7:561:7 | 1 | main.rs:561:5:561:8 | a[1] |  |
+| main.rs:561:12:561:12 | 5 | main.rs:561:5:561:12 | ... = ... |  |
+| main.rs:562:5:562:13 | print_i64 | main.rs:562:15:562:15 | a |  |
+| main.rs:562:5:562:19 | print_i64(...) | main.rs:563:5:563:18 | ExprStmt |  |
+| main.rs:562:5:562:20 | ExprStmt | main.rs:562:5:562:13 | print_i64 |  |
+| main.rs:562:15:562:15 | a | main.rs:562:17:562:17 | 1 |  |
+| main.rs:562:15:562:18 | a[1] | main.rs:562:5:562:19 | print_i64(...) |  |
+| main.rs:562:17:562:17 | 1 | main.rs:562:15:562:18 | a[1] |  |
+| main.rs:563:5:563:5 | a | main.rs:563:10:563:10 | 4 |  |
+| main.rs:563:5:563:17 | ... = ... | main.rs:564:5:564:20 | ExprStmt |  |
+| main.rs:563:5:563:18 | ExprStmt | main.rs:563:5:563:5 | a |  |
+| main.rs:563:9:563:17 | [...] | main.rs:563:5:563:17 | ... = ... |  |
+| main.rs:563:10:563:10 | 4 | main.rs:563:13:563:13 | 5 |  |
+| main.rs:563:13:563:13 | 5 | main.rs:563:16:563:16 | 6 |  |
+| main.rs:563:16:563:16 | 6 | main.rs:563:9:563:17 | [...] |  |
+| main.rs:564:5:564:13 | print_i64 | main.rs:564:15:564:15 | a |  |
+| main.rs:564:5:564:19 | print_i64(...) | main.rs:558:13:565:1 | { ... } |  |
+| main.rs:564:5:564:20 | ExprStmt | main.rs:564:5:564:13 | print_i64 |  |
+| main.rs:564:15:564:15 | a | main.rs:564:17:564:17 | 2 |  |
+| main.rs:564:15:564:18 | a[2] | main.rs:564:5:564:19 | print_i64(...) |  |
+| main.rs:564:17:564:17 | 2 | main.rs:564:15:564:18 | a[2] |  |
+| main.rs:567:1:574:1 | enter fn ref_arg | main.rs:568:5:568:15 | let ... = 16 |  |
+| main.rs:567:1:574:1 | exit fn ref_arg (normal) | main.rs:567:1:574:1 | exit fn ref_arg |  |
+| main.rs:567:14:574:1 | { ... } | main.rs:567:1:574:1 | exit fn ref_arg (normal) |  |
+| main.rs:568:5:568:15 | let ... = 16 | main.rs:568:13:568:14 | 16 |  |
+| main.rs:568:9:568:9 | x | main.rs:568:9:568:9 | x |  |
+| main.rs:568:9:568:9 | x | main.rs:569:5:569:22 | ExprStmt | match |
+| main.rs:568:13:568:14 | 16 | main.rs:568:9:568:9 | x |  |
+| main.rs:569:5:569:17 | print_i64_ref | main.rs:569:20:569:20 | x |  |
+| main.rs:569:5:569:21 | print_i64_ref(...) | main.rs:570:5:570:17 | ExprStmt |  |
+| main.rs:569:5:569:22 | ExprStmt | main.rs:569:5:569:17 | print_i64_ref |  |
+| main.rs:569:19:569:20 | &x | main.rs:569:5:569:21 | print_i64_ref(...) |  |
+| main.rs:569:20:569:20 | x | main.rs:569:19:569:20 | &x |  |
+| main.rs:570:5:570:13 | print_i64 | main.rs:570:15:570:15 | x |  |
+| main.rs:570:5:570:16 | print_i64(...) | main.rs:572:5:572:15 | let ... = 17 |  |
+| main.rs:570:5:570:17 | ExprStmt | main.rs:570:5:570:13 | print_i64 |  |
+| main.rs:570:15:570:15 | x | main.rs:570:5:570:16 | print_i64(...) |  |
+| main.rs:572:5:572:15 | let ... = 17 | main.rs:572:13:572:14 | 17 |  |
+| main.rs:572:9:572:9 | z | main.rs:572:9:572:9 | z |  |
+| main.rs:572:9:572:9 | z | main.rs:573:5:573:22 | ExprStmt | match |
+| main.rs:572:13:572:14 | 17 | main.rs:572:9:572:9 | z |  |
+| main.rs:573:5:573:17 | print_i64_ref | main.rs:573:20:573:20 | z |  |
+| main.rs:573:5:573:21 | print_i64_ref(...) | main.rs:567:14:574:1 | { ... } |  |
+| main.rs:573:5:573:22 | ExprStmt | main.rs:573:5:573:17 | print_i64_ref |  |
+| main.rs:573:19:573:20 | &z | main.rs:573:5:573:21 | print_i64_ref(...) |  |
+| main.rs:573:20:573:20 | z | main.rs:573:19:573:20 | &z |  |
+| main.rs:581:5:583:5 | enter fn bar | main.rs:581:17:581:20 | self |  |
+| main.rs:581:5:583:5 | exit fn bar (normal) | main.rs:581:5:583:5 | exit fn bar |  |
+| main.rs:581:12:581:20 | SelfParam | main.rs:582:9:582:36 | ExprStmt |  |
+| main.rs:581:17:581:20 | self | main.rs:581:12:581:20 | SelfParam |  |
+| main.rs:581:23:583:5 | { ... } | main.rs:581:5:583:5 | exit fn bar (normal) |  |
+| main.rs:582:9:582:13 | * ... | main.rs:582:33:582:33 | 3 |  |
+| main.rs:582:9:582:35 | ... = ... | main.rs:581:23:583:5 | { ... } |  |
+| main.rs:582:9:582:36 | ExprStmt | main.rs:582:10:582:13 | self |  |
+| main.rs:582:10:582:13 | self | main.rs:582:9:582:13 | * ... |  |
+| main.rs:582:17:582:35 | MyStruct {...} | main.rs:582:9:582:35 | ... = ... |  |
+| main.rs:582:33:582:33 | 3 | main.rs:582:17:582:35 | MyStruct {...} |  |
+| main.rs:586:1:591:1 | enter fn ref_methodcall_receiver | main.rs:587:5:587:36 | let ... = ... |  |
+| main.rs:586:1:591:1 | exit fn ref_methodcall_receiver (normal) | main.rs:586:1:591:1 | exit fn ref_methodcall_receiver |  |
+| main.rs:586:30:591:1 | { ... } | main.rs:586:1:591:1 | exit fn ref_methodcall_receiver (normal) |  |
+| main.rs:587:5:587:36 | let ... = ... | main.rs:587:33:587:33 | 1 |  |
+| main.rs:587:9:587:13 | mut a | main.rs:588:5:588:12 | ExprStmt | match |
+| main.rs:587:13:587:13 | a | main.rs:587:9:587:13 | mut a |  |
+| main.rs:587:17:587:35 | MyStruct {...} | main.rs:587:13:587:13 | a |  |
+| main.rs:587:33:587:33 | 1 | main.rs:587:17:587:35 | MyStruct {...} |  |
+| main.rs:588:5:588:5 | a | main.rs:588:5:588:11 | a.bar() |  |
+| main.rs:588:5:588:11 | a.bar() | main.rs:590:5:590:21 | ExprStmt |  |
+| main.rs:588:5:588:12 | ExprStmt | main.rs:588:5:588:5 | a |  |
+| main.rs:590:5:590:13 | print_i64 | main.rs:590:15:590:15 | a |  |
+| main.rs:590:5:590:20 | print_i64(...) | main.rs:586:30:591:1 | { ... } |  |
+| main.rs:590:5:590:21 | ExprStmt | main.rs:590:5:590:13 | print_i64 |  |
+| main.rs:590:15:590:15 | a | main.rs:590:15:590:19 | a.val |  |
+| main.rs:590:15:590:19 | a.val | main.rs:590:5:590:20 | print_i64(...) |  |
+| main.rs:607:1:617:1 | enter fn macro_invocation | main.rs:608:5:609:26 | let ... = ... |  |
+| main.rs:607:1:617:1 | exit fn macro_invocation (normal) | main.rs:607:1:617:1 | exit fn macro_invocation |  |
+| main.rs:607:23:617:1 | { ... } | main.rs:607:1:617:1 | exit fn macro_invocation (normal) |  |
+| main.rs:608:5:609:26 | let ... = ... | main.rs:609:23:609:24 | let ... = 37 |  |
+| main.rs:608:9:608:22 | var_from_macro | main.rs:608:9:608:22 | var_from_macro |  |
+| main.rs:608:9:608:22 | var_from_macro | main.rs:610:5:610:30 | ExprStmt | match |
+| main.rs:609:9:609:25 | MacroExpr | main.rs:608:9:608:22 | var_from_macro |  |
+| main.rs:609:9:609:25 | let_in_macro!... | main.rs:609:9:609:25 | MacroExpr |  |
+| main.rs:609:9:609:25 | var_in_macro | main.rs:609:9:609:25 | var_in_macro |  |
+| main.rs:609:9:609:25 | var_in_macro | main.rs:609:9:609:25 | var_in_macro | match |
+| main.rs:609:9:609:25 | var_in_macro | main.rs:609:23:609:24 | { ... } |  |
+| main.rs:609:23:609:24 | 37 | main.rs:609:9:609:25 | var_in_macro |  |
+| main.rs:609:23:609:24 | let ... = 37 | main.rs:609:23:609:24 | 37 |  |
+| main.rs:609:23:609:24 | { ... } | main.rs:609:9:609:25 | let_in_macro!... |  |
+| main.rs:610:5:610:13 | print_i64 | main.rs:610:15:610:28 | var_from_macro |  |
+| main.rs:610:5:610:29 | print_i64(...) | main.rs:611:5:611:26 | let ... = 33 |  |
+| main.rs:610:5:610:30 | ExprStmt | main.rs:610:5:610:13 | print_i64 |  |
+| main.rs:610:15:610:28 | var_from_macro | main.rs:610:5:610:29 | print_i64(...) |  |
+| main.rs:611:5:611:26 | let ... = 33 | main.rs:611:24:611:25 | 33 |  |
+| main.rs:611:9:611:20 | var_in_macro | main.rs:611:9:611:20 | var_in_macro |  |
+| main.rs:611:9:611:20 | var_in_macro | main.rs:615:5:615:44 | ExprStmt | match |
+| main.rs:611:24:611:25 | 33 | main.rs:611:9:611:20 | var_in_macro |  |
+| main.rs:615:5:615:13 | print_i64 | main.rs:615:15:615:42 | let ... = 0 |  |
+| main.rs:615:5:615:43 | print_i64(...) | main.rs:616:5:616:28 | ExprStmt |  |
+| main.rs:615:5:615:44 | ExprStmt | main.rs:615:5:615:13 | print_i64 |  |
+| main.rs:615:15:615:42 | 0 | main.rs:615:15:615:42 | var_in_macro |  |
+| main.rs:615:15:615:42 | MacroExpr | main.rs:615:5:615:43 | print_i64(...) |  |
+| main.rs:615:15:615:42 | let ... = 0 | main.rs:615:15:615:42 | 0 |  |
+| main.rs:615:15:615:42 | let_in_macro2!... | main.rs:615:15:615:42 | MacroExpr |  |
+| main.rs:615:15:615:42 | var_in_macro | main.rs:615:15:615:42 | var_in_macro |  |
+| main.rs:615:15:615:42 | var_in_macro | main.rs:615:30:615:41 | var_in_macro | match |
+| main.rs:615:30:615:41 | var_in_macro | main.rs:615:30:615:41 | { ... } |  |
+| main.rs:615:30:615:41 | { ... } | main.rs:615:15:615:42 | let_in_macro2!... |  |
+| main.rs:616:5:616:13 | print_i64 | main.rs:616:15:616:26 | var_in_macro |  |
+| main.rs:616:5:616:27 | print_i64(...) | main.rs:607:23:617:1 | { ... } |  |
+| main.rs:616:5:616:28 | ExprStmt | main.rs:616:5:616:13 | print_i64 |  |
+| main.rs:616:15:616:26 | var_in_macro | main.rs:616:5:616:27 | print_i64(...) |  |
+| main.rs:619:1:623:1 | enter fn let_without_initializer | main.rs:620:5:620:10 | let ... |  |
+| main.rs:619:1:623:1 | exit fn let_without_initializer (normal) | main.rs:619:1:623:1 | exit fn let_without_initializer |  |
+| main.rs:619:30:623:1 | { ... } | main.rs:619:1:623:1 | exit fn let_without_initializer (normal) |  |
+| main.rs:620:5:620:10 | let ... | main.rs:620:9:620:9 | x |  |
+| main.rs:620:9:620:9 | x | main.rs:620:9:620:9 | x |  |
+| main.rs:620:9:620:9 | x | main.rs:621:5:621:10 | ExprStmt | match |
+| main.rs:621:5:621:5 | x | main.rs:621:9:621:9 | 1 |  |
+| main.rs:621:5:621:9 | ... = ... | main.rs:622:5:622:17 | ExprStmt |  |
+| main.rs:621:5:621:10 | ExprStmt | main.rs:621:5:621:5 | x |  |
+| main.rs:621:9:621:9 | 1 | main.rs:621:5:621:9 | ... = ... |  |
+| main.rs:622:5:622:13 | print_i64 | main.rs:622:15:622:15 | x |  |
+| main.rs:622:5:622:16 | print_i64(...) | main.rs:619:30:623:1 | { ... } |  |
+| main.rs:622:5:622:17 | ExprStmt | main.rs:622:5:622:13 | print_i64 |  |
+| main.rs:622:15:622:15 | x | main.rs:622:5:622:16 | print_i64(...) |  |
+| main.rs:625:1:635:1 | enter fn capture_phi | main.rs:626:5:626:20 | let ... = 100 |  |
+| main.rs:625:1:635:1 | exit fn capture_phi (normal) | main.rs:625:1:635:1 | exit fn capture_phi |  |
+| main.rs:625:18:635:1 | { ... } | main.rs:625:1:635:1 | exit fn capture_phi (normal) |  |
+| main.rs:626:5:626:20 | let ... = 100 | main.rs:626:17:626:19 | 100 |  |
+| main.rs:626:9:626:13 | mut x | main.rs:627:5:632:6 | let ... = ... | match |
+| main.rs:626:13:626:13 | x | main.rs:626:9:626:13 | mut x |  |
+| main.rs:626:17:626:19 | 100 | main.rs:626:13:626:13 | x |  |
+| main.rs:627:5:632:6 | let ... = ... | main.rs:627:19:632:5 | \|...\| ... |  |
+| main.rs:627:9:627:15 | mut cap | main.rs:633:5:633:14 | ExprStmt | match |
+| main.rs:627:13:627:15 | cap | main.rs:627:9:627:15 | mut cap |  |
+| main.rs:627:19:632:5 | \|...\| ... | main.rs:627:13:627:15 | cap |  |
+| main.rs:627:19:632:5 | enter \|...\| ... | main.rs:627:20:627:20 | b |  |
+| main.rs:627:19:632:5 | exit \|...\| ... (normal) | main.rs:627:19:632:5 | exit \|...\| ... |  |
+| main.rs:627:20:627:20 | b | main.rs:627:20:627:20 | b |  |
+| main.rs:627:20:627:20 | b | main.rs:627:20:627:26 | ...: bool | match |
+| main.rs:627:20:627:26 | ...: bool | main.rs:628:9:631:10 | let _ = ... |  |
+| main.rs:627:29:632:5 | { ... } | main.rs:627:19:632:5 | exit \|...\| ... (normal) |  |
+| main.rs:628:9:631:10 | let _ = ... | main.rs:629:20:629:20 | b |  |
+| main.rs:629:13:629:13 | _ | main.rs:627:29:632:5 | { ... } | match |
+| main.rs:629:17:631:9 | if b {...} | main.rs:629:13:629:13 | _ |  |
+| main.rs:629:20:629:20 | b | main.rs:629:17:631:9 | if b {...} | false |
+| main.rs:629:20:629:20 | b | main.rs:630:13:630:20 | ExprStmt | true |
+| main.rs:629:22:631:9 | { ... } | main.rs:629:17:631:9 | if b {...} |  |
+| main.rs:630:13:630:13 | x | main.rs:630:17:630:19 | 200 |  |
+| main.rs:630:13:630:19 | ... = ... | main.rs:629:22:631:9 | { ... } |  |
+| main.rs:630:13:630:20 | ExprStmt | main.rs:630:13:630:13 | x |  |
+| main.rs:630:17:630:19 | 200 | main.rs:630:13:630:19 | ... = ... |  |
+| main.rs:633:5:633:7 | cap | main.rs:633:9:633:12 | true |  |
+| main.rs:633:5:633:13 | cap(...) | main.rs:634:5:634:17 | ExprStmt |  |
+| main.rs:633:5:633:14 | ExprStmt | main.rs:633:5:633:7 | cap |  |
+| main.rs:633:9:633:12 | true | main.rs:633:5:633:13 | cap(...) |  |
+| main.rs:634:5:634:13 | print_i64 | main.rs:634:15:634:15 | x |  |
+| main.rs:634:5:634:16 | print_i64(...) | main.rs:625:18:635:1 | { ... } |  |
+| main.rs:634:5:634:17 | ExprStmt | main.rs:634:5:634:13 | print_i64 |  |
+| main.rs:634:15:634:15 | x | main.rs:634:5:634:16 | print_i64(...) |  |
+| main.rs:637:1:674:1 | enter fn main | main.rs:638:5:638:25 | ExprStmt |  |
+| main.rs:637:1:674:1 | exit fn main (normal) | main.rs:637:1:674:1 | exit fn main |  |
+| main.rs:637:11:674:1 | { ... } | main.rs:637:1:674:1 | exit fn main (normal) |  |
+| main.rs:638:5:638:22 | immutable_variable | main.rs:638:5:638:24 | immutable_variable(...) |  |
+| main.rs:638:5:638:24 | immutable_variable(...) | main.rs:639:5:639:23 | ExprStmt |  |
+| main.rs:638:5:638:25 | ExprStmt | main.rs:638:5:638:22 | immutable_variable |  |
+| main.rs:639:5:639:20 | mutable_variable | main.rs:639:5:639:22 | mutable_variable(...) |  |
+| main.rs:639:5:639:22 | mutable_variable(...) | main.rs:640:5:640:40 | ExprStmt |  |
+| main.rs:639:5:639:23 | ExprStmt | main.rs:639:5:639:20 | mutable_variable |  |
+| main.rs:640:5:640:37 | mutable_variable_immutable_borrow | main.rs:640:5:640:39 | mutable_variable_immutable_borrow(...) |  |
+| main.rs:640:5:640:39 | mutable_variable_immutable_borrow(...) | main.rs:641:5:641:23 | ExprStmt |  |
+| main.rs:640:5:640:40 | ExprStmt | main.rs:640:5:640:37 | mutable_variable_immutable_borrow |  |
+| main.rs:641:5:641:20 | variable_shadow1 | main.rs:641:5:641:22 | variable_shadow1(...) |  |
+| main.rs:641:5:641:22 | variable_shadow1(...) | main.rs:642:5:642:23 | ExprStmt |  |
+| main.rs:641:5:641:23 | ExprStmt | main.rs:641:5:641:20 | variable_shadow1 |  |
+| main.rs:642:5:642:20 | variable_shadow2 | main.rs:642:5:642:22 | variable_shadow2(...) |  |
+| main.rs:642:5:642:22 | variable_shadow2(...) | main.rs:643:5:643:19 | ExprStmt |  |
+| main.rs:642:5:642:23 | ExprStmt | main.rs:642:5:642:20 | variable_shadow2 |  |
+| main.rs:643:5:643:16 | let_pattern1 | main.rs:643:5:643:18 | let_pattern1(...) |  |
+| main.rs:643:5:643:18 | let_pattern1(...) | main.rs:644:5:644:19 | ExprStmt |  |
+| main.rs:643:5:643:19 | ExprStmt | main.rs:643:5:643:16 | let_pattern1 |  |
+| main.rs:644:5:644:16 | let_pattern2 | main.rs:644:5:644:18 | let_pattern2(...) |  |
+| main.rs:644:5:644:18 | let_pattern2(...) | main.rs:645:5:645:19 | ExprStmt |  |
+| main.rs:644:5:644:19 | ExprStmt | main.rs:644:5:644:16 | let_pattern2 |  |
+| main.rs:645:5:645:16 | let_pattern3 | main.rs:645:5:645:18 | let_pattern3(...) |  |
+| main.rs:645:5:645:18 | let_pattern3(...) | main.rs:646:5:646:19 | ExprStmt |  |
+| main.rs:645:5:645:19 | ExprStmt | main.rs:645:5:645:16 | let_pattern3 |  |
+| main.rs:646:5:646:16 | let_pattern4 | main.rs:646:5:646:18 | let_pattern4(...) |  |
+| main.rs:646:5:646:18 | let_pattern4(...) | main.rs:647:5:647:21 | ExprStmt |  |
+| main.rs:646:5:646:19 | ExprStmt | main.rs:646:5:646:16 | let_pattern4 |  |
+| main.rs:647:5:647:18 | match_pattern1 | main.rs:647:5:647:20 | match_pattern1(...) |  |
+| main.rs:647:5:647:20 | match_pattern1(...) | main.rs:648:5:648:21 | ExprStmt |  |
+| main.rs:647:5:647:21 | ExprStmt | main.rs:647:5:647:18 | match_pattern1 |  |
+| main.rs:648:5:648:18 | match_pattern2 | main.rs:648:5:648:20 | match_pattern2(...) |  |
+| main.rs:648:5:648:20 | match_pattern2(...) | main.rs:649:5:649:21 | ExprStmt |  |
+| main.rs:648:5:648:21 | ExprStmt | main.rs:648:5:648:18 | match_pattern2 |  |
+| main.rs:649:5:649:18 | match_pattern3 | main.rs:649:5:649:20 | match_pattern3(...) |  |
+| main.rs:649:5:649:20 | match_pattern3(...) | main.rs:650:5:650:21 | ExprStmt |  |
+| main.rs:649:5:649:21 | ExprStmt | main.rs:649:5:649:18 | match_pattern3 |  |
+| main.rs:650:5:650:18 | match_pattern4 | main.rs:650:5:650:20 | match_pattern4(...) |  |
+| main.rs:650:5:650:20 | match_pattern4(...) | main.rs:651:5:651:21 | ExprStmt |  |
+| main.rs:650:5:650:21 | ExprStmt | main.rs:650:5:650:18 | match_pattern4 |  |
+| main.rs:651:5:651:18 | match_pattern5 | main.rs:651:5:651:20 | match_pattern5(...) |  |
+| main.rs:651:5:651:20 | match_pattern5(...) | main.rs:652:5:652:21 | ExprStmt |  |
+| main.rs:651:5:651:21 | ExprStmt | main.rs:651:5:651:18 | match_pattern5 |  |
+| main.rs:652:5:652:18 | match_pattern6 | main.rs:652:5:652:20 | match_pattern6(...) |  |
+| main.rs:652:5:652:20 | match_pattern6(...) | main.rs:653:5:653:21 | ExprStmt |  |
+| main.rs:652:5:652:21 | ExprStmt | main.rs:652:5:652:18 | match_pattern6 |  |
+| main.rs:653:5:653:18 | match_pattern7 | main.rs:653:5:653:20 | match_pattern7(...) |  |
+| main.rs:653:5:653:20 | match_pattern7(...) | main.rs:654:5:654:21 | ExprStmt |  |
+| main.rs:653:5:653:21 | ExprStmt | main.rs:653:5:653:18 | match_pattern7 |  |
+| main.rs:654:5:654:18 | match_pattern8 | main.rs:654:5:654:20 | match_pattern8(...) |  |
+| main.rs:654:5:654:20 | match_pattern8(...) | main.rs:655:5:655:21 | ExprStmt |  |
+| main.rs:654:5:654:21 | ExprStmt | main.rs:654:5:654:18 | match_pattern8 |  |
+| main.rs:655:5:655:18 | match_pattern9 | main.rs:655:5:655:20 | match_pattern9(...) |  |
+| main.rs:655:5:655:20 | match_pattern9(...) | main.rs:656:5:656:36 | ExprStmt |  |
+| main.rs:655:5:655:21 | ExprStmt | main.rs:655:5:655:18 | match_pattern9 |  |
+| main.rs:656:5:656:18 | param_pattern1 | main.rs:656:20:656:22 | "a" |  |
+| main.rs:656:5:656:35 | param_pattern1(...) | main.rs:657:5:657:37 | ExprStmt |  |
+| main.rs:656:5:656:36 | ExprStmt | main.rs:656:5:656:18 | param_pattern1 |  |
+| main.rs:656:20:656:22 | "a" | main.rs:656:26:656:28 | "b" |  |
+| main.rs:656:25:656:34 | TupleExpr | main.rs:656:5:656:35 | param_pattern1(...) |  |
+| main.rs:656:26:656:28 | "b" | main.rs:656:31:656:33 | "c" |  |
+| main.rs:656:31:656:33 | "c" | main.rs:656:25:656:34 | TupleExpr |  |
+| main.rs:657:5:657:18 | param_pattern2 | main.rs:657:20:657:31 | ...::Left |  |
+| main.rs:657:5:657:36 | param_pattern2(...) | main.rs:658:5:658:26 | ExprStmt |  |
+| main.rs:657:5:657:37 | ExprStmt | main.rs:657:5:657:18 | param_pattern2 |  |
+| main.rs:657:20:657:31 | ...::Left | main.rs:657:33:657:34 | 45 |  |
+| main.rs:657:20:657:35 | ...::Left(...) | main.rs:657:5:657:36 | param_pattern2(...) |  |
+| main.rs:657:33:657:34 | 45 | main.rs:657:20:657:35 | ...::Left(...) |  |
+| main.rs:658:5:658:23 | destruct_assignment | main.rs:658:5:658:25 | destruct_assignment(...) |  |
+| main.rs:658:5:658:25 | destruct_assignment(...) | main.rs:659:5:659:23 | ExprStmt |  |
+| main.rs:658:5:658:26 | ExprStmt | main.rs:658:5:658:23 | destruct_assignment |  |
+| main.rs:659:5:659:20 | closure_variable | main.rs:659:5:659:22 | closure_variable(...) |  |
+| main.rs:659:5:659:22 | closure_variable(...) | main.rs:660:5:660:22 | ExprStmt |  |
+| main.rs:659:5:659:23 | ExprStmt | main.rs:659:5:659:20 | closure_variable |  |
+| main.rs:660:5:660:19 | nested_function | main.rs:660:5:660:21 | nested_function(...) |  |
+| main.rs:660:5:660:21 | nested_function(...) | main.rs:661:5:661:19 | ExprStmt |  |
+| main.rs:660:5:660:22 | ExprStmt | main.rs:660:5:660:19 | nested_function |  |
+| main.rs:661:5:661:16 | for_variable | main.rs:661:5:661:18 | for_variable(...) |  |
+| main.rs:661:5:661:18 | for_variable(...) | main.rs:662:5:662:17 | ExprStmt |  |
+| main.rs:661:5:661:19 | ExprStmt | main.rs:661:5:661:16 | for_variable |  |
+| main.rs:662:5:662:14 | add_assign | main.rs:662:5:662:16 | add_assign(...) |  |
+| main.rs:662:5:662:16 | add_assign(...) | main.rs:663:5:663:13 | ExprStmt |  |
+| main.rs:662:5:662:17 | ExprStmt | main.rs:662:5:662:14 | add_assign |  |
+| main.rs:663:5:663:10 | mutate | main.rs:663:5:663:12 | mutate(...) |  |
+| main.rs:663:5:663:12 | mutate(...) | main.rs:664:5:664:17 | ExprStmt |  |
+| main.rs:663:5:663:13 | ExprStmt | main.rs:663:5:663:10 | mutate |  |
+| main.rs:664:5:664:14 | mutate_arg | main.rs:664:5:664:16 | mutate_arg(...) |  |
+| main.rs:664:5:664:16 | mutate_arg(...) | main.rs:665:5:665:12 | ExprStmt |  |
+| main.rs:664:5:664:17 | ExprStmt | main.rs:664:5:664:14 | mutate_arg |  |
+| main.rs:665:5:665:9 | alias | main.rs:665:5:665:11 | alias(...) |  |
+| main.rs:665:5:665:11 | alias(...) | main.rs:666:5:666:18 | ExprStmt |  |
+| main.rs:665:5:665:12 | ExprStmt | main.rs:665:5:665:9 | alias |  |
+| main.rs:666:5:666:15 | capture_mut | main.rs:666:5:666:17 | capture_mut(...) |  |
+| main.rs:666:5:666:17 | capture_mut(...) | main.rs:667:5:667:20 | ExprStmt |  |
+| main.rs:666:5:666:18 | ExprStmt | main.rs:666:5:666:15 | capture_mut |  |
+| main.rs:667:5:667:17 | capture_immut | main.rs:667:5:667:19 | capture_immut(...) |  |
+| main.rs:667:5:667:19 | capture_immut(...) | main.rs:668:5:668:26 | ExprStmt |  |
+| main.rs:667:5:667:20 | ExprStmt | main.rs:667:5:667:17 | capture_immut |  |
+| main.rs:668:5:668:23 | async_block_capture | main.rs:668:5:668:25 | async_block_capture(...) |  |
+| main.rs:668:5:668:25 | async_block_capture(...) | main.rs:669:5:669:14 | ExprStmt |  |
+| main.rs:668:5:668:26 | ExprStmt | main.rs:668:5:668:23 | async_block_capture |  |
+| main.rs:669:5:669:11 | structs | main.rs:669:5:669:13 | structs(...) |  |
+| main.rs:669:5:669:13 | structs(...) | main.rs:670:5:670:14 | ExprStmt |  |
+| main.rs:669:5:669:14 | ExprStmt | main.rs:669:5:669:11 | structs |  |
+| main.rs:670:5:670:11 | ref_arg | main.rs:670:5:670:13 | ref_arg(...) |  |
+| main.rs:670:5:670:13 | ref_arg(...) | main.rs:671:5:671:30 | ExprStmt |  |
+| main.rs:670:5:670:14 | ExprStmt | main.rs:670:5:670:11 | ref_arg |  |
+| main.rs:671:5:671:27 | ref_methodcall_receiver | main.rs:671:5:671:29 | ref_methodcall_receiver(...) |  |
+| main.rs:671:5:671:29 | ref_methodcall_receiver(...) | main.rs:672:5:672:23 | ExprStmt |  |
+| main.rs:671:5:671:30 | ExprStmt | main.rs:671:5:671:27 | ref_methodcall_receiver |  |
+| main.rs:672:5:672:20 | macro_invocation | main.rs:672:5:672:22 | macro_invocation(...) |  |
+| main.rs:672:5:672:22 | macro_invocation(...) | main.rs:673:5:673:18 | ExprStmt |  |
+| main.rs:672:5:672:23 | ExprStmt | main.rs:672:5:672:20 | macro_invocation |  |
+| main.rs:673:5:673:15 | capture_phi | main.rs:673:5:673:17 | capture_phi(...) |  |
+| main.rs:673:5:673:17 | capture_phi(...) | main.rs:637:11:674:1 | { ... } |  |
+| main.rs:673:5:673:18 | ExprStmt | main.rs:673:5:673:15 | capture_phi |  |
 breakTarget
 continueTarget

--- a/rust/ql/test/library-tests/variables/Ssa.expected
+++ b/rust/ql/test/library-tests/variables/Ssa.expected
@@ -1,644 +1,665 @@
 definition
 | main.rs:3:14:3:14 | s | main.rs:3:14:3:14 | s |
-| main.rs:7:14:7:14 | i | main.rs:7:14:7:14 | i |
-| main.rs:11:18:11:18 | i | main.rs:11:18:11:18 | i |
-| main.rs:16:9:16:10 | x1 | main.rs:16:9:16:10 | x1 |
-| main.rs:21:13:21:14 | x2 | main.rs:21:13:21:14 | x2 |
-| main.rs:23:5:23:6 | x2 | main.rs:21:13:21:14 | x2 |
-| main.rs:28:13:28:13 | x | main.rs:28:13:28:13 | x |
-| main.rs:30:5:30:5 | x | main.rs:28:13:28:13 | x |
-| main.rs:35:9:35:10 | x3 | main.rs:35:9:35:10 | x3 |
+| main.rs:8:14:8:14 | i | main.rs:8:14:8:14 | i |
+| main.rs:13:18:13:18 | i | main.rs:13:18:13:18 | i |
+| main.rs:18:9:18:10 | x1 | main.rs:18:9:18:10 | x1 |
+| main.rs:23:13:23:14 | x2 | main.rs:23:13:23:14 | x2 |
+| main.rs:25:5:25:6 | x2 | main.rs:23:13:23:14 | x2 |
+| main.rs:30:13:30:13 | x | main.rs:30:13:30:13 | x |
+| main.rs:32:5:32:5 | x | main.rs:30:13:30:13 | x |
 | main.rs:37:9:37:10 | x3 | main.rs:37:9:37:10 | x3 |
-| main.rs:43:9:43:10 | x4 | main.rs:43:9:43:10 | x4 |
-| main.rs:46:13:46:14 | x4 | main.rs:46:13:46:14 | x4 |
-| main.rs:60:13:60:14 | a1 | main.rs:60:13:60:14 | a1 |
-| main.rs:61:13:61:14 | b1 | main.rs:61:13:61:14 | b1 |
-| main.rs:64:13:64:13 | x | main.rs:64:13:64:13 | x |
-| main.rs:65:13:65:13 | y | main.rs:65:13:65:13 | y |
-| main.rs:75:9:75:10 | p1 | main.rs:75:9:75:10 | p1 |
-| main.rs:77:12:77:13 | a2 | main.rs:77:12:77:13 | a2 |
-| main.rs:78:12:78:13 | b2 | main.rs:78:12:78:13 | b2 |
-| main.rs:85:9:85:10 | s1 | main.rs:85:9:85:10 | s1 |
-| main.rs:87:21:87:22 | s2 | main.rs:87:21:87:22 | s2 |
-| main.rs:94:14:94:15 | x5 | main.rs:94:14:94:15 | x5 |
-| main.rs:102:9:102:10 | s1 | main.rs:102:9:102:10 | s1 |
-| main.rs:104:24:104:25 | s2 | main.rs:104:24:104:25 | s2 |
-| main.rs:111:9:111:10 | x6 | main.rs:111:9:111:10 | x6 |
-| main.rs:112:9:112:10 | y1 | main.rs:112:9:112:10 | y1 |
-| main.rs:116:14:116:15 | y1 | main.rs:116:14:116:15 | y1 |
-| main.rs:128:9:128:15 | numbers | main.rs:128:9:128:15 | numbers |
-| main.rs:132:13:132:17 | first | main.rs:132:13:132:17 | first |
-| main.rs:133:13:133:17 | third | main.rs:133:13:133:17 | third |
-| main.rs:134:13:134:17 | fifth | main.rs:134:13:134:17 | fifth |
-| main.rs:144:13:144:17 | first | main.rs:144:13:144:17 | first |
-| main.rs:146:13:146:16 | last | main.rs:146:13:146:16 | last |
-| main.rs:155:9:155:10 | p2 | main.rs:155:9:155:10 | p2 |
-| main.rs:159:16:159:17 | x7 | main.rs:159:16:159:17 | x7 |
-| main.rs:169:9:169:11 | msg | main.rs:169:9:169:11 | msg |
-| main.rs:173:17:173:27 | id_variable | main.rs:173:17:173:27 | id_variable |
-| main.rs:178:26:178:27 | id | main.rs:178:26:178:27 | id |
-| main.rs:189:9:189:14 | either | main.rs:189:9:189:14 | either |
-| main.rs:191:9:191:44 | SSA phi(a3) | main.rs:191:9:191:44 | a3 |
-| main.rs:191:22:191:23 | a3 | main.rs:191:9:191:44 | a3 |
-| main.rs:191:42:191:43 | a3 | main.rs:191:9:191:44 | a3 |
-| main.rs:203:9:203:10 | tv | main.rs:203:9:203:10 | tv |
-| main.rs:205:9:205:81 | SSA phi(a4) | main.rs:205:9:205:81 | a4 |
-| main.rs:205:28:205:29 | a4 | main.rs:205:9:205:81 | a4 |
-| main.rs:205:54:205:55 | a4 | main.rs:205:9:205:81 | a4 |
-| main.rs:205:79:205:80 | a4 | main.rs:205:9:205:81 | a4 |
-| main.rs:209:9:209:83 | SSA phi(a5) | main.rs:209:9:209:83 | a5 |
-| main.rs:209:10:209:57 | [match(true)] SSA phi(a5) | main.rs:209:9:209:83 | a5 |
-| main.rs:209:29:209:30 | a5 | main.rs:209:9:209:83 | a5 |
-| main.rs:209:55:209:56 | a5 | main.rs:209:9:209:83 | a5 |
-| main.rs:209:81:209:82 | a5 | main.rs:209:9:209:83 | a5 |
-| main.rs:213:9:213:83 | SSA phi(a6) | main.rs:213:9:213:83 | a6 |
-| main.rs:213:28:213:29 | a6 | main.rs:213:9:213:83 | a6 |
-| main.rs:213:35:213:82 | SSA phi(a6) | main.rs:213:9:213:83 | a6 |
-| main.rs:213:55:213:56 | a6 | main.rs:213:9:213:83 | a6 |
-| main.rs:213:80:213:81 | a6 | main.rs:213:9:213:83 | a6 |
-| main.rs:219:9:219:14 | either | main.rs:219:9:219:14 | either |
-| main.rs:221:9:221:44 | [match(true)] SSA phi(a7) | main.rs:221:9:221:44 | a7 |
-| main.rs:221:22:221:23 | a7 | main.rs:221:9:221:44 | a7 |
-| main.rs:221:42:221:43 | a7 | main.rs:221:9:221:44 | a7 |
-| main.rs:229:9:229:14 | either | main.rs:229:9:229:14 | either |
-| main.rs:232:13:232:13 | e | main.rs:232:13:232:13 | e |
-| main.rs:233:14:233:51 | [match(true)] SSA phi(a11) | main.rs:233:14:233:51 | a11 |
-| main.rs:233:27:233:29 | a11 | main.rs:233:14:233:51 | a11 |
-| main.rs:233:48:233:50 | a11 | main.rs:233:14:233:51 | a11 |
-| main.rs:236:33:236:35 | a12 | main.rs:236:33:236:35 | a12 |
-| main.rs:253:9:253:10 | fv | main.rs:253:9:253:10 | fv |
-| main.rs:255:9:255:109 | SSA phi(a13) | main.rs:255:9:255:109 | a13 |
-| main.rs:255:27:255:29 | a13 | main.rs:255:9:255:109 | a13 |
-| main.rs:255:35:255:82 | [match(true)] SSA phi(a13) | main.rs:255:9:255:109 | a13 |
-| main.rs:255:54:255:56 | a13 | main.rs:255:9:255:109 | a13 |
-| main.rs:255:79:255:81 | a13 | main.rs:255:9:255:109 | a13 |
-| main.rs:255:106:255:108 | a13 | main.rs:255:9:255:109 | a13 |
-| main.rs:261:5:261:6 | a8 | main.rs:261:5:261:6 | a8 |
-| main.rs:263:9:263:10 | b3 | main.rs:263:9:263:10 | b3 |
-| main.rs:264:9:264:10 | c1 | main.rs:264:9:264:10 | c1 |
-| main.rs:272:6:272:41 | SSA phi(a9) | main.rs:272:6:272:41 | a9 |
-| main.rs:272:19:272:20 | a9 | main.rs:272:6:272:41 | a9 |
-| main.rs:272:39:272:40 | a9 | main.rs:272:6:272:41 | a9 |
-| main.rs:279:13:279:15 | a10 | main.rs:279:13:279:15 | a10 |
-| main.rs:280:13:280:14 | b4 | main.rs:280:13:280:14 | b4 |
-| main.rs:281:13:281:14 | c2 | main.rs:281:13:281:14 | c2 |
-| main.rs:288:9:288:10 | c2 | main.rs:281:13:281:14 | c2 |
-| main.rs:289:9:289:10 | b4 | main.rs:280:13:280:14 | b4 |
-| main.rs:290:9:290:11 | a10 | main.rs:279:13:279:15 | a10 |
-| main.rs:302:13:302:15 | a10 | main.rs:302:13:302:15 | a10 |
-| main.rs:303:13:303:14 | b4 | main.rs:303:13:303:14 | b4 |
-| main.rs:315:9:315:23 | example_closure | main.rs:315:9:315:23 | example_closure |
-| main.rs:316:10:316:10 | x | main.rs:316:10:316:10 | x |
-| main.rs:318:9:318:10 | n1 | main.rs:318:9:318:10 | n1 |
-| main.rs:323:9:323:26 | immutable_variable | main.rs:323:9:323:26 | immutable_variable |
-| main.rs:324:10:324:10 | x | main.rs:324:10:324:10 | x |
-| main.rs:326:9:326:10 | n2 | main.rs:326:9:326:10 | n2 |
-| main.rs:333:9:333:9 | f | main.rs:333:9:333:9 | f |
-| main.rs:334:10:334:10 | x | main.rs:334:10:334:10 | x |
-| main.rs:338:10:338:10 | x | main.rs:338:10:338:10 | x |
-| main.rs:346:14:346:14 | x | main.rs:346:14:346:14 | x |
-| main.rs:354:13:354:13 | f | main.rs:354:13:354:13 | f |
-| main.rs:355:14:355:14 | x | main.rs:355:14:355:14 | x |
-| main.rs:362:9:362:9 | v | main.rs:362:9:362:9 | v |
-| main.rs:364:9:364:12 | text | main.rs:364:9:364:12 | text |
-| main.rs:371:13:371:13 | a | main.rs:371:13:371:13 | a |
-| main.rs:372:5:372:5 | a | main.rs:371:13:371:13 | a |
-| main.rs:374:6:374:11 | &mut a | main.rs:371:13:371:13 | a |
-| main.rs:379:13:379:13 | i | main.rs:379:13:379:13 | i |
-| main.rs:380:9:380:13 | ref_i | main.rs:380:9:380:13 | ref_i |
-| main.rs:381:9:381:14 | &mut i | main.rs:379:13:379:13 | i |
-| main.rs:386:17:386:17 | x | main.rs:386:17:386:17 | x |
-| main.rs:393:22:393:22 | x | main.rs:393:22:393:22 | x |
-| main.rs:393:39:393:39 | y | main.rs:393:39:393:39 | y |
-| main.rs:402:13:402:13 | x | main.rs:402:13:402:13 | x |
-| main.rs:403:9:403:9 | y | main.rs:403:9:403:9 | y |
-| main.rs:404:22:404:27 | &mut x | main.rs:402:13:402:13 | x |
-| main.rs:409:13:409:13 | z | main.rs:409:13:409:13 | z |
-| main.rs:410:9:410:9 | w | main.rs:410:9:410:9 | w |
-| main.rs:413:9:413:14 | &mut z | main.rs:409:13:409:13 | z |
-| main.rs:422:13:422:13 | x | main.rs:422:13:422:13 | x |
-| main.rs:423:9:423:9 | y | main.rs:423:9:423:9 | y |
-| main.rs:424:9:424:14 | &mut x | main.rs:422:13:422:13 | x |
-| main.rs:430:9:430:9 | x | main.rs:430:9:430:9 | x |
-| main.rs:432:9:432:11 | cap | main.rs:432:9:432:11 | cap |
-| main.rs:432:15:434:5 | <captured entry> x | main.rs:430:9:430:9 | x |
-| main.rs:440:13:440:13 | x | main.rs:440:13:440:13 | x |
-| main.rs:442:9:442:16 | closure1 | main.rs:442:9:442:16 | closure1 |
-| main.rs:442:20:444:5 | <captured entry> x | main.rs:440:13:440:13 | x |
-| main.rs:448:13:448:13 | y | main.rs:448:13:448:13 | y |
-| main.rs:450:13:450:20 | closure2 | main.rs:450:13:450:20 | closure2 |
-| main.rs:451:9:451:9 | y | main.rs:448:13:448:13 | y |
-| main.rs:453:5:453:14 | <captured exit> y | main.rs:448:13:448:13 | y |
-| main.rs:456:13:456:13 | z | main.rs:456:13:456:13 | z |
-| main.rs:458:13:458:20 | closure3 | main.rs:458:13:458:20 | closure3 |
-| main.rs:458:24:460:5 | <captured entry> z | main.rs:456:13:456:13 | z |
-| main.rs:466:13:466:13 | i | main.rs:466:13:466:13 | i |
-| main.rs:467:9:467:13 | block | main.rs:467:9:467:13 | block |
-| main.rs:468:9:468:9 | i | main.rs:466:13:466:13 | i |
-| main.rs:471:5:471:15 | <captured exit> i | main.rs:466:13:466:13 | i |
-| main.rs:475:8:475:8 | b | main.rs:475:8:475:8 | b |
-| main.rs:476:13:476:13 | x | main.rs:476:13:476:13 | x |
-| main.rs:479:5:487:5 | SSA phi(x) | main.rs:476:13:476:13 | x |
-| main.rs:480:9:480:9 | x | main.rs:476:13:476:13 | x |
-| main.rs:484:9:484:9 | x | main.rs:476:13:476:13 | x |
-| main.rs:491:13:491:14 | b1 | main.rs:491:13:491:14 | b1 |
-| main.rs:491:24:491:25 | b2 | main.rs:491:24:491:25 | b2 |
-| main.rs:492:9:492:9 | x | main.rs:492:9:492:9 | x |
-| main.rs:512:20:512:23 | self | main.rs:512:20:512:23 | self |
-| main.rs:516:11:516:14 | self | main.rs:516:11:516:14 | self |
-| main.rs:520:23:520:26 | self | main.rs:520:23:520:26 | self |
-| main.rs:521:17:521:17 | f | main.rs:521:17:521:17 | f |
-| main.rs:521:21:524:9 | <captured entry> self | main.rs:520:23:520:26 | self |
-| main.rs:521:22:521:22 | n | main.rs:521:22:521:22 | n |
-| main.rs:531:13:531:13 | a | main.rs:531:13:531:13 | a |
-| main.rs:532:15:532:15 | a | main.rs:531:13:531:13 | a |
-| main.rs:535:5:535:5 | a | main.rs:531:13:531:13 | a |
-| main.rs:540:13:540:13 | a | main.rs:540:13:540:13 | a |
-| main.rs:544:5:544:5 | a | main.rs:540:13:540:13 | a |
-| main.rs:549:9:549:9 | x | main.rs:549:9:549:9 | x |
-| main.rs:553:9:553:9 | z | main.rs:553:9:553:9 | z |
-| main.rs:562:15:562:18 | self | main.rs:562:15:562:18 | self |
-| main.rs:568:11:568:11 | a | main.rs:568:11:568:11 | a |
-| main.rs:569:3:569:3 | a | main.rs:568:11:568:11 | a |
-| main.rs:593:9:593:22 | var_from_macro | main.rs:593:9:593:22 | var_from_macro |
-| main.rs:594:9:594:25 | var_in_macro | main.rs:594:9:594:25 | var_in_macro |
-| main.rs:596:9:596:20 | var_in_macro | main.rs:596:9:596:20 | var_in_macro |
-| main.rs:600:15:600:42 | var_in_macro | main.rs:600:15:600:42 | var_in_macro |
+| main.rs:39:9:39:10 | x3 | main.rs:39:9:39:10 | x3 |
+| main.rs:45:9:45:10 | x4 | main.rs:45:9:45:10 | x4 |
+| main.rs:48:13:48:14 | x4 | main.rs:48:13:48:14 | x4 |
+| main.rs:62:13:62:14 | a1 | main.rs:62:13:62:14 | a1 |
+| main.rs:63:13:63:14 | b1 | main.rs:63:13:63:14 | b1 |
+| main.rs:66:13:66:13 | x | main.rs:66:13:66:13 | x |
+| main.rs:67:13:67:13 | y | main.rs:67:13:67:13 | y |
+| main.rs:77:9:77:10 | p1 | main.rs:77:9:77:10 | p1 |
+| main.rs:79:12:79:13 | a2 | main.rs:79:12:79:13 | a2 |
+| main.rs:80:12:80:13 | b2 | main.rs:80:12:80:13 | b2 |
+| main.rs:87:9:87:10 | s1 | main.rs:87:9:87:10 | s1 |
+| main.rs:89:21:89:22 | s2 | main.rs:89:21:89:22 | s2 |
+| main.rs:96:14:96:15 | x5 | main.rs:96:14:96:15 | x5 |
+| main.rs:106:9:106:10 | s1 | main.rs:106:9:106:10 | s1 |
+| main.rs:108:24:108:25 | s2 | main.rs:108:24:108:25 | s2 |
+| main.rs:115:9:115:10 | x6 | main.rs:115:9:115:10 | x6 |
+| main.rs:116:9:116:10 | y1 | main.rs:116:9:116:10 | y1 |
+| main.rs:120:14:120:15 | y1 | main.rs:120:14:120:15 | y1 |
+| main.rs:132:9:132:15 | numbers | main.rs:132:9:132:15 | numbers |
+| main.rs:137:13:137:17 | first | main.rs:137:13:137:17 | first |
+| main.rs:139:13:139:17 | third | main.rs:139:13:139:17 | third |
+| main.rs:141:13:141:17 | fifth | main.rs:141:13:141:17 | fifth |
+| main.rs:152:13:152:17 | first | main.rs:152:13:152:17 | first |
+| main.rs:154:13:154:16 | last | main.rs:154:13:154:16 | last |
+| main.rs:163:9:163:10 | p2 | main.rs:163:9:163:10 | p2 |
+| main.rs:167:16:167:17 | x7 | main.rs:167:16:167:17 | x7 |
+| main.rs:177:9:177:11 | msg | main.rs:177:9:177:11 | msg |
+| main.rs:182:17:182:27 | id_variable | main.rs:182:17:182:27 | id_variable |
+| main.rs:187:26:187:27 | id | main.rs:187:26:187:27 | id |
+| main.rs:201:9:201:14 | either | main.rs:201:9:201:14 | either |
+| main.rs:203:9:203:44 | SSA phi(a3) | main.rs:203:9:203:44 | a3 |
+| main.rs:203:22:203:23 | a3 | main.rs:203:9:203:44 | a3 |
+| main.rs:203:42:203:43 | a3 | main.rs:203:9:203:44 | a3 |
+| main.rs:215:9:215:10 | tv | main.rs:215:9:215:10 | tv |
+| main.rs:217:9:217:81 | SSA phi(a4) | main.rs:217:9:217:81 | a4 |
+| main.rs:217:28:217:29 | a4 | main.rs:217:9:217:81 | a4 |
+| main.rs:217:54:217:55 | a4 | main.rs:217:9:217:81 | a4 |
+| main.rs:217:79:217:80 | a4 | main.rs:217:9:217:81 | a4 |
+| main.rs:221:9:221:83 | SSA phi(a5) | main.rs:221:9:221:83 | a5 |
+| main.rs:221:10:221:57 | [match(true)] SSA phi(a5) | main.rs:221:9:221:83 | a5 |
+| main.rs:221:29:221:30 | a5 | main.rs:221:9:221:83 | a5 |
+| main.rs:221:55:221:56 | a5 | main.rs:221:9:221:83 | a5 |
+| main.rs:221:81:221:82 | a5 | main.rs:221:9:221:83 | a5 |
+| main.rs:225:9:225:83 | SSA phi(a6) | main.rs:225:9:225:83 | a6 |
+| main.rs:225:28:225:29 | a6 | main.rs:225:9:225:83 | a6 |
+| main.rs:225:35:225:82 | SSA phi(a6) | main.rs:225:9:225:83 | a6 |
+| main.rs:225:55:225:56 | a6 | main.rs:225:9:225:83 | a6 |
+| main.rs:225:80:225:81 | a6 | main.rs:225:9:225:83 | a6 |
+| main.rs:231:9:231:14 | either | main.rs:231:9:231:14 | either |
+| main.rs:233:9:233:44 | [match(true)] SSA phi(a7) | main.rs:233:9:233:44 | a7 |
+| main.rs:233:22:233:23 | a7 | main.rs:233:9:233:44 | a7 |
+| main.rs:233:42:233:43 | a7 | main.rs:233:9:233:44 | a7 |
+| main.rs:241:9:241:14 | either | main.rs:241:9:241:14 | either |
+| main.rs:244:13:244:13 | e | main.rs:244:13:244:13 | e |
+| main.rs:245:14:245:51 | [match(true)] SSA phi(a11) | main.rs:245:14:245:51 | a11 |
+| main.rs:245:27:245:29 | a11 | main.rs:245:14:245:51 | a11 |
+| main.rs:245:48:245:50 | a11 | main.rs:245:14:245:51 | a11 |
+| main.rs:248:33:248:35 | a12 | main.rs:248:33:248:35 | a12 |
+| main.rs:265:9:265:10 | fv | main.rs:265:9:265:10 | fv |
+| main.rs:267:9:267:109 | SSA phi(a13) | main.rs:267:9:267:109 | a13 |
+| main.rs:267:27:267:29 | a13 | main.rs:267:9:267:109 | a13 |
+| main.rs:267:35:267:82 | [match(true)] SSA phi(a13) | main.rs:267:9:267:109 | a13 |
+| main.rs:267:54:267:56 | a13 | main.rs:267:9:267:109 | a13 |
+| main.rs:267:79:267:81 | a13 | main.rs:267:9:267:109 | a13 |
+| main.rs:267:106:267:108 | a13 | main.rs:267:9:267:109 | a13 |
+| main.rs:273:5:273:6 | a8 | main.rs:273:5:273:6 | a8 |
+| main.rs:275:9:275:10 | b3 | main.rs:275:9:275:10 | b3 |
+| main.rs:276:9:276:10 | c1 | main.rs:276:9:276:10 | c1 |
+| main.rs:284:20:284:55 | SSA phi(a9) | main.rs:284:20:284:55 | a9 |
+| main.rs:284:33:284:34 | a9 | main.rs:284:20:284:55 | a9 |
+| main.rs:284:53:284:54 | a9 | main.rs:284:20:284:55 | a9 |
+| main.rs:291:13:291:15 | a10 | main.rs:291:13:291:15 | a10 |
+| main.rs:292:13:292:14 | b4 | main.rs:292:13:292:14 | b4 |
+| main.rs:293:13:293:14 | c2 | main.rs:293:13:293:14 | c2 |
+| main.rs:300:9:300:10 | c2 | main.rs:293:13:293:14 | c2 |
+| main.rs:301:9:301:10 | b4 | main.rs:292:13:292:14 | b4 |
+| main.rs:302:9:302:11 | a10 | main.rs:291:13:291:15 | a10 |
+| main.rs:314:13:314:15 | a10 | main.rs:314:13:314:15 | a10 |
+| main.rs:315:13:315:14 | b4 | main.rs:315:13:315:14 | b4 |
+| main.rs:327:9:327:23 | example_closure | main.rs:327:9:327:23 | example_closure |
+| main.rs:328:10:328:10 | x | main.rs:328:10:328:10 | x |
+| main.rs:330:9:330:10 | n1 | main.rs:330:9:330:10 | n1 |
+| main.rs:335:9:335:26 | immutable_variable | main.rs:335:9:335:26 | immutable_variable |
+| main.rs:336:6:336:6 | x | main.rs:336:6:336:6 | x |
+| main.rs:338:9:338:10 | n2 | main.rs:338:9:338:10 | n2 |
+| main.rs:345:9:345:9 | f | main.rs:345:9:345:9 | f |
+| main.rs:346:10:346:10 | x | main.rs:346:10:346:10 | x |
+| main.rs:350:10:350:10 | x | main.rs:350:10:350:10 | x |
+| main.rs:359:14:359:14 | x | main.rs:359:14:359:14 | x |
+| main.rs:368:13:368:13 | f | main.rs:368:13:368:13 | f |
+| main.rs:369:14:369:14 | x | main.rs:369:14:369:14 | x |
+| main.rs:376:9:376:9 | v | main.rs:376:9:376:9 | v |
+| main.rs:378:9:378:12 | text | main.rs:378:9:378:12 | text |
+| main.rs:385:13:385:13 | a | main.rs:385:13:385:13 | a |
+| main.rs:386:5:386:5 | a | main.rs:385:13:385:13 | a |
+| main.rs:388:6:388:11 | &mut a | main.rs:385:13:385:13 | a |
+| main.rs:393:13:393:13 | i | main.rs:393:13:393:13 | i |
+| main.rs:394:9:394:13 | ref_i | main.rs:394:9:394:13 | ref_i |
+| main.rs:395:9:395:14 | &mut i | main.rs:393:13:393:13 | i |
+| main.rs:400:17:400:17 | x | main.rs:400:17:400:17 | x |
+| main.rs:407:22:407:22 | x | main.rs:407:22:407:22 | x |
+| main.rs:407:38:407:38 | y | main.rs:407:38:407:38 | y |
+| main.rs:416:13:416:13 | x | main.rs:416:13:416:13 | x |
+| main.rs:417:9:417:9 | y | main.rs:417:9:417:9 | y |
+| main.rs:418:22:418:27 | &mut x | main.rs:416:13:416:13 | x |
+| main.rs:423:13:423:13 | z | main.rs:423:13:423:13 | z |
+| main.rs:424:9:424:9 | w | main.rs:424:9:424:9 | w |
+| main.rs:427:9:427:14 | &mut z | main.rs:423:13:423:13 | z |
+| main.rs:436:13:436:13 | x | main.rs:436:13:436:13 | x |
+| main.rs:437:9:437:9 | y | main.rs:437:9:437:9 | y |
+| main.rs:438:9:438:14 | &mut x | main.rs:436:13:436:13 | x |
+| main.rs:444:9:444:9 | x | main.rs:444:9:444:9 | x |
+| main.rs:446:9:446:11 | cap | main.rs:446:9:446:11 | cap |
+| main.rs:446:15:448:5 | <captured entry> x | main.rs:444:9:444:9 | x |
+| main.rs:454:13:454:13 | x | main.rs:454:13:454:13 | x |
+| main.rs:456:9:456:16 | closure1 | main.rs:456:9:456:16 | closure1 |
+| main.rs:456:20:458:5 | <captured entry> x | main.rs:454:13:454:13 | x |
+| main.rs:462:13:462:13 | y | main.rs:462:13:462:13 | y |
+| main.rs:464:13:464:20 | closure2 | main.rs:464:13:464:20 | closure2 |
+| main.rs:465:9:465:9 | y | main.rs:462:13:462:13 | y |
+| main.rs:467:5:467:14 | <captured exit> y | main.rs:462:13:462:13 | y |
+| main.rs:470:13:470:13 | z | main.rs:470:13:470:13 | z |
+| main.rs:472:13:472:20 | closure3 | main.rs:472:13:472:20 | closure3 |
+| main.rs:472:24:474:5 | <captured entry> z | main.rs:470:13:470:13 | z |
+| main.rs:480:13:480:13 | i | main.rs:480:13:480:13 | i |
+| main.rs:481:9:481:13 | block | main.rs:481:9:481:13 | block |
+| main.rs:482:9:482:9 | i | main.rs:480:13:480:13 | i |
+| main.rs:485:5:485:15 | <captured exit> i | main.rs:480:13:480:13 | i |
+| main.rs:489:8:489:8 | b | main.rs:489:8:489:8 | b |
+| main.rs:490:13:490:13 | x | main.rs:490:13:490:13 | x |
+| main.rs:494:13:503:5 | SSA phi(x) | main.rs:490:13:490:13 | x |
+| main.rs:496:9:496:9 | x | main.rs:490:13:490:13 | x |
+| main.rs:500:9:500:9 | x | main.rs:490:13:490:13 | x |
+| main.rs:507:13:507:14 | b1 | main.rs:507:13:507:14 | b1 |
+| main.rs:507:23:507:24 | b2 | main.rs:507:23:507:24 | b2 |
+| main.rs:508:9:508:9 | x | main.rs:508:9:508:9 | x |
+| main.rs:531:20:531:23 | self | main.rs:531:20:531:23 | self |
+| main.rs:535:11:535:14 | self | main.rs:535:11:535:14 | self |
+| main.rs:539:23:539:26 | self | main.rs:539:23:539:26 | self |
+| main.rs:540:17:540:17 | f | main.rs:540:17:540:17 | f |
+| main.rs:540:21:543:9 | <captured entry> self | main.rs:539:23:539:26 | self |
+| main.rs:540:22:540:22 | n | main.rs:540:22:540:22 | n |
+| main.rs:550:13:550:13 | a | main.rs:550:13:550:13 | a |
+| main.rs:551:15:551:15 | a | main.rs:550:13:550:13 | a |
+| main.rs:554:5:554:5 | a | main.rs:550:13:550:13 | a |
+| main.rs:559:13:559:13 | a | main.rs:559:13:559:13 | a |
+| main.rs:563:5:563:5 | a | main.rs:559:13:559:13 | a |
+| main.rs:568:9:568:9 | x | main.rs:568:9:568:9 | x |
+| main.rs:572:9:572:9 | z | main.rs:572:9:572:9 | z |
+| main.rs:581:17:581:20 | self | main.rs:581:17:581:20 | self |
+| main.rs:587:13:587:13 | a | main.rs:587:13:587:13 | a |
+| main.rs:588:5:588:5 | a | main.rs:587:13:587:13 | a |
+| main.rs:608:9:608:22 | var_from_macro | main.rs:608:9:608:22 | var_from_macro |
+| main.rs:609:9:609:25 | var_in_macro | main.rs:609:9:609:25 | var_in_macro |
+| main.rs:611:9:611:20 | var_in_macro | main.rs:611:9:611:20 | var_in_macro |
+| main.rs:615:15:615:42 | var_in_macro | main.rs:615:15:615:42 | var_in_macro |
+| main.rs:621:5:621:5 | x | main.rs:620:9:620:9 | x |
+| main.rs:626:13:626:13 | x | main.rs:626:13:626:13 | x |
+| main.rs:627:13:627:15 | cap | main.rs:627:13:627:15 | cap |
+| main.rs:627:20:627:20 | b | main.rs:627:20:627:20 | b |
+| main.rs:629:17:631:9 | SSA phi(x) | main.rs:626:13:626:13 | x |
+| main.rs:630:13:630:13 | x | main.rs:626:13:626:13 | x |
+| main.rs:633:5:633:13 | <captured exit> x | main.rs:626:13:626:13 | x |
 read
-| main.rs:3:14:3:14 | s | main.rs:3:14:3:14 | s | main.rs:4:20:4:20 | s |
-| main.rs:7:14:7:14 | i | main.rs:7:14:7:14 | i | main.rs:8:20:8:20 | i |
-| main.rs:11:18:11:18 | i | main.rs:11:18:11:18 | i | main.rs:12:16:12:16 | i |
-| main.rs:16:9:16:10 | x1 | main.rs:16:9:16:10 | x1 | main.rs:17:15:17:16 | x1 |
-| main.rs:21:13:21:14 | x2 | main.rs:21:13:21:14 | x2 | main.rs:22:15:22:16 | x2 |
-| main.rs:23:5:23:6 | x2 | main.rs:21:13:21:14 | x2 | main.rs:24:15:24:16 | x2 |
-| main.rs:28:13:28:13 | x | main.rs:28:13:28:13 | x | main.rs:29:20:29:20 | x |
-| main.rs:30:5:30:5 | x | main.rs:28:13:28:13 | x | main.rs:31:20:31:20 | x |
-| main.rs:35:9:35:10 | x3 | main.rs:35:9:35:10 | x3 | main.rs:36:15:36:16 | x3 |
-| main.rs:35:9:35:10 | x3 | main.rs:35:9:35:10 | x3 | main.rs:38:9:38:10 | x3 |
-| main.rs:37:9:37:10 | x3 | main.rs:37:9:37:10 | x3 | main.rs:39:15:39:16 | x3 |
-| main.rs:43:9:43:10 | x4 | main.rs:43:9:43:10 | x4 | main.rs:44:15:44:16 | x4 |
-| main.rs:43:9:43:10 | x4 | main.rs:43:9:43:10 | x4 | main.rs:49:15:49:16 | x4 |
-| main.rs:46:13:46:14 | x4 | main.rs:46:13:46:14 | x4 | main.rs:47:19:47:20 | x4 |
-| main.rs:60:13:60:14 | a1 | main.rs:60:13:60:14 | a1 | main.rs:68:15:68:16 | a1 |
-| main.rs:61:13:61:14 | b1 | main.rs:61:13:61:14 | b1 | main.rs:69:15:69:16 | b1 |
-| main.rs:64:13:64:13 | x | main.rs:64:13:64:13 | x | main.rs:70:15:70:15 | x |
-| main.rs:65:13:65:13 | y | main.rs:65:13:65:13 | y | main.rs:71:15:71:15 | y |
-| main.rs:75:9:75:10 | p1 | main.rs:75:9:75:10 | p1 | main.rs:79:9:79:10 | p1 |
-| main.rs:77:12:77:13 | a2 | main.rs:77:12:77:13 | a2 | main.rs:80:15:80:16 | a2 |
-| main.rs:78:12:78:13 | b2 | main.rs:78:12:78:13 | b2 | main.rs:81:15:81:16 | b2 |
-| main.rs:85:9:85:10 | s1 | main.rs:85:9:85:10 | s1 | main.rs:88:11:88:12 | s1 |
-| main.rs:87:21:87:22 | s2 | main.rs:87:21:87:22 | s2 | main.rs:89:19:89:20 | s2 |
-| main.rs:94:14:94:15 | x5 | main.rs:94:14:94:15 | x5 | main.rs:98:15:98:16 | x5 |
-| main.rs:102:9:102:10 | s1 | main.rs:102:9:102:10 | s1 | main.rs:105:11:105:12 | s1 |
-| main.rs:104:24:104:25 | s2 | main.rs:104:24:104:25 | s2 | main.rs:106:19:106:20 | s2 |
-| main.rs:111:9:111:10 | x6 | main.rs:111:9:111:10 | x6 | main.rs:114:11:114:12 | x6 |
-| main.rs:112:9:112:10 | y1 | main.rs:112:9:112:10 | y1 | main.rs:124:15:124:16 | y1 |
-| main.rs:116:14:116:15 | y1 | main.rs:116:14:116:15 | y1 | main.rs:119:23:119:24 | y1 |
-| main.rs:128:9:128:15 | numbers | main.rs:128:9:128:15 | numbers | main.rs:130:11:130:17 | numbers |
-| main.rs:128:9:128:15 | numbers | main.rs:128:9:128:15 | numbers | main.rs:142:11:142:17 | numbers |
-| main.rs:132:13:132:17 | first | main.rs:132:13:132:17 | first | main.rs:136:23:136:27 | first |
-| main.rs:133:13:133:17 | third | main.rs:133:13:133:17 | third | main.rs:137:23:137:27 | third |
-| main.rs:134:13:134:17 | fifth | main.rs:134:13:134:17 | fifth | main.rs:138:23:138:27 | fifth |
-| main.rs:144:13:144:17 | first | main.rs:144:13:144:17 | first | main.rs:148:23:148:27 | first |
-| main.rs:146:13:146:16 | last | main.rs:146:13:146:16 | last | main.rs:149:23:149:26 | last |
-| main.rs:155:9:155:10 | p2 | main.rs:155:9:155:10 | p2 | main.rs:157:11:157:12 | p2 |
-| main.rs:159:16:159:17 | x7 | main.rs:159:16:159:17 | x7 | main.rs:160:24:160:25 | x7 |
-| main.rs:169:9:169:11 | msg | main.rs:169:9:169:11 | msg | main.rs:171:11:171:13 | msg |
-| main.rs:173:17:173:27 | id_variable | main.rs:173:17:173:27 | id_variable | main.rs:174:24:174:34 | id_variable |
-| main.rs:178:26:178:27 | id | main.rs:178:26:178:27 | id | main.rs:179:23:179:24 | id |
-| main.rs:189:9:189:14 | either | main.rs:189:9:189:14 | either | main.rs:190:11:190:16 | either |
-| main.rs:191:9:191:44 | SSA phi(a3) | main.rs:191:9:191:44 | a3 | main.rs:192:26:192:27 | a3 |
-| main.rs:203:9:203:10 | tv | main.rs:203:9:203:10 | tv | main.rs:204:11:204:12 | tv |
-| main.rs:203:9:203:10 | tv | main.rs:203:9:203:10 | tv | main.rs:208:11:208:12 | tv |
-| main.rs:203:9:203:10 | tv | main.rs:203:9:203:10 | tv | main.rs:212:11:212:12 | tv |
-| main.rs:205:9:205:81 | SSA phi(a4) | main.rs:205:9:205:81 | a4 | main.rs:206:26:206:27 | a4 |
-| main.rs:209:9:209:83 | SSA phi(a5) | main.rs:209:9:209:83 | a5 | main.rs:210:26:210:27 | a5 |
-| main.rs:213:9:213:83 | SSA phi(a6) | main.rs:213:9:213:83 | a6 | main.rs:214:26:214:27 | a6 |
-| main.rs:219:9:219:14 | either | main.rs:219:9:219:14 | either | main.rs:220:11:220:16 | either |
-| main.rs:221:9:221:44 | [match(true)] SSA phi(a7) | main.rs:221:9:221:44 | a7 | main.rs:222:16:222:17 | a7 |
-| main.rs:221:9:221:44 | [match(true)] SSA phi(a7) | main.rs:221:9:221:44 | a7 | main.rs:223:26:223:27 | a7 |
-| main.rs:229:9:229:14 | either | main.rs:229:9:229:14 | either | main.rs:231:11:231:16 | either |
-| main.rs:232:13:232:13 | e | main.rs:232:13:232:13 | e | main.rs:237:15:237:15 | e |
-| main.rs:233:14:233:51 | [match(true)] SSA phi(a11) | main.rs:233:14:233:51 | a11 | main.rs:235:23:235:25 | a11 |
-| main.rs:236:33:236:35 | a12 | main.rs:236:33:236:35 | a12 | main.rs:238:28:238:30 | a12 |
-| main.rs:253:9:253:10 | fv | main.rs:253:9:253:10 | fv | main.rs:254:11:254:12 | fv |
-| main.rs:255:9:255:109 | SSA phi(a13) | main.rs:255:9:255:109 | a13 | main.rs:256:26:256:28 | a13 |
-| main.rs:261:5:261:6 | a8 | main.rs:261:5:261:6 | a8 | main.rs:266:15:266:16 | a8 |
-| main.rs:263:9:263:10 | b3 | main.rs:263:9:263:10 | b3 | main.rs:267:15:267:16 | b3 |
-| main.rs:264:9:264:10 | c1 | main.rs:264:9:264:10 | c1 | main.rs:268:15:268:16 | c1 |
-| main.rs:272:6:272:41 | SSA phi(a9) | main.rs:272:6:272:41 | a9 | main.rs:274:15:274:16 | a9 |
-| main.rs:279:13:279:15 | a10 | main.rs:279:13:279:15 | a10 | main.rs:283:15:283:17 | a10 |
-| main.rs:280:13:280:14 | b4 | main.rs:280:13:280:14 | b4 | main.rs:284:15:284:16 | b4 |
-| main.rs:281:13:281:14 | c2 | main.rs:281:13:281:14 | c2 | main.rs:285:15:285:16 | c2 |
-| main.rs:288:9:288:10 | c2 | main.rs:281:13:281:14 | c2 | main.rs:294:9:294:10 | c2 |
-| main.rs:288:9:288:10 | c2 | main.rs:281:13:281:14 | c2 | main.rs:298:15:298:16 | c2 |
-| main.rs:289:9:289:10 | b4 | main.rs:280:13:280:14 | b4 | main.rs:293:9:293:10 | b4 |
-| main.rs:289:9:289:10 | b4 | main.rs:280:13:280:14 | b4 | main.rs:297:15:297:16 | b4 |
-| main.rs:289:9:289:10 | b4 | main.rs:280:13:280:14 | b4 | main.rs:311:15:311:16 | b4 |
-| main.rs:290:9:290:11 | a10 | main.rs:279:13:279:15 | a10 | main.rs:292:9:292:11 | a10 |
-| main.rs:290:9:290:11 | a10 | main.rs:279:13:279:15 | a10 | main.rs:296:15:296:17 | a10 |
-| main.rs:290:9:290:11 | a10 | main.rs:279:13:279:15 | a10 | main.rs:310:15:310:17 | a10 |
-| main.rs:302:13:302:15 | a10 | main.rs:302:13:302:15 | a10 | main.rs:305:23:305:25 | a10 |
-| main.rs:303:13:303:14 | b4 | main.rs:303:13:303:14 | b4 | main.rs:306:23:306:24 | b4 |
-| main.rs:315:9:315:23 | example_closure | main.rs:315:9:315:23 | example_closure | main.rs:319:9:319:23 | example_closure |
-| main.rs:316:10:316:10 | x | main.rs:316:10:316:10 | x | main.rs:317:9:317:9 | x |
-| main.rs:318:9:318:10 | n1 | main.rs:318:9:318:10 | n1 | main.rs:320:15:320:16 | n1 |
-| main.rs:323:9:323:26 | immutable_variable | main.rs:323:9:323:26 | immutable_variable | main.rs:327:9:327:26 | immutable_variable |
-| main.rs:324:10:324:10 | x | main.rs:324:10:324:10 | x | main.rs:325:9:325:9 | x |
-| main.rs:326:9:326:10 | n2 | main.rs:326:9:326:10 | n2 | main.rs:328:15:328:16 | n2 |
-| main.rs:333:9:333:9 | f | main.rs:333:9:333:9 | f | main.rs:336:15:336:15 | f |
-| main.rs:333:9:333:9 | f | main.rs:333:9:333:9 | f | main.rs:342:15:342:15 | f |
-| main.rs:334:10:334:10 | x | main.rs:334:10:334:10 | x | main.rs:335:9:335:9 | x |
-| main.rs:338:10:338:10 | x | main.rs:338:10:338:10 | x | main.rs:339:9:339:9 | x |
-| main.rs:346:14:346:14 | x | main.rs:346:14:346:14 | x | main.rs:347:17:347:17 | x |
-| main.rs:354:13:354:13 | f | main.rs:354:13:354:13 | f | main.rs:357:19:357:19 | f |
-| main.rs:355:14:355:14 | x | main.rs:355:14:355:14 | x | main.rs:356:13:356:13 | x |
-| main.rs:362:9:362:9 | v | main.rs:362:9:362:9 | v | main.rs:365:12:365:12 | v |
-| main.rs:364:9:364:12 | text | main.rs:364:9:364:12 | text | main.rs:366:19:366:22 | text |
-| main.rs:371:13:371:13 | a | main.rs:371:13:371:13 | a | main.rs:372:5:372:5 | a |
-| main.rs:372:5:372:5 | a | main.rs:371:13:371:13 | a | main.rs:373:15:373:15 | a |
-| main.rs:372:5:372:5 | a | main.rs:371:13:371:13 | a | main.rs:374:11:374:11 | a |
-| main.rs:374:6:374:11 | &mut a | main.rs:371:13:371:13 | a | main.rs:375:15:375:15 | a |
-| main.rs:379:13:379:13 | i | main.rs:379:13:379:13 | i | main.rs:381:14:381:14 | i |
-| main.rs:380:9:380:13 | ref_i | main.rs:380:9:380:13 | ref_i | main.rs:382:6:382:10 | ref_i |
-| main.rs:381:9:381:14 | &mut i | main.rs:379:13:379:13 | i | main.rs:383:15:383:15 | i |
-| main.rs:386:17:386:17 | x | main.rs:386:17:386:17 | x | main.rs:387:6:387:6 | x |
-| main.rs:386:17:386:17 | x | main.rs:386:17:386:17 | x | main.rs:388:10:388:10 | x |
-| main.rs:386:17:386:17 | x | main.rs:386:17:386:17 | x | main.rs:389:10:389:10 | x |
-| main.rs:386:17:386:17 | x | main.rs:386:17:386:17 | x | main.rs:390:12:390:12 | x |
-| main.rs:393:22:393:22 | x | main.rs:393:22:393:22 | x | main.rs:394:6:394:6 | x |
-| main.rs:393:22:393:22 | x | main.rs:393:22:393:22 | x | main.rs:395:10:395:10 | x |
-| main.rs:393:22:393:22 | x | main.rs:393:22:393:22 | x | main.rs:396:10:396:10 | x |
-| main.rs:393:22:393:22 | x | main.rs:393:22:393:22 | x | main.rs:398:9:398:9 | x |
-| main.rs:393:39:393:39 | y | main.rs:393:39:393:39 | y | main.rs:397:6:397:6 | y |
-| main.rs:402:13:402:13 | x | main.rs:402:13:402:13 | x | main.rs:404:27:404:27 | x |
-| main.rs:403:9:403:9 | y | main.rs:403:9:403:9 | y | main.rs:405:6:405:6 | y |
-| main.rs:404:22:404:27 | &mut x | main.rs:402:13:402:13 | x | main.rs:407:15:407:15 | x |
-| main.rs:404:22:404:27 | &mut x | main.rs:402:13:402:13 | x | main.rs:411:19:411:19 | x |
-| main.rs:409:13:409:13 | z | main.rs:409:13:409:13 | z | main.rs:413:14:413:14 | z |
-| main.rs:410:9:410:9 | w | main.rs:410:9:410:9 | w | main.rs:414:9:414:9 | w |
-| main.rs:410:9:410:9 | w | main.rs:410:9:410:9 | w | main.rs:416:7:416:7 | w |
-| main.rs:413:9:413:14 | &mut z | main.rs:409:13:409:13 | z | main.rs:418:15:418:15 | z |
-| main.rs:422:13:422:13 | x | main.rs:422:13:422:13 | x | main.rs:424:14:424:14 | x |
-| main.rs:423:9:423:9 | y | main.rs:423:9:423:9 | y | main.rs:425:6:425:6 | y |
-| main.rs:424:9:424:14 | &mut x | main.rs:422:13:422:13 | x | main.rs:426:15:426:15 | x |
-| main.rs:430:9:430:9 | x | main.rs:430:9:430:9 | x | main.rs:436:15:436:15 | x |
-| main.rs:432:9:432:11 | cap | main.rs:432:9:432:11 | cap | main.rs:435:5:435:7 | cap |
-| main.rs:432:15:434:5 | <captured entry> x | main.rs:430:9:430:9 | x | main.rs:433:19:433:19 | x |
-| main.rs:440:13:440:13 | x | main.rs:440:13:440:13 | x | main.rs:446:15:446:15 | x |
-| main.rs:442:9:442:16 | closure1 | main.rs:442:9:442:16 | closure1 | main.rs:445:5:445:12 | closure1 |
-| main.rs:442:20:444:5 | <captured entry> x | main.rs:440:13:440:13 | x | main.rs:443:19:443:19 | x |
-| main.rs:450:13:450:20 | closure2 | main.rs:450:13:450:20 | closure2 | main.rs:453:5:453:12 | closure2 |
-| main.rs:453:5:453:14 | <captured exit> y | main.rs:448:13:448:13 | y | main.rs:454:15:454:15 | y |
-| main.rs:456:13:456:13 | z | main.rs:456:13:456:13 | z | main.rs:462:15:462:15 | z |
-| main.rs:458:13:458:20 | closure3 | main.rs:458:13:458:20 | closure3 | main.rs:461:5:461:12 | closure3 |
-| main.rs:458:24:460:5 | <captured entry> z | main.rs:456:13:456:13 | z | main.rs:459:9:459:9 | z |
-| main.rs:467:9:467:13 | block | main.rs:467:9:467:13 | block | main.rs:471:5:471:9 | block |
-| main.rs:471:5:471:15 | <captured exit> i | main.rs:466:13:466:13 | i | main.rs:472:15:472:15 | i |
-| main.rs:475:8:475:8 | b | main.rs:475:8:475:8 | b | main.rs:479:8:479:8 | b |
-| main.rs:476:13:476:13 | x | main.rs:476:13:476:13 | x | main.rs:477:15:477:15 | x |
-| main.rs:476:13:476:13 | x | main.rs:476:13:476:13 | x | main.rs:478:15:478:15 | x |
-| main.rs:479:5:487:5 | SSA phi(x) | main.rs:476:13:476:13 | x | main.rs:488:15:488:15 | x |
-| main.rs:480:9:480:9 | x | main.rs:476:13:476:13 | x | main.rs:481:19:481:19 | x |
-| main.rs:480:9:480:9 | x | main.rs:476:13:476:13 | x | main.rs:482:19:482:19 | x |
-| main.rs:484:9:484:9 | x | main.rs:476:13:476:13 | x | main.rs:485:19:485:19 | x |
-| main.rs:484:9:484:9 | x | main.rs:476:13:476:13 | x | main.rs:486:19:486:19 | x |
-| main.rs:491:13:491:14 | b1 | main.rs:491:13:491:14 | b1 | main.rs:493:8:493:9 | b1 |
-| main.rs:491:24:491:25 | b2 | main.rs:491:24:491:25 | b2 | main.rs:499:8:499:9 | b2 |
-| main.rs:492:9:492:9 | x | main.rs:492:9:492:9 | x | main.rs:494:19:494:19 | x |
-| main.rs:492:9:492:9 | x | main.rs:492:9:492:9 | x | main.rs:496:19:496:19 | x |
-| main.rs:492:9:492:9 | x | main.rs:492:9:492:9 | x | main.rs:500:19:500:19 | x |
-| main.rs:492:9:492:9 | x | main.rs:492:9:492:9 | x | main.rs:502:19:502:19 | x |
-| main.rs:512:20:512:23 | self | main.rs:512:20:512:23 | self | main.rs:513:16:513:19 | self |
-| main.rs:516:11:516:14 | self | main.rs:516:11:516:14 | self | main.rs:517:9:517:12 | self |
-| main.rs:521:17:521:17 | f | main.rs:521:17:521:17 | f | main.rs:525:9:525:9 | f |
-| main.rs:521:17:521:17 | f | main.rs:521:17:521:17 | f | main.rs:526:9:526:9 | f |
-| main.rs:521:21:524:9 | <captured entry> self | main.rs:520:23:520:26 | self | main.rs:523:13:523:16 | self |
-| main.rs:521:22:521:22 | n | main.rs:521:22:521:22 | n | main.rs:523:25:523:25 | n |
-| main.rs:531:13:531:13 | a | main.rs:531:13:531:13 | a | main.rs:532:15:532:15 | a |
-| main.rs:532:15:532:15 | a | main.rs:531:13:531:13 | a | main.rs:533:5:533:5 | a |
-| main.rs:532:15:532:15 | a | main.rs:531:13:531:13 | a | main.rs:534:15:534:15 | a |
-| main.rs:535:5:535:5 | a | main.rs:531:13:531:13 | a | main.rs:536:15:536:15 | a |
-| main.rs:540:13:540:13 | a | main.rs:540:13:540:13 | a | main.rs:541:15:541:15 | a |
-| main.rs:540:13:540:13 | a | main.rs:540:13:540:13 | a | main.rs:542:5:542:5 | a |
-| main.rs:540:13:540:13 | a | main.rs:540:13:540:13 | a | main.rs:543:15:543:15 | a |
-| main.rs:544:5:544:5 | a | main.rs:540:13:540:13 | a | main.rs:545:15:545:15 | a |
-| main.rs:549:9:549:9 | x | main.rs:549:9:549:9 | x | main.rs:550:20:550:20 | x |
-| main.rs:549:9:549:9 | x | main.rs:549:9:549:9 | x | main.rs:551:15:551:15 | x |
-| main.rs:553:9:553:9 | z | main.rs:553:9:553:9 | z | main.rs:554:20:554:20 | z |
-| main.rs:562:15:562:18 | self | main.rs:562:15:562:18 | self | main.rs:563:6:563:9 | self |
-| main.rs:568:11:568:11 | a | main.rs:568:11:568:11 | a | main.rs:569:3:569:3 | a |
-| main.rs:569:3:569:3 | a | main.rs:568:11:568:11 | a | main.rs:571:13:571:13 | a |
-| main.rs:593:9:593:22 | var_from_macro | main.rs:593:9:593:22 | var_from_macro | main.rs:595:15:595:28 | var_from_macro |
-| main.rs:594:9:594:25 | var_in_macro | main.rs:594:9:594:25 | var_in_macro | main.rs:594:9:594:25 | var_in_macro |
-| main.rs:596:9:596:20 | var_in_macro | main.rs:596:9:596:20 | var_in_macro | main.rs:601:15:601:26 | var_in_macro |
-| main.rs:600:15:600:42 | var_in_macro | main.rs:600:15:600:42 | var_in_macro | main.rs:600:30:600:41 | var_in_macro |
+| main.rs:3:14:3:14 | s | main.rs:3:14:3:14 | s | main.rs:5:20:5:20 | s |
+| main.rs:8:14:8:14 | i | main.rs:8:14:8:14 | i | main.rs:10:20:10:20 | i |
+| main.rs:13:18:13:18 | i | main.rs:13:18:13:18 | i | main.rs:14:16:14:16 | i |
+| main.rs:18:9:18:10 | x1 | main.rs:18:9:18:10 | x1 | main.rs:19:15:19:16 | x1 |
+| main.rs:23:13:23:14 | x2 | main.rs:23:13:23:14 | x2 | main.rs:24:15:24:16 | x2 |
+| main.rs:25:5:25:6 | x2 | main.rs:23:13:23:14 | x2 | main.rs:26:15:26:16 | x2 |
+| main.rs:30:13:30:13 | x | main.rs:30:13:30:13 | x | main.rs:31:20:31:20 | x |
+| main.rs:32:5:32:5 | x | main.rs:30:13:30:13 | x | main.rs:33:20:33:20 | x |
+| main.rs:37:9:37:10 | x3 | main.rs:37:9:37:10 | x3 | main.rs:38:15:38:16 | x3 |
+| main.rs:37:9:37:10 | x3 | main.rs:37:9:37:10 | x3 | main.rs:40:9:40:10 | x3 |
+| main.rs:39:9:39:10 | x3 | main.rs:39:9:39:10 | x3 | main.rs:41:15:41:16 | x3 |
+| main.rs:45:9:45:10 | x4 | main.rs:45:9:45:10 | x4 | main.rs:46:15:46:16 | x4 |
+| main.rs:45:9:45:10 | x4 | main.rs:45:9:45:10 | x4 | main.rs:51:15:51:16 | x4 |
+| main.rs:48:13:48:14 | x4 | main.rs:48:13:48:14 | x4 | main.rs:49:19:49:20 | x4 |
+| main.rs:62:13:62:14 | a1 | main.rs:62:13:62:14 | a1 | main.rs:70:15:70:16 | a1 |
+| main.rs:63:13:63:14 | b1 | main.rs:63:13:63:14 | b1 | main.rs:71:15:71:16 | b1 |
+| main.rs:66:13:66:13 | x | main.rs:66:13:66:13 | x | main.rs:72:15:72:15 | x |
+| main.rs:67:13:67:13 | y | main.rs:67:13:67:13 | y | main.rs:73:15:73:15 | y |
+| main.rs:77:9:77:10 | p1 | main.rs:77:9:77:10 | p1 | main.rs:81:9:81:10 | p1 |
+| main.rs:79:12:79:13 | a2 | main.rs:79:12:79:13 | a2 | main.rs:82:15:82:16 | a2 |
+| main.rs:80:12:80:13 | b2 | main.rs:80:12:80:13 | b2 | main.rs:83:15:83:16 | b2 |
+| main.rs:87:9:87:10 | s1 | main.rs:87:9:87:10 | s1 | main.rs:90:11:90:12 | s1 |
+| main.rs:89:21:89:22 | s2 | main.rs:89:21:89:22 | s2 | main.rs:91:19:91:20 | s2 |
+| main.rs:96:14:96:15 | x5 | main.rs:96:14:96:15 | x5 | main.rs:102:15:102:16 | x5 |
+| main.rs:106:9:106:10 | s1 | main.rs:106:9:106:10 | s1 | main.rs:109:11:109:12 | s1 |
+| main.rs:108:24:108:25 | s2 | main.rs:108:24:108:25 | s2 | main.rs:110:19:110:20 | s2 |
+| main.rs:115:9:115:10 | x6 | main.rs:115:9:115:10 | x6 | main.rs:118:11:118:12 | x6 |
+| main.rs:116:9:116:10 | y1 | main.rs:116:9:116:10 | y1 | main.rs:128:15:128:16 | y1 |
+| main.rs:120:14:120:15 | y1 | main.rs:120:14:120:15 | y1 | main.rs:123:23:123:24 | y1 |
+| main.rs:132:9:132:15 | numbers | main.rs:132:9:132:15 | numbers | main.rs:134:11:134:17 | numbers |
+| main.rs:132:9:132:15 | numbers | main.rs:132:9:132:15 | numbers | main.rs:149:11:149:17 | numbers |
+| main.rs:137:13:137:17 | first | main.rs:137:13:137:17 | first | main.rs:143:23:143:27 | first |
+| main.rs:139:13:139:17 | third | main.rs:139:13:139:17 | third | main.rs:144:23:144:27 | third |
+| main.rs:141:13:141:17 | fifth | main.rs:141:13:141:17 | fifth | main.rs:145:23:145:27 | fifth |
+| main.rs:152:13:152:17 | first | main.rs:152:13:152:17 | first | main.rs:156:23:156:27 | first |
+| main.rs:154:13:154:16 | last | main.rs:154:13:154:16 | last | main.rs:157:23:157:26 | last |
+| main.rs:163:9:163:10 | p2 | main.rs:163:9:163:10 | p2 | main.rs:165:11:165:12 | p2 |
+| main.rs:167:16:167:17 | x7 | main.rs:167:16:167:17 | x7 | main.rs:168:24:168:25 | x7 |
+| main.rs:177:9:177:11 | msg | main.rs:177:9:177:11 | msg | main.rs:179:11:179:13 | msg |
+| main.rs:182:17:182:27 | id_variable | main.rs:182:17:182:27 | id_variable | main.rs:183:24:183:34 | id_variable |
+| main.rs:187:26:187:27 | id | main.rs:187:26:187:27 | id | main.rs:190:23:190:24 | id |
+| main.rs:201:9:201:14 | either | main.rs:201:9:201:14 | either | main.rs:202:11:202:16 | either |
+| main.rs:203:9:203:44 | SSA phi(a3) | main.rs:203:9:203:44 | a3 | main.rs:204:26:204:27 | a3 |
+| main.rs:215:9:215:10 | tv | main.rs:215:9:215:10 | tv | main.rs:216:11:216:12 | tv |
+| main.rs:215:9:215:10 | tv | main.rs:215:9:215:10 | tv | main.rs:220:11:220:12 | tv |
+| main.rs:215:9:215:10 | tv | main.rs:215:9:215:10 | tv | main.rs:224:11:224:12 | tv |
+| main.rs:217:9:217:81 | SSA phi(a4) | main.rs:217:9:217:81 | a4 | main.rs:218:26:218:27 | a4 |
+| main.rs:221:9:221:83 | SSA phi(a5) | main.rs:221:9:221:83 | a5 | main.rs:222:26:222:27 | a5 |
+| main.rs:225:9:225:83 | SSA phi(a6) | main.rs:225:9:225:83 | a6 | main.rs:226:26:226:27 | a6 |
+| main.rs:231:9:231:14 | either | main.rs:231:9:231:14 | either | main.rs:232:11:232:16 | either |
+| main.rs:233:9:233:44 | [match(true)] SSA phi(a7) | main.rs:233:9:233:44 | a7 | main.rs:234:16:234:17 | a7 |
+| main.rs:233:9:233:44 | [match(true)] SSA phi(a7) | main.rs:233:9:233:44 | a7 | main.rs:235:26:235:27 | a7 |
+| main.rs:241:9:241:14 | either | main.rs:241:9:241:14 | either | main.rs:243:11:243:16 | either |
+| main.rs:244:13:244:13 | e | main.rs:244:13:244:13 | e | main.rs:249:15:249:15 | e |
+| main.rs:245:14:245:51 | [match(true)] SSA phi(a11) | main.rs:245:14:245:51 | a11 | main.rs:247:23:247:25 | a11 |
+| main.rs:248:33:248:35 | a12 | main.rs:248:33:248:35 | a12 | main.rs:250:28:250:30 | a12 |
+| main.rs:265:9:265:10 | fv | main.rs:265:9:265:10 | fv | main.rs:266:11:266:12 | fv |
+| main.rs:267:9:267:109 | SSA phi(a13) | main.rs:267:9:267:109 | a13 | main.rs:268:26:268:28 | a13 |
+| main.rs:273:5:273:6 | a8 | main.rs:273:5:273:6 | a8 | main.rs:279:15:279:16 | a8 |
+| main.rs:275:9:275:10 | b3 | main.rs:275:9:275:10 | b3 | main.rs:280:15:280:16 | b3 |
+| main.rs:276:9:276:10 | c1 | main.rs:276:9:276:10 | c1 | main.rs:281:15:281:16 | c1 |
+| main.rs:284:20:284:55 | SSA phi(a9) | main.rs:284:20:284:55 | a9 | main.rs:286:15:286:16 | a9 |
+| main.rs:291:13:291:15 | a10 | main.rs:291:13:291:15 | a10 | main.rs:295:15:295:17 | a10 |
+| main.rs:292:13:292:14 | b4 | main.rs:292:13:292:14 | b4 | main.rs:296:15:296:16 | b4 |
+| main.rs:293:13:293:14 | c2 | main.rs:293:13:293:14 | c2 | main.rs:297:15:297:16 | c2 |
+| main.rs:300:9:300:10 | c2 | main.rs:293:13:293:14 | c2 | main.rs:306:9:306:10 | c2 |
+| main.rs:300:9:300:10 | c2 | main.rs:293:13:293:14 | c2 | main.rs:310:15:310:16 | c2 |
+| main.rs:301:9:301:10 | b4 | main.rs:292:13:292:14 | b4 | main.rs:305:9:305:10 | b4 |
+| main.rs:301:9:301:10 | b4 | main.rs:292:13:292:14 | b4 | main.rs:309:15:309:16 | b4 |
+| main.rs:301:9:301:10 | b4 | main.rs:292:13:292:14 | b4 | main.rs:323:15:323:16 | b4 |
+| main.rs:302:9:302:11 | a10 | main.rs:291:13:291:15 | a10 | main.rs:304:9:304:11 | a10 |
+| main.rs:302:9:302:11 | a10 | main.rs:291:13:291:15 | a10 | main.rs:308:15:308:17 | a10 |
+| main.rs:302:9:302:11 | a10 | main.rs:291:13:291:15 | a10 | main.rs:322:15:322:17 | a10 |
+| main.rs:314:13:314:15 | a10 | main.rs:314:13:314:15 | a10 | main.rs:317:23:317:25 | a10 |
+| main.rs:315:13:315:14 | b4 | main.rs:315:13:315:14 | b4 | main.rs:318:23:318:24 | b4 |
+| main.rs:327:9:327:23 | example_closure | main.rs:327:9:327:23 | example_closure | main.rs:331:9:331:23 | example_closure |
+| main.rs:328:10:328:10 | x | main.rs:328:10:328:10 | x | main.rs:329:9:329:9 | x |
+| main.rs:330:9:330:10 | n1 | main.rs:330:9:330:10 | n1 | main.rs:332:15:332:16 | n1 |
+| main.rs:335:9:335:26 | immutable_variable | main.rs:335:9:335:26 | immutable_variable | main.rs:339:9:339:26 | immutable_variable |
+| main.rs:336:6:336:6 | x | main.rs:336:6:336:6 | x | main.rs:337:9:337:9 | x |
+| main.rs:338:9:338:10 | n2 | main.rs:338:9:338:10 | n2 | main.rs:340:15:340:16 | n2 |
+| main.rs:345:9:345:9 | f | main.rs:345:9:345:9 | f | main.rs:348:15:348:15 | f |
+| main.rs:345:9:345:9 | f | main.rs:345:9:345:9 | f | main.rs:355:15:355:15 | f |
+| main.rs:346:10:346:10 | x | main.rs:346:10:346:10 | x | main.rs:347:9:347:9 | x |
+| main.rs:350:10:350:10 | x | main.rs:350:10:350:10 | x | main.rs:352:9:352:9 | x |
+| main.rs:359:14:359:14 | x | main.rs:359:14:359:14 | x | main.rs:361:17:361:17 | x |
+| main.rs:368:13:368:13 | f | main.rs:368:13:368:13 | f | main.rs:371:19:371:19 | f |
+| main.rs:369:14:369:14 | x | main.rs:369:14:369:14 | x | main.rs:370:13:370:13 | x |
+| main.rs:376:9:376:9 | v | main.rs:376:9:376:9 | v | main.rs:379:12:379:12 | v |
+| main.rs:378:9:378:12 | text | main.rs:378:9:378:12 | text | main.rs:380:19:380:22 | text |
+| main.rs:385:13:385:13 | a | main.rs:385:13:385:13 | a | main.rs:386:5:386:5 | a |
+| main.rs:386:5:386:5 | a | main.rs:385:13:385:13 | a | main.rs:387:15:387:15 | a |
+| main.rs:386:5:386:5 | a | main.rs:385:13:385:13 | a | main.rs:388:11:388:11 | a |
+| main.rs:388:6:388:11 | &mut a | main.rs:385:13:385:13 | a | main.rs:389:15:389:15 | a |
+| main.rs:393:13:393:13 | i | main.rs:393:13:393:13 | i | main.rs:395:14:395:14 | i |
+| main.rs:394:9:394:13 | ref_i | main.rs:394:9:394:13 | ref_i | main.rs:396:6:396:10 | ref_i |
+| main.rs:395:9:395:14 | &mut i | main.rs:393:13:393:13 | i | main.rs:397:15:397:15 | i |
+| main.rs:400:17:400:17 | x | main.rs:400:17:400:17 | x | main.rs:401:6:401:6 | x |
+| main.rs:400:17:400:17 | x | main.rs:400:17:400:17 | x | main.rs:402:10:402:10 | x |
+| main.rs:400:17:400:17 | x | main.rs:400:17:400:17 | x | main.rs:403:10:403:10 | x |
+| main.rs:400:17:400:17 | x | main.rs:400:17:400:17 | x | main.rs:404:12:404:12 | x |
+| main.rs:407:22:407:22 | x | main.rs:407:22:407:22 | x | main.rs:408:6:408:6 | x |
+| main.rs:407:22:407:22 | x | main.rs:407:22:407:22 | x | main.rs:409:10:409:10 | x |
+| main.rs:407:22:407:22 | x | main.rs:407:22:407:22 | x | main.rs:410:10:410:10 | x |
+| main.rs:407:22:407:22 | x | main.rs:407:22:407:22 | x | main.rs:412:9:412:9 | x |
+| main.rs:407:38:407:38 | y | main.rs:407:38:407:38 | y | main.rs:411:6:411:6 | y |
+| main.rs:416:13:416:13 | x | main.rs:416:13:416:13 | x | main.rs:418:27:418:27 | x |
+| main.rs:417:9:417:9 | y | main.rs:417:9:417:9 | y | main.rs:419:6:419:6 | y |
+| main.rs:418:22:418:27 | &mut x | main.rs:416:13:416:13 | x | main.rs:421:15:421:15 | x |
+| main.rs:418:22:418:27 | &mut x | main.rs:416:13:416:13 | x | main.rs:425:19:425:19 | x |
+| main.rs:423:13:423:13 | z | main.rs:423:13:423:13 | z | main.rs:427:14:427:14 | z |
+| main.rs:424:9:424:9 | w | main.rs:424:9:424:9 | w | main.rs:428:9:428:9 | w |
+| main.rs:424:9:424:9 | w | main.rs:424:9:424:9 | w | main.rs:430:7:430:7 | w |
+| main.rs:427:9:427:14 | &mut z | main.rs:423:13:423:13 | z | main.rs:432:15:432:15 | z |
+| main.rs:436:13:436:13 | x | main.rs:436:13:436:13 | x | main.rs:438:14:438:14 | x |
+| main.rs:437:9:437:9 | y | main.rs:437:9:437:9 | y | main.rs:439:6:439:6 | y |
+| main.rs:438:9:438:14 | &mut x | main.rs:436:13:436:13 | x | main.rs:440:15:440:15 | x |
+| main.rs:444:9:444:9 | x | main.rs:444:9:444:9 | x | main.rs:450:15:450:15 | x |
+| main.rs:446:9:446:11 | cap | main.rs:446:9:446:11 | cap | main.rs:449:5:449:7 | cap |
+| main.rs:446:15:448:5 | <captured entry> x | main.rs:444:9:444:9 | x | main.rs:447:19:447:19 | x |
+| main.rs:454:13:454:13 | x | main.rs:454:13:454:13 | x | main.rs:460:15:460:15 | x |
+| main.rs:456:9:456:16 | closure1 | main.rs:456:9:456:16 | closure1 | main.rs:459:5:459:12 | closure1 |
+| main.rs:456:20:458:5 | <captured entry> x | main.rs:454:13:454:13 | x | main.rs:457:19:457:19 | x |
+| main.rs:464:13:464:20 | closure2 | main.rs:464:13:464:20 | closure2 | main.rs:467:5:467:12 | closure2 |
+| main.rs:467:5:467:14 | <captured exit> y | main.rs:462:13:462:13 | y | main.rs:468:15:468:15 | y |
+| main.rs:470:13:470:13 | z | main.rs:470:13:470:13 | z | main.rs:476:15:476:15 | z |
+| main.rs:472:13:472:20 | closure3 | main.rs:472:13:472:20 | closure3 | main.rs:475:5:475:12 | closure3 |
+| main.rs:472:24:474:5 | <captured entry> z | main.rs:470:13:470:13 | z | main.rs:473:9:473:9 | z |
+| main.rs:481:9:481:13 | block | main.rs:481:9:481:13 | block | main.rs:485:5:485:9 | block |
+| main.rs:485:5:485:15 | <captured exit> i | main.rs:480:13:480:13 | i | main.rs:486:15:486:15 | i |
+| main.rs:489:8:489:8 | b | main.rs:489:8:489:8 | b | main.rs:494:16:494:16 | b |
+| main.rs:490:13:490:13 | x | main.rs:490:13:490:13 | x | main.rs:491:15:491:15 | x |
+| main.rs:490:13:490:13 | x | main.rs:490:13:490:13 | x | main.rs:492:15:492:15 | x |
+| main.rs:494:13:503:5 | SSA phi(x) | main.rs:490:13:490:13 | x | main.rs:504:15:504:15 | x |
+| main.rs:496:9:496:9 | x | main.rs:490:13:490:13 | x | main.rs:497:19:497:19 | x |
+| main.rs:496:9:496:9 | x | main.rs:490:13:490:13 | x | main.rs:498:19:498:19 | x |
+| main.rs:500:9:500:9 | x | main.rs:490:13:490:13 | x | main.rs:501:19:501:19 | x |
+| main.rs:500:9:500:9 | x | main.rs:490:13:490:13 | x | main.rs:502:19:502:19 | x |
+| main.rs:507:13:507:14 | b1 | main.rs:507:13:507:14 | b1 | main.rs:510:16:510:17 | b1 |
+| main.rs:507:23:507:24 | b2 | main.rs:507:23:507:24 | b2 | main.rs:518:16:518:17 | b2 |
+| main.rs:508:9:508:9 | x | main.rs:508:9:508:9 | x | main.rs:512:19:512:19 | x |
+| main.rs:508:9:508:9 | x | main.rs:508:9:508:9 | x | main.rs:514:19:514:19 | x |
+| main.rs:508:9:508:9 | x | main.rs:508:9:508:9 | x | main.rs:520:19:520:19 | x |
+| main.rs:508:9:508:9 | x | main.rs:508:9:508:9 | x | main.rs:522:19:522:19 | x |
+| main.rs:531:20:531:23 | self | main.rs:531:20:531:23 | self | main.rs:532:16:532:19 | self |
+| main.rs:535:11:535:14 | self | main.rs:535:11:535:14 | self | main.rs:536:9:536:12 | self |
+| main.rs:540:17:540:17 | f | main.rs:540:17:540:17 | f | main.rs:544:9:544:9 | f |
+| main.rs:540:17:540:17 | f | main.rs:540:17:540:17 | f | main.rs:545:9:545:9 | f |
+| main.rs:540:21:543:9 | <captured entry> self | main.rs:539:23:539:26 | self | main.rs:542:13:542:16 | self |
+| main.rs:540:22:540:22 | n | main.rs:540:22:540:22 | n | main.rs:542:25:542:25 | n |
+| main.rs:550:13:550:13 | a | main.rs:550:13:550:13 | a | main.rs:551:15:551:15 | a |
+| main.rs:551:15:551:15 | a | main.rs:550:13:550:13 | a | main.rs:552:5:552:5 | a |
+| main.rs:551:15:551:15 | a | main.rs:550:13:550:13 | a | main.rs:553:15:553:15 | a |
+| main.rs:554:5:554:5 | a | main.rs:550:13:550:13 | a | main.rs:555:15:555:15 | a |
+| main.rs:559:13:559:13 | a | main.rs:559:13:559:13 | a | main.rs:560:15:560:15 | a |
+| main.rs:559:13:559:13 | a | main.rs:559:13:559:13 | a | main.rs:561:5:561:5 | a |
+| main.rs:559:13:559:13 | a | main.rs:559:13:559:13 | a | main.rs:562:15:562:15 | a |
+| main.rs:563:5:563:5 | a | main.rs:559:13:559:13 | a | main.rs:564:15:564:15 | a |
+| main.rs:568:9:568:9 | x | main.rs:568:9:568:9 | x | main.rs:569:20:569:20 | x |
+| main.rs:568:9:568:9 | x | main.rs:568:9:568:9 | x | main.rs:570:15:570:15 | x |
+| main.rs:572:9:572:9 | z | main.rs:572:9:572:9 | z | main.rs:573:20:573:20 | z |
+| main.rs:581:17:581:20 | self | main.rs:581:17:581:20 | self | main.rs:582:10:582:13 | self |
+| main.rs:587:13:587:13 | a | main.rs:587:13:587:13 | a | main.rs:588:5:588:5 | a |
+| main.rs:588:5:588:5 | a | main.rs:587:13:587:13 | a | main.rs:590:15:590:15 | a |
+| main.rs:608:9:608:22 | var_from_macro | main.rs:608:9:608:22 | var_from_macro | main.rs:610:15:610:28 | var_from_macro |
+| main.rs:609:9:609:25 | var_in_macro | main.rs:609:9:609:25 | var_in_macro | main.rs:609:9:609:25 | var_in_macro |
+| main.rs:611:9:611:20 | var_in_macro | main.rs:611:9:611:20 | var_in_macro | main.rs:616:15:616:26 | var_in_macro |
+| main.rs:615:15:615:42 | var_in_macro | main.rs:615:15:615:42 | var_in_macro | main.rs:615:30:615:41 | var_in_macro |
+| main.rs:621:5:621:5 | x | main.rs:620:9:620:9 | x | main.rs:622:15:622:15 | x |
+| main.rs:627:13:627:15 | cap | main.rs:627:13:627:15 | cap | main.rs:633:5:633:7 | cap |
+| main.rs:627:20:627:20 | b | main.rs:627:20:627:20 | b | main.rs:629:20:629:20 | b |
+| main.rs:633:5:633:13 | <captured exit> x | main.rs:626:13:626:13 | x | main.rs:634:15:634:15 | x |
 firstRead
-| main.rs:3:14:3:14 | s | main.rs:3:14:3:14 | s | main.rs:4:20:4:20 | s |
-| main.rs:7:14:7:14 | i | main.rs:7:14:7:14 | i | main.rs:8:20:8:20 | i |
-| main.rs:11:18:11:18 | i | main.rs:11:18:11:18 | i | main.rs:12:16:12:16 | i |
-| main.rs:16:9:16:10 | x1 | main.rs:16:9:16:10 | x1 | main.rs:17:15:17:16 | x1 |
-| main.rs:21:13:21:14 | x2 | main.rs:21:13:21:14 | x2 | main.rs:22:15:22:16 | x2 |
-| main.rs:23:5:23:6 | x2 | main.rs:21:13:21:14 | x2 | main.rs:24:15:24:16 | x2 |
-| main.rs:28:13:28:13 | x | main.rs:28:13:28:13 | x | main.rs:29:20:29:20 | x |
-| main.rs:30:5:30:5 | x | main.rs:28:13:28:13 | x | main.rs:31:20:31:20 | x |
-| main.rs:35:9:35:10 | x3 | main.rs:35:9:35:10 | x3 | main.rs:36:15:36:16 | x3 |
-| main.rs:37:9:37:10 | x3 | main.rs:37:9:37:10 | x3 | main.rs:39:15:39:16 | x3 |
-| main.rs:43:9:43:10 | x4 | main.rs:43:9:43:10 | x4 | main.rs:44:15:44:16 | x4 |
-| main.rs:46:13:46:14 | x4 | main.rs:46:13:46:14 | x4 | main.rs:47:19:47:20 | x4 |
-| main.rs:60:13:60:14 | a1 | main.rs:60:13:60:14 | a1 | main.rs:68:15:68:16 | a1 |
-| main.rs:61:13:61:14 | b1 | main.rs:61:13:61:14 | b1 | main.rs:69:15:69:16 | b1 |
-| main.rs:64:13:64:13 | x | main.rs:64:13:64:13 | x | main.rs:70:15:70:15 | x |
-| main.rs:65:13:65:13 | y | main.rs:65:13:65:13 | y | main.rs:71:15:71:15 | y |
-| main.rs:75:9:75:10 | p1 | main.rs:75:9:75:10 | p1 | main.rs:79:9:79:10 | p1 |
-| main.rs:77:12:77:13 | a2 | main.rs:77:12:77:13 | a2 | main.rs:80:15:80:16 | a2 |
-| main.rs:78:12:78:13 | b2 | main.rs:78:12:78:13 | b2 | main.rs:81:15:81:16 | b2 |
-| main.rs:85:9:85:10 | s1 | main.rs:85:9:85:10 | s1 | main.rs:88:11:88:12 | s1 |
-| main.rs:87:21:87:22 | s2 | main.rs:87:21:87:22 | s2 | main.rs:89:19:89:20 | s2 |
-| main.rs:94:14:94:15 | x5 | main.rs:94:14:94:15 | x5 | main.rs:98:15:98:16 | x5 |
-| main.rs:102:9:102:10 | s1 | main.rs:102:9:102:10 | s1 | main.rs:105:11:105:12 | s1 |
-| main.rs:104:24:104:25 | s2 | main.rs:104:24:104:25 | s2 | main.rs:106:19:106:20 | s2 |
-| main.rs:111:9:111:10 | x6 | main.rs:111:9:111:10 | x6 | main.rs:114:11:114:12 | x6 |
-| main.rs:112:9:112:10 | y1 | main.rs:112:9:112:10 | y1 | main.rs:124:15:124:16 | y1 |
-| main.rs:116:14:116:15 | y1 | main.rs:116:14:116:15 | y1 | main.rs:119:23:119:24 | y1 |
-| main.rs:128:9:128:15 | numbers | main.rs:128:9:128:15 | numbers | main.rs:130:11:130:17 | numbers |
-| main.rs:132:13:132:17 | first | main.rs:132:13:132:17 | first | main.rs:136:23:136:27 | first |
-| main.rs:133:13:133:17 | third | main.rs:133:13:133:17 | third | main.rs:137:23:137:27 | third |
-| main.rs:134:13:134:17 | fifth | main.rs:134:13:134:17 | fifth | main.rs:138:23:138:27 | fifth |
-| main.rs:144:13:144:17 | first | main.rs:144:13:144:17 | first | main.rs:148:23:148:27 | first |
-| main.rs:146:13:146:16 | last | main.rs:146:13:146:16 | last | main.rs:149:23:149:26 | last |
-| main.rs:155:9:155:10 | p2 | main.rs:155:9:155:10 | p2 | main.rs:157:11:157:12 | p2 |
-| main.rs:159:16:159:17 | x7 | main.rs:159:16:159:17 | x7 | main.rs:160:24:160:25 | x7 |
-| main.rs:169:9:169:11 | msg | main.rs:169:9:169:11 | msg | main.rs:171:11:171:13 | msg |
-| main.rs:173:17:173:27 | id_variable | main.rs:173:17:173:27 | id_variable | main.rs:174:24:174:34 | id_variable |
-| main.rs:178:26:178:27 | id | main.rs:178:26:178:27 | id | main.rs:179:23:179:24 | id |
-| main.rs:189:9:189:14 | either | main.rs:189:9:189:14 | either | main.rs:190:11:190:16 | either |
-| main.rs:191:9:191:44 | SSA phi(a3) | main.rs:191:9:191:44 | a3 | main.rs:192:26:192:27 | a3 |
-| main.rs:203:9:203:10 | tv | main.rs:203:9:203:10 | tv | main.rs:204:11:204:12 | tv |
-| main.rs:205:9:205:81 | SSA phi(a4) | main.rs:205:9:205:81 | a4 | main.rs:206:26:206:27 | a4 |
-| main.rs:209:9:209:83 | SSA phi(a5) | main.rs:209:9:209:83 | a5 | main.rs:210:26:210:27 | a5 |
-| main.rs:213:9:213:83 | SSA phi(a6) | main.rs:213:9:213:83 | a6 | main.rs:214:26:214:27 | a6 |
-| main.rs:219:9:219:14 | either | main.rs:219:9:219:14 | either | main.rs:220:11:220:16 | either |
-| main.rs:221:9:221:44 | [match(true)] SSA phi(a7) | main.rs:221:9:221:44 | a7 | main.rs:222:16:222:17 | a7 |
-| main.rs:229:9:229:14 | either | main.rs:229:9:229:14 | either | main.rs:231:11:231:16 | either |
-| main.rs:232:13:232:13 | e | main.rs:232:13:232:13 | e | main.rs:237:15:237:15 | e |
-| main.rs:233:14:233:51 | [match(true)] SSA phi(a11) | main.rs:233:14:233:51 | a11 | main.rs:235:23:235:25 | a11 |
-| main.rs:236:33:236:35 | a12 | main.rs:236:33:236:35 | a12 | main.rs:238:28:238:30 | a12 |
-| main.rs:253:9:253:10 | fv | main.rs:253:9:253:10 | fv | main.rs:254:11:254:12 | fv |
-| main.rs:255:9:255:109 | SSA phi(a13) | main.rs:255:9:255:109 | a13 | main.rs:256:26:256:28 | a13 |
-| main.rs:261:5:261:6 | a8 | main.rs:261:5:261:6 | a8 | main.rs:266:15:266:16 | a8 |
-| main.rs:263:9:263:10 | b3 | main.rs:263:9:263:10 | b3 | main.rs:267:15:267:16 | b3 |
-| main.rs:264:9:264:10 | c1 | main.rs:264:9:264:10 | c1 | main.rs:268:15:268:16 | c1 |
-| main.rs:272:6:272:41 | SSA phi(a9) | main.rs:272:6:272:41 | a9 | main.rs:274:15:274:16 | a9 |
-| main.rs:279:13:279:15 | a10 | main.rs:279:13:279:15 | a10 | main.rs:283:15:283:17 | a10 |
-| main.rs:280:13:280:14 | b4 | main.rs:280:13:280:14 | b4 | main.rs:284:15:284:16 | b4 |
-| main.rs:281:13:281:14 | c2 | main.rs:281:13:281:14 | c2 | main.rs:285:15:285:16 | c2 |
-| main.rs:288:9:288:10 | c2 | main.rs:281:13:281:14 | c2 | main.rs:294:9:294:10 | c2 |
-| main.rs:289:9:289:10 | b4 | main.rs:280:13:280:14 | b4 | main.rs:293:9:293:10 | b4 |
-| main.rs:290:9:290:11 | a10 | main.rs:279:13:279:15 | a10 | main.rs:292:9:292:11 | a10 |
-| main.rs:302:13:302:15 | a10 | main.rs:302:13:302:15 | a10 | main.rs:305:23:305:25 | a10 |
-| main.rs:303:13:303:14 | b4 | main.rs:303:13:303:14 | b4 | main.rs:306:23:306:24 | b4 |
-| main.rs:315:9:315:23 | example_closure | main.rs:315:9:315:23 | example_closure | main.rs:319:9:319:23 | example_closure |
-| main.rs:316:10:316:10 | x | main.rs:316:10:316:10 | x | main.rs:317:9:317:9 | x |
-| main.rs:318:9:318:10 | n1 | main.rs:318:9:318:10 | n1 | main.rs:320:15:320:16 | n1 |
-| main.rs:323:9:323:26 | immutable_variable | main.rs:323:9:323:26 | immutable_variable | main.rs:327:9:327:26 | immutable_variable |
-| main.rs:324:10:324:10 | x | main.rs:324:10:324:10 | x | main.rs:325:9:325:9 | x |
-| main.rs:326:9:326:10 | n2 | main.rs:326:9:326:10 | n2 | main.rs:328:15:328:16 | n2 |
-| main.rs:333:9:333:9 | f | main.rs:333:9:333:9 | f | main.rs:336:15:336:15 | f |
-| main.rs:334:10:334:10 | x | main.rs:334:10:334:10 | x | main.rs:335:9:335:9 | x |
-| main.rs:338:10:338:10 | x | main.rs:338:10:338:10 | x | main.rs:339:9:339:9 | x |
-| main.rs:346:14:346:14 | x | main.rs:346:14:346:14 | x | main.rs:347:17:347:17 | x |
-| main.rs:354:13:354:13 | f | main.rs:354:13:354:13 | f | main.rs:357:19:357:19 | f |
-| main.rs:355:14:355:14 | x | main.rs:355:14:355:14 | x | main.rs:356:13:356:13 | x |
-| main.rs:362:9:362:9 | v | main.rs:362:9:362:9 | v | main.rs:365:12:365:12 | v |
-| main.rs:364:9:364:12 | text | main.rs:364:9:364:12 | text | main.rs:366:19:366:22 | text |
-| main.rs:371:13:371:13 | a | main.rs:371:13:371:13 | a | main.rs:372:5:372:5 | a |
-| main.rs:372:5:372:5 | a | main.rs:371:13:371:13 | a | main.rs:373:15:373:15 | a |
-| main.rs:374:6:374:11 | &mut a | main.rs:371:13:371:13 | a | main.rs:375:15:375:15 | a |
-| main.rs:379:13:379:13 | i | main.rs:379:13:379:13 | i | main.rs:381:14:381:14 | i |
-| main.rs:380:9:380:13 | ref_i | main.rs:380:9:380:13 | ref_i | main.rs:382:6:382:10 | ref_i |
-| main.rs:381:9:381:14 | &mut i | main.rs:379:13:379:13 | i | main.rs:383:15:383:15 | i |
-| main.rs:386:17:386:17 | x | main.rs:386:17:386:17 | x | main.rs:387:6:387:6 | x |
-| main.rs:393:22:393:22 | x | main.rs:393:22:393:22 | x | main.rs:394:6:394:6 | x |
-| main.rs:393:39:393:39 | y | main.rs:393:39:393:39 | y | main.rs:397:6:397:6 | y |
-| main.rs:402:13:402:13 | x | main.rs:402:13:402:13 | x | main.rs:404:27:404:27 | x |
-| main.rs:403:9:403:9 | y | main.rs:403:9:403:9 | y | main.rs:405:6:405:6 | y |
-| main.rs:404:22:404:27 | &mut x | main.rs:402:13:402:13 | x | main.rs:407:15:407:15 | x |
-| main.rs:409:13:409:13 | z | main.rs:409:13:409:13 | z | main.rs:413:14:413:14 | z |
-| main.rs:410:9:410:9 | w | main.rs:410:9:410:9 | w | main.rs:414:9:414:9 | w |
-| main.rs:413:9:413:14 | &mut z | main.rs:409:13:409:13 | z | main.rs:418:15:418:15 | z |
-| main.rs:422:13:422:13 | x | main.rs:422:13:422:13 | x | main.rs:424:14:424:14 | x |
-| main.rs:423:9:423:9 | y | main.rs:423:9:423:9 | y | main.rs:425:6:425:6 | y |
-| main.rs:424:9:424:14 | &mut x | main.rs:422:13:422:13 | x | main.rs:426:15:426:15 | x |
-| main.rs:430:9:430:9 | x | main.rs:430:9:430:9 | x | main.rs:436:15:436:15 | x |
-| main.rs:432:9:432:11 | cap | main.rs:432:9:432:11 | cap | main.rs:435:5:435:7 | cap |
-| main.rs:432:15:434:5 | <captured entry> x | main.rs:430:9:430:9 | x | main.rs:433:19:433:19 | x |
-| main.rs:440:13:440:13 | x | main.rs:440:13:440:13 | x | main.rs:446:15:446:15 | x |
-| main.rs:442:9:442:16 | closure1 | main.rs:442:9:442:16 | closure1 | main.rs:445:5:445:12 | closure1 |
-| main.rs:442:20:444:5 | <captured entry> x | main.rs:440:13:440:13 | x | main.rs:443:19:443:19 | x |
-| main.rs:450:13:450:20 | closure2 | main.rs:450:13:450:20 | closure2 | main.rs:453:5:453:12 | closure2 |
-| main.rs:453:5:453:14 | <captured exit> y | main.rs:448:13:448:13 | y | main.rs:454:15:454:15 | y |
-| main.rs:456:13:456:13 | z | main.rs:456:13:456:13 | z | main.rs:462:15:462:15 | z |
-| main.rs:458:13:458:20 | closure3 | main.rs:458:13:458:20 | closure3 | main.rs:461:5:461:12 | closure3 |
-| main.rs:458:24:460:5 | <captured entry> z | main.rs:456:13:456:13 | z | main.rs:459:9:459:9 | z |
-| main.rs:467:9:467:13 | block | main.rs:467:9:467:13 | block | main.rs:471:5:471:9 | block |
-| main.rs:471:5:471:15 | <captured exit> i | main.rs:466:13:466:13 | i | main.rs:472:15:472:15 | i |
-| main.rs:475:8:475:8 | b | main.rs:475:8:475:8 | b | main.rs:479:8:479:8 | b |
-| main.rs:476:13:476:13 | x | main.rs:476:13:476:13 | x | main.rs:477:15:477:15 | x |
-| main.rs:479:5:487:5 | SSA phi(x) | main.rs:476:13:476:13 | x | main.rs:488:15:488:15 | x |
-| main.rs:480:9:480:9 | x | main.rs:476:13:476:13 | x | main.rs:481:19:481:19 | x |
-| main.rs:484:9:484:9 | x | main.rs:476:13:476:13 | x | main.rs:485:19:485:19 | x |
-| main.rs:491:13:491:14 | b1 | main.rs:491:13:491:14 | b1 | main.rs:493:8:493:9 | b1 |
-| main.rs:491:24:491:25 | b2 | main.rs:491:24:491:25 | b2 | main.rs:499:8:499:9 | b2 |
-| main.rs:492:9:492:9 | x | main.rs:492:9:492:9 | x | main.rs:494:19:494:19 | x |
-| main.rs:492:9:492:9 | x | main.rs:492:9:492:9 | x | main.rs:496:19:496:19 | x |
-| main.rs:512:20:512:23 | self | main.rs:512:20:512:23 | self | main.rs:513:16:513:19 | self |
-| main.rs:516:11:516:14 | self | main.rs:516:11:516:14 | self | main.rs:517:9:517:12 | self |
-| main.rs:521:17:521:17 | f | main.rs:521:17:521:17 | f | main.rs:525:9:525:9 | f |
-| main.rs:521:21:524:9 | <captured entry> self | main.rs:520:23:520:26 | self | main.rs:523:13:523:16 | self |
-| main.rs:521:22:521:22 | n | main.rs:521:22:521:22 | n | main.rs:523:25:523:25 | n |
-| main.rs:531:13:531:13 | a | main.rs:531:13:531:13 | a | main.rs:532:15:532:15 | a |
-| main.rs:532:15:532:15 | a | main.rs:531:13:531:13 | a | main.rs:533:5:533:5 | a |
-| main.rs:535:5:535:5 | a | main.rs:531:13:531:13 | a | main.rs:536:15:536:15 | a |
-| main.rs:540:13:540:13 | a | main.rs:540:13:540:13 | a | main.rs:541:15:541:15 | a |
-| main.rs:544:5:544:5 | a | main.rs:540:13:540:13 | a | main.rs:545:15:545:15 | a |
-| main.rs:549:9:549:9 | x | main.rs:549:9:549:9 | x | main.rs:550:20:550:20 | x |
-| main.rs:553:9:553:9 | z | main.rs:553:9:553:9 | z | main.rs:554:20:554:20 | z |
-| main.rs:562:15:562:18 | self | main.rs:562:15:562:18 | self | main.rs:563:6:563:9 | self |
-| main.rs:568:11:568:11 | a | main.rs:568:11:568:11 | a | main.rs:569:3:569:3 | a |
-| main.rs:569:3:569:3 | a | main.rs:568:11:568:11 | a | main.rs:571:13:571:13 | a |
-| main.rs:593:9:593:22 | var_from_macro | main.rs:593:9:593:22 | var_from_macro | main.rs:595:15:595:28 | var_from_macro |
-| main.rs:594:9:594:25 | var_in_macro | main.rs:594:9:594:25 | var_in_macro | main.rs:594:9:594:25 | var_in_macro |
-| main.rs:596:9:596:20 | var_in_macro | main.rs:596:9:596:20 | var_in_macro | main.rs:601:15:601:26 | var_in_macro |
-| main.rs:600:15:600:42 | var_in_macro | main.rs:600:15:600:42 | var_in_macro | main.rs:600:30:600:41 | var_in_macro |
+| main.rs:3:14:3:14 | s | main.rs:3:14:3:14 | s | main.rs:5:20:5:20 | s |
+| main.rs:8:14:8:14 | i | main.rs:8:14:8:14 | i | main.rs:10:20:10:20 | i |
+| main.rs:13:18:13:18 | i | main.rs:13:18:13:18 | i | main.rs:14:16:14:16 | i |
+| main.rs:18:9:18:10 | x1 | main.rs:18:9:18:10 | x1 | main.rs:19:15:19:16 | x1 |
+| main.rs:23:13:23:14 | x2 | main.rs:23:13:23:14 | x2 | main.rs:24:15:24:16 | x2 |
+| main.rs:25:5:25:6 | x2 | main.rs:23:13:23:14 | x2 | main.rs:26:15:26:16 | x2 |
+| main.rs:30:13:30:13 | x | main.rs:30:13:30:13 | x | main.rs:31:20:31:20 | x |
+| main.rs:32:5:32:5 | x | main.rs:30:13:30:13 | x | main.rs:33:20:33:20 | x |
+| main.rs:37:9:37:10 | x3 | main.rs:37:9:37:10 | x3 | main.rs:38:15:38:16 | x3 |
+| main.rs:39:9:39:10 | x3 | main.rs:39:9:39:10 | x3 | main.rs:41:15:41:16 | x3 |
+| main.rs:45:9:45:10 | x4 | main.rs:45:9:45:10 | x4 | main.rs:46:15:46:16 | x4 |
+| main.rs:48:13:48:14 | x4 | main.rs:48:13:48:14 | x4 | main.rs:49:19:49:20 | x4 |
+| main.rs:62:13:62:14 | a1 | main.rs:62:13:62:14 | a1 | main.rs:70:15:70:16 | a1 |
+| main.rs:63:13:63:14 | b1 | main.rs:63:13:63:14 | b1 | main.rs:71:15:71:16 | b1 |
+| main.rs:66:13:66:13 | x | main.rs:66:13:66:13 | x | main.rs:72:15:72:15 | x |
+| main.rs:67:13:67:13 | y | main.rs:67:13:67:13 | y | main.rs:73:15:73:15 | y |
+| main.rs:77:9:77:10 | p1 | main.rs:77:9:77:10 | p1 | main.rs:81:9:81:10 | p1 |
+| main.rs:79:12:79:13 | a2 | main.rs:79:12:79:13 | a2 | main.rs:82:15:82:16 | a2 |
+| main.rs:80:12:80:13 | b2 | main.rs:80:12:80:13 | b2 | main.rs:83:15:83:16 | b2 |
+| main.rs:87:9:87:10 | s1 | main.rs:87:9:87:10 | s1 | main.rs:90:11:90:12 | s1 |
+| main.rs:89:21:89:22 | s2 | main.rs:89:21:89:22 | s2 | main.rs:91:19:91:20 | s2 |
+| main.rs:96:14:96:15 | x5 | main.rs:96:14:96:15 | x5 | main.rs:102:15:102:16 | x5 |
+| main.rs:106:9:106:10 | s1 | main.rs:106:9:106:10 | s1 | main.rs:109:11:109:12 | s1 |
+| main.rs:108:24:108:25 | s2 | main.rs:108:24:108:25 | s2 | main.rs:110:19:110:20 | s2 |
+| main.rs:115:9:115:10 | x6 | main.rs:115:9:115:10 | x6 | main.rs:118:11:118:12 | x6 |
+| main.rs:116:9:116:10 | y1 | main.rs:116:9:116:10 | y1 | main.rs:128:15:128:16 | y1 |
+| main.rs:120:14:120:15 | y1 | main.rs:120:14:120:15 | y1 | main.rs:123:23:123:24 | y1 |
+| main.rs:132:9:132:15 | numbers | main.rs:132:9:132:15 | numbers | main.rs:134:11:134:17 | numbers |
+| main.rs:137:13:137:17 | first | main.rs:137:13:137:17 | first | main.rs:143:23:143:27 | first |
+| main.rs:139:13:139:17 | third | main.rs:139:13:139:17 | third | main.rs:144:23:144:27 | third |
+| main.rs:141:13:141:17 | fifth | main.rs:141:13:141:17 | fifth | main.rs:145:23:145:27 | fifth |
+| main.rs:152:13:152:17 | first | main.rs:152:13:152:17 | first | main.rs:156:23:156:27 | first |
+| main.rs:154:13:154:16 | last | main.rs:154:13:154:16 | last | main.rs:157:23:157:26 | last |
+| main.rs:163:9:163:10 | p2 | main.rs:163:9:163:10 | p2 | main.rs:165:11:165:12 | p2 |
+| main.rs:167:16:167:17 | x7 | main.rs:167:16:167:17 | x7 | main.rs:168:24:168:25 | x7 |
+| main.rs:177:9:177:11 | msg | main.rs:177:9:177:11 | msg | main.rs:179:11:179:13 | msg |
+| main.rs:182:17:182:27 | id_variable | main.rs:182:17:182:27 | id_variable | main.rs:183:24:183:34 | id_variable |
+| main.rs:187:26:187:27 | id | main.rs:187:26:187:27 | id | main.rs:190:23:190:24 | id |
+| main.rs:201:9:201:14 | either | main.rs:201:9:201:14 | either | main.rs:202:11:202:16 | either |
+| main.rs:203:9:203:44 | SSA phi(a3) | main.rs:203:9:203:44 | a3 | main.rs:204:26:204:27 | a3 |
+| main.rs:215:9:215:10 | tv | main.rs:215:9:215:10 | tv | main.rs:216:11:216:12 | tv |
+| main.rs:217:9:217:81 | SSA phi(a4) | main.rs:217:9:217:81 | a4 | main.rs:218:26:218:27 | a4 |
+| main.rs:221:9:221:83 | SSA phi(a5) | main.rs:221:9:221:83 | a5 | main.rs:222:26:222:27 | a5 |
+| main.rs:225:9:225:83 | SSA phi(a6) | main.rs:225:9:225:83 | a6 | main.rs:226:26:226:27 | a6 |
+| main.rs:231:9:231:14 | either | main.rs:231:9:231:14 | either | main.rs:232:11:232:16 | either |
+| main.rs:233:9:233:44 | [match(true)] SSA phi(a7) | main.rs:233:9:233:44 | a7 | main.rs:234:16:234:17 | a7 |
+| main.rs:241:9:241:14 | either | main.rs:241:9:241:14 | either | main.rs:243:11:243:16 | either |
+| main.rs:244:13:244:13 | e | main.rs:244:13:244:13 | e | main.rs:249:15:249:15 | e |
+| main.rs:245:14:245:51 | [match(true)] SSA phi(a11) | main.rs:245:14:245:51 | a11 | main.rs:247:23:247:25 | a11 |
+| main.rs:248:33:248:35 | a12 | main.rs:248:33:248:35 | a12 | main.rs:250:28:250:30 | a12 |
+| main.rs:265:9:265:10 | fv | main.rs:265:9:265:10 | fv | main.rs:266:11:266:12 | fv |
+| main.rs:267:9:267:109 | SSA phi(a13) | main.rs:267:9:267:109 | a13 | main.rs:268:26:268:28 | a13 |
+| main.rs:273:5:273:6 | a8 | main.rs:273:5:273:6 | a8 | main.rs:279:15:279:16 | a8 |
+| main.rs:275:9:275:10 | b3 | main.rs:275:9:275:10 | b3 | main.rs:280:15:280:16 | b3 |
+| main.rs:276:9:276:10 | c1 | main.rs:276:9:276:10 | c1 | main.rs:281:15:281:16 | c1 |
+| main.rs:284:20:284:55 | SSA phi(a9) | main.rs:284:20:284:55 | a9 | main.rs:286:15:286:16 | a9 |
+| main.rs:291:13:291:15 | a10 | main.rs:291:13:291:15 | a10 | main.rs:295:15:295:17 | a10 |
+| main.rs:292:13:292:14 | b4 | main.rs:292:13:292:14 | b4 | main.rs:296:15:296:16 | b4 |
+| main.rs:293:13:293:14 | c2 | main.rs:293:13:293:14 | c2 | main.rs:297:15:297:16 | c2 |
+| main.rs:300:9:300:10 | c2 | main.rs:293:13:293:14 | c2 | main.rs:306:9:306:10 | c2 |
+| main.rs:301:9:301:10 | b4 | main.rs:292:13:292:14 | b4 | main.rs:305:9:305:10 | b4 |
+| main.rs:302:9:302:11 | a10 | main.rs:291:13:291:15 | a10 | main.rs:304:9:304:11 | a10 |
+| main.rs:314:13:314:15 | a10 | main.rs:314:13:314:15 | a10 | main.rs:317:23:317:25 | a10 |
+| main.rs:315:13:315:14 | b4 | main.rs:315:13:315:14 | b4 | main.rs:318:23:318:24 | b4 |
+| main.rs:327:9:327:23 | example_closure | main.rs:327:9:327:23 | example_closure | main.rs:331:9:331:23 | example_closure |
+| main.rs:328:10:328:10 | x | main.rs:328:10:328:10 | x | main.rs:329:9:329:9 | x |
+| main.rs:330:9:330:10 | n1 | main.rs:330:9:330:10 | n1 | main.rs:332:15:332:16 | n1 |
+| main.rs:335:9:335:26 | immutable_variable | main.rs:335:9:335:26 | immutable_variable | main.rs:339:9:339:26 | immutable_variable |
+| main.rs:336:6:336:6 | x | main.rs:336:6:336:6 | x | main.rs:337:9:337:9 | x |
+| main.rs:338:9:338:10 | n2 | main.rs:338:9:338:10 | n2 | main.rs:340:15:340:16 | n2 |
+| main.rs:345:9:345:9 | f | main.rs:345:9:345:9 | f | main.rs:348:15:348:15 | f |
+| main.rs:346:10:346:10 | x | main.rs:346:10:346:10 | x | main.rs:347:9:347:9 | x |
+| main.rs:350:10:350:10 | x | main.rs:350:10:350:10 | x | main.rs:352:9:352:9 | x |
+| main.rs:359:14:359:14 | x | main.rs:359:14:359:14 | x | main.rs:361:17:361:17 | x |
+| main.rs:368:13:368:13 | f | main.rs:368:13:368:13 | f | main.rs:371:19:371:19 | f |
+| main.rs:369:14:369:14 | x | main.rs:369:14:369:14 | x | main.rs:370:13:370:13 | x |
+| main.rs:376:9:376:9 | v | main.rs:376:9:376:9 | v | main.rs:379:12:379:12 | v |
+| main.rs:378:9:378:12 | text | main.rs:378:9:378:12 | text | main.rs:380:19:380:22 | text |
+| main.rs:385:13:385:13 | a | main.rs:385:13:385:13 | a | main.rs:386:5:386:5 | a |
+| main.rs:386:5:386:5 | a | main.rs:385:13:385:13 | a | main.rs:387:15:387:15 | a |
+| main.rs:388:6:388:11 | &mut a | main.rs:385:13:385:13 | a | main.rs:389:15:389:15 | a |
+| main.rs:393:13:393:13 | i | main.rs:393:13:393:13 | i | main.rs:395:14:395:14 | i |
+| main.rs:394:9:394:13 | ref_i | main.rs:394:9:394:13 | ref_i | main.rs:396:6:396:10 | ref_i |
+| main.rs:395:9:395:14 | &mut i | main.rs:393:13:393:13 | i | main.rs:397:15:397:15 | i |
+| main.rs:400:17:400:17 | x | main.rs:400:17:400:17 | x | main.rs:401:6:401:6 | x |
+| main.rs:407:22:407:22 | x | main.rs:407:22:407:22 | x | main.rs:408:6:408:6 | x |
+| main.rs:407:38:407:38 | y | main.rs:407:38:407:38 | y | main.rs:411:6:411:6 | y |
+| main.rs:416:13:416:13 | x | main.rs:416:13:416:13 | x | main.rs:418:27:418:27 | x |
+| main.rs:417:9:417:9 | y | main.rs:417:9:417:9 | y | main.rs:419:6:419:6 | y |
+| main.rs:418:22:418:27 | &mut x | main.rs:416:13:416:13 | x | main.rs:421:15:421:15 | x |
+| main.rs:423:13:423:13 | z | main.rs:423:13:423:13 | z | main.rs:427:14:427:14 | z |
+| main.rs:424:9:424:9 | w | main.rs:424:9:424:9 | w | main.rs:428:9:428:9 | w |
+| main.rs:427:9:427:14 | &mut z | main.rs:423:13:423:13 | z | main.rs:432:15:432:15 | z |
+| main.rs:436:13:436:13 | x | main.rs:436:13:436:13 | x | main.rs:438:14:438:14 | x |
+| main.rs:437:9:437:9 | y | main.rs:437:9:437:9 | y | main.rs:439:6:439:6 | y |
+| main.rs:438:9:438:14 | &mut x | main.rs:436:13:436:13 | x | main.rs:440:15:440:15 | x |
+| main.rs:444:9:444:9 | x | main.rs:444:9:444:9 | x | main.rs:450:15:450:15 | x |
+| main.rs:446:9:446:11 | cap | main.rs:446:9:446:11 | cap | main.rs:449:5:449:7 | cap |
+| main.rs:446:15:448:5 | <captured entry> x | main.rs:444:9:444:9 | x | main.rs:447:19:447:19 | x |
+| main.rs:454:13:454:13 | x | main.rs:454:13:454:13 | x | main.rs:460:15:460:15 | x |
+| main.rs:456:9:456:16 | closure1 | main.rs:456:9:456:16 | closure1 | main.rs:459:5:459:12 | closure1 |
+| main.rs:456:20:458:5 | <captured entry> x | main.rs:454:13:454:13 | x | main.rs:457:19:457:19 | x |
+| main.rs:464:13:464:20 | closure2 | main.rs:464:13:464:20 | closure2 | main.rs:467:5:467:12 | closure2 |
+| main.rs:467:5:467:14 | <captured exit> y | main.rs:462:13:462:13 | y | main.rs:468:15:468:15 | y |
+| main.rs:470:13:470:13 | z | main.rs:470:13:470:13 | z | main.rs:476:15:476:15 | z |
+| main.rs:472:13:472:20 | closure3 | main.rs:472:13:472:20 | closure3 | main.rs:475:5:475:12 | closure3 |
+| main.rs:472:24:474:5 | <captured entry> z | main.rs:470:13:470:13 | z | main.rs:473:9:473:9 | z |
+| main.rs:481:9:481:13 | block | main.rs:481:9:481:13 | block | main.rs:485:5:485:9 | block |
+| main.rs:485:5:485:15 | <captured exit> i | main.rs:480:13:480:13 | i | main.rs:486:15:486:15 | i |
+| main.rs:489:8:489:8 | b | main.rs:489:8:489:8 | b | main.rs:494:16:494:16 | b |
+| main.rs:490:13:490:13 | x | main.rs:490:13:490:13 | x | main.rs:491:15:491:15 | x |
+| main.rs:494:13:503:5 | SSA phi(x) | main.rs:490:13:490:13 | x | main.rs:504:15:504:15 | x |
+| main.rs:496:9:496:9 | x | main.rs:490:13:490:13 | x | main.rs:497:19:497:19 | x |
+| main.rs:500:9:500:9 | x | main.rs:490:13:490:13 | x | main.rs:501:19:501:19 | x |
+| main.rs:507:13:507:14 | b1 | main.rs:507:13:507:14 | b1 | main.rs:510:16:510:17 | b1 |
+| main.rs:507:23:507:24 | b2 | main.rs:507:23:507:24 | b2 | main.rs:518:16:518:17 | b2 |
+| main.rs:508:9:508:9 | x | main.rs:508:9:508:9 | x | main.rs:512:19:512:19 | x |
+| main.rs:508:9:508:9 | x | main.rs:508:9:508:9 | x | main.rs:514:19:514:19 | x |
+| main.rs:531:20:531:23 | self | main.rs:531:20:531:23 | self | main.rs:532:16:532:19 | self |
+| main.rs:535:11:535:14 | self | main.rs:535:11:535:14 | self | main.rs:536:9:536:12 | self |
+| main.rs:540:17:540:17 | f | main.rs:540:17:540:17 | f | main.rs:544:9:544:9 | f |
+| main.rs:540:21:543:9 | <captured entry> self | main.rs:539:23:539:26 | self | main.rs:542:13:542:16 | self |
+| main.rs:540:22:540:22 | n | main.rs:540:22:540:22 | n | main.rs:542:25:542:25 | n |
+| main.rs:550:13:550:13 | a | main.rs:550:13:550:13 | a | main.rs:551:15:551:15 | a |
+| main.rs:551:15:551:15 | a | main.rs:550:13:550:13 | a | main.rs:552:5:552:5 | a |
+| main.rs:554:5:554:5 | a | main.rs:550:13:550:13 | a | main.rs:555:15:555:15 | a |
+| main.rs:559:13:559:13 | a | main.rs:559:13:559:13 | a | main.rs:560:15:560:15 | a |
+| main.rs:563:5:563:5 | a | main.rs:559:13:559:13 | a | main.rs:564:15:564:15 | a |
+| main.rs:568:9:568:9 | x | main.rs:568:9:568:9 | x | main.rs:569:20:569:20 | x |
+| main.rs:572:9:572:9 | z | main.rs:572:9:572:9 | z | main.rs:573:20:573:20 | z |
+| main.rs:581:17:581:20 | self | main.rs:581:17:581:20 | self | main.rs:582:10:582:13 | self |
+| main.rs:587:13:587:13 | a | main.rs:587:13:587:13 | a | main.rs:588:5:588:5 | a |
+| main.rs:588:5:588:5 | a | main.rs:587:13:587:13 | a | main.rs:590:15:590:15 | a |
+| main.rs:608:9:608:22 | var_from_macro | main.rs:608:9:608:22 | var_from_macro | main.rs:610:15:610:28 | var_from_macro |
+| main.rs:609:9:609:25 | var_in_macro | main.rs:609:9:609:25 | var_in_macro | main.rs:609:9:609:25 | var_in_macro |
+| main.rs:611:9:611:20 | var_in_macro | main.rs:611:9:611:20 | var_in_macro | main.rs:616:15:616:26 | var_in_macro |
+| main.rs:615:15:615:42 | var_in_macro | main.rs:615:15:615:42 | var_in_macro | main.rs:615:30:615:41 | var_in_macro |
+| main.rs:621:5:621:5 | x | main.rs:620:9:620:9 | x | main.rs:622:15:622:15 | x |
+| main.rs:627:13:627:15 | cap | main.rs:627:13:627:15 | cap | main.rs:633:5:633:7 | cap |
+| main.rs:627:20:627:20 | b | main.rs:627:20:627:20 | b | main.rs:629:20:629:20 | b |
+| main.rs:633:5:633:13 | <captured exit> x | main.rs:626:13:626:13 | x | main.rs:634:15:634:15 | x |
 adjacentReads
-| main.rs:35:9:35:10 | x3 | main.rs:35:9:35:10 | x3 | main.rs:36:15:36:16 | x3 | main.rs:38:9:38:10 | x3 |
-| main.rs:43:9:43:10 | x4 | main.rs:43:9:43:10 | x4 | main.rs:44:15:44:16 | x4 | main.rs:49:15:49:16 | x4 |
-| main.rs:102:9:102:10 | s1 | main.rs:102:9:102:10 | s1 | main.rs:105:11:105:12 | s1 | main.rs:105:11:105:12 | s1 |
-| main.rs:128:9:128:15 | numbers | main.rs:128:9:128:15 | numbers | main.rs:130:11:130:17 | numbers | main.rs:142:11:142:17 | numbers |
-| main.rs:203:9:203:10 | tv | main.rs:203:9:203:10 | tv | main.rs:204:11:204:12 | tv | main.rs:208:11:208:12 | tv |
-| main.rs:203:9:203:10 | tv | main.rs:203:9:203:10 | tv | main.rs:208:11:208:12 | tv | main.rs:212:11:212:12 | tv |
-| main.rs:221:9:221:44 | [match(true)] SSA phi(a7) | main.rs:221:9:221:44 | a7 | main.rs:222:16:222:17 | a7 | main.rs:223:26:223:27 | a7 |
-| main.rs:288:9:288:10 | c2 | main.rs:281:13:281:14 | c2 | main.rs:294:9:294:10 | c2 | main.rs:298:15:298:16 | c2 |
-| main.rs:289:9:289:10 | b4 | main.rs:280:13:280:14 | b4 | main.rs:293:9:293:10 | b4 | main.rs:297:15:297:16 | b4 |
-| main.rs:289:9:289:10 | b4 | main.rs:280:13:280:14 | b4 | main.rs:297:15:297:16 | b4 | main.rs:311:15:311:16 | b4 |
-| main.rs:290:9:290:11 | a10 | main.rs:279:13:279:15 | a10 | main.rs:292:9:292:11 | a10 | main.rs:296:15:296:17 | a10 |
-| main.rs:290:9:290:11 | a10 | main.rs:279:13:279:15 | a10 | main.rs:296:15:296:17 | a10 | main.rs:310:15:310:17 | a10 |
-| main.rs:333:9:333:9 | f | main.rs:333:9:333:9 | f | main.rs:336:15:336:15 | f | main.rs:342:15:342:15 | f |
-| main.rs:372:5:372:5 | a | main.rs:371:13:371:13 | a | main.rs:373:15:373:15 | a | main.rs:374:11:374:11 | a |
-| main.rs:386:17:386:17 | x | main.rs:386:17:386:17 | x | main.rs:387:6:387:6 | x | main.rs:388:10:388:10 | x |
-| main.rs:386:17:386:17 | x | main.rs:386:17:386:17 | x | main.rs:388:10:388:10 | x | main.rs:389:10:389:10 | x |
-| main.rs:386:17:386:17 | x | main.rs:386:17:386:17 | x | main.rs:389:10:389:10 | x | main.rs:390:12:390:12 | x |
-| main.rs:393:22:393:22 | x | main.rs:393:22:393:22 | x | main.rs:394:6:394:6 | x | main.rs:395:10:395:10 | x |
-| main.rs:393:22:393:22 | x | main.rs:393:22:393:22 | x | main.rs:395:10:395:10 | x | main.rs:396:10:396:10 | x |
-| main.rs:393:22:393:22 | x | main.rs:393:22:393:22 | x | main.rs:396:10:396:10 | x | main.rs:398:9:398:9 | x |
-| main.rs:404:22:404:27 | &mut x | main.rs:402:13:402:13 | x | main.rs:407:15:407:15 | x | main.rs:411:19:411:19 | x |
-| main.rs:410:9:410:9 | w | main.rs:410:9:410:9 | w | main.rs:414:9:414:9 | w | main.rs:416:7:416:7 | w |
-| main.rs:476:13:476:13 | x | main.rs:476:13:476:13 | x | main.rs:477:15:477:15 | x | main.rs:478:15:478:15 | x |
-| main.rs:480:9:480:9 | x | main.rs:476:13:476:13 | x | main.rs:481:19:481:19 | x | main.rs:482:19:482:19 | x |
-| main.rs:484:9:484:9 | x | main.rs:476:13:476:13 | x | main.rs:485:19:485:19 | x | main.rs:486:19:486:19 | x |
-| main.rs:492:9:492:9 | x | main.rs:492:9:492:9 | x | main.rs:494:19:494:19 | x | main.rs:500:19:500:19 | x |
-| main.rs:492:9:492:9 | x | main.rs:492:9:492:9 | x | main.rs:494:19:494:19 | x | main.rs:502:19:502:19 | x |
-| main.rs:492:9:492:9 | x | main.rs:492:9:492:9 | x | main.rs:496:19:496:19 | x | main.rs:500:19:500:19 | x |
-| main.rs:492:9:492:9 | x | main.rs:492:9:492:9 | x | main.rs:496:19:496:19 | x | main.rs:502:19:502:19 | x |
-| main.rs:521:17:521:17 | f | main.rs:521:17:521:17 | f | main.rs:525:9:525:9 | f | main.rs:526:9:526:9 | f |
-| main.rs:532:15:532:15 | a | main.rs:531:13:531:13 | a | main.rs:533:5:533:5 | a | main.rs:534:15:534:15 | a |
-| main.rs:540:13:540:13 | a | main.rs:540:13:540:13 | a | main.rs:541:15:541:15 | a | main.rs:542:5:542:5 | a |
-| main.rs:540:13:540:13 | a | main.rs:540:13:540:13 | a | main.rs:542:5:542:5 | a | main.rs:543:15:543:15 | a |
-| main.rs:549:9:549:9 | x | main.rs:549:9:549:9 | x | main.rs:550:20:550:20 | x | main.rs:551:15:551:15 | x |
+| main.rs:37:9:37:10 | x3 | main.rs:37:9:37:10 | x3 | main.rs:38:15:38:16 | x3 | main.rs:40:9:40:10 | x3 |
+| main.rs:45:9:45:10 | x4 | main.rs:45:9:45:10 | x4 | main.rs:46:15:46:16 | x4 | main.rs:51:15:51:16 | x4 |
+| main.rs:106:9:106:10 | s1 | main.rs:106:9:106:10 | s1 | main.rs:109:11:109:12 | s1 | main.rs:109:11:109:12 | s1 |
+| main.rs:132:9:132:15 | numbers | main.rs:132:9:132:15 | numbers | main.rs:134:11:134:17 | numbers | main.rs:149:11:149:17 | numbers |
+| main.rs:215:9:215:10 | tv | main.rs:215:9:215:10 | tv | main.rs:216:11:216:12 | tv | main.rs:220:11:220:12 | tv |
+| main.rs:215:9:215:10 | tv | main.rs:215:9:215:10 | tv | main.rs:220:11:220:12 | tv | main.rs:224:11:224:12 | tv |
+| main.rs:233:9:233:44 | [match(true)] SSA phi(a7) | main.rs:233:9:233:44 | a7 | main.rs:234:16:234:17 | a7 | main.rs:235:26:235:27 | a7 |
+| main.rs:300:9:300:10 | c2 | main.rs:293:13:293:14 | c2 | main.rs:306:9:306:10 | c2 | main.rs:310:15:310:16 | c2 |
+| main.rs:301:9:301:10 | b4 | main.rs:292:13:292:14 | b4 | main.rs:305:9:305:10 | b4 | main.rs:309:15:309:16 | b4 |
+| main.rs:301:9:301:10 | b4 | main.rs:292:13:292:14 | b4 | main.rs:309:15:309:16 | b4 | main.rs:323:15:323:16 | b4 |
+| main.rs:302:9:302:11 | a10 | main.rs:291:13:291:15 | a10 | main.rs:304:9:304:11 | a10 | main.rs:308:15:308:17 | a10 |
+| main.rs:302:9:302:11 | a10 | main.rs:291:13:291:15 | a10 | main.rs:308:15:308:17 | a10 | main.rs:322:15:322:17 | a10 |
+| main.rs:345:9:345:9 | f | main.rs:345:9:345:9 | f | main.rs:348:15:348:15 | f | main.rs:355:15:355:15 | f |
+| main.rs:386:5:386:5 | a | main.rs:385:13:385:13 | a | main.rs:387:15:387:15 | a | main.rs:388:11:388:11 | a |
+| main.rs:400:17:400:17 | x | main.rs:400:17:400:17 | x | main.rs:401:6:401:6 | x | main.rs:402:10:402:10 | x |
+| main.rs:400:17:400:17 | x | main.rs:400:17:400:17 | x | main.rs:402:10:402:10 | x | main.rs:403:10:403:10 | x |
+| main.rs:400:17:400:17 | x | main.rs:400:17:400:17 | x | main.rs:403:10:403:10 | x | main.rs:404:12:404:12 | x |
+| main.rs:407:22:407:22 | x | main.rs:407:22:407:22 | x | main.rs:408:6:408:6 | x | main.rs:409:10:409:10 | x |
+| main.rs:407:22:407:22 | x | main.rs:407:22:407:22 | x | main.rs:409:10:409:10 | x | main.rs:410:10:410:10 | x |
+| main.rs:407:22:407:22 | x | main.rs:407:22:407:22 | x | main.rs:410:10:410:10 | x | main.rs:412:9:412:9 | x |
+| main.rs:418:22:418:27 | &mut x | main.rs:416:13:416:13 | x | main.rs:421:15:421:15 | x | main.rs:425:19:425:19 | x |
+| main.rs:424:9:424:9 | w | main.rs:424:9:424:9 | w | main.rs:428:9:428:9 | w | main.rs:430:7:430:7 | w |
+| main.rs:490:13:490:13 | x | main.rs:490:13:490:13 | x | main.rs:491:15:491:15 | x | main.rs:492:15:492:15 | x |
+| main.rs:496:9:496:9 | x | main.rs:490:13:490:13 | x | main.rs:497:19:497:19 | x | main.rs:498:19:498:19 | x |
+| main.rs:500:9:500:9 | x | main.rs:490:13:490:13 | x | main.rs:501:19:501:19 | x | main.rs:502:19:502:19 | x |
+| main.rs:508:9:508:9 | x | main.rs:508:9:508:9 | x | main.rs:512:19:512:19 | x | main.rs:520:19:520:19 | x |
+| main.rs:508:9:508:9 | x | main.rs:508:9:508:9 | x | main.rs:512:19:512:19 | x | main.rs:522:19:522:19 | x |
+| main.rs:508:9:508:9 | x | main.rs:508:9:508:9 | x | main.rs:514:19:514:19 | x | main.rs:520:19:520:19 | x |
+| main.rs:508:9:508:9 | x | main.rs:508:9:508:9 | x | main.rs:514:19:514:19 | x | main.rs:522:19:522:19 | x |
+| main.rs:540:17:540:17 | f | main.rs:540:17:540:17 | f | main.rs:544:9:544:9 | f | main.rs:545:9:545:9 | f |
+| main.rs:551:15:551:15 | a | main.rs:550:13:550:13 | a | main.rs:552:5:552:5 | a | main.rs:553:15:553:15 | a |
+| main.rs:559:13:559:13 | a | main.rs:559:13:559:13 | a | main.rs:560:15:560:15 | a | main.rs:561:5:561:5 | a |
+| main.rs:559:13:559:13 | a | main.rs:559:13:559:13 | a | main.rs:561:5:561:5 | a | main.rs:562:15:562:15 | a |
+| main.rs:568:9:568:9 | x | main.rs:568:9:568:9 | x | main.rs:569:20:569:20 | x | main.rs:570:15:570:15 | x |
 phi
-| main.rs:191:9:191:44 | SSA phi(a3) | main.rs:191:9:191:44 | a3 | main.rs:191:22:191:23 | a3 |
-| main.rs:191:9:191:44 | SSA phi(a3) | main.rs:191:9:191:44 | a3 | main.rs:191:42:191:43 | a3 |
-| main.rs:205:9:205:81 | SSA phi(a4) | main.rs:205:9:205:81 | a4 | main.rs:205:28:205:29 | a4 |
-| main.rs:205:9:205:81 | SSA phi(a4) | main.rs:205:9:205:81 | a4 | main.rs:205:54:205:55 | a4 |
-| main.rs:205:9:205:81 | SSA phi(a4) | main.rs:205:9:205:81 | a4 | main.rs:205:79:205:80 | a4 |
-| main.rs:209:9:209:83 | SSA phi(a5) | main.rs:209:9:209:83 | a5 | main.rs:209:10:209:57 | [match(true)] SSA phi(a5) |
-| main.rs:209:9:209:83 | SSA phi(a5) | main.rs:209:9:209:83 | a5 | main.rs:209:81:209:82 | a5 |
-| main.rs:209:10:209:57 | [match(true)] SSA phi(a5) | main.rs:209:9:209:83 | a5 | main.rs:209:29:209:30 | a5 |
-| main.rs:209:10:209:57 | [match(true)] SSA phi(a5) | main.rs:209:9:209:83 | a5 | main.rs:209:55:209:56 | a5 |
-| main.rs:213:9:213:83 | SSA phi(a6) | main.rs:213:9:213:83 | a6 | main.rs:213:28:213:29 | a6 |
-| main.rs:213:9:213:83 | SSA phi(a6) | main.rs:213:9:213:83 | a6 | main.rs:213:35:213:82 | SSA phi(a6) |
-| main.rs:213:35:213:82 | SSA phi(a6) | main.rs:213:9:213:83 | a6 | main.rs:213:55:213:56 | a6 |
-| main.rs:213:35:213:82 | SSA phi(a6) | main.rs:213:9:213:83 | a6 | main.rs:213:80:213:81 | a6 |
-| main.rs:221:9:221:44 | [match(true)] SSA phi(a7) | main.rs:221:9:221:44 | a7 | main.rs:221:22:221:23 | a7 |
-| main.rs:221:9:221:44 | [match(true)] SSA phi(a7) | main.rs:221:9:221:44 | a7 | main.rs:221:42:221:43 | a7 |
-| main.rs:233:14:233:51 | [match(true)] SSA phi(a11) | main.rs:233:14:233:51 | a11 | main.rs:233:27:233:29 | a11 |
-| main.rs:233:14:233:51 | [match(true)] SSA phi(a11) | main.rs:233:14:233:51 | a11 | main.rs:233:48:233:50 | a11 |
-| main.rs:255:9:255:109 | SSA phi(a13) | main.rs:255:9:255:109 | a13 | main.rs:255:27:255:29 | a13 |
-| main.rs:255:9:255:109 | SSA phi(a13) | main.rs:255:9:255:109 | a13 | main.rs:255:35:255:82 | [match(true)] SSA phi(a13) |
-| main.rs:255:9:255:109 | SSA phi(a13) | main.rs:255:9:255:109 | a13 | main.rs:255:106:255:108 | a13 |
-| main.rs:255:35:255:82 | [match(true)] SSA phi(a13) | main.rs:255:9:255:109 | a13 | main.rs:255:54:255:56 | a13 |
-| main.rs:255:35:255:82 | [match(true)] SSA phi(a13) | main.rs:255:9:255:109 | a13 | main.rs:255:79:255:81 | a13 |
-| main.rs:272:6:272:41 | SSA phi(a9) | main.rs:272:6:272:41 | a9 | main.rs:272:19:272:20 | a9 |
-| main.rs:272:6:272:41 | SSA phi(a9) | main.rs:272:6:272:41 | a9 | main.rs:272:39:272:40 | a9 |
-| main.rs:479:5:487:5 | SSA phi(x) | main.rs:476:13:476:13 | x | main.rs:480:9:480:9 | x |
-| main.rs:479:5:487:5 | SSA phi(x) | main.rs:476:13:476:13 | x | main.rs:484:9:484:9 | x |
+| main.rs:203:9:203:44 | SSA phi(a3) | main.rs:203:9:203:44 | a3 | main.rs:203:22:203:23 | a3 |
+| main.rs:203:9:203:44 | SSA phi(a3) | main.rs:203:9:203:44 | a3 | main.rs:203:42:203:43 | a3 |
+| main.rs:217:9:217:81 | SSA phi(a4) | main.rs:217:9:217:81 | a4 | main.rs:217:28:217:29 | a4 |
+| main.rs:217:9:217:81 | SSA phi(a4) | main.rs:217:9:217:81 | a4 | main.rs:217:54:217:55 | a4 |
+| main.rs:217:9:217:81 | SSA phi(a4) | main.rs:217:9:217:81 | a4 | main.rs:217:79:217:80 | a4 |
+| main.rs:221:9:221:83 | SSA phi(a5) | main.rs:221:9:221:83 | a5 | main.rs:221:10:221:57 | [match(true)] SSA phi(a5) |
+| main.rs:221:9:221:83 | SSA phi(a5) | main.rs:221:9:221:83 | a5 | main.rs:221:81:221:82 | a5 |
+| main.rs:221:10:221:57 | [match(true)] SSA phi(a5) | main.rs:221:9:221:83 | a5 | main.rs:221:29:221:30 | a5 |
+| main.rs:221:10:221:57 | [match(true)] SSA phi(a5) | main.rs:221:9:221:83 | a5 | main.rs:221:55:221:56 | a5 |
+| main.rs:225:9:225:83 | SSA phi(a6) | main.rs:225:9:225:83 | a6 | main.rs:225:28:225:29 | a6 |
+| main.rs:225:9:225:83 | SSA phi(a6) | main.rs:225:9:225:83 | a6 | main.rs:225:35:225:82 | SSA phi(a6) |
+| main.rs:225:35:225:82 | SSA phi(a6) | main.rs:225:9:225:83 | a6 | main.rs:225:55:225:56 | a6 |
+| main.rs:225:35:225:82 | SSA phi(a6) | main.rs:225:9:225:83 | a6 | main.rs:225:80:225:81 | a6 |
+| main.rs:233:9:233:44 | [match(true)] SSA phi(a7) | main.rs:233:9:233:44 | a7 | main.rs:233:22:233:23 | a7 |
+| main.rs:233:9:233:44 | [match(true)] SSA phi(a7) | main.rs:233:9:233:44 | a7 | main.rs:233:42:233:43 | a7 |
+| main.rs:245:14:245:51 | [match(true)] SSA phi(a11) | main.rs:245:14:245:51 | a11 | main.rs:245:27:245:29 | a11 |
+| main.rs:245:14:245:51 | [match(true)] SSA phi(a11) | main.rs:245:14:245:51 | a11 | main.rs:245:48:245:50 | a11 |
+| main.rs:267:9:267:109 | SSA phi(a13) | main.rs:267:9:267:109 | a13 | main.rs:267:27:267:29 | a13 |
+| main.rs:267:9:267:109 | SSA phi(a13) | main.rs:267:9:267:109 | a13 | main.rs:267:35:267:82 | [match(true)] SSA phi(a13) |
+| main.rs:267:9:267:109 | SSA phi(a13) | main.rs:267:9:267:109 | a13 | main.rs:267:106:267:108 | a13 |
+| main.rs:267:35:267:82 | [match(true)] SSA phi(a13) | main.rs:267:9:267:109 | a13 | main.rs:267:54:267:56 | a13 |
+| main.rs:267:35:267:82 | [match(true)] SSA phi(a13) | main.rs:267:9:267:109 | a13 | main.rs:267:79:267:81 | a13 |
+| main.rs:284:20:284:55 | SSA phi(a9) | main.rs:284:20:284:55 | a9 | main.rs:284:33:284:34 | a9 |
+| main.rs:284:20:284:55 | SSA phi(a9) | main.rs:284:20:284:55 | a9 | main.rs:284:53:284:54 | a9 |
+| main.rs:494:13:503:5 | SSA phi(x) | main.rs:490:13:490:13 | x | main.rs:496:9:496:9 | x |
+| main.rs:494:13:503:5 | SSA phi(x) | main.rs:490:13:490:13 | x | main.rs:500:9:500:9 | x |
+| main.rs:629:17:631:9 | SSA phi(x) | main.rs:626:13:626:13 | x | main.rs:630:13:630:13 | x |
 phiReadNode
-| main.rs:104:11:105:12 | SSA phi read(s1) | main.rs:102:9:102:10 | s1 |
-| main.rs:493:5:497:5 | SSA phi read(x) | main.rs:492:9:492:9 | x |
+| main.rs:108:11:109:12 | SSA phi read(s1) | main.rs:106:9:106:10 | s1 |
+| main.rs:510:13:515:5 | SSA phi read(x) | main.rs:508:9:508:9 | x |
 phiReadNodeFirstRead
-| main.rs:104:11:105:12 | SSA phi read(s1) | main.rs:102:9:102:10 | s1 | main.rs:105:11:105:12 | s1 |
-| main.rs:493:5:497:5 | SSA phi read(x) | main.rs:492:9:492:9 | x | main.rs:500:19:500:19 | x |
-| main.rs:493:5:497:5 | SSA phi read(x) | main.rs:492:9:492:9 | x | main.rs:502:19:502:19 | x |
+| main.rs:108:11:109:12 | SSA phi read(s1) | main.rs:106:9:106:10 | s1 | main.rs:109:11:109:12 | s1 |
+| main.rs:510:13:515:5 | SSA phi read(x) | main.rs:508:9:508:9 | x | main.rs:520:19:520:19 | x |
+| main.rs:510:13:515:5 | SSA phi read(x) | main.rs:508:9:508:9 | x | main.rs:522:19:522:19 | x |
 phiReadInput
-| main.rs:104:11:105:12 | SSA phi read(s1) | main.rs:102:9:102:10 | s1 |
-| main.rs:104:11:105:12 | SSA phi read(s1) | main.rs:105:11:105:12 | SSA read(s1) |
-| main.rs:493:5:497:5 | SSA phi read(x) | main.rs:494:19:494:19 | SSA read(x) |
-| main.rs:493:5:497:5 | SSA phi read(x) | main.rs:496:19:496:19 | SSA read(x) |
+| main.rs:108:11:109:12 | SSA phi read(s1) | main.rs:106:9:106:10 | s1 |
+| main.rs:108:11:109:12 | SSA phi read(s1) | main.rs:109:11:109:12 | SSA read(s1) |
+| main.rs:510:13:515:5 | SSA phi read(x) | main.rs:512:19:512:19 | SSA read(x) |
+| main.rs:510:13:515:5 | SSA phi read(x) | main.rs:514:19:514:19 | SSA read(x) |
 ultimateDef
-| main.rs:191:9:191:44 | SSA phi(a3) | main.rs:191:22:191:23 | a3 |
-| main.rs:191:9:191:44 | SSA phi(a3) | main.rs:191:42:191:43 | a3 |
-| main.rs:205:9:205:81 | SSA phi(a4) | main.rs:205:28:205:29 | a4 |
-| main.rs:205:9:205:81 | SSA phi(a4) | main.rs:205:54:205:55 | a4 |
-| main.rs:205:9:205:81 | SSA phi(a4) | main.rs:205:79:205:80 | a4 |
-| main.rs:209:9:209:83 | SSA phi(a5) | main.rs:209:29:209:30 | a5 |
-| main.rs:209:9:209:83 | SSA phi(a5) | main.rs:209:55:209:56 | a5 |
-| main.rs:209:9:209:83 | SSA phi(a5) | main.rs:209:81:209:82 | a5 |
-| main.rs:209:10:209:57 | [match(true)] SSA phi(a5) | main.rs:209:29:209:30 | a5 |
-| main.rs:209:10:209:57 | [match(true)] SSA phi(a5) | main.rs:209:55:209:56 | a5 |
-| main.rs:213:9:213:83 | SSA phi(a6) | main.rs:213:28:213:29 | a6 |
-| main.rs:213:9:213:83 | SSA phi(a6) | main.rs:213:55:213:56 | a6 |
-| main.rs:213:9:213:83 | SSA phi(a6) | main.rs:213:80:213:81 | a6 |
-| main.rs:213:35:213:82 | SSA phi(a6) | main.rs:213:55:213:56 | a6 |
-| main.rs:213:35:213:82 | SSA phi(a6) | main.rs:213:80:213:81 | a6 |
-| main.rs:221:9:221:44 | [match(true)] SSA phi(a7) | main.rs:221:22:221:23 | a7 |
-| main.rs:221:9:221:44 | [match(true)] SSA phi(a7) | main.rs:221:42:221:43 | a7 |
-| main.rs:233:14:233:51 | [match(true)] SSA phi(a11) | main.rs:233:27:233:29 | a11 |
-| main.rs:233:14:233:51 | [match(true)] SSA phi(a11) | main.rs:233:48:233:50 | a11 |
-| main.rs:255:9:255:109 | SSA phi(a13) | main.rs:255:27:255:29 | a13 |
-| main.rs:255:9:255:109 | SSA phi(a13) | main.rs:255:54:255:56 | a13 |
-| main.rs:255:9:255:109 | SSA phi(a13) | main.rs:255:79:255:81 | a13 |
-| main.rs:255:9:255:109 | SSA phi(a13) | main.rs:255:106:255:108 | a13 |
-| main.rs:255:35:255:82 | [match(true)] SSA phi(a13) | main.rs:255:54:255:56 | a13 |
-| main.rs:255:35:255:82 | [match(true)] SSA phi(a13) | main.rs:255:79:255:81 | a13 |
-| main.rs:272:6:272:41 | SSA phi(a9) | main.rs:272:19:272:20 | a9 |
-| main.rs:272:6:272:41 | SSA phi(a9) | main.rs:272:39:272:40 | a9 |
-| main.rs:479:5:487:5 | SSA phi(x) | main.rs:480:9:480:9 | x |
-| main.rs:479:5:487:5 | SSA phi(x) | main.rs:484:9:484:9 | x |
+| main.rs:203:9:203:44 | SSA phi(a3) | main.rs:203:22:203:23 | a3 |
+| main.rs:203:9:203:44 | SSA phi(a3) | main.rs:203:42:203:43 | a3 |
+| main.rs:217:9:217:81 | SSA phi(a4) | main.rs:217:28:217:29 | a4 |
+| main.rs:217:9:217:81 | SSA phi(a4) | main.rs:217:54:217:55 | a4 |
+| main.rs:217:9:217:81 | SSA phi(a4) | main.rs:217:79:217:80 | a4 |
+| main.rs:221:9:221:83 | SSA phi(a5) | main.rs:221:29:221:30 | a5 |
+| main.rs:221:9:221:83 | SSA phi(a5) | main.rs:221:55:221:56 | a5 |
+| main.rs:221:9:221:83 | SSA phi(a5) | main.rs:221:81:221:82 | a5 |
+| main.rs:221:10:221:57 | [match(true)] SSA phi(a5) | main.rs:221:29:221:30 | a5 |
+| main.rs:221:10:221:57 | [match(true)] SSA phi(a5) | main.rs:221:55:221:56 | a5 |
+| main.rs:225:9:225:83 | SSA phi(a6) | main.rs:225:28:225:29 | a6 |
+| main.rs:225:9:225:83 | SSA phi(a6) | main.rs:225:55:225:56 | a6 |
+| main.rs:225:9:225:83 | SSA phi(a6) | main.rs:225:80:225:81 | a6 |
+| main.rs:225:35:225:82 | SSA phi(a6) | main.rs:225:55:225:56 | a6 |
+| main.rs:225:35:225:82 | SSA phi(a6) | main.rs:225:80:225:81 | a6 |
+| main.rs:233:9:233:44 | [match(true)] SSA phi(a7) | main.rs:233:22:233:23 | a7 |
+| main.rs:233:9:233:44 | [match(true)] SSA phi(a7) | main.rs:233:42:233:43 | a7 |
+| main.rs:245:14:245:51 | [match(true)] SSA phi(a11) | main.rs:245:27:245:29 | a11 |
+| main.rs:245:14:245:51 | [match(true)] SSA phi(a11) | main.rs:245:48:245:50 | a11 |
+| main.rs:267:9:267:109 | SSA phi(a13) | main.rs:267:27:267:29 | a13 |
+| main.rs:267:9:267:109 | SSA phi(a13) | main.rs:267:54:267:56 | a13 |
+| main.rs:267:9:267:109 | SSA phi(a13) | main.rs:267:79:267:81 | a13 |
+| main.rs:267:9:267:109 | SSA phi(a13) | main.rs:267:106:267:108 | a13 |
+| main.rs:267:35:267:82 | [match(true)] SSA phi(a13) | main.rs:267:54:267:56 | a13 |
+| main.rs:267:35:267:82 | [match(true)] SSA phi(a13) | main.rs:267:79:267:81 | a13 |
+| main.rs:284:20:284:55 | SSA phi(a9) | main.rs:284:33:284:34 | a9 |
+| main.rs:284:20:284:55 | SSA phi(a9) | main.rs:284:53:284:54 | a9 |
+| main.rs:494:13:503:5 | SSA phi(x) | main.rs:496:9:496:9 | x |
+| main.rs:494:13:503:5 | SSA phi(x) | main.rs:500:9:500:9 | x |
+| main.rs:629:17:631:9 | SSA phi(x) | main.rs:630:13:630:13 | x |
 assigns
-| main.rs:16:9:16:10 | x1 | main.rs:16:14:16:16 | "a" |
-| main.rs:21:13:21:14 | x2 | main.rs:21:18:21:18 | 4 |
-| main.rs:23:5:23:6 | x2 | main.rs:23:10:23:10 | 5 |
-| main.rs:28:13:28:13 | x | main.rs:28:17:28:17 | 1 |
-| main.rs:30:5:30:5 | x | main.rs:30:9:30:9 | 2 |
-| main.rs:35:9:35:10 | x3 | main.rs:35:14:35:14 | 1 |
-| main.rs:37:9:37:10 | x3 | main.rs:38:9:38:14 | ... + ... |
-| main.rs:43:9:43:10 | x4 | main.rs:43:14:43:16 | "a" |
-| main.rs:46:13:46:14 | x4 | main.rs:46:18:46:20 | "b" |
-| main.rs:75:9:75:10 | p1 | main.rs:75:14:75:37 | Point {...} |
-| main.rs:85:9:85:10 | s1 | main.rs:85:14:85:41 | Some(...) |
-| main.rs:102:9:102:10 | s1 | main.rs:102:14:102:41 | Some(...) |
-| main.rs:111:9:111:10 | x6 | main.rs:111:14:111:20 | Some(...) |
-| main.rs:112:9:112:10 | y1 | main.rs:112:14:112:15 | 10 |
-| main.rs:128:9:128:15 | numbers | main.rs:128:19:128:35 | TupleExpr |
-| main.rs:155:9:155:10 | p2 | main.rs:155:14:155:37 | Point {...} |
-| main.rs:169:9:169:11 | msg | main.rs:169:15:169:38 | ...::Hello {...} |
-| main.rs:189:9:189:14 | either | main.rs:189:18:189:33 | ...::Left(...) |
-| main.rs:203:9:203:10 | tv | main.rs:203:14:203:36 | ...::Second(...) |
-| main.rs:219:9:219:14 | either | main.rs:219:18:219:33 | ...::Left(...) |
-| main.rs:229:9:229:14 | either | main.rs:229:18:229:33 | ...::Left(...) |
-| main.rs:253:9:253:10 | fv | main.rs:253:14:253:35 | ...::Second(...) |
-| main.rs:315:9:315:23 | example_closure | main.rs:316:9:317:9 | \|...\| x |
-| main.rs:318:9:318:10 | n1 | main.rs:319:9:319:26 | example_closure(...) |
-| main.rs:323:9:323:26 | immutable_variable | main.rs:324:9:325:9 | \|...\| x |
-| main.rs:326:9:326:10 | n2 | main.rs:327:9:327:29 | immutable_variable(...) |
-| main.rs:333:9:333:9 | f | main.rs:334:9:335:9 | \|...\| x |
-| main.rs:354:13:354:13 | f | main.rs:355:13:356:13 | \|...\| x |
-| main.rs:362:9:362:9 | v | main.rs:362:13:362:41 | &... |
-| main.rs:371:13:371:13 | a | main.rs:371:17:371:17 | 0 |
-| main.rs:379:13:379:13 | i | main.rs:379:17:379:17 | 1 |
-| main.rs:380:9:380:13 | ref_i | main.rs:381:9:381:14 | &mut i |
-| main.rs:402:13:402:13 | x | main.rs:402:17:402:17 | 2 |
-| main.rs:403:9:403:9 | y | main.rs:404:9:404:28 | mutate_param(...) |
-| main.rs:409:13:409:13 | z | main.rs:409:17:409:17 | 4 |
-| main.rs:410:9:410:9 | w | main.rs:411:9:411:19 | &mut ... |
-| main.rs:422:13:422:13 | x | main.rs:422:17:422:17 | 1 |
-| main.rs:423:9:423:9 | y | main.rs:424:9:424:14 | &mut x |
-| main.rs:430:9:430:9 | x | main.rs:430:13:430:15 | 100 |
-| main.rs:432:9:432:11 | cap | main.rs:432:15:434:5 | \|...\| ... |
-| main.rs:440:13:440:13 | x | main.rs:440:17:440:17 | 1 |
-| main.rs:442:9:442:16 | closure1 | main.rs:442:20:444:5 | \|...\| ... |
-| main.rs:448:13:448:13 | y | main.rs:448:17:448:17 | 2 |
-| main.rs:450:13:450:20 | closure2 | main.rs:450:24:452:5 | \|...\| ... |
-| main.rs:451:9:451:9 | y | main.rs:451:13:451:13 | 3 |
-| main.rs:456:13:456:13 | z | main.rs:456:17:456:17 | 2 |
-| main.rs:458:13:458:20 | closure3 | main.rs:458:24:460:5 | \|...\| ... |
-| main.rs:466:13:466:13 | i | main.rs:466:22:466:22 | 0 |
-| main.rs:467:9:467:13 | block | main.rs:467:17:469:5 | { ... } |
-| main.rs:468:9:468:9 | i | main.rs:468:13:468:13 | 1 |
-| main.rs:476:13:476:13 | x | main.rs:476:17:476:17 | 1 |
-| main.rs:480:9:480:9 | x | main.rs:480:13:480:13 | 2 |
-| main.rs:484:9:484:9 | x | main.rs:484:13:484:13 | 3 |
-| main.rs:492:9:492:9 | x | main.rs:492:13:492:13 | 1 |
-| main.rs:521:17:521:17 | f | main.rs:521:21:524:9 | \|...\| ... |
-| main.rs:531:13:531:13 | a | main.rs:531:17:531:35 | MyStruct {...} |
-| main.rs:535:5:535:5 | a | main.rs:535:9:535:27 | MyStruct {...} |
-| main.rs:540:13:540:13 | a | main.rs:540:17:540:25 | [...] |
-| main.rs:544:5:544:5 | a | main.rs:544:9:544:17 | [...] |
-| main.rs:549:9:549:9 | x | main.rs:549:13:549:14 | 16 |
-| main.rs:553:9:553:9 | z | main.rs:553:13:553:14 | 17 |
-| main.rs:568:11:568:11 | a | main.rs:568:15:568:33 | MyStruct {...} |
-| main.rs:593:9:593:22 | var_from_macro | main.rs:594:9:594:25 | MacroExpr |
-| main.rs:594:9:594:25 | var_in_macro | main.rs:594:23:594:24 | 37 |
-| main.rs:596:9:596:20 | var_in_macro | main.rs:596:24:596:25 | 33 |
-| main.rs:600:15:600:42 | var_in_macro | main.rs:600:15:600:42 | 0 |
+| main.rs:18:9:18:10 | x1 | main.rs:18:14:18:16 | "a" |
+| main.rs:23:13:23:14 | x2 | main.rs:23:18:23:18 | 4 |
+| main.rs:25:5:25:6 | x2 | main.rs:25:10:25:10 | 5 |
+| main.rs:30:13:30:13 | x | main.rs:30:17:30:17 | 1 |
+| main.rs:32:5:32:5 | x | main.rs:32:9:32:9 | 2 |
+| main.rs:37:9:37:10 | x3 | main.rs:37:14:37:14 | 1 |
+| main.rs:39:9:39:10 | x3 | main.rs:40:9:40:14 | ... + ... |
+| main.rs:45:9:45:10 | x4 | main.rs:45:14:45:16 | "a" |
+| main.rs:48:13:48:14 | x4 | main.rs:48:18:48:20 | "b" |
+| main.rs:77:9:77:10 | p1 | main.rs:77:14:77:37 | Point {...} |
+| main.rs:87:9:87:10 | s1 | main.rs:87:14:87:41 | Some(...) |
+| main.rs:106:9:106:10 | s1 | main.rs:106:14:106:41 | Some(...) |
+| main.rs:115:9:115:10 | x6 | main.rs:115:14:115:20 | Some(...) |
+| main.rs:116:9:116:10 | y1 | main.rs:116:14:116:15 | 10 |
+| main.rs:132:9:132:15 | numbers | main.rs:132:19:132:35 | TupleExpr |
+| main.rs:163:9:163:10 | p2 | main.rs:163:14:163:37 | Point {...} |
+| main.rs:177:9:177:11 | msg | main.rs:177:15:177:38 | ...::Hello {...} |
+| main.rs:201:9:201:14 | either | main.rs:201:18:201:33 | ...::Left(...) |
+| main.rs:215:9:215:10 | tv | main.rs:215:14:215:36 | ...::Second(...) |
+| main.rs:231:9:231:14 | either | main.rs:231:18:231:33 | ...::Left(...) |
+| main.rs:241:9:241:14 | either | main.rs:241:18:241:33 | ...::Left(...) |
+| main.rs:265:9:265:10 | fv | main.rs:265:14:265:35 | ...::Second(...) |
+| main.rs:327:9:327:23 | example_closure | main.rs:328:9:329:9 | \|...\| x |
+| main.rs:330:9:330:10 | n1 | main.rs:331:9:331:26 | example_closure(...) |
+| main.rs:335:9:335:26 | immutable_variable | main.rs:336:5:337:9 | \|...\| x |
+| main.rs:338:9:338:10 | n2 | main.rs:339:9:339:29 | immutable_variable(...) |
+| main.rs:345:9:345:9 | f | main.rs:346:9:347:9 | \|...\| x |
+| main.rs:368:13:368:13 | f | main.rs:369:13:370:13 | \|...\| x |
+| main.rs:376:9:376:9 | v | main.rs:376:13:376:41 | &... |
+| main.rs:385:13:385:13 | a | main.rs:385:17:385:17 | 0 |
+| main.rs:393:13:393:13 | i | main.rs:393:17:393:17 | 1 |
+| main.rs:394:9:394:13 | ref_i | main.rs:395:9:395:14 | &mut i |
+| main.rs:416:13:416:13 | x | main.rs:416:17:416:17 | 2 |
+| main.rs:417:9:417:9 | y | main.rs:418:9:418:28 | mutate_param(...) |
+| main.rs:423:13:423:13 | z | main.rs:423:17:423:17 | 4 |
+| main.rs:424:9:424:9 | w | main.rs:425:9:425:19 | &mut ... |
+| main.rs:436:13:436:13 | x | main.rs:436:17:436:17 | 1 |
+| main.rs:437:9:437:9 | y | main.rs:438:9:438:14 | &mut x |
+| main.rs:444:9:444:9 | x | main.rs:444:13:444:15 | 100 |
+| main.rs:446:9:446:11 | cap | main.rs:446:15:448:5 | \|...\| ... |
+| main.rs:454:13:454:13 | x | main.rs:454:17:454:17 | 1 |
+| main.rs:456:9:456:16 | closure1 | main.rs:456:20:458:5 | \|...\| ... |
+| main.rs:462:13:462:13 | y | main.rs:462:17:462:17 | 2 |
+| main.rs:464:13:464:20 | closure2 | main.rs:464:24:466:5 | \|...\| ... |
+| main.rs:465:9:465:9 | y | main.rs:465:13:465:13 | 3 |
+| main.rs:470:13:470:13 | z | main.rs:470:17:470:17 | 2 |
+| main.rs:472:13:472:20 | closure3 | main.rs:472:24:474:5 | \|...\| ... |
+| main.rs:480:13:480:13 | i | main.rs:480:22:480:22 | 0 |
+| main.rs:481:9:481:13 | block | main.rs:481:17:483:5 | { ... } |
+| main.rs:482:9:482:9 | i | main.rs:482:13:482:13 | 1 |
+| main.rs:490:13:490:13 | x | main.rs:490:17:490:17 | 1 |
+| main.rs:496:9:496:9 | x | main.rs:496:13:496:13 | 2 |
+| main.rs:500:9:500:9 | x | main.rs:500:13:500:13 | 3 |
+| main.rs:508:9:508:9 | x | main.rs:508:13:508:13 | 1 |
+| main.rs:540:17:540:17 | f | main.rs:540:21:543:9 | \|...\| ... |
+| main.rs:550:13:550:13 | a | main.rs:550:17:550:35 | MyStruct {...} |
+| main.rs:554:5:554:5 | a | main.rs:554:9:554:27 | MyStruct {...} |
+| main.rs:559:13:559:13 | a | main.rs:559:17:559:25 | [...] |
+| main.rs:563:5:563:5 | a | main.rs:563:9:563:17 | [...] |
+| main.rs:568:9:568:9 | x | main.rs:568:13:568:14 | 16 |
+| main.rs:572:9:572:9 | z | main.rs:572:13:572:14 | 17 |
+| main.rs:587:13:587:13 | a | main.rs:587:17:587:35 | MyStruct {...} |
+| main.rs:608:9:608:22 | var_from_macro | main.rs:609:9:609:25 | MacroExpr |
+| main.rs:609:9:609:25 | var_in_macro | main.rs:609:23:609:24 | 37 |
+| main.rs:611:9:611:20 | var_in_macro | main.rs:611:24:611:25 | 33 |
+| main.rs:615:15:615:42 | var_in_macro | main.rs:615:15:615:42 | 0 |
+| main.rs:621:5:621:5 | x | main.rs:621:9:621:9 | 1 |
+| main.rs:626:13:626:13 | x | main.rs:626:17:626:19 | 100 |
+| main.rs:627:13:627:15 | cap | main.rs:627:19:632:5 | \|...\| ... |
+| main.rs:630:13:630:13 | x | main.rs:630:17:630:19 | 200 |

--- a/rust/ql/test/library-tests/variables/Ssa.expected
+++ b/rust/ql/test/library-tests/variables/Ssa.expected
@@ -167,6 +167,7 @@ definition
 | main.rs:621:5:621:5 | x | main.rs:620:9:620:9 | x |
 | main.rs:626:13:626:13 | x | main.rs:626:13:626:13 | x |
 | main.rs:627:13:627:15 | cap | main.rs:627:13:627:15 | cap |
+| main.rs:627:19:632:5 | <captured entry> x | main.rs:626:13:626:13 | x |
 | main.rs:627:20:627:20 | b | main.rs:627:20:627:20 | b |
 | main.rs:629:17:631:9 | SSA phi(x) | main.rs:626:13:626:13 | x |
 | main.rs:630:13:630:13 | x | main.rs:626:13:626:13 | x |
@@ -548,6 +549,7 @@ phi
 | main.rs:284:20:284:55 | SSA phi(a9) | main.rs:284:20:284:55 | a9 | main.rs:284:53:284:54 | a9 |
 | main.rs:494:13:503:5 | SSA phi(x) | main.rs:490:13:490:13 | x | main.rs:496:9:496:9 | x |
 | main.rs:494:13:503:5 | SSA phi(x) | main.rs:490:13:490:13 | x | main.rs:500:9:500:9 | x |
+| main.rs:629:17:631:9 | SSA phi(x) | main.rs:626:13:626:13 | x | main.rs:627:19:632:5 | <captured entry> x |
 | main.rs:629:17:631:9 | SSA phi(x) | main.rs:626:13:626:13 | x | main.rs:630:13:630:13 | x |
 phiReadNode
 | main.rs:108:11:109:12 | SSA phi read(s1) | main.rs:106:9:106:10 | s1 |
@@ -591,6 +593,7 @@ ultimateDef
 | main.rs:284:20:284:55 | SSA phi(a9) | main.rs:284:53:284:54 | a9 |
 | main.rs:494:13:503:5 | SSA phi(x) | main.rs:496:9:496:9 | x |
 | main.rs:494:13:503:5 | SSA phi(x) | main.rs:500:9:500:9 | x |
+| main.rs:629:17:631:9 | SSA phi(x) | main.rs:627:19:632:5 | <captured entry> x |
 | main.rs:629:17:631:9 | SSA phi(x) | main.rs:630:13:630:13 | x |
 assigns
 | main.rs:18:9:18:10 | x1 | main.rs:18:14:18:16 | "a" |

--- a/rust/ql/test/library-tests/variables/main.rs
+++ b/rust/ql/test/library-tests/variables/main.rs
@@ -1,10 +1,12 @@
 use std::ops::AddAssign;
 
-fn print_str(s: &str) { // s
+fn print_str(s: &str) // s
+{
     println!("{}", s); // $ read_access=s
 }
 
-fn print_i64(i: i64) { // i
+fn print_i64(i: i64) // i
+{
     println!("{}", i); // $ read_access=i
 }
 
@@ -91,10 +93,12 @@ fn let_pattern3() {
 }
 
 fn let_pattern4() {
-    let Some(x5): Option<&str> = Some("x5") // x5
-        else {
-            todo!()
-        };
+    let Some(x5): Option<&str> // x5
+    = Some("x5")
+
+    else {
+        todo!()
+    };
     print_str(x5); // $ read_access=x5
 }
 
@@ -127,11 +131,14 @@ fn match_pattern1() {
 fn match_pattern2() {
     let numbers = (2, 4, 8, 16, 32); // numbers
 
-    match numbers { // $ read_access=numbers
+    match numbers // $ read_access=numbers
+    {
         (
-            first, _, // first
-            third, _, // third
-            fifth // fifth
+            first, // first
+            _,
+            third, // third
+            _,
+            fifth, // fifth
         ) => {
             print_i64(first); // $ read_access=first
             print_i64(third); // $ read_access=third
@@ -139,11 +146,12 @@ fn match_pattern2() {
         }
     }
 
-    match numbers { // $ read_access=numbers
+    match numbers // $ read_access=numbers
+    {
         (
             first, // first
             ..,
-            last // last
+            last, // last
         ) => {
             print_i64(first); // $ read_access=first
             print_i64(last); // $ read_access=last
@@ -168,15 +176,19 @@ enum Message {
 fn match_pattern4() {
     let msg = Message::Hello { id: 0 }; // msg
 
-    match msg { // $ read_access=msg
+    match msg // $ read_access=msg
+    {
         Message::Hello {
             id: id_variable @ 3..=7, // id_variable
         } => print_i64(id_variable), // $ read_access=id_variable
         Message::Hello { id: 10..=12 } => {
             println!("Found an id in another range")
         }
-        Message::Hello { id } => // id
-            print_i64(id), // $ read_access=id
+        Message::Hello { id } // id
+        =>
+        {
+            print_i64(id) // $ read_access=id
+        }
     }
 }
 
@@ -262,14 +274,14 @@ fn param_pattern1(
     (
         b3, // b3
         c1, // c1
-    ): (&str, &str)) -> () {
+    ): (&str, &str),
+) -> () {
     print_str(a8); // $ read_access=a8
     print_str(b3); // $ read_access=b3
     print_str(c1); // $ read_access=c1
 }
 
-fn param_pattern2(
-    (Either::Left(a9) | Either::Right(a9)): Either // a9
+fn param_pattern2((Either::Left(a9) | Either::Right(a9)): Either, // a9
 ) -> () {
     print_i64(a9); // $ read_access=a9
 }
@@ -277,21 +289,21 @@ fn param_pattern2(
 fn destruct_assignment() {
     let (
         mut a10, // a10
-        mut b4, // b4
-        mut c2 // c2
+        mut b4,  // b4
+        mut c2,  // c2
     ) = (1, 2, 3);
     print_i64(a10); // $ read_access=a10
     print_i64(b4); // $ read_access=b4
     print_i64(c2); // $ read_access=c2
 
     (
-        c2, // $ write_access=c2
-        b4, // $ write_access=b4
-        a10 // $ write_access=a10
+        c2,  // $ write_access=c2
+        b4,  // $ write_access=b4
+        a10, // $ write_access=a10
     ) = (
         a10, // $ read_access=a10
-        b4, // $ read_access=b4
-        c2 // $ read_access=c2
+        b4,  // $ read_access=b4
+        c2,  // $ read_access=c2
     );
     print_i64(a10); // $ read_access=a10
     print_i64(b4); // $ read_access=b4
@@ -300,7 +312,7 @@ fn destruct_assignment() {
     match (4, 5) {
         (
             a10, // a10_2
-            b4 // b4
+            b4,  // b4
         ) => {
             print_i64(a10); // $ read_access=a10_2
             print_i64(b4); // $ read_access=b4
@@ -320,8 +332,8 @@ fn closure_variable() {
     print_i64(n1); // $ read_access=n1
 
     immutable_variable();
-    let immutable_variable =
-        |x: i64| // x_2
+    let immutable_variable = // immutable_variable
+    |x: i64| // x_2
         x; // $ read_access=x_2
     let n2 = // n2
         immutable_variable(6); // $ read_access=immutable_variable
@@ -335,7 +347,8 @@ fn nested_function() {
         x; // $ read_access=x_1
     print_i64(f(1)); // $ read_access=f1
 
-    fn f(x: i64) -> i64 { // x_2
+    fn f(x: i64) -> i64 // x_2
+    {
         x + 1 // $ read_access=x_2
     }
 
@@ -343,7 +356,8 @@ fn nested_function() {
 
     {
         print_i64(f(3));
-        fn f(x: i64) -> i64 { // x_3
+        fn f(x: i64) -> i64 // x_3
+        {
             2 * x // $ read_access=x_3
         }
 
@@ -383,14 +397,14 @@ fn mutate() {
     print_i64(i); // $ read_access=i
 }
 
-fn mutate_param(x : &mut i64) -> &mut i64 {
+fn mutate_param(x: &mut i64) -> &mut i64 {
     *x = // $ read_access=x
         *x + // $ read_access=x
         *x; // $ read_access=x
     return x; // $ read_access=x
 }
 
-fn mutate_param2<'a>(x : &'a mut i64, y :&mut &'a mut i64) {
+fn mutate_param2<'a>(x: &'a mut i64, y: &mut &'a mut i64) {
     *x = // $ read_access=x
         *x + // $ read_access=x
         *x; // $ read_access=x
@@ -411,7 +425,7 @@ fn mutate_arg() {
         &mut &mut x; // $ access=x
     mutate_param2(
         &mut z, // $ access=z
-        w // $ read_access=w
+        w,      // $ read_access=w
     );
     **w = 11; // $ read_access=w
     // prints 11, not 8
@@ -472,11 +486,13 @@ async fn async_block_capture() {
     print_i64(i); // $ read_access=i
 }
 
-fn phi(b : bool) {
+fn phi(b: bool) {
     let mut x = 1; // x
     print_i64(x); // $ read_access=x
     print_i64(x + 1); // $ read_access=x
-    if b { // $ read_access=b
+    #[rustfmt::skip]
+    let _ = if b // $ read_access=b
+    {
         x = 2; // $ write_access=x
         print_i64(x); // $ read_access=x
         print_i64(x + 1); // $ read_access=x
@@ -484,25 +500,28 @@ fn phi(b : bool) {
         x = 3; // $ write_access=x
         print_i64(x); // $ read_access=x
         print_i64(x + 1); // $ read_access=x
-    }
+    };
     print_i64(x); // $ read_access=x
 }
 
-fn phi_read(b1 : bool, b2 : bool) {
+fn phi_read(b1: bool, b2: bool) {
     let x = 1; // x
-    if b1 { // $ read_access=b1
+    #[rustfmt::skip]
+    let _ = if b1 // $ read_access=b1
+    {
         print_i64(x); // $ read_access=x
     } else {
         print_i64(x); // $ read_access=x
-    }
+    };
 
-    if b2 { // $ read_access=b2
+    #[rustfmt::skip]
+    let _ = if b2 // $ read_access=b2
+    {
         print_i64(x); // $ read_access=x
     } else {
         print_i64(x); // $ read_access=x
-    }
+    };
 }
-
 
 struct MyStruct {
     val: i64,
@@ -555,38 +574,34 @@ fn ref_arg() {
 }
 
 trait Bar {
-  fn bar(&self);
+    fn bar(&self);
 }
 
 impl MyStruct {
-  fn bar(&mut self) {
-    *self = MyStruct { val: 3 }; // $ read_access=self
-  }
+    fn bar(&mut self) {
+        *self = MyStruct { val: 3 }; // $ read_access=self
+    }
 }
 
 fn ref_methodcall_receiver() {
-  let mut a = MyStruct { val: 1 }; // a
-  a.bar(); // $ read_access=a
-  // prints 3, not 1
-  print_i64(a.val); // $ read_access=a
+    let mut a = MyStruct { val: 1 }; // a
+    a.bar(); // $ read_access=a
+    // prints 3, not 1
+    print_i64(a.val); // $ read_access=a
 }
 
 macro_rules! let_in_macro {
-    ($e:expr) => {
-        {
-            let var_in_macro = $e;
-            var_in_macro
-        }
-    };
+    ($e:expr) => {{
+        let var_in_macro = $e;
+        var_in_macro
+    }};
 }
 
 macro_rules! let_in_macro2 {
-    ($e:expr) => {
-        {
-            let var_in_macro = 0;
-            $e
-        }
-    };
+    ($e:expr) => {{
+        let var_in_macro = 0;
+        $e
+    }};
 }
 
 fn macro_invocation() {
@@ -599,6 +614,24 @@ fn macro_invocation() {
     // all we have access to is the expanded AST
     print_i64(let_in_macro2!(var_in_macro)); // $ MISSING: read_access=var_in_macro1 $ SPURIOUS: read_access=var_in_macro
     print_i64(var_in_macro); // $ read_access=var_in_macro1
+}
+
+fn let_without_initializer() {
+    let x; // x
+    x = 1; // $ write_access=x
+    print_i64(x); // $ read_access=x
+}
+
+fn capture_phi() {
+    let mut x = 100; // x
+    let mut cap = |b: bool| {
+        #[rustfmt::skip]
+        let _ = if b { // $ read_access=b
+            x = 200; // $ write_access=x
+        };
+    };
+    cap(true); // $ read_access=cap
+    print_i64(x); // $ read_access=x
 }
 
 fn main() {
@@ -637,4 +670,5 @@ fn main() {
     ref_arg();
     ref_methodcall_receiver();
     macro_invocation();
+    capture_phi();
 }

--- a/rust/ql/test/library-tests/variables/variables.expected
+++ b/rust/ql/test/library-tests/variables/variables.expected
@@ -1,543 +1,563 @@
 testFailures
 variable
 | main.rs:3:14:3:14 | s |
-| main.rs:7:14:7:14 | i |
-| main.rs:11:18:11:18 | i |
-| main.rs:16:9:16:10 | x1 |
-| main.rs:21:13:21:14 | x2 |
-| main.rs:28:13:28:13 | x |
-| main.rs:35:9:35:10 | x3 |
+| main.rs:8:14:8:14 | i |
+| main.rs:13:18:13:18 | i |
+| main.rs:18:9:18:10 | x1 |
+| main.rs:23:13:23:14 | x2 |
+| main.rs:30:13:30:13 | x |
 | main.rs:37:9:37:10 | x3 |
-| main.rs:43:9:43:10 | x4 |
-| main.rs:46:13:46:14 | x4 |
-| main.rs:60:13:60:14 | a1 |
-| main.rs:61:13:61:14 | b1 |
-| main.rs:64:13:64:13 | x |
-| main.rs:65:13:65:13 | y |
-| main.rs:75:9:75:10 | p1 |
-| main.rs:77:12:77:13 | a2 |
-| main.rs:78:12:78:13 | b2 |
-| main.rs:85:9:85:10 | s1 |
-| main.rs:87:21:87:22 | s2 |
-| main.rs:94:14:94:15 | x5 |
-| main.rs:102:9:102:10 | s1 |
-| main.rs:104:24:104:25 | s2 |
-| main.rs:111:9:111:10 | x6 |
-| main.rs:112:9:112:10 | y1 |
-| main.rs:116:14:116:15 | y1 |
-| main.rs:128:9:128:15 | numbers |
-| main.rs:132:13:132:17 | first |
-| main.rs:133:13:133:17 | third |
-| main.rs:134:13:134:17 | fifth |
-| main.rs:144:13:144:17 | first |
-| main.rs:146:13:146:16 | last |
-| main.rs:155:9:155:10 | p2 |
-| main.rs:159:16:159:17 | x7 |
-| main.rs:169:9:169:11 | msg |
-| main.rs:173:17:173:27 | id_variable |
-| main.rs:178:26:178:27 | id |
-| main.rs:189:9:189:14 | either |
-| main.rs:191:9:191:44 | a3 |
-| main.rs:203:9:203:10 | tv |
-| main.rs:205:9:205:81 | a4 |
-| main.rs:209:9:209:83 | a5 |
-| main.rs:213:9:213:83 | a6 |
-| main.rs:219:9:219:14 | either |
-| main.rs:221:9:221:44 | a7 |
-| main.rs:229:9:229:14 | either |
-| main.rs:232:13:232:13 | e |
-| main.rs:233:14:233:51 | a11 |
-| main.rs:236:33:236:35 | a12 |
-| main.rs:253:9:253:10 | fv |
-| main.rs:255:9:255:109 | a13 |
-| main.rs:261:5:261:6 | a8 |
-| main.rs:263:9:263:10 | b3 |
-| main.rs:264:9:264:10 | c1 |
-| main.rs:272:6:272:41 | a9 |
-| main.rs:279:13:279:15 | a10 |
-| main.rs:280:13:280:14 | b4 |
-| main.rs:281:13:281:14 | c2 |
-| main.rs:302:13:302:15 | a10 |
-| main.rs:303:13:303:14 | b4 |
-| main.rs:315:9:315:23 | example_closure |
-| main.rs:316:10:316:10 | x |
-| main.rs:318:9:318:10 | n1 |
-| main.rs:323:9:323:26 | immutable_variable |
-| main.rs:324:10:324:10 | x |
-| main.rs:326:9:326:10 | n2 |
-| main.rs:333:9:333:9 | f |
-| main.rs:334:10:334:10 | x |
-| main.rs:338:10:338:10 | x |
-| main.rs:346:14:346:14 | x |
-| main.rs:354:13:354:13 | f |
-| main.rs:355:14:355:14 | x |
-| main.rs:362:9:362:9 | v |
-| main.rs:364:9:364:12 | text |
-| main.rs:371:13:371:13 | a |
-| main.rs:379:13:379:13 | i |
-| main.rs:380:9:380:13 | ref_i |
-| main.rs:386:17:386:17 | x |
-| main.rs:393:22:393:22 | x |
-| main.rs:393:39:393:39 | y |
-| main.rs:402:13:402:13 | x |
-| main.rs:403:9:403:9 | y |
-| main.rs:409:13:409:13 | z |
-| main.rs:410:9:410:9 | w |
-| main.rs:422:13:422:13 | x |
-| main.rs:423:9:423:9 | y |
-| main.rs:430:9:430:9 | x |
-| main.rs:432:9:432:11 | cap |
-| main.rs:440:13:440:13 | x |
-| main.rs:442:9:442:16 | closure1 |
-| main.rs:448:13:448:13 | y |
-| main.rs:450:13:450:20 | closure2 |
-| main.rs:456:13:456:13 | z |
-| main.rs:458:13:458:20 | closure3 |
-| main.rs:466:13:466:13 | i |
-| main.rs:467:9:467:13 | block |
-| main.rs:475:8:475:8 | b |
-| main.rs:476:13:476:13 | x |
-| main.rs:491:13:491:14 | b1 |
-| main.rs:491:24:491:25 | b2 |
-| main.rs:492:9:492:9 | x |
-| main.rs:512:20:512:23 | self |
-| main.rs:516:11:516:14 | self |
-| main.rs:520:23:520:26 | self |
-| main.rs:521:17:521:17 | f |
-| main.rs:521:22:521:22 | n |
-| main.rs:531:13:531:13 | a |
-| main.rs:540:13:540:13 | a |
-| main.rs:549:9:549:9 | x |
-| main.rs:553:9:553:9 | z |
-| main.rs:562:15:562:18 | self |
-| main.rs:568:11:568:11 | a |
-| main.rs:593:9:593:22 | var_from_macro |
-| main.rs:594:9:594:25 | var_in_macro |
-| main.rs:596:9:596:20 | var_in_macro |
-| main.rs:600:15:600:42 | var_in_macro |
+| main.rs:39:9:39:10 | x3 |
+| main.rs:45:9:45:10 | x4 |
+| main.rs:48:13:48:14 | x4 |
+| main.rs:62:13:62:14 | a1 |
+| main.rs:63:13:63:14 | b1 |
+| main.rs:66:13:66:13 | x |
+| main.rs:67:13:67:13 | y |
+| main.rs:77:9:77:10 | p1 |
+| main.rs:79:12:79:13 | a2 |
+| main.rs:80:12:80:13 | b2 |
+| main.rs:87:9:87:10 | s1 |
+| main.rs:89:21:89:22 | s2 |
+| main.rs:96:14:96:15 | x5 |
+| main.rs:106:9:106:10 | s1 |
+| main.rs:108:24:108:25 | s2 |
+| main.rs:115:9:115:10 | x6 |
+| main.rs:116:9:116:10 | y1 |
+| main.rs:120:14:120:15 | y1 |
+| main.rs:132:9:132:15 | numbers |
+| main.rs:137:13:137:17 | first |
+| main.rs:139:13:139:17 | third |
+| main.rs:141:13:141:17 | fifth |
+| main.rs:152:13:152:17 | first |
+| main.rs:154:13:154:16 | last |
+| main.rs:163:9:163:10 | p2 |
+| main.rs:167:16:167:17 | x7 |
+| main.rs:177:9:177:11 | msg |
+| main.rs:182:17:182:27 | id_variable |
+| main.rs:187:26:187:27 | id |
+| main.rs:201:9:201:14 | either |
+| main.rs:203:9:203:44 | a3 |
+| main.rs:215:9:215:10 | tv |
+| main.rs:217:9:217:81 | a4 |
+| main.rs:221:9:221:83 | a5 |
+| main.rs:225:9:225:83 | a6 |
+| main.rs:231:9:231:14 | either |
+| main.rs:233:9:233:44 | a7 |
+| main.rs:241:9:241:14 | either |
+| main.rs:244:13:244:13 | e |
+| main.rs:245:14:245:51 | a11 |
+| main.rs:248:33:248:35 | a12 |
+| main.rs:265:9:265:10 | fv |
+| main.rs:267:9:267:109 | a13 |
+| main.rs:273:5:273:6 | a8 |
+| main.rs:275:9:275:10 | b3 |
+| main.rs:276:9:276:10 | c1 |
+| main.rs:284:20:284:55 | a9 |
+| main.rs:291:13:291:15 | a10 |
+| main.rs:292:13:292:14 | b4 |
+| main.rs:293:13:293:14 | c2 |
+| main.rs:314:13:314:15 | a10 |
+| main.rs:315:13:315:14 | b4 |
+| main.rs:327:9:327:23 | example_closure |
+| main.rs:328:10:328:10 | x |
+| main.rs:330:9:330:10 | n1 |
+| main.rs:335:9:335:26 | immutable_variable |
+| main.rs:336:6:336:6 | x |
+| main.rs:338:9:338:10 | n2 |
+| main.rs:345:9:345:9 | f |
+| main.rs:346:10:346:10 | x |
+| main.rs:350:10:350:10 | x |
+| main.rs:359:14:359:14 | x |
+| main.rs:368:13:368:13 | f |
+| main.rs:369:14:369:14 | x |
+| main.rs:376:9:376:9 | v |
+| main.rs:378:9:378:12 | text |
+| main.rs:385:13:385:13 | a |
+| main.rs:393:13:393:13 | i |
+| main.rs:394:9:394:13 | ref_i |
+| main.rs:400:17:400:17 | x |
+| main.rs:407:22:407:22 | x |
+| main.rs:407:38:407:38 | y |
+| main.rs:416:13:416:13 | x |
+| main.rs:417:9:417:9 | y |
+| main.rs:423:13:423:13 | z |
+| main.rs:424:9:424:9 | w |
+| main.rs:436:13:436:13 | x |
+| main.rs:437:9:437:9 | y |
+| main.rs:444:9:444:9 | x |
+| main.rs:446:9:446:11 | cap |
+| main.rs:454:13:454:13 | x |
+| main.rs:456:9:456:16 | closure1 |
+| main.rs:462:13:462:13 | y |
+| main.rs:464:13:464:20 | closure2 |
+| main.rs:470:13:470:13 | z |
+| main.rs:472:13:472:20 | closure3 |
+| main.rs:480:13:480:13 | i |
+| main.rs:481:9:481:13 | block |
+| main.rs:489:8:489:8 | b |
+| main.rs:490:13:490:13 | x |
+| main.rs:507:13:507:14 | b1 |
+| main.rs:507:23:507:24 | b2 |
+| main.rs:508:9:508:9 | x |
+| main.rs:531:20:531:23 | self |
+| main.rs:535:11:535:14 | self |
+| main.rs:539:23:539:26 | self |
+| main.rs:540:17:540:17 | f |
+| main.rs:540:22:540:22 | n |
+| main.rs:550:13:550:13 | a |
+| main.rs:559:13:559:13 | a |
+| main.rs:568:9:568:9 | x |
+| main.rs:572:9:572:9 | z |
+| main.rs:581:17:581:20 | self |
+| main.rs:587:13:587:13 | a |
+| main.rs:608:9:608:22 | var_from_macro |
+| main.rs:609:9:609:25 | var_in_macro |
+| main.rs:611:9:611:20 | var_in_macro |
+| main.rs:615:15:615:42 | var_in_macro |
+| main.rs:620:9:620:9 | x |
+| main.rs:626:13:626:13 | x |
+| main.rs:627:13:627:15 | cap |
+| main.rs:627:20:627:20 | b |
 variableAccess
-| main.rs:4:20:4:20 | s | main.rs:3:14:3:14 | s |
-| main.rs:8:20:8:20 | i | main.rs:7:14:7:14 | i |
-| main.rs:12:16:12:16 | i | main.rs:11:18:11:18 | i |
-| main.rs:17:15:17:16 | x1 | main.rs:16:9:16:10 | x1 |
-| main.rs:22:15:22:16 | x2 | main.rs:21:13:21:14 | x2 |
-| main.rs:23:5:23:6 | x2 | main.rs:21:13:21:14 | x2 |
-| main.rs:24:15:24:16 | x2 | main.rs:21:13:21:14 | x2 |
-| main.rs:29:20:29:20 | x | main.rs:28:13:28:13 | x |
-| main.rs:30:5:30:5 | x | main.rs:28:13:28:13 | x |
-| main.rs:31:20:31:20 | x | main.rs:28:13:28:13 | x |
-| main.rs:36:15:36:16 | x3 | main.rs:35:9:35:10 | x3 |
-| main.rs:38:9:38:10 | x3 | main.rs:35:9:35:10 | x3 |
-| main.rs:39:15:39:16 | x3 | main.rs:37:9:37:10 | x3 |
-| main.rs:44:15:44:16 | x4 | main.rs:43:9:43:10 | x4 |
-| main.rs:47:19:47:20 | x4 | main.rs:46:13:46:14 | x4 |
-| main.rs:49:15:49:16 | x4 | main.rs:43:9:43:10 | x4 |
-| main.rs:68:15:68:16 | a1 | main.rs:60:13:60:14 | a1 |
-| main.rs:69:15:69:16 | b1 | main.rs:61:13:61:14 | b1 |
-| main.rs:70:15:70:15 | x | main.rs:64:13:64:13 | x |
-| main.rs:71:15:71:15 | y | main.rs:65:13:65:13 | y |
-| main.rs:79:9:79:10 | p1 | main.rs:75:9:75:10 | p1 |
-| main.rs:80:15:80:16 | a2 | main.rs:77:12:77:13 | a2 |
-| main.rs:81:15:81:16 | b2 | main.rs:78:12:78:13 | b2 |
-| main.rs:88:11:88:12 | s1 | main.rs:85:9:85:10 | s1 |
-| main.rs:89:19:89:20 | s2 | main.rs:87:21:87:22 | s2 |
-| main.rs:98:15:98:16 | x5 | main.rs:94:14:94:15 | x5 |
-| main.rs:105:11:105:12 | s1 | main.rs:102:9:102:10 | s1 |
-| main.rs:106:19:106:20 | s2 | main.rs:104:24:104:25 | s2 |
-| main.rs:114:11:114:12 | x6 | main.rs:111:9:111:10 | x6 |
-| main.rs:119:23:119:24 | y1 | main.rs:116:14:116:15 | y1 |
-| main.rs:124:15:124:16 | y1 | main.rs:112:9:112:10 | y1 |
-| main.rs:130:11:130:17 | numbers | main.rs:128:9:128:15 | numbers |
-| main.rs:136:23:136:27 | first | main.rs:132:13:132:17 | first |
-| main.rs:137:23:137:27 | third | main.rs:133:13:133:17 | third |
-| main.rs:138:23:138:27 | fifth | main.rs:134:13:134:17 | fifth |
-| main.rs:142:11:142:17 | numbers | main.rs:128:9:128:15 | numbers |
-| main.rs:148:23:148:27 | first | main.rs:144:13:144:17 | first |
-| main.rs:149:23:149:26 | last | main.rs:146:13:146:16 | last |
-| main.rs:157:11:157:12 | p2 | main.rs:155:9:155:10 | p2 |
-| main.rs:160:24:160:25 | x7 | main.rs:159:16:159:17 | x7 |
-| main.rs:171:11:171:13 | msg | main.rs:169:9:169:11 | msg |
-| main.rs:174:24:174:34 | id_variable | main.rs:173:17:173:27 | id_variable |
-| main.rs:179:23:179:24 | id | main.rs:178:26:178:27 | id |
-| main.rs:190:11:190:16 | either | main.rs:189:9:189:14 | either |
-| main.rs:192:26:192:27 | a3 | main.rs:191:9:191:44 | a3 |
-| main.rs:204:11:204:12 | tv | main.rs:203:9:203:10 | tv |
-| main.rs:206:26:206:27 | a4 | main.rs:205:9:205:81 | a4 |
-| main.rs:208:11:208:12 | tv | main.rs:203:9:203:10 | tv |
-| main.rs:210:26:210:27 | a5 | main.rs:209:9:209:83 | a5 |
-| main.rs:212:11:212:12 | tv | main.rs:203:9:203:10 | tv |
-| main.rs:214:26:214:27 | a6 | main.rs:213:9:213:83 | a6 |
-| main.rs:220:11:220:16 | either | main.rs:219:9:219:14 | either |
-| main.rs:222:16:222:17 | a7 | main.rs:221:9:221:44 | a7 |
-| main.rs:223:26:223:27 | a7 | main.rs:221:9:221:44 | a7 |
-| main.rs:231:11:231:16 | either | main.rs:229:9:229:14 | either |
-| main.rs:235:23:235:25 | a11 | main.rs:233:14:233:51 | a11 |
-| main.rs:237:15:237:15 | e | main.rs:232:13:232:13 | e |
-| main.rs:238:28:238:30 | a12 | main.rs:236:33:236:35 | a12 |
-| main.rs:254:11:254:12 | fv | main.rs:253:9:253:10 | fv |
-| main.rs:256:26:256:28 | a13 | main.rs:255:9:255:109 | a13 |
-| main.rs:266:15:266:16 | a8 | main.rs:261:5:261:6 | a8 |
-| main.rs:267:15:267:16 | b3 | main.rs:263:9:263:10 | b3 |
-| main.rs:268:15:268:16 | c1 | main.rs:264:9:264:10 | c1 |
-| main.rs:274:15:274:16 | a9 | main.rs:272:6:272:41 | a9 |
-| main.rs:283:15:283:17 | a10 | main.rs:279:13:279:15 | a10 |
-| main.rs:284:15:284:16 | b4 | main.rs:280:13:280:14 | b4 |
-| main.rs:285:15:285:16 | c2 | main.rs:281:13:281:14 | c2 |
-| main.rs:288:9:288:10 | c2 | main.rs:281:13:281:14 | c2 |
-| main.rs:289:9:289:10 | b4 | main.rs:280:13:280:14 | b4 |
-| main.rs:290:9:290:11 | a10 | main.rs:279:13:279:15 | a10 |
-| main.rs:292:9:292:11 | a10 | main.rs:279:13:279:15 | a10 |
-| main.rs:293:9:293:10 | b4 | main.rs:280:13:280:14 | b4 |
-| main.rs:294:9:294:10 | c2 | main.rs:281:13:281:14 | c2 |
-| main.rs:296:15:296:17 | a10 | main.rs:279:13:279:15 | a10 |
-| main.rs:297:15:297:16 | b4 | main.rs:280:13:280:14 | b4 |
-| main.rs:298:15:298:16 | c2 | main.rs:281:13:281:14 | c2 |
-| main.rs:305:23:305:25 | a10 | main.rs:302:13:302:15 | a10 |
-| main.rs:306:23:306:24 | b4 | main.rs:303:13:303:14 | b4 |
-| main.rs:310:15:310:17 | a10 | main.rs:279:13:279:15 | a10 |
-| main.rs:311:15:311:16 | b4 | main.rs:280:13:280:14 | b4 |
-| main.rs:317:9:317:9 | x | main.rs:316:10:316:10 | x |
-| main.rs:319:9:319:23 | example_closure | main.rs:315:9:315:23 | example_closure |
-| main.rs:320:15:320:16 | n1 | main.rs:318:9:318:10 | n1 |
-| main.rs:325:9:325:9 | x | main.rs:324:10:324:10 | x |
-| main.rs:327:9:327:26 | immutable_variable | main.rs:323:9:323:26 | immutable_variable |
-| main.rs:328:15:328:16 | n2 | main.rs:326:9:326:10 | n2 |
-| main.rs:335:9:335:9 | x | main.rs:334:10:334:10 | x |
-| main.rs:336:15:336:15 | f | main.rs:333:9:333:9 | f |
-| main.rs:339:9:339:9 | x | main.rs:338:10:338:10 | x |
-| main.rs:342:15:342:15 | f | main.rs:333:9:333:9 | f |
-| main.rs:347:17:347:17 | x | main.rs:346:14:346:14 | x |
-| main.rs:356:13:356:13 | x | main.rs:355:14:355:14 | x |
-| main.rs:357:19:357:19 | f | main.rs:354:13:354:13 | f |
-| main.rs:365:12:365:12 | v | main.rs:362:9:362:9 | v |
-| main.rs:366:19:366:22 | text | main.rs:364:9:364:12 | text |
-| main.rs:372:5:372:5 | a | main.rs:371:13:371:13 | a |
-| main.rs:373:15:373:15 | a | main.rs:371:13:371:13 | a |
-| main.rs:374:11:374:11 | a | main.rs:371:13:371:13 | a |
-| main.rs:375:15:375:15 | a | main.rs:371:13:371:13 | a |
-| main.rs:381:14:381:14 | i | main.rs:379:13:379:13 | i |
-| main.rs:382:6:382:10 | ref_i | main.rs:380:9:380:13 | ref_i |
-| main.rs:383:15:383:15 | i | main.rs:379:13:379:13 | i |
-| main.rs:387:6:387:6 | x | main.rs:386:17:386:17 | x |
-| main.rs:388:10:388:10 | x | main.rs:386:17:386:17 | x |
-| main.rs:389:10:389:10 | x | main.rs:386:17:386:17 | x |
-| main.rs:390:12:390:12 | x | main.rs:386:17:386:17 | x |
-| main.rs:394:6:394:6 | x | main.rs:393:22:393:22 | x |
-| main.rs:395:10:395:10 | x | main.rs:393:22:393:22 | x |
-| main.rs:396:10:396:10 | x | main.rs:393:22:393:22 | x |
-| main.rs:397:6:397:6 | y | main.rs:393:39:393:39 | y |
-| main.rs:398:9:398:9 | x | main.rs:393:22:393:22 | x |
-| main.rs:404:27:404:27 | x | main.rs:402:13:402:13 | x |
-| main.rs:405:6:405:6 | y | main.rs:403:9:403:9 | y |
-| main.rs:407:15:407:15 | x | main.rs:402:13:402:13 | x |
-| main.rs:411:19:411:19 | x | main.rs:402:13:402:13 | x |
-| main.rs:413:14:413:14 | z | main.rs:409:13:409:13 | z |
-| main.rs:414:9:414:9 | w | main.rs:410:9:410:9 | w |
-| main.rs:416:7:416:7 | w | main.rs:410:9:410:9 | w |
-| main.rs:418:15:418:15 | z | main.rs:409:13:409:13 | z |
-| main.rs:424:14:424:14 | x | main.rs:422:13:422:13 | x |
-| main.rs:425:6:425:6 | y | main.rs:423:9:423:9 | y |
-| main.rs:426:15:426:15 | x | main.rs:422:13:422:13 | x |
-| main.rs:433:19:433:19 | x | main.rs:430:9:430:9 | x |
-| main.rs:435:5:435:7 | cap | main.rs:432:9:432:11 | cap |
-| main.rs:436:15:436:15 | x | main.rs:430:9:430:9 | x |
-| main.rs:443:19:443:19 | x | main.rs:440:13:440:13 | x |
-| main.rs:445:5:445:12 | closure1 | main.rs:442:9:442:16 | closure1 |
-| main.rs:446:15:446:15 | x | main.rs:440:13:440:13 | x |
-| main.rs:451:9:451:9 | y | main.rs:448:13:448:13 | y |
-| main.rs:453:5:453:12 | closure2 | main.rs:450:13:450:20 | closure2 |
-| main.rs:454:15:454:15 | y | main.rs:448:13:448:13 | y |
-| main.rs:459:9:459:9 | z | main.rs:456:13:456:13 | z |
-| main.rs:461:5:461:12 | closure3 | main.rs:458:13:458:20 | closure3 |
-| main.rs:462:15:462:15 | z | main.rs:456:13:456:13 | z |
-| main.rs:468:9:468:9 | i | main.rs:466:13:466:13 | i |
-| main.rs:471:5:471:9 | block | main.rs:467:9:467:13 | block |
-| main.rs:472:15:472:15 | i | main.rs:466:13:466:13 | i |
-| main.rs:477:15:477:15 | x | main.rs:476:13:476:13 | x |
-| main.rs:478:15:478:15 | x | main.rs:476:13:476:13 | x |
-| main.rs:479:8:479:8 | b | main.rs:475:8:475:8 | b |
-| main.rs:480:9:480:9 | x | main.rs:476:13:476:13 | x |
-| main.rs:481:19:481:19 | x | main.rs:476:13:476:13 | x |
-| main.rs:482:19:482:19 | x | main.rs:476:13:476:13 | x |
-| main.rs:484:9:484:9 | x | main.rs:476:13:476:13 | x |
-| main.rs:485:19:485:19 | x | main.rs:476:13:476:13 | x |
-| main.rs:486:19:486:19 | x | main.rs:476:13:476:13 | x |
-| main.rs:488:15:488:15 | x | main.rs:476:13:476:13 | x |
-| main.rs:493:8:493:9 | b1 | main.rs:491:13:491:14 | b1 |
-| main.rs:494:19:494:19 | x | main.rs:492:9:492:9 | x |
-| main.rs:496:19:496:19 | x | main.rs:492:9:492:9 | x |
-| main.rs:499:8:499:9 | b2 | main.rs:491:24:491:25 | b2 |
-| main.rs:500:19:500:19 | x | main.rs:492:9:492:9 | x |
-| main.rs:502:19:502:19 | x | main.rs:492:9:492:9 | x |
-| main.rs:513:16:513:19 | self | main.rs:512:20:512:23 | self |
-| main.rs:517:9:517:12 | self | main.rs:516:11:516:14 | self |
-| main.rs:523:13:523:16 | self | main.rs:520:23:520:26 | self |
-| main.rs:523:25:523:25 | n | main.rs:521:22:521:22 | n |
-| main.rs:525:9:525:9 | f | main.rs:521:17:521:17 | f |
-| main.rs:526:9:526:9 | f | main.rs:521:17:521:17 | f |
-| main.rs:532:15:532:15 | a | main.rs:531:13:531:13 | a |
-| main.rs:533:5:533:5 | a | main.rs:531:13:531:13 | a |
-| main.rs:534:15:534:15 | a | main.rs:531:13:531:13 | a |
-| main.rs:535:5:535:5 | a | main.rs:531:13:531:13 | a |
-| main.rs:536:15:536:15 | a | main.rs:531:13:531:13 | a |
-| main.rs:541:15:541:15 | a | main.rs:540:13:540:13 | a |
-| main.rs:542:5:542:5 | a | main.rs:540:13:540:13 | a |
-| main.rs:543:15:543:15 | a | main.rs:540:13:540:13 | a |
-| main.rs:544:5:544:5 | a | main.rs:540:13:540:13 | a |
-| main.rs:545:15:545:15 | a | main.rs:540:13:540:13 | a |
-| main.rs:550:20:550:20 | x | main.rs:549:9:549:9 | x |
-| main.rs:551:15:551:15 | x | main.rs:549:9:549:9 | x |
-| main.rs:554:20:554:20 | z | main.rs:553:9:553:9 | z |
-| main.rs:563:6:563:9 | self | main.rs:562:15:562:18 | self |
-| main.rs:569:3:569:3 | a | main.rs:568:11:568:11 | a |
-| main.rs:571:13:571:13 | a | main.rs:568:11:568:11 | a |
-| main.rs:594:9:594:25 | var_in_macro | main.rs:594:9:594:25 | var_in_macro |
-| main.rs:595:15:595:28 | var_from_macro | main.rs:593:9:593:22 | var_from_macro |
-| main.rs:600:30:600:41 | var_in_macro | main.rs:600:15:600:42 | var_in_macro |
-| main.rs:601:15:601:26 | var_in_macro | main.rs:596:9:596:20 | var_in_macro |
+| main.rs:5:20:5:20 | s | main.rs:3:14:3:14 | s |
+| main.rs:10:20:10:20 | i | main.rs:8:14:8:14 | i |
+| main.rs:14:16:14:16 | i | main.rs:13:18:13:18 | i |
+| main.rs:19:15:19:16 | x1 | main.rs:18:9:18:10 | x1 |
+| main.rs:24:15:24:16 | x2 | main.rs:23:13:23:14 | x2 |
+| main.rs:25:5:25:6 | x2 | main.rs:23:13:23:14 | x2 |
+| main.rs:26:15:26:16 | x2 | main.rs:23:13:23:14 | x2 |
+| main.rs:31:20:31:20 | x | main.rs:30:13:30:13 | x |
+| main.rs:32:5:32:5 | x | main.rs:30:13:30:13 | x |
+| main.rs:33:20:33:20 | x | main.rs:30:13:30:13 | x |
+| main.rs:38:15:38:16 | x3 | main.rs:37:9:37:10 | x3 |
+| main.rs:40:9:40:10 | x3 | main.rs:37:9:37:10 | x3 |
+| main.rs:41:15:41:16 | x3 | main.rs:39:9:39:10 | x3 |
+| main.rs:46:15:46:16 | x4 | main.rs:45:9:45:10 | x4 |
+| main.rs:49:19:49:20 | x4 | main.rs:48:13:48:14 | x4 |
+| main.rs:51:15:51:16 | x4 | main.rs:45:9:45:10 | x4 |
+| main.rs:70:15:70:16 | a1 | main.rs:62:13:62:14 | a1 |
+| main.rs:71:15:71:16 | b1 | main.rs:63:13:63:14 | b1 |
+| main.rs:72:15:72:15 | x | main.rs:66:13:66:13 | x |
+| main.rs:73:15:73:15 | y | main.rs:67:13:67:13 | y |
+| main.rs:81:9:81:10 | p1 | main.rs:77:9:77:10 | p1 |
+| main.rs:82:15:82:16 | a2 | main.rs:79:12:79:13 | a2 |
+| main.rs:83:15:83:16 | b2 | main.rs:80:12:80:13 | b2 |
+| main.rs:90:11:90:12 | s1 | main.rs:87:9:87:10 | s1 |
+| main.rs:91:19:91:20 | s2 | main.rs:89:21:89:22 | s2 |
+| main.rs:102:15:102:16 | x5 | main.rs:96:14:96:15 | x5 |
+| main.rs:109:11:109:12 | s1 | main.rs:106:9:106:10 | s1 |
+| main.rs:110:19:110:20 | s2 | main.rs:108:24:108:25 | s2 |
+| main.rs:118:11:118:12 | x6 | main.rs:115:9:115:10 | x6 |
+| main.rs:123:23:123:24 | y1 | main.rs:120:14:120:15 | y1 |
+| main.rs:128:15:128:16 | y1 | main.rs:116:9:116:10 | y1 |
+| main.rs:134:11:134:17 | numbers | main.rs:132:9:132:15 | numbers |
+| main.rs:143:23:143:27 | first | main.rs:137:13:137:17 | first |
+| main.rs:144:23:144:27 | third | main.rs:139:13:139:17 | third |
+| main.rs:145:23:145:27 | fifth | main.rs:141:13:141:17 | fifth |
+| main.rs:149:11:149:17 | numbers | main.rs:132:9:132:15 | numbers |
+| main.rs:156:23:156:27 | first | main.rs:152:13:152:17 | first |
+| main.rs:157:23:157:26 | last | main.rs:154:13:154:16 | last |
+| main.rs:165:11:165:12 | p2 | main.rs:163:9:163:10 | p2 |
+| main.rs:168:24:168:25 | x7 | main.rs:167:16:167:17 | x7 |
+| main.rs:179:11:179:13 | msg | main.rs:177:9:177:11 | msg |
+| main.rs:183:24:183:34 | id_variable | main.rs:182:17:182:27 | id_variable |
+| main.rs:190:23:190:24 | id | main.rs:187:26:187:27 | id |
+| main.rs:202:11:202:16 | either | main.rs:201:9:201:14 | either |
+| main.rs:204:26:204:27 | a3 | main.rs:203:9:203:44 | a3 |
+| main.rs:216:11:216:12 | tv | main.rs:215:9:215:10 | tv |
+| main.rs:218:26:218:27 | a4 | main.rs:217:9:217:81 | a4 |
+| main.rs:220:11:220:12 | tv | main.rs:215:9:215:10 | tv |
+| main.rs:222:26:222:27 | a5 | main.rs:221:9:221:83 | a5 |
+| main.rs:224:11:224:12 | tv | main.rs:215:9:215:10 | tv |
+| main.rs:226:26:226:27 | a6 | main.rs:225:9:225:83 | a6 |
+| main.rs:232:11:232:16 | either | main.rs:231:9:231:14 | either |
+| main.rs:234:16:234:17 | a7 | main.rs:233:9:233:44 | a7 |
+| main.rs:235:26:235:27 | a7 | main.rs:233:9:233:44 | a7 |
+| main.rs:243:11:243:16 | either | main.rs:241:9:241:14 | either |
+| main.rs:247:23:247:25 | a11 | main.rs:245:14:245:51 | a11 |
+| main.rs:249:15:249:15 | e | main.rs:244:13:244:13 | e |
+| main.rs:250:28:250:30 | a12 | main.rs:248:33:248:35 | a12 |
+| main.rs:266:11:266:12 | fv | main.rs:265:9:265:10 | fv |
+| main.rs:268:26:268:28 | a13 | main.rs:267:9:267:109 | a13 |
+| main.rs:279:15:279:16 | a8 | main.rs:273:5:273:6 | a8 |
+| main.rs:280:15:280:16 | b3 | main.rs:275:9:275:10 | b3 |
+| main.rs:281:15:281:16 | c1 | main.rs:276:9:276:10 | c1 |
+| main.rs:286:15:286:16 | a9 | main.rs:284:20:284:55 | a9 |
+| main.rs:295:15:295:17 | a10 | main.rs:291:13:291:15 | a10 |
+| main.rs:296:15:296:16 | b4 | main.rs:292:13:292:14 | b4 |
+| main.rs:297:15:297:16 | c2 | main.rs:293:13:293:14 | c2 |
+| main.rs:300:9:300:10 | c2 | main.rs:293:13:293:14 | c2 |
+| main.rs:301:9:301:10 | b4 | main.rs:292:13:292:14 | b4 |
+| main.rs:302:9:302:11 | a10 | main.rs:291:13:291:15 | a10 |
+| main.rs:304:9:304:11 | a10 | main.rs:291:13:291:15 | a10 |
+| main.rs:305:9:305:10 | b4 | main.rs:292:13:292:14 | b4 |
+| main.rs:306:9:306:10 | c2 | main.rs:293:13:293:14 | c2 |
+| main.rs:308:15:308:17 | a10 | main.rs:291:13:291:15 | a10 |
+| main.rs:309:15:309:16 | b4 | main.rs:292:13:292:14 | b4 |
+| main.rs:310:15:310:16 | c2 | main.rs:293:13:293:14 | c2 |
+| main.rs:317:23:317:25 | a10 | main.rs:314:13:314:15 | a10 |
+| main.rs:318:23:318:24 | b4 | main.rs:315:13:315:14 | b4 |
+| main.rs:322:15:322:17 | a10 | main.rs:291:13:291:15 | a10 |
+| main.rs:323:15:323:16 | b4 | main.rs:292:13:292:14 | b4 |
+| main.rs:329:9:329:9 | x | main.rs:328:10:328:10 | x |
+| main.rs:331:9:331:23 | example_closure | main.rs:327:9:327:23 | example_closure |
+| main.rs:332:15:332:16 | n1 | main.rs:330:9:330:10 | n1 |
+| main.rs:337:9:337:9 | x | main.rs:336:6:336:6 | x |
+| main.rs:339:9:339:26 | immutable_variable | main.rs:335:9:335:26 | immutable_variable |
+| main.rs:340:15:340:16 | n2 | main.rs:338:9:338:10 | n2 |
+| main.rs:347:9:347:9 | x | main.rs:346:10:346:10 | x |
+| main.rs:348:15:348:15 | f | main.rs:345:9:345:9 | f |
+| main.rs:352:9:352:9 | x | main.rs:350:10:350:10 | x |
+| main.rs:355:15:355:15 | f | main.rs:345:9:345:9 | f |
+| main.rs:361:17:361:17 | x | main.rs:359:14:359:14 | x |
+| main.rs:370:13:370:13 | x | main.rs:369:14:369:14 | x |
+| main.rs:371:19:371:19 | f | main.rs:368:13:368:13 | f |
+| main.rs:379:12:379:12 | v | main.rs:376:9:376:9 | v |
+| main.rs:380:19:380:22 | text | main.rs:378:9:378:12 | text |
+| main.rs:386:5:386:5 | a | main.rs:385:13:385:13 | a |
+| main.rs:387:15:387:15 | a | main.rs:385:13:385:13 | a |
+| main.rs:388:11:388:11 | a | main.rs:385:13:385:13 | a |
+| main.rs:389:15:389:15 | a | main.rs:385:13:385:13 | a |
+| main.rs:395:14:395:14 | i | main.rs:393:13:393:13 | i |
+| main.rs:396:6:396:10 | ref_i | main.rs:394:9:394:13 | ref_i |
+| main.rs:397:15:397:15 | i | main.rs:393:13:393:13 | i |
+| main.rs:401:6:401:6 | x | main.rs:400:17:400:17 | x |
+| main.rs:402:10:402:10 | x | main.rs:400:17:400:17 | x |
+| main.rs:403:10:403:10 | x | main.rs:400:17:400:17 | x |
+| main.rs:404:12:404:12 | x | main.rs:400:17:400:17 | x |
+| main.rs:408:6:408:6 | x | main.rs:407:22:407:22 | x |
+| main.rs:409:10:409:10 | x | main.rs:407:22:407:22 | x |
+| main.rs:410:10:410:10 | x | main.rs:407:22:407:22 | x |
+| main.rs:411:6:411:6 | y | main.rs:407:38:407:38 | y |
+| main.rs:412:9:412:9 | x | main.rs:407:22:407:22 | x |
+| main.rs:418:27:418:27 | x | main.rs:416:13:416:13 | x |
+| main.rs:419:6:419:6 | y | main.rs:417:9:417:9 | y |
+| main.rs:421:15:421:15 | x | main.rs:416:13:416:13 | x |
+| main.rs:425:19:425:19 | x | main.rs:416:13:416:13 | x |
+| main.rs:427:14:427:14 | z | main.rs:423:13:423:13 | z |
+| main.rs:428:9:428:9 | w | main.rs:424:9:424:9 | w |
+| main.rs:430:7:430:7 | w | main.rs:424:9:424:9 | w |
+| main.rs:432:15:432:15 | z | main.rs:423:13:423:13 | z |
+| main.rs:438:14:438:14 | x | main.rs:436:13:436:13 | x |
+| main.rs:439:6:439:6 | y | main.rs:437:9:437:9 | y |
+| main.rs:440:15:440:15 | x | main.rs:436:13:436:13 | x |
+| main.rs:447:19:447:19 | x | main.rs:444:9:444:9 | x |
+| main.rs:449:5:449:7 | cap | main.rs:446:9:446:11 | cap |
+| main.rs:450:15:450:15 | x | main.rs:444:9:444:9 | x |
+| main.rs:457:19:457:19 | x | main.rs:454:13:454:13 | x |
+| main.rs:459:5:459:12 | closure1 | main.rs:456:9:456:16 | closure1 |
+| main.rs:460:15:460:15 | x | main.rs:454:13:454:13 | x |
+| main.rs:465:9:465:9 | y | main.rs:462:13:462:13 | y |
+| main.rs:467:5:467:12 | closure2 | main.rs:464:13:464:20 | closure2 |
+| main.rs:468:15:468:15 | y | main.rs:462:13:462:13 | y |
+| main.rs:473:9:473:9 | z | main.rs:470:13:470:13 | z |
+| main.rs:475:5:475:12 | closure3 | main.rs:472:13:472:20 | closure3 |
+| main.rs:476:15:476:15 | z | main.rs:470:13:470:13 | z |
+| main.rs:482:9:482:9 | i | main.rs:480:13:480:13 | i |
+| main.rs:485:5:485:9 | block | main.rs:481:9:481:13 | block |
+| main.rs:486:15:486:15 | i | main.rs:480:13:480:13 | i |
+| main.rs:491:15:491:15 | x | main.rs:490:13:490:13 | x |
+| main.rs:492:15:492:15 | x | main.rs:490:13:490:13 | x |
+| main.rs:494:16:494:16 | b | main.rs:489:8:489:8 | b |
+| main.rs:496:9:496:9 | x | main.rs:490:13:490:13 | x |
+| main.rs:497:19:497:19 | x | main.rs:490:13:490:13 | x |
+| main.rs:498:19:498:19 | x | main.rs:490:13:490:13 | x |
+| main.rs:500:9:500:9 | x | main.rs:490:13:490:13 | x |
+| main.rs:501:19:501:19 | x | main.rs:490:13:490:13 | x |
+| main.rs:502:19:502:19 | x | main.rs:490:13:490:13 | x |
+| main.rs:504:15:504:15 | x | main.rs:490:13:490:13 | x |
+| main.rs:510:16:510:17 | b1 | main.rs:507:13:507:14 | b1 |
+| main.rs:512:19:512:19 | x | main.rs:508:9:508:9 | x |
+| main.rs:514:19:514:19 | x | main.rs:508:9:508:9 | x |
+| main.rs:518:16:518:17 | b2 | main.rs:507:23:507:24 | b2 |
+| main.rs:520:19:520:19 | x | main.rs:508:9:508:9 | x |
+| main.rs:522:19:522:19 | x | main.rs:508:9:508:9 | x |
+| main.rs:532:16:532:19 | self | main.rs:531:20:531:23 | self |
+| main.rs:536:9:536:12 | self | main.rs:535:11:535:14 | self |
+| main.rs:542:13:542:16 | self | main.rs:539:23:539:26 | self |
+| main.rs:542:25:542:25 | n | main.rs:540:22:540:22 | n |
+| main.rs:544:9:544:9 | f | main.rs:540:17:540:17 | f |
+| main.rs:545:9:545:9 | f | main.rs:540:17:540:17 | f |
+| main.rs:551:15:551:15 | a | main.rs:550:13:550:13 | a |
+| main.rs:552:5:552:5 | a | main.rs:550:13:550:13 | a |
+| main.rs:553:15:553:15 | a | main.rs:550:13:550:13 | a |
+| main.rs:554:5:554:5 | a | main.rs:550:13:550:13 | a |
+| main.rs:555:15:555:15 | a | main.rs:550:13:550:13 | a |
+| main.rs:560:15:560:15 | a | main.rs:559:13:559:13 | a |
+| main.rs:561:5:561:5 | a | main.rs:559:13:559:13 | a |
+| main.rs:562:15:562:15 | a | main.rs:559:13:559:13 | a |
+| main.rs:563:5:563:5 | a | main.rs:559:13:559:13 | a |
+| main.rs:564:15:564:15 | a | main.rs:559:13:559:13 | a |
+| main.rs:569:20:569:20 | x | main.rs:568:9:568:9 | x |
+| main.rs:570:15:570:15 | x | main.rs:568:9:568:9 | x |
+| main.rs:573:20:573:20 | z | main.rs:572:9:572:9 | z |
+| main.rs:582:10:582:13 | self | main.rs:581:17:581:20 | self |
+| main.rs:588:5:588:5 | a | main.rs:587:13:587:13 | a |
+| main.rs:590:15:590:15 | a | main.rs:587:13:587:13 | a |
+| main.rs:609:9:609:25 | var_in_macro | main.rs:609:9:609:25 | var_in_macro |
+| main.rs:610:15:610:28 | var_from_macro | main.rs:608:9:608:22 | var_from_macro |
+| main.rs:615:30:615:41 | var_in_macro | main.rs:615:15:615:42 | var_in_macro |
+| main.rs:616:15:616:26 | var_in_macro | main.rs:611:9:611:20 | var_in_macro |
+| main.rs:621:5:621:5 | x | main.rs:620:9:620:9 | x |
+| main.rs:622:15:622:15 | x | main.rs:620:9:620:9 | x |
+| main.rs:629:20:629:20 | b | main.rs:627:20:627:20 | b |
+| main.rs:630:13:630:13 | x | main.rs:626:13:626:13 | x |
+| main.rs:633:5:633:7 | cap | main.rs:627:13:627:15 | cap |
+| main.rs:634:15:634:15 | x | main.rs:626:13:626:13 | x |
 variableWriteAccess
-| main.rs:23:5:23:6 | x2 | main.rs:21:13:21:14 | x2 |
-| main.rs:30:5:30:5 | x | main.rs:28:13:28:13 | x |
-| main.rs:288:9:288:10 | c2 | main.rs:281:13:281:14 | c2 |
-| main.rs:289:9:289:10 | b4 | main.rs:280:13:280:14 | b4 |
-| main.rs:290:9:290:11 | a10 | main.rs:279:13:279:15 | a10 |
-| main.rs:451:9:451:9 | y | main.rs:448:13:448:13 | y |
-| main.rs:468:9:468:9 | i | main.rs:466:13:466:13 | i |
-| main.rs:480:9:480:9 | x | main.rs:476:13:476:13 | x |
-| main.rs:484:9:484:9 | x | main.rs:476:13:476:13 | x |
-| main.rs:535:5:535:5 | a | main.rs:531:13:531:13 | a |
-| main.rs:544:5:544:5 | a | main.rs:540:13:540:13 | a |
+| main.rs:25:5:25:6 | x2 | main.rs:23:13:23:14 | x2 |
+| main.rs:32:5:32:5 | x | main.rs:30:13:30:13 | x |
+| main.rs:300:9:300:10 | c2 | main.rs:293:13:293:14 | c2 |
+| main.rs:301:9:301:10 | b4 | main.rs:292:13:292:14 | b4 |
+| main.rs:302:9:302:11 | a10 | main.rs:291:13:291:15 | a10 |
+| main.rs:465:9:465:9 | y | main.rs:462:13:462:13 | y |
+| main.rs:482:9:482:9 | i | main.rs:480:13:480:13 | i |
+| main.rs:496:9:496:9 | x | main.rs:490:13:490:13 | x |
+| main.rs:500:9:500:9 | x | main.rs:490:13:490:13 | x |
+| main.rs:554:5:554:5 | a | main.rs:550:13:550:13 | a |
+| main.rs:563:5:563:5 | a | main.rs:559:13:559:13 | a |
+| main.rs:621:5:621:5 | x | main.rs:620:9:620:9 | x |
+| main.rs:630:13:630:13 | x | main.rs:626:13:626:13 | x |
 variableReadAccess
-| main.rs:4:20:4:20 | s | main.rs:3:14:3:14 | s |
-| main.rs:8:20:8:20 | i | main.rs:7:14:7:14 | i |
-| main.rs:12:16:12:16 | i | main.rs:11:18:11:18 | i |
-| main.rs:17:15:17:16 | x1 | main.rs:16:9:16:10 | x1 |
-| main.rs:22:15:22:16 | x2 | main.rs:21:13:21:14 | x2 |
-| main.rs:24:15:24:16 | x2 | main.rs:21:13:21:14 | x2 |
-| main.rs:36:15:36:16 | x3 | main.rs:35:9:35:10 | x3 |
-| main.rs:38:9:38:10 | x3 | main.rs:35:9:35:10 | x3 |
-| main.rs:39:15:39:16 | x3 | main.rs:37:9:37:10 | x3 |
-| main.rs:44:15:44:16 | x4 | main.rs:43:9:43:10 | x4 |
-| main.rs:47:19:47:20 | x4 | main.rs:46:13:46:14 | x4 |
-| main.rs:49:15:49:16 | x4 | main.rs:43:9:43:10 | x4 |
-| main.rs:68:15:68:16 | a1 | main.rs:60:13:60:14 | a1 |
-| main.rs:69:15:69:16 | b1 | main.rs:61:13:61:14 | b1 |
-| main.rs:70:15:70:15 | x | main.rs:64:13:64:13 | x |
-| main.rs:71:15:71:15 | y | main.rs:65:13:65:13 | y |
-| main.rs:79:9:79:10 | p1 | main.rs:75:9:75:10 | p1 |
-| main.rs:80:15:80:16 | a2 | main.rs:77:12:77:13 | a2 |
-| main.rs:81:15:81:16 | b2 | main.rs:78:12:78:13 | b2 |
-| main.rs:88:11:88:12 | s1 | main.rs:85:9:85:10 | s1 |
-| main.rs:89:19:89:20 | s2 | main.rs:87:21:87:22 | s2 |
-| main.rs:98:15:98:16 | x5 | main.rs:94:14:94:15 | x5 |
-| main.rs:105:11:105:12 | s1 | main.rs:102:9:102:10 | s1 |
-| main.rs:106:19:106:20 | s2 | main.rs:104:24:104:25 | s2 |
-| main.rs:114:11:114:12 | x6 | main.rs:111:9:111:10 | x6 |
-| main.rs:119:23:119:24 | y1 | main.rs:116:14:116:15 | y1 |
-| main.rs:124:15:124:16 | y1 | main.rs:112:9:112:10 | y1 |
-| main.rs:130:11:130:17 | numbers | main.rs:128:9:128:15 | numbers |
-| main.rs:136:23:136:27 | first | main.rs:132:13:132:17 | first |
-| main.rs:137:23:137:27 | third | main.rs:133:13:133:17 | third |
-| main.rs:138:23:138:27 | fifth | main.rs:134:13:134:17 | fifth |
-| main.rs:142:11:142:17 | numbers | main.rs:128:9:128:15 | numbers |
-| main.rs:148:23:148:27 | first | main.rs:144:13:144:17 | first |
-| main.rs:149:23:149:26 | last | main.rs:146:13:146:16 | last |
-| main.rs:157:11:157:12 | p2 | main.rs:155:9:155:10 | p2 |
-| main.rs:160:24:160:25 | x7 | main.rs:159:16:159:17 | x7 |
-| main.rs:171:11:171:13 | msg | main.rs:169:9:169:11 | msg |
-| main.rs:174:24:174:34 | id_variable | main.rs:173:17:173:27 | id_variable |
-| main.rs:179:23:179:24 | id | main.rs:178:26:178:27 | id |
-| main.rs:190:11:190:16 | either | main.rs:189:9:189:14 | either |
-| main.rs:192:26:192:27 | a3 | main.rs:191:9:191:44 | a3 |
-| main.rs:204:11:204:12 | tv | main.rs:203:9:203:10 | tv |
-| main.rs:206:26:206:27 | a4 | main.rs:205:9:205:81 | a4 |
-| main.rs:208:11:208:12 | tv | main.rs:203:9:203:10 | tv |
-| main.rs:210:26:210:27 | a5 | main.rs:209:9:209:83 | a5 |
-| main.rs:212:11:212:12 | tv | main.rs:203:9:203:10 | tv |
-| main.rs:214:26:214:27 | a6 | main.rs:213:9:213:83 | a6 |
-| main.rs:220:11:220:16 | either | main.rs:219:9:219:14 | either |
-| main.rs:222:16:222:17 | a7 | main.rs:221:9:221:44 | a7 |
-| main.rs:223:26:223:27 | a7 | main.rs:221:9:221:44 | a7 |
-| main.rs:231:11:231:16 | either | main.rs:229:9:229:14 | either |
-| main.rs:235:23:235:25 | a11 | main.rs:233:14:233:51 | a11 |
-| main.rs:237:15:237:15 | e | main.rs:232:13:232:13 | e |
-| main.rs:238:28:238:30 | a12 | main.rs:236:33:236:35 | a12 |
-| main.rs:254:11:254:12 | fv | main.rs:253:9:253:10 | fv |
-| main.rs:256:26:256:28 | a13 | main.rs:255:9:255:109 | a13 |
-| main.rs:266:15:266:16 | a8 | main.rs:261:5:261:6 | a8 |
-| main.rs:267:15:267:16 | b3 | main.rs:263:9:263:10 | b3 |
-| main.rs:268:15:268:16 | c1 | main.rs:264:9:264:10 | c1 |
-| main.rs:274:15:274:16 | a9 | main.rs:272:6:272:41 | a9 |
-| main.rs:283:15:283:17 | a10 | main.rs:279:13:279:15 | a10 |
-| main.rs:284:15:284:16 | b4 | main.rs:280:13:280:14 | b4 |
-| main.rs:285:15:285:16 | c2 | main.rs:281:13:281:14 | c2 |
-| main.rs:292:9:292:11 | a10 | main.rs:279:13:279:15 | a10 |
-| main.rs:293:9:293:10 | b4 | main.rs:280:13:280:14 | b4 |
-| main.rs:294:9:294:10 | c2 | main.rs:281:13:281:14 | c2 |
-| main.rs:296:15:296:17 | a10 | main.rs:279:13:279:15 | a10 |
-| main.rs:297:15:297:16 | b4 | main.rs:280:13:280:14 | b4 |
-| main.rs:298:15:298:16 | c2 | main.rs:281:13:281:14 | c2 |
-| main.rs:305:23:305:25 | a10 | main.rs:302:13:302:15 | a10 |
-| main.rs:306:23:306:24 | b4 | main.rs:303:13:303:14 | b4 |
-| main.rs:310:15:310:17 | a10 | main.rs:279:13:279:15 | a10 |
-| main.rs:311:15:311:16 | b4 | main.rs:280:13:280:14 | b4 |
-| main.rs:317:9:317:9 | x | main.rs:316:10:316:10 | x |
-| main.rs:319:9:319:23 | example_closure | main.rs:315:9:315:23 | example_closure |
-| main.rs:320:15:320:16 | n1 | main.rs:318:9:318:10 | n1 |
-| main.rs:325:9:325:9 | x | main.rs:324:10:324:10 | x |
-| main.rs:327:9:327:26 | immutable_variable | main.rs:323:9:323:26 | immutable_variable |
-| main.rs:328:15:328:16 | n2 | main.rs:326:9:326:10 | n2 |
-| main.rs:335:9:335:9 | x | main.rs:334:10:334:10 | x |
-| main.rs:336:15:336:15 | f | main.rs:333:9:333:9 | f |
-| main.rs:339:9:339:9 | x | main.rs:338:10:338:10 | x |
-| main.rs:342:15:342:15 | f | main.rs:333:9:333:9 | f |
-| main.rs:347:17:347:17 | x | main.rs:346:14:346:14 | x |
-| main.rs:356:13:356:13 | x | main.rs:355:14:355:14 | x |
-| main.rs:357:19:357:19 | f | main.rs:354:13:354:13 | f |
-| main.rs:365:12:365:12 | v | main.rs:362:9:362:9 | v |
-| main.rs:366:19:366:22 | text | main.rs:364:9:364:12 | text |
-| main.rs:373:15:373:15 | a | main.rs:371:13:371:13 | a |
-| main.rs:375:15:375:15 | a | main.rs:371:13:371:13 | a |
-| main.rs:382:6:382:10 | ref_i | main.rs:380:9:380:13 | ref_i |
-| main.rs:383:15:383:15 | i | main.rs:379:13:379:13 | i |
-| main.rs:387:6:387:6 | x | main.rs:386:17:386:17 | x |
-| main.rs:388:10:388:10 | x | main.rs:386:17:386:17 | x |
-| main.rs:389:10:389:10 | x | main.rs:386:17:386:17 | x |
-| main.rs:390:12:390:12 | x | main.rs:386:17:386:17 | x |
-| main.rs:394:6:394:6 | x | main.rs:393:22:393:22 | x |
-| main.rs:395:10:395:10 | x | main.rs:393:22:393:22 | x |
-| main.rs:396:10:396:10 | x | main.rs:393:22:393:22 | x |
-| main.rs:397:6:397:6 | y | main.rs:393:39:393:39 | y |
-| main.rs:398:9:398:9 | x | main.rs:393:22:393:22 | x |
-| main.rs:405:6:405:6 | y | main.rs:403:9:403:9 | y |
-| main.rs:407:15:407:15 | x | main.rs:402:13:402:13 | x |
-| main.rs:414:9:414:9 | w | main.rs:410:9:410:9 | w |
-| main.rs:416:7:416:7 | w | main.rs:410:9:410:9 | w |
-| main.rs:418:15:418:15 | z | main.rs:409:13:409:13 | z |
-| main.rs:425:6:425:6 | y | main.rs:423:9:423:9 | y |
-| main.rs:426:15:426:15 | x | main.rs:422:13:422:13 | x |
-| main.rs:433:19:433:19 | x | main.rs:430:9:430:9 | x |
-| main.rs:435:5:435:7 | cap | main.rs:432:9:432:11 | cap |
-| main.rs:436:15:436:15 | x | main.rs:430:9:430:9 | x |
-| main.rs:443:19:443:19 | x | main.rs:440:13:440:13 | x |
-| main.rs:445:5:445:12 | closure1 | main.rs:442:9:442:16 | closure1 |
-| main.rs:446:15:446:15 | x | main.rs:440:13:440:13 | x |
-| main.rs:453:5:453:12 | closure2 | main.rs:450:13:450:20 | closure2 |
-| main.rs:454:15:454:15 | y | main.rs:448:13:448:13 | y |
-| main.rs:459:9:459:9 | z | main.rs:456:13:456:13 | z |
-| main.rs:461:5:461:12 | closure3 | main.rs:458:13:458:20 | closure3 |
-| main.rs:462:15:462:15 | z | main.rs:456:13:456:13 | z |
-| main.rs:471:5:471:9 | block | main.rs:467:9:467:13 | block |
-| main.rs:472:15:472:15 | i | main.rs:466:13:466:13 | i |
-| main.rs:477:15:477:15 | x | main.rs:476:13:476:13 | x |
-| main.rs:478:15:478:15 | x | main.rs:476:13:476:13 | x |
-| main.rs:479:8:479:8 | b | main.rs:475:8:475:8 | b |
-| main.rs:481:19:481:19 | x | main.rs:476:13:476:13 | x |
-| main.rs:482:19:482:19 | x | main.rs:476:13:476:13 | x |
-| main.rs:485:19:485:19 | x | main.rs:476:13:476:13 | x |
-| main.rs:486:19:486:19 | x | main.rs:476:13:476:13 | x |
-| main.rs:488:15:488:15 | x | main.rs:476:13:476:13 | x |
-| main.rs:493:8:493:9 | b1 | main.rs:491:13:491:14 | b1 |
-| main.rs:494:19:494:19 | x | main.rs:492:9:492:9 | x |
-| main.rs:496:19:496:19 | x | main.rs:492:9:492:9 | x |
-| main.rs:499:8:499:9 | b2 | main.rs:491:24:491:25 | b2 |
-| main.rs:500:19:500:19 | x | main.rs:492:9:492:9 | x |
-| main.rs:502:19:502:19 | x | main.rs:492:9:492:9 | x |
-| main.rs:513:16:513:19 | self | main.rs:512:20:512:23 | self |
-| main.rs:517:9:517:12 | self | main.rs:516:11:516:14 | self |
-| main.rs:523:13:523:16 | self | main.rs:520:23:520:26 | self |
-| main.rs:523:25:523:25 | n | main.rs:521:22:521:22 | n |
-| main.rs:525:9:525:9 | f | main.rs:521:17:521:17 | f |
-| main.rs:526:9:526:9 | f | main.rs:521:17:521:17 | f |
-| main.rs:532:15:532:15 | a | main.rs:531:13:531:13 | a |
-| main.rs:533:5:533:5 | a | main.rs:531:13:531:13 | a |
-| main.rs:534:15:534:15 | a | main.rs:531:13:531:13 | a |
-| main.rs:536:15:536:15 | a | main.rs:531:13:531:13 | a |
-| main.rs:541:15:541:15 | a | main.rs:540:13:540:13 | a |
-| main.rs:542:5:542:5 | a | main.rs:540:13:540:13 | a |
-| main.rs:543:15:543:15 | a | main.rs:540:13:540:13 | a |
-| main.rs:545:15:545:15 | a | main.rs:540:13:540:13 | a |
-| main.rs:551:15:551:15 | x | main.rs:549:9:549:9 | x |
-| main.rs:563:6:563:9 | self | main.rs:562:15:562:18 | self |
-| main.rs:569:3:569:3 | a | main.rs:568:11:568:11 | a |
-| main.rs:571:13:571:13 | a | main.rs:568:11:568:11 | a |
-| main.rs:594:9:594:25 | var_in_macro | main.rs:594:9:594:25 | var_in_macro |
-| main.rs:595:15:595:28 | var_from_macro | main.rs:593:9:593:22 | var_from_macro |
-| main.rs:600:30:600:41 | var_in_macro | main.rs:600:15:600:42 | var_in_macro |
-| main.rs:601:15:601:26 | var_in_macro | main.rs:596:9:596:20 | var_in_macro |
+| main.rs:5:20:5:20 | s | main.rs:3:14:3:14 | s |
+| main.rs:10:20:10:20 | i | main.rs:8:14:8:14 | i |
+| main.rs:14:16:14:16 | i | main.rs:13:18:13:18 | i |
+| main.rs:19:15:19:16 | x1 | main.rs:18:9:18:10 | x1 |
+| main.rs:24:15:24:16 | x2 | main.rs:23:13:23:14 | x2 |
+| main.rs:26:15:26:16 | x2 | main.rs:23:13:23:14 | x2 |
+| main.rs:38:15:38:16 | x3 | main.rs:37:9:37:10 | x3 |
+| main.rs:40:9:40:10 | x3 | main.rs:37:9:37:10 | x3 |
+| main.rs:41:15:41:16 | x3 | main.rs:39:9:39:10 | x3 |
+| main.rs:46:15:46:16 | x4 | main.rs:45:9:45:10 | x4 |
+| main.rs:49:19:49:20 | x4 | main.rs:48:13:48:14 | x4 |
+| main.rs:51:15:51:16 | x4 | main.rs:45:9:45:10 | x4 |
+| main.rs:70:15:70:16 | a1 | main.rs:62:13:62:14 | a1 |
+| main.rs:71:15:71:16 | b1 | main.rs:63:13:63:14 | b1 |
+| main.rs:72:15:72:15 | x | main.rs:66:13:66:13 | x |
+| main.rs:73:15:73:15 | y | main.rs:67:13:67:13 | y |
+| main.rs:81:9:81:10 | p1 | main.rs:77:9:77:10 | p1 |
+| main.rs:82:15:82:16 | a2 | main.rs:79:12:79:13 | a2 |
+| main.rs:83:15:83:16 | b2 | main.rs:80:12:80:13 | b2 |
+| main.rs:90:11:90:12 | s1 | main.rs:87:9:87:10 | s1 |
+| main.rs:91:19:91:20 | s2 | main.rs:89:21:89:22 | s2 |
+| main.rs:102:15:102:16 | x5 | main.rs:96:14:96:15 | x5 |
+| main.rs:109:11:109:12 | s1 | main.rs:106:9:106:10 | s1 |
+| main.rs:110:19:110:20 | s2 | main.rs:108:24:108:25 | s2 |
+| main.rs:118:11:118:12 | x6 | main.rs:115:9:115:10 | x6 |
+| main.rs:123:23:123:24 | y1 | main.rs:120:14:120:15 | y1 |
+| main.rs:128:15:128:16 | y1 | main.rs:116:9:116:10 | y1 |
+| main.rs:134:11:134:17 | numbers | main.rs:132:9:132:15 | numbers |
+| main.rs:143:23:143:27 | first | main.rs:137:13:137:17 | first |
+| main.rs:144:23:144:27 | third | main.rs:139:13:139:17 | third |
+| main.rs:145:23:145:27 | fifth | main.rs:141:13:141:17 | fifth |
+| main.rs:149:11:149:17 | numbers | main.rs:132:9:132:15 | numbers |
+| main.rs:156:23:156:27 | first | main.rs:152:13:152:17 | first |
+| main.rs:157:23:157:26 | last | main.rs:154:13:154:16 | last |
+| main.rs:165:11:165:12 | p2 | main.rs:163:9:163:10 | p2 |
+| main.rs:168:24:168:25 | x7 | main.rs:167:16:167:17 | x7 |
+| main.rs:179:11:179:13 | msg | main.rs:177:9:177:11 | msg |
+| main.rs:183:24:183:34 | id_variable | main.rs:182:17:182:27 | id_variable |
+| main.rs:190:23:190:24 | id | main.rs:187:26:187:27 | id |
+| main.rs:202:11:202:16 | either | main.rs:201:9:201:14 | either |
+| main.rs:204:26:204:27 | a3 | main.rs:203:9:203:44 | a3 |
+| main.rs:216:11:216:12 | tv | main.rs:215:9:215:10 | tv |
+| main.rs:218:26:218:27 | a4 | main.rs:217:9:217:81 | a4 |
+| main.rs:220:11:220:12 | tv | main.rs:215:9:215:10 | tv |
+| main.rs:222:26:222:27 | a5 | main.rs:221:9:221:83 | a5 |
+| main.rs:224:11:224:12 | tv | main.rs:215:9:215:10 | tv |
+| main.rs:226:26:226:27 | a6 | main.rs:225:9:225:83 | a6 |
+| main.rs:232:11:232:16 | either | main.rs:231:9:231:14 | either |
+| main.rs:234:16:234:17 | a7 | main.rs:233:9:233:44 | a7 |
+| main.rs:235:26:235:27 | a7 | main.rs:233:9:233:44 | a7 |
+| main.rs:243:11:243:16 | either | main.rs:241:9:241:14 | either |
+| main.rs:247:23:247:25 | a11 | main.rs:245:14:245:51 | a11 |
+| main.rs:249:15:249:15 | e | main.rs:244:13:244:13 | e |
+| main.rs:250:28:250:30 | a12 | main.rs:248:33:248:35 | a12 |
+| main.rs:266:11:266:12 | fv | main.rs:265:9:265:10 | fv |
+| main.rs:268:26:268:28 | a13 | main.rs:267:9:267:109 | a13 |
+| main.rs:279:15:279:16 | a8 | main.rs:273:5:273:6 | a8 |
+| main.rs:280:15:280:16 | b3 | main.rs:275:9:275:10 | b3 |
+| main.rs:281:15:281:16 | c1 | main.rs:276:9:276:10 | c1 |
+| main.rs:286:15:286:16 | a9 | main.rs:284:20:284:55 | a9 |
+| main.rs:295:15:295:17 | a10 | main.rs:291:13:291:15 | a10 |
+| main.rs:296:15:296:16 | b4 | main.rs:292:13:292:14 | b4 |
+| main.rs:297:15:297:16 | c2 | main.rs:293:13:293:14 | c2 |
+| main.rs:304:9:304:11 | a10 | main.rs:291:13:291:15 | a10 |
+| main.rs:305:9:305:10 | b4 | main.rs:292:13:292:14 | b4 |
+| main.rs:306:9:306:10 | c2 | main.rs:293:13:293:14 | c2 |
+| main.rs:308:15:308:17 | a10 | main.rs:291:13:291:15 | a10 |
+| main.rs:309:15:309:16 | b4 | main.rs:292:13:292:14 | b4 |
+| main.rs:310:15:310:16 | c2 | main.rs:293:13:293:14 | c2 |
+| main.rs:317:23:317:25 | a10 | main.rs:314:13:314:15 | a10 |
+| main.rs:318:23:318:24 | b4 | main.rs:315:13:315:14 | b4 |
+| main.rs:322:15:322:17 | a10 | main.rs:291:13:291:15 | a10 |
+| main.rs:323:15:323:16 | b4 | main.rs:292:13:292:14 | b4 |
+| main.rs:329:9:329:9 | x | main.rs:328:10:328:10 | x |
+| main.rs:331:9:331:23 | example_closure | main.rs:327:9:327:23 | example_closure |
+| main.rs:332:15:332:16 | n1 | main.rs:330:9:330:10 | n1 |
+| main.rs:337:9:337:9 | x | main.rs:336:6:336:6 | x |
+| main.rs:339:9:339:26 | immutable_variable | main.rs:335:9:335:26 | immutable_variable |
+| main.rs:340:15:340:16 | n2 | main.rs:338:9:338:10 | n2 |
+| main.rs:347:9:347:9 | x | main.rs:346:10:346:10 | x |
+| main.rs:348:15:348:15 | f | main.rs:345:9:345:9 | f |
+| main.rs:352:9:352:9 | x | main.rs:350:10:350:10 | x |
+| main.rs:355:15:355:15 | f | main.rs:345:9:345:9 | f |
+| main.rs:361:17:361:17 | x | main.rs:359:14:359:14 | x |
+| main.rs:370:13:370:13 | x | main.rs:369:14:369:14 | x |
+| main.rs:371:19:371:19 | f | main.rs:368:13:368:13 | f |
+| main.rs:379:12:379:12 | v | main.rs:376:9:376:9 | v |
+| main.rs:380:19:380:22 | text | main.rs:378:9:378:12 | text |
+| main.rs:387:15:387:15 | a | main.rs:385:13:385:13 | a |
+| main.rs:389:15:389:15 | a | main.rs:385:13:385:13 | a |
+| main.rs:396:6:396:10 | ref_i | main.rs:394:9:394:13 | ref_i |
+| main.rs:397:15:397:15 | i | main.rs:393:13:393:13 | i |
+| main.rs:401:6:401:6 | x | main.rs:400:17:400:17 | x |
+| main.rs:402:10:402:10 | x | main.rs:400:17:400:17 | x |
+| main.rs:403:10:403:10 | x | main.rs:400:17:400:17 | x |
+| main.rs:404:12:404:12 | x | main.rs:400:17:400:17 | x |
+| main.rs:408:6:408:6 | x | main.rs:407:22:407:22 | x |
+| main.rs:409:10:409:10 | x | main.rs:407:22:407:22 | x |
+| main.rs:410:10:410:10 | x | main.rs:407:22:407:22 | x |
+| main.rs:411:6:411:6 | y | main.rs:407:38:407:38 | y |
+| main.rs:412:9:412:9 | x | main.rs:407:22:407:22 | x |
+| main.rs:419:6:419:6 | y | main.rs:417:9:417:9 | y |
+| main.rs:421:15:421:15 | x | main.rs:416:13:416:13 | x |
+| main.rs:428:9:428:9 | w | main.rs:424:9:424:9 | w |
+| main.rs:430:7:430:7 | w | main.rs:424:9:424:9 | w |
+| main.rs:432:15:432:15 | z | main.rs:423:13:423:13 | z |
+| main.rs:439:6:439:6 | y | main.rs:437:9:437:9 | y |
+| main.rs:440:15:440:15 | x | main.rs:436:13:436:13 | x |
+| main.rs:447:19:447:19 | x | main.rs:444:9:444:9 | x |
+| main.rs:449:5:449:7 | cap | main.rs:446:9:446:11 | cap |
+| main.rs:450:15:450:15 | x | main.rs:444:9:444:9 | x |
+| main.rs:457:19:457:19 | x | main.rs:454:13:454:13 | x |
+| main.rs:459:5:459:12 | closure1 | main.rs:456:9:456:16 | closure1 |
+| main.rs:460:15:460:15 | x | main.rs:454:13:454:13 | x |
+| main.rs:467:5:467:12 | closure2 | main.rs:464:13:464:20 | closure2 |
+| main.rs:468:15:468:15 | y | main.rs:462:13:462:13 | y |
+| main.rs:473:9:473:9 | z | main.rs:470:13:470:13 | z |
+| main.rs:475:5:475:12 | closure3 | main.rs:472:13:472:20 | closure3 |
+| main.rs:476:15:476:15 | z | main.rs:470:13:470:13 | z |
+| main.rs:485:5:485:9 | block | main.rs:481:9:481:13 | block |
+| main.rs:486:15:486:15 | i | main.rs:480:13:480:13 | i |
+| main.rs:491:15:491:15 | x | main.rs:490:13:490:13 | x |
+| main.rs:492:15:492:15 | x | main.rs:490:13:490:13 | x |
+| main.rs:494:16:494:16 | b | main.rs:489:8:489:8 | b |
+| main.rs:497:19:497:19 | x | main.rs:490:13:490:13 | x |
+| main.rs:498:19:498:19 | x | main.rs:490:13:490:13 | x |
+| main.rs:501:19:501:19 | x | main.rs:490:13:490:13 | x |
+| main.rs:502:19:502:19 | x | main.rs:490:13:490:13 | x |
+| main.rs:504:15:504:15 | x | main.rs:490:13:490:13 | x |
+| main.rs:510:16:510:17 | b1 | main.rs:507:13:507:14 | b1 |
+| main.rs:512:19:512:19 | x | main.rs:508:9:508:9 | x |
+| main.rs:514:19:514:19 | x | main.rs:508:9:508:9 | x |
+| main.rs:518:16:518:17 | b2 | main.rs:507:23:507:24 | b2 |
+| main.rs:520:19:520:19 | x | main.rs:508:9:508:9 | x |
+| main.rs:522:19:522:19 | x | main.rs:508:9:508:9 | x |
+| main.rs:532:16:532:19 | self | main.rs:531:20:531:23 | self |
+| main.rs:536:9:536:12 | self | main.rs:535:11:535:14 | self |
+| main.rs:542:13:542:16 | self | main.rs:539:23:539:26 | self |
+| main.rs:542:25:542:25 | n | main.rs:540:22:540:22 | n |
+| main.rs:544:9:544:9 | f | main.rs:540:17:540:17 | f |
+| main.rs:545:9:545:9 | f | main.rs:540:17:540:17 | f |
+| main.rs:551:15:551:15 | a | main.rs:550:13:550:13 | a |
+| main.rs:552:5:552:5 | a | main.rs:550:13:550:13 | a |
+| main.rs:553:15:553:15 | a | main.rs:550:13:550:13 | a |
+| main.rs:555:15:555:15 | a | main.rs:550:13:550:13 | a |
+| main.rs:560:15:560:15 | a | main.rs:559:13:559:13 | a |
+| main.rs:561:5:561:5 | a | main.rs:559:13:559:13 | a |
+| main.rs:562:15:562:15 | a | main.rs:559:13:559:13 | a |
+| main.rs:564:15:564:15 | a | main.rs:559:13:559:13 | a |
+| main.rs:570:15:570:15 | x | main.rs:568:9:568:9 | x |
+| main.rs:582:10:582:13 | self | main.rs:581:17:581:20 | self |
+| main.rs:588:5:588:5 | a | main.rs:587:13:587:13 | a |
+| main.rs:590:15:590:15 | a | main.rs:587:13:587:13 | a |
+| main.rs:609:9:609:25 | var_in_macro | main.rs:609:9:609:25 | var_in_macro |
+| main.rs:610:15:610:28 | var_from_macro | main.rs:608:9:608:22 | var_from_macro |
+| main.rs:615:30:615:41 | var_in_macro | main.rs:615:15:615:42 | var_in_macro |
+| main.rs:616:15:616:26 | var_in_macro | main.rs:611:9:611:20 | var_in_macro |
+| main.rs:622:15:622:15 | x | main.rs:620:9:620:9 | x |
+| main.rs:629:20:629:20 | b | main.rs:627:20:627:20 | b |
+| main.rs:633:5:633:7 | cap | main.rs:627:13:627:15 | cap |
+| main.rs:634:15:634:15 | x | main.rs:626:13:626:13 | x |
 variableInitializer
-| main.rs:16:9:16:10 | x1 | main.rs:16:14:16:16 | "a" |
-| main.rs:21:13:21:14 | x2 | main.rs:21:18:21:18 | 4 |
-| main.rs:28:13:28:13 | x | main.rs:28:17:28:17 | 1 |
-| main.rs:35:9:35:10 | x3 | main.rs:35:14:35:14 | 1 |
-| main.rs:37:9:37:10 | x3 | main.rs:38:9:38:14 | ... + ... |
-| main.rs:43:9:43:10 | x4 | main.rs:43:14:43:16 | "a" |
-| main.rs:46:13:46:14 | x4 | main.rs:46:18:46:20 | "b" |
-| main.rs:75:9:75:10 | p1 | main.rs:75:14:75:37 | Point {...} |
-| main.rs:85:9:85:10 | s1 | main.rs:85:14:85:41 | Some(...) |
-| main.rs:102:9:102:10 | s1 | main.rs:102:14:102:41 | Some(...) |
-| main.rs:111:9:111:10 | x6 | main.rs:111:14:111:20 | Some(...) |
-| main.rs:112:9:112:10 | y1 | main.rs:112:14:112:15 | 10 |
-| main.rs:128:9:128:15 | numbers | main.rs:128:19:128:35 | TupleExpr |
-| main.rs:155:9:155:10 | p2 | main.rs:155:14:155:37 | Point {...} |
-| main.rs:169:9:169:11 | msg | main.rs:169:15:169:38 | ...::Hello {...} |
-| main.rs:189:9:189:14 | either | main.rs:189:18:189:33 | ...::Left(...) |
-| main.rs:203:9:203:10 | tv | main.rs:203:14:203:36 | ...::Second(...) |
-| main.rs:219:9:219:14 | either | main.rs:219:18:219:33 | ...::Left(...) |
-| main.rs:229:9:229:14 | either | main.rs:229:18:229:33 | ...::Left(...) |
-| main.rs:253:9:253:10 | fv | main.rs:253:14:253:35 | ...::Second(...) |
-| main.rs:315:9:315:23 | example_closure | main.rs:316:9:317:9 | \|...\| x |
-| main.rs:318:9:318:10 | n1 | main.rs:319:9:319:26 | example_closure(...) |
-| main.rs:323:9:323:26 | immutable_variable | main.rs:324:9:325:9 | \|...\| x |
-| main.rs:326:9:326:10 | n2 | main.rs:327:9:327:29 | immutable_variable(...) |
-| main.rs:333:9:333:9 | f | main.rs:334:9:335:9 | \|...\| x |
-| main.rs:354:13:354:13 | f | main.rs:355:13:356:13 | \|...\| x |
-| main.rs:362:9:362:9 | v | main.rs:362:13:362:41 | &... |
-| main.rs:371:13:371:13 | a | main.rs:371:17:371:17 | 0 |
-| main.rs:379:13:379:13 | i | main.rs:379:17:379:17 | 1 |
-| main.rs:380:9:380:13 | ref_i | main.rs:381:9:381:14 | &mut i |
-| main.rs:402:13:402:13 | x | main.rs:402:17:402:17 | 2 |
-| main.rs:403:9:403:9 | y | main.rs:404:9:404:28 | mutate_param(...) |
-| main.rs:409:13:409:13 | z | main.rs:409:17:409:17 | 4 |
-| main.rs:410:9:410:9 | w | main.rs:411:9:411:19 | &mut ... |
-| main.rs:422:13:422:13 | x | main.rs:422:17:422:17 | 1 |
-| main.rs:423:9:423:9 | y | main.rs:424:9:424:14 | &mut x |
-| main.rs:430:9:430:9 | x | main.rs:430:13:430:15 | 100 |
-| main.rs:432:9:432:11 | cap | main.rs:432:15:434:5 | \|...\| ... |
-| main.rs:440:13:440:13 | x | main.rs:440:17:440:17 | 1 |
-| main.rs:442:9:442:16 | closure1 | main.rs:442:20:444:5 | \|...\| ... |
-| main.rs:448:13:448:13 | y | main.rs:448:17:448:17 | 2 |
-| main.rs:450:13:450:20 | closure2 | main.rs:450:24:452:5 | \|...\| ... |
-| main.rs:456:13:456:13 | z | main.rs:456:17:456:17 | 2 |
-| main.rs:458:13:458:20 | closure3 | main.rs:458:24:460:5 | \|...\| ... |
-| main.rs:466:13:466:13 | i | main.rs:466:22:466:22 | 0 |
-| main.rs:467:9:467:13 | block | main.rs:467:17:469:5 | { ... } |
-| main.rs:476:13:476:13 | x | main.rs:476:17:476:17 | 1 |
-| main.rs:492:9:492:9 | x | main.rs:492:13:492:13 | 1 |
-| main.rs:521:17:521:17 | f | main.rs:521:21:524:9 | \|...\| ... |
-| main.rs:531:13:531:13 | a | main.rs:531:17:531:35 | MyStruct {...} |
-| main.rs:540:13:540:13 | a | main.rs:540:17:540:25 | [...] |
-| main.rs:549:9:549:9 | x | main.rs:549:13:549:14 | 16 |
-| main.rs:553:9:553:9 | z | main.rs:553:13:553:14 | 17 |
-| main.rs:568:11:568:11 | a | main.rs:568:15:568:33 | MyStruct {...} |
-| main.rs:593:9:593:22 | var_from_macro | main.rs:594:9:594:25 | MacroExpr |
-| main.rs:594:9:594:25 | var_in_macro | main.rs:594:23:594:24 | 37 |
-| main.rs:596:9:596:20 | var_in_macro | main.rs:596:24:596:25 | 33 |
-| main.rs:600:15:600:42 | var_in_macro | main.rs:600:15:600:42 | 0 |
+| main.rs:18:9:18:10 | x1 | main.rs:18:14:18:16 | "a" |
+| main.rs:23:13:23:14 | x2 | main.rs:23:18:23:18 | 4 |
+| main.rs:30:13:30:13 | x | main.rs:30:17:30:17 | 1 |
+| main.rs:37:9:37:10 | x3 | main.rs:37:14:37:14 | 1 |
+| main.rs:39:9:39:10 | x3 | main.rs:40:9:40:14 | ... + ... |
+| main.rs:45:9:45:10 | x4 | main.rs:45:14:45:16 | "a" |
+| main.rs:48:13:48:14 | x4 | main.rs:48:18:48:20 | "b" |
+| main.rs:77:9:77:10 | p1 | main.rs:77:14:77:37 | Point {...} |
+| main.rs:87:9:87:10 | s1 | main.rs:87:14:87:41 | Some(...) |
+| main.rs:106:9:106:10 | s1 | main.rs:106:14:106:41 | Some(...) |
+| main.rs:115:9:115:10 | x6 | main.rs:115:14:115:20 | Some(...) |
+| main.rs:116:9:116:10 | y1 | main.rs:116:14:116:15 | 10 |
+| main.rs:132:9:132:15 | numbers | main.rs:132:19:132:35 | TupleExpr |
+| main.rs:163:9:163:10 | p2 | main.rs:163:14:163:37 | Point {...} |
+| main.rs:177:9:177:11 | msg | main.rs:177:15:177:38 | ...::Hello {...} |
+| main.rs:201:9:201:14 | either | main.rs:201:18:201:33 | ...::Left(...) |
+| main.rs:215:9:215:10 | tv | main.rs:215:14:215:36 | ...::Second(...) |
+| main.rs:231:9:231:14 | either | main.rs:231:18:231:33 | ...::Left(...) |
+| main.rs:241:9:241:14 | either | main.rs:241:18:241:33 | ...::Left(...) |
+| main.rs:265:9:265:10 | fv | main.rs:265:14:265:35 | ...::Second(...) |
+| main.rs:327:9:327:23 | example_closure | main.rs:328:9:329:9 | \|...\| x |
+| main.rs:330:9:330:10 | n1 | main.rs:331:9:331:26 | example_closure(...) |
+| main.rs:335:9:335:26 | immutable_variable | main.rs:336:5:337:9 | \|...\| x |
+| main.rs:338:9:338:10 | n2 | main.rs:339:9:339:29 | immutable_variable(...) |
+| main.rs:345:9:345:9 | f | main.rs:346:9:347:9 | \|...\| x |
+| main.rs:368:13:368:13 | f | main.rs:369:13:370:13 | \|...\| x |
+| main.rs:376:9:376:9 | v | main.rs:376:13:376:41 | &... |
+| main.rs:385:13:385:13 | a | main.rs:385:17:385:17 | 0 |
+| main.rs:393:13:393:13 | i | main.rs:393:17:393:17 | 1 |
+| main.rs:394:9:394:13 | ref_i | main.rs:395:9:395:14 | &mut i |
+| main.rs:416:13:416:13 | x | main.rs:416:17:416:17 | 2 |
+| main.rs:417:9:417:9 | y | main.rs:418:9:418:28 | mutate_param(...) |
+| main.rs:423:13:423:13 | z | main.rs:423:17:423:17 | 4 |
+| main.rs:424:9:424:9 | w | main.rs:425:9:425:19 | &mut ... |
+| main.rs:436:13:436:13 | x | main.rs:436:17:436:17 | 1 |
+| main.rs:437:9:437:9 | y | main.rs:438:9:438:14 | &mut x |
+| main.rs:444:9:444:9 | x | main.rs:444:13:444:15 | 100 |
+| main.rs:446:9:446:11 | cap | main.rs:446:15:448:5 | \|...\| ... |
+| main.rs:454:13:454:13 | x | main.rs:454:17:454:17 | 1 |
+| main.rs:456:9:456:16 | closure1 | main.rs:456:20:458:5 | \|...\| ... |
+| main.rs:462:13:462:13 | y | main.rs:462:17:462:17 | 2 |
+| main.rs:464:13:464:20 | closure2 | main.rs:464:24:466:5 | \|...\| ... |
+| main.rs:470:13:470:13 | z | main.rs:470:17:470:17 | 2 |
+| main.rs:472:13:472:20 | closure3 | main.rs:472:24:474:5 | \|...\| ... |
+| main.rs:480:13:480:13 | i | main.rs:480:22:480:22 | 0 |
+| main.rs:481:9:481:13 | block | main.rs:481:17:483:5 | { ... } |
+| main.rs:490:13:490:13 | x | main.rs:490:17:490:17 | 1 |
+| main.rs:508:9:508:9 | x | main.rs:508:13:508:13 | 1 |
+| main.rs:540:17:540:17 | f | main.rs:540:21:543:9 | \|...\| ... |
+| main.rs:550:13:550:13 | a | main.rs:550:17:550:35 | MyStruct {...} |
+| main.rs:559:13:559:13 | a | main.rs:559:17:559:25 | [...] |
+| main.rs:568:9:568:9 | x | main.rs:568:13:568:14 | 16 |
+| main.rs:572:9:572:9 | z | main.rs:572:13:572:14 | 17 |
+| main.rs:587:13:587:13 | a | main.rs:587:17:587:35 | MyStruct {...} |
+| main.rs:608:9:608:22 | var_from_macro | main.rs:609:9:609:25 | MacroExpr |
+| main.rs:609:9:609:25 | var_in_macro | main.rs:609:23:609:24 | 37 |
+| main.rs:611:9:611:20 | var_in_macro | main.rs:611:24:611:25 | 33 |
+| main.rs:615:15:615:42 | var_in_macro | main.rs:615:15:615:42 | 0 |
+| main.rs:626:13:626:13 | x | main.rs:626:17:626:19 | 100 |
+| main.rs:627:13:627:15 | cap | main.rs:627:19:632:5 | \|...\| ... |
 capturedVariable
-| main.rs:430:9:430:9 | x |
-| main.rs:440:13:440:13 | x |
-| main.rs:448:13:448:13 | y |
-| main.rs:456:13:456:13 | z |
-| main.rs:466:13:466:13 | i |
-| main.rs:520:23:520:26 | self |
+| main.rs:444:9:444:9 | x |
+| main.rs:454:13:454:13 | x |
+| main.rs:462:13:462:13 | y |
+| main.rs:470:13:470:13 | z |
+| main.rs:480:13:480:13 | i |
+| main.rs:539:23:539:26 | self |
+| main.rs:626:13:626:13 | x |
 capturedAccess
-| main.rs:433:19:433:19 | x |
-| main.rs:443:19:443:19 | x |
-| main.rs:451:9:451:9 | y |
-| main.rs:459:9:459:9 | z |
-| main.rs:468:9:468:9 | i |
-| main.rs:523:13:523:16 | self |
+| main.rs:447:19:447:19 | x |
+| main.rs:457:19:457:19 | x |
+| main.rs:465:9:465:9 | y |
+| main.rs:473:9:473:9 | z |
+| main.rs:482:9:482:9 | i |
+| main.rs:542:13:542:16 | self |
+| main.rs:630:13:630:13 | x |
 nestedFunctionAccess
-| main.rs:345:19:345:19 | f | main.rs:346:9:348:9 | fn f |
-| main.rs:351:23:351:23 | f | main.rs:346:9:348:9 | fn f |
+| main.rs:358:19:358:19 | f | main.rs:359:9:362:9 | fn f |
+| main.rs:365:23:365:23 | f | main.rs:359:9:362:9 | fn f |


### PR DESCRIPTION
This PR inserts missing SSA definitions; [DCA](https://github.com/github/codeql-dca-main/issues/30034) confirms that ~ 2/3 of all SSA inconsistencies are fixed.