### PR TITLE
rust integration test: use all output from codeql test run

### DIFF
--- a/rust/ql/integration-tests/qltest/test_qltest.py
+++ b/rust/ql/integration-tests/qltest/test_qltest.py
@@ -20,7 +20,7 @@ def test(codeql, rust, expected_files, dir):
     codeql.test.run(dir)
 
 def test_failing_cargo_check(codeql, rust):
-    out = codeql.test.run("failing_cargo_check", _assert_failure=True, _capture="stderr")
+    out = codeql.test.run("failing_cargo_check", _assert_failure=True, _capture="all")
     # TODO: QL test output redirection is currently broken on windows, leaving it up for follow-up work
     if not runs_on.windows:
         assert "requested cargo check failed" in out


### PR DESCRIPTION
The integration test expectes to find a certain phrase from the extractor repeated in the _stderr_ of `codeql test run`. However, that subcommand is about to start reproducing the extractor output as-is, which means the phrase will instead appear in _stdout_.

Change the integration test to capture all of the output, so it will keep passing across the change.