### PR TITLE
Rust: Add type inference test cases for tuples.

### DIFF
--- a/rust/ql/test/library-tests/type-inference/main.rs
+++ b/rust/ql/test/library-tests/type-inference/main.rs
@@ -2228,6 +2228,33 @@ mod explicit_type_args {
     }
 }
 
+mod tuples {
+    struct S1 {
+    }
+
+    impl S1 {
+        fn get_pair() -> (S1, S1) { (S1 {}, S1 {}) }
+        fn foo(self) { }
+    }
+
+    pub fn f() {
+        let a = S1::get_pair(); // $ method=get_pair MISSING: type=a:?
+        let mut b = S1::get_pair(); // $ method=get_pair MISSING: type=b:?
+        let (c, d) = S1::get_pair(); // $ method=get_pair MISSING: type=c:? type=d:?
+        let (mut e, f) = S1::get_pair(); // $ method=get_pair MISSING: type=e: type=f:
+        let (mut g, mut h) = S1::get_pair(); // $ method=get_pair MISSING: type=g:? type=h:?
+
+        a.0.foo(); // $ MISSING: method=foo
+        b.1.foo(); // $ MISSING: method=foo
+        c.foo(); // $ MISSING: method=foo
+        d.foo(); // $ MISSING: method=foo
+        e.foo(); // $ MISSING: method=foo
+        f.foo(); // $ MISSING: method=foo
+        g.foo(); // $ MISSING: method=foo
+        h.foo(); // $ MISSING: method=foo
+    }
+}
+
 fn main() {
     field_access::f(); // $ method=f
     method_impl::f(); // $ method=f
@@ -2251,7 +2278,9 @@ fn main() {
     impl_trait::f(); // $ method=f
     indexers::f(); // $ method=f
     loops::f(); // $ method=f
+    explicit_type_args::f(); // $ method=f
     macros::f(); // $ method=f
     method_determined_by_argument_type::f(); // $ method=f
+    tuples::f(); // $ method=f
     dereference::test(); // $ method=test
 }

--- a/rust/ql/test/library-tests/type-inference/type-inference.expected
+++ b/rust/ql/test/library-tests/type-inference/type-inference.expected
@@ -3636,9 +3636,12 @@ inferType
 | main.rs:2224:19:2227:9 | S5 {...} |  | main.rs:2204:5:2206:5 | S5 |
 | main.rs:2224:19:2227:9 | S5 {...} | T5 | main.rs:2183:5:2184:14 | S2 |
 | main.rs:2226:20:2226:32 | ...::default(...) |  | main.rs:2183:5:2184:14 | S2 |
-| main.rs:2233:5:2233:20 | ...::f(...) |  | main.rs:72:5:72:21 | Foo |
-| main.rs:2234:5:2234:60 | ...::g(...) |  | main.rs:72:5:72:21 | Foo |
-| main.rs:2234:20:2234:38 | ...::Foo {...} |  | main.rs:72:5:72:21 | Foo |
-| main.rs:2234:41:2234:59 | ...::Foo {...} |  | main.rs:72:5:72:21 | Foo |
-| main.rs:2250:5:2250:15 | ...::f(...) |  | {EXTERNAL LOCATION} | trait Future |
+| main.rs:2236:38:2236:42 | S1 {...} |  | main.rs:2232:5:2233:5 | S1 |
+| main.rs:2236:45:2236:49 | S1 {...} |  | main.rs:2232:5:2233:5 | S1 |
+| main.rs:2237:16:2237:19 | SelfParam |  | main.rs:2232:5:2233:5 | S1 |
+| main.rs:2260:5:2260:20 | ...::f(...) |  | main.rs:72:5:72:21 | Foo |
+| main.rs:2261:5:2261:60 | ...::g(...) |  | main.rs:72:5:72:21 | Foo |
+| main.rs:2261:20:2261:38 | ...::Foo {...} |  | main.rs:72:5:72:21 | Foo |
+| main.rs:2261:41:2261:59 | ...::Foo {...} |  | main.rs:72:5:72:21 | Foo |
+| main.rs:2277:5:2277:15 | ...::f(...) |  | {EXTERNAL LOCATION} | trait Future |
 testFailures


### PR DESCRIPTION
Add type inference test cases for tuples.  We worked around this in https://github.com/github/codeql/pull/19946/files#r2192987950 .  @hvitved FYI.