### PR TITLE
JS: Remove two invalid QHelp links

### DIFF
--- a/javascript/ql/src/Expressions/ExprHasNoEffect.qhelp
+++ b/javascript/ql/src/Expressions/ExprHasNoEffect.qhelp
@@ -51,10 +51,4 @@ assign it an initial value, which also serves to document its expected type:
 <sample src="examples/ExprHasNoEffect-PseudoDeclGood.js"/>
 
 </example>
-<references>
-
-<li>JSLint Error Explanations: <a href="http://jslinterrors.com/expected-an-assignment-or-function-call">Expected an assignment or function call</a>.</li>
-
-
-</references>
 </qhelp>

--- a/javascript/ql/src/LanguageFeatures/DeleteVar.qhelp
+++ b/javascript/ql/src/LanguageFeatures/DeleteVar.qhelp
@@ -35,11 +35,4 @@ function <code>compute</code> to the outside world):
 <sample src="examples/DeleteVarGood.js" />
 
 </example>
-<references>
-
-
-<li>JSLint Error Explanations: <a href="http://jslinterrors.com/only-properties-should-be-deleted">Only properties should be deleted</a>.</li>
-
-
-</references>
 </qhelp>


### PR DESCRIPTION
Thanks to @mysteq for pointing out [here](https://github.com/github/codeql/issues/20685).