### PR TITLE
DataFlow: Permit local flow between post-update nodes

### DIFF
--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-consistency.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-consistency.expected
@@ -50,37 +50,21 @@ argHasPostUpdate
 postWithInFlow
 | BarrierGuard.cpp:49:6:49:6 | x [post update] | PostUpdateNode should not be the target of local flow. |
 | BarrierGuard.cpp:60:7:60:7 | x [post update] | PostUpdateNode should not be the target of local flow. |
-| clang.cpp:22:9:22:20 | sourceArray1 [inner post update] | PostUpdateNode should not be the target of local flow. |
-| clang.cpp:23:18:23:29 | sourceArray1 [inner post update] | PostUpdateNode should not be the target of local flow. |
 | clang.cpp:29:22:29:23 | m1 [post update] | PostUpdateNode should not be the target of local flow. |
-| clang.cpp:51:3:51:12 | stackArray [inner post update] | PostUpdateNode should not be the target of local flow. |
 | clang.cpp:51:3:51:15 | access to array [post update] | PostUpdateNode should not be the target of local flow. |
 | dispatch.cpp:60:3:60:14 | globalBottom [post update] | PostUpdateNode should not be the target of local flow. |
 | dispatch.cpp:61:3:61:14 | globalMiddle [post update] | PostUpdateNode should not be the target of local flow. |
-| dispatch.cpp:78:24:78:37 | call to allocateBottom [inner post update] | PostUpdateNode should not be the target of local flow. |
 | dispatch.cpp:148:5:148:5 | f [post update] | PostUpdateNode should not be the target of local flow. |
 | dispatch.cpp:168:8:168:8 | f [post update] | PostUpdateNode should not be the target of local flow. |
 | example.c:24:9:24:9 | x [post update] | PostUpdateNode should not be the target of local flow. |
 | example.c:24:20:24:20 | y [post update] | PostUpdateNode should not be the target of local flow. |
 | example.c:26:9:26:9 | x [post update] | PostUpdateNode should not be the target of local flow. |
-| example.c:26:19:26:24 | coords [inner post update] | PostUpdateNode should not be the target of local flow. |
-| example.c:28:23:28:25 | pos [inner post update] | PostUpdateNode should not be the target of local flow. |
 | flowOut.cpp:5:5:5:12 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
-| flowOut.cpp:5:6:5:12 | toTaint [inner post update] | PostUpdateNode should not be the target of local flow. |
 | flowOut.cpp:8:5:8:12 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
-| flowOut.cpp:8:6:8:12 | toTaint [inner post update] | PostUpdateNode should not be the target of local flow. |
-| flowOut.cpp:18:17:18:17 | x [inner post update] | PostUpdateNode should not be the target of local flow. |
-| flowOut.cpp:30:12:30:12 | x [inner post update] | PostUpdateNode should not be the target of local flow. |
-| flowOut.cpp:37:5:37:6 | p2 [inner post update] | PostUpdateNode should not be the target of local flow. |
 | flowOut.cpp:37:5:37:9 | access to array [post update] | PostUpdateNode should not be the target of local flow. |
-| flowOut.cpp:84:3:84:7 | call to deref [inner post update] | PostUpdateNode should not be the target of local flow. |
 | flowOut.cpp:84:3:84:14 | access to array [post update] | PostUpdateNode should not be the target of local flow. |
-| flowOut.cpp:84:10:84:10 | p [inner post update] | PostUpdateNode should not be the target of local flow. |
 | flowOut.cpp:90:3:90:4 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
-| flowOut.cpp:90:4:90:4 | q [inner post update] | PostUpdateNode should not be the target of local flow. |
-| flowOut.cpp:101:14:101:14 | p [inner post update] | PostUpdateNode should not be the target of local flow. |
 | flowOut.cpp:168:3:168:10 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
-| flowOut.cpp:168:4:168:10 | toTaint [inner post update] | PostUpdateNode should not be the target of local flow. |
 | globals.cpp:13:5:13:19 | flowTestGlobal1 [post update] | PostUpdateNode should not be the target of local flow. |
 | globals.cpp:23:5:23:19 | flowTestGlobal2 [post update] | PostUpdateNode should not be the target of local flow. |
 | lambdas.cpp:23:3:23:14 | v [post update] | PostUpdateNode should not be the target of local flow. |
@@ -106,57 +90,30 @@ postWithInFlow
 | ref.cpp:109:9:109:11 | val [post update] | PostUpdateNode should not be the target of local flow. |
 | ref.cpp:113:11:113:13 | val [post update] | PostUpdateNode should not be the target of local flow. |
 | ref.cpp:115:11:115:13 | val [post update] | PostUpdateNode should not be the target of local flow. |
-| self_parameter_flow.cpp:3:4:3:5 | ps [inner post update] | PostUpdateNode should not be the target of local flow. |
-| self_parameter_flow.cpp:8:9:8:9 | s [inner post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:91:3:91:9 | source1 [post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:115:3:115:6 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
-| test.cpp:115:4:115:6 | out [inner post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:120:3:120:6 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
-| test.cpp:120:4:120:6 | out [inner post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:125:3:125:6 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
-| test.cpp:125:4:125:6 | out [inner post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:333:5:333:13 | globalVar [post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:347:5:347:13 | globalVar [post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:359:5:359:9 | field [post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:373:5:373:9 | field [post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:384:10:384:13 | ref arg & ... | PostUpdateNode should not be the target of local flow. |
-| test.cpp:384:11:384:13 | tmp [inner post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:391:10:391:13 | ref arg & ... | PostUpdateNode should not be the target of local flow. |
-| test.cpp:391:11:391:13 | tmp [inner post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:400:10:400:13 | ref arg & ... | PostUpdateNode should not be the target of local flow. |
-| test.cpp:400:11:400:13 | tmp [inner post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:407:10:407:13 | ref arg & ... | PostUpdateNode should not be the target of local flow. |
-| test.cpp:407:11:407:13 | tmp [inner post update] | PostUpdateNode should not be the target of local flow. |
-| test.cpp:423:21:423:25 | local [inner post update] | PostUpdateNode should not be the target of local flow. |
-| test.cpp:441:19:441:23 | local [inner post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:472:3:472:4 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
-| test.cpp:472:4:472:4 | p [inner post update] | PostUpdateNode should not be the target of local flow. |
-| test.cpp:477:22:477:22 | x [inner post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:506:3:506:4 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
-| test.cpp:506:4:506:4 | p [inner post update] | PostUpdateNode should not be the target of local flow. |
-| test.cpp:512:35:512:35 | x [inner post update] | PostUpdateNode should not be the target of local flow. |
-| test.cpp:519:3:519:12 | stackArray [inner post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:519:3:519:15 | access to array [post update] | PostUpdateNode should not be the target of local flow. |
-| test.cpp:520:3:520:12 | stackArray [inner post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:520:3:520:15 | access to array [post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:526:3:526:4 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
-| test.cpp:526:4:526:4 | e [inner post update] | PostUpdateNode should not be the target of local flow. |
-| test.cpp:531:40:531:40 | e [inner post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:537:5:537:6 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
-| test.cpp:537:6:537:6 | p [inner post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:542:5:542:6 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
-| test.cpp:542:6:542:6 | p [inner post update] | PostUpdateNode should not be the target of local flow. |
-| test.cpp:548:25:548:25 | x [inner post update] | PostUpdateNode should not be the target of local flow. |
-| test.cpp:552:25:552:25 | y [inner post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:562:5:562:13 | globalInt [post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:576:5:576:13 | globalInt [post update] | PostUpdateNode should not be the target of local flow. |
-| test.cpp:589:19:589:19 | x [inner post update] | PostUpdateNode should not be the target of local flow. |
-| test.cpp:596:3:596:4 | xs [inner post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:596:3:596:7 | access to array [post update] | PostUpdateNode should not be the target of local flow. |
-| test.cpp:602:3:602:3 | p [inner post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:602:3:602:7 | access to array [post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:608:3:608:4 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
-| test.cpp:608:4:608:4 | p [inner post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:639:3:639:3 | x [post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:646:3:646:3 | x [post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:652:3:652:3 | x [post update] | PostUpdateNode should not be the target of local flow. |
@@ -167,40 +124,23 @@ postWithInFlow
 | test.cpp:681:3:681:3 | s [post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:689:3:689:3 | s [post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:690:3:690:3 | s [post update] | PostUpdateNode should not be the target of local flow. |
-| test.cpp:694:4:694:6 | buf [inner post update] | PostUpdateNode should not be the target of local flow. |
-| test.cpp:704:23:704:25 | buf [inner post update] | PostUpdateNode should not be the target of local flow. |
-| test.cpp:715:25:715:25 | c [inner post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:728:3:728:4 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
-| test.cpp:728:4:728:4 | p [inner post update] | PostUpdateNode should not be the target of local flow. |
-| test.cpp:734:41:734:41 | x [inner post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:808:5:808:21 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
-| test.cpp:808:6:808:21 | global_indirect1 [inner post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:832:5:832:17 | global_direct [post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:931:5:931:18 | global_pointer [post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:932:5:932:19 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
-| test.cpp:932:6:932:19 | global_pointer [inner post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:1045:9:1045:11 | ref arg buf | PostUpdateNode should not be the target of local flow. |
 | test.cpp:1066:5:1066:5 | i [post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:1069:5:1069:5 | i [post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:1087:5:1087:11 | content [post update] | PostUpdateNode should not be the target of local flow. |
-| test.cpp:1088:9:1088:9 | a [inner post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:1092:5:1092:7 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
-| test.cpp:1092:6:1092:7 | pp [inner post update] | PostUpdateNode should not be the target of local flow. |
-| test.cpp:1098:53:1098:53 | p [inner post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:1108:3:1108:4 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
-| test.cpp:1108:4:1108:4 | p [inner post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:1109:3:1109:4 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
-| test.cpp:1109:4:1109:4 | p [inner post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:1138:3:1138:13 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
-| test.cpp:1138:5:1138:8 | data [inner post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:1139:3:1139:7 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
-| test.cpp:1139:4:1139:7 | data [inner post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:1153:5:1153:6 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
-| test.cpp:1153:6:1153:6 | p [inner post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:1165:5:1165:6 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
-| test.cpp:1165:6:1165:6 | p [inner post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:1195:5:1195:6 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
-| test.cpp:1195:6:1195:6 | p [inner post update] | PostUpdateNode should not be the target of local flow. |
 viableImplInCallContextTooLarge
 uniqueParameterNodeAtPosition
 uniqueParameterNodePosition

--- a/cpp/ql/test/library-tests/dataflow/fields/dataflow-consistency.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/dataflow-consistency.expected
@@ -48,8 +48,6 @@ argHasPostUpdate
 postWithInFlow
 | A.cpp:25:13:25:13 | c [post update] | PostUpdateNode should not be the target of local flow. |
 | A.cpp:27:28:27:28 | c [post update] | PostUpdateNode should not be the target of local flow. |
-| A.cpp:42:11:42:12 | cc [inner post update] | PostUpdateNode should not be the target of local flow. |
-| A.cpp:43:11:43:12 | ct [inner post update] | PostUpdateNode should not be the target of local flow. |
 | A.cpp:100:9:100:9 | a [post update] | PostUpdateNode should not be the target of local flow. |
 | A.cpp:142:10:142:10 | c [post update] | PostUpdateNode should not be the target of local flow. |
 | A.cpp:143:13:143:13 | b [post update] | PostUpdateNode should not be the target of local flow. |
@@ -67,11 +65,9 @@ postWithInFlow
 | D.cpp:44:19:44:22 | elem [post update] | PostUpdateNode should not be the target of local flow. |
 | D.cpp:57:5:57:12 | boxfield [post update] | PostUpdateNode should not be the target of local flow. |
 | D.cpp:58:20:58:23 | elem [post update] | PostUpdateNode should not be the target of local flow. |
-| E.cpp:33:19:33:19 | p [inner post update] | PostUpdateNode should not be the target of local flow. |
 | aliasing.cpp:9:6:9:7 | m1 [post update] | PostUpdateNode should not be the target of local flow. |
 | aliasing.cpp:13:5:13:6 | m1 [post update] | PostUpdateNode should not be the target of local flow. |
 | aliasing.cpp:17:5:17:6 | m1 [post update] | PostUpdateNode should not be the target of local flow. |
-| aliasing.cpp:25:18:25:19 | s1 [inner post update] | PostUpdateNode should not be the target of local flow. |
 | aliasing.cpp:37:8:37:9 | m1 [post update] | PostUpdateNode should not be the target of local flow. |
 | aliasing.cpp:42:6:42:7 | m1 [post update] | PostUpdateNode should not be the target of local flow. |
 | aliasing.cpp:49:9:49:10 | m1 [post update] | PostUpdateNode should not be the target of local flow. |
@@ -83,70 +79,31 @@ postWithInFlow
 | aliasing.cpp:92:7:92:8 | m1 [post update] | PostUpdateNode should not be the target of local flow. |
 | aliasing.cpp:98:5:98:6 | m1 [post update] | PostUpdateNode should not be the target of local flow. |
 | aliasing.cpp:106:3:106:5 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
-| aliasing.cpp:106:4:106:5 | pa [inner post update] | PostUpdateNode should not be the target of local flow. |
-| aliasing.cpp:111:18:111:19 | m1 [inner post update] | PostUpdateNode should not be the target of local flow. |
-| aliasing.cpp:126:15:126:16 | xs [inner post update] | PostUpdateNode should not be the target of local flow. |
-| aliasing.cpp:136:16:136:17 | xs [inner post update] | PostUpdateNode should not be the target of local flow. |
-| aliasing.cpp:147:16:147:16 | s [inner post update] | PostUpdateNode should not be the target of local flow. |
-| aliasing.cpp:147:21:147:22 | m1 [inner post update] | PostUpdateNode should not be the target of local flow. |
-| aliasing.cpp:175:21:175:22 | m1 [inner post update] | PostUpdateNode should not be the target of local flow. |
-| aliasing.cpp:181:21:181:22 | m1 [inner post update] | PostUpdateNode should not be the target of local flow. |
-| aliasing.cpp:187:21:187:22 | m1 [inner post update] | PostUpdateNode should not be the target of local flow. |
-| aliasing.cpp:194:21:194:22 | m1 [inner post update] | PostUpdateNode should not be the target of local flow. |
-| aliasing.cpp:200:23:200:24 | m1 [inner post update] | PostUpdateNode should not be the target of local flow. |
-| aliasing.cpp:205:23:205:24 | m1 [inner post update] | PostUpdateNode should not be the target of local flow. |
 | aliasing.cpp:215:14:215:15 | m1 [post update] | PostUpdateNode should not be the target of local flow. |
 | aliasing.cpp:223:17:223:18 | m1 [post update] | PostUpdateNode should not be the target of local flow. |
 | aliasing.cpp:234:19:234:20 | m1 [post update] | PostUpdateNode should not be the target of local flow. |
 | aliasing.cpp:242:22:242:23 | m1 [post update] | PostUpdateNode should not be the target of local flow. |
 | aliasing.cpp:252:5:252:31 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
-| aliasing.cpp:252:28:252:31 | data [inner post update] | PostUpdateNode should not be the target of local flow. |
 | aliasing.cpp:262:5:262:29 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
-| aliasing.cpp:262:26:262:29 | data [inner post update] | PostUpdateNode should not be the target of local flow. |
-| arrays.cpp:6:3:6:5 | arr [inner post update] | PostUpdateNode should not be the target of local flow. |
 | arrays.cpp:6:3:6:8 | access to array [post update] | PostUpdateNode should not be the target of local flow. |
 | arrays.cpp:15:3:15:10 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
-| arrays.cpp:15:5:15:7 | arr [inner post update] | PostUpdateNode should not be the target of local flow. |
-| arrays.cpp:36:12:36:14 | arr [inner post update] | PostUpdateNode should not be the target of local flow. |
 | arrays.cpp:36:19:36:22 | data [post update] | PostUpdateNode should not be the target of local flow. |
-| arrays.cpp:37:17:37:19 | arr [inner post update] | PostUpdateNode should not be the target of local flow. |
-| arrays.cpp:38:17:38:19 | arr [inner post update] | PostUpdateNode should not be the target of local flow. |
-| arrays.cpp:42:15:42:17 | arr [inner post update] | PostUpdateNode should not be the target of local flow. |
 | arrays.cpp:42:22:42:25 | data [post update] | PostUpdateNode should not be the target of local flow. |
-| arrays.cpp:43:20:43:22 | arr [inner post update] | PostUpdateNode should not be the target of local flow. |
-| arrays.cpp:44:20:44:22 | arr [inner post update] | PostUpdateNode should not be the target of local flow. |
-| arrays.cpp:48:15:48:17 | ptr [inner post update] | PostUpdateNode should not be the target of local flow. |
 | arrays.cpp:48:22:48:25 | data [post update] | PostUpdateNode should not be the target of local flow. |
-| arrays.cpp:49:20:49:22 | ptr [inner post update] | PostUpdateNode should not be the target of local flow. |
-| arrays.cpp:50:20:50:22 | ptr [inner post update] | PostUpdateNode should not be the target of local flow. |
 | by_reference.cpp:12:8:12:8 | a [post update] | PostUpdateNode should not be the target of local flow. |
 | by_reference.cpp:16:11:16:11 | a [post update] | PostUpdateNode should not be the target of local flow. |
-| by_reference.cpp:68:18:68:18 | s [inner post update] | PostUpdateNode should not be the target of local flow. |
 | by_reference.cpp:84:10:84:10 | a [post update] | PostUpdateNode should not be the target of local flow. |
 | by_reference.cpp:88:9:88:9 | a [post update] | PostUpdateNode should not be the target of local flow. |
 | by_reference.cpp:92:3:92:5 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
-| by_reference.cpp:92:4:92:5 | pa [inner post update] | PostUpdateNode should not be the target of local flow. |
 | by_reference.cpp:96:3:96:4 | pa [post update] | PostUpdateNode should not be the target of local flow. |
-| by_reference.cpp:102:28:102:39 | inner_nested [inner post update] | PostUpdateNode should not be the target of local flow. |
-| by_reference.cpp:104:22:104:22 | a [inner post update] | PostUpdateNode should not be the target of local flow. |
-| by_reference.cpp:106:30:106:41 | inner_nested [inner post update] | PostUpdateNode should not be the target of local flow. |
-| by_reference.cpp:108:24:108:24 | a [inner post update] | PostUpdateNode should not be the target of local flow. |
-| by_reference.cpp:123:28:123:36 | inner_ptr [inner post update] | PostUpdateNode should not be the target of local flow. |
-| by_reference.cpp:127:30:127:38 | inner_ptr [inner post update] | PostUpdateNode should not be the target of local flow. |
 | clearning.cpp:19:3:19:6 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
-| clearning.cpp:19:6:19:6 | x [inner post update] | PostUpdateNode should not be the target of local flow. |
 | clearning.cpp:32:3:32:6 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
-| clearning.cpp:32:6:32:6 | x [inner post update] | PostUpdateNode should not be the target of local flow. |
 | clearning.cpp:39:3:39:6 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
-| clearning.cpp:39:6:39:6 | x [inner post update] | PostUpdateNode should not be the target of local flow. |
 | clearning.cpp:40:5:40:5 | x [post update] | PostUpdateNode should not be the target of local flow. |
 | clearning.cpp:47:5:47:5 | x [post update] | PostUpdateNode should not be the target of local flow. |
 | clearning.cpp:53:3:53:6 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
-| clearning.cpp:53:6:53:6 | x [inner post update] | PostUpdateNode should not be the target of local flow. |
 | clearning.cpp:75:2:75:10 | access to array [post update] | PostUpdateNode should not be the target of local flow. |
-| clearning.cpp:75:4:75:6 | val [inner post update] | PostUpdateNode should not be the target of local flow. |
 | clearning.cpp:82:2:82:9 | access to array [post update] | PostUpdateNode should not be the target of local flow. |
-| clearning.cpp:82:4:82:6 | val [inner post update] | PostUpdateNode should not be the target of local flow. |
 | clearning.cpp:83:7:83:9 | val [post update] | PostUpdateNode should not be the target of local flow. |
 | clearning.cpp:97:4:97:6 | val [post update] | PostUpdateNode should not be the target of local flow. |
 | clearning.cpp:124:4:124:6 | val [post update] | PostUpdateNode should not be the target of local flow. |
@@ -162,7 +119,6 @@ postWithInFlow
 | complex.cpp:11:22:11:23 | a_ [post update] | PostUpdateNode should not be the target of local flow. |
 | complex.cpp:12:22:12:23 | b_ [post update] | PostUpdateNode should not be the target of local flow. |
 | conflated.cpp:10:3:10:7 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
-| conflated.cpp:10:7:10:7 | p [inner post update] | PostUpdateNode should not be the target of local flow. |
 | conflated.cpp:29:7:29:7 | x [post update] | PostUpdateNode should not be the target of local flow. |
 | conflated.cpp:36:7:36:7 | x [post update] | PostUpdateNode should not be the target of local flow. |
 | conflated.cpp:53:7:53:10 | next [post update] | PostUpdateNode should not be the target of local flow. |
@@ -174,19 +130,11 @@ postWithInFlow
 | qualifiers.cpp:12:56:12:56 | a [post update] | PostUpdateNode should not be the target of local flow. |
 | qualifiers.cpp:13:57:13:57 | a [post update] | PostUpdateNode should not be the target of local flow. |
 | qualifiers.cpp:22:23:22:23 | a [post update] | PostUpdateNode should not be the target of local flow. |
-| qualifiers.cpp:37:26:37:33 | call to getInner [inner post update] | PostUpdateNode should not be the target of local flow. |
-| qualifiers.cpp:42:13:42:20 | call to getInner [inner post update] | PostUpdateNode should not be the target of local flow. |
 | qualifiers.cpp:42:25:42:25 | a [post update] | PostUpdateNode should not be the target of local flow. |
-| qualifiers.cpp:47:7:47:11 | outer [inner post update] | PostUpdateNode should not be the target of local flow. |
 | qualifiers.cpp:47:27:47:27 | a [post update] | PostUpdateNode should not be the target of local flow. |
-| realistic.cpp:49:13:49:15 | bar [inner post update] | PostUpdateNode should not be the target of local flow. |
 | realistic.cpp:49:20:49:22 | baz [post update] | PostUpdateNode should not be the target of local flow. |
-| realistic.cpp:53:13:53:15 | bar [inner post update] | PostUpdateNode should not be the target of local flow. |
 | realistic.cpp:53:35:53:43 | bufferLen [post update] | PostUpdateNode should not be the target of local flow. |
-| realistic.cpp:54:20:54:22 | bar [inner post update] | PostUpdateNode should not be the target of local flow. |
 | realistic.cpp:60:16:60:18 | ref arg dst | PostUpdateNode should not be the target of local flow. |
-| realistic.cpp:61:25:61:27 | bar [inner post update] | PostUpdateNode should not be the target of local flow. |
-| realistic.cpp:65:25:65:27 | bar [inner post update] | PostUpdateNode should not be the target of local flow. |
 | simple.cpp:20:24:20:25 | a_ [post update] | PostUpdateNode should not be the target of local flow. |
 | simple.cpp:21:24:21:25 | b_ [post update] | PostUpdateNode should not be the target of local flow. |
 | simple.cpp:65:7:65:7 | i [post update] | PostUpdateNode should not be the target of local flow. |
@@ -194,9 +142,6 @@ postWithInFlow
 | simple.cpp:92:7:92:7 | i [post update] | PostUpdateNode should not be the target of local flow. |
 | simple.cpp:118:7:118:7 | i [post update] | PostUpdateNode should not be the target of local flow. |
 | simple.cpp:124:5:124:6 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
-| simple.cpp:124:6:124:6 | p [inner post update] | PostUpdateNode should not be the target of local flow. |
-| struct_init.c:24:11:24:12 | ab [inner post update] | PostUpdateNode should not be the target of local flow. |
-| struct_init.c:36:17:36:24 | nestedAB [inner post update] | PostUpdateNode should not be the target of local flow. |
 viableImplInCallContextTooLarge
 uniqueParameterNodeAtPosition
 uniqueParameterNodePosition

--- a/cpp/ql/test/library-tests/dataflow/models-as-data/consistency.expected
+++ b/cpp/ql/test/library-tests/dataflow/models-as-data/consistency.expected
@@ -18,7 +18,6 @@ postIsInSameCallable
 reverseRead
 argHasPostUpdate
 postWithInFlow
-| tests.cpp:436:6:436:25 | [summary] to write: Argument[1] in madCallArg0WithValue | PostUpdateNode should not be the target of local flow. |
 viableImplInCallContextTooLarge
 uniqueParameterNodeAtPosition
 uniqueParameterNodePosition

--- a/cpp/ql/test/library-tests/syntax-zoo/dataflow-consistency.expected
+++ b/cpp/ql/test/library-tests/syntax-zoo/dataflow-consistency.expected
@@ -48,21 +48,10 @@ argHasPostUpdate
 | ir.cpp:623:5:623:5 | r | ArgumentNode is missing PostUpdateNode. |
 | ir.cpp:625:5:625:5 | s | ArgumentNode is missing PostUpdateNode. |
 postWithInFlow
-| VacuousDestructorCall.cpp:10:22:10:22 | i [inner post update] | PostUpdateNode should not be the target of local flow. |
 | allocators.cpp:4:18:4:20 | m_x [post update] | PostUpdateNode should not be the target of local flow. |
 | allocators.cpp:4:24:4:26 | m_y [post update] | PostUpdateNode should not be the target of local flow. |
 | assignexpr.cpp:11:4:11:4 | i [post update] | PostUpdateNode should not be the target of local flow. |
-| builtin.c:34:23:34:31 | staticint [inner post update] | PostUpdateNode should not be the target of local flow. |
-| builtin.c:39:37:39:45 | carry_out [inner post update] | PostUpdateNode should not be the target of local flow. |
-| builtin.c:43:41:43:49 | staticint [inner post update] | PostUpdateNode should not be the target of local flow. |
-| builtin.c:51:30:51:38 | staticint [inner post update] | PostUpdateNode should not be the target of local flow. |
-| builtin.c:54:29:54:38 | atomic_int [inner post update] | PostUpdateNode should not be the target of local flow. |
 | condition_decls.cpp:3:5:3:9 | m_ptr [post update] | PostUpdateNode should not be the target of local flow. |
-| condition_decls.cpp:17:11:17:15 | m_ptr [inner post update] | PostUpdateNode should not be the target of local flow. |
-| condition_decls.cpp:20:11:20:15 | m_ptr [inner post update] | PostUpdateNode should not be the target of local flow. |
-| condition_decls.cpp:28:11:28:15 | m_ptr [inner post update] | PostUpdateNode should not be the target of local flow. |
-| condition_decls.cpp:31:11:31:15 | m_ptr [inner post update] | PostUpdateNode should not be the target of local flow. |
-| condition_decls.cpp:34:9:34:13 | m_ptr [inner post update] | PostUpdateNode should not be the target of local flow. |
 | conditional_destructors.cpp:6:13:6:15 | val [post update] | PostUpdateNode should not be the target of local flow. |
 | conditional_destructors.cpp:18:13:18:15 | val [post update] | PostUpdateNode should not be the target of local flow. |
 | cpp11.cpp:7:7:7:8 | el [post update] | PostUpdateNode should not be the target of local flow. |
@@ -70,26 +59,16 @@ postWithInFlow
 | cpp11.cpp:82:11:82:14 | call to Val | PostUpdateNode should not be the target of local flow. |
 | cpp11.cpp:82:45:82:48 | call to Val | PostUpdateNode should not be the target of local flow. |
 | cpp11.cpp:82:51:82:51 | call to Val | PostUpdateNode should not be the target of local flow. |
-| ir.cpp:177:5:177:5 | p [inner post update] | PostUpdateNode should not be the target of local flow. |
 | ir.cpp:177:5:177:8 | access to array [post update] | PostUpdateNode should not be the target of local flow. |
 | ir.cpp:178:5:178:8 | access to array [post update] | PostUpdateNode should not be the target of local flow. |
-| ir.cpp:178:7:178:7 | p [inner post update] | PostUpdateNode should not be the target of local flow. |
-| ir.cpp:183:5:183:5 | a [inner post update] | PostUpdateNode should not be the target of local flow. |
 | ir.cpp:183:5:183:8 | access to array [post update] | PostUpdateNode should not be the target of local flow. |
 | ir.cpp:184:5:184:8 | access to array [post update] | PostUpdateNode should not be the target of local flow. |
-| ir.cpp:184:7:184:7 | a [inner post update] | PostUpdateNode should not be the target of local flow. |
 | ir.cpp:342:5:342:6 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
-| ir.cpp:342:6:342:6 | p [inner post update] | PostUpdateNode should not be the target of local flow. |
 | ir.cpp:428:8:428:8 | x [post update] | PostUpdateNode should not be the target of local flow. |
 | ir.cpp:429:8:429:8 | y [post update] | PostUpdateNode should not be the target of local flow. |
 | ir.cpp:644:15:644:17 | m_a [post update] | PostUpdateNode should not be the target of local flow. |
-| ir.cpp:645:11:645:14 | this [inner post update] | PostUpdateNode should not be the target of local flow. |
 | ir.cpp:645:17:645:19 | m_a [post update] | PostUpdateNode should not be the target of local flow. |
 | ir.cpp:646:9:646:11 | m_a [post update] | PostUpdateNode should not be the target of local flow. |
-| ir.cpp:655:11:655:14 | this [inner post update] | PostUpdateNode should not be the target of local flow. |
-| ir.cpp:747:8:747:8 | base_s [inner post update] | PostUpdateNode should not be the target of local flow. |
-| ir.cpp:756:8:756:8 | middle_s [inner post update] | PostUpdateNode should not be the target of local flow. |
-| ir.cpp:765:8:765:8 | derived_s [inner post update] | PostUpdateNode should not be the target of local flow. |
 | ir.cpp:811:7:811:13 | call to Base | PostUpdateNode should not be the target of local flow. |
 | ir.cpp:812:7:812:26 | call to Base | PostUpdateNode should not be the target of local flow. |
 | ir.cpp:825:7:825:13 | call to Base | PostUpdateNode should not be the target of local flow. |
@@ -97,7 +76,6 @@ postWithInFlow
 | misc.c:130:7:130:7 | i [post update] | PostUpdateNode should not be the target of local flow. |
 | misc.c:131:9:131:9 | i [post update] | PostUpdateNode should not be the target of local flow. |
 | misc.c:220:3:220:5 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
-| misc.c:220:4:220:5 | sp [inner post update] | PostUpdateNode should not be the target of local flow. |
 | static_init_templates.cpp:3:2:3:4 | ref [post update] | PostUpdateNode should not be the target of local flow. |
 | static_init_templates.cpp:21:2:21:4 | val [post update] | PostUpdateNode should not be the target of local flow. |
 | try_catch.cpp:7:8:7:8 | call to exception | PostUpdateNode should not be the target of local flow. |

--- a/javascript/ql/test/library-tests/FlowSummary/DataFlowConsistency.expected
+++ b/javascript/ql/test/library-tests/FlowSummary/DataFlowConsistency.expected
@@ -20,21 +20,6 @@ reverseRead
 | tst.js:267:28:267:31 | map3 | Origin of readStep is missing a PostUpdateNode. |
 argHasPostUpdate
 postWithInFlow
-| file://:0:0:0:0 | [summary] to write: Argument[0] in _.tap | PostUpdateNode should not be the target of local flow. |
-| file://:0:0:0:0 | [summary] to write: Argument[1] in Array method with flow into callback | PostUpdateNode should not be the target of local flow. |
-| file://:0:0:0:0 | [summary] to write: Argument[1] in Array#filter | PostUpdateNode should not be the target of local flow. |
-| file://:0:0:0:0 | [summary] to write: Argument[1] in Array#find / Array#findLast | PostUpdateNode should not be the target of local flow. |
-| file://:0:0:0:0 | [summary] to write: Argument[1] in Array#flatMap | PostUpdateNode should not be the target of local flow. |
-| file://:0:0:0:0 | [summary] to write: Argument[1] in Array#forEach / Map#forEach / Set#forEach | PostUpdateNode should not be the target of local flow. |
-| file://:0:0:0:0 | [summary] to write: Argument[1] in Array#map | PostUpdateNode should not be the target of local flow. |
-| file://:0:0:0:0 | [summary] to write: Argument[1] in Array#reduce / Array#reduceRight | PostUpdateNode should not be the target of local flow. |
-| file://:0:0:0:0 | [summary] to write: Argument[2] in 'array.prototype.find' / 'array-find' | PostUpdateNode should not be the target of local flow. |
-| file://:0:0:0:0 | [summary] to write: Argument[2] in Array.from(arg, callback, [thisArg]) | PostUpdateNode should not be the target of local flow. |
-| file://:0:0:0:0 | [summary] to write: Argument[2] in _.reduce-like | PostUpdateNode should not be the target of local flow. |
-| file://:0:0:0:0 | [summary] to write: Argument[this] in Array#flatMap | PostUpdateNode should not be the target of local flow. |
-| file://:0:0:0:0 | [summary] to write: Argument[this] in Array#forEach / Map#forEach / Set#forEach | PostUpdateNode should not be the target of local flow. |
-| file://:0:0:0:0 | [summary] to write: Argument[this] in Array#map | PostUpdateNode should not be the target of local flow. |
-| file://:0:0:0:0 | [summary] to write: Argument[this] in Array#reduce / Array#reduceRight | PostUpdateNode should not be the target of local flow. |
 viableImplInCallContextTooLarge
 uniqueParameterNodeAtPosition
 uniqueParameterNodePosition

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImplConsistency.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImplConsistency.qll
@@ -254,7 +254,10 @@ module MakeConsistency<
 
   query predicate postWithInFlow(PostUpdateNode n, string msg) {
     not clearsContent(n, _) and
-    simpleLocalFlowStep(_, n, _) and
+    exists(Node pred |
+      simpleLocalFlowStep(pred, n, _) and
+      not pred instanceof PostUpdateNode
+    ) and
     not Input::postWithInFlowExclude(n) and
     msg = "PostUpdateNode should not be the target of local flow."
   }


### PR DESCRIPTION
Stops reporting local flow edges between post-update nodes as a consistency errors. Such flow tends to occur when parameters are used as callback arguments in a flow summary.

E.g fixes the consistency errors observed after adding the new flow summaries in https://github.com/github/codeql/pull/20375.