### PR TITLE
Java: Move `extractorInformationSkipKey` predicate to library pack

### DIFF
--- a/java/ql/integration-tests/kotlin/all-platforms/extractor_information_kotlin1/ExtractorInformation.ext.yml
+++ b/java/ql/integration-tests/kotlin/all-platforms/extractor_information_kotlin1/ExtractorInformation.ext.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
-      pack: codeql/java-queries
+      pack: codeql/java-all
       extensible: extractorInformationSkipKey
     data:
       # These will have unstable values, as they are dependent on the

--- a/java/ql/integration-tests/kotlin/all-platforms/extractor_information_kotlin2/ExtractorInformation.ext.yml
+++ b/java/ql/integration-tests/kotlin/all-platforms/extractor_information_kotlin2/ExtractorInformation.ext.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
-      pack: codeql/java-queries
+      pack: codeql/java-all
       extensible: extractorInformationSkipKey
     data:
       # These will have unstable values, as they are dependent on the

--- a/java/ql/lib/semmle/code/java/Diagnostics.qll
+++ b/java/ql/lib/semmle/code/java/Diagnostics.qll
@@ -61,3 +61,9 @@ class Diagnostic extends @diagnostic {
   /** Gets a textual representation of this diagnostic. */
   string toString() { result = this.getMessage() }
 }
+
+/**
+ * Holds for extraction information keys that should be skipped from telemetry reports.
+ * This predicate can be extended by other packs to filter out specific telemetry keys.
+ */
+extensible predicate extractorInformationSkipKey(string key);

--- a/java/ql/src/Telemetry/ExtractorInformation.ql
+++ b/java/ql/src/Telemetry/ExtractorInformation.ql
@@ -10,8 +10,6 @@ import java
 import semmle.code.java.Diagnostics
 import DatabaseQuality
 
-extensible predicate extractorInformationSkipKey(string key);
-
 predicate compilationInfo(string key, int value) {
   exists(Compilation c, string infoKey |
     key = infoKey + ": " + c.getInfo(infoKey) and

--- a/java/ql/src/Telemetry/ExtractorInformation.yml
+++ b/java/ql/src/Telemetry/ExtractorInformation.yml
@@ -1,5 +1,5 @@
 extensions:
   - addsTo:
-      pack: codeql/java-queries
+      pack: codeql/java-all
       extensible: extractorInformationSkipKey
     data: []


### PR DESCRIPTION
Fixes compilation error where extensible predicate was declared in the same pack that was trying to extend it.

See internal PR for more details.