### PR TITLE
Rust: Fix minor typo in bound in comment

### DIFF
--- a/rust/ql/lib/codeql/rust/internal/TypeInference.qll
+++ b/rust/ql/lib/codeql/rust/internal/TypeInference.qll
@@ -405,7 +405,7 @@ private module CertainTypeInference {
     inferCertainType(n, path) != t
     or
     // If we infer that `n` has _some_ type at `T1.T2....Tn`, and we also
-    // know that `n` certainly has type `certainType` at `T1.T2...Ti`, `i <=0 < n`,
+    // know that `n` certainly has type `certainType` at `T1.T2...Ti`, `0 <= i < n`,
     // then it must be the case that `T(i+1)` is a type parameter of `certainType`,
     // otherwise there is a conflict.
     //


### PR DESCRIPTION
I think the `0` and `i` where intended to be the other way around.