### PR TITLE
Rust: Add rust/diagnostics/type-inference-consistency-counts.

### DIFF
--- a/rust/ql/integration-tests/query-suite/rust-code-scanning.qls.expected
+++ b/rust/ql/integration-tests/query-suite/rust-code-scanning.qls.expected
@@ -5,6 +5,7 @@ ql/rust/ql/src/queries/diagnostics/ExtractedFiles.ql
 ql/rust/ql/src/queries/diagnostics/ExtractionErrors.ql
 ql/rust/ql/src/queries/diagnostics/ExtractionWarnings.ql
 ql/rust/ql/src/queries/diagnostics/SsaConsistencyCounts.ql
+ql/rust/ql/src/queries/diagnostics/TypeInferenceConsistencyCounts.ql
 ql/rust/ql/src/queries/diagnostics/UnextractedElements.ql
 ql/rust/ql/src/queries/diagnostics/UnresolvedMacroCalls.ql
 ql/rust/ql/src/queries/security/CWE-020/RegexInjection.ql

--- a/rust/ql/integration-tests/query-suite/rust-security-and-quality.qls.expected
+++ b/rust/ql/integration-tests/query-suite/rust-security-and-quality.qls.expected
@@ -5,6 +5,7 @@ ql/rust/ql/src/queries/diagnostics/ExtractedFiles.ql
 ql/rust/ql/src/queries/diagnostics/ExtractionErrors.ql
 ql/rust/ql/src/queries/diagnostics/ExtractionWarnings.ql
 ql/rust/ql/src/queries/diagnostics/SsaConsistencyCounts.ql
+ql/rust/ql/src/queries/diagnostics/TypeInferenceConsistencyCounts.ql
 ql/rust/ql/src/queries/diagnostics/UnextractedElements.ql
 ql/rust/ql/src/queries/diagnostics/UnresolvedMacroCalls.ql
 ql/rust/ql/src/queries/security/CWE-020/RegexInjection.ql

--- a/rust/ql/integration-tests/query-suite/rust-security-extended.qls.expected
+++ b/rust/ql/integration-tests/query-suite/rust-security-extended.qls.expected
@@ -5,6 +5,7 @@ ql/rust/ql/src/queries/diagnostics/ExtractedFiles.ql
 ql/rust/ql/src/queries/diagnostics/ExtractionErrors.ql
 ql/rust/ql/src/queries/diagnostics/ExtractionWarnings.ql
 ql/rust/ql/src/queries/diagnostics/SsaConsistencyCounts.ql
+ql/rust/ql/src/queries/diagnostics/TypeInferenceConsistencyCounts.ql
 ql/rust/ql/src/queries/diagnostics/UnextractedElements.ql
 ql/rust/ql/src/queries/diagnostics/UnresolvedMacroCalls.ql
 ql/rust/ql/src/queries/security/CWE-020/RegexInjection.ql

--- a/rust/ql/src/queries/diagnostics/TypeInferenceConsistencyCounts.ql
+++ b/rust/ql/src/queries/diagnostics/TypeInferenceConsistencyCounts.ql
@@ -1,0 +1,14 @@
+/**
+ * @name Type inference inconsistency counts
+ * @description Counts the number of type inference inconsistencies of each type.  This query is intended for internal use.
+ * @kind diagnostic
+ * @id rust/diagnostics/type-inference-consistency-counts
+ */
+
+private import codeql.rust.internal.TypeInferenceConsistency as Consistency
+
+// see also `rust/diagnostics/type-inference-consistency`, which lists the
+// individual inconsistency results.
+from string type, int num
+where num = Consistency::getTypeInferenceInconsistencyCounts(type)
+select type, num


### PR DESCRIPTION
Add `rust/diagnostics/type-inference-consistency-counts`.  We have one of these for each of the other inconsistency types, to aid debugging.