### PR TITLE
feat: add getASupertype() predicate in ValueOrRefType.

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/Type.qll
+++ b/csharp/ql/lib/semmle/code/csharp/Type.qll
@@ -138,6 +138,9 @@ class ValueOrRefType extends Type, Attributable, @value_or_ref_type {
   /** Gets an immediate subtype of this type, if any. */
   ValueOrRefType getASubType() { result.getABaseType() = this }
 
+  /** Gets an immediate supertype of this type, if any. */
+  ValueOrRefType getASupertype() { this.getABaseType() = result }
+
   /** Gets a member of this type, if any. */
   Member getAMember() { result.getDeclaringType() = this }
 


### PR DESCRIPTION
Add the `getASupertype()` predicate in `ValueOrRefType` like in Java: https://codeql.github.com/codeql-standard-libraries/java/semmle/code/java/Type.qll/predicate.Type$RefType$getASupertype.0.html

It's my first PR for CodeQL let me know if I did something wrong :)