### PR TITLE
Rust: Make rust/summary/query-sinks less noisy

### DIFF
--- a/rust/ql/src/queries/summary/QuerySinks.ql
+++ b/rust/ql/src/queries/summary/QuerySinks.ql
@@ -2,7 +2,8 @@
  * @name Query Sinks
  * @description Lists query sinks that are found in the database. Query sinks are flow sinks that
  *              are used as possible locations for query results. Cryptographic operations are
- *              excluded (see `rust/summary/cryptographic-operations` instead).
+ *              excluded (see `rust/summary/cryptographic-operations` instead), as are certain
+ *              sink types that are ubiquitous in most code.
  * @kind problem
  * @problem.severity info
  * @id rust/summary/query-sinks
@@ -13,6 +14,11 @@ import rust
 import codeql.rust.dataflow.DataFlow
 import codeql.rust.Concepts
 import Stats
+import codeql.rust.security.AccessInvalidPointerExtensions
+import codeql.rust.security.CleartextLoggingExtensions
 
 from QuerySink s
+where
+  not s instanceof AccessInvalidPointer::Sink and
+  not s instanceof CleartextLogging::Sink
 select s, "Sink for " + concat(s.getSinkType(), ", ") + "."


### PR DESCRIPTION
Make `rust/summary/query-sinks` less noisy.  This is the one used in the DCA meta queries output, and occasionally used ad-hoc to get a feel for a database - but it is *not* used in metrics (the counts produced by `rust/summary/query-sink-counts` and `rust/summary/summary-statistics` are not affected by this change).  Currently for both uses results for this query are typically clogged with dereference and logging sinks, which obscures and in the case of the DCA meta queries output can completely hide other more interesting results.