### PR TITLE
Docs: remove 1-year deprecation period for QL libraries

### DIFF
--- a/docs/supported-queries.md
+++ b/docs/supported-queries.md
@@ -3,7 +3,7 @@
 Queries and libraries outside [the `experimental` directories](experimental.md) are _supported_ by GitHub, allowing our users to rely on their continued existence and functionality in the future:
 
 1. Once a query has appeared in a stable release, a one-year deprecation period is required before we can remove it.
-2. Major changes to supported queries and libraries are always announced in the [change notes for stable releases](../change-notes/).
+2. Major changes to supported queries and libraries are always announced in the change notes for stable releases.
 3. We will do our best to address user reports of false positives or false negatives.
 
 Because of these commitments, we set a high bar for accepting new supported queries. The requirements are detailed in the rest of this document.


### PR DESCRIPTION
Internal reference: codeql-team ADR 0011.

We can now change QL libraries without a 1-year deprecation period, allowing the libraries to converge more quickly toward greater usability. However,
* We'll continue to write change notes for breaking changes.
* We'll continue to bump the major version of QL packs when there are breaking changes, so downstream code should only need updating if they depend on the latest version.
* We'll continue to be mindful of the burden we place on library consumers, both those inside and outside GitHub.