### PR TITLE
C#: Increase attempts to reach nuget.org in integration tests to reduce flakiness.

### DIFF
--- a/csharp/ql/integration-tests/all-platforms/standalone_resx/test.py
+++ b/csharp/ql/integration-tests/all-platforms/standalone_resx/test.py
@@ -2,5 +2,9 @@ import os
 
 
 def test(codeql, csharp):
+    # Making sure the reachability test of `nuget.org` succeeds:
+    os.environ["CODEQL_EXTRACTOR_CSHARP_BUILDLESS_NUGET_FEEDS_CHECK_FALLBACK_TIMEOUT"] = "1000"
+    os.environ["CODEQL_EXTRACTOR_CSHARP_BUILDLESS_NUGET_FEEDS_CHECK_FALLBACK_LIMIT"] = "5"
+
     os.environ["CODEQL_EXTRACTOR_CSHARP_BUILDLESS_EXTRACT_RESOURCES"] = "true"
     codeql.database.create(build_mode="none")

--- a/csharp/ql/integration-tests/all-platforms/standalone_winforms/test.py
+++ b/csharp/ql/integration-tests/all-platforms/standalone_winforms/test.py
@@ -1,2 +1,9 @@
+import os
+
+
 def test(codeql, csharp):
+    # Making sure the reachability test of `nuget.org` succeeds:
+    os.environ["CODEQL_EXTRACTOR_CSHARP_BUILDLESS_NUGET_FEEDS_CHECK_FALLBACK_TIMEOUT"] = "1000"
+    os.environ["CODEQL_EXTRACTOR_CSHARP_BUILDLESS_NUGET_FEEDS_CHECK_FALLBACK_LIMIT"] = "5"
+
     codeql.database.create(build_mode="none")

--- a/csharp/ql/integration-tests/posix/standalone_dependencies_nuget_config_error/test.py
+++ b/csharp/ql/integration-tests/posix/standalone_dependencies_nuget_config_error/test.py
@@ -1,6 +1,11 @@
+import os
 import runs_on
 
 
 @runs_on.posix
 def test(codeql, csharp):
+    # Making sure the reachability test of `nuget.org` succeeds:
+    os.environ["CODEQL_EXTRACTOR_CSHARP_BUILDLESS_NUGET_FEEDS_CHECK_FALLBACK_TIMEOUT"] = "1000"
+    os.environ["CODEQL_EXTRACTOR_CSHARP_BUILDLESS_NUGET_FEEDS_CHECK_FALLBACK_LIMIT"] = "5"
+
     codeql.database.create(build_mode="none")


### PR DESCRIPTION
In this PR we increase the number of attempts (and thus the timeout) for reaching `nuget.org` (which is the default nuget fallback feed) to reduce integration test flakiness. If we still see an unacceptable level of flakiness we would consider to remove the check from some of the tests to reduce network impact on the integration tests.