### PR TITLE
JS: remove quality tag from SyntaxError query

### DIFF
--- a/javascript/ql/integration-tests/query-suite/javascript-code-quality-extended.qls.expected
+++ b/javascript/ql/integration-tests/query-suite/javascript-code-quality-extended.qls.expected
@@ -71,7 +71,6 @@ ql/javascript/ql/src/LanguageFeatures/SemicolonInsertion.ql
 ql/javascript/ql/src/LanguageFeatures/SetterReturn.ql
 ql/javascript/ql/src/LanguageFeatures/SpuriousArguments.ql
 ql/javascript/ql/src/LanguageFeatures/StrictModeCallStackIntrospection.ql
-ql/javascript/ql/src/LanguageFeatures/SyntaxError.ql
 ql/javascript/ql/src/LanguageFeatures/TemplateSyntaxInStringLiteral.ql
 ql/javascript/ql/src/LanguageFeatures/ThisBeforeSuper.ql
 ql/javascript/ql/src/LanguageFeatures/UnusedIndexVariable.ql

--- a/javascript/ql/integration-tests/query-suite/javascript-code-quality.qls.expected
+++ b/javascript/ql/integration-tests/query-suite/javascript-code-quality.qls.expected
@@ -63,7 +63,6 @@ ql/javascript/ql/src/LanguageFeatures/SemicolonInsertion.ql
 ql/javascript/ql/src/LanguageFeatures/SetterReturn.ql
 ql/javascript/ql/src/LanguageFeatures/SpuriousArguments.ql
 ql/javascript/ql/src/LanguageFeatures/StrictModeCallStackIntrospection.ql
-ql/javascript/ql/src/LanguageFeatures/SyntaxError.ql
 ql/javascript/ql/src/LanguageFeatures/TemplateSyntaxInStringLiteral.ql
 ql/javascript/ql/src/LanguageFeatures/ThisBeforeSuper.ql
 ql/javascript/ql/src/LanguageFeatures/UnusedIndexVariable.ql

--- a/javascript/ql/src/LanguageFeatures/SyntaxError.ql
+++ b/javascript/ql/src/LanguageFeatures/SyntaxError.ql
@@ -4,8 +4,7 @@
  * @kind problem
  * @problem.severity recommendation
  * @id js/syntax-error
- * @tags quality
- *       reliability
+ * @tags reliability
  *       correctness
  *       language-features
  * @precision very-high


### PR DESCRIPTION
Removes the SyntaxError query from the `quality` and `quality-extended` suites, while it remains in the `security-and-quality` suite.