### PR TITLE
Rust: Add metric for DCA and debug predicates for type that reach the length limit

### DIFF
--- a/rust/ql/integration-tests/query-suite/rust-code-scanning.qls.expected
+++ b/rust/ql/integration-tests/query-suite/rust-code-scanning.qls.expected
@@ -19,6 +19,7 @@ ql/rust/ql/src/queries/security/CWE-798/HardcodedCryptographicValue.ql
 ql/rust/ql/src/queries/security/CWE-825/AccessInvalidPointer.ql
 ql/rust/ql/src/queries/summary/LinesOfCode.ql
 ql/rust/ql/src/queries/summary/LinesOfUserCode.ql
+ql/rust/ql/src/queries/summary/NodesWithTypeAtLengthLimit.ql
 ql/rust/ql/src/queries/summary/NumberOfFilesExtractedWithErrors.ql
 ql/rust/ql/src/queries/summary/NumberOfSuccessfullyExtractedFiles.ql
 ql/rust/ql/src/queries/summary/QuerySinkCounts.ql

--- a/rust/ql/integration-tests/query-suite/rust-security-and-quality.qls.expected
+++ b/rust/ql/integration-tests/query-suite/rust-security-and-quality.qls.expected
@@ -21,6 +21,7 @@ ql/rust/ql/src/queries/security/CWE-825/AccessAfterLifetime.ql
 ql/rust/ql/src/queries/security/CWE-825/AccessInvalidPointer.ql
 ql/rust/ql/src/queries/summary/LinesOfCode.ql
 ql/rust/ql/src/queries/summary/LinesOfUserCode.ql
+ql/rust/ql/src/queries/summary/NodesWithTypeAtLengthLimit.ql
 ql/rust/ql/src/queries/summary/NumberOfFilesExtractedWithErrors.ql
 ql/rust/ql/src/queries/summary/NumberOfSuccessfullyExtractedFiles.ql
 ql/rust/ql/src/queries/summary/QuerySinkCounts.ql

--- a/rust/ql/integration-tests/query-suite/rust-security-extended.qls.expected
+++ b/rust/ql/integration-tests/query-suite/rust-security-extended.qls.expected
@@ -20,6 +20,7 @@ ql/rust/ql/src/queries/security/CWE-825/AccessAfterLifetime.ql
 ql/rust/ql/src/queries/security/CWE-825/AccessInvalidPointer.ql
 ql/rust/ql/src/queries/summary/LinesOfCode.ql
 ql/rust/ql/src/queries/summary/LinesOfUserCode.ql
+ql/rust/ql/src/queries/summary/NodesWithTypeAtLengthLimit.ql
 ql/rust/ql/src/queries/summary/NumberOfFilesExtractedWithErrors.ql
 ql/rust/ql/src/queries/summary/NumberOfSuccessfullyExtractedFiles.ql
 ql/rust/ql/src/queries/summary/QuerySinkCounts.ql

--- a/rust/ql/lib/codeql/rust/internal/TypeInference.qll
+++ b/rust/ql/lib/codeql/rust/internal/TypeInference.qll
@@ -127,6 +127,8 @@ private module Input1 implements InputSig1<Location> {
         tp0 order by kind, id1, id2
       )
   }
+
+  int getTypePathLimit() { result = 10 }
 }
 
 private import Input1
@@ -134,6 +136,8 @@ private import Input1
 private module M1 = Make1<Location, Input1>;
 
 private import M1
+
+predicate getTypePathLimit = Input1::getTypePathLimit/0;
 
 class TypePath = M1::TypePath;
 
@@ -2263,6 +2267,16 @@ private module Debug {
   private int countTypesAtPath(AstNode n, TypePath path, Type t) {
     t = inferType(n, path) and
     result = strictcount(Type t0 | t0 = inferType(n, path))
+  }
+
+  Type debugInferTypeForNodeAtLimit(AstNode n, TypePath path) {
+    result = inferType(n, path) and
+    exists(TypePath path0 | exists(inferType(n, path0)) and path0.length() >= getTypePathLimit())
+  }
+
+  predicate countTypesForNodeAtLimit(AstNode n, int c) {
+    n = getRelevantLocatable() and
+    c = strictcount(Type t, TypePath path | t = debugInferTypeForNodeAtLimit(n, path))
   }
 
   predicate maxTypes(AstNode n, TypePath path, Type t, int c) {

--- a/rust/ql/src/queries/summary/NodesWithTypeAtLengthLimit.ql
+++ b/rust/ql/src/queries/summary/NodesWithTypeAtLengthLimit.ql
@@ -1,0 +1,20 @@
+/**
+ * @name Nodes With Type At Length Limit
+ * @description Counts the number of AST nodes with a type at the type path length limit.
+ * @kind metric
+ * @id rust/summary/nodes-at-type-path-length-limit
+ * @tags summary
+ */
+
+import rust
+import codeql.rust.internal.TypeInference
+
+from int atLimit
+where
+  atLimit =
+    count(AstNode n, TypePath path |
+      exists(inferType(n, path)) and path.length() = getTypePathLimit()
+    |
+      n
+    )
+select atLimit


### PR DESCRIPTION
A node can have a type at a type path that reaches the length limit of 10 if: 1/ the type is 10 levels deep (not likely) or 2/ type inference got in some infinite cycle and reached the type path length limit.

We'v previously had a performance issue due to the latter and now it seems that something similar is happening in https://github.com/github/codeql/pull/20140: We have some existing types that reach the limit and something in #20140 causes that latent issue to explode even further.

This PR adds a metric for DCA that tracks how many nodes have a type that reach the type path length limit. These infinite cycles may not show up as performance issues initially, but they could later, so having DCA report them will let us catch things earlier and will help us work towards getting the metric to zero which should be possible in most/all projects. 

NOTE: I don't know much about DCA things, so please double check that the metric query is usable for DCA 🙏 