### PR TITLE
Rust: Fix bad join

### DIFF
--- a/rust/ql/lib/codeql/rust/internal/PathResolution.qll
+++ b/rust/ql/lib/codeql/rust/internal/PathResolution.qll
@@ -1464,6 +1464,18 @@ private predicate externCrateEdge(ExternCrateItemNode ec, string name, CrateItem
   )
 }
 
+pragma[nomagic]
+private predicate preludeItem(string name, ItemNode i) {
+  exists(Crate stdOrCore, ModuleLikeNode mod, ModuleItemNode prelude, ModuleItemNode rust |
+    stdOrCore.getName() = ["std", "core"] and
+    mod = stdOrCore.getSourceFile() and
+    prelude = mod.getASuccessorRec("prelude") and
+    rust = prelude.getASuccessorRec(["rust_2015", "rust_2018", "rust_2021", "rust_2024"]) and
+    i = rust.getASuccessorRec(name) and
+    not i instanceof Use
+  )
+}
+
 /**
  * Holds if `i` is available inside `f` because it is reexported in
  * [the `core` prelude][1] or [the `std` prelude][2].
@@ -1476,15 +1488,8 @@ private predicate externCrateEdge(ExternCrateItemNode ec, string name, CrateItem
  */
 pragma[nomagic]
 private predicate preludeEdge(SourceFile f, string name, ItemNode i) {
-  not declares(f, _, name) and
-  exists(Crate stdOrCore, ModuleLikeNode mod, ModuleItemNode prelude, ModuleItemNode rust |
-    stdOrCore.getName() = ["std", "core"] and
-    mod = stdOrCore.getSourceFile() and
-    prelude = mod.getASuccessorRec("prelude") and
-    rust = prelude.getASuccessorRec(["rust_2015", "rust_2018", "rust_2021", "rust_2024"]) and
-    i = rust.getASuccessorRec(name) and
-    not i instanceof Use
-  )
+  preludeItem(name, i) and
+  not declares(f, _, name)
 }
 
 pragma[nomagic]


### PR DESCRIPTION
```
Evaluated relational algebra for predicate _Crate::Crate.getSourceFile/0#dispred#e7adf9d7_Crate::Generated::Crate.getName/0#dispred#f4d3b3bf_Pa__#join_rhs@5a04a7t0 with tuple counts:
        34471980   ~0%    {3} r1 = JOIN `PathResolution::isSourceFile/1#803de032` WITH `Crate::Crate.getSourceFile/0#dispred#e7adf9d7` CARTESIAN PRODUCT OUTPUT Rhs.0, Lhs.0, Rhs.1
        34471980  ~37%    {4}    | JOIN WITH `Crate::Generated::Crate.getName/0#dispred#f4d3b3bf` ON FIRST 1 OUTPUT Lhs.1, Lhs.2, Rhs.1, _
                          {3}    | REWRITE WITH NOT [Tmp.3 := "std", TEST InOut.2 != Tmp.3, Tmp.3 := "core", TEST InOut.2 != Tmp.3] KEEPING 3
           93420  ~91%    {3}    | SCAN OUTPUT In.1, _, In.0
           93420  ~87%    {3}    | REWRITE WITH Out.1 := "prelude"
                          return r1
```