### PR TITLE
Java: use java 17 in `no-wrapper` tests

### DIFF
--- a/java/ql/integration-tests/java/android-sample-kotlin-build-script-no-wrapper/test.py
+++ b/java/ql/integration-tests/java/android-sample-kotlin-build-script-no-wrapper/test.py
@@ -1,2 +1,2 @@
-def test(codeql, use_java_11, java, android_sdk):
+def test(codeql, use_java_17, java, android_sdk):
     codeql.database.create()

--- a/java/ql/integration-tests/java/android-sample-no-wrapper/test.py
+++ b/java/ql/integration-tests/java/android-sample-no-wrapper/test.py
@@ -1,2 +1,2 @@
-def test(codeql, use_java_11, java, android_sdk):
+def test(codeql, use_java_17, java, android_sdk):
     codeql.database.create()

--- a/java/ql/integration-tests/java/android-sample-old-style-kotlin-build-script-no-wrapper/test.py
+++ b/java/ql/integration-tests/java/android-sample-old-style-kotlin-build-script-no-wrapper/test.py
@@ -1,2 +1,2 @@
-def test(codeql, use_java_11, java, android_sdk, actions_toolchains_file):
+def test(codeql, use_java_17, java, android_sdk, actions_toolchains_file):
     codeql.database.create(_env={"LGTM_INDEX_MAVEN_TOOLCHAINS_FILE": str(actions_toolchains_file)})

--- a/java/ql/integration-tests/java/android-sample-old-style-no-wrapper/test.py
+++ b/java/ql/integration-tests/java/android-sample-old-style-no-wrapper/test.py
@@ -1,2 +1,2 @@
-def test(codeql, use_java_11, java, android_sdk, actions_toolchains_file):
+def test(codeql, use_java_17, java, android_sdk, actions_toolchains_file):
     codeql.database.create(_env={"LGTM_INDEX_MAVEN_TOOLCHAINS_FILE": str(actions_toolchains_file)})


### PR DESCRIPTION
Gradle 9 requires Java 17.

(cherry picked from commit 72843b56e84b97117c785338417810a0cdec8f8d)