### PR TITLE
C++: Fix global variable dataflow FP

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
@@ -153,6 +153,10 @@ private predicate isGlobalDefImpl(
   GlobalLikeVariable v, IRFunction f, int indirection, int indirectionIndex
 ) {
   exists(VariableAddressInstruction vai |
+    // The right-hand side of an initialization of a global variable
+    // creates its own `IRFunction`. We don't want flow into that `IRFunction`
+    // since the variable is only initialized once.
+    not vai.getEnclosingFunction() = v and
     vai.getEnclosingIRFunction() = f and
     vai.getAstVariable() = v and
     isUse(_, _, vai, indirection, indirectionIndex) and

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-consistency.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-consistency.expected
@@ -6,9 +6,15 @@ uniqueEnclosingCallable
 | test.cpp:1126:33:1129:1 | {...} | Node should have one enclosing callable but has 0. |
 | test.cpp:1127:3:1127:13 | reads_input | Node should have one enclosing callable but has 0. |
 | test.cpp:1128:3:1128:21 | not_does_read_input | Node should have one enclosing callable but has 0. |
+| test.cpp:1158:18:1158:21 | call to sink | Node should have one enclosing callable but has 0. |
+| test.cpp:1158:18:1158:42 | ... , ... | Node should have one enclosing callable but has 0. |
+| test.cpp:1158:23:1158:31 | recursion | Node should have one enclosing callable but has 0. |
+| test.cpp:1158:35:1158:40 | call to source | Node should have one enclosing callable but has 0. |
 uniqueCallEnclosingCallable
 | test.cpp:864:47:864:54 | call to source | Call should have one enclosing callable but has 0. |
 | test.cpp:872:46:872:51 | call to source | Call should have one enclosing callable but has 0. |
+| test.cpp:1158:18:1158:21 | call to sink | Call should have one enclosing callable but has 0. |
+| test.cpp:1158:35:1158:40 | call to source | Call should have one enclosing callable but has 0. |
 uniqueType
 uniqueNodeLocation
 missingLocation

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test-source-sink.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test-source-sink.expected
@@ -327,7 +327,6 @@ irFlow
 | test.cpp:1117:27:1117:34 | call to source | test.cpp:1117:27:1117:34 | call to source |
 | test.cpp:1132:11:1132:16 | call to source | test.cpp:1121:8:1121:8 | x |
 | test.cpp:1138:17:1138:22 | call to source | test.cpp:1140:8:1140:18 | * ... |
-| test.cpp:1158:18:1158:42 | ... , ... | test.cpp:1158:23:1158:31 | recursion |
 | true_upon_entry.cpp:9:11:9:16 | call to source | true_upon_entry.cpp:13:8:13:8 | x |
 | true_upon_entry.cpp:17:11:17:16 | call to source | true_upon_entry.cpp:21:8:21:8 | x |
 | true_upon_entry.cpp:27:9:27:14 | call to source | true_upon_entry.cpp:29:8:29:8 | x |

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test-source-sink.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test-source-sink.expected
@@ -327,6 +327,7 @@ irFlow
 | test.cpp:1117:27:1117:34 | call to source | test.cpp:1117:27:1117:34 | call to source |
 | test.cpp:1132:11:1132:16 | call to source | test.cpp:1121:8:1121:8 | x |
 | test.cpp:1138:17:1138:22 | call to source | test.cpp:1140:8:1140:18 | * ... |
+| test.cpp:1158:18:1158:42 | ... , ... | test.cpp:1158:23:1158:31 | recursion |
 | true_upon_entry.cpp:9:11:9:16 | call to source | true_upon_entry.cpp:13:8:13:8 | x |
 | true_upon_entry.cpp:17:11:17:16 | call to source | true_upon_entry.cpp:21:8:21:8 | x |
 | true_upon_entry.cpp:27:9:27:14 | call to source | true_upon_entry.cpp:29:8:29:8 | x |

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
@@ -1155,4 +1155,4 @@ namespace conflation_regression {
   }
 }
 
-int recursion = (sink(recursion), source()); // $ SPURIOUS: ir
+int recursion = (sink(recursion), source()); // clean

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
@@ -1154,3 +1154,5 @@ namespace conflation_regression {
     read_deref_deref(p);
   }
 }
+
+int recursion = (sink(recursion), source()); // $ SPURIOUS: ir


### PR DESCRIPTION
This PR fixes a very odd corner case of global dataflow through global variables.

Consider this snippet (which I've also added as a test):
```cpp
int recursion = (sink(recursion), source());
```
The IR we generate for this snippet is roughly equivalent to:
```cpp
void __initialize_recursion() {
  sink(recursion);
  recursion = source();
}
```
where `__recursion` represents the actual global variable. Since this is an `IRFunction` just like any other `Function`, it gets an initial SSA definition of the global variables that it reads, and it gets a final SSA use of the global variables that it defines. So for the point-of-view of dataflow the function ends up looking like:
```cpp
void __initialize_recursion() {
  recursion = __initialize_global; // (3)
  sink(recursion); // (4)
  recursion = source(); // (1)
  __final_use(recursion); // (2)
}
```
where `__initialize_global` represents the initial SSA definition (a `InitialGlobalValue` node), and `__final_use(recursion)` represents the final SSA use (a `FinalGlobalValue` node).

And now global variable dataflow does its things and this happens:
1. A write to `recursion` at `// (1)` flows to the final SSA use at `// (2)`
2. A jump step causes flow from `// (2)` to the global dataflow node (a `GlobalLikeVariableNode`) for `recursion`
3. Another jump step from the global dataflow node for `recursion` to the initial SSA definition for `recursion` at `// (3)`
4. A normal flow step from `// (3)` to the use at `// (4)`.

But clearly we should not have flow in this case! So this PR fixes the FP by removing the `InitialGlobalValue` node for some global variable `v` at the entry for the `IRFunction` that initializes `v`.

I don't think this will ever happen on any real codebase. But since it was so easy to fix we might as well get this fix in 😄