### PR TITLE
Add code owners for `/shared/`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,6 +9,7 @@
 /python/ @github/codeql-python
 /ruby/ @github/codeql-ruby
 /rust/ @github/codeql-rust
+/shared/ @aschackmull @hvitved @owen-mc
 /swift/ @github/codeql-swift
 /misc/codegen/ @github/codeql-swift
 /java/kotlin-extractor/ @github/codeql-kotlin


### PR DESCRIPTION
Currently no one is added as a reviewer, except in the `/shared/quantum/` subfolder.

Talking points:
* Is it worth setting up some kind of team for this? I see that was done for ql-for-ql.
* Does anyone else want to be added? @MathiasVP maybe?