### PR TITLE
C++: Static variables are initialized to zero or null by compiler

### DIFF
--- a/cpp/ql/src/Critical/InitialisationNotRun.ql
+++ b/cpp/ql/src/Critical/InitialisationNotRun.ql
@@ -32,9 +32,18 @@ predicate called(Function f) {
   exists(FunctionAccess fa | fa.getTarget() = f)
 }
 
+predicate staticWithoutDereference(GlobalVariable v) {
+  v.isStatic() and
+  not exists(VariableAccess va |
+    va = v.getAnAccess() and
+    dereferenced(va)
+  )
+}
+
 from GlobalVariable v
 where
   global(v) and
+  not staticWithoutDereference(v) and
   not exists(VariableAccess lval |
     v.getAnAccess() = lval and
     lval.isUsedAsLValue() and

--- a/cpp/ql/src/change-notes/2025-07-27-avoid-reporting-static-global-variable.md
+++ b/cpp/ql/src/change-notes/2025-07-27-avoid-reporting-static-global-variable.md
@@ -1,4 +1,4 @@
 ---
 category: minorAnalysis
 ---
-* The "GlobalVariable not initialized" query (`cpp/not-initialised`) no longer reports an alert on static global variables that has no dereference.
+* The "Initialization code not run" query (`cpp/initialization-not-run`) no longer reports an alert on static global variables that has no dereference.

--- a/cpp/ql/src/change-notes/2025-07-27-avoid-reporting-static-global-variable.md
+++ b/cpp/ql/src/change-notes/2025-07-27-avoid-reporting-static-global-variable.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The "GlobalVariable not initialized" query (`cpp/not-initialised`) no longer reports an alert on static global variables that has no dereference.

--- a/cpp/ql/test/query-tests/Critical/InitialisationNotRun/InitialisationNotRun.expected
+++ b/cpp/ql/test/query-tests/Critical/InitialisationNotRun/InitialisationNotRun.expected
@@ -1,0 +1,2 @@
+| test.cpp:12:16:12:17 | g1 | Initialization code for 'g1' is never run. |
+| test.cpp:14:23:14:24 | g3 | Initialization code for 'g3' is never run. |

--- a/cpp/ql/test/query-tests/Critical/InitialisationNotRun/InitialisationNotRun.qlref
+++ b/cpp/ql/test/query-tests/Critical/InitialisationNotRun/InitialisationNotRun.qlref
@@ -1,0 +1,1 @@
+Critical/InitialisationNotRun.ql

--- a/cpp/ql/test/query-tests/Critical/InitialisationNotRun/test.cpp
+++ b/cpp/ql/test/query-tests/Critical/InitialisationNotRun/test.cpp
@@ -1,4 +1,8 @@
-#include <string.h>
+// --- stubs ---
+
+char *strcpy(char *dest, const char *src);
+
+// --- tests ---
 
 class GlobalStorage {
 public:

--- a/cpp/ql/test/query-tests/Critical/InitialisationNotRun/test.cpp
+++ b/cpp/ql/test/query-tests/Critical/InitialisationNotRun/test.cpp
@@ -1,0 +1,32 @@
+#include <string.h>
+
+class GlobalStorage {
+public:
+    char name[1000];
+};
+
+GlobalStorage *g1; // BAD
+static GlobalStorage g2; // GOOD
+static GlobalStorage *g3; // BAD
+// static variables are initialized by compilers
+static int a;  // GOOD
+static int b = 0;  // GOOD
+
+void init() { //initializes g_storage, but is never run from main
+  g1 = new GlobalStorage();
+  g3 = new GlobalStorage();
+}
+
+void init2(int b) {
+  for (int i = 0; i < b; ++i)
+    a *= -1;
+}
+
+int main(int argc, char *argv[]) {
+	//init not called
+  strcpy(g1->name, argv[1]); // g1 is used before init() is called
+  strcpy(g2.name, argv[1]); // g2 is initialised by compiler
+  strcpy(g3->name, argv[1]);
+  b++;
+  return 0;
+}


### PR DESCRIPTION
Static variables are initialized to zero or null by compilers; there is no need to get an initializer for them.
See https://stackoverflow.com/questions/13251083/the-initialization-of-static-variables-in-c
See 6.7.8/10 in the [C99 Standard](http://www.open-std.org/JTC1/sc22/wg14/www/docs/n1256.pdf)

Please see a relevant PR: https://github.com/github/codeql/pull/16527