### PR TITLE
Rust: Include tuple structs/variants in `CallExprBase.getStaticTarget()`

### DIFF
--- a/rust/ql/lib/codeql/rust/elements/internal/CallExprBaseImpl.qll
+++ b/rust/ql/lib/codeql/rust/elements/internal/CallExprBaseImpl.qll
@@ -19,8 +19,8 @@ module Impl {
    * A function or method call expression. See `CallExpr` and `MethodCallExpr` for further details.
    */
   class CallExprBase extends Generated::CallExprBase {
-    /** Gets the static target of this call, if any. */
-    final Function getStaticTarget() { result = TypeInference::resolveCallTarget(this) }
+    /** Gets the static target (function or tuple struct/variant) of this call, if any. */
+    final Addressable getStaticTarget() { result = TypeInference::resolveCallTarget(this) }
 
     override Expr getArg(int index) { result = this.getArgList().getArg(index) }
   }

--- a/rust/ql/lib/codeql/rust/elements/internal/MethodCallExprImpl.qll
+++ b/rust/ql/lib/codeql/rust/elements/internal/MethodCallExprImpl.qll
@@ -38,5 +38,8 @@ module Impl {
     override string toStringImpl() {
       result = strictconcat(int i | | this.toStringPart(i) order by i)
     }
+
+    /** Gets the static target of this method call, if any. */
+    final Function getStaticTarget() { result = super.getStaticTarget() }
   }
 }

--- a/rust/ql/lib/codeql/rust/frameworks/rustcrypto/RustCrypto.qll
+++ b/rust/ql/lib/codeql/rust/frameworks/rustcrypto/RustCrypto.qll
@@ -26,7 +26,7 @@ class StreamCipherInit extends Cryptography::CryptographicOperation::Range {
     // `cipher::KeyIvInit::new`, `cipher::KeyIvInit::new_from_slices`, `rc2::Rc2::new_with_eff_key_len` or similar.
     exists(CallExprBase ce, string rawAlgorithmName |
       ce = this.asExpr().getExpr() and
-      ce.getStaticTarget().getName().getText() =
+      ce.getStaticTarget().(Function).getName().getText() =
         ["new", "new_from_slice", "new_with_eff_key_len", "new_from_slices"] and
       // extract the algorithm name from the type of `ce` or its receiver.
       exists(Type t, TypePath tp |

--- a/rust/ql/lib/codeql/rust/internal/TypeInference.qll
+++ b/rust/ql/lib/codeql/rust/internal/TypeInference.qll
@@ -2505,9 +2505,9 @@ private module Cached {
     )
   }
 
-  /** Gets a function that `call` resolves to, if any. */
+  /** Gets an item (function or tuple struct/variant) that `call` resolves to, if any. */
   cached
-  Function resolveCallTarget(Call call) {
+  Addressable resolveCallTarget(Call call) {
     result = resolveMethodCallTarget(call)
     or
     result = resolveFunctionCallTarget(call)

--- a/rust/ql/test/library-tests/definitions/Definitions.expected
+++ b/rust/ql/test/library-tests/definitions/Definitions.expected
@@ -7,6 +7,7 @@
 | main.rs:18:16:18:16 | T | main.rs:18:10:18:10 | T | path |
 | main.rs:19:23:19:23 | T | main.rs:18:10:18:10 | T | path |
 | main.rs:19:29:19:32 | Self | main.rs:16:5:16:24 | struct S2 | path |
+| main.rs:20:13:20:14 | S2 | main.rs:16:5:16:24 | struct S2 | path |
 | main.rs:20:16:20:16 | x | main.rs:19:20:19:20 | x | local variable |
 | main.rs:29:5:29:11 | println | {EXTERNAL LOCATION} | MacroRules | path |
 | main.rs:29:22:29:26 | value | main.rs:29:50:29:54 | value | format argument |


### PR DESCRIPTION
This change means we now measure call resolution rates correctly. [DCA](https://github.com/github/codeql-dca-main/issues/32129) confirms with an increased call resolution rate from `62.5 %` to `74.85 %`.