### PR TITLE
Ruby: Diff-informed queries: phase 3 (non-trivial locations)

### DIFF
--- a/ruby/ql/lib/codeql/ruby/security/regexp/MissingFullAnchorQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/regexp/MissingFullAnchorQuery.qll
@@ -17,6 +17,10 @@ private module MissingFullAnchorConfig implements DataFlow::ConfigSig {
   predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
 
   predicate isBarrier(DataFlow::Node node) { node instanceof Sanitizer }
+
+  predicate observeDiffInformedIncrementalMode() {
+    none() // can't be made diff-informed because the locations of Ruby RegExpTerms aren't correct when the regexp is parsed from a string arising from constant folding
+  }
 }
 
 /**


### PR DESCRIPTION
This PR enables diff-informed mode on queries that select a location other than dataflow source or sink. This entails adding a non-trivial location override that returns the locations that are actually selected.

Prior work includes PRs like https://github.com/github/codeql/pull/19663, https://github.com/github/codeql/pull/19759, and https://github.com/github/codeql/pull/19817. This PR uses the same patch script as those PRs to find candidate queries to convert to diff-enabled. This is the final step in mass-enabling diff-informed queries on all the languages.

Commit-by-commit reviewing is recommended.

- I have split the commits that add/modify tests from the ones that enable/disable diff-informed queries.
- If the commit modifies a .qll file, in the commit message I've included links to the queries that depend on that .qll for easier reviewing.
- Feel free to delegate parts of the review to others who may be more specialized in certain languages.
