### PR TITLE
Shared: Fix this bad join `boundedPhiRankStep`

### DIFF
--- a/shared/rangeanalysis/codeql/rangeanalysis/RangeAnalysis.qll
+++ b/shared/rangeanalysis/codeql/rangeanalysis/RangeAnalysis.qll
@@ -1045,7 +1045,8 @@ module RangeStage<
     D::Delta origdelta, SemReason reason, int rix
   ) {
     exists(Sem::SsaVariable inp, SsaReadPositionPhiInputEdge edge |
-      rankedPhiInput(phi, inp, edge, rix) and
+      rankedPhiInput(pragma[only_bind_into](phi), pragma[only_bind_into](inp),
+        pragma[only_bind_into](edge), rix) and
       boundedPhiCandValidForEdge(phi, b, delta, upper, fromBackEdge, origdelta, reason, inp, edge)
     |
       rix = 1


### PR DESCRIPTION
Before (when running `cpp/invalid-pointer-deref` on neovim):
```
Pipeline standard for RangeAnalysisImpl::ConstantStage::boundedPhiRankStep/8#99a39015@6875a9w9 was evaluated in 8990 iterations totaling 30117ms (delta sizes total: 688791).
            685940   ~1%    {9} r1 = SCAN `RangeAnalysisImpl::ConstantStage::boundedPhiRankStep/8#99a39015#prev_delta` OUTPUT In.0, In.1, In.2, In.3, In.4, In.5, In.6, _, In.7
            685940   ~1%    {8}    | REWRITE WITH Tmp.7 := 1, Out.7 := (Tmp.7 + In.8) KEEPING 8
        2143300387   ~1%    {10}    | JOIN WITH `RangeAnalysisImpl::ConstantStage::boundedPhiCandValidForEdge/9#17e05352#prev` ON FIRST 7 OUTPUT Lhs.0, Rhs.7, Rhs.8, Lhs.7, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5, Lhs.6
            582448   ~1%    {8}    | JOIN WITH `RangeUtils::MakeUtils<SemanticLocation::SemLocation,RangeAnalysisImpl::Sem,FloatDelta::FloatDelta>::rankedPhiInput/4#d3c444f0` ON FIRST 4 OUTPUT Lhs.0, Lhs.4, Lhs.5, Lhs.6, Lhs.7, Lhs.8, Lhs.9, Lhs.3
                        
          44172560   ~0%    {9} r2 = SCAN `RangeAnalysisImpl::ConstantStage::boundedPhiCandValidForEdge/9#17e05352#prev_delta` OUTPUT In.0, In.7, In.8, In.1, In.2, In.3, In.4, In.5, In.6
                        
          44172560   ~0%    {9} r3 = JOIN r2 WITH `RangeUtils::MakeUtils<SemanticLocation::SemLocation,RangeAnalysisImpl::Sem,FloatDelta::FloatDelta>::rankedPhiInput/4#d3c444f0` ON FIRST 3 OUTPUT Lhs.0, Lhs.3, Lhs.4, Lhs.5, Lhs.6, Lhs.7, Lhs.8, _, Rhs.3
          44172560   ~1%    {9}    | REWRITE WITH Tmp.7 := 1, Out.7 := (InOut.8 - Tmp.7)
              4135   ~2%    {8}    | JOIN WITH `RangeAnalysisImpl::ConstantStage::boundedPhiRankStep/8#99a39015#prev` ON FIRST 8 OUTPUT Lhs.0, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5, Lhs.6, Lhs.8
                        
          44172560   ~0%    {11} r4 = JOIN r2 WITH `RangeUtils::MakeUtils<SemanticLocation::SemLocation,RangeAnalysisImpl::Sem,FloatDelta::FloatDelta>::rankedPhiInput/4#d3c444f0` ON FIRST 3 OUTPUT Lhs.0, Lhs.3, Lhs.4, Lhs.5, Lhs.6, Lhs.7, Lhs.8, Lhs.1, Lhs.2, Rhs.3, _
                            {10}    | REWRITE WITH Tmp.10 := 1, TEST InOut.9 = Tmp.10 KEEPING 10
            106321   ~3%    {10}    | SCAN OUTPUT In.0, In.7, In.8, _, In.1, In.2, In.3, In.4, In.5, In.6
            106321   ~2%    {10}    | REWRITE WITH Out.3 := 1
            106321   ~4%    {8}    | JOIN WITH `RangeUtils::MakeUtils<SemanticLocation::SemLocation,RangeAnalysisImpl::Sem,FloatDelta::FloatDelta>::rankedPhiInput/4#d3c444f0` ON FIRST 4 OUTPUT Lhs.0, Lhs.4, Lhs.5, Lhs.6, Lhs.7, Lhs.8, Lhs.9, _
            106321   ~5%    {8}    | REWRITE WITH Out.7 := 1
                        
            692904   ~1%    {8} r5 = r1 UNION r3 UNION r4
            688879   ~1%    {8}    | AND NOT `RangeAnalysisImpl::ConstantStage::boundedPhiRankStep/8#99a39015#prev`(FIRST 8)
                            return r5
```
After:
```
Pipeline standard for RangeAnalysisImpl::ConstantStage::boundedPhiRankStep/8#99a39015@65a349wa was evaluated in 8990 iterations totaling 1016ms (delta sizes total: 688356).
        44172868   ~3%    {9} r1 = SCAN `RangeAnalysisImpl::ConstantStage::boundedPhiCandValidForEdge/9#17e05352#prev_delta` OUTPUT In.0, In.7, In.8, In.1, In.2, In.3, In.4, In.5, In.6
                      
          106399   ~5%    {8} r2 = JOIN r1 WITH `_RangeUtils::MakeUtils<SemanticLocation::SemLocation,RangeAnalysisImpl::Sem,FloatDelta::FloatDelta>:__#join_rhs` ON FIRST 3 OUTPUT Lhs.0, Lhs.3, Lhs.4, Lhs.5, Lhs.6, Lhs.7, Lhs.8, _
          106399   ~5%    {8}    | REWRITE WITH Out.7 := 1
                      
          685940   ~1%    {8} r3 = SCAN `RangeAnalysisImpl::ConstantStage::boundedPhiRankStep/8#99a39015#prev_delta` OUTPUT In.0, In.7, In.1, In.2, In.3, In.4, In.5, In.6
          659753   ~0%    {10}    | JOIN WITH `RangeUtils::MakeUtils<SemanticLocation::SemLocation,RangeAnalysisImpl::Sem,FloatDelta::FloatDelta>::rankedPhiInput/4#d3c444f0_0_expr_123#join_rhs` ON FIRST 2 OUTPUT Lhs.0, Lhs.2, Lhs.3, Lhs.4, Lhs.5, Lhs.6, Lhs.7, Rhs.2, Rhs.3, Rhs.4
          581543   ~0%    {8}    | JOIN WITH `RangeAnalysisImpl::ConstantStage::boundedPhiCandValidForEdge/9#17e05352#prev` ON FIRST 9 OUTPUT Lhs.0, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5, Lhs.6, Lhs.9
                      
        44172868   ~0%    {9} r4 = JOIN r1 WITH `RangeUtils::MakeUtils<SemanticLocation::SemLocation,RangeAnalysisImpl::Sem,FloatDelta::FloatDelta>::rankedPhiInput/4#d3c444f0` ON FIRST 3 OUTPUT Lhs.0, Lhs.3, Lhs.4, Lhs.5, Lhs.6, Lhs.7, Lhs.8, _, Rhs.3
        44172868   ~1%    {9}    | REWRITE WITH Tmp.7 := 1, Out.7 := (InOut.8 - Tmp.7)
            4135   ~2%    {8}    | JOIN WITH `RangeAnalysisImpl::ConstantStage::boundedPhiRankStep/8#99a39015#prev` ON FIRST 8 OUTPUT Lhs.0, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5, Lhs.6, Lhs.8
                      
          692077   ~1%    {8} r5 = r2 UNION r3 UNION r4
          688749   ~1%    {8}    | AND NOT `RangeAnalysisImpl::ConstantStage::boundedPhiRankStep/8#99a39015#prev`(FIRST 8)
                          return r5
```