### PR TITLE
Java integration test: wait for test servers to come up before running test

### DIFF
--- a/java/ql/integration-tests/java/buildless-dependency-different-repository/test.py
+++ b/java/ql/integration-tests/java/buildless-dependency-different-repository/test.py
@@ -1,12 +1,29 @@
 import subprocess
 import logging
+import time
+import socket
+
+
+def wait_for_port(port, process, timeout=100):
+    start = time.time()
+    while time.time() - start < timeout:
+        # Check if process died
+        if process.poll() is not None:
+            raise RuntimeError(f"Server process exited with code {process.returncode}")
+        try:
+            with socket.create_connection(("localhost", port), timeout=1):
+                return True
+        except (socket.timeout, ConnectionRefusedError, OSError):
+            time.sleep(0.2)
+    raise RuntimeError(f"Port {port} not ready within {timeout}s")
 
 
 def test(codeql, java):
-    # Each of these serves the "repo" and "repo2" directories on http://localhost:924[89]
-    repo_server_process = subprocess.Popen(["python3", "-m", "http.server", "9428", "-b", "localhost"], cwd="repo")
-    repo_server_process2 = subprocess.Popen(["python3", "-m", "http.server", "9429", "-b", "localhost"], cwd="repo2")
+    repo_server_process = subprocess.Popen(["python3", "-m", "http.server", "9428", "-b", "localhost"], cwd="repo", stderr=subprocess.PIPE, stdout=subprocess.PIPE)
+    repo_server_process2 = subprocess.Popen(["python3", "-m", "http.server", "9429", "-b", "localhost"], cwd="repo2", stderr=subprocess.PIPE, stdout=subprocess.PIPE)
     try:
+        wait_for_port(9428, repo_server_process)
+        wait_for_port(9429, repo_server_process2)
         codeql.database.create(
             extractor_option="buildless=true",
             _env={"CODEQL_EXTRACTOR_JAVA_OPTION_BUILDLESS_CLASSPATH_FROM_BUILD_FILES": "true"},


### PR DESCRIPTION
This PR fixes [test failures](https://github.com/github/semmle-code/actions/runs/18342752379/job/52244906697) on macOS 26 where Maven would timeout connecting to test HTTP servers that weren't ready yet.

The main change is the addition of the `wait_for_port()` function that verifies if servers are accepting connections before  running the tests.