### PR TITLE
Java: Update qhelp: SnakeYaml is safe from version 2.0

### DIFF
--- a/java/ql/src/Security/CWE/CWE-502/UnsafeDeserialization.qhelp
+++ b/java/ql/src/Security/CWE/CWE-502/UnsafeDeserialization.qhelp
@@ -121,7 +121,7 @@ Alvaro Muñoz &amp; Christian Schneider, RSAConference 2016:
 </li>
 <li>
 SnakeYaml documentation on deserialization:
-<a href="https://bitbucket.org/snakeyaml/snakeyaml/wiki/Documentation#markdown-header-loading-yaml">SnakeYaml deserialization</a>.
+<a href="https://bitbucket.org/snakeyaml/snakeyaml/wiki/Documentation#markdown-header-loading-yaml">SnakeYaml deserialization</a> (not updated for new behaviour in version 2.0).
 </li>
 <li>
 Hessian deserialization and related gadget chains:

--- a/java/ql/src/Security/CWE/CWE-502/UnsafeDeserialization.qhelp
+++ b/java/ql/src/Security/CWE/CWE-502/UnsafeDeserialization.qhelp
@@ -64,8 +64,8 @@ Recommendations specific to particular frameworks supported by this query:
 <p></p>
 <p><b>SnakeYAML</b> - <code>org.yaml:snakeyaml</code></p>
     <ul>
-        <li><b>Secure by Default</b>: No</li>
-        <li><b>Recommendation</b>: Pass an instance of <code>org.yaml.snakeyaml.constructor.SafeConstructor</code> to  <code>org.yaml.snakeyaml.Yaml</code>'s constructor before using it to deserialize untrusted data.</li>
+        <li><b>Secure by Default</b>: As of version 2.0.</li>
+        <li><b>Recommendation</b>: For versions before 2.0, pass an instance of <code>org.yaml.snakeyaml.constructor.SafeConstructor</code> to  <code>org.yaml.snakeyaml.Yaml</code>'s constructor before using it to deserialize untrusted data.</li>
     </ul>
 <p></p>
 <p><b>XML Decoder</b> - <code>Standard Java Library</code></p>


### PR DESCRIPTION
It was brought to our attention in https://github.com/github/codeql/issues/19664 that SnakeYaml is not vulnerable to `java/unsafe-deserialization` as of version 2.0 (released in 2023). This is because all constructors now extend `SafeConstructor`. We already had an exclusion for constructors which extend `SafeConstructor`, so the query does not need to be updated. This PR updates the qhelp file.