### PR TITLE
JS: Avoid overriding Expr predicates in xUnit.qll

### DIFF
--- a/javascript/ql/lib/semmle/javascript/frameworks/xUnit.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/xUnit.qll
@@ -23,6 +23,8 @@ private predicate possiblyAttribute(Expr e, string name) {
   )
 }
 
+final private class FinalExpr = Expr;
+
 /**
  * A bracketed list of expressions.
  *
@@ -34,15 +36,22 @@ private predicate possiblyAttribute(Expr e, string name) {
  *
  * We also allow singleton lists, as in `[a][b]`.
  */
-abstract private class BracketedListOfExpressions extends Expr {
+abstract private class BracketedListOfExpressions extends FinalExpr {
   /** Gets the `i`th element expression of this list. */
   abstract Expr getElement(int i);
+
+  /** Gets the first token in this bracketed list of expressions */
+  Token getFirstToken() { result = Expr.super.getFirstToken() }
+
+  /** Gets the last token in this bracketed list of expressions */
+  Token getLastToken() { result = Expr.super.getLastToken() }
 }
 
 /**
  * An array expression viewed as a bracketed list of expressions.
  */
-private class ArrayExprIsABracketedListOfExpressions extends ArrayExpr, BracketedListOfExpressions {
+private class ArrayExprIsABracketedListOfExpressions extends BracketedListOfExpressions instanceof ArrayExpr
+{
   /** Gets the `i`th element of this array literal. */
   override Expr getElement(int i) { result = ArrayExpr.super.getElement(i) }
 }

--- a/javascript/ql/test/library-tests/frameworks/xUnit/tests.expected
+++ b/javascript/ql/test/library-tests/frameworks/xUnit/tests.expected
@@ -3,10 +3,10 @@ xUnitAnnotationfrom
 | tst.js:5:5:5:13 | [Fixture] | tst.js:6:5:13:5 | functio ... }\\n    } |
 | tst.js:7:9:7:14 | [Fact] | tst.js:8:9:12:9 | functio ...       } |
 | tst.js:16:1:16:43 | [Import ... t.js")] | tst.js:18:1:22:2 | Test.xU ... ..]\\n\\n}; |
-| tst.js:17:1:17:9 | Fixture | tst.js:18:1:22:2 | Test.xU ... ..]\\n\\n}; |
+| tst.js:17:2:17:8 | Fixture | tst.js:18:1:22:2 | Test.xU ... ..]\\n\\n}; |
 | tst.js:24:1:24:9 | [Fixture] | tst.js:25:1:34:2 | Test.Ex ...    }\\n}; |
 | tst.js:27:5:29:7 | [Import ...     })] | tst.js:31:5:33:5 | functio ... ]\\n    } |
-| tst.js:30:5:30:10 | Fact | tst.js:31:5:33:5 | functio ... ]\\n    } |
+| tst.js:30:6:30:9 | Fact | tst.js:31:5:33:5 | functio ... ]\\n    } |
 xUnitAttribute
 | tst.js:3:2:3:8 | Fixture | Fixture | 0 |
 | tst.js:5:6:5:12 | Fixture | Fixture | 0 |
@@ -24,7 +24,7 @@ xUnitFixture
 | tst.js:4:20:14:1 | functio ...     }\\n} | tst.js:3:1:3:9 | [Fixture] |
 | tst.js:6:5:13:5 | functio ... }\\n    } | tst.js:5:5:5:13 | [Fixture] |
 | tst.js:18:24:22:1 | functio ... ...]\\n\\n} | tst.js:16:1:16:43 | [Import ... t.js")] |
-| tst.js:18:24:22:1 | functio ... ...]\\n\\n} | tst.js:17:1:17:9 | Fixture |
+| tst.js:18:24:22:1 | functio ... ...]\\n\\n} | tst.js:17:2:17:8 | Fixture |
 | tst.js:25:21:34:1 | functio ...     }\\n} | tst.js:24:1:24:9 | [Fixture] |
 xUnitTarget
 | tst.js:4:1:14:2 | Test.Ex ...    }\\n}; |


### PR DESCRIPTION
The XUnit family of library models contained an override of `getFirstToken` and `getLastToken`. Overriding the common definitions was not actually necessary, and induced some dependencies that are problematic for overlay locality.

This PR removes the problematic dependency by introducing separate root-defs for the custom interpretation of these predicates.