### PR TITLE
Rust: Fix two bad joins introduced by magic

### DIFF
--- a/rust/ql/lib/codeql/rust/internal/TypeInference.qll
+++ b/rust/ql/lib/codeql/rust/internal/TypeInference.qll
@@ -1495,6 +1495,7 @@ private TypePath closureReturnPath() {
 }
 
 /** Gets the path to a closure with arity `arity`s `index`th parameter type. */
+pragma[nomagic]
 private TypePath closureParameterPath(int arity, int index) {
   result =
     TypePath::cons(TDynTraitTypeParameter(any(FnOnceTrait t).getTypeParam()),
@@ -1510,6 +1511,7 @@ private TypePath fnReturnPath() {
  * Gets the path to the parameter type of the `FnOnce` trait with arity `arity`
  * and index `index`.
  */
+pragma[nomagic]
 private TypePath fnParameterPath(int arity, int index) {
   result =
     TypePath::cons(TTypeParamTypeParameter(any(FnOnceTrait t).getTypeParam()),


### PR DESCRIPTION
```
Evaluated relational algebra for predicate TypeInference::closureParameterPath/2#9d0bf423#bbf@ba08cc1s with tuple counts:
           565067    ~172652%    {2} r1 = JOIN `Callable::Callable.getParam/1#dispred#ce0254b3_01#count_range` WITH `Callable::Generated::Callable.getNumberOfParams/0#dispred#abb45996` ON FIRST 1 OUTPUT Rhs.1, Lhs.1
            24684     ~11784%    {3}    | JOIN WITH Type::TTupleTypeParameter#5ca17706 ON FIRST 2 OUTPUT Rhs.2, Lhs.1, Lhs.0
             2970      ~1391%    {3}    | JOIN WITH `TypeInference::TypePath::singleton/1#ee45de3b` ON FIRST 1 OUTPUT Lhs.1, Lhs.2, Rhs.1
              664       ~242%    {4}    | JOIN WITH `Stdlib::FnOnceTrait.getTypeParam/0#dispred#93f20bbc` CARTESIAN PRODUCT OUTPUT Rhs.1, Lhs.0, Lhs.1, Lhs.2
              303        ~49%    {4}    | JOIN WITH Type::TDynTraitTypeParameter#e16268df ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3
              198         ~0%    {8}    | JOIN WITH `TypeInference::TypePath::singleton/1#ee45de3b` ON FIRST 1 OUTPUT Lhs.1, Lhs.2, _, _, Rhs.1, Lhs.3, _, _
                                 {4}    | REWRITE WITH Out.2 := (In.4 ++ In.5), Tmp.3 := (In.4 ++ In.5), Tmp.6 := "[0-9]+", Tmp.7 := "", Out.3 := regexpReplaceAll(Tmp.3,Tmp.6,Tmp.7) KEEPING 4
              198         ~0%    {6}    | SCAN OUTPUT In.0, In.1, In.2, _, In.3, _
                                 {4}    | REWRITE WITH Out.3 := length(In.4), Tmp.5 := 10, TEST Out.3 <= Tmp.5 KEEPING 4
              198         ~0%    {3}    | SCAN OUTPUT In.1, In.0, In.2

           877984   ~1444714%    {1} r2 = SCAN `CallExprBase::CallExprBase.getArg/1#dispred#d775f13d` OUTPUT In.1
           299888     ~83707%    {3}    | JOIN WITH Type::TTupleTypeParameter#5ca17706_102#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.0, Rhs.2
        515462762     ~59140%    {4}    | JOIN WITH `CallExprBase::Generated::CallExprBase.getNumberOfArgs/0#dispred#0975fe12_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.0, Lhs.2
          9429188  ~25728933%    {3}    | JOIN WITH TypeInference::InvokedClosureExpr#24e5dacb_1#join_rhs ON FIRST 1 OUTPUT Lhs.3, Lhs.1, Lhs.2
            53669    ~142315%    {3}    | JOIN WITH `TypeInference::TypePath::singleton/1#ee45de3b` ON FIRST 1 OUTPUT Lhs.1, Lhs.2, Rhs.1
             4003     ~10522%    {4}    | JOIN WITH `Stdlib::FnOnceTrait.getTypeParam/0#dispred#93f20bbc` CARTESIAN PRODUCT OUTPUT Rhs.1, Lhs.0, Lhs.1, Lhs.2
              370       ~910%    {4}    | JOIN WITH Type::TDynTraitTypeParameter#e16268df ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3
              148       ~293%    {8}    | JOIN WITH `TypeInference::TypePath::singleton/1#ee45de3b` ON FIRST 1 OUTPUT Lhs.1, Lhs.2, _, _, Rhs.1, Lhs.3, _, _
                                 {4}    | REWRITE WITH Out.2 := (In.4 ++ In.5), Tmp.3 := (In.4 ++ In.5), Tmp.6 := "[0-9]+", Tmp.7 := "", Out.3 := regexpReplaceAll(Tmp.3,Tmp.6,Tmp.7) KEEPING 4
              148       ~316%    {6}    | SCAN OUTPUT In.0, In.1, In.2, _, In.3, _
                                 {4}    | REWRITE WITH Out.3 := length(In.4), Tmp.5 := 10, TEST Out.3 <= Tmp.5 KEEPING 4
              148       ~293%    {3}    | SCAN OUTPUT In.1, In.0, In.2

              346        ~75%    {3} r3 = r1 UNION r2
                                 return r3
```

and

```
Evaluated relational algebra for predicate TypeInference::fnParameterPath/2#4dea2880#bbf@d56000vi with tuple counts:
                1         ~0%    {1} r1 = SCAN `Stdlib::FnOnceTrait.getTypeParam/0#dispred#93f20bbc` OUTPUT In.1
                1         ~0%    {1}    | JOIN WITH Type::TTypeParamTypeParameter#868c69a5 ON FIRST 1 OUTPUT Rhs.1
                1         ~0%    {1}    | JOIN WITH `TypeInference::TypePath::singleton/1#ee45de3b` ON FIRST 1 OUTPUT Rhs.1
           877984   ~1350201%    {2}    | JOIN WITH `ArgList::Generated::ArgList.getArg/1#dispred#b07adc80` CARTESIAN PRODUCT OUTPUT Rhs.1, Lhs.0
           321252     ~90755%    {4}    | JOIN WITH Type::TTupleTypeParameter#5ca17706_102#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.0, Rhs.2
        553043191     ~65412%    {5}    | JOIN WITH `CallExprBase::Generated::CallExprBase.getNumberOfArgs/0#dispred#0975fe12_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.0, Lhs.3
         10089088  ~26772053%    {4}    | JOIN WITH TypeInference::InvokedClosureExpr#24e5dacb_1#join_rhs ON FIRST 1 OUTPUT Lhs.4, Lhs.1, Lhs.2, Lhs.3
            57729    ~157423%    {8}    | JOIN WITH `TypeInference::TypePath::singleton/1#ee45de3b` ON FIRST 1 OUTPUT Lhs.2, Lhs.3, _, _, Lhs.1, Rhs.1, _, _
                                 {4}    | REWRITE WITH Out.2 := (In.4 ++ In.5), Tmp.3 := (In.4 ++ In.5), Tmp.6 := "[0-9]+", Tmp.7 := "", Out.3 := regexpReplaceAll(Tmp.3,Tmp.6,Tmp.7) KEEPING 4
            57729    ~157423%    {6}    | SCAN OUTPUT In.0, In.1, In.2, _, In.3, _
                                 {4}    | REWRITE WITH Out.3 := length(In.4), Tmp.5 := 10, TEST Out.3 <= Tmp.5 KEEPING 4
            57729    ~157423%    {3}    | SCAN OUTPUT In.1, In.0, In.2
                                 return r1
```