### PR TITLE
Python: Fix `ImportError` in `imp.py` under Python 3.14

### DIFF
--- a/python/extractor/imp.py
+++ b/python/extractor/imp.py
@@ -17,8 +17,15 @@ except ImportError:
     # Platform doesn't support dynamic loading.
     create_dynamic = None
 
-from importlib._bootstrap import _ERR_MSG, _exec, _load, _builtin_from_name
+from importlib._bootstrap import _exec, _load, _builtin_from_name
 from importlib._bootstrap_external import SourcelessFileLoader
+
+# In Python 3.14, `_ERR_MSG` was removed in favor of `_ERR_MSG_PREFIX`.
+try:
+    from importlib._bootstrap import _ERR_MSG
+except ImportError:
+    from importlib._bootstrap import _ERR_MSG_PREFIX
+    _ERR_MSG = _ERR_MSG_PREFIX + '{name!r}'
 
 from importlib import machinery
 from importlib import util

--- a/python/extractor/semmle/util.py
+++ b/python/extractor/semmle/util.py
@@ -10,7 +10,7 @@ from io import BytesIO
 
 #Semantic version of extractor.
 #Update this if any changes are made
-VERSION = "7.1.4"
+VERSION = "7.1.5"
 
 PY_EXTENSIONS = ".py", ".pyw"
 

--- a/python/ql/lib/change-notes/2025-10-13-fix-importerror-on-python-3.14.md
+++ b/python/ql/lib/change-notes/2025-10-13-fix-importerror-on-python-3.14.md
@@ -1,0 +1,4 @@
+---
+category: fix
+---
+* The Python extractor no longer crashes with an `ImportError` when run using Python 3.14.


### PR DESCRIPTION
It seems `_ERR_MSG` was silently removed in Python 3.14, leading to an `ImportError` when running the extractor.

To fix this, we explicitly set `_ERR_MSG` when the existing import fails (using `_ERR_MSG_PREFIX` which is available in Python 3.14+, along with the bits that make up the difference between this and `_ERR_MSG`).