### PR TITLE
Java: allow the definition of `java/unsafe-deserialization` sinks using data extensions

### DIFF
--- a/java/ql/lib/change-notes/2025-07-16-models-as-data-unsafe-deserialization-sinks.md
+++ b/java/ql/lib/change-notes/2025-07-16-models-as-data-unsafe-deserialization-sinks.md
@@ -1,0 +1,4 @@
+---
+category: feature
+---
+* You can now add sinks for the query "Deserialization of user-controlled data" (`java/unsafe-deserialization`) using [data extensions](https://codeql.github.com/docs/codeql-language-guides/customizing-library-models-for-java-and-kotlin/#extensible-predicates-used-to-create-custom-models-in-java-and-kotlin) by extending `sinkModel` and using the kind "unsafe-deserialization". The existing sinks which do not require extra logic to determine if they are unsafe are now defined in this way.

--- a/java/ql/lib/change-notes/2025-07-16-unsafe-deserialization-sinks-deprecation.md
+++ b/java/ql/lib/change-notes/2025-07-16-unsafe-deserialization-sinks-deprecation.md
@@ -1,8 +1,8 @@
 ---
 category: deprecated
 ---
-* The module `semmle.code.java.frameworks.Castor` has been deprecated and will be removed in a future release, including its two classes `CastorUnmarshaller` and `CastorUnmarshalMethod`.
-* The module `semmle.code.java.frameworks.JYaml` has been deprecated and will be removed in a future release, including its two classes `JYamlLoader` and `JYamlLoaderUnsafeLoadMethod`.
+* The module `semmle.code.java.frameworks.Castor` has been deprecated and will be removed in a future release.
+* The module `semmle.code.java.frameworks.JYaml` has been deprecated and will be removed in a future release.
 * The classes `UnsafeHessianInputReadObjectMethod` and `BurlapInputReadObjectMethod` in the module `semmle.code.java.frameworks.HessianBurlap` have been deprecated and will be removed in a future release.
 * The class `YamlBeansReaderReadMethod` in the module `semmle.code.java.frameworks.YamlBeans` has been deprecated and will be removed in a future release.
 * The class `MethodApacheSerializationUtilsDeserialize` in the module `semmle.code.java.frameworks.apache.Lang` has been deprecated and will be removed in a future release.

--- a/java/ql/lib/change-notes/2025-07-16-unsafe-deserialization-sinks-deprecation.md
+++ b/java/ql/lib/change-notes/2025-07-16-unsafe-deserialization-sinks-deprecation.md
@@ -1,0 +1,8 @@
+---
+category: deprecated
+---
+* The module `semmle.code.java.frameworks.Castor` has been deprecated and will be removed in a future release, including its two classes `CastorUnmarshaller` and `CastorUnmarshalMethod`.
+* The module `semmle.code.java.frameworks.JYaml` has been deprecated and will be removed in a future release, including its two classes `JYamlLoader` and `JYamlLoaderUnsafeLoadMethod`.
+* The classes `UnsafeHessianInputReadObjectMethod` and `BurlapInputReadObjectMethod` in the module `semmle.code.java.frameworks.HessianBurlap` have been deprecated and will be removed in a future release.
+* The class `YamlBeansReaderReadMethod` in the module `semmle.code.java.frameworks.YamlBeans` has been deprecated and will be removed in a future release.
+* The class `MethodApacheSerializationUtilsDeserialize` in the module `semmle.code.java.frameworks.apache.Lang` has been deprecated and will be removed in a future release.

--- a/java/ql/lib/ext/com.alibaba.com.caucho.hessian.io.model.yml
+++ b/java/ql/lib/ext/com.alibaba.com.caucho.hessian.io.model.yml
@@ -1,0 +1,7 @@
+extensions:
+  - addsTo:
+      pack: codeql/java-all
+      extensible: sinkModel
+    data:
+      - ["com.alibaba.com.caucho.hessian.io", "AbstractHessianInput", True, "readObject", "", "", "Argument[this]", "unsafe-deserialization", "manual"]
+      - ["com.alibaba.com.caucho.hessian.io", "Hessian2StreamingInput", True, "readObject", "", "", "Argument[this]", "unsafe-deserialization", "manual"]

--- a/java/ql/lib/ext/com.caucho.burlap.io.model.yml
+++ b/java/ql/lib/ext/com.caucho.burlap.io.model.yml
@@ -1,0 +1,6 @@
+extensions:
+  - addsTo:
+      pack: codeql/java-all
+      extensible: sinkModel
+    data:
+      - ["com.caucho.burlap.io", "BurlapInput", True, "readObject", "", "", "Argument[this]", "unsafe-deserialization", "manual"]

--- a/java/ql/lib/ext/com.caucho.hessian.io.model.yml
+++ b/java/ql/lib/ext/com.caucho.hessian.io.model.yml
@@ -1,0 +1,7 @@
+extensions:
+  - addsTo:
+      pack: codeql/java-all
+      extensible: sinkModel
+    data:
+      - ["com.caucho.hessian.io", "AbstractHessianInput", True, "readObject", "", "", "Argument[this]", "unsafe-deserialization", "manual"]
+      - ["com.caucho.hessian.io", "Hessian2StreamingInput", True, "readObject", "", "", "Argument[this]", "unsafe-deserialization", "manual"]

--- a/java/ql/lib/ext/com.cedarsoftware.util.io.model.yml
+++ b/java/ql/lib/ext/com.cedarsoftware.util.io.model.yml
@@ -1,0 +1,7 @@
+extensions:
+  - addsTo:
+      pack: codeql/java-all
+      extensible: sinkModel
+    data:
+      - ["com.cedarsoftware.util.io", "JsonReader", False, "jsonToJava", "", "", "Argument[0]", "unsafe-deserialization", "manual"]
+      - ["com.cedarsoftware.util.io", "JsonReader", True, "readObject", "", "", "Argument[this]", "unsafe-deserialization", "manual"]

--- a/java/ql/lib/ext/com.esotericsoftware.yamlbeans.model.yml
+++ b/java/ql/lib/ext/com.esotericsoftware.yamlbeans.model.yml
@@ -1,0 +1,6 @@
+extensions:
+  - addsTo:
+      pack: codeql/java-all
+      extensible: sinkModel
+    data:
+      - ["com.esotericsoftware.yamlbeans", "YamlReader", True, "read", "", "", "Argument[this]", "unsafe-deserialization", "manual"]

--- a/java/ql/lib/ext/java.beans.model.yml
+++ b/java/ql/lib/ext/java.beans.model.yml
@@ -13,3 +13,8 @@ extensions:
       - ["java.beans", "PropertyEditor", "getValue", "()", "summary", "df-manual"] # needs to be modeled by regular CodeQL matching the get and set keys to reduce FPs
       - ["java.beans", "PropertyEditor", "setAsText", "()", "summary", "df-manual"] # needs to be modeled by regular CodeQL matching the get and set keys to reduce FPs
       - ["java.beans", "PropertyEditor", "setValue", "()", "summary", "df-manual"] # needs to be modeled by regular CodeQL matching the get and set keys to reduce FPs
+  - addsTo:
+      pack: codeql/java-all
+      extensible: sinkModel
+    data:
+      - ["java.beans", "XMLDecoder", True, "readObject", "()", "", "Argument[this]", "unsafe-deserialization", "manual"]

--- a/java/ql/lib/ext/org.apache.commons.lang.model.yml
+++ b/java/ql/lib/ext/org.apache.commons.lang.model.yml
@@ -5,3 +5,8 @@ extensions:
     data:
       - ["org.apache.commons.lang", "StringEscapeUtils", true, "escapeHtml", "(String)", "", "Argument[0]", "ReturnValue", "taint", "manual"]
       - ["org.apache.commons.lang", "StringEscapeUtils", true, "escapeHtml", "(Writer,String)", "", "Argument[1]", "Argument[0]", "taint", "manual"]
+  - addsTo:
+      pack: codeql/java-all
+      extensible: sinkModel
+    data:
+      - ["org.apache.commons.lang", "SerializationUtils", False, "deserialize", "", "", "Argument[0]", "unsafe-deserialization", "manual"]

--- a/java/ql/lib/ext/org.apache.commons.lang3.model.yml
+++ b/java/ql/lib/ext/org.apache.commons.lang3.model.yml
@@ -3,6 +3,7 @@ extensions:
       pack: codeql/java-all
       extensible: sinkModel
     data:
+      - ["org.apache.commons.lang3", "SerializationUtils", False, "deserialize", "", "", "Argument[0]", "unsafe-deserialization", "manual"]
       # Note these sinks do not use the sink kind `regex-use[0]` because the regex injection query needs to select them separately from
       # other `regex-use[0]` sinks in order to avoid FPs. As a result, these sinks are currently not used in the polynomial ReDoS query.
       # TODO: refactor the `regex-use%` sink kind so that the polynomial ReDoS query can also use these sinks.

--- a/java/ql/lib/ext/org.exolab.castor.xml.model.yml
+++ b/java/ql/lib/ext/org.exolab.castor.xml.model.yml
@@ -1,0 +1,6 @@
+extensions:
+  - addsTo:
+      pack: codeql/java-all
+      extensible: sinkModel
+    data:
+      - ["org.exolab.castor.xml", "Unmarshaller", True, "unmarshal", "", "", "Argument[0..1]", "unsafe-deserialization", "manual"]

--- a/java/ql/lib/ext/org.ho.yaml.model.yml
+++ b/java/ql/lib/ext/org.ho.yaml.model.yml
@@ -1,0 +1,13 @@
+extensions:
+  - addsTo:
+      pack: codeql/java-all
+      extensible: sinkModel
+    data:
+      - ["org.ho.yaml", "Yaml", False, "load", "", "", "Argument[0]", "unsafe-deserialization", "manual"]
+      - ["org.ho.yaml", "Yaml", False, "loadStream", "", "", "Argument[0]", "unsafe-deserialization", "manual"]
+      - ["org.ho.yaml", "Yaml", False, "loadStreamOfType", "", "", "Argument[0]", "unsafe-deserialization", "manual"]
+      - ["org.ho.yaml", "Yaml", False, "loadType", "", "", "Argument[0]", "unsafe-deserialization", "manual"]
+      - ["org.ho.yaml", "YamlConfig", False, "load", "", "", "Argument[0]", "unsafe-deserialization", "manual"]
+      - ["org.ho.yaml", "YamlConfig", False, "loadStream", "", "", "Argument[0]", "unsafe-deserialization", "manual"]
+      - ["org.ho.yaml", "YamlConfig", False, "loadStreamOfType", "", "", "Argument[0]", "unsafe-deserialization", "manual"]
+      - ["org.ho.yaml", "YamlConfig", False, "loadType", "", "", "Argument[0]", "unsafe-deserialization", "manual"]

--- a/java/ql/lib/ext/org.jabsorb.model.yml
+++ b/java/ql/lib/ext/org.jabsorb.model.yml
@@ -1,0 +1,6 @@
+extensions:
+  - addsTo:
+      pack: codeql/java-all
+      extensible: sinkModel
+    data:
+      - ["org.jabsorb", "JSONSerializer", True, "fromJSON", "", "", "Argument[0]", "unsafe-deserialization", "manual"]

--- a/java/ql/lib/semmle/code/java/frameworks/Castor.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/Castor.qll
@@ -1,20 +1,28 @@
 /**
+ * DEPRECATED: Now modeled using data extensions instead.
+ *
  * Provides classes and predicates for working with the Castor framework.
  */
 overlay[local?]
-module;
+deprecated module;
 
 import java
 
 /**
+ * DEPRECATED: Now modeled using data extensions instead.
+ *
  * The class `org.exolab.castor.xml.Unmarshaller`.
  */
-class CastorUnmarshaller extends RefType {
+deprecated class CastorUnmarshaller extends RefType {
   CastorUnmarshaller() { this.hasQualifiedName("org.exolab.castor.xml", "Unmarshaller") }
 }
 
-/** A method with the name `unmarshal` declared in `org.exolab.castor.xml.Unmarshaller`. */
-class CastorUnmarshalMethod extends Method {
+/**
+ * DEPRECATED: Now modeled using data extensions instead.
+ *
+ * A method with the name `unmarshal` declared in `org.exolab.castor.xml.Unmarshaller`.
+ */
+deprecated class CastorUnmarshalMethod extends Method {
   CastorUnmarshalMethod() {
     this.getDeclaringType() instanceof CastorUnmarshaller and
     this.getName() = "unmarshal"

--- a/java/ql/lib/semmle/code/java/frameworks/Castor.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/Castor.qll
@@ -9,20 +9,16 @@ deprecated module;
 import java
 
 /**
- * DEPRECATED: Now modeled using data extensions instead.
- *
  * The class `org.exolab.castor.xml.Unmarshaller`.
  */
-deprecated class CastorUnmarshaller extends RefType {
+class CastorUnmarshaller extends RefType {
   CastorUnmarshaller() { this.hasQualifiedName("org.exolab.castor.xml", "Unmarshaller") }
 }
 
 /**
- * DEPRECATED: Now modeled using data extensions instead.
- *
  * A method with the name `unmarshal` declared in `org.exolab.castor.xml.Unmarshaller`.
  */
-deprecated class CastorUnmarshalMethod extends Method {
+class CastorUnmarshalMethod extends Method {
   CastorUnmarshalMethod() {
     this.getDeclaringType() instanceof CastorUnmarshaller and
     this.getName() = "unmarshal"

--- a/java/ql/lib/semmle/code/java/frameworks/HessianBurlap.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/HessianBurlap.qll
@@ -17,10 +17,12 @@ class UnsafeHessianInput extends RefType {
 }
 
 /**
+ * DEPRECATED: Now modeled using data extensions instead.
+ *
  * A AbstractHessianInput or Hessian2StreamingInput subclass readObject method.
  * This is either `AbstractHessianInput.readObject` or `Hessian2StreamingInput.readObject`.
  */
-class UnsafeHessianInputReadObjectMethod extends Method {
+deprecated class UnsafeHessianInputReadObjectMethod extends Method {
   UnsafeHessianInputReadObjectMethod() {
     this.getDeclaringType().getAnAncestor() instanceof UnsafeHessianInput and
     this.getName() = "readObject"
@@ -34,8 +36,12 @@ class BurlapInput extends RefType {
   BurlapInput() { this.hasQualifiedName("com.caucho.burlap.io", "BurlapInput") }
 }
 
-/** A method with the name `readObject` declared in `com.caucho.burlap.io.BurlapInput`. */
-class BurlapInputReadObjectMethod extends Method {
+/**
+ * DEPRECATED: Now modeled using data extensions instead.
+ *
+ *  A method with the name `readObject` declared in `com.caucho.burlap.io.BurlapInput`.
+ */
+deprecated class BurlapInputReadObjectMethod extends Method {
   BurlapInputReadObjectMethod() {
     this.getDeclaringType() instanceof BurlapInput and
     this.getName() = "readObject"

--- a/java/ql/lib/semmle/code/java/frameworks/JYaml.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/JYaml.qll
@@ -9,20 +9,16 @@ deprecated module;
 import java
 
 /**
- * DEPRECATED: Now modeled using data extensions instead.
- *
  * The class `org.ho.yaml.Yaml` or `org.ho.yaml.YamlConfig`.
  */
-deprecated class JYamlLoader extends RefType {
+class JYamlLoader extends RefType {
   JYamlLoader() { this.hasQualifiedName("org.ho.yaml", ["Yaml", "YamlConfig"]) }
 }
 
 /**
- * DEPRECATED: Now modeled using data extensions instead.
- *
  * A JYaml unsafe load method, declared on either `Yaml` or `YamlConfig`.
  */
-deprecated class JYamlLoaderUnsafeLoadMethod extends Method {
+class JYamlLoaderUnsafeLoadMethod extends Method {
   JYamlLoaderUnsafeLoadMethod() {
     this.getDeclaringType() instanceof JYamlLoader and
     this.getName() in ["load", "loadType", "loadStream", "loadStreamOfType"]

--- a/java/ql/lib/semmle/code/java/frameworks/JYaml.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/JYaml.qll
@@ -1,22 +1,28 @@
 /**
+ * DEPRECATED: Now modeled using data extensions instead.
+ *
  * Provides classes and predicates for working with the JYaml framework.
  */
 overlay[local?]
-module;
+deprecated module;
 
 import java
 
 /**
+ * DEPRECATED: Now modeled using data extensions instead.
+ *
  * The class `org.ho.yaml.Yaml` or `org.ho.yaml.YamlConfig`.
  */
-class JYamlLoader extends RefType {
+deprecated class JYamlLoader extends RefType {
   JYamlLoader() { this.hasQualifiedName("org.ho.yaml", ["Yaml", "YamlConfig"]) }
 }
 
 /**
+ * DEPRECATED: Now modeled using data extensions instead.
+ *
  * A JYaml unsafe load method, declared on either `Yaml` or `YamlConfig`.
  */
-class JYamlLoaderUnsafeLoadMethod extends Method {
+deprecated class JYamlLoaderUnsafeLoadMethod extends Method {
   JYamlLoaderUnsafeLoadMethod() {
     this.getDeclaringType() instanceof JYamlLoader and
     this.getName() in ["load", "loadType", "loadStream", "loadStreamOfType"]

--- a/java/ql/lib/semmle/code/java/frameworks/Jabsorb.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/Jabsorb.qll
@@ -19,8 +19,12 @@ class JabsorbUnmarshallMethod extends Method {
   }
 }
 
-/** The deserialization method `fromJSON`. */
-class JabsorbFromJsonMethod extends Method {
+/**
+ * DEPRECATED: Now modeled using data extensions instead.
+ *
+ * The deserialization method `fromJSON`.
+ */
+deprecated class JabsorbFromJsonMethod extends Method {
   JabsorbFromJsonMethod() {
     this.getDeclaringType().getAnAncestor() instanceof JabsorbSerializer and
     this.getName() = "fromJSON"

--- a/java/ql/lib/semmle/code/java/frameworks/YamlBeans.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/YamlBeans.qll
@@ -13,8 +13,12 @@ class YamlBeansReader extends RefType {
   YamlBeansReader() { this.hasQualifiedName("com.esotericsoftware.yamlbeans", "YamlReader") }
 }
 
-/** A method with the name `read` declared in `com.esotericsoftware.yamlbeans.YamlReader`. */
-class YamlBeansReaderReadMethod extends Method {
+/**
+ * DEPRECATED: Now modeled using data extensions instead.
+ *
+ * A method with the name `read` declared in `com.esotericsoftware.yamlbeans.YamlReader`.
+ */
+deprecated class YamlBeansReaderReadMethod extends Method {
   YamlBeansReaderReadMethod() {
     this.getDeclaringType() instanceof YamlBeansReader and
     this.getName() = "read"

--- a/java/ql/lib/semmle/code/java/frameworks/apache/Lang.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/apache/Lang.qll
@@ -16,10 +16,12 @@ class TypeApacheRandomStringUtils extends Class {
 }
 
 /**
+ * DEPRECATED: Now modeled using data extensions instead.
+ *
  * The method `deserialize` in either `org.apache.commons.lang.SerializationUtils`
  * or `org.apache.commons.lang3.SerializationUtils`.
  */
-class MethodApacheSerializationUtilsDeserialize extends Method {
+deprecated class MethodApacheSerializationUtilsDeserialize extends Method {
   MethodApacheSerializationUtilsDeserialize() {
     this.getDeclaringType()
         .hasQualifiedName(["org.apache.commons.lang", "org.apache.commons.lang3"],

--- a/java/ql/lib/semmle/code/java/security/UnsafeDeserializationQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/UnsafeDeserializationQuery.qll
@@ -3,17 +3,16 @@
  */
 
 import semmle.code.java.dataflow.FlowSources
+private import semmle.code.java.dataflow.ExternalFlow
 private import semmle.code.java.dataflow.FlowSinks
 private import semmle.code.java.dispatch.VirtualDispatch
 private import semmle.code.java.frameworks.Kryo
 private import semmle.code.java.frameworks.XStream
 private import semmle.code.java.frameworks.SnakeYaml
 private import semmle.code.java.frameworks.FastJson
-private import semmle.code.java.frameworks.JYaml
 private import semmle.code.java.frameworks.JsonIo
 private import semmle.code.java.frameworks.YamlBeans
 private import semmle.code.java.frameworks.HessianBurlap
-private import semmle.code.java.frameworks.Castor
 private import semmle.code.java.frameworks.Jackson
 private import semmle.code.java.frameworks.Jabsorb
 private import semmle.code.java.frameworks.Jms
@@ -149,8 +148,15 @@ private module SafeKryoConfig implements DataFlow::ConfigSig {
 
 private module SafeKryoFlow = DataFlow::Global<SafeKryoConfig>;
 
+private class DefaultUnsafeDeserializationSink extends DataFlow::Node {
+  DefaultUnsafeDeserializationSink() { sinkNode(this, "unsafe-deserialization") }
+}
+
 /**
  * Holds if `ma` is a call that deserializes data from `sink`.
+ *
+ * Note that this does not include deserialization methods that have been
+ * specified using models-as-data.
  */
 predicate unsafeDeserialization(MethodCall ma, Expr sink) {
   exists(Method m | m = ma.getMethod() |
@@ -162,9 +168,6 @@ predicate unsafeDeserialization(MethodCall ma, Expr sink) {
     sink = ma.getQualifier() and
     not DataFlow::exprNode(sink).getTypeBound() instanceof SafeObjectInputStreamType
     or
-    m instanceof XmlDecoderReadObjectMethod and
-    sink = ma.getQualifier()
-    or
     m instanceof XStreamReadObjectMethod and
     sink = ma.getAnArgument() and
     not SafeXStreamFlow::flowToExpr(ma.getQualifier())
@@ -173,32 +176,12 @@ predicate unsafeDeserialization(MethodCall ma, Expr sink) {
     sink = ma.getAnArgument() and
     not SafeKryoFlow::flowToExpr(ma.getQualifier())
     or
-    m instanceof MethodApacheSerializationUtilsDeserialize and
-    sink = ma.getArgument(0)
-    or
     ma instanceof UnsafeSnakeYamlParse and
     sink = ma.getArgument(0)
     or
     ma.getMethod() instanceof FastJsonParseMethod and
     not fastJsonLooksSafe() and
     sink = ma.getArgument(0)
-    or
-    ma.getMethod() instanceof JYamlLoaderUnsafeLoadMethod and
-    sink = ma.getArgument(0)
-    or
-    ma.getMethod() instanceof JsonIoJsonToJavaMethod and
-    sink = ma.getArgument(0)
-    or
-    ma.getMethod() instanceof JsonIoReadObjectMethod and
-    sink = ma.getQualifier()
-    or
-    ma.getMethod() instanceof YamlBeansReaderReadMethod and sink = ma.getQualifier()
-    or
-    ma.getMethod() instanceof UnsafeHessianInputReadObjectMethod and sink = ma.getQualifier()
-    or
-    ma.getMethod() instanceof CastorUnmarshalMethod and sink = ma.getAnArgument()
-    or
-    ma.getMethod() instanceof BurlapInputReadObjectMethod and sink = ma.getQualifier()
     or
     ma.getMethod() instanceof ObjectMapperReadMethod and
     sink = ma.getArgument(0) and
@@ -214,9 +197,6 @@ predicate unsafeDeserialization(MethodCall ma, Expr sink) {
     m instanceof JabsorbUnmarshallMethod and
     sink = ma.getArgument(2) and
     UnsafeTypeFlow::flowToExpr(ma.getArgument(1))
-    or
-    m instanceof JabsorbFromJsonMethod and
-    sink = ma.getArgument(0)
     or
     m instanceof JoddJsonParseMethod and
     sink = ma.getArgument(0) and
@@ -244,10 +224,17 @@ predicate unsafeDeserialization(MethodCall ma, Expr sink) {
 
 /** A sink for unsafe deserialization. */
 class UnsafeDeserializationSink extends ApiSinkNode, DataFlow::ExprNode {
-  UnsafeDeserializationSink() { unsafeDeserialization(_, this.getExpr()) }
+  MethodCall mc;
+
+  UnsafeDeserializationSink() {
+    unsafeDeserialization(mc, this.getExpr())
+    or
+    this instanceof DefaultUnsafeDeserializationSink and
+    this.getExpr() = [mc.getQualifier(), mc.getAnArgument()]
+  }
 
   /** Gets a call that triggers unsafe deserialization. */
-  MethodCall getMethodCall() { unsafeDeserialization(result, this.getExpr()) }
+  MethodCall getMethodCall() { result = mc }
 }
 
 /** Holds if `node` is a sanitizer for unsafe deserialization */

--- a/java/ql/lib/semmle/code/java/security/UnsafeDeserializationQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/UnsafeDeserializationQuery.qll
@@ -50,13 +50,6 @@ private class SafeObjectInputStreamType extends RefType {
   }
 }
 
-private class XmlDecoderReadObjectMethod extends Method {
-  XmlDecoderReadObjectMethod() {
-    this.getDeclaringType().hasQualifiedName("java.beans", "XMLDecoder") and
-    this.hasName("readObject")
-  }
-}
-
 private module SafeXStreamConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node src) {
     any(XStreamEnableWhiteListing ma).getQualifier().(VarAccess).getVariable().getAnAccess() =

--- a/java/ql/test/query-tests/security/CWE-502/UnsafeDeserialization.expected
+++ b/java/ql/test/query-tests/security/CWE-502/UnsafeDeserialization.expected
@@ -74,119 +74,121 @@
 | ParcelableEntity.java:32:30:32:70 | fromJson(...) | GsonActivity.java:15:54:15:64 | getIntent(...) : Intent | ParcelableEntity.java:32:44:32:62 | readString(...) | Unsafe deserialization depends on a $@. | GsonActivity.java:15:54:15:64 | getIntent(...) | user-provided value |
 | TestMessageBodyReader.java:22:18:22:65 | readObject(...) | TestMessageBodyReader.java:20:55:20:78 | entityStream : InputStream | TestMessageBodyReader.java:22:18:22:52 | new ObjectInputStream(...) | Unsafe deserialization depends on a $@. | TestMessageBodyReader.java:20:55:20:78 | entityStream | user-provided value |
 edges
-| A.java:17:31:17:51 | getInputStream(...) : InputStream | A.java:18:50:18:60 | inputStream : InputStream | provenance | Src:MaD:1  |
-| A.java:17:31:17:51 | getInputStream(...) : InputStream | A.java:19:12:19:13 | in | provenance | Src:MaD:1 inputStreamWrapper |
+| A.java:17:31:17:51 | getInputStream(...) : InputStream | A.java:18:50:18:60 | inputStream : InputStream | provenance | Src:MaD:17  |
+| A.java:17:31:17:51 | getInputStream(...) : InputStream | A.java:19:12:19:13 | in | provenance | Src:MaD:17 inputStreamWrapper |
 | A.java:18:28:18:61 | new ObjectInputStream(...) : ObjectInputStream | A.java:19:12:19:13 | in | provenance |  |
-| A.java:18:50:18:60 | inputStream : InputStream | A.java:18:28:18:61 | new ObjectInputStream(...) : ObjectInputStream | provenance | MaD:13 |
-| A.java:23:31:23:55 | getTaintedObjectInput(...) : ObjectInput | A.java:24:12:24:22 | objectInput | provenance | Src:MaD:5  |
-| A.java:28:33:28:59 | getTaintedMyObjectInput(...) : MyObjectInput | A.java:29:12:29:22 | objectInput | provenance | Src:MaD:4  |
-| A.java:33:31:33:51 | getInputStream(...) : InputStream | A.java:34:50:34:60 | inputStream : InputStream | provenance | Src:MaD:1  |
-| A.java:33:31:33:51 | getInputStream(...) : InputStream | A.java:35:12:35:13 | in | provenance | Src:MaD:1 inputStreamWrapper |
+| A.java:18:50:18:60 | inputStream : InputStream | A.java:18:28:18:61 | new ObjectInputStream(...) : ObjectInputStream | provenance | MaD:29 |
+| A.java:23:31:23:55 | getTaintedObjectInput(...) : ObjectInput | A.java:24:12:24:22 | objectInput | provenance | Src:MaD:21  |
+| A.java:28:33:28:59 | getTaintedMyObjectInput(...) : MyObjectInput | A.java:29:12:29:22 | objectInput | provenance | Src:MaD:20  |
+| A.java:33:31:33:51 | getInputStream(...) : InputStream | A.java:34:50:34:60 | inputStream : InputStream | provenance | Src:MaD:17  |
+| A.java:33:31:33:51 | getInputStream(...) : InputStream | A.java:35:12:35:13 | in | provenance | Src:MaD:17 inputStreamWrapper |
 | A.java:34:28:34:61 | new ObjectInputStream(...) : ObjectInputStream | A.java:35:12:35:13 | in | provenance |  |
-| A.java:34:50:34:60 | inputStream : InputStream | A.java:34:28:34:61 | new ObjectInputStream(...) : ObjectInputStream | provenance | MaD:13 |
-| A.java:45:31:45:51 | getInputStream(...) : InputStream | A.java:46:35:46:45 | inputStream : InputStream | provenance | Src:MaD:1  |
-| A.java:46:20:46:46 | new XMLDecoder(...) : XMLDecoder | A.java:47:12:47:12 | d | provenance |  |
-| A.java:46:35:46:45 | inputStream : InputStream | A.java:46:20:46:46 | new XMLDecoder(...) : XMLDecoder | provenance | MaD:9 |
-| A.java:52:31:52:51 | getInputStream(...) : InputStream | A.java:53:43:53:53 | inputStream : InputStream | provenance | Src:MaD:1  |
+| A.java:34:50:34:60 | inputStream : InputStream | A.java:34:28:34:61 | new ObjectInputStream(...) : ObjectInputStream | provenance | MaD:29 |
+| A.java:45:31:45:51 | getInputStream(...) : InputStream | A.java:46:35:46:45 | inputStream : InputStream | provenance | Src:MaD:17  |
+| A.java:46:20:46:46 | new XMLDecoder(...) : XMLDecoder | A.java:47:12:47:12 | d | provenance | Sink:MaD:6 |
+| A.java:46:35:46:45 | inputStream : InputStream | A.java:46:20:46:46 | new XMLDecoder(...) : XMLDecoder | provenance | MaD:25 |
+| A.java:52:31:52:51 | getInputStream(...) : InputStream | A.java:53:43:53:53 | inputStream : InputStream | provenance | Src:MaD:17  |
 | A.java:53:21:53:54 | new InputStreamReader(...) : InputStreamReader | A.java:54:23:54:28 | reader | provenance |  |
-| A.java:53:43:53:53 | inputStream : InputStream | A.java:53:21:53:54 | new InputStreamReader(...) : InputStreamReader | provenance | MaD:12 |
+| A.java:53:43:53:53 | inputStream : InputStream | A.java:53:21:53:54 | new InputStreamReader(...) : InputStreamReader | provenance | MaD:28 |
 | A.java:59:19:59:50 | new Input(...) : Input | A.java:60:28:60:32 | input | provenance |  |
 | A.java:59:19:59:50 | new Input(...) : Input | A.java:61:34:61:38 | input | provenance |  |
 | A.java:59:19:59:50 | new Input(...) : Input | A.java:62:40:62:44 | input | provenance |  |
-| A.java:59:29:59:49 | getInputStream(...) : InputStream | A.java:59:19:59:50 | new Input(...) : Input | provenance | Src:MaD:1 MaD:7 |
-| A.java:80:25:80:45 | getInputStream(...) : InputStream | A.java:81:26:81:30 | input | provenance | Src:MaD:1  |
-| A.java:80:25:80:45 | getInputStream(...) : InputStream | A.java:82:30:82:34 | input | provenance | Src:MaD:1  |
-| A.java:80:25:80:45 | getInputStream(...) : InputStream | A.java:83:50:83:54 | input : InputStream | provenance | Src:MaD:1  |
-| A.java:80:25:80:45 | getInputStream(...) : InputStream | A.java:84:24:84:28 | input | provenance | Src:MaD:1  |
-| A.java:80:25:80:45 | getInputStream(...) : InputStream | A.java:85:46:85:50 | input : InputStream | provenance | Src:MaD:1  |
-| A.java:83:50:83:54 | input : InputStream | A.java:83:28:83:55 | new InputStreamReader(...) | provenance | MaD:12 |
-| A.java:85:46:85:50 | input : InputStream | A.java:85:24:85:51 | new InputStreamReader(...) | provenance | MaD:12 |
-| A.java:90:25:90:45 | getInputStream(...) : InputStream | A.java:91:26:91:30 | input | provenance | Src:MaD:1  |
-| A.java:90:25:90:45 | getInputStream(...) : InputStream | A.java:92:30:92:34 | input | provenance | Src:MaD:1  |
-| A.java:90:25:90:45 | getInputStream(...) : InputStream | A.java:93:50:93:54 | input : InputStream | provenance | Src:MaD:1  |
-| A.java:90:25:90:45 | getInputStream(...) : InputStream | A.java:94:24:94:28 | input | provenance | Src:MaD:1  |
-| A.java:90:25:90:45 | getInputStream(...) : InputStream | A.java:95:46:95:50 | input : InputStream | provenance | Src:MaD:1  |
-| A.java:93:50:93:54 | input : InputStream | A.java:93:28:93:55 | new InputStreamReader(...) | provenance | MaD:12 |
-| A.java:95:46:95:50 | input : InputStream | A.java:95:24:95:51 | new InputStreamReader(...) | provenance | MaD:12 |
-| A.java:110:25:110:45 | getInputStream(...) : InputStream | A.java:111:26:111:30 | input | provenance | Src:MaD:1  |
-| A.java:110:25:110:45 | getInputStream(...) : InputStream | A.java:112:30:112:34 | input | provenance | Src:MaD:1  |
-| A.java:110:25:110:45 | getInputStream(...) : InputStream | A.java:113:50:113:54 | input : InputStream | provenance | Src:MaD:1  |
-| A.java:110:25:110:45 | getInputStream(...) : InputStream | A.java:114:24:114:28 | input | provenance | Src:MaD:1  |
-| A.java:110:25:110:45 | getInputStream(...) : InputStream | A.java:115:46:115:50 | input : InputStream | provenance | Src:MaD:1  |
-| A.java:113:50:113:54 | input : InputStream | A.java:113:28:113:55 | new InputStreamReader(...) | provenance | MaD:12 |
-| A.java:115:46:115:50 | input : InputStream | A.java:115:24:115:51 | new InputStreamReader(...) | provenance | MaD:12 |
-| B.java:7:31:7:51 | getInputStream(...) : InputStream | B.java:8:29:8:39 | inputStream | provenance | Src:MaD:1  |
-| B.java:12:31:12:51 | getInputStream(...) : InputStream | B.java:14:5:14:15 | inputStream : InputStream | provenance | Src:MaD:1  |
-| B.java:14:5:14:15 | inputStream : InputStream | B.java:14:22:14:26 | bytes [post update] : byte[] | provenance | MaD:11 |
+| A.java:59:29:59:49 | getInputStream(...) : InputStream | A.java:59:19:59:50 | new Input(...) : Input | provenance | Src:MaD:17 MaD:23 |
+| A.java:80:25:80:45 | getInputStream(...) : InputStream | A.java:81:26:81:30 | input | provenance | Src:MaD:17  |
+| A.java:80:25:80:45 | getInputStream(...) : InputStream | A.java:82:30:82:34 | input | provenance | Src:MaD:17  |
+| A.java:80:25:80:45 | getInputStream(...) : InputStream | A.java:83:50:83:54 | input : InputStream | provenance | Src:MaD:17  |
+| A.java:80:25:80:45 | getInputStream(...) : InputStream | A.java:84:24:84:28 | input | provenance | Src:MaD:17  |
+| A.java:80:25:80:45 | getInputStream(...) : InputStream | A.java:85:46:85:50 | input : InputStream | provenance | Src:MaD:17  |
+| A.java:83:50:83:54 | input : InputStream | A.java:83:28:83:55 | new InputStreamReader(...) | provenance | MaD:28 |
+| A.java:85:46:85:50 | input : InputStream | A.java:85:24:85:51 | new InputStreamReader(...) | provenance | MaD:28 |
+| A.java:90:25:90:45 | getInputStream(...) : InputStream | A.java:91:26:91:30 | input | provenance | Src:MaD:17  |
+| A.java:90:25:90:45 | getInputStream(...) : InputStream | A.java:92:30:92:34 | input | provenance | Src:MaD:17  |
+| A.java:90:25:90:45 | getInputStream(...) : InputStream | A.java:93:50:93:54 | input : InputStream | provenance | Src:MaD:17  |
+| A.java:90:25:90:45 | getInputStream(...) : InputStream | A.java:94:24:94:28 | input | provenance | Src:MaD:17  |
+| A.java:90:25:90:45 | getInputStream(...) : InputStream | A.java:95:46:95:50 | input : InputStream | provenance | Src:MaD:17  |
+| A.java:93:50:93:54 | input : InputStream | A.java:93:28:93:55 | new InputStreamReader(...) | provenance | MaD:28 |
+| A.java:95:46:95:50 | input : InputStream | A.java:95:24:95:51 | new InputStreamReader(...) | provenance | MaD:28 |
+| A.java:110:25:110:45 | getInputStream(...) : InputStream | A.java:111:26:111:30 | input | provenance | Src:MaD:17  |
+| A.java:110:25:110:45 | getInputStream(...) : InputStream | A.java:112:30:112:34 | input | provenance | Src:MaD:17  |
+| A.java:110:25:110:45 | getInputStream(...) : InputStream | A.java:113:50:113:54 | input : InputStream | provenance | Src:MaD:17  |
+| A.java:110:25:110:45 | getInputStream(...) : InputStream | A.java:114:24:114:28 | input | provenance | Src:MaD:17  |
+| A.java:110:25:110:45 | getInputStream(...) : InputStream | A.java:115:46:115:50 | input : InputStream | provenance | Src:MaD:17  |
+| A.java:113:50:113:54 | input : InputStream | A.java:113:28:113:55 | new InputStreamReader(...) | provenance | MaD:28 |
+| A.java:115:46:115:50 | input : InputStream | A.java:115:24:115:51 | new InputStreamReader(...) | provenance | MaD:28 |
+| B.java:7:31:7:51 | getInputStream(...) : InputStream | B.java:8:29:8:39 | inputStream | provenance | Src:MaD:17  |
+| B.java:12:31:12:51 | getInputStream(...) : InputStream | B.java:14:5:14:15 | inputStream : InputStream | provenance | Src:MaD:17  |
+| B.java:14:5:14:15 | inputStream : InputStream | B.java:14:22:14:26 | bytes [post update] : byte[] | provenance | MaD:27 |
 | B.java:14:22:14:26 | bytes [post update] : byte[] | B.java:15:23:15:27 | bytes | provenance |  |
-| B.java:19:31:19:51 | getInputStream(...) : InputStream | B.java:21:5:21:15 | inputStream : InputStream | provenance | Src:MaD:1  |
-| B.java:21:5:21:15 | inputStream : InputStream | B.java:21:22:21:26 | bytes [post update] : byte[] | provenance | MaD:11 |
+| B.java:19:31:19:51 | getInputStream(...) : InputStream | B.java:21:5:21:15 | inputStream : InputStream | provenance | Src:MaD:17  |
+| B.java:21:5:21:15 | inputStream : InputStream | B.java:21:22:21:26 | bytes [post update] : byte[] | provenance | MaD:27 |
 | B.java:21:22:21:26 | bytes [post update] : byte[] | B.java:22:27:22:31 | bytes : byte[] | provenance |  |
 | B.java:22:16:22:32 | new String(...) : String | B.java:23:29:23:29 | s | provenance |  |
-| B.java:22:27:22:31 | bytes : byte[] | B.java:22:16:22:32 | new String(...) : String | provenance | MaD:15 |
-| B.java:27:31:27:51 | getInputStream(...) : InputStream | B.java:29:5:29:15 | inputStream : InputStream | provenance | Src:MaD:1  |
-| B.java:29:5:29:15 | inputStream : InputStream | B.java:29:22:29:26 | bytes [post update] : byte[] | provenance | MaD:11 |
+| B.java:22:27:22:31 | bytes : byte[] | B.java:22:16:22:32 | new String(...) : String | provenance | MaD:31 |
+| B.java:27:31:27:51 | getInputStream(...) : InputStream | B.java:29:5:29:15 | inputStream : InputStream | provenance | Src:MaD:17  |
+| B.java:29:5:29:15 | inputStream : InputStream | B.java:29:22:29:26 | bytes [post update] : byte[] | provenance | MaD:27 |
 | B.java:29:22:29:26 | bytes [post update] : byte[] | B.java:30:27:30:31 | bytes : byte[] | provenance |  |
 | B.java:30:16:30:32 | new String(...) : String | B.java:31:23:31:23 | s | provenance |  |
-| B.java:30:27:30:31 | bytes : byte[] | B.java:30:16:30:32 | new String(...) : String | provenance | MaD:15 |
-| C.java:23:17:23:44 | getParameter(...) : String | C.java:24:13:24:16 | data | provenance | Src:MaD:3  |
-| C.java:23:17:23:44 | getParameter(...) : String | C.java:25:19:25:22 | data | provenance | Src:MaD:3  |
-| C.java:23:17:23:44 | getParameter(...) : String | C.java:26:25:26:28 | data | provenance | Src:MaD:3  |
-| C.java:23:17:23:44 | getParameter(...) : String | C.java:27:17:27:20 | data | provenance | Src:MaD:3  |
-| C.java:23:17:23:44 | getParameter(...) : String | C.java:30:19:30:22 | data | provenance | Src:MaD:3  |
-| C.java:23:17:23:44 | getParameter(...) : String | C.java:31:25:31:28 | data | provenance | Src:MaD:3  |
-| C.java:23:17:23:44 | getParameter(...) : String | C.java:32:31:32:34 | data | provenance | Src:MaD:3  |
-| C.java:23:17:23:44 | getParameter(...) : String | C.java:33:23:33:26 | data | provenance | Src:MaD:3  |
-| C.java:38:17:38:44 | getParameter(...) : String | C.java:43:25:43:28 | data | provenance | Src:MaD:3  |
-| C.java:38:17:38:44 | getParameter(...) : String | C.java:45:34:45:37 | data : String | provenance | Src:MaD:3  |
-| C.java:45:19:45:44 | new JsonReader(...) : JsonReader | C.java:46:3:46:4 | jr | provenance |  |
+| B.java:30:27:30:31 | bytes : byte[] | B.java:30:16:30:32 | new String(...) : String | provenance | MaD:31 |
+| C.java:23:17:23:44 | getParameter(...) : String | C.java:24:13:24:16 | data | provenance | Src:MaD:19 Sink:MaD:8 |
+| C.java:23:17:23:44 | getParameter(...) : String | C.java:25:19:25:22 | data | provenance | Src:MaD:19 Sink:MaD:9 |
+| C.java:23:17:23:44 | getParameter(...) : String | C.java:26:25:26:28 | data | provenance | Src:MaD:19 Sink:MaD:10 |
+| C.java:23:17:23:44 | getParameter(...) : String | C.java:27:17:27:20 | data | provenance | Src:MaD:19 Sink:MaD:11 |
+| C.java:23:17:23:44 | getParameter(...) : String | C.java:30:19:30:22 | data | provenance | Src:MaD:19 Sink:MaD:12 |
+| C.java:23:17:23:44 | getParameter(...) : String | C.java:31:25:31:28 | data | provenance | Src:MaD:19 Sink:MaD:13 |
+| C.java:23:17:23:44 | getParameter(...) : String | C.java:32:31:32:34 | data | provenance | Src:MaD:19 Sink:MaD:14 |
+| C.java:23:17:23:44 | getParameter(...) : String | C.java:33:23:33:26 | data | provenance | Src:MaD:19 Sink:MaD:15 |
+| C.java:38:17:38:44 | getParameter(...) : String | C.java:43:25:43:28 | data | provenance | Src:MaD:19 Sink:MaD:3 |
+| C.java:38:17:38:44 | getParameter(...) : String | C.java:45:34:45:37 | data : String | provenance | Src:MaD:19  |
+| C.java:45:19:45:44 | new JsonReader(...) : JsonReader | C.java:46:3:46:4 | jr | provenance | Sink:MaD:4 |
 | C.java:45:34:45:37 | data : String | C.java:45:19:45:44 | new JsonReader(...) : JsonReader | provenance | Config |
-| C.java:51:17:51:44 | getParameter(...) : String | C.java:52:33:52:36 | data : String | provenance | Src:MaD:3  |
-| C.java:52:18:52:37 | new YamlReader(...) : YamlReader | C.java:53:3:53:3 | r | provenance |  |
-| C.java:52:18:52:37 | new YamlReader(...) : YamlReader | C.java:54:3:54:3 | r | provenance |  |
-| C.java:52:18:52:37 | new YamlReader(...) : YamlReader | C.java:55:3:55:3 | r | provenance |  |
+| C.java:51:17:51:44 | getParameter(...) : String | C.java:52:33:52:36 | data : String | provenance | Src:MaD:19  |
+| C.java:52:18:52:37 | new YamlReader(...) : YamlReader | C.java:53:3:53:3 | r | provenance | Sink:MaD:5 |
+| C.java:52:18:52:37 | new YamlReader(...) : YamlReader | C.java:54:3:54:3 | r | provenance | Sink:MaD:5 |
+| C.java:52:18:52:37 | new YamlReader(...) : YamlReader | C.java:55:3:55:3 | r | provenance | Sink:MaD:5 |
 | C.java:52:33:52:36 | data : String | C.java:52:18:52:37 | new YamlReader(...) : YamlReader | provenance | Config |
-| C.java:60:18:60:45 | getParameter(...) : String | C.java:60:18:60:56 | getBytes(...) : byte[] | provenance | Src:MaD:3 MaD:16 |
+| C.java:60:18:60:45 | getParameter(...) : String | C.java:60:18:60:56 | getBytes(...) : byte[] | provenance | Src:MaD:19 MaD:32 |
 | C.java:60:18:60:56 | getBytes(...) : byte[] | C.java:61:55:61:59 | bytes : byte[] | provenance |  |
 | C.java:60:18:60:56 | getBytes(...) : byte[] | C.java:62:48:62:50 | bis : ByteArrayInputStream | provenance | inputStreamWrapper |
 | C.java:61:30:61:60 | new ByteArrayInputStream(...) : ByteArrayInputStream | C.java:62:48:62:50 | bis : ByteArrayInputStream | provenance |  |
-| C.java:61:55:61:59 | bytes : byte[] | C.java:61:30:61:60 | new ByteArrayInputStream(...) : ByteArrayInputStream | provenance | MaD:10 |
-| C.java:62:31:62:51 | new HessianInput(...) : HessianInput | C.java:63:3:63:14 | hessianInput | provenance |  |
-| C.java:62:31:62:51 | new HessianInput(...) : HessianInput | C.java:64:3:64:14 | hessianInput | provenance |  |
+| C.java:61:55:61:59 | bytes : byte[] | C.java:61:30:61:60 | new ByteArrayInputStream(...) : ByteArrayInputStream | provenance | MaD:26 |
+| C.java:62:31:62:51 | new HessianInput(...) : HessianInput | C.java:63:3:63:14 | hessianInput | provenance | Sink:MaD:2 |
+| C.java:62:31:62:51 | new HessianInput(...) : HessianInput | C.java:64:3:64:14 | hessianInput | provenance | Sink:MaD:2 |
 | C.java:62:48:62:50 | bis : ByteArrayInputStream | C.java:62:31:62:51 | new HessianInput(...) : HessianInput | provenance | Config |
-| C.java:69:18:69:45 | getParameter(...) : String | C.java:69:18:69:56 | getBytes(...) : byte[] | provenance | Src:MaD:3 MaD:16 |
+| C.java:69:18:69:45 | getParameter(...) : String | C.java:69:18:69:56 | getBytes(...) : byte[] | provenance | Src:MaD:19 MaD:32 |
 | C.java:69:18:69:56 | getBytes(...) : byte[] | C.java:70:55:70:59 | bytes : byte[] | provenance |  |
 | C.java:69:18:69:56 | getBytes(...) : byte[] | C.java:71:50:71:52 | bis : ByteArrayInputStream | provenance | inputStreamWrapper |
 | C.java:70:30:70:60 | new ByteArrayInputStream(...) : ByteArrayInputStream | C.java:71:50:71:52 | bis : ByteArrayInputStream | provenance |  |
-| C.java:70:55:70:59 | bytes : byte[] | C.java:70:30:70:60 | new ByteArrayInputStream(...) : ByteArrayInputStream | provenance | MaD:10 |
-| C.java:71:32:71:53 | new Hessian2Input(...) : Hessian2Input | C.java:72:3:72:14 | hessianInput | provenance |  |
-| C.java:71:32:71:53 | new Hessian2Input(...) : Hessian2Input | C.java:73:3:73:14 | hessianInput | provenance |  |
+| C.java:70:55:70:59 | bytes : byte[] | C.java:70:30:70:60 | new ByteArrayInputStream(...) : ByteArrayInputStream | provenance | MaD:26 |
+| C.java:71:32:71:53 | new Hessian2Input(...) : Hessian2Input | C.java:72:3:72:14 | hessianInput | provenance | Sink:MaD:2 |
+| C.java:71:32:71:53 | new Hessian2Input(...) : Hessian2Input | C.java:73:3:73:14 | hessianInput | provenance | Sink:MaD:2 |
 | C.java:71:50:71:52 | bis : ByteArrayInputStream | C.java:71:32:71:53 | new Hessian2Input(...) : Hessian2Input | provenance | Config |
-| C.java:79:43:79:70 | getParameter(...) : String | C.java:79:26:79:71 | new StringReader(...) | provenance | Src:MaD:3 MaD:14 |
-| C.java:84:27:84:54 | getParameter(...) : String | C.java:84:27:84:65 | getBytes(...) : byte[] | provenance | Src:MaD:3 MaD:16 |
+| C.java:79:43:79:70 | getParameter(...) : String | C.java:79:26:79:71 | new StringReader(...) | provenance | Src:MaD:19 MaD:30 Sink:MaD:7 |
+| C.java:84:27:84:54 | getParameter(...) : String | C.java:84:27:84:65 | getBytes(...) : byte[] | provenance | Src:MaD:19 MaD:32 |
 | C.java:84:27:84:65 | getBytes(...) : byte[] | C.java:85:54:85:67 | serializedData : byte[] | provenance |  |
 | C.java:84:27:84:65 | getBytes(...) : byte[] | C.java:86:45:86:46 | is : ByteArrayInputStream | provenance | inputStreamWrapper |
 | C.java:85:29:85:68 | new ByteArrayInputStream(...) : ByteArrayInputStream | C.java:86:45:86:46 | is : ByteArrayInputStream | provenance |  |
-| C.java:85:54:85:67 | serializedData : byte[] | C.java:85:29:85:68 | new ByteArrayInputStream(...) : ByteArrayInputStream | provenance | MaD:10 |
-| C.java:86:29:86:47 | new BurlapInput(...) : BurlapInput | C.java:87:3:87:13 | burlapInput | provenance |  |
+| C.java:85:54:85:67 | serializedData : byte[] | C.java:85:29:85:68 | new ByteArrayInputStream(...) : ByteArrayInputStream | provenance | MaD:26 |
+| C.java:86:29:86:47 | new BurlapInput(...) : BurlapInput | C.java:87:3:87:13 | burlapInput | provenance | Sink:MaD:1 |
+| C.java:86:29:86:47 | new BurlapInput(...) : BurlapInput | C.java:87:3:87:13 | burlapInput | provenance | Sink:MaD:2 |
 | C.java:86:45:86:46 | is : ByteArrayInputStream | C.java:86:29:86:47 | new BurlapInput(...) : BurlapInput | provenance | Config |
 | C.java:86:45:86:46 | is : ByteArrayInputStream | C.java:90:21:90:22 | is : ByteArrayInputStream | provenance |  |
-| C.java:90:3:90:14 | burlapInput1 : BurlapInput | C.java:91:3:91:14 | burlapInput1 | provenance |  |
+| C.java:90:3:90:14 | burlapInput1 : BurlapInput | C.java:91:3:91:14 | burlapInput1 | provenance | Sink:MaD:1 |
+| C.java:90:3:90:14 | burlapInput1 : BurlapInput | C.java:91:3:91:14 | burlapInput1 | provenance | Sink:MaD:2 |
 | C.java:90:21:90:22 | is : ByteArrayInputStream | C.java:90:3:90:14 | burlapInput1 : BurlapInput | provenance | Config |
-| FlexjsonServlet.java:67:23:67:46 | getParameter(...) : String | FlexjsonServlet.java:68:127:68:130 | json | provenance | Src:MaD:3  |
-| FlexjsonServlet.java:79:23:79:46 | getParameter(...) : String | FlexjsonServlet.java:80:93:80:96 | json | provenance | Src:MaD:3  |
-| FlexjsonServlet.java:119:23:119:46 | getParameter(...) : String | FlexjsonServlet.java:124:50:124:53 | json | provenance | Src:MaD:3  |
+| FlexjsonServlet.java:67:23:67:46 | getParameter(...) : String | FlexjsonServlet.java:68:127:68:130 | json | provenance | Src:MaD:19  |
+| FlexjsonServlet.java:79:23:79:46 | getParameter(...) : String | FlexjsonServlet.java:80:93:80:96 | json | provenance | Src:MaD:19  |
+| FlexjsonServlet.java:119:23:119:46 | getParameter(...) : String | FlexjsonServlet.java:124:50:124:53 | json | provenance | Src:MaD:19  |
 | GsonActivity.java:15:54:15:64 | getIntent(...) : Intent | ParcelableEntity.java:29:50:29:62 | parcel : Parcel | provenance | Config |
-| GsonServlet.java:39:23:39:46 | getParameter(...) : String | GsonServlet.java:44:40:44:43 | json | provenance | Src:MaD:3  |
-| GsonServlet.java:53:23:53:46 | getParameter(...) : String | GsonServlet.java:60:40:60:43 | json | provenance | Src:MaD:3  |
-| JabsorbServlet.java:89:23:89:46 | getParameter(...) : String | JabsorbServlet.java:93:48:93:51 | json : String | provenance | Src:MaD:3  |
+| GsonServlet.java:39:23:39:46 | getParameter(...) : String | GsonServlet.java:44:40:44:43 | json | provenance | Src:MaD:19  |
+| GsonServlet.java:53:23:53:46 | getParameter(...) : String | GsonServlet.java:60:40:60:43 | json | provenance | Src:MaD:19  |
+| JabsorbServlet.java:89:23:89:46 | getParameter(...) : String | JabsorbServlet.java:93:48:93:51 | json : String | provenance | Src:MaD:19  |
 | JabsorbServlet.java:93:33:93:52 | new JSONObject(...) : JSONObject | JabsorbServlet.java:102:83:102:92 | jsonObject | provenance |  |
-| JabsorbServlet.java:93:48:93:51 | json : String | JabsorbServlet.java:93:33:93:52 | new JSONObject(...) : JSONObject | provenance | MaD:18 |
-| JabsorbServlet.java:110:23:110:46 | getParameter(...) : String | JabsorbServlet.java:116:52:116:55 | json | provenance | Src:MaD:3  |
-| JacksonTest.java:20:25:20:47 | getInputStream(...) : InputStream | JacksonTest.java:20:54:20:58 | bytes [post update] : byte[] | provenance | Src:MaD:1 MaD:11 |
+| JabsorbServlet.java:93:48:93:51 | json : String | JabsorbServlet.java:93:33:93:52 | new JSONObject(...) : JSONObject | provenance | MaD:34 |
+| JabsorbServlet.java:110:23:110:46 | getParameter(...) : String | JabsorbServlet.java:116:52:116:55 | json | provenance | Src:MaD:19 Sink:MaD:16 |
+| JacksonTest.java:20:25:20:47 | getInputStream(...) : InputStream | JacksonTest.java:20:54:20:58 | bytes [post update] : byte[] | provenance | Src:MaD:17 MaD:27 |
 | JacksonTest.java:20:54:20:58 | bytes [post update] : byte[] | JacksonTest.java:21:46:21:50 | bytes : byte[] | provenance |  |
 | JacksonTest.java:21:35:21:57 | new String(...) : String | JacksonTest.java:22:28:22:35 | jexlExpr : String | provenance |  |
-| JacksonTest.java:21:46:21:50 | bytes : byte[] | JacksonTest.java:21:35:21:57 | new String(...) : String | provenance | MaD:15 |
+| JacksonTest.java:21:46:21:50 | bytes : byte[] | JacksonTest.java:21:35:21:57 | new String(...) : String | provenance | MaD:31 |
 | JacksonTest.java:22:28:22:35 | jexlExpr : String | JacksonTest.java:74:32:74:37 | string : String | provenance |  |
 | JacksonTest.java:22:28:22:35 | jexlExpr : String | JacksonTest.java:83:32:83:37 | string : String | provenance |  |
 | JacksonTest.java:22:28:22:35 | jexlExpr : String | JacksonTest.java:92:32:92:37 | string : String | provenance |  |
@@ -201,45 +203,61 @@ edges
 | JacksonTest.java:139:32:139:37 | string : String | JacksonTest.java:142:30:142:35 | string | provenance |  |
 | JacksonTest.java:148:32:148:37 | string : String | JacksonTest.java:151:62:151:67 | string : String | provenance |  |
 | JacksonTest.java:151:62:151:67 | string : String | JacksonTest.java:151:31:151:68 | createParser(...) | provenance | Config |
-| JacksonTest.java:151:62:151:67 | string : String | JacksonTest.java:151:31:151:68 | createParser(...) | provenance | MaD:8 |
+| JacksonTest.java:151:62:151:67 | string : String | JacksonTest.java:151:31:151:68 | createParser(...) | provenance | MaD:24 |
 | JacksonTest.java:157:32:157:37 | string : String | JacksonTest.java:160:48:160:53 | string : String | provenance |  |
 | JacksonTest.java:160:48:160:53 | string : String | JacksonTest.java:160:32:160:54 | readTree(...) | provenance | Config |
 | JacksonTest.java:166:32:166:36 | input : String | JacksonTest.java:167:30:167:34 | input : String | provenance |  |
-| JacksonTest.java:167:30:167:34 | input : String | JacksonTest.java:167:30:167:45 | split(...) : String[] | provenance | MaD:17 |
+| JacksonTest.java:167:30:167:34 | input : String | JacksonTest.java:167:30:167:45 | split(...) : String[] | provenance | MaD:33 |
 | JacksonTest.java:167:30:167:45 | split(...) : String[] | JacksonTest.java:172:30:172:33 | data | provenance |  |
 | JacksonTest.java:178:32:178:36 | input : String | JacksonTest.java:179:30:179:34 | input : String | provenance |  |
-| JacksonTest.java:179:30:179:34 | input : String | JacksonTest.java:179:30:179:45 | split(...) : String[] | provenance | MaD:17 |
+| JacksonTest.java:179:30:179:34 | input : String | JacksonTest.java:179:30:179:45 | split(...) : String[] | provenance | MaD:33 |
 | JacksonTest.java:179:30:179:45 | split(...) : String[] | JacksonTest.java:183:30:183:33 | data | provenance |  |
-| JoddJsonServlet.java:32:23:32:46 | getParameter(...) : String | JoddJsonServlet.java:45:37:45:40 | json | provenance | Src:MaD:3  |
-| JoddJsonServlet.java:32:23:32:46 | getParameter(...) : String | JoddJsonServlet.java:47:56:47:59 | json | provenance | Src:MaD:3  |
-| JoddJsonServlet.java:32:23:32:46 | getParameter(...) : String | JoddJsonServlet.java:49:67:49:70 | json | provenance | Src:MaD:3  |
-| JoddJsonServlet.java:32:23:32:46 | getParameter(...) : String | JoddJsonServlet.java:51:61:51:64 | json | provenance | Src:MaD:3  |
-| JoddJsonServlet.java:58:23:58:46 | getParameter(...) : String | JoddJsonServlet.java:63:39:63:42 | json | provenance | Src:MaD:3  |
-| ObjectMessageTest.java:6:27:6:41 | message : Message | ObjectMessageTest.java:7:26:7:32 | message | provenance | Src:MaD:2  |
+| JoddJsonServlet.java:32:23:32:46 | getParameter(...) : String | JoddJsonServlet.java:45:37:45:40 | json | provenance | Src:MaD:19  |
+| JoddJsonServlet.java:32:23:32:46 | getParameter(...) : String | JoddJsonServlet.java:47:56:47:59 | json | provenance | Src:MaD:19  |
+| JoddJsonServlet.java:32:23:32:46 | getParameter(...) : String | JoddJsonServlet.java:49:67:49:70 | json | provenance | Src:MaD:19  |
+| JoddJsonServlet.java:32:23:32:46 | getParameter(...) : String | JoddJsonServlet.java:51:61:51:64 | json | provenance | Src:MaD:19  |
+| JoddJsonServlet.java:58:23:58:46 | getParameter(...) : String | JoddJsonServlet.java:63:39:63:42 | json | provenance | Src:MaD:19  |
+| ObjectMessageTest.java:6:27:6:41 | message : Message | ObjectMessageTest.java:7:26:7:32 | message | provenance | Src:MaD:18  |
 | ParcelableEntity.java:29:50:29:62 | parcel : Parcel | ParcelableEntity.java:32:44:32:49 | parcel : Parcel | provenance |  |
-| ParcelableEntity.java:32:44:32:49 | parcel : Parcel | ParcelableEntity.java:32:44:32:62 | readString(...) | provenance | MaD:6 |
+| ParcelableEntity.java:32:44:32:49 | parcel : Parcel | ParcelableEntity.java:32:44:32:62 | readString(...) | provenance | MaD:22 |
 | TestMessageBodyReader.java:20:55:20:78 | entityStream : InputStream | TestMessageBodyReader.java:22:18:22:52 | new ObjectInputStream(...) | provenance | inputStreamWrapper |
 | TestMessageBodyReader.java:20:55:20:78 | entityStream : InputStream | TestMessageBodyReader.java:22:40:22:51 | entityStream : InputStream | provenance |  |
-| TestMessageBodyReader.java:22:40:22:51 | entityStream : InputStream | TestMessageBodyReader.java:22:18:22:52 | new ObjectInputStream(...) | provenance | MaD:13 |
+| TestMessageBodyReader.java:22:40:22:51 | entityStream : InputStream | TestMessageBodyReader.java:22:18:22:52 | new ObjectInputStream(...) | provenance | MaD:29 |
 models
-| 1 | Source: java.net; Socket; false; getInputStream; (); ; ReturnValue; remote; manual |
-| 2 | Source: javax.jms; MessageListener; true; onMessage; (Message); ; Parameter[0]; remote; manual |
-| 3 | Source: javax.servlet; ServletRequest; false; getParameter; (String); ; ReturnValue; remote; manual |
-| 4 | Source: unsafedeserialization; A; false; getTaintedMyObjectInput; (); ; ReturnValue; remote; manual |
-| 5 | Source: unsafedeserialization; A; false; getTaintedObjectInput; (); ; ReturnValue; remote; manual |
-| 6 | Summary: android.os; Parcel; false; readString; ; ; Argument[this]; ReturnValue; taint; manual |
-| 7 | Summary: com.esotericsoftware.kryo.io; Input; false; Input; ; ; Argument[0]; Argument[this]; taint; manual |
-| 8 | Summary: com.fasterxml.jackson.core; JsonFactory; false; createParser; ; ; Argument[0]; ReturnValue; taint; manual |
-| 9 | Summary: java.beans; XMLDecoder; false; XMLDecoder; ; ; Argument[0]; Argument[this]; taint; manual |
-| 10 | Summary: java.io; ByteArrayInputStream; false; ByteArrayInputStream; ; ; Argument[0]; Argument[this]; taint; manual |
-| 11 | Summary: java.io; InputStream; true; read; (byte[]); ; Argument[this]; Argument[0]; taint; manual |
-| 12 | Summary: java.io; InputStreamReader; false; InputStreamReader; ; ; Argument[0]; Argument[this]; taint; manual |
-| 13 | Summary: java.io; ObjectInputStream; false; ObjectInputStream; ; ; Argument[0]; Argument[this]; taint; manual |
-| 14 | Summary: java.io; StringReader; false; StringReader; ; ; Argument[0]; Argument[this]; taint; manual |
-| 15 | Summary: java.lang; String; false; String; ; ; Argument[0]; Argument[this]; taint; manual |
-| 16 | Summary: java.lang; String; false; getBytes; ; ; Argument[this]; ReturnValue; taint; manual |
-| 17 | Summary: java.lang; String; false; split; ; ; Argument[this]; ReturnValue; taint; manual |
-| 18 | Summary: org.json; JSONObject; false; JSONObject; (String); ; Argument[0]; Argument[this]; taint; manual |
+| 1 | Sink: com.caucho.burlap.io; BurlapInput; true; readObject; ; ; Argument[this]; unsafe-deserialization; manual |
+| 2 | Sink: com.caucho.hessian.io; AbstractHessianInput; true; readObject; ; ; Argument[this]; unsafe-deserialization; manual |
+| 3 | Sink: com.cedarsoftware.util.io; JsonReader; false; jsonToJava; ; ; Argument[0]; unsafe-deserialization; manual |
+| 4 | Sink: com.cedarsoftware.util.io; JsonReader; true; readObject; ; ; Argument[this]; unsafe-deserialization; manual |
+| 5 | Sink: com.esotericsoftware.yamlbeans; YamlReader; true; read; ; ; Argument[this]; unsafe-deserialization; manual |
+| 6 | Sink: java.beans; XMLDecoder; true; readObject; (); ; Argument[this]; unsafe-deserialization; manual |
+| 7 | Sink: org.exolab.castor.xml; Unmarshaller; true; unmarshal; ; ; Argument[0..1]; unsafe-deserialization; manual |
+| 8 | Sink: org.ho.yaml; Yaml; false; load; ; ; Argument[0]; unsafe-deserialization; manual |
+| 9 | Sink: org.ho.yaml; Yaml; false; loadStream; ; ; Argument[0]; unsafe-deserialization; manual |
+| 10 | Sink: org.ho.yaml; Yaml; false; loadStreamOfType; ; ; Argument[0]; unsafe-deserialization; manual |
+| 11 | Sink: org.ho.yaml; Yaml; false; loadType; ; ; Argument[0]; unsafe-deserialization; manual |
+| 12 | Sink: org.ho.yaml; YamlConfig; false; load; ; ; Argument[0]; unsafe-deserialization; manual |
+| 13 | Sink: org.ho.yaml; YamlConfig; false; loadStream; ; ; Argument[0]; unsafe-deserialization; manual |
+| 14 | Sink: org.ho.yaml; YamlConfig; false; loadStreamOfType; ; ; Argument[0]; unsafe-deserialization; manual |
+| 15 | Sink: org.ho.yaml; YamlConfig; false; loadType; ; ; Argument[0]; unsafe-deserialization; manual |
+| 16 | Sink: org.jabsorb; JSONSerializer; true; fromJSON; ; ; Argument[0]; unsafe-deserialization; manual |
+| 17 | Source: java.net; Socket; false; getInputStream; (); ; ReturnValue; remote; manual |
+| 18 | Source: javax.jms; MessageListener; true; onMessage; (Message); ; Parameter[0]; remote; manual |
+| 19 | Source: javax.servlet; ServletRequest; false; getParameter; (String); ; ReturnValue; remote; manual |
+| 20 | Source: unsafedeserialization; A; false; getTaintedMyObjectInput; (); ; ReturnValue; remote; manual |
+| 21 | Source: unsafedeserialization; A; false; getTaintedObjectInput; (); ; ReturnValue; remote; manual |
+| 22 | Summary: android.os; Parcel; false; readString; ; ; Argument[this]; ReturnValue; taint; manual |
+| 23 | Summary: com.esotericsoftware.kryo.io; Input; false; Input; ; ; Argument[0]; Argument[this]; taint; manual |
+| 24 | Summary: com.fasterxml.jackson.core; JsonFactory; false; createParser; ; ; Argument[0]; ReturnValue; taint; manual |
+| 25 | Summary: java.beans; XMLDecoder; false; XMLDecoder; ; ; Argument[0]; Argument[this]; taint; manual |
+| 26 | Summary: java.io; ByteArrayInputStream; false; ByteArrayInputStream; ; ; Argument[0]; Argument[this]; taint; manual |
+| 27 | Summary: java.io; InputStream; true; read; (byte[]); ; Argument[this]; Argument[0]; taint; manual |
+| 28 | Summary: java.io; InputStreamReader; false; InputStreamReader; ; ; Argument[0]; Argument[this]; taint; manual |
+| 29 | Summary: java.io; ObjectInputStream; false; ObjectInputStream; ; ; Argument[0]; Argument[this]; taint; manual |
+| 30 | Summary: java.io; StringReader; false; StringReader; ; ; Argument[0]; Argument[this]; taint; manual |
+| 31 | Summary: java.lang; String; false; String; ; ; Argument[0]; Argument[this]; taint; manual |
+| 32 | Summary: java.lang; String; false; getBytes; ; ; Argument[this]; ReturnValue; taint; manual |
+| 33 | Summary: java.lang; String; false; split; ; ; Argument[this]; ReturnValue; taint; manual |
+| 34 | Summary: org.json; JSONObject; false; JSONObject; (String); ; Argument[0]; Argument[this]; taint; manual |
 nodes
 | A.java:17:31:17:51 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | A.java:18:28:18:61 | new ObjectInputStream(...) : ObjectInputStream | semmle.label | new ObjectInputStream(...) : ObjectInputStream |

--- a/java/ql/test/query-tests/security/CWE-611/XXE.expected
+++ b/java/ql/test/query-tests/security/CWE-611/XXE.expected
@@ -113,117 +113,118 @@
 | XmlInputFactoryTests.java:55:35:55:55 | getInputStream(...) | XmlInputFactoryTests.java:55:35:55:55 | getInputStream(...) | XmlInputFactoryTests.java:55:35:55:55 | getInputStream(...) | XML parsing depends on a $@ without guarding against external entity expansion. | XmlInputFactoryTests.java:55:35:55:55 | getInputStream(...) | user-provided value |
 | XmlInputFactoryTests.java:56:34:56:54 | getInputStream(...) | XmlInputFactoryTests.java:56:34:56:54 | getInputStream(...) | XmlInputFactoryTests.java:56:34:56:54 | getInputStream(...) | XML parsing depends on a $@ without guarding against external entity expansion. | XmlInputFactoryTests.java:56:34:56:54 | getInputStream(...) | user-provided value |
 edges
-| CdaUtilTests.java:10:26:10:46 | getInputStream(...) : InputStream | CdaUtilTests.java:11:66:11:67 | is : InputStream | provenance | Src:MaD:1  |
-| CdaUtilTests.java:10:26:10:46 | getInputStream(...) : InputStream | CdaUtilTests.java:12:22:12:23 | is | provenance | Src:MaD:1  |
-| CdaUtilTests.java:10:26:10:46 | getInputStream(...) : InputStream | CdaUtilTests.java:14:22:14:23 | is | provenance | Src:MaD:1  |
-| CdaUtilTests.java:10:26:10:46 | getInputStream(...) : InputStream | CdaUtilTests.java:15:22:15:23 | is | provenance | Src:MaD:1  |
-| CdaUtilTests.java:10:26:10:46 | getInputStream(...) : InputStream | CdaUtilTests.java:16:34:16:35 | is | provenance | Src:MaD:1  |
-| CdaUtilTests.java:10:26:10:46 | getInputStream(...) : InputStream | CdaUtilTests.java:20:24:20:25 | is | provenance | Src:MaD:1  |
-| CdaUtilTests.java:10:26:10:46 | getInputStream(...) : InputStream | CdaUtilTests.java:21:24:21:25 | is | provenance | Src:MaD:1  |
+| CdaUtilTests.java:10:26:10:46 | getInputStream(...) : InputStream | CdaUtilTests.java:11:66:11:67 | is : InputStream | provenance | Src:MaD:2  |
+| CdaUtilTests.java:10:26:10:46 | getInputStream(...) : InputStream | CdaUtilTests.java:12:22:12:23 | is | provenance | Src:MaD:2  |
+| CdaUtilTests.java:10:26:10:46 | getInputStream(...) : InputStream | CdaUtilTests.java:14:22:14:23 | is | provenance | Src:MaD:2  |
+| CdaUtilTests.java:10:26:10:46 | getInputStream(...) : InputStream | CdaUtilTests.java:15:22:15:23 | is | provenance | Src:MaD:2  |
+| CdaUtilTests.java:10:26:10:46 | getInputStream(...) : InputStream | CdaUtilTests.java:16:34:16:35 | is | provenance | Src:MaD:2  |
+| CdaUtilTests.java:10:26:10:46 | getInputStream(...) : InputStream | CdaUtilTests.java:20:24:20:25 | is | provenance | Src:MaD:2  |
+| CdaUtilTests.java:10:26:10:46 | getInputStream(...) : InputStream | CdaUtilTests.java:21:24:21:25 | is | provenance | Src:MaD:2  |
 | CdaUtilTests.java:11:28:11:69 | new InputSource(...) : InputSource | CdaUtilTests.java:13:22:13:25 | iSrc | provenance |  |
 | CdaUtilTests.java:11:28:11:69 | new InputSource(...) : InputSource | CdaUtilTests.java:17:22:17:25 | iSrc | provenance |  |
 | CdaUtilTests.java:11:28:11:69 | new InputSource(...) : InputSource | CdaUtilTests.java:18:22:18:25 | iSrc | provenance |  |
 | CdaUtilTests.java:11:28:11:69 | new InputSource(...) : InputSource | CdaUtilTests.java:19:34:19:37 | iSrc | provenance |  |
-| CdaUtilTests.java:11:44:11:68 | new InputStreamReader(...) : InputStreamReader | CdaUtilTests.java:11:28:11:69 | new InputSource(...) : InputSource | provenance | MaD:13 |
-| CdaUtilTests.java:11:66:11:67 | is : InputStream | CdaUtilTests.java:11:44:11:68 | new InputStreamReader(...) : InputStreamReader | provenance | MaD:5 |
-| DigesterTests.java:14:49:14:72 | getInputStream(...) : ServletInputStream | DigesterTests.java:16:24:16:41 | servletInputStream | provenance | Src:MaD:2  |
+| CdaUtilTests.java:11:44:11:68 | new InputStreamReader(...) : InputStreamReader | CdaUtilTests.java:11:28:11:69 | new InputSource(...) : InputSource | provenance | MaD:14 |
+| CdaUtilTests.java:11:66:11:67 | is : InputStream | CdaUtilTests.java:11:44:11:68 | new InputStreamReader(...) : InputStreamReader | provenance | MaD:6 |
+| DigesterTests.java:14:49:14:72 | getInputStream(...) : ServletInputStream | DigesterTests.java:16:24:16:41 | servletInputStream | provenance | Src:MaD:3  |
 | DocumentBuilderTests.java:95:24:95:76 | new SAXSource(...) : SAXSource | DocumentBuilderTests.java:96:19:96:24 | source : SAXSource | provenance |  |
-| DocumentBuilderTests.java:95:38:95:75 | new InputSource(...) : InputSource | DocumentBuilderTests.java:95:24:95:76 | new SAXSource(...) : SAXSource | provenance | MaD:7 |
-| DocumentBuilderTests.java:95:54:95:74 | getInputStream(...) : InputStream | DocumentBuilderTests.java:95:38:95:75 | new InputSource(...) : InputSource | provenance | Src:MaD:1 MaD:13 |
-| DocumentBuilderTests.java:96:19:96:24 | source : SAXSource | DocumentBuilderTests.java:96:19:96:41 | getInputSource(...) | provenance | MaD:9 |
+| DocumentBuilderTests.java:95:38:95:75 | new InputSource(...) : InputSource | DocumentBuilderTests.java:95:24:95:76 | new SAXSource(...) : SAXSource | provenance | MaD:8 |
+| DocumentBuilderTests.java:95:54:95:74 | getInputStream(...) : InputStream | DocumentBuilderTests.java:95:38:95:75 | new InputSource(...) : InputSource | provenance | Src:MaD:2 MaD:14 |
+| DocumentBuilderTests.java:96:19:96:24 | source : SAXSource | DocumentBuilderTests.java:96:19:96:41 | getInputSource(...) | provenance | MaD:10 |
 | DocumentBuilderTests.java:102:27:102:65 | new StreamSource(...) : StreamSource | DocumentBuilderTests.java:103:49:103:54 | source : StreamSource | provenance |  |
 | DocumentBuilderTests.java:102:27:102:65 | new StreamSource(...) : StreamSource | DocumentBuilderTests.java:104:19:104:24 | source : StreamSource | provenance |  |
-| DocumentBuilderTests.java:102:44:102:64 | getInputStream(...) : InputStream | DocumentBuilderTests.java:102:27:102:65 | new StreamSource(...) : StreamSource | provenance | Src:MaD:1 MaD:11 |
-| DocumentBuilderTests.java:103:49:103:54 | source : StreamSource | DocumentBuilderTests.java:103:19:103:55 | sourceToInputSource(...) | provenance | MaD:10 |
-| DocumentBuilderTests.java:104:19:104:24 | source : StreamSource | DocumentBuilderTests.java:104:19:104:41 | getInputStream(...) | provenance | MaD:12 |
+| DocumentBuilderTests.java:102:44:102:64 | getInputStream(...) : InputStream | DocumentBuilderTests.java:102:27:102:65 | new StreamSource(...) : StreamSource | provenance | Src:MaD:2 MaD:12 |
+| DocumentBuilderTests.java:103:49:103:54 | source : StreamSource | DocumentBuilderTests.java:103:19:103:55 | sourceToInputSource(...) | provenance | MaD:11 |
+| DocumentBuilderTests.java:104:19:104:24 | source : StreamSource | DocumentBuilderTests.java:104:19:104:41 | getInputStream(...) | provenance | MaD:13 |
 | SAXSourceTests.java:17:24:17:84 | new SAXSource(...) : SAXSource | SAXSourceTests.java:20:18:20:23 | source | provenance |  |
-| SAXSourceTests.java:17:46:17:83 | new InputSource(...) : InputSource | SAXSourceTests.java:17:24:17:84 | new SAXSource(...) : SAXSource | provenance | MaD:8 |
-| SAXSourceTests.java:17:62:17:82 | getInputStream(...) : InputStream | SAXSourceTests.java:17:46:17:83 | new InputSource(...) : InputSource | provenance | Src:MaD:1 MaD:13 |
-| SchemaTests.java:12:56:12:76 | getInputStream(...) : InputStream | SchemaTests.java:12:39:12:77 | new StreamSource(...) | provenance | Src:MaD:1 MaD:11 |
-| SchemaTests.java:25:56:25:76 | getInputStream(...) : InputStream | SchemaTests.java:25:39:25:77 | new StreamSource(...) | provenance | Src:MaD:1 MaD:11 |
-| SchemaTests.java:31:56:31:76 | getInputStream(...) : InputStream | SchemaTests.java:31:39:31:77 | new StreamSource(...) | provenance | Src:MaD:1 MaD:11 |
-| SchemaTests.java:38:56:38:76 | getInputStream(...) : InputStream | SchemaTests.java:38:39:38:77 | new StreamSource(...) | provenance | Src:MaD:1 MaD:11 |
-| SchemaTests.java:45:56:45:76 | getInputStream(...) : InputStream | SchemaTests.java:45:39:45:77 | new StreamSource(...) | provenance | Src:MaD:1 MaD:11 |
-| SimpleXMLTests.java:24:63:24:83 | getInputStream(...) : InputStream | SimpleXMLTests.java:24:41:24:84 | new InputStreamReader(...) | provenance | Src:MaD:1 MaD:5 |
-| SimpleXMLTests.java:30:5:30:25 | getInputStream(...) : InputStream | SimpleXMLTests.java:30:32:30:32 | b [post update] : byte[] | provenance | Src:MaD:1 MaD:4 |
+| SAXSourceTests.java:17:46:17:83 | new InputSource(...) : InputSource | SAXSourceTests.java:17:24:17:84 | new SAXSource(...) : SAXSource | provenance | MaD:9 |
+| SAXSourceTests.java:17:62:17:82 | getInputStream(...) : InputStream | SAXSourceTests.java:17:46:17:83 | new InputSource(...) : InputSource | provenance | Src:MaD:2 MaD:14 |
+| SchemaTests.java:12:56:12:76 | getInputStream(...) : InputStream | SchemaTests.java:12:39:12:77 | new StreamSource(...) | provenance | Src:MaD:2 MaD:12 |
+| SchemaTests.java:25:56:25:76 | getInputStream(...) : InputStream | SchemaTests.java:25:39:25:77 | new StreamSource(...) | provenance | Src:MaD:2 MaD:12 |
+| SchemaTests.java:31:56:31:76 | getInputStream(...) : InputStream | SchemaTests.java:31:39:31:77 | new StreamSource(...) | provenance | Src:MaD:2 MaD:12 |
+| SchemaTests.java:38:56:38:76 | getInputStream(...) : InputStream | SchemaTests.java:38:39:38:77 | new StreamSource(...) | provenance | Src:MaD:2 MaD:12 |
+| SchemaTests.java:45:56:45:76 | getInputStream(...) : InputStream | SchemaTests.java:45:39:45:77 | new StreamSource(...) | provenance | Src:MaD:2 MaD:12 |
+| SimpleXMLTests.java:24:63:24:83 | getInputStream(...) : InputStream | SimpleXMLTests.java:24:41:24:84 | new InputStreamReader(...) | provenance | Src:MaD:2 MaD:6 |
+| SimpleXMLTests.java:30:5:30:25 | getInputStream(...) : InputStream | SimpleXMLTests.java:30:32:30:32 | b [post update] : byte[] | provenance | Src:MaD:2 MaD:5 |
 | SimpleXMLTests.java:30:32:30:32 | b [post update] : byte[] | SimpleXMLTests.java:31:52:31:52 | b : byte[] | provenance |  |
-| SimpleXMLTests.java:31:52:31:52 | b : byte[] | SimpleXMLTests.java:31:41:31:53 | new String(...) | provenance | MaD:6 |
-| SimpleXMLTests.java:37:5:37:25 | getInputStream(...) : InputStream | SimpleXMLTests.java:37:32:37:32 | b [post update] : byte[] | provenance | Src:MaD:1 MaD:4 |
+| SimpleXMLTests.java:31:52:31:52 | b : byte[] | SimpleXMLTests.java:31:41:31:53 | new String(...) | provenance | MaD:7 |
+| SimpleXMLTests.java:37:5:37:25 | getInputStream(...) : InputStream | SimpleXMLTests.java:37:32:37:32 | b [post update] : byte[] | provenance | Src:MaD:2 MaD:5 |
 | SimpleXMLTests.java:37:32:37:32 | b [post update] : byte[] | SimpleXMLTests.java:38:52:38:52 | b : byte[] | provenance |  |
-| SimpleXMLTests.java:38:52:38:52 | b : byte[] | SimpleXMLTests.java:38:41:38:53 | new String(...) | provenance | MaD:6 |
-| SimpleXMLTests.java:43:63:43:83 | getInputStream(...) : InputStream | SimpleXMLTests.java:43:41:43:84 | new InputStreamReader(...) | provenance | Src:MaD:1 MaD:5 |
-| SimpleXMLTests.java:68:59:68:79 | getInputStream(...) : InputStream | SimpleXMLTests.java:68:37:68:80 | new InputStreamReader(...) | provenance | Src:MaD:1 MaD:5 |
-| SimpleXMLTests.java:73:59:73:79 | getInputStream(...) : InputStream | SimpleXMLTests.java:73:37:73:80 | new InputStreamReader(...) | provenance | Src:MaD:1 MaD:5 |
-| SimpleXMLTests.java:78:48:78:68 | getInputStream(...) : InputStream | SimpleXMLTests.java:78:26:78:69 | new InputStreamReader(...) | provenance | Src:MaD:1 MaD:5 |
-| SimpleXMLTests.java:83:48:83:68 | getInputStream(...) : InputStream | SimpleXMLTests.java:83:26:83:69 | new InputStreamReader(...) | provenance | Src:MaD:1 MaD:5 |
-| SimpleXMLTests.java:89:5:89:25 | getInputStream(...) : InputStream | SimpleXMLTests.java:89:32:89:32 | b [post update] : byte[] | provenance | Src:MaD:1 MaD:4 |
+| SimpleXMLTests.java:38:52:38:52 | b : byte[] | SimpleXMLTests.java:38:41:38:53 | new String(...) | provenance | MaD:7 |
+| SimpleXMLTests.java:43:63:43:83 | getInputStream(...) : InputStream | SimpleXMLTests.java:43:41:43:84 | new InputStreamReader(...) | provenance | Src:MaD:2 MaD:6 |
+| SimpleXMLTests.java:68:59:68:79 | getInputStream(...) : InputStream | SimpleXMLTests.java:68:37:68:80 | new InputStreamReader(...) | provenance | Src:MaD:2 MaD:6 |
+| SimpleXMLTests.java:73:59:73:79 | getInputStream(...) : InputStream | SimpleXMLTests.java:73:37:73:80 | new InputStreamReader(...) | provenance | Src:MaD:2 MaD:6 |
+| SimpleXMLTests.java:78:48:78:68 | getInputStream(...) : InputStream | SimpleXMLTests.java:78:26:78:69 | new InputStreamReader(...) | provenance | Src:MaD:2 MaD:6 |
+| SimpleXMLTests.java:83:48:83:68 | getInputStream(...) : InputStream | SimpleXMLTests.java:83:26:83:69 | new InputStreamReader(...) | provenance | Src:MaD:2 MaD:6 |
+| SimpleXMLTests.java:89:5:89:25 | getInputStream(...) : InputStream | SimpleXMLTests.java:89:32:89:32 | b [post update] : byte[] | provenance | Src:MaD:2 MaD:5 |
 | SimpleXMLTests.java:89:32:89:32 | b [post update] : byte[] | SimpleXMLTests.java:90:48:90:48 | b : byte[] | provenance |  |
-| SimpleXMLTests.java:90:48:90:48 | b : byte[] | SimpleXMLTests.java:90:37:90:49 | new String(...) | provenance | MaD:6 |
-| SimpleXMLTests.java:96:5:96:25 | getInputStream(...) : InputStream | SimpleXMLTests.java:96:32:96:32 | b [post update] : byte[] | provenance | Src:MaD:1 MaD:4 |
+| SimpleXMLTests.java:90:48:90:48 | b : byte[] | SimpleXMLTests.java:90:37:90:49 | new String(...) | provenance | MaD:7 |
+| SimpleXMLTests.java:96:5:96:25 | getInputStream(...) : InputStream | SimpleXMLTests.java:96:32:96:32 | b [post update] : byte[] | provenance | Src:MaD:2 MaD:5 |
 | SimpleXMLTests.java:96:32:96:32 | b [post update] : byte[] | SimpleXMLTests.java:97:48:97:48 | b : byte[] | provenance |  |
-| SimpleXMLTests.java:97:48:97:48 | b : byte[] | SimpleXMLTests.java:97:37:97:49 | new String(...) | provenance | MaD:6 |
-| SimpleXMLTests.java:103:5:103:25 | getInputStream(...) : InputStream | SimpleXMLTests.java:103:32:103:32 | b [post update] : byte[] | provenance | Src:MaD:1 MaD:4 |
+| SimpleXMLTests.java:97:48:97:48 | b : byte[] | SimpleXMLTests.java:97:37:97:49 | new String(...) | provenance | MaD:7 |
+| SimpleXMLTests.java:103:5:103:25 | getInputStream(...) : InputStream | SimpleXMLTests.java:103:32:103:32 | b [post update] : byte[] | provenance | Src:MaD:2 MaD:5 |
 | SimpleXMLTests.java:103:32:103:32 | b [post update] : byte[] | SimpleXMLTests.java:104:37:104:37 | b : byte[] | provenance |  |
-| SimpleXMLTests.java:104:37:104:37 | b : byte[] | SimpleXMLTests.java:104:26:104:38 | new String(...) | provenance | MaD:6 |
-| SimpleXMLTests.java:110:5:110:25 | getInputStream(...) : InputStream | SimpleXMLTests.java:110:32:110:32 | b [post update] : byte[] | provenance | Src:MaD:1 MaD:4 |
+| SimpleXMLTests.java:104:37:104:37 | b : byte[] | SimpleXMLTests.java:104:26:104:38 | new String(...) | provenance | MaD:7 |
+| SimpleXMLTests.java:110:5:110:25 | getInputStream(...) : InputStream | SimpleXMLTests.java:110:32:110:32 | b [post update] : byte[] | provenance | Src:MaD:2 MaD:5 |
 | SimpleXMLTests.java:110:32:110:32 | b [post update] : byte[] | SimpleXMLTests.java:111:37:111:37 | b : byte[] | provenance |  |
-| SimpleXMLTests.java:111:37:111:37 | b : byte[] | SimpleXMLTests.java:111:26:111:38 | new String(...) | provenance | MaD:6 |
-| SimpleXMLTests.java:119:44:119:64 | getInputStream(...) : InputStream | SimpleXMLTests.java:119:22:119:65 | new InputStreamReader(...) | provenance | Src:MaD:1 MaD:5 |
-| SimpleXMLTests.java:129:44:129:64 | getInputStream(...) : InputStream | SimpleXMLTests.java:129:22:129:65 | new InputStreamReader(...) | provenance | Src:MaD:1 MaD:5 |
-| SimpleXMLTests.java:139:44:139:64 | getInputStream(...) : InputStream | SimpleXMLTests.java:139:22:139:65 | new InputStreamReader(...) | provenance | Src:MaD:1 MaD:5 |
-| SimpleXMLTests.java:145:5:145:25 | getInputStream(...) : InputStream | SimpleXMLTests.java:145:32:145:32 | b [post update] : byte[] | provenance | Src:MaD:1 MaD:4 |
+| SimpleXMLTests.java:111:37:111:37 | b : byte[] | SimpleXMLTests.java:111:26:111:38 | new String(...) | provenance | MaD:7 |
+| SimpleXMLTests.java:119:44:119:64 | getInputStream(...) : InputStream | SimpleXMLTests.java:119:22:119:65 | new InputStreamReader(...) | provenance | Src:MaD:2 MaD:6 |
+| SimpleXMLTests.java:129:44:129:64 | getInputStream(...) : InputStream | SimpleXMLTests.java:129:22:129:65 | new InputStreamReader(...) | provenance | Src:MaD:2 MaD:6 |
+| SimpleXMLTests.java:139:44:139:64 | getInputStream(...) : InputStream | SimpleXMLTests.java:139:22:139:65 | new InputStreamReader(...) | provenance | Src:MaD:2 MaD:6 |
+| SimpleXMLTests.java:145:5:145:25 | getInputStream(...) : InputStream | SimpleXMLTests.java:145:32:145:32 | b [post update] : byte[] | provenance | Src:MaD:2 MaD:5 |
 | SimpleXMLTests.java:145:32:145:32 | b [post update] : byte[] | SimpleXMLTests.java:146:33:146:33 | b : byte[] | provenance |  |
-| SimpleXMLTests.java:146:33:146:33 | b : byte[] | SimpleXMLTests.java:146:22:146:34 | new String(...) | provenance | MaD:6 |
-| SimpleXMLTests.java:152:5:152:25 | getInputStream(...) : InputStream | SimpleXMLTests.java:152:32:152:32 | b [post update] : byte[] | provenance | Src:MaD:1 MaD:4 |
+| SimpleXMLTests.java:146:33:146:33 | b : byte[] | SimpleXMLTests.java:146:22:146:34 | new String(...) | provenance | MaD:7 |
+| SimpleXMLTests.java:152:5:152:25 | getInputStream(...) : InputStream | SimpleXMLTests.java:152:32:152:32 | b [post update] : byte[] | provenance | Src:MaD:2 MaD:5 |
 | SimpleXMLTests.java:152:32:152:32 | b [post update] : byte[] | SimpleXMLTests.java:153:33:153:33 | b : byte[] | provenance |  |
-| SimpleXMLTests.java:153:33:153:33 | b : byte[] | SimpleXMLTests.java:153:22:153:34 | new String(...) | provenance | MaD:6 |
-| TransformerTests.java:20:44:20:64 | getInputStream(...) : InputStream | TransformerTests.java:20:27:20:65 | new StreamSource(...) | provenance | Src:MaD:1 MaD:11 |
-| TransformerTests.java:21:40:21:60 | getInputStream(...) : InputStream | TransformerTests.java:21:23:21:61 | new StreamSource(...) | provenance | Src:MaD:1 MaD:11 |
-| TransformerTests.java:71:44:71:64 | getInputStream(...) : InputStream | TransformerTests.java:71:27:71:65 | new StreamSource(...) | provenance | Src:MaD:1 MaD:11 |
-| TransformerTests.java:72:40:72:60 | getInputStream(...) : InputStream | TransformerTests.java:72:23:72:61 | new StreamSource(...) | provenance | Src:MaD:1 MaD:11 |
-| TransformerTests.java:79:44:79:64 | getInputStream(...) : InputStream | TransformerTests.java:79:27:79:65 | new StreamSource(...) | provenance | Src:MaD:1 MaD:11 |
-| TransformerTests.java:80:40:80:60 | getInputStream(...) : InputStream | TransformerTests.java:80:23:80:61 | new StreamSource(...) | provenance | Src:MaD:1 MaD:11 |
-| TransformerTests.java:88:44:88:64 | getInputStream(...) : InputStream | TransformerTests.java:88:27:88:65 | new StreamSource(...) | provenance | Src:MaD:1 MaD:11 |
-| TransformerTests.java:89:40:89:60 | getInputStream(...) : InputStream | TransformerTests.java:89:23:89:61 | new StreamSource(...) | provenance | Src:MaD:1 MaD:11 |
-| TransformerTests.java:97:44:97:64 | getInputStream(...) : InputStream | TransformerTests.java:97:27:97:65 | new StreamSource(...) | provenance | Src:MaD:1 MaD:11 |
-| TransformerTests.java:98:40:98:60 | getInputStream(...) : InputStream | TransformerTests.java:98:23:98:61 | new StreamSource(...) | provenance | Src:MaD:1 MaD:11 |
-| TransformerTests.java:103:38:103:58 | getInputStream(...) : InputStream | TransformerTests.java:103:21:103:59 | new StreamSource(...) | provenance | Src:MaD:1 MaD:11 |
-| TransformerTests.java:116:38:116:58 | getInputStream(...) : InputStream | TransformerTests.java:116:21:116:59 | new StreamSource(...) | provenance | Src:MaD:1 MaD:11 |
-| TransformerTests.java:122:38:122:58 | getInputStream(...) : InputStream | TransformerTests.java:122:21:122:59 | new StreamSource(...) | provenance | Src:MaD:1 MaD:11 |
-| TransformerTests.java:129:38:129:58 | getInputStream(...) : InputStream | TransformerTests.java:129:21:129:59 | new StreamSource(...) | provenance | Src:MaD:1 MaD:11 |
-| TransformerTests.java:136:38:136:58 | getInputStream(...) : InputStream | TransformerTests.java:136:21:136:59 | new StreamSource(...) | provenance | Src:MaD:1 MaD:11 |
-| TransformerTests.java:141:35:141:72 | new InputSource(...) : InputSource | TransformerTests.java:141:21:141:73 | new SAXSource(...) | provenance | MaD:7 |
-| TransformerTests.java:141:51:141:71 | getInputStream(...) : InputStream | TransformerTests.java:141:35:141:72 | new InputSource(...) : InputSource | provenance | Src:MaD:1 MaD:13 |
-| ValidatorTests.java:17:49:17:72 | getInputStream(...) : ServletInputStream | ValidatorTests.java:21:48:21:65 | servletInputStream : ServletInputStream | provenance | Src:MaD:2  |
+| SimpleXMLTests.java:153:33:153:33 | b : byte[] | SimpleXMLTests.java:153:22:153:34 | new String(...) | provenance | MaD:7 |
+| TransformerTests.java:20:44:20:64 | getInputStream(...) : InputStream | TransformerTests.java:20:27:20:65 | new StreamSource(...) | provenance | Src:MaD:2 MaD:12 |
+| TransformerTests.java:21:40:21:60 | getInputStream(...) : InputStream | TransformerTests.java:21:23:21:61 | new StreamSource(...) | provenance | Src:MaD:2 MaD:12 |
+| TransformerTests.java:71:44:71:64 | getInputStream(...) : InputStream | TransformerTests.java:71:27:71:65 | new StreamSource(...) | provenance | Src:MaD:2 MaD:12 |
+| TransformerTests.java:72:40:72:60 | getInputStream(...) : InputStream | TransformerTests.java:72:23:72:61 | new StreamSource(...) | provenance | Src:MaD:2 MaD:12 |
+| TransformerTests.java:79:44:79:64 | getInputStream(...) : InputStream | TransformerTests.java:79:27:79:65 | new StreamSource(...) | provenance | Src:MaD:2 MaD:12 |
+| TransformerTests.java:80:40:80:60 | getInputStream(...) : InputStream | TransformerTests.java:80:23:80:61 | new StreamSource(...) | provenance | Src:MaD:2 MaD:12 |
+| TransformerTests.java:88:44:88:64 | getInputStream(...) : InputStream | TransformerTests.java:88:27:88:65 | new StreamSource(...) | provenance | Src:MaD:2 MaD:12 |
+| TransformerTests.java:89:40:89:60 | getInputStream(...) : InputStream | TransformerTests.java:89:23:89:61 | new StreamSource(...) | provenance | Src:MaD:2 MaD:12 |
+| TransformerTests.java:97:44:97:64 | getInputStream(...) : InputStream | TransformerTests.java:97:27:97:65 | new StreamSource(...) | provenance | Src:MaD:2 MaD:12 |
+| TransformerTests.java:98:40:98:60 | getInputStream(...) : InputStream | TransformerTests.java:98:23:98:61 | new StreamSource(...) | provenance | Src:MaD:2 MaD:12 |
+| TransformerTests.java:103:38:103:58 | getInputStream(...) : InputStream | TransformerTests.java:103:21:103:59 | new StreamSource(...) | provenance | Src:MaD:2 MaD:12 |
+| TransformerTests.java:116:38:116:58 | getInputStream(...) : InputStream | TransformerTests.java:116:21:116:59 | new StreamSource(...) | provenance | Src:MaD:2 MaD:12 |
+| TransformerTests.java:122:38:122:58 | getInputStream(...) : InputStream | TransformerTests.java:122:21:122:59 | new StreamSource(...) | provenance | Src:MaD:2 MaD:12 |
+| TransformerTests.java:129:38:129:58 | getInputStream(...) : InputStream | TransformerTests.java:129:21:129:59 | new StreamSource(...) | provenance | Src:MaD:2 MaD:12 |
+| TransformerTests.java:136:38:136:58 | getInputStream(...) : InputStream | TransformerTests.java:136:21:136:59 | new StreamSource(...) | provenance | Src:MaD:2 MaD:12 |
+| TransformerTests.java:141:35:141:72 | new InputSource(...) : InputSource | TransformerTests.java:141:21:141:73 | new SAXSource(...) | provenance | MaD:8 |
+| TransformerTests.java:141:51:141:71 | getInputStream(...) : InputStream | TransformerTests.java:141:35:141:72 | new InputSource(...) : InputSource | provenance | Src:MaD:2 MaD:14 |
+| ValidatorTests.java:17:49:17:72 | getInputStream(...) : ServletInputStream | ValidatorTests.java:21:48:21:65 | servletInputStream : ServletInputStream | provenance | Src:MaD:3  |
 | ValidatorTests.java:21:31:21:66 | new StreamSource(...) : StreamSource | ValidatorTests.java:22:28:22:33 | source | provenance |  |
-| ValidatorTests.java:21:48:21:65 | servletInputStream : ServletInputStream | ValidatorTests.java:21:31:21:66 | new StreamSource(...) : StreamSource | provenance | MaD:11 |
-| XMLDecoderTests.java:16:49:16:72 | getInputStream(...) : ServletInputStream | XMLDecoderTests.java:17:48:17:65 | servletInputStream : ServletInputStream | provenance | Src:MaD:2  |
-| XMLDecoderTests.java:17:33:17:66 | new XMLDecoder(...) : XMLDecoder | XMLDecoderTests.java:18:9:18:18 | xmlDecoder | provenance |  |
-| XMLDecoderTests.java:17:48:17:65 | servletInputStream : ServletInputStream | XMLDecoderTests.java:17:33:17:66 | new XMLDecoder(...) : XMLDecoder | provenance | MaD:3 |
-| XMLReaderTests.java:16:34:16:54 | getInputStream(...) : InputStream | XMLReaderTests.java:16:18:16:55 | new InputSource(...) | provenance | Src:MaD:1 MaD:13 |
-| XMLReaderTests.java:56:34:56:54 | getInputStream(...) : InputStream | XMLReaderTests.java:56:18:56:55 | new InputSource(...) | provenance | Src:MaD:1 MaD:13 |
-| XMLReaderTests.java:63:34:63:54 | getInputStream(...) : InputStream | XMLReaderTests.java:63:18:63:55 | new InputSource(...) | provenance | Src:MaD:1 MaD:13 |
-| XMLReaderTests.java:70:34:70:54 | getInputStream(...) : InputStream | XMLReaderTests.java:70:18:70:55 | new InputSource(...) | provenance | Src:MaD:1 MaD:13 |
-| XMLReaderTests.java:78:34:78:54 | getInputStream(...) : InputStream | XMLReaderTests.java:78:18:78:55 | new InputSource(...) | provenance | Src:MaD:1 MaD:13 |
-| XMLReaderTests.java:86:34:86:54 | getInputStream(...) : InputStream | XMLReaderTests.java:86:18:86:55 | new InputSource(...) | provenance | Src:MaD:1 MaD:13 |
-| XMLReaderTests.java:94:34:94:54 | getInputStream(...) : InputStream | XMLReaderTests.java:94:18:94:55 | new InputSource(...) | provenance | Src:MaD:1 MaD:13 |
-| XMLReaderTests.java:100:34:100:54 | getInputStream(...) : InputStream | XMLReaderTests.java:100:18:100:55 | new InputSource(...) | provenance | Src:MaD:1 MaD:13 |
-| XPathExpressionTests.java:27:35:27:55 | getInputStream(...) : InputStream | XPathExpressionTests.java:27:19:27:56 | new InputSource(...) | provenance | Src:MaD:1 MaD:13 |
-| XPathExpressionTests.java:42:39:42:59 | getInputStream(...) : InputStream | XPathExpressionTests.java:42:23:42:60 | new InputSource(...) | provenance | Src:MaD:1 MaD:13 |
+| ValidatorTests.java:21:48:21:65 | servletInputStream : ServletInputStream | ValidatorTests.java:21:31:21:66 | new StreamSource(...) : StreamSource | provenance | MaD:12 |
+| XMLDecoderTests.java:16:49:16:72 | getInputStream(...) : ServletInputStream | XMLDecoderTests.java:17:48:17:65 | servletInputStream : ServletInputStream | provenance | Src:MaD:3  |
+| XMLDecoderTests.java:17:33:17:66 | new XMLDecoder(...) : XMLDecoder | XMLDecoderTests.java:18:9:18:18 | xmlDecoder | provenance | Sink:MaD:1 |
+| XMLDecoderTests.java:17:48:17:65 | servletInputStream : ServletInputStream | XMLDecoderTests.java:17:33:17:66 | new XMLDecoder(...) : XMLDecoder | provenance | MaD:4 |
+| XMLReaderTests.java:16:34:16:54 | getInputStream(...) : InputStream | XMLReaderTests.java:16:18:16:55 | new InputSource(...) | provenance | Src:MaD:2 MaD:14 |
+| XMLReaderTests.java:56:34:56:54 | getInputStream(...) : InputStream | XMLReaderTests.java:56:18:56:55 | new InputSource(...) | provenance | Src:MaD:2 MaD:14 |
+| XMLReaderTests.java:63:34:63:54 | getInputStream(...) : InputStream | XMLReaderTests.java:63:18:63:55 | new InputSource(...) | provenance | Src:MaD:2 MaD:14 |
+| XMLReaderTests.java:70:34:70:54 | getInputStream(...) : InputStream | XMLReaderTests.java:70:18:70:55 | new InputSource(...) | provenance | Src:MaD:2 MaD:14 |
+| XMLReaderTests.java:78:34:78:54 | getInputStream(...) : InputStream | XMLReaderTests.java:78:18:78:55 | new InputSource(...) | provenance | Src:MaD:2 MaD:14 |
+| XMLReaderTests.java:86:34:86:54 | getInputStream(...) : InputStream | XMLReaderTests.java:86:18:86:55 | new InputSource(...) | provenance | Src:MaD:2 MaD:14 |
+| XMLReaderTests.java:94:34:94:54 | getInputStream(...) : InputStream | XMLReaderTests.java:94:18:94:55 | new InputSource(...) | provenance | Src:MaD:2 MaD:14 |
+| XMLReaderTests.java:100:34:100:54 | getInputStream(...) : InputStream | XMLReaderTests.java:100:18:100:55 | new InputSource(...) | provenance | Src:MaD:2 MaD:14 |
+| XPathExpressionTests.java:27:35:27:55 | getInputStream(...) : InputStream | XPathExpressionTests.java:27:19:27:56 | new InputSource(...) | provenance | Src:MaD:2 MaD:14 |
+| XPathExpressionTests.java:42:39:42:59 | getInputStream(...) : InputStream | XPathExpressionTests.java:42:23:42:60 | new InputSource(...) | provenance | Src:MaD:2 MaD:14 |
 models
-| 1 | Source: java.net; Socket; false; getInputStream; (); ; ReturnValue; remote; manual |
-| 2 | Source: javax.servlet; ServletRequest; false; getInputStream; (); ; ReturnValue; remote; manual |
-| 3 | Summary: java.beans; XMLDecoder; false; XMLDecoder; ; ; Argument[0]; Argument[this]; taint; manual |
-| 4 | Summary: java.io; InputStream; true; read; (byte[]); ; Argument[this]; Argument[0]; taint; manual |
-| 5 | Summary: java.io; InputStreamReader; false; InputStreamReader; ; ; Argument[0]; Argument[this]; taint; manual |
-| 6 | Summary: java.lang; String; false; String; ; ; Argument[0]; Argument[this]; taint; manual |
-| 7 | Summary: javax.xml.transform.sax; SAXSource; false; SAXSource; (InputSource); ; Argument[0]; Argument[this]; taint; manual |
-| 8 | Summary: javax.xml.transform.sax; SAXSource; false; SAXSource; (XMLReader,InputSource); ; Argument[1]; Argument[this]; taint; manual |
-| 9 | Summary: javax.xml.transform.sax; SAXSource; false; getInputSource; ; ; Argument[this]; ReturnValue; taint; manual |
-| 10 | Summary: javax.xml.transform.sax; SAXSource; false; sourceToInputSource; ; ; Argument[0]; ReturnValue; taint; manual |
-| 11 | Summary: javax.xml.transform.stream; StreamSource; false; StreamSource; ; ; Argument[0]; Argument[this]; taint; manual |
-| 12 | Summary: javax.xml.transform.stream; StreamSource; false; getInputStream; ; ; Argument[this]; ReturnValue; taint; manual |
-| 13 | Summary: org.xml.sax; InputSource; false; InputSource; ; ; Argument[0]; Argument[this]; taint; manual |
+| 1 | Sink: java.beans; XMLDecoder; true; readObject; (); ; Argument[this]; unsafe-deserialization; manual |
+| 2 | Source: java.net; Socket; false; getInputStream; (); ; ReturnValue; remote; manual |
+| 3 | Source: javax.servlet; ServletRequest; false; getInputStream; (); ; ReturnValue; remote; manual |
+| 4 | Summary: java.beans; XMLDecoder; false; XMLDecoder; ; ; Argument[0]; Argument[this]; taint; manual |
+| 5 | Summary: java.io; InputStream; true; read; (byte[]); ; Argument[this]; Argument[0]; taint; manual |
+| 6 | Summary: java.io; InputStreamReader; false; InputStreamReader; ; ; Argument[0]; Argument[this]; taint; manual |
+| 7 | Summary: java.lang; String; false; String; ; ; Argument[0]; Argument[this]; taint; manual |
+| 8 | Summary: javax.xml.transform.sax; SAXSource; false; SAXSource; (InputSource); ; Argument[0]; Argument[this]; taint; manual |
+| 9 | Summary: javax.xml.transform.sax; SAXSource; false; SAXSource; (XMLReader,InputSource); ; Argument[1]; Argument[this]; taint; manual |
+| 10 | Summary: javax.xml.transform.sax; SAXSource; false; getInputSource; ; ; Argument[this]; ReturnValue; taint; manual |
+| 11 | Summary: javax.xml.transform.sax; SAXSource; false; sourceToInputSource; ; ; Argument[0]; ReturnValue; taint; manual |
+| 12 | Summary: javax.xml.transform.stream; StreamSource; false; StreamSource; ; ; Argument[0]; Argument[this]; taint; manual |
+| 13 | Summary: javax.xml.transform.stream; StreamSource; false; getInputStream; ; ; Argument[this]; ReturnValue; taint; manual |
+| 14 | Summary: org.xml.sax; InputSource; false; InputSource; ; ; Argument[0]; Argument[this]; taint; manual |
 nodes
 | CdaUtilTests.java:10:26:10:46 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | CdaUtilTests.java:11:28:11:69 | new InputSource(...) : InputSource | semmle.label | new InputSource(...) : InputSource |

--- a/shared/mad/codeql/mad/ModelValidation.qll
+++ b/shared/mad/codeql/mad/ModelValidation.qll
@@ -29,8 +29,9 @@ module KindValidation<KindValidationConfigSig Config> {
         [
           // shared
           "code-injection", "command-injection", "environment-injection", "file-content-store",
-          "html-injection", "js-injection", "ldap-injection", "log-injection", "path-injection",
-          "request-forgery", "sql-injection", "url-redirection", "xpath-injection",
+          "html-injection", "js-injection", "ldap-injection", "log-injection", "nosql-injection",
+          "path-injection", "request-forgery", "sql-injection", "url-redirection",
+          "xpath-injection", "unsafe-deserialization",
           // Java-only currently, but may be shared in the future
           "bean-validation", "fragment-injection", "groovy-injection", "hostname-verification",
           "information-leak", "intent-redirection", "jexl-injection", "jndi-injection",
@@ -38,7 +39,7 @@ module KindValidation<KindValidationConfigSig Config> {
           "response-splitting", "trust-boundary-violation", "template-injection", "url-forward",
           "xslt-injection",
           // JavaScript-only currently, but may be shared in the future
-          "mongodb.sink", "nosql-injection", "unsafe-deserialization",
+          "mongodb.sink",
           // Swift-only currently, but may be shared in the future
           "database-store", "format-string", "hash-iteration-count", "predicate-injection",
           "preferences-store", "tls-protocol-version", "transmission", "webview-fetch", "xxe",


### PR DESCRIPTION
This PR allows sinks for `java/unsafe-deserialization` to be specified using models-as-data, and also converts some of the sinks to use that format and deprecates any classes that no longer have any uses. Many of the sinks have to stay defined in QL because they have extra logic around whether they are safe or not.

I ran MRVA on this query using 1000 repos and found no differences in the results before and after. There are also no test result differences except adding more models and changes to the numbering of the existing models. These two things give me confidence that the conversions have not changed behaviour.

