### PR TITLE
Rust: Fix bad join

### DIFF
--- a/rust/ql/lib/codeql/rust/frameworks/stdlib/Stdlib.qll
+++ b/rust/ql/lib/codeql/rust/frameworks/stdlib/Stdlib.qll
@@ -29,6 +29,7 @@ private class StartswithCall extends Path::SafeAccessCheck::Range, CfgNodes::Met
  * [1]: https://doc.rust-lang.org/std/option/enum.Option.html
  */
 class OptionEnum extends Enum {
+  pragma[nomagic]
   OptionEnum() { this.getCanonicalPath() = "core::option::Option" }
 
   /** Gets the `Some` variant. */
@@ -41,6 +42,7 @@ class OptionEnum extends Enum {
  * [1]: https://doc.rust-lang.org/stable/std/result/enum.Result.html
  */
 class ResultEnum extends Enum {
+  pragma[nomagic]
   ResultEnum() { this.getCanonicalPath() = "core::result::Result" }
 
   /** Gets the `Ok` variant. */
@@ -56,6 +58,7 @@ class ResultEnum extends Enum {
  * [1]: https://doc.rust-lang.org/core/ops/struct.Range.html
  */
 class RangeStruct extends Struct {
+  pragma[nomagic]
   RangeStruct() { this.getCanonicalPath() = "core::ops::range::Range" }
 
   /** Gets the `start` field. */
@@ -71,6 +74,7 @@ class RangeStruct extends Struct {
  * [1]: https://doc.rust-lang.org/core/ops/struct.RangeFrom.html
  */
 class RangeFromStruct extends Struct {
+  pragma[nomagic]
   RangeFromStruct() { this.getCanonicalPath() = "core::ops::range::RangeFrom" }
 
   /** Gets the `start` field. */
@@ -83,6 +87,7 @@ class RangeFromStruct extends Struct {
  * [1]: https://doc.rust-lang.org/core/ops/struct.RangeTo.html
  */
 class RangeToStruct extends Struct {
+  pragma[nomagic]
   RangeToStruct() { this.getCanonicalPath() = "core::ops::range::RangeTo" }
 
   /** Gets the `end` field. */
@@ -95,6 +100,7 @@ class RangeToStruct extends Struct {
  * [1]: https://doc.rust-lang.org/core/ops/struct.RangeInclusive.html
  */
 class RangeInclusiveStruct extends Struct {
+  pragma[nomagic]
   RangeInclusiveStruct() { this.getCanonicalPath() = "core::ops::range::RangeInclusive" }
 
   /** Gets the `start` field. */
@@ -110,6 +116,7 @@ class RangeInclusiveStruct extends Struct {
  * [1]: https://doc.rust-lang.org/core/ops/struct.RangeToInclusive.html
  */
 class RangeToInclusiveStruct extends Struct {
+  pragma[nomagic]
   RangeToInclusiveStruct() { this.getCanonicalPath() = "core::ops::range::RangeToInclusive" }
 
   /** Gets the `end` field. */
@@ -122,6 +129,7 @@ class RangeToInclusiveStruct extends Struct {
  * [1]: https://doc.rust-lang.org/std/future/trait.Future.html
  */
 class FutureTrait extends Trait {
+  pragma[nomagic]
   FutureTrait() { this.getCanonicalPath() = "core::future::future::Future" }
 
   /** Gets the `Output` associated type. */
@@ -138,6 +146,7 @@ class FutureTrait extends Trait {
  * [1]: https://doc.rust-lang.org/std/iter/trait.Iterator.html
  */
 class IteratorTrait extends Trait {
+  pragma[nomagic]
   IteratorTrait() { this.getCanonicalPath() = "core::iter::traits::iterator::Iterator" }
 
   /** Gets the `Item` associated type. */
@@ -154,6 +163,7 @@ class IteratorTrait extends Trait {
  * [1]: https://doc.rust-lang.org/std/iter/trait.IntoIterator.html
  */
 class IntoIteratorTrait extends Trait {
+  pragma[nomagic]
   IntoIteratorTrait() { this.getCanonicalPath() = "core::iter::traits::collect::IntoIterator" }
 
   /** Gets the `Item` associated type. */
@@ -170,5 +180,6 @@ class IntoIteratorTrait extends Trait {
  * [1]: https://doc.rust-lang.org/std/string/struct.String.html
  */
 class StringStruct extends Struct {
+  pragma[nomagic]
   StringStruct() { this.getCanonicalPath() = "alloc::string::String" }
 }


### PR DESCRIPTION
Before
```
Evaluated relational algebra for predicate TypeInference::getRangeType/1#b4219ae9@c15c3f0b with tuple counts:
               1   ~0%    {1} r1 = CONSTANT(unique string)[".."]
             692   ~0%    {1}    | JOIN WITH `RangeExpr::Generated::RangeExpr.getOperatorName/0#dispred#7c90645c_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1

             453   ~0%    {1} r2 = JOIN r1 WITH `RangeExpr::Generated::RangeExpr.getStart/0#dispred#914c8207` ON FIRST 1 OUTPUT Lhs.0

             266   ~1%    {1} r3 = JOIN r2 WITH `RangeExpr::Generated::RangeExpr.getEnd/0#dispred#6c692cfa` ON FIRST 1 OUTPUT Lhs.0
        10684422   ~0%    {3}    | JOIN WITH cached_Synth::Synth::TStruct#c298e97c CARTESIAN PRODUCT OUTPUT Rhs.1, _, Lhs.0
        10684422   ~0%    {3}    | REWRITE WITH Out.1 := "core::ops::range::Range"
             266   ~0%    {2}    | JOIN WITH `Addressable::Addressable.getCanonicalPath/0#dispred#6044348f#bb` ON FIRST 2 OUTPUT Lhs.2, Lhs.0

             363   ~3%    {1} r4 = JOIN r1 WITH `RangeExpr::Generated::RangeExpr.getEnd/0#dispred#6c692cfa` ON FIRST 1 OUTPUT Lhs.0
              97   ~2%    {1}    | AND NOT `RangeExpr::Generated::RangeExpr.getStart/0#dispred#914c8207_0#antijoin_rhs`(FIRST 1)
         3896199   ~0%    {3}    | JOIN WITH cached_Synth::Synth::TStruct#c298e97c CARTESIAN PRODUCT OUTPUT Rhs.1, _, Lhs.0
         3896199   ~0%    {3}    | REWRITE WITH Out.1 := "core::ops::range::RangeTo"
              97   ~1%    {2}    | JOIN WITH `Addressable::Addressable.getCanonicalPath/0#dispred#6044348f#bb` ON FIRST 2 OUTPUT Lhs.2, Lhs.0

             187   ~0%    {1} r5 = r2 AND NOT `RangeExpr::Generated::RangeExpr.getEnd/0#dispred#6c692cfa_0#antijoin_rhs`(FIRST 1)
         7511229   ~2%    {3}    | JOIN WITH cached_Synth::Synth::TStruct#c298e97c CARTESIAN PRODUCT OUTPUT Rhs.1, _, Lhs.0
         7511229   ~0%    {3}    | REWRITE WITH Out.1 := "core::ops::range::RangeFrom"
             187   ~1%    {2}    | JOIN WITH `Addressable::Addressable.getCanonicalPath/0#dispred#6044348f#bb` ON FIRST 2 OUTPUT Lhs.2, Lhs.0

               1   ~0%    {1} r6 = CONSTANT(unique string)["..="]
             138   ~0%    {1}    | JOIN WITH `RangeExpr::Generated::RangeExpr.getOperatorName/0#dispred#7c90645c_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1

             131   ~0%    {1} r7 = JOIN r6 WITH `RangeExpr::Generated::RangeExpr.getStart/0#dispred#914c8207` ON FIRST 1 OUTPUT Lhs.0
             131   ~0%    {1}    | JOIN WITH `RangeExpr::Generated::RangeExpr.getEnd/0#dispred#6c692cfa` ON FIRST 1 OUTPUT Lhs.0
         5261877   ~0%    {3}    | JOIN WITH cached_Synth::Synth::TStruct#c298e97c CARTESIAN PRODUCT OUTPUT Rhs.1, _, Lhs.0
         5261877   ~0%    {3}    | REWRITE WITH Out.1 := "core::ops::range::RangeInclusive"
             131   ~3%    {2}    | JOIN WITH `Addressable::Addressable.getCanonicalPath/0#dispred#6044348f#bb` ON FIRST 2 OUTPUT Lhs.2, Lhs.0

             138   ~0%    {1} r8 = JOIN r6 WITH `RangeExpr::Generated::RangeExpr.getEnd/0#dispred#6c692cfa` ON FIRST 1 OUTPUT Lhs.0
               7   ~0%    {1}    | AND NOT `RangeExpr::Generated::RangeExpr.getStart/0#dispred#914c8207_0#antijoin_rhs`(FIRST 1)
          281169   ~0%    {3}    | JOIN WITH cached_Synth::Synth::TStruct#c298e97c CARTESIAN PRODUCT OUTPUT Rhs.1, _, Lhs.0
          281169   ~2%    {3}    | REWRITE WITH Out.1 := "core::ops::range::RangeToInclusive"
               7   ~0%    {2}    | JOIN WITH `Addressable::Addressable.getCanonicalPath/0#dispred#6044348f#bb` ON FIRST 2 OUTPUT Lhs.2, Lhs.0

             688   ~0%    {2} r9 = r3 UNION r4 UNION r5 UNION r7 UNION r8
                          return r9
```

After
```
Evaluated relational algebra for predicate TypeInference::getRangeType/1#b4219ae9@7d06d41t with tuple counts:
          1   ~0%    {2} r1 = SCAN Stdlib::RangeToStruct#236b6b84 OUTPUT _, In.0
          1   ~0%    {2}    | REWRITE WITH Out.0 := ".."
        692   ~0%    {2}    | JOIN WITH `RangeExpr::Generated::RangeExpr.getOperatorName/0#dispred#7c90645c_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1
        363   ~0%    {2}    | JOIN WITH `RangeExpr::Generated::RangeExpr.getEnd/0#dispred#6c692cfa` ON FIRST 1 OUTPUT Lhs.0, Lhs.1
         97   ~0%    {2}    | AND NOT `RangeExpr::Generated::RangeExpr.getStart/0#dispred#914c8207_0#antijoin_rhs`(FIRST 1)

          1   ~0%    {2} r2 = SCAN Stdlib::RangeFromStruct#8edcefe7 OUTPUT _, In.0
          1   ~0%    {2}    | REWRITE WITH Out.0 := ".."
        692   ~0%    {2}    | JOIN WITH `RangeExpr::Generated::RangeExpr.getOperatorName/0#dispred#7c90645c_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1
        453   ~0%    {2}    | JOIN WITH `RangeExpr::Generated::RangeExpr.getStart/0#dispred#914c8207` ON FIRST 1 OUTPUT Lhs.0, Lhs.1
        187   ~0%    {2}    | AND NOT `RangeExpr::Generated::RangeExpr.getEnd/0#dispred#6c692cfa_0#antijoin_rhs`(FIRST 1)

          1   ~0%    {2} r3 = SCAN Stdlib::RangeToInclusiveStruct#fe43a433 OUTPUT _, In.0
          1   ~0%    {2}    | REWRITE WITH Out.0 := "..="
        138   ~0%    {2}    | JOIN WITH `RangeExpr::Generated::RangeExpr.getOperatorName/0#dispred#7c90645c_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1
        138   ~0%    {2}    | JOIN WITH `RangeExpr::Generated::RangeExpr.getEnd/0#dispred#6c692cfa` ON FIRST 1 OUTPUT Lhs.0, Lhs.1
          7   ~0%    {2}    | AND NOT `RangeExpr::Generated::RangeExpr.getStart/0#dispred#914c8207_0#antijoin_rhs`(FIRST 1)

          1   ~0%    {2} r4 = SCAN Stdlib::RangeStruct#0fabc810 OUTPUT _, In.0
          1   ~0%    {2}    | REWRITE WITH Out.0 := ".."
        692   ~3%    {2}    | JOIN WITH `RangeExpr::Generated::RangeExpr.getOperatorName/0#dispred#7c90645c_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1
        453   ~4%    {2}    | JOIN WITH `RangeExpr::Generated::RangeExpr.getStart/0#dispred#914c8207` ON FIRST 1 OUTPUT Lhs.0, Lhs.1
        266   ~2%    {2}    | JOIN WITH `RangeExpr::Generated::RangeExpr.getEnd/0#dispred#6c692cfa` ON FIRST 1 OUTPUT Lhs.0, Lhs.1

          1   ~0%    {2} r5 = SCAN Stdlib::RangeInclusiveStruct#a869750a OUTPUT _, In.0
          1   ~0%    {2}    | REWRITE WITH Out.0 := "..="
        138   ~0%    {2}    | JOIN WITH `RangeExpr::Generated::RangeExpr.getOperatorName/0#dispred#7c90645c_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1
        131   ~0%    {2}    | JOIN WITH `RangeExpr::Generated::RangeExpr.getStart/0#dispred#914c8207` ON FIRST 1 OUTPUT Lhs.0, Lhs.1
        131   ~0%    {2}    | JOIN WITH `RangeExpr::Generated::RangeExpr.getEnd/0#dispred#6c692cfa` ON FIRST 1 OUTPUT Lhs.0, Lhs.1

        688   ~7%    {2} r6 = r1 UNION r2 UNION r3 UNION r4 UNION r5
                     return r6
```