### PR TITLE
Make web.config match case insensitive

### DIFF
--- a/csharp/ql/lib/semmle/code/asp/WebConfig.qll
+++ b/csharp/ql/lib/semmle/code/asp/WebConfig.qll
@@ -8,14 +8,14 @@ import csharp
  * A `Web.config` file.
  */
 class WebConfigXml extends XmlFile {
-  WebConfigXml() { this.getName().matches("%Web.config") }
+  WebConfigXml() { this.getName().toLowerCase().matches("%web.config") }
 }
 
 /**
  * A `Web.config` transformation file.
  */
 class WebConfigReleaseTransformXml extends XmlFile {
-  WebConfigReleaseTransformXml() { this.getName().matches("%Web.Release.config") }
+  WebConfigReleaseTransformXml() { this.getName().toLowerCase().matches("%web.release.config") }
 }
 
 /** A `<configuration>` tag in an ASP.NET configuration file. */


### PR DESCRIPTION
Web.config files are case insensitive, at least on Windows hosts, and can be `web.config`, `Web.config`, or any variation. At the moment codeql is not scanning anything other than `Web.config`.