### PR TITLE
Overlay: Add XML and Java property discarding

### DIFF
--- a/java/ql/lib/semmle/code/java/Overlay.qll
+++ b/java/ql/lib/semmle/code/java/Overlay.qll
@@ -99,3 +99,23 @@ private predicate discardBaseConfigLocatable(@configLocatable el) {
   // should be discarded.
   baseConfigLocatable(el) and overlayHasConfigLocatables()
 }
+
+overlay[local]
+private predicate baseXmlLocatable(@xmllocatable l) {
+  not isOverlay() and not files(l, _) and not xmlNs(l, _, _, _)
+}
+
+overlay[local]
+private predicate overlayHasXmlLocatable() {
+  isOverlay() and
+  exists(@xmllocatable l | not files(l, _) and not xmlNs(l, _, _, _))
+}
+
+overlay[discard_entity]
+private predicate discardBaseXmlLocatable(@xmllocatable el) {
+  // The XML extractor is currently not incremental, so if
+  // the overlay contains any XML locatables, the overlay should
+  // contain a full extraction and all XML locatables from base
+  // should be discarded.
+  baseXmlLocatable(el) and overlayHasXmlLocatable()
+}

--- a/java/ql/lib/semmle/code/java/Overlay.qll
+++ b/java/ql/lib/semmle/code/java/Overlay.qll
@@ -83,7 +83,7 @@ private predicate discardReferableLocatable(@locatable el) {
 }
 
 overlay[local]
-private predicate baseConfigLocatable(@configLocatable l) { not isOverlay() and l = l }
+private predicate baseConfigLocatable(@configLocatable l) { not isOverlay() and exists(l) }
 
 overlay[local]
 private predicate overlayHasConfigLocatables() {

--- a/java/ql/lib/semmle/code/java/Overlay.qll
+++ b/java/ql/lib/semmle/code/java/Overlay.qll
@@ -81,3 +81,21 @@ private predicate discardReferableLocatable(@locatable el) {
     not drl.existsInOverlay()
   )
 }
+
+overlay[local]
+private predicate baseConfigLocatable(@configLocatable l) { not isOverlay() and l = l }
+
+overlay[local]
+private predicate overlayHasConfigLocatables() {
+  isOverlay() and
+  exists(@configLocatable el)
+}
+
+overlay[discard_entity]
+private predicate discardBaseConfigLocatable(@configLocatable el) {
+  // The properties extractor is currently not incremental, so if
+  // the overlay contains any config locatables, the overlay should
+  // contain a full extraction and all config locatables from base
+  // should be discarded.
+  baseConfigLocatable(el) and overlayHasConfigLocatables()
+}


### PR DESCRIPTION
This PR adds discard predicates for Java to discard XML locatables and Java properties. XML and Java property extraction is not incremental and the overlay therefore contains a full XML and Java property extraction during overlay analysis. If the overlay contains any XML locatables, all XML locatables are discarded from base, and likewise for Java properties. 

Overlay compilation is currently disabled for Java and the discard predicates currently have no effect on compilation or evaluation. 