### PR TITLE
Crypto: Add some example Java cryptographic discovery queries

### DIFF
--- a/java/ql/src/experimental/quantum/InventorySlices/KnownAsymmetricAlgorithm.ql
+++ b/java/ql/src/experimental/quantum/InventorySlices/KnownAsymmetricAlgorithm.ql
@@ -2,7 +2,8 @@
  * @name Operations using known asymmetric cipher algorithms (slice)
  * @description Outputs operations where the algorithm used is a known asymmetric cipher algorithm.
  * @id java/quantum/slices/known-asymmetric-algorithm
- * @kind table
+ * @kind problem
+ * @severity recommendation
  * @tags quantum
  *       experimental
  */

--- a/java/ql/src/experimental/quantum/InventorySlices/KnownAsymmetricCipherAlgorithm.ql
+++ b/java/ql/src/experimental/quantum/InventorySlices/KnownAsymmetricCipherAlgorithm.ql
@@ -2,13 +2,15 @@
  * @name Known asymmetric cipher algorithms (slice)
  * @description Outputs known asymmetric cipher algorithms.
  * @id java/quantum/slices/known-asymmetric-cipher-algorithm
- * @kind table
+ * @kind problem
+ * @severity recommendation
  * @tags quantum
  *       experimental
  */
 
 import java
 import experimental.quantum.Language
+/* import codeql.quantum.experimental.Model */
 
 from Crypto::KeyOperationAlgorithmNode a
 where a.getAlgorithmType() instanceof Crypto::KeyOpAlg::AsymmetricCipherAlgorithmType

--- a/java/ql/src/experimental/quantum/InventorySlices/KnownAsymmetricOperationAlgorithm.ql
+++ b/java/ql/src/experimental/quantum/InventorySlices/KnownAsymmetricOperationAlgorithm.ql
@@ -2,7 +2,8 @@
  * @name Operations using known asymmetric algorithms (slice)
  * @description Outputs operations where the algorithm used is a known asymmetric algorithm.
  * @id java/quantum/slices/known-asymmetric-operation-algorithm
- * @kind table
+ * @kind problem
+ * @severity recommendation
  * @tags quantum
  *       experimental
  */

--- a/java/ql/src/experimental/quantum/InventorySlices/KnownCipherAlgorithm.ql
+++ b/java/ql/src/experimental/quantum/InventorySlices/KnownCipherAlgorithm.ql
@@ -2,13 +2,15 @@
  * @name Known cipher algorithms (slice)
  * @description Outputs known cipher algorithms.
  * @id java/quantum/slices/known-cipher-algorithm
- * @kind table
+ * @kind problem
+ * @severity recommendation
  * @tags quantum
  *       experimental
  */
 
 import java
 import experimental.quantum.Language
+import codeql.quantum.experimental.Model
 
 // TODO: should there be a cipher algorithm node?
 from Crypto::KeyOperationAlgorithmNode a

--- a/java/ql/src/experimental/quantum/InventorySlices/KnownEllipticCurveAlgorithm.ql
+++ b/java/ql/src/experimental/quantum/InventorySlices/KnownEllipticCurveAlgorithm.ql
@@ -2,7 +2,8 @@
  * @name Known elliptic curve algorithms (slice)
  * @description Outputs known elliptic curve algorithms.
  * @id java/quantum/slices/known-elliptic-curve-algorithm
- * @kind table
+ * @kind problem
+ * @severity recommendation
  * @tags quantum
  *       experimental
  */

--- a/java/ql/src/experimental/quantum/InventorySlices/KnownHashingAlgorithm.ql
+++ b/java/ql/src/experimental/quantum/InventorySlices/KnownHashingAlgorithm.ql
@@ -2,7 +2,8 @@
  * @name Known hashing algorithms (slice)
  * @description Outputs known hashing algorithms.
  * @id java/quantum/slices/known-hashing-algorithm
- * @kind table
+ * @kind problem
+ * @severity recommendation
  * @tags quantum
  *       experimental
  */

--- a/java/ql/src/experimental/quantum/InventorySlices/KnownHashingOperationAlgorithm.ql
+++ b/java/ql/src/experimental/quantum/InventorySlices/KnownHashingOperationAlgorithm.ql
@@ -2,7 +2,8 @@
  * @name Operations using known hashing algorithms (slice)
  * @description Outputs operations where the algorithm used is a known hashing algorithm.
  * @id java/quantum/slices/operation-with-known-hashing-algorithm
- * @kind table
+ * @kind problem
+ * @severity recommendation
  * @tags quantum
  *       experimental
  */

--- a/java/ql/src/experimental/quantum/InventorySlices/KnownKeyDerivationAlgorithm.ql
+++ b/java/ql/src/experimental/quantum/InventorySlices/KnownKeyDerivationAlgorithm.ql
@@ -2,7 +2,8 @@
  * @name Known key derivation algorithms (slice)
  * @description Outputs known key derivation algorithms.
  * @id java/quantum/slices/known-key-derivation-algorithm
- * @kind table
+ * @kind problem
+ * @severity recommendation
  * @tags quantum
  *       experimental
  */

--- a/java/ql/src/experimental/quantum/InventorySlices/KnownKeyDerivationOperationAlgorithm.ql
+++ b/java/ql/src/experimental/quantum/InventorySlices/KnownKeyDerivationOperationAlgorithm.ql
@@ -2,7 +2,8 @@
  * @name Operations using known key derivation algorithms (slice)
  * @description Outputs operations where the algorithm used is a known key derivation algorithm.
  * @id java/quantum/slices/operation-with-known-kdf-algorithm
- * @kind table
+ * @kind problem
+ * @severity recommendation
  * @tags quantum
  *       experimental
  */

--- a/java/ql/src/experimental/quantum/InventorySlices/KnownSymmetricCipherAlgorithm.ql
+++ b/java/ql/src/experimental/quantum/InventorySlices/KnownSymmetricCipherAlgorithm.ql
@@ -2,7 +2,8 @@
  * @name Known symmetric cipher algorithms (slice)
  * @description Outputs known symmetric cipher algorithms.
  * @id java/quantum/slices/known-symmetric-cipher-algorithm
- * @kind table
+ * @kind problem
+ * @severity recommendation
  * @tags quantum
  *       experimental
  */

--- a/java/ql/src/experimental/quantum/InventorySlices/LikelyCryptoAPIFunction.ql
+++ b/java/ql/src/experimental/quantum/InventorySlices/LikelyCryptoAPIFunction.ql
@@ -3,7 +3,7 @@
  * @description Outputs functions that take in crypto configuration parameters but calls are not detected in source.
  * @id java/quantum/slices/likely-crypto-api-function
  * @kind problem
- * @severity info
+ * @severity recommendation
  * @tags quantum
  *       experimental
  */

--- a/java/ql/src/experimental/quantum/InventorySlices/UnknownOperationAlgorithm.ql
+++ b/java/ql/src/experimental/quantum/InventorySlices/UnknownOperationAlgorithm.ql
@@ -3,7 +3,7 @@
  * @description Outputs operations where the algorithm applied is unknown
  * @id java/quantum/slices/operation-with-unknown-algorithm
  * @kind problem
- * @severity info
+ * @severity recommendation
  * @tags quantum
  *       experimental
  */


### PR DESCRIPTION
These queries have been developed out of the existing queries, with the following additions:
* more relevant discovery modes that are required in a diverse enterprise
* normalised headers to fix GH action output

The final point is related to PR #20566 and defeating alert fatigue from CodeQL output in GHAS Code Scanning pane from the uploaded SARIF files.