### PR TITLE
Java: Fix bug in ConstantExpAppearsNonConstant.

### DIFF
--- a/java/ql/src/Likely Bugs/Arithmetic/ConstantExpAppearsNonConstant.ql
+++ b/java/ql/src/Likely Bugs/Arithmetic/ConstantExpAppearsNonConstant.ql
@@ -19,7 +19,7 @@ predicate isConstantExp(Expr e) {
   // A literal is constant.
   e instanceof Literal
   or
-  e instanceof TypeAccess and not e.(TypeAccess).getType() instanceof ErrorType
+  e instanceof TypeAccess
   or
   e instanceof ArrayTypeAccess
   or
@@ -53,6 +53,7 @@ predicate isConstantExp(Expr e) {
 from Expr e
 where
   isConstantExp(e) and
+  not e.(TypeAccess).getType() instanceof ErrorType and
   exists(Expr child | e.getAChildExpr() = child |
     not isConstantExp(child) and
     not child instanceof Annotation


### PR DESCRIPTION
The fix in https://github.com/github/codeql/pull/20546 was slightly buggy - the introduced negation also appeared in a negated context, so it accidentally introduced a bunch of new FPs. This PR moves the filter, so it only removes results without introducing new ones.