### PR TITLE
Python: Refine the location of `flask.request` flow sources

### DIFF
--- a/python/ql/lib/change-notes/2025-08-25-refine-location-of-flask-request-sources.md
+++ b/python/ql/lib/change-notes/2025-08-25-refine-location-of-flask-request-sources.md
@@ -1,0 +1,5 @@
+---
+category: minorAnalysis
+---
+
+- The modelling of Flask requests (as sources of user-controlled data) has been improved. Rather than treating `from flask import request` as a source of remote flow, the modelling now behaves as if the first occurrence (inside a request handler) of a reference to that `request` object is a source of remote flow. This makes it much easier to understand alert messages that refer to the source of remote flow.


### PR DESCRIPTION
The `flask.request` global object is commonly used in request handlers to access data in the active request. In our modelling, we handled this by treating the initial (module-local) definition of `request` as a source of remote flow. In practice this meant a lot of alerts would act as if `from flask import request` was the ultimate "source" of remote flow, and to find the actual request-handler-local instance of `request` one would have to inspect the data-flow path between source and sink.

To improve this state of affairs, I have made the following changes to the definition of `FlaskRequestSource`:

- We no longer consider `from flask import request` to be a source.
- Instead, we look at all places where that `request` value can flow, and include only the ones that are `LocalSourceNode`s (so that inside a request handler, the first occurrence of the `request` object is the source).

In practice, this leads to alerts that are much easier to decipher.