### PR TITLE
Shared: Add Option types with location

### DIFF
--- a/shared/util/codeql/util/Option.qll
+++ b/shared/util/codeql/util/Option.qll
@@ -8,6 +8,16 @@ private signature class TypeWithToString {
   string toString();
 }
 
+/** A type with `toString` and `hasLocationInfo` */
+private signature class TypeWithToStringAndLocation {
+  bindingset[this]
+  string toString();
+
+  predicate hasLocationInfo(
+    string filePath, int startLine, int startColumn, int endLine, int endColumn
+  );
+}
+
 /**
  * Constructs an `Option` type that is a disjoint union of the given type and an
  * additional singleton element.
@@ -44,4 +54,53 @@ module Option<TypeWithToString T> {
 
   /** Gets the given element wrapped as an `Option`. */
   Some some(T c) { result = TSome(c) }
+}
+
+/**
+ * Constructs an `Option` type that is a disjoint union of the given type and an
+ * additional singleton element, and has a `hasLocationInfo` predicate.
+ */
+module LocOption<TypeWithToStringAndLocation T> {
+  private module O = Option<T>;
+
+  final private class BOption = O::Option;
+
+  final private class BNone = O::None;
+
+  final private class BSome = O::Some;
+
+  /**
+   * An option type. This is either a singleton `None` or a `Some` wrapping the
+   * given type.
+   */
+  class Option extends BOption {
+    /**
+     * Holds if this element is at the specified location.
+     * The location spans column `startColumn` of line `startLine` to
+     * column `endColumn` of line `endLine` in file `filepath`.
+     * For more information, see
+     * [Providing locations in CodeQL queries](https://codeql.github.com/docs/writing-codeql-queries/providing-locations-in-codeql-queries/).
+     */
+    predicate hasLocationInfo(
+      string filePath, int startLine, int startColumn, int endLine, int endColumn
+    ) {
+      this.isNone() and
+      filePath = "" and
+      startLine = 0 and
+      startColumn = 0 and
+      endLine = 0 and
+      endColumn = 0
+      or
+      this.asSome().hasLocationInfo(filePath, startLine, startColumn, endLine, endColumn)
+    }
+  }
+
+  /** The singleton `None` element. */
+  class None extends BNone, Option { }
+
+  /** A wrapper for the given type. */
+  class Some extends BSome, Option { }
+
+  /** Gets the given element wrapped as an `Option`. */
+  Some some(T c) { result = O::some(c) }
 }


### PR DESCRIPTION
Adds to the shared library parameterised modules for Option types with location support. 

Potential for bikeshedding on the names, especially `LocOption2`; unsure of a better name to describe its purpose. 

`LocOption` requires a type that has a `hasLocationInfo` predicate, and `LocOption2` requires a type with a `getLocation` predicate, and also needs to know about its result `Location` type.

This may be useful for queries with variable-length alert messages. 
This is applicable to 2 in-flight PRs for Python quality queries (and is cherry-picked from one of them); these PRs will be rebased to depend on this one shortly: https://github.com/github/codeql/pull/20217, https://github.com/github/codeql/pull/19932. 

I'm not that familiar with the use of parameterised modules, so if there are clearer ways to handle the implementation that I've that i've missed, let me know. 