### PR TITLE
C#: Exclude enum types as they don't inherit the default toString.

### DIFF
--- a/csharp/ql/src/Useless code/DefaultToStringQuery.qll
+++ b/csharp/ql/src/Useless code/DefaultToStringQuery.qll
@@ -47,6 +47,7 @@ private predicate alwaysInvokesToString(ParameterRead pr) {
  */
 predicate alwaysDefaultToString(ValueOrRefType t) {
   not t instanceof TupleType and
+  not t instanceof Enum and
   exists(ToStringMethod m | t.hasMethod(m) |
     m.getDeclaringType() instanceof SystemObjectClass or
     m.getDeclaringType() instanceof SystemValueTypeClass

--- a/csharp/ql/src/change-notes/2025-09-16-default-tostring-enum.md
+++ b/csharp/ql/src/change-notes/2025-09-16-default-tostring-enum.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The query `cs/call-to-object-tostring` has been improved to remove false positives for enum types.


### PR DESCRIPTION
A minor drive-by FP removal improvement.