### PR TITLE
Rust: Type inference refactor and improve join orders

### DIFF
--- a/shared/typeinference/codeql/typeinference/internal/TypeInference.qll
+++ b/shared/typeinference/codeql/typeinference/internal/TypeInference.qll
@@ -989,7 +989,7 @@ module Make1<LocationSig Location, InputSig1<Location> Input1> {
           path = prefix0.append(suffix)
         )
         or
-        tt.getTypeAt(TypePath::nil()) = constraint and
+        hasTypeConstraint(tt, constraint, constraint) and
         t = tt.getTypeAt(path)
       }
     }

--- a/shared/typeinference/codeql/typeinference/internal/TypeInference.qll
+++ b/shared/typeinference/codeql/typeinference/internal/TypeInference.qll
@@ -1229,11 +1229,8 @@ module Make1<LocationSig Location, InputSig1<Location> Input1> {
         predicate relevantAccessConstraint(
           Access a, Declaration target, AccessPosition apos, TypePath path, Type constraint
         ) {
-          exists(DeclarationPosition dpos |
-            accessDeclarationPositionMatch(apos, dpos) and
-            target = a.getTarget() and
-            typeParameterConstraintHasTypeParameter(target, dpos, path, _, constraint, _, _)
-          )
+          target = a.getTarget() and
+          typeParameterConstraintHasTypeParameter(target, apos, path, constraint, _, _)
         }
 
         private newtype TRelevantAccess =
@@ -1276,12 +1273,11 @@ module Make1<LocationSig Location, InputSig1<Location> Input1> {
         }
 
         predicate satisfiesConstraintType(
-          Access a, AccessPosition apos, TypePath prefix, Type constraint, TypePath path, Type t
+          Access a, Declaration target, AccessPosition apos, TypePath prefix, Type constraint,
+          TypePath path, Type t
         ) {
-          exists(RelevantAccess at | at = MkRelevantAccess(a, _, apos, prefix) |
-            SatisfiesConstraint<RelevantAccess, SatisfiesConstraintInput>::satisfiesConstraintType(at,
-              constraint, path, t)
-          )
+          SatisfiesConstraint<RelevantAccess, SatisfiesConstraintInput>::satisfiesConstraintType(MkRelevantAccess(a,
+              target, apos, prefix), constraint, path, t)
         }
       }
 
@@ -1370,37 +1366,38 @@ module Make1<LocationSig Location, InputSig1<Location> Input1> {
       }
 
       /**
-       * Holds if `tp1` and `tp2` are distinct type parameters of `target`, the
-       * declared type at `dpos` mentions `tp1` at `path1`, `tp1` has a base
-       * type mention of type `constraint` that mentions `tp2` at the path
-       * `path2`.
+       * Holds if the declared type of `target` contains a type parameter at
+       * `apos` and `pathToConstrained` that must satisfy `constraint` and `tp`
+       * occurs at `pathToTp` in `constraint`.
        *
-       * For this example
+       * For example, in
        * ```csharp
        * interface IFoo<A> { }
        * T1 M<T1, T2>(T2 item) where T2 : IFoo<T1> { }
        * ```
-       * with the method declaration being the target and the for the first
-       * parameter position, we have the following
-       * - `path1 = ""`,
-       * - `tp1 = T2`,
+       * with the method declaration being the target and with `apos`
+       * corresponding to `item`, we have the following
+       * - `pathToConstrained = ""`,
+       * - `tp = T1`,
        * - `constraint = IFoo`,
-       * - `path2 = "A"`, and
-       * - `tp2 = T1`.
+       * - `pathToTp = "A"`.
        */
       pragma[nomagic]
       private predicate typeParameterConstraintHasTypeParameter(
-        Declaration target, DeclarationPosition dpos, TypePath path1, TypeParameter tp1,
-        Type constraint, TypePath path2, TypeParameter tp2
+        Declaration target, AccessPosition apos, TypePath pathToConstrained, Type constraint,
+        TypePath pathToTp, TypeParameter tp
       ) {
-        tp1 = target.getTypeParameter(_) and
-        tp2 = target.getTypeParameter(_) and
-        tp1 != tp2 and
-        tp1 = target.getDeclaredType(dpos, path1) and
-        exists(TypeMention tm |
-          tm = getATypeParameterConstraint(tp1) and
-          tm.resolveTypeAt(path2) = tp2 and
-          constraint = resolveTypeMentionRoot(tm)
+        exists(DeclarationPosition dpos, TypeParameter constrainedTp |
+          accessDeclarationPositionMatch(apos, dpos) and
+          constrainedTp = target.getTypeParameter(_) and
+          tp = target.getTypeParameter(_) and
+          constrainedTp != tp and
+          constrainedTp = target.getDeclaredType(dpos, pathToConstrained) and
+          exists(TypeMention tm |
+            tm = getATypeParameterConstraint(constrainedTp) and
+            tm.resolveTypeAt(pathToTp) = tp and
+            constraint = resolveTypeMentionRoot(tm)
+          )
         )
       }
 
@@ -1409,15 +1406,9 @@ module Make1<LocationSig Location, InputSig1<Location> Input1> {
         Access a, Declaration target, TypePath path, Type t, TypeParameter tp
       ) {
         not exists(getTypeArgument(a, target, tp, _)) and
-        target = a.getTarget() and
-        exists(
-          Type constraint, AccessPosition apos, DeclarationPosition dpos, TypePath pathToTp,
-          TypePath pathToTp2
-        |
-          accessDeclarationPositionMatch(apos, dpos) and
-          typeParameterConstraintHasTypeParameter(target, dpos, pathToTp2, _, constraint, pathToTp,
-            tp) and
-          AccessConstraint::satisfiesConstraintType(a, apos, pathToTp2, constraint,
+        exists(Type constraint, AccessPosition apos, TypePath pathToTp, TypePath pathToTp2 |
+          typeParameterConstraintHasTypeParameter(target, apos, pathToTp2, constraint, pathToTp, tp) and
+          AccessConstraint::satisfiesConstraintType(a, target, apos, pathToTp2, constraint,
             pathToTp.appendInverse(path), t)
         )
       }


### PR DESCRIPTION
This PR makes a few refactors to the type inference library.

I think these changes make sense on their own, but on `databend` they also reduce the total number of tuples (observed using "Compare Performance" in VSCode) and the following bad join reported by VScode (also observed on `databend`) disappears:
<details>
<summary>Bad join</summary>

```
Pipeline standard for TypeInference::CallExprBaseMatching::typeConstraintBaseTypeMatch/5#ebeb4216@f3cabgyd was evaluated in 530 iterations totaling 145ms (delta sizes total: 36047).
             5442   ~0%    {5} r1 = JOIN `TypeInference::CallExprBaseMatchingInput::Access.getTarget/0#dispred#29d66fd1#prev_delta` WITH TypeInference::CallExprBaseMatching::AccessConstraint::MkRelevantAccess#8a6252ad#prev ON FIRST 1 OUTPUT Rhs.2, Lhs.0, Lhs.1, Rhs.3, Rhs.4
             5442   ~0%    {5}    | JOIN WITH `TypeInference::CallExprBaseMatchingInput::accessDeclarationPositionMatch/2#6c58c89d` ON FIRST 1 OUTPUT Lhs.2, Rhs.1, Lhs.3, Lhs.1, Lhs.4
              240   ~0%    {6}    | JOIN WITH `project#TypeInference::CallExprBaseMatching::typeParameterConstraintHasTypeParameter/7#7f1e227b#2` ON FIRST 3 OUTPUT Lhs.3, Lhs.0, Lhs.4, Rhs.3, Rhs.4, Rhs.5
                           {6}    | AND NOT `_GenericParamList::GenericParamList.getTypeParam/1#dispred#01a987e9_21#join_rhs_Type::Type#75554d9d___#antijoin_rhs#1`(FIRST 6)
              184   ~0%    {6}    | SCAN OUTPUT In.2, In.3, In.0, In.1, In.4, In.5
                0   ~0%    {7}    | JOIN WITH `TypeInference::M2::SatisfiesConstraint<TypeInference::CallExprBaseMatching::AccessConstraint::RelevantAccess,TypeInference::CallExprBaseMatching::AccessConstraint::SatisfiesConstraintInput>::satisfiesConstraintType/4#d5b1679c#prev` ON FIRST 2 OUTPUT Lhs.2, Lhs.3, Lhs.5, Rhs.3, _, Lhs.4, Rhs.2
                           {5}    | REWRITE WITH Tmp.4 := "", Out.4 := InverseAppend(In.5,Tmp.4,In.6) KEEPING 5
                0   ~0%    {5}    | SCAN OUTPUT In.0, In.1, In.4, In.3, In.2
                       
          2676185   ~2%    {6} r2 = JOIN `TypeInference::M2::SatisfiesConstraint<TypeInference::CallExprBaseMatching::AccessConstraint::RelevantAccess,TypeInference::CallExprBaseMatching::AccessConstraint::SatisfiesConstraintInput>::satisfiesConstraintType/4#d5b1679c#prev_delta` WITH TypeInference::CallExprBaseMatching::AccessConstraint::MkRelevantAccess#8a6252ad#reorder_4_0_1_2_3#prev ON FIRST 1 OUTPUT Rhs.3, Lhs.1, Lhs.2, Lhs.3, Rhs.1, Rhs.4
          2669957   ~3%    {6}    | JOIN WITH `TypeInference::CallExprBaseMatchingInput::accessDeclarationPositionMatch/2#6c58c89d` ON FIRST 1 OUTPUT Lhs.4, Lhs.1, Lhs.2, Lhs.3, Lhs.5, Rhs.1
        143545032   ~8%    {7}    | JOIN WITH `TypeInference::CallExprBaseMatchingInput::Access.getTarget/0#dispred#29d66fd1#prev` ON FIRST 1 OUTPUT Rhs.1, Lhs.5, Lhs.4, Lhs.1, Lhs.2, Lhs.3, Lhs.0
            63836   ~1%    {6}    | JOIN WITH `project#TypeInference::CallExprBaseMatching::typeParameterConstraintHasTypeParameter/7#7f1e227b#2` ON FIRST 4 OUTPUT Lhs.4, Lhs.5, Lhs.6, Lhs.0, Rhs.4, Rhs.5
                           {6}    | AND NOT `_GenericParamList::GenericParamList.getTypeParam/1#dispred#01a987e9_21#join_rhs_Type::Type#75554d9d___#antijoin_rhs#2`(FIRST 6)
            63701   ~0%    {7}    | SCAN OUTPUT In.1, In.2, In.3, In.5, _, In.4, In.0
                           {5}    | REWRITE WITH Tmp.4 := "", Out.4 := InverseAppend(In.5,Tmp.4,In.6) KEEPING 5
            42102   ~1%    {5}    | SCAN OUTPUT In.1, In.2, In.4, In.0, In.3
                       
            65650   ~1%    {4} r3 = SCAN TypeInference::CallExprBaseMatching::AccessConstraint::MkRelevantAccess#8a6252ad#prev_delta OUTPUT In.0, In.2, In.3, In.4
            80414   ~1%    {5}    | JOIN WITH `TypeInference::CallExprBaseMatchingInput::Access.getTarget/0#dispred#29d66fd1#prev` ON FIRST 1 OUTPUT Lhs.1, Lhs.0, Lhs.2, Lhs.3, Rhs.1
            80414   ~0%    {5}    | JOIN WITH `TypeInference::CallExprBaseMatchingInput::accessDeclarationPositionMatch/2#6c58c89d` ON FIRST 1 OUTPUT Lhs.4, Rhs.1, Lhs.2, Lhs.1, Lhs.3
            98323   ~1%    {6}    | JOIN WITH `project#TypeInference::CallExprBaseMatching::typeParameterConstraintHasTypeParameter/7#7f1e227b#2` ON FIRST 3 OUTPUT Lhs.3, Lhs.4, Lhs.0, Rhs.3, Rhs.4, Rhs.5
                           {6}    | AND NOT `_GenericParamList::GenericParamList.getTypeParam/1#dispred#01a987e9_21#join_rhs_Type::Type#75554d9d___#antijoin_rhs#3`(FIRST 6)
            98176   ~0%    {6}    | SCAN OUTPUT In.1, In.3, In.0, In.2, In.4, In.5
                0   ~0%    {7}    | JOIN WITH `TypeInference::M2::SatisfiesConstraint<TypeInference::CallExprBaseMatching::AccessConstraint::RelevantAccess,TypeInference::CallExprBaseMatching::AccessConstraint::SatisfiesConstraintInput>::satisfiesConstraintType/4#d5b1679c#prev` ON FIRST 2 OUTPUT Lhs.2, Lhs.3, Lhs.5, Rhs.3, _, Lhs.4, Rhs.2
                           {5}    | REWRITE WITH Tmp.4 := "", Out.4 := InverseAppend(In.5,Tmp.4,In.6) KEEPING 5
                0   ~0%    {5}    | SCAN OUTPUT In.0, In.1, In.4, In.3, In.2
                       
            42102   ~1%    {5} r4 = r1 UNION r2 UNION r3
            36047   ~1%    {5}    | AND NOT `TypeInference::CallExprBaseMatching::typeConstraintBaseTypeMatch/5#ebeb4216#prev`(FIRST 5)
                           return r4
```
</details>
I don't have an "after" join order to show as I can't find the equivalent thing after the refactors.

DCA is uneventful and don't show any change in analysis time 😢 