### PR TITLE
C++: Reduce duplication in `cpp/uncontrolled-process-operation`

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-114/UncontrolledProcessOperation.ql
+++ b/cpp/ql/src/Security/CWE/CWE-114/UncontrolledProcessOperation.ql
@@ -23,7 +23,7 @@ predicate isProcessOperationExplanation(DataFlow::Node arg, string processOperat
   exists(int processOperationArg, FunctionCall call |
     isProcessOperationArgument(processOperation, processOperationArg) and
     call.getTarget().getName() = processOperation and
-    call.getArgument(processOperationArg) = [arg.asExpr(), arg.asIndirectExpr()]
+    call.getArgument(processOperationArg) = arg.asIndirectExpr()
   )
 }
 


### PR DESCRIPTION
Having both `asExpr()` and `asIndirectExpr()` doesn't appear to change any results. This was a leftover from back when we ported the default-taint-tracking queries over, and we still had a few remaining bugs in `asExpr` and `asIndirectExpr`, and probably some remaining pointer sources that needed to be converted to pointee sources.

I've manually verified that all the removed results from DCA are due to deduplication.