### PR TITLE
C#: Improve log messages in `DotNetCliInvoker`

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DotNetCliInvoker.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DotNetCliInvoker.cs
@@ -44,7 +44,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             // Configure the proxy settings, if applicable.
             if (this.proxy != null)
             {
-                logger.LogInfo($"Setting up Dependabot proxy at {this.proxy.Address}");
+                logger.LogDebug($"Configuring environment variables for the Dependabot proxy at {this.proxy.Address}");
 
                 startInfo.EnvironmentVariables["HTTP_PROXY"] = this.proxy.Address;
                 startInfo.EnvironmentVariables["HTTPS_PROXY"] = this.proxy.Address;
@@ -57,11 +57,11 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         private bool RunCommandAux(string args, string? workingDirectory, out IList<string> output, bool silent)
         {
             var dirLog = string.IsNullOrWhiteSpace(workingDirectory) ? "" : $" in {workingDirectory}";
-            logger.LogInfo($"Running '{Exec} {args}'{dirLog}");
             var pi = MakeDotnetStartInfo(args, workingDirectory);
             var threadId = Environment.CurrentManagedThreadId;
             void onOut(string s) => logger.Log(silent ? Severity.Debug : Severity.Info, s, threadId);
             void onError(string s) => logger.LogError(s, threadId);
+            logger.LogInfo($"Running '{Exec} {args}'{dirLog}");
             var exitCode = pi.ReadOutput(out output, onOut, onError);
             if (exitCode != 0)
             {


### PR DESCRIPTION
Currently, the "Setting up Dependabot proxy at ${address}" log message (if applicable) follows the one for "Running '${command}'", which can be confusing if the command takes a long time to run, because the last message was "Setting up Dependabot proxy" and it looks like that is taking a long time.

This PR makes two changes to these messages:

- It moves the "Running '${command}'" message to only get logged right before the command is actually run.
- The "Setting up Dependabot proxy at ${address}" message is changed to be clearer about what it does to avoid giving the impression that the proxy is being initialised, rather than us just setting some environment variables for a `dotnet` process.