### PR TITLE
C++: Mark the write to `fprintf`'s 0'th argument as partial

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaImpl.qll
@@ -756,9 +756,9 @@ private predicate modeledFlowBarrier(Node n) {
     partialFlowFunc = call.getStaticCallTarget() and
     not partialFlowFunc.isPartialWrite(output)
   |
-    call.getStaticCallTarget().(DataFlow::DataFlowFunction).hasDataFlow(_, output)
+    partialFlowFunc.(DataFlow::DataFlowFunction).hasDataFlow(_, output)
     or
-    call.getStaticCallTarget().(Taint::TaintFunction).hasTaintFlow(_, output)
+    partialFlowFunc.(Taint::TaintFunction).hasTaintFlow(_, output)
   )
   or
   exists(Operand operand, Instruction instr, Node n0, int indirectionIndex |

--- a/cpp/ql/lib/semmle/code/cpp/models/interfaces/FormattingFunction.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/interfaces/FormattingFunction.qll
@@ -170,6 +170,16 @@ abstract class FormattingFunction extends ArrayFunction, TaintFunction {
       output.isParameterDeref(this.getOutputParameterIndex(_))
     )
   }
+
+  final override predicate isPartialWrite(FunctionOutput output) {
+    exists(int outputParameterIndex |
+      output.isParameterDeref(outputParameterIndex) and
+      // We require the output to be a stream since that definitely means that
+      // it's a partial write. If it's not a stream then it will most likely
+      // fill the whole buffer.
+      outputParameterIndex = this.getOutputParameterIndex(true)
+    )
+  }
 }
 
 /**

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -7767,6 +7767,10 @@ WARNING: module 'TaintTracking' has been deprecated and may be removed in future
 | taint.cpp:830:20:830:34 | call to indirect_source | taint.cpp:832:23:832:24 | in |  |
 | taint.cpp:831:15:831:17 | out | taint.cpp:832:18:832:20 | out |  |
 | taint.cpp:831:15:831:17 | out | taint.cpp:833:8:833:10 | out |  |
+| taint.cpp:841:21:841:35 | call to indirect_source | taint.cpp:842:11:842:12 | fp |  |
+| taint.cpp:841:21:841:35 | call to indirect_source | taint.cpp:843:16:843:17 | fp |  |
+| taint.cpp:842:11:842:12 | ref arg fp | taint.cpp:843:16:843:17 | fp |  |
+| taint.cpp:842:15:842:16 |  | taint.cpp:842:11:842:12 | ref arg fp | TAINT |
 | thread.cpp:10:27:10:27 | s | thread.cpp:10:27:10:27 | s |  |
 | thread.cpp:10:27:10:27 | s | thread.cpp:11:8:11:8 | s |  |
 | thread.cpp:14:26:14:26 | s | thread.cpp:15:8:15:8 | s |  |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
@@ -840,6 +840,6 @@ int f7(void)
 {
   FILE* fp = (FILE*)indirect_source();
   fprintf(fp, "");
-	indirect_sink(fp); // $ MISSING: ast,ir
+	indirect_sink(fp); // $ ir MISSING: ast
   return 0;
 }

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
@@ -832,3 +832,14 @@ void test_write_to_const_ptr_ptr() {
   take_const_ptr(out, in);
   sink(out); // $ SPURIOUS: ast
 }
+
+void indirect_sink(FILE *fp);
+int fprintf(FILE *fp, const char *format, ...);
+
+int f7(void)
+{
+  FILE* fp = (FILE*)indirect_source();
+  fprintf(fp, "");
+	indirect_sink(fp); // $ MISSING: ast,ir
+  return 0;
+}

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.ql
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.ql
@@ -117,6 +117,11 @@ module IRTest {
         call.getTarget().getName() = "sink" and
         [sink.asExpr(), sink.asIndirectExpr()] = call.getAnArgument()
       )
+      or
+      exists(FunctionCall call |
+        call.getTarget().getName() = "indirect_sink" and
+        sink.asIndirectExpr() = call.getAnArgument()
+      )
     }
 
     predicate isBarrier(DataFlow::Node barrier) {


### PR DESCRIPTION
This fixes a FN that @jketema noticed on the Coding Standards queries.

The new results in `cpp/non-constant-format` and `cpp/tainted-format-string` highlight some really weird code:
```cpp
#define die(fmt,args...) do { fprintf(stderr, fmt, ## args ); fflush(stderr); exit(-1); } while(0)
...
if(/*NEEDTMP &&*/ !(tmp = (unsigned char*)malloc(ns))) die(stderr, "malloc error\n");
```
We get new results on `stderr`. It took me a second to spot the issue, but it looks like `die` expands to:
```cpp
do { fprintf(stderr, stderr, "malloc error\n"); fflush(stderr); exit(-1); } 
```

Which seems very bad! So this looks like TPs 🎉