### PR TITLE
Rust: Docs updates

### DIFF
--- a/docs/codeql/codeql-overview/system-requirements.rst
+++ b/docs/codeql/codeql-overview/system-requirements.rst
@@ -44,7 +44,7 @@ For Ruby extraction:
 
 For Rust extraction:
 
-- `rustup`` and ``cargo`` must be installed.
+- ``rustup`` and ``cargo`` must be installed.
 
 For Java extraction:
 

--- a/docs/codeql/codeql-overview/system-requirements.rst
+++ b/docs/codeql/codeql-overview/system-requirements.rst
@@ -44,7 +44,7 @@ For Ruby extraction:
 
 For Rust extraction:
 
-- Requires ``rustup`` and ``cargo`` to be installed.
+- `rustup`` and ``cargo`` must be installed.
 
 For Java extraction:
 

--- a/docs/codeql/codeql-overview/system-requirements.rst
+++ b/docs/codeql/codeql-overview/system-requirements.rst
@@ -42,6 +42,10 @@ For Ruby extraction:
 
 - On Windows, the ``msvcp140.dll`` must be installed and available on the system. This can be installed by downloading the appropriate Microsoft Visual C++ Redistributable for Visual Studio.
 
+For Rust extraction:
+
+- Requires ``rustup`` and ``cargo`` to be installed.
+
 For Java extraction:
 
 - There must be a ``java`` or ``java.exe`` executable available on the ``PATH``, and the ``JAVA_HOME`` environment variable must point to the corresponding JDK's home directory.

--- a/docs/codeql/reusables/supported-frameworks.rst
+++ b/docs/codeql/reusables/supported-frameworks.rst
@@ -313,7 +313,6 @@ Rust built-in support
 Provided by the current versions of the
 CodeQL query pack ``codeql/rust-queries`` (`changelog <https://github.com/github/codeql/tree/codeql-cli/latest/rust/ql/src/CHANGELOG.md>`__, `source <https://github.com/github/codeql/tree/codeql-cli/latest/rust/ql/src>`__)
 and the CodeQL library pack ``codeql/rust-all`` (`changelog <https://github.com/github/codeql/tree/codeql-cli/latest/rust/ql/lib/CHANGELOG.md>`__, `source <https://github.com/github/codeql/tree/codeql-cli/latest/rust/ql/lib>`__).
-All support is experimental.
 
 .. csv-table::
    :header-rows: 1

--- a/docs/codeql/writing-codeql-queries/creating-path-queries.rst
+++ b/docs/codeql/writing-codeql-queries/creating-path-queries.rst
@@ -60,7 +60,7 @@ You should use the following template:
      */
 
     import <language>
-    // For some languages (Java/C++/Python/Swift) you need to explicitly import the data flow library, such as
+    // For some languages (Java/C++/Python/Rust/Swift) you need to explicitly import the data flow library, such as
     // import semmle.code.java.dataflow.DataFlow or import codeql.swift.dataflow.DataFlow
     ...
 
@@ -125,7 +125,7 @@ Declaring sources and sinks
 You must provide information about the ``source`` and ``sink`` in your path query. These are objects that correspond to the nodes of the paths that you are exploring.
 The name and the type of the ``source`` and the ``sink`` must be declared in the ``from`` statement of the query, and the types must be compatible with the nodes of the graph computed by the ``edges`` predicate.
 
-If you are querying C/C++, C#, Go, Java/Kotlin, JavaScript/TypeScript, Python, or Ruby code (and you have used ``import MyFlow::PathGraph`` in your query), the definitions of the ``source`` and ``sink`` are accessed via the module resulting from the application of the ``Global<..>`` module in the data flow library. You should declare both of these objects in the ``from`` statement.
+If you are querying C/C++, C#, Go, Java/Kotlin, JavaScript/TypeScript, Python, Ruby or Rust code (and you have used ``import MyFlow::PathGraph`` in your query), the definitions of the ``source`` and ``sink`` are accessed via the module resulting from the application of the ``Global<..>`` module in the data flow library. You should declare both of these objects in the ``from`` statement.
 For example:
 
 .. code-block:: ql
@@ -146,7 +146,7 @@ The configuration module must be defined to include definitions of sources and s
 - ``isSource()`` defines where data may flow from.
 - ``isSink()`` defines where data may flow to.
 
-For more information on using the configuration class in your analysis see the sections on global data flow in ":ref:`Analyzing data flow in C/C++ <analyzing-data-flow-in-cpp>`," ":ref:`Analyzing data flow in C# <analyzing-data-flow-in-csharp>`," and ":ref:`Analyzing data flow in Python <analyzing-data-flow-in-python>`."
+For more information on using the configuration class in your analysis see the sections on global data flow in ":ref:`Analyzing data flow in C/C++ <analyzing-data-flow-in-cpp>`," ":ref:`Analyzing data flow in C# <analyzing-data-flow-in-csharp>`," ":ref:`Analyzing data flow in Python <analyzing-data-flow-in-python>`," and ":ref:`Analyzing data flow in Rust <analyzing-data-flow-in-rust>`."
 
 You can also create a configuration for different frameworks and environments by extending the ``Configuration`` class. For more information, see ":ref:`Types <defining-a-class>`" in the QL language reference.
 

--- a/docs/codeql/writing-codeql-queries/creating-path-queries.rst
+++ b/docs/codeql/writing-codeql-queries/creating-path-queries.rst
@@ -33,6 +33,7 @@ For more language-specific information on analyzing data flow, see:
 - ":ref:`Analyzing data flow in JavaScript/TypeScript <analyzing-data-flow-in-javascript-and-typescript>`"
 - ":ref:`Analyzing data flow in Python <analyzing-data-flow-in-python>`"
 - ":ref:`Analyzing data flow in Ruby <analyzing-data-flow-in-ruby>`"
+- ":ref:`Analyzing data flow in Rust <analyzing-data-flow-in-rust>`"
 - ":ref:`Analyzing data flow in Swift <analyzing-data-flow-in-swift>`"
 
 Path query examples

--- a/docs/codeql/writing-codeql-queries/creating-path-queries.rst
+++ b/docs/codeql/writing-codeql-queries/creating-path-queries.rst
@@ -125,7 +125,7 @@ Declaring sources and sinks
 You must provide information about the ``source`` and ``sink`` in your path query. These are objects that correspond to the nodes of the paths that you are exploring.
 The name and the type of the ``source`` and the ``sink`` must be declared in the ``from`` statement of the query, and the types must be compatible with the nodes of the graph computed by the ``edges`` predicate.
 
-If you are querying C/C++, C#, Go, Java/Kotlin, JavaScript/TypeScript, Python, Ruby or Rust code (and you have used ``import MyFlow::PathGraph`` in your query), the definitions of the ``source`` and ``sink`` are accessed via the module resulting from the application of the ``Global<..>`` module in the data flow library. You should declare both of these objects in the ``from`` statement.
+If you are querying C/C++, C#, Go, Java/Kotlin, JavaScript/TypeScript, Python, Ruby, or Rust code (and you have used ``import MyFlow::PathGraph`` in your query), the definitions of the ``source`` and ``sink`` are accessed via the module resulting from the application of the ``Global<..>`` module in the data flow library. You should declare both of these objects in the ``from`` statement.
 For example:
 
 .. code-block:: ql


### PR DESCRIPTION
Some more docs updates - odds and ends in the `codeql` repo:
- mirror information from `supported-versions-compilers.rst` in `system-requirements.rst` (@redsun82 can you confirm this information is correct?).
- remove a reference to libraries being "experimental".  We plan Rust GA for the next release (2.23.3), so nothing will be "experimental" any more.
- add missing link to the `analyzing-data-flow-in-rust` doc.
- add references to Rust in various places where it was missing and should be.