### PR TITLE
Go: Update Go version to 1.25.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -15,7 +15,7 @@ local_path_override(
 # see https://registry.bazel.build/ for a list of available packages
 
 bazel_dep(name = "platforms", version = "0.0.11")
-bazel_dep(name = "rules_go", version = "0.50.1")
+bazel_dep(name = "rules_go", version = "0.56.1")
 bazel_dep(name = "rules_pkg", version = "1.0.1")
 bazel_dep(name = "rules_nodejs", version = "6.2.0-codeql.1")
 bazel_dep(name = "rules_python", version = "0.40.0")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -263,7 +263,7 @@ use_repo(
 )
 
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
-go_sdk.download(version = "1.24.0")
+go_sdk.download(version = "1.25.0")
 
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//go/extractor:go.mod")

--- a/go/actions/test/action.yml
+++ b/go/actions/test/action.yml
@@ -4,7 +4,7 @@ inputs:
   go-test-version:
     description: Which Go version to use for running the tests
     required: false
-    default: "~1.24.0"
+    default: "~1.25.0"
   run-code-checks:
     description: Whether to run formatting, code and qhelp generation checks
     required: false

--- a/go/extractor/autobuilder/build-environment.go
+++ b/go/extractor/autobuilder/build-environment.go
@@ -12,7 +12,7 @@ import (
 )
 
 var minGoVersion = util.NewSemVer("1.11")
-var maxGoVersion = util.NewSemVer("1.24")
+var maxGoVersion = util.NewSemVer("1.25")
 
 type versionInfo struct {
 	goModVersion util.SemVer // The version of Go found in the go directive in the `go.mod` file.

--- a/go/extractor/go.mod
+++ b/go/extractor/go.mod
@@ -1,8 +1,8 @@
 module github.com/github/codeql-go/extractor
 
-go 1.24
+go 1.25
 
-toolchain go1.24.0
+toolchain go1.25.0
 
 // when updating this, run
 //    bazel run @rules_go//go -- mod tidy


### PR DESCRIPTION
The failure of Go Resolve Build Environment Tests looks expected. The test does pass on the internal PR (after workflow updates).

See the internal PR for a DCA experiment.