### PR TITLE
C++: Add more thread creation models

### DIFF
--- a/cpp/ql/lib/ext/pthread.model.yml
+++ b/cpp/ql/lib/ext/pthread.model.yml
@@ -1,0 +1,6 @@
+extensions:
+  - addsTo:
+      pack: codeql/cpp-all
+      extensible: summaryModel
+    data: # namespace, type, subtypes, name, signature, ext, input, output, kind, provenance
+      - ["", "", False, "pthread_create", "", "", "Argument[@3]", "Argument[2].Parameter[@0]", "value", "manual"]

--- a/cpp/ql/lib/ext/std.thread.model.yml
+++ b/cpp/ql/lib/ext/std.thread.model.yml
@@ -1,0 +1,11 @@
+extensions:
+  - addsTo:
+      pack: codeql/cpp-all
+      extensible: summaryModel
+    data: # namespace, type, subtypes, name, signature, ext, input, output, kind, provenance
+      - ["std", "thread", True, "thread", "", "", "Argument[*@1]", "Argument[0].Parameter[@0]", "value", "manual"]
+      - ["std", "thread", True, "thread", "", "", "Argument[*@2]", "Argument[0].Parameter[@1]", "value", "manual"]
+      - ["std", "thread", True, "thread", "", "", "Argument[*@3]", "Argument[0].Parameter[@2]", "value", "manual"]
+      - ["std", "thread", True, "thread", "", "", "Argument[*@4]", "Argument[0].Parameter[@3]", "value", "manual"]
+      - ["std", "thread", True, "thread", "", "", "Argument[*@5]", "Argument[0].Parameter[@4]", "value", "manual"]
+      

--- a/cpp/ql/src/change-notes/2025-07-10-pthread-and-std-thread.md
+++ b/cpp/ql/src/change-notes/2025-07-10-pthread-and-std-thread.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added flow models for `pthread_create` and `std::thread`.

--- a/cpp/ql/test/library-tests/dataflow/external-models/flow.expected
+++ b/cpp/ql/test/library-tests/dataflow/external-models/flow.expected
@@ -21,12 +21,13 @@ models
 | 20 | Summary: ; ; false; CreateRemoteThreadEx; ; ; Argument[@4]; Argument[3].Parameter[@0]; value; manual |
 | 21 | Summary: ; ; false; CreateThread; ; ; Argument[@3]; Argument[2].Parameter[@0]; value; manual |
 | 22 | Summary: ; ; false; ReadFileEx; ; ; Argument[*3].Field[@hEvent]; Argument[4].Parameter[*2].Field[@hEvent]; value; manual |
-| 23 | Summary: ; ; false; ymlStepGenerated; ; ; Argument[0]; ReturnValue; taint; df-generated |
-| 24 | Summary: ; ; false; ymlStepManual; ; ; Argument[0]; ReturnValue; taint; manual |
-| 25 | Summary: ; ; false; ymlStepManual_with_body; ; ; Argument[0]; ReturnValue; taint; manual |
-| 26 | Summary: boost::asio; ; false; buffer; ; ; Argument[*0]; ReturnValue; taint; manual |
+| 23 | Summary: ; ; false; pthread_create; ; ; Argument[@3]; Argument[2].Parameter[@0]; value; manual |
+| 24 | Summary: ; ; false; ymlStepGenerated; ; ; Argument[0]; ReturnValue; taint; df-generated |
+| 25 | Summary: ; ; false; ymlStepManual; ; ; Argument[0]; ReturnValue; taint; manual |
+| 26 | Summary: ; ; false; ymlStepManual_with_body; ; ; Argument[0]; ReturnValue; taint; manual |
+| 27 | Summary: boost::asio; ; false; buffer; ; ; Argument[*0]; ReturnValue; taint; manual |
 edges
-| asio_streams.cpp:56:18:56:23 | [summary param] *0 in buffer | asio_streams.cpp:56:18:56:23 | [summary] to write: ReturnValue in buffer | provenance | MaD:26 |
+| asio_streams.cpp:56:18:56:23 | [summary param] *0 in buffer | asio_streams.cpp:56:18:56:23 | [summary] to write: ReturnValue in buffer | provenance | MaD:27 |
 | asio_streams.cpp:87:34:87:44 | read_until output argument | asio_streams.cpp:91:7:91:17 | recv_buffer | provenance | Src:MaD:17  |
 | asio_streams.cpp:87:34:87:44 | read_until output argument | asio_streams.cpp:93:29:93:39 | *recv_buffer | provenance | Src:MaD:17 Sink:MaD:2 |
 | asio_streams.cpp:97:37:97:44 | call to source | asio_streams.cpp:98:7:98:14 | send_str | provenance | TaintFunction |
@@ -35,10 +36,10 @@ edges
 | asio_streams.cpp:100:44:100:62 | call to buffer | asio_streams.cpp:101:7:101:17 | send_buffer | provenance |  |
 | asio_streams.cpp:100:44:100:62 | call to buffer | asio_streams.cpp:103:29:103:39 | *send_buffer | provenance | Sink:MaD:2 |
 | asio_streams.cpp:100:64:100:71 | *send_str | asio_streams.cpp:56:18:56:23 | [summary param] *0 in buffer | provenance |  |
-| asio_streams.cpp:100:64:100:71 | *send_str | asio_streams.cpp:100:44:100:62 | call to buffer | provenance | MaD:26 |
-| test.cpp:4:5:4:17 | [summary param] 0 in ymlStepManual | test.cpp:4:5:4:17 | [summary] to write: ReturnValue in ymlStepManual | provenance | MaD:24 |
-| test.cpp:5:5:5:20 | [summary param] 0 in ymlStepGenerated | test.cpp:5:5:5:20 | [summary] to write: ReturnValue in ymlStepGenerated | provenance | MaD:23 |
-| test.cpp:6:5:6:27 | [summary param] 0 in ymlStepManual_with_body | test.cpp:6:5:6:27 | [summary] to write: ReturnValue in ymlStepManual_with_body | provenance | MaD:25 |
+| asio_streams.cpp:100:64:100:71 | *send_str | asio_streams.cpp:100:44:100:62 | call to buffer | provenance | MaD:27 |
+| test.cpp:4:5:4:17 | [summary param] 0 in ymlStepManual | test.cpp:4:5:4:17 | [summary] to write: ReturnValue in ymlStepManual | provenance | MaD:25 |
+| test.cpp:5:5:5:20 | [summary param] 0 in ymlStepGenerated | test.cpp:5:5:5:20 | [summary] to write: ReturnValue in ymlStepGenerated | provenance | MaD:24 |
+| test.cpp:6:5:6:27 | [summary param] 0 in ymlStepManual_with_body | test.cpp:6:5:6:27 | [summary] to write: ReturnValue in ymlStepManual_with_body | provenance | MaD:26 |
 | test.cpp:7:47:7:52 | value2 | test.cpp:7:64:7:69 | value2 | provenance |  |
 | test.cpp:7:64:7:69 | value2 | test.cpp:7:5:7:30 | *ymlStepGenerated_with_body | provenance |  |
 | test.cpp:10:10:10:18 | call to ymlSource | test.cpp:10:10:10:18 | call to ymlSource | provenance | Src:MaD:16  |
@@ -50,19 +51,28 @@ edges
 | test.cpp:17:10:17:22 | call to ymlStepManual | test.cpp:17:10:17:22 | call to ymlStepManual | provenance |  |
 | test.cpp:17:10:17:22 | call to ymlStepManual | test.cpp:18:10:18:10 | y | provenance | Sink:MaD:1 |
 | test.cpp:17:24:17:24 | x | test.cpp:4:5:4:17 | [summary param] 0 in ymlStepManual | provenance |  |
-| test.cpp:17:24:17:24 | x | test.cpp:17:10:17:22 | call to ymlStepManual | provenance | MaD:24 |
+| test.cpp:17:24:17:24 | x | test.cpp:17:10:17:22 | call to ymlStepManual | provenance | MaD:25 |
 | test.cpp:21:10:21:25 | call to ymlStepGenerated | test.cpp:21:10:21:25 | call to ymlStepGenerated | provenance |  |
 | test.cpp:21:10:21:25 | call to ymlStepGenerated | test.cpp:22:10:22:10 | z | provenance | Sink:MaD:1 |
 | test.cpp:21:27:21:27 | x | test.cpp:5:5:5:20 | [summary param] 0 in ymlStepGenerated | provenance |  |
-| test.cpp:21:27:21:27 | x | test.cpp:21:10:21:25 | call to ymlStepGenerated | provenance | MaD:23 |
+| test.cpp:21:27:21:27 | x | test.cpp:21:10:21:25 | call to ymlStepGenerated | provenance | MaD:24 |
 | test.cpp:25:11:25:33 | call to ymlStepManual_with_body | test.cpp:25:11:25:33 | call to ymlStepManual_with_body | provenance |  |
 | test.cpp:25:11:25:33 | call to ymlStepManual_with_body | test.cpp:26:10:26:11 | y2 | provenance | Sink:MaD:1 |
 | test.cpp:25:35:25:35 | x | test.cpp:6:5:6:27 | [summary param] 0 in ymlStepManual_with_body | provenance |  |
-| test.cpp:25:35:25:35 | x | test.cpp:25:11:25:33 | call to ymlStepManual_with_body | provenance | MaD:25 |
+| test.cpp:25:35:25:35 | x | test.cpp:25:11:25:33 | call to ymlStepManual_with_body | provenance | MaD:26 |
 | test.cpp:32:11:32:36 | call to ymlStepGenerated_with_body | test.cpp:32:11:32:36 | call to ymlStepGenerated_with_body | provenance |  |
 | test.cpp:32:11:32:36 | call to ymlStepGenerated_with_body | test.cpp:33:10:33:11 | z2 | provenance | Sink:MaD:1 |
 | test.cpp:32:41:32:41 | x | test.cpp:7:47:7:52 | value2 | provenance |  |
 | test.cpp:32:41:32:41 | x | test.cpp:32:11:32:36 | call to ymlStepGenerated_with_body | provenance |  |
+| test.cpp:46:30:46:32 | *arg [x] | test.cpp:47:12:47:19 | *arg [x] | provenance |  |
+| test.cpp:47:12:47:19 | *arg [x] | test.cpp:48:11:48:11 | *s [x] | provenance |  |
+| test.cpp:48:11:48:11 | *s [x] | test.cpp:48:14:48:14 | x | provenance | Sink:MaD:1 |
+| test.cpp:52:5:52:18 | [summary param] *3 in pthread_create [x] | test.cpp:52:5:52:18 | [summary] to write: Argument[2].Parameter[*0] in pthread_create [x] | provenance | MaD:23 |
+| test.cpp:52:5:52:18 | [summary] to write: Argument[2].Parameter[*0] in pthread_create [x] | test.cpp:46:30:46:32 | *arg [x] | provenance |  |
+| test.cpp:56:2:56:2 | *s [post update] [x] | test.cpp:59:55:59:64 | *& ... [x] | provenance |  |
+| test.cpp:56:2:56:18 | ... = ... | test.cpp:56:2:56:2 | *s [post update] [x] | provenance |  |
+| test.cpp:56:8:56:16 | call to ymlSource | test.cpp:56:2:56:18 | ... = ... | provenance | Src:MaD:16  |
+| test.cpp:59:55:59:64 | *& ... [x] | test.cpp:52:5:52:18 | [summary param] *3 in pthread_create [x] | provenance |  |
 | windows.cpp:17:8:17:25 | [summary param] *0 in CommandLineToArgvA | windows.cpp:17:8:17:25 | [summary] to write: ReturnValue[**] in CommandLineToArgvA | provenance | MaD:18 |
 | windows.cpp:22:15:22:29 | *call to GetCommandLineA | windows.cpp:22:15:22:29 | *call to GetCommandLineA | provenance | Src:MaD:3  |
 | windows.cpp:22:15:22:29 | *call to GetCommandLineA | windows.cpp:24:8:24:11 | * ... | provenance |  |
@@ -189,6 +199,16 @@ nodes
 | test.cpp:32:11:32:36 | call to ymlStepGenerated_with_body | semmle.label | call to ymlStepGenerated_with_body |
 | test.cpp:32:41:32:41 | x | semmle.label | x |
 | test.cpp:33:10:33:11 | z2 | semmle.label | z2 |
+| test.cpp:46:30:46:32 | *arg [x] | semmle.label | *arg [x] |
+| test.cpp:47:12:47:19 | *arg [x] | semmle.label | *arg [x] |
+| test.cpp:48:11:48:11 | *s [x] | semmle.label | *s [x] |
+| test.cpp:48:14:48:14 | x | semmle.label | x |
+| test.cpp:52:5:52:18 | [summary param] *3 in pthread_create [x] | semmle.label | [summary param] *3 in pthread_create [x] |
+| test.cpp:52:5:52:18 | [summary] to write: Argument[2].Parameter[*0] in pthread_create [x] | semmle.label | [summary] to write: Argument[2].Parameter[*0] in pthread_create [x] |
+| test.cpp:56:2:56:2 | *s [post update] [x] | semmle.label | *s [post update] [x] |
+| test.cpp:56:2:56:18 | ... = ... | semmle.label | ... = ... |
+| test.cpp:56:8:56:16 | call to ymlSource | semmle.label | call to ymlSource |
+| test.cpp:59:55:59:64 | *& ... [x] | semmle.label | *& ... [x] |
 | windows.cpp:17:8:17:25 | [summary param] *0 in CommandLineToArgvA | semmle.label | [summary param] *0 in CommandLineToArgvA |
 | windows.cpp:17:8:17:25 | [summary] to write: ReturnValue[**] in CommandLineToArgvA | semmle.label | [summary] to write: ReturnValue[**] in CommandLineToArgvA |
 | windows.cpp:22:15:22:29 | *call to GetCommandLineA | semmle.label | *call to GetCommandLineA |

--- a/cpp/ql/test/library-tests/dataflow/external-models/flow.expected
+++ b/cpp/ql/test/library-tests/dataflow/external-models/flow.expected
@@ -65,8 +65,8 @@ edges
 | test.cpp:32:41:32:41 | x | test.cpp:7:47:7:52 | value2 | provenance |  |
 | test.cpp:32:41:32:41 | x | test.cpp:32:11:32:36 | call to ymlStepGenerated_with_body | provenance |  |
 | test.cpp:46:30:46:32 | *arg [x] | test.cpp:47:12:47:19 | *arg [x] | provenance |  |
-| test.cpp:47:12:47:19 | *arg [x] | test.cpp:48:11:48:11 | *s [x] | provenance |  |
-| test.cpp:48:11:48:11 | *s [x] | test.cpp:48:14:48:14 | x | provenance | Sink:MaD:1 |
+| test.cpp:47:12:47:19 | *arg [x] | test.cpp:48:13:48:13 | *s [x] | provenance |  |
+| test.cpp:48:13:48:13 | *s [x] | test.cpp:48:16:48:16 | x | provenance | Sink:MaD:1 |
 | test.cpp:52:5:52:18 | [summary param] *3 in pthread_create [x] | test.cpp:52:5:52:18 | [summary] to write: Argument[2].Parameter[*0] in pthread_create [x] | provenance | MaD:23 |
 | test.cpp:52:5:52:18 | [summary] to write: Argument[2].Parameter[*0] in pthread_create [x] | test.cpp:46:30:46:32 | *arg [x] | provenance |  |
 | test.cpp:56:2:56:2 | *s [post update] [x] | test.cpp:59:55:59:64 | *& ... [x] | provenance |  |
@@ -201,8 +201,8 @@ nodes
 | test.cpp:33:10:33:11 | z2 | semmle.label | z2 |
 | test.cpp:46:30:46:32 | *arg [x] | semmle.label | *arg [x] |
 | test.cpp:47:12:47:19 | *arg [x] | semmle.label | *arg [x] |
-| test.cpp:48:11:48:11 | *s [x] | semmle.label | *s [x] |
-| test.cpp:48:14:48:14 | x | semmle.label | x |
+| test.cpp:48:13:48:13 | *s [x] | semmle.label | *s [x] |
+| test.cpp:48:16:48:16 | x | semmle.label | x |
 | test.cpp:52:5:52:18 | [summary param] *3 in pthread_create [x] | semmle.label | [summary param] *3 in pthread_create [x] |
 | test.cpp:52:5:52:18 | [summary] to write: Argument[2].Parameter[*0] in pthread_create [x] | semmle.label | [summary] to write: Argument[2].Parameter[*0] in pthread_create [x] |
 | test.cpp:56:2:56:2 | *s [post update] [x] | semmle.label | *s [post update] [x] |

--- a/cpp/ql/test/library-tests/dataflow/external-models/sinks.expected
+++ b/cpp/ql/test/library-tests/dataflow/external-models/sinks.expected
@@ -8,3 +8,4 @@
 | test.cpp:29:10:29:11 | y3 | test-sink |
 | test.cpp:33:10:33:11 | z2 | test-sink |
 | test.cpp:36:10:36:11 | z3 | test-sink |
+| test.cpp:48:14:48:14 | x | test-sink |

--- a/cpp/ql/test/library-tests/dataflow/external-models/sinks.expected
+++ b/cpp/ql/test/library-tests/dataflow/external-models/sinks.expected
@@ -8,4 +8,4 @@
 | test.cpp:29:10:29:11 | y3 | test-sink |
 | test.cpp:33:10:33:11 | z2 | test-sink |
 | test.cpp:36:10:36:11 | z3 | test-sink |
-| test.cpp:48:14:48:14 | x | test-sink |
+| test.cpp:48:16:48:16 | x | test-sink |

--- a/cpp/ql/test/library-tests/dataflow/external-models/sources.expected
+++ b/cpp/ql/test/library-tests/dataflow/external-models/sources.expected
@@ -1,5 +1,6 @@
 | asio_streams.cpp:87:34:87:44 | read_until output argument | remote |
 | test.cpp:10:10:10:18 | call to ymlSource | local |
+| test.cpp:56:8:56:16 | call to ymlSource | local |
 | windows.cpp:22:15:22:29 | *call to GetCommandLineA | local |
 | windows.cpp:34:17:34:38 | *call to GetEnvironmentStringsA | local |
 | windows.cpp:39:36:39:38 | GetEnvironmentVariableA output argument | local |

--- a/cpp/ql/test/library-tests/dataflow/external-models/test.cpp
+++ b/cpp/ql/test/library-tests/dataflow/external-models/test.cpp
@@ -45,7 +45,7 @@ using pthread_attr_t = void*;
 
 void *myThreadFunction(void *arg) {
     S* s = (S *)arg;
-		ymlSink(s->x); // $ MISSING: ir
+		ymlSink(s->x); // $ ir
     return nullptr;
 }
 

--- a/cpp/ql/test/library-tests/dataflow/external-models/test.cpp
+++ b/cpp/ql/test/library-tests/dataflow/external-models/test.cpp
@@ -45,7 +45,7 @@ using pthread_attr_t = void*;
 
 void *myThreadFunction(void *arg) {
     S* s = (S *)arg;
-		ymlSink(s->x); // $ ir
+    ymlSink(s->x); // $ ir
     return nullptr;
 }
 

--- a/cpp/ql/test/library-tests/dataflow/external-models/test.cpp
+++ b/cpp/ql/test/library-tests/dataflow/external-models/test.cpp
@@ -35,3 +35,26 @@ void test() {
 	int z3 = ymlStepGenerated_with_body(x, 0);
 	ymlSink(z3); // clean
 }
+
+struct S {
+	int x;
+};
+
+using pthread_t = unsigned long;
+using pthread_attr_t = void*;
+
+void *myThreadFunction(void *arg) {
+    S* s = (S *)arg;
+		ymlSink(s->x); // $ MISSING: ir
+    return nullptr;
+}
+
+int pthread_create(pthread_t *thread, const pthread_attr_t * attr, void *(*start_routine)(void*), void *arg);
+
+int test_pthread_create() {
+	S s;
+	s.x = ymlSource();
+
+	pthread_t threadId;
+	pthread_create(&threadId, nullptr, myThreadFunction, (void *)&s);
+}

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -7767,6 +7767,27 @@ WARNING: module 'TaintTracking' has been deprecated and may be removed in future
 | taint.cpp:830:20:830:34 | call to indirect_source | taint.cpp:832:23:832:24 | in |  |
 | taint.cpp:831:15:831:17 | out | taint.cpp:832:18:832:20 | out |  |
 | taint.cpp:831:15:831:17 | out | taint.cpp:833:8:833:10 | out |  |
+| thread.cpp:10:27:10:27 | s | thread.cpp:10:27:10:27 | s |  |
+| thread.cpp:10:27:10:27 | s | thread.cpp:11:8:11:8 | s |  |
+| thread.cpp:14:26:14:26 | s | thread.cpp:15:8:15:8 | s |  |
+| thread.cpp:18:27:18:27 | s | thread.cpp:18:27:18:27 | s |  |
+| thread.cpp:18:27:18:27 | s | thread.cpp:19:8:19:8 | s |  |
+| thread.cpp:18:34:18:34 | y | thread.cpp:20:8:20:8 | y |  |
+| thread.cpp:24:5:24:5 | s | thread.cpp:25:3:25:3 | s |  |
+| thread.cpp:24:5:24:5 | s | thread.cpp:26:38:26:38 | s |  |
+| thread.cpp:24:5:24:5 | s | thread.cpp:27:37:27:37 | s |  |
+| thread.cpp:24:5:24:5 | s | thread.cpp:28:38:28:38 | s |  |
+| thread.cpp:25:3:25:3 | s [post update] | thread.cpp:26:38:26:38 | s |  |
+| thread.cpp:25:3:25:3 | s [post update] | thread.cpp:27:37:27:37 | s |  |
+| thread.cpp:25:3:25:3 | s [post update] | thread.cpp:28:38:28:38 | s |  |
+| thread.cpp:25:3:25:16 | ... = ... | thread.cpp:25:5:25:5 | x [post update] |  |
+| thread.cpp:25:9:25:14 | call to source | thread.cpp:25:3:25:16 | ... = ... |  |
+| thread.cpp:26:18:26:39 | call to thread | thread.cpp:29:1:29:1 | t1 |  |
+| thread.cpp:26:38:26:38 | s | thread.cpp:26:37:26:38 | & ... |  |
+| thread.cpp:27:18:27:38 | call to thread | thread.cpp:29:1:29:1 | t2 |  |
+| thread.cpp:27:37:27:37 | ref arg s | thread.cpp:28:38:28:38 | s |  |
+| thread.cpp:28:18:28:43 | call to thread | thread.cpp:29:1:29:1 | t3 |  |
+| thread.cpp:28:38:28:38 | s | thread.cpp:28:37:28:38 | & ... |  |
 | vector.cpp:16:43:16:49 | source1 | vector.cpp:17:26:17:32 | source1 |  |
 | vector.cpp:16:43:16:49 | source1 | vector.cpp:31:38:31:44 | source1 |  |
 | vector.cpp:17:21:17:33 | call to vector | vector.cpp:19:14:19:14 | v |  |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/stl.h
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/stl.h
@@ -682,3 +682,16 @@ namespace std {
 	template <typename... Args>
 	int same_signature_as_format_but_different_name(format_string, Args &&...args);
 }
+
+namespace std {
+	class thread {
+		public:
+		template<class F, class... Args>
+		explicit thread(F&&, Args&&...);
+
+		~thread();
+
+		void join();
+		void detach();
+	};
+}

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/thread.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/thread.cpp
@@ -1,0 +1,29 @@
+#include "stl.h"
+
+int source();
+void sink(int);
+
+struct S {
+  int x;
+};
+
+void thread_function_1(S* s) {
+  sink(s->x); // $ MISSING: ir
+}
+
+void thread_function_2(S s) {
+  sink(s.x); // $ MISSING: ir
+}
+
+void thread_function_3(S* s, int y) {
+  sink(s->x); // $ MISSING: ir
+  sink(y); // clean
+}
+
+void test_thread() {
+  S s;
+  s.x = source();
+  std::thread t1(thread_function_1, &s);
+  std::thread t2(thread_function_2, s);
+  std::thread t3(thread_function_3, &s, 42);
+}

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/thread.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/thread.cpp
@@ -8,15 +8,15 @@ struct S {
 };
 
 void thread_function_1(S* s) {
-  sink(s->x); // $ MISSING: ir
+  sink(s->x); // $ ir
 }
 
 void thread_function_2(S s) {
-  sink(s.x); // $ MISSING: ir
+  sink(s.x); // $ ir
 }
 
 void thread_function_3(S* s, int y) {
-  sink(s->x); // $ MISSING: ir
+  sink(s->x); // $ ir
   sink(y); // clean
 }
 


### PR DESCRIPTION
This is https://github.com/github/codeql/pull/19955, but for `pthread`s and `std::thread`s.

Commit-by-commit review recommended.