### PR TITLE
C++: Fix some Ql4Ql violations (crypto).

### DIFF
--- a/cpp/ql/lib/experimental/cryptography/CryptoArtifact.qll
+++ b/cpp/ql/lib/experimental/cryptography/CryptoArtifact.qll
@@ -127,7 +127,7 @@ abstract class CryptographicAlgorithm extends CryptographicArtifact {
   /**
    * Normalizes a raw name into a normalized name as found in `CryptoAlgorithmNames.qll`.
    * Subclassess should override for more api-specific normalization.
-   * By deafult, converts a raw name to upper-case with no hyphen, underscore, hash, or space.
+   * By default, converts a raw name to upper-case with no hyphen, underscore, hash, or space.
    */
   bindingset[s]
   string normalizeName(string s) {

--- a/cpp/ql/lib/experimental/cryptography/modules/OpenSSL.qll
+++ b/cpp/ql/lib/experimental/cryptography/modules/OpenSSL.qll
@@ -652,14 +652,14 @@ module KeyGeneration {
    * Trace from EVP_PKEY_CTX* at algorithm sink to keygen,
    * users can then extrapolatae the matching algorithm from the alg sink to the keygen
    */
-  module EVP_PKEY_CTX_Ptr_Source_to_KeyGenOperationWithNoSize implements DataFlow::ConfigSig {
+  module EVP_PKEY_CTX_Ptr_Source_to_KeyGenOperationWithNoSizeConfig implements DataFlow::ConfigSig {
     predicate isSource(DataFlow::Node source) { isEVP_PKEY_CTX_Source(source, _) }
 
     predicate isSink(DataFlow::Node sink) { isKeyGen_EVP_PKEY_CTX_Sink(sink, _) }
   }
 
   module EVP_PKEY_CTX_Ptr_Source_to_KeyGenOperationWithNoSize_Flow =
-    DataFlow::Global<EVP_PKEY_CTX_Ptr_Source_to_KeyGenOperationWithNoSize>;
+    DataFlow::Global<EVP_PKEY_CTX_Ptr_Source_to_KeyGenOperationWithNoSizeConfig>;
 
   /**
    * UNKNOWN key sizes to general purpose key generation functions (i.e., that take in no key size and assume

--- a/cpp/ql/lib/experimental/cryptography/utils/OpenSSL/CryptoFunction.qll
+++ b/cpp/ql/lib/experimental/cryptography/utils/OpenSSL/CryptoFunction.qll
@@ -59,7 +59,7 @@ private string privateNormalizeFunctionName(Function f, string algType) {
  *
  * The predicate attempts to restrict normalization to what looks like an openssl
  * library by looking for functions only in an openssl path (see `isPossibleOpenSSLFunction`).
- * This may give false postive functions if a directory erronously appears to be openssl;
+ * This may give false positive functions if a directory erronously appears to be openssl;
  * however, we take the stance that if a function
  * exists strongly mapping to a known function name in a directory such as these,
  * regardless of whether its actually a part of openSSL or not, we will analyze it as though it were.

--- a/cpp/ql/lib/experimental/cryptography/utils/OpenSSL/DataBuilders.qll
+++ b/cpp/ql/lib/experimental/cryptography/utils/OpenSSL/DataBuilders.qll
@@ -49,7 +49,7 @@ private string privateNormalizeFunctionName(Function f, string algType) {
  *
  * The predicate attempts to restrict normalization to what looks like an openssl
  * library by looking for functions only in an openssl path (see `isPossibleOpenSSLFunction`).
- * This may give false postive functions if a directory erronously appears to be openssl;
+ * This may give false positive functions if a directory erronously appears to be openssl;
  * however, we take the stance that if a function
  * exists strongly mapping to a known function name in a directory such as these,
  * regardless of whether its actually a part of openSSL or not, we will analyze it as though it were.

--- a/cpp/ql/lib/experimental/cryptography/utils/OpenSSL/PassthroughFunction.qll
+++ b/cpp/ql/lib/experimental/cryptography/utils/OpenSSL/PassthroughFunction.qll
@@ -31,7 +31,7 @@ predicate knownPassthroughFunction(Function f, int inInd, int outInd) {
 
 /**
  * `c` is a call to a function that preserves the algorithm but changes its form.
- * `onExpr` is the input argument passing through to, `outExpr` is the next expression in a dataflow step associated with `c`
+ * `inExpr` is the input argument passing through to, `outExpr` is the next expression in a dataflow step associated with `c`
  */
 predicate knownPassthoughCall(Call c, Expr inExpr, Expr outExpr) {
   exists(int inInd, int outInd |


### PR DESCRIPTION
Fix some Ql4Ql violations based on the following checks

- `ql/field-only-used-in-charpred`
- `ql/could-be-cast`
- `ql/counting-to-zero`
- `ql/dataflow-module-naming-convention`
- `ql/if-with-none`
 - `ql/missing-parameter-qldoc`
- `ql/misspelling`