### PR TITLE
Experiment: Make all data flow incremental

### DIFF
--- a/java/ql/lib/qlpack.yml
+++ b/java/ql/lib/qlpack.yml
@@ -23,3 +23,4 @@ dataExtensions:
   - ext/generated/*.model.yml
   - ext/experimental/*.model.yml
 warnOnImplicitThis: true
+compileForOverlayEval: true

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplSpecific.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplSpecific.qll
@@ -6,6 +6,7 @@ module;
 
 private import semmle.code.Location
 private import codeql.dataflow.DataFlow
+private import semmle.code.java.Overlay
 
 module Private {
   import DataFlowPrivate
@@ -29,4 +30,6 @@ module JavaDataFlow implements InputSig<Location> {
   predicate mayBenefitFromCallContext = Private::mayBenefitFromCallContext/1;
 
   predicate viableImplInCallContext = Private::viableImplInCallContext/2;
+
+  predicate isEvaluatingInOverlay = isOverlay/0;
 }

--- a/shared/dataflow/codeql/dataflow/DataFlow.qll
+++ b/shared/dataflow/codeql/dataflow/DataFlow.qll
@@ -349,6 +349,18 @@ signature module InputSig<LocationSig Location> {
 
   /** Holds if `fieldFlowBranchLimit` should be ignored for flow going into/out of `c`. */
   default predicate ignoreFieldFlowBranchLimit(DataFlowCallable c) { none() }
+
+  /**
+   * Holds if the evaluator is currently evaluating with an overlay. The
+   * implementation of this predicate needs to be `overlay[local]`. For a
+   * language with no overlay support, `none()` is a valid implementation.
+   *
+   * When called from a local predicate, this predicate holds if we are in the
+   * overlay-only local evaluation. When called from a global predicate, this
+   * predicate holds if we are evaluating globally with overlay and base both
+   * visible.
+   */
+  default predicate isEvaluatingInOverlay() { none() }
 }
 
 module Configs<LocationSig Location, InputSig<Location> Lang> {

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImplStage1.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImplStage1.qll
@@ -4,7 +4,7 @@
  * Provides an implementation of a fast initial pruning of global
  * (interprocedural) data flow reachability (Stage 1).
  */
-overlay[local?]
+overlay[local?] // when this is removed, put `overlay[local?]` on `isOverlayNode`.
 module;
 
 private import codeql.util.Unit
@@ -129,14 +129,38 @@ module MakeImplStage1<LocationSig Location, InputSig<Location> Lang> {
 
       private module AlertFiltering = AlertFilteringImpl<Location>;
 
+      /**
+       * Holds if the given node is visible in overlay-only local evaluation.
+       *
+       * This predicate needs to be `overlay[local?]`, either directly or
+       * through annotations from an outer scope. If `Node` is global for the
+       * language under analysis, then every node is considered an overlay
+       * node, which means there will effectively be no overlay-based
+       * filtering of sources and sinks.
+       */
+      private predicate isOverlayNode(Node node) {
+        isEvaluatingInOverlay() and
+        // Any local node is an overlay node if we are evaluating in overlay mode
+        exists(node)
+      }
+
+      overlay[global]
       pragma[nomagic]
       private predicate isFilteredSource(Node source) {
         Config::isSource(source, _) and
         if Config::observeDiffInformedIncrementalMode()
         then AlertFiltering::filterByLocation(Config::getASelectedSourceLocation(source))
-        else any()
+        else (
+          // If we are in base-only global evaluation, do not filter out any sources.
+          not isEvaluatingInOverlay()
+          or
+          // If we are in global evaluation with an overlay present, restrict
+          // sources to those visible in the overlay.
+          isOverlayNode(source)
+        )
       }
 
+      overlay[global]
       pragma[nomagic]
       private predicate isFilteredSink(Node sink) {
         (
@@ -145,7 +169,14 @@ module MakeImplStage1<LocationSig Location, InputSig<Location> Lang> {
         ) and
         if Config::observeDiffInformedIncrementalMode()
         then AlertFiltering::filterByLocation(Config::getASelectedSinkLocation(sink))
-        else any()
+        else (
+          // If we are in base-only global evaluation, do not filter out any sinks.
+          not isEvaluatingInOverlay()
+          or
+          // If we are in global evaluation with an overlay present, restrict
+          // sinks to those visible in the overlay.
+          isOverlayNode(sink)
+        )
       }
 
       private predicate hasFilteredSource() { isFilteredSource(_) }

--- a/shared/util/codeql/util/AlertFiltering.qll
+++ b/shared/util/codeql/util/AlertFiltering.qll
@@ -82,6 +82,21 @@ module AlertFilteringImpl<LocationSig Location> {
     )
   }
 
+  /** Holds if diff information is available in this evaluation. */
+  predicate diffInformationAvailable() {
+    restrictAlertsTo(_, _, _) or restrictAlertsToExactLocation(_, _, _, _, _)
+  }
+
+  /**
+   * Holds if diff information is available, and `filePath` is in the diff
+   * range.
+   */
+  predicate fileIsInDiff(string filePath) {
+    restrictAlertsTo(filePath, _, _)
+    or
+    restrictAlertsToExactLocation(filePath, _, _, _, _)
+  }
+
   /**
    * Holds if the given location intersects the diff range. When that is the
    * case, ensuring that alerts mentioning this location are included in the
@@ -103,8 +118,17 @@ module AlertFilteringImpl<LocationSig Location> {
    */
   bindingset[location]
   predicate filterByLocation(Location location) {
-    not restrictAlertsTo(_, _, _) and not restrictAlertsToExactLocation(_, _, _, _, _)
+    not diffInformationAvailable()
     or
+    locationIsInDiff(location)
+  }
+
+  /**
+   * Like `filterByLocation`, except that if there is no diff range, this
+   * predicate never holds.
+   */
+  bindingset[location]
+  predicate locationIsInDiff(Location location) {
     exists(string filePath |
       restrictAlertsToEntireFile(filePath) and
       location.hasLocationInfo(filePath, _, _, _, _)


### PR DESCRIPTION
I've polished up this branch for testing and to communicate a proof-of-concept for what it would look like to have all data flow incremental, either diff-informed or "overlay-informed". The last commit uses `forceLocal` to add in the base-to-base results, but it has some problems:
* I wasn't able to test performance because it turns out we don't get any cache hits when `forceLocal` is in use. Alex is on it.
* It only works for Java because the predicate that calls `forceLocal` can't currently be marked as `local?`. The shared code in this PR won't compile for other languages than Java because it requires `Node` to be local.

To achieve the full vision of incrementality, the type tracking library also needs to be overlay-aware. That library seems to be the main performance bottleneck that we know how to address in QL.

As I'm going out on holiday now, I want to leave this PR for @alexet and @aschackmull to work from or take inspiration from.