### PR TITLE
Ruby: Fix some Ql4Ql violations.

### DIFF
--- a/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
+++ b/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
@@ -1,5 +1,5 @@
 /**
- * Provides an implementation of _API graphs_, which allow efficient modelling of how a given
+ * Provides an implementation of _API graphs_, which allow efficient modeling of how a given
  * value is used by the code base or how values produced by the code base are consumed by a library.
  *
  * See `API::Node` for more details.

--- a/ruby/ql/lib/codeql/ruby/frameworks/core/Kernel.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/core/Kernel.qll
@@ -50,7 +50,7 @@ module Kernel {
   }
 
   /**
-   * Private methods in the `Kernel` module.
+   * Holds if `method` is a name of a private method in the `Kernel` module.
    * These can be be invoked on `self`, on `Kernel`, or using a low-level primitive like `send` or `instance_eval`.
    * ```ruby
    * puts "hello world"

--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/NetHttp.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/NetHttp.qll
@@ -27,11 +27,10 @@ private import codeql.ruby.DataFlow
 class NetHttpRequest extends Http::Client::Request::Range instanceof DataFlow::CallNode {
   private DataFlow::CallNode request;
   API::Node requestNode;
-  API::Node connectionNode;
   private boolean returnsResponseBody;
 
   NetHttpRequest() {
-    exists(string method |
+    exists(string method, API::Node connectionNode |
       request = requestNode.asSource() and
       this = request and
       requestNode = connectionNode.getReturn(method)

--- a/ruby/ql/lib/codeql/ruby/regexp/internal/ParseRegExp.qll
+++ b/ruby/ql/lib/codeql/ruby/regexp/internal/ParseRegExp.qll
@@ -194,7 +194,7 @@ abstract class RegExp extends Ast::StringlikeLiteral {
   }
 
   /**
-   * Holds if the character set starting at `charset_start` contains a character range
+   * Holds if the character set starting at `charsetStart` contains a character range
    * with lower bound found between `start` and `lowerEnd`
    * and upper bound found between `upperStart` and `end`.
    */

--- a/ruby/ql/lib/codeql/ruby/security/ImproperMemoizationQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/ImproperMemoizationQuery.qll
@@ -45,7 +45,7 @@ private class MemoCandidate extends Method {
 }
 
 /**
- * Holds if parameter `p` of `m` is read in the right hand side of `assign`.
+ * Holds if parameter `p` of `m` is read in the right hand side of `a`.
  */
 private predicate parameterUsedInMemoValue(Method m, Parameter p, MemoStmt a) {
   p = m.getAParameter() and
@@ -54,7 +54,7 @@ private predicate parameterUsedInMemoValue(Method m, Parameter p, MemoStmt a) {
 }
 
 /**
- * Holds if parameter `p` of `m` is read in the left hand side of `assign`.
+ * Holds if parameter `p` of `m` is read in the left hand side of `a`.
  */
 private predicate parameterUsedInMemoKey(Method m, Parameter p, HashMemoStmt a) {
   p = m.getAParameter() and


### PR DESCRIPTION
Fix some Ql4Ql violations based on the following checks

- `ql/field-only-used-in-charpred`
- `ql/could-be-cast`
- `ql/counting-to-zero`
- `ql/dataflow-module-naming-convention`
- `ql/if-with-none`
 - `ql/missing-parameter-qldoc`
- `ql/misspelling`

DCA looks good.