### PR TITLE
Java: Prune PathGraph for CsrfUnprotectedRequestType.ql

### DIFF
--- a/java/ql/src/Security/CWE/CWE-352/CsrfUnprotectedRequestType.ql
+++ b/java/ql/src/Security/CWE/CWE-352/CsrfUnprotectedRequestType.ql
@@ -15,7 +15,7 @@
 import java
 import semmle.code.java.security.CsrfUnprotectedRequestTypeQuery
 
-query predicate edges(CallPathNode pred, CallPathNode succ) { CallGraph::edges(pred, succ) }
+query predicate edges(CallPathNode pred, CallPathNode succ) { relevantEdge(pred, succ) }
 
 from CallPathNode source, CallPathNode sink
 where unprotectedStateChange(source, sink)


### PR DESCRIPTION
This should be completely behaviour-preserving, but saves hundreds of MBs of output for some repos. Dca has had trouble processing the output of this query even for cases with zero alerts for several repos.

See also comments here: https://github.com/github/codeql/pull/19872#issuecomment-3083292194