### PR TITLE
Docs: fix taint tracking query

### DIFF
--- a/docs/codeql/codeql-language-guides/analyzing-data-flow-in-python.rst
+++ b/docs/codeql/codeql-language-guides/analyzing-data-flow-in-python.rst
@@ -306,7 +306,7 @@ This query shows a data flow configuration that uses all network input as data s
     /**
     * @kind path-problem
     * @problem.severity warning
-    * @id filesystemacess
+    * @id filesystemaccess
     */
     import python
     import semmle.python.dataflow.new.DataFlow


### PR DESCRIPTION
👋 Several query examples in the CodeQL docs for analyzing global dataflow seem to be wrong, and don't work as expected. E.g. in [docs for Python](https://codeql.github.com/docs/codeql-language-guides/analyzing-data-flow-in-python/) the query:
```codeql
import python
import semmle.python.dataflow.new.DataFlow
import semmle.python.dataflow.new.TaintTracking
import semmle.python.dataflow.new.RemoteFlowSources
import semmle.python.Concepts

module RemoteToFileConfiguration implements DataFlow::ConfigSig {
  predicate isSource(DataFlow::Node source) {
    source instanceof RemoteFlowSource
  }

  predicate isSink(DataFlow::Node sink) {
    sink = any(FileSystemAccess fa).getAPathArgument()
  }
}

module RemoteToFileFlow = TaintTracking::Global<RemoteToFileConfiguration>;

from DataFlow::Node input, DataFlow::Node fileAccess
where RemoteToFileFlow::flow(input, fileAccess)
select fileAccess, "This file access uses data from $@.",
  input, "user-controllable input."
```
Results of running the query:
<img width="646" height="367" alt="image" src="https://github.com/user-attachments/assets/d4ea44eb-5b55-42e2-8a52-ba65dcfda4c0" />
This won’t show a path query, but a #select because:
- `@kind path-problem` is missing
 - there is no `import RemoteToFileFlow:PathGraph`
 - The query should be using `RemoteToFileFlow:PathNode` types, not `DataFlow::Node`
```codeql
from DataFlow::Node input, DataFlow::Node fileAccess
where RemoteToFileFlow::flow(input, fileAccess)
select fileAccess, "This file access uses data from $@.",
  input, "user-controllable input."
```
- should be `where RemoteToFileFlow::flowPath(input, fileAccess)` instead of `RemoteToFileFlow::flow(input, fileAccess)`
- the query selects the wrong number of columns for a path query, and should be `select fileAccess.getNode(), input, fileAccess, "This file access uses data from $@.", input, "user-controllable input."`
Making the changes fixes the query to display like in screenshot:

<img width="649" height="328" alt="image" src="https://github.com/user-attachments/assets/4fd8a0e8-e143-45af-80fc-d022c3051ccb" />


This PR fixes this specific query. However, I noticed that very similar issues, like the ones I listed above, seem to exist in docs for other languages too, in the Analyzing data flow in [language] pages.