### PR TITLE
Ruby: Update CSRF protection notes in documentation

### DIFF
--- a/ruby/ql/src/queries/security/cwe-352/CSRFProtectionDisabled.qhelp
+++ b/ruby/ql/src/queries/security/cwe-352/CSRFProtectionDisabled.qhelp
@@ -61,8 +61,8 @@
       Note this remains true even in Rails version 5 and later: these versions
       automatically run <code>protect_from_forgery with: :exception</code>
       by default, but manually calling <code>protect_from_forgery</code> with
-      no <code>with</code> argument will still downgrade protection to null the
-      session rather than raise an exception.
+      no <code>with</code> argument will still downgrade protection to provide an
+      empty session rather than raise an exception.
     </p>
 
   </example>

--- a/ruby/ql/src/queries/security/cwe-352/CSRFProtectionNotEnabled.qhelp
+++ b/ruby/ql/src/queries/security/cwe-352/CSRFProtectionNotEnabled.qhelp
@@ -43,10 +43,10 @@
       <code>protect_from_forgery with: :exception</code> can help to avoid this
       by raising an exception on an invalid CSRF token instead.
 
-      Note that Rails version 5 and later
+      Note that Rails versions 5 and later
       automatically run <code>protect_from_forgery with: :exception</code>
       by default, but manually calling <code>protect_from_forgery</code> with
-      no <code>with</code> argument will downgrade protection to null the
+      no <code>with</code> argument will downgrade protection to provide an empty
       session rather than raise an exception.
     </p>
   </recommendation>


### PR DESCRIPTION
Autofix is confused about how the `protect_from_forgery` method works in Rails >= 5: GPT-5 says:

> In modern Rails versions (>=5, including 6 and 7 which this gem permits), ActionController::Base already enables CSRF protection by default with the `:exception` strategy; an explicit call to `protect_from_forgery` without options does not weaken security.

This is false: manual testing confirms that it actually does downgrade from `:exception` to `:null-session` behaviour when a manual call is made.

I can't find any authoritative source showing this gotcha, so I can see how the AI is confused and how humans might also struggle to verify the truth.