### PR TITLE
Java: Fix broken performance.

### DIFF
--- a/java/ql/src/Violations of Best Practice/Naming Conventions/ConfusingOverloading.ql
+++ b/java/ql/src/Violations of Best Practice/Naming Conventions/ConfusingOverloading.ql
@@ -66,8 +66,8 @@ private predicate candidateMethod(RefType t, Method m, string name, int numParam
 predicate paramTypePair(Type t1, Type t2) {
   exists(Method n, Method m, int i |
     overloadedMethodsMostSpecific(n, m) and
-    t1 = n.getParameterType(i) and
-    t2 = m.getParameterType(i)
+    t1 = n.getParameterType(pragma[only_bind_into](i)) and
+    t2 = m.getParameterType(pragma[only_bind_into](i))
   )
 }
 
@@ -93,6 +93,7 @@ predicate potentiallyConfusingTypesRefTypes(RefType t1, RefType t2) {
 }
 
 // then check hasSubtypeOrInstantiation
+pragma[nomagic]
 predicate potentiallyConfusingTypes(Type t1, Type t2) {
   potentiallyConfusingTypesSimple(t1, t2)
   or


### PR DESCRIPTION
Performance of `ConfusingOverloading.ql` was broken by https://github.com/github/codeql/pull/20116. This PR fixes things. There were two issues: the dreaded join-on-index and a case of bad magic.