### PR TITLE
Kotlin: Update regex patterns to use raw string notation

### DIFF
--- a/java/kotlin-extractor/generate_dbscheme.py
+++ b/java/kotlin-extractor/generate_dbscheme.py
@@ -35,10 +35,10 @@ def parse_dbscheme(filename):
         unions[name] = typs
 
     # tables
-    for relname, body in re.findall('\n([\w_]+)(\([^)]*\))',
+    for relname, body in re.findall(r'\n([\w_]+)(\([^)]*\))',
                                     dbscheme,
                                     flags=re.DOTALL):
-        columns = list(re.findall('(\S+)\s*:\s*([^\s,]+)(?:\s+(ref)|)', body))
+        columns = list(re.findall(r'(\S+)\s*:\s*([^\s,]+)(?:\s+(ref)|)', body))
         tables[relname] = columns
 
 parse_dbscheme(dbscheme)


### PR DESCRIPTION

This PR updates the regex patterns to utilize raw string notation, which resolves warnings related to invalid escape sequences, such as '\S'.
