### PR TITLE
Rust: Consistency fix for reusables/extractors.rst.

### DIFF
--- a/docs/codeql/reusables/extractors.rst
+++ b/docs/codeql/reusables/extractors.rst
@@ -20,7 +20,7 @@
      - ``python``
    * - Ruby
      - ``ruby``
-     - Rust
+   * - Rust
      - ``rust``
    * - Swift
      - ``swift``


### PR DESCRIPTION
Consistency fix for `reusables/extractors.rst` - I noticed a `*` was missing in the list.

I'd appreciate a :+1: from someone on the docs team who understands how this is rendered.