### PR TITLE
Java: Add most `medium` precision queries to the `code-quality-extended` suite.

### DIFF
--- a/java/ql/integration-tests/java/query-suite/java-code-quality-extended.qls.expected
+++ b/java/ql/integration-tests/java/query-suite/java-code-quality-extended.qls.expected
@@ -1,61 +1,122 @@
 ql/java/ql/src/Advisory/Declarations/MissingOverrideAnnotation.ql
+ql/java/ql/src/Advisory/Declarations/NonFinalImmutableField.ql
+ql/java/ql/src/Advisory/Declarations/NonPrivateField.ql
 ql/java/ql/src/Advisory/Documentation/ImpossibleJavadocThrows.ql
+ql/java/ql/src/Advisory/Documentation/MissingJavadocMethods.ql
+ql/java/ql/src/Advisory/Documentation/MissingJavadocParameters.ql
+ql/java/ql/src/Advisory/Documentation/MissingJavadocReturnValues.ql
+ql/java/ql/src/Advisory/Documentation/MissingJavadocThrows.ql
+ql/java/ql/src/Advisory/Documentation/MissingJavadocTypes.ql
 ql/java/ql/src/Advisory/Documentation/SpuriousJavadocParam.ql
+ql/java/ql/src/Advisory/Java Objects/AvoidCloneMethodAccess.ql
+ql/java/ql/src/Advisory/Java Objects/AvoidCloneOverride.ql
+ql/java/ql/src/Advisory/Java Objects/AvoidCloneableInterface.ql
+ql/java/ql/src/Advisory/Java Objects/AvoidFinalizeOverride.ql
+ql/java/ql/src/Advisory/Naming/NamingConventionsConstants.ql
+ql/java/ql/src/Advisory/Naming/NamingConventionsMethods.ql
+ql/java/ql/src/Advisory/Naming/NamingConventionsPackages.ql
+ql/java/ql/src/Advisory/Naming/NamingConventionsRefTypes.ql
+ql/java/ql/src/Advisory/Naming/NamingConventionsVariables.ql
+ql/java/ql/src/Advisory/Statements/MissingDefaultInSwitch.ql
+ql/java/ql/src/Advisory/Statements/OneStatementPerLine.ql
+ql/java/ql/src/Advisory/Statements/TerminateIfElseIfWithElse.ql
+ql/java/ql/src/Advisory/Types/GenericsConstructor.ql
+ql/java/ql/src/Advisory/Types/GenericsReturnType.ql
+ql/java/ql/src/Advisory/Types/GenericsVariable.ql
 ql/java/ql/src/Compatibility/JDK9/JdkInternalAccess.ql
 ql/java/ql/src/Compatibility/JDK9/UnderscoreIdentifier.ql
+ql/java/ql/src/DeadCode/DeadClass.ql
+ql/java/ql/src/DeadCode/DeadEnumConstant.ql
+ql/java/ql/src/DeadCode/DeadField.ql
+ql/java/ql/src/DeadCode/DeadMethod.ql
 ql/java/ql/src/DeadCode/UselessParameter.ql
 ql/java/ql/src/Language Abuse/EmptyMethod.ql
 ql/java/ql/src/Language Abuse/IterableIterator.ql
 ql/java/ql/src/Language Abuse/LabelInSwitch.ql
+ql/java/ql/src/Language Abuse/OverridePackagePrivate.ql
+ql/java/ql/src/Language Abuse/TypeVarExtendsFinalType.ql
 ql/java/ql/src/Language Abuse/TypeVariableHidesType.ql
 ql/java/ql/src/Language Abuse/UselessNullCheck.ql
 ql/java/ql/src/Language Abuse/UselessTypeTest.ql
 ql/java/ql/src/Language Abuse/WrappedIterator.ql
+ql/java/ql/src/Likely Bugs/Arithmetic/BadAbsOfRandom.ql
 ql/java/ql/src/Likely Bugs/Arithmetic/ConstantExpAppearsNonConstant.ql
 ql/java/ql/src/Likely Bugs/Arithmetic/IntMultToLong.ql
 ql/java/ql/src/Likely Bugs/Arithmetic/LShiftLargerThanTypeWidth.ql
+ql/java/ql/src/Likely Bugs/Arithmetic/MultiplyRemainder.ql
+ql/java/ql/src/Likely Bugs/Arithmetic/RandomUsedOnce.ql
 ql/java/ql/src/Likely Bugs/Arithmetic/WhitespaceContradictsPrecedence.ql
+ql/java/ql/src/Likely Bugs/Cloning/MissingCallToSuperClone.ql
+ql/java/ql/src/Likely Bugs/Cloning/MissingMethodClone.ql
 ql/java/ql/src/Likely Bugs/Collections/ArrayIndexOutOfBounds.ql
 ql/java/ql/src/Likely Bugs/Collections/ContainsTypeMismatch.ql
+ql/java/ql/src/Likely Bugs/Collections/IteratorRemoveMayFail.ql
 ql/java/ql/src/Likely Bugs/Collections/ReadOnlyContainer.ql
 ql/java/ql/src/Likely Bugs/Collections/RemoveTypeMismatch.ql
 ql/java/ql/src/Likely Bugs/Collections/WriteOnlyContainer.ql
 ql/java/ql/src/Likely Bugs/Comparison/CompareIdenticalValues.ql
+ql/java/ql/src/Likely Bugs/Comparison/CovariantCompareTo.ql
+ql/java/ql/src/Likely Bugs/Comparison/CovariantEquals.ql
 ql/java/ql/src/Likely Bugs/Comparison/EqualsArray.ql
 ql/java/ql/src/Likely Bugs/Comparison/HashedButNoHash.ql
 ql/java/ql/src/Likely Bugs/Comparison/IncomparableEquals.ql
+ql/java/ql/src/Likely Bugs/Comparison/InconsistentCompareTo.ql
 ql/java/ql/src/Likely Bugs/Comparison/InconsistentEqualsHashCode.ql
 ql/java/ql/src/Likely Bugs/Comparison/MissingInstanceofInEquals.ql
 ql/java/ql/src/Likely Bugs/Comparison/RefEqBoxed.ql
+ql/java/ql/src/Likely Bugs/Comparison/StringComparison.ql
 ql/java/ql/src/Likely Bugs/Comparison/UselessComparisonTest.ql
 ql/java/ql/src/Likely Bugs/Comparison/WrongNanComparison.ql
+ql/java/ql/src/Likely Bugs/Concurrency/CallsToConditionWait.ql
 ql/java/ql/src/Likely Bugs/Concurrency/CallsToRunnableRun.ql
+ql/java/ql/src/Likely Bugs/Concurrency/DateFormatThreadUnsafe.ql
 ql/java/ql/src/Likely Bugs/Concurrency/DoubleCheckedLocking.ql
 ql/java/ql/src/Likely Bugs/Concurrency/DoubleCheckedLockingWithInitRace.ql
+ql/java/ql/src/Likely Bugs/Concurrency/FutileSynchOnField.ql
 ql/java/ql/src/Likely Bugs/Concurrency/NonSynchronizedOverride.ql
+ql/java/ql/src/Likely Bugs/Concurrency/NotifyNotNotifyAll.ql
 ql/java/ql/src/Likely Bugs/Concurrency/ScheduledThreadPoolExecutorZeroThread.ql
+ql/java/ql/src/Likely Bugs/Concurrency/SleepWithLock.ql
+ql/java/ql/src/Likely Bugs/Concurrency/StartInConstructor.ql
 ql/java/ql/src/Likely Bugs/Concurrency/SynchOnBoxedType.ql
 ql/java/ql/src/Likely Bugs/Concurrency/SynchSetUnsynchGet.ql
+ql/java/ql/src/Likely Bugs/Concurrency/SynchWriteObject.ql
+ql/java/ql/src/Likely Bugs/Finalization/NullifiedSuperFinalize.ql
+ql/java/ql/src/Likely Bugs/Frameworks/JUnit/BadSuiteMethod.ql
 ql/java/ql/src/Likely Bugs/Frameworks/JUnit/JUnit5MissingNestedAnnotation.ql
+ql/java/ql/src/Likely Bugs/Frameworks/Swing/BadlyOverriddenAdapter.ql
 ql/java/ql/src/Likely Bugs/Inheritance/NoNonFinalInConstructor.ql
 ql/java/ql/src/Likely Bugs/Likely Typos/ContainerSizeCmpZero.ql
 ql/java/ql/src/Likely Bugs/Likely Typos/ContradictoryTypeChecks.ql
+ql/java/ql/src/Likely Bugs/Likely Typos/DangerousNonCircuitLogic.ql
+ql/java/ql/src/Likely Bugs/Likely Typos/EqualsTypo.ql
+ql/java/ql/src/Likely Bugs/Likely Typos/HashCodeTypo.ql
 ql/java/ql/src/Likely Bugs/Likely Typos/MissingFormatArg.ql
 ql/java/ql/src/Likely Bugs/Likely Typos/MissingSpaceTypo.ql
 ql/java/ql/src/Likely Bugs/Likely Typos/SelfAssignment.ql
 ql/java/ql/src/Likely Bugs/Likely Typos/StringBufferCharInit.ql
 ql/java/ql/src/Likely Bugs/Likely Typos/SuspiciousDateFormat.ql
+ql/java/ql/src/Likely Bugs/Likely Typos/ToStringTypo.ql
 ql/java/ql/src/Likely Bugs/Likely Typos/UnusedFormatArg.ql
 ql/java/ql/src/Likely Bugs/Nullness/NullAlways.ql
 ql/java/ql/src/Likely Bugs/Nullness/NullExprDeref.ql
 ql/java/ql/src/Likely Bugs/Nullness/NullMaybe.ql
+ql/java/ql/src/Likely Bugs/Reflection/AnnotationPresentCheck.ql
 ql/java/ql/src/Likely Bugs/Resource Leaks/CloseReader.ql
 ql/java/ql/src/Likely Bugs/Resource Leaks/CloseSql.ql
 ql/java/ql/src/Likely Bugs/Resource Leaks/CloseWriter.ql
+ql/java/ql/src/Likely Bugs/Serialization/IncorrectSerialVersionUID.ql
+ql/java/ql/src/Likely Bugs/Serialization/IncorrectSerializableMethods.ql
+ql/java/ql/src/Likely Bugs/Serialization/MissingVoidConstructorOnExternalizable.ql
+ql/java/ql/src/Likely Bugs/Serialization/MissingVoidConstructorsOnSerializable.ql
+ql/java/ql/src/Likely Bugs/Serialization/NonSerializableInnerClass.ql
+ql/java/ql/src/Likely Bugs/Serialization/ReadResolveObject.ql
 ql/java/ql/src/Likely Bugs/Statements/ContinueInFalseLoop.ql
+ql/java/ql/src/Likely Bugs/Statements/MissingEnumInSwitch.ql
 ql/java/ql/src/Likely Bugs/Statements/PartiallyMaskedCatch.ql
 ql/java/ql/src/Likely Bugs/Statements/UseBraces.ql
 ql/java/ql/src/Likely Bugs/Termination/ConstantLoopCondition.ql
+ql/java/ql/src/Likely Bugs/Termination/SpinOnField.ql
 ql/java/ql/src/Performance/InefficientEmptyStringTest.ql
 ql/java/ql/src/Performance/InefficientKeySetIterator.ql
 ql/java/ql/src/Performance/InefficientOutputStream.ql
@@ -64,6 +125,7 @@ ql/java/ql/src/Performance/InnerClassCouldBeStatic.ql
 ql/java/ql/src/Performance/NewStringString.ql
 ql/java/ql/src/Performance/StringReplaceAllWithNonRegex.ql
 ql/java/ql/src/Violations of Best Practice/Boxed Types/BoxedVariable.ql
+ql/java/ql/src/Violations of Best Practice/Dead Code/CreatesEmptyZip.ql
 ql/java/ql/src/Violations of Best Practice/Dead Code/DeadRefTypes.ql
 ql/java/ql/src/Violations of Best Practice/Dead Code/InterfaceCannotBeImplemented.ql
 ql/java/ql/src/Violations of Best Practice/Dead Code/UnreadLocal.ql
@@ -73,10 +135,12 @@ ql/java/ql/src/Violations of Best Practice/Exception Handling/IgnoreExceptionalR
 ql/java/ql/src/Violations of Best Practice/Exception Handling/NumberFormatException.ql
 ql/java/ql/src/Violations of Best Practice/Implementation Hiding/AbstractToConcreteCollection.ql
 ql/java/ql/src/Violations of Best Practice/Implementation Hiding/ExposeRepresentation.ql
+ql/java/ql/src/Violations of Best Practice/Implementation Hiding/GetClassGetResource.ql
 ql/java/ql/src/Violations of Best Practice/Implementation Hiding/VisibleForTestingAbuse.ql
 ql/java/ql/src/Violations of Best Practice/Naming Conventions/AmbiguousOuterSuper.ql
 ql/java/ql/src/Violations of Best Practice/Naming Conventions/ConfusingMethodNames.ql
 ql/java/ql/src/Violations of Best Practice/Naming Conventions/ConfusingOverloading.ql
+ql/java/ql/src/Violations of Best Practice/Naming Conventions/FieldMasksSuperField.ql
 ql/java/ql/src/Violations of Best Practice/Naming Conventions/LocalShadowsFieldConfusing.ql
 ql/java/ql/src/Violations of Best Practice/Naming Conventions/SameNameAsSuper.ql
 ql/java/ql/src/Violations of Best Practice/Records/IgnoredSerializationMembersOfRecordClass.ql
@@ -87,4 +151,5 @@ ql/java/ql/src/Violations of Best Practice/Undesirable Calls/CallsToStringToStri
 ql/java/ql/src/Violations of Best Practice/Undesirable Calls/CallsToSystemExit.ql
 ql/java/ql/src/Violations of Best Practice/Undesirable Calls/DefaultToString.ql
 ql/java/ql/src/Violations of Best Practice/Undesirable Calls/DoNotCallFinalize.ql
+ql/java/ql/src/Violations of Best Practice/Undesirable Calls/NextFromIterator.ql
 ql/java/ql/src/Violations of Best Practice/Undesirable Calls/PrintLnArray.ql

--- a/java/ql/integration-tests/java/query-suite/java-code-quality-extended.qls.expected
+++ b/java/ql/integration-tests/java/query-suite/java-code-quality-extended.qls.expected
@@ -2,11 +2,6 @@ ql/java/ql/src/Advisory/Declarations/MissingOverrideAnnotation.ql
 ql/java/ql/src/Advisory/Declarations/NonFinalImmutableField.ql
 ql/java/ql/src/Advisory/Declarations/NonPrivateField.ql
 ql/java/ql/src/Advisory/Documentation/ImpossibleJavadocThrows.ql
-ql/java/ql/src/Advisory/Documentation/MissingJavadocMethods.ql
-ql/java/ql/src/Advisory/Documentation/MissingJavadocParameters.ql
-ql/java/ql/src/Advisory/Documentation/MissingJavadocReturnValues.ql
-ql/java/ql/src/Advisory/Documentation/MissingJavadocThrows.ql
-ql/java/ql/src/Advisory/Documentation/MissingJavadocTypes.ql
 ql/java/ql/src/Advisory/Documentation/SpuriousJavadocParam.ql
 ql/java/ql/src/Advisory/Java Objects/AvoidCloneMethodAccess.ql
 ql/java/ql/src/Advisory/Java Objects/AvoidCloneOverride.ql

--- a/java/ql/integration-tests/java/query-suite/not_included_in_qls.expected
+++ b/java/ql/integration-tests/java/query-suite/not_included_in_qls.expected
@@ -1,25 +1,3 @@
-ql/java/ql/src/Advisory/Declarations/NonFinalImmutableField.ql
-ql/java/ql/src/Advisory/Declarations/NonPrivateField.ql
-ql/java/ql/src/Advisory/Documentation/MissingJavadocMethods.ql
-ql/java/ql/src/Advisory/Documentation/MissingJavadocParameters.ql
-ql/java/ql/src/Advisory/Documentation/MissingJavadocReturnValues.ql
-ql/java/ql/src/Advisory/Documentation/MissingJavadocThrows.ql
-ql/java/ql/src/Advisory/Documentation/MissingJavadocTypes.ql
-ql/java/ql/src/Advisory/Java Objects/AvoidCloneMethodAccess.ql
-ql/java/ql/src/Advisory/Java Objects/AvoidCloneOverride.ql
-ql/java/ql/src/Advisory/Java Objects/AvoidCloneableInterface.ql
-ql/java/ql/src/Advisory/Java Objects/AvoidFinalizeOverride.ql
-ql/java/ql/src/Advisory/Naming/NamingConventionsConstants.ql
-ql/java/ql/src/Advisory/Naming/NamingConventionsMethods.ql
-ql/java/ql/src/Advisory/Naming/NamingConventionsPackages.ql
-ql/java/ql/src/Advisory/Naming/NamingConventionsRefTypes.ql
-ql/java/ql/src/Advisory/Naming/NamingConventionsVariables.ql
-ql/java/ql/src/Advisory/Statements/MissingDefaultInSwitch.ql
-ql/java/ql/src/Advisory/Statements/OneStatementPerLine.ql
-ql/java/ql/src/Advisory/Statements/TerminateIfElseIfWithElse.ql
-ql/java/ql/src/Advisory/Types/GenericsConstructor.ql
-ql/java/ql/src/Advisory/Types/GenericsReturnType.ql
-ql/java/ql/src/Advisory/Types/GenericsVariable.ql
 ql/java/ql/src/AlertSuppression.ql
 ql/java/ql/src/AlertSuppressionAnnotations.ql
 ql/java/ql/src/Architecture/Dependencies/MutualDependency.ql
@@ -31,10 +9,6 @@ ql/java/ql/src/Architecture/Refactoring Opportunities/HubClasses.ql
 ql/java/ql/src/Architecture/Refactoring Opportunities/InappropriateIntimacy.ql
 ql/java/ql/src/Complexity/BlockWithTooManyStatements.ql
 ql/java/ql/src/Complexity/ComplexCondition.ql
-ql/java/ql/src/DeadCode/DeadClass.ql
-ql/java/ql/src/DeadCode/DeadEnumConstant.ql
-ql/java/ql/src/DeadCode/DeadField.ql
-ql/java/ql/src/DeadCode/DeadMethod.ql
 ql/java/ql/src/DeadCode/FLinesOfDeadCode.ql
 ql/java/ql/src/Frameworks/JavaEE/EJB/EjbContainerInterference.ql
 ql/java/ql/src/Frameworks/JavaEE/EJB/EjbFileIO.ql

--- a/java/ql/integration-tests/java/query-suite/not_included_in_qls.expected
+++ b/java/ql/integration-tests/java/query-suite/not_included_in_qls.expected
@@ -1,3 +1,8 @@
+ql/java/ql/src/Advisory/Documentation/MissingJavadocMethods.ql
+ql/java/ql/src/Advisory/Documentation/MissingJavadocParameters.ql
+ql/java/ql/src/Advisory/Documentation/MissingJavadocReturnValues.ql
+ql/java/ql/src/Advisory/Documentation/MissingJavadocThrows.ql
+ql/java/ql/src/Advisory/Documentation/MissingJavadocTypes.ql
 ql/java/ql/src/AlertSuppression.ql
 ql/java/ql/src/AlertSuppressionAnnotations.ql
 ql/java/ql/src/Architecture/Dependencies/MutualDependency.ql

--- a/java/ql/src/Advisory/Declarations/NonFinalImmutableField.ql
+++ b/java/ql/src/Advisory/Declarations/NonFinalImmutableField.ql
@@ -7,7 +7,10 @@
  * @problem.severity recommendation
  * @precision medium
  * @id java/non-final-immutable-field
- * @tags reliability
+ * @tags quality
+ *       reliability
+ *       correctness
+ *       readability
  */
 
 import java

--- a/java/ql/src/Advisory/Declarations/NonPrivateField.ql
+++ b/java/ql/src/Advisory/Declarations/NonPrivateField.ql
@@ -6,7 +6,10 @@
  * @problem.severity recommendation
  * @precision medium
  * @id java/non-private-field
- * @tags maintainability
+ * @tags quality
+ *       maintainability
+ *       readability
+ *       complexity
  */
 
 import java

--- a/java/ql/src/Advisory/Documentation/MissingJavadocMethods.ql
+++ b/java/ql/src/Advisory/Documentation/MissingJavadocMethods.ql
@@ -6,8 +6,7 @@
  * @problem.severity recommendation
  * @precision medium
  * @id java/undocumented-function
- * @tags quality
- *       maintainability
+ * @tags maintainability
  *       readability
  */
 

--- a/java/ql/src/Advisory/Documentation/MissingJavadocMethods.ql
+++ b/java/ql/src/Advisory/Documentation/MissingJavadocMethods.ql
@@ -6,7 +6,9 @@
  * @problem.severity recommendation
  * @precision medium
  * @id java/undocumented-function
- * @tags maintainability
+ * @tags quality
+ *       maintainability
+ *       readability
  */
 
 import java

--- a/java/ql/src/Advisory/Documentation/MissingJavadocParameters.ql
+++ b/java/ql/src/Advisory/Documentation/MissingJavadocParameters.ql
@@ -6,8 +6,7 @@
  * @problem.severity recommendation
  * @precision medium
  * @id java/undocumented-parameter
- * @tags quality
- *       maintainability
+ * @tags maintainability
  *       readability
  */
 

--- a/java/ql/src/Advisory/Documentation/MissingJavadocParameters.ql
+++ b/java/ql/src/Advisory/Documentation/MissingJavadocParameters.ql
@@ -6,7 +6,9 @@
  * @problem.severity recommendation
  * @precision medium
  * @id java/undocumented-parameter
- * @tags maintainability
+ * @tags quality
+ *       maintainability
+ *       readability
  */
 
 import java

--- a/java/ql/src/Advisory/Documentation/MissingJavadocReturnValues.ql
+++ b/java/ql/src/Advisory/Documentation/MissingJavadocReturnValues.ql
@@ -6,8 +6,7 @@
  * @problem.severity recommendation
  * @precision medium
  * @id java/undocumented-return-value
- * @tags quality
- *       maintainability
+ * @tags maintainability
  *       readability
  */
 

--- a/java/ql/src/Advisory/Documentation/MissingJavadocReturnValues.ql
+++ b/java/ql/src/Advisory/Documentation/MissingJavadocReturnValues.ql
@@ -6,7 +6,9 @@
  * @problem.severity recommendation
  * @precision medium
  * @id java/undocumented-return-value
- * @tags maintainability
+ * @tags quality
+ *       maintainability
+ *       readability
  */
 
 import java

--- a/java/ql/src/Advisory/Documentation/MissingJavadocThrows.ql
+++ b/java/ql/src/Advisory/Documentation/MissingJavadocThrows.ql
@@ -6,8 +6,7 @@
  * @problem.severity recommendation
  * @precision medium
  * @id java/undocumented-exception
- * @tags quality
- *       maintainability
+ * @tags maintainability
  *       readability
  *       error-handling
  */

--- a/java/ql/src/Advisory/Documentation/MissingJavadocThrows.ql
+++ b/java/ql/src/Advisory/Documentation/MissingJavadocThrows.ql
@@ -6,7 +6,10 @@
  * @problem.severity recommendation
  * @precision medium
  * @id java/undocumented-exception
- * @tags maintainability
+ * @tags quality
+ *       maintainability
+ *       readability
+ *       error-handling
  */
 
 import java

--- a/java/ql/src/Advisory/Documentation/MissingJavadocTypes.ql
+++ b/java/ql/src/Advisory/Documentation/MissingJavadocTypes.ql
@@ -6,7 +6,9 @@
  * @problem.severity recommendation
  * @precision medium
  * @id java/undocumented-type
- * @tags maintainability
+ * @tags quality
+ *       maintainability
+ *       readability
  */
 
 import java

--- a/java/ql/src/Advisory/Documentation/MissingJavadocTypes.ql
+++ b/java/ql/src/Advisory/Documentation/MissingJavadocTypes.ql
@@ -6,8 +6,7 @@
  * @problem.severity recommendation
  * @precision medium
  * @id java/undocumented-type
- * @tags quality
- *       maintainability
+ * @tags maintainability
  *       readability
  */
 

--- a/java/ql/src/Advisory/Java Objects/AvoidCloneMethodAccess.ql
+++ b/java/ql/src/Advisory/Java Objects/AvoidCloneMethodAccess.ql
@@ -6,7 +6,9 @@
  * @problem.severity recommendation
  * @precision medium
  * @id java/use-of-clone-method
- * @tags reliability
+ * @tags quality
+ *       reliability
+ *       correctness
  */
 
 import java

--- a/java/ql/src/Advisory/Java Objects/AvoidCloneOverride.ql
+++ b/java/ql/src/Advisory/Java Objects/AvoidCloneOverride.ql
@@ -6,7 +6,9 @@
  * @problem.severity recommendation
  * @precision medium
  * @id java/override-of-clone-method
- * @tags reliability
+ * @tags quality
+ *       reliability
+ *       correctness
  */
 
 import java

--- a/java/ql/src/Advisory/Java Objects/AvoidCloneableInterface.ql
+++ b/java/ql/src/Advisory/Java Objects/AvoidCloneableInterface.ql
@@ -6,7 +6,9 @@
  * @problem.severity recommendation
  * @precision medium
  * @id java/use-of-cloneable-interface
- * @tags reliability
+ * @tags quality
+ *       reliability
+ *       correctness
  */
 
 import java

--- a/java/ql/src/Advisory/Java Objects/AvoidFinalizeOverride.ql
+++ b/java/ql/src/Advisory/Java Objects/AvoidFinalizeOverride.ql
@@ -5,7 +5,9 @@
  * @problem.severity recommendation
  * @precision medium
  * @id java/override-of-finalize-method
- * @tags reliability
+ * @tags quality
+ *       reliability
+ *       correctness
  */
 
 import java

--- a/java/ql/src/Advisory/Naming/NamingConventionsConstants.ql
+++ b/java/ql/src/Advisory/Naming/NamingConventionsConstants.ql
@@ -5,7 +5,9 @@
  * @problem.severity recommendation
  * @precision medium
  * @id java/misnamed-constant
- * @tags maintainability
+ * @tags quality
+ *       maintainability
+ *       readability
  */
 
 import java

--- a/java/ql/src/Advisory/Naming/NamingConventionsMethods.ql
+++ b/java/ql/src/Advisory/Naming/NamingConventionsMethods.ql
@@ -5,7 +5,9 @@
  * @problem.severity recommendation
  * @precision medium
  * @id java/misnamed-function
- * @tags maintainability
+ * @tags quality
+ *       maintainability
+ *       readability
  */
 
 import java

--- a/java/ql/src/Advisory/Naming/NamingConventionsPackages.ql
+++ b/java/ql/src/Advisory/Naming/NamingConventionsPackages.ql
@@ -5,7 +5,9 @@
  * @problem.severity recommendation
  * @precision medium
  * @id java/misnamed-package
- * @tags maintainability
+ * @tags quality
+ *       maintainability
+ *       readability
  */
 
 import java

--- a/java/ql/src/Advisory/Naming/NamingConventionsRefTypes.ql
+++ b/java/ql/src/Advisory/Naming/NamingConventionsRefTypes.ql
@@ -5,7 +5,9 @@
  * @problem.severity recommendation
  * @precision medium
  * @id java/misnamed-type
- * @tags maintainability
+ * @tags quality
+ *       maintainability
+ *       readability
  */
 
 import java

--- a/java/ql/src/Advisory/Naming/NamingConventionsVariables.ql
+++ b/java/ql/src/Advisory/Naming/NamingConventionsVariables.ql
@@ -5,7 +5,9 @@
  * @problem.severity recommendation
  * @precision medium
  * @id java/misnamed-variable
- * @tags maintainability
+ * @tags quality
+ *       maintainability
+ *       readability
  */
 
 import java

--- a/java/ql/src/Advisory/Statements/MissingDefaultInSwitch.ql
+++ b/java/ql/src/Advisory/Statements/MissingDefaultInSwitch.ql
@@ -6,7 +6,9 @@
  * @problem.severity recommendation
  * @precision medium
  * @id java/missing-default-in-switch
- * @tags reliability
+ * @tags quality
+ *       reliability
+ *       correctness
  *       external/cwe/cwe-478
  */
 

--- a/java/ql/src/Advisory/Statements/OneStatementPerLine.ql
+++ b/java/ql/src/Advisory/Statements/OneStatementPerLine.ql
@@ -5,7 +5,9 @@
  * @problem.severity recommendation
  * @precision medium
  * @id java/multiple-statements-on-same-line
- * @tags maintainability
+ * @tags quality
+ *       maintainability
+ *       readability
  */
 
 import java

--- a/java/ql/src/Advisory/Statements/TerminateIfElseIfWithElse.ql
+++ b/java/ql/src/Advisory/Statements/TerminateIfElseIfWithElse.ql
@@ -6,7 +6,9 @@
  * @problem.severity recommendation
  * @precision medium
  * @id java/non-terminated-if-else-if-chain
- * @tags reliability
+ * @tags quality
+ *       reliability
+ *       correctness
  */
 
 import java

--- a/java/ql/src/Advisory/Types/GenericsConstructor.ql
+++ b/java/ql/src/Advisory/Types/GenericsConstructor.ql
@@ -6,7 +6,10 @@
  * @problem.severity recommendation
  * @precision medium
  * @id java/raw-constructor-invocation
- * @tags maintainability
+ * @tags quality
+ *       maintainability
+ *       readability
+ *       correctness
  */
 
 import java

--- a/java/ql/src/Advisory/Types/GenericsReturnType.ql
+++ b/java/ql/src/Advisory/Types/GenericsReturnType.ql
@@ -6,7 +6,10 @@
  * @problem.severity recommendation
  * @precision medium
  * @id java/raw-return-type
- * @tags maintainability
+ * @tags quality
+ *       maintainability
+ *       readability
+ *       correctness
  */
 
 import java

--- a/java/ql/src/Advisory/Types/GenericsVariable.ql
+++ b/java/ql/src/Advisory/Types/GenericsVariable.ql
@@ -6,7 +6,10 @@
  * @problem.severity recommendation
  * @precision medium
  * @id java/raw-variable
- * @tags maintainability
+ * @tags quality
+ *       maintainability
+ *       readability
+ *       correctness
  */
 
 import java

--- a/java/ql/src/DeadCode/DeadClass.ql
+++ b/java/ql/src/DeadCode/DeadClass.ql
@@ -5,7 +5,8 @@
  * @problem.severity recommendation
  * @precision medium
  * @id java/dead-class
- * @tags maintainability
+ * @tags quality
+ *       maintainability
  *       useless-code
  *       external/cwe/cwe-561
  */

--- a/java/ql/src/DeadCode/DeadEnumConstant.ql
+++ b/java/ql/src/DeadCode/DeadEnumConstant.ql
@@ -5,7 +5,8 @@
  * @problem.severity recommendation
  * @precision medium
  * @id java/dead-enum-constant
- * @tags maintainability
+ * @tags quality
+ *       maintainability
  *       useless-code
  *       external/cwe/cwe-561
  */

--- a/java/ql/src/DeadCode/DeadField.ql
+++ b/java/ql/src/DeadCode/DeadField.ql
@@ -5,7 +5,8 @@
  * @problem.severity recommendation
  * @precision medium
  * @id java/dead-field
- * @tags maintainability
+ * @tags quality
+ *       maintainability
  *       useless-code
  *       external/cwe/cwe-561
  */

--- a/java/ql/src/DeadCode/DeadMethod.ql
+++ b/java/ql/src/DeadCode/DeadMethod.ql
@@ -5,7 +5,8 @@
  * @problem.severity recommendation
  * @precision medium
  * @id java/dead-function
- * @tags maintainability
+ * @tags quality
+ *       maintainability
  *       useless-code
  *       external/cwe/cwe-561
  */

--- a/java/ql/src/Language Abuse/OverridePackagePrivate.ql
+++ b/java/ql/src/Language Abuse/OverridePackagePrivate.ql
@@ -6,8 +6,10 @@
  * @problem.severity warning
  * @precision medium
  * @id java/non-overriding-package-private
- * @tags maintainability
+ * @tags quality
+ *       maintainability
  *       readability
+ *       correctness
  */
 
 import java

--- a/java/ql/src/Language Abuse/TypeVarExtendsFinalType.ql
+++ b/java/ql/src/Language Abuse/TypeVarExtendsFinalType.ql
@@ -7,9 +7,9 @@
  * @problem.severity warning
  * @precision medium
  * @id java/type-bound-extends-final
- * @tags maintainability
+ * @tags quality
+ *       maintainability
  *       readability
- *       types
  */
 
 import java

--- a/java/ql/src/Likely Bugs/Arithmetic/BadAbsOfRandom.ql
+++ b/java/ql/src/Likely Bugs/Arithmetic/BadAbsOfRandom.ql
@@ -6,8 +6,9 @@
  * @problem.severity warning
  * @precision medium
  * @id java/abs-of-random
- * @tags reliability
- *       maintainability
+ * @tags quality
+ *       reliability
+ *       correctness
  */
 
 import java

--- a/java/ql/src/Likely Bugs/Arithmetic/MultiplyRemainder.ql
+++ b/java/ql/src/Likely Bugs/Arithmetic/MultiplyRemainder.ql
@@ -6,7 +6,9 @@
  * @problem.severity warning
  * @precision medium
  * @id java/multiplication-of-remainder
- * @tags maintainability
+ * @tags quality
+ *       maintainability
+ *       readability
  *       correctness
  */
 

--- a/java/ql/src/Likely Bugs/Arithmetic/RandomUsedOnce.ql
+++ b/java/ql/src/Likely Bugs/Arithmetic/RandomUsedOnce.ql
@@ -6,8 +6,9 @@
  * @problem.severity warning
  * @precision medium
  * @id java/random-used-once
- * @tags reliability
- *       maintainability
+ * @tags quality
+ *       reliability
+ *       correctness
  *       external/cwe/cwe-335
  */
 

--- a/java/ql/src/Likely Bugs/Cloning/MissingCallToSuperClone.ql
+++ b/java/ql/src/Likely Bugs/Cloning/MissingCallToSuperClone.ql
@@ -7,8 +7,9 @@
  * @problem.severity error
  * @precision medium
  * @id java/missing-call-to-super-clone
- * @tags reliability
- *       maintainability
+ * @tags quality
+ *       reliability
+ *       correctness
  *       external/cwe/cwe-580
  */
 

--- a/java/ql/src/Likely Bugs/Cloning/MissingMethodClone.ql
+++ b/java/ql/src/Likely Bugs/Cloning/MissingMethodClone.ql
@@ -6,8 +6,9 @@
  * @problem.severity error
  * @precision medium
  * @id java/missing-clone-method
- * @tags reliability
- *       maintainability
+ * @tags quality
+ *       reliability
+ *       correctness
  */
 
 import java

--- a/java/ql/src/Likely Bugs/Collections/IteratorRemoveMayFail.ql
+++ b/java/ql/src/Likely Bugs/Collections/IteratorRemoveMayFail.ql
@@ -6,9 +6,9 @@
  * @problem.severity warning
  * @precision medium
  * @id java/iterator-remove-failure
- * @tags reliability
+ * @tags quality
+ *       reliability
  *       correctness
- *       logic
  */
 
 import java

--- a/java/ql/src/Likely Bugs/Comparison/CovariantCompareTo.ql
+++ b/java/ql/src/Likely Bugs/Comparison/CovariantCompareTo.ql
@@ -6,7 +6,8 @@
  * @problem.severity error
  * @precision medium
  * @id java/wrong-compareto-signature
- * @tags reliability
+ * @tags quality
+ *       reliability
  *       correctness
  */
 

--- a/java/ql/src/Likely Bugs/Comparison/CovariantEquals.ql
+++ b/java/ql/src/Likely Bugs/Comparison/CovariantEquals.ql
@@ -6,7 +6,8 @@
  * @problem.severity error
  * @precision medium
  * @id java/wrong-equals-signature
- * @tags reliability
+ * @tags quality
+ *       reliability
  *       correctness
  */
 

--- a/java/ql/src/Likely Bugs/Comparison/InconsistentCompareTo.ql
+++ b/java/ql/src/Likely Bugs/Comparison/InconsistentCompareTo.ql
@@ -6,7 +6,8 @@
  * @problem.severity warning
  * @precision medium
  * @id java/inconsistent-compareto-and-equals
- * @tags reliability
+ * @tags quality
+ *       reliability
  *       correctness
  */
 

--- a/java/ql/src/Likely Bugs/Comparison/StringComparison.ql
+++ b/java/ql/src/Likely Bugs/Comparison/StringComparison.ql
@@ -6,7 +6,9 @@
  * @problem.severity warning
  * @precision medium
  * @id java/reference-equality-on-strings
- * @tags reliability
+ * @tags quality
+ *       reliability
+ *       correctness
  *       external/cwe/cwe-597
  */
 

--- a/java/ql/src/Likely Bugs/Concurrency/CallsToConditionWait.ql
+++ b/java/ql/src/Likely Bugs/Concurrency/CallsToConditionWait.ql
@@ -6,7 +6,8 @@
  * @problem.severity error
  * @precision medium
  * @id java/wait-on-condition-interface
- * @tags reliability
+ * @tags quality
+ *       reliability
  *       correctness
  *       concurrency
  *       external/cwe/cwe-662

--- a/java/ql/src/Likely Bugs/Concurrency/DateFormatThreadUnsafe.ql
+++ b/java/ql/src/Likely Bugs/Concurrency/DateFormatThreadUnsafe.ql
@@ -6,7 +6,8 @@
  * @problem.severity warning
  * @precision medium
  * @id java/thread-unsafe-dateformat
- * @tags reliability
+ * @tags quality
+ *       reliability
  *       correctness
  *       concurrency
  */

--- a/java/ql/src/Likely Bugs/Concurrency/FutileSynchOnField.ql
+++ b/java/ql/src/Likely Bugs/Concurrency/FutileSynchOnField.ql
@@ -6,7 +6,8 @@
  * @problem.severity error
  * @precision medium
  * @id java/unsafe-sync-on-field
- * @tags reliability
+ * @tags quality
+ *       reliability
  *       correctness
  *       concurrency
  *       language-features

--- a/java/ql/src/Likely Bugs/Concurrency/NotifyNotNotifyAll.ql
+++ b/java/ql/src/Likely Bugs/Concurrency/NotifyNotNotifyAll.ql
@@ -6,7 +6,8 @@
  * @problem.severity warning
  * @precision medium
  * @id java/notify-instead-of-notify-all
- * @tags reliability
+ * @tags quality
+ *       reliability
  *       correctness
  *       concurrency
  *       external/cwe/cwe-662

--- a/java/ql/src/Likely Bugs/Concurrency/SleepWithLock.ql
+++ b/java/ql/src/Likely Bugs/Concurrency/SleepWithLock.ql
@@ -6,9 +6,11 @@
  * @problem.severity error
  * @precision medium
  * @id java/sleep-with-lock-held
- * @tags reliability
+ * @tags quality
+ *       reliability
  *       correctness
  *       concurrency
+ *       performance
  *       external/cwe/cwe-833
  */
 

--- a/java/ql/src/Likely Bugs/Concurrency/StartInConstructor.ql
+++ b/java/ql/src/Likely Bugs/Concurrency/StartInConstructor.ql
@@ -7,7 +7,8 @@
  * @problem.severity warning
  * @precision medium
  * @id java/thread-start-in-constructor
- * @tags reliability
+ * @tags quality
+ *       reliability
  *       correctness
  *       concurrency
  */

--- a/java/ql/src/Likely Bugs/Concurrency/SynchWriteObject.ql
+++ b/java/ql/src/Likely Bugs/Concurrency/SynchWriteObject.ql
@@ -6,10 +6,10 @@
  * @problem.severity warning
  * @precision medium
  * @id java/inconsistent-sync-writeobject
- * @tags reliability
+ * @tags quality
+ *       reliability
  *       correctness
  *       concurrency
- *       language-features
  *       external/cwe/cwe-662
  */
 

--- a/java/ql/src/Likely Bugs/Finalization/NullifiedSuperFinalize.ql
+++ b/java/ql/src/Likely Bugs/Finalization/NullifiedSuperFinalize.ql
@@ -6,8 +6,9 @@
  * @problem.severity error
  * @precision medium
  * @id java/missing-super-finalize
- * @tags reliability
- *       maintainability
+ * @tags quality
+ *       reliability
+ *       correctness
  *       external/cwe/cwe-568
  */
 

--- a/java/ql/src/Likely Bugs/Frameworks/JUnit/BadSuiteMethod.ql
+++ b/java/ql/src/Likely Bugs/Frameworks/JUnit/BadSuiteMethod.ql
@@ -6,9 +6,9 @@
  * @problem.severity warning
  * @precision medium
  * @id java/wrong-junit-suite-signature
- * @tags testability
- *       maintainability
- *       frameworks/junit
+ * @tags quality
+ *       reliability
+ *       correctness
  */
 
 import java

--- a/java/ql/src/Likely Bugs/Frameworks/Swing/BadlyOverriddenAdapter.ql
+++ b/java/ql/src/Likely Bugs/Frameworks/Swing/BadlyOverriddenAdapter.ql
@@ -7,9 +7,9 @@
  * @problem.severity warning
  * @precision medium
  * @id java/wrong-swing-event-adapter-signature
- * @tags reliability
- *       maintainability
- *       frameworks/swing
+ * @tags quality
+ *       reliability
+ *       correctness
  */
 
 import java

--- a/java/ql/src/Likely Bugs/Likely Typos/DangerousNonCircuitLogic.ql
+++ b/java/ql/src/Likely Bugs/Likely Typos/DangerousNonCircuitLogic.ql
@@ -7,7 +7,9 @@
  * @problem.severity warning
  * @precision medium
  * @id java/non-short-circuit-evaluation
- * @tags reliability
+ * @tags quality
+ *       reliability
+ *       correctness
  *       readability
  *       external/cwe/cwe-691
  */

--- a/java/ql/src/Likely Bugs/Likely Typos/EqualsTypo.ql
+++ b/java/ql/src/Likely Bugs/Likely Typos/EqualsTypo.ql
@@ -5,9 +5,10 @@
  * @problem.severity warning
  * @precision medium
  * @id java/equals-typo
- * @tags maintainability
+ * @tags quality
+ *       reliability
+ *       correctness
  *       readability
- *       naming
  */
 
 import java

--- a/java/ql/src/Likely Bugs/Likely Typos/HashCodeTypo.ql
+++ b/java/ql/src/Likely Bugs/Likely Typos/HashCodeTypo.ql
@@ -5,9 +5,10 @@
  * @problem.severity warning
  * @precision medium
  * @id java/hashcode-typo
- * @tags maintainability
+ * @tags quality
+ *       reliability
+ *       correctness
  *       readability
- *       naming
  */
 
 import java

--- a/java/ql/src/Likely Bugs/Likely Typos/ToStringTypo.ql
+++ b/java/ql/src/Likely Bugs/Likely Typos/ToStringTypo.ql
@@ -5,9 +5,10 @@
  * @problem.severity warning
  * @precision medium
  * @id java/tostring-typo
- * @tags maintainability
+ * @tags quality
+ *       reliability
+ *       correctness
  *       readability
- *       naming
  */
 
 import java

--- a/java/ql/src/Likely Bugs/Reflection/AnnotationPresentCheck.ql
+++ b/java/ql/src/Likely Bugs/Reflection/AnnotationPresentCheck.ql
@@ -6,8 +6,9 @@
  * @problem.severity error
  * @precision medium
  * @id java/ineffective-annotation-present-check
- * @tags correctness
- *       logic
+ * @tags quality
+ *       reliability
+ *       correctness
  */
 
 import java

--- a/java/ql/src/Likely Bugs/Serialization/IncorrectSerialVersionUID.ql
+++ b/java/ql/src/Likely Bugs/Serialization/IncorrectSerialVersionUID.ql
@@ -6,9 +6,9 @@
  * @problem.severity warning
  * @precision medium
  * @id java/incorrect-serial-version-uid
- * @tags reliability
- *       maintainability
- *       language-features
+ * @tags quality
+ *       reliability
+ *       correctness
  */
 
 import java

--- a/java/ql/src/Likely Bugs/Serialization/IncorrectSerializableMethods.ql
+++ b/java/ql/src/Likely Bugs/Serialization/IncorrectSerializableMethods.ql
@@ -6,9 +6,9 @@
  * @problem.severity warning
  * @precision medium
  * @id java/wrong-object-serialization-signature
- * @tags reliability
- *       maintainability
- *       language-features
+ * @tags quality
+ *       reliability
+ *       correctness
  */
 
 import java

--- a/java/ql/src/Likely Bugs/Serialization/MissingVoidConstructorOnExternalizable.ql
+++ b/java/ql/src/Likely Bugs/Serialization/MissingVoidConstructorOnExternalizable.ql
@@ -6,9 +6,9 @@
  * @problem.severity warning
  * @precision medium
  * @id java/missing-no-arg-constructor-on-externalizable
- * @tags reliability
- *       maintainability
- *       language-features
+ * @tags quality
+ *       reliability
+ *       correctness
  */
 
 import java

--- a/java/ql/src/Likely Bugs/Serialization/MissingVoidConstructorsOnSerializable.ql
+++ b/java/ql/src/Likely Bugs/Serialization/MissingVoidConstructorsOnSerializable.ql
@@ -7,9 +7,9 @@
  * @problem.severity warning
  * @precision medium
  * @id java/missing-no-arg-constructor-on-serializable
- * @tags reliability
- *       maintainability
- *       language-features
+ * @tags quality
+ *       reliability
+ *       correctness
  */
 
 import java

--- a/java/ql/src/Likely Bugs/Serialization/NonSerializableInnerClass.ql
+++ b/java/ql/src/Likely Bugs/Serialization/NonSerializableInnerClass.ql
@@ -6,9 +6,9 @@
  * @problem.severity warning
  * @precision medium
  * @id java/non-serializable-inner-class
- * @tags reliability
- *       maintainability
- *       language-features
+ * @tags quality
+ *       reliability
+ *       correctness
  */
 
 import java

--- a/java/ql/src/Likely Bugs/Serialization/ReadResolveObject.ql
+++ b/java/ql/src/Likely Bugs/Serialization/ReadResolveObject.ql
@@ -7,9 +7,9 @@
  * @problem.severity warning
  * @precision medium
  * @id java/wrong-readresolve-signature
- * @tags reliability
- *       maintainability
- *       language-features
+ * @tags quality
+ *       reliability
+ *       correctness
  */
 
 import java

--- a/java/ql/src/Likely Bugs/Statements/MissingEnumInSwitch.ql
+++ b/java/ql/src/Likely Bugs/Statements/MissingEnumInSwitch.ql
@@ -6,8 +6,9 @@
  * @problem.severity warning
  * @precision medium
  * @id java/missing-case-in-switch
- * @tags reliability
- *       readability
+ * @tags quality
+ *       reliability
+ *       correctness
  *       external/cwe/cwe-478
  */
 

--- a/java/ql/src/Likely Bugs/Termination/SpinOnField.ql
+++ b/java/ql/src/Likely Bugs/Termination/SpinOnField.ql
@@ -6,9 +6,11 @@
  * @problem.severity warning
  * @precision medium
  * @id java/spin-on-field
- * @tags efficiency
+ * @tags quality
+ *       reliability
  *       correctness
  *       concurrency
+ *       performance
  */
 
 import java

--- a/java/ql/src/Violations of Best Practice/Dead Code/CreatesEmptyZip.ql
+++ b/java/ql/src/Violations of Best Practice/Dead Code/CreatesEmptyZip.ql
@@ -6,8 +6,9 @@
  * @problem.severity warning
  * @precision medium
  * @id java/empty-zip-file-entry
- * @tags reliability
- *       readability
+ * @tags quality
+ *       reliability
+ *       correctness
  */
 
 import java

--- a/java/ql/src/Violations of Best Practice/Implementation Hiding/GetClassGetResource.ql
+++ b/java/ql/src/Violations of Best Practice/Implementation Hiding/GetClassGetResource.ql
@@ -6,8 +6,9 @@
  * @problem.severity warning
  * @precision medium
  * @id java/unsafe-get-resource
- * @tags reliability
- *       maintainability
+ * @tags quality
+ *       reliability
+ *       correctness
  */
 
 import java

--- a/java/ql/src/Violations of Best Practice/Naming Conventions/FieldMasksSuperField.ql
+++ b/java/ql/src/Violations of Best Practice/Naming Conventions/FieldMasksSuperField.ql
@@ -7,8 +7,10 @@
  * @problem.severity warning
  * @precision medium
  * @id java/field-masks-super-field
- * @tags maintainability
+ * @tags quality
+ *       maintainability
  *       readability
+ *       correctness
  */
 
 import java

--- a/java/ql/src/Violations of Best Practice/Undesirable Calls/NextFromIterator.ql
+++ b/java/ql/src/Violations of Best Practice/Undesirable Calls/NextFromIterator.ql
@@ -6,7 +6,8 @@
  * @problem.severity warning
  * @precision medium
  * @id java/iterator-hasnext-calls-next
- * @tags reliability
+ * @tags quality
+ *       reliability
  *       correctness
  */
 


### PR DESCRIPTION
In this PR we add most `medium` precision queries to the `codeql-quality-extended` suite, with the exception of

- The `java/undocumented-*` queries as they produce a massive amount of results (missing documentation queries have also been excluded for other languages).

DCA looks good.
- The performance when adding the queries looks acceptable (adding medium precision queries adds to 10% to the analysis time compared to only running queries with precision very-high and high).