### PR TITLE
Rust: Minor tweaks to certain type inference

### DIFF
--- a/rust/ql/lib/codeql/rust/elements/RangeExprExt.qll
+++ b/rust/ql/lib/codeql/rust/elements/RangeExprExt.qll
@@ -47,6 +47,20 @@ final class RangeFromToExpr extends RangeExpr {
 }
 
 /**
+ * A range-full expression. For example:
+ * ```rust
+ * let x = ..;
+ * ```
+ */
+final class RangeFullExpr extends RangeExpr {
+  RangeFullExpr() {
+    this.getOperatorName() = ".." and
+    not this.hasStart() and
+    not this.hasEnd()
+  }
+}
+
+/**
  * A range-inclusive expression. For example:
  * ```rust
  * let x = 1..=10;

--- a/rust/ql/lib/codeql/rust/frameworks/stdlib/Stdlib.qll
+++ b/rust/ql/lib/codeql/rust/frameworks/stdlib/Stdlib.qll
@@ -95,6 +95,16 @@ class RangeToStruct extends Struct {
 }
 
 /**
+ * The [`RangeFull` struct][1].
+ *
+ * [1]: https://doc.rust-lang.org/core/ops/struct.RangeFull.html
+ */
+class RangeFullStruct extends Struct {
+  pragma[nomagic]
+  RangeFullStruct() { this.getCanonicalPath() = "core::ops::range::RangeFull" }
+}
+
+/**
  * The [`RangeInclusive` struct][1].
  *
  * [1]: https://doc.rust-lang.org/core/ops/struct.RangeInclusive.html

--- a/rust/ql/lib/codeql/rust/internal/TypeInference.qll
+++ b/rust/ql/lib/codeql/rust/internal/TypeInference.qll
@@ -383,6 +383,8 @@ private module CertainTypeInference {
     result = inferRefNodeType(n) and
     path.isEmpty()
     or
+    result = inferLogicalOperationType(n, path)
+    or
     result = inferTupleRootType(n) and
     path.isEmpty()
     or
@@ -440,11 +442,10 @@ private module CertainTypeInference {
 }
 
 private Type inferLogicalOperationType(AstNode n, TypePath path) {
-  exists(Builtins::BuiltinType t, BinaryLogicalOperation be |
+  exists(Builtins::Bool t, BinaryLogicalOperation be |
     n = [be, be.getLhs(), be.getRhs()] and
     path.isEmpty() and
-    result = TStruct(t) and
-    t instanceof Builtins::Bool
+    result = TStruct(t)
   )
 }
 
@@ -2380,8 +2381,6 @@ private module Cached {
     ) and
     (
       result = inferAnnotatedType(n, path)
-      or
-      result = inferLogicalOperationType(n, path)
       or
       result = inferAssignmentOperationType(n, path)
       or

--- a/rust/ql/lib/codeql/rust/internal/TypeInference.qll
+++ b/rust/ql/lib/codeql/rust/internal/TypeInference.qll
@@ -385,6 +385,9 @@ private module CertainTypeInference {
     or
     result = inferLogicalOperationType(n, path)
     or
+    result = inferRangeExprType(n) and
+    path.isEmpty()
+    or
     result = inferTupleRootType(n) and
     path.isEmpty()
     or
@@ -462,6 +465,9 @@ private Struct getRangeType(RangeExpr re) {
   or
   re instanceof RangeToExpr and
   result instanceof RangeToStruct
+  or
+  re instanceof RangeFullExpr and
+  result instanceof RangeFullStruct
   or
   re instanceof RangeFromToExpr and
   result instanceof RangeStruct
@@ -2401,9 +2407,6 @@ private module Cached {
       result = inferLiteralType(n, path, false)
       or
       result = inferAwaitExprType(n, path)
-      or
-      result = inferRangeExprType(n) and
-      path.isEmpty()
       or
       result = inferIndexExprType(n, path)
       or

--- a/rust/ql/lib/codeql/rust/internal/TypeInference.qll
+++ b/rust/ql/lib/codeql/rust/internal/TypeInference.qll
@@ -324,13 +324,19 @@ private module CertainTypeInference {
       or
       // A `let` statement with a type annotation is a coercion site and hence
       // is not a certain type equality.
-      exists(LetStmt let | not let.hasTypeRepr() |
-        let.getPat() = n1 and
+      exists(LetStmt let |
+        not let.hasTypeRepr() and
+        // Due to "binding modes" the type of the pattern is not necessarily the
+        // same as the type of the initializer. The pattern being an identifier
+        // pattern is sufficient to ensure that this is not the case.
+        let.getPat().(IdentPat) = n1 and
         let.getInitializer() = n2
       )
       or
       exists(LetExpr let |
-        let.getPat() = n1 and
+        // Similarly as for let statements, we need to rule out binding modes
+        // changing the type.
+        let.getPat().(IdentPat) = n1 and
         let.getScrutinee() = n2
       )
       or
@@ -485,6 +491,11 @@ private predicate typeEquality(AstNode n1, TypePath prefix1, AstNode n2, TypePat
     n1 = n2.(IfExpr).getABranch()
     or
     n1 = n2.(MatchExpr).getAnArm().getExpr()
+    or
+    exists(LetExpr let |
+      n1 = let.getScrutinee() and
+      n2 = let.getPat()
+    )
     or
     exists(MatchExpr me |
       n1 = me.getScrutinee() and

--- a/rust/ql/test/library-tests/type-inference/CONSISTENCY/TypeInferenceConsistency.expected
+++ b/rust/ql/test/library-tests/type-inference/CONSISTENCY/TypeInferenceConsistency.expected
@@ -1,9 +1,0 @@
-nonUniqueCertainType
-| pattern_matching.rs:487:9:487:18 | ref_tuple1 |  |
-| pattern_matching.rs:487:9:487:18 | ref_tuple1 |  |
-| pattern_matching.rs:488:12:488:17 | TuplePat |  |
-| pattern_matching.rs:488:21:488:30 | ref_tuple1 |  |
-| pattern_matching.rs:494:9:494:18 | ref_tuple2 |  |
-| pattern_matching.rs:494:9:494:18 | ref_tuple2 |  |
-| pattern_matching.rs:495:9:495:14 | TuplePat |  |
-| pattern_matching.rs:495:18:495:27 | ref_tuple2 |  |

--- a/rust/ql/test/library-tests/type-inference/CONSISTENCY/TypeInferenceConsistency.expected
+++ b/rust/ql/test/library-tests/type-inference/CONSISTENCY/TypeInferenceConsistency.expected
@@ -1,0 +1,9 @@
+nonUniqueCertainType
+| pattern_matching.rs:487:9:487:18 | ref_tuple1 |  |
+| pattern_matching.rs:487:9:487:18 | ref_tuple1 |  |
+| pattern_matching.rs:488:12:488:17 | TuplePat |  |
+| pattern_matching.rs:488:21:488:30 | ref_tuple1 |  |
+| pattern_matching.rs:494:9:494:18 | ref_tuple2 |  |
+| pattern_matching.rs:494:9:494:18 | ref_tuple2 |  |
+| pattern_matching.rs:495:9:495:14 | TuplePat |  |
+| pattern_matching.rs:495:18:495:27 | ref_tuple2 |  |

--- a/rust/ql/test/library-tests/type-inference/main.rs
+++ b/rust/ql/test/library-tests/type-inference/main.rs
@@ -2332,6 +2332,8 @@ mod loops {
         for u in [0u8..10] {} // $ type=u:Range type=u:Idx.u8
         let range = 0..10; // $ type=range:Range type=range:Idx.i32
         for i in range {} // $ type=i:i32
+        let range_full = ..; // $ MISSING: type=range_full:RangeFull
+        for i in &[1i64, 2i64, 3i64][range_full] {} // $ target=index MISSING: type=i:&T.i64
 
         let range1 = // $ type=range1:Range type=range1:Idx.u16
         std::ops::Range {
@@ -2558,12 +2560,11 @@ pub mod exec {
 pub mod path_buf {
     // a highly simplified model of `PathBuf::canonicalize`
 
-    pub struct Path {
-    }
+    pub struct Path {}
 
     impl Path {
         pub const fn new() -> Path {
-            Path { }
+            Path {}
         }
 
         pub fn canonicalize(&self) -> Result<PathBuf, ()> {
@@ -2571,12 +2572,11 @@ pub mod path_buf {
         }
     }
 
-    pub struct PathBuf {
-    }
+    pub struct PathBuf {}
 
     impl PathBuf {
         pub const fn new() -> PathBuf {
-            PathBuf { }
+            PathBuf {}
         }
     }
 
@@ -2587,7 +2587,7 @@ pub mod path_buf {
         #[inline]
         fn deref(&self) -> &Path {
             // (very much not a real implementation)
-            static path : Path = Path::new(); // $ target=new
+            static path: Path = Path::new(); // $ target=new
             &path
         }
     }

--- a/rust/ql/test/library-tests/type-inference/main.rs
+++ b/rust/ql/test/library-tests/type-inference/main.rs
@@ -2332,7 +2332,7 @@ mod loops {
         for u in [0u8..10] {} // $ type=u:Range type=u:Idx.u8
         let range = 0..10; // $ type=range:Range type=range:Idx.i32
         for i in range {} // $ type=i:i32
-        let range_full = ..; // $ MISSING: type=range_full:RangeFull
+        let range_full = ..; // $ type=range_full:RangeFull
         for i in &[1i64, 2i64, 3i64][range_full] {} // $ target=index MISSING: type=i:&T.i64
 
         let range1 = // $ type=range1:Range type=range1:Idx.u16

--- a/rust/ql/test/library-tests/type-inference/pattern_matching.rs
+++ b/rust/ql/test/library-tests/type-inference/pattern_matching.rs
@@ -482,6 +482,19 @@ pub fn tuple_patterns() {
             println!("Single element tuple: {}", single_elem);
         }
     }
+
+    // Tuple pattern on reference to tuple in `let` expression
+    let ref_tuple1: &(i32, i32) = &(1, 2);
+    if let (n, m) = ref_tuple1 {
+        println!("n: {}", n);
+        println!("m: {}", m);
+    }
+
+    // Tuple pattern on reference to tuple in `let` statement
+    let ref_tuple2: &(i32, i32) = &(1, 2);
+    let (n, m) = ref_tuple2;
+    println!("n: {}", n);
+    println!("m: {}", m);
 }
 
 pub fn parenthesized_patterns() {

--- a/rust/ql/test/library-tests/type-inference/type-inference.expected
+++ b/rust/ql/test/library-tests/type-inference/type-inference.expected
@@ -5884,7 +5884,6 @@ inferType
 | pattern_matching.rs:482:22:482:60 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
 | pattern_matching.rs:482:50:482:60 | single_elem |  | {EXTERNAL LOCATION} | i32 |
 | pattern_matching.rs:487:9:487:18 | ref_tuple1 |  | file://:0:0:0:0 | & |
-| pattern_matching.rs:487:9:487:18 | ref_tuple1 |  | file://:0:0:0:0 | (T_2) |
 | pattern_matching.rs:487:9:487:18 | ref_tuple1 | &T | file://:0:0:0:0 | (T_2) |
 | pattern_matching.rs:487:9:487:18 | ref_tuple1 | &T.0(2) | {EXTERNAL LOCATION} | i32 |
 | pattern_matching.rs:487:9:487:18 | ref_tuple1 | &T.1(2) | {EXTERNAL LOCATION} | i32 |
@@ -5897,13 +5896,8 @@ inferType
 | pattern_matching.rs:487:36:487:41 | TupleExpr | 1(2) | {EXTERNAL LOCATION} | i32 |
 | pattern_matching.rs:487:37:487:37 | 1 |  | {EXTERNAL LOCATION} | i32 |
 | pattern_matching.rs:487:40:487:40 | 2 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:488:12:488:17 | TuplePat |  | file://:0:0:0:0 | & |
 | pattern_matching.rs:488:12:488:17 | TuplePat |  | file://:0:0:0:0 | (T_2) |
-| pattern_matching.rs:488:12:488:17 | TuplePat | &T | file://:0:0:0:0 | (T_2) |
-| pattern_matching.rs:488:12:488:17 | TuplePat | &T.0(2) | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:488:12:488:17 | TuplePat | &T.1(2) | {EXTERNAL LOCATION} | i32 |
 | pattern_matching.rs:488:21:488:30 | ref_tuple1 |  | file://:0:0:0:0 | & |
-| pattern_matching.rs:488:21:488:30 | ref_tuple1 |  | file://:0:0:0:0 | (T_2) |
 | pattern_matching.rs:488:21:488:30 | ref_tuple1 | &T | file://:0:0:0:0 | (T_2) |
 | pattern_matching.rs:488:21:488:30 | ref_tuple1 | &T.0(2) | {EXTERNAL LOCATION} | i32 |
 | pattern_matching.rs:488:21:488:30 | ref_tuple1 | &T.1(2) | {EXTERNAL LOCATION} | i32 |
@@ -5916,7 +5910,6 @@ inferType
 | pattern_matching.rs:490:18:490:27 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
 | pattern_matching.rs:490:18:490:27 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
 | pattern_matching.rs:494:9:494:18 | ref_tuple2 |  | file://:0:0:0:0 | & |
-| pattern_matching.rs:494:9:494:18 | ref_tuple2 |  | file://:0:0:0:0 | (T_2) |
 | pattern_matching.rs:494:9:494:18 | ref_tuple2 | &T | file://:0:0:0:0 | (T_2) |
 | pattern_matching.rs:494:9:494:18 | ref_tuple2 | &T.0(2) | {EXTERNAL LOCATION} | i32 |
 | pattern_matching.rs:494:9:494:18 | ref_tuple2 | &T.1(2) | {EXTERNAL LOCATION} | i32 |
@@ -5929,13 +5922,8 @@ inferType
 | pattern_matching.rs:494:36:494:41 | TupleExpr | 1(2) | {EXTERNAL LOCATION} | i32 |
 | pattern_matching.rs:494:37:494:37 | 1 |  | {EXTERNAL LOCATION} | i32 |
 | pattern_matching.rs:494:40:494:40 | 2 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:495:9:495:14 | TuplePat |  | file://:0:0:0:0 | & |
 | pattern_matching.rs:495:9:495:14 | TuplePat |  | file://:0:0:0:0 | (T_2) |
-| pattern_matching.rs:495:9:495:14 | TuplePat | &T | file://:0:0:0:0 | (T_2) |
-| pattern_matching.rs:495:9:495:14 | TuplePat | &T.0(2) | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:495:9:495:14 | TuplePat | &T.1(2) | {EXTERNAL LOCATION} | i32 |
 | pattern_matching.rs:495:18:495:27 | ref_tuple2 |  | file://:0:0:0:0 | & |
-| pattern_matching.rs:495:18:495:27 | ref_tuple2 |  | file://:0:0:0:0 | (T_2) |
 | pattern_matching.rs:495:18:495:27 | ref_tuple2 | &T | file://:0:0:0:0 | (T_2) |
 | pattern_matching.rs:495:18:495:27 | ref_tuple2 | &T.0(2) | {EXTERNAL LOCATION} | i32 |
 | pattern_matching.rs:495:18:495:27 | ref_tuple2 | &T.1(2) | {EXTERNAL LOCATION} | i32 |

--- a/rust/ql/test/library-tests/type-inference/type-inference.expected
+++ b/rust/ql/test/library-tests/type-inference/type-inference.expected
@@ -4367,620 +4367,627 @@ inferType
 | main.rs:2334:13:2334:13 | i |  | {EXTERNAL LOCATION} | i32 |
 | main.rs:2334:18:2334:22 | range |  | {EXTERNAL LOCATION} | Range |
 | main.rs:2334:18:2334:22 | range | Idx | {EXTERNAL LOCATION} | i32 |
-| main.rs:2336:13:2336:18 | range1 |  | {EXTERNAL LOCATION} | Range |
-| main.rs:2336:13:2336:18 | range1 | Idx | {EXTERNAL LOCATION} | u16 |
-| main.rs:2337:9:2340:9 | ...::Range {...} |  | {EXTERNAL LOCATION} | Range |
-| main.rs:2337:9:2340:9 | ...::Range {...} | Idx | {EXTERNAL LOCATION} | u16 |
-| main.rs:2338:20:2338:23 | 0u16 |  | {EXTERNAL LOCATION} | u16 |
-| main.rs:2339:18:2339:22 | 10u16 |  | {EXTERNAL LOCATION} | u16 |
-| main.rs:2341:13:2341:13 | u |  | {EXTERNAL LOCATION} | Item |
-| main.rs:2341:13:2341:13 | u |  | {EXTERNAL LOCATION} | u16 |
-| main.rs:2341:18:2341:23 | range1 |  | {EXTERNAL LOCATION} | Range |
-| main.rs:2341:18:2341:23 | range1 | Idx | {EXTERNAL LOCATION} | u16 |
-| main.rs:2345:26:2345:26 | 1 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2345:29:2345:29 | 2 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2345:32:2345:32 | 3 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2348:13:2348:18 | vals4a |  | {EXTERNAL LOCATION} | Vec |
-| main.rs:2348:13:2348:18 | vals4a | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2348:13:2348:18 | vals4a | T | {EXTERNAL LOCATION} | u16 |
-| main.rs:2348:32:2348:43 | [...] |  | file://:0:0:0:0 | [] |
-| main.rs:2348:32:2348:43 | [...] | [T;...] | {EXTERNAL LOCATION} | i32 |
-| main.rs:2348:32:2348:43 | [...] | [T;...] | {EXTERNAL LOCATION} | u16 |
-| main.rs:2348:32:2348:52 | ... .to_vec() |  | {EXTERNAL LOCATION} | Vec |
-| main.rs:2348:32:2348:52 | ... .to_vec() | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2348:32:2348:52 | ... .to_vec() | T | {EXTERNAL LOCATION} | u16 |
-| main.rs:2348:33:2348:36 | 1u16 |  | {EXTERNAL LOCATION} | u16 |
-| main.rs:2348:39:2348:39 | 2 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2348:39:2348:39 | 2 |  | {EXTERNAL LOCATION} | u16 |
-| main.rs:2348:42:2348:42 | 3 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2348:42:2348:42 | 3 |  | {EXTERNAL LOCATION} | u16 |
-| main.rs:2349:13:2349:13 | u |  | {EXTERNAL LOCATION} | u16 |
-| main.rs:2349:13:2349:13 | u |  | file://:0:0:0:0 | & |
-| main.rs:2349:18:2349:23 | vals4a |  | {EXTERNAL LOCATION} | Vec |
-| main.rs:2349:18:2349:23 | vals4a | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2349:18:2349:23 | vals4a | T | {EXTERNAL LOCATION} | u16 |
-| main.rs:2351:22:2351:33 | [...] |  | file://:0:0:0:0 | [] |
-| main.rs:2351:22:2351:33 | [...] | [T;...] | {EXTERNAL LOCATION} | i32 |
-| main.rs:2351:22:2351:33 | [...] | [T;...] | {EXTERNAL LOCATION} | u16 |
-| main.rs:2351:23:2351:26 | 1u16 |  | {EXTERNAL LOCATION} | u16 |
-| main.rs:2351:29:2351:29 | 2 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2351:29:2351:29 | 2 |  | {EXTERNAL LOCATION} | u16 |
-| main.rs:2351:32:2351:32 | 3 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2351:32:2351:32 | 3 |  | {EXTERNAL LOCATION} | u16 |
-| main.rs:2354:13:2354:17 | vals5 |  | {EXTERNAL LOCATION} | Vec |
-| main.rs:2354:13:2354:17 | vals5 | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2354:13:2354:17 | vals5 | T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2354:13:2354:17 | vals5 | T | {EXTERNAL LOCATION} | u32 |
-| main.rs:2354:21:2354:43 | ...::from(...) |  | {EXTERNAL LOCATION} | Vec |
-| main.rs:2354:21:2354:43 | ...::from(...) | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2354:21:2354:43 | ...::from(...) | T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2354:21:2354:43 | ...::from(...) | T | {EXTERNAL LOCATION} | u32 |
-| main.rs:2354:31:2354:42 | [...] |  | file://:0:0:0:0 | [] |
-| main.rs:2354:31:2354:42 | [...] | [T;...] | {EXTERNAL LOCATION} | i32 |
-| main.rs:2354:31:2354:42 | [...] | [T;...] | {EXTERNAL LOCATION} | u32 |
-| main.rs:2354:32:2354:35 | 1u32 |  | {EXTERNAL LOCATION} | u32 |
-| main.rs:2354:38:2354:38 | 2 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2354:38:2354:38 | 2 |  | {EXTERNAL LOCATION} | u32 |
-| main.rs:2354:41:2354:41 | 3 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2354:41:2354:41 | 3 |  | {EXTERNAL LOCATION} | u32 |
-| main.rs:2355:13:2355:13 | u |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2355:13:2355:13 | u |  | {EXTERNAL LOCATION} | u32 |
-| main.rs:2355:13:2355:13 | u |  | file://:0:0:0:0 | & |
-| main.rs:2355:18:2355:22 | vals5 |  | {EXTERNAL LOCATION} | Vec |
-| main.rs:2355:18:2355:22 | vals5 | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2355:18:2355:22 | vals5 | T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2355:18:2355:22 | vals5 | T | {EXTERNAL LOCATION} | u32 |
-| main.rs:2357:13:2357:17 | vals6 |  | {EXTERNAL LOCATION} | Vec |
-| main.rs:2357:13:2357:17 | vals6 | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2357:13:2357:17 | vals6 | T | file://:0:0:0:0 | & |
-| main.rs:2357:13:2357:17 | vals6 | T.&T | {EXTERNAL LOCATION} | u64 |
-| main.rs:2357:32:2357:43 | [...] |  | file://:0:0:0:0 | [] |
-| main.rs:2357:32:2357:43 | [...] | [T;...] | {EXTERNAL LOCATION} | i32 |
-| main.rs:2357:32:2357:43 | [...] | [T;...] | {EXTERNAL LOCATION} | u64 |
-| main.rs:2357:32:2357:60 | ... .collect() |  | {EXTERNAL LOCATION} | Vec |
-| main.rs:2357:32:2357:60 | ... .collect() | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2357:32:2357:60 | ... .collect() | T | file://:0:0:0:0 | & |
-| main.rs:2357:32:2357:60 | ... .collect() | T.&T | {EXTERNAL LOCATION} | u64 |
-| main.rs:2357:33:2357:36 | 1u64 |  | {EXTERNAL LOCATION} | u64 |
-| main.rs:2357:39:2357:39 | 2 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2357:39:2357:39 | 2 |  | {EXTERNAL LOCATION} | u64 |
-| main.rs:2357:42:2357:42 | 3 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2357:42:2357:42 | 3 |  | {EXTERNAL LOCATION} | u64 |
-| main.rs:2358:13:2358:13 | u |  | file://:0:0:0:0 | & |
-| main.rs:2358:13:2358:13 | u | &T | {EXTERNAL LOCATION} | u64 |
-| main.rs:2358:18:2358:22 | vals6 |  | {EXTERNAL LOCATION} | Vec |
-| main.rs:2358:18:2358:22 | vals6 | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2358:18:2358:22 | vals6 | T | file://:0:0:0:0 | & |
-| main.rs:2358:18:2358:22 | vals6 | T.&T | {EXTERNAL LOCATION} | u64 |
-| main.rs:2360:17:2360:21 | vals7 |  | {EXTERNAL LOCATION} | Vec |
-| main.rs:2360:17:2360:21 | vals7 | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2360:17:2360:21 | vals7 | T | {EXTERNAL LOCATION} | u8 |
-| main.rs:2360:25:2360:34 | ...::new(...) |  | {EXTERNAL LOCATION} | Vec |
-| main.rs:2360:25:2360:34 | ...::new(...) | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2360:25:2360:34 | ...::new(...) | T | {EXTERNAL LOCATION} | u8 |
-| main.rs:2361:9:2361:13 | vals7 |  | {EXTERNAL LOCATION} | Vec |
-| main.rs:2361:9:2361:13 | vals7 | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2361:9:2361:13 | vals7 | T | {EXTERNAL LOCATION} | u8 |
-| main.rs:2361:20:2361:22 | 1u8 |  | {EXTERNAL LOCATION} | u8 |
-| main.rs:2362:13:2362:13 | u |  | {EXTERNAL LOCATION} | u8 |
-| main.rs:2362:13:2362:13 | u |  | file://:0:0:0:0 | & |
-| main.rs:2362:18:2362:22 | vals7 |  | {EXTERNAL LOCATION} | Vec |
-| main.rs:2362:18:2362:22 | vals7 | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2362:18:2362:22 | vals7 | T | {EXTERNAL LOCATION} | u8 |
-| main.rs:2364:33:2364:33 | 1 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2364:36:2364:36 | 2 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2364:45:2364:45 | 3 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2364:48:2364:48 | 4 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2371:17:2371:20 | map1 |  | {EXTERNAL LOCATION} | HashMap |
-| main.rs:2371:17:2371:20 | map1 | K | {EXTERNAL LOCATION} | i32 |
-| main.rs:2371:17:2371:20 | map1 | S | {EXTERNAL LOCATION} | RandomState |
-| main.rs:2371:17:2371:20 | map1 | V | {EXTERNAL LOCATION} | Box |
-| main.rs:2371:17:2371:20 | map1 | V.A | {EXTERNAL LOCATION} | Global |
-| main.rs:2371:17:2371:20 | map1 | V.T | file://:0:0:0:0 | & |
-| main.rs:2371:17:2371:20 | map1 | V.T.&T | {EXTERNAL LOCATION} | str |
-| main.rs:2371:24:2371:55 | ...::new(...) |  | {EXTERNAL LOCATION} | HashMap |
-| main.rs:2371:24:2371:55 | ...::new(...) | K | {EXTERNAL LOCATION} | i32 |
-| main.rs:2371:24:2371:55 | ...::new(...) | S | {EXTERNAL LOCATION} | RandomState |
-| main.rs:2371:24:2371:55 | ...::new(...) | V | {EXTERNAL LOCATION} | Box |
-| main.rs:2371:24:2371:55 | ...::new(...) | V.A | {EXTERNAL LOCATION} | Global |
-| main.rs:2371:24:2371:55 | ...::new(...) | V.T | file://:0:0:0:0 | & |
-| main.rs:2371:24:2371:55 | ...::new(...) | V.T.&T | {EXTERNAL LOCATION} | str |
-| main.rs:2372:9:2372:12 | map1 |  | {EXTERNAL LOCATION} | HashMap |
-| main.rs:2372:9:2372:12 | map1 | K | {EXTERNAL LOCATION} | i32 |
-| main.rs:2372:9:2372:12 | map1 | S | {EXTERNAL LOCATION} | RandomState |
-| main.rs:2372:9:2372:12 | map1 | V | {EXTERNAL LOCATION} | Box |
-| main.rs:2372:9:2372:12 | map1 | V.A | {EXTERNAL LOCATION} | Global |
-| main.rs:2372:9:2372:12 | map1 | V.T | file://:0:0:0:0 | & |
-| main.rs:2372:9:2372:12 | map1 | V.T.&T | {EXTERNAL LOCATION} | str |
-| main.rs:2372:9:2372:39 | map1.insert(...) |  | {EXTERNAL LOCATION} | Option |
-| main.rs:2372:9:2372:39 | map1.insert(...) | T | {EXTERNAL LOCATION} | Box |
-| main.rs:2372:9:2372:39 | map1.insert(...) | T.A | {EXTERNAL LOCATION} | Global |
-| main.rs:2372:9:2372:39 | map1.insert(...) | T.T | file://:0:0:0:0 | & |
-| main.rs:2372:9:2372:39 | map1.insert(...) | T.T.&T | {EXTERNAL LOCATION} | str |
-| main.rs:2372:21:2372:21 | 1 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2372:24:2372:38 | ...::new(...) |  | {EXTERNAL LOCATION} | Box |
-| main.rs:2372:24:2372:38 | ...::new(...) | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2372:24:2372:38 | ...::new(...) | T | file://:0:0:0:0 | & |
-| main.rs:2372:24:2372:38 | ...::new(...) | T.&T | {EXTERNAL LOCATION} | str |
-| main.rs:2372:33:2372:37 | "one" |  | file://:0:0:0:0 | & |
-| main.rs:2372:33:2372:37 | "one" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:2373:9:2373:12 | map1 |  | {EXTERNAL LOCATION} | HashMap |
-| main.rs:2373:9:2373:12 | map1 | K | {EXTERNAL LOCATION} | i32 |
-| main.rs:2373:9:2373:12 | map1 | S | {EXTERNAL LOCATION} | RandomState |
-| main.rs:2373:9:2373:12 | map1 | V | {EXTERNAL LOCATION} | Box |
-| main.rs:2373:9:2373:12 | map1 | V.A | {EXTERNAL LOCATION} | Global |
-| main.rs:2373:9:2373:12 | map1 | V.T | file://:0:0:0:0 | & |
-| main.rs:2373:9:2373:12 | map1 | V.T.&T | {EXTERNAL LOCATION} | str |
-| main.rs:2373:9:2373:39 | map1.insert(...) |  | {EXTERNAL LOCATION} | Option |
-| main.rs:2373:9:2373:39 | map1.insert(...) | T | {EXTERNAL LOCATION} | Box |
-| main.rs:2373:9:2373:39 | map1.insert(...) | T.A | {EXTERNAL LOCATION} | Global |
-| main.rs:2373:9:2373:39 | map1.insert(...) | T.T | file://:0:0:0:0 | & |
-| main.rs:2373:9:2373:39 | map1.insert(...) | T.T.&T | {EXTERNAL LOCATION} | str |
-| main.rs:2373:21:2373:21 | 2 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2373:24:2373:38 | ...::new(...) |  | {EXTERNAL LOCATION} | Box |
-| main.rs:2373:24:2373:38 | ...::new(...) | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2373:24:2373:38 | ...::new(...) | T | file://:0:0:0:0 | & |
-| main.rs:2373:24:2373:38 | ...::new(...) | T.&T | {EXTERNAL LOCATION} | str |
-| main.rs:2373:33:2373:37 | "two" |  | file://:0:0:0:0 | & |
-| main.rs:2373:33:2373:37 | "two" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:2374:13:2374:15 | key |  | {EXTERNAL LOCATION} | Item |
-| main.rs:2374:13:2374:15 | key |  | file://:0:0:0:0 | & |
-| main.rs:2374:13:2374:15 | key | &T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2374:20:2374:23 | map1 |  | {EXTERNAL LOCATION} | HashMap |
-| main.rs:2374:20:2374:23 | map1 | K | {EXTERNAL LOCATION} | i32 |
-| main.rs:2374:20:2374:23 | map1 | S | {EXTERNAL LOCATION} | RandomState |
-| main.rs:2374:20:2374:23 | map1 | V | {EXTERNAL LOCATION} | Box |
-| main.rs:2374:20:2374:23 | map1 | V.A | {EXTERNAL LOCATION} | Global |
-| main.rs:2374:20:2374:23 | map1 | V.T | file://:0:0:0:0 | & |
-| main.rs:2374:20:2374:23 | map1 | V.T.&T | {EXTERNAL LOCATION} | str |
-| main.rs:2374:20:2374:30 | map1.keys() |  | {EXTERNAL LOCATION} | Keys |
-| main.rs:2374:20:2374:30 | map1.keys() | K | {EXTERNAL LOCATION} | i32 |
-| main.rs:2374:20:2374:30 | map1.keys() | V | {EXTERNAL LOCATION} | Box |
-| main.rs:2374:20:2374:30 | map1.keys() | V.A | {EXTERNAL LOCATION} | Global |
-| main.rs:2374:20:2374:30 | map1.keys() | V.T | file://:0:0:0:0 | & |
-| main.rs:2374:20:2374:30 | map1.keys() | V.T.&T | {EXTERNAL LOCATION} | str |
-| main.rs:2375:13:2375:17 | value |  | {EXTERNAL LOCATION} | Item |
-| main.rs:2375:13:2375:17 | value |  | file://:0:0:0:0 | & |
-| main.rs:2375:13:2375:17 | value | &T | {EXTERNAL LOCATION} | Box |
-| main.rs:2375:13:2375:17 | value | &T.A | {EXTERNAL LOCATION} | Global |
-| main.rs:2375:13:2375:17 | value | &T.T | file://:0:0:0:0 | & |
-| main.rs:2375:13:2375:17 | value | &T.T.&T | {EXTERNAL LOCATION} | str |
-| main.rs:2375:22:2375:25 | map1 |  | {EXTERNAL LOCATION} | HashMap |
-| main.rs:2375:22:2375:25 | map1 | K | {EXTERNAL LOCATION} | i32 |
-| main.rs:2375:22:2375:25 | map1 | S | {EXTERNAL LOCATION} | RandomState |
-| main.rs:2375:22:2375:25 | map1 | V | {EXTERNAL LOCATION} | Box |
-| main.rs:2375:22:2375:25 | map1 | V.A | {EXTERNAL LOCATION} | Global |
-| main.rs:2375:22:2375:25 | map1 | V.T | file://:0:0:0:0 | & |
-| main.rs:2375:22:2375:25 | map1 | V.T.&T | {EXTERNAL LOCATION} | str |
-| main.rs:2375:22:2375:34 | map1.values() |  | {EXTERNAL LOCATION} | Values |
-| main.rs:2375:22:2375:34 | map1.values() | K | {EXTERNAL LOCATION} | i32 |
-| main.rs:2375:22:2375:34 | map1.values() | V | {EXTERNAL LOCATION} | Box |
-| main.rs:2375:22:2375:34 | map1.values() | V.A | {EXTERNAL LOCATION} | Global |
-| main.rs:2375:22:2375:34 | map1.values() | V.T | file://:0:0:0:0 | & |
-| main.rs:2375:22:2375:34 | map1.values() | V.T.&T | {EXTERNAL LOCATION} | str |
-| main.rs:2376:13:2376:24 | TuplePat |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2376:13:2376:24 | TuplePat | 0(2) | file://:0:0:0:0 | & |
-| main.rs:2376:13:2376:24 | TuplePat | 0(2).&T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2376:13:2376:24 | TuplePat | 1(2) | file://:0:0:0:0 | & |
-| main.rs:2376:13:2376:24 | TuplePat | 1(2).&T | {EXTERNAL LOCATION} | Box |
-| main.rs:2376:13:2376:24 | TuplePat | 1(2).&T.A | {EXTERNAL LOCATION} | Global |
-| main.rs:2376:13:2376:24 | TuplePat | 1(2).&T.T | file://:0:0:0:0 | & |
-| main.rs:2376:13:2376:24 | TuplePat | 1(2).&T.T.&T | {EXTERNAL LOCATION} | str |
-| main.rs:2376:14:2376:16 | key |  | file://:0:0:0:0 | & |
-| main.rs:2376:14:2376:16 | key | &T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2376:19:2376:23 | value |  | file://:0:0:0:0 | & |
-| main.rs:2376:19:2376:23 | value | &T | {EXTERNAL LOCATION} | Box |
-| main.rs:2376:19:2376:23 | value | &T.A | {EXTERNAL LOCATION} | Global |
-| main.rs:2376:19:2376:23 | value | &T.T | file://:0:0:0:0 | & |
-| main.rs:2376:19:2376:23 | value | &T.T.&T | {EXTERNAL LOCATION} | str |
-| main.rs:2376:29:2376:32 | map1 |  | {EXTERNAL LOCATION} | HashMap |
-| main.rs:2376:29:2376:32 | map1 | K | {EXTERNAL LOCATION} | i32 |
-| main.rs:2376:29:2376:32 | map1 | S | {EXTERNAL LOCATION} | RandomState |
-| main.rs:2376:29:2376:32 | map1 | V | {EXTERNAL LOCATION} | Box |
-| main.rs:2376:29:2376:32 | map1 | V.A | {EXTERNAL LOCATION} | Global |
-| main.rs:2376:29:2376:32 | map1 | V.T | file://:0:0:0:0 | & |
-| main.rs:2376:29:2376:32 | map1 | V.T.&T | {EXTERNAL LOCATION} | str |
-| main.rs:2376:29:2376:39 | map1.iter() |  | {EXTERNAL LOCATION} | Iter |
-| main.rs:2376:29:2376:39 | map1.iter() | K | {EXTERNAL LOCATION} | i32 |
-| main.rs:2376:29:2376:39 | map1.iter() | V | {EXTERNAL LOCATION} | Box |
-| main.rs:2376:29:2376:39 | map1.iter() | V.A | {EXTERNAL LOCATION} | Global |
-| main.rs:2376:29:2376:39 | map1.iter() | V.T | file://:0:0:0:0 | & |
-| main.rs:2376:29:2376:39 | map1.iter() | V.T.&T | {EXTERNAL LOCATION} | str |
-| main.rs:2377:13:2377:24 | TuplePat |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2377:13:2377:24 | TuplePat | 0(2) | file://:0:0:0:0 | & |
-| main.rs:2377:13:2377:24 | TuplePat | 0(2).&T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2377:13:2377:24 | TuplePat | 1(2) | file://:0:0:0:0 | & |
-| main.rs:2377:13:2377:24 | TuplePat | 1(2).&T | {EXTERNAL LOCATION} | Box |
-| main.rs:2377:13:2377:24 | TuplePat | 1(2).&T.A | {EXTERNAL LOCATION} | Global |
-| main.rs:2377:13:2377:24 | TuplePat | 1(2).&T.T | file://:0:0:0:0 | & |
-| main.rs:2377:13:2377:24 | TuplePat | 1(2).&T.T.&T | {EXTERNAL LOCATION} | str |
-| main.rs:2377:14:2377:16 | key |  | file://:0:0:0:0 | & |
-| main.rs:2377:14:2377:16 | key | &T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2377:19:2377:23 | value |  | file://:0:0:0:0 | & |
-| main.rs:2377:19:2377:23 | value | &T | {EXTERNAL LOCATION} | Box |
-| main.rs:2377:19:2377:23 | value | &T.A | {EXTERNAL LOCATION} | Global |
-| main.rs:2377:19:2377:23 | value | &T.T | file://:0:0:0:0 | & |
-| main.rs:2377:19:2377:23 | value | &T.T.&T | {EXTERNAL LOCATION} | str |
-| main.rs:2377:29:2377:33 | &map1 |  | file://:0:0:0:0 | & |
-| main.rs:2377:29:2377:33 | &map1 | &T | {EXTERNAL LOCATION} | HashMap |
-| main.rs:2377:29:2377:33 | &map1 | &T.K | {EXTERNAL LOCATION} | i32 |
-| main.rs:2377:29:2377:33 | &map1 | &T.S | {EXTERNAL LOCATION} | RandomState |
-| main.rs:2377:29:2377:33 | &map1 | &T.V | {EXTERNAL LOCATION} | Box |
-| main.rs:2377:29:2377:33 | &map1 | &T.V.A | {EXTERNAL LOCATION} | Global |
-| main.rs:2377:29:2377:33 | &map1 | &T.V.T | file://:0:0:0:0 | & |
-| main.rs:2377:29:2377:33 | &map1 | &T.V.T.&T | {EXTERNAL LOCATION} | str |
-| main.rs:2377:30:2377:33 | map1 |  | {EXTERNAL LOCATION} | HashMap |
-| main.rs:2377:30:2377:33 | map1 | K | {EXTERNAL LOCATION} | i32 |
-| main.rs:2377:30:2377:33 | map1 | S | {EXTERNAL LOCATION} | RandomState |
-| main.rs:2377:30:2377:33 | map1 | V | {EXTERNAL LOCATION} | Box |
-| main.rs:2377:30:2377:33 | map1 | V.A | {EXTERNAL LOCATION} | Global |
-| main.rs:2377:30:2377:33 | map1 | V.T | file://:0:0:0:0 | & |
-| main.rs:2377:30:2377:33 | map1 | V.T.&T | {EXTERNAL LOCATION} | str |
-| main.rs:2381:17:2381:17 | a |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2381:26:2381:26 | 0 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2381:26:2381:26 | 0 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2383:23:2383:23 | a |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2383:23:2383:28 | ... < ... |  | {EXTERNAL LOCATION} | bool |
-| main.rs:2383:27:2383:28 | 10 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2383:27:2383:28 | 10 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2385:13:2385:13 | a |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2385:13:2385:18 | ... += ... |  | file://:0:0:0:0 | () |
-| main.rs:2385:18:2385:18 | 1 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2397:40:2399:9 | { ... } |  | {EXTERNAL LOCATION} | Option |
-| main.rs:2397:40:2399:9 | { ... } | T | main.rs:2391:5:2391:20 | S1 |
-| main.rs:2397:40:2399:9 | { ... } | T.T | main.rs:2396:10:2396:19 | T |
-| main.rs:2398:13:2398:16 | None |  | {EXTERNAL LOCATION} | Option |
-| main.rs:2398:13:2398:16 | None | T | main.rs:2391:5:2391:20 | S1 |
-| main.rs:2398:13:2398:16 | None | T.T | main.rs:2396:10:2396:19 | T |
-| main.rs:2401:30:2403:9 | { ... } |  | main.rs:2391:5:2391:20 | S1 |
-| main.rs:2401:30:2403:9 | { ... } | T | main.rs:2396:10:2396:19 | T |
-| main.rs:2402:13:2402:28 | S1(...) |  | main.rs:2391:5:2391:20 | S1 |
-| main.rs:2402:13:2402:28 | S1(...) | T | main.rs:2396:10:2396:19 | T |
-| main.rs:2402:16:2402:27 | ...::default(...) |  | main.rs:2396:10:2396:19 | T |
-| main.rs:2405:19:2405:22 | SelfParam |  | main.rs:2391:5:2391:20 | S1 |
-| main.rs:2405:19:2405:22 | SelfParam | T | main.rs:2396:10:2396:19 | T |
-| main.rs:2405:33:2407:9 | { ... } |  | main.rs:2391:5:2391:20 | S1 |
-| main.rs:2405:33:2407:9 | { ... } | T | main.rs:2396:10:2396:19 | T |
-| main.rs:2406:13:2406:16 | self |  | main.rs:2391:5:2391:20 | S1 |
-| main.rs:2406:13:2406:16 | self | T | main.rs:2396:10:2396:19 | T |
-| main.rs:2418:15:2418:15 | x |  | main.rs:2418:12:2418:12 | T |
-| main.rs:2418:26:2420:5 | { ... } |  | main.rs:2418:12:2418:12 | T |
-| main.rs:2419:9:2419:9 | x |  | main.rs:2418:12:2418:12 | T |
-| main.rs:2423:13:2423:14 | x1 |  | {EXTERNAL LOCATION} | Option |
-| main.rs:2423:13:2423:14 | x1 | T | main.rs:2391:5:2391:20 | S1 |
-| main.rs:2423:13:2423:14 | x1 | T.T | main.rs:2393:5:2394:14 | S2 |
-| main.rs:2423:34:2423:48 | ...::assoc_fun(...) |  | {EXTERNAL LOCATION} | Option |
-| main.rs:2423:34:2423:48 | ...::assoc_fun(...) | T | main.rs:2391:5:2391:20 | S1 |
-| main.rs:2423:34:2423:48 | ...::assoc_fun(...) | T.T | main.rs:2393:5:2394:14 | S2 |
-| main.rs:2424:13:2424:14 | x2 |  | {EXTERNAL LOCATION} | Option |
-| main.rs:2424:13:2424:14 | x2 | T | main.rs:2391:5:2391:20 | S1 |
-| main.rs:2424:13:2424:14 | x2 | T.T | main.rs:2393:5:2394:14 | S2 |
-| main.rs:2424:18:2424:38 | ...::assoc_fun(...) |  | {EXTERNAL LOCATION} | Option |
-| main.rs:2424:18:2424:38 | ...::assoc_fun(...) | T | main.rs:2391:5:2391:20 | S1 |
-| main.rs:2424:18:2424:38 | ...::assoc_fun(...) | T.T | main.rs:2393:5:2394:14 | S2 |
-| main.rs:2425:13:2425:14 | x3 |  | {EXTERNAL LOCATION} | Option |
-| main.rs:2425:13:2425:14 | x3 | T | main.rs:2391:5:2391:20 | S1 |
-| main.rs:2425:13:2425:14 | x3 | T.T | main.rs:2393:5:2394:14 | S2 |
-| main.rs:2425:18:2425:32 | ...::assoc_fun(...) |  | {EXTERNAL LOCATION} | Option |
-| main.rs:2425:18:2425:32 | ...::assoc_fun(...) | T | main.rs:2391:5:2391:20 | S1 |
-| main.rs:2425:18:2425:32 | ...::assoc_fun(...) | T.T | main.rs:2393:5:2394:14 | S2 |
-| main.rs:2426:13:2426:14 | x4 |  | main.rs:2391:5:2391:20 | S1 |
-| main.rs:2426:13:2426:14 | x4 | T | main.rs:2393:5:2394:14 | S2 |
-| main.rs:2426:18:2426:48 | ...::method(...) |  | main.rs:2391:5:2391:20 | S1 |
-| main.rs:2426:18:2426:48 | ...::method(...) | T | main.rs:2393:5:2394:14 | S2 |
-| main.rs:2426:35:2426:47 | ...::default(...) |  | main.rs:2391:5:2391:20 | S1 |
-| main.rs:2426:35:2426:47 | ...::default(...) | T | main.rs:2393:5:2394:14 | S2 |
-| main.rs:2427:13:2427:14 | x5 |  | main.rs:2391:5:2391:20 | S1 |
-| main.rs:2427:13:2427:14 | x5 | T | main.rs:2393:5:2394:14 | S2 |
-| main.rs:2427:18:2427:42 | ...::method(...) |  | main.rs:2391:5:2391:20 | S1 |
-| main.rs:2427:18:2427:42 | ...::method(...) | T | main.rs:2393:5:2394:14 | S2 |
-| main.rs:2427:29:2427:41 | ...::default(...) |  | main.rs:2391:5:2391:20 | S1 |
-| main.rs:2427:29:2427:41 | ...::default(...) | T | main.rs:2393:5:2394:14 | S2 |
-| main.rs:2428:13:2428:14 | x6 |  | main.rs:2412:5:2412:27 | S4 |
-| main.rs:2428:13:2428:14 | x6 | T4 | main.rs:2393:5:2394:14 | S2 |
-| main.rs:2428:18:2428:45 | S4::<...>(...) |  | main.rs:2412:5:2412:27 | S4 |
-| main.rs:2428:18:2428:45 | S4::<...>(...) | T4 | main.rs:2393:5:2394:14 | S2 |
-| main.rs:2428:27:2428:44 | ...::default(...) |  | main.rs:2393:5:2394:14 | S2 |
-| main.rs:2429:13:2429:14 | x7 |  | main.rs:2412:5:2412:27 | S4 |
-| main.rs:2429:13:2429:14 | x7 | T4 | main.rs:2393:5:2394:14 | S2 |
-| main.rs:2429:18:2429:23 | S4(...) |  | main.rs:2412:5:2412:27 | S4 |
-| main.rs:2429:18:2429:23 | S4(...) | T4 | main.rs:2393:5:2394:14 | S2 |
-| main.rs:2429:21:2429:22 | S2 |  | main.rs:2393:5:2394:14 | S2 |
-| main.rs:2430:13:2430:14 | x8 |  | main.rs:2412:5:2412:27 | S4 |
-| main.rs:2430:13:2430:14 | x8 | T4 | {EXTERNAL LOCATION} | i32 |
-| main.rs:2430:18:2430:22 | S4(...) |  | main.rs:2412:5:2412:27 | S4 |
-| main.rs:2430:18:2430:22 | S4(...) | T4 | {EXTERNAL LOCATION} | i32 |
-| main.rs:2430:21:2430:21 | 0 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2431:13:2431:14 | x9 |  | main.rs:2412:5:2412:27 | S4 |
-| main.rs:2431:13:2431:14 | x9 | T4 | main.rs:2393:5:2394:14 | S2 |
-| main.rs:2431:18:2431:34 | S4(...) |  | main.rs:2412:5:2412:27 | S4 |
-| main.rs:2431:18:2431:34 | S4(...) | T4 | main.rs:2393:5:2394:14 | S2 |
-| main.rs:2431:21:2431:33 | ...::default(...) |  | main.rs:2393:5:2394:14 | S2 |
-| main.rs:2432:13:2432:15 | x10 |  | main.rs:2414:5:2416:5 | S5 |
-| main.rs:2432:13:2432:15 | x10 | T5 | main.rs:2393:5:2394:14 | S2 |
-| main.rs:2432:19:2435:9 | S5::<...> {...} |  | main.rs:2414:5:2416:5 | S5 |
-| main.rs:2432:19:2435:9 | S5::<...> {...} | T5 | main.rs:2393:5:2394:14 | S2 |
-| main.rs:2434:20:2434:37 | ...::default(...) |  | main.rs:2393:5:2394:14 | S2 |
-| main.rs:2436:13:2436:15 | x11 |  | main.rs:2414:5:2416:5 | S5 |
-| main.rs:2436:13:2436:15 | x11 | T5 | main.rs:2393:5:2394:14 | S2 |
-| main.rs:2436:19:2436:34 | S5 {...} |  | main.rs:2414:5:2416:5 | S5 |
-| main.rs:2436:19:2436:34 | S5 {...} | T5 | main.rs:2393:5:2394:14 | S2 |
-| main.rs:2436:31:2436:32 | S2 |  | main.rs:2393:5:2394:14 | S2 |
-| main.rs:2437:13:2437:15 | x12 |  | main.rs:2414:5:2416:5 | S5 |
-| main.rs:2437:13:2437:15 | x12 | T5 | {EXTERNAL LOCATION} | i32 |
-| main.rs:2437:19:2437:33 | S5 {...} |  | main.rs:2414:5:2416:5 | S5 |
-| main.rs:2437:19:2437:33 | S5 {...} | T5 | {EXTERNAL LOCATION} | i32 |
-| main.rs:2437:31:2437:31 | 0 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2438:13:2438:15 | x13 |  | main.rs:2414:5:2416:5 | S5 |
-| main.rs:2438:13:2438:15 | x13 | T5 | main.rs:2393:5:2394:14 | S2 |
-| main.rs:2438:19:2441:9 | S5 {...} |  | main.rs:2414:5:2416:5 | S5 |
-| main.rs:2438:19:2441:9 | S5 {...} | T5 | main.rs:2393:5:2394:14 | S2 |
-| main.rs:2440:20:2440:32 | ...::default(...) |  | main.rs:2393:5:2394:14 | S2 |
-| main.rs:2442:13:2442:15 | x14 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2442:19:2442:48 | foo::<...>(...) |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2442:30:2442:47 | ...::default(...) |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2451:35:2453:9 | { ... } |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2451:35:2453:9 | { ... } | 0(2) | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2451:35:2453:9 | { ... } | 1(2) | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2452:13:2452:26 | TupleExpr |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2452:13:2452:26 | TupleExpr | 0(2) | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2452:13:2452:26 | TupleExpr | 1(2) | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2452:14:2452:18 | S1 {...} |  | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2452:21:2452:25 | S1 {...} |  | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2454:16:2454:19 | SelfParam |  | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2458:13:2458:13 | a |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2458:13:2458:13 | a | 0(2) | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2458:13:2458:13 | a | 1(2) | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2458:17:2458:30 | ...::get_pair(...) |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2458:17:2458:30 | ...::get_pair(...) | 0(2) | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2458:17:2458:30 | ...::get_pair(...) | 1(2) | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2459:17:2459:17 | b |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2459:17:2459:17 | b | 0(2) | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2459:17:2459:17 | b | 1(2) | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2459:21:2459:34 | ...::get_pair(...) |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2459:21:2459:34 | ...::get_pair(...) | 0(2) | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2459:21:2459:34 | ...::get_pair(...) | 1(2) | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2460:13:2460:18 | TuplePat |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2460:13:2460:18 | TuplePat | 0(2) | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2460:13:2460:18 | TuplePat | 1(2) | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2460:14:2460:14 | c |  | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2460:17:2460:17 | d |  | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2460:22:2460:35 | ...::get_pair(...) |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2460:22:2460:35 | ...::get_pair(...) | 0(2) | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2460:22:2460:35 | ...::get_pair(...) | 1(2) | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2461:13:2461:22 | TuplePat |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2461:13:2461:22 | TuplePat | 0(2) | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2461:13:2461:22 | TuplePat | 1(2) | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2461:18:2461:18 | e |  | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2461:21:2461:21 | f |  | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2461:26:2461:39 | ...::get_pair(...) |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2461:26:2461:39 | ...::get_pair(...) | 0(2) | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2461:26:2461:39 | ...::get_pair(...) | 1(2) | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2462:13:2462:26 | TuplePat |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2462:13:2462:26 | TuplePat | 0(2) | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2462:13:2462:26 | TuplePat | 1(2) | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2462:18:2462:18 | g |  | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2462:25:2462:25 | h |  | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2462:30:2462:43 | ...::get_pair(...) |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2462:30:2462:43 | ...::get_pair(...) | 0(2) | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2462:30:2462:43 | ...::get_pair(...) | 1(2) | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2464:9:2464:9 | a |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2464:9:2464:9 | a | 0(2) | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2464:9:2464:9 | a | 1(2) | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2464:9:2464:11 | a.0 |  | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2465:9:2465:9 | b |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2465:9:2465:9 | b | 0(2) | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2465:9:2465:9 | b | 1(2) | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2465:9:2465:11 | b.1 |  | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2466:9:2466:9 | c |  | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2467:9:2467:9 | d |  | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2468:9:2468:9 | e |  | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2469:9:2469:9 | f |  | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2470:9:2470:9 | g |  | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2471:9:2471:9 | h |  | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2476:13:2476:13 | a |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2476:17:2476:34 | ...::default(...) |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2477:13:2477:13 | b |  | {EXTERNAL LOCATION} | bool |
-| main.rs:2477:17:2477:34 | ...::default(...) |  | {EXTERNAL LOCATION} | bool |
-| main.rs:2478:13:2478:16 | pair |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2478:13:2478:16 | pair | 0(2) | {EXTERNAL LOCATION} | i64 |
-| main.rs:2478:13:2478:16 | pair | 1(2) | {EXTERNAL LOCATION} | bool |
-| main.rs:2478:20:2478:25 | TupleExpr |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2478:20:2478:25 | TupleExpr | 0(2) | {EXTERNAL LOCATION} | i64 |
-| main.rs:2478:20:2478:25 | TupleExpr | 1(2) | {EXTERNAL LOCATION} | bool |
-| main.rs:2478:21:2478:21 | a |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2478:24:2478:24 | b |  | {EXTERNAL LOCATION} | bool |
-| main.rs:2479:13:2479:13 | i |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2479:22:2479:25 | pair |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2479:22:2479:25 | pair | 0(2) | {EXTERNAL LOCATION} | i64 |
-| main.rs:2479:22:2479:25 | pair | 1(2) | {EXTERNAL LOCATION} | bool |
-| main.rs:2479:22:2479:27 | pair.0 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2480:13:2480:13 | j |  | {EXTERNAL LOCATION} | bool |
-| main.rs:2480:23:2480:26 | pair |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2480:23:2480:26 | pair | 0(2) | {EXTERNAL LOCATION} | i64 |
-| main.rs:2480:23:2480:26 | pair | 1(2) | {EXTERNAL LOCATION} | bool |
-| main.rs:2480:23:2480:28 | pair.1 |  | {EXTERNAL LOCATION} | bool |
-| main.rs:2482:13:2482:16 | pair |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2482:13:2482:16 | pair | 0(2) | {EXTERNAL LOCATION} | i32 |
-| main.rs:2482:13:2482:16 | pair | 1(2) | {EXTERNAL LOCATION} | i32 |
-| main.rs:2482:20:2482:25 | [...] |  | file://:0:0:0:0 | [] |
-| main.rs:2482:20:2482:25 | [...] | [T;...] | {EXTERNAL LOCATION} | i32 |
-| main.rs:2482:20:2482:32 | ... .into() |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2482:20:2482:32 | ... .into() | 0(2) | {EXTERNAL LOCATION} | i32 |
-| main.rs:2482:20:2482:32 | ... .into() | 1(2) | {EXTERNAL LOCATION} | i32 |
-| main.rs:2482:21:2482:21 | 1 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2482:24:2482:24 | 1 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2483:15:2483:18 | pair |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2483:15:2483:18 | pair | 0(2) | {EXTERNAL LOCATION} | i32 |
-| main.rs:2483:15:2483:18 | pair | 1(2) | {EXTERNAL LOCATION} | i32 |
-| main.rs:2484:13:2484:18 | TuplePat |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2484:13:2484:18 | TuplePat | 0(2) | {EXTERNAL LOCATION} | i32 |
-| main.rs:2484:13:2484:18 | TuplePat | 1(2) | {EXTERNAL LOCATION} | i32 |
-| main.rs:2484:14:2484:14 | 0 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2484:17:2484:17 | 0 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2484:30:2484:41 | "unexpected" |  | file://:0:0:0:0 | & |
-| main.rs:2484:30:2484:41 | "unexpected" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:2484:30:2484:41 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:2484:30:2484:41 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:2485:13:2485:13 | _ |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2485:13:2485:13 | _ | 0(2) | {EXTERNAL LOCATION} | i32 |
-| main.rs:2485:13:2485:13 | _ | 1(2) | {EXTERNAL LOCATION} | i32 |
-| main.rs:2485:25:2485:34 | "expected" |  | file://:0:0:0:0 | & |
-| main.rs:2485:25:2485:34 | "expected" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:2485:25:2485:34 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:2485:25:2485:34 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:2487:13:2487:13 | x |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2487:17:2487:20 | pair |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2487:17:2487:20 | pair | 0(2) | {EXTERNAL LOCATION} | i32 |
-| main.rs:2487:17:2487:20 | pair | 1(2) | {EXTERNAL LOCATION} | i32 |
-| main.rs:2487:17:2487:22 | pair.0 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2489:13:2489:13 | y |  | file://:0:0:0:0 | & |
-| main.rs:2489:13:2489:13 | y | &T | file://:0:0:0:0 | (T_2) |
-| main.rs:2489:13:2489:13 | y | &T.0(2) | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2489:13:2489:13 | y | &T.1(2) | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2489:17:2489:31 | &... |  | file://:0:0:0:0 | & |
-| main.rs:2489:17:2489:31 | &... | &T | file://:0:0:0:0 | (T_2) |
-| main.rs:2489:17:2489:31 | &... | &T.0(2) | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2489:17:2489:31 | &... | &T.1(2) | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2489:18:2489:31 | ...::get_pair(...) |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2489:18:2489:31 | ...::get_pair(...) | 0(2) | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2489:18:2489:31 | ...::get_pair(...) | 1(2) | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2490:9:2490:9 | y |  | file://:0:0:0:0 | & |
-| main.rs:2490:9:2490:9 | y | &T | file://:0:0:0:0 | (T_2) |
-| main.rs:2490:9:2490:9 | y | &T.0(2) | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2490:9:2490:9 | y | &T.1(2) | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2490:9:2490:11 | y.0 |  | main.rs:2447:5:2448:16 | S1 |
-| main.rs:2497:13:2497:23 | boxed_value |  | {EXTERNAL LOCATION} | Box |
-| main.rs:2497:13:2497:23 | boxed_value | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2497:13:2497:23 | boxed_value | T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2497:27:2497:42 | ...::new(...) |  | {EXTERNAL LOCATION} | Box |
-| main.rs:2497:27:2497:42 | ...::new(...) | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2497:27:2497:42 | ...::new(...) | T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2497:36:2497:41 | 100i32 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2500:15:2500:25 | boxed_value |  | {EXTERNAL LOCATION} | Box |
-| main.rs:2500:15:2500:25 | boxed_value | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2500:15:2500:25 | boxed_value | T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2501:13:2501:19 | box 100 |  | {EXTERNAL LOCATION} | Box |
-| main.rs:2501:13:2501:19 | box 100 | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2501:13:2501:19 | box 100 | T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2501:17:2501:19 | 100 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2502:26:2502:36 | "Boxed 100\\n" |  | file://:0:0:0:0 | & |
-| main.rs:2502:26:2502:36 | "Boxed 100\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:2502:26:2502:36 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:2502:26:2502:36 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:2504:13:2504:17 | box ... |  | {EXTERNAL LOCATION} | Box |
-| main.rs:2504:13:2504:17 | box ... | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2504:13:2504:17 | box ... | T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2506:26:2506:42 | "Boxed value: {}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:2506:26:2506:42 | "Boxed value: {}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:2506:26:2506:51 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:2506:26:2506:51 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:2511:13:2511:22 | nested_box |  | {EXTERNAL LOCATION} | Box |
-| main.rs:2511:13:2511:22 | nested_box | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2511:13:2511:22 | nested_box | T | {EXTERNAL LOCATION} | Box |
-| main.rs:2511:13:2511:22 | nested_box | T.A | {EXTERNAL LOCATION} | Global |
-| main.rs:2511:13:2511:22 | nested_box | T.T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2511:26:2511:50 | ...::new(...) |  | {EXTERNAL LOCATION} | Box |
-| main.rs:2511:26:2511:50 | ...::new(...) | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2511:26:2511:50 | ...::new(...) | T | {EXTERNAL LOCATION} | Box |
-| main.rs:2511:26:2511:50 | ...::new(...) | T.A | {EXTERNAL LOCATION} | Global |
-| main.rs:2511:26:2511:50 | ...::new(...) | T.T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2511:35:2511:49 | ...::new(...) |  | {EXTERNAL LOCATION} | Box |
-| main.rs:2511:35:2511:49 | ...::new(...) | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2511:35:2511:49 | ...::new(...) | T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2511:44:2511:48 | 42i32 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2512:15:2512:24 | nested_box |  | {EXTERNAL LOCATION} | Box |
-| main.rs:2512:15:2512:24 | nested_box | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2512:15:2512:24 | nested_box | T | {EXTERNAL LOCATION} | Box |
-| main.rs:2512:15:2512:24 | nested_box | T.A | {EXTERNAL LOCATION} | Global |
-| main.rs:2512:15:2512:24 | nested_box | T.T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2513:13:2513:21 | box ... |  | {EXTERNAL LOCATION} | Box |
-| main.rs:2513:13:2513:21 | box ... | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2513:13:2513:21 | box ... | T | {EXTERNAL LOCATION} | Box |
-| main.rs:2513:13:2513:21 | box ... | T.A | {EXTERNAL LOCATION} | Global |
-| main.rs:2513:13:2513:21 | box ... | T.T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2515:26:2515:43 | "Nested boxed: {}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:2515:26:2515:43 | "Nested boxed: {}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:2515:26:2515:59 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:2515:26:2515:59 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:2527:21:2527:25 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:2527:21:2527:25 | SelfParam | &T | main.rs:2526:5:2529:5 | Self [trait Executor] |
-| main.rs:2528:24:2528:28 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:2528:24:2528:28 | SelfParam | &T | main.rs:2526:5:2529:5 | Self [trait Executor] |
-| main.rs:2528:31:2528:35 | query |  | main.rs:2528:21:2528:21 | E |
-| main.rs:2532:21:2532:25 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:2532:21:2532:25 | SelfParam | &T | main.rs:2531:10:2531:22 | T |
-| main.rs:2533:22:2533:41 | "Executor::execute1\\n" |  | file://:0:0:0:0 | & |
-| main.rs:2533:22:2533:41 | "Executor::execute1\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:2533:22:2533:41 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:2533:22:2533:41 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:2536:24:2536:28 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:2536:24:2536:28 | SelfParam | &T | main.rs:2531:10:2531:22 | T |
-| main.rs:2536:31:2536:36 | _query |  | main.rs:2536:21:2536:21 | E |
-| main.rs:2537:22:2537:41 | "Executor::execute2\\n" |  | file://:0:0:0:0 | & |
-| main.rs:2537:22:2537:41 | "Executor::execute2\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:2537:22:2537:41 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:2537:22:2537:41 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:2546:13:2546:13 | c |  | main.rs:2541:5:2541:29 | MySqlConnection |
-| main.rs:2546:17:2546:34 | MySqlConnection {...} |  | main.rs:2541:5:2541:29 | MySqlConnection |
-| main.rs:2548:9:2548:9 | c |  | main.rs:2541:5:2541:29 | MySqlConnection |
-| main.rs:2549:35:2549:36 | &c |  | file://:0:0:0:0 | & |
-| main.rs:2549:35:2549:36 | &c | &T | main.rs:2541:5:2541:29 | MySqlConnection |
-| main.rs:2549:36:2549:36 | c |  | main.rs:2541:5:2541:29 | MySqlConnection |
-| main.rs:2551:9:2551:9 | c |  | main.rs:2541:5:2541:29 | MySqlConnection |
-| main.rs:2551:20:2551:40 | "SELECT * FROM users" |  | file://:0:0:0:0 | & |
-| main.rs:2551:20:2551:40 | "SELECT * FROM users" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:2552:9:2552:9 | c |  | main.rs:2541:5:2541:29 | MySqlConnection |
-| main.rs:2552:28:2552:48 | "SELECT * FROM users" |  | file://:0:0:0:0 | & |
-| main.rs:2552:28:2552:48 | "SELECT * FROM users" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:2553:35:2553:36 | &c |  | file://:0:0:0:0 | & |
-| main.rs:2553:35:2553:36 | &c | &T | main.rs:2541:5:2541:29 | MySqlConnection |
-| main.rs:2553:36:2553:36 | c |  | main.rs:2541:5:2541:29 | MySqlConnection |
-| main.rs:2553:39:2553:59 | "SELECT * FROM users" |  | file://:0:0:0:0 | & |
-| main.rs:2553:39:2553:59 | "SELECT * FROM users" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:2554:43:2554:44 | &c |  | file://:0:0:0:0 | & |
-| main.rs:2554:43:2554:44 | &c | &T | main.rs:2541:5:2541:29 | MySqlConnection |
-| main.rs:2554:44:2554:44 | c |  | main.rs:2541:5:2541:29 | MySqlConnection |
-| main.rs:2554:47:2554:67 | "SELECT * FROM users" |  | file://:0:0:0:0 | & |
-| main.rs:2554:47:2554:67 | "SELECT * FROM users" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:2565:36:2567:9 | { ... } |  | main.rs:2561:5:2562:5 | Path |
-| main.rs:2566:13:2566:20 | Path {...} |  | main.rs:2561:5:2562:5 | Path |
-| main.rs:2569:29:2569:33 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:2569:29:2569:33 | SelfParam | &T | main.rs:2561:5:2562:5 | Path |
-| main.rs:2569:59:2571:9 | { ... } |  | {EXTERNAL LOCATION} | Result |
-| main.rs:2569:59:2571:9 | { ... } | E | file://:0:0:0:0 | () |
-| main.rs:2569:59:2571:9 | { ... } | T | main.rs:2574:5:2575:5 | PathBuf |
-| main.rs:2570:13:2570:30 | Ok(...) |  | {EXTERNAL LOCATION} | Result |
-| main.rs:2570:13:2570:30 | Ok(...) | E | file://:0:0:0:0 | () |
-| main.rs:2570:13:2570:30 | Ok(...) | T | main.rs:2574:5:2575:5 | PathBuf |
-| main.rs:2570:16:2570:29 | ...::new(...) |  | main.rs:2574:5:2575:5 | PathBuf |
-| main.rs:2578:39:2580:9 | { ... } |  | main.rs:2574:5:2575:5 | PathBuf |
-| main.rs:2579:13:2579:23 | PathBuf {...} |  | main.rs:2574:5:2575:5 | PathBuf |
+| main.rs:2336:13:2336:13 | i |  | {EXTERNAL LOCATION} | Item |
+| main.rs:2336:18:2336:48 | &... |  | file://:0:0:0:0 | & |
+| main.rs:2336:19:2336:36 | [...] |  | file://:0:0:0:0 | [] |
+| main.rs:2336:19:2336:36 | [...] | [T;...] | {EXTERNAL LOCATION} | i64 |
+| main.rs:2336:20:2336:23 | 1i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2336:26:2336:29 | 2i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2336:32:2336:35 | 3i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2338:13:2338:18 | range1 |  | {EXTERNAL LOCATION} | Range |
+| main.rs:2338:13:2338:18 | range1 | Idx | {EXTERNAL LOCATION} | u16 |
+| main.rs:2339:9:2342:9 | ...::Range {...} |  | {EXTERNAL LOCATION} | Range |
+| main.rs:2339:9:2342:9 | ...::Range {...} | Idx | {EXTERNAL LOCATION} | u16 |
+| main.rs:2340:20:2340:23 | 0u16 |  | {EXTERNAL LOCATION} | u16 |
+| main.rs:2341:18:2341:22 | 10u16 |  | {EXTERNAL LOCATION} | u16 |
+| main.rs:2343:13:2343:13 | u |  | {EXTERNAL LOCATION} | Item |
+| main.rs:2343:13:2343:13 | u |  | {EXTERNAL LOCATION} | u16 |
+| main.rs:2343:18:2343:23 | range1 |  | {EXTERNAL LOCATION} | Range |
+| main.rs:2343:18:2343:23 | range1 | Idx | {EXTERNAL LOCATION} | u16 |
+| main.rs:2347:26:2347:26 | 1 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2347:29:2347:29 | 2 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2347:32:2347:32 | 3 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2350:13:2350:18 | vals4a |  | {EXTERNAL LOCATION} | Vec |
+| main.rs:2350:13:2350:18 | vals4a | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2350:13:2350:18 | vals4a | T | {EXTERNAL LOCATION} | u16 |
+| main.rs:2350:32:2350:43 | [...] |  | file://:0:0:0:0 | [] |
+| main.rs:2350:32:2350:43 | [...] | [T;...] | {EXTERNAL LOCATION} | i32 |
+| main.rs:2350:32:2350:43 | [...] | [T;...] | {EXTERNAL LOCATION} | u16 |
+| main.rs:2350:32:2350:52 | ... .to_vec() |  | {EXTERNAL LOCATION} | Vec |
+| main.rs:2350:32:2350:52 | ... .to_vec() | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2350:32:2350:52 | ... .to_vec() | T | {EXTERNAL LOCATION} | u16 |
+| main.rs:2350:33:2350:36 | 1u16 |  | {EXTERNAL LOCATION} | u16 |
+| main.rs:2350:39:2350:39 | 2 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2350:39:2350:39 | 2 |  | {EXTERNAL LOCATION} | u16 |
+| main.rs:2350:42:2350:42 | 3 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2350:42:2350:42 | 3 |  | {EXTERNAL LOCATION} | u16 |
+| main.rs:2351:13:2351:13 | u |  | {EXTERNAL LOCATION} | u16 |
+| main.rs:2351:13:2351:13 | u |  | file://:0:0:0:0 | & |
+| main.rs:2351:18:2351:23 | vals4a |  | {EXTERNAL LOCATION} | Vec |
+| main.rs:2351:18:2351:23 | vals4a | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2351:18:2351:23 | vals4a | T | {EXTERNAL LOCATION} | u16 |
+| main.rs:2353:22:2353:33 | [...] |  | file://:0:0:0:0 | [] |
+| main.rs:2353:22:2353:33 | [...] | [T;...] | {EXTERNAL LOCATION} | i32 |
+| main.rs:2353:22:2353:33 | [...] | [T;...] | {EXTERNAL LOCATION} | u16 |
+| main.rs:2353:23:2353:26 | 1u16 |  | {EXTERNAL LOCATION} | u16 |
+| main.rs:2353:29:2353:29 | 2 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2353:29:2353:29 | 2 |  | {EXTERNAL LOCATION} | u16 |
+| main.rs:2353:32:2353:32 | 3 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2353:32:2353:32 | 3 |  | {EXTERNAL LOCATION} | u16 |
+| main.rs:2356:13:2356:17 | vals5 |  | {EXTERNAL LOCATION} | Vec |
+| main.rs:2356:13:2356:17 | vals5 | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2356:13:2356:17 | vals5 | T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2356:13:2356:17 | vals5 | T | {EXTERNAL LOCATION} | u32 |
+| main.rs:2356:21:2356:43 | ...::from(...) |  | {EXTERNAL LOCATION} | Vec |
+| main.rs:2356:21:2356:43 | ...::from(...) | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2356:21:2356:43 | ...::from(...) | T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2356:21:2356:43 | ...::from(...) | T | {EXTERNAL LOCATION} | u32 |
+| main.rs:2356:31:2356:42 | [...] |  | file://:0:0:0:0 | [] |
+| main.rs:2356:31:2356:42 | [...] | [T;...] | {EXTERNAL LOCATION} | i32 |
+| main.rs:2356:31:2356:42 | [...] | [T;...] | {EXTERNAL LOCATION} | u32 |
+| main.rs:2356:32:2356:35 | 1u32 |  | {EXTERNAL LOCATION} | u32 |
+| main.rs:2356:38:2356:38 | 2 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2356:38:2356:38 | 2 |  | {EXTERNAL LOCATION} | u32 |
+| main.rs:2356:41:2356:41 | 3 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2356:41:2356:41 | 3 |  | {EXTERNAL LOCATION} | u32 |
+| main.rs:2357:13:2357:13 | u |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2357:13:2357:13 | u |  | {EXTERNAL LOCATION} | u32 |
+| main.rs:2357:13:2357:13 | u |  | file://:0:0:0:0 | & |
+| main.rs:2357:18:2357:22 | vals5 |  | {EXTERNAL LOCATION} | Vec |
+| main.rs:2357:18:2357:22 | vals5 | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2357:18:2357:22 | vals5 | T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2357:18:2357:22 | vals5 | T | {EXTERNAL LOCATION} | u32 |
+| main.rs:2359:13:2359:17 | vals6 |  | {EXTERNAL LOCATION} | Vec |
+| main.rs:2359:13:2359:17 | vals6 | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2359:13:2359:17 | vals6 | T | file://:0:0:0:0 | & |
+| main.rs:2359:13:2359:17 | vals6 | T.&T | {EXTERNAL LOCATION} | u64 |
+| main.rs:2359:32:2359:43 | [...] |  | file://:0:0:0:0 | [] |
+| main.rs:2359:32:2359:43 | [...] | [T;...] | {EXTERNAL LOCATION} | i32 |
+| main.rs:2359:32:2359:43 | [...] | [T;...] | {EXTERNAL LOCATION} | u64 |
+| main.rs:2359:32:2359:60 | ... .collect() |  | {EXTERNAL LOCATION} | Vec |
+| main.rs:2359:32:2359:60 | ... .collect() | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2359:32:2359:60 | ... .collect() | T | file://:0:0:0:0 | & |
+| main.rs:2359:32:2359:60 | ... .collect() | T.&T | {EXTERNAL LOCATION} | u64 |
+| main.rs:2359:33:2359:36 | 1u64 |  | {EXTERNAL LOCATION} | u64 |
+| main.rs:2359:39:2359:39 | 2 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2359:39:2359:39 | 2 |  | {EXTERNAL LOCATION} | u64 |
+| main.rs:2359:42:2359:42 | 3 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2359:42:2359:42 | 3 |  | {EXTERNAL LOCATION} | u64 |
+| main.rs:2360:13:2360:13 | u |  | file://:0:0:0:0 | & |
+| main.rs:2360:13:2360:13 | u | &T | {EXTERNAL LOCATION} | u64 |
+| main.rs:2360:18:2360:22 | vals6 |  | {EXTERNAL LOCATION} | Vec |
+| main.rs:2360:18:2360:22 | vals6 | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2360:18:2360:22 | vals6 | T | file://:0:0:0:0 | & |
+| main.rs:2360:18:2360:22 | vals6 | T.&T | {EXTERNAL LOCATION} | u64 |
+| main.rs:2362:17:2362:21 | vals7 |  | {EXTERNAL LOCATION} | Vec |
+| main.rs:2362:17:2362:21 | vals7 | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2362:17:2362:21 | vals7 | T | {EXTERNAL LOCATION} | u8 |
+| main.rs:2362:25:2362:34 | ...::new(...) |  | {EXTERNAL LOCATION} | Vec |
+| main.rs:2362:25:2362:34 | ...::new(...) | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2362:25:2362:34 | ...::new(...) | T | {EXTERNAL LOCATION} | u8 |
+| main.rs:2363:9:2363:13 | vals7 |  | {EXTERNAL LOCATION} | Vec |
+| main.rs:2363:9:2363:13 | vals7 | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2363:9:2363:13 | vals7 | T | {EXTERNAL LOCATION} | u8 |
+| main.rs:2363:20:2363:22 | 1u8 |  | {EXTERNAL LOCATION} | u8 |
+| main.rs:2364:13:2364:13 | u |  | {EXTERNAL LOCATION} | u8 |
+| main.rs:2364:13:2364:13 | u |  | file://:0:0:0:0 | & |
+| main.rs:2364:18:2364:22 | vals7 |  | {EXTERNAL LOCATION} | Vec |
+| main.rs:2364:18:2364:22 | vals7 | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2364:18:2364:22 | vals7 | T | {EXTERNAL LOCATION} | u8 |
+| main.rs:2366:33:2366:33 | 1 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2366:36:2366:36 | 2 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2366:45:2366:45 | 3 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2366:48:2366:48 | 4 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2373:17:2373:20 | map1 |  | {EXTERNAL LOCATION} | HashMap |
+| main.rs:2373:17:2373:20 | map1 | K | {EXTERNAL LOCATION} | i32 |
+| main.rs:2373:17:2373:20 | map1 | S | {EXTERNAL LOCATION} | RandomState |
+| main.rs:2373:17:2373:20 | map1 | V | {EXTERNAL LOCATION} | Box |
+| main.rs:2373:17:2373:20 | map1 | V.A | {EXTERNAL LOCATION} | Global |
+| main.rs:2373:17:2373:20 | map1 | V.T | file://:0:0:0:0 | & |
+| main.rs:2373:17:2373:20 | map1 | V.T.&T | {EXTERNAL LOCATION} | str |
+| main.rs:2373:24:2373:55 | ...::new(...) |  | {EXTERNAL LOCATION} | HashMap |
+| main.rs:2373:24:2373:55 | ...::new(...) | K | {EXTERNAL LOCATION} | i32 |
+| main.rs:2373:24:2373:55 | ...::new(...) | S | {EXTERNAL LOCATION} | RandomState |
+| main.rs:2373:24:2373:55 | ...::new(...) | V | {EXTERNAL LOCATION} | Box |
+| main.rs:2373:24:2373:55 | ...::new(...) | V.A | {EXTERNAL LOCATION} | Global |
+| main.rs:2373:24:2373:55 | ...::new(...) | V.T | file://:0:0:0:0 | & |
+| main.rs:2373:24:2373:55 | ...::new(...) | V.T.&T | {EXTERNAL LOCATION} | str |
+| main.rs:2374:9:2374:12 | map1 |  | {EXTERNAL LOCATION} | HashMap |
+| main.rs:2374:9:2374:12 | map1 | K | {EXTERNAL LOCATION} | i32 |
+| main.rs:2374:9:2374:12 | map1 | S | {EXTERNAL LOCATION} | RandomState |
+| main.rs:2374:9:2374:12 | map1 | V | {EXTERNAL LOCATION} | Box |
+| main.rs:2374:9:2374:12 | map1 | V.A | {EXTERNAL LOCATION} | Global |
+| main.rs:2374:9:2374:12 | map1 | V.T | file://:0:0:0:0 | & |
+| main.rs:2374:9:2374:12 | map1 | V.T.&T | {EXTERNAL LOCATION} | str |
+| main.rs:2374:9:2374:39 | map1.insert(...) |  | {EXTERNAL LOCATION} | Option |
+| main.rs:2374:9:2374:39 | map1.insert(...) | T | {EXTERNAL LOCATION} | Box |
+| main.rs:2374:9:2374:39 | map1.insert(...) | T.A | {EXTERNAL LOCATION} | Global |
+| main.rs:2374:9:2374:39 | map1.insert(...) | T.T | file://:0:0:0:0 | & |
+| main.rs:2374:9:2374:39 | map1.insert(...) | T.T.&T | {EXTERNAL LOCATION} | str |
+| main.rs:2374:21:2374:21 | 1 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2374:24:2374:38 | ...::new(...) |  | {EXTERNAL LOCATION} | Box |
+| main.rs:2374:24:2374:38 | ...::new(...) | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2374:24:2374:38 | ...::new(...) | T | file://:0:0:0:0 | & |
+| main.rs:2374:24:2374:38 | ...::new(...) | T.&T | {EXTERNAL LOCATION} | str |
+| main.rs:2374:33:2374:37 | "one" |  | file://:0:0:0:0 | & |
+| main.rs:2374:33:2374:37 | "one" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:2375:9:2375:12 | map1 |  | {EXTERNAL LOCATION} | HashMap |
+| main.rs:2375:9:2375:12 | map1 | K | {EXTERNAL LOCATION} | i32 |
+| main.rs:2375:9:2375:12 | map1 | S | {EXTERNAL LOCATION} | RandomState |
+| main.rs:2375:9:2375:12 | map1 | V | {EXTERNAL LOCATION} | Box |
+| main.rs:2375:9:2375:12 | map1 | V.A | {EXTERNAL LOCATION} | Global |
+| main.rs:2375:9:2375:12 | map1 | V.T | file://:0:0:0:0 | & |
+| main.rs:2375:9:2375:12 | map1 | V.T.&T | {EXTERNAL LOCATION} | str |
+| main.rs:2375:9:2375:39 | map1.insert(...) |  | {EXTERNAL LOCATION} | Option |
+| main.rs:2375:9:2375:39 | map1.insert(...) | T | {EXTERNAL LOCATION} | Box |
+| main.rs:2375:9:2375:39 | map1.insert(...) | T.A | {EXTERNAL LOCATION} | Global |
+| main.rs:2375:9:2375:39 | map1.insert(...) | T.T | file://:0:0:0:0 | & |
+| main.rs:2375:9:2375:39 | map1.insert(...) | T.T.&T | {EXTERNAL LOCATION} | str |
+| main.rs:2375:21:2375:21 | 2 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2375:24:2375:38 | ...::new(...) |  | {EXTERNAL LOCATION} | Box |
+| main.rs:2375:24:2375:38 | ...::new(...) | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2375:24:2375:38 | ...::new(...) | T | file://:0:0:0:0 | & |
+| main.rs:2375:24:2375:38 | ...::new(...) | T.&T | {EXTERNAL LOCATION} | str |
+| main.rs:2375:33:2375:37 | "two" |  | file://:0:0:0:0 | & |
+| main.rs:2375:33:2375:37 | "two" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:2376:13:2376:15 | key |  | {EXTERNAL LOCATION} | Item |
+| main.rs:2376:13:2376:15 | key |  | file://:0:0:0:0 | & |
+| main.rs:2376:13:2376:15 | key | &T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2376:20:2376:23 | map1 |  | {EXTERNAL LOCATION} | HashMap |
+| main.rs:2376:20:2376:23 | map1 | K | {EXTERNAL LOCATION} | i32 |
+| main.rs:2376:20:2376:23 | map1 | S | {EXTERNAL LOCATION} | RandomState |
+| main.rs:2376:20:2376:23 | map1 | V | {EXTERNAL LOCATION} | Box |
+| main.rs:2376:20:2376:23 | map1 | V.A | {EXTERNAL LOCATION} | Global |
+| main.rs:2376:20:2376:23 | map1 | V.T | file://:0:0:0:0 | & |
+| main.rs:2376:20:2376:23 | map1 | V.T.&T | {EXTERNAL LOCATION} | str |
+| main.rs:2376:20:2376:30 | map1.keys() |  | {EXTERNAL LOCATION} | Keys |
+| main.rs:2376:20:2376:30 | map1.keys() | K | {EXTERNAL LOCATION} | i32 |
+| main.rs:2376:20:2376:30 | map1.keys() | V | {EXTERNAL LOCATION} | Box |
+| main.rs:2376:20:2376:30 | map1.keys() | V.A | {EXTERNAL LOCATION} | Global |
+| main.rs:2376:20:2376:30 | map1.keys() | V.T | file://:0:0:0:0 | & |
+| main.rs:2376:20:2376:30 | map1.keys() | V.T.&T | {EXTERNAL LOCATION} | str |
+| main.rs:2377:13:2377:17 | value |  | {EXTERNAL LOCATION} | Item |
+| main.rs:2377:13:2377:17 | value |  | file://:0:0:0:0 | & |
+| main.rs:2377:13:2377:17 | value | &T | {EXTERNAL LOCATION} | Box |
+| main.rs:2377:13:2377:17 | value | &T.A | {EXTERNAL LOCATION} | Global |
+| main.rs:2377:13:2377:17 | value | &T.T | file://:0:0:0:0 | & |
+| main.rs:2377:13:2377:17 | value | &T.T.&T | {EXTERNAL LOCATION} | str |
+| main.rs:2377:22:2377:25 | map1 |  | {EXTERNAL LOCATION} | HashMap |
+| main.rs:2377:22:2377:25 | map1 | K | {EXTERNAL LOCATION} | i32 |
+| main.rs:2377:22:2377:25 | map1 | S | {EXTERNAL LOCATION} | RandomState |
+| main.rs:2377:22:2377:25 | map1 | V | {EXTERNAL LOCATION} | Box |
+| main.rs:2377:22:2377:25 | map1 | V.A | {EXTERNAL LOCATION} | Global |
+| main.rs:2377:22:2377:25 | map1 | V.T | file://:0:0:0:0 | & |
+| main.rs:2377:22:2377:25 | map1 | V.T.&T | {EXTERNAL LOCATION} | str |
+| main.rs:2377:22:2377:34 | map1.values() |  | {EXTERNAL LOCATION} | Values |
+| main.rs:2377:22:2377:34 | map1.values() | K | {EXTERNAL LOCATION} | i32 |
+| main.rs:2377:22:2377:34 | map1.values() | V | {EXTERNAL LOCATION} | Box |
+| main.rs:2377:22:2377:34 | map1.values() | V.A | {EXTERNAL LOCATION} | Global |
+| main.rs:2377:22:2377:34 | map1.values() | V.T | file://:0:0:0:0 | & |
+| main.rs:2377:22:2377:34 | map1.values() | V.T.&T | {EXTERNAL LOCATION} | str |
+| main.rs:2378:13:2378:24 | TuplePat |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2378:13:2378:24 | TuplePat | 0(2) | file://:0:0:0:0 | & |
+| main.rs:2378:13:2378:24 | TuplePat | 0(2).&T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2378:13:2378:24 | TuplePat | 1(2) | file://:0:0:0:0 | & |
+| main.rs:2378:13:2378:24 | TuplePat | 1(2).&T | {EXTERNAL LOCATION} | Box |
+| main.rs:2378:13:2378:24 | TuplePat | 1(2).&T.A | {EXTERNAL LOCATION} | Global |
+| main.rs:2378:13:2378:24 | TuplePat | 1(2).&T.T | file://:0:0:0:0 | & |
+| main.rs:2378:13:2378:24 | TuplePat | 1(2).&T.T.&T | {EXTERNAL LOCATION} | str |
+| main.rs:2378:14:2378:16 | key |  | file://:0:0:0:0 | & |
+| main.rs:2378:14:2378:16 | key | &T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2378:19:2378:23 | value |  | file://:0:0:0:0 | & |
+| main.rs:2378:19:2378:23 | value | &T | {EXTERNAL LOCATION} | Box |
+| main.rs:2378:19:2378:23 | value | &T.A | {EXTERNAL LOCATION} | Global |
+| main.rs:2378:19:2378:23 | value | &T.T | file://:0:0:0:0 | & |
+| main.rs:2378:19:2378:23 | value | &T.T.&T | {EXTERNAL LOCATION} | str |
+| main.rs:2378:29:2378:32 | map1 |  | {EXTERNAL LOCATION} | HashMap |
+| main.rs:2378:29:2378:32 | map1 | K | {EXTERNAL LOCATION} | i32 |
+| main.rs:2378:29:2378:32 | map1 | S | {EXTERNAL LOCATION} | RandomState |
+| main.rs:2378:29:2378:32 | map1 | V | {EXTERNAL LOCATION} | Box |
+| main.rs:2378:29:2378:32 | map1 | V.A | {EXTERNAL LOCATION} | Global |
+| main.rs:2378:29:2378:32 | map1 | V.T | file://:0:0:0:0 | & |
+| main.rs:2378:29:2378:32 | map1 | V.T.&T | {EXTERNAL LOCATION} | str |
+| main.rs:2378:29:2378:39 | map1.iter() |  | {EXTERNAL LOCATION} | Iter |
+| main.rs:2378:29:2378:39 | map1.iter() | K | {EXTERNAL LOCATION} | i32 |
+| main.rs:2378:29:2378:39 | map1.iter() | V | {EXTERNAL LOCATION} | Box |
+| main.rs:2378:29:2378:39 | map1.iter() | V.A | {EXTERNAL LOCATION} | Global |
+| main.rs:2378:29:2378:39 | map1.iter() | V.T | file://:0:0:0:0 | & |
+| main.rs:2378:29:2378:39 | map1.iter() | V.T.&T | {EXTERNAL LOCATION} | str |
+| main.rs:2379:13:2379:24 | TuplePat |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2379:13:2379:24 | TuplePat | 0(2) | file://:0:0:0:0 | & |
+| main.rs:2379:13:2379:24 | TuplePat | 0(2).&T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2379:13:2379:24 | TuplePat | 1(2) | file://:0:0:0:0 | & |
+| main.rs:2379:13:2379:24 | TuplePat | 1(2).&T | {EXTERNAL LOCATION} | Box |
+| main.rs:2379:13:2379:24 | TuplePat | 1(2).&T.A | {EXTERNAL LOCATION} | Global |
+| main.rs:2379:13:2379:24 | TuplePat | 1(2).&T.T | file://:0:0:0:0 | & |
+| main.rs:2379:13:2379:24 | TuplePat | 1(2).&T.T.&T | {EXTERNAL LOCATION} | str |
+| main.rs:2379:14:2379:16 | key |  | file://:0:0:0:0 | & |
+| main.rs:2379:14:2379:16 | key | &T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2379:19:2379:23 | value |  | file://:0:0:0:0 | & |
+| main.rs:2379:19:2379:23 | value | &T | {EXTERNAL LOCATION} | Box |
+| main.rs:2379:19:2379:23 | value | &T.A | {EXTERNAL LOCATION} | Global |
+| main.rs:2379:19:2379:23 | value | &T.T | file://:0:0:0:0 | & |
+| main.rs:2379:19:2379:23 | value | &T.T.&T | {EXTERNAL LOCATION} | str |
+| main.rs:2379:29:2379:33 | &map1 |  | file://:0:0:0:0 | & |
+| main.rs:2379:29:2379:33 | &map1 | &T | {EXTERNAL LOCATION} | HashMap |
+| main.rs:2379:29:2379:33 | &map1 | &T.K | {EXTERNAL LOCATION} | i32 |
+| main.rs:2379:29:2379:33 | &map1 | &T.S | {EXTERNAL LOCATION} | RandomState |
+| main.rs:2379:29:2379:33 | &map1 | &T.V | {EXTERNAL LOCATION} | Box |
+| main.rs:2379:29:2379:33 | &map1 | &T.V.A | {EXTERNAL LOCATION} | Global |
+| main.rs:2379:29:2379:33 | &map1 | &T.V.T | file://:0:0:0:0 | & |
+| main.rs:2379:29:2379:33 | &map1 | &T.V.T.&T | {EXTERNAL LOCATION} | str |
+| main.rs:2379:30:2379:33 | map1 |  | {EXTERNAL LOCATION} | HashMap |
+| main.rs:2379:30:2379:33 | map1 | K | {EXTERNAL LOCATION} | i32 |
+| main.rs:2379:30:2379:33 | map1 | S | {EXTERNAL LOCATION} | RandomState |
+| main.rs:2379:30:2379:33 | map1 | V | {EXTERNAL LOCATION} | Box |
+| main.rs:2379:30:2379:33 | map1 | V.A | {EXTERNAL LOCATION} | Global |
+| main.rs:2379:30:2379:33 | map1 | V.T | file://:0:0:0:0 | & |
+| main.rs:2379:30:2379:33 | map1 | V.T.&T | {EXTERNAL LOCATION} | str |
+| main.rs:2383:17:2383:17 | a |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2383:26:2383:26 | 0 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2383:26:2383:26 | 0 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2385:23:2385:23 | a |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2385:23:2385:28 | ... < ... |  | {EXTERNAL LOCATION} | bool |
+| main.rs:2385:27:2385:28 | 10 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2385:27:2385:28 | 10 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2387:13:2387:13 | a |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2387:13:2387:18 | ... += ... |  | file://:0:0:0:0 | () |
+| main.rs:2387:18:2387:18 | 1 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2399:40:2401:9 | { ... } |  | {EXTERNAL LOCATION} | Option |
+| main.rs:2399:40:2401:9 | { ... } | T | main.rs:2393:5:2393:20 | S1 |
+| main.rs:2399:40:2401:9 | { ... } | T.T | main.rs:2398:10:2398:19 | T |
+| main.rs:2400:13:2400:16 | None |  | {EXTERNAL LOCATION} | Option |
+| main.rs:2400:13:2400:16 | None | T | main.rs:2393:5:2393:20 | S1 |
+| main.rs:2400:13:2400:16 | None | T.T | main.rs:2398:10:2398:19 | T |
+| main.rs:2403:30:2405:9 | { ... } |  | main.rs:2393:5:2393:20 | S1 |
+| main.rs:2403:30:2405:9 | { ... } | T | main.rs:2398:10:2398:19 | T |
+| main.rs:2404:13:2404:28 | S1(...) |  | main.rs:2393:5:2393:20 | S1 |
+| main.rs:2404:13:2404:28 | S1(...) | T | main.rs:2398:10:2398:19 | T |
+| main.rs:2404:16:2404:27 | ...::default(...) |  | main.rs:2398:10:2398:19 | T |
+| main.rs:2407:19:2407:22 | SelfParam |  | main.rs:2393:5:2393:20 | S1 |
+| main.rs:2407:19:2407:22 | SelfParam | T | main.rs:2398:10:2398:19 | T |
+| main.rs:2407:33:2409:9 | { ... } |  | main.rs:2393:5:2393:20 | S1 |
+| main.rs:2407:33:2409:9 | { ... } | T | main.rs:2398:10:2398:19 | T |
+| main.rs:2408:13:2408:16 | self |  | main.rs:2393:5:2393:20 | S1 |
+| main.rs:2408:13:2408:16 | self | T | main.rs:2398:10:2398:19 | T |
+| main.rs:2420:15:2420:15 | x |  | main.rs:2420:12:2420:12 | T |
+| main.rs:2420:26:2422:5 | { ... } |  | main.rs:2420:12:2420:12 | T |
+| main.rs:2421:9:2421:9 | x |  | main.rs:2420:12:2420:12 | T |
+| main.rs:2425:13:2425:14 | x1 |  | {EXTERNAL LOCATION} | Option |
+| main.rs:2425:13:2425:14 | x1 | T | main.rs:2393:5:2393:20 | S1 |
+| main.rs:2425:13:2425:14 | x1 | T.T | main.rs:2395:5:2396:14 | S2 |
+| main.rs:2425:34:2425:48 | ...::assoc_fun(...) |  | {EXTERNAL LOCATION} | Option |
+| main.rs:2425:34:2425:48 | ...::assoc_fun(...) | T | main.rs:2393:5:2393:20 | S1 |
+| main.rs:2425:34:2425:48 | ...::assoc_fun(...) | T.T | main.rs:2395:5:2396:14 | S2 |
+| main.rs:2426:13:2426:14 | x2 |  | {EXTERNAL LOCATION} | Option |
+| main.rs:2426:13:2426:14 | x2 | T | main.rs:2393:5:2393:20 | S1 |
+| main.rs:2426:13:2426:14 | x2 | T.T | main.rs:2395:5:2396:14 | S2 |
+| main.rs:2426:18:2426:38 | ...::assoc_fun(...) |  | {EXTERNAL LOCATION} | Option |
+| main.rs:2426:18:2426:38 | ...::assoc_fun(...) | T | main.rs:2393:5:2393:20 | S1 |
+| main.rs:2426:18:2426:38 | ...::assoc_fun(...) | T.T | main.rs:2395:5:2396:14 | S2 |
+| main.rs:2427:13:2427:14 | x3 |  | {EXTERNAL LOCATION} | Option |
+| main.rs:2427:13:2427:14 | x3 | T | main.rs:2393:5:2393:20 | S1 |
+| main.rs:2427:13:2427:14 | x3 | T.T | main.rs:2395:5:2396:14 | S2 |
+| main.rs:2427:18:2427:32 | ...::assoc_fun(...) |  | {EXTERNAL LOCATION} | Option |
+| main.rs:2427:18:2427:32 | ...::assoc_fun(...) | T | main.rs:2393:5:2393:20 | S1 |
+| main.rs:2427:18:2427:32 | ...::assoc_fun(...) | T.T | main.rs:2395:5:2396:14 | S2 |
+| main.rs:2428:13:2428:14 | x4 |  | main.rs:2393:5:2393:20 | S1 |
+| main.rs:2428:13:2428:14 | x4 | T | main.rs:2395:5:2396:14 | S2 |
+| main.rs:2428:18:2428:48 | ...::method(...) |  | main.rs:2393:5:2393:20 | S1 |
+| main.rs:2428:18:2428:48 | ...::method(...) | T | main.rs:2395:5:2396:14 | S2 |
+| main.rs:2428:35:2428:47 | ...::default(...) |  | main.rs:2393:5:2393:20 | S1 |
+| main.rs:2428:35:2428:47 | ...::default(...) | T | main.rs:2395:5:2396:14 | S2 |
+| main.rs:2429:13:2429:14 | x5 |  | main.rs:2393:5:2393:20 | S1 |
+| main.rs:2429:13:2429:14 | x5 | T | main.rs:2395:5:2396:14 | S2 |
+| main.rs:2429:18:2429:42 | ...::method(...) |  | main.rs:2393:5:2393:20 | S1 |
+| main.rs:2429:18:2429:42 | ...::method(...) | T | main.rs:2395:5:2396:14 | S2 |
+| main.rs:2429:29:2429:41 | ...::default(...) |  | main.rs:2393:5:2393:20 | S1 |
+| main.rs:2429:29:2429:41 | ...::default(...) | T | main.rs:2395:5:2396:14 | S2 |
+| main.rs:2430:13:2430:14 | x6 |  | main.rs:2414:5:2414:27 | S4 |
+| main.rs:2430:13:2430:14 | x6 | T4 | main.rs:2395:5:2396:14 | S2 |
+| main.rs:2430:18:2430:45 | S4::<...>(...) |  | main.rs:2414:5:2414:27 | S4 |
+| main.rs:2430:18:2430:45 | S4::<...>(...) | T4 | main.rs:2395:5:2396:14 | S2 |
+| main.rs:2430:27:2430:44 | ...::default(...) |  | main.rs:2395:5:2396:14 | S2 |
+| main.rs:2431:13:2431:14 | x7 |  | main.rs:2414:5:2414:27 | S4 |
+| main.rs:2431:13:2431:14 | x7 | T4 | main.rs:2395:5:2396:14 | S2 |
+| main.rs:2431:18:2431:23 | S4(...) |  | main.rs:2414:5:2414:27 | S4 |
+| main.rs:2431:18:2431:23 | S4(...) | T4 | main.rs:2395:5:2396:14 | S2 |
+| main.rs:2431:21:2431:22 | S2 |  | main.rs:2395:5:2396:14 | S2 |
+| main.rs:2432:13:2432:14 | x8 |  | main.rs:2414:5:2414:27 | S4 |
+| main.rs:2432:13:2432:14 | x8 | T4 | {EXTERNAL LOCATION} | i32 |
+| main.rs:2432:18:2432:22 | S4(...) |  | main.rs:2414:5:2414:27 | S4 |
+| main.rs:2432:18:2432:22 | S4(...) | T4 | {EXTERNAL LOCATION} | i32 |
+| main.rs:2432:21:2432:21 | 0 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2433:13:2433:14 | x9 |  | main.rs:2414:5:2414:27 | S4 |
+| main.rs:2433:13:2433:14 | x9 | T4 | main.rs:2395:5:2396:14 | S2 |
+| main.rs:2433:18:2433:34 | S4(...) |  | main.rs:2414:5:2414:27 | S4 |
+| main.rs:2433:18:2433:34 | S4(...) | T4 | main.rs:2395:5:2396:14 | S2 |
+| main.rs:2433:21:2433:33 | ...::default(...) |  | main.rs:2395:5:2396:14 | S2 |
+| main.rs:2434:13:2434:15 | x10 |  | main.rs:2416:5:2418:5 | S5 |
+| main.rs:2434:13:2434:15 | x10 | T5 | main.rs:2395:5:2396:14 | S2 |
+| main.rs:2434:19:2437:9 | S5::<...> {...} |  | main.rs:2416:5:2418:5 | S5 |
+| main.rs:2434:19:2437:9 | S5::<...> {...} | T5 | main.rs:2395:5:2396:14 | S2 |
+| main.rs:2436:20:2436:37 | ...::default(...) |  | main.rs:2395:5:2396:14 | S2 |
+| main.rs:2438:13:2438:15 | x11 |  | main.rs:2416:5:2418:5 | S5 |
+| main.rs:2438:13:2438:15 | x11 | T5 | main.rs:2395:5:2396:14 | S2 |
+| main.rs:2438:19:2438:34 | S5 {...} |  | main.rs:2416:5:2418:5 | S5 |
+| main.rs:2438:19:2438:34 | S5 {...} | T5 | main.rs:2395:5:2396:14 | S2 |
+| main.rs:2438:31:2438:32 | S2 |  | main.rs:2395:5:2396:14 | S2 |
+| main.rs:2439:13:2439:15 | x12 |  | main.rs:2416:5:2418:5 | S5 |
+| main.rs:2439:13:2439:15 | x12 | T5 | {EXTERNAL LOCATION} | i32 |
+| main.rs:2439:19:2439:33 | S5 {...} |  | main.rs:2416:5:2418:5 | S5 |
+| main.rs:2439:19:2439:33 | S5 {...} | T5 | {EXTERNAL LOCATION} | i32 |
+| main.rs:2439:31:2439:31 | 0 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2440:13:2440:15 | x13 |  | main.rs:2416:5:2418:5 | S5 |
+| main.rs:2440:13:2440:15 | x13 | T5 | main.rs:2395:5:2396:14 | S2 |
+| main.rs:2440:19:2443:9 | S5 {...} |  | main.rs:2416:5:2418:5 | S5 |
+| main.rs:2440:19:2443:9 | S5 {...} | T5 | main.rs:2395:5:2396:14 | S2 |
+| main.rs:2442:20:2442:32 | ...::default(...) |  | main.rs:2395:5:2396:14 | S2 |
+| main.rs:2444:13:2444:15 | x14 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2444:19:2444:48 | foo::<...>(...) |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2444:30:2444:47 | ...::default(...) |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2453:35:2455:9 | { ... } |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2453:35:2455:9 | { ... } | 0(2) | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2453:35:2455:9 | { ... } | 1(2) | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2454:13:2454:26 | TupleExpr |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2454:13:2454:26 | TupleExpr | 0(2) | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2454:13:2454:26 | TupleExpr | 1(2) | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2454:14:2454:18 | S1 {...} |  | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2454:21:2454:25 | S1 {...} |  | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2456:16:2456:19 | SelfParam |  | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2460:13:2460:13 | a |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2460:13:2460:13 | a | 0(2) | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2460:13:2460:13 | a | 1(2) | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2460:17:2460:30 | ...::get_pair(...) |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2460:17:2460:30 | ...::get_pair(...) | 0(2) | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2460:17:2460:30 | ...::get_pair(...) | 1(2) | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2461:17:2461:17 | b |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2461:17:2461:17 | b | 0(2) | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2461:17:2461:17 | b | 1(2) | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2461:21:2461:34 | ...::get_pair(...) |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2461:21:2461:34 | ...::get_pair(...) | 0(2) | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2461:21:2461:34 | ...::get_pair(...) | 1(2) | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2462:13:2462:18 | TuplePat |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2462:13:2462:18 | TuplePat | 0(2) | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2462:13:2462:18 | TuplePat | 1(2) | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2462:14:2462:14 | c |  | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2462:17:2462:17 | d |  | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2462:22:2462:35 | ...::get_pair(...) |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2462:22:2462:35 | ...::get_pair(...) | 0(2) | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2462:22:2462:35 | ...::get_pair(...) | 1(2) | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2463:13:2463:22 | TuplePat |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2463:13:2463:22 | TuplePat | 0(2) | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2463:13:2463:22 | TuplePat | 1(2) | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2463:18:2463:18 | e |  | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2463:21:2463:21 | f |  | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2463:26:2463:39 | ...::get_pair(...) |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2463:26:2463:39 | ...::get_pair(...) | 0(2) | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2463:26:2463:39 | ...::get_pair(...) | 1(2) | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2464:13:2464:26 | TuplePat |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2464:13:2464:26 | TuplePat | 0(2) | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2464:13:2464:26 | TuplePat | 1(2) | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2464:18:2464:18 | g |  | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2464:25:2464:25 | h |  | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2464:30:2464:43 | ...::get_pair(...) |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2464:30:2464:43 | ...::get_pair(...) | 0(2) | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2464:30:2464:43 | ...::get_pair(...) | 1(2) | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2466:9:2466:9 | a |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2466:9:2466:9 | a | 0(2) | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2466:9:2466:9 | a | 1(2) | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2466:9:2466:11 | a.0 |  | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2467:9:2467:9 | b |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2467:9:2467:9 | b | 0(2) | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2467:9:2467:9 | b | 1(2) | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2467:9:2467:11 | b.1 |  | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2468:9:2468:9 | c |  | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2469:9:2469:9 | d |  | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2470:9:2470:9 | e |  | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2471:9:2471:9 | f |  | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2472:9:2472:9 | g |  | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2473:9:2473:9 | h |  | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2478:13:2478:13 | a |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2478:17:2478:34 | ...::default(...) |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2479:13:2479:13 | b |  | {EXTERNAL LOCATION} | bool |
+| main.rs:2479:17:2479:34 | ...::default(...) |  | {EXTERNAL LOCATION} | bool |
+| main.rs:2480:13:2480:16 | pair |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2480:13:2480:16 | pair | 0(2) | {EXTERNAL LOCATION} | i64 |
+| main.rs:2480:13:2480:16 | pair | 1(2) | {EXTERNAL LOCATION} | bool |
+| main.rs:2480:20:2480:25 | TupleExpr |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2480:20:2480:25 | TupleExpr | 0(2) | {EXTERNAL LOCATION} | i64 |
+| main.rs:2480:20:2480:25 | TupleExpr | 1(2) | {EXTERNAL LOCATION} | bool |
+| main.rs:2480:21:2480:21 | a |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2480:24:2480:24 | b |  | {EXTERNAL LOCATION} | bool |
+| main.rs:2481:13:2481:13 | i |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2481:22:2481:25 | pair |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2481:22:2481:25 | pair | 0(2) | {EXTERNAL LOCATION} | i64 |
+| main.rs:2481:22:2481:25 | pair | 1(2) | {EXTERNAL LOCATION} | bool |
+| main.rs:2481:22:2481:27 | pair.0 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2482:13:2482:13 | j |  | {EXTERNAL LOCATION} | bool |
+| main.rs:2482:23:2482:26 | pair |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2482:23:2482:26 | pair | 0(2) | {EXTERNAL LOCATION} | i64 |
+| main.rs:2482:23:2482:26 | pair | 1(2) | {EXTERNAL LOCATION} | bool |
+| main.rs:2482:23:2482:28 | pair.1 |  | {EXTERNAL LOCATION} | bool |
+| main.rs:2484:13:2484:16 | pair |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2484:13:2484:16 | pair | 0(2) | {EXTERNAL LOCATION} | i32 |
+| main.rs:2484:13:2484:16 | pair | 1(2) | {EXTERNAL LOCATION} | i32 |
+| main.rs:2484:20:2484:25 | [...] |  | file://:0:0:0:0 | [] |
+| main.rs:2484:20:2484:25 | [...] | [T;...] | {EXTERNAL LOCATION} | i32 |
+| main.rs:2484:20:2484:32 | ... .into() |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2484:20:2484:32 | ... .into() | 0(2) | {EXTERNAL LOCATION} | i32 |
+| main.rs:2484:20:2484:32 | ... .into() | 1(2) | {EXTERNAL LOCATION} | i32 |
+| main.rs:2484:21:2484:21 | 1 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2484:24:2484:24 | 1 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2485:15:2485:18 | pair |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2485:15:2485:18 | pair | 0(2) | {EXTERNAL LOCATION} | i32 |
+| main.rs:2485:15:2485:18 | pair | 1(2) | {EXTERNAL LOCATION} | i32 |
+| main.rs:2486:13:2486:18 | TuplePat |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2486:13:2486:18 | TuplePat | 0(2) | {EXTERNAL LOCATION} | i32 |
+| main.rs:2486:13:2486:18 | TuplePat | 1(2) | {EXTERNAL LOCATION} | i32 |
+| main.rs:2486:14:2486:14 | 0 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2486:17:2486:17 | 0 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2486:30:2486:41 | "unexpected" |  | file://:0:0:0:0 | & |
+| main.rs:2486:30:2486:41 | "unexpected" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:2486:30:2486:41 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:2486:30:2486:41 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:2487:13:2487:13 | _ |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2487:13:2487:13 | _ | 0(2) | {EXTERNAL LOCATION} | i32 |
+| main.rs:2487:13:2487:13 | _ | 1(2) | {EXTERNAL LOCATION} | i32 |
+| main.rs:2487:25:2487:34 | "expected" |  | file://:0:0:0:0 | & |
+| main.rs:2487:25:2487:34 | "expected" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:2487:25:2487:34 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:2487:25:2487:34 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:2489:13:2489:13 | x |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2489:17:2489:20 | pair |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2489:17:2489:20 | pair | 0(2) | {EXTERNAL LOCATION} | i32 |
+| main.rs:2489:17:2489:20 | pair | 1(2) | {EXTERNAL LOCATION} | i32 |
+| main.rs:2489:17:2489:22 | pair.0 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2491:13:2491:13 | y |  | file://:0:0:0:0 | & |
+| main.rs:2491:13:2491:13 | y | &T | file://:0:0:0:0 | (T_2) |
+| main.rs:2491:13:2491:13 | y | &T.0(2) | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2491:13:2491:13 | y | &T.1(2) | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2491:17:2491:31 | &... |  | file://:0:0:0:0 | & |
+| main.rs:2491:17:2491:31 | &... | &T | file://:0:0:0:0 | (T_2) |
+| main.rs:2491:17:2491:31 | &... | &T.0(2) | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2491:17:2491:31 | &... | &T.1(2) | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2491:18:2491:31 | ...::get_pair(...) |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2491:18:2491:31 | ...::get_pair(...) | 0(2) | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2491:18:2491:31 | ...::get_pair(...) | 1(2) | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2492:9:2492:9 | y |  | file://:0:0:0:0 | & |
+| main.rs:2492:9:2492:9 | y | &T | file://:0:0:0:0 | (T_2) |
+| main.rs:2492:9:2492:9 | y | &T.0(2) | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2492:9:2492:9 | y | &T.1(2) | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2492:9:2492:11 | y.0 |  | main.rs:2449:5:2450:16 | S1 |
+| main.rs:2499:13:2499:23 | boxed_value |  | {EXTERNAL LOCATION} | Box |
+| main.rs:2499:13:2499:23 | boxed_value | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2499:13:2499:23 | boxed_value | T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2499:27:2499:42 | ...::new(...) |  | {EXTERNAL LOCATION} | Box |
+| main.rs:2499:27:2499:42 | ...::new(...) | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2499:27:2499:42 | ...::new(...) | T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2499:36:2499:41 | 100i32 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2502:15:2502:25 | boxed_value |  | {EXTERNAL LOCATION} | Box |
+| main.rs:2502:15:2502:25 | boxed_value | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2502:15:2502:25 | boxed_value | T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2503:13:2503:19 | box 100 |  | {EXTERNAL LOCATION} | Box |
+| main.rs:2503:13:2503:19 | box 100 | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2503:13:2503:19 | box 100 | T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2503:17:2503:19 | 100 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2504:26:2504:36 | "Boxed 100\\n" |  | file://:0:0:0:0 | & |
+| main.rs:2504:26:2504:36 | "Boxed 100\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:2504:26:2504:36 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:2504:26:2504:36 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:2506:13:2506:17 | box ... |  | {EXTERNAL LOCATION} | Box |
+| main.rs:2506:13:2506:17 | box ... | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2506:13:2506:17 | box ... | T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2508:26:2508:42 | "Boxed value: {}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:2508:26:2508:42 | "Boxed value: {}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:2508:26:2508:51 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:2508:26:2508:51 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:2513:13:2513:22 | nested_box |  | {EXTERNAL LOCATION} | Box |
+| main.rs:2513:13:2513:22 | nested_box | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2513:13:2513:22 | nested_box | T | {EXTERNAL LOCATION} | Box |
+| main.rs:2513:13:2513:22 | nested_box | T.A | {EXTERNAL LOCATION} | Global |
+| main.rs:2513:13:2513:22 | nested_box | T.T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2513:26:2513:50 | ...::new(...) |  | {EXTERNAL LOCATION} | Box |
+| main.rs:2513:26:2513:50 | ...::new(...) | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2513:26:2513:50 | ...::new(...) | T | {EXTERNAL LOCATION} | Box |
+| main.rs:2513:26:2513:50 | ...::new(...) | T.A | {EXTERNAL LOCATION} | Global |
+| main.rs:2513:26:2513:50 | ...::new(...) | T.T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2513:35:2513:49 | ...::new(...) |  | {EXTERNAL LOCATION} | Box |
+| main.rs:2513:35:2513:49 | ...::new(...) | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2513:35:2513:49 | ...::new(...) | T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2513:44:2513:48 | 42i32 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2514:15:2514:24 | nested_box |  | {EXTERNAL LOCATION} | Box |
+| main.rs:2514:15:2514:24 | nested_box | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2514:15:2514:24 | nested_box | T | {EXTERNAL LOCATION} | Box |
+| main.rs:2514:15:2514:24 | nested_box | T.A | {EXTERNAL LOCATION} | Global |
+| main.rs:2514:15:2514:24 | nested_box | T.T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2515:13:2515:21 | box ... |  | {EXTERNAL LOCATION} | Box |
+| main.rs:2515:13:2515:21 | box ... | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2515:13:2515:21 | box ... | T | {EXTERNAL LOCATION} | Box |
+| main.rs:2515:13:2515:21 | box ... | T.A | {EXTERNAL LOCATION} | Global |
+| main.rs:2515:13:2515:21 | box ... | T.T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2517:26:2517:43 | "Nested boxed: {}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:2517:26:2517:43 | "Nested boxed: {}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:2517:26:2517:59 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:2517:26:2517:59 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:2529:21:2529:25 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:2529:21:2529:25 | SelfParam | &T | main.rs:2528:5:2531:5 | Self [trait Executor] |
+| main.rs:2530:24:2530:28 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:2530:24:2530:28 | SelfParam | &T | main.rs:2528:5:2531:5 | Self [trait Executor] |
+| main.rs:2530:31:2530:35 | query |  | main.rs:2530:21:2530:21 | E |
+| main.rs:2534:21:2534:25 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:2534:21:2534:25 | SelfParam | &T | main.rs:2533:10:2533:22 | T |
+| main.rs:2535:22:2535:41 | "Executor::execute1\\n" |  | file://:0:0:0:0 | & |
+| main.rs:2535:22:2535:41 | "Executor::execute1\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:2535:22:2535:41 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:2535:22:2535:41 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:2538:24:2538:28 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:2538:24:2538:28 | SelfParam | &T | main.rs:2533:10:2533:22 | T |
+| main.rs:2538:31:2538:36 | _query |  | main.rs:2538:21:2538:21 | E |
+| main.rs:2539:22:2539:41 | "Executor::execute2\\n" |  | file://:0:0:0:0 | & |
+| main.rs:2539:22:2539:41 | "Executor::execute2\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:2539:22:2539:41 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:2539:22:2539:41 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:2548:13:2548:13 | c |  | main.rs:2543:5:2543:29 | MySqlConnection |
+| main.rs:2548:17:2548:34 | MySqlConnection {...} |  | main.rs:2543:5:2543:29 | MySqlConnection |
+| main.rs:2550:9:2550:9 | c |  | main.rs:2543:5:2543:29 | MySqlConnection |
+| main.rs:2551:35:2551:36 | &c |  | file://:0:0:0:0 | & |
+| main.rs:2551:35:2551:36 | &c | &T | main.rs:2543:5:2543:29 | MySqlConnection |
+| main.rs:2551:36:2551:36 | c |  | main.rs:2543:5:2543:29 | MySqlConnection |
+| main.rs:2553:9:2553:9 | c |  | main.rs:2543:5:2543:29 | MySqlConnection |
+| main.rs:2553:20:2553:40 | "SELECT * FROM users" |  | file://:0:0:0:0 | & |
+| main.rs:2553:20:2553:40 | "SELECT * FROM users" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:2554:9:2554:9 | c |  | main.rs:2543:5:2543:29 | MySqlConnection |
+| main.rs:2554:28:2554:48 | "SELECT * FROM users" |  | file://:0:0:0:0 | & |
+| main.rs:2554:28:2554:48 | "SELECT * FROM users" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:2555:35:2555:36 | &c |  | file://:0:0:0:0 | & |
+| main.rs:2555:35:2555:36 | &c | &T | main.rs:2543:5:2543:29 | MySqlConnection |
+| main.rs:2555:36:2555:36 | c |  | main.rs:2543:5:2543:29 | MySqlConnection |
+| main.rs:2555:39:2555:59 | "SELECT * FROM users" |  | file://:0:0:0:0 | & |
+| main.rs:2555:39:2555:59 | "SELECT * FROM users" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:2556:43:2556:44 | &c |  | file://:0:0:0:0 | & |
+| main.rs:2556:43:2556:44 | &c | &T | main.rs:2543:5:2543:29 | MySqlConnection |
+| main.rs:2556:44:2556:44 | c |  | main.rs:2543:5:2543:29 | MySqlConnection |
+| main.rs:2556:47:2556:67 | "SELECT * FROM users" |  | file://:0:0:0:0 | & |
+| main.rs:2556:47:2556:67 | "SELECT * FROM users" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:2566:36:2568:9 | { ... } |  | main.rs:2563:5:2563:22 | Path |
+| main.rs:2567:13:2567:19 | Path {...} |  | main.rs:2563:5:2563:22 | Path |
+| main.rs:2570:29:2570:33 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:2570:29:2570:33 | SelfParam | &T | main.rs:2563:5:2563:22 | Path |
+| main.rs:2570:59:2572:9 | { ... } |  | {EXTERNAL LOCATION} | Result |
+| main.rs:2570:59:2572:9 | { ... } | E | file://:0:0:0:0 | () |
+| main.rs:2570:59:2572:9 | { ... } | T | main.rs:2575:5:2575:25 | PathBuf |
+| main.rs:2571:13:2571:30 | Ok(...) |  | {EXTERNAL LOCATION} | Result |
+| main.rs:2571:13:2571:30 | Ok(...) | E | file://:0:0:0:0 | () |
+| main.rs:2571:13:2571:30 | Ok(...) | T | main.rs:2575:5:2575:25 | PathBuf |
+| main.rs:2571:16:2571:29 | ...::new(...) |  | main.rs:2575:5:2575:25 | PathBuf |
+| main.rs:2578:39:2580:9 | { ... } |  | main.rs:2575:5:2575:25 | PathBuf |
+| main.rs:2579:13:2579:22 | PathBuf {...} |  | main.rs:2575:5:2575:25 | PathBuf |
 | main.rs:2588:18:2588:22 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:2588:18:2588:22 | SelfParam | &T | main.rs:2574:5:2575:5 | PathBuf |
+| main.rs:2588:18:2588:22 | SelfParam | &T | main.rs:2575:5:2575:25 | PathBuf |
 | main.rs:2588:34:2592:9 | { ... } |  | file://:0:0:0:0 | & |
-| main.rs:2588:34:2592:9 | { ... } | &T | main.rs:2561:5:2562:5 | Path |
-| main.rs:2590:34:2590:44 | ...::new(...) |  | main.rs:2561:5:2562:5 | Path |
+| main.rs:2588:34:2592:9 | { ... } | &T | main.rs:2563:5:2563:22 | Path |
+| main.rs:2590:33:2590:43 | ...::new(...) |  | main.rs:2563:5:2563:22 | Path |
 | main.rs:2591:13:2591:17 | &path |  | file://:0:0:0:0 | & |
-| main.rs:2591:13:2591:17 | &path | &T | main.rs:2561:5:2562:5 | Path |
-| main.rs:2591:14:2591:17 | path |  | main.rs:2561:5:2562:5 | Path |
-| main.rs:2596:13:2596:17 | path1 |  | main.rs:2561:5:2562:5 | Path |
-| main.rs:2596:21:2596:31 | ...::new(...) |  | main.rs:2561:5:2562:5 | Path |
+| main.rs:2591:13:2591:17 | &path | &T | main.rs:2563:5:2563:22 | Path |
+| main.rs:2591:14:2591:17 | path |  | main.rs:2563:5:2563:22 | Path |
+| main.rs:2596:13:2596:17 | path1 |  | main.rs:2563:5:2563:22 | Path |
+| main.rs:2596:21:2596:31 | ...::new(...) |  | main.rs:2563:5:2563:22 | Path |
 | main.rs:2597:13:2597:17 | path2 |  | {EXTERNAL LOCATION} | Result |
 | main.rs:2597:13:2597:17 | path2 | E | file://:0:0:0:0 | () |
-| main.rs:2597:13:2597:17 | path2 | T | main.rs:2574:5:2575:5 | PathBuf |
-| main.rs:2597:21:2597:25 | path1 |  | main.rs:2561:5:2562:5 | Path |
+| main.rs:2597:13:2597:17 | path2 | T | main.rs:2575:5:2575:25 | PathBuf |
+| main.rs:2597:21:2597:25 | path1 |  | main.rs:2563:5:2563:22 | Path |
 | main.rs:2597:21:2597:40 | path1.canonicalize() |  | {EXTERNAL LOCATION} | Result |
 | main.rs:2597:21:2597:40 | path1.canonicalize() | E | file://:0:0:0:0 | () |
-| main.rs:2597:21:2597:40 | path1.canonicalize() | T | main.rs:2574:5:2575:5 | PathBuf |
-| main.rs:2598:13:2598:17 | path3 |  | main.rs:2574:5:2575:5 | PathBuf |
+| main.rs:2597:21:2597:40 | path1.canonicalize() | T | main.rs:2575:5:2575:25 | PathBuf |
+| main.rs:2598:13:2598:17 | path3 |  | main.rs:2575:5:2575:25 | PathBuf |
 | main.rs:2598:21:2598:25 | path2 |  | {EXTERNAL LOCATION} | Result |
 | main.rs:2598:21:2598:25 | path2 | E | file://:0:0:0:0 | () |
-| main.rs:2598:21:2598:25 | path2 | T | main.rs:2574:5:2575:5 | PathBuf |
-| main.rs:2598:21:2598:34 | path2.unwrap() |  | main.rs:2574:5:2575:5 | PathBuf |
-| main.rs:2600:13:2600:20 | pathbuf1 |  | main.rs:2574:5:2575:5 | PathBuf |
-| main.rs:2600:24:2600:37 | ...::new(...) |  | main.rs:2574:5:2575:5 | PathBuf |
-| main.rs:2601:24:2601:31 | pathbuf1 |  | main.rs:2574:5:2575:5 | PathBuf |
+| main.rs:2598:21:2598:25 | path2 | T | main.rs:2575:5:2575:25 | PathBuf |
+| main.rs:2598:21:2598:34 | path2.unwrap() |  | main.rs:2575:5:2575:25 | PathBuf |
+| main.rs:2600:13:2600:20 | pathbuf1 |  | main.rs:2575:5:2575:25 | PathBuf |
+| main.rs:2600:24:2600:37 | ...::new(...) |  | main.rs:2575:5:2575:25 | PathBuf |
+| main.rs:2601:24:2601:31 | pathbuf1 |  | main.rs:2575:5:2575:25 | PathBuf |
 | main.rs:2612:5:2612:20 | ...::f(...) |  | main.rs:72:5:72:21 | Foo |
 | main.rs:2613:5:2613:60 | ...::g(...) |  | main.rs:72:5:72:21 | Foo |
 | main.rs:2613:20:2613:38 | ...::Foo {...} |  | main.rs:72:5:72:21 | Foo |

--- a/rust/ql/test/library-tests/type-inference/type-inference.expected
+++ b/rust/ql/test/library-tests/type-inference/type-inference.expected
@@ -5883,668 +5883,732 @@ inferType
 | pattern_matching.rs:482:22:482:60 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
 | pattern_matching.rs:482:22:482:60 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
 | pattern_matching.rs:482:50:482:60 | single_elem |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:488:9:488:13 | value |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:488:17:488:21 | 42i32 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:491:11:491:15 | value |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:492:9:492:11 | (...) |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:492:10:492:10 | x |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:493:17:493:27 | paren_bound |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:493:31:493:31 | x |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:494:22:494:48 | "Parenthesized pattern: {}\\n" |  | file://:0:0:0:0 | & |
-| pattern_matching.rs:494:22:494:48 | "Parenthesized pattern: {}\\n" | &T | {EXTERNAL LOCATION} | str |
-| pattern_matching.rs:494:22:494:61 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:494:22:494:61 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:494:51:494:61 | paren_bound |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:499:9:499:13 | tuple |  | file://:0:0:0:0 | (T_2) |
-| pattern_matching.rs:499:9:499:13 | tuple | 0(2) | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:499:9:499:13 | tuple | 1(2) | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:499:17:499:28 | TupleExpr |  | file://:0:0:0:0 | (T_2) |
-| pattern_matching.rs:499:17:499:28 | TupleExpr | 0(2) | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:499:17:499:28 | TupleExpr | 1(2) | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:499:18:499:21 | 1i32 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:499:24:499:27 | 2i32 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:500:11:500:15 | tuple |  | file://:0:0:0:0 | (T_2) |
-| pattern_matching.rs:500:11:500:15 | tuple | 0(2) | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:500:11:500:15 | tuple | 1(2) | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:501:9:501:16 | TuplePat |  | file://:0:0:0:0 | (T_2) |
-| pattern_matching.rs:501:9:501:16 | TuplePat | 0(2) | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:501:9:501:16 | TuplePat | 1(2) | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:501:10:501:10 | x |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:501:13:501:15 | (...) |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:501:14:501:14 | y |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:502:17:502:23 | paren_x |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:502:27:502:27 | x |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:503:17:503:23 | paren_y |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:503:27:503:27 | y |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:504:22:504:53 | "Parenthesized in tuple: {}, {... |  | file://:0:0:0:0 | & |
-| pattern_matching.rs:504:22:504:53 | "Parenthesized in tuple: {}, {... | &T | {EXTERNAL LOCATION} | str |
-| pattern_matching.rs:504:22:504:71 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:504:22:504:71 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:504:56:504:62 | paren_x |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:504:65:504:71 | paren_y |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:510:9:510:13 | slice |  | file://:0:0:0:0 | & |
-| pattern_matching.rs:510:9:510:13 | slice | &T | file://:0:0:0:0 | [] |
-| pattern_matching.rs:510:9:510:13 | slice | &T.[T] | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:510:25:510:40 | &... |  | file://:0:0:0:0 | & |
-| pattern_matching.rs:510:25:510:40 | &... | &T | file://:0:0:0:0 | [] |
-| pattern_matching.rs:510:25:510:40 | &... | &T | file://:0:0:0:0 | [] |
-| pattern_matching.rs:510:25:510:40 | &... | &T.[T;...] | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:510:25:510:40 | &... | &T.[T] | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:510:26:510:40 | [...] |  | file://:0:0:0:0 | [] |
-| pattern_matching.rs:510:26:510:40 | [...] | [T;...] | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:510:27:510:27 | 1 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:510:30:510:30 | 2 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:510:33:510:33 | 3 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:510:36:510:36 | 4 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:510:39:510:39 | 5 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:513:11:513:15 | slice |  | file://:0:0:0:0 | & |
-| pattern_matching.rs:513:11:513:15 | slice | &T | file://:0:0:0:0 | [] |
-| pattern_matching.rs:513:11:513:15 | slice | &T.[T] | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:514:9:514:10 | SlicePat |  | file://:0:0:0:0 | & |
-| pattern_matching.rs:514:9:514:10 | SlicePat | &T | file://:0:0:0:0 | [] |
-| pattern_matching.rs:514:9:514:10 | SlicePat | &T.[T] | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:515:17:515:27 | empty_slice |  | file://:0:0:0:0 | & |
-| pattern_matching.rs:515:17:515:27 | empty_slice | &T | file://:0:0:0:0 | [] |
-| pattern_matching.rs:515:17:515:27 | empty_slice | &T.[T] | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:515:31:515:35 | slice |  | file://:0:0:0:0 | & |
-| pattern_matching.rs:515:31:515:35 | slice | &T | file://:0:0:0:0 | [] |
-| pattern_matching.rs:515:31:515:35 | slice | &T.[T] | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:516:22:516:40 | "Empty slice: {:?}\\n" |  | file://:0:0:0:0 | & |
-| pattern_matching.rs:516:22:516:40 | "Empty slice: {:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| pattern_matching.rs:516:22:516:53 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:516:22:516:53 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:516:43:516:53 | empty_slice |  | file://:0:0:0:0 | & |
-| pattern_matching.rs:516:43:516:53 | empty_slice | &T | file://:0:0:0:0 | [] |
-| pattern_matching.rs:516:43:516:53 | empty_slice | &T.[T] | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:518:9:518:11 | SlicePat |  | file://:0:0:0:0 | & |
-| pattern_matching.rs:518:9:518:11 | SlicePat | &T | file://:0:0:0:0 | [] |
-| pattern_matching.rs:518:9:518:11 | SlicePat | &T.[T] | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:520:22:520:41 | "Single element: {}\\n" |  | file://:0:0:0:0 | & |
-| pattern_matching.rs:520:22:520:41 | "Single element: {}\\n" | &T | {EXTERNAL LOCATION} | str |
-| pattern_matching.rs:520:22:520:54 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:520:22:520:54 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:522:9:522:23 | SlicePat |  | file://:0:0:0:0 | & |
-| pattern_matching.rs:522:9:522:23 | SlicePat | &T | file://:0:0:0:0 | [] |
-| pattern_matching.rs:522:9:522:23 | SlicePat | &T.[T] | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:525:22:525:43 | "Two elements: {}, {}\\n" |  | file://:0:0:0:0 | & |
-| pattern_matching.rs:525:22:525:43 | "Two elements: {}, {}\\n" | &T | {EXTERNAL LOCATION} | str |
-| pattern_matching.rs:525:22:525:70 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:525:22:525:70 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:527:9:527:34 | SlicePat |  | file://:0:0:0:0 | & |
-| pattern_matching.rs:527:9:527:34 | SlicePat | &T | file://:0:0:0:0 | [] |
-| pattern_matching.rs:527:9:527:34 | SlicePat | &T.[T] | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:532:17:532:53 | "First: {}, last: {}, middle l... |  | file://:0:0:0:0 | & |
-| pattern_matching.rs:532:17:532:53 | "First: {}, last: {}, middle l... | &T | {EXTERNAL LOCATION} | str |
-| pattern_matching.rs:532:17:535:34 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:532:17:535:34 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:541:9:541:13 | array |  | file://:0:0:0:0 | [] |
-| pattern_matching.rs:541:9:541:13 | array | [T;...] | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:541:17:541:28 | [...] |  | file://:0:0:0:0 | [] |
-| pattern_matching.rs:541:17:541:28 | [...] | [T;...] | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:541:18:541:21 | 1i32 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:541:24:541:24 | 2 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:541:27:541:27 | 3 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:542:11:542:15 | array |  | file://:0:0:0:0 | [] |
-| pattern_matching.rs:542:11:542:15 | array | [T;...] | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:543:9:543:17 | SlicePat |  | file://:0:0:0:0 | [] |
-| pattern_matching.rs:543:9:543:17 | SlicePat | [T;...] | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:547:22:547:49 | "Array elements: {}, {}, {}\\n" |  | file://:0:0:0:0 | & |
-| pattern_matching.rs:547:22:547:49 | "Array elements: {}, {}, {}\\n" | &T | {EXTERNAL LOCATION} | str |
-| pattern_matching.rs:547:22:547:70 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:547:22:547:70 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:554:27:554:28 | 42 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:555:9:555:13 | value |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:555:17:555:21 | 42i32 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:557:11:557:15 | value |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:558:9:558:16 | CONSTANT |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:559:17:559:27 | const_match |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:559:31:559:35 | value |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:560:22:560:43 | "Matches constant: {}\\n" |  | file://:0:0:0:0 | & |
-| pattern_matching.rs:560:22:560:43 | "Matches constant: {}\\n" | &T | {EXTERNAL LOCATION} | str |
-| pattern_matching.rs:560:22:560:56 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:560:22:560:56 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:560:46:560:56 | const_match |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:562:9:562:9 | _ |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:566:9:566:14 | option |  | pattern_matching.rs:152:1:156:1 | MyOption |
-| pattern_matching.rs:566:9:566:14 | option | T | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:566:18:566:38 | ...::Some(...) |  | pattern_matching.rs:152:1:156:1 | MyOption |
-| pattern_matching.rs:566:18:566:38 | ...::Some(...) | T | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:566:33:566:37 | 10i32 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:567:11:567:16 | option |  | pattern_matching.rs:152:1:156:1 | MyOption |
-| pattern_matching.rs:567:11:567:16 | option | T | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:568:9:568:22 | ...::None |  | pattern_matching.rs:152:1:156:1 | MyOption |
-| pattern_matching.rs:568:9:568:22 | ...::None | T | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:569:22:569:35 | "None variant\\n" |  | file://:0:0:0:0 | & |
-| pattern_matching.rs:569:22:569:35 | "None variant\\n" | &T | {EXTERNAL LOCATION} | str |
-| pattern_matching.rs:569:22:569:35 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:569:22:569:35 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:571:9:571:25 | ...::Some(...) |  | pattern_matching.rs:152:1:156:1 | MyOption |
-| pattern_matching.rs:571:9:571:25 | ...::Some(...) | T | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:571:24:571:24 | x |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:572:17:572:26 | some_value |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:572:30:572:30 | x |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:573:22:573:37 | "Some value: {}\\n" |  | file://:0:0:0:0 | & |
-| pattern_matching.rs:573:22:573:37 | "Some value: {}\\n" | &T | {EXTERNAL LOCATION} | str |
-| pattern_matching.rs:573:22:573:49 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:573:22:573:49 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:573:40:573:49 | some_value |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:578:11:578:51 | ...::Ok::<...>(...) |  | {EXTERNAL LOCATION} | Result |
-| pattern_matching.rs:578:11:578:51 | ...::Ok::<...>(...) | E | {EXTERNAL LOCATION} | usize |
-| pattern_matching.rs:578:11:578:51 | ...::Ok::<...>(...) | T | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:578:49:578:50 | 42 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:579:9:579:34 | ...::Ok(...) |  | {EXTERNAL LOCATION} | Result |
-| pattern_matching.rs:579:9:579:34 | ...::Ok(...) | E | {EXTERNAL LOCATION} | usize |
-| pattern_matching.rs:579:9:579:34 | ...::Ok(...) | T | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:579:33:579:33 | x |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:580:17:580:24 | ok_value |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:580:28:580:28 | x |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:581:22:581:35 | "Ok value: {}\\n" |  | file://:0:0:0:0 | & |
-| pattern_matching.rs:581:22:581:35 | "Ok value: {}\\n" | &T | {EXTERNAL LOCATION} | str |
-| pattern_matching.rs:581:22:581:45 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:581:22:581:45 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:581:38:581:45 | ok_value |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:583:9:583:35 | ...::Err(...) |  | {EXTERNAL LOCATION} | Result |
-| pattern_matching.rs:583:9:583:35 | ...::Err(...) | E | {EXTERNAL LOCATION} | usize |
-| pattern_matching.rs:583:9:583:35 | ...::Err(...) | T | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:583:34:583:34 | e |  | {EXTERNAL LOCATION} | usize |
-| pattern_matching.rs:584:17:584:25 | err_value |  | {EXTERNAL LOCATION} | usize |
-| pattern_matching.rs:584:29:584:29 | e |  | {EXTERNAL LOCATION} | usize |
-| pattern_matching.rs:585:22:585:32 | "Error: {}\\n" |  | file://:0:0:0:0 | & |
-| pattern_matching.rs:585:22:585:32 | "Error: {}\\n" | &T | {EXTERNAL LOCATION} | str |
-| pattern_matching.rs:585:22:585:43 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:585:22:585:43 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:585:35:585:43 | err_value |  | {EXTERNAL LOCATION} | usize |
-| pattern_matching.rs:591:9:591:13 | value |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:591:17:591:21 | 42i32 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:594:11:594:15 | value |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:595:9:595:9 | 1 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:595:9:595:17 | 1 \| 2 \| 3 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:595:13:595:13 | 2 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:595:17:595:17 | 3 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:596:17:596:25 | small_num |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:596:29:596:33 | value |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:597:22:597:39 | "Small number: {}\\n" |  | file://:0:0:0:0 | & |
-| pattern_matching.rs:597:22:597:39 | "Small number: {}\\n" | &T | {EXTERNAL LOCATION} | str |
-| pattern_matching.rs:597:22:597:50 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:597:22:597:50 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:597:42:597:50 | small_num |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:599:9:599:10 | 10 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:599:9:599:15 | 10 \| 20 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:599:14:599:15 | 20 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:600:17:600:25 | round_num |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:600:29:600:33 | value |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:601:22:601:39 | "Round number: {}\\n" |  | file://:0:0:0:0 | & |
-| pattern_matching.rs:601:22:601:39 | "Round number: {}\\n" | &T | {EXTERNAL LOCATION} | str |
-| pattern_matching.rs:601:22:601:50 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:601:22:601:50 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:601:42:601:50 | round_num |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:603:9:603:9 | _ |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:607:9:607:13 | point |  | pattern_matching.rs:135:1:140:1 | Point |
-| pattern_matching.rs:607:17:607:36 | Point {...} |  | pattern_matching.rs:135:1:140:1 | Point |
-| pattern_matching.rs:607:28:607:28 | 0 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:607:34:607:34 | 5 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:608:11:608:15 | point |  | pattern_matching.rs:135:1:140:1 | Point |
-| pattern_matching.rs:609:9:609:29 | Point {...} |  | pattern_matching.rs:135:1:140:1 | Point |
-| pattern_matching.rs:609:9:609:53 | ... \| ... |  | pattern_matching.rs:135:1:140:1 | Point |
-| pattern_matching.rs:609:20:609:20 | x |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:609:24:609:24 | 0 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:609:27:609:27 | y |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:609:33:609:53 | Point {...} |  | pattern_matching.rs:135:1:140:1 | Point |
-| pattern_matching.rs:609:41:609:41 | x |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:609:47:609:47 | y |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:609:51:609:51 | 0 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:610:17:610:22 | axis_x |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:610:26:610:26 | x |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:611:17:611:22 | axis_y |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:611:26:611:26 | y |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:612:22:612:46 | "Point on axis: ({}, {})\\n" |  | file://:0:0:0:0 | & |
-| pattern_matching.rs:612:22:612:46 | "Point on axis: ({}, {})\\n" | &T | {EXTERNAL LOCATION} | str |
-| pattern_matching.rs:612:22:612:62 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:612:22:612:62 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:612:49:612:54 | axis_x |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:612:57:612:62 | axis_y |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:614:9:614:9 | _ |  | pattern_matching.rs:135:1:140:1 | Point |
-| pattern_matching.rs:618:11:618:15 | value |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:619:9:619:9 | 1 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:619:9:619:14 | RangePat |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:619:9:619:25 | ... \| ... |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:619:13:619:14 | 10 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:619:18:619:19 | 90 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:619:18:619:25 | RangePat |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:619:23:619:25 | 100 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:620:17:620:30 | range_or_value |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:620:34:620:38 | value |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:621:22:621:35 | "In range: {}\\n" |  | file://:0:0:0:0 | & |
-| pattern_matching.rs:621:22:621:35 | "In range: {}\\n" | &T | {EXTERNAL LOCATION} | str |
-| pattern_matching.rs:621:22:621:51 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:621:22:621:51 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:621:38:621:51 | range_or_value |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:623:9:623:9 | _ |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:628:9:628:13 | tuple |  | file://:0:0:0:0 | (T_4) |
-| pattern_matching.rs:628:9:628:13 | tuple | 0(4) | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:628:9:628:13 | tuple | 1(4) | {EXTERNAL LOCATION} | i64 |
-| pattern_matching.rs:628:9:628:13 | tuple | 2(4) | {EXTERNAL LOCATION} | f32 |
-| pattern_matching.rs:628:9:628:13 | tuple | 3(4) | {EXTERNAL LOCATION} | u8 |
-| pattern_matching.rs:628:17:628:41 | TupleExpr |  | file://:0:0:0:0 | (T_4) |
-| pattern_matching.rs:628:17:628:41 | TupleExpr | 0(4) | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:628:17:628:41 | TupleExpr | 1(4) | {EXTERNAL LOCATION} | i64 |
-| pattern_matching.rs:628:17:628:41 | TupleExpr | 2(4) | {EXTERNAL LOCATION} | f32 |
-| pattern_matching.rs:628:17:628:41 | TupleExpr | 3(4) | {EXTERNAL LOCATION} | u8 |
-| pattern_matching.rs:628:18:628:21 | 1i32 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:628:24:628:27 | 2i64 |  | {EXTERNAL LOCATION} | i64 |
-| pattern_matching.rs:628:30:628:35 | 3.0f32 |  | {EXTERNAL LOCATION} | f32 |
-| pattern_matching.rs:628:38:628:40 | 4u8 |  | {EXTERNAL LOCATION} | u8 |
-| pattern_matching.rs:631:11:631:15 | tuple |  | file://:0:0:0:0 | (T_4) |
-| pattern_matching.rs:631:11:631:15 | tuple | 0(4) | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:631:11:631:15 | tuple | 1(4) | {EXTERNAL LOCATION} | i64 |
-| pattern_matching.rs:631:11:631:15 | tuple | 2(4) | {EXTERNAL LOCATION} | f32 |
-| pattern_matching.rs:631:11:631:15 | tuple | 3(4) | {EXTERNAL LOCATION} | u8 |
-| pattern_matching.rs:632:9:632:19 | TuplePat |  | file://:0:0:0:0 | (T_4) |
-| pattern_matching.rs:632:9:632:19 | TuplePat | 0(4) | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:632:9:632:19 | TuplePat | 1(4) | {EXTERNAL LOCATION} | i64 |
-| pattern_matching.rs:632:9:632:19 | TuplePat | 2(4) | {EXTERNAL LOCATION} | f32 |
-| pattern_matching.rs:632:9:632:19 | TuplePat | 3(4) | {EXTERNAL LOCATION} | u8 |
-| pattern_matching.rs:634:22:634:42 | "First with rest: {}\\n" |  | file://:0:0:0:0 | & |
-| pattern_matching.rs:634:22:634:42 | "First with rest: {}\\n" | &T | {EXTERNAL LOCATION} | str |
-| pattern_matching.rs:634:22:634:54 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:634:22:634:54 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:638:11:638:15 | tuple |  | file://:0:0:0:0 | (T_4) |
-| pattern_matching.rs:638:11:638:15 | tuple | 0(4) | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:638:11:638:15 | tuple | 1(4) | {EXTERNAL LOCATION} | i64 |
-| pattern_matching.rs:638:11:638:15 | tuple | 2(4) | {EXTERNAL LOCATION} | f32 |
-| pattern_matching.rs:638:11:638:15 | tuple | 3(4) | {EXTERNAL LOCATION} | u8 |
-| pattern_matching.rs:639:9:639:18 | TuplePat |  | file://:0:0:0:0 | (T_4) |
-| pattern_matching.rs:639:9:639:18 | TuplePat | 0(4) | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:639:9:639:18 | TuplePat | 1(4) | {EXTERNAL LOCATION} | i64 |
-| pattern_matching.rs:639:9:639:18 | TuplePat | 2(4) | {EXTERNAL LOCATION} | f32 |
-| pattern_matching.rs:639:9:639:18 | TuplePat | 3(4) | {EXTERNAL LOCATION} | u8 |
-| pattern_matching.rs:641:22:641:41 | "Last with rest: {}\\n" |  | file://:0:0:0:0 | & |
-| pattern_matching.rs:641:22:641:41 | "Last with rest: {}\\n" | &T | {EXTERNAL LOCATION} | str |
-| pattern_matching.rs:641:22:641:52 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:641:22:641:52 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:645:11:645:15 | tuple |  | file://:0:0:0:0 | (T_4) |
-| pattern_matching.rs:645:11:645:15 | tuple | 0(4) | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:645:11:645:15 | tuple | 1(4) | {EXTERNAL LOCATION} | i64 |
-| pattern_matching.rs:645:11:645:15 | tuple | 2(4) | {EXTERNAL LOCATION} | f32 |
-| pattern_matching.rs:645:11:645:15 | tuple | 3(4) | {EXTERNAL LOCATION} | u8 |
-| pattern_matching.rs:646:9:646:25 | TuplePat |  | file://:0:0:0:0 | (T_4) |
-| pattern_matching.rs:646:9:646:25 | TuplePat | 0(4) | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:646:9:646:25 | TuplePat | 1(4) | {EXTERNAL LOCATION} | i64 |
-| pattern_matching.rs:646:9:646:25 | TuplePat | 2(4) | {EXTERNAL LOCATION} | f32 |
-| pattern_matching.rs:646:9:646:25 | TuplePat | 3(4) | {EXTERNAL LOCATION} | u8 |
-| pattern_matching.rs:649:22:649:45 | "First and last: {}, {}\\n" |  | file://:0:0:0:0 | & |
-| pattern_matching.rs:649:22:649:45 | "First and last: {}, {}\\n" | &T | {EXTERNAL LOCATION} | str |
-| pattern_matching.rs:649:22:649:67 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:649:22:649:67 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:654:9:654:13 | point |  | pattern_matching.rs:135:1:140:1 | Point |
-| pattern_matching.rs:654:17:654:38 | Point {...} |  | pattern_matching.rs:135:1:140:1 | Point |
-| pattern_matching.rs:654:28:654:29 | 10 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:654:35:654:36 | 20 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:655:11:655:15 | point |  | pattern_matching.rs:135:1:140:1 | Point |
-| pattern_matching.rs:656:9:656:23 | Point {...} |  | pattern_matching.rs:135:1:140:1 | Point |
-| pattern_matching.rs:656:17:656:17 | x |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:657:17:657:22 | rest_x |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:657:26:657:26 | x |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:658:22:658:39 | "X coordinate: {}\\n" |  | file://:0:0:0:0 | & |
-| pattern_matching.rs:658:22:658:39 | "X coordinate: {}\\n" | &T | {EXTERNAL LOCATION} | str |
-| pattern_matching.rs:658:22:658:47 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:658:22:658:47 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:658:42:658:47 | rest_x |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:665:17:665:18 | 42 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:666:17:666:17 | x |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:681:21:681:25 | 42i32 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:681:21:681:25 | 42i32 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:681:28:681:29 | 42 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:682:21:682:25 | 10i32 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:682:21:682:25 | 10i32 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:682:28:682:28 | x |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:687:9:687:20 | complex_data |  | file://:0:0:0:0 | (T_2) |
-| pattern_matching.rs:687:9:687:20 | complex_data | 0(2) | pattern_matching.rs:135:1:140:1 | Point |
-| pattern_matching.rs:687:9:687:20 | complex_data | 1(2) | pattern_matching.rs:152:1:156:1 | MyOption |
-| pattern_matching.rs:687:9:687:20 | complex_data | 1(2).T | pattern_matching.rs:142:1:143:25 | Color |
-| pattern_matching.rs:687:24:687:79 | TupleExpr |  | file://:0:0:0:0 | (T_2) |
-| pattern_matching.rs:687:24:687:79 | TupleExpr | 0(2) | pattern_matching.rs:135:1:140:1 | Point |
-| pattern_matching.rs:687:24:687:79 | TupleExpr | 1(2) | pattern_matching.rs:152:1:156:1 | MyOption |
-| pattern_matching.rs:687:24:687:79 | TupleExpr | 1(2).T | pattern_matching.rs:142:1:143:25 | Color |
-| pattern_matching.rs:687:25:687:44 | Point {...} |  | pattern_matching.rs:135:1:140:1 | Point |
-| pattern_matching.rs:687:36:687:36 | 1 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:687:42:687:42 | 2 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:687:47:687:78 | ...::Some(...) |  | pattern_matching.rs:152:1:156:1 | MyOption |
-| pattern_matching.rs:687:47:687:78 | ...::Some(...) | T | pattern_matching.rs:142:1:143:25 | Color |
-| pattern_matching.rs:687:62:687:77 | Color(...) |  | pattern_matching.rs:142:1:143:25 | Color |
-| pattern_matching.rs:687:68:687:70 | 255 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:687:68:687:70 | 255 |  | {EXTERNAL LOCATION} | u8 |
-| pattern_matching.rs:687:73:687:73 | 0 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:687:73:687:73 | 0 |  | {EXTERNAL LOCATION} | u8 |
-| pattern_matching.rs:687:76:687:76 | 0 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:687:76:687:76 | 0 |  | {EXTERNAL LOCATION} | u8 |
-| pattern_matching.rs:689:11:689:22 | complex_data |  | file://:0:0:0:0 | (T_2) |
-| pattern_matching.rs:689:11:689:22 | complex_data | 0(2) | pattern_matching.rs:135:1:140:1 | Point |
-| pattern_matching.rs:689:11:689:22 | complex_data | 1(2) | pattern_matching.rs:152:1:156:1 | MyOption |
-| pattern_matching.rs:689:11:689:22 | complex_data | 1(2).T | pattern_matching.rs:142:1:143:25 | Color |
-| pattern_matching.rs:691:9:691:61 | TuplePat |  | file://:0:0:0:0 | (T_2) |
-| pattern_matching.rs:691:9:691:61 | TuplePat | 0(2) | pattern_matching.rs:135:1:140:1 | Point |
-| pattern_matching.rs:691:9:691:61 | TuplePat | 1(2) | pattern_matching.rs:152:1:156:1 | MyOption |
-| pattern_matching.rs:691:9:691:61 | TuplePat | 1(2).T | pattern_matching.rs:142:1:143:25 | Color |
-| pattern_matching.rs:691:10:691:26 | Point {...} |  | pattern_matching.rs:135:1:140:1 | Point |
-| pattern_matching.rs:691:21:691:21 | 1 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:691:24:691:24 | y |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:691:29:691:60 | ...::Some(...) |  | pattern_matching.rs:152:1:156:1 | MyOption |
-| pattern_matching.rs:691:29:691:60 | ...::Some(...) | T | pattern_matching.rs:142:1:143:25 | Color |
-| pattern_matching.rs:691:44:691:59 | Color(...) |  | pattern_matching.rs:142:1:143:25 | Color |
-| pattern_matching.rs:691:50:691:52 | 255 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:691:50:691:52 | 255 |  | {EXTERNAL LOCATION} | u8 |
-| pattern_matching.rs:691:55:691:55 | g |  | {EXTERNAL LOCATION} | u8 |
-| pattern_matching.rs:691:58:691:58 | b |  | {EXTERNAL LOCATION} | u8 |
-| pattern_matching.rs:692:17:692:24 | nested_y |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:692:28:692:28 | y |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:693:17:693:24 | nested_g |  | {EXTERNAL LOCATION} | u8 |
-| pattern_matching.rs:693:28:693:28 | g |  | {EXTERNAL LOCATION} | u8 |
-| pattern_matching.rs:694:17:694:24 | nested_b |  | {EXTERNAL LOCATION} | u8 |
-| pattern_matching.rs:694:28:694:28 | b |  | {EXTERNAL LOCATION} | u8 |
-| pattern_matching.rs:696:17:696:57 | "Complex nested: y={}, green={... |  | file://:0:0:0:0 | & |
-| pattern_matching.rs:696:17:696:57 | "Complex nested: y={}, green={... | &T | {EXTERNAL LOCATION} | str |
-| pattern_matching.rs:696:17:697:44 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:696:17:697:44 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:697:17:697:24 | nested_y |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:697:27:697:34 | nested_g |  | {EXTERNAL LOCATION} | u8 |
-| pattern_matching.rs:697:37:697:44 | nested_b |  | {EXTERNAL LOCATION} | u8 |
-| pattern_matching.rs:701:9:701:41 | TuplePat |  | file://:0:0:0:0 | (T_2) |
-| pattern_matching.rs:701:9:701:41 | TuplePat | 0(2) | pattern_matching.rs:135:1:140:1 | Point |
-| pattern_matching.rs:701:9:701:41 | TuplePat | 1(2) | pattern_matching.rs:152:1:156:1 | MyOption |
-| pattern_matching.rs:701:9:701:41 | TuplePat | 1(2).T | pattern_matching.rs:142:1:143:25 | Color |
-| pattern_matching.rs:701:9:701:71 | ... \| ... |  | file://:0:0:0:0 | (T_2) |
-| pattern_matching.rs:701:9:701:71 | ... \| ... | 0(2) | pattern_matching.rs:135:1:140:1 | Point |
-| pattern_matching.rs:701:9:701:71 | ... \| ... | 1(2) | pattern_matching.rs:152:1:156:1 | MyOption |
-| pattern_matching.rs:701:9:701:71 | ... \| ... | 1(2).T | pattern_matching.rs:142:1:143:25 | Color |
-| pattern_matching.rs:701:10:701:24 | Point {...} |  | pattern_matching.rs:135:1:140:1 | Point |
-| pattern_matching.rs:701:18:701:18 | x |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:701:27:701:40 | ...::None |  | pattern_matching.rs:152:1:156:1 | MyOption |
-| pattern_matching.rs:701:27:701:40 | ...::None | T | pattern_matching.rs:142:1:143:25 | Color |
-| pattern_matching.rs:701:45:701:71 | TuplePat |  | file://:0:0:0:0 | (T_2) |
-| pattern_matching.rs:701:45:701:71 | TuplePat | 0(2) | pattern_matching.rs:135:1:140:1 | Point |
-| pattern_matching.rs:701:45:701:71 | TuplePat | 1(2) | pattern_matching.rs:152:1:156:1 | MyOption |
-| pattern_matching.rs:701:45:701:71 | TuplePat | 1(2).T | pattern_matching.rs:142:1:143:25 | Color |
-| pattern_matching.rs:701:46:701:67 | Point {...} |  | pattern_matching.rs:135:1:140:1 | Point |
-| pattern_matching.rs:701:57:701:57 | x |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:701:61:701:61 | 0 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:701:70:701:70 | _ |  | pattern_matching.rs:152:1:156:1 | MyOption |
-| pattern_matching.rs:701:70:701:70 | _ | T | pattern_matching.rs:142:1:143:25 | Color |
-| pattern_matching.rs:702:17:702:29 | alt_complex_x |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:702:33:702:33 | x |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:703:22:703:50 | "Alternative complex: x={:?}\\n... |  | file://:0:0:0:0 | & |
-| pattern_matching.rs:703:22:703:50 | "Alternative complex: x={:?}\\n... | &T | {EXTERNAL LOCATION} | str |
-| pattern_matching.rs:703:22:703:65 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:703:22:703:65 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:703:53:703:65 | alt_complex_x |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:706:9:706:13 | other |  | file://:0:0:0:0 | (T_2) |
-| pattern_matching.rs:706:9:706:13 | other | 0(2) | pattern_matching.rs:135:1:140:1 | Point |
-| pattern_matching.rs:706:9:706:13 | other | 1(2) | pattern_matching.rs:152:1:156:1 | MyOption |
-| pattern_matching.rs:706:9:706:13 | other | 1(2).T | pattern_matching.rs:142:1:143:25 | Color |
-| pattern_matching.rs:707:17:707:29 | other_complex |  | file://:0:0:0:0 | (T_2) |
-| pattern_matching.rs:707:17:707:29 | other_complex | 0(2) | pattern_matching.rs:135:1:140:1 | Point |
-| pattern_matching.rs:707:17:707:29 | other_complex | 1(2) | pattern_matching.rs:152:1:156:1 | MyOption |
-| pattern_matching.rs:707:17:707:29 | other_complex | 1(2).T | pattern_matching.rs:142:1:143:25 | Color |
-| pattern_matching.rs:707:33:707:37 | other |  | file://:0:0:0:0 | (T_2) |
-| pattern_matching.rs:707:33:707:37 | other | 0(2) | pattern_matching.rs:135:1:140:1 | Point |
-| pattern_matching.rs:707:33:707:37 | other | 1(2) | pattern_matching.rs:152:1:156:1 | MyOption |
-| pattern_matching.rs:707:33:707:37 | other | 1(2).T | pattern_matching.rs:142:1:143:25 | Color |
-| pattern_matching.rs:708:22:708:47 | "Other complex data: {:?}\\n" |  | file://:0:0:0:0 | & |
-| pattern_matching.rs:708:22:708:47 | "Other complex data: {:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| pattern_matching.rs:708:22:708:62 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:708:22:708:62 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:708:50:708:62 | other_complex |  | file://:0:0:0:0 | (T_2) |
-| pattern_matching.rs:708:50:708:62 | other_complex | 0(2) | pattern_matching.rs:135:1:140:1 | Point |
-| pattern_matching.rs:708:50:708:62 | other_complex | 1(2) | pattern_matching.rs:152:1:156:1 | MyOption |
-| pattern_matching.rs:708:50:708:62 | other_complex | 1(2).T | pattern_matching.rs:142:1:143:25 | Color |
-| pattern_matching.rs:715:9:715:13 | point |  | pattern_matching.rs:135:1:140:1 | Point |
-| pattern_matching.rs:715:17:715:38 | Point {...} |  | pattern_matching.rs:135:1:140:1 | Point |
-| pattern_matching.rs:715:28:715:29 | 10 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:715:35:715:36 | 20 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:716:9:716:22 | Point {...} |  | pattern_matching.rs:135:1:140:1 | Point |
-| pattern_matching.rs:716:17:716:17 | x |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:716:20:716:20 | y |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:716:26:716:30 | point |  | pattern_matching.rs:135:1:140:1 | Point |
-| pattern_matching.rs:717:9:717:13 | let_x |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:717:17:717:17 | x |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:718:9:718:13 | let_y |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:718:17:718:17 | y |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:720:9:720:13 | tuple |  | file://:0:0:0:0 | (T_3) |
-| pattern_matching.rs:720:9:720:13 | tuple | 0(3) | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:720:9:720:13 | tuple | 1(3) | {EXTERNAL LOCATION} | i64 |
-| pattern_matching.rs:720:9:720:13 | tuple | 2(3) | {EXTERNAL LOCATION} | f32 |
-| pattern_matching.rs:720:17:720:36 | TupleExpr |  | file://:0:0:0:0 | (T_3) |
-| pattern_matching.rs:720:17:720:36 | TupleExpr | 0(3) | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:720:17:720:36 | TupleExpr | 1(3) | {EXTERNAL LOCATION} | i64 |
-| pattern_matching.rs:720:17:720:36 | TupleExpr | 2(3) | {EXTERNAL LOCATION} | f32 |
-| pattern_matching.rs:720:18:720:21 | 1i32 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:720:24:720:27 | 2i64 |  | {EXTERNAL LOCATION} | i64 |
-| pattern_matching.rs:720:30:720:35 | 3.0f32 |  | {EXTERNAL LOCATION} | f32 |
-| pattern_matching.rs:721:9:721:17 | TuplePat |  | file://:0:0:0:0 | (T_3) |
-| pattern_matching.rs:721:9:721:17 | TuplePat | 0(3) | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:721:9:721:17 | TuplePat | 1(3) | {EXTERNAL LOCATION} | i64 |
-| pattern_matching.rs:721:9:721:17 | TuplePat | 2(3) | {EXTERNAL LOCATION} | f32 |
-| pattern_matching.rs:721:10:721:10 | a |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:721:13:721:13 | b |  | {EXTERNAL LOCATION} | i64 |
-| pattern_matching.rs:721:16:721:16 | c |  | {EXTERNAL LOCATION} | f32 |
-| pattern_matching.rs:721:21:721:25 | tuple |  | file://:0:0:0:0 | (T_3) |
-| pattern_matching.rs:721:21:721:25 | tuple | 0(3) | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:721:21:721:25 | tuple | 1(3) | {EXTERNAL LOCATION} | i64 |
-| pattern_matching.rs:721:21:721:25 | tuple | 2(3) | {EXTERNAL LOCATION} | f32 |
-| pattern_matching.rs:722:9:722:13 | let_a |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:722:17:722:17 | a |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:723:9:723:13 | let_b |  | {EXTERNAL LOCATION} | i64 |
-| pattern_matching.rs:723:17:723:17 | b |  | {EXTERNAL LOCATION} | i64 |
-| pattern_matching.rs:724:9:724:13 | let_c |  | {EXTERNAL LOCATION} | f32 |
-| pattern_matching.rs:724:17:724:17 | c |  | {EXTERNAL LOCATION} | f32 |
-| pattern_matching.rs:726:9:726:13 | array |  | file://:0:0:0:0 | [] |
-| pattern_matching.rs:726:9:726:13 | array | [T;...] | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:726:17:726:34 | [...] |  | file://:0:0:0:0 | [] |
-| pattern_matching.rs:726:17:726:34 | [...] | [T;...] | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:726:18:726:21 | 1i32 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:726:24:726:24 | 2 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:726:27:726:27 | 3 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:726:30:726:30 | 4 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:726:33:726:33 | 5 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:727:9:727:25 | SlicePat |  | file://:0:0:0:0 | [] |
-| pattern_matching.rs:727:9:727:25 | SlicePat | [T;...] | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:727:29:727:33 | array |  | file://:0:0:0:0 | [] |
-| pattern_matching.rs:727:29:727:33 | array | [T;...] | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:731:9:731:13 | color |  | pattern_matching.rs:142:1:143:25 | Color |
-| pattern_matching.rs:731:17:731:34 | Color(...) |  | pattern_matching.rs:142:1:143:25 | Color |
-| pattern_matching.rs:731:23:731:25 | 255 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:731:23:731:25 | 255 |  | {EXTERNAL LOCATION} | u8 |
-| pattern_matching.rs:731:28:731:30 | 128 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:731:28:731:30 | 128 |  | {EXTERNAL LOCATION} | u8 |
-| pattern_matching.rs:731:33:731:33 | 0 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:731:33:731:33 | 0 |  | {EXTERNAL LOCATION} | u8 |
-| pattern_matching.rs:732:9:732:22 | Color(...) |  | pattern_matching.rs:142:1:143:25 | Color |
-| pattern_matching.rs:732:15:732:15 | r |  | {EXTERNAL LOCATION} | u8 |
-| pattern_matching.rs:732:18:732:18 | g |  | {EXTERNAL LOCATION} | u8 |
-| pattern_matching.rs:732:21:732:21 | b |  | {EXTERNAL LOCATION} | u8 |
-| pattern_matching.rs:732:26:732:30 | color |  | pattern_matching.rs:142:1:143:25 | Color |
-| pattern_matching.rs:733:9:733:13 | let_r |  | {EXTERNAL LOCATION} | u8 |
-| pattern_matching.rs:733:17:733:17 | r |  | {EXTERNAL LOCATION} | u8 |
-| pattern_matching.rs:734:9:734:13 | let_g |  | {EXTERNAL LOCATION} | u8 |
-| pattern_matching.rs:734:17:734:17 | g |  | {EXTERNAL LOCATION} | u8 |
-| pattern_matching.rs:735:9:735:13 | let_b |  | {EXTERNAL LOCATION} | u8 |
-| pattern_matching.rs:735:17:735:17 | b |  | {EXTERNAL LOCATION} | u8 |
-| pattern_matching.rs:738:9:738:13 | value |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:738:17:738:21 | 42i32 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:739:13:739:19 | ref_val |  | file://:0:0:0:0 | & |
-| pattern_matching.rs:739:13:739:19 | ref_val | &T | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:739:23:739:27 | value |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:740:9:740:15 | let_ref |  | file://:0:0:0:0 | & |
-| pattern_matching.rs:740:9:740:15 | let_ref | &T | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:740:19:740:25 | ref_val |  | file://:0:0:0:0 | & |
-| pattern_matching.rs:740:19:740:25 | ref_val | &T | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:743:13:743:19 | mut_val |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:743:23:743:27 | 10i32 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:744:9:744:15 | let_mut |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:744:19:744:25 | mut_val |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:750:22:750:35 | Point {...} |  | pattern_matching.rs:135:1:140:1 | Point |
-| pattern_matching.rs:750:30:750:30 | x |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:750:33:750:33 | y |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:750:59:754:5 | { ... } |  | file://:0:0:0:0 | (T_2) |
-| pattern_matching.rs:750:59:754:5 | { ... } | 0(2) | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:750:59:754:5 | { ... } | 1(2) | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:751:13:751:19 | param_x |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:751:23:751:23 | x |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:752:13:752:19 | param_y |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:752:23:752:23 | y |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:753:9:753:26 | TupleExpr |  | file://:0:0:0:0 | (T_2) |
-| pattern_matching.rs:753:9:753:26 | TupleExpr | 0(2) | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:753:9:753:26 | TupleExpr | 1(2) | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:753:10:753:16 | param_x |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:753:19:753:25 | param_y |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:756:22:756:35 | Color(...) |  | pattern_matching.rs:142:1:143:25 | Color |
-| pattern_matching.rs:756:28:756:28 | r |  | {EXTERNAL LOCATION} | u8 |
-| pattern_matching.rs:756:31:756:31 | _ |  | {EXTERNAL LOCATION} | u8 |
-| pattern_matching.rs:756:34:756:34 | _ |  | {EXTERNAL LOCATION} | u8 |
-| pattern_matching.rs:756:51:759:5 | { ... } |  | {EXTERNAL LOCATION} | u8 |
-| pattern_matching.rs:757:13:757:19 | param_r |  | {EXTERNAL LOCATION} | u8 |
-| pattern_matching.rs:757:23:757:23 | r |  | {EXTERNAL LOCATION} | u8 |
-| pattern_matching.rs:758:9:758:15 | param_r |  | {EXTERNAL LOCATION} | u8 |
-| pattern_matching.rs:761:22:761:38 | TuplePat |  | file://:0:0:0:0 | (T_3) |
-| pattern_matching.rs:761:22:761:38 | TuplePat | 0(3) | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:761:22:761:38 | TuplePat | 1(3) | {EXTERNAL LOCATION} | f64 |
-| pattern_matching.rs:761:22:761:38 | TuplePat | 2(3) | {EXTERNAL LOCATION} | bool |
-| pattern_matching.rs:761:23:761:27 | first |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:761:30:761:30 | _ |  | {EXTERNAL LOCATION} | f64 |
-| pattern_matching.rs:761:33:761:37 | third |  | {EXTERNAL LOCATION} | bool |
-| pattern_matching.rs:761:74:765:5 | { ... } |  | file://:0:0:0:0 | (T_2) |
-| pattern_matching.rs:761:74:765:5 | { ... } | 0(2) | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:761:74:765:5 | { ... } | 1(2) | {EXTERNAL LOCATION} | bool |
-| pattern_matching.rs:762:13:762:23 | param_first |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:762:27:762:31 | first |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:763:13:763:23 | param_third |  | {EXTERNAL LOCATION} | bool |
-| pattern_matching.rs:763:27:763:31 | third |  | {EXTERNAL LOCATION} | bool |
-| pattern_matching.rs:764:9:764:34 | TupleExpr |  | file://:0:0:0:0 | (T_2) |
-| pattern_matching.rs:764:9:764:34 | TupleExpr | 0(2) | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:764:9:764:34 | TupleExpr | 1(2) | {EXTERNAL LOCATION} | bool |
-| pattern_matching.rs:764:10:764:20 | param_first |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:764:23:764:33 | param_third |  | {EXTERNAL LOCATION} | bool |
-| pattern_matching.rs:768:9:768:13 | point |  | pattern_matching.rs:135:1:140:1 | Point |
-| pattern_matching.rs:768:17:768:37 | Point {...} |  | pattern_matching.rs:135:1:140:1 | Point |
-| pattern_matching.rs:768:28:768:28 | 5 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:768:34:768:35 | 10 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:769:9:769:17 | extracted |  | file://:0:0:0:0 | (T_2) |
-| pattern_matching.rs:769:9:769:17 | extracted | 0(2) | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:769:9:769:17 | extracted | 1(2) | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:769:21:769:40 | extract_point(...) |  | file://:0:0:0:0 | (T_2) |
-| pattern_matching.rs:769:21:769:40 | extract_point(...) | 0(2) | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:769:21:769:40 | extract_point(...) | 1(2) | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:769:35:769:39 | point |  | pattern_matching.rs:135:1:140:1 | Point |
-| pattern_matching.rs:771:9:771:13 | color |  | pattern_matching.rs:142:1:143:25 | Color |
-| pattern_matching.rs:771:17:771:35 | Color(...) |  | pattern_matching.rs:142:1:143:25 | Color |
-| pattern_matching.rs:771:23:771:25 | 200 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:771:23:771:25 | 200 |  | {EXTERNAL LOCATION} | u8 |
-| pattern_matching.rs:771:28:771:30 | 100 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:771:28:771:30 | 100 |  | {EXTERNAL LOCATION} | u8 |
-| pattern_matching.rs:771:33:771:34 | 50 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:771:33:771:34 | 50 |  | {EXTERNAL LOCATION} | u8 |
-| pattern_matching.rs:772:9:772:11 | red |  | {EXTERNAL LOCATION} | u8 |
-| pattern_matching.rs:772:15:772:34 | extract_color(...) |  | {EXTERNAL LOCATION} | u8 |
-| pattern_matching.rs:772:29:772:33 | color |  | pattern_matching.rs:142:1:143:25 | Color |
-| pattern_matching.rs:774:9:774:13 | tuple |  | file://:0:0:0:0 | (T_3) |
-| pattern_matching.rs:774:9:774:13 | tuple | 0(3) | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:774:9:774:13 | tuple | 1(3) | {EXTERNAL LOCATION} | f64 |
-| pattern_matching.rs:774:9:774:13 | tuple | 2(3) | {EXTERNAL LOCATION} | bool |
-| pattern_matching.rs:774:17:774:38 | TupleExpr |  | file://:0:0:0:0 | (T_3) |
-| pattern_matching.rs:774:17:774:38 | TupleExpr | 0(3) | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:774:17:774:38 | TupleExpr | 1(3) | {EXTERNAL LOCATION} | f64 |
-| pattern_matching.rs:774:17:774:38 | TupleExpr | 2(3) | {EXTERNAL LOCATION} | bool |
-| pattern_matching.rs:774:18:774:22 | 42i32 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:774:25:774:31 | 3.14f64 |  | {EXTERNAL LOCATION} | f64 |
-| pattern_matching.rs:774:34:774:37 | true |  | {EXTERNAL LOCATION} | bool |
-| pattern_matching.rs:775:9:775:23 | tuple_extracted |  | file://:0:0:0:0 | (T_2) |
-| pattern_matching.rs:775:9:775:23 | tuple_extracted | 0(2) | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:775:9:775:23 | tuple_extracted | 1(2) | {EXTERNAL LOCATION} | bool |
-| pattern_matching.rs:775:27:775:46 | extract_tuple(...) |  | file://:0:0:0:0 | (T_2) |
-| pattern_matching.rs:775:27:775:46 | extract_tuple(...) | 0(2) | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:775:27:775:46 | extract_tuple(...) | 1(2) | {EXTERNAL LOCATION} | bool |
-| pattern_matching.rs:775:41:775:45 | tuple |  | file://:0:0:0:0 | (T_3) |
-| pattern_matching.rs:775:41:775:45 | tuple | 0(3) | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:775:41:775:45 | tuple | 1(3) | {EXTERNAL LOCATION} | f64 |
-| pattern_matching.rs:775:41:775:45 | tuple | 2(3) | {EXTERNAL LOCATION} | bool |
-| pattern_matching.rs:781:23:781:42 | (...) |  | pattern_matching.rs:135:1:140:1 | Point |
-| pattern_matching.rs:781:23:781:42 | Point {...} |  | pattern_matching.rs:135:1:140:1 | Point |
-| pattern_matching.rs:781:34:781:34 | 1 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:781:40:781:40 | 2 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:781:45:781:64 | (...) |  | pattern_matching.rs:135:1:140:1 | Point |
-| pattern_matching.rs:781:45:781:64 | Point {...} |  | pattern_matching.rs:135:1:140:1 | Point |
-| pattern_matching.rs:781:56:781:56 | 3 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:781:62:781:62 | 4 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:782:9:782:22 | Point {...} |  | pattern_matching.rs:135:1:140:1 | Point |
-| pattern_matching.rs:782:17:782:17 | x |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:782:20:782:20 | y |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:783:13:783:18 | loop_x |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:783:22:783:22 | x |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:784:13:784:18 | loop_y |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:784:22:784:22 | y |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:785:18:785:42 | "Point in loop: ({}, {})\\n" |  | file://:0:0:0:0 | & |
-| pattern_matching.rs:785:18:785:42 | "Point in loop: ({}, {})\\n" | &T | {EXTERNAL LOCATION} | str |
-| pattern_matching.rs:785:18:785:58 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:785:18:785:58 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:785:45:785:50 | loop_x |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:785:53:785:58 | loop_y |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:789:9:789:20 | option_value |  | pattern_matching.rs:152:1:156:1 | MyOption |
-| pattern_matching.rs:789:9:789:20 | option_value | T | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:789:24:789:44 | ...::Some(...) |  | pattern_matching.rs:152:1:156:1 | MyOption |
-| pattern_matching.rs:789:24:789:44 | ...::Some(...) | T | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:789:39:789:43 | 42i32 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:790:12:790:33 | ...::Some(...) |  | pattern_matching.rs:152:1:156:1 | MyOption |
-| pattern_matching.rs:790:12:790:33 | ...::Some(...) | T | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:790:27:790:27 | x |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:790:31:790:32 | 42 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:790:37:790:48 | option_value |  | pattern_matching.rs:152:1:156:1 | MyOption |
-| pattern_matching.rs:790:37:790:48 | option_value | T | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:791:13:791:20 | if_let_x |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:791:24:791:24 | x |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:792:18:792:44 | "If let with @ pattern: {}\\n" |  | file://:0:0:0:0 | & |
-| pattern_matching.rs:792:18:792:44 | "If let with @ pattern: {}\\n" | &T | {EXTERNAL LOCATION} | str |
-| pattern_matching.rs:792:18:792:54 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:792:18:792:54 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:792:47:792:54 | if_let_x |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:796:13:796:17 | stack |  | {EXTERNAL LOCATION} | Vec |
-| pattern_matching.rs:796:13:796:17 | stack | A | {EXTERNAL LOCATION} | Global |
-| pattern_matching.rs:796:13:796:17 | stack | T | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:796:31:796:46 | MacroExpr |  | {EXTERNAL LOCATION} | Vec |
-| pattern_matching.rs:796:31:796:46 | MacroExpr | A | {EXTERNAL LOCATION} | Global |
-| pattern_matching.rs:796:31:796:46 | MacroExpr | T | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:796:36:796:39 | 1i32 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:796:42:796:42 | 2 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:796:45:796:45 | 3 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:797:15:797:21 | Some(...) |  | {EXTERNAL LOCATION} | Option |
-| pattern_matching.rs:797:15:797:21 | Some(...) | T | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:797:20:797:20 | x |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:797:25:797:29 | stack |  | {EXTERNAL LOCATION} | Vec |
-| pattern_matching.rs:797:25:797:29 | stack | A | {EXTERNAL LOCATION} | Global |
-| pattern_matching.rs:797:25:797:29 | stack | T | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:797:25:797:35 | stack.pop() |  | {EXTERNAL LOCATION} | Option |
-| pattern_matching.rs:797:25:797:35 | stack.pop() | T | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:798:13:798:23 | while_let_x |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:798:27:798:27 | x |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:799:18:799:29 | "Popped: {}\\n" |  | file://:0:0:0:0 | & |
-| pattern_matching.rs:799:18:799:29 | "Popped: {}\\n" | &T | {EXTERNAL LOCATION} | str |
-| pattern_matching.rs:799:18:799:42 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:799:18:799:42 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:799:32:799:42 | while_let_x |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:803:9:803:13 | value |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:803:17:803:21 | 42i32 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:804:11:804:15 | value |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:805:9:805:9 | x |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:805:14:805:14 | x |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:805:14:805:18 | ... > ... |  | {EXTERNAL LOCATION} | bool |
-| pattern_matching.rs:805:18:805:18 | 0 |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:806:17:806:23 | guard_x |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:806:27:806:27 | x |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:807:22:807:35 | "Positive: {}\\n" |  | file://:0:0:0:0 | & |
-| pattern_matching.rs:807:22:807:35 | "Positive: {}\\n" | &T | {EXTERNAL LOCATION} | str |
-| pattern_matching.rs:807:22:807:44 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:807:22:807:44 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| pattern_matching.rs:807:38:807:44 | guard_x |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:809:9:809:9 | _ |  | {EXTERNAL LOCATION} | i32 |
-| pattern_matching.rs:814:5:814:7 | f(...) |  | {EXTERNAL LOCATION} | Option |
-| pattern_matching.rs:814:5:814:7 | f(...) | T | file://:0:0:0:0 | () |
+| pattern_matching.rs:487:9:487:18 | ref_tuple1 |  | file://:0:0:0:0 | & |
+| pattern_matching.rs:487:9:487:18 | ref_tuple1 |  | file://:0:0:0:0 | (T_2) |
+| pattern_matching.rs:487:9:487:18 | ref_tuple1 | &T | file://:0:0:0:0 | (T_2) |
+| pattern_matching.rs:487:9:487:18 | ref_tuple1 | &T.0(2) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:487:9:487:18 | ref_tuple1 | &T.1(2) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:487:35:487:41 | &... |  | file://:0:0:0:0 | & |
+| pattern_matching.rs:487:35:487:41 | &... | &T | file://:0:0:0:0 | (T_2) |
+| pattern_matching.rs:487:35:487:41 | &... | &T.0(2) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:487:35:487:41 | &... | &T.1(2) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:487:36:487:41 | TupleExpr |  | file://:0:0:0:0 | (T_2) |
+| pattern_matching.rs:487:36:487:41 | TupleExpr | 0(2) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:487:36:487:41 | TupleExpr | 1(2) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:487:37:487:37 | 1 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:487:40:487:40 | 2 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:488:12:488:17 | TuplePat |  | file://:0:0:0:0 | & |
+| pattern_matching.rs:488:12:488:17 | TuplePat |  | file://:0:0:0:0 | (T_2) |
+| pattern_matching.rs:488:12:488:17 | TuplePat | &T | file://:0:0:0:0 | (T_2) |
+| pattern_matching.rs:488:12:488:17 | TuplePat | &T.0(2) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:488:12:488:17 | TuplePat | &T.1(2) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:488:21:488:30 | ref_tuple1 |  | file://:0:0:0:0 | & |
+| pattern_matching.rs:488:21:488:30 | ref_tuple1 |  | file://:0:0:0:0 | (T_2) |
+| pattern_matching.rs:488:21:488:30 | ref_tuple1 | &T | file://:0:0:0:0 | (T_2) |
+| pattern_matching.rs:488:21:488:30 | ref_tuple1 | &T.0(2) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:488:21:488:30 | ref_tuple1 | &T.1(2) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:489:18:489:24 | "n: {}\\n" |  | file://:0:0:0:0 | & |
+| pattern_matching.rs:489:18:489:24 | "n: {}\\n" | &T | {EXTERNAL LOCATION} | str |
+| pattern_matching.rs:489:18:489:27 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:489:18:489:27 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:490:18:490:24 | "m: {}\\n" |  | file://:0:0:0:0 | & |
+| pattern_matching.rs:490:18:490:24 | "m: {}\\n" | &T | {EXTERNAL LOCATION} | str |
+| pattern_matching.rs:490:18:490:27 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:490:18:490:27 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:494:9:494:18 | ref_tuple2 |  | file://:0:0:0:0 | & |
+| pattern_matching.rs:494:9:494:18 | ref_tuple2 |  | file://:0:0:0:0 | (T_2) |
+| pattern_matching.rs:494:9:494:18 | ref_tuple2 | &T | file://:0:0:0:0 | (T_2) |
+| pattern_matching.rs:494:9:494:18 | ref_tuple2 | &T.0(2) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:494:9:494:18 | ref_tuple2 | &T.1(2) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:494:35:494:41 | &... |  | file://:0:0:0:0 | & |
+| pattern_matching.rs:494:35:494:41 | &... | &T | file://:0:0:0:0 | (T_2) |
+| pattern_matching.rs:494:35:494:41 | &... | &T.0(2) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:494:35:494:41 | &... | &T.1(2) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:494:36:494:41 | TupleExpr |  | file://:0:0:0:0 | (T_2) |
+| pattern_matching.rs:494:36:494:41 | TupleExpr | 0(2) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:494:36:494:41 | TupleExpr | 1(2) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:494:37:494:37 | 1 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:494:40:494:40 | 2 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:495:9:495:14 | TuplePat |  | file://:0:0:0:0 | & |
+| pattern_matching.rs:495:9:495:14 | TuplePat |  | file://:0:0:0:0 | (T_2) |
+| pattern_matching.rs:495:9:495:14 | TuplePat | &T | file://:0:0:0:0 | (T_2) |
+| pattern_matching.rs:495:9:495:14 | TuplePat | &T.0(2) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:495:9:495:14 | TuplePat | &T.1(2) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:495:18:495:27 | ref_tuple2 |  | file://:0:0:0:0 | & |
+| pattern_matching.rs:495:18:495:27 | ref_tuple2 |  | file://:0:0:0:0 | (T_2) |
+| pattern_matching.rs:495:18:495:27 | ref_tuple2 | &T | file://:0:0:0:0 | (T_2) |
+| pattern_matching.rs:495:18:495:27 | ref_tuple2 | &T.0(2) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:495:18:495:27 | ref_tuple2 | &T.1(2) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:496:14:496:20 | "n: {}\\n" |  | file://:0:0:0:0 | & |
+| pattern_matching.rs:496:14:496:20 | "n: {}\\n" | &T | {EXTERNAL LOCATION} | str |
+| pattern_matching.rs:496:14:496:23 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:496:14:496:23 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:497:14:497:20 | "m: {}\\n" |  | file://:0:0:0:0 | & |
+| pattern_matching.rs:497:14:497:20 | "m: {}\\n" | &T | {EXTERNAL LOCATION} | str |
+| pattern_matching.rs:497:14:497:23 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:497:14:497:23 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:501:9:501:13 | value |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:501:17:501:21 | 42i32 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:504:11:504:15 | value |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:505:9:505:11 | (...) |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:505:10:505:10 | x |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:506:17:506:27 | paren_bound |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:506:31:506:31 | x |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:507:22:507:48 | "Parenthesized pattern: {}\\n" |  | file://:0:0:0:0 | & |
+| pattern_matching.rs:507:22:507:48 | "Parenthesized pattern: {}\\n" | &T | {EXTERNAL LOCATION} | str |
+| pattern_matching.rs:507:22:507:61 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:507:22:507:61 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:507:51:507:61 | paren_bound |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:512:9:512:13 | tuple |  | file://:0:0:0:0 | (T_2) |
+| pattern_matching.rs:512:9:512:13 | tuple | 0(2) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:512:9:512:13 | tuple | 1(2) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:512:17:512:28 | TupleExpr |  | file://:0:0:0:0 | (T_2) |
+| pattern_matching.rs:512:17:512:28 | TupleExpr | 0(2) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:512:17:512:28 | TupleExpr | 1(2) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:512:18:512:21 | 1i32 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:512:24:512:27 | 2i32 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:513:11:513:15 | tuple |  | file://:0:0:0:0 | (T_2) |
+| pattern_matching.rs:513:11:513:15 | tuple | 0(2) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:513:11:513:15 | tuple | 1(2) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:514:9:514:16 | TuplePat |  | file://:0:0:0:0 | (T_2) |
+| pattern_matching.rs:514:9:514:16 | TuplePat | 0(2) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:514:9:514:16 | TuplePat | 1(2) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:514:10:514:10 | x |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:514:13:514:15 | (...) |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:514:14:514:14 | y |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:515:17:515:23 | paren_x |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:515:27:515:27 | x |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:516:17:516:23 | paren_y |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:516:27:516:27 | y |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:517:22:517:53 | "Parenthesized in tuple: {}, {... |  | file://:0:0:0:0 | & |
+| pattern_matching.rs:517:22:517:53 | "Parenthesized in tuple: {}, {... | &T | {EXTERNAL LOCATION} | str |
+| pattern_matching.rs:517:22:517:71 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:517:22:517:71 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:517:56:517:62 | paren_x |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:517:65:517:71 | paren_y |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:523:9:523:13 | slice |  | file://:0:0:0:0 | & |
+| pattern_matching.rs:523:9:523:13 | slice | &T | file://:0:0:0:0 | [] |
+| pattern_matching.rs:523:9:523:13 | slice | &T.[T] | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:523:25:523:40 | &... |  | file://:0:0:0:0 | & |
+| pattern_matching.rs:523:25:523:40 | &... | &T | file://:0:0:0:0 | [] |
+| pattern_matching.rs:523:25:523:40 | &... | &T | file://:0:0:0:0 | [] |
+| pattern_matching.rs:523:25:523:40 | &... | &T.[T;...] | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:523:25:523:40 | &... | &T.[T] | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:523:26:523:40 | [...] |  | file://:0:0:0:0 | [] |
+| pattern_matching.rs:523:26:523:40 | [...] | [T;...] | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:523:27:523:27 | 1 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:523:30:523:30 | 2 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:523:33:523:33 | 3 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:523:36:523:36 | 4 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:523:39:523:39 | 5 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:526:11:526:15 | slice |  | file://:0:0:0:0 | & |
+| pattern_matching.rs:526:11:526:15 | slice | &T | file://:0:0:0:0 | [] |
+| pattern_matching.rs:526:11:526:15 | slice | &T.[T] | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:527:9:527:10 | SlicePat |  | file://:0:0:0:0 | & |
+| pattern_matching.rs:527:9:527:10 | SlicePat | &T | file://:0:0:0:0 | [] |
+| pattern_matching.rs:527:9:527:10 | SlicePat | &T.[T] | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:528:17:528:27 | empty_slice |  | file://:0:0:0:0 | & |
+| pattern_matching.rs:528:17:528:27 | empty_slice | &T | file://:0:0:0:0 | [] |
+| pattern_matching.rs:528:17:528:27 | empty_slice | &T.[T] | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:528:31:528:35 | slice |  | file://:0:0:0:0 | & |
+| pattern_matching.rs:528:31:528:35 | slice | &T | file://:0:0:0:0 | [] |
+| pattern_matching.rs:528:31:528:35 | slice | &T.[T] | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:529:22:529:40 | "Empty slice: {:?}\\n" |  | file://:0:0:0:0 | & |
+| pattern_matching.rs:529:22:529:40 | "Empty slice: {:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| pattern_matching.rs:529:22:529:53 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:529:22:529:53 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:529:43:529:53 | empty_slice |  | file://:0:0:0:0 | & |
+| pattern_matching.rs:529:43:529:53 | empty_slice | &T | file://:0:0:0:0 | [] |
+| pattern_matching.rs:529:43:529:53 | empty_slice | &T.[T] | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:531:9:531:11 | SlicePat |  | file://:0:0:0:0 | & |
+| pattern_matching.rs:531:9:531:11 | SlicePat | &T | file://:0:0:0:0 | [] |
+| pattern_matching.rs:531:9:531:11 | SlicePat | &T.[T] | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:533:22:533:41 | "Single element: {}\\n" |  | file://:0:0:0:0 | & |
+| pattern_matching.rs:533:22:533:41 | "Single element: {}\\n" | &T | {EXTERNAL LOCATION} | str |
+| pattern_matching.rs:533:22:533:54 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:533:22:533:54 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:535:9:535:23 | SlicePat |  | file://:0:0:0:0 | & |
+| pattern_matching.rs:535:9:535:23 | SlicePat | &T | file://:0:0:0:0 | [] |
+| pattern_matching.rs:535:9:535:23 | SlicePat | &T.[T] | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:538:22:538:43 | "Two elements: {}, {}\\n" |  | file://:0:0:0:0 | & |
+| pattern_matching.rs:538:22:538:43 | "Two elements: {}, {}\\n" | &T | {EXTERNAL LOCATION} | str |
+| pattern_matching.rs:538:22:538:70 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:538:22:538:70 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:540:9:540:34 | SlicePat |  | file://:0:0:0:0 | & |
+| pattern_matching.rs:540:9:540:34 | SlicePat | &T | file://:0:0:0:0 | [] |
+| pattern_matching.rs:540:9:540:34 | SlicePat | &T.[T] | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:545:17:545:53 | "First: {}, last: {}, middle l... |  | file://:0:0:0:0 | & |
+| pattern_matching.rs:545:17:545:53 | "First: {}, last: {}, middle l... | &T | {EXTERNAL LOCATION} | str |
+| pattern_matching.rs:545:17:548:34 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:545:17:548:34 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:554:9:554:13 | array |  | file://:0:0:0:0 | [] |
+| pattern_matching.rs:554:9:554:13 | array | [T;...] | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:554:17:554:28 | [...] |  | file://:0:0:0:0 | [] |
+| pattern_matching.rs:554:17:554:28 | [...] | [T;...] | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:554:18:554:21 | 1i32 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:554:24:554:24 | 2 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:554:27:554:27 | 3 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:555:11:555:15 | array |  | file://:0:0:0:0 | [] |
+| pattern_matching.rs:555:11:555:15 | array | [T;...] | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:556:9:556:17 | SlicePat |  | file://:0:0:0:0 | [] |
+| pattern_matching.rs:556:9:556:17 | SlicePat | [T;...] | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:560:22:560:49 | "Array elements: {}, {}, {}\\n" |  | file://:0:0:0:0 | & |
+| pattern_matching.rs:560:22:560:49 | "Array elements: {}, {}, {}\\n" | &T | {EXTERNAL LOCATION} | str |
+| pattern_matching.rs:560:22:560:70 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:560:22:560:70 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:567:27:567:28 | 42 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:568:9:568:13 | value |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:568:17:568:21 | 42i32 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:570:11:570:15 | value |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:571:9:571:16 | CONSTANT |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:572:17:572:27 | const_match |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:572:31:572:35 | value |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:573:22:573:43 | "Matches constant: {}\\n" |  | file://:0:0:0:0 | & |
+| pattern_matching.rs:573:22:573:43 | "Matches constant: {}\\n" | &T | {EXTERNAL LOCATION} | str |
+| pattern_matching.rs:573:22:573:56 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:573:22:573:56 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:573:46:573:56 | const_match |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:575:9:575:9 | _ |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:579:9:579:14 | option |  | pattern_matching.rs:152:1:156:1 | MyOption |
+| pattern_matching.rs:579:9:579:14 | option | T | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:579:18:579:38 | ...::Some(...) |  | pattern_matching.rs:152:1:156:1 | MyOption |
+| pattern_matching.rs:579:18:579:38 | ...::Some(...) | T | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:579:33:579:37 | 10i32 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:580:11:580:16 | option |  | pattern_matching.rs:152:1:156:1 | MyOption |
+| pattern_matching.rs:580:11:580:16 | option | T | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:581:9:581:22 | ...::None |  | pattern_matching.rs:152:1:156:1 | MyOption |
+| pattern_matching.rs:581:9:581:22 | ...::None | T | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:582:22:582:35 | "None variant\\n" |  | file://:0:0:0:0 | & |
+| pattern_matching.rs:582:22:582:35 | "None variant\\n" | &T | {EXTERNAL LOCATION} | str |
+| pattern_matching.rs:582:22:582:35 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:582:22:582:35 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:584:9:584:25 | ...::Some(...) |  | pattern_matching.rs:152:1:156:1 | MyOption |
+| pattern_matching.rs:584:9:584:25 | ...::Some(...) | T | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:584:24:584:24 | x |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:585:17:585:26 | some_value |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:585:30:585:30 | x |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:586:22:586:37 | "Some value: {}\\n" |  | file://:0:0:0:0 | & |
+| pattern_matching.rs:586:22:586:37 | "Some value: {}\\n" | &T | {EXTERNAL LOCATION} | str |
+| pattern_matching.rs:586:22:586:49 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:586:22:586:49 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:586:40:586:49 | some_value |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:591:11:591:51 | ...::Ok::<...>(...) |  | {EXTERNAL LOCATION} | Result |
+| pattern_matching.rs:591:11:591:51 | ...::Ok::<...>(...) | E | {EXTERNAL LOCATION} | usize |
+| pattern_matching.rs:591:11:591:51 | ...::Ok::<...>(...) | T | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:591:49:591:50 | 42 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:592:9:592:34 | ...::Ok(...) |  | {EXTERNAL LOCATION} | Result |
+| pattern_matching.rs:592:9:592:34 | ...::Ok(...) | E | {EXTERNAL LOCATION} | usize |
+| pattern_matching.rs:592:9:592:34 | ...::Ok(...) | T | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:592:33:592:33 | x |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:593:17:593:24 | ok_value |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:593:28:593:28 | x |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:594:22:594:35 | "Ok value: {}\\n" |  | file://:0:0:0:0 | & |
+| pattern_matching.rs:594:22:594:35 | "Ok value: {}\\n" | &T | {EXTERNAL LOCATION} | str |
+| pattern_matching.rs:594:22:594:45 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:594:22:594:45 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:594:38:594:45 | ok_value |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:596:9:596:35 | ...::Err(...) |  | {EXTERNAL LOCATION} | Result |
+| pattern_matching.rs:596:9:596:35 | ...::Err(...) | E | {EXTERNAL LOCATION} | usize |
+| pattern_matching.rs:596:9:596:35 | ...::Err(...) | T | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:596:34:596:34 | e |  | {EXTERNAL LOCATION} | usize |
+| pattern_matching.rs:597:17:597:25 | err_value |  | {EXTERNAL LOCATION} | usize |
+| pattern_matching.rs:597:29:597:29 | e |  | {EXTERNAL LOCATION} | usize |
+| pattern_matching.rs:598:22:598:32 | "Error: {}\\n" |  | file://:0:0:0:0 | & |
+| pattern_matching.rs:598:22:598:32 | "Error: {}\\n" | &T | {EXTERNAL LOCATION} | str |
+| pattern_matching.rs:598:22:598:43 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:598:22:598:43 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:598:35:598:43 | err_value |  | {EXTERNAL LOCATION} | usize |
+| pattern_matching.rs:604:9:604:13 | value |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:604:17:604:21 | 42i32 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:607:11:607:15 | value |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:608:9:608:9 | 1 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:608:9:608:17 | 1 \| 2 \| 3 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:608:13:608:13 | 2 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:608:17:608:17 | 3 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:609:17:609:25 | small_num |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:609:29:609:33 | value |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:610:22:610:39 | "Small number: {}\\n" |  | file://:0:0:0:0 | & |
+| pattern_matching.rs:610:22:610:39 | "Small number: {}\\n" | &T | {EXTERNAL LOCATION} | str |
+| pattern_matching.rs:610:22:610:50 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:610:22:610:50 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:610:42:610:50 | small_num |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:612:9:612:10 | 10 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:612:9:612:15 | 10 \| 20 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:612:14:612:15 | 20 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:613:17:613:25 | round_num |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:613:29:613:33 | value |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:614:22:614:39 | "Round number: {}\\n" |  | file://:0:0:0:0 | & |
+| pattern_matching.rs:614:22:614:39 | "Round number: {}\\n" | &T | {EXTERNAL LOCATION} | str |
+| pattern_matching.rs:614:22:614:50 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:614:22:614:50 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:614:42:614:50 | round_num |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:616:9:616:9 | _ |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:620:9:620:13 | point |  | pattern_matching.rs:135:1:140:1 | Point |
+| pattern_matching.rs:620:17:620:36 | Point {...} |  | pattern_matching.rs:135:1:140:1 | Point |
+| pattern_matching.rs:620:28:620:28 | 0 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:620:34:620:34 | 5 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:621:11:621:15 | point |  | pattern_matching.rs:135:1:140:1 | Point |
+| pattern_matching.rs:622:9:622:29 | Point {...} |  | pattern_matching.rs:135:1:140:1 | Point |
+| pattern_matching.rs:622:9:622:53 | ... \| ... |  | pattern_matching.rs:135:1:140:1 | Point |
+| pattern_matching.rs:622:20:622:20 | x |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:622:24:622:24 | 0 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:622:27:622:27 | y |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:622:33:622:53 | Point {...} |  | pattern_matching.rs:135:1:140:1 | Point |
+| pattern_matching.rs:622:41:622:41 | x |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:622:47:622:47 | y |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:622:51:622:51 | 0 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:623:17:623:22 | axis_x |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:623:26:623:26 | x |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:624:17:624:22 | axis_y |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:624:26:624:26 | y |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:625:22:625:46 | "Point on axis: ({}, {})\\n" |  | file://:0:0:0:0 | & |
+| pattern_matching.rs:625:22:625:46 | "Point on axis: ({}, {})\\n" | &T | {EXTERNAL LOCATION} | str |
+| pattern_matching.rs:625:22:625:62 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:625:22:625:62 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:625:49:625:54 | axis_x |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:625:57:625:62 | axis_y |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:627:9:627:9 | _ |  | pattern_matching.rs:135:1:140:1 | Point |
+| pattern_matching.rs:631:11:631:15 | value |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:632:9:632:9 | 1 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:632:9:632:14 | RangePat |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:632:9:632:25 | ... \| ... |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:632:13:632:14 | 10 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:632:18:632:19 | 90 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:632:18:632:25 | RangePat |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:632:23:632:25 | 100 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:633:17:633:30 | range_or_value |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:633:34:633:38 | value |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:634:22:634:35 | "In range: {}\\n" |  | file://:0:0:0:0 | & |
+| pattern_matching.rs:634:22:634:35 | "In range: {}\\n" | &T | {EXTERNAL LOCATION} | str |
+| pattern_matching.rs:634:22:634:51 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:634:22:634:51 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:634:38:634:51 | range_or_value |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:636:9:636:9 | _ |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:641:9:641:13 | tuple |  | file://:0:0:0:0 | (T_4) |
+| pattern_matching.rs:641:9:641:13 | tuple | 0(4) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:641:9:641:13 | tuple | 1(4) | {EXTERNAL LOCATION} | i64 |
+| pattern_matching.rs:641:9:641:13 | tuple | 2(4) | {EXTERNAL LOCATION} | f32 |
+| pattern_matching.rs:641:9:641:13 | tuple | 3(4) | {EXTERNAL LOCATION} | u8 |
+| pattern_matching.rs:641:17:641:41 | TupleExpr |  | file://:0:0:0:0 | (T_4) |
+| pattern_matching.rs:641:17:641:41 | TupleExpr | 0(4) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:641:17:641:41 | TupleExpr | 1(4) | {EXTERNAL LOCATION} | i64 |
+| pattern_matching.rs:641:17:641:41 | TupleExpr | 2(4) | {EXTERNAL LOCATION} | f32 |
+| pattern_matching.rs:641:17:641:41 | TupleExpr | 3(4) | {EXTERNAL LOCATION} | u8 |
+| pattern_matching.rs:641:18:641:21 | 1i32 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:641:24:641:27 | 2i64 |  | {EXTERNAL LOCATION} | i64 |
+| pattern_matching.rs:641:30:641:35 | 3.0f32 |  | {EXTERNAL LOCATION} | f32 |
+| pattern_matching.rs:641:38:641:40 | 4u8 |  | {EXTERNAL LOCATION} | u8 |
+| pattern_matching.rs:644:11:644:15 | tuple |  | file://:0:0:0:0 | (T_4) |
+| pattern_matching.rs:644:11:644:15 | tuple | 0(4) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:644:11:644:15 | tuple | 1(4) | {EXTERNAL LOCATION} | i64 |
+| pattern_matching.rs:644:11:644:15 | tuple | 2(4) | {EXTERNAL LOCATION} | f32 |
+| pattern_matching.rs:644:11:644:15 | tuple | 3(4) | {EXTERNAL LOCATION} | u8 |
+| pattern_matching.rs:645:9:645:19 | TuplePat |  | file://:0:0:0:0 | (T_4) |
+| pattern_matching.rs:645:9:645:19 | TuplePat | 0(4) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:645:9:645:19 | TuplePat | 1(4) | {EXTERNAL LOCATION} | i64 |
+| pattern_matching.rs:645:9:645:19 | TuplePat | 2(4) | {EXTERNAL LOCATION} | f32 |
+| pattern_matching.rs:645:9:645:19 | TuplePat | 3(4) | {EXTERNAL LOCATION} | u8 |
+| pattern_matching.rs:647:22:647:42 | "First with rest: {}\\n" |  | file://:0:0:0:0 | & |
+| pattern_matching.rs:647:22:647:42 | "First with rest: {}\\n" | &T | {EXTERNAL LOCATION} | str |
+| pattern_matching.rs:647:22:647:54 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:647:22:647:54 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:651:11:651:15 | tuple |  | file://:0:0:0:0 | (T_4) |
+| pattern_matching.rs:651:11:651:15 | tuple | 0(4) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:651:11:651:15 | tuple | 1(4) | {EXTERNAL LOCATION} | i64 |
+| pattern_matching.rs:651:11:651:15 | tuple | 2(4) | {EXTERNAL LOCATION} | f32 |
+| pattern_matching.rs:651:11:651:15 | tuple | 3(4) | {EXTERNAL LOCATION} | u8 |
+| pattern_matching.rs:652:9:652:18 | TuplePat |  | file://:0:0:0:0 | (T_4) |
+| pattern_matching.rs:652:9:652:18 | TuplePat | 0(4) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:652:9:652:18 | TuplePat | 1(4) | {EXTERNAL LOCATION} | i64 |
+| pattern_matching.rs:652:9:652:18 | TuplePat | 2(4) | {EXTERNAL LOCATION} | f32 |
+| pattern_matching.rs:652:9:652:18 | TuplePat | 3(4) | {EXTERNAL LOCATION} | u8 |
+| pattern_matching.rs:654:22:654:41 | "Last with rest: {}\\n" |  | file://:0:0:0:0 | & |
+| pattern_matching.rs:654:22:654:41 | "Last with rest: {}\\n" | &T | {EXTERNAL LOCATION} | str |
+| pattern_matching.rs:654:22:654:52 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:654:22:654:52 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:658:11:658:15 | tuple |  | file://:0:0:0:0 | (T_4) |
+| pattern_matching.rs:658:11:658:15 | tuple | 0(4) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:658:11:658:15 | tuple | 1(4) | {EXTERNAL LOCATION} | i64 |
+| pattern_matching.rs:658:11:658:15 | tuple | 2(4) | {EXTERNAL LOCATION} | f32 |
+| pattern_matching.rs:658:11:658:15 | tuple | 3(4) | {EXTERNAL LOCATION} | u8 |
+| pattern_matching.rs:659:9:659:25 | TuplePat |  | file://:0:0:0:0 | (T_4) |
+| pattern_matching.rs:659:9:659:25 | TuplePat | 0(4) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:659:9:659:25 | TuplePat | 1(4) | {EXTERNAL LOCATION} | i64 |
+| pattern_matching.rs:659:9:659:25 | TuplePat | 2(4) | {EXTERNAL LOCATION} | f32 |
+| pattern_matching.rs:659:9:659:25 | TuplePat | 3(4) | {EXTERNAL LOCATION} | u8 |
+| pattern_matching.rs:662:22:662:45 | "First and last: {}, {}\\n" |  | file://:0:0:0:0 | & |
+| pattern_matching.rs:662:22:662:45 | "First and last: {}, {}\\n" | &T | {EXTERNAL LOCATION} | str |
+| pattern_matching.rs:662:22:662:67 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:662:22:662:67 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:667:9:667:13 | point |  | pattern_matching.rs:135:1:140:1 | Point |
+| pattern_matching.rs:667:17:667:38 | Point {...} |  | pattern_matching.rs:135:1:140:1 | Point |
+| pattern_matching.rs:667:28:667:29 | 10 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:667:35:667:36 | 20 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:668:11:668:15 | point |  | pattern_matching.rs:135:1:140:1 | Point |
+| pattern_matching.rs:669:9:669:23 | Point {...} |  | pattern_matching.rs:135:1:140:1 | Point |
+| pattern_matching.rs:669:17:669:17 | x |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:670:17:670:22 | rest_x |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:670:26:670:26 | x |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:671:22:671:39 | "X coordinate: {}\\n" |  | file://:0:0:0:0 | & |
+| pattern_matching.rs:671:22:671:39 | "X coordinate: {}\\n" | &T | {EXTERNAL LOCATION} | str |
+| pattern_matching.rs:671:22:671:47 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:671:22:671:47 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:671:42:671:47 | rest_x |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:678:17:678:18 | 42 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:679:17:679:17 | x |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:694:21:694:25 | 42i32 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:694:21:694:25 | 42i32 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:694:28:694:29 | 42 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:695:21:695:25 | 10i32 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:695:21:695:25 | 10i32 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:695:28:695:28 | x |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:700:9:700:20 | complex_data |  | file://:0:0:0:0 | (T_2) |
+| pattern_matching.rs:700:9:700:20 | complex_data | 0(2) | pattern_matching.rs:135:1:140:1 | Point |
+| pattern_matching.rs:700:9:700:20 | complex_data | 1(2) | pattern_matching.rs:152:1:156:1 | MyOption |
+| pattern_matching.rs:700:9:700:20 | complex_data | 1(2).T | pattern_matching.rs:142:1:143:25 | Color |
+| pattern_matching.rs:700:24:700:79 | TupleExpr |  | file://:0:0:0:0 | (T_2) |
+| pattern_matching.rs:700:24:700:79 | TupleExpr | 0(2) | pattern_matching.rs:135:1:140:1 | Point |
+| pattern_matching.rs:700:24:700:79 | TupleExpr | 1(2) | pattern_matching.rs:152:1:156:1 | MyOption |
+| pattern_matching.rs:700:24:700:79 | TupleExpr | 1(2).T | pattern_matching.rs:142:1:143:25 | Color |
+| pattern_matching.rs:700:25:700:44 | Point {...} |  | pattern_matching.rs:135:1:140:1 | Point |
+| pattern_matching.rs:700:36:700:36 | 1 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:700:42:700:42 | 2 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:700:47:700:78 | ...::Some(...) |  | pattern_matching.rs:152:1:156:1 | MyOption |
+| pattern_matching.rs:700:47:700:78 | ...::Some(...) | T | pattern_matching.rs:142:1:143:25 | Color |
+| pattern_matching.rs:700:62:700:77 | Color(...) |  | pattern_matching.rs:142:1:143:25 | Color |
+| pattern_matching.rs:700:68:700:70 | 255 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:700:68:700:70 | 255 |  | {EXTERNAL LOCATION} | u8 |
+| pattern_matching.rs:700:73:700:73 | 0 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:700:73:700:73 | 0 |  | {EXTERNAL LOCATION} | u8 |
+| pattern_matching.rs:700:76:700:76 | 0 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:700:76:700:76 | 0 |  | {EXTERNAL LOCATION} | u8 |
+| pattern_matching.rs:702:11:702:22 | complex_data |  | file://:0:0:0:0 | (T_2) |
+| pattern_matching.rs:702:11:702:22 | complex_data | 0(2) | pattern_matching.rs:135:1:140:1 | Point |
+| pattern_matching.rs:702:11:702:22 | complex_data | 1(2) | pattern_matching.rs:152:1:156:1 | MyOption |
+| pattern_matching.rs:702:11:702:22 | complex_data | 1(2).T | pattern_matching.rs:142:1:143:25 | Color |
+| pattern_matching.rs:704:9:704:61 | TuplePat |  | file://:0:0:0:0 | (T_2) |
+| pattern_matching.rs:704:9:704:61 | TuplePat | 0(2) | pattern_matching.rs:135:1:140:1 | Point |
+| pattern_matching.rs:704:9:704:61 | TuplePat | 1(2) | pattern_matching.rs:152:1:156:1 | MyOption |
+| pattern_matching.rs:704:9:704:61 | TuplePat | 1(2).T | pattern_matching.rs:142:1:143:25 | Color |
+| pattern_matching.rs:704:10:704:26 | Point {...} |  | pattern_matching.rs:135:1:140:1 | Point |
+| pattern_matching.rs:704:21:704:21 | 1 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:704:24:704:24 | y |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:704:29:704:60 | ...::Some(...) |  | pattern_matching.rs:152:1:156:1 | MyOption |
+| pattern_matching.rs:704:29:704:60 | ...::Some(...) | T | pattern_matching.rs:142:1:143:25 | Color |
+| pattern_matching.rs:704:44:704:59 | Color(...) |  | pattern_matching.rs:142:1:143:25 | Color |
+| pattern_matching.rs:704:50:704:52 | 255 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:704:50:704:52 | 255 |  | {EXTERNAL LOCATION} | u8 |
+| pattern_matching.rs:704:55:704:55 | g |  | {EXTERNAL LOCATION} | u8 |
+| pattern_matching.rs:704:58:704:58 | b |  | {EXTERNAL LOCATION} | u8 |
+| pattern_matching.rs:705:17:705:24 | nested_y |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:705:28:705:28 | y |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:706:17:706:24 | nested_g |  | {EXTERNAL LOCATION} | u8 |
+| pattern_matching.rs:706:28:706:28 | g |  | {EXTERNAL LOCATION} | u8 |
+| pattern_matching.rs:707:17:707:24 | nested_b |  | {EXTERNAL LOCATION} | u8 |
+| pattern_matching.rs:707:28:707:28 | b |  | {EXTERNAL LOCATION} | u8 |
+| pattern_matching.rs:709:17:709:57 | "Complex nested: y={}, green={... |  | file://:0:0:0:0 | & |
+| pattern_matching.rs:709:17:709:57 | "Complex nested: y={}, green={... | &T | {EXTERNAL LOCATION} | str |
+| pattern_matching.rs:709:17:710:44 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:709:17:710:44 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:710:17:710:24 | nested_y |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:710:27:710:34 | nested_g |  | {EXTERNAL LOCATION} | u8 |
+| pattern_matching.rs:710:37:710:44 | nested_b |  | {EXTERNAL LOCATION} | u8 |
+| pattern_matching.rs:714:9:714:41 | TuplePat |  | file://:0:0:0:0 | (T_2) |
+| pattern_matching.rs:714:9:714:41 | TuplePat | 0(2) | pattern_matching.rs:135:1:140:1 | Point |
+| pattern_matching.rs:714:9:714:41 | TuplePat | 1(2) | pattern_matching.rs:152:1:156:1 | MyOption |
+| pattern_matching.rs:714:9:714:41 | TuplePat | 1(2).T | pattern_matching.rs:142:1:143:25 | Color |
+| pattern_matching.rs:714:9:714:71 | ... \| ... |  | file://:0:0:0:0 | (T_2) |
+| pattern_matching.rs:714:9:714:71 | ... \| ... | 0(2) | pattern_matching.rs:135:1:140:1 | Point |
+| pattern_matching.rs:714:9:714:71 | ... \| ... | 1(2) | pattern_matching.rs:152:1:156:1 | MyOption |
+| pattern_matching.rs:714:9:714:71 | ... \| ... | 1(2).T | pattern_matching.rs:142:1:143:25 | Color |
+| pattern_matching.rs:714:10:714:24 | Point {...} |  | pattern_matching.rs:135:1:140:1 | Point |
+| pattern_matching.rs:714:18:714:18 | x |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:714:27:714:40 | ...::None |  | pattern_matching.rs:152:1:156:1 | MyOption |
+| pattern_matching.rs:714:27:714:40 | ...::None | T | pattern_matching.rs:142:1:143:25 | Color |
+| pattern_matching.rs:714:45:714:71 | TuplePat |  | file://:0:0:0:0 | (T_2) |
+| pattern_matching.rs:714:45:714:71 | TuplePat | 0(2) | pattern_matching.rs:135:1:140:1 | Point |
+| pattern_matching.rs:714:45:714:71 | TuplePat | 1(2) | pattern_matching.rs:152:1:156:1 | MyOption |
+| pattern_matching.rs:714:45:714:71 | TuplePat | 1(2).T | pattern_matching.rs:142:1:143:25 | Color |
+| pattern_matching.rs:714:46:714:67 | Point {...} |  | pattern_matching.rs:135:1:140:1 | Point |
+| pattern_matching.rs:714:57:714:57 | x |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:714:61:714:61 | 0 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:714:70:714:70 | _ |  | pattern_matching.rs:152:1:156:1 | MyOption |
+| pattern_matching.rs:714:70:714:70 | _ | T | pattern_matching.rs:142:1:143:25 | Color |
+| pattern_matching.rs:715:17:715:29 | alt_complex_x |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:715:33:715:33 | x |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:716:22:716:50 | "Alternative complex: x={:?}\\n... |  | file://:0:0:0:0 | & |
+| pattern_matching.rs:716:22:716:50 | "Alternative complex: x={:?}\\n... | &T | {EXTERNAL LOCATION} | str |
+| pattern_matching.rs:716:22:716:65 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:716:22:716:65 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:716:53:716:65 | alt_complex_x |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:719:9:719:13 | other |  | file://:0:0:0:0 | (T_2) |
+| pattern_matching.rs:719:9:719:13 | other | 0(2) | pattern_matching.rs:135:1:140:1 | Point |
+| pattern_matching.rs:719:9:719:13 | other | 1(2) | pattern_matching.rs:152:1:156:1 | MyOption |
+| pattern_matching.rs:719:9:719:13 | other | 1(2).T | pattern_matching.rs:142:1:143:25 | Color |
+| pattern_matching.rs:720:17:720:29 | other_complex |  | file://:0:0:0:0 | (T_2) |
+| pattern_matching.rs:720:17:720:29 | other_complex | 0(2) | pattern_matching.rs:135:1:140:1 | Point |
+| pattern_matching.rs:720:17:720:29 | other_complex | 1(2) | pattern_matching.rs:152:1:156:1 | MyOption |
+| pattern_matching.rs:720:17:720:29 | other_complex | 1(2).T | pattern_matching.rs:142:1:143:25 | Color |
+| pattern_matching.rs:720:33:720:37 | other |  | file://:0:0:0:0 | (T_2) |
+| pattern_matching.rs:720:33:720:37 | other | 0(2) | pattern_matching.rs:135:1:140:1 | Point |
+| pattern_matching.rs:720:33:720:37 | other | 1(2) | pattern_matching.rs:152:1:156:1 | MyOption |
+| pattern_matching.rs:720:33:720:37 | other | 1(2).T | pattern_matching.rs:142:1:143:25 | Color |
+| pattern_matching.rs:721:22:721:47 | "Other complex data: {:?}\\n" |  | file://:0:0:0:0 | & |
+| pattern_matching.rs:721:22:721:47 | "Other complex data: {:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| pattern_matching.rs:721:22:721:62 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:721:22:721:62 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:721:50:721:62 | other_complex |  | file://:0:0:0:0 | (T_2) |
+| pattern_matching.rs:721:50:721:62 | other_complex | 0(2) | pattern_matching.rs:135:1:140:1 | Point |
+| pattern_matching.rs:721:50:721:62 | other_complex | 1(2) | pattern_matching.rs:152:1:156:1 | MyOption |
+| pattern_matching.rs:721:50:721:62 | other_complex | 1(2).T | pattern_matching.rs:142:1:143:25 | Color |
+| pattern_matching.rs:728:9:728:13 | point |  | pattern_matching.rs:135:1:140:1 | Point |
+| pattern_matching.rs:728:17:728:38 | Point {...} |  | pattern_matching.rs:135:1:140:1 | Point |
+| pattern_matching.rs:728:28:728:29 | 10 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:728:35:728:36 | 20 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:729:9:729:22 | Point {...} |  | pattern_matching.rs:135:1:140:1 | Point |
+| pattern_matching.rs:729:17:729:17 | x |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:729:20:729:20 | y |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:729:26:729:30 | point |  | pattern_matching.rs:135:1:140:1 | Point |
+| pattern_matching.rs:730:9:730:13 | let_x |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:730:17:730:17 | x |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:731:9:731:13 | let_y |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:731:17:731:17 | y |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:733:9:733:13 | tuple |  | file://:0:0:0:0 | (T_3) |
+| pattern_matching.rs:733:9:733:13 | tuple | 0(3) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:733:9:733:13 | tuple | 1(3) | {EXTERNAL LOCATION} | i64 |
+| pattern_matching.rs:733:9:733:13 | tuple | 2(3) | {EXTERNAL LOCATION} | f32 |
+| pattern_matching.rs:733:17:733:36 | TupleExpr |  | file://:0:0:0:0 | (T_3) |
+| pattern_matching.rs:733:17:733:36 | TupleExpr | 0(3) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:733:17:733:36 | TupleExpr | 1(3) | {EXTERNAL LOCATION} | i64 |
+| pattern_matching.rs:733:17:733:36 | TupleExpr | 2(3) | {EXTERNAL LOCATION} | f32 |
+| pattern_matching.rs:733:18:733:21 | 1i32 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:733:24:733:27 | 2i64 |  | {EXTERNAL LOCATION} | i64 |
+| pattern_matching.rs:733:30:733:35 | 3.0f32 |  | {EXTERNAL LOCATION} | f32 |
+| pattern_matching.rs:734:9:734:17 | TuplePat |  | file://:0:0:0:0 | (T_3) |
+| pattern_matching.rs:734:9:734:17 | TuplePat | 0(3) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:734:9:734:17 | TuplePat | 1(3) | {EXTERNAL LOCATION} | i64 |
+| pattern_matching.rs:734:9:734:17 | TuplePat | 2(3) | {EXTERNAL LOCATION} | f32 |
+| pattern_matching.rs:734:10:734:10 | a |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:734:13:734:13 | b |  | {EXTERNAL LOCATION} | i64 |
+| pattern_matching.rs:734:16:734:16 | c |  | {EXTERNAL LOCATION} | f32 |
+| pattern_matching.rs:734:21:734:25 | tuple |  | file://:0:0:0:0 | (T_3) |
+| pattern_matching.rs:734:21:734:25 | tuple | 0(3) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:734:21:734:25 | tuple | 1(3) | {EXTERNAL LOCATION} | i64 |
+| pattern_matching.rs:734:21:734:25 | tuple | 2(3) | {EXTERNAL LOCATION} | f32 |
+| pattern_matching.rs:735:9:735:13 | let_a |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:735:17:735:17 | a |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:736:9:736:13 | let_b |  | {EXTERNAL LOCATION} | i64 |
+| pattern_matching.rs:736:17:736:17 | b |  | {EXTERNAL LOCATION} | i64 |
+| pattern_matching.rs:737:9:737:13 | let_c |  | {EXTERNAL LOCATION} | f32 |
+| pattern_matching.rs:737:17:737:17 | c |  | {EXTERNAL LOCATION} | f32 |
+| pattern_matching.rs:739:9:739:13 | array |  | file://:0:0:0:0 | [] |
+| pattern_matching.rs:739:9:739:13 | array | [T;...] | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:739:17:739:34 | [...] |  | file://:0:0:0:0 | [] |
+| pattern_matching.rs:739:17:739:34 | [...] | [T;...] | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:739:18:739:21 | 1i32 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:739:24:739:24 | 2 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:739:27:739:27 | 3 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:739:30:739:30 | 4 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:739:33:739:33 | 5 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:740:9:740:25 | SlicePat |  | file://:0:0:0:0 | [] |
+| pattern_matching.rs:740:9:740:25 | SlicePat | [T;...] | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:740:29:740:33 | array |  | file://:0:0:0:0 | [] |
+| pattern_matching.rs:740:29:740:33 | array | [T;...] | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:744:9:744:13 | color |  | pattern_matching.rs:142:1:143:25 | Color |
+| pattern_matching.rs:744:17:744:34 | Color(...) |  | pattern_matching.rs:142:1:143:25 | Color |
+| pattern_matching.rs:744:23:744:25 | 255 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:744:23:744:25 | 255 |  | {EXTERNAL LOCATION} | u8 |
+| pattern_matching.rs:744:28:744:30 | 128 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:744:28:744:30 | 128 |  | {EXTERNAL LOCATION} | u8 |
+| pattern_matching.rs:744:33:744:33 | 0 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:744:33:744:33 | 0 |  | {EXTERNAL LOCATION} | u8 |
+| pattern_matching.rs:745:9:745:22 | Color(...) |  | pattern_matching.rs:142:1:143:25 | Color |
+| pattern_matching.rs:745:15:745:15 | r |  | {EXTERNAL LOCATION} | u8 |
+| pattern_matching.rs:745:18:745:18 | g |  | {EXTERNAL LOCATION} | u8 |
+| pattern_matching.rs:745:21:745:21 | b |  | {EXTERNAL LOCATION} | u8 |
+| pattern_matching.rs:745:26:745:30 | color |  | pattern_matching.rs:142:1:143:25 | Color |
+| pattern_matching.rs:746:9:746:13 | let_r |  | {EXTERNAL LOCATION} | u8 |
+| pattern_matching.rs:746:17:746:17 | r |  | {EXTERNAL LOCATION} | u8 |
+| pattern_matching.rs:747:9:747:13 | let_g |  | {EXTERNAL LOCATION} | u8 |
+| pattern_matching.rs:747:17:747:17 | g |  | {EXTERNAL LOCATION} | u8 |
+| pattern_matching.rs:748:9:748:13 | let_b |  | {EXTERNAL LOCATION} | u8 |
+| pattern_matching.rs:748:17:748:17 | b |  | {EXTERNAL LOCATION} | u8 |
+| pattern_matching.rs:751:9:751:13 | value |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:751:17:751:21 | 42i32 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:752:13:752:19 | ref_val |  | file://:0:0:0:0 | & |
+| pattern_matching.rs:752:13:752:19 | ref_val | &T | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:752:23:752:27 | value |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:753:9:753:15 | let_ref |  | file://:0:0:0:0 | & |
+| pattern_matching.rs:753:9:753:15 | let_ref | &T | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:753:19:753:25 | ref_val |  | file://:0:0:0:0 | & |
+| pattern_matching.rs:753:19:753:25 | ref_val | &T | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:756:13:756:19 | mut_val |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:756:23:756:27 | 10i32 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:757:9:757:15 | let_mut |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:757:19:757:25 | mut_val |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:763:22:763:35 | Point {...} |  | pattern_matching.rs:135:1:140:1 | Point |
+| pattern_matching.rs:763:30:763:30 | x |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:763:33:763:33 | y |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:763:59:767:5 | { ... } |  | file://:0:0:0:0 | (T_2) |
+| pattern_matching.rs:763:59:767:5 | { ... } | 0(2) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:763:59:767:5 | { ... } | 1(2) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:764:13:764:19 | param_x |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:764:23:764:23 | x |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:765:13:765:19 | param_y |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:765:23:765:23 | y |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:766:9:766:26 | TupleExpr |  | file://:0:0:0:0 | (T_2) |
+| pattern_matching.rs:766:9:766:26 | TupleExpr | 0(2) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:766:9:766:26 | TupleExpr | 1(2) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:766:10:766:16 | param_x |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:766:19:766:25 | param_y |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:769:22:769:35 | Color(...) |  | pattern_matching.rs:142:1:143:25 | Color |
+| pattern_matching.rs:769:28:769:28 | r |  | {EXTERNAL LOCATION} | u8 |
+| pattern_matching.rs:769:31:769:31 | _ |  | {EXTERNAL LOCATION} | u8 |
+| pattern_matching.rs:769:34:769:34 | _ |  | {EXTERNAL LOCATION} | u8 |
+| pattern_matching.rs:769:51:772:5 | { ... } |  | {EXTERNAL LOCATION} | u8 |
+| pattern_matching.rs:770:13:770:19 | param_r |  | {EXTERNAL LOCATION} | u8 |
+| pattern_matching.rs:770:23:770:23 | r |  | {EXTERNAL LOCATION} | u8 |
+| pattern_matching.rs:771:9:771:15 | param_r |  | {EXTERNAL LOCATION} | u8 |
+| pattern_matching.rs:774:22:774:38 | TuplePat |  | file://:0:0:0:0 | (T_3) |
+| pattern_matching.rs:774:22:774:38 | TuplePat | 0(3) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:774:22:774:38 | TuplePat | 1(3) | {EXTERNAL LOCATION} | f64 |
+| pattern_matching.rs:774:22:774:38 | TuplePat | 2(3) | {EXTERNAL LOCATION} | bool |
+| pattern_matching.rs:774:23:774:27 | first |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:774:30:774:30 | _ |  | {EXTERNAL LOCATION} | f64 |
+| pattern_matching.rs:774:33:774:37 | third |  | {EXTERNAL LOCATION} | bool |
+| pattern_matching.rs:774:74:778:5 | { ... } |  | file://:0:0:0:0 | (T_2) |
+| pattern_matching.rs:774:74:778:5 | { ... } | 0(2) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:774:74:778:5 | { ... } | 1(2) | {EXTERNAL LOCATION} | bool |
+| pattern_matching.rs:775:13:775:23 | param_first |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:775:27:775:31 | first |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:776:13:776:23 | param_third |  | {EXTERNAL LOCATION} | bool |
+| pattern_matching.rs:776:27:776:31 | third |  | {EXTERNAL LOCATION} | bool |
+| pattern_matching.rs:777:9:777:34 | TupleExpr |  | file://:0:0:0:0 | (T_2) |
+| pattern_matching.rs:777:9:777:34 | TupleExpr | 0(2) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:777:9:777:34 | TupleExpr | 1(2) | {EXTERNAL LOCATION} | bool |
+| pattern_matching.rs:777:10:777:20 | param_first |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:777:23:777:33 | param_third |  | {EXTERNAL LOCATION} | bool |
+| pattern_matching.rs:781:9:781:13 | point |  | pattern_matching.rs:135:1:140:1 | Point |
+| pattern_matching.rs:781:17:781:37 | Point {...} |  | pattern_matching.rs:135:1:140:1 | Point |
+| pattern_matching.rs:781:28:781:28 | 5 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:781:34:781:35 | 10 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:782:9:782:17 | extracted |  | file://:0:0:0:0 | (T_2) |
+| pattern_matching.rs:782:9:782:17 | extracted | 0(2) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:782:9:782:17 | extracted | 1(2) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:782:21:782:40 | extract_point(...) |  | file://:0:0:0:0 | (T_2) |
+| pattern_matching.rs:782:21:782:40 | extract_point(...) | 0(2) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:782:21:782:40 | extract_point(...) | 1(2) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:782:35:782:39 | point |  | pattern_matching.rs:135:1:140:1 | Point |
+| pattern_matching.rs:784:9:784:13 | color |  | pattern_matching.rs:142:1:143:25 | Color |
+| pattern_matching.rs:784:17:784:35 | Color(...) |  | pattern_matching.rs:142:1:143:25 | Color |
+| pattern_matching.rs:784:23:784:25 | 200 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:784:23:784:25 | 200 |  | {EXTERNAL LOCATION} | u8 |
+| pattern_matching.rs:784:28:784:30 | 100 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:784:28:784:30 | 100 |  | {EXTERNAL LOCATION} | u8 |
+| pattern_matching.rs:784:33:784:34 | 50 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:784:33:784:34 | 50 |  | {EXTERNAL LOCATION} | u8 |
+| pattern_matching.rs:785:9:785:11 | red |  | {EXTERNAL LOCATION} | u8 |
+| pattern_matching.rs:785:15:785:34 | extract_color(...) |  | {EXTERNAL LOCATION} | u8 |
+| pattern_matching.rs:785:29:785:33 | color |  | pattern_matching.rs:142:1:143:25 | Color |
+| pattern_matching.rs:787:9:787:13 | tuple |  | file://:0:0:0:0 | (T_3) |
+| pattern_matching.rs:787:9:787:13 | tuple | 0(3) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:787:9:787:13 | tuple | 1(3) | {EXTERNAL LOCATION} | f64 |
+| pattern_matching.rs:787:9:787:13 | tuple | 2(3) | {EXTERNAL LOCATION} | bool |
+| pattern_matching.rs:787:17:787:38 | TupleExpr |  | file://:0:0:0:0 | (T_3) |
+| pattern_matching.rs:787:17:787:38 | TupleExpr | 0(3) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:787:17:787:38 | TupleExpr | 1(3) | {EXTERNAL LOCATION} | f64 |
+| pattern_matching.rs:787:17:787:38 | TupleExpr | 2(3) | {EXTERNAL LOCATION} | bool |
+| pattern_matching.rs:787:18:787:22 | 42i32 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:787:25:787:31 | 3.14f64 |  | {EXTERNAL LOCATION} | f64 |
+| pattern_matching.rs:787:34:787:37 | true |  | {EXTERNAL LOCATION} | bool |
+| pattern_matching.rs:788:9:788:23 | tuple_extracted |  | file://:0:0:0:0 | (T_2) |
+| pattern_matching.rs:788:9:788:23 | tuple_extracted | 0(2) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:788:9:788:23 | tuple_extracted | 1(2) | {EXTERNAL LOCATION} | bool |
+| pattern_matching.rs:788:27:788:46 | extract_tuple(...) |  | file://:0:0:0:0 | (T_2) |
+| pattern_matching.rs:788:27:788:46 | extract_tuple(...) | 0(2) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:788:27:788:46 | extract_tuple(...) | 1(2) | {EXTERNAL LOCATION} | bool |
+| pattern_matching.rs:788:41:788:45 | tuple |  | file://:0:0:0:0 | (T_3) |
+| pattern_matching.rs:788:41:788:45 | tuple | 0(3) | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:788:41:788:45 | tuple | 1(3) | {EXTERNAL LOCATION} | f64 |
+| pattern_matching.rs:788:41:788:45 | tuple | 2(3) | {EXTERNAL LOCATION} | bool |
+| pattern_matching.rs:794:23:794:42 | (...) |  | pattern_matching.rs:135:1:140:1 | Point |
+| pattern_matching.rs:794:23:794:42 | Point {...} |  | pattern_matching.rs:135:1:140:1 | Point |
+| pattern_matching.rs:794:34:794:34 | 1 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:794:40:794:40 | 2 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:794:45:794:64 | (...) |  | pattern_matching.rs:135:1:140:1 | Point |
+| pattern_matching.rs:794:45:794:64 | Point {...} |  | pattern_matching.rs:135:1:140:1 | Point |
+| pattern_matching.rs:794:56:794:56 | 3 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:794:62:794:62 | 4 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:795:9:795:22 | Point {...} |  | pattern_matching.rs:135:1:140:1 | Point |
+| pattern_matching.rs:795:17:795:17 | x |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:795:20:795:20 | y |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:796:13:796:18 | loop_x |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:796:22:796:22 | x |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:797:13:797:18 | loop_y |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:797:22:797:22 | y |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:798:18:798:42 | "Point in loop: ({}, {})\\n" |  | file://:0:0:0:0 | & |
+| pattern_matching.rs:798:18:798:42 | "Point in loop: ({}, {})\\n" | &T | {EXTERNAL LOCATION} | str |
+| pattern_matching.rs:798:18:798:58 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:798:18:798:58 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:798:45:798:50 | loop_x |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:798:53:798:58 | loop_y |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:802:9:802:20 | option_value |  | pattern_matching.rs:152:1:156:1 | MyOption |
+| pattern_matching.rs:802:9:802:20 | option_value | T | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:802:24:802:44 | ...::Some(...) |  | pattern_matching.rs:152:1:156:1 | MyOption |
+| pattern_matching.rs:802:24:802:44 | ...::Some(...) | T | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:802:39:802:43 | 42i32 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:803:12:803:33 | ...::Some(...) |  | pattern_matching.rs:152:1:156:1 | MyOption |
+| pattern_matching.rs:803:12:803:33 | ...::Some(...) | T | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:803:27:803:27 | x |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:803:31:803:32 | 42 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:803:37:803:48 | option_value |  | pattern_matching.rs:152:1:156:1 | MyOption |
+| pattern_matching.rs:803:37:803:48 | option_value | T | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:804:13:804:20 | if_let_x |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:804:24:804:24 | x |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:805:18:805:44 | "If let with @ pattern: {}\\n" |  | file://:0:0:0:0 | & |
+| pattern_matching.rs:805:18:805:44 | "If let with @ pattern: {}\\n" | &T | {EXTERNAL LOCATION} | str |
+| pattern_matching.rs:805:18:805:54 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:805:18:805:54 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:805:47:805:54 | if_let_x |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:809:13:809:17 | stack |  | {EXTERNAL LOCATION} | Vec |
+| pattern_matching.rs:809:13:809:17 | stack | A | {EXTERNAL LOCATION} | Global |
+| pattern_matching.rs:809:13:809:17 | stack | T | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:809:31:809:46 | MacroExpr |  | {EXTERNAL LOCATION} | Vec |
+| pattern_matching.rs:809:31:809:46 | MacroExpr | A | {EXTERNAL LOCATION} | Global |
+| pattern_matching.rs:809:31:809:46 | MacroExpr | T | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:809:36:809:39 | 1i32 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:809:42:809:42 | 2 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:809:45:809:45 | 3 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:810:15:810:21 | Some(...) |  | {EXTERNAL LOCATION} | Option |
+| pattern_matching.rs:810:15:810:21 | Some(...) | T | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:810:20:810:20 | x |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:810:25:810:29 | stack |  | {EXTERNAL LOCATION} | Vec |
+| pattern_matching.rs:810:25:810:29 | stack | A | {EXTERNAL LOCATION} | Global |
+| pattern_matching.rs:810:25:810:29 | stack | T | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:810:25:810:35 | stack.pop() |  | {EXTERNAL LOCATION} | Option |
+| pattern_matching.rs:810:25:810:35 | stack.pop() | T | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:811:13:811:23 | while_let_x |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:811:27:811:27 | x |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:812:18:812:29 | "Popped: {}\\n" |  | file://:0:0:0:0 | & |
+| pattern_matching.rs:812:18:812:29 | "Popped: {}\\n" | &T | {EXTERNAL LOCATION} | str |
+| pattern_matching.rs:812:18:812:42 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:812:18:812:42 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:812:32:812:42 | while_let_x |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:816:9:816:13 | value |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:816:17:816:21 | 42i32 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:817:11:817:15 | value |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:818:9:818:9 | x |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:818:14:818:14 | x |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:818:14:818:18 | ... > ... |  | {EXTERNAL LOCATION} | bool |
+| pattern_matching.rs:818:18:818:18 | 0 |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:819:17:819:23 | guard_x |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:819:27:819:27 | x |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:820:22:820:35 | "Positive: {}\\n" |  | file://:0:0:0:0 | & |
+| pattern_matching.rs:820:22:820:35 | "Positive: {}\\n" | &T | {EXTERNAL LOCATION} | str |
+| pattern_matching.rs:820:22:820:44 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:820:22:820:44 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| pattern_matching.rs:820:38:820:44 | guard_x |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:822:9:822:9 | _ |  | {EXTERNAL LOCATION} | i32 |
+| pattern_matching.rs:827:5:827:7 | f(...) |  | {EXTERNAL LOCATION} | Option |
+| pattern_matching.rs:827:5:827:7 | f(...) | T | file://:0:0:0:0 | () |
 testFailures

--- a/rust/ql/test/library-tests/type-inference/type-inference.expected
+++ b/rust/ql/test/library-tests/type-inference/type-inference.expected
@@ -4367,6 +4367,8 @@ inferType
 | main.rs:2334:13:2334:13 | i |  | {EXTERNAL LOCATION} | i32 |
 | main.rs:2334:18:2334:22 | range |  | {EXTERNAL LOCATION} | Range |
 | main.rs:2334:18:2334:22 | range | Idx | {EXTERNAL LOCATION} | i32 |
+| main.rs:2335:13:2335:22 | range_full |  | {EXTERNAL LOCATION} | RangeFull |
+| main.rs:2335:26:2335:27 | .. |  | {EXTERNAL LOCATION} | RangeFull |
 | main.rs:2336:13:2336:13 | i |  | {EXTERNAL LOCATION} | Item |
 | main.rs:2336:18:2336:48 | &... |  | file://:0:0:0:0 | & |
 | main.rs:2336:19:2336:36 | [...] |  | file://:0:0:0:0 | [] |
@@ -4374,6 +4376,7 @@ inferType
 | main.rs:2336:20:2336:23 | 1i64 |  | {EXTERNAL LOCATION} | i64 |
 | main.rs:2336:26:2336:29 | 2i64 |  | {EXTERNAL LOCATION} | i64 |
 | main.rs:2336:32:2336:35 | 3i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2336:38:2336:47 | range_full |  | {EXTERNAL LOCATION} | RangeFull |
 | main.rs:2338:13:2338:18 | range1 |  | {EXTERNAL LOCATION} | Range |
 | main.rs:2338:13:2338:18 | range1 | Idx | {EXTERNAL LOCATION} | u16 |
 | main.rs:2339:9:2342:9 | ...::Range {...} |  | {EXTERNAL LOCATION} | Range |


### PR DESCRIPTION
* Fixes a type inference inconsistency where multiple certain types could be inferred for the same node due to match ergonomics/binding modes in pattern matching.
* Makes inference of logical operators certain.
* Makes inference of range expression certain and adds support for the `..` range.