### PR TITLE
Rust: Improve macro call stats in DatabaseQualityDiagnostics

### DIFF
--- a/rust/ql/src/queries/telemetry/DatabaseQuality.qll
+++ b/rust/ql/src/queries/telemetry/DatabaseQuality.qll
@@ -30,9 +30,9 @@ module CallTargetStats implements StatsSig {
 }
 
 module MacroCallTargetStats implements StatsSig {
-  int getNumberOfOk() { result = count(MacroCall c | c.hasMacroCallExpansion()) }
+  int getNumberOfOk() { result = count(MacroCall c | c.fromSource() and c.hasMacroCallExpansion()) }
 
-  additional predicate isNotOkCall(MacroCall c) { not c.hasMacroCallExpansion() }
+  additional predicate isNotOkCall(MacroCall c) { c.fromSource() and not c.hasMacroCallExpansion() }
 
   int getNumberOfNotOk() { result = count(MacroCall c | isNotOkCall(c)) }
 


### PR DESCRIPTION
Restrict the macro call stats in `DatabaseQualityDiagnostics` (used on the tool status page) to consider only macros in extracted files (`.fromSource()`).  This focusses the metric on the user code for analysis, and is already the way we measure this in `rust/diagnostics/unresolved-macro-calls` and `rust/summary/summary-statistics`.

In the MRVA-1000, this change will reduce the number of projects with warnings about macro resolution on the tool status page from 30 to 16 (21 fixed, 9 unfixed, 7 newly failing), and significantly improves the margin of success in many more projects where we don't believe there is a real problem.