### PR TITLE
Crypto: Add Java cryptographic check queries

### DIFF
--- a/java/ql/src/experimental/quantum/Analysis/InsecureNonceGeneration.ql
+++ b/java/ql/src/experimental/quantum/Analysis/InsecureNonceGeneration.ql
@@ -5,7 +5,6 @@
  *              vulnerabilities such as replay attacks or key recovery.
  * @kind problem
  * @problem.severity error
- * @security.severity low
  * @precision high
  * @tags quantum
  *       experimental

--- a/java/ql/src/experimental/quantum/Analysis/NonAESGCMCipher.ql
+++ b/java/ql/src/experimental/quantum/Analysis/NonAESGCMCipher.ql
@@ -4,7 +4,6 @@
  * @description An AES cipher is in use without GCM
  * @kind problem
  * @problem.severity error
- * @security.severity low
  * @precision high
  * @tags quantum
  *       experimental

--- a/java/ql/src/experimental/quantum/Analysis/NonceReuse.ql
+++ b/java/ql/src/experimental/quantum/Analysis/NonceReuse.ql
@@ -4,7 +4,6 @@
  * @id java/quantum/reused-nonce
  * @kind problem
  * @problem.severity error
- * @security.severity low
  * @precision medium
  * @tags quantum
  *       experimental

--- a/java/ql/src/experimental/quantum/Analysis/UnknownKDFIterationCount.ql
+++ b/java/ql/src/experimental/quantum/Analysis/UnknownKDFIterationCount.ql
@@ -4,7 +4,6 @@
  * @id java/quantum/unknown-kdf-iteration-count
  * @kind problem
  * @precision medium
- * @severity warning
  * @tags quantum
  *       experimental
  */

--- a/java/ql/src/experimental/quantum/Analysis/WeakAsymmetric.ql
+++ b/java/ql/src/experimental/quantum/Analysis/WeakAsymmetric.ql
@@ -4,7 +4,6 @@
  * @description An asymmetric cipher with a short key size is in use
  * @kind problem
  * @problem.severity error
- * @security.severity low
  * @precision high
  * @tags quantum
  *       experimental

--- a/java/ql/src/experimental/quantum/Analysis/WeakBlockModes.ql
+++ b/java/ql/src/experimental/quantum/Analysis/WeakBlockModes.ql
@@ -4,7 +4,6 @@
  * @description An AES cipher is in use with an insecure block mode
  * @kind problem
  * @problem.severity error
- * @security.severity low
  * @precision high
  * @tags quantum
  *       experimental

--- a/java/ql/src/experimental/quantum/Analysis/WeakHashing.ql
+++ b/java/ql/src/experimental/quantum/Analysis/WeakHashing.ql
@@ -4,7 +4,6 @@
  * @id java/quantum/slices/weak-hashes
  * @kind problem
  * @problem.severity error
- * @security.severity low
  * @precision high
  * @tags external/cwe/cwe-327
  */

--- a/java/ql/src/experimental/quantum/Analysis/WeakKDFIterationCount.ql
+++ b/java/ql/src/experimental/quantum/Analysis/WeakKDFIterationCount.ql
@@ -4,7 +4,6 @@
  * @id java/quantum/weak-kdf-iteration-count
  * @kind problem
  * @problem.severity error
- * @security.severity low
  * @precision high
  * @tags quantum
  *       experimental

--- a/java/ql/src/experimental/quantum/Analysis/WeakKDFKeySize.ql
+++ b/java/ql/src/experimental/quantum/Analysis/WeakKDFKeySize.ql
@@ -4,7 +4,6 @@
  * @id java/quantum/weak-kdf-iteration-count
  * @kind problem
  * @problem.severity error
- * @security.severity low
  * @precision high
  * @tags quantum
  *       experimental

--- a/java/ql/src/experimental/quantum/Analysis/WeakRSA.ql
+++ b/java/ql/src/experimental/quantum/Analysis/WeakRSA.ql
@@ -4,7 +4,6 @@
  * @description RSA with a key length <2048 found
  * @kind problem
  * @problem.severity error
- * @security.severity low
  * @precision high
  * @tags quantum
  *       experimental

--- a/java/ql/src/experimental/quantum/Analysis/WeakSymmetricCiphers.ql
+++ b/java/ql/src/experimental/quantum/Analysis/WeakSymmetricCiphers.ql
@@ -4,7 +4,6 @@
  * @id java/quantum/slices/weak-ciphers
  * @kind problem
  * @problem.severity error
- * @security.severity low
  * @precision high
  * @tags external/cwe/cwe-327
  */


### PR DESCRIPTION
These are some example queries that check the cryptography present in output from a java source repo. Again, these build on the existing examples both in java and in other CBOM and cryptographic issue checking codeQL queries:

* InsecureNonceGeneration.ql - as before
* InsecureNonceSource.ql - as before
* KnownWeakKDFIterationCount.ql - as before
* NonAESGCMCipher.ql - detects non-AES in GCM mode ciphers. Can be updated to be 'non AES256 in GCM mode' but this gives more alerts on inferred key lengths. 
* NonceReuse.ql - as before
* ReusedNonce.ql - as before
* UnknownKDFIterationCount.ql - as before
* WeakAsymmetric.ql - finds weak asymmetric RSA ciphers using key lengths < 2048
* WeakBlockModes.ql - similar to NonAESGCM, this finds instances of known-bad block modes ECB, CFB, OFB, and CTR
* WeakHashing.ql - finds potentially weak hashing instances using the whitelist of SHA256, SHA384, and SHA512 (though this is yet to be checked against SHA3 variants)
* WeakKDFIterationCount.ql - as before
* WeakKDFKeySize.ql - as before
* WeakRSA.ql - an allternative method from WeakAsymmetric.ql, but functionally the same. 
* WeakSymmetricCiphers.ql - detects known-weak ciphers from a blocklist of DES, TripleDES, DoubleDES, RC2, RC4, IDEA, and Blowfish.