### PR TITLE
Add data extensions for remote tainted sources

### DIFF
--- a/java/ql/lib/ext/jakarta.servlet.http.model.yml
+++ b/java/ql/lib/ext/jakarta.servlet.http.model.yml
@@ -4,3 +4,15 @@ extensions:
       extensible: sourceModel
     data:
       - ["jakarta.servlet.http", "HttpServletRequest", True, "getServletPath", "", "", "ReturnValue", "remote", "manual"]
+      - ["jakarta.servlet.http", "HttpServletRequest", False, "getHeader", "(String)", "", "ReturnValue", "remote", "manual"]
+      - ["jakarta.servlet.http", "HttpServletRequest", False, "getHeaderNames", "()", "", "ReturnValue", "remote", "manual"]
+      - ["jakarta.servlet.http", "HttpServletRequest", False, "getHeaders", "(String)", "", "ReturnValue", "remote", "manual"]
+      - ["jakarta.servlet.http", "HttpServletRequest", False, "getParameter", "(String)", "", "ReturnValue", "remote", "manual"]
+      - ["jakarta.servlet.http", "HttpServletRequest", False, "getParameterMap", "()", "", "ReturnValue", "remote", "manual"]
+      - ["jakarta.servlet.http", "HttpServletRequest", False, "getParameterNames", "()", "", "ReturnValue", "remote", "manual"]
+      - ["jakarta.servlet.http", "HttpServletRequest", False, "getParameterValues", "(String)", "", "ReturnValue", "remote", "manual"]
+      - ["jakarta.servlet.http", "HttpServletRequest", False, "getPathInfo", "()", "", "ReturnValue", "remote", "manual"]
+      - ["jakarta.servlet.http", "HttpServletRequest", False, "getQueryString", "()", "", "ReturnValue", "remote", "manual"]
+      - ["jakarta.servlet.http", "HttpServletRequest", False, "getRemoteUser", "()", "", "ReturnValue", "remote", "manual"]
+      - ["jakarta.servlet.http", "HttpServletRequest", False, "getRequestURI", "()", "", "ReturnValue", "remote", "manual"]
+      - ["jakarta.servlet.http", "HttpServletRequest", False, "getRequestURL", "()", "", "ReturnValue", "remote", "manual"]

--- a/java/ql/lib/ext/jakarta.servlet.model.yml
+++ b/java/ql/lib/ext/jakarta.servlet.model.yml
@@ -1,6 +1,16 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
+      extensible: sourceModel
+    data:
+      - ["jakarta.servlet", "ServletRequest", False, "getInputStream", "()", "", "ReturnValue", "remote", "manual"]
+      - ["jakarta.servlet", "ServletRequest", False, "getParameter", "(String)", "", "ReturnValue", "remote", "manual"]
+      - ["jakarta.servlet", "ServletRequest", False, "getParameterMap", "()", "", "ReturnValue", "remote", "manual"]
+      - ["jakarta.servlet", "ServletRequest", False, "getParameterNames", "()", "", "ReturnValue", "remote", "manual"]
+      - ["jakarta.servlet", "ServletRequest", False, "getParameterValues", "(String)", "", "ReturnValue", "remote", "manual"]
+      - ["jakarta.servlet", "ServletRequest", False, "getReader", "()", "", "ReturnValue", "remote", "manual"]
+  - addsTo:
+      pack: codeql/java-all
       extensible: sinkModel
     data:
       - ["jakarta.servlet", "ServletContext", True, "getRequestDispatcher", "(String)", "", "Argument[0]", "url-forward", "manual"]


### PR DESCRIPTION
Add relevant APIs that are modeled as remote tainted sources under `javax.servlet.ServletRequest` and `javax.servlet.http.HttpServletRequest` for `jakarta.servlet.ServletRequest` and `jakarta.servlet.http.HttpServletRequest` as well. 