### PR TITLE
Go: Try `exclude-paths` for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,8 @@ updates:
     allow:
       - dependency-name: "golang.org/x/mod"
       - dependency-name: "golang.org/x/tools"
+    exclude-paths:
+      - "go/ql/**"
     groups:
       extractor-dependencies:
         patterns:


### PR DESCRIPTION
The second `gomod` configuration we had in `dependabot.yml` was intended to exclude all test dependencies, but never really worked because the Dependabot PRs we got for them were security updates that have to be disabled in the repository settings for the test directories instead.

We are still occasionally seeing [nuisance PRs from Dependabot for dependencies of test projects](https://github.com/github/codeql/pull/20608), so this PR changes the Dependabot configuration in the repo to use the `exclude-paths` to see if that helps. If not, we'll likely need to make some more adjustments in the repo settings.