### PR TITLE
Java: Add `previous-id` and adjust tags for `java/garbage-collection` and `java/run-finalizers-on-exit`

### DIFF
--- a/java/ql/integration-tests/java/query-suite/java-code-quality-extended.qls.expected
+++ b/java/ql/integration-tests/java/query-suite/java-code-quality-extended.qls.expected
@@ -80,6 +80,7 @@ ql/java/ql/src/Violations of Best Practice/Naming Conventions/LocalShadowsFieldC
 ql/java/ql/src/Violations of Best Practice/Naming Conventions/SameNameAsSuper.ql
 ql/java/ql/src/Violations of Best Practice/Records/IgnoredSerializationMembersOfRecordClass.ql
 ql/java/ql/src/Violations of Best Practice/SpecialCharactersInLiterals/NonExplicitControlAndWhitespaceCharsInLiterals.ql
+ql/java/ql/src/Violations of Best Practice/Undesirable Calls/CallsToRunFinalizersOnExit.ql
 ql/java/ql/src/Violations of Best Practice/Undesirable Calls/CallsToStringToString.ql
 ql/java/ql/src/Violations of Best Practice/Undesirable Calls/DefaultToString.ql
 ql/java/ql/src/Violations of Best Practice/Undesirable Calls/DoNotCallFinalize.ql

--- a/java/ql/src/Violations of Best Practice/Undesirable Calls/CallsToRunFinalizersOnExit.ql
+++ b/java/ql/src/Violations of Best Practice/Undesirable Calls/CallsToRunFinalizersOnExit.ql
@@ -7,8 +7,11 @@
  * @problem.severity error
  * @precision medium
  * @id java/run-finalizers-on-exit
- * @tags reliability
- *       maintainability
+ * @previous-id java/do-not-use-finalizers
+ * @tags quality
+ *       reliability
+ *       correctness
+ *       performance
  */
 
 import java

--- a/java/ql/src/Violations of Best Practice/Undesirable Calls/GarbageCollection.ql
+++ b/java/ql/src/Violations of Best Practice/Undesirable Calls/GarbageCollection.ql
@@ -6,8 +6,10 @@
  * @problem.severity recommendation
  * @precision low
  * @id java/garbage-collection
- * @tags reliability
- *       maintainability
+ * @previous-id java/do-not-use-finalizers
+ * @tags quality
+ *       reliability
+ *       correctness
  */
 
 import java

--- a/java/ql/src/change-notes/2025-07-19-adjust-tags.md
+++ b/java/ql/src/change-notes/2025-07-19-adjust-tags.md
@@ -1,0 +1,5 @@
+---
+category: queryMetadata
+---
+* The tag `maintainability` has been removed from `java/run-finalizers-on-exit` and the tags `quality`, `correctness`, and `performance` have been added.
+* The tag `maintainability` has been removed from `java/garbage-collection` and the tags `quality` and `correctness` have been added.


### PR DESCRIPTION
Adds `previous-id` and adjusts tags for `java/garbage-collection` and `java/run-finalizers-on-exit`. Follow-up to https://github.com/github/codeql/pull/19075.

This will add `java/run-finalizers-on-exit` to the code-quality-extended suite. `java/garbage-collection` will not be added to any suite due to its `low` precision.