### PR TITLE
Java: Restrict results to source literals.

### DIFF
--- a/java/ql/src/Violations of Best Practice/SpecialCharactersInLiterals/NonExplicitControlAndWhitespaceCharsInLiterals.ql
+++ b/java/ql/src/Violations of Best Practice/SpecialCharactersInLiterals/NonExplicitControlAndWhitespaceCharsInLiterals.ql
@@ -23,6 +23,7 @@ class ReservedUnicodeInLiteral extends Literal {
 
   ReservedUnicodeInLiteral() {
     not this instanceof CharacterLiteral and
+    this.getCompilationUnit().fromSource() and
     exists(int codePoint |
       this.getLiteral().codePointAt(indexStart) = codePoint and
       (
@@ -45,6 +46,9 @@ where
   literal.getIndexStart() = charIndex and
   literal.getLiteral().codePointAt(charIndex) = codePoint and
   not literal.getEnclosingCallable() instanceof LikelyTestMethod and
+  // Kotlin extraction doesn't preserve the literal value so we can't distinguish
+  // between control characters and their escaped versions, so we exclude Kotlin
+  // to avoid false positives.
   not literal.getFile().isKotlinSourceFile()
 select literal,
   "Literal value contains control or non-printable whitespace character(s) starting with Unicode code point "


### PR DESCRIPTION
Some literals extracted from `.class` files can contain many control chars, which can cause this query to blow up. Those results are pretty useless, so we can simply exclude them.