### PR TITLE
C++: Fix barrier in `cpp/unbounded-write`

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-120/UnboundedWrite.ql
+++ b/cpp/ql/src/Security/CWE/CWE-120/UnboundedWrite.ql
@@ -109,7 +109,7 @@ predicate lessThanOrEqual(IRGuardCondition g, Expr e, boolean branch) {
     g.comparesEq(left, _, _, true, branch)
   |
     interestingLessThanOrEqual(left) and
-    left.getDef().getUnconvertedResultExpression() = e
+    left.getDef().getConvertedResultExpression() = e
   )
 }
 


### PR DESCRIPTION
Due to historical reasons the predicate you supply to `DataFlow::BarrierGuard` (let's call it `p`) is actually called with the _converted_ expression (see [here](https://github.com/github/codeql/blob/c375f24598e3142063e69d20c691ca21112a34dd/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll#L2354)). Because of this, `p` must handle possible conversions on the expression.

We do this in all other `DataFlow::BarrierGuard` cases, but not on this one.

I didn't manage to write a testcase that broke with the current barrier guard implementation, but it fixes a bunch of regressions when upgrading to the shared guards library.