### PR TITLE
Add .orig files to the .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ node_modules/
 # some upgrade/downgrade checks create these files
 **/upgrades/*/*.dbscheme.stats
 **/downgrades/*/*.dbscheme.stats
+
+# Mergetool files
+*.orig


### PR DESCRIPTION
Add `.orig` files to the `.gitignore`.  I believe these files are sometimes left over by `git mergetool` and we don't want them adding to the repo.