### PR TITLE
C++: Diff-informed queries: phase 3 (non-trivial locations)

### DIFF
--- a/cpp/ql/src/Critical/OverflowDestination.ql
+++ b/cpp/ql/src/Critical/OverflowDestination.ql
@@ -82,6 +82,16 @@ module OverflowDestinationConfig implements DataFlow::ConfigSig {
       nodeIsBarrierEqualityCandidate(node, access, checkedVar)
     )
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSourceLocation(DataFlow::Node source) { none() }
+
+  Location getASelectedSinkLocation(DataFlow::Node sink) {
+    exists(FunctionCall fc | result = fc.getLocation() |
+      sourceSized(fc, sink.asIndirectConvertedExpr())
+    )
+  }
 }
 
 module OverflowDestination = TaintTracking::Global<OverflowDestinationConfig>;

--- a/cpp/ql/src/Likely Bugs/Format/NonConstantFormat.ql
+++ b/cpp/ql/src/Likely Bugs/Format/NonConstantFormat.ql
@@ -168,6 +168,19 @@ module NonConstFlowConfig implements DataFlow::ConfigSig {
       cannotContainString(t)
     )
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSourceLocation(DataFlow::Node source) { none() }
+
+  Location getASelectedSinkLocation(DataFlow::Node sink) {
+    result = sink.getLocation()
+    or
+    exists(FormattingFunctionCall call, Expr formatString | result = call.getLocation() |
+      isSinkImpl(sink, formatString) and
+      call.getArgument(call.getFormatParameterIndex()) = formatString
+    )
+  }
 }
 
 module NonConstFlow = TaintTracking::Global<NonConstFlowConfig>;

--- a/cpp/ql/src/Likely Bugs/Leap Year/LeapYear.qll
+++ b/cpp/ql/src/Likely Bugs/Leap Year/LeapYear.qll
@@ -215,6 +215,10 @@ private module LeapYearCheckConfig implements DataFlow::ConfigSig {
   predicate isSink(DataFlow::Node sink) {
     exists(ChecksForLeapYearFunctionCall fc | sink.asExpr() = fc.getAnArgument())
   }
+
+  predicate observeDiffInformedIncrementalMode() {
+    none() // only used negatively in UncheckedLeapYearAfterYearModification.ql
+  }
 }
 
 module LeapYearCheckFlow = DataFlow::Global<LeapYearCheckConfig>;
@@ -285,6 +289,14 @@ private module PossibleYearArithmeticOperationCheckConfig implements DataFlow::C
       aexpr.getLValue() = fa
     )
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSourceLocation(DataFlow::Node source) {
+    result = source.asExpr().getLocation()
+  }
+
+  Location getASelectedSinkLocation(DataFlow::Node sink) { result = sink.asExpr().getLocation() }
 }
 
 module PossibleYearArithmeticOperationCheckFlow =

--- a/cpp/ql/src/Security/CWE/CWE-020/ExternalAPIsSpecific.qll
+++ b/cpp/ql/src/Security/CWE/CWE-020/ExternalAPIsSpecific.qll
@@ -51,6 +51,10 @@ private module UntrustedDataToExternalApiConfig implements DataFlow::ConfigSig {
   }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof ExternalApiDataNode }
+
+  predicate observeDiffInformedIncrementalMode() {
+    none() // risky since used in library: normal use in UntrustedDataToExternalApi.ql; used via ExternalApiUsedWithUntrustedData (no location) in CountUntrustedDataToExternalAPI.ql
+  }
 }
 
 module UntrustedDataToExternalApiFlow = TaintTracking::Global<UntrustedDataToExternalApiConfig>;

--- a/cpp/ql/src/Security/CWE/CWE-020/ir/ExternalAPIsSpecific.qll
+++ b/cpp/ql/src/Security/CWE/CWE-020/ir/ExternalAPIsSpecific.qll
@@ -46,6 +46,10 @@ private module UntrustedDataToExternalApiConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof ExternalApiDataNode }
+
+  predicate observeDiffInformedIncrementalMode() {
+    none() // risky since used in library: normal use in IRUntrustedDataToExternalApi.ql; used via ExternalApiUsedWithUntrustedData (no location) in IRCountUntrustedDataToExternalAPI.ql
+  }
 }
 
 module UntrustedDataToExternalApiFlow = TaintTracking::Global<UntrustedDataToExternalApiConfig>;

--- a/cpp/ql/src/Security/CWE/CWE-022/TaintedPath.ql
+++ b/cpp/ql/src/Security/CWE/CWE-022/TaintedPath.ql
@@ -93,6 +93,12 @@ module TaintedPathConfig implements DataFlow::ConfigSig {
     // make sinks barriers so that we only report the closest instance
     isSink(node)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSinkLocation(DataFlow::Node sink) {
+    result = sink.asIndirectArgument().getLocation()
+  }
 }
 
 module TaintedPath = TaintTracking::Global<TaintedPathConfig>;

--- a/cpp/ql/src/Security/CWE/CWE-078/ExecTainted.ql
+++ b/cpp/ql/src/Security/CWE/CWE-078/ExecTainted.ql
@@ -150,6 +150,17 @@ module ExecTaintConfig implements DataFlow::StateConfigSig {
   predicate isBarrierOut(DataFlow::Node node) {
     isSink(node, _) // Prevent duplicates along a call chain, since `shellCommand` will include wrappers
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSinkLocation(DataFlow::Node sink) {
+    exists(DataFlow::Node concatResult, Expr command, ExecState state |
+      result = [concatResult.getLocation(), command.getLocation()] and
+      isSink(sink, state) and
+      isSinkImpl(sink, command, _) and
+      concatResult = state.getOutgoingNode()
+    )
+  }
 }
 
 module ExecTaint = TaintTracking::GlobalWithState<ExecTaintConfig>;

--- a/cpp/ql/src/Security/CWE/CWE-079/CgiXss.ql
+++ b/cpp/ql/src/Security/CWE/CWE-079/CgiXss.ql
@@ -39,6 +39,12 @@ module Config implements DataFlow::ConfigSig {
     or
     node.asCertainDefinition().getUnspecifiedType() instanceof ArithmeticType
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSourceLocation(DataFlow::Node source) {
+    exists(QueryString query | result = query.getLocation() | query = source.asIndirectExpr())
+  }
 }
 
 module Flow = TaintTracking::Global<Config>;

--- a/cpp/ql/src/Security/CWE/CWE-089/SqlTainted.ql
+++ b/cpp/ql/src/Security/CWE/CWE-089/SqlTainted.ql
@@ -54,6 +54,12 @@ module SqlTaintedConfig implements DataFlow::ConfigSig {
       sql.barrierSqlArgument(input, _)
     )
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSinkLocation(DataFlow::Node sink) {
+    exists(Expr taintedArg | result = taintedArg.getLocation() | taintedArg = asSinkExpr(sink))
+  }
 }
 
 module SqlTainted = TaintTracking::Global<SqlTaintedConfig>;

--- a/cpp/ql/src/Security/CWE/CWE-120/UnboundedWrite.ql
+++ b/cpp/ql/src/Security/CWE/CWE-120/UnboundedWrite.ql
@@ -124,6 +124,12 @@ module Config implements DataFlow::ConfigSig {
     // Block flow if the node is guarded by any <, <= or = operations.
     node = DataFlow::BarrierGuard<lessThanOrEqual/3>::getABarrierNode()
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSinkLocation(DataFlow::Node sink) {
+    exists(BufferWrite bw | result = bw.getLocation() | isSink(sink, bw, _))
+  }
 }
 
 module Flow = TaintTracking::Global<Config>;

--- a/cpp/ql/src/Security/CWE/CWE-170/ImproperNullTerminationTainted.ql
+++ b/cpp/ql/src/Security/CWE/CWE-170/ImproperNullTerminationTainted.ql
@@ -43,6 +43,12 @@ private module Config implements DataFlow::ConfigSig {
   }
 
   predicate isSink(DataFlow::Node sink) { isSink(sink, _) }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSinkLocation(DataFlow::Node sink) {
+    exists(VariableAccess va | result = va.getLocation() | isSink(sink, va))
+  }
 }
 
 module Flow = TaintTracking::Global<Config>;

--- a/cpp/ql/src/Security/CWE/CWE-190/ArithmeticTainted.ql
+++ b/cpp/ql/src/Security/CWE/CWE-190/ArithmeticTainted.ql
@@ -106,6 +106,12 @@ module Config implements DataFlow::ConfigSig {
       not iTo instanceof PointerArithmeticInstruction
     )
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSinkLocation(DataFlow::Node sink) {
+    exists(Expr e | result = e.getLocation() | isSink(sink, _, e))
+  }
 }
 
 module Flow = TaintTracking::Global<Config>;

--- a/cpp/ql/src/Security/CWE/CWE-190/ArithmeticUncontrolled.ql
+++ b/cpp/ql/src/Security/CWE/CWE-190/ArithmeticUncontrolled.ql
@@ -120,6 +120,12 @@ module UncontrolledArithConfig implements DataFlow::ConfigSig {
     // block unintended flow to pointers
     node.asExpr().getUnspecifiedType() instanceof PointerType
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSourceLocation(DataFlow::Node source) {
+    result = getExpr(source).getLocation()
+  }
 }
 
 module UncontrolledArith = TaintTracking::Global<UncontrolledArithConfig>;

--- a/cpp/ql/src/Security/CWE/CWE-190/ArithmeticWithExtremeValues.ql
+++ b/cpp/ql/src/Security/CWE/CWE-190/ArithmeticWithExtremeValues.ql
@@ -113,6 +113,12 @@ module Config implements DataFlow::ConfigSig {
       not iTo instanceof PointerArithmeticInstruction
     )
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSinkLocation(DataFlow::Node sink) {
+    exists(VariableAccess va | result = va.getLocation() | isSink(sink, va, _))
+  }
 }
 
 module Flow = TaintTracking::Global<Config>;

--- a/cpp/ql/src/Security/CWE/CWE-190/TaintedAllocationSize.ql
+++ b/cpp/ql/src/Security/CWE/CWE-190/TaintedAllocationSize.ql
@@ -91,6 +91,12 @@ module TaintedAllocationSizeConfig implements DataFlow::ConfigSig {
     // to duplicate results)
     any(HeuristicAllocationFunction f).getAParameter() = node.asParameter()
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSinkLocation(DataFlow::Node sink) {
+    exists(Expr alloc | result = alloc.getLocation() | allocSink(alloc, sink))
+  }
 }
 
 module TaintedAllocationSize = TaintTracking::Global<TaintedAllocationSizeConfig>;

--- a/cpp/ql/src/Security/CWE/CWE-290/AuthenticationBypass.ql
+++ b/cpp/ql/src/Security/CWE/CWE-290/AuthenticationBypass.ql
@@ -72,6 +72,12 @@ module Config implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) { isSource(source, _) }
 
   predicate isSink(DataFlow::Node sink) { isSink(sink, _) }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSinkLocation(DataFlow::Node sink) {
+    exists(Expr condition | result = condition.getLocation() | isSink(sink, condition))
+  }
 }
 
 module Flow = TaintTracking::Global<Config>;

--- a/cpp/ql/src/Security/CWE/CWE-295/SSLResultConflation.ql
+++ b/cpp/ql/src/Security/CWE/CWE-295/SSLResultConflation.ql
@@ -31,6 +31,14 @@ module VerifyResultConfig implements DataFlow::ConfigSig {
   predicate isSink(DataFlow::Node sink) {
     exists(GuardCondition guard | guard.getAChild*() = sink.asExpr())
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSinkLocation(DataFlow::Node sink) {
+    exists(GuardCondition guard | result = guard.getLocation() |
+      guard.comparesEq(sink.asExpr(), _, 0, false, _)
+    )
+  }
 }
 
 module VerifyResult = DataFlow::Global<VerifyResultConfig>;

--- a/cpp/ql/src/Security/CWE/CWE-311/CleartextBufferWrite.ql
+++ b/cpp/ql/src/Security/CWE/CWE-311/CleartextBufferWrite.ql
@@ -47,6 +47,12 @@ module ToBufferConfig implements DataFlow::ConfigSig {
   }
 
   predicate isSink(DataFlow::Node sink) { isSinkImpl(sink, _) }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSinkLocation(DataFlow::Node sink) {
+    exists(SensitiveBufferWrite w | result = w.getLocation() | isSinkImpl(sink, w))
+  }
 }
 
 module ToBufferFlow = TaintTracking::Global<ToBufferConfig>;

--- a/cpp/ql/src/Security/CWE/CWE-311/CleartextFileWrite.ql
+++ b/cpp/ql/src/Security/CWE/CWE-311/CleartextFileWrite.ql
@@ -31,6 +31,16 @@ module FromSensitiveConfig implements DataFlow::ConfigSig {
   predicate isBarrier(DataFlow::Node node) {
     node.asExpr().getUnspecifiedType() instanceof IntegralType
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSourceLocation(DataFlow::Node sourceNode) {
+    exists(SensitiveExpr source | result = source.getLocation() | isSourceImpl(sourceNode, source))
+  }
+
+  Location getASelectedSinkLocation(DataFlow::Node sink) {
+    exists(FileWrite w | result = w.getLocation() | isSinkImpl(sink, w, _))
+  }
 }
 
 module FromSensitiveFlow = TaintTracking::Global<FromSensitiveConfig>;

--- a/cpp/ql/src/Security/CWE/CWE-311/CleartextTransmission.ql
+++ b/cpp/ql/src/Security/CWE/CWE-311/CleartextTransmission.ql
@@ -245,6 +245,14 @@ module FromSensitiveConfig implements DataFlow::ConfigSig {
     // sources to not get path duplication.
     isSource(node)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSinkLocation(DataFlow::Node sink) {
+    exists(NetworkSendRecv networkSendRecv | result = networkSendRecv.getLocation() |
+      isSinkSendRecv(sink, networkSendRecv)
+    )
+  }
 }
 
 module FromSensitiveFlow = TaintTracking::Global<FromSensitiveConfig>;
@@ -266,6 +274,10 @@ module ToEncryptionConfig implements DataFlow::ConfigSig {
     // sources to not get path duplication.
     isSource(node)
   }
+
+  predicate observeDiffInformedIncrementalMode() {
+    none() // only used negatively
+  }
 }
 
 module ToEncryptionFlow = TaintTracking::Global<ToEncryptionConfig>;
@@ -280,6 +292,10 @@ module FromEncryptionConfig implements DataFlow::ConfigSig {
 
   predicate isBarrier(DataFlow::Node node) {
     node.asExpr().getUnspecifiedType() instanceof IntegralType
+  }
+
+  predicate observeDiffInformedIncrementalMode() {
+    none() // only used negatively
   }
 }
 

--- a/cpp/ql/src/Security/CWE/CWE-313/CleartextSqliteDatabase.ql
+++ b/cpp/ql/src/Security/CWE/CWE-313/CleartextSqliteDatabase.ql
@@ -123,6 +123,20 @@ module FromSensitiveConfig implements DataFlow::ConfigSig {
       content.(DataFlow::FieldContent).getField() = getRecField(t.stripType())
     )
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSourceLocation(DataFlow::Node source) {
+    exists(SensitiveExpr sensitive | result = sensitive.getLocation() |
+      isSourceImpl(source, sensitive)
+    )
+  }
+
+  Location getASelectedSinkLocation(DataFlow::Node sink) {
+    exists(SqliteFunctionCall sqliteCall | result = sqliteCall.getLocation() |
+      isSinkImpl(sink, sqliteCall, _)
+    )
+  }
 }
 
 module FromSensitiveFlow = TaintTracking::Global<FromSensitiveConfig>;

--- a/cpp/ql/src/Security/CWE/CWE-319/UseOfHttp.ql
+++ b/cpp/ql/src/Security/CWE/CWE-319/UseOfHttp.ql
@@ -87,6 +87,14 @@ module HttpStringToUrlOpenConfig implements DataFlow::ConfigSig {
       sink.asIndirectExpr() = fc.getArgument(3)
     )
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSourceLocation(DataFlow::Node source) {
+    result = source.asIndirectExpr().getLocation()
+  }
+
+  Location getASelectedSinkLocation(DataFlow::Node sink) { none() }
 }
 
 module HttpStringToUrlOpen = TaintTracking::Global<HttpStringToUrlOpenConfig>;

--- a/cpp/ql/src/Security/CWE/CWE-326/InsufficientKeySize.ql
+++ b/cpp/ql/src/Security/CWE/CWE-326/InsufficientKeySize.ql
@@ -44,6 +44,12 @@ module KeyStrengthFlowConfig implements DataFlow::ConfigSig {
       exists(getMinimumKeyStrength(name, param))
     )
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSinkLocation(DataFlow::Node sink) {
+    exists(FunctionCall fc | result = fc.getLocation() | sink.asExpr() = fc.getArgument(_))
+  }
 }
 
 module KeyStrengthFlow = DataFlow::Global<KeyStrengthFlowConfig>;

--- a/cpp/ql/src/Security/CWE/CWE-416/IteratorToExpiredContainer.ql
+++ b/cpp/ql/src/Security/CWE/CWE-416/IteratorToExpiredContainer.ql
@@ -145,6 +145,18 @@ module Config implements DataFlow::StateConfigSig {
     // ```
     result instanceof DataFlow::FeatureHasSinkCallContext
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSourceLocation(DataFlow::Node source) { none() }
+
+  Location getASelectedSinkLocation(DataFlow::Node sink) {
+    exists(DataFlow::Node mid, FlowState state | result = mid.getLocation() |
+      destroyedToBeginSink(sink) and
+      isSink(sink, state) and
+      state = Config::DestroyedToBegin(mid)
+    )
+  }
 }
 
 module Flow = DataFlow::GlobalWithState<Config>;

--- a/cpp/ql/src/Security/CWE/CWE-428/UnsafeCreateProcessCall.ql
+++ b/cpp/ql/src/Security/CWE/CWE-428/UnsafeCreateProcessCall.ql
@@ -62,6 +62,16 @@ module NullAppNameCreateProcessFunctionConfig implements DataFlow::ConfigSig {
       val = call.getArgument(call.getApplicationNameArgumentId())
     )
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSourceLocation(DataFlow::Node source) { none() }
+
+  Location getASelectedSinkLocation(DataFlow::Node sink) {
+    exists(CreateProcessFunctionCall call | result = call.getLocation() |
+      sink.asExpr() = call.getArgument(call.getApplicationNameArgumentId())
+    )
+  }
 }
 
 module NullAppNameCreateProcessFunction = DataFlow::Global<NullAppNameCreateProcessFunctionConfig>;
@@ -80,6 +90,16 @@ module QuotedCommandInCreateProcessFunctionConfig implements DataFlow::ConfigSig
   predicate isSink(DataFlow::Node sink) {
     exists(CreateProcessFunctionCall call, Expr val | val = sink.asExpr() |
       val = call.getArgument(call.getCommandLineArgumentId())
+    )
+  }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSourceLocation(DataFlow::Node source) { none() }
+
+  Location getASelectedSinkLocation(DataFlow::Node sink) {
+    exists(CreateProcessFunctionCall call | result = call.getLocation() |
+      sink.asExpr() = call.getArgument(call.getCommandLineArgumentId())
     )
   }
 }

--- a/cpp/ql/src/Security/CWE/CWE-732/UnsafeDaclSecurityDescriptor.ql
+++ b/cpp/ql/src/Security/CWE/CWE-732/UnsafeDaclSecurityDescriptor.ql
@@ -37,6 +37,16 @@ module NullDaclConfig implements DataFlow::ConfigSig {
       val = call.getArgument(2)
     )
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSourceLocation(DataFlow::Node source) { none() }
+
+  Location getASelectedSinkLocation(DataFlow::Node sink) {
+    exists(SetSecurityDescriptorDaclFunctionCall call | result = call.getLocation() |
+      sink.asExpr() = call.getArgument(2)
+    )
+  }
 }
 
 module NullDaclFlow = DataFlow::Global<NullDaclConfig>;
@@ -67,6 +77,10 @@ module NonNullDaclConfig implements DataFlow::ConfigSig {
 
   predicate isSink(DataFlow::Node sink) {
     exists(SetSecurityDescriptorDaclFunctionCall call | sink.asExpr() = call.getArgument(2))
+  }
+
+  predicate observeDiffInformedIncrementalMode() {
+    none() // only used negatively
   }
 }
 

--- a/cpp/ql/src/Security/CWE/CWE-807/TaintedCondition.ql
+++ b/cpp/ql/src/Security/CWE/CWE-807/TaintedCondition.ql
@@ -65,6 +65,16 @@ module Config implements DataFlow::ConfigSig {
       iFrom1 != iFrom2
     )
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSinkLocation(DataFlow::Node sink) {
+    result = sink.getLocation()
+    or
+    exists(Expr raise | result = raise.getLocation() |
+      sensitiveCondition([sink.asExpr(), sink.asIndirectExpr()], raise)
+    )
+  }
 }
 
 module Flow = TaintTracking::Global<Config>;

--- a/cpp/ql/src/Security/CWE/CWE-843/TypeConfusion.ql
+++ b/cpp/ql/src/Security/CWE/CWE-843/TypeConfusion.ql
@@ -178,6 +178,10 @@ module Config implements DataFlow::ConfigSig {
   predicate isSink(DataFlow::Node sink) { sink.asExpr() = any(UnsafeCast cast).getUnconverted() }
 
   int fieldFlowBranchLimit() { result = 0 }
+
+  predicate observeDiffInformedIncrementalMode() {
+    none() // used both positively and negatively
+  }
 }
 
 module Flow = DataFlow::Global<Config>;

--- a/cpp/ql/src/experimental/Security/CWE/CWE-193/ConstantSizeArrayOffByOne.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-193/ConstantSizeArrayOffByOne.ql
@@ -183,6 +183,20 @@ module ArrayAddressToDerefConfig implements DataFlow::StateConfigSig {
       pointerArithOverflow(pai, _)
     )
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSourceLocation(DataFlow::Node source) {
+    exists(Variable v | result = v.getLocation() | isSourceImpl(source, v))
+  }
+
+  Location getASelectedSinkLocation(DataFlow::Node sink) {
+    exists(PointerArithmeticInstruction pai, Instruction deref |
+      result = [pai, deref].getLocation() and
+      isInvalidPointerDerefSink2(sink, deref, _) and
+      isSink(sink, ArrayAddressToDerefConfig::TOverflowArithmetic(pai))
+    )
+  }
 }
 
 module ArrayAddressToDerefFlow = DataFlow::GlobalWithState<ArrayAddressToDerefConfig>;

--- a/cpp/ql/src/experimental/Security/CWE/CWE-409/DecompressionBombs.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-409/DecompressionBombs.ql
@@ -28,6 +28,14 @@ module DecompressionTaintConfig implements DataFlow::ConfigSig {
   predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
     any(DecompressionFlowStep s).isAdditionalFlowStep(node1, node2)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSourceLocation(DataFlow::Node source) { none() }
+
+  Location getASelectedSinkLocation(DataFlow::Node sink) {
+    exists(FunctionCall fc | result = [sink.getLocation(), fc.getLocation()] | isSink(fc, sink))
+  }
 }
 
 module DecompressionTaint = TaintTracking::Global<DecompressionTaintConfig>;

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-020/CountUntrustedDataToExternalAPI.qlref
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-020/CountUntrustedDataToExternalAPI.qlref
@@ -1,0 +1,4 @@
+query: Security/CWE/CWE-020/CountUntrustedDataToExternalAPI.ql
+postprocess:
+ - utils/test/PrettyPrintModels.ql
+ - utils/test/InlineExpectationsTestQuery.ql

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-020/ExternalAPISinkExample.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-020/ExternalAPISinkExample.cpp
@@ -1,0 +1,18 @@
+typedef unsigned long size_t;
+typedef size_t FILE;
+
+char *strcat(char *s1, const char *s2);
+char *fgets(char *s, int n, FILE *stream);
+char *fputs(const char *s, FILE *stream);
+
+void do_get(FILE* request, FILE* response) {
+  char page[1024];
+  fgets(page, 1024, request);
+
+  char buffer[1024];
+  strcat(buffer, "The page \"");
+  strcat(buffer, page);
+  strcat(buffer, "\" was not found.");
+
+  fputs(buffer, response);
+}

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-020/ExternalAPITaintStepExample.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-020/ExternalAPITaintStepExample.cpp
@@ -1,0 +1,18 @@
+typedef unsigned long size_t;
+typedef size_t FILE;
+
+char *strcat(char *s1, const char *s2);
+char *fgets(char *s, int n, FILE *stream);
+char *fputs(const char *s, FILE *stream);
+
+void do_get(FILE* request, FILE* response) {
+  char user_id[1024];
+  fgets(user_id, 1024, request);
+
+  char buffer[1024];
+  strcat(buffer, "SELECT * FROM user WHERE user_id='");
+  strcat(buffer, user_id);
+  strcat(buffer, "'");
+
+  // ...
+}

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-020/IRCountUntrustedDataToExternalAPI.qlref
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-020/IRCountUntrustedDataToExternalAPI.qlref
@@ -1,0 +1,4 @@
+query: Security/CWE/CWE-020/IRCountUntrustedDataToExternalAPI.ql
+postprocess:
+ - utils/test/PrettyPrintModels.ql
+ - utils/test/InlineExpectationsTestQuery.ql

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-020/IRUntrustedDataToExternalAPI.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-020/IRUntrustedDataToExternalAPI.expected
@@ -1,0 +1,4 @@
+#select
+edges
+nodes
+subpaths

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-020/IRUntrustedDataToExternalAPI.qlref
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-020/IRUntrustedDataToExternalAPI.qlref
@@ -1,0 +1,4 @@
+query: Security/CWE/CWE-020/IRUntrustedDataToExternalAPI.ql
+postprocess:
+ - utils/test/PrettyPrintModels.ql
+ - utils/test/InlineExpectationsTestQuery.ql

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-020/UntrustedDataToExternalAPI.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-020/UntrustedDataToExternalAPI.expected
@@ -1,0 +1,4 @@
+#select
+edges
+nodes
+subpaths

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-020/UntrustedDataToExternalAPI.qlref
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-020/UntrustedDataToExternalAPI.qlref
@@ -1,0 +1,4 @@
+query: Security/CWE/CWE-020/UntrustedDataToExternalAPI.ql
+postprocess:
+ - utils/test/PrettyPrintModels.ql
+ - utils/test/InlineExpectationsTestQuery.ql

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-313/CleartextSqliteDatabase.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-313/CleartextSqliteDatabase.cpp
@@ -1,0 +1,121 @@
+typedef unsigned long size_t;
+typedef struct sqlite3 sqlite3;
+typedef struct sqlite3_stmt sqlite3_stmt;
+typedef struct sqlite3_str sqlite3_str;
+
+int snprintf(char *str, size_t size, const char *format, ...);
+int sqlite3_open(const char *filename, sqlite3 **ppDb);
+int sqlite3_close(sqlite3*);
+int sqlite3_exec(sqlite3*, const char *sql, int (*callback)(void*,int,char**,char**), void *, char **errmsg);
+int sqlite3_prepare_v2(sqlite3 *db, const char *zSql, int nByte, sqlite3_stmt **ppStmt, const char **pzTail);
+int sqlite3_step(sqlite3_stmt*);
+int sqlite3_finalize(sqlite3_stmt*);
+int sqlite3_bind_text(sqlite3_stmt*, int, const char*, int n, void(*)(void*));
+sqlite3_str* sqlite3_str_new(sqlite3*);
+void sqlite3_str_appendf(sqlite3_str*, const char *zFormat, ...);
+char* sqlite3_str_finish(sqlite3_str*);
+
+#define SQLITE_TRANSIENT ((void(*)(void*))-1)
+
+// Simulate a sensitive value
+const char* getSensitivePassword() {
+    return "super_secret_password";
+}
+
+void storePasswordCleartext(sqlite3* db, const char* password) {
+    // BAD: Storing sensitive data in cleartext
+    char sql[256];
+    // Unsafe: no escaping, for test purposes only
+    snprintf(sql, sizeof(sql), "INSERT INTO users(password) VALUES('%s');", password); // $ Source
+    char* errMsg = 0;
+    sqlite3_exec(db, sql, 0, 0, &errMsg); // $ Alert
+}
+
+void storePasswordWithPrepare(sqlite3* db, const char* password) {
+    // BAD: Storing sensitive data in cleartext using sqlite3_prepare
+    char sql[256];
+    snprintf(sql, sizeof(sql), "INSERT INTO users(password) VALUES('%s');", password); // $ Source
+    sqlite3_stmt* stmt = 0;
+    sqlite3_prepare_v2(db, sql, -1, &stmt, 0); // $ Alert
+    sqlite3_step(stmt);
+    sqlite3_finalize(stmt);
+}
+
+void storePasswordWithBind(sqlite3* db, const char* password) {
+    // BAD: Storing sensitive data in cleartext using sqlite3_bind_text
+    const char* sql = "INSERT INTO users(password) VALUES(?);";
+    sqlite3_stmt* stmt = 0;
+    sqlite3_prepare_v2(db, sql, -1, &stmt, 0);
+    sqlite3_bind_text(stmt, 1, password, -1, SQLITE_TRANSIENT); // $ Alert
+    sqlite3_step(stmt);
+    sqlite3_finalize(stmt);
+}
+
+void storePasswordWithAppendf(sqlite3_str* pStr, const char* password) {
+    // BAD: Storing sensitive data in cleartext using sqlite3_str_appendf
+    sqlite3_str_appendf(pStr, "INSERT INTO users(password) VALUES('%s');", password); // $ Alert
+}
+
+// Example sanitizer: hashes the sensitive value before storage
+void hashSensitiveValue(const char* input, char* output, size_t outSize) {
+    // Dummy hash for illustration (not cryptographically secure)
+    unsigned int hash = 5381;
+    for (const char* p = input; *p; ++p)
+        hash = ((hash << 5) + hash) + (unsigned char)(*p);
+    snprintf(output, outSize, "%u", hash);
+}
+
+void storeSanitizedPasswordCleartext(sqlite3* db, const char* password) {
+    // GOOD: Sanitizing sensitive data before storage
+    char hashed[64];
+    hashSensitiveValue(password, hashed, sizeof(hashed));
+    char sql[256];
+    snprintf(sql, sizeof(sql), "INSERT INTO users(password) VALUES('%s');", hashed);
+    char* errMsg = 0;
+    sqlite3_exec(db, sql, 0, 0, &errMsg);
+}
+
+void storeSanitizedPasswordWithBind(sqlite3* db, const char* password) {
+    // GOOD: Sanitizing sensitive data before storage with bind
+    char hashed[64];
+    hashSensitiveValue(password, hashed, sizeof(hashed));
+    const char* sql = "INSERT INTO users(password) VALUES(?);";
+    sqlite3_stmt* stmt = 0;
+    sqlite3_prepare_v2(db, sql, -1, &stmt, 0);
+    sqlite3_bind_text(stmt, 1, hashed, -1, SQLITE_TRANSIENT);
+    sqlite3_step(stmt);
+    sqlite3_finalize(stmt);
+}
+
+void storeSanitizedPasswordWithAppendf(sqlite3_str* pStr, const char* password) {
+    // GOOD: Sanitizing sensitive data before storage with appendf
+    char hashed[64];
+    hashSensitiveValue(password, hashed, sizeof(hashed));
+    sqlite3_str_appendf(pStr, "INSERT INTO users(password) VALUES('%s');", hashed);
+}
+
+int main() {
+    sqlite3* db = 0;
+    sqlite3_open(":memory:", &db);
+
+    // Create table
+    const char* createTableSQL = "CREATE TABLE users(id INTEGER PRIMARY KEY, password TEXT);";
+    sqlite3_exec(db, createTableSQL, 0, 0, 0);
+
+    const char* sensitive = getSensitivePassword();
+
+    storePasswordCleartext(db, sensitive);
+    storePasswordWithPrepare(db, sensitive);
+    storePasswordWithBind(db, sensitive);
+    storeSanitizedPasswordCleartext(db, sensitive);
+    storeSanitizedPasswordWithBind(db, sensitive);
+
+    // If sqlite3_str is available
+    sqlite3_str* pStr = sqlite3_str_new(db);
+    storePasswordWithAppendf(pStr, sensitive);
+    storeSanitizedPasswordWithAppendf(pStr, sensitive);
+    sqlite3_str_finish(pStr);
+
+    sqlite3_close(db);
+    return 0;
+}

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-313/CleartextSqliteDatabase.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-313/CleartextSqliteDatabase.expected
@@ -1,0 +1,16 @@
+#select
+| CleartextSqliteDatabase.cpp:31:5:31:16 | call to sqlite3_exec | CleartextSqliteDatabase.cpp:29:77:29:84 | password | CleartextSqliteDatabase.cpp:31:22:31:24 | *sql | This SQLite call may store $@ in a non-encrypted SQLite database. | CleartextSqliteDatabase.cpp:29:77:29:84 | password | sensitive information |
+| CleartextSqliteDatabase.cpp:39:5:39:22 | call to sqlite3_prepare_v2 | CleartextSqliteDatabase.cpp:37:77:37:84 | password | CleartextSqliteDatabase.cpp:39:28:39:30 | *sql | This SQLite call may store $@ in a non-encrypted SQLite database. | CleartextSqliteDatabase.cpp:37:77:37:84 | password | sensitive information |
+| CleartextSqliteDatabase.cpp:49:5:49:21 | call to sqlite3_bind_text | CleartextSqliteDatabase.cpp:49:32:49:39 | password | CleartextSqliteDatabase.cpp:49:32:49:39 | password | This SQLite call may store $@ in a non-encrypted SQLite database. | CleartextSqliteDatabase.cpp:49:32:49:39 | password | sensitive information |
+| CleartextSqliteDatabase.cpp:56:5:56:23 | call to sqlite3_str_appendf | CleartextSqliteDatabase.cpp:56:76:56:83 | password | CleartextSqliteDatabase.cpp:56:76:56:83 | password | This SQLite call may store $@ in a non-encrypted SQLite database. | CleartextSqliteDatabase.cpp:56:76:56:83 | password | sensitive information |
+edges
+| CleartextSqliteDatabase.cpp:29:77:29:84 | password | CleartextSqliteDatabase.cpp:31:22:31:24 | *sql | provenance | TaintFunction |
+| CleartextSqliteDatabase.cpp:37:77:37:84 | password | CleartextSqliteDatabase.cpp:39:28:39:30 | *sql | provenance | TaintFunction |
+nodes
+| CleartextSqliteDatabase.cpp:29:77:29:84 | password | semmle.label | password |
+| CleartextSqliteDatabase.cpp:31:22:31:24 | *sql | semmle.label | *sql |
+| CleartextSqliteDatabase.cpp:37:77:37:84 | password | semmle.label | password |
+| CleartextSqliteDatabase.cpp:39:28:39:30 | *sql | semmle.label | *sql |
+| CleartextSqliteDatabase.cpp:49:32:49:39 | password | semmle.label | password |
+| CleartextSqliteDatabase.cpp:56:76:56:83 | password | semmle.label | password |
+subpaths

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-313/CleartextSqliteDatabase.qlref
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-313/CleartextSqliteDatabase.qlref
@@ -1,0 +1,4 @@
+query: Security/CWE/CWE-313/CleartextSqliteDatabase.ql
+postprocess:
+ - utils/test/PrettyPrintModels.ql
+ - utils/test/InlineExpectationsTestQuery.ql


### PR DESCRIPTION
This PR enables diff-informed mode on queries that select a location other than dataflow source or sink. This entails adding a non-trivial location override that returns the locations that are actually selected.

Prior work includes PRs like https://github.com/github/codeql/pull/19663, https://github.com/github/codeql/pull/19759, and https://github.com/github/codeql/pull/19817. This PR uses the same patch script as those PRs to find candidate queries to convert to diff-enabled. This is the final step in mass-enabling diff-informed queries on all the languages.

Commit-by-commit reviewing is recommended.

- I have split the commits that add/modify tests from the ones that enable/disable diff-informed queries.
- If the commit modifies a .qll file, in the commit message I've included links to the queries that depend on that .qll for easier reviewing.
- Feel free to delegate parts of the review to others who may be more specialized in certain languages.

Potentially tricky cases:

- [[TEST] C++: CWE-020/ExternalAPI: add tests based on qlhelp](https://github.com/github/codeql/pull/19957/commits/6485899024496ec117edc76ae64a76c1f3d6230d): I wasn't able to get alerts to show up for the qhelp-based tests; can someone from the language team chip in to what a useful test would look like? Similar case with the [Python TimingAttackAgainstHash test](https://github.com/github/codeql/pull/19957/commits/7f9570d9fa79d7fca7d3a270220c2aa0c4487005). In contrast, in [[TEST] Java: CWE-020/ExternalAPI](https://github.com/github/codeql/pull/19957/commits/999e74e6484c073474357ccbc119732fe58ee5ec) I was able to get alerts just from the qhelp example, and in [[TEST] C++: CleartextSqliteDatabase](https://github.com/github/codeql/pull/19957/commits/9fda6f5c86912cf41ae739271fb27b59de3fca13) I was able to get alerts from a mostly Copilot-written test.
