### PR TITLE
Rust: Take transitive dependencies into account when computing canonical paths

### DIFF
--- a/rust/ql/lib/codeql/rust/internal/PathResolution.qll
+++ b/rust/ql/lib/codeql/rust/internal/PathResolution.qll
@@ -615,7 +615,7 @@ class ImplItemNode extends ImplOrTraitItemNode instanceof Impl {
       if this.hasCanonicalPath(c2)
       then c1 = c2
       else (
-        c2 = c1.getADependency() or c1 = c2.getADependency()
+        c2 = c1.getADependency+() or c1 = c2.getADependency+()
       )
     )
   }


### PR DESCRIPTION
[DCA](https://github.com/github/codeql-dca-main/issues/30822) looks fine; not unexpected to have a few more path resolution inconsistencies, as we now compute more canonical paths, and hence more rows in `multipleCanonicalPaths`.