### PR TITLE
Actions: Diff-informed queries: phase 3 (non-trivial locations)

### DIFF
--- a/actions/ql/lib/codeql/actions/security/CommandInjectionQuery.qll
+++ b/actions/ql/lib/codeql/actions/security/CommandInjectionQuery.qll
@@ -3,6 +3,7 @@ private import codeql.actions.TaintTracking
 private import codeql.actions.dataflow.ExternalFlow
 import codeql.actions.dataflow.FlowSources
 import codeql.actions.DataFlow
+import codeql.actions.security.ControlChecks
 
 private class CommandInjectionSink extends DataFlow::Node {
   CommandInjectionSink() { madSink(this, "command-injection") }
@@ -16,6 +17,22 @@ private module CommandInjectionConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof CommandInjectionSink }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSourceLocation(DataFlow::Node source) { none() }
+
+  Location getASelectedSinkLocation(DataFlow::Node sink) {
+    result = sink.getLocation()
+    or
+    // where clause from CommandInjectionCritical.ql
+    exists(Event event | result = event.getLocation() |
+      inPrivilegedContext(sink.asExpr(), event) and
+      not exists(ControlCheck check |
+        check.protects(sink.asExpr(), event, ["command-injection", "code-injection"])
+      )
+    )
+  }
 }
 
 /** Tracks flow of unsafe user input that is used to construct and evaluate a system command. */


### PR DESCRIPTION
This PR enables diff-informed mode on queries that select a location other than dataflow source or sink. This entails adding a non-trivial location override that returns the locations that are actually selected.

Prior work includes PRs like #19663, #19759, and #19817. This PR uses the same patch script as those PRs to find candidate queries to convert to diff-enabled. This is the final step in mass-enabling diff-informed queries on all the languages.

Commit-by-commit reviewing is recommended.

* I have split the commits that add/modify tests from the ones that enable/disable diff-informed queries.
* If the commit modifies a .qll file, in the commit message I've included links to the queries that depend on that .qll for easier reviewing.
* Feel free to delegate parts of the review to others who may be more specialized in certain languages.
