### PR TITLE
Crypto: Alert fatigue remediation (legacy queries)

### DIFF
--- a/cpp/ql/src/experimental/cryptography/inventory/new_models/AllAsymmetricAlgorithms.ql
+++ b/cpp/ql/src/experimental/cryptography/inventory/new_models/AllAsymmetricAlgorithms.ql
@@ -3,7 +3,7 @@
  * @description Finds all potential usage of asymmeric keys (RSA & ECC) using the supported libraries.
  * @kind problem
  * @id cpp/quantum-readiness/cbom/all-asymmetric-algorithms
- * @problem.severity error
+ * @severity recommendation
  * @tags cbom
  *       cryptography
  */

--- a/cpp/ql/src/experimental/cryptography/inventory/new_models/AllCryptoAlgorithms.ql
+++ b/cpp/ql/src/experimental/cryptography/inventory/new_models/AllCryptoAlgorithms.ql
@@ -3,7 +3,7 @@
  * @description Finds all potential usage of cryptographic algorithms usage using the supported libraries.
  * @kind problem
  * @id cpp/quantum-readiness/cbom/all-cryptographic-algorithms
- * @problem.severity error
+ * @severity recommendation
  * @tags cbom
  *       cryptography
  */

--- a/cpp/ql/src/experimental/cryptography/inventory/new_models/AsymmetricEncryptionAlgorithms.ql
+++ b/cpp/ql/src/experimental/cryptography/inventory/new_models/AsymmetricEncryptionAlgorithms.ql
@@ -3,7 +3,7 @@
  * @description Finds all potential usage of asymmeric keys for encryption or key exchange using the supported libraries.
  * @kind problem
  * @id cpp/quantum-readiness/cbom/all-asymmetric-encryption-algorithms
- * @problem.severity error
+ * @severity recommendation
  * @tags cbom
  *       cryptography
  */

--- a/cpp/ql/src/experimental/cryptography/inventory/new_models/AsymmetricPaddingAlgorithms.ql
+++ b/cpp/ql/src/experimental/cryptography/inventory/new_models/AsymmetricPaddingAlgorithms.ql
@@ -3,7 +3,7 @@
  * @description Finds all potential usage of padding schemes used with asymmeric algorithms.
  * @kind problem
  * @id cpp/quantum-readiness/cbom/asymmetric-padding-schemes
- * @problem.severity error
+ * @severity recommendation
  * @tags cbom
  *       cryptography
  */

--- a/cpp/ql/src/experimental/cryptography/inventory/new_models/AuthenticatedEncryptionAlgorithms.ql
+++ b/cpp/ql/src/experimental/cryptography/inventory/new_models/AuthenticatedEncryptionAlgorithms.ql
@@ -3,7 +3,7 @@
  * @description Finds all potential usage of authenticated encryption schemes using the supported libraries.
  * @kind problem
  * @id cpp/quantum-readiness/cbom/authenticated-encryption-algorithms
- * @problem.severity error
+ * @severity recommendation
  * @tags cbom
  *       cryptography
  */

--- a/cpp/ql/src/experimental/cryptography/inventory/new_models/BlockModeAlgorithms.ql
+++ b/cpp/ql/src/experimental/cryptography/inventory/new_models/BlockModeAlgorithms.ql
@@ -3,7 +3,7 @@
  * @description Finds all potential block cipher modes of operations using the supported libraries.
  * @kind problem
  * @id cpp/quantum-readiness/cbom/block-cipher-mode
- * @problem.severity error
+ * @severity recommendation
  * @tags cbom
  *       cryptography
  */

--- a/cpp/ql/src/experimental/cryptography/inventory/new_models/BlockModeKnownIVsOrNonces.ql
+++ b/cpp/ql/src/experimental/cryptography/inventory/new_models/BlockModeKnownIVsOrNonces.ql
@@ -3,7 +3,7 @@
  * @description Finds all potential sources for initialization vectors (IV) or nonce used in block ciphers while using the supported libraries.
  * @kind problem
  * @id cpp/quantum-readiness/cbom/iv-sources
- * @problem.severity error
+ * @severity recommendation
  * @tags cbom
  *       cryptography
  */

--- a/cpp/ql/src/experimental/cryptography/inventory/new_models/BlockModeUnknownIVsOrNonces.ql
+++ b/cpp/ql/src/experimental/cryptography/inventory/new_models/BlockModeUnknownIVsOrNonces.ql
@@ -3,7 +3,7 @@
  * @description Finds all potentially unknown sources for initialization vectors (IV) or nonce used in block ciphers while using the supported libraries.
  * @kind problem
  * @id cpp/quantum-readiness/cbom/unkown-iv-sources
- * @problem.severity error
+ * @severity recommendation
  * @tags cbom
  *       cryptography
  */

--- a/cpp/ql/src/experimental/cryptography/inventory/new_models/EllipticCurveAlgorithmSize.ql
+++ b/cpp/ql/src/experimental/cryptography/inventory/new_models/EllipticCurveAlgorithmSize.ql
@@ -3,7 +3,7 @@
  * @description Finds all potential key lengths for elliptic curve algorithms usage.
  * @kind problem
  * @id cpp/quantum-readiness/cbom/elliptic-curve-key-length
- * @problem.severity error
+ * @severity recommendation
  * @tags cbom
  *       cryptography
  */

--- a/cpp/ql/src/experimental/cryptography/inventory/new_models/EllipticCurveAlgorithms.ql
+++ b/cpp/ql/src/experimental/cryptography/inventory/new_models/EllipticCurveAlgorithms.ql
@@ -3,7 +3,7 @@
  * @description Finds all potential usage of elliptic curve algorithms using the supported libraries.
  * @kind problem
  * @id cpp/quantum-readiness/cbom/elliptic-curve-algorithms
- * @problem.severity error
+ * @severity recommendation
  * @tags cbom
  *       cryptography
  */

--- a/cpp/ql/src/experimental/cryptography/inventory/new_models/HashingAlgorithms.ql
+++ b/cpp/ql/src/experimental/cryptography/inventory/new_models/HashingAlgorithms.ql
@@ -3,7 +3,7 @@
  * @description Finds all potential usage of cryptographic hash algorithms using the supported libraries.
  * @kind problem
  * @id cpp/quantum-readiness/cbom/hash-algorithms
- * @problem.severity error
+ * @severity recommendation
  * @tags cbom
  *       cryptography
  */

--- a/cpp/ql/src/experimental/cryptography/inventory/new_models/KeyExchangeAlgorithms.ql
+++ b/cpp/ql/src/experimental/cryptography/inventory/new_models/KeyExchangeAlgorithms.ql
@@ -3,7 +3,7 @@
  * @description Finds all potential usage of key exchange using the supported libraries.
  * @kind problem
  * @id cpp/quantum-readiness/cbom/key-exchange
- * @problem.severity error
+ * @severity recommendation
  * @tags cbom
  *       cryptography
  */

--- a/cpp/ql/src/experimental/cryptography/inventory/new_models/KnownAsymmetricKeyGeneration.ql
+++ b/cpp/ql/src/experimental/cryptography/inventory/new_models/KnownAsymmetricKeyGeneration.ql
@@ -3,7 +3,7 @@
  * @description Finds all known potential sources for asymmetric key generation while using the supported libraries.
  * @kind problem
  * @id cpp/quantum-readiness/cbom/asymmetric-key-generation
- * @problem.severity error
+ * @severity recommendation
  * @tags cbom
  *       cryptography
  */

--- a/cpp/ql/src/experimental/cryptography/inventory/new_models/SigningAlgorithms.ql
+++ b/cpp/ql/src/experimental/cryptography/inventory/new_models/SigningAlgorithms.ql
@@ -3,7 +3,7 @@
  * @description Finds all potential usage of signing algorithms using the supported libraries.
  * @kind problem
  * @id cpp/quantum-readiness/cbom/signing-algorithms
- * @problem.severity error
+ * @severity recommendation
  * @tags cbom
  *       cryptography
  */

--- a/cpp/ql/src/experimental/cryptography/inventory/new_models/SymmetricEncryptionAlgorithms.ql
+++ b/cpp/ql/src/experimental/cryptography/inventory/new_models/SymmetricEncryptionAlgorithms.ql
@@ -3,7 +3,7 @@
  * @description Finds all potential usage of symmetric encryption algorithms using the supported libraries.
  * @kind problem
  * @id cpp/quantum-readiness/cbom/symmetric-encryption-algorithms
- * @problem.severity error
+ * @severity recommendation
  * @tags cbom
  *       cryptography
  */

--- a/cpp/ql/src/experimental/cryptography/inventory/new_models/SymmetricPaddingAlgorithms.ql
+++ b/cpp/ql/src/experimental/cryptography/inventory/new_models/SymmetricPaddingAlgorithms.ql
@@ -3,7 +3,7 @@
  * @description Finds all potential usage of padding schemes used with symmeric algorithms.
  * @kind problem
  * @id cpp/quantum-readiness/cbom/symmetric-padding-schemes
- * @problem.severity error
+ * @severity recommendation
  * @tags cbom
  *       cryptography
  */

--- a/cpp/ql/src/experimental/cryptography/inventory/new_models/UnknownAsymmetricKeyGeneration.ql
+++ b/cpp/ql/src/experimental/cryptography/inventory/new_models/UnknownAsymmetricKeyGeneration.ql
@@ -3,7 +3,7 @@
  * @description Finds all unknown potential sources for asymmetric key generation while using the supported libraries.
  * @kind problem
  * @id cpp/quantum-readiness/cbom/unkwon-asymmetric-key-generation
- * @problem.severity error
+ * @severity recommendation
  * @tags cbom
  *       cryptography
  */

--- a/python/ql/src/experimental/cryptography/inventory/new_models/AllAsymmetricAlgorithms.ql
+++ b/python/ql/src/experimental/cryptography/inventory/new_models/AllAsymmetricAlgorithms.ql
@@ -3,7 +3,7 @@
  * @description Finds all potential usage of asymmeric keys (RSA & ECC) using the supported libraries.
  * @kind problem
  * @id py/quantum-readiness/cbom/all-asymmetric-algorithms
- * @problem.severity error
+ * @severity recommendation
  * @tags cbom
  *       cryptography
  */

--- a/python/ql/src/experimental/cryptography/inventory/new_models/AllCryptoAlgorithms.ql
+++ b/python/ql/src/experimental/cryptography/inventory/new_models/AllCryptoAlgorithms.ql
@@ -3,7 +3,7 @@
  * @description Finds all potential usage of cryptographic algorithms usage using the supported libraries.
  * @kind problem
  * @id py/quantum-readiness/cbom/all-cryptographic-algorithms
- * @problem.severity error
+ * @severity recommendation
  * @tags cbom
  *       cryptography
  */

--- a/python/ql/src/experimental/cryptography/inventory/new_models/AsymmetricEncryptionAlgorithms.ql
+++ b/python/ql/src/experimental/cryptography/inventory/new_models/AsymmetricEncryptionAlgorithms.ql
@@ -3,7 +3,7 @@
  * @description Finds all potential usage of asymmeric keys for encryption or key exchange using the supported libraries.
  * @kind problem
  * @id py/quantum-readiness/cbom/all-asymmetric-encryption-algorithms
- * @problem.severity error
+ * @severity recommendation
  * @tags cbom
  *       cryptography
  */

--- a/python/ql/src/experimental/cryptography/inventory/new_models/AsymmetricKeyGenOperation.ql
+++ b/python/ql/src/experimental/cryptography/inventory/new_models/AsymmetricKeyGenOperation.ql
@@ -3,7 +3,7 @@
  * @description Finds all known potential sources for asymmetric key generation while using the supported libraries.
  * @kind problem
  * @id py/quantum-readiness/cbom/asymmetric-key-generation
- * @problem.severity error
+ * @severity recommendation
  * @tags cbom
  *       cryptography
  */

--- a/python/ql/src/experimental/cryptography/inventory/new_models/AsymmetricPaddingAlgorithms.ql
+++ b/python/ql/src/experimental/cryptography/inventory/new_models/AsymmetricPaddingAlgorithms.ql
@@ -3,7 +3,7 @@
  * @description Finds all potential usage of padding schemes used with asymmeric algorithms.
  * @kind problem
  * @id py/quantum-readiness/cbom/asymmetric-padding-schemes
- * @problem.severity error
+ * @severity recommendation
  * @tags cbom
  *       cryptography
  */

--- a/python/ql/src/experimental/cryptography/inventory/new_models/AuthenticatedEncryptionAlgorithms.ql
+++ b/python/ql/src/experimental/cryptography/inventory/new_models/AuthenticatedEncryptionAlgorithms.ql
@@ -3,7 +3,7 @@
  * @description Finds all potential usage of authenticated encryption schemes using the supported libraries.
  * @kind problem
  * @id py/quantum-readiness/cbom/authenticated-encryption-algorithms
- * @problem.severity error
+ * @severity recommendation
  * @tags cbom
  *       cryptography
  */

--- a/python/ql/src/experimental/cryptography/inventory/new_models/BlockModeAlgorithms.ql
+++ b/python/ql/src/experimental/cryptography/inventory/new_models/BlockModeAlgorithms.ql
@@ -3,7 +3,7 @@
  * @description Finds all potential block cipher modes of operations using the supported libraries.
  * @kind problem
  * @id py/quantum-readiness/cbom/block-cipher-mode
- * @problem.severity error
+ * @severity recommendation
  * @tags cbom
  *       cryptography
  */

--- a/python/ql/src/experimental/cryptography/inventory/new_models/BlockModeKnownIVsOrNonces.ql
+++ b/python/ql/src/experimental/cryptography/inventory/new_models/BlockModeKnownIVsOrNonces.ql
@@ -3,7 +3,7 @@
  * @description Finds all potential sources for initialization vectors (IV) or nonce used in block ciphers while using the supported libraries.
  * @kind problem
  * @id py/quantum-readiness/cbom/iv-sources
- * @problem.severity error
+ * @severity recommendation
  * @tags cbom
  *       cryptography
  */

--- a/python/ql/src/experimental/cryptography/inventory/new_models/BlockModeUnknownIVsOrNonces.ql
+++ b/python/ql/src/experimental/cryptography/inventory/new_models/BlockModeUnknownIVsOrNonces.ql
@@ -3,7 +3,7 @@
  * @description Finds all potentially unknown sources for initialization vectors (IV) or nonce used in block ciphers while using the supported libraries.
  * @kind problem
  * @id py/quantum-readiness/cbom/unkown-iv-sources
- * @problem.severity error
+ * @severity recommendation
  * @tags cbom
  *       cryptography
  */

--- a/python/ql/src/experimental/cryptography/inventory/new_models/EllipticCurveAlgorithms.ql
+++ b/python/ql/src/experimental/cryptography/inventory/new_models/EllipticCurveAlgorithms.ql
@@ -3,7 +3,7 @@
  * @description Finds all potential usage of elliptic curve algorithms using the supported libraries.
  * @kind problem
  * @id py/quantum-readiness/cbom/elliptic-curve-algorithms
- * @problem.severity error
+ * @severity recommendation
  * @tags cbom
  *       cryptography
  */

--- a/python/ql/src/experimental/cryptography/inventory/new_models/HashingAlgorithms.ql
+++ b/python/ql/src/experimental/cryptography/inventory/new_models/HashingAlgorithms.ql
@@ -3,7 +3,7 @@
  * @description Finds all potential usage of cryptographic hash algorithms using the supported libraries.
  * @kind problem
  * @id py/quantum-readiness/cbom/hash-algorithms
- * @problem.severity error
+ * @severity recommendation
  * @tags cbom
  *       cryptography
  */

--- a/python/ql/src/experimental/cryptography/inventory/new_models/KeyDerivationAlgorithms.ql
+++ b/python/ql/src/experimental/cryptography/inventory/new_models/KeyDerivationAlgorithms.ql
@@ -3,7 +3,7 @@
  * @description Finds all potential usage of key derivation using the supported libraries.
  * @kind problem
  * @id py/quantum-readiness/cbom/key-derivation
- * @problem.severity error
+ * @severity recommendation
  * @tags cbom
  *       cryptography
  */

--- a/python/ql/src/experimental/cryptography/inventory/new_models/KeyExchangeAlgorithms.ql
+++ b/python/ql/src/experimental/cryptography/inventory/new_models/KeyExchangeAlgorithms.ql
@@ -3,7 +3,7 @@
  * @description Finds all potential usage of key exchange using the supported libraries.
  * @kind problem
  * @id py/quantum-readiness/cbom/key-exchange
- * @problem.severity error
+ * @severity recommendation
  * @tags cbom
  *       cryptography
  */

--- a/python/ql/src/experimental/cryptography/inventory/new_models/SigningAlgorithms.ql
+++ b/python/ql/src/experimental/cryptography/inventory/new_models/SigningAlgorithms.ql
@@ -3,7 +3,7 @@
  * @description Finds all potential usage of signing algorithms using the supported libraries.
  * @kind problem
  * @id py/quantum-readiness/cbom/signing-algorithms
- * @problem.severity error
+ * @severity recommendation
  * @tags cbom
  *       cryptography
  */

--- a/python/ql/src/experimental/cryptography/inventory/new_models/SymmetricEncryptionAlgorithms.ql
+++ b/python/ql/src/experimental/cryptography/inventory/new_models/SymmetricEncryptionAlgorithms.ql
@@ -3,7 +3,7 @@
  * @description Finds all potential usage of symmetric encryption algorithms using the supported libraries.
  * @kind problem
  * @id py/quantum-readiness/cbom/symmetric-encryption-algorithms
- * @problem.severity error
+ * @severity recommendation
  * @tags cbom
  *       cryptography
  */

--- a/python/ql/src/experimental/cryptography/inventory/new_models/SymmetricPaddingAlgorithms.ql
+++ b/python/ql/src/experimental/cryptography/inventory/new_models/SymmetricPaddingAlgorithms.ql
@@ -3,7 +3,7 @@
  * @description Finds all potential usage of padding schemes used with symmeric algorithms.
  * @kind problem
  * @id py/quantum-readiness/cbom/symmetric-padding-schemes
- * @problem.severity error
+ * @severity recommendation
  * @tags cbom
  *       cryptography
  */


### PR DESCRIPTION
When these queries are used in conjunction with [the advanced security codeql action](https://github.com/advanced-security/cbom-action) it generates lots of alerts in the Security -> Code Scanning pane. 

This is fine for issues, such as 'Weak Hashes' etc, but it's problematic for the CBOM stuff as it'll either push it to not be used because it generates alerts where there is not necessarily a problem, or that it will cause issues by influencing the number of errors coming out of a CodeQL analysis. 

To this end, we've changed up the `@problem.severity error` for `@severity recommendation` in the existing queries for C/C++/python. 