### PR TITLE
Shared and Sync: Fix some Ql4Ql violations.

### DIFF
--- a/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModelsExtensions.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModelsExtensions.qll
@@ -4,7 +4,7 @@
 
 /**
  * Holds if the value at `(type, path)` should be seen as a flow
- * source of the given `kind`.
+ * source of the given `kind` and `madId` is the data extension row number.
  *
  * The kind `remote` represents a general remote flow source.
  */
@@ -14,13 +14,14 @@ extensible predicate sourceModel(
 
 /**
  * Holds if the value at `(type, path)` should be seen as a sink
- * of the given `kind`.
+ * of the given `kind` and `madId` is the data extension row number.
  */
 extensible predicate sinkModel(string type, string path, string kind, QlBuiltins::ExtensionId madId);
 
 /**
  * Holds if in calls to `(type, path)`, the value referred to by `input`
- * can flow to the value referred to by `output`.
+ * can flow to the value referred to by `output` and `madId` is the data
+ * extension row number.
  *
  * `kind` should be either `value` or `taint`, for value-preserving or taint-preserving steps,
  * respectively.

--- a/python/ql/lib/semmle/python/frameworks/data/internal/ApiGraphModelsExtensions.qll
+++ b/python/ql/lib/semmle/python/frameworks/data/internal/ApiGraphModelsExtensions.qll
@@ -4,7 +4,7 @@
 
 /**
  * Holds if the value at `(type, path)` should be seen as a flow
- * source of the given `kind`.
+ * source of the given `kind` and `madId` is the data extension row number.
  *
  * The kind `remote` represents a general remote flow source.
  */
@@ -14,13 +14,14 @@ extensible predicate sourceModel(
 
 /**
  * Holds if the value at `(type, path)` should be seen as a sink
- * of the given `kind`.
+ * of the given `kind` and `madId` is the data extension row number.
  */
 extensible predicate sinkModel(string type, string path, string kind, QlBuiltins::ExtensionId madId);
 
 /**
  * Holds if in calls to `(type, path)`, the value referred to by `input`
- * can flow to the value referred to by `output`.
+ * can flow to the value referred to by `output` and `madId` is the data
+ * extension row number.
  *
  * `kind` should be either `value` or `taint`, for value-preserving or taint-preserving steps,
  * respectively.

--- a/ruby/ql/lib/codeql/ruby/frameworks/data/internal/ApiGraphModelsExtensions.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/data/internal/ApiGraphModelsExtensions.qll
@@ -4,7 +4,7 @@
 
 /**
  * Holds if the value at `(type, path)` should be seen as a flow
- * source of the given `kind`.
+ * source of the given `kind` and `madId` is the data extension row number.
  *
  * The kind `remote` represents a general remote flow source.
  */
@@ -14,13 +14,14 @@ extensible predicate sourceModel(
 
 /**
  * Holds if the value at `(type, path)` should be seen as a sink
- * of the given `kind`.
+ * of the given `kind` and `madId` is the data extension row number.
  */
 extensible predicate sinkModel(string type, string path, string kind, QlBuiltins::ExtensionId madId);
 
 /**
  * Holds if in calls to `(type, path)`, the value referred to by `input`
- * can flow to the value referred to by `output`.
+ * can flow to the value referred to by `output` and `madId` is the data
+ * extension row number.
  *
  * `kind` should be either `value` or `taint`, for value-preserving or taint-preserving steps,
  * respectively.

--- a/shared/quantum/codeql/quantum/experimental/Model.qll
+++ b/shared/quantum/codeql/quantum/experimental/Model.qll
@@ -365,7 +365,7 @@ module CryptographyBase<LocationSig Location, InputSig<Location> Input> {
    */
   abstract class ArtifactConsumer extends ConsumerElement {
     /**
-     * Use `getAKnownArtifactSource() instead. The behaviour of these two predicates is equivalent.
+     * Use `getAKnownArtifactSource() instead. The behavior of these two predicates is equivalent.
      */
     final override KnownElement getAKnownSource() { result = this.getAKnownArtifactSource() }
 
@@ -1841,9 +1841,7 @@ module CryptographyBase<LocationSig Location, InputSig<Location> Input> {
    * An SCRYPT key derivation algorithm node.
    */
   class ScryptAlgorithmNode extends KeyDerivationAlgorithmNode {
-    ScryptAlgorithmInstance scryptInstance;
-
-    ScryptAlgorithmNode() { scryptInstance = instance.asAlg() }
+    ScryptAlgorithmNode() { instance.asAlg() instanceof ScryptAlgorithmInstance }
 
     /**
      * Gets the iteration count (`N`) argument


### PR DESCRIPTION
Fix some Ql4Ql violations based on the following checks
- `ql/field-only-used-in-charpred`
- `ql/could-be-cast`
- `ql/counting-to-zero`
- `ql/dataflow-module-naming-convention`
- `ql/if-with-none`
- `ql/missing-parameter-qldoc`
- `ql/misspelling`