### PR TITLE
Bazel: do not force `lld` and fix `platforms` warning

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -33,10 +33,6 @@ common --@rules_dotnet//dotnet/settings:strict_deps=false
 # we only configure a nightly toolchain
 common --@rules_rust//rust/toolchain/channel=nightly
 
-# rust does not like the gold linker, while bazel does by default, so let's avoid using it
-common:linux --linkopt=-fuse-ld=lld
-common:macos --linkopt=-fuse-ld=lld
-
 # Reduce this eventually to empty, once we've fixed all our usages of java, and https://github.com/bazel-contrib/rules_go/issues/4193 is fixed
 common --incompatible_autoload_externally="+@rules_java,+@rules_shell"
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -14,7 +14,7 @@ local_path_override(
 
 # see https://registry.bazel.build/ for a list of available packages
 
-bazel_dep(name = "platforms", version = "0.0.11")
+bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "rules_go", version = "0.56.1")
 bazel_dep(name = "rules_pkg", version = "1.0.1")
 bazel_dep(name = "rules_nodejs", version = "6.2.0-codeql.1")


### PR DESCRIPTION
This was meant to avoid using `gold`, but `lld` might not be installed. Having `gold` installed results in the following warning:
```
warning: the gold linker is deprecated and has known bugs with Rust
  |
  = help: consider using LLD or ld from GNU binutils instead
```

* if a user sees this warning, they can provide the `lld` or whatever linker they prefer themselves, or make sure to uninstall `gold`
* in any case, this is not what we use for releasing (where we are sure we don't use `gold`).