### PR TITLE
Overlay: Discard Java config and XML base entities in overlay extracted files

### DIFF
--- a/java/ql/lib/semmle/code/java/Overlay.qll
+++ b/java/ql/lib/semmle/code/java/Overlay.qll
@@ -102,3 +102,31 @@ private predicate discardBaseConfigLocatable(@configLocatable el) {
   // property files than those included in overlayChangedFiles.
   overlayConfigExtracted(baseConfigLocatable(el))
 }
+
+/**
+ * An `@xmllocatable` that should be discarded in the base variant if its file is
+ * extracted in the overlay variant.
+ */
+overlay[local]
+abstract class DiscardableXmlLocatable extends @xmllocatable {
+  /** Gets the raw file for an xmllocatable in base. */
+  string getRawFileInBase() { not isOverlay() and result = getRawFile(this) }
+
+  /** Gets a textual representation of this discardable xmllocatable. */
+  string toString() { none() }
+}
+
+overlay[local]
+private predicate overlayXmlExtracted(string file) {
+  isOverlay() and
+  exists(@xmllocatable el | not files(el, _) and not xmlNs(el, _, _, _) and file = getRawFile(el))
+}
+
+overlay[discard_entity]
+private predicate discardXmlLocatable(@xmllocatable el) {
+  overlayChangedFiles(el.(DiscardableXmlLocatable).getRawFileInBase())
+  or
+  // The XML extractor is currently not incremental and may extract more
+  // XML files than those included in overlayChangedFiles.
+  overlayXmlExtracted(el.(DiscardableXmlLocatable).getRawFileInBase())
+}

--- a/java/ql/lib/semmle/code/xml/XML.qll
+++ b/java/ql/lib/semmle/code/xml/XML.qll
@@ -71,12 +71,12 @@ private module Input implements InputSig<File, Location> {
 
 import Make<File, Location, Input>
 
-private class DiscardableXmlAttribute extends DiscardableLocatable, @xmlattribute { }
+private class DiscardableXmlAttribute extends DiscardableXmlLocatable, @xmlattribute { }
 
-private class DiscardableXmlElement extends DiscardableLocatable, @xmlelement { }
+private class DiscardableXmlElement extends DiscardableXmlLocatable, @xmlelement { }
 
-private class DiscardableXmlComment extends DiscardableLocatable, @xmlcomment { }
+private class DiscardableXmlComment extends DiscardableXmlLocatable, @xmlcomment { }
 
-private class DiscardableXmlCharacters extends DiscardableLocatable, @xmlcharacters { }
+private class DiscardableXmlCharacters extends DiscardableXmlLocatable, @xmlcharacters { }
 
-private class DiscardableXmlDtd extends DiscardableLocatable, @xmldtd { }
+private class DiscardableXmlDtd extends DiscardableXmlLocatable, @xmldtd { }


### PR DESCRIPTION
This PR improves the Java config and XML discard predicates to avoid apparent bqrs accuracy regressions under the current non-incremental Java property and XML extraction. Under non-incremental extraction, the Java property and XML extractors may extract files outside of `overlayChangedFiles`. To account for these files and properly discard from base, this PR extends the discard predicates to discard Java config and XML base entities in all overlay extracted files, even if they do not appear in `overlayChangedFiles`. The use of `overlayChangedFiles` is still necessary to discard from deleted Java property and XML files. 

DCA experiments ([variant](https://github.com/github/codeql-dca-main/tree/data/kaspersv/auto/main/affb98d/1758623698186/reports) vs [baseline](https://github.com/github/codeql-dca-main/tree/data/kaspersv/auto/main/e2e59a8/1758189720539/reports#overlay-query-result-tuple-count-accuracy)) shows the expected accuracy improvements for `java/maven/non-https-url`, `java/maven/dependency-upon-bintray` and `java/spring-boot-exposed-actuators-config`.