### PR TITLE
Rust: Include `getAttributeMacroExpansion` in `isInMacroExpansion`

### DIFF
--- a/rust/ql/lib/change-notes/2025-08-25-in-macro-expansion.md
+++ b/rust/ql/lib/change-notes/2025-08-25-in-macro-expansion.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Attribute macros are now taken into account when identifying macro-expanded code. This affects the queries `rust/unused-variable` and `rust/unused-value`, which exclude results in macro-expanded code.

--- a/rust/ql/lib/codeql/rust/elements/internal/MacroCallImpl.qll
+++ b/rust/ql/lib/codeql/rust/elements/internal/MacroCallImpl.qll
@@ -19,6 +19,8 @@ module Impl {
     or
     n = root.(Adt).getDeriveMacroExpansion(_)
     or
+    n = root.(Item).getAttributeMacroExpansion()
+    or
     isInMacroExpansion(root, n.getParentNode())
   }
 


### PR DESCRIPTION
When investigating [this false positive report](https://github.com/github/codeql/issues/20256), I realized that the underlying cause was that attribute macros were not taken into account when filtering away results inside expansions.

[DCA](https://github.com/github/codeql-dca-main/issues/30919) confirms that the FPs have been eliminated.