### PR TITLE
Many languages: Update broken algo qhelp

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-327/BrokenCryptoAlgorithm.qhelp
+++ b/cpp/ql/src/Security/CWE/CWE-327/BrokenCryptoAlgorithm.qhelp
@@ -3,11 +3,15 @@
   "qhelp.dtd">
 <qhelp>
 <overview>
-<p>Using broken or weak cryptographic algorithms can leave data vulnerable to being decrypted.</p>
+<p>Using broken or weak cryptographic algorithms may compromise security guarantees such as confidentiality, integrity, and authenticity.</p>
 
-<p>Many cryptographic algorithms provided by cryptography libraries are known to be weak, or 
-flawed. Using such an algorithm means that an attacker may be able to easily decrypt the encrypted
-data.</p>
+<p>Many cryptographic algorithms are known to be weak or flawed. The security guarantees of a system often rely on the underlying cryptography, so using a weak algorithm can have severe consequences. For example:
+</p>
+<ul>
+  <li>If a weak encryption algorithm is used, an attacker may be able to decrypt sensitive data.</li>
+  <li>If a weak hashing algorithm is used to protect data integrity, an attacker may be able to craft a malicious input that has the same hash as a benign one.</li>
+  <li>If a weak algorithm is used for digital signatures, an attacker may be able to forge signatures and impersonate legitimate users.</li>
+</ul>
 
 </overview>
 <recommendation>

--- a/java/ql/src/Security/CWE/CWE-327/BrokenCryptoAlgorithm.qhelp
+++ b/java/ql/src/Security/CWE/CWE-327/BrokenCryptoAlgorithm.qhelp
@@ -3,11 +3,15 @@
   "qhelp.dtd">
 <qhelp>
 <overview>
-<p>Using broken or weak cryptographic algorithms can leave data vulnerable to being decrypted.</p>
+<p>Using broken or weak cryptographic algorithms may compromise security guarantees such as confidentiality, integrity, and authenticity.</p>
 
-<p>Many cryptographic algorithms provided by cryptography libraries are known to be weak, or 
-flawed. Using such an algorithm means that an attacker may be able to easily decrypt the encrypted
-data.</p>
+<p>Many cryptographic algorithms are known to be weak or flawed. The security guarantees of a system often rely on the underlying cryptography, so using a weak algorithm can have severe consequences. For example:
+</p>
+<ul>
+  <li>If a weak encryption algorithm is used, an attacker may be able to decrypt sensitive data.</li>
+  <li>If a weak hashing algorithm is used to protect data integrity, an attacker may be able to craft a malicious input that has the same hash as a benign one.</li>
+  <li>If a weak algorithm is used for digital signatures, an attacker may be able to forge signatures and impersonate legitimate users.</li>
+</ul>
 
 </overview>
 <recommendation>

--- a/javascript/ql/src/Security/CWE-327/BrokenCryptoAlgorithm.qhelp
+++ b/javascript/ql/src/Security/CWE-327/BrokenCryptoAlgorithm.qhelp
@@ -4,16 +4,33 @@
 <qhelp>
 	<overview>
 		<p>
-			Using broken or weak cryptographic algorithms can leave data
-			vulnerable to being decrypted or forged by an attacker.
+			Using broken or weak cryptographic algorithms may compromise
+			security guarantees such as confidentiality, integrity, and
+			authenticity.
 		</p>
 
 		<p>
-			Many cryptographic algorithms provided by cryptography
-			libraries are known to be weak, or flawed. Using such an
-			algorithm means that encrypted or hashed data is less
-			secure than it appears to be.
+			Many cryptographic algorithms are known to be weak or flawed. The
+			security guarantees of a system often rely on the underlying
+			cryptography, so using a weak algorithm can have severe consequences.
+			For example:
 		</p>
+
+		<ul>
+			<li>
+			If a weak encryption algorithm is used, an attacker may be able to
+			decrypt sensitive data.
+			</li>
+			<li>
+			If a weak hashing algorithm is used to protect data integrity, an
+			attacker may be able to craft a malicious input that has the same
+			hash as a benign one.
+			</li>
+			<li>
+			If a weak algorithm is used for digital signatures, an attacker may
+			be able to forge signatures and impersonate legitimate users.
+			</li>
+		</ul>
 
 	</overview>
 	<recommendation>

--- a/python/ql/src/Security/CWE-327/BrokenCryptoAlgorithm.qhelp
+++ b/python/ql/src/Security/CWE-327/BrokenCryptoAlgorithm.qhelp
@@ -3,17 +3,35 @@
 "qhelp.dtd">
 <qhelp>
      <overview>
+
           <p>
-               Using broken or weak cryptographic algorithms can leave data
-               vulnerable to being decrypted or forged by an attacker.
+               Using broken or weak cryptographic algorithms may compromise
+               security guarantees such as confidentiality, integrity, and
+               authenticity.
           </p>
 
           <p>
-               Many cryptographic algorithms provided by cryptography
-               libraries are known to be weak, or flawed. Using such an
-               algorithm means that encrypted or hashed data is less
-               secure than it appears to be.
+               Many cryptographic algorithms are known to be weak or flawed. The
+               security guarantees of a system often rely on the underlying
+               cryptography, so using a weak algorithm can have severe consequences.
+               For example:
           </p>
+
+          <ul>
+               <li>
+               If a weak encryption algorithm is used, an attacker may be able to
+               decrypt sensitive data.
+               </li>
+               <li>
+               If a weak hashing algorithm is used to protect data integrity, an
+               attacker may be able to craft a malicious input that has the same
+               hash as a benign one.
+               </li>
+               <li>
+               If a weak algorithm is used for digital signatures, an attacker may
+               be able to forge signatures and impersonate legitimate users.
+               </li>
+          </ul>
 
           <p>
                This query alerts on any use of a weak cryptographic algorithm that is

--- a/python/ql/src/Security/CWE-327/BrokenCryptoAlgorithm.qhelp
+++ b/python/ql/src/Security/CWE-327/BrokenCryptoAlgorithm.qhelp
@@ -16,7 +16,7 @@
           </p>
 
           <p>
-               This query alerts on any use of a weak cryptographic algorithm, that is
+               This query alerts on any use of a weak cryptographic algorithm that is
                not a hashing algorithm. Use of broken or weak cryptographic hash
                functions are handled by the
                <code>py/weak-sensitive-data-hashing</code> query.

--- a/ruby/ql/src/queries/security/cwe-327/BrokenCryptoAlgorithm.qhelp
+++ b/ruby/ql/src/queries/security/cwe-327/BrokenCryptoAlgorithm.qhelp
@@ -13,6 +13,12 @@
       algorithm means that encrypted or hashed data is less
       secure than it appears to be.
     </p>
+    <p>
+      This query alerts on any use of a weak cryptographic algorithm, that is
+      not a hashing algorithm. Use of broken or weak cryptographic hash
+      functions are handled by the
+      <code>rb/weak-sensitive-data-hashing</code> query.
+    </p>
   </overview>
   <recommendation>
     <p>

--- a/ruby/ql/src/queries/security/cwe-327/BrokenCryptoAlgorithm.qhelp
+++ b/ruby/ql/src/queries/security/cwe-327/BrokenCryptoAlgorithm.qhelp
@@ -14,7 +14,7 @@
       secure than it appears to be.
     </p>
     <p>
-      This query alerts on any use of a weak cryptographic algorithm, that is
+      This query alerts on any use of a weak cryptographic algorithm that is
       not a hashing algorithm. Use of broken or weak cryptographic hash
       functions are handled by the
       <code>rb/weak-sensitive-data-hashing</code> query.

--- a/ruby/ql/src/queries/security/cwe-327/BrokenCryptoAlgorithm.qhelp
+++ b/ruby/ql/src/queries/security/cwe-327/BrokenCryptoAlgorithm.qhelp
@@ -4,15 +4,33 @@
 <qhelp>
   <overview>
     <p>
-      Using broken or weak cryptographic algorithms can leave data
-      vulnerable to being decrypted or forged by an attacker.
+      Using broken or weak cryptographic algorithms may compromise
+      security guarantees such as confidentiality, integrity, and
+      authenticity.
     </p>
+
     <p>
-      Many cryptographic algorithms provided by cryptography
-      libraries are known to be weak, or flawed. Using such an
-      algorithm means that encrypted or hashed data is less
-      secure than it appears to be.
+      Many cryptographic algorithms are known to be weak or flawed. The
+      security guarantees of a system often rely on the underlying
+      cryptography, so using a weak algorithm can have severe consequences.
+      For example:
     </p>
+
+    <ul>
+      <li>
+      If a weak encryption algorithm is used, an attacker may be able to
+      decrypt sensitive data.
+      </li>
+      <li>
+      If a weak hashing algorithm is used to protect data integrity, an
+      attacker may be able to craft a malicious input that has the same
+      hash as a benign one.
+      </li>
+      <li>
+      If a weak algorithm is used for digital signatures, an attacker may
+      be able to forge signatures and impersonate legitimate users.
+      </li>
+    </ul>
     <p>
       This query alerts on any use of a weak cryptographic algorithm that is
       not a hashing algorithm. Use of broken or weak cryptographic hash

--- a/rust/ql/src/queries/security/CWE-327/BrokenCryptoAlgorithm.qhelp
+++ b/rust/ql/src/queries/security/CWE-327/BrokenCryptoAlgorithm.qhelp
@@ -16,7 +16,7 @@
           </p>
 
           <p>
-               This query alerts on any use of a weak cryptographic algorithm, that is
+               This query alerts on any use of a weak cryptographic algorithm that is
                not a hashing algorithm. Use of broken or weak cryptographic hash
                functions are handled by the
                <code>rust/weak-sensitive-data-hashing</code> query.

--- a/rust/ql/src/queries/security/CWE-327/BrokenCryptoAlgorithm.qhelp
+++ b/rust/ql/src/queries/security/CWE-327/BrokenCryptoAlgorithm.qhelp
@@ -3,17 +3,34 @@
 "qhelp.dtd">
 <qhelp>
      <overview>
-          <p>
-               Using broken or weak cryptographic algorithms can leave data
-               vulnerable to being decrypted or forged by an attacker.
-          </p>
+		<p>
+			Using broken or weak cryptographic algorithms may compromise
+			security guarantees such as confidentiality, integrity, and
+			authenticity.
+		</p>
 
-          <p>
-               Many cryptographic algorithms provided by cryptography
-               libraries are known to be weak, or flawed. Using such an
-               algorithm means that encrypted or hashed data is less
-               secure than it appears to be.
-          </p>
+		<p>
+			Many cryptographic algorithms are known to be weak or flawed. The
+			security guarantees of a system often rely on the underlying
+			cryptography, so using a weak algorithm can have severe consequences.
+			For example:
+		</p>
+
+		<ul>
+			<li>
+			If a weak encryption algorithm is used, an attacker may be able to
+			decrypt sensitive data.
+			</li>
+			<li>
+			If a weak hashing algorithm is used to protect data integrity, an
+			attacker may be able to craft a malicious input that has the same
+			hash as a benign one.
+			</li>
+			<li>
+			If a weak algorithm is used for digital signatures, an attacker may
+			be able to forge signatures and impersonate legitimate users.
+			</li>
+		</ul>
 
           <p>
                This query alerts on any use of a weak cryptographic algorithm that is


### PR DESCRIPTION
Currently it focusses too much on the risk of data being decrypted, and doesn't explain why using weak algorithms can be a problem in other contexts.

Note that many of these queries would only alert for encryption algorithms, so the current text makes sense for them. But `java/potentially-weak-cryptographic-algorithm`, which shares the same help text as `java/weak-cryptographic-algorithm`, alerts for more algorithms, and so does `js/weak-cryptographic-algorithm`. It seems good to update all the qhelp files at once.