### PR TITLE
C++: Remove redundants casts from IR

### DIFF
--- a/cpp/ql/test/library-tests/ir/ir/aliased_ir.expected
+++ b/cpp/ql/test/library-tests/ir/ir/aliased_ir.expected
@@ -245,9 +245,8 @@ bad_asts.cpp:
 #   27|     r27_2(glval<Point &>) = VariableAddress[a]       : 
 #   27|     r27_3(Point &)        = Load[a]                  : &:r27_2, m26_6
 #   27|     r27_4(glval<Point>)   = CopyValue                : r27_3
-#   27|     r27_5(glval<Point>)   = Convert                  : r27_4
-#   27|     r27_6(Point)          = Load[?]                  : &:r27_5, ~m26_8
-#   27|     m27_7(Point)          = Store[b]                 : &:r27_1, r27_6
+#   27|     r27_5(Point)          = Load[?]                  : &:r27_4, ~m26_8
+#   27|     m27_6(Point)          = Store[b]                 : &:r27_1, r27_5
 #   28|     v28_1(void)           = NoOp                     : 
 #   26|     v26_9(void)           = ReturnIndirection[a]     : &:r26_7, m26_8
 #   26|     v26_10(void)          = ReturnVoid               : 
@@ -897,170 +896,162 @@ coroutines.cpp:
 #   87|     m87_28(suspend_always *)      = Store[#temp0:0]                           : &:r0_1, r87_27
 #-----|     r0_2(suspend_always *)        = Load[#temp0:0]                            : &:r0_1, m87_28
 #   87|     r87_29(glval<suspend_always>) = CopyValue                                 : r0_2
-#   87|     r87_30(glval<suspend_always>) = Convert                                   : r87_29
-#   87|     r87_31(glval<unknown>)        = FunctionAddress[await_ready]              : 
-#   87|     r87_32(bool)                  = Call[await_ready]                         : func:r87_31, this:r87_30
-#   87|     m87_33(unknown)               = ^CallSideEffect                           : ~m87_26
-#   87|     m87_34(unknown)               = Chi                                       : total:m87_26, partial:m87_33
-#   87|     v87_35(void)                  = ^IndirectReadSideEffect[-1]               : &:r87_30, ~m87_34
-#-----|     v0_3(void)                    = ConditionalBranch                         : r87_32
+#   87|     r87_30(glval<unknown>)        = FunctionAddress[await_ready]              : 
+#   87|     r87_31(bool)                  = Call[await_ready]                         : func:r87_30, this:r87_29
+#   87|     m87_32(unknown)               = ^CallSideEffect                           : ~m87_26
+#   87|     m87_33(unknown)               = Chi                                       : total:m87_26, partial:m87_32
+#   87|     v87_34(void)                  = ^IndirectReadSideEffect[-1]               : &:r87_29, ~m87_33
+#-----|     v0_3(void)                    = ConditionalBranch                         : r87_31
 #-----|   False -> Block 2
 #-----|   True -> Block 1
 
 #-----|   Block 1
-#-----|     m0_4(unknown)                 = Phi                                       : from 0:~m87_34, from 2:~m87_61
+#-----|     m0_4(unknown)                 = Phi                                       : from 0:~m87_33, from 2:~m87_59
 #-----|     r0_5(bool)                    = Constant[1]                               : 
 #-----|     r0_6(glval<bool>)             = VariableAddress[(unnamed local variable)] : 
 #-----|     m0_7(bool)                    = Store[(unnamed local variable)]           : &:r0_6, r0_5
-#   87|     r87_36(suspend_always *)      = CopyValue                                 : r87_27
-#   87|     r87_37(glval<suspend_always>) = CopyValue                                 : r87_36
-#-----|     r0_8(glval<suspend_always>)   = Convert                                   : r87_37
-#   87|     r87_38(glval<unknown>)        = FunctionAddress[await_resume]             : 
-#   87|     v87_39(void)                  = Call[await_resume]                        : func:r87_38, this:r0_8
-#   87|     m87_40(unknown)               = ^CallSideEffect                           : ~m0_4
-#   87|     m87_41(unknown)               = Chi                                       : total:m0_4, partial:m87_40
-#-----|     v0_9(void)                    = ^IndirectReadSideEffect[-1]               : &:r0_8, ~m87_41
-#-----|     v0_10(void)                   = CopyValue                                 : v87_39
-#-----|     r0_11(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
-#-----|     r0_12(glval<unknown>)         = FunctionAddress[return_void]              : 
-#-----|     v0_13(void)                   = Call[return_void]                         : func:r0_12, this:r0_11
-#-----|     m0_14(unknown)                = ^CallSideEffect                           : ~m87_41
-#-----|     m0_15(unknown)                = Chi                                       : total:m87_41, partial:m0_14
-#-----|     v0_16(void)                   = ^IndirectReadSideEffect[-1]               : &:r0_11, ~m0_15
-#-----|     m0_17(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r0_11
-#-----|     m0_18(unknown)                = Chi                                       : total:m0_15, partial:m0_17
+#   87|     r87_35(suspend_always *)      = CopyValue                                 : r87_27
+#   87|     r87_36(glval<suspend_always>) = CopyValue                                 : r87_35
+#   87|     r87_37(glval<unknown>)        = FunctionAddress[await_resume]             : 
+#   87|     v87_38(void)                  = Call[await_resume]                        : func:r87_37, this:r87_36
+#   87|     m87_39(unknown)               = ^CallSideEffect                           : ~m0_4
+#   87|     m87_40(unknown)               = Chi                                       : total:m0_4, partial:m87_39
+#-----|     v0_8(void)                    = ^IndirectReadSideEffect[-1]               : &:r87_36, ~m87_40
+#-----|     v0_9(void)                    = CopyValue                                 : v87_38
+#-----|     r0_10(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
+#-----|     r0_11(glval<unknown>)         = FunctionAddress[return_void]              : 
+#-----|     v0_12(void)                   = Call[return_void]                         : func:r0_11, this:r0_10
+#-----|     m0_13(unknown)                = ^CallSideEffect                           : ~m87_40
+#-----|     m0_14(unknown)                = Chi                                       : total:m87_40, partial:m0_13
+#-----|     v0_15(void)                   = ^IndirectReadSideEffect[-1]               : &:r0_10, ~m0_14
+#-----|     m0_16(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r0_10
+#-----|     m0_17(unknown)                = Chi                                       : total:m0_14, partial:m0_16
 #-----|   C++ Exception -> Block 4
 #-----|   Goto -> Block 3
 
 #   87|   Block 2
-#   87|     r87_42(suspend_always *)                      = CopyValue                                 : r87_27
-#   87|     r87_43(glval<suspend_always>)                 = CopyValue                                 : r87_42
-#-----|     r0_19(glval<suspend_always>)                  = Convert                                   : r87_43
-#   87|     r87_44(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
-#   87|     r87_45(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp87:20]               : 
-#   87|     m87_46(coroutine_handle<promise_type>)        = Uninitialized[#temp87:20]                 : &:r87_45
-#   87|     m87_47(unknown)                               = Chi                                       : total:m87_34, partial:m87_46
-#   87|     r87_48(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
-#   87|     r87_49(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
-#   87|     r87_50(glval<coroutine_handle<promise_type>>) = Convert                                   : r87_49
-#   87|     r87_51(coroutine_handle<promise_type> &)      = CopyValue                                 : r87_50
-#   87|     v87_52(void)                                  = Call[coroutine_handle]                    : func:r87_48, this:r87_45, 0:r87_51
-#   87|     m87_53(unknown)                               = ^CallSideEffect                           : ~m87_47
-#   87|     m87_54(unknown)                               = Chi                                       : total:m87_47, partial:m87_53
-#   87|     v87_55(void)                                  = ^BufferReadSideEffect[0]                  : &:r87_51, ~m87_54
-#   87|     m87_56(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r87_45
-#   87|     m87_57(unknown)                               = Chi                                       : total:m87_54, partial:m87_56
-#   87|     r87_58(coroutine_handle<promise_type>)        = Load[#temp87:20]                          : &:r87_45, ~m87_57
-#   87|     v87_59(void)                                  = Call[await_suspend]                       : func:r87_44, this:r0_19, 0:r87_58
-#   87|     m87_60(unknown)                               = ^CallSideEffect                           : ~m87_57
-#   87|     m87_61(unknown)                               = Chi                                       : total:m87_57, partial:m87_60
-#-----|     v0_20(void)                                   = ^IndirectReadSideEffect[-1]               : &:r0_19, ~m87_61
+#   87|     r87_41(suspend_always *)                      = CopyValue                                 : r87_27
+#   87|     r87_42(glval<suspend_always>)                 = CopyValue                                 : r87_41
+#   87|     r87_43(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
+#   87|     r87_44(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp87:20]               : 
+#   87|     m87_45(coroutine_handle<promise_type>)        = Uninitialized[#temp87:20]                 : &:r87_44
+#   87|     m87_46(unknown)                               = Chi                                       : total:m87_33, partial:m87_45
+#   87|     r87_47(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
+#   87|     r87_48(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
+#   87|     r87_49(coroutine_handle<promise_type> &)      = CopyValue                                 : r87_48
+#   87|     v87_50(void)                                  = Call[coroutine_handle]                    : func:r87_47, this:r87_44, 0:r87_49
+#   87|     m87_51(unknown)                               = ^CallSideEffect                           : ~m87_46
+#   87|     m87_52(unknown)                               = Chi                                       : total:m87_46, partial:m87_51
+#   87|     v87_53(void)                                  = ^BufferReadSideEffect[0]                  : &:r87_49, ~m87_52
+#   87|     m87_54(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r87_44
+#   87|     m87_55(unknown)                               = Chi                                       : total:m87_52, partial:m87_54
+#   87|     r87_56(coroutine_handle<promise_type>)        = Load[#temp87:20]                          : &:r87_44, ~m87_55
+#   87|     v87_57(void)                                  = Call[await_suspend]                       : func:r87_43, this:r87_42, 0:r87_56
+#   87|     m87_58(unknown)                               = ^CallSideEffect                           : ~m87_55
+#   87|     m87_59(unknown)                               = Chi                                       : total:m87_55, partial:m87_58
+#-----|     v0_18(void)                                   = ^IndirectReadSideEffect[-1]               : &:r87_42, ~m87_59
 #-----|   Goto -> Block 1
 
 #   88|   Block 3
 #   88|     v88_1(void) = NoOp : 
-#-----|     v0_21(void) = NoOp : 
+#-----|     v0_19(void) = NoOp : 
 #-----|   Goto (back edge) -> Block 6
 
 #-----|   Block 4
-#-----|     v0_22(void)        = CatchAny                                  : 
-#-----|     r0_23(glval<bool>) = VariableAddress[(unnamed local variable)] : 
-#-----|     r0_24(bool)        = Load[(unnamed local variable)]            : &:r0_23, m0_7
-#-----|     r0_25(bool)        = LogicalNot                                : r0_24
-#-----|     v0_26(void)        = ConditionalBranch                         : r0_25
+#-----|     v0_20(void)        = CatchAny                                  : 
+#-----|     r0_21(glval<bool>) = VariableAddress[(unnamed local variable)] : 
+#-----|     r0_22(bool)        = Load[(unnamed local variable)]            : &:r0_21, m0_7
+#-----|     r0_23(bool)        = LogicalNot                                : r0_22
+#-----|     v0_24(void)        = ConditionalBranch                         : r0_23
 #-----|   False -> Block 5
 #-----|   True -> Block 9
 
 #   87|   Block 5
-#   87|     r87_62(glval<promise_type>) = VariableAddress[(unnamed local variable)] : 
-#   87|     r87_63(glval<unknown>)      = FunctionAddress[unhandled_exception]      : 
-#   87|     v87_64(void)                = Call[unhandled_exception]                 : func:r87_63, this:r87_62
-#   87|     m87_65(unknown)             = ^CallSideEffect                           : ~m0_18
-#   87|     m87_66(unknown)             = Chi                                       : total:m0_18, partial:m87_65
-#   87|     v87_67(void)                = ^IndirectReadSideEffect[-1]               : &:r87_62, ~m87_66
-#   87|     m87_68(promise_type)        = ^IndirectMayWriteSideEffect[-1]           : &:r87_62
-#   87|     m87_69(unknown)             = Chi                                       : total:m87_66, partial:m87_68
+#   87|     r87_60(glval<promise_type>) = VariableAddress[(unnamed local variable)] : 
+#   87|     r87_61(glval<unknown>)      = FunctionAddress[unhandled_exception]      : 
+#   87|     v87_62(void)                = Call[unhandled_exception]                 : func:r87_61, this:r87_60
+#   87|     m87_63(unknown)             = ^CallSideEffect                           : ~m0_17
+#   87|     m87_64(unknown)             = Chi                                       : total:m0_17, partial:m87_63
+#   87|     v87_65(void)                = ^IndirectReadSideEffect[-1]               : &:r87_60, ~m87_64
+#   87|     m87_66(promise_type)        = ^IndirectMayWriteSideEffect[-1]           : &:r87_60
+#   87|     m87_67(unknown)             = Chi                                       : total:m87_64, partial:m87_66
 #-----|   Goto -> Block 6
 
 #-----|   Block 6
-#-----|     m0_27(unknown)                 = Phi                                       : from 3:~m0_18, from 5:~m87_69
-#-----|     v0_28(void)                    = NoOp                                      : 
-#   87|     r87_70(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
-#   87|     r87_71(glval<unknown>)         = FunctionAddress[final_suspend]            : 
-#   87|     r87_72(suspend_always)         = Call[final_suspend]                       : func:r87_71, this:r87_70
-#   87|     m87_73(unknown)                = ^CallSideEffect                           : ~m0_27
-#   87|     m87_74(unknown)                = Chi                                       : total:m0_27, partial:m87_73
-#   87|     v87_75(void)                   = ^IndirectReadSideEffect[-1]               : &:r87_70, ~m87_74
-#   87|     m87_76(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r87_70
-#   87|     m87_77(unknown)                = Chi                                       : total:m87_74, partial:m87_76
-#-----|     r0_29(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
-#   87|     r87_78(glval<suspend_always>)  = VariableAddress[#temp87:20]               : 
-#   87|     r87_79(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
-#   87|     r87_80(glval<unknown>)         = FunctionAddress[final_suspend]            : 
-#   87|     r87_81(suspend_always)         = Call[final_suspend]                       : func:r87_80, this:r87_79
-#   87|     m87_82(unknown)                = ^CallSideEffect                           : ~m87_77
-#   87|     m87_83(unknown)                = Chi                                       : total:m87_77, partial:m87_82
-#   87|     v87_84(void)                   = ^IndirectReadSideEffect[-1]               : &:r87_79, ~m87_83
-#   87|     m87_85(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r87_79
-#   87|     m87_86(unknown)                = Chi                                       : total:m87_83, partial:m87_85
-#   87|     m87_87(suspend_always)         = Store[#temp87:20]                         : &:r87_78, r87_81
-#   87|     m87_88(unknown)                = Chi                                       : total:m87_86, partial:m87_87
-#   87|     r87_89(suspend_always *)       = CopyValue                                 : r87_78
-#   87|     m87_90(suspend_always *)       = Store[#temp0:0]                           : &:r0_29, r87_89
-#-----|     r0_30(suspend_always *)        = Load[#temp0:0]                            : &:r0_29, m87_90
-#   87|     r87_91(glval<suspend_always>)  = CopyValue                                 : r0_30
-#   87|     r87_92(glval<suspend_always>)  = Convert                                   : r87_91
-#   87|     r87_93(glval<unknown>)         = FunctionAddress[await_ready]              : 
-#   87|     r87_94(bool)                   = Call[await_ready]                         : func:r87_93, this:r87_92
-#   87|     m87_95(unknown)                = ^CallSideEffect                           : ~m87_88
-#   87|     m87_96(unknown)                = Chi                                       : total:m87_88, partial:m87_95
-#   87|     v87_97(void)                   = ^IndirectReadSideEffect[-1]               : &:r87_92, ~m87_96
-#-----|     v0_31(void)                    = ConditionalBranch                         : r87_94
+#-----|     m0_25(unknown)                 = Phi                                       : from 3:~m0_17, from 5:~m87_67
+#-----|     v0_26(void)                    = NoOp                                      : 
+#   87|     r87_68(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
+#   87|     r87_69(glval<unknown>)         = FunctionAddress[final_suspend]            : 
+#   87|     r87_70(suspend_always)         = Call[final_suspend]                       : func:r87_69, this:r87_68
+#   87|     m87_71(unknown)                = ^CallSideEffect                           : ~m0_25
+#   87|     m87_72(unknown)                = Chi                                       : total:m0_25, partial:m87_71
+#   87|     v87_73(void)                   = ^IndirectReadSideEffect[-1]               : &:r87_68, ~m87_72
+#   87|     m87_74(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r87_68
+#   87|     m87_75(unknown)                = Chi                                       : total:m87_72, partial:m87_74
+#-----|     r0_27(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
+#   87|     r87_76(glval<suspend_always>)  = VariableAddress[#temp87:20]               : 
+#   87|     r87_77(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
+#   87|     r87_78(glval<unknown>)         = FunctionAddress[final_suspend]            : 
+#   87|     r87_79(suspend_always)         = Call[final_suspend]                       : func:r87_78, this:r87_77
+#   87|     m87_80(unknown)                = ^CallSideEffect                           : ~m87_75
+#   87|     m87_81(unknown)                = Chi                                       : total:m87_75, partial:m87_80
+#   87|     v87_82(void)                   = ^IndirectReadSideEffect[-1]               : &:r87_77, ~m87_81
+#   87|     m87_83(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r87_77
+#   87|     m87_84(unknown)                = Chi                                       : total:m87_81, partial:m87_83
+#   87|     m87_85(suspend_always)         = Store[#temp87:20]                         : &:r87_76, r87_79
+#   87|     m87_86(unknown)                = Chi                                       : total:m87_84, partial:m87_85
+#   87|     r87_87(suspend_always *)       = CopyValue                                 : r87_76
+#   87|     m87_88(suspend_always *)       = Store[#temp0:0]                           : &:r0_27, r87_87
+#-----|     r0_28(suspend_always *)        = Load[#temp0:0]                            : &:r0_27, m87_88
+#   87|     r87_89(glval<suspend_always>)  = CopyValue                                 : r0_28
+#   87|     r87_90(glval<unknown>)         = FunctionAddress[await_ready]              : 
+#   87|     r87_91(bool)                   = Call[await_ready]                         : func:r87_90, this:r87_89
+#   87|     m87_92(unknown)                = ^CallSideEffect                           : ~m87_86
+#   87|     m87_93(unknown)                = Chi                                       : total:m87_86, partial:m87_92
+#   87|     v87_94(void)                   = ^IndirectReadSideEffect[-1]               : &:r87_89, ~m87_93
+#-----|     v0_29(void)                    = ConditionalBranch                         : r87_91
 #-----|   False -> Block 8
 #-----|   True -> Block 7
 
 #   87|   Block 7
-#   87|     m87_98(unknown)                    = Phi                           : from 6:~m87_96, from 8:~m87_128
-#   87|     r87_99(suspend_always *)           = CopyValue                     : r87_89
-#   87|     r87_100(glval<suspend_always>)     = CopyValue                     : r87_99
-#-----|     r0_32(glval<suspend_always>)       = Convert                       : r87_100
-#   87|     r87_101(glval<unknown>)            = FunctionAddress[await_resume] : 
-#   87|     v87_102(void)                      = Call[await_resume]            : func:r87_101, this:r0_32
-#   87|     m87_103(unknown)                   = ^CallSideEffect               : ~m87_98
-#   87|     m87_104(unknown)                   = Chi                           : total:m87_98, partial:m87_103
-#-----|     v0_33(void)                        = ^IndirectReadSideEffect[-1]   : &:r0_32, ~m87_104
-#   87|     r87_105(glval<co_returnable_void>) = VariableAddress[#return]      : 
-#   87|     v87_106(void)                      = ReturnValue                   : &:r87_105, ~m87_104
-#   87|     v87_107(void)                      = AliasedUse                    : ~m87_104
-#   87|     v87_108(void)                      = ExitFunction                  : 
+#   87|     m87_95(unknown)                    = Phi                           : from 6:~m87_93, from 8:~m87_124
+#   87|     r87_96(suspend_always *)           = CopyValue                     : r87_87
+#   87|     r87_97(glval<suspend_always>)      = CopyValue                     : r87_96
+#   87|     r87_98(glval<unknown>)             = FunctionAddress[await_resume] : 
+#   87|     v87_99(void)                       = Call[await_resume]            : func:r87_98, this:r87_97
+#   87|     m87_100(unknown)                   = ^CallSideEffect               : ~m87_95
+#   87|     m87_101(unknown)                   = Chi                           : total:m87_95, partial:m87_100
+#-----|     v0_30(void)                        = ^IndirectReadSideEffect[-1]   : &:r87_97, ~m87_101
+#   87|     r87_102(glval<co_returnable_void>) = VariableAddress[#return]      : 
+#   87|     v87_103(void)                      = ReturnValue                   : &:r87_102, ~m87_101
+#   87|     v87_104(void)                      = AliasedUse                    : ~m87_101
+#   87|     v87_105(void)                      = ExitFunction                  : 
 
 #   87|   Block 8
-#   87|     r87_109(suspend_always *)                      = CopyValue                                 : r87_89
-#   87|     r87_110(glval<suspend_always>)                 = CopyValue                                 : r87_109
-#-----|     r0_34(glval<suspend_always>)                   = Convert                                   : r87_110
-#   87|     r87_111(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
-#   87|     r87_112(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp87:20]               : 
-#   87|     m87_113(coroutine_handle<promise_type>)        = Uninitialized[#temp87:20]                 : &:r87_112
-#   87|     m87_114(unknown)                               = Chi                                       : total:m87_96, partial:m87_113
-#   87|     r87_115(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
-#   87|     r87_116(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
-#   87|     r87_117(glval<coroutine_handle<promise_type>>) = Convert                                   : r87_116
-#   87|     r87_118(coroutine_handle<promise_type> &)      = CopyValue                                 : r87_117
-#   87|     v87_119(void)                                  = Call[coroutine_handle]                    : func:r87_115, this:r87_112, 0:r87_118
-#   87|     m87_120(unknown)                               = ^CallSideEffect                           : ~m87_114
-#   87|     m87_121(unknown)                               = Chi                                       : total:m87_114, partial:m87_120
-#   87|     v87_122(void)                                  = ^BufferReadSideEffect[0]                  : &:r87_118, ~m87_121
-#   87|     m87_123(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r87_112
-#   87|     m87_124(unknown)                               = Chi                                       : total:m87_121, partial:m87_123
-#   87|     r87_125(coroutine_handle<promise_type>)        = Load[#temp87:20]                          : &:r87_112, ~m87_124
-#   87|     v87_126(void)                                  = Call[await_suspend]                       : func:r87_111, this:r0_34, 0:r87_125
-#   87|     m87_127(unknown)                               = ^CallSideEffect                           : ~m87_124
-#   87|     m87_128(unknown)                               = Chi                                       : total:m87_124, partial:m87_127
-#-----|     v0_35(void)                                    = ^IndirectReadSideEffect[-1]               : &:r0_34, ~m87_128
+#   87|     r87_106(suspend_always *)                      = CopyValue                                 : r87_87
+#   87|     r87_107(glval<suspend_always>)                 = CopyValue                                 : r87_106
+#   87|     r87_108(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
+#   87|     r87_109(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp87:20]               : 
+#   87|     m87_110(coroutine_handle<promise_type>)        = Uninitialized[#temp87:20]                 : &:r87_109
+#   87|     m87_111(unknown)                               = Chi                                       : total:m87_93, partial:m87_110
+#   87|     r87_112(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
+#   87|     r87_113(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
+#   87|     r87_114(coroutine_handle<promise_type> &)      = CopyValue                                 : r87_113
+#   87|     v87_115(void)                                  = Call[coroutine_handle]                    : func:r87_112, this:r87_109, 0:r87_114
+#   87|     m87_116(unknown)                               = ^CallSideEffect                           : ~m87_111
+#   87|     m87_117(unknown)                               = Chi                                       : total:m87_111, partial:m87_116
+#   87|     v87_118(void)                                  = ^BufferReadSideEffect[0]                  : &:r87_114, ~m87_117
+#   87|     m87_119(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r87_109
+#   87|     m87_120(unknown)                               = Chi                                       : total:m87_117, partial:m87_119
+#   87|     r87_121(coroutine_handle<promise_type>)        = Load[#temp87:20]                          : &:r87_109, ~m87_120
+#   87|     v87_122(void)                                  = Call[await_suspend]                       : func:r87_108, this:r87_107, 0:r87_121
+#   87|     m87_123(unknown)                               = ^CallSideEffect                           : ~m87_120
+#   87|     m87_124(unknown)                               = Chi                                       : total:m87_120, partial:m87_123
+#-----|     v0_31(void)                                    = ^IndirectReadSideEffect[-1]               : &:r87_107, ~m87_124
 #-----|   Goto -> Block 7
 
 #   87|   Block 9
-#   87|     v87_129(void) = Unreached : 
+#   87|     v87_125(void) = Unreached : 
 
 #   91| co_returnable_value co_return_int(int)
 #   91|   Block 0
@@ -1101,172 +1092,164 @@ coroutines.cpp:
 #   91|     m91_30(suspend_always *)      = Store[#temp0:0]                           : &:r0_5, r91_29
 #-----|     r0_6(suspend_always *)        = Load[#temp0:0]                            : &:r0_5, m91_30
 #   91|     r91_31(glval<suspend_always>) = CopyValue                                 : r0_6
-#   91|     r91_32(glval<suspend_always>) = Convert                                   : r91_31
-#   91|     r91_33(glval<unknown>)        = FunctionAddress[await_ready]              : 
-#   91|     r91_34(bool)                  = Call[await_ready]                         : func:r91_33, this:r91_32
-#   91|     m91_35(unknown)               = ^CallSideEffect                           : ~m91_28
-#   91|     m91_36(unknown)               = Chi                                       : total:m91_28, partial:m91_35
-#   91|     v91_37(void)                  = ^IndirectReadSideEffect[-1]               : &:r91_32, ~m91_36
-#-----|     v0_7(void)                    = ConditionalBranch                         : r91_34
+#   91|     r91_32(glval<unknown>)        = FunctionAddress[await_ready]              : 
+#   91|     r91_33(bool)                  = Call[await_ready]                         : func:r91_32, this:r91_31
+#   91|     m91_34(unknown)               = ^CallSideEffect                           : ~m91_28
+#   91|     m91_35(unknown)               = Chi                                       : total:m91_28, partial:m91_34
+#   91|     v91_36(void)                  = ^IndirectReadSideEffect[-1]               : &:r91_31, ~m91_35
+#-----|     v0_7(void)                    = ConditionalBranch                         : r91_33
 #-----|   False -> Block 2
 #-----|   True -> Block 1
 
 #-----|   Block 1
-#-----|     m0_8(unknown)                 = Phi                                       : from 0:~m91_36, from 2:~m91_63
+#-----|     m0_8(unknown)                 = Phi                                       : from 0:~m91_35, from 2:~m91_61
 #-----|     r0_9(bool)                    = Constant[1]                               : 
 #-----|     r0_10(glval<bool>)            = VariableAddress[(unnamed local variable)] : 
 #-----|     m0_11(bool)                   = Store[(unnamed local variable)]           : &:r0_10, r0_9
-#   91|     r91_38(suspend_always *)      = CopyValue                                 : r91_29
-#   91|     r91_39(glval<suspend_always>) = CopyValue                                 : r91_38
-#-----|     r0_12(glval<suspend_always>)  = Convert                                   : r91_39
-#   91|     r91_40(glval<unknown>)        = FunctionAddress[await_resume]             : 
-#   91|     v91_41(void)                  = Call[await_resume]                        : func:r91_40, this:r0_12
-#   91|     m91_42(unknown)               = ^CallSideEffect                           : ~m0_8
-#   91|     m91_43(unknown)               = Chi                                       : total:m0_8, partial:m91_42
-#-----|     v0_13(void)                   = ^IndirectReadSideEffect[-1]               : &:r0_12, ~m91_43
-#-----|     v0_14(void)                   = CopyValue                                 : v91_41
-#-----|     r0_15(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
-#-----|     r0_16(glval<unknown>)         = FunctionAddress[return_value]             : 
+#   91|     r91_37(suspend_always *)      = CopyValue                                 : r91_29
+#   91|     r91_38(glval<suspend_always>) = CopyValue                                 : r91_37
+#   91|     r91_39(glval<unknown>)        = FunctionAddress[await_resume]             : 
+#   91|     v91_40(void)                  = Call[await_resume]                        : func:r91_39, this:r91_38
+#   91|     m91_41(unknown)               = ^CallSideEffect                           : ~m0_8
+#   91|     m91_42(unknown)               = Chi                                       : total:m0_8, partial:m91_41
+#-----|     v0_12(void)                   = ^IndirectReadSideEffect[-1]               : &:r91_38, ~m91_42
+#-----|     v0_13(void)                   = CopyValue                                 : v91_40
+#-----|     r0_14(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
+#-----|     r0_15(glval<unknown>)         = FunctionAddress[return_value]             : 
 #   92|     r92_1(glval<int>)             = VariableAddress[i]                        : 
 #   92|     r92_2(int)                    = Load[i]                                   : &:r92_1, m0_4
-#-----|     v0_17(void)                   = Call[return_value]                        : func:r0_16, this:r0_15, 0:r92_2
-#-----|     m0_18(unknown)                = ^CallSideEffect                           : ~m91_43
-#-----|     m0_19(unknown)                = Chi                                       : total:m91_43, partial:m0_18
-#-----|     v0_20(void)                   = ^IndirectReadSideEffect[-1]               : &:r0_15, ~m0_19
-#-----|     m0_21(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r0_15
-#-----|     m0_22(unknown)                = Chi                                       : total:m0_19, partial:m0_21
+#-----|     v0_16(void)                   = Call[return_value]                        : func:r0_15, this:r0_14, 0:r92_2
+#-----|     m0_17(unknown)                = ^CallSideEffect                           : ~m91_42
+#-----|     m0_18(unknown)                = Chi                                       : total:m91_42, partial:m0_17
+#-----|     v0_19(void)                   = ^IndirectReadSideEffect[-1]               : &:r0_14, ~m0_18
+#-----|     m0_20(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r0_14
+#-----|     m0_21(unknown)                = Chi                                       : total:m0_18, partial:m0_20
 #-----|   C++ Exception -> Block 4
 #-----|   Goto -> Block 3
 
 #   91|   Block 2
-#   91|     r91_44(suspend_always *)                      = CopyValue                                 : r91_29
-#   91|     r91_45(glval<suspend_always>)                 = CopyValue                                 : r91_44
-#-----|     r0_23(glval<suspend_always>)                  = Convert                                   : r91_45
-#   91|     r91_46(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
-#   91|     r91_47(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp91:21]               : 
-#   91|     m91_48(coroutine_handle<promise_type>)        = Uninitialized[#temp91:21]                 : &:r91_47
-#   91|     m91_49(unknown)                               = Chi                                       : total:m91_36, partial:m91_48
-#   91|     r91_50(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
-#   91|     r91_51(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
-#   91|     r91_52(glval<coroutine_handle<promise_type>>) = Convert                                   : r91_51
-#   91|     r91_53(coroutine_handle<promise_type> &)      = CopyValue                                 : r91_52
-#   91|     v91_54(void)                                  = Call[coroutine_handle]                    : func:r91_50, this:r91_47, 0:r91_53
-#   91|     m91_55(unknown)                               = ^CallSideEffect                           : ~m91_49
-#   91|     m91_56(unknown)                               = Chi                                       : total:m91_49, partial:m91_55
-#   91|     v91_57(void)                                  = ^BufferReadSideEffect[0]                  : &:r91_53, ~m91_56
-#   91|     m91_58(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r91_47
-#   91|     m91_59(unknown)                               = Chi                                       : total:m91_56, partial:m91_58
-#   91|     r91_60(coroutine_handle<promise_type>)        = Load[#temp91:21]                          : &:r91_47, ~m91_59
-#   91|     v91_61(void)                                  = Call[await_suspend]                       : func:r91_46, this:r0_23, 0:r91_60
-#   91|     m91_62(unknown)                               = ^CallSideEffect                           : ~m91_59
-#   91|     m91_63(unknown)                               = Chi                                       : total:m91_59, partial:m91_62
-#-----|     v0_24(void)                                   = ^IndirectReadSideEffect[-1]               : &:r0_23, ~m91_63
+#   91|     r91_43(suspend_always *)                      = CopyValue                                 : r91_29
+#   91|     r91_44(glval<suspend_always>)                 = CopyValue                                 : r91_43
+#   91|     r91_45(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
+#   91|     r91_46(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp91:21]               : 
+#   91|     m91_47(coroutine_handle<promise_type>)        = Uninitialized[#temp91:21]                 : &:r91_46
+#   91|     m91_48(unknown)                               = Chi                                       : total:m91_35, partial:m91_47
+#   91|     r91_49(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
+#   91|     r91_50(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
+#   91|     r91_51(coroutine_handle<promise_type> &)      = CopyValue                                 : r91_50
+#   91|     v91_52(void)                                  = Call[coroutine_handle]                    : func:r91_49, this:r91_46, 0:r91_51
+#   91|     m91_53(unknown)                               = ^CallSideEffect                           : ~m91_48
+#   91|     m91_54(unknown)                               = Chi                                       : total:m91_48, partial:m91_53
+#   91|     v91_55(void)                                  = ^BufferReadSideEffect[0]                  : &:r91_51, ~m91_54
+#   91|     m91_56(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r91_46
+#   91|     m91_57(unknown)                               = Chi                                       : total:m91_54, partial:m91_56
+#   91|     r91_58(coroutine_handle<promise_type>)        = Load[#temp91:21]                          : &:r91_46, ~m91_57
+#   91|     v91_59(void)                                  = Call[await_suspend]                       : func:r91_45, this:r91_44, 0:r91_58
+#   91|     m91_60(unknown)                               = ^CallSideEffect                           : ~m91_57
+#   91|     m91_61(unknown)                               = Chi                                       : total:m91_57, partial:m91_60
+#-----|     v0_22(void)                                   = ^IndirectReadSideEffect[-1]               : &:r91_44, ~m91_61
 #-----|   Goto -> Block 1
 
 #   92|   Block 3
 #   92|     v92_3(void) = NoOp : 
-#-----|     v0_25(void) = NoOp : 
+#-----|     v0_23(void) = NoOp : 
 #-----|   Goto (back edge) -> Block 6
 
 #-----|   Block 4
-#-----|     v0_26(void)        = CatchAny                                  : 
-#-----|     r0_27(glval<bool>) = VariableAddress[(unnamed local variable)] : 
-#-----|     r0_28(bool)        = Load[(unnamed local variable)]            : &:r0_27, m0_11
-#-----|     r0_29(bool)        = LogicalNot                                : r0_28
-#-----|     v0_30(void)        = ConditionalBranch                         : r0_29
+#-----|     v0_24(void)        = CatchAny                                  : 
+#-----|     r0_25(glval<bool>) = VariableAddress[(unnamed local variable)] : 
+#-----|     r0_26(bool)        = Load[(unnamed local variable)]            : &:r0_25, m0_11
+#-----|     r0_27(bool)        = LogicalNot                                : r0_26
+#-----|     v0_28(void)        = ConditionalBranch                         : r0_27
 #-----|   False -> Block 5
 #-----|   True -> Block 9
 
 #   91|   Block 5
-#   91|     r91_64(glval<promise_type>) = VariableAddress[(unnamed local variable)] : 
-#   91|     r91_65(glval<unknown>)      = FunctionAddress[unhandled_exception]      : 
-#   91|     v91_66(void)                = Call[unhandled_exception]                 : func:r91_65, this:r91_64
-#   91|     m91_67(unknown)             = ^CallSideEffect                           : ~m0_22
-#   91|     m91_68(unknown)             = Chi                                       : total:m0_22, partial:m91_67
-#   91|     v91_69(void)                = ^IndirectReadSideEffect[-1]               : &:r91_64, ~m91_68
-#   91|     m91_70(promise_type)        = ^IndirectMayWriteSideEffect[-1]           : &:r91_64
-#   91|     m91_71(unknown)             = Chi                                       : total:m91_68, partial:m91_70
+#   91|     r91_62(glval<promise_type>) = VariableAddress[(unnamed local variable)] : 
+#   91|     r91_63(glval<unknown>)      = FunctionAddress[unhandled_exception]      : 
+#   91|     v91_64(void)                = Call[unhandled_exception]                 : func:r91_63, this:r91_62
+#   91|     m91_65(unknown)             = ^CallSideEffect                           : ~m0_21
+#   91|     m91_66(unknown)             = Chi                                       : total:m0_21, partial:m91_65
+#   91|     v91_67(void)                = ^IndirectReadSideEffect[-1]               : &:r91_62, ~m91_66
+#   91|     m91_68(promise_type)        = ^IndirectMayWriteSideEffect[-1]           : &:r91_62
+#   91|     m91_69(unknown)             = Chi                                       : total:m91_66, partial:m91_68
 #-----|   Goto -> Block 6
 
 #-----|   Block 6
-#-----|     m0_31(unknown)                 = Phi                                       : from 3:~m0_22, from 5:~m91_71
-#-----|     v0_32(void)                    = NoOp                                      : 
-#   91|     r91_72(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
-#   91|     r91_73(glval<unknown>)         = FunctionAddress[final_suspend]            : 
-#   91|     r91_74(suspend_always)         = Call[final_suspend]                       : func:r91_73, this:r91_72
-#   91|     m91_75(unknown)                = ^CallSideEffect                           : ~m0_31
-#   91|     m91_76(unknown)                = Chi                                       : total:m0_31, partial:m91_75
-#   91|     v91_77(void)                   = ^IndirectReadSideEffect[-1]               : &:r91_72, ~m91_76
-#   91|     m91_78(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r91_72
-#   91|     m91_79(unknown)                = Chi                                       : total:m91_76, partial:m91_78
-#-----|     r0_33(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
-#   91|     r91_80(glval<suspend_always>)  = VariableAddress[#temp91:21]               : 
-#   91|     r91_81(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
-#   91|     r91_82(glval<unknown>)         = FunctionAddress[final_suspend]            : 
-#   91|     r91_83(suspend_always)         = Call[final_suspend]                       : func:r91_82, this:r91_81
-#   91|     m91_84(unknown)                = ^CallSideEffect                           : ~m91_79
-#   91|     m91_85(unknown)                = Chi                                       : total:m91_79, partial:m91_84
-#   91|     v91_86(void)                   = ^IndirectReadSideEffect[-1]               : &:r91_81, ~m91_85
-#   91|     m91_87(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r91_81
-#   91|     m91_88(unknown)                = Chi                                       : total:m91_85, partial:m91_87
-#   91|     m91_89(suspend_always)         = Store[#temp91:21]                         : &:r91_80, r91_83
-#   91|     m91_90(unknown)                = Chi                                       : total:m91_88, partial:m91_89
-#   91|     r91_91(suspend_always *)       = CopyValue                                 : r91_80
-#   91|     m91_92(suspend_always *)       = Store[#temp0:0]                           : &:r0_33, r91_91
-#-----|     r0_34(suspend_always *)        = Load[#temp0:0]                            : &:r0_33, m91_92
-#   91|     r91_93(glval<suspend_always>)  = CopyValue                                 : r0_34
-#   91|     r91_94(glval<suspend_always>)  = Convert                                   : r91_93
-#   91|     r91_95(glval<unknown>)         = FunctionAddress[await_ready]              : 
-#   91|     r91_96(bool)                   = Call[await_ready]                         : func:r91_95, this:r91_94
-#   91|     m91_97(unknown)                = ^CallSideEffect                           : ~m91_90
-#   91|     m91_98(unknown)                = Chi                                       : total:m91_90, partial:m91_97
-#   91|     v91_99(void)                   = ^IndirectReadSideEffect[-1]               : &:r91_94, ~m91_98
-#-----|     v0_35(void)                    = ConditionalBranch                         : r91_96
+#-----|     m0_29(unknown)                 = Phi                                       : from 3:~m0_21, from 5:~m91_69
+#-----|     v0_30(void)                    = NoOp                                      : 
+#   91|     r91_70(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
+#   91|     r91_71(glval<unknown>)         = FunctionAddress[final_suspend]            : 
+#   91|     r91_72(suspend_always)         = Call[final_suspend]                       : func:r91_71, this:r91_70
+#   91|     m91_73(unknown)                = ^CallSideEffect                           : ~m0_29
+#   91|     m91_74(unknown)                = Chi                                       : total:m0_29, partial:m91_73
+#   91|     v91_75(void)                   = ^IndirectReadSideEffect[-1]               : &:r91_70, ~m91_74
+#   91|     m91_76(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r91_70
+#   91|     m91_77(unknown)                = Chi                                       : total:m91_74, partial:m91_76
+#-----|     r0_31(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
+#   91|     r91_78(glval<suspend_always>)  = VariableAddress[#temp91:21]               : 
+#   91|     r91_79(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
+#   91|     r91_80(glval<unknown>)         = FunctionAddress[final_suspend]            : 
+#   91|     r91_81(suspend_always)         = Call[final_suspend]                       : func:r91_80, this:r91_79
+#   91|     m91_82(unknown)                = ^CallSideEffect                           : ~m91_77
+#   91|     m91_83(unknown)                = Chi                                       : total:m91_77, partial:m91_82
+#   91|     v91_84(void)                   = ^IndirectReadSideEffect[-1]               : &:r91_79, ~m91_83
+#   91|     m91_85(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r91_79
+#   91|     m91_86(unknown)                = Chi                                       : total:m91_83, partial:m91_85
+#   91|     m91_87(suspend_always)         = Store[#temp91:21]                         : &:r91_78, r91_81
+#   91|     m91_88(unknown)                = Chi                                       : total:m91_86, partial:m91_87
+#   91|     r91_89(suspend_always *)       = CopyValue                                 : r91_78
+#   91|     m91_90(suspend_always *)       = Store[#temp0:0]                           : &:r0_31, r91_89
+#-----|     r0_32(suspend_always *)        = Load[#temp0:0]                            : &:r0_31, m91_90
+#   91|     r91_91(glval<suspend_always>)  = CopyValue                                 : r0_32
+#   91|     r91_92(glval<unknown>)         = FunctionAddress[await_ready]              : 
+#   91|     r91_93(bool)                   = Call[await_ready]                         : func:r91_92, this:r91_91
+#   91|     m91_94(unknown)                = ^CallSideEffect                           : ~m91_88
+#   91|     m91_95(unknown)                = Chi                                       : total:m91_88, partial:m91_94
+#   91|     v91_96(void)                   = ^IndirectReadSideEffect[-1]               : &:r91_91, ~m91_95
+#-----|     v0_33(void)                    = ConditionalBranch                         : r91_93
 #-----|   False -> Block 8
 #-----|   True -> Block 7
 
 #   91|   Block 7
-#   91|     m91_100(unknown)                    = Phi                           : from 6:~m91_98, from 8:~m91_130
-#   91|     r91_101(suspend_always *)           = CopyValue                     : r91_91
-#   91|     r91_102(glval<suspend_always>)      = CopyValue                     : r91_101
-#-----|     r0_36(glval<suspend_always>)        = Convert                       : r91_102
-#   91|     r91_103(glval<unknown>)             = FunctionAddress[await_resume] : 
-#   91|     v91_104(void)                       = Call[await_resume]            : func:r91_103, this:r0_36
-#   91|     m91_105(unknown)                    = ^CallSideEffect               : ~m91_100
-#   91|     m91_106(unknown)                    = Chi                           : total:m91_100, partial:m91_105
-#-----|     v0_37(void)                         = ^IndirectReadSideEffect[-1]   : &:r0_36, ~m91_106
-#   91|     r91_107(glval<co_returnable_value>) = VariableAddress[#return]      : 
-#   91|     v91_108(void)                       = ReturnValue                   : &:r91_107, ~m91_106
-#   91|     v91_109(void)                       = AliasedUse                    : ~m91_106
-#   91|     v91_110(void)                       = ExitFunction                  : 
+#   91|     m91_97(unknown)                     = Phi                           : from 6:~m91_95, from 8:~m91_126
+#   91|     r91_98(suspend_always *)            = CopyValue                     : r91_89
+#   91|     r91_99(glval<suspend_always>)       = CopyValue                     : r91_98
+#   91|     r91_100(glval<unknown>)             = FunctionAddress[await_resume] : 
+#   91|     v91_101(void)                       = Call[await_resume]            : func:r91_100, this:r91_99
+#   91|     m91_102(unknown)                    = ^CallSideEffect               : ~m91_97
+#   91|     m91_103(unknown)                    = Chi                           : total:m91_97, partial:m91_102
+#-----|     v0_34(void)                         = ^IndirectReadSideEffect[-1]   : &:r91_99, ~m91_103
+#   91|     r91_104(glval<co_returnable_value>) = VariableAddress[#return]      : 
+#   91|     v91_105(void)                       = ReturnValue                   : &:r91_104, ~m91_103
+#   91|     v91_106(void)                       = AliasedUse                    : ~m91_103
+#   91|     v91_107(void)                       = ExitFunction                  : 
 
 #   91|   Block 8
-#   91|     r91_111(suspend_always *)                      = CopyValue                                 : r91_91
-#   91|     r91_112(glval<suspend_always>)                 = CopyValue                                 : r91_111
-#-----|     r0_38(glval<suspend_always>)                   = Convert                                   : r91_112
-#   91|     r91_113(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
-#   91|     r91_114(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp91:21]               : 
-#   91|     m91_115(coroutine_handle<promise_type>)        = Uninitialized[#temp91:21]                 : &:r91_114
-#   91|     m91_116(unknown)                               = Chi                                       : total:m91_98, partial:m91_115
-#   91|     r91_117(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
-#   91|     r91_118(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
-#   91|     r91_119(glval<coroutine_handle<promise_type>>) = Convert                                   : r91_118
-#   91|     r91_120(coroutine_handle<promise_type> &)      = CopyValue                                 : r91_119
-#   91|     v91_121(void)                                  = Call[coroutine_handle]                    : func:r91_117, this:r91_114, 0:r91_120
-#   91|     m91_122(unknown)                               = ^CallSideEffect                           : ~m91_116
-#   91|     m91_123(unknown)                               = Chi                                       : total:m91_116, partial:m91_122
-#   91|     v91_124(void)                                  = ^BufferReadSideEffect[0]                  : &:r91_120, ~m91_123
-#   91|     m91_125(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r91_114
-#   91|     m91_126(unknown)                               = Chi                                       : total:m91_123, partial:m91_125
-#   91|     r91_127(coroutine_handle<promise_type>)        = Load[#temp91:21]                          : &:r91_114, ~m91_126
-#   91|     v91_128(void)                                  = Call[await_suspend]                       : func:r91_113, this:r0_38, 0:r91_127
-#   91|     m91_129(unknown)                               = ^CallSideEffect                           : ~m91_126
-#   91|     m91_130(unknown)                               = Chi                                       : total:m91_126, partial:m91_129
-#-----|     v0_39(void)                                    = ^IndirectReadSideEffect[-1]               : &:r0_38, ~m91_130
+#   91|     r91_108(suspend_always *)                      = CopyValue                                 : r91_89
+#   91|     r91_109(glval<suspend_always>)                 = CopyValue                                 : r91_108
+#   91|     r91_110(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
+#   91|     r91_111(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp91:21]               : 
+#   91|     m91_112(coroutine_handle<promise_type>)        = Uninitialized[#temp91:21]                 : &:r91_111
+#   91|     m91_113(unknown)                               = Chi                                       : total:m91_95, partial:m91_112
+#   91|     r91_114(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
+#   91|     r91_115(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
+#   91|     r91_116(coroutine_handle<promise_type> &)      = CopyValue                                 : r91_115
+#   91|     v91_117(void)                                  = Call[coroutine_handle]                    : func:r91_114, this:r91_111, 0:r91_116
+#   91|     m91_118(unknown)                               = ^CallSideEffect                           : ~m91_113
+#   91|     m91_119(unknown)                               = Chi                                       : total:m91_113, partial:m91_118
+#   91|     v91_120(void)                                  = ^BufferReadSideEffect[0]                  : &:r91_116, ~m91_119
+#   91|     m91_121(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r91_111
+#   91|     m91_122(unknown)                               = Chi                                       : total:m91_119, partial:m91_121
+#   91|     r91_123(coroutine_handle<promise_type>)        = Load[#temp91:21]                          : &:r91_111, ~m91_122
+#   91|     v91_124(void)                                  = Call[await_suspend]                       : func:r91_110, this:r91_109, 0:r91_123
+#   91|     m91_125(unknown)                               = ^CallSideEffect                           : ~m91_122
+#   91|     m91_126(unknown)                               = Chi                                       : total:m91_122, partial:m91_125
+#-----|     v0_35(void)                                    = ^IndirectReadSideEffect[-1]               : &:r91_109, ~m91_126
 #-----|   Goto -> Block 7
 
 #   91|   Block 9
-#   91|     v91_131(void) = Unreached : 
+#   91|     v91_127(void) = Unreached : 
 
 #   95| co_returnable_void co_yield_value_void(int)
 #   95|   Block 0
@@ -1307,37 +1290,35 @@ coroutines.cpp:
 #   95|     m95_30(suspend_always *)      = Store[#temp0:0]                           : &:r0_5, r95_29
 #-----|     r0_6(suspend_always *)        = Load[#temp0:0]                            : &:r0_5, m95_30
 #   95|     r95_31(glval<suspend_always>) = CopyValue                                 : r0_6
-#   95|     r95_32(glval<suspend_always>) = Convert                                   : r95_31
-#   95|     r95_33(glval<unknown>)        = FunctionAddress[await_ready]              : 
-#   95|     r95_34(bool)                  = Call[await_ready]                         : func:r95_33, this:r95_32
-#   95|     m95_35(unknown)               = ^CallSideEffect                           : ~m95_28
-#   95|     m95_36(unknown)               = Chi                                       : total:m95_28, partial:m95_35
-#   95|     v95_37(void)                  = ^IndirectReadSideEffect[-1]               : &:r95_32, ~m95_36
-#-----|     v0_7(void)                    = ConditionalBranch                         : r95_34
+#   95|     r95_32(glval<unknown>)        = FunctionAddress[await_ready]              : 
+#   95|     r95_33(bool)                  = Call[await_ready]                         : func:r95_32, this:r95_31
+#   95|     m95_34(unknown)               = ^CallSideEffect                           : ~m95_28
+#   95|     m95_35(unknown)               = Chi                                       : total:m95_28, partial:m95_34
+#   95|     v95_36(void)                  = ^IndirectReadSideEffect[-1]               : &:r95_31, ~m95_35
+#-----|     v0_7(void)                    = ConditionalBranch                         : r95_33
 #-----|   False -> Block 2
 #-----|   True -> Block 1
 
 #-----|   Block 1
-#-----|     m0_8(unknown)                 = Phi                                       : from 0:~m95_36, from 2:~m95_63
+#-----|     m0_8(unknown)                 = Phi                                       : from 0:~m95_35, from 2:~m95_61
 #-----|     r0_9(bool)                    = Constant[1]                               : 
 #-----|     r0_10(glval<bool>)            = VariableAddress[(unnamed local variable)] : 
 #-----|     m0_11(bool)                   = Store[(unnamed local variable)]           : &:r0_10, r0_9
-#   95|     r95_38(suspend_always *)      = CopyValue                                 : r95_29
-#   95|     r95_39(glval<suspend_always>) = CopyValue                                 : r95_38
-#-----|     r0_12(glval<suspend_always>)  = Convert                                   : r95_39
-#   95|     r95_40(glval<unknown>)        = FunctionAddress[await_resume]             : 
-#   95|     v95_41(void)                  = Call[await_resume]                        : func:r95_40, this:r0_12
-#   95|     m95_42(unknown)               = ^CallSideEffect                           : ~m0_8
-#   95|     m95_43(unknown)               = Chi                                       : total:m0_8, partial:m95_42
-#-----|     v0_13(void)                   = ^IndirectReadSideEffect[-1]               : &:r0_12, ~m95_43
-#-----|     v0_14(void)                   = CopyValue                                 : v95_41
+#   95|     r95_37(suspend_always *)      = CopyValue                                 : r95_29
+#   95|     r95_38(glval<suspend_always>) = CopyValue                                 : r95_37
+#   95|     r95_39(glval<unknown>)        = FunctionAddress[await_resume]             : 
+#   95|     v95_40(void)                  = Call[await_resume]                        : func:r95_39, this:r95_38
+#   95|     m95_41(unknown)               = ^CallSideEffect                           : ~m0_8
+#   95|     m95_42(unknown)               = Chi                                       : total:m0_8, partial:m95_41
+#-----|     v0_12(void)                   = ^IndirectReadSideEffect[-1]               : &:r95_38, ~m95_42
+#-----|     v0_13(void)                   = CopyValue                                 : v95_40
 #   96|     r96_1(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
 #   96|     r96_2(glval<unknown>)         = FunctionAddress[yield_value]              : 
 #   96|     r96_3(glval<int>)             = VariableAddress[i]                        : 
 #   96|     r96_4(int)                    = Load[i]                                   : &:r96_3, m0_4
 #   96|     r96_5(suspend_always)         = Call[yield_value]                         : func:r96_2, this:r96_1, 0:r96_4
-#   96|     m96_6(unknown)                = ^CallSideEffect                           : ~m95_43
-#   96|     m96_7(unknown)                = Chi                                       : total:m95_43, partial:m96_6
+#   96|     m96_6(unknown)                = ^CallSideEffect                           : ~m95_42
+#   96|     m96_7(unknown)                = Chi                                       : total:m95_42, partial:m96_6
 #   96|     v96_8(void)                   = ^IndirectReadSideEffect[-1]               : &:r96_1, ~m96_7
 #   96|     m96_9(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r96_1
 #   96|     m96_10(unknown)               = Chi                                       : total:m96_7, partial:m96_9
@@ -1345,32 +1326,30 @@ coroutines.cpp:
 #-----|   Goto -> Block 3
 
 #   95|   Block 2
-#   95|     r95_44(suspend_always *)                      = CopyValue                                 : r95_29
-#   95|     r95_45(glval<suspend_always>)                 = CopyValue                                 : r95_44
-#-----|     r0_15(glval<suspend_always>)                  = Convert                                   : r95_45
-#   95|     r95_46(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
-#   95|     r95_47(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp95:20]               : 
-#   95|     m95_48(coroutine_handle<promise_type>)        = Uninitialized[#temp95:20]                 : &:r95_47
-#   95|     m95_49(unknown)                               = Chi                                       : total:m95_36, partial:m95_48
-#   95|     r95_50(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
-#   95|     r95_51(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
-#   95|     r95_52(glval<coroutine_handle<promise_type>>) = Convert                                   : r95_51
-#   95|     r95_53(coroutine_handle<promise_type> &)      = CopyValue                                 : r95_52
-#   95|     v95_54(void)                                  = Call[coroutine_handle]                    : func:r95_50, this:r95_47, 0:r95_53
-#   95|     m95_55(unknown)                               = ^CallSideEffect                           : ~m95_49
-#   95|     m95_56(unknown)                               = Chi                                       : total:m95_49, partial:m95_55
-#   95|     v95_57(void)                                  = ^BufferReadSideEffect[0]                  : &:r95_53, ~m95_56
-#   95|     m95_58(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r95_47
-#   95|     m95_59(unknown)                               = Chi                                       : total:m95_56, partial:m95_58
-#   95|     r95_60(coroutine_handle<promise_type>)        = Load[#temp95:20]                          : &:r95_47, ~m95_59
-#   95|     v95_61(void)                                  = Call[await_suspend]                       : func:r95_46, this:r0_15, 0:r95_60
-#   95|     m95_62(unknown)                               = ^CallSideEffect                           : ~m95_59
-#   95|     m95_63(unknown)                               = Chi                                       : total:m95_59, partial:m95_62
-#-----|     v0_16(void)                                   = ^IndirectReadSideEffect[-1]               : &:r0_15, ~m95_63
+#   95|     r95_43(suspend_always *)                      = CopyValue                                 : r95_29
+#   95|     r95_44(glval<suspend_always>)                 = CopyValue                                 : r95_43
+#   95|     r95_45(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
+#   95|     r95_46(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp95:20]               : 
+#   95|     m95_47(coroutine_handle<promise_type>)        = Uninitialized[#temp95:20]                 : &:r95_46
+#   95|     m95_48(unknown)                               = Chi                                       : total:m95_35, partial:m95_47
+#   95|     r95_49(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
+#   95|     r95_50(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
+#   95|     r95_51(coroutine_handle<promise_type> &)      = CopyValue                                 : r95_50
+#   95|     v95_52(void)                                  = Call[coroutine_handle]                    : func:r95_49, this:r95_46, 0:r95_51
+#   95|     m95_53(unknown)                               = ^CallSideEffect                           : ~m95_48
+#   95|     m95_54(unknown)                               = Chi                                       : total:m95_48, partial:m95_53
+#   95|     v95_55(void)                                  = ^BufferReadSideEffect[0]                  : &:r95_51, ~m95_54
+#   95|     m95_56(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r95_46
+#   95|     m95_57(unknown)                               = Chi                                       : total:m95_54, partial:m95_56
+#   95|     r95_58(coroutine_handle<promise_type>)        = Load[#temp95:20]                          : &:r95_46, ~m95_57
+#   95|     v95_59(void)                                  = Call[await_suspend]                       : func:r95_45, this:r95_44, 0:r95_58
+#   95|     m95_60(unknown)                               = ^CallSideEffect                           : ~m95_57
+#   95|     m95_61(unknown)                               = Chi                                       : total:m95_57, partial:m95_60
+#-----|     v0_14(void)                                   = ^IndirectReadSideEffect[-1]               : &:r95_44, ~m95_61
 #-----|   Goto -> Block 1
 
 #-----|   Block 3
-#-----|     r0_17(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
+#-----|     r0_15(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
 #   96|     r96_11(glval<suspend_always>)  = VariableAddress[#temp96:13]               : 
 #   96|     r96_12(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
 #   96|     r96_13(glval<unknown>)         = FunctionAddress[yield_value]              : 
@@ -1389,170 +1368,162 @@ coroutines.cpp:
 #   96|     m96_22(suspend_always)        = Store[#temp96:13]            : &:r96_11, r96_16
 #   96|     m96_23(unknown)               = Chi                          : total:m96_21, partial:m96_22
 #   96|     r96_24(suspend_always *)      = CopyValue                    : r96_11
-#   96|     m96_25(suspend_always *)      = Store[#temp0:0]              : &:r0_17, r96_24
-#-----|     r0_18(suspend_always *)       = Load[#temp0:0]               : &:r0_17, m96_25
-#   96|     r96_26(glval<suspend_always>) = CopyValue                    : r0_18
-#   96|     r96_27(glval<suspend_always>) = Convert                      : r96_26
-#   96|     r96_28(glval<unknown>)        = FunctionAddress[await_ready] : 
-#   96|     r96_29(bool)                  = Call[await_ready]            : func:r96_28, this:r96_27
-#   96|     m96_30(unknown)               = ^CallSideEffect              : ~m96_23
-#   96|     m96_31(unknown)               = Chi                          : total:m96_23, partial:m96_30
-#   96|     v96_32(void)                  = ^IndirectReadSideEffect[-1]  : &:r96_27, ~m96_31
-#   96|     v96_33(void)                  = ConditionalBranch            : r96_29
+#   96|     m96_25(suspend_always *)      = Store[#temp0:0]              : &:r0_15, r96_24
+#-----|     r0_16(suspend_always *)       = Load[#temp0:0]               : &:r0_15, m96_25
+#   96|     r96_26(glval<suspend_always>) = CopyValue                    : r0_16
+#   96|     r96_27(glval<unknown>)        = FunctionAddress[await_ready] : 
+#   96|     r96_28(bool)                  = Call[await_ready]            : func:r96_27, this:r96_26
+#   96|     m96_29(unknown)               = ^CallSideEffect              : ~m96_23
+#   96|     m96_30(unknown)               = Chi                          : total:m96_23, partial:m96_29
+#   96|     v96_31(void)                  = ^IndirectReadSideEffect[-1]  : &:r96_26, ~m96_30
+#   96|     v96_32(void)                  = ConditionalBranch            : r96_28
 #-----|   False -> Block 6
 #-----|   True -> Block 5
 
 #   96|   Block 5
-#   96|     m96_34(unknown)               = Phi                                       : from 4:~m96_31, from 6:~m96_60
-#   96|     r96_35(suspend_always *)      = CopyValue                                 : r96_24
-#   96|     r96_36(glval<suspend_always>) = CopyValue                                 : r96_35
-#-----|     r0_19(glval<suspend_always>)  = Convert                                   : r96_36
-#   96|     r96_37(glval<unknown>)        = FunctionAddress[await_resume]             : 
-#   96|     v96_38(void)                  = Call[await_resume]                        : func:r96_37, this:r0_19
-#   96|     m96_39(unknown)               = ^CallSideEffect                           : ~m96_34
-#   96|     m96_40(unknown)               = Chi                                       : total:m96_34, partial:m96_39
-#-----|     v0_20(void)                   = ^IndirectReadSideEffect[-1]               : &:r0_19, ~m96_40
-#-----|     r0_21(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
-#-----|     r0_22(glval<unknown>)         = FunctionAddress[return_void]              : 
-#-----|     v0_23(void)                   = Call[return_void]                         : func:r0_22, this:r0_21
-#-----|     m0_24(unknown)                = ^CallSideEffect                           : ~m96_40
-#-----|     m0_25(unknown)                = Chi                                       : total:m96_40, partial:m0_24
-#-----|     v0_26(void)                   = ^IndirectReadSideEffect[-1]               : &:r0_21, ~m0_25
-#-----|     m0_27(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r0_21
-#-----|     m0_28(unknown)                = Chi                                       : total:m0_25, partial:m0_27
+#   96|     m96_33(unknown)               = Phi                                       : from 4:~m96_30, from 6:~m96_58
+#   96|     r96_34(suspend_always *)      = CopyValue                                 : r96_24
+#   96|     r96_35(glval<suspend_always>) = CopyValue                                 : r96_34
+#   96|     r96_36(glval<unknown>)        = FunctionAddress[await_resume]             : 
+#   96|     v96_37(void)                  = Call[await_resume]                        : func:r96_36, this:r96_35
+#   96|     m96_38(unknown)               = ^CallSideEffect                           : ~m96_33
+#   96|     m96_39(unknown)               = Chi                                       : total:m96_33, partial:m96_38
+#-----|     v0_17(void)                   = ^IndirectReadSideEffect[-1]               : &:r96_35, ~m96_39
+#-----|     r0_18(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
+#-----|     r0_19(glval<unknown>)         = FunctionAddress[return_void]              : 
+#-----|     v0_20(void)                   = Call[return_void]                         : func:r0_19, this:r0_18
+#-----|     m0_21(unknown)                = ^CallSideEffect                           : ~m96_39
+#-----|     m0_22(unknown)                = Chi                                       : total:m96_39, partial:m0_21
+#-----|     v0_23(void)                   = ^IndirectReadSideEffect[-1]               : &:r0_18, ~m0_22
+#-----|     m0_24(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r0_18
+#-----|     m0_25(unknown)                = Chi                                       : total:m0_22, partial:m0_24
 #-----|   C++ Exception -> Block 8
 #-----|   Goto -> Block 7
 
 #   96|   Block 6
-#   96|     r96_41(suspend_always *)                      = CopyValue                                 : r96_24
-#   96|     r96_42(glval<suspend_always>)                 = CopyValue                                 : r96_41
-#-----|     r0_29(glval<suspend_always>)                  = Convert                                   : r96_42
-#   96|     r96_43(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
-#   96|     r96_44(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp96:3]                : 
-#   96|     m96_45(coroutine_handle<promise_type>)        = Uninitialized[#temp96:3]                  : &:r96_44
-#   96|     m96_46(unknown)                               = Chi                                       : total:m96_31, partial:m96_45
-#   96|     r96_47(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
-#   96|     r96_48(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
-#   96|     r96_49(glval<coroutine_handle<promise_type>>) = Convert                                   : r96_48
-#   96|     r96_50(coroutine_handle<promise_type> &)      = CopyValue                                 : r96_49
-#   96|     v96_51(void)                                  = Call[coroutine_handle]                    : func:r96_47, this:r96_44, 0:r96_50
-#   96|     m96_52(unknown)                               = ^CallSideEffect                           : ~m96_46
-#   96|     m96_53(unknown)                               = Chi                                       : total:m96_46, partial:m96_52
-#   96|     v96_54(void)                                  = ^BufferReadSideEffect[0]                  : &:r96_50, ~m96_53
-#   96|     m96_55(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r96_44
-#   96|     m96_56(unknown)                               = Chi                                       : total:m96_53, partial:m96_55
-#   96|     r96_57(coroutine_handle<promise_type>)        = Load[#temp96:3]                           : &:r96_44, ~m96_56
-#   96|     v96_58(void)                                  = Call[await_suspend]                       : func:r96_43, this:r0_29, 0:r96_57
-#   96|     m96_59(unknown)                               = ^CallSideEffect                           : ~m96_56
-#   96|     m96_60(unknown)                               = Chi                                       : total:m96_56, partial:m96_59
-#-----|     v0_30(void)                                   = ^IndirectReadSideEffect[-1]               : &:r0_29, ~m96_60
+#   96|     r96_40(suspend_always *)                      = CopyValue                                 : r96_24
+#   96|     r96_41(glval<suspend_always>)                 = CopyValue                                 : r96_40
+#   96|     r96_42(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
+#   96|     r96_43(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp96:3]                : 
+#   96|     m96_44(coroutine_handle<promise_type>)        = Uninitialized[#temp96:3]                  : &:r96_43
+#   96|     m96_45(unknown)                               = Chi                                       : total:m96_30, partial:m96_44
+#   96|     r96_46(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
+#   96|     r96_47(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
+#   96|     r96_48(coroutine_handle<promise_type> &)      = CopyValue                                 : r96_47
+#   96|     v96_49(void)                                  = Call[coroutine_handle]                    : func:r96_46, this:r96_43, 0:r96_48
+#   96|     m96_50(unknown)                               = ^CallSideEffect                           : ~m96_45
+#   96|     m96_51(unknown)                               = Chi                                       : total:m96_45, partial:m96_50
+#   96|     v96_52(void)                                  = ^BufferReadSideEffect[0]                  : &:r96_48, ~m96_51
+#   96|     m96_53(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r96_43
+#   96|     m96_54(unknown)                               = Chi                                       : total:m96_51, partial:m96_53
+#   96|     r96_55(coroutine_handle<promise_type>)        = Load[#temp96:3]                           : &:r96_43, ~m96_54
+#   96|     v96_56(void)                                  = Call[await_suspend]                       : func:r96_42, this:r96_41, 0:r96_55
+#   96|     m96_57(unknown)                               = ^CallSideEffect                           : ~m96_54
+#   96|     m96_58(unknown)                               = Chi                                       : total:m96_54, partial:m96_57
+#-----|     v0_26(void)                                   = ^IndirectReadSideEffect[-1]               : &:r96_41, ~m96_58
 #-----|   Goto -> Block 5
 
 #   97|   Block 7
 #   97|     v97_1(void) = NoOp : 
-#-----|     v0_31(void) = NoOp : 
+#-----|     v0_27(void) = NoOp : 
 #-----|   Goto (back edge) -> Block 10
 
 #-----|   Block 8
-#-----|     m0_32(unknown)     = Phi                                       : from 1:~m96_10, from 3:~m96_21, from 5:~m0_28
-#-----|     v0_33(void)        = CatchAny                                  : 
-#-----|     r0_34(glval<bool>) = VariableAddress[(unnamed local variable)] : 
-#-----|     r0_35(bool)        = Load[(unnamed local variable)]            : &:r0_34, m0_11
-#-----|     r0_36(bool)        = LogicalNot                                : r0_35
-#-----|     v0_37(void)        = ConditionalBranch                         : r0_36
+#-----|     m0_28(unknown)     = Phi                                       : from 1:~m96_10, from 3:~m96_21, from 5:~m0_25
+#-----|     v0_29(void)        = CatchAny                                  : 
+#-----|     r0_30(glval<bool>) = VariableAddress[(unnamed local variable)] : 
+#-----|     r0_31(bool)        = Load[(unnamed local variable)]            : &:r0_30, m0_11
+#-----|     r0_32(bool)        = LogicalNot                                : r0_31
+#-----|     v0_33(void)        = ConditionalBranch                         : r0_32
 #-----|   False -> Block 9
 #-----|   True -> Block 13
 
 #   95|   Block 9
-#   95|     r95_64(glval<promise_type>) = VariableAddress[(unnamed local variable)] : 
-#   95|     r95_65(glval<unknown>)      = FunctionAddress[unhandled_exception]      : 
-#   95|     v95_66(void)                = Call[unhandled_exception]                 : func:r95_65, this:r95_64
-#   95|     m95_67(unknown)             = ^CallSideEffect                           : ~m0_32
-#   95|     m95_68(unknown)             = Chi                                       : total:m0_32, partial:m95_67
-#   95|     v95_69(void)                = ^IndirectReadSideEffect[-1]               : &:r95_64, ~m95_68
-#   95|     m95_70(promise_type)        = ^IndirectMayWriteSideEffect[-1]           : &:r95_64
-#   95|     m95_71(unknown)             = Chi                                       : total:m95_68, partial:m95_70
+#   95|     r95_62(glval<promise_type>) = VariableAddress[(unnamed local variable)] : 
+#   95|     r95_63(glval<unknown>)      = FunctionAddress[unhandled_exception]      : 
+#   95|     v95_64(void)                = Call[unhandled_exception]                 : func:r95_63, this:r95_62
+#   95|     m95_65(unknown)             = ^CallSideEffect                           : ~m0_28
+#   95|     m95_66(unknown)             = Chi                                       : total:m0_28, partial:m95_65
+#   95|     v95_67(void)                = ^IndirectReadSideEffect[-1]               : &:r95_62, ~m95_66
+#   95|     m95_68(promise_type)        = ^IndirectMayWriteSideEffect[-1]           : &:r95_62
+#   95|     m95_69(unknown)             = Chi                                       : total:m95_66, partial:m95_68
 #-----|   Goto -> Block 10
 
 #-----|   Block 10
-#-----|     m0_38(unknown)                 = Phi                                       : from 7:~m0_28, from 9:~m95_71
-#-----|     v0_39(void)                    = NoOp                                      : 
-#   95|     r95_72(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
-#   95|     r95_73(glval<unknown>)         = FunctionAddress[final_suspend]            : 
-#   95|     r95_74(suspend_always)         = Call[final_suspend]                       : func:r95_73, this:r95_72
-#   95|     m95_75(unknown)                = ^CallSideEffect                           : ~m0_38
-#   95|     m95_76(unknown)                = Chi                                       : total:m0_38, partial:m95_75
-#   95|     v95_77(void)                   = ^IndirectReadSideEffect[-1]               : &:r95_72, ~m95_76
-#   95|     m95_78(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r95_72
-#   95|     m95_79(unknown)                = Chi                                       : total:m95_76, partial:m95_78
-#-----|     r0_40(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
-#   95|     r95_80(glval<suspend_always>)  = VariableAddress[#temp95:20]               : 
-#   95|     r95_81(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
-#   95|     r95_82(glval<unknown>)         = FunctionAddress[final_suspend]            : 
-#   95|     r95_83(suspend_always)         = Call[final_suspend]                       : func:r95_82, this:r95_81
-#   95|     m95_84(unknown)                = ^CallSideEffect                           : ~m95_79
-#   95|     m95_85(unknown)                = Chi                                       : total:m95_79, partial:m95_84
-#   95|     v95_86(void)                   = ^IndirectReadSideEffect[-1]               : &:r95_81, ~m95_85
-#   95|     m95_87(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r95_81
-#   95|     m95_88(unknown)                = Chi                                       : total:m95_85, partial:m95_87
-#   95|     m95_89(suspend_always)         = Store[#temp95:20]                         : &:r95_80, r95_83
-#   95|     m95_90(unknown)                = Chi                                       : total:m95_88, partial:m95_89
-#   95|     r95_91(suspend_always *)       = CopyValue                                 : r95_80
-#   95|     m95_92(suspend_always *)       = Store[#temp0:0]                           : &:r0_40, r95_91
-#-----|     r0_41(suspend_always *)        = Load[#temp0:0]                            : &:r0_40, m95_92
-#   95|     r95_93(glval<suspend_always>)  = CopyValue                                 : r0_41
-#   95|     r95_94(glval<suspend_always>)  = Convert                                   : r95_93
-#   95|     r95_95(glval<unknown>)         = FunctionAddress[await_ready]              : 
-#   95|     r95_96(bool)                   = Call[await_ready]                         : func:r95_95, this:r95_94
-#   95|     m95_97(unknown)                = ^CallSideEffect                           : ~m95_90
-#   95|     m95_98(unknown)                = Chi                                       : total:m95_90, partial:m95_97
-#   95|     v95_99(void)                   = ^IndirectReadSideEffect[-1]               : &:r95_94, ~m95_98
-#-----|     v0_42(void)                    = ConditionalBranch                         : r95_96
+#-----|     m0_34(unknown)                 = Phi                                       : from 7:~m0_25, from 9:~m95_69
+#-----|     v0_35(void)                    = NoOp                                      : 
+#   95|     r95_70(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
+#   95|     r95_71(glval<unknown>)         = FunctionAddress[final_suspend]            : 
+#   95|     r95_72(suspend_always)         = Call[final_suspend]                       : func:r95_71, this:r95_70
+#   95|     m95_73(unknown)                = ^CallSideEffect                           : ~m0_34
+#   95|     m95_74(unknown)                = Chi                                       : total:m0_34, partial:m95_73
+#   95|     v95_75(void)                   = ^IndirectReadSideEffect[-1]               : &:r95_70, ~m95_74
+#   95|     m95_76(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r95_70
+#   95|     m95_77(unknown)                = Chi                                       : total:m95_74, partial:m95_76
+#-----|     r0_36(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
+#   95|     r95_78(glval<suspend_always>)  = VariableAddress[#temp95:20]               : 
+#   95|     r95_79(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
+#   95|     r95_80(glval<unknown>)         = FunctionAddress[final_suspend]            : 
+#   95|     r95_81(suspend_always)         = Call[final_suspend]                       : func:r95_80, this:r95_79
+#   95|     m95_82(unknown)                = ^CallSideEffect                           : ~m95_77
+#   95|     m95_83(unknown)                = Chi                                       : total:m95_77, partial:m95_82
+#   95|     v95_84(void)                   = ^IndirectReadSideEffect[-1]               : &:r95_79, ~m95_83
+#   95|     m95_85(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r95_79
+#   95|     m95_86(unknown)                = Chi                                       : total:m95_83, partial:m95_85
+#   95|     m95_87(suspend_always)         = Store[#temp95:20]                         : &:r95_78, r95_81
+#   95|     m95_88(unknown)                = Chi                                       : total:m95_86, partial:m95_87
+#   95|     r95_89(suspend_always *)       = CopyValue                                 : r95_78
+#   95|     m95_90(suspend_always *)       = Store[#temp0:0]                           : &:r0_36, r95_89
+#-----|     r0_37(suspend_always *)        = Load[#temp0:0]                            : &:r0_36, m95_90
+#   95|     r95_91(glval<suspend_always>)  = CopyValue                                 : r0_37
+#   95|     r95_92(glval<unknown>)         = FunctionAddress[await_ready]              : 
+#   95|     r95_93(bool)                   = Call[await_ready]                         : func:r95_92, this:r95_91
+#   95|     m95_94(unknown)                = ^CallSideEffect                           : ~m95_88
+#   95|     m95_95(unknown)                = Chi                                       : total:m95_88, partial:m95_94
+#   95|     v95_96(void)                   = ^IndirectReadSideEffect[-1]               : &:r95_91, ~m95_95
+#-----|     v0_38(void)                    = ConditionalBranch                         : r95_93
 #-----|   False -> Block 12
 #-----|   True -> Block 11
 
 #   95|   Block 11
-#   95|     m95_100(unknown)                   = Phi                           : from 10:~m95_98, from 12:~m95_130
-#   95|     r95_101(suspend_always *)          = CopyValue                     : r95_91
-#   95|     r95_102(glval<suspend_always>)     = CopyValue                     : r95_101
-#-----|     r0_43(glval<suspend_always>)       = Convert                       : r95_102
-#   95|     r95_103(glval<unknown>)            = FunctionAddress[await_resume] : 
-#   95|     v95_104(void)                      = Call[await_resume]            : func:r95_103, this:r0_43
-#   95|     m95_105(unknown)                   = ^CallSideEffect               : ~m95_100
-#   95|     m95_106(unknown)                   = Chi                           : total:m95_100, partial:m95_105
-#-----|     v0_44(void)                        = ^IndirectReadSideEffect[-1]   : &:r0_43, ~m95_106
-#   95|     r95_107(glval<co_returnable_void>) = VariableAddress[#return]      : 
-#   95|     v95_108(void)                      = ReturnValue                   : &:r95_107, ~m95_106
-#   95|     v95_109(void)                      = AliasedUse                    : ~m95_106
-#   95|     v95_110(void)                      = ExitFunction                  : 
+#   95|     m95_97(unknown)                    = Phi                           : from 10:~m95_95, from 12:~m95_126
+#   95|     r95_98(suspend_always *)           = CopyValue                     : r95_89
+#   95|     r95_99(glval<suspend_always>)      = CopyValue                     : r95_98
+#   95|     r95_100(glval<unknown>)            = FunctionAddress[await_resume] : 
+#   95|     v95_101(void)                      = Call[await_resume]            : func:r95_100, this:r95_99
+#   95|     m95_102(unknown)                   = ^CallSideEffect               : ~m95_97
+#   95|     m95_103(unknown)                   = Chi                           : total:m95_97, partial:m95_102
+#-----|     v0_39(void)                        = ^IndirectReadSideEffect[-1]   : &:r95_99, ~m95_103
+#   95|     r95_104(glval<co_returnable_void>) = VariableAddress[#return]      : 
+#   95|     v95_105(void)                      = ReturnValue                   : &:r95_104, ~m95_103
+#   95|     v95_106(void)                      = AliasedUse                    : ~m95_103
+#   95|     v95_107(void)                      = ExitFunction                  : 
 
 #   95|   Block 12
-#   95|     r95_111(suspend_always *)                      = CopyValue                                 : r95_91
-#   95|     r95_112(glval<suspend_always>)                 = CopyValue                                 : r95_111
-#-----|     r0_45(glval<suspend_always>)                   = Convert                                   : r95_112
-#   95|     r95_113(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
-#   95|     r95_114(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp95:20]               : 
-#   95|     m95_115(coroutine_handle<promise_type>)        = Uninitialized[#temp95:20]                 : &:r95_114
-#   95|     m95_116(unknown)                               = Chi                                       : total:m95_98, partial:m95_115
-#   95|     r95_117(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
-#   95|     r95_118(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
-#   95|     r95_119(glval<coroutine_handle<promise_type>>) = Convert                                   : r95_118
-#   95|     r95_120(coroutine_handle<promise_type> &)      = CopyValue                                 : r95_119
-#   95|     v95_121(void)                                  = Call[coroutine_handle]                    : func:r95_117, this:r95_114, 0:r95_120
-#   95|     m95_122(unknown)                               = ^CallSideEffect                           : ~m95_116
-#   95|     m95_123(unknown)                               = Chi                                       : total:m95_116, partial:m95_122
-#   95|     v95_124(void)                                  = ^BufferReadSideEffect[0]                  : &:r95_120, ~m95_123
-#   95|     m95_125(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r95_114
-#   95|     m95_126(unknown)                               = Chi                                       : total:m95_123, partial:m95_125
-#   95|     r95_127(coroutine_handle<promise_type>)        = Load[#temp95:20]                          : &:r95_114, ~m95_126
-#   95|     v95_128(void)                                  = Call[await_suspend]                       : func:r95_113, this:r0_45, 0:r95_127
-#   95|     m95_129(unknown)                               = ^CallSideEffect                           : ~m95_126
-#   95|     m95_130(unknown)                               = Chi                                       : total:m95_126, partial:m95_129
-#-----|     v0_46(void)                                    = ^IndirectReadSideEffect[-1]               : &:r0_45, ~m95_130
+#   95|     r95_108(suspend_always *)                      = CopyValue                                 : r95_89
+#   95|     r95_109(glval<suspend_always>)                 = CopyValue                                 : r95_108
+#   95|     r95_110(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
+#   95|     r95_111(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp95:20]               : 
+#   95|     m95_112(coroutine_handle<promise_type>)        = Uninitialized[#temp95:20]                 : &:r95_111
+#   95|     m95_113(unknown)                               = Chi                                       : total:m95_95, partial:m95_112
+#   95|     r95_114(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
+#   95|     r95_115(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
+#   95|     r95_116(coroutine_handle<promise_type> &)      = CopyValue                                 : r95_115
+#   95|     v95_117(void)                                  = Call[coroutine_handle]                    : func:r95_114, this:r95_111, 0:r95_116
+#   95|     m95_118(unknown)                               = ^CallSideEffect                           : ~m95_113
+#   95|     m95_119(unknown)                               = Chi                                       : total:m95_113, partial:m95_118
+#   95|     v95_120(void)                                  = ^BufferReadSideEffect[0]                  : &:r95_116, ~m95_119
+#   95|     m95_121(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r95_111
+#   95|     m95_122(unknown)                               = Chi                                       : total:m95_119, partial:m95_121
+#   95|     r95_123(coroutine_handle<promise_type>)        = Load[#temp95:20]                          : &:r95_111, ~m95_122
+#   95|     v95_124(void)                                  = Call[await_suspend]                       : func:r95_110, this:r95_109, 0:r95_123
+#   95|     m95_125(unknown)                               = ^CallSideEffect                           : ~m95_122
+#   95|     m95_126(unknown)                               = Chi                                       : total:m95_122, partial:m95_125
+#-----|     v0_40(void)                                    = ^IndirectReadSideEffect[-1]               : &:r95_109, ~m95_126
 #-----|   Goto -> Block 11
 
 #   95|   Block 13
-#   95|     v95_131(void) = Unreached : 
+#   95|     v95_127(void) = Unreached : 
 
 #   99| co_returnable_value co_yield_value_value(int)
 #   99|   Block 0
@@ -1593,37 +1564,35 @@ coroutines.cpp:
 #   99|     m99_30(suspend_always *)      = Store[#temp0:0]                           : &:r0_5, r99_29
 #-----|     r0_6(suspend_always *)        = Load[#temp0:0]                            : &:r0_5, m99_30
 #   99|     r99_31(glval<suspend_always>) = CopyValue                                 : r0_6
-#   99|     r99_32(glval<suspend_always>) = Convert                                   : r99_31
-#   99|     r99_33(glval<unknown>)        = FunctionAddress[await_ready]              : 
-#   99|     r99_34(bool)                  = Call[await_ready]                         : func:r99_33, this:r99_32
-#   99|     m99_35(unknown)               = ^CallSideEffect                           : ~m99_28
-#   99|     m99_36(unknown)               = Chi                                       : total:m99_28, partial:m99_35
-#   99|     v99_37(void)                  = ^IndirectReadSideEffect[-1]               : &:r99_32, ~m99_36
-#-----|     v0_7(void)                    = ConditionalBranch                         : r99_34
+#   99|     r99_32(glval<unknown>)        = FunctionAddress[await_ready]              : 
+#   99|     r99_33(bool)                  = Call[await_ready]                         : func:r99_32, this:r99_31
+#   99|     m99_34(unknown)               = ^CallSideEffect                           : ~m99_28
+#   99|     m99_35(unknown)               = Chi                                       : total:m99_28, partial:m99_34
+#   99|     v99_36(void)                  = ^IndirectReadSideEffect[-1]               : &:r99_31, ~m99_35
+#-----|     v0_7(void)                    = ConditionalBranch                         : r99_33
 #-----|   False -> Block 2
 #-----|   True -> Block 1
 
 #-----|   Block 1
-#-----|     m0_8(unknown)                 = Phi                                       : from 0:~m99_36, from 2:~m99_63
+#-----|     m0_8(unknown)                 = Phi                                       : from 0:~m99_35, from 2:~m99_61
 #-----|     r0_9(bool)                    = Constant[1]                               : 
 #-----|     r0_10(glval<bool>)            = VariableAddress[(unnamed local variable)] : 
 #-----|     m0_11(bool)                   = Store[(unnamed local variable)]           : &:r0_10, r0_9
-#   99|     r99_38(suspend_always *)      = CopyValue                                 : r99_29
-#   99|     r99_39(glval<suspend_always>) = CopyValue                                 : r99_38
-#-----|     r0_12(glval<suspend_always>)  = Convert                                   : r99_39
-#   99|     r99_40(glval<unknown>)        = FunctionAddress[await_resume]             : 
-#   99|     v99_41(void)                  = Call[await_resume]                        : func:r99_40, this:r0_12
-#   99|     m99_42(unknown)               = ^CallSideEffect                           : ~m0_8
-#   99|     m99_43(unknown)               = Chi                                       : total:m0_8, partial:m99_42
-#-----|     v0_13(void)                   = ^IndirectReadSideEffect[-1]               : &:r0_12, ~m99_43
-#-----|     v0_14(void)                   = CopyValue                                 : v99_41
+#   99|     r99_37(suspend_always *)      = CopyValue                                 : r99_29
+#   99|     r99_38(glval<suspend_always>) = CopyValue                                 : r99_37
+#   99|     r99_39(glval<unknown>)        = FunctionAddress[await_resume]             : 
+#   99|     v99_40(void)                  = Call[await_resume]                        : func:r99_39, this:r99_38
+#   99|     m99_41(unknown)               = ^CallSideEffect                           : ~m0_8
+#   99|     m99_42(unknown)               = Chi                                       : total:m0_8, partial:m99_41
+#-----|     v0_12(void)                   = ^IndirectReadSideEffect[-1]               : &:r99_38, ~m99_42
+#-----|     v0_13(void)                   = CopyValue                                 : v99_40
 #  100|     r100_1(glval<promise_type>)   = VariableAddress[(unnamed local variable)] : 
 #  100|     r100_2(glval<unknown>)        = FunctionAddress[yield_value]              : 
 #  100|     r100_3(glval<int>)            = VariableAddress[i]                        : 
 #  100|     r100_4(int)                   = Load[i]                                   : &:r100_3, m0_4
 #  100|     r100_5(suspend_always)        = Call[yield_value]                         : func:r100_2, this:r100_1, 0:r100_4
-#  100|     m100_6(unknown)               = ^CallSideEffect                           : ~m99_43
-#  100|     m100_7(unknown)               = Chi                                       : total:m99_43, partial:m100_6
+#  100|     m100_6(unknown)               = ^CallSideEffect                           : ~m99_42
+#  100|     m100_7(unknown)               = Chi                                       : total:m99_42, partial:m100_6
 #  100|     v100_8(void)                  = ^IndirectReadSideEffect[-1]               : &:r100_1, ~m100_7
 #  100|     m100_9(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r100_1
 #  100|     m100_10(unknown)              = Chi                                       : total:m100_7, partial:m100_9
@@ -1631,32 +1600,30 @@ coroutines.cpp:
 #-----|   Goto -> Block 3
 
 #   99|   Block 2
-#   99|     r99_44(suspend_always *)                      = CopyValue                                 : r99_29
-#   99|     r99_45(glval<suspend_always>)                 = CopyValue                                 : r99_44
-#-----|     r0_15(glval<suspend_always>)                  = Convert                                   : r99_45
-#   99|     r99_46(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
-#   99|     r99_47(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp99:21]               : 
-#   99|     m99_48(coroutine_handle<promise_type>)        = Uninitialized[#temp99:21]                 : &:r99_47
-#   99|     m99_49(unknown)                               = Chi                                       : total:m99_36, partial:m99_48
-#   99|     r99_50(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
-#   99|     r99_51(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
-#   99|     r99_52(glval<coroutine_handle<promise_type>>) = Convert                                   : r99_51
-#   99|     r99_53(coroutine_handle<promise_type> &)      = CopyValue                                 : r99_52
-#   99|     v99_54(void)                                  = Call[coroutine_handle]                    : func:r99_50, this:r99_47, 0:r99_53
-#   99|     m99_55(unknown)                               = ^CallSideEffect                           : ~m99_49
-#   99|     m99_56(unknown)                               = Chi                                       : total:m99_49, partial:m99_55
-#   99|     v99_57(void)                                  = ^BufferReadSideEffect[0]                  : &:r99_53, ~m99_56
-#   99|     m99_58(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r99_47
-#   99|     m99_59(unknown)                               = Chi                                       : total:m99_56, partial:m99_58
-#   99|     r99_60(coroutine_handle<promise_type>)        = Load[#temp99:21]                          : &:r99_47, ~m99_59
-#   99|     v99_61(void)                                  = Call[await_suspend]                       : func:r99_46, this:r0_15, 0:r99_60
-#   99|     m99_62(unknown)                               = ^CallSideEffect                           : ~m99_59
-#   99|     m99_63(unknown)                               = Chi                                       : total:m99_59, partial:m99_62
-#-----|     v0_16(void)                                   = ^IndirectReadSideEffect[-1]               : &:r0_15, ~m99_63
+#   99|     r99_43(suspend_always *)                      = CopyValue                                 : r99_29
+#   99|     r99_44(glval<suspend_always>)                 = CopyValue                                 : r99_43
+#   99|     r99_45(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
+#   99|     r99_46(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp99:21]               : 
+#   99|     m99_47(coroutine_handle<promise_type>)        = Uninitialized[#temp99:21]                 : &:r99_46
+#   99|     m99_48(unknown)                               = Chi                                       : total:m99_35, partial:m99_47
+#   99|     r99_49(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
+#   99|     r99_50(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
+#   99|     r99_51(coroutine_handle<promise_type> &)      = CopyValue                                 : r99_50
+#   99|     v99_52(void)                                  = Call[coroutine_handle]                    : func:r99_49, this:r99_46, 0:r99_51
+#   99|     m99_53(unknown)                               = ^CallSideEffect                           : ~m99_48
+#   99|     m99_54(unknown)                               = Chi                                       : total:m99_48, partial:m99_53
+#   99|     v99_55(void)                                  = ^BufferReadSideEffect[0]                  : &:r99_51, ~m99_54
+#   99|     m99_56(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r99_46
+#   99|     m99_57(unknown)                               = Chi                                       : total:m99_54, partial:m99_56
+#   99|     r99_58(coroutine_handle<promise_type>)        = Load[#temp99:21]                          : &:r99_46, ~m99_57
+#   99|     v99_59(void)                                  = Call[await_suspend]                       : func:r99_45, this:r99_44, 0:r99_58
+#   99|     m99_60(unknown)                               = ^CallSideEffect                           : ~m99_57
+#   99|     m99_61(unknown)                               = Chi                                       : total:m99_57, partial:m99_60
+#-----|     v0_14(void)                                   = ^IndirectReadSideEffect[-1]               : &:r99_44, ~m99_61
 #-----|   Goto -> Block 1
 
 #-----|   Block 3
-#-----|     r0_17(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
+#-----|     r0_15(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
 #  100|     r100_11(glval<suspend_always>) = VariableAddress[#temp100:13]              : 
 #  100|     r100_12(glval<promise_type>)   = VariableAddress[(unnamed local variable)] : 
 #  100|     r100_13(glval<unknown>)        = FunctionAddress[yield_value]              : 
@@ -1675,156 +1642,148 @@ coroutines.cpp:
 #  100|     m100_22(suspend_always)        = Store[#temp100:13]           : &:r100_11, r100_16
 #  100|     m100_23(unknown)               = Chi                          : total:m100_21, partial:m100_22
 #  100|     r100_24(suspend_always *)      = CopyValue                    : r100_11
-#  100|     m100_25(suspend_always *)      = Store[#temp0:0]              : &:r0_17, r100_24
-#-----|     r0_18(suspend_always *)        = Load[#temp0:0]               : &:r0_17, m100_25
-#  100|     r100_26(glval<suspend_always>) = CopyValue                    : r0_18
-#  100|     r100_27(glval<suspend_always>) = Convert                      : r100_26
-#  100|     r100_28(glval<unknown>)        = FunctionAddress[await_ready] : 
-#  100|     r100_29(bool)                  = Call[await_ready]            : func:r100_28, this:r100_27
-#  100|     m100_30(unknown)               = ^CallSideEffect              : ~m100_23
-#  100|     m100_31(unknown)               = Chi                          : total:m100_23, partial:m100_30
-#  100|     v100_32(void)                  = ^IndirectReadSideEffect[-1]  : &:r100_27, ~m100_31
-#  100|     v100_33(void)                  = ConditionalBranch            : r100_29
+#  100|     m100_25(suspend_always *)      = Store[#temp0:0]              : &:r0_15, r100_24
+#-----|     r0_16(suspend_always *)        = Load[#temp0:0]               : &:r0_15, m100_25
+#  100|     r100_26(glval<suspend_always>) = CopyValue                    : r0_16
+#  100|     r100_27(glval<unknown>)        = FunctionAddress[await_ready] : 
+#  100|     r100_28(bool)                  = Call[await_ready]            : func:r100_27, this:r100_26
+#  100|     m100_29(unknown)               = ^CallSideEffect              : ~m100_23
+#  100|     m100_30(unknown)               = Chi                          : total:m100_23, partial:m100_29
+#  100|     v100_31(void)                  = ^IndirectReadSideEffect[-1]  : &:r100_26, ~m100_30
+#  100|     v100_32(void)                  = ConditionalBranch            : r100_28
 #-----|   False -> Block 6
 #-----|   True -> Block 5
 
 #  100|   Block 5
-#  100|     m100_34(unknown)               = Phi                           : from 4:~m100_31, from 6:~m100_60
-#  100|     r100_35(suspend_always *)      = CopyValue                     : r100_24
-#  100|     r100_36(glval<suspend_always>) = CopyValue                     : r100_35
-#-----|     r0_19(glval<suspend_always>)   = Convert                       : r100_36
-#  100|     r100_37(glval<unknown>)        = FunctionAddress[await_resume] : 
-#  100|     v100_38(void)                  = Call[await_resume]            : func:r100_37, this:r0_19
-#  100|     m100_39(unknown)               = ^CallSideEffect               : ~m100_34
-#  100|     m100_40(unknown)               = Chi                           : total:m100_34, partial:m100_39
-#-----|     v0_20(void)                    = ^IndirectReadSideEffect[-1]   : &:r0_19, ~m100_40
+#  100|     m100_33(unknown)               = Phi                           : from 4:~m100_30, from 6:~m100_58
+#  100|     r100_34(suspend_always *)      = CopyValue                     : r100_24
+#  100|     r100_35(glval<suspend_always>) = CopyValue                     : r100_34
+#  100|     r100_36(glval<unknown>)        = FunctionAddress[await_resume] : 
+#  100|     v100_37(void)                  = Call[await_resume]            : func:r100_36, this:r100_35
+#  100|     m100_38(unknown)               = ^CallSideEffect               : ~m100_33
+#  100|     m100_39(unknown)               = Chi                           : total:m100_33, partial:m100_38
+#-----|     v0_17(void)                    = ^IndirectReadSideEffect[-1]   : &:r100_35, ~m100_39
 #-----|   Goto -> Block 9
 
 #  100|   Block 6
-#  100|     r100_41(suspend_always *)                      = CopyValue                                 : r100_24
-#  100|     r100_42(glval<suspend_always>)                 = CopyValue                                 : r100_41
-#-----|     r0_21(glval<suspend_always>)                   = Convert                                   : r100_42
-#  100|     r100_43(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
-#  100|     r100_44(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp100:3]               : 
-#  100|     m100_45(coroutine_handle<promise_type>)        = Uninitialized[#temp100:3]                 : &:r100_44
-#  100|     m100_46(unknown)                               = Chi                                       : total:m100_31, partial:m100_45
-#  100|     r100_47(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
-#  100|     r100_48(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
-#  100|     r100_49(glval<coroutine_handle<promise_type>>) = Convert                                   : r100_48
-#  100|     r100_50(coroutine_handle<promise_type> &)      = CopyValue                                 : r100_49
-#  100|     v100_51(void)                                  = Call[coroutine_handle]                    : func:r100_47, this:r100_44, 0:r100_50
-#  100|     m100_52(unknown)                               = ^CallSideEffect                           : ~m100_46
-#  100|     m100_53(unknown)                               = Chi                                       : total:m100_46, partial:m100_52
-#  100|     v100_54(void)                                  = ^BufferReadSideEffect[0]                  : &:r100_50, ~m100_53
-#  100|     m100_55(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r100_44
-#  100|     m100_56(unknown)                               = Chi                                       : total:m100_53, partial:m100_55
-#  100|     r100_57(coroutine_handle<promise_type>)        = Load[#temp100:3]                          : &:r100_44, ~m100_56
-#  100|     v100_58(void)                                  = Call[await_suspend]                       : func:r100_43, this:r0_21, 0:r100_57
-#  100|     m100_59(unknown)                               = ^CallSideEffect                           : ~m100_56
-#  100|     m100_60(unknown)                               = Chi                                       : total:m100_56, partial:m100_59
-#-----|     v0_22(void)                                    = ^IndirectReadSideEffect[-1]               : &:r0_21, ~m100_60
+#  100|     r100_40(suspend_always *)                      = CopyValue                                 : r100_24
+#  100|     r100_41(glval<suspend_always>)                 = CopyValue                                 : r100_40
+#  100|     r100_42(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
+#  100|     r100_43(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp100:3]               : 
+#  100|     m100_44(coroutine_handle<promise_type>)        = Uninitialized[#temp100:3]                 : &:r100_43
+#  100|     m100_45(unknown)                               = Chi                                       : total:m100_30, partial:m100_44
+#  100|     r100_46(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
+#  100|     r100_47(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
+#  100|     r100_48(coroutine_handle<promise_type> &)      = CopyValue                                 : r100_47
+#  100|     v100_49(void)                                  = Call[coroutine_handle]                    : func:r100_46, this:r100_43, 0:r100_48
+#  100|     m100_50(unknown)                               = ^CallSideEffect                           : ~m100_45
+#  100|     m100_51(unknown)                               = Chi                                       : total:m100_45, partial:m100_50
+#  100|     v100_52(void)                                  = ^BufferReadSideEffect[0]                  : &:r100_48, ~m100_51
+#  100|     m100_53(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r100_43
+#  100|     m100_54(unknown)                               = Chi                                       : total:m100_51, partial:m100_53
+#  100|     r100_55(coroutine_handle<promise_type>)        = Load[#temp100:3]                          : &:r100_43, ~m100_54
+#  100|     v100_56(void)                                  = Call[await_suspend]                       : func:r100_42, this:r100_41, 0:r100_55
+#  100|     m100_57(unknown)                               = ^CallSideEffect                           : ~m100_54
+#  100|     m100_58(unknown)                               = Chi                                       : total:m100_54, partial:m100_57
+#-----|     v0_18(void)                                    = ^IndirectReadSideEffect[-1]               : &:r100_41, ~m100_58
 #-----|   Goto -> Block 5
 
 #-----|   Block 7
-#-----|     m0_23(unknown)     = Phi                                       : from 1:~m100_10, from 3:~m100_21
-#-----|     v0_24(void)        = CatchAny                                  : 
-#-----|     r0_25(glval<bool>) = VariableAddress[(unnamed local variable)] : 
-#-----|     r0_26(bool)        = Load[(unnamed local variable)]            : &:r0_25, m0_11
-#-----|     r0_27(bool)        = LogicalNot                                : r0_26
-#-----|     v0_28(void)        = ConditionalBranch                         : r0_27
+#-----|     m0_19(unknown)     = Phi                                       : from 1:~m100_10, from 3:~m100_21
+#-----|     v0_20(void)        = CatchAny                                  : 
+#-----|     r0_21(glval<bool>) = VariableAddress[(unnamed local variable)] : 
+#-----|     r0_22(bool)        = Load[(unnamed local variable)]            : &:r0_21, m0_11
+#-----|     r0_23(bool)        = LogicalNot                                : r0_22
+#-----|     v0_24(void)        = ConditionalBranch                         : r0_23
 #-----|   False -> Block 8
 #-----|   True -> Block 12
 
 #   99|   Block 8
-#   99|     r99_64(glval<promise_type>) = VariableAddress[(unnamed local variable)] : 
-#   99|     r99_65(glval<unknown>)      = FunctionAddress[unhandled_exception]      : 
-#   99|     v99_66(void)                = Call[unhandled_exception]                 : func:r99_65, this:r99_64
-#   99|     m99_67(unknown)             = ^CallSideEffect                           : ~m0_23
-#   99|     m99_68(unknown)             = Chi                                       : total:m0_23, partial:m99_67
-#   99|     v99_69(void)                = ^IndirectReadSideEffect[-1]               : &:r99_64, ~m99_68
-#   99|     m99_70(promise_type)        = ^IndirectMayWriteSideEffect[-1]           : &:r99_64
-#   99|     m99_71(unknown)             = Chi                                       : total:m99_68, partial:m99_70
+#   99|     r99_62(glval<promise_type>) = VariableAddress[(unnamed local variable)] : 
+#   99|     r99_63(glval<unknown>)      = FunctionAddress[unhandled_exception]      : 
+#   99|     v99_64(void)                = Call[unhandled_exception]                 : func:r99_63, this:r99_62
+#   99|     m99_65(unknown)             = ^CallSideEffect                           : ~m0_19
+#   99|     m99_66(unknown)             = Chi                                       : total:m0_19, partial:m99_65
+#   99|     v99_67(void)                = ^IndirectReadSideEffect[-1]               : &:r99_62, ~m99_66
+#   99|     m99_68(promise_type)        = ^IndirectMayWriteSideEffect[-1]           : &:r99_62
+#   99|     m99_69(unknown)             = Chi                                       : total:m99_66, partial:m99_68
 #-----|   Goto -> Block 9
 
 #-----|   Block 9
-#-----|     m0_29(unknown)                 = Phi                                       : from 5:~m100_40, from 8:~m99_71
-#-----|     v0_30(void)                    = NoOp                                      : 
-#   99|     r99_72(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
-#   99|     r99_73(glval<unknown>)         = FunctionAddress[final_suspend]            : 
-#   99|     r99_74(suspend_always)         = Call[final_suspend]                       : func:r99_73, this:r99_72
-#   99|     m99_75(unknown)                = ^CallSideEffect                           : ~m0_29
-#   99|     m99_76(unknown)                = Chi                                       : total:m0_29, partial:m99_75
-#   99|     v99_77(void)                   = ^IndirectReadSideEffect[-1]               : &:r99_72, ~m99_76
-#   99|     m99_78(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r99_72
-#   99|     m99_79(unknown)                = Chi                                       : total:m99_76, partial:m99_78
-#-----|     r0_31(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
-#   99|     r99_80(glval<suspend_always>)  = VariableAddress[#temp99:21]               : 
-#   99|     r99_81(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
-#   99|     r99_82(glval<unknown>)         = FunctionAddress[final_suspend]            : 
-#   99|     r99_83(suspend_always)         = Call[final_suspend]                       : func:r99_82, this:r99_81
-#   99|     m99_84(unknown)                = ^CallSideEffect                           : ~m99_79
-#   99|     m99_85(unknown)                = Chi                                       : total:m99_79, partial:m99_84
-#   99|     v99_86(void)                   = ^IndirectReadSideEffect[-1]               : &:r99_81, ~m99_85
-#   99|     m99_87(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r99_81
-#   99|     m99_88(unknown)                = Chi                                       : total:m99_85, partial:m99_87
-#   99|     m99_89(suspend_always)         = Store[#temp99:21]                         : &:r99_80, r99_83
-#   99|     m99_90(unknown)                = Chi                                       : total:m99_88, partial:m99_89
-#   99|     r99_91(suspend_always *)       = CopyValue                                 : r99_80
-#   99|     m99_92(suspend_always *)       = Store[#temp0:0]                           : &:r0_31, r99_91
-#-----|     r0_32(suspend_always *)        = Load[#temp0:0]                            : &:r0_31, m99_92
-#   99|     r99_93(glval<suspend_always>)  = CopyValue                                 : r0_32
-#   99|     r99_94(glval<suspend_always>)  = Convert                                   : r99_93
-#   99|     r99_95(glval<unknown>)         = FunctionAddress[await_ready]              : 
-#   99|     r99_96(bool)                   = Call[await_ready]                         : func:r99_95, this:r99_94
-#   99|     m99_97(unknown)                = ^CallSideEffect                           : ~m99_90
-#   99|     m99_98(unknown)                = Chi                                       : total:m99_90, partial:m99_97
-#   99|     v99_99(void)                   = ^IndirectReadSideEffect[-1]               : &:r99_94, ~m99_98
-#-----|     v0_33(void)                    = ConditionalBranch                         : r99_96
+#-----|     m0_25(unknown)                 = Phi                                       : from 5:~m100_39, from 8:~m99_69
+#-----|     v0_26(void)                    = NoOp                                      : 
+#   99|     r99_70(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
+#   99|     r99_71(glval<unknown>)         = FunctionAddress[final_suspend]            : 
+#   99|     r99_72(suspend_always)         = Call[final_suspend]                       : func:r99_71, this:r99_70
+#   99|     m99_73(unknown)                = ^CallSideEffect                           : ~m0_25
+#   99|     m99_74(unknown)                = Chi                                       : total:m0_25, partial:m99_73
+#   99|     v99_75(void)                   = ^IndirectReadSideEffect[-1]               : &:r99_70, ~m99_74
+#   99|     m99_76(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r99_70
+#   99|     m99_77(unknown)                = Chi                                       : total:m99_74, partial:m99_76
+#-----|     r0_27(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
+#   99|     r99_78(glval<suspend_always>)  = VariableAddress[#temp99:21]               : 
+#   99|     r99_79(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
+#   99|     r99_80(glval<unknown>)         = FunctionAddress[final_suspend]            : 
+#   99|     r99_81(suspend_always)         = Call[final_suspend]                       : func:r99_80, this:r99_79
+#   99|     m99_82(unknown)                = ^CallSideEffect                           : ~m99_77
+#   99|     m99_83(unknown)                = Chi                                       : total:m99_77, partial:m99_82
+#   99|     v99_84(void)                   = ^IndirectReadSideEffect[-1]               : &:r99_79, ~m99_83
+#   99|     m99_85(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r99_79
+#   99|     m99_86(unknown)                = Chi                                       : total:m99_83, partial:m99_85
+#   99|     m99_87(suspend_always)         = Store[#temp99:21]                         : &:r99_78, r99_81
+#   99|     m99_88(unknown)                = Chi                                       : total:m99_86, partial:m99_87
+#   99|     r99_89(suspend_always *)       = CopyValue                                 : r99_78
+#   99|     m99_90(suspend_always *)       = Store[#temp0:0]                           : &:r0_27, r99_89
+#-----|     r0_28(suspend_always *)        = Load[#temp0:0]                            : &:r0_27, m99_90
+#   99|     r99_91(glval<suspend_always>)  = CopyValue                                 : r0_28
+#   99|     r99_92(glval<unknown>)         = FunctionAddress[await_ready]              : 
+#   99|     r99_93(bool)                   = Call[await_ready]                         : func:r99_92, this:r99_91
+#   99|     m99_94(unknown)                = ^CallSideEffect                           : ~m99_88
+#   99|     m99_95(unknown)                = Chi                                       : total:m99_88, partial:m99_94
+#   99|     v99_96(void)                   = ^IndirectReadSideEffect[-1]               : &:r99_91, ~m99_95
+#-----|     v0_29(void)                    = ConditionalBranch                         : r99_93
 #-----|   False -> Block 11
 #-----|   True -> Block 10
 
 #   99|   Block 10
-#   99|     m99_100(unknown)                    = Phi                           : from 9:~m99_98, from 11:~m99_130
-#   99|     r99_101(suspend_always *)           = CopyValue                     : r99_91
-#   99|     r99_102(glval<suspend_always>)      = CopyValue                     : r99_101
-#-----|     r0_34(glval<suspend_always>)        = Convert                       : r99_102
-#   99|     r99_103(glval<unknown>)             = FunctionAddress[await_resume] : 
-#   99|     v99_104(void)                       = Call[await_resume]            : func:r99_103, this:r0_34
-#   99|     m99_105(unknown)                    = ^CallSideEffect               : ~m99_100
-#   99|     m99_106(unknown)                    = Chi                           : total:m99_100, partial:m99_105
-#-----|     v0_35(void)                         = ^IndirectReadSideEffect[-1]   : &:r0_34, ~m99_106
-#   99|     r99_107(glval<co_returnable_value>) = VariableAddress[#return]      : 
-#   99|     v99_108(void)                       = ReturnValue                   : &:r99_107, ~m99_106
-#   99|     v99_109(void)                       = AliasedUse                    : ~m99_106
-#   99|     v99_110(void)                       = ExitFunction                  : 
+#   99|     m99_97(unknown)                     = Phi                           : from 9:~m99_95, from 11:~m99_126
+#   99|     r99_98(suspend_always *)            = CopyValue                     : r99_89
+#   99|     r99_99(glval<suspend_always>)       = CopyValue                     : r99_98
+#   99|     r99_100(glval<unknown>)             = FunctionAddress[await_resume] : 
+#   99|     v99_101(void)                       = Call[await_resume]            : func:r99_100, this:r99_99
+#   99|     m99_102(unknown)                    = ^CallSideEffect               : ~m99_97
+#   99|     m99_103(unknown)                    = Chi                           : total:m99_97, partial:m99_102
+#-----|     v0_30(void)                         = ^IndirectReadSideEffect[-1]   : &:r99_99, ~m99_103
+#   99|     r99_104(glval<co_returnable_value>) = VariableAddress[#return]      : 
+#   99|     v99_105(void)                       = ReturnValue                   : &:r99_104, ~m99_103
+#   99|     v99_106(void)                       = AliasedUse                    : ~m99_103
+#   99|     v99_107(void)                       = ExitFunction                  : 
 
 #   99|   Block 11
-#   99|     r99_111(suspend_always *)                      = CopyValue                                 : r99_91
-#   99|     r99_112(glval<suspend_always>)                 = CopyValue                                 : r99_111
-#-----|     r0_36(glval<suspend_always>)                   = Convert                                   : r99_112
-#   99|     r99_113(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
-#   99|     r99_114(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp99:21]               : 
-#   99|     m99_115(coroutine_handle<promise_type>)        = Uninitialized[#temp99:21]                 : &:r99_114
-#   99|     m99_116(unknown)                               = Chi                                       : total:m99_98, partial:m99_115
-#   99|     r99_117(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
-#   99|     r99_118(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
-#   99|     r99_119(glval<coroutine_handle<promise_type>>) = Convert                                   : r99_118
-#   99|     r99_120(coroutine_handle<promise_type> &)      = CopyValue                                 : r99_119
-#   99|     v99_121(void)                                  = Call[coroutine_handle]                    : func:r99_117, this:r99_114, 0:r99_120
-#   99|     m99_122(unknown)                               = ^CallSideEffect                           : ~m99_116
-#   99|     m99_123(unknown)                               = Chi                                       : total:m99_116, partial:m99_122
-#   99|     v99_124(void)                                  = ^BufferReadSideEffect[0]                  : &:r99_120, ~m99_123
-#   99|     m99_125(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r99_114
-#   99|     m99_126(unknown)                               = Chi                                       : total:m99_123, partial:m99_125
-#   99|     r99_127(coroutine_handle<promise_type>)        = Load[#temp99:21]                          : &:r99_114, ~m99_126
-#   99|     v99_128(void)                                  = Call[await_suspend]                       : func:r99_113, this:r0_36, 0:r99_127
-#   99|     m99_129(unknown)                               = ^CallSideEffect                           : ~m99_126
-#   99|     m99_130(unknown)                               = Chi                                       : total:m99_126, partial:m99_129
-#-----|     v0_37(void)                                    = ^IndirectReadSideEffect[-1]               : &:r0_36, ~m99_130
+#   99|     r99_108(suspend_always *)                      = CopyValue                                 : r99_89
+#   99|     r99_109(glval<suspend_always>)                 = CopyValue                                 : r99_108
+#   99|     r99_110(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
+#   99|     r99_111(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp99:21]               : 
+#   99|     m99_112(coroutine_handle<promise_type>)        = Uninitialized[#temp99:21]                 : &:r99_111
+#   99|     m99_113(unknown)                               = Chi                                       : total:m99_95, partial:m99_112
+#   99|     r99_114(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
+#   99|     r99_115(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
+#   99|     r99_116(coroutine_handle<promise_type> &)      = CopyValue                                 : r99_115
+#   99|     v99_117(void)                                  = Call[coroutine_handle]                    : func:r99_114, this:r99_111, 0:r99_116
+#   99|     m99_118(unknown)                               = ^CallSideEffect                           : ~m99_113
+#   99|     m99_119(unknown)                               = Chi                                       : total:m99_113, partial:m99_118
+#   99|     v99_120(void)                                  = ^BufferReadSideEffect[0]                  : &:r99_116, ~m99_119
+#   99|     m99_121(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r99_111
+#   99|     m99_122(unknown)                               = Chi                                       : total:m99_119, partial:m99_121
+#   99|     r99_123(coroutine_handle<promise_type>)        = Load[#temp99:21]                          : &:r99_111, ~m99_122
+#   99|     v99_124(void)                                  = Call[await_suspend]                       : func:r99_110, this:r99_109, 0:r99_123
+#   99|     m99_125(unknown)                               = ^CallSideEffect                           : ~m99_122
+#   99|     m99_126(unknown)                               = Chi                                       : total:m99_122, partial:m99_125
+#-----|     v0_31(void)                                    = ^IndirectReadSideEffect[-1]               : &:r99_109, ~m99_126
 #-----|   Goto -> Block 10
 
 #   99|   Block 12
-#   99|     v99_131(void) = Unreached : 
+#   99|     v99_127(void) = Unreached : 
 
 #  103| co_returnable_void co_yield_and_return_void(int)
 #  103|   Block 0
@@ -1865,37 +1824,35 @@ coroutines.cpp:
 #  103|     m103_30(suspend_always *)      = Store[#temp0:0]                           : &:r0_5, r103_29
 #-----|     r0_6(suspend_always *)         = Load[#temp0:0]                            : &:r0_5, m103_30
 #  103|     r103_31(glval<suspend_always>) = CopyValue                                 : r0_6
-#  103|     r103_32(glval<suspend_always>) = Convert                                   : r103_31
-#  103|     r103_33(glval<unknown>)        = FunctionAddress[await_ready]              : 
-#  103|     r103_34(bool)                  = Call[await_ready]                         : func:r103_33, this:r103_32
-#  103|     m103_35(unknown)               = ^CallSideEffect                           : ~m103_28
-#  103|     m103_36(unknown)               = Chi                                       : total:m103_28, partial:m103_35
-#  103|     v103_37(void)                  = ^IndirectReadSideEffect[-1]               : &:r103_32, ~m103_36
-#-----|     v0_7(void)                     = ConditionalBranch                         : r103_34
+#  103|     r103_32(glval<unknown>)        = FunctionAddress[await_ready]              : 
+#  103|     r103_33(bool)                  = Call[await_ready]                         : func:r103_32, this:r103_31
+#  103|     m103_34(unknown)               = ^CallSideEffect                           : ~m103_28
+#  103|     m103_35(unknown)               = Chi                                       : total:m103_28, partial:m103_34
+#  103|     v103_36(void)                  = ^IndirectReadSideEffect[-1]               : &:r103_31, ~m103_35
+#-----|     v0_7(void)                     = ConditionalBranch                         : r103_33
 #-----|   False -> Block 2
 #-----|   True -> Block 1
 
 #-----|   Block 1
-#-----|     m0_8(unknown)                  = Phi                                       : from 0:~m103_36, from 2:~m103_63
+#-----|     m0_8(unknown)                  = Phi                                       : from 0:~m103_35, from 2:~m103_61
 #-----|     r0_9(bool)                     = Constant[1]                               : 
 #-----|     r0_10(glval<bool>)             = VariableAddress[(unnamed local variable)] : 
 #-----|     m0_11(bool)                    = Store[(unnamed local variable)]           : &:r0_10, r0_9
-#  103|     r103_38(suspend_always *)      = CopyValue                                 : r103_29
-#  103|     r103_39(glval<suspend_always>) = CopyValue                                 : r103_38
-#-----|     r0_12(glval<suspend_always>)   = Convert                                   : r103_39
-#  103|     r103_40(glval<unknown>)        = FunctionAddress[await_resume]             : 
-#  103|     v103_41(void)                  = Call[await_resume]                        : func:r103_40, this:r0_12
-#  103|     m103_42(unknown)               = ^CallSideEffect                           : ~m0_8
-#  103|     m103_43(unknown)               = Chi                                       : total:m0_8, partial:m103_42
-#-----|     v0_13(void)                    = ^IndirectReadSideEffect[-1]               : &:r0_12, ~m103_43
-#-----|     v0_14(void)                    = CopyValue                                 : v103_41
+#  103|     r103_37(suspend_always *)      = CopyValue                                 : r103_29
+#  103|     r103_38(glval<suspend_always>) = CopyValue                                 : r103_37
+#  103|     r103_39(glval<unknown>)        = FunctionAddress[await_resume]             : 
+#  103|     v103_40(void)                  = Call[await_resume]                        : func:r103_39, this:r103_38
+#  103|     m103_41(unknown)               = ^CallSideEffect                           : ~m0_8
+#  103|     m103_42(unknown)               = Chi                                       : total:m0_8, partial:m103_41
+#-----|     v0_12(void)                    = ^IndirectReadSideEffect[-1]               : &:r103_38, ~m103_42
+#-----|     v0_13(void)                    = CopyValue                                 : v103_40
 #  104|     r104_1(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
 #  104|     r104_2(glval<unknown>)         = FunctionAddress[yield_value]              : 
 #  104|     r104_3(glval<int>)             = VariableAddress[i]                        : 
 #  104|     r104_4(int)                    = Load[i]                                   : &:r104_3, m0_4
 #  104|     r104_5(suspend_always)         = Call[yield_value]                         : func:r104_2, this:r104_1, 0:r104_4
-#  104|     m104_6(unknown)                = ^CallSideEffect                           : ~m103_43
-#  104|     m104_7(unknown)                = Chi                                       : total:m103_43, partial:m104_6
+#  104|     m104_6(unknown)                = ^CallSideEffect                           : ~m103_42
+#  104|     m104_7(unknown)                = Chi                                       : total:m103_42, partial:m104_6
 #  104|     v104_8(void)                   = ^IndirectReadSideEffect[-1]               : &:r104_1, ~m104_7
 #  104|     m104_9(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r104_1
 #  104|     m104_10(unknown)               = Chi                                       : total:m104_7, partial:m104_9
@@ -1903,32 +1860,30 @@ coroutines.cpp:
 #-----|   Goto -> Block 3
 
 #  103|   Block 2
-#  103|     r103_44(suspend_always *)                      = CopyValue                                 : r103_29
-#  103|     r103_45(glval<suspend_always>)                 = CopyValue                                 : r103_44
-#-----|     r0_15(glval<suspend_always>)                   = Convert                                   : r103_45
-#  103|     r103_46(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
-#  103|     r103_47(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp103:20]              : 
-#  103|     m103_48(coroutine_handle<promise_type>)        = Uninitialized[#temp103:20]                : &:r103_47
-#  103|     m103_49(unknown)                               = Chi                                       : total:m103_36, partial:m103_48
-#  103|     r103_50(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
-#  103|     r103_51(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
-#  103|     r103_52(glval<coroutine_handle<promise_type>>) = Convert                                   : r103_51
-#  103|     r103_53(coroutine_handle<promise_type> &)      = CopyValue                                 : r103_52
-#  103|     v103_54(void)                                  = Call[coroutine_handle]                    : func:r103_50, this:r103_47, 0:r103_53
-#  103|     m103_55(unknown)                               = ^CallSideEffect                           : ~m103_49
-#  103|     m103_56(unknown)                               = Chi                                       : total:m103_49, partial:m103_55
-#  103|     v103_57(void)                                  = ^BufferReadSideEffect[0]                  : &:r103_53, ~m103_56
-#  103|     m103_58(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r103_47
-#  103|     m103_59(unknown)                               = Chi                                       : total:m103_56, partial:m103_58
-#  103|     r103_60(coroutine_handle<promise_type>)        = Load[#temp103:20]                         : &:r103_47, ~m103_59
-#  103|     v103_61(void)                                  = Call[await_suspend]                       : func:r103_46, this:r0_15, 0:r103_60
-#  103|     m103_62(unknown)                               = ^CallSideEffect                           : ~m103_59
-#  103|     m103_63(unknown)                               = Chi                                       : total:m103_59, partial:m103_62
-#-----|     v0_16(void)                                    = ^IndirectReadSideEffect[-1]               : &:r0_15, ~m103_63
+#  103|     r103_43(suspend_always *)                      = CopyValue                                 : r103_29
+#  103|     r103_44(glval<suspend_always>)                 = CopyValue                                 : r103_43
+#  103|     r103_45(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
+#  103|     r103_46(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp103:20]              : 
+#  103|     m103_47(coroutine_handle<promise_type>)        = Uninitialized[#temp103:20]                : &:r103_46
+#  103|     m103_48(unknown)                               = Chi                                       : total:m103_35, partial:m103_47
+#  103|     r103_49(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
+#  103|     r103_50(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
+#  103|     r103_51(coroutine_handle<promise_type> &)      = CopyValue                                 : r103_50
+#  103|     v103_52(void)                                  = Call[coroutine_handle]                    : func:r103_49, this:r103_46, 0:r103_51
+#  103|     m103_53(unknown)                               = ^CallSideEffect                           : ~m103_48
+#  103|     m103_54(unknown)                               = Chi                                       : total:m103_48, partial:m103_53
+#  103|     v103_55(void)                                  = ^BufferReadSideEffect[0]                  : &:r103_51, ~m103_54
+#  103|     m103_56(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r103_46
+#  103|     m103_57(unknown)                               = Chi                                       : total:m103_54, partial:m103_56
+#  103|     r103_58(coroutine_handle<promise_type>)        = Load[#temp103:20]                         : &:r103_46, ~m103_57
+#  103|     v103_59(void)                                  = Call[await_suspend]                       : func:r103_45, this:r103_44, 0:r103_58
+#  103|     m103_60(unknown)                               = ^CallSideEffect                           : ~m103_57
+#  103|     m103_61(unknown)                               = Chi                                       : total:m103_57, partial:m103_60
+#-----|     v0_14(void)                                    = ^IndirectReadSideEffect[-1]               : &:r103_44, ~m103_61
 #-----|   Goto -> Block 1
 
 #-----|   Block 3
-#-----|     r0_17(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
+#-----|     r0_15(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
 #  104|     r104_11(glval<suspend_always>) = VariableAddress[#temp104:13]              : 
 #  104|     r104_12(glval<promise_type>)   = VariableAddress[(unnamed local variable)] : 
 #  104|     r104_13(glval<unknown>)        = FunctionAddress[yield_value]              : 
@@ -1947,170 +1902,162 @@ coroutines.cpp:
 #  104|     m104_22(suspend_always)        = Store[#temp104:13]           : &:r104_11, r104_16
 #  104|     m104_23(unknown)               = Chi                          : total:m104_21, partial:m104_22
 #  104|     r104_24(suspend_always *)      = CopyValue                    : r104_11
-#  104|     m104_25(suspend_always *)      = Store[#temp0:0]              : &:r0_17, r104_24
-#-----|     r0_18(suspend_always *)        = Load[#temp0:0]               : &:r0_17, m104_25
-#  104|     r104_26(glval<suspend_always>) = CopyValue                    : r0_18
-#  104|     r104_27(glval<suspend_always>) = Convert                      : r104_26
-#  104|     r104_28(glval<unknown>)        = FunctionAddress[await_ready] : 
-#  104|     r104_29(bool)                  = Call[await_ready]            : func:r104_28, this:r104_27
-#  104|     m104_30(unknown)               = ^CallSideEffect              : ~m104_23
-#  104|     m104_31(unknown)               = Chi                          : total:m104_23, partial:m104_30
-#  104|     v104_32(void)                  = ^IndirectReadSideEffect[-1]  : &:r104_27, ~m104_31
-#  104|     v104_33(void)                  = ConditionalBranch            : r104_29
+#  104|     m104_25(suspend_always *)      = Store[#temp0:0]              : &:r0_15, r104_24
+#-----|     r0_16(suspend_always *)        = Load[#temp0:0]               : &:r0_15, m104_25
+#  104|     r104_26(glval<suspend_always>) = CopyValue                    : r0_16
+#  104|     r104_27(glval<unknown>)        = FunctionAddress[await_ready] : 
+#  104|     r104_28(bool)                  = Call[await_ready]            : func:r104_27, this:r104_26
+#  104|     m104_29(unknown)               = ^CallSideEffect              : ~m104_23
+#  104|     m104_30(unknown)               = Chi                          : total:m104_23, partial:m104_29
+#  104|     v104_31(void)                  = ^IndirectReadSideEffect[-1]  : &:r104_26, ~m104_30
+#  104|     v104_32(void)                  = ConditionalBranch            : r104_28
 #-----|   False -> Block 6
 #-----|   True -> Block 5
 
 #  104|   Block 5
-#  104|     m104_34(unknown)               = Phi                                       : from 4:~m104_31, from 6:~m104_60
-#  104|     r104_35(suspend_always *)      = CopyValue                                 : r104_24
-#  104|     r104_36(glval<suspend_always>) = CopyValue                                 : r104_35
-#-----|     r0_19(glval<suspend_always>)   = Convert                                   : r104_36
-#  104|     r104_37(glval<unknown>)        = FunctionAddress[await_resume]             : 
-#  104|     v104_38(void)                  = Call[await_resume]                        : func:r104_37, this:r0_19
-#  104|     m104_39(unknown)               = ^CallSideEffect                           : ~m104_34
-#  104|     m104_40(unknown)               = Chi                                       : total:m104_34, partial:m104_39
-#-----|     v0_20(void)                    = ^IndirectReadSideEffect[-1]               : &:r0_19, ~m104_40
-#-----|     r0_21(glval<promise_type>)     = VariableAddress[(unnamed local variable)] : 
-#-----|     r0_22(glval<unknown>)          = FunctionAddress[return_void]              : 
-#-----|     v0_23(void)                    = Call[return_void]                         : func:r0_22, this:r0_21
-#-----|     m0_24(unknown)                 = ^CallSideEffect                           : ~m104_40
-#-----|     m0_25(unknown)                 = Chi                                       : total:m104_40, partial:m0_24
-#-----|     v0_26(void)                    = ^IndirectReadSideEffect[-1]               : &:r0_21, ~m0_25
-#-----|     m0_27(promise_type)            = ^IndirectMayWriteSideEffect[-1]           : &:r0_21
-#-----|     m0_28(unknown)                 = Chi                                       : total:m0_25, partial:m0_27
+#  104|     m104_33(unknown)               = Phi                                       : from 4:~m104_30, from 6:~m104_58
+#  104|     r104_34(suspend_always *)      = CopyValue                                 : r104_24
+#  104|     r104_35(glval<suspend_always>) = CopyValue                                 : r104_34
+#  104|     r104_36(glval<unknown>)        = FunctionAddress[await_resume]             : 
+#  104|     v104_37(void)                  = Call[await_resume]                        : func:r104_36, this:r104_35
+#  104|     m104_38(unknown)               = ^CallSideEffect                           : ~m104_33
+#  104|     m104_39(unknown)               = Chi                                       : total:m104_33, partial:m104_38
+#-----|     v0_17(void)                    = ^IndirectReadSideEffect[-1]               : &:r104_35, ~m104_39
+#-----|     r0_18(glval<promise_type>)     = VariableAddress[(unnamed local variable)] : 
+#-----|     r0_19(glval<unknown>)          = FunctionAddress[return_void]              : 
+#-----|     v0_20(void)                    = Call[return_void]                         : func:r0_19, this:r0_18
+#-----|     m0_21(unknown)                 = ^CallSideEffect                           : ~m104_39
+#-----|     m0_22(unknown)                 = Chi                                       : total:m104_39, partial:m0_21
+#-----|     v0_23(void)                    = ^IndirectReadSideEffect[-1]               : &:r0_18, ~m0_22
+#-----|     m0_24(promise_type)            = ^IndirectMayWriteSideEffect[-1]           : &:r0_18
+#-----|     m0_25(unknown)                 = Chi                                       : total:m0_22, partial:m0_24
 #-----|   C++ Exception -> Block 8
 #-----|   Goto -> Block 7
 
 #  104|   Block 6
-#  104|     r104_41(suspend_always *)                      = CopyValue                                 : r104_24
-#  104|     r104_42(glval<suspend_always>)                 = CopyValue                                 : r104_41
-#-----|     r0_29(glval<suspend_always>)                   = Convert                                   : r104_42
-#  104|     r104_43(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
-#  104|     r104_44(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp104:3]               : 
-#  104|     m104_45(coroutine_handle<promise_type>)        = Uninitialized[#temp104:3]                 : &:r104_44
-#  104|     m104_46(unknown)                               = Chi                                       : total:m104_31, partial:m104_45
-#  104|     r104_47(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
-#  104|     r104_48(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
-#  104|     r104_49(glval<coroutine_handle<promise_type>>) = Convert                                   : r104_48
-#  104|     r104_50(coroutine_handle<promise_type> &)      = CopyValue                                 : r104_49
-#  104|     v104_51(void)                                  = Call[coroutine_handle]                    : func:r104_47, this:r104_44, 0:r104_50
-#  104|     m104_52(unknown)                               = ^CallSideEffect                           : ~m104_46
-#  104|     m104_53(unknown)                               = Chi                                       : total:m104_46, partial:m104_52
-#  104|     v104_54(void)                                  = ^BufferReadSideEffect[0]                  : &:r104_50, ~m104_53
-#  104|     m104_55(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r104_44
-#  104|     m104_56(unknown)                               = Chi                                       : total:m104_53, partial:m104_55
-#  104|     r104_57(coroutine_handle<promise_type>)        = Load[#temp104:3]                          : &:r104_44, ~m104_56
-#  104|     v104_58(void)                                  = Call[await_suspend]                       : func:r104_43, this:r0_29, 0:r104_57
-#  104|     m104_59(unknown)                               = ^CallSideEffect                           : ~m104_56
-#  104|     m104_60(unknown)                               = Chi                                       : total:m104_56, partial:m104_59
-#-----|     v0_30(void)                                    = ^IndirectReadSideEffect[-1]               : &:r0_29, ~m104_60
+#  104|     r104_40(suspend_always *)                      = CopyValue                                 : r104_24
+#  104|     r104_41(glval<suspend_always>)                 = CopyValue                                 : r104_40
+#  104|     r104_42(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
+#  104|     r104_43(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp104:3]               : 
+#  104|     m104_44(coroutine_handle<promise_type>)        = Uninitialized[#temp104:3]                 : &:r104_43
+#  104|     m104_45(unknown)                               = Chi                                       : total:m104_30, partial:m104_44
+#  104|     r104_46(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
+#  104|     r104_47(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
+#  104|     r104_48(coroutine_handle<promise_type> &)      = CopyValue                                 : r104_47
+#  104|     v104_49(void)                                  = Call[coroutine_handle]                    : func:r104_46, this:r104_43, 0:r104_48
+#  104|     m104_50(unknown)                               = ^CallSideEffect                           : ~m104_45
+#  104|     m104_51(unknown)                               = Chi                                       : total:m104_45, partial:m104_50
+#  104|     v104_52(void)                                  = ^BufferReadSideEffect[0]                  : &:r104_48, ~m104_51
+#  104|     m104_53(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r104_43
+#  104|     m104_54(unknown)                               = Chi                                       : total:m104_51, partial:m104_53
+#  104|     r104_55(coroutine_handle<promise_type>)        = Load[#temp104:3]                          : &:r104_43, ~m104_54
+#  104|     v104_56(void)                                  = Call[await_suspend]                       : func:r104_42, this:r104_41, 0:r104_55
+#  104|     m104_57(unknown)                               = ^CallSideEffect                           : ~m104_54
+#  104|     m104_58(unknown)                               = Chi                                       : total:m104_54, partial:m104_57
+#-----|     v0_26(void)                                    = ^IndirectReadSideEffect[-1]               : &:r104_41, ~m104_58
 #-----|   Goto -> Block 5
 
 #  105|   Block 7
 #  105|     v105_1(void) = NoOp : 
-#-----|     v0_31(void)  = NoOp : 
+#-----|     v0_27(void)  = NoOp : 
 #-----|   Goto (back edge) -> Block 10
 
 #-----|   Block 8
-#-----|     m0_32(unknown)     = Phi                                       : from 1:~m104_10, from 3:~m104_21, from 5:~m0_28
-#-----|     v0_33(void)        = CatchAny                                  : 
-#-----|     r0_34(glval<bool>) = VariableAddress[(unnamed local variable)] : 
-#-----|     r0_35(bool)        = Load[(unnamed local variable)]            : &:r0_34, m0_11
-#-----|     r0_36(bool)        = LogicalNot                                : r0_35
-#-----|     v0_37(void)        = ConditionalBranch                         : r0_36
+#-----|     m0_28(unknown)     = Phi                                       : from 1:~m104_10, from 3:~m104_21, from 5:~m0_25
+#-----|     v0_29(void)        = CatchAny                                  : 
+#-----|     r0_30(glval<bool>) = VariableAddress[(unnamed local variable)] : 
+#-----|     r0_31(bool)        = Load[(unnamed local variable)]            : &:r0_30, m0_11
+#-----|     r0_32(bool)        = LogicalNot                                : r0_31
+#-----|     v0_33(void)        = ConditionalBranch                         : r0_32
 #-----|   False -> Block 9
 #-----|   True -> Block 13
 
 #  103|   Block 9
-#  103|     r103_64(glval<promise_type>) = VariableAddress[(unnamed local variable)] : 
-#  103|     r103_65(glval<unknown>)      = FunctionAddress[unhandled_exception]      : 
-#  103|     v103_66(void)                = Call[unhandled_exception]                 : func:r103_65, this:r103_64
-#  103|     m103_67(unknown)             = ^CallSideEffect                           : ~m0_32
-#  103|     m103_68(unknown)             = Chi                                       : total:m0_32, partial:m103_67
-#  103|     v103_69(void)                = ^IndirectReadSideEffect[-1]               : &:r103_64, ~m103_68
-#  103|     m103_70(promise_type)        = ^IndirectMayWriteSideEffect[-1]           : &:r103_64
-#  103|     m103_71(unknown)             = Chi                                       : total:m103_68, partial:m103_70
+#  103|     r103_62(glval<promise_type>) = VariableAddress[(unnamed local variable)] : 
+#  103|     r103_63(glval<unknown>)      = FunctionAddress[unhandled_exception]      : 
+#  103|     v103_64(void)                = Call[unhandled_exception]                 : func:r103_63, this:r103_62
+#  103|     m103_65(unknown)             = ^CallSideEffect                           : ~m0_28
+#  103|     m103_66(unknown)             = Chi                                       : total:m0_28, partial:m103_65
+#  103|     v103_67(void)                = ^IndirectReadSideEffect[-1]               : &:r103_62, ~m103_66
+#  103|     m103_68(promise_type)        = ^IndirectMayWriteSideEffect[-1]           : &:r103_62
+#  103|     m103_69(unknown)             = Chi                                       : total:m103_66, partial:m103_68
 #-----|   Goto -> Block 10
 
 #-----|   Block 10
-#-----|     m0_38(unknown)                 = Phi                                       : from 7:~m0_28, from 9:~m103_71
-#-----|     v0_39(void)                    = NoOp                                      : 
-#  103|     r103_72(glval<promise_type>)   = VariableAddress[(unnamed local variable)] : 
-#  103|     r103_73(glval<unknown>)        = FunctionAddress[final_suspend]            : 
-#  103|     r103_74(suspend_always)        = Call[final_suspend]                       : func:r103_73, this:r103_72
-#  103|     m103_75(unknown)               = ^CallSideEffect                           : ~m0_38
-#  103|     m103_76(unknown)               = Chi                                       : total:m0_38, partial:m103_75
-#  103|     v103_77(void)                  = ^IndirectReadSideEffect[-1]               : &:r103_72, ~m103_76
-#  103|     m103_78(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r103_72
-#  103|     m103_79(unknown)               = Chi                                       : total:m103_76, partial:m103_78
-#-----|     r0_40(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
-#  103|     r103_80(glval<suspend_always>) = VariableAddress[#temp103:20]              : 
-#  103|     r103_81(glval<promise_type>)   = VariableAddress[(unnamed local variable)] : 
-#  103|     r103_82(glval<unknown>)        = FunctionAddress[final_suspend]            : 
-#  103|     r103_83(suspend_always)        = Call[final_suspend]                       : func:r103_82, this:r103_81
-#  103|     m103_84(unknown)               = ^CallSideEffect                           : ~m103_79
-#  103|     m103_85(unknown)               = Chi                                       : total:m103_79, partial:m103_84
-#  103|     v103_86(void)                  = ^IndirectReadSideEffect[-1]               : &:r103_81, ~m103_85
-#  103|     m103_87(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r103_81
-#  103|     m103_88(unknown)               = Chi                                       : total:m103_85, partial:m103_87
-#  103|     m103_89(suspend_always)        = Store[#temp103:20]                        : &:r103_80, r103_83
-#  103|     m103_90(unknown)               = Chi                                       : total:m103_88, partial:m103_89
-#  103|     r103_91(suspend_always *)      = CopyValue                                 : r103_80
-#  103|     m103_92(suspend_always *)      = Store[#temp0:0]                           : &:r0_40, r103_91
-#-----|     r0_41(suspend_always *)        = Load[#temp0:0]                            : &:r0_40, m103_92
-#  103|     r103_93(glval<suspend_always>) = CopyValue                                 : r0_41
-#  103|     r103_94(glval<suspend_always>) = Convert                                   : r103_93
-#  103|     r103_95(glval<unknown>)        = FunctionAddress[await_ready]              : 
-#  103|     r103_96(bool)                  = Call[await_ready]                         : func:r103_95, this:r103_94
-#  103|     m103_97(unknown)               = ^CallSideEffect                           : ~m103_90
-#  103|     m103_98(unknown)               = Chi                                       : total:m103_90, partial:m103_97
-#  103|     v103_99(void)                  = ^IndirectReadSideEffect[-1]               : &:r103_94, ~m103_98
-#-----|     v0_42(void)                    = ConditionalBranch                         : r103_96
+#-----|     m0_34(unknown)                 = Phi                                       : from 7:~m0_25, from 9:~m103_69
+#-----|     v0_35(void)                    = NoOp                                      : 
+#  103|     r103_70(glval<promise_type>)   = VariableAddress[(unnamed local variable)] : 
+#  103|     r103_71(glval<unknown>)        = FunctionAddress[final_suspend]            : 
+#  103|     r103_72(suspend_always)        = Call[final_suspend]                       : func:r103_71, this:r103_70
+#  103|     m103_73(unknown)               = ^CallSideEffect                           : ~m0_34
+#  103|     m103_74(unknown)               = Chi                                       : total:m0_34, partial:m103_73
+#  103|     v103_75(void)                  = ^IndirectReadSideEffect[-1]               : &:r103_70, ~m103_74
+#  103|     m103_76(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r103_70
+#  103|     m103_77(unknown)               = Chi                                       : total:m103_74, partial:m103_76
+#-----|     r0_36(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
+#  103|     r103_78(glval<suspend_always>) = VariableAddress[#temp103:20]              : 
+#  103|     r103_79(glval<promise_type>)   = VariableAddress[(unnamed local variable)] : 
+#  103|     r103_80(glval<unknown>)        = FunctionAddress[final_suspend]            : 
+#  103|     r103_81(suspend_always)        = Call[final_suspend]                       : func:r103_80, this:r103_79
+#  103|     m103_82(unknown)               = ^CallSideEffect                           : ~m103_77
+#  103|     m103_83(unknown)               = Chi                                       : total:m103_77, partial:m103_82
+#  103|     v103_84(void)                  = ^IndirectReadSideEffect[-1]               : &:r103_79, ~m103_83
+#  103|     m103_85(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r103_79
+#  103|     m103_86(unknown)               = Chi                                       : total:m103_83, partial:m103_85
+#  103|     m103_87(suspend_always)        = Store[#temp103:20]                        : &:r103_78, r103_81
+#  103|     m103_88(unknown)               = Chi                                       : total:m103_86, partial:m103_87
+#  103|     r103_89(suspend_always *)      = CopyValue                                 : r103_78
+#  103|     m103_90(suspend_always *)      = Store[#temp0:0]                           : &:r0_36, r103_89
+#-----|     r0_37(suspend_always *)        = Load[#temp0:0]                            : &:r0_36, m103_90
+#  103|     r103_91(glval<suspend_always>) = CopyValue                                 : r0_37
+#  103|     r103_92(glval<unknown>)        = FunctionAddress[await_ready]              : 
+#  103|     r103_93(bool)                  = Call[await_ready]                         : func:r103_92, this:r103_91
+#  103|     m103_94(unknown)               = ^CallSideEffect                           : ~m103_88
+#  103|     m103_95(unknown)               = Chi                                       : total:m103_88, partial:m103_94
+#  103|     v103_96(void)                  = ^IndirectReadSideEffect[-1]               : &:r103_91, ~m103_95
+#-----|     v0_38(void)                    = ConditionalBranch                         : r103_93
 #-----|   False -> Block 12
 #-----|   True -> Block 11
 
 #  103|   Block 11
-#  103|     m103_100(unknown)                   = Phi                           : from 10:~m103_98, from 12:~m103_130
-#  103|     r103_101(suspend_always *)          = CopyValue                     : r103_91
-#  103|     r103_102(glval<suspend_always>)     = CopyValue                     : r103_101
-#-----|     r0_43(glval<suspend_always>)        = Convert                       : r103_102
-#  103|     r103_103(glval<unknown>)            = FunctionAddress[await_resume] : 
-#  103|     v103_104(void)                      = Call[await_resume]            : func:r103_103, this:r0_43
-#  103|     m103_105(unknown)                   = ^CallSideEffect               : ~m103_100
-#  103|     m103_106(unknown)                   = Chi                           : total:m103_100, partial:m103_105
-#-----|     v0_44(void)                         = ^IndirectReadSideEffect[-1]   : &:r0_43, ~m103_106
-#  103|     r103_107(glval<co_returnable_void>) = VariableAddress[#return]      : 
-#  103|     v103_108(void)                      = ReturnValue                   : &:r103_107, ~m103_106
-#  103|     v103_109(void)                      = AliasedUse                    : ~m103_106
-#  103|     v103_110(void)                      = ExitFunction                  : 
+#  103|     m103_97(unknown)                    = Phi                           : from 10:~m103_95, from 12:~m103_126
+#  103|     r103_98(suspend_always *)           = CopyValue                     : r103_89
+#  103|     r103_99(glval<suspend_always>)      = CopyValue                     : r103_98
+#  103|     r103_100(glval<unknown>)            = FunctionAddress[await_resume] : 
+#  103|     v103_101(void)                      = Call[await_resume]            : func:r103_100, this:r103_99
+#  103|     m103_102(unknown)                   = ^CallSideEffect               : ~m103_97
+#  103|     m103_103(unknown)                   = Chi                           : total:m103_97, partial:m103_102
+#-----|     v0_39(void)                         = ^IndirectReadSideEffect[-1]   : &:r103_99, ~m103_103
+#  103|     r103_104(glval<co_returnable_void>) = VariableAddress[#return]      : 
+#  103|     v103_105(void)                      = ReturnValue                   : &:r103_104, ~m103_103
+#  103|     v103_106(void)                      = AliasedUse                    : ~m103_103
+#  103|     v103_107(void)                      = ExitFunction                  : 
 
 #  103|   Block 12
-#  103|     r103_111(suspend_always *)                      = CopyValue                                 : r103_91
-#  103|     r103_112(glval<suspend_always>)                 = CopyValue                                 : r103_111
-#-----|     r0_45(glval<suspend_always>)                    = Convert                                   : r103_112
-#  103|     r103_113(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
-#  103|     r103_114(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp103:20]              : 
-#  103|     m103_115(coroutine_handle<promise_type>)        = Uninitialized[#temp103:20]                : &:r103_114
-#  103|     m103_116(unknown)                               = Chi                                       : total:m103_98, partial:m103_115
-#  103|     r103_117(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
-#  103|     r103_118(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
-#  103|     r103_119(glval<coroutine_handle<promise_type>>) = Convert                                   : r103_118
-#  103|     r103_120(coroutine_handle<promise_type> &)      = CopyValue                                 : r103_119
-#  103|     v103_121(void)                                  = Call[coroutine_handle]                    : func:r103_117, this:r103_114, 0:r103_120
-#  103|     m103_122(unknown)                               = ^CallSideEffect                           : ~m103_116
-#  103|     m103_123(unknown)                               = Chi                                       : total:m103_116, partial:m103_122
-#  103|     v103_124(void)                                  = ^BufferReadSideEffect[0]                  : &:r103_120, ~m103_123
-#  103|     m103_125(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r103_114
-#  103|     m103_126(unknown)                               = Chi                                       : total:m103_123, partial:m103_125
-#  103|     r103_127(coroutine_handle<promise_type>)        = Load[#temp103:20]                         : &:r103_114, ~m103_126
-#  103|     v103_128(void)                                  = Call[await_suspend]                       : func:r103_113, this:r0_45, 0:r103_127
-#  103|     m103_129(unknown)                               = ^CallSideEffect                           : ~m103_126
-#  103|     m103_130(unknown)                               = Chi                                       : total:m103_126, partial:m103_129
-#-----|     v0_46(void)                                     = ^IndirectReadSideEffect[-1]               : &:r0_45, ~m103_130
+#  103|     r103_108(suspend_always *)                      = CopyValue                                 : r103_89
+#  103|     r103_109(glval<suspend_always>)                 = CopyValue                                 : r103_108
+#  103|     r103_110(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
+#  103|     r103_111(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp103:20]              : 
+#  103|     m103_112(coroutine_handle<promise_type>)        = Uninitialized[#temp103:20]                : &:r103_111
+#  103|     m103_113(unknown)                               = Chi                                       : total:m103_95, partial:m103_112
+#  103|     r103_114(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
+#  103|     r103_115(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
+#  103|     r103_116(coroutine_handle<promise_type> &)      = CopyValue                                 : r103_115
+#  103|     v103_117(void)                                  = Call[coroutine_handle]                    : func:r103_114, this:r103_111, 0:r103_116
+#  103|     m103_118(unknown)                               = ^CallSideEffect                           : ~m103_113
+#  103|     m103_119(unknown)                               = Chi                                       : total:m103_113, partial:m103_118
+#  103|     v103_120(void)                                  = ^BufferReadSideEffect[0]                  : &:r103_116, ~m103_119
+#  103|     m103_121(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r103_111
+#  103|     m103_122(unknown)                               = Chi                                       : total:m103_119, partial:m103_121
+#  103|     r103_123(coroutine_handle<promise_type>)        = Load[#temp103:20]                         : &:r103_111, ~m103_122
+#  103|     v103_124(void)                                  = Call[await_suspend]                       : func:r103_110, this:r103_109, 0:r103_123
+#  103|     m103_125(unknown)                               = ^CallSideEffect                           : ~m103_122
+#  103|     m103_126(unknown)                               = Chi                                       : total:m103_122, partial:m103_125
+#-----|     v0_40(void)                                     = ^IndirectReadSideEffect[-1]               : &:r103_109, ~m103_126
 #-----|   Goto -> Block 11
 
 #  103|   Block 13
-#  103|     v103_131(void) = Unreached : 
+#  103|     v103_127(void) = Unreached : 
 
 #  108| co_returnable_value co_yield_and_return_value(int)
 #  108|   Block 0
@@ -2151,37 +2098,35 @@ coroutines.cpp:
 #  108|     m108_30(suspend_always *)      = Store[#temp0:0]                           : &:r0_5, r108_29
 #-----|     r0_6(suspend_always *)         = Load[#temp0:0]                            : &:r0_5, m108_30
 #  108|     r108_31(glval<suspend_always>) = CopyValue                                 : r0_6
-#  108|     r108_32(glval<suspend_always>) = Convert                                   : r108_31
-#  108|     r108_33(glval<unknown>)        = FunctionAddress[await_ready]              : 
-#  108|     r108_34(bool)                  = Call[await_ready]                         : func:r108_33, this:r108_32
-#  108|     m108_35(unknown)               = ^CallSideEffect                           : ~m108_28
-#  108|     m108_36(unknown)               = Chi                                       : total:m108_28, partial:m108_35
-#  108|     v108_37(void)                  = ^IndirectReadSideEffect[-1]               : &:r108_32, ~m108_36
-#-----|     v0_7(void)                     = ConditionalBranch                         : r108_34
+#  108|     r108_32(glval<unknown>)        = FunctionAddress[await_ready]              : 
+#  108|     r108_33(bool)                  = Call[await_ready]                         : func:r108_32, this:r108_31
+#  108|     m108_34(unknown)               = ^CallSideEffect                           : ~m108_28
+#  108|     m108_35(unknown)               = Chi                                       : total:m108_28, partial:m108_34
+#  108|     v108_36(void)                  = ^IndirectReadSideEffect[-1]               : &:r108_31, ~m108_35
+#-----|     v0_7(void)                     = ConditionalBranch                         : r108_33
 #-----|   False -> Block 2
 #-----|   True -> Block 1
 
 #-----|   Block 1
-#-----|     m0_8(unknown)                  = Phi                                       : from 0:~m108_36, from 2:~m108_63
+#-----|     m0_8(unknown)                  = Phi                                       : from 0:~m108_35, from 2:~m108_61
 #-----|     r0_9(bool)                     = Constant[1]                               : 
 #-----|     r0_10(glval<bool>)             = VariableAddress[(unnamed local variable)] : 
 #-----|     m0_11(bool)                    = Store[(unnamed local variable)]           : &:r0_10, r0_9
-#  108|     r108_38(suspend_always *)      = CopyValue                                 : r108_29
-#  108|     r108_39(glval<suspend_always>) = CopyValue                                 : r108_38
-#-----|     r0_12(glval<suspend_always>)   = Convert                                   : r108_39
-#  108|     r108_40(glval<unknown>)        = FunctionAddress[await_resume]             : 
-#  108|     v108_41(void)                  = Call[await_resume]                        : func:r108_40, this:r0_12
-#  108|     m108_42(unknown)               = ^CallSideEffect                           : ~m0_8
-#  108|     m108_43(unknown)               = Chi                                       : total:m0_8, partial:m108_42
-#-----|     v0_13(void)                    = ^IndirectReadSideEffect[-1]               : &:r0_12, ~m108_43
-#-----|     v0_14(void)                    = CopyValue                                 : v108_41
+#  108|     r108_37(suspend_always *)      = CopyValue                                 : r108_29
+#  108|     r108_38(glval<suspend_always>) = CopyValue                                 : r108_37
+#  108|     r108_39(glval<unknown>)        = FunctionAddress[await_resume]             : 
+#  108|     v108_40(void)                  = Call[await_resume]                        : func:r108_39, this:r108_38
+#  108|     m108_41(unknown)               = ^CallSideEffect                           : ~m0_8
+#  108|     m108_42(unknown)               = Chi                                       : total:m0_8, partial:m108_41
+#-----|     v0_12(void)                    = ^IndirectReadSideEffect[-1]               : &:r108_38, ~m108_42
+#-----|     v0_13(void)                    = CopyValue                                 : v108_40
 #  109|     r109_1(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
 #  109|     r109_2(glval<unknown>)         = FunctionAddress[yield_value]              : 
 #  109|     r109_3(glval<int>)             = VariableAddress[i]                        : 
 #  109|     r109_4(int)                    = Load[i]                                   : &:r109_3, m0_4
 #  109|     r109_5(suspend_always)         = Call[yield_value]                         : func:r109_2, this:r109_1, 0:r109_4
-#  109|     m109_6(unknown)                = ^CallSideEffect                           : ~m108_43
-#  109|     m109_7(unknown)                = Chi                                       : total:m108_43, partial:m109_6
+#  109|     m109_6(unknown)                = ^CallSideEffect                           : ~m108_42
+#  109|     m109_7(unknown)                = Chi                                       : total:m108_42, partial:m109_6
 #  109|     v109_8(void)                   = ^IndirectReadSideEffect[-1]               : &:r109_1, ~m109_7
 #  109|     m109_9(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r109_1
 #  109|     m109_10(unknown)               = Chi                                       : total:m109_7, partial:m109_9
@@ -2189,32 +2134,30 @@ coroutines.cpp:
 #-----|   Goto -> Block 3
 
 #  108|   Block 2
-#  108|     r108_44(suspend_always *)                      = CopyValue                                 : r108_29
-#  108|     r108_45(glval<suspend_always>)                 = CopyValue                                 : r108_44
-#-----|     r0_15(glval<suspend_always>)                   = Convert                                   : r108_45
-#  108|     r108_46(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
-#  108|     r108_47(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp108:21]              : 
-#  108|     m108_48(coroutine_handle<promise_type>)        = Uninitialized[#temp108:21]                : &:r108_47
-#  108|     m108_49(unknown)                               = Chi                                       : total:m108_36, partial:m108_48
-#  108|     r108_50(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
-#  108|     r108_51(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
-#  108|     r108_52(glval<coroutine_handle<promise_type>>) = Convert                                   : r108_51
-#  108|     r108_53(coroutine_handle<promise_type> &)      = CopyValue                                 : r108_52
-#  108|     v108_54(void)                                  = Call[coroutine_handle]                    : func:r108_50, this:r108_47, 0:r108_53
-#  108|     m108_55(unknown)                               = ^CallSideEffect                           : ~m108_49
-#  108|     m108_56(unknown)                               = Chi                                       : total:m108_49, partial:m108_55
-#  108|     v108_57(void)                                  = ^BufferReadSideEffect[0]                  : &:r108_53, ~m108_56
-#  108|     m108_58(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r108_47
-#  108|     m108_59(unknown)                               = Chi                                       : total:m108_56, partial:m108_58
-#  108|     r108_60(coroutine_handle<promise_type>)        = Load[#temp108:21]                         : &:r108_47, ~m108_59
-#  108|     v108_61(void)                                  = Call[await_suspend]                       : func:r108_46, this:r0_15, 0:r108_60
-#  108|     m108_62(unknown)                               = ^CallSideEffect                           : ~m108_59
-#  108|     m108_63(unknown)                               = Chi                                       : total:m108_59, partial:m108_62
-#-----|     v0_16(void)                                    = ^IndirectReadSideEffect[-1]               : &:r0_15, ~m108_63
+#  108|     r108_43(suspend_always *)                      = CopyValue                                 : r108_29
+#  108|     r108_44(glval<suspend_always>)                 = CopyValue                                 : r108_43
+#  108|     r108_45(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
+#  108|     r108_46(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp108:21]              : 
+#  108|     m108_47(coroutine_handle<promise_type>)        = Uninitialized[#temp108:21]                : &:r108_46
+#  108|     m108_48(unknown)                               = Chi                                       : total:m108_35, partial:m108_47
+#  108|     r108_49(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
+#  108|     r108_50(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
+#  108|     r108_51(coroutine_handle<promise_type> &)      = CopyValue                                 : r108_50
+#  108|     v108_52(void)                                  = Call[coroutine_handle]                    : func:r108_49, this:r108_46, 0:r108_51
+#  108|     m108_53(unknown)                               = ^CallSideEffect                           : ~m108_48
+#  108|     m108_54(unknown)                               = Chi                                       : total:m108_48, partial:m108_53
+#  108|     v108_55(void)                                  = ^BufferReadSideEffect[0]                  : &:r108_51, ~m108_54
+#  108|     m108_56(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r108_46
+#  108|     m108_57(unknown)                               = Chi                                       : total:m108_54, partial:m108_56
+#  108|     r108_58(coroutine_handle<promise_type>)        = Load[#temp108:21]                         : &:r108_46, ~m108_57
+#  108|     v108_59(void)                                  = Call[await_suspend]                       : func:r108_45, this:r108_44, 0:r108_58
+#  108|     m108_60(unknown)                               = ^CallSideEffect                           : ~m108_57
+#  108|     m108_61(unknown)                               = Chi                                       : total:m108_57, partial:m108_60
+#-----|     v0_14(void)                                    = ^IndirectReadSideEffect[-1]               : &:r108_44, ~m108_61
 #-----|   Goto -> Block 1
 
 #-----|   Block 3
-#-----|     r0_17(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
+#-----|     r0_15(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
 #  109|     r109_11(glval<suspend_always>) = VariableAddress[#temp109:13]              : 
 #  109|     r109_12(glval<promise_type>)   = VariableAddress[(unnamed local variable)] : 
 #  109|     r109_13(glval<unknown>)        = FunctionAddress[yield_value]              : 
@@ -2233,174 +2176,166 @@ coroutines.cpp:
 #  109|     m109_22(suspend_always)        = Store[#temp109:13]           : &:r109_11, r109_16
 #  109|     m109_23(unknown)               = Chi                          : total:m109_21, partial:m109_22
 #  109|     r109_24(suspend_always *)      = CopyValue                    : r109_11
-#  109|     m109_25(suspend_always *)      = Store[#temp0:0]              : &:r0_17, r109_24
-#-----|     r0_18(suspend_always *)        = Load[#temp0:0]               : &:r0_17, m109_25
-#  109|     r109_26(glval<suspend_always>) = CopyValue                    : r0_18
-#  109|     r109_27(glval<suspend_always>) = Convert                      : r109_26
-#  109|     r109_28(glval<unknown>)        = FunctionAddress[await_ready] : 
-#  109|     r109_29(bool)                  = Call[await_ready]            : func:r109_28, this:r109_27
-#  109|     m109_30(unknown)               = ^CallSideEffect              : ~m109_23
-#  109|     m109_31(unknown)               = Chi                          : total:m109_23, partial:m109_30
-#  109|     v109_32(void)                  = ^IndirectReadSideEffect[-1]  : &:r109_27, ~m109_31
-#  109|     v109_33(void)                  = ConditionalBranch            : r109_29
+#  109|     m109_25(suspend_always *)      = Store[#temp0:0]              : &:r0_15, r109_24
+#-----|     r0_16(suspend_always *)        = Load[#temp0:0]               : &:r0_15, m109_25
+#  109|     r109_26(glval<suspend_always>) = CopyValue                    : r0_16
+#  109|     r109_27(glval<unknown>)        = FunctionAddress[await_ready] : 
+#  109|     r109_28(bool)                  = Call[await_ready]            : func:r109_27, this:r109_26
+#  109|     m109_29(unknown)               = ^CallSideEffect              : ~m109_23
+#  109|     m109_30(unknown)               = Chi                          : total:m109_23, partial:m109_29
+#  109|     v109_31(void)                  = ^IndirectReadSideEffect[-1]  : &:r109_26, ~m109_30
+#  109|     v109_32(void)                  = ConditionalBranch            : r109_28
 #-----|   False -> Block 6
 #-----|   True -> Block 5
 
 #  109|   Block 5
-#  109|     m109_34(unknown)               = Phi                                       : from 4:~m109_31, from 6:~m109_60
-#  109|     r109_35(suspend_always *)      = CopyValue                                 : r109_24
-#  109|     r109_36(glval<suspend_always>) = CopyValue                                 : r109_35
-#-----|     r0_19(glval<suspend_always>)   = Convert                                   : r109_36
-#  109|     r109_37(glval<unknown>)        = FunctionAddress[await_resume]             : 
-#  109|     v109_38(void)                  = Call[await_resume]                        : func:r109_37, this:r0_19
-#  109|     m109_39(unknown)               = ^CallSideEffect                           : ~m109_34
-#  109|     m109_40(unknown)               = Chi                                       : total:m109_34, partial:m109_39
-#-----|     v0_20(void)                    = ^IndirectReadSideEffect[-1]               : &:r0_19, ~m109_40
-#-----|     r0_21(glval<promise_type>)     = VariableAddress[(unnamed local variable)] : 
-#-----|     r0_22(glval<unknown>)          = FunctionAddress[return_value]             : 
+#  109|     m109_33(unknown)               = Phi                                       : from 4:~m109_30, from 6:~m109_58
+#  109|     r109_34(suspend_always *)      = CopyValue                                 : r109_24
+#  109|     r109_35(glval<suspend_always>) = CopyValue                                 : r109_34
+#  109|     r109_36(glval<unknown>)        = FunctionAddress[await_resume]             : 
+#  109|     v109_37(void)                  = Call[await_resume]                        : func:r109_36, this:r109_35
+#  109|     m109_38(unknown)               = ^CallSideEffect                           : ~m109_33
+#  109|     m109_39(unknown)               = Chi                                       : total:m109_33, partial:m109_38
+#-----|     v0_17(void)                    = ^IndirectReadSideEffect[-1]               : &:r109_35, ~m109_39
+#-----|     r0_18(glval<promise_type>)     = VariableAddress[(unnamed local variable)] : 
+#-----|     r0_19(glval<unknown>)          = FunctionAddress[return_value]             : 
 #  110|     r110_1(glval<int>)             = VariableAddress[i]                        : 
 #  110|     r110_2(int)                    = Load[i]                                   : &:r110_1, m0_4
 #  110|     r110_3(int)                    = Constant[1]                               : 
 #  110|     r110_4(int)                    = Add                                       : r110_2, r110_3
-#-----|     v0_23(void)                    = Call[return_value]                        : func:r0_22, this:r0_21, 0:r110_4
-#-----|     m0_24(unknown)                 = ^CallSideEffect                           : ~m109_40
-#-----|     m0_25(unknown)                 = Chi                                       : total:m109_40, partial:m0_24
-#-----|     v0_26(void)                    = ^IndirectReadSideEffect[-1]               : &:r0_21, ~m0_25
-#-----|     m0_27(promise_type)            = ^IndirectMayWriteSideEffect[-1]           : &:r0_21
-#-----|     m0_28(unknown)                 = Chi                                       : total:m0_25, partial:m0_27
+#-----|     v0_20(void)                    = Call[return_value]                        : func:r0_19, this:r0_18, 0:r110_4
+#-----|     m0_21(unknown)                 = ^CallSideEffect                           : ~m109_39
+#-----|     m0_22(unknown)                 = Chi                                       : total:m109_39, partial:m0_21
+#-----|     v0_23(void)                    = ^IndirectReadSideEffect[-1]               : &:r0_18, ~m0_22
+#-----|     m0_24(promise_type)            = ^IndirectMayWriteSideEffect[-1]           : &:r0_18
+#-----|     m0_25(unknown)                 = Chi                                       : total:m0_22, partial:m0_24
 #-----|   C++ Exception -> Block 8
 #-----|   Goto -> Block 7
 
 #  109|   Block 6
-#  109|     r109_41(suspend_always *)                      = CopyValue                                 : r109_24
-#  109|     r109_42(glval<suspend_always>)                 = CopyValue                                 : r109_41
-#-----|     r0_29(glval<suspend_always>)                   = Convert                                   : r109_42
-#  109|     r109_43(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
-#  109|     r109_44(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp109:3]               : 
-#  109|     m109_45(coroutine_handle<promise_type>)        = Uninitialized[#temp109:3]                 : &:r109_44
-#  109|     m109_46(unknown)                               = Chi                                       : total:m109_31, partial:m109_45
-#  109|     r109_47(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
-#  109|     r109_48(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
-#  109|     r109_49(glval<coroutine_handle<promise_type>>) = Convert                                   : r109_48
-#  109|     r109_50(coroutine_handle<promise_type> &)      = CopyValue                                 : r109_49
-#  109|     v109_51(void)                                  = Call[coroutine_handle]                    : func:r109_47, this:r109_44, 0:r109_50
-#  109|     m109_52(unknown)                               = ^CallSideEffect                           : ~m109_46
-#  109|     m109_53(unknown)                               = Chi                                       : total:m109_46, partial:m109_52
-#  109|     v109_54(void)                                  = ^BufferReadSideEffect[0]                  : &:r109_50, ~m109_53
-#  109|     m109_55(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r109_44
-#  109|     m109_56(unknown)                               = Chi                                       : total:m109_53, partial:m109_55
-#  109|     r109_57(coroutine_handle<promise_type>)        = Load[#temp109:3]                          : &:r109_44, ~m109_56
-#  109|     v109_58(void)                                  = Call[await_suspend]                       : func:r109_43, this:r0_29, 0:r109_57
-#  109|     m109_59(unknown)                               = ^CallSideEffect                           : ~m109_56
-#  109|     m109_60(unknown)                               = Chi                                       : total:m109_56, partial:m109_59
-#-----|     v0_30(void)                                    = ^IndirectReadSideEffect[-1]               : &:r0_29, ~m109_60
+#  109|     r109_40(suspend_always *)                      = CopyValue                                 : r109_24
+#  109|     r109_41(glval<suspend_always>)                 = CopyValue                                 : r109_40
+#  109|     r109_42(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
+#  109|     r109_43(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp109:3]               : 
+#  109|     m109_44(coroutine_handle<promise_type>)        = Uninitialized[#temp109:3]                 : &:r109_43
+#  109|     m109_45(unknown)                               = Chi                                       : total:m109_30, partial:m109_44
+#  109|     r109_46(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
+#  109|     r109_47(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
+#  109|     r109_48(coroutine_handle<promise_type> &)      = CopyValue                                 : r109_47
+#  109|     v109_49(void)                                  = Call[coroutine_handle]                    : func:r109_46, this:r109_43, 0:r109_48
+#  109|     m109_50(unknown)                               = ^CallSideEffect                           : ~m109_45
+#  109|     m109_51(unknown)                               = Chi                                       : total:m109_45, partial:m109_50
+#  109|     v109_52(void)                                  = ^BufferReadSideEffect[0]                  : &:r109_48, ~m109_51
+#  109|     m109_53(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r109_43
+#  109|     m109_54(unknown)                               = Chi                                       : total:m109_51, partial:m109_53
+#  109|     r109_55(coroutine_handle<promise_type>)        = Load[#temp109:3]                          : &:r109_43, ~m109_54
+#  109|     v109_56(void)                                  = Call[await_suspend]                       : func:r109_42, this:r109_41, 0:r109_55
+#  109|     m109_57(unknown)                               = ^CallSideEffect                           : ~m109_54
+#  109|     m109_58(unknown)                               = Chi                                       : total:m109_54, partial:m109_57
+#-----|     v0_26(void)                                    = ^IndirectReadSideEffect[-1]               : &:r109_41, ~m109_58
 #-----|   Goto -> Block 5
 
 #  110|   Block 7
 #  110|     v110_5(void) = NoOp : 
-#-----|     v0_31(void)  = NoOp : 
+#-----|     v0_27(void)  = NoOp : 
 #-----|   Goto (back edge) -> Block 10
 
 #-----|   Block 8
-#-----|     m0_32(unknown)     = Phi                                       : from 1:~m109_10, from 3:~m109_21, from 5:~m0_28
-#-----|     v0_33(void)        = CatchAny                                  : 
-#-----|     r0_34(glval<bool>) = VariableAddress[(unnamed local variable)] : 
-#-----|     r0_35(bool)        = Load[(unnamed local variable)]            : &:r0_34, m0_11
-#-----|     r0_36(bool)        = LogicalNot                                : r0_35
-#-----|     v0_37(void)        = ConditionalBranch                         : r0_36
+#-----|     m0_28(unknown)     = Phi                                       : from 1:~m109_10, from 3:~m109_21, from 5:~m0_25
+#-----|     v0_29(void)        = CatchAny                                  : 
+#-----|     r0_30(glval<bool>) = VariableAddress[(unnamed local variable)] : 
+#-----|     r0_31(bool)        = Load[(unnamed local variable)]            : &:r0_30, m0_11
+#-----|     r0_32(bool)        = LogicalNot                                : r0_31
+#-----|     v0_33(void)        = ConditionalBranch                         : r0_32
 #-----|   False -> Block 9
 #-----|   True -> Block 13
 
 #  108|   Block 9
-#  108|     r108_64(glval<promise_type>) = VariableAddress[(unnamed local variable)] : 
-#  108|     r108_65(glval<unknown>)      = FunctionAddress[unhandled_exception]      : 
-#  108|     v108_66(void)                = Call[unhandled_exception]                 : func:r108_65, this:r108_64
-#  108|     m108_67(unknown)             = ^CallSideEffect                           : ~m0_32
-#  108|     m108_68(unknown)             = Chi                                       : total:m0_32, partial:m108_67
-#  108|     v108_69(void)                = ^IndirectReadSideEffect[-1]               : &:r108_64, ~m108_68
-#  108|     m108_70(promise_type)        = ^IndirectMayWriteSideEffect[-1]           : &:r108_64
-#  108|     m108_71(unknown)             = Chi                                       : total:m108_68, partial:m108_70
+#  108|     r108_62(glval<promise_type>) = VariableAddress[(unnamed local variable)] : 
+#  108|     r108_63(glval<unknown>)      = FunctionAddress[unhandled_exception]      : 
+#  108|     v108_64(void)                = Call[unhandled_exception]                 : func:r108_63, this:r108_62
+#  108|     m108_65(unknown)             = ^CallSideEffect                           : ~m0_28
+#  108|     m108_66(unknown)             = Chi                                       : total:m0_28, partial:m108_65
+#  108|     v108_67(void)                = ^IndirectReadSideEffect[-1]               : &:r108_62, ~m108_66
+#  108|     m108_68(promise_type)        = ^IndirectMayWriteSideEffect[-1]           : &:r108_62
+#  108|     m108_69(unknown)             = Chi                                       : total:m108_66, partial:m108_68
 #-----|   Goto -> Block 10
 
 #-----|   Block 10
-#-----|     m0_38(unknown)                 = Phi                                       : from 7:~m0_28, from 9:~m108_71
-#-----|     v0_39(void)                    = NoOp                                      : 
-#  108|     r108_72(glval<promise_type>)   = VariableAddress[(unnamed local variable)] : 
-#  108|     r108_73(glval<unknown>)        = FunctionAddress[final_suspend]            : 
-#  108|     r108_74(suspend_always)        = Call[final_suspend]                       : func:r108_73, this:r108_72
-#  108|     m108_75(unknown)               = ^CallSideEffect                           : ~m0_38
-#  108|     m108_76(unknown)               = Chi                                       : total:m0_38, partial:m108_75
-#  108|     v108_77(void)                  = ^IndirectReadSideEffect[-1]               : &:r108_72, ~m108_76
-#  108|     m108_78(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r108_72
-#  108|     m108_79(unknown)               = Chi                                       : total:m108_76, partial:m108_78
-#-----|     r0_40(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
-#  108|     r108_80(glval<suspend_always>) = VariableAddress[#temp108:21]              : 
-#  108|     r108_81(glval<promise_type>)   = VariableAddress[(unnamed local variable)] : 
-#  108|     r108_82(glval<unknown>)        = FunctionAddress[final_suspend]            : 
-#  108|     r108_83(suspend_always)        = Call[final_suspend]                       : func:r108_82, this:r108_81
-#  108|     m108_84(unknown)               = ^CallSideEffect                           : ~m108_79
-#  108|     m108_85(unknown)               = Chi                                       : total:m108_79, partial:m108_84
-#  108|     v108_86(void)                  = ^IndirectReadSideEffect[-1]               : &:r108_81, ~m108_85
-#  108|     m108_87(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r108_81
-#  108|     m108_88(unknown)               = Chi                                       : total:m108_85, partial:m108_87
-#  108|     m108_89(suspend_always)        = Store[#temp108:21]                        : &:r108_80, r108_83
-#  108|     m108_90(unknown)               = Chi                                       : total:m108_88, partial:m108_89
-#  108|     r108_91(suspend_always *)      = CopyValue                                 : r108_80
-#  108|     m108_92(suspend_always *)      = Store[#temp0:0]                           : &:r0_40, r108_91
-#-----|     r0_41(suspend_always *)        = Load[#temp0:0]                            : &:r0_40, m108_92
-#  108|     r108_93(glval<suspend_always>) = CopyValue                                 : r0_41
-#  108|     r108_94(glval<suspend_always>) = Convert                                   : r108_93
-#  108|     r108_95(glval<unknown>)        = FunctionAddress[await_ready]              : 
-#  108|     r108_96(bool)                  = Call[await_ready]                         : func:r108_95, this:r108_94
-#  108|     m108_97(unknown)               = ^CallSideEffect                           : ~m108_90
-#  108|     m108_98(unknown)               = Chi                                       : total:m108_90, partial:m108_97
-#  108|     v108_99(void)                  = ^IndirectReadSideEffect[-1]               : &:r108_94, ~m108_98
-#-----|     v0_42(void)                    = ConditionalBranch                         : r108_96
+#-----|     m0_34(unknown)                 = Phi                                       : from 7:~m0_25, from 9:~m108_69
+#-----|     v0_35(void)                    = NoOp                                      : 
+#  108|     r108_70(glval<promise_type>)   = VariableAddress[(unnamed local variable)] : 
+#  108|     r108_71(glval<unknown>)        = FunctionAddress[final_suspend]            : 
+#  108|     r108_72(suspend_always)        = Call[final_suspend]                       : func:r108_71, this:r108_70
+#  108|     m108_73(unknown)               = ^CallSideEffect                           : ~m0_34
+#  108|     m108_74(unknown)               = Chi                                       : total:m0_34, partial:m108_73
+#  108|     v108_75(void)                  = ^IndirectReadSideEffect[-1]               : &:r108_70, ~m108_74
+#  108|     m108_76(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r108_70
+#  108|     m108_77(unknown)               = Chi                                       : total:m108_74, partial:m108_76
+#-----|     r0_36(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
+#  108|     r108_78(glval<suspend_always>) = VariableAddress[#temp108:21]              : 
+#  108|     r108_79(glval<promise_type>)   = VariableAddress[(unnamed local variable)] : 
+#  108|     r108_80(glval<unknown>)        = FunctionAddress[final_suspend]            : 
+#  108|     r108_81(suspend_always)        = Call[final_suspend]                       : func:r108_80, this:r108_79
+#  108|     m108_82(unknown)               = ^CallSideEffect                           : ~m108_77
+#  108|     m108_83(unknown)               = Chi                                       : total:m108_77, partial:m108_82
+#  108|     v108_84(void)                  = ^IndirectReadSideEffect[-1]               : &:r108_79, ~m108_83
+#  108|     m108_85(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r108_79
+#  108|     m108_86(unknown)               = Chi                                       : total:m108_83, partial:m108_85
+#  108|     m108_87(suspend_always)        = Store[#temp108:21]                        : &:r108_78, r108_81
+#  108|     m108_88(unknown)               = Chi                                       : total:m108_86, partial:m108_87
+#  108|     r108_89(suspend_always *)      = CopyValue                                 : r108_78
+#  108|     m108_90(suspend_always *)      = Store[#temp0:0]                           : &:r0_36, r108_89
+#-----|     r0_37(suspend_always *)        = Load[#temp0:0]                            : &:r0_36, m108_90
+#  108|     r108_91(glval<suspend_always>) = CopyValue                                 : r0_37
+#  108|     r108_92(glval<unknown>)        = FunctionAddress[await_ready]              : 
+#  108|     r108_93(bool)                  = Call[await_ready]                         : func:r108_92, this:r108_91
+#  108|     m108_94(unknown)               = ^CallSideEffect                           : ~m108_88
+#  108|     m108_95(unknown)               = Chi                                       : total:m108_88, partial:m108_94
+#  108|     v108_96(void)                  = ^IndirectReadSideEffect[-1]               : &:r108_91, ~m108_95
+#-----|     v0_38(void)                    = ConditionalBranch                         : r108_93
 #-----|   False -> Block 12
 #-----|   True -> Block 11
 
 #  108|   Block 11
-#  108|     m108_100(unknown)                    = Phi                           : from 10:~m108_98, from 12:~m108_130
-#  108|     r108_101(suspend_always *)           = CopyValue                     : r108_91
-#  108|     r108_102(glval<suspend_always>)      = CopyValue                     : r108_101
-#-----|     r0_43(glval<suspend_always>)         = Convert                       : r108_102
-#  108|     r108_103(glval<unknown>)             = FunctionAddress[await_resume] : 
-#  108|     v108_104(void)                       = Call[await_resume]            : func:r108_103, this:r0_43
-#  108|     m108_105(unknown)                    = ^CallSideEffect               : ~m108_100
-#  108|     m108_106(unknown)                    = Chi                           : total:m108_100, partial:m108_105
-#-----|     v0_44(void)                          = ^IndirectReadSideEffect[-1]   : &:r0_43, ~m108_106
-#  108|     r108_107(glval<co_returnable_value>) = VariableAddress[#return]      : 
-#  108|     v108_108(void)                       = ReturnValue                   : &:r108_107, ~m108_106
-#  108|     v108_109(void)                       = AliasedUse                    : ~m108_106
-#  108|     v108_110(void)                       = ExitFunction                  : 
+#  108|     m108_97(unknown)                     = Phi                           : from 10:~m108_95, from 12:~m108_126
+#  108|     r108_98(suspend_always *)            = CopyValue                     : r108_89
+#  108|     r108_99(glval<suspend_always>)       = CopyValue                     : r108_98
+#  108|     r108_100(glval<unknown>)             = FunctionAddress[await_resume] : 
+#  108|     v108_101(void)                       = Call[await_resume]            : func:r108_100, this:r108_99
+#  108|     m108_102(unknown)                    = ^CallSideEffect               : ~m108_97
+#  108|     m108_103(unknown)                    = Chi                           : total:m108_97, partial:m108_102
+#-----|     v0_39(void)                          = ^IndirectReadSideEffect[-1]   : &:r108_99, ~m108_103
+#  108|     r108_104(glval<co_returnable_value>) = VariableAddress[#return]      : 
+#  108|     v108_105(void)                       = ReturnValue                   : &:r108_104, ~m108_103
+#  108|     v108_106(void)                       = AliasedUse                    : ~m108_103
+#  108|     v108_107(void)                       = ExitFunction                  : 
 
 #  108|   Block 12
-#  108|     r108_111(suspend_always *)                      = CopyValue                                 : r108_91
-#  108|     r108_112(glval<suspend_always>)                 = CopyValue                                 : r108_111
-#-----|     r0_45(glval<suspend_always>)                    = Convert                                   : r108_112
-#  108|     r108_113(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
-#  108|     r108_114(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp108:21]              : 
-#  108|     m108_115(coroutine_handle<promise_type>)        = Uninitialized[#temp108:21]                : &:r108_114
-#  108|     m108_116(unknown)                               = Chi                                       : total:m108_98, partial:m108_115
-#  108|     r108_117(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
-#  108|     r108_118(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
-#  108|     r108_119(glval<coroutine_handle<promise_type>>) = Convert                                   : r108_118
-#  108|     r108_120(coroutine_handle<promise_type> &)      = CopyValue                                 : r108_119
-#  108|     v108_121(void)                                  = Call[coroutine_handle]                    : func:r108_117, this:r108_114, 0:r108_120
-#  108|     m108_122(unknown)                               = ^CallSideEffect                           : ~m108_116
-#  108|     m108_123(unknown)                               = Chi                                       : total:m108_116, partial:m108_122
-#  108|     v108_124(void)                                  = ^BufferReadSideEffect[0]                  : &:r108_120, ~m108_123
-#  108|     m108_125(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r108_114
-#  108|     m108_126(unknown)                               = Chi                                       : total:m108_123, partial:m108_125
-#  108|     r108_127(coroutine_handle<promise_type>)        = Load[#temp108:21]                         : &:r108_114, ~m108_126
-#  108|     v108_128(void)                                  = Call[await_suspend]                       : func:r108_113, this:r0_45, 0:r108_127
-#  108|     m108_129(unknown)                               = ^CallSideEffect                           : ~m108_126
-#  108|     m108_130(unknown)                               = Chi                                       : total:m108_126, partial:m108_129
-#-----|     v0_46(void)                                     = ^IndirectReadSideEffect[-1]               : &:r0_45, ~m108_130
+#  108|     r108_108(suspend_always *)                      = CopyValue                                 : r108_89
+#  108|     r108_109(glval<suspend_always>)                 = CopyValue                                 : r108_108
+#  108|     r108_110(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
+#  108|     r108_111(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp108:21]              : 
+#  108|     m108_112(coroutine_handle<promise_type>)        = Uninitialized[#temp108:21]                : &:r108_111
+#  108|     m108_113(unknown)                               = Chi                                       : total:m108_95, partial:m108_112
+#  108|     r108_114(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
+#  108|     r108_115(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
+#  108|     r108_116(coroutine_handle<promise_type> &)      = CopyValue                                 : r108_115
+#  108|     v108_117(void)                                  = Call[coroutine_handle]                    : func:r108_114, this:r108_111, 0:r108_116
+#  108|     m108_118(unknown)                               = ^CallSideEffect                           : ~m108_113
+#  108|     m108_119(unknown)                               = Chi                                       : total:m108_113, partial:m108_118
+#  108|     v108_120(void)                                  = ^BufferReadSideEffect[0]                  : &:r108_116, ~m108_119
+#  108|     m108_121(coroutine_handle<promise_type>)        = ^IndirectMayWriteSideEffect[-1]           : &:r108_111
+#  108|     m108_122(unknown)                               = Chi                                       : total:m108_119, partial:m108_121
+#  108|     r108_123(coroutine_handle<promise_type>)        = Load[#temp108:21]                         : &:r108_111, ~m108_122
+#  108|     v108_124(void)                                  = Call[await_suspend]                       : func:r108_110, this:r108_109, 0:r108_123
+#  108|     m108_125(unknown)                               = ^CallSideEffect                           : ~m108_122
+#  108|     m108_126(unknown)                               = Chi                                       : total:m108_122, partial:m108_125
+#-----|     v0_40(void)                                     = ^IndirectReadSideEffect[-1]               : &:r108_109, ~m108_126
 #-----|   Goto -> Block 11
 
 #  108|   Block 13
-#  108|     v108_131(void) = Unreached : 
+#  108|     v108_127(void) = Unreached : 
 
 destructors_for_temps.cpp:
 #    9| void ClassWithConstructor::ClassWithConstructor(ClassWithConstructor&&)
@@ -2614,9 +2549,8 @@ destructors_for_temps.cpp:
 #   30|     m30_6(unknown)                       = Chi                                    : total:m29_4, partial:m30_5
 #   30|     m30_7(ClassWithDestructor2)          = Store[#temp30:38]                      : &:r30_2, r30_4
 #   30|     m30_8(unknown)                       = Chi                                    : total:m30_6, partial:m30_7
-#   30|     r30_9(glval<ClassWithDestructor2>)   = Convert                                : r30_2
-#   30|     r30_10(ClassWithDestructor2 &)       = CopyValue                              : r30_9
-#   30|     m30_11(ClassWithDestructor2 &)       = Store[rs]                              : &:r30_1, r30_10
+#   30|     r30_9(ClassWithDestructor2 &)        = CopyValue                              : r30_2
+#   30|     m30_10(ClassWithDestructor2 &)       = Store[rs]                              : &:r30_1, r30_9
 #   31|     v31_1(void)                          = NoOp                                   : 
 #   31|     r31_2(glval<ClassWithDestructor2>)   = CopyValue                              : r30_2
 #   31|     r31_3(glval<unknown>)                = FunctionAddress[~ClassWithDestructor2] : 
@@ -2653,9 +2587,8 @@ destructors_for_temps.cpp:
 #   35|     m35_6(unknown)                       = Chi                                    : total:m34_9, partial:m35_5
 #   35|     m35_7(ClassWithDestructor2)          = Store[#temp35:39]                      : &:r35_2, r35_4
 #   35|     m35_8(unknown)                       = Chi                                    : total:m35_6, partial:m35_7
-#   35|     r35_9(glval<ClassWithDestructor2>)   = Convert                                : r35_2
-#   35|     r35_10(ClassWithDestructor2 &)       = CopyValue                              : r35_9
-#   35|     m35_11(ClassWithDestructor2 &)       = Store[rs2]                             : &:r35_1, r35_10
+#   35|     r35_9(ClassWithDestructor2 &)        = CopyValue                              : r35_2
+#   35|     m35_10(ClassWithDestructor2 &)       = Store[rs2]                             : &:r35_1, r35_9
 #   36|     v36_1(void)                          = NoOp                                   : 
 #   36|     r36_2(glval<ClassWithDestructor2>)   = CopyValue                              : r35_2
 #   36|     r36_3(glval<unknown>)                = FunctionAddress[~ClassWithDestructor2] : 
@@ -3315,10 +3248,9 @@ generic.c:
 #   16|     r16_1(glval<char *>)  = VariableAddress[#return] : 
 #   16|     r16_2(glval<char[4]>) = Constant[int]            : 
 #   16|     r16_3(char *)         = Convert                  : r16_2
-#   16|     r16_4(char *)         = Convert                  : r16_3
-#   16|     m16_5(char *)         = Store[#return]           : &:r16_1, r16_4
+#   16|     m16_4(char *)         = Store[#return]           : &:r16_1, r16_3
 #   12|     r12_5(glval<char *>)  = VariableAddress[#return] : 
-#   12|     v12_6(void)           = ReturnValue              : &:r12_5, m16_5
+#   12|     v12_6(void)           = ReturnValue              : &:r12_5, m16_4
 #   12|     v12_7(void)           = AliasedUse               : m12_3
 #   12|     v12_8(void)           = ExitFunction             : 
 
@@ -3333,10 +3265,9 @@ generic.c:
 #   23|     r23_1(glval<char *>)  = VariableAddress[#return] : 
 #   23|     r23_2(glval<char[4]>) = Constant[int]            : 
 #   23|     r23_3(char *)         = Convert                  : r23_2
-#   23|     r23_4(char *)         = Convert                  : r23_3
-#   23|     m23_5(char *)         = Store[#return]           : &:r23_1, r23_4
+#   23|     m23_4(char *)         = Store[#return]           : &:r23_1, r23_3
 #   19|     r19_5(glval<char *>)  = VariableAddress[#return] : 
-#   19|     v19_6(void)           = ReturnValue              : &:r19_5, m23_5
+#   19|     v19_6(void)           = ReturnValue              : &:r19_5, m23_4
 #   19|     v19_7(void)           = AliasedUse               : m19_3
 #   19|     v19_8(void)           = ExitFunction             : 
 
@@ -4796,11 +4727,10 @@ ir.cpp:
 #  189|     r189_1(glval<wchar_t *>)  = VariableAddress[pwc]   : 
 #  189|     r189_2(glval<wchar_t[4]>) = StringConstant[L"Bar"] : 
 #  189|     r189_3(wchar_t *)         = Convert                : r189_2
-#  189|     r189_4(wchar_t *)         = Convert                : r189_3
-#  189|     m189_5(wchar_t *)         = Store[pwc]             : &:r189_1, r189_4
+#  189|     m189_4(wchar_t *)         = Store[pwc]             : &:r189_1, r189_3
 #  190|     r190_1(glval<wchar_t>)    = VariableAddress[wc]    : 
 #  190|     r190_2(glval<wchar_t *>)  = VariableAddress[pwc]   : 
-#  190|     r190_3(wchar_t *)         = Load[pwc]              : &:r190_2, m189_5
+#  190|     r190_3(wchar_t *)         = Load[pwc]              : &:r190_2, m189_4
 #  190|     r190_4(glval<int>)        = VariableAddress[i]     : 
 #  190|     r190_5(int)               = Load[i]                : &:r190_4, m187_6
 #  190|     r190_6(glval<wchar_t>)    = PointerAdd[4]          : r190_3, r190_5
@@ -6848,32 +6778,29 @@ ir.cpp:
 #  623|     r623_1(glval<String &>)  = VariableAddress[r]          : 
 #  623|     r623_2(String &)         = Load[r]                     : &:r623_1, m622_6
 #  623|     r623_3(glval<String>)    = CopyValue                   : r623_2
-#  623|     r623_4(glval<String>)    = Convert                     : r623_3
-#  623|     r623_5(glval<unknown>)   = FunctionAddress[c_str]      : 
-#  623|     r623_6(char *)           = Call[c_str]                 : func:r623_5, this:r623_4
-#  623|     m623_7(unknown)          = ^CallSideEffect             : ~m622_17
-#  623|     m623_8(unknown)          = Chi                         : total:m622_17, partial:m623_7
-#  623|     v623_9(void)             = ^IndirectReadSideEffect[-1] : &:r623_4, ~m623_8
+#  623|     r623_4(glval<unknown>)   = FunctionAddress[c_str]      : 
+#  623|     r623_5(char *)           = Call[c_str]                 : func:r623_4, this:r623_3
+#  623|     m623_6(unknown)          = ^CallSideEffect             : ~m622_17
+#  623|     m623_7(unknown)          = Chi                         : total:m622_17, partial:m623_6
+#  623|     v623_8(void)             = ^IndirectReadSideEffect[-1] : &:r623_3, ~m623_7
 #  624|     r624_1(glval<String *>)  = VariableAddress[p]          : 
 #  624|     r624_2(String *)         = Load[p]                     : &:r624_1, m622_11
-#  624|     r624_3(String *)         = Convert                     : r624_2
-#  624|     r624_4(glval<unknown>)   = FunctionAddress[c_str]      : 
-#  624|     r624_5(char *)           = Call[c_str]                 : func:r624_4, this:r624_3
-#  624|     m624_6(unknown)          = ^CallSideEffect             : ~m623_8
-#  624|     m624_7(unknown)          = Chi                         : total:m623_8, partial:m624_6
-#  624|     v624_8(void)             = ^IndirectReadSideEffect[-1] : &:r624_3, ~m624_7
+#  624|     r624_3(glval<unknown>)   = FunctionAddress[c_str]      : 
+#  624|     r624_4(char *)           = Call[c_str]                 : func:r624_3, this:r624_2
+#  624|     m624_5(unknown)          = ^CallSideEffect             : ~m623_7
+#  624|     m624_6(unknown)          = Chi                         : total:m623_7, partial:m624_5
+#  624|     v624_7(void)             = ^IndirectReadSideEffect[-1] : &:r624_2, ~m624_6
 #  625|     r625_1(glval<String>)    = VariableAddress[s]          : 
-#  625|     r625_2(glval<String>)    = Convert                     : r625_1
-#  625|     r625_3(glval<unknown>)   = FunctionAddress[c_str]      : 
-#  625|     r625_4(char *)           = Call[c_str]                 : func:r625_3, this:r625_2
-#  625|     m625_5(unknown)          = ^CallSideEffect             : ~m624_7
-#  625|     m625_6(unknown)          = Chi                         : total:m624_7, partial:m625_5
-#  625|     v625_7(void)             = ^IndirectReadSideEffect[-1] : &:r625_2, ~m625_6
+#  625|     r625_2(glval<unknown>)   = FunctionAddress[c_str]      : 
+#  625|     r625_3(char *)           = Call[c_str]                 : func:r625_2, this:r625_1
+#  625|     m625_4(unknown)          = ^CallSideEffect             : ~m624_6
+#  625|     m625_5(unknown)          = Chi                         : total:m624_6, partial:m625_4
+#  625|     v625_6(void)             = ^IndirectReadSideEffect[-1] : &:r625_1, ~m625_5
 #  626|     v626_1(void)             = NoOp                        : 
-#  622|     v622_18(void)            = ReturnIndirection[r]        : &:r622_7, ~m625_6
-#  622|     v622_19(void)            = ReturnIndirection[p]        : &:r622_12, ~m625_6
+#  622|     v622_18(void)            = ReturnIndirection[r]        : &:r622_7, ~m625_5
+#  622|     v622_19(void)            = ReturnIndirection[p]        : &:r622_12, ~m625_5
 #  622|     v622_20(void)            = ReturnVoid                  : 
-#  622|     v622_21(void)            = AliasedUse                  : ~m625_6
+#  622|     v622_21(void)            = AliasedUse                  : ~m625_5
 #  622|     v622_22(void)            = ExitFunction                : 
 
 #  628| void C::~C()
@@ -7173,9 +7100,8 @@ ir.cpp:
 #  688|     m688_4(unknown)         = ^CallSideEffect                  : ~m685_4
 #  688|     m688_5(unknown)         = Chi                              : total:m685_4, partial:m688_4
 #  688|     r688_6(glval<String>)   = CopyValue                        : r688_3
-#  688|     r688_7(glval<String>)   = Convert                          : r688_6
-#  688|     r688_8(String &)        = CopyValue                        : r688_7
-#  688|     m688_9(String &)        = Store[r3]                        : &:r688_1, r688_8
+#  688|     r688_7(String &)        = CopyValue                        : r688_6
+#  688|     m688_8(String &)        = Store[r3]                        : &:r688_1, r688_7
 #  689|     v689_1(void)            = NoOp                             : 
 #  685|     v685_7(void)            = ReturnVoid                       : 
 #  685|     v685_8(void)            = AliasedUse                       : ~m688_5
@@ -8093,29 +8019,28 @@ ir.cpp:
 #  809|     v809_13(void)              = ^BufferReadSideEffect[0]                  : &:r809_9, ~m809_12
 #  809|     m809_14(Base)              = ^IndirectMayWriteSideEffect[-1]           : &:r809_3
 #  809|     m809_15(unknown)           = Chi                                       : total:m809_12, partial:m809_14
-#  809|     r809_16(glval<Base>)       = Convert                                   : r809_3
-#  809|     r809_17(Base &)            = CopyValue                                 : r809_16
-#  809|     r809_18(Base &)            = Call[operator=]                           : func:r809_2, this:r809_1, 0:r809_17
-#  809|     m809_19(unknown)           = ^CallSideEffect                           : ~m809_15
-#  809|     m809_20(unknown)           = Chi                                       : total:m809_15, partial:m809_19
-#  809|     v809_21(void)              = ^IndirectReadSideEffect[-1]               : &:r809_1, ~m809_20
-#  809|     v809_22(void)              = ^BufferReadSideEffect[0]                  : &:r809_17, ~m809_20
-#  809|     m809_23(Base)              = ^IndirectMayWriteSideEffect[-1]           : &:r809_1
-#  809|     m809_24(unknown)           = Chi                                       : total:m809_20, partial:m809_23
-#  809|     r809_25(glval<Base>)       = CopyValue                                 : r809_3
-#  809|     r809_26(glval<unknown>)    = FunctionAddress[~Base]                    : 
-#  809|     v809_27(void)              = Call[~Base]                               : func:r809_26, this:r809_25
-#  809|     m809_28(unknown)           = ^CallSideEffect                           : ~m809_24
-#  809|     m809_29(unknown)           = Chi                                       : total:m809_24, partial:m809_28
-#  809|     v809_30(void)              = ^IndirectReadSideEffect[-1]               : &:r809_25, ~m809_29
-#  809|     m809_31(Base)              = ^IndirectMayWriteSideEffect[-1]           : &:r809_25
-#  809|     m809_32(unknown)           = Chi                                       : total:m809_29, partial:m809_31
-#  809|     r809_33(glval<Base>)       = CopyValue                                 : r809_18
+#  809|     r809_16(Base &)            = CopyValue                                 : r809_3
+#  809|     r809_17(Base &)            = Call[operator=]                           : func:r809_2, this:r809_1, 0:r809_16
+#  809|     m809_18(unknown)           = ^CallSideEffect                           : ~m809_15
+#  809|     m809_19(unknown)           = Chi                                       : total:m809_15, partial:m809_18
+#  809|     v809_20(void)              = ^IndirectReadSideEffect[-1]               : &:r809_1, ~m809_19
+#  809|     v809_21(void)              = ^BufferReadSideEffect[0]                  : &:r809_16, ~m809_19
+#  809|     m809_22(Base)              = ^IndirectMayWriteSideEffect[-1]           : &:r809_1
+#  809|     m809_23(unknown)           = Chi                                       : total:m809_19, partial:m809_22
+#  809|     r809_24(glval<Base>)       = CopyValue                                 : r809_3
+#  809|     r809_25(glval<unknown>)    = FunctionAddress[~Base]                    : 
+#  809|     v809_26(void)              = Call[~Base]                               : func:r809_25, this:r809_24
+#  809|     m809_27(unknown)           = ^CallSideEffect                           : ~m809_23
+#  809|     m809_28(unknown)           = Chi                                       : total:m809_23, partial:m809_27
+#  809|     v809_29(void)              = ^IndirectReadSideEffect[-1]               : &:r809_24, ~m809_28
+#  809|     m809_30(Base)              = ^IndirectMayWriteSideEffect[-1]           : &:r809_24
+#  809|     m809_31(unknown)           = Chi                                       : total:m809_28, partial:m809_30
+#  809|     r809_32(glval<Base>)       = CopyValue                                 : r809_17
 #  810|     r810_1(glval<Base>)        = VariableAddress[b]                        : 
 #  810|     r810_2(glval<unknown>)     = FunctionAddress[operator=]                : 
 #  810|     r810_3(glval<Base>)        = VariableAddress[#temp810:7]               : 
 #  810|     m810_4(Base)               = Uninitialized[#temp810:7]                 : &:r810_3
-#  810|     m810_5(unknown)            = Chi                                       : total:m809_32, partial:m810_4
+#  810|     m810_5(unknown)            = Chi                                       : total:m809_31, partial:m810_4
 #  810|     r810_6(glval<unknown>)     = FunctionAddress[Base]                     : 
 #  810|     r810_7(glval<Middle>)      = VariableAddress[m]                        : 
 #  810|     r810_8(glval<Base>)        = ConvertToNonVirtualBase[Middle : Base]    : r810_7
@@ -8126,24 +8051,23 @@ ir.cpp:
 #  810|     v810_13(void)              = ^BufferReadSideEffect[0]                  : &:r810_9, ~m810_12
 #  810|     m810_14(Base)              = ^IndirectMayWriteSideEffect[-1]           : &:r810_3
 #  810|     m810_15(unknown)           = Chi                                       : total:m810_12, partial:m810_14
-#  810|     r810_16(glval<Base>)       = Convert                                   : r810_3
-#  810|     r810_17(Base &)            = CopyValue                                 : r810_16
-#  810|     r810_18(Base &)            = Call[operator=]                           : func:r810_2, this:r810_1, 0:r810_17
-#  810|     m810_19(unknown)           = ^CallSideEffect                           : ~m810_15
-#  810|     m810_20(unknown)           = Chi                                       : total:m810_15, partial:m810_19
-#  810|     v810_21(void)              = ^IndirectReadSideEffect[-1]               : &:r810_1, ~m810_20
-#  810|     v810_22(void)              = ^BufferReadSideEffect[0]                  : &:r810_17, ~m810_20
-#  810|     m810_23(Base)              = ^IndirectMayWriteSideEffect[-1]           : &:r810_1
-#  810|     m810_24(unknown)           = Chi                                       : total:m810_20, partial:m810_23
-#  810|     r810_25(glval<Base>)       = CopyValue                                 : r810_3
-#  810|     r810_26(glval<unknown>)    = FunctionAddress[~Base]                    : 
-#  810|     v810_27(void)              = Call[~Base]                               : func:r810_26, this:r810_25
-#  810|     m810_28(unknown)           = ^CallSideEffect                           : ~m810_24
-#  810|     m810_29(unknown)           = Chi                                       : total:m810_24, partial:m810_28
-#  810|     v810_30(void)              = ^IndirectReadSideEffect[-1]               : &:r810_25, ~m810_29
-#  810|     m810_31(Base)              = ^IndirectMayWriteSideEffect[-1]           : &:r810_25
-#  810|     m810_32(unknown)           = Chi                                       : total:m810_29, partial:m810_31
-#  810|     r810_33(glval<Base>)       = CopyValue                                 : r810_18
+#  810|     r810_16(Base &)            = CopyValue                                 : r810_3
+#  810|     r810_17(Base &)            = Call[operator=]                           : func:r810_2, this:r810_1, 0:r810_16
+#  810|     m810_18(unknown)           = ^CallSideEffect                           : ~m810_15
+#  810|     m810_19(unknown)           = Chi                                       : total:m810_15, partial:m810_18
+#  810|     v810_20(void)              = ^IndirectReadSideEffect[-1]               : &:r810_1, ~m810_19
+#  810|     v810_21(void)              = ^BufferReadSideEffect[0]                  : &:r810_16, ~m810_19
+#  810|     m810_22(Base)              = ^IndirectMayWriteSideEffect[-1]           : &:r810_1
+#  810|     m810_23(unknown)           = Chi                                       : total:m810_19, partial:m810_22
+#  810|     r810_24(glval<Base>)       = CopyValue                                 : r810_3
+#  810|     r810_25(glval<unknown>)    = FunctionAddress[~Base]                    : 
+#  810|     v810_26(void)              = Call[~Base]                               : func:r810_25, this:r810_24
+#  810|     m810_27(unknown)           = ^CallSideEffect                           : ~m810_23
+#  810|     m810_28(unknown)           = Chi                                       : total:m810_23, partial:m810_27
+#  810|     v810_29(void)              = ^IndirectReadSideEffect[-1]               : &:r810_24, ~m810_28
+#  810|     m810_30(Base)              = ^IndirectMayWriteSideEffect[-1]           : &:r810_24
+#  810|     m810_31(unknown)           = Chi                                       : total:m810_28, partial:m810_30
+#  810|     r810_32(glval<Base>)       = CopyValue                                 : r810_17
 #  811|     r811_1(glval<Middle *>)    = VariableAddress[pm]                       : 
 #  811|     r811_2(Middle *)           = Load[pm]                                  : &:r811_1, m805_4
 #  811|     r811_3(Base *)             = ConvertToNonVirtualBase[Middle : Base]    : r811_2
@@ -8168,30 +8092,28 @@ ir.cpp:
 #  816|     r816_2(glval<unknown>)     = FunctionAddress[operator=]                : 
 #  816|     r816_3(glval<Base>)        = VariableAddress[b]                        : 
 #  816|     r816_4(glval<Middle>)      = ConvertToDerived[Middle : Base]           : r816_3
-#  816|     r816_5(glval<Middle>)      = Convert                                   : r816_4
-#  816|     r816_6(Middle &)           = CopyValue                                 : r816_5
-#  816|     r816_7(Middle &)           = Call[operator=]                           : func:r816_2, this:r816_1, 0:r816_6
-#  816|     m816_8(unknown)            = ^CallSideEffect                           : ~m810_32
-#  816|     m816_9(unknown)            = Chi                                       : total:m810_32, partial:m816_8
-#  816|     v816_10(void)              = ^IndirectReadSideEffect[-1]               : &:r816_1, ~m816_9
-#  816|     v816_11(void)              = ^BufferReadSideEffect[0]                  : &:r816_6, ~m816_9
-#  816|     m816_12(Middle)            = ^IndirectMayWriteSideEffect[-1]           : &:r816_1
-#  816|     m816_13(unknown)           = Chi                                       : total:m816_9, partial:m816_12
-#  816|     r816_14(glval<Middle>)     = CopyValue                                 : r816_7
+#  816|     r816_5(Middle &)           = CopyValue                                 : r816_4
+#  816|     r816_6(Middle &)           = Call[operator=]                           : func:r816_2, this:r816_1, 0:r816_5
+#  816|     m816_7(unknown)            = ^CallSideEffect                           : ~m810_31
+#  816|     m816_8(unknown)            = Chi                                       : total:m810_31, partial:m816_7
+#  816|     v816_9(void)               = ^IndirectReadSideEffect[-1]               : &:r816_1, ~m816_8
+#  816|     v816_10(void)              = ^BufferReadSideEffect[0]                  : &:r816_5, ~m816_8
+#  816|     m816_11(Middle)            = ^IndirectMayWriteSideEffect[-1]           : &:r816_1
+#  816|     m816_12(unknown)           = Chi                                       : total:m816_8, partial:m816_11
+#  816|     r816_13(glval<Middle>)     = CopyValue                                 : r816_6
 #  817|     r817_1(glval<Middle>)      = VariableAddress[m]                        : 
 #  817|     r817_2(glval<unknown>)     = FunctionAddress[operator=]                : 
 #  817|     r817_3(glval<Base>)        = VariableAddress[b]                        : 
 #  817|     r817_4(glval<Middle>)      = ConvertToDerived[Middle : Base]           : r817_3
-#  817|     r817_5(glval<Middle>)      = Convert                                   : r817_4
-#  817|     r817_6(Middle &)           = CopyValue                                 : r817_5
-#  817|     r817_7(Middle &)           = Call[operator=]                           : func:r817_2, this:r817_1, 0:r817_6
-#  817|     m817_8(unknown)            = ^CallSideEffect                           : ~m816_13
-#  817|     m817_9(unknown)            = Chi                                       : total:m816_13, partial:m817_8
-#  817|     v817_10(void)              = ^IndirectReadSideEffect[-1]               : &:r817_1, ~m817_9
-#  817|     v817_11(void)              = ^BufferReadSideEffect[0]                  : &:r817_6, ~m817_9
-#  817|     m817_12(Middle)            = ^IndirectMayWriteSideEffect[-1]           : &:r817_1
-#  817|     m817_13(unknown)           = Chi                                       : total:m817_9, partial:m817_12
-#  817|     r817_14(glval<Middle>)     = CopyValue                                 : r817_7
+#  817|     r817_5(Middle &)           = CopyValue                                 : r817_4
+#  817|     r817_6(Middle &)           = Call[operator=]                           : func:r817_2, this:r817_1, 0:r817_5
+#  817|     m817_7(unknown)            = ^CallSideEffect                           : ~m816_12
+#  817|     m817_8(unknown)            = Chi                                       : total:m816_12, partial:m817_7
+#  817|     v817_9(void)               = ^IndirectReadSideEffect[-1]               : &:r817_1, ~m817_8
+#  817|     v817_10(void)              = ^BufferReadSideEffect[0]                  : &:r817_5, ~m817_8
+#  817|     m817_11(Middle)            = ^IndirectMayWriteSideEffect[-1]           : &:r817_1
+#  817|     m817_12(unknown)           = Chi                                       : total:m817_8, partial:m817_11
+#  817|     r817_13(glval<Middle>)     = CopyValue                                 : r817_6
 #  818|     r818_1(glval<Base *>)      = VariableAddress[pb]                       : 
 #  818|     r818_2(Base *)             = Load[pb]                                  : &:r818_1, m814_5
 #  818|     r818_3(Middle *)           = ConvertToDerived[Middle : Base]           : r818_2
@@ -8214,8 +8136,8 @@ ir.cpp:
 #  822|     r822_5(glval<Base>)        = ConvertToNonVirtualBase[Middle : Base]    : r822_4
 #  822|     r822_6(Base &)             = CopyValue                                 : r822_5
 #  822|     r822_7(Base &)             = Call[operator=]                           : func:r822_2, this:r822_1, 0:r822_6
-#  822|     m822_8(unknown)            = ^CallSideEffect                           : ~m817_13
-#  822|     m822_9(unknown)            = Chi                                       : total:m817_13, partial:m822_8
+#  822|     m822_8(unknown)            = ^CallSideEffect                           : ~m817_12
+#  822|     m822_9(unknown)            = Chi                                       : total:m817_12, partial:m822_8
 #  822|     v822_10(void)              = ^IndirectReadSideEffect[-1]               : &:r822_1, ~m822_9
 #  822|     v822_11(void)              = ^BufferReadSideEffect[0]                  : &:r822_6, ~m822_9
 #  822|     m822_12(Base)              = ^IndirectMayWriteSideEffect[-1]           : &:r822_1
@@ -8237,29 +8159,28 @@ ir.cpp:
 #  823|     v823_14(void)              = ^BufferReadSideEffect[0]                  : &:r823_10, ~m823_13
 #  823|     m823_15(Base)              = ^IndirectMayWriteSideEffect[-1]           : &:r823_3
 #  823|     m823_16(unknown)           = Chi                                       : total:m823_13, partial:m823_15
-#  823|     r823_17(glval<Base>)       = Convert                                   : r823_3
-#  823|     r823_18(Base &)            = CopyValue                                 : r823_17
-#  823|     r823_19(Base &)            = Call[operator=]                           : func:r823_2, this:r823_1, 0:r823_18
-#  823|     m823_20(unknown)           = ^CallSideEffect                           : ~m823_16
-#  823|     m823_21(unknown)           = Chi                                       : total:m823_16, partial:m823_20
-#  823|     v823_22(void)              = ^IndirectReadSideEffect[-1]               : &:r823_1, ~m823_21
-#  823|     v823_23(void)              = ^BufferReadSideEffect[0]                  : &:r823_18, ~m823_21
-#  823|     m823_24(Base)              = ^IndirectMayWriteSideEffect[-1]           : &:r823_1
-#  823|     m823_25(unknown)           = Chi                                       : total:m823_21, partial:m823_24
-#  823|     r823_26(glval<Base>)       = CopyValue                                 : r823_3
-#  823|     r823_27(glval<unknown>)    = FunctionAddress[~Base]                    : 
-#  823|     v823_28(void)              = Call[~Base]                               : func:r823_27, this:r823_26
-#  823|     m823_29(unknown)           = ^CallSideEffect                           : ~m823_25
-#  823|     m823_30(unknown)           = Chi                                       : total:m823_25, partial:m823_29
-#  823|     v823_31(void)              = ^IndirectReadSideEffect[-1]               : &:r823_26, ~m823_30
-#  823|     m823_32(Base)              = ^IndirectMayWriteSideEffect[-1]           : &:r823_26
-#  823|     m823_33(unknown)           = Chi                                       : total:m823_30, partial:m823_32
-#  823|     r823_34(glval<Base>)       = CopyValue                                 : r823_19
+#  823|     r823_17(Base &)            = CopyValue                                 : r823_3
+#  823|     r823_18(Base &)            = Call[operator=]                           : func:r823_2, this:r823_1, 0:r823_17
+#  823|     m823_19(unknown)           = ^CallSideEffect                           : ~m823_16
+#  823|     m823_20(unknown)           = Chi                                       : total:m823_16, partial:m823_19
+#  823|     v823_21(void)              = ^IndirectReadSideEffect[-1]               : &:r823_1, ~m823_20
+#  823|     v823_22(void)              = ^BufferReadSideEffect[0]                  : &:r823_17, ~m823_20
+#  823|     m823_23(Base)              = ^IndirectMayWriteSideEffect[-1]           : &:r823_1
+#  823|     m823_24(unknown)           = Chi                                       : total:m823_20, partial:m823_23
+#  823|     r823_25(glval<Base>)       = CopyValue                                 : r823_3
+#  823|     r823_26(glval<unknown>)    = FunctionAddress[~Base]                    : 
+#  823|     v823_27(void)              = Call[~Base]                               : func:r823_26, this:r823_25
+#  823|     m823_28(unknown)           = ^CallSideEffect                           : ~m823_24
+#  823|     m823_29(unknown)           = Chi                                       : total:m823_24, partial:m823_28
+#  823|     v823_30(void)              = ^IndirectReadSideEffect[-1]               : &:r823_25, ~m823_29
+#  823|     m823_31(Base)              = ^IndirectMayWriteSideEffect[-1]           : &:r823_25
+#  823|     m823_32(unknown)           = Chi                                       : total:m823_29, partial:m823_31
+#  823|     r823_33(glval<Base>)       = CopyValue                                 : r823_18
 #  824|     r824_1(glval<Base>)        = VariableAddress[b]                        : 
 #  824|     r824_2(glval<unknown>)     = FunctionAddress[operator=]                : 
 #  824|     r824_3(glval<Base>)        = VariableAddress[#temp824:7]               : 
 #  824|     m824_4(Base)               = Uninitialized[#temp824:7]                 : &:r824_3
-#  824|     m824_5(unknown)            = Chi                                       : total:m823_33, partial:m824_4
+#  824|     m824_5(unknown)            = Chi                                       : total:m823_32, partial:m824_4
 #  824|     r824_6(glval<unknown>)     = FunctionAddress[Base]                     : 
 #  824|     r824_7(glval<Derived>)     = VariableAddress[d]                        : 
 #  824|     r824_8(glval<Middle>)      = ConvertToNonVirtualBase[Derived : Middle] : r824_7
@@ -8271,24 +8192,23 @@ ir.cpp:
 #  824|     v824_14(void)              = ^BufferReadSideEffect[0]                  : &:r824_10, ~m824_13
 #  824|     m824_15(Base)              = ^IndirectMayWriteSideEffect[-1]           : &:r824_3
 #  824|     m824_16(unknown)           = Chi                                       : total:m824_13, partial:m824_15
-#  824|     r824_17(glval<Base>)       = Convert                                   : r824_3
-#  824|     r824_18(Base &)            = CopyValue                                 : r824_17
-#  824|     r824_19(Base &)            = Call[operator=]                           : func:r824_2, this:r824_1, 0:r824_18
-#  824|     m824_20(unknown)           = ^CallSideEffect                           : ~m824_16
-#  824|     m824_21(unknown)           = Chi                                       : total:m824_16, partial:m824_20
-#  824|     v824_22(void)              = ^IndirectReadSideEffect[-1]               : &:r824_1, ~m824_21
-#  824|     v824_23(void)              = ^BufferReadSideEffect[0]                  : &:r824_18, ~m824_21
-#  824|     m824_24(Base)              = ^IndirectMayWriteSideEffect[-1]           : &:r824_1
-#  824|     m824_25(unknown)           = Chi                                       : total:m824_21, partial:m824_24
-#  824|     r824_26(glval<Base>)       = CopyValue                                 : r824_3
-#  824|     r824_27(glval<unknown>)    = FunctionAddress[~Base]                    : 
-#  824|     v824_28(void)              = Call[~Base]                               : func:r824_27, this:r824_26
-#  824|     m824_29(unknown)           = ^CallSideEffect                           : ~m824_25
-#  824|     m824_30(unknown)           = Chi                                       : total:m824_25, partial:m824_29
-#  824|     v824_31(void)              = ^IndirectReadSideEffect[-1]               : &:r824_26, ~m824_30
-#  824|     m824_32(Base)              = ^IndirectMayWriteSideEffect[-1]           : &:r824_26
-#  824|     m824_33(unknown)           = Chi                                       : total:m824_30, partial:m824_32
-#  824|     r824_34(glval<Base>)       = CopyValue                                 : r824_19
+#  824|     r824_17(Base &)            = CopyValue                                 : r824_3
+#  824|     r824_18(Base &)            = Call[operator=]                           : func:r824_2, this:r824_1, 0:r824_17
+#  824|     m824_19(unknown)           = ^CallSideEffect                           : ~m824_16
+#  824|     m824_20(unknown)           = Chi                                       : total:m824_16, partial:m824_19
+#  824|     v824_21(void)              = ^IndirectReadSideEffect[-1]               : &:r824_1, ~m824_20
+#  824|     v824_22(void)              = ^BufferReadSideEffect[0]                  : &:r824_17, ~m824_20
+#  824|     m824_23(Base)              = ^IndirectMayWriteSideEffect[-1]           : &:r824_1
+#  824|     m824_24(unknown)           = Chi                                       : total:m824_20, partial:m824_23
+#  824|     r824_25(glval<Base>)       = CopyValue                                 : r824_3
+#  824|     r824_26(glval<unknown>)    = FunctionAddress[~Base]                    : 
+#  824|     v824_27(void)              = Call[~Base]                               : func:r824_26, this:r824_25
+#  824|     m824_28(unknown)           = ^CallSideEffect                           : ~m824_24
+#  824|     m824_29(unknown)           = Chi                                       : total:m824_24, partial:m824_28
+#  824|     v824_30(void)              = ^IndirectReadSideEffect[-1]               : &:r824_25, ~m824_29
+#  824|     m824_31(Base)              = ^IndirectMayWriteSideEffect[-1]           : &:r824_25
+#  824|     m824_32(unknown)           = Chi                                       : total:m824_29, partial:m824_31
+#  824|     r824_33(glval<Base>)       = CopyValue                                 : r824_18
 #  825|     r825_1(glval<Derived *>)   = VariableAddress[pd]                       : 
 #  825|     r825_2(Derived *)          = Load[pd]                                  : &:r825_1, m806_4
 #  825|     r825_3(Middle *)           = ConvertToNonVirtualBase[Derived : Middle] : r825_2
@@ -8317,31 +8237,29 @@ ir.cpp:
 #  830|     r830_3(glval<Base>)        = VariableAddress[b]                        : 
 #  830|     r830_4(glval<Middle>)      = ConvertToDerived[Middle : Base]           : r830_3
 #  830|     r830_5(glval<Derived>)     = ConvertToDerived[Derived : Middle]        : r830_4
-#  830|     r830_6(glval<Derived>)     = Convert                                   : r830_5
-#  830|     r830_7(Derived &)          = CopyValue                                 : r830_6
-#  830|     r830_8(Derived &)          = Call[operator=]                           : func:r830_2, this:r830_1, 0:r830_7
-#  830|     m830_9(unknown)            = ^CallSideEffect                           : ~m824_33
-#  830|     m830_10(unknown)           = Chi                                       : total:m824_33, partial:m830_9
-#  830|     v830_11(void)              = ^IndirectReadSideEffect[-1]               : &:r830_1, ~m830_10
-#  830|     v830_12(void)              = ^BufferReadSideEffect[0]                  : &:r830_7, ~m830_10
-#  830|     m830_13(Derived)           = ^IndirectMayWriteSideEffect[-1]           : &:r830_1
-#  830|     m830_14(unknown)           = Chi                                       : total:m830_10, partial:m830_13
-#  830|     r830_15(glval<Derived>)    = CopyValue                                 : r830_8
+#  830|     r830_6(Derived &)          = CopyValue                                 : r830_5
+#  830|     r830_7(Derived &)          = Call[operator=]                           : func:r830_2, this:r830_1, 0:r830_6
+#  830|     m830_8(unknown)            = ^CallSideEffect                           : ~m824_32
+#  830|     m830_9(unknown)            = Chi                                       : total:m824_32, partial:m830_8
+#  830|     v830_10(void)              = ^IndirectReadSideEffect[-1]               : &:r830_1, ~m830_9
+#  830|     v830_11(void)              = ^BufferReadSideEffect[0]                  : &:r830_6, ~m830_9
+#  830|     m830_12(Derived)           = ^IndirectMayWriteSideEffect[-1]           : &:r830_1
+#  830|     m830_13(unknown)           = Chi                                       : total:m830_9, partial:m830_12
+#  830|     r830_14(glval<Derived>)    = CopyValue                                 : r830_7
 #  831|     r831_1(glval<Derived>)     = VariableAddress[d]                        : 
 #  831|     r831_2(glval<unknown>)     = FunctionAddress[operator=]                : 
 #  831|     r831_3(glval<Base>)        = VariableAddress[b]                        : 
 #  831|     r831_4(glval<Middle>)      = ConvertToDerived[Middle : Base]           : r831_3
 #  831|     r831_5(glval<Derived>)     = ConvertToDerived[Derived : Middle]        : r831_4
-#  831|     r831_6(glval<Derived>)     = Convert                                   : r831_5
-#  831|     r831_7(Derived &)          = CopyValue                                 : r831_6
-#  831|     r831_8(Derived &)          = Call[operator=]                           : func:r831_2, this:r831_1, 0:r831_7
-#  831|     m831_9(unknown)            = ^CallSideEffect                           : ~m830_14
-#  831|     m831_10(unknown)           = Chi                                       : total:m830_14, partial:m831_9
-#  831|     v831_11(void)              = ^IndirectReadSideEffect[-1]               : &:r831_1, ~m831_10
-#  831|     v831_12(void)              = ^BufferReadSideEffect[0]                  : &:r831_7, ~m831_10
-#  831|     m831_13(Derived)           = ^IndirectMayWriteSideEffect[-1]           : &:r831_1
-#  831|     m831_14(unknown)           = Chi                                       : total:m831_10, partial:m831_13
-#  831|     r831_15(glval<Derived>)    = CopyValue                                 : r831_8
+#  831|     r831_6(Derived &)          = CopyValue                                 : r831_5
+#  831|     r831_7(Derived &)          = Call[operator=]                           : func:r831_2, this:r831_1, 0:r831_6
+#  831|     m831_8(unknown)            = ^CallSideEffect                           : ~m830_13
+#  831|     m831_9(unknown)            = Chi                                       : total:m830_13, partial:m831_8
+#  831|     v831_10(void)              = ^IndirectReadSideEffect[-1]               : &:r831_1, ~m831_9
+#  831|     v831_11(void)              = ^BufferReadSideEffect[0]                  : &:r831_6, ~m831_9
+#  831|     m831_12(Derived)           = ^IndirectMayWriteSideEffect[-1]           : &:r831_1
+#  831|     m831_13(unknown)           = Chi                                       : total:m831_9, partial:m831_12
+#  831|     r831_14(glval<Derived>)    = CopyValue                                 : r831_7
 #  832|     r832_1(glval<Base *>)      = VariableAddress[pb]                       : 
 #  832|     r832_2(Base *)             = Load[pb]                                  : &:r832_1, m828_5
 #  832|     r832_3(Middle *)           = ConvertToDerived[Middle : Base]           : r832_2
@@ -8379,8 +8297,8 @@ ir.cpp:
 #  840|     r840_2(glval<Derived>)     = VariableAddress[d]                        : 
 #  840|     r840_3(glval<unknown>)     = FunctionAddress[~Derived]                 : 
 #  840|     v840_4(void)               = Call[~Derived]                            : func:r840_3, this:r840_2
-#  840|     m840_5(unknown)            = ^CallSideEffect                           : ~m831_14
-#  840|     m840_6(unknown)            = Chi                                       : total:m831_14, partial:m840_5
+#  840|     m840_5(unknown)            = ^CallSideEffect                           : ~m831_13
+#  840|     m840_6(unknown)            = Chi                                       : total:m831_13, partial:m840_5
 #  840|     v840_7(void)               = ^IndirectReadSideEffect[-1]               : &:r840_2, ~m840_6
 #  840|     m840_8(Derived)            = ^IndirectMayWriteSideEffect[-1]           : &:r840_2
 #  840|     m840_9(unknown)            = Chi                                       : total:m840_6, partial:m840_8
@@ -8585,8 +8503,7 @@ ir.cpp:
 #  873|     r873_1(glval<char *>)     = VariableAddress[p]     : 
 #  873|     r873_2(glval<char[5]>)    = VariableAddress[a]     : 
 #  873|     r873_3(char *)            = Convert                : r873_2
-#  873|     r873_4(char *)            = Convert                : r873_3
-#  873|     m873_5(char *)            = Store[p]               : &:r873_1, r873_4
+#  873|     m873_4(char *)            = Store[p]               : &:r873_1, r873_3
 #  874|     r874_1(glval<char[5]>)    = StringConstant["test"] : 
 #  874|     r874_2(char *)            = Convert                : r874_1
 #  874|     r874_3(glval<char *>)     = VariableAddress[p]     : 
@@ -8596,9 +8513,8 @@ ir.cpp:
 #  875|     r875_3(int)               = Constant[0]            : 
 #  875|     r875_4(glval<char>)       = PointerAdd[1]          : r875_2, r875_3
 #  875|     r875_5(char *)            = CopyValue              : r875_4
-#  875|     r875_6(char *)            = Convert                : r875_5
-#  875|     r875_7(glval<char *>)     = VariableAddress[p]     : 
-#  875|     m875_8(char *)            = Store[p]               : &:r875_7, r875_6
+#  875|     r875_6(glval<char *>)     = VariableAddress[p]     : 
+#  875|     m875_7(char *)            = Store[p]               : &:r875_6, r875_5
 #  876|     r876_1(glval<char[5]>)    = StringConstant["test"] : 
 #  876|     r876_2(char *)            = Convert                : r876_1
 #  876|     r876_3(int)               = Constant[0]            : 
@@ -8617,8 +8533,7 @@ ir.cpp:
 #  879|     r879_1(glval<char(*)[5]>) = VariableAddress[pa]    : 
 #  879|     r879_2(glval<char[5]>)    = VariableAddress[a]     : 
 #  879|     r879_3(char(*)[5])        = CopyValue              : r879_2
-#  879|     r879_4(char(*)[5])        = Convert                : r879_3
-#  879|     m879_5(char(*)[5])        = Store[pa]              : &:r879_1, r879_4
+#  879|     m879_4(char(*)[5])        = Store[pa]              : &:r879_1, r879_3
 #  880|     r880_1(glval<char[5]>)    = StringConstant["test"] : 
 #  880|     r880_2(char(*)[5])        = CopyValue              : r880_1
 #  880|     r880_3(glval<char(*)[5]>) = VariableAddress[pa]    : 
@@ -9529,17 +9444,16 @@ ir.cpp:
 # 1043|     r1043_13(decltype([...](...){...}))        = Load[#temp1043:20]                     : &:r1043_2, m0_3
 # 1043|     m1043_14(decltype([...](...){...}))        = Store[lambda_ref]                      : &:r1043_1, r1043_13
 # 1044|     r1044_1(glval<decltype([...](...){...})>)  = VariableAddress[lambda_ref]            : 
-# 1044|     r1044_2(glval<decltype([...](...){...})>)  = Convert                                : r1044_1
-# 1044|     r1044_3(glval<unknown>)                    = FunctionAddress[operator()]            : 
-# 1044|     r1044_4(float)                             = Constant[1.0]                          : 
-# 1044|     r1044_5(char)                              = Call[operator()]                       : func:r1044_3, this:r1044_2, 0:r1044_4
-# 1044|     m1044_6(unknown)                           = ^CallSideEffect                        : ~m1040_12
-# 1044|     m1044_7(unknown)                           = Chi                                    : total:m1040_12, partial:m1044_6
-# 1044|     v1044_8(void)                              = ^IndirectReadSideEffect[-1]            : &:r1044_2, m1043_14
+# 1044|     r1044_2(glval<unknown>)                    = FunctionAddress[operator()]            : 
+# 1044|     r1044_3(float)                             = Constant[1.0]                          : 
+# 1044|     r1044_4(char)                              = Call[operator()]                       : func:r1044_2, this:r1044_1, 0:r1044_3
+# 1044|     m1044_5(unknown)                           = ^CallSideEffect                        : ~m1040_12
+# 1044|     m1044_6(unknown)                           = Chi                                    : total:m1040_12, partial:m1044_5
+# 1044|     v1044_7(void)                              = ^IndirectReadSideEffect[-1]            : &:r1044_1, m1043_14
 # 1045|     r1045_1(glval<decltype([...](...){...})>)  = VariableAddress[lambda_val]            : 
 # 1045|     r1045_2(glval<decltype([...](...){...})>)  = VariableAddress[#temp1045:20]          : 
 # 1045|     m1045_3(decltype([...](...){...}))         = Uninitialized[#temp1045:20]            : &:r1045_2
-# 1045|     m1045_4(unknown)                           = Chi                                    : total:m1044_7, partial:m1045_3
+# 1045|     m1045_4(unknown)                           = Chi                                    : total:m1044_6, partial:m1045_3
 # 1045|     r1045_5(glval<String>)                     = FieldAddress[s]                        : r1045_2
 # 1045|     r1045_6(glval<unknown>)                    = FunctionAddress[String]                : 
 # 1045|     v1045_7(void)                              = Call[String]                           : func:r1045_6, this:r1045_5
@@ -9556,13 +9470,12 @@ ir.cpp:
 # 1045|     m1045_18(decltype([...](...){...}))        = Store[lambda_val]                      : &:r1045_1, r1045_17
 # 1045|     m1045_19(unknown)                          = Chi                                    : total:m1045_16, partial:m1045_18
 # 1046|     r1046_1(glval<decltype([...](...){...})>)  = VariableAddress[lambda_val]            : 
-# 1046|     r1046_2(glval<decltype([...](...){...})>)  = Convert                                : r1046_1
-# 1046|     r1046_3(glval<unknown>)                    = FunctionAddress[operator()]            : 
-# 1046|     r1046_4(float)                             = Constant[2.0]                          : 
-# 1046|     r1046_5(char)                              = Call[operator()]                       : func:r1046_3, this:r1046_2, 0:r1046_4
-# 1046|     m1046_6(unknown)                           = ^CallSideEffect                        : ~m1045_19
-# 1046|     m1046_7(unknown)                           = Chi                                    : total:m1045_19, partial:m1046_6
-# 1046|     v1046_8(void)                              = ^IndirectReadSideEffect[-1]            : &:r1046_2, ~m1046_7
+# 1046|     r1046_2(glval<unknown>)                    = FunctionAddress[operator()]            : 
+# 1046|     r1046_3(float)                             = Constant[2.0]                          : 
+# 1046|     r1046_4(char)                              = Call[operator()]                       : func:r1046_2, this:r1046_1, 0:r1046_3
+# 1046|     m1046_5(unknown)                           = ^CallSideEffect                        : ~m1045_19
+# 1046|     m1046_6(unknown)                           = Chi                                    : total:m1045_19, partial:m1046_5
+# 1046|     v1046_7(void)                              = ^IndirectReadSideEffect[-1]            : &:r1046_1, ~m1046_6
 # 1047|     r1047_1(glval<decltype([...](...){...})>)  = VariableAddress[lambda_ref_explicit]   : 
 # 1047|     r1047_2(glval<decltype([...](...){...})>)  = VariableAddress[#temp1047:29]          : 
 # 1047|     m1047_3(decltype([...](...){...}))         = Uninitialized[#temp1047:29]            : &:r1047_2
@@ -9575,17 +9488,16 @@ ir.cpp:
 # 1047|     r1047_10(decltype([...](...){...}))        = Load[#temp1047:29]                     : &:r1047_2, ~m1047_9
 # 1047|     m1047_11(decltype([...](...){...}))        = Store[lambda_ref_explicit]             : &:r1047_1, r1047_10
 # 1048|     r1048_1(glval<decltype([...](...){...})>)  = VariableAddress[lambda_ref_explicit]   : 
-# 1048|     r1048_2(glval<decltype([...](...){...})>)  = Convert                                : r1048_1
-# 1048|     r1048_3(glval<unknown>)                    = FunctionAddress[operator()]            : 
-# 1048|     r1048_4(float)                             = Constant[3.0]                          : 
-# 1048|     r1048_5(char)                              = Call[operator()]                       : func:r1048_3, this:r1048_2, 0:r1048_4
-# 1048|     m1048_6(unknown)                           = ^CallSideEffect                        : ~m1046_7
-# 1048|     m1048_7(unknown)                           = Chi                                    : total:m1046_7, partial:m1048_6
-# 1048|     v1048_8(void)                              = ^IndirectReadSideEffect[-1]            : &:r1048_2, m1047_11
+# 1048|     r1048_2(glval<unknown>)                    = FunctionAddress[operator()]            : 
+# 1048|     r1048_3(float)                             = Constant[3.0]                          : 
+# 1048|     r1048_4(char)                              = Call[operator()]                       : func:r1048_2, this:r1048_1, 0:r1048_3
+# 1048|     m1048_5(unknown)                           = ^CallSideEffect                        : ~m1046_6
+# 1048|     m1048_6(unknown)                           = Chi                                    : total:m1046_6, partial:m1048_5
+# 1048|     v1048_7(void)                              = ^IndirectReadSideEffect[-1]            : &:r1048_1, m1047_11
 # 1049|     r1049_1(glval<decltype([...](...){...})>)  = VariableAddress[lambda_val_explicit]   : 
 # 1049|     r1049_2(glval<decltype([...](...){...})>)  = VariableAddress[#temp1049:29]          : 
 # 1049|     m1049_3(decltype([...](...){...}))         = Uninitialized[#temp1049:29]            : &:r1049_2
-# 1049|     m1049_4(unknown)                           = Chi                                    : total:m1048_7, partial:m1049_3
+# 1049|     m1049_4(unknown)                           = Chi                                    : total:m1048_6, partial:m1049_3
 # 1049|     r1049_5(glval<String>)                     = FieldAddress[s]                        : r1049_2
 # 1049|     r1049_6(glval<unknown>)                    = FunctionAddress[String]                : 
 # 1049|     v1049_7(void)                              = Call[String]                           : func:r1049_6, this:r1049_5
@@ -9597,13 +9509,12 @@ ir.cpp:
 # 1049|     m1049_13(decltype([...](...){...}))        = Store[lambda_val_explicit]             : &:r1049_1, r1049_12
 # 1049|     m1049_14(unknown)                          = Chi                                    : total:m1049_11, partial:m1049_13
 # 1050|     r1050_1(glval<decltype([...](...){...})>)  = VariableAddress[lambda_val_explicit]   : 
-# 1050|     r1050_2(glval<decltype([...](...){...})>)  = Convert                                : r1050_1
-# 1050|     r1050_3(glval<unknown>)                    = FunctionAddress[operator()]            : 
-# 1050|     r1050_4(float)                             = Constant[4.0]                          : 
-# 1050|     r1050_5(char)                              = Call[operator()]                       : func:r1050_3, this:r1050_2, 0:r1050_4
-# 1050|     m1050_6(unknown)                           = ^CallSideEffect                        : ~m1049_14
-# 1050|     m1050_7(unknown)                           = Chi                                    : total:m1049_14, partial:m1050_6
-# 1050|     v1050_8(void)                              = ^IndirectReadSideEffect[-1]            : &:r1050_2, ~m1050_7
+# 1050|     r1050_2(glval<unknown>)                    = FunctionAddress[operator()]            : 
+# 1050|     r1050_3(float)                             = Constant[4.0]                          : 
+# 1050|     r1050_4(char)                              = Call[operator()]                       : func:r1050_2, this:r1050_1, 0:r1050_3
+# 1050|     m1050_5(unknown)                           = ^CallSideEffect                        : ~m1049_14
+# 1050|     m1050_6(unknown)                           = Chi                                    : total:m1049_14, partial:m1050_5
+# 1050|     v1050_7(void)                              = ^IndirectReadSideEffect[-1]            : &:r1050_1, ~m1050_6
 # 1051|     r1051_1(glval<decltype([...](...){...})>)  = VariableAddress[lambda_mixed_explicit] : 
 # 1051|     r1051_2(glval<decltype([...](...){...})>)  = VariableAddress[#temp1051:31]          : 
 # 1051|     m1051_3(decltype([...](...){...}))         = Uninitialized[#temp1051:31]            : &:r1051_2
@@ -9616,26 +9527,25 @@ ir.cpp:
 # 1051|     m1051_10(decltype([...](...){...}))        = Chi                                    : total:m1051_3, partial:m1051_9
 # 1051|     r1051_11(glval<int>)                       = FieldAddress[x]                        : r1051_2
 # 1051|     r1051_12(glval<int>)                       = VariableAddress[x]                     : 
-# 1051|     r1051_13(int)                              = Load[x]                                : &:r1051_12, ~m1050_7
+# 1051|     r1051_13(int)                              = Load[x]                                : &:r1051_12, ~m1050_6
 # 1051|     m1051_14(int)                              = Store[?]                               : &:r1051_11, r1051_13
 # 1051|     m1051_15(decltype([...](...){...}))        = Chi                                    : total:m1051_10, partial:m1051_14
 # 1051|     r1051_16(decltype([...](...){...}))        = Load[#temp1051:31]                     : &:r1051_2, m1051_15
 # 1051|     m1051_17(decltype([...](...){...}))        = Store[lambda_mixed_explicit]           : &:r1051_1, r1051_16
 # 1052|     r1052_1(glval<decltype([...](...){...})>)  = VariableAddress[lambda_mixed_explicit] : 
-# 1052|     r1052_2(glval<decltype([...](...){...})>)  = Convert                                : r1052_1
-# 1052|     r1052_3(glval<unknown>)                    = FunctionAddress[operator()]            : 
-# 1052|     r1052_4(float)                             = Constant[5.0]                          : 
-# 1052|     r1052_5(char)                              = Call[operator()]                       : func:r1052_3, this:r1052_2, 0:r1052_4
-# 1052|     m1052_6(unknown)                           = ^CallSideEffect                        : ~m1050_7
-# 1052|     m1052_7(unknown)                           = Chi                                    : total:m1050_7, partial:m1052_6
-# 1052|     v1052_8(void)                              = ^IndirectReadSideEffect[-1]            : &:r1052_2, m1051_17
+# 1052|     r1052_2(glval<unknown>)                    = FunctionAddress[operator()]            : 
+# 1052|     r1052_3(float)                             = Constant[5.0]                          : 
+# 1052|     r1052_4(char)                              = Call[operator()]                       : func:r1052_2, this:r1052_1, 0:r1052_3
+# 1052|     m1052_5(unknown)                           = ^CallSideEffect                        : ~m1050_6
+# 1052|     m1052_6(unknown)                           = Chi                                    : total:m1050_6, partial:m1052_5
+# 1052|     v1052_7(void)                              = ^IndirectReadSideEffect[-1]            : &:r1052_1, m1051_17
 # 1053|     r1053_1(glval<int>)                        = VariableAddress[r]                     : 
 # 1053|     r1053_2(glval<int>)                        = VariableAddress[x]                     : 
-# 1053|     r1053_3(int)                               = Load[x]                                : &:r1053_2, ~m1052_7
+# 1053|     r1053_3(int)                               = Load[x]                                : &:r1053_2, ~m1052_6
 # 1053|     r1053_4(int)                               = Constant[1]                            : 
 # 1053|     r1053_5(int)                               = Sub                                    : r1053_3, r1053_4
 # 1053|     m1053_6(int)                               = Store[r]                               : &:r1053_1, r1053_5
-# 1053|     m1053_7(unknown)                           = Chi                                    : total:m1052_7, partial:m1053_6
+# 1053|     m1053_7(unknown)                           = Chi                                    : total:m1052_6, partial:m1053_6
 # 1054|     r1054_1(glval<decltype([...](...){...})>)  = VariableAddress[lambda_inits]          : 
 # 1054|     r1054_2(glval<decltype([...](...){...})>)  = VariableAddress[#temp1054:22]          : 
 # 1054|     m1054_3(decltype([...](...){...}))         = Uninitialized[#temp1054:22]            : &:r1054_2
@@ -9648,12 +9558,12 @@ ir.cpp:
 # 1054|     m1054_10(decltype([...](...){...}))        = Chi                                    : total:m1054_3, partial:m1054_9
 # 1054|     r1054_11(glval<int>)                       = FieldAddress[x]                        : r1054_2
 # 1054|     r1054_12(glval<int>)                       = VariableAddress[x]                     : 
-# 1054|     r1054_13(int)                              = Load[x]                                : &:r1054_12, ~m1052_7
+# 1054|     r1054_13(int)                              = Load[x]                                : &:r1054_12, ~m1052_6
 # 1054|     m1054_14(int)                              = Store[?]                               : &:r1054_11, r1054_13
 # 1054|     m1054_15(decltype([...](...){...}))        = Chi                                    : total:m1054_10, partial:m1054_14
 # 1054|     r1054_16(glval<int>)                       = FieldAddress[i]                        : r1054_2
 # 1054|     r1054_17(glval<int>)                       = VariableAddress[x]                     : 
-# 1054|     r1054_18(int)                              = Load[x]                                : &:r1054_17, ~m1052_7
+# 1054|     r1054_18(int)                              = Load[x]                                : &:r1054_17, ~m1052_6
 # 1054|     r1054_19(int)                              = Constant[1]                            : 
 # 1054|     r1054_20(int)                              = Add                                    : r1054_18, r1054_19
 # 1054|     m1054_21(int)                              = Store[?]                               : &:r1054_16, r1054_20
@@ -9666,19 +9576,18 @@ ir.cpp:
 # 1054|     r1054_28(decltype([...](...){...}))        = Load[#temp1054:22]                     : &:r1054_2, m1054_27
 # 1054|     m1054_29(decltype([...](...){...}))        = Store[lambda_inits]                    : &:r1054_1, r1054_28
 # 1055|     r1055_1(glval<decltype([...](...){...})>)  = VariableAddress[lambda_inits]          : 
-# 1055|     r1055_2(glval<decltype([...](...){...})>)  = Convert                                : r1055_1
-# 1055|     r1055_3(glval<unknown>)                    = FunctionAddress[operator()]            : 
-# 1055|     r1055_4(float)                             = Constant[6.0]                          : 
-# 1055|     r1055_5(char)                              = Call[operator()]                       : func:r1055_3, this:r1055_2, 0:r1055_4
-# 1055|     m1055_6(unknown)                           = ^CallSideEffect                        : ~m1053_7
-# 1055|     m1055_7(unknown)                           = Chi                                    : total:m1053_7, partial:m1055_6
-# 1055|     v1055_8(void)                              = ^IndirectReadSideEffect[-1]            : &:r1055_2, m1054_29
+# 1055|     r1055_2(glval<unknown>)                    = FunctionAddress[operator()]            : 
+# 1055|     r1055_3(float)                             = Constant[6.0]                          : 
+# 1055|     r1055_4(char)                              = Call[operator()]                       : func:r1055_2, this:r1055_1, 0:r1055_3
+# 1055|     m1055_5(unknown)                           = ^CallSideEffect                        : ~m1053_7
+# 1055|     m1055_6(unknown)                           = Chi                                    : total:m1053_7, partial:m1055_5
+# 1055|     v1055_7(void)                              = ^IndirectReadSideEffect[-1]            : &:r1055_1, m1054_29
 # 1056|     v1056_1(void)                              = NoOp                                   : 
 # 1056|     r1056_2(glval<decltype([...](...){...})>)  = VariableAddress[lambda_val_explicit]   : 
 # 1056|     r1056_3(glval<unknown>)                    = FunctionAddress[~<unnamed>]            : 
 # 1056|     v1056_4(void)                              = Call[~<unnamed>]                       : func:r1056_3, this:r1056_2
-# 1056|     m1056_5(unknown)                           = ^CallSideEffect                        : ~m1055_7
-# 1056|     m1056_6(unknown)                           = Chi                                    : total:m1055_7, partial:m1056_5
+# 1056|     m1056_5(unknown)                           = ^CallSideEffect                        : ~m1055_6
+# 1056|     m1056_6(unknown)                           = Chi                                    : total:m1055_6, partial:m1056_5
 # 1056|     v1056_7(void)                              = ^IndirectReadSideEffect[-1]            : &:r1056_2, ~m1056_6
 # 1056|     m1056_8(decltype([...](...){...}))         = ^IndirectMayWriteSideEffect[-1]        : &:r1056_2
 # 1056|     m1056_9(unknown)                           = Chi                                    : total:m1056_6, partial:m1056_8
@@ -10059,24 +9968,22 @@ ir.cpp:
 # 1127|     m1127_20(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)        = Phi                             : from 0:m1127_12, from 4:m1127_45
 # 1127|     m1127_21(unknown)                                                                   = Phi                             : from 0:~m1127_19, from 4:~m1127_30
 # 1127|     r1127_22(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>) = VariableAddress[(__begin)]      : 
-#-----|     r0_5(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>)     = Convert                         : r1127_22
 # 1127|     r1127_23(glval<unknown>)                                                            = FunctionAddress[operator!=]     : 
-#-----|     r0_6(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>)     = VariableAddress[#temp0:0]       : 
-#-----|     m0_7(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)            = Uninitialized[#temp0:0]         : &:r0_6
-#-----|     m0_8(unknown)                                                                       = Chi                             : total:m1127_21, partial:m0_7
+#-----|     r0_5(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>)     = VariableAddress[#temp0:0]       : 
+#-----|     m0_6(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)            = Uninitialized[#temp0:0]         : &:r0_5
+#-----|     m0_7(unknown)                                                                       = Chi                             : total:m1127_21, partial:m0_6
 # 1127|     r1127_24(glval<unknown>)                                                            = FunctionAddress[iterator]       : 
 # 1127|     r1127_25(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>) = VariableAddress[(__end)]        : 
-#-----|     r0_9(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>)     = Convert                         : r1127_25
-#-----|     r0_10(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &> &)         = CopyValue                       : r0_9
-# 1127|     v1127_26(void)                                                                      = Call[iterator]                  : func:r1127_24, this:r0_6, 0:r0_10
-# 1127|     m1127_27(unknown)                                                                   = ^CallSideEffect                 : ~m0_8
-# 1127|     m1127_28(unknown)                                                                   = Chi                             : total:m0_8, partial:m1127_27
-#-----|     v0_11(void)                                                                         = ^BufferReadSideEffect[0]        : &:r0_10, ~m1127_28
-# 1127|     m1127_29(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)        = ^IndirectMayWriteSideEffect[-1] : &:r0_6
+#-----|     r0_8(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &> &)          = CopyValue                       : r1127_25
+# 1127|     v1127_26(void)                                                                      = Call[iterator]                  : func:r1127_24, this:r0_5, 0:r0_8
+# 1127|     m1127_27(unknown)                                                                   = ^CallSideEffect                 : ~m0_7
+# 1127|     m1127_28(unknown)                                                                   = Chi                             : total:m0_7, partial:m1127_27
+#-----|     v0_9(void)                                                                          = ^BufferReadSideEffect[0]        : &:r0_8, ~m1127_28
+# 1127|     m1127_29(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)        = ^IndirectMayWriteSideEffect[-1] : &:r0_5
 # 1127|     m1127_30(unknown)                                                                   = Chi                             : total:m1127_28, partial:m1127_29
-#-----|     r0_12(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)           = Load[#temp0:0]                  : &:r0_6, ~m1127_30
-# 1127|     r1127_31(bool)                                                                      = Call[operator!=]                : func:r1127_23, this:r0_5, 0:r0_12
-#-----|     v0_13(void)                                                                         = ^IndirectReadSideEffect[-1]     : &:r0_5, m1127_20
+#-----|     r0_10(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)           = Load[#temp0:0]                  : &:r0_5, ~m1127_30
+# 1127|     r1127_31(bool)                                                                      = Call[operator!=]                : func:r1127_23, this:r1127_22, 0:r0_10
+#-----|     v0_11(void)                                                                         = ^IndirectReadSideEffect[-1]     : &:r1127_22, m1127_20
 # 1127|     v1127_32(void)                                                                      = ConditionalBranch               : r1127_31
 #-----|   False -> Block 5
 #-----|   True -> Block 2
@@ -10084,10 +9991,9 @@ ir.cpp:
 # 1127|   Block 2
 # 1127|     r1127_33(glval<int>)                                                                = VariableAddress[e]          : 
 # 1127|     r1127_34(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>) = VariableAddress[(__begin)]  : 
-#-----|     r0_14(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>)    = Convert                     : r1127_34
 # 1127|     r1127_35(glval<unknown>)                                                            = FunctionAddress[operator*]  : 
-# 1127|     r1127_36(int &)                                                                     = Call[operator*]             : func:r1127_35, this:r0_14
-#-----|     v0_15(void)                                                                         = ^IndirectReadSideEffect[-1] : &:r0_14, m1127_20
+# 1127|     r1127_36(int &)                                                                     = Call[operator*]             : func:r1127_35, this:r1127_34
+#-----|     v0_12(void)                                                                         = ^IndirectReadSideEffect[-1] : &:r1127_34, m1127_20
 # 1127|     r1127_37(int)                                                                       = Load[?]                     : &:r1127_36, ~m1127_30
 # 1127|     m1127_38(int)                                                                       = Store[e]                    : &:r1127_33, r1127_37
 # 1128|     r1128_1(glval<int>)                                                                 = VariableAddress[e]          : 
@@ -10123,18 +10029,18 @@ ir.cpp:
 # 1133|     r1133_7(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>)  = VariableAddress[(__begin)]  : 
 # 1133|     r1133_8(glval<vector<int> &>)                                                       = VariableAddress[(__range)]  : 
 # 1133|     r1133_9(vector<int> &)                                                              = Load[(__range)]             : &:r1133_8, m1133_6
-#-----|     r0_16(glval<vector<int>>)                                                           = CopyValue                   : r1133_9
+#-----|     r0_13(glval<vector<int>>)                                                           = CopyValue                   : r1133_9
 # 1133|     r1133_10(glval<unknown>)                                                            = FunctionAddress[begin]      : 
-# 1133|     r1133_11(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)        = Call[begin]                 : func:r1133_10, this:r0_16
-#-----|     v0_17(void)                                                                         = ^IndirectReadSideEffect[-1] : &:r0_16, ~m1126_8
+# 1133|     r1133_11(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)        = Call[begin]                 : func:r1133_10, this:r0_13
+#-----|     v0_14(void)                                                                         = ^IndirectReadSideEffect[-1] : &:r0_13, ~m1126_8
 # 1133|     m1133_12(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)        = Store[(__begin)]            : &:r1133_7, r1133_11
 # 1133|     r1133_13(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>) = VariableAddress[(__end)]    : 
 # 1133|     r1133_14(glval<vector<int> &>)                                                      = VariableAddress[(__range)]  : 
 # 1133|     r1133_15(vector<int> &)                                                             = Load[(__range)]             : &:r1133_14, m1133_6
-#-----|     r0_18(glval<vector<int>>)                                                           = CopyValue                   : r1133_15
+#-----|     r0_15(glval<vector<int>>)                                                           = CopyValue                   : r1133_15
 # 1133|     r1133_16(glval<unknown>)                                                            = FunctionAddress[end]        : 
-# 1133|     r1133_17(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)        = Call[end]                   : func:r1133_16, this:r0_18
-#-----|     v0_19(void)                                                                         = ^IndirectReadSideEffect[-1] : &:r0_18, ~m1126_8
+# 1133|     r1133_17(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)        = Call[end]                   : func:r1133_16, this:r0_15
+#-----|     v0_16(void)                                                                         = ^IndirectReadSideEffect[-1] : &:r0_15, ~m1126_8
 # 1133|     m1133_18(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)        = Store[(__end)]              : &:r1133_13, r1133_17
 # 1133|     m1133_19(unknown)                                                                   = Chi                         : total:m1127_30, partial:m1133_18
 #-----|   Goto -> Block 6
@@ -10143,24 +10049,22 @@ ir.cpp:
 # 1133|     m1133_20(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)        = Phi                             : from 5:m1133_12, from 7:m1133_38
 # 1133|     m1133_21(unknown)                                                                   = Phi                             : from 5:~m1133_19, from 7:~m1133_30
 # 1133|     r1133_22(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>) = VariableAddress[(__begin)]      : 
-#-----|     r0_20(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>)    = Convert                         : r1133_22
 # 1133|     r1133_23(glval<unknown>)                                                            = FunctionAddress[operator!=]     : 
-#-----|     r0_21(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>)    = VariableAddress[#temp0:0]       : 
-#-----|     m0_22(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)           = Uninitialized[#temp0:0]         : &:r0_21
-#-----|     m0_23(unknown)                                                                      = Chi                             : total:m1133_21, partial:m0_22
+#-----|     r0_17(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>)    = VariableAddress[#temp0:0]       : 
+#-----|     m0_18(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)           = Uninitialized[#temp0:0]         : &:r0_17
+#-----|     m0_19(unknown)                                                                      = Chi                             : total:m1133_21, partial:m0_18
 # 1133|     r1133_24(glval<unknown>)                                                            = FunctionAddress[iterator]       : 
 # 1133|     r1133_25(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>) = VariableAddress[(__end)]        : 
-#-----|     r0_24(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>)    = Convert                         : r1133_25
-#-----|     r0_25(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &> &)         = CopyValue                       : r0_24
-# 1133|     v1133_26(void)                                                                      = Call[iterator]                  : func:r1133_24, this:r0_21, 0:r0_25
-# 1133|     m1133_27(unknown)                                                                   = ^CallSideEffect                 : ~m0_23
-# 1133|     m1133_28(unknown)                                                                   = Chi                             : total:m0_23, partial:m1133_27
-#-----|     v0_26(void)                                                                         = ^BufferReadSideEffect[0]        : &:r0_25, ~m1133_28
-# 1133|     m1133_29(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)        = ^IndirectMayWriteSideEffect[-1] : &:r0_21
+#-----|     r0_20(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &> &)         = CopyValue                       : r1133_25
+# 1133|     v1133_26(void)                                                                      = Call[iterator]                  : func:r1133_24, this:r0_17, 0:r0_20
+# 1133|     m1133_27(unknown)                                                                   = ^CallSideEffect                 : ~m0_19
+# 1133|     m1133_28(unknown)                                                                   = Chi                             : total:m0_19, partial:m1133_27
+#-----|     v0_21(void)                                                                         = ^BufferReadSideEffect[0]        : &:r0_20, ~m1133_28
+# 1133|     m1133_29(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)        = ^IndirectMayWriteSideEffect[-1] : &:r0_17
 # 1133|     m1133_30(unknown)                                                                   = Chi                             : total:m1133_28, partial:m1133_29
-#-----|     r0_27(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)           = Load[#temp0:0]                  : &:r0_21, ~m1133_30
-# 1133|     r1133_31(bool)                                                                      = Call[operator!=]                : func:r1133_23, this:r0_20, 0:r0_27
-#-----|     v0_28(void)                                                                         = ^IndirectReadSideEffect[-1]     : &:r0_20, m1133_20
+#-----|     r0_22(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)           = Load[#temp0:0]                  : &:r0_17, ~m1133_30
+# 1133|     r1133_31(bool)                                                                      = Call[operator!=]                : func:r1133_23, this:r1133_22, 0:r0_22
+#-----|     v0_23(void)                                                                         = ^IndirectReadSideEffect[-1]     : &:r1133_22, m1133_20
 # 1133|     v1133_32(void)                                                                      = ConditionalBranch               : r1133_31
 #-----|   False -> Block 10
 #-----|   True -> Block 8
@@ -10178,16 +10082,14 @@ ir.cpp:
 # 1133|   Block 8
 # 1133|     r1133_40(glval<int &>)                                                              = VariableAddress[e]          : 
 # 1133|     r1133_41(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>) = VariableAddress[(__begin)]  : 
-#-----|     r0_29(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>)    = Convert                     : r1133_41
 # 1133|     r1133_42(glval<unknown>)                                                            = FunctionAddress[operator*]  : 
-# 1133|     r1133_43(int &)                                                                     = Call[operator*]             : func:r1133_42, this:r0_29
-#-----|     v0_30(void)                                                                         = ^IndirectReadSideEffect[-1] : &:r0_29, m1133_20
+# 1133|     r1133_43(int &)                                                                     = Call[operator*]             : func:r1133_42, this:r1133_41
+#-----|     v0_24(void)                                                                         = ^IndirectReadSideEffect[-1] : &:r1133_41, m1133_20
 # 1133|     r1133_44(glval<int>)                                                                = CopyValue                   : r1133_43
-# 1133|     r1133_45(glval<int>)                                                                = Convert                     : r1133_44
-# 1133|     r1133_46(int &)                                                                     = CopyValue                   : r1133_45
-# 1133|     m1133_47(int &)                                                                     = Store[e]                    : &:r1133_40, r1133_46
+# 1133|     r1133_45(int &)                                                                     = CopyValue                   : r1133_44
+# 1133|     m1133_46(int &)                                                                     = Store[e]                    : &:r1133_40, r1133_45
 # 1134|     r1134_1(glval<int &>)                                                               = VariableAddress[e]          : 
-# 1134|     r1134_2(int &)                                                                      = Load[e]                     : &:r1134_1, m1133_47
+# 1134|     r1134_2(int &)                                                                      = Load[e]                     : &:r1134_1, m1133_46
 # 1134|     r1134_3(int)                                                                        = Load[?]                     : &:r1134_2, ~m1133_30
 # 1134|     r1134_4(int)                                                                        = Constant[5]                 : 
 # 1134|     r1134_5(bool)                                                                       = CompareLT                   : r1134_3, r1134_4
@@ -10902,25 +10804,23 @@ ir.cpp:
 # 1303|     r1303_3(char *)            = Convert                      : r1303_2
 # 1303|     r1303_4(glval<char *>)     = VariableAddress[s1]          : 
 # 1303|     r1303_5(char *)            = Load[s1]                     : &:r1303_4, m1300_6
-# 1303|     r1303_6(char *)            = Convert                      : r1303_5
-# 1303|     r1303_7(char *)            = Call[strcpy]                 : func:r1303_1, 0:r1303_3, 1:r1303_6
-# 1303|     v1303_8(void)              = ^BufferReadSideEffect[1]     : &:r1303_6, ~m1300_8
-# 1303|     m1303_9(unknown)           = ^BufferMayWriteSideEffect[0] : &:r1303_3
-# 1303|     m1303_10(unknown)          = Chi                          : total:m1301_13, partial:m1303_9
+# 1303|     r1303_6(char *)            = Call[strcpy]                 : func:r1303_1, 0:r1303_3, 1:r1303_5
+# 1303|     v1303_7(void)              = ^BufferReadSideEffect[1]     : &:r1303_5, ~m1300_8
+# 1303|     m1303_8(unknown)           = ^BufferMayWriteSideEffect[0] : &:r1303_3
+# 1303|     m1303_9(unknown)           = Chi                          : total:m1301_13, partial:m1303_8
 # 1304|     r1304_1(glval<unknown>)    = FunctionAddress[strcat]      : 
 # 1304|     r1304_2(glval<char[1024]>) = VariableAddress[buffer]      : 
 # 1304|     r1304_3(char *)            = Convert                      : r1304_2
 # 1304|     r1304_4(glval<char *>)     = VariableAddress[s2]          : 
 # 1304|     r1304_5(char *)            = Load[s2]                     : &:r1304_4, m1300_11
-# 1304|     r1304_6(char *)            = Convert                      : r1304_5
-# 1304|     r1304_7(char *)            = Call[strcat]                 : func:r1304_1, 0:r1304_3, 1:r1304_6
-# 1304|     v1304_8(void)              = ^BufferReadSideEffect[0]     : &:r1304_3, ~m1303_10
-# 1304|     v1304_9(void)              = ^BufferReadSideEffect[1]     : &:r1304_6, ~m1300_13
-# 1304|     m1304_10(unknown)          = ^BufferMayWriteSideEffect[0] : &:r1304_3
-# 1304|     m1304_11(unknown)          = Chi                          : total:m1303_10, partial:m1304_10
+# 1304|     r1304_6(char *)            = Call[strcat]                 : func:r1304_1, 0:r1304_3, 1:r1304_5
+# 1304|     v1304_7(void)              = ^BufferReadSideEffect[0]     : &:r1304_3, ~m1303_9
+# 1304|     v1304_8(void)              = ^BufferReadSideEffect[1]     : &:r1304_5, ~m1300_13
+# 1304|     m1304_9(unknown)           = ^BufferMayWriteSideEffect[0] : &:r1304_3
+# 1304|     m1304_10(unknown)          = Chi                          : total:m1303_9, partial:m1304_9
 # 1305|     v1305_1(void)              = NoOp                         : 
-# 1300|     v1300_15(void)             = ReturnIndirection[s1]        : &:r1300_7, ~m1304_11
-# 1300|     v1300_16(void)             = ReturnIndirection[s2]        : &:r1300_12, ~m1304_11
+# 1300|     v1300_15(void)             = ReturnIndirection[s1]        : &:r1300_7, ~m1304_10
+# 1300|     v1300_16(void)             = ReturnIndirection[s2]        : &:r1300_12, ~m1304_10
 # 1300|     v1300_17(void)             = ReturnVoid                   : 
 # 1300|     v1300_18(void)             = AliasedUse                   : ~m1300_14
 # 1300|     v1300_19(void)             = ExitFunction                 : 
@@ -11546,21 +11446,19 @@ ir.cpp:
 # 1416|     m1416_6(unknown)         = Chi                               : total:m1415_7, partial:m1416_5
 # 1416|     m1416_7(String)          = Store[#temp1416:24]               : &:r1416_2, r1416_4
 # 1416|     m1416_8(unknown)         = Chi                               : total:m1416_6, partial:m1416_7
-# 1416|     r1416_9(glval<String>)   = Convert                           : r1416_2
-# 1416|     r1416_10(String &)       = CopyValue                         : r1416_9
-# 1416|     m1416_11(String &)       = Store[rs]                         : &:r1416_1, r1416_10
+# 1416|     r1416_9(String &)        = CopyValue                         : r1416_2
+# 1416|     m1416_10(String &)       = Store[rs]                         : &:r1416_1, r1416_9
 # 1418|     r1418_1(glval<unknown>)  = FunctionAddress[acceptRef]        : 
 # 1418|     r1418_2(glval<String>)   = VariableAddress[s]                : 
-# 1418|     r1418_3(glval<String>)   = Convert                           : r1418_2
-# 1418|     r1418_4(String &)        = CopyValue                         : r1418_3
-# 1418|     v1418_5(void)            = Call[acceptRef]                   : func:r1418_1, 0:r1418_4
-# 1418|     m1418_6(unknown)         = ^CallSideEffect                   : ~m1416_8
-# 1418|     m1418_7(unknown)         = Chi                               : total:m1416_8, partial:m1418_6
-# 1418|     v1418_8(void)            = ^BufferReadSideEffect[0]          : &:r1418_4, ~m1418_7
+# 1418|     r1418_3(String &)        = CopyValue                         : r1418_2
+# 1418|     v1418_4(void)            = Call[acceptRef]                   : func:r1418_1, 0:r1418_3
+# 1418|     m1418_5(unknown)         = ^CallSideEffect                   : ~m1416_8
+# 1418|     m1418_6(unknown)         = Chi                               : total:m1416_8, partial:m1418_5
+# 1418|     v1418_7(void)            = ^BufferReadSideEffect[0]          : &:r1418_3, ~m1418_6
 # 1419|     r1419_1(glval<unknown>)  = FunctionAddress[acceptRef]        : 
 # 1419|     r1419_2(glval<String>)   = VariableAddress[#temp1419:23]     : 
 # 1419|     m1419_3(String)          = Uninitialized[#temp1419:23]       : &:r1419_2
-# 1419|     m1419_4(unknown)         = Chi                               : total:m1418_7, partial:m1419_3
+# 1419|     m1419_4(unknown)         = Chi                               : total:m1418_6, partial:m1419_3
 # 1419|     r1419_5(glval<unknown>)  = FunctionAddress[String]           : 
 # 1419|     r1419_6(glval<char[4]>)  = StringConstant["foo"]             : 
 # 1419|     r1419_7(char *)          = Convert                           : r1419_6
@@ -11589,30 +11487,29 @@ ir.cpp:
 # 1420|     m1420_4(unknown)         = Chi                               : total:m1419_26, partial:m1420_3
 # 1420|     r1420_5(glval<unknown>)  = FunctionAddress[String]           : 
 # 1420|     r1420_6(glval<String>)   = VariableAddress[s]                : 
-# 1420|     r1420_7(glval<String>)   = Convert                           : r1420_6
-# 1420|     r1420_8(String &)        = CopyValue                         : r1420_7
-# 1420|     v1420_9(void)            = Call[String]                      : func:r1420_5, this:r1420_2, 0:r1420_8
-# 1420|     m1420_10(unknown)        = ^CallSideEffect                   : ~m1420_4
-# 1420|     m1420_11(unknown)        = Chi                               : total:m1420_4, partial:m1420_10
-# 1420|     v1420_12(void)           = ^BufferReadSideEffect[0]          : &:r1420_8, ~m1420_11
-# 1420|     m1420_13(String)         = ^IndirectMayWriteSideEffect[-1]   : &:r1420_2
-# 1420|     m1420_14(unknown)        = Chi                               : total:m1420_11, partial:m1420_13
-# 1420|     r1420_15(String)         = Load[#temp1420:17]                : &:r1420_2, ~m1420_14
-# 1420|     v1420_16(void)           = Call[acceptValue]                 : func:r1420_1, 0:r1420_15
-# 1420|     m1420_17(unknown)        = ^CallSideEffect                   : ~m1420_14
-# 1420|     m1420_18(unknown)        = Chi                               : total:m1420_14, partial:m1420_17
-# 1420|     r1420_19(glval<String>)  = CopyValue                         : r1420_2
-# 1420|     r1420_20(glval<unknown>) = FunctionAddress[~String]          : 
-# 1420|     v1420_21(void)           = Call[~String]                     : func:r1420_20, this:r1420_19
-# 1420|     m1420_22(unknown)        = ^CallSideEffect                   : ~m1420_18
-# 1420|     m1420_23(unknown)        = Chi                               : total:m1420_18, partial:m1420_22
-# 1420|     v1420_24(void)           = ^IndirectReadSideEffect[-1]       : &:r1420_19, ~m1420_23
-# 1420|     m1420_25(String)         = ^IndirectMayWriteSideEffect[-1]   : &:r1420_19
-# 1420|     m1420_26(unknown)        = Chi                               : total:m1420_23, partial:m1420_25
+# 1420|     r1420_7(String &)        = CopyValue                         : r1420_6
+# 1420|     v1420_8(void)            = Call[String]                      : func:r1420_5, this:r1420_2, 0:r1420_7
+# 1420|     m1420_9(unknown)         = ^CallSideEffect                   : ~m1420_4
+# 1420|     m1420_10(unknown)        = Chi                               : total:m1420_4, partial:m1420_9
+# 1420|     v1420_11(void)           = ^BufferReadSideEffect[0]          : &:r1420_7, ~m1420_10
+# 1420|     m1420_12(String)         = ^IndirectMayWriteSideEffect[-1]   : &:r1420_2
+# 1420|     m1420_13(unknown)        = Chi                               : total:m1420_10, partial:m1420_12
+# 1420|     r1420_14(String)         = Load[#temp1420:17]                : &:r1420_2, ~m1420_13
+# 1420|     v1420_15(void)           = Call[acceptValue]                 : func:r1420_1, 0:r1420_14
+# 1420|     m1420_16(unknown)        = ^CallSideEffect                   : ~m1420_13
+# 1420|     m1420_17(unknown)        = Chi                               : total:m1420_13, partial:m1420_16
+# 1420|     r1420_18(glval<String>)  = CopyValue                         : r1420_2
+# 1420|     r1420_19(glval<unknown>) = FunctionAddress[~String]          : 
+# 1420|     v1420_20(void)           = Call[~String]                     : func:r1420_19, this:r1420_18
+# 1420|     m1420_21(unknown)        = ^CallSideEffect                   : ~m1420_17
+# 1420|     m1420_22(unknown)        = Chi                               : total:m1420_17, partial:m1420_21
+# 1420|     v1420_23(void)           = ^IndirectReadSideEffect[-1]       : &:r1420_18, ~m1420_22
+# 1420|     m1420_24(String)         = ^IndirectMayWriteSideEffect[-1]   : &:r1420_18
+# 1420|     m1420_25(unknown)        = Chi                               : total:m1420_22, partial:m1420_24
 # 1421|     r1421_1(glval<unknown>)  = FunctionAddress[acceptValue]      : 
 # 1421|     r1421_2(glval<String>)   = VariableAddress[#temp1421:25]     : 
 # 1421|     m1421_3(String)          = Uninitialized[#temp1421:25]       : &:r1421_2
-# 1421|     m1421_4(unknown)         = Chi                               : total:m1420_26, partial:m1421_3
+# 1421|     m1421_4(unknown)         = Chi                               : total:m1420_25, partial:m1421_3
 # 1421|     r1421_5(glval<unknown>)  = FunctionAddress[String]           : 
 # 1421|     r1421_6(glval<char[4]>)  = StringConstant["foo"]             : 
 # 1421|     r1421_7(char *)          = Convert                           : r1421_6
@@ -11643,46 +11540,44 @@ ir.cpp:
 # 1422|     m1422_7(unknown)         = Chi                               : total:m1422_3, partial:m1422_6
 # 1422|     m1422_8(String)          = ^IndirectMayWriteSideEffect[-1]   : &:r1422_1
 # 1422|     m1422_9(unknown)         = Chi                               : total:m1422_7, partial:m1422_8
-# 1422|     r1422_10(glval<String>)  = Convert                           : r1422_1
-# 1422|     r1422_11(glval<unknown>) = FunctionAddress[c_str]            : 
-# 1422|     r1422_12(char *)         = Call[c_str]                       : func:r1422_11, this:r1422_10
-# 1422|     m1422_13(unknown)        = ^CallSideEffect                   : ~m1422_9
-# 1422|     m1422_14(unknown)        = Chi                               : total:m1422_9, partial:m1422_13
-# 1422|     v1422_15(void)           = ^IndirectReadSideEffect[-1]       : &:r1422_10, ~m1422_14
-# 1422|     r1422_16(glval<String>)  = CopyValue                         : r1422_1
-# 1422|     r1422_17(glval<unknown>) = FunctionAddress[~String]          : 
-# 1422|     v1422_18(void)           = Call[~String]                     : func:r1422_17, this:r1422_16
-# 1422|     m1422_19(unknown)        = ^CallSideEffect                   : ~m1422_14
-# 1422|     m1422_20(unknown)        = Chi                               : total:m1422_14, partial:m1422_19
-# 1422|     v1422_21(void)           = ^IndirectReadSideEffect[-1]       : &:r1422_16, ~m1422_20
-# 1422|     m1422_22(String)         = ^IndirectMayWriteSideEffect[-1]   : &:r1422_16
-# 1422|     m1422_23(unknown)        = Chi                               : total:m1422_20, partial:m1422_22
+# 1422|     r1422_10(glval<unknown>) = FunctionAddress[c_str]            : 
+# 1422|     r1422_11(char *)         = Call[c_str]                       : func:r1422_10, this:r1422_1
+# 1422|     m1422_12(unknown)        = ^CallSideEffect                   : ~m1422_9
+# 1422|     m1422_13(unknown)        = Chi                               : total:m1422_9, partial:m1422_12
+# 1422|     v1422_14(void)           = ^IndirectReadSideEffect[-1]       : &:r1422_1, ~m1422_13
+# 1422|     r1422_15(glval<String>)  = CopyValue                         : r1422_1
+# 1422|     r1422_16(glval<unknown>) = FunctionAddress[~String]          : 
+# 1422|     v1422_17(void)           = Call[~String]                     : func:r1422_16, this:r1422_15
+# 1422|     m1422_18(unknown)        = ^CallSideEffect                   : ~m1422_13
+# 1422|     m1422_19(unknown)        = Chi                               : total:m1422_13, partial:m1422_18
+# 1422|     v1422_20(void)           = ^IndirectReadSideEffect[-1]       : &:r1422_15, ~m1422_19
+# 1422|     m1422_21(String)         = ^IndirectMayWriteSideEffect[-1]   : &:r1422_15
+# 1422|     m1422_22(unknown)        = Chi                               : total:m1422_19, partial:m1422_21
 # 1423|     r1423_1(glval<String>)   = VariableAddress[#temp1423:5]      : 
 # 1423|     r1423_2(glval<unknown>)  = FunctionAddress[returnValue]      : 
 # 1423|     r1423_3(String)          = Call[returnValue]                 : func:r1423_2
-# 1423|     m1423_4(unknown)         = ^CallSideEffect                   : ~m1422_23
-# 1423|     m1423_5(unknown)         = Chi                               : total:m1422_23, partial:m1423_4
+# 1423|     m1423_4(unknown)         = ^CallSideEffect                   : ~m1422_22
+# 1423|     m1423_5(unknown)         = Chi                               : total:m1422_22, partial:m1423_4
 # 1423|     m1423_6(String)          = Store[#temp1423:5]                : &:r1423_1, r1423_3
 # 1423|     m1423_7(unknown)         = Chi                               : total:m1423_5, partial:m1423_6
-# 1423|     r1423_8(glval<String>)   = Convert                           : r1423_1
-# 1423|     r1423_9(glval<unknown>)  = FunctionAddress[c_str]            : 
-# 1423|     r1423_10(char *)         = Call[c_str]                       : func:r1423_9, this:r1423_8
-# 1423|     m1423_11(unknown)        = ^CallSideEffect                   : ~m1423_7
-# 1423|     m1423_12(unknown)        = Chi                               : total:m1423_7, partial:m1423_11
-# 1423|     v1423_13(void)           = ^IndirectReadSideEffect[-1]       : &:r1423_8, ~m1423_12
-# 1423|     r1423_14(glval<String>)  = CopyValue                         : r1423_1
-# 1423|     r1423_15(glval<unknown>) = FunctionAddress[~String]          : 
-# 1423|     v1423_16(void)           = Call[~String]                     : func:r1423_15, this:r1423_14
-# 1423|     m1423_17(unknown)        = ^CallSideEffect                   : ~m1423_12
-# 1423|     m1423_18(unknown)        = Chi                               : total:m1423_12, partial:m1423_17
-# 1423|     v1423_19(void)           = ^IndirectReadSideEffect[-1]       : &:r1423_14, ~m1423_18
-# 1423|     m1423_20(String)         = ^IndirectMayWriteSideEffect[-1]   : &:r1423_14
-# 1423|     m1423_21(unknown)        = Chi                               : total:m1423_18, partial:m1423_20
+# 1423|     r1423_8(glval<unknown>)  = FunctionAddress[c_str]            : 
+# 1423|     r1423_9(char *)          = Call[c_str]                       : func:r1423_8, this:r1423_1
+# 1423|     m1423_10(unknown)        = ^CallSideEffect                   : ~m1423_7
+# 1423|     m1423_11(unknown)        = Chi                               : total:m1423_7, partial:m1423_10
+# 1423|     v1423_12(void)           = ^IndirectReadSideEffect[-1]       : &:r1423_1, ~m1423_11
+# 1423|     r1423_13(glval<String>)  = CopyValue                         : r1423_1
+# 1423|     r1423_14(glval<unknown>) = FunctionAddress[~String]          : 
+# 1423|     v1423_15(void)           = Call[~String]                     : func:r1423_14, this:r1423_13
+# 1423|     m1423_16(unknown)        = ^CallSideEffect                   : ~m1423_11
+# 1423|     m1423_17(unknown)        = Chi                               : total:m1423_11, partial:m1423_16
+# 1423|     v1423_18(void)           = ^IndirectReadSideEffect[-1]       : &:r1423_13, ~m1423_17
+# 1423|     m1423_19(String)         = ^IndirectMayWriteSideEffect[-1]   : &:r1423_13
+# 1423|     m1423_20(unknown)        = Chi                               : total:m1423_17, partial:m1423_19
 # 1425|     r1425_1(glval<String>)   = VariableAddress[#temp1425:5]      : 
 # 1425|     r1425_2(glval<unknown>)  = FunctionAddress[defaultConstruct] : 
 # 1425|     r1425_3(String)          = Call[defaultConstruct]            : func:r1425_2
-# 1425|     m1425_4(unknown)         = ^CallSideEffect                   : ~m1423_21
-# 1425|     m1425_5(unknown)         = Chi                               : total:m1423_21, partial:m1425_4
+# 1425|     m1425_4(unknown)         = ^CallSideEffect                   : ~m1423_20
+# 1425|     m1425_5(unknown)         = Chi                               : total:m1423_20, partial:m1425_4
 # 1425|     m1425_6(String)          = Store[#temp1425:5]                : &:r1425_1, r1425_3
 # 1425|     m1425_7(unknown)         = Chi                               : total:m1425_5, partial:m1425_6
 # 1425|     r1425_8(glval<String>)   = CopyValue                         : r1425_1
@@ -11735,26 +11630,24 @@ ir.cpp:
 # 1430|     m1430_6(unknown)                  = Chi                               : total:m1429_7, partial:m1430_5
 # 1430|     m1430_7(destructor_only)          = Store[#temp1430:33]               : &:r1430_2, r1430_4
 # 1430|     m1430_8(unknown)                  = Chi                               : total:m1430_6, partial:m1430_7
-# 1430|     r1430_9(glval<destructor_only>)   = Convert                           : r1430_2
-# 1430|     r1430_10(destructor_only &)       = CopyValue                         : r1430_9
-# 1430|     m1430_11(destructor_only &)       = Store[rd]                         : &:r1430_1, r1430_10
+# 1430|     r1430_9(destructor_only &)        = CopyValue                         : r1430_2
+# 1430|     m1430_10(destructor_only &)       = Store[rd]                         : &:r1430_1, r1430_9
 # 1431|     r1431_1(glval<destructor_only>)   = VariableAddress[d2]               : 
 # 1431|     m1431_2(destructor_only)          = Uninitialized[d2]                 : &:r1431_1
 # 1431|     m1431_3(unknown)                  = Chi                               : total:m1430_8, partial:m1431_2
 # 1432|     r1432_1(glval<unknown>)           = FunctionAddress[acceptRef]        : 
 # 1432|     r1432_2(glval<destructor_only>)   = VariableAddress[d]                : 
-# 1432|     r1432_3(glval<destructor_only>)   = Convert                           : r1432_2
-# 1432|     r1432_4(destructor_only &)        = CopyValue                         : r1432_3
-# 1432|     v1432_5(void)                     = Call[acceptRef]                   : func:r1432_1, 0:r1432_4
-# 1432|     m1432_6(unknown)                  = ^CallSideEffect                   : ~m1431_3
-# 1432|     m1432_7(unknown)                  = Chi                               : total:m1431_3, partial:m1432_6
-# 1432|     v1432_8(void)                     = ^BufferReadSideEffect[0]          : &:r1432_4, ~m1432_7
+# 1432|     r1432_3(destructor_only &)        = CopyValue                         : r1432_2
+# 1432|     v1432_4(void)                     = Call[acceptRef]                   : func:r1432_1, 0:r1432_3
+# 1432|     m1432_5(unknown)                  = ^CallSideEffect                   : ~m1431_3
+# 1432|     m1432_6(unknown)                  = Chi                               : total:m1431_3, partial:m1432_5
+# 1432|     v1432_7(void)                     = ^BufferReadSideEffect[0]          : &:r1432_3, ~m1432_6
 # 1433|     r1433_1(glval<unknown>)           = FunctionAddress[acceptValue]      : 
 # 1433|     r1433_2(glval<destructor_only>)   = VariableAddress[#temp1433:17]     : 
 # 1433|     r1433_3(glval<destructor_only>)   = VariableAddress[d]                : 
-# 1433|     r1433_4(destructor_only)          = Load[d]                           : &:r1433_3, ~m1432_7
+# 1433|     r1433_4(destructor_only)          = Load[d]                           : &:r1433_3, ~m1432_6
 # 1433|     m1433_5(destructor_only)          = Store[#temp1433:17]               : &:r1433_2, r1433_4
-# 1433|     m1433_6(unknown)                  = Chi                               : total:m1432_7, partial:m1433_5
+# 1433|     m1433_6(unknown)                  = Chi                               : total:m1432_6, partial:m1433_5
 # 1433|     r1433_7(destructor_only)          = Load[#temp1433:17]                : &:r1433_2, m1433_5
 # 1433|     v1433_8(void)                     = Call[acceptValue]                 : func:r1433_1, 0:r1433_7
 # 1433|     m1433_9(unknown)                  = ^CallSideEffect                   : ~m1433_6
@@ -11872,9 +11765,8 @@ ir.cpp:
 # 1442|     m1442_5(unknown)                   = ^CallSideEffect                   : ~m1441_7
 # 1442|     m1442_6(unknown)                   = Chi                               : total:m1441_7, partial:m1442_5
 # 1442|     m1442_7(copy_constructor)          = Store[#temp1442:34]               : &:r1442_2, r1442_4
-# 1442|     r1442_8(glval<copy_constructor>)   = Convert                           : r1442_2
-# 1442|     r1442_9(copy_constructor &)        = CopyValue                         : r1442_8
-# 1442|     m1442_10(copy_constructor &)       = Store[rd]                         : &:r1442_1, r1442_9
+# 1442|     r1442_8(copy_constructor &)        = CopyValue                         : r1442_2
+# 1442|     m1442_9(copy_constructor &)        = Store[rd]                         : &:r1442_1, r1442_8
 # 1443|     r1443_1(glval<copy_constructor>)   = VariableAddress[d2]               : 
 # 1443|     m1443_2(copy_constructor)          = Uninitialized[d2]                 : &:r1443_1
 # 1443|     m1443_3(unknown)                   = Chi                               : total:m1442_6, partial:m1443_2
@@ -11886,33 +11778,31 @@ ir.cpp:
 # 1443|     m1443_9(unknown)                   = Chi                               : total:m1443_7, partial:m1443_8
 # 1444|     r1444_1(glval<unknown>)            = FunctionAddress[acceptRef]        : 
 # 1444|     r1444_2(glval<copy_constructor>)   = VariableAddress[d]                : 
-# 1444|     r1444_3(glval<copy_constructor>)   = Convert                           : r1444_2
-# 1444|     r1444_4(copy_constructor &)        = CopyValue                         : r1444_3
-# 1444|     v1444_5(void)                      = Call[acceptRef]                   : func:r1444_1, 0:r1444_4
-# 1444|     m1444_6(unknown)                   = ^CallSideEffect                   : ~m1443_9
-# 1444|     m1444_7(unknown)                   = Chi                               : total:m1443_9, partial:m1444_6
-# 1444|     v1444_8(void)                      = ^BufferReadSideEffect[0]          : &:r1444_4, ~m1444_7
+# 1444|     r1444_3(copy_constructor &)        = CopyValue                         : r1444_2
+# 1444|     v1444_4(void)                      = Call[acceptRef]                   : func:r1444_1, 0:r1444_3
+# 1444|     m1444_5(unknown)                   = ^CallSideEffect                   : ~m1443_9
+# 1444|     m1444_6(unknown)                   = Chi                               : total:m1443_9, partial:m1444_5
+# 1444|     v1444_7(void)                      = ^BufferReadSideEffect[0]          : &:r1444_3, ~m1444_6
 # 1445|     r1445_1(glval<unknown>)            = FunctionAddress[acceptValue]      : 
 # 1445|     r1445_2(glval<copy_constructor>)   = VariableAddress[#temp1445:17]     : 
 # 1445|     m1445_3(copy_constructor)          = Uninitialized[#temp1445:17]       : &:r1445_2
-# 1445|     m1445_4(unknown)                   = Chi                               : total:m1444_7, partial:m1445_3
+# 1445|     m1445_4(unknown)                   = Chi                               : total:m1444_6, partial:m1445_3
 # 1445|     r1445_5(glval<unknown>)            = FunctionAddress[copy_constructor] : 
 # 1445|     r1445_6(glval<copy_constructor>)   = VariableAddress[d]                : 
-# 1445|     r1445_7(glval<copy_constructor>)   = Convert                           : r1445_6
-# 1445|     r1445_8(copy_constructor &)        = CopyValue                         : r1445_7
-# 1445|     v1445_9(void)                      = Call[copy_constructor]            : func:r1445_5, this:r1445_2, 0:r1445_8
-# 1445|     m1445_10(unknown)                  = ^CallSideEffect                   : ~m1445_4
-# 1445|     m1445_11(unknown)                  = Chi                               : total:m1445_4, partial:m1445_10
-# 1445|     v1445_12(void)                     = ^BufferReadSideEffect[0]          : &:r1445_8, ~m1445_11
-# 1445|     m1445_13(copy_constructor)         = ^IndirectMayWriteSideEffect[-1]   : &:r1445_2
-# 1445|     m1445_14(unknown)                  = Chi                               : total:m1445_11, partial:m1445_13
-# 1445|     r1445_15(copy_constructor)         = Load[#temp1445:17]                : &:r1445_2, ~m1445_14
-# 1445|     v1445_16(void)                     = Call[acceptValue]                 : func:r1445_1, 0:r1445_15
-# 1445|     m1445_17(unknown)                  = ^CallSideEffect                   : ~m1445_14
-# 1445|     m1445_18(unknown)                  = Chi                               : total:m1445_14, partial:m1445_17
+# 1445|     r1445_7(copy_constructor &)        = CopyValue                         : r1445_6
+# 1445|     v1445_8(void)                      = Call[copy_constructor]            : func:r1445_5, this:r1445_2, 0:r1445_7
+# 1445|     m1445_9(unknown)                   = ^CallSideEffect                   : ~m1445_4
+# 1445|     m1445_10(unknown)                  = Chi                               : total:m1445_4, partial:m1445_9
+# 1445|     v1445_11(void)                     = ^BufferReadSideEffect[0]          : &:r1445_7, ~m1445_10
+# 1445|     m1445_12(copy_constructor)         = ^IndirectMayWriteSideEffect[-1]   : &:r1445_2
+# 1445|     m1445_13(unknown)                  = Chi                               : total:m1445_10, partial:m1445_12
+# 1445|     r1445_14(copy_constructor)         = Load[#temp1445:17]                : &:r1445_2, ~m1445_13
+# 1445|     v1445_15(void)                     = Call[acceptValue]                 : func:r1445_1, 0:r1445_14
+# 1445|     m1445_16(unknown)                  = ^CallSideEffect                   : ~m1445_13
+# 1445|     m1445_17(unknown)                  = Chi                               : total:m1445_13, partial:m1445_16
 # 1446|     r1446_1(glval<copy_constructor>)   = VariableAddress[#temp1446:5]      : 
 # 1446|     m1446_2(copy_constructor)          = Uninitialized[#temp1446:5]        : &:r1446_1
-# 1446|     m1446_3(unknown)                   = Chi                               : total:m1445_18, partial:m1446_2
+# 1446|     m1446_3(unknown)                   = Chi                               : total:m1445_17, partial:m1446_2
 # 1446|     r1446_4(glval<unknown>)            = FunctionAddress[copy_constructor] : 
 # 1446|     v1446_5(void)                      = Call[copy_constructor]            : func:r1446_4, this:r1446_1
 # 1446|     m1446_6(unknown)                   = ^CallSideEffect                   : ~m1446_3
@@ -11981,23 +11871,21 @@ ir.cpp:
 # 1455|     m1455_5(unknown)        = ^CallSideEffect                   : ~m1454_7
 # 1455|     m1455_6(unknown)        = Chi                               : total:m1454_7, partial:m1455_5
 # 1455|     m1455_7(Point)          = Store[#temp1455:23]               : &:r1455_2, r1455_4
-# 1455|     r1455_8(glval<Point>)   = Convert                           : r1455_2
-# 1455|     r1455_9(Point &)        = CopyValue                         : r1455_8
-# 1455|     m1455_10(Point &)       = Store[rp]                         : &:r1455_1, r1455_9
+# 1455|     r1455_8(Point &)        = CopyValue                         : r1455_2
+# 1455|     m1455_9(Point &)        = Store[rp]                         : &:r1455_1, r1455_8
 # 1457|     r1457_1(glval<unknown>) = FunctionAddress[acceptRef]        : 
 # 1457|     r1457_2(glval<Point>)   = VariableAddress[p]                : 
-# 1457|     r1457_3(glval<Point>)   = Convert                           : r1457_2
-# 1457|     r1457_4(Point &)        = CopyValue                         : r1457_3
-# 1457|     v1457_5(void)           = Call[acceptRef]                   : func:r1457_1, 0:r1457_4
-# 1457|     m1457_6(unknown)        = ^CallSideEffect                   : ~m1455_6
-# 1457|     m1457_7(unknown)        = Chi                               : total:m1455_6, partial:m1457_6
-# 1457|     v1457_8(void)           = ^BufferReadSideEffect[0]          : &:r1457_4, ~m1457_7
+# 1457|     r1457_3(Point &)        = CopyValue                         : r1457_2
+# 1457|     v1457_4(void)           = Call[acceptRef]                   : func:r1457_1, 0:r1457_3
+# 1457|     m1457_5(unknown)        = ^CallSideEffect                   : ~m1455_6
+# 1457|     m1457_6(unknown)        = Chi                               : total:m1455_6, partial:m1457_5
+# 1457|     v1457_7(void)           = ^BufferReadSideEffect[0]          : &:r1457_3, ~m1457_6
 # 1458|     r1458_1(glval<unknown>) = FunctionAddress[acceptValue]      : 
 # 1458|     r1458_2(glval<Point>)   = VariableAddress[p]                : 
-# 1458|     r1458_3(Point)          = Load[p]                           : &:r1458_2, ~m1457_7
+# 1458|     r1458_3(Point)          = Load[p]                           : &:r1458_2, ~m1457_6
 # 1458|     v1458_4(void)           = Call[acceptValue]                 : func:r1458_1, 0:r1458_3
-# 1458|     m1458_5(unknown)        = ^CallSideEffect                   : ~m1457_7
-# 1458|     m1458_6(unknown)        = Chi                               : total:m1457_7, partial:m1458_5
+# 1458|     m1458_5(unknown)        = ^CallSideEffect                   : ~m1457_6
+# 1458|     m1458_6(unknown)        = Chi                               : total:m1457_6, partial:m1458_5
 # 1459|     r1459_1(int)            = Constant[0]                       : 
 # 1460|     r1460_1(glval<int>)     = VariableAddress[y]                : 
 # 1460|     r1460_2(glval<unknown>) = FunctionAddress[returnValue]      : 
@@ -12034,9 +11922,8 @@ ir.cpp:
 # 1471|     r1471_8(glval<int &>)         = FieldAddress[r]               : r1471_6
 # 1471|     r1471_9(int &)                = Load[?]                       : &:r1471_8, ~m1471_7
 # 1471|     r1471_10(glval<int>)          = CopyValue                     : r1471_9
-# 1471|     r1471_11(glval<int>)          = Convert                       : r1471_10
-# 1471|     r1471_12(int &)               = CopyValue                     : r1471_11
-# 1471|     m1471_13(int &)               = Store[rx]                     : &:r1471_1, r1471_12
+# 1471|     r1471_11(int &)               = CopyValue                     : r1471_10
+# 1471|     m1471_12(int &)               = Store[rx]                     : &:r1471_1, r1471_11
 # 1472|     r1472_1(glval<int>)           = VariableAddress[x]            : 
 # 1472|     r1472_2(glval<unknown>)       = FunctionAddress[returnValue]  : 
 # 1472|     r1472_3(UnusualFields)        = Call[returnValue]             : func:r1472_2
@@ -12059,9 +11946,8 @@ ir.cpp:
 # 1474|     r1474_9(float *)              = Convert                       : r1474_8
 # 1474|     r1474_10(int)                 = Constant[3]                   : 
 # 1474|     r1474_11(glval<float>)        = PointerAdd[4]                 : r1474_9, r1474_10
-# 1474|     r1474_12(glval<float>)        = Convert                       : r1474_11
-# 1474|     r1474_13(float &)             = CopyValue                     : r1474_12
-# 1474|     m1474_14(float &)             = Store[rf]                     : &:r1474_1, r1474_13
+# 1474|     r1474_12(float &)             = CopyValue                     : r1474_11
+# 1474|     m1474_13(float &)             = Store[rf]                     : &:r1474_1, r1474_12
 # 1475|     r1475_1(glval<float>)         = VariableAddress[f]            : 
 # 1475|     r1475_2(glval<unknown>)       = FunctionAddress[returnValue]  : 
 # 1475|     r1475_3(UnusualFields)        = Call[returnValue]             : func:r1475_2
@@ -12129,12 +12015,11 @@ ir.cpp:
 # 1496|     m1496_7(unknown)            = Chi                                               : total:m1496_5, partial:m1496_6
 #-----|     r0_9(glval<POD_Middle>)     = ConvertToNonVirtualBase[POD_Derived : POD_Middle] : r0_8
 #-----|     r0_10(glval<POD_Base>)      = ConvertToNonVirtualBase[POD_Middle : POD_Base]    : r0_9
-#-----|     r0_11(glval<POD_Base>)      = Convert                                           : r0_10
 # 1496|     r1496_8(glval<unknown>)     = FunctionAddress[f]                                : 
-# 1496|     r1496_9(float)              = Call[f]                                           : func:r1496_8, this:r0_11
+# 1496|     r1496_9(float)              = Call[f]                                           : func:r1496_8, this:r0_10
 # 1496|     m1496_10(unknown)           = ^CallSideEffect                                   : ~m1496_7
 # 1496|     m1496_11(unknown)           = Chi                                               : total:m1496_7, partial:m1496_10
-#-----|     v0_12(void)                 = ^IndirectReadSideEffect[-1]                       : &:r0_11, ~m1496_11
+#-----|     v0_11(void)                 = ^IndirectReadSideEffect[-1]                       : &:r0_10, ~m1496_11
 # 1496|     m1496_12(float)             = Store[f]                                          : &:r1496_1, r1496_9
 # 1497|     v1497_1(void)               = NoOp                                              : 
 # 1492|     v1492_5(void)               = ReturnVoid                                        : 
@@ -13210,9 +13095,8 @@ ir.cpp:
 # 1734|     m1734_7(unknown)                          = Chi                                  : total:m1732_4, partial:m1734_6
 # 1734|     m1734_8(CapturedLambdaMyObj)              = ^IndirectMayWriteSideEffect[-1]      : &:r1734_2
 # 1734|     m1734_9(CapturedLambdaMyObj)              = Chi                                  : total:m1734_3, partial:m1734_8
-# 1734|     r1734_10(glval<CapturedLambdaMyObj>)      = Convert                              : r1734_2
-# 1734|     r1734_11(CapturedLambdaMyObj &)           = CopyValue                            : r1734_10
-# 1734|     m1734_12(CapturedLambdaMyObj &)           = Store[obj1]                          : &:r1734_1, r1734_11
+# 1734|     r1734_10(CapturedLambdaMyObj &)           = CopyValue                            : r1734_2
+# 1734|     m1734_11(CapturedLambdaMyObj &)           = Store[obj1]                          : &:r1734_1, r1734_10
 # 1735|     r1735_1(glval<CapturedLambdaMyObj>)       = VariableAddress[obj2]                : 
 # 1735|     m1735_2(CapturedLambdaMyObj)              = Uninitialized[obj2]                  : &:r1735_1
 # 1735|     r1735_3(glval<unknown>)                   = FunctionAddress[CapturedLambdaMyObj] : 
@@ -13226,7 +13110,7 @@ ir.cpp:
 # 1737|     m1737_3(decltype([...](...){...}))        = Uninitialized[#temp1737:24]          : &:r1737_2
 # 1737|     r1737_4(glval<CapturedLambdaMyObj>)       = FieldAddress[obj1]                   : r1737_2
 # 1737|     r1737_5(glval<CapturedLambdaMyObj &>)     = VariableAddress[obj1]                : 
-# 1737|     r1737_6(CapturedLambdaMyObj &)            = Load[obj1]                           : &:r1737_5, m1734_12
+# 1737|     r1737_6(CapturedLambdaMyObj &)            = Load[obj1]                           : &:r1737_5, m1734_11
 #-----|     r0_1(CapturedLambdaMyObj)                 = Load[?]                              : &:r1737_6, m1734_9
 #-----|     m0_2(CapturedLambdaMyObj)                 = Store[?]                             : &:r1737_4, r0_1
 #-----|     m0_3(decltype([...](...){...}))           = Chi                                  : total:m1737_3, partial:m0_2
@@ -13463,9 +13347,8 @@ ir.cpp:
 # 1763|     r1763_2(glval<TrivialLambdaClass>)        = VariableAddress[#temp1763:36] : 
 # 1763|     r1763_3(TrivialLambdaClass)               = Constant[0]                   : 
 # 1763|     m1763_4(TrivialLambdaClass)               = Store[#temp1763:36]           : &:r1763_2, r1763_3
-# 1763|     r1763_5(glval<TrivialLambdaClass>)        = Convert                       : r1763_2
-# 1763|     r1763_6(TrivialLambdaClass &)             = CopyValue                     : r1763_5
-# 1763|     m1763_7(TrivialLambdaClass &)             = Store[l2]                     : &:r1763_1, r1763_6
+# 1763|     r1763_5(TrivialLambdaClass &)             = CopyValue                     : r1763_2
+# 1763|     m1763_6(TrivialLambdaClass &)             = Store[l2]                     : &:r1763_1, r1763_5
 # 1765|     r1765_1(glval<decltype([...](...){...})>) = VariableAddress[l_outer1]     : 
 # 1765|     r1765_2(glval<decltype([...](...){...})>) = VariableAddress[#temp1765:20] : 
 # 1765|     m1765_3(decltype([...](...){...}))        = Uninitialized[#temp1765:20]   : &:r1765_2
@@ -13493,7 +13376,7 @@ ir.cpp:
 # 1765|     m1765_19(decltype([...](...){...}))       = Chi                           : total:m0_6, partial:m1765_18
 # 1765|     r1765_20(glval<TrivialLambdaClass>)       = FieldAddress[l2]              : r1765_2
 # 1765|     r1765_21(glval<TrivialLambdaClass &>)     = VariableAddress[l2]           : 
-# 1765|     r1765_22(TrivialLambdaClass &)            = Load[l2]                      : &:r1765_21, m1763_7
+# 1765|     r1765_22(TrivialLambdaClass &)            = Load[l2]                      : &:r1765_21, m1763_6
 #-----|     r0_7(TrivialLambdaClass)                  = Load[?]                       : &:r1765_22, m1763_4
 #-----|     m0_8(TrivialLambdaClass)                  = Store[?]                      : &:r1765_20, r0_7
 #-----|     m0_9(decltype([...](...){...}))           = Chi                           : total:m1765_19, partial:m0_8
@@ -14152,12 +14035,11 @@ ir.cpp:
 # 1878|     r1878_3(glval<char *>)   = VariableAddress[global_string]  : 
 # 1878|     r1878_4(glval<char[14]>) = StringConstant["global string"] : 
 # 1878|     r1878_5(char *)          = Convert                         : r1878_4
-# 1878|     r1878_6(char *)          = Convert                         : r1878_5
-# 1878|     m1878_7(char *)          = Store[global_string]            : &:r1878_3, r1878_6
-# 1878|     m1878_8(unknown)         = Chi                             : total:m1878_2, partial:m1878_7
-# 1878|     v1878_9(void)            = ReturnVoid                      : 
-# 1878|     v1878_10(void)           = AliasedUse                      : ~m1878_8
-# 1878|     v1878_11(void)           = ExitFunction                    : 
+# 1878|     m1878_6(char *)          = Store[global_string]            : &:r1878_3, r1878_5
+# 1878|     m1878_7(unknown)         = Chi                             : total:m1878_2, partial:m1878_6
+# 1878|     v1878_8(void)            = ReturnVoid                      : 
+# 1878|     v1878_9(void)            = AliasedUse                      : ~m1878_7
+# 1878|     v1878_10(void)           = ExitFunction                    : 
 
 # 1880| int global_6
 # 1880|   Block 0
@@ -15338,19 +15220,18 @@ ir.cpp:
 #-----|   True -> Block 2
 
 # 2081|   Block 1
-# 2081|     m2081_6(glval<TernaryNonPodObj>)  = Phi                             : from 2:m2081_21, from 3:m2081_24
+# 2081|     m2081_6(glval<TernaryNonPodObj>)  = Phi                             : from 2:m2081_20, from 3:m2081_23
 # 2081|     r2081_7(glval<unknown>)           = VariableAddress[#temp2081:9]    : 
 # 2081|     r2081_8(glval<TernaryNonPodObj>)  = Load[#temp2081:9]               : &:r2081_7, m2081_6
-# 2081|     r2081_9(glval<TernaryNonPodObj>)  = Convert                         : r2081_8
-# 2081|     r2081_10(TernaryNonPodObj &)      = CopyValue                       : r2081_9
-# 2081|     r2081_11(TernaryNonPodObj &)      = Call[operator=]                 : func:r2081_2, this:r2081_1, 0:r2081_10
-# 2081|     m2081_12(unknown)                 = ^CallSideEffect                 : ~m2080_4
-# 2081|     m2081_13(unknown)                 = Chi                             : total:m2080_4, partial:m2081_12
-# 2081|     v2081_14(void)                    = ^IndirectReadSideEffect[-1]     : &:r2081_1, m2080_15
-# 2081|     v2081_15(void)                    = ^BufferReadSideEffect[0]        : &:r2081_10, ~m2080_13
-# 2081|     m2081_16(TernaryNonPodObj)        = ^IndirectMayWriteSideEffect[-1] : &:r2081_1
-# 2081|     m2081_17(TernaryNonPodObj)        = Chi                             : total:m2080_15, partial:m2081_16
-# 2081|     r2081_18(glval<TernaryNonPodObj>) = CopyValue                       : r2081_11
+# 2081|     r2081_9(TernaryNonPodObj &)       = CopyValue                       : r2081_8
+# 2081|     r2081_10(TernaryNonPodObj &)      = Call[operator=]                 : func:r2081_2, this:r2081_1, 0:r2081_9
+# 2081|     m2081_11(unknown)                 = ^CallSideEffect                 : ~m2080_4
+# 2081|     m2081_12(unknown)                 = Chi                             : total:m2080_4, partial:m2081_11
+# 2081|     v2081_13(void)                    = ^IndirectReadSideEffect[-1]     : &:r2081_1, m2080_15
+# 2081|     v2081_14(void)                    = ^BufferReadSideEffect[0]        : &:r2081_9, ~m2080_13
+# 2081|     m2081_15(TernaryNonPodObj)        = ^IndirectMayWriteSideEffect[-1] : &:r2081_1
+# 2081|     m2081_16(TernaryNonPodObj)        = Chi                             : total:m2080_15, partial:m2081_15
+# 2081|     r2081_17(glval<TernaryNonPodObj>) = CopyValue                       : r2081_10
 # 2082|     r2082_1(glval<TernaryNonPodObj>)  = VariableAddress[z]              : 
 # 2082|     r2082_2(glval<unknown>)           = FunctionAddress[operator=]      : 
 # 2082|     r2082_3(glval<TernaryNonPodObj>)  = VariableAddress[#temp2082:9]    : 
@@ -15361,42 +15242,41 @@ ir.cpp:
 #-----|   True -> Block 5
 
 # 2081|   Block 2
-# 2081|     r2081_19(glval<TernaryNonPodObj>) = VariableAddress[x]           : 
-# 2081|     r2081_20(glval<unknown>)          = VariableAddress[#temp2081:9] : 
-# 2081|     m2081_21(glval<TernaryNonPodObj>) = Store[#temp2081:9]           : &:r2081_20, r2081_19
+# 2081|     r2081_18(glval<TernaryNonPodObj>) = VariableAddress[x]           : 
+# 2081|     r2081_19(glval<unknown>)          = VariableAddress[#temp2081:9] : 
+# 2081|     m2081_20(glval<TernaryNonPodObj>) = Store[#temp2081:9]           : &:r2081_19, r2081_18
 #-----|   Goto -> Block 1
 
 # 2081|   Block 3
-# 2081|     r2081_22(glval<TernaryNonPodObj>) = VariableAddress[y]           : 
-# 2081|     r2081_23(glval<unknown>)          = VariableAddress[#temp2081:9] : 
-# 2081|     m2081_24(glval<TernaryNonPodObj>) = Store[#temp2081:9]           : &:r2081_23, r2081_22
+# 2081|     r2081_21(glval<TernaryNonPodObj>) = VariableAddress[y]           : 
+# 2081|     r2081_22(glval<unknown>)          = VariableAddress[#temp2081:9] : 
+# 2081|     m2081_23(glval<TernaryNonPodObj>) = Store[#temp2081:9]           : &:r2081_22, r2081_21
 #-----|   Goto -> Block 1
 
 # 2082|   Block 4
-# 2082|     m2082_7(unknown)                  = Phi                                : from 5:~m2082_39, from 6:~m2082_51
-# 2082|     m2082_8(TernaryNonPodObj)         = Phi                                : from 5:m2082_45, from 6:m2082_56
+# 2082|     m2082_7(unknown)                  = Phi                                : from 5:~m2082_37, from 6:~m2082_49
+# 2082|     m2082_8(TernaryNonPodObj)         = Phi                                : from 5:m2082_43, from 6:m2082_54
 # 2082|     r2082_9(glval<TernaryNonPodObj>)  = VariableAddress[#temp2082:9]       : 
 # 2082|     r2082_10(TernaryNonPodObj)        = Load[#temp2082:9]                  : &:r2082_9, m2082_8
 # 2082|     m2082_11(TernaryNonPodObj)        = Store[#temp2082:9]                 : &:r2082_3, r2082_10
 # 2082|     m2082_12(unknown)                 = Chi                                : total:m2082_7, partial:m2082_11
-# 2082|     r2082_13(glval<TernaryNonPodObj>) = Convert                            : r2082_3
-# 2082|     r2082_14(TernaryNonPodObj &)      = CopyValue                          : r2082_13
-# 2082|     r2082_15(TernaryNonPodObj &)      = Call[operator=]                    : func:r2082_2, this:r2082_1, 0:r2082_14
-# 2082|     m2082_16(unknown)                 = ^CallSideEffect                    : ~m2082_12
-# 2082|     m2082_17(unknown)                 = Chi                                : total:m2082_12, partial:m2082_16
-# 2082|     v2082_18(void)                    = ^IndirectReadSideEffect[-1]        : &:r2082_1, m2081_17
-# 2082|     v2082_19(void)                    = ^BufferReadSideEffect[0]           : &:r2082_14, ~m2082_17
-# 2082|     m2082_20(TernaryNonPodObj)        = ^IndirectMayWriteSideEffect[-1]    : &:r2082_1
-# 2082|     m2082_21(TernaryNonPodObj)        = Chi                                : total:m2081_17, partial:m2082_20
-# 2082|     r2082_22(glval<TernaryNonPodObj>) = CopyValue                          : r2082_3
-# 2082|     r2082_23(glval<unknown>)          = FunctionAddress[~TernaryNonPodObj] : 
-# 2082|     v2082_24(void)                    = Call[~TernaryNonPodObj]            : func:r2082_23, this:r2082_22
-# 2082|     m2082_25(unknown)                 = ^CallSideEffect                    : ~m2082_17
-# 2082|     m2082_26(unknown)                 = Chi                                : total:m2082_17, partial:m2082_25
-# 2082|     v2082_27(void)                    = ^IndirectReadSideEffect[-1]        : &:r2082_22, ~m2082_26
-# 2082|     m2082_28(TernaryNonPodObj)        = ^IndirectMayWriteSideEffect[-1]    : &:r2082_22
-# 2082|     m2082_29(unknown)                 = Chi                                : total:m2082_26, partial:m2082_28
-# 2082|     r2082_30(glval<TernaryNonPodObj>) = CopyValue                          : r2082_15
+# 2082|     r2082_13(TernaryNonPodObj &)      = CopyValue                          : r2082_3
+# 2082|     r2082_14(TernaryNonPodObj &)      = Call[operator=]                    : func:r2082_2, this:r2082_1, 0:r2082_13
+# 2082|     m2082_15(unknown)                 = ^CallSideEffect                    : ~m2082_12
+# 2082|     m2082_16(unknown)                 = Chi                                : total:m2082_12, partial:m2082_15
+# 2082|     v2082_17(void)                    = ^IndirectReadSideEffect[-1]        : &:r2082_1, m2081_16
+# 2082|     v2082_18(void)                    = ^BufferReadSideEffect[0]           : &:r2082_13, ~m2082_16
+# 2082|     m2082_19(TernaryNonPodObj)        = ^IndirectMayWriteSideEffect[-1]    : &:r2082_1
+# 2082|     m2082_20(TernaryNonPodObj)        = Chi                                : total:m2081_16, partial:m2082_19
+# 2082|     r2082_21(glval<TernaryNonPodObj>) = CopyValue                          : r2082_3
+# 2082|     r2082_22(glval<unknown>)          = FunctionAddress[~TernaryNonPodObj] : 
+# 2082|     v2082_23(void)                    = Call[~TernaryNonPodObj]            : func:r2082_22, this:r2082_21
+# 2082|     m2082_24(unknown)                 = ^CallSideEffect                    : ~m2082_16
+# 2082|     m2082_25(unknown)                 = Chi                                : total:m2082_16, partial:m2082_24
+# 2082|     v2082_26(void)                    = ^IndirectReadSideEffect[-1]        : &:r2082_21, ~m2082_25
+# 2082|     m2082_27(TernaryNonPodObj)        = ^IndirectMayWriteSideEffect[-1]    : &:r2082_21
+# 2082|     m2082_28(unknown)                 = Chi                                : total:m2082_25, partial:m2082_27
+# 2082|     r2082_29(glval<TernaryNonPodObj>) = CopyValue                          : r2082_14
 # 2083|     r2083_1(glval<TernaryNonPodObj>)  = VariableAddress[z]                 : 
 # 2083|     r2083_2(glval<unknown>)           = FunctionAddress[operator=]         : 
 # 2083|     r2083_3(glval<TernaryNonPodObj>)  = VariableAddress[#temp2083:9]       : 
@@ -15407,62 +15287,60 @@ ir.cpp:
 #-----|   True -> Block 8
 
 # 2082|   Block 5
-# 2082|     r2082_31(glval<TernaryNonPodObj>) = VariableAddress[#temp2082:13]     : 
-# 2082|     m2082_32(TernaryNonPodObj)        = Uninitialized[#temp2082:13]       : &:r2082_31
-# 2082|     r2082_33(glval<unknown>)          = FunctionAddress[TernaryNonPodObj] : 
-# 2082|     r2082_34(glval<TernaryNonPodObj>) = VariableAddress[x]                : 
-# 2082|     r2082_35(glval<TernaryNonPodObj>) = Convert                           : r2082_34
-# 2082|     r2082_36(TernaryNonPodObj &)      = CopyValue                         : r2082_35
-# 2082|     v2082_37(void)                    = Call[TernaryNonPodObj]            : func:r2082_33, this:r2082_31, 0:r2082_36
-# 2082|     m2082_38(unknown)                 = ^CallSideEffect                   : ~m2081_13
-# 2082|     m2082_39(unknown)                 = Chi                               : total:m2081_13, partial:m2082_38
-# 2082|     v2082_40(void)                    = ^BufferReadSideEffect[0]          : &:r2082_36, ~m2080_9
-# 2082|     m2082_41(TernaryNonPodObj)        = ^IndirectMayWriteSideEffect[-1]   : &:r2082_31
-# 2082|     m2082_42(TernaryNonPodObj)        = Chi                               : total:m2082_32, partial:m2082_41
-# 2082|     r2082_43(TernaryNonPodObj)        = Load[#temp2082:13]                : &:r2082_31, m2082_42
-# 2082|     r2082_44(glval<TernaryNonPodObj>) = VariableAddress[#temp2082:9]      : 
-# 2082|     m2082_45(TernaryNonPodObj)        = Store[#temp2082:9]                : &:r2082_44, r2082_43
+# 2082|     r2082_30(glval<TernaryNonPodObj>) = VariableAddress[#temp2082:13]     : 
+# 2082|     m2082_31(TernaryNonPodObj)        = Uninitialized[#temp2082:13]       : &:r2082_30
+# 2082|     r2082_32(glval<unknown>)          = FunctionAddress[TernaryNonPodObj] : 
+# 2082|     r2082_33(glval<TernaryNonPodObj>) = VariableAddress[x]                : 
+# 2082|     r2082_34(TernaryNonPodObj &)      = CopyValue                         : r2082_33
+# 2082|     v2082_35(void)                    = Call[TernaryNonPodObj]            : func:r2082_32, this:r2082_30, 0:r2082_34
+# 2082|     m2082_36(unknown)                 = ^CallSideEffect                   : ~m2081_12
+# 2082|     m2082_37(unknown)                 = Chi                               : total:m2081_12, partial:m2082_36
+# 2082|     v2082_38(void)                    = ^BufferReadSideEffect[0]          : &:r2082_34, ~m2080_9
+# 2082|     m2082_39(TernaryNonPodObj)        = ^IndirectMayWriteSideEffect[-1]   : &:r2082_30
+# 2082|     m2082_40(TernaryNonPodObj)        = Chi                               : total:m2082_31, partial:m2082_39
+# 2082|     r2082_41(TernaryNonPodObj)        = Load[#temp2082:13]                : &:r2082_30, m2082_40
+# 2082|     r2082_42(glval<TernaryNonPodObj>) = VariableAddress[#temp2082:9]      : 
+# 2082|     m2082_43(TernaryNonPodObj)        = Store[#temp2082:9]                : &:r2082_42, r2082_41
 #-----|   Goto -> Block 4
 
 # 2082|   Block 6
-# 2082|     r2082_46(glval<TernaryNonPodObj>) = VariableAddress[#temp2082:17]     : 
-# 2082|     m2082_47(TernaryNonPodObj)        = Uninitialized[#temp2082:17]       : &:r2082_46
-# 2082|     r2082_48(glval<unknown>)          = FunctionAddress[TernaryNonPodObj] : 
-# 2082|     v2082_49(void)                    = Call[TernaryNonPodObj]            : func:r2082_48, this:r2082_46
-# 2082|     m2082_50(unknown)                 = ^CallSideEffect                   : ~m2081_13
-# 2082|     m2082_51(unknown)                 = Chi                               : total:m2081_13, partial:m2082_50
-# 2082|     m2082_52(TernaryNonPodObj)        = ^IndirectMayWriteSideEffect[-1]   : &:r2082_46
-# 2082|     m2082_53(TernaryNonPodObj)        = Chi                               : total:m2082_47, partial:m2082_52
-# 2082|     r2082_54(TernaryNonPodObj)        = Load[#temp2082:17]                : &:r2082_46, m2082_53
-# 2082|     r2082_55(glval<TernaryNonPodObj>) = VariableAddress[#temp2082:9]      : 
-# 2082|     m2082_56(TernaryNonPodObj)        = Store[#temp2082:9]                : &:r2082_55, r2082_54
+# 2082|     r2082_44(glval<TernaryNonPodObj>) = VariableAddress[#temp2082:17]     : 
+# 2082|     m2082_45(TernaryNonPodObj)        = Uninitialized[#temp2082:17]       : &:r2082_44
+# 2082|     r2082_46(glval<unknown>)          = FunctionAddress[TernaryNonPodObj] : 
+# 2082|     v2082_47(void)                    = Call[TernaryNonPodObj]            : func:r2082_46, this:r2082_44
+# 2082|     m2082_48(unknown)                 = ^CallSideEffect                   : ~m2081_12
+# 2082|     m2082_49(unknown)                 = Chi                               : total:m2081_12, partial:m2082_48
+# 2082|     m2082_50(TernaryNonPodObj)        = ^IndirectMayWriteSideEffect[-1]   : &:r2082_44
+# 2082|     m2082_51(TernaryNonPodObj)        = Chi                               : total:m2082_45, partial:m2082_50
+# 2082|     r2082_52(TernaryNonPodObj)        = Load[#temp2082:17]                : &:r2082_44, m2082_51
+# 2082|     r2082_53(glval<TernaryNonPodObj>) = VariableAddress[#temp2082:9]      : 
+# 2082|     m2082_54(TernaryNonPodObj)        = Store[#temp2082:9]                : &:r2082_53, r2082_52
 #-----|   Goto -> Block 4
 
 # 2083|   Block 7
-# 2083|     m2083_7(unknown)                  = Phi                                : from 8:~m2083_36, from 9:~m2083_47
-# 2083|     m2083_8(TernaryNonPodObj)         = Phi                                : from 8:m2083_41, from 9:m2083_52
+# 2083|     m2083_7(unknown)                  = Phi                                : from 8:~m2083_35, from 9:~m2083_46
+# 2083|     m2083_8(TernaryNonPodObj)         = Phi                                : from 8:m2083_40, from 9:m2083_51
 # 2083|     r2083_9(glval<TernaryNonPodObj>)  = VariableAddress[#temp2083:9]       : 
 # 2083|     r2083_10(TernaryNonPodObj)        = Load[#temp2083:9]                  : &:r2083_9, m2083_8
 # 2083|     m2083_11(TernaryNonPodObj)        = Store[#temp2083:9]                 : &:r2083_3, r2083_10
 # 2083|     m2083_12(unknown)                 = Chi                                : total:m2083_7, partial:m2083_11
-# 2083|     r2083_13(glval<TernaryNonPodObj>) = Convert                            : r2083_3
-# 2083|     r2083_14(TernaryNonPodObj &)      = CopyValue                          : r2083_13
-# 2083|     r2083_15(TernaryNonPodObj &)      = Call[operator=]                    : func:r2083_2, this:r2083_1, 0:r2083_14
-# 2083|     m2083_16(unknown)                 = ^CallSideEffect                    : ~m2083_12
-# 2083|     m2083_17(unknown)                 = Chi                                : total:m2083_12, partial:m2083_16
-# 2083|     v2083_18(void)                    = ^IndirectReadSideEffect[-1]        : &:r2083_1, m2082_21
-# 2083|     v2083_19(void)                    = ^BufferReadSideEffect[0]           : &:r2083_14, ~m2083_17
-# 2083|     m2083_20(TernaryNonPodObj)        = ^IndirectMayWriteSideEffect[-1]    : &:r2083_1
-# 2083|     m2083_21(TernaryNonPodObj)        = Chi                                : total:m2082_21, partial:m2083_20
-# 2083|     r2083_22(glval<TernaryNonPodObj>) = CopyValue                          : r2083_3
-# 2083|     r2083_23(glval<unknown>)          = FunctionAddress[~TernaryNonPodObj] : 
-# 2083|     v2083_24(void)                    = Call[~TernaryNonPodObj]            : func:r2083_23, this:r2083_22
-# 2083|     m2083_25(unknown)                 = ^CallSideEffect                    : ~m2083_17
-# 2083|     m2083_26(unknown)                 = Chi                                : total:m2083_17, partial:m2083_25
-# 2083|     v2083_27(void)                    = ^IndirectReadSideEffect[-1]        : &:r2083_22, ~m2083_26
-# 2083|     m2083_28(TernaryNonPodObj)        = ^IndirectMayWriteSideEffect[-1]    : &:r2083_22
-# 2083|     m2083_29(unknown)                 = Chi                                : total:m2083_26, partial:m2083_28
-# 2083|     r2083_30(glval<TernaryNonPodObj>) = CopyValue                          : r2083_15
+# 2083|     r2083_13(TernaryNonPodObj &)      = CopyValue                          : r2083_3
+# 2083|     r2083_14(TernaryNonPodObj &)      = Call[operator=]                    : func:r2083_2, this:r2083_1, 0:r2083_13
+# 2083|     m2083_15(unknown)                 = ^CallSideEffect                    : ~m2083_12
+# 2083|     m2083_16(unknown)                 = Chi                                : total:m2083_12, partial:m2083_15
+# 2083|     v2083_17(void)                    = ^IndirectReadSideEffect[-1]        : &:r2083_1, m2082_20
+# 2083|     v2083_18(void)                    = ^BufferReadSideEffect[0]           : &:r2083_13, ~m2083_16
+# 2083|     m2083_19(TernaryNonPodObj)        = ^IndirectMayWriteSideEffect[-1]    : &:r2083_1
+# 2083|     m2083_20(TernaryNonPodObj)        = Chi                                : total:m2082_20, partial:m2083_19
+# 2083|     r2083_21(glval<TernaryNonPodObj>) = CopyValue                          : r2083_3
+# 2083|     r2083_22(glval<unknown>)          = FunctionAddress[~TernaryNonPodObj] : 
+# 2083|     v2083_23(void)                    = Call[~TernaryNonPodObj]            : func:r2083_22, this:r2083_21
+# 2083|     m2083_24(unknown)                 = ^CallSideEffect                    : ~m2083_16
+# 2083|     m2083_25(unknown)                 = Chi                                : total:m2083_16, partial:m2083_24
+# 2083|     v2083_26(void)                    = ^IndirectReadSideEffect[-1]        : &:r2083_21, ~m2083_25
+# 2083|     m2083_27(TernaryNonPodObj)        = ^IndirectMayWriteSideEffect[-1]    : &:r2083_21
+# 2083|     m2083_28(unknown)                 = Chi                                : total:m2083_25, partial:m2083_27
+# 2083|     r2083_29(glval<TernaryNonPodObj>) = CopyValue                          : r2083_14
 # 2084|     r2084_1(glval<TernaryNonPodObj>)  = VariableAddress[z]                 : 
 # 2084|     r2084_2(glval<unknown>)           = FunctionAddress[operator=]         : 
 # 2084|     r2084_3(glval<bool>)              = VariableAddress[a]                 : 
@@ -15472,90 +15350,88 @@ ir.cpp:
 #-----|   True -> Block 11
 
 # 2083|   Block 8
-# 2083|     r2083_31(glval<TernaryNonPodObj>) = VariableAddress[#temp2083:13]     : 
-# 2083|     m2083_32(TernaryNonPodObj)        = Uninitialized[#temp2083:13]       : &:r2083_31
-# 2083|     r2083_33(glval<unknown>)          = FunctionAddress[TernaryNonPodObj] : 
-# 2083|     v2083_34(void)                    = Call[TernaryNonPodObj]            : func:r2083_33, this:r2083_31
-# 2083|     m2083_35(unknown)                 = ^CallSideEffect                   : ~m2082_29
-# 2083|     m2083_36(unknown)                 = Chi                               : total:m2082_29, partial:m2083_35
-# 2083|     m2083_37(TernaryNonPodObj)        = ^IndirectMayWriteSideEffect[-1]   : &:r2083_31
-# 2083|     m2083_38(TernaryNonPodObj)        = Chi                               : total:m2083_32, partial:m2083_37
-# 2083|     r2083_39(TernaryNonPodObj)        = Load[#temp2083:13]                : &:r2083_31, m2083_38
-# 2083|     r2083_40(glval<TernaryNonPodObj>) = VariableAddress[#temp2083:9]      : 
-# 2083|     m2083_41(TernaryNonPodObj)        = Store[#temp2083:9]                : &:r2083_40, r2083_39
+# 2083|     r2083_30(glval<TernaryNonPodObj>) = VariableAddress[#temp2083:13]     : 
+# 2083|     m2083_31(TernaryNonPodObj)        = Uninitialized[#temp2083:13]       : &:r2083_30
+# 2083|     r2083_32(glval<unknown>)          = FunctionAddress[TernaryNonPodObj] : 
+# 2083|     v2083_33(void)                    = Call[TernaryNonPodObj]            : func:r2083_32, this:r2083_30
+# 2083|     m2083_34(unknown)                 = ^CallSideEffect                   : ~m2082_28
+# 2083|     m2083_35(unknown)                 = Chi                               : total:m2082_28, partial:m2083_34
+# 2083|     m2083_36(TernaryNonPodObj)        = ^IndirectMayWriteSideEffect[-1]   : &:r2083_30
+# 2083|     m2083_37(TernaryNonPodObj)        = Chi                               : total:m2083_31, partial:m2083_36
+# 2083|     r2083_38(TernaryNonPodObj)        = Load[#temp2083:13]                : &:r2083_30, m2083_37
+# 2083|     r2083_39(glval<TernaryNonPodObj>) = VariableAddress[#temp2083:9]      : 
+# 2083|     m2083_40(TernaryNonPodObj)        = Store[#temp2083:9]                : &:r2083_39, r2083_38
 #-----|   Goto -> Block 7
 
 # 2083|   Block 9
-# 2083|     r2083_42(glval<TernaryNonPodObj>) = VariableAddress[#temp2083:34]     : 
-# 2083|     m2083_43(TernaryNonPodObj)        = Uninitialized[#temp2083:34]       : &:r2083_42
-# 2083|     r2083_44(glval<unknown>)          = FunctionAddress[TernaryNonPodObj] : 
-# 2083|     v2083_45(void)                    = Call[TernaryNonPodObj]            : func:r2083_44, this:r2083_42
-# 2083|     m2083_46(unknown)                 = ^CallSideEffect                   : ~m2082_29
-# 2083|     m2083_47(unknown)                 = Chi                               : total:m2082_29, partial:m2083_46
-# 2083|     m2083_48(TernaryNonPodObj)        = ^IndirectMayWriteSideEffect[-1]   : &:r2083_42
-# 2083|     m2083_49(TernaryNonPodObj)        = Chi                               : total:m2083_43, partial:m2083_48
-# 2083|     r2083_50(TernaryNonPodObj)        = Load[#temp2083:34]                : &:r2083_42, m2083_49
-# 2083|     r2083_51(glval<TernaryNonPodObj>) = VariableAddress[#temp2083:9]      : 
-# 2083|     m2083_52(TernaryNonPodObj)        = Store[#temp2083:9]                : &:r2083_51, r2083_50
+# 2083|     r2083_41(glval<TernaryNonPodObj>) = VariableAddress[#temp2083:34]     : 
+# 2083|     m2083_42(TernaryNonPodObj)        = Uninitialized[#temp2083:34]       : &:r2083_41
+# 2083|     r2083_43(glval<unknown>)          = FunctionAddress[TernaryNonPodObj] : 
+# 2083|     v2083_44(void)                    = Call[TernaryNonPodObj]            : func:r2083_43, this:r2083_41
+# 2083|     m2083_45(unknown)                 = ^CallSideEffect                   : ~m2082_28
+# 2083|     m2083_46(unknown)                 = Chi                               : total:m2082_28, partial:m2083_45
+# 2083|     m2083_47(TernaryNonPodObj)        = ^IndirectMayWriteSideEffect[-1]   : &:r2083_41
+# 2083|     m2083_48(TernaryNonPodObj)        = Chi                               : total:m2083_42, partial:m2083_47
+# 2083|     r2083_49(TernaryNonPodObj)        = Load[#temp2083:34]                : &:r2083_41, m2083_48
+# 2083|     r2083_50(glval<TernaryNonPodObj>) = VariableAddress[#temp2083:9]      : 
+# 2083|     m2083_51(TernaryNonPodObj)        = Store[#temp2083:9]                : &:r2083_50, r2083_49
 #-----|   Goto -> Block 7
 
 # 2084|   Block 10
-# 2084|     m2084_6(glval<TernaryNonPodObj>)  = Phi                                : from 11:m2084_49, from 12:m2084_52
+# 2084|     m2084_6(glval<TernaryNonPodObj>)  = Phi                                : from 11:m2084_47, from 12:m2084_50
 # 2084|     r2084_7(glval<unknown>)           = VariableAddress[#temp2084:10]      : 
 # 2084|     r2084_8(glval<TernaryNonPodObj>)  = Load[#temp2084:10]                 : &:r2084_7, m2084_6
-# 2084|     r2084_9(glval<TernaryNonPodObj>)  = Convert                            : r2084_8
-# 2084|     r2084_10(TernaryNonPodObj &)      = CopyValue                          : r2084_9
-# 2084|     r2084_11(TernaryNonPodObj &)      = Call[operator=]                    : func:r2084_2, this:r2084_1, 0:r2084_10
-# 2084|     m2084_12(unknown)                 = ^CallSideEffect                    : ~m2083_29
-# 2084|     m2084_13(unknown)                 = Chi                                : total:m2083_29, partial:m2084_12
-# 2084|     v2084_14(void)                    = ^IndirectReadSideEffect[-1]        : &:r2084_1, m2083_21
-# 2084|     v2084_15(void)                    = ^BufferReadSideEffect[0]           : &:r2084_10, ~m2080_13
-# 2084|     m2084_16(TernaryNonPodObj)        = ^IndirectMayWriteSideEffect[-1]    : &:r2084_1
-# 2084|     m2084_17(TernaryNonPodObj)        = Chi                                : total:m2083_21, partial:m2084_16
-# 2084|     r2084_18(glval<TernaryNonPodObj>) = CopyValue                          : r2084_11
-# 2084|     r2084_19(glval<unknown>)          = FunctionAddress[operator=]         : 
-# 2084|     r2084_20(glval<TernaryNonPodObj>) = VariableAddress[#temp2084:23]      : 
-# 2084|     m2084_21(TernaryNonPodObj)        = Uninitialized[#temp2084:23]        : &:r2084_20
-# 2084|     m2084_22(unknown)                 = Chi                                : total:m2084_13, partial:m2084_21
-# 2084|     r2084_23(glval<unknown>)          = FunctionAddress[TernaryNonPodObj]  : 
-# 2084|     v2084_24(void)                    = Call[TernaryNonPodObj]             : func:r2084_23, this:r2084_20
-# 2084|     m2084_25(unknown)                 = ^CallSideEffect                    : ~m2084_22
-# 2084|     m2084_26(unknown)                 = Chi                                : total:m2084_22, partial:m2084_25
-# 2084|     m2084_27(TernaryNonPodObj)        = ^IndirectMayWriteSideEffect[-1]    : &:r2084_20
-# 2084|     m2084_28(unknown)                 = Chi                                : total:m2084_26, partial:m2084_27
-# 2084|     r2084_29(glval<TernaryNonPodObj>) = Convert                            : r2084_20
-# 2084|     r2084_30(TernaryNonPodObj &)      = CopyValue                          : r2084_29
-# 2084|     r2084_31(TernaryNonPodObj &)      = Call[operator=]                    : func:r2084_19, this:r2084_18, 0:r2084_30
-# 2084|     m2084_32(unknown)                 = ^CallSideEffect                    : ~m2084_28
-# 2084|     m2084_33(unknown)                 = Chi                                : total:m2084_28, partial:m2084_32
-# 2084|     v2084_34(void)                    = ^IndirectReadSideEffect[-1]        : &:r2084_18, m2084_17
-# 2084|     v2084_35(void)                    = ^BufferReadSideEffect[0]           : &:r2084_30, ~m2084_33
-# 2084|     m2084_36(TernaryNonPodObj)        = ^IndirectMayWriteSideEffect[-1]    : &:r2084_18
-# 2084|     m2084_37(TernaryNonPodObj)        = Chi                                : total:m2084_17, partial:m2084_36
-# 2084|     r2084_38(glval<TernaryNonPodObj>) = CopyValue                          : r2084_20
-# 2084|     r2084_39(glval<unknown>)          = FunctionAddress[~TernaryNonPodObj] : 
-# 2084|     v2084_40(void)                    = Call[~TernaryNonPodObj]            : func:r2084_39, this:r2084_38
-# 2084|     m2084_41(unknown)                 = ^CallSideEffect                    : ~m2084_33
-# 2084|     m2084_42(unknown)                 = Chi                                : total:m2084_33, partial:m2084_41
-# 2084|     v2084_43(void)                    = ^IndirectReadSideEffect[-1]        : &:r2084_38, ~m2084_42
-# 2084|     m2084_44(TernaryNonPodObj)        = ^IndirectMayWriteSideEffect[-1]    : &:r2084_38
-# 2084|     m2084_45(unknown)                 = Chi                                : total:m2084_42, partial:m2084_44
-# 2084|     r2084_46(glval<TernaryNonPodObj>) = CopyValue                          : r2084_31
+# 2084|     r2084_9(TernaryNonPodObj &)       = CopyValue                          : r2084_8
+# 2084|     r2084_10(TernaryNonPodObj &)      = Call[operator=]                    : func:r2084_2, this:r2084_1, 0:r2084_9
+# 2084|     m2084_11(unknown)                 = ^CallSideEffect                    : ~m2083_28
+# 2084|     m2084_12(unknown)                 = Chi                                : total:m2083_28, partial:m2084_11
+# 2084|     v2084_13(void)                    = ^IndirectReadSideEffect[-1]        : &:r2084_1, m2083_20
+# 2084|     v2084_14(void)                    = ^BufferReadSideEffect[0]           : &:r2084_9, ~m2080_13
+# 2084|     m2084_15(TernaryNonPodObj)        = ^IndirectMayWriteSideEffect[-1]    : &:r2084_1
+# 2084|     m2084_16(TernaryNonPodObj)        = Chi                                : total:m2083_20, partial:m2084_15
+# 2084|     r2084_17(glval<TernaryNonPodObj>) = CopyValue                          : r2084_10
+# 2084|     r2084_18(glval<unknown>)          = FunctionAddress[operator=]         : 
+# 2084|     r2084_19(glval<TernaryNonPodObj>) = VariableAddress[#temp2084:23]      : 
+# 2084|     m2084_20(TernaryNonPodObj)        = Uninitialized[#temp2084:23]        : &:r2084_19
+# 2084|     m2084_21(unknown)                 = Chi                                : total:m2084_12, partial:m2084_20
+# 2084|     r2084_22(glval<unknown>)          = FunctionAddress[TernaryNonPodObj]  : 
+# 2084|     v2084_23(void)                    = Call[TernaryNonPodObj]             : func:r2084_22, this:r2084_19
+# 2084|     m2084_24(unknown)                 = ^CallSideEffect                    : ~m2084_21
+# 2084|     m2084_25(unknown)                 = Chi                                : total:m2084_21, partial:m2084_24
+# 2084|     m2084_26(TernaryNonPodObj)        = ^IndirectMayWriteSideEffect[-1]    : &:r2084_19
+# 2084|     m2084_27(unknown)                 = Chi                                : total:m2084_25, partial:m2084_26
+# 2084|     r2084_28(TernaryNonPodObj &)      = CopyValue                          : r2084_19
+# 2084|     r2084_29(TernaryNonPodObj &)      = Call[operator=]                    : func:r2084_18, this:r2084_17, 0:r2084_28
+# 2084|     m2084_30(unknown)                 = ^CallSideEffect                    : ~m2084_27
+# 2084|     m2084_31(unknown)                 = Chi                                : total:m2084_27, partial:m2084_30
+# 2084|     v2084_32(void)                    = ^IndirectReadSideEffect[-1]        : &:r2084_17, m2084_16
+# 2084|     v2084_33(void)                    = ^BufferReadSideEffect[0]           : &:r2084_28, ~m2084_31
+# 2084|     m2084_34(TernaryNonPodObj)        = ^IndirectMayWriteSideEffect[-1]    : &:r2084_17
+# 2084|     m2084_35(TernaryNonPodObj)        = Chi                                : total:m2084_16, partial:m2084_34
+# 2084|     r2084_36(glval<TernaryNonPodObj>) = CopyValue                          : r2084_19
+# 2084|     r2084_37(glval<unknown>)          = FunctionAddress[~TernaryNonPodObj] : 
+# 2084|     v2084_38(void)                    = Call[~TernaryNonPodObj]            : func:r2084_37, this:r2084_36
+# 2084|     m2084_39(unknown)                 = ^CallSideEffect                    : ~m2084_31
+# 2084|     m2084_40(unknown)                 = Chi                                : total:m2084_31, partial:m2084_39
+# 2084|     v2084_41(void)                    = ^IndirectReadSideEffect[-1]        : &:r2084_36, ~m2084_40
+# 2084|     m2084_42(TernaryNonPodObj)        = ^IndirectMayWriteSideEffect[-1]    : &:r2084_36
+# 2084|     m2084_43(unknown)                 = Chi                                : total:m2084_40, partial:m2084_42
+# 2084|     r2084_44(glval<TernaryNonPodObj>) = CopyValue                          : r2084_29
 # 2085|     v2085_1(void)                     = NoOp                               : 
 # 2080|     v2080_16(void)                    = ReturnVoid                         : 
-# 2080|     v2080_17(void)                    = AliasedUse                         : ~m2084_42
+# 2080|     v2080_17(void)                    = AliasedUse                         : ~m2084_40
 # 2080|     v2080_18(void)                    = ExitFunction                       : 
 
 # 2084|   Block 11
-# 2084|     r2084_47(glval<TernaryNonPodObj>) = VariableAddress[x]            : 
-# 2084|     r2084_48(glval<unknown>)          = VariableAddress[#temp2084:10] : 
-# 2084|     m2084_49(glval<TernaryNonPodObj>) = Store[#temp2084:10]           : &:r2084_48, r2084_47
+# 2084|     r2084_45(glval<TernaryNonPodObj>) = VariableAddress[x]            : 
+# 2084|     r2084_46(glval<unknown>)          = VariableAddress[#temp2084:10] : 
+# 2084|     m2084_47(glval<TernaryNonPodObj>) = Store[#temp2084:10]           : &:r2084_46, r2084_45
 #-----|   Goto -> Block 10
 
 # 2084|   Block 12
-# 2084|     r2084_50(glval<TernaryNonPodObj>) = VariableAddress[y]            : 
-# 2084|     r2084_51(glval<unknown>)          = VariableAddress[#temp2084:10] : 
-# 2084|     m2084_52(glval<TernaryNonPodObj>) = Store[#temp2084:10]           : &:r2084_51, r2084_50
+# 2084|     r2084_48(glval<TernaryNonPodObj>) = VariableAddress[y]            : 
+# 2084|     r2084_49(glval<unknown>)          = VariableAddress[#temp2084:10] : 
+# 2084|     m2084_50(glval<TernaryNonPodObj>) = Store[#temp2084:10]           : &:r2084_49, r2084_48
 #-----|   Goto -> Block 10
 
 # 2089| unsigned int CommaTest(unsigned int)
@@ -16080,17 +15956,16 @@ ir.cpp:
 # 2174|     r2174_2(glval<unknown>) = FunctionAddress[strtod]        : 
 # 2174|     r2174_3(glval<char *>)  = VariableAddress[s]             : 
 # 2174|     r2174_4(char *)         = Load[s]                        : &:r2174_3, m2172_6
-# 2174|     r2174_5(char *)         = Convert                        : r2174_4
-# 2174|     r2174_6(glval<char *>)  = VariableAddress[end]           : 
-# 2174|     r2174_7(char **)        = CopyValue                      : r2174_6
-# 2174|     r2174_8(double)         = Call[strtod]                   : func:r2174_2, 0:r2174_5, 1:r2174_7
-# 2174|     v2174_9(void)           = ^BufferReadSideEffect[0]       : &:r2174_5, ~m2172_8
-# 2174|     m2174_10(char *)        = ^IndirectMayWriteSideEffect[1] : &:r2174_7
-# 2174|     m2174_11(char *)        = Chi                            : total:m2173_2, partial:m2174_10
-# 2174|     m2174_12(double)        = Store[d]                       : &:r2174_1, r2174_8
+# 2174|     r2174_5(glval<char *>)  = VariableAddress[end]           : 
+# 2174|     r2174_6(char **)        = CopyValue                      : r2174_5
+# 2174|     r2174_7(double)         = Call[strtod]                   : func:r2174_2, 0:r2174_4, 1:r2174_6
+# 2174|     v2174_8(void)           = ^BufferReadSideEffect[0]       : &:r2174_4, ~m2172_8
+# 2174|     m2174_9(char *)         = ^IndirectMayWriteSideEffect[1] : &:r2174_6
+# 2174|     m2174_10(char *)        = Chi                            : total:m2173_2, partial:m2174_9
+# 2174|     m2174_11(double)        = Store[d]                       : &:r2174_1, r2174_7
 # 2175|     r2175_1(glval<char *>)  = VariableAddress[#return]       : 
 # 2175|     r2175_2(glval<char *>)  = VariableAddress[end]           : 
-# 2175|     r2175_3(char *)         = Load[end]                      : &:r2175_2, m2174_11
+# 2175|     r2175_3(char *)         = Load[end]                      : &:r2175_2, m2174_10
 # 2175|     m2175_4(char *)         = Store[#return]                 : &:r2175_1, r2175_3
 # 2172|     v2172_10(void)          = ReturnIndirection[s]           : &:r2172_7, m2172_8
 # 2172|     r2172_11(glval<char *>) = VariableAddress[#return]       : 
@@ -16455,19 +16330,17 @@ ir.cpp:
 # 2216|     r2216_24(glval<vector<ClassWithDestructor> &>)                                                                                      = VariableAddress[(__range)]            : 
 # 2216|     r2216_25(vector<ClassWithDestructor> &)                                                                                             = Load[(__range)]                       : &:r2216_24, m2216_22
 #-----|     r0_1(glval<vector<ClassWithDestructor>>)                                                                                            = CopyValue                             : r2216_25
-#-----|     r0_2(glval<vector<ClassWithDestructor>>)                                                                                            = Convert                               : r0_1
 # 2216|     r2216_26(glval<unknown>)                                                                                                            = FunctionAddress[begin]                : 
-# 2216|     r2216_27(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)        = Call[begin]                           : func:r2216_26, this:r0_2
-#-----|     v0_3(void)                                                                                                                          = ^IndirectReadSideEffect[-1]           : &:r0_2, m2216_10
+# 2216|     r2216_27(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)        = Call[begin]                           : func:r2216_26, this:r0_1
+#-----|     v0_2(void)                                                                                                                          = ^IndirectReadSideEffect[-1]           : &:r0_1, m2216_10
 # 2216|     m2216_28(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)        = Store[(__begin)]                      : &:r2216_23, r2216_27
 # 2216|     r2216_29(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>) = VariableAddress[(__end)]              : 
 # 2216|     r2216_30(glval<vector<ClassWithDestructor> &>)                                                                                      = VariableAddress[(__range)]            : 
 # 2216|     r2216_31(vector<ClassWithDestructor> &)                                                                                             = Load[(__range)]                       : &:r2216_30, m2216_22
-#-----|     r0_4(glval<vector<ClassWithDestructor>>)                                                                                            = CopyValue                             : r2216_31
-#-----|     r0_5(glval<vector<ClassWithDestructor>>)                                                                                            = Convert                               : r0_4
+#-----|     r0_3(glval<vector<ClassWithDestructor>>)                                                                                            = CopyValue                             : r2216_31
 # 2216|     r2216_32(glval<unknown>)                                                                                                            = FunctionAddress[end]                  : 
-# 2216|     r2216_33(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)        = Call[end]                             : func:r2216_32, this:r0_5
-#-----|     v0_6(void)                                                                                                                          = ^IndirectReadSideEffect[-1]           : &:r0_5, m2216_10
+# 2216|     r2216_33(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)        = Call[end]                             : func:r2216_32, this:r0_3
+#-----|     v0_4(void)                                                                                                                          = ^IndirectReadSideEffect[-1]           : &:r0_3, m2216_10
 # 2216|     m2216_34(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)        = Store[(__end)]                        : &:r2216_29, r2216_33
 # 2216|     m2216_35(unknown)                                                                                                                   = Chi                                   : total:m2216_15, partial:m2216_34
 #-----|   Goto -> Block 8
@@ -16476,24 +16349,22 @@ ir.cpp:
 # 2216|     m2216_36(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)        = Phi                             : from 7:m2216_28, from 9:m2216_60
 # 2216|     m2216_37(unknown)                                                                                                                   = Phi                             : from 7:~m2216_35, from 9:~m2216_65
 # 2216|     r2216_38(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>) = VariableAddress[(__begin)]      : 
-#-----|     r0_7(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>)     = Convert                         : r2216_38
 # 2216|     r2216_39(glval<unknown>)                                                                                                            = FunctionAddress[operator!=]     : 
-#-----|     r0_8(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>)     = VariableAddress[#temp0:0]       : 
-#-----|     m0_9(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)            = Uninitialized[#temp0:0]         : &:r0_8
-#-----|     m0_10(unknown)                                                                                                                      = Chi                             : total:m2216_37, partial:m0_9
+#-----|     r0_5(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>)     = VariableAddress[#temp0:0]       : 
+#-----|     m0_6(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)            = Uninitialized[#temp0:0]         : &:r0_5
+#-----|     m0_7(unknown)                                                                                                                       = Chi                             : total:m2216_37, partial:m0_6
 # 2216|     r2216_40(glval<unknown>)                                                                                                            = FunctionAddress[iterator]       : 
 # 2216|     r2216_41(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>) = VariableAddress[(__end)]        : 
-#-----|     r0_11(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>)    = Convert                         : r2216_41
-#-----|     r0_12(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &> &)         = CopyValue                       : r0_11
-# 2216|     v2216_42(void)                                                                                                                      = Call[iterator]                  : func:r2216_40, this:r0_8, 0:r0_12
-# 2216|     m2216_43(unknown)                                                                                                                   = ^CallSideEffect                 : ~m0_10
-# 2216|     m2216_44(unknown)                                                                                                                   = Chi                             : total:m0_10, partial:m2216_43
-#-----|     v0_13(void)                                                                                                                         = ^BufferReadSideEffect[0]        : &:r0_12, ~m2216_44
-# 2216|     m2216_45(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)        = ^IndirectMayWriteSideEffect[-1] : &:r0_8
+#-----|     r0_8(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &> &)          = CopyValue                       : r2216_41
+# 2216|     v2216_42(void)                                                                                                                      = Call[iterator]                  : func:r2216_40, this:r0_5, 0:r0_8
+# 2216|     m2216_43(unknown)                                                                                                                   = ^CallSideEffect                 : ~m0_7
+# 2216|     m2216_44(unknown)                                                                                                                   = Chi                             : total:m0_7, partial:m2216_43
+#-----|     v0_9(void)                                                                                                                          = ^BufferReadSideEffect[0]        : &:r0_8, ~m2216_44
+# 2216|     m2216_45(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)        = ^IndirectMayWriteSideEffect[-1] : &:r0_5
 # 2216|     m2216_46(unknown)                                                                                                                   = Chi                             : total:m2216_44, partial:m2216_45
-#-----|     r0_14(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)           = Load[#temp0:0]                  : &:r0_8, ~m2216_46
-# 2216|     r2216_47(bool)                                                                                                                      = Call[operator!=]                : func:r2216_39, this:r0_7, 0:r0_14
-#-----|     v0_15(void)                                                                                                                         = ^IndirectReadSideEffect[-1]     : &:r0_7, m2216_36
+#-----|     r0_10(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)           = Load[#temp0:0]                  : &:r0_5, ~m2216_46
+# 2216|     r2216_47(bool)                                                                                                                      = Call[operator!=]                : func:r2216_39, this:r2216_38, 0:r0_10
+#-----|     v0_11(void)                                                                                                                         = ^IndirectReadSideEffect[-1]     : &:r2216_38, m2216_36
 # 2216|     v2216_48(void)                                                                                                                      = ConditionalBranch               : r2216_47
 #-----|   False -> Block 10
 #-----|   True -> Block 9
@@ -16501,10 +16372,9 @@ ir.cpp:
 # 2216|   Block 9
 # 2216|     r2216_49(glval<ClassWithDestructor>)                                                                                                = VariableAddress[y]                    : 
 # 2216|     r2216_50(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>) = VariableAddress[(__begin)]            : 
-#-----|     r0_16(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>)    = Convert                               : r2216_50
 # 2216|     r2216_51(glval<unknown>)                                                                                                            = FunctionAddress[operator*]            : 
-# 2216|     r2216_52(ClassWithDestructor &)                                                                                                     = Call[operator*]                       : func:r2216_51, this:r0_16
-#-----|     v0_17(void)                                                                                                                         = ^IndirectReadSideEffect[-1]           : &:r0_16, m2216_36
+# 2216|     r2216_52(ClassWithDestructor &)                                                                                                     = Call[operator*]                       : func:r2216_51, this:r2216_50
+#-----|     v0_12(void)                                                                                                                         = ^IndirectReadSideEffect[-1]           : &:r2216_50, m2216_36
 # 2216|     r2216_53(ClassWithDestructor)                                                                                                       = Load[?]                               : &:r2216_52, ~m2216_46
 # 2216|     m2216_54(ClassWithDestructor)                                                                                                       = Store[y]                              : &:r2216_49, r2216_53
 # 2217|     r2217_1(glval<ClassWithDestructor>)                                                                                                 = VariableAddress[y]                    : 
@@ -16564,20 +16434,18 @@ ir.cpp:
 # 2219|     r2219_23(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>) = VariableAddress[(__begin)]            : 
 # 2219|     r2219_24(glval<vector<ClassWithDestructor> &>)                                                                                      = VariableAddress[(__range)]            : 
 # 2219|     r2219_25(vector<ClassWithDestructor> &)                                                                                             = Load[(__range)]                       : &:r2219_24, m2219_22
-#-----|     r0_18(glval<vector<ClassWithDestructor>>)                                                                                           = CopyValue                             : r2219_25
-#-----|     r0_19(glval<vector<ClassWithDestructor>>)                                                                                           = Convert                               : r0_18
+#-----|     r0_13(glval<vector<ClassWithDestructor>>)                                                                                           = CopyValue                             : r2219_25
 # 2219|     r2219_26(glval<unknown>)                                                                                                            = FunctionAddress[begin]                : 
-# 2219|     r2219_27(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)        = Call[begin]                           : func:r2219_26, this:r0_19
-#-----|     v0_20(void)                                                                                                                         = ^IndirectReadSideEffect[-1]           : &:r0_19, m2219_10
+# 2219|     r2219_27(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)        = Call[begin]                           : func:r2219_26, this:r0_13
+#-----|     v0_14(void)                                                                                                                         = ^IndirectReadSideEffect[-1]           : &:r0_13, m2219_10
 # 2219|     m2219_28(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)        = Store[(__begin)]                      : &:r2219_23, r2219_27
 # 2219|     r2219_29(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>) = VariableAddress[(__end)]              : 
 # 2219|     r2219_30(glval<vector<ClassWithDestructor> &>)                                                                                      = VariableAddress[(__range)]            : 
 # 2219|     r2219_31(vector<ClassWithDestructor> &)                                                                                             = Load[(__range)]                       : &:r2219_30, m2219_22
-#-----|     r0_21(glval<vector<ClassWithDestructor>>)                                                                                           = CopyValue                             : r2219_31
-#-----|     r0_22(glval<vector<ClassWithDestructor>>)                                                                                           = Convert                               : r0_21
+#-----|     r0_15(glval<vector<ClassWithDestructor>>)                                                                                           = CopyValue                             : r2219_31
 # 2219|     r2219_32(glval<unknown>)                                                                                                            = FunctionAddress[end]                  : 
-# 2219|     r2219_33(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)        = Call[end]                             : func:r2219_32, this:r0_22
-#-----|     v0_23(void)                                                                                                                         = ^IndirectReadSideEffect[-1]           : &:r0_22, m2219_10
+# 2219|     r2219_33(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)        = Call[end]                             : func:r2219_32, this:r0_15
+#-----|     v0_16(void)                                                                                                                         = ^IndirectReadSideEffect[-1]           : &:r0_15, m2219_10
 # 2219|     m2219_34(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)        = Store[(__end)]                        : &:r2219_29, r2219_33
 # 2219|     m2219_35(unknown)                                                                                                                   = Chi                                   : total:m2219_15, partial:m2219_34
 #-----|   Goto -> Block 11
@@ -16586,24 +16454,22 @@ ir.cpp:
 # 2219|     m2219_36(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)        = Phi                             : from 10:m2219_28, from 12:m2219_54
 # 2219|     m2219_37(unknown)                                                                                                                   = Phi                             : from 10:~m2219_35, from 12:~m2219_59
 # 2219|     r2219_38(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>) = VariableAddress[(__begin)]      : 
-#-----|     r0_24(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>)    = Convert                         : r2219_38
 # 2219|     r2219_39(glval<unknown>)                                                                                                            = FunctionAddress[operator!=]     : 
-#-----|     r0_25(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>)    = VariableAddress[#temp0:0]       : 
-#-----|     m0_26(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)           = Uninitialized[#temp0:0]         : &:r0_25
-#-----|     m0_27(unknown)                                                                                                                      = Chi                             : total:m2219_37, partial:m0_26
+#-----|     r0_17(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>)    = VariableAddress[#temp0:0]       : 
+#-----|     m0_18(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)           = Uninitialized[#temp0:0]         : &:r0_17
+#-----|     m0_19(unknown)                                                                                                                      = Chi                             : total:m2219_37, partial:m0_18
 # 2219|     r2219_40(glval<unknown>)                                                                                                            = FunctionAddress[iterator]       : 
 # 2219|     r2219_41(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>) = VariableAddress[(__end)]        : 
-#-----|     r0_28(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>)    = Convert                         : r2219_41
-#-----|     r0_29(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &> &)         = CopyValue                       : r0_28
-# 2219|     v2219_42(void)                                                                                                                      = Call[iterator]                  : func:r2219_40, this:r0_25, 0:r0_29
-# 2219|     m2219_43(unknown)                                                                                                                   = ^CallSideEffect                 : ~m0_27
-# 2219|     m2219_44(unknown)                                                                                                                   = Chi                             : total:m0_27, partial:m2219_43
-#-----|     v0_30(void)                                                                                                                         = ^BufferReadSideEffect[0]        : &:r0_29, ~m2219_44
-# 2219|     m2219_45(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)        = ^IndirectMayWriteSideEffect[-1] : &:r0_25
+#-----|     r0_20(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &> &)         = CopyValue                       : r2219_41
+# 2219|     v2219_42(void)                                                                                                                      = Call[iterator]                  : func:r2219_40, this:r0_17, 0:r0_20
+# 2219|     m2219_43(unknown)                                                                                                                   = ^CallSideEffect                 : ~m0_19
+# 2219|     m2219_44(unknown)                                                                                                                   = Chi                             : total:m0_19, partial:m2219_43
+#-----|     v0_21(void)                                                                                                                         = ^BufferReadSideEffect[0]        : &:r0_20, ~m2219_44
+# 2219|     m2219_45(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)        = ^IndirectMayWriteSideEffect[-1] : &:r0_17
 # 2219|     m2219_46(unknown)                                                                                                                   = Chi                             : total:m2219_44, partial:m2219_45
-#-----|     r0_31(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)           = Load[#temp0:0]                  : &:r0_25, ~m2219_46
-# 2219|     r2219_47(bool)                                                                                                                      = Call[operator!=]                : func:r2219_39, this:r0_24, 0:r0_31
-#-----|     v0_32(void)                                                                                                                         = ^IndirectReadSideEffect[-1]     : &:r0_24, m2219_36
+#-----|     r0_22(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)           = Load[#temp0:0]                  : &:r0_17, ~m2219_46
+# 2219|     r2219_47(bool)                                                                                                                      = Call[operator!=]                : func:r2219_39, this:r2219_38, 0:r0_22
+#-----|     v0_23(void)                                                                                                                         = ^IndirectReadSideEffect[-1]     : &:r2219_38, m2219_36
 # 2219|     v2219_48(void)                                                                                                                      = ConditionalBranch               : r2219_47
 #-----|   False -> Block 15
 #-----|   True -> Block 13
@@ -16629,10 +16495,9 @@ ir.cpp:
 # 2219|   Block 13
 # 2219|     r2219_64(glval<ClassWithDestructor>)                                                                                                = VariableAddress[y]              : 
 # 2219|     r2219_65(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>) = VariableAddress[(__begin)]      : 
-#-----|     r0_33(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>)    = Convert                         : r2219_65
 # 2219|     r2219_66(glval<unknown>)                                                                                                            = FunctionAddress[operator*]      : 
-# 2219|     r2219_67(ClassWithDestructor &)                                                                                                     = Call[operator*]                 : func:r2219_66, this:r0_33
-#-----|     v0_34(void)                                                                                                                         = ^IndirectReadSideEffect[-1]     : &:r0_33, m2219_36
+# 2219|     r2219_67(ClassWithDestructor &)                                                                                                     = Call[operator*]                 : func:r2219_66, this:r2219_65
+#-----|     v0_24(void)                                                                                                                         = ^IndirectReadSideEffect[-1]     : &:r2219_65, m2219_36
 # 2219|     r2219_68(ClassWithDestructor)                                                                                                       = Load[?]                         : &:r2219_67, ~m2219_46
 # 2219|     m2219_69(ClassWithDestructor)                                                                                                       = Store[y]                        : &:r2219_64, r2219_68
 # 2220|     r2220_1(glval<ClassWithDestructor>)                                                                                                 = VariableAddress[y]              : 
@@ -16703,20 +16568,18 @@ ir.cpp:
 # 2225|     r2225_11(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>) = VariableAddress[(__begin)]       : 
 # 2225|     r2225_12(glval<vector<int> &>)                                                      = VariableAddress[(__range)]       : 
 # 2225|     r2225_13(vector<int> &)                                                             = Load[(__range)]                  : &:r2225_12, m2225_10
-#-----|     r0_35(glval<vector<int>>)                                                           = CopyValue                        : r2225_13
-#-----|     r0_36(glval<vector<int>>)                                                           = Convert                          : r0_35
+#-----|     r0_25(glval<vector<int>>)                                                           = CopyValue                        : r2225_13
 # 2225|     r2225_14(glval<unknown>)                                                            = FunctionAddress[begin]           : 
-# 2225|     r2225_15(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)        = Call[begin]                      : func:r2225_14, this:r0_36
-#-----|     v0_37(void)                                                                         = ^IndirectReadSideEffect[-1]      : &:r0_36, m2225_6
+# 2225|     r2225_15(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)        = Call[begin]                      : func:r2225_14, this:r0_25
+#-----|     v0_26(void)                                                                         = ^IndirectReadSideEffect[-1]      : &:r0_25, m2225_6
 # 2225|     m2225_16(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)        = Store[(__begin)]                 : &:r2225_11, r2225_15
 # 2225|     r2225_17(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>) = VariableAddress[(__end)]         : 
 # 2225|     r2225_18(glval<vector<int> &>)                                                      = VariableAddress[(__range)]       : 
 # 2225|     r2225_19(vector<int> &)                                                             = Load[(__range)]                  : &:r2225_18, m2225_10
-#-----|     r0_38(glval<vector<int>>)                                                           = CopyValue                        : r2225_19
-#-----|     r0_39(glval<vector<int>>)                                                           = Convert                          : r0_38
+#-----|     r0_27(glval<vector<int>>)                                                           = CopyValue                        : r2225_19
 # 2225|     r2225_20(glval<unknown>)                                                            = FunctionAddress[end]             : 
-# 2225|     r2225_21(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)        = Call[end]                        : func:r2225_20, this:r0_39
-#-----|     v0_40(void)                                                                         = ^IndirectReadSideEffect[-1]      : &:r0_39, m2225_6
+# 2225|     r2225_21(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)        = Call[end]                        : func:r2225_20, this:r0_27
+#-----|     v0_28(void)                                                                         = ^IndirectReadSideEffect[-1]      : &:r0_27, m2225_6
 # 2225|     m2225_22(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)        = Store[(__end)]                   : &:r2225_17, r2225_21
 # 2225|     m2225_23(unknown)                                                                   = Chi                              : total:m2219_46, partial:m2225_22
 #-----|   Goto -> Block 16
@@ -16725,24 +16588,22 @@ ir.cpp:
 # 2225|     m2225_24(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)        = Phi                             : from 15:m2225_16, from 17:m2225_42
 # 2225|     m2225_25(unknown)                                                                   = Phi                             : from 15:~m2225_23, from 17:~m2225_34
 # 2225|     r2225_26(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>) = VariableAddress[(__begin)]      : 
-#-----|     r0_41(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>)    = Convert                         : r2225_26
 # 2225|     r2225_27(glval<unknown>)                                                            = FunctionAddress[operator!=]     : 
-#-----|     r0_42(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>)    = VariableAddress[#temp0:0]       : 
-#-----|     m0_43(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)           = Uninitialized[#temp0:0]         : &:r0_42
-#-----|     m0_44(unknown)                                                                      = Chi                             : total:m2225_25, partial:m0_43
+#-----|     r0_29(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>)    = VariableAddress[#temp0:0]       : 
+#-----|     m0_30(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)           = Uninitialized[#temp0:0]         : &:r0_29
+#-----|     m0_31(unknown)                                                                      = Chi                             : total:m2225_25, partial:m0_30
 # 2225|     r2225_28(glval<unknown>)                                                            = FunctionAddress[iterator]       : 
 # 2225|     r2225_29(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>) = VariableAddress[(__end)]        : 
-#-----|     r0_45(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>)    = Convert                         : r2225_29
-#-----|     r0_46(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &> &)         = CopyValue                       : r0_45
-# 2225|     v2225_30(void)                                                                      = Call[iterator]                  : func:r2225_28, this:r0_42, 0:r0_46
-# 2225|     m2225_31(unknown)                                                                   = ^CallSideEffect                 : ~m0_44
-# 2225|     m2225_32(unknown)                                                                   = Chi                             : total:m0_44, partial:m2225_31
-#-----|     v0_47(void)                                                                         = ^BufferReadSideEffect[0]        : &:r0_46, ~m2225_32
-# 2225|     m2225_33(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)        = ^IndirectMayWriteSideEffect[-1] : &:r0_42
+#-----|     r0_32(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &> &)         = CopyValue                       : r2225_29
+# 2225|     v2225_30(void)                                                                      = Call[iterator]                  : func:r2225_28, this:r0_29, 0:r0_32
+# 2225|     m2225_31(unknown)                                                                   = ^CallSideEffect                 : ~m0_31
+# 2225|     m2225_32(unknown)                                                                   = Chi                             : total:m0_31, partial:m2225_31
+#-----|     v0_33(void)                                                                         = ^BufferReadSideEffect[0]        : &:r0_32, ~m2225_32
+# 2225|     m2225_33(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)        = ^IndirectMayWriteSideEffect[-1] : &:r0_29
 # 2225|     m2225_34(unknown)                                                                   = Chi                             : total:m2225_32, partial:m2225_33
-#-----|     r0_48(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)           = Load[#temp0:0]                  : &:r0_42, ~m2225_34
-# 2225|     r2225_35(bool)                                                                      = Call[operator!=]                : func:r2225_27, this:r0_41, 0:r0_48
-#-----|     v0_49(void)                                                                         = ^IndirectReadSideEffect[-1]     : &:r0_41, m2225_24
+#-----|     r0_34(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)           = Load[#temp0:0]                  : &:r0_29, ~m2225_34
+# 2225|     r2225_35(bool)                                                                      = Call[operator!=]                : func:r2225_27, this:r2225_26, 0:r0_34
+#-----|     v0_35(void)                                                                         = ^IndirectReadSideEffect[-1]     : &:r2225_26, m2225_24
 # 2225|     v2225_36(void)                                                                      = ConditionalBranch               : r2225_35
 #-----|   False -> Block 20
 #-----|   True -> Block 18
@@ -16760,10 +16621,9 @@ ir.cpp:
 # 2225|   Block 18
 # 2225|     r2225_44(glval<int>)                                                                = VariableAddress[y]          : 
 # 2225|     r2225_45(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>) = VariableAddress[(__begin)]  : 
-#-----|     r0_50(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>)    = Convert                     : r2225_45
 # 2225|     r2225_46(glval<unknown>)                                                            = FunctionAddress[operator*]  : 
-# 2225|     r2225_47(int &)                                                                     = Call[operator*]             : func:r2225_46, this:r0_50
-#-----|     v0_51(void)                                                                         = ^IndirectReadSideEffect[-1] : &:r0_50, m2225_24
+# 2225|     r2225_47(int &)                                                                     = Call[operator*]             : func:r2225_46, this:r2225_45
+#-----|     v0_36(void)                                                                         = ^IndirectReadSideEffect[-1] : &:r2225_45, m2225_24
 # 2225|     r2225_48(int)                                                                       = Load[?]                     : &:r2225_47, ~m2225_34
 # 2225|     m2225_49(int)                                                                       = Store[y]                    : &:r2225_44, r2225_48
 # 2226|     r2226_1(glval<int>)                                                                 = VariableAddress[y]          : 
@@ -16822,20 +16682,18 @@ ir.cpp:
 # 2230|     r2230_23(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>) = VariableAddress[(__begin)]            : 
 # 2230|     r2230_24(glval<vector<ClassWithDestructor> &>)                                                                                      = VariableAddress[(__range)]            : 
 # 2230|     r2230_25(vector<ClassWithDestructor> &)                                                                                             = Load[(__range)]                       : &:r2230_24, m2230_22
-#-----|     r0_52(glval<vector<ClassWithDestructor>>)                                                                                           = CopyValue                             : r2230_25
-#-----|     r0_53(glval<vector<ClassWithDestructor>>)                                                                                           = Convert                               : r0_52
+#-----|     r0_37(glval<vector<ClassWithDestructor>>)                                                                                           = CopyValue                             : r2230_25
 # 2230|     r2230_26(glval<unknown>)                                                                                                            = FunctionAddress[begin]                : 
-# 2230|     r2230_27(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)        = Call[begin]                           : func:r2230_26, this:r0_53
-#-----|     v0_54(void)                                                                                                                         = ^IndirectReadSideEffect[-1]           : &:r0_53, m2230_10
+# 2230|     r2230_27(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)        = Call[begin]                           : func:r2230_26, this:r0_37
+#-----|     v0_38(void)                                                                                                                         = ^IndirectReadSideEffect[-1]           : &:r0_37, m2230_10
 # 2230|     m2230_28(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)        = Store[(__begin)]                      : &:r2230_23, r2230_27
 # 2230|     r2230_29(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>) = VariableAddress[(__end)]              : 
 # 2230|     r2230_30(glval<vector<ClassWithDestructor> &>)                                                                                      = VariableAddress[(__range)]            : 
 # 2230|     r2230_31(vector<ClassWithDestructor> &)                                                                                             = Load[(__range)]                       : &:r2230_30, m2230_22
-#-----|     r0_55(glval<vector<ClassWithDestructor>>)                                                                                           = CopyValue                             : r2230_31
-#-----|     r0_56(glval<vector<ClassWithDestructor>>)                                                                                           = Convert                               : r0_55
+#-----|     r0_39(glval<vector<ClassWithDestructor>>)                                                                                           = CopyValue                             : r2230_31
 # 2230|     r2230_32(glval<unknown>)                                                                                                            = FunctionAddress[end]                  : 
-# 2230|     r2230_33(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)        = Call[end]                             : func:r2230_32, this:r0_56
-#-----|     v0_57(void)                                                                                                                         = ^IndirectReadSideEffect[-1]           : &:r0_56, m2230_10
+# 2230|     r2230_33(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)        = Call[end]                             : func:r2230_32, this:r0_39
+#-----|     v0_40(void)                                                                                                                         = ^IndirectReadSideEffect[-1]           : &:r0_39, m2230_10
 # 2230|     m2230_34(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)        = Store[(__end)]                        : &:r2230_29, r2230_33
 # 2230|     m2230_35(unknown)                                                                                                                   = Chi                                   : total:m2230_15, partial:m2230_34
 #-----|   Goto -> Block 21
@@ -16844,24 +16702,22 @@ ir.cpp:
 # 2230|     m2230_36(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)        = Phi                             : from 20:m2230_28, from 22:m2230_60
 # 2230|     m2230_37(unknown)                                                                                                                   = Phi                             : from 20:~m2230_35, from 22:~m2230_65
 # 2230|     r2230_38(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>) = VariableAddress[(__begin)]      : 
-#-----|     r0_58(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>)    = Convert                         : r2230_38
 # 2230|     r2230_39(glval<unknown>)                                                                                                            = FunctionAddress[operator!=]     : 
-#-----|     r0_59(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>)    = VariableAddress[#temp0:0]       : 
-#-----|     m0_60(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)           = Uninitialized[#temp0:0]         : &:r0_59
-#-----|     m0_61(unknown)                                                                                                                      = Chi                             : total:m2230_37, partial:m0_60
+#-----|     r0_41(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>)    = VariableAddress[#temp0:0]       : 
+#-----|     m0_42(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)           = Uninitialized[#temp0:0]         : &:r0_41
+#-----|     m0_43(unknown)                                                                                                                      = Chi                             : total:m2230_37, partial:m0_42
 # 2230|     r2230_40(glval<unknown>)                                                                                                            = FunctionAddress[iterator]       : 
 # 2230|     r2230_41(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>) = VariableAddress[(__end)]        : 
-#-----|     r0_62(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>)    = Convert                         : r2230_41
-#-----|     r0_63(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &> &)         = CopyValue                       : r0_62
-# 2230|     v2230_42(void)                                                                                                                      = Call[iterator]                  : func:r2230_40, this:r0_59, 0:r0_63
-# 2230|     m2230_43(unknown)                                                                                                                   = ^CallSideEffect                 : ~m0_61
-# 2230|     m2230_44(unknown)                                                                                                                   = Chi                             : total:m0_61, partial:m2230_43
-#-----|     v0_64(void)                                                                                                                         = ^BufferReadSideEffect[0]        : &:r0_63, ~m2230_44
-# 2230|     m2230_45(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)        = ^IndirectMayWriteSideEffect[-1] : &:r0_59
+#-----|     r0_44(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &> &)         = CopyValue                       : r2230_41
+# 2230|     v2230_42(void)                                                                                                                      = Call[iterator]                  : func:r2230_40, this:r0_41, 0:r0_44
+# 2230|     m2230_43(unknown)                                                                                                                   = ^CallSideEffect                 : ~m0_43
+# 2230|     m2230_44(unknown)                                                                                                                   = Chi                             : total:m0_43, partial:m2230_43
+#-----|     v0_45(void)                                                                                                                         = ^BufferReadSideEffect[0]        : &:r0_44, ~m2230_44
+# 2230|     m2230_45(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)        = ^IndirectMayWriteSideEffect[-1] : &:r0_41
 # 2230|     m2230_46(unknown)                                                                                                                   = Chi                             : total:m2230_44, partial:m2230_45
-#-----|     r0_65(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)           = Load[#temp0:0]                  : &:r0_59, ~m2230_46
-# 2230|     r2230_47(bool)                                                                                                                      = Call[operator!=]                : func:r2230_39, this:r0_58, 0:r0_65
-#-----|     v0_66(void)                                                                                                                         = ^IndirectReadSideEffect[-1]     : &:r0_58, m2230_36
+#-----|     r0_46(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)           = Load[#temp0:0]                  : &:r0_41, ~m2230_46
+# 2230|     r2230_47(bool)                                                                                                                      = Call[operator!=]                : func:r2230_39, this:r2230_38, 0:r0_46
+#-----|     v0_47(void)                                                                                                                         = ^IndirectReadSideEffect[-1]     : &:r2230_38, m2230_36
 # 2230|     v2230_48(void)                                                                                                                      = ConditionalBranch               : r2230_47
 #-----|   False -> Block 23
 #-----|   True -> Block 22
@@ -16869,10 +16725,9 @@ ir.cpp:
 # 2230|   Block 22
 # 2230|     r2230_49(glval<ClassWithDestructor>)                                                                                                = VariableAddress[y]                    : 
 # 2230|     r2230_50(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>) = VariableAddress[(__begin)]            : 
-#-----|     r0_67(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>)    = Convert                               : r2230_50
 # 2230|     r2230_51(glval<unknown>)                                                                                                            = FunctionAddress[operator*]            : 
-# 2230|     r2230_52(ClassWithDestructor &)                                                                                                     = Call[operator*]                       : func:r2230_51, this:r0_67
-#-----|     v0_68(void)                                                                                                                         = ^IndirectReadSideEffect[-1]           : &:r0_67, m2230_36
+# 2230|     r2230_52(ClassWithDestructor &)                                                                                                     = Call[operator*]                       : func:r2230_51, this:r2230_50
+#-----|     v0_48(void)                                                                                                                         = ^IndirectReadSideEffect[-1]           : &:r2230_50, m2230_36
 # 2230|     r2230_53(ClassWithDestructor)                                                                                                       = Load[?]                               : &:r2230_52, ~m2230_46
 # 2230|     m2230_54(ClassWithDestructor)                                                                                                       = Store[y]                              : &:r2230_49, r2230_53
 # 2231|     r2231_1(glval<ClassWithDestructor>)                                                                                                 = VariableAddress[z1]                   : 
@@ -17622,45 +17477,41 @@ ir.cpp:
 # 2308|     r2308_31(glval<vector<String> &&>)                                                           = VariableAddress[(__range)]       : 
 # 2308|     r2308_32(vector<String> &&)                                                                  = Load[(__range)]                  : &:r2308_31, m2308_29
 #-----|     r0_1(glval<vector<String>>)                                                                  = CopyValue                        : r2308_32
-#-----|     r0_2(glval<vector<String>>)                                                                  = Convert                          : r0_1
 # 2308|     r2308_33(glval<unknown>)                                                                     = FunctionAddress[begin]           : 
-# 2308|     r2308_34(iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>)        = Call[begin]                      : func:r2308_33, this:r0_2
-#-----|     v0_3(void)                                                                                   = ^IndirectReadSideEffect[-1]      : &:r0_2, m2308_19
+# 2308|     r2308_34(iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>)        = Call[begin]                      : func:r2308_33, this:r0_1
+#-----|     v0_2(void)                                                                                   = ^IndirectReadSideEffect[-1]      : &:r0_1, m2308_19
 # 2308|     m2308_35(iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>)        = Store[(__begin)]                 : &:r2308_30, r2308_34
 # 2308|     r2308_36(glval<iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>>) = VariableAddress[(__end)]         : 
 # 2308|     r2308_37(glval<vector<String> &&>)                                                           = VariableAddress[(__range)]       : 
 # 2308|     r2308_38(vector<String> &&)                                                                  = Load[(__range)]                  : &:r2308_37, m2308_29
-#-----|     r0_4(glval<vector<String>>)                                                                  = CopyValue                        : r2308_38
-#-----|     r0_5(glval<vector<String>>)                                                                  = Convert                          : r0_4
+#-----|     r0_3(glval<vector<String>>)                                                                  = CopyValue                        : r2308_38
 # 2308|     r2308_39(glval<unknown>)                                                                     = FunctionAddress[end]             : 
-# 2308|     r2308_40(iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>)        = Call[end]                        : func:r2308_39, this:r0_5
-#-----|     v0_6(void)                                                                                   = ^IndirectReadSideEffect[-1]      : &:r0_5, m2308_19
+# 2308|     r2308_40(iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>)        = Call[end]                        : func:r2308_39, this:r0_3
+#-----|     v0_4(void)                                                                                   = ^IndirectReadSideEffect[-1]      : &:r0_3, m2308_19
 # 2308|     m2308_41(iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>)        = Store[(__end)]                   : &:r2308_36, r2308_40
 # 2308|     m2308_42(unknown)                                                                            = Chi                              : total:m2308_27, partial:m2308_41
 #-----|   Goto -> Block 4
 
 # 2308|   Block 4
-# 2308|     m2308_43(iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>)        = Phi                             : from 3:m2308_35, from 5:m2308_77
-# 2308|     m2308_44(unknown)                                                                            = Phi                             : from 3:~m2308_42, from 5:~m2308_85
+# 2308|     m2308_43(iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>)        = Phi                             : from 3:m2308_35, from 5:m2308_76
+# 2308|     m2308_44(unknown)                                                                            = Phi                             : from 3:~m2308_42, from 5:~m2308_84
 # 2308|     r2308_45(glval<iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>>) = VariableAddress[(__begin)]      : 
-#-----|     r0_7(glval<iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>>)     = Convert                         : r2308_45
 # 2308|     r2308_46(glval<unknown>)                                                                     = FunctionAddress[operator!=]     : 
-#-----|     r0_8(glval<iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>>)     = VariableAddress[#temp0:0]       : 
-#-----|     m0_9(iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>)            = Uninitialized[#temp0:0]         : &:r0_8
-#-----|     m0_10(unknown)                                                                               = Chi                             : total:m2308_44, partial:m0_9
+#-----|     r0_5(glval<iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>>)     = VariableAddress[#temp0:0]       : 
+#-----|     m0_6(iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>)            = Uninitialized[#temp0:0]         : &:r0_5
+#-----|     m0_7(unknown)                                                                                = Chi                             : total:m2308_44, partial:m0_6
 # 2308|     r2308_47(glval<unknown>)                                                                     = FunctionAddress[iterator]       : 
 # 2308|     r2308_48(glval<iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>>) = VariableAddress[(__end)]        : 
-#-----|     r0_11(glval<iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>>)    = Convert                         : r2308_48
-#-----|     r0_12(iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &> &)         = CopyValue                       : r0_11
-# 2308|     v2308_49(void)                                                                               = Call[iterator]                  : func:r2308_47, this:r0_8, 0:r0_12
-# 2308|     m2308_50(unknown)                                                                            = ^CallSideEffect                 : ~m0_10
-# 2308|     m2308_51(unknown)                                                                            = Chi                             : total:m0_10, partial:m2308_50
-#-----|     v0_13(void)                                                                                  = ^BufferReadSideEffect[0]        : &:r0_12, ~m2308_51
-# 2308|     m2308_52(iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>)        = ^IndirectMayWriteSideEffect[-1] : &:r0_8
+#-----|     r0_8(iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &> &)          = CopyValue                       : r2308_48
+# 2308|     v2308_49(void)                                                                               = Call[iterator]                  : func:r2308_47, this:r0_5, 0:r0_8
+# 2308|     m2308_50(unknown)                                                                            = ^CallSideEffect                 : ~m0_7
+# 2308|     m2308_51(unknown)                                                                            = Chi                             : total:m0_7, partial:m2308_50
+#-----|     v0_9(void)                                                                                   = ^BufferReadSideEffect[0]        : &:r0_8, ~m2308_51
+# 2308|     m2308_52(iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>)        = ^IndirectMayWriteSideEffect[-1] : &:r0_5
 # 2308|     m2308_53(unknown)                                                                            = Chi                             : total:m2308_51, partial:m2308_52
-#-----|     r0_14(iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>)           = Load[#temp0:0]                  : &:r0_8, ~m2308_53
-# 2308|     r2308_54(bool)                                                                               = Call[operator!=]                : func:r2308_46, this:r0_7, 0:r0_14
-#-----|     v0_15(void)                                                                                  = ^IndirectReadSideEffect[-1]     : &:r0_7, m2308_43
+#-----|     r0_10(iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>)           = Load[#temp0:0]                  : &:r0_5, ~m2308_53
+# 2308|     r2308_54(bool)                                                                               = Call[operator!=]                : func:r2308_46, this:r2308_45, 0:r0_10
+#-----|     v0_11(void)                                                                                  = ^IndirectReadSideEffect[-1]     : &:r2308_45, m2308_43
 # 2308|     v2308_55(void)                                                                               = ConditionalBranch               : r2308_54
 #-----|   False -> Block 6
 #-----|   True -> Block 5
@@ -17671,22 +17522,20 @@ ir.cpp:
 # 2308|     m2308_58(unknown)                                                                            = Chi                             : total:m2308_53, partial:m2308_57
 # 2308|     r2308_59(glval<unknown>)                                                                     = FunctionAddress[String]         : 
 # 2308|     r2308_60(glval<iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>>) = VariableAddress[(__begin)]      : 
-#-----|     r0_16(glval<iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>>)    = Convert                         : r2308_60
 # 2308|     r2308_61(glval<unknown>)                                                                     = FunctionAddress[operator*]      : 
-# 2308|     r2308_62(String &)                                                                           = Call[operator*]                 : func:r2308_61, this:r0_16
-#-----|     v0_17(void)                                                                                  = ^IndirectReadSideEffect[-1]     : &:r0_16, m2308_43
+# 2308|     r2308_62(String &)                                                                           = Call[operator*]                 : func:r2308_61, this:r2308_60
+#-----|     v0_12(void)                                                                                  = ^IndirectReadSideEffect[-1]     : &:r2308_60, m2308_43
 # 2308|     r2308_63(glval<String>)                                                                      = CopyValue                       : r2308_62
-# 2308|     r2308_64(glval<String>)                                                                      = Convert                         : r2308_63
-# 2308|     r2308_65(String &)                                                                           = CopyValue                       : r2308_64
-# 2308|     v2308_66(void)                                                                               = Call[String]                    : func:r2308_59, this:r2308_56, 0:r2308_65
-# 2308|     m2308_67(unknown)                                                                            = ^CallSideEffect                 : ~m2308_58
-# 2308|     m2308_68(unknown)                                                                            = Chi                             : total:m2308_58, partial:m2308_67
-# 2308|     v2308_69(void)                                                                               = ^BufferReadSideEffect[0]        : &:r2308_65, ~m2308_68
-# 2308|     m2308_70(String)                                                                             = ^IndirectMayWriteSideEffect[-1] : &:r2308_56
-# 2308|     m2308_71(unknown)                                                                            = Chi                             : total:m2308_68, partial:m2308_70
+# 2308|     r2308_64(String &)                                                                           = CopyValue                       : r2308_63
+# 2308|     v2308_65(void)                                                                               = Call[String]                    : func:r2308_59, this:r2308_56, 0:r2308_64
+# 2308|     m2308_66(unknown)                                                                            = ^CallSideEffect                 : ~m2308_58
+# 2308|     m2308_67(unknown)                                                                            = Chi                             : total:m2308_58, partial:m2308_66
+# 2308|     v2308_68(void)                                                                               = ^BufferReadSideEffect[0]        : &:r2308_64, ~m2308_67
+# 2308|     m2308_69(String)                                                                             = ^IndirectMayWriteSideEffect[-1] : &:r2308_56
+# 2308|     m2308_70(unknown)                                                                            = Chi                             : total:m2308_67, partial:m2308_69
 # 2309|     r2309_1(glval<String>)                                                                       = VariableAddress[s2]             : 
 # 2309|     m2309_2(String)                                                                              = Uninitialized[s2]               : &:r2309_1
-# 2309|     m2309_3(unknown)                                                                             = Chi                             : total:m2308_71, partial:m2309_2
+# 2309|     m2309_3(unknown)                                                                             = Chi                             : total:m2308_70, partial:m2309_2
 # 2309|     r2309_4(glval<unknown>)                                                                      = FunctionAddress[String]         : 
 # 2309|     v2309_5(void)                                                                                = Call[String]                    : func:r2309_4, this:r2309_1
 # 2309|     m2309_6(unknown)                                                                             = ^CallSideEffect                 : ~m2309_3
@@ -17701,29 +17550,29 @@ ir.cpp:
 # 2310|     v2310_6(void)                                                                                = ^IndirectReadSideEffect[-1]     : &:r2310_1, ~m2310_5
 # 2310|     m2310_7(String)                                                                              = ^IndirectMayWriteSideEffect[-1] : &:r2310_1
 # 2310|     m2310_8(unknown)                                                                             = Chi                             : total:m2310_5, partial:m2310_7
-# 2308|     r2308_72(glval<iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>>) = VariableAddress[(__begin)]      : 
-# 2308|     r2308_73(glval<unknown>)                                                                     = FunctionAddress[operator++]     : 
-# 2308|     r2308_74(iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &> &)      = Call[operator++]                : func:r2308_73, this:r2308_72
-# 2308|     v2308_75(void)                                                                               = ^IndirectReadSideEffect[-1]     : &:r2308_72, m2308_43
-# 2308|     m2308_76(iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>)        = ^IndirectMayWriteSideEffect[-1] : &:r2308_72
-# 2308|     m2308_77(iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>)        = Chi                             : total:m2308_43, partial:m2308_76
-# 2308|     r2308_78(glval<String>)                                                                      = VariableAddress[s]              : 
-# 2308|     r2308_79(glval<unknown>)                                                                     = FunctionAddress[~String]        : 
-# 2308|     v2308_80(void)                                                                               = Call[~String]                   : func:r2308_79, this:r2308_78
-# 2308|     m2308_81(unknown)                                                                            = ^CallSideEffect                 : ~m2310_8
-# 2308|     m2308_82(unknown)                                                                            = Chi                             : total:m2310_8, partial:m2308_81
-# 2308|     v2308_83(void)                                                                               = ^IndirectReadSideEffect[-1]     : &:r2308_78, ~m2308_82
-# 2308|     m2308_84(String)                                                                             = ^IndirectMayWriteSideEffect[-1] : &:r2308_78
-# 2308|     m2308_85(unknown)                                                                            = Chi                             : total:m2308_82, partial:m2308_84
-# 2308|     r2308_86(glval<iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>>) = CopyValue                       : r2308_74
+# 2308|     r2308_71(glval<iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>>) = VariableAddress[(__begin)]      : 
+# 2308|     r2308_72(glval<unknown>)                                                                     = FunctionAddress[operator++]     : 
+# 2308|     r2308_73(iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &> &)      = Call[operator++]                : func:r2308_72, this:r2308_71
+# 2308|     v2308_74(void)                                                                               = ^IndirectReadSideEffect[-1]     : &:r2308_71, m2308_43
+# 2308|     m2308_75(iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>)        = ^IndirectMayWriteSideEffect[-1] : &:r2308_71
+# 2308|     m2308_76(iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>)        = Chi                             : total:m2308_43, partial:m2308_75
+# 2308|     r2308_77(glval<String>)                                                                      = VariableAddress[s]              : 
+# 2308|     r2308_78(glval<unknown>)                                                                     = FunctionAddress[~String]        : 
+# 2308|     v2308_79(void)                                                                               = Call[~String]                   : func:r2308_78, this:r2308_77
+# 2308|     m2308_80(unknown)                                                                            = ^CallSideEffect                 : ~m2310_8
+# 2308|     m2308_81(unknown)                                                                            = Chi                             : total:m2310_8, partial:m2308_80
+# 2308|     v2308_82(void)                                                                               = ^IndirectReadSideEffect[-1]     : &:r2308_77, ~m2308_81
+# 2308|     m2308_83(String)                                                                             = ^IndirectMayWriteSideEffect[-1] : &:r2308_77
+# 2308|     m2308_84(unknown)                                                                            = Chi                             : total:m2308_81, partial:m2308_83
+# 2308|     r2308_85(glval<iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>>) = CopyValue                       : r2308_73
 #-----|   Goto (back edge) -> Block 4
 
 # 2308|   Block 6
-# 2308|     r2308_87(glval<vector<String>>) = CopyValue                        : r2308_2
-# 2308|     r2308_88(glval<unknown>)        = FunctionAddress[~vector]         : 
-# 2308|     v2308_89(void)                  = Call[~vector]                    : func:r2308_88, this:r2308_87
-# 2308|     v2308_90(void)                  = ^IndirectReadSideEffect[-1]      : &:r2308_87, m2308_19
-# 2308|     m2308_91(vector<String>)        = ^IndirectMustWriteSideEffect[-1] : &:r2308_87
+# 2308|     r2308_86(glval<vector<String>>) = CopyValue                        : r2308_2
+# 2308|     r2308_87(glval<unknown>)        = FunctionAddress[~vector]         : 
+# 2308|     v2308_88(void)                  = Call[~vector]                    : func:r2308_87, this:r2308_86
+# 2308|     v2308_89(void)                  = ^IndirectReadSideEffect[-1]      : &:r2308_86, m2308_19
+# 2308|     m2308_90(vector<String>)        = ^IndirectMustWriteSideEffect[-1] : &:r2308_86
 # 2312|     r2312_1(glval<String>)          = VariableAddress[s]               : 
 # 2312|     m2312_2(String)                 = Uninitialized[s]                 : &:r2312_1
 # 2312|     m2312_3(unknown)                = Chi                              : total:m2308_53, partial:m2312_2
@@ -18512,19 +18361,17 @@ ir.cpp:
 # 2431|     r2431_37(glval<vector<char> &&>)                                                       = VariableAddress[(__range)]            : 
 # 2431|     r2431_38(vector<char> &&)                                                              = Load[(__range)]                       : &:r2431_37, m2431_35
 #-----|     r0_1(glval<vector<char>>)                                                              = CopyValue                             : r2431_38
-#-----|     r0_2(glval<vector<char>>)                                                              = Convert                               : r0_1
 # 2431|     r2431_39(glval<unknown>)                                                               = FunctionAddress[begin]                : 
-# 2431|     r2431_40(iterator<random_access_iterator_tag, char, ptrdiff_t, char *, char &>)        = Call[begin]                           : func:r2431_39, this:r0_2
-#-----|     v0_3(void)                                                                             = ^IndirectReadSideEffect[-1]           : &:r0_2, m2431_33
+# 2431|     r2431_40(iterator<random_access_iterator_tag, char, ptrdiff_t, char *, char &>)        = Call[begin]                           : func:r2431_39, this:r0_1
+#-----|     v0_2(void)                                                                             = ^IndirectReadSideEffect[-1]           : &:r0_1, m2431_33
 # 2431|     m2431_41(iterator<random_access_iterator_tag, char, ptrdiff_t, char *, char &>)        = Store[(__begin)]                      : &:r2431_36, r2431_40
 # 2431|     r2431_42(glval<iterator<random_access_iterator_tag, char, ptrdiff_t, char *, char &>>) = VariableAddress[(__end)]              : 
 # 2431|     r2431_43(glval<vector<char> &&>)                                                       = VariableAddress[(__range)]            : 
 # 2431|     r2431_44(vector<char> &&)                                                              = Load[(__range)]                       : &:r2431_43, m2431_35
-#-----|     r0_4(glval<vector<char>>)                                                              = CopyValue                             : r2431_44
-#-----|     r0_5(glval<vector<char>>)                                                              = Convert                               : r0_4
+#-----|     r0_3(glval<vector<char>>)                                                              = CopyValue                             : r2431_44
 # 2431|     r2431_45(glval<unknown>)                                                               = FunctionAddress[end]                  : 
-# 2431|     r2431_46(iterator<random_access_iterator_tag, char, ptrdiff_t, char *, char &>)        = Call[end]                             : func:r2431_45, this:r0_5
-#-----|     v0_6(void)                                                                             = ^IndirectReadSideEffect[-1]           : &:r0_5, m2431_33
+# 2431|     r2431_46(iterator<random_access_iterator_tag, char, ptrdiff_t, char *, char &>)        = Call[end]                             : func:r2431_45, this:r0_3
+#-----|     v0_4(void)                                                                             = ^IndirectReadSideEffect[-1]           : &:r0_3, m2431_33
 # 2431|     m2431_47(iterator<random_access_iterator_tag, char, ptrdiff_t, char *, char &>)        = Store[(__end)]                        : &:r2431_42, r2431_46
 # 2431|     m2431_48(unknown)                                                                      = Chi                                   : total:m2431_21, partial:m2431_47
 #-----|   Goto -> Block 10
@@ -18533,24 +18380,22 @@ ir.cpp:
 # 2431|     m2431_49(iterator<random_access_iterator_tag, char, ptrdiff_t, char *, char &>)        = Phi                             : from 9:m2431_41, from 11:m2431_73
 # 2431|     m2431_50(unknown)                                                                      = Phi                             : from 9:~m2431_48, from 11:~m2431_59
 # 2431|     r2431_51(glval<iterator<random_access_iterator_tag, char, ptrdiff_t, char *, char &>>) = VariableAddress[(__begin)]      : 
-#-----|     r0_7(glval<iterator<random_access_iterator_tag, char, ptrdiff_t, char *, char &>>)     = Convert                         : r2431_51
 # 2431|     r2431_52(glval<unknown>)                                                               = FunctionAddress[operator!=]     : 
-#-----|     r0_8(glval<iterator<random_access_iterator_tag, char, ptrdiff_t, char *, char &>>)     = VariableAddress[#temp0:0]       : 
-#-----|     m0_9(iterator<random_access_iterator_tag, char, ptrdiff_t, char *, char &>)            = Uninitialized[#temp0:0]         : &:r0_8
-#-----|     m0_10(unknown)                                                                         = Chi                             : total:m2431_50, partial:m0_9
+#-----|     r0_5(glval<iterator<random_access_iterator_tag, char, ptrdiff_t, char *, char &>>)     = VariableAddress[#temp0:0]       : 
+#-----|     m0_6(iterator<random_access_iterator_tag, char, ptrdiff_t, char *, char &>)            = Uninitialized[#temp0:0]         : &:r0_5
+#-----|     m0_7(unknown)                                                                          = Chi                             : total:m2431_50, partial:m0_6
 # 2431|     r2431_53(glval<unknown>)                                                               = FunctionAddress[iterator]       : 
 # 2431|     r2431_54(glval<iterator<random_access_iterator_tag, char, ptrdiff_t, char *, char &>>) = VariableAddress[(__end)]        : 
-#-----|     r0_11(glval<iterator<random_access_iterator_tag, char, ptrdiff_t, char *, char &>>)    = Convert                         : r2431_54
-#-----|     r0_12(iterator<random_access_iterator_tag, char, ptrdiff_t, char *, char &> &)         = CopyValue                       : r0_11
-# 2431|     v2431_55(void)                                                                         = Call[iterator]                  : func:r2431_53, this:r0_8, 0:r0_12
-# 2431|     m2431_56(unknown)                                                                      = ^CallSideEffect                 : ~m0_10
-# 2431|     m2431_57(unknown)                                                                      = Chi                             : total:m0_10, partial:m2431_56
-#-----|     v0_13(void)                                                                            = ^BufferReadSideEffect[0]        : &:r0_12, ~m2431_57
-# 2431|     m2431_58(iterator<random_access_iterator_tag, char, ptrdiff_t, char *, char &>)        = ^IndirectMayWriteSideEffect[-1] : &:r0_8
+#-----|     r0_8(iterator<random_access_iterator_tag, char, ptrdiff_t, char *, char &> &)          = CopyValue                       : r2431_54
+# 2431|     v2431_55(void)                                                                         = Call[iterator]                  : func:r2431_53, this:r0_5, 0:r0_8
+# 2431|     m2431_56(unknown)                                                                      = ^CallSideEffect                 : ~m0_7
+# 2431|     m2431_57(unknown)                                                                      = Chi                             : total:m0_7, partial:m2431_56
+#-----|     v0_9(void)                                                                             = ^BufferReadSideEffect[0]        : &:r0_8, ~m2431_57
+# 2431|     m2431_58(iterator<random_access_iterator_tag, char, ptrdiff_t, char *, char &>)        = ^IndirectMayWriteSideEffect[-1] : &:r0_5
 # 2431|     m2431_59(unknown)                                                                      = Chi                             : total:m2431_57, partial:m2431_58
-#-----|     r0_14(iterator<random_access_iterator_tag, char, ptrdiff_t, char *, char &>)           = Load[#temp0:0]                  : &:r0_8, ~m2431_59
-# 2431|     r2431_60(bool)                                                                         = Call[operator!=]                : func:r2431_52, this:r0_7, 0:r0_14
-#-----|     v0_15(void)                                                                            = ^IndirectReadSideEffect[-1]     : &:r0_7, m2431_49
+#-----|     r0_10(iterator<random_access_iterator_tag, char, ptrdiff_t, char *, char &>)           = Load[#temp0:0]                  : &:r0_5, ~m2431_59
+# 2431|     r2431_60(bool)                                                                         = Call[operator!=]                : func:r2431_52, this:r2431_51, 0:r0_10
+#-----|     v0_11(void)                                                                            = ^IndirectReadSideEffect[-1]     : &:r2431_51, m2431_49
 # 2431|     v2431_61(void)                                                                         = ConditionalBranch               : r2431_60
 #-----|   False -> Block 12
 #-----|   True -> Block 11
@@ -18558,10 +18403,9 @@ ir.cpp:
 # 2431|   Block 11
 # 2431|     r2431_62(glval<char>)                                                                  = VariableAddress[y]              : 
 # 2431|     r2431_63(glval<iterator<random_access_iterator_tag, char, ptrdiff_t, char *, char &>>) = VariableAddress[(__begin)]      : 
-#-----|     r0_16(glval<iterator<random_access_iterator_tag, char, ptrdiff_t, char *, char &>>)    = Convert                         : r2431_63
 # 2431|     r2431_64(glval<unknown>)                                                               = FunctionAddress[operator*]      : 
-# 2431|     r2431_65(char &)                                                                       = Call[operator*]                 : func:r2431_64, this:r0_16
-#-----|     v0_17(void)                                                                            = ^IndirectReadSideEffect[-1]     : &:r0_16, m2431_49
+# 2431|     r2431_65(char &)                                                                       = Call[operator*]                 : func:r2431_64, this:r2431_63
+#-----|     v0_12(void)                                                                            = ^IndirectReadSideEffect[-1]     : &:r2431_63, m2431_49
 # 2431|     r2431_66(char)                                                                         = Load[?]                         : &:r2431_65, ~m2431_59
 # 2431|     m2431_67(char)                                                                         = Store[y]                        : &:r2431_62, r2431_66
 # 2432|     r2432_1(glval<char>)                                                                   = VariableAddress[x]              : 
@@ -18745,26 +18589,25 @@ ir.cpp:
 # 2481|     m2481_6(unknown)              = Chi                             : total:m2479_4, partial:m2481_5
 # 2481|     m2481_7(B)                    = Store[#temp2481:18]             : &:r2481_2, r2481_4
 # 2481|     m2481_8(unknown)              = Chi                             : total:m2481_6, partial:m2481_7
-# 2481|     r2481_9(glval<B>)             = Convert                         : r2481_2
-# 2481|     r2481_10(glval<unknown>)      = FunctionAddress[operator->]     : 
-# 2481|     r2481_11(A *)                 = Call[operator->]                : func:r2481_10, this:r2481_9
-# 2481|     m2481_12(unknown)             = ^CallSideEffect                 : ~m2481_8
-# 2481|     m2481_13(unknown)             = Chi                             : total:m2481_8, partial:m2481_12
-# 2481|     v2481_14(void)                = ^IndirectReadSideEffect[-1]     : &:r2481_9, ~m2481_13
-# 2481|     r2481_15(glval<unsigned int>) = FieldAddress[a]                 : r2481_11
-# 2481|     r2481_16(glval<B>)            = CopyValue                       : r2481_2
-# 2481|     r2481_17(glval<unknown>)      = FunctionAddress[~B]             : 
-# 2481|     v2481_18(void)                = Call[~B]                        : func:r2481_17, this:r2481_16
-# 2481|     m2481_19(unknown)             = ^CallSideEffect                 : ~m2481_13
-# 2481|     m2481_20(unknown)             = Chi                             : total:m2481_13, partial:m2481_19
-# 2481|     v2481_21(void)                = ^IndirectReadSideEffect[-1]     : &:r2481_16, ~m2481_20
-# 2481|     m2481_22(B)                   = ^IndirectMayWriteSideEffect[-1] : &:r2481_16
-# 2481|     m2481_23(unknown)             = Chi                             : total:m2481_20, partial:m2481_22
-# 2481|     r2481_24(unsigned int)        = Load[?]                         : &:r2481_15, ~m2481_23
-# 2481|     m2481_25(unsigned int)        = Store[a]                        : &:r2481_1, r2481_24
+# 2481|     r2481_9(glval<unknown>)       = FunctionAddress[operator->]     : 
+# 2481|     r2481_10(A *)                 = Call[operator->]                : func:r2481_9, this:r2481_2
+# 2481|     m2481_11(unknown)             = ^CallSideEffect                 : ~m2481_8
+# 2481|     m2481_12(unknown)             = Chi                             : total:m2481_8, partial:m2481_11
+# 2481|     v2481_13(void)                = ^IndirectReadSideEffect[-1]     : &:r2481_2, ~m2481_12
+# 2481|     r2481_14(glval<unsigned int>) = FieldAddress[a]                 : r2481_10
+# 2481|     r2481_15(glval<B>)            = CopyValue                       : r2481_2
+# 2481|     r2481_16(glval<unknown>)      = FunctionAddress[~B]             : 
+# 2481|     v2481_17(void)                = Call[~B]                        : func:r2481_16, this:r2481_15
+# 2481|     m2481_18(unknown)             = ^CallSideEffect                 : ~m2481_12
+# 2481|     m2481_19(unknown)             = Chi                             : total:m2481_12, partial:m2481_18
+# 2481|     v2481_20(void)                = ^IndirectReadSideEffect[-1]     : &:r2481_15, ~m2481_19
+# 2481|     m2481_21(B)                   = ^IndirectMayWriteSideEffect[-1] : &:r2481_15
+# 2481|     m2481_22(unknown)             = Chi                             : total:m2481_19, partial:m2481_21
+# 2481|     r2481_23(unsigned int)        = Load[?]                         : &:r2481_14, ~m2481_22
+# 2481|     m2481_24(unsigned int)        = Store[a]                        : &:r2481_1, r2481_23
 # 2482|     v2482_1(void)                 = NoOp                            : 
 # 2479|     v2479_5(void)                 = ReturnVoid                      : 
-# 2479|     v2479_6(void)                 = AliasedUse                      : ~m2481_20
+# 2479|     v2479_6(void)                 = AliasedUse                      : ~m2481_19
 # 2479|     v2479_7(void)                 = ExitFunction                    : 
 
 # 2485| void destructor_without_block(bool)
@@ -19165,19 +19008,18 @@ ir.cpp:
 # 2546|     m2546_6(unknown)                       = Chi                                     : total:m2545_4, partial:m2546_5
 # 2546|     m2546_7(ClassWithDestructor)           = Store[#temp2546:38]                     : &:r2546_2, r2546_4
 # 2546|     m2546_8(unknown)                       = Chi                                     : total:m2546_6, partial:m2546_7
-# 2546|     r2546_9(glval<ClassWithDestructor>)    = Convert                                 : r2546_2
-# 2546|     r2546_10(ClassWithDestructor &)        = CopyValue                               : r2546_9
-# 2546|     m2546_11(ClassWithDestructor &)        = Store[a]                                : &:r2546_1, r2546_10
-# 2546|     r2546_12(glval<ClassWithDestructor &>) = VariableAddress[a]                      : 
-# 2546|     r2546_13(ClassWithDestructor &)        = Load[a]                                 : &:r2546_12, m2546_11
-# 2546|     r2546_14(ClassWithDestructor)          = CopyValue                               : r2546_13
-# 2546|     r2546_15(glval<unknown>)               = FunctionAddress[operator bool]          : 
-# 2546|     r2546_16(bool)                         = Call[operator bool]                     : func:r2546_15, this:r2546_14
-# 2546|     m2546_17(unknown)                      = ^CallSideEffect                         : ~m2546_8
-# 2546|     m2546_18(unknown)                      = Chi                                     : total:m2546_8, partial:m2546_17
-# 2546|     v2546_19(void)                         = ^IndirectReadSideEffect[-1]             : &:r2546_14, ~m2546_18
-# 2546|     r2546_20(bool)                         = CopyValue                               : r2546_16
-# 2546|     v2546_21(void)                         = ConditionalBranch                       : r2546_20
+# 2546|     r2546_9(ClassWithDestructor &)         = CopyValue                               : r2546_2
+# 2546|     m2546_10(ClassWithDestructor &)        = Store[a]                                : &:r2546_1, r2546_9
+# 2546|     r2546_11(glval<ClassWithDestructor &>) = VariableAddress[a]                      : 
+# 2546|     r2546_12(ClassWithDestructor &)        = Load[a]                                 : &:r2546_11, m2546_10
+# 2546|     r2546_13(ClassWithDestructor)          = CopyValue                               : r2546_12
+# 2546|     r2546_14(glval<unknown>)               = FunctionAddress[operator bool]          : 
+# 2546|     r2546_15(bool)                         = Call[operator bool]                     : func:r2546_14, this:r2546_13
+# 2546|     m2546_16(unknown)                      = ^CallSideEffect                         : ~m2546_8
+# 2546|     m2546_17(unknown)                      = Chi                                     : total:m2546_8, partial:m2546_16
+# 2546|     v2546_18(void)                         = ^IndirectReadSideEffect[-1]             : &:r2546_13, ~m2546_17
+# 2546|     r2546_19(bool)                         = CopyValue                               : r2546_15
+# 2546|     v2546_20(void)                         = ConditionalBranch                       : r2546_19
 #-----|   False -> Block 2
 #-----|   True -> Block 1
 
@@ -19189,8 +19031,8 @@ ir.cpp:
 # 2547|     r2547_2(glval<ClassWithDestructor>) = CopyValue                             : r2546_2
 # 2547|     r2547_3(glval<unknown>)             = FunctionAddress[~ClassWithDestructor] : 
 # 2547|     v2547_4(void)                       = Call[~ClassWithDestructor]            : func:r2547_3, this:r2547_2
-# 2547|     m2547_5(unknown)                    = ^CallSideEffect                       : ~m2546_18
-# 2547|     m2547_6(unknown)                    = Chi                                   : total:m2546_18, partial:m2547_5
+# 2547|     m2547_5(unknown)                    = ^CallSideEffect                       : ~m2546_17
+# 2547|     m2547_6(unknown)                    = Chi                                   : total:m2546_17, partial:m2547_5
 # 2547|     v2547_7(void)                       = ^IndirectReadSideEffect[-1]           : &:r2547_2, ~m2547_6
 # 2547|     m2547_8(ClassWithDestructor)        = ^IndirectMayWriteSideEffect[-1]       : &:r2547_2
 # 2547|     m2547_9(unknown)                    = Chi                                   : total:m2547_6, partial:m2547_8
@@ -19214,11 +19056,10 @@ ir.cpp:
 # 2551|     m2551_5(unknown)                      = ^CallSideEffect                         : ~m2550_4
 # 2551|     m2551_6(unknown)                      = Chi                                     : total:m2550_4, partial:m2551_5
 # 2551|     m2551_7(ClassWithDestructor)          = Store[#temp2551:48]                     : &:r2551_2, r2551_4
-# 2551|     r2551_8(glval<ClassWithDestructor>)   = Convert                                 : r2551_2
-# 2551|     r2551_9(ClassWithDestructor &)        = CopyValue                               : r2551_8
-# 2551|     m2551_10(ClassWithDestructor &)       = Store[a]                                : &:r2551_1, r2551_9
-# 2551|     r2551_11(bool)                        = Constant[1]                             : 
-# 2551|     v2551_12(void)                        = ConditionalBranch                       : r2551_11
+# 2551|     r2551_8(ClassWithDestructor &)        = CopyValue                               : r2551_2
+# 2551|     m2551_9(ClassWithDestructor &)        = Store[a]                                : &:r2551_1, r2551_8
+# 2551|     r2551_10(bool)                        = Constant[1]                             : 
+# 2551|     v2551_11(void)                        = ConditionalBranch                       : r2551_10
 #-----|   False -> Block 2
 #-----|   True -> Block 1
 
@@ -19533,14 +19374,13 @@ ir.cpp:
 # 2630|     r2630_2(glval<unknown>) = FunctionAddress[use_const_int] : 
 # 2630|     r2630_3(glval<int *>)   = VariableAddress[data]          : 
 # 2630|     r2630_4(int *)          = Load[data]                     : &:r2630_3, m2630_1
-# 2630|     r2630_5(int *)          = Convert                        : r2630_4
-# 2630|     v2630_6(void)           = Call[use_const_int]            : func:r2630_2, 0:r2630_5
-# 2630|     m2630_7(unknown)        = ^CallSideEffect                : ~m2621_6
-# 2630|     m2630_8(unknown)        = Chi                            : total:m2621_6, partial:m2630_7
-# 2630|     v2630_9(void)           = ^BufferReadSideEffect[0]       : &:r2630_5, ~m2630_8
+# 2630|     v2630_5(void)           = Call[use_const_int]            : func:r2630_2, 0:r2630_4
+# 2630|     m2630_6(unknown)        = ^CallSideEffect                : ~m2621_6
+# 2630|     m2630_7(unknown)        = Chi                            : total:m2621_6, partial:m2630_6
+# 2630|     v2630_8(void)           = ^BufferReadSideEffect[0]       : &:r2630_4, ~m2630_7
 # 2631|     v2631_1(void)           = NoOp                           : 
 # 2618|     v2618_9(void)           = ReturnVoid                     : 
-# 2618|     v2618_10(void)          = AliasedUse                     : ~m2630_8
+# 2618|     v2618_10(void)          = AliasedUse                     : ~m2630_7
 # 2618|     v2618_11(void)          = ExitFunction                   : 
 
 # 2639| void needs_chi_for_initialize_groups()
@@ -20241,14 +20081,12 @@ ir.cpp:
 # 2739|     r2739_4(int *)        = PointerAdd[4]            : r2739_2, r2739_3
 # 2739|     m2739_5(int *)        = Store[p]                 : &:r2739_1, r2739_4
 # 2739|     r2739_6(int *)        = CopyValue                : r2739_2
-# 2739|     r2739_7(int *)        = Convert                  : r2739_6
 # 2740|     r2740_1(glval<int>)   = VariableAddress[q]       : 
 # 2740|     r2740_2(int)          = Load[q]                  : &:r2740_1, m2738_6
 # 2740|     r2740_3(int)          = Constant[1]              : 
 # 2740|     r2740_4(int)          = Add                      : r2740_2, r2740_3
 # 2740|     m2740_5(int)          = Store[q]                 : &:r2740_1, r2740_4
 # 2740|     r2740_6(int)          = CopyValue                : r2740_2
-# 2740|     r2740_7(int)          = Convert                  : r2740_6
 # 2741|     r2741_1(glval<int *>) = VariableAddress[p2]      : 
 # 2741|     r2741_2(glval<int *>) = VariableAddress[p]       : 
 # 2741|     r2741_3(int *)        = Load[p]                  : &:r2741_2, m2739_5
@@ -20256,8 +20094,7 @@ ir.cpp:
 # 2741|     r2741_5(int *)        = PointerAdd[4]            : r2741_3, r2741_4
 # 2741|     m2741_6(int *)        = Store[p]                 : &:r2741_2, r2741_5
 # 2741|     r2741_7(int *)        = CopyValue                : r2741_3
-# 2741|     r2741_8(int *)        = Convert                  : r2741_7
-# 2741|     m2741_9(int *)        = Store[p2]                : &:r2741_1, r2741_8
+# 2741|     m2741_8(int *)        = Store[p2]                : &:r2741_1, r2741_7
 # 2742|     r2742_1(glval<int>)   = VariableAddress[q2]      : 
 # 2742|     r2742_2(glval<int>)   = VariableAddress[q]       : 
 # 2742|     r2742_3(int)          = Load[q]                  : &:r2742_2, m2740_5
@@ -20265,8 +20102,7 @@ ir.cpp:
 # 2742|     r2742_5(int)          = Add                      : r2742_3, r2742_4
 # 2742|     m2742_6(int)          = Store[q]                 : &:r2742_2, r2742_5
 # 2742|     r2742_7(int)          = CopyValue                : r2742_3
-# 2742|     r2742_8(int)          = Convert                  : r2742_7
-# 2742|     m2742_9(int)          = Store[q2]                : &:r2742_1, r2742_8
+# 2742|     m2742_8(int)          = Store[q2]                : &:r2742_1, r2742_7
 # 2743|     v2743_1(void)         = NoOp                     : 
 # 2728|     v2728_12(void)        = ReturnIndirection[p]     : &:r2728_7, m2728_8
 # 2728|     v2728_13(void)        = ReturnVoid               : 
@@ -39079,35 +38915,34 @@ smart_ptr.cpp:
 #   19|     m19_3(shared_ptr<float>)         = Uninitialized[#temp19:20]        : &:r19_2
 #   19|     r19_4(glval<unknown>)            = FunctionAddress[shared_ptr]      : 
 #   19|     r19_5(glval<shared_ptr<float>>)  = VariableAddress[sp]              : 
-#   19|     r19_6(glval<shared_ptr<float>>)  = Convert                          : r19_5
-#   19|     r19_7(shared_ptr<float> &)       = CopyValue                        : r19_6
-#   19|     v19_8(void)                      = Call[shared_ptr]                 : func:r19_4, this:r19_2, 0:r19_7
-#   19|     m19_9(unknown)                   = ^CallSideEffect                  : ~m18_11
-#   19|     m19_10(unknown)                  = Chi                              : total:m18_11, partial:m19_9
-#   19|     v19_11(void)                     = ^IndirectReadSideEffect[0]       : &:r19_7, ~m19_10
-#   19|     m19_12(shared_ptr<float>)        = ^IndirectMustWriteSideEffect[-1] : &:r19_2
-#   19|     r19_13(shared_ptr<float>)        = Load[#temp19:20]                 : &:r19_2, m19_12
-#   19|     v19_14(void)                     = Call[shared_ptr_arg]             : func:r19_1, 0:r19_13
-#   19|     m19_15(unknown)                  = ^CallSideEffect                  : ~m19_10
-#   19|     m19_16(unknown)                  = Chi                              : total:m19_10, partial:m19_15
-#   19|     v19_17(void)                     = ^BufferReadSideEffect[0]         : &:r19_13, ~m19_16
-#   19|     m19_18(unknown)                  = ^BufferMayWriteSideEffect[0]     : &:r19_13
-#   19|     m19_19(unknown)                  = Chi                              : total:m19_16, partial:m19_18
-#   19|     r19_20(glval<shared_ptr<float>>) = CopyValue                        : r19_2
-#   19|     r19_21(glval<unknown>)           = FunctionAddress[~shared_ptr]     : 
-#   19|     v19_22(void)                     = Call[~shared_ptr]                : func:r19_21, this:r19_20
-#   19|     v19_23(void)                     = ^IndirectReadSideEffect[-1]      : &:r19_20, m19_12
-#   19|     m19_24(shared_ptr<float>)        = ^IndirectMustWriteSideEffect[-1] : &:r19_20
+#   19|     r19_6(shared_ptr<float> &)       = CopyValue                        : r19_5
+#   19|     v19_7(void)                      = Call[shared_ptr]                 : func:r19_4, this:r19_2, 0:r19_6
+#   19|     m19_8(unknown)                   = ^CallSideEffect                  : ~m18_11
+#   19|     m19_9(unknown)                   = Chi                              : total:m18_11, partial:m19_8
+#   19|     v19_10(void)                     = ^IndirectReadSideEffect[0]       : &:r19_6, ~m19_9
+#   19|     m19_11(shared_ptr<float>)        = ^IndirectMustWriteSideEffect[-1] : &:r19_2
+#   19|     r19_12(shared_ptr<float>)        = Load[#temp19:20]                 : &:r19_2, m19_11
+#   19|     v19_13(void)                     = Call[shared_ptr_arg]             : func:r19_1, 0:r19_12
+#   19|     m19_14(unknown)                  = ^CallSideEffect                  : ~m19_9
+#   19|     m19_15(unknown)                  = Chi                              : total:m19_9, partial:m19_14
+#   19|     v19_16(void)                     = ^BufferReadSideEffect[0]         : &:r19_12, ~m19_15
+#   19|     m19_17(unknown)                  = ^BufferMayWriteSideEffect[0]     : &:r19_12
+#   19|     m19_18(unknown)                  = Chi                              : total:m19_15, partial:m19_17
+#   19|     r19_19(glval<shared_ptr<float>>) = CopyValue                        : r19_2
+#   19|     r19_20(glval<unknown>)           = FunctionAddress[~shared_ptr]     : 
+#   19|     v19_21(void)                     = Call[~shared_ptr]                : func:r19_20, this:r19_19
+#   19|     v19_22(void)                     = ^IndirectReadSideEffect[-1]      : &:r19_19, m19_11
+#   19|     m19_23(shared_ptr<float>)        = ^IndirectMustWriteSideEffect[-1] : &:r19_19
 #   20|     v20_1(void)                      = NoOp                             : 
 #   20|     r20_2(glval<shared_ptr<float>>)  = VariableAddress[sp]              : 
 #   20|     r20_3(glval<unknown>)            = FunctionAddress[~shared_ptr]     : 
 #   20|     v20_4(void)                      = Call[~shared_ptr]                : func:r20_3, this:r20_2
-#   20|     v20_5(void)                      = ^IndirectReadSideEffect[-1]      : &:r20_2, ~m19_19
+#   20|     v20_5(void)                      = ^IndirectReadSideEffect[-1]      : &:r20_2, ~m19_18
 #   20|     m20_6(shared_ptr<float>)         = ^IndirectMustWriteSideEffect[-1] : &:r20_2
-#   20|     m20_7(unknown)                   = Chi                              : total:m19_19, partial:m20_6
+#   20|     m20_7(unknown)                   = Chi                              : total:m19_18, partial:m20_6
 #   17|     v17_10(void)                     = ReturnIndirection[p]             : &:r17_7, ~m20_7
 #   17|     v17_11(void)                     = ReturnVoid                       : 
-#   17|     v17_12(void)                     = AliasedUse                       : ~m19_19
+#   17|     v17_12(void)                     = AliasedUse                       : ~m19_18
 #   17|     v17_13(void)                     = ExitFunction                     : 
 
 #   28| void call_shared_ptr_consts()
@@ -39124,162 +38959,157 @@ smart_ptr.cpp:
 #   31|     m31_3(shared_ptr<const int>)                           = Uninitialized[#temp31:26]                              : &:r31_2
 #   31|     r31_4(glval<unknown>)                                  = FunctionAddress[shared_ptr]                            : 
 #   31|     r31_5(glval<shared_ptr<const int>>)                    = VariableAddress[sp_const_int]                          : 
-#   31|     r31_6(glval<shared_ptr<const int>>)                    = Convert                                                : r31_5
-#   31|     r31_7(shared_ptr<const int> &)                         = CopyValue                                              : r31_6
-#   31|     v31_8(void)                                            = Call[shared_ptr]                                       : func:r31_4, this:r31_2, 0:r31_7
-#   31|     m31_9(unknown)                                         = ^CallSideEffect                                        : ~m29_3
-#   31|     m31_10(unknown)                                        = Chi                                                    : total:m29_3, partial:m31_9
-#   31|     v31_11(void)                                           = ^IndirectReadSideEffect[0]                             : &:r31_7, ~m31_10
-#   31|     m31_12(shared_ptr<const int>)                          = ^IndirectMustWriteSideEffect[-1]                       : &:r31_2
-#   31|     r31_13(shared_ptr<const int>)                          = Load[#temp31:26]                                       : &:r31_2, m31_12
-#   31|     v31_14(void)                                           = Call[shared_ptr_const_int]                             : func:r31_1, 0:r31_13
-#   31|     m31_15(unknown)                                        = ^CallSideEffect                                        : ~m31_10
-#   31|     m31_16(unknown)                                        = Chi                                                    : total:m31_10, partial:m31_15
-#   31|     v31_17(void)                                           = ^BufferReadSideEffect[0]                               : &:r31_13, ~m31_16
-#   31|     r31_18(glval<shared_ptr<const int>>)                   = CopyValue                                              : r31_2
-#   31|     r31_19(glval<unknown>)                                 = FunctionAddress[~shared_ptr]                           : 
-#   31|     v31_20(void)                                           = Call[~shared_ptr]                                      : func:r31_19, this:r31_18
-#   31|     v31_21(void)                                           = ^IndirectReadSideEffect[-1]                            : &:r31_18, m31_12
-#   31|     m31_22(shared_ptr<const int>)                          = ^IndirectMustWriteSideEffect[-1]                       : &:r31_18
+#   31|     r31_6(shared_ptr<const int> &)                         = CopyValue                                              : r31_5
+#   31|     v31_7(void)                                            = Call[shared_ptr]                                       : func:r31_4, this:r31_2, 0:r31_6
+#   31|     m31_8(unknown)                                         = ^CallSideEffect                                        : ~m29_3
+#   31|     m31_9(unknown)                                         = Chi                                                    : total:m29_3, partial:m31_8
+#   31|     v31_10(void)                                           = ^IndirectReadSideEffect[0]                             : &:r31_6, ~m31_9
+#   31|     m31_11(shared_ptr<const int>)                          = ^IndirectMustWriteSideEffect[-1]                       : &:r31_2
+#   31|     r31_12(shared_ptr<const int>)                          = Load[#temp31:26]                                       : &:r31_2, m31_11
+#   31|     v31_13(void)                                           = Call[shared_ptr_const_int]                             : func:r31_1, 0:r31_12
+#   31|     m31_14(unknown)                                        = ^CallSideEffect                                        : ~m31_9
+#   31|     m31_15(unknown)                                        = Chi                                                    : total:m31_9, partial:m31_14
+#   31|     v31_16(void)                                           = ^BufferReadSideEffect[0]                               : &:r31_12, ~m31_15
+#   31|     r31_17(glval<shared_ptr<const int>>)                   = CopyValue                                              : r31_2
+#   31|     r31_18(glval<unknown>)                                 = FunctionAddress[~shared_ptr]                           : 
+#   31|     v31_19(void)                                           = Call[~shared_ptr]                                      : func:r31_18, this:r31_17
+#   31|     v31_20(void)                                           = ^IndirectReadSideEffect[-1]                            : &:r31_17, m31_11
+#   31|     m31_21(shared_ptr<const int>)                          = ^IndirectMustWriteSideEffect[-1]                       : &:r31_17
 #   33|     r33_1(glval<shared_ptr<int *const>>)                   = VariableAddress[sp_const_int_pointer]                  : 
 #   33|     m33_2(shared_ptr<int *const>)                          = Uninitialized[sp_const_int_pointer]                    : &:r33_1
-#   33|     m33_3(unknown)                                         = Chi                                                    : total:m31_16, partial:m33_2
+#   33|     m33_3(unknown)                                         = Chi                                                    : total:m31_15, partial:m33_2
 #   35|     r35_1(glval<unknown>)                                  = FunctionAddress[shared_ptr_const_int_ptr]              : 
 #   35|     r35_2(glval<shared_ptr<int *const>>)                   = VariableAddress[#temp35:30]                            : 
 #   35|     m35_3(shared_ptr<int *const>)                          = Uninitialized[#temp35:30]                              : &:r35_2
 #   35|     r35_4(glval<unknown>)                                  = FunctionAddress[shared_ptr]                            : 
 #   35|     r35_5(glval<shared_ptr<int *const>>)                   = VariableAddress[sp_const_int_pointer]                  : 
-#   35|     r35_6(glval<shared_ptr<int *const>>)                   = Convert                                                : r35_5
-#   35|     r35_7(shared_ptr<int *const> &)                        = CopyValue                                              : r35_6
-#   35|     v35_8(void)                                            = Call[shared_ptr]                                       : func:r35_4, this:r35_2, 0:r35_7
-#   35|     m35_9(unknown)                                         = ^CallSideEffect                                        : ~m33_3
-#   35|     m35_10(unknown)                                        = Chi                                                    : total:m33_3, partial:m35_9
-#   35|     v35_11(void)                                           = ^IndirectReadSideEffect[0]                             : &:r35_7, ~m35_10
-#   35|     m35_12(shared_ptr<int *const>)                         = ^IndirectMustWriteSideEffect[-1]                       : &:r35_2
-#   35|     r35_13(shared_ptr<int *const>)                         = Load[#temp35:30]                                       : &:r35_2, m35_12
-#   35|     v35_14(void)                                           = Call[shared_ptr_const_int_ptr]                         : func:r35_1, 0:r35_13
-#   35|     m35_15(unknown)                                        = ^CallSideEffect                                        : ~m35_10
-#   35|     m35_16(unknown)                                        = Chi                                                    : total:m35_10, partial:m35_15
-#   35|     v35_17(void)                                           = ^BufferReadSideEffect[0]                               : &:r35_13, ~m35_16
-#   35|     m35_18(unknown)                                        = ^BufferMayWriteSideEffect[0]                           : &:r35_13
-#   35|     m35_19(unknown)                                        = Chi                                                    : total:m35_16, partial:m35_18
-#   35|     r35_20(glval<shared_ptr<int *const>>)                  = CopyValue                                              : r35_2
-#   35|     r35_21(glval<unknown>)                                 = FunctionAddress[~shared_ptr]                           : 
-#   35|     v35_22(void)                                           = Call[~shared_ptr]                                      : func:r35_21, this:r35_20
-#   35|     v35_23(void)                                           = ^IndirectReadSideEffect[-1]                            : &:r35_20, m35_12
-#   35|     m35_24(shared_ptr<int *const>)                         = ^IndirectMustWriteSideEffect[-1]                       : &:r35_20
+#   35|     r35_6(shared_ptr<int *const> &)                        = CopyValue                                              : r35_5
+#   35|     v35_7(void)                                            = Call[shared_ptr]                                       : func:r35_4, this:r35_2, 0:r35_6
+#   35|     m35_8(unknown)                                         = ^CallSideEffect                                        : ~m33_3
+#   35|     m35_9(unknown)                                         = Chi                                                    : total:m33_3, partial:m35_8
+#   35|     v35_10(void)                                           = ^IndirectReadSideEffect[0]                             : &:r35_6, ~m35_9
+#   35|     m35_11(shared_ptr<int *const>)                         = ^IndirectMustWriteSideEffect[-1]                       : &:r35_2
+#   35|     r35_12(shared_ptr<int *const>)                         = Load[#temp35:30]                                       : &:r35_2, m35_11
+#   35|     v35_13(void)                                           = Call[shared_ptr_const_int_ptr]                         : func:r35_1, 0:r35_12
+#   35|     m35_14(unknown)                                        = ^CallSideEffect                                        : ~m35_9
+#   35|     m35_15(unknown)                                        = Chi                                                    : total:m35_9, partial:m35_14
+#   35|     v35_16(void)                                           = ^BufferReadSideEffect[0]                               : &:r35_12, ~m35_15
+#   35|     m35_17(unknown)                                        = ^BufferMayWriteSideEffect[0]                           : &:r35_12
+#   35|     m35_18(unknown)                                        = Chi                                                    : total:m35_15, partial:m35_17
+#   35|     r35_19(glval<shared_ptr<int *const>>)                  = CopyValue                                              : r35_2
+#   35|     r35_20(glval<unknown>)                                 = FunctionAddress[~shared_ptr]                           : 
+#   35|     v35_21(void)                                           = Call[~shared_ptr]                                      : func:r35_20, this:r35_19
+#   35|     v35_22(void)                                           = ^IndirectReadSideEffect[-1]                            : &:r35_19, m35_11
+#   35|     m35_23(shared_ptr<int *const>)                         = ^IndirectMustWriteSideEffect[-1]                       : &:r35_19
 #   37|     r37_1(glval<shared_ptr<shared_ptr<const int>>>)        = VariableAddress[sp_sp_const_int]                       : 
 #   37|     m37_2(shared_ptr<shared_ptr<const int>>)               = Uninitialized[sp_sp_const_int]                         : &:r37_1
-#   37|     m37_3(unknown)                                         = Chi                                                    : total:m35_19, partial:m37_2
+#   37|     m37_3(unknown)                                         = Chi                                                    : total:m35_18, partial:m37_2
 #   39|     r39_1(glval<unknown>)                                  = FunctionAddress[shared_ptr_shared_ptr_const_int]       : 
 #   39|     r39_2(glval<shared_ptr<shared_ptr<const int>>>)        = VariableAddress[#temp39:37]                            : 
 #   39|     m39_3(shared_ptr<shared_ptr<const int>>)               = Uninitialized[#temp39:37]                              : &:r39_2
 #   39|     r39_4(glval<unknown>)                                  = FunctionAddress[shared_ptr]                            : 
 #   39|     r39_5(glval<shared_ptr<shared_ptr<const int>>>)        = VariableAddress[sp_sp_const_int]                       : 
-#   39|     r39_6(glval<shared_ptr<shared_ptr<const int>>>)        = Convert                                                : r39_5
-#   39|     r39_7(shared_ptr<shared_ptr<const int>> &)             = CopyValue                                              : r39_6
-#   39|     v39_8(void)                                            = Call[shared_ptr]                                       : func:r39_4, this:r39_2, 0:r39_7
-#   39|     m39_9(unknown)                                         = ^CallSideEffect                                        : ~m37_3
-#   39|     m39_10(unknown)                                        = Chi                                                    : total:m37_3, partial:m39_9
-#   39|     v39_11(void)                                           = ^IndirectReadSideEffect[0]                             : &:r39_7, ~m39_10
-#   39|     m39_12(shared_ptr<shared_ptr<const int>>)              = ^IndirectMustWriteSideEffect[-1]                       : &:r39_2
-#   39|     r39_13(shared_ptr<shared_ptr<const int>>)              = Load[#temp39:37]                                       : &:r39_2, m39_12
-#   39|     v39_14(void)                                           = Call[shared_ptr_shared_ptr_const_int]                  : func:r39_1, 0:r39_13
-#   39|     m39_15(unknown)                                        = ^CallSideEffect                                        : ~m39_10
-#   39|     m39_16(unknown)                                        = Chi                                                    : total:m39_10, partial:m39_15
-#   39|     v39_17(void)                                           = ^BufferReadSideEffect[0]                               : &:r39_13, ~m39_16
-#   39|     m39_18(unknown)                                        = ^BufferMayWriteSideEffect[0]                           : &:r39_13
-#   39|     m39_19(unknown)                                        = Chi                                                    : total:m39_16, partial:m39_18
-#   39|     r39_20(glval<shared_ptr<shared_ptr<const int>>>)       = CopyValue                                              : r39_2
-#   39|     r39_21(glval<unknown>)                                 = FunctionAddress[~shared_ptr]                           : 
-#   39|     v39_22(void)                                           = Call[~shared_ptr]                                      : func:r39_21, this:r39_20
-#   39|     v39_23(void)                                           = ^IndirectReadSideEffect[-1]                            : &:r39_20, m39_12
-#   39|     m39_24(shared_ptr<shared_ptr<const int>>)              = ^IndirectMustWriteSideEffect[-1]                       : &:r39_20
+#   39|     r39_6(shared_ptr<shared_ptr<const int>> &)             = CopyValue                                              : r39_5
+#   39|     v39_7(void)                                            = Call[shared_ptr]                                       : func:r39_4, this:r39_2, 0:r39_6
+#   39|     m39_8(unknown)                                         = ^CallSideEffect                                        : ~m37_3
+#   39|     m39_9(unknown)                                         = Chi                                                    : total:m37_3, partial:m39_8
+#   39|     v39_10(void)                                           = ^IndirectReadSideEffect[0]                             : &:r39_6, ~m39_9
+#   39|     m39_11(shared_ptr<shared_ptr<const int>>)              = ^IndirectMustWriteSideEffect[-1]                       : &:r39_2
+#   39|     r39_12(shared_ptr<shared_ptr<const int>>)              = Load[#temp39:37]                                       : &:r39_2, m39_11
+#   39|     v39_13(void)                                           = Call[shared_ptr_shared_ptr_const_int]                  : func:r39_1, 0:r39_12
+#   39|     m39_14(unknown)                                        = ^CallSideEffect                                        : ~m39_9
+#   39|     m39_15(unknown)                                        = Chi                                                    : total:m39_9, partial:m39_14
+#   39|     v39_16(void)                                           = ^BufferReadSideEffect[0]                               : &:r39_12, ~m39_15
+#   39|     m39_17(unknown)                                        = ^BufferMayWriteSideEffect[0]                           : &:r39_12
+#   39|     m39_18(unknown)                                        = Chi                                                    : total:m39_15, partial:m39_17
+#   39|     r39_19(glval<shared_ptr<shared_ptr<const int>>>)       = CopyValue                                              : r39_2
+#   39|     r39_20(glval<unknown>)                                 = FunctionAddress[~shared_ptr]                           : 
+#   39|     v39_21(void)                                           = Call[~shared_ptr]                                      : func:r39_20, this:r39_19
+#   39|     v39_22(void)                                           = ^IndirectReadSideEffect[-1]                            : &:r39_19, m39_11
+#   39|     m39_23(shared_ptr<shared_ptr<const int>>)              = ^IndirectMustWriteSideEffect[-1]                       : &:r39_19
 #   41|     r41_1(glval<shared_ptr<const shared_ptr<int>>>)        = VariableAddress[sp_const_sp_int]                       : 
 #   41|     m41_2(shared_ptr<const shared_ptr<int>>)               = Uninitialized[sp_const_sp_int]                         : &:r41_1
-#   41|     m41_3(unknown)                                         = Chi                                                    : total:m39_19, partial:m41_2
+#   41|     m41_3(unknown)                                         = Chi                                                    : total:m39_18, partial:m41_2
 #   43|     r43_1(glval<unknown>)                                  = FunctionAddress[shared_ptr_const_shared_ptr_int]       : 
 #   43|     r43_2(glval<shared_ptr<const shared_ptr<int>>>)        = VariableAddress[#temp43:37]                            : 
 #   43|     m43_3(shared_ptr<const shared_ptr<int>>)               = Uninitialized[#temp43:37]                              : &:r43_2
 #   43|     r43_4(glval<unknown>)                                  = FunctionAddress[shared_ptr]                            : 
 #   43|     r43_5(glval<shared_ptr<const shared_ptr<int>>>)        = VariableAddress[sp_const_sp_int]                       : 
-#   43|     r43_6(glval<shared_ptr<const shared_ptr<int>>>)        = Convert                                                : r43_5
-#   43|     r43_7(shared_ptr<const shared_ptr<int>> &)             = CopyValue                                              : r43_6
-#   43|     v43_8(void)                                            = Call[shared_ptr]                                       : func:r43_4, this:r43_2, 0:r43_7
-#   43|     m43_9(unknown)                                         = ^CallSideEffect                                        : ~m41_3
-#   43|     m43_10(unknown)                                        = Chi                                                    : total:m41_3, partial:m43_9
-#   43|     v43_11(void)                                           = ^IndirectReadSideEffect[0]                             : &:r43_7, ~m43_10
-#   43|     m43_12(shared_ptr<const shared_ptr<int>>)              = ^IndirectMustWriteSideEffect[-1]                       : &:r43_2
-#   43|     r43_13(shared_ptr<const shared_ptr<int>>)              = Load[#temp43:37]                                       : &:r43_2, m43_12
-#   43|     v43_14(void)                                           = Call[shared_ptr_const_shared_ptr_int]                  : func:r43_1, 0:r43_13
-#   43|     m43_15(unknown)                                        = ^CallSideEffect                                        : ~m43_10
-#   43|     m43_16(unknown)                                        = Chi                                                    : total:m43_10, partial:m43_15
-#   43|     v43_17(void)                                           = ^BufferReadSideEffect[0]                               : &:r43_13, ~m43_16
-#   43|     m43_18(unknown)                                        = ^BufferMayWriteSideEffect[0]                           : &:r43_13
-#   43|     m43_19(unknown)                                        = Chi                                                    : total:m43_16, partial:m43_18
-#   43|     r43_20(glval<shared_ptr<const shared_ptr<int>>>)       = CopyValue                                              : r43_2
-#   43|     r43_21(glval<unknown>)                                 = FunctionAddress[~shared_ptr]                           : 
-#   43|     v43_22(void)                                           = Call[~shared_ptr]                                      : func:r43_21, this:r43_20
-#   43|     v43_23(void)                                           = ^IndirectReadSideEffect[-1]                            : &:r43_20, m43_12
-#   43|     m43_24(shared_ptr<const shared_ptr<int>>)              = ^IndirectMustWriteSideEffect[-1]                       : &:r43_20
+#   43|     r43_6(shared_ptr<const shared_ptr<int>> &)             = CopyValue                                              : r43_5
+#   43|     v43_7(void)                                            = Call[shared_ptr]                                       : func:r43_4, this:r43_2, 0:r43_6
+#   43|     m43_8(unknown)                                         = ^CallSideEffect                                        : ~m41_3
+#   43|     m43_9(unknown)                                         = Chi                                                    : total:m41_3, partial:m43_8
+#   43|     v43_10(void)                                           = ^IndirectReadSideEffect[0]                             : &:r43_6, ~m43_9
+#   43|     m43_11(shared_ptr<const shared_ptr<int>>)              = ^IndirectMustWriteSideEffect[-1]                       : &:r43_2
+#   43|     r43_12(shared_ptr<const shared_ptr<int>>)              = Load[#temp43:37]                                       : &:r43_2, m43_11
+#   43|     v43_13(void)                                           = Call[shared_ptr_const_shared_ptr_int]                  : func:r43_1, 0:r43_12
+#   43|     m43_14(unknown)                                        = ^CallSideEffect                                        : ~m43_9
+#   43|     m43_15(unknown)                                        = Chi                                                    : total:m43_9, partial:m43_14
+#   43|     v43_16(void)                                           = ^BufferReadSideEffect[0]                               : &:r43_12, ~m43_15
+#   43|     m43_17(unknown)                                        = ^BufferMayWriteSideEffect[0]                           : &:r43_12
+#   43|     m43_18(unknown)                                        = Chi                                                    : total:m43_15, partial:m43_17
+#   43|     r43_19(glval<shared_ptr<const shared_ptr<int>>>)       = CopyValue                                              : r43_2
+#   43|     r43_20(glval<unknown>)                                 = FunctionAddress[~shared_ptr]                           : 
+#   43|     v43_21(void)                                           = Call[~shared_ptr]                                      : func:r43_20, this:r43_19
+#   43|     v43_22(void)                                           = ^IndirectReadSideEffect[-1]                            : &:r43_19, m43_11
+#   43|     m43_23(shared_ptr<const shared_ptr<int>>)              = ^IndirectMustWriteSideEffect[-1]                       : &:r43_19
 #   45|     r45_1(glval<shared_ptr<const shared_ptr<const int>>>)  = VariableAddress[sp_const_sp_const_int]                 : 
 #   45|     m45_2(shared_ptr<const shared_ptr<const int>>)         = Uninitialized[sp_const_sp_const_int]                   : &:r45_1
-#   45|     m45_3(unknown)                                         = Chi                                                    : total:m43_19, partial:m45_2
+#   45|     m45_3(unknown)                                         = Chi                                                    : total:m43_18, partial:m45_2
 #   47|     r47_1(glval<unknown>)                                  = FunctionAddress[shared_ptr_const_shared_ptr_const_int] : 
 #   47|     r47_2(glval<shared_ptr<const shared_ptr<const int>>>)  = VariableAddress[#temp47:43]                            : 
 #   47|     m47_3(shared_ptr<const shared_ptr<const int>>)         = Uninitialized[#temp47:43]                              : &:r47_2
 #   47|     r47_4(glval<unknown>)                                  = FunctionAddress[shared_ptr]                            : 
 #   47|     r47_5(glval<shared_ptr<const shared_ptr<const int>>>)  = VariableAddress[sp_const_sp_const_int]                 : 
-#   47|     r47_6(glval<shared_ptr<const shared_ptr<const int>>>)  = Convert                                                : r47_5
-#   47|     r47_7(shared_ptr<const shared_ptr<const int>> &)       = CopyValue                                              : r47_6
-#   47|     v47_8(void)                                            = Call[shared_ptr]                                       : func:r47_4, this:r47_2, 0:r47_7
-#   47|     m47_9(unknown)                                         = ^CallSideEffect                                        : ~m45_3
-#   47|     m47_10(unknown)                                        = Chi                                                    : total:m45_3, partial:m47_9
-#   47|     v47_11(void)                                           = ^IndirectReadSideEffect[0]                             : &:r47_7, ~m47_10
-#   47|     m47_12(shared_ptr<const shared_ptr<const int>>)        = ^IndirectMustWriteSideEffect[-1]                       : &:r47_2
-#   47|     r47_13(shared_ptr<const shared_ptr<const int>>)        = Load[#temp47:43]                                       : &:r47_2, m47_12
-#   47|     v47_14(void)                                           = Call[shared_ptr_const_shared_ptr_const_int]            : func:r47_1, 0:r47_13
-#   47|     m47_15(unknown)                                        = ^CallSideEffect                                        : ~m47_10
-#   47|     m47_16(unknown)                                        = Chi                                                    : total:m47_10, partial:m47_15
-#   47|     v47_17(void)                                           = ^BufferReadSideEffect[0]                               : &:r47_13, ~m47_16
-#   47|     r47_18(glval<shared_ptr<const shared_ptr<const int>>>) = CopyValue                                              : r47_2
-#   47|     r47_19(glval<unknown>)                                 = FunctionAddress[~shared_ptr]                           : 
-#   47|     v47_20(void)                                           = Call[~shared_ptr]                                      : func:r47_19, this:r47_18
-#   47|     v47_21(void)                                           = ^IndirectReadSideEffect[-1]                            : &:r47_18, m47_12
-#   47|     m47_22(shared_ptr<const shared_ptr<const int>>)        = ^IndirectMustWriteSideEffect[-1]                       : &:r47_18
+#   47|     r47_6(shared_ptr<const shared_ptr<const int>> &)       = CopyValue                                              : r47_5
+#   47|     v47_7(void)                                            = Call[shared_ptr]                                       : func:r47_4, this:r47_2, 0:r47_6
+#   47|     m47_8(unknown)                                         = ^CallSideEffect                                        : ~m45_3
+#   47|     m47_9(unknown)                                         = Chi                                                    : total:m45_3, partial:m47_8
+#   47|     v47_10(void)                                           = ^IndirectReadSideEffect[0]                             : &:r47_6, ~m47_9
+#   47|     m47_11(shared_ptr<const shared_ptr<const int>>)        = ^IndirectMustWriteSideEffect[-1]                       : &:r47_2
+#   47|     r47_12(shared_ptr<const shared_ptr<const int>>)        = Load[#temp47:43]                                       : &:r47_2, m47_11
+#   47|     v47_13(void)                                           = Call[shared_ptr_const_shared_ptr_const_int]            : func:r47_1, 0:r47_12
+#   47|     m47_14(unknown)                                        = ^CallSideEffect                                        : ~m47_9
+#   47|     m47_15(unknown)                                        = Chi                                                    : total:m47_9, partial:m47_14
+#   47|     v47_16(void)                                           = ^BufferReadSideEffect[0]                               : &:r47_12, ~m47_15
+#   47|     r47_17(glval<shared_ptr<const shared_ptr<const int>>>) = CopyValue                                              : r47_2
+#   47|     r47_18(glval<unknown>)                                 = FunctionAddress[~shared_ptr]                           : 
+#   47|     v47_19(void)                                           = Call[~shared_ptr]                                      : func:r47_18, this:r47_17
+#   47|     v47_20(void)                                           = ^IndirectReadSideEffect[-1]                            : &:r47_17, m47_11
+#   47|     m47_21(shared_ptr<const shared_ptr<const int>>)        = ^IndirectMustWriteSideEffect[-1]                       : &:r47_17
 #   48|     v48_1(void)                                            = NoOp                                                   : 
 #   48|     r48_2(glval<shared_ptr<const shared_ptr<const int>>>)  = VariableAddress[sp_const_sp_const_int]                 : 
 #   48|     r48_3(glval<unknown>)                                  = FunctionAddress[~shared_ptr]                           : 
 #   48|     v48_4(void)                                            = Call[~shared_ptr]                                      : func:r48_3, this:r48_2
-#   48|     v48_5(void)                                            = ^IndirectReadSideEffect[-1]                            : &:r48_2, ~m47_16
+#   48|     v48_5(void)                                            = ^IndirectReadSideEffect[-1]                            : &:r48_2, ~m47_15
 #   48|     m48_6(shared_ptr<const shared_ptr<const int>>)         = ^IndirectMustWriteSideEffect[-1]                       : &:r48_2
-#   48|     m48_7(unknown)                                         = Chi                                                    : total:m47_16, partial:m48_6
+#   48|     m48_7(unknown)                                         = Chi                                                    : total:m47_15, partial:m48_6
 #   48|     r48_8(glval<shared_ptr<const shared_ptr<int>>>)        = VariableAddress[sp_const_sp_int]                       : 
 #   48|     r48_9(glval<unknown>)                                  = FunctionAddress[~shared_ptr]                           : 
 #   48|     v48_10(void)                                           = Call[~shared_ptr]                                      : func:r48_9, this:r48_8
-#   48|     v48_11(void)                                           = ^IndirectReadSideEffect[-1]                            : &:r48_8, ~m47_16
+#   48|     v48_11(void)                                           = ^IndirectReadSideEffect[-1]                            : &:r48_8, ~m47_15
 #   48|     m48_12(shared_ptr<const shared_ptr<int>>)              = ^IndirectMustWriteSideEffect[-1]                       : &:r48_8
 #   48|     m48_13(unknown)                                        = Chi                                                    : total:m48_7, partial:m48_12
 #   48|     r48_14(glval<shared_ptr<shared_ptr<const int>>>)       = VariableAddress[sp_sp_const_int]                       : 
 #   48|     r48_15(glval<unknown>)                                 = FunctionAddress[~shared_ptr]                           : 
 #   48|     v48_16(void)                                           = Call[~shared_ptr]                                      : func:r48_15, this:r48_14
-#   48|     v48_17(void)                                           = ^IndirectReadSideEffect[-1]                            : &:r48_14, ~m47_16
+#   48|     v48_17(void)                                           = ^IndirectReadSideEffect[-1]                            : &:r48_14, ~m47_15
 #   48|     m48_18(shared_ptr<shared_ptr<const int>>)              = ^IndirectMustWriteSideEffect[-1]                       : &:r48_14
 #   48|     m48_19(unknown)                                        = Chi                                                    : total:m48_13, partial:m48_18
 #   48|     r48_20(glval<shared_ptr<int *const>>)                  = VariableAddress[sp_const_int_pointer]                  : 
 #   48|     r48_21(glval<unknown>)                                 = FunctionAddress[~shared_ptr]                           : 
 #   48|     v48_22(void)                                           = Call[~shared_ptr]                                      : func:r48_21, this:r48_20
-#   48|     v48_23(void)                                           = ^IndirectReadSideEffect[-1]                            : &:r48_20, ~m47_16
+#   48|     v48_23(void)                                           = ^IndirectReadSideEffect[-1]                            : &:r48_20, ~m47_15
 #   48|     m48_24(shared_ptr<int *const>)                         = ^IndirectMustWriteSideEffect[-1]                       : &:r48_20
 #   48|     m48_25(unknown)                                        = Chi                                                    : total:m48_19, partial:m48_24
 #   48|     r48_26(glval<shared_ptr<const int>>)                   = VariableAddress[sp_const_int]                          : 
 #   48|     r48_27(glval<unknown>)                                 = FunctionAddress[~shared_ptr]                           : 
 #   48|     v48_28(void)                                           = Call[~shared_ptr]                                      : func:r48_27, this:r48_26
-#   48|     v48_29(void)                                           = ^IndirectReadSideEffect[-1]                            : &:r48_26, ~m47_16
+#   48|     v48_29(void)                                           = ^IndirectReadSideEffect[-1]                            : &:r48_26, ~m47_15
 #   48|     m48_30(shared_ptr<const int>)                          = ^IndirectMustWriteSideEffect[-1]                       : &:r48_26
 #   48|     m48_31(unknown)                                        = Chi                                                    : total:m48_25, partial:m48_30
 #   28|     v28_5(void)                                            = ReturnVoid                                             : 
-#   28|     v28_6(void)                                            = AliasedUse                                             : ~m47_16
+#   28|     v28_6(void)                                            = AliasedUse                                             : ~m47_15
 #   28|     v28_7(void)                                            = ExitFunction                                           : 
 
 struct_init.cpp:

--- a/cpp/ql/test/library-tests/ir/ir/raw_ir.expected
+++ b/cpp/ql/test/library-tests/ir/ir/raw_ir.expected
@@ -228,9 +228,8 @@ bad_asts.cpp:
 #   27|     r27_2(glval<Point &>) = VariableAddress[a]       : 
 #   27|     r27_3(Point &)        = Load[a]                  : &:r27_2, ~m?
 #   27|     r27_4(glval<Point>)   = CopyValue                : r27_3
-#   27|     r27_5(glval<Point>)   = Convert                  : r27_4
-#   27|     r27_6(Point)          = Load[?]                  : &:r27_5, ~m?
-#   27|     mu27_7(Point)         = Store[b]                 : &:r27_1, r27_6
+#   27|     r27_5(Point)          = Load[?]                  : &:r27_4, ~m?
+#   27|     mu27_6(Point)         = Store[b]                 : &:r27_1, r27_5
 #   28|     v28_1(void)           = NoOp                     : 
 #   26|     v26_8(void)           = ReturnIndirection[a]     : &:r26_6, ~m?
 #   26|     v26_9(void)           = ReturnVoid               : 
@@ -868,153 +867,145 @@ coroutines.cpp:
 #   87|     mu87_21(suspend_always *)     = Store[#temp0:0]                           : &:r0_1, r87_20
 #-----|     r0_2(suspend_always *)        = Load[#temp0:0]                            : &:r0_1, ~m?
 #   87|     r87_22(glval<suspend_always>) = CopyValue                                 : r0_2
-#   87|     r87_23(glval<suspend_always>) = Convert                                   : r87_22
-#   87|     r87_24(glval<unknown>)        = FunctionAddress[await_ready]              : 
-#   87|     r87_25(bool)                  = Call[await_ready]                         : func:r87_24, this:r87_23
-#   87|     mu87_26(unknown)              = ^CallSideEffect                           : ~m?
-#   87|     v87_27(void)                  = ^IndirectReadSideEffect[-1]               : &:r87_23, ~m?
-#-----|     v0_3(void)                    = ConditionalBranch                         : r87_25
+#   87|     r87_23(glval<unknown>)        = FunctionAddress[await_ready]              : 
+#   87|     r87_24(bool)                  = Call[await_ready]                         : func:r87_23, this:r87_22
+#   87|     mu87_25(unknown)              = ^CallSideEffect                           : ~m?
+#   87|     v87_26(void)                  = ^IndirectReadSideEffect[-1]               : &:r87_22, ~m?
+#-----|     v0_3(void)                    = ConditionalBranch                         : r87_24
 #-----|   False -> Block 4
 #-----|   True -> Block 3
 
 #   87|   Block 1
-#   87|     v87_28(void) = AliasedUse   : ~m?
-#   87|     v87_29(void) = ExitFunction : 
+#   87|     v87_27(void) = AliasedUse   : ~m?
+#   87|     v87_28(void) = ExitFunction : 
 
 #   87|   Block 2
-#   87|     v87_30(void) = Unwind : 
+#   87|     v87_29(void) = Unwind : 
 #-----|   Goto -> Block 1
 
 #-----|   Block 3
 #-----|     r0_4(bool)                    = Constant[1]                               : 
 #-----|     r0_5(glval<bool>)             = VariableAddress[(unnamed local variable)] : 
 #-----|     mu0_6(bool)                   = Store[(unnamed local variable)]           : &:r0_5, r0_4
-#   87|     r87_31(suspend_always *)      = CopyValue                                 : r87_20
-#   87|     r87_32(glval<suspend_always>) = CopyValue                                 : r87_31
-#-----|     r0_7(glval<suspend_always>)   = Convert                                   : r87_32
-#   87|     r87_33(glval<unknown>)        = FunctionAddress[await_resume]             : 
-#   87|     v87_34(void)                  = Call[await_resume]                        : func:r87_33, this:r0_7
-#   87|     mu87_35(unknown)              = ^CallSideEffect                           : ~m?
-#-----|     v0_8(void)                    = ^IndirectReadSideEffect[-1]               : &:r0_7, ~m?
-#-----|     v0_9(void)                    = CopyValue                                 : v87_34
-#-----|     r0_10(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
-#-----|     r0_11(glval<unknown>)         = FunctionAddress[return_void]              : 
-#-----|     v0_12(void)                   = Call[return_void]                         : func:r0_11, this:r0_10
-#-----|     mu0_13(unknown)               = ^CallSideEffect                           : ~m?
-#-----|     v0_14(void)                   = ^IndirectReadSideEffect[-1]               : &:r0_10, ~m?
-#-----|     mu0_15(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r0_10
+#   87|     r87_30(suspend_always *)      = CopyValue                                 : r87_20
+#   87|     r87_31(glval<suspend_always>) = CopyValue                                 : r87_30
+#   87|     r87_32(glval<unknown>)        = FunctionAddress[await_resume]             : 
+#   87|     v87_33(void)                  = Call[await_resume]                        : func:r87_32, this:r87_31
+#   87|     mu87_34(unknown)              = ^CallSideEffect                           : ~m?
+#-----|     v0_7(void)                    = ^IndirectReadSideEffect[-1]               : &:r87_31, ~m?
+#-----|     v0_8(void)                    = CopyValue                                 : v87_33
+#-----|     r0_9(glval<promise_type>)     = VariableAddress[(unnamed local variable)] : 
+#-----|     r0_10(glval<unknown>)         = FunctionAddress[return_void]              : 
+#-----|     v0_11(void)                   = Call[return_void]                         : func:r0_10, this:r0_9
+#-----|     mu0_12(unknown)               = ^CallSideEffect                           : ~m?
+#-----|     v0_13(void)                   = ^IndirectReadSideEffect[-1]               : &:r0_9, ~m?
+#-----|     mu0_14(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r0_9
 #-----|   C++ Exception -> Block 6
 #-----|   Goto -> Block 5
 
 #   87|   Block 4
-#   87|     r87_36(suspend_always *)                      = CopyValue                                 : r87_20
-#   87|     r87_37(glval<suspend_always>)                 = CopyValue                                 : r87_36
-#-----|     r0_16(glval<suspend_always>)                  = Convert                                   : r87_37
-#   87|     r87_38(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
-#   87|     r87_39(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp87:20]               : 
-#   87|     mu87_40(coroutine_handle<promise_type>)       = Uninitialized[#temp87:20]                 : &:r87_39
-#   87|     r87_41(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
-#   87|     r87_42(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
-#   87|     r87_43(glval<coroutine_handle<promise_type>>) = Convert                                   : r87_42
-#   87|     r87_44(coroutine_handle<promise_type> &)      = CopyValue                                 : r87_43
-#   87|     v87_45(void)                                  = Call[coroutine_handle]                    : func:r87_41, this:r87_39, 0:r87_44
-#   87|     mu87_46(unknown)                              = ^CallSideEffect                           : ~m?
-#   87|     v87_47(void)                                  = ^BufferReadSideEffect[0]                  : &:r87_44, ~m?
-#   87|     mu87_48(coroutine_handle<promise_type>)       = ^IndirectMayWriteSideEffect[-1]           : &:r87_39
-#   87|     r87_49(coroutine_handle<promise_type>)        = Load[#temp87:20]                          : &:r87_39, ~m?
-#   87|     v87_50(void)                                  = Call[await_suspend]                       : func:r87_38, this:r0_16, 0:r87_49
-#   87|     mu87_51(unknown)                              = ^CallSideEffect                           : ~m?
-#-----|     v0_17(void)                                   = ^IndirectReadSideEffect[-1]               : &:r0_16, ~m?
+#   87|     r87_35(suspend_always *)                      = CopyValue                                 : r87_20
+#   87|     r87_36(glval<suspend_always>)                 = CopyValue                                 : r87_35
+#   87|     r87_37(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
+#   87|     r87_38(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp87:20]               : 
+#   87|     mu87_39(coroutine_handle<promise_type>)       = Uninitialized[#temp87:20]                 : &:r87_38
+#   87|     r87_40(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
+#   87|     r87_41(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
+#   87|     r87_42(coroutine_handle<promise_type> &)      = CopyValue                                 : r87_41
+#   87|     v87_43(void)                                  = Call[coroutine_handle]                    : func:r87_40, this:r87_38, 0:r87_42
+#   87|     mu87_44(unknown)                              = ^CallSideEffect                           : ~m?
+#   87|     v87_45(void)                                  = ^BufferReadSideEffect[0]                  : &:r87_42, ~m?
+#   87|     mu87_46(coroutine_handle<promise_type>)       = ^IndirectMayWriteSideEffect[-1]           : &:r87_38
+#   87|     r87_47(coroutine_handle<promise_type>)        = Load[#temp87:20]                          : &:r87_38, ~m?
+#   87|     v87_48(void)                                  = Call[await_suspend]                       : func:r87_37, this:r87_36, 0:r87_47
+#   87|     mu87_49(unknown)                              = ^CallSideEffect                           : ~m?
+#-----|     v0_15(void)                                   = ^IndirectReadSideEffect[-1]               : &:r87_36, ~m?
 #-----|   Goto -> Block 3
 
 #   88|   Block 5
 #   88|     v88_1(void) = NoOp : 
-#-----|     v0_18(void) = NoOp : 
+#-----|     v0_16(void) = NoOp : 
 #-----|   Goto (back edge) -> Block 9
 
 #-----|   Block 6
-#-----|     v0_19(void)        = CatchAny                                  : 
-#-----|     r0_20(glval<bool>) = VariableAddress[(unnamed local variable)] : 
-#-----|     r0_21(bool)        = Load[(unnamed local variable)]            : &:r0_20, ~m?
-#-----|     r0_22(bool)        = LogicalNot                                : r0_21
-#-----|     v0_23(void)        = ConditionalBranch                         : r0_22
+#-----|     v0_17(void)        = CatchAny                                  : 
+#-----|     r0_18(glval<bool>) = VariableAddress[(unnamed local variable)] : 
+#-----|     r0_19(bool)        = Load[(unnamed local variable)]            : &:r0_18, ~m?
+#-----|     r0_20(bool)        = LogicalNot                                : r0_19
+#-----|     v0_21(void)        = ConditionalBranch                         : r0_20
 #-----|   False -> Block 8
 #-----|   True -> Block 7
 
 #-----|   Block 7
-#-----|     v0_24(void) = ReThrow : 
+#-----|     v0_22(void) = ReThrow : 
 #-----|   C++ Exception -> Block 2
 
 #   87|   Block 8
-#   87|     r87_52(glval<promise_type>) = VariableAddress[(unnamed local variable)] : 
-#   87|     r87_53(glval<unknown>)      = FunctionAddress[unhandled_exception]      : 
-#   87|     v87_54(void)                = Call[unhandled_exception]                 : func:r87_53, this:r87_52
-#   87|     mu87_55(unknown)            = ^CallSideEffect                           : ~m?
-#   87|     v87_56(void)                = ^IndirectReadSideEffect[-1]               : &:r87_52, ~m?
-#   87|     mu87_57(promise_type)       = ^IndirectMayWriteSideEffect[-1]           : &:r87_52
+#   87|     r87_50(glval<promise_type>) = VariableAddress[(unnamed local variable)] : 
+#   87|     r87_51(glval<unknown>)      = FunctionAddress[unhandled_exception]      : 
+#   87|     v87_52(void)                = Call[unhandled_exception]                 : func:r87_51, this:r87_50
+#   87|     mu87_53(unknown)            = ^CallSideEffect                           : ~m?
+#   87|     v87_54(void)                = ^IndirectReadSideEffect[-1]               : &:r87_50, ~m?
+#   87|     mu87_55(promise_type)       = ^IndirectMayWriteSideEffect[-1]           : &:r87_50
 #-----|   Goto -> Block 9
 
 #-----|   Block 9
-#-----|     v0_25(void)                    = NoOp                                      : 
-#   87|     r87_58(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
-#   87|     r87_59(glval<unknown>)         = FunctionAddress[final_suspend]            : 
-#   87|     r87_60(suspend_always)         = Call[final_suspend]                       : func:r87_59, this:r87_58
-#   87|     mu87_61(unknown)               = ^CallSideEffect                           : ~m?
-#   87|     v87_62(void)                   = ^IndirectReadSideEffect[-1]               : &:r87_58, ~m?
-#   87|     mu87_63(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r87_58
-#-----|     r0_26(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
-#   87|     r87_64(glval<suspend_always>)  = VariableAddress[#temp87:20]               : 
-#   87|     r87_65(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
-#   87|     r87_66(glval<unknown>)         = FunctionAddress[final_suspend]            : 
-#   87|     r87_67(suspend_always)         = Call[final_suspend]                       : func:r87_66, this:r87_65
-#   87|     mu87_68(unknown)               = ^CallSideEffect                           : ~m?
-#   87|     v87_69(void)                   = ^IndirectReadSideEffect[-1]               : &:r87_65, ~m?
-#   87|     mu87_70(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r87_65
-#   87|     mu87_71(suspend_always)        = Store[#temp87:20]                         : &:r87_64, r87_67
-#   87|     r87_72(suspend_always *)       = CopyValue                                 : r87_64
-#   87|     mu87_73(suspend_always *)      = Store[#temp0:0]                           : &:r0_26, r87_72
-#-----|     r0_27(suspend_always *)        = Load[#temp0:0]                            : &:r0_26, ~m?
-#   87|     r87_74(glval<suspend_always>)  = CopyValue                                 : r0_27
-#   87|     r87_75(glval<suspend_always>)  = Convert                                   : r87_74
-#   87|     r87_76(glval<unknown>)         = FunctionAddress[await_ready]              : 
-#   87|     r87_77(bool)                   = Call[await_ready]                         : func:r87_76, this:r87_75
-#   87|     mu87_78(unknown)               = ^CallSideEffect                           : ~m?
-#   87|     v87_79(void)                   = ^IndirectReadSideEffect[-1]               : &:r87_75, ~m?
-#-----|     v0_28(void)                    = ConditionalBranch                         : r87_77
+#-----|     v0_23(void)                    = NoOp                                      : 
+#   87|     r87_56(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
+#   87|     r87_57(glval<unknown>)         = FunctionAddress[final_suspend]            : 
+#   87|     r87_58(suspend_always)         = Call[final_suspend]                       : func:r87_57, this:r87_56
+#   87|     mu87_59(unknown)               = ^CallSideEffect                           : ~m?
+#   87|     v87_60(void)                   = ^IndirectReadSideEffect[-1]               : &:r87_56, ~m?
+#   87|     mu87_61(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r87_56
+#-----|     r0_24(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
+#   87|     r87_62(glval<suspend_always>)  = VariableAddress[#temp87:20]               : 
+#   87|     r87_63(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
+#   87|     r87_64(glval<unknown>)         = FunctionAddress[final_suspend]            : 
+#   87|     r87_65(suspend_always)         = Call[final_suspend]                       : func:r87_64, this:r87_63
+#   87|     mu87_66(unknown)               = ^CallSideEffect                           : ~m?
+#   87|     v87_67(void)                   = ^IndirectReadSideEffect[-1]               : &:r87_63, ~m?
+#   87|     mu87_68(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r87_63
+#   87|     mu87_69(suspend_always)        = Store[#temp87:20]                         : &:r87_62, r87_65
+#   87|     r87_70(suspend_always *)       = CopyValue                                 : r87_62
+#   87|     mu87_71(suspend_always *)      = Store[#temp0:0]                           : &:r0_24, r87_70
+#-----|     r0_25(suspend_always *)        = Load[#temp0:0]                            : &:r0_24, ~m?
+#   87|     r87_72(glval<suspend_always>)  = CopyValue                                 : r0_25
+#   87|     r87_73(glval<unknown>)         = FunctionAddress[await_ready]              : 
+#   87|     r87_74(bool)                   = Call[await_ready]                         : func:r87_73, this:r87_72
+#   87|     mu87_75(unknown)               = ^CallSideEffect                           : ~m?
+#   87|     v87_76(void)                   = ^IndirectReadSideEffect[-1]               : &:r87_72, ~m?
+#-----|     v0_26(void)                    = ConditionalBranch                         : r87_74
 #-----|   False -> Block 11
 #-----|   True -> Block 10
 
 #   87|   Block 10
-#   87|     r87_80(suspend_always *)          = CopyValue                     : r87_72
-#   87|     r87_81(glval<suspend_always>)     = CopyValue                     : r87_80
-#-----|     r0_29(glval<suspend_always>)      = Convert                       : r87_81
-#   87|     r87_82(glval<unknown>)            = FunctionAddress[await_resume] : 
-#   87|     v87_83(void)                      = Call[await_resume]            : func:r87_82, this:r0_29
-#   87|     mu87_84(unknown)                  = ^CallSideEffect               : ~m?
-#-----|     v0_30(void)                       = ^IndirectReadSideEffect[-1]   : &:r0_29, ~m?
-#   87|     r87_85(glval<co_returnable_void>) = VariableAddress[#return]      : 
-#   87|     v87_86(void)                      = ReturnValue                   : &:r87_85, ~m?
+#   87|     r87_77(suspend_always *)          = CopyValue                     : r87_70
+#   87|     r87_78(glval<suspend_always>)     = CopyValue                     : r87_77
+#   87|     r87_79(glval<unknown>)            = FunctionAddress[await_resume] : 
+#   87|     v87_80(void)                      = Call[await_resume]            : func:r87_79, this:r87_78
+#   87|     mu87_81(unknown)                  = ^CallSideEffect               : ~m?
+#-----|     v0_27(void)                       = ^IndirectReadSideEffect[-1]   : &:r87_78, ~m?
+#   87|     r87_82(glval<co_returnable_void>) = VariableAddress[#return]      : 
+#   87|     v87_83(void)                      = ReturnValue                   : &:r87_82, ~m?
 #-----|   Goto -> Block 1
 
 #   87|   Block 11
-#   87|     r87_87(suspend_always *)                      = CopyValue                                 : r87_72
-#   87|     r87_88(glval<suspend_always>)                 = CopyValue                                 : r87_87
-#-----|     r0_31(glval<suspend_always>)                  = Convert                                   : r87_88
-#   87|     r87_89(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
-#   87|     r87_90(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp87:20]               : 
-#   87|     mu87_91(coroutine_handle<promise_type>)       = Uninitialized[#temp87:20]                 : &:r87_90
-#   87|     r87_92(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
-#   87|     r87_93(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
-#   87|     r87_94(glval<coroutine_handle<promise_type>>) = Convert                                   : r87_93
-#   87|     r87_95(coroutine_handle<promise_type> &)      = CopyValue                                 : r87_94
-#   87|     v87_96(void)                                  = Call[coroutine_handle]                    : func:r87_92, this:r87_90, 0:r87_95
-#   87|     mu87_97(unknown)                              = ^CallSideEffect                           : ~m?
-#   87|     v87_98(void)                                  = ^BufferReadSideEffect[0]                  : &:r87_95, ~m?
-#   87|     mu87_99(coroutine_handle<promise_type>)       = ^IndirectMayWriteSideEffect[-1]           : &:r87_90
-#   87|     r87_100(coroutine_handle<promise_type>)       = Load[#temp87:20]                          : &:r87_90, ~m?
-#   87|     v87_101(void)                                 = Call[await_suspend]                       : func:r87_89, this:r0_31, 0:r87_100
-#   87|     mu87_102(unknown)                             = ^CallSideEffect                           : ~m?
-#-----|     v0_32(void)                                   = ^IndirectReadSideEffect[-1]               : &:r0_31, ~m?
+#   87|     r87_84(suspend_always *)                      = CopyValue                                 : r87_70
+#   87|     r87_85(glval<suspend_always>)                 = CopyValue                                 : r87_84
+#   87|     r87_86(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
+#   87|     r87_87(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp87:20]               : 
+#   87|     mu87_88(coroutine_handle<promise_type>)       = Uninitialized[#temp87:20]                 : &:r87_87
+#   87|     r87_89(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
+#   87|     r87_90(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
+#   87|     r87_91(coroutine_handle<promise_type> &)      = CopyValue                                 : r87_90
+#   87|     v87_92(void)                                  = Call[coroutine_handle]                    : func:r87_89, this:r87_87, 0:r87_91
+#   87|     mu87_93(unknown)                              = ^CallSideEffect                           : ~m?
+#   87|     v87_94(void)                                  = ^BufferReadSideEffect[0]                  : &:r87_91, ~m?
+#   87|     mu87_95(coroutine_handle<promise_type>)       = ^IndirectMayWriteSideEffect[-1]           : &:r87_87
+#   87|     r87_96(coroutine_handle<promise_type>)        = Load[#temp87:20]                          : &:r87_87, ~m?
+#   87|     v87_97(void)                                  = Call[await_suspend]                       : func:r87_86, this:r87_85, 0:r87_96
+#   87|     mu87_98(unknown)                              = ^CallSideEffect                           : ~m?
+#-----|     v0_28(void)                                   = ^IndirectReadSideEffect[-1]               : &:r87_85, ~m?
 #-----|   Goto -> Block 10
 
 #   91| co_returnable_value co_return_int(int)
@@ -1049,155 +1040,147 @@ coroutines.cpp:
 #   91|     mu91_23(suspend_always *)     = Store[#temp0:0]                           : &:r0_5, r91_22
 #-----|     r0_6(suspend_always *)        = Load[#temp0:0]                            : &:r0_5, ~m?
 #   91|     r91_24(glval<suspend_always>) = CopyValue                                 : r0_6
-#   91|     r91_25(glval<suspend_always>) = Convert                                   : r91_24
-#   91|     r91_26(glval<unknown>)        = FunctionAddress[await_ready]              : 
-#   91|     r91_27(bool)                  = Call[await_ready]                         : func:r91_26, this:r91_25
-#   91|     mu91_28(unknown)              = ^CallSideEffect                           : ~m?
-#   91|     v91_29(void)                  = ^IndirectReadSideEffect[-1]               : &:r91_25, ~m?
-#-----|     v0_7(void)                    = ConditionalBranch                         : r91_27
+#   91|     r91_25(glval<unknown>)        = FunctionAddress[await_ready]              : 
+#   91|     r91_26(bool)                  = Call[await_ready]                         : func:r91_25, this:r91_24
+#   91|     mu91_27(unknown)              = ^CallSideEffect                           : ~m?
+#   91|     v91_28(void)                  = ^IndirectReadSideEffect[-1]               : &:r91_24, ~m?
+#-----|     v0_7(void)                    = ConditionalBranch                         : r91_26
 #-----|   False -> Block 4
 #-----|   True -> Block 3
 
 #   91|   Block 1
-#   91|     v91_30(void) = AliasedUse   : ~m?
-#   91|     v91_31(void) = ExitFunction : 
+#   91|     v91_29(void) = AliasedUse   : ~m?
+#   91|     v91_30(void) = ExitFunction : 
 
 #   91|   Block 2
-#   91|     v91_32(void) = Unwind : 
+#   91|     v91_31(void) = Unwind : 
 #-----|   Goto -> Block 1
 
 #-----|   Block 3
 #-----|     r0_8(bool)                    = Constant[1]                               : 
 #-----|     r0_9(glval<bool>)             = VariableAddress[(unnamed local variable)] : 
 #-----|     mu0_10(bool)                  = Store[(unnamed local variable)]           : &:r0_9, r0_8
-#   91|     r91_33(suspend_always *)      = CopyValue                                 : r91_22
-#   91|     r91_34(glval<suspend_always>) = CopyValue                                 : r91_33
-#-----|     r0_11(glval<suspend_always>)  = Convert                                   : r91_34
-#   91|     r91_35(glval<unknown>)        = FunctionAddress[await_resume]             : 
-#   91|     v91_36(void)                  = Call[await_resume]                        : func:r91_35, this:r0_11
-#   91|     mu91_37(unknown)              = ^CallSideEffect                           : ~m?
-#-----|     v0_12(void)                   = ^IndirectReadSideEffect[-1]               : &:r0_11, ~m?
-#-----|     v0_13(void)                   = CopyValue                                 : v91_36
-#-----|     r0_14(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
-#-----|     r0_15(glval<unknown>)         = FunctionAddress[return_value]             : 
+#   91|     r91_32(suspend_always *)      = CopyValue                                 : r91_22
+#   91|     r91_33(glval<suspend_always>) = CopyValue                                 : r91_32
+#   91|     r91_34(glval<unknown>)        = FunctionAddress[await_resume]             : 
+#   91|     v91_35(void)                  = Call[await_resume]                        : func:r91_34, this:r91_33
+#   91|     mu91_36(unknown)              = ^CallSideEffect                           : ~m?
+#-----|     v0_11(void)                   = ^IndirectReadSideEffect[-1]               : &:r91_33, ~m?
+#-----|     v0_12(void)                   = CopyValue                                 : v91_35
+#-----|     r0_13(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
+#-----|     r0_14(glval<unknown>)         = FunctionAddress[return_value]             : 
 #   92|     r92_1(glval<int>)             = VariableAddress[i]                        : 
 #   92|     r92_2(int)                    = Load[i]                                   : &:r92_1, ~m?
-#-----|     v0_16(void)                   = Call[return_value]                        : func:r0_15, this:r0_14, 0:r92_2
-#-----|     mu0_17(unknown)               = ^CallSideEffect                           : ~m?
-#-----|     v0_18(void)                   = ^IndirectReadSideEffect[-1]               : &:r0_14, ~m?
-#-----|     mu0_19(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r0_14
+#-----|     v0_15(void)                   = Call[return_value]                        : func:r0_14, this:r0_13, 0:r92_2
+#-----|     mu0_16(unknown)               = ^CallSideEffect                           : ~m?
+#-----|     v0_17(void)                   = ^IndirectReadSideEffect[-1]               : &:r0_13, ~m?
+#-----|     mu0_18(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r0_13
 #-----|   C++ Exception -> Block 6
 #-----|   Goto -> Block 5
 
 #   91|   Block 4
-#   91|     r91_38(suspend_always *)                      = CopyValue                                 : r91_22
-#   91|     r91_39(glval<suspend_always>)                 = CopyValue                                 : r91_38
-#-----|     r0_20(glval<suspend_always>)                  = Convert                                   : r91_39
-#   91|     r91_40(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
-#   91|     r91_41(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp91:21]               : 
-#   91|     mu91_42(coroutine_handle<promise_type>)       = Uninitialized[#temp91:21]                 : &:r91_41
-#   91|     r91_43(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
-#   91|     r91_44(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
-#   91|     r91_45(glval<coroutine_handle<promise_type>>) = Convert                                   : r91_44
-#   91|     r91_46(coroutine_handle<promise_type> &)      = CopyValue                                 : r91_45
-#   91|     v91_47(void)                                  = Call[coroutine_handle]                    : func:r91_43, this:r91_41, 0:r91_46
-#   91|     mu91_48(unknown)                              = ^CallSideEffect                           : ~m?
-#   91|     v91_49(void)                                  = ^BufferReadSideEffect[0]                  : &:r91_46, ~m?
-#   91|     mu91_50(coroutine_handle<promise_type>)       = ^IndirectMayWriteSideEffect[-1]           : &:r91_41
-#   91|     r91_51(coroutine_handle<promise_type>)        = Load[#temp91:21]                          : &:r91_41, ~m?
-#   91|     v91_52(void)                                  = Call[await_suspend]                       : func:r91_40, this:r0_20, 0:r91_51
-#   91|     mu91_53(unknown)                              = ^CallSideEffect                           : ~m?
-#-----|     v0_21(void)                                   = ^IndirectReadSideEffect[-1]               : &:r0_20, ~m?
+#   91|     r91_37(suspend_always *)                      = CopyValue                                 : r91_22
+#   91|     r91_38(glval<suspend_always>)                 = CopyValue                                 : r91_37
+#   91|     r91_39(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
+#   91|     r91_40(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp91:21]               : 
+#   91|     mu91_41(coroutine_handle<promise_type>)       = Uninitialized[#temp91:21]                 : &:r91_40
+#   91|     r91_42(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
+#   91|     r91_43(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
+#   91|     r91_44(coroutine_handle<promise_type> &)      = CopyValue                                 : r91_43
+#   91|     v91_45(void)                                  = Call[coroutine_handle]                    : func:r91_42, this:r91_40, 0:r91_44
+#   91|     mu91_46(unknown)                              = ^CallSideEffect                           : ~m?
+#   91|     v91_47(void)                                  = ^BufferReadSideEffect[0]                  : &:r91_44, ~m?
+#   91|     mu91_48(coroutine_handle<promise_type>)       = ^IndirectMayWriteSideEffect[-1]           : &:r91_40
+#   91|     r91_49(coroutine_handle<promise_type>)        = Load[#temp91:21]                          : &:r91_40, ~m?
+#   91|     v91_50(void)                                  = Call[await_suspend]                       : func:r91_39, this:r91_38, 0:r91_49
+#   91|     mu91_51(unknown)                              = ^CallSideEffect                           : ~m?
+#-----|     v0_19(void)                                   = ^IndirectReadSideEffect[-1]               : &:r91_38, ~m?
 #-----|   Goto -> Block 3
 
 #   92|   Block 5
 #   92|     v92_3(void) = NoOp : 
-#-----|     v0_22(void) = NoOp : 
+#-----|     v0_20(void) = NoOp : 
 #-----|   Goto (back edge) -> Block 9
 
 #-----|   Block 6
-#-----|     v0_23(void)        = CatchAny                                  : 
-#-----|     r0_24(glval<bool>) = VariableAddress[(unnamed local variable)] : 
-#-----|     r0_25(bool)        = Load[(unnamed local variable)]            : &:r0_24, ~m?
-#-----|     r0_26(bool)        = LogicalNot                                : r0_25
-#-----|     v0_27(void)        = ConditionalBranch                         : r0_26
+#-----|     v0_21(void)        = CatchAny                                  : 
+#-----|     r0_22(glval<bool>) = VariableAddress[(unnamed local variable)] : 
+#-----|     r0_23(bool)        = Load[(unnamed local variable)]            : &:r0_22, ~m?
+#-----|     r0_24(bool)        = LogicalNot                                : r0_23
+#-----|     v0_25(void)        = ConditionalBranch                         : r0_24
 #-----|   False -> Block 8
 #-----|   True -> Block 7
 
 #-----|   Block 7
-#-----|     v0_28(void) = ReThrow : 
+#-----|     v0_26(void) = ReThrow : 
 #-----|   C++ Exception -> Block 2
 
 #   91|   Block 8
-#   91|     r91_54(glval<promise_type>) = VariableAddress[(unnamed local variable)] : 
-#   91|     r91_55(glval<unknown>)      = FunctionAddress[unhandled_exception]      : 
-#   91|     v91_56(void)                = Call[unhandled_exception]                 : func:r91_55, this:r91_54
-#   91|     mu91_57(unknown)            = ^CallSideEffect                           : ~m?
-#   91|     v91_58(void)                = ^IndirectReadSideEffect[-1]               : &:r91_54, ~m?
-#   91|     mu91_59(promise_type)       = ^IndirectMayWriteSideEffect[-1]           : &:r91_54
+#   91|     r91_52(glval<promise_type>) = VariableAddress[(unnamed local variable)] : 
+#   91|     r91_53(glval<unknown>)      = FunctionAddress[unhandled_exception]      : 
+#   91|     v91_54(void)                = Call[unhandled_exception]                 : func:r91_53, this:r91_52
+#   91|     mu91_55(unknown)            = ^CallSideEffect                           : ~m?
+#   91|     v91_56(void)                = ^IndirectReadSideEffect[-1]               : &:r91_52, ~m?
+#   91|     mu91_57(promise_type)       = ^IndirectMayWriteSideEffect[-1]           : &:r91_52
 #-----|   Goto -> Block 9
 
 #-----|   Block 9
-#-----|     v0_29(void)                    = NoOp                                      : 
-#   91|     r91_60(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
-#   91|     r91_61(glval<unknown>)         = FunctionAddress[final_suspend]            : 
-#   91|     r91_62(suspend_always)         = Call[final_suspend]                       : func:r91_61, this:r91_60
-#   91|     mu91_63(unknown)               = ^CallSideEffect                           : ~m?
-#   91|     v91_64(void)                   = ^IndirectReadSideEffect[-1]               : &:r91_60, ~m?
-#   91|     mu91_65(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r91_60
-#-----|     r0_30(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
-#   91|     r91_66(glval<suspend_always>)  = VariableAddress[#temp91:21]               : 
-#   91|     r91_67(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
-#   91|     r91_68(glval<unknown>)         = FunctionAddress[final_suspend]            : 
-#   91|     r91_69(suspend_always)         = Call[final_suspend]                       : func:r91_68, this:r91_67
-#   91|     mu91_70(unknown)               = ^CallSideEffect                           : ~m?
-#   91|     v91_71(void)                   = ^IndirectReadSideEffect[-1]               : &:r91_67, ~m?
-#   91|     mu91_72(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r91_67
-#   91|     mu91_73(suspend_always)        = Store[#temp91:21]                         : &:r91_66, r91_69
-#   91|     r91_74(suspend_always *)       = CopyValue                                 : r91_66
-#   91|     mu91_75(suspend_always *)      = Store[#temp0:0]                           : &:r0_30, r91_74
-#-----|     r0_31(suspend_always *)        = Load[#temp0:0]                            : &:r0_30, ~m?
-#   91|     r91_76(glval<suspend_always>)  = CopyValue                                 : r0_31
-#   91|     r91_77(glval<suspend_always>)  = Convert                                   : r91_76
-#   91|     r91_78(glval<unknown>)         = FunctionAddress[await_ready]              : 
-#   91|     r91_79(bool)                   = Call[await_ready]                         : func:r91_78, this:r91_77
-#   91|     mu91_80(unknown)               = ^CallSideEffect                           : ~m?
-#   91|     v91_81(void)                   = ^IndirectReadSideEffect[-1]               : &:r91_77, ~m?
-#-----|     v0_32(void)                    = ConditionalBranch                         : r91_79
+#-----|     v0_27(void)                    = NoOp                                      : 
+#   91|     r91_58(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
+#   91|     r91_59(glval<unknown>)         = FunctionAddress[final_suspend]            : 
+#   91|     r91_60(suspend_always)         = Call[final_suspend]                       : func:r91_59, this:r91_58
+#   91|     mu91_61(unknown)               = ^CallSideEffect                           : ~m?
+#   91|     v91_62(void)                   = ^IndirectReadSideEffect[-1]               : &:r91_58, ~m?
+#   91|     mu91_63(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r91_58
+#-----|     r0_28(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
+#   91|     r91_64(glval<suspend_always>)  = VariableAddress[#temp91:21]               : 
+#   91|     r91_65(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
+#   91|     r91_66(glval<unknown>)         = FunctionAddress[final_suspend]            : 
+#   91|     r91_67(suspend_always)         = Call[final_suspend]                       : func:r91_66, this:r91_65
+#   91|     mu91_68(unknown)               = ^CallSideEffect                           : ~m?
+#   91|     v91_69(void)                   = ^IndirectReadSideEffect[-1]               : &:r91_65, ~m?
+#   91|     mu91_70(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r91_65
+#   91|     mu91_71(suspend_always)        = Store[#temp91:21]                         : &:r91_64, r91_67
+#   91|     r91_72(suspend_always *)       = CopyValue                                 : r91_64
+#   91|     mu91_73(suspend_always *)      = Store[#temp0:0]                           : &:r0_28, r91_72
+#-----|     r0_29(suspend_always *)        = Load[#temp0:0]                            : &:r0_28, ~m?
+#   91|     r91_74(glval<suspend_always>)  = CopyValue                                 : r0_29
+#   91|     r91_75(glval<unknown>)         = FunctionAddress[await_ready]              : 
+#   91|     r91_76(bool)                   = Call[await_ready]                         : func:r91_75, this:r91_74
+#   91|     mu91_77(unknown)               = ^CallSideEffect                           : ~m?
+#   91|     v91_78(void)                   = ^IndirectReadSideEffect[-1]               : &:r91_74, ~m?
+#-----|     v0_30(void)                    = ConditionalBranch                         : r91_76
 #-----|   False -> Block 11
 #-----|   True -> Block 10
 
 #   91|   Block 10
-#   91|     r91_82(suspend_always *)           = CopyValue                     : r91_74
-#   91|     r91_83(glval<suspend_always>)      = CopyValue                     : r91_82
-#-----|     r0_33(glval<suspend_always>)       = Convert                       : r91_83
-#   91|     r91_84(glval<unknown>)             = FunctionAddress[await_resume] : 
-#   91|     v91_85(void)                       = Call[await_resume]            : func:r91_84, this:r0_33
-#   91|     mu91_86(unknown)                   = ^CallSideEffect               : ~m?
-#-----|     v0_34(void)                        = ^IndirectReadSideEffect[-1]   : &:r0_33, ~m?
-#   91|     r91_87(glval<co_returnable_value>) = VariableAddress[#return]      : 
-#   91|     v91_88(void)                       = ReturnValue                   : &:r91_87, ~m?
+#   91|     r91_79(suspend_always *)           = CopyValue                     : r91_72
+#   91|     r91_80(glval<suspend_always>)      = CopyValue                     : r91_79
+#   91|     r91_81(glval<unknown>)             = FunctionAddress[await_resume] : 
+#   91|     v91_82(void)                       = Call[await_resume]            : func:r91_81, this:r91_80
+#   91|     mu91_83(unknown)                   = ^CallSideEffect               : ~m?
+#-----|     v0_31(void)                        = ^IndirectReadSideEffect[-1]   : &:r91_80, ~m?
+#   91|     r91_84(glval<co_returnable_value>) = VariableAddress[#return]      : 
+#   91|     v91_85(void)                       = ReturnValue                   : &:r91_84, ~m?
 #-----|   Goto -> Block 1
 
 #   91|   Block 11
-#   91|     r91_89(suspend_always *)                      = CopyValue                                 : r91_74
-#   91|     r91_90(glval<suspend_always>)                 = CopyValue                                 : r91_89
-#-----|     r0_35(glval<suspend_always>)                  = Convert                                   : r91_90
-#   91|     r91_91(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
-#   91|     r91_92(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp91:21]               : 
-#   91|     mu91_93(coroutine_handle<promise_type>)       = Uninitialized[#temp91:21]                 : &:r91_92
-#   91|     r91_94(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
-#   91|     r91_95(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
-#   91|     r91_96(glval<coroutine_handle<promise_type>>) = Convert                                   : r91_95
-#   91|     r91_97(coroutine_handle<promise_type> &)      = CopyValue                                 : r91_96
-#   91|     v91_98(void)                                  = Call[coroutine_handle]                    : func:r91_94, this:r91_92, 0:r91_97
-#   91|     mu91_99(unknown)                              = ^CallSideEffect                           : ~m?
-#   91|     v91_100(void)                                 = ^BufferReadSideEffect[0]                  : &:r91_97, ~m?
-#   91|     mu91_101(coroutine_handle<promise_type>)      = ^IndirectMayWriteSideEffect[-1]           : &:r91_92
-#   91|     r91_102(coroutine_handle<promise_type>)       = Load[#temp91:21]                          : &:r91_92, ~m?
-#   91|     v91_103(void)                                 = Call[await_suspend]                       : func:r91_91, this:r0_35, 0:r91_102
-#   91|     mu91_104(unknown)                             = ^CallSideEffect                           : ~m?
-#-----|     v0_36(void)                                   = ^IndirectReadSideEffect[-1]               : &:r0_35, ~m?
+#   91|     r91_86(suspend_always *)                      = CopyValue                                 : r91_72
+#   91|     r91_87(glval<suspend_always>)                 = CopyValue                                 : r91_86
+#   91|     r91_88(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
+#   91|     r91_89(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp91:21]               : 
+#   91|     mu91_90(coroutine_handle<promise_type>)       = Uninitialized[#temp91:21]                 : &:r91_89
+#   91|     r91_91(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
+#   91|     r91_92(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
+#   91|     r91_93(coroutine_handle<promise_type> &)      = CopyValue                                 : r91_92
+#   91|     v91_94(void)                                  = Call[coroutine_handle]                    : func:r91_91, this:r91_89, 0:r91_93
+#   91|     mu91_95(unknown)                              = ^CallSideEffect                           : ~m?
+#   91|     v91_96(void)                                  = ^BufferReadSideEffect[0]                  : &:r91_93, ~m?
+#   91|     mu91_97(coroutine_handle<promise_type>)       = ^IndirectMayWriteSideEffect[-1]           : &:r91_89
+#   91|     r91_98(coroutine_handle<promise_type>)        = Load[#temp91:21]                          : &:r91_89, ~m?
+#   91|     v91_99(void)                                  = Call[await_suspend]                       : func:r91_88, this:r91_87, 0:r91_98
+#   91|     mu91_100(unknown)                             = ^CallSideEffect                           : ~m?
+#-----|     v0_32(void)                                   = ^IndirectReadSideEffect[-1]               : &:r91_87, ~m?
 #-----|   Goto -> Block 10
 
 #   95| co_returnable_void co_yield_value_void(int)
@@ -1232,35 +1215,33 @@ coroutines.cpp:
 #   95|     mu95_23(suspend_always *)     = Store[#temp0:0]                           : &:r0_5, r95_22
 #-----|     r0_6(suspend_always *)        = Load[#temp0:0]                            : &:r0_5, ~m?
 #   95|     r95_24(glval<suspend_always>) = CopyValue                                 : r0_6
-#   95|     r95_25(glval<suspend_always>) = Convert                                   : r95_24
-#   95|     r95_26(glval<unknown>)        = FunctionAddress[await_ready]              : 
-#   95|     r95_27(bool)                  = Call[await_ready]                         : func:r95_26, this:r95_25
-#   95|     mu95_28(unknown)              = ^CallSideEffect                           : ~m?
-#   95|     v95_29(void)                  = ^IndirectReadSideEffect[-1]               : &:r95_25, ~m?
-#-----|     v0_7(void)                    = ConditionalBranch                         : r95_27
+#   95|     r95_25(glval<unknown>)        = FunctionAddress[await_ready]              : 
+#   95|     r95_26(bool)                  = Call[await_ready]                         : func:r95_25, this:r95_24
+#   95|     mu95_27(unknown)              = ^CallSideEffect                           : ~m?
+#   95|     v95_28(void)                  = ^IndirectReadSideEffect[-1]               : &:r95_24, ~m?
+#-----|     v0_7(void)                    = ConditionalBranch                         : r95_26
 #-----|   False -> Block 4
 #-----|   True -> Block 3
 
 #   95|   Block 1
-#   95|     v95_30(void) = AliasedUse   : ~m?
-#   95|     v95_31(void) = ExitFunction : 
+#   95|     v95_29(void) = AliasedUse   : ~m?
+#   95|     v95_30(void) = ExitFunction : 
 
 #   95|   Block 2
-#   95|     v95_32(void) = Unwind : 
+#   95|     v95_31(void) = Unwind : 
 #-----|   Goto -> Block 1
 
 #-----|   Block 3
 #-----|     r0_8(bool)                    = Constant[1]                               : 
 #-----|     r0_9(glval<bool>)             = VariableAddress[(unnamed local variable)] : 
 #-----|     mu0_10(bool)                  = Store[(unnamed local variable)]           : &:r0_9, r0_8
-#   95|     r95_33(suspend_always *)      = CopyValue                                 : r95_22
-#   95|     r95_34(glval<suspend_always>) = CopyValue                                 : r95_33
-#-----|     r0_11(glval<suspend_always>)  = Convert                                   : r95_34
-#   95|     r95_35(glval<unknown>)        = FunctionAddress[await_resume]             : 
-#   95|     v95_36(void)                  = Call[await_resume]                        : func:r95_35, this:r0_11
-#   95|     mu95_37(unknown)              = ^CallSideEffect                           : ~m?
-#-----|     v0_12(void)                   = ^IndirectReadSideEffect[-1]               : &:r0_11, ~m?
-#-----|     v0_13(void)                   = CopyValue                                 : v95_36
+#   95|     r95_32(suspend_always *)      = CopyValue                                 : r95_22
+#   95|     r95_33(glval<suspend_always>) = CopyValue                                 : r95_32
+#   95|     r95_34(glval<unknown>)        = FunctionAddress[await_resume]             : 
+#   95|     v95_35(void)                  = Call[await_resume]                        : func:r95_34, this:r95_33
+#   95|     mu95_36(unknown)              = ^CallSideEffect                           : ~m?
+#-----|     v0_11(void)                   = ^IndirectReadSideEffect[-1]               : &:r95_33, ~m?
+#-----|     v0_12(void)                   = CopyValue                                 : v95_35
 #   96|     r96_1(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
 #   96|     r96_2(glval<unknown>)         = FunctionAddress[yield_value]              : 
 #   96|     r96_3(glval<int>)             = VariableAddress[i]                        : 
@@ -1273,28 +1254,26 @@ coroutines.cpp:
 #-----|   Goto -> Block 5
 
 #   95|   Block 4
-#   95|     r95_38(suspend_always *)                      = CopyValue                                 : r95_22
-#   95|     r95_39(glval<suspend_always>)                 = CopyValue                                 : r95_38
-#-----|     r0_14(glval<suspend_always>)                  = Convert                                   : r95_39
-#   95|     r95_40(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
-#   95|     r95_41(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp95:20]               : 
-#   95|     mu95_42(coroutine_handle<promise_type>)       = Uninitialized[#temp95:20]                 : &:r95_41
-#   95|     r95_43(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
-#   95|     r95_44(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
-#   95|     r95_45(glval<coroutine_handle<promise_type>>) = Convert                                   : r95_44
-#   95|     r95_46(coroutine_handle<promise_type> &)      = CopyValue                                 : r95_45
-#   95|     v95_47(void)                                  = Call[coroutine_handle]                    : func:r95_43, this:r95_41, 0:r95_46
-#   95|     mu95_48(unknown)                              = ^CallSideEffect                           : ~m?
-#   95|     v95_49(void)                                  = ^BufferReadSideEffect[0]                  : &:r95_46, ~m?
-#   95|     mu95_50(coroutine_handle<promise_type>)       = ^IndirectMayWriteSideEffect[-1]           : &:r95_41
-#   95|     r95_51(coroutine_handle<promise_type>)        = Load[#temp95:20]                          : &:r95_41, ~m?
-#   95|     v95_52(void)                                  = Call[await_suspend]                       : func:r95_40, this:r0_14, 0:r95_51
-#   95|     mu95_53(unknown)                              = ^CallSideEffect                           : ~m?
-#-----|     v0_15(void)                                   = ^IndirectReadSideEffect[-1]               : &:r0_14, ~m?
+#   95|     r95_37(suspend_always *)                      = CopyValue                                 : r95_22
+#   95|     r95_38(glval<suspend_always>)                 = CopyValue                                 : r95_37
+#   95|     r95_39(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
+#   95|     r95_40(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp95:20]               : 
+#   95|     mu95_41(coroutine_handle<promise_type>)       = Uninitialized[#temp95:20]                 : &:r95_40
+#   95|     r95_42(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
+#   95|     r95_43(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
+#   95|     r95_44(coroutine_handle<promise_type> &)      = CopyValue                                 : r95_43
+#   95|     v95_45(void)                                  = Call[coroutine_handle]                    : func:r95_42, this:r95_40, 0:r95_44
+#   95|     mu95_46(unknown)                              = ^CallSideEffect                           : ~m?
+#   95|     v95_47(void)                                  = ^BufferReadSideEffect[0]                  : &:r95_44, ~m?
+#   95|     mu95_48(coroutine_handle<promise_type>)       = ^IndirectMayWriteSideEffect[-1]           : &:r95_40
+#   95|     r95_49(coroutine_handle<promise_type>)        = Load[#temp95:20]                          : &:r95_40, ~m?
+#   95|     v95_50(void)                                  = Call[await_suspend]                       : func:r95_39, this:r95_38, 0:r95_49
+#   95|     mu95_51(unknown)                              = ^CallSideEffect                           : ~m?
+#-----|     v0_13(void)                                   = ^IndirectReadSideEffect[-1]               : &:r95_38, ~m?
 #-----|   Goto -> Block 3
 
 #-----|   Block 5
-#-----|     r0_16(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
+#-----|     r0_14(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
 #   96|     r96_9(glval<suspend_always>)   = VariableAddress[#temp96:13]               : 
 #   96|     r96_10(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
 #   96|     r96_11(glval<unknown>)         = FunctionAddress[yield_value]              : 
@@ -1310,144 +1289,136 @@ coroutines.cpp:
 #   96|   Block 6
 #   96|     mu96_18(suspend_always)       = Store[#temp96:13]            : &:r96_9, r96_14
 #   96|     r96_19(suspend_always *)      = CopyValue                    : r96_9
-#   96|     mu96_20(suspend_always *)     = Store[#temp0:0]              : &:r0_16, r96_19
-#-----|     r0_17(suspend_always *)       = Load[#temp0:0]               : &:r0_16, ~m?
-#   96|     r96_21(glval<suspend_always>) = CopyValue                    : r0_17
-#   96|     r96_22(glval<suspend_always>) = Convert                      : r96_21
-#   96|     r96_23(glval<unknown>)        = FunctionAddress[await_ready] : 
-#   96|     r96_24(bool)                  = Call[await_ready]            : func:r96_23, this:r96_22
-#   96|     mu96_25(unknown)              = ^CallSideEffect              : ~m?
-#   96|     v96_26(void)                  = ^IndirectReadSideEffect[-1]  : &:r96_22, ~m?
-#   96|     v96_27(void)                  = ConditionalBranch            : r96_24
+#   96|     mu96_20(suspend_always *)     = Store[#temp0:0]              : &:r0_14, r96_19
+#-----|     r0_15(suspend_always *)       = Load[#temp0:0]               : &:r0_14, ~m?
+#   96|     r96_21(glval<suspend_always>) = CopyValue                    : r0_15
+#   96|     r96_22(glval<unknown>)        = FunctionAddress[await_ready] : 
+#   96|     r96_23(bool)                  = Call[await_ready]            : func:r96_22, this:r96_21
+#   96|     mu96_24(unknown)              = ^CallSideEffect              : ~m?
+#   96|     v96_25(void)                  = ^IndirectReadSideEffect[-1]  : &:r96_21, ~m?
+#   96|     v96_26(void)                  = ConditionalBranch            : r96_23
 #-----|   False -> Block 8
 #-----|   True -> Block 7
 
 #   96|   Block 7
-#   96|     r96_28(suspend_always *)      = CopyValue                                 : r96_19
-#   96|     r96_29(glval<suspend_always>) = CopyValue                                 : r96_28
-#-----|     r0_18(glval<suspend_always>)  = Convert                                   : r96_29
-#   96|     r96_30(glval<unknown>)        = FunctionAddress[await_resume]             : 
-#   96|     v96_31(void)                  = Call[await_resume]                        : func:r96_30, this:r0_18
-#   96|     mu96_32(unknown)              = ^CallSideEffect                           : ~m?
-#-----|     v0_19(void)                   = ^IndirectReadSideEffect[-1]               : &:r0_18, ~m?
-#-----|     r0_20(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
-#-----|     r0_21(glval<unknown>)         = FunctionAddress[return_void]              : 
-#-----|     v0_22(void)                   = Call[return_void]                         : func:r0_21, this:r0_20
-#-----|     mu0_23(unknown)               = ^CallSideEffect                           : ~m?
-#-----|     v0_24(void)                   = ^IndirectReadSideEffect[-1]               : &:r0_20, ~m?
-#-----|     mu0_25(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r0_20
+#   96|     r96_27(suspend_always *)      = CopyValue                                 : r96_19
+#   96|     r96_28(glval<suspend_always>) = CopyValue                                 : r96_27
+#   96|     r96_29(glval<unknown>)        = FunctionAddress[await_resume]             : 
+#   96|     v96_30(void)                  = Call[await_resume]                        : func:r96_29, this:r96_28
+#   96|     mu96_31(unknown)              = ^CallSideEffect                           : ~m?
+#-----|     v0_16(void)                   = ^IndirectReadSideEffect[-1]               : &:r96_28, ~m?
+#-----|     r0_17(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
+#-----|     r0_18(glval<unknown>)         = FunctionAddress[return_void]              : 
+#-----|     v0_19(void)                   = Call[return_void]                         : func:r0_18, this:r0_17
+#-----|     mu0_20(unknown)               = ^CallSideEffect                           : ~m?
+#-----|     v0_21(void)                   = ^IndirectReadSideEffect[-1]               : &:r0_17, ~m?
+#-----|     mu0_22(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r0_17
 #-----|   C++ Exception -> Block 10
 #-----|   Goto -> Block 9
 
 #   96|   Block 8
-#   96|     r96_33(suspend_always *)                      = CopyValue                                 : r96_19
-#   96|     r96_34(glval<suspend_always>)                 = CopyValue                                 : r96_33
-#-----|     r0_26(glval<suspend_always>)                  = Convert                                   : r96_34
-#   96|     r96_35(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
-#   96|     r96_36(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp96:3]                : 
-#   96|     mu96_37(coroutine_handle<promise_type>)       = Uninitialized[#temp96:3]                  : &:r96_36
-#   96|     r96_38(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
-#   96|     r96_39(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
-#   96|     r96_40(glval<coroutine_handle<promise_type>>) = Convert                                   : r96_39
-#   96|     r96_41(coroutine_handle<promise_type> &)      = CopyValue                                 : r96_40
-#   96|     v96_42(void)                                  = Call[coroutine_handle]                    : func:r96_38, this:r96_36, 0:r96_41
-#   96|     mu96_43(unknown)                              = ^CallSideEffect                           : ~m?
-#   96|     v96_44(void)                                  = ^BufferReadSideEffect[0]                  : &:r96_41, ~m?
-#   96|     mu96_45(coroutine_handle<promise_type>)       = ^IndirectMayWriteSideEffect[-1]           : &:r96_36
-#   96|     r96_46(coroutine_handle<promise_type>)        = Load[#temp96:3]                           : &:r96_36, ~m?
-#   96|     v96_47(void)                                  = Call[await_suspend]                       : func:r96_35, this:r0_26, 0:r96_46
-#   96|     mu96_48(unknown)                              = ^CallSideEffect                           : ~m?
-#-----|     v0_27(void)                                   = ^IndirectReadSideEffect[-1]               : &:r0_26, ~m?
+#   96|     r96_32(suspend_always *)                      = CopyValue                                 : r96_19
+#   96|     r96_33(glval<suspend_always>)                 = CopyValue                                 : r96_32
+#   96|     r96_34(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
+#   96|     r96_35(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp96:3]                : 
+#   96|     mu96_36(coroutine_handle<promise_type>)       = Uninitialized[#temp96:3]                  : &:r96_35
+#   96|     r96_37(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
+#   96|     r96_38(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
+#   96|     r96_39(coroutine_handle<promise_type> &)      = CopyValue                                 : r96_38
+#   96|     v96_40(void)                                  = Call[coroutine_handle]                    : func:r96_37, this:r96_35, 0:r96_39
+#   96|     mu96_41(unknown)                              = ^CallSideEffect                           : ~m?
+#   96|     v96_42(void)                                  = ^BufferReadSideEffect[0]                  : &:r96_39, ~m?
+#   96|     mu96_43(coroutine_handle<promise_type>)       = ^IndirectMayWriteSideEffect[-1]           : &:r96_35
+#   96|     r96_44(coroutine_handle<promise_type>)        = Load[#temp96:3]                           : &:r96_35, ~m?
+#   96|     v96_45(void)                                  = Call[await_suspend]                       : func:r96_34, this:r96_33, 0:r96_44
+#   96|     mu96_46(unknown)                              = ^CallSideEffect                           : ~m?
+#-----|     v0_23(void)                                   = ^IndirectReadSideEffect[-1]               : &:r96_33, ~m?
 #-----|   Goto -> Block 7
 
 #   97|   Block 9
 #   97|     v97_1(void) = NoOp : 
-#-----|     v0_28(void) = NoOp : 
+#-----|     v0_24(void) = NoOp : 
 #-----|   Goto (back edge) -> Block 13
 
 #-----|   Block 10
-#-----|     v0_29(void)        = CatchAny                                  : 
-#-----|     r0_30(glval<bool>) = VariableAddress[(unnamed local variable)] : 
-#-----|     r0_31(bool)        = Load[(unnamed local variable)]            : &:r0_30, ~m?
-#-----|     r0_32(bool)        = LogicalNot                                : r0_31
-#-----|     v0_33(void)        = ConditionalBranch                         : r0_32
+#-----|     v0_25(void)        = CatchAny                                  : 
+#-----|     r0_26(glval<bool>) = VariableAddress[(unnamed local variable)] : 
+#-----|     r0_27(bool)        = Load[(unnamed local variable)]            : &:r0_26, ~m?
+#-----|     r0_28(bool)        = LogicalNot                                : r0_27
+#-----|     v0_29(void)        = ConditionalBranch                         : r0_28
 #-----|   False -> Block 12
 #-----|   True -> Block 11
 
 #-----|   Block 11
-#-----|     v0_34(void) = ReThrow : 
+#-----|     v0_30(void) = ReThrow : 
 #-----|   C++ Exception -> Block 2
 
 #   95|   Block 12
-#   95|     r95_54(glval<promise_type>) = VariableAddress[(unnamed local variable)] : 
-#   95|     r95_55(glval<unknown>)      = FunctionAddress[unhandled_exception]      : 
-#   95|     v95_56(void)                = Call[unhandled_exception]                 : func:r95_55, this:r95_54
-#   95|     mu95_57(unknown)            = ^CallSideEffect                           : ~m?
-#   95|     v95_58(void)                = ^IndirectReadSideEffect[-1]               : &:r95_54, ~m?
-#   95|     mu95_59(promise_type)       = ^IndirectMayWriteSideEffect[-1]           : &:r95_54
+#   95|     r95_52(glval<promise_type>) = VariableAddress[(unnamed local variable)] : 
+#   95|     r95_53(glval<unknown>)      = FunctionAddress[unhandled_exception]      : 
+#   95|     v95_54(void)                = Call[unhandled_exception]                 : func:r95_53, this:r95_52
+#   95|     mu95_55(unknown)            = ^CallSideEffect                           : ~m?
+#   95|     v95_56(void)                = ^IndirectReadSideEffect[-1]               : &:r95_52, ~m?
+#   95|     mu95_57(promise_type)       = ^IndirectMayWriteSideEffect[-1]           : &:r95_52
 #-----|   Goto -> Block 13
 
 #-----|   Block 13
-#-----|     v0_35(void)                    = NoOp                                      : 
-#   95|     r95_60(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
-#   95|     r95_61(glval<unknown>)         = FunctionAddress[final_suspend]            : 
-#   95|     r95_62(suspend_always)         = Call[final_suspend]                       : func:r95_61, this:r95_60
-#   95|     mu95_63(unknown)               = ^CallSideEffect                           : ~m?
-#   95|     v95_64(void)                   = ^IndirectReadSideEffect[-1]               : &:r95_60, ~m?
-#   95|     mu95_65(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r95_60
-#-----|     r0_36(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
-#   95|     r95_66(glval<suspend_always>)  = VariableAddress[#temp95:20]               : 
-#   95|     r95_67(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
-#   95|     r95_68(glval<unknown>)         = FunctionAddress[final_suspend]            : 
-#   95|     r95_69(suspend_always)         = Call[final_suspend]                       : func:r95_68, this:r95_67
-#   95|     mu95_70(unknown)               = ^CallSideEffect                           : ~m?
-#   95|     v95_71(void)                   = ^IndirectReadSideEffect[-1]               : &:r95_67, ~m?
-#   95|     mu95_72(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r95_67
-#   95|     mu95_73(suspend_always)        = Store[#temp95:20]                         : &:r95_66, r95_69
-#   95|     r95_74(suspend_always *)       = CopyValue                                 : r95_66
-#   95|     mu95_75(suspend_always *)      = Store[#temp0:0]                           : &:r0_36, r95_74
-#-----|     r0_37(suspend_always *)        = Load[#temp0:0]                            : &:r0_36, ~m?
-#   95|     r95_76(glval<suspend_always>)  = CopyValue                                 : r0_37
-#   95|     r95_77(glval<suspend_always>)  = Convert                                   : r95_76
-#   95|     r95_78(glval<unknown>)         = FunctionAddress[await_ready]              : 
-#   95|     r95_79(bool)                   = Call[await_ready]                         : func:r95_78, this:r95_77
-#   95|     mu95_80(unknown)               = ^CallSideEffect                           : ~m?
-#   95|     v95_81(void)                   = ^IndirectReadSideEffect[-1]               : &:r95_77, ~m?
-#-----|     v0_38(void)                    = ConditionalBranch                         : r95_79
+#-----|     v0_31(void)                    = NoOp                                      : 
+#   95|     r95_58(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
+#   95|     r95_59(glval<unknown>)         = FunctionAddress[final_suspend]            : 
+#   95|     r95_60(suspend_always)         = Call[final_suspend]                       : func:r95_59, this:r95_58
+#   95|     mu95_61(unknown)               = ^CallSideEffect                           : ~m?
+#   95|     v95_62(void)                   = ^IndirectReadSideEffect[-1]               : &:r95_58, ~m?
+#   95|     mu95_63(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r95_58
+#-----|     r0_32(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
+#   95|     r95_64(glval<suspend_always>)  = VariableAddress[#temp95:20]               : 
+#   95|     r95_65(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
+#   95|     r95_66(glval<unknown>)         = FunctionAddress[final_suspend]            : 
+#   95|     r95_67(suspend_always)         = Call[final_suspend]                       : func:r95_66, this:r95_65
+#   95|     mu95_68(unknown)               = ^CallSideEffect                           : ~m?
+#   95|     v95_69(void)                   = ^IndirectReadSideEffect[-1]               : &:r95_65, ~m?
+#   95|     mu95_70(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r95_65
+#   95|     mu95_71(suspend_always)        = Store[#temp95:20]                         : &:r95_64, r95_67
+#   95|     r95_72(suspend_always *)       = CopyValue                                 : r95_64
+#   95|     mu95_73(suspend_always *)      = Store[#temp0:0]                           : &:r0_32, r95_72
+#-----|     r0_33(suspend_always *)        = Load[#temp0:0]                            : &:r0_32, ~m?
+#   95|     r95_74(glval<suspend_always>)  = CopyValue                                 : r0_33
+#   95|     r95_75(glval<unknown>)         = FunctionAddress[await_ready]              : 
+#   95|     r95_76(bool)                   = Call[await_ready]                         : func:r95_75, this:r95_74
+#   95|     mu95_77(unknown)               = ^CallSideEffect                           : ~m?
+#   95|     v95_78(void)                   = ^IndirectReadSideEffect[-1]               : &:r95_74, ~m?
+#-----|     v0_34(void)                    = ConditionalBranch                         : r95_76
 #-----|   False -> Block 15
 #-----|   True -> Block 14
 
 #   95|   Block 14
-#   95|     r95_82(suspend_always *)          = CopyValue                     : r95_74
-#   95|     r95_83(glval<suspend_always>)     = CopyValue                     : r95_82
-#-----|     r0_39(glval<suspend_always>)      = Convert                       : r95_83
-#   95|     r95_84(glval<unknown>)            = FunctionAddress[await_resume] : 
-#   95|     v95_85(void)                      = Call[await_resume]            : func:r95_84, this:r0_39
-#   95|     mu95_86(unknown)                  = ^CallSideEffect               : ~m?
-#-----|     v0_40(void)                       = ^IndirectReadSideEffect[-1]   : &:r0_39, ~m?
-#   95|     r95_87(glval<co_returnable_void>) = VariableAddress[#return]      : 
-#   95|     v95_88(void)                      = ReturnValue                   : &:r95_87, ~m?
+#   95|     r95_79(suspend_always *)          = CopyValue                     : r95_72
+#   95|     r95_80(glval<suspend_always>)     = CopyValue                     : r95_79
+#   95|     r95_81(glval<unknown>)            = FunctionAddress[await_resume] : 
+#   95|     v95_82(void)                      = Call[await_resume]            : func:r95_81, this:r95_80
+#   95|     mu95_83(unknown)                  = ^CallSideEffect               : ~m?
+#-----|     v0_35(void)                       = ^IndirectReadSideEffect[-1]   : &:r95_80, ~m?
+#   95|     r95_84(glval<co_returnable_void>) = VariableAddress[#return]      : 
+#   95|     v95_85(void)                      = ReturnValue                   : &:r95_84, ~m?
 #-----|   Goto -> Block 1
 
 #   95|   Block 15
-#   95|     r95_89(suspend_always *)                      = CopyValue                                 : r95_74
-#   95|     r95_90(glval<suspend_always>)                 = CopyValue                                 : r95_89
-#-----|     r0_41(glval<suspend_always>)                  = Convert                                   : r95_90
-#   95|     r95_91(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
-#   95|     r95_92(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp95:20]               : 
-#   95|     mu95_93(coroutine_handle<promise_type>)       = Uninitialized[#temp95:20]                 : &:r95_92
-#   95|     r95_94(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
-#   95|     r95_95(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
-#   95|     r95_96(glval<coroutine_handle<promise_type>>) = Convert                                   : r95_95
-#   95|     r95_97(coroutine_handle<promise_type> &)      = CopyValue                                 : r95_96
-#   95|     v95_98(void)                                  = Call[coroutine_handle]                    : func:r95_94, this:r95_92, 0:r95_97
-#   95|     mu95_99(unknown)                              = ^CallSideEffect                           : ~m?
-#   95|     v95_100(void)                                 = ^BufferReadSideEffect[0]                  : &:r95_97, ~m?
-#   95|     mu95_101(coroutine_handle<promise_type>)      = ^IndirectMayWriteSideEffect[-1]           : &:r95_92
-#   95|     r95_102(coroutine_handle<promise_type>)       = Load[#temp95:20]                          : &:r95_92, ~m?
-#   95|     v95_103(void)                                 = Call[await_suspend]                       : func:r95_91, this:r0_41, 0:r95_102
-#   95|     mu95_104(unknown)                             = ^CallSideEffect                           : ~m?
-#-----|     v0_42(void)                                   = ^IndirectReadSideEffect[-1]               : &:r0_41, ~m?
+#   95|     r95_86(suspend_always *)                      = CopyValue                                 : r95_72
+#   95|     r95_87(glval<suspend_always>)                 = CopyValue                                 : r95_86
+#   95|     r95_88(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
+#   95|     r95_89(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp95:20]               : 
+#   95|     mu95_90(coroutine_handle<promise_type>)       = Uninitialized[#temp95:20]                 : &:r95_89
+#   95|     r95_91(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
+#   95|     r95_92(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
+#   95|     r95_93(coroutine_handle<promise_type> &)      = CopyValue                                 : r95_92
+#   95|     v95_94(void)                                  = Call[coroutine_handle]                    : func:r95_91, this:r95_89, 0:r95_93
+#   95|     mu95_95(unknown)                              = ^CallSideEffect                           : ~m?
+#   95|     v95_96(void)                                  = ^BufferReadSideEffect[0]                  : &:r95_93, ~m?
+#   95|     mu95_97(coroutine_handle<promise_type>)       = ^IndirectMayWriteSideEffect[-1]           : &:r95_89
+#   95|     r95_98(coroutine_handle<promise_type>)        = Load[#temp95:20]                          : &:r95_89, ~m?
+#   95|     v95_99(void)                                  = Call[await_suspend]                       : func:r95_88, this:r95_87, 0:r95_98
+#   95|     mu95_100(unknown)                             = ^CallSideEffect                           : ~m?
+#-----|     v0_36(void)                                   = ^IndirectReadSideEffect[-1]               : &:r95_87, ~m?
 #-----|   Goto -> Block 14
 
 #   99| co_returnable_value co_yield_value_value(int)
@@ -1482,35 +1453,33 @@ coroutines.cpp:
 #   99|     mu99_23(suspend_always *)     = Store[#temp0:0]                           : &:r0_5, r99_22
 #-----|     r0_6(suspend_always *)        = Load[#temp0:0]                            : &:r0_5, ~m?
 #   99|     r99_24(glval<suspend_always>) = CopyValue                                 : r0_6
-#   99|     r99_25(glval<suspend_always>) = Convert                                   : r99_24
-#   99|     r99_26(glval<unknown>)        = FunctionAddress[await_ready]              : 
-#   99|     r99_27(bool)                  = Call[await_ready]                         : func:r99_26, this:r99_25
-#   99|     mu99_28(unknown)              = ^CallSideEffect                           : ~m?
-#   99|     v99_29(void)                  = ^IndirectReadSideEffect[-1]               : &:r99_25, ~m?
-#-----|     v0_7(void)                    = ConditionalBranch                         : r99_27
+#   99|     r99_25(glval<unknown>)        = FunctionAddress[await_ready]              : 
+#   99|     r99_26(bool)                  = Call[await_ready]                         : func:r99_25, this:r99_24
+#   99|     mu99_27(unknown)              = ^CallSideEffect                           : ~m?
+#   99|     v99_28(void)                  = ^IndirectReadSideEffect[-1]               : &:r99_24, ~m?
+#-----|     v0_7(void)                    = ConditionalBranch                         : r99_26
 #-----|   False -> Block 4
 #-----|   True -> Block 3
 
 #   99|   Block 1
-#   99|     v99_30(void) = AliasedUse   : ~m?
-#   99|     v99_31(void) = ExitFunction : 
+#   99|     v99_29(void) = AliasedUse   : ~m?
+#   99|     v99_30(void) = ExitFunction : 
 
 #   99|   Block 2
-#   99|     v99_32(void) = Unwind : 
+#   99|     v99_31(void) = Unwind : 
 #-----|   Goto -> Block 1
 
 #-----|   Block 3
 #-----|     r0_8(bool)                    = Constant[1]                               : 
 #-----|     r0_9(glval<bool>)             = VariableAddress[(unnamed local variable)] : 
 #-----|     mu0_10(bool)                  = Store[(unnamed local variable)]           : &:r0_9, r0_8
-#   99|     r99_33(suspend_always *)      = CopyValue                                 : r99_22
-#   99|     r99_34(glval<suspend_always>) = CopyValue                                 : r99_33
-#-----|     r0_11(glval<suspend_always>)  = Convert                                   : r99_34
-#   99|     r99_35(glval<unknown>)        = FunctionAddress[await_resume]             : 
-#   99|     v99_36(void)                  = Call[await_resume]                        : func:r99_35, this:r0_11
-#   99|     mu99_37(unknown)              = ^CallSideEffect                           : ~m?
-#-----|     v0_12(void)                   = ^IndirectReadSideEffect[-1]               : &:r0_11, ~m?
-#-----|     v0_13(void)                   = CopyValue                                 : v99_36
+#   99|     r99_32(suspend_always *)      = CopyValue                                 : r99_22
+#   99|     r99_33(glval<suspend_always>) = CopyValue                                 : r99_32
+#   99|     r99_34(glval<unknown>)        = FunctionAddress[await_resume]             : 
+#   99|     v99_35(void)                  = Call[await_resume]                        : func:r99_34, this:r99_33
+#   99|     mu99_36(unknown)              = ^CallSideEffect                           : ~m?
+#-----|     v0_11(void)                   = ^IndirectReadSideEffect[-1]               : &:r99_33, ~m?
+#-----|     v0_12(void)                   = CopyValue                                 : v99_35
 #  100|     r100_1(glval<promise_type>)   = VariableAddress[(unnamed local variable)] : 
 #  100|     r100_2(glval<unknown>)        = FunctionAddress[yield_value]              : 
 #  100|     r100_3(glval<int>)            = VariableAddress[i]                        : 
@@ -1523,28 +1492,26 @@ coroutines.cpp:
 #-----|   Goto -> Block 5
 
 #   99|   Block 4
-#   99|     r99_38(suspend_always *)                      = CopyValue                                 : r99_22
-#   99|     r99_39(glval<suspend_always>)                 = CopyValue                                 : r99_38
-#-----|     r0_14(glval<suspend_always>)                  = Convert                                   : r99_39
-#   99|     r99_40(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
-#   99|     r99_41(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp99:21]               : 
-#   99|     mu99_42(coroutine_handle<promise_type>)       = Uninitialized[#temp99:21]                 : &:r99_41
-#   99|     r99_43(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
-#   99|     r99_44(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
-#   99|     r99_45(glval<coroutine_handle<promise_type>>) = Convert                                   : r99_44
-#   99|     r99_46(coroutine_handle<promise_type> &)      = CopyValue                                 : r99_45
-#   99|     v99_47(void)                                  = Call[coroutine_handle]                    : func:r99_43, this:r99_41, 0:r99_46
-#   99|     mu99_48(unknown)                              = ^CallSideEffect                           : ~m?
-#   99|     v99_49(void)                                  = ^BufferReadSideEffect[0]                  : &:r99_46, ~m?
-#   99|     mu99_50(coroutine_handle<promise_type>)       = ^IndirectMayWriteSideEffect[-1]           : &:r99_41
-#   99|     r99_51(coroutine_handle<promise_type>)        = Load[#temp99:21]                          : &:r99_41, ~m?
-#   99|     v99_52(void)                                  = Call[await_suspend]                       : func:r99_40, this:r0_14, 0:r99_51
-#   99|     mu99_53(unknown)                              = ^CallSideEffect                           : ~m?
-#-----|     v0_15(void)                                   = ^IndirectReadSideEffect[-1]               : &:r0_14, ~m?
+#   99|     r99_37(suspend_always *)                      = CopyValue                                 : r99_22
+#   99|     r99_38(glval<suspend_always>)                 = CopyValue                                 : r99_37
+#   99|     r99_39(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
+#   99|     r99_40(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp99:21]               : 
+#   99|     mu99_41(coroutine_handle<promise_type>)       = Uninitialized[#temp99:21]                 : &:r99_40
+#   99|     r99_42(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
+#   99|     r99_43(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
+#   99|     r99_44(coroutine_handle<promise_type> &)      = CopyValue                                 : r99_43
+#   99|     v99_45(void)                                  = Call[coroutine_handle]                    : func:r99_42, this:r99_40, 0:r99_44
+#   99|     mu99_46(unknown)                              = ^CallSideEffect                           : ~m?
+#   99|     v99_47(void)                                  = ^BufferReadSideEffect[0]                  : &:r99_44, ~m?
+#   99|     mu99_48(coroutine_handle<promise_type>)       = ^IndirectMayWriteSideEffect[-1]           : &:r99_40
+#   99|     r99_49(coroutine_handle<promise_type>)        = Load[#temp99:21]                          : &:r99_40, ~m?
+#   99|     v99_50(void)                                  = Call[await_suspend]                       : func:r99_39, this:r99_38, 0:r99_49
+#   99|     mu99_51(unknown)                              = ^CallSideEffect                           : ~m?
+#-----|     v0_13(void)                                   = ^IndirectReadSideEffect[-1]               : &:r99_38, ~m?
 #-----|   Goto -> Block 3
 
 #-----|   Block 5
-#-----|     r0_16(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
+#-----|     r0_14(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
 #  100|     r100_9(glval<suspend_always>)  = VariableAddress[#temp100:13]              : 
 #  100|     r100_10(glval<promise_type>)   = VariableAddress[(unnamed local variable)] : 
 #  100|     r100_11(glval<unknown>)        = FunctionAddress[yield_value]              : 
@@ -1560,132 +1527,124 @@ coroutines.cpp:
 #  100|   Block 6
 #  100|     mu100_18(suspend_always)       = Store[#temp100:13]           : &:r100_9, r100_14
 #  100|     r100_19(suspend_always *)      = CopyValue                    : r100_9
-#  100|     mu100_20(suspend_always *)     = Store[#temp0:0]              : &:r0_16, r100_19
-#-----|     r0_17(suspend_always *)        = Load[#temp0:0]               : &:r0_16, ~m?
-#  100|     r100_21(glval<suspend_always>) = CopyValue                    : r0_17
-#  100|     r100_22(glval<suspend_always>) = Convert                      : r100_21
-#  100|     r100_23(glval<unknown>)        = FunctionAddress[await_ready] : 
-#  100|     r100_24(bool)                  = Call[await_ready]            : func:r100_23, this:r100_22
-#  100|     mu100_25(unknown)              = ^CallSideEffect              : ~m?
-#  100|     v100_26(void)                  = ^IndirectReadSideEffect[-1]  : &:r100_22, ~m?
-#  100|     v100_27(void)                  = ConditionalBranch            : r100_24
+#  100|     mu100_20(suspend_always *)     = Store[#temp0:0]              : &:r0_14, r100_19
+#-----|     r0_15(suspend_always *)        = Load[#temp0:0]               : &:r0_14, ~m?
+#  100|     r100_21(glval<suspend_always>) = CopyValue                    : r0_15
+#  100|     r100_22(glval<unknown>)        = FunctionAddress[await_ready] : 
+#  100|     r100_23(bool)                  = Call[await_ready]            : func:r100_22, this:r100_21
+#  100|     mu100_24(unknown)              = ^CallSideEffect              : ~m?
+#  100|     v100_25(void)                  = ^IndirectReadSideEffect[-1]  : &:r100_21, ~m?
+#  100|     v100_26(void)                  = ConditionalBranch            : r100_23
 #-----|   False -> Block 8
 #-----|   True -> Block 7
 
 #  100|   Block 7
-#  100|     r100_28(suspend_always *)      = CopyValue                     : r100_19
-#  100|     r100_29(glval<suspend_always>) = CopyValue                     : r100_28
-#-----|     r0_18(glval<suspend_always>)   = Convert                       : r100_29
-#  100|     r100_30(glval<unknown>)        = FunctionAddress[await_resume] : 
-#  100|     v100_31(void)                  = Call[await_resume]            : func:r100_30, this:r0_18
-#  100|     mu100_32(unknown)              = ^CallSideEffect               : ~m?
-#-----|     v0_19(void)                    = ^IndirectReadSideEffect[-1]   : &:r0_18, ~m?
+#  100|     r100_27(suspend_always *)      = CopyValue                     : r100_19
+#  100|     r100_28(glval<suspend_always>) = CopyValue                     : r100_27
+#  100|     r100_29(glval<unknown>)        = FunctionAddress[await_resume] : 
+#  100|     v100_30(void)                  = Call[await_resume]            : func:r100_29, this:r100_28
+#  100|     mu100_31(unknown)              = ^CallSideEffect               : ~m?
+#-----|     v0_16(void)                    = ^IndirectReadSideEffect[-1]   : &:r100_28, ~m?
 #-----|   Goto -> Block 12
 
 #  100|   Block 8
-#  100|     r100_33(suspend_always *)                      = CopyValue                                 : r100_19
-#  100|     r100_34(glval<suspend_always>)                 = CopyValue                                 : r100_33
-#-----|     r0_20(glval<suspend_always>)                   = Convert                                   : r100_34
-#  100|     r100_35(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
-#  100|     r100_36(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp100:3]               : 
-#  100|     mu100_37(coroutine_handle<promise_type>)       = Uninitialized[#temp100:3]                 : &:r100_36
-#  100|     r100_38(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
-#  100|     r100_39(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
-#  100|     r100_40(glval<coroutine_handle<promise_type>>) = Convert                                   : r100_39
-#  100|     r100_41(coroutine_handle<promise_type> &)      = CopyValue                                 : r100_40
-#  100|     v100_42(void)                                  = Call[coroutine_handle]                    : func:r100_38, this:r100_36, 0:r100_41
-#  100|     mu100_43(unknown)                              = ^CallSideEffect                           : ~m?
-#  100|     v100_44(void)                                  = ^BufferReadSideEffect[0]                  : &:r100_41, ~m?
-#  100|     mu100_45(coroutine_handle<promise_type>)       = ^IndirectMayWriteSideEffect[-1]           : &:r100_36
-#  100|     r100_46(coroutine_handle<promise_type>)        = Load[#temp100:3]                          : &:r100_36, ~m?
-#  100|     v100_47(void)                                  = Call[await_suspend]                       : func:r100_35, this:r0_20, 0:r100_46
-#  100|     mu100_48(unknown)                              = ^CallSideEffect                           : ~m?
-#-----|     v0_21(void)                                    = ^IndirectReadSideEffect[-1]               : &:r0_20, ~m?
+#  100|     r100_32(suspend_always *)                      = CopyValue                                 : r100_19
+#  100|     r100_33(glval<suspend_always>)                 = CopyValue                                 : r100_32
+#  100|     r100_34(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
+#  100|     r100_35(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp100:3]               : 
+#  100|     mu100_36(coroutine_handle<promise_type>)       = Uninitialized[#temp100:3]                 : &:r100_35
+#  100|     r100_37(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
+#  100|     r100_38(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
+#  100|     r100_39(coroutine_handle<promise_type> &)      = CopyValue                                 : r100_38
+#  100|     v100_40(void)                                  = Call[coroutine_handle]                    : func:r100_37, this:r100_35, 0:r100_39
+#  100|     mu100_41(unknown)                              = ^CallSideEffect                           : ~m?
+#  100|     v100_42(void)                                  = ^BufferReadSideEffect[0]                  : &:r100_39, ~m?
+#  100|     mu100_43(coroutine_handle<promise_type>)       = ^IndirectMayWriteSideEffect[-1]           : &:r100_35
+#  100|     r100_44(coroutine_handle<promise_type>)        = Load[#temp100:3]                          : &:r100_35, ~m?
+#  100|     v100_45(void)                                  = Call[await_suspend]                       : func:r100_34, this:r100_33, 0:r100_44
+#  100|     mu100_46(unknown)                              = ^CallSideEffect                           : ~m?
+#-----|     v0_17(void)                                    = ^IndirectReadSideEffect[-1]               : &:r100_33, ~m?
 #-----|   Goto -> Block 7
 
 #-----|   Block 9
-#-----|     v0_22(void)        = CatchAny                                  : 
-#-----|     r0_23(glval<bool>) = VariableAddress[(unnamed local variable)] : 
-#-----|     r0_24(bool)        = Load[(unnamed local variable)]            : &:r0_23, ~m?
-#-----|     r0_25(bool)        = LogicalNot                                : r0_24
-#-----|     v0_26(void)        = ConditionalBranch                         : r0_25
+#-----|     v0_18(void)        = CatchAny                                  : 
+#-----|     r0_19(glval<bool>) = VariableAddress[(unnamed local variable)] : 
+#-----|     r0_20(bool)        = Load[(unnamed local variable)]            : &:r0_19, ~m?
+#-----|     r0_21(bool)        = LogicalNot                                : r0_20
+#-----|     v0_22(void)        = ConditionalBranch                         : r0_21
 #-----|   False -> Block 11
 #-----|   True -> Block 10
 
 #-----|   Block 10
-#-----|     v0_27(void) = ReThrow : 
+#-----|     v0_23(void) = ReThrow : 
 #-----|   C++ Exception -> Block 2
 
 #   99|   Block 11
-#   99|     r99_54(glval<promise_type>) = VariableAddress[(unnamed local variable)] : 
-#   99|     r99_55(glval<unknown>)      = FunctionAddress[unhandled_exception]      : 
-#   99|     v99_56(void)                = Call[unhandled_exception]                 : func:r99_55, this:r99_54
-#   99|     mu99_57(unknown)            = ^CallSideEffect                           : ~m?
-#   99|     v99_58(void)                = ^IndirectReadSideEffect[-1]               : &:r99_54, ~m?
-#   99|     mu99_59(promise_type)       = ^IndirectMayWriteSideEffect[-1]           : &:r99_54
+#   99|     r99_52(glval<promise_type>) = VariableAddress[(unnamed local variable)] : 
+#   99|     r99_53(glval<unknown>)      = FunctionAddress[unhandled_exception]      : 
+#   99|     v99_54(void)                = Call[unhandled_exception]                 : func:r99_53, this:r99_52
+#   99|     mu99_55(unknown)            = ^CallSideEffect                           : ~m?
+#   99|     v99_56(void)                = ^IndirectReadSideEffect[-1]               : &:r99_52, ~m?
+#   99|     mu99_57(promise_type)       = ^IndirectMayWriteSideEffect[-1]           : &:r99_52
 #-----|   Goto -> Block 12
 
 #-----|   Block 12
-#-----|     v0_28(void)                    = NoOp                                      : 
-#   99|     r99_60(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
-#   99|     r99_61(glval<unknown>)         = FunctionAddress[final_suspend]            : 
-#   99|     r99_62(suspend_always)         = Call[final_suspend]                       : func:r99_61, this:r99_60
-#   99|     mu99_63(unknown)               = ^CallSideEffect                           : ~m?
-#   99|     v99_64(void)                   = ^IndirectReadSideEffect[-1]               : &:r99_60, ~m?
-#   99|     mu99_65(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r99_60
-#-----|     r0_29(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
-#   99|     r99_66(glval<suspend_always>)  = VariableAddress[#temp99:21]               : 
-#   99|     r99_67(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
-#   99|     r99_68(glval<unknown>)         = FunctionAddress[final_suspend]            : 
-#   99|     r99_69(suspend_always)         = Call[final_suspend]                       : func:r99_68, this:r99_67
-#   99|     mu99_70(unknown)               = ^CallSideEffect                           : ~m?
-#   99|     v99_71(void)                   = ^IndirectReadSideEffect[-1]               : &:r99_67, ~m?
-#   99|     mu99_72(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r99_67
-#   99|     mu99_73(suspend_always)        = Store[#temp99:21]                         : &:r99_66, r99_69
-#   99|     r99_74(suspend_always *)       = CopyValue                                 : r99_66
-#   99|     mu99_75(suspend_always *)      = Store[#temp0:0]                           : &:r0_29, r99_74
-#-----|     r0_30(suspend_always *)        = Load[#temp0:0]                            : &:r0_29, ~m?
-#   99|     r99_76(glval<suspend_always>)  = CopyValue                                 : r0_30
-#   99|     r99_77(glval<suspend_always>)  = Convert                                   : r99_76
-#   99|     r99_78(glval<unknown>)         = FunctionAddress[await_ready]              : 
-#   99|     r99_79(bool)                   = Call[await_ready]                         : func:r99_78, this:r99_77
-#   99|     mu99_80(unknown)               = ^CallSideEffect                           : ~m?
-#   99|     v99_81(void)                   = ^IndirectReadSideEffect[-1]               : &:r99_77, ~m?
-#-----|     v0_31(void)                    = ConditionalBranch                         : r99_79
+#-----|     v0_24(void)                    = NoOp                                      : 
+#   99|     r99_58(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
+#   99|     r99_59(glval<unknown>)         = FunctionAddress[final_suspend]            : 
+#   99|     r99_60(suspend_always)         = Call[final_suspend]                       : func:r99_59, this:r99_58
+#   99|     mu99_61(unknown)               = ^CallSideEffect                           : ~m?
+#   99|     v99_62(void)                   = ^IndirectReadSideEffect[-1]               : &:r99_58, ~m?
+#   99|     mu99_63(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r99_58
+#-----|     r0_25(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
+#   99|     r99_64(glval<suspend_always>)  = VariableAddress[#temp99:21]               : 
+#   99|     r99_65(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
+#   99|     r99_66(glval<unknown>)         = FunctionAddress[final_suspend]            : 
+#   99|     r99_67(suspend_always)         = Call[final_suspend]                       : func:r99_66, this:r99_65
+#   99|     mu99_68(unknown)               = ^CallSideEffect                           : ~m?
+#   99|     v99_69(void)                   = ^IndirectReadSideEffect[-1]               : &:r99_65, ~m?
+#   99|     mu99_70(promise_type)          = ^IndirectMayWriteSideEffect[-1]           : &:r99_65
+#   99|     mu99_71(suspend_always)        = Store[#temp99:21]                         : &:r99_64, r99_67
+#   99|     r99_72(suspend_always *)       = CopyValue                                 : r99_64
+#   99|     mu99_73(suspend_always *)      = Store[#temp0:0]                           : &:r0_25, r99_72
+#-----|     r0_26(suspend_always *)        = Load[#temp0:0]                            : &:r0_25, ~m?
+#   99|     r99_74(glval<suspend_always>)  = CopyValue                                 : r0_26
+#   99|     r99_75(glval<unknown>)         = FunctionAddress[await_ready]              : 
+#   99|     r99_76(bool)                   = Call[await_ready]                         : func:r99_75, this:r99_74
+#   99|     mu99_77(unknown)               = ^CallSideEffect                           : ~m?
+#   99|     v99_78(void)                   = ^IndirectReadSideEffect[-1]               : &:r99_74, ~m?
+#-----|     v0_27(void)                    = ConditionalBranch                         : r99_76
 #-----|   False -> Block 14
 #-----|   True -> Block 13
 
 #   99|   Block 13
-#   99|     r99_82(suspend_always *)           = CopyValue                     : r99_74
-#   99|     r99_83(glval<suspend_always>)      = CopyValue                     : r99_82
-#-----|     r0_32(glval<suspend_always>)       = Convert                       : r99_83
-#   99|     r99_84(glval<unknown>)             = FunctionAddress[await_resume] : 
-#   99|     v99_85(void)                       = Call[await_resume]            : func:r99_84, this:r0_32
-#   99|     mu99_86(unknown)                   = ^CallSideEffect               : ~m?
-#-----|     v0_33(void)                        = ^IndirectReadSideEffect[-1]   : &:r0_32, ~m?
-#   99|     r99_87(glval<co_returnable_value>) = VariableAddress[#return]      : 
-#   99|     v99_88(void)                       = ReturnValue                   : &:r99_87, ~m?
+#   99|     r99_79(suspend_always *)           = CopyValue                     : r99_72
+#   99|     r99_80(glval<suspend_always>)      = CopyValue                     : r99_79
+#   99|     r99_81(glval<unknown>)             = FunctionAddress[await_resume] : 
+#   99|     v99_82(void)                       = Call[await_resume]            : func:r99_81, this:r99_80
+#   99|     mu99_83(unknown)                   = ^CallSideEffect               : ~m?
+#-----|     v0_28(void)                        = ^IndirectReadSideEffect[-1]   : &:r99_80, ~m?
+#   99|     r99_84(glval<co_returnable_value>) = VariableAddress[#return]      : 
+#   99|     v99_85(void)                       = ReturnValue                   : &:r99_84, ~m?
 #-----|   Goto -> Block 1
 
 #   99|   Block 14
-#   99|     r99_89(suspend_always *)                      = CopyValue                                 : r99_74
-#   99|     r99_90(glval<suspend_always>)                 = CopyValue                                 : r99_89
-#-----|     r0_34(glval<suspend_always>)                  = Convert                                   : r99_90
-#   99|     r99_91(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
-#   99|     r99_92(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp99:21]               : 
-#   99|     mu99_93(coroutine_handle<promise_type>)       = Uninitialized[#temp99:21]                 : &:r99_92
-#   99|     r99_94(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
-#   99|     r99_95(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
-#   99|     r99_96(glval<coroutine_handle<promise_type>>) = Convert                                   : r99_95
-#   99|     r99_97(coroutine_handle<promise_type> &)      = CopyValue                                 : r99_96
-#   99|     v99_98(void)                                  = Call[coroutine_handle]                    : func:r99_94, this:r99_92, 0:r99_97
-#   99|     mu99_99(unknown)                              = ^CallSideEffect                           : ~m?
-#   99|     v99_100(void)                                 = ^BufferReadSideEffect[0]                  : &:r99_97, ~m?
-#   99|     mu99_101(coroutine_handle<promise_type>)      = ^IndirectMayWriteSideEffect[-1]           : &:r99_92
-#   99|     r99_102(coroutine_handle<promise_type>)       = Load[#temp99:21]                          : &:r99_92, ~m?
-#   99|     v99_103(void)                                 = Call[await_suspend]                       : func:r99_91, this:r0_34, 0:r99_102
-#   99|     mu99_104(unknown)                             = ^CallSideEffect                           : ~m?
-#-----|     v0_35(void)                                   = ^IndirectReadSideEffect[-1]               : &:r0_34, ~m?
+#   99|     r99_86(suspend_always *)                      = CopyValue                                 : r99_72
+#   99|     r99_87(glval<suspend_always>)                 = CopyValue                                 : r99_86
+#   99|     r99_88(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
+#   99|     r99_89(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp99:21]               : 
+#   99|     mu99_90(coroutine_handle<promise_type>)       = Uninitialized[#temp99:21]                 : &:r99_89
+#   99|     r99_91(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
+#   99|     r99_92(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
+#   99|     r99_93(coroutine_handle<promise_type> &)      = CopyValue                                 : r99_92
+#   99|     v99_94(void)                                  = Call[coroutine_handle]                    : func:r99_91, this:r99_89, 0:r99_93
+#   99|     mu99_95(unknown)                              = ^CallSideEffect                           : ~m?
+#   99|     v99_96(void)                                  = ^BufferReadSideEffect[0]                  : &:r99_93, ~m?
+#   99|     mu99_97(coroutine_handle<promise_type>)       = ^IndirectMayWriteSideEffect[-1]           : &:r99_89
+#   99|     r99_98(coroutine_handle<promise_type>)        = Load[#temp99:21]                          : &:r99_89, ~m?
+#   99|     v99_99(void)                                  = Call[await_suspend]                       : func:r99_88, this:r99_87, 0:r99_98
+#   99|     mu99_100(unknown)                             = ^CallSideEffect                           : ~m?
+#-----|     v0_29(void)                                   = ^IndirectReadSideEffect[-1]               : &:r99_87, ~m?
 #-----|   Goto -> Block 13
 
 #  103| co_returnable_void co_yield_and_return_void(int)
@@ -1720,35 +1679,33 @@ coroutines.cpp:
 #  103|     mu103_23(suspend_always *)     = Store[#temp0:0]                           : &:r0_5, r103_22
 #-----|     r0_6(suspend_always *)         = Load[#temp0:0]                            : &:r0_5, ~m?
 #  103|     r103_24(glval<suspend_always>) = CopyValue                                 : r0_6
-#  103|     r103_25(glval<suspend_always>) = Convert                                   : r103_24
-#  103|     r103_26(glval<unknown>)        = FunctionAddress[await_ready]              : 
-#  103|     r103_27(bool)                  = Call[await_ready]                         : func:r103_26, this:r103_25
-#  103|     mu103_28(unknown)              = ^CallSideEffect                           : ~m?
-#  103|     v103_29(void)                  = ^IndirectReadSideEffect[-1]               : &:r103_25, ~m?
-#-----|     v0_7(void)                     = ConditionalBranch                         : r103_27
+#  103|     r103_25(glval<unknown>)        = FunctionAddress[await_ready]              : 
+#  103|     r103_26(bool)                  = Call[await_ready]                         : func:r103_25, this:r103_24
+#  103|     mu103_27(unknown)              = ^CallSideEffect                           : ~m?
+#  103|     v103_28(void)                  = ^IndirectReadSideEffect[-1]               : &:r103_24, ~m?
+#-----|     v0_7(void)                     = ConditionalBranch                         : r103_26
 #-----|   False -> Block 4
 #-----|   True -> Block 3
 
 #  103|   Block 1
-#  103|     v103_30(void) = AliasedUse   : ~m?
-#  103|     v103_31(void) = ExitFunction : 
+#  103|     v103_29(void) = AliasedUse   : ~m?
+#  103|     v103_30(void) = ExitFunction : 
 
 #  103|   Block 2
-#  103|     v103_32(void) = Unwind : 
+#  103|     v103_31(void) = Unwind : 
 #-----|   Goto -> Block 1
 
 #-----|   Block 3
 #-----|     r0_8(bool)                     = Constant[1]                               : 
 #-----|     r0_9(glval<bool>)              = VariableAddress[(unnamed local variable)] : 
 #-----|     mu0_10(bool)                   = Store[(unnamed local variable)]           : &:r0_9, r0_8
-#  103|     r103_33(suspend_always *)      = CopyValue                                 : r103_22
-#  103|     r103_34(glval<suspend_always>) = CopyValue                                 : r103_33
-#-----|     r0_11(glval<suspend_always>)   = Convert                                   : r103_34
-#  103|     r103_35(glval<unknown>)        = FunctionAddress[await_resume]             : 
-#  103|     v103_36(void)                  = Call[await_resume]                        : func:r103_35, this:r0_11
-#  103|     mu103_37(unknown)              = ^CallSideEffect                           : ~m?
-#-----|     v0_12(void)                    = ^IndirectReadSideEffect[-1]               : &:r0_11, ~m?
-#-----|     v0_13(void)                    = CopyValue                                 : v103_36
+#  103|     r103_32(suspend_always *)      = CopyValue                                 : r103_22
+#  103|     r103_33(glval<suspend_always>) = CopyValue                                 : r103_32
+#  103|     r103_34(glval<unknown>)        = FunctionAddress[await_resume]             : 
+#  103|     v103_35(void)                  = Call[await_resume]                        : func:r103_34, this:r103_33
+#  103|     mu103_36(unknown)              = ^CallSideEffect                           : ~m?
+#-----|     v0_11(void)                    = ^IndirectReadSideEffect[-1]               : &:r103_33, ~m?
+#-----|     v0_12(void)                    = CopyValue                                 : v103_35
 #  104|     r104_1(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
 #  104|     r104_2(glval<unknown>)         = FunctionAddress[yield_value]              : 
 #  104|     r104_3(glval<int>)             = VariableAddress[i]                        : 
@@ -1761,28 +1718,26 @@ coroutines.cpp:
 #-----|   Goto -> Block 5
 
 #  103|   Block 4
-#  103|     r103_38(suspend_always *)                      = CopyValue                                 : r103_22
-#  103|     r103_39(glval<suspend_always>)                 = CopyValue                                 : r103_38
-#-----|     r0_14(glval<suspend_always>)                   = Convert                                   : r103_39
-#  103|     r103_40(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
-#  103|     r103_41(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp103:20]              : 
-#  103|     mu103_42(coroutine_handle<promise_type>)       = Uninitialized[#temp103:20]                : &:r103_41
-#  103|     r103_43(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
-#  103|     r103_44(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
-#  103|     r103_45(glval<coroutine_handle<promise_type>>) = Convert                                   : r103_44
-#  103|     r103_46(coroutine_handle<promise_type> &)      = CopyValue                                 : r103_45
-#  103|     v103_47(void)                                  = Call[coroutine_handle]                    : func:r103_43, this:r103_41, 0:r103_46
-#  103|     mu103_48(unknown)                              = ^CallSideEffect                           : ~m?
-#  103|     v103_49(void)                                  = ^BufferReadSideEffect[0]                  : &:r103_46, ~m?
-#  103|     mu103_50(coroutine_handle<promise_type>)       = ^IndirectMayWriteSideEffect[-1]           : &:r103_41
-#  103|     r103_51(coroutine_handle<promise_type>)        = Load[#temp103:20]                         : &:r103_41, ~m?
-#  103|     v103_52(void)                                  = Call[await_suspend]                       : func:r103_40, this:r0_14, 0:r103_51
-#  103|     mu103_53(unknown)                              = ^CallSideEffect                           : ~m?
-#-----|     v0_15(void)                                    = ^IndirectReadSideEffect[-1]               : &:r0_14, ~m?
+#  103|     r103_37(suspend_always *)                      = CopyValue                                 : r103_22
+#  103|     r103_38(glval<suspend_always>)                 = CopyValue                                 : r103_37
+#  103|     r103_39(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
+#  103|     r103_40(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp103:20]              : 
+#  103|     mu103_41(coroutine_handle<promise_type>)       = Uninitialized[#temp103:20]                : &:r103_40
+#  103|     r103_42(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
+#  103|     r103_43(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
+#  103|     r103_44(coroutine_handle<promise_type> &)      = CopyValue                                 : r103_43
+#  103|     v103_45(void)                                  = Call[coroutine_handle]                    : func:r103_42, this:r103_40, 0:r103_44
+#  103|     mu103_46(unknown)                              = ^CallSideEffect                           : ~m?
+#  103|     v103_47(void)                                  = ^BufferReadSideEffect[0]                  : &:r103_44, ~m?
+#  103|     mu103_48(coroutine_handle<promise_type>)       = ^IndirectMayWriteSideEffect[-1]           : &:r103_40
+#  103|     r103_49(coroutine_handle<promise_type>)        = Load[#temp103:20]                         : &:r103_40, ~m?
+#  103|     v103_50(void)                                  = Call[await_suspend]                       : func:r103_39, this:r103_38, 0:r103_49
+#  103|     mu103_51(unknown)                              = ^CallSideEffect                           : ~m?
+#-----|     v0_13(void)                                    = ^IndirectReadSideEffect[-1]               : &:r103_38, ~m?
 #-----|   Goto -> Block 3
 
 #-----|   Block 5
-#-----|     r0_16(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
+#-----|     r0_14(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
 #  104|     r104_9(glval<suspend_always>)  = VariableAddress[#temp104:13]              : 
 #  104|     r104_10(glval<promise_type>)   = VariableAddress[(unnamed local variable)] : 
 #  104|     r104_11(glval<unknown>)        = FunctionAddress[yield_value]              : 
@@ -1798,144 +1753,136 @@ coroutines.cpp:
 #  104|   Block 6
 #  104|     mu104_18(suspend_always)       = Store[#temp104:13]           : &:r104_9, r104_14
 #  104|     r104_19(suspend_always *)      = CopyValue                    : r104_9
-#  104|     mu104_20(suspend_always *)     = Store[#temp0:0]              : &:r0_16, r104_19
-#-----|     r0_17(suspend_always *)        = Load[#temp0:0]               : &:r0_16, ~m?
-#  104|     r104_21(glval<suspend_always>) = CopyValue                    : r0_17
-#  104|     r104_22(glval<suspend_always>) = Convert                      : r104_21
-#  104|     r104_23(glval<unknown>)        = FunctionAddress[await_ready] : 
-#  104|     r104_24(bool)                  = Call[await_ready]            : func:r104_23, this:r104_22
-#  104|     mu104_25(unknown)              = ^CallSideEffect              : ~m?
-#  104|     v104_26(void)                  = ^IndirectReadSideEffect[-1]  : &:r104_22, ~m?
-#  104|     v104_27(void)                  = ConditionalBranch            : r104_24
+#  104|     mu104_20(suspend_always *)     = Store[#temp0:0]              : &:r0_14, r104_19
+#-----|     r0_15(suspend_always *)        = Load[#temp0:0]               : &:r0_14, ~m?
+#  104|     r104_21(glval<suspend_always>) = CopyValue                    : r0_15
+#  104|     r104_22(glval<unknown>)        = FunctionAddress[await_ready] : 
+#  104|     r104_23(bool)                  = Call[await_ready]            : func:r104_22, this:r104_21
+#  104|     mu104_24(unknown)              = ^CallSideEffect              : ~m?
+#  104|     v104_25(void)                  = ^IndirectReadSideEffect[-1]  : &:r104_21, ~m?
+#  104|     v104_26(void)                  = ConditionalBranch            : r104_23
 #-----|   False -> Block 8
 #-----|   True -> Block 7
 
 #  104|   Block 7
-#  104|     r104_28(suspend_always *)      = CopyValue                                 : r104_19
-#  104|     r104_29(glval<suspend_always>) = CopyValue                                 : r104_28
-#-----|     r0_18(glval<suspend_always>)   = Convert                                   : r104_29
-#  104|     r104_30(glval<unknown>)        = FunctionAddress[await_resume]             : 
-#  104|     v104_31(void)                  = Call[await_resume]                        : func:r104_30, this:r0_18
-#  104|     mu104_32(unknown)              = ^CallSideEffect                           : ~m?
-#-----|     v0_19(void)                    = ^IndirectReadSideEffect[-1]               : &:r0_18, ~m?
-#-----|     r0_20(glval<promise_type>)     = VariableAddress[(unnamed local variable)] : 
-#-----|     r0_21(glval<unknown>)          = FunctionAddress[return_void]              : 
-#-----|     v0_22(void)                    = Call[return_void]                         : func:r0_21, this:r0_20
-#-----|     mu0_23(unknown)                = ^CallSideEffect                           : ~m?
-#-----|     v0_24(void)                    = ^IndirectReadSideEffect[-1]               : &:r0_20, ~m?
-#-----|     mu0_25(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r0_20
+#  104|     r104_27(suspend_always *)      = CopyValue                                 : r104_19
+#  104|     r104_28(glval<suspend_always>) = CopyValue                                 : r104_27
+#  104|     r104_29(glval<unknown>)        = FunctionAddress[await_resume]             : 
+#  104|     v104_30(void)                  = Call[await_resume]                        : func:r104_29, this:r104_28
+#  104|     mu104_31(unknown)              = ^CallSideEffect                           : ~m?
+#-----|     v0_16(void)                    = ^IndirectReadSideEffect[-1]               : &:r104_28, ~m?
+#-----|     r0_17(glval<promise_type>)     = VariableAddress[(unnamed local variable)] : 
+#-----|     r0_18(glval<unknown>)          = FunctionAddress[return_void]              : 
+#-----|     v0_19(void)                    = Call[return_void]                         : func:r0_18, this:r0_17
+#-----|     mu0_20(unknown)                = ^CallSideEffect                           : ~m?
+#-----|     v0_21(void)                    = ^IndirectReadSideEffect[-1]               : &:r0_17, ~m?
+#-----|     mu0_22(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r0_17
 #-----|   C++ Exception -> Block 10
 #-----|   Goto -> Block 9
 
 #  104|   Block 8
-#  104|     r104_33(suspend_always *)                      = CopyValue                                 : r104_19
-#  104|     r104_34(glval<suspend_always>)                 = CopyValue                                 : r104_33
-#-----|     r0_26(glval<suspend_always>)                   = Convert                                   : r104_34
-#  104|     r104_35(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
-#  104|     r104_36(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp104:3]               : 
-#  104|     mu104_37(coroutine_handle<promise_type>)       = Uninitialized[#temp104:3]                 : &:r104_36
-#  104|     r104_38(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
-#  104|     r104_39(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
-#  104|     r104_40(glval<coroutine_handle<promise_type>>) = Convert                                   : r104_39
-#  104|     r104_41(coroutine_handle<promise_type> &)      = CopyValue                                 : r104_40
-#  104|     v104_42(void)                                  = Call[coroutine_handle]                    : func:r104_38, this:r104_36, 0:r104_41
-#  104|     mu104_43(unknown)                              = ^CallSideEffect                           : ~m?
-#  104|     v104_44(void)                                  = ^BufferReadSideEffect[0]                  : &:r104_41, ~m?
-#  104|     mu104_45(coroutine_handle<promise_type>)       = ^IndirectMayWriteSideEffect[-1]           : &:r104_36
-#  104|     r104_46(coroutine_handle<promise_type>)        = Load[#temp104:3]                          : &:r104_36, ~m?
-#  104|     v104_47(void)                                  = Call[await_suspend]                       : func:r104_35, this:r0_26, 0:r104_46
-#  104|     mu104_48(unknown)                              = ^CallSideEffect                           : ~m?
-#-----|     v0_27(void)                                    = ^IndirectReadSideEffect[-1]               : &:r0_26, ~m?
+#  104|     r104_32(suspend_always *)                      = CopyValue                                 : r104_19
+#  104|     r104_33(glval<suspend_always>)                 = CopyValue                                 : r104_32
+#  104|     r104_34(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
+#  104|     r104_35(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp104:3]               : 
+#  104|     mu104_36(coroutine_handle<promise_type>)       = Uninitialized[#temp104:3]                 : &:r104_35
+#  104|     r104_37(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
+#  104|     r104_38(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
+#  104|     r104_39(coroutine_handle<promise_type> &)      = CopyValue                                 : r104_38
+#  104|     v104_40(void)                                  = Call[coroutine_handle]                    : func:r104_37, this:r104_35, 0:r104_39
+#  104|     mu104_41(unknown)                              = ^CallSideEffect                           : ~m?
+#  104|     v104_42(void)                                  = ^BufferReadSideEffect[0]                  : &:r104_39, ~m?
+#  104|     mu104_43(coroutine_handle<promise_type>)       = ^IndirectMayWriteSideEffect[-1]           : &:r104_35
+#  104|     r104_44(coroutine_handle<promise_type>)        = Load[#temp104:3]                          : &:r104_35, ~m?
+#  104|     v104_45(void)                                  = Call[await_suspend]                       : func:r104_34, this:r104_33, 0:r104_44
+#  104|     mu104_46(unknown)                              = ^CallSideEffect                           : ~m?
+#-----|     v0_23(void)                                    = ^IndirectReadSideEffect[-1]               : &:r104_33, ~m?
 #-----|   Goto -> Block 7
 
 #  105|   Block 9
 #  105|     v105_1(void) = NoOp : 
-#-----|     v0_28(void)  = NoOp : 
+#-----|     v0_24(void)  = NoOp : 
 #-----|   Goto (back edge) -> Block 13
 
 #-----|   Block 10
-#-----|     v0_29(void)        = CatchAny                                  : 
-#-----|     r0_30(glval<bool>) = VariableAddress[(unnamed local variable)] : 
-#-----|     r0_31(bool)        = Load[(unnamed local variable)]            : &:r0_30, ~m?
-#-----|     r0_32(bool)        = LogicalNot                                : r0_31
-#-----|     v0_33(void)        = ConditionalBranch                         : r0_32
+#-----|     v0_25(void)        = CatchAny                                  : 
+#-----|     r0_26(glval<bool>) = VariableAddress[(unnamed local variable)] : 
+#-----|     r0_27(bool)        = Load[(unnamed local variable)]            : &:r0_26, ~m?
+#-----|     r0_28(bool)        = LogicalNot                                : r0_27
+#-----|     v0_29(void)        = ConditionalBranch                         : r0_28
 #-----|   False -> Block 12
 #-----|   True -> Block 11
 
 #-----|   Block 11
-#-----|     v0_34(void) = ReThrow : 
+#-----|     v0_30(void) = ReThrow : 
 #-----|   C++ Exception -> Block 2
 
 #  103|   Block 12
-#  103|     r103_54(glval<promise_type>) = VariableAddress[(unnamed local variable)] : 
-#  103|     r103_55(glval<unknown>)      = FunctionAddress[unhandled_exception]      : 
-#  103|     v103_56(void)                = Call[unhandled_exception]                 : func:r103_55, this:r103_54
-#  103|     mu103_57(unknown)            = ^CallSideEffect                           : ~m?
-#  103|     v103_58(void)                = ^IndirectReadSideEffect[-1]               : &:r103_54, ~m?
-#  103|     mu103_59(promise_type)       = ^IndirectMayWriteSideEffect[-1]           : &:r103_54
+#  103|     r103_52(glval<promise_type>) = VariableAddress[(unnamed local variable)] : 
+#  103|     r103_53(glval<unknown>)      = FunctionAddress[unhandled_exception]      : 
+#  103|     v103_54(void)                = Call[unhandled_exception]                 : func:r103_53, this:r103_52
+#  103|     mu103_55(unknown)            = ^CallSideEffect                           : ~m?
+#  103|     v103_56(void)                = ^IndirectReadSideEffect[-1]               : &:r103_52, ~m?
+#  103|     mu103_57(promise_type)       = ^IndirectMayWriteSideEffect[-1]           : &:r103_52
 #-----|   Goto -> Block 13
 
 #-----|   Block 13
-#-----|     v0_35(void)                    = NoOp                                      : 
-#  103|     r103_60(glval<promise_type>)   = VariableAddress[(unnamed local variable)] : 
-#  103|     r103_61(glval<unknown>)        = FunctionAddress[final_suspend]            : 
-#  103|     r103_62(suspend_always)        = Call[final_suspend]                       : func:r103_61, this:r103_60
-#  103|     mu103_63(unknown)              = ^CallSideEffect                           : ~m?
-#  103|     v103_64(void)                  = ^IndirectReadSideEffect[-1]               : &:r103_60, ~m?
-#  103|     mu103_65(promise_type)         = ^IndirectMayWriteSideEffect[-1]           : &:r103_60
-#-----|     r0_36(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
-#  103|     r103_66(glval<suspend_always>) = VariableAddress[#temp103:20]              : 
-#  103|     r103_67(glval<promise_type>)   = VariableAddress[(unnamed local variable)] : 
-#  103|     r103_68(glval<unknown>)        = FunctionAddress[final_suspend]            : 
-#  103|     r103_69(suspend_always)        = Call[final_suspend]                       : func:r103_68, this:r103_67
-#  103|     mu103_70(unknown)              = ^CallSideEffect                           : ~m?
-#  103|     v103_71(void)                  = ^IndirectReadSideEffect[-1]               : &:r103_67, ~m?
-#  103|     mu103_72(promise_type)         = ^IndirectMayWriteSideEffect[-1]           : &:r103_67
-#  103|     mu103_73(suspend_always)       = Store[#temp103:20]                        : &:r103_66, r103_69
-#  103|     r103_74(suspend_always *)      = CopyValue                                 : r103_66
-#  103|     mu103_75(suspend_always *)     = Store[#temp0:0]                           : &:r0_36, r103_74
-#-----|     r0_37(suspend_always *)        = Load[#temp0:0]                            : &:r0_36, ~m?
-#  103|     r103_76(glval<suspend_always>) = CopyValue                                 : r0_37
-#  103|     r103_77(glval<suspend_always>) = Convert                                   : r103_76
-#  103|     r103_78(glval<unknown>)        = FunctionAddress[await_ready]              : 
-#  103|     r103_79(bool)                  = Call[await_ready]                         : func:r103_78, this:r103_77
-#  103|     mu103_80(unknown)              = ^CallSideEffect                           : ~m?
-#  103|     v103_81(void)                  = ^IndirectReadSideEffect[-1]               : &:r103_77, ~m?
-#-----|     v0_38(void)                    = ConditionalBranch                         : r103_79
+#-----|     v0_31(void)                    = NoOp                                      : 
+#  103|     r103_58(glval<promise_type>)   = VariableAddress[(unnamed local variable)] : 
+#  103|     r103_59(glval<unknown>)        = FunctionAddress[final_suspend]            : 
+#  103|     r103_60(suspend_always)        = Call[final_suspend]                       : func:r103_59, this:r103_58
+#  103|     mu103_61(unknown)              = ^CallSideEffect                           : ~m?
+#  103|     v103_62(void)                  = ^IndirectReadSideEffect[-1]               : &:r103_58, ~m?
+#  103|     mu103_63(promise_type)         = ^IndirectMayWriteSideEffect[-1]           : &:r103_58
+#-----|     r0_32(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
+#  103|     r103_64(glval<suspend_always>) = VariableAddress[#temp103:20]              : 
+#  103|     r103_65(glval<promise_type>)   = VariableAddress[(unnamed local variable)] : 
+#  103|     r103_66(glval<unknown>)        = FunctionAddress[final_suspend]            : 
+#  103|     r103_67(suspend_always)        = Call[final_suspend]                       : func:r103_66, this:r103_65
+#  103|     mu103_68(unknown)              = ^CallSideEffect                           : ~m?
+#  103|     v103_69(void)                  = ^IndirectReadSideEffect[-1]               : &:r103_65, ~m?
+#  103|     mu103_70(promise_type)         = ^IndirectMayWriteSideEffect[-1]           : &:r103_65
+#  103|     mu103_71(suspend_always)       = Store[#temp103:20]                        : &:r103_64, r103_67
+#  103|     r103_72(suspend_always *)      = CopyValue                                 : r103_64
+#  103|     mu103_73(suspend_always *)     = Store[#temp0:0]                           : &:r0_32, r103_72
+#-----|     r0_33(suspend_always *)        = Load[#temp0:0]                            : &:r0_32, ~m?
+#  103|     r103_74(glval<suspend_always>) = CopyValue                                 : r0_33
+#  103|     r103_75(glval<unknown>)        = FunctionAddress[await_ready]              : 
+#  103|     r103_76(bool)                  = Call[await_ready]                         : func:r103_75, this:r103_74
+#  103|     mu103_77(unknown)              = ^CallSideEffect                           : ~m?
+#  103|     v103_78(void)                  = ^IndirectReadSideEffect[-1]               : &:r103_74, ~m?
+#-----|     v0_34(void)                    = ConditionalBranch                         : r103_76
 #-----|   False -> Block 15
 #-----|   True -> Block 14
 
 #  103|   Block 14
-#  103|     r103_82(suspend_always *)          = CopyValue                     : r103_74
-#  103|     r103_83(glval<suspend_always>)     = CopyValue                     : r103_82
-#-----|     r0_39(glval<suspend_always>)       = Convert                       : r103_83
-#  103|     r103_84(glval<unknown>)            = FunctionAddress[await_resume] : 
-#  103|     v103_85(void)                      = Call[await_resume]            : func:r103_84, this:r0_39
-#  103|     mu103_86(unknown)                  = ^CallSideEffect               : ~m?
-#-----|     v0_40(void)                        = ^IndirectReadSideEffect[-1]   : &:r0_39, ~m?
-#  103|     r103_87(glval<co_returnable_void>) = VariableAddress[#return]      : 
-#  103|     v103_88(void)                      = ReturnValue                   : &:r103_87, ~m?
+#  103|     r103_79(suspend_always *)          = CopyValue                     : r103_72
+#  103|     r103_80(glval<suspend_always>)     = CopyValue                     : r103_79
+#  103|     r103_81(glval<unknown>)            = FunctionAddress[await_resume] : 
+#  103|     v103_82(void)                      = Call[await_resume]            : func:r103_81, this:r103_80
+#  103|     mu103_83(unknown)                  = ^CallSideEffect               : ~m?
+#-----|     v0_35(void)                        = ^IndirectReadSideEffect[-1]   : &:r103_80, ~m?
+#  103|     r103_84(glval<co_returnable_void>) = VariableAddress[#return]      : 
+#  103|     v103_85(void)                      = ReturnValue                   : &:r103_84, ~m?
 #-----|   Goto -> Block 1
 
 #  103|   Block 15
-#  103|     r103_89(suspend_always *)                      = CopyValue                                 : r103_74
-#  103|     r103_90(glval<suspend_always>)                 = CopyValue                                 : r103_89
-#-----|     r0_41(glval<suspend_always>)                   = Convert                                   : r103_90
-#  103|     r103_91(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
-#  103|     r103_92(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp103:20]              : 
-#  103|     mu103_93(coroutine_handle<promise_type>)       = Uninitialized[#temp103:20]                : &:r103_92
-#  103|     r103_94(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
-#  103|     r103_95(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
-#  103|     r103_96(glval<coroutine_handle<promise_type>>) = Convert                                   : r103_95
-#  103|     r103_97(coroutine_handle<promise_type> &)      = CopyValue                                 : r103_96
-#  103|     v103_98(void)                                  = Call[coroutine_handle]                    : func:r103_94, this:r103_92, 0:r103_97
-#  103|     mu103_99(unknown)                              = ^CallSideEffect                           : ~m?
-#  103|     v103_100(void)                                 = ^BufferReadSideEffect[0]                  : &:r103_97, ~m?
-#  103|     mu103_101(coroutine_handle<promise_type>)      = ^IndirectMayWriteSideEffect[-1]           : &:r103_92
-#  103|     r103_102(coroutine_handle<promise_type>)       = Load[#temp103:20]                         : &:r103_92, ~m?
-#  103|     v103_103(void)                                 = Call[await_suspend]                       : func:r103_91, this:r0_41, 0:r103_102
-#  103|     mu103_104(unknown)                             = ^CallSideEffect                           : ~m?
-#-----|     v0_42(void)                                    = ^IndirectReadSideEffect[-1]               : &:r0_41, ~m?
+#  103|     r103_86(suspend_always *)                      = CopyValue                                 : r103_72
+#  103|     r103_87(glval<suspend_always>)                 = CopyValue                                 : r103_86
+#  103|     r103_88(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
+#  103|     r103_89(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp103:20]              : 
+#  103|     mu103_90(coroutine_handle<promise_type>)       = Uninitialized[#temp103:20]                : &:r103_89
+#  103|     r103_91(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
+#  103|     r103_92(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
+#  103|     r103_93(coroutine_handle<promise_type> &)      = CopyValue                                 : r103_92
+#  103|     v103_94(void)                                  = Call[coroutine_handle]                    : func:r103_91, this:r103_89, 0:r103_93
+#  103|     mu103_95(unknown)                              = ^CallSideEffect                           : ~m?
+#  103|     v103_96(void)                                  = ^BufferReadSideEffect[0]                  : &:r103_93, ~m?
+#  103|     mu103_97(coroutine_handle<promise_type>)       = ^IndirectMayWriteSideEffect[-1]           : &:r103_89
+#  103|     r103_98(coroutine_handle<promise_type>)        = Load[#temp103:20]                         : &:r103_89, ~m?
+#  103|     v103_99(void)                                  = Call[await_suspend]                       : func:r103_88, this:r103_87, 0:r103_98
+#  103|     mu103_100(unknown)                             = ^CallSideEffect                           : ~m?
+#-----|     v0_36(void)                                    = ^IndirectReadSideEffect[-1]               : &:r103_87, ~m?
 #-----|   Goto -> Block 14
 
 #  108| co_returnable_value co_yield_and_return_value(int)
@@ -1970,35 +1917,33 @@ coroutines.cpp:
 #  108|     mu108_23(suspend_always *)     = Store[#temp0:0]                           : &:r0_5, r108_22
 #-----|     r0_6(suspend_always *)         = Load[#temp0:0]                            : &:r0_5, ~m?
 #  108|     r108_24(glval<suspend_always>) = CopyValue                                 : r0_6
-#  108|     r108_25(glval<suspend_always>) = Convert                                   : r108_24
-#  108|     r108_26(glval<unknown>)        = FunctionAddress[await_ready]              : 
-#  108|     r108_27(bool)                  = Call[await_ready]                         : func:r108_26, this:r108_25
-#  108|     mu108_28(unknown)              = ^CallSideEffect                           : ~m?
-#  108|     v108_29(void)                  = ^IndirectReadSideEffect[-1]               : &:r108_25, ~m?
-#-----|     v0_7(void)                     = ConditionalBranch                         : r108_27
+#  108|     r108_25(glval<unknown>)        = FunctionAddress[await_ready]              : 
+#  108|     r108_26(bool)                  = Call[await_ready]                         : func:r108_25, this:r108_24
+#  108|     mu108_27(unknown)              = ^CallSideEffect                           : ~m?
+#  108|     v108_28(void)                  = ^IndirectReadSideEffect[-1]               : &:r108_24, ~m?
+#-----|     v0_7(void)                     = ConditionalBranch                         : r108_26
 #-----|   False -> Block 4
 #-----|   True -> Block 3
 
 #  108|   Block 1
-#  108|     v108_30(void) = AliasedUse   : ~m?
-#  108|     v108_31(void) = ExitFunction : 
+#  108|     v108_29(void) = AliasedUse   : ~m?
+#  108|     v108_30(void) = ExitFunction : 
 
 #  108|   Block 2
-#  108|     v108_32(void) = Unwind : 
+#  108|     v108_31(void) = Unwind : 
 #-----|   Goto -> Block 1
 
 #-----|   Block 3
 #-----|     r0_8(bool)                     = Constant[1]                               : 
 #-----|     r0_9(glval<bool>)              = VariableAddress[(unnamed local variable)] : 
 #-----|     mu0_10(bool)                   = Store[(unnamed local variable)]           : &:r0_9, r0_8
-#  108|     r108_33(suspend_always *)      = CopyValue                                 : r108_22
-#  108|     r108_34(glval<suspend_always>) = CopyValue                                 : r108_33
-#-----|     r0_11(glval<suspend_always>)   = Convert                                   : r108_34
-#  108|     r108_35(glval<unknown>)        = FunctionAddress[await_resume]             : 
-#  108|     v108_36(void)                  = Call[await_resume]                        : func:r108_35, this:r0_11
-#  108|     mu108_37(unknown)              = ^CallSideEffect                           : ~m?
-#-----|     v0_12(void)                    = ^IndirectReadSideEffect[-1]               : &:r0_11, ~m?
-#-----|     v0_13(void)                    = CopyValue                                 : v108_36
+#  108|     r108_32(suspend_always *)      = CopyValue                                 : r108_22
+#  108|     r108_33(glval<suspend_always>) = CopyValue                                 : r108_32
+#  108|     r108_34(glval<unknown>)        = FunctionAddress[await_resume]             : 
+#  108|     v108_35(void)                  = Call[await_resume]                        : func:r108_34, this:r108_33
+#  108|     mu108_36(unknown)              = ^CallSideEffect                           : ~m?
+#-----|     v0_11(void)                    = ^IndirectReadSideEffect[-1]               : &:r108_33, ~m?
+#-----|     v0_12(void)                    = CopyValue                                 : v108_35
 #  109|     r109_1(glval<promise_type>)    = VariableAddress[(unnamed local variable)] : 
 #  109|     r109_2(glval<unknown>)         = FunctionAddress[yield_value]              : 
 #  109|     r109_3(glval<int>)             = VariableAddress[i]                        : 
@@ -2011,28 +1956,26 @@ coroutines.cpp:
 #-----|   Goto -> Block 5
 
 #  108|   Block 4
-#  108|     r108_38(suspend_always *)                      = CopyValue                                 : r108_22
-#  108|     r108_39(glval<suspend_always>)                 = CopyValue                                 : r108_38
-#-----|     r0_14(glval<suspend_always>)                   = Convert                                   : r108_39
-#  108|     r108_40(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
-#  108|     r108_41(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp108:21]              : 
-#  108|     mu108_42(coroutine_handle<promise_type>)       = Uninitialized[#temp108:21]                : &:r108_41
-#  108|     r108_43(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
-#  108|     r108_44(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
-#  108|     r108_45(glval<coroutine_handle<promise_type>>) = Convert                                   : r108_44
-#  108|     r108_46(coroutine_handle<promise_type> &)      = CopyValue                                 : r108_45
-#  108|     v108_47(void)                                  = Call[coroutine_handle]                    : func:r108_43, this:r108_41, 0:r108_46
-#  108|     mu108_48(unknown)                              = ^CallSideEffect                           : ~m?
-#  108|     v108_49(void)                                  = ^BufferReadSideEffect[0]                  : &:r108_46, ~m?
-#  108|     mu108_50(coroutine_handle<promise_type>)       = ^IndirectMayWriteSideEffect[-1]           : &:r108_41
-#  108|     r108_51(coroutine_handle<promise_type>)        = Load[#temp108:21]                         : &:r108_41, ~m?
-#  108|     v108_52(void)                                  = Call[await_suspend]                       : func:r108_40, this:r0_14, 0:r108_51
-#  108|     mu108_53(unknown)                              = ^CallSideEffect                           : ~m?
-#-----|     v0_15(void)                                    = ^IndirectReadSideEffect[-1]               : &:r0_14, ~m?
+#  108|     r108_37(suspend_always *)                      = CopyValue                                 : r108_22
+#  108|     r108_38(glval<suspend_always>)                 = CopyValue                                 : r108_37
+#  108|     r108_39(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
+#  108|     r108_40(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp108:21]              : 
+#  108|     mu108_41(coroutine_handle<promise_type>)       = Uninitialized[#temp108:21]                : &:r108_40
+#  108|     r108_42(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
+#  108|     r108_43(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
+#  108|     r108_44(coroutine_handle<promise_type> &)      = CopyValue                                 : r108_43
+#  108|     v108_45(void)                                  = Call[coroutine_handle]                    : func:r108_42, this:r108_40, 0:r108_44
+#  108|     mu108_46(unknown)                              = ^CallSideEffect                           : ~m?
+#  108|     v108_47(void)                                  = ^BufferReadSideEffect[0]                  : &:r108_44, ~m?
+#  108|     mu108_48(coroutine_handle<promise_type>)       = ^IndirectMayWriteSideEffect[-1]           : &:r108_40
+#  108|     r108_49(coroutine_handle<promise_type>)        = Load[#temp108:21]                         : &:r108_40, ~m?
+#  108|     v108_50(void)                                  = Call[await_suspend]                       : func:r108_39, this:r108_38, 0:r108_49
+#  108|     mu108_51(unknown)                              = ^CallSideEffect                           : ~m?
+#-----|     v0_13(void)                                    = ^IndirectReadSideEffect[-1]               : &:r108_38, ~m?
 #-----|   Goto -> Block 3
 
 #-----|   Block 5
-#-----|     r0_16(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
+#-----|     r0_14(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
 #  109|     r109_9(glval<suspend_always>)  = VariableAddress[#temp109:13]              : 
 #  109|     r109_10(glval<promise_type>)   = VariableAddress[(unnamed local variable)] : 
 #  109|     r109_11(glval<unknown>)        = FunctionAddress[yield_value]              : 
@@ -2048,148 +1991,140 @@ coroutines.cpp:
 #  109|   Block 6
 #  109|     mu109_18(suspend_always)       = Store[#temp109:13]           : &:r109_9, r109_14
 #  109|     r109_19(suspend_always *)      = CopyValue                    : r109_9
-#  109|     mu109_20(suspend_always *)     = Store[#temp0:0]              : &:r0_16, r109_19
-#-----|     r0_17(suspend_always *)        = Load[#temp0:0]               : &:r0_16, ~m?
-#  109|     r109_21(glval<suspend_always>) = CopyValue                    : r0_17
-#  109|     r109_22(glval<suspend_always>) = Convert                      : r109_21
-#  109|     r109_23(glval<unknown>)        = FunctionAddress[await_ready] : 
-#  109|     r109_24(bool)                  = Call[await_ready]            : func:r109_23, this:r109_22
-#  109|     mu109_25(unknown)              = ^CallSideEffect              : ~m?
-#  109|     v109_26(void)                  = ^IndirectReadSideEffect[-1]  : &:r109_22, ~m?
-#  109|     v109_27(void)                  = ConditionalBranch            : r109_24
+#  109|     mu109_20(suspend_always *)     = Store[#temp0:0]              : &:r0_14, r109_19
+#-----|     r0_15(suspend_always *)        = Load[#temp0:0]               : &:r0_14, ~m?
+#  109|     r109_21(glval<suspend_always>) = CopyValue                    : r0_15
+#  109|     r109_22(glval<unknown>)        = FunctionAddress[await_ready] : 
+#  109|     r109_23(bool)                  = Call[await_ready]            : func:r109_22, this:r109_21
+#  109|     mu109_24(unknown)              = ^CallSideEffect              : ~m?
+#  109|     v109_25(void)                  = ^IndirectReadSideEffect[-1]  : &:r109_21, ~m?
+#  109|     v109_26(void)                  = ConditionalBranch            : r109_23
 #-----|   False -> Block 8
 #-----|   True -> Block 7
 
 #  109|   Block 7
-#  109|     r109_28(suspend_always *)      = CopyValue                                 : r109_19
-#  109|     r109_29(glval<suspend_always>) = CopyValue                                 : r109_28
-#-----|     r0_18(glval<suspend_always>)   = Convert                                   : r109_29
-#  109|     r109_30(glval<unknown>)        = FunctionAddress[await_resume]             : 
-#  109|     v109_31(void)                  = Call[await_resume]                        : func:r109_30, this:r0_18
-#  109|     mu109_32(unknown)              = ^CallSideEffect                           : ~m?
-#-----|     v0_19(void)                    = ^IndirectReadSideEffect[-1]               : &:r0_18, ~m?
-#-----|     r0_20(glval<promise_type>)     = VariableAddress[(unnamed local variable)] : 
-#-----|     r0_21(glval<unknown>)          = FunctionAddress[return_value]             : 
+#  109|     r109_27(suspend_always *)      = CopyValue                                 : r109_19
+#  109|     r109_28(glval<suspend_always>) = CopyValue                                 : r109_27
+#  109|     r109_29(glval<unknown>)        = FunctionAddress[await_resume]             : 
+#  109|     v109_30(void)                  = Call[await_resume]                        : func:r109_29, this:r109_28
+#  109|     mu109_31(unknown)              = ^CallSideEffect                           : ~m?
+#-----|     v0_16(void)                    = ^IndirectReadSideEffect[-1]               : &:r109_28, ~m?
+#-----|     r0_17(glval<promise_type>)     = VariableAddress[(unnamed local variable)] : 
+#-----|     r0_18(glval<unknown>)          = FunctionAddress[return_value]             : 
 #  110|     r110_1(glval<int>)             = VariableAddress[i]                        : 
 #  110|     r110_2(int)                    = Load[i]                                   : &:r110_1, ~m?
 #  110|     r110_3(int)                    = Constant[1]                               : 
 #  110|     r110_4(int)                    = Add                                       : r110_2, r110_3
-#-----|     v0_22(void)                    = Call[return_value]                        : func:r0_21, this:r0_20, 0:r110_4
-#-----|     mu0_23(unknown)                = ^CallSideEffect                           : ~m?
-#-----|     v0_24(void)                    = ^IndirectReadSideEffect[-1]               : &:r0_20, ~m?
-#-----|     mu0_25(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r0_20
+#-----|     v0_19(void)                    = Call[return_value]                        : func:r0_18, this:r0_17, 0:r110_4
+#-----|     mu0_20(unknown)                = ^CallSideEffect                           : ~m?
+#-----|     v0_21(void)                    = ^IndirectReadSideEffect[-1]               : &:r0_17, ~m?
+#-----|     mu0_22(promise_type)           = ^IndirectMayWriteSideEffect[-1]           : &:r0_17
 #-----|   C++ Exception -> Block 10
 #-----|   Goto -> Block 9
 
 #  109|   Block 8
-#  109|     r109_33(suspend_always *)                      = CopyValue                                 : r109_19
-#  109|     r109_34(glval<suspend_always>)                 = CopyValue                                 : r109_33
-#-----|     r0_26(glval<suspend_always>)                   = Convert                                   : r109_34
-#  109|     r109_35(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
-#  109|     r109_36(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp109:3]               : 
-#  109|     mu109_37(coroutine_handle<promise_type>)       = Uninitialized[#temp109:3]                 : &:r109_36
-#  109|     r109_38(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
-#  109|     r109_39(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
-#  109|     r109_40(glval<coroutine_handle<promise_type>>) = Convert                                   : r109_39
-#  109|     r109_41(coroutine_handle<promise_type> &)      = CopyValue                                 : r109_40
-#  109|     v109_42(void)                                  = Call[coroutine_handle]                    : func:r109_38, this:r109_36, 0:r109_41
-#  109|     mu109_43(unknown)                              = ^CallSideEffect                           : ~m?
-#  109|     v109_44(void)                                  = ^BufferReadSideEffect[0]                  : &:r109_41, ~m?
-#  109|     mu109_45(coroutine_handle<promise_type>)       = ^IndirectMayWriteSideEffect[-1]           : &:r109_36
-#  109|     r109_46(coroutine_handle<promise_type>)        = Load[#temp109:3]                          : &:r109_36, ~m?
-#  109|     v109_47(void)                                  = Call[await_suspend]                       : func:r109_35, this:r0_26, 0:r109_46
-#  109|     mu109_48(unknown)                              = ^CallSideEffect                           : ~m?
-#-----|     v0_27(void)                                    = ^IndirectReadSideEffect[-1]               : &:r0_26, ~m?
+#  109|     r109_32(suspend_always *)                      = CopyValue                                 : r109_19
+#  109|     r109_33(glval<suspend_always>)                 = CopyValue                                 : r109_32
+#  109|     r109_34(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
+#  109|     r109_35(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp109:3]               : 
+#  109|     mu109_36(coroutine_handle<promise_type>)       = Uninitialized[#temp109:3]                 : &:r109_35
+#  109|     r109_37(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
+#  109|     r109_38(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
+#  109|     r109_39(coroutine_handle<promise_type> &)      = CopyValue                                 : r109_38
+#  109|     v109_40(void)                                  = Call[coroutine_handle]                    : func:r109_37, this:r109_35, 0:r109_39
+#  109|     mu109_41(unknown)                              = ^CallSideEffect                           : ~m?
+#  109|     v109_42(void)                                  = ^BufferReadSideEffect[0]                  : &:r109_39, ~m?
+#  109|     mu109_43(coroutine_handle<promise_type>)       = ^IndirectMayWriteSideEffect[-1]           : &:r109_35
+#  109|     r109_44(coroutine_handle<promise_type>)        = Load[#temp109:3]                          : &:r109_35, ~m?
+#  109|     v109_45(void)                                  = Call[await_suspend]                       : func:r109_34, this:r109_33, 0:r109_44
+#  109|     mu109_46(unknown)                              = ^CallSideEffect                           : ~m?
+#-----|     v0_23(void)                                    = ^IndirectReadSideEffect[-1]               : &:r109_33, ~m?
 #-----|   Goto -> Block 7
 
 #  110|   Block 9
 #  110|     v110_5(void) = NoOp : 
-#-----|     v0_28(void)  = NoOp : 
+#-----|     v0_24(void)  = NoOp : 
 #-----|   Goto (back edge) -> Block 13
 
 #-----|   Block 10
-#-----|     v0_29(void)        = CatchAny                                  : 
-#-----|     r0_30(glval<bool>) = VariableAddress[(unnamed local variable)] : 
-#-----|     r0_31(bool)        = Load[(unnamed local variable)]            : &:r0_30, ~m?
-#-----|     r0_32(bool)        = LogicalNot                                : r0_31
-#-----|     v0_33(void)        = ConditionalBranch                         : r0_32
+#-----|     v0_25(void)        = CatchAny                                  : 
+#-----|     r0_26(glval<bool>) = VariableAddress[(unnamed local variable)] : 
+#-----|     r0_27(bool)        = Load[(unnamed local variable)]            : &:r0_26, ~m?
+#-----|     r0_28(bool)        = LogicalNot                                : r0_27
+#-----|     v0_29(void)        = ConditionalBranch                         : r0_28
 #-----|   False -> Block 12
 #-----|   True -> Block 11
 
 #-----|   Block 11
-#-----|     v0_34(void) = ReThrow : 
+#-----|     v0_30(void) = ReThrow : 
 #-----|   C++ Exception -> Block 2
 
 #  108|   Block 12
-#  108|     r108_54(glval<promise_type>) = VariableAddress[(unnamed local variable)] : 
-#  108|     r108_55(glval<unknown>)      = FunctionAddress[unhandled_exception]      : 
-#  108|     v108_56(void)                = Call[unhandled_exception]                 : func:r108_55, this:r108_54
-#  108|     mu108_57(unknown)            = ^CallSideEffect                           : ~m?
-#  108|     v108_58(void)                = ^IndirectReadSideEffect[-1]               : &:r108_54, ~m?
-#  108|     mu108_59(promise_type)       = ^IndirectMayWriteSideEffect[-1]           : &:r108_54
+#  108|     r108_52(glval<promise_type>) = VariableAddress[(unnamed local variable)] : 
+#  108|     r108_53(glval<unknown>)      = FunctionAddress[unhandled_exception]      : 
+#  108|     v108_54(void)                = Call[unhandled_exception]                 : func:r108_53, this:r108_52
+#  108|     mu108_55(unknown)            = ^CallSideEffect                           : ~m?
+#  108|     v108_56(void)                = ^IndirectReadSideEffect[-1]               : &:r108_52, ~m?
+#  108|     mu108_57(promise_type)       = ^IndirectMayWriteSideEffect[-1]           : &:r108_52
 #-----|   Goto -> Block 13
 
 #-----|   Block 13
-#-----|     v0_35(void)                    = NoOp                                      : 
-#  108|     r108_60(glval<promise_type>)   = VariableAddress[(unnamed local variable)] : 
-#  108|     r108_61(glval<unknown>)        = FunctionAddress[final_suspend]            : 
-#  108|     r108_62(suspend_always)        = Call[final_suspend]                       : func:r108_61, this:r108_60
-#  108|     mu108_63(unknown)              = ^CallSideEffect                           : ~m?
-#  108|     v108_64(void)                  = ^IndirectReadSideEffect[-1]               : &:r108_60, ~m?
-#  108|     mu108_65(promise_type)         = ^IndirectMayWriteSideEffect[-1]           : &:r108_60
-#-----|     r0_36(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
-#  108|     r108_66(glval<suspend_always>) = VariableAddress[#temp108:21]              : 
-#  108|     r108_67(glval<promise_type>)   = VariableAddress[(unnamed local variable)] : 
-#  108|     r108_68(glval<unknown>)        = FunctionAddress[final_suspend]            : 
-#  108|     r108_69(suspend_always)        = Call[final_suspend]                       : func:r108_68, this:r108_67
-#  108|     mu108_70(unknown)              = ^CallSideEffect                           : ~m?
-#  108|     v108_71(void)                  = ^IndirectReadSideEffect[-1]               : &:r108_67, ~m?
-#  108|     mu108_72(promise_type)         = ^IndirectMayWriteSideEffect[-1]           : &:r108_67
-#  108|     mu108_73(suspend_always)       = Store[#temp108:21]                        : &:r108_66, r108_69
-#  108|     r108_74(suspend_always *)      = CopyValue                                 : r108_66
-#  108|     mu108_75(suspend_always *)     = Store[#temp0:0]                           : &:r0_36, r108_74
-#-----|     r0_37(suspend_always *)        = Load[#temp0:0]                            : &:r0_36, ~m?
-#  108|     r108_76(glval<suspend_always>) = CopyValue                                 : r0_37
-#  108|     r108_77(glval<suspend_always>) = Convert                                   : r108_76
-#  108|     r108_78(glval<unknown>)        = FunctionAddress[await_ready]              : 
-#  108|     r108_79(bool)                  = Call[await_ready]                         : func:r108_78, this:r108_77
-#  108|     mu108_80(unknown)              = ^CallSideEffect                           : ~m?
-#  108|     v108_81(void)                  = ^IndirectReadSideEffect[-1]               : &:r108_77, ~m?
-#-----|     v0_38(void)                    = ConditionalBranch                         : r108_79
+#-----|     v0_31(void)                    = NoOp                                      : 
+#  108|     r108_58(glval<promise_type>)   = VariableAddress[(unnamed local variable)] : 
+#  108|     r108_59(glval<unknown>)        = FunctionAddress[final_suspend]            : 
+#  108|     r108_60(suspend_always)        = Call[final_suspend]                       : func:r108_59, this:r108_58
+#  108|     mu108_61(unknown)              = ^CallSideEffect                           : ~m?
+#  108|     v108_62(void)                  = ^IndirectReadSideEffect[-1]               : &:r108_58, ~m?
+#  108|     mu108_63(promise_type)         = ^IndirectMayWriteSideEffect[-1]           : &:r108_58
+#-----|     r0_32(glval<suspend_always *>) = VariableAddress[#temp0:0]                 : 
+#  108|     r108_64(glval<suspend_always>) = VariableAddress[#temp108:21]              : 
+#  108|     r108_65(glval<promise_type>)   = VariableAddress[(unnamed local variable)] : 
+#  108|     r108_66(glval<unknown>)        = FunctionAddress[final_suspend]            : 
+#  108|     r108_67(suspend_always)        = Call[final_suspend]                       : func:r108_66, this:r108_65
+#  108|     mu108_68(unknown)              = ^CallSideEffect                           : ~m?
+#  108|     v108_69(void)                  = ^IndirectReadSideEffect[-1]               : &:r108_65, ~m?
+#  108|     mu108_70(promise_type)         = ^IndirectMayWriteSideEffect[-1]           : &:r108_65
+#  108|     mu108_71(suspend_always)       = Store[#temp108:21]                        : &:r108_64, r108_67
+#  108|     r108_72(suspend_always *)      = CopyValue                                 : r108_64
+#  108|     mu108_73(suspend_always *)     = Store[#temp0:0]                           : &:r0_32, r108_72
+#-----|     r0_33(suspend_always *)        = Load[#temp0:0]                            : &:r0_32, ~m?
+#  108|     r108_74(glval<suspend_always>) = CopyValue                                 : r0_33
+#  108|     r108_75(glval<unknown>)        = FunctionAddress[await_ready]              : 
+#  108|     r108_76(bool)                  = Call[await_ready]                         : func:r108_75, this:r108_74
+#  108|     mu108_77(unknown)              = ^CallSideEffect                           : ~m?
+#  108|     v108_78(void)                  = ^IndirectReadSideEffect[-1]               : &:r108_74, ~m?
+#-----|     v0_34(void)                    = ConditionalBranch                         : r108_76
 #-----|   False -> Block 15
 #-----|   True -> Block 14
 
 #  108|   Block 14
-#  108|     r108_82(suspend_always *)           = CopyValue                     : r108_74
-#  108|     r108_83(glval<suspend_always>)      = CopyValue                     : r108_82
-#-----|     r0_39(glval<suspend_always>)        = Convert                       : r108_83
-#  108|     r108_84(glval<unknown>)             = FunctionAddress[await_resume] : 
-#  108|     v108_85(void)                       = Call[await_resume]            : func:r108_84, this:r0_39
-#  108|     mu108_86(unknown)                   = ^CallSideEffect               : ~m?
-#-----|     v0_40(void)                         = ^IndirectReadSideEffect[-1]   : &:r0_39, ~m?
-#  108|     r108_87(glval<co_returnable_value>) = VariableAddress[#return]      : 
-#  108|     v108_88(void)                       = ReturnValue                   : &:r108_87, ~m?
+#  108|     r108_79(suspend_always *)           = CopyValue                     : r108_72
+#  108|     r108_80(glval<suspend_always>)      = CopyValue                     : r108_79
+#  108|     r108_81(glval<unknown>)             = FunctionAddress[await_resume] : 
+#  108|     v108_82(void)                       = Call[await_resume]            : func:r108_81, this:r108_80
+#  108|     mu108_83(unknown)                   = ^CallSideEffect               : ~m?
+#-----|     v0_35(void)                         = ^IndirectReadSideEffect[-1]   : &:r108_80, ~m?
+#  108|     r108_84(glval<co_returnable_value>) = VariableAddress[#return]      : 
+#  108|     v108_85(void)                       = ReturnValue                   : &:r108_84, ~m?
 #-----|   Goto -> Block 1
 
 #  108|   Block 15
-#  108|     r108_89(suspend_always *)                      = CopyValue                                 : r108_74
-#  108|     r108_90(glval<suspend_always>)                 = CopyValue                                 : r108_89
-#-----|     r0_41(glval<suspend_always>)                   = Convert                                   : r108_90
-#  108|     r108_91(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
-#  108|     r108_92(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp108:21]              : 
-#  108|     mu108_93(coroutine_handle<promise_type>)       = Uninitialized[#temp108:21]                : &:r108_92
-#  108|     r108_94(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
-#  108|     r108_95(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
-#  108|     r108_96(glval<coroutine_handle<promise_type>>) = Convert                                   : r108_95
-#  108|     r108_97(coroutine_handle<promise_type> &)      = CopyValue                                 : r108_96
-#  108|     v108_98(void)                                  = Call[coroutine_handle]                    : func:r108_94, this:r108_92, 0:r108_97
-#  108|     mu108_99(unknown)                              = ^CallSideEffect                           : ~m?
-#  108|     v108_100(void)                                 = ^BufferReadSideEffect[0]                  : &:r108_97, ~m?
-#  108|     mu108_101(coroutine_handle<promise_type>)      = ^IndirectMayWriteSideEffect[-1]           : &:r108_92
-#  108|     r108_102(coroutine_handle<promise_type>)       = Load[#temp108:21]                         : &:r108_92, ~m?
-#  108|     v108_103(void)                                 = Call[await_suspend]                       : func:r108_91, this:r0_41, 0:r108_102
-#  108|     mu108_104(unknown)                             = ^CallSideEffect                           : ~m?
-#-----|     v0_42(void)                                    = ^IndirectReadSideEffect[-1]               : &:r0_41, ~m?
+#  108|     r108_86(suspend_always *)                      = CopyValue                                 : r108_72
+#  108|     r108_87(glval<suspend_always>)                 = CopyValue                                 : r108_86
+#  108|     r108_88(glval<unknown>)                        = FunctionAddress[await_suspend]            : 
+#  108|     r108_89(glval<coroutine_handle<promise_type>>) = VariableAddress[#temp108:21]              : 
+#  108|     mu108_90(coroutine_handle<promise_type>)       = Uninitialized[#temp108:21]                : &:r108_89
+#  108|     r108_91(glval<unknown>)                        = FunctionAddress[coroutine_handle]         : 
+#  108|     r108_92(glval<coroutine_handle<promise_type>>) = VariableAddress[(unnamed local variable)] : 
+#  108|     r108_93(coroutine_handle<promise_type> &)      = CopyValue                                 : r108_92
+#  108|     v108_94(void)                                  = Call[coroutine_handle]                    : func:r108_91, this:r108_89, 0:r108_93
+#  108|     mu108_95(unknown)                              = ^CallSideEffect                           : ~m?
+#  108|     v108_96(void)                                  = ^BufferReadSideEffect[0]                  : &:r108_93, ~m?
+#  108|     mu108_97(coroutine_handle<promise_type>)       = ^IndirectMayWriteSideEffect[-1]           : &:r108_89
+#  108|     r108_98(coroutine_handle<promise_type>)        = Load[#temp108:21]                         : &:r108_89, ~m?
+#  108|     v108_99(void)                                  = Call[await_suspend]                       : func:r108_88, this:r108_87, 0:r108_98
+#  108|     mu108_100(unknown)                             = ^CallSideEffect                           : ~m?
+#-----|     v0_36(void)                                    = ^IndirectReadSideEffect[-1]               : &:r108_87, ~m?
 #-----|   Goto -> Block 14
 
 destructors_for_temps.cpp:
@@ -2356,9 +2291,8 @@ destructors_for_temps.cpp:
 #   30|     r30_4(ClassWithDestructor2)          = Call[returnValue]                      : func:r30_3
 #   30|     mu30_5(unknown)                      = ^CallSideEffect                        : ~m?
 #   30|     mu30_6(ClassWithDestructor2)         = Store[#temp30:38]                      : &:r30_2, r30_4
-#   30|     r30_7(glval<ClassWithDestructor2>)   = Convert                                : r30_2
-#   30|     r30_8(ClassWithDestructor2 &)        = CopyValue                              : r30_7
-#   30|     mu30_9(ClassWithDestructor2 &)       = Store[rs]                              : &:r30_1, r30_8
+#   30|     r30_7(ClassWithDestructor2 &)        = CopyValue                              : r30_2
+#   30|     mu30_8(ClassWithDestructor2 &)       = Store[rs]                              : &:r30_1, r30_7
 #   31|     v31_1(void)                          = NoOp                                   : 
 #   31|     r31_2(glval<ClassWithDestructor2>)   = CopyValue                              : r30_2
 #   31|     r31_3(glval<unknown>)                = FunctionAddress[~ClassWithDestructor2] : 
@@ -2387,9 +2321,8 @@ destructors_for_temps.cpp:
 #   35|     r35_4(ClassWithDestructor2)          = Call[returnValue]                      : func:r35_3
 #   35|     mu35_5(unknown)                      = ^CallSideEffect                        : ~m?
 #   35|     mu35_6(ClassWithDestructor2)         = Store[#temp35:39]                      : &:r35_2, r35_4
-#   35|     r35_7(glval<ClassWithDestructor2>)   = Convert                                : r35_2
-#   35|     r35_8(ClassWithDestructor2 &)        = CopyValue                              : r35_7
-#   35|     mu35_9(ClassWithDestructor2 &)       = Store[rs2]                             : &:r35_1, r35_8
+#   35|     r35_7(ClassWithDestructor2 &)        = CopyValue                              : r35_2
+#   35|     mu35_8(ClassWithDestructor2 &)       = Store[rs2]                             : &:r35_1, r35_7
 #   36|     v36_1(void)                          = NoOp                                   : 
 #   36|     r36_2(glval<ClassWithDestructor2>)   = CopyValue                              : r35_2
 #   36|     r36_3(glval<unknown>)                = FunctionAddress[~ClassWithDestructor2] : 
@@ -2934,8 +2867,7 @@ generic.c:
 #   16|     r16_1(glval<char *>)  = VariableAddress[#return] : 
 #   16|     r16_2(glval<char[4]>) = Constant[int]            : 
 #   16|     r16_3(char *)         = Convert                  : r16_2
-#   16|     r16_4(char *)         = Convert                  : r16_3
-#   16|     mu16_5(char *)        = Store[#return]           : &:r16_1, r16_4
+#   16|     mu16_4(char *)        = Store[#return]           : &:r16_1, r16_3
 #   12|     r12_4(glval<char *>)  = VariableAddress[#return] : 
 #   12|     v12_5(void)           = ReturnValue              : &:r12_4, ~m?
 #   12|     v12_6(void)           = AliasedUse               : ~m?
@@ -2951,8 +2883,7 @@ generic.c:
 #   23|     r23_1(glval<char *>)  = VariableAddress[#return] : 
 #   23|     r23_2(glval<char[4]>) = Constant[int]            : 
 #   23|     r23_3(char *)         = Convert                  : r23_2
-#   23|     r23_4(char *)         = Convert                  : r23_3
-#   23|     mu23_5(char *)        = Store[#return]           : &:r23_1, r23_4
+#   23|     mu23_4(char *)        = Store[#return]           : &:r23_1, r23_3
 #   19|     r19_4(glval<char *>)  = VariableAddress[#return] : 
 #   19|     v19_5(void)           = ReturnValue              : &:r19_4, ~m?
 #   19|     v19_6(void)           = AliasedUse               : ~m?
@@ -4416,8 +4347,7 @@ ir.cpp:
 #  189|     r189_1(glval<wchar_t *>)  = VariableAddress[pwc]   : 
 #  189|     r189_2(glval<wchar_t[4]>) = StringConstant[L"Bar"] : 
 #  189|     r189_3(wchar_t *)         = Convert                : r189_2
-#  189|     r189_4(wchar_t *)         = Convert                : r189_3
-#  189|     mu189_5(wchar_t *)        = Store[pwc]             : &:r189_1, r189_4
+#  189|     mu189_4(wchar_t *)        = Store[pwc]             : &:r189_1, r189_3
 #  190|     r190_1(glval<wchar_t>)    = VariableAddress[wc]    : 
 #  190|     r190_2(glval<wchar_t *>)  = VariableAddress[pwc]   : 
 #  190|     r190_3(wchar_t *)         = Load[pwc]              : &:r190_2, ~m?
@@ -6374,24 +6304,21 @@ ir.cpp:
 #  623|     r623_1(glval<String &>) = VariableAddress[r]          : 
 #  623|     r623_2(String &)        = Load[r]                     : &:r623_1, ~m?
 #  623|     r623_3(glval<String>)   = CopyValue                   : r623_2
-#  623|     r623_4(glval<String>)   = Convert                     : r623_3
-#  623|     r623_5(glval<unknown>)  = FunctionAddress[c_str]      : 
-#  623|     r623_6(char *)          = Call[c_str]                 : func:r623_5, this:r623_4
-#  623|     mu623_7(unknown)        = ^CallSideEffect             : ~m?
-#  623|     v623_8(void)            = ^IndirectReadSideEffect[-1] : &:r623_4, ~m?
+#  623|     r623_4(glval<unknown>)  = FunctionAddress[c_str]      : 
+#  623|     r623_5(char *)          = Call[c_str]                 : func:r623_4, this:r623_3
+#  623|     mu623_6(unknown)        = ^CallSideEffect             : ~m?
+#  623|     v623_7(void)            = ^IndirectReadSideEffect[-1] : &:r623_3, ~m?
 #  624|     r624_1(glval<String *>) = VariableAddress[p]          : 
 #  624|     r624_2(String *)        = Load[p]                     : &:r624_1, ~m?
-#  624|     r624_3(String *)        = Convert                     : r624_2
-#  624|     r624_4(glval<unknown>)  = FunctionAddress[c_str]      : 
-#  624|     r624_5(char *)          = Call[c_str]                 : func:r624_4, this:r624_3
-#  624|     mu624_6(unknown)        = ^CallSideEffect             : ~m?
-#  624|     v624_7(void)            = ^IndirectReadSideEffect[-1] : &:r624_3, ~m?
+#  624|     r624_3(glval<unknown>)  = FunctionAddress[c_str]      : 
+#  624|     r624_4(char *)          = Call[c_str]                 : func:r624_3, this:r624_2
+#  624|     mu624_5(unknown)        = ^CallSideEffect             : ~m?
+#  624|     v624_6(void)            = ^IndirectReadSideEffect[-1] : &:r624_2, ~m?
 #  625|     r625_1(glval<String>)   = VariableAddress[s]          : 
-#  625|     r625_2(glval<String>)   = Convert                     : r625_1
-#  625|     r625_3(glval<unknown>)  = FunctionAddress[c_str]      : 
-#  625|     r625_4(char *)          = Call[c_str]                 : func:r625_3, this:r625_2
-#  625|     mu625_5(unknown)        = ^CallSideEffect             : ~m?
-#  625|     v625_6(void)            = ^IndirectReadSideEffect[-1] : &:r625_2, ~m?
+#  625|     r625_2(glval<unknown>)  = FunctionAddress[c_str]      : 
+#  625|     r625_3(char *)          = Call[c_str]                 : func:r625_2, this:r625_1
+#  625|     mu625_4(unknown)        = ^CallSideEffect             : ~m?
+#  625|     v625_5(void)            = ^IndirectReadSideEffect[-1] : &:r625_1, ~m?
 #  626|     v626_1(void)            = NoOp                        : 
 #  622|     v622_14(void)           = ReturnIndirection[r]        : &:r622_6, ~m?
 #  622|     v622_15(void)           = ReturnIndirection[p]        : &:r622_10, ~m?
@@ -6665,9 +6592,8 @@ ir.cpp:
 #  688|     r688_3(String &)        = Call[ReturnReference]            : func:r688_2
 #  688|     mu688_4(unknown)        = ^CallSideEffect                  : ~m?
 #  688|     r688_5(glval<String>)   = CopyValue                        : r688_3
-#  688|     r688_6(glval<String>)   = Convert                          : r688_5
-#  688|     r688_7(String &)        = CopyValue                        : r688_6
-#  688|     mu688_8(String &)       = Store[r3]                        : &:r688_1, r688_7
+#  688|     r688_6(String &)        = CopyValue                        : r688_5
+#  688|     mu688_7(String &)       = Store[r3]                        : &:r688_1, r688_6
 #  689|     v689_1(void)            = NoOp                             : 
 #  685|     v685_6(void)            = ReturnVoid                       : 
 #  685|     v685_7(void)            = AliasedUse                       : ~m?
@@ -7497,20 +7423,19 @@ ir.cpp:
 #  809|     mu809_10(unknown)          = ^CallSideEffect                           : ~m?
 #  809|     v809_11(void)              = ^BufferReadSideEffect[0]                  : &:r809_8, ~m?
 #  809|     mu809_12(Base)             = ^IndirectMayWriteSideEffect[-1]           : &:r809_3
-#  809|     r809_13(glval<Base>)       = Convert                                   : r809_3
-#  809|     r809_14(Base &)            = CopyValue                                 : r809_13
-#  809|     r809_15(Base &)            = Call[operator=]                           : func:r809_2, this:r809_1, 0:r809_14
-#  809|     mu809_16(unknown)          = ^CallSideEffect                           : ~m?
-#  809|     v809_17(void)              = ^IndirectReadSideEffect[-1]               : &:r809_1, ~m?
-#  809|     v809_18(void)              = ^BufferReadSideEffect[0]                  : &:r809_14, ~m?
-#  809|     mu809_19(Base)             = ^IndirectMayWriteSideEffect[-1]           : &:r809_1
-#  809|     r809_20(glval<Base>)       = CopyValue                                 : r809_3
-#  809|     r809_21(glval<unknown>)    = FunctionAddress[~Base]                    : 
-#  809|     v809_22(void)              = Call[~Base]                               : func:r809_21, this:r809_20
-#  809|     mu809_23(unknown)          = ^CallSideEffect                           : ~m?
-#  809|     v809_24(void)              = ^IndirectReadSideEffect[-1]               : &:r809_20, ~m?
-#  809|     mu809_25(Base)             = ^IndirectMayWriteSideEffect[-1]           : &:r809_20
-#  809|     r809_26(glval<Base>)       = CopyValue                                 : r809_15
+#  809|     r809_13(Base &)            = CopyValue                                 : r809_3
+#  809|     r809_14(Base &)            = Call[operator=]                           : func:r809_2, this:r809_1, 0:r809_13
+#  809|     mu809_15(unknown)          = ^CallSideEffect                           : ~m?
+#  809|     v809_16(void)              = ^IndirectReadSideEffect[-1]               : &:r809_1, ~m?
+#  809|     v809_17(void)              = ^BufferReadSideEffect[0]                  : &:r809_13, ~m?
+#  809|     mu809_18(Base)             = ^IndirectMayWriteSideEffect[-1]           : &:r809_1
+#  809|     r809_19(glval<Base>)       = CopyValue                                 : r809_3
+#  809|     r809_20(glval<unknown>)    = FunctionAddress[~Base]                    : 
+#  809|     v809_21(void)              = Call[~Base]                               : func:r809_20, this:r809_19
+#  809|     mu809_22(unknown)          = ^CallSideEffect                           : ~m?
+#  809|     v809_23(void)              = ^IndirectReadSideEffect[-1]               : &:r809_19, ~m?
+#  809|     mu809_24(Base)             = ^IndirectMayWriteSideEffect[-1]           : &:r809_19
+#  809|     r809_25(glval<Base>)       = CopyValue                                 : r809_14
 #  810|     r810_1(glval<Base>)        = VariableAddress[b]                        : 
 #  810|     r810_2(glval<unknown>)     = FunctionAddress[operator=]                : 
 #  810|     r810_3(glval<Base>)        = VariableAddress[#temp810:7]               : 
@@ -7523,20 +7448,19 @@ ir.cpp:
 #  810|     mu810_10(unknown)          = ^CallSideEffect                           : ~m?
 #  810|     v810_11(void)              = ^BufferReadSideEffect[0]                  : &:r810_8, ~m?
 #  810|     mu810_12(Base)             = ^IndirectMayWriteSideEffect[-1]           : &:r810_3
-#  810|     r810_13(glval<Base>)       = Convert                                   : r810_3
-#  810|     r810_14(Base &)            = CopyValue                                 : r810_13
-#  810|     r810_15(Base &)            = Call[operator=]                           : func:r810_2, this:r810_1, 0:r810_14
-#  810|     mu810_16(unknown)          = ^CallSideEffect                           : ~m?
-#  810|     v810_17(void)              = ^IndirectReadSideEffect[-1]               : &:r810_1, ~m?
-#  810|     v810_18(void)              = ^BufferReadSideEffect[0]                  : &:r810_14, ~m?
-#  810|     mu810_19(Base)             = ^IndirectMayWriteSideEffect[-1]           : &:r810_1
-#  810|     r810_20(glval<Base>)       = CopyValue                                 : r810_3
-#  810|     r810_21(glval<unknown>)    = FunctionAddress[~Base]                    : 
-#  810|     v810_22(void)              = Call[~Base]                               : func:r810_21, this:r810_20
-#  810|     mu810_23(unknown)          = ^CallSideEffect                           : ~m?
-#  810|     v810_24(void)              = ^IndirectReadSideEffect[-1]               : &:r810_20, ~m?
-#  810|     mu810_25(Base)             = ^IndirectMayWriteSideEffect[-1]           : &:r810_20
-#  810|     r810_26(glval<Base>)       = CopyValue                                 : r810_15
+#  810|     r810_13(Base &)            = CopyValue                                 : r810_3
+#  810|     r810_14(Base &)            = Call[operator=]                           : func:r810_2, this:r810_1, 0:r810_13
+#  810|     mu810_15(unknown)          = ^CallSideEffect                           : ~m?
+#  810|     v810_16(void)              = ^IndirectReadSideEffect[-1]               : &:r810_1, ~m?
+#  810|     v810_17(void)              = ^BufferReadSideEffect[0]                  : &:r810_13, ~m?
+#  810|     mu810_18(Base)             = ^IndirectMayWriteSideEffect[-1]           : &:r810_1
+#  810|     r810_19(glval<Base>)       = CopyValue                                 : r810_3
+#  810|     r810_20(glval<unknown>)    = FunctionAddress[~Base]                    : 
+#  810|     v810_21(void)              = Call[~Base]                               : func:r810_20, this:r810_19
+#  810|     mu810_22(unknown)          = ^CallSideEffect                           : ~m?
+#  810|     v810_23(void)              = ^IndirectReadSideEffect[-1]               : &:r810_19, ~m?
+#  810|     mu810_24(Base)             = ^IndirectMayWriteSideEffect[-1]           : &:r810_19
+#  810|     r810_25(glval<Base>)       = CopyValue                                 : r810_14
 #  811|     r811_1(glval<Middle *>)    = VariableAddress[pm]                       : 
 #  811|     r811_2(Middle *)           = Load[pm]                                  : &:r811_1, ~m?
 #  811|     r811_3(Base *)             = ConvertToNonVirtualBase[Middle : Base]    : r811_2
@@ -7561,26 +7485,24 @@ ir.cpp:
 #  816|     r816_2(glval<unknown>)     = FunctionAddress[operator=]                : 
 #  816|     r816_3(glval<Base>)        = VariableAddress[b]                        : 
 #  816|     r816_4(glval<Middle>)      = ConvertToDerived[Middle : Base]           : r816_3
-#  816|     r816_5(glval<Middle>)      = Convert                                   : r816_4
-#  816|     r816_6(Middle &)           = CopyValue                                 : r816_5
-#  816|     r816_7(Middle &)           = Call[operator=]                           : func:r816_2, this:r816_1, 0:r816_6
-#  816|     mu816_8(unknown)           = ^CallSideEffect                           : ~m?
-#  816|     v816_9(void)               = ^IndirectReadSideEffect[-1]               : &:r816_1, ~m?
-#  816|     v816_10(void)              = ^BufferReadSideEffect[0]                  : &:r816_6, ~m?
-#  816|     mu816_11(Middle)           = ^IndirectMayWriteSideEffect[-1]           : &:r816_1
-#  816|     r816_12(glval<Middle>)     = CopyValue                                 : r816_7
+#  816|     r816_5(Middle &)           = CopyValue                                 : r816_4
+#  816|     r816_6(Middle &)           = Call[operator=]                           : func:r816_2, this:r816_1, 0:r816_5
+#  816|     mu816_7(unknown)           = ^CallSideEffect                           : ~m?
+#  816|     v816_8(void)               = ^IndirectReadSideEffect[-1]               : &:r816_1, ~m?
+#  816|     v816_9(void)               = ^BufferReadSideEffect[0]                  : &:r816_5, ~m?
+#  816|     mu816_10(Middle)           = ^IndirectMayWriteSideEffect[-1]           : &:r816_1
+#  816|     r816_11(glval<Middle>)     = CopyValue                                 : r816_6
 #  817|     r817_1(glval<Middle>)      = VariableAddress[m]                        : 
 #  817|     r817_2(glval<unknown>)     = FunctionAddress[operator=]                : 
 #  817|     r817_3(glval<Base>)        = VariableAddress[b]                        : 
 #  817|     r817_4(glval<Middle>)      = ConvertToDerived[Middle : Base]           : r817_3
-#  817|     r817_5(glval<Middle>)      = Convert                                   : r817_4
-#  817|     r817_6(Middle &)           = CopyValue                                 : r817_5
-#  817|     r817_7(Middle &)           = Call[operator=]                           : func:r817_2, this:r817_1, 0:r817_6
-#  817|     mu817_8(unknown)           = ^CallSideEffect                           : ~m?
-#  817|     v817_9(void)               = ^IndirectReadSideEffect[-1]               : &:r817_1, ~m?
-#  817|     v817_10(void)              = ^BufferReadSideEffect[0]                  : &:r817_6, ~m?
-#  817|     mu817_11(Middle)           = ^IndirectMayWriteSideEffect[-1]           : &:r817_1
-#  817|     r817_12(glval<Middle>)     = CopyValue                                 : r817_7
+#  817|     r817_5(Middle &)           = CopyValue                                 : r817_4
+#  817|     r817_6(Middle &)           = Call[operator=]                           : func:r817_2, this:r817_1, 0:r817_5
+#  817|     mu817_7(unknown)           = ^CallSideEffect                           : ~m?
+#  817|     v817_8(void)               = ^IndirectReadSideEffect[-1]               : &:r817_1, ~m?
+#  817|     v817_9(void)               = ^BufferReadSideEffect[0]                  : &:r817_5, ~m?
+#  817|     mu817_10(Middle)           = ^IndirectMayWriteSideEffect[-1]           : &:r817_1
+#  817|     r817_11(glval<Middle>)     = CopyValue                                 : r817_6
 #  818|     r818_1(glval<Base *>)      = VariableAddress[pb]                       : 
 #  818|     r818_2(Base *)             = Load[pb]                                  : &:r818_1, ~m?
 #  818|     r818_3(Middle *)           = ConvertToDerived[Middle : Base]           : r818_2
@@ -7621,20 +7543,19 @@ ir.cpp:
 #  823|     mu823_11(unknown)          = ^CallSideEffect                           : ~m?
 #  823|     v823_12(void)              = ^BufferReadSideEffect[0]                  : &:r823_9, ~m?
 #  823|     mu823_13(Base)             = ^IndirectMayWriteSideEffect[-1]           : &:r823_3
-#  823|     r823_14(glval<Base>)       = Convert                                   : r823_3
-#  823|     r823_15(Base &)            = CopyValue                                 : r823_14
-#  823|     r823_16(Base &)            = Call[operator=]                           : func:r823_2, this:r823_1, 0:r823_15
-#  823|     mu823_17(unknown)          = ^CallSideEffect                           : ~m?
-#  823|     v823_18(void)              = ^IndirectReadSideEffect[-1]               : &:r823_1, ~m?
-#  823|     v823_19(void)              = ^BufferReadSideEffect[0]                  : &:r823_15, ~m?
-#  823|     mu823_20(Base)             = ^IndirectMayWriteSideEffect[-1]           : &:r823_1
-#  823|     r823_21(glval<Base>)       = CopyValue                                 : r823_3
-#  823|     r823_22(glval<unknown>)    = FunctionAddress[~Base]                    : 
-#  823|     v823_23(void)              = Call[~Base]                               : func:r823_22, this:r823_21
-#  823|     mu823_24(unknown)          = ^CallSideEffect                           : ~m?
-#  823|     v823_25(void)              = ^IndirectReadSideEffect[-1]               : &:r823_21, ~m?
-#  823|     mu823_26(Base)             = ^IndirectMayWriteSideEffect[-1]           : &:r823_21
-#  823|     r823_27(glval<Base>)       = CopyValue                                 : r823_16
+#  823|     r823_14(Base &)            = CopyValue                                 : r823_3
+#  823|     r823_15(Base &)            = Call[operator=]                           : func:r823_2, this:r823_1, 0:r823_14
+#  823|     mu823_16(unknown)          = ^CallSideEffect                           : ~m?
+#  823|     v823_17(void)              = ^IndirectReadSideEffect[-1]               : &:r823_1, ~m?
+#  823|     v823_18(void)              = ^BufferReadSideEffect[0]                  : &:r823_14, ~m?
+#  823|     mu823_19(Base)             = ^IndirectMayWriteSideEffect[-1]           : &:r823_1
+#  823|     r823_20(glval<Base>)       = CopyValue                                 : r823_3
+#  823|     r823_21(glval<unknown>)    = FunctionAddress[~Base]                    : 
+#  823|     v823_22(void)              = Call[~Base]                               : func:r823_21, this:r823_20
+#  823|     mu823_23(unknown)          = ^CallSideEffect                           : ~m?
+#  823|     v823_24(void)              = ^IndirectReadSideEffect[-1]               : &:r823_20, ~m?
+#  823|     mu823_25(Base)             = ^IndirectMayWriteSideEffect[-1]           : &:r823_20
+#  823|     r823_26(glval<Base>)       = CopyValue                                 : r823_15
 #  824|     r824_1(glval<Base>)        = VariableAddress[b]                        : 
 #  824|     r824_2(glval<unknown>)     = FunctionAddress[operator=]                : 
 #  824|     r824_3(glval<Base>)        = VariableAddress[#temp824:7]               : 
@@ -7648,20 +7569,19 @@ ir.cpp:
 #  824|     mu824_11(unknown)          = ^CallSideEffect                           : ~m?
 #  824|     v824_12(void)              = ^BufferReadSideEffect[0]                  : &:r824_9, ~m?
 #  824|     mu824_13(Base)             = ^IndirectMayWriteSideEffect[-1]           : &:r824_3
-#  824|     r824_14(glval<Base>)       = Convert                                   : r824_3
-#  824|     r824_15(Base &)            = CopyValue                                 : r824_14
-#  824|     r824_16(Base &)            = Call[operator=]                           : func:r824_2, this:r824_1, 0:r824_15
-#  824|     mu824_17(unknown)          = ^CallSideEffect                           : ~m?
-#  824|     v824_18(void)              = ^IndirectReadSideEffect[-1]               : &:r824_1, ~m?
-#  824|     v824_19(void)              = ^BufferReadSideEffect[0]                  : &:r824_15, ~m?
-#  824|     mu824_20(Base)             = ^IndirectMayWriteSideEffect[-1]           : &:r824_1
-#  824|     r824_21(glval<Base>)       = CopyValue                                 : r824_3
-#  824|     r824_22(glval<unknown>)    = FunctionAddress[~Base]                    : 
-#  824|     v824_23(void)              = Call[~Base]                               : func:r824_22, this:r824_21
-#  824|     mu824_24(unknown)          = ^CallSideEffect                           : ~m?
-#  824|     v824_25(void)              = ^IndirectReadSideEffect[-1]               : &:r824_21, ~m?
-#  824|     mu824_26(Base)             = ^IndirectMayWriteSideEffect[-1]           : &:r824_21
-#  824|     r824_27(glval<Base>)       = CopyValue                                 : r824_16
+#  824|     r824_14(Base &)            = CopyValue                                 : r824_3
+#  824|     r824_15(Base &)            = Call[operator=]                           : func:r824_2, this:r824_1, 0:r824_14
+#  824|     mu824_16(unknown)          = ^CallSideEffect                           : ~m?
+#  824|     v824_17(void)              = ^IndirectReadSideEffect[-1]               : &:r824_1, ~m?
+#  824|     v824_18(void)              = ^BufferReadSideEffect[0]                  : &:r824_14, ~m?
+#  824|     mu824_19(Base)             = ^IndirectMayWriteSideEffect[-1]           : &:r824_1
+#  824|     r824_20(glval<Base>)       = CopyValue                                 : r824_3
+#  824|     r824_21(glval<unknown>)    = FunctionAddress[~Base]                    : 
+#  824|     v824_22(void)              = Call[~Base]                               : func:r824_21, this:r824_20
+#  824|     mu824_23(unknown)          = ^CallSideEffect                           : ~m?
+#  824|     v824_24(void)              = ^IndirectReadSideEffect[-1]               : &:r824_20, ~m?
+#  824|     mu824_25(Base)             = ^IndirectMayWriteSideEffect[-1]           : &:r824_20
+#  824|     r824_26(glval<Base>)       = CopyValue                                 : r824_15
 #  825|     r825_1(glval<Derived *>)   = VariableAddress[pd]                       : 
 #  825|     r825_2(Derived *)          = Load[pd]                                  : &:r825_1, ~m?
 #  825|     r825_3(Middle *)           = ConvertToNonVirtualBase[Derived : Middle] : r825_2
@@ -7690,27 +7610,25 @@ ir.cpp:
 #  830|     r830_3(glval<Base>)        = VariableAddress[b]                        : 
 #  830|     r830_4(glval<Middle>)      = ConvertToDerived[Middle : Base]           : r830_3
 #  830|     r830_5(glval<Derived>)     = ConvertToDerived[Derived : Middle]        : r830_4
-#  830|     r830_6(glval<Derived>)     = Convert                                   : r830_5
-#  830|     r830_7(Derived &)          = CopyValue                                 : r830_6
-#  830|     r830_8(Derived &)          = Call[operator=]                           : func:r830_2, this:r830_1, 0:r830_7
-#  830|     mu830_9(unknown)           = ^CallSideEffect                           : ~m?
-#  830|     v830_10(void)              = ^IndirectReadSideEffect[-1]               : &:r830_1, ~m?
-#  830|     v830_11(void)              = ^BufferReadSideEffect[0]                  : &:r830_7, ~m?
-#  830|     mu830_12(Derived)          = ^IndirectMayWriteSideEffect[-1]           : &:r830_1
-#  830|     r830_13(glval<Derived>)    = CopyValue                                 : r830_8
+#  830|     r830_6(Derived &)          = CopyValue                                 : r830_5
+#  830|     r830_7(Derived &)          = Call[operator=]                           : func:r830_2, this:r830_1, 0:r830_6
+#  830|     mu830_8(unknown)           = ^CallSideEffect                           : ~m?
+#  830|     v830_9(void)               = ^IndirectReadSideEffect[-1]               : &:r830_1, ~m?
+#  830|     v830_10(void)              = ^BufferReadSideEffect[0]                  : &:r830_6, ~m?
+#  830|     mu830_11(Derived)          = ^IndirectMayWriteSideEffect[-1]           : &:r830_1
+#  830|     r830_12(glval<Derived>)    = CopyValue                                 : r830_7
 #  831|     r831_1(glval<Derived>)     = VariableAddress[d]                        : 
 #  831|     r831_2(glval<unknown>)     = FunctionAddress[operator=]                : 
 #  831|     r831_3(glval<Base>)        = VariableAddress[b]                        : 
 #  831|     r831_4(glval<Middle>)      = ConvertToDerived[Middle : Base]           : r831_3
 #  831|     r831_5(glval<Derived>)     = ConvertToDerived[Derived : Middle]        : r831_4
-#  831|     r831_6(glval<Derived>)     = Convert                                   : r831_5
-#  831|     r831_7(Derived &)          = CopyValue                                 : r831_6
-#  831|     r831_8(Derived &)          = Call[operator=]                           : func:r831_2, this:r831_1, 0:r831_7
-#  831|     mu831_9(unknown)           = ^CallSideEffect                           : ~m?
-#  831|     v831_10(void)              = ^IndirectReadSideEffect[-1]               : &:r831_1, ~m?
-#  831|     v831_11(void)              = ^BufferReadSideEffect[0]                  : &:r831_7, ~m?
-#  831|     mu831_12(Derived)          = ^IndirectMayWriteSideEffect[-1]           : &:r831_1
-#  831|     r831_13(glval<Derived>)    = CopyValue                                 : r831_8
+#  831|     r831_6(Derived &)          = CopyValue                                 : r831_5
+#  831|     r831_7(Derived &)          = Call[operator=]                           : func:r831_2, this:r831_1, 0:r831_6
+#  831|     mu831_8(unknown)           = ^CallSideEffect                           : ~m?
+#  831|     v831_9(void)               = ^IndirectReadSideEffect[-1]               : &:r831_1, ~m?
+#  831|     v831_10(void)              = ^BufferReadSideEffect[0]                  : &:r831_6, ~m?
+#  831|     mu831_11(Derived)          = ^IndirectMayWriteSideEffect[-1]           : &:r831_1
+#  831|     r831_12(glval<Derived>)    = CopyValue                                 : r831_7
 #  832|     r832_1(glval<Base *>)      = VariableAddress[pb]                       : 
 #  832|     r832_2(Base *)             = Load[pb]                                  : &:r832_1, ~m?
 #  832|     r832_3(Middle *)           = ConvertToDerived[Middle : Base]           : r832_2
@@ -7925,8 +7843,7 @@ ir.cpp:
 #  873|     r873_1(glval<char *>)     = VariableAddress[p]     : 
 #  873|     r873_2(glval<char[5]>)    = VariableAddress[a]     : 
 #  873|     r873_3(char *)            = Convert                : r873_2
-#  873|     r873_4(char *)            = Convert                : r873_3
-#  873|     mu873_5(char *)           = Store[p]               : &:r873_1, r873_4
+#  873|     mu873_4(char *)           = Store[p]               : &:r873_1, r873_3
 #  874|     r874_1(glval<char[5]>)    = StringConstant["test"] : 
 #  874|     r874_2(char *)            = Convert                : r874_1
 #  874|     r874_3(glval<char *>)     = VariableAddress[p]     : 
@@ -7936,9 +7853,8 @@ ir.cpp:
 #  875|     r875_3(int)               = Constant[0]            : 
 #  875|     r875_4(glval<char>)       = PointerAdd[1]          : r875_2, r875_3
 #  875|     r875_5(char *)            = CopyValue              : r875_4
-#  875|     r875_6(char *)            = Convert                : r875_5
-#  875|     r875_7(glval<char *>)     = VariableAddress[p]     : 
-#  875|     mu875_8(char *)           = Store[p]               : &:r875_7, r875_6
+#  875|     r875_6(glval<char *>)     = VariableAddress[p]     : 
+#  875|     mu875_7(char *)           = Store[p]               : &:r875_6, r875_5
 #  876|     r876_1(glval<char[5]>)    = StringConstant["test"] : 
 #  876|     r876_2(char *)            = Convert                : r876_1
 #  876|     r876_3(int)               = Constant[0]            : 
@@ -7957,8 +7873,7 @@ ir.cpp:
 #  879|     r879_1(glval<char(*)[5]>) = VariableAddress[pa]    : 
 #  879|     r879_2(glval<char[5]>)    = VariableAddress[a]     : 
 #  879|     r879_3(char(*)[5])        = CopyValue              : r879_2
-#  879|     r879_4(char(*)[5])        = Convert                : r879_3
-#  879|     mu879_5(char(*)[5])       = Store[pa]              : &:r879_1, r879_4
+#  879|     mu879_4(char(*)[5])       = Store[pa]              : &:r879_1, r879_3
 #  880|     r880_1(glval<char[5]>)    = StringConstant["test"] : 
 #  880|     r880_2(char(*)[5])        = CopyValue              : r880_1
 #  880|     r880_3(glval<char(*)[5]>) = VariableAddress[pa]    : 
@@ -8790,12 +8705,11 @@ ir.cpp:
 # 1043|     r1043_12(decltype([...](...){...}))       = Load[#temp1043:20]                     : &:r1043_2, ~m?
 # 1043|     mu1043_13(decltype([...](...){...}))      = Store[lambda_ref]                      : &:r1043_1, r1043_12
 # 1044|     r1044_1(glval<decltype([...](...){...})>) = VariableAddress[lambda_ref]            : 
-# 1044|     r1044_2(glval<decltype([...](...){...})>) = Convert                                : r1044_1
-# 1044|     r1044_3(glval<unknown>)                   = FunctionAddress[operator()]            : 
-# 1044|     r1044_4(float)                            = Constant[1.0]                          : 
-# 1044|     r1044_5(char)                             = Call[operator()]                       : func:r1044_3, this:r1044_2, 0:r1044_4
-# 1044|     mu1044_6(unknown)                         = ^CallSideEffect                        : ~m?
-# 1044|     v1044_7(void)                             = ^IndirectReadSideEffect[-1]            : &:r1044_2, ~m?
+# 1044|     r1044_2(glval<unknown>)                   = FunctionAddress[operator()]            : 
+# 1044|     r1044_3(float)                            = Constant[1.0]                          : 
+# 1044|     r1044_4(char)                             = Call[operator()]                       : func:r1044_2, this:r1044_1, 0:r1044_3
+# 1044|     mu1044_5(unknown)                         = ^CallSideEffect                        : ~m?
+# 1044|     v1044_6(void)                             = ^IndirectReadSideEffect[-1]            : &:r1044_1, ~m?
 # 1045|     r1045_1(glval<decltype([...](...){...})>) = VariableAddress[lambda_val]            : 
 # 1045|     r1045_2(glval<decltype([...](...){...})>) = VariableAddress[#temp1045:20]          : 
 # 1045|     mu1045_3(decltype([...](...){...}))       = Uninitialized[#temp1045:20]            : &:r1045_2
@@ -8811,12 +8725,11 @@ ir.cpp:
 # 1045|     r1045_13(decltype([...](...){...}))       = Load[#temp1045:20]                     : &:r1045_2, ~m?
 # 1045|     mu1045_14(decltype([...](...){...}))      = Store[lambda_val]                      : &:r1045_1, r1045_13
 # 1046|     r1046_1(glval<decltype([...](...){...})>) = VariableAddress[lambda_val]            : 
-# 1046|     r1046_2(glval<decltype([...](...){...})>) = Convert                                : r1046_1
-# 1046|     r1046_3(glval<unknown>)                   = FunctionAddress[operator()]            : 
-# 1046|     r1046_4(float)                            = Constant[2.0]                          : 
-# 1046|     r1046_5(char)                             = Call[operator()]                       : func:r1046_3, this:r1046_2, 0:r1046_4
-# 1046|     mu1046_6(unknown)                         = ^CallSideEffect                        : ~m?
-# 1046|     v1046_7(void)                             = ^IndirectReadSideEffect[-1]            : &:r1046_2, ~m?
+# 1046|     r1046_2(glval<unknown>)                   = FunctionAddress[operator()]            : 
+# 1046|     r1046_3(float)                            = Constant[2.0]                          : 
+# 1046|     r1046_4(char)                             = Call[operator()]                       : func:r1046_2, this:r1046_1, 0:r1046_3
+# 1046|     mu1046_5(unknown)                         = ^CallSideEffect                        : ~m?
+# 1046|     v1046_6(void)                             = ^IndirectReadSideEffect[-1]            : &:r1046_1, ~m?
 # 1047|     r1047_1(glval<decltype([...](...){...})>) = VariableAddress[lambda_ref_explicit]   : 
 # 1047|     r1047_2(glval<decltype([...](...){...})>) = VariableAddress[#temp1047:29]          : 
 # 1047|     mu1047_3(decltype([...](...){...}))       = Uninitialized[#temp1047:29]            : &:r1047_2
@@ -8829,12 +8742,11 @@ ir.cpp:
 # 1047|     r1047_10(decltype([...](...){...}))       = Load[#temp1047:29]                     : &:r1047_2, ~m?
 # 1047|     mu1047_11(decltype([...](...){...}))      = Store[lambda_ref_explicit]             : &:r1047_1, r1047_10
 # 1048|     r1048_1(glval<decltype([...](...){...})>) = VariableAddress[lambda_ref_explicit]   : 
-# 1048|     r1048_2(glval<decltype([...](...){...})>) = Convert                                : r1048_1
-# 1048|     r1048_3(glval<unknown>)                   = FunctionAddress[operator()]            : 
-# 1048|     r1048_4(float)                            = Constant[3.0]                          : 
-# 1048|     r1048_5(char)                             = Call[operator()]                       : func:r1048_3, this:r1048_2, 0:r1048_4
-# 1048|     mu1048_6(unknown)                         = ^CallSideEffect                        : ~m?
-# 1048|     v1048_7(void)                             = ^IndirectReadSideEffect[-1]            : &:r1048_2, ~m?
+# 1048|     r1048_2(glval<unknown>)                   = FunctionAddress[operator()]            : 
+# 1048|     r1048_3(float)                            = Constant[3.0]                          : 
+# 1048|     r1048_4(char)                             = Call[operator()]                       : func:r1048_2, this:r1048_1, 0:r1048_3
+# 1048|     mu1048_5(unknown)                         = ^CallSideEffect                        : ~m?
+# 1048|     v1048_6(void)                             = ^IndirectReadSideEffect[-1]            : &:r1048_1, ~m?
 # 1049|     r1049_1(glval<decltype([...](...){...})>) = VariableAddress[lambda_val_explicit]   : 
 # 1049|     r1049_2(glval<decltype([...](...){...})>) = VariableAddress[#temp1049:29]          : 
 # 1049|     mu1049_3(decltype([...](...){...}))       = Uninitialized[#temp1049:29]            : &:r1049_2
@@ -8846,12 +8758,11 @@ ir.cpp:
 # 1049|     r1049_9(decltype([...](...){...}))        = Load[#temp1049:29]                     : &:r1049_2, ~m?
 # 1049|     mu1049_10(decltype([...](...){...}))      = Store[lambda_val_explicit]             : &:r1049_1, r1049_9
 # 1050|     r1050_1(glval<decltype([...](...){...})>) = VariableAddress[lambda_val_explicit]   : 
-# 1050|     r1050_2(glval<decltype([...](...){...})>) = Convert                                : r1050_1
-# 1050|     r1050_3(glval<unknown>)                   = FunctionAddress[operator()]            : 
-# 1050|     r1050_4(float)                            = Constant[4.0]                          : 
-# 1050|     r1050_5(char)                             = Call[operator()]                       : func:r1050_3, this:r1050_2, 0:r1050_4
-# 1050|     mu1050_6(unknown)                         = ^CallSideEffect                        : ~m?
-# 1050|     v1050_7(void)                             = ^IndirectReadSideEffect[-1]            : &:r1050_2, ~m?
+# 1050|     r1050_2(glval<unknown>)                   = FunctionAddress[operator()]            : 
+# 1050|     r1050_3(float)                            = Constant[4.0]                          : 
+# 1050|     r1050_4(char)                             = Call[operator()]                       : func:r1050_2, this:r1050_1, 0:r1050_3
+# 1050|     mu1050_5(unknown)                         = ^CallSideEffect                        : ~m?
+# 1050|     v1050_6(void)                             = ^IndirectReadSideEffect[-1]            : &:r1050_1, ~m?
 # 1051|     r1051_1(glval<decltype([...](...){...})>) = VariableAddress[lambda_mixed_explicit] : 
 # 1051|     r1051_2(glval<decltype([...](...){...})>) = VariableAddress[#temp1051:31]          : 
 # 1051|     mu1051_3(decltype([...](...){...}))       = Uninitialized[#temp1051:31]            : &:r1051_2
@@ -8868,12 +8779,11 @@ ir.cpp:
 # 1051|     r1051_14(decltype([...](...){...}))       = Load[#temp1051:31]                     : &:r1051_2, ~m?
 # 1051|     mu1051_15(decltype([...](...){...}))      = Store[lambda_mixed_explicit]           : &:r1051_1, r1051_14
 # 1052|     r1052_1(glval<decltype([...](...){...})>) = VariableAddress[lambda_mixed_explicit] : 
-# 1052|     r1052_2(glval<decltype([...](...){...})>) = Convert                                : r1052_1
-# 1052|     r1052_3(glval<unknown>)                   = FunctionAddress[operator()]            : 
-# 1052|     r1052_4(float)                            = Constant[5.0]                          : 
-# 1052|     r1052_5(char)                             = Call[operator()]                       : func:r1052_3, this:r1052_2, 0:r1052_4
-# 1052|     mu1052_6(unknown)                         = ^CallSideEffect                        : ~m?
-# 1052|     v1052_7(void)                             = ^IndirectReadSideEffect[-1]            : &:r1052_2, ~m?
+# 1052|     r1052_2(glval<unknown>)                   = FunctionAddress[operator()]            : 
+# 1052|     r1052_3(float)                            = Constant[5.0]                          : 
+# 1052|     r1052_4(char)                             = Call[operator()]                       : func:r1052_2, this:r1052_1, 0:r1052_3
+# 1052|     mu1052_5(unknown)                         = ^CallSideEffect                        : ~m?
+# 1052|     v1052_6(void)                             = ^IndirectReadSideEffect[-1]            : &:r1052_1, ~m?
 # 1053|     r1053_1(glval<int>)                       = VariableAddress[r]                     : 
 # 1053|     r1053_2(glval<int>)                       = VariableAddress[x]                     : 
 # 1053|     r1053_3(int)                              = Load[x]                                : &:r1053_2, ~m?
@@ -8906,12 +8816,11 @@ ir.cpp:
 # 1054|     r1054_24(decltype([...](...){...}))       = Load[#temp1054:22]                     : &:r1054_2, ~m?
 # 1054|     mu1054_25(decltype([...](...){...}))      = Store[lambda_inits]                    : &:r1054_1, r1054_24
 # 1055|     r1055_1(glval<decltype([...](...){...})>) = VariableAddress[lambda_inits]          : 
-# 1055|     r1055_2(glval<decltype([...](...){...})>) = Convert                                : r1055_1
-# 1055|     r1055_3(glval<unknown>)                   = FunctionAddress[operator()]            : 
-# 1055|     r1055_4(float)                            = Constant[6.0]                          : 
-# 1055|     r1055_5(char)                             = Call[operator()]                       : func:r1055_3, this:r1055_2, 0:r1055_4
-# 1055|     mu1055_6(unknown)                         = ^CallSideEffect                        : ~m?
-# 1055|     v1055_7(void)                             = ^IndirectReadSideEffect[-1]            : &:r1055_2, ~m?
+# 1055|     r1055_2(glval<unknown>)                   = FunctionAddress[operator()]            : 
+# 1055|     r1055_3(float)                            = Constant[6.0]                          : 
+# 1055|     r1055_4(char)                             = Call[operator()]                       : func:r1055_2, this:r1055_1, 0:r1055_3
+# 1055|     mu1055_5(unknown)                         = ^CallSideEffect                        : ~m?
+# 1055|     v1055_6(void)                             = ^IndirectReadSideEffect[-1]            : &:r1055_1, ~m?
 # 1056|     v1056_1(void)                             = NoOp                                   : 
 # 1056|     r1056_2(glval<decltype([...](...){...})>) = VariableAddress[lambda_val_explicit]   : 
 # 1056|     r1056_3(glval<unknown>)                   = FunctionAddress[~<unnamed>]            : 
@@ -9267,21 +9176,19 @@ ir.cpp:
 
 # 1127|   Block 1
 # 1127|     r1127_19(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>) = VariableAddress[(__begin)]      : 
-#-----|     r0_5(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>)     = Convert                         : r1127_19
 # 1127|     r1127_20(glval<unknown>)                                                            = FunctionAddress[operator!=]     : 
-#-----|     r0_6(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>)     = VariableAddress[#temp0:0]       : 
-#-----|     mu0_7(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)           = Uninitialized[#temp0:0]         : &:r0_6
+#-----|     r0_5(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>)     = VariableAddress[#temp0:0]       : 
+#-----|     mu0_6(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)           = Uninitialized[#temp0:0]         : &:r0_5
 # 1127|     r1127_21(glval<unknown>)                                                            = FunctionAddress[iterator]       : 
 # 1127|     r1127_22(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>) = VariableAddress[(__end)]        : 
-#-----|     r0_8(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>)     = Convert                         : r1127_22
-#-----|     r0_9(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &> &)          = CopyValue                       : r0_8
-# 1127|     v1127_23(void)                                                                      = Call[iterator]                  : func:r1127_21, this:r0_6, 0:r0_9
+#-----|     r0_7(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &> &)          = CopyValue                       : r1127_22
+# 1127|     v1127_23(void)                                                                      = Call[iterator]                  : func:r1127_21, this:r0_5, 0:r0_7
 # 1127|     mu1127_24(unknown)                                                                  = ^CallSideEffect                 : ~m?
-#-----|     v0_10(void)                                                                         = ^BufferReadSideEffect[0]        : &:r0_9, ~m?
-# 1127|     mu1127_25(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)       = ^IndirectMayWriteSideEffect[-1] : &:r0_6
-#-----|     r0_11(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)           = Load[#temp0:0]                  : &:r0_6, ~m?
-# 1127|     r1127_26(bool)                                                                      = Call[operator!=]                : func:r1127_20, this:r0_5, 0:r0_11
-#-----|     v0_12(void)                                                                         = ^IndirectReadSideEffect[-1]     : &:r0_5, ~m?
+#-----|     v0_8(void)                                                                          = ^BufferReadSideEffect[0]        : &:r0_7, ~m?
+# 1127|     mu1127_25(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)       = ^IndirectMayWriteSideEffect[-1] : &:r0_5
+#-----|     r0_9(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)            = Load[#temp0:0]                  : &:r0_5, ~m?
+# 1127|     r1127_26(bool)                                                                      = Call[operator!=]                : func:r1127_20, this:r1127_19, 0:r0_9
+#-----|     v0_10(void)                                                                         = ^IndirectReadSideEffect[-1]     : &:r1127_19, ~m?
 # 1127|     v1127_27(void)                                                                      = ConditionalBranch               : r1127_26
 #-----|   False -> Block 5
 #-----|   True -> Block 2
@@ -9289,10 +9196,9 @@ ir.cpp:
 # 1127|   Block 2
 # 1127|     r1127_28(glval<int>)                                                                = VariableAddress[e]          : 
 # 1127|     r1127_29(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>) = VariableAddress[(__begin)]  : 
-#-----|     r0_13(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>)    = Convert                     : r1127_29
 # 1127|     r1127_30(glval<unknown>)                                                            = FunctionAddress[operator*]  : 
-# 1127|     r1127_31(int &)                                                                     = Call[operator*]             : func:r1127_30, this:r0_13
-#-----|     v0_14(void)                                                                         = ^IndirectReadSideEffect[-1] : &:r0_13, ~m?
+# 1127|     r1127_31(int &)                                                                     = Call[operator*]             : func:r1127_30, this:r1127_29
+#-----|     v0_11(void)                                                                         = ^IndirectReadSideEffect[-1] : &:r1127_29, ~m?
 # 1127|     r1127_32(int)                                                                       = Load[?]                     : &:r1127_31, ~m?
 # 1127|     mu1127_33(int)                                                                      = Store[e]                    : &:r1127_28, r1127_32
 # 1128|     r1128_1(glval<int>)                                                                 = VariableAddress[e]          : 
@@ -9327,38 +9233,36 @@ ir.cpp:
 # 1133|     r1133_7(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>)  = VariableAddress[(__begin)]  : 
 # 1133|     r1133_8(glval<vector<int> &>)                                                       = VariableAddress[(__range)]  : 
 # 1133|     r1133_9(vector<int> &)                                                              = Load[(__range)]             : &:r1133_8, ~m?
-#-----|     r0_15(glval<vector<int>>)                                                           = CopyValue                   : r1133_9
+#-----|     r0_12(glval<vector<int>>)                                                           = CopyValue                   : r1133_9
 # 1133|     r1133_10(glval<unknown>)                                                            = FunctionAddress[begin]      : 
-# 1133|     r1133_11(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)        = Call[begin]                 : func:r1133_10, this:r0_15
-#-----|     v0_16(void)                                                                         = ^IndirectReadSideEffect[-1] : &:r0_15, ~m?
+# 1133|     r1133_11(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)        = Call[begin]                 : func:r1133_10, this:r0_12
+#-----|     v0_13(void)                                                                         = ^IndirectReadSideEffect[-1] : &:r0_12, ~m?
 # 1133|     mu1133_12(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)       = Store[(__begin)]            : &:r1133_7, r1133_11
 # 1133|     r1133_13(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>) = VariableAddress[(__end)]    : 
 # 1133|     r1133_14(glval<vector<int> &>)                                                      = VariableAddress[(__range)]  : 
 # 1133|     r1133_15(vector<int> &)                                                             = Load[(__range)]             : &:r1133_14, ~m?
-#-----|     r0_17(glval<vector<int>>)                                                           = CopyValue                   : r1133_15
+#-----|     r0_14(glval<vector<int>>)                                                           = CopyValue                   : r1133_15
 # 1133|     r1133_16(glval<unknown>)                                                            = FunctionAddress[end]        : 
-# 1133|     r1133_17(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)        = Call[end]                   : func:r1133_16, this:r0_17
-#-----|     v0_18(void)                                                                         = ^IndirectReadSideEffect[-1] : &:r0_17, ~m?
+# 1133|     r1133_17(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)        = Call[end]                   : func:r1133_16, this:r0_14
+#-----|     v0_15(void)                                                                         = ^IndirectReadSideEffect[-1] : &:r0_14, ~m?
 # 1133|     mu1133_18(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)       = Store[(__end)]              : &:r1133_13, r1133_17
 #-----|   Goto -> Block 6
 
 # 1133|   Block 6
 # 1133|     r1133_19(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>) = VariableAddress[(__begin)]      : 
-#-----|     r0_19(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>)    = Convert                         : r1133_19
 # 1133|     r1133_20(glval<unknown>)                                                            = FunctionAddress[operator!=]     : 
-#-----|     r0_20(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>)    = VariableAddress[#temp0:0]       : 
-#-----|     mu0_21(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)          = Uninitialized[#temp0:0]         : &:r0_20
+#-----|     r0_16(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>)    = VariableAddress[#temp0:0]       : 
+#-----|     mu0_17(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)          = Uninitialized[#temp0:0]         : &:r0_16
 # 1133|     r1133_21(glval<unknown>)                                                            = FunctionAddress[iterator]       : 
 # 1133|     r1133_22(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>) = VariableAddress[(__end)]        : 
-#-----|     r0_22(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>)    = Convert                         : r1133_22
-#-----|     r0_23(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &> &)         = CopyValue                       : r0_22
-# 1133|     v1133_23(void)                                                                      = Call[iterator]                  : func:r1133_21, this:r0_20, 0:r0_23
+#-----|     r0_18(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &> &)         = CopyValue                       : r1133_22
+# 1133|     v1133_23(void)                                                                      = Call[iterator]                  : func:r1133_21, this:r0_16, 0:r0_18
 # 1133|     mu1133_24(unknown)                                                                  = ^CallSideEffect                 : ~m?
-#-----|     v0_24(void)                                                                         = ^BufferReadSideEffect[0]        : &:r0_23, ~m?
-# 1133|     mu1133_25(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)       = ^IndirectMayWriteSideEffect[-1] : &:r0_20
-#-----|     r0_25(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)           = Load[#temp0:0]                  : &:r0_20, ~m?
-# 1133|     r1133_26(bool)                                                                      = Call[operator!=]                : func:r1133_20, this:r0_19, 0:r0_25
-#-----|     v0_26(void)                                                                         = ^IndirectReadSideEffect[-1]     : &:r0_19, ~m?
+#-----|     v0_19(void)                                                                         = ^BufferReadSideEffect[0]        : &:r0_18, ~m?
+# 1133|     mu1133_25(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)       = ^IndirectMayWriteSideEffect[-1] : &:r0_16
+#-----|     r0_20(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)           = Load[#temp0:0]                  : &:r0_16, ~m?
+# 1133|     r1133_26(bool)                                                                      = Call[operator!=]                : func:r1133_20, this:r1133_19, 0:r0_20
+#-----|     v0_21(void)                                                                         = ^IndirectReadSideEffect[-1]     : &:r1133_19, ~m?
 # 1133|     v1133_27(void)                                                                      = ConditionalBranch               : r1133_26
 #-----|   False -> Block 10
 #-----|   True -> Block 8
@@ -9375,14 +9279,12 @@ ir.cpp:
 # 1133|   Block 8
 # 1133|     r1133_34(glval<int &>)                                                              = VariableAddress[e]          : 
 # 1133|     r1133_35(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>) = VariableAddress[(__begin)]  : 
-#-----|     r0_27(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>)    = Convert                     : r1133_35
 # 1133|     r1133_36(glval<unknown>)                                                            = FunctionAddress[operator*]  : 
-# 1133|     r1133_37(int &)                                                                     = Call[operator*]             : func:r1133_36, this:r0_27
-#-----|     v0_28(void)                                                                         = ^IndirectReadSideEffect[-1] : &:r0_27, ~m?
+# 1133|     r1133_37(int &)                                                                     = Call[operator*]             : func:r1133_36, this:r1133_35
+#-----|     v0_22(void)                                                                         = ^IndirectReadSideEffect[-1] : &:r1133_35, ~m?
 # 1133|     r1133_38(glval<int>)                                                                = CopyValue                   : r1133_37
-# 1133|     r1133_39(glval<int>)                                                                = Convert                     : r1133_38
-# 1133|     r1133_40(int &)                                                                     = CopyValue                   : r1133_39
-# 1133|     mu1133_41(int &)                                                                    = Store[e]                    : &:r1133_34, r1133_40
+# 1133|     r1133_39(int &)                                                                     = CopyValue                   : r1133_38
+# 1133|     mu1133_40(int &)                                                                    = Store[e]                    : &:r1133_34, r1133_39
 # 1134|     r1134_1(glval<int &>)                                                               = VariableAddress[e]          : 
 # 1134|     r1134_2(int &)                                                                      = Load[e]                     : &:r1134_1, ~m?
 # 1134|     r1134_3(int)                                                                        = Load[?]                     : &:r1134_2, ~m?
@@ -10067,20 +9969,18 @@ ir.cpp:
 # 1303|     r1303_3(char *)            = Convert                      : r1303_2
 # 1303|     r1303_4(glval<char *>)     = VariableAddress[s1]          : 
 # 1303|     r1303_5(char *)            = Load[s1]                     : &:r1303_4, ~m?
-# 1303|     r1303_6(char *)            = Convert                      : r1303_5
-# 1303|     r1303_7(char *)            = Call[strcpy]                 : func:r1303_1, 0:r1303_3, 1:r1303_6
-# 1303|     v1303_8(void)              = ^BufferReadSideEffect[1]     : &:r1303_6, ~m?
-# 1303|     mu1303_9(unknown)          = ^BufferMayWriteSideEffect[0] : &:r1303_3
+# 1303|     r1303_6(char *)            = Call[strcpy]                 : func:r1303_1, 0:r1303_3, 1:r1303_5
+# 1303|     v1303_7(void)              = ^BufferReadSideEffect[1]     : &:r1303_5, ~m?
+# 1303|     mu1303_8(unknown)          = ^BufferMayWriteSideEffect[0] : &:r1303_3
 # 1304|     r1304_1(glval<unknown>)    = FunctionAddress[strcat]      : 
 # 1304|     r1304_2(glval<char[1024]>) = VariableAddress[buffer]      : 
 # 1304|     r1304_3(char *)            = Convert                      : r1304_2
 # 1304|     r1304_4(glval<char *>)     = VariableAddress[s2]          : 
 # 1304|     r1304_5(char *)            = Load[s2]                     : &:r1304_4, ~m?
-# 1304|     r1304_6(char *)            = Convert                      : r1304_5
-# 1304|     r1304_7(char *)            = Call[strcat]                 : func:r1304_1, 0:r1304_3, 1:r1304_6
-# 1304|     v1304_8(void)              = ^BufferReadSideEffect[0]     : &:r1304_3, ~m?
-# 1304|     v1304_9(void)              = ^BufferReadSideEffect[1]     : &:r1304_6, ~m?
-# 1304|     mu1304_10(unknown)         = ^BufferMayWriteSideEffect[0] : &:r1304_3
+# 1304|     r1304_6(char *)            = Call[strcat]                 : func:r1304_1, 0:r1304_3, 1:r1304_5
+# 1304|     v1304_7(void)              = ^BufferReadSideEffect[0]     : &:r1304_3, ~m?
+# 1304|     v1304_8(void)              = ^BufferReadSideEffect[1]     : &:r1304_5, ~m?
+# 1304|     mu1304_9(unknown)          = ^BufferMayWriteSideEffect[0] : &:r1304_3
 # 1305|     v1305_1(void)              = NoOp                         : 
 # 1300|     v1300_12(void)             = ReturnIndirection[s1]        : &:r1300_6, ~m?
 # 1300|     v1300_13(void)             = ReturnIndirection[s2]        : &:r1300_10, ~m?
@@ -10648,16 +10548,14 @@ ir.cpp:
 # 1416|     r1416_4(String)          = Call[returnValue]                 : func:r1416_3
 # 1416|     mu1416_5(unknown)        = ^CallSideEffect                   : ~m?
 # 1416|     mu1416_6(String)         = Store[#temp1416:24]               : &:r1416_2, r1416_4
-# 1416|     r1416_7(glval<String>)   = Convert                           : r1416_2
-# 1416|     r1416_8(String &)        = CopyValue                         : r1416_7
-# 1416|     mu1416_9(String &)       = Store[rs]                         : &:r1416_1, r1416_8
+# 1416|     r1416_7(String &)        = CopyValue                         : r1416_2
+# 1416|     mu1416_8(String &)       = Store[rs]                         : &:r1416_1, r1416_7
 # 1418|     r1418_1(glval<unknown>)  = FunctionAddress[acceptRef]        : 
 # 1418|     r1418_2(glval<String>)   = VariableAddress[s]                : 
-# 1418|     r1418_3(glval<String>)   = Convert                           : r1418_2
-# 1418|     r1418_4(String &)        = CopyValue                         : r1418_3
-# 1418|     v1418_5(void)            = Call[acceptRef]                   : func:r1418_1, 0:r1418_4
-# 1418|     mu1418_6(unknown)        = ^CallSideEffect                   : ~m?
-# 1418|     v1418_7(void)            = ^BufferReadSideEffect[0]          : &:r1418_4, ~m?
+# 1418|     r1418_3(String &)        = CopyValue                         : r1418_2
+# 1418|     v1418_4(void)            = Call[acceptRef]                   : func:r1418_1, 0:r1418_3
+# 1418|     mu1418_5(unknown)        = ^CallSideEffect                   : ~m?
+# 1418|     v1418_6(void)            = ^BufferReadSideEffect[0]          : &:r1418_3, ~m?
 # 1419|     r1419_1(glval<unknown>)  = FunctionAddress[acceptRef]        : 
 # 1419|     r1419_2(glval<String>)   = VariableAddress[#temp1419:23]     : 
 # 1419|     mu1419_3(String)         = Uninitialized[#temp1419:23]       : &:r1419_2
@@ -10683,21 +10581,20 @@ ir.cpp:
 # 1420|     mu1420_3(String)         = Uninitialized[#temp1420:17]       : &:r1420_2
 # 1420|     r1420_4(glval<unknown>)  = FunctionAddress[String]           : 
 # 1420|     r1420_5(glval<String>)   = VariableAddress[s]                : 
-# 1420|     r1420_6(glval<String>)   = Convert                           : r1420_5
-# 1420|     r1420_7(String &)        = CopyValue                         : r1420_6
-# 1420|     v1420_8(void)            = Call[String]                      : func:r1420_4, this:r1420_2, 0:r1420_7
-# 1420|     mu1420_9(unknown)        = ^CallSideEffect                   : ~m?
-# 1420|     v1420_10(void)           = ^BufferReadSideEffect[0]          : &:r1420_7, ~m?
-# 1420|     mu1420_11(String)        = ^IndirectMayWriteSideEffect[-1]   : &:r1420_2
-# 1420|     r1420_12(String)         = Load[#temp1420:17]                : &:r1420_2, ~m?
-# 1420|     v1420_13(void)           = Call[acceptValue]                 : func:r1420_1, 0:r1420_12
-# 1420|     mu1420_14(unknown)       = ^CallSideEffect                   : ~m?
-# 1420|     r1420_15(glval<String>)  = CopyValue                         : r1420_2
-# 1420|     r1420_16(glval<unknown>) = FunctionAddress[~String]          : 
-# 1420|     v1420_17(void)           = Call[~String]                     : func:r1420_16, this:r1420_15
-# 1420|     mu1420_18(unknown)       = ^CallSideEffect                   : ~m?
-# 1420|     v1420_19(void)           = ^IndirectReadSideEffect[-1]       : &:r1420_15, ~m?
-# 1420|     mu1420_20(String)        = ^IndirectMayWriteSideEffect[-1]   : &:r1420_15
+# 1420|     r1420_6(String &)        = CopyValue                         : r1420_5
+# 1420|     v1420_7(void)            = Call[String]                      : func:r1420_4, this:r1420_2, 0:r1420_6
+# 1420|     mu1420_8(unknown)        = ^CallSideEffect                   : ~m?
+# 1420|     v1420_9(void)            = ^BufferReadSideEffect[0]          : &:r1420_6, ~m?
+# 1420|     mu1420_10(String)        = ^IndirectMayWriteSideEffect[-1]   : &:r1420_2
+# 1420|     r1420_11(String)         = Load[#temp1420:17]                : &:r1420_2, ~m?
+# 1420|     v1420_12(void)           = Call[acceptValue]                 : func:r1420_1, 0:r1420_11
+# 1420|     mu1420_13(unknown)       = ^CallSideEffect                   : ~m?
+# 1420|     r1420_14(glval<String>)  = CopyValue                         : r1420_2
+# 1420|     r1420_15(glval<unknown>) = FunctionAddress[~String]          : 
+# 1420|     v1420_16(void)           = Call[~String]                     : func:r1420_15, this:r1420_14
+# 1420|     mu1420_17(unknown)       = ^CallSideEffect                   : ~m?
+# 1420|     v1420_18(void)           = ^IndirectReadSideEffect[-1]       : &:r1420_14, ~m?
+# 1420|     mu1420_19(String)        = ^IndirectMayWriteSideEffect[-1]   : &:r1420_14
 # 1421|     r1421_1(glval<unknown>)  = FunctionAddress[acceptValue]      : 
 # 1421|     r1421_2(glval<String>)   = VariableAddress[#temp1421:25]     : 
 # 1421|     mu1421_3(String)         = Uninitialized[#temp1421:25]       : &:r1421_2
@@ -10723,33 +10620,31 @@ ir.cpp:
 # 1422|     v1422_4(void)            = Call[String]                      : func:r1422_3, this:r1422_1
 # 1422|     mu1422_5(unknown)        = ^CallSideEffect                   : ~m?
 # 1422|     mu1422_6(String)         = ^IndirectMayWriteSideEffect[-1]   : &:r1422_1
-# 1422|     r1422_7(glval<String>)   = Convert                           : r1422_1
-# 1422|     r1422_8(glval<unknown>)  = FunctionAddress[c_str]            : 
-# 1422|     r1422_9(char *)          = Call[c_str]                       : func:r1422_8, this:r1422_7
-# 1422|     mu1422_10(unknown)       = ^CallSideEffect                   : ~m?
-# 1422|     v1422_11(void)           = ^IndirectReadSideEffect[-1]       : &:r1422_7, ~m?
-# 1422|     r1422_12(glval<String>)  = CopyValue                         : r1422_1
-# 1422|     r1422_13(glval<unknown>) = FunctionAddress[~String]          : 
-# 1422|     v1422_14(void)           = Call[~String]                     : func:r1422_13, this:r1422_12
-# 1422|     mu1422_15(unknown)       = ^CallSideEffect                   : ~m?
-# 1422|     v1422_16(void)           = ^IndirectReadSideEffect[-1]       : &:r1422_12, ~m?
-# 1422|     mu1422_17(String)        = ^IndirectMayWriteSideEffect[-1]   : &:r1422_12
+# 1422|     r1422_7(glval<unknown>)  = FunctionAddress[c_str]            : 
+# 1422|     r1422_8(char *)          = Call[c_str]                       : func:r1422_7, this:r1422_1
+# 1422|     mu1422_9(unknown)        = ^CallSideEffect                   : ~m?
+# 1422|     v1422_10(void)           = ^IndirectReadSideEffect[-1]       : &:r1422_1, ~m?
+# 1422|     r1422_11(glval<String>)  = CopyValue                         : r1422_1
+# 1422|     r1422_12(glval<unknown>) = FunctionAddress[~String]          : 
+# 1422|     v1422_13(void)           = Call[~String]                     : func:r1422_12, this:r1422_11
+# 1422|     mu1422_14(unknown)       = ^CallSideEffect                   : ~m?
+# 1422|     v1422_15(void)           = ^IndirectReadSideEffect[-1]       : &:r1422_11, ~m?
+# 1422|     mu1422_16(String)        = ^IndirectMayWriteSideEffect[-1]   : &:r1422_11
 # 1423|     r1423_1(glval<String>)   = VariableAddress[#temp1423:5]      : 
 # 1423|     r1423_2(glval<unknown>)  = FunctionAddress[returnValue]      : 
 # 1423|     r1423_3(String)          = Call[returnValue]                 : func:r1423_2
 # 1423|     mu1423_4(unknown)        = ^CallSideEffect                   : ~m?
 # 1423|     mu1423_5(String)         = Store[#temp1423:5]                : &:r1423_1, r1423_3
-# 1423|     r1423_6(glval<String>)   = Convert                           : r1423_1
-# 1423|     r1423_7(glval<unknown>)  = FunctionAddress[c_str]            : 
-# 1423|     r1423_8(char *)          = Call[c_str]                       : func:r1423_7, this:r1423_6
-# 1423|     mu1423_9(unknown)        = ^CallSideEffect                   : ~m?
-# 1423|     v1423_10(void)           = ^IndirectReadSideEffect[-1]       : &:r1423_6, ~m?
-# 1423|     r1423_11(glval<String>)  = CopyValue                         : r1423_1
-# 1423|     r1423_12(glval<unknown>) = FunctionAddress[~String]          : 
-# 1423|     v1423_13(void)           = Call[~String]                     : func:r1423_12, this:r1423_11
-# 1423|     mu1423_14(unknown)       = ^CallSideEffect                   : ~m?
-# 1423|     v1423_15(void)           = ^IndirectReadSideEffect[-1]       : &:r1423_11, ~m?
-# 1423|     mu1423_16(String)        = ^IndirectMayWriteSideEffect[-1]   : &:r1423_11
+# 1423|     r1423_6(glval<unknown>)  = FunctionAddress[c_str]            : 
+# 1423|     r1423_7(char *)          = Call[c_str]                       : func:r1423_6, this:r1423_1
+# 1423|     mu1423_8(unknown)        = ^CallSideEffect                   : ~m?
+# 1423|     v1423_9(void)            = ^IndirectReadSideEffect[-1]       : &:r1423_1, ~m?
+# 1423|     r1423_10(glval<String>)  = CopyValue                         : r1423_1
+# 1423|     r1423_11(glval<unknown>) = FunctionAddress[~String]          : 
+# 1423|     v1423_12(void)           = Call[~String]                     : func:r1423_11, this:r1423_10
+# 1423|     mu1423_13(unknown)       = ^CallSideEffect                   : ~m?
+# 1423|     v1423_14(void)           = ^IndirectReadSideEffect[-1]       : &:r1423_10, ~m?
+# 1423|     mu1423_15(String)        = ^IndirectMayWriteSideEffect[-1]   : &:r1423_10
 # 1425|     r1425_1(glval<String>)   = VariableAddress[#temp1425:5]      : 
 # 1425|     r1425_2(glval<unknown>)  = FunctionAddress[defaultConstruct] : 
 # 1425|     r1425_3(String)          = Call[defaultConstruct]            : func:r1425_2
@@ -10794,18 +10689,16 @@ ir.cpp:
 # 1430|     r1430_4(destructor_only)          = Call[returnValue]                 : func:r1430_3
 # 1430|     mu1430_5(unknown)                 = ^CallSideEffect                   : ~m?
 # 1430|     mu1430_6(destructor_only)         = Store[#temp1430:33]               : &:r1430_2, r1430_4
-# 1430|     r1430_7(glval<destructor_only>)   = Convert                           : r1430_2
-# 1430|     r1430_8(destructor_only &)        = CopyValue                         : r1430_7
-# 1430|     mu1430_9(destructor_only &)       = Store[rd]                         : &:r1430_1, r1430_8
+# 1430|     r1430_7(destructor_only &)        = CopyValue                         : r1430_2
+# 1430|     mu1430_8(destructor_only &)       = Store[rd]                         : &:r1430_1, r1430_7
 # 1431|     r1431_1(glval<destructor_only>)   = VariableAddress[d2]               : 
 # 1431|     mu1431_2(destructor_only)         = Uninitialized[d2]                 : &:r1431_1
 # 1432|     r1432_1(glval<unknown>)           = FunctionAddress[acceptRef]        : 
 # 1432|     r1432_2(glval<destructor_only>)   = VariableAddress[d]                : 
-# 1432|     r1432_3(glval<destructor_only>)   = Convert                           : r1432_2
-# 1432|     r1432_4(destructor_only &)        = CopyValue                         : r1432_3
-# 1432|     v1432_5(void)                     = Call[acceptRef]                   : func:r1432_1, 0:r1432_4
-# 1432|     mu1432_6(unknown)                 = ^CallSideEffect                   : ~m?
-# 1432|     v1432_7(void)                     = ^BufferReadSideEffect[0]          : &:r1432_4, ~m?
+# 1432|     r1432_3(destructor_only &)        = CopyValue                         : r1432_2
+# 1432|     v1432_4(void)                     = Call[acceptRef]                   : func:r1432_1, 0:r1432_3
+# 1432|     mu1432_5(unknown)                 = ^CallSideEffect                   : ~m?
+# 1432|     v1432_6(void)                     = ^BufferReadSideEffect[0]          : &:r1432_3, ~m?
 # 1433|     r1433_1(glval<unknown>)           = FunctionAddress[acceptValue]      : 
 # 1433|     r1433_2(glval<destructor_only>)   = VariableAddress[#temp1433:17]     : 
 # 1433|     r1433_3(glval<destructor_only>)   = VariableAddress[d]                : 
@@ -10900,9 +10793,8 @@ ir.cpp:
 # 1442|     r1442_4(copy_constructor)          = Call[returnValue]                 : func:r1442_3
 # 1442|     mu1442_5(unknown)                  = ^CallSideEffect                   : ~m?
 # 1442|     mu1442_6(copy_constructor)         = Store[#temp1442:34]               : &:r1442_2, r1442_4
-# 1442|     r1442_7(glval<copy_constructor>)   = Convert                           : r1442_2
-# 1442|     r1442_8(copy_constructor &)        = CopyValue                         : r1442_7
-# 1442|     mu1442_9(copy_constructor &)       = Store[rd]                         : &:r1442_1, r1442_8
+# 1442|     r1442_7(copy_constructor &)        = CopyValue                         : r1442_2
+# 1442|     mu1442_8(copy_constructor &)       = Store[rd]                         : &:r1442_1, r1442_7
 # 1443|     r1443_1(glval<copy_constructor>)   = VariableAddress[d2]               : 
 # 1443|     mu1443_2(copy_constructor)         = Uninitialized[d2]                 : &:r1443_1
 # 1443|     r1443_3(glval<unknown>)            = FunctionAddress[copy_constructor] : 
@@ -10911,25 +10803,23 @@ ir.cpp:
 # 1443|     mu1443_6(copy_constructor)         = ^IndirectMayWriteSideEffect[-1]   : &:r1443_1
 # 1444|     r1444_1(glval<unknown>)            = FunctionAddress[acceptRef]        : 
 # 1444|     r1444_2(glval<copy_constructor>)   = VariableAddress[d]                : 
-# 1444|     r1444_3(glval<copy_constructor>)   = Convert                           : r1444_2
-# 1444|     r1444_4(copy_constructor &)        = CopyValue                         : r1444_3
-# 1444|     v1444_5(void)                      = Call[acceptRef]                   : func:r1444_1, 0:r1444_4
-# 1444|     mu1444_6(unknown)                  = ^CallSideEffect                   : ~m?
-# 1444|     v1444_7(void)                      = ^BufferReadSideEffect[0]          : &:r1444_4, ~m?
+# 1444|     r1444_3(copy_constructor &)        = CopyValue                         : r1444_2
+# 1444|     v1444_4(void)                      = Call[acceptRef]                   : func:r1444_1, 0:r1444_3
+# 1444|     mu1444_5(unknown)                  = ^CallSideEffect                   : ~m?
+# 1444|     v1444_6(void)                      = ^BufferReadSideEffect[0]          : &:r1444_3, ~m?
 # 1445|     r1445_1(glval<unknown>)            = FunctionAddress[acceptValue]      : 
 # 1445|     r1445_2(glval<copy_constructor>)   = VariableAddress[#temp1445:17]     : 
 # 1445|     mu1445_3(copy_constructor)         = Uninitialized[#temp1445:17]       : &:r1445_2
 # 1445|     r1445_4(glval<unknown>)            = FunctionAddress[copy_constructor] : 
 # 1445|     r1445_5(glval<copy_constructor>)   = VariableAddress[d]                : 
-# 1445|     r1445_6(glval<copy_constructor>)   = Convert                           : r1445_5
-# 1445|     r1445_7(copy_constructor &)        = CopyValue                         : r1445_6
-# 1445|     v1445_8(void)                      = Call[copy_constructor]            : func:r1445_4, this:r1445_2, 0:r1445_7
-# 1445|     mu1445_9(unknown)                  = ^CallSideEffect                   : ~m?
-# 1445|     v1445_10(void)                     = ^BufferReadSideEffect[0]          : &:r1445_7, ~m?
-# 1445|     mu1445_11(copy_constructor)        = ^IndirectMayWriteSideEffect[-1]   : &:r1445_2
-# 1445|     r1445_12(copy_constructor)         = Load[#temp1445:17]                : &:r1445_2, ~m?
-# 1445|     v1445_13(void)                     = Call[acceptValue]                 : func:r1445_1, 0:r1445_12
-# 1445|     mu1445_14(unknown)                 = ^CallSideEffect                   : ~m?
+# 1445|     r1445_6(copy_constructor &)        = CopyValue                         : r1445_5
+# 1445|     v1445_7(void)                      = Call[copy_constructor]            : func:r1445_4, this:r1445_2, 0:r1445_6
+# 1445|     mu1445_8(unknown)                  = ^CallSideEffect                   : ~m?
+# 1445|     v1445_9(void)                      = ^BufferReadSideEffect[0]          : &:r1445_6, ~m?
+# 1445|     mu1445_10(copy_constructor)        = ^IndirectMayWriteSideEffect[-1]   : &:r1445_2
+# 1445|     r1445_11(copy_constructor)         = Load[#temp1445:17]                : &:r1445_2, ~m?
+# 1445|     v1445_12(void)                     = Call[acceptValue]                 : func:r1445_1, 0:r1445_11
+# 1445|     mu1445_13(unknown)                 = ^CallSideEffect                   : ~m?
 # 1446|     r1446_1(glval<copy_constructor>)   = VariableAddress[#temp1446:5]      : 
 # 1446|     mu1446_2(copy_constructor)         = Uninitialized[#temp1446:5]        : &:r1446_1
 # 1446|     r1446_3(glval<unknown>)            = FunctionAddress[copy_constructor] : 
@@ -10986,16 +10876,14 @@ ir.cpp:
 # 1455|     r1455_4(Point)          = Call[returnValue]                 : func:r1455_3
 # 1455|     mu1455_5(unknown)       = ^CallSideEffect                   : ~m?
 # 1455|     mu1455_6(Point)         = Store[#temp1455:23]               : &:r1455_2, r1455_4
-# 1455|     r1455_7(glval<Point>)   = Convert                           : r1455_2
-# 1455|     r1455_8(Point &)        = CopyValue                         : r1455_7
-# 1455|     mu1455_9(Point &)       = Store[rp]                         : &:r1455_1, r1455_8
+# 1455|     r1455_7(Point &)        = CopyValue                         : r1455_2
+# 1455|     mu1455_8(Point &)       = Store[rp]                         : &:r1455_1, r1455_7
 # 1457|     r1457_1(glval<unknown>) = FunctionAddress[acceptRef]        : 
 # 1457|     r1457_2(glval<Point>)   = VariableAddress[p]                : 
-# 1457|     r1457_3(glval<Point>)   = Convert                           : r1457_2
-# 1457|     r1457_4(Point &)        = CopyValue                         : r1457_3
-# 1457|     v1457_5(void)           = Call[acceptRef]                   : func:r1457_1, 0:r1457_4
-# 1457|     mu1457_6(unknown)       = ^CallSideEffect                   : ~m?
-# 1457|     v1457_7(void)           = ^BufferReadSideEffect[0]          : &:r1457_4, ~m?
+# 1457|     r1457_3(Point &)        = CopyValue                         : r1457_2
+# 1457|     v1457_4(void)           = Call[acceptRef]                   : func:r1457_1, 0:r1457_3
+# 1457|     mu1457_5(unknown)       = ^CallSideEffect                   : ~m?
+# 1457|     v1457_6(void)           = ^BufferReadSideEffect[0]          : &:r1457_3, ~m?
 # 1458|     r1458_1(glval<unknown>) = FunctionAddress[acceptValue]      : 
 # 1458|     r1458_2(glval<Point>)   = VariableAddress[p]                : 
 # 1458|     r1458_3(Point)          = Load[p]                           : &:r1458_2, ~m?
@@ -11033,9 +10921,8 @@ ir.cpp:
 # 1471|     r1471_7(glval<int &>)         = FieldAddress[r]               : r1471_5
 # 1471|     r1471_8(int &)                = Load[?]                       : &:r1471_7, ~m?
 # 1471|     r1471_9(glval<int>)           = CopyValue                     : r1471_8
-# 1471|     r1471_10(glval<int>)          = Convert                       : r1471_9
-# 1471|     r1471_11(int &)               = CopyValue                     : r1471_10
-# 1471|     mu1471_12(int &)              = Store[rx]                     : &:r1471_1, r1471_11
+# 1471|     r1471_10(int &)               = CopyValue                     : r1471_9
+# 1471|     mu1471_11(int &)              = Store[rx]                     : &:r1471_1, r1471_10
 # 1472|     r1472_1(glval<int>)           = VariableAddress[x]            : 
 # 1472|     r1472_2(glval<unknown>)       = FunctionAddress[returnValue]  : 
 # 1472|     r1472_3(UnusualFields)        = Call[returnValue]             : func:r1472_2
@@ -11056,9 +10943,8 @@ ir.cpp:
 # 1474|     r1474_8(float *)              = Convert                       : r1474_7
 # 1474|     r1474_9(int)                  = Constant[3]                   : 
 # 1474|     r1474_10(glval<float>)        = PointerAdd[4]                 : r1474_8, r1474_9
-# 1474|     r1474_11(glval<float>)        = Convert                       : r1474_10
-# 1474|     r1474_12(float &)             = CopyValue                     : r1474_11
-# 1474|     mu1474_13(float &)            = Store[rf]                     : &:r1474_1, r1474_12
+# 1474|     r1474_11(float &)             = CopyValue                     : r1474_10
+# 1474|     mu1474_12(float &)            = Store[rf]                     : &:r1474_1, r1474_11
 # 1475|     r1475_1(glval<float>)         = VariableAddress[f]            : 
 # 1475|     r1475_2(glval<unknown>)       = FunctionAddress[returnValue]  : 
 # 1475|     r1475_3(UnusualFields)        = Call[returnValue]             : func:r1475_2
@@ -11119,11 +11005,10 @@ ir.cpp:
 # 1496|     mu1496_5(POD_Derived)       = Store[#temp0:0]                                   : &:r0_8, r1496_3
 #-----|     r0_9(glval<POD_Middle>)     = ConvertToNonVirtualBase[POD_Derived : POD_Middle] : r0_8
 #-----|     r0_10(glval<POD_Base>)      = ConvertToNonVirtualBase[POD_Middle : POD_Base]    : r0_9
-#-----|     r0_11(glval<POD_Base>)      = Convert                                           : r0_10
 # 1496|     r1496_6(glval<unknown>)     = FunctionAddress[f]                                : 
-# 1496|     r1496_7(float)              = Call[f]                                           : func:r1496_6, this:r0_11
+# 1496|     r1496_7(float)              = Call[f]                                           : func:r1496_6, this:r0_10
 # 1496|     mu1496_8(unknown)           = ^CallSideEffect                                   : ~m?
-#-----|     v0_12(void)                 = ^IndirectReadSideEffect[-1]                       : &:r0_11, ~m?
+#-----|     v0_11(void)                 = ^IndirectReadSideEffect[-1]                       : &:r0_10, ~m?
 # 1496|     mu1496_9(float)             = Store[f]                                          : &:r1496_1, r1496_7
 # 1497|     v1497_1(void)               = NoOp                                              : 
 # 1492|     v1492_4(void)               = ReturnVoid                                        : 
@@ -12126,9 +12011,8 @@ ir.cpp:
 # 1734|     v1734_5(void)                             = Call[CapturedLambdaMyObj]            : func:r1734_4, this:r1734_2
 # 1734|     mu1734_6(unknown)                         = ^CallSideEffect                      : ~m?
 # 1734|     mu1734_7(CapturedLambdaMyObj)             = ^IndirectMayWriteSideEffect[-1]      : &:r1734_2
-# 1734|     r1734_8(glval<CapturedLambdaMyObj>)       = Convert                              : r1734_2
-# 1734|     r1734_9(CapturedLambdaMyObj &)            = CopyValue                            : r1734_8
-# 1734|     mu1734_10(CapturedLambdaMyObj &)          = Store[obj1]                          : &:r1734_1, r1734_9
+# 1734|     r1734_8(CapturedLambdaMyObj &)            = CopyValue                            : r1734_2
+# 1734|     mu1734_9(CapturedLambdaMyObj &)           = Store[obj1]                          : &:r1734_1, r1734_8
 # 1735|     r1735_1(glval<CapturedLambdaMyObj>)       = VariableAddress[obj2]                : 
 # 1735|     mu1735_2(CapturedLambdaMyObj)             = Uninitialized[obj2]                  : &:r1735_1
 # 1735|     r1735_3(glval<unknown>)                   = FunctionAddress[CapturedLambdaMyObj] : 
@@ -12358,9 +12242,8 @@ ir.cpp:
 # 1763|     r1763_2(glval<TrivialLambdaClass>)        = VariableAddress[#temp1763:36] : 
 # 1763|     r1763_3(TrivialLambdaClass)               = Constant[0]                   : 
 # 1763|     mu1763_4(TrivialLambdaClass)              = Store[#temp1763:36]           : &:r1763_2, r1763_3
-# 1763|     r1763_5(glval<TrivialLambdaClass>)        = Convert                       : r1763_2
-# 1763|     r1763_6(TrivialLambdaClass &)             = CopyValue                     : r1763_5
-# 1763|     mu1763_7(TrivialLambdaClass &)            = Store[l2]                     : &:r1763_1, r1763_6
+# 1763|     r1763_5(TrivialLambdaClass &)             = CopyValue                     : r1763_2
+# 1763|     mu1763_6(TrivialLambdaClass &)            = Store[l2]                     : &:r1763_1, r1763_5
 # 1765|     r1765_1(glval<decltype([...](...){...})>) = VariableAddress[l_outer1]     : 
 # 1765|     r1765_2(glval<decltype([...](...){...})>) = VariableAddress[#temp1765:20] : 
 # 1765|     mu1765_3(decltype([...](...){...}))       = Uninitialized[#temp1765:20]   : &:r1765_2
@@ -13000,11 +12883,10 @@ ir.cpp:
 # 1878|     r1878_3(glval<char *>)   = VariableAddress[global_string]  : 
 # 1878|     r1878_4(glval<char[14]>) = StringConstant["global string"] : 
 # 1878|     r1878_5(char *)          = Convert                         : r1878_4
-# 1878|     r1878_6(char *)          = Convert                         : r1878_5
-# 1878|     mu1878_7(char *)         = Store[global_string]            : &:r1878_3, r1878_6
-# 1878|     v1878_8(void)            = ReturnVoid                      : 
-# 1878|     v1878_9(void)            = AliasedUse                      : ~m?
-# 1878|     v1878_10(void)           = ExitFunction                    : 
+# 1878|     mu1878_6(char *)         = Store[global_string]            : &:r1878_3, r1878_5
+# 1878|     v1878_7(void)            = ReturnVoid                      : 
+# 1878|     v1878_8(void)            = AliasedUse                      : ~m?
+# 1878|     v1878_9(void)            = ExitFunction                    : 
 
 # 1880| int global_6
 # 1880|   Block 0
@@ -14088,14 +13970,13 @@ ir.cpp:
 # 2081|   Block 1
 # 2081|     r2081_6(glval<unknown>)           = VariableAddress[#temp2081:9]    : 
 # 2081|     r2081_7(glval<TernaryNonPodObj>)  = Load[#temp2081:9]               : &:r2081_6, ~m?
-# 2081|     r2081_8(glval<TernaryNonPodObj>)  = Convert                         : r2081_7
-# 2081|     r2081_9(TernaryNonPodObj &)       = CopyValue                       : r2081_8
-# 2081|     r2081_10(TernaryNonPodObj &)      = Call[operator=]                 : func:r2081_2, this:r2081_1, 0:r2081_9
-# 2081|     mu2081_11(unknown)                = ^CallSideEffect                 : ~m?
-# 2081|     v2081_12(void)                    = ^IndirectReadSideEffect[-1]     : &:r2081_1, ~m?
-# 2081|     v2081_13(void)                    = ^BufferReadSideEffect[0]        : &:r2081_9, ~m?
-# 2081|     mu2081_14(TernaryNonPodObj)       = ^IndirectMayWriteSideEffect[-1] : &:r2081_1
-# 2081|     r2081_15(glval<TernaryNonPodObj>) = CopyValue                       : r2081_10
+# 2081|     r2081_8(TernaryNonPodObj &)       = CopyValue                       : r2081_7
+# 2081|     r2081_9(TernaryNonPodObj &)       = Call[operator=]                 : func:r2081_2, this:r2081_1, 0:r2081_8
+# 2081|     mu2081_10(unknown)                = ^CallSideEffect                 : ~m?
+# 2081|     v2081_11(void)                    = ^IndirectReadSideEffect[-1]     : &:r2081_1, ~m?
+# 2081|     v2081_12(void)                    = ^BufferReadSideEffect[0]        : &:r2081_8, ~m?
+# 2081|     mu2081_13(TernaryNonPodObj)       = ^IndirectMayWriteSideEffect[-1] : &:r2081_1
+# 2081|     r2081_14(glval<TernaryNonPodObj>) = CopyValue                       : r2081_9
 # 2082|     r2082_1(glval<TernaryNonPodObj>)  = VariableAddress[z]              : 
 # 2082|     r2082_2(glval<unknown>)           = FunctionAddress[operator=]      : 
 # 2082|     r2082_3(glval<TernaryNonPodObj>)  = VariableAddress[#temp2082:9]    : 
@@ -14106,35 +13987,34 @@ ir.cpp:
 #-----|   True -> Block 5
 
 # 2081|   Block 2
-# 2081|     r2081_16(glval<TernaryNonPodObj>)  = VariableAddress[x]           : 
-# 2081|     r2081_17(glval<unknown>)           = VariableAddress[#temp2081:9] : 
-# 2081|     mu2081_18(glval<TernaryNonPodObj>) = Store[#temp2081:9]           : &:r2081_17, r2081_16
+# 2081|     r2081_15(glval<TernaryNonPodObj>)  = VariableAddress[x]           : 
+# 2081|     r2081_16(glval<unknown>)           = VariableAddress[#temp2081:9] : 
+# 2081|     mu2081_17(glval<TernaryNonPodObj>) = Store[#temp2081:9]           : &:r2081_16, r2081_15
 #-----|   Goto -> Block 1
 
 # 2081|   Block 3
-# 2081|     r2081_19(glval<TernaryNonPodObj>)  = VariableAddress[y]           : 
-# 2081|     r2081_20(glval<unknown>)           = VariableAddress[#temp2081:9] : 
-# 2081|     mu2081_21(glval<TernaryNonPodObj>) = Store[#temp2081:9]           : &:r2081_20, r2081_19
+# 2081|     r2081_18(glval<TernaryNonPodObj>)  = VariableAddress[y]           : 
+# 2081|     r2081_19(glval<unknown>)           = VariableAddress[#temp2081:9] : 
+# 2081|     mu2081_20(glval<TernaryNonPodObj>) = Store[#temp2081:9]           : &:r2081_19, r2081_18
 #-----|   Goto -> Block 1
 
 # 2082|   Block 4
 # 2082|     r2082_7(glval<TernaryNonPodObj>)  = VariableAddress[#temp2082:9]       : 
 # 2082|     r2082_8(TernaryNonPodObj)         = Load[#temp2082:9]                  : &:r2082_7, ~m?
 # 2082|     mu2082_9(TernaryNonPodObj)        = Store[#temp2082:9]                 : &:r2082_3, r2082_8
-# 2082|     r2082_10(glval<TernaryNonPodObj>) = Convert                            : r2082_3
-# 2082|     r2082_11(TernaryNonPodObj &)      = CopyValue                          : r2082_10
-# 2082|     r2082_12(TernaryNonPodObj &)      = Call[operator=]                    : func:r2082_2, this:r2082_1, 0:r2082_11
-# 2082|     mu2082_13(unknown)                = ^CallSideEffect                    : ~m?
-# 2082|     v2082_14(void)                    = ^IndirectReadSideEffect[-1]        : &:r2082_1, ~m?
-# 2082|     v2082_15(void)                    = ^BufferReadSideEffect[0]           : &:r2082_11, ~m?
-# 2082|     mu2082_16(TernaryNonPodObj)       = ^IndirectMayWriteSideEffect[-1]    : &:r2082_1
-# 2082|     r2082_17(glval<TernaryNonPodObj>) = CopyValue                          : r2082_3
-# 2082|     r2082_18(glval<unknown>)          = FunctionAddress[~TernaryNonPodObj] : 
-# 2082|     v2082_19(void)                    = Call[~TernaryNonPodObj]            : func:r2082_18, this:r2082_17
-# 2082|     mu2082_20(unknown)                = ^CallSideEffect                    : ~m?
-# 2082|     v2082_21(void)                    = ^IndirectReadSideEffect[-1]        : &:r2082_17, ~m?
-# 2082|     mu2082_22(TernaryNonPodObj)       = ^IndirectMayWriteSideEffect[-1]    : &:r2082_17
-# 2082|     r2082_23(glval<TernaryNonPodObj>) = CopyValue                          : r2082_12
+# 2082|     r2082_10(TernaryNonPodObj &)      = CopyValue                          : r2082_3
+# 2082|     r2082_11(TernaryNonPodObj &)      = Call[operator=]                    : func:r2082_2, this:r2082_1, 0:r2082_10
+# 2082|     mu2082_12(unknown)                = ^CallSideEffect                    : ~m?
+# 2082|     v2082_13(void)                    = ^IndirectReadSideEffect[-1]        : &:r2082_1, ~m?
+# 2082|     v2082_14(void)                    = ^BufferReadSideEffect[0]           : &:r2082_10, ~m?
+# 2082|     mu2082_15(TernaryNonPodObj)       = ^IndirectMayWriteSideEffect[-1]    : &:r2082_1
+# 2082|     r2082_16(glval<TernaryNonPodObj>) = CopyValue                          : r2082_3
+# 2082|     r2082_17(glval<unknown>)          = FunctionAddress[~TernaryNonPodObj] : 
+# 2082|     v2082_18(void)                    = Call[~TernaryNonPodObj]            : func:r2082_17, this:r2082_16
+# 2082|     mu2082_19(unknown)                = ^CallSideEffect                    : ~m?
+# 2082|     v2082_20(void)                    = ^IndirectReadSideEffect[-1]        : &:r2082_16, ~m?
+# 2082|     mu2082_21(TernaryNonPodObj)       = ^IndirectMayWriteSideEffect[-1]    : &:r2082_16
+# 2082|     r2082_22(glval<TernaryNonPodObj>) = CopyValue                          : r2082_11
 # 2083|     r2083_1(glval<TernaryNonPodObj>)  = VariableAddress[z]                 : 
 # 2083|     r2083_2(glval<unknown>)           = FunctionAddress[operator=]         : 
 # 2083|     r2083_3(glval<TernaryNonPodObj>)  = VariableAddress[#temp2083:9]       : 
@@ -14145,51 +14025,49 @@ ir.cpp:
 #-----|   True -> Block 8
 
 # 2082|   Block 5
-# 2082|     r2082_24(glval<TernaryNonPodObj>) = VariableAddress[#temp2082:13]     : 
-# 2082|     mu2082_25(TernaryNonPodObj)       = Uninitialized[#temp2082:13]       : &:r2082_24
-# 2082|     r2082_26(glval<unknown>)          = FunctionAddress[TernaryNonPodObj] : 
-# 2082|     r2082_27(glval<TernaryNonPodObj>) = VariableAddress[x]                : 
-# 2082|     r2082_28(glval<TernaryNonPodObj>) = Convert                           : r2082_27
-# 2082|     r2082_29(TernaryNonPodObj &)      = CopyValue                         : r2082_28
-# 2082|     v2082_30(void)                    = Call[TernaryNonPodObj]            : func:r2082_26, this:r2082_24, 0:r2082_29
-# 2082|     mu2082_31(unknown)                = ^CallSideEffect                   : ~m?
-# 2082|     v2082_32(void)                    = ^BufferReadSideEffect[0]          : &:r2082_29, ~m?
-# 2082|     mu2082_33(TernaryNonPodObj)       = ^IndirectMayWriteSideEffect[-1]   : &:r2082_24
-# 2082|     r2082_34(TernaryNonPodObj)        = Load[#temp2082:13]                : &:r2082_24, ~m?
-# 2082|     r2082_35(glval<TernaryNonPodObj>) = VariableAddress[#temp2082:9]      : 
-# 2082|     mu2082_36(TernaryNonPodObj)       = Store[#temp2082:9]                : &:r2082_35, r2082_34
+# 2082|     r2082_23(glval<TernaryNonPodObj>) = VariableAddress[#temp2082:13]     : 
+# 2082|     mu2082_24(TernaryNonPodObj)       = Uninitialized[#temp2082:13]       : &:r2082_23
+# 2082|     r2082_25(glval<unknown>)          = FunctionAddress[TernaryNonPodObj] : 
+# 2082|     r2082_26(glval<TernaryNonPodObj>) = VariableAddress[x]                : 
+# 2082|     r2082_27(TernaryNonPodObj &)      = CopyValue                         : r2082_26
+# 2082|     v2082_28(void)                    = Call[TernaryNonPodObj]            : func:r2082_25, this:r2082_23, 0:r2082_27
+# 2082|     mu2082_29(unknown)                = ^CallSideEffect                   : ~m?
+# 2082|     v2082_30(void)                    = ^BufferReadSideEffect[0]          : &:r2082_27, ~m?
+# 2082|     mu2082_31(TernaryNonPodObj)       = ^IndirectMayWriteSideEffect[-1]   : &:r2082_23
+# 2082|     r2082_32(TernaryNonPodObj)        = Load[#temp2082:13]                : &:r2082_23, ~m?
+# 2082|     r2082_33(glval<TernaryNonPodObj>) = VariableAddress[#temp2082:9]      : 
+# 2082|     mu2082_34(TernaryNonPodObj)       = Store[#temp2082:9]                : &:r2082_33, r2082_32
 #-----|   Goto -> Block 4
 
 # 2082|   Block 6
-# 2082|     r2082_37(glval<TernaryNonPodObj>) = VariableAddress[#temp2082:17]     : 
-# 2082|     mu2082_38(TernaryNonPodObj)       = Uninitialized[#temp2082:17]       : &:r2082_37
-# 2082|     r2082_39(glval<unknown>)          = FunctionAddress[TernaryNonPodObj] : 
-# 2082|     v2082_40(void)                    = Call[TernaryNonPodObj]            : func:r2082_39, this:r2082_37
-# 2082|     mu2082_41(unknown)                = ^CallSideEffect                   : ~m?
-# 2082|     mu2082_42(TernaryNonPodObj)       = ^IndirectMayWriteSideEffect[-1]   : &:r2082_37
-# 2082|     r2082_43(TernaryNonPodObj)        = Load[#temp2082:17]                : &:r2082_37, ~m?
-# 2082|     r2082_44(glval<TernaryNonPodObj>) = VariableAddress[#temp2082:9]      : 
-# 2082|     mu2082_45(TernaryNonPodObj)       = Store[#temp2082:9]                : &:r2082_44, r2082_43
+# 2082|     r2082_35(glval<TernaryNonPodObj>) = VariableAddress[#temp2082:17]     : 
+# 2082|     mu2082_36(TernaryNonPodObj)       = Uninitialized[#temp2082:17]       : &:r2082_35
+# 2082|     r2082_37(glval<unknown>)          = FunctionAddress[TernaryNonPodObj] : 
+# 2082|     v2082_38(void)                    = Call[TernaryNonPodObj]            : func:r2082_37, this:r2082_35
+# 2082|     mu2082_39(unknown)                = ^CallSideEffect                   : ~m?
+# 2082|     mu2082_40(TernaryNonPodObj)       = ^IndirectMayWriteSideEffect[-1]   : &:r2082_35
+# 2082|     r2082_41(TernaryNonPodObj)        = Load[#temp2082:17]                : &:r2082_35, ~m?
+# 2082|     r2082_42(glval<TernaryNonPodObj>) = VariableAddress[#temp2082:9]      : 
+# 2082|     mu2082_43(TernaryNonPodObj)       = Store[#temp2082:9]                : &:r2082_42, r2082_41
 #-----|   Goto -> Block 4
 
 # 2083|   Block 7
 # 2083|     r2083_7(glval<TernaryNonPodObj>)  = VariableAddress[#temp2083:9]       : 
 # 2083|     r2083_8(TernaryNonPodObj)         = Load[#temp2083:9]                  : &:r2083_7, ~m?
 # 2083|     mu2083_9(TernaryNonPodObj)        = Store[#temp2083:9]                 : &:r2083_3, r2083_8
-# 2083|     r2083_10(glval<TernaryNonPodObj>) = Convert                            : r2083_3
-# 2083|     r2083_11(TernaryNonPodObj &)      = CopyValue                          : r2083_10
-# 2083|     r2083_12(TernaryNonPodObj &)      = Call[operator=]                    : func:r2083_2, this:r2083_1, 0:r2083_11
-# 2083|     mu2083_13(unknown)                = ^CallSideEffect                    : ~m?
-# 2083|     v2083_14(void)                    = ^IndirectReadSideEffect[-1]        : &:r2083_1, ~m?
-# 2083|     v2083_15(void)                    = ^BufferReadSideEffect[0]           : &:r2083_11, ~m?
-# 2083|     mu2083_16(TernaryNonPodObj)       = ^IndirectMayWriteSideEffect[-1]    : &:r2083_1
-# 2083|     r2083_17(glval<TernaryNonPodObj>) = CopyValue                          : r2083_3
-# 2083|     r2083_18(glval<unknown>)          = FunctionAddress[~TernaryNonPodObj] : 
-# 2083|     v2083_19(void)                    = Call[~TernaryNonPodObj]            : func:r2083_18, this:r2083_17
-# 2083|     mu2083_20(unknown)                = ^CallSideEffect                    : ~m?
-# 2083|     v2083_21(void)                    = ^IndirectReadSideEffect[-1]        : &:r2083_17, ~m?
-# 2083|     mu2083_22(TernaryNonPodObj)       = ^IndirectMayWriteSideEffect[-1]    : &:r2083_17
-# 2083|     r2083_23(glval<TernaryNonPodObj>) = CopyValue                          : r2083_12
+# 2083|     r2083_10(TernaryNonPodObj &)      = CopyValue                          : r2083_3
+# 2083|     r2083_11(TernaryNonPodObj &)      = Call[operator=]                    : func:r2083_2, this:r2083_1, 0:r2083_10
+# 2083|     mu2083_12(unknown)                = ^CallSideEffect                    : ~m?
+# 2083|     v2083_13(void)                    = ^IndirectReadSideEffect[-1]        : &:r2083_1, ~m?
+# 2083|     v2083_14(void)                    = ^BufferReadSideEffect[0]           : &:r2083_10, ~m?
+# 2083|     mu2083_15(TernaryNonPodObj)       = ^IndirectMayWriteSideEffect[-1]    : &:r2083_1
+# 2083|     r2083_16(glval<TernaryNonPodObj>) = CopyValue                          : r2083_3
+# 2083|     r2083_17(glval<unknown>)          = FunctionAddress[~TernaryNonPodObj] : 
+# 2083|     v2083_18(void)                    = Call[~TernaryNonPodObj]            : func:r2083_17, this:r2083_16
+# 2083|     mu2083_19(unknown)                = ^CallSideEffect                    : ~m?
+# 2083|     v2083_20(void)                    = ^IndirectReadSideEffect[-1]        : &:r2083_16, ~m?
+# 2083|     mu2083_21(TernaryNonPodObj)       = ^IndirectMayWriteSideEffect[-1]    : &:r2083_16
+# 2083|     r2083_22(glval<TernaryNonPodObj>) = CopyValue                          : r2083_11
 # 2084|     r2084_1(glval<TernaryNonPodObj>)  = VariableAddress[z]                 : 
 # 2084|     r2084_2(glval<unknown>)           = FunctionAddress[operator=]         : 
 # 2084|     r2084_3(glval<bool>)              = VariableAddress[a]                 : 
@@ -14199,76 +14077,74 @@ ir.cpp:
 #-----|   True -> Block 11
 
 # 2083|   Block 8
-# 2083|     r2083_24(glval<TernaryNonPodObj>) = VariableAddress[#temp2083:13]     : 
-# 2083|     mu2083_25(TernaryNonPodObj)       = Uninitialized[#temp2083:13]       : &:r2083_24
-# 2083|     r2083_26(glval<unknown>)          = FunctionAddress[TernaryNonPodObj] : 
-# 2083|     v2083_27(void)                    = Call[TernaryNonPodObj]            : func:r2083_26, this:r2083_24
-# 2083|     mu2083_28(unknown)                = ^CallSideEffect                   : ~m?
-# 2083|     mu2083_29(TernaryNonPodObj)       = ^IndirectMayWriteSideEffect[-1]   : &:r2083_24
-# 2083|     r2083_30(TernaryNonPodObj)        = Load[#temp2083:13]                : &:r2083_24, ~m?
-# 2083|     r2083_31(glval<TernaryNonPodObj>) = VariableAddress[#temp2083:9]      : 
-# 2083|     mu2083_32(TernaryNonPodObj)       = Store[#temp2083:9]                : &:r2083_31, r2083_30
+# 2083|     r2083_23(glval<TernaryNonPodObj>) = VariableAddress[#temp2083:13]     : 
+# 2083|     mu2083_24(TernaryNonPodObj)       = Uninitialized[#temp2083:13]       : &:r2083_23
+# 2083|     r2083_25(glval<unknown>)          = FunctionAddress[TernaryNonPodObj] : 
+# 2083|     v2083_26(void)                    = Call[TernaryNonPodObj]            : func:r2083_25, this:r2083_23
+# 2083|     mu2083_27(unknown)                = ^CallSideEffect                   : ~m?
+# 2083|     mu2083_28(TernaryNonPodObj)       = ^IndirectMayWriteSideEffect[-1]   : &:r2083_23
+# 2083|     r2083_29(TernaryNonPodObj)        = Load[#temp2083:13]                : &:r2083_23, ~m?
+# 2083|     r2083_30(glval<TernaryNonPodObj>) = VariableAddress[#temp2083:9]      : 
+# 2083|     mu2083_31(TernaryNonPodObj)       = Store[#temp2083:9]                : &:r2083_30, r2083_29
 #-----|   Goto -> Block 7
 
 # 2083|   Block 9
-# 2083|     r2083_33(glval<TernaryNonPodObj>) = VariableAddress[#temp2083:34]     : 
-# 2083|     mu2083_34(TernaryNonPodObj)       = Uninitialized[#temp2083:34]       : &:r2083_33
-# 2083|     r2083_35(glval<unknown>)          = FunctionAddress[TernaryNonPodObj] : 
-# 2083|     v2083_36(void)                    = Call[TernaryNonPodObj]            : func:r2083_35, this:r2083_33
-# 2083|     mu2083_37(unknown)                = ^CallSideEffect                   : ~m?
-# 2083|     mu2083_38(TernaryNonPodObj)       = ^IndirectMayWriteSideEffect[-1]   : &:r2083_33
-# 2083|     r2083_39(TernaryNonPodObj)        = Load[#temp2083:34]                : &:r2083_33, ~m?
-# 2083|     r2083_40(glval<TernaryNonPodObj>) = VariableAddress[#temp2083:9]      : 
-# 2083|     mu2083_41(TernaryNonPodObj)       = Store[#temp2083:9]                : &:r2083_40, r2083_39
+# 2083|     r2083_32(glval<TernaryNonPodObj>) = VariableAddress[#temp2083:34]     : 
+# 2083|     mu2083_33(TernaryNonPodObj)       = Uninitialized[#temp2083:34]       : &:r2083_32
+# 2083|     r2083_34(glval<unknown>)          = FunctionAddress[TernaryNonPodObj] : 
+# 2083|     v2083_35(void)                    = Call[TernaryNonPodObj]            : func:r2083_34, this:r2083_32
+# 2083|     mu2083_36(unknown)                = ^CallSideEffect                   : ~m?
+# 2083|     mu2083_37(TernaryNonPodObj)       = ^IndirectMayWriteSideEffect[-1]   : &:r2083_32
+# 2083|     r2083_38(TernaryNonPodObj)        = Load[#temp2083:34]                : &:r2083_32, ~m?
+# 2083|     r2083_39(glval<TernaryNonPodObj>) = VariableAddress[#temp2083:9]      : 
+# 2083|     mu2083_40(TernaryNonPodObj)       = Store[#temp2083:9]                : &:r2083_39, r2083_38
 #-----|   Goto -> Block 7
 
 # 2084|   Block 10
 # 2084|     r2084_6(glval<unknown>)           = VariableAddress[#temp2084:10]      : 
 # 2084|     r2084_7(glval<TernaryNonPodObj>)  = Load[#temp2084:10]                 : &:r2084_6, ~m?
-# 2084|     r2084_8(glval<TernaryNonPodObj>)  = Convert                            : r2084_7
-# 2084|     r2084_9(TernaryNonPodObj &)       = CopyValue                          : r2084_8
-# 2084|     r2084_10(TernaryNonPodObj &)      = Call[operator=]                    : func:r2084_2, this:r2084_1, 0:r2084_9
-# 2084|     mu2084_11(unknown)                = ^CallSideEffect                    : ~m?
-# 2084|     v2084_12(void)                    = ^IndirectReadSideEffect[-1]        : &:r2084_1, ~m?
-# 2084|     v2084_13(void)                    = ^BufferReadSideEffect[0]           : &:r2084_9, ~m?
-# 2084|     mu2084_14(TernaryNonPodObj)       = ^IndirectMayWriteSideEffect[-1]    : &:r2084_1
-# 2084|     r2084_15(glval<TernaryNonPodObj>) = CopyValue                          : r2084_10
-# 2084|     r2084_16(glval<unknown>)          = FunctionAddress[operator=]         : 
-# 2084|     r2084_17(glval<TernaryNonPodObj>) = VariableAddress[#temp2084:23]      : 
-# 2084|     mu2084_18(TernaryNonPodObj)       = Uninitialized[#temp2084:23]        : &:r2084_17
-# 2084|     r2084_19(glval<unknown>)          = FunctionAddress[TernaryNonPodObj]  : 
-# 2084|     v2084_20(void)                    = Call[TernaryNonPodObj]             : func:r2084_19, this:r2084_17
-# 2084|     mu2084_21(unknown)                = ^CallSideEffect                    : ~m?
-# 2084|     mu2084_22(TernaryNonPodObj)       = ^IndirectMayWriteSideEffect[-1]    : &:r2084_17
-# 2084|     r2084_23(glval<TernaryNonPodObj>) = Convert                            : r2084_17
-# 2084|     r2084_24(TernaryNonPodObj &)      = CopyValue                          : r2084_23
-# 2084|     r2084_25(TernaryNonPodObj &)      = Call[operator=]                    : func:r2084_16, this:r2084_15, 0:r2084_24
-# 2084|     mu2084_26(unknown)                = ^CallSideEffect                    : ~m?
-# 2084|     v2084_27(void)                    = ^IndirectReadSideEffect[-1]        : &:r2084_15, ~m?
-# 2084|     v2084_28(void)                    = ^BufferReadSideEffect[0]           : &:r2084_24, ~m?
-# 2084|     mu2084_29(TernaryNonPodObj)       = ^IndirectMayWriteSideEffect[-1]    : &:r2084_15
-# 2084|     r2084_30(glval<TernaryNonPodObj>) = CopyValue                          : r2084_17
-# 2084|     r2084_31(glval<unknown>)          = FunctionAddress[~TernaryNonPodObj] : 
-# 2084|     v2084_32(void)                    = Call[~TernaryNonPodObj]            : func:r2084_31, this:r2084_30
-# 2084|     mu2084_33(unknown)                = ^CallSideEffect                    : ~m?
-# 2084|     v2084_34(void)                    = ^IndirectReadSideEffect[-1]        : &:r2084_30, ~m?
-# 2084|     mu2084_35(TernaryNonPodObj)       = ^IndirectMayWriteSideEffect[-1]    : &:r2084_30
-# 2084|     r2084_36(glval<TernaryNonPodObj>) = CopyValue                          : r2084_25
+# 2084|     r2084_8(TernaryNonPodObj &)       = CopyValue                          : r2084_7
+# 2084|     r2084_9(TernaryNonPodObj &)       = Call[operator=]                    : func:r2084_2, this:r2084_1, 0:r2084_8
+# 2084|     mu2084_10(unknown)                = ^CallSideEffect                    : ~m?
+# 2084|     v2084_11(void)                    = ^IndirectReadSideEffect[-1]        : &:r2084_1, ~m?
+# 2084|     v2084_12(void)                    = ^BufferReadSideEffect[0]           : &:r2084_8, ~m?
+# 2084|     mu2084_13(TernaryNonPodObj)       = ^IndirectMayWriteSideEffect[-1]    : &:r2084_1
+# 2084|     r2084_14(glval<TernaryNonPodObj>) = CopyValue                          : r2084_9
+# 2084|     r2084_15(glval<unknown>)          = FunctionAddress[operator=]         : 
+# 2084|     r2084_16(glval<TernaryNonPodObj>) = VariableAddress[#temp2084:23]      : 
+# 2084|     mu2084_17(TernaryNonPodObj)       = Uninitialized[#temp2084:23]        : &:r2084_16
+# 2084|     r2084_18(glval<unknown>)          = FunctionAddress[TernaryNonPodObj]  : 
+# 2084|     v2084_19(void)                    = Call[TernaryNonPodObj]             : func:r2084_18, this:r2084_16
+# 2084|     mu2084_20(unknown)                = ^CallSideEffect                    : ~m?
+# 2084|     mu2084_21(TernaryNonPodObj)       = ^IndirectMayWriteSideEffect[-1]    : &:r2084_16
+# 2084|     r2084_22(TernaryNonPodObj &)      = CopyValue                          : r2084_16
+# 2084|     r2084_23(TernaryNonPodObj &)      = Call[operator=]                    : func:r2084_15, this:r2084_14, 0:r2084_22
+# 2084|     mu2084_24(unknown)                = ^CallSideEffect                    : ~m?
+# 2084|     v2084_25(void)                    = ^IndirectReadSideEffect[-1]        : &:r2084_14, ~m?
+# 2084|     v2084_26(void)                    = ^BufferReadSideEffect[0]           : &:r2084_22, ~m?
+# 2084|     mu2084_27(TernaryNonPodObj)       = ^IndirectMayWriteSideEffect[-1]    : &:r2084_14
+# 2084|     r2084_28(glval<TernaryNonPodObj>) = CopyValue                          : r2084_16
+# 2084|     r2084_29(glval<unknown>)          = FunctionAddress[~TernaryNonPodObj] : 
+# 2084|     v2084_30(void)                    = Call[~TernaryNonPodObj]            : func:r2084_29, this:r2084_28
+# 2084|     mu2084_31(unknown)                = ^CallSideEffect                    : ~m?
+# 2084|     v2084_32(void)                    = ^IndirectReadSideEffect[-1]        : &:r2084_28, ~m?
+# 2084|     mu2084_33(TernaryNonPodObj)       = ^IndirectMayWriteSideEffect[-1]    : &:r2084_28
+# 2084|     r2084_34(glval<TernaryNonPodObj>) = CopyValue                          : r2084_23
 # 2085|     v2085_1(void)                     = NoOp                               : 
 # 2080|     v2080_12(void)                    = ReturnVoid                         : 
 # 2080|     v2080_13(void)                    = AliasedUse                         : ~m?
 # 2080|     v2080_14(void)                    = ExitFunction                       : 
 
 # 2084|   Block 11
-# 2084|     r2084_37(glval<TernaryNonPodObj>)  = VariableAddress[x]            : 
-# 2084|     r2084_38(glval<unknown>)           = VariableAddress[#temp2084:10] : 
-# 2084|     mu2084_39(glval<TernaryNonPodObj>) = Store[#temp2084:10]           : &:r2084_38, r2084_37
+# 2084|     r2084_35(glval<TernaryNonPodObj>)  = VariableAddress[x]            : 
+# 2084|     r2084_36(glval<unknown>)           = VariableAddress[#temp2084:10] : 
+# 2084|     mu2084_37(glval<TernaryNonPodObj>) = Store[#temp2084:10]           : &:r2084_36, r2084_35
 #-----|   Goto -> Block 10
 
 # 2084|   Block 12
-# 2084|     r2084_40(glval<TernaryNonPodObj>)  = VariableAddress[y]            : 
-# 2084|     r2084_41(glval<unknown>)           = VariableAddress[#temp2084:10] : 
-# 2084|     mu2084_42(glval<TernaryNonPodObj>) = Store[#temp2084:10]           : &:r2084_41, r2084_40
+# 2084|     r2084_38(glval<TernaryNonPodObj>)  = VariableAddress[y]            : 
+# 2084|     r2084_39(glval<unknown>)           = VariableAddress[#temp2084:10] : 
+# 2084|     mu2084_40(glval<TernaryNonPodObj>) = Store[#temp2084:10]           : &:r2084_39, r2084_38
 #-----|   Goto -> Block 10
 
 # 2089| unsigned int CommaTest(unsigned int)
@@ -14734,13 +14610,12 @@ ir.cpp:
 # 2174|     r2174_2(glval<unknown>) = FunctionAddress[strtod]        : 
 # 2174|     r2174_3(glval<char *>)  = VariableAddress[s]             : 
 # 2174|     r2174_4(char *)         = Load[s]                        : &:r2174_3, ~m?
-# 2174|     r2174_5(char *)         = Convert                        : r2174_4
-# 2174|     r2174_6(glval<char *>)  = VariableAddress[end]           : 
-# 2174|     r2174_7(char **)        = CopyValue                      : r2174_6
-# 2174|     r2174_8(double)         = Call[strtod]                   : func:r2174_2, 0:r2174_5, 1:r2174_7
-# 2174|     v2174_9(void)           = ^BufferReadSideEffect[0]       : &:r2174_5, ~m?
-# 2174|     mu2174_10(char *)       = ^IndirectMayWriteSideEffect[1] : &:r2174_7
-# 2174|     mu2174_11(double)       = Store[d]                       : &:r2174_1, r2174_8
+# 2174|     r2174_5(glval<char *>)  = VariableAddress[end]           : 
+# 2174|     r2174_6(char **)        = CopyValue                      : r2174_5
+# 2174|     r2174_7(double)         = Call[strtod]                   : func:r2174_2, 0:r2174_4, 1:r2174_6
+# 2174|     v2174_8(void)           = ^BufferReadSideEffect[0]       : &:r2174_4, ~m?
+# 2174|     mu2174_9(char *)        = ^IndirectMayWriteSideEffect[1] : &:r2174_6
+# 2174|     mu2174_10(double)       = Store[d]                       : &:r2174_1, r2174_7
 # 2175|     r2175_1(glval<char *>)  = VariableAddress[#return]       : 
 # 2175|     r2175_2(glval<char *>)  = VariableAddress[end]           : 
 # 2175|     r2175_3(char *)         = Load[end]                      : &:r2175_2, ~m?
@@ -15073,39 +14948,35 @@ ir.cpp:
 # 2216|     r2216_22(glval<vector<ClassWithDestructor> &>)                                                                                      = VariableAddress[(__range)]            : 
 # 2216|     r2216_23(vector<ClassWithDestructor> &)                                                                                             = Load[(__range)]                       : &:r2216_22, ~m?
 #-----|     r0_1(glval<vector<ClassWithDestructor>>)                                                                                            = CopyValue                             : r2216_23
-#-----|     r0_2(glval<vector<ClassWithDestructor>>)                                                                                            = Convert                               : r0_1
 # 2216|     r2216_24(glval<unknown>)                                                                                                            = FunctionAddress[begin]                : 
-# 2216|     r2216_25(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)        = Call[begin]                           : func:r2216_24, this:r0_2
-#-----|     v0_3(void)                                                                                                                          = ^IndirectReadSideEffect[-1]           : &:r0_2, ~m?
+# 2216|     r2216_25(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)        = Call[begin]                           : func:r2216_24, this:r0_1
+#-----|     v0_2(void)                                                                                                                          = ^IndirectReadSideEffect[-1]           : &:r0_1, ~m?
 # 2216|     mu2216_26(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)       = Store[(__begin)]                      : &:r2216_21, r2216_25
 # 2216|     r2216_27(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>) = VariableAddress[(__end)]              : 
 # 2216|     r2216_28(glval<vector<ClassWithDestructor> &>)                                                                                      = VariableAddress[(__range)]            : 
 # 2216|     r2216_29(vector<ClassWithDestructor> &)                                                                                             = Load[(__range)]                       : &:r2216_28, ~m?
-#-----|     r0_4(glval<vector<ClassWithDestructor>>)                                                                                            = CopyValue                             : r2216_29
-#-----|     r0_5(glval<vector<ClassWithDestructor>>)                                                                                            = Convert                               : r0_4
+#-----|     r0_3(glval<vector<ClassWithDestructor>>)                                                                                            = CopyValue                             : r2216_29
 # 2216|     r2216_30(glval<unknown>)                                                                                                            = FunctionAddress[end]                  : 
-# 2216|     r2216_31(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)        = Call[end]                             : func:r2216_30, this:r0_5
-#-----|     v0_6(void)                                                                                                                          = ^IndirectReadSideEffect[-1]           : &:r0_5, ~m?
+# 2216|     r2216_31(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)        = Call[end]                             : func:r2216_30, this:r0_3
+#-----|     v0_4(void)                                                                                                                          = ^IndirectReadSideEffect[-1]           : &:r0_3, ~m?
 # 2216|     mu2216_32(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)       = Store[(__end)]                        : &:r2216_27, r2216_31
 #-----|   Goto -> Block 10
 
 # 2216|   Block 10
 # 2216|     r2216_33(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>) = VariableAddress[(__begin)]      : 
-#-----|     r0_7(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>)     = Convert                         : r2216_33
 # 2216|     r2216_34(glval<unknown>)                                                                                                            = FunctionAddress[operator!=]     : 
-#-----|     r0_8(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>)     = VariableAddress[#temp0:0]       : 
-#-----|     mu0_9(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)           = Uninitialized[#temp0:0]         : &:r0_8
+#-----|     r0_5(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>)     = VariableAddress[#temp0:0]       : 
+#-----|     mu0_6(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)           = Uninitialized[#temp0:0]         : &:r0_5
 # 2216|     r2216_35(glval<unknown>)                                                                                                            = FunctionAddress[iterator]       : 
 # 2216|     r2216_36(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>) = VariableAddress[(__end)]        : 
-#-----|     r0_10(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>)    = Convert                         : r2216_36
-#-----|     r0_11(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &> &)         = CopyValue                       : r0_10
-# 2216|     v2216_37(void)                                                                                                                      = Call[iterator]                  : func:r2216_35, this:r0_8, 0:r0_11
+#-----|     r0_7(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &> &)          = CopyValue                       : r2216_36
+# 2216|     v2216_37(void)                                                                                                                      = Call[iterator]                  : func:r2216_35, this:r0_5, 0:r0_7
 # 2216|     mu2216_38(unknown)                                                                                                                  = ^CallSideEffect                 : ~m?
-#-----|     v0_12(void)                                                                                                                         = ^BufferReadSideEffect[0]        : &:r0_11, ~m?
-# 2216|     mu2216_39(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)       = ^IndirectMayWriteSideEffect[-1] : &:r0_8
-#-----|     r0_13(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)           = Load[#temp0:0]                  : &:r0_8, ~m?
-# 2216|     r2216_40(bool)                                                                                                                      = Call[operator!=]                : func:r2216_34, this:r0_7, 0:r0_13
-#-----|     v0_14(void)                                                                                                                         = ^IndirectReadSideEffect[-1]     : &:r0_7, ~m?
+#-----|     v0_8(void)                                                                                                                          = ^BufferReadSideEffect[0]        : &:r0_7, ~m?
+# 2216|     mu2216_39(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)       = ^IndirectMayWriteSideEffect[-1] : &:r0_5
+#-----|     r0_9(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)            = Load[#temp0:0]                  : &:r0_5, ~m?
+# 2216|     r2216_40(bool)                                                                                                                      = Call[operator!=]                : func:r2216_34, this:r2216_33, 0:r0_9
+#-----|     v0_10(void)                                                                                                                         = ^IndirectReadSideEffect[-1]     : &:r2216_33, ~m?
 # 2216|     v2216_41(void)                                                                                                                      = ConditionalBranch               : r2216_40
 #-----|   False -> Block 12
 #-----|   True -> Block 11
@@ -15113,10 +14984,9 @@ ir.cpp:
 # 2216|   Block 11
 # 2216|     r2216_42(glval<ClassWithDestructor>)                                                                                                = VariableAddress[y]                    : 
 # 2216|     r2216_43(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>) = VariableAddress[(__begin)]            : 
-#-----|     r0_15(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>)    = Convert                               : r2216_43
 # 2216|     r2216_44(glval<unknown>)                                                                                                            = FunctionAddress[operator*]            : 
-# 2216|     r2216_45(ClassWithDestructor &)                                                                                                     = Call[operator*]                       : func:r2216_44, this:r0_15
-#-----|     v0_16(void)                                                                                                                         = ^IndirectReadSideEffect[-1]           : &:r0_15, ~m?
+# 2216|     r2216_45(ClassWithDestructor &)                                                                                                     = Call[operator*]                       : func:r2216_44, this:r2216_43
+#-----|     v0_11(void)                                                                                                                         = ^IndirectReadSideEffect[-1]           : &:r2216_43, ~m?
 # 2216|     r2216_46(ClassWithDestructor)                                                                                                       = Load[?]                               : &:r2216_45, ~m?
 # 2216|     mu2216_47(ClassWithDestructor)                                                                                                      = Store[y]                              : &:r2216_42, r2216_46
 # 2217|     r2217_1(glval<ClassWithDestructor>)                                                                                                 = VariableAddress[y]                    : 
@@ -15169,40 +15039,36 @@ ir.cpp:
 # 2219|     r2219_21(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>) = VariableAddress[(__begin)]            : 
 # 2219|     r2219_22(glval<vector<ClassWithDestructor> &>)                                                                                      = VariableAddress[(__range)]            : 
 # 2219|     r2219_23(vector<ClassWithDestructor> &)                                                                                             = Load[(__range)]                       : &:r2219_22, ~m?
-#-----|     r0_17(glval<vector<ClassWithDestructor>>)                                                                                           = CopyValue                             : r2219_23
-#-----|     r0_18(glval<vector<ClassWithDestructor>>)                                                                                           = Convert                               : r0_17
+#-----|     r0_12(glval<vector<ClassWithDestructor>>)                                                                                           = CopyValue                             : r2219_23
 # 2219|     r2219_24(glval<unknown>)                                                                                                            = FunctionAddress[begin]                : 
-# 2219|     r2219_25(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)        = Call[begin]                           : func:r2219_24, this:r0_18
-#-----|     v0_19(void)                                                                                                                         = ^IndirectReadSideEffect[-1]           : &:r0_18, ~m?
+# 2219|     r2219_25(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)        = Call[begin]                           : func:r2219_24, this:r0_12
+#-----|     v0_13(void)                                                                                                                         = ^IndirectReadSideEffect[-1]           : &:r0_12, ~m?
 # 2219|     mu2219_26(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)       = Store[(__begin)]                      : &:r2219_21, r2219_25
 # 2219|     r2219_27(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>) = VariableAddress[(__end)]              : 
 # 2219|     r2219_28(glval<vector<ClassWithDestructor> &>)                                                                                      = VariableAddress[(__range)]            : 
 # 2219|     r2219_29(vector<ClassWithDestructor> &)                                                                                             = Load[(__range)]                       : &:r2219_28, ~m?
-#-----|     r0_20(glval<vector<ClassWithDestructor>>)                                                                                           = CopyValue                             : r2219_29
-#-----|     r0_21(glval<vector<ClassWithDestructor>>)                                                                                           = Convert                               : r0_20
+#-----|     r0_14(glval<vector<ClassWithDestructor>>)                                                                                           = CopyValue                             : r2219_29
 # 2219|     r2219_30(glval<unknown>)                                                                                                            = FunctionAddress[end]                  : 
-# 2219|     r2219_31(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)        = Call[end]                             : func:r2219_30, this:r0_21
-#-----|     v0_22(void)                                                                                                                         = ^IndirectReadSideEffect[-1]           : &:r0_21, ~m?
+# 2219|     r2219_31(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)        = Call[end]                             : func:r2219_30, this:r0_14
+#-----|     v0_15(void)                                                                                                                         = ^IndirectReadSideEffect[-1]           : &:r0_14, ~m?
 # 2219|     mu2219_32(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)       = Store[(__end)]                        : &:r2219_27, r2219_31
 #-----|   Goto -> Block 13
 
 # 2219|   Block 13
 # 2219|     r2219_33(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>) = VariableAddress[(__begin)]      : 
-#-----|     r0_23(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>)    = Convert                         : r2219_33
 # 2219|     r2219_34(glval<unknown>)                                                                                                            = FunctionAddress[operator!=]     : 
-#-----|     r0_24(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>)    = VariableAddress[#temp0:0]       : 
-#-----|     mu0_25(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)          = Uninitialized[#temp0:0]         : &:r0_24
+#-----|     r0_16(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>)    = VariableAddress[#temp0:0]       : 
+#-----|     mu0_17(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)          = Uninitialized[#temp0:0]         : &:r0_16
 # 2219|     r2219_35(glval<unknown>)                                                                                                            = FunctionAddress[iterator]       : 
 # 2219|     r2219_36(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>) = VariableAddress[(__end)]        : 
-#-----|     r0_26(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>)    = Convert                         : r2219_36
-#-----|     r0_27(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &> &)         = CopyValue                       : r0_26
-# 2219|     v2219_37(void)                                                                                                                      = Call[iterator]                  : func:r2219_35, this:r0_24, 0:r0_27
+#-----|     r0_18(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &> &)         = CopyValue                       : r2219_36
+# 2219|     v2219_37(void)                                                                                                                      = Call[iterator]                  : func:r2219_35, this:r0_16, 0:r0_18
 # 2219|     mu2219_38(unknown)                                                                                                                  = ^CallSideEffect                 : ~m?
-#-----|     v0_28(void)                                                                                                                         = ^BufferReadSideEffect[0]        : &:r0_27, ~m?
-# 2219|     mu2219_39(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)       = ^IndirectMayWriteSideEffect[-1] : &:r0_24
-#-----|     r0_29(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)           = Load[#temp0:0]                  : &:r0_24, ~m?
-# 2219|     r2219_40(bool)                                                                                                                      = Call[operator!=]                : func:r2219_34, this:r0_23, 0:r0_29
-#-----|     v0_30(void)                                                                                                                         = ^IndirectReadSideEffect[-1]     : &:r0_23, ~m?
+#-----|     v0_19(void)                                                                                                                         = ^BufferReadSideEffect[0]        : &:r0_18, ~m?
+# 2219|     mu2219_39(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)       = ^IndirectMayWriteSideEffect[-1] : &:r0_16
+#-----|     r0_20(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)           = Load[#temp0:0]                  : &:r0_16, ~m?
+# 2219|     r2219_40(bool)                                                                                                                      = Call[operator!=]                : func:r2219_34, this:r2219_33, 0:r0_20
+#-----|     v0_21(void)                                                                                                                         = ^IndirectReadSideEffect[-1]     : &:r2219_33, ~m?
 # 2219|     v2219_41(void)                                                                                                                      = ConditionalBranch               : r2219_40
 #-----|   False -> Block 17
 #-----|   True -> Block 15
@@ -15225,10 +15091,9 @@ ir.cpp:
 # 2219|   Block 15
 # 2219|     r2219_54(glval<ClassWithDestructor>)                                                                                                = VariableAddress[y]              : 
 # 2219|     r2219_55(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>) = VariableAddress[(__begin)]      : 
-#-----|     r0_31(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>)    = Convert                         : r2219_55
 # 2219|     r2219_56(glval<unknown>)                                                                                                            = FunctionAddress[operator*]      : 
-# 2219|     r2219_57(ClassWithDestructor &)                                                                                                     = Call[operator*]                 : func:r2219_56, this:r0_31
-#-----|     v0_32(void)                                                                                                                         = ^IndirectReadSideEffect[-1]     : &:r0_31, ~m?
+# 2219|     r2219_57(ClassWithDestructor &)                                                                                                     = Call[operator*]                 : func:r2219_56, this:r2219_55
+#-----|     v0_22(void)                                                                                                                         = ^IndirectReadSideEffect[-1]     : &:r2219_55, ~m?
 # 2219|     r2219_58(ClassWithDestructor)                                                                                                       = Load[?]                         : &:r2219_57, ~m?
 # 2219|     mu2219_59(ClassWithDestructor)                                                                                                      = Store[y]                        : &:r2219_54, r2219_58
 # 2220|     r2220_1(glval<ClassWithDestructor>)                                                                                                 = VariableAddress[y]              : 
@@ -15291,40 +15156,36 @@ ir.cpp:
 # 2225|     r2225_11(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>) = VariableAddress[(__begin)]       : 
 # 2225|     r2225_12(glval<vector<int> &>)                                                      = VariableAddress[(__range)]       : 
 # 2225|     r2225_13(vector<int> &)                                                             = Load[(__range)]                  : &:r2225_12, ~m?
-#-----|     r0_33(glval<vector<int>>)                                                           = CopyValue                        : r2225_13
-#-----|     r0_34(glval<vector<int>>)                                                           = Convert                          : r0_33
+#-----|     r0_23(glval<vector<int>>)                                                           = CopyValue                        : r2225_13
 # 2225|     r2225_14(glval<unknown>)                                                            = FunctionAddress[begin]           : 
-# 2225|     r2225_15(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)        = Call[begin]                      : func:r2225_14, this:r0_34
-#-----|     v0_35(void)                                                                         = ^IndirectReadSideEffect[-1]      : &:r0_34, ~m?
+# 2225|     r2225_15(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)        = Call[begin]                      : func:r2225_14, this:r0_23
+#-----|     v0_24(void)                                                                         = ^IndirectReadSideEffect[-1]      : &:r0_23, ~m?
 # 2225|     mu2225_16(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)       = Store[(__begin)]                 : &:r2225_11, r2225_15
 # 2225|     r2225_17(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>) = VariableAddress[(__end)]         : 
 # 2225|     r2225_18(glval<vector<int> &>)                                                      = VariableAddress[(__range)]       : 
 # 2225|     r2225_19(vector<int> &)                                                             = Load[(__range)]                  : &:r2225_18, ~m?
-#-----|     r0_36(glval<vector<int>>)                                                           = CopyValue                        : r2225_19
-#-----|     r0_37(glval<vector<int>>)                                                           = Convert                          : r0_36
+#-----|     r0_25(glval<vector<int>>)                                                           = CopyValue                        : r2225_19
 # 2225|     r2225_20(glval<unknown>)                                                            = FunctionAddress[end]             : 
-# 2225|     r2225_21(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)        = Call[end]                        : func:r2225_20, this:r0_37
-#-----|     v0_38(void)                                                                         = ^IndirectReadSideEffect[-1]      : &:r0_37, ~m?
+# 2225|     r2225_21(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)        = Call[end]                        : func:r2225_20, this:r0_25
+#-----|     v0_26(void)                                                                         = ^IndirectReadSideEffect[-1]      : &:r0_25, ~m?
 # 2225|     mu2225_22(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)       = Store[(__end)]                   : &:r2225_17, r2225_21
 #-----|   Goto -> Block 18
 
 # 2225|   Block 18
 # 2225|     r2225_23(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>) = VariableAddress[(__begin)]      : 
-#-----|     r0_39(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>)    = Convert                         : r2225_23
 # 2225|     r2225_24(glval<unknown>)                                                            = FunctionAddress[operator!=]     : 
-#-----|     r0_40(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>)    = VariableAddress[#temp0:0]       : 
-#-----|     mu0_41(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)          = Uninitialized[#temp0:0]         : &:r0_40
+#-----|     r0_27(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>)    = VariableAddress[#temp0:0]       : 
+#-----|     mu0_28(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)          = Uninitialized[#temp0:0]         : &:r0_27
 # 2225|     r2225_25(glval<unknown>)                                                            = FunctionAddress[iterator]       : 
 # 2225|     r2225_26(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>) = VariableAddress[(__end)]        : 
-#-----|     r0_42(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>)    = Convert                         : r2225_26
-#-----|     r0_43(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &> &)         = CopyValue                       : r0_42
-# 2225|     v2225_27(void)                                                                      = Call[iterator]                  : func:r2225_25, this:r0_40, 0:r0_43
+#-----|     r0_29(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &> &)         = CopyValue                       : r2225_26
+# 2225|     v2225_27(void)                                                                      = Call[iterator]                  : func:r2225_25, this:r0_27, 0:r0_29
 # 2225|     mu2225_28(unknown)                                                                  = ^CallSideEffect                 : ~m?
-#-----|     v0_44(void)                                                                         = ^BufferReadSideEffect[0]        : &:r0_43, ~m?
-# 2225|     mu2225_29(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)       = ^IndirectMayWriteSideEffect[-1] : &:r0_40
-#-----|     r0_45(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)           = Load[#temp0:0]                  : &:r0_40, ~m?
-# 2225|     r2225_30(bool)                                                                      = Call[operator!=]                : func:r2225_24, this:r0_39, 0:r0_45
-#-----|     v0_46(void)                                                                         = ^IndirectReadSideEffect[-1]     : &:r0_39, ~m?
+#-----|     v0_30(void)                                                                         = ^BufferReadSideEffect[0]        : &:r0_29, ~m?
+# 2225|     mu2225_29(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)       = ^IndirectMayWriteSideEffect[-1] : &:r0_27
+#-----|     r0_31(iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>)           = Load[#temp0:0]                  : &:r0_27, ~m?
+# 2225|     r2225_30(bool)                                                                      = Call[operator!=]                : func:r2225_24, this:r2225_23, 0:r0_31
+#-----|     v0_32(void)                                                                         = ^IndirectReadSideEffect[-1]     : &:r2225_23, ~m?
 # 2225|     v2225_31(void)                                                                      = ConditionalBranch               : r2225_30
 #-----|   False -> Block 22
 #-----|   True -> Block 20
@@ -15341,10 +15202,9 @@ ir.cpp:
 # 2225|   Block 20
 # 2225|     r2225_38(glval<int>)                                                                = VariableAddress[y]          : 
 # 2225|     r2225_39(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>) = VariableAddress[(__begin)]  : 
-#-----|     r0_47(glval<iterator<random_access_iterator_tag, int, ptrdiff_t, int *, int &>>)    = Convert                     : r2225_39
 # 2225|     r2225_40(glval<unknown>)                                                            = FunctionAddress[operator*]  : 
-# 2225|     r2225_41(int &)                                                                     = Call[operator*]             : func:r2225_40, this:r0_47
-#-----|     v0_48(void)                                                                         = ^IndirectReadSideEffect[-1] : &:r0_47, ~m?
+# 2225|     r2225_41(int &)                                                                     = Call[operator*]             : func:r2225_40, this:r2225_39
+#-----|     v0_33(void)                                                                         = ^IndirectReadSideEffect[-1] : &:r2225_39, ~m?
 # 2225|     r2225_42(int)                                                                       = Load[?]                     : &:r2225_41, ~m?
 # 2225|     mu2225_43(int)                                                                      = Store[y]                    : &:r2225_38, r2225_42
 # 2226|     r2226_1(glval<int>)                                                                 = VariableAddress[y]          : 
@@ -15399,40 +15259,36 @@ ir.cpp:
 # 2230|     r2230_21(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>) = VariableAddress[(__begin)]            : 
 # 2230|     r2230_22(glval<vector<ClassWithDestructor> &>)                                                                                      = VariableAddress[(__range)]            : 
 # 2230|     r2230_23(vector<ClassWithDestructor> &)                                                                                             = Load[(__range)]                       : &:r2230_22, ~m?
-#-----|     r0_49(glval<vector<ClassWithDestructor>>)                                                                                           = CopyValue                             : r2230_23
-#-----|     r0_50(glval<vector<ClassWithDestructor>>)                                                                                           = Convert                               : r0_49
+#-----|     r0_34(glval<vector<ClassWithDestructor>>)                                                                                           = CopyValue                             : r2230_23
 # 2230|     r2230_24(glval<unknown>)                                                                                                            = FunctionAddress[begin]                : 
-# 2230|     r2230_25(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)        = Call[begin]                           : func:r2230_24, this:r0_50
-#-----|     v0_51(void)                                                                                                                         = ^IndirectReadSideEffect[-1]           : &:r0_50, ~m?
+# 2230|     r2230_25(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)        = Call[begin]                           : func:r2230_24, this:r0_34
+#-----|     v0_35(void)                                                                                                                         = ^IndirectReadSideEffect[-1]           : &:r0_34, ~m?
 # 2230|     mu2230_26(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)       = Store[(__begin)]                      : &:r2230_21, r2230_25
 # 2230|     r2230_27(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>) = VariableAddress[(__end)]              : 
 # 2230|     r2230_28(glval<vector<ClassWithDestructor> &>)                                                                                      = VariableAddress[(__range)]            : 
 # 2230|     r2230_29(vector<ClassWithDestructor> &)                                                                                             = Load[(__range)]                       : &:r2230_28, ~m?
-#-----|     r0_52(glval<vector<ClassWithDestructor>>)                                                                                           = CopyValue                             : r2230_29
-#-----|     r0_53(glval<vector<ClassWithDestructor>>)                                                                                           = Convert                               : r0_52
+#-----|     r0_36(glval<vector<ClassWithDestructor>>)                                                                                           = CopyValue                             : r2230_29
 # 2230|     r2230_30(glval<unknown>)                                                                                                            = FunctionAddress[end]                  : 
-# 2230|     r2230_31(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)        = Call[end]                             : func:r2230_30, this:r0_53
-#-----|     v0_54(void)                                                                                                                         = ^IndirectReadSideEffect[-1]           : &:r0_53, ~m?
+# 2230|     r2230_31(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)        = Call[end]                             : func:r2230_30, this:r0_36
+#-----|     v0_37(void)                                                                                                                         = ^IndirectReadSideEffect[-1]           : &:r0_36, ~m?
 # 2230|     mu2230_32(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)       = Store[(__end)]                        : &:r2230_27, r2230_31
 #-----|   Goto -> Block 23
 
 # 2230|   Block 23
 # 2230|     r2230_33(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>) = VariableAddress[(__begin)]      : 
-#-----|     r0_55(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>)    = Convert                         : r2230_33
 # 2230|     r2230_34(glval<unknown>)                                                                                                            = FunctionAddress[operator!=]     : 
-#-----|     r0_56(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>)    = VariableAddress[#temp0:0]       : 
-#-----|     mu0_57(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)          = Uninitialized[#temp0:0]         : &:r0_56
+#-----|     r0_38(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>)    = VariableAddress[#temp0:0]       : 
+#-----|     mu0_39(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)          = Uninitialized[#temp0:0]         : &:r0_38
 # 2230|     r2230_35(glval<unknown>)                                                                                                            = FunctionAddress[iterator]       : 
 # 2230|     r2230_36(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>) = VariableAddress[(__end)]        : 
-#-----|     r0_58(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>)    = Convert                         : r2230_36
-#-----|     r0_59(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &> &)         = CopyValue                       : r0_58
-# 2230|     v2230_37(void)                                                                                                                      = Call[iterator]                  : func:r2230_35, this:r0_56, 0:r0_59
+#-----|     r0_40(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &> &)         = CopyValue                       : r2230_36
+# 2230|     v2230_37(void)                                                                                                                      = Call[iterator]                  : func:r2230_35, this:r0_38, 0:r0_40
 # 2230|     mu2230_38(unknown)                                                                                                                  = ^CallSideEffect                 : ~m?
-#-----|     v0_60(void)                                                                                                                         = ^BufferReadSideEffect[0]        : &:r0_59, ~m?
-# 2230|     mu2230_39(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)       = ^IndirectMayWriteSideEffect[-1] : &:r0_56
-#-----|     r0_61(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)           = Load[#temp0:0]                  : &:r0_56, ~m?
-# 2230|     r2230_40(bool)                                                                                                                      = Call[operator!=]                : func:r2230_34, this:r0_55, 0:r0_61
-#-----|     v0_62(void)                                                                                                                         = ^IndirectReadSideEffect[-1]     : &:r0_55, ~m?
+#-----|     v0_41(void)                                                                                                                         = ^BufferReadSideEffect[0]        : &:r0_40, ~m?
+# 2230|     mu2230_39(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)       = ^IndirectMayWriteSideEffect[-1] : &:r0_38
+#-----|     r0_42(iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>)           = Load[#temp0:0]                  : &:r0_38, ~m?
+# 2230|     r2230_40(bool)                                                                                                                      = Call[operator!=]                : func:r2230_34, this:r2230_33, 0:r0_42
+#-----|     v0_43(void)                                                                                                                         = ^IndirectReadSideEffect[-1]     : &:r2230_33, ~m?
 # 2230|     v2230_41(void)                                                                                                                      = ConditionalBranch               : r2230_40
 #-----|   False -> Block 25
 #-----|   True -> Block 24
@@ -15440,10 +15296,9 @@ ir.cpp:
 # 2230|   Block 24
 # 2230|     r2230_42(glval<ClassWithDestructor>)                                                                                                = VariableAddress[y]                    : 
 # 2230|     r2230_43(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>) = VariableAddress[(__begin)]            : 
-#-----|     r0_63(glval<iterator<random_access_iterator_tag, ClassWithDestructor, ptrdiff_t, ClassWithDestructor *, ClassWithDestructor &>>)    = Convert                               : r2230_43
 # 2230|     r2230_44(glval<unknown>)                                                                                                            = FunctionAddress[operator*]            : 
-# 2230|     r2230_45(ClassWithDestructor &)                                                                                                     = Call[operator*]                       : func:r2230_44, this:r0_63
-#-----|     v0_64(void)                                                                                                                         = ^IndirectReadSideEffect[-1]           : &:r0_63, ~m?
+# 2230|     r2230_45(ClassWithDestructor &)                                                                                                     = Call[operator*]                       : func:r2230_44, this:r2230_43
+#-----|     v0_44(void)                                                                                                                         = ^IndirectReadSideEffect[-1]           : &:r2230_43, ~m?
 # 2230|     r2230_46(ClassWithDestructor)                                                                                                       = Load[?]                               : &:r2230_45, ~m?
 # 2230|     mu2230_47(ClassWithDestructor)                                                                                                      = Store[y]                              : &:r2230_42, r2230_46
 # 2231|     r2231_1(glval<ClassWithDestructor>)                                                                                                 = VariableAddress[z1]                   : 
@@ -16061,39 +15916,35 @@ ir.cpp:
 # 2308|     r2308_26(glval<vector<String> &&>)                                                           = VariableAddress[(__range)]       : 
 # 2308|     r2308_27(vector<String> &&)                                                                  = Load[(__range)]                  : &:r2308_26, ~m?
 #-----|     r0_1(glval<vector<String>>)                                                                  = CopyValue                        : r2308_27
-#-----|     r0_2(glval<vector<String>>)                                                                  = Convert                          : r0_1
 # 2308|     r2308_28(glval<unknown>)                                                                     = FunctionAddress[begin]           : 
-# 2308|     r2308_29(iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>)        = Call[begin]                      : func:r2308_28, this:r0_2
-#-----|     v0_3(void)                                                                                   = ^IndirectReadSideEffect[-1]      : &:r0_2, ~m?
+# 2308|     r2308_29(iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>)        = Call[begin]                      : func:r2308_28, this:r0_1
+#-----|     v0_2(void)                                                                                   = ^IndirectReadSideEffect[-1]      : &:r0_1, ~m?
 # 2308|     mu2308_30(iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>)       = Store[(__begin)]                 : &:r2308_25, r2308_29
 # 2308|     r2308_31(glval<iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>>) = VariableAddress[(__end)]         : 
 # 2308|     r2308_32(glval<vector<String> &&>)                                                           = VariableAddress[(__range)]       : 
 # 2308|     r2308_33(vector<String> &&)                                                                  = Load[(__range)]                  : &:r2308_32, ~m?
-#-----|     r0_4(glval<vector<String>>)                                                                  = CopyValue                        : r2308_33
-#-----|     r0_5(glval<vector<String>>)                                                                  = Convert                          : r0_4
+#-----|     r0_3(glval<vector<String>>)                                                                  = CopyValue                        : r2308_33
 # 2308|     r2308_34(glval<unknown>)                                                                     = FunctionAddress[end]             : 
-# 2308|     r2308_35(iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>)        = Call[end]                        : func:r2308_34, this:r0_5
-#-----|     v0_6(void)                                                                                   = ^IndirectReadSideEffect[-1]      : &:r0_5, ~m?
+# 2308|     r2308_35(iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>)        = Call[end]                        : func:r2308_34, this:r0_3
+#-----|     v0_4(void)                                                                                   = ^IndirectReadSideEffect[-1]      : &:r0_3, ~m?
 # 2308|     mu2308_36(iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>)       = Store[(__end)]                   : &:r2308_31, r2308_35
 #-----|   Goto -> Block 4
 
 # 2308|   Block 4
 # 2308|     r2308_37(glval<iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>>) = VariableAddress[(__begin)]      : 
-#-----|     r0_7(glval<iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>>)     = Convert                         : r2308_37
 # 2308|     r2308_38(glval<unknown>)                                                                     = FunctionAddress[operator!=]     : 
-#-----|     r0_8(glval<iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>>)     = VariableAddress[#temp0:0]       : 
-#-----|     mu0_9(iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>)           = Uninitialized[#temp0:0]         : &:r0_8
+#-----|     r0_5(glval<iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>>)     = VariableAddress[#temp0:0]       : 
+#-----|     mu0_6(iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>)           = Uninitialized[#temp0:0]         : &:r0_5
 # 2308|     r2308_39(glval<unknown>)                                                                     = FunctionAddress[iterator]       : 
 # 2308|     r2308_40(glval<iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>>) = VariableAddress[(__end)]        : 
-#-----|     r0_10(glval<iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>>)    = Convert                         : r2308_40
-#-----|     r0_11(iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &> &)         = CopyValue                       : r0_10
-# 2308|     v2308_41(void)                                                                               = Call[iterator]                  : func:r2308_39, this:r0_8, 0:r0_11
+#-----|     r0_7(iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &> &)          = CopyValue                       : r2308_40
+# 2308|     v2308_41(void)                                                                               = Call[iterator]                  : func:r2308_39, this:r0_5, 0:r0_7
 # 2308|     mu2308_42(unknown)                                                                           = ^CallSideEffect                 : ~m?
-#-----|     v0_12(void)                                                                                  = ^BufferReadSideEffect[0]        : &:r0_11, ~m?
-# 2308|     mu2308_43(iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>)       = ^IndirectMayWriteSideEffect[-1] : &:r0_8
-#-----|     r0_13(iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>)           = Load[#temp0:0]                  : &:r0_8, ~m?
-# 2308|     r2308_44(bool)                                                                               = Call[operator!=]                : func:r2308_38, this:r0_7, 0:r0_13
-#-----|     v0_14(void)                                                                                  = ^IndirectReadSideEffect[-1]     : &:r0_7, ~m?
+#-----|     v0_8(void)                                                                                   = ^BufferReadSideEffect[0]        : &:r0_7, ~m?
+# 2308|     mu2308_43(iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>)       = ^IndirectMayWriteSideEffect[-1] : &:r0_5
+#-----|     r0_9(iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>)            = Load[#temp0:0]                  : &:r0_5, ~m?
+# 2308|     r2308_44(bool)                                                                               = Call[operator!=]                : func:r2308_38, this:r2308_37, 0:r0_9
+#-----|     v0_10(void)                                                                                  = ^IndirectReadSideEffect[-1]     : &:r2308_37, ~m?
 # 2308|     v2308_45(void)                                                                               = ConditionalBranch               : r2308_44
 #-----|   False -> Block 6
 #-----|   True -> Block 5
@@ -16103,17 +15954,15 @@ ir.cpp:
 # 2308|     mu2308_47(String)                                                                            = Uninitialized[s]                : &:r2308_46
 # 2308|     r2308_48(glval<unknown>)                                                                     = FunctionAddress[String]         : 
 # 2308|     r2308_49(glval<iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>>) = VariableAddress[(__begin)]      : 
-#-----|     r0_15(glval<iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>>)    = Convert                         : r2308_49
 # 2308|     r2308_50(glval<unknown>)                                                                     = FunctionAddress[operator*]      : 
-# 2308|     r2308_51(String &)                                                                           = Call[operator*]                 : func:r2308_50, this:r0_15
-#-----|     v0_16(void)                                                                                  = ^IndirectReadSideEffect[-1]     : &:r0_15, ~m?
+# 2308|     r2308_51(String &)                                                                           = Call[operator*]                 : func:r2308_50, this:r2308_49
+#-----|     v0_11(void)                                                                                  = ^IndirectReadSideEffect[-1]     : &:r2308_49, ~m?
 # 2308|     r2308_52(glval<String>)                                                                      = CopyValue                       : r2308_51
-# 2308|     r2308_53(glval<String>)                                                                      = Convert                         : r2308_52
-# 2308|     r2308_54(String &)                                                                           = CopyValue                       : r2308_53
-# 2308|     v2308_55(void)                                                                               = Call[String]                    : func:r2308_48, this:r2308_46, 0:r2308_54
-# 2308|     mu2308_56(unknown)                                                                           = ^CallSideEffect                 : ~m?
-# 2308|     v2308_57(void)                                                                               = ^BufferReadSideEffect[0]        : &:r2308_54, ~m?
-# 2308|     mu2308_58(String)                                                                            = ^IndirectMayWriteSideEffect[-1] : &:r2308_46
+# 2308|     r2308_53(String &)                                                                           = CopyValue                       : r2308_52
+# 2308|     v2308_54(void)                                                                               = Call[String]                    : func:r2308_48, this:r2308_46, 0:r2308_53
+# 2308|     mu2308_55(unknown)                                                                           = ^CallSideEffect                 : ~m?
+# 2308|     v2308_56(void)                                                                               = ^BufferReadSideEffect[0]        : &:r2308_53, ~m?
+# 2308|     mu2308_57(String)                                                                            = ^IndirectMayWriteSideEffect[-1] : &:r2308_46
 # 2309|     r2309_1(glval<String>)                                                                       = VariableAddress[s2]             : 
 # 2309|     mu2309_2(String)                                                                             = Uninitialized[s2]               : &:r2309_1
 # 2309|     r2309_3(glval<unknown>)                                                                      = FunctionAddress[String]         : 
@@ -16126,26 +15975,26 @@ ir.cpp:
 # 2310|     mu2310_4(unknown)                                                                            = ^CallSideEffect                 : ~m?
 # 2310|     v2310_5(void)                                                                                = ^IndirectReadSideEffect[-1]     : &:r2310_1, ~m?
 # 2310|     mu2310_6(String)                                                                             = ^IndirectMayWriteSideEffect[-1] : &:r2310_1
-# 2308|     r2308_59(glval<iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>>) = VariableAddress[(__begin)]      : 
-# 2308|     r2308_60(glval<unknown>)                                                                     = FunctionAddress[operator++]     : 
-# 2308|     r2308_61(iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &> &)      = Call[operator++]                : func:r2308_60, this:r2308_59
-# 2308|     v2308_62(void)                                                                               = ^IndirectReadSideEffect[-1]     : &:r2308_59, ~m?
-# 2308|     mu2308_63(iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>)       = ^IndirectMayWriteSideEffect[-1] : &:r2308_59
-# 2308|     r2308_64(glval<String>)                                                                      = VariableAddress[s]              : 
-# 2308|     r2308_65(glval<unknown>)                                                                     = FunctionAddress[~String]        : 
-# 2308|     v2308_66(void)                                                                               = Call[~String]                   : func:r2308_65, this:r2308_64
-# 2308|     mu2308_67(unknown)                                                                           = ^CallSideEffect                 : ~m?
-# 2308|     v2308_68(void)                                                                               = ^IndirectReadSideEffect[-1]     : &:r2308_64, ~m?
-# 2308|     mu2308_69(String)                                                                            = ^IndirectMayWriteSideEffect[-1] : &:r2308_64
-# 2308|     r2308_70(glval<iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>>) = CopyValue                       : r2308_61
+# 2308|     r2308_58(glval<iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>>) = VariableAddress[(__begin)]      : 
+# 2308|     r2308_59(glval<unknown>)                                                                     = FunctionAddress[operator++]     : 
+# 2308|     r2308_60(iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &> &)      = Call[operator++]                : func:r2308_59, this:r2308_58
+# 2308|     v2308_61(void)                                                                               = ^IndirectReadSideEffect[-1]     : &:r2308_58, ~m?
+# 2308|     mu2308_62(iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>)       = ^IndirectMayWriteSideEffect[-1] : &:r2308_58
+# 2308|     r2308_63(glval<String>)                                                                      = VariableAddress[s]              : 
+# 2308|     r2308_64(glval<unknown>)                                                                     = FunctionAddress[~String]        : 
+# 2308|     v2308_65(void)                                                                               = Call[~String]                   : func:r2308_64, this:r2308_63
+# 2308|     mu2308_66(unknown)                                                                           = ^CallSideEffect                 : ~m?
+# 2308|     v2308_67(void)                                                                               = ^IndirectReadSideEffect[-1]     : &:r2308_63, ~m?
+# 2308|     mu2308_68(String)                                                                            = ^IndirectMayWriteSideEffect[-1] : &:r2308_63
+# 2308|     r2308_69(glval<iterator<random_access_iterator_tag, String, ptrdiff_t, String *, String &>>) = CopyValue                       : r2308_60
 #-----|   Goto (back edge) -> Block 4
 
 # 2308|   Block 6
-# 2308|     r2308_71(glval<vector<String>>) = CopyValue                        : r2308_2
-# 2308|     r2308_72(glval<unknown>)        = FunctionAddress[~vector]         : 
-# 2308|     v2308_73(void)                  = Call[~vector]                    : func:r2308_72, this:r2308_71
-# 2308|     v2308_74(void)                  = ^IndirectReadSideEffect[-1]      : &:r2308_71, ~m?
-# 2308|     mu2308_75(vector<String>)       = ^IndirectMustWriteSideEffect[-1] : &:r2308_71
+# 2308|     r2308_70(glval<vector<String>>) = CopyValue                        : r2308_2
+# 2308|     r2308_71(glval<unknown>)        = FunctionAddress[~vector]         : 
+# 2308|     v2308_72(void)                  = Call[~vector]                    : func:r2308_71, this:r2308_70
+# 2308|     v2308_73(void)                  = ^IndirectReadSideEffect[-1]      : &:r2308_70, ~m?
+# 2308|     mu2308_74(vector<String>)       = ^IndirectMustWriteSideEffect[-1] : &:r2308_70
 # 2312|     r2312_1(glval<String>)          = VariableAddress[s]               : 
 # 2312|     mu2312_2(String)                = Uninitialized[s]                 : &:r2312_1
 # 2312|     r2312_3(glval<unknown>)         = FunctionAddress[String]          : 
@@ -16810,39 +16659,35 @@ ir.cpp:
 # 2431|     r2431_31(glval<vector<char> &&>)                                                       = VariableAddress[(__range)]            : 
 # 2431|     r2431_32(vector<char> &&)                                                              = Load[(__range)]                       : &:r2431_31, ~m?
 #-----|     r0_1(glval<vector<char>>)                                                              = CopyValue                             : r2431_32
-#-----|     r0_2(glval<vector<char>>)                                                              = Convert                               : r0_1
 # 2431|     r2431_33(glval<unknown>)                                                               = FunctionAddress[begin]                : 
-# 2431|     r2431_34(iterator<random_access_iterator_tag, char, ptrdiff_t, char *, char &>)        = Call[begin]                           : func:r2431_33, this:r0_2
-#-----|     v0_3(void)                                                                             = ^IndirectReadSideEffect[-1]           : &:r0_2, ~m?
+# 2431|     r2431_34(iterator<random_access_iterator_tag, char, ptrdiff_t, char *, char &>)        = Call[begin]                           : func:r2431_33, this:r0_1
+#-----|     v0_2(void)                                                                             = ^IndirectReadSideEffect[-1]           : &:r0_1, ~m?
 # 2431|     mu2431_35(iterator<random_access_iterator_tag, char, ptrdiff_t, char *, char &>)       = Store[(__begin)]                      : &:r2431_30, r2431_34
 # 2431|     r2431_36(glval<iterator<random_access_iterator_tag, char, ptrdiff_t, char *, char &>>) = VariableAddress[(__end)]              : 
 # 2431|     r2431_37(glval<vector<char> &&>)                                                       = VariableAddress[(__range)]            : 
 # 2431|     r2431_38(vector<char> &&)                                                              = Load[(__range)]                       : &:r2431_37, ~m?
-#-----|     r0_4(glval<vector<char>>)                                                              = CopyValue                             : r2431_38
-#-----|     r0_5(glval<vector<char>>)                                                              = Convert                               : r0_4
+#-----|     r0_3(glval<vector<char>>)                                                              = CopyValue                             : r2431_38
 # 2431|     r2431_39(glval<unknown>)                                                               = FunctionAddress[end]                  : 
-# 2431|     r2431_40(iterator<random_access_iterator_tag, char, ptrdiff_t, char *, char &>)        = Call[end]                             : func:r2431_39, this:r0_5
-#-----|     v0_6(void)                                                                             = ^IndirectReadSideEffect[-1]           : &:r0_5, ~m?
+# 2431|     r2431_40(iterator<random_access_iterator_tag, char, ptrdiff_t, char *, char &>)        = Call[end]                             : func:r2431_39, this:r0_3
+#-----|     v0_4(void)                                                                             = ^IndirectReadSideEffect[-1]           : &:r0_3, ~m?
 # 2431|     mu2431_41(iterator<random_access_iterator_tag, char, ptrdiff_t, char *, char &>)       = Store[(__end)]                        : &:r2431_36, r2431_40
 #-----|   Goto -> Block 11
 
 # 2431|   Block 11
 # 2431|     r2431_42(glval<iterator<random_access_iterator_tag, char, ptrdiff_t, char *, char &>>) = VariableAddress[(__begin)]      : 
-#-----|     r0_7(glval<iterator<random_access_iterator_tag, char, ptrdiff_t, char *, char &>>)     = Convert                         : r2431_42
 # 2431|     r2431_43(glval<unknown>)                                                               = FunctionAddress[operator!=]     : 
-#-----|     r0_8(glval<iterator<random_access_iterator_tag, char, ptrdiff_t, char *, char &>>)     = VariableAddress[#temp0:0]       : 
-#-----|     mu0_9(iterator<random_access_iterator_tag, char, ptrdiff_t, char *, char &>)           = Uninitialized[#temp0:0]         : &:r0_8
+#-----|     r0_5(glval<iterator<random_access_iterator_tag, char, ptrdiff_t, char *, char &>>)     = VariableAddress[#temp0:0]       : 
+#-----|     mu0_6(iterator<random_access_iterator_tag, char, ptrdiff_t, char *, char &>)           = Uninitialized[#temp0:0]         : &:r0_5
 # 2431|     r2431_44(glval<unknown>)                                                               = FunctionAddress[iterator]       : 
 # 2431|     r2431_45(glval<iterator<random_access_iterator_tag, char, ptrdiff_t, char *, char &>>) = VariableAddress[(__end)]        : 
-#-----|     r0_10(glval<iterator<random_access_iterator_tag, char, ptrdiff_t, char *, char &>>)    = Convert                         : r2431_45
-#-----|     r0_11(iterator<random_access_iterator_tag, char, ptrdiff_t, char *, char &> &)         = CopyValue                       : r0_10
-# 2431|     v2431_46(void)                                                                         = Call[iterator]                  : func:r2431_44, this:r0_8, 0:r0_11
+#-----|     r0_7(iterator<random_access_iterator_tag, char, ptrdiff_t, char *, char &> &)          = CopyValue                       : r2431_45
+# 2431|     v2431_46(void)                                                                         = Call[iterator]                  : func:r2431_44, this:r0_5, 0:r0_7
 # 2431|     mu2431_47(unknown)                                                                     = ^CallSideEffect                 : ~m?
-#-----|     v0_12(void)                                                                            = ^BufferReadSideEffect[0]        : &:r0_11, ~m?
-# 2431|     mu2431_48(iterator<random_access_iterator_tag, char, ptrdiff_t, char *, char &>)       = ^IndirectMayWriteSideEffect[-1] : &:r0_8
-#-----|     r0_13(iterator<random_access_iterator_tag, char, ptrdiff_t, char *, char &>)           = Load[#temp0:0]                  : &:r0_8, ~m?
-# 2431|     r2431_49(bool)                                                                         = Call[operator!=]                : func:r2431_43, this:r0_7, 0:r0_13
-#-----|     v0_14(void)                                                                            = ^IndirectReadSideEffect[-1]     : &:r0_7, ~m?
+#-----|     v0_8(void)                                                                             = ^BufferReadSideEffect[0]        : &:r0_7, ~m?
+# 2431|     mu2431_48(iterator<random_access_iterator_tag, char, ptrdiff_t, char *, char &>)       = ^IndirectMayWriteSideEffect[-1] : &:r0_5
+#-----|     r0_9(iterator<random_access_iterator_tag, char, ptrdiff_t, char *, char &>)            = Load[#temp0:0]                  : &:r0_5, ~m?
+# 2431|     r2431_49(bool)                                                                         = Call[operator!=]                : func:r2431_43, this:r2431_42, 0:r0_9
+#-----|     v0_10(void)                                                                            = ^IndirectReadSideEffect[-1]     : &:r2431_42, ~m?
 # 2431|     v2431_50(void)                                                                         = ConditionalBranch               : r2431_49
 #-----|   False -> Block 13
 #-----|   True -> Block 12
@@ -16850,10 +16695,9 @@ ir.cpp:
 # 2431|   Block 12
 # 2431|     r2431_51(glval<char>)                                                                  = VariableAddress[y]              : 
 # 2431|     r2431_52(glval<iterator<random_access_iterator_tag, char, ptrdiff_t, char *, char &>>) = VariableAddress[(__begin)]      : 
-#-----|     r0_15(glval<iterator<random_access_iterator_tag, char, ptrdiff_t, char *, char &>>)    = Convert                         : r2431_52
 # 2431|     r2431_53(glval<unknown>)                                                               = FunctionAddress[operator*]      : 
-# 2431|     r2431_54(char &)                                                                       = Call[operator*]                 : func:r2431_53, this:r0_15
-#-----|     v0_16(void)                                                                            = ^IndirectReadSideEffect[-1]     : &:r0_15, ~m?
+# 2431|     r2431_54(char &)                                                                       = Call[operator*]                 : func:r2431_53, this:r2431_52
+#-----|     v0_11(void)                                                                            = ^IndirectReadSideEffect[-1]     : &:r2431_52, ~m?
 # 2431|     r2431_55(char)                                                                         = Load[?]                         : &:r2431_54, ~m?
 # 2431|     mu2431_56(char)                                                                        = Store[y]                        : &:r2431_51, r2431_55
 # 2432|     r2432_1(glval<char>)                                                                   = VariableAddress[x]              : 
@@ -17021,20 +16865,19 @@ ir.cpp:
 # 2481|     r2481_4(B)                    = Call[get]                       : func:r2481_3
 # 2481|     mu2481_5(unknown)             = ^CallSideEffect                 : ~m?
 # 2481|     mu2481_6(B)                   = Store[#temp2481:18]             : &:r2481_2, r2481_4
-# 2481|     r2481_7(glval<B>)             = Convert                         : r2481_2
-# 2481|     r2481_8(glval<unknown>)       = FunctionAddress[operator->]     : 
-# 2481|     r2481_9(A *)                  = Call[operator->]                : func:r2481_8, this:r2481_7
-# 2481|     mu2481_10(unknown)            = ^CallSideEffect                 : ~m?
-# 2481|     v2481_11(void)                = ^IndirectReadSideEffect[-1]     : &:r2481_7, ~m?
-# 2481|     r2481_12(glval<unsigned int>) = FieldAddress[a]                 : r2481_9
-# 2481|     r2481_13(glval<B>)            = CopyValue                       : r2481_2
-# 2481|     r2481_14(glval<unknown>)      = FunctionAddress[~B]             : 
-# 2481|     v2481_15(void)                = Call[~B]                        : func:r2481_14, this:r2481_13
-# 2481|     mu2481_16(unknown)            = ^CallSideEffect                 : ~m?
-# 2481|     v2481_17(void)                = ^IndirectReadSideEffect[-1]     : &:r2481_13, ~m?
-# 2481|     mu2481_18(B)                  = ^IndirectMayWriteSideEffect[-1] : &:r2481_13
-# 2481|     r2481_19(unsigned int)        = Load[?]                         : &:r2481_12, ~m?
-# 2481|     mu2481_20(unsigned int)       = Store[a]                        : &:r2481_1, r2481_19
+# 2481|     r2481_7(glval<unknown>)       = FunctionAddress[operator->]     : 
+# 2481|     r2481_8(A *)                  = Call[operator->]                : func:r2481_7, this:r2481_2
+# 2481|     mu2481_9(unknown)             = ^CallSideEffect                 : ~m?
+# 2481|     v2481_10(void)                = ^IndirectReadSideEffect[-1]     : &:r2481_2, ~m?
+# 2481|     r2481_11(glval<unsigned int>) = FieldAddress[a]                 : r2481_8
+# 2481|     r2481_12(glval<B>)            = CopyValue                       : r2481_2
+# 2481|     r2481_13(glval<unknown>)      = FunctionAddress[~B]             : 
+# 2481|     v2481_14(void)                = Call[~B]                        : func:r2481_13, this:r2481_12
+# 2481|     mu2481_15(unknown)            = ^CallSideEffect                 : ~m?
+# 2481|     v2481_16(void)                = ^IndirectReadSideEffect[-1]     : &:r2481_12, ~m?
+# 2481|     mu2481_17(B)                  = ^IndirectMayWriteSideEffect[-1] : &:r2481_12
+# 2481|     r2481_18(unsigned int)        = Load[?]                         : &:r2481_11, ~m?
+# 2481|     mu2481_19(unsigned int)       = Store[a]                        : &:r2481_1, r2481_18
 # 2482|     v2482_1(void)                 = NoOp                            : 
 # 2479|     v2479_4(void)                 = ReturnVoid                      : 
 # 2479|     v2479_5(void)                 = AliasedUse                      : ~m?
@@ -17401,29 +17244,28 @@ ir.cpp:
 
 # 2545| void this_inconsistency(bool)
 # 2545|   Block 0
-# 2545|     v2545_1(void)                          = EnterFunction                           : 
-# 2545|     mu2545_2(unknown)                      = AliasedDefinition                       : 
-# 2545|     mu2545_3(unknown)                      = InitializeNonLocal                      : 
-# 2545|     r2545_4(glval<bool>)                   = VariableAddress[b]                      : 
-# 2545|     mu2545_5(bool)                         = InitializeParameter[b]                  : &:r2545_4
-# 2546|     r2546_1(glval<ClassWithDestructor &>)  = VariableAddress[a]                      : 
-# 2546|     r2546_2(glval<ClassWithDestructor>)    = VariableAddress[#temp2546:38]           : 
-# 2546|     r2546_3(glval<unknown>)                = FunctionAddress[getClassWithDestructor] : 
-# 2546|     r2546_4(ClassWithDestructor)           = Call[getClassWithDestructor]            : func:r2546_3
-# 2546|     mu2546_5(unknown)                      = ^CallSideEffect                         : ~m?
-# 2546|     mu2546_6(ClassWithDestructor)          = Store[#temp2546:38]                     : &:r2546_2, r2546_4
-# 2546|     r2546_7(glval<ClassWithDestructor>)    = Convert                                 : r2546_2
-# 2546|     r2546_8(ClassWithDestructor &)         = CopyValue                               : r2546_7
-# 2546|     mu2546_9(ClassWithDestructor &)        = Store[a]                                : &:r2546_1, r2546_8
-# 2546|     r2546_10(glval<ClassWithDestructor &>) = VariableAddress[a]                      : 
-# 2546|     r2546_11(ClassWithDestructor &)        = Load[a]                                 : &:r2546_10, ~m?
-# 2546|     r2546_12(ClassWithDestructor)          = CopyValue                               : r2546_11
-# 2546|     r2546_13(glval<unknown>)               = FunctionAddress[operator bool]          : 
-# 2546|     r2546_14(bool)                         = Call[operator bool]                     : func:r2546_13, this:r2546_12
-# 2546|     mu2546_15(unknown)                     = ^CallSideEffect                         : ~m?
-# 2546|     v2546_16(void)                         = ^IndirectReadSideEffect[-1]             : &:r2546_12, ~m?
-# 2546|     r2546_17(bool)                         = CopyValue                               : r2546_14
-# 2546|     v2546_18(void)                         = ConditionalBranch                       : r2546_17
+# 2545|     v2545_1(void)                         = EnterFunction                           : 
+# 2545|     mu2545_2(unknown)                     = AliasedDefinition                       : 
+# 2545|     mu2545_3(unknown)                     = InitializeNonLocal                      : 
+# 2545|     r2545_4(glval<bool>)                  = VariableAddress[b]                      : 
+# 2545|     mu2545_5(bool)                        = InitializeParameter[b]                  : &:r2545_4
+# 2546|     r2546_1(glval<ClassWithDestructor &>) = VariableAddress[a]                      : 
+# 2546|     r2546_2(glval<ClassWithDestructor>)   = VariableAddress[#temp2546:38]           : 
+# 2546|     r2546_3(glval<unknown>)               = FunctionAddress[getClassWithDestructor] : 
+# 2546|     r2546_4(ClassWithDestructor)          = Call[getClassWithDestructor]            : func:r2546_3
+# 2546|     mu2546_5(unknown)                     = ^CallSideEffect                         : ~m?
+# 2546|     mu2546_6(ClassWithDestructor)         = Store[#temp2546:38]                     : &:r2546_2, r2546_4
+# 2546|     r2546_7(ClassWithDestructor &)        = CopyValue                               : r2546_2
+# 2546|     mu2546_8(ClassWithDestructor &)       = Store[a]                                : &:r2546_1, r2546_7
+# 2546|     r2546_9(glval<ClassWithDestructor &>) = VariableAddress[a]                      : 
+# 2546|     r2546_10(ClassWithDestructor &)       = Load[a]                                 : &:r2546_9, ~m?
+# 2546|     r2546_11(ClassWithDestructor)         = CopyValue                               : r2546_10
+# 2546|     r2546_12(glval<unknown>)              = FunctionAddress[operator bool]          : 
+# 2546|     r2546_13(bool)                        = Call[operator bool]                     : func:r2546_12, this:r2546_11
+# 2546|     mu2546_14(unknown)                    = ^CallSideEffect                         : ~m?
+# 2546|     v2546_15(void)                        = ^IndirectReadSideEffect[-1]             : &:r2546_11, ~m?
+# 2546|     r2546_16(bool)                        = CopyValue                               : r2546_13
+# 2546|     v2546_17(void)                        = ConditionalBranch                       : r2546_16
 #-----|   False -> Block 2
 #-----|   True -> Block 1
 
@@ -17456,11 +17298,10 @@ ir.cpp:
 # 2551|     r2551_4(ClassWithDestructor)          = Call[getClassWithDestructor]            : func:r2551_3
 # 2551|     mu2551_5(unknown)                     = ^CallSideEffect                         : ~m?
 # 2551|     mu2551_6(ClassWithDestructor)         = Store[#temp2551:48]                     : &:r2551_2, r2551_4
-# 2551|     r2551_7(glval<ClassWithDestructor>)   = Convert                                 : r2551_2
-# 2551|     r2551_8(ClassWithDestructor &)        = CopyValue                               : r2551_7
-# 2551|     mu2551_9(ClassWithDestructor &)       = Store[a]                                : &:r2551_1, r2551_8
-# 2551|     r2551_10(bool)                        = Constant[1]                             : 
-# 2551|     v2551_11(void)                        = ConditionalBranch                       : r2551_10
+# 2551|     r2551_7(ClassWithDestructor &)        = CopyValue                               : r2551_2
+# 2551|     mu2551_8(ClassWithDestructor &)       = Store[a]                                : &:r2551_1, r2551_7
+# 2551|     r2551_9(bool)                         = Constant[1]                             : 
+# 2551|     v2551_10(void)                        = ConditionalBranch                       : r2551_9
 #-----|   False -> Block 2
 #-----|   True -> Block 1
 
@@ -17736,10 +17577,9 @@ ir.cpp:
 # 2630|     r2630_1(glval<unknown>) = FunctionAddress[use_const_int] : 
 # 2630|     r2630_2(glval<int *>)   = VariableAddress[data]          : 
 # 2630|     r2630_3(int *)          = Load[data]                     : &:r2630_2, ~m?
-# 2630|     r2630_4(int *)          = Convert                        : r2630_3
-# 2630|     v2630_5(void)           = Call[use_const_int]            : func:r2630_1, 0:r2630_4
-# 2630|     mu2630_6(unknown)       = ^CallSideEffect                : ~m?
-# 2630|     v2630_7(void)           = ^BufferReadSideEffect[0]       : &:r2630_4, ~m?
+# 2630|     v2630_4(void)           = Call[use_const_int]            : func:r2630_1, 0:r2630_3
+# 2630|     mu2630_5(unknown)       = ^CallSideEffect                : ~m?
+# 2630|     v2630_6(void)           = ^BufferReadSideEffect[0]       : &:r2630_3, ~m?
 # 2631|     v2631_1(void)           = NoOp                           : 
 # 2618|     v2618_6(void)           = ReturnVoid                     : 
 # 2618|     v2618_7(void)           = AliasedUse                     : ~m?
@@ -18400,14 +18240,12 @@ ir.cpp:
 # 2739|     r2739_4(int *)        = PointerAdd[4]            : r2739_2, r2739_3
 # 2739|     mu2739_5(int *)       = Store[p]                 : &:r2739_1, r2739_4
 # 2739|     r2739_6(int *)        = CopyValue                : r2739_2
-# 2739|     r2739_7(int *)        = Convert                  : r2739_6
 # 2740|     r2740_1(glval<int>)   = VariableAddress[q]       : 
 # 2740|     r2740_2(int)          = Load[q]                  : &:r2740_1, ~m?
 # 2740|     r2740_3(int)          = Constant[1]              : 
 # 2740|     r2740_4(int)          = Add                      : r2740_2, r2740_3
 # 2740|     mu2740_5(int)         = Store[q]                 : &:r2740_1, r2740_4
 # 2740|     r2740_6(int)          = CopyValue                : r2740_2
-# 2740|     r2740_7(int)          = Convert                  : r2740_6
 # 2741|     r2741_1(glval<int *>) = VariableAddress[p2]      : 
 # 2741|     r2741_2(glval<int *>) = VariableAddress[p]       : 
 # 2741|     r2741_3(int *)        = Load[p]                  : &:r2741_2, ~m?
@@ -18415,8 +18253,7 @@ ir.cpp:
 # 2741|     r2741_5(int *)        = PointerAdd[4]            : r2741_3, r2741_4
 # 2741|     mu2741_6(int *)       = Store[p]                 : &:r2741_2, r2741_5
 # 2741|     r2741_7(int *)        = CopyValue                : r2741_3
-# 2741|     r2741_8(int *)        = Convert                  : r2741_7
-# 2741|     mu2741_9(int *)       = Store[p2]                : &:r2741_1, r2741_8
+# 2741|     mu2741_8(int *)       = Store[p2]                : &:r2741_1, r2741_7
 # 2742|     r2742_1(glval<int>)   = VariableAddress[q2]      : 
 # 2742|     r2742_2(glval<int>)   = VariableAddress[q]       : 
 # 2742|     r2742_3(int)          = Load[q]                  : &:r2742_2, ~m?
@@ -18424,8 +18261,7 @@ ir.cpp:
 # 2742|     r2742_5(int)          = Add                      : r2742_3, r2742_4
 # 2742|     mu2742_6(int)         = Store[q]                 : &:r2742_2, r2742_5
 # 2742|     r2742_7(int)          = CopyValue                : r2742_3
-# 2742|     r2742_8(int)          = Convert                  : r2742_7
-# 2742|     mu2742_9(int)         = Store[q2]                : &:r2742_1, r2742_8
+# 2742|     mu2742_8(int)         = Store[q2]                : &:r2742_1, r2742_7
 # 2743|     v2743_1(void)         = NoOp                     : 
 # 2728|     v2728_10(void)        = ReturnIndirection[p]     : &:r2728_6, ~m?
 # 2728|     v2728_11(void)        = ReturnVoid               : 
@@ -37254,22 +37090,21 @@ smart_ptr.cpp:
 #   19|     mu19_3(shared_ptr<float>)        = Uninitialized[#temp19:20]        : &:r19_2
 #   19|     r19_4(glval<unknown>)            = FunctionAddress[shared_ptr]      : 
 #   19|     r19_5(glval<shared_ptr<float>>)  = VariableAddress[sp]              : 
-#   19|     r19_6(glval<shared_ptr<float>>)  = Convert                          : r19_5
-#   19|     r19_7(shared_ptr<float> &)       = CopyValue                        : r19_6
-#   19|     v19_8(void)                      = Call[shared_ptr]                 : func:r19_4, this:r19_2, 0:r19_7
-#   19|     mu19_9(unknown)                  = ^CallSideEffect                  : ~m?
-#   19|     v19_10(void)                     = ^IndirectReadSideEffect[0]       : &:r19_7, ~m?
-#   19|     mu19_11(shared_ptr<float>)       = ^IndirectMustWriteSideEffect[-1] : &:r19_2
-#   19|     r19_12(shared_ptr<float>)        = Load[#temp19:20]                 : &:r19_2, ~m?
-#   19|     v19_13(void)                     = Call[shared_ptr_arg]             : func:r19_1, 0:r19_12
-#   19|     mu19_14(unknown)                 = ^CallSideEffect                  : ~m?
-#   19|     v19_15(void)                     = ^BufferReadSideEffect[0]         : &:r19_12, ~m?
-#   19|     mu19_16(unknown)                 = ^BufferMayWriteSideEffect[0]     : &:r19_12
-#   19|     r19_17(glval<shared_ptr<float>>) = CopyValue                        : r19_2
-#   19|     r19_18(glval<unknown>)           = FunctionAddress[~shared_ptr]     : 
-#   19|     v19_19(void)                     = Call[~shared_ptr]                : func:r19_18, this:r19_17
-#   19|     v19_20(void)                     = ^IndirectReadSideEffect[-1]      : &:r19_17, ~m?
-#   19|     mu19_21(shared_ptr<float>)       = ^IndirectMustWriteSideEffect[-1] : &:r19_17
+#   19|     r19_6(shared_ptr<float> &)       = CopyValue                        : r19_5
+#   19|     v19_7(void)                      = Call[shared_ptr]                 : func:r19_4, this:r19_2, 0:r19_6
+#   19|     mu19_8(unknown)                  = ^CallSideEffect                  : ~m?
+#   19|     v19_9(void)                      = ^IndirectReadSideEffect[0]       : &:r19_6, ~m?
+#   19|     mu19_10(shared_ptr<float>)       = ^IndirectMustWriteSideEffect[-1] : &:r19_2
+#   19|     r19_11(shared_ptr<float>)        = Load[#temp19:20]                 : &:r19_2, ~m?
+#   19|     v19_12(void)                     = Call[shared_ptr_arg]             : func:r19_1, 0:r19_11
+#   19|     mu19_13(unknown)                 = ^CallSideEffect                  : ~m?
+#   19|     v19_14(void)                     = ^BufferReadSideEffect[0]         : &:r19_11, ~m?
+#   19|     mu19_15(unknown)                 = ^BufferMayWriteSideEffect[0]     : &:r19_11
+#   19|     r19_16(glval<shared_ptr<float>>) = CopyValue                        : r19_2
+#   19|     r19_17(glval<unknown>)           = FunctionAddress[~shared_ptr]     : 
+#   19|     v19_18(void)                     = Call[~shared_ptr]                : func:r19_17, this:r19_16
+#   19|     v19_19(void)                     = ^IndirectReadSideEffect[-1]      : &:r19_16, ~m?
+#   19|     mu19_20(shared_ptr<float>)       = ^IndirectMustWriteSideEffect[-1] : &:r19_16
 #   20|     v20_1(void)                      = NoOp                             : 
 #   20|     r20_2(glval<shared_ptr<float>>)  = VariableAddress[sp]              : 
 #   20|     r20_3(glval<unknown>)            = FunctionAddress[~shared_ptr]     : 
@@ -37293,21 +37128,20 @@ smart_ptr.cpp:
 #   31|     mu31_3(shared_ptr<const int>)                          = Uninitialized[#temp31:26]                              : &:r31_2
 #   31|     r31_4(glval<unknown>)                                  = FunctionAddress[shared_ptr]                            : 
 #   31|     r31_5(glval<shared_ptr<const int>>)                    = VariableAddress[sp_const_int]                          : 
-#   31|     r31_6(glval<shared_ptr<const int>>)                    = Convert                                                : r31_5
-#   31|     r31_7(shared_ptr<const int> &)                         = CopyValue                                              : r31_6
-#   31|     v31_8(void)                                            = Call[shared_ptr]                                       : func:r31_4, this:r31_2, 0:r31_7
-#   31|     mu31_9(unknown)                                        = ^CallSideEffect                                        : ~m?
-#   31|     v31_10(void)                                           = ^IndirectReadSideEffect[0]                             : &:r31_7, ~m?
-#   31|     mu31_11(shared_ptr<const int>)                         = ^IndirectMustWriteSideEffect[-1]                       : &:r31_2
-#   31|     r31_12(shared_ptr<const int>)                          = Load[#temp31:26]                                       : &:r31_2, ~m?
-#   31|     v31_13(void)                                           = Call[shared_ptr_const_int]                             : func:r31_1, 0:r31_12
-#   31|     mu31_14(unknown)                                       = ^CallSideEffect                                        : ~m?
-#   31|     v31_15(void)                                           = ^BufferReadSideEffect[0]                               : &:r31_12, ~m?
-#   31|     r31_16(glval<shared_ptr<const int>>)                   = CopyValue                                              : r31_2
-#   31|     r31_17(glval<unknown>)                                 = FunctionAddress[~shared_ptr]                           : 
-#   31|     v31_18(void)                                           = Call[~shared_ptr]                                      : func:r31_17, this:r31_16
-#   31|     v31_19(void)                                           = ^IndirectReadSideEffect[-1]                            : &:r31_16, ~m?
-#   31|     mu31_20(shared_ptr<const int>)                         = ^IndirectMustWriteSideEffect[-1]                       : &:r31_16
+#   31|     r31_6(shared_ptr<const int> &)                         = CopyValue                                              : r31_5
+#   31|     v31_7(void)                                            = Call[shared_ptr]                                       : func:r31_4, this:r31_2, 0:r31_6
+#   31|     mu31_8(unknown)                                        = ^CallSideEffect                                        : ~m?
+#   31|     v31_9(void)                                            = ^IndirectReadSideEffect[0]                             : &:r31_6, ~m?
+#   31|     mu31_10(shared_ptr<const int>)                         = ^IndirectMustWriteSideEffect[-1]                       : &:r31_2
+#   31|     r31_11(shared_ptr<const int>)                          = Load[#temp31:26]                                       : &:r31_2, ~m?
+#   31|     v31_12(void)                                           = Call[shared_ptr_const_int]                             : func:r31_1, 0:r31_11
+#   31|     mu31_13(unknown)                                       = ^CallSideEffect                                        : ~m?
+#   31|     v31_14(void)                                           = ^BufferReadSideEffect[0]                               : &:r31_11, ~m?
+#   31|     r31_15(glval<shared_ptr<const int>>)                   = CopyValue                                              : r31_2
+#   31|     r31_16(glval<unknown>)                                 = FunctionAddress[~shared_ptr]                           : 
+#   31|     v31_17(void)                                           = Call[~shared_ptr]                                      : func:r31_16, this:r31_15
+#   31|     v31_18(void)                                           = ^IndirectReadSideEffect[-1]                            : &:r31_15, ~m?
+#   31|     mu31_19(shared_ptr<const int>)                         = ^IndirectMustWriteSideEffect[-1]                       : &:r31_15
 #   33|     r33_1(glval<shared_ptr<int *const>>)                   = VariableAddress[sp_const_int_pointer]                  : 
 #   33|     mu33_2(shared_ptr<int *const>)                         = Uninitialized[sp_const_int_pointer]                    : &:r33_1
 #   35|     r35_1(glval<unknown>)                                  = FunctionAddress[shared_ptr_const_int_ptr]              : 
@@ -37315,22 +37149,21 @@ smart_ptr.cpp:
 #   35|     mu35_3(shared_ptr<int *const>)                         = Uninitialized[#temp35:30]                              : &:r35_2
 #   35|     r35_4(glval<unknown>)                                  = FunctionAddress[shared_ptr]                            : 
 #   35|     r35_5(glval<shared_ptr<int *const>>)                   = VariableAddress[sp_const_int_pointer]                  : 
-#   35|     r35_6(glval<shared_ptr<int *const>>)                   = Convert                                                : r35_5
-#   35|     r35_7(shared_ptr<int *const> &)                        = CopyValue                                              : r35_6
-#   35|     v35_8(void)                                            = Call[shared_ptr]                                       : func:r35_4, this:r35_2, 0:r35_7
-#   35|     mu35_9(unknown)                                        = ^CallSideEffect                                        : ~m?
-#   35|     v35_10(void)                                           = ^IndirectReadSideEffect[0]                             : &:r35_7, ~m?
-#   35|     mu35_11(shared_ptr<int *const>)                        = ^IndirectMustWriteSideEffect[-1]                       : &:r35_2
-#   35|     r35_12(shared_ptr<int *const>)                         = Load[#temp35:30]                                       : &:r35_2, ~m?
-#   35|     v35_13(void)                                           = Call[shared_ptr_const_int_ptr]                         : func:r35_1, 0:r35_12
-#   35|     mu35_14(unknown)                                       = ^CallSideEffect                                        : ~m?
-#   35|     v35_15(void)                                           = ^BufferReadSideEffect[0]                               : &:r35_12, ~m?
-#   35|     mu35_16(unknown)                                       = ^BufferMayWriteSideEffect[0]                           : &:r35_12
-#   35|     r35_17(glval<shared_ptr<int *const>>)                  = CopyValue                                              : r35_2
-#   35|     r35_18(glval<unknown>)                                 = FunctionAddress[~shared_ptr]                           : 
-#   35|     v35_19(void)                                           = Call[~shared_ptr]                                      : func:r35_18, this:r35_17
-#   35|     v35_20(void)                                           = ^IndirectReadSideEffect[-1]                            : &:r35_17, ~m?
-#   35|     mu35_21(shared_ptr<int *const>)                        = ^IndirectMustWriteSideEffect[-1]                       : &:r35_17
+#   35|     r35_6(shared_ptr<int *const> &)                        = CopyValue                                              : r35_5
+#   35|     v35_7(void)                                            = Call[shared_ptr]                                       : func:r35_4, this:r35_2, 0:r35_6
+#   35|     mu35_8(unknown)                                        = ^CallSideEffect                                        : ~m?
+#   35|     v35_9(void)                                            = ^IndirectReadSideEffect[0]                             : &:r35_6, ~m?
+#   35|     mu35_10(shared_ptr<int *const>)                        = ^IndirectMustWriteSideEffect[-1]                       : &:r35_2
+#   35|     r35_11(shared_ptr<int *const>)                         = Load[#temp35:30]                                       : &:r35_2, ~m?
+#   35|     v35_12(void)                                           = Call[shared_ptr_const_int_ptr]                         : func:r35_1, 0:r35_11
+#   35|     mu35_13(unknown)                                       = ^CallSideEffect                                        : ~m?
+#   35|     v35_14(void)                                           = ^BufferReadSideEffect[0]                               : &:r35_11, ~m?
+#   35|     mu35_15(unknown)                                       = ^BufferMayWriteSideEffect[0]                           : &:r35_11
+#   35|     r35_16(glval<shared_ptr<int *const>>)                  = CopyValue                                              : r35_2
+#   35|     r35_17(glval<unknown>)                                 = FunctionAddress[~shared_ptr]                           : 
+#   35|     v35_18(void)                                           = Call[~shared_ptr]                                      : func:r35_17, this:r35_16
+#   35|     v35_19(void)                                           = ^IndirectReadSideEffect[-1]                            : &:r35_16, ~m?
+#   35|     mu35_20(shared_ptr<int *const>)                        = ^IndirectMustWriteSideEffect[-1]                       : &:r35_16
 #   37|     r37_1(glval<shared_ptr<shared_ptr<const int>>>)        = VariableAddress[sp_sp_const_int]                       : 
 #   37|     mu37_2(shared_ptr<shared_ptr<const int>>)              = Uninitialized[sp_sp_const_int]                         : &:r37_1
 #   39|     r39_1(glval<unknown>)                                  = FunctionAddress[shared_ptr_shared_ptr_const_int]       : 
@@ -37338,22 +37171,21 @@ smart_ptr.cpp:
 #   39|     mu39_3(shared_ptr<shared_ptr<const int>>)              = Uninitialized[#temp39:37]                              : &:r39_2
 #   39|     r39_4(glval<unknown>)                                  = FunctionAddress[shared_ptr]                            : 
 #   39|     r39_5(glval<shared_ptr<shared_ptr<const int>>>)        = VariableAddress[sp_sp_const_int]                       : 
-#   39|     r39_6(glval<shared_ptr<shared_ptr<const int>>>)        = Convert                                                : r39_5
-#   39|     r39_7(shared_ptr<shared_ptr<const int>> &)             = CopyValue                                              : r39_6
-#   39|     v39_8(void)                                            = Call[shared_ptr]                                       : func:r39_4, this:r39_2, 0:r39_7
-#   39|     mu39_9(unknown)                                        = ^CallSideEffect                                        : ~m?
-#   39|     v39_10(void)                                           = ^IndirectReadSideEffect[0]                             : &:r39_7, ~m?
-#   39|     mu39_11(shared_ptr<shared_ptr<const int>>)             = ^IndirectMustWriteSideEffect[-1]                       : &:r39_2
-#   39|     r39_12(shared_ptr<shared_ptr<const int>>)              = Load[#temp39:37]                                       : &:r39_2, ~m?
-#   39|     v39_13(void)                                           = Call[shared_ptr_shared_ptr_const_int]                  : func:r39_1, 0:r39_12
-#   39|     mu39_14(unknown)                                       = ^CallSideEffect                                        : ~m?
-#   39|     v39_15(void)                                           = ^BufferReadSideEffect[0]                               : &:r39_12, ~m?
-#   39|     mu39_16(unknown)                                       = ^BufferMayWriteSideEffect[0]                           : &:r39_12
-#   39|     r39_17(glval<shared_ptr<shared_ptr<const int>>>)       = CopyValue                                              : r39_2
-#   39|     r39_18(glval<unknown>)                                 = FunctionAddress[~shared_ptr]                           : 
-#   39|     v39_19(void)                                           = Call[~shared_ptr]                                      : func:r39_18, this:r39_17
-#   39|     v39_20(void)                                           = ^IndirectReadSideEffect[-1]                            : &:r39_17, ~m?
-#   39|     mu39_21(shared_ptr<shared_ptr<const int>>)             = ^IndirectMustWriteSideEffect[-1]                       : &:r39_17
+#   39|     r39_6(shared_ptr<shared_ptr<const int>> &)             = CopyValue                                              : r39_5
+#   39|     v39_7(void)                                            = Call[shared_ptr]                                       : func:r39_4, this:r39_2, 0:r39_6
+#   39|     mu39_8(unknown)                                        = ^CallSideEffect                                        : ~m?
+#   39|     v39_9(void)                                            = ^IndirectReadSideEffect[0]                             : &:r39_6, ~m?
+#   39|     mu39_10(shared_ptr<shared_ptr<const int>>)             = ^IndirectMustWriteSideEffect[-1]                       : &:r39_2
+#   39|     r39_11(shared_ptr<shared_ptr<const int>>)              = Load[#temp39:37]                                       : &:r39_2, ~m?
+#   39|     v39_12(void)                                           = Call[shared_ptr_shared_ptr_const_int]                  : func:r39_1, 0:r39_11
+#   39|     mu39_13(unknown)                                       = ^CallSideEffect                                        : ~m?
+#   39|     v39_14(void)                                           = ^BufferReadSideEffect[0]                               : &:r39_11, ~m?
+#   39|     mu39_15(unknown)                                       = ^BufferMayWriteSideEffect[0]                           : &:r39_11
+#   39|     r39_16(glval<shared_ptr<shared_ptr<const int>>>)       = CopyValue                                              : r39_2
+#   39|     r39_17(glval<unknown>)                                 = FunctionAddress[~shared_ptr]                           : 
+#   39|     v39_18(void)                                           = Call[~shared_ptr]                                      : func:r39_17, this:r39_16
+#   39|     v39_19(void)                                           = ^IndirectReadSideEffect[-1]                            : &:r39_16, ~m?
+#   39|     mu39_20(shared_ptr<shared_ptr<const int>>)             = ^IndirectMustWriteSideEffect[-1]                       : &:r39_16
 #   41|     r41_1(glval<shared_ptr<const shared_ptr<int>>>)        = VariableAddress[sp_const_sp_int]                       : 
 #   41|     mu41_2(shared_ptr<const shared_ptr<int>>)              = Uninitialized[sp_const_sp_int]                         : &:r41_1
 #   43|     r43_1(glval<unknown>)                                  = FunctionAddress[shared_ptr_const_shared_ptr_int]       : 
@@ -37361,22 +37193,21 @@ smart_ptr.cpp:
 #   43|     mu43_3(shared_ptr<const shared_ptr<int>>)              = Uninitialized[#temp43:37]                              : &:r43_2
 #   43|     r43_4(glval<unknown>)                                  = FunctionAddress[shared_ptr]                            : 
 #   43|     r43_5(glval<shared_ptr<const shared_ptr<int>>>)        = VariableAddress[sp_const_sp_int]                       : 
-#   43|     r43_6(glval<shared_ptr<const shared_ptr<int>>>)        = Convert                                                : r43_5
-#   43|     r43_7(shared_ptr<const shared_ptr<int>> &)             = CopyValue                                              : r43_6
-#   43|     v43_8(void)                                            = Call[shared_ptr]                                       : func:r43_4, this:r43_2, 0:r43_7
-#   43|     mu43_9(unknown)                                        = ^CallSideEffect                                        : ~m?
-#   43|     v43_10(void)                                           = ^IndirectReadSideEffect[0]                             : &:r43_7, ~m?
-#   43|     mu43_11(shared_ptr<const shared_ptr<int>>)             = ^IndirectMustWriteSideEffect[-1]                       : &:r43_2
-#   43|     r43_12(shared_ptr<const shared_ptr<int>>)              = Load[#temp43:37]                                       : &:r43_2, ~m?
-#   43|     v43_13(void)                                           = Call[shared_ptr_const_shared_ptr_int]                  : func:r43_1, 0:r43_12
-#   43|     mu43_14(unknown)                                       = ^CallSideEffect                                        : ~m?
-#   43|     v43_15(void)                                           = ^BufferReadSideEffect[0]                               : &:r43_12, ~m?
-#   43|     mu43_16(unknown)                                       = ^BufferMayWriteSideEffect[0]                           : &:r43_12
-#   43|     r43_17(glval<shared_ptr<const shared_ptr<int>>>)       = CopyValue                                              : r43_2
-#   43|     r43_18(glval<unknown>)                                 = FunctionAddress[~shared_ptr]                           : 
-#   43|     v43_19(void)                                           = Call[~shared_ptr]                                      : func:r43_18, this:r43_17
-#   43|     v43_20(void)                                           = ^IndirectReadSideEffect[-1]                            : &:r43_17, ~m?
-#   43|     mu43_21(shared_ptr<const shared_ptr<int>>)             = ^IndirectMustWriteSideEffect[-1]                       : &:r43_17
+#   43|     r43_6(shared_ptr<const shared_ptr<int>> &)             = CopyValue                                              : r43_5
+#   43|     v43_7(void)                                            = Call[shared_ptr]                                       : func:r43_4, this:r43_2, 0:r43_6
+#   43|     mu43_8(unknown)                                        = ^CallSideEffect                                        : ~m?
+#   43|     v43_9(void)                                            = ^IndirectReadSideEffect[0]                             : &:r43_6, ~m?
+#   43|     mu43_10(shared_ptr<const shared_ptr<int>>)             = ^IndirectMustWriteSideEffect[-1]                       : &:r43_2
+#   43|     r43_11(shared_ptr<const shared_ptr<int>>)              = Load[#temp43:37]                                       : &:r43_2, ~m?
+#   43|     v43_12(void)                                           = Call[shared_ptr_const_shared_ptr_int]                  : func:r43_1, 0:r43_11
+#   43|     mu43_13(unknown)                                       = ^CallSideEffect                                        : ~m?
+#   43|     v43_14(void)                                           = ^BufferReadSideEffect[0]                               : &:r43_11, ~m?
+#   43|     mu43_15(unknown)                                       = ^BufferMayWriteSideEffect[0]                           : &:r43_11
+#   43|     r43_16(glval<shared_ptr<const shared_ptr<int>>>)       = CopyValue                                              : r43_2
+#   43|     r43_17(glval<unknown>)                                 = FunctionAddress[~shared_ptr]                           : 
+#   43|     v43_18(void)                                           = Call[~shared_ptr]                                      : func:r43_17, this:r43_16
+#   43|     v43_19(void)                                           = ^IndirectReadSideEffect[-1]                            : &:r43_16, ~m?
+#   43|     mu43_20(shared_ptr<const shared_ptr<int>>)             = ^IndirectMustWriteSideEffect[-1]                       : &:r43_16
 #   45|     r45_1(glval<shared_ptr<const shared_ptr<const int>>>)  = VariableAddress[sp_const_sp_const_int]                 : 
 #   45|     mu45_2(shared_ptr<const shared_ptr<const int>>)        = Uninitialized[sp_const_sp_const_int]                   : &:r45_1
 #   47|     r47_1(glval<unknown>)                                  = FunctionAddress[shared_ptr_const_shared_ptr_const_int] : 
@@ -37384,21 +37215,20 @@ smart_ptr.cpp:
 #   47|     mu47_3(shared_ptr<const shared_ptr<const int>>)        = Uninitialized[#temp47:43]                              : &:r47_2
 #   47|     r47_4(glval<unknown>)                                  = FunctionAddress[shared_ptr]                            : 
 #   47|     r47_5(glval<shared_ptr<const shared_ptr<const int>>>)  = VariableAddress[sp_const_sp_const_int]                 : 
-#   47|     r47_6(glval<shared_ptr<const shared_ptr<const int>>>)  = Convert                                                : r47_5
-#   47|     r47_7(shared_ptr<const shared_ptr<const int>> &)       = CopyValue                                              : r47_6
-#   47|     v47_8(void)                                            = Call[shared_ptr]                                       : func:r47_4, this:r47_2, 0:r47_7
-#   47|     mu47_9(unknown)                                        = ^CallSideEffect                                        : ~m?
-#   47|     v47_10(void)                                           = ^IndirectReadSideEffect[0]                             : &:r47_7, ~m?
-#   47|     mu47_11(shared_ptr<const shared_ptr<const int>>)       = ^IndirectMustWriteSideEffect[-1]                       : &:r47_2
-#   47|     r47_12(shared_ptr<const shared_ptr<const int>>)        = Load[#temp47:43]                                       : &:r47_2, ~m?
-#   47|     v47_13(void)                                           = Call[shared_ptr_const_shared_ptr_const_int]            : func:r47_1, 0:r47_12
-#   47|     mu47_14(unknown)                                       = ^CallSideEffect                                        : ~m?
-#   47|     v47_15(void)                                           = ^BufferReadSideEffect[0]                               : &:r47_12, ~m?
-#   47|     r47_16(glval<shared_ptr<const shared_ptr<const int>>>) = CopyValue                                              : r47_2
-#   47|     r47_17(glval<unknown>)                                 = FunctionAddress[~shared_ptr]                           : 
-#   47|     v47_18(void)                                           = Call[~shared_ptr]                                      : func:r47_17, this:r47_16
-#   47|     v47_19(void)                                           = ^IndirectReadSideEffect[-1]                            : &:r47_16, ~m?
-#   47|     mu47_20(shared_ptr<const shared_ptr<const int>>)       = ^IndirectMustWriteSideEffect[-1]                       : &:r47_16
+#   47|     r47_6(shared_ptr<const shared_ptr<const int>> &)       = CopyValue                                              : r47_5
+#   47|     v47_7(void)                                            = Call[shared_ptr]                                       : func:r47_4, this:r47_2, 0:r47_6
+#   47|     mu47_8(unknown)                                        = ^CallSideEffect                                        : ~m?
+#   47|     v47_9(void)                                            = ^IndirectReadSideEffect[0]                             : &:r47_6, ~m?
+#   47|     mu47_10(shared_ptr<const shared_ptr<const int>>)       = ^IndirectMustWriteSideEffect[-1]                       : &:r47_2
+#   47|     r47_11(shared_ptr<const shared_ptr<const int>>)        = Load[#temp47:43]                                       : &:r47_2, ~m?
+#   47|     v47_12(void)                                           = Call[shared_ptr_const_shared_ptr_const_int]            : func:r47_1, 0:r47_11
+#   47|     mu47_13(unknown)                                       = ^CallSideEffect                                        : ~m?
+#   47|     v47_14(void)                                           = ^BufferReadSideEffect[0]                               : &:r47_11, ~m?
+#   47|     r47_15(glval<shared_ptr<const shared_ptr<const int>>>) = CopyValue                                              : r47_2
+#   47|     r47_16(glval<unknown>)                                 = FunctionAddress[~shared_ptr]                           : 
+#   47|     v47_17(void)                                           = Call[~shared_ptr]                                      : func:r47_16, this:r47_15
+#   47|     v47_18(void)                                           = ^IndirectReadSideEffect[-1]                            : &:r47_15, ~m?
+#   47|     mu47_19(shared_ptr<const shared_ptr<const int>>)       = ^IndirectMustWriteSideEffect[-1]                       : &:r47_15
 #   48|     v48_1(void)                                            = NoOp                                                   : 
 #   48|     r48_2(glval<shared_ptr<const shared_ptr<const int>>>)  = VariableAddress[sp_const_sp_const_int]                 : 
 #   48|     r48_3(glval<unknown>)                                  = FunctionAddress[~shared_ptr]                           : 


### PR DESCRIPTION
Consider the following snippet:
```cpp
struct S {
  void foo() const;
};

void test() {
  S s;
  s.foo();
}
```
Because `foo` is a `const` member function there will be a `GlvalueConversion` which converts the qualifier from a `glval<S>` to a `glval<const S>` before it's passed to `foo`. This conversion will generate a `Convert` instruction.

However, there is very little value in keeping those conversions. In fact, it sometimes makes analysis harder for us. For example, the value number of the qualifier to `foo` (i.e., `s` after the conversion) is different from any other uses of `s` since those uses likely have type `glval<S>`. This fact bit me today!

This PR removes these conversions which previously generated a `Convert` instruction, but only modified the specifiers (i.e., `const`ness, `volatile`ness, etc.)