### PR TITLE
Specify default queries in `codeql-extractor.yml`

### DIFF
--- a/actions/extractor/codeql-extractor.yml
+++ b/actions/extractor/codeql-extractor.yml
@@ -6,6 +6,8 @@ column_kind: "utf16"
 unicode_newlines: true
 build_modes:
   - none
+default_queries:
+  - codeql/actions-queries
 file_coverage_languages: []
 github_api_languages: []
 scc_languages: []

--- a/csharp/codeql-extractor.yml
+++ b/csharp/codeql-extractor.yml
@@ -10,6 +10,8 @@ build_modes:
   - autobuild
   - manual
   - none
+default_queries:
+  - codeql/csharp-queries
 github_api_languages:
   - C#
 scc_languages:

--- a/go/codeql-extractor.yml
+++ b/go/codeql-extractor.yml
@@ -9,6 +9,8 @@ column_kind: "utf8"
 build_modes:
   - autobuild
   - manual
+default_queries:
+  - codeql/go-queries
 github_api_languages:
   - Go
 scc_languages:

--- a/javascript/resources/codeql-extractor.yml
+++ b/javascript/resources/codeql-extractor.yml
@@ -8,6 +8,8 @@ column_kind: "utf16"
 unicode_newlines: true
 build_modes:
   - none
+default_queries:
+  - codeql/javascript-queries
 file_coverage_languages:
   - name: javascript
     display_name: JavaScript

--- a/python/codeql-extractor.yml
+++ b/python/codeql-extractor.yml
@@ -4,6 +4,8 @@ version: 1.22.1
 column_kind: utf32
 build_modes:
   - none
+default_queries:
+  - codeql/python-queries
 github_api_languages:
   - Python
 scc_languages:

--- a/ruby/codeql-extractor.yml
+++ b/ruby/codeql-extractor.yml
@@ -6,6 +6,8 @@ legacy_qltest_extraction: true
 overlay_support_version: 20250626
 build_modes:
   - none
+default_queries:
+  - codeql/ruby-queries
 github_api_languages:
   - Ruby
 scc_languages:

--- a/rust/codeql-extractor.yml
+++ b/rust/codeql-extractor.yml
@@ -5,6 +5,8 @@ column_kind: "utf8"
 legacy_qltest_extraction: true
 build_modes:
   - none
+default_queries:
+  - codeql/rust-queries
 github_api_languages:
   - Rust
 scc_languages:

--- a/swift/codeql-extractor.yml
+++ b/swift/codeql-extractor.yml
@@ -6,6 +6,8 @@ legacy_qltest_extraction: true
 build_modes:
   - autobuild
   - manual
+default_queries:
+  - codeql/swift-queries
 github_api_languages:
   - Swift
 scc_languages:


### PR DESCRIPTION
The current CodeQL Action relies on a hard-coded list of supported languages.  This PR specifies default queries for each CodeQL language, allowing us to remove that list and instead detect languages dynamically:

We now select languages whose extractors are present in the CodeQL search path and provide default queries.

Reasoning:

- We choose to start providing default queries information since we only want to select extractors which have first-class support e.g. JavaScript, but not .properties.  What differentiates these extractors is whether they have queries associated with them.
- Makes it easier for third-parties to develop and test extractors: they don't need to fork the Action, and don't get stuck on the current hard-coded `codeql/<lang>-queries` default queries in the CLI.
- Makes it easier for us to develop new extractors since we no longer need to change the Action to start using a new extractor.