### PR TITLE
JS: Change pruning to not rely on Import

### DIFF
--- a/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModelsSpecific.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModelsSpecific.qll
@@ -58,9 +58,11 @@ predicate parseTypeString(string rawType, string package, string qualifiedName) 
 predicate isPackageUsed(string package) {
   package = "global"
   or
-  package = any(JS::Import imp).getImportedPathString()
+  // To simplify which dependencies are needed to construct DataFlow::Node, we don't want to rely on `Import` here.
+  // Just check all string literals.
+  package = any(JS::Expr imp).getStringValue()
   or
-  any(JS::TypeAnnotation t).hasUnderlyingType(package, _)
+  package = any(JS::StringLiteralTypeExpr t).getValue() // Can be used in `import("foo")`
   or
   exists(JS::PackageJson json | json.getPackageName() = package)
 }


### PR DESCRIPTION
Background: To ensure MaD library models have a near-zero cost for codebases that don't use the modelled library, we prune models based on what packages are imported in the current codebase. This means we don't parse the access paths or synthesise data flow nodes for irrelevant models.

This means that in order to generate `DataFlow::Node`, we first have to compute imported paths. There is thus a dependency on the `Import` class. However, the `Import` class also depends on local data flow. We therefore have `TEarlyStageNode`, which is used by `Import` but does not contain flow summary-generated nodes.

For overlay mode, the `TEarlyStageNode` has no effect on locality as the entire newtype needs to be made local. The dependency above puts us in an "all or nothing" situation where _a lot_ needs to be made local in order for `DataFlow::Node` to become local.

In order to simplify the problem, I'm cutting the dependency in this PR, so pruning of flow summaries only depends on an over-approximation, roughly based on what string literals appear in the program.

Note that there are more dependencies to be cut, but I'm trying to split this into small independent PRs.

[Evaluation](https://github.com/github/codeql-dca-main/issues/30969) looks neutral.