### PR TITLE
Rust, shared: Support `Parameter` in source MaD models

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/FlowSummaryImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/FlowSummaryImpl.qll
@@ -104,7 +104,9 @@ private module StepsInput implements Impl::Private::StepsInputSig {
     result.getStaticCallTarget().getUnderlyingCallable() = sc
   }
 
-  Node getSourceNode(Input::SourceBase source, Impl::Private::SummaryComponent sc) { none() }
+  DataFlowCallable getSourceNodeEnclosingCallable(Input::SourceBase source) { none() }
+
+  Node getSourceNode(Input::SourceBase source, Impl::Private::SummaryComponentStack s) { none() }
 
   Node getSinkNode(Input::SinkBase sink, Impl::Private::SummaryComponent sc) { none() }
 }

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImpl.qll
@@ -183,7 +183,7 @@ private module TypesInput implements Impl::Private::TypesInputSig {
     )
   }
 
-  DataFlowType getSourceType(Input::SourceBase source, Impl::Private::SummaryComponent sc) {
+  DataFlowType getSourceType(Input::SourceBase source, Impl::Private::SummaryComponentStack s) {
     none()
   }
 
@@ -195,7 +195,9 @@ private module StepsInput implements Impl::Private::StepsInputSig {
     sc = viableCallable(result).asSummarizedCallable()
   }
 
-  Node getSourceNode(Input::SourceBase source, Impl::Private::SummaryComponent sc) { none() }
+  DataFlowCallable getSourceNodeEnclosingCallable(Input::SourceBase source) { none() }
+
+  Node getSourceNode(Input::SourceBase source, Impl::Private::SummaryComponentStack s) { none() }
 
   Node getSinkNode(Input::SinkBase sink, Impl::Private::SummaryComponent sc) { none() }
 }

--- a/go/ql/lib/semmle/go/dataflow/internal/FlowSummaryImpl.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/FlowSummaryImpl.qll
@@ -117,7 +117,9 @@ private module StepsInput implements Impl::Private::StepsInputSig {
     )
   }
 
-  Node getSourceNode(Input::SourceBase source, Impl::Private::SummaryComponent sc) { none() }
+  DataFlowCallable getSourceNodeEnclosingCallable(Input::SourceBase source) { none() }
+
+  Node getSourceNode(Input::SourceBase source, Impl::Private::SummaryComponentStack s) { none() }
 
   Node getSinkNode(Input::SinkBase sink, Impl::Private::SummaryComponent sc) { none() }
 }

--- a/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImpl.qll
@@ -132,7 +132,7 @@ private module TypesInput implements Impl::Private::TypesInputSig {
     exists(rk)
   }
 
-  DataFlowType getSourceType(Input::SourceBase source, Impl::Private::SummaryComponent sc) {
+  DataFlowType getSourceType(Input::SourceBase source, Impl::Private::SummaryComponentStack s) {
     none()
   }
 
@@ -144,7 +144,9 @@ private module StepsInput implements Impl::Private::StepsInputSig {
     sc = viableCallable(result).asSummarizedCallable()
   }
 
-  Node getSourceNode(Input::SourceBase source, Impl::Private::SummaryComponent sc) { none() }
+  DataFlowCallable getSourceNodeEnclosingCallable(Input::SourceBase source) { none() }
+
+  Node getSourceNode(Input::SourceBase source, Impl::Private::SummaryComponentStack s) { none() }
 
   Node getSinkNode(Input::SinkBase sink, Impl::Private::SummaryComponent sc) { none() }
 }

--- a/javascript/ql/lib/semmle/javascript/dataflow/internal/FlowSummaryPrivate.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/internal/FlowSummaryPrivate.qll
@@ -150,7 +150,9 @@ private module FlowSummaryStepInput implements Private::StepsInputSig {
     )
   }
 
-  DataFlow::Node getSourceNode(SourceBase source, Private::SummaryComponent sc) { none() }
+  DataFlowCallable getSourceNodeEnclosingCallable(SourceBase source) { none() }
+
+  DataFlow::Node getSourceNode(SourceBase source, Private::SummaryComponentStack s) { none() }
 
   DataFlow::Node getSinkNode(SinkBase sink, Private::SummaryComponent sc) { none() }
 }

--- a/python/ql/lib/semmle/python/dataflow/new/internal/FlowSummaryImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/FlowSummaryImpl.qll
@@ -105,7 +105,9 @@ private module StepsInput implements Impl::Private::StepsInputSig {
         ])
   }
 
-  Node getSourceNode(Input::SourceBase source, Impl::Private::SummaryComponent sc) { none() }
+  DataFlowCallable getSourceNodeEnclosingCallable(Input::SourceBase source) { none() }
+
+  Node getSourceNode(Input::SourceBase source, Impl::Private::SummaryComponentStack s) { none() }
 
   Node getSinkNode(Input::SinkBase sink, Impl::Private::SummaryComponent sc) { none() }
 }

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImpl.qll
@@ -161,7 +161,9 @@ private module StepsInput implements Impl::Private::StepsInputSig {
     result.asCall().getAstNode() = sc.(LibraryCallable).getACallSimple()
   }
 
-  Node getSourceNode(Input::SourceBase source, Impl::Private::SummaryComponent sc) { none() }
+  DataFlowCallable getSourceNodeEnclosingCallable(Input::SourceBase source) { none() }
+
+  Node getSourceNode(Input::SourceBase source, Impl::Private::SummaryComponentStack s) { none() }
 
   Node getSinkNode(Input::SinkBase sink, Impl::Private::SummaryComponent sc) { none() }
 }

--- a/rust/ql/lib/change-notes/2025-09-19-parameter-mad.md
+++ b/rust/ql/lib/change-notes/2025-09-19-parameter-mad.md
@@ -1,0 +1,7 @@
+---
+category: feature
+---
+* The models-as-data format for sources now supports access paths of the form
+  `Argument[i].Parameter[j]`. This denotes that the source passes tainted data to
+  the `j`th parameter of it's `i`th argument (which must be a function or a
+  closure).

--- a/rust/ql/lib/change-notes/2025-09-19-parameter-mad.md
+++ b/rust/ql/lib/change-notes/2025-09-19-parameter-mad.md
@@ -3,5 +3,5 @@ category: feature
 ---
 * The models-as-data format for sources now supports access paths of the form
   `Argument[i].Parameter[j]`. This denotes that the source passes tainted data to
-  the `j`th parameter of it's `i`th argument (which must be a function or a
+  the `j`th parameter of its `i`th argument (which must be a function or a
   closure).

--- a/rust/ql/lib/codeql/rust/dataflow/internal/DataFlowImpl.qll
+++ b/rust/ql/lib/codeql/rust/dataflow/internal/DataFlowImpl.qll
@@ -508,7 +508,8 @@ module RustDataFlow implements InputSig<Location> {
    */
   predicate jumpStep(Node node1, Node node2) {
     FlowSummaryImpl::Private::Steps::summaryJumpStep(node1.(FlowSummaryNode).getSummaryNode(),
-      node2.(FlowSummaryNode).getSummaryNode())
+      node2.(FlowSummaryNode).getSummaryNode()) or
+    FlowSummaryImpl::Private::Steps::sourceJumpStep(node1.(FlowSummaryNode).getSummaryNode(), node2)
   }
 
   pragma[nomagic]

--- a/rust/ql/lib/codeql/rust/dataflow/internal/FlowSummaryImpl.qll
+++ b/rust/ql/lib/codeql/rust/dataflow/internal/FlowSummaryImpl.qll
@@ -168,12 +168,12 @@ private module StepsInput implements Impl::Private::StepsInputSig {
     or
     exists(ArgumentPosition pos, Expr arg |
       s.head() = Impl::Private::SummaryComponent::parameter(pos) and
-      arg = getSourceNodeArgument(source, s.tail().head()) and
+      arg = getSourceNodeArgument(source, s.tail().headOfSingleton()) and
       result.asParameter() = getCallable(arg).getParam(pos.getPosition())
     )
     or
     result.(RustDataFlow::PostUpdateNode).getPreUpdateNode().asExpr().getExpr() =
-      getSourceNodeArgument(source, s.head())
+      getSourceNodeArgument(source, s.headOfSingleton())
   }
 
   RustDataFlow::Node getSinkNode(Input::SinkBase sink, Impl::Private::SummaryComponent sc) {

--- a/rust/ql/lib/codeql/rust/dataflow/internal/FlowSummaryImpl.qll
+++ b/rust/ql/lib/codeql/rust/dataflow/internal/FlowSummaryImpl.qll
@@ -6,7 +6,10 @@ private import rust
 private import codeql.dataflow.internal.FlowSummaryImpl
 private import codeql.dataflow.internal.AccessPathSyntax as AccessPath
 private import codeql.rust.dataflow.internal.DataFlowImpl
+private import codeql.rust.internal.PathResolution
 private import codeql.rust.dataflow.FlowSummary
+private import codeql.rust.dataflow.Ssa
+private import codeql.rust.controlflow.CfgNodes
 private import Content
 
 module Input implements InputSig<Location, RustDataFlow> {
@@ -133,16 +136,44 @@ private module StepsInput implements Impl::Private::StepsInputSig {
     result.asCallCfgNode().getCall().getStaticTarget() = sc
   }
 
-  RustDataFlow::Node getSourceNode(Input::SourceBase source, Impl::Private::SummaryComponent sc) {
-    sc = Impl::Private::SummaryComponent::return(_) and
+  /** Gets the argument of `source` described by `sc`, if any. */
+  private Expr getSourceNodeArgument(Input::SourceBase source, Impl::Private::SummaryComponent sc) {
+    exists(ArgumentPosition pos |
+      sc = Impl::Private::SummaryComponent::argument(pos) and
+      result = pos.getArgument(source.getCall())
+    )
+  }
+
+  /** Get the callable that `expr` refers to. */
+  private Callable getCallable(Expr expr) {
+    result = resolvePath(expr.(PathExpr).getPath()).(Function)
+    or
+    result = expr.(ClosureExpr)
+    or
+    // The expression is an SSA read of an assignment of a closure
+    exists(Ssa::Definition def, ExprCfgNode value |
+      def.getARead().getAstNode() = expr and
+      def.getAnUltimateDefinition().(Ssa::WriteDefinition).assigns(value) and
+      result = value.getExpr().(ClosureExpr)
+    )
+  }
+
+  RustDataFlow::DataFlowCallable getSourceNodeEnclosingCallable(Input::SourceBase source) {
+    result.asCfgScope() = source.getEnclosingCfgScope()
+  }
+
+  RustDataFlow::Node getSourceNode(Input::SourceBase source, Impl::Private::SummaryComponentStack s) {
+    s.head() = Impl::Private::SummaryComponent::return(_) and
     result.asExpr().getExpr() = source.getCall()
     or
-    exists(CallExprBase call, Expr arg, ArgumentPosition pos |
-      result.(RustDataFlow::PostUpdateNode).getPreUpdateNode().asExpr().getExpr() = arg and
-      sc = Impl::Private::SummaryComponent::argument(pos) and
-      call = source.getCall() and
-      arg = pos.getArgument(call)
+    exists(ArgumentPosition pos, Expr arg |
+      s.head() = Impl::Private::SummaryComponent::parameter(pos) and
+      arg = getSourceNodeArgument(source, s.tail().head()) and
+      result.asParameter() = getCallable(arg).getParam(pos.getPosition())
     )
+    or
+    result.(RustDataFlow::PostUpdateNode).getPreUpdateNode().asExpr().getExpr() =
+      getSourceNodeArgument(source, s.head())
   }
 
   RustDataFlow::Node getSinkNode(Input::SinkBase sink, Impl::Private::SummaryComponent sc) {

--- a/rust/ql/lib/utils/test/InlineFlowTest.qll
+++ b/rust/ql/lib/utils/test/InlineFlowTest.qll
@@ -34,10 +34,9 @@ private module FlowTestImpl implements InputSig<Location, RustDataFlow> {
     result = src.asExpr().(CallExprCfgNode).getArgument(0).toString()
     or
     sourceNode(src, _) and
-    exists(CallExprBase call |
-      call = src.(Node::FlowSummaryNode).getSourceElement().getCall() and
-      result = call.getArgList().getArg(0).toString()
-    )
+    result = src.(Node::FlowSummaryNode).getSourceElement().getCall().getArg(0).toString() and
+    // Don't use the result if it contains spaces
+    not result.matches("% %")
   }
 
   bindingset[src, sink]

--- a/rust/ql/test/library-tests/dataflow/models/CONSISTENCY/PathResolutionConsistency.expected
+++ b/rust/ql/test/library-tests/dataflow/models/CONSISTENCY/PathResolutionConsistency.expected
@@ -1,2 +1,2 @@
 multipleCallTargets
-| main.rs:362:14:362:30 | ... .lt(...) |
+| main.rs:389:14:389:30 | ... .lt(...) |

--- a/rust/ql/test/library-tests/dataflow/models/main.rs
+++ b/rust/ql/test/library-tests/dataflow/models/main.rs
@@ -249,6 +249,33 @@ fn test_enum_method_source() {
     }
 }
 
+mod source_into_function {
+    use super::sink;
+
+    // has a source model
+    fn pass_source<A>(_i: i64, f: impl FnOnce(i64) -> A) -> A {
+        f(42)
+    }
+
+    fn test_source_into_function() {
+        let a = |a| sink(a); // $ MISSING: hasValueFlow=1
+        pass_source(1, a);
+
+        pass_source(2, |a| {
+            sink(a); // $ MISSING: hasValueFlow=2
+        });
+
+        fn f(a: i64) {
+            sink(a) // $ MISSING: hasValueFlow=3
+        }
+        pass_source(3, f);
+
+        pass_source(4, async move |a| {
+            sink(a); // $ MISSING: hasValueFlow=4
+        });
+    }
+}
+
 // has a sink model
 fn enum_sink(e: MyFieldEnum) {}
 

--- a/rust/ql/test/library-tests/dataflow/models/main.rs
+++ b/rust/ql/test/library-tests/dataflow/models/main.rs
@@ -258,20 +258,20 @@ mod source_into_function {
     }
 
     fn test_source_into_function() {
-        let a = |a| sink(a); // $ MISSING: hasValueFlow=1
+        let a = |a| sink(a); // $ hasValueFlow=1
         pass_source(1, a);
 
         pass_source(2, |a| {
-            sink(a); // $ MISSING: hasValueFlow=2
+            sink(a); // $ hasValueFlow=2
         });
 
         fn f(a: i64) {
-            sink(a) // $ MISSING: hasValueFlow=3
+            sink(a) // $ hasValueFlow=3
         }
         pass_source(3, f);
 
         pass_source(4, async move |a| {
-            sink(a); // $ MISSING: hasValueFlow=4
+            sink(a); // $ hasValueFlow=4
         });
     }
 }

--- a/rust/ql/test/library-tests/dataflow/models/models.expected
+++ b/rust/ql/test/library-tests/dataflow/models/models.expected
@@ -6,22 +6,23 @@ models
 | 5 | Source: main::arg_source; Argument[0]; test-source |
 | 6 | Source: main::enum_source; ReturnValue.Field[main::MyFieldEnum::D::field_d]; test-source |
 | 7 | Source: main::simple_source; ReturnValue; test-source |
-| 8 | Summary: <_ as core::cmp::Ord>::max; Argument[self]; ReturnValue; value |
-| 9 | Summary: <_ as core::cmp::PartialOrd>::lt; Argument[self].Reference; ReturnValue; taint |
-| 10 | Summary: main::apply; Argument[0]; Argument[1].Parameter[0]; value |
-| 11 | Summary: main::apply; Argument[1].ReturnValue; ReturnValue; value |
-| 12 | Summary: main::coerce; Argument[0]; ReturnValue; taint |
-| 13 | Summary: main::get_array_element; Argument[0].Element; ReturnValue; value |
-| 14 | Summary: main::get_async_number; Argument[0]; ReturnValue.Future; value |
-| 15 | Summary: main::get_struct_field; Argument[0].Field[main::MyStruct::field1]; ReturnValue; value |
-| 16 | Summary: main::get_tuple_element; Argument[0].Field[0]; ReturnValue; value |
-| 17 | Summary: main::get_var_field; Argument[0].Field[main::MyFieldEnum::C::field_c]; ReturnValue; value |
-| 18 | Summary: main::get_var_pos; Argument[0].Field[main::MyPosEnum::A(0)]; ReturnValue; value |
-| 19 | Summary: main::set_array_element; Argument[0]; ReturnValue.Element; value |
-| 20 | Summary: main::set_struct_field; Argument[0]; ReturnValue.Field[main::MyStruct::field2]; value |
-| 21 | Summary: main::set_tuple_element; Argument[0]; ReturnValue.Field[1]; value |
-| 22 | Summary: main::set_var_field; Argument[0]; ReturnValue.Field[main::MyFieldEnum::D::field_d]; value |
-| 23 | Summary: main::set_var_pos; Argument[0]; ReturnValue.Field[main::MyPosEnum::B(0)]; value |
+| 8 | Source: main::source_into_function::pass_source; Argument[1].Parameter[0]; test-source |
+| 9 | Summary: <_ as core::cmp::Ord>::max; Argument[self]; ReturnValue; value |
+| 10 | Summary: <_ as core::cmp::PartialOrd>::lt; Argument[self].Reference; ReturnValue; taint |
+| 11 | Summary: main::apply; Argument[0]; Argument[1].Parameter[0]; value |
+| 12 | Summary: main::apply; Argument[1].ReturnValue; ReturnValue; value |
+| 13 | Summary: main::coerce; Argument[0]; ReturnValue; taint |
+| 14 | Summary: main::get_array_element; Argument[0].Element; ReturnValue; value |
+| 15 | Summary: main::get_async_number; Argument[0]; ReturnValue.Future; value |
+| 16 | Summary: main::get_struct_field; Argument[0].Field[main::MyStruct::field1]; ReturnValue; value |
+| 17 | Summary: main::get_tuple_element; Argument[0].Field[0]; ReturnValue; value |
+| 18 | Summary: main::get_var_field; Argument[0].Field[main::MyFieldEnum::C::field_c]; ReturnValue; value |
+| 19 | Summary: main::get_var_pos; Argument[0].Field[main::MyPosEnum::A(0)]; ReturnValue; value |
+| 20 | Summary: main::set_array_element; Argument[0]; ReturnValue.Element; value |
+| 21 | Summary: main::set_struct_field; Argument[0]; ReturnValue.Field[main::MyStruct::field2]; value |
+| 22 | Summary: main::set_tuple_element; Argument[0]; ReturnValue.Field[1]; value |
+| 23 | Summary: main::set_var_field; Argument[0]; ReturnValue.Field[main::MyFieldEnum::D::field_d]; value |
+| 24 | Summary: main::set_var_pos; Argument[0]; ReturnValue.Field[main::MyPosEnum::B(0)]; value |
 edges
 | main.rs:15:9:15:9 | s | main.rs:16:19:16:19 | s | provenance |  |
 | main.rs:15:9:15:9 | s | main.rs:16:19:16:19 | s | provenance |  |
@@ -31,7 +32,7 @@ edges
 | main.rs:16:19:16:19 | s | main.rs:16:10:16:20 | identity(...) | provenance | QL |
 | main.rs:25:9:25:9 | s | main.rs:26:17:26:17 | s | provenance |  |
 | main.rs:25:13:25:22 | source(...) | main.rs:25:9:25:9 | s | provenance |  |
-| main.rs:26:17:26:17 | s | main.rs:26:10:26:18 | coerce(...) | provenance | MaD:12 |
+| main.rs:26:17:26:17 | s | main.rs:26:10:26:18 | coerce(...) | provenance | MaD:13 |
 | main.rs:40:9:40:9 | s | main.rs:41:27:41:27 | s | provenance |  |
 | main.rs:40:9:40:9 | s | main.rs:41:27:41:27 | s | provenance |  |
 | main.rs:40:13:40:21 | source(...) | main.rs:40:9:40:9 | s | provenance |  |
@@ -42,8 +43,8 @@ edges
 | main.rs:41:14:41:28 | ...::A(...) [A] | main.rs:41:9:41:10 | e1 [A] | provenance |  |
 | main.rs:41:27:41:27 | s | main.rs:41:14:41:28 | ...::A(...) [A] | provenance |  |
 | main.rs:41:27:41:27 | s | main.rs:41:14:41:28 | ...::A(...) [A] | provenance |  |
-| main.rs:42:22:42:23 | e1 [A] | main.rs:42:10:42:24 | get_var_pos(...) | provenance | MaD:18 |
-| main.rs:42:22:42:23 | e1 [A] | main.rs:42:10:42:24 | get_var_pos(...) | provenance | MaD:18 |
+| main.rs:42:22:42:23 | e1 [A] | main.rs:42:10:42:24 | get_var_pos(...) | provenance | MaD:19 |
+| main.rs:42:22:42:23 | e1 [A] | main.rs:42:10:42:24 | get_var_pos(...) | provenance | MaD:19 |
 | main.rs:53:9:53:9 | s | main.rs:54:26:54:26 | s | provenance |  |
 | main.rs:53:9:53:9 | s | main.rs:54:26:54:26 | s | provenance |  |
 | main.rs:53:13:53:21 | source(...) | main.rs:53:9:53:9 | s | provenance |  |
@@ -52,8 +53,8 @@ edges
 | main.rs:54:9:54:10 | e1 [B] | main.rs:55:11:55:12 | e1 [B] | provenance |  |
 | main.rs:54:14:54:27 | set_var_pos(...) [B] | main.rs:54:9:54:10 | e1 [B] | provenance |  |
 | main.rs:54:14:54:27 | set_var_pos(...) [B] | main.rs:54:9:54:10 | e1 [B] | provenance |  |
-| main.rs:54:26:54:26 | s | main.rs:54:14:54:27 | set_var_pos(...) [B] | provenance | MaD:23 |
-| main.rs:54:26:54:26 | s | main.rs:54:14:54:27 | set_var_pos(...) [B] | provenance | MaD:23 |
+| main.rs:54:26:54:26 | s | main.rs:54:14:54:27 | set_var_pos(...) [B] | provenance | MaD:24 |
+| main.rs:54:26:54:26 | s | main.rs:54:14:54:27 | set_var_pos(...) [B] | provenance | MaD:24 |
 | main.rs:55:11:55:12 | e1 [B] | main.rs:57:9:57:23 | ...::B(...) [B] | provenance |  |
 | main.rs:55:11:55:12 | e1 [B] | main.rs:57:9:57:23 | ...::B(...) [B] | provenance |  |
 | main.rs:57:9:57:23 | ...::B(...) [B] | main.rs:57:22:57:22 | i | provenance |  |
@@ -70,8 +71,8 @@ edges
 | main.rs:73:14:73:42 | ...::C {...} [C] | main.rs:73:9:73:10 | e1 [C] | provenance |  |
 | main.rs:73:40:73:40 | s | main.rs:73:14:73:42 | ...::C {...} [C] | provenance |  |
 | main.rs:73:40:73:40 | s | main.rs:73:14:73:42 | ...::C {...} [C] | provenance |  |
-| main.rs:74:24:74:25 | e1 [C] | main.rs:74:10:74:26 | get_var_field(...) | provenance | MaD:17 |
-| main.rs:74:24:74:25 | e1 [C] | main.rs:74:10:74:26 | get_var_field(...) | provenance | MaD:17 |
+| main.rs:74:24:74:25 | e1 [C] | main.rs:74:10:74:26 | get_var_field(...) | provenance | MaD:18 |
+| main.rs:74:24:74:25 | e1 [C] | main.rs:74:10:74:26 | get_var_field(...) | provenance | MaD:18 |
 | main.rs:85:9:85:9 | s | main.rs:86:28:86:28 | s | provenance |  |
 | main.rs:85:9:85:9 | s | main.rs:86:28:86:28 | s | provenance |  |
 | main.rs:85:13:85:21 | source(...) | main.rs:85:9:85:9 | s | provenance |  |
@@ -80,8 +81,8 @@ edges
 | main.rs:86:9:86:10 | e1 [D] | main.rs:87:11:87:12 | e1 [D] | provenance |  |
 | main.rs:86:14:86:29 | set_var_field(...) [D] | main.rs:86:9:86:10 | e1 [D] | provenance |  |
 | main.rs:86:14:86:29 | set_var_field(...) [D] | main.rs:86:9:86:10 | e1 [D] | provenance |  |
-| main.rs:86:28:86:28 | s | main.rs:86:14:86:29 | set_var_field(...) [D] | provenance | MaD:22 |
-| main.rs:86:28:86:28 | s | main.rs:86:14:86:29 | set_var_field(...) [D] | provenance | MaD:22 |
+| main.rs:86:28:86:28 | s | main.rs:86:14:86:29 | set_var_field(...) [D] | provenance | MaD:23 |
+| main.rs:86:28:86:28 | s | main.rs:86:14:86:29 | set_var_field(...) [D] | provenance | MaD:23 |
 | main.rs:87:11:87:12 | e1 [D] | main.rs:89:9:89:37 | ...::D {...} [D] | provenance |  |
 | main.rs:87:11:87:12 | e1 [D] | main.rs:89:9:89:37 | ...::D {...} [D] | provenance |  |
 | main.rs:89:9:89:37 | ...::D {...} [D] | main.rs:89:35:89:35 | i | provenance |  |
@@ -98,8 +99,8 @@ edges
 | main.rs:105:21:108:5 | MyStruct {...} [MyStruct.field1] | main.rs:105:9:105:17 | my_struct [MyStruct.field1] | provenance |  |
 | main.rs:106:17:106:17 | s | main.rs:105:21:108:5 | MyStruct {...} [MyStruct.field1] | provenance |  |
 | main.rs:106:17:106:17 | s | main.rs:105:21:108:5 | MyStruct {...} [MyStruct.field1] | provenance |  |
-| main.rs:109:27:109:35 | my_struct [MyStruct.field1] | main.rs:109:10:109:36 | get_struct_field(...) | provenance | MaD:15 |
-| main.rs:109:27:109:35 | my_struct [MyStruct.field1] | main.rs:109:10:109:36 | get_struct_field(...) | provenance | MaD:15 |
+| main.rs:109:27:109:35 | my_struct [MyStruct.field1] | main.rs:109:10:109:36 | get_struct_field(...) | provenance | MaD:16 |
+| main.rs:109:27:109:35 | my_struct [MyStruct.field1] | main.rs:109:10:109:36 | get_struct_field(...) | provenance | MaD:16 |
 | main.rs:126:9:126:9 | s | main.rs:127:38:127:38 | s | provenance |  |
 | main.rs:126:9:126:9 | s | main.rs:127:38:127:38 | s | provenance |  |
 | main.rs:126:13:126:21 | source(...) | main.rs:126:9:126:9 | s | provenance |  |
@@ -108,16 +109,16 @@ edges
 | main.rs:127:9:127:17 | my_struct [MyStruct.field2] | main.rs:129:10:129:18 | my_struct [MyStruct.field2] | provenance |  |
 | main.rs:127:21:127:39 | set_struct_field(...) [MyStruct.field2] | main.rs:127:9:127:17 | my_struct [MyStruct.field2] | provenance |  |
 | main.rs:127:21:127:39 | set_struct_field(...) [MyStruct.field2] | main.rs:127:9:127:17 | my_struct [MyStruct.field2] | provenance |  |
-| main.rs:127:38:127:38 | s | main.rs:127:21:127:39 | set_struct_field(...) [MyStruct.field2] | provenance | MaD:20 |
-| main.rs:127:38:127:38 | s | main.rs:127:21:127:39 | set_struct_field(...) [MyStruct.field2] | provenance | MaD:20 |
+| main.rs:127:38:127:38 | s | main.rs:127:21:127:39 | set_struct_field(...) [MyStruct.field2] | provenance | MaD:21 |
+| main.rs:127:38:127:38 | s | main.rs:127:21:127:39 | set_struct_field(...) [MyStruct.field2] | provenance | MaD:21 |
 | main.rs:129:10:129:18 | my_struct [MyStruct.field2] | main.rs:129:10:129:25 | my_struct.field2 | provenance |  |
 | main.rs:129:10:129:18 | my_struct [MyStruct.field2] | main.rs:129:10:129:25 | my_struct.field2 | provenance |  |
 | main.rs:138:9:138:9 | s | main.rs:139:29:139:29 | s | provenance |  |
 | main.rs:138:9:138:9 | s | main.rs:139:29:139:29 | s | provenance |  |
 | main.rs:138:13:138:21 | source(...) | main.rs:138:9:138:9 | s | provenance |  |
 | main.rs:138:13:138:21 | source(...) | main.rs:138:9:138:9 | s | provenance |  |
-| main.rs:139:28:139:30 | [...] [element] | main.rs:139:10:139:31 | get_array_element(...) | provenance | MaD:13 |
-| main.rs:139:28:139:30 | [...] [element] | main.rs:139:10:139:31 | get_array_element(...) | provenance | MaD:13 |
+| main.rs:139:28:139:30 | [...] [element] | main.rs:139:10:139:31 | get_array_element(...) | provenance | MaD:14 |
+| main.rs:139:28:139:30 | [...] [element] | main.rs:139:10:139:31 | get_array_element(...) | provenance | MaD:14 |
 | main.rs:139:29:139:29 | s | main.rs:139:28:139:30 | [...] [element] | provenance |  |
 | main.rs:139:29:139:29 | s | main.rs:139:28:139:30 | [...] [element] | provenance |  |
 | main.rs:148:9:148:9 | s | main.rs:149:33:149:33 | s | provenance |  |
@@ -128,8 +129,8 @@ edges
 | main.rs:149:9:149:11 | arr [element] | main.rs:150:10:150:12 | arr [element] | provenance |  |
 | main.rs:149:15:149:34 | set_array_element(...) [element] | main.rs:149:9:149:11 | arr [element] | provenance |  |
 | main.rs:149:15:149:34 | set_array_element(...) [element] | main.rs:149:9:149:11 | arr [element] | provenance |  |
-| main.rs:149:33:149:33 | s | main.rs:149:15:149:34 | set_array_element(...) [element] | provenance | MaD:19 |
-| main.rs:149:33:149:33 | s | main.rs:149:15:149:34 | set_array_element(...) [element] | provenance | MaD:19 |
+| main.rs:149:33:149:33 | s | main.rs:149:15:149:34 | set_array_element(...) [element] | provenance | MaD:20 |
+| main.rs:149:33:149:33 | s | main.rs:149:15:149:34 | set_array_element(...) [element] | provenance | MaD:20 |
 | main.rs:150:10:150:12 | arr [element] | main.rs:150:10:150:15 | arr[0] | provenance |  |
 | main.rs:150:10:150:12 | arr [element] | main.rs:150:10:150:15 | arr[0] | provenance |  |
 | main.rs:159:9:159:9 | s | main.rs:160:14:160:14 | s | provenance |  |
@@ -142,8 +143,8 @@ edges
 | main.rs:160:13:160:18 | TupleExpr [tuple.0] | main.rs:160:9:160:9 | t [tuple.0] | provenance |  |
 | main.rs:160:14:160:14 | s | main.rs:160:13:160:18 | TupleExpr [tuple.0] | provenance |  |
 | main.rs:160:14:160:14 | s | main.rs:160:13:160:18 | TupleExpr [tuple.0] | provenance |  |
-| main.rs:161:28:161:28 | t [tuple.0] | main.rs:161:10:161:29 | get_tuple_element(...) | provenance | MaD:16 |
-| main.rs:161:28:161:28 | t [tuple.0] | main.rs:161:10:161:29 | get_tuple_element(...) | provenance | MaD:16 |
+| main.rs:161:28:161:28 | t [tuple.0] | main.rs:161:10:161:29 | get_tuple_element(...) | provenance | MaD:17 |
+| main.rs:161:28:161:28 | t [tuple.0] | main.rs:161:10:161:29 | get_tuple_element(...) | provenance | MaD:17 |
 | main.rs:172:9:172:9 | s | main.rs:173:31:173:31 | s | provenance |  |
 | main.rs:172:9:172:9 | s | main.rs:173:31:173:31 | s | provenance |  |
 | main.rs:172:13:172:22 | source(...) | main.rs:172:9:172:9 | s | provenance |  |
@@ -152,8 +153,8 @@ edges
 | main.rs:173:9:173:9 | t [tuple.1] | main.rs:175:10:175:10 | t [tuple.1] | provenance |  |
 | main.rs:173:13:173:32 | set_tuple_element(...) [tuple.1] | main.rs:173:9:173:9 | t [tuple.1] | provenance |  |
 | main.rs:173:13:173:32 | set_tuple_element(...) [tuple.1] | main.rs:173:9:173:9 | t [tuple.1] | provenance |  |
-| main.rs:173:31:173:31 | s | main.rs:173:13:173:32 | set_tuple_element(...) [tuple.1] | provenance | MaD:21 |
-| main.rs:173:31:173:31 | s | main.rs:173:13:173:32 | set_tuple_element(...) [tuple.1] | provenance | MaD:21 |
+| main.rs:173:31:173:31 | s | main.rs:173:13:173:32 | set_tuple_element(...) [tuple.1] | provenance | MaD:22 |
+| main.rs:173:31:173:31 | s | main.rs:173:13:173:32 | set_tuple_element(...) [tuple.1] | provenance | MaD:22 |
 | main.rs:175:10:175:10 | t [tuple.1] | main.rs:175:10:175:12 | t.1 | provenance |  |
 | main.rs:175:10:175:10 | t [tuple.1] | main.rs:175:10:175:12 | t.1 | provenance |  |
 | main.rs:187:9:187:9 | s | main.rs:192:11:192:11 | s | provenance |  |
@@ -162,8 +163,8 @@ edges
 | main.rs:187:13:187:22 | source(...) | main.rs:187:9:187:9 | s | provenance |  |
 | main.rs:188:14:188:14 | ... | main.rs:189:14:189:14 | n | provenance |  |
 | main.rs:188:14:188:14 | ... | main.rs:189:14:189:14 | n | provenance |  |
-| main.rs:192:11:192:11 | s | main.rs:188:14:188:14 | ... | provenance | MaD:10 |
-| main.rs:192:11:192:11 | s | main.rs:188:14:188:14 | ... | provenance | MaD:10 |
+| main.rs:192:11:192:11 | s | main.rs:188:14:188:14 | ... | provenance | MaD:11 |
+| main.rs:192:11:192:11 | s | main.rs:188:14:188:14 | ... | provenance | MaD:11 |
 | main.rs:196:13:196:22 | source(...) | main.rs:198:23:198:23 | f [captured s] | provenance |  |
 | main.rs:196:13:196:22 | source(...) | main.rs:198:23:198:23 | f [captured s] | provenance |  |
 | main.rs:197:40:197:40 | s | main.rs:197:17:197:42 | if ... {...} else {...} | provenance |  |
@@ -172,14 +173,14 @@ edges
 | main.rs:198:9:198:9 | t | main.rs:199:10:199:10 | t | provenance |  |
 | main.rs:198:13:198:24 | apply(...) | main.rs:198:9:198:9 | t | provenance |  |
 | main.rs:198:13:198:24 | apply(...) | main.rs:198:9:198:9 | t | provenance |  |
-| main.rs:198:23:198:23 | f [captured s] | main.rs:197:40:197:40 | s | provenance | MaD:10 |
-| main.rs:198:23:198:23 | f [captured s] | main.rs:197:40:197:40 | s | provenance | MaD:10 |
 | main.rs:198:23:198:23 | f [captured s] | main.rs:197:40:197:40 | s | provenance | MaD:11 |
 | main.rs:198:23:198:23 | f [captured s] | main.rs:197:40:197:40 | s | provenance | MaD:11 |
-| main.rs:198:23:198:23 | f [captured s] | main.rs:198:13:198:24 | apply(...) | provenance | MaD:10 |
-| main.rs:198:23:198:23 | f [captured s] | main.rs:198:13:198:24 | apply(...) | provenance | MaD:10 |
+| main.rs:198:23:198:23 | f [captured s] | main.rs:197:40:197:40 | s | provenance | MaD:12 |
+| main.rs:198:23:198:23 | f [captured s] | main.rs:197:40:197:40 | s | provenance | MaD:12 |
 | main.rs:198:23:198:23 | f [captured s] | main.rs:198:13:198:24 | apply(...) | provenance | MaD:11 |
 | main.rs:198:23:198:23 | f [captured s] | main.rs:198:13:198:24 | apply(...) | provenance | MaD:11 |
+| main.rs:198:23:198:23 | f [captured s] | main.rs:198:13:198:24 | apply(...) | provenance | MaD:12 |
+| main.rs:198:23:198:23 | f [captured s] | main.rs:198:13:198:24 | apply(...) | provenance | MaD:12 |
 | main.rs:203:9:203:9 | s | main.rs:205:19:205:19 | s | provenance |  |
 | main.rs:203:9:203:9 | s | main.rs:205:19:205:19 | s | provenance |  |
 | main.rs:203:13:203:22 | source(...) | main.rs:203:9:203:9 | s | provenance |  |
@@ -190,10 +191,10 @@ edges
 | main.rs:205:9:205:9 | t | main.rs:206:10:206:10 | t | provenance |  |
 | main.rs:205:13:205:23 | apply(...) | main.rs:205:9:205:9 | t | provenance |  |
 | main.rs:205:13:205:23 | apply(...) | main.rs:205:9:205:9 | t | provenance |  |
-| main.rs:205:19:205:19 | s | main.rs:204:14:204:14 | ... | provenance | MaD:10 |
-| main.rs:205:19:205:19 | s | main.rs:204:14:204:14 | ... | provenance | MaD:10 |
-| main.rs:205:19:205:19 | s | main.rs:205:13:205:23 | apply(...) | provenance | MaD:10 |
-| main.rs:205:19:205:19 | s | main.rs:205:13:205:23 | apply(...) | provenance | MaD:10 |
+| main.rs:205:19:205:19 | s | main.rs:204:14:204:14 | ... | provenance | MaD:11 |
+| main.rs:205:19:205:19 | s | main.rs:204:14:204:14 | ... | provenance | MaD:11 |
+| main.rs:205:19:205:19 | s | main.rs:205:13:205:23 | apply(...) | provenance | MaD:11 |
+| main.rs:205:19:205:19 | s | main.rs:205:13:205:23 | apply(...) | provenance | MaD:11 |
 | main.rs:215:9:215:9 | s | main.rs:216:30:216:30 | s | provenance |  |
 | main.rs:215:9:215:9 | s | main.rs:216:30:216:30 | s | provenance |  |
 | main.rs:215:13:215:22 | source(...) | main.rs:215:9:215:9 | s | provenance |  |
@@ -204,8 +205,8 @@ edges
 | main.rs:216:13:216:31 | get_async_number(...) [future] | main.rs:216:13:216:37 | await ... | provenance |  |
 | main.rs:216:13:216:37 | await ... | main.rs:216:9:216:9 | t | provenance |  |
 | main.rs:216:13:216:37 | await ... | main.rs:216:9:216:9 | t | provenance |  |
-| main.rs:216:30:216:30 | s | main.rs:216:13:216:31 | get_async_number(...) [future] | provenance | MaD:14 |
-| main.rs:216:30:216:30 | s | main.rs:216:13:216:31 | get_async_number(...) [future] | provenance | MaD:14 |
+| main.rs:216:30:216:30 | s | main.rs:216:13:216:31 | get_async_number(...) [future] | provenance | MaD:15 |
+| main.rs:216:30:216:30 | s | main.rs:216:13:216:31 | get_async_number(...) [future] | provenance | MaD:15 |
 | main.rs:236:9:236:9 | s [D] | main.rs:237:11:237:11 | s [D] | provenance |  |
 | main.rs:236:9:236:9 | s [D] | main.rs:237:11:237:11 | s [D] | provenance |  |
 | main.rs:236:13:236:23 | enum_source | main.rs:236:13:236:27 | enum_source(...) [D] | provenance | Src:MaD:6  |
@@ -230,6 +231,22 @@ edges
 | main.rs:247:9:247:37 | ...::C {...} [C] | main.rs:247:35:247:35 | i | provenance |  |
 | main.rs:247:35:247:35 | i | main.rs:247:47:247:47 | i | provenance |  |
 | main.rs:247:35:247:35 | i | main.rs:247:47:247:47 | i | provenance |  |
+| main.rs:261:18:261:18 | ... | main.rs:261:26:261:26 | a | provenance |  |
+| main.rs:261:18:261:18 | ... | main.rs:261:26:261:26 | a | provenance |  |
+| main.rs:262:9:262:19 | pass_source | main.rs:261:18:261:18 | ... | provenance | Src:MaD:8 MaD:8 |
+| main.rs:262:9:262:19 | pass_source | main.rs:261:18:261:18 | ... | provenance | Src:MaD:8 MaD:8 |
+| main.rs:264:9:264:19 | pass_source | main.rs:264:25:264:25 | ... | provenance | Src:MaD:8 MaD:8 |
+| main.rs:264:9:264:19 | pass_source | main.rs:264:25:264:25 | ... | provenance | Src:MaD:8 MaD:8 |
+| main.rs:264:25:264:25 | ... | main.rs:265:18:265:18 | a | provenance |  |
+| main.rs:264:25:264:25 | ... | main.rs:265:18:265:18 | a | provenance |  |
+| main.rs:268:14:268:19 | ...: i64 | main.rs:269:18:269:18 | a | provenance |  |
+| main.rs:268:14:268:19 | ...: i64 | main.rs:269:18:269:18 | a | provenance |  |
+| main.rs:271:9:271:19 | pass_source | main.rs:268:14:268:19 | ...: i64 | provenance | Src:MaD:8 MaD:8 |
+| main.rs:271:9:271:19 | pass_source | main.rs:268:14:268:19 | ...: i64 | provenance | Src:MaD:8 MaD:8 |
+| main.rs:273:9:273:19 | pass_source | main.rs:273:36:273:36 | ... | provenance | Src:MaD:8 MaD:8 |
+| main.rs:273:9:273:19 | pass_source | main.rs:273:36:273:36 | ... | provenance | Src:MaD:8 MaD:8 |
+| main.rs:273:36:273:36 | ... | main.rs:274:18:274:18 | a | provenance |  |
+| main.rs:273:36:273:36 | ... | main.rs:274:18:274:18 | a | provenance |  |
 | main.rs:283:9:283:9 | s | main.rs:284:41:284:41 | s | provenance |  |
 | main.rs:283:9:283:9 | s | main.rs:284:41:284:41 | s | provenance |  |
 | main.rs:283:13:283:22 | source(...) | main.rs:283:9:283:9 | s | provenance |  |
@@ -268,31 +285,31 @@ edges
 | main.rs:317:16:317:16 | [post] i | main.rs:318:10:318:10 | i | provenance |  |
 | main.rs:370:9:370:10 | x1 | main.rs:371:10:371:11 | x1 | provenance |  |
 | main.rs:370:9:370:10 | x1 | main.rs:371:10:371:11 | x1 | provenance |  |
-| main.rs:370:14:370:23 | source(...) | main.rs:370:14:370:30 | ... .max(...) | provenance | MaD:8 |
-| main.rs:370:14:370:23 | source(...) | main.rs:370:14:370:30 | ... .max(...) | provenance | MaD:8 |
+| main.rs:370:14:370:23 | source(...) | main.rs:370:14:370:30 | ... .max(...) | provenance | MaD:9 |
+| main.rs:370:14:370:23 | source(...) | main.rs:370:14:370:30 | ... .max(...) | provenance | MaD:9 |
 | main.rs:370:14:370:30 | ... .max(...) | main.rs:370:9:370:10 | x1 | provenance |  |
 | main.rs:370:14:370:30 | ... .max(...) | main.rs:370:9:370:10 | x1 | provenance |  |
 | main.rs:373:9:373:10 | x2 [MyStruct.field1] | main.rs:381:10:381:11 | x2 [MyStruct.field1] | provenance |  |
 | main.rs:373:9:373:10 | x2 [MyStruct.field1] | main.rs:381:10:381:11 | x2 [MyStruct.field1] | provenance |  |
 | main.rs:373:14:380:6 | ... .max(...) [MyStruct.field1] | main.rs:373:9:373:10 | x2 [MyStruct.field1] | provenance |  |
 | main.rs:373:14:380:6 | ... .max(...) [MyStruct.field1] | main.rs:373:9:373:10 | x2 [MyStruct.field1] | provenance |  |
-| main.rs:373:15:376:5 | MyStruct {...} [MyStruct.field1] | main.rs:373:14:380:6 | ... .max(...) [MyStruct.field1] | provenance | MaD:8 |
-| main.rs:373:15:376:5 | MyStruct {...} [MyStruct.field1] | main.rs:373:14:380:6 | ... .max(...) [MyStruct.field1] | provenance | MaD:8 |
+| main.rs:373:15:376:5 | MyStruct {...} [MyStruct.field1] | main.rs:373:14:380:6 | ... .max(...) [MyStruct.field1] | provenance | MaD:9 |
+| main.rs:373:15:376:5 | MyStruct {...} [MyStruct.field1] | main.rs:373:14:380:6 | ... .max(...) [MyStruct.field1] | provenance | MaD:9 |
 | main.rs:374:17:374:26 | source(...) | main.rs:373:15:376:5 | MyStruct {...} [MyStruct.field1] | provenance |  |
 | main.rs:374:17:374:26 | source(...) | main.rs:373:15:376:5 | MyStruct {...} [MyStruct.field1] | provenance |  |
 | main.rs:381:10:381:11 | x2 [MyStruct.field1] | main.rs:381:10:381:18 | x2.field1 | provenance |  |
 | main.rs:381:10:381:11 | x2 [MyStruct.field1] | main.rs:381:10:381:18 | x2.field1 | provenance |  |
 | main.rs:386:9:386:10 | x4 | main.rs:387:10:387:11 | x4 | provenance |  |
 | main.rs:386:9:386:10 | x4 | main.rs:387:10:387:11 | x4 | provenance |  |
-| main.rs:386:14:386:23 | source(...) | main.rs:386:14:386:30 | ... .max(...) | provenance | MaD:8 |
-| main.rs:386:14:386:23 | source(...) | main.rs:386:14:386:30 | ... .max(...) | provenance | MaD:8 |
+| main.rs:386:14:386:23 | source(...) | main.rs:386:14:386:30 | ... .max(...) | provenance | MaD:9 |
+| main.rs:386:14:386:23 | source(...) | main.rs:386:14:386:30 | ... .max(...) | provenance | MaD:9 |
 | main.rs:386:14:386:30 | ... .max(...) | main.rs:386:9:386:10 | x4 | provenance |  |
 | main.rs:386:14:386:30 | ... .max(...) | main.rs:386:9:386:10 | x4 | provenance |  |
 | main.rs:389:9:389:10 | x5 | main.rs:390:10:390:11 | x5 | provenance |  |
-| main.rs:389:14:389:23 | source(...) | main.rs:389:14:389:30 | ... .lt(...) | provenance | MaD:9 |
+| main.rs:389:14:389:23 | source(...) | main.rs:389:14:389:30 | ... .lt(...) | provenance | MaD:10 |
 | main.rs:389:14:389:30 | ... .lt(...) | main.rs:389:9:389:10 | x5 | provenance |  |
 | main.rs:392:9:392:10 | x6 | main.rs:393:10:393:11 | x6 | provenance |  |
-| main.rs:392:14:392:23 | source(...) | main.rs:392:14:392:27 | ... < ... | provenance | MaD:9 |
+| main.rs:392:14:392:23 | source(...) | main.rs:392:14:392:27 | ... < ... | provenance | MaD:10 |
 | main.rs:392:14:392:27 | ... < ... | main.rs:392:9:392:10 | x6 | provenance |  |
 nodes
 | main.rs:15:9:15:9 | s | semmle.label | s |
@@ -533,6 +550,30 @@ nodes
 | main.rs:247:35:247:35 | i | semmle.label | i |
 | main.rs:247:47:247:47 | i | semmle.label | i |
 | main.rs:247:47:247:47 | i | semmle.label | i |
+| main.rs:261:18:261:18 | ... | semmle.label | ... |
+| main.rs:261:18:261:18 | ... | semmle.label | ... |
+| main.rs:261:26:261:26 | a | semmle.label | a |
+| main.rs:261:26:261:26 | a | semmle.label | a |
+| main.rs:262:9:262:19 | pass_source | semmle.label | pass_source |
+| main.rs:262:9:262:19 | pass_source | semmle.label | pass_source |
+| main.rs:264:9:264:19 | pass_source | semmle.label | pass_source |
+| main.rs:264:9:264:19 | pass_source | semmle.label | pass_source |
+| main.rs:264:25:264:25 | ... | semmle.label | ... |
+| main.rs:264:25:264:25 | ... | semmle.label | ... |
+| main.rs:265:18:265:18 | a | semmle.label | a |
+| main.rs:265:18:265:18 | a | semmle.label | a |
+| main.rs:268:14:268:19 | ...: i64 | semmle.label | ...: i64 |
+| main.rs:268:14:268:19 | ...: i64 | semmle.label | ...: i64 |
+| main.rs:269:18:269:18 | a | semmle.label | a |
+| main.rs:269:18:269:18 | a | semmle.label | a |
+| main.rs:271:9:271:19 | pass_source | semmle.label | pass_source |
+| main.rs:271:9:271:19 | pass_source | semmle.label | pass_source |
+| main.rs:273:9:273:19 | pass_source | semmle.label | pass_source |
+| main.rs:273:9:273:19 | pass_source | semmle.label | pass_source |
+| main.rs:273:36:273:36 | ... | semmle.label | ... |
+| main.rs:273:36:273:36 | ... | semmle.label | ... |
+| main.rs:274:18:274:18 | a | semmle.label | a |
+| main.rs:274:18:274:18 | a | semmle.label | a |
 | main.rs:283:9:283:9 | s | semmle.label | s |
 | main.rs:283:9:283:9 | s | semmle.label | s |
 | main.rs:283:13:283:22 | source(...) | semmle.label | source(...) |
@@ -658,6 +699,14 @@ invalidSpecComponent
 | main.rs:239:47:239:47 | i | main.rs:236:13:236:23 | enum_source | main.rs:239:47:239:47 | i | $@ | main.rs:236:13:236:23 | enum_source | enum_source |
 | main.rs:247:47:247:47 | i | main.rs:245:15:245:20 | source | main.rs:247:47:247:47 | i | $@ | main.rs:245:15:245:20 | source | source |
 | main.rs:247:47:247:47 | i | main.rs:245:15:245:20 | source | main.rs:247:47:247:47 | i | $@ | main.rs:245:15:245:20 | source | source |
+| main.rs:261:26:261:26 | a | main.rs:262:9:262:19 | pass_source | main.rs:261:26:261:26 | a | $@ | main.rs:262:9:262:19 | pass_source | pass_source |
+| main.rs:261:26:261:26 | a | main.rs:262:9:262:19 | pass_source | main.rs:261:26:261:26 | a | $@ | main.rs:262:9:262:19 | pass_source | pass_source |
+| main.rs:265:18:265:18 | a | main.rs:264:9:264:19 | pass_source | main.rs:265:18:265:18 | a | $@ | main.rs:264:9:264:19 | pass_source | pass_source |
+| main.rs:265:18:265:18 | a | main.rs:264:9:264:19 | pass_source | main.rs:265:18:265:18 | a | $@ | main.rs:264:9:264:19 | pass_source | pass_source |
+| main.rs:269:18:269:18 | a | main.rs:271:9:271:19 | pass_source | main.rs:269:18:269:18 | a | $@ | main.rs:271:9:271:19 | pass_source | pass_source |
+| main.rs:269:18:269:18 | a | main.rs:271:9:271:19 | pass_source | main.rs:269:18:269:18 | a | $@ | main.rs:271:9:271:19 | pass_source | pass_source |
+| main.rs:274:18:274:18 | a | main.rs:273:9:273:19 | pass_source | main.rs:274:18:274:18 | a | $@ | main.rs:273:9:273:19 | pass_source | pass_source |
+| main.rs:274:18:274:18 | a | main.rs:273:9:273:19 | pass_source | main.rs:274:18:274:18 | a | $@ | main.rs:273:9:273:19 | pass_source | pass_source |
 | main.rs:284:5:284:13 | enum_sink | main.rs:283:13:283:22 | source(...) | main.rs:284:5:284:13 | enum_sink | $@ | main.rs:283:13:283:22 | source(...) | source(...) |
 | main.rs:284:5:284:13 | enum_sink | main.rs:283:13:283:22 | source(...) | main.rs:284:5:284:13 | enum_sink | $@ | main.rs:283:13:283:22 | source(...) | source(...) |
 | main.rs:291:7:291:10 | sink | main.rs:289:13:289:22 | source(...) | main.rs:291:7:291:10 | sink | $@ | main.rs:289:13:289:22 | source(...) | source(...) |

--- a/rust/ql/test/library-tests/dataflow/models/models.expected
+++ b/rust/ql/test/library-tests/dataflow/models/models.expected
@@ -230,70 +230,70 @@ edges
 | main.rs:247:9:247:37 | ...::C {...} [C] | main.rs:247:35:247:35 | i | provenance |  |
 | main.rs:247:35:247:35 | i | main.rs:247:47:247:47 | i | provenance |  |
 | main.rs:247:35:247:35 | i | main.rs:247:47:247:47 | i | provenance |  |
-| main.rs:256:9:256:9 | s | main.rs:257:41:257:41 | s | provenance |  |
-| main.rs:256:9:256:9 | s | main.rs:257:41:257:41 | s | provenance |  |
-| main.rs:256:13:256:22 | source(...) | main.rs:256:9:256:9 | s | provenance |  |
-| main.rs:256:13:256:22 | source(...) | main.rs:256:9:256:9 | s | provenance |  |
-| main.rs:257:15:257:43 | ...::C {...} [C] | main.rs:257:5:257:13 | enum_sink | provenance | MaD:2 Sink:MaD:2 |
-| main.rs:257:15:257:43 | ...::C {...} [C] | main.rs:257:5:257:13 | enum_sink | provenance | MaD:2 Sink:MaD:2 |
-| main.rs:257:41:257:41 | s | main.rs:257:15:257:43 | ...::C {...} [C] | provenance |  |
-| main.rs:257:41:257:41 | s | main.rs:257:15:257:43 | ...::C {...} [C] | provenance |  |
-| main.rs:262:9:262:9 | s | main.rs:263:39:263:39 | s | provenance |  |
-| main.rs:262:9:262:9 | s | main.rs:263:39:263:39 | s | provenance |  |
-| main.rs:262:13:262:22 | source(...) | main.rs:262:9:262:9 | s | provenance |  |
-| main.rs:262:13:262:22 | source(...) | main.rs:262:9:262:9 | s | provenance |  |
-| main.rs:263:9:263:9 | e [D] | main.rs:264:5:264:5 | e [D] | provenance |  |
-| main.rs:263:9:263:9 | e [D] | main.rs:264:5:264:5 | e [D] | provenance |  |
-| main.rs:263:13:263:41 | ...::D {...} [D] | main.rs:263:9:263:9 | e [D] | provenance |  |
-| main.rs:263:13:263:41 | ...::D {...} [D] | main.rs:263:9:263:9 | e [D] | provenance |  |
-| main.rs:263:39:263:39 | s | main.rs:263:13:263:41 | ...::D {...} [D] | provenance |  |
-| main.rs:263:39:263:39 | s | main.rs:263:13:263:41 | ...::D {...} [D] | provenance |  |
-| main.rs:264:5:264:5 | e [D] | main.rs:264:7:264:10 | sink | provenance | MaD:1 Sink:MaD:1 |
-| main.rs:264:5:264:5 | e [D] | main.rs:264:7:264:10 | sink | provenance | MaD:1 Sink:MaD:1 |
-| main.rs:273:9:273:9 | s | main.rs:274:10:274:10 | s | provenance |  |
-| main.rs:273:9:273:9 | s | main.rs:274:10:274:10 | s | provenance |  |
-| main.rs:273:13:273:25 | simple_source | main.rs:273:13:273:29 | simple_source(...) | provenance | Src:MaD:7 MaD:7 |
-| main.rs:273:13:273:25 | simple_source | main.rs:273:13:273:29 | simple_source(...) | provenance | Src:MaD:7 MaD:7 |
-| main.rs:273:13:273:29 | simple_source(...) | main.rs:273:9:273:9 | s | provenance |  |
-| main.rs:273:13:273:29 | simple_source(...) | main.rs:273:9:273:9 | s | provenance |  |
-| main.rs:281:9:281:9 | s | main.rs:282:17:282:17 | s | provenance |  |
-| main.rs:281:9:281:9 | s | main.rs:282:17:282:17 | s | provenance |  |
-| main.rs:281:13:281:22 | source(...) | main.rs:281:9:281:9 | s | provenance |  |
-| main.rs:281:13:281:22 | source(...) | main.rs:281:9:281:9 | s | provenance |  |
-| main.rs:282:17:282:17 | s | main.rs:282:5:282:15 | simple_sink | provenance | MaD:3 Sink:MaD:3 |
-| main.rs:282:17:282:17 | s | main.rs:282:5:282:15 | simple_sink | provenance | MaD:3 Sink:MaD:3 |
-| main.rs:290:5:290:14 | arg_source | main.rs:290:16:290:16 | [post] i | provenance | Src:MaD:5 MaD:5 |
-| main.rs:290:5:290:14 | arg_source | main.rs:290:16:290:16 | [post] i | provenance | Src:MaD:5 MaD:5 |
-| main.rs:290:16:290:16 | [post] i | main.rs:291:10:291:10 | i | provenance |  |
-| main.rs:290:16:290:16 | [post] i | main.rs:291:10:291:10 | i | provenance |  |
-| main.rs:343:9:343:10 | x1 | main.rs:344:10:344:11 | x1 | provenance |  |
-| main.rs:343:9:343:10 | x1 | main.rs:344:10:344:11 | x1 | provenance |  |
-| main.rs:343:14:343:23 | source(...) | main.rs:343:14:343:30 | ... .max(...) | provenance | MaD:8 |
-| main.rs:343:14:343:23 | source(...) | main.rs:343:14:343:30 | ... .max(...) | provenance | MaD:8 |
-| main.rs:343:14:343:30 | ... .max(...) | main.rs:343:9:343:10 | x1 | provenance |  |
-| main.rs:343:14:343:30 | ... .max(...) | main.rs:343:9:343:10 | x1 | provenance |  |
-| main.rs:346:9:346:10 | x2 [MyStruct.field1] | main.rs:354:10:354:11 | x2 [MyStruct.field1] | provenance |  |
-| main.rs:346:9:346:10 | x2 [MyStruct.field1] | main.rs:354:10:354:11 | x2 [MyStruct.field1] | provenance |  |
-| main.rs:346:14:353:6 | ... .max(...) [MyStruct.field1] | main.rs:346:9:346:10 | x2 [MyStruct.field1] | provenance |  |
-| main.rs:346:14:353:6 | ... .max(...) [MyStruct.field1] | main.rs:346:9:346:10 | x2 [MyStruct.field1] | provenance |  |
-| main.rs:346:15:349:5 | MyStruct {...} [MyStruct.field1] | main.rs:346:14:353:6 | ... .max(...) [MyStruct.field1] | provenance | MaD:8 |
-| main.rs:346:15:349:5 | MyStruct {...} [MyStruct.field1] | main.rs:346:14:353:6 | ... .max(...) [MyStruct.field1] | provenance | MaD:8 |
-| main.rs:347:17:347:26 | source(...) | main.rs:346:15:349:5 | MyStruct {...} [MyStruct.field1] | provenance |  |
-| main.rs:347:17:347:26 | source(...) | main.rs:346:15:349:5 | MyStruct {...} [MyStruct.field1] | provenance |  |
-| main.rs:354:10:354:11 | x2 [MyStruct.field1] | main.rs:354:10:354:18 | x2.field1 | provenance |  |
-| main.rs:354:10:354:11 | x2 [MyStruct.field1] | main.rs:354:10:354:18 | x2.field1 | provenance |  |
-| main.rs:359:9:359:10 | x4 | main.rs:360:10:360:11 | x4 | provenance |  |
-| main.rs:359:9:359:10 | x4 | main.rs:360:10:360:11 | x4 | provenance |  |
-| main.rs:359:14:359:23 | source(...) | main.rs:359:14:359:30 | ... .max(...) | provenance | MaD:8 |
-| main.rs:359:14:359:23 | source(...) | main.rs:359:14:359:30 | ... .max(...) | provenance | MaD:8 |
-| main.rs:359:14:359:30 | ... .max(...) | main.rs:359:9:359:10 | x4 | provenance |  |
-| main.rs:359:14:359:30 | ... .max(...) | main.rs:359:9:359:10 | x4 | provenance |  |
-| main.rs:362:9:362:10 | x5 | main.rs:363:10:363:11 | x5 | provenance |  |
-| main.rs:362:14:362:23 | source(...) | main.rs:362:14:362:30 | ... .lt(...) | provenance | MaD:9 |
-| main.rs:362:14:362:30 | ... .lt(...) | main.rs:362:9:362:10 | x5 | provenance |  |
-| main.rs:365:9:365:10 | x6 | main.rs:366:10:366:11 | x6 | provenance |  |
-| main.rs:365:14:365:23 | source(...) | main.rs:365:14:365:27 | ... < ... | provenance | MaD:9 |
-| main.rs:365:14:365:27 | ... < ... | main.rs:365:9:365:10 | x6 | provenance |  |
+| main.rs:283:9:283:9 | s | main.rs:284:41:284:41 | s | provenance |  |
+| main.rs:283:9:283:9 | s | main.rs:284:41:284:41 | s | provenance |  |
+| main.rs:283:13:283:22 | source(...) | main.rs:283:9:283:9 | s | provenance |  |
+| main.rs:283:13:283:22 | source(...) | main.rs:283:9:283:9 | s | provenance |  |
+| main.rs:284:15:284:43 | ...::C {...} [C] | main.rs:284:5:284:13 | enum_sink | provenance | MaD:2 Sink:MaD:2 |
+| main.rs:284:15:284:43 | ...::C {...} [C] | main.rs:284:5:284:13 | enum_sink | provenance | MaD:2 Sink:MaD:2 |
+| main.rs:284:41:284:41 | s | main.rs:284:15:284:43 | ...::C {...} [C] | provenance |  |
+| main.rs:284:41:284:41 | s | main.rs:284:15:284:43 | ...::C {...} [C] | provenance |  |
+| main.rs:289:9:289:9 | s | main.rs:290:39:290:39 | s | provenance |  |
+| main.rs:289:9:289:9 | s | main.rs:290:39:290:39 | s | provenance |  |
+| main.rs:289:13:289:22 | source(...) | main.rs:289:9:289:9 | s | provenance |  |
+| main.rs:289:13:289:22 | source(...) | main.rs:289:9:289:9 | s | provenance |  |
+| main.rs:290:9:290:9 | e [D] | main.rs:291:5:291:5 | e [D] | provenance |  |
+| main.rs:290:9:290:9 | e [D] | main.rs:291:5:291:5 | e [D] | provenance |  |
+| main.rs:290:13:290:41 | ...::D {...} [D] | main.rs:290:9:290:9 | e [D] | provenance |  |
+| main.rs:290:13:290:41 | ...::D {...} [D] | main.rs:290:9:290:9 | e [D] | provenance |  |
+| main.rs:290:39:290:39 | s | main.rs:290:13:290:41 | ...::D {...} [D] | provenance |  |
+| main.rs:290:39:290:39 | s | main.rs:290:13:290:41 | ...::D {...} [D] | provenance |  |
+| main.rs:291:5:291:5 | e [D] | main.rs:291:7:291:10 | sink | provenance | MaD:1 Sink:MaD:1 |
+| main.rs:291:5:291:5 | e [D] | main.rs:291:7:291:10 | sink | provenance | MaD:1 Sink:MaD:1 |
+| main.rs:300:9:300:9 | s | main.rs:301:10:301:10 | s | provenance |  |
+| main.rs:300:9:300:9 | s | main.rs:301:10:301:10 | s | provenance |  |
+| main.rs:300:13:300:25 | simple_source | main.rs:300:13:300:29 | simple_source(...) | provenance | Src:MaD:7 MaD:7 |
+| main.rs:300:13:300:25 | simple_source | main.rs:300:13:300:29 | simple_source(...) | provenance | Src:MaD:7 MaD:7 |
+| main.rs:300:13:300:29 | simple_source(...) | main.rs:300:9:300:9 | s | provenance |  |
+| main.rs:300:13:300:29 | simple_source(...) | main.rs:300:9:300:9 | s | provenance |  |
+| main.rs:308:9:308:9 | s | main.rs:309:17:309:17 | s | provenance |  |
+| main.rs:308:9:308:9 | s | main.rs:309:17:309:17 | s | provenance |  |
+| main.rs:308:13:308:22 | source(...) | main.rs:308:9:308:9 | s | provenance |  |
+| main.rs:308:13:308:22 | source(...) | main.rs:308:9:308:9 | s | provenance |  |
+| main.rs:309:17:309:17 | s | main.rs:309:5:309:15 | simple_sink | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:309:17:309:17 | s | main.rs:309:5:309:15 | simple_sink | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:317:5:317:14 | arg_source | main.rs:317:16:317:16 | [post] i | provenance | Src:MaD:5 MaD:5 |
+| main.rs:317:5:317:14 | arg_source | main.rs:317:16:317:16 | [post] i | provenance | Src:MaD:5 MaD:5 |
+| main.rs:317:16:317:16 | [post] i | main.rs:318:10:318:10 | i | provenance |  |
+| main.rs:317:16:317:16 | [post] i | main.rs:318:10:318:10 | i | provenance |  |
+| main.rs:370:9:370:10 | x1 | main.rs:371:10:371:11 | x1 | provenance |  |
+| main.rs:370:9:370:10 | x1 | main.rs:371:10:371:11 | x1 | provenance |  |
+| main.rs:370:14:370:23 | source(...) | main.rs:370:14:370:30 | ... .max(...) | provenance | MaD:8 |
+| main.rs:370:14:370:23 | source(...) | main.rs:370:14:370:30 | ... .max(...) | provenance | MaD:8 |
+| main.rs:370:14:370:30 | ... .max(...) | main.rs:370:9:370:10 | x1 | provenance |  |
+| main.rs:370:14:370:30 | ... .max(...) | main.rs:370:9:370:10 | x1 | provenance |  |
+| main.rs:373:9:373:10 | x2 [MyStruct.field1] | main.rs:381:10:381:11 | x2 [MyStruct.field1] | provenance |  |
+| main.rs:373:9:373:10 | x2 [MyStruct.field1] | main.rs:381:10:381:11 | x2 [MyStruct.field1] | provenance |  |
+| main.rs:373:14:380:6 | ... .max(...) [MyStruct.field1] | main.rs:373:9:373:10 | x2 [MyStruct.field1] | provenance |  |
+| main.rs:373:14:380:6 | ... .max(...) [MyStruct.field1] | main.rs:373:9:373:10 | x2 [MyStruct.field1] | provenance |  |
+| main.rs:373:15:376:5 | MyStruct {...} [MyStruct.field1] | main.rs:373:14:380:6 | ... .max(...) [MyStruct.field1] | provenance | MaD:8 |
+| main.rs:373:15:376:5 | MyStruct {...} [MyStruct.field1] | main.rs:373:14:380:6 | ... .max(...) [MyStruct.field1] | provenance | MaD:8 |
+| main.rs:374:17:374:26 | source(...) | main.rs:373:15:376:5 | MyStruct {...} [MyStruct.field1] | provenance |  |
+| main.rs:374:17:374:26 | source(...) | main.rs:373:15:376:5 | MyStruct {...} [MyStruct.field1] | provenance |  |
+| main.rs:381:10:381:11 | x2 [MyStruct.field1] | main.rs:381:10:381:18 | x2.field1 | provenance |  |
+| main.rs:381:10:381:11 | x2 [MyStruct.field1] | main.rs:381:10:381:18 | x2.field1 | provenance |  |
+| main.rs:386:9:386:10 | x4 | main.rs:387:10:387:11 | x4 | provenance |  |
+| main.rs:386:9:386:10 | x4 | main.rs:387:10:387:11 | x4 | provenance |  |
+| main.rs:386:14:386:23 | source(...) | main.rs:386:14:386:30 | ... .max(...) | provenance | MaD:8 |
+| main.rs:386:14:386:23 | source(...) | main.rs:386:14:386:30 | ... .max(...) | provenance | MaD:8 |
+| main.rs:386:14:386:30 | ... .max(...) | main.rs:386:9:386:10 | x4 | provenance |  |
+| main.rs:386:14:386:30 | ... .max(...) | main.rs:386:9:386:10 | x4 | provenance |  |
+| main.rs:389:9:389:10 | x5 | main.rs:390:10:390:11 | x5 | provenance |  |
+| main.rs:389:14:389:23 | source(...) | main.rs:389:14:389:30 | ... .lt(...) | provenance | MaD:9 |
+| main.rs:389:14:389:30 | ... .lt(...) | main.rs:389:9:389:10 | x5 | provenance |  |
+| main.rs:392:9:392:10 | x6 | main.rs:393:10:393:11 | x6 | provenance |  |
+| main.rs:392:14:392:23 | source(...) | main.rs:392:14:392:27 | ... < ... | provenance | MaD:9 |
+| main.rs:392:14:392:27 | ... < ... | main.rs:392:9:392:10 | x6 | provenance |  |
 nodes
 | main.rs:15:9:15:9 | s | semmle.label | s |
 | main.rs:15:9:15:9 | s | semmle.label | s |
@@ -533,88 +533,88 @@ nodes
 | main.rs:247:35:247:35 | i | semmle.label | i |
 | main.rs:247:47:247:47 | i | semmle.label | i |
 | main.rs:247:47:247:47 | i | semmle.label | i |
-| main.rs:256:9:256:9 | s | semmle.label | s |
-| main.rs:256:9:256:9 | s | semmle.label | s |
-| main.rs:256:13:256:22 | source(...) | semmle.label | source(...) |
-| main.rs:256:13:256:22 | source(...) | semmle.label | source(...) |
-| main.rs:257:5:257:13 | enum_sink | semmle.label | enum_sink |
-| main.rs:257:5:257:13 | enum_sink | semmle.label | enum_sink |
-| main.rs:257:15:257:43 | ...::C {...} [C] | semmle.label | ...::C {...} [C] |
-| main.rs:257:15:257:43 | ...::C {...} [C] | semmle.label | ...::C {...} [C] |
-| main.rs:257:41:257:41 | s | semmle.label | s |
-| main.rs:257:41:257:41 | s | semmle.label | s |
-| main.rs:262:9:262:9 | s | semmle.label | s |
-| main.rs:262:9:262:9 | s | semmle.label | s |
-| main.rs:262:13:262:22 | source(...) | semmle.label | source(...) |
-| main.rs:262:13:262:22 | source(...) | semmle.label | source(...) |
-| main.rs:263:9:263:9 | e [D] | semmle.label | e [D] |
-| main.rs:263:9:263:9 | e [D] | semmle.label | e [D] |
-| main.rs:263:13:263:41 | ...::D {...} [D] | semmle.label | ...::D {...} [D] |
-| main.rs:263:13:263:41 | ...::D {...} [D] | semmle.label | ...::D {...} [D] |
-| main.rs:263:39:263:39 | s | semmle.label | s |
-| main.rs:263:39:263:39 | s | semmle.label | s |
-| main.rs:264:5:264:5 | e [D] | semmle.label | e [D] |
-| main.rs:264:5:264:5 | e [D] | semmle.label | e [D] |
-| main.rs:264:7:264:10 | sink | semmle.label | sink |
-| main.rs:264:7:264:10 | sink | semmle.label | sink |
-| main.rs:273:9:273:9 | s | semmle.label | s |
-| main.rs:273:9:273:9 | s | semmle.label | s |
-| main.rs:273:13:273:25 | simple_source | semmle.label | simple_source |
-| main.rs:273:13:273:25 | simple_source | semmle.label | simple_source |
-| main.rs:273:13:273:29 | simple_source(...) | semmle.label | simple_source(...) |
-| main.rs:273:13:273:29 | simple_source(...) | semmle.label | simple_source(...) |
-| main.rs:274:10:274:10 | s | semmle.label | s |
-| main.rs:274:10:274:10 | s | semmle.label | s |
-| main.rs:281:9:281:9 | s | semmle.label | s |
-| main.rs:281:9:281:9 | s | semmle.label | s |
-| main.rs:281:13:281:22 | source(...) | semmle.label | source(...) |
-| main.rs:281:13:281:22 | source(...) | semmle.label | source(...) |
-| main.rs:282:5:282:15 | simple_sink | semmle.label | simple_sink |
-| main.rs:282:5:282:15 | simple_sink | semmle.label | simple_sink |
-| main.rs:282:17:282:17 | s | semmle.label | s |
-| main.rs:282:17:282:17 | s | semmle.label | s |
-| main.rs:290:5:290:14 | arg_source | semmle.label | arg_source |
-| main.rs:290:5:290:14 | arg_source | semmle.label | arg_source |
-| main.rs:290:16:290:16 | [post] i | semmle.label | [post] i |
-| main.rs:290:16:290:16 | [post] i | semmle.label | [post] i |
-| main.rs:291:10:291:10 | i | semmle.label | i |
-| main.rs:291:10:291:10 | i | semmle.label | i |
-| main.rs:343:9:343:10 | x1 | semmle.label | x1 |
-| main.rs:343:9:343:10 | x1 | semmle.label | x1 |
-| main.rs:343:14:343:23 | source(...) | semmle.label | source(...) |
-| main.rs:343:14:343:23 | source(...) | semmle.label | source(...) |
-| main.rs:343:14:343:30 | ... .max(...) | semmle.label | ... .max(...) |
-| main.rs:343:14:343:30 | ... .max(...) | semmle.label | ... .max(...) |
-| main.rs:344:10:344:11 | x1 | semmle.label | x1 |
-| main.rs:344:10:344:11 | x1 | semmle.label | x1 |
-| main.rs:346:9:346:10 | x2 [MyStruct.field1] | semmle.label | x2 [MyStruct.field1] |
-| main.rs:346:9:346:10 | x2 [MyStruct.field1] | semmle.label | x2 [MyStruct.field1] |
-| main.rs:346:14:353:6 | ... .max(...) [MyStruct.field1] | semmle.label | ... .max(...) [MyStruct.field1] |
-| main.rs:346:14:353:6 | ... .max(...) [MyStruct.field1] | semmle.label | ... .max(...) [MyStruct.field1] |
-| main.rs:346:15:349:5 | MyStruct {...} [MyStruct.field1] | semmle.label | MyStruct {...} [MyStruct.field1] |
-| main.rs:346:15:349:5 | MyStruct {...} [MyStruct.field1] | semmle.label | MyStruct {...} [MyStruct.field1] |
-| main.rs:347:17:347:26 | source(...) | semmle.label | source(...) |
-| main.rs:347:17:347:26 | source(...) | semmle.label | source(...) |
-| main.rs:354:10:354:11 | x2 [MyStruct.field1] | semmle.label | x2 [MyStruct.field1] |
-| main.rs:354:10:354:11 | x2 [MyStruct.field1] | semmle.label | x2 [MyStruct.field1] |
-| main.rs:354:10:354:18 | x2.field1 | semmle.label | x2.field1 |
-| main.rs:354:10:354:18 | x2.field1 | semmle.label | x2.field1 |
-| main.rs:359:9:359:10 | x4 | semmle.label | x4 |
-| main.rs:359:9:359:10 | x4 | semmle.label | x4 |
-| main.rs:359:14:359:23 | source(...) | semmle.label | source(...) |
-| main.rs:359:14:359:23 | source(...) | semmle.label | source(...) |
-| main.rs:359:14:359:30 | ... .max(...) | semmle.label | ... .max(...) |
-| main.rs:359:14:359:30 | ... .max(...) | semmle.label | ... .max(...) |
-| main.rs:360:10:360:11 | x4 | semmle.label | x4 |
-| main.rs:360:10:360:11 | x4 | semmle.label | x4 |
-| main.rs:362:9:362:10 | x5 | semmle.label | x5 |
-| main.rs:362:14:362:23 | source(...) | semmle.label | source(...) |
-| main.rs:362:14:362:30 | ... .lt(...) | semmle.label | ... .lt(...) |
-| main.rs:363:10:363:11 | x5 | semmle.label | x5 |
-| main.rs:365:9:365:10 | x6 | semmle.label | x6 |
-| main.rs:365:14:365:23 | source(...) | semmle.label | source(...) |
-| main.rs:365:14:365:27 | ... < ... | semmle.label | ... < ... |
-| main.rs:366:10:366:11 | x6 | semmle.label | x6 |
+| main.rs:283:9:283:9 | s | semmle.label | s |
+| main.rs:283:9:283:9 | s | semmle.label | s |
+| main.rs:283:13:283:22 | source(...) | semmle.label | source(...) |
+| main.rs:283:13:283:22 | source(...) | semmle.label | source(...) |
+| main.rs:284:5:284:13 | enum_sink | semmle.label | enum_sink |
+| main.rs:284:5:284:13 | enum_sink | semmle.label | enum_sink |
+| main.rs:284:15:284:43 | ...::C {...} [C] | semmle.label | ...::C {...} [C] |
+| main.rs:284:15:284:43 | ...::C {...} [C] | semmle.label | ...::C {...} [C] |
+| main.rs:284:41:284:41 | s | semmle.label | s |
+| main.rs:284:41:284:41 | s | semmle.label | s |
+| main.rs:289:9:289:9 | s | semmle.label | s |
+| main.rs:289:9:289:9 | s | semmle.label | s |
+| main.rs:289:13:289:22 | source(...) | semmle.label | source(...) |
+| main.rs:289:13:289:22 | source(...) | semmle.label | source(...) |
+| main.rs:290:9:290:9 | e [D] | semmle.label | e [D] |
+| main.rs:290:9:290:9 | e [D] | semmle.label | e [D] |
+| main.rs:290:13:290:41 | ...::D {...} [D] | semmle.label | ...::D {...} [D] |
+| main.rs:290:13:290:41 | ...::D {...} [D] | semmle.label | ...::D {...} [D] |
+| main.rs:290:39:290:39 | s | semmle.label | s |
+| main.rs:290:39:290:39 | s | semmle.label | s |
+| main.rs:291:5:291:5 | e [D] | semmle.label | e [D] |
+| main.rs:291:5:291:5 | e [D] | semmle.label | e [D] |
+| main.rs:291:7:291:10 | sink | semmle.label | sink |
+| main.rs:291:7:291:10 | sink | semmle.label | sink |
+| main.rs:300:9:300:9 | s | semmle.label | s |
+| main.rs:300:9:300:9 | s | semmle.label | s |
+| main.rs:300:13:300:25 | simple_source | semmle.label | simple_source |
+| main.rs:300:13:300:25 | simple_source | semmle.label | simple_source |
+| main.rs:300:13:300:29 | simple_source(...) | semmle.label | simple_source(...) |
+| main.rs:300:13:300:29 | simple_source(...) | semmle.label | simple_source(...) |
+| main.rs:301:10:301:10 | s | semmle.label | s |
+| main.rs:301:10:301:10 | s | semmle.label | s |
+| main.rs:308:9:308:9 | s | semmle.label | s |
+| main.rs:308:9:308:9 | s | semmle.label | s |
+| main.rs:308:13:308:22 | source(...) | semmle.label | source(...) |
+| main.rs:308:13:308:22 | source(...) | semmle.label | source(...) |
+| main.rs:309:5:309:15 | simple_sink | semmle.label | simple_sink |
+| main.rs:309:5:309:15 | simple_sink | semmle.label | simple_sink |
+| main.rs:309:17:309:17 | s | semmle.label | s |
+| main.rs:309:17:309:17 | s | semmle.label | s |
+| main.rs:317:5:317:14 | arg_source | semmle.label | arg_source |
+| main.rs:317:5:317:14 | arg_source | semmle.label | arg_source |
+| main.rs:317:16:317:16 | [post] i | semmle.label | [post] i |
+| main.rs:317:16:317:16 | [post] i | semmle.label | [post] i |
+| main.rs:318:10:318:10 | i | semmle.label | i |
+| main.rs:318:10:318:10 | i | semmle.label | i |
+| main.rs:370:9:370:10 | x1 | semmle.label | x1 |
+| main.rs:370:9:370:10 | x1 | semmle.label | x1 |
+| main.rs:370:14:370:23 | source(...) | semmle.label | source(...) |
+| main.rs:370:14:370:23 | source(...) | semmle.label | source(...) |
+| main.rs:370:14:370:30 | ... .max(...) | semmle.label | ... .max(...) |
+| main.rs:370:14:370:30 | ... .max(...) | semmle.label | ... .max(...) |
+| main.rs:371:10:371:11 | x1 | semmle.label | x1 |
+| main.rs:371:10:371:11 | x1 | semmle.label | x1 |
+| main.rs:373:9:373:10 | x2 [MyStruct.field1] | semmle.label | x2 [MyStruct.field1] |
+| main.rs:373:9:373:10 | x2 [MyStruct.field1] | semmle.label | x2 [MyStruct.field1] |
+| main.rs:373:14:380:6 | ... .max(...) [MyStruct.field1] | semmle.label | ... .max(...) [MyStruct.field1] |
+| main.rs:373:14:380:6 | ... .max(...) [MyStruct.field1] | semmle.label | ... .max(...) [MyStruct.field1] |
+| main.rs:373:15:376:5 | MyStruct {...} [MyStruct.field1] | semmle.label | MyStruct {...} [MyStruct.field1] |
+| main.rs:373:15:376:5 | MyStruct {...} [MyStruct.field1] | semmle.label | MyStruct {...} [MyStruct.field1] |
+| main.rs:374:17:374:26 | source(...) | semmle.label | source(...) |
+| main.rs:374:17:374:26 | source(...) | semmle.label | source(...) |
+| main.rs:381:10:381:11 | x2 [MyStruct.field1] | semmle.label | x2 [MyStruct.field1] |
+| main.rs:381:10:381:11 | x2 [MyStruct.field1] | semmle.label | x2 [MyStruct.field1] |
+| main.rs:381:10:381:18 | x2.field1 | semmle.label | x2.field1 |
+| main.rs:381:10:381:18 | x2.field1 | semmle.label | x2.field1 |
+| main.rs:386:9:386:10 | x4 | semmle.label | x4 |
+| main.rs:386:9:386:10 | x4 | semmle.label | x4 |
+| main.rs:386:14:386:23 | source(...) | semmle.label | source(...) |
+| main.rs:386:14:386:23 | source(...) | semmle.label | source(...) |
+| main.rs:386:14:386:30 | ... .max(...) | semmle.label | ... .max(...) |
+| main.rs:386:14:386:30 | ... .max(...) | semmle.label | ... .max(...) |
+| main.rs:387:10:387:11 | x4 | semmle.label | x4 |
+| main.rs:387:10:387:11 | x4 | semmle.label | x4 |
+| main.rs:389:9:389:10 | x5 | semmle.label | x5 |
+| main.rs:389:14:389:23 | source(...) | semmle.label | source(...) |
+| main.rs:389:14:389:30 | ... .lt(...) | semmle.label | ... .lt(...) |
+| main.rs:390:10:390:11 | x5 | semmle.label | x5 |
+| main.rs:392:9:392:10 | x6 | semmle.label | x6 |
+| main.rs:392:14:392:23 | source(...) | semmle.label | source(...) |
+| main.rs:392:14:392:27 | ... < ... | semmle.label | ... < ... |
+| main.rs:393:10:393:11 | x6 | semmle.label | x6 |
 subpaths
 | main.rs:198:23:198:23 | f [captured s] | main.rs:197:40:197:40 | s | main.rs:197:17:197:42 | if ... {...} else {...} | main.rs:198:13:198:24 | apply(...) |
 | main.rs:198:23:198:23 | f [captured s] | main.rs:197:40:197:40 | s | main.rs:197:17:197:42 | if ... {...} else {...} | main.rs:198:13:198:24 | apply(...) |
@@ -658,21 +658,21 @@ invalidSpecComponent
 | main.rs:239:47:239:47 | i | main.rs:236:13:236:23 | enum_source | main.rs:239:47:239:47 | i | $@ | main.rs:236:13:236:23 | enum_source | enum_source |
 | main.rs:247:47:247:47 | i | main.rs:245:15:245:20 | source | main.rs:247:47:247:47 | i | $@ | main.rs:245:15:245:20 | source | source |
 | main.rs:247:47:247:47 | i | main.rs:245:15:245:20 | source | main.rs:247:47:247:47 | i | $@ | main.rs:245:15:245:20 | source | source |
-| main.rs:257:5:257:13 | enum_sink | main.rs:256:13:256:22 | source(...) | main.rs:257:5:257:13 | enum_sink | $@ | main.rs:256:13:256:22 | source(...) | source(...) |
-| main.rs:257:5:257:13 | enum_sink | main.rs:256:13:256:22 | source(...) | main.rs:257:5:257:13 | enum_sink | $@ | main.rs:256:13:256:22 | source(...) | source(...) |
-| main.rs:264:7:264:10 | sink | main.rs:262:13:262:22 | source(...) | main.rs:264:7:264:10 | sink | $@ | main.rs:262:13:262:22 | source(...) | source(...) |
-| main.rs:264:7:264:10 | sink | main.rs:262:13:262:22 | source(...) | main.rs:264:7:264:10 | sink | $@ | main.rs:262:13:262:22 | source(...) | source(...) |
-| main.rs:274:10:274:10 | s | main.rs:273:13:273:25 | simple_source | main.rs:274:10:274:10 | s | $@ | main.rs:273:13:273:25 | simple_source | simple_source |
-| main.rs:274:10:274:10 | s | main.rs:273:13:273:25 | simple_source | main.rs:274:10:274:10 | s | $@ | main.rs:273:13:273:25 | simple_source | simple_source |
-| main.rs:282:5:282:15 | simple_sink | main.rs:281:13:281:22 | source(...) | main.rs:282:5:282:15 | simple_sink | $@ | main.rs:281:13:281:22 | source(...) | source(...) |
-| main.rs:282:5:282:15 | simple_sink | main.rs:281:13:281:22 | source(...) | main.rs:282:5:282:15 | simple_sink | $@ | main.rs:281:13:281:22 | source(...) | source(...) |
-| main.rs:291:10:291:10 | i | main.rs:290:5:290:14 | arg_source | main.rs:291:10:291:10 | i | $@ | main.rs:290:5:290:14 | arg_source | arg_source |
-| main.rs:291:10:291:10 | i | main.rs:290:5:290:14 | arg_source | main.rs:291:10:291:10 | i | $@ | main.rs:290:5:290:14 | arg_source | arg_source |
-| main.rs:344:10:344:11 | x1 | main.rs:343:14:343:23 | source(...) | main.rs:344:10:344:11 | x1 | $@ | main.rs:343:14:343:23 | source(...) | source(...) |
-| main.rs:344:10:344:11 | x1 | main.rs:343:14:343:23 | source(...) | main.rs:344:10:344:11 | x1 | $@ | main.rs:343:14:343:23 | source(...) | source(...) |
-| main.rs:354:10:354:18 | x2.field1 | main.rs:347:17:347:26 | source(...) | main.rs:354:10:354:18 | x2.field1 | $@ | main.rs:347:17:347:26 | source(...) | source(...) |
-| main.rs:354:10:354:18 | x2.field1 | main.rs:347:17:347:26 | source(...) | main.rs:354:10:354:18 | x2.field1 | $@ | main.rs:347:17:347:26 | source(...) | source(...) |
-| main.rs:360:10:360:11 | x4 | main.rs:359:14:359:23 | source(...) | main.rs:360:10:360:11 | x4 | $@ | main.rs:359:14:359:23 | source(...) | source(...) |
-| main.rs:360:10:360:11 | x4 | main.rs:359:14:359:23 | source(...) | main.rs:360:10:360:11 | x4 | $@ | main.rs:359:14:359:23 | source(...) | source(...) |
-| main.rs:363:10:363:11 | x5 | main.rs:362:14:362:23 | source(...) | main.rs:363:10:363:11 | x5 | $@ | main.rs:362:14:362:23 | source(...) | source(...) |
-| main.rs:366:10:366:11 | x6 | main.rs:365:14:365:23 | source(...) | main.rs:366:10:366:11 | x6 | $@ | main.rs:365:14:365:23 | source(...) | source(...) |
+| main.rs:284:5:284:13 | enum_sink | main.rs:283:13:283:22 | source(...) | main.rs:284:5:284:13 | enum_sink | $@ | main.rs:283:13:283:22 | source(...) | source(...) |
+| main.rs:284:5:284:13 | enum_sink | main.rs:283:13:283:22 | source(...) | main.rs:284:5:284:13 | enum_sink | $@ | main.rs:283:13:283:22 | source(...) | source(...) |
+| main.rs:291:7:291:10 | sink | main.rs:289:13:289:22 | source(...) | main.rs:291:7:291:10 | sink | $@ | main.rs:289:13:289:22 | source(...) | source(...) |
+| main.rs:291:7:291:10 | sink | main.rs:289:13:289:22 | source(...) | main.rs:291:7:291:10 | sink | $@ | main.rs:289:13:289:22 | source(...) | source(...) |
+| main.rs:301:10:301:10 | s | main.rs:300:13:300:25 | simple_source | main.rs:301:10:301:10 | s | $@ | main.rs:300:13:300:25 | simple_source | simple_source |
+| main.rs:301:10:301:10 | s | main.rs:300:13:300:25 | simple_source | main.rs:301:10:301:10 | s | $@ | main.rs:300:13:300:25 | simple_source | simple_source |
+| main.rs:309:5:309:15 | simple_sink | main.rs:308:13:308:22 | source(...) | main.rs:309:5:309:15 | simple_sink | $@ | main.rs:308:13:308:22 | source(...) | source(...) |
+| main.rs:309:5:309:15 | simple_sink | main.rs:308:13:308:22 | source(...) | main.rs:309:5:309:15 | simple_sink | $@ | main.rs:308:13:308:22 | source(...) | source(...) |
+| main.rs:318:10:318:10 | i | main.rs:317:5:317:14 | arg_source | main.rs:318:10:318:10 | i | $@ | main.rs:317:5:317:14 | arg_source | arg_source |
+| main.rs:318:10:318:10 | i | main.rs:317:5:317:14 | arg_source | main.rs:318:10:318:10 | i | $@ | main.rs:317:5:317:14 | arg_source | arg_source |
+| main.rs:371:10:371:11 | x1 | main.rs:370:14:370:23 | source(...) | main.rs:371:10:371:11 | x1 | $@ | main.rs:370:14:370:23 | source(...) | source(...) |
+| main.rs:371:10:371:11 | x1 | main.rs:370:14:370:23 | source(...) | main.rs:371:10:371:11 | x1 | $@ | main.rs:370:14:370:23 | source(...) | source(...) |
+| main.rs:381:10:381:18 | x2.field1 | main.rs:374:17:374:26 | source(...) | main.rs:381:10:381:18 | x2.field1 | $@ | main.rs:374:17:374:26 | source(...) | source(...) |
+| main.rs:381:10:381:18 | x2.field1 | main.rs:374:17:374:26 | source(...) | main.rs:381:10:381:18 | x2.field1 | $@ | main.rs:374:17:374:26 | source(...) | source(...) |
+| main.rs:387:10:387:11 | x4 | main.rs:386:14:386:23 | source(...) | main.rs:387:10:387:11 | x4 | $@ | main.rs:386:14:386:23 | source(...) | source(...) |
+| main.rs:387:10:387:11 | x4 | main.rs:386:14:386:23 | source(...) | main.rs:387:10:387:11 | x4 | $@ | main.rs:386:14:386:23 | source(...) | source(...) |
+| main.rs:390:10:390:11 | x5 | main.rs:389:14:389:23 | source(...) | main.rs:390:10:390:11 | x5 | $@ | main.rs:389:14:389:23 | source(...) | source(...) |
+| main.rs:393:10:393:11 | x6 | main.rs:392:14:392:23 | source(...) | main.rs:393:10:393:11 | x6 | $@ | main.rs:392:14:392:23 | source(...) | source(...) |

--- a/rust/ql/test/library-tests/dataflow/models/models.expected
+++ b/rust/ql/test/library-tests/dataflow/models/models.expected
@@ -233,18 +233,18 @@ edges
 | main.rs:247:35:247:35 | i | main.rs:247:47:247:47 | i | provenance |  |
 | main.rs:261:18:261:18 | ... | main.rs:261:26:261:26 | a | provenance |  |
 | main.rs:261:18:261:18 | ... | main.rs:261:26:261:26 | a | provenance |  |
-| main.rs:262:9:262:19 | pass_source | main.rs:261:18:261:18 | ... | provenance | Src:MaD:8 MaD:8 |
-| main.rs:262:9:262:19 | pass_source | main.rs:261:18:261:18 | ... | provenance | Src:MaD:8 MaD:8 |
-| main.rs:264:9:264:19 | pass_source | main.rs:264:25:264:25 | ... | provenance | Src:MaD:8 MaD:8 |
-| main.rs:264:9:264:19 | pass_source | main.rs:264:25:264:25 | ... | provenance | Src:MaD:8 MaD:8 |
+| main.rs:262:9:262:19 | pass_source | main.rs:261:18:261:18 | ... | provenance | Src:MaD:8  |
+| main.rs:262:9:262:19 | pass_source | main.rs:261:18:261:18 | ... | provenance | Src:MaD:8  |
+| main.rs:264:9:264:19 | pass_source | main.rs:264:25:264:25 | ... | provenance | Src:MaD:8  |
+| main.rs:264:9:264:19 | pass_source | main.rs:264:25:264:25 | ... | provenance | Src:MaD:8  |
 | main.rs:264:25:264:25 | ... | main.rs:265:18:265:18 | a | provenance |  |
 | main.rs:264:25:264:25 | ... | main.rs:265:18:265:18 | a | provenance |  |
 | main.rs:268:14:268:19 | ...: i64 | main.rs:269:18:269:18 | a | provenance |  |
 | main.rs:268:14:268:19 | ...: i64 | main.rs:269:18:269:18 | a | provenance |  |
-| main.rs:271:9:271:19 | pass_source | main.rs:268:14:268:19 | ...: i64 | provenance | Src:MaD:8 MaD:8 |
-| main.rs:271:9:271:19 | pass_source | main.rs:268:14:268:19 | ...: i64 | provenance | Src:MaD:8 MaD:8 |
-| main.rs:273:9:273:19 | pass_source | main.rs:273:36:273:36 | ... | provenance | Src:MaD:8 MaD:8 |
-| main.rs:273:9:273:19 | pass_source | main.rs:273:36:273:36 | ... | provenance | Src:MaD:8 MaD:8 |
+| main.rs:271:9:271:19 | pass_source | main.rs:268:14:268:19 | ...: i64 | provenance | Src:MaD:8  |
+| main.rs:271:9:271:19 | pass_source | main.rs:268:14:268:19 | ...: i64 | provenance | Src:MaD:8  |
+| main.rs:273:9:273:19 | pass_source | main.rs:273:36:273:36 | ... | provenance | Src:MaD:8  |
+| main.rs:273:9:273:19 | pass_source | main.rs:273:36:273:36 | ... | provenance | Src:MaD:8  |
 | main.rs:273:36:273:36 | ... | main.rs:274:18:274:18 | a | provenance |  |
 | main.rs:273:36:273:36 | ... | main.rs:274:18:274:18 | a | provenance |  |
 | main.rs:283:9:283:9 | s | main.rs:284:41:284:41 | s | provenance |  |

--- a/rust/ql/test/library-tests/dataflow/models/models.ext.yml
+++ b/rust/ql/test/library-tests/dataflow/models/models.ext.yml
@@ -7,6 +7,7 @@ extensions:
       - ["main::enum_source", "ReturnValue.Field[main::MyFieldEnum::D::field_d]", "test-source", "manual"]
       - ["<main::MyFieldEnum>::source", "ReturnValue.Field[main::MyFieldEnum::C::field_c]", "test-source", "manual"]
       - ["main::arg_source", "Argument[0]", "test-source", "manual"]
+      - ["main::source_into_function::pass_source", "Argument[1].Parameter[0]", "test-source", "manual"]
   - addsTo:
       pack: codeql/rust-all
       extensible: sinkModel

--- a/rust/ql/test/library-tests/dataflow/sources/InlineFlow.expected
+++ b/rust/ql/test/library-tests/dataflow/sources/InlineFlow.expected
@@ -1,142 +1,145 @@
 models
-| 1 | Source: <async_std::fs::file::File>::open; ReturnValue.Future.Field[core::result::Result::Ok(0)]; file |
-| 2 | Source: <async_std::fs::open_options::OpenOptions>::open; ReturnValue.Future.Field[core::result::Result::Ok(0)]; file |
-| 3 | Source: <async_std::net::tcp::stream::TcpStream>::connect; ReturnValue.Future.Field[core::result::Result::Ok(0)]; remote |
-| 4 | Source: <hyper::client::conn::http1::SendRequest>::send_request; ReturnValue.Future.Field[core::result::Result::Ok(0)]; remote |
-| 5 | Source: <std::fs::DirEntry>::file_name; ReturnValue; file |
-| 6 | Source: <std::fs::DirEntry>::path; ReturnValue; file |
-| 7 | Source: <std::fs::File>::open; ReturnValue.Field[core::result::Result::Ok(0)]; file |
-| 8 | Source: <std::fs::OpenOptions>::open; ReturnValue.Field[core::result::Result::Ok(0)]; file |
-| 9 | Source: <std::net::tcp::TcpStream>::connect; ReturnValue.Field[core::result::Result::Ok(0)]; remote |
-| 10 | Source: <std::net::tcp::TcpStream>::connect_timeout; ReturnValue.Field[core::result::Result::Ok(0)]; remote |
-| 11 | Source: <tokio::fs::file::File>::open; ReturnValue.Future.Field[core::result::Result::Ok(0)]; file |
-| 12 | Source: <tokio::fs::open_options::OpenOptions>::open; ReturnValue.Future.Field[core::result::Result::Ok(0)]; file |
-| 13 | Source: <tokio::fs::read_dir::DirEntry>::file_name; ReturnValue; file |
-| 14 | Source: <tokio::fs::read_dir::DirEntry>::path; ReturnValue; file |
-| 15 | Source: <tokio::net::tcp::stream::TcpStream>::connect; ReturnValue.Future.Field[core::result::Result::Ok(0)]; remote |
-| 16 | Source: reqwest::blocking::get; ReturnValue.Field[core::result::Result::Ok(0)]; remote |
-| 17 | Source: reqwest::get; ReturnValue.Future.Field[core::result::Result::Ok(0)]; remote |
-| 18 | Source: std::env::args; ReturnValue.Element; commandargs |
-| 19 | Source: std::env::args_os; ReturnValue.Element; commandargs |
-| 20 | Source: std::env::current_dir; ReturnValue.Field[core::result::Result::Ok(0)]; commandargs |
-| 21 | Source: std::env::current_exe; ReturnValue.Field[core::result::Result::Ok(0)]; commandargs |
-| 22 | Source: std::env::home_dir; ReturnValue.Field[core::option::Option::Some(0)]; commandargs |
-| 23 | Source: std::env::var; ReturnValue.Field[core::result::Result::Ok(0)]; environment |
-| 24 | Source: std::env::var_os; ReturnValue.Field[core::option::Option::Some(0)]; environment |
-| 25 | Source: std::fs::read; ReturnValue.Field[core::result::Result::Ok(0)]; file |
-| 26 | Source: std::fs::read; ReturnValue; file |
-| 27 | Source: std::fs::read_link; ReturnValue.Field[core::result::Result::Ok(0)]; file |
-| 28 | Source: std::fs::read_to_string; ReturnValue.Field[core::result::Result::Ok(0)]; file |
-| 29 | Source: std::fs::read_to_string; ReturnValue; file |
-| 30 | Source: std::io::stdio::stdin; ReturnValue; stdin |
-| 31 | Source: tokio::fs::read::read; ReturnValue.Future.Field[core::result::Result::Ok(0)]; file |
-| 32 | Source: tokio::fs::read_link::read_link; ReturnValue.Future.Field[core::result::Result::Ok(0)]; file |
-| 33 | Source: tokio::fs::read_to_string::read_to_string; ReturnValue.Future.Field[core::result::Result::Ok(0)]; file |
-| 34 | Source: tokio::io::stdin::stdin; ReturnValue; stdin |
-| 35 | Summary: <_ as async_std::io::read::ReadExt>::read; Argument[self].Reference; Argument[0].Reference; taint |
-| 36 | Summary: <_ as async_std::io::read::ReadExt>::read; Argument[self]; Argument[0].Reference; taint |
-| 37 | Summary: <_ as core::clone::Clone>::clone; Argument[self].Reference; ReturnValue; value |
-| 38 | Summary: <_ as core::iter::traits::iterator::Iterator>::collect; Argument[self].Element; ReturnValue.Element; value |
-| 39 | Summary: <_ as core::iter::traits::iterator::Iterator>::nth; Argument[self].Element; ReturnValue.Field[core::option::Option::Some(0)]; value |
-| 40 | Summary: <_ as futures_io::if_std::AsyncBufRead>::poll_fill_buf; Argument[self].Reference; ReturnValue.Field[core::task::poll::Poll::Ready(0)].Field[core::result::Result::Ok(0)]; taint |
-| 41 | Summary: <_ as futures_util::io::AsyncBufReadExt>::fill_buf; Argument[self]; ReturnValue.Future.Field[core::result::Result::Ok(0)]; taint |
-| 42 | Summary: <_ as futures_util::io::AsyncBufReadExt>::read_line; Argument[self].Reference; Argument[0].Reference; taint |
-| 43 | Summary: <_ as futures_util::io::AsyncBufReadExt>::read_line; Argument[self]; Argument[0].Reference; taint |
-| 44 | Summary: <_ as futures_util::io::AsyncBufReadExt>::read_until; Argument[self].Reference; Argument[1].Reference; taint |
-| 45 | Summary: <_ as futures_util::io::AsyncBufReadExt>::read_until; Argument[self]; Argument[1].Reference; taint |
-| 46 | Summary: <_ as futures_util::io::AsyncReadExt>::read; Argument[self].Reference; Argument[0].Reference; taint |
-| 47 | Summary: <_ as futures_util::io::AsyncReadExt>::read; Argument[self]; Argument[0].Reference; taint |
-| 48 | Summary: <_ as futures_util::io::AsyncReadExt>::read_to_end; Argument[self].Reference; Argument[0].Reference; taint |
-| 49 | Summary: <_ as futures_util::io::AsyncReadExt>::read_to_end; Argument[self]; Argument[0].Reference; taint |
-| 50 | Summary: <_ as std::io::BufRead>::lines; Argument[self]; ReturnValue; taint |
-| 51 | Summary: <_ as std::io::BufRead>::read_line; Argument[self]; Argument[0].Reference; taint |
-| 52 | Summary: <_ as std::io::BufRead>::read_until; Argument[self]; Argument[1].Reference; taint |
-| 53 | Summary: <_ as std::io::BufRead>::split; Argument[self]; ReturnValue; taint |
-| 54 | Summary: <_ as std::io::Read>::bytes; Argument[self]; ReturnValue; taint |
-| 55 | Summary: <_ as std::io::Read>::chain; Argument[0]; ReturnValue; taint |
-| 56 | Summary: <_ as std::io::Read>::chain; Argument[self]; ReturnValue; taint |
-| 57 | Summary: <_ as std::io::Read>::read; Argument[self]; Argument[0].Reference; taint |
-| 58 | Summary: <_ as std::io::Read>::read_exact; Argument[self]; Argument[0].Reference; taint |
-| 59 | Summary: <_ as std::io::Read>::read_to_end; Argument[self]; Argument[0].Reference; taint |
-| 60 | Summary: <_ as std::io::Read>::read_to_string; Argument[self]; Argument[0].Reference; taint |
-| 61 | Summary: <_ as std::io::Read>::take; Argument[self]; ReturnValue; taint |
-| 62 | Summary: <_ as tokio::io::util::async_buf_read_ext::AsyncBufReadExt>::fill_buf; Argument[self]; ReturnValue.Future.Field[core::result::Result::Ok(0)]; taint |
-| 63 | Summary: <_ as tokio::io::util::async_buf_read_ext::AsyncBufReadExt>::lines; Argument[self]; ReturnValue; taint |
-| 64 | Summary: <_ as tokio::io::util::async_buf_read_ext::AsyncBufReadExt>::read_line; Argument[self]; Argument[0].Reference; taint |
-| 65 | Summary: <_ as tokio::io::util::async_buf_read_ext::AsyncBufReadExt>::read_until; Argument[self]; Argument[1].Reference; taint |
-| 66 | Summary: <_ as tokio::io::util::async_buf_read_ext::AsyncBufReadExt>::split; Argument[self]; ReturnValue; taint |
-| 67 | Summary: <_ as tokio::io::util::async_read_ext::AsyncReadExt>::read; Argument[self]; Argument[0].Reference; taint |
-| 68 | Summary: <_ as tokio::io::util::async_read_ext::AsyncReadExt>::read_buf; Argument[self]; Argument[0].Reference; taint |
-| 69 | Summary: <_ as tokio::io::util::async_read_ext::AsyncReadExt>::read_exact; Argument[self]; Argument[0].Reference; taint |
-| 70 | Summary: <_ as tokio::io::util::async_read_ext::AsyncReadExt>::read_f32; Argument[self]; ReturnValue.Future.Field[core::result::Result::Ok(0)]; taint |
-| 71 | Summary: <_ as tokio::io::util::async_read_ext::AsyncReadExt>::read_i16; Argument[self]; ReturnValue.Future.Field[core::result::Result::Ok(0)]; taint |
-| 72 | Summary: <_ as tokio::io::util::async_read_ext::AsyncReadExt>::read_i64_le; Argument[self]; ReturnValue.Future.Field[core::result::Result::Ok(0)]; taint |
-| 73 | Summary: <_ as tokio::io::util::async_read_ext::AsyncReadExt>::read_to_end; Argument[self]; Argument[0].Reference; taint |
-| 74 | Summary: <_ as tokio::io::util::async_read_ext::AsyncReadExt>::read_to_string; Argument[self]; Argument[0].Reference; taint |
-| 75 | Summary: <_ as tokio::io::util::async_read_ext::AsyncReadExt>::read_u8; Argument[self]; ReturnValue.Future.Field[core::result::Result::Ok(0)]; taint |
-| 76 | Summary: <alloc::string::String>::as_bytes; Argument[self]; ReturnValue; value |
-| 77 | Summary: <alloc::string::String>::as_str; Argument[self]; ReturnValue; value |
-| 78 | Summary: <core::option::Option>::expect; Argument[self].Field[core::option::Option::Some(0)]; ReturnValue; value |
-| 79 | Summary: <core::option::Option>::unwrap; Argument[self].Field[core::option::Option::Some(0)]; ReturnValue; value |
-| 80 | Summary: <core::pin::Pin>::new; Argument[0].Reference; ReturnValue; value |
-| 81 | Summary: <core::pin::Pin>::new; Argument[0]; ReturnValue.Field[core::pin::Pin::__pointer]; value |
-| 82 | Summary: <core::pin::Pin>::new; Argument[0]; ReturnValue; value |
-| 83 | Summary: <core::result::Result>::expect; Argument[self].Field[core::result::Result::Ok(0)]; ReturnValue; value |
-| 84 | Summary: <core::result::Result>::unwrap; Argument[self].Field[core::result::Result::Ok(0)]; ReturnValue; value |
-| 85 | Summary: <core::str>::as_bytes; Argument[self]; ReturnValue; value |
-| 86 | Summary: <core::str>::as_str; Argument[self]; ReturnValue; value |
-| 87 | Summary: <core::str>::parse; Argument[self]; ReturnValue.Field[core::result::Result::Ok(0)]; taint |
-| 88 | Summary: <futures_rustls::TlsConnector>::connect; Argument[1]; ReturnValue.Future.Field[core::result::Result::Ok(0)]; taint |
-| 89 | Summary: <futures_util::io::buf_reader::BufReader>::new; Argument[0]; ReturnValue; taint |
-| 90 | Summary: <reqwest::async_impl::response::Response>::bytes; Argument[self]; ReturnValue.Future.Field[core::result::Result::Ok(0)]; taint |
-| 91 | Summary: <reqwest::async_impl::response::Response>::chunk; Argument[self]; ReturnValue.Future.Field[core::result::Result::Ok(0)].Field[core::option::Option::Some(0)]; taint |
-| 92 | Summary: <reqwest::async_impl::response::Response>::text; Argument[self]; ReturnValue.Future.Field[core::result::Result::Ok(0)]; taint |
-| 93 | Summary: <reqwest::blocking::response::Response>::bytes; Argument[self]; ReturnValue.Field[core::result::Result::Ok(0)]; taint |
-| 94 | Summary: <reqwest::blocking::response::Response>::text; Argument[self]; ReturnValue.Field[core::result::Result::Ok(0)]; taint |
-| 95 | Summary: <reqwest::blocking::response::Response>::text_with_charset; Argument[self]; ReturnValue.Field[core::result::Result::Ok(0)]; taint |
-| 96 | Summary: <std::fs::File as std::io::Read>::read; Argument[self]; Argument[0].Reference; taint |
-| 97 | Summary: <std::fs::File as std::io::Read>::read; Argument[self]; Argument[0]; taint |
-| 98 | Summary: <std::fs::File as std::io::Read>::read_to_end; Argument[self]; Argument[0].Reference; taint |
-| 99 | Summary: <std::fs::File as std::io::Read>::read_to_end; Argument[self]; Argument[0]; taint |
-| 100 | Summary: <std::fs::File as std::io::Read>::read_to_string; Argument[self]; Argument[0].Reference; taint |
-| 101 | Summary: <std::fs::File as std::io::Read>::read_to_string; Argument[self]; Argument[0]; taint |
-| 102 | Summary: <std::io::Split as core::iter::traits::iterator::Iterator>::next; Argument[self]; ReturnValue.Field[core::option::Option::Some(0)].Field[core::result::Result::Ok(0)]; taint |
-| 103 | Summary: <std::io::buffered::bufreader::BufReader as std::io::BufRead>::fill_buf; Argument[self]; ReturnValue.Field[core::result::Result::Ok(0)]; taint |
-| 104 | Summary: <std::io::buffered::bufreader::BufReader>::buffer; Argument[self]; ReturnValue; taint |
-| 105 | Summary: <std::io::buffered::bufreader::BufReader>::new; Argument[0]; ReturnValue; taint |
-| 106 | Summary: <std::io::stdio::Stdin as std::io::Read>::read; Argument[self]; Argument[0].Reference; taint |
-| 107 | Summary: <std::io::stdio::Stdin as std::io::Read>::read; Argument[self]; Argument[0]; taint |
-| 108 | Summary: <std::io::stdio::Stdin as std::io::Read>::read_exact; Argument[self]; Argument[0].Reference; taint |
-| 109 | Summary: <std::io::stdio::Stdin as std::io::Read>::read_exact; Argument[self]; Argument[0]; taint |
-| 110 | Summary: <std::io::stdio::Stdin as std::io::Read>::read_to_end; Argument[self]; Argument[0].Reference; taint |
-| 111 | Summary: <std::io::stdio::Stdin as std::io::Read>::read_to_string; Argument[self]; Argument[0].Reference; taint |
-| 112 | Summary: <std::io::stdio::Stdin as std::io::Read>::read_to_string; Argument[self]; Argument[0]; taint |
-| 113 | Summary: <std::io::stdio::Stdin>::lock; Argument[self]; ReturnValue; taint |
-| 114 | Summary: <std::io::stdio::StdinLock as std::io::Read>::read_to_string; Argument[self]; Argument[0].Reference; taint |
-| 115 | Summary: <std::net::tcp::TcpStream as std::io::Read>::read; Argument[self]; Argument[0].Reference; taint |
-| 116 | Summary: <std::path::PathBuf>::as_path; Argument[self]; ReturnValue; value |
-| 117 | Summary: <tokio::io::util::buf_reader::BufReader>::buffer; Argument[self]; ReturnValue; taint |
-| 118 | Summary: <tokio::io::util::buf_reader::BufReader>::new; Argument[0]; ReturnValue; taint |
-| 119 | Summary: <tokio::io::util::lines::Lines>::next_line; Argument[self]; ReturnValue.Future.Field[core::result::Result::Ok(0)].Field[core::option::Option::Some(0)]; taint |
-| 120 | Summary: <tokio::io::util::split::Split>::next_segment; Argument[self]; ReturnValue.Future.Field[core::result::Result::Ok(0)].Field[core::option::Option::Some(0)]; taint |
-| 121 | Summary: <tokio::net::tcp::stream::TcpStream>::peek; Argument[self]; Argument[0].Reference; taint |
-| 122 | Summary: <tokio::net::tcp::stream::TcpStream>::try_read; Argument[self]; Argument[0].Reference; taint |
-| 123 | Summary: <tokio::net::tcp::stream::TcpStream>::try_read_buf; Argument[self]; Argument[0].Reference; taint |
+| 1 | Source: <_ as warp::filter::Filter>::and_then; Argument[0].Parameter[0..7]; remote |
+| 2 | Source: <_ as warp::filter::Filter>::map; Argument[0].Parameter[0..7]; remote |
+| 3 | Source: <_ as warp::filter::Filter>::then; Argument[0].Parameter[0..7]; remote |
+| 4 | Source: <async_std::fs::file::File>::open; ReturnValue.Future.Field[core::result::Result::Ok(0)]; file |
+| 5 | Source: <async_std::fs::open_options::OpenOptions>::open; ReturnValue.Future.Field[core::result::Result::Ok(0)]; file |
+| 6 | Source: <async_std::net::tcp::stream::TcpStream>::connect; ReturnValue.Future.Field[core::result::Result::Ok(0)]; remote |
+| 7 | Source: <hyper::client::conn::http1::SendRequest>::send_request; ReturnValue.Future.Field[core::result::Result::Ok(0)]; remote |
+| 8 | Source: <std::fs::DirEntry>::file_name; ReturnValue; file |
+| 9 | Source: <std::fs::DirEntry>::path; ReturnValue; file |
+| 10 | Source: <std::fs::File>::open; ReturnValue.Field[core::result::Result::Ok(0)]; file |
+| 11 | Source: <std::fs::OpenOptions>::open; ReturnValue.Field[core::result::Result::Ok(0)]; file |
+| 12 | Source: <std::net::tcp::TcpStream>::connect; ReturnValue.Field[core::result::Result::Ok(0)]; remote |
+| 13 | Source: <std::net::tcp::TcpStream>::connect_timeout; ReturnValue.Field[core::result::Result::Ok(0)]; remote |
+| 14 | Source: <tokio::fs::file::File>::open; ReturnValue.Future.Field[core::result::Result::Ok(0)]; file |
+| 15 | Source: <tokio::fs::open_options::OpenOptions>::open; ReturnValue.Future.Field[core::result::Result::Ok(0)]; file |
+| 16 | Source: <tokio::fs::read_dir::DirEntry>::file_name; ReturnValue; file |
+| 17 | Source: <tokio::fs::read_dir::DirEntry>::path; ReturnValue; file |
+| 18 | Source: <tokio::net::tcp::stream::TcpStream>::connect; ReturnValue.Future.Field[core::result::Result::Ok(0)]; remote |
+| 19 | Source: reqwest::blocking::get; ReturnValue.Field[core::result::Result::Ok(0)]; remote |
+| 20 | Source: reqwest::get; ReturnValue.Future.Field[core::result::Result::Ok(0)]; remote |
+| 21 | Source: std::env::args; ReturnValue.Element; commandargs |
+| 22 | Source: std::env::args_os; ReturnValue.Element; commandargs |
+| 23 | Source: std::env::current_dir; ReturnValue.Field[core::result::Result::Ok(0)]; commandargs |
+| 24 | Source: std::env::current_exe; ReturnValue.Field[core::result::Result::Ok(0)]; commandargs |
+| 25 | Source: std::env::home_dir; ReturnValue.Field[core::option::Option::Some(0)]; commandargs |
+| 26 | Source: std::env::var; ReturnValue.Field[core::result::Result::Ok(0)]; environment |
+| 27 | Source: std::env::var_os; ReturnValue.Field[core::option::Option::Some(0)]; environment |
+| 28 | Source: std::fs::read; ReturnValue.Field[core::result::Result::Ok(0)]; file |
+| 29 | Source: std::fs::read; ReturnValue; file |
+| 30 | Source: std::fs::read_link; ReturnValue.Field[core::result::Result::Ok(0)]; file |
+| 31 | Source: std::fs::read_to_string; ReturnValue.Field[core::result::Result::Ok(0)]; file |
+| 32 | Source: std::fs::read_to_string; ReturnValue; file |
+| 33 | Source: std::io::stdio::stdin; ReturnValue; stdin |
+| 34 | Source: tokio::fs::read::read; ReturnValue.Future.Field[core::result::Result::Ok(0)]; file |
+| 35 | Source: tokio::fs::read_link::read_link; ReturnValue.Future.Field[core::result::Result::Ok(0)]; file |
+| 36 | Source: tokio::fs::read_to_string::read_to_string; ReturnValue.Future.Field[core::result::Result::Ok(0)]; file |
+| 37 | Source: tokio::io::stdin::stdin; ReturnValue; stdin |
+| 38 | Summary: <_ as async_std::io::read::ReadExt>::read; Argument[self].Reference; Argument[0].Reference; taint |
+| 39 | Summary: <_ as async_std::io::read::ReadExt>::read; Argument[self]; Argument[0].Reference; taint |
+| 40 | Summary: <_ as core::clone::Clone>::clone; Argument[self].Reference; ReturnValue; value |
+| 41 | Summary: <_ as core::iter::traits::iterator::Iterator>::collect; Argument[self].Element; ReturnValue.Element; value |
+| 42 | Summary: <_ as core::iter::traits::iterator::Iterator>::nth; Argument[self].Element; ReturnValue.Field[core::option::Option::Some(0)]; value |
+| 43 | Summary: <_ as futures_io::if_std::AsyncBufRead>::poll_fill_buf; Argument[self].Reference; ReturnValue.Field[core::task::poll::Poll::Ready(0)].Field[core::result::Result::Ok(0)]; taint |
+| 44 | Summary: <_ as futures_util::io::AsyncBufReadExt>::fill_buf; Argument[self]; ReturnValue.Future.Field[core::result::Result::Ok(0)]; taint |
+| 45 | Summary: <_ as futures_util::io::AsyncBufReadExt>::read_line; Argument[self].Reference; Argument[0].Reference; taint |
+| 46 | Summary: <_ as futures_util::io::AsyncBufReadExt>::read_line; Argument[self]; Argument[0].Reference; taint |
+| 47 | Summary: <_ as futures_util::io::AsyncBufReadExt>::read_until; Argument[self].Reference; Argument[1].Reference; taint |
+| 48 | Summary: <_ as futures_util::io::AsyncBufReadExt>::read_until; Argument[self]; Argument[1].Reference; taint |
+| 49 | Summary: <_ as futures_util::io::AsyncReadExt>::read; Argument[self].Reference; Argument[0].Reference; taint |
+| 50 | Summary: <_ as futures_util::io::AsyncReadExt>::read; Argument[self]; Argument[0].Reference; taint |
+| 51 | Summary: <_ as futures_util::io::AsyncReadExt>::read_to_end; Argument[self].Reference; Argument[0].Reference; taint |
+| 52 | Summary: <_ as futures_util::io::AsyncReadExt>::read_to_end; Argument[self]; Argument[0].Reference; taint |
+| 53 | Summary: <_ as std::io::BufRead>::lines; Argument[self]; ReturnValue; taint |
+| 54 | Summary: <_ as std::io::BufRead>::read_line; Argument[self]; Argument[0].Reference; taint |
+| 55 | Summary: <_ as std::io::BufRead>::read_until; Argument[self]; Argument[1].Reference; taint |
+| 56 | Summary: <_ as std::io::BufRead>::split; Argument[self]; ReturnValue; taint |
+| 57 | Summary: <_ as std::io::Read>::bytes; Argument[self]; ReturnValue; taint |
+| 58 | Summary: <_ as std::io::Read>::chain; Argument[0]; ReturnValue; taint |
+| 59 | Summary: <_ as std::io::Read>::chain; Argument[self]; ReturnValue; taint |
+| 60 | Summary: <_ as std::io::Read>::read; Argument[self]; Argument[0].Reference; taint |
+| 61 | Summary: <_ as std::io::Read>::read_exact; Argument[self]; Argument[0].Reference; taint |
+| 62 | Summary: <_ as std::io::Read>::read_to_end; Argument[self]; Argument[0].Reference; taint |
+| 63 | Summary: <_ as std::io::Read>::read_to_string; Argument[self]; Argument[0].Reference; taint |
+| 64 | Summary: <_ as std::io::Read>::take; Argument[self]; ReturnValue; taint |
+| 65 | Summary: <_ as tokio::io::util::async_buf_read_ext::AsyncBufReadExt>::fill_buf; Argument[self]; ReturnValue.Future.Field[core::result::Result::Ok(0)]; taint |
+| 66 | Summary: <_ as tokio::io::util::async_buf_read_ext::AsyncBufReadExt>::lines; Argument[self]; ReturnValue; taint |
+| 67 | Summary: <_ as tokio::io::util::async_buf_read_ext::AsyncBufReadExt>::read_line; Argument[self]; Argument[0].Reference; taint |
+| 68 | Summary: <_ as tokio::io::util::async_buf_read_ext::AsyncBufReadExt>::read_until; Argument[self]; Argument[1].Reference; taint |
+| 69 | Summary: <_ as tokio::io::util::async_buf_read_ext::AsyncBufReadExt>::split; Argument[self]; ReturnValue; taint |
+| 70 | Summary: <_ as tokio::io::util::async_read_ext::AsyncReadExt>::read; Argument[self]; Argument[0].Reference; taint |
+| 71 | Summary: <_ as tokio::io::util::async_read_ext::AsyncReadExt>::read_buf; Argument[self]; Argument[0].Reference; taint |
+| 72 | Summary: <_ as tokio::io::util::async_read_ext::AsyncReadExt>::read_exact; Argument[self]; Argument[0].Reference; taint |
+| 73 | Summary: <_ as tokio::io::util::async_read_ext::AsyncReadExt>::read_f32; Argument[self]; ReturnValue.Future.Field[core::result::Result::Ok(0)]; taint |
+| 74 | Summary: <_ as tokio::io::util::async_read_ext::AsyncReadExt>::read_i16; Argument[self]; ReturnValue.Future.Field[core::result::Result::Ok(0)]; taint |
+| 75 | Summary: <_ as tokio::io::util::async_read_ext::AsyncReadExt>::read_i64_le; Argument[self]; ReturnValue.Future.Field[core::result::Result::Ok(0)]; taint |
+| 76 | Summary: <_ as tokio::io::util::async_read_ext::AsyncReadExt>::read_to_end; Argument[self]; Argument[0].Reference; taint |
+| 77 | Summary: <_ as tokio::io::util::async_read_ext::AsyncReadExt>::read_to_string; Argument[self]; Argument[0].Reference; taint |
+| 78 | Summary: <_ as tokio::io::util::async_read_ext::AsyncReadExt>::read_u8; Argument[self]; ReturnValue.Future.Field[core::result::Result::Ok(0)]; taint |
+| 79 | Summary: <alloc::string::String>::as_bytes; Argument[self]; ReturnValue; value |
+| 80 | Summary: <alloc::string::String>::as_str; Argument[self]; ReturnValue; value |
+| 81 | Summary: <core::option::Option>::expect; Argument[self].Field[core::option::Option::Some(0)]; ReturnValue; value |
+| 82 | Summary: <core::option::Option>::unwrap; Argument[self].Field[core::option::Option::Some(0)]; ReturnValue; value |
+| 83 | Summary: <core::pin::Pin>::new; Argument[0].Reference; ReturnValue; value |
+| 84 | Summary: <core::pin::Pin>::new; Argument[0]; ReturnValue.Field[core::pin::Pin::__pointer]; value |
+| 85 | Summary: <core::pin::Pin>::new; Argument[0]; ReturnValue; value |
+| 86 | Summary: <core::result::Result>::expect; Argument[self].Field[core::result::Result::Ok(0)]; ReturnValue; value |
+| 87 | Summary: <core::result::Result>::unwrap; Argument[self].Field[core::result::Result::Ok(0)]; ReturnValue; value |
+| 88 | Summary: <core::str>::as_bytes; Argument[self]; ReturnValue; value |
+| 89 | Summary: <core::str>::as_str; Argument[self]; ReturnValue; value |
+| 90 | Summary: <core::str>::parse; Argument[self]; ReturnValue.Field[core::result::Result::Ok(0)]; taint |
+| 91 | Summary: <futures_rustls::TlsConnector>::connect; Argument[1]; ReturnValue.Future.Field[core::result::Result::Ok(0)]; taint |
+| 92 | Summary: <futures_util::io::buf_reader::BufReader>::new; Argument[0]; ReturnValue; taint |
+| 93 | Summary: <reqwest::async_impl::response::Response>::bytes; Argument[self]; ReturnValue.Future.Field[core::result::Result::Ok(0)]; taint |
+| 94 | Summary: <reqwest::async_impl::response::Response>::chunk; Argument[self]; ReturnValue.Future.Field[core::result::Result::Ok(0)].Field[core::option::Option::Some(0)]; taint |
+| 95 | Summary: <reqwest::async_impl::response::Response>::text; Argument[self]; ReturnValue.Future.Field[core::result::Result::Ok(0)]; taint |
+| 96 | Summary: <reqwest::blocking::response::Response>::bytes; Argument[self]; ReturnValue.Field[core::result::Result::Ok(0)]; taint |
+| 97 | Summary: <reqwest::blocking::response::Response>::text; Argument[self]; ReturnValue.Field[core::result::Result::Ok(0)]; taint |
+| 98 | Summary: <reqwest::blocking::response::Response>::text_with_charset; Argument[self]; ReturnValue.Field[core::result::Result::Ok(0)]; taint |
+| 99 | Summary: <std::fs::File as std::io::Read>::read; Argument[self]; Argument[0].Reference; taint |
+| 100 | Summary: <std::fs::File as std::io::Read>::read; Argument[self]; Argument[0]; taint |
+| 101 | Summary: <std::fs::File as std::io::Read>::read_to_end; Argument[self]; Argument[0].Reference; taint |
+| 102 | Summary: <std::fs::File as std::io::Read>::read_to_end; Argument[self]; Argument[0]; taint |
+| 103 | Summary: <std::fs::File as std::io::Read>::read_to_string; Argument[self]; Argument[0].Reference; taint |
+| 104 | Summary: <std::fs::File as std::io::Read>::read_to_string; Argument[self]; Argument[0]; taint |
+| 105 | Summary: <std::io::Split as core::iter::traits::iterator::Iterator>::next; Argument[self]; ReturnValue.Field[core::option::Option::Some(0)].Field[core::result::Result::Ok(0)]; taint |
+| 106 | Summary: <std::io::buffered::bufreader::BufReader as std::io::BufRead>::fill_buf; Argument[self]; ReturnValue.Field[core::result::Result::Ok(0)]; taint |
+| 107 | Summary: <std::io::buffered::bufreader::BufReader>::buffer; Argument[self]; ReturnValue; taint |
+| 108 | Summary: <std::io::buffered::bufreader::BufReader>::new; Argument[0]; ReturnValue; taint |
+| 109 | Summary: <std::io::stdio::Stdin as std::io::Read>::read; Argument[self]; Argument[0].Reference; taint |
+| 110 | Summary: <std::io::stdio::Stdin as std::io::Read>::read; Argument[self]; Argument[0]; taint |
+| 111 | Summary: <std::io::stdio::Stdin as std::io::Read>::read_exact; Argument[self]; Argument[0].Reference; taint |
+| 112 | Summary: <std::io::stdio::Stdin as std::io::Read>::read_exact; Argument[self]; Argument[0]; taint |
+| 113 | Summary: <std::io::stdio::Stdin as std::io::Read>::read_to_end; Argument[self]; Argument[0].Reference; taint |
+| 114 | Summary: <std::io::stdio::Stdin as std::io::Read>::read_to_string; Argument[self]; Argument[0].Reference; taint |
+| 115 | Summary: <std::io::stdio::Stdin as std::io::Read>::read_to_string; Argument[self]; Argument[0]; taint |
+| 116 | Summary: <std::io::stdio::Stdin>::lock; Argument[self]; ReturnValue; taint |
+| 117 | Summary: <std::io::stdio::StdinLock as std::io::Read>::read_to_string; Argument[self]; Argument[0].Reference; taint |
+| 118 | Summary: <std::net::tcp::TcpStream as std::io::Read>::read; Argument[self]; Argument[0].Reference; taint |
+| 119 | Summary: <std::path::PathBuf>::as_path; Argument[self]; ReturnValue; value |
+| 120 | Summary: <tokio::io::util::buf_reader::BufReader>::buffer; Argument[self]; ReturnValue; taint |
+| 121 | Summary: <tokio::io::util::buf_reader::BufReader>::new; Argument[0]; ReturnValue; taint |
+| 122 | Summary: <tokio::io::util::lines::Lines>::next_line; Argument[self]; ReturnValue.Future.Field[core::result::Result::Ok(0)].Field[core::option::Option::Some(0)]; taint |
+| 123 | Summary: <tokio::io::util::split::Split>::next_segment; Argument[self]; ReturnValue.Future.Field[core::result::Result::Ok(0)].Field[core::option::Option::Some(0)]; taint |
+| 124 | Summary: <tokio::net::tcp::stream::TcpStream>::peek; Argument[self]; Argument[0].Reference; taint |
+| 125 | Summary: <tokio::net::tcp::stream::TcpStream>::try_read; Argument[self]; Argument[0].Reference; taint |
+| 126 | Summary: <tokio::net::tcp::stream::TcpStream>::try_read_buf; Argument[self]; Argument[0].Reference; taint |
 edges
-| test.rs:8:10:8:22 | ...::var | test.rs:8:10:8:30 | ...::var(...) | provenance | Src:MaD:23  |
-| test.rs:9:10:9:25 | ...::var_os | test.rs:9:10:9:33 | ...::var_os(...) | provenance | Src:MaD:24  |
+| test.rs:8:10:8:22 | ...::var | test.rs:8:10:8:30 | ...::var(...) | provenance | Src:MaD:26  |
+| test.rs:9:10:9:25 | ...::var_os | test.rs:9:10:9:33 | ...::var_os(...) | provenance | Src:MaD:27  |
 | test.rs:11:9:11:12 | var1 | test.rs:14:10:14:13 | var1 | provenance |  |
-| test.rs:11:16:11:28 | ...::var | test.rs:11:16:11:36 | ...::var(...) [Ok] | provenance | Src:MaD:23  |
-| test.rs:11:16:11:36 | ...::var(...) [Ok] | test.rs:11:16:11:59 | ... .expect(...) | provenance | MaD:83 |
+| test.rs:11:16:11:28 | ...::var | test.rs:11:16:11:36 | ...::var(...) [Ok] | provenance | Src:MaD:26  |
+| test.rs:11:16:11:36 | ...::var(...) [Ok] | test.rs:11:16:11:59 | ... .expect(...) | provenance | MaD:86 |
 | test.rs:11:16:11:59 | ... .expect(...) | test.rs:11:9:11:12 | var1 | provenance |  |
 | test.rs:12:9:12:12 | var2 | test.rs:15:10:15:13 | var2 | provenance |  |
-| test.rs:12:16:12:31 | ...::var_os | test.rs:12:16:12:39 | ...::var_os(...) [Some] | provenance | Src:MaD:24  |
-| test.rs:12:16:12:39 | ...::var_os(...) [Some] | test.rs:12:16:12:48 | ... .unwrap() | provenance | MaD:79 |
+| test.rs:12:16:12:31 | ...::var_os | test.rs:12:16:12:39 | ...::var_os(...) [Some] | provenance | Src:MaD:27  |
+| test.rs:12:16:12:39 | ...::var_os(...) [Some] | test.rs:12:16:12:48 | ... .unwrap() | provenance | MaD:82 |
 | test.rs:12:16:12:48 | ... .unwrap() | test.rs:12:9:12:12 | var2 | provenance |  |
 | test.rs:29:9:29:12 | args [element] | test.rs:30:20:30:23 | args [element] | provenance |  |
 | test.rs:29:9:29:12 | args [element] | test.rs:31:17:31:20 | args [element] | provenance |  |
-| test.rs:29:29:29:42 | ...::args | test.rs:29:29:29:44 | ...::args(...) [element] | provenance | Src:MaD:18  |
-| test.rs:29:29:29:44 | ...::args(...) [element] | test.rs:29:29:29:54 | ... .collect() [element] | provenance | MaD:38 |
+| test.rs:29:29:29:42 | ...::args | test.rs:29:29:29:44 | ...::args(...) [element] | provenance | Src:MaD:21  |
+| test.rs:29:29:29:44 | ...::args(...) [element] | test.rs:29:29:29:54 | ... .collect() [element] | provenance | MaD:41 |
 | test.rs:29:29:29:54 | ... .collect() [element] | test.rs:29:9:29:12 | args [element] | provenance |  |
 | test.rs:30:9:30:15 | my_path [&ref] | test.rs:36:10:36:16 | my_path | provenance |  |
 | test.rs:30:19:30:26 | &... [&ref] | test.rs:30:9:30:15 | my_path [&ref] | provenance |  |
@@ -147,89 +150,89 @@ edges
 | test.rs:31:17:31:20 | args [element] | test.rs:31:17:31:23 | args[1] | provenance |  |
 | test.rs:31:17:31:23 | args[1] | test.rs:31:16:31:23 | &... [&ref] | provenance |  |
 | test.rs:32:9:32:12 | arg2 | test.rs:38:10:38:13 | arg2 | provenance |  |
-| test.rs:32:16:32:29 | ...::args | test.rs:32:16:32:31 | ...::args(...) [element] | provenance | Src:MaD:18  |
-| test.rs:32:16:32:31 | ...::args(...) [element] | test.rs:32:16:32:38 | ... .nth(...) [Some] | provenance | MaD:39 |
-| test.rs:32:16:32:38 | ... .nth(...) [Some] | test.rs:32:16:32:47 | ... .unwrap() | provenance | MaD:79 |
+| test.rs:32:16:32:29 | ...::args | test.rs:32:16:32:31 | ...::args(...) [element] | provenance | Src:MaD:21  |
+| test.rs:32:16:32:31 | ...::args(...) [element] | test.rs:32:16:32:38 | ... .nth(...) [Some] | provenance | MaD:42 |
+| test.rs:32:16:32:38 | ... .nth(...) [Some] | test.rs:32:16:32:47 | ... .unwrap() | provenance | MaD:82 |
 | test.rs:32:16:32:47 | ... .unwrap() | test.rs:32:9:32:12 | arg2 | provenance |  |
 | test.rs:33:9:33:12 | arg3 | test.rs:39:10:39:13 | arg3 | provenance |  |
-| test.rs:33:16:33:32 | ...::args_os | test.rs:33:16:33:34 | ...::args_os(...) [element] | provenance | Src:MaD:19  |
-| test.rs:33:16:33:34 | ...::args_os(...) [element] | test.rs:33:16:33:41 | ... .nth(...) [Some] | provenance | MaD:39 |
-| test.rs:33:16:33:41 | ... .nth(...) [Some] | test.rs:33:16:33:50 | ... .unwrap() | provenance | MaD:79 |
+| test.rs:33:16:33:32 | ...::args_os | test.rs:33:16:33:34 | ...::args_os(...) [element] | provenance | Src:MaD:22  |
+| test.rs:33:16:33:34 | ...::args_os(...) [element] | test.rs:33:16:33:41 | ... .nth(...) [Some] | provenance | MaD:42 |
+| test.rs:33:16:33:41 | ... .nth(...) [Some] | test.rs:33:16:33:50 | ... .unwrap() | provenance | MaD:82 |
 | test.rs:33:16:33:50 | ... .unwrap() | test.rs:33:9:33:12 | arg3 | provenance |  |
 | test.rs:34:9:34:12 | arg4 | test.rs:40:10:40:13 | arg4 | provenance |  |
-| test.rs:34:16:34:29 | ...::args | test.rs:34:16:34:31 | ...::args(...) [element] | provenance | Src:MaD:18  |
-| test.rs:34:16:34:31 | ...::args(...) [element] | test.rs:34:16:34:38 | ... .nth(...) [Some] | provenance | MaD:39 |
-| test.rs:34:16:34:38 | ... .nth(...) [Some] | test.rs:34:16:34:47 | ... .unwrap() | provenance | MaD:79 |
-| test.rs:34:16:34:47 | ... .unwrap() | test.rs:34:16:34:64 | ... .parse() [Ok] | provenance | MaD:87 |
-| test.rs:34:16:34:64 | ... .parse() [Ok] | test.rs:34:16:34:73 | ... .unwrap() | provenance | MaD:84 |
+| test.rs:34:16:34:29 | ...::args | test.rs:34:16:34:31 | ...::args(...) [element] | provenance | Src:MaD:21  |
+| test.rs:34:16:34:31 | ...::args(...) [element] | test.rs:34:16:34:38 | ... .nth(...) [Some] | provenance | MaD:42 |
+| test.rs:34:16:34:38 | ... .nth(...) [Some] | test.rs:34:16:34:47 | ... .unwrap() | provenance | MaD:82 |
+| test.rs:34:16:34:47 | ... .unwrap() | test.rs:34:16:34:64 | ... .parse() [Ok] | provenance | MaD:90 |
+| test.rs:34:16:34:64 | ... .parse() [Ok] | test.rs:34:16:34:73 | ... .unwrap() | provenance | MaD:87 |
 | test.rs:34:16:34:73 | ... .unwrap() | test.rs:34:9:34:12 | arg4 | provenance |  |
 | test.rs:42:9:42:11 | arg | test.rs:43:14:43:16 | arg | provenance |  |
-| test.rs:42:16:42:29 | ...::args | test.rs:42:16:42:31 | ...::args(...) [element] | provenance | Src:MaD:18  |
+| test.rs:42:16:42:29 | ...::args | test.rs:42:16:42:31 | ...::args(...) [element] | provenance | Src:MaD:21  |
 | test.rs:42:16:42:31 | ...::args(...) [element] | test.rs:42:9:42:11 | arg | provenance |  |
 | test.rs:46:9:46:11 | arg | test.rs:47:14:47:16 | arg | provenance |  |
-| test.rs:46:16:46:32 | ...::args_os | test.rs:46:16:46:34 | ...::args_os(...) [element] | provenance | Src:MaD:19  |
+| test.rs:46:16:46:32 | ...::args_os | test.rs:46:16:46:34 | ...::args_os(...) [element] | provenance | Src:MaD:22  |
 | test.rs:46:16:46:34 | ...::args_os(...) [element] | test.rs:46:9:46:11 | arg | provenance |  |
 | test.rs:52:9:52:11 | dir | test.rs:56:10:56:12 | dir | provenance |  |
-| test.rs:52:15:52:35 | ...::current_dir | test.rs:52:15:52:37 | ...::current_dir(...) [Ok] | provenance | Src:MaD:20  |
-| test.rs:52:15:52:37 | ...::current_dir(...) [Ok] | test.rs:52:15:52:54 | ... .expect(...) | provenance | MaD:83 |
+| test.rs:52:15:52:35 | ...::current_dir | test.rs:52:15:52:37 | ...::current_dir(...) [Ok] | provenance | Src:MaD:23  |
+| test.rs:52:15:52:37 | ...::current_dir(...) [Ok] | test.rs:52:15:52:54 | ... .expect(...) | provenance | MaD:86 |
 | test.rs:52:15:52:54 | ... .expect(...) | test.rs:52:9:52:11 | dir | provenance |  |
 | test.rs:53:9:53:11 | exe | test.rs:57:10:57:12 | exe | provenance |  |
-| test.rs:53:15:53:35 | ...::current_exe | test.rs:53:15:53:37 | ...::current_exe(...) [Ok] | provenance | Src:MaD:21  |
-| test.rs:53:15:53:37 | ...::current_exe(...) [Ok] | test.rs:53:15:53:54 | ... .expect(...) | provenance | MaD:83 |
+| test.rs:53:15:53:35 | ...::current_exe | test.rs:53:15:53:37 | ...::current_exe(...) [Ok] | provenance | Src:MaD:24  |
+| test.rs:53:15:53:37 | ...::current_exe(...) [Ok] | test.rs:53:15:53:54 | ... .expect(...) | provenance | MaD:86 |
 | test.rs:53:15:53:54 | ... .expect(...) | test.rs:53:9:53:11 | exe | provenance |  |
 | test.rs:54:9:54:12 | home | test.rs:58:10:58:13 | home | provenance |  |
-| test.rs:54:16:54:33 | ...::home_dir | test.rs:54:16:54:35 | ...::home_dir(...) [Some] | provenance | Src:MaD:22  |
-| test.rs:54:16:54:35 | ...::home_dir(...) [Some] | test.rs:54:16:54:52 | ... .expect(...) | provenance | MaD:78 |
+| test.rs:54:16:54:33 | ...::home_dir | test.rs:54:16:54:35 | ...::home_dir(...) [Some] | provenance | Src:MaD:25  |
+| test.rs:54:16:54:35 | ...::home_dir(...) [Some] | test.rs:54:16:54:52 | ... .expect(...) | provenance | MaD:81 |
 | test.rs:54:16:54:52 | ... .expect(...) | test.rs:54:9:54:12 | home | provenance |  |
 | test.rs:62:9:62:22 | remote_string1 | test.rs:63:10:63:23 | remote_string1 | provenance |  |
-| test.rs:62:26:62:47 | ...::get | test.rs:62:26:62:62 | ...::get(...) [Ok] | provenance | Src:MaD:16  |
+| test.rs:62:26:62:47 | ...::get | test.rs:62:26:62:62 | ...::get(...) [Ok] | provenance | Src:MaD:19  |
 | test.rs:62:26:62:62 | ...::get(...) [Ok] | test.rs:62:26:62:63 | TryExpr | provenance |  |
-| test.rs:62:26:62:63 | TryExpr | test.rs:62:26:62:70 | ... .text() [Ok] | provenance | MaD:94 |
+| test.rs:62:26:62:63 | TryExpr | test.rs:62:26:62:70 | ... .text() [Ok] | provenance | MaD:97 |
 | test.rs:62:26:62:70 | ... .text() [Ok] | test.rs:62:26:62:71 | TryExpr | provenance |  |
 | test.rs:62:26:62:71 | TryExpr | test.rs:62:9:62:22 | remote_string1 | provenance |  |
 | test.rs:65:9:65:22 | remote_string2 | test.rs:66:10:66:23 | remote_string2 | provenance |  |
-| test.rs:65:26:65:47 | ...::get | test.rs:65:26:65:62 | ...::get(...) [Ok] | provenance | Src:MaD:16  |
-| test.rs:65:26:65:62 | ...::get(...) [Ok] | test.rs:65:26:65:71 | ... .unwrap() | provenance | MaD:84 |
-| test.rs:65:26:65:71 | ... .unwrap() | test.rs:65:26:65:78 | ... .text() [Ok] | provenance | MaD:94 |
-| test.rs:65:26:65:78 | ... .text() [Ok] | test.rs:65:26:65:87 | ... .unwrap() | provenance | MaD:84 |
+| test.rs:65:26:65:47 | ...::get | test.rs:65:26:65:62 | ...::get(...) [Ok] | provenance | Src:MaD:19  |
+| test.rs:65:26:65:62 | ...::get(...) [Ok] | test.rs:65:26:65:71 | ... .unwrap() | provenance | MaD:87 |
+| test.rs:65:26:65:71 | ... .unwrap() | test.rs:65:26:65:78 | ... .text() [Ok] | provenance | MaD:97 |
+| test.rs:65:26:65:78 | ... .text() [Ok] | test.rs:65:26:65:87 | ... .unwrap() | provenance | MaD:87 |
 | test.rs:65:26:65:87 | ... .unwrap() | test.rs:65:9:65:22 | remote_string2 | provenance |  |
 | test.rs:68:9:68:22 | remote_string3 | test.rs:69:10:69:23 | remote_string3 | provenance |  |
-| test.rs:68:26:68:47 | ...::get | test.rs:68:26:68:62 | ...::get(...) [Ok] | provenance | Src:MaD:16  |
-| test.rs:68:26:68:62 | ...::get(...) [Ok] | test.rs:68:26:68:71 | ... .unwrap() | provenance | MaD:84 |
-| test.rs:68:26:68:71 | ... .unwrap() | test.rs:68:26:68:98 | ... .text_with_charset(...) [Ok] | provenance | MaD:95 |
-| test.rs:68:26:68:98 | ... .text_with_charset(...) [Ok] | test.rs:68:26:68:107 | ... .unwrap() | provenance | MaD:84 |
+| test.rs:68:26:68:47 | ...::get | test.rs:68:26:68:62 | ...::get(...) [Ok] | provenance | Src:MaD:19  |
+| test.rs:68:26:68:62 | ...::get(...) [Ok] | test.rs:68:26:68:71 | ... .unwrap() | provenance | MaD:87 |
+| test.rs:68:26:68:71 | ... .unwrap() | test.rs:68:26:68:98 | ... .text_with_charset(...) [Ok] | provenance | MaD:98 |
+| test.rs:68:26:68:98 | ... .text_with_charset(...) [Ok] | test.rs:68:26:68:107 | ... .unwrap() | provenance | MaD:87 |
 | test.rs:68:26:68:107 | ... .unwrap() | test.rs:68:9:68:22 | remote_string3 | provenance |  |
 | test.rs:71:9:71:22 | remote_string4 | test.rs:72:10:72:23 | remote_string4 | provenance |  |
-| test.rs:71:26:71:47 | ...::get | test.rs:71:26:71:62 | ...::get(...) [Ok] | provenance | Src:MaD:16  |
-| test.rs:71:26:71:62 | ...::get(...) [Ok] | test.rs:71:26:71:71 | ... .unwrap() | provenance | MaD:84 |
-| test.rs:71:26:71:71 | ... .unwrap() | test.rs:71:26:71:79 | ... .bytes() [Ok] | provenance | MaD:93 |
-| test.rs:71:26:71:79 | ... .bytes() [Ok] | test.rs:71:26:71:88 | ... .unwrap() | provenance | MaD:84 |
+| test.rs:71:26:71:47 | ...::get | test.rs:71:26:71:62 | ...::get(...) [Ok] | provenance | Src:MaD:19  |
+| test.rs:71:26:71:62 | ...::get(...) [Ok] | test.rs:71:26:71:71 | ... .unwrap() | provenance | MaD:87 |
+| test.rs:71:26:71:71 | ... .unwrap() | test.rs:71:26:71:79 | ... .bytes() [Ok] | provenance | MaD:96 |
+| test.rs:71:26:71:79 | ... .bytes() [Ok] | test.rs:71:26:71:88 | ... .unwrap() | provenance | MaD:87 |
 | test.rs:71:26:71:88 | ... .unwrap() | test.rs:71:9:71:22 | remote_string4 | provenance |  |
 | test.rs:74:9:74:22 | remote_string5 | test.rs:75:10:75:23 | remote_string5 | provenance |  |
-| test.rs:74:26:74:37 | ...::get | test.rs:74:26:74:52 | ...::get(...) [future, Ok] | provenance | Src:MaD:17  |
+| test.rs:74:26:74:37 | ...::get | test.rs:74:26:74:52 | ...::get(...) [future, Ok] | provenance | Src:MaD:20  |
 | test.rs:74:26:74:52 | ...::get(...) [future, Ok] | test.rs:74:26:74:58 | await ... [Ok] | provenance |  |
 | test.rs:74:26:74:58 | await ... [Ok] | test.rs:74:26:74:59 | TryExpr | provenance |  |
-| test.rs:74:26:74:59 | TryExpr | test.rs:74:26:74:66 | ... .text() [future, Ok] | provenance | MaD:92 |
+| test.rs:74:26:74:59 | TryExpr | test.rs:74:26:74:66 | ... .text() [future, Ok] | provenance | MaD:95 |
 | test.rs:74:26:74:66 | ... .text() [future, Ok] | test.rs:74:26:74:72 | await ... [Ok] | provenance |  |
 | test.rs:74:26:74:72 | await ... [Ok] | test.rs:74:26:74:73 | TryExpr | provenance |  |
 | test.rs:74:26:74:73 | TryExpr | test.rs:74:9:74:22 | remote_string5 | provenance |  |
 | test.rs:77:9:77:22 | remote_string6 | test.rs:78:10:78:23 | remote_string6 | provenance |  |
-| test.rs:77:26:77:37 | ...::get | test.rs:77:26:77:52 | ...::get(...) [future, Ok] | provenance | Src:MaD:17  |
+| test.rs:77:26:77:37 | ...::get | test.rs:77:26:77:52 | ...::get(...) [future, Ok] | provenance | Src:MaD:20  |
 | test.rs:77:26:77:52 | ...::get(...) [future, Ok] | test.rs:77:26:77:58 | await ... [Ok] | provenance |  |
 | test.rs:77:26:77:58 | await ... [Ok] | test.rs:77:26:77:59 | TryExpr | provenance |  |
-| test.rs:77:26:77:59 | TryExpr | test.rs:77:26:77:67 | ... .bytes() [future, Ok] | provenance | MaD:90 |
+| test.rs:77:26:77:59 | TryExpr | test.rs:77:26:77:67 | ... .bytes() [future, Ok] | provenance | MaD:93 |
 | test.rs:77:26:77:67 | ... .bytes() [future, Ok] | test.rs:77:26:77:73 | await ... [Ok] | provenance |  |
 | test.rs:77:26:77:73 | await ... [Ok] | test.rs:77:26:77:74 | TryExpr | provenance |  |
 | test.rs:77:26:77:74 | TryExpr | test.rs:77:9:77:22 | remote_string6 | provenance |  |
-| test.rs:80:9:80:20 | mut request1 | test.rs:81:10:81:25 | request1.chunk() [future, Ok, Some] | provenance | MaD:91 |
-| test.rs:80:9:80:20 | mut request1 | test.rs:82:29:82:44 | request1.chunk() [future, Ok, Some] | provenance | MaD:91 |
-| test.rs:80:24:80:35 | ...::get | test.rs:80:24:80:50 | ...::get(...) [future, Ok] | provenance | Src:MaD:17  |
+| test.rs:80:9:80:20 | mut request1 | test.rs:81:10:81:25 | request1.chunk() [future, Ok, Some] | provenance | MaD:94 |
+| test.rs:80:9:80:20 | mut request1 | test.rs:82:29:82:44 | request1.chunk() [future, Ok, Some] | provenance | MaD:94 |
+| test.rs:80:24:80:35 | ...::get | test.rs:80:24:80:50 | ...::get(...) [future, Ok] | provenance | Src:MaD:20  |
 | test.rs:80:24:80:50 | ...::get(...) [future, Ok] | test.rs:80:24:80:56 | await ... [Ok] | provenance |  |
 | test.rs:80:24:80:56 | await ... [Ok] | test.rs:80:24:80:57 | TryExpr | provenance |  |
 | test.rs:80:24:80:57 | TryExpr | test.rs:80:9:80:20 | mut request1 | provenance |  |
 | test.rs:81:10:81:25 | request1.chunk() [future, Ok, Some] | test.rs:81:10:81:31 | await ... [Ok, Some] | provenance |  |
 | test.rs:81:10:81:31 | await ... [Ok, Some] | test.rs:81:10:81:32 | TryExpr [Some] | provenance |  |
-| test.rs:81:10:81:32 | TryExpr [Some] | test.rs:81:10:81:41 | ... .unwrap() | provenance | MaD:79 |
+| test.rs:81:10:81:32 | TryExpr [Some] | test.rs:81:10:81:41 | ... .unwrap() | provenance | MaD:82 |
 | test.rs:82:15:82:25 | Some(...) [Some] | test.rs:82:20:82:24 | chunk | provenance |  |
 | test.rs:82:20:82:24 | chunk | test.rs:83:14:83:18 | chunk | provenance |  |
 | test.rs:82:29:82:44 | request1.chunk() [future, Ok, Some] | test.rs:82:29:82:50 | await ... [Ok, Some] | provenance |  |
@@ -240,129 +243,129 @@ edges
 | test.rs:114:24:114:51 | sender.send_request(...) [future, Ok] | test.rs:114:24:114:57 | await ... [Ok] | provenance |  |
 | test.rs:114:24:114:57 | await ... [Ok] | test.rs:114:24:114:58 | TryExpr | provenance |  |
 | test.rs:114:24:114:58 | TryExpr | test.rs:114:13:114:20 | response | provenance |  |
-| test.rs:114:31:114:42 | send_request | test.rs:114:24:114:51 | sender.send_request(...) [future, Ok] | provenance | Src:MaD:4  |
+| test.rs:114:31:114:42 | send_request | test.rs:114:24:114:51 | sender.send_request(...) [future, Ok] | provenance | Src:MaD:7  |
 | test.rs:115:15:115:22 | response | test.rs:115:14:115:22 | &response | provenance |  |
 | test.rs:121:9:121:20 | mut response | test.rs:122:11:122:18 | response | provenance |  |
 | test.rs:121:24:121:51 | sender.send_request(...) [future, Ok] | test.rs:121:24:121:57 | await ... [Ok] | provenance |  |
 | test.rs:121:24:121:57 | await ... [Ok] | test.rs:121:24:121:58 | TryExpr | provenance |  |
 | test.rs:121:24:121:58 | TryExpr | test.rs:121:9:121:20 | mut response | provenance |  |
-| test.rs:121:31:121:42 | send_request | test.rs:121:24:121:51 | sender.send_request(...) [future, Ok] | provenance | Src:MaD:4  |
+| test.rs:121:31:121:42 | send_request | test.rs:121:24:121:51 | sender.send_request(...) [future, Ok] | provenance | Src:MaD:7  |
 | test.rs:122:11:122:18 | response | test.rs:122:10:122:18 | &response | provenance |  |
-| test.rs:211:22:211:35 | ...::stdin | test.rs:211:22:211:37 | ...::stdin(...) | provenance | Src:MaD:30 MaD:30 |
-| test.rs:211:22:211:37 | ...::stdin(...) | test.rs:211:44:211:54 | [post] &mut buffer | provenance | MaD:107 |
-| test.rs:211:22:211:37 | ...::stdin(...) | test.rs:211:44:211:54 | [post] &mut buffer [&ref] | provenance | MaD:57 |
-| test.rs:211:22:211:37 | ...::stdin(...) | test.rs:211:44:211:54 | [post] &mut buffer [&ref] | provenance | MaD:106 |
+| test.rs:211:22:211:35 | ...::stdin | test.rs:211:22:211:37 | ...::stdin(...) | provenance | Src:MaD:33 MaD:33 |
+| test.rs:211:22:211:37 | ...::stdin(...) | test.rs:211:44:211:54 | [post] &mut buffer | provenance | MaD:110 |
+| test.rs:211:22:211:37 | ...::stdin(...) | test.rs:211:44:211:54 | [post] &mut buffer [&ref] | provenance | MaD:60 |
+| test.rs:211:22:211:37 | ...::stdin(...) | test.rs:211:44:211:54 | [post] &mut buffer [&ref] | provenance | MaD:109 |
 | test.rs:211:44:211:54 | [post] &mut buffer | test.rs:212:15:212:20 | buffer | provenance |  |
 | test.rs:211:44:211:54 | [post] &mut buffer [&ref] | test.rs:211:49:211:54 | [post] buffer | provenance |  |
 | test.rs:211:49:211:54 | [post] buffer | test.rs:212:15:212:20 | buffer | provenance |  |
 | test.rs:212:15:212:20 | buffer | test.rs:212:14:212:20 | &buffer | provenance |  |
-| test.rs:217:22:217:35 | ...::stdin | test.rs:217:22:217:37 | ...::stdin(...) | provenance | Src:MaD:30 MaD:30 |
-| test.rs:217:22:217:37 | ...::stdin(...) | test.rs:217:51:217:61 | [post] &mut buffer [&ref] | provenance | MaD:59 |
-| test.rs:217:22:217:37 | ...::stdin(...) | test.rs:217:51:217:61 | [post] &mut buffer [&ref] | provenance | MaD:110 |
+| test.rs:217:22:217:35 | ...::stdin | test.rs:217:22:217:37 | ...::stdin(...) | provenance | Src:MaD:33 MaD:33 |
+| test.rs:217:22:217:37 | ...::stdin(...) | test.rs:217:51:217:61 | [post] &mut buffer [&ref] | provenance | MaD:62 |
+| test.rs:217:22:217:37 | ...::stdin(...) | test.rs:217:51:217:61 | [post] &mut buffer [&ref] | provenance | MaD:113 |
 | test.rs:217:51:217:61 | [post] &mut buffer [&ref] | test.rs:217:56:217:61 | [post] buffer | provenance |  |
 | test.rs:217:56:217:61 | [post] buffer | test.rs:218:15:218:20 | buffer | provenance |  |
 | test.rs:218:15:218:20 | buffer | test.rs:218:14:218:20 | &buffer | provenance |  |
-| test.rs:223:22:223:35 | ...::stdin | test.rs:223:22:223:37 | ...::stdin(...) | provenance | Src:MaD:30 MaD:30 |
-| test.rs:223:22:223:37 | ...::stdin(...) | test.rs:223:54:223:64 | [post] &mut buffer | provenance | MaD:112 |
-| test.rs:223:22:223:37 | ...::stdin(...) | test.rs:223:54:223:64 | [post] &mut buffer [&ref] | provenance | MaD:60 |
-| test.rs:223:22:223:37 | ...::stdin(...) | test.rs:223:54:223:64 | [post] &mut buffer [&ref] | provenance | MaD:111 |
+| test.rs:223:22:223:35 | ...::stdin | test.rs:223:22:223:37 | ...::stdin(...) | provenance | Src:MaD:33 MaD:33 |
+| test.rs:223:22:223:37 | ...::stdin(...) | test.rs:223:54:223:64 | [post] &mut buffer | provenance | MaD:115 |
+| test.rs:223:22:223:37 | ...::stdin(...) | test.rs:223:54:223:64 | [post] &mut buffer [&ref] | provenance | MaD:63 |
+| test.rs:223:22:223:37 | ...::stdin(...) | test.rs:223:54:223:64 | [post] &mut buffer [&ref] | provenance | MaD:114 |
 | test.rs:223:54:223:64 | [post] &mut buffer | test.rs:224:15:224:20 | buffer | provenance |  |
 | test.rs:223:54:223:64 | [post] &mut buffer [&ref] | test.rs:223:59:223:64 | [post] buffer | provenance |  |
 | test.rs:223:59:223:64 | [post] buffer | test.rs:224:15:224:20 | buffer | provenance |  |
 | test.rs:224:15:224:20 | buffer | test.rs:224:14:224:20 | &buffer | provenance |  |
-| test.rs:229:22:229:35 | ...::stdin | test.rs:229:22:229:37 | ...::stdin(...) | provenance | Src:MaD:30 MaD:30 |
-| test.rs:229:22:229:37 | ...::stdin(...) | test.rs:229:22:229:44 | ... .lock() | provenance | MaD:113 |
-| test.rs:229:22:229:44 | ... .lock() | test.rs:229:61:229:71 | [post] &mut buffer [&ref] | provenance | MaD:60 |
-| test.rs:229:22:229:44 | ... .lock() | test.rs:229:61:229:71 | [post] &mut buffer [&ref] | provenance | MaD:114 |
+| test.rs:229:22:229:35 | ...::stdin | test.rs:229:22:229:37 | ...::stdin(...) | provenance | Src:MaD:33 MaD:33 |
+| test.rs:229:22:229:37 | ...::stdin(...) | test.rs:229:22:229:44 | ... .lock() | provenance | MaD:116 |
+| test.rs:229:22:229:44 | ... .lock() | test.rs:229:61:229:71 | [post] &mut buffer [&ref] | provenance | MaD:63 |
+| test.rs:229:22:229:44 | ... .lock() | test.rs:229:61:229:71 | [post] &mut buffer [&ref] | provenance | MaD:117 |
 | test.rs:229:61:229:71 | [post] &mut buffer [&ref] | test.rs:229:66:229:71 | [post] buffer | provenance |  |
 | test.rs:229:66:229:71 | [post] buffer | test.rs:230:15:230:20 | buffer | provenance |  |
 | test.rs:230:15:230:20 | buffer | test.rs:230:14:230:20 | &buffer | provenance |  |
-| test.rs:235:9:235:22 | ...::stdin | test.rs:235:9:235:24 | ...::stdin(...) | provenance | Src:MaD:30 MaD:30 |
-| test.rs:235:9:235:24 | ...::stdin(...) | test.rs:235:37:235:47 | [post] &mut buffer | provenance | MaD:109 |
-| test.rs:235:9:235:24 | ...::stdin(...) | test.rs:235:37:235:47 | [post] &mut buffer [&ref] | provenance | MaD:58 |
-| test.rs:235:9:235:24 | ...::stdin(...) | test.rs:235:37:235:47 | [post] &mut buffer [&ref] | provenance | MaD:108 |
+| test.rs:235:9:235:22 | ...::stdin | test.rs:235:9:235:24 | ...::stdin(...) | provenance | Src:MaD:33 MaD:33 |
+| test.rs:235:9:235:24 | ...::stdin(...) | test.rs:235:37:235:47 | [post] &mut buffer | provenance | MaD:112 |
+| test.rs:235:9:235:24 | ...::stdin(...) | test.rs:235:37:235:47 | [post] &mut buffer [&ref] | provenance | MaD:61 |
+| test.rs:235:9:235:24 | ...::stdin(...) | test.rs:235:37:235:47 | [post] &mut buffer [&ref] | provenance | MaD:111 |
 | test.rs:235:37:235:47 | [post] &mut buffer | test.rs:236:15:236:20 | buffer | provenance |  |
 | test.rs:235:37:235:47 | [post] &mut buffer [&ref] | test.rs:235:42:235:47 | [post] buffer | provenance |  |
 | test.rs:235:42:235:47 | [post] buffer | test.rs:236:15:236:20 | buffer | provenance |  |
 | test.rs:236:15:236:20 | buffer | test.rs:236:14:236:20 | &buffer | provenance |  |
-| test.rs:239:17:239:30 | ...::stdin | test.rs:239:17:239:32 | ...::stdin(...) | provenance | Src:MaD:30 MaD:30 |
-| test.rs:239:17:239:32 | ...::stdin(...) | test.rs:239:17:239:40 | ... .bytes() | provenance | MaD:54 |
+| test.rs:239:17:239:30 | ...::stdin | test.rs:239:17:239:32 | ...::stdin(...) | provenance | Src:MaD:33 MaD:33 |
+| test.rs:239:17:239:32 | ...::stdin(...) | test.rs:239:17:239:40 | ... .bytes() | provenance | MaD:57 |
 | test.rs:239:17:239:40 | ... .bytes() | test.rs:240:14:240:17 | byte | provenance |  |
-| test.rs:246:13:246:22 | mut reader | test.rs:247:20:247:36 | reader.fill_buf() [Ok] | provenance | MaD:103 |
+| test.rs:246:13:246:22 | mut reader | test.rs:247:20:247:36 | reader.fill_buf() [Ok] | provenance | MaD:106 |
 | test.rs:246:26:246:66 | ...::new(...) | test.rs:246:13:246:22 | mut reader | provenance |  |
-| test.rs:246:50:246:63 | ...::stdin | test.rs:246:50:246:65 | ...::stdin(...) | provenance | Src:MaD:30 MaD:30 |
-| test.rs:246:50:246:65 | ...::stdin(...) | test.rs:246:26:246:66 | ...::new(...) | provenance | MaD:105 |
+| test.rs:246:50:246:63 | ...::stdin | test.rs:246:50:246:65 | ...::stdin(...) | provenance | Src:MaD:33 MaD:33 |
+| test.rs:246:50:246:65 | ...::stdin(...) | test.rs:246:26:246:66 | ...::new(...) | provenance | MaD:108 |
 | test.rs:247:13:247:16 | data | test.rs:248:15:248:18 | data | provenance |  |
 | test.rs:247:20:247:36 | reader.fill_buf() [Ok] | test.rs:247:20:247:37 | TryExpr | provenance |  |
 | test.rs:247:20:247:37 | TryExpr | test.rs:247:13:247:16 | data | provenance |  |
 | test.rs:248:15:248:18 | data | test.rs:248:14:248:18 | &data | provenance |  |
-| test.rs:252:13:252:18 | reader | test.rs:253:20:253:34 | reader.buffer() | provenance | MaD:104 |
+| test.rs:252:13:252:18 | reader | test.rs:253:20:253:34 | reader.buffer() | provenance | MaD:107 |
 | test.rs:252:22:252:62 | ...::new(...) | test.rs:252:13:252:18 | reader | provenance |  |
-| test.rs:252:46:252:59 | ...::stdin | test.rs:252:46:252:61 | ...::stdin(...) | provenance | Src:MaD:30 MaD:30 |
-| test.rs:252:46:252:61 | ...::stdin(...) | test.rs:252:22:252:62 | ...::new(...) | provenance | MaD:105 |
+| test.rs:252:46:252:59 | ...::stdin | test.rs:252:46:252:61 | ...::stdin(...) | provenance | Src:MaD:33 MaD:33 |
+| test.rs:252:46:252:61 | ...::stdin(...) | test.rs:252:22:252:62 | ...::new(...) | provenance | MaD:108 |
 | test.rs:253:13:253:16 | data | test.rs:254:15:254:18 | data | provenance |  |
 | test.rs:253:20:253:34 | reader.buffer() | test.rs:253:13:253:16 | data | provenance |  |
 | test.rs:254:15:254:18 | data | test.rs:254:14:254:18 | &data | provenance |  |
-| test.rs:259:13:259:22 | mut reader | test.rs:260:26:260:36 | [post] &mut buffer [&ref] | provenance | MaD:51 |
+| test.rs:259:13:259:22 | mut reader | test.rs:260:26:260:36 | [post] &mut buffer [&ref] | provenance | MaD:54 |
 | test.rs:259:26:259:66 | ...::new(...) | test.rs:259:13:259:22 | mut reader | provenance |  |
-| test.rs:259:50:259:63 | ...::stdin | test.rs:259:50:259:65 | ...::stdin(...) | provenance | Src:MaD:30 MaD:30 |
-| test.rs:259:50:259:65 | ...::stdin(...) | test.rs:259:26:259:66 | ...::new(...) | provenance | MaD:105 |
+| test.rs:259:50:259:63 | ...::stdin | test.rs:259:50:259:65 | ...::stdin(...) | provenance | Src:MaD:33 MaD:33 |
+| test.rs:259:50:259:65 | ...::stdin(...) | test.rs:259:26:259:66 | ...::new(...) | provenance | MaD:108 |
 | test.rs:260:26:260:36 | [post] &mut buffer [&ref] | test.rs:260:31:260:36 | [post] buffer | provenance |  |
 | test.rs:260:31:260:36 | [post] buffer | test.rs:261:15:261:20 | buffer | provenance |  |
 | test.rs:261:15:261:20 | buffer | test.rs:261:14:261:20 | &buffer | provenance |  |
-| test.rs:266:13:266:22 | mut reader | test.rs:267:33:267:43 | [post] &mut buffer [&ref] | provenance | MaD:52 |
+| test.rs:266:13:266:22 | mut reader | test.rs:267:33:267:43 | [post] &mut buffer [&ref] | provenance | MaD:55 |
 | test.rs:266:26:266:66 | ...::new(...) | test.rs:266:13:266:22 | mut reader | provenance |  |
-| test.rs:266:50:266:63 | ...::stdin | test.rs:266:50:266:65 | ...::stdin(...) | provenance | Src:MaD:30 MaD:30 |
-| test.rs:266:50:266:65 | ...::stdin(...) | test.rs:266:26:266:66 | ...::new(...) | provenance | MaD:105 |
+| test.rs:266:50:266:63 | ...::stdin | test.rs:266:50:266:65 | ...::stdin(...) | provenance | Src:MaD:33 MaD:33 |
+| test.rs:266:50:266:65 | ...::stdin(...) | test.rs:266:26:266:66 | ...::new(...) | provenance | MaD:108 |
 | test.rs:267:33:267:43 | [post] &mut buffer [&ref] | test.rs:267:38:267:43 | [post] buffer | provenance |  |
 | test.rs:267:38:267:43 | [post] buffer | test.rs:268:15:268:20 | buffer | provenance |  |
 | test.rs:267:38:267:43 | [post] buffer | test.rs:269:14:269:22 | buffer[0] | provenance |  |
 | test.rs:268:15:268:20 | buffer | test.rs:268:14:268:20 | &buffer | provenance |  |
-| test.rs:273:13:273:28 | mut reader_split | test.rs:274:14:274:32 | reader_split.next() [Some, Ok] | provenance | MaD:102 |
-| test.rs:273:13:273:28 | mut reader_split | test.rs:275:33:275:51 | reader_split.next() [Some, Ok] | provenance | MaD:102 |
-| test.rs:273:32:273:72 | ...::new(...) | test.rs:273:32:273:84 | ... .split(...) | provenance | MaD:53 |
+| test.rs:273:13:273:28 | mut reader_split | test.rs:274:14:274:32 | reader_split.next() [Some, Ok] | provenance | MaD:105 |
+| test.rs:273:13:273:28 | mut reader_split | test.rs:275:33:275:51 | reader_split.next() [Some, Ok] | provenance | MaD:105 |
+| test.rs:273:32:273:72 | ...::new(...) | test.rs:273:32:273:84 | ... .split(...) | provenance | MaD:56 |
 | test.rs:273:32:273:84 | ... .split(...) | test.rs:273:13:273:28 | mut reader_split | provenance |  |
-| test.rs:273:56:273:69 | ...::stdin | test.rs:273:56:273:71 | ...::stdin(...) | provenance | Src:MaD:30 MaD:30 |
-| test.rs:273:56:273:71 | ...::stdin(...) | test.rs:273:32:273:72 | ...::new(...) | provenance | MaD:105 |
-| test.rs:274:14:274:32 | reader_split.next() [Some, Ok] | test.rs:274:14:274:41 | ... .unwrap() [Ok] | provenance | MaD:79 |
-| test.rs:274:14:274:41 | ... .unwrap() [Ok] | test.rs:274:14:274:50 | ... .unwrap() | provenance | MaD:84 |
+| test.rs:273:56:273:69 | ...::stdin | test.rs:273:56:273:71 | ...::stdin(...) | provenance | Src:MaD:33 MaD:33 |
+| test.rs:273:56:273:71 | ...::stdin(...) | test.rs:273:32:273:72 | ...::new(...) | provenance | MaD:108 |
+| test.rs:274:14:274:32 | reader_split.next() [Some, Ok] | test.rs:274:14:274:41 | ... .unwrap() [Ok] | provenance | MaD:82 |
+| test.rs:274:14:274:41 | ... .unwrap() [Ok] | test.rs:274:14:274:50 | ... .unwrap() | provenance | MaD:87 |
 | test.rs:275:19:275:29 | Some(...) [Some, Ok] | test.rs:275:24:275:28 | chunk [Ok] | provenance |  |
-| test.rs:275:24:275:28 | chunk [Ok] | test.rs:276:18:276:31 | chunk.unwrap() | provenance | MaD:84 |
+| test.rs:275:24:275:28 | chunk [Ok] | test.rs:276:18:276:31 | chunk.unwrap() | provenance | MaD:87 |
 | test.rs:275:33:275:51 | reader_split.next() [Some, Ok] | test.rs:275:19:275:29 | Some(...) [Some, Ok] | provenance |  |
-| test.rs:281:13:281:18 | reader | test.rs:282:21:282:34 | reader.lines() | provenance | MaD:50 |
+| test.rs:281:13:281:18 | reader | test.rs:282:21:282:34 | reader.lines() | provenance | MaD:53 |
 | test.rs:281:22:281:62 | ...::new(...) | test.rs:281:13:281:18 | reader | provenance |  |
-| test.rs:281:46:281:59 | ...::stdin | test.rs:281:46:281:61 | ...::stdin(...) | provenance | Src:MaD:30 MaD:30 |
-| test.rs:281:46:281:61 | ...::stdin(...) | test.rs:281:22:281:62 | ...::new(...) | provenance | MaD:105 |
+| test.rs:281:46:281:59 | ...::stdin | test.rs:281:46:281:61 | ...::stdin(...) | provenance | Src:MaD:33 MaD:33 |
+| test.rs:281:46:281:61 | ...::stdin(...) | test.rs:281:22:281:62 | ...::new(...) | provenance | MaD:108 |
 | test.rs:282:21:282:34 | reader.lines() | test.rs:283:18:283:21 | line | provenance |  |
-| test.rs:309:13:309:21 | mut stdin | test.rs:311:33:311:43 | [post] &mut buffer [&ref] | provenance | MaD:67 |
-| test.rs:309:25:309:40 | ...::stdin | test.rs:309:25:309:42 | ...::stdin(...) | provenance | Src:MaD:34 MaD:34 |
+| test.rs:309:13:309:21 | mut stdin | test.rs:311:33:311:43 | [post] &mut buffer [&ref] | provenance | MaD:70 |
+| test.rs:309:25:309:40 | ...::stdin | test.rs:309:25:309:42 | ...::stdin(...) | provenance | Src:MaD:37 MaD:37 |
 | test.rs:309:25:309:42 | ...::stdin(...) | test.rs:309:13:309:21 | mut stdin | provenance |  |
 | test.rs:311:33:311:43 | [post] &mut buffer [&ref] | test.rs:311:38:311:43 | [post] buffer | provenance |  |
 | test.rs:311:38:311:43 | [post] buffer | test.rs:312:15:312:20 | buffer | provenance |  |
 | test.rs:312:15:312:20 | buffer | test.rs:312:14:312:20 | &buffer | provenance |  |
-| test.rs:316:13:316:21 | mut stdin | test.rs:318:40:318:50 | [post] &mut buffer [&ref] | provenance | MaD:73 |
-| test.rs:316:25:316:40 | ...::stdin | test.rs:316:25:316:42 | ...::stdin(...) | provenance | Src:MaD:34 MaD:34 |
+| test.rs:316:13:316:21 | mut stdin | test.rs:318:40:318:50 | [post] &mut buffer [&ref] | provenance | MaD:76 |
+| test.rs:316:25:316:40 | ...::stdin | test.rs:316:25:316:42 | ...::stdin(...) | provenance | Src:MaD:37 MaD:37 |
 | test.rs:316:25:316:42 | ...::stdin(...) | test.rs:316:13:316:21 | mut stdin | provenance |  |
 | test.rs:318:40:318:50 | [post] &mut buffer [&ref] | test.rs:318:45:318:50 | [post] buffer | provenance |  |
 | test.rs:318:45:318:50 | [post] buffer | test.rs:319:15:319:20 | buffer | provenance |  |
 | test.rs:319:15:319:20 | buffer | test.rs:319:14:319:20 | &buffer | provenance |  |
-| test.rs:323:13:323:21 | mut stdin | test.rs:325:43:325:53 | [post] &mut buffer [&ref] | provenance | MaD:74 |
-| test.rs:323:25:323:40 | ...::stdin | test.rs:323:25:323:42 | ...::stdin(...) | provenance | Src:MaD:34 MaD:34 |
+| test.rs:323:13:323:21 | mut stdin | test.rs:325:43:325:53 | [post] &mut buffer [&ref] | provenance | MaD:77 |
+| test.rs:323:25:323:40 | ...::stdin | test.rs:323:25:323:42 | ...::stdin(...) | provenance | Src:MaD:37 MaD:37 |
 | test.rs:323:25:323:42 | ...::stdin(...) | test.rs:323:13:323:21 | mut stdin | provenance |  |
 | test.rs:325:43:325:53 | [post] &mut buffer [&ref] | test.rs:325:48:325:53 | [post] buffer | provenance |  |
 | test.rs:325:48:325:53 | [post] buffer | test.rs:326:15:326:20 | buffer | provenance |  |
 | test.rs:326:15:326:20 | buffer | test.rs:326:14:326:20 | &buffer | provenance |  |
-| test.rs:330:13:330:21 | mut stdin | test.rs:332:26:332:36 | [post] &mut buffer [&ref] | provenance | MaD:69 |
-| test.rs:330:25:330:40 | ...::stdin | test.rs:330:25:330:42 | ...::stdin(...) | provenance | Src:MaD:34 MaD:34 |
+| test.rs:330:13:330:21 | mut stdin | test.rs:332:26:332:36 | [post] &mut buffer [&ref] | provenance | MaD:72 |
+| test.rs:330:25:330:40 | ...::stdin | test.rs:330:25:330:42 | ...::stdin(...) | provenance | Src:MaD:37 MaD:37 |
 | test.rs:330:25:330:42 | ...::stdin(...) | test.rs:330:13:330:21 | mut stdin | provenance |  |
 | test.rs:332:26:332:36 | [post] &mut buffer [&ref] | test.rs:332:31:332:36 | [post] buffer | provenance |  |
 | test.rs:332:31:332:36 | [post] buffer | test.rs:333:15:333:20 | buffer | provenance |  |
 | test.rs:333:15:333:20 | buffer | test.rs:333:14:333:20 | &buffer | provenance |  |
-| test.rs:337:13:337:21 | mut stdin | test.rs:338:18:338:32 | stdin.read_u8() [future, Ok] | provenance | MaD:75 |
-| test.rs:337:13:337:21 | mut stdin | test.rs:339:18:339:33 | stdin.read_i16() [future, Ok] | provenance | MaD:71 |
-| test.rs:337:13:337:21 | mut stdin | test.rs:340:18:340:33 | stdin.read_f32() [future, Ok] | provenance | MaD:70 |
-| test.rs:337:13:337:21 | mut stdin | test.rs:341:18:341:36 | stdin.read_i64_le() [future, Ok] | provenance | MaD:72 |
-| test.rs:337:25:337:40 | ...::stdin | test.rs:337:25:337:42 | ...::stdin(...) | provenance | Src:MaD:34 MaD:34 |
+| test.rs:337:13:337:21 | mut stdin | test.rs:338:18:338:32 | stdin.read_u8() [future, Ok] | provenance | MaD:78 |
+| test.rs:337:13:337:21 | mut stdin | test.rs:339:18:339:33 | stdin.read_i16() [future, Ok] | provenance | MaD:74 |
+| test.rs:337:13:337:21 | mut stdin | test.rs:340:18:340:33 | stdin.read_f32() [future, Ok] | provenance | MaD:73 |
+| test.rs:337:13:337:21 | mut stdin | test.rs:341:18:341:36 | stdin.read_i64_le() [future, Ok] | provenance | MaD:75 |
+| test.rs:337:25:337:40 | ...::stdin | test.rs:337:25:337:42 | ...::stdin(...) | provenance | Src:MaD:37 MaD:37 |
 | test.rs:337:25:337:42 | ...::stdin(...) | test.rs:337:13:337:21 | mut stdin | provenance |  |
 | test.rs:338:13:338:14 | v1 | test.rs:342:14:342:15 | v1 | provenance |  |
 | test.rs:338:18:338:32 | stdin.read_u8() [future, Ok] | test.rs:338:18:338:38 | await ... [Ok] | provenance |  |
@@ -380,150 +383,150 @@ edges
 | test.rs:341:18:341:36 | stdin.read_i64_le() [future, Ok] | test.rs:341:18:341:42 | await ... [Ok] | provenance |  |
 | test.rs:341:18:341:42 | await ... [Ok] | test.rs:341:18:341:43 | TryExpr | provenance |  |
 | test.rs:341:18:341:43 | TryExpr | test.rs:341:13:341:14 | v4 | provenance |  |
-| test.rs:349:13:349:21 | mut stdin | test.rs:351:24:351:34 | [post] &mut buffer [&ref] | provenance | MaD:68 |
-| test.rs:349:25:349:40 | ...::stdin | test.rs:349:25:349:42 | ...::stdin(...) | provenance | Src:MaD:34 MaD:34 |
+| test.rs:349:13:349:21 | mut stdin | test.rs:351:24:351:34 | [post] &mut buffer [&ref] | provenance | MaD:71 |
+| test.rs:349:25:349:40 | ...::stdin | test.rs:349:25:349:42 | ...::stdin(...) | provenance | Src:MaD:37 MaD:37 |
 | test.rs:349:25:349:42 | ...::stdin(...) | test.rs:349:13:349:21 | mut stdin | provenance |  |
 | test.rs:351:24:351:34 | [post] &mut buffer [&ref] | test.rs:351:29:351:34 | [post] buffer | provenance |  |
 | test.rs:351:29:351:34 | [post] buffer | test.rs:352:15:352:20 | buffer | provenance |  |
 | test.rs:352:15:352:20 | buffer | test.rs:352:14:352:20 | &buffer | provenance |  |
-| test.rs:358:13:358:22 | mut reader | test.rs:359:20:359:36 | reader.fill_buf() [future, Ok] | provenance | MaD:62 |
+| test.rs:358:13:358:22 | mut reader | test.rs:359:20:359:36 | reader.fill_buf() [future, Ok] | provenance | MaD:65 |
 | test.rs:358:26:358:70 | ...::new(...) | test.rs:358:13:358:22 | mut reader | provenance |  |
-| test.rs:358:52:358:67 | ...::stdin | test.rs:358:52:358:69 | ...::stdin(...) | provenance | Src:MaD:34 MaD:34 |
-| test.rs:358:52:358:69 | ...::stdin(...) | test.rs:358:26:358:70 | ...::new(...) | provenance | MaD:118 |
+| test.rs:358:52:358:67 | ...::stdin | test.rs:358:52:358:69 | ...::stdin(...) | provenance | Src:MaD:37 MaD:37 |
+| test.rs:358:52:358:69 | ...::stdin(...) | test.rs:358:26:358:70 | ...::new(...) | provenance | MaD:121 |
 | test.rs:359:13:359:16 | data | test.rs:360:15:360:18 | data | provenance |  |
 | test.rs:359:20:359:36 | reader.fill_buf() [future, Ok] | test.rs:359:20:359:42 | await ... [Ok] | provenance |  |
 | test.rs:359:20:359:42 | await ... [Ok] | test.rs:359:20:359:43 | TryExpr | provenance |  |
 | test.rs:359:20:359:43 | TryExpr | test.rs:359:13:359:16 | data | provenance |  |
 | test.rs:360:15:360:18 | data | test.rs:360:14:360:18 | &data | provenance |  |
-| test.rs:364:13:364:18 | reader | test.rs:365:20:365:34 | reader.buffer() | provenance | MaD:117 |
+| test.rs:364:13:364:18 | reader | test.rs:365:20:365:34 | reader.buffer() | provenance | MaD:120 |
 | test.rs:364:22:364:66 | ...::new(...) | test.rs:364:13:364:18 | reader | provenance |  |
-| test.rs:364:48:364:63 | ...::stdin | test.rs:364:48:364:65 | ...::stdin(...) | provenance | Src:MaD:34 MaD:34 |
-| test.rs:364:48:364:65 | ...::stdin(...) | test.rs:364:22:364:66 | ...::new(...) | provenance | MaD:118 |
+| test.rs:364:48:364:63 | ...::stdin | test.rs:364:48:364:65 | ...::stdin(...) | provenance | Src:MaD:37 MaD:37 |
+| test.rs:364:48:364:65 | ...::stdin(...) | test.rs:364:22:364:66 | ...::new(...) | provenance | MaD:121 |
 | test.rs:365:13:365:16 | data | test.rs:366:15:366:18 | data | provenance |  |
 | test.rs:365:20:365:34 | reader.buffer() | test.rs:365:13:365:16 | data | provenance |  |
 | test.rs:366:15:366:18 | data | test.rs:366:14:366:18 | &data | provenance |  |
-| test.rs:371:13:371:22 | mut reader | test.rs:372:26:372:36 | [post] &mut buffer [&ref] | provenance | MaD:64 |
+| test.rs:371:13:371:22 | mut reader | test.rs:372:26:372:36 | [post] &mut buffer [&ref] | provenance | MaD:67 |
 | test.rs:371:26:371:70 | ...::new(...) | test.rs:371:13:371:22 | mut reader | provenance |  |
-| test.rs:371:52:371:67 | ...::stdin | test.rs:371:52:371:69 | ...::stdin(...) | provenance | Src:MaD:34 MaD:34 |
-| test.rs:371:52:371:69 | ...::stdin(...) | test.rs:371:26:371:70 | ...::new(...) | provenance | MaD:118 |
+| test.rs:371:52:371:67 | ...::stdin | test.rs:371:52:371:69 | ...::stdin(...) | provenance | Src:MaD:37 MaD:37 |
+| test.rs:371:52:371:69 | ...::stdin(...) | test.rs:371:26:371:70 | ...::new(...) | provenance | MaD:121 |
 | test.rs:372:26:372:36 | [post] &mut buffer [&ref] | test.rs:372:31:372:36 | [post] buffer | provenance |  |
 | test.rs:372:31:372:36 | [post] buffer | test.rs:373:15:373:20 | buffer | provenance |  |
 | test.rs:373:15:373:20 | buffer | test.rs:373:14:373:20 | &buffer | provenance |  |
-| test.rs:378:13:378:22 | mut reader | test.rs:379:33:379:43 | [post] &mut buffer [&ref] | provenance | MaD:65 |
+| test.rs:378:13:378:22 | mut reader | test.rs:379:33:379:43 | [post] &mut buffer [&ref] | provenance | MaD:68 |
 | test.rs:378:26:378:70 | ...::new(...) | test.rs:378:13:378:22 | mut reader | provenance |  |
-| test.rs:378:52:378:67 | ...::stdin | test.rs:378:52:378:69 | ...::stdin(...) | provenance | Src:MaD:34 MaD:34 |
-| test.rs:378:52:378:69 | ...::stdin(...) | test.rs:378:26:378:70 | ...::new(...) | provenance | MaD:118 |
+| test.rs:378:52:378:67 | ...::stdin | test.rs:378:52:378:69 | ...::stdin(...) | provenance | Src:MaD:37 MaD:37 |
+| test.rs:378:52:378:69 | ...::stdin(...) | test.rs:378:26:378:70 | ...::new(...) | provenance | MaD:121 |
 | test.rs:379:33:379:43 | [post] &mut buffer [&ref] | test.rs:379:38:379:43 | [post] buffer | provenance |  |
 | test.rs:379:38:379:43 | [post] buffer | test.rs:380:15:380:20 | buffer | provenance |  |
 | test.rs:379:38:379:43 | [post] buffer | test.rs:381:14:381:22 | buffer[0] | provenance |  |
 | test.rs:380:15:380:20 | buffer | test.rs:380:14:380:20 | &buffer | provenance |  |
-| test.rs:385:13:385:28 | mut reader_split | test.rs:386:14:386:40 | reader_split.next_segment() [future, Ok, Some] | provenance | MaD:120 |
-| test.rs:385:13:385:28 | mut reader_split | test.rs:387:33:387:59 | reader_split.next_segment() [future, Ok, Some] | provenance | MaD:120 |
-| test.rs:385:32:385:76 | ...::new(...) | test.rs:385:32:385:88 | ... .split(...) | provenance | MaD:66 |
+| test.rs:385:13:385:28 | mut reader_split | test.rs:386:14:386:40 | reader_split.next_segment() [future, Ok, Some] | provenance | MaD:123 |
+| test.rs:385:13:385:28 | mut reader_split | test.rs:387:33:387:59 | reader_split.next_segment() [future, Ok, Some] | provenance | MaD:123 |
+| test.rs:385:32:385:76 | ...::new(...) | test.rs:385:32:385:88 | ... .split(...) | provenance | MaD:69 |
 | test.rs:385:32:385:88 | ... .split(...) | test.rs:385:13:385:28 | mut reader_split | provenance |  |
-| test.rs:385:58:385:73 | ...::stdin | test.rs:385:58:385:75 | ...::stdin(...) | provenance | Src:MaD:34 MaD:34 |
-| test.rs:385:58:385:75 | ...::stdin(...) | test.rs:385:32:385:76 | ...::new(...) | provenance | MaD:118 |
+| test.rs:385:58:385:73 | ...::stdin | test.rs:385:58:385:75 | ...::stdin(...) | provenance | Src:MaD:37 MaD:37 |
+| test.rs:385:58:385:75 | ...::stdin(...) | test.rs:385:32:385:76 | ...::new(...) | provenance | MaD:121 |
 | test.rs:386:14:386:40 | reader_split.next_segment() [future, Ok, Some] | test.rs:386:14:386:46 | await ... [Ok, Some] | provenance |  |
 | test.rs:386:14:386:46 | await ... [Ok, Some] | test.rs:386:14:386:47 | TryExpr [Some] | provenance |  |
-| test.rs:386:14:386:47 | TryExpr [Some] | test.rs:386:14:386:56 | ... .unwrap() | provenance | MaD:79 |
+| test.rs:386:14:386:47 | TryExpr [Some] | test.rs:386:14:386:56 | ... .unwrap() | provenance | MaD:82 |
 | test.rs:387:19:387:29 | Some(...) [Some] | test.rs:387:24:387:28 | chunk | provenance |  |
 | test.rs:387:24:387:28 | chunk | test.rs:388:18:388:22 | chunk | provenance |  |
 | test.rs:387:33:387:59 | reader_split.next_segment() [future, Ok, Some] | test.rs:387:33:387:65 | await ... [Ok, Some] | provenance |  |
 | test.rs:387:33:387:65 | await ... [Ok, Some] | test.rs:387:33:387:66 | TryExpr [Some] | provenance |  |
 | test.rs:387:33:387:66 | TryExpr [Some] | test.rs:387:19:387:29 | Some(...) [Some] | provenance |  |
-| test.rs:393:13:393:18 | reader | test.rs:394:25:394:38 | reader.lines() | provenance | MaD:63 |
+| test.rs:393:13:393:18 | reader | test.rs:394:25:394:38 | reader.lines() | provenance | MaD:66 |
 | test.rs:393:22:393:66 | ...::new(...) | test.rs:393:13:393:18 | reader | provenance |  |
-| test.rs:393:48:393:63 | ...::stdin | test.rs:393:48:393:65 | ...::stdin(...) | provenance | Src:MaD:34 MaD:34 |
-| test.rs:393:48:393:65 | ...::stdin(...) | test.rs:393:22:393:66 | ...::new(...) | provenance | MaD:118 |
-| test.rs:394:13:394:21 | mut lines | test.rs:395:14:395:30 | lines.next_line() [future, Ok, Some] | provenance | MaD:119 |
-| test.rs:394:13:394:21 | mut lines | test.rs:396:32:396:48 | lines.next_line() [future, Ok, Some] | provenance | MaD:119 |
+| test.rs:393:48:393:63 | ...::stdin | test.rs:393:48:393:65 | ...::stdin(...) | provenance | Src:MaD:37 MaD:37 |
+| test.rs:393:48:393:65 | ...::stdin(...) | test.rs:393:22:393:66 | ...::new(...) | provenance | MaD:121 |
+| test.rs:394:13:394:21 | mut lines | test.rs:395:14:395:30 | lines.next_line() [future, Ok, Some] | provenance | MaD:122 |
+| test.rs:394:13:394:21 | mut lines | test.rs:396:32:396:48 | lines.next_line() [future, Ok, Some] | provenance | MaD:122 |
 | test.rs:394:25:394:38 | reader.lines() | test.rs:394:13:394:21 | mut lines | provenance |  |
 | test.rs:395:14:395:30 | lines.next_line() [future, Ok, Some] | test.rs:395:14:395:36 | await ... [Ok, Some] | provenance |  |
 | test.rs:395:14:395:36 | await ... [Ok, Some] | test.rs:395:14:395:37 | TryExpr [Some] | provenance |  |
-| test.rs:395:14:395:37 | TryExpr [Some] | test.rs:395:14:395:46 | ... .unwrap() | provenance | MaD:79 |
+| test.rs:395:14:395:37 | TryExpr [Some] | test.rs:395:14:395:46 | ... .unwrap() | provenance | MaD:82 |
 | test.rs:396:19:396:28 | Some(...) [Some] | test.rs:396:24:396:27 | line | provenance |  |
 | test.rs:396:24:396:27 | line | test.rs:397:18:397:21 | line | provenance |  |
 | test.rs:396:32:396:48 | lines.next_line() [future, Ok, Some] | test.rs:396:32:396:54 | await ... [Ok, Some] | provenance |  |
 | test.rs:396:32:396:54 | await ... [Ok, Some] | test.rs:396:32:396:55 | TryExpr [Some] | provenance |  |
 | test.rs:396:32:396:55 | TryExpr [Some] | test.rs:396:19:396:28 | Some(...) [Some] | provenance |  |
 | test.rs:408:13:408:18 | buffer | test.rs:409:14:409:19 | buffer | provenance |  |
-| test.rs:408:31:408:43 | ...::read | test.rs:408:31:408:43 | ...::read [Ok] | provenance | Src:MaD:25  |
-| test.rs:408:31:408:43 | ...::read | test.rs:408:31:408:55 | ...::read(...) [Ok] | provenance | Src:MaD:25  |
-| test.rs:408:31:408:43 | ...::read [Ok] | test.rs:408:31:408:55 | ...::read(...) [Ok] | provenance | MaD:26 |
+| test.rs:408:31:408:43 | ...::read | test.rs:408:31:408:43 | ...::read [Ok] | provenance | Src:MaD:28  |
+| test.rs:408:31:408:43 | ...::read | test.rs:408:31:408:55 | ...::read(...) [Ok] | provenance | Src:MaD:28  |
+| test.rs:408:31:408:43 | ...::read [Ok] | test.rs:408:31:408:55 | ...::read(...) [Ok] | provenance | MaD:29 |
 | test.rs:408:31:408:55 | ...::read(...) [Ok] | test.rs:408:31:408:56 | TryExpr | provenance |  |
 | test.rs:408:31:408:56 | TryExpr | test.rs:408:13:408:18 | buffer | provenance |  |
 | test.rs:413:13:413:18 | buffer | test.rs:414:14:414:19 | buffer | provenance |  |
-| test.rs:413:31:413:38 | ...::read | test.rs:413:31:413:38 | ...::read [Ok] | provenance | Src:MaD:25  |
-| test.rs:413:31:413:38 | ...::read | test.rs:413:31:413:50 | ...::read(...) [Ok] | provenance | Src:MaD:25  |
-| test.rs:413:31:413:38 | ...::read [Ok] | test.rs:413:31:413:50 | ...::read(...) [Ok] | provenance | MaD:26 |
+| test.rs:413:31:413:38 | ...::read | test.rs:413:31:413:38 | ...::read [Ok] | provenance | Src:MaD:28  |
+| test.rs:413:31:413:38 | ...::read | test.rs:413:31:413:50 | ...::read(...) [Ok] | provenance | Src:MaD:28  |
+| test.rs:413:31:413:38 | ...::read [Ok] | test.rs:413:31:413:50 | ...::read(...) [Ok] | provenance | MaD:29 |
 | test.rs:413:31:413:50 | ...::read(...) [Ok] | test.rs:413:31:413:51 | TryExpr | provenance |  |
 | test.rs:413:31:413:51 | TryExpr | test.rs:413:13:413:18 | buffer | provenance |  |
 | test.rs:418:13:418:18 | buffer | test.rs:419:14:419:19 | buffer | provenance |  |
-| test.rs:418:22:418:39 | ...::read_to_string | test.rs:418:22:418:39 | ...::read_to_string [Ok] | provenance | Src:MaD:28  |
-| test.rs:418:22:418:39 | ...::read_to_string | test.rs:418:22:418:51 | ...::read_to_string(...) [Ok] | provenance | Src:MaD:28  |
-| test.rs:418:22:418:39 | ...::read_to_string [Ok] | test.rs:418:22:418:51 | ...::read_to_string(...) [Ok] | provenance | MaD:29 |
+| test.rs:418:22:418:39 | ...::read_to_string | test.rs:418:22:418:39 | ...::read_to_string [Ok] | provenance | Src:MaD:31  |
+| test.rs:418:22:418:39 | ...::read_to_string | test.rs:418:22:418:51 | ...::read_to_string(...) [Ok] | provenance | Src:MaD:31  |
+| test.rs:418:22:418:39 | ...::read_to_string [Ok] | test.rs:418:22:418:51 | ...::read_to_string(...) [Ok] | provenance | MaD:32 |
 | test.rs:418:22:418:51 | ...::read_to_string(...) [Ok] | test.rs:418:22:418:52 | TryExpr | provenance |  |
 | test.rs:418:22:418:52 | TryExpr | test.rs:418:13:418:18 | buffer | provenance |  |
 | test.rs:425:13:425:16 | path | test.rs:426:14:426:17 | path | provenance |  |
-| test.rs:425:13:425:16 | path | test.rs:426:14:426:25 | path.clone() | provenance | MaD:37 |
+| test.rs:425:13:425:16 | path | test.rs:426:14:426:25 | path.clone() | provenance | MaD:40 |
 | test.rs:425:13:425:16 | path | test.rs:427:14:427:17 | path | provenance |  |
-| test.rs:425:13:425:16 | path | test.rs:427:14:427:25 | path.clone() | provenance | MaD:37 |
+| test.rs:425:13:425:16 | path | test.rs:427:14:427:25 | path.clone() | provenance | MaD:40 |
 | test.rs:425:13:425:16 | path | test.rs:437:14:437:17 | path | provenance |  |
 | test.rs:425:20:425:27 | e.path() | test.rs:425:13:425:16 | path | provenance |  |
-| test.rs:425:22:425:25 | path | test.rs:425:20:425:27 | e.path() | provenance | Src:MaD:6 MaD:6 |
-| test.rs:426:14:426:17 | path | test.rs:426:14:426:25 | path.clone() | provenance | MaD:37 |
-| test.rs:427:14:427:17 | path | test.rs:427:14:427:25 | path.clone() | provenance | MaD:37 |
-| test.rs:427:14:427:25 | path.clone() | test.rs:427:14:427:35 | ... .as_path() | provenance | MaD:116 |
+| test.rs:425:22:425:25 | path | test.rs:425:20:425:27 | e.path() | provenance | Src:MaD:9 MaD:9 |
+| test.rs:426:14:426:17 | path | test.rs:426:14:426:25 | path.clone() | provenance | MaD:40 |
+| test.rs:427:14:427:17 | path | test.rs:427:14:427:25 | path.clone() | provenance | MaD:40 |
+| test.rs:427:14:427:25 | path.clone() | test.rs:427:14:427:35 | ... .as_path() | provenance | MaD:119 |
 | test.rs:439:13:439:21 | file_name | test.rs:440:14:440:22 | file_name | provenance |  |
-| test.rs:439:13:439:21 | file_name | test.rs:440:14:440:30 | file_name.clone() | provenance | MaD:37 |
+| test.rs:439:13:439:21 | file_name | test.rs:440:14:440:30 | file_name.clone() | provenance | MaD:40 |
 | test.rs:439:13:439:21 | file_name | test.rs:445:14:445:22 | file_name | provenance |  |
 | test.rs:439:25:439:37 | e.file_name() | test.rs:439:13:439:21 | file_name | provenance |  |
-| test.rs:439:27:439:35 | file_name | test.rs:439:25:439:37 | e.file_name() | provenance | Src:MaD:5 MaD:5 |
-| test.rs:440:14:440:22 | file_name | test.rs:440:14:440:30 | file_name.clone() | provenance | MaD:37 |
+| test.rs:439:27:439:35 | file_name | test.rs:439:25:439:37 | e.file_name() | provenance | Src:MaD:8 MaD:8 |
+| test.rs:440:14:440:22 | file_name | test.rs:440:14:440:30 | file_name.clone() | provenance | MaD:40 |
 | test.rs:461:13:461:18 | target | test.rs:462:14:462:19 | target | provenance |  |
-| test.rs:461:22:461:34 | ...::read_link | test.rs:461:22:461:49 | ...::read_link(...) [Ok] | provenance | Src:MaD:27  |
+| test.rs:461:22:461:34 | ...::read_link | test.rs:461:22:461:49 | ...::read_link(...) [Ok] | provenance | Src:MaD:30  |
 | test.rs:461:22:461:49 | ...::read_link(...) [Ok] | test.rs:461:22:461:50 | TryExpr | provenance |  |
 | test.rs:461:22:461:50 | TryExpr | test.rs:461:13:461:18 | target | provenance |  |
 | test.rs:470:13:470:18 | buffer | test.rs:471:14:471:19 | buffer | provenance |  |
-| test.rs:470:31:470:45 | ...::read | test.rs:470:31:470:57 | ...::read(...) [future, Ok] | provenance | Src:MaD:31  |
+| test.rs:470:31:470:45 | ...::read | test.rs:470:31:470:57 | ...::read(...) [future, Ok] | provenance | Src:MaD:34  |
 | test.rs:470:31:470:57 | ...::read(...) [future, Ok] | test.rs:470:31:470:63 | await ... [Ok] | provenance |  |
 | test.rs:470:31:470:63 | await ... [Ok] | test.rs:470:31:470:64 | TryExpr | provenance |  |
 | test.rs:470:31:470:64 | TryExpr | test.rs:470:13:470:18 | buffer | provenance |  |
 | test.rs:475:13:475:18 | buffer | test.rs:476:14:476:19 | buffer | provenance |  |
-| test.rs:475:31:475:45 | ...::read | test.rs:475:31:475:57 | ...::read(...) [future, Ok] | provenance | Src:MaD:31  |
+| test.rs:475:31:475:45 | ...::read | test.rs:475:31:475:57 | ...::read(...) [future, Ok] | provenance | Src:MaD:34  |
 | test.rs:475:31:475:57 | ...::read(...) [future, Ok] | test.rs:475:31:475:63 | await ... [Ok] | provenance |  |
 | test.rs:475:31:475:63 | await ... [Ok] | test.rs:475:31:475:64 | TryExpr | provenance |  |
 | test.rs:475:31:475:64 | TryExpr | test.rs:475:13:475:18 | buffer | provenance |  |
 | test.rs:480:13:480:18 | buffer | test.rs:481:14:481:19 | buffer | provenance |  |
-| test.rs:480:22:480:46 | ...::read_to_string | test.rs:480:22:480:58 | ...::read_to_string(...) [future, Ok] | provenance | Src:MaD:33  |
+| test.rs:480:22:480:46 | ...::read_to_string | test.rs:480:22:480:58 | ...::read_to_string(...) [future, Ok] | provenance | Src:MaD:36  |
 | test.rs:480:22:480:58 | ...::read_to_string(...) [future, Ok] | test.rs:480:22:480:64 | await ... [Ok] | provenance |  |
 | test.rs:480:22:480:64 | await ... [Ok] | test.rs:480:22:480:65 | TryExpr | provenance |  |
 | test.rs:480:22:480:65 | TryExpr | test.rs:480:13:480:18 | buffer | provenance |  |
 | test.rs:486:13:486:16 | path | test.rs:488:14:488:17 | path | provenance |  |
 | test.rs:486:20:486:31 | entry.path() | test.rs:486:13:486:16 | path | provenance |  |
-| test.rs:486:26:486:29 | path | test.rs:486:20:486:31 | entry.path() | provenance | Src:MaD:14 MaD:14 |
-| test.rs:486:26:486:29 | path | test.rs:486:20:486:31 | entry.path() | provenance | Src:MaD:14 MaD:14 |
+| test.rs:486:26:486:29 | path | test.rs:486:20:486:31 | entry.path() | provenance | Src:MaD:17 MaD:17 |
+| test.rs:486:26:486:29 | path | test.rs:486:20:486:31 | entry.path() | provenance | Src:MaD:17 MaD:17 |
 | test.rs:487:13:487:21 | file_name | test.rs:489:14:489:22 | file_name | provenance |  |
 | test.rs:487:25:487:41 | entry.file_name() | test.rs:487:13:487:21 | file_name | provenance |  |
-| test.rs:487:31:487:39 | file_name | test.rs:487:25:487:41 | entry.file_name() | provenance | Src:MaD:13 MaD:13 |
-| test.rs:487:31:487:39 | file_name | test.rs:487:25:487:41 | entry.file_name() | provenance | Src:MaD:13 MaD:13 |
+| test.rs:487:31:487:39 | file_name | test.rs:487:25:487:41 | entry.file_name() | provenance | Src:MaD:16 MaD:16 |
+| test.rs:487:31:487:39 | file_name | test.rs:487:25:487:41 | entry.file_name() | provenance | Src:MaD:16 MaD:16 |
 | test.rs:493:13:493:18 | target | test.rs:494:14:494:19 | target | provenance |  |
-| test.rs:493:22:493:41 | ...::read_link | test.rs:493:22:493:56 | ...::read_link(...) [future, Ok] | provenance | Src:MaD:32  |
+| test.rs:493:22:493:41 | ...::read_link | test.rs:493:22:493:56 | ...::read_link(...) [future, Ok] | provenance | Src:MaD:35  |
 | test.rs:493:22:493:56 | ...::read_link(...) [future, Ok] | test.rs:493:22:493:62 | await ... [Ok] | provenance |  |
 | test.rs:493:22:493:62 | await ... [Ok] | test.rs:493:22:493:63 | TryExpr | provenance |  |
 | test.rs:493:22:493:63 | TryExpr | test.rs:493:13:493:18 | target | provenance |  |
-| test.rs:503:9:503:16 | mut file | test.rs:507:32:507:42 | [post] &mut buffer | provenance | MaD:97 |
-| test.rs:503:9:503:16 | mut file | test.rs:507:32:507:42 | [post] &mut buffer [&ref] | provenance | MaD:57 |
-| test.rs:503:9:503:16 | mut file | test.rs:507:32:507:42 | [post] &mut buffer [&ref] | provenance | MaD:96 |
-| test.rs:503:9:503:16 | mut file | test.rs:513:39:513:49 | [post] &mut buffer | provenance | MaD:99 |
-| test.rs:503:9:503:16 | mut file | test.rs:513:39:513:49 | [post] &mut buffer [&ref] | provenance | MaD:59 |
-| test.rs:503:9:503:16 | mut file | test.rs:513:39:513:49 | [post] &mut buffer [&ref] | provenance | MaD:98 |
-| test.rs:503:9:503:16 | mut file | test.rs:519:42:519:52 | [post] &mut buffer | provenance | MaD:101 |
-| test.rs:503:9:503:16 | mut file | test.rs:519:42:519:52 | [post] &mut buffer [&ref] | provenance | MaD:60 |
-| test.rs:503:9:503:16 | mut file | test.rs:519:42:519:52 | [post] &mut buffer [&ref] | provenance | MaD:100 |
-| test.rs:503:9:503:16 | mut file | test.rs:525:25:525:35 | [post] &mut buffer [&ref] | provenance | MaD:58 |
-| test.rs:503:9:503:16 | mut file | test.rs:529:17:529:28 | file.bytes() | provenance | MaD:54 |
-| test.rs:503:20:503:38 | ...::open | test.rs:503:20:503:50 | ...::open(...) [Ok] | provenance | Src:MaD:7  |
+| test.rs:503:9:503:16 | mut file | test.rs:507:32:507:42 | [post] &mut buffer | provenance | MaD:100 |
+| test.rs:503:9:503:16 | mut file | test.rs:507:32:507:42 | [post] &mut buffer [&ref] | provenance | MaD:60 |
+| test.rs:503:9:503:16 | mut file | test.rs:507:32:507:42 | [post] &mut buffer [&ref] | provenance | MaD:99 |
+| test.rs:503:9:503:16 | mut file | test.rs:513:39:513:49 | [post] &mut buffer | provenance | MaD:102 |
+| test.rs:503:9:503:16 | mut file | test.rs:513:39:513:49 | [post] &mut buffer [&ref] | provenance | MaD:62 |
+| test.rs:503:9:503:16 | mut file | test.rs:513:39:513:49 | [post] &mut buffer [&ref] | provenance | MaD:101 |
+| test.rs:503:9:503:16 | mut file | test.rs:519:42:519:52 | [post] &mut buffer | provenance | MaD:104 |
+| test.rs:503:9:503:16 | mut file | test.rs:519:42:519:52 | [post] &mut buffer [&ref] | provenance | MaD:63 |
+| test.rs:503:9:503:16 | mut file | test.rs:519:42:519:52 | [post] &mut buffer [&ref] | provenance | MaD:103 |
+| test.rs:503:9:503:16 | mut file | test.rs:525:25:525:35 | [post] &mut buffer [&ref] | provenance | MaD:61 |
+| test.rs:503:9:503:16 | mut file | test.rs:529:17:529:28 | file.bytes() | provenance | MaD:57 |
+| test.rs:503:20:503:38 | ...::open | test.rs:503:20:503:50 | ...::open(...) [Ok] | provenance | Src:MaD:10  |
 | test.rs:503:20:503:50 | ...::open(...) [Ok] | test.rs:503:20:503:51 | TryExpr | provenance |  |
 | test.rs:503:20:503:51 | TryExpr | test.rs:503:9:503:16 | mut file | provenance |  |
 | test.rs:507:32:507:42 | [post] &mut buffer | test.rs:508:15:508:20 | buffer | provenance |  |
@@ -542,69 +545,69 @@ edges
 | test.rs:525:30:525:35 | [post] buffer | test.rs:526:15:526:20 | buffer | provenance |  |
 | test.rs:526:15:526:20 | buffer | test.rs:526:14:526:20 | &buffer | provenance |  |
 | test.rs:529:17:529:28 | file.bytes() | test.rs:530:14:530:17 | byte | provenance |  |
-| test.rs:536:13:536:18 | mut f1 | test.rs:538:30:538:40 | [post] &mut buffer | provenance | MaD:97 |
-| test.rs:536:13:536:18 | mut f1 | test.rs:538:30:538:40 | [post] &mut buffer [&ref] | provenance | MaD:57 |
-| test.rs:536:13:536:18 | mut f1 | test.rs:538:30:538:40 | [post] &mut buffer [&ref] | provenance | MaD:96 |
-| test.rs:536:22:536:63 | ... .open(...) [Ok] | test.rs:536:22:536:72 | ... .unwrap() | provenance | MaD:84 |
+| test.rs:536:13:536:18 | mut f1 | test.rs:538:30:538:40 | [post] &mut buffer | provenance | MaD:100 |
+| test.rs:536:13:536:18 | mut f1 | test.rs:538:30:538:40 | [post] &mut buffer [&ref] | provenance | MaD:60 |
+| test.rs:536:13:536:18 | mut f1 | test.rs:538:30:538:40 | [post] &mut buffer [&ref] | provenance | MaD:99 |
+| test.rs:536:22:536:63 | ... .open(...) [Ok] | test.rs:536:22:536:72 | ... .unwrap() | provenance | MaD:87 |
 | test.rs:536:22:536:72 | ... .unwrap() | test.rs:536:13:536:18 | mut f1 | provenance |  |
-| test.rs:536:50:536:53 | open | test.rs:536:22:536:63 | ... .open(...) [Ok] | provenance | Src:MaD:8  |
+| test.rs:536:50:536:53 | open | test.rs:536:22:536:63 | ... .open(...) [Ok] | provenance | Src:MaD:11  |
 | test.rs:538:30:538:40 | [post] &mut buffer | test.rs:539:15:539:20 | buffer | provenance |  |
 | test.rs:538:30:538:40 | [post] &mut buffer [&ref] | test.rs:538:35:538:40 | [post] buffer | provenance |  |
 | test.rs:538:35:538:40 | [post] buffer | test.rs:539:15:539:20 | buffer | provenance |  |
 | test.rs:539:15:539:20 | buffer | test.rs:539:14:539:20 | &buffer | provenance |  |
-| test.rs:543:13:543:18 | mut f2 | test.rs:545:30:545:40 | [post] &mut buffer | provenance | MaD:97 |
-| test.rs:543:13:543:18 | mut f2 | test.rs:545:30:545:40 | [post] &mut buffer [&ref] | provenance | MaD:57 |
-| test.rs:543:13:543:18 | mut f2 | test.rs:545:30:545:40 | [post] &mut buffer [&ref] | provenance | MaD:96 |
-| test.rs:543:22:543:80 | ... .open(...) [Ok] | test.rs:543:22:543:89 | ... .unwrap() | provenance | MaD:84 |
+| test.rs:543:13:543:18 | mut f2 | test.rs:545:30:545:40 | [post] &mut buffer | provenance | MaD:100 |
+| test.rs:543:13:543:18 | mut f2 | test.rs:545:30:545:40 | [post] &mut buffer [&ref] | provenance | MaD:60 |
+| test.rs:543:13:543:18 | mut f2 | test.rs:545:30:545:40 | [post] &mut buffer [&ref] | provenance | MaD:99 |
+| test.rs:543:22:543:80 | ... .open(...) [Ok] | test.rs:543:22:543:89 | ... .unwrap() | provenance | MaD:87 |
 | test.rs:543:22:543:89 | ... .unwrap() | test.rs:543:13:543:18 | mut f2 | provenance |  |
-| test.rs:543:67:543:70 | open | test.rs:543:22:543:80 | ... .open(...) [Ok] | provenance | Src:MaD:8  |
+| test.rs:543:67:543:70 | open | test.rs:543:22:543:80 | ... .open(...) [Ok] | provenance | Src:MaD:11  |
 | test.rs:545:30:545:40 | [post] &mut buffer | test.rs:546:15:546:20 | buffer | provenance |  |
 | test.rs:545:30:545:40 | [post] &mut buffer [&ref] | test.rs:545:35:545:40 | [post] buffer | provenance |  |
 | test.rs:545:35:545:40 | [post] buffer | test.rs:546:15:546:20 | buffer | provenance |  |
 | test.rs:546:15:546:20 | buffer | test.rs:546:14:546:20 | &buffer | provenance |  |
-| test.rs:550:13:550:18 | mut f3 | test.rs:552:30:552:40 | [post] &mut buffer | provenance | MaD:97 |
-| test.rs:550:13:550:18 | mut f3 | test.rs:552:30:552:40 | [post] &mut buffer [&ref] | provenance | MaD:57 |
-| test.rs:550:13:550:18 | mut f3 | test.rs:552:30:552:40 | [post] &mut buffer [&ref] | provenance | MaD:96 |
-| test.rs:550:22:550:114 | ... .open(...) [Ok] | test.rs:550:22:550:123 | ... .unwrap() | provenance | MaD:84 |
+| test.rs:550:13:550:18 | mut f3 | test.rs:552:30:552:40 | [post] &mut buffer | provenance | MaD:100 |
+| test.rs:550:13:550:18 | mut f3 | test.rs:552:30:552:40 | [post] &mut buffer [&ref] | provenance | MaD:60 |
+| test.rs:550:13:550:18 | mut f3 | test.rs:552:30:552:40 | [post] &mut buffer [&ref] | provenance | MaD:99 |
+| test.rs:550:22:550:114 | ... .open(...) [Ok] | test.rs:550:22:550:123 | ... .unwrap() | provenance | MaD:87 |
 | test.rs:550:22:550:123 | ... .unwrap() | test.rs:550:13:550:18 | mut f3 | provenance |  |
-| test.rs:550:101:550:104 | open | test.rs:550:22:550:114 | ... .open(...) [Ok] | provenance | Src:MaD:8  |
+| test.rs:550:101:550:104 | open | test.rs:550:22:550:114 | ... .open(...) [Ok] | provenance | Src:MaD:11  |
 | test.rs:552:30:552:40 | [post] &mut buffer | test.rs:553:15:553:20 | buffer | provenance |  |
 | test.rs:552:30:552:40 | [post] &mut buffer [&ref] | test.rs:552:35:552:40 | [post] buffer | provenance |  |
 | test.rs:552:35:552:40 | [post] buffer | test.rs:553:15:553:20 | buffer | provenance |  |
 | test.rs:553:15:553:20 | buffer | test.rs:553:14:553:20 | &buffer | provenance |  |
-| test.rs:560:13:560:17 | file1 | test.rs:562:26:562:43 | file1.chain(...) | provenance | MaD:56 |
-| test.rs:560:21:560:39 | ...::open | test.rs:560:21:560:51 | ...::open(...) [Ok] | provenance | Src:MaD:7  |
+| test.rs:560:13:560:17 | file1 | test.rs:562:26:562:43 | file1.chain(...) | provenance | MaD:59 |
+| test.rs:560:21:560:39 | ...::open | test.rs:560:21:560:51 | ...::open(...) [Ok] | provenance | Src:MaD:10  |
 | test.rs:560:21:560:51 | ...::open(...) [Ok] | test.rs:560:21:560:52 | TryExpr | provenance |  |
 | test.rs:560:21:560:52 | TryExpr | test.rs:560:13:560:17 | file1 | provenance |  |
 | test.rs:561:13:561:17 | file2 | test.rs:562:38:562:42 | file2 | provenance |  |
-| test.rs:561:21:561:39 | ...::open | test.rs:561:21:561:59 | ...::open(...) [Ok] | provenance | Src:MaD:7  |
+| test.rs:561:21:561:39 | ...::open | test.rs:561:21:561:59 | ...::open(...) [Ok] | provenance | Src:MaD:10  |
 | test.rs:561:21:561:59 | ...::open(...) [Ok] | test.rs:561:21:561:60 | TryExpr | provenance |  |
 | test.rs:561:21:561:60 | TryExpr | test.rs:561:13:561:17 | file2 | provenance |  |
-| test.rs:562:13:562:22 | mut reader | test.rs:563:31:563:41 | [post] &mut buffer [&ref] | provenance | MaD:60 |
+| test.rs:562:13:562:22 | mut reader | test.rs:563:31:563:41 | [post] &mut buffer [&ref] | provenance | MaD:63 |
 | test.rs:562:26:562:43 | file1.chain(...) | test.rs:562:13:562:22 | mut reader | provenance |  |
-| test.rs:562:38:562:42 | file2 | test.rs:562:26:562:43 | file1.chain(...) | provenance | MaD:55 |
+| test.rs:562:38:562:42 | file2 | test.rs:562:26:562:43 | file1.chain(...) | provenance | MaD:58 |
 | test.rs:563:31:563:41 | [post] &mut buffer [&ref] | test.rs:563:36:563:41 | [post] buffer | provenance |  |
 | test.rs:563:36:563:41 | [post] buffer | test.rs:564:15:564:20 | buffer | provenance |  |
 | test.rs:564:15:564:20 | buffer | test.rs:564:14:564:20 | &buffer | provenance |  |
-| test.rs:569:13:569:17 | file1 | test.rs:570:26:570:40 | file1.take(...) | provenance | MaD:61 |
-| test.rs:569:21:569:39 | ...::open | test.rs:569:21:569:51 | ...::open(...) [Ok] | provenance | Src:MaD:7  |
+| test.rs:569:13:569:17 | file1 | test.rs:570:26:570:40 | file1.take(...) | provenance | MaD:64 |
+| test.rs:569:21:569:39 | ...::open | test.rs:569:21:569:51 | ...::open(...) [Ok] | provenance | Src:MaD:10  |
 | test.rs:569:21:569:51 | ...::open(...) [Ok] | test.rs:569:21:569:52 | TryExpr | provenance |  |
 | test.rs:569:21:569:52 | TryExpr | test.rs:569:13:569:17 | file1 | provenance |  |
-| test.rs:570:13:570:22 | mut reader | test.rs:571:31:571:41 | [post] &mut buffer [&ref] | provenance | MaD:60 |
+| test.rs:570:13:570:22 | mut reader | test.rs:571:31:571:41 | [post] &mut buffer [&ref] | provenance | MaD:63 |
 | test.rs:570:26:570:40 | file1.take(...) | test.rs:570:13:570:22 | mut reader | provenance |  |
 | test.rs:571:31:571:41 | [post] &mut buffer [&ref] | test.rs:571:36:571:41 | [post] buffer | provenance |  |
 | test.rs:571:36:571:41 | [post] buffer | test.rs:572:15:572:20 | buffer | provenance |  |
 | test.rs:572:15:572:20 | buffer | test.rs:572:14:572:20 | &buffer | provenance |  |
-| test.rs:581:9:581:16 | mut file | test.rs:585:32:585:42 | [post] &mut buffer [&ref] | provenance | MaD:67 |
-| test.rs:581:9:581:16 | mut file | test.rs:591:39:591:49 | [post] &mut buffer [&ref] | provenance | MaD:73 |
-| test.rs:581:9:581:16 | mut file | test.rs:597:42:597:52 | [post] &mut buffer [&ref] | provenance | MaD:74 |
-| test.rs:581:9:581:16 | mut file | test.rs:603:25:603:35 | [post] &mut buffer [&ref] | provenance | MaD:69 |
-| test.rs:581:9:581:16 | mut file | test.rs:608:18:608:31 | file.read_u8() [future, Ok] | provenance | MaD:75 |
-| test.rs:581:9:581:16 | mut file | test.rs:609:18:609:32 | file.read_i16() [future, Ok] | provenance | MaD:71 |
-| test.rs:581:9:581:16 | mut file | test.rs:610:18:610:32 | file.read_f32() [future, Ok] | provenance | MaD:70 |
-| test.rs:581:9:581:16 | mut file | test.rs:611:18:611:35 | file.read_i64_le() [future, Ok] | provenance | MaD:72 |
-| test.rs:581:9:581:16 | mut file | test.rs:620:23:620:33 | [post] &mut buffer [&ref] | provenance | MaD:68 |
-| test.rs:581:20:581:40 | ...::open | test.rs:581:20:581:52 | ...::open(...) [future, Ok] | provenance | Src:MaD:11  |
+| test.rs:581:9:581:16 | mut file | test.rs:585:32:585:42 | [post] &mut buffer [&ref] | provenance | MaD:70 |
+| test.rs:581:9:581:16 | mut file | test.rs:591:39:591:49 | [post] &mut buffer [&ref] | provenance | MaD:76 |
+| test.rs:581:9:581:16 | mut file | test.rs:597:42:597:52 | [post] &mut buffer [&ref] | provenance | MaD:77 |
+| test.rs:581:9:581:16 | mut file | test.rs:603:25:603:35 | [post] &mut buffer [&ref] | provenance | MaD:72 |
+| test.rs:581:9:581:16 | mut file | test.rs:608:18:608:31 | file.read_u8() [future, Ok] | provenance | MaD:78 |
+| test.rs:581:9:581:16 | mut file | test.rs:609:18:609:32 | file.read_i16() [future, Ok] | provenance | MaD:74 |
+| test.rs:581:9:581:16 | mut file | test.rs:610:18:610:32 | file.read_f32() [future, Ok] | provenance | MaD:73 |
+| test.rs:581:9:581:16 | mut file | test.rs:611:18:611:35 | file.read_i64_le() [future, Ok] | provenance | MaD:75 |
+| test.rs:581:9:581:16 | mut file | test.rs:620:23:620:33 | [post] &mut buffer [&ref] | provenance | MaD:71 |
+| test.rs:581:20:581:40 | ...::open | test.rs:581:20:581:52 | ...::open(...) [future, Ok] | provenance | Src:MaD:14  |
 | test.rs:581:20:581:52 | ...::open(...) [future, Ok] | test.rs:581:20:581:58 | await ... [Ok] | provenance |  |
 | test.rs:581:20:581:58 | await ... [Ok] | test.rs:581:20:581:59 | TryExpr | provenance |  |
 | test.rs:581:20:581:59 | TryExpr | test.rs:581:9:581:16 | mut file | provenance |  |
@@ -639,45 +642,45 @@ edges
 | test.rs:620:23:620:33 | [post] &mut buffer [&ref] | test.rs:620:28:620:33 | [post] buffer | provenance |  |
 | test.rs:620:28:620:33 | [post] buffer | test.rs:621:15:621:20 | buffer | provenance |  |
 | test.rs:621:15:621:20 | buffer | test.rs:621:14:621:20 | &buffer | provenance |  |
-| test.rs:627:13:627:18 | mut f1 | test.rs:629:30:629:40 | [post] &mut buffer [&ref] | provenance | MaD:67 |
+| test.rs:627:13:627:18 | mut f1 | test.rs:629:30:629:40 | [post] &mut buffer [&ref] | provenance | MaD:70 |
 | test.rs:627:22:627:65 | ... .open(...) [future, Ok] | test.rs:627:22:627:71 | await ... [Ok] | provenance |  |
 | test.rs:627:22:627:71 | await ... [Ok] | test.rs:627:22:627:72 | TryExpr | provenance |  |
 | test.rs:627:22:627:72 | TryExpr | test.rs:627:13:627:18 | mut f1 | provenance |  |
-| test.rs:627:52:627:55 | open | test.rs:627:22:627:65 | ... .open(...) [future, Ok] | provenance | Src:MaD:12  |
+| test.rs:627:52:627:55 | open | test.rs:627:22:627:65 | ... .open(...) [future, Ok] | provenance | Src:MaD:15  |
 | test.rs:629:30:629:40 | [post] &mut buffer [&ref] | test.rs:629:35:629:40 | [post] buffer | provenance |  |
 | test.rs:629:35:629:40 | [post] buffer | test.rs:630:15:630:20 | buffer | provenance |  |
 | test.rs:630:15:630:20 | buffer | test.rs:630:14:630:20 | &buffer | provenance |  |
 | test.rs:660:9:660:16 | mut file | test.rs:664:22:664:25 | file | provenance |  |
-| test.rs:660:9:660:16 | mut file | test.rs:664:32:664:42 | [post] &mut buffer [&ref] | provenance | MaD:35 |
-| test.rs:660:9:660:16 | mut file | test.rs:664:32:664:42 | [post] &mut buffer [&ref] | provenance | MaD:36 |
-| test.rs:660:9:660:16 | mut file | test.rs:664:32:664:42 | [post] &mut buffer [&ref] | provenance | MaD:46 |
-| test.rs:660:9:660:16 | mut file | test.rs:664:32:664:42 | [post] &mut buffer [&ref] | provenance | MaD:47 |
-| test.rs:660:20:660:44 | ...::open | test.rs:660:20:660:56 | ...::open(...) [future, Ok] | provenance | Src:MaD:1  |
+| test.rs:660:9:660:16 | mut file | test.rs:664:32:664:42 | [post] &mut buffer [&ref] | provenance | MaD:38 |
+| test.rs:660:9:660:16 | mut file | test.rs:664:32:664:42 | [post] &mut buffer [&ref] | provenance | MaD:39 |
+| test.rs:660:9:660:16 | mut file | test.rs:664:32:664:42 | [post] &mut buffer [&ref] | provenance | MaD:49 |
+| test.rs:660:9:660:16 | mut file | test.rs:664:32:664:42 | [post] &mut buffer [&ref] | provenance | MaD:50 |
+| test.rs:660:20:660:44 | ...::open | test.rs:660:20:660:56 | ...::open(...) [future, Ok] | provenance | Src:MaD:4  |
 | test.rs:660:20:660:56 | ...::open(...) [future, Ok] | test.rs:660:20:660:62 | await ... [Ok] | provenance |  |
 | test.rs:660:20:660:62 | await ... [Ok] | test.rs:660:20:660:63 | TryExpr | provenance |  |
 | test.rs:660:20:660:63 | TryExpr | test.rs:660:9:660:16 | mut file | provenance |  |
-| test.rs:664:22:664:25 | file | test.rs:664:32:664:42 | [post] &mut buffer [&ref] | provenance | MaD:35 |
-| test.rs:664:22:664:25 | file | test.rs:664:32:664:42 | [post] &mut buffer [&ref] | provenance | MaD:46 |
+| test.rs:664:22:664:25 | file | test.rs:664:32:664:42 | [post] &mut buffer [&ref] | provenance | MaD:38 |
+| test.rs:664:22:664:25 | file | test.rs:664:32:664:42 | [post] &mut buffer [&ref] | provenance | MaD:49 |
 | test.rs:664:32:664:42 | [post] &mut buffer [&ref] | test.rs:664:37:664:42 | [post] buffer | provenance |  |
 | test.rs:664:37:664:42 | [post] buffer | test.rs:665:15:665:20 | buffer | provenance |  |
 | test.rs:665:15:665:20 | buffer | test.rs:665:14:665:20 | &buffer | provenance |  |
 | test.rs:671:13:671:18 | mut f1 | test.rs:673:22:673:23 | f1 | provenance |  |
-| test.rs:671:13:671:18 | mut f1 | test.rs:673:30:673:40 | [post] &mut buffer [&ref] | provenance | MaD:35 |
-| test.rs:671:13:671:18 | mut f1 | test.rs:673:30:673:40 | [post] &mut buffer [&ref] | provenance | MaD:36 |
-| test.rs:671:13:671:18 | mut f1 | test.rs:673:30:673:40 | [post] &mut buffer [&ref] | provenance | MaD:46 |
-| test.rs:671:13:671:18 | mut f1 | test.rs:673:30:673:40 | [post] &mut buffer [&ref] | provenance | MaD:47 |
+| test.rs:671:13:671:18 | mut f1 | test.rs:673:30:673:40 | [post] &mut buffer [&ref] | provenance | MaD:38 |
+| test.rs:671:13:671:18 | mut f1 | test.rs:673:30:673:40 | [post] &mut buffer [&ref] | provenance | MaD:39 |
+| test.rs:671:13:671:18 | mut f1 | test.rs:673:30:673:40 | [post] &mut buffer [&ref] | provenance | MaD:49 |
+| test.rs:671:13:671:18 | mut f1 | test.rs:673:30:673:40 | [post] &mut buffer [&ref] | provenance | MaD:50 |
 | test.rs:671:22:671:69 | ... .open(...) [future, Ok] | test.rs:671:22:671:75 | await ... [Ok] | provenance |  |
 | test.rs:671:22:671:75 | await ... [Ok] | test.rs:671:22:671:76 | TryExpr | provenance |  |
 | test.rs:671:22:671:76 | TryExpr | test.rs:671:13:671:18 | mut f1 | provenance |  |
-| test.rs:671:56:671:59 | open | test.rs:671:22:671:69 | ... .open(...) [future, Ok] | provenance | Src:MaD:2  |
-| test.rs:673:22:673:23 | f1 | test.rs:673:30:673:40 | [post] &mut buffer [&ref] | provenance | MaD:35 |
-| test.rs:673:22:673:23 | f1 | test.rs:673:30:673:40 | [post] &mut buffer [&ref] | provenance | MaD:46 |
+| test.rs:671:56:671:59 | open | test.rs:671:22:671:69 | ... .open(...) [future, Ok] | provenance | Src:MaD:5  |
+| test.rs:673:22:673:23 | f1 | test.rs:673:30:673:40 | [post] &mut buffer [&ref] | provenance | MaD:38 |
+| test.rs:673:22:673:23 | f1 | test.rs:673:30:673:40 | [post] &mut buffer [&ref] | provenance | MaD:49 |
 | test.rs:673:30:673:40 | [post] &mut buffer [&ref] | test.rs:673:35:673:40 | [post] buffer | provenance |  |
 | test.rs:673:35:673:40 | [post] buffer | test.rs:674:15:674:20 | buffer | provenance |  |
 | test.rs:674:15:674:20 | buffer | test.rs:674:14:674:20 | &buffer | provenance |  |
-| test.rs:688:13:688:22 | mut stream | test.rs:695:29:695:39 | [post] &mut buffer [&ref] | provenance | MaD:57 |
-| test.rs:688:13:688:22 | mut stream | test.rs:695:29:695:39 | [post] &mut buffer [&ref] | provenance | MaD:115 |
-| test.rs:688:26:688:53 | ...::connect | test.rs:688:26:688:62 | ...::connect(...) [Ok] | provenance | Src:MaD:9  |
+| test.rs:688:13:688:22 | mut stream | test.rs:695:29:695:39 | [post] &mut buffer [&ref] | provenance | MaD:60 |
+| test.rs:688:13:688:22 | mut stream | test.rs:695:29:695:39 | [post] &mut buffer [&ref] | provenance | MaD:118 |
+| test.rs:688:26:688:53 | ...::connect | test.rs:688:26:688:62 | ...::connect(...) [Ok] | provenance | Src:MaD:12  |
 | test.rs:688:26:688:62 | ...::connect(...) [Ok] | test.rs:688:26:688:63 | TryExpr | provenance |  |
 | test.rs:688:26:688:63 | TryExpr | test.rs:688:13:688:22 | mut stream | provenance |  |
 | test.rs:695:29:695:39 | [post] &mut buffer [&ref] | test.rs:695:34:695:39 | [post] buffer | provenance |  |
@@ -685,21 +688,21 @@ edges
 | test.rs:695:34:695:39 | [post] buffer | test.rs:699:14:699:22 | buffer[0] | provenance |  |
 | test.rs:698:15:698:20 | buffer | test.rs:698:14:698:20 | &buffer | provenance |  |
 | test.rs:707:13:707:22 | mut stream | test.rs:715:58:715:63 | stream | provenance |  |
-| test.rs:707:26:707:61 | ...::connect_timeout | test.rs:707:26:707:105 | ...::connect_timeout(...) [Ok] | provenance | Src:MaD:10  |
+| test.rs:707:26:707:61 | ...::connect_timeout | test.rs:707:26:707:105 | ...::connect_timeout(...) [Ok] | provenance | Src:MaD:13  |
 | test.rs:707:26:707:105 | ...::connect_timeout(...) [Ok] | test.rs:707:26:707:106 | TryExpr | provenance |  |
 | test.rs:707:26:707:106 | TryExpr | test.rs:707:13:707:22 | mut stream | provenance |  |
-| test.rs:715:21:715:30 | mut reader | test.rs:718:44:718:52 | [post] &mut line [&ref] | provenance | MaD:51 |
-| test.rs:715:34:715:64 | ...::new(...) | test.rs:715:34:715:74 | ... .take(...) | provenance | MaD:61 |
+| test.rs:715:21:715:30 | mut reader | test.rs:718:44:718:52 | [post] &mut line [&ref] | provenance | MaD:54 |
+| test.rs:715:34:715:64 | ...::new(...) | test.rs:715:34:715:74 | ... .take(...) | provenance | MaD:64 |
 | test.rs:715:34:715:74 | ... .take(...) | test.rs:715:21:715:30 | mut reader | provenance |  |
-| test.rs:715:58:715:63 | stream | test.rs:715:34:715:64 | ...::new(...) | provenance | MaD:105 |
+| test.rs:715:58:715:63 | stream | test.rs:715:34:715:64 | ...::new(...) | provenance | MaD:108 |
 | test.rs:718:44:718:52 | [post] &mut line [&ref] | test.rs:718:49:718:52 | [post] line | provenance |  |
 | test.rs:718:49:718:52 | [post] line | test.rs:725:35:725:38 | line | provenance |  |
 | test.rs:725:35:725:38 | line | test.rs:725:34:725:38 | &line | provenance |  |
-| test.rs:759:9:759:24 | mut tokio_stream | test.rs:767:35:767:46 | [post] &mut buffer1 [&ref] | provenance | MaD:121 |
-| test.rs:759:9:759:24 | mut tokio_stream | test.rs:771:36:771:47 | [post] &mut buffer2 [&ref] | provenance | MaD:67 |
-| test.rs:759:9:759:24 | mut tokio_stream | test.rs:787:41:787:51 | [post] &mut buffer [&ref] | provenance | MaD:122 |
-| test.rs:759:9:759:24 | mut tokio_stream | test.rs:810:45:810:55 | [post] &mut buffer [&ref] | provenance | MaD:123 |
-| test.rs:759:28:759:57 | ...::connect | test.rs:759:28:759:66 | ...::connect(...) [future, Ok] | provenance | Src:MaD:15  |
+| test.rs:759:9:759:24 | mut tokio_stream | test.rs:767:35:767:46 | [post] &mut buffer1 [&ref] | provenance | MaD:124 |
+| test.rs:759:9:759:24 | mut tokio_stream | test.rs:771:36:771:47 | [post] &mut buffer2 [&ref] | provenance | MaD:70 |
+| test.rs:759:9:759:24 | mut tokio_stream | test.rs:787:41:787:51 | [post] &mut buffer [&ref] | provenance | MaD:125 |
+| test.rs:759:9:759:24 | mut tokio_stream | test.rs:810:45:810:55 | [post] &mut buffer [&ref] | provenance | MaD:126 |
+| test.rs:759:28:759:57 | ...::connect | test.rs:759:28:759:66 | ...::connect(...) [future, Ok] | provenance | Src:MaD:18  |
 | test.rs:759:28:759:66 | ...::connect(...) [future, Ok] | test.rs:759:28:759:72 | await ... [Ok] | provenance |  |
 | test.rs:759:28:759:72 | await ... [Ok] | test.rs:759:28:759:73 | TryExpr | provenance |  |
 | test.rs:759:28:759:73 | TryExpr | test.rs:759:9:759:24 | mut tokio_stream | provenance |  |
@@ -719,7 +722,7 @@ edges
 | test.rs:817:27:817:32 | buffer | test.rs:817:26:817:32 | &buffer | provenance |  |
 | test_futures_io.rs:19:9:19:11 | tcp | test_futures_io.rs:20:11:20:13 | tcp | provenance |  |
 | test_futures_io.rs:19:9:19:11 | tcp | test_futures_io.rs:26:53:26:55 | tcp | provenance |  |
-| test_futures_io.rs:19:15:19:32 | ...::connect | test_futures_io.rs:19:15:19:37 | ...::connect(...) [future, Ok] | provenance | Src:MaD:3  |
+| test_futures_io.rs:19:15:19:32 | ...::connect | test_futures_io.rs:19:15:19:37 | ...::connect(...) [future, Ok] | provenance | Src:MaD:6  |
 | test_futures_io.rs:19:15:19:37 | ...::connect(...) [future, Ok] | test_futures_io.rs:19:15:19:43 | await ... [Ok] | provenance |  |
 | test_futures_io.rs:19:15:19:43 | await ... [Ok] | test_futures_io.rs:19:15:19:44 | TryExpr | provenance |  |
 | test_futures_io.rs:19:15:19:44 | TryExpr | test_futures_io.rs:19:9:19:11 | tcp | provenance |  |
@@ -728,15 +731,15 @@ edges
 | test_futures_io.rs:26:9:26:18 | mut reader | test_futures_io.rs:32:40:32:45 | reader | provenance |  |
 | test_futures_io.rs:26:9:26:18 | mut reader | test_futures_io.rs:45:64:45:69 | reader | provenance |  |
 | test_futures_io.rs:26:9:26:18 | mut reader | test_futures_io.rs:49:27:49:32 | reader | provenance |  |
-| test_futures_io.rs:26:9:26:18 | mut reader | test_futures_io.rs:49:39:49:50 | [post] &mut buffer2 [&ref] | provenance | MaD:35 |
-| test_futures_io.rs:26:9:26:18 | mut reader | test_futures_io.rs:49:39:49:50 | [post] &mut buffer2 [&ref] | provenance | MaD:36 |
-| test_futures_io.rs:26:9:26:18 | mut reader | test_futures_io.rs:49:39:49:50 | [post] &mut buffer2 [&ref] | provenance | MaD:46 |
-| test_futures_io.rs:26:9:26:18 | mut reader | test_futures_io.rs:49:39:49:50 | [post] &mut buffer2 [&ref] | provenance | MaD:47 |
+| test_futures_io.rs:26:9:26:18 | mut reader | test_futures_io.rs:49:39:49:50 | [post] &mut buffer2 [&ref] | provenance | MaD:38 |
+| test_futures_io.rs:26:9:26:18 | mut reader | test_futures_io.rs:49:39:49:50 | [post] &mut buffer2 [&ref] | provenance | MaD:39 |
+| test_futures_io.rs:26:9:26:18 | mut reader | test_futures_io.rs:49:39:49:50 | [post] &mut buffer2 [&ref] | provenance | MaD:49 |
+| test_futures_io.rs:26:9:26:18 | mut reader | test_futures_io.rs:49:39:49:50 | [post] &mut buffer2 [&ref] | provenance | MaD:50 |
 | test_futures_io.rs:26:9:26:18 | mut reader | test_futures_io.rs:54:51:54:56 | reader | provenance |  |
 | test_futures_io.rs:26:22:26:56 | connector.connect(...) [future, Ok] | test_futures_io.rs:26:22:26:62 | await ... [Ok] | provenance |  |
 | test_futures_io.rs:26:22:26:62 | await ... [Ok] | test_futures_io.rs:26:22:26:63 | TryExpr | provenance |  |
 | test_futures_io.rs:26:22:26:63 | TryExpr | test_futures_io.rs:26:9:26:18 | mut reader | provenance |  |
-| test_futures_io.rs:26:53:26:55 | tcp | test_futures_io.rs:26:22:26:56 | connector.connect(...) [future, Ok] | provenance | MaD:88 |
+| test_futures_io.rs:26:53:26:55 | tcp | test_futures_io.rs:26:22:26:56 | connector.connect(...) [future, Ok] | provenance | MaD:91 |
 | test_futures_io.rs:27:11:27:16 | reader | test_futures_io.rs:27:10:27:16 | &reader | provenance |  |
 | test_futures_io.rs:32:13:32:22 | mut pinned | test_futures_io.rs:33:15:33:20 | pinned | provenance |  |
 | test_futures_io.rs:32:13:32:22 | mut pinned [&ref] | test_futures_io.rs:33:15:33:20 | pinned [&ref] | provenance |  |
@@ -744,60 +747,60 @@ edges
 | test_futures_io.rs:32:26:32:46 | ...::new(...) | test_futures_io.rs:32:13:32:22 | mut pinned | provenance |  |
 | test_futures_io.rs:32:26:32:46 | ...::new(...) [&ref] | test_futures_io.rs:32:13:32:22 | mut pinned [&ref] | provenance |  |
 | test_futures_io.rs:32:26:32:46 | ...::new(...) [Pin, &ref] | test_futures_io.rs:32:13:32:22 | mut pinned [Pin, &ref] | provenance |  |
-| test_futures_io.rs:32:35:32:45 | &mut reader [&ref] | test_futures_io.rs:32:26:32:46 | ...::new(...) | provenance | MaD:80 |
-| test_futures_io.rs:32:35:32:45 | &mut reader [&ref] | test_futures_io.rs:32:26:32:46 | ...::new(...) [&ref] | provenance | MaD:82 |
-| test_futures_io.rs:32:35:32:45 | &mut reader [&ref] | test_futures_io.rs:32:26:32:46 | ...::new(...) [Pin, &ref] | provenance | MaD:81 |
+| test_futures_io.rs:32:35:32:45 | &mut reader [&ref] | test_futures_io.rs:32:26:32:46 | ...::new(...) | provenance | MaD:83 |
+| test_futures_io.rs:32:35:32:45 | &mut reader [&ref] | test_futures_io.rs:32:26:32:46 | ...::new(...) [&ref] | provenance | MaD:85 |
+| test_futures_io.rs:32:35:32:45 | &mut reader [&ref] | test_futures_io.rs:32:26:32:46 | ...::new(...) [Pin, &ref] | provenance | MaD:84 |
 | test_futures_io.rs:32:40:32:45 | reader | test_futures_io.rs:32:35:32:45 | &mut reader [&ref] | provenance |  |
 | test_futures_io.rs:33:15:33:20 | pinned | test_futures_io.rs:33:14:33:20 | &pinned | provenance |  |
 | test_futures_io.rs:33:15:33:20 | pinned [&ref] | test_futures_io.rs:33:14:33:20 | &pinned | provenance |  |
 | test_futures_io.rs:33:15:33:20 | pinned [Pin, &ref] | test_futures_io.rs:33:14:33:20 | &pinned | provenance |  |
-| test_futures_io.rs:45:59:45:69 | &mut reader [&ref] | test_futures_io.rs:45:72:45:83 | [post] &mut buffer1 [&ref] | provenance | MaD:35 |
-| test_futures_io.rs:45:59:45:69 | &mut reader [&ref] | test_futures_io.rs:45:72:45:83 | [post] &mut buffer1 [&ref] | provenance | MaD:46 |
+| test_futures_io.rs:45:59:45:69 | &mut reader [&ref] | test_futures_io.rs:45:72:45:83 | [post] &mut buffer1 [&ref] | provenance | MaD:38 |
+| test_futures_io.rs:45:59:45:69 | &mut reader [&ref] | test_futures_io.rs:45:72:45:83 | [post] &mut buffer1 [&ref] | provenance | MaD:49 |
 | test_futures_io.rs:45:64:45:69 | reader | test_futures_io.rs:45:59:45:69 | &mut reader [&ref] | provenance |  |
 | test_futures_io.rs:45:72:45:83 | [post] &mut buffer1 [&ref] | test_futures_io.rs:45:77:45:83 | [post] buffer1 | provenance |  |
 | test_futures_io.rs:45:77:45:83 | [post] buffer1 | test_futures_io.rs:46:15:46:36 | buffer1[...] | provenance |  |
 | test_futures_io.rs:46:15:46:36 | buffer1[...] | test_futures_io.rs:46:14:46:36 | &... | provenance |  |
-| test_futures_io.rs:49:27:49:32 | reader | test_futures_io.rs:49:39:49:50 | [post] &mut buffer2 [&ref] | provenance | MaD:35 |
-| test_futures_io.rs:49:27:49:32 | reader | test_futures_io.rs:49:39:49:50 | [post] &mut buffer2 [&ref] | provenance | MaD:46 |
+| test_futures_io.rs:49:27:49:32 | reader | test_futures_io.rs:49:39:49:50 | [post] &mut buffer2 [&ref] | provenance | MaD:38 |
+| test_futures_io.rs:49:27:49:32 | reader | test_futures_io.rs:49:39:49:50 | [post] &mut buffer2 [&ref] | provenance | MaD:49 |
 | test_futures_io.rs:49:39:49:50 | [post] &mut buffer2 [&ref] | test_futures_io.rs:49:44:49:50 | [post] buffer2 | provenance |  |
 | test_futures_io.rs:49:44:49:50 | [post] buffer2 | test_futures_io.rs:51:15:51:36 | buffer2[...] | provenance |  |
 | test_futures_io.rs:51:15:51:36 | buffer2[...] | test_futures_io.rs:51:14:51:36 | &... | provenance |  |
 | test_futures_io.rs:54:9:54:19 | mut reader2 | test_futures_io.rs:55:11:55:17 | reader2 | provenance |  |
 | test_futures_io.rs:54:9:54:19 | mut reader2 | test_futures_io.rs:59:40:59:46 | reader2 | provenance |  |
 | test_futures_io.rs:54:9:54:19 | mut reader2 | test_futures_io.rs:69:37:69:43 | reader2 | provenance |  |
-| test_futures_io.rs:54:9:54:19 | mut reader2 | test_futures_io.rs:83:22:83:39 | reader2.fill_buf() [future, Ok] | provenance | MaD:41 |
+| test_futures_io.rs:54:9:54:19 | mut reader2 | test_futures_io.rs:83:22:83:39 | reader2.fill_buf() [future, Ok] | provenance | MaD:44 |
 | test_futures_io.rs:54:9:54:19 | mut reader2 | test_futures_io.rs:90:40:90:46 | reader2 | provenance |  |
 | test_futures_io.rs:54:9:54:19 | mut reader2 | test_futures_io.rs:103:64:103:70 | reader2 | provenance |  |
 | test_futures_io.rs:54:9:54:19 | mut reader2 | test_futures_io.rs:107:27:107:33 | reader2 | provenance |  |
-| test_futures_io.rs:54:9:54:19 | mut reader2 | test_futures_io.rs:107:40:107:51 | [post] &mut buffer2 [&ref] | provenance | MaD:35 |
-| test_futures_io.rs:54:9:54:19 | mut reader2 | test_futures_io.rs:107:40:107:51 | [post] &mut buffer2 [&ref] | provenance | MaD:36 |
-| test_futures_io.rs:54:9:54:19 | mut reader2 | test_futures_io.rs:107:40:107:51 | [post] &mut buffer2 [&ref] | provenance | MaD:46 |
-| test_futures_io.rs:54:9:54:19 | mut reader2 | test_futures_io.rs:107:40:107:51 | [post] &mut buffer2 [&ref] | provenance | MaD:47 |
+| test_futures_io.rs:54:9:54:19 | mut reader2 | test_futures_io.rs:107:40:107:51 | [post] &mut buffer2 [&ref] | provenance | MaD:38 |
+| test_futures_io.rs:54:9:54:19 | mut reader2 | test_futures_io.rs:107:40:107:51 | [post] &mut buffer2 [&ref] | provenance | MaD:39 |
+| test_futures_io.rs:54:9:54:19 | mut reader2 | test_futures_io.rs:107:40:107:51 | [post] &mut buffer2 [&ref] | provenance | MaD:49 |
+| test_futures_io.rs:54:9:54:19 | mut reader2 | test_futures_io.rs:107:40:107:51 | [post] &mut buffer2 [&ref] | provenance | MaD:50 |
 | test_futures_io.rs:54:9:54:19 | mut reader2 | test_futures_io.rs:113:40:113:46 | reader2 | provenance |  |
-| test_futures_io.rs:54:9:54:19 | mut reader2 | test_futures_io.rs:125:22:125:39 | reader2.fill_buf() [future, Ok] | provenance | MaD:41 |
+| test_futures_io.rs:54:9:54:19 | mut reader2 | test_futures_io.rs:125:22:125:39 | reader2.fill_buf() [future, Ok] | provenance | MaD:44 |
 | test_futures_io.rs:54:9:54:19 | mut reader2 | test_futures_io.rs:132:27:132:33 | reader2 | provenance |  |
-| test_futures_io.rs:54:9:54:19 | mut reader2 | test_futures_io.rs:132:53:132:61 | [post] &mut line [&ref] | provenance | MaD:44 |
-| test_futures_io.rs:54:9:54:19 | mut reader2 | test_futures_io.rs:132:53:132:61 | [post] &mut line [&ref] | provenance | MaD:45 |
+| test_futures_io.rs:54:9:54:19 | mut reader2 | test_futures_io.rs:132:53:132:61 | [post] &mut line [&ref] | provenance | MaD:47 |
+| test_futures_io.rs:54:9:54:19 | mut reader2 | test_futures_io.rs:132:53:132:61 | [post] &mut line [&ref] | provenance | MaD:48 |
 | test_futures_io.rs:54:9:54:19 | mut reader2 | test_futures_io.rs:139:27:139:33 | reader2 | provenance |  |
-| test_futures_io.rs:54:9:54:19 | mut reader2 | test_futures_io.rs:139:45:139:53 | [post] &mut line [&ref] | provenance | MaD:42 |
-| test_futures_io.rs:54:9:54:19 | mut reader2 | test_futures_io.rs:139:45:139:53 | [post] &mut line [&ref] | provenance | MaD:43 |
+| test_futures_io.rs:54:9:54:19 | mut reader2 | test_futures_io.rs:139:45:139:53 | [post] &mut line [&ref] | provenance | MaD:45 |
+| test_futures_io.rs:54:9:54:19 | mut reader2 | test_futures_io.rs:139:45:139:53 | [post] &mut line [&ref] | provenance | MaD:46 |
 | test_futures_io.rs:54:9:54:19 | mut reader2 | test_futures_io.rs:146:27:146:33 | reader2 | provenance |  |
-| test_futures_io.rs:54:9:54:19 | mut reader2 | test_futures_io.rs:146:47:146:57 | [post] &mut buffer [&ref] | provenance | MaD:48 |
-| test_futures_io.rs:54:9:54:19 | mut reader2 | test_futures_io.rs:146:47:146:57 | [post] &mut buffer [&ref] | provenance | MaD:49 |
+| test_futures_io.rs:54:9:54:19 | mut reader2 | test_futures_io.rs:146:47:146:57 | [post] &mut buffer [&ref] | provenance | MaD:51 |
+| test_futures_io.rs:54:9:54:19 | mut reader2 | test_futures_io.rs:146:47:146:57 | [post] &mut buffer [&ref] | provenance | MaD:52 |
 | test_futures_io.rs:54:23:54:57 | ...::new(...) | test_futures_io.rs:54:9:54:19 | mut reader2 | provenance |  |
-| test_futures_io.rs:54:51:54:56 | reader | test_futures_io.rs:54:23:54:57 | ...::new(...) | provenance | MaD:89 |
+| test_futures_io.rs:54:51:54:56 | reader | test_futures_io.rs:54:23:54:57 | ...::new(...) | provenance | MaD:92 |
 | test_futures_io.rs:55:11:55:17 | reader2 | test_futures_io.rs:55:10:55:17 | &reader2 | provenance |  |
 | test_futures_io.rs:59:13:59:22 | mut pinned | test_futures_io.rs:60:15:60:20 | pinned | provenance |  |
-| test_futures_io.rs:59:13:59:22 | mut pinned | test_futures_io.rs:62:22:62:50 | pinned.poll_fill_buf(...) [Ready, Ok] | provenance | MaD:40 |
+| test_futures_io.rs:59:13:59:22 | mut pinned | test_futures_io.rs:62:22:62:50 | pinned.poll_fill_buf(...) [Ready, Ok] | provenance | MaD:43 |
 | test_futures_io.rs:59:13:59:22 | mut pinned [&ref] | test_futures_io.rs:60:15:60:20 | pinned [&ref] | provenance |  |
-| test_futures_io.rs:59:13:59:22 | mut pinned [&ref] | test_futures_io.rs:62:22:62:50 | pinned.poll_fill_buf(...) [Ready, Ok] | provenance | MaD:40 |
+| test_futures_io.rs:59:13:59:22 | mut pinned [&ref] | test_futures_io.rs:62:22:62:50 | pinned.poll_fill_buf(...) [Ready, Ok] | provenance | MaD:43 |
 | test_futures_io.rs:59:13:59:22 | mut pinned [Pin, &ref] | test_futures_io.rs:60:15:60:20 | pinned [Pin, &ref] | provenance |  |
 | test_futures_io.rs:59:26:59:47 | ...::new(...) | test_futures_io.rs:59:13:59:22 | mut pinned | provenance |  |
 | test_futures_io.rs:59:26:59:47 | ...::new(...) [&ref] | test_futures_io.rs:59:13:59:22 | mut pinned [&ref] | provenance |  |
 | test_futures_io.rs:59:26:59:47 | ...::new(...) [Pin, &ref] | test_futures_io.rs:59:13:59:22 | mut pinned [Pin, &ref] | provenance |  |
-| test_futures_io.rs:59:35:59:46 | &mut reader2 [&ref] | test_futures_io.rs:59:26:59:47 | ...::new(...) | provenance | MaD:80 |
-| test_futures_io.rs:59:35:59:46 | &mut reader2 [&ref] | test_futures_io.rs:59:26:59:47 | ...::new(...) [&ref] | provenance | MaD:82 |
-| test_futures_io.rs:59:35:59:46 | &mut reader2 [&ref] | test_futures_io.rs:59:26:59:47 | ...::new(...) [Pin, &ref] | provenance | MaD:81 |
+| test_futures_io.rs:59:35:59:46 | &mut reader2 [&ref] | test_futures_io.rs:59:26:59:47 | ...::new(...) | provenance | MaD:83 |
+| test_futures_io.rs:59:35:59:46 | &mut reader2 [&ref] | test_futures_io.rs:59:26:59:47 | ...::new(...) [&ref] | provenance | MaD:85 |
+| test_futures_io.rs:59:35:59:46 | &mut reader2 [&ref] | test_futures_io.rs:59:26:59:47 | ...::new(...) [Pin, &ref] | provenance | MaD:84 |
 | test_futures_io.rs:59:40:59:46 | reader2 | test_futures_io.rs:59:35:59:46 | &mut reader2 [&ref] | provenance |  |
 | test_futures_io.rs:60:15:60:20 | pinned | test_futures_io.rs:60:14:60:20 | &pinned | provenance |  |
 | test_futures_io.rs:60:15:60:20 | pinned [&ref] | test_futures_io.rs:60:14:60:20 | &pinned | provenance |  |
@@ -810,11 +813,11 @@ edges
 | test_futures_io.rs:63:31:63:33 | buf | test_futures_io.rs:65:18:65:20 | buf | provenance |  |
 | test_futures_io.rs:64:19:64:24 | buffer [Ready, Ok] | test_futures_io.rs:64:18:64:24 | &buffer | provenance |  |
 | test_futures_io.rs:69:13:69:19 | buffer2 [Ready, Ok] | test_futures_io.rs:70:16:70:22 | buffer2 [Ready, Ok] | provenance |  |
-| test_futures_io.rs:69:23:69:44 | ...::new(...) | test_futures_io.rs:69:23:69:67 | ... .poll_fill_buf(...) [Ready, Ok] | provenance | MaD:40 |
-| test_futures_io.rs:69:23:69:44 | ...::new(...) [&ref] | test_futures_io.rs:69:23:69:67 | ... .poll_fill_buf(...) [Ready, Ok] | provenance | MaD:40 |
+| test_futures_io.rs:69:23:69:44 | ...::new(...) | test_futures_io.rs:69:23:69:67 | ... .poll_fill_buf(...) [Ready, Ok] | provenance | MaD:43 |
+| test_futures_io.rs:69:23:69:44 | ...::new(...) [&ref] | test_futures_io.rs:69:23:69:67 | ... .poll_fill_buf(...) [Ready, Ok] | provenance | MaD:43 |
 | test_futures_io.rs:69:23:69:67 | ... .poll_fill_buf(...) [Ready, Ok] | test_futures_io.rs:69:13:69:19 | buffer2 [Ready, Ok] | provenance |  |
-| test_futures_io.rs:69:32:69:43 | &mut reader2 [&ref] | test_futures_io.rs:69:23:69:44 | ...::new(...) | provenance | MaD:80 |
-| test_futures_io.rs:69:32:69:43 | &mut reader2 [&ref] | test_futures_io.rs:69:23:69:44 | ...::new(...) [&ref] | provenance | MaD:82 |
+| test_futures_io.rs:69:32:69:43 | &mut reader2 [&ref] | test_futures_io.rs:69:23:69:44 | ...::new(...) | provenance | MaD:83 |
+| test_futures_io.rs:69:32:69:43 | &mut reader2 [&ref] | test_futures_io.rs:69:23:69:44 | ...::new(...) [&ref] | provenance | MaD:85 |
 | test_futures_io.rs:69:37:69:43 | reader2 | test_futures_io.rs:69:32:69:43 | &mut reader2 [&ref] | provenance |  |
 | test_futures_io.rs:70:16:70:22 | buffer2 [Ready, Ok] | test_futures_io.rs:71:13:71:32 | ...::Ready(...) [Ready, Ok] | provenance |  |
 | test_futures_io.rs:70:16:70:22 | buffer2 [Ready, Ok] | test_futures_io.rs:72:23:72:29 | buffer2 [Ready, Ok] | provenance |  |
@@ -832,35 +835,35 @@ edges
 | test_futures_io.rs:90:26:90:47 | ...::new(...) | test_futures_io.rs:90:13:90:22 | mut pinned | provenance |  |
 | test_futures_io.rs:90:26:90:47 | ...::new(...) [&ref] | test_futures_io.rs:90:13:90:22 | mut pinned [&ref] | provenance |  |
 | test_futures_io.rs:90:26:90:47 | ...::new(...) [Pin, &ref] | test_futures_io.rs:90:13:90:22 | mut pinned [Pin, &ref] | provenance |  |
-| test_futures_io.rs:90:35:90:46 | &mut reader2 [&ref] | test_futures_io.rs:90:26:90:47 | ...::new(...) | provenance | MaD:80 |
-| test_futures_io.rs:90:35:90:46 | &mut reader2 [&ref] | test_futures_io.rs:90:26:90:47 | ...::new(...) [&ref] | provenance | MaD:82 |
-| test_futures_io.rs:90:35:90:46 | &mut reader2 [&ref] | test_futures_io.rs:90:26:90:47 | ...::new(...) [Pin, &ref] | provenance | MaD:81 |
+| test_futures_io.rs:90:35:90:46 | &mut reader2 [&ref] | test_futures_io.rs:90:26:90:47 | ...::new(...) | provenance | MaD:83 |
+| test_futures_io.rs:90:35:90:46 | &mut reader2 [&ref] | test_futures_io.rs:90:26:90:47 | ...::new(...) [&ref] | provenance | MaD:85 |
+| test_futures_io.rs:90:35:90:46 | &mut reader2 [&ref] | test_futures_io.rs:90:26:90:47 | ...::new(...) [Pin, &ref] | provenance | MaD:84 |
 | test_futures_io.rs:90:40:90:46 | reader2 | test_futures_io.rs:90:35:90:46 | &mut reader2 [&ref] | provenance |  |
 | test_futures_io.rs:91:15:91:20 | pinned | test_futures_io.rs:91:14:91:20 | &pinned | provenance |  |
 | test_futures_io.rs:91:15:91:20 | pinned [&ref] | test_futures_io.rs:91:14:91:20 | &pinned | provenance |  |
 | test_futures_io.rs:91:15:91:20 | pinned [Pin, &ref] | test_futures_io.rs:91:14:91:20 | &pinned | provenance |  |
-| test_futures_io.rs:103:59:103:70 | &mut reader2 [&ref] | test_futures_io.rs:103:73:103:84 | [post] &mut buffer1 [&ref] | provenance | MaD:35 |
-| test_futures_io.rs:103:59:103:70 | &mut reader2 [&ref] | test_futures_io.rs:103:73:103:84 | [post] &mut buffer1 [&ref] | provenance | MaD:46 |
+| test_futures_io.rs:103:59:103:70 | &mut reader2 [&ref] | test_futures_io.rs:103:73:103:84 | [post] &mut buffer1 [&ref] | provenance | MaD:38 |
+| test_futures_io.rs:103:59:103:70 | &mut reader2 [&ref] | test_futures_io.rs:103:73:103:84 | [post] &mut buffer1 [&ref] | provenance | MaD:49 |
 | test_futures_io.rs:103:64:103:70 | reader2 | test_futures_io.rs:103:59:103:70 | &mut reader2 [&ref] | provenance |  |
 | test_futures_io.rs:103:73:103:84 | [post] &mut buffer1 [&ref] | test_futures_io.rs:103:78:103:84 | [post] buffer1 | provenance |  |
 | test_futures_io.rs:103:78:103:84 | [post] buffer1 | test_futures_io.rs:104:15:104:36 | buffer1[...] | provenance |  |
 | test_futures_io.rs:104:15:104:36 | buffer1[...] | test_futures_io.rs:104:14:104:36 | &... | provenance |  |
-| test_futures_io.rs:107:27:107:33 | reader2 | test_futures_io.rs:107:40:107:51 | [post] &mut buffer2 [&ref] | provenance | MaD:35 |
-| test_futures_io.rs:107:27:107:33 | reader2 | test_futures_io.rs:107:40:107:51 | [post] &mut buffer2 [&ref] | provenance | MaD:46 |
+| test_futures_io.rs:107:27:107:33 | reader2 | test_futures_io.rs:107:40:107:51 | [post] &mut buffer2 [&ref] | provenance | MaD:38 |
+| test_futures_io.rs:107:27:107:33 | reader2 | test_futures_io.rs:107:40:107:51 | [post] &mut buffer2 [&ref] | provenance | MaD:49 |
 | test_futures_io.rs:107:40:107:51 | [post] &mut buffer2 [&ref] | test_futures_io.rs:107:45:107:51 | [post] buffer2 | provenance |  |
 | test_futures_io.rs:107:45:107:51 | [post] buffer2 | test_futures_io.rs:108:15:108:36 | buffer2[...] | provenance |  |
 | test_futures_io.rs:108:15:108:36 | buffer2[...] | test_futures_io.rs:108:14:108:36 | &... | provenance |  |
 | test_futures_io.rs:113:13:113:22 | mut pinned | test_futures_io.rs:114:15:114:20 | pinned | provenance |  |
-| test_futures_io.rs:113:13:113:22 | mut pinned | test_futures_io.rs:116:22:116:50 | pinned.poll_fill_buf(...) [Ready, Ok] | provenance | MaD:40 |
+| test_futures_io.rs:113:13:113:22 | mut pinned | test_futures_io.rs:116:22:116:50 | pinned.poll_fill_buf(...) [Ready, Ok] | provenance | MaD:43 |
 | test_futures_io.rs:113:13:113:22 | mut pinned [&ref] | test_futures_io.rs:114:15:114:20 | pinned [&ref] | provenance |  |
-| test_futures_io.rs:113:13:113:22 | mut pinned [&ref] | test_futures_io.rs:116:22:116:50 | pinned.poll_fill_buf(...) [Ready, Ok] | provenance | MaD:40 |
+| test_futures_io.rs:113:13:113:22 | mut pinned [&ref] | test_futures_io.rs:116:22:116:50 | pinned.poll_fill_buf(...) [Ready, Ok] | provenance | MaD:43 |
 | test_futures_io.rs:113:13:113:22 | mut pinned [Pin, &ref] | test_futures_io.rs:114:15:114:20 | pinned [Pin, &ref] | provenance |  |
 | test_futures_io.rs:113:26:113:47 | ...::new(...) | test_futures_io.rs:113:13:113:22 | mut pinned | provenance |  |
 | test_futures_io.rs:113:26:113:47 | ...::new(...) [&ref] | test_futures_io.rs:113:13:113:22 | mut pinned [&ref] | provenance |  |
 | test_futures_io.rs:113:26:113:47 | ...::new(...) [Pin, &ref] | test_futures_io.rs:113:13:113:22 | mut pinned [Pin, &ref] | provenance |  |
-| test_futures_io.rs:113:35:113:46 | &mut reader2 [&ref] | test_futures_io.rs:113:26:113:47 | ...::new(...) | provenance | MaD:80 |
-| test_futures_io.rs:113:35:113:46 | &mut reader2 [&ref] | test_futures_io.rs:113:26:113:47 | ...::new(...) [&ref] | provenance | MaD:82 |
-| test_futures_io.rs:113:35:113:46 | &mut reader2 [&ref] | test_futures_io.rs:113:26:113:47 | ...::new(...) [Pin, &ref] | provenance | MaD:81 |
+| test_futures_io.rs:113:35:113:46 | &mut reader2 [&ref] | test_futures_io.rs:113:26:113:47 | ...::new(...) | provenance | MaD:83 |
+| test_futures_io.rs:113:35:113:46 | &mut reader2 [&ref] | test_futures_io.rs:113:26:113:47 | ...::new(...) [&ref] | provenance | MaD:85 |
+| test_futures_io.rs:113:35:113:46 | &mut reader2 [&ref] | test_futures_io.rs:113:26:113:47 | ...::new(...) [Pin, &ref] | provenance | MaD:84 |
 | test_futures_io.rs:113:40:113:46 | reader2 | test_futures_io.rs:113:35:113:46 | &mut reader2 [&ref] | provenance |  |
 | test_futures_io.rs:114:15:114:20 | pinned | test_futures_io.rs:114:14:114:20 | &pinned | provenance |  |
 | test_futures_io.rs:114:15:114:20 | pinned [&ref] | test_futures_io.rs:114:14:114:20 | &pinned | provenance |  |
@@ -876,42 +879,58 @@ edges
 | test_futures_io.rs:125:22:125:39 | reader2.fill_buf() [future, Ok] | test_futures_io.rs:125:22:125:45 | await ... [Ok] | provenance |  |
 | test_futures_io.rs:125:22:125:45 | await ... [Ok] | test_futures_io.rs:125:22:125:46 | TryExpr | provenance |  |
 | test_futures_io.rs:125:22:125:46 | TryExpr | test_futures_io.rs:125:13:125:18 | buffer | provenance |  |
-| test_futures_io.rs:132:27:132:33 | reader2 | test_futures_io.rs:132:53:132:61 | [post] &mut line [&ref] | provenance | MaD:44 |
+| test_futures_io.rs:132:27:132:33 | reader2 | test_futures_io.rs:132:53:132:61 | [post] &mut line [&ref] | provenance | MaD:47 |
 | test_futures_io.rs:132:53:132:61 | [post] &mut line [&ref] | test_futures_io.rs:132:58:132:61 | [post] line | provenance |  |
 | test_futures_io.rs:132:58:132:61 | [post] line | test_futures_io.rs:133:15:133:18 | line | provenance |  |
 | test_futures_io.rs:133:15:133:18 | line | test_futures_io.rs:133:14:133:18 | &line | provenance |  |
-| test_futures_io.rs:139:27:139:33 | reader2 | test_futures_io.rs:139:45:139:53 | [post] &mut line [&ref] | provenance | MaD:42 |
+| test_futures_io.rs:139:27:139:33 | reader2 | test_futures_io.rs:139:45:139:53 | [post] &mut line [&ref] | provenance | MaD:45 |
 | test_futures_io.rs:139:45:139:53 | [post] &mut line [&ref] | test_futures_io.rs:139:50:139:53 | [post] line | provenance |  |
 | test_futures_io.rs:139:50:139:53 | [post] line | test_futures_io.rs:140:15:140:18 | line | provenance |  |
 | test_futures_io.rs:140:15:140:18 | line | test_futures_io.rs:140:14:140:18 | &line | provenance |  |
-| test_futures_io.rs:146:27:146:33 | reader2 | test_futures_io.rs:146:47:146:57 | [post] &mut buffer [&ref] | provenance | MaD:48 |
+| test_futures_io.rs:146:27:146:33 | reader2 | test_futures_io.rs:146:47:146:57 | [post] &mut buffer [&ref] | provenance | MaD:51 |
 | test_futures_io.rs:146:47:146:57 | [post] &mut buffer [&ref] | test_futures_io.rs:146:52:146:57 | [post] buffer | provenance |  |
 | test_futures_io.rs:146:52:146:57 | [post] buffer | test_futures_io.rs:147:15:147:20 | buffer | provenance |  |
 | test_futures_io.rs:147:15:147:20 | buffer | test_futures_io.rs:147:14:147:20 | &buffer | provenance |  |
 | web_frameworks.rs:11:31:11:31 | a | web_frameworks.rs:13:14:13:14 | a | provenance |  |
 | web_frameworks.rs:11:31:11:31 | a | web_frameworks.rs:13:14:13:14 | a | provenance |  |
-| web_frameworks.rs:11:31:11:31 | a | web_frameworks.rs:13:14:13:22 | a.as_str() | provenance | MaD:77 |
-| web_frameworks.rs:11:31:11:31 | a | web_frameworks.rs:13:14:13:22 | a.as_str() | provenance | MaD:86 |
-| web_frameworks.rs:11:31:11:31 | a | web_frameworks.rs:13:14:13:23 | a.as_str() | provenance | MaD:77 |
-| web_frameworks.rs:11:31:11:31 | a | web_frameworks.rs:13:14:13:23 | a.as_str() | provenance | MaD:86 |
+| web_frameworks.rs:11:31:11:31 | a | web_frameworks.rs:13:14:13:22 | a.as_str() | provenance | MaD:80 |
+| web_frameworks.rs:11:31:11:31 | a | web_frameworks.rs:13:14:13:22 | a.as_str() | provenance | MaD:89 |
+| web_frameworks.rs:11:31:11:31 | a | web_frameworks.rs:13:14:13:23 | a.as_str() | provenance | MaD:80 |
+| web_frameworks.rs:11:31:11:31 | a | web_frameworks.rs:13:14:13:23 | a.as_str() | provenance | MaD:89 |
 | web_frameworks.rs:11:31:11:31 | a | web_frameworks.rs:14:14:14:14 | a | provenance |  |
 | web_frameworks.rs:11:31:11:31 | a | web_frameworks.rs:14:14:14:14 | a | provenance |  |
-| web_frameworks.rs:11:31:11:31 | a | web_frameworks.rs:14:14:14:24 | a.as_bytes() | provenance | MaD:76 |
-| web_frameworks.rs:11:31:11:31 | a | web_frameworks.rs:14:14:14:24 | a.as_bytes() | provenance | MaD:85 |
-| web_frameworks.rs:11:31:11:31 | a | web_frameworks.rs:14:14:14:25 | a.as_bytes() | provenance | MaD:76 |
-| web_frameworks.rs:11:31:11:31 | a | web_frameworks.rs:14:14:14:25 | a.as_bytes() | provenance | MaD:85 |
+| web_frameworks.rs:11:31:11:31 | a | web_frameworks.rs:14:14:14:24 | a.as_bytes() | provenance | MaD:79 |
+| web_frameworks.rs:11:31:11:31 | a | web_frameworks.rs:14:14:14:24 | a.as_bytes() | provenance | MaD:88 |
+| web_frameworks.rs:11:31:11:31 | a | web_frameworks.rs:14:14:14:25 | a.as_bytes() | provenance | MaD:79 |
+| web_frameworks.rs:11:31:11:31 | a | web_frameworks.rs:14:14:14:25 | a.as_bytes() | provenance | MaD:88 |
 | web_frameworks.rs:11:31:11:31 | a | web_frameworks.rs:15:14:15:14 | a | provenance |  |
 | web_frameworks.rs:11:31:11:31 | a | web_frameworks.rs:15:14:15:14 | a | provenance |  |
-| web_frameworks.rs:13:14:13:14 | a | web_frameworks.rs:13:14:13:22 | a.as_str() | provenance | MaD:77 |
-| web_frameworks.rs:13:14:13:14 | a | web_frameworks.rs:13:14:13:22 | a.as_str() | provenance | MaD:86 |
-| web_frameworks.rs:13:14:13:14 | a | web_frameworks.rs:13:14:13:23 | a.as_str() | provenance | MaD:77 |
-| web_frameworks.rs:13:14:13:14 | a | web_frameworks.rs:13:14:13:23 | a.as_str() | provenance | MaD:86 |
-| web_frameworks.rs:14:14:14:14 | a | web_frameworks.rs:14:14:14:24 | a.as_bytes() | provenance | MaD:76 |
-| web_frameworks.rs:14:14:14:14 | a | web_frameworks.rs:14:14:14:24 | a.as_bytes() | provenance | MaD:85 |
-| web_frameworks.rs:14:14:14:14 | a | web_frameworks.rs:14:14:14:25 | a.as_bytes() | provenance | MaD:76 |
-| web_frameworks.rs:14:14:14:14 | a | web_frameworks.rs:14:14:14:25 | a.as_bytes() | provenance | MaD:85 |
+| web_frameworks.rs:13:14:13:14 | a | web_frameworks.rs:13:14:13:22 | a.as_str() | provenance | MaD:80 |
+| web_frameworks.rs:13:14:13:14 | a | web_frameworks.rs:13:14:13:22 | a.as_str() | provenance | MaD:89 |
+| web_frameworks.rs:13:14:13:14 | a | web_frameworks.rs:13:14:13:23 | a.as_str() | provenance | MaD:80 |
+| web_frameworks.rs:13:14:13:14 | a | web_frameworks.rs:13:14:13:23 | a.as_str() | provenance | MaD:89 |
+| web_frameworks.rs:14:14:14:14 | a | web_frameworks.rs:14:14:14:24 | a.as_bytes() | provenance | MaD:79 |
+| web_frameworks.rs:14:14:14:14 | a | web_frameworks.rs:14:14:14:24 | a.as_bytes() | provenance | MaD:88 |
+| web_frameworks.rs:14:14:14:14 | a | web_frameworks.rs:14:14:14:25 | a.as_bytes() | provenance | MaD:79 |
+| web_frameworks.rs:14:14:14:14 | a | web_frameworks.rs:14:14:14:25 | a.as_bytes() | provenance | MaD:88 |
 | web_frameworks.rs:68:15:68:15 | a | web_frameworks.rs:70:14:70:14 | a | provenance |  |
 | web_frameworks.rs:68:15:68:15 | a | web_frameworks.rs:70:14:70:14 | a | provenance |  |
+| web_frameworks.rs:242:33:242:35 | map | web_frameworks.rs:242:38:242:46 | ...: String | provenance | Src:MaD:2  |
+| web_frameworks.rs:242:33:242:35 | map | web_frameworks.rs:242:38:242:46 | ...: String | provenance | Src:MaD:2  |
+| web_frameworks.rs:242:38:242:46 | ...: String | web_frameworks.rs:244:18:244:18 | a | provenance |  |
+| web_frameworks.rs:242:38:242:46 | ...: String | web_frameworks.rs:244:18:244:18 | a | provenance |  |
+| web_frameworks.rs:250:46:250:49 | then | web_frameworks.rs:251:25:251:33 | ...: String | provenance | Src:MaD:3  |
+| web_frameworks.rs:250:46:250:49 | then | web_frameworks.rs:251:25:251:33 | ...: String | provenance | Src:MaD:3  |
+| web_frameworks.rs:251:25:251:33 | ...: String | web_frameworks.rs:252:22:252:22 | a | provenance |  |
+| web_frameworks.rs:251:25:251:33 | ...: String | web_frameworks.rs:252:22:252:22 | a | provenance |  |
+| web_frameworks.rs:259:50:259:57 | and_then | web_frameworks.rs:260:26:260:32 | ...: u64 | provenance | Src:MaD:1  |
+| web_frameworks.rs:259:50:259:57 | and_then | web_frameworks.rs:260:26:260:32 | ...: u64 | provenance | Src:MaD:1  |
+| web_frameworks.rs:260:26:260:32 | ...: u64 | web_frameworks.rs:263:22:263:23 | id | provenance |  |
+| web_frameworks.rs:260:26:260:32 | ...: u64 | web_frameworks.rs:263:22:263:23 | id | provenance |  |
+| web_frameworks.rs:272:75:272:77 | map | web_frameworks.rs:273:15:273:23 | ...: String | provenance | Src:MaD:2  |
+| web_frameworks.rs:272:75:272:77 | map | web_frameworks.rs:273:15:273:23 | ...: String | provenance | Src:MaD:2  |
+| web_frameworks.rs:273:15:273:23 | ...: String | web_frameworks.rs:275:22:275:22 | a | provenance |  |
+| web_frameworks.rs:273:15:273:23 | ...: String | web_frameworks.rs:275:22:275:22 | a | provenance |  |
 nodes
 | test.rs:8:10:8:22 | ...::var | semmle.label | ...::var |
 | test.rs:8:10:8:30 | ...::var(...) | semmle.label | ...::var(...) |
@@ -1700,6 +1719,30 @@ nodes
 | web_frameworks.rs:68:15:68:15 | a | semmle.label | a |
 | web_frameworks.rs:70:14:70:14 | a | semmle.label | a |
 | web_frameworks.rs:70:14:70:14 | a | semmle.label | a |
+| web_frameworks.rs:242:33:242:35 | map | semmle.label | map |
+| web_frameworks.rs:242:33:242:35 | map | semmle.label | map |
+| web_frameworks.rs:242:38:242:46 | ...: String | semmle.label | ...: String |
+| web_frameworks.rs:242:38:242:46 | ...: String | semmle.label | ...: String |
+| web_frameworks.rs:244:18:244:18 | a | semmle.label | a |
+| web_frameworks.rs:244:18:244:18 | a | semmle.label | a |
+| web_frameworks.rs:250:46:250:49 | then | semmle.label | then |
+| web_frameworks.rs:250:46:250:49 | then | semmle.label | then |
+| web_frameworks.rs:251:25:251:33 | ...: String | semmle.label | ...: String |
+| web_frameworks.rs:251:25:251:33 | ...: String | semmle.label | ...: String |
+| web_frameworks.rs:252:22:252:22 | a | semmle.label | a |
+| web_frameworks.rs:252:22:252:22 | a | semmle.label | a |
+| web_frameworks.rs:259:50:259:57 | and_then | semmle.label | and_then |
+| web_frameworks.rs:259:50:259:57 | and_then | semmle.label | and_then |
+| web_frameworks.rs:260:26:260:32 | ...: u64 | semmle.label | ...: u64 |
+| web_frameworks.rs:260:26:260:32 | ...: u64 | semmle.label | ...: u64 |
+| web_frameworks.rs:263:22:263:23 | id | semmle.label | id |
+| web_frameworks.rs:263:22:263:23 | id | semmle.label | id |
+| web_frameworks.rs:272:75:272:77 | map | semmle.label | map |
+| web_frameworks.rs:272:75:272:77 | map | semmle.label | map |
+| web_frameworks.rs:273:15:273:23 | ...: String | semmle.label | ...: String |
+| web_frameworks.rs:273:15:273:23 | ...: String | semmle.label | ...: String |
+| web_frameworks.rs:275:22:275:22 | a | semmle.label | a |
+| web_frameworks.rs:275:22:275:22 | a | semmle.label | a |
 subpaths
 testFailures
 #select
@@ -1839,3 +1882,11 @@ testFailures
 | web_frameworks.rs:15:14:15:14 | a | web_frameworks.rs:11:31:11:31 | a | web_frameworks.rs:15:14:15:14 | a | $@ | web_frameworks.rs:11:31:11:31 | a | a |
 | web_frameworks.rs:70:14:70:14 | a | web_frameworks.rs:68:15:68:15 | a | web_frameworks.rs:70:14:70:14 | a | $@ | web_frameworks.rs:68:15:68:15 | a | a |
 | web_frameworks.rs:70:14:70:14 | a | web_frameworks.rs:68:15:68:15 | a | web_frameworks.rs:70:14:70:14 | a | $@ | web_frameworks.rs:68:15:68:15 | a | a |
+| web_frameworks.rs:244:18:244:18 | a | web_frameworks.rs:242:33:242:35 | map | web_frameworks.rs:244:18:244:18 | a | $@ | web_frameworks.rs:242:33:242:35 | map | map |
+| web_frameworks.rs:244:18:244:18 | a | web_frameworks.rs:242:33:242:35 | map | web_frameworks.rs:244:18:244:18 | a | $@ | web_frameworks.rs:242:33:242:35 | map | map |
+| web_frameworks.rs:252:22:252:22 | a | web_frameworks.rs:250:46:250:49 | then | web_frameworks.rs:252:22:252:22 | a | $@ | web_frameworks.rs:250:46:250:49 | then | then |
+| web_frameworks.rs:252:22:252:22 | a | web_frameworks.rs:250:46:250:49 | then | web_frameworks.rs:252:22:252:22 | a | $@ | web_frameworks.rs:250:46:250:49 | then | then |
+| web_frameworks.rs:263:22:263:23 | id | web_frameworks.rs:259:50:259:57 | and_then | web_frameworks.rs:263:22:263:23 | id | $@ | web_frameworks.rs:259:50:259:57 | and_then | and_then |
+| web_frameworks.rs:263:22:263:23 | id | web_frameworks.rs:259:50:259:57 | and_then | web_frameworks.rs:263:22:263:23 | id | $@ | web_frameworks.rs:259:50:259:57 | and_then | and_then |
+| web_frameworks.rs:275:22:275:22 | a | web_frameworks.rs:272:75:272:77 | map | web_frameworks.rs:275:22:275:22 | a | $@ | web_frameworks.rs:272:75:272:77 | map | map |
+| web_frameworks.rs:275:22:275:22 | a | web_frameworks.rs:272:75:272:77 | map | web_frameworks.rs:275:22:275:22 | a | $@ | web_frameworks.rs:272:75:272:77 | map | map |

--- a/rust/ql/test/library-tests/dataflow/sources/web_frameworks.rs
+++ b/rust/ql/test/library-tests/dataflow/sources/web_frameworks.rs
@@ -241,7 +241,7 @@ mod warp_test {
         let map_route =
             warp::path::param().map(|a: String| // $ Alert[rust/summary/taint-sources]
             {
-            sink(a); // $ MISSING: hasTaintFlow
+            sink(a); // $ hasTaintFlow
 
             "".to_string()
         });
@@ -249,7 +249,7 @@ mod warp_test {
         // A route with parameter and `then`
         let then_route = warp::path::param().then( // $ Alert[rust/summary/taint-sources]
             async move |a: String| {
-                sink(a); // $ MISSING: hasTaintFlow
+                sink(a); // $ hasTaintFlow
 
                 "".to_string()
             },
@@ -260,7 +260,7 @@ mod warp_test {
             async move | id: u64 |
             {
             if id != 0 {
-                sink(id); // $ MISSING: hasTaintFlow
+                sink(id); // $ hasTaintFlow
                 Ok("".to_string())
             } else {
                 Err(warp::reject::not_found())
@@ -272,7 +272,7 @@ mod warp_test {
         let path_and_map_route = warp::path("1").and(warp::path::param()).map( // $ Alert[rust/summary/taint-sources] 
             | a: String |
             {
-                sink(a); // $ MISSING: hasTaintFlow
+                sink(a); // $ hasTaintFlow
 
                 "".to_string()
              },

--- a/rust/ql/test/query-tests/security/CWE-918/Cargo.lock
+++ b/rust/ql/test/query-tests/security/CWE-918/Cargo.lock
@@ -715,6 +715,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -850,6 +860,26 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1133,6 +1163,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1337,6 +1373,7 @@ dependencies = [
  "poem",
  "reqwest",
  "tokio",
+ "warp",
 ]
 
 [[package]]
@@ -1501,6 +1538,7 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -1546,6 +1584,12 @@ checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
 dependencies = [
  "version_check",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"
@@ -1596,6 +1640,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
+]
+
+[[package]]
+name = "warp"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d06d9202adc1f15d709c4f4a2069be5428aa912cc025d6f268ac441ab066b0"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "headers",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project",
+ "scoped-tls",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-util",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/rust/ql/test/query-tests/security/CWE-918/RequestForgery.expected
+++ b/rust/ql/test/query-tests/security/CWE-918/RequestForgery.expected
@@ -8,6 +8,8 @@
 | request_forgery_tests.rs:31:29:31:40 | ...::get | request_forgery_tests.rs:5:29:5:36 | user_url | request_forgery_tests.rs:31:29:31:40 | ...::get | The URL of this request depends on a $@. | request_forgery_tests.rs:5:29:5:36 | user_url | user-provided value |
 | request_forgery_tests.rs:37:37:37:48 | ...::get | request_forgery_tests.rs:5:29:5:36 | user_url | request_forgery_tests.rs:37:37:37:48 | ...::get | The URL of this request depends on a $@. | request_forgery_tests.rs:5:29:5:36 | user_url | user-provided value |
 | request_forgery_tests.rs:37:37:37:48 | ...::get | request_forgery_tests.rs:5:29:5:36 | user_url | request_forgery_tests.rs:37:37:37:48 | ...::get | The URL of this request depends on a $@. | request_forgery_tests.rs:5:29:5:36 | user_url | user-provided value |
+| request_forgery_tests.rs:68:28:68:39 | ...::get | request_forgery_tests.rs:65:33:65:40 | and_then | request_forgery_tests.rs:68:28:68:39 | ...::get | The URL of this request depends on a $@. | request_forgery_tests.rs:65:33:65:40 | and_then | user-provided value |
+| request_forgery_tests.rs:68:28:68:39 | ...::get | request_forgery_tests.rs:65:33:65:40 | and_then | request_forgery_tests.rs:68:28:68:39 | ...::get | The URL of this request depends on a $@. | request_forgery_tests.rs:65:33:65:40 | and_then | user-provided value |
 edges
 | request_forgery_tests.rs:4:5:4:14 | res | request_forgery_tests.rs:16:27:16:49 | { ... } | provenance |  |
 | request_forgery_tests.rs:4:5:4:14 | res | request_forgery_tests.rs:20:27:20:57 | { ... } | provenance |  |
@@ -28,22 +30,22 @@ edges
 | request_forgery_tests.rs:16:13:16:15 | url | request_forgery_tests.rs:17:39:17:41 | url | provenance |  |
 | request_forgery_tests.rs:16:27:16:49 | ...::format(...) | request_forgery_tests.rs:4:5:4:14 | res | provenance |  |
 | request_forgery_tests.rs:16:27:16:49 | ...::must_use(...) | request_forgery_tests.rs:16:13:16:15 | url | provenance |  |
-| request_forgery_tests.rs:16:27:16:49 | MacroExpr | request_forgery_tests.rs:16:27:16:49 | ...::format(...) | provenance | MaD:2 |
-| request_forgery_tests.rs:16:27:16:49 | { ... } | request_forgery_tests.rs:16:27:16:49 | ...::must_use(...) | provenance | MaD:3 |
+| request_forgery_tests.rs:16:27:16:49 | MacroExpr | request_forgery_tests.rs:16:27:16:49 | ...::format(...) | provenance | MaD:3 |
+| request_forgery_tests.rs:16:27:16:49 | { ... } | request_forgery_tests.rs:16:27:16:49 | ...::must_use(...) | provenance | MaD:4 |
 | request_forgery_tests.rs:17:38:17:41 | &url [&ref] | request_forgery_tests.rs:17:25:17:36 | ...::get | provenance | MaD:1 Sink:MaD:1 |
 | request_forgery_tests.rs:17:39:17:41 | url | request_forgery_tests.rs:17:38:17:41 | &url [&ref] | provenance |  |
 | request_forgery_tests.rs:20:13:20:15 | url | request_forgery_tests.rs:21:39:21:41 | url | provenance |  |
 | request_forgery_tests.rs:20:27:20:57 | ...::format(...) | request_forgery_tests.rs:4:5:4:14 | res | provenance |  |
 | request_forgery_tests.rs:20:27:20:57 | ...::must_use(...) | request_forgery_tests.rs:20:13:20:15 | url | provenance |  |
-| request_forgery_tests.rs:20:27:20:57 | MacroExpr | request_forgery_tests.rs:20:27:20:57 | ...::format(...) | provenance | MaD:2 |
-| request_forgery_tests.rs:20:27:20:57 | { ... } | request_forgery_tests.rs:20:27:20:57 | ...::must_use(...) | provenance | MaD:3 |
+| request_forgery_tests.rs:20:27:20:57 | MacroExpr | request_forgery_tests.rs:20:27:20:57 | ...::format(...) | provenance | MaD:3 |
+| request_forgery_tests.rs:20:27:20:57 | { ... } | request_forgery_tests.rs:20:27:20:57 | ...::must_use(...) | provenance | MaD:4 |
 | request_forgery_tests.rs:21:38:21:41 | &url [&ref] | request_forgery_tests.rs:21:25:21:36 | ...::get | provenance | MaD:1 Sink:MaD:1 |
 | request_forgery_tests.rs:21:39:21:41 | url | request_forgery_tests.rs:21:38:21:41 | &url [&ref] | provenance |  |
 | request_forgery_tests.rs:24:13:24:15 | url | request_forgery_tests.rs:25:39:25:41 | url | provenance |  |
 | request_forgery_tests.rs:24:27:24:70 | ...::format(...) | request_forgery_tests.rs:4:5:4:14 | res | provenance |  |
 | request_forgery_tests.rs:24:27:24:70 | ...::must_use(...) | request_forgery_tests.rs:24:13:24:15 | url | provenance |  |
-| request_forgery_tests.rs:24:27:24:70 | MacroExpr | request_forgery_tests.rs:24:27:24:70 | ...::format(...) | provenance | MaD:2 |
-| request_forgery_tests.rs:24:27:24:70 | { ... } | request_forgery_tests.rs:24:27:24:70 | ...::must_use(...) | provenance | MaD:3 |
+| request_forgery_tests.rs:24:27:24:70 | MacroExpr | request_forgery_tests.rs:24:27:24:70 | ...::format(...) | provenance | MaD:3 |
+| request_forgery_tests.rs:24:27:24:70 | { ... } | request_forgery_tests.rs:24:27:24:70 | ...::must_use(...) | provenance | MaD:4 |
 | request_forgery_tests.rs:25:38:25:41 | &url [&ref] | request_forgery_tests.rs:25:25:25:36 | ...::get | provenance | MaD:1 Sink:MaD:1 |
 | request_forgery_tests.rs:25:39:25:41 | url | request_forgery_tests.rs:25:38:25:41 | &url [&ref] | provenance |  |
 | request_forgery_tests.rs:31:42:31:50 | &user_url [&ref] | request_forgery_tests.rs:31:29:31:40 | ...::get | provenance | MaD:1 Sink:MaD:1 |
@@ -54,10 +56,19 @@ edges
 | request_forgery_tests.rs:37:50:37:58 | &user_url [&ref] | request_forgery_tests.rs:37:37:37:48 | ...::get | provenance | MaD:1 Sink:MaD:1 |
 | request_forgery_tests.rs:37:51:37:58 | user_url | request_forgery_tests.rs:37:50:37:58 | &user_url [&ref] | provenance |  |
 | request_forgery_tests.rs:37:51:37:58 | user_url | request_forgery_tests.rs:37:50:37:58 | &user_url [&ref] | provenance |  |
+| request_forgery_tests.rs:65:33:65:40 | and_then | request_forgery_tests.rs:65:49:65:57 | ...: String | provenance | Src:MaD:2  |
+| request_forgery_tests.rs:65:33:65:40 | and_then | request_forgery_tests.rs:65:49:65:57 | ...: String | provenance | Src:MaD:2  |
+| request_forgery_tests.rs:65:49:65:57 | ...: String | request_forgery_tests.rs:68:42:68:42 | a | provenance |  |
+| request_forgery_tests.rs:65:49:65:57 | ...: String | request_forgery_tests.rs:68:42:68:42 | a | provenance |  |
+| request_forgery_tests.rs:68:41:68:42 | &a [&ref] | request_forgery_tests.rs:68:28:68:39 | ...::get | provenance | MaD:1 Sink:MaD:1 |
+| request_forgery_tests.rs:68:41:68:42 | &a [&ref] | request_forgery_tests.rs:68:28:68:39 | ...::get | provenance | MaD:1 Sink:MaD:1 |
+| request_forgery_tests.rs:68:42:68:42 | a | request_forgery_tests.rs:68:41:68:42 | &a [&ref] | provenance |  |
+| request_forgery_tests.rs:68:42:68:42 | a | request_forgery_tests.rs:68:41:68:42 | &a [&ref] | provenance |  |
 models
 | 1 | Sink: reqwest::get; Argument[0]; request-url |
-| 2 | Summary: alloc::fmt::format; Argument[0]; ReturnValue; taint |
-| 3 | Summary: core::hint::must_use; Argument[0]; ReturnValue; value |
+| 2 | Source: <_ as warp::filter::Filter>::and_then; Argument[0].Parameter[0..7]; remote |
+| 3 | Summary: alloc::fmt::format; Argument[0]; ReturnValue; taint |
+| 4 | Summary: core::hint::must_use; Argument[0]; ReturnValue; value |
 nodes
 | request_forgery_tests.rs:4:5:4:14 | res | semmle.label | res |
 | request_forgery_tests.rs:4:5:4:14 | res | semmle.label | res |
@@ -106,4 +117,14 @@ nodes
 | request_forgery_tests.rs:37:50:37:58 | &user_url [&ref] | semmle.label | &user_url [&ref] |
 | request_forgery_tests.rs:37:51:37:58 | user_url | semmle.label | user_url |
 | request_forgery_tests.rs:37:51:37:58 | user_url | semmle.label | user_url |
+| request_forgery_tests.rs:65:33:65:40 | and_then | semmle.label | and_then |
+| request_forgery_tests.rs:65:33:65:40 | and_then | semmle.label | and_then |
+| request_forgery_tests.rs:65:49:65:57 | ...: String | semmle.label | ...: String |
+| request_forgery_tests.rs:65:49:65:57 | ...: String | semmle.label | ...: String |
+| request_forgery_tests.rs:68:28:68:39 | ...::get | semmle.label | ...::get |
+| request_forgery_tests.rs:68:28:68:39 | ...::get | semmle.label | ...::get |
+| request_forgery_tests.rs:68:41:68:42 | &a [&ref] | semmle.label | &a [&ref] |
+| request_forgery_tests.rs:68:41:68:42 | &a [&ref] | semmle.label | &a [&ref] |
+| request_forgery_tests.rs:68:42:68:42 | a | semmle.label | a |
+| request_forgery_tests.rs:68:42:68:42 | a | semmle.label | a |
 subpaths

--- a/rust/ql/test/query-tests/security/CWE-918/options.yml
+++ b/rust/ql/test/query-tests/security/CWE-918/options.yml
@@ -3,3 +3,4 @@ qltest_dependencies:
     - reqwest = { version = "0.12.23", features = ["blocking", "json"] }
     - tokio = { version = "1.0", features = ["full"] }
     - poem = { version = "3.1.12", features = ["server"] }
+    - warp = { version = "0.4.2", features = ["server"] }

--- a/rust/ql/test/query-tests/security/CWE-918/request_forgery_tests.rs
+++ b/rust/ql/test/query-tests/security/CWE-918/request_forgery_tests.rs
@@ -54,6 +54,26 @@ mod poem_server {
     }
 }
 
+mod warp_test {
+    use warp::Filter;
+
+    #[tokio::main]
+    #[rustfmt::skip]
+    async fn test_warp() {
+        // A route with parameter and `and_then`
+        let map_route =
+            warp::path::param().and_then(async |a: String| // $ MISSING: Source=a
+            {
+
+            let response = reqwest::get(&a).await; // $ MISSING: Alert[rust/request-forgery]=a
+            match response {
+                Ok(resp) => Ok(resp.text().await.unwrap_or_default()),
+                Err(_err) => Err(warp::reject::not_found()),
+            }
+        });
+    }
+}
+
 /// Start the Poem web application
 pub fn start() {
     tokio::runtime::Runtime::new()

--- a/rust/ql/test/query-tests/security/CWE-918/request_forgery_tests.rs
+++ b/rust/ql/test/query-tests/security/CWE-918/request_forgery_tests.rs
@@ -62,10 +62,10 @@ mod warp_test {
     async fn test_warp() {
         // A route with parameter and `and_then`
         let map_route =
-            warp::path::param().and_then(async |a: String| // $ MISSING: Source=a
+            warp::path::param().and_then(async |a: String| // $ Source=a
             {
 
-            let response = reqwest::get(&a).await; // $ MISSING: Alert[rust/request-forgery]=a
+            let response = reqwest::get(&a).await; // $ Alert[rust/request-forgery]=a
             match response {
                 Ok(resp) => Ok(resp.text().await.unwrap_or_default()),
                 Err(_err) => Err(warp::reject::not_found()),

--- a/shared/dataflow/codeql/dataflow/internal/FlowSummaryImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/FlowSummaryImpl.qll
@@ -709,6 +709,9 @@ module Make<
         this = TConsSummaryComponentStack(result, _)
       }
 
+      /** Gets the head of this stack if it is a singleton. */
+      SummaryComponent headOfSingleton() { this = TSingletonSummaryComponentStack(result) }
+
       /** Gets the tail of this stack, if any. */
       SummaryComponentStack tail() { this = TConsSummaryComponentStack(_, result) }
 

--- a/shared/dataflow/codeql/dataflow/internal/FlowSummaryImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/FlowSummaryImpl.qll
@@ -1206,12 +1206,12 @@ module Make<
        * Holds if this node is an exit node, i.e. after all stores have been performed.
        *
        * A local flow step should be added from this node to a data flow node representing
-       * `sc` inside `source`.
+       * `s` inside `source`.
        */
-      predicate isExit(SourceElement source, SummaryComponent sc, string model) {
+      predicate isExit(SourceElement source, SummaryComponentStack s, string model) {
         source = source_ and
         model = model_ and
-        state_.isSourceOutputState(source, TSingletonSummaryComponentStack(sc), _, model)
+        state_.isSourceOutputState(source, s, _, model)
       }
 
       override predicate isHidden() { not this.isEntry(_, _) }
@@ -1460,7 +1460,7 @@ module Make<
 
       DataFlowType getSyntheticGlobalType(SyntheticGlobal sg);
 
-      DataFlowType getSourceType(SourceBase source, SummaryComponent sc);
+      DataFlowType getSourceType(SourceBase source, SummaryComponentStack sc);
 
       DataFlowType getSinkType(SinkBase sink, SummaryComponent sc);
     }
@@ -1543,9 +1543,9 @@ module Make<
         )
         or
         exists(SourceElement source |
-          exists(SummaryComponent sc |
-            n.(SourceOutputNode).isExit(source, sc, _) and
-            result = getSourceType(source, sc)
+          exists(SummaryComponentStack s |
+            n.(SourceOutputNode).isExit(source, s, _) and
+            result = getSourceType(source, s)
           )
           or
           exists(SummaryComponentStack s, ContentSet cont |
@@ -1574,13 +1574,16 @@ module Make<
       /** Gets a call that targets summarized callable `sc`. */
       DataFlowCall getACall(SummarizedCallable sc);
 
+      /** Gets the enclosing callable of `source`. */
+      DataFlowCallable getSourceNodeEnclosingCallable(SourceBase source);
+
       /**
-       * Gets a data flow node corresponding to the `sc` part of `source`.
+       * Gets a data flow node corresponding to the `s` part of `source`.
        *
-       * `sc` is typically `ReturnValue` and the result is the node that
+       * `s` is typically `ReturnValue` and the result is the node that
        * represents the return value of `source`.
        */
-      Node getSourceNode(SourceBase source, SummaryComponent sc);
+      Node getSourceNode(SourceBase source, SummaryComponentStack s);
 
       /**
        * Gets a data flow node corresponding to the `sc` part of `sink`.
@@ -1622,11 +1625,18 @@ module Make<
         )
       }
 
-      predicate sourceLocalStep(SourceOutputNode nodeFrom, Node nodeTo, string model) {
-        exists(SummaryComponent sc, SourceElement source |
+      predicate sourceStep(SourceOutputNode nodeFrom, Node nodeTo, string model, boolean local) {
+        exists(SummaryComponentStack sc, SourceElement source |
           nodeFrom.isExit(source, sc, model) and
-          nodeTo = StepsInput::getSourceNode(source, sc)
+          nodeTo = StepsInput::getSourceNode(source, sc) and
+          if StepsInput::getSourceNodeEnclosingCallable(source) = getNodeEnclosingCallable(nodeTo)
+          then local = true
+          else local = false
         )
+      }
+
+      predicate sourceLocalStep(SourceOutputNode nodeFrom, Node nodeTo, string model) {
+        sourceStep(nodeFrom, nodeTo, model, true)
       }
 
       predicate sinkLocalStep(Node nodeFrom, SinkInputNode nodeTo, string model) {
@@ -1687,6 +1697,10 @@ module Make<
           pred = summaryNodeOutputState(_, s) and
           succ = summaryNodeInputState(_, s)
         )
+      }
+
+      predicate sourceJumpStep(SourceOutputNode nodeFrom, Node nodeTo) {
+        sourceStep(nodeFrom, nodeTo, _, false)
       }
 
       /**

--- a/swift/ql/lib/codeql/swift/dataflow/internal/FlowSummaryImpl.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/FlowSummaryImpl.qll
@@ -113,7 +113,9 @@ private import Make<Location, DataFlowImplSpecific::SwiftDataFlow, Input> as Imp
 private module StepsInput implements Impl::Private::StepsInputSig {
   DataFlowCall getACall(Public::SummarizedCallable sc) { result.asCall().getStaticTarget() = sc }
 
-  Node getSourceNode(Input::SourceBase source, Impl::Private::SummaryComponent sc) { none() }
+  DataFlowCallable getSourceNodeEnclosingCallable(Input::SourceBase source) { none() }
+
+  Node getSourceNode(Input::SourceBase source, Impl::Private::SummaryComponentStack s) { none() }
 
   Node getSinkNode(Input::SinkBase sink, Impl::Private::SummaryComponent sc) { none() }
 }


### PR DESCRIPTION
This PR adds support for MaD sources with an `Argument[_].Parameter[_]` access path. This corresponds to sources that pass tainted data to a callback/function.

The implementation is my interpretation of a comment on Slack by @hvitved. My understanding is that this is not necessarily the long-term ideal way to implement this, but it is a quick way to give us something that works and that lets us write the models that we want to write for Rust.

[The DCA report](https://github.com/github/codeql-dca-main/issues/31579) looks good. Taint reach triples on `rust-vulnerable-apps` which makes sense as it uses Warp for which we now have working models.