### PR TITLE
JavaScript: Ignore `outDir`s that would exclude everything

### DIFF
--- a/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
@@ -754,7 +754,11 @@ public class AutoBuild {
             continue;
           }
           Path odir = cfg.getParent().resolve(root.getCompilerOptions().getOutDir()).toAbsolutePath().normalize();
-          outDirs.add(odir);
+          // Only exclude outDirs that are proper subdirectories of the source root
+          // This prevents excluding all code when outDir points outside the source root or to the source root itself
+          if (tryRelativize(LGTM_SRC, odir) != null && !odir.equals(LGTM_SRC)) {
+            outDirs.add(odir);
+          }
         }
       } catch (Exception e) {
         // ignore malformed tsconfig or missing fields

--- a/javascript/extractor/test/com/semmle/js/extractor/test/AutoBuildTests.java
+++ b/javascript/extractor/test/com/semmle/js/extractor/test/AutoBuildTests.java
@@ -266,6 +266,21 @@ public class AutoBuildTests {
   }
 
   @Test
+  public void skipFilesInTsconfigOutDirWithRelativePath() throws IOException {
+    // Test that outDir with relative path "somedir/.." (resolves to root) is ignored
+    addFile(true, LGTM_SRC, "tsconfig.json");
+    Path config = Paths.get(LGTM_SRC.toString(), "tsconfig.json");
+    Files.write(config,
+        "{\"compilerOptions\":{\"outDir\":\"somedir/..\"}}".getBytes(StandardCharsets.UTF_8));
+
+    // All files should be extracted since outDir resolving to root should be ignored
+    addFile(true, LGTM_SRC, "src", "app.ts");
+    addFile(true, LGTM_SRC, "main.js");
+
+    runTest();
+  }
+
+  @Test
   public void includeFile() throws IOException {
     envVars.put("LGTM_INDEX_INCLUDE", "tst.js");
     addFile(true, LGTM_SRC, "tst.js");

--- a/javascript/extractor/test/com/semmle/js/extractor/test/AutoBuildTests.java
+++ b/javascript/extractor/test/com/semmle/js/extractor/test/AutoBuildTests.java
@@ -236,6 +236,36 @@ public class AutoBuildTests {
   }
 
   @Test
+  public void skipFilesInTsconfigOutDirPointingToParent() throws IOException {
+    // Test that outDir pointing to parent directory (outside source root) is ignored
+    addFile(true, LGTM_SRC, "tsconfig.json");
+    Path config = Paths.get(LGTM_SRC.toString(), "tsconfig.json");
+    Files.write(config,
+        "{\"compilerOptions\":{\"outDir\":\"..\"}}".getBytes(StandardCharsets.UTF_8));
+
+    // All files should be extracted since outDir pointing outside source root should be ignored
+    addFile(true, LGTM_SRC, "src", "app.ts");
+    addFile(true, LGTM_SRC, "main.js");
+
+    runTest();
+  }
+
+  @Test
+  public void skipFilesInTsconfigOutDirPointingToSourceRoot() throws IOException {
+    // Test that outDir pointing to source root itself is ignored
+    addFile(true, LGTM_SRC, "tsconfig.json");
+    Path config = Paths.get(LGTM_SRC.toString(), "tsconfig.json");
+    Files.write(config,
+        "{\"compilerOptions\":{\"outDir\":\".\"}}".getBytes(StandardCharsets.UTF_8));
+
+    // All files should be extracted since outDir pointing to source root should be ignored
+    addFile(true, LGTM_SRC, "src", "app.ts");
+    addFile(true, LGTM_SRC, "main.js");
+
+    runTest();
+  }
+
+  @Test
   public void includeFile() throws IOException {
     envVars.put("LGTM_INDEX_INCLUDE", "tst.js");
     addFile(true, LGTM_SRC, "tst.js");

--- a/javascript/ql/lib/change-notes/2025-07-11-ignore-outdirs-that-would-exclude-everything.md
+++ b/javascript/ql/lib/change-notes/2025-07-11-ignore-outdirs-that-would-exclude-everything.md
@@ -1,0 +1,4 @@
+---
+category: fix
+---
+* The JavaScript extractor no longer ignores source files specified in the `tsconfig.json` compiler options `outDir` if doing so would result in excluding all source code.


### PR DESCRIPTION
In https://github.com/github/codeql/pull/19680 we added support for automatically ignoring files in the `outDir` directory as specified in the TSconfig compiler options (as these files were likely duplicates of `.ts` file we were already scanning).

However, in some cases people put `outDir: "."` or even `outDir: ".."` in their configuration, which had the side effect of excluding _all_ files, leading to a failed extraction.

With the changes in this PR, we now ignore any `outDir`s that are not  properly contained within the source root of the code being scanned. This should prevent the files from being extracted, while still allowing us to not double-scan files in, say, a `.github` directory, as seen in some Actions workflows.