### PR TITLE
Java: Fix accidental CP in CFG for asserts.

### DIFF
--- a/java/ql/lib/semmle/code/java/ControlFlowGraph.qll
+++ b/java/ql/lib/semmle/code/java/ControlFlowGraph.qll
@@ -1621,7 +1621,8 @@ private module ControlFlowGraphImpl {
         result.(AssertThrowNode).getAstNode() = assertstmt
       )
       or
-      last(assertstmt.getMessage(), n, NormalCompletion()) and
+      last(assertstmt.getMessage(), n, completion) and
+      completion = NormalCompletion() and
       result.(AssertThrowNode).getAstNode() = assertstmt
     )
     or


### PR DESCRIPTION
The somewhat recent change to the CFG for Java assert statements introduced an accidental cartesian product. The product is between completions and assert statements, both of which are somewhat limited in number, which is why we haven't discovered this before now. It was identified by the join-order metric, since the CP was confusing the optimiser to select a particularly bad join order.

Before:
```
              444   ~4%    {2} r34 = JOIN Completion::Completion#3da5aa6a WITH num#Completion::NormalCompletion#17a01869 CARTESIAN PRODUCT OUTPUT Rhs.0, Lhs.0
        257653644   ~0%    {3}    | JOIN WITH `ControlFlowGraph::ControlFlowGraphImpl::last/3#f72f2d15_201#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Rhs.2
            17760   ~0%    {3}    | JOIN WITH `Statement::AssertStmt.getMessage/0#dispred#911385b1_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
            17760   ~0%    {3}    | JOIN WITH num#ControlFlowGraph::ControlFlow::TAssertThrowNode#fd4ea142 ON FIRST 1 OUTPUT Lhs.2, Lhs.1, Rhs.1
```
After:
```
[2025-07-18 13:46:42] Evaluated non-recursive predicate _ControlFlowGraph::ControlFlowGraphImpl::last/3#f72f2d15_201#join_rhs_num#Completion::NormalCompleti__#shared@4f47f1qe in 92ms (size: 580301).
Evaluated relational algebra for predicate _ControlFlowGraph::ControlFlowGraphImpl::last/3#f72f2d15_201#join_rhs_num#Completion::NormalCompleti__#shared@4f47f1qe with tuple counts:
        580301  ~1%    {3} r1 = JOIN `ControlFlowGraph::ControlFlowGraphImpl::last/3#f72f2d15_201#join_rhs` WITH num#Completion::NormalCompletion#17a01869 ON FIRST 1 OUTPUT Lhs.1, Lhs.0, Lhs.2
                       return r1

...
            40   ~3%    {3} r4 = JOIN `_ControlFlowGraph::ControlFlowGraphImpl::last/3#f72f2d15_201#join_rhs_num#Completion::NormalCompleti__#shared` WITH `Statement::AssertStmt.getMessage/0#dispred#911385b1_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
            40   ~0%    {3}    | JOIN WITH num#ControlFlowGraph::ControlFlow::TAssertThrowNode#fd4ea142 ON FIRST 1 OUTPUT Lhs.2, Lhs.1, Rhs.1
```