### PR TITLE
C#: Diff-informed queries: phase 3 (non-trivial locations)

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/security/dataflow/ConditionalBypassQuery.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/dataflow/ConditionalBypassQuery.qll
@@ -39,6 +39,15 @@ private module ConditionalBypassConfig implements DataFlow::ConfigSig {
   predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
 
   predicate isBarrier(DataFlow::Node node) { node instanceof Sanitizer }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSinkLocation(DataFlow::Node sink) {
+    result = sink.getLocation()
+    or
+    // from ConditionalBypass.ql
+    result = sink.(Sink).getSensitiveMethodCall().getLocation()
+  }
 }
 
 /**

--- a/csharp/ql/lib/semmle/code/csharp/security/dataflow/ExternalAPIsQuery.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/dataflow/ExternalAPIsQuery.qll
@@ -78,6 +78,8 @@ private module RemoteSourceToExternalApiConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) { source instanceof ActiveThreatModelSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof ExternalApiDataNode }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /** A module for tracking flow from `ActiveThreatModelSource`s to `ExternalApiDataNode`s. */

--- a/csharp/ql/lib/semmle/code/csharp/security/dataflow/UnsafeDeserializationQuery.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/dataflow/UnsafeDeserializationQuery.qll
@@ -59,6 +59,10 @@ private module TaintToObjectMethodTrackingConfig implements DataFlow::ConfigSig 
   predicate isSink(DataFlow::Node sink) { sink instanceof InstanceMethodSink }
 
   predicate isBarrier(DataFlow::Node node) { node instanceof Sanitizer }
+
+  predicate observeDiffInformedIncrementalMode() {
+    any() // used in one of the disjuncts in UnsafeDeserializationUntrustedInput.ql
+  }
 }
 
 /**
@@ -77,6 +81,10 @@ private module JsonConvertTrackingConfig implements DataFlow::ConfigSig {
   }
 
   predicate isBarrier(DataFlow::Node node) { node instanceof Sanitizer }
+
+  predicate observeDiffInformedIncrementalMode() {
+    any() // used in one of the disjuncts in UnsafeDeserializationUntrustedInput.ql
+  }
 }
 
 /**
@@ -133,6 +141,10 @@ private module TypeNameTrackingConfig implements DataFlow::ConfigSig {
       )
     )
   }
+
+  predicate observeDiffInformedIncrementalMode() {
+    none() // Only used as secondary config in UnsafeDeserializationUntrustedInput.ql
+  }
 }
 
 /**
@@ -149,6 +161,10 @@ private module TaintToConstructorOrStaticMethodTrackingConfig implements DataFlo
   predicate isSink(DataFlow::Node sink) { sink instanceof ConstructorOrStaticMethodSink }
 
   predicate isBarrier(DataFlow::Node node) { node instanceof Sanitizer }
+
+  predicate observeDiffInformedIncrementalMode() {
+    any() // used in one of the disjuncts in UnsafeDeserializationUntrustedInput.ql
+  }
 }
 
 /**
@@ -186,6 +202,10 @@ private module TaintToObjectTypeTrackingConfig implements DataFlow::ConfigSig {
       oc.getObjectType() instanceof StrongTypeDeserializer
     )
   }
+
+  predicate observeDiffInformedIncrementalMode() {
+    none() // only used as secondary config in UnsafeDeserializationUntrustedInput.ql
+  }
 }
 
 /**
@@ -209,6 +229,10 @@ private module WeakTypeCreationToUsageTrackingConfig implements DataFlow::Config
       mc.getTarget() instanceof UnsafeDeserializer and
       sink.asExpr() = mc.getQualifier()
     )
+  }
+
+  predicate observeDiffInformedIncrementalMode() {
+    none() // only used as secondary config in UnsafeDeserializationUntrustedInput.ql
   }
 }
 

--- a/csharp/ql/src/Likely Bugs/ThreadUnsafeICryptoTransformLambda.ql
+++ b/csharp/ql/src/Likely Bugs/ThreadUnsafeICryptoTransformLambda.ql
@@ -24,6 +24,8 @@ module NotThreadSafeCryptoUsageIntoParallelInvokeConfig implements DataFlow::Con
   }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof ParallelSink }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 module NotThreadSafeCryptoUsageIntoParallelInvoke =

--- a/csharp/ql/src/Security Features/CWE-798/HardcodedConnectionString.ql
+++ b/csharp/ql/src/Security Features/CWE-798/HardcodedConnectionString.ql
@@ -38,6 +38,12 @@ module ConnectionStringConfig implements DataFlow::ConfigSig {
   }
 
   predicate isBarrier(DataFlow::Node node) { node instanceof StringFormatSanitizer }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSinkLocation(DataFlow::Node sink) {
+    any(Call call | call.getAnArgument() = sink.asExpr()).getLocation() = result
+  }
 }
 
 /**


### PR DESCRIPTION
This PR enables diff-informed mode on queries that select a location other than dataflow source or sink. This entails adding a non-trivial location override that returns the locations that are actually selected.

Prior work includes PRs like https://github.com/github/codeql/pull/19663, https://github.com/github/codeql/pull/19759, and https://github.com/github/codeql/pull/19817. This PR uses the same patch script as those PRs to find candidate queries to convert to diff-enabled. This is the final step in mass-enabling diff-informed queries on all the languages.

Commit-by-commit reviewing is recommended.

- I have split the commits that add/modify tests from the ones that enable/disable diff-informed queries.
- If the commit modifies a .qll file, in the commit message I've included links to the queries that depend on that .qll for easier reviewing.
- Feel free to delegate parts of the review to others who may be more specialized in certain languages.
