### PR TITLE
Go: Support `git_source`

### DIFF
--- a/go/extractor/util/registryproxy.go
+++ b/go/extractor/util/registryproxy.go
@@ -53,7 +53,13 @@ func getEnvVars() []string {
 	if proxy_host, proxy_host_set := os.LookupEnv(PROXY_HOST); proxy_host_set && proxy_host != "" {
 		if proxy_port, proxy_port_set := os.LookupEnv(PROXY_PORT); proxy_port_set && proxy_port != "" {
 			proxy_address = fmt.Sprintf("http://%s:%s", proxy_host, proxy_port)
-			result = append(result, fmt.Sprintf("HTTP_PROXY=%s", proxy_address), fmt.Sprintf("HTTPS_PROXY=%s", proxy_address))
+			result = append(
+				result,
+				fmt.Sprintf("HTTP_PROXY=%s", proxy_address),
+				fmt.Sprintf("HTTPS_PROXY=%s", proxy_address),
+				fmt.Sprintf("http_proxy=%s", proxy_address),
+				fmt.Sprintf("https_proxy=%s", proxy_address),
+			)
 
 			slog.Info("Found private registry proxy", slog.String("proxy_address", proxy_address))
 		}

--- a/go/extractor/util/registryproxy.go
+++ b/go/extractor/util/registryproxy.go
@@ -129,6 +129,18 @@ func getEnvVars() []string {
 
 			if len(git_sources) > 0 {
 				goprivate = append(goprivate, git_sources...)
+
+				if proxy_cert_file != "" {
+					slog.Info("Configuring `git` to use proxy certificate", slog.String("path", proxy_cert_file))
+					cmd := exec.Command("git", "config", "--global", "http.sslCAInfo", proxy_cert_file)
+
+					out, cmdErr := cmd.CombinedOutput()
+					slog.Info(string(out))
+
+					if cmdErr != nil {
+						slog.Error("Failed to configure `git` to accept the certificate file", slog.String("error", cmdErr.Error()))
+					}
+				}
 			}
 
 			result = append(result, fmt.Sprintf("GOPRIVATE=%s", strings.Join(goprivate, ",")))

--- a/go/extractor/util/registryproxy.go
+++ b/go/extractor/util/registryproxy.go
@@ -26,9 +26,8 @@ var proxy_address string
 // The path to the temporary file that stores the proxy certificate, if any.
 var proxy_cert_file string
 
-// An array of registry configurations that are relevant to Go.
-// This excludes other registry configurations that may be available, but are not relevant to Go.
-var proxy_configs []RegistryConfig
+// An array of goproxy server URLs.
+var goproxy_servers []string
 
 // Stores the environment variables that we wish to pass on to `go` commands.
 var proxy_vars []string = nil
@@ -97,16 +96,16 @@ func getEnvVars() []string {
 			// filter others out at this point.
 			for _, cfg := range val {
 				if cfg.Type == GOPROXY_SERVER {
-					proxy_configs = append(proxy_configs, cfg)
+					goproxy_servers = append(goproxy_servers, cfg.URL)
 					slog.Info("Found GOPROXY server", slog.String("url", cfg.URL))
 				}
 			}
 
-			if len(proxy_configs) > 0 {
+			if len(goproxy_servers) > 0 {
 				goproxy_val := "https://proxy.golang.org,direct"
 
-				for _, cfg := range proxy_configs {
-					goproxy_val = cfg.URL + "," + goproxy_val
+				for _, url := range goproxy_servers {
+					goproxy_val = url + "," + goproxy_val
 				}
 
 				result = append(result, fmt.Sprintf("GOPROXY=%s", goproxy_val), "GOPRIVATE=", "GONOPROXY=")

--- a/go/extractor/util/registryproxy.go
+++ b/go/extractor/util/registryproxy.go
@@ -103,7 +103,11 @@ func getEnvVars() []string {
 					goproxy_servers = append(goproxy_servers, cfg.URL)
 					slog.Info("Found GOPROXY server", slog.String("url", cfg.URL))
 				} else if cfg.Type == GIT_SOURCE {
-					git_sources = append(git_sources, cfg.URL)
+					if strings.HasSuffix(cfg.URL, "*") {
+						git_sources = append(git_sources, cfg.URL)
+					} else {
+						git_sources = append(git_sources, cfg.URL+"*")
+					}
 					slog.Info("Found Git source", slog.String("url", cfg.URL))
 				}
 			}

--- a/go/extractor/util/registryproxy.go
+++ b/go/extractor/util/registryproxy.go
@@ -113,11 +113,6 @@ func getEnvVars() []string {
 
 // Applies private package proxy related environment variables to `cmd`.
 func ApplyProxyEnvVars(cmd *exec.Cmd) {
-	slog.Debug(
-		"Applying private registry proxy environment variables",
-		slog.String("cmd_args", strings.Join(cmd.Args, " ")),
-	)
-
 	// If we haven't done so yet, check whether the proxy environment variables are set
 	// and extract information from them.
 	if !proxy_vars_checked {
@@ -131,4 +126,10 @@ func ApplyProxyEnvVars(cmd *exec.Cmd) {
 	if proxy_vars != nil {
 		cmd.Env = append(os.Environ(), proxy_vars...)
 	}
+
+	slog.Debug(
+		"Applying private registry proxy environment variables",
+		slog.String("cmd_args", strings.Join(cmd.Args, " ")),
+		slog.String("proxy_vars", strings.Join(proxy_vars, ",")),
+	)
 }

--- a/go/extractor/util/registryproxy.go
+++ b/go/extractor/util/registryproxy.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"os"
 	"os/exec"
 	"strings"
@@ -103,12 +104,14 @@ func getEnvVars() []string {
 					goproxy_servers = append(goproxy_servers, cfg.URL)
 					slog.Info("Found GOPROXY server", slog.String("url", cfg.URL))
 				} else if cfg.Type == GIT_SOURCE {
-					if strings.HasSuffix(cfg.URL, "*") {
-						git_sources = append(git_sources, cfg.URL)
+					parsed, err := url.Parse(cfg.URL)
+					if err == nil && parsed.Hostname() != "" {
+						git_source := parsed.Hostname() + parsed.Path + "*"
+						git_sources = append(git_sources, git_source)
+						slog.Info("Found Git source", slog.String("source", git_source))
 					} else {
-						git_sources = append(git_sources, cfg.URL+"*")
+						slog.Warn("Not a valid URL for Git source", slog.String("url", cfg.URL))
 					}
-					slog.Info("Found Git source", slog.String("url", cfg.URL))
 				}
 			}
 

--- a/go/extractor/util/registryproxy_test.go
+++ b/go/extractor/util/registryproxy_test.go
@@ -47,3 +47,31 @@ func TestParseRegistryConfigs(t *testing.T) {
 		t.Fatalf("Expected `URL` to be `https://proxy.example.com/mod`, but got `%s`", first.URL)
 	}
 }
+
+func TestParseRegistryConfigsMultiple(t *testing.T) {
+	multiple := parseRegistryConfigsSuccess(t, "[{ \"type\": \"git_source\", \"url\": \"https://github.com/github\" }, { \"type\": \"goproxy_server\", \"url\": \"https://proxy.example.com/mod\" }]")
+
+	if len(multiple) != 2 {
+		t.Fatalf("Expected `parseRegistryConfigs` to return two configurations, but got %d.", len(multiple))
+	}
+
+	first := multiple[0]
+
+	if first.Type != "git_source" {
+		t.Fatalf("Expected `Type` to be `git_source`, but got `%s`", first.Type)
+	}
+
+	if first.URL != "https://github.com/github" {
+		t.Fatalf("Expected `URL` to be `https://github.com/github`, but got `%s`", first.URL)
+	}
+
+	second := multiple[1]
+
+	if second.Type != "goproxy_server" {
+		t.Fatalf("Expected `Type` to be `goproxy_server`, but got `%s`", second.Type)
+	}
+
+	if second.URL != "https://proxy.example.com/mod" {
+		t.Fatalf("Expected `URL` to be `https://proxy.example.com/mod`, but got `%s`", second.URL)
+	}
+}


### PR DESCRIPTION
This PR modifies the Go autobuilder/extractor to support `git_source` private registry configurations, in addition to the `goproxy_server` configurations that were already supported.

In https://github.com/github/codeql-action/pull/3079, we modified the CodeQL Action so that `git_source` configurations are now propagated to the Go autobuilder/extractor.

With the changes in this PR, if a `git_source` configuration is provided, we set `GOPRIVATE` to include a pattern for the hostname provided in the configuration. The `GOPRIVATE` variable instructs `go` which packages should not be fetched via a `GOPROXY` (whether it's the default one or a custom one). For example, if the `git_source` configuration is for `https://github.com/foo`, then we'd set `GOPRIVATE=github.com/foo*`.

This is a simplification of what is necessary for `GOPRIVATE`, because Go modules may not have the same name as the address of the repository that contains them. Ideally, we would make `GOPRIVATE` configurable somehow, possibly using a `go.env` file in the repository or similar. However, for initially supporting this, the behaviour here should be sufficient.

If a `git_source` is configured, we also configure `git` on the runner to use the self-signed proxy certificate. Otherwise, it will refuse to connect.