### PR TITLE
Rust: path resolution: handle items in `extern` blocks

### DIFF
--- a/rust/ql/lib/codeql/rust/internal/PathResolution.qll
+++ b/rust/ql/lib/codeql/rust/internal/PathResolution.qll
@@ -147,12 +147,6 @@ abstract class ItemNode extends Locatable {
       )
     )
     or
-    // items made available through macro calls are available to nodes that contain the macro call
-    exists(MacroCallItemNode call |
-      call = this.getASuccessorRec(_) and
-      result = call.(ItemNode).getASuccessorRec(name)
-    )
-    or
     // a trait has access to the associated items of its supertraits
     this =
       any(TraitItemNode trait |
@@ -680,32 +674,6 @@ private class ImplTraitTypeReprItemNode extends ItemNode instanceof ImplTraitTyp
   override string getCanonicalPath(Crate c) { none() }
 }
 
-private class MacroCallItemNode extends AssocItemNode instanceof MacroCall {
-  override string getName() { result = "(macro call)" }
-
-  override predicate hasImplementation() { none() }
-
-  override Namespace getNamespace() { none() }
-
-  override TypeParam getTypeParam(int i) { none() }
-
-  override Visibility getVisibility() { none() }
-
-  override predicate providesCanonicalPathPrefixFor(Crate c, ItemNode child) {
-    any(ItemNode parent).providesCanonicalPathPrefixFor(c, this) and
-    child.getImmediateParent() = this
-  }
-
-  override string getCanonicalPathPrefixFor(Crate c, ItemNode child) {
-    result = this.getCanonicalPathPrefix(c) and
-    this.providesCanonicalPathPrefixFor(c, child)
-  }
-
-  override predicate hasCanonicalPath(Crate c) { none() }
-
-  override string getCanonicalPath(Crate c) { none() }
-}
-
 private class ModuleItemNode extends ModuleLikeNode instanceof Module {
   override string getName() { result = Module.super.getName().getText() }
 
@@ -726,11 +694,6 @@ private class ModuleItemNode extends ModuleLikeNode instanceof Module {
       )
       or
       this = child.getImmediateParent()
-      or
-      exists(ItemNode mid |
-        this.providesCanonicalPathPrefixFor(c, mid) and
-        mid.(MacroCallItemNode) = child.getImmediateParent()
-      )
     )
   }
 
@@ -1185,11 +1148,6 @@ private predicate declares(ItemNode item, Namespace ns, string name) {
     or
     useTreeDeclares(child.(Use).getUseTree(), name) and
     exists(ns) // `use foo::bar` can refer to both a value and a type
-  )
-  or
-  exists(MacroCallItemNode call |
-    declares(call, ns, name) and
-    call.getImmediateParent() = item
   )
 }
 

--- a/rust/ql/lib/codeql/rust/internal/PathResolution.qll
+++ b/rust/ql/lib/codeql/rust/internal/PathResolution.qll
@@ -567,7 +567,7 @@ class ImplItemNode extends ImplOrTraitItemNode instanceof Impl {
 
   TraitItemNode resolveTraitTy() { result = resolvePath(this.getTraitPath()) }
 
-  override AssocItemNode getAnAssocItem() { result = super.getAssocItemList().getAnAssocItem() }
+  override AssocItemNode getAnAssocItem() { result = this.getADescendant() }
 
   override string getName() { result = "(impl)" }
 
@@ -760,7 +760,7 @@ class TraitItemNode extends ImplOrTraitItemNode, TypeItemNode instanceof Trait {
   pragma[nomagic]
   ItemNode resolveABound() { result = resolvePath(this.getABoundPath()) }
 
-  override AssocItemNode getAnAssocItem() { result = super.getAssocItemList().getAnAssocItem() }
+  override AssocItemNode getAnAssocItem() { result = this.getADescendant() }
 
   override string getName() { result = Trait.super.getName().getText() }
 
@@ -956,7 +956,7 @@ class TypeParamItemNode extends TypeItemNode instanceof TypeParam {
 
 /** Holds if `item` has the name `name` and is a top-level item inside `f`. */
 private predicate sourceFileEdge(SourceFile f, string name, ItemNode item) {
-  item = f.getAnItem() and
+  item = f.(ItemNode).getADescendant() and
   name = item.getName()
 }
 

--- a/rust/ql/test/extractor-tests/canonical_path/canonical_paths.expected
+++ b/rust/ql/test/extractor-tests/canonical_path/canonical_paths.expected
@@ -25,6 +25,7 @@ canonicalPath
 | regular.rs:40:1:46:1 | fn enum_qualified_usage | test::regular::enum_qualified_usage |
 | regular.rs:48:1:55:1 | fn enum_unqualified_usage | test::regular::enum_unqualified_usage |
 | regular.rs:57:1:63:1 | fn enum_match | test::regular::enum_match |
+| regular.rs:66:5:66:40 | fn is_alphanum | test::regular::is_alphanum |
 | regular.rs:69:1:71:1 | fn is_number_or_letter | test::regular::is_number_or_letter |
 canonicalPaths
 | anonymous.rs:1:1:1:26 | use ...::Trait | None | None |

--- a/rust/ql/test/extractor-tests/canonical_path/canonical_paths.expected
+++ b/rust/ql/test/extractor-tests/canonical_path/canonical_paths.expected
@@ -25,6 +25,7 @@ canonicalPath
 | regular.rs:40:1:46:1 | fn enum_qualified_usage | test::regular::enum_qualified_usage |
 | regular.rs:48:1:55:1 | fn enum_unqualified_usage | test::regular::enum_unqualified_usage |
 | regular.rs:57:1:63:1 | fn enum_match | test::regular::enum_match |
+| regular.rs:69:1:71:1 | fn is_number_or_letter | test::regular::is_number_or_letter |
 canonicalPaths
 | anonymous.rs:1:1:1:26 | use ...::Trait | None | None |
 | anonymous.rs:3:1:32:1 | fn canonicals | repo::test | crate::anonymous::canonicals |
@@ -65,6 +66,9 @@ canonicalPaths
 | regular.rs:48:1:55:1 | fn enum_unqualified_usage | repo::test | crate::regular::enum_unqualified_usage |
 | regular.rs:51:5:51:18 | use MyEnum::* | None | None |
 | regular.rs:57:1:63:1 | fn enum_match | repo::test | crate::regular::enum_match |
+| regular.rs:65:1:67:1 | ExternBlock | None | None |
+| regular.rs:66:5:66:40 | fn is_alphanum | repo::test | ::is_alphanum |
+| regular.rs:69:1:71:1 | fn is_number_or_letter | repo::test | crate::regular::is_number_or_letter |
 resolvedPaths
 | anonymous.rs:27:17:27:30 | OtherStruct {...} | None | None |
 | anonymous.rs:28:9:28:9 | s | None | None |
@@ -96,3 +100,5 @@ resolvedPaths
 | regular.rs:59:9:59:24 | ...::Variant1 | repo::test | crate::regular::MyEnum::Variant1 |
 | regular.rs:60:9:60:27 | ...::Variant2(...) | repo::test | crate::regular::MyEnum::Variant2 |
 | regular.rs:61:9:61:31 | ...::Variant3 {...} | repo::test | crate::regular::MyEnum::Variant3 |
+| regular.rs:70:14:70:24 | is_alphanum | repo::test | ::is_alphanum |
+| regular.rs:70:26:70:28 | chr | None | None |

--- a/rust/ql/test/extractor-tests/canonical_path/regular.rs
+++ b/rust/ql/test/extractor-tests/canonical_path/regular.rs
@@ -61,3 +61,11 @@ fn enum_match(e: MyEnum) {
         MyEnum::Variant3 { .. } => {}
     }
 }
+
+extern "C" {
+    pub fn is_alphanum(chr: u8) -> bool;
+}
+
+pub fn is_number_or_letter(chr: u8) -> bool {
+    unsafe { is_alphanum(chr) }
+}


### PR DESCRIPTION
This should cover cases where items are defined in `extern {}` blocks. 

* https://github.com/rust-lang/libc/blob/8e6f36c6ba5c91c150f2d79a06ffdc3d0b83a0f6/src/lib.rs#L75-L83
* https://github.com/rust-lang/libc/blob/8e6f36c6ba5c91c150f2d79a06ffdc3d0b83a0f6/src/unix/mod.rs#L583-L586