### PR TITLE
Rust: Unify type inference for tuple indexing expressions

### DIFF
--- a/rust/ql/lib/codeql/rust/internal/Type.qll
+++ b/rust/ql/lib/codeql/rust/internal/Type.qll
@@ -119,7 +119,7 @@ class TupleType extends Type, TTuple {
 }
 
 /** The unit type `()`. */
-class UnitType extends TupleType, TTuple {
+class UnitType extends TupleType {
   UnitType() { this = TTuple(0) }
 
   override string toString() { result = "()" }

--- a/rust/ql/test/library-tests/type-inference/main.rs
+++ b/rust/ql/test/library-tests/type-inference/main.rs
@@ -2487,7 +2487,7 @@ mod tuples {
         let x = pair.0; // $ type=x:i32
 
         let y = &S1::get_pair(); // $ target=get_pair
-        y.0.foo(); // $ MISSING: target=foo
+        y.0.foo(); // $ target=foo
     }
 }
 

--- a/rust/ql/test/library-tests/type-inference/type-inference.expected
+++ b/rust/ql/test/library-tests/type-inference/type-inference.expected
@@ -4856,6 +4856,7 @@ inferType
 | main.rs:2490:9:2490:9 | y | &T | file://:0:0:0:0 | (T_2) |
 | main.rs:2490:9:2490:9 | y | &T.0(2) | main.rs:2447:5:2448:16 | S1 |
 | main.rs:2490:9:2490:9 | y | &T.1(2) | main.rs:2447:5:2448:16 | S1 |
+| main.rs:2490:9:2490:11 | y.0 |  | main.rs:2447:5:2448:16 | S1 |
 | main.rs:2497:13:2497:23 | boxed_value |  | {EXTERNAL LOCATION} | Box |
 | main.rs:2497:13:2497:23 | boxed_value | A | {EXTERNAL LOCATION} | Global |
 | main.rs:2497:13:2497:23 | boxed_value | T | {EXTERNAL LOCATION} | i32 |


### PR DESCRIPTION
This PR adresses the comment https://github.com/github/codeql/pull/20041/files#r2207752592, i.e. type inference for _all_ field expressions, `x.i`, are treated uniformly, regardless of whether the type of `x` is a tuple or a tuple struct/enum.