### PR TITLE
Rust: Remove source/library deduplication in path resolution

### DIFF
--- a/rust/ql/lib/codeql/rust/internal/CachedStages.qll
+++ b/rust/ql/lib/codeql/rust/internal/CachedStages.qll
@@ -120,7 +120,7 @@ module Stages {
       or
       exists(resolvePath(_))
       or
-      exists(any(ItemNode i).getASuccessorFull(_))
+      exists(any(ItemNode i).getASuccessor(_))
       or
       exists(any(ItemNode i).getASuccessorRec(_))
       or


### PR DESCRIPTION
Removes logic that was left over from when library code was not extracted as source code.