### PR TITLE
JS: Refactor default import interop

### DIFF
--- a/javascript/ql/lib/semmle/javascript/ApiGraphs.qll
+++ b/javascript/ql/lib/semmle/javascript/ApiGraphs.qll
@@ -822,7 +822,7 @@ module API {
           or
           // special case: from `require('m')` to an export of `prop` in `m`
           exists(Import imp, Module m, string prop |
-            pred = imp.getImportedModuleNode() and
+            pred = imp.getImportedModuleNodeIfUnambiguous() and
             m = imp.getImportedModule() and
             lbl = Label::member(prop) and
             rhs = m.getAnExportedValue(prop)
@@ -1337,7 +1337,9 @@ module API {
       result = nd.getALocalSource()
       or
       // additional backwards step from `require('m')` to `exports` or `module.exports` in m
-      exists(Import imp | imp.getImportedModuleNode() = trackDefNode(nd, t.continue()) |
+      exists(Import imp |
+        imp.getImportedModuleNodeIfUnambiguous() = trackDefNode(nd, t.continue())
+      |
         result = DataFlow::exportsVarNode(imp.getImportedModule())
         or
         result = DataFlow::moduleVarNode(imp.getImportedModule()).getAPropertyRead("exports")

--- a/javascript/ql/lib/semmle/javascript/ES2015Modules.qll
+++ b/javascript/ql/lib/semmle/javascript/ES2015Modules.qll
@@ -140,7 +140,7 @@ class ImportDeclaration extends Stmt, Import, @import_declaration {
       // For compatibility with the non-standard implementation of default imports,
       // treat default imports as namespace imports. In cases where it causes ambiguity
       // between named exports and the properties of a default-exported object, the caller
-      // of `getImportedModuleNode()` must check `isDefaultImport()` and correct the behaviour.
+      // of `getImportedModuleNode()` must check `isDefaultImport()` and correct the behavior.
       this.hasOnlyDefaultImport()
     )
     or

--- a/javascript/ql/lib/semmle/javascript/Modules.qll
+++ b/javascript/ql/lib/semmle/javascript/Modules.qll
@@ -203,7 +203,7 @@ abstract class Import extends AstNode {
   abstract DataFlow::Node getImportedModuleNode();
 
   /**
-   * Holds of the result of `getImportedModuleNode` actually refers to the export binding named `"default"`,
+   * Holds if the result of `getImportedModuleNode` actually refers to the export binding named `"default"`,
    * as opposed an object whose properties correspond to the export bindings of the imported module.
    *
    * For compatibility with non-standard interpretations of `default` imports, the default
@@ -220,7 +220,7 @@ abstract class Import extends AstNode {
   predicate isDefaultImport() { none() }
 
   /**
-   * Gets the same as `getImportedModuleNode()` expect this has no result for default imports when the target module
+   * Gets the same as `getImportedModuleNode()` except this has no result for default imports when the target module
    * has both default and named exports.
    *
    * This is to avoid ambiguity between named export bindings and the properties of the default-exported object.

--- a/javascript/ql/lib/semmle/javascript/Modules.qll
+++ b/javascript/ql/lib/semmle/javascript/Modules.qll
@@ -227,10 +227,10 @@ abstract class Import extends AstNode {
    */
   pragma[nomagic]
   final DataFlow::Node getImportedModuleNodeIfUnambiguous() {
-    if
+    result = this.getImportedModuleNode() and
+    not (
       this.isDefaultImport() and
       this.getImportedModule().(ES2015Module).hasBothNamedAndDefaultExports()
-    then none()
-    else result = this.getImportedModuleNode()
+    )
   }
 }

--- a/javascript/ql/lib/semmle/javascript/Modules.qll
+++ b/javascript/ql/lib/semmle/javascript/Modules.qll
@@ -198,7 +198,7 @@ abstract class Import extends AstNode {
    * For statements of form `import foo from "bar'`, this gives the node corresponding to `foo`.
    * Technically this should refer to the export binding named `"default"`, not the whole module, but for compatibility with non-standard
    * interpretations of default imports, this node is usually treated as also referring to the whole module.
-   * If this behaviour is not wanted, use `isDefaultImport()` to handle that case differently.
+   * If this behavior is not wanted, use `isDefaultImport()` to handle that case differently.
    */
   abstract DataFlow::Node getImportedModuleNode();
 
@@ -207,7 +207,7 @@ abstract class Import extends AstNode {
    * as opposed an object whose properties correspond to the export bindings of the imported module.
    *
    * For compatibility with non-standard interpretations of `default` imports, the default
-   * import is usually returned by `getImportedModuleNode()`. If such behaviour is not wanted,
+   * import is usually returned by `getImportedModuleNode()`. If such behavior is not wanted,
    * this predicate can be used to handle that case differently.
    *
    * For example, `getImportedModuleNode()` returns `foo` in both of these imports, but `isDefaultImport()`


### PR DESCRIPTION
For overlay locality, we want `Import.getImportedModuleNode()` to be local, without necessarily making `Import.getImportedModule()` local.

This means `getImportedModuleNode()` shouldn't depend on `getImportedModule()`, but currently some logic for dealing  with non-standard `default` import semantics relies on it.

This PR refactors `getImportedModuleNode()` so it can be `overlay[local]`, and introduces `getImportedModuleNodeIfUnambiguous()` which is `overlay[global]` and performs some extra checks to avoid incorrect data flow. Most use-cases can just continue using `getImportedModuleNode()`.