### PR TITLE
Java: Fix false positives in evaluation-to-constant query for ErrorType

### DIFF
--- a/java/ql/integration-tests/java/evaluation-to-constant-errortype/ConstantExpAppearsNonConstant.expected
+++ b/java/ql/integration-tests/java/evaluation-to-constant-errortype/ConstantExpAppearsNonConstant.expected
@@ -1,1 +1,0 @@
-| Test.java:3:8:3:15 | <TypeAccess of ErrorType> | Expression always evaluates to the same value. |

--- a/java/ql/integration-tests/java/evaluation-to-constant-errortype/ConstantExpAppearsNonConstant.expected
+++ b/java/ql/integration-tests/java/evaluation-to-constant-errortype/ConstantExpAppearsNonConstant.expected
@@ -1,0 +1,1 @@
+| Test.java:3:8:3:15 | <TypeAccess of ErrorType> | Expression always evaluates to the same value. |

--- a/java/ql/integration-tests/java/evaluation-to-constant-errortype/ConstantExpAppearsNonConstant.qlref
+++ b/java/ql/integration-tests/java/evaluation-to-constant-errortype/ConstantExpAppearsNonConstant.qlref
@@ -1,0 +1,1 @@
+Likely Bugs/Arithmetic/ConstantExpAppearsNonConstant.ql

--- a/java/ql/integration-tests/java/evaluation-to-constant-errortype/ConstantExpAppearsNonConstant.qlref
+++ b/java/ql/integration-tests/java/evaluation-to-constant-errortype/ConstantExpAppearsNonConstant.qlref
@@ -1,1 +1,2 @@
-Likely Bugs/Arithmetic/ConstantExpAppearsNonConstant.ql
+query: Likely Bugs/Arithmetic/ConstantExpAppearsNonConstant.ql
+postprocess: utils/test/InlineExpectationsTestQuery.ql

--- a/java/ql/integration-tests/java/evaluation-to-constant-errortype/Test.java
+++ b/java/ql/integration-tests/java/evaluation-to-constant-errortype/Test.java
@@ -1,0 +1,7 @@
+class Test {
+  public static void updateFlashlights(Minecraft mc){
+    if(mc.world != null){
+
+    }
+   }
+}

--- a/java/ql/integration-tests/java/evaluation-to-constant-errortype/test.py
+++ b/java/ql/integration-tests/java/evaluation-to-constant-errortype/test.py
@@ -1,0 +1,2 @@
+def test(codeql, java):
+    codeql.database.create(build_mode="none")

--- a/java/ql/src/Likely Bugs/Arithmetic/ConstantExpAppearsNonConstant.ql
+++ b/java/ql/src/Likely Bugs/Arithmetic/ConstantExpAppearsNonConstant.ql
@@ -19,7 +19,7 @@ predicate isConstantExp(Expr e) {
   // A literal is constant.
   e instanceof Literal
   or
-  e instanceof TypeAccess
+  exists(TypeAccess ta | ta = e | not ta.getType() instanceof ErrorType)
   or
   e instanceof ArrayTypeAccess
   or

--- a/java/ql/src/Likely Bugs/Arithmetic/ConstantExpAppearsNonConstant.ql
+++ b/java/ql/src/Likely Bugs/Arithmetic/ConstantExpAppearsNonConstant.ql
@@ -19,7 +19,7 @@ predicate isConstantExp(Expr e) {
   // A literal is constant.
   e instanceof Literal
   or
-  exists(TypeAccess ta | ta = e | not ta.getType() instanceof ErrorType)
+  e instanceof TypeAccess and not e.(TypeAccess).getType() instanceof ErrorType
   or
   e instanceof ArrayTypeAccess
   or


### PR DESCRIPTION
This PR fixes the FPs described in the issue linked below.

Closes: http://github.com/github/codeql-java-team/issues/425

DCA Nightly Buildless: https://github.com/github/codeql-dca-main/issues/31838
DCA Nightly: https://github.com/github/codeql-dca-main/issues/31839