### PR TITLE
QL4QL: Discard predicates are always alive

### DIFF
--- a/ql/ql/src/codeql_ql/ast/Ast.qll
+++ b/ql/ql/src/codeql_ql/ast/Ast.qll
@@ -2554,6 +2554,10 @@ private class LocalQArg extends AnnotationArg {
   LocalQArg() { this.getValue() = "local?" }
 }
 
+private class DiscardEntityArg extends AnnotationArg {
+  DiscardEntityArg() { this.getValue() = "discard_entity" }
+}
+
 private class MonotonicAggregatesArg extends AnnotationArg {
   MonotonicAggregatesArg() { this.getValue() = "monotonicAggregates" }
 }
@@ -2639,6 +2643,15 @@ class OverlayLocalQ extends Annotation {
   OverlayLocalQ() { this.getName() = "overlay" and this.getArgs(0) instanceof LocalQArg }
 
   override string toString() { result = "overlay[local?]" }
+}
+
+/** An `overlay[discard_entity]` annotation. */
+class OverlayDiscardEntity extends Annotation {
+  OverlayDiscardEntity() {
+    this.getName() = "overlay" and this.getArgs(0) instanceof DiscardEntityArg
+  }
+
+  override string toString() { result = "overlay[discard_entity]" }
 }
 
 /** A `language[monotonicAggregates]` annotation. */

--- a/ql/ql/src/codeql_ql/style/DeadCodeQuery.qll
+++ b/ql/ql/src/codeql_ql/style/DeadCodeQuery.qll
@@ -39,6 +39,10 @@ private AstNode queryPredicate() {
   result = queryPredicate().getAChild()
 }
 
+private AstNode discardPredicate() {
+  result.(Predicate).getAnAnnotation() instanceof OverlayDiscardEntity
+}
+
 AstNode hackyShouldBeTreatedAsAlive() {
   // Stages from the shared DataFlow impl are copy-pasted, so predicates that are dead in one stage are not dead in another.
   result = any(Module mod | mod.getName().matches("Stage%")).getAMember().(ClasslessPredicate) and
@@ -58,7 +62,7 @@ AstNode hackyShouldBeTreatedAsAlive() {
  */
 private AstNode alive() {
   //
-  // The 4 base cases.
+  // The 5 base cases.
   //
   // 1) everything that can be imported.
   result = publicApi()
@@ -72,6 +76,9 @@ private AstNode alive() {
   or
   // 4) Things that aren't really alive, but that this query treats as live.
   result = hackyShouldBeTreatedAsAlive()
+  or
+  // 5) discard predicates
+  result = discardPredicate()
   or
   result instanceof TopLevel // toplevel is always alive.
   or

--- a/ql/ql/src/codeql_ql/style/DeadCodeQuery.qll
+++ b/ql/ql/src/codeql_ql/style/DeadCodeQuery.qll
@@ -62,7 +62,7 @@ AstNode hackyShouldBeTreatedAsAlive() {
  */
 private AstNode alive() {
   //
-  // The 5 base cases.
+  // The 6 base cases.
   //
   // 1) everything that can be imported.
   result = publicApi()
@@ -80,7 +80,8 @@ private AstNode alive() {
   // 5) discard predicates
   result = discardPredicate()
   or
-  result instanceof TopLevel // toplevel is always alive.
+  // 6) toplevel is always alive.
+  result instanceof TopLevel
   or
   // recursive cases
   result = aliveStep(alive())

--- a/ql/ql/test/queries/style/DeadCode/Foo.qll
+++ b/ql/ql/test/queries/style/DeadCode/Foo.qll
@@ -66,3 +66,6 @@ private class CImpl1 extends AstNode { }
 final class CPublic1 = CImpl1;
 
 private class CImpl2 extends AstNode { }
+
+overlay[discard_entity]
+private predicate discard(@foo x) { any() }


### PR DESCRIPTION
Private discard entity predicates are currently marked as dead code by the QL4QL dead code query. This PR updates the query such that discard predicates are always considered alive. 