### PR TITLE
JS: Diff-informed queries: phase 3 (non-trivial locations)

### DIFF
--- a/javascript/ql/lib/semmle/javascript/security/dataflow/IndirectCommandInjectionQuery.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/IndirectCommandInjectionQuery.qll
@@ -30,9 +30,10 @@ module IndirectCommandInjectionConfig implements DataFlow::ConfigSig {
   predicate observeDiffInformedIncrementalMode() { any() }
 
   Location getASelectedSinkLocation(DataFlow::Node sink) {
-    exists(DataFlow::Node node |
-      isSinkWithHighlight(sink, node) and
-      result = node.getLocation()
+    exists(DataFlow::Node highlight | result = highlight.getLocation() |
+      if isSinkWithHighlight(sink, _)
+      then isSinkWithHighlight(sink, highlight)
+      else highlight = sink
     )
   }
 }

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/ShellCommandInjectionFromEnvironmentQuery.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/ShellCommandInjectionFromEnvironmentQuery.qll
@@ -31,9 +31,10 @@ module ShellCommandInjectionFromEnvironmentConfig implements DataFlow::ConfigSig
   predicate observeDiffInformedIncrementalMode() { any() }
 
   Location getASelectedSinkLocation(DataFlow::Node sink) {
-    exists(DataFlow::Node node |
-      isSinkWithHighlight(sink, node) and
-      result = node.getLocation()
+    exists(DataFlow::Node highlight | result = highlight.getLocation() |
+      if isSinkWithHighlight(sink, _)
+      then isSinkWithHighlight(sink, highlight)
+      else highlight = sink
     )
   }
 }

--- a/javascript/ql/src/experimental/Security/CWE-099/EnvValueAndKeyInjection.ql
+++ b/javascript/ql/src/experimental/Security/CWE-099/EnvValueAndKeyInjection.ql
@@ -33,6 +33,10 @@ module EnvValueAndKeyInjectionConfig implements DataFlow::ConfigSig {
       )
     )
   }
+
+  predicate observeDiffInformedIncrementalMode() {
+    none() // can't override location accurately because of secondary use in select.
+  }
 }
 
 module EnvValueAndKeyInjectionFlow = TaintTracking::Global<EnvValueAndKeyInjectionConfig>;

--- a/javascript/ql/src/experimental/Security/CWE-347/decodeJwtWithoutVerification.ql
+++ b/javascript/ql/src/experimental/Security/CWE-347/decodeJwtWithoutVerification.ql
@@ -27,6 +27,10 @@ module VerifiedDecodeConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) { source instanceof ActiveThreatModelSource }
 
   predicate isSink(DataFlow::Node sink) { sink = verifiedDecode() }
+
+  predicate observeDiffInformedIncrementalMode() {
+    none() // used as secondary config
+  }
 }
 
 module VerifiedDecodeFlow = TaintTracking::Global<VerifiedDecodeConfig>;


### PR DESCRIPTION
This PR enables diff-informed mode on queries that select a location other than dataflow source or sink. This entails adding a non-trivial location override that returns the locations that are actually selected.

Prior work includes PRs like https://github.com/github/codeql/pull/19663, https://github.com/github/codeql/pull/19759, and https://github.com/github/codeql/pull/19817. This PR uses the same patch script as those PRs to find candidate queries to convert to diff-enabled. This is the final step in mass-enabling diff-informed queries on all the languages.

Commit-by-commit reviewing is recommended.

- I have split the commits that add/modify tests from the ones that enable/disable diff-informed queries.
- If the commit modifies a .qll file, in the commit message I've included links to the queries that depend on that .qll for easier reviewing.
- Feel free to delegate parts of the review to others who may be more specialized in certain languages.
