### PR TITLE
Rust: Tune rust/diagnostic/database-quality

### DIFF
--- a/rust/ql/src/change-notes/2025-08-28-diagnostic-database-quality.md
+++ b/rust/ql/src/change-notes/2025-08-28-diagnostic-database-quality.md
@@ -1,0 +1,4 @@
+---
+category: fix
+---
+* The "Low Rust analysis quality" query (`rust/diagnostic/database-quality`) has been tuned so that it won't trigger on databases that have extracted normally. This will remove spurious messages of "Low Rust analysis quality" on the CodeQL status page.

--- a/rust/ql/src/queries/telemetry/DatabaseQualityDiagnostics.ql
+++ b/rust/ql/src/queries/telemetry/DatabaseQualityDiagnostics.ql
@@ -12,11 +12,9 @@ import codeql.util.Unit
 class DbQualityDiagnostic extends Unit {
   DbQualityDiagnostic() {
     exists(float percentageGood |
-      CallTargetStatsReport::percentageOfOk(_, percentageGood)
+      CallTargetStatsReport::percentageOfOk(_, percentageGood) and percentageGood < 50
       or
-      MacroCallTargetStatsReport::percentageOfOk(_, percentageGood)
-    |
-      percentageGood < 95
+      MacroCallTargetStatsReport::percentageOfOk(_, percentageGood) and percentageGood < 50
     )
   }
 


### PR DESCRIPTION
Tune `rust/diagnostic/database-quality` to reflect the range of values typically seen in the metrics it measures.  This will greatly reduce the proportion of databases the warning triggers on, avoiding unnecessary alarm.