### PR TITLE
Go: Update `go/path-injection` docs to include more sanitizers

### DIFF
--- a/go/ql/src/Security/CWE-022/TaintedPath.qhelp
+++ b/go/ql/src/Security/CWE-022/TaintedPath.qhelp
@@ -38,6 +38,20 @@ result in the string "../" if only "../" sequences are removed.
 Finally, the simplest (but most restrictive) option is to use an allow list of safe patterns
 and make sure that the user input matches one of these patterns.
 </p>
+
+<p>
+<b>Sanitizer functions from the Go standard library:</b>
+</p>
+<p>
+The Go standard library provides several functions that can help sanitize paths:
+</p>
+<ul>
+<li><code>filepath.Rel(basepath, targpath)</code> - Returns a relative path from basepath to targpath. If the path is not contained within basepath, it returns an error, making it useful for validating that a path stays within expected boundaries.</li>
+<li><code>filepath.Clean(path)</code> - When used with a path that starts with "/" (e.g., <code>filepath.Clean("/" + userPath)</code>), it normalizes the path and can help prevent path traversal by resolving ".." sequences.</li>
+<li><code>filepath.IsLocal(path)</code> - Returns true if the path is local (doesn't start with "/" and doesn't contain ".."), making it useful for validating relative paths.</li>
+<li><code>strings.Contains(path, "..")</code> - Can be used to detect path traversal sequences in user input.</li>
+<li><code>strings.HasPrefix(path, safePrefix)</code> - Can be used to ensure paths start with expected safe prefixes.</li>
+</ul>
 </recommendation>
 
 <example>
@@ -70,6 +84,13 @@ You can do this by resolving the input with respect to that directory, and then 
 that the resulting path is still within it.
 </p>
 <sample src="TaintedPathGood2.go" />
+<p>
+<b>Using Go standard library sanitizers:</b>
+</p>
+<p>
+You can also use Go's built-in path validation functions for additional safety:
+</p>
+<sample src="TaintedPathSanitizers.go" />
 <p>
 Note that <code>/home/user</code> is just an example, you should replace it with the actual
 safe directory in your application. Also, while in this example the path of the safe

--- a/go/ql/src/Security/CWE-022/TaintedPathSanitizers.go
+++ b/go/ql/src/Security/CWE-022/TaintedPathSanitizers.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func handleFileWithSanitizers(w http.ResponseWriter, r *http.Request) {
+	userPath := r.URL.Query().Get("file")
+	safeDir := "/home/user/documents"
+
+	// Method 1: Using filepath.IsLocal to validate the path is local
+	if !filepath.IsLocal(userPath) {
+		http.Error(w, "Invalid path: must be local", http.StatusBadRequest)
+		return
+	}
+
+	// Method 2: Using strings.Contains to check for path traversal sequences
+	if strings.Contains(userPath, "..") {
+		http.Error(w, "Invalid path: contains path traversal", http.StatusBadRequest)
+		return
+	}
+
+	// Method 3: Using filepath.Rel to ensure path is within safe directory
+	relPath, err := filepath.Rel(safeDir, filepath.Join(safeDir, userPath))
+	if err != nil || strings.HasPrefix(relPath, "..") {
+		http.Error(w, "Invalid path: outside safe directory", http.StatusBadRequest)
+		return
+	}
+
+	// Method 4: Using filepath.Clean with absolute prefix for normalization
+	cleanPath := filepath.Clean("/" + userPath)
+	if strings.Contains(cleanPath, "..") {
+		http.Error(w, "Invalid path after normalization", http.StatusBadRequest)
+		return
+	}
+
+	// Method 5: Using strings.HasPrefix for additional validation
+	finalPath := filepath.Join(safeDir, userPath)
+	if !strings.HasPrefix(finalPath, safeDir) {
+		http.Error(w, "Invalid path: must be within safe directory", http.StatusBadRequest)
+		return
+	}
+
+	// Safe to open file
+	file, err := os.Open(finalPath)
+	if err != nil {
+		http.Error(w, "File not found", http.StatusNotFound)
+		return
+	}
+	defer file.Close()
+
+	// Process file...
+}
+
+// Example using mime/multipart filename sanitization
+func handleUpload(w http.ResponseWriter, r *http.Request) {
+	err := r.ParseMultipartForm(32 << 20) // 32MB max
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	file, header, err := r.FormFile("upload")
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	defer file.Close()
+
+	// The Filename field is automatically sanitized by mime/multipart
+	// using filepath.Base, making it safe from path traversal
+	filename := header.Filename
+
+	// Additional validation can still be useful
+	if strings.Contains(filename, "..") || strings.ContainsAny(filename, "/\\") {
+		http.Error(w, "Invalid filename", http.StatusBadRequest)
+		return
+	}
+
+	// Safe to use filename
+	_ = filename
+}

--- a/go/ql/src/Security/CWE-022/TaintedPathSanitizers.go
+++ b/go/ql/src/Security/CWE-022/TaintedPathSanitizers.go
@@ -54,32 +54,3 @@ func handleFileWithSanitizers(w http.ResponseWriter, r *http.Request) {
 
 	// Process file...
 }
-
-// Example using mime/multipart filename sanitization
-func handleUpload(w http.ResponseWriter, r *http.Request) {
-	err := r.ParseMultipartForm(32 << 20) // 32MB max
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-
-	file, header, err := r.FormFile("upload")
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-	defer file.Close()
-
-	// The Filename field is automatically sanitized by mime/multipart
-	// using filepath.Base, making it safe from path traversal
-	filename := header.Filename
-
-	// Additional validation can still be useful
-	if strings.Contains(filename, "..") || strings.ContainsAny(filename, "/\\") {
-		http.Error(w, "Invalid filename", http.StatusBadRequest)
-		return
-	}
-
-	// Safe to use filename
-	_ = filename
-}


### PR DESCRIPTION
This was done by copilot coding agent, but in the wrong repo, so I'm transferring it manually.

Open questions: is this too long-winded? Should we have so many examples? Should we try and indicate where each one is useful?