### PR TITLE
Java: Enable BarrierGuard wrappers

### DIFF
--- a/java/ql/lib/semmle/code/java/Member.qll
+++ b/java/ql/lib/semmle/code/java/Member.qll
@@ -256,7 +256,15 @@ class Callable extends StmtParent, Member, @callable {
   Exception getAnException() { exceptions(result, _, this) }
 
   /** Gets an exception type that occurs in the `throws` clause of this callable. */
-  RefType getAThrownExceptionType() { result = this.getAnException().getType() }
+  RefType getAThrownExceptionType() {
+    result = this.getAnException().getType()
+    or
+    exists(Annotation a |
+      this.getAnAnnotation() = a and
+      a.getType().hasQualifiedName("kotlin.jvm", "Throws") and
+      a.getATypeArrayValue(_) = result
+    )
+  }
 
   /** Gets a call site that references this callable. */
   Call getAReference() { result.getCallee() = this }

--- a/java/ql/lib/semmle/code/java/controlflow/Guards.qll
+++ b/java/ql/lib/semmle/code/java/controlflow/Guards.qll
@@ -490,12 +490,6 @@ module Guards_v2 = GuardsImpl::Logic<LogicInput_v2>;
 /** INTERNAL: Don't use. */
 module Guards_v3 = GuardsImpl::Logic<LogicInput_v3>;
 
-/** INTERNAL: Don't use. */
-predicate implies_v3(Guard g1, boolean b1, Guard g2, boolean b2) {
-  Guards_v3::boolImplies(g1, any(GuardValue v | v.asBooleanValue() = b1), g2,
-    any(GuardValue v | v.asBooleanValue() = b2))
-}
-
 /**
  * A guard. This may be any expression whose value determines subsequent
  * control flow. It may also be a switch case, which as a guard is considered

--- a/java/ql/lib/semmle/code/java/dataflow/internal/SsaImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/SsaImpl.qll
@@ -567,13 +567,15 @@ private module Cached {
       }
 
       private predicate guardChecksWithWrappers(
-        DataFlowIntegrationInput::Guard g, DataFlowIntegrationInput::Expr e, Guards::GuardValue val
+        DataFlowIntegrationInput::Guard g, Definition def, Guards::GuardValue val, Unit state
       ) {
-        Guards::Guards_v3::ValidationWrapper<guardChecksAdjTypes/3>::guardChecks(g, e, val)
+        Guards::Guards_v3::ValidationWrapper<guardChecksAdjTypes/3>::guardChecksDef(g, def, val) and
+        exists(state)
       }
 
       private Node getABarrierNodeImpl() {
-        result = DataFlowIntegrationImpl::BarrierGuard<guardChecksWithWrappers/3>::getABarrierNode()
+        result =
+          DataFlowIntegrationImpl::BarrierGuardDefWithState<Unit, guardChecksWithWrappers/4>::getABarrierNode(_)
       }
 
       predicate getABarrierNode = getABarrierNodeImpl/0;

--- a/java/ql/lib/semmle/code/java/dataflow/internal/SsaImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/SsaImpl.qll
@@ -562,14 +562,18 @@ private module Cached {
 
     cached // nothing is actually cached
     module BarrierGuard<guardChecksSig/3 guardChecks> {
-      private predicate guardChecksAdjTypes(
+      private predicate guardChecksAdjTypes(Guards::Guards_v3::Guard g, Expr e, boolean branch) {
+        guardChecks(g, e, branch)
+      }
+
+      private predicate guardChecksWithWrappers(
         DataFlowIntegrationInput::Guard g, DataFlowIntegrationInput::Expr e, Guards::GuardValue val
       ) {
-        guardChecks(g, e, val.asBooleanValue())
+        Guards::Guards_v3::ValidationWrapper<guardChecksAdjTypes/3>::guardChecks(g, e, val)
       }
 
       private Node getABarrierNodeImpl() {
-        result = DataFlowIntegrationImpl::BarrierGuard<guardChecksAdjTypes/3>::getABarrierNode()
+        result = DataFlowIntegrationImpl::BarrierGuard<guardChecksWithWrappers/3>::getABarrierNode()
       }
 
       predicate getABarrierNode = getABarrierNodeImpl/0;

--- a/shared/controlflow/codeql/controlflow/Guards.qll
+++ b/shared/controlflow/codeql/controlflow/Guards.qll
@@ -935,18 +935,6 @@ module Make<LocationSig Location, InputSig<Location> Input> {
       }
     }
 
-    private predicate booleanGuard(Guard guard, GuardValue val) {
-      exists(guard) and exists(val.asBooleanValue())
-    }
-
-    private module BooleanImplies = ImpliesTC<booleanGuard/2>;
-
-    /** INTERNAL: Don't use. */
-    predicate boolImplies(Guard g1, GuardValue v1, Guard g2, GuardValue v2) {
-      BooleanImplies::guardControls(g2, v2, g1, v1) and
-      g2 != g1
-    }
-
     /**
      * Holds if `guard` evaluating to `v` implies that `e` is guaranteed to be
      * null if `isNull` is true, and non-null if `isNull` is false.

--- a/shared/controlflow/codeql/controlflow/Guards.qll
+++ b/shared/controlflow/codeql/controlflow/Guards.qll
@@ -1130,10 +1130,10 @@ module Make<LocationSig Location, InputSig<Location> Input> {
       private module StatefulWrapper = ValidationWrapperWithState<Unit, guardChecksWithState/4>;
 
       /**
-       * Holds if the guard `g` validates the expression `e` upon evaluating to `val`.
+       * Holds if the guard `g` validates the SSA definition `def` upon evaluating to `val`.
        */
-      predicate guardChecks(Guard g, Expr e, GuardValue val) {
-        StatefulWrapper::guardChecks(g, e, val, _)
+      predicate guardChecksDef(Guard g, SsaDefinition def, GuardValue val) {
+        StatefulWrapper::guardChecksDef(g, def, val, _)
       }
     }
 
@@ -1156,7 +1156,7 @@ module Make<LocationSig Location, InputSig<Location> Input> {
         exists(NonOverridableMethod m, SsaDefinition param, Guard guard, GuardValue val |
           m.getAReturnExpr() = ret and
           parameterDefinition(m.getParameter(ppos), param) and
-          guardChecks(guard, param.getARead(), val, state)
+          guardChecksDef(guard, param, val, state)
         |
           guard.valueControls(ret.getBasicBlock(), val) and
           relevantReturnValue(m, retval)
@@ -1185,7 +1185,7 @@ module Make<LocationSig Location, InputSig<Location> Input> {
         or
         exists(SsaDefinition param, BasicBlock bb, Guard guard, GuardValue val |
           parameterDefinition(result.getParameter(ppos), param) and
-          guardChecks(guard, param.getARead(), val, state) and
+          guardChecksDef(guard, param, val, state) and
           guard.valueControls(bb, val) and
           normalExitBlock(bb) and
           retval = TException(false)
@@ -1195,7 +1195,7 @@ module Make<LocationSig Location, InputSig<Location> Input> {
       /**
        * Holds if the guard `g` validates the expression `e` upon evaluating to `val`.
        */
-      predicate guardChecks(Guard g, Expr e, GuardValue val, State state) {
+      private predicate guardChecks(Guard g, Expr e, GuardValue val, State state) {
         guardChecks0(g, e, val.asBooleanValue(), state)
         or
         exists(NonOverridableMethodCall call, ParameterPosition ppos, ArgumentPosition apos |
@@ -1203,6 +1203,16 @@ module Make<LocationSig Location, InputSig<Location> Input> {
           call.getMethod() = validationWrapper(ppos, val, state) and
           call.getArgument(apos) = e and
           parameterMatch(pragma[only_bind_out](ppos), pragma[only_bind_out](apos))
+        )
+      }
+
+      /**
+       * Holds if the guard `g` validates the SSA definition `def` upon evaluating to `val`.
+       */
+      predicate guardChecksDef(Guard g, SsaDefinition def, GuardValue val, State state) {
+        exists(Expr e |
+          guardChecks(g, e, val, state) and
+          guardReadsSsaVar(e, def)
         )
       }
     }


### PR DESCRIPTION
This enables the Guards library wrapper guard integration with BarrierGuard such that data flow sanitizers make use of the full power of the Guards library including wrapped validation checks.

Some individual barriers had ad-hoc support for this, which can now be deleted as it becomes superfluous.