### PR TITLE
Kotlin: tweak plugin test

### DIFF
--- a/java/ql/integration-tests/kotlin/linux/custom_plugin/plugin/BUILD.bazel
+++ b/java/ql/integration-tests/kotlin/linux/custom_plugin/plugin/BUILD.bazel
@@ -17,7 +17,10 @@ kt_jvm_library(
     srcs = ["Plugin.kt"],
     kotlinc_opts = ":kotlinc-options",
     module_name = "test",
-    resource_strip_prefix = "%s/resources" % package_name(),
+    resource_strip_prefix = "../%s/%s/resources" % (
+        repo_name(),
+        package_name(),
+    ),
     resources = glob(["resources/**"]),
     deps = [
         "@kotlin-compiler-%s" % _version,

--- a/java/ql/integration-tests/kotlin/linux/custom_plugin/test.py
+++ b/java/ql/integration-tests/kotlin/linux/custom_plugin/test.py
@@ -15,6 +15,7 @@ def test(codeql, java_full, cwd, semmle_code_dir, test_dir):
             "@codeql//java/ql/integration-tests/kotlin/linux/custom_plugin/plugin",
         ],
         _cwd=semmle_code_dir,
+        _env={"CODEQL_BAZEL_REMOTE_CACHE": "false"},
     )
     shutil.copy(
         f"{semmle_code_dir}/bazel-bin/external/ql+/java/ql/integration-tests/kotlin/linux/custom_plugin/plugin/plugin.jar",

--- a/java/ql/integration-tests/kotlin/linux/custom_plugin/test.py
+++ b/java/ql/integration-tests/kotlin/linux/custom_plugin/test.py
@@ -10,20 +10,14 @@ def test(codeql, java_full, cwd, semmle_code_dir, test_dir):
     commands.run(
         [
             f"{semmle_code_dir}/tools/bazel",
-            f"--output_user_root={build_dir}",
             "--max_idle_secs=1",
             "build",
-            "//java/ql/integration-tests/kotlin/linux/custom_plugin/plugin",
-            "--spawn_strategy=local",
-            "--nouse_action_cache",
-            "--noremote_accept_cached",
-            "--noremote_upload_local_results",
-            f'--symlink_prefix={cwd / "bazel-"}',
+            "@codeql//java/ql/integration-tests/kotlin/linux/custom_plugin/plugin",
         ],
-        _cwd=test_dir,
+        _cwd=semmle_code_dir,
     )
     shutil.copy(
-        "bazel-bin/java/ql/integration-tests/kotlin/linux/custom_plugin/plugin/plugin.jar",
+        f"{semmle_code_dir}/bazel-bin/external/ql+/java/ql/integration-tests/kotlin/linux/custom_plugin/plugin/plugin.jar",
         "plugin.jar",
     )
     codeql.database.create(


### PR DESCRIPTION
Put less emphasis on plugin build isolation, to get a better DevEx out of it. The crux of the test is the database extraction part, not the plugin build.

The plugin build is now done from the internal repo, and reusing whatever cached things are there.