### PR TITLE
Rust: Infer certain type for shorthand `self`

### DIFF
--- a/rust/ql/lib/codeql/rust/internal/TypeInference.qll
+++ b/rust/ql/lib/codeql/rust/internal/TypeInference.qll
@@ -226,7 +226,13 @@ module Consistency {
 
   predicate nonUniqueCertainType(AstNode n, TypePath path, Type t) {
     strictcount(CertainTypeInference::inferCertainType(n, path)) > 1 and
-    t = CertainTypeInference::inferCertainType(n, path)
+    t = CertainTypeInference::inferCertainType(n, path) and
+    // Suppress the inconsistency if `n` is a self parameter and the type
+    // mention for the self type has multiple types for a path.
+    not exists(ImplItemNode impl, TypePath path0 |
+      n = impl.getAnAssocItem().(Function).getParamList().getSelfParam() and
+      strictcount(impl.(Impl).getSelfTy().(TypeMention).resolveTypeAt(path0)) > 1
+    )
   }
 }
 

--- a/rust/ql/lib/codeql/rust/internal/TypeInference.qll
+++ b/rust/ql/lib/codeql/rust/internal/TypeInference.qll
@@ -229,9 +229,9 @@ module Consistency {
     t = CertainTypeInference::inferCertainType(n, path) and
     // Suppress the inconsistency if `n` is a self parameter and the type
     // mention for the self type has multiple types for a path.
-    not exists(ImplItemNode impl, TypePath path0 |
+    not exists(ImplItemNode impl, TypePath selfTypePath |
       n = impl.getAnAssocItem().(Function).getParamList().getSelfParam() and
-      strictcount(impl.(Impl).getSelfTy().(TypeMention).resolveTypeAt(path0)) > 1
+      strictcount(impl.(Impl).getSelfTy().(TypeMention).resolveTypeAt(selfTypePath)) > 1
     )
   }
 }

--- a/rust/ql/test/library-tests/type-inference/main.rs
+++ b/rust/ql/test/library-tests/type-inference/main.rs
@@ -73,7 +73,7 @@ mod method_impl {
 
     impl Foo {
         pub fn m1(self) -> Self {
-            self // $ type=self:Foo
+            self // $ certainType=self:Foo
         }
 
         pub fn m2(self) -> Foo {
@@ -108,7 +108,7 @@ mod trait_impl {
     impl MyTrait<bool> for MyThing {
         // MyThing::trait_method
         fn trait_method(self) -> bool {
-            self.field // $ type=self:MyThing fieldof=MyThing
+            self.field // $ certainType=self:MyThing fieldof=MyThing
         }
     }
 

--- a/rust/ql/test/library-tests/type-inference/main.rs
+++ b/rust/ql/test/library-tests/type-inference/main.rs
@@ -73,7 +73,7 @@ mod method_impl {
 
     impl Foo {
         pub fn m1(self) -> Self {
-            self
+            self // $ type=self:Foo
         }
 
         pub fn m2(self) -> Foo {
@@ -108,7 +108,7 @@ mod trait_impl {
     impl MyTrait<bool> for MyThing {
         // MyThing::trait_method
         fn trait_method(self) -> bool {
-            self.field // $ fieldof=MyThing
+            self.field // $ type=self:MyThing fieldof=MyThing
         }
     }
 

--- a/rust/ql/test/library-tests/type-inference/type-inference.expected
+++ b/rust/ql/test/library-tests/type-inference/type-inference.expected
@@ -2467,7 +2467,6 @@ inferType
 | main.rs:1328:33:1328:36 | SelfParam |  | main.rs:1326:5:1329:5 | Self [trait ATrait] |
 | main.rs:1334:29:1334:33 | SelfParam |  | file://:0:0:0:0 | & |
 | main.rs:1334:29:1334:33 | SelfParam | &T | file://:0:0:0:0 | & |
-| main.rs:1334:29:1334:33 | SelfParam | &T | main.rs:1307:5:1310:5 | MyInt |
 | main.rs:1334:29:1334:33 | SelfParam | &T.&T | main.rs:1307:5:1310:5 | MyInt |
 | main.rs:1334:43:1336:9 | { ... } |  | {EXTERNAL LOCATION} | i64 |
 | main.rs:1335:13:1335:22 | (...) |  | main.rs:1307:5:1310:5 | MyInt |
@@ -2481,7 +2480,6 @@ inferType
 | main.rs:1335:16:1335:20 | * ... | &T | main.rs:1307:5:1310:5 | MyInt |
 | main.rs:1335:17:1335:20 | self |  | file://:0:0:0:0 | & |
 | main.rs:1335:17:1335:20 | self | &T | file://:0:0:0:0 | & |
-| main.rs:1335:17:1335:20 | self | &T | main.rs:1307:5:1310:5 | MyInt |
 | main.rs:1335:17:1335:20 | self | &T.&T | main.rs:1307:5:1310:5 | MyInt |
 | main.rs:1339:33:1339:36 | SelfParam |  | file://:0:0:0:0 | & |
 | main.rs:1339:33:1339:36 | SelfParam | &T | main.rs:1307:5:1310:5 | MyInt |
@@ -3798,7 +3796,6 @@ inferType
 | main.rs:2030:31:2032:9 | { ... } |  | main.rs:2002:5:2002:14 | S2 |
 | main.rs:2031:13:2031:14 | S2 |  | main.rs:2002:5:2002:14 | S2 |
 | main.rs:2036:18:2036:22 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:2036:18:2036:22 | SelfParam |  | main.rs:2003:5:2003:22 | S3 |
 | main.rs:2036:18:2036:22 | SelfParam | &T | main.rs:2003:5:2003:22 | S3 |
 | main.rs:2036:18:2036:22 | SelfParam | &T.T3 | main.rs:2035:10:2035:17 | T |
 | main.rs:2036:30:2039:9 | { ... } |  | main.rs:2035:10:2035:17 | T |
@@ -3807,7 +3804,6 @@ inferType
 | main.rs:2037:17:2037:21 | S3(...) | &T | main.rs:2003:5:2003:22 | S3 |
 | main.rs:2037:17:2037:21 | S3(...) | &T.T3 | main.rs:2035:10:2035:17 | T |
 | main.rs:2037:25:2037:28 | self |  | file://:0:0:0:0 | & |
-| main.rs:2037:25:2037:28 | self |  | main.rs:2003:5:2003:22 | S3 |
 | main.rs:2037:25:2037:28 | self | &T | main.rs:2003:5:2003:22 | S3 |
 | main.rs:2037:25:2037:28 | self | &T.T3 | main.rs:2035:10:2035:17 | T |
 | main.rs:2038:13:2038:21 | t.clone() |  | main.rs:2035:10:2035:17 | T |


### PR DESCRIPTION
We currently infer certain type information for `self` in `fn f(self: Self)` but not for `self` in `fn f(self)` even though the latter is just syntactic sugar for the former. This PR removes that distinction. Just in our tests, that removes 4 spurious types.

The PR uses the word "shorthand" which comes from the Rust reference which uses the terms ["shorthand self"](https://doc.rust-lang.org/reference/items/functions.html#grammar-ShorthandSelf) and ["shorthand syntax"](https://doc.rust-lang.org/stable/reference/items/associated-items.html#r-associated.fn.method.self-pat-shorthands).

The logic for inferring the type of a shorthand self parameters is now included inside `inferAnnotatedType` which I think makes sense as there's explicit annotations right beneath the sugar.

The [first DCA run](https://github.com/github/codeql-dca-main/tree/data/paldepind/PR-20348-0-rust__1/reports) showed a performance regression that I can't reproduce locally (I tried quick evaling `inferType` on `iced`). The [second DCA run](https://github.com/github/codeql-dca-main/tree/data/paldepind/PR-20348-0-rust__2/reports) shows only a tiny performance regression, and doesn't really agree with the first. For instance, neon-empty-diff was the biggest regression in the first run but shows a speedup in the second. So I think it's just noice, and the rest of the DCA report looks as expected.