### PR TITLE
Rust: Update BadCtorInitialization.ql to use getCanonicalPath.

### DIFF
--- a/rust/ql/src/queries/security/CWE-696/BadCtorInitialization.ql
+++ b/rust/ql/src/queries/security/CWE-696/BadCtorInitialization.ql
@@ -32,8 +32,7 @@ class CtorAttr extends Attr {
  */
 class StdCall extends Expr {
   StdCall() {
-    this.(CallExpr).getFunction().(PathExpr).getResolvedCrateOrigin() = "lang:std" or
-    this.(MethodCallExpr).getResolvedCrateOrigin() = "lang:std"
+    this.(CallExprBase).getStaticTarget().getCanonicalPath().matches(["std::%", "<std::%"])
   }
 }
 


### PR DESCRIPTION
Update `BadCtorInitialization.ql` to use `getCanonicalPath()` rather than `getResolvedCrateOrigin()`.

- tests all pass.
- on MRVA we lose a proportion of results due to them not having a [resolved] `getStaticTarget()`, but results are otherwise identical (that is, we don't lose any due to the `matches` expression failing).
- DCA LGTM.