### PR TITLE
Java: Fix buildless test HTTP server binding on macOS26

### DIFF
--- a/java/ql/integration-tests/java/buildless-dependency-different-repository/test.py
+++ b/java/ql/integration-tests/java/buildless-dependency-different-repository/test.py
@@ -4,8 +4,8 @@ import logging
 
 def test(codeql, java):
     # Each of these serves the "repo" and "repo2" directories on http://localhost:924[89]
-    repo_server_process = subprocess.Popen(["python3", "-m", "http.server", "9428"], cwd="repo")
-    repo_server_process2 = subprocess.Popen(["python3", "-m", "http.server", "9429"], cwd="repo2")
+    repo_server_process = subprocess.Popen(["python3", "-m", "http.server", "9428", "-b", "localhost"], cwd="repo")
+    repo_server_process2 = subprocess.Popen(["python3", "-m", "http.server", "9429", "-b", "localhost"], cwd="repo2")
     try:
         codeql.database.create(
             extractor_option="buildless=true",


### PR DESCRIPTION
The `buildless-dependency-different-repository` test was timing out when trying to fetch Maven dependencies from local HTTP servers. Turns out Python's `http.server` on newer macOS versions binds only to IPv6 by default, but Maven tries to connect via IPv4. 

Added `-b localhost` to the server commands to make them listen on both IPv4 and IPv6, just like we already do in the `buildless-snapshot-repository` test.