### PR TITLE
JS: Do not override AST methods in React model

### DIFF
--- a/javascript/ql/lib/semmle/javascript/frameworks/React.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/React.qll
@@ -361,7 +361,7 @@ abstract private class SharedReactPreactClassComponent extends ReactComponent in
    * Note that every class has a constructor: if no explicit constructor
    * is declared, it has a synthetic default constructor.
    */
-  ConstructorDeclaration getConstructor() { result = ClassDefinition.super.getAMethod() }
+  ConstructorDeclaration getConstructor() { result = ClassDefinition.super.getConstructor() }
 }
 
 /**


### PR DESCRIPTION
The React model contained an override of `ClassDefinition.getInstanceMethod`, which simply forwarded to the same predicate, but was needed at the time to avoid ambiguous inheritance.

This PR removes the problematic dependency, as it was blocking overlay locality.