### PR TITLE
JS: Add most `medium` precision queries to the `code-quality-extended` suite. 

### DIFF
--- a/javascript/ql/integration-tests/query-suite/javascript-code-quality-extended.qls.expected
+++ b/javascript/ql/integration-tests/query-suite/javascript-code-quality-extended.qls.expected
@@ -4,6 +4,9 @@ ql/javascript/ql/src/AngularJS/IncompatibleService.ql
 ql/javascript/ql/src/AngularJS/MissingExplicitInjection.ql
 ql/javascript/ql/src/AngularJS/RepeatedInjection.ql
 ql/javascript/ql/src/AngularJS/UseNgSrc.ql
+ql/javascript/ql/src/Comments/CommentedOutCode.ql
+ql/javascript/ql/src/Comments/TodoComments.ql
+ql/javascript/ql/src/DOM/Alert.ql
 ql/javascript/ql/src/DOM/DuplicateAttributes.ql
 ql/javascript/ql/src/DOM/MalformedIdAttribute.ql
 ql/javascript/ql/src/DOM/PseudoEval.ql
@@ -20,11 +23,13 @@ ql/javascript/ql/src/Declarations/IneffectiveParameterType.ql
 ql/javascript/ql/src/Declarations/MissingThisQualifier.ql
 ql/javascript/ql/src/Declarations/MissingVarDecl.ql
 ql/javascript/ql/src/Declarations/MixedStaticInstanceThisAccess.ql
+ql/javascript/ql/src/Declarations/RedeclaredVariable.ql
 ql/javascript/ql/src/Declarations/SuspiciousMethodNameDeclaration.ql
 ql/javascript/ql/src/Declarations/TemporalDeadZone.ql
 ql/javascript/ql/src/Declarations/UniqueParameterNames.ql
 ql/javascript/ql/src/Declarations/UniquePropertyNames.ql
 ql/javascript/ql/src/Declarations/UnreachableMethodOverloads.ql
+ql/javascript/ql/src/Declarations/UnusedParameter.ql
 ql/javascript/ql/src/Declarations/UnusedVariable.ql
 ql/javascript/ql/src/Expressions/ComparisonWithNaN.ql
 ql/javascript/ql/src/Expressions/DuplicateCondition.ql
@@ -48,9 +53,12 @@ ql/javascript/ql/src/Expressions/UnclearOperatorPrecedence.ql
 ql/javascript/ql/src/Expressions/UnknownDirective.ql
 ql/javascript/ql/src/Expressions/UnneededDefensiveProgramming.ql
 ql/javascript/ql/src/Expressions/WhitespaceContradictsPrecedence.ql
+ql/javascript/ql/src/LanguageFeatures/ArgumentsCallerCallee.ql
 ql/javascript/ql/src/LanguageFeatures/BadTypeof.ql
 ql/javascript/ql/src/LanguageFeatures/ConditionalComments.ql
+ql/javascript/ql/src/LanguageFeatures/DebuggerStatement.ql
 ql/javascript/ql/src/LanguageFeatures/DeleteVar.ql
+ql/javascript/ql/src/LanguageFeatures/Eval.ql
 ql/javascript/ql/src/LanguageFeatures/ExpressionClosures.ql
 ql/javascript/ql/src/LanguageFeatures/ForInComprehensionBlocks.ql
 ql/javascript/ql/src/LanguageFeatures/IllegalInvocation.ql
@@ -71,6 +79,7 @@ ql/javascript/ql/src/LanguageFeatures/WithStatement.ql
 ql/javascript/ql/src/LanguageFeatures/YieldInNonGenerator.ql
 ql/javascript/ql/src/NodeJS/InvalidExport.ql
 ql/javascript/ql/src/NodeJS/MissingExports.ql
+ql/javascript/ql/src/Performance/ReassignParameterAndUseArguments.ql
 ql/javascript/ql/src/Quality/UnhandledErrorInStreamPipeline.ql
 ql/javascript/ql/src/React/DirectStateMutation.ql
 ql/javascript/ql/src/React/InconsistentStateUpdate.ql
@@ -78,6 +87,7 @@ ql/javascript/ql/src/React/UnsupportedStateUpdateInLifecycleMethod.ql
 ql/javascript/ql/src/React/UnusedOrUndefinedStateProperty.ql
 ql/javascript/ql/src/RegExp/BackrefBeforeGroup.ql
 ql/javascript/ql/src/RegExp/BackrefIntoNegativeLookahead.ql
+ql/javascript/ql/src/RegExp/BackspaceEscape.ql
 ql/javascript/ql/src/RegExp/DuplicateCharacterInCharacterClass.ql
 ql/javascript/ql/src/RegExp/EmptyCharacterClass.ql
 ql/javascript/ql/src/RegExp/RegExpAlwaysMatches.ql
@@ -86,7 +96,9 @@ ql/javascript/ql/src/RegExp/UnmatchableCaret.ql
 ql/javascript/ql/src/RegExp/UnmatchableDollar.ql
 ql/javascript/ql/src/Statements/DanglingElse.ql
 ql/javascript/ql/src/Statements/IgnoreArrayResult.ql
+ql/javascript/ql/src/Statements/ImplicitReturn.ql
 ql/javascript/ql/src/Statements/InconsistentLoopOrientation.ql
+ql/javascript/ql/src/Statements/InconsistentReturn.ql
 ql/javascript/ql/src/Statements/LabelInCase.ql
 ql/javascript/ql/src/Statements/LoopIterationSkippedDueToShifting.ql
 ql/javascript/ql/src/Statements/MisleadingIndentationAfterControlStmt.ql

--- a/javascript/ql/integration-tests/query-suite/not_included_in_qls.expected
+++ b/javascript/ql/integration-tests/query-suite/not_included_in_qls.expected
@@ -1,18 +1,13 @@
 ql/javascript/ql/src/AlertSuppression.ql
 ql/javascript/ql/src/AngularJS/DeadAngularJSEventListener.ql
 ql/javascript/ql/src/AngularJS/UnusedAngularDependency.ql
-ql/javascript/ql/src/Comments/CommentedOutCode.ql
 ql/javascript/ql/src/Comments/FCommentedOutCode.ql
-ql/javascript/ql/src/Comments/TodoComments.ql
-ql/javascript/ql/src/DOM/Alert.ql
 ql/javascript/ql/src/DOM/AmbiguousIdAttribute.ql
 ql/javascript/ql/src/DOM/ConflictingAttributes.ql
 ql/javascript/ql/src/DOM/TargetBlank.ql
 ql/javascript/ql/src/Declarations/DeadStoreOfGlobal.ql
-ql/javascript/ql/src/Declarations/RedeclaredVariable.ql
 ql/javascript/ql/src/Declarations/TooManyParameters.ql
 ql/javascript/ql/src/Declarations/UnstableCyclicImport.ql
-ql/javascript/ql/src/Declarations/UnusedParameter.ql
 ql/javascript/ql/src/Declarations/UnusedProperty.ql
 ql/javascript/ql/src/Electron/EnablingNodeIntegration.ql
 ql/javascript/ql/src/Expressions/BitwiseSignCheck.ql
@@ -21,10 +16,7 @@ ql/javascript/ql/src/Expressions/MisspelledIdentifier.ql
 ql/javascript/ql/src/JSDoc/BadParamTag.ql
 ql/javascript/ql/src/JSDoc/JSDocForNonExistentParameter.ql
 ql/javascript/ql/src/JSDoc/UndocumentedParameter.ql
-ql/javascript/ql/src/LanguageFeatures/ArgumentsCallerCallee.ql
-ql/javascript/ql/src/LanguageFeatures/DebuggerStatement.ql
 ql/javascript/ql/src/LanguageFeatures/EmptyArrayInit.ql
-ql/javascript/ql/src/LanguageFeatures/Eval.ql
 ql/javascript/ql/src/LanguageFeatures/JumpFromFinally.ql
 ql/javascript/ql/src/LanguageFeatures/SetterIgnoresParameter.ql
 ql/javascript/ql/src/LanguageFeatures/WrongExtensionJSON.ql
@@ -48,8 +40,6 @@ ql/javascript/ql/src/NodeJS/DubiousImport.ql
 ql/javascript/ql/src/NodeJS/UnresolvableImport.ql
 ql/javascript/ql/src/NodeJS/UnusedDependency.ql
 ql/javascript/ql/src/Performance/NonLocalForIn.ql
-ql/javascript/ql/src/Performance/ReassignParameterAndUseArguments.ql
-ql/javascript/ql/src/RegExp/BackspaceEscape.ql
 ql/javascript/ql/src/RegExp/MalformedRegExp.ql
 ql/javascript/ql/src/Security/CWE-020/ExternalAPIsUsedWithUntrustedData.ql
 ql/javascript/ql/src/Security/CWE-020/UntrustedDataToExternalAPI.ql
@@ -59,8 +49,6 @@ ql/javascript/ql/src/Security/CWE-798/HardcodedCredentials.ql
 ql/javascript/ql/src/Security/CWE-807/DifferentKindsComparisonBypass.ql
 ql/javascript/ql/src/Security/trest/test.ql
 ql/javascript/ql/src/Statements/EphemeralLoop.ql
-ql/javascript/ql/src/Statements/ImplicitReturn.ql
-ql/javascript/ql/src/Statements/InconsistentReturn.ql
 ql/javascript/ql/src/Statements/NestedLoopsSameVariable.ql
 ql/javascript/ql/src/Statements/ReturnOutsideFunction.ql
 ql/javascript/ql/src/Summary/TaintSinks.ql

--- a/javascript/ql/src/Comments/CommentedOutCode.ql
+++ b/javascript/ql/src/Comments/CommentedOutCode.ql
@@ -4,9 +4,9 @@
  * @kind problem
  * @problem.severity recommendation
  * @id js/commented-out-code
- * @tags maintainability
- *       statistical
- *       non-attributable
+ * @tags quality
+ *       maintainability
+ *       readability
  * @precision medium
  */
 

--- a/javascript/ql/src/Comments/TodoComments.ql
+++ b/javascript/ql/src/Comments/TodoComments.ql
@@ -5,7 +5,9 @@
  * @kind problem
  * @problem.severity recommendation
  * @id js/todo-comment
- * @tags maintainability
+ * @tags quality
+ *       maintainability
+ *       readability
  *       external/cwe/cwe-546
  * @precision medium
  */

--- a/javascript/ql/src/DOM/Alert.ql
+++ b/javascript/ql/src/DOM/Alert.ql
@@ -4,7 +4,9 @@
  * @kind problem
  * @problem.severity recommendation
  * @id js/alert-call
- * @tags maintainability
+ * @tags quality
+ *       reliability
+ *       correctness
  *       external/cwe/cwe-489
  * @precision medium
  */

--- a/javascript/ql/src/Declarations/RedeclaredVariable.ql
+++ b/javascript/ql/src/Declarations/RedeclaredVariable.ql
@@ -4,7 +4,9 @@
  * @kind problem
  * @problem.severity recommendation
  * @id js/variable-redeclaration
- * @tags reliability
+ * @tags quality
+ *       reliability
+ *       correctness
  *       readability
  * @precision medium
  */

--- a/javascript/ql/src/Declarations/UnusedParameter.ql
+++ b/javascript/ql/src/Declarations/UnusedParameter.ql
@@ -4,7 +4,10 @@
  * @kind problem
  * @problem.severity recommendation
  * @id js/unused-parameter
- * @tags maintainability
+ * @tags quality
+ *       reliability
+ *       correctness
+ *       readability
  * @precision medium
  */
 

--- a/javascript/ql/src/LanguageFeatures/ArgumentsCallerCallee.ql
+++ b/javascript/ql/src/LanguageFeatures/ArgumentsCallerCallee.ql
@@ -5,8 +5,9 @@
  * @kind problem
  * @problem.severity recommendation
  * @id js/call-stack-introspection
- * @tags maintainability
- *       language-features
+ * @tags quality
+ *       reliability
+ *       correctness
  * @precision medium
  */
 

--- a/javascript/ql/src/LanguageFeatures/DebuggerStatement.ql
+++ b/javascript/ql/src/LanguageFeatures/DebuggerStatement.ql
@@ -4,9 +4,10 @@
  * @kind problem
  * @problem.severity recommendation
  * @id js/debugger-statement
- * @tags efficiency
- *       maintainability
- *       language-features
+ * @tags quality
+ *       reliability
+ *       correctness
+ *       performance
  *       external/cwe/cwe-489
  * @precision medium
  */

--- a/javascript/ql/src/LanguageFeatures/Eval.ql
+++ b/javascript/ql/src/LanguageFeatures/Eval.ql
@@ -5,8 +5,9 @@
  * @kind problem
  * @problem.severity recommendation
  * @id js/eval-call
- * @tags maintainability
- *       language-features
+ * @tags quality
+ *       reliability
+ *       correctness
  *       external/cwe/cwe-676
  * @precision medium
  */

--- a/javascript/ql/src/Performance/ReassignParameterAndUseArguments.ql
+++ b/javascript/ql/src/Performance/ReassignParameterAndUseArguments.ql
@@ -5,8 +5,9 @@
  * @kind problem
  * @problem.severity recommendation
  * @id js/parameter-reassignment-with-arguments
- * @tags efficiency
- *       maintainability
+ * @tags quality
+ *       reliability
+ *       performance
  * @precision medium
  */
 

--- a/javascript/ql/src/RegExp/BackspaceEscape.ql
+++ b/javascript/ql/src/RegExp/BackspaceEscape.ql
@@ -5,9 +5,10 @@
  * @kind problem
  * @problem.severity recommendation
  * @id js/regex/backspace-escape
- * @tags maintainability
+ * @tags quality
+ *       maintainability
  *       readability
- *       regular-expressions
+ *       correctness
  * @precision medium
  */
 

--- a/javascript/ql/src/Statements/ImplicitReturn.ql
+++ b/javascript/ql/src/Statements/ImplicitReturn.ql
@@ -5,7 +5,10 @@
  * @kind problem
  * @problem.severity recommendation
  * @id js/implicit-return
- * @tags maintainability
+ * @tags quality
+ *       reliability
+ *       correctness
+ *       readability
  * @precision medium
  */
 

--- a/javascript/ql/src/Statements/InconsistentReturn.ql
+++ b/javascript/ql/src/Statements/InconsistentReturn.ql
@@ -4,8 +4,10 @@
  * @kind problem
  * @problem.severity recommendation
  * @id js/mixed-returns
- * @tags reliability
- *       maintainability
+ * @tags quality
+ *       reliability
+ *       correctness
+ *       readability
  * @precision medium
  */
 


### PR DESCRIPTION
In this PR we add most `medium` precision queries to the `codeql-quality-extended` suite, with the exception of
- `js/summary/taint-sources` and `js/summary/taint-sinks` which highlights potential sources and sinks (look like debugging queries).

DCA looks good.
- It appears that none of the `medium` precision queries results in an overwhelming number of alerts.
- Adding the `medium` precision queries (on top of `high` and `very-high`) only increases analysis time around 5%.
