### PR TITLE
Rust: Clean up some odds and ends

### DIFF
--- a/rust/ql/lib/codeql/rust/dataflow/internal/ModelsAsData.qll
+++ b/rust/ql/lib/codeql/rust/dataflow/internal/ModelsAsData.qll
@@ -68,9 +68,8 @@ extensible predicate sourceModel(
  *
  * For example, `input = Argument[0]` means the first argument of the call.
  *
- * The following kinds are supported:
- *
- * - `sql-injection`: a flow sink for SQL injection.
+ * The sink kinds supported by queries can be found by searching for uses of
+ * the `sinkNode` predicate.
  */
 extensible predicate sinkModel(
   string path, string input, string kind, string provenance, QlBuiltins::ExtensionId madId

--- a/rust/ql/lib/codeql/rust/security/CleartextLoggingExtensions.qll
+++ b/rust/ql/lib/codeql/rust/security/CleartextLoggingExtensions.qll
@@ -40,6 +40,6 @@ module CleartextLogging {
    * A sink for logging from model data.
    */
   private class ModelsAsDataSink extends Sink {
-    ModelsAsDataSink() { exists(string s | sinkNode(this, s) and s.matches("log-injection%")) }
+    ModelsAsDataSink() { sinkNode(this, "log-injection") }
   }
 }

--- a/rust/ql/src/queries/security/CWE-311/CleartextTransmission.ql
+++ b/rust/ql/src/queries/security/CWE-311/CleartextTransmission.ql
@@ -48,6 +48,6 @@ import CleartextTransmissionFlow::PathGraph
 from CleartextTransmissionFlow::PathNode sourceNode, CleartextTransmissionFlow::PathNode sinkNode
 where CleartextTransmissionFlow::flowPath(sourceNode, sinkNode)
 select sinkNode.getNode(), sourceNode, sinkNode,
-  "The operation '" + sinkNode.getNode().toString() +
-    "', transmits data which may contain unencrypted sensitive data from $@.", sourceNode,
+  "This '" + sinkNode.getNode().toString() +
+    "' operation transmits data which may contain unencrypted sensitive data from $@.", sourceNode,
   sourceNode.getNode().toString()

--- a/rust/ql/test/query-tests/security/CWE-311/CleartextTransmission.expected
+++ b/rust/ql/test/query-tests/security/CWE-311/CleartextTransmission.expected
@@ -1,9 +1,9 @@
 #select
-| main.rs:7:5:7:26 | ...::get | main.rs:6:50:6:57 | password | main.rs:7:5:7:26 | ...::get | The operation '...::get', transmits data which may contain unencrypted sensitive data from $@. | main.rs:6:50:6:57 | password | password |
-| main.rs:14:5:14:26 | ...::get | main.rs:12:50:12:57 | password | main.rs:14:5:14:26 | ...::get | The operation '...::get', transmits data which may contain unencrypted sensitive data from $@. | main.rs:12:50:12:57 | password | password |
-| main.rs:21:12:21:15 | post | main.rs:19:50:19:57 | password | main.rs:21:12:21:15 | post | The operation 'post', transmits data which may contain unencrypted sensitive data from $@. | main.rs:19:50:19:57 | password | password |
-| main.rs:28:12:28:18 | request | main.rs:26:50:26:57 | password | main.rs:28:12:28:18 | request | The operation 'request', transmits data which may contain unencrypted sensitive data from $@. | main.rs:26:50:26:57 | password | password |
-| main.rs:35:12:35:18 | request | main.rs:33:50:33:57 | password | main.rs:35:12:35:18 | request | The operation 'request', transmits data which may contain unencrypted sensitive data from $@. | main.rs:33:50:33:57 | password | password |
+| main.rs:7:5:7:26 | ...::get | main.rs:6:50:6:57 | password | main.rs:7:5:7:26 | ...::get | This '...::get' operation transmits data which may contain unencrypted sensitive data from $@. | main.rs:6:50:6:57 | password | password |
+| main.rs:14:5:14:26 | ...::get | main.rs:12:50:12:57 | password | main.rs:14:5:14:26 | ...::get | This '...::get' operation transmits data which may contain unencrypted sensitive data from $@. | main.rs:12:50:12:57 | password | password |
+| main.rs:21:12:21:15 | post | main.rs:19:50:19:57 | password | main.rs:21:12:21:15 | post | This 'post' operation transmits data which may contain unencrypted sensitive data from $@. | main.rs:19:50:19:57 | password | password |
+| main.rs:28:12:28:18 | request | main.rs:26:50:26:57 | password | main.rs:28:12:28:18 | request | This 'request' operation transmits data which may contain unencrypted sensitive data from $@. | main.rs:26:50:26:57 | password | password |
+| main.rs:35:12:35:18 | request | main.rs:33:50:33:57 | password | main.rs:35:12:35:18 | request | This 'request' operation transmits data which may contain unencrypted sensitive data from $@. | main.rs:33:50:33:57 | password | password |
 edges
 | main.rs:6:9:6:11 | url | main.rs:7:28:7:30 | url | provenance |  |
 | main.rs:6:15:6:58 | res | main.rs:6:23:6:57 | { ... } | provenance |  |


### PR DESCRIPTION
Clean up some odds and ends:
- address a maintainability issue in the QLDoc for the `sinkModel` predicate.
- remove unnecessary pattern matching in `CleartextLoggingExtensions.qll`.
- reword the alert message for `rust/cleartext-transmission` to be more consistent with similar Rust and non-Rust queries.