### PR TITLE
C++: Value numbering for casts that only modify specifiers

### DIFF
--- a/cpp/ql/lib/change-notes/2025-08-02-gvn.md
+++ b/cpp/ql/lib/change-notes/2025-08-02-gvn.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The global value numbering library (`semmle.code.cpp.valuenumbering.GlobalValueNumbering` and `semmle.code.cpp.ir.ValueNumbering`) has been improved so more expressions are assigned the same value number.

--- a/cpp/ql/test/library-tests/valuenumbering/GlobalValueNumbering/ir_gvn.expected
+++ b/cpp/ql/test/library-tests/valuenumbering/GlobalValueNumbering/ir_gvn.expected
@@ -1156,7 +1156,7 @@ test.cpp:
 #  166|     m166_4(unknown)                              = Chi                                  : total:m166_2, partial:m166_3
 #  166|         valnum = unique
 #  167|     r167_1(glval<StructWithConstMemberFunction>) = VariableAddress[s]                   : 
-#  167|         valnum = r167_1, r168_2, r169_1
+#  167|         valnum = r167_1, r168_2, r169_1, r169_2
 #  167|     m167_2(StructWithConstMemberFunction)        = Uninitialized[s]                     : &:r167_1
 #  167|         valnum = m167_2, m168_4, r168_3
 #  167|     m167_3(unknown)                              = Chi                                  : total:m166_4, partial:m167_2
@@ -1164,15 +1164,15 @@ test.cpp:
 #  168|     r168_1(glval<StructWithConstMemberFunction>) = VariableAddress[s2]                  : 
 #  168|         valnum = unique
 #  168|     r168_2(glval<StructWithConstMemberFunction>) = VariableAddress[s]                   : 
-#  168|         valnum = r167_1, r168_2, r169_1
+#  168|         valnum = r167_1, r168_2, r169_1, r169_2
 #  168|     r168_3(StructWithConstMemberFunction)        = Load[s]                              : &:r168_2, m167_2
 #  168|         valnum = m167_2, m168_4, r168_3
 #  168|     m168_4(StructWithConstMemberFunction)        = Store[s2]                            : &:r168_1, r168_3
 #  168|         valnum = m167_2, m168_4, r168_3
 #  169|     r169_1(glval<StructWithConstMemberFunction>) = VariableAddress[s]                   : 
-#  169|         valnum = r167_1, r168_2, r169_1
+#  169|         valnum = r167_1, r168_2, r169_1, r169_2
 #  169|     r169_2(glval<StructWithConstMemberFunction>) = Convert                              : r169_1
-#  169|         valnum = unique
+#  169|         valnum = r167_1, r168_2, r169_1, r169_2
 #  169|     r169_3(glval<unknown>)                       = FunctionAddress[constMemberFunction] : 
 #  169|         valnum = unique
 #  169|     v169_4(void)                                 = Call[constMemberFunction]            : func:r169_3, this:r169_2

--- a/cpp/ql/test/library-tests/valuenumbering/GlobalValueNumbering/ir_gvn.expected
+++ b/cpp/ql/test/library-tests/valuenumbering/GlobalValueNumbering/ir_gvn.expected
@@ -1145,3 +1145,43 @@ test.cpp:
 #  152|     v152_7(void)       = ReturnVoid                : 
 #  152|     v152_8(void)       = AliasedUse                : ~m156_7
 #  152|     v152_9(void)       = ExitFunction              : 
+
+#  166| void test_constMemberFunction()
+#  166|   Block 0
+#  166|     v166_1(void)                                 = EnterFunction                        : 
+#  166|     m166_2(unknown)                              = AliasedDefinition                    : 
+#  166|         valnum = unique
+#  166|     m166_3(unknown)                              = InitializeNonLocal                   : 
+#  166|         valnum = unique
+#  166|     m166_4(unknown)                              = Chi                                  : total:m166_2, partial:m166_3
+#  166|         valnum = unique
+#  167|     r167_1(glval<StructWithConstMemberFunction>) = VariableAddress[s]                   : 
+#  167|         valnum = r167_1, r168_2, r169_1
+#  167|     m167_2(StructWithConstMemberFunction)        = Uninitialized[s]                     : &:r167_1
+#  167|         valnum = m167_2, m168_4, r168_3
+#  167|     m167_3(unknown)                              = Chi                                  : total:m166_4, partial:m167_2
+#  167|         valnum = unique
+#  168|     r168_1(glval<StructWithConstMemberFunction>) = VariableAddress[s2]                  : 
+#  168|         valnum = unique
+#  168|     r168_2(glval<StructWithConstMemberFunction>) = VariableAddress[s]                   : 
+#  168|         valnum = r167_1, r168_2, r169_1
+#  168|     r168_3(StructWithConstMemberFunction)        = Load[s]                              : &:r168_2, m167_2
+#  168|         valnum = m167_2, m168_4, r168_3
+#  168|     m168_4(StructWithConstMemberFunction)        = Store[s2]                            : &:r168_1, r168_3
+#  168|         valnum = m167_2, m168_4, r168_3
+#  169|     r169_1(glval<StructWithConstMemberFunction>) = VariableAddress[s]                   : 
+#  169|         valnum = r167_1, r168_2, r169_1
+#  169|     r169_2(glval<StructWithConstMemberFunction>) = Convert                              : r169_1
+#  169|         valnum = unique
+#  169|     r169_3(glval<unknown>)                       = FunctionAddress[constMemberFunction] : 
+#  169|         valnum = unique
+#  169|     v169_4(void)                                 = Call[constMemberFunction]            : func:r169_3, this:r169_2
+#  169|     m169_5(unknown)                              = ^CallSideEffect                      : ~m167_3
+#  169|         valnum = unique
+#  169|     m169_6(unknown)                              = Chi                                  : total:m167_3, partial:m169_5
+#  169|         valnum = unique
+#  169|     v169_7(void)                                 = ^IndirectReadSideEffect[-1]          : &:r169_2, ~m169_6
+#  170|     v170_1(void)                                 = NoOp                                 : 
+#  166|     v166_5(void)                                 = ReturnVoid                           : 
+#  166|     v166_6(void)                                 = AliasedUse                           : ~m169_6
+#  166|     v166_7(void)                                 = ExitFunction                         : 

--- a/cpp/ql/test/library-tests/valuenumbering/GlobalValueNumbering/test.cpp
+++ b/cpp/ql/test/library-tests/valuenumbering/GlobalValueNumbering/test.cpp
@@ -157,3 +157,14 @@ void test_read_global_different(int n) {
 
   int d = global_a->x;
 }
+
+struct StructWithConstMemberFunction {
+  int x;
+  void constMemberFunction() const;
+};
+
+void test_constMemberFunction() {
+  StructWithConstMemberFunction s;
+  StructWithConstMemberFunction s2 = s;
+  s.constMemberFunction();
+}

--- a/cpp/ql/test/query-tests/Likely Bugs/Memory Management/StrncpyFlippedArgs/StrncpyFlippedArgs.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Memory Management/StrncpyFlippedArgs/StrncpyFlippedArgs.expected
@@ -13,7 +13,6 @@
 | test.cpp:49:2:49:9 | call to strcpy_s | Potentially unsafe call to strcpy_s; second argument should be size of destination. |
 | test.cpp:62:3:62:9 | call to strncpy | Potentially unsafe call to strncpy; third argument should be size of destination. |
 | test.cpp:65:3:65:9 | call to strncpy | Potentially unsafe call to strncpy; third argument should be size of destination. |
-| test.cpp:70:2:70:8 | call to strncpy | Potentially unsafe call to strncpy; third argument should be size of destination. |
 | test.cpp:81:3:81:9 | call to strncpy | Potentially unsafe call to strncpy; third argument should be size of destination. |
 | test.cpp:84:3:84:9 | call to strncpy | Potentially unsafe call to strncpy; third argument should be size of destination. |
 | test.cpp:105:2:105:10 | call to wcsxfrm_l | Potentially unsafe call to wcsxfrm_l; third argument should be size of destination. |


### PR DESCRIPTION
Consider the following snippet:
```cpp
struct S {
  void foo() const;
  void bar();
};

void test() {
  S s;
  s.foo();
  s.bar();
}
```
Because `foo` is a `const` member function there will be a `GlvalueConversion` which converts the qualifier from a `glval<S>` to a `glval<const S>` before it's passed to `foo`. This conversion will generate a `Convert` instruction.

However, since `bar` isn't a `const` member function there won't be a `Convert` instruction, and so global value numbering (GVN) concludes that the two qualifiers won't necessarily evaluate to the same value at runtime (although, they obviously will).

This PR modifies GVN so that conversions that only modify specifiers receive the same global value number.

Commit-by-commit review recommended.

There was 1 query test change (see 099e00715fb3a5f1675fb4693a9a33be2ea98f70) which fixes a false positive. I went digging a bit into when that FP was introduced, and it turns out this was all the way back in https://github.com/github/codeql/pull/2851 when we put the IR into production (i.e., when we replaced the AST-based GVN with the IR-based GVN)!

DCA was uneventful.