### PR TITLE
Attribute `js/cors-permissive-configuration` to original author

### DIFF
--- a/javascript/ql/src/CHANGELOG.md
+++ b/javascript/ql/src/CHANGELOG.md
@@ -10,7 +10,7 @@
 * Data flow is now tracked through the `Promise.try` and `Array.prototype.with` functions.
 * Query `js/index-out-of-bounds` no longer produces a false-positive when a strictly-less-than check overrides a previous less-than-or-equal test.
 * The query `js/remote-property-injection` now detects property injection vulnerabilities through object enumeration patterns such as `Object.keys()`. 
-* The query "Permissive CORS configuration" (`js/cors-permissive-configuration`) has been promoted from experimental and is now part of the default security suite.
+* The query "Permissive CORS configuration" (`js/cors-permissive-configuration`) has been promoted from experimental and is now part of the default security suite. Thank you to @maikypedia who [submitted the original experimental query](https://github.com/github/codeql/pull/14342)!
 
 ## 2.0.3
 

--- a/javascript/ql/src/change-notes/released/2.1.0.md
+++ b/javascript/ql/src/change-notes/released/2.1.0.md
@@ -10,4 +10,4 @@
 * Data flow is now tracked through the `Promise.try` and `Array.prototype.with` functions.
 * Query `js/index-out-of-bounds` no longer produces a false-positive when a strictly-less-than check overrides a previous less-than-or-equal test.
 * The query `js/remote-property-injection` now detects property injection vulnerabilities through object enumeration patterns such as `Object.keys()`. 
-* The query "Permissive CORS configuration" (`js/cors-permissive-configuration`) has been promoted from experimental and is now part of the default security suite. Thank you to @maikypedia who submitted the original experimental query!
+* The query "Permissive CORS configuration" (`js/cors-permissive-configuration`) has been promoted from experimental and is now part of the default security suite. Thank you to @maikypedia who [submitted the original experimental query](https://github.com/github/codeql/pull/14342)!

--- a/javascript/ql/src/change-notes/released/2.1.0.md
+++ b/javascript/ql/src/change-notes/released/2.1.0.md
@@ -10,4 +10,4 @@
 * Data flow is now tracked through the `Promise.try` and `Array.prototype.with` functions.
 * Query `js/index-out-of-bounds` no longer produces a false-positive when a strictly-less-than check overrides a previous less-than-or-equal test.
 * The query `js/remote-property-injection` now detects property injection vulnerabilities through object enumeration patterns such as `Object.keys()`. 
-* The query "Permissive CORS configuration" (`js/cors-permissive-configuration`) has been promoted from experimental and is now part of the default security suite.
+* The query "Permissive CORS configuration" (`js/cors-permissive-configuration`) has been promoted from experimental and is now part of the default security suite. Thank you to @maikypedia who submitted the original experimental query!


### PR DESCRIPTION
This pull request updates the documentation to acknowledge the original contributor of the "Permissive CORS configuration" query after its promotion from experimental to the default security suite.