### PR TITLE
Rust: Improve handling of `Self` type parameter

### DIFF
--- a/rust/ql/test/library-tests/type-inference/CONSISTENCY/PathResolutionConsistency.expected
+++ b/rust/ql/test/library-tests/type-inference/CONSISTENCY/PathResolutionConsistency.expected
@@ -5,9 +5,9 @@ multipleCallTargets
 | dereference.rs:184:17:184:30 | ... .foo() |
 | dereference.rs:186:17:186:25 | S.bar(...) |
 | dereference.rs:187:17:187:29 | S.bar(...) |
+| main.rs:2481:13:2481:31 | ...::from(...) |
 | main.rs:2482:13:2482:31 | ...::from(...) |
 | main.rs:2483:13:2483:31 | ...::from(...) |
-| main.rs:2484:13:2484:31 | ...::from(...) |
+| main.rs:2489:13:2489:31 | ...::from(...) |
 | main.rs:2490:13:2490:31 | ...::from(...) |
 | main.rs:2491:13:2491:31 | ...::from(...) |
-| main.rs:2492:13:2492:31 | ...::from(...) |

--- a/rust/ql/test/library-tests/type-inference/main.rs
+++ b/rust/ql/test/library-tests/type-inference/main.rs
@@ -654,7 +654,6 @@ mod type_parameter_bounds {
 
 mod trait_default_self_type_parameter {
     // A trait with a type parameter that defaults to `Self`.
-    // trait TraitWithSelfTp<A = Self> {
     trait TraitWithSelfTp<A = Option<Self>> {
         // TraitWithSelfTp::get_a
         fn get_a(&self) -> A;

--- a/rust/ql/test/library-tests/type-inference/type-inference.expected
+++ b/rust/ql/test/library-tests/type-inference/type-inference.expected
@@ -2002,3246 +2002,3265 @@ inferType
 | main.rs:651:18:651:37 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
 | main.rs:651:32:651:33 | s1 |  | {EXTERNAL LOCATION} | u8 |
 | main.rs:651:36:651:37 | s2 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:660:18:660:22 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:660:18:660:22 | SelfParam | &T | main.rs:656:5:661:5 | Self [trait TraitWithSelfTp] |
-| main.rs:663:40:663:44 | thing |  | file://:0:0:0:0 | & |
-| main.rs:663:40:663:44 | thing | &T | main.rs:663:17:663:37 | T |
-| main.rs:663:56:665:5 | { ... } |  | main.rs:663:14:663:14 | A |
-| main.rs:664:9:664:13 | thing |  | file://:0:0:0:0 | & |
-| main.rs:664:9:664:13 | thing | &T | main.rs:663:17:663:37 | T |
-| main.rs:664:9:664:21 | thing.get_a() |  | main.rs:663:14:663:14 | A |
-| main.rs:668:44:668:48 | thing |  | main.rs:668:24:668:41 | S |
-| main.rs:668:61:671:5 | { ... } |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:669:13:669:15 | _ms |  | {EXTERNAL LOCATION} | Option |
-| main.rs:669:13:669:15 | _ms | T | main.rs:668:24:668:41 | S |
-| main.rs:669:19:669:23 | thing |  | main.rs:668:24:668:41 | S |
-| main.rs:669:19:669:31 | thing.get_a() |  | {EXTERNAL LOCATION} | Option |
-| main.rs:669:19:669:31 | thing.get_a() | T | main.rs:668:24:668:41 | S |
-| main.rs:670:9:670:9 | 0 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:670:9:670:9 | 0 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:676:55:676:59 | thing |  | file://:0:0:0:0 | & |
-| main.rs:676:55:676:59 | thing | &T | main.rs:676:25:676:52 | S |
-| main.rs:678:13:678:15 | _ms |  | {EXTERNAL LOCATION} | Option |
-| main.rs:678:13:678:15 | _ms | T | main.rs:676:25:676:52 | S |
-| main.rs:678:19:678:30 | get_a(...) |  | {EXTERNAL LOCATION} | Option |
-| main.rs:678:19:678:30 | get_a(...) | T | main.rs:676:25:676:52 | S |
-| main.rs:678:25:678:29 | thing |  | file://:0:0:0:0 | & |
-| main.rs:678:25:678:29 | thing | &T | main.rs:676:25:676:52 | S |
-| main.rs:687:18:687:22 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:687:18:687:22 | SelfParam | &T | main.rs:681:5:683:5 | MyStruct |
-| main.rs:687:41:689:9 | { ... } |  | {EXTERNAL LOCATION} | Option |
-| main.rs:687:41:689:9 | { ... } | T | main.rs:681:5:683:5 | MyStruct |
-| main.rs:688:13:688:48 | Some(...) |  | {EXTERNAL LOCATION} | Option |
-| main.rs:688:13:688:48 | Some(...) | T | main.rs:681:5:683:5 | MyStruct |
-| main.rs:688:18:688:47 | MyStruct {...} |  | main.rs:681:5:683:5 | MyStruct |
-| main.rs:688:36:688:39 | self |  | file://:0:0:0:0 | & |
-| main.rs:688:36:688:39 | self | &T | main.rs:681:5:683:5 | MyStruct |
-| main.rs:688:36:688:45 | self.value |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:695:13:695:13 | s |  | main.rs:681:5:683:5 | MyStruct |
-| main.rs:695:17:695:37 | MyStruct {...} |  | main.rs:681:5:683:5 | MyStruct |
-| main.rs:695:35:695:35 | 0 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:696:13:696:15 | _ms |  | {EXTERNAL LOCATION} | Option |
-| main.rs:696:13:696:15 | _ms | T | main.rs:681:5:683:5 | MyStruct |
-| main.rs:696:19:696:27 | get_a(...) |  | {EXTERNAL LOCATION} | Option |
-| main.rs:696:19:696:27 | get_a(...) | T | main.rs:681:5:683:5 | MyStruct |
-| main.rs:696:25:696:26 | &s |  | file://:0:0:0:0 | & |
-| main.rs:696:25:696:26 | &s | &T | main.rs:681:5:683:5 | MyStruct |
-| main.rs:696:26:696:26 | s |  | main.rs:681:5:683:5 | MyStruct |
-| main.rs:712:15:712:18 | SelfParam |  | main.rs:711:5:722:5 | Self [trait MyTrait] |
-| main.rs:714:15:714:18 | SelfParam |  | main.rs:711:5:722:5 | Self [trait MyTrait] |
-| main.rs:717:9:719:9 | { ... } |  | main.rs:711:19:711:19 | A |
-| main.rs:718:13:718:16 | self |  | main.rs:711:5:722:5 | Self [trait MyTrait] |
-| main.rs:718:13:718:21 | self.m1() |  | main.rs:711:19:711:19 | A |
-| main.rs:721:18:721:18 | x |  | main.rs:711:5:722:5 | Self [trait MyTrait] |
-| main.rs:726:50:726:50 | x |  | main.rs:726:26:726:47 | T2 |
-| main.rs:726:63:729:5 | { ... } |  | main.rs:726:22:726:23 | T1 |
-| main.rs:727:9:727:9 | x |  | main.rs:726:26:726:47 | T2 |
-| main.rs:727:9:727:14 | x.m1() |  | main.rs:726:22:726:23 | T1 |
-| main.rs:728:9:728:9 | x |  | main.rs:726:26:726:47 | T2 |
-| main.rs:728:9:728:14 | x.m1() |  | main.rs:726:22:726:23 | T1 |
-| main.rs:730:52:730:52 | x |  | main.rs:730:28:730:49 | T2 |
-| main.rs:730:65:734:5 | { ... } |  | main.rs:730:24:730:25 | T1 |
-| main.rs:731:13:731:13 | y |  | main.rs:730:24:730:25 | T1 |
-| main.rs:731:17:731:25 | ...::m1(...) |  | main.rs:730:24:730:25 | T1 |
-| main.rs:731:24:731:24 | x |  | main.rs:730:28:730:49 | T2 |
-| main.rs:732:9:732:9 | y |  | main.rs:730:24:730:25 | T1 |
-| main.rs:733:9:733:17 | ...::m1(...) |  | main.rs:730:24:730:25 | T1 |
-| main.rs:733:16:733:16 | x |  | main.rs:730:28:730:49 | T2 |
-| main.rs:735:52:735:52 | x |  | main.rs:735:28:735:49 | T2 |
-| main.rs:735:65:739:5 | { ... } |  | main.rs:735:24:735:25 | T1 |
-| main.rs:736:13:736:13 | y |  | main.rs:735:24:735:25 | T1 |
-| main.rs:736:17:736:30 | ...::m1(...) |  | main.rs:735:24:735:25 | T1 |
-| main.rs:736:29:736:29 | x |  | main.rs:735:28:735:49 | T2 |
-| main.rs:737:9:737:9 | y |  | main.rs:735:24:735:25 | T1 |
-| main.rs:738:9:738:22 | ...::m1(...) |  | main.rs:735:24:735:25 | T1 |
-| main.rs:738:21:738:21 | x |  | main.rs:735:28:735:49 | T2 |
-| main.rs:740:55:740:55 | x |  | main.rs:740:31:740:52 | T2 |
-| main.rs:740:68:744:5 | { ... } |  | main.rs:740:27:740:28 | T1 |
-| main.rs:741:13:741:13 | y |  | main.rs:740:27:740:28 | T1 |
-| main.rs:741:17:741:28 | ...::assoc(...) |  | main.rs:740:27:740:28 | T1 |
-| main.rs:741:27:741:27 | x |  | main.rs:740:31:740:52 | T2 |
-| main.rs:742:9:742:9 | y |  | main.rs:740:27:740:28 | T1 |
-| main.rs:743:9:743:20 | ...::assoc(...) |  | main.rs:740:27:740:28 | T1 |
-| main.rs:743:19:743:19 | x |  | main.rs:740:31:740:52 | T2 |
-| main.rs:745:55:745:55 | x |  | main.rs:745:31:745:52 | T2 |
-| main.rs:745:68:749:5 | { ... } |  | main.rs:745:27:745:28 | T1 |
-| main.rs:746:13:746:13 | y |  | main.rs:745:27:745:28 | T1 |
-| main.rs:746:17:746:33 | ...::assoc(...) |  | main.rs:745:27:745:28 | T1 |
-| main.rs:746:32:746:32 | x |  | main.rs:745:31:745:52 | T2 |
-| main.rs:747:9:747:9 | y |  | main.rs:745:27:745:28 | T1 |
-| main.rs:748:9:748:25 | ...::assoc(...) |  | main.rs:745:27:745:28 | T1 |
-| main.rs:748:24:748:24 | x |  | main.rs:745:31:745:52 | T2 |
-| main.rs:753:49:753:49 | x |  | main.rs:701:5:704:5 | MyThing |
-| main.rs:753:49:753:49 | x | T | main.rs:753:32:753:46 | T2 |
-| main.rs:753:71:755:5 | { ... } |  | main.rs:753:28:753:29 | T1 |
-| main.rs:754:9:754:9 | x |  | main.rs:701:5:704:5 | MyThing |
-| main.rs:754:9:754:9 | x | T | main.rs:753:32:753:46 | T2 |
-| main.rs:754:9:754:11 | x.a |  | main.rs:753:32:753:46 | T2 |
-| main.rs:754:9:754:16 | ... .m1() |  | main.rs:753:28:753:29 | T1 |
-| main.rs:756:51:756:51 | x |  | main.rs:701:5:704:5 | MyThing |
-| main.rs:756:51:756:51 | x | T | main.rs:756:34:756:48 | T2 |
-| main.rs:756:73:758:5 | { ... } |  | main.rs:756:30:756:31 | T1 |
-| main.rs:757:9:757:19 | ...::m1(...) |  | main.rs:756:30:756:31 | T1 |
-| main.rs:757:16:757:16 | x |  | main.rs:701:5:704:5 | MyThing |
-| main.rs:757:16:757:16 | x | T | main.rs:756:34:756:48 | T2 |
-| main.rs:757:16:757:18 | x.a |  | main.rs:756:34:756:48 | T2 |
-| main.rs:759:51:759:51 | x |  | main.rs:701:5:704:5 | MyThing |
-| main.rs:759:51:759:51 | x | T | main.rs:759:34:759:48 | T2 |
-| main.rs:759:73:761:5 | { ... } |  | main.rs:759:30:759:31 | T1 |
-| main.rs:760:9:760:24 | ...::m1(...) |  | main.rs:759:30:759:31 | T1 |
-| main.rs:760:21:760:21 | x |  | main.rs:701:5:704:5 | MyThing |
-| main.rs:760:21:760:21 | x | T | main.rs:759:34:759:48 | T2 |
-| main.rs:760:21:760:23 | x.a |  | main.rs:759:34:759:48 | T2 |
-| main.rs:764:15:764:18 | SelfParam |  | main.rs:701:5:704:5 | MyThing |
-| main.rs:764:15:764:18 | SelfParam | T | main.rs:763:10:763:10 | T |
-| main.rs:764:26:766:9 | { ... } |  | main.rs:763:10:763:10 | T |
-| main.rs:765:13:765:16 | self |  | main.rs:701:5:704:5 | MyThing |
-| main.rs:765:13:765:16 | self | T | main.rs:763:10:763:10 | T |
-| main.rs:765:13:765:18 | self.a |  | main.rs:763:10:763:10 | T |
-| main.rs:768:18:768:18 | x |  | main.rs:701:5:704:5 | MyThing |
-| main.rs:768:18:768:18 | x | T | main.rs:763:10:763:10 | T |
-| main.rs:768:32:770:9 | { ... } |  | main.rs:763:10:763:10 | T |
-| main.rs:769:13:769:13 | x |  | main.rs:701:5:704:5 | MyThing |
-| main.rs:769:13:769:13 | x | T | main.rs:763:10:763:10 | T |
-| main.rs:769:13:769:15 | x.a |  | main.rs:763:10:763:10 | T |
-| main.rs:774:13:774:13 | x |  | main.rs:701:5:704:5 | MyThing |
-| main.rs:774:13:774:13 | x | T | main.rs:706:5:707:14 | S1 |
-| main.rs:774:17:774:33 | MyThing {...} |  | main.rs:701:5:704:5 | MyThing |
-| main.rs:774:17:774:33 | MyThing {...} | T | main.rs:706:5:707:14 | S1 |
-| main.rs:774:30:774:31 | S1 |  | main.rs:706:5:707:14 | S1 |
-| main.rs:775:13:775:13 | y |  | main.rs:701:5:704:5 | MyThing |
-| main.rs:775:13:775:13 | y | T | main.rs:708:5:709:14 | S2 |
-| main.rs:775:17:775:33 | MyThing {...} |  | main.rs:701:5:704:5 | MyThing |
-| main.rs:775:17:775:33 | MyThing {...} | T | main.rs:708:5:709:14 | S2 |
-| main.rs:775:30:775:31 | S2 |  | main.rs:708:5:709:14 | S2 |
+| main.rs:659:18:659:22 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:659:18:659:22 | SelfParam | &T | main.rs:656:5:660:5 | Self [trait TraitWithSelfTp] |
+| main.rs:662:40:662:44 | thing |  | file://:0:0:0:0 | & |
+| main.rs:662:40:662:44 | thing | &T | main.rs:662:17:662:37 | T |
+| main.rs:662:56:664:5 | { ... } |  | main.rs:662:14:662:14 | A |
+| main.rs:663:9:663:13 | thing |  | file://:0:0:0:0 | & |
+| main.rs:663:9:663:13 | thing | &T | main.rs:662:17:662:37 | T |
+| main.rs:663:9:663:21 | thing.get_a() |  | main.rs:662:14:662:14 | A |
+| main.rs:667:44:667:48 | thing |  | main.rs:667:24:667:41 | S |
+| main.rs:667:61:670:5 | { ... } |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:668:13:668:15 | _ms |  | {EXTERNAL LOCATION} | Option |
+| main.rs:668:13:668:15 | _ms | T | main.rs:667:24:667:41 | S |
+| main.rs:668:19:668:23 | thing |  | main.rs:667:24:667:41 | S |
+| main.rs:668:19:668:31 | thing.get_a() |  | {EXTERNAL LOCATION} | Option |
+| main.rs:668:19:668:31 | thing.get_a() | T | main.rs:667:24:667:41 | S |
+| main.rs:669:9:669:9 | 0 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:669:9:669:9 | 0 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:675:55:675:59 | thing |  | file://:0:0:0:0 | & |
+| main.rs:675:55:675:59 | thing | &T | main.rs:675:25:675:52 | S |
+| main.rs:677:13:677:15 | _ms |  | {EXTERNAL LOCATION} | Option |
+| main.rs:677:13:677:15 | _ms | T | main.rs:675:25:675:52 | S |
+| main.rs:677:19:677:30 | get_a(...) |  | {EXTERNAL LOCATION} | Option |
+| main.rs:677:19:677:30 | get_a(...) | T | main.rs:675:25:675:52 | S |
+| main.rs:677:25:677:29 | thing |  | file://:0:0:0:0 | & |
+| main.rs:677:25:677:29 | thing | &T | main.rs:675:25:675:52 | S |
+| main.rs:686:18:686:22 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:686:18:686:22 | SelfParam | &T | main.rs:680:5:682:5 | MyStruct |
+| main.rs:686:41:688:9 | { ... } |  | {EXTERNAL LOCATION} | Option |
+| main.rs:686:41:688:9 | { ... } | T | main.rs:680:5:682:5 | MyStruct |
+| main.rs:687:13:687:48 | Some(...) |  | {EXTERNAL LOCATION} | Option |
+| main.rs:687:13:687:48 | Some(...) | T | main.rs:680:5:682:5 | MyStruct |
+| main.rs:687:18:687:47 | MyStruct {...} |  | main.rs:680:5:682:5 | MyStruct |
+| main.rs:687:36:687:39 | self |  | file://:0:0:0:0 | & |
+| main.rs:687:36:687:39 | self | &T | main.rs:680:5:682:5 | MyStruct |
+| main.rs:687:36:687:45 | self.value |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:694:13:694:13 | s |  | main.rs:680:5:682:5 | MyStruct |
+| main.rs:694:17:694:37 | MyStruct {...} |  | main.rs:680:5:682:5 | MyStruct |
+| main.rs:694:35:694:35 | 0 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:695:13:695:15 | _ms |  | {EXTERNAL LOCATION} | Option |
+| main.rs:695:13:695:15 | _ms | T | main.rs:680:5:682:5 | MyStruct |
+| main.rs:695:19:695:27 | get_a(...) |  | {EXTERNAL LOCATION} | Option |
+| main.rs:695:19:695:27 | get_a(...) | T | main.rs:680:5:682:5 | MyStruct |
+| main.rs:695:25:695:26 | &s |  | file://:0:0:0:0 | & |
+| main.rs:695:25:695:26 | &s | &T | main.rs:680:5:682:5 | MyStruct |
+| main.rs:695:26:695:26 | s |  | main.rs:680:5:682:5 | MyStruct |
+| main.rs:711:15:711:18 | SelfParam |  | main.rs:710:5:721:5 | Self [trait MyTrait] |
+| main.rs:713:15:713:18 | SelfParam |  | main.rs:710:5:721:5 | Self [trait MyTrait] |
+| main.rs:716:9:718:9 | { ... } |  | main.rs:710:19:710:19 | A |
+| main.rs:717:13:717:16 | self |  | main.rs:710:5:721:5 | Self [trait MyTrait] |
+| main.rs:717:13:717:21 | self.m1() |  | main.rs:710:19:710:19 | A |
+| main.rs:720:18:720:18 | x |  | main.rs:710:5:721:5 | Self [trait MyTrait] |
+| main.rs:725:50:725:50 | x |  | main.rs:725:26:725:47 | T2 |
+| main.rs:725:63:728:5 | { ... } |  | main.rs:725:22:725:23 | T1 |
+| main.rs:726:9:726:9 | x |  | main.rs:725:26:725:47 | T2 |
+| main.rs:726:9:726:14 | x.m1() |  | main.rs:725:22:725:23 | T1 |
+| main.rs:727:9:727:9 | x |  | main.rs:725:26:725:47 | T2 |
+| main.rs:727:9:727:14 | x.m1() |  | main.rs:725:22:725:23 | T1 |
+| main.rs:729:52:729:52 | x |  | main.rs:729:28:729:49 | T2 |
+| main.rs:729:65:733:5 | { ... } |  | main.rs:729:24:729:25 | T1 |
+| main.rs:730:13:730:13 | y |  | main.rs:729:24:729:25 | T1 |
+| main.rs:730:17:730:25 | ...::m1(...) |  | main.rs:729:24:729:25 | T1 |
+| main.rs:730:24:730:24 | x |  | main.rs:729:28:729:49 | T2 |
+| main.rs:731:9:731:9 | y |  | main.rs:729:24:729:25 | T1 |
+| main.rs:732:9:732:17 | ...::m1(...) |  | main.rs:729:24:729:25 | T1 |
+| main.rs:732:16:732:16 | x |  | main.rs:729:28:729:49 | T2 |
+| main.rs:734:52:734:52 | x |  | main.rs:734:28:734:49 | T2 |
+| main.rs:734:65:738:5 | { ... } |  | main.rs:734:24:734:25 | T1 |
+| main.rs:735:13:735:13 | y |  | main.rs:734:24:734:25 | T1 |
+| main.rs:735:17:735:30 | ...::m1(...) |  | main.rs:734:24:734:25 | T1 |
+| main.rs:735:29:735:29 | x |  | main.rs:734:28:734:49 | T2 |
+| main.rs:736:9:736:9 | y |  | main.rs:734:24:734:25 | T1 |
+| main.rs:737:9:737:22 | ...::m1(...) |  | main.rs:734:24:734:25 | T1 |
+| main.rs:737:21:737:21 | x |  | main.rs:734:28:734:49 | T2 |
+| main.rs:739:55:739:55 | x |  | main.rs:739:31:739:52 | T2 |
+| main.rs:739:68:743:5 | { ... } |  | main.rs:739:27:739:28 | T1 |
+| main.rs:740:13:740:13 | y |  | main.rs:739:27:739:28 | T1 |
+| main.rs:740:17:740:28 | ...::assoc(...) |  | main.rs:739:27:739:28 | T1 |
+| main.rs:740:27:740:27 | x |  | main.rs:739:31:739:52 | T2 |
+| main.rs:741:9:741:9 | y |  | main.rs:739:27:739:28 | T1 |
+| main.rs:742:9:742:20 | ...::assoc(...) |  | main.rs:739:27:739:28 | T1 |
+| main.rs:742:19:742:19 | x |  | main.rs:739:31:739:52 | T2 |
+| main.rs:744:55:744:55 | x |  | main.rs:744:31:744:52 | T2 |
+| main.rs:744:68:748:5 | { ... } |  | main.rs:744:27:744:28 | T1 |
+| main.rs:745:13:745:13 | y |  | main.rs:744:27:744:28 | T1 |
+| main.rs:745:17:745:33 | ...::assoc(...) |  | main.rs:744:27:744:28 | T1 |
+| main.rs:745:32:745:32 | x |  | main.rs:744:31:744:52 | T2 |
+| main.rs:746:9:746:9 | y |  | main.rs:744:27:744:28 | T1 |
+| main.rs:747:9:747:25 | ...::assoc(...) |  | main.rs:744:27:744:28 | T1 |
+| main.rs:747:24:747:24 | x |  | main.rs:744:31:744:52 | T2 |
+| main.rs:752:49:752:49 | x |  | main.rs:700:5:703:5 | MyThing |
+| main.rs:752:49:752:49 | x | T | main.rs:752:32:752:46 | T2 |
+| main.rs:752:71:754:5 | { ... } |  | main.rs:752:28:752:29 | T1 |
+| main.rs:753:9:753:9 | x |  | main.rs:700:5:703:5 | MyThing |
+| main.rs:753:9:753:9 | x | T | main.rs:752:32:752:46 | T2 |
+| main.rs:753:9:753:11 | x.a |  | main.rs:752:32:752:46 | T2 |
+| main.rs:753:9:753:16 | ... .m1() |  | main.rs:752:28:752:29 | T1 |
+| main.rs:755:51:755:51 | x |  | main.rs:700:5:703:5 | MyThing |
+| main.rs:755:51:755:51 | x | T | main.rs:755:34:755:48 | T2 |
+| main.rs:755:73:757:5 | { ... } |  | main.rs:755:30:755:31 | T1 |
+| main.rs:756:9:756:19 | ...::m1(...) |  | main.rs:755:30:755:31 | T1 |
+| main.rs:756:16:756:16 | x |  | main.rs:700:5:703:5 | MyThing |
+| main.rs:756:16:756:16 | x | T | main.rs:755:34:755:48 | T2 |
+| main.rs:756:16:756:18 | x.a |  | main.rs:755:34:755:48 | T2 |
+| main.rs:758:51:758:51 | x |  | main.rs:700:5:703:5 | MyThing |
+| main.rs:758:51:758:51 | x | T | main.rs:758:34:758:48 | T2 |
+| main.rs:758:73:760:5 | { ... } |  | main.rs:758:30:758:31 | T1 |
+| main.rs:759:9:759:24 | ...::m1(...) |  | main.rs:758:30:758:31 | T1 |
+| main.rs:759:21:759:21 | x |  | main.rs:700:5:703:5 | MyThing |
+| main.rs:759:21:759:21 | x | T | main.rs:758:34:758:48 | T2 |
+| main.rs:759:21:759:23 | x.a |  | main.rs:758:34:758:48 | T2 |
+| main.rs:763:15:763:18 | SelfParam |  | main.rs:700:5:703:5 | MyThing |
+| main.rs:763:15:763:18 | SelfParam | T | main.rs:762:10:762:10 | T |
+| main.rs:763:26:765:9 | { ... } |  | main.rs:762:10:762:10 | T |
+| main.rs:764:13:764:16 | self |  | main.rs:700:5:703:5 | MyThing |
+| main.rs:764:13:764:16 | self | T | main.rs:762:10:762:10 | T |
+| main.rs:764:13:764:18 | self.a |  | main.rs:762:10:762:10 | T |
+| main.rs:767:18:767:18 | x |  | main.rs:700:5:703:5 | MyThing |
+| main.rs:767:18:767:18 | x | T | main.rs:762:10:762:10 | T |
+| main.rs:767:32:769:9 | { ... } |  | main.rs:762:10:762:10 | T |
+| main.rs:768:13:768:13 | x |  | main.rs:700:5:703:5 | MyThing |
+| main.rs:768:13:768:13 | x | T | main.rs:762:10:762:10 | T |
+| main.rs:768:13:768:15 | x.a |  | main.rs:762:10:762:10 | T |
+| main.rs:773:13:773:13 | x |  | main.rs:700:5:703:5 | MyThing |
+| main.rs:773:13:773:13 | x | T | main.rs:705:5:706:14 | S1 |
+| main.rs:773:17:773:33 | MyThing {...} |  | main.rs:700:5:703:5 | MyThing |
+| main.rs:773:17:773:33 | MyThing {...} | T | main.rs:705:5:706:14 | S1 |
+| main.rs:773:30:773:31 | S1 |  | main.rs:705:5:706:14 | S1 |
+| main.rs:774:13:774:13 | y |  | main.rs:700:5:703:5 | MyThing |
+| main.rs:774:13:774:13 | y | T | main.rs:707:5:708:14 | S2 |
+| main.rs:774:17:774:33 | MyThing {...} |  | main.rs:700:5:703:5 | MyThing |
+| main.rs:774:17:774:33 | MyThing {...} | T | main.rs:707:5:708:14 | S2 |
+| main.rs:774:30:774:31 | S2 |  | main.rs:707:5:708:14 | S2 |
+| main.rs:776:18:776:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:776:18:776:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:776:18:776:31 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:776:18:776:31 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:776:26:776:26 | x |  | main.rs:700:5:703:5 | MyThing |
+| main.rs:776:26:776:26 | x | T | main.rs:705:5:706:14 | S1 |
+| main.rs:776:26:776:31 | x.m1() |  | main.rs:705:5:706:14 | S1 |
 | main.rs:777:18:777:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
 | main.rs:777:18:777:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
 | main.rs:777:18:777:31 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
 | main.rs:777:18:777:31 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:777:26:777:26 | x |  | main.rs:701:5:704:5 | MyThing |
-| main.rs:777:26:777:26 | x | T | main.rs:706:5:707:14 | S1 |
-| main.rs:777:26:777:31 | x.m1() |  | main.rs:706:5:707:14 | S1 |
-| main.rs:778:18:778:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:778:18:778:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:778:18:778:31 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:778:18:778:31 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:778:26:778:26 | y |  | main.rs:701:5:704:5 | MyThing |
-| main.rs:778:26:778:26 | y | T | main.rs:708:5:709:14 | S2 |
-| main.rs:778:26:778:31 | y.m1() |  | main.rs:708:5:709:14 | S2 |
-| main.rs:780:13:780:13 | x |  | main.rs:701:5:704:5 | MyThing |
-| main.rs:780:13:780:13 | x | T | main.rs:706:5:707:14 | S1 |
-| main.rs:780:17:780:33 | MyThing {...} |  | main.rs:701:5:704:5 | MyThing |
-| main.rs:780:17:780:33 | MyThing {...} | T | main.rs:706:5:707:14 | S1 |
-| main.rs:780:30:780:31 | S1 |  | main.rs:706:5:707:14 | S1 |
-| main.rs:781:13:781:13 | y |  | main.rs:701:5:704:5 | MyThing |
-| main.rs:781:13:781:13 | y | T | main.rs:708:5:709:14 | S2 |
-| main.rs:781:17:781:33 | MyThing {...} |  | main.rs:701:5:704:5 | MyThing |
-| main.rs:781:17:781:33 | MyThing {...} | T | main.rs:708:5:709:14 | S2 |
-| main.rs:781:30:781:31 | S2 |  | main.rs:708:5:709:14 | S2 |
+| main.rs:777:26:777:26 | y |  | main.rs:700:5:703:5 | MyThing |
+| main.rs:777:26:777:26 | y | T | main.rs:707:5:708:14 | S2 |
+| main.rs:777:26:777:31 | y.m1() |  | main.rs:707:5:708:14 | S2 |
+| main.rs:779:13:779:13 | x |  | main.rs:700:5:703:5 | MyThing |
+| main.rs:779:13:779:13 | x | T | main.rs:705:5:706:14 | S1 |
+| main.rs:779:17:779:33 | MyThing {...} |  | main.rs:700:5:703:5 | MyThing |
+| main.rs:779:17:779:33 | MyThing {...} | T | main.rs:705:5:706:14 | S1 |
+| main.rs:779:30:779:31 | S1 |  | main.rs:705:5:706:14 | S1 |
+| main.rs:780:13:780:13 | y |  | main.rs:700:5:703:5 | MyThing |
+| main.rs:780:13:780:13 | y | T | main.rs:707:5:708:14 | S2 |
+| main.rs:780:17:780:33 | MyThing {...} |  | main.rs:700:5:703:5 | MyThing |
+| main.rs:780:17:780:33 | MyThing {...} | T | main.rs:707:5:708:14 | S2 |
+| main.rs:780:30:780:31 | S2 |  | main.rs:707:5:708:14 | S2 |
+| main.rs:782:18:782:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:782:18:782:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:782:18:782:31 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:782:18:782:31 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:782:26:782:26 | x |  | main.rs:700:5:703:5 | MyThing |
+| main.rs:782:26:782:26 | x | T | main.rs:705:5:706:14 | S1 |
+| main.rs:782:26:782:31 | x.m2() |  | main.rs:705:5:706:14 | S1 |
 | main.rs:783:18:783:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
 | main.rs:783:18:783:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
 | main.rs:783:18:783:31 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
 | main.rs:783:18:783:31 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:783:26:783:26 | x |  | main.rs:701:5:704:5 | MyThing |
-| main.rs:783:26:783:26 | x | T | main.rs:706:5:707:14 | S1 |
-| main.rs:783:26:783:31 | x.m2() |  | main.rs:706:5:707:14 | S1 |
-| main.rs:784:18:784:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:784:18:784:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:784:18:784:31 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:784:18:784:31 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:784:26:784:26 | y |  | main.rs:701:5:704:5 | MyThing |
-| main.rs:784:26:784:26 | y | T | main.rs:708:5:709:14 | S2 |
-| main.rs:784:26:784:31 | y.m2() |  | main.rs:708:5:709:14 | S2 |
-| main.rs:786:13:786:14 | x2 |  | main.rs:701:5:704:5 | MyThing |
-| main.rs:786:13:786:14 | x2 | T | main.rs:706:5:707:14 | S1 |
-| main.rs:786:18:786:34 | MyThing {...} |  | main.rs:701:5:704:5 | MyThing |
-| main.rs:786:18:786:34 | MyThing {...} | T | main.rs:706:5:707:14 | S1 |
-| main.rs:786:31:786:32 | S1 |  | main.rs:706:5:707:14 | S1 |
-| main.rs:787:13:787:14 | y2 |  | main.rs:701:5:704:5 | MyThing |
-| main.rs:787:13:787:14 | y2 | T | main.rs:708:5:709:14 | S2 |
-| main.rs:787:18:787:34 | MyThing {...} |  | main.rs:701:5:704:5 | MyThing |
-| main.rs:787:18:787:34 | MyThing {...} | T | main.rs:708:5:709:14 | S2 |
-| main.rs:787:31:787:32 | S2 |  | main.rs:708:5:709:14 | S2 |
-| main.rs:789:13:789:13 | a |  | main.rs:706:5:707:14 | S1 |
-| main.rs:789:17:789:33 | call_trait_m1(...) |  | main.rs:706:5:707:14 | S1 |
-| main.rs:789:31:789:32 | x2 |  | main.rs:701:5:704:5 | MyThing |
-| main.rs:789:31:789:32 | x2 | T | main.rs:706:5:707:14 | S1 |
-| main.rs:790:18:790:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:790:18:790:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:790:18:790:26 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:790:18:790:26 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:790:26:790:26 | a |  | main.rs:706:5:707:14 | S1 |
-| main.rs:791:13:791:13 | a |  | main.rs:706:5:707:14 | S1 |
-| main.rs:791:17:791:35 | call_trait_m1_2(...) |  | main.rs:706:5:707:14 | S1 |
-| main.rs:791:33:791:34 | x2 |  | main.rs:701:5:704:5 | MyThing |
-| main.rs:791:33:791:34 | x2 | T | main.rs:706:5:707:14 | S1 |
-| main.rs:792:18:792:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:792:18:792:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:792:18:792:26 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:792:18:792:26 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:792:26:792:26 | a |  | main.rs:706:5:707:14 | S1 |
-| main.rs:793:13:793:13 | a |  | main.rs:706:5:707:14 | S1 |
-| main.rs:793:17:793:35 | call_trait_m1_3(...) |  | main.rs:706:5:707:14 | S1 |
-| main.rs:793:33:793:34 | x2 |  | main.rs:701:5:704:5 | MyThing |
-| main.rs:793:33:793:34 | x2 | T | main.rs:706:5:707:14 | S1 |
-| main.rs:794:18:794:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:794:18:794:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:794:18:794:26 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:794:18:794:26 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:794:26:794:26 | a |  | main.rs:706:5:707:14 | S1 |
-| main.rs:795:13:795:13 | a |  | main.rs:708:5:709:14 | S2 |
-| main.rs:795:17:795:33 | call_trait_m1(...) |  | main.rs:708:5:709:14 | S2 |
-| main.rs:795:31:795:32 | y2 |  | main.rs:701:5:704:5 | MyThing |
-| main.rs:795:31:795:32 | y2 | T | main.rs:708:5:709:14 | S2 |
-| main.rs:796:18:796:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:796:18:796:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:796:18:796:26 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:796:18:796:26 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:796:26:796:26 | a |  | main.rs:708:5:709:14 | S2 |
-| main.rs:797:13:797:13 | a |  | main.rs:708:5:709:14 | S2 |
-| main.rs:797:17:797:35 | call_trait_m1_2(...) |  | main.rs:708:5:709:14 | S2 |
-| main.rs:797:33:797:34 | y2 |  | main.rs:701:5:704:5 | MyThing |
-| main.rs:797:33:797:34 | y2 | T | main.rs:708:5:709:14 | S2 |
-| main.rs:798:18:798:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:798:18:798:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:798:18:798:26 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:798:18:798:26 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:798:26:798:26 | a |  | main.rs:708:5:709:14 | S2 |
-| main.rs:799:13:799:13 | a |  | main.rs:708:5:709:14 | S2 |
-| main.rs:799:17:799:35 | call_trait_m1_3(...) |  | main.rs:708:5:709:14 | S2 |
-| main.rs:799:33:799:34 | y2 |  | main.rs:701:5:704:5 | MyThing |
-| main.rs:799:33:799:34 | y2 | T | main.rs:708:5:709:14 | S2 |
-| main.rs:800:18:800:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:800:18:800:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:800:18:800:26 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:800:18:800:26 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:800:26:800:26 | a |  | main.rs:708:5:709:14 | S2 |
-| main.rs:801:13:801:13 | a |  | main.rs:706:5:707:14 | S1 |
-| main.rs:801:17:801:38 | call_trait_assoc_1(...) |  | main.rs:706:5:707:14 | S1 |
-| main.rs:801:36:801:37 | x2 |  | main.rs:701:5:704:5 | MyThing |
-| main.rs:801:36:801:37 | x2 | T | main.rs:706:5:707:14 | S1 |
-| main.rs:802:18:802:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:802:18:802:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:802:18:802:26 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:802:18:802:26 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:802:26:802:26 | a |  | main.rs:706:5:707:14 | S1 |
-| main.rs:803:13:803:13 | a |  | main.rs:706:5:707:14 | S1 |
-| main.rs:803:17:803:38 | call_trait_assoc_2(...) |  | main.rs:706:5:707:14 | S1 |
-| main.rs:803:36:803:37 | x2 |  | main.rs:701:5:704:5 | MyThing |
-| main.rs:803:36:803:37 | x2 | T | main.rs:706:5:707:14 | S1 |
-| main.rs:804:18:804:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:804:18:804:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:804:18:804:26 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:804:18:804:26 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:804:26:804:26 | a |  | main.rs:706:5:707:14 | S1 |
-| main.rs:805:13:805:13 | a |  | main.rs:708:5:709:14 | S2 |
-| main.rs:805:17:805:38 | call_trait_assoc_1(...) |  | main.rs:708:5:709:14 | S2 |
-| main.rs:805:36:805:37 | y2 |  | main.rs:701:5:704:5 | MyThing |
-| main.rs:805:36:805:37 | y2 | T | main.rs:708:5:709:14 | S2 |
-| main.rs:806:18:806:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:806:18:806:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:806:18:806:26 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:806:18:806:26 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:806:26:806:26 | a |  | main.rs:708:5:709:14 | S2 |
-| main.rs:807:13:807:13 | a |  | main.rs:708:5:709:14 | S2 |
-| main.rs:807:17:807:38 | call_trait_assoc_2(...) |  | main.rs:708:5:709:14 | S2 |
-| main.rs:807:36:807:37 | y2 |  | main.rs:701:5:704:5 | MyThing |
-| main.rs:807:36:807:37 | y2 | T | main.rs:708:5:709:14 | S2 |
-| main.rs:808:18:808:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:808:18:808:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:808:18:808:26 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:808:18:808:26 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:808:26:808:26 | a |  | main.rs:708:5:709:14 | S2 |
-| main.rs:810:13:810:14 | x3 |  | main.rs:701:5:704:5 | MyThing |
-| main.rs:810:13:810:14 | x3 | T | main.rs:701:5:704:5 | MyThing |
-| main.rs:810:13:810:14 | x3 | T.T | main.rs:706:5:707:14 | S1 |
-| main.rs:810:18:812:9 | MyThing {...} |  | main.rs:701:5:704:5 | MyThing |
-| main.rs:810:18:812:9 | MyThing {...} | T | main.rs:701:5:704:5 | MyThing |
-| main.rs:810:18:812:9 | MyThing {...} | T.T | main.rs:706:5:707:14 | S1 |
-| main.rs:811:16:811:32 | MyThing {...} |  | main.rs:701:5:704:5 | MyThing |
-| main.rs:811:16:811:32 | MyThing {...} | T | main.rs:706:5:707:14 | S1 |
-| main.rs:811:29:811:30 | S1 |  | main.rs:706:5:707:14 | S1 |
-| main.rs:813:13:813:14 | y3 |  | main.rs:701:5:704:5 | MyThing |
-| main.rs:813:13:813:14 | y3 | T | main.rs:701:5:704:5 | MyThing |
-| main.rs:813:13:813:14 | y3 | T.T | main.rs:708:5:709:14 | S2 |
-| main.rs:813:18:815:9 | MyThing {...} |  | main.rs:701:5:704:5 | MyThing |
-| main.rs:813:18:815:9 | MyThing {...} | T | main.rs:701:5:704:5 | MyThing |
-| main.rs:813:18:815:9 | MyThing {...} | T.T | main.rs:708:5:709:14 | S2 |
-| main.rs:814:16:814:32 | MyThing {...} |  | main.rs:701:5:704:5 | MyThing |
-| main.rs:814:16:814:32 | MyThing {...} | T | main.rs:708:5:709:14 | S2 |
-| main.rs:814:29:814:30 | S2 |  | main.rs:708:5:709:14 | S2 |
-| main.rs:817:13:817:13 | a |  | main.rs:706:5:707:14 | S1 |
-| main.rs:817:17:817:39 | call_trait_thing_m1(...) |  | main.rs:706:5:707:14 | S1 |
-| main.rs:817:37:817:38 | x3 |  | main.rs:701:5:704:5 | MyThing |
-| main.rs:817:37:817:38 | x3 | T | main.rs:701:5:704:5 | MyThing |
-| main.rs:817:37:817:38 | x3 | T.T | main.rs:706:5:707:14 | S1 |
-| main.rs:818:18:818:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:818:18:818:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:818:18:818:26 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:818:18:818:26 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:818:26:818:26 | a |  | main.rs:706:5:707:14 | S1 |
-| main.rs:819:13:819:13 | a |  | main.rs:706:5:707:14 | S1 |
-| main.rs:819:17:819:41 | call_trait_thing_m1_2(...) |  | main.rs:706:5:707:14 | S1 |
-| main.rs:819:39:819:40 | x3 |  | main.rs:701:5:704:5 | MyThing |
-| main.rs:819:39:819:40 | x3 | T | main.rs:701:5:704:5 | MyThing |
-| main.rs:819:39:819:40 | x3 | T.T | main.rs:706:5:707:14 | S1 |
-| main.rs:820:18:820:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:820:18:820:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:820:18:820:26 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:820:18:820:26 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:820:26:820:26 | a |  | main.rs:706:5:707:14 | S1 |
-| main.rs:821:13:821:13 | a |  | main.rs:706:5:707:14 | S1 |
-| main.rs:821:17:821:41 | call_trait_thing_m1_3(...) |  | main.rs:706:5:707:14 | S1 |
-| main.rs:821:39:821:40 | x3 |  | main.rs:701:5:704:5 | MyThing |
-| main.rs:821:39:821:40 | x3 | T | main.rs:701:5:704:5 | MyThing |
-| main.rs:821:39:821:40 | x3 | T.T | main.rs:706:5:707:14 | S1 |
-| main.rs:822:18:822:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:822:18:822:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:822:18:822:26 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:822:18:822:26 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:822:26:822:26 | a |  | main.rs:706:5:707:14 | S1 |
-| main.rs:823:13:823:13 | b |  | main.rs:708:5:709:14 | S2 |
-| main.rs:823:17:823:39 | call_trait_thing_m1(...) |  | main.rs:708:5:709:14 | S2 |
-| main.rs:823:37:823:38 | y3 |  | main.rs:701:5:704:5 | MyThing |
-| main.rs:823:37:823:38 | y3 | T | main.rs:701:5:704:5 | MyThing |
-| main.rs:823:37:823:38 | y3 | T.T | main.rs:708:5:709:14 | S2 |
-| main.rs:824:18:824:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:824:18:824:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:824:18:824:26 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:824:18:824:26 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:824:26:824:26 | b |  | main.rs:708:5:709:14 | S2 |
-| main.rs:825:13:825:13 | b |  | main.rs:708:5:709:14 | S2 |
-| main.rs:825:17:825:41 | call_trait_thing_m1_2(...) |  | main.rs:708:5:709:14 | S2 |
-| main.rs:825:39:825:40 | y3 |  | main.rs:701:5:704:5 | MyThing |
-| main.rs:825:39:825:40 | y3 | T | main.rs:701:5:704:5 | MyThing |
-| main.rs:825:39:825:40 | y3 | T.T | main.rs:708:5:709:14 | S2 |
-| main.rs:826:18:826:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:826:18:826:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:826:18:826:26 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:826:18:826:26 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:826:26:826:26 | b |  | main.rs:708:5:709:14 | S2 |
-| main.rs:827:13:827:13 | b |  | main.rs:708:5:709:14 | S2 |
-| main.rs:827:17:827:41 | call_trait_thing_m1_3(...) |  | main.rs:708:5:709:14 | S2 |
-| main.rs:827:39:827:40 | y3 |  | main.rs:701:5:704:5 | MyThing |
-| main.rs:827:39:827:40 | y3 | T | main.rs:701:5:704:5 | MyThing |
-| main.rs:827:39:827:40 | y3 | T.T | main.rs:708:5:709:14 | S2 |
-| main.rs:828:18:828:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:828:18:828:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:828:18:828:26 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:828:18:828:26 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:828:26:828:26 | b |  | main.rs:708:5:709:14 | S2 |
-| main.rs:839:19:839:22 | SelfParam |  | main.rs:833:5:836:5 | Wrapper |
-| main.rs:839:19:839:22 | SelfParam | A | main.rs:838:10:838:10 | A |
-| main.rs:839:30:841:9 | { ... } |  | main.rs:838:10:838:10 | A |
-| main.rs:840:13:840:16 | self |  | main.rs:833:5:836:5 | Wrapper |
-| main.rs:840:13:840:16 | self | A | main.rs:838:10:838:10 | A |
-| main.rs:840:13:840:22 | self.field |  | main.rs:838:10:838:10 | A |
-| main.rs:848:15:848:18 | SelfParam |  | main.rs:844:5:858:5 | Self [trait MyTrait] |
-| main.rs:850:15:850:18 | SelfParam |  | main.rs:844:5:858:5 | Self [trait MyTrait] |
-| main.rs:854:9:857:9 | { ... } |  | main.rs:845:9:845:28 | AssociatedType |
-| main.rs:855:13:855:16 | self |  | main.rs:844:5:858:5 | Self [trait MyTrait] |
-| main.rs:855:13:855:21 | self.m1() |  | main.rs:845:9:845:28 | AssociatedType |
-| main.rs:856:13:856:43 | ...::default(...) |  | main.rs:845:9:845:28 | AssociatedType |
-| main.rs:864:19:864:23 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:864:19:864:23 | SelfParam | &T | main.rs:860:5:870:5 | Self [trait MyTraitAssoc2] |
-| main.rs:864:26:864:26 | a |  | main.rs:864:16:864:16 | A |
-| main.rs:866:22:866:26 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:866:22:866:26 | SelfParam | &T | main.rs:860:5:870:5 | Self [trait MyTraitAssoc2] |
-| main.rs:866:29:866:29 | a |  | main.rs:866:19:866:19 | A |
-| main.rs:866:35:866:35 | b |  | main.rs:866:19:866:19 | A |
-| main.rs:866:75:869:9 | { ... } |  | main.rs:861:9:861:52 | GenericAssociatedType |
+| main.rs:783:26:783:26 | y |  | main.rs:700:5:703:5 | MyThing |
+| main.rs:783:26:783:26 | y | T | main.rs:707:5:708:14 | S2 |
+| main.rs:783:26:783:31 | y.m2() |  | main.rs:707:5:708:14 | S2 |
+| main.rs:785:13:785:14 | x2 |  | main.rs:700:5:703:5 | MyThing |
+| main.rs:785:13:785:14 | x2 | T | main.rs:705:5:706:14 | S1 |
+| main.rs:785:18:785:34 | MyThing {...} |  | main.rs:700:5:703:5 | MyThing |
+| main.rs:785:18:785:34 | MyThing {...} | T | main.rs:705:5:706:14 | S1 |
+| main.rs:785:31:785:32 | S1 |  | main.rs:705:5:706:14 | S1 |
+| main.rs:786:13:786:14 | y2 |  | main.rs:700:5:703:5 | MyThing |
+| main.rs:786:13:786:14 | y2 | T | main.rs:707:5:708:14 | S2 |
+| main.rs:786:18:786:34 | MyThing {...} |  | main.rs:700:5:703:5 | MyThing |
+| main.rs:786:18:786:34 | MyThing {...} | T | main.rs:707:5:708:14 | S2 |
+| main.rs:786:31:786:32 | S2 |  | main.rs:707:5:708:14 | S2 |
+| main.rs:788:13:788:13 | a |  | main.rs:705:5:706:14 | S1 |
+| main.rs:788:17:788:33 | call_trait_m1(...) |  | main.rs:705:5:706:14 | S1 |
+| main.rs:788:31:788:32 | x2 |  | main.rs:700:5:703:5 | MyThing |
+| main.rs:788:31:788:32 | x2 | T | main.rs:705:5:706:14 | S1 |
+| main.rs:789:18:789:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:789:18:789:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:789:18:789:26 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:789:18:789:26 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:789:26:789:26 | a |  | main.rs:705:5:706:14 | S1 |
+| main.rs:790:13:790:13 | a |  | main.rs:705:5:706:14 | S1 |
+| main.rs:790:17:790:35 | call_trait_m1_2(...) |  | main.rs:705:5:706:14 | S1 |
+| main.rs:790:33:790:34 | x2 |  | main.rs:700:5:703:5 | MyThing |
+| main.rs:790:33:790:34 | x2 | T | main.rs:705:5:706:14 | S1 |
+| main.rs:791:18:791:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:791:18:791:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:791:18:791:26 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:791:18:791:26 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:791:26:791:26 | a |  | main.rs:705:5:706:14 | S1 |
+| main.rs:792:13:792:13 | a |  | main.rs:705:5:706:14 | S1 |
+| main.rs:792:17:792:35 | call_trait_m1_3(...) |  | main.rs:705:5:706:14 | S1 |
+| main.rs:792:33:792:34 | x2 |  | main.rs:700:5:703:5 | MyThing |
+| main.rs:792:33:792:34 | x2 | T | main.rs:705:5:706:14 | S1 |
+| main.rs:793:18:793:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:793:18:793:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:793:18:793:26 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:793:18:793:26 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:793:26:793:26 | a |  | main.rs:705:5:706:14 | S1 |
+| main.rs:794:13:794:13 | a |  | main.rs:707:5:708:14 | S2 |
+| main.rs:794:17:794:33 | call_trait_m1(...) |  | main.rs:707:5:708:14 | S2 |
+| main.rs:794:31:794:32 | y2 |  | main.rs:700:5:703:5 | MyThing |
+| main.rs:794:31:794:32 | y2 | T | main.rs:707:5:708:14 | S2 |
+| main.rs:795:18:795:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:795:18:795:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:795:18:795:26 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:795:18:795:26 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:795:26:795:26 | a |  | main.rs:707:5:708:14 | S2 |
+| main.rs:796:13:796:13 | a |  | main.rs:707:5:708:14 | S2 |
+| main.rs:796:17:796:35 | call_trait_m1_2(...) |  | main.rs:707:5:708:14 | S2 |
+| main.rs:796:33:796:34 | y2 |  | main.rs:700:5:703:5 | MyThing |
+| main.rs:796:33:796:34 | y2 | T | main.rs:707:5:708:14 | S2 |
+| main.rs:797:18:797:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:797:18:797:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:797:18:797:26 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:797:18:797:26 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:797:26:797:26 | a |  | main.rs:707:5:708:14 | S2 |
+| main.rs:798:13:798:13 | a |  | main.rs:707:5:708:14 | S2 |
+| main.rs:798:17:798:35 | call_trait_m1_3(...) |  | main.rs:707:5:708:14 | S2 |
+| main.rs:798:33:798:34 | y2 |  | main.rs:700:5:703:5 | MyThing |
+| main.rs:798:33:798:34 | y2 | T | main.rs:707:5:708:14 | S2 |
+| main.rs:799:18:799:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:799:18:799:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:799:18:799:26 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:799:18:799:26 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:799:26:799:26 | a |  | main.rs:707:5:708:14 | S2 |
+| main.rs:800:13:800:13 | a |  | main.rs:705:5:706:14 | S1 |
+| main.rs:800:17:800:38 | call_trait_assoc_1(...) |  | main.rs:705:5:706:14 | S1 |
+| main.rs:800:36:800:37 | x2 |  | main.rs:700:5:703:5 | MyThing |
+| main.rs:800:36:800:37 | x2 | T | main.rs:705:5:706:14 | S1 |
+| main.rs:801:18:801:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:801:18:801:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:801:18:801:26 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:801:18:801:26 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:801:26:801:26 | a |  | main.rs:705:5:706:14 | S1 |
+| main.rs:802:13:802:13 | a |  | main.rs:705:5:706:14 | S1 |
+| main.rs:802:17:802:38 | call_trait_assoc_2(...) |  | main.rs:705:5:706:14 | S1 |
+| main.rs:802:36:802:37 | x2 |  | main.rs:700:5:703:5 | MyThing |
+| main.rs:802:36:802:37 | x2 | T | main.rs:705:5:706:14 | S1 |
+| main.rs:803:18:803:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:803:18:803:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:803:18:803:26 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:803:18:803:26 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:803:26:803:26 | a |  | main.rs:705:5:706:14 | S1 |
+| main.rs:804:13:804:13 | a |  | main.rs:707:5:708:14 | S2 |
+| main.rs:804:17:804:38 | call_trait_assoc_1(...) |  | main.rs:707:5:708:14 | S2 |
+| main.rs:804:36:804:37 | y2 |  | main.rs:700:5:703:5 | MyThing |
+| main.rs:804:36:804:37 | y2 | T | main.rs:707:5:708:14 | S2 |
+| main.rs:805:18:805:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:805:18:805:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:805:18:805:26 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:805:18:805:26 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:805:26:805:26 | a |  | main.rs:707:5:708:14 | S2 |
+| main.rs:806:13:806:13 | a |  | main.rs:707:5:708:14 | S2 |
+| main.rs:806:17:806:38 | call_trait_assoc_2(...) |  | main.rs:707:5:708:14 | S2 |
+| main.rs:806:36:806:37 | y2 |  | main.rs:700:5:703:5 | MyThing |
+| main.rs:806:36:806:37 | y2 | T | main.rs:707:5:708:14 | S2 |
+| main.rs:807:18:807:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:807:18:807:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:807:18:807:26 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:807:18:807:26 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:807:26:807:26 | a |  | main.rs:707:5:708:14 | S2 |
+| main.rs:809:13:809:14 | x3 |  | main.rs:700:5:703:5 | MyThing |
+| main.rs:809:13:809:14 | x3 | T | main.rs:700:5:703:5 | MyThing |
+| main.rs:809:13:809:14 | x3 | T.T | main.rs:705:5:706:14 | S1 |
+| main.rs:809:18:811:9 | MyThing {...} |  | main.rs:700:5:703:5 | MyThing |
+| main.rs:809:18:811:9 | MyThing {...} | T | main.rs:700:5:703:5 | MyThing |
+| main.rs:809:18:811:9 | MyThing {...} | T.T | main.rs:705:5:706:14 | S1 |
+| main.rs:810:16:810:32 | MyThing {...} |  | main.rs:700:5:703:5 | MyThing |
+| main.rs:810:16:810:32 | MyThing {...} | T | main.rs:705:5:706:14 | S1 |
+| main.rs:810:29:810:30 | S1 |  | main.rs:705:5:706:14 | S1 |
+| main.rs:812:13:812:14 | y3 |  | main.rs:700:5:703:5 | MyThing |
+| main.rs:812:13:812:14 | y3 | T | main.rs:700:5:703:5 | MyThing |
+| main.rs:812:13:812:14 | y3 | T.T | main.rs:707:5:708:14 | S2 |
+| main.rs:812:18:814:9 | MyThing {...} |  | main.rs:700:5:703:5 | MyThing |
+| main.rs:812:18:814:9 | MyThing {...} | T | main.rs:700:5:703:5 | MyThing |
+| main.rs:812:18:814:9 | MyThing {...} | T.T | main.rs:707:5:708:14 | S2 |
+| main.rs:813:16:813:32 | MyThing {...} |  | main.rs:700:5:703:5 | MyThing |
+| main.rs:813:16:813:32 | MyThing {...} | T | main.rs:707:5:708:14 | S2 |
+| main.rs:813:29:813:30 | S2 |  | main.rs:707:5:708:14 | S2 |
+| main.rs:816:13:816:13 | a |  | main.rs:705:5:706:14 | S1 |
+| main.rs:816:17:816:39 | call_trait_thing_m1(...) |  | main.rs:705:5:706:14 | S1 |
+| main.rs:816:37:816:38 | x3 |  | main.rs:700:5:703:5 | MyThing |
+| main.rs:816:37:816:38 | x3 | T | main.rs:700:5:703:5 | MyThing |
+| main.rs:816:37:816:38 | x3 | T.T | main.rs:705:5:706:14 | S1 |
+| main.rs:817:18:817:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:817:18:817:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:817:18:817:26 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:817:18:817:26 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:817:26:817:26 | a |  | main.rs:705:5:706:14 | S1 |
+| main.rs:818:13:818:13 | a |  | main.rs:705:5:706:14 | S1 |
+| main.rs:818:17:818:41 | call_trait_thing_m1_2(...) |  | main.rs:705:5:706:14 | S1 |
+| main.rs:818:39:818:40 | x3 |  | main.rs:700:5:703:5 | MyThing |
+| main.rs:818:39:818:40 | x3 | T | main.rs:700:5:703:5 | MyThing |
+| main.rs:818:39:818:40 | x3 | T.T | main.rs:705:5:706:14 | S1 |
+| main.rs:819:18:819:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:819:18:819:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:819:18:819:26 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:819:18:819:26 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:819:26:819:26 | a |  | main.rs:705:5:706:14 | S1 |
+| main.rs:820:13:820:13 | a |  | main.rs:705:5:706:14 | S1 |
+| main.rs:820:17:820:41 | call_trait_thing_m1_3(...) |  | main.rs:705:5:706:14 | S1 |
+| main.rs:820:39:820:40 | x3 |  | main.rs:700:5:703:5 | MyThing |
+| main.rs:820:39:820:40 | x3 | T | main.rs:700:5:703:5 | MyThing |
+| main.rs:820:39:820:40 | x3 | T.T | main.rs:705:5:706:14 | S1 |
+| main.rs:821:18:821:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:821:18:821:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:821:18:821:26 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:821:18:821:26 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:821:26:821:26 | a |  | main.rs:705:5:706:14 | S1 |
+| main.rs:822:13:822:13 | b |  | main.rs:707:5:708:14 | S2 |
+| main.rs:822:17:822:39 | call_trait_thing_m1(...) |  | main.rs:707:5:708:14 | S2 |
+| main.rs:822:37:822:38 | y3 |  | main.rs:700:5:703:5 | MyThing |
+| main.rs:822:37:822:38 | y3 | T | main.rs:700:5:703:5 | MyThing |
+| main.rs:822:37:822:38 | y3 | T.T | main.rs:707:5:708:14 | S2 |
+| main.rs:823:18:823:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:823:18:823:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:823:18:823:26 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:823:18:823:26 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:823:26:823:26 | b |  | main.rs:707:5:708:14 | S2 |
+| main.rs:824:13:824:13 | b |  | main.rs:707:5:708:14 | S2 |
+| main.rs:824:17:824:41 | call_trait_thing_m1_2(...) |  | main.rs:707:5:708:14 | S2 |
+| main.rs:824:39:824:40 | y3 |  | main.rs:700:5:703:5 | MyThing |
+| main.rs:824:39:824:40 | y3 | T | main.rs:700:5:703:5 | MyThing |
+| main.rs:824:39:824:40 | y3 | T.T | main.rs:707:5:708:14 | S2 |
+| main.rs:825:18:825:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:825:18:825:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:825:18:825:26 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:825:18:825:26 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:825:26:825:26 | b |  | main.rs:707:5:708:14 | S2 |
+| main.rs:826:13:826:13 | b |  | main.rs:707:5:708:14 | S2 |
+| main.rs:826:17:826:41 | call_trait_thing_m1_3(...) |  | main.rs:707:5:708:14 | S2 |
+| main.rs:826:39:826:40 | y3 |  | main.rs:700:5:703:5 | MyThing |
+| main.rs:826:39:826:40 | y3 | T | main.rs:700:5:703:5 | MyThing |
+| main.rs:826:39:826:40 | y3 | T.T | main.rs:707:5:708:14 | S2 |
+| main.rs:827:18:827:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:827:18:827:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:827:18:827:26 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:827:18:827:26 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:827:26:827:26 | b |  | main.rs:707:5:708:14 | S2 |
+| main.rs:838:19:838:22 | SelfParam |  | main.rs:832:5:835:5 | Wrapper |
+| main.rs:838:19:838:22 | SelfParam | A | main.rs:837:10:837:10 | A |
+| main.rs:838:30:840:9 | { ... } |  | main.rs:837:10:837:10 | A |
+| main.rs:839:13:839:16 | self |  | main.rs:832:5:835:5 | Wrapper |
+| main.rs:839:13:839:16 | self | A | main.rs:837:10:837:10 | A |
+| main.rs:839:13:839:22 | self.field |  | main.rs:837:10:837:10 | A |
+| main.rs:847:15:847:18 | SelfParam |  | main.rs:843:5:857:5 | Self [trait MyTrait] |
+| main.rs:849:15:849:18 | SelfParam |  | main.rs:843:5:857:5 | Self [trait MyTrait] |
+| main.rs:853:9:856:9 | { ... } |  | main.rs:844:9:844:28 | AssociatedType |
+| main.rs:854:13:854:16 | self |  | main.rs:843:5:857:5 | Self [trait MyTrait] |
+| main.rs:854:13:854:21 | self.m1() |  | main.rs:844:9:844:28 | AssociatedType |
+| main.rs:855:13:855:43 | ...::default(...) |  | main.rs:844:9:844:28 | AssociatedType |
+| main.rs:863:19:863:23 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:863:19:863:23 | SelfParam | &T | main.rs:859:5:869:5 | Self [trait MyTraitAssoc2] |
+| main.rs:863:26:863:26 | a |  | main.rs:863:16:863:16 | A |
+| main.rs:865:22:865:26 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:865:22:865:26 | SelfParam | &T | main.rs:859:5:869:5 | Self [trait MyTraitAssoc2] |
+| main.rs:865:29:865:29 | a |  | main.rs:865:19:865:19 | A |
+| main.rs:865:35:865:35 | b |  | main.rs:865:19:865:19 | A |
+| main.rs:865:75:868:9 | { ... } |  | main.rs:860:9:860:52 | GenericAssociatedType |
+| main.rs:866:13:866:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:866:13:866:16 | self | &T | main.rs:859:5:869:5 | Self [trait MyTraitAssoc2] |
+| main.rs:866:13:866:23 | self.put(...) |  | main.rs:860:9:860:52 | GenericAssociatedType |
+| main.rs:866:22:866:22 | a |  | main.rs:865:19:865:19 | A |
 | main.rs:867:13:867:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:867:13:867:16 | self | &T | main.rs:860:5:870:5 | Self [trait MyTraitAssoc2] |
-| main.rs:867:13:867:23 | self.put(...) |  | main.rs:861:9:861:52 | GenericAssociatedType |
-| main.rs:867:22:867:22 | a |  | main.rs:866:19:866:19 | A |
-| main.rs:868:13:868:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:868:13:868:16 | self | &T | main.rs:860:5:870:5 | Self [trait MyTraitAssoc2] |
-| main.rs:868:13:868:23 | self.put(...) |  | main.rs:861:9:861:52 | GenericAssociatedType |
-| main.rs:868:22:868:22 | b |  | main.rs:866:19:866:19 | A |
-| main.rs:877:21:877:25 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:877:21:877:25 | SelfParam | &T | main.rs:872:5:882:5 | Self [trait TraitMultipleAssoc] |
-| main.rs:879:20:879:24 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:879:20:879:24 | SelfParam | &T | main.rs:872:5:882:5 | Self [trait TraitMultipleAssoc] |
-| main.rs:881:20:881:24 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:881:20:881:24 | SelfParam | &T | main.rs:872:5:882:5 | Self [trait TraitMultipleAssoc] |
-| main.rs:897:15:897:18 | SelfParam |  | main.rs:884:5:885:13 | S |
-| main.rs:897:45:899:9 | { ... } |  | main.rs:890:5:891:14 | AT |
-| main.rs:898:13:898:14 | AT |  | main.rs:890:5:891:14 | AT |
-| main.rs:907:19:907:23 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:907:19:907:23 | SelfParam | &T | main.rs:884:5:885:13 | S |
-| main.rs:907:26:907:26 | a |  | main.rs:907:16:907:16 | A |
-| main.rs:907:46:909:9 | { ... } |  | main.rs:833:5:836:5 | Wrapper |
-| main.rs:907:46:909:9 | { ... } | A | main.rs:907:16:907:16 | A |
-| main.rs:908:13:908:32 | Wrapper {...} |  | main.rs:833:5:836:5 | Wrapper |
-| main.rs:908:13:908:32 | Wrapper {...} | A | main.rs:907:16:907:16 | A |
-| main.rs:908:30:908:30 | a |  | main.rs:907:16:907:16 | A |
-| main.rs:916:15:916:18 | SelfParam |  | main.rs:887:5:888:14 | S2 |
-| main.rs:916:45:918:9 | { ... } |  | main.rs:833:5:836:5 | Wrapper |
-| main.rs:916:45:918:9 | { ... } | A | main.rs:887:5:888:14 | S2 |
-| main.rs:917:13:917:35 | Wrapper {...} |  | main.rs:833:5:836:5 | Wrapper |
-| main.rs:917:13:917:35 | Wrapper {...} | A | main.rs:887:5:888:14 | S2 |
-| main.rs:917:30:917:33 | self |  | main.rs:887:5:888:14 | S2 |
-| main.rs:923:30:925:9 | { ... } |  | main.rs:833:5:836:5 | Wrapper |
-| main.rs:923:30:925:9 | { ... } | A | main.rs:887:5:888:14 | S2 |
-| main.rs:924:13:924:33 | Wrapper {...} |  | main.rs:833:5:836:5 | Wrapper |
-| main.rs:924:13:924:33 | Wrapper {...} | A | main.rs:887:5:888:14 | S2 |
-| main.rs:924:30:924:31 | S2 |  | main.rs:887:5:888:14 | S2 |
-| main.rs:930:22:930:26 | thing |  | main.rs:930:10:930:19 | T |
-| main.rs:931:9:931:13 | thing |  | main.rs:930:10:930:19 | T |
-| main.rs:938:21:938:25 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:938:21:938:25 | SelfParam | &T | main.rs:890:5:891:14 | AT |
-| main.rs:938:34:940:9 | { ... } |  | main.rs:890:5:891:14 | AT |
-| main.rs:939:13:939:14 | AT |  | main.rs:890:5:891:14 | AT |
-| main.rs:942:20:942:24 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:942:20:942:24 | SelfParam | &T | main.rs:890:5:891:14 | AT |
-| main.rs:942:43:944:9 | { ... } |  | main.rs:884:5:885:13 | S |
-| main.rs:943:13:943:13 | S |  | main.rs:884:5:885:13 | S |
-| main.rs:946:20:946:24 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:946:20:946:24 | SelfParam | &T | main.rs:890:5:891:14 | AT |
-| main.rs:946:43:948:9 | { ... } |  | main.rs:887:5:888:14 | S2 |
-| main.rs:947:13:947:14 | S2 |  | main.rs:887:5:888:14 | S2 |
-| main.rs:952:13:952:14 | x1 |  | main.rs:884:5:885:13 | S |
-| main.rs:952:18:952:18 | S |  | main.rs:884:5:885:13 | S |
-| main.rs:954:18:954:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:954:18:954:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:954:18:954:32 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:954:18:954:32 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:954:26:954:27 | x1 |  | main.rs:884:5:885:13 | S |
-| main.rs:954:26:954:32 | x1.m1() |  | main.rs:890:5:891:14 | AT |
-| main.rs:956:13:956:14 | x2 |  | main.rs:884:5:885:13 | S |
-| main.rs:956:18:956:18 | S |  | main.rs:884:5:885:13 | S |
-| main.rs:958:13:958:13 | y |  | main.rs:890:5:891:14 | AT |
-| main.rs:958:17:958:18 | x2 |  | main.rs:884:5:885:13 | S |
-| main.rs:958:17:958:23 | x2.m2() |  | main.rs:890:5:891:14 | AT |
-| main.rs:959:18:959:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:959:18:959:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:959:18:959:26 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:959:18:959:26 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:959:26:959:26 | y |  | main.rs:890:5:891:14 | AT |
-| main.rs:961:13:961:14 | x3 |  | main.rs:884:5:885:13 | S |
-| main.rs:961:18:961:18 | S |  | main.rs:884:5:885:13 | S |
-| main.rs:963:18:963:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:963:18:963:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:963:18:963:43 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:963:18:963:43 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:963:26:963:27 | x3 |  | main.rs:884:5:885:13 | S |
-| main.rs:963:26:963:34 | x3.put(...) |  | main.rs:833:5:836:5 | Wrapper |
-| main.rs:963:26:963:34 | x3.put(...) | A | {EXTERNAL LOCATION} | i32 |
-| main.rs:963:26:963:43 | ... .unwrap() |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:963:33:963:33 | 1 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:966:18:966:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:966:18:966:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:966:18:966:49 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:966:18:966:49 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:966:26:966:27 | x3 |  | main.rs:884:5:885:13 | S |
-| main.rs:966:26:966:40 | x3.putTwo(...) |  | main.rs:833:5:836:5 | Wrapper |
-| main.rs:966:26:966:40 | x3.putTwo(...) | A | main.rs:904:36:904:50 | AssociatedParam |
-| main.rs:966:26:966:49 | ... .unwrap() |  | main.rs:904:36:904:50 | AssociatedParam |
-| main.rs:966:36:966:36 | 2 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:966:39:966:39 | 3 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:968:20:968:20 | S |  | main.rs:884:5:885:13 | S |
-| main.rs:969:18:969:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:969:18:969:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:969:18:969:27 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:969:18:969:27 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:971:13:971:14 | x5 |  | main.rs:887:5:888:14 | S2 |
-| main.rs:971:18:971:19 | S2 |  | main.rs:887:5:888:14 | S2 |
-| main.rs:972:18:972:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:972:18:972:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:972:18:972:32 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:972:18:972:32 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:972:26:972:27 | x5 |  | main.rs:887:5:888:14 | S2 |
-| main.rs:972:26:972:32 | x5.m1() |  | main.rs:833:5:836:5 | Wrapper |
-| main.rs:972:26:972:32 | x5.m1() | A | main.rs:887:5:888:14 | S2 |
-| main.rs:973:13:973:14 | x6 |  | main.rs:887:5:888:14 | S2 |
-| main.rs:973:18:973:19 | S2 |  | main.rs:887:5:888:14 | S2 |
-| main.rs:974:18:974:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:974:18:974:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:974:18:974:32 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:974:18:974:32 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:974:26:974:27 | x6 |  | main.rs:887:5:888:14 | S2 |
-| main.rs:974:26:974:32 | x6.m2() |  | main.rs:833:5:836:5 | Wrapper |
-| main.rs:974:26:974:32 | x6.m2() | A | main.rs:887:5:888:14 | S2 |
-| main.rs:976:13:976:22 | assoc_zero |  | main.rs:890:5:891:14 | AT |
-| main.rs:976:26:976:27 | AT |  | main.rs:890:5:891:14 | AT |
-| main.rs:976:26:976:38 | AT.get_zero() |  | main.rs:890:5:891:14 | AT |
-| main.rs:977:13:977:21 | assoc_one |  | main.rs:884:5:885:13 | S |
-| main.rs:977:25:977:26 | AT |  | main.rs:890:5:891:14 | AT |
-| main.rs:977:25:977:36 | AT.get_one() |  | main.rs:884:5:885:13 | S |
-| main.rs:978:13:978:21 | assoc_two |  | main.rs:887:5:888:14 | S2 |
-| main.rs:978:25:978:26 | AT |  | main.rs:890:5:891:14 | AT |
-| main.rs:978:25:978:36 | AT.get_two() |  | main.rs:887:5:888:14 | S2 |
-| main.rs:986:19:986:23 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:986:19:986:23 | SelfParam | &T | main.rs:983:5:987:5 | Self [trait Supertrait] |
-| main.rs:986:26:986:32 | content |  | main.rs:984:9:984:21 | Content |
-| main.rs:991:24:991:28 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:991:24:991:28 | SelfParam | &T | main.rs:989:5:992:5 | Self [trait Subtrait] |
-| main.rs:1000:23:1000:27 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:1000:23:1000:27 | SelfParam | &T | main.rs:994:5:1004:5 | Self [trait Subtrait2] |
-| main.rs:1000:30:1000:31 | c1 |  | main.rs:984:9:984:21 | Content |
-| main.rs:1000:49:1000:50 | c2 |  | main.rs:984:9:984:21 | Content |
+| main.rs:867:13:867:16 | self | &T | main.rs:859:5:869:5 | Self [trait MyTraitAssoc2] |
+| main.rs:867:13:867:23 | self.put(...) |  | main.rs:860:9:860:52 | GenericAssociatedType |
+| main.rs:867:22:867:22 | b |  | main.rs:865:19:865:19 | A |
+| main.rs:876:21:876:25 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:876:21:876:25 | SelfParam | &T | main.rs:871:5:881:5 | Self [trait TraitMultipleAssoc] |
+| main.rs:878:20:878:24 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:878:20:878:24 | SelfParam | &T | main.rs:871:5:881:5 | Self [trait TraitMultipleAssoc] |
+| main.rs:880:20:880:24 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:880:20:880:24 | SelfParam | &T | main.rs:871:5:881:5 | Self [trait TraitMultipleAssoc] |
+| main.rs:896:15:896:18 | SelfParam |  | main.rs:883:5:884:13 | S |
+| main.rs:896:45:898:9 | { ... } |  | main.rs:889:5:890:14 | AT |
+| main.rs:897:13:897:14 | AT |  | main.rs:889:5:890:14 | AT |
+| main.rs:906:19:906:23 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:906:19:906:23 | SelfParam | &T | main.rs:883:5:884:13 | S |
+| main.rs:906:26:906:26 | a |  | main.rs:906:16:906:16 | A |
+| main.rs:906:46:908:9 | { ... } |  | main.rs:832:5:835:5 | Wrapper |
+| main.rs:906:46:908:9 | { ... } | A | main.rs:906:16:906:16 | A |
+| main.rs:907:13:907:32 | Wrapper {...} |  | main.rs:832:5:835:5 | Wrapper |
+| main.rs:907:13:907:32 | Wrapper {...} | A | main.rs:906:16:906:16 | A |
+| main.rs:907:30:907:30 | a |  | main.rs:906:16:906:16 | A |
+| main.rs:915:15:915:18 | SelfParam |  | main.rs:886:5:887:14 | S2 |
+| main.rs:915:45:917:9 | { ... } |  | main.rs:832:5:835:5 | Wrapper |
+| main.rs:915:45:917:9 | { ... } | A | main.rs:886:5:887:14 | S2 |
+| main.rs:916:13:916:35 | Wrapper {...} |  | main.rs:832:5:835:5 | Wrapper |
+| main.rs:916:13:916:35 | Wrapper {...} | A | main.rs:886:5:887:14 | S2 |
+| main.rs:916:30:916:33 | self |  | main.rs:886:5:887:14 | S2 |
+| main.rs:922:30:924:9 | { ... } |  | main.rs:832:5:835:5 | Wrapper |
+| main.rs:922:30:924:9 | { ... } | A | main.rs:886:5:887:14 | S2 |
+| main.rs:923:13:923:33 | Wrapper {...} |  | main.rs:832:5:835:5 | Wrapper |
+| main.rs:923:13:923:33 | Wrapper {...} | A | main.rs:886:5:887:14 | S2 |
+| main.rs:923:30:923:31 | S2 |  | main.rs:886:5:887:14 | S2 |
+| main.rs:929:22:929:26 | thing |  | main.rs:929:10:929:19 | T |
+| main.rs:930:9:930:13 | thing |  | main.rs:929:10:929:19 | T |
+| main.rs:937:21:937:25 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:937:21:937:25 | SelfParam | &T | main.rs:889:5:890:14 | AT |
+| main.rs:937:34:939:9 | { ... } |  | main.rs:889:5:890:14 | AT |
+| main.rs:938:13:938:14 | AT |  | main.rs:889:5:890:14 | AT |
+| main.rs:941:20:941:24 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:941:20:941:24 | SelfParam | &T | main.rs:889:5:890:14 | AT |
+| main.rs:941:43:943:9 | { ... } |  | main.rs:883:5:884:13 | S |
+| main.rs:942:13:942:13 | S |  | main.rs:883:5:884:13 | S |
+| main.rs:945:20:945:24 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:945:20:945:24 | SelfParam | &T | main.rs:889:5:890:14 | AT |
+| main.rs:945:43:947:9 | { ... } |  | main.rs:886:5:887:14 | S2 |
+| main.rs:946:13:946:14 | S2 |  | main.rs:886:5:887:14 | S2 |
+| main.rs:951:13:951:14 | x1 |  | main.rs:883:5:884:13 | S |
+| main.rs:951:18:951:18 | S |  | main.rs:883:5:884:13 | S |
+| main.rs:953:18:953:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:953:18:953:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:953:18:953:32 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:953:18:953:32 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:953:26:953:27 | x1 |  | main.rs:883:5:884:13 | S |
+| main.rs:953:26:953:32 | x1.m1() |  | main.rs:889:5:890:14 | AT |
+| main.rs:955:13:955:14 | x2 |  | main.rs:883:5:884:13 | S |
+| main.rs:955:18:955:18 | S |  | main.rs:883:5:884:13 | S |
+| main.rs:957:13:957:13 | y |  | main.rs:889:5:890:14 | AT |
+| main.rs:957:17:957:18 | x2 |  | main.rs:883:5:884:13 | S |
+| main.rs:957:17:957:23 | x2.m2() |  | main.rs:889:5:890:14 | AT |
+| main.rs:958:18:958:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:958:18:958:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:958:18:958:26 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:958:18:958:26 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:958:26:958:26 | y |  | main.rs:889:5:890:14 | AT |
+| main.rs:960:13:960:14 | x3 |  | main.rs:883:5:884:13 | S |
+| main.rs:960:18:960:18 | S |  | main.rs:883:5:884:13 | S |
+| main.rs:962:18:962:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:962:18:962:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:962:18:962:43 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:962:18:962:43 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:962:26:962:27 | x3 |  | main.rs:883:5:884:13 | S |
+| main.rs:962:26:962:34 | x3.put(...) |  | main.rs:832:5:835:5 | Wrapper |
+| main.rs:962:26:962:34 | x3.put(...) | A | {EXTERNAL LOCATION} | i32 |
+| main.rs:962:26:962:43 | ... .unwrap() |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:962:33:962:33 | 1 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:965:18:965:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:965:18:965:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:965:18:965:49 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:965:18:965:49 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:965:26:965:27 | x3 |  | main.rs:883:5:884:13 | S |
+| main.rs:965:26:965:40 | x3.putTwo(...) |  | main.rs:832:5:835:5 | Wrapper |
+| main.rs:965:26:965:40 | x3.putTwo(...) | A | main.rs:903:36:903:50 | AssociatedParam |
+| main.rs:965:26:965:49 | ... .unwrap() |  | main.rs:903:36:903:50 | AssociatedParam |
+| main.rs:965:36:965:36 | 2 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:965:39:965:39 | 3 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:967:20:967:20 | S |  | main.rs:883:5:884:13 | S |
+| main.rs:968:18:968:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:968:18:968:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:968:18:968:27 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:968:18:968:27 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:970:13:970:14 | x5 |  | main.rs:886:5:887:14 | S2 |
+| main.rs:970:18:970:19 | S2 |  | main.rs:886:5:887:14 | S2 |
+| main.rs:971:18:971:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:971:18:971:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:971:18:971:32 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:971:18:971:32 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:971:26:971:27 | x5 |  | main.rs:886:5:887:14 | S2 |
+| main.rs:971:26:971:32 | x5.m1() |  | main.rs:832:5:835:5 | Wrapper |
+| main.rs:971:26:971:32 | x5.m1() | A | main.rs:886:5:887:14 | S2 |
+| main.rs:972:13:972:14 | x6 |  | main.rs:886:5:887:14 | S2 |
+| main.rs:972:18:972:19 | S2 |  | main.rs:886:5:887:14 | S2 |
+| main.rs:973:18:973:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:973:18:973:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:973:18:973:32 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:973:18:973:32 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:973:26:973:27 | x6 |  | main.rs:886:5:887:14 | S2 |
+| main.rs:973:26:973:32 | x6.m2() |  | main.rs:832:5:835:5 | Wrapper |
+| main.rs:973:26:973:32 | x6.m2() | A | main.rs:886:5:887:14 | S2 |
+| main.rs:975:13:975:22 | assoc_zero |  | main.rs:889:5:890:14 | AT |
+| main.rs:975:26:975:27 | AT |  | main.rs:889:5:890:14 | AT |
+| main.rs:975:26:975:38 | AT.get_zero() |  | main.rs:889:5:890:14 | AT |
+| main.rs:976:13:976:21 | assoc_one |  | main.rs:883:5:884:13 | S |
+| main.rs:976:25:976:26 | AT |  | main.rs:889:5:890:14 | AT |
+| main.rs:976:25:976:36 | AT.get_one() |  | main.rs:883:5:884:13 | S |
+| main.rs:977:13:977:21 | assoc_two |  | main.rs:886:5:887:14 | S2 |
+| main.rs:977:25:977:26 | AT |  | main.rs:889:5:890:14 | AT |
+| main.rs:977:25:977:36 | AT.get_two() |  | main.rs:886:5:887:14 | S2 |
+| main.rs:985:19:985:23 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:985:19:985:23 | SelfParam | &T | main.rs:982:5:986:5 | Self [trait Supertrait] |
+| main.rs:985:26:985:32 | content |  | main.rs:983:9:983:21 | Content |
+| main.rs:990:24:990:28 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:990:24:990:28 | SelfParam | &T | main.rs:988:5:991:5 | Self [trait Subtrait] |
+| main.rs:999:23:999:27 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:999:23:999:27 | SelfParam | &T | main.rs:993:5:1003:5 | Self [trait Subtrait2] |
+| main.rs:999:30:999:31 | c1 |  | main.rs:983:9:983:21 | Content |
+| main.rs:999:49:999:50 | c2 |  | main.rs:983:9:983:21 | Content |
+| main.rs:1000:13:1000:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1000:13:1000:16 | self | &T | main.rs:993:5:1003:5 | Self [trait Subtrait2] |
+| main.rs:1000:25:1000:26 | c1 |  | main.rs:983:9:983:21 | Content |
 | main.rs:1001:13:1001:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:1001:13:1001:16 | self | &T | main.rs:994:5:1004:5 | Self [trait Subtrait2] |
-| main.rs:1001:25:1001:26 | c1 |  | main.rs:984:9:984:21 | Content |
-| main.rs:1002:13:1002:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:1002:13:1002:16 | self | &T | main.rs:994:5:1004:5 | Self [trait Subtrait2] |
-| main.rs:1002:25:1002:26 | c2 |  | main.rs:984:9:984:21 | Content |
-| main.rs:1010:19:1010:23 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:1010:19:1010:23 | SelfParam | &T | main.rs:1006:5:1006:24 | MyType |
-| main.rs:1010:19:1010:23 | SelfParam | &T.T | main.rs:1008:10:1008:10 | T |
-| main.rs:1010:26:1010:33 | _content |  | main.rs:1008:10:1008:10 | T |
-| main.rs:1011:22:1011:42 | "Inserting content: \\n" |  | file://:0:0:0:0 | & |
-| main.rs:1011:22:1011:42 | "Inserting content: \\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:1011:22:1011:42 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1011:22:1011:42 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1017:24:1017:28 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:1017:24:1017:28 | SelfParam | &T | main.rs:1006:5:1006:24 | MyType |
-| main.rs:1017:24:1017:28 | SelfParam | &T.T | main.rs:1015:10:1015:17 | T |
-| main.rs:1017:48:1019:9 | { ... } |  | main.rs:1015:10:1015:17 | T |
-| main.rs:1018:13:1018:19 | (...) |  | main.rs:1006:5:1006:24 | MyType |
-| main.rs:1018:13:1018:19 | (...) | T | main.rs:1015:10:1015:17 | T |
-| main.rs:1018:13:1018:21 | ... .0 |  | main.rs:1015:10:1015:17 | T |
-| main.rs:1018:13:1018:29 | ... .clone() |  | main.rs:1015:10:1015:17 | T |
-| main.rs:1018:14:1018:18 | * ... |  | main.rs:1006:5:1006:24 | MyType |
-| main.rs:1018:14:1018:18 | * ... | T | main.rs:1015:10:1015:17 | T |
-| main.rs:1018:15:1018:18 | self |  | file://:0:0:0:0 | & |
-| main.rs:1018:15:1018:18 | self | &T | main.rs:1006:5:1006:24 | MyType |
-| main.rs:1018:15:1018:18 | self | &T.T | main.rs:1015:10:1015:17 | T |
-| main.rs:1022:33:1022:36 | item |  | file://:0:0:0:0 | & |
-| main.rs:1022:33:1022:36 | item | &T | main.rs:1022:20:1022:30 | T |
-| main.rs:1022:57:1024:5 | { ... } |  | main.rs:984:9:984:21 | Content |
-| main.rs:1023:9:1023:12 | item |  | file://:0:0:0:0 | & |
-| main.rs:1023:9:1023:12 | item | &T | main.rs:1022:20:1022:30 | T |
-| main.rs:1023:9:1023:26 | item.get_content() |  | main.rs:984:9:984:21 | Content |
-| main.rs:1026:35:1026:38 | item |  | file://:0:0:0:0 | & |
-| main.rs:1026:35:1026:38 | item | &T | main.rs:1026:21:1026:32 | T |
-| main.rs:1026:45:1026:46 | c1 |  | main.rs:984:9:984:21 | Content |
-| main.rs:1026:61:1026:62 | c2 |  | main.rs:984:9:984:21 | Content |
-| main.rs:1026:77:1026:78 | c3 |  | main.rs:984:9:984:21 | Content |
+| main.rs:1001:13:1001:16 | self | &T | main.rs:993:5:1003:5 | Self [trait Subtrait2] |
+| main.rs:1001:25:1001:26 | c2 |  | main.rs:983:9:983:21 | Content |
+| main.rs:1009:19:1009:23 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1009:19:1009:23 | SelfParam | &T | main.rs:1005:5:1005:24 | MyType |
+| main.rs:1009:19:1009:23 | SelfParam | &T.T | main.rs:1007:10:1007:10 | T |
+| main.rs:1009:26:1009:33 | _content |  | main.rs:1007:10:1007:10 | T |
+| main.rs:1010:22:1010:42 | "Inserting content: \\n" |  | file://:0:0:0:0 | & |
+| main.rs:1010:22:1010:42 | "Inserting content: \\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:1010:22:1010:42 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1010:22:1010:42 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1016:24:1016:28 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1016:24:1016:28 | SelfParam | &T | main.rs:1005:5:1005:24 | MyType |
+| main.rs:1016:24:1016:28 | SelfParam | &T.T | main.rs:1014:10:1014:17 | T |
+| main.rs:1016:48:1018:9 | { ... } |  | main.rs:1014:10:1014:17 | T |
+| main.rs:1017:13:1017:19 | (...) |  | main.rs:1005:5:1005:24 | MyType |
+| main.rs:1017:13:1017:19 | (...) | T | main.rs:1014:10:1014:17 | T |
+| main.rs:1017:13:1017:21 | ... .0 |  | main.rs:1014:10:1014:17 | T |
+| main.rs:1017:13:1017:29 | ... .clone() |  | main.rs:1014:10:1014:17 | T |
+| main.rs:1017:14:1017:18 | * ... |  | main.rs:1005:5:1005:24 | MyType |
+| main.rs:1017:14:1017:18 | * ... | T | main.rs:1014:10:1014:17 | T |
+| main.rs:1017:15:1017:18 | self |  | file://:0:0:0:0 | & |
+| main.rs:1017:15:1017:18 | self | &T | main.rs:1005:5:1005:24 | MyType |
+| main.rs:1017:15:1017:18 | self | &T.T | main.rs:1014:10:1014:17 | T |
+| main.rs:1021:33:1021:36 | item |  | file://:0:0:0:0 | & |
+| main.rs:1021:33:1021:36 | item | &T | main.rs:1021:20:1021:30 | T |
+| main.rs:1021:57:1023:5 | { ... } |  | main.rs:983:9:983:21 | Content |
+| main.rs:1022:9:1022:12 | item |  | file://:0:0:0:0 | & |
+| main.rs:1022:9:1022:12 | item | &T | main.rs:1021:20:1021:30 | T |
+| main.rs:1022:9:1022:26 | item.get_content() |  | main.rs:983:9:983:21 | Content |
+| main.rs:1025:35:1025:38 | item |  | file://:0:0:0:0 | & |
+| main.rs:1025:35:1025:38 | item | &T | main.rs:1025:21:1025:32 | T |
+| main.rs:1025:45:1025:46 | c1 |  | main.rs:983:9:983:21 | Content |
+| main.rs:1025:61:1025:62 | c2 |  | main.rs:983:9:983:21 | Content |
+| main.rs:1025:77:1025:78 | c3 |  | main.rs:983:9:983:21 | Content |
+| main.rs:1026:9:1026:12 | item |  | file://:0:0:0:0 | & |
+| main.rs:1026:9:1026:12 | item | &T | main.rs:1025:21:1025:32 | T |
+| main.rs:1026:21:1026:22 | c1 |  | main.rs:983:9:983:21 | Content |
 | main.rs:1027:9:1027:12 | item |  | file://:0:0:0:0 | & |
-| main.rs:1027:9:1027:12 | item | &T | main.rs:1026:21:1026:32 | T |
-| main.rs:1027:21:1027:22 | c1 |  | main.rs:984:9:984:21 | Content |
-| main.rs:1028:9:1028:12 | item |  | file://:0:0:0:0 | & |
-| main.rs:1028:9:1028:12 | item | &T | main.rs:1026:21:1026:32 | T |
-| main.rs:1028:25:1028:26 | c2 |  | main.rs:984:9:984:21 | Content |
-| main.rs:1028:29:1028:30 | c3 |  | main.rs:984:9:984:21 | Content |
-| main.rs:1032:13:1032:17 | item1 |  | main.rs:1006:5:1006:24 | MyType |
-| main.rs:1032:13:1032:17 | item1 | T | {EXTERNAL LOCATION} | i64 |
-| main.rs:1032:21:1032:33 | MyType(...) |  | main.rs:1006:5:1006:24 | MyType |
-| main.rs:1032:21:1032:33 | MyType(...) | T | {EXTERNAL LOCATION} | i64 |
-| main.rs:1032:28:1032:32 | 42i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1033:25:1033:29 | item1 |  | main.rs:1006:5:1006:24 | MyType |
-| main.rs:1033:25:1033:29 | item1 | T | {EXTERNAL LOCATION} | i64 |
-| main.rs:1035:13:1035:17 | item2 |  | main.rs:1006:5:1006:24 | MyType |
-| main.rs:1035:13:1035:17 | item2 | T | {EXTERNAL LOCATION} | bool |
-| main.rs:1035:21:1035:32 | MyType(...) |  | main.rs:1006:5:1006:24 | MyType |
-| main.rs:1035:21:1035:32 | MyType(...) | T | {EXTERNAL LOCATION} | bool |
-| main.rs:1035:28:1035:31 | true |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1036:37:1036:42 | &item2 |  | file://:0:0:0:0 | & |
-| main.rs:1036:37:1036:42 | &item2 | &T | main.rs:1006:5:1006:24 | MyType |
-| main.rs:1036:37:1036:42 | &item2 | &T.T | {EXTERNAL LOCATION} | bool |
-| main.rs:1036:38:1036:42 | item2 |  | main.rs:1006:5:1006:24 | MyType |
-| main.rs:1036:38:1036:42 | item2 | T | {EXTERNAL LOCATION} | bool |
-| main.rs:1053:15:1053:18 | SelfParam |  | main.rs:1041:5:1045:5 | MyEnum |
-| main.rs:1053:15:1053:18 | SelfParam | A | main.rs:1052:10:1052:10 | T |
-| main.rs:1053:26:1058:9 | { ... } |  | main.rs:1052:10:1052:10 | T |
-| main.rs:1054:13:1057:13 | match self { ... } |  | main.rs:1052:10:1052:10 | T |
-| main.rs:1054:19:1054:22 | self |  | main.rs:1041:5:1045:5 | MyEnum |
-| main.rs:1054:19:1054:22 | self | A | main.rs:1052:10:1052:10 | T |
-| main.rs:1055:17:1055:29 | ...::C1(...) |  | main.rs:1041:5:1045:5 | MyEnum |
-| main.rs:1055:17:1055:29 | ...::C1(...) | A | main.rs:1052:10:1052:10 | T |
-| main.rs:1055:28:1055:28 | a |  | main.rs:1052:10:1052:10 | T |
-| main.rs:1055:34:1055:34 | a |  | main.rs:1052:10:1052:10 | T |
-| main.rs:1056:17:1056:32 | ...::C2 {...} |  | main.rs:1041:5:1045:5 | MyEnum |
-| main.rs:1056:17:1056:32 | ...::C2 {...} | A | main.rs:1052:10:1052:10 | T |
-| main.rs:1056:30:1056:30 | a |  | main.rs:1052:10:1052:10 | T |
-| main.rs:1056:37:1056:37 | a |  | main.rs:1052:10:1052:10 | T |
-| main.rs:1062:13:1062:13 | x |  | main.rs:1041:5:1045:5 | MyEnum |
-| main.rs:1062:13:1062:13 | x | A | main.rs:1047:5:1048:14 | S1 |
-| main.rs:1062:17:1062:30 | ...::C1(...) |  | main.rs:1041:5:1045:5 | MyEnum |
-| main.rs:1062:17:1062:30 | ...::C1(...) | A | main.rs:1047:5:1048:14 | S1 |
-| main.rs:1062:28:1062:29 | S1 |  | main.rs:1047:5:1048:14 | S1 |
-| main.rs:1063:13:1063:13 | y |  | main.rs:1041:5:1045:5 | MyEnum |
-| main.rs:1063:13:1063:13 | y | A | main.rs:1049:5:1050:14 | S2 |
-| main.rs:1063:17:1063:36 | ...::C2 {...} |  | main.rs:1041:5:1045:5 | MyEnum |
-| main.rs:1063:17:1063:36 | ...::C2 {...} | A | main.rs:1049:5:1050:14 | S2 |
-| main.rs:1063:33:1063:34 | S2 |  | main.rs:1049:5:1050:14 | S2 |
+| main.rs:1027:9:1027:12 | item | &T | main.rs:1025:21:1025:32 | T |
+| main.rs:1027:25:1027:26 | c2 |  | main.rs:983:9:983:21 | Content |
+| main.rs:1027:29:1027:30 | c3 |  | main.rs:983:9:983:21 | Content |
+| main.rs:1031:13:1031:17 | item1 |  | main.rs:1005:5:1005:24 | MyType |
+| main.rs:1031:13:1031:17 | item1 | T | {EXTERNAL LOCATION} | i64 |
+| main.rs:1031:21:1031:33 | MyType(...) |  | main.rs:1005:5:1005:24 | MyType |
+| main.rs:1031:21:1031:33 | MyType(...) | T | {EXTERNAL LOCATION} | i64 |
+| main.rs:1031:28:1031:32 | 42i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1032:25:1032:29 | item1 |  | main.rs:1005:5:1005:24 | MyType |
+| main.rs:1032:25:1032:29 | item1 | T | {EXTERNAL LOCATION} | i64 |
+| main.rs:1034:13:1034:17 | item2 |  | main.rs:1005:5:1005:24 | MyType |
+| main.rs:1034:13:1034:17 | item2 | T | {EXTERNAL LOCATION} | bool |
+| main.rs:1034:21:1034:32 | MyType(...) |  | main.rs:1005:5:1005:24 | MyType |
+| main.rs:1034:21:1034:32 | MyType(...) | T | {EXTERNAL LOCATION} | bool |
+| main.rs:1034:28:1034:31 | true |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1035:37:1035:42 | &item2 |  | file://:0:0:0:0 | & |
+| main.rs:1035:37:1035:42 | &item2 | &T | main.rs:1005:5:1005:24 | MyType |
+| main.rs:1035:37:1035:42 | &item2 | &T.T | {EXTERNAL LOCATION} | bool |
+| main.rs:1035:38:1035:42 | item2 |  | main.rs:1005:5:1005:24 | MyType |
+| main.rs:1035:38:1035:42 | item2 | T | {EXTERNAL LOCATION} | bool |
+| main.rs:1052:15:1052:18 | SelfParam |  | main.rs:1040:5:1044:5 | MyEnum |
+| main.rs:1052:15:1052:18 | SelfParam | A | main.rs:1051:10:1051:10 | T |
+| main.rs:1052:26:1057:9 | { ... } |  | main.rs:1051:10:1051:10 | T |
+| main.rs:1053:13:1056:13 | match self { ... } |  | main.rs:1051:10:1051:10 | T |
+| main.rs:1053:19:1053:22 | self |  | main.rs:1040:5:1044:5 | MyEnum |
+| main.rs:1053:19:1053:22 | self | A | main.rs:1051:10:1051:10 | T |
+| main.rs:1054:17:1054:29 | ...::C1(...) |  | main.rs:1040:5:1044:5 | MyEnum |
+| main.rs:1054:17:1054:29 | ...::C1(...) | A | main.rs:1051:10:1051:10 | T |
+| main.rs:1054:28:1054:28 | a |  | main.rs:1051:10:1051:10 | T |
+| main.rs:1054:34:1054:34 | a |  | main.rs:1051:10:1051:10 | T |
+| main.rs:1055:17:1055:32 | ...::C2 {...} |  | main.rs:1040:5:1044:5 | MyEnum |
+| main.rs:1055:17:1055:32 | ...::C2 {...} | A | main.rs:1051:10:1051:10 | T |
+| main.rs:1055:30:1055:30 | a |  | main.rs:1051:10:1051:10 | T |
+| main.rs:1055:37:1055:37 | a |  | main.rs:1051:10:1051:10 | T |
+| main.rs:1061:13:1061:13 | x |  | main.rs:1040:5:1044:5 | MyEnum |
+| main.rs:1061:13:1061:13 | x | A | main.rs:1046:5:1047:14 | S1 |
+| main.rs:1061:17:1061:30 | ...::C1(...) |  | main.rs:1040:5:1044:5 | MyEnum |
+| main.rs:1061:17:1061:30 | ...::C1(...) | A | main.rs:1046:5:1047:14 | S1 |
+| main.rs:1061:28:1061:29 | S1 |  | main.rs:1046:5:1047:14 | S1 |
+| main.rs:1062:13:1062:13 | y |  | main.rs:1040:5:1044:5 | MyEnum |
+| main.rs:1062:13:1062:13 | y | A | main.rs:1048:5:1049:14 | S2 |
+| main.rs:1062:17:1062:36 | ...::C2 {...} |  | main.rs:1040:5:1044:5 | MyEnum |
+| main.rs:1062:17:1062:36 | ...::C2 {...} | A | main.rs:1048:5:1049:14 | S2 |
+| main.rs:1062:33:1062:34 | S2 |  | main.rs:1048:5:1049:14 | S2 |
+| main.rs:1064:18:1064:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:1064:18:1064:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:1064:18:1064:31 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1064:18:1064:31 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1064:26:1064:26 | x |  | main.rs:1040:5:1044:5 | MyEnum |
+| main.rs:1064:26:1064:26 | x | A | main.rs:1046:5:1047:14 | S1 |
+| main.rs:1064:26:1064:31 | x.m1() |  | main.rs:1046:5:1047:14 | S1 |
 | main.rs:1065:18:1065:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
 | main.rs:1065:18:1065:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
 | main.rs:1065:18:1065:31 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
 | main.rs:1065:18:1065:31 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1065:26:1065:26 | x |  | main.rs:1041:5:1045:5 | MyEnum |
-| main.rs:1065:26:1065:26 | x | A | main.rs:1047:5:1048:14 | S1 |
-| main.rs:1065:26:1065:31 | x.m1() |  | main.rs:1047:5:1048:14 | S1 |
-| main.rs:1066:18:1066:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:1066:18:1066:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:1066:18:1066:31 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1066:18:1066:31 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1066:26:1066:26 | y |  | main.rs:1041:5:1045:5 | MyEnum |
-| main.rs:1066:26:1066:26 | y | A | main.rs:1049:5:1050:14 | S2 |
-| main.rs:1066:26:1066:31 | y.m1() |  | main.rs:1049:5:1050:14 | S2 |
-| main.rs:1088:15:1088:18 | SelfParam |  | main.rs:1086:5:1089:5 | Self [trait MyTrait1] |
-| main.rs:1093:15:1093:19 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:1093:15:1093:19 | SelfParam | &T | main.rs:1091:5:1103:5 | Self [trait MyTrait2] |
-| main.rs:1096:9:1102:9 | { ... } |  | main.rs:1091:20:1091:22 | Tr2 |
-| main.rs:1097:13:1101:13 | if ... {...} else {...} |  | main.rs:1091:20:1091:22 | Tr2 |
-| main.rs:1097:16:1097:16 | 3 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:1097:16:1097:20 | ... > ... |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1097:20:1097:20 | 2 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:1097:22:1099:13 | { ... } |  | main.rs:1091:20:1091:22 | Tr2 |
-| main.rs:1098:17:1098:20 | self |  | file://:0:0:0:0 | & |
-| main.rs:1098:17:1098:20 | self | &T | main.rs:1091:5:1103:5 | Self [trait MyTrait2] |
-| main.rs:1098:17:1098:25 | self.m1() |  | main.rs:1091:20:1091:22 | Tr2 |
-| main.rs:1099:20:1101:13 | { ... } |  | main.rs:1091:20:1091:22 | Tr2 |
-| main.rs:1100:17:1100:31 | ...::m1(...) |  | main.rs:1091:20:1091:22 | Tr2 |
-| main.rs:1100:26:1100:30 | * ... |  | main.rs:1091:5:1103:5 | Self [trait MyTrait2] |
-| main.rs:1100:27:1100:30 | self |  | file://:0:0:0:0 | & |
-| main.rs:1100:27:1100:30 | self | &T | main.rs:1091:5:1103:5 | Self [trait MyTrait2] |
-| main.rs:1107:15:1107:18 | SelfParam |  | main.rs:1105:5:1117:5 | Self [trait MyTrait3] |
-| main.rs:1110:9:1116:9 | { ... } |  | main.rs:1105:20:1105:22 | Tr3 |
-| main.rs:1111:13:1115:13 | if ... {...} else {...} |  | main.rs:1105:20:1105:22 | Tr3 |
-| main.rs:1111:16:1111:16 | 3 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:1111:16:1111:20 | ... > ... |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1111:20:1111:20 | 2 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:1111:22:1113:13 | { ... } |  | main.rs:1105:20:1105:22 | Tr3 |
-| main.rs:1112:17:1112:20 | self |  | main.rs:1105:5:1117:5 | Self [trait MyTrait3] |
-| main.rs:1112:17:1112:25 | self.m2() |  | main.rs:1071:5:1074:5 | MyThing |
-| main.rs:1112:17:1112:25 | self.m2() | A | main.rs:1105:20:1105:22 | Tr3 |
-| main.rs:1112:17:1112:27 | ... .a |  | main.rs:1105:20:1105:22 | Tr3 |
-| main.rs:1113:20:1115:13 | { ... } |  | main.rs:1105:20:1105:22 | Tr3 |
-| main.rs:1114:17:1114:31 | ...::m2(...) |  | main.rs:1071:5:1074:5 | MyThing |
-| main.rs:1114:17:1114:31 | ...::m2(...) | A | main.rs:1105:20:1105:22 | Tr3 |
-| main.rs:1114:17:1114:33 | ... .a |  | main.rs:1105:20:1105:22 | Tr3 |
-| main.rs:1114:26:1114:30 | &self |  | file://:0:0:0:0 | & |
-| main.rs:1114:26:1114:30 | &self | &T | main.rs:1105:5:1117:5 | Self [trait MyTrait3] |
-| main.rs:1114:27:1114:30 | self |  | main.rs:1105:5:1117:5 | Self [trait MyTrait3] |
-| main.rs:1121:15:1121:18 | SelfParam |  | main.rs:1071:5:1074:5 | MyThing |
-| main.rs:1121:15:1121:18 | SelfParam | A | main.rs:1119:10:1119:10 | T |
-| main.rs:1121:26:1123:9 | { ... } |  | main.rs:1119:10:1119:10 | T |
-| main.rs:1122:13:1122:16 | self |  | main.rs:1071:5:1074:5 | MyThing |
-| main.rs:1122:13:1122:16 | self | A | main.rs:1119:10:1119:10 | T |
-| main.rs:1122:13:1122:18 | self.a |  | main.rs:1119:10:1119:10 | T |
-| main.rs:1130:15:1130:18 | SelfParam |  | main.rs:1076:5:1079:5 | MyThing2 |
-| main.rs:1130:15:1130:18 | SelfParam | A | main.rs:1128:10:1128:10 | T |
-| main.rs:1130:35:1132:9 | { ... } |  | main.rs:1071:5:1074:5 | MyThing |
-| main.rs:1130:35:1132:9 | { ... } | A | main.rs:1128:10:1128:10 | T |
-| main.rs:1131:13:1131:33 | MyThing {...} |  | main.rs:1071:5:1074:5 | MyThing |
-| main.rs:1131:13:1131:33 | MyThing {...} | A | main.rs:1128:10:1128:10 | T |
-| main.rs:1131:26:1131:29 | self |  | main.rs:1076:5:1079:5 | MyThing2 |
-| main.rs:1131:26:1131:29 | self | A | main.rs:1128:10:1128:10 | T |
-| main.rs:1131:26:1131:31 | self.a |  | main.rs:1128:10:1128:10 | T |
-| main.rs:1139:44:1139:44 | x |  | main.rs:1139:26:1139:41 | T2 |
-| main.rs:1139:57:1141:5 | { ... } |  | main.rs:1139:22:1139:23 | T1 |
-| main.rs:1140:9:1140:9 | x |  | main.rs:1139:26:1139:41 | T2 |
-| main.rs:1140:9:1140:14 | x.m1() |  | main.rs:1139:22:1139:23 | T1 |
-| main.rs:1143:56:1143:56 | x |  | main.rs:1143:39:1143:53 | T |
-| main.rs:1145:13:1145:13 | a |  | main.rs:1071:5:1074:5 | MyThing |
-| main.rs:1145:13:1145:13 | a | A | main.rs:1081:5:1082:14 | S1 |
-| main.rs:1145:17:1145:17 | x |  | main.rs:1143:39:1143:53 | T |
-| main.rs:1145:17:1145:22 | x.m1() |  | main.rs:1071:5:1074:5 | MyThing |
-| main.rs:1145:17:1145:22 | x.m1() | A | main.rs:1081:5:1082:14 | S1 |
-| main.rs:1146:18:1146:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:1146:18:1146:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:1146:18:1146:26 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1146:18:1146:26 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1146:26:1146:26 | a |  | main.rs:1071:5:1074:5 | MyThing |
-| main.rs:1146:26:1146:26 | a | A | main.rs:1081:5:1082:14 | S1 |
-| main.rs:1150:13:1150:13 | x |  | main.rs:1071:5:1074:5 | MyThing |
-| main.rs:1150:13:1150:13 | x | A | main.rs:1081:5:1082:14 | S1 |
-| main.rs:1150:17:1150:33 | MyThing {...} |  | main.rs:1071:5:1074:5 | MyThing |
-| main.rs:1150:17:1150:33 | MyThing {...} | A | main.rs:1081:5:1082:14 | S1 |
-| main.rs:1150:30:1150:31 | S1 |  | main.rs:1081:5:1082:14 | S1 |
-| main.rs:1151:13:1151:13 | y |  | main.rs:1071:5:1074:5 | MyThing |
-| main.rs:1151:13:1151:13 | y | A | main.rs:1083:5:1084:14 | S2 |
-| main.rs:1151:17:1151:33 | MyThing {...} |  | main.rs:1071:5:1074:5 | MyThing |
-| main.rs:1151:17:1151:33 | MyThing {...} | A | main.rs:1083:5:1084:14 | S2 |
-| main.rs:1151:30:1151:31 | S2 |  | main.rs:1083:5:1084:14 | S2 |
+| main.rs:1065:26:1065:26 | y |  | main.rs:1040:5:1044:5 | MyEnum |
+| main.rs:1065:26:1065:26 | y | A | main.rs:1048:5:1049:14 | S2 |
+| main.rs:1065:26:1065:31 | y.m1() |  | main.rs:1048:5:1049:14 | S2 |
+| main.rs:1087:15:1087:18 | SelfParam |  | main.rs:1085:5:1088:5 | Self [trait MyTrait1] |
+| main.rs:1092:15:1092:19 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1092:15:1092:19 | SelfParam | &T | main.rs:1090:5:1102:5 | Self [trait MyTrait2] |
+| main.rs:1095:9:1101:9 | { ... } |  | main.rs:1090:20:1090:22 | Tr2 |
+| main.rs:1096:13:1100:13 | if ... {...} else {...} |  | main.rs:1090:20:1090:22 | Tr2 |
+| main.rs:1096:16:1096:16 | 3 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:1096:16:1096:20 | ... > ... |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1096:20:1096:20 | 2 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:1096:22:1098:13 | { ... } |  | main.rs:1090:20:1090:22 | Tr2 |
+| main.rs:1097:17:1097:20 | self |  | file://:0:0:0:0 | & |
+| main.rs:1097:17:1097:20 | self | &T | main.rs:1090:5:1102:5 | Self [trait MyTrait2] |
+| main.rs:1097:17:1097:25 | self.m1() |  | main.rs:1090:20:1090:22 | Tr2 |
+| main.rs:1098:20:1100:13 | { ... } |  | main.rs:1090:20:1090:22 | Tr2 |
+| main.rs:1099:17:1099:31 | ...::m1(...) |  | main.rs:1090:20:1090:22 | Tr2 |
+| main.rs:1099:26:1099:30 | * ... |  | main.rs:1090:5:1102:5 | Self [trait MyTrait2] |
+| main.rs:1099:27:1099:30 | self |  | file://:0:0:0:0 | & |
+| main.rs:1099:27:1099:30 | self | &T | main.rs:1090:5:1102:5 | Self [trait MyTrait2] |
+| main.rs:1106:15:1106:18 | SelfParam |  | main.rs:1104:5:1116:5 | Self [trait MyTrait3] |
+| main.rs:1109:9:1115:9 | { ... } |  | main.rs:1104:20:1104:22 | Tr3 |
+| main.rs:1110:13:1114:13 | if ... {...} else {...} |  | main.rs:1104:20:1104:22 | Tr3 |
+| main.rs:1110:16:1110:16 | 3 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:1110:16:1110:20 | ... > ... |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1110:20:1110:20 | 2 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:1110:22:1112:13 | { ... } |  | main.rs:1104:20:1104:22 | Tr3 |
+| main.rs:1111:17:1111:20 | self |  | main.rs:1104:5:1116:5 | Self [trait MyTrait3] |
+| main.rs:1111:17:1111:25 | self.m2() |  | main.rs:1070:5:1073:5 | MyThing |
+| main.rs:1111:17:1111:25 | self.m2() | A | main.rs:1104:20:1104:22 | Tr3 |
+| main.rs:1111:17:1111:27 | ... .a |  | main.rs:1104:20:1104:22 | Tr3 |
+| main.rs:1112:20:1114:13 | { ... } |  | main.rs:1104:20:1104:22 | Tr3 |
+| main.rs:1113:17:1113:31 | ...::m2(...) |  | main.rs:1070:5:1073:5 | MyThing |
+| main.rs:1113:17:1113:31 | ...::m2(...) | A | main.rs:1104:20:1104:22 | Tr3 |
+| main.rs:1113:17:1113:33 | ... .a |  | main.rs:1104:20:1104:22 | Tr3 |
+| main.rs:1113:26:1113:30 | &self |  | file://:0:0:0:0 | & |
+| main.rs:1113:26:1113:30 | &self | &T | main.rs:1104:5:1116:5 | Self [trait MyTrait3] |
+| main.rs:1113:27:1113:30 | self |  | main.rs:1104:5:1116:5 | Self [trait MyTrait3] |
+| main.rs:1120:15:1120:18 | SelfParam |  | main.rs:1070:5:1073:5 | MyThing |
+| main.rs:1120:15:1120:18 | SelfParam | A | main.rs:1118:10:1118:10 | T |
+| main.rs:1120:26:1122:9 | { ... } |  | main.rs:1118:10:1118:10 | T |
+| main.rs:1121:13:1121:16 | self |  | main.rs:1070:5:1073:5 | MyThing |
+| main.rs:1121:13:1121:16 | self | A | main.rs:1118:10:1118:10 | T |
+| main.rs:1121:13:1121:18 | self.a |  | main.rs:1118:10:1118:10 | T |
+| main.rs:1129:15:1129:18 | SelfParam |  | main.rs:1075:5:1078:5 | MyThing2 |
+| main.rs:1129:15:1129:18 | SelfParam | A | main.rs:1127:10:1127:10 | T |
+| main.rs:1129:35:1131:9 | { ... } |  | main.rs:1070:5:1073:5 | MyThing |
+| main.rs:1129:35:1131:9 | { ... } | A | main.rs:1127:10:1127:10 | T |
+| main.rs:1130:13:1130:33 | MyThing {...} |  | main.rs:1070:5:1073:5 | MyThing |
+| main.rs:1130:13:1130:33 | MyThing {...} | A | main.rs:1127:10:1127:10 | T |
+| main.rs:1130:26:1130:29 | self |  | main.rs:1075:5:1078:5 | MyThing2 |
+| main.rs:1130:26:1130:29 | self | A | main.rs:1127:10:1127:10 | T |
+| main.rs:1130:26:1130:31 | self.a |  | main.rs:1127:10:1127:10 | T |
+| main.rs:1138:44:1138:44 | x |  | main.rs:1138:26:1138:41 | T2 |
+| main.rs:1138:57:1140:5 | { ... } |  | main.rs:1138:22:1138:23 | T1 |
+| main.rs:1139:9:1139:9 | x |  | main.rs:1138:26:1138:41 | T2 |
+| main.rs:1139:9:1139:14 | x.m1() |  | main.rs:1138:22:1138:23 | T1 |
+| main.rs:1142:56:1142:56 | x |  | main.rs:1142:39:1142:53 | T |
+| main.rs:1144:13:1144:13 | a |  | main.rs:1070:5:1073:5 | MyThing |
+| main.rs:1144:13:1144:13 | a | A | main.rs:1080:5:1081:14 | S1 |
+| main.rs:1144:17:1144:17 | x |  | main.rs:1142:39:1142:53 | T |
+| main.rs:1144:17:1144:22 | x.m1() |  | main.rs:1070:5:1073:5 | MyThing |
+| main.rs:1144:17:1144:22 | x.m1() | A | main.rs:1080:5:1081:14 | S1 |
+| main.rs:1145:18:1145:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:1145:18:1145:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:1145:18:1145:26 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1145:18:1145:26 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1145:26:1145:26 | a |  | main.rs:1070:5:1073:5 | MyThing |
+| main.rs:1145:26:1145:26 | a | A | main.rs:1080:5:1081:14 | S1 |
+| main.rs:1149:13:1149:13 | x |  | main.rs:1070:5:1073:5 | MyThing |
+| main.rs:1149:13:1149:13 | x | A | main.rs:1080:5:1081:14 | S1 |
+| main.rs:1149:17:1149:33 | MyThing {...} |  | main.rs:1070:5:1073:5 | MyThing |
+| main.rs:1149:17:1149:33 | MyThing {...} | A | main.rs:1080:5:1081:14 | S1 |
+| main.rs:1149:30:1149:31 | S1 |  | main.rs:1080:5:1081:14 | S1 |
+| main.rs:1150:13:1150:13 | y |  | main.rs:1070:5:1073:5 | MyThing |
+| main.rs:1150:13:1150:13 | y | A | main.rs:1082:5:1083:14 | S2 |
+| main.rs:1150:17:1150:33 | MyThing {...} |  | main.rs:1070:5:1073:5 | MyThing |
+| main.rs:1150:17:1150:33 | MyThing {...} | A | main.rs:1082:5:1083:14 | S2 |
+| main.rs:1150:30:1150:31 | S2 |  | main.rs:1082:5:1083:14 | S2 |
+| main.rs:1152:18:1152:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:1152:18:1152:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:1152:18:1152:31 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1152:18:1152:31 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1152:26:1152:26 | x |  | main.rs:1070:5:1073:5 | MyThing |
+| main.rs:1152:26:1152:26 | x | A | main.rs:1080:5:1081:14 | S1 |
+| main.rs:1152:26:1152:31 | x.m1() |  | main.rs:1080:5:1081:14 | S1 |
 | main.rs:1153:18:1153:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
 | main.rs:1153:18:1153:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
 | main.rs:1153:18:1153:31 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
 | main.rs:1153:18:1153:31 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1153:26:1153:26 | x |  | main.rs:1071:5:1074:5 | MyThing |
-| main.rs:1153:26:1153:26 | x | A | main.rs:1081:5:1082:14 | S1 |
-| main.rs:1153:26:1153:31 | x.m1() |  | main.rs:1081:5:1082:14 | S1 |
-| main.rs:1154:18:1154:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:1154:18:1154:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:1154:18:1154:31 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1154:18:1154:31 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1154:26:1154:26 | y |  | main.rs:1071:5:1074:5 | MyThing |
-| main.rs:1154:26:1154:26 | y | A | main.rs:1083:5:1084:14 | S2 |
-| main.rs:1154:26:1154:31 | y.m1() |  | main.rs:1083:5:1084:14 | S2 |
-| main.rs:1156:13:1156:13 | x |  | main.rs:1071:5:1074:5 | MyThing |
-| main.rs:1156:13:1156:13 | x | A | main.rs:1081:5:1082:14 | S1 |
-| main.rs:1156:17:1156:33 | MyThing {...} |  | main.rs:1071:5:1074:5 | MyThing |
-| main.rs:1156:17:1156:33 | MyThing {...} | A | main.rs:1081:5:1082:14 | S1 |
-| main.rs:1156:30:1156:31 | S1 |  | main.rs:1081:5:1082:14 | S1 |
-| main.rs:1157:13:1157:13 | y |  | main.rs:1071:5:1074:5 | MyThing |
-| main.rs:1157:13:1157:13 | y | A | main.rs:1083:5:1084:14 | S2 |
-| main.rs:1157:17:1157:33 | MyThing {...} |  | main.rs:1071:5:1074:5 | MyThing |
-| main.rs:1157:17:1157:33 | MyThing {...} | A | main.rs:1083:5:1084:14 | S2 |
-| main.rs:1157:30:1157:31 | S2 |  | main.rs:1083:5:1084:14 | S2 |
+| main.rs:1153:26:1153:26 | y |  | main.rs:1070:5:1073:5 | MyThing |
+| main.rs:1153:26:1153:26 | y | A | main.rs:1082:5:1083:14 | S2 |
+| main.rs:1153:26:1153:31 | y.m1() |  | main.rs:1082:5:1083:14 | S2 |
+| main.rs:1155:13:1155:13 | x |  | main.rs:1070:5:1073:5 | MyThing |
+| main.rs:1155:13:1155:13 | x | A | main.rs:1080:5:1081:14 | S1 |
+| main.rs:1155:17:1155:33 | MyThing {...} |  | main.rs:1070:5:1073:5 | MyThing |
+| main.rs:1155:17:1155:33 | MyThing {...} | A | main.rs:1080:5:1081:14 | S1 |
+| main.rs:1155:30:1155:31 | S1 |  | main.rs:1080:5:1081:14 | S1 |
+| main.rs:1156:13:1156:13 | y |  | main.rs:1070:5:1073:5 | MyThing |
+| main.rs:1156:13:1156:13 | y | A | main.rs:1082:5:1083:14 | S2 |
+| main.rs:1156:17:1156:33 | MyThing {...} |  | main.rs:1070:5:1073:5 | MyThing |
+| main.rs:1156:17:1156:33 | MyThing {...} | A | main.rs:1082:5:1083:14 | S2 |
+| main.rs:1156:30:1156:31 | S2 |  | main.rs:1082:5:1083:14 | S2 |
+| main.rs:1158:18:1158:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:1158:18:1158:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:1158:18:1158:31 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1158:18:1158:31 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1158:26:1158:26 | x |  | main.rs:1070:5:1073:5 | MyThing |
+| main.rs:1158:26:1158:26 | x | A | main.rs:1080:5:1081:14 | S1 |
+| main.rs:1158:26:1158:31 | x.m2() |  | main.rs:1080:5:1081:14 | S1 |
 | main.rs:1159:18:1159:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
 | main.rs:1159:18:1159:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
 | main.rs:1159:18:1159:31 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
 | main.rs:1159:18:1159:31 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1159:26:1159:26 | x |  | main.rs:1071:5:1074:5 | MyThing |
-| main.rs:1159:26:1159:26 | x | A | main.rs:1081:5:1082:14 | S1 |
-| main.rs:1159:26:1159:31 | x.m2() |  | main.rs:1081:5:1082:14 | S1 |
-| main.rs:1160:18:1160:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:1160:18:1160:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:1160:18:1160:31 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1160:18:1160:31 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1160:26:1160:26 | y |  | main.rs:1071:5:1074:5 | MyThing |
-| main.rs:1160:26:1160:26 | y | A | main.rs:1083:5:1084:14 | S2 |
-| main.rs:1160:26:1160:31 | y.m2() |  | main.rs:1083:5:1084:14 | S2 |
-| main.rs:1162:13:1162:13 | x |  | main.rs:1076:5:1079:5 | MyThing2 |
-| main.rs:1162:13:1162:13 | x | A | main.rs:1081:5:1082:14 | S1 |
-| main.rs:1162:17:1162:34 | MyThing2 {...} |  | main.rs:1076:5:1079:5 | MyThing2 |
-| main.rs:1162:17:1162:34 | MyThing2 {...} | A | main.rs:1081:5:1082:14 | S1 |
-| main.rs:1162:31:1162:32 | S1 |  | main.rs:1081:5:1082:14 | S1 |
-| main.rs:1163:13:1163:13 | y |  | main.rs:1076:5:1079:5 | MyThing2 |
-| main.rs:1163:13:1163:13 | y | A | main.rs:1083:5:1084:14 | S2 |
-| main.rs:1163:17:1163:34 | MyThing2 {...} |  | main.rs:1076:5:1079:5 | MyThing2 |
-| main.rs:1163:17:1163:34 | MyThing2 {...} | A | main.rs:1083:5:1084:14 | S2 |
-| main.rs:1163:31:1163:32 | S2 |  | main.rs:1083:5:1084:14 | S2 |
+| main.rs:1159:26:1159:26 | y |  | main.rs:1070:5:1073:5 | MyThing |
+| main.rs:1159:26:1159:26 | y | A | main.rs:1082:5:1083:14 | S2 |
+| main.rs:1159:26:1159:31 | y.m2() |  | main.rs:1082:5:1083:14 | S2 |
+| main.rs:1161:13:1161:13 | x |  | main.rs:1075:5:1078:5 | MyThing2 |
+| main.rs:1161:13:1161:13 | x | A | main.rs:1080:5:1081:14 | S1 |
+| main.rs:1161:17:1161:34 | MyThing2 {...} |  | main.rs:1075:5:1078:5 | MyThing2 |
+| main.rs:1161:17:1161:34 | MyThing2 {...} | A | main.rs:1080:5:1081:14 | S1 |
+| main.rs:1161:31:1161:32 | S1 |  | main.rs:1080:5:1081:14 | S1 |
+| main.rs:1162:13:1162:13 | y |  | main.rs:1075:5:1078:5 | MyThing2 |
+| main.rs:1162:13:1162:13 | y | A | main.rs:1082:5:1083:14 | S2 |
+| main.rs:1162:17:1162:34 | MyThing2 {...} |  | main.rs:1075:5:1078:5 | MyThing2 |
+| main.rs:1162:17:1162:34 | MyThing2 {...} | A | main.rs:1082:5:1083:14 | S2 |
+| main.rs:1162:31:1162:32 | S2 |  | main.rs:1082:5:1083:14 | S2 |
+| main.rs:1164:18:1164:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:1164:18:1164:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:1164:18:1164:31 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1164:18:1164:31 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1164:26:1164:26 | x |  | main.rs:1075:5:1078:5 | MyThing2 |
+| main.rs:1164:26:1164:26 | x | A | main.rs:1080:5:1081:14 | S1 |
+| main.rs:1164:26:1164:31 | x.m3() |  | main.rs:1080:5:1081:14 | S1 |
 | main.rs:1165:18:1165:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
 | main.rs:1165:18:1165:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
 | main.rs:1165:18:1165:31 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
 | main.rs:1165:18:1165:31 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1165:26:1165:26 | x |  | main.rs:1076:5:1079:5 | MyThing2 |
-| main.rs:1165:26:1165:26 | x | A | main.rs:1081:5:1082:14 | S1 |
-| main.rs:1165:26:1165:31 | x.m3() |  | main.rs:1081:5:1082:14 | S1 |
-| main.rs:1166:18:1166:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:1166:18:1166:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:1166:18:1166:31 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1166:18:1166:31 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1166:26:1166:26 | y |  | main.rs:1076:5:1079:5 | MyThing2 |
-| main.rs:1166:26:1166:26 | y | A | main.rs:1083:5:1084:14 | S2 |
-| main.rs:1166:26:1166:31 | y.m3() |  | main.rs:1083:5:1084:14 | S2 |
-| main.rs:1168:13:1168:13 | x |  | main.rs:1071:5:1074:5 | MyThing |
-| main.rs:1168:13:1168:13 | x | A | main.rs:1081:5:1082:14 | S1 |
-| main.rs:1168:17:1168:33 | MyThing {...} |  | main.rs:1071:5:1074:5 | MyThing |
-| main.rs:1168:17:1168:33 | MyThing {...} | A | main.rs:1081:5:1082:14 | S1 |
-| main.rs:1168:30:1168:31 | S1 |  | main.rs:1081:5:1082:14 | S1 |
-| main.rs:1169:13:1169:13 | s |  | main.rs:1081:5:1082:14 | S1 |
-| main.rs:1169:17:1169:32 | call_trait_m1(...) |  | main.rs:1081:5:1082:14 | S1 |
-| main.rs:1169:31:1169:31 | x |  | main.rs:1071:5:1074:5 | MyThing |
-| main.rs:1169:31:1169:31 | x | A | main.rs:1081:5:1082:14 | S1 |
-| main.rs:1171:13:1171:13 | x |  | main.rs:1076:5:1079:5 | MyThing2 |
-| main.rs:1171:13:1171:13 | x | A | main.rs:1083:5:1084:14 | S2 |
-| main.rs:1171:17:1171:34 | MyThing2 {...} |  | main.rs:1076:5:1079:5 | MyThing2 |
-| main.rs:1171:17:1171:34 | MyThing2 {...} | A | main.rs:1083:5:1084:14 | S2 |
-| main.rs:1171:31:1171:32 | S2 |  | main.rs:1083:5:1084:14 | S2 |
-| main.rs:1172:13:1172:13 | s |  | main.rs:1071:5:1074:5 | MyThing |
-| main.rs:1172:13:1172:13 | s | A | main.rs:1083:5:1084:14 | S2 |
-| main.rs:1172:17:1172:32 | call_trait_m1(...) |  | main.rs:1071:5:1074:5 | MyThing |
-| main.rs:1172:17:1172:32 | call_trait_m1(...) | A | main.rs:1083:5:1084:14 | S2 |
-| main.rs:1172:31:1172:31 | x |  | main.rs:1076:5:1079:5 | MyThing2 |
-| main.rs:1172:31:1172:31 | x | A | main.rs:1083:5:1084:14 | S2 |
-| main.rs:1189:22:1189:22 | x |  | file://:0:0:0:0 | & |
-| main.rs:1189:22:1189:22 | x | &T | main.rs:1189:11:1189:19 | T |
-| main.rs:1189:35:1191:5 | { ... } |  | file://:0:0:0:0 | & |
-| main.rs:1189:35:1191:5 | { ... } | &T | main.rs:1189:11:1189:19 | T |
-| main.rs:1190:9:1190:9 | x |  | file://:0:0:0:0 | & |
-| main.rs:1190:9:1190:9 | x | &T | main.rs:1189:11:1189:19 | T |
-| main.rs:1194:17:1194:20 | SelfParam |  | main.rs:1179:5:1180:14 | S1 |
-| main.rs:1194:29:1196:9 | { ... } |  | main.rs:1182:5:1183:14 | S2 |
-| main.rs:1195:13:1195:14 | S2 |  | main.rs:1182:5:1183:14 | S2 |
-| main.rs:1199:21:1199:21 | x |  | main.rs:1199:13:1199:14 | T1 |
-| main.rs:1202:5:1204:5 | { ... } |  | main.rs:1199:17:1199:18 | T2 |
-| main.rs:1203:9:1203:9 | x |  | main.rs:1199:13:1199:14 | T1 |
-| main.rs:1203:9:1203:16 | x.into() |  | main.rs:1199:17:1199:18 | T2 |
-| main.rs:1207:13:1207:13 | x |  | main.rs:1179:5:1180:14 | S1 |
-| main.rs:1207:17:1207:18 | S1 |  | main.rs:1179:5:1180:14 | S1 |
-| main.rs:1208:18:1208:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:1208:18:1208:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:1208:18:1208:31 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1208:18:1208:31 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1208:26:1208:31 | id(...) |  | file://:0:0:0:0 | & |
-| main.rs:1208:26:1208:31 | id(...) | &T | main.rs:1179:5:1180:14 | S1 |
-| main.rs:1208:29:1208:30 | &x |  | file://:0:0:0:0 | & |
-| main.rs:1208:29:1208:30 | &x | &T | main.rs:1179:5:1180:14 | S1 |
-| main.rs:1208:30:1208:30 | x |  | main.rs:1179:5:1180:14 | S1 |
-| main.rs:1210:13:1210:13 | x |  | main.rs:1179:5:1180:14 | S1 |
-| main.rs:1210:17:1210:18 | S1 |  | main.rs:1179:5:1180:14 | S1 |
-| main.rs:1211:18:1211:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:1211:18:1211:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:1211:18:1211:37 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1211:18:1211:37 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1211:26:1211:37 | id::<...>(...) |  | file://:0:0:0:0 | & |
-| main.rs:1211:26:1211:37 | id::<...>(...) | &T | main.rs:1179:5:1180:14 | S1 |
-| main.rs:1211:35:1211:36 | &x |  | file://:0:0:0:0 | & |
-| main.rs:1211:35:1211:36 | &x | &T | main.rs:1179:5:1180:14 | S1 |
-| main.rs:1211:36:1211:36 | x |  | main.rs:1179:5:1180:14 | S1 |
-| main.rs:1213:13:1213:13 | x |  | main.rs:1179:5:1180:14 | S1 |
-| main.rs:1213:13:1213:13 | x |  | main.rs:1185:5:1185:25 | dyn Trait |
-| main.rs:1213:17:1213:18 | S1 |  | main.rs:1179:5:1180:14 | S1 |
-| main.rs:1213:17:1213:18 | S1 |  | main.rs:1185:5:1185:25 | dyn Trait |
-| main.rs:1215:18:1215:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:1215:18:1215:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:1215:18:1215:44 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1215:18:1215:44 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1215:26:1215:44 | id::<...>(...) |  | file://:0:0:0:0 | & |
-| main.rs:1215:26:1215:44 | id::<...>(...) | &T | main.rs:1185:5:1185:25 | dyn Trait |
-| main.rs:1215:42:1215:43 | &x |  | file://:0:0:0:0 | & |
-| main.rs:1215:42:1215:43 | &x | &T | main.rs:1179:5:1180:14 | S1 |
-| main.rs:1215:42:1215:43 | &x | &T | main.rs:1185:5:1185:25 | dyn Trait |
-| main.rs:1215:43:1215:43 | x |  | main.rs:1179:5:1180:14 | S1 |
-| main.rs:1215:43:1215:43 | x |  | main.rs:1185:5:1185:25 | dyn Trait |
-| main.rs:1217:13:1217:13 | x |  | main.rs:1179:5:1180:14 | S1 |
-| main.rs:1217:17:1217:18 | S1 |  | main.rs:1179:5:1180:14 | S1 |
-| main.rs:1218:9:1218:25 | into::<...>(...) |  | main.rs:1182:5:1183:14 | S2 |
-| main.rs:1218:24:1218:24 | x |  | main.rs:1179:5:1180:14 | S1 |
-| main.rs:1220:13:1220:13 | x |  | main.rs:1179:5:1180:14 | S1 |
-| main.rs:1220:17:1220:18 | S1 |  | main.rs:1179:5:1180:14 | S1 |
-| main.rs:1221:13:1221:13 | y |  | main.rs:1182:5:1183:14 | S2 |
-| main.rs:1221:21:1221:27 | into(...) |  | main.rs:1182:5:1183:14 | S2 |
-| main.rs:1221:26:1221:26 | x |  | main.rs:1179:5:1180:14 | S1 |
-| main.rs:1235:22:1235:25 | SelfParam |  | main.rs:1226:5:1232:5 | PairOption |
-| main.rs:1235:22:1235:25 | SelfParam | Fst | main.rs:1234:10:1234:12 | Fst |
-| main.rs:1235:22:1235:25 | SelfParam | Snd | main.rs:1234:15:1234:17 | Snd |
-| main.rs:1235:35:1242:9 | { ... } |  | main.rs:1234:15:1234:17 | Snd |
-| main.rs:1236:13:1241:13 | match self { ... } |  | main.rs:1234:15:1234:17 | Snd |
-| main.rs:1236:19:1236:22 | self |  | main.rs:1226:5:1232:5 | PairOption |
-| main.rs:1236:19:1236:22 | self | Fst | main.rs:1234:10:1234:12 | Fst |
-| main.rs:1236:19:1236:22 | self | Snd | main.rs:1234:15:1234:17 | Snd |
-| main.rs:1237:17:1237:38 | ...::PairNone(...) |  | main.rs:1226:5:1232:5 | PairOption |
-| main.rs:1237:17:1237:38 | ...::PairNone(...) | Fst | main.rs:1234:10:1234:12 | Fst |
-| main.rs:1237:17:1237:38 | ...::PairNone(...) | Snd | main.rs:1234:15:1234:17 | Snd |
-| main.rs:1237:43:1237:82 | MacroExpr |  | main.rs:1234:15:1234:17 | Snd |
-| main.rs:1237:50:1237:81 | "PairNone has no second elemen... |  | file://:0:0:0:0 | & |
-| main.rs:1237:50:1237:81 | "PairNone has no second elemen... | &T | {EXTERNAL LOCATION} | str |
-| main.rs:1237:50:1237:81 | ...::panic_fmt(...) |  | file://:0:0:0:0 | ! |
-| main.rs:1237:50:1237:81 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1237:50:1237:81 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1237:50:1237:81 | MacroExpr |  | main.rs:1234:15:1234:17 | Snd |
-| main.rs:1237:50:1237:81 | { ... } |  | main.rs:1234:15:1234:17 | Snd |
-| main.rs:1238:17:1238:38 | ...::PairFst(...) |  | main.rs:1226:5:1232:5 | PairOption |
-| main.rs:1238:17:1238:38 | ...::PairFst(...) | Fst | main.rs:1234:10:1234:12 | Fst |
-| main.rs:1238:17:1238:38 | ...::PairFst(...) | Snd | main.rs:1234:15:1234:17 | Snd |
-| main.rs:1238:37:1238:37 | _ |  | main.rs:1234:10:1234:12 | Fst |
-| main.rs:1238:43:1238:81 | MacroExpr |  | main.rs:1234:15:1234:17 | Snd |
-| main.rs:1238:50:1238:80 | "PairFst has no second element... |  | file://:0:0:0:0 | & |
-| main.rs:1238:50:1238:80 | "PairFst has no second element... | &T | {EXTERNAL LOCATION} | str |
-| main.rs:1238:50:1238:80 | ...::panic_fmt(...) |  | file://:0:0:0:0 | ! |
-| main.rs:1238:50:1238:80 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1238:50:1238:80 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1238:50:1238:80 | MacroExpr |  | main.rs:1234:15:1234:17 | Snd |
-| main.rs:1238:50:1238:80 | { ... } |  | main.rs:1234:15:1234:17 | Snd |
-| main.rs:1239:17:1239:40 | ...::PairSnd(...) |  | main.rs:1226:5:1232:5 | PairOption |
-| main.rs:1239:17:1239:40 | ...::PairSnd(...) | Fst | main.rs:1234:10:1234:12 | Fst |
-| main.rs:1239:17:1239:40 | ...::PairSnd(...) | Snd | main.rs:1234:15:1234:17 | Snd |
-| main.rs:1239:37:1239:39 | snd |  | main.rs:1234:15:1234:17 | Snd |
-| main.rs:1239:45:1239:47 | snd |  | main.rs:1234:15:1234:17 | Snd |
-| main.rs:1240:17:1240:44 | ...::PairBoth(...) |  | main.rs:1226:5:1232:5 | PairOption |
-| main.rs:1240:17:1240:44 | ...::PairBoth(...) | Fst | main.rs:1234:10:1234:12 | Fst |
-| main.rs:1240:17:1240:44 | ...::PairBoth(...) | Snd | main.rs:1234:15:1234:17 | Snd |
-| main.rs:1240:38:1240:38 | _ |  | main.rs:1234:10:1234:12 | Fst |
-| main.rs:1240:41:1240:43 | snd |  | main.rs:1234:15:1234:17 | Snd |
-| main.rs:1240:49:1240:51 | snd |  | main.rs:1234:15:1234:17 | Snd |
-| main.rs:1266:10:1266:10 | t |  | main.rs:1226:5:1232:5 | PairOption |
-| main.rs:1266:10:1266:10 | t | Fst | main.rs:1248:5:1249:14 | S2 |
-| main.rs:1266:10:1266:10 | t | Snd | main.rs:1226:5:1232:5 | PairOption |
-| main.rs:1266:10:1266:10 | t | Snd.Fst | main.rs:1248:5:1249:14 | S2 |
-| main.rs:1266:10:1266:10 | t | Snd.Snd | main.rs:1251:5:1252:14 | S3 |
-| main.rs:1267:13:1267:13 | x |  | main.rs:1251:5:1252:14 | S3 |
-| main.rs:1267:17:1267:17 | t |  | main.rs:1226:5:1232:5 | PairOption |
-| main.rs:1267:17:1267:17 | t | Fst | main.rs:1248:5:1249:14 | S2 |
-| main.rs:1267:17:1267:17 | t | Snd | main.rs:1226:5:1232:5 | PairOption |
-| main.rs:1267:17:1267:17 | t | Snd.Fst | main.rs:1248:5:1249:14 | S2 |
-| main.rs:1267:17:1267:17 | t | Snd.Snd | main.rs:1251:5:1252:14 | S3 |
-| main.rs:1267:17:1267:29 | t.unwrapSnd() |  | main.rs:1226:5:1232:5 | PairOption |
-| main.rs:1267:17:1267:29 | t.unwrapSnd() | Fst | main.rs:1248:5:1249:14 | S2 |
-| main.rs:1267:17:1267:29 | t.unwrapSnd() | Snd | main.rs:1251:5:1252:14 | S3 |
-| main.rs:1267:17:1267:41 | ... .unwrapSnd() |  | main.rs:1251:5:1252:14 | S3 |
-| main.rs:1268:18:1268:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:1268:18:1268:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:1268:18:1268:26 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1268:18:1268:26 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1268:26:1268:26 | x |  | main.rs:1251:5:1252:14 | S3 |
-| main.rs:1283:22:1283:25 | SelfParam |  | main.rs:1281:5:1284:5 | Self [trait TraitWithAssocType] |
-| main.rs:1291:22:1291:25 | SelfParam |  | main.rs:1279:5:1279:28 | GenS |
-| main.rs:1291:22:1291:25 | SelfParam | GenT | main.rs:1286:10:1286:15 | Output |
-| main.rs:1291:44:1293:9 | { ... } |  | {EXTERNAL LOCATION} | Result |
-| main.rs:1291:44:1293:9 | { ... } | E | main.rs:1286:10:1286:15 | Output |
-| main.rs:1291:44:1293:9 | { ... } | T | main.rs:1286:10:1286:15 | Output |
-| main.rs:1292:13:1292:22 | Ok(...) |  | {EXTERNAL LOCATION} | Result |
-| main.rs:1292:13:1292:22 | Ok(...) | E | main.rs:1286:10:1286:15 | Output |
-| main.rs:1292:13:1292:22 | Ok(...) | T | main.rs:1286:10:1286:15 | Output |
-| main.rs:1292:16:1292:19 | self |  | main.rs:1279:5:1279:28 | GenS |
-| main.rs:1292:16:1292:19 | self | GenT | main.rs:1286:10:1286:15 | Output |
-| main.rs:1292:16:1292:21 | self.0 |  | main.rs:1286:10:1286:15 | Output |
-| main.rs:1298:13:1298:14 | p1 |  | main.rs:1226:5:1232:5 | PairOption |
-| main.rs:1298:13:1298:14 | p1 | Fst | main.rs:1245:5:1246:14 | S1 |
-| main.rs:1298:13:1298:14 | p1 | Snd | main.rs:1248:5:1249:14 | S2 |
-| main.rs:1298:26:1298:53 | ...::PairBoth(...) |  | main.rs:1226:5:1232:5 | PairOption |
-| main.rs:1298:26:1298:53 | ...::PairBoth(...) | Fst | main.rs:1245:5:1246:14 | S1 |
-| main.rs:1298:26:1298:53 | ...::PairBoth(...) | Snd | main.rs:1248:5:1249:14 | S2 |
-| main.rs:1298:47:1298:48 | S1 |  | main.rs:1245:5:1246:14 | S1 |
-| main.rs:1298:51:1298:52 | S2 |  | main.rs:1248:5:1249:14 | S2 |
-| main.rs:1299:18:1299:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:1299:18:1299:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:1299:18:1299:27 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1299:18:1299:27 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1299:26:1299:27 | p1 |  | main.rs:1226:5:1232:5 | PairOption |
-| main.rs:1299:26:1299:27 | p1 | Fst | main.rs:1245:5:1246:14 | S1 |
-| main.rs:1299:26:1299:27 | p1 | Snd | main.rs:1248:5:1249:14 | S2 |
-| main.rs:1302:13:1302:14 | p2 |  | main.rs:1226:5:1232:5 | PairOption |
-| main.rs:1302:13:1302:14 | p2 | Fst | main.rs:1245:5:1246:14 | S1 |
-| main.rs:1302:13:1302:14 | p2 | Snd | main.rs:1248:5:1249:14 | S2 |
-| main.rs:1302:26:1302:47 | ...::PairNone(...) |  | main.rs:1226:5:1232:5 | PairOption |
-| main.rs:1302:26:1302:47 | ...::PairNone(...) | Fst | main.rs:1245:5:1246:14 | S1 |
-| main.rs:1302:26:1302:47 | ...::PairNone(...) | Snd | main.rs:1248:5:1249:14 | S2 |
-| main.rs:1303:18:1303:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:1303:18:1303:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:1303:18:1303:27 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1303:18:1303:27 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1303:26:1303:27 | p2 |  | main.rs:1226:5:1232:5 | PairOption |
-| main.rs:1303:26:1303:27 | p2 | Fst | main.rs:1245:5:1246:14 | S1 |
-| main.rs:1303:26:1303:27 | p2 | Snd | main.rs:1248:5:1249:14 | S2 |
-| main.rs:1306:13:1306:14 | p3 |  | main.rs:1226:5:1232:5 | PairOption |
-| main.rs:1306:13:1306:14 | p3 | Fst | main.rs:1248:5:1249:14 | S2 |
-| main.rs:1306:13:1306:14 | p3 | Snd | main.rs:1251:5:1252:14 | S3 |
-| main.rs:1306:34:1306:56 | ...::PairSnd(...) |  | main.rs:1226:5:1232:5 | PairOption |
-| main.rs:1306:34:1306:56 | ...::PairSnd(...) | Fst | main.rs:1248:5:1249:14 | S2 |
-| main.rs:1306:34:1306:56 | ...::PairSnd(...) | Snd | main.rs:1251:5:1252:14 | S3 |
-| main.rs:1306:54:1306:55 | S3 |  | main.rs:1251:5:1252:14 | S3 |
-| main.rs:1307:18:1307:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:1307:18:1307:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:1307:18:1307:27 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1307:18:1307:27 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1307:26:1307:27 | p3 |  | main.rs:1226:5:1232:5 | PairOption |
-| main.rs:1307:26:1307:27 | p3 | Fst | main.rs:1248:5:1249:14 | S2 |
-| main.rs:1307:26:1307:27 | p3 | Snd | main.rs:1251:5:1252:14 | S3 |
-| main.rs:1310:13:1310:14 | p3 |  | main.rs:1226:5:1232:5 | PairOption |
-| main.rs:1310:13:1310:14 | p3 | Fst | main.rs:1248:5:1249:14 | S2 |
-| main.rs:1310:13:1310:14 | p3 | Snd | main.rs:1251:5:1252:14 | S3 |
-| main.rs:1310:35:1310:56 | ...::PairNone(...) |  | main.rs:1226:5:1232:5 | PairOption |
-| main.rs:1310:35:1310:56 | ...::PairNone(...) | Fst | main.rs:1248:5:1249:14 | S2 |
-| main.rs:1310:35:1310:56 | ...::PairNone(...) | Snd | main.rs:1251:5:1252:14 | S3 |
-| main.rs:1311:18:1311:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:1311:18:1311:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:1311:18:1311:27 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1311:18:1311:27 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1311:26:1311:27 | p3 |  | main.rs:1226:5:1232:5 | PairOption |
-| main.rs:1311:26:1311:27 | p3 | Fst | main.rs:1248:5:1249:14 | S2 |
-| main.rs:1311:26:1311:27 | p3 | Snd | main.rs:1251:5:1252:14 | S3 |
-| main.rs:1313:11:1313:54 | ...::PairSnd(...) |  | main.rs:1226:5:1232:5 | PairOption |
-| main.rs:1313:11:1313:54 | ...::PairSnd(...) | Fst | main.rs:1248:5:1249:14 | S2 |
-| main.rs:1313:11:1313:54 | ...::PairSnd(...) | Snd | main.rs:1226:5:1232:5 | PairOption |
-| main.rs:1313:11:1313:54 | ...::PairSnd(...) | Snd.Fst | main.rs:1248:5:1249:14 | S2 |
-| main.rs:1313:11:1313:54 | ...::PairSnd(...) | Snd.Snd | main.rs:1251:5:1252:14 | S3 |
-| main.rs:1313:31:1313:53 | ...::PairSnd(...) |  | main.rs:1226:5:1232:5 | PairOption |
-| main.rs:1313:31:1313:53 | ...::PairSnd(...) | Fst | main.rs:1248:5:1249:14 | S2 |
-| main.rs:1313:31:1313:53 | ...::PairSnd(...) | Snd | main.rs:1251:5:1252:14 | S3 |
-| main.rs:1313:51:1313:52 | S3 |  | main.rs:1251:5:1252:14 | S3 |
-| main.rs:1315:13:1315:13 | x |  | {EXTERNAL LOCATION} | Result |
-| main.rs:1315:13:1315:13 | x | E | main.rs:1245:5:1246:14 | S1 |
-| main.rs:1315:13:1315:13 | x | T | main.rs:1271:5:1271:34 | S4 |
-| main.rs:1315:13:1315:13 | x | T.T41 | main.rs:1248:5:1249:14 | S2 |
-| main.rs:1315:13:1315:13 | x | T.T42 | main.rs:1273:5:1273:22 | S5 |
-| main.rs:1315:13:1315:13 | x | T.T42.T5 | main.rs:1248:5:1249:14 | S2 |
-| main.rs:1317:13:1317:13 | y |  | {EXTERNAL LOCATION} | Result |
-| main.rs:1317:13:1317:13 | y | E | {EXTERNAL LOCATION} | bool |
-| main.rs:1317:13:1317:13 | y | T | {EXTERNAL LOCATION} | bool |
-| main.rs:1317:17:1317:26 | GenS(...) |  | main.rs:1279:5:1279:28 | GenS |
-| main.rs:1317:17:1317:26 | GenS(...) | GenT | {EXTERNAL LOCATION} | bool |
-| main.rs:1317:17:1317:38 | ... .get_input() |  | {EXTERNAL LOCATION} | Result |
-| main.rs:1317:17:1317:38 | ... .get_input() | E | {EXTERNAL LOCATION} | bool |
-| main.rs:1317:17:1317:38 | ... .get_input() | T | {EXTERNAL LOCATION} | bool |
-| main.rs:1317:22:1317:25 | true |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1330:16:1330:24 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:1330:16:1330:24 | SelfParam | &T | main.rs:1328:5:1335:5 | Self [trait MyTrait] |
-| main.rs:1330:27:1330:31 | value |  | main.rs:1328:19:1328:19 | S |
-| main.rs:1332:21:1332:29 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:1332:21:1332:29 | SelfParam | &T | main.rs:1328:5:1335:5 | Self [trait MyTrait] |
-| main.rs:1332:32:1332:36 | value |  | main.rs:1328:19:1328:19 | S |
-| main.rs:1333:13:1333:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:1333:13:1333:16 | self | &T | main.rs:1328:5:1335:5 | Self [trait MyTrait] |
-| main.rs:1333:22:1333:26 | value |  | main.rs:1328:19:1328:19 | S |
-| main.rs:1339:16:1339:24 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:1339:16:1339:24 | SelfParam | &T | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1339:16:1339:24 | SelfParam | &T.T | main.rs:1337:10:1337:10 | T |
-| main.rs:1339:27:1339:31 | value |  | main.rs:1337:10:1337:10 | T |
-| main.rs:1343:26:1345:9 | { ... } |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1343:26:1345:9 | { ... } | T | main.rs:1342:10:1342:10 | T |
-| main.rs:1344:13:1344:30 | ...::MyNone(...) |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1344:13:1344:30 | ...::MyNone(...) | T | main.rs:1342:10:1342:10 | T |
-| main.rs:1349:20:1349:23 | SelfParam |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1349:20:1349:23 | SelfParam | T | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1349:20:1349:23 | SelfParam | T.T | main.rs:1348:10:1348:10 | T |
-| main.rs:1349:41:1354:9 | { ... } |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1349:41:1354:9 | { ... } | T | main.rs:1348:10:1348:10 | T |
-| main.rs:1350:13:1353:13 | match self { ... } |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1350:13:1353:13 | match self { ... } | T | main.rs:1348:10:1348:10 | T |
-| main.rs:1350:19:1350:22 | self |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1350:19:1350:22 | self | T | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1350:19:1350:22 | self | T.T | main.rs:1348:10:1348:10 | T |
-| main.rs:1351:17:1351:34 | ...::MyNone(...) |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1351:17:1351:34 | ...::MyNone(...) | T | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1351:17:1351:34 | ...::MyNone(...) | T.T | main.rs:1348:10:1348:10 | T |
-| main.rs:1351:39:1351:56 | ...::MyNone(...) |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1351:39:1351:56 | ...::MyNone(...) | T | main.rs:1348:10:1348:10 | T |
-| main.rs:1352:17:1352:35 | ...::MySome(...) |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1352:17:1352:35 | ...::MySome(...) | T | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1352:17:1352:35 | ...::MySome(...) | T.T | main.rs:1348:10:1348:10 | T |
-| main.rs:1352:34:1352:34 | x |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1352:34:1352:34 | x | T | main.rs:1348:10:1348:10 | T |
-| main.rs:1352:40:1352:40 | x |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1352:40:1352:40 | x | T | main.rs:1348:10:1348:10 | T |
-| main.rs:1361:13:1361:14 | x1 |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1361:13:1361:14 | x1 | T | main.rs:1357:5:1358:13 | S |
-| main.rs:1361:18:1361:37 | ...::new(...) |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1361:18:1361:37 | ...::new(...) | T | main.rs:1357:5:1358:13 | S |
-| main.rs:1362:18:1362:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:1362:18:1362:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:1362:18:1362:27 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1362:18:1362:27 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1362:26:1362:27 | x1 |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1362:26:1362:27 | x1 | T | main.rs:1357:5:1358:13 | S |
-| main.rs:1364:17:1364:18 | x2 |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1364:17:1364:18 | x2 | T | main.rs:1357:5:1358:13 | S |
-| main.rs:1364:22:1364:36 | ...::new(...) |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1364:22:1364:36 | ...::new(...) | T | main.rs:1357:5:1358:13 | S |
-| main.rs:1365:9:1365:10 | x2 |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1365:9:1365:10 | x2 | T | main.rs:1357:5:1358:13 | S |
-| main.rs:1365:16:1365:16 | S |  | main.rs:1357:5:1358:13 | S |
-| main.rs:1366:18:1366:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:1366:18:1366:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:1366:18:1366:27 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1366:18:1366:27 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1366:26:1366:27 | x2 |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1366:26:1366:27 | x2 | T | main.rs:1357:5:1358:13 | S |
-| main.rs:1369:17:1369:18 | x3 |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1369:22:1369:36 | ...::new(...) |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1370:9:1370:10 | x3 |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1370:21:1370:21 | S |  | main.rs:1357:5:1358:13 | S |
-| main.rs:1371:18:1371:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:1371:18:1371:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:1371:18:1371:27 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1371:18:1371:27 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1371:26:1371:27 | x3 |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1373:17:1373:18 | x4 |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1373:17:1373:18 | x4 | T | main.rs:1357:5:1358:13 | S |
-| main.rs:1373:22:1373:36 | ...::new(...) |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1373:22:1373:36 | ...::new(...) | T | main.rs:1357:5:1358:13 | S |
-| main.rs:1374:23:1374:29 | &mut x4 |  | file://:0:0:0:0 | & |
-| main.rs:1374:23:1374:29 | &mut x4 | &T | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1374:23:1374:29 | &mut x4 | &T.T | main.rs:1357:5:1358:13 | S |
-| main.rs:1374:28:1374:29 | x4 |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1374:28:1374:29 | x4 | T | main.rs:1357:5:1358:13 | S |
-| main.rs:1374:32:1374:32 | S |  | main.rs:1357:5:1358:13 | S |
-| main.rs:1375:18:1375:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:1375:18:1375:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:1375:18:1375:27 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1375:18:1375:27 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1375:26:1375:27 | x4 |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1375:26:1375:27 | x4 | T | main.rs:1357:5:1358:13 | S |
-| main.rs:1377:13:1377:14 | x5 |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1377:13:1377:14 | x5 | T | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1377:13:1377:14 | x5 | T.T | main.rs:1357:5:1358:13 | S |
-| main.rs:1377:18:1377:58 | ...::MySome(...) |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1377:18:1377:58 | ...::MySome(...) | T | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1377:18:1377:58 | ...::MySome(...) | T.T | main.rs:1357:5:1358:13 | S |
-| main.rs:1377:35:1377:57 | ...::MyNone(...) |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1377:35:1377:57 | ...::MyNone(...) | T | main.rs:1357:5:1358:13 | S |
-| main.rs:1378:18:1378:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:1378:18:1378:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:1378:18:1378:37 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1378:18:1378:37 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1378:26:1378:27 | x5 |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1378:26:1378:27 | x5 | T | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1378:26:1378:27 | x5 | T.T | main.rs:1357:5:1358:13 | S |
-| main.rs:1378:26:1378:37 | x5.flatten() |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1378:26:1378:37 | x5.flatten() | T | main.rs:1357:5:1358:13 | S |
-| main.rs:1380:13:1380:14 | x6 |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1380:13:1380:14 | x6 | T | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1380:13:1380:14 | x6 | T.T | main.rs:1357:5:1358:13 | S |
-| main.rs:1380:18:1380:58 | ...::MySome(...) |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1380:18:1380:58 | ...::MySome(...) | T | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1380:18:1380:58 | ...::MySome(...) | T.T | main.rs:1357:5:1358:13 | S |
-| main.rs:1380:35:1380:57 | ...::MyNone(...) |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1380:35:1380:57 | ...::MyNone(...) | T | main.rs:1357:5:1358:13 | S |
-| main.rs:1381:18:1381:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:1381:18:1381:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:1381:18:1381:61 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1381:18:1381:61 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1381:26:1381:61 | ...::flatten(...) |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1381:26:1381:61 | ...::flatten(...) | T | main.rs:1357:5:1358:13 | S |
-| main.rs:1381:59:1381:60 | x6 |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1381:59:1381:60 | x6 | T | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1381:59:1381:60 | x6 | T.T | main.rs:1357:5:1358:13 | S |
-| main.rs:1384:13:1384:19 | from_if |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1384:13:1384:19 | from_if | T | main.rs:1357:5:1358:13 | S |
-| main.rs:1384:23:1388:9 | if ... {...} else {...} |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1384:23:1388:9 | if ... {...} else {...} | T | main.rs:1357:5:1358:13 | S |
-| main.rs:1384:26:1384:26 | 3 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:1384:26:1384:30 | ... > ... |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1384:30:1384:30 | 2 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:1384:32:1386:9 | { ... } |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1384:32:1386:9 | { ... } | T | main.rs:1357:5:1358:13 | S |
-| main.rs:1385:13:1385:30 | ...::MyNone(...) |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1385:13:1385:30 | ...::MyNone(...) | T | main.rs:1357:5:1358:13 | S |
-| main.rs:1386:16:1388:9 | { ... } |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1386:16:1388:9 | { ... } | T | main.rs:1357:5:1358:13 | S |
-| main.rs:1387:13:1387:31 | ...::MySome(...) |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1387:13:1387:31 | ...::MySome(...) | T | main.rs:1357:5:1358:13 | S |
-| main.rs:1387:30:1387:30 | S |  | main.rs:1357:5:1358:13 | S |
-| main.rs:1389:18:1389:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:1389:18:1389:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:1389:18:1389:32 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1389:18:1389:32 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1389:26:1389:32 | from_if |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1389:26:1389:32 | from_if | T | main.rs:1357:5:1358:13 | S |
-| main.rs:1392:13:1392:22 | from_match |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1392:13:1392:22 | from_match | T | main.rs:1357:5:1358:13 | S |
-| main.rs:1392:26:1395:9 | match ... { ... } |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1392:26:1395:9 | match ... { ... } | T | main.rs:1357:5:1358:13 | S |
-| main.rs:1392:32:1392:32 | 3 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:1392:32:1392:36 | ... > ... |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1392:36:1392:36 | 2 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:1393:13:1393:16 | true |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1393:21:1393:38 | ...::MyNone(...) |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1393:21:1393:38 | ...::MyNone(...) | T | main.rs:1357:5:1358:13 | S |
-| main.rs:1394:13:1394:17 | false |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1394:22:1394:40 | ...::MySome(...) |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1394:22:1394:40 | ...::MySome(...) | T | main.rs:1357:5:1358:13 | S |
-| main.rs:1394:39:1394:39 | S |  | main.rs:1357:5:1358:13 | S |
-| main.rs:1396:18:1396:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:1396:18:1396:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:1396:18:1396:35 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1396:18:1396:35 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1396:26:1396:35 | from_match |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1396:26:1396:35 | from_match | T | main.rs:1357:5:1358:13 | S |
-| main.rs:1399:13:1399:21 | from_loop |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1399:13:1399:21 | from_loop | T | main.rs:1357:5:1358:13 | S |
-| main.rs:1399:25:1404:9 | loop { ... } |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1399:25:1404:9 | loop { ... } | T | main.rs:1357:5:1358:13 | S |
-| main.rs:1400:16:1400:16 | 3 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:1400:16:1400:20 | ... > ... |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1400:20:1400:20 | 2 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:1401:23:1401:40 | ...::MyNone(...) |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1401:23:1401:40 | ...::MyNone(...) | T | main.rs:1357:5:1358:13 | S |
-| main.rs:1403:19:1403:37 | ...::MySome(...) |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1403:19:1403:37 | ...::MySome(...) | T | main.rs:1357:5:1358:13 | S |
-| main.rs:1403:36:1403:36 | S |  | main.rs:1357:5:1358:13 | S |
-| main.rs:1405:18:1405:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:1405:18:1405:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:1405:18:1405:34 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1405:18:1405:34 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1405:26:1405:34 | from_loop |  | main.rs:1322:5:1326:5 | MyOption |
-| main.rs:1405:26:1405:34 | from_loop | T | main.rs:1357:5:1358:13 | S |
-| main.rs:1423:15:1423:18 | SelfParam |  | main.rs:1411:5:1412:19 | S |
-| main.rs:1423:15:1423:18 | SelfParam | T | main.rs:1422:10:1422:10 | T |
-| main.rs:1423:26:1425:9 | { ... } |  | main.rs:1422:10:1422:10 | T |
-| main.rs:1424:13:1424:16 | self |  | main.rs:1411:5:1412:19 | S |
-| main.rs:1424:13:1424:16 | self | T | main.rs:1422:10:1422:10 | T |
-| main.rs:1424:13:1424:18 | self.0 |  | main.rs:1422:10:1422:10 | T |
-| main.rs:1427:15:1427:19 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:1427:15:1427:19 | SelfParam | &T | main.rs:1411:5:1412:19 | S |
-| main.rs:1427:15:1427:19 | SelfParam | &T.T | main.rs:1422:10:1422:10 | T |
-| main.rs:1427:28:1429:9 | { ... } |  | file://:0:0:0:0 | & |
-| main.rs:1427:28:1429:9 | { ... } | &T | main.rs:1422:10:1422:10 | T |
-| main.rs:1428:13:1428:19 | &... |  | file://:0:0:0:0 | & |
-| main.rs:1428:13:1428:19 | &... | &T | main.rs:1422:10:1422:10 | T |
-| main.rs:1428:14:1428:17 | self |  | file://:0:0:0:0 | & |
-| main.rs:1428:14:1428:17 | self | &T | main.rs:1411:5:1412:19 | S |
-| main.rs:1428:14:1428:17 | self | &T.T | main.rs:1422:10:1422:10 | T |
-| main.rs:1428:14:1428:19 | self.0 |  | main.rs:1422:10:1422:10 | T |
-| main.rs:1431:15:1431:25 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:1431:15:1431:25 | SelfParam | &T | main.rs:1411:5:1412:19 | S |
-| main.rs:1431:15:1431:25 | SelfParam | &T.T | main.rs:1422:10:1422:10 | T |
-| main.rs:1431:34:1433:9 | { ... } |  | file://:0:0:0:0 | & |
-| main.rs:1431:34:1433:9 | { ... } | &T | main.rs:1422:10:1422:10 | T |
-| main.rs:1432:13:1432:19 | &... |  | file://:0:0:0:0 | & |
-| main.rs:1432:13:1432:19 | &... | &T | main.rs:1422:10:1422:10 | T |
-| main.rs:1432:14:1432:17 | self |  | file://:0:0:0:0 | & |
-| main.rs:1432:14:1432:17 | self | &T | main.rs:1411:5:1412:19 | S |
-| main.rs:1432:14:1432:17 | self | &T.T | main.rs:1422:10:1422:10 | T |
-| main.rs:1432:14:1432:19 | self.0 |  | main.rs:1422:10:1422:10 | T |
-| main.rs:1437:29:1437:33 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:1437:29:1437:33 | SelfParam | &T | main.rs:1436:5:1439:5 | Self [trait ATrait] |
-| main.rs:1438:33:1438:36 | SelfParam |  | main.rs:1436:5:1439:5 | Self [trait ATrait] |
-| main.rs:1444:29:1444:33 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:1444:29:1444:33 | SelfParam | &T | file://:0:0:0:0 | & |
-| main.rs:1444:29:1444:33 | SelfParam | &T.&T | main.rs:1417:5:1420:5 | MyInt |
-| main.rs:1444:43:1446:9 | { ... } |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1445:13:1445:22 | (...) |  | main.rs:1417:5:1420:5 | MyInt |
-| main.rs:1445:13:1445:24 | ... .a |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1445:14:1445:21 | * ... |  | main.rs:1417:5:1420:5 | MyInt |
-| main.rs:1445:15:1445:21 | (...) |  | file://:0:0:0:0 | & |
-| main.rs:1445:15:1445:21 | (...) | &T | main.rs:1417:5:1420:5 | MyInt |
-| main.rs:1445:16:1445:20 | * ... |  | file://:0:0:0:0 | & |
-| main.rs:1445:16:1445:20 | * ... | &T | main.rs:1417:5:1420:5 | MyInt |
-| main.rs:1445:17:1445:20 | self |  | file://:0:0:0:0 | & |
-| main.rs:1445:17:1445:20 | self | &T | file://:0:0:0:0 | & |
-| main.rs:1445:17:1445:20 | self | &T.&T | main.rs:1417:5:1420:5 | MyInt |
-| main.rs:1449:33:1449:36 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:1449:33:1449:36 | SelfParam | &T | main.rs:1417:5:1420:5 | MyInt |
-| main.rs:1449:46:1451:9 | { ... } |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1450:13:1450:19 | (...) |  | main.rs:1417:5:1420:5 | MyInt |
-| main.rs:1450:13:1450:21 | ... .a |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1450:14:1450:18 | * ... |  | main.rs:1417:5:1420:5 | MyInt |
-| main.rs:1450:15:1450:18 | self |  | file://:0:0:0:0 | & |
-| main.rs:1450:15:1450:18 | self | &T | main.rs:1417:5:1420:5 | MyInt |
-| main.rs:1455:13:1455:14 | x1 |  | main.rs:1411:5:1412:19 | S |
-| main.rs:1455:13:1455:14 | x1 | T | main.rs:1414:5:1415:14 | S2 |
-| main.rs:1455:18:1455:22 | S(...) |  | main.rs:1411:5:1412:19 | S |
-| main.rs:1455:18:1455:22 | S(...) | T | main.rs:1414:5:1415:14 | S2 |
-| main.rs:1455:20:1455:21 | S2 |  | main.rs:1414:5:1415:14 | S2 |
-| main.rs:1456:18:1456:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:1456:18:1456:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:1456:18:1456:32 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1456:18:1456:32 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1456:26:1456:27 | x1 |  | main.rs:1411:5:1412:19 | S |
-| main.rs:1456:26:1456:27 | x1 | T | main.rs:1414:5:1415:14 | S2 |
-| main.rs:1456:26:1456:32 | x1.m1() |  | main.rs:1414:5:1415:14 | S2 |
-| main.rs:1458:13:1458:14 | x2 |  | main.rs:1411:5:1412:19 | S |
-| main.rs:1458:13:1458:14 | x2 | T | main.rs:1414:5:1415:14 | S2 |
-| main.rs:1458:18:1458:22 | S(...) |  | main.rs:1411:5:1412:19 | S |
-| main.rs:1458:18:1458:22 | S(...) | T | main.rs:1414:5:1415:14 | S2 |
-| main.rs:1458:20:1458:21 | S2 |  | main.rs:1414:5:1415:14 | S2 |
+| main.rs:1165:26:1165:26 | y |  | main.rs:1075:5:1078:5 | MyThing2 |
+| main.rs:1165:26:1165:26 | y | A | main.rs:1082:5:1083:14 | S2 |
+| main.rs:1165:26:1165:31 | y.m3() |  | main.rs:1082:5:1083:14 | S2 |
+| main.rs:1167:13:1167:13 | x |  | main.rs:1070:5:1073:5 | MyThing |
+| main.rs:1167:13:1167:13 | x | A | main.rs:1080:5:1081:14 | S1 |
+| main.rs:1167:17:1167:33 | MyThing {...} |  | main.rs:1070:5:1073:5 | MyThing |
+| main.rs:1167:17:1167:33 | MyThing {...} | A | main.rs:1080:5:1081:14 | S1 |
+| main.rs:1167:30:1167:31 | S1 |  | main.rs:1080:5:1081:14 | S1 |
+| main.rs:1168:13:1168:13 | s |  | main.rs:1080:5:1081:14 | S1 |
+| main.rs:1168:17:1168:32 | call_trait_m1(...) |  | main.rs:1080:5:1081:14 | S1 |
+| main.rs:1168:31:1168:31 | x |  | main.rs:1070:5:1073:5 | MyThing |
+| main.rs:1168:31:1168:31 | x | A | main.rs:1080:5:1081:14 | S1 |
+| main.rs:1170:13:1170:13 | x |  | main.rs:1075:5:1078:5 | MyThing2 |
+| main.rs:1170:13:1170:13 | x | A | main.rs:1082:5:1083:14 | S2 |
+| main.rs:1170:17:1170:34 | MyThing2 {...} |  | main.rs:1075:5:1078:5 | MyThing2 |
+| main.rs:1170:17:1170:34 | MyThing2 {...} | A | main.rs:1082:5:1083:14 | S2 |
+| main.rs:1170:31:1170:32 | S2 |  | main.rs:1082:5:1083:14 | S2 |
+| main.rs:1171:13:1171:13 | s |  | main.rs:1070:5:1073:5 | MyThing |
+| main.rs:1171:13:1171:13 | s | A | main.rs:1082:5:1083:14 | S2 |
+| main.rs:1171:17:1171:32 | call_trait_m1(...) |  | main.rs:1070:5:1073:5 | MyThing |
+| main.rs:1171:17:1171:32 | call_trait_m1(...) | A | main.rs:1082:5:1083:14 | S2 |
+| main.rs:1171:31:1171:31 | x |  | main.rs:1075:5:1078:5 | MyThing2 |
+| main.rs:1171:31:1171:31 | x | A | main.rs:1082:5:1083:14 | S2 |
+| main.rs:1188:22:1188:22 | x |  | file://:0:0:0:0 | & |
+| main.rs:1188:22:1188:22 | x | &T | main.rs:1188:11:1188:19 | T |
+| main.rs:1188:35:1190:5 | { ... } |  | file://:0:0:0:0 | & |
+| main.rs:1188:35:1190:5 | { ... } | &T | main.rs:1188:11:1188:19 | T |
+| main.rs:1189:9:1189:9 | x |  | file://:0:0:0:0 | & |
+| main.rs:1189:9:1189:9 | x | &T | main.rs:1188:11:1188:19 | T |
+| main.rs:1193:17:1193:20 | SelfParam |  | main.rs:1178:5:1179:14 | S1 |
+| main.rs:1193:29:1195:9 | { ... } |  | main.rs:1181:5:1182:14 | S2 |
+| main.rs:1194:13:1194:14 | S2 |  | main.rs:1181:5:1182:14 | S2 |
+| main.rs:1198:21:1198:21 | x |  | main.rs:1198:13:1198:14 | T1 |
+| main.rs:1201:5:1203:5 | { ... } |  | main.rs:1198:17:1198:18 | T2 |
+| main.rs:1202:9:1202:9 | x |  | main.rs:1198:13:1198:14 | T1 |
+| main.rs:1202:9:1202:16 | x.into() |  | main.rs:1198:17:1198:18 | T2 |
+| main.rs:1206:13:1206:13 | x |  | main.rs:1178:5:1179:14 | S1 |
+| main.rs:1206:17:1206:18 | S1 |  | main.rs:1178:5:1179:14 | S1 |
+| main.rs:1207:18:1207:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:1207:18:1207:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:1207:18:1207:31 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1207:18:1207:31 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1207:26:1207:31 | id(...) |  | file://:0:0:0:0 | & |
+| main.rs:1207:26:1207:31 | id(...) | &T | main.rs:1178:5:1179:14 | S1 |
+| main.rs:1207:29:1207:30 | &x |  | file://:0:0:0:0 | & |
+| main.rs:1207:29:1207:30 | &x | &T | main.rs:1178:5:1179:14 | S1 |
+| main.rs:1207:30:1207:30 | x |  | main.rs:1178:5:1179:14 | S1 |
+| main.rs:1209:13:1209:13 | x |  | main.rs:1178:5:1179:14 | S1 |
+| main.rs:1209:17:1209:18 | S1 |  | main.rs:1178:5:1179:14 | S1 |
+| main.rs:1210:18:1210:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:1210:18:1210:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:1210:18:1210:37 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1210:18:1210:37 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1210:26:1210:37 | id::<...>(...) |  | file://:0:0:0:0 | & |
+| main.rs:1210:26:1210:37 | id::<...>(...) | &T | main.rs:1178:5:1179:14 | S1 |
+| main.rs:1210:35:1210:36 | &x |  | file://:0:0:0:0 | & |
+| main.rs:1210:35:1210:36 | &x | &T | main.rs:1178:5:1179:14 | S1 |
+| main.rs:1210:36:1210:36 | x |  | main.rs:1178:5:1179:14 | S1 |
+| main.rs:1212:13:1212:13 | x |  | main.rs:1178:5:1179:14 | S1 |
+| main.rs:1212:13:1212:13 | x |  | main.rs:1184:5:1184:25 | dyn Trait |
+| main.rs:1212:17:1212:18 | S1 |  | main.rs:1178:5:1179:14 | S1 |
+| main.rs:1212:17:1212:18 | S1 |  | main.rs:1184:5:1184:25 | dyn Trait |
+| main.rs:1214:18:1214:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:1214:18:1214:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:1214:18:1214:44 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1214:18:1214:44 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1214:26:1214:44 | id::<...>(...) |  | file://:0:0:0:0 | & |
+| main.rs:1214:26:1214:44 | id::<...>(...) | &T | main.rs:1184:5:1184:25 | dyn Trait |
+| main.rs:1214:42:1214:43 | &x |  | file://:0:0:0:0 | & |
+| main.rs:1214:42:1214:43 | &x | &T | main.rs:1178:5:1179:14 | S1 |
+| main.rs:1214:42:1214:43 | &x | &T | main.rs:1184:5:1184:25 | dyn Trait |
+| main.rs:1214:43:1214:43 | x |  | main.rs:1178:5:1179:14 | S1 |
+| main.rs:1214:43:1214:43 | x |  | main.rs:1184:5:1184:25 | dyn Trait |
+| main.rs:1216:13:1216:13 | x |  | main.rs:1178:5:1179:14 | S1 |
+| main.rs:1216:17:1216:18 | S1 |  | main.rs:1178:5:1179:14 | S1 |
+| main.rs:1217:9:1217:25 | into::<...>(...) |  | main.rs:1181:5:1182:14 | S2 |
+| main.rs:1217:24:1217:24 | x |  | main.rs:1178:5:1179:14 | S1 |
+| main.rs:1219:13:1219:13 | x |  | main.rs:1178:5:1179:14 | S1 |
+| main.rs:1219:17:1219:18 | S1 |  | main.rs:1178:5:1179:14 | S1 |
+| main.rs:1220:13:1220:13 | y |  | main.rs:1181:5:1182:14 | S2 |
+| main.rs:1220:21:1220:27 | into(...) |  | main.rs:1181:5:1182:14 | S2 |
+| main.rs:1220:26:1220:26 | x |  | main.rs:1178:5:1179:14 | S1 |
+| main.rs:1234:22:1234:25 | SelfParam |  | main.rs:1225:5:1231:5 | PairOption |
+| main.rs:1234:22:1234:25 | SelfParam | Fst | main.rs:1233:10:1233:12 | Fst |
+| main.rs:1234:22:1234:25 | SelfParam | Snd | main.rs:1233:15:1233:17 | Snd |
+| main.rs:1234:35:1241:9 | { ... } |  | main.rs:1233:15:1233:17 | Snd |
+| main.rs:1235:13:1240:13 | match self { ... } |  | main.rs:1233:15:1233:17 | Snd |
+| main.rs:1235:19:1235:22 | self |  | main.rs:1225:5:1231:5 | PairOption |
+| main.rs:1235:19:1235:22 | self | Fst | main.rs:1233:10:1233:12 | Fst |
+| main.rs:1235:19:1235:22 | self | Snd | main.rs:1233:15:1233:17 | Snd |
+| main.rs:1236:17:1236:38 | ...::PairNone(...) |  | main.rs:1225:5:1231:5 | PairOption |
+| main.rs:1236:17:1236:38 | ...::PairNone(...) | Fst | main.rs:1233:10:1233:12 | Fst |
+| main.rs:1236:17:1236:38 | ...::PairNone(...) | Snd | main.rs:1233:15:1233:17 | Snd |
+| main.rs:1236:43:1236:82 | MacroExpr |  | main.rs:1233:15:1233:17 | Snd |
+| main.rs:1236:50:1236:81 | "PairNone has no second elemen... |  | file://:0:0:0:0 | & |
+| main.rs:1236:50:1236:81 | "PairNone has no second elemen... | &T | {EXTERNAL LOCATION} | str |
+| main.rs:1236:50:1236:81 | ...::panic_fmt(...) |  | file://:0:0:0:0 | ! |
+| main.rs:1236:50:1236:81 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1236:50:1236:81 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1236:50:1236:81 | MacroExpr |  | main.rs:1233:15:1233:17 | Snd |
+| main.rs:1236:50:1236:81 | { ... } |  | main.rs:1233:15:1233:17 | Snd |
+| main.rs:1237:17:1237:38 | ...::PairFst(...) |  | main.rs:1225:5:1231:5 | PairOption |
+| main.rs:1237:17:1237:38 | ...::PairFst(...) | Fst | main.rs:1233:10:1233:12 | Fst |
+| main.rs:1237:17:1237:38 | ...::PairFst(...) | Snd | main.rs:1233:15:1233:17 | Snd |
+| main.rs:1237:37:1237:37 | _ |  | main.rs:1233:10:1233:12 | Fst |
+| main.rs:1237:43:1237:81 | MacroExpr |  | main.rs:1233:15:1233:17 | Snd |
+| main.rs:1237:50:1237:80 | "PairFst has no second element... |  | file://:0:0:0:0 | & |
+| main.rs:1237:50:1237:80 | "PairFst has no second element... | &T | {EXTERNAL LOCATION} | str |
+| main.rs:1237:50:1237:80 | ...::panic_fmt(...) |  | file://:0:0:0:0 | ! |
+| main.rs:1237:50:1237:80 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1237:50:1237:80 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1237:50:1237:80 | MacroExpr |  | main.rs:1233:15:1233:17 | Snd |
+| main.rs:1237:50:1237:80 | { ... } |  | main.rs:1233:15:1233:17 | Snd |
+| main.rs:1238:17:1238:40 | ...::PairSnd(...) |  | main.rs:1225:5:1231:5 | PairOption |
+| main.rs:1238:17:1238:40 | ...::PairSnd(...) | Fst | main.rs:1233:10:1233:12 | Fst |
+| main.rs:1238:17:1238:40 | ...::PairSnd(...) | Snd | main.rs:1233:15:1233:17 | Snd |
+| main.rs:1238:37:1238:39 | snd |  | main.rs:1233:15:1233:17 | Snd |
+| main.rs:1238:45:1238:47 | snd |  | main.rs:1233:15:1233:17 | Snd |
+| main.rs:1239:17:1239:44 | ...::PairBoth(...) |  | main.rs:1225:5:1231:5 | PairOption |
+| main.rs:1239:17:1239:44 | ...::PairBoth(...) | Fst | main.rs:1233:10:1233:12 | Fst |
+| main.rs:1239:17:1239:44 | ...::PairBoth(...) | Snd | main.rs:1233:15:1233:17 | Snd |
+| main.rs:1239:38:1239:38 | _ |  | main.rs:1233:10:1233:12 | Fst |
+| main.rs:1239:41:1239:43 | snd |  | main.rs:1233:15:1233:17 | Snd |
+| main.rs:1239:49:1239:51 | snd |  | main.rs:1233:15:1233:17 | Snd |
+| main.rs:1265:10:1265:10 | t |  | main.rs:1225:5:1231:5 | PairOption |
+| main.rs:1265:10:1265:10 | t | Fst | main.rs:1247:5:1248:14 | S2 |
+| main.rs:1265:10:1265:10 | t | Snd | main.rs:1225:5:1231:5 | PairOption |
+| main.rs:1265:10:1265:10 | t | Snd.Fst | main.rs:1247:5:1248:14 | S2 |
+| main.rs:1265:10:1265:10 | t | Snd.Snd | main.rs:1250:5:1251:14 | S3 |
+| main.rs:1266:13:1266:13 | x |  | main.rs:1250:5:1251:14 | S3 |
+| main.rs:1266:17:1266:17 | t |  | main.rs:1225:5:1231:5 | PairOption |
+| main.rs:1266:17:1266:17 | t | Fst | main.rs:1247:5:1248:14 | S2 |
+| main.rs:1266:17:1266:17 | t | Snd | main.rs:1225:5:1231:5 | PairOption |
+| main.rs:1266:17:1266:17 | t | Snd.Fst | main.rs:1247:5:1248:14 | S2 |
+| main.rs:1266:17:1266:17 | t | Snd.Snd | main.rs:1250:5:1251:14 | S3 |
+| main.rs:1266:17:1266:29 | t.unwrapSnd() |  | main.rs:1225:5:1231:5 | PairOption |
+| main.rs:1266:17:1266:29 | t.unwrapSnd() | Fst | main.rs:1247:5:1248:14 | S2 |
+| main.rs:1266:17:1266:29 | t.unwrapSnd() | Snd | main.rs:1250:5:1251:14 | S3 |
+| main.rs:1266:17:1266:41 | ... .unwrapSnd() |  | main.rs:1250:5:1251:14 | S3 |
+| main.rs:1267:18:1267:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:1267:18:1267:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:1267:18:1267:26 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1267:18:1267:26 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1267:26:1267:26 | x |  | main.rs:1250:5:1251:14 | S3 |
+| main.rs:1282:22:1282:25 | SelfParam |  | main.rs:1280:5:1283:5 | Self [trait TraitWithAssocType] |
+| main.rs:1290:22:1290:25 | SelfParam |  | main.rs:1278:5:1278:28 | GenS |
+| main.rs:1290:22:1290:25 | SelfParam | GenT | main.rs:1285:10:1285:15 | Output |
+| main.rs:1290:44:1292:9 | { ... } |  | {EXTERNAL LOCATION} | Result |
+| main.rs:1290:44:1292:9 | { ... } | E | main.rs:1285:10:1285:15 | Output |
+| main.rs:1290:44:1292:9 | { ... } | T | main.rs:1285:10:1285:15 | Output |
+| main.rs:1291:13:1291:22 | Ok(...) |  | {EXTERNAL LOCATION} | Result |
+| main.rs:1291:13:1291:22 | Ok(...) | E | main.rs:1285:10:1285:15 | Output |
+| main.rs:1291:13:1291:22 | Ok(...) | T | main.rs:1285:10:1285:15 | Output |
+| main.rs:1291:16:1291:19 | self |  | main.rs:1278:5:1278:28 | GenS |
+| main.rs:1291:16:1291:19 | self | GenT | main.rs:1285:10:1285:15 | Output |
+| main.rs:1291:16:1291:21 | self.0 |  | main.rs:1285:10:1285:15 | Output |
+| main.rs:1297:13:1297:14 | p1 |  | main.rs:1225:5:1231:5 | PairOption |
+| main.rs:1297:13:1297:14 | p1 | Fst | main.rs:1244:5:1245:14 | S1 |
+| main.rs:1297:13:1297:14 | p1 | Snd | main.rs:1247:5:1248:14 | S2 |
+| main.rs:1297:26:1297:53 | ...::PairBoth(...) |  | main.rs:1225:5:1231:5 | PairOption |
+| main.rs:1297:26:1297:53 | ...::PairBoth(...) | Fst | main.rs:1244:5:1245:14 | S1 |
+| main.rs:1297:26:1297:53 | ...::PairBoth(...) | Snd | main.rs:1247:5:1248:14 | S2 |
+| main.rs:1297:47:1297:48 | S1 |  | main.rs:1244:5:1245:14 | S1 |
+| main.rs:1297:51:1297:52 | S2 |  | main.rs:1247:5:1248:14 | S2 |
+| main.rs:1298:18:1298:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:1298:18:1298:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:1298:18:1298:27 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1298:18:1298:27 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1298:26:1298:27 | p1 |  | main.rs:1225:5:1231:5 | PairOption |
+| main.rs:1298:26:1298:27 | p1 | Fst | main.rs:1244:5:1245:14 | S1 |
+| main.rs:1298:26:1298:27 | p1 | Snd | main.rs:1247:5:1248:14 | S2 |
+| main.rs:1301:13:1301:14 | p2 |  | main.rs:1225:5:1231:5 | PairOption |
+| main.rs:1301:13:1301:14 | p2 | Fst | main.rs:1244:5:1245:14 | S1 |
+| main.rs:1301:13:1301:14 | p2 | Snd | main.rs:1247:5:1248:14 | S2 |
+| main.rs:1301:26:1301:47 | ...::PairNone(...) |  | main.rs:1225:5:1231:5 | PairOption |
+| main.rs:1301:26:1301:47 | ...::PairNone(...) | Fst | main.rs:1244:5:1245:14 | S1 |
+| main.rs:1301:26:1301:47 | ...::PairNone(...) | Snd | main.rs:1247:5:1248:14 | S2 |
+| main.rs:1302:18:1302:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:1302:18:1302:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:1302:18:1302:27 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1302:18:1302:27 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1302:26:1302:27 | p2 |  | main.rs:1225:5:1231:5 | PairOption |
+| main.rs:1302:26:1302:27 | p2 | Fst | main.rs:1244:5:1245:14 | S1 |
+| main.rs:1302:26:1302:27 | p2 | Snd | main.rs:1247:5:1248:14 | S2 |
+| main.rs:1305:13:1305:14 | p3 |  | main.rs:1225:5:1231:5 | PairOption |
+| main.rs:1305:13:1305:14 | p3 | Fst | main.rs:1247:5:1248:14 | S2 |
+| main.rs:1305:13:1305:14 | p3 | Snd | main.rs:1250:5:1251:14 | S3 |
+| main.rs:1305:34:1305:56 | ...::PairSnd(...) |  | main.rs:1225:5:1231:5 | PairOption |
+| main.rs:1305:34:1305:56 | ...::PairSnd(...) | Fst | main.rs:1247:5:1248:14 | S2 |
+| main.rs:1305:34:1305:56 | ...::PairSnd(...) | Snd | main.rs:1250:5:1251:14 | S3 |
+| main.rs:1305:54:1305:55 | S3 |  | main.rs:1250:5:1251:14 | S3 |
+| main.rs:1306:18:1306:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:1306:18:1306:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:1306:18:1306:27 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1306:18:1306:27 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1306:26:1306:27 | p3 |  | main.rs:1225:5:1231:5 | PairOption |
+| main.rs:1306:26:1306:27 | p3 | Fst | main.rs:1247:5:1248:14 | S2 |
+| main.rs:1306:26:1306:27 | p3 | Snd | main.rs:1250:5:1251:14 | S3 |
+| main.rs:1309:13:1309:14 | p3 |  | main.rs:1225:5:1231:5 | PairOption |
+| main.rs:1309:13:1309:14 | p3 | Fst | main.rs:1247:5:1248:14 | S2 |
+| main.rs:1309:13:1309:14 | p3 | Snd | main.rs:1250:5:1251:14 | S3 |
+| main.rs:1309:35:1309:56 | ...::PairNone(...) |  | main.rs:1225:5:1231:5 | PairOption |
+| main.rs:1309:35:1309:56 | ...::PairNone(...) | Fst | main.rs:1247:5:1248:14 | S2 |
+| main.rs:1309:35:1309:56 | ...::PairNone(...) | Snd | main.rs:1250:5:1251:14 | S3 |
+| main.rs:1310:18:1310:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:1310:18:1310:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:1310:18:1310:27 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1310:18:1310:27 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1310:26:1310:27 | p3 |  | main.rs:1225:5:1231:5 | PairOption |
+| main.rs:1310:26:1310:27 | p3 | Fst | main.rs:1247:5:1248:14 | S2 |
+| main.rs:1310:26:1310:27 | p3 | Snd | main.rs:1250:5:1251:14 | S3 |
+| main.rs:1312:11:1312:54 | ...::PairSnd(...) |  | main.rs:1225:5:1231:5 | PairOption |
+| main.rs:1312:11:1312:54 | ...::PairSnd(...) | Fst | main.rs:1247:5:1248:14 | S2 |
+| main.rs:1312:11:1312:54 | ...::PairSnd(...) | Snd | main.rs:1225:5:1231:5 | PairOption |
+| main.rs:1312:11:1312:54 | ...::PairSnd(...) | Snd.Fst | main.rs:1247:5:1248:14 | S2 |
+| main.rs:1312:11:1312:54 | ...::PairSnd(...) | Snd.Snd | main.rs:1250:5:1251:14 | S3 |
+| main.rs:1312:31:1312:53 | ...::PairSnd(...) |  | main.rs:1225:5:1231:5 | PairOption |
+| main.rs:1312:31:1312:53 | ...::PairSnd(...) | Fst | main.rs:1247:5:1248:14 | S2 |
+| main.rs:1312:31:1312:53 | ...::PairSnd(...) | Snd | main.rs:1250:5:1251:14 | S3 |
+| main.rs:1312:51:1312:52 | S3 |  | main.rs:1250:5:1251:14 | S3 |
+| main.rs:1314:13:1314:13 | x |  | {EXTERNAL LOCATION} | Result |
+| main.rs:1314:13:1314:13 | x | E | main.rs:1244:5:1245:14 | S1 |
+| main.rs:1314:13:1314:13 | x | T | main.rs:1270:5:1270:34 | S4 |
+| main.rs:1314:13:1314:13 | x | T.T41 | main.rs:1247:5:1248:14 | S2 |
+| main.rs:1314:13:1314:13 | x | T.T42 | main.rs:1272:5:1272:22 | S5 |
+| main.rs:1314:13:1314:13 | x | T.T42.T5 | main.rs:1247:5:1248:14 | S2 |
+| main.rs:1316:13:1316:13 | y |  | {EXTERNAL LOCATION} | Result |
+| main.rs:1316:13:1316:13 | y | E | {EXTERNAL LOCATION} | bool |
+| main.rs:1316:13:1316:13 | y | T | {EXTERNAL LOCATION} | bool |
+| main.rs:1316:17:1316:26 | GenS(...) |  | main.rs:1278:5:1278:28 | GenS |
+| main.rs:1316:17:1316:26 | GenS(...) | GenT | {EXTERNAL LOCATION} | bool |
+| main.rs:1316:17:1316:38 | ... .get_input() |  | {EXTERNAL LOCATION} | Result |
+| main.rs:1316:17:1316:38 | ... .get_input() | E | {EXTERNAL LOCATION} | bool |
+| main.rs:1316:17:1316:38 | ... .get_input() | T | {EXTERNAL LOCATION} | bool |
+| main.rs:1316:22:1316:25 | true |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1329:16:1329:24 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1329:16:1329:24 | SelfParam | &T | main.rs:1327:5:1334:5 | Self [trait MyTrait] |
+| main.rs:1329:27:1329:31 | value |  | main.rs:1327:19:1327:19 | S |
+| main.rs:1331:21:1331:29 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1331:21:1331:29 | SelfParam | &T | main.rs:1327:5:1334:5 | Self [trait MyTrait] |
+| main.rs:1331:32:1331:36 | value |  | main.rs:1327:19:1327:19 | S |
+| main.rs:1332:13:1332:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1332:13:1332:16 | self | &T | main.rs:1327:5:1334:5 | Self [trait MyTrait] |
+| main.rs:1332:22:1332:26 | value |  | main.rs:1327:19:1327:19 | S |
+| main.rs:1338:16:1338:24 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1338:16:1338:24 | SelfParam | &T | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1338:16:1338:24 | SelfParam | &T.T | main.rs:1336:10:1336:10 | T |
+| main.rs:1338:27:1338:31 | value |  | main.rs:1336:10:1336:10 | T |
+| main.rs:1342:26:1344:9 | { ... } |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1342:26:1344:9 | { ... } | T | main.rs:1341:10:1341:10 | T |
+| main.rs:1343:13:1343:30 | ...::MyNone(...) |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1343:13:1343:30 | ...::MyNone(...) | T | main.rs:1341:10:1341:10 | T |
+| main.rs:1348:20:1348:23 | SelfParam |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1348:20:1348:23 | SelfParam | T | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1348:20:1348:23 | SelfParam | T.T | main.rs:1347:10:1347:10 | T |
+| main.rs:1348:41:1353:9 | { ... } |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1348:41:1353:9 | { ... } | T | main.rs:1347:10:1347:10 | T |
+| main.rs:1349:13:1352:13 | match self { ... } |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1349:13:1352:13 | match self { ... } | T | main.rs:1347:10:1347:10 | T |
+| main.rs:1349:19:1349:22 | self |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1349:19:1349:22 | self | T | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1349:19:1349:22 | self | T.T | main.rs:1347:10:1347:10 | T |
+| main.rs:1350:17:1350:34 | ...::MyNone(...) |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1350:17:1350:34 | ...::MyNone(...) | T | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1350:17:1350:34 | ...::MyNone(...) | T.T | main.rs:1347:10:1347:10 | T |
+| main.rs:1350:39:1350:56 | ...::MyNone(...) |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1350:39:1350:56 | ...::MyNone(...) | T | main.rs:1347:10:1347:10 | T |
+| main.rs:1351:17:1351:35 | ...::MySome(...) |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1351:17:1351:35 | ...::MySome(...) | T | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1351:17:1351:35 | ...::MySome(...) | T.T | main.rs:1347:10:1347:10 | T |
+| main.rs:1351:34:1351:34 | x |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1351:34:1351:34 | x | T | main.rs:1347:10:1347:10 | T |
+| main.rs:1351:40:1351:40 | x |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1351:40:1351:40 | x | T | main.rs:1347:10:1347:10 | T |
+| main.rs:1360:13:1360:14 | x1 |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1360:13:1360:14 | x1 | T | main.rs:1356:5:1357:13 | S |
+| main.rs:1360:18:1360:37 | ...::new(...) |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1360:18:1360:37 | ...::new(...) | T | main.rs:1356:5:1357:13 | S |
+| main.rs:1361:18:1361:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:1361:18:1361:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:1361:18:1361:27 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1361:18:1361:27 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1361:26:1361:27 | x1 |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1361:26:1361:27 | x1 | T | main.rs:1356:5:1357:13 | S |
+| main.rs:1363:17:1363:18 | x2 |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1363:17:1363:18 | x2 | T | main.rs:1356:5:1357:13 | S |
+| main.rs:1363:22:1363:36 | ...::new(...) |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1363:22:1363:36 | ...::new(...) | T | main.rs:1356:5:1357:13 | S |
+| main.rs:1364:9:1364:10 | x2 |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1364:9:1364:10 | x2 | T | main.rs:1356:5:1357:13 | S |
+| main.rs:1364:16:1364:16 | S |  | main.rs:1356:5:1357:13 | S |
+| main.rs:1365:18:1365:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:1365:18:1365:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:1365:18:1365:27 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1365:18:1365:27 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1365:26:1365:27 | x2 |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1365:26:1365:27 | x2 | T | main.rs:1356:5:1357:13 | S |
+| main.rs:1368:17:1368:18 | x3 |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1368:22:1368:36 | ...::new(...) |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1369:9:1369:10 | x3 |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1369:21:1369:21 | S |  | main.rs:1356:5:1357:13 | S |
+| main.rs:1370:18:1370:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:1370:18:1370:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:1370:18:1370:27 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1370:18:1370:27 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1370:26:1370:27 | x3 |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1372:17:1372:18 | x4 |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1372:17:1372:18 | x4 | T | main.rs:1356:5:1357:13 | S |
+| main.rs:1372:22:1372:36 | ...::new(...) |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1372:22:1372:36 | ...::new(...) | T | main.rs:1356:5:1357:13 | S |
+| main.rs:1373:23:1373:29 | &mut x4 |  | file://:0:0:0:0 | & |
+| main.rs:1373:23:1373:29 | &mut x4 | &T | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1373:23:1373:29 | &mut x4 | &T.T | main.rs:1356:5:1357:13 | S |
+| main.rs:1373:28:1373:29 | x4 |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1373:28:1373:29 | x4 | T | main.rs:1356:5:1357:13 | S |
+| main.rs:1373:32:1373:32 | S |  | main.rs:1356:5:1357:13 | S |
+| main.rs:1374:18:1374:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:1374:18:1374:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:1374:18:1374:27 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1374:18:1374:27 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1374:26:1374:27 | x4 |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1374:26:1374:27 | x4 | T | main.rs:1356:5:1357:13 | S |
+| main.rs:1376:13:1376:14 | x5 |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1376:13:1376:14 | x5 | T | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1376:13:1376:14 | x5 | T.T | main.rs:1356:5:1357:13 | S |
+| main.rs:1376:18:1376:58 | ...::MySome(...) |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1376:18:1376:58 | ...::MySome(...) | T | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1376:18:1376:58 | ...::MySome(...) | T.T | main.rs:1356:5:1357:13 | S |
+| main.rs:1376:35:1376:57 | ...::MyNone(...) |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1376:35:1376:57 | ...::MyNone(...) | T | main.rs:1356:5:1357:13 | S |
+| main.rs:1377:18:1377:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:1377:18:1377:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:1377:18:1377:37 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1377:18:1377:37 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1377:26:1377:27 | x5 |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1377:26:1377:27 | x5 | T | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1377:26:1377:27 | x5 | T.T | main.rs:1356:5:1357:13 | S |
+| main.rs:1377:26:1377:37 | x5.flatten() |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1377:26:1377:37 | x5.flatten() | T | main.rs:1356:5:1357:13 | S |
+| main.rs:1379:13:1379:14 | x6 |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1379:13:1379:14 | x6 | T | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1379:13:1379:14 | x6 | T.T | main.rs:1356:5:1357:13 | S |
+| main.rs:1379:18:1379:58 | ...::MySome(...) |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1379:18:1379:58 | ...::MySome(...) | T | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1379:18:1379:58 | ...::MySome(...) | T.T | main.rs:1356:5:1357:13 | S |
+| main.rs:1379:35:1379:57 | ...::MyNone(...) |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1379:35:1379:57 | ...::MyNone(...) | T | main.rs:1356:5:1357:13 | S |
+| main.rs:1380:18:1380:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:1380:18:1380:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:1380:18:1380:61 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1380:18:1380:61 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1380:26:1380:61 | ...::flatten(...) |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1380:26:1380:61 | ...::flatten(...) | T | main.rs:1356:5:1357:13 | S |
+| main.rs:1380:59:1380:60 | x6 |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1380:59:1380:60 | x6 | T | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1380:59:1380:60 | x6 | T.T | main.rs:1356:5:1357:13 | S |
+| main.rs:1383:13:1383:19 | from_if |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1383:13:1383:19 | from_if | T | main.rs:1356:5:1357:13 | S |
+| main.rs:1383:23:1387:9 | if ... {...} else {...} |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1383:23:1387:9 | if ... {...} else {...} | T | main.rs:1356:5:1357:13 | S |
+| main.rs:1383:26:1383:26 | 3 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:1383:26:1383:30 | ... > ... |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1383:30:1383:30 | 2 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:1383:32:1385:9 | { ... } |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1383:32:1385:9 | { ... } | T | main.rs:1356:5:1357:13 | S |
+| main.rs:1384:13:1384:30 | ...::MyNone(...) |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1384:13:1384:30 | ...::MyNone(...) | T | main.rs:1356:5:1357:13 | S |
+| main.rs:1385:16:1387:9 | { ... } |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1385:16:1387:9 | { ... } | T | main.rs:1356:5:1357:13 | S |
+| main.rs:1386:13:1386:31 | ...::MySome(...) |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1386:13:1386:31 | ...::MySome(...) | T | main.rs:1356:5:1357:13 | S |
+| main.rs:1386:30:1386:30 | S |  | main.rs:1356:5:1357:13 | S |
+| main.rs:1388:18:1388:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:1388:18:1388:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:1388:18:1388:32 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1388:18:1388:32 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1388:26:1388:32 | from_if |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1388:26:1388:32 | from_if | T | main.rs:1356:5:1357:13 | S |
+| main.rs:1391:13:1391:22 | from_match |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1391:13:1391:22 | from_match | T | main.rs:1356:5:1357:13 | S |
+| main.rs:1391:26:1394:9 | match ... { ... } |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1391:26:1394:9 | match ... { ... } | T | main.rs:1356:5:1357:13 | S |
+| main.rs:1391:32:1391:32 | 3 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:1391:32:1391:36 | ... > ... |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1391:36:1391:36 | 2 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:1392:13:1392:16 | true |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1392:21:1392:38 | ...::MyNone(...) |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1392:21:1392:38 | ...::MyNone(...) | T | main.rs:1356:5:1357:13 | S |
+| main.rs:1393:13:1393:17 | false |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1393:22:1393:40 | ...::MySome(...) |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1393:22:1393:40 | ...::MySome(...) | T | main.rs:1356:5:1357:13 | S |
+| main.rs:1393:39:1393:39 | S |  | main.rs:1356:5:1357:13 | S |
+| main.rs:1395:18:1395:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:1395:18:1395:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:1395:18:1395:35 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1395:18:1395:35 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1395:26:1395:35 | from_match |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1395:26:1395:35 | from_match | T | main.rs:1356:5:1357:13 | S |
+| main.rs:1398:13:1398:21 | from_loop |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1398:13:1398:21 | from_loop | T | main.rs:1356:5:1357:13 | S |
+| main.rs:1398:25:1403:9 | loop { ... } |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1398:25:1403:9 | loop { ... } | T | main.rs:1356:5:1357:13 | S |
+| main.rs:1399:16:1399:16 | 3 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:1399:16:1399:20 | ... > ... |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1399:20:1399:20 | 2 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:1400:23:1400:40 | ...::MyNone(...) |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1400:23:1400:40 | ...::MyNone(...) | T | main.rs:1356:5:1357:13 | S |
+| main.rs:1402:19:1402:37 | ...::MySome(...) |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1402:19:1402:37 | ...::MySome(...) | T | main.rs:1356:5:1357:13 | S |
+| main.rs:1402:36:1402:36 | S |  | main.rs:1356:5:1357:13 | S |
+| main.rs:1404:18:1404:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:1404:18:1404:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:1404:18:1404:34 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1404:18:1404:34 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1404:26:1404:34 | from_loop |  | main.rs:1321:5:1325:5 | MyOption |
+| main.rs:1404:26:1404:34 | from_loop | T | main.rs:1356:5:1357:13 | S |
+| main.rs:1422:15:1422:18 | SelfParam |  | main.rs:1410:5:1411:19 | S |
+| main.rs:1422:15:1422:18 | SelfParam | T | main.rs:1421:10:1421:10 | T |
+| main.rs:1422:26:1424:9 | { ... } |  | main.rs:1421:10:1421:10 | T |
+| main.rs:1423:13:1423:16 | self |  | main.rs:1410:5:1411:19 | S |
+| main.rs:1423:13:1423:16 | self | T | main.rs:1421:10:1421:10 | T |
+| main.rs:1423:13:1423:18 | self.0 |  | main.rs:1421:10:1421:10 | T |
+| main.rs:1426:15:1426:19 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1426:15:1426:19 | SelfParam | &T | main.rs:1410:5:1411:19 | S |
+| main.rs:1426:15:1426:19 | SelfParam | &T.T | main.rs:1421:10:1421:10 | T |
+| main.rs:1426:28:1428:9 | { ... } |  | file://:0:0:0:0 | & |
+| main.rs:1426:28:1428:9 | { ... } | &T | main.rs:1421:10:1421:10 | T |
+| main.rs:1427:13:1427:19 | &... |  | file://:0:0:0:0 | & |
+| main.rs:1427:13:1427:19 | &... | &T | main.rs:1421:10:1421:10 | T |
+| main.rs:1427:14:1427:17 | self |  | file://:0:0:0:0 | & |
+| main.rs:1427:14:1427:17 | self | &T | main.rs:1410:5:1411:19 | S |
+| main.rs:1427:14:1427:17 | self | &T.T | main.rs:1421:10:1421:10 | T |
+| main.rs:1427:14:1427:19 | self.0 |  | main.rs:1421:10:1421:10 | T |
+| main.rs:1430:15:1430:25 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1430:15:1430:25 | SelfParam | &T | main.rs:1410:5:1411:19 | S |
+| main.rs:1430:15:1430:25 | SelfParam | &T.T | main.rs:1421:10:1421:10 | T |
+| main.rs:1430:34:1432:9 | { ... } |  | file://:0:0:0:0 | & |
+| main.rs:1430:34:1432:9 | { ... } | &T | main.rs:1421:10:1421:10 | T |
+| main.rs:1431:13:1431:19 | &... |  | file://:0:0:0:0 | & |
+| main.rs:1431:13:1431:19 | &... | &T | main.rs:1421:10:1421:10 | T |
+| main.rs:1431:14:1431:17 | self |  | file://:0:0:0:0 | & |
+| main.rs:1431:14:1431:17 | self | &T | main.rs:1410:5:1411:19 | S |
+| main.rs:1431:14:1431:17 | self | &T.T | main.rs:1421:10:1421:10 | T |
+| main.rs:1431:14:1431:19 | self.0 |  | main.rs:1421:10:1421:10 | T |
+| main.rs:1436:29:1436:33 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1436:29:1436:33 | SelfParam | &T | main.rs:1435:5:1438:5 | Self [trait ATrait] |
+| main.rs:1437:33:1437:36 | SelfParam |  | main.rs:1435:5:1438:5 | Self [trait ATrait] |
+| main.rs:1443:29:1443:33 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1443:29:1443:33 | SelfParam | &T | file://:0:0:0:0 | & |
+| main.rs:1443:29:1443:33 | SelfParam | &T.&T | main.rs:1416:5:1419:5 | MyInt |
+| main.rs:1443:43:1445:9 | { ... } |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1444:13:1444:22 | (...) |  | main.rs:1416:5:1419:5 | MyInt |
+| main.rs:1444:13:1444:24 | ... .a |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1444:14:1444:21 | * ... |  | main.rs:1416:5:1419:5 | MyInt |
+| main.rs:1444:15:1444:21 | (...) |  | file://:0:0:0:0 | & |
+| main.rs:1444:15:1444:21 | (...) | &T | main.rs:1416:5:1419:5 | MyInt |
+| main.rs:1444:16:1444:20 | * ... |  | file://:0:0:0:0 | & |
+| main.rs:1444:16:1444:20 | * ... | &T | main.rs:1416:5:1419:5 | MyInt |
+| main.rs:1444:17:1444:20 | self |  | file://:0:0:0:0 | & |
+| main.rs:1444:17:1444:20 | self | &T | file://:0:0:0:0 | & |
+| main.rs:1444:17:1444:20 | self | &T.&T | main.rs:1416:5:1419:5 | MyInt |
+| main.rs:1448:33:1448:36 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1448:33:1448:36 | SelfParam | &T | main.rs:1416:5:1419:5 | MyInt |
+| main.rs:1448:46:1450:9 | { ... } |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1449:13:1449:19 | (...) |  | main.rs:1416:5:1419:5 | MyInt |
+| main.rs:1449:13:1449:21 | ... .a |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1449:14:1449:18 | * ... |  | main.rs:1416:5:1419:5 | MyInt |
+| main.rs:1449:15:1449:18 | self |  | file://:0:0:0:0 | & |
+| main.rs:1449:15:1449:18 | self | &T | main.rs:1416:5:1419:5 | MyInt |
+| main.rs:1454:13:1454:14 | x1 |  | main.rs:1410:5:1411:19 | S |
+| main.rs:1454:13:1454:14 | x1 | T | main.rs:1413:5:1414:14 | S2 |
+| main.rs:1454:18:1454:22 | S(...) |  | main.rs:1410:5:1411:19 | S |
+| main.rs:1454:18:1454:22 | S(...) | T | main.rs:1413:5:1414:14 | S2 |
+| main.rs:1454:20:1454:21 | S2 |  | main.rs:1413:5:1414:14 | S2 |
+| main.rs:1455:18:1455:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:1455:18:1455:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:1455:18:1455:32 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1455:18:1455:32 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1455:26:1455:27 | x1 |  | main.rs:1410:5:1411:19 | S |
+| main.rs:1455:26:1455:27 | x1 | T | main.rs:1413:5:1414:14 | S2 |
+| main.rs:1455:26:1455:32 | x1.m1() |  | main.rs:1413:5:1414:14 | S2 |
+| main.rs:1457:13:1457:14 | x2 |  | main.rs:1410:5:1411:19 | S |
+| main.rs:1457:13:1457:14 | x2 | T | main.rs:1413:5:1414:14 | S2 |
+| main.rs:1457:18:1457:22 | S(...) |  | main.rs:1410:5:1411:19 | S |
+| main.rs:1457:18:1457:22 | S(...) | T | main.rs:1413:5:1414:14 | S2 |
+| main.rs:1457:20:1457:21 | S2 |  | main.rs:1413:5:1414:14 | S2 |
+| main.rs:1459:18:1459:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:1459:18:1459:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:1459:18:1459:32 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1459:18:1459:32 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1459:26:1459:27 | x2 |  | main.rs:1410:5:1411:19 | S |
+| main.rs:1459:26:1459:27 | x2 | T | main.rs:1413:5:1414:14 | S2 |
+| main.rs:1459:26:1459:32 | x2.m2() |  | file://:0:0:0:0 | & |
+| main.rs:1459:26:1459:32 | x2.m2() | &T | main.rs:1413:5:1414:14 | S2 |
 | main.rs:1460:18:1460:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
 | main.rs:1460:18:1460:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
 | main.rs:1460:18:1460:32 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
 | main.rs:1460:18:1460:32 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1460:26:1460:27 | x2 |  | main.rs:1411:5:1412:19 | S |
-| main.rs:1460:26:1460:27 | x2 | T | main.rs:1414:5:1415:14 | S2 |
-| main.rs:1460:26:1460:32 | x2.m2() |  | file://:0:0:0:0 | & |
-| main.rs:1460:26:1460:32 | x2.m2() | &T | main.rs:1414:5:1415:14 | S2 |
-| main.rs:1461:18:1461:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:1461:18:1461:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:1461:18:1461:32 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1461:18:1461:32 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1461:26:1461:27 | x2 |  | main.rs:1411:5:1412:19 | S |
-| main.rs:1461:26:1461:27 | x2 | T | main.rs:1414:5:1415:14 | S2 |
-| main.rs:1461:26:1461:32 | x2.m3() |  | file://:0:0:0:0 | & |
-| main.rs:1461:26:1461:32 | x2.m3() | &T | main.rs:1414:5:1415:14 | S2 |
-| main.rs:1463:13:1463:14 | x3 |  | main.rs:1411:5:1412:19 | S |
-| main.rs:1463:13:1463:14 | x3 | T | main.rs:1414:5:1415:14 | S2 |
-| main.rs:1463:18:1463:22 | S(...) |  | main.rs:1411:5:1412:19 | S |
-| main.rs:1463:18:1463:22 | S(...) | T | main.rs:1414:5:1415:14 | S2 |
-| main.rs:1463:20:1463:21 | S2 |  | main.rs:1414:5:1415:14 | S2 |
+| main.rs:1460:26:1460:27 | x2 |  | main.rs:1410:5:1411:19 | S |
+| main.rs:1460:26:1460:27 | x2 | T | main.rs:1413:5:1414:14 | S2 |
+| main.rs:1460:26:1460:32 | x2.m3() |  | file://:0:0:0:0 | & |
+| main.rs:1460:26:1460:32 | x2.m3() | &T | main.rs:1413:5:1414:14 | S2 |
+| main.rs:1462:13:1462:14 | x3 |  | main.rs:1410:5:1411:19 | S |
+| main.rs:1462:13:1462:14 | x3 | T | main.rs:1413:5:1414:14 | S2 |
+| main.rs:1462:18:1462:22 | S(...) |  | main.rs:1410:5:1411:19 | S |
+| main.rs:1462:18:1462:22 | S(...) | T | main.rs:1413:5:1414:14 | S2 |
+| main.rs:1462:20:1462:21 | S2 |  | main.rs:1413:5:1414:14 | S2 |
+| main.rs:1464:18:1464:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:1464:18:1464:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:1464:18:1464:41 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1464:18:1464:41 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1464:26:1464:41 | ...::m2(...) |  | file://:0:0:0:0 | & |
+| main.rs:1464:26:1464:41 | ...::m2(...) | &T | main.rs:1413:5:1414:14 | S2 |
+| main.rs:1464:38:1464:40 | &x3 |  | file://:0:0:0:0 | & |
+| main.rs:1464:38:1464:40 | &x3 | &T | main.rs:1410:5:1411:19 | S |
+| main.rs:1464:38:1464:40 | &x3 | &T.T | main.rs:1413:5:1414:14 | S2 |
+| main.rs:1464:39:1464:40 | x3 |  | main.rs:1410:5:1411:19 | S |
+| main.rs:1464:39:1464:40 | x3 | T | main.rs:1413:5:1414:14 | S2 |
 | main.rs:1465:18:1465:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
 | main.rs:1465:18:1465:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
 | main.rs:1465:18:1465:41 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
 | main.rs:1465:18:1465:41 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1465:26:1465:41 | ...::m2(...) |  | file://:0:0:0:0 | & |
-| main.rs:1465:26:1465:41 | ...::m2(...) | &T | main.rs:1414:5:1415:14 | S2 |
+| main.rs:1465:26:1465:41 | ...::m3(...) |  | file://:0:0:0:0 | & |
+| main.rs:1465:26:1465:41 | ...::m3(...) | &T | main.rs:1413:5:1414:14 | S2 |
 | main.rs:1465:38:1465:40 | &x3 |  | file://:0:0:0:0 | & |
-| main.rs:1465:38:1465:40 | &x3 | &T | main.rs:1411:5:1412:19 | S |
-| main.rs:1465:38:1465:40 | &x3 | &T.T | main.rs:1414:5:1415:14 | S2 |
-| main.rs:1465:39:1465:40 | x3 |  | main.rs:1411:5:1412:19 | S |
-| main.rs:1465:39:1465:40 | x3 | T | main.rs:1414:5:1415:14 | S2 |
-| main.rs:1466:18:1466:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:1466:18:1466:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:1466:18:1466:41 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1466:18:1466:41 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1466:26:1466:41 | ...::m3(...) |  | file://:0:0:0:0 | & |
-| main.rs:1466:26:1466:41 | ...::m3(...) | &T | main.rs:1414:5:1415:14 | S2 |
-| main.rs:1466:38:1466:40 | &x3 |  | file://:0:0:0:0 | & |
-| main.rs:1466:38:1466:40 | &x3 | &T | main.rs:1411:5:1412:19 | S |
-| main.rs:1466:38:1466:40 | &x3 | &T.T | main.rs:1414:5:1415:14 | S2 |
-| main.rs:1466:39:1466:40 | x3 |  | main.rs:1411:5:1412:19 | S |
-| main.rs:1466:39:1466:40 | x3 | T | main.rs:1414:5:1415:14 | S2 |
-| main.rs:1468:13:1468:14 | x4 |  | file://:0:0:0:0 | & |
-| main.rs:1468:13:1468:14 | x4 | &T | main.rs:1411:5:1412:19 | S |
-| main.rs:1468:13:1468:14 | x4 | &T.T | main.rs:1414:5:1415:14 | S2 |
-| main.rs:1468:18:1468:23 | &... |  | file://:0:0:0:0 | & |
-| main.rs:1468:18:1468:23 | &... | &T | main.rs:1411:5:1412:19 | S |
-| main.rs:1468:18:1468:23 | &... | &T.T | main.rs:1414:5:1415:14 | S2 |
-| main.rs:1468:19:1468:23 | S(...) |  | main.rs:1411:5:1412:19 | S |
-| main.rs:1468:19:1468:23 | S(...) | T | main.rs:1414:5:1415:14 | S2 |
-| main.rs:1468:21:1468:22 | S2 |  | main.rs:1414:5:1415:14 | S2 |
+| main.rs:1465:38:1465:40 | &x3 | &T | main.rs:1410:5:1411:19 | S |
+| main.rs:1465:38:1465:40 | &x3 | &T.T | main.rs:1413:5:1414:14 | S2 |
+| main.rs:1465:39:1465:40 | x3 |  | main.rs:1410:5:1411:19 | S |
+| main.rs:1465:39:1465:40 | x3 | T | main.rs:1413:5:1414:14 | S2 |
+| main.rs:1467:13:1467:14 | x4 |  | file://:0:0:0:0 | & |
+| main.rs:1467:13:1467:14 | x4 | &T | main.rs:1410:5:1411:19 | S |
+| main.rs:1467:13:1467:14 | x4 | &T.T | main.rs:1413:5:1414:14 | S2 |
+| main.rs:1467:18:1467:23 | &... |  | file://:0:0:0:0 | & |
+| main.rs:1467:18:1467:23 | &... | &T | main.rs:1410:5:1411:19 | S |
+| main.rs:1467:18:1467:23 | &... | &T.T | main.rs:1413:5:1414:14 | S2 |
+| main.rs:1467:19:1467:23 | S(...) |  | main.rs:1410:5:1411:19 | S |
+| main.rs:1467:19:1467:23 | S(...) | T | main.rs:1413:5:1414:14 | S2 |
+| main.rs:1467:21:1467:22 | S2 |  | main.rs:1413:5:1414:14 | S2 |
+| main.rs:1469:18:1469:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:1469:18:1469:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:1469:18:1469:32 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1469:18:1469:32 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1469:26:1469:27 | x4 |  | file://:0:0:0:0 | & |
+| main.rs:1469:26:1469:27 | x4 | &T | main.rs:1410:5:1411:19 | S |
+| main.rs:1469:26:1469:27 | x4 | &T.T | main.rs:1413:5:1414:14 | S2 |
+| main.rs:1469:26:1469:32 | x4.m2() |  | file://:0:0:0:0 | & |
+| main.rs:1469:26:1469:32 | x4.m2() | &T | main.rs:1413:5:1414:14 | S2 |
 | main.rs:1470:18:1470:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
 | main.rs:1470:18:1470:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
 | main.rs:1470:18:1470:32 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
 | main.rs:1470:18:1470:32 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
 | main.rs:1470:26:1470:27 | x4 |  | file://:0:0:0:0 | & |
-| main.rs:1470:26:1470:27 | x4 | &T | main.rs:1411:5:1412:19 | S |
-| main.rs:1470:26:1470:27 | x4 | &T.T | main.rs:1414:5:1415:14 | S2 |
-| main.rs:1470:26:1470:32 | x4.m2() |  | file://:0:0:0:0 | & |
-| main.rs:1470:26:1470:32 | x4.m2() | &T | main.rs:1414:5:1415:14 | S2 |
-| main.rs:1471:18:1471:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:1471:18:1471:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:1471:18:1471:32 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1471:18:1471:32 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1471:26:1471:27 | x4 |  | file://:0:0:0:0 | & |
-| main.rs:1471:26:1471:27 | x4 | &T | main.rs:1411:5:1412:19 | S |
-| main.rs:1471:26:1471:27 | x4 | &T.T | main.rs:1414:5:1415:14 | S2 |
-| main.rs:1471:26:1471:32 | x4.m3() |  | file://:0:0:0:0 | & |
-| main.rs:1471:26:1471:32 | x4.m3() | &T | main.rs:1414:5:1415:14 | S2 |
-| main.rs:1473:13:1473:14 | x5 |  | file://:0:0:0:0 | & |
-| main.rs:1473:13:1473:14 | x5 | &T | main.rs:1411:5:1412:19 | S |
-| main.rs:1473:13:1473:14 | x5 | &T.T | main.rs:1414:5:1415:14 | S2 |
-| main.rs:1473:18:1473:23 | &... |  | file://:0:0:0:0 | & |
-| main.rs:1473:18:1473:23 | &... | &T | main.rs:1411:5:1412:19 | S |
-| main.rs:1473:18:1473:23 | &... | &T.T | main.rs:1414:5:1415:14 | S2 |
-| main.rs:1473:19:1473:23 | S(...) |  | main.rs:1411:5:1412:19 | S |
-| main.rs:1473:19:1473:23 | S(...) | T | main.rs:1414:5:1415:14 | S2 |
-| main.rs:1473:21:1473:22 | S2 |  | main.rs:1414:5:1415:14 | S2 |
+| main.rs:1470:26:1470:27 | x4 | &T | main.rs:1410:5:1411:19 | S |
+| main.rs:1470:26:1470:27 | x4 | &T.T | main.rs:1413:5:1414:14 | S2 |
+| main.rs:1470:26:1470:32 | x4.m3() |  | file://:0:0:0:0 | & |
+| main.rs:1470:26:1470:32 | x4.m3() | &T | main.rs:1413:5:1414:14 | S2 |
+| main.rs:1472:13:1472:14 | x5 |  | file://:0:0:0:0 | & |
+| main.rs:1472:13:1472:14 | x5 | &T | main.rs:1410:5:1411:19 | S |
+| main.rs:1472:13:1472:14 | x5 | &T.T | main.rs:1413:5:1414:14 | S2 |
+| main.rs:1472:18:1472:23 | &... |  | file://:0:0:0:0 | & |
+| main.rs:1472:18:1472:23 | &... | &T | main.rs:1410:5:1411:19 | S |
+| main.rs:1472:18:1472:23 | &... | &T.T | main.rs:1413:5:1414:14 | S2 |
+| main.rs:1472:19:1472:23 | S(...) |  | main.rs:1410:5:1411:19 | S |
+| main.rs:1472:19:1472:23 | S(...) | T | main.rs:1413:5:1414:14 | S2 |
+| main.rs:1472:21:1472:22 | S2 |  | main.rs:1413:5:1414:14 | S2 |
+| main.rs:1474:18:1474:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:1474:18:1474:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:1474:18:1474:32 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1474:18:1474:32 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1474:26:1474:27 | x5 |  | file://:0:0:0:0 | & |
+| main.rs:1474:26:1474:27 | x5 | &T | main.rs:1410:5:1411:19 | S |
+| main.rs:1474:26:1474:27 | x5 | &T.T | main.rs:1413:5:1414:14 | S2 |
+| main.rs:1474:26:1474:32 | x5.m1() |  | main.rs:1413:5:1414:14 | S2 |
 | main.rs:1475:18:1475:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
 | main.rs:1475:18:1475:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:1475:18:1475:32 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1475:18:1475:32 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1475:18:1475:29 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1475:18:1475:29 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
 | main.rs:1475:26:1475:27 | x5 |  | file://:0:0:0:0 | & |
-| main.rs:1475:26:1475:27 | x5 | &T | main.rs:1411:5:1412:19 | S |
-| main.rs:1475:26:1475:27 | x5 | &T.T | main.rs:1414:5:1415:14 | S2 |
-| main.rs:1475:26:1475:32 | x5.m1() |  | main.rs:1414:5:1415:14 | S2 |
-| main.rs:1476:18:1476:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:1476:18:1476:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:1476:18:1476:29 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1476:18:1476:29 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1476:26:1476:27 | x5 |  | file://:0:0:0:0 | & |
-| main.rs:1476:26:1476:27 | x5 | &T | main.rs:1411:5:1412:19 | S |
-| main.rs:1476:26:1476:27 | x5 | &T.T | main.rs:1414:5:1415:14 | S2 |
-| main.rs:1476:26:1476:29 | x5.0 |  | main.rs:1414:5:1415:14 | S2 |
-| main.rs:1478:13:1478:14 | x6 |  | file://:0:0:0:0 | & |
-| main.rs:1478:13:1478:14 | x6 | &T | main.rs:1411:5:1412:19 | S |
-| main.rs:1478:13:1478:14 | x6 | &T.T | main.rs:1414:5:1415:14 | S2 |
-| main.rs:1478:18:1478:23 | &... |  | file://:0:0:0:0 | & |
-| main.rs:1478:18:1478:23 | &... | &T | main.rs:1411:5:1412:19 | S |
-| main.rs:1478:18:1478:23 | &... | &T.T | main.rs:1414:5:1415:14 | S2 |
-| main.rs:1478:19:1478:23 | S(...) |  | main.rs:1411:5:1412:19 | S |
-| main.rs:1478:19:1478:23 | S(...) | T | main.rs:1414:5:1415:14 | S2 |
-| main.rs:1478:21:1478:22 | S2 |  | main.rs:1414:5:1415:14 | S2 |
-| main.rs:1481:18:1481:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:1481:18:1481:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:1481:18:1481:35 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1481:18:1481:35 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1481:26:1481:30 | (...) |  | main.rs:1411:5:1412:19 | S |
-| main.rs:1481:26:1481:30 | (...) | T | main.rs:1414:5:1415:14 | S2 |
-| main.rs:1481:26:1481:35 | ... .m1() |  | main.rs:1414:5:1415:14 | S2 |
-| main.rs:1481:27:1481:29 | * ... |  | main.rs:1411:5:1412:19 | S |
-| main.rs:1481:27:1481:29 | * ... | T | main.rs:1414:5:1415:14 | S2 |
-| main.rs:1481:28:1481:29 | x6 |  | file://:0:0:0:0 | & |
-| main.rs:1481:28:1481:29 | x6 | &T | main.rs:1411:5:1412:19 | S |
-| main.rs:1481:28:1481:29 | x6 | &T.T | main.rs:1414:5:1415:14 | S2 |
-| main.rs:1483:13:1483:14 | x7 |  | main.rs:1411:5:1412:19 | S |
-| main.rs:1483:13:1483:14 | x7 | T | file://:0:0:0:0 | & |
-| main.rs:1483:13:1483:14 | x7 | T.&T | main.rs:1414:5:1415:14 | S2 |
-| main.rs:1483:18:1483:23 | S(...) |  | main.rs:1411:5:1412:19 | S |
-| main.rs:1483:18:1483:23 | S(...) | T | file://:0:0:0:0 | & |
-| main.rs:1483:18:1483:23 | S(...) | T.&T | main.rs:1414:5:1415:14 | S2 |
-| main.rs:1483:20:1483:22 | &S2 |  | file://:0:0:0:0 | & |
-| main.rs:1483:20:1483:22 | &S2 | &T | main.rs:1414:5:1415:14 | S2 |
-| main.rs:1483:21:1483:22 | S2 |  | main.rs:1414:5:1415:14 | S2 |
-| main.rs:1486:13:1486:13 | t |  | file://:0:0:0:0 | & |
-| main.rs:1486:13:1486:13 | t | &T | main.rs:1414:5:1415:14 | S2 |
-| main.rs:1486:17:1486:18 | x7 |  | main.rs:1411:5:1412:19 | S |
-| main.rs:1486:17:1486:18 | x7 | T | file://:0:0:0:0 | & |
-| main.rs:1486:17:1486:18 | x7 | T.&T | main.rs:1414:5:1415:14 | S2 |
-| main.rs:1486:17:1486:23 | x7.m1() |  | file://:0:0:0:0 | & |
-| main.rs:1486:17:1486:23 | x7.m1() | &T | main.rs:1414:5:1415:14 | S2 |
-| main.rs:1487:18:1487:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:1487:18:1487:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:1487:18:1487:27 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1487:18:1487:27 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1487:26:1487:27 | x7 |  | main.rs:1411:5:1412:19 | S |
-| main.rs:1487:26:1487:27 | x7 | T | file://:0:0:0:0 | & |
-| main.rs:1487:26:1487:27 | x7 | T.&T | main.rs:1414:5:1415:14 | S2 |
-| main.rs:1489:13:1489:14 | x9 |  | {EXTERNAL LOCATION} | String |
-| main.rs:1489:26:1489:32 | "Hello" |  | file://:0:0:0:0 | & |
-| main.rs:1489:26:1489:32 | "Hello" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:1489:26:1489:44 | "Hello".to_string() |  | {EXTERNAL LOCATION} | String |
-| main.rs:1493:13:1493:13 | u |  | {EXTERNAL LOCATION} | Result |
-| main.rs:1493:13:1493:13 | u | T | {EXTERNAL LOCATION} | u32 |
-| main.rs:1493:17:1493:18 | x9 |  | {EXTERNAL LOCATION} | String |
-| main.rs:1493:17:1493:33 | x9.parse() |  | {EXTERNAL LOCATION} | Result |
-| main.rs:1493:17:1493:33 | x9.parse() | T | {EXTERNAL LOCATION} | u32 |
-| main.rs:1495:13:1495:20 | my_thing |  | file://:0:0:0:0 | & |
-| main.rs:1495:13:1495:20 | my_thing | &T | main.rs:1417:5:1420:5 | MyInt |
-| main.rs:1495:24:1495:39 | &... |  | file://:0:0:0:0 | & |
-| main.rs:1495:24:1495:39 | &... | &T | main.rs:1417:5:1420:5 | MyInt |
-| main.rs:1495:25:1495:39 | MyInt {...} |  | main.rs:1417:5:1420:5 | MyInt |
-| main.rs:1495:36:1495:37 | 37 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:1495:36:1495:37 | 37 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1497:13:1497:13 | a |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1497:17:1497:24 | my_thing |  | file://:0:0:0:0 | & |
-| main.rs:1497:17:1497:24 | my_thing | &T | main.rs:1417:5:1420:5 | MyInt |
-| main.rs:1497:17:1497:43 | my_thing.method_on_borrow() |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1498:18:1498:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:1498:18:1498:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:1498:18:1498:26 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1498:18:1498:26 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1498:26:1498:26 | a |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1501:13:1501:20 | my_thing |  | file://:0:0:0:0 | & |
-| main.rs:1501:13:1501:20 | my_thing | &T | main.rs:1417:5:1420:5 | MyInt |
-| main.rs:1501:24:1501:39 | &... |  | file://:0:0:0:0 | & |
-| main.rs:1501:24:1501:39 | &... | &T | main.rs:1417:5:1420:5 | MyInt |
-| main.rs:1501:25:1501:39 | MyInt {...} |  | main.rs:1417:5:1420:5 | MyInt |
-| main.rs:1501:36:1501:37 | 38 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:1501:36:1501:37 | 38 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1502:13:1502:13 | a |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1502:17:1502:24 | my_thing |  | file://:0:0:0:0 | & |
-| main.rs:1502:17:1502:24 | my_thing | &T | main.rs:1417:5:1420:5 | MyInt |
-| main.rs:1502:17:1502:47 | my_thing.method_not_on_borrow() |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1503:18:1503:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:1503:18:1503:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:1503:18:1503:26 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1503:18:1503:26 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1503:26:1503:26 | a |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1510:16:1510:20 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:1510:16:1510:20 | SelfParam | &T | main.rs:1508:5:1516:5 | Self [trait MyTrait] |
-| main.rs:1513:16:1513:20 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:1513:16:1513:20 | SelfParam | &T | main.rs:1508:5:1516:5 | Self [trait MyTrait] |
-| main.rs:1513:32:1515:9 | { ... } |  | file://:0:0:0:0 | & |
-| main.rs:1513:32:1515:9 | { ... } | &T | main.rs:1508:5:1516:5 | Self [trait MyTrait] |
-| main.rs:1514:13:1514:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:1514:13:1514:16 | self | &T | main.rs:1508:5:1516:5 | Self [trait MyTrait] |
-| main.rs:1514:13:1514:22 | self.foo() |  | file://:0:0:0:0 | & |
-| main.rs:1514:13:1514:22 | self.foo() | &T | main.rs:1508:5:1516:5 | Self [trait MyTrait] |
-| main.rs:1522:16:1522:20 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:1522:16:1522:20 | SelfParam | &T | main.rs:1518:5:1518:20 | MyStruct |
-| main.rs:1522:36:1524:9 | { ... } |  | file://:0:0:0:0 | & |
-| main.rs:1522:36:1524:9 | { ... } | &T | main.rs:1518:5:1518:20 | MyStruct |
-| main.rs:1523:13:1523:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:1523:13:1523:16 | self | &T | main.rs:1518:5:1518:20 | MyStruct |
-| main.rs:1528:13:1528:13 | x |  | main.rs:1518:5:1518:20 | MyStruct |
-| main.rs:1528:17:1528:24 | MyStruct |  | main.rs:1518:5:1518:20 | MyStruct |
-| main.rs:1529:9:1529:9 | x |  | main.rs:1518:5:1518:20 | MyStruct |
-| main.rs:1529:9:1529:15 | x.bar() |  | file://:0:0:0:0 | & |
-| main.rs:1529:9:1529:15 | x.bar() | &T | main.rs:1518:5:1518:20 | MyStruct |
-| main.rs:1539:16:1539:20 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:1539:16:1539:20 | SelfParam | &T | main.rs:1536:5:1536:26 | MyStruct |
-| main.rs:1539:16:1539:20 | SelfParam | &T.T | main.rs:1538:10:1538:10 | T |
-| main.rs:1539:32:1541:9 | { ... } |  | file://:0:0:0:0 | & |
-| main.rs:1539:32:1541:9 | { ... } | &T | main.rs:1536:5:1536:26 | MyStruct |
-| main.rs:1539:32:1541:9 | { ... } | &T.T | main.rs:1538:10:1538:10 | T |
-| main.rs:1540:13:1540:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:1540:13:1540:16 | self | &T | main.rs:1536:5:1536:26 | MyStruct |
-| main.rs:1540:13:1540:16 | self | &T.T | main.rs:1538:10:1538:10 | T |
-| main.rs:1545:13:1545:13 | x |  | main.rs:1536:5:1536:26 | MyStruct |
-| main.rs:1545:13:1545:13 | x | T | main.rs:1534:5:1534:13 | S |
-| main.rs:1545:17:1545:27 | MyStruct(...) |  | main.rs:1536:5:1536:26 | MyStruct |
-| main.rs:1545:17:1545:27 | MyStruct(...) | T | main.rs:1534:5:1534:13 | S |
-| main.rs:1545:26:1545:26 | S |  | main.rs:1534:5:1534:13 | S |
-| main.rs:1546:9:1546:9 | x |  | main.rs:1536:5:1536:26 | MyStruct |
-| main.rs:1546:9:1546:9 | x | T | main.rs:1534:5:1534:13 | S |
-| main.rs:1546:9:1546:15 | x.foo() |  | file://:0:0:0:0 | & |
-| main.rs:1546:9:1546:15 | x.foo() | &T | main.rs:1536:5:1536:26 | MyStruct |
-| main.rs:1546:9:1546:15 | x.foo() | &T.T | main.rs:1534:5:1534:13 | S |
-| main.rs:1557:17:1557:25 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:1557:17:1557:25 | SelfParam | &T | main.rs:1551:5:1554:5 | MyFlag |
-| main.rs:1558:13:1558:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:1558:13:1558:16 | self | &T | main.rs:1551:5:1554:5 | MyFlag |
-| main.rs:1558:13:1558:21 | self.bool |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1558:13:1558:34 | ... = ... |  | file://:0:0:0:0 | () |
-| main.rs:1558:25:1558:34 | ! ... |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1558:26:1558:29 | self |  | file://:0:0:0:0 | & |
-| main.rs:1558:26:1558:29 | self | &T | main.rs:1551:5:1554:5 | MyFlag |
-| main.rs:1558:26:1558:34 | self.bool |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1565:15:1565:19 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:1565:15:1565:19 | SelfParam | &T | main.rs:1562:5:1562:13 | S |
-| main.rs:1565:31:1567:9 | { ... } |  | file://:0:0:0:0 | & |
-| main.rs:1565:31:1567:9 | { ... } | &T | main.rs:1562:5:1562:13 | S |
-| main.rs:1566:13:1566:19 | &... |  | file://:0:0:0:0 | & |
-| main.rs:1566:13:1566:19 | &... | &T | file://:0:0:0:0 | & |
-| main.rs:1566:13:1566:19 | &... | &T | main.rs:1562:5:1562:13 | S |
-| main.rs:1566:13:1566:19 | &... | &T.&T | file://:0:0:0:0 | & |
-| main.rs:1566:13:1566:19 | &... | &T.&T.&T | file://:0:0:0:0 | & |
-| main.rs:1566:13:1566:19 | &... | &T.&T.&T.&T | main.rs:1562:5:1562:13 | S |
-| main.rs:1566:14:1566:19 | &... |  | file://:0:0:0:0 | & |
-| main.rs:1566:14:1566:19 | &... | &T | file://:0:0:0:0 | & |
-| main.rs:1566:14:1566:19 | &... | &T.&T | file://:0:0:0:0 | & |
-| main.rs:1566:14:1566:19 | &... | &T.&T.&T | main.rs:1562:5:1562:13 | S |
-| main.rs:1566:15:1566:19 | &self |  | file://:0:0:0:0 | & |
-| main.rs:1566:15:1566:19 | &self | &T | file://:0:0:0:0 | & |
-| main.rs:1566:15:1566:19 | &self | &T.&T | main.rs:1562:5:1562:13 | S |
-| main.rs:1566:16:1566:19 | self |  | file://:0:0:0:0 | & |
-| main.rs:1566:16:1566:19 | self | &T | main.rs:1562:5:1562:13 | S |
-| main.rs:1569:15:1569:25 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:1569:15:1569:25 | SelfParam | &T | main.rs:1562:5:1562:13 | S |
-| main.rs:1569:37:1571:9 | { ... } |  | file://:0:0:0:0 | & |
-| main.rs:1569:37:1571:9 | { ... } | &T | main.rs:1562:5:1562:13 | S |
-| main.rs:1570:13:1570:19 | &... |  | file://:0:0:0:0 | & |
-| main.rs:1570:13:1570:19 | &... | &T | file://:0:0:0:0 | & |
-| main.rs:1570:13:1570:19 | &... | &T | main.rs:1562:5:1562:13 | S |
-| main.rs:1570:13:1570:19 | &... | &T.&T | file://:0:0:0:0 | & |
-| main.rs:1570:13:1570:19 | &... | &T.&T.&T | file://:0:0:0:0 | & |
-| main.rs:1570:13:1570:19 | &... | &T.&T.&T.&T | main.rs:1562:5:1562:13 | S |
-| main.rs:1570:14:1570:19 | &... |  | file://:0:0:0:0 | & |
-| main.rs:1570:14:1570:19 | &... | &T | file://:0:0:0:0 | & |
-| main.rs:1570:14:1570:19 | &... | &T.&T | file://:0:0:0:0 | & |
-| main.rs:1570:14:1570:19 | &... | &T.&T.&T | main.rs:1562:5:1562:13 | S |
-| main.rs:1570:15:1570:19 | &self |  | file://:0:0:0:0 | & |
-| main.rs:1570:15:1570:19 | &self | &T | file://:0:0:0:0 | & |
-| main.rs:1570:15:1570:19 | &self | &T.&T | main.rs:1562:5:1562:13 | S |
-| main.rs:1570:16:1570:19 | self |  | file://:0:0:0:0 | & |
-| main.rs:1570:16:1570:19 | self | &T | main.rs:1562:5:1562:13 | S |
-| main.rs:1573:15:1573:15 | x |  | file://:0:0:0:0 | & |
-| main.rs:1573:15:1573:15 | x | &T | main.rs:1562:5:1562:13 | S |
-| main.rs:1573:34:1575:9 | { ... } |  | file://:0:0:0:0 | & |
-| main.rs:1573:34:1575:9 | { ... } | &T | main.rs:1562:5:1562:13 | S |
-| main.rs:1574:13:1574:13 | x |  | file://:0:0:0:0 | & |
-| main.rs:1574:13:1574:13 | x | &T | main.rs:1562:5:1562:13 | S |
-| main.rs:1577:15:1577:15 | x |  | file://:0:0:0:0 | & |
-| main.rs:1577:15:1577:15 | x | &T | main.rs:1562:5:1562:13 | S |
-| main.rs:1577:34:1579:9 | { ... } |  | file://:0:0:0:0 | & |
-| main.rs:1577:34:1579:9 | { ... } | &T | main.rs:1562:5:1562:13 | S |
-| main.rs:1578:13:1578:16 | &... |  | file://:0:0:0:0 | & |
-| main.rs:1578:13:1578:16 | &... | &T | file://:0:0:0:0 | & |
-| main.rs:1578:13:1578:16 | &... | &T | main.rs:1562:5:1562:13 | S |
-| main.rs:1578:13:1578:16 | &... | &T.&T | file://:0:0:0:0 | & |
-| main.rs:1578:13:1578:16 | &... | &T.&T.&T | file://:0:0:0:0 | & |
-| main.rs:1578:13:1578:16 | &... | &T.&T.&T.&T | main.rs:1562:5:1562:13 | S |
-| main.rs:1578:14:1578:16 | &... |  | file://:0:0:0:0 | & |
-| main.rs:1578:14:1578:16 | &... | &T | file://:0:0:0:0 | & |
-| main.rs:1578:14:1578:16 | &... | &T.&T | file://:0:0:0:0 | & |
-| main.rs:1578:14:1578:16 | &... | &T.&T.&T | main.rs:1562:5:1562:13 | S |
-| main.rs:1578:15:1578:16 | &x |  | file://:0:0:0:0 | & |
-| main.rs:1578:15:1578:16 | &x | &T | file://:0:0:0:0 | & |
-| main.rs:1578:15:1578:16 | &x | &T.&T | main.rs:1562:5:1562:13 | S |
-| main.rs:1578:16:1578:16 | x |  | file://:0:0:0:0 | & |
-| main.rs:1578:16:1578:16 | x | &T | main.rs:1562:5:1562:13 | S |
-| main.rs:1583:13:1583:13 | x |  | main.rs:1562:5:1562:13 | S |
-| main.rs:1583:17:1583:20 | S {...} |  | main.rs:1562:5:1562:13 | S |
-| main.rs:1584:9:1584:9 | x |  | main.rs:1562:5:1562:13 | S |
-| main.rs:1584:9:1584:14 | x.f1() |  | file://:0:0:0:0 | & |
-| main.rs:1584:9:1584:14 | x.f1() | &T | main.rs:1562:5:1562:13 | S |
-| main.rs:1585:9:1585:9 | x |  | main.rs:1562:5:1562:13 | S |
-| main.rs:1585:9:1585:14 | x.f2() |  | file://:0:0:0:0 | & |
-| main.rs:1585:9:1585:14 | x.f2() | &T | main.rs:1562:5:1562:13 | S |
-| main.rs:1586:9:1586:17 | ...::f3(...) |  | file://:0:0:0:0 | & |
-| main.rs:1586:9:1586:17 | ...::f3(...) | &T | main.rs:1562:5:1562:13 | S |
-| main.rs:1586:15:1586:16 | &x |  | file://:0:0:0:0 | & |
-| main.rs:1586:15:1586:16 | &x | &T | main.rs:1562:5:1562:13 | S |
-| main.rs:1586:16:1586:16 | x |  | main.rs:1562:5:1562:13 | S |
-| main.rs:1588:13:1588:13 | n |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1588:17:1588:24 | * ... |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1588:18:1588:24 | * ... |  | file://:0:0:0:0 | & |
-| main.rs:1588:18:1588:24 | * ... | &T | {EXTERNAL LOCATION} | bool |
-| main.rs:1588:19:1588:24 | &... |  | file://:0:0:0:0 | & |
-| main.rs:1588:19:1588:24 | &... | &T | file://:0:0:0:0 | & |
-| main.rs:1588:19:1588:24 | &... | &T.&T | {EXTERNAL LOCATION} | bool |
-| main.rs:1588:20:1588:24 | &true |  | file://:0:0:0:0 | & |
-| main.rs:1588:20:1588:24 | &true | &T | {EXTERNAL LOCATION} | bool |
-| main.rs:1588:21:1588:24 | true |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1592:17:1592:20 | flag |  | main.rs:1551:5:1554:5 | MyFlag |
-| main.rs:1592:24:1592:41 | ...::default(...) |  | main.rs:1551:5:1554:5 | MyFlag |
-| main.rs:1593:22:1593:30 | &mut flag |  | file://:0:0:0:0 | & |
-| main.rs:1593:22:1593:30 | &mut flag | &T | main.rs:1551:5:1554:5 | MyFlag |
-| main.rs:1593:27:1593:30 | flag |  | main.rs:1551:5:1554:5 | MyFlag |
-| main.rs:1594:18:1594:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:1594:18:1594:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:1594:18:1594:29 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1594:18:1594:29 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1594:26:1594:29 | flag |  | main.rs:1551:5:1554:5 | MyFlag |
-| main.rs:1609:43:1612:5 | { ... } |  | {EXTERNAL LOCATION} | Result |
-| main.rs:1609:43:1612:5 | { ... } | E | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1609:43:1612:5 | { ... } | T | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1610:13:1610:13 | x |  | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1610:17:1610:30 | ...::Ok(...) |  | {EXTERNAL LOCATION} | Result |
-| main.rs:1610:17:1610:30 | ...::Ok(...) | T | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1610:17:1610:31 | TryExpr |  | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1610:28:1610:29 | S1 |  | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1611:9:1611:22 | ...::Ok(...) |  | {EXTERNAL LOCATION} | Result |
-| main.rs:1611:9:1611:22 | ...::Ok(...) | E | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1611:9:1611:22 | ...::Ok(...) | T | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1611:20:1611:21 | S1 |  | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1616:46:1620:5 | { ... } |  | {EXTERNAL LOCATION} | Result |
-| main.rs:1616:46:1620:5 | { ... } | E | main.rs:1604:5:1605:14 | S2 |
-| main.rs:1616:46:1620:5 | { ... } | T | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1617:13:1617:13 | x |  | {EXTERNAL LOCATION} | Result |
-| main.rs:1617:13:1617:13 | x | T | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1617:17:1617:30 | ...::Ok(...) |  | {EXTERNAL LOCATION} | Result |
-| main.rs:1617:17:1617:30 | ...::Ok(...) | T | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1617:28:1617:29 | S1 |  | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1618:13:1618:13 | y |  | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1618:17:1618:17 | x |  | {EXTERNAL LOCATION} | Result |
-| main.rs:1618:17:1618:17 | x | T | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1618:17:1618:18 | TryExpr |  | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1619:9:1619:22 | ...::Ok(...) |  | {EXTERNAL LOCATION} | Result |
-| main.rs:1619:9:1619:22 | ...::Ok(...) | E | main.rs:1604:5:1605:14 | S2 |
-| main.rs:1619:9:1619:22 | ...::Ok(...) | T | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1619:20:1619:21 | S1 |  | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1624:40:1629:5 | { ... } |  | {EXTERNAL LOCATION} | Result |
-| main.rs:1624:40:1629:5 | { ... } | E | main.rs:1604:5:1605:14 | S2 |
-| main.rs:1624:40:1629:5 | { ... } | T | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1625:13:1625:13 | x |  | {EXTERNAL LOCATION} | Result |
-| main.rs:1625:13:1625:13 | x | T | {EXTERNAL LOCATION} | Result |
-| main.rs:1625:13:1625:13 | x | T.T | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1625:17:1625:42 | ...::Ok(...) |  | {EXTERNAL LOCATION} | Result |
-| main.rs:1625:17:1625:42 | ...::Ok(...) | T | {EXTERNAL LOCATION} | Result |
-| main.rs:1625:17:1625:42 | ...::Ok(...) | T.T | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1625:28:1625:41 | ...::Ok(...) |  | {EXTERNAL LOCATION} | Result |
-| main.rs:1625:28:1625:41 | ...::Ok(...) | T | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1625:39:1625:40 | S1 |  | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1627:17:1627:17 | x |  | {EXTERNAL LOCATION} | Result |
-| main.rs:1627:17:1627:17 | x | T | {EXTERNAL LOCATION} | Result |
-| main.rs:1627:17:1627:17 | x | T.T | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1627:17:1627:18 | TryExpr |  | {EXTERNAL LOCATION} | Result |
-| main.rs:1627:17:1627:18 | TryExpr | T | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1627:17:1627:29 | ... .map(...) |  | {EXTERNAL LOCATION} | Result |
-| main.rs:1627:24:1627:28 | \|...\| s |  | {EXTERNAL LOCATION} | dyn FnOnce |
-| main.rs:1627:24:1627:28 | \|...\| s | dyn(Args) | file://:0:0:0:0 | (T_1) |
-| main.rs:1628:9:1628:22 | ...::Ok(...) |  | {EXTERNAL LOCATION} | Result |
-| main.rs:1628:9:1628:22 | ...::Ok(...) | E | main.rs:1604:5:1605:14 | S2 |
-| main.rs:1628:9:1628:22 | ...::Ok(...) | T | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1628:20:1628:21 | S1 |  | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1633:30:1633:34 | input |  | {EXTERNAL LOCATION} | Result |
-| main.rs:1633:30:1633:34 | input | E | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1633:30:1633:34 | input | T | main.rs:1633:20:1633:27 | T |
-| main.rs:1633:69:1640:5 | { ... } |  | {EXTERNAL LOCATION} | Result |
-| main.rs:1633:69:1640:5 | { ... } | E | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1633:69:1640:5 | { ... } | T | main.rs:1633:20:1633:27 | T |
-| main.rs:1634:13:1634:17 | value |  | main.rs:1633:20:1633:27 | T |
-| main.rs:1634:21:1634:25 | input |  | {EXTERNAL LOCATION} | Result |
-| main.rs:1634:21:1634:25 | input | E | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1634:21:1634:25 | input | T | main.rs:1633:20:1633:27 | T |
-| main.rs:1634:21:1634:26 | TryExpr |  | main.rs:1633:20:1633:27 | T |
-| main.rs:1635:22:1635:38 | ...::Ok(...) |  | {EXTERNAL LOCATION} | Result |
-| main.rs:1635:22:1635:38 | ...::Ok(...) | E | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1635:22:1635:38 | ...::Ok(...) | T | main.rs:1633:20:1633:27 | T |
-| main.rs:1635:22:1638:10 | ... .and_then(...) |  | {EXTERNAL LOCATION} | Result |
-| main.rs:1635:22:1638:10 | ... .and_then(...) | E | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1635:33:1635:37 | value |  | main.rs:1633:20:1633:27 | T |
-| main.rs:1635:49:1638:9 | \|...\| ... |  | {EXTERNAL LOCATION} | dyn FnOnce |
-| main.rs:1635:49:1638:9 | \|...\| ... | dyn(Args) | file://:0:0:0:0 | (T_1) |
-| main.rs:1635:49:1638:9 | \|...\| ... | dyn(Output) | {EXTERNAL LOCATION} | Result |
-| main.rs:1635:49:1638:9 | \|...\| ... | dyn(Output).E | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1635:53:1638:9 | { ... } |  | {EXTERNAL LOCATION} | Result |
-| main.rs:1635:53:1638:9 | { ... } | E | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1636:22:1636:27 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:1636:22:1636:27 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:1636:22:1636:30 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1636:22:1636:30 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1637:13:1637:34 | ...::Ok::<...>(...) |  | {EXTERNAL LOCATION} | Result |
-| main.rs:1637:13:1637:34 | ...::Ok::<...>(...) | E | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1639:9:1639:23 | ...::Err(...) |  | {EXTERNAL LOCATION} | Result |
-| main.rs:1639:9:1639:23 | ...::Err(...) | E | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1639:9:1639:23 | ...::Err(...) | T | main.rs:1633:20:1633:27 | T |
-| main.rs:1639:21:1639:22 | S1 |  | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1644:16:1644:33 | ...::Ok(...) |  | {EXTERNAL LOCATION} | Result |
-| main.rs:1644:16:1644:33 | ...::Ok(...) | E | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1644:16:1644:33 | ...::Ok(...) | T | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1644:27:1644:32 | result |  | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1644:37:1644:52 | try_same_error(...) |  | {EXTERNAL LOCATION} | Result |
-| main.rs:1644:37:1644:52 | try_same_error(...) | E | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1644:37:1644:52 | try_same_error(...) | T | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1645:22:1645:27 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:1645:22:1645:27 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:1645:22:1645:35 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1645:22:1645:35 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1645:30:1645:35 | result |  | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1648:16:1648:33 | ...::Ok(...) |  | {EXTERNAL LOCATION} | Result |
-| main.rs:1648:16:1648:33 | ...::Ok(...) | E | main.rs:1604:5:1605:14 | S2 |
-| main.rs:1648:16:1648:33 | ...::Ok(...) | T | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1648:27:1648:32 | result |  | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1648:37:1648:55 | try_convert_error(...) |  | {EXTERNAL LOCATION} | Result |
-| main.rs:1648:37:1648:55 | try_convert_error(...) | E | main.rs:1604:5:1605:14 | S2 |
-| main.rs:1648:37:1648:55 | try_convert_error(...) | T | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1649:22:1649:27 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:1649:22:1649:27 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:1649:22:1649:35 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1649:22:1649:35 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1649:30:1649:35 | result |  | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1652:16:1652:33 | ...::Ok(...) |  | {EXTERNAL LOCATION} | Result |
-| main.rs:1652:16:1652:33 | ...::Ok(...) | E | main.rs:1604:5:1605:14 | S2 |
-| main.rs:1652:16:1652:33 | ...::Ok(...) | T | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1652:27:1652:32 | result |  | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1652:37:1652:49 | try_chained(...) |  | {EXTERNAL LOCATION} | Result |
-| main.rs:1652:37:1652:49 | try_chained(...) | E | main.rs:1604:5:1605:14 | S2 |
-| main.rs:1652:37:1652:49 | try_chained(...) | T | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1653:22:1653:27 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:1653:22:1653:27 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:1653:22:1653:35 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1653:22:1653:35 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1653:30:1653:35 | result |  | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1656:16:1656:33 | ...::Ok(...) |  | {EXTERNAL LOCATION} | Result |
-| main.rs:1656:16:1656:33 | ...::Ok(...) | E | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1656:16:1656:33 | ...::Ok(...) | T | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1656:27:1656:32 | result |  | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1656:37:1656:63 | try_complex(...) |  | {EXTERNAL LOCATION} | Result |
-| main.rs:1656:37:1656:63 | try_complex(...) | E | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1656:37:1656:63 | try_complex(...) | T | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1656:49:1656:62 | ...::Ok(...) |  | {EXTERNAL LOCATION} | Result |
-| main.rs:1656:49:1656:62 | ...::Ok(...) | E | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1656:49:1656:62 | ...::Ok(...) | T | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1656:60:1656:61 | S1 |  | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1657:22:1657:27 | "{:?}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:1657:22:1657:27 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:1657:22:1657:35 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1657:22:1657:35 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:1657:30:1657:35 | result |  | main.rs:1601:5:1602:14 | S1 |
-| main.rs:1664:13:1664:13 | x |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:1664:22:1664:22 | 1 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:1665:13:1665:13 | y |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:1665:17:1665:17 | 2 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:1475:26:1475:27 | x5 | &T | main.rs:1410:5:1411:19 | S |
+| main.rs:1475:26:1475:27 | x5 | &T.T | main.rs:1413:5:1414:14 | S2 |
+| main.rs:1475:26:1475:29 | x5.0 |  | main.rs:1413:5:1414:14 | S2 |
+| main.rs:1477:13:1477:14 | x6 |  | file://:0:0:0:0 | & |
+| main.rs:1477:13:1477:14 | x6 | &T | main.rs:1410:5:1411:19 | S |
+| main.rs:1477:13:1477:14 | x6 | &T.T | main.rs:1413:5:1414:14 | S2 |
+| main.rs:1477:18:1477:23 | &... |  | file://:0:0:0:0 | & |
+| main.rs:1477:18:1477:23 | &... | &T | main.rs:1410:5:1411:19 | S |
+| main.rs:1477:18:1477:23 | &... | &T.T | main.rs:1413:5:1414:14 | S2 |
+| main.rs:1477:19:1477:23 | S(...) |  | main.rs:1410:5:1411:19 | S |
+| main.rs:1477:19:1477:23 | S(...) | T | main.rs:1413:5:1414:14 | S2 |
+| main.rs:1477:21:1477:22 | S2 |  | main.rs:1413:5:1414:14 | S2 |
+| main.rs:1480:18:1480:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:1480:18:1480:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:1480:18:1480:35 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1480:18:1480:35 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1480:26:1480:30 | (...) |  | main.rs:1410:5:1411:19 | S |
+| main.rs:1480:26:1480:30 | (...) | T | main.rs:1413:5:1414:14 | S2 |
+| main.rs:1480:26:1480:35 | ... .m1() |  | main.rs:1413:5:1414:14 | S2 |
+| main.rs:1480:27:1480:29 | * ... |  | main.rs:1410:5:1411:19 | S |
+| main.rs:1480:27:1480:29 | * ... | T | main.rs:1413:5:1414:14 | S2 |
+| main.rs:1480:28:1480:29 | x6 |  | file://:0:0:0:0 | & |
+| main.rs:1480:28:1480:29 | x6 | &T | main.rs:1410:5:1411:19 | S |
+| main.rs:1480:28:1480:29 | x6 | &T.T | main.rs:1413:5:1414:14 | S2 |
+| main.rs:1482:13:1482:14 | x7 |  | main.rs:1410:5:1411:19 | S |
+| main.rs:1482:13:1482:14 | x7 | T | file://:0:0:0:0 | & |
+| main.rs:1482:13:1482:14 | x7 | T.&T | main.rs:1413:5:1414:14 | S2 |
+| main.rs:1482:18:1482:23 | S(...) |  | main.rs:1410:5:1411:19 | S |
+| main.rs:1482:18:1482:23 | S(...) | T | file://:0:0:0:0 | & |
+| main.rs:1482:18:1482:23 | S(...) | T.&T | main.rs:1413:5:1414:14 | S2 |
+| main.rs:1482:20:1482:22 | &S2 |  | file://:0:0:0:0 | & |
+| main.rs:1482:20:1482:22 | &S2 | &T | main.rs:1413:5:1414:14 | S2 |
+| main.rs:1482:21:1482:22 | S2 |  | main.rs:1413:5:1414:14 | S2 |
+| main.rs:1485:13:1485:13 | t |  | file://:0:0:0:0 | & |
+| main.rs:1485:13:1485:13 | t | &T | main.rs:1413:5:1414:14 | S2 |
+| main.rs:1485:17:1485:18 | x7 |  | main.rs:1410:5:1411:19 | S |
+| main.rs:1485:17:1485:18 | x7 | T | file://:0:0:0:0 | & |
+| main.rs:1485:17:1485:18 | x7 | T.&T | main.rs:1413:5:1414:14 | S2 |
+| main.rs:1485:17:1485:23 | x7.m1() |  | file://:0:0:0:0 | & |
+| main.rs:1485:17:1485:23 | x7.m1() | &T | main.rs:1413:5:1414:14 | S2 |
+| main.rs:1486:18:1486:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:1486:18:1486:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:1486:18:1486:27 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1486:18:1486:27 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1486:26:1486:27 | x7 |  | main.rs:1410:5:1411:19 | S |
+| main.rs:1486:26:1486:27 | x7 | T | file://:0:0:0:0 | & |
+| main.rs:1486:26:1486:27 | x7 | T.&T | main.rs:1413:5:1414:14 | S2 |
+| main.rs:1488:13:1488:14 | x9 |  | {EXTERNAL LOCATION} | String |
+| main.rs:1488:26:1488:32 | "Hello" |  | file://:0:0:0:0 | & |
+| main.rs:1488:26:1488:32 | "Hello" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:1488:26:1488:44 | "Hello".to_string() |  | {EXTERNAL LOCATION} | String |
+| main.rs:1492:13:1492:13 | u |  | {EXTERNAL LOCATION} | Result |
+| main.rs:1492:13:1492:13 | u | T | {EXTERNAL LOCATION} | u32 |
+| main.rs:1492:17:1492:18 | x9 |  | {EXTERNAL LOCATION} | String |
+| main.rs:1492:17:1492:33 | x9.parse() |  | {EXTERNAL LOCATION} | Result |
+| main.rs:1492:17:1492:33 | x9.parse() | T | {EXTERNAL LOCATION} | u32 |
+| main.rs:1494:13:1494:20 | my_thing |  | file://:0:0:0:0 | & |
+| main.rs:1494:13:1494:20 | my_thing | &T | main.rs:1416:5:1419:5 | MyInt |
+| main.rs:1494:24:1494:39 | &... |  | file://:0:0:0:0 | & |
+| main.rs:1494:24:1494:39 | &... | &T | main.rs:1416:5:1419:5 | MyInt |
+| main.rs:1494:25:1494:39 | MyInt {...} |  | main.rs:1416:5:1419:5 | MyInt |
+| main.rs:1494:36:1494:37 | 37 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:1494:36:1494:37 | 37 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1496:13:1496:13 | a |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1496:17:1496:24 | my_thing |  | file://:0:0:0:0 | & |
+| main.rs:1496:17:1496:24 | my_thing | &T | main.rs:1416:5:1419:5 | MyInt |
+| main.rs:1496:17:1496:43 | my_thing.method_on_borrow() |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1497:18:1497:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:1497:18:1497:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:1497:18:1497:26 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1497:18:1497:26 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1497:26:1497:26 | a |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1500:13:1500:20 | my_thing |  | file://:0:0:0:0 | & |
+| main.rs:1500:13:1500:20 | my_thing | &T | main.rs:1416:5:1419:5 | MyInt |
+| main.rs:1500:24:1500:39 | &... |  | file://:0:0:0:0 | & |
+| main.rs:1500:24:1500:39 | &... | &T | main.rs:1416:5:1419:5 | MyInt |
+| main.rs:1500:25:1500:39 | MyInt {...} |  | main.rs:1416:5:1419:5 | MyInt |
+| main.rs:1500:36:1500:37 | 38 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:1500:36:1500:37 | 38 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1501:13:1501:13 | a |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1501:17:1501:24 | my_thing |  | file://:0:0:0:0 | & |
+| main.rs:1501:17:1501:24 | my_thing | &T | main.rs:1416:5:1419:5 | MyInt |
+| main.rs:1501:17:1501:47 | my_thing.method_not_on_borrow() |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1502:18:1502:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:1502:18:1502:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:1502:18:1502:26 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1502:18:1502:26 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1502:26:1502:26 | a |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1509:16:1509:20 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1509:16:1509:20 | SelfParam | &T | main.rs:1507:5:1515:5 | Self [trait MyTrait] |
+| main.rs:1512:16:1512:20 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1512:16:1512:20 | SelfParam | &T | main.rs:1507:5:1515:5 | Self [trait MyTrait] |
+| main.rs:1512:32:1514:9 | { ... } |  | file://:0:0:0:0 | & |
+| main.rs:1512:32:1514:9 | { ... } | &T | main.rs:1507:5:1515:5 | Self [trait MyTrait] |
+| main.rs:1513:13:1513:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1513:13:1513:16 | self | &T | main.rs:1507:5:1515:5 | Self [trait MyTrait] |
+| main.rs:1513:13:1513:22 | self.foo() |  | file://:0:0:0:0 | & |
+| main.rs:1513:13:1513:22 | self.foo() | &T | main.rs:1507:5:1515:5 | Self [trait MyTrait] |
+| main.rs:1521:16:1521:20 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1521:16:1521:20 | SelfParam | &T | main.rs:1517:5:1517:20 | MyStruct |
+| main.rs:1521:36:1523:9 | { ... } |  | file://:0:0:0:0 | & |
+| main.rs:1521:36:1523:9 | { ... } | &T | main.rs:1517:5:1517:20 | MyStruct |
+| main.rs:1522:13:1522:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1522:13:1522:16 | self | &T | main.rs:1517:5:1517:20 | MyStruct |
+| main.rs:1527:13:1527:13 | x |  | main.rs:1517:5:1517:20 | MyStruct |
+| main.rs:1527:17:1527:24 | MyStruct |  | main.rs:1517:5:1517:20 | MyStruct |
+| main.rs:1528:9:1528:9 | x |  | main.rs:1517:5:1517:20 | MyStruct |
+| main.rs:1528:9:1528:15 | x.bar() |  | file://:0:0:0:0 | & |
+| main.rs:1528:9:1528:15 | x.bar() | &T | main.rs:1517:5:1517:20 | MyStruct |
+| main.rs:1538:16:1538:20 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1538:16:1538:20 | SelfParam | &T | main.rs:1535:5:1535:26 | MyStruct |
+| main.rs:1538:16:1538:20 | SelfParam | &T.T | main.rs:1537:10:1537:10 | T |
+| main.rs:1538:32:1540:9 | { ... } |  | file://:0:0:0:0 | & |
+| main.rs:1538:32:1540:9 | { ... } | &T | main.rs:1535:5:1535:26 | MyStruct |
+| main.rs:1538:32:1540:9 | { ... } | &T.T | main.rs:1537:10:1537:10 | T |
+| main.rs:1539:13:1539:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1539:13:1539:16 | self | &T | main.rs:1535:5:1535:26 | MyStruct |
+| main.rs:1539:13:1539:16 | self | &T.T | main.rs:1537:10:1537:10 | T |
+| main.rs:1544:13:1544:13 | x |  | main.rs:1535:5:1535:26 | MyStruct |
+| main.rs:1544:13:1544:13 | x | T | main.rs:1533:5:1533:13 | S |
+| main.rs:1544:17:1544:27 | MyStruct(...) |  | main.rs:1535:5:1535:26 | MyStruct |
+| main.rs:1544:17:1544:27 | MyStruct(...) | T | main.rs:1533:5:1533:13 | S |
+| main.rs:1544:26:1544:26 | S |  | main.rs:1533:5:1533:13 | S |
+| main.rs:1545:9:1545:9 | x |  | main.rs:1535:5:1535:26 | MyStruct |
+| main.rs:1545:9:1545:9 | x | T | main.rs:1533:5:1533:13 | S |
+| main.rs:1545:9:1545:15 | x.foo() |  | file://:0:0:0:0 | & |
+| main.rs:1545:9:1545:15 | x.foo() | &T | main.rs:1535:5:1535:26 | MyStruct |
+| main.rs:1545:9:1545:15 | x.foo() | &T.T | main.rs:1533:5:1533:13 | S |
+| main.rs:1556:17:1556:25 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1556:17:1556:25 | SelfParam | &T | main.rs:1550:5:1553:5 | MyFlag |
+| main.rs:1557:13:1557:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1557:13:1557:16 | self | &T | main.rs:1550:5:1553:5 | MyFlag |
+| main.rs:1557:13:1557:21 | self.bool |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1557:13:1557:34 | ... = ... |  | file://:0:0:0:0 | () |
+| main.rs:1557:25:1557:34 | ! ... |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1557:26:1557:29 | self |  | file://:0:0:0:0 | & |
+| main.rs:1557:26:1557:29 | self | &T | main.rs:1550:5:1553:5 | MyFlag |
+| main.rs:1557:26:1557:34 | self.bool |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1564:15:1564:19 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1564:15:1564:19 | SelfParam | &T | main.rs:1561:5:1561:13 | S |
+| main.rs:1564:31:1566:9 | { ... } |  | file://:0:0:0:0 | & |
+| main.rs:1564:31:1566:9 | { ... } | &T | main.rs:1561:5:1561:13 | S |
+| main.rs:1565:13:1565:19 | &... |  | file://:0:0:0:0 | & |
+| main.rs:1565:13:1565:19 | &... | &T | file://:0:0:0:0 | & |
+| main.rs:1565:13:1565:19 | &... | &T | main.rs:1561:5:1561:13 | S |
+| main.rs:1565:13:1565:19 | &... | &T.&T | file://:0:0:0:0 | & |
+| main.rs:1565:13:1565:19 | &... | &T.&T.&T | file://:0:0:0:0 | & |
+| main.rs:1565:13:1565:19 | &... | &T.&T.&T.&T | main.rs:1561:5:1561:13 | S |
+| main.rs:1565:14:1565:19 | &... |  | file://:0:0:0:0 | & |
+| main.rs:1565:14:1565:19 | &... | &T | file://:0:0:0:0 | & |
+| main.rs:1565:14:1565:19 | &... | &T.&T | file://:0:0:0:0 | & |
+| main.rs:1565:14:1565:19 | &... | &T.&T.&T | main.rs:1561:5:1561:13 | S |
+| main.rs:1565:15:1565:19 | &self |  | file://:0:0:0:0 | & |
+| main.rs:1565:15:1565:19 | &self | &T | file://:0:0:0:0 | & |
+| main.rs:1565:15:1565:19 | &self | &T.&T | main.rs:1561:5:1561:13 | S |
+| main.rs:1565:16:1565:19 | self |  | file://:0:0:0:0 | & |
+| main.rs:1565:16:1565:19 | self | &T | main.rs:1561:5:1561:13 | S |
+| main.rs:1568:15:1568:25 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1568:15:1568:25 | SelfParam | &T | main.rs:1561:5:1561:13 | S |
+| main.rs:1568:37:1570:9 | { ... } |  | file://:0:0:0:0 | & |
+| main.rs:1568:37:1570:9 | { ... } | &T | main.rs:1561:5:1561:13 | S |
+| main.rs:1569:13:1569:19 | &... |  | file://:0:0:0:0 | & |
+| main.rs:1569:13:1569:19 | &... | &T | file://:0:0:0:0 | & |
+| main.rs:1569:13:1569:19 | &... | &T | main.rs:1561:5:1561:13 | S |
+| main.rs:1569:13:1569:19 | &... | &T.&T | file://:0:0:0:0 | & |
+| main.rs:1569:13:1569:19 | &... | &T.&T.&T | file://:0:0:0:0 | & |
+| main.rs:1569:13:1569:19 | &... | &T.&T.&T.&T | main.rs:1561:5:1561:13 | S |
+| main.rs:1569:14:1569:19 | &... |  | file://:0:0:0:0 | & |
+| main.rs:1569:14:1569:19 | &... | &T | file://:0:0:0:0 | & |
+| main.rs:1569:14:1569:19 | &... | &T.&T | file://:0:0:0:0 | & |
+| main.rs:1569:14:1569:19 | &... | &T.&T.&T | main.rs:1561:5:1561:13 | S |
+| main.rs:1569:15:1569:19 | &self |  | file://:0:0:0:0 | & |
+| main.rs:1569:15:1569:19 | &self | &T | file://:0:0:0:0 | & |
+| main.rs:1569:15:1569:19 | &self | &T.&T | main.rs:1561:5:1561:13 | S |
+| main.rs:1569:16:1569:19 | self |  | file://:0:0:0:0 | & |
+| main.rs:1569:16:1569:19 | self | &T | main.rs:1561:5:1561:13 | S |
+| main.rs:1572:15:1572:15 | x |  | file://:0:0:0:0 | & |
+| main.rs:1572:15:1572:15 | x | &T | main.rs:1561:5:1561:13 | S |
+| main.rs:1572:34:1574:9 | { ... } |  | file://:0:0:0:0 | & |
+| main.rs:1572:34:1574:9 | { ... } | &T | main.rs:1561:5:1561:13 | S |
+| main.rs:1573:13:1573:13 | x |  | file://:0:0:0:0 | & |
+| main.rs:1573:13:1573:13 | x | &T | main.rs:1561:5:1561:13 | S |
+| main.rs:1576:15:1576:15 | x |  | file://:0:0:0:0 | & |
+| main.rs:1576:15:1576:15 | x | &T | main.rs:1561:5:1561:13 | S |
+| main.rs:1576:34:1578:9 | { ... } |  | file://:0:0:0:0 | & |
+| main.rs:1576:34:1578:9 | { ... } | &T | main.rs:1561:5:1561:13 | S |
+| main.rs:1577:13:1577:16 | &... |  | file://:0:0:0:0 | & |
+| main.rs:1577:13:1577:16 | &... | &T | file://:0:0:0:0 | & |
+| main.rs:1577:13:1577:16 | &... | &T | main.rs:1561:5:1561:13 | S |
+| main.rs:1577:13:1577:16 | &... | &T.&T | file://:0:0:0:0 | & |
+| main.rs:1577:13:1577:16 | &... | &T.&T.&T | file://:0:0:0:0 | & |
+| main.rs:1577:13:1577:16 | &... | &T.&T.&T.&T | main.rs:1561:5:1561:13 | S |
+| main.rs:1577:14:1577:16 | &... |  | file://:0:0:0:0 | & |
+| main.rs:1577:14:1577:16 | &... | &T | file://:0:0:0:0 | & |
+| main.rs:1577:14:1577:16 | &... | &T.&T | file://:0:0:0:0 | & |
+| main.rs:1577:14:1577:16 | &... | &T.&T.&T | main.rs:1561:5:1561:13 | S |
+| main.rs:1577:15:1577:16 | &x |  | file://:0:0:0:0 | & |
+| main.rs:1577:15:1577:16 | &x | &T | file://:0:0:0:0 | & |
+| main.rs:1577:15:1577:16 | &x | &T.&T | main.rs:1561:5:1561:13 | S |
+| main.rs:1577:16:1577:16 | x |  | file://:0:0:0:0 | & |
+| main.rs:1577:16:1577:16 | x | &T | main.rs:1561:5:1561:13 | S |
+| main.rs:1582:13:1582:13 | x |  | main.rs:1561:5:1561:13 | S |
+| main.rs:1582:17:1582:20 | S {...} |  | main.rs:1561:5:1561:13 | S |
+| main.rs:1583:9:1583:9 | x |  | main.rs:1561:5:1561:13 | S |
+| main.rs:1583:9:1583:14 | x.f1() |  | file://:0:0:0:0 | & |
+| main.rs:1583:9:1583:14 | x.f1() | &T | main.rs:1561:5:1561:13 | S |
+| main.rs:1584:9:1584:9 | x |  | main.rs:1561:5:1561:13 | S |
+| main.rs:1584:9:1584:14 | x.f2() |  | file://:0:0:0:0 | & |
+| main.rs:1584:9:1584:14 | x.f2() | &T | main.rs:1561:5:1561:13 | S |
+| main.rs:1585:9:1585:17 | ...::f3(...) |  | file://:0:0:0:0 | & |
+| main.rs:1585:9:1585:17 | ...::f3(...) | &T | main.rs:1561:5:1561:13 | S |
+| main.rs:1585:15:1585:16 | &x |  | file://:0:0:0:0 | & |
+| main.rs:1585:15:1585:16 | &x | &T | main.rs:1561:5:1561:13 | S |
+| main.rs:1585:16:1585:16 | x |  | main.rs:1561:5:1561:13 | S |
+| main.rs:1587:13:1587:13 | n |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1587:17:1587:24 | * ... |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1587:18:1587:24 | * ... |  | file://:0:0:0:0 | & |
+| main.rs:1587:18:1587:24 | * ... | &T | {EXTERNAL LOCATION} | bool |
+| main.rs:1587:19:1587:24 | &... |  | file://:0:0:0:0 | & |
+| main.rs:1587:19:1587:24 | &... | &T | file://:0:0:0:0 | & |
+| main.rs:1587:19:1587:24 | &... | &T.&T | {EXTERNAL LOCATION} | bool |
+| main.rs:1587:20:1587:24 | &true |  | file://:0:0:0:0 | & |
+| main.rs:1587:20:1587:24 | &true | &T | {EXTERNAL LOCATION} | bool |
+| main.rs:1587:21:1587:24 | true |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1591:17:1591:20 | flag |  | main.rs:1550:5:1553:5 | MyFlag |
+| main.rs:1591:24:1591:41 | ...::default(...) |  | main.rs:1550:5:1553:5 | MyFlag |
+| main.rs:1592:22:1592:30 | &mut flag |  | file://:0:0:0:0 | & |
+| main.rs:1592:22:1592:30 | &mut flag | &T | main.rs:1550:5:1553:5 | MyFlag |
+| main.rs:1592:27:1592:30 | flag |  | main.rs:1550:5:1553:5 | MyFlag |
+| main.rs:1593:18:1593:23 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:1593:18:1593:23 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:1593:18:1593:29 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1593:18:1593:29 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1593:26:1593:29 | flag |  | main.rs:1550:5:1553:5 | MyFlag |
+| main.rs:1608:43:1611:5 | { ... } |  | {EXTERNAL LOCATION} | Result |
+| main.rs:1608:43:1611:5 | { ... } | E | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1608:43:1611:5 | { ... } | T | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1609:13:1609:13 | x |  | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1609:17:1609:30 | ...::Ok(...) |  | {EXTERNAL LOCATION} | Result |
+| main.rs:1609:17:1609:30 | ...::Ok(...) | T | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1609:17:1609:31 | TryExpr |  | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1609:28:1609:29 | S1 |  | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1610:9:1610:22 | ...::Ok(...) |  | {EXTERNAL LOCATION} | Result |
+| main.rs:1610:9:1610:22 | ...::Ok(...) | E | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1610:9:1610:22 | ...::Ok(...) | T | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1610:20:1610:21 | S1 |  | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1615:46:1619:5 | { ... } |  | {EXTERNAL LOCATION} | Result |
+| main.rs:1615:46:1619:5 | { ... } | E | main.rs:1603:5:1604:14 | S2 |
+| main.rs:1615:46:1619:5 | { ... } | T | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1616:13:1616:13 | x |  | {EXTERNAL LOCATION} | Result |
+| main.rs:1616:13:1616:13 | x | T | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1616:17:1616:30 | ...::Ok(...) |  | {EXTERNAL LOCATION} | Result |
+| main.rs:1616:17:1616:30 | ...::Ok(...) | T | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1616:28:1616:29 | S1 |  | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1617:13:1617:13 | y |  | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1617:17:1617:17 | x |  | {EXTERNAL LOCATION} | Result |
+| main.rs:1617:17:1617:17 | x | T | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1617:17:1617:18 | TryExpr |  | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1618:9:1618:22 | ...::Ok(...) |  | {EXTERNAL LOCATION} | Result |
+| main.rs:1618:9:1618:22 | ...::Ok(...) | E | main.rs:1603:5:1604:14 | S2 |
+| main.rs:1618:9:1618:22 | ...::Ok(...) | T | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1618:20:1618:21 | S1 |  | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1623:40:1628:5 | { ... } |  | {EXTERNAL LOCATION} | Result |
+| main.rs:1623:40:1628:5 | { ... } | E | main.rs:1603:5:1604:14 | S2 |
+| main.rs:1623:40:1628:5 | { ... } | T | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1624:13:1624:13 | x |  | {EXTERNAL LOCATION} | Result |
+| main.rs:1624:13:1624:13 | x | T | {EXTERNAL LOCATION} | Result |
+| main.rs:1624:13:1624:13 | x | T.T | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1624:17:1624:42 | ...::Ok(...) |  | {EXTERNAL LOCATION} | Result |
+| main.rs:1624:17:1624:42 | ...::Ok(...) | T | {EXTERNAL LOCATION} | Result |
+| main.rs:1624:17:1624:42 | ...::Ok(...) | T.T | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1624:28:1624:41 | ...::Ok(...) |  | {EXTERNAL LOCATION} | Result |
+| main.rs:1624:28:1624:41 | ...::Ok(...) | T | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1624:39:1624:40 | S1 |  | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1626:17:1626:17 | x |  | {EXTERNAL LOCATION} | Result |
+| main.rs:1626:17:1626:17 | x | T | {EXTERNAL LOCATION} | Result |
+| main.rs:1626:17:1626:17 | x | T.T | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1626:17:1626:18 | TryExpr |  | {EXTERNAL LOCATION} | Result |
+| main.rs:1626:17:1626:18 | TryExpr | T | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1626:17:1626:29 | ... .map(...) |  | {EXTERNAL LOCATION} | Result |
+| main.rs:1626:24:1626:28 | \|...\| s |  | {EXTERNAL LOCATION} | dyn FnOnce |
+| main.rs:1626:24:1626:28 | \|...\| s | dyn(Args) | file://:0:0:0:0 | (T_1) |
+| main.rs:1627:9:1627:22 | ...::Ok(...) |  | {EXTERNAL LOCATION} | Result |
+| main.rs:1627:9:1627:22 | ...::Ok(...) | E | main.rs:1603:5:1604:14 | S2 |
+| main.rs:1627:9:1627:22 | ...::Ok(...) | T | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1627:20:1627:21 | S1 |  | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1632:30:1632:34 | input |  | {EXTERNAL LOCATION} | Result |
+| main.rs:1632:30:1632:34 | input | E | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1632:30:1632:34 | input | T | main.rs:1632:20:1632:27 | T |
+| main.rs:1632:69:1639:5 | { ... } |  | {EXTERNAL LOCATION} | Result |
+| main.rs:1632:69:1639:5 | { ... } | E | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1632:69:1639:5 | { ... } | T | main.rs:1632:20:1632:27 | T |
+| main.rs:1633:13:1633:17 | value |  | main.rs:1632:20:1632:27 | T |
+| main.rs:1633:21:1633:25 | input |  | {EXTERNAL LOCATION} | Result |
+| main.rs:1633:21:1633:25 | input | E | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1633:21:1633:25 | input | T | main.rs:1632:20:1632:27 | T |
+| main.rs:1633:21:1633:26 | TryExpr |  | main.rs:1632:20:1632:27 | T |
+| main.rs:1634:22:1634:38 | ...::Ok(...) |  | {EXTERNAL LOCATION} | Result |
+| main.rs:1634:22:1634:38 | ...::Ok(...) | E | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1634:22:1634:38 | ...::Ok(...) | T | main.rs:1632:20:1632:27 | T |
+| main.rs:1634:22:1637:10 | ... .and_then(...) |  | {EXTERNAL LOCATION} | Result |
+| main.rs:1634:22:1637:10 | ... .and_then(...) | E | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1634:33:1634:37 | value |  | main.rs:1632:20:1632:27 | T |
+| main.rs:1634:49:1637:9 | \|...\| ... |  | {EXTERNAL LOCATION} | dyn FnOnce |
+| main.rs:1634:49:1637:9 | \|...\| ... | dyn(Args) | file://:0:0:0:0 | (T_1) |
+| main.rs:1634:49:1637:9 | \|...\| ... | dyn(Output) | {EXTERNAL LOCATION} | Result |
+| main.rs:1634:49:1637:9 | \|...\| ... | dyn(Output).E | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1634:53:1637:9 | { ... } |  | {EXTERNAL LOCATION} | Result |
+| main.rs:1634:53:1637:9 | { ... } | E | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1635:22:1635:27 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:1635:22:1635:27 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:1635:22:1635:30 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1635:22:1635:30 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1636:13:1636:34 | ...::Ok::<...>(...) |  | {EXTERNAL LOCATION} | Result |
+| main.rs:1636:13:1636:34 | ...::Ok::<...>(...) | E | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1638:9:1638:23 | ...::Err(...) |  | {EXTERNAL LOCATION} | Result |
+| main.rs:1638:9:1638:23 | ...::Err(...) | E | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1638:9:1638:23 | ...::Err(...) | T | main.rs:1632:20:1632:27 | T |
+| main.rs:1638:21:1638:22 | S1 |  | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1643:16:1643:33 | ...::Ok(...) |  | {EXTERNAL LOCATION} | Result |
+| main.rs:1643:16:1643:33 | ...::Ok(...) | E | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1643:16:1643:33 | ...::Ok(...) | T | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1643:27:1643:32 | result |  | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1643:37:1643:52 | try_same_error(...) |  | {EXTERNAL LOCATION} | Result |
+| main.rs:1643:37:1643:52 | try_same_error(...) | E | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1643:37:1643:52 | try_same_error(...) | T | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1644:22:1644:27 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:1644:22:1644:27 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:1644:22:1644:35 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1644:22:1644:35 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1644:30:1644:35 | result |  | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1647:16:1647:33 | ...::Ok(...) |  | {EXTERNAL LOCATION} | Result |
+| main.rs:1647:16:1647:33 | ...::Ok(...) | E | main.rs:1603:5:1604:14 | S2 |
+| main.rs:1647:16:1647:33 | ...::Ok(...) | T | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1647:27:1647:32 | result |  | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1647:37:1647:55 | try_convert_error(...) |  | {EXTERNAL LOCATION} | Result |
+| main.rs:1647:37:1647:55 | try_convert_error(...) | E | main.rs:1603:5:1604:14 | S2 |
+| main.rs:1647:37:1647:55 | try_convert_error(...) | T | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1648:22:1648:27 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:1648:22:1648:27 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:1648:22:1648:35 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1648:22:1648:35 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1648:30:1648:35 | result |  | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1651:16:1651:33 | ...::Ok(...) |  | {EXTERNAL LOCATION} | Result |
+| main.rs:1651:16:1651:33 | ...::Ok(...) | E | main.rs:1603:5:1604:14 | S2 |
+| main.rs:1651:16:1651:33 | ...::Ok(...) | T | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1651:27:1651:32 | result |  | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1651:37:1651:49 | try_chained(...) |  | {EXTERNAL LOCATION} | Result |
+| main.rs:1651:37:1651:49 | try_chained(...) | E | main.rs:1603:5:1604:14 | S2 |
+| main.rs:1651:37:1651:49 | try_chained(...) | T | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1652:22:1652:27 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:1652:22:1652:27 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:1652:22:1652:35 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1652:22:1652:35 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1652:30:1652:35 | result |  | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1655:16:1655:33 | ...::Ok(...) |  | {EXTERNAL LOCATION} | Result |
+| main.rs:1655:16:1655:33 | ...::Ok(...) | E | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1655:16:1655:33 | ...::Ok(...) | T | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1655:27:1655:32 | result |  | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1655:37:1655:63 | try_complex(...) |  | {EXTERNAL LOCATION} | Result |
+| main.rs:1655:37:1655:63 | try_complex(...) | E | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1655:37:1655:63 | try_complex(...) | T | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1655:49:1655:62 | ...::Ok(...) |  | {EXTERNAL LOCATION} | Result |
+| main.rs:1655:49:1655:62 | ...::Ok(...) | E | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1655:49:1655:62 | ...::Ok(...) | T | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1655:60:1655:61 | S1 |  | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1656:22:1656:27 | "{:?}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:1656:22:1656:27 | "{:?}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:1656:22:1656:35 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1656:22:1656:35 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:1656:30:1656:35 | result |  | main.rs:1600:5:1601:14 | S1 |
+| main.rs:1663:13:1663:13 | x |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:1663:22:1663:22 | 1 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:1664:13:1664:13 | y |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:1664:17:1664:17 | 2 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:1665:13:1665:13 | z |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:1665:17:1665:17 | x |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:1665:17:1665:21 | ... + ... |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:1665:21:1665:21 | y |  | {EXTERNAL LOCATION} | i32 |
 | main.rs:1666:13:1666:13 | z |  | {EXTERNAL LOCATION} | i32 |
 | main.rs:1666:17:1666:17 | x |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:1666:17:1666:21 | ... + ... |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:1666:21:1666:21 | y |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:1667:13:1667:13 | z |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:1667:17:1667:17 | x |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:1667:17:1667:23 | x.abs() |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:1668:13:1668:13 | c |  | {EXTERNAL LOCATION} | char |
-| main.rs:1668:17:1668:19 | 'c' |  | {EXTERNAL LOCATION} | char |
-| main.rs:1669:13:1669:17 | hello |  | file://:0:0:0:0 | & |
-| main.rs:1669:13:1669:17 | hello | &T | {EXTERNAL LOCATION} | str |
-| main.rs:1669:21:1669:27 | "Hello" |  | file://:0:0:0:0 | & |
-| main.rs:1669:21:1669:27 | "Hello" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:1670:13:1670:13 | f |  | {EXTERNAL LOCATION} | f64 |
-| main.rs:1670:17:1670:24 | 123.0f64 |  | {EXTERNAL LOCATION} | f64 |
-| main.rs:1671:13:1671:13 | t |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1671:17:1671:20 | true |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1672:13:1672:13 | f |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1672:17:1672:21 | false |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1679:13:1679:13 | x |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1666:17:1666:23 | x.abs() |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:1667:13:1667:13 | c |  | {EXTERNAL LOCATION} | char |
+| main.rs:1667:17:1667:19 | 'c' |  | {EXTERNAL LOCATION} | char |
+| main.rs:1668:13:1668:17 | hello |  | file://:0:0:0:0 | & |
+| main.rs:1668:13:1668:17 | hello | &T | {EXTERNAL LOCATION} | str |
+| main.rs:1668:21:1668:27 | "Hello" |  | file://:0:0:0:0 | & |
+| main.rs:1668:21:1668:27 | "Hello" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:1669:13:1669:13 | f |  | {EXTERNAL LOCATION} | f64 |
+| main.rs:1669:17:1669:24 | 123.0f64 |  | {EXTERNAL LOCATION} | f64 |
+| main.rs:1670:13:1670:13 | t |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1670:17:1670:20 | true |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1671:13:1671:13 | f |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1671:17:1671:21 | false |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1678:13:1678:13 | x |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1678:17:1678:20 | true |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1678:17:1678:29 | ... && ... |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1678:25:1678:29 | false |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1679:13:1679:13 | y |  | {EXTERNAL LOCATION} | bool |
 | main.rs:1679:17:1679:20 | true |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1679:17:1679:29 | ... && ... |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1679:17:1679:29 | ... \|\| ... |  | {EXTERNAL LOCATION} | bool |
 | main.rs:1679:25:1679:29 | false |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1680:13:1680:13 | y |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1680:17:1680:20 | true |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1680:17:1680:29 | ... \|\| ... |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1680:25:1680:29 | false |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1682:17:1682:17 | a |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:1683:13:1683:16 | cond |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1683:20:1683:21 | 34 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:1683:20:1683:27 | ... == ... |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1683:26:1683:27 | 33 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:1684:12:1684:15 | cond |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1685:17:1685:17 | z |  | file://:0:0:0:0 | () |
-| main.rs:1685:21:1685:27 | (...) |  | file://:0:0:0:0 | () |
-| main.rs:1685:22:1685:22 | a |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:1685:22:1685:26 | ... = ... |  | file://:0:0:0:0 | () |
-| main.rs:1685:26:1685:26 | 1 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:1687:13:1687:13 | a |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:1687:13:1687:17 | ... = ... |  | file://:0:0:0:0 | () |
-| main.rs:1687:17:1687:17 | 2 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:1689:9:1689:9 | a |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:1703:30:1705:9 | { ... } |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1704:13:1704:31 | Vec2 {...} |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1704:23:1704:23 | 0 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:1704:23:1704:23 | 0 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1704:29:1704:29 | 0 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:1704:29:1704:29 | 0 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1711:16:1711:19 | SelfParam |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1711:22:1711:24 | rhs |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1711:41:1716:9 | { ... } |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1712:13:1715:13 | Vec2 {...} |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1713:20:1713:23 | self |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1713:20:1713:25 | self.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1681:17:1681:17 | a |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:1682:13:1682:16 | cond |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1682:20:1682:21 | 34 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:1682:20:1682:27 | ... == ... |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1682:26:1682:27 | 33 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:1683:12:1683:15 | cond |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1684:17:1684:17 | z |  | file://:0:0:0:0 | () |
+| main.rs:1684:21:1684:27 | (...) |  | file://:0:0:0:0 | () |
+| main.rs:1684:22:1684:22 | a |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:1684:22:1684:26 | ... = ... |  | file://:0:0:0:0 | () |
+| main.rs:1684:26:1684:26 | 1 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:1686:13:1686:13 | a |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:1686:13:1686:17 | ... = ... |  | file://:0:0:0:0 | () |
+| main.rs:1686:17:1686:17 | 2 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:1688:9:1688:9 | a |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:1702:30:1704:9 | { ... } |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1703:13:1703:31 | Vec2 {...} |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1703:23:1703:23 | 0 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:1703:23:1703:23 | 0 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1703:29:1703:29 | 0 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:1703:29:1703:29 | 0 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1710:16:1710:19 | SelfParam |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1710:22:1710:24 | rhs |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1710:41:1715:9 | { ... } |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1711:13:1714:13 | Vec2 {...} |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1712:20:1712:23 | self |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1712:20:1712:25 | self.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1712:20:1712:33 | ... + ... |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1712:29:1712:31 | rhs |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1712:29:1712:33 | rhs.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1713:20:1713:23 | self |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1713:20:1713:25 | self.y |  | {EXTERNAL LOCATION} | i64 |
 | main.rs:1713:20:1713:33 | ... + ... |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1713:29:1713:31 | rhs |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1713:29:1713:33 | rhs.x |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1714:20:1714:23 | self |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1714:20:1714:25 | self.y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1714:20:1714:33 | ... + ... |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1714:29:1714:31 | rhs |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1714:29:1714:33 | rhs.y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1721:23:1721:31 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:1721:23:1721:31 | SelfParam | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1721:34:1721:36 | rhs |  | main.rs:1696:5:1701:5 | Vec2 |
+| main.rs:1713:29:1713:31 | rhs |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1713:29:1713:33 | rhs.y |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1720:23:1720:31 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1720:23:1720:31 | SelfParam | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1720:34:1720:36 | rhs |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1721:13:1721:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1721:13:1721:16 | self | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1721:13:1721:18 | self.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1721:13:1721:27 | ... += ... |  | file://:0:0:0:0 | () |
+| main.rs:1721:23:1721:25 | rhs |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1721:23:1721:27 | rhs.x |  | {EXTERNAL LOCATION} | i64 |
 | main.rs:1722:13:1722:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:1722:13:1722:16 | self | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1722:13:1722:18 | self.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1722:13:1722:16 | self | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1722:13:1722:18 | self.y |  | {EXTERNAL LOCATION} | i64 |
 | main.rs:1722:13:1722:27 | ... += ... |  | file://:0:0:0:0 | () |
-| main.rs:1722:23:1722:25 | rhs |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1722:23:1722:27 | rhs.x |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1723:13:1723:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:1723:13:1723:16 | self | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1723:13:1723:18 | self.y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1723:13:1723:27 | ... += ... |  | file://:0:0:0:0 | () |
-| main.rs:1723:23:1723:25 | rhs |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1723:23:1723:27 | rhs.y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1729:16:1729:19 | SelfParam |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1729:22:1729:24 | rhs |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1729:41:1734:9 | { ... } |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1730:13:1733:13 | Vec2 {...} |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1731:20:1731:23 | self |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1731:20:1731:25 | self.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1722:23:1722:25 | rhs |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1722:23:1722:27 | rhs.y |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1728:16:1728:19 | SelfParam |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1728:22:1728:24 | rhs |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1728:41:1733:9 | { ... } |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1729:13:1732:13 | Vec2 {...} |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1730:20:1730:23 | self |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1730:20:1730:25 | self.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1730:20:1730:33 | ... - ... |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1730:29:1730:31 | rhs |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1730:29:1730:33 | rhs.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1731:20:1731:23 | self |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1731:20:1731:25 | self.y |  | {EXTERNAL LOCATION} | i64 |
 | main.rs:1731:20:1731:33 | ... - ... |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1731:29:1731:31 | rhs |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1731:29:1731:33 | rhs.x |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1732:20:1732:23 | self |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1732:20:1732:25 | self.y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1732:20:1732:33 | ... - ... |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1732:29:1732:31 | rhs |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1732:29:1732:33 | rhs.y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1739:23:1739:31 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:1739:23:1739:31 | SelfParam | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1739:34:1739:36 | rhs |  | main.rs:1696:5:1701:5 | Vec2 |
+| main.rs:1731:29:1731:31 | rhs |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1731:29:1731:33 | rhs.y |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1738:23:1738:31 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1738:23:1738:31 | SelfParam | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1738:34:1738:36 | rhs |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1739:13:1739:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1739:13:1739:16 | self | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1739:13:1739:18 | self.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1739:13:1739:27 | ... -= ... |  | file://:0:0:0:0 | () |
+| main.rs:1739:23:1739:25 | rhs |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1739:23:1739:27 | rhs.x |  | {EXTERNAL LOCATION} | i64 |
 | main.rs:1740:13:1740:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:1740:13:1740:16 | self | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1740:13:1740:18 | self.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1740:13:1740:16 | self | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1740:13:1740:18 | self.y |  | {EXTERNAL LOCATION} | i64 |
 | main.rs:1740:13:1740:27 | ... -= ... |  | file://:0:0:0:0 | () |
-| main.rs:1740:23:1740:25 | rhs |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1740:23:1740:27 | rhs.x |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1741:13:1741:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:1741:13:1741:16 | self | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1741:13:1741:18 | self.y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1741:13:1741:27 | ... -= ... |  | file://:0:0:0:0 | () |
-| main.rs:1741:23:1741:25 | rhs |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1741:23:1741:27 | rhs.y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1747:16:1747:19 | SelfParam |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1747:22:1747:24 | rhs |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1747:41:1752:9 | { ... } |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1748:13:1751:13 | Vec2 {...} |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1749:20:1749:23 | self |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1749:20:1749:25 | self.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1740:23:1740:25 | rhs |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1740:23:1740:27 | rhs.y |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1746:16:1746:19 | SelfParam |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1746:22:1746:24 | rhs |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1746:41:1751:9 | { ... } |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1747:13:1750:13 | Vec2 {...} |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1748:20:1748:23 | self |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1748:20:1748:25 | self.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1748:20:1748:33 | ... * ... |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1748:29:1748:31 | rhs |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1748:29:1748:33 | rhs.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1749:20:1749:23 | self |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1749:20:1749:25 | self.y |  | {EXTERNAL LOCATION} | i64 |
 | main.rs:1749:20:1749:33 | ... * ... |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1749:29:1749:31 | rhs |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1749:29:1749:33 | rhs.x |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1750:20:1750:23 | self |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1750:20:1750:25 | self.y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1750:20:1750:33 | ... * ... |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1750:29:1750:31 | rhs |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1750:29:1750:33 | rhs.y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1756:23:1756:31 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:1756:23:1756:31 | SelfParam | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1756:34:1756:36 | rhs |  | main.rs:1696:5:1701:5 | Vec2 |
+| main.rs:1749:29:1749:31 | rhs |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1749:29:1749:33 | rhs.y |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1755:23:1755:31 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1755:23:1755:31 | SelfParam | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1755:34:1755:36 | rhs |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1756:13:1756:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1756:13:1756:16 | self | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1756:13:1756:18 | self.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1756:13:1756:27 | ... *= ... |  | file://:0:0:0:0 | () |
+| main.rs:1756:23:1756:25 | rhs |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1756:23:1756:27 | rhs.x |  | {EXTERNAL LOCATION} | i64 |
 | main.rs:1757:13:1757:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:1757:13:1757:16 | self | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1757:13:1757:18 | self.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1757:13:1757:16 | self | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1757:13:1757:18 | self.y |  | {EXTERNAL LOCATION} | i64 |
 | main.rs:1757:13:1757:27 | ... *= ... |  | file://:0:0:0:0 | () |
-| main.rs:1757:23:1757:25 | rhs |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1757:23:1757:27 | rhs.x |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1758:13:1758:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:1758:13:1758:16 | self | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1758:13:1758:18 | self.y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1758:13:1758:27 | ... *= ... |  | file://:0:0:0:0 | () |
-| main.rs:1758:23:1758:25 | rhs |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1758:23:1758:27 | rhs.y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1764:16:1764:19 | SelfParam |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1764:22:1764:24 | rhs |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1764:41:1769:9 | { ... } |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1765:13:1768:13 | Vec2 {...} |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1766:20:1766:23 | self |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1766:20:1766:25 | self.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1757:23:1757:25 | rhs |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1757:23:1757:27 | rhs.y |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1763:16:1763:19 | SelfParam |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1763:22:1763:24 | rhs |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1763:41:1768:9 | { ... } |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1764:13:1767:13 | Vec2 {...} |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1765:20:1765:23 | self |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1765:20:1765:25 | self.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1765:20:1765:33 | ... / ... |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1765:29:1765:31 | rhs |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1765:29:1765:33 | rhs.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1766:20:1766:23 | self |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1766:20:1766:25 | self.y |  | {EXTERNAL LOCATION} | i64 |
 | main.rs:1766:20:1766:33 | ... / ... |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1766:29:1766:31 | rhs |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1766:29:1766:33 | rhs.x |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1767:20:1767:23 | self |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1767:20:1767:25 | self.y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1767:20:1767:33 | ... / ... |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1767:29:1767:31 | rhs |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1767:29:1767:33 | rhs.y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1773:23:1773:31 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:1773:23:1773:31 | SelfParam | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1773:34:1773:36 | rhs |  | main.rs:1696:5:1701:5 | Vec2 |
+| main.rs:1766:29:1766:31 | rhs |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1766:29:1766:33 | rhs.y |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1772:23:1772:31 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1772:23:1772:31 | SelfParam | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1772:34:1772:36 | rhs |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1773:13:1773:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1773:13:1773:16 | self | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1773:13:1773:18 | self.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1773:13:1773:27 | ... /= ... |  | file://:0:0:0:0 | () |
+| main.rs:1773:23:1773:25 | rhs |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1773:23:1773:27 | rhs.x |  | {EXTERNAL LOCATION} | i64 |
 | main.rs:1774:13:1774:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:1774:13:1774:16 | self | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1774:13:1774:18 | self.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1774:13:1774:16 | self | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1774:13:1774:18 | self.y |  | {EXTERNAL LOCATION} | i64 |
 | main.rs:1774:13:1774:27 | ... /= ... |  | file://:0:0:0:0 | () |
-| main.rs:1774:23:1774:25 | rhs |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1774:23:1774:27 | rhs.x |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1775:13:1775:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:1775:13:1775:16 | self | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1775:13:1775:18 | self.y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1775:13:1775:27 | ... /= ... |  | file://:0:0:0:0 | () |
-| main.rs:1775:23:1775:25 | rhs |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1775:23:1775:27 | rhs.y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1781:16:1781:19 | SelfParam |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1781:22:1781:24 | rhs |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1781:41:1786:9 | { ... } |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1782:13:1785:13 | Vec2 {...} |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1783:20:1783:23 | self |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1783:20:1783:25 | self.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1774:23:1774:25 | rhs |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1774:23:1774:27 | rhs.y |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1780:16:1780:19 | SelfParam |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1780:22:1780:24 | rhs |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1780:41:1785:9 | { ... } |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1781:13:1784:13 | Vec2 {...} |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1782:20:1782:23 | self |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1782:20:1782:25 | self.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1782:20:1782:33 | ... % ... |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1782:29:1782:31 | rhs |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1782:29:1782:33 | rhs.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1783:20:1783:23 | self |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1783:20:1783:25 | self.y |  | {EXTERNAL LOCATION} | i64 |
 | main.rs:1783:20:1783:33 | ... % ... |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1783:29:1783:31 | rhs |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1783:29:1783:33 | rhs.x |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1784:20:1784:23 | self |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1784:20:1784:25 | self.y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1784:20:1784:33 | ... % ... |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1784:29:1784:31 | rhs |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1784:29:1784:33 | rhs.y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1790:23:1790:31 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:1790:23:1790:31 | SelfParam | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1790:34:1790:36 | rhs |  | main.rs:1696:5:1701:5 | Vec2 |
+| main.rs:1783:29:1783:31 | rhs |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1783:29:1783:33 | rhs.y |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1789:23:1789:31 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1789:23:1789:31 | SelfParam | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1789:34:1789:36 | rhs |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1790:13:1790:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1790:13:1790:16 | self | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1790:13:1790:18 | self.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1790:13:1790:27 | ... %= ... |  | file://:0:0:0:0 | () |
+| main.rs:1790:23:1790:25 | rhs |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1790:23:1790:27 | rhs.x |  | {EXTERNAL LOCATION} | i64 |
 | main.rs:1791:13:1791:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:1791:13:1791:16 | self | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1791:13:1791:18 | self.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1791:13:1791:16 | self | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1791:13:1791:18 | self.y |  | {EXTERNAL LOCATION} | i64 |
 | main.rs:1791:13:1791:27 | ... %= ... |  | file://:0:0:0:0 | () |
-| main.rs:1791:23:1791:25 | rhs |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1791:23:1791:27 | rhs.x |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1792:13:1792:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:1792:13:1792:16 | self | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1792:13:1792:18 | self.y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1792:13:1792:27 | ... %= ... |  | file://:0:0:0:0 | () |
-| main.rs:1792:23:1792:25 | rhs |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1792:23:1792:27 | rhs.y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1798:19:1798:22 | SelfParam |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1798:25:1798:27 | rhs |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1798:44:1803:9 | { ... } |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1799:13:1802:13 | Vec2 {...} |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1800:20:1800:23 | self |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1800:20:1800:25 | self.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1791:23:1791:25 | rhs |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1791:23:1791:27 | rhs.y |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1797:19:1797:22 | SelfParam |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1797:25:1797:27 | rhs |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1797:44:1802:9 | { ... } |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1798:13:1801:13 | Vec2 {...} |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1799:20:1799:23 | self |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1799:20:1799:25 | self.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1799:20:1799:33 | ... & ... |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1799:29:1799:31 | rhs |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1799:29:1799:33 | rhs.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1800:20:1800:23 | self |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1800:20:1800:25 | self.y |  | {EXTERNAL LOCATION} | i64 |
 | main.rs:1800:20:1800:33 | ... & ... |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1800:29:1800:31 | rhs |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1800:29:1800:33 | rhs.x |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1801:20:1801:23 | self |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1801:20:1801:25 | self.y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1801:20:1801:33 | ... & ... |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1801:29:1801:31 | rhs |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1801:29:1801:33 | rhs.y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1807:26:1807:34 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:1807:26:1807:34 | SelfParam | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1807:37:1807:39 | rhs |  | main.rs:1696:5:1701:5 | Vec2 |
+| main.rs:1800:29:1800:31 | rhs |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1800:29:1800:33 | rhs.y |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1806:26:1806:34 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1806:26:1806:34 | SelfParam | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1806:37:1806:39 | rhs |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1807:13:1807:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1807:13:1807:16 | self | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1807:13:1807:18 | self.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1807:13:1807:27 | ... &= ... |  | file://:0:0:0:0 | () |
+| main.rs:1807:23:1807:25 | rhs |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1807:23:1807:27 | rhs.x |  | {EXTERNAL LOCATION} | i64 |
 | main.rs:1808:13:1808:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:1808:13:1808:16 | self | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1808:13:1808:18 | self.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1808:13:1808:16 | self | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1808:13:1808:18 | self.y |  | {EXTERNAL LOCATION} | i64 |
 | main.rs:1808:13:1808:27 | ... &= ... |  | file://:0:0:0:0 | () |
-| main.rs:1808:23:1808:25 | rhs |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1808:23:1808:27 | rhs.x |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1809:13:1809:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:1809:13:1809:16 | self | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1809:13:1809:18 | self.y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1809:13:1809:27 | ... &= ... |  | file://:0:0:0:0 | () |
-| main.rs:1809:23:1809:25 | rhs |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1809:23:1809:27 | rhs.y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1815:18:1815:21 | SelfParam |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1815:24:1815:26 | rhs |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1815:43:1820:9 | { ... } |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1816:13:1819:13 | Vec2 {...} |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1817:20:1817:23 | self |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1817:20:1817:25 | self.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1808:23:1808:25 | rhs |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1808:23:1808:27 | rhs.y |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1814:18:1814:21 | SelfParam |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1814:24:1814:26 | rhs |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1814:43:1819:9 | { ... } |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1815:13:1818:13 | Vec2 {...} |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1816:20:1816:23 | self |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1816:20:1816:25 | self.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1816:20:1816:33 | ... \| ... |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1816:29:1816:31 | rhs |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1816:29:1816:33 | rhs.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1817:20:1817:23 | self |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1817:20:1817:25 | self.y |  | {EXTERNAL LOCATION} | i64 |
 | main.rs:1817:20:1817:33 | ... \| ... |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1817:29:1817:31 | rhs |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1817:29:1817:33 | rhs.x |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1818:20:1818:23 | self |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1818:20:1818:25 | self.y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1818:20:1818:33 | ... \| ... |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1818:29:1818:31 | rhs |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1818:29:1818:33 | rhs.y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1824:25:1824:33 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:1824:25:1824:33 | SelfParam | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1824:36:1824:38 | rhs |  | main.rs:1696:5:1701:5 | Vec2 |
+| main.rs:1817:29:1817:31 | rhs |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1817:29:1817:33 | rhs.y |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1823:25:1823:33 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1823:25:1823:33 | SelfParam | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1823:36:1823:38 | rhs |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1824:13:1824:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1824:13:1824:16 | self | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1824:13:1824:18 | self.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1824:13:1824:27 | ... \|= ... |  | file://:0:0:0:0 | () |
+| main.rs:1824:23:1824:25 | rhs |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1824:23:1824:27 | rhs.x |  | {EXTERNAL LOCATION} | i64 |
 | main.rs:1825:13:1825:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:1825:13:1825:16 | self | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1825:13:1825:18 | self.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1825:13:1825:16 | self | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1825:13:1825:18 | self.y |  | {EXTERNAL LOCATION} | i64 |
 | main.rs:1825:13:1825:27 | ... \|= ... |  | file://:0:0:0:0 | () |
-| main.rs:1825:23:1825:25 | rhs |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1825:23:1825:27 | rhs.x |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1826:13:1826:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:1826:13:1826:16 | self | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1826:13:1826:18 | self.y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1826:13:1826:27 | ... \|= ... |  | file://:0:0:0:0 | () |
-| main.rs:1826:23:1826:25 | rhs |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1826:23:1826:27 | rhs.y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1832:19:1832:22 | SelfParam |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1832:25:1832:27 | rhs |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1832:44:1837:9 | { ... } |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1833:13:1836:13 | Vec2 {...} |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1834:20:1834:23 | self |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1834:20:1834:25 | self.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1825:23:1825:25 | rhs |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1825:23:1825:27 | rhs.y |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1831:19:1831:22 | SelfParam |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1831:25:1831:27 | rhs |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1831:44:1836:9 | { ... } |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1832:13:1835:13 | Vec2 {...} |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1833:20:1833:23 | self |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1833:20:1833:25 | self.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1833:20:1833:33 | ... ^ ... |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1833:29:1833:31 | rhs |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1833:29:1833:33 | rhs.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1834:20:1834:23 | self |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1834:20:1834:25 | self.y |  | {EXTERNAL LOCATION} | i64 |
 | main.rs:1834:20:1834:33 | ... ^ ... |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1834:29:1834:31 | rhs |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1834:29:1834:33 | rhs.x |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1835:20:1835:23 | self |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1835:20:1835:25 | self.y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1835:20:1835:33 | ... ^ ... |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1835:29:1835:31 | rhs |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1835:29:1835:33 | rhs.y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1841:26:1841:34 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:1841:26:1841:34 | SelfParam | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1841:37:1841:39 | rhs |  | main.rs:1696:5:1701:5 | Vec2 |
+| main.rs:1834:29:1834:31 | rhs |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1834:29:1834:33 | rhs.y |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1840:26:1840:34 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1840:26:1840:34 | SelfParam | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1840:37:1840:39 | rhs |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1841:13:1841:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1841:13:1841:16 | self | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1841:13:1841:18 | self.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1841:13:1841:27 | ... ^= ... |  | file://:0:0:0:0 | () |
+| main.rs:1841:23:1841:25 | rhs |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1841:23:1841:27 | rhs.x |  | {EXTERNAL LOCATION} | i64 |
 | main.rs:1842:13:1842:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:1842:13:1842:16 | self | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1842:13:1842:18 | self.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1842:13:1842:16 | self | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1842:13:1842:18 | self.y |  | {EXTERNAL LOCATION} | i64 |
 | main.rs:1842:13:1842:27 | ... ^= ... |  | file://:0:0:0:0 | () |
-| main.rs:1842:23:1842:25 | rhs |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1842:23:1842:27 | rhs.x |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1843:13:1843:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:1843:13:1843:16 | self | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1843:13:1843:18 | self.y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1843:13:1843:27 | ... ^= ... |  | file://:0:0:0:0 | () |
-| main.rs:1843:23:1843:25 | rhs |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1843:23:1843:27 | rhs.y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1849:16:1849:19 | SelfParam |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1849:22:1849:24 | rhs |  | {EXTERNAL LOCATION} | u32 |
-| main.rs:1849:40:1854:9 | { ... } |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1850:13:1853:13 | Vec2 {...} |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1851:20:1851:23 | self |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1851:20:1851:25 | self.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1842:23:1842:25 | rhs |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1842:23:1842:27 | rhs.y |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1848:16:1848:19 | SelfParam |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1848:22:1848:24 | rhs |  | {EXTERNAL LOCATION} | u32 |
+| main.rs:1848:40:1853:9 | { ... } |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1849:13:1852:13 | Vec2 {...} |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1850:20:1850:23 | self |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1850:20:1850:25 | self.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1850:20:1850:32 | ... << ... |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1850:30:1850:32 | rhs |  | {EXTERNAL LOCATION} | u32 |
+| main.rs:1851:20:1851:23 | self |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1851:20:1851:25 | self.y |  | {EXTERNAL LOCATION} | i64 |
 | main.rs:1851:20:1851:32 | ... << ... |  | {EXTERNAL LOCATION} | i64 |
 | main.rs:1851:30:1851:32 | rhs |  | {EXTERNAL LOCATION} | u32 |
-| main.rs:1852:20:1852:23 | self |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1852:20:1852:25 | self.y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1852:20:1852:32 | ... << ... |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1852:30:1852:32 | rhs |  | {EXTERNAL LOCATION} | u32 |
-| main.rs:1858:23:1858:31 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:1858:23:1858:31 | SelfParam | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1858:34:1858:36 | rhs |  | {EXTERNAL LOCATION} | u32 |
+| main.rs:1857:23:1857:31 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1857:23:1857:31 | SelfParam | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1857:34:1857:36 | rhs |  | {EXTERNAL LOCATION} | u32 |
+| main.rs:1858:13:1858:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1858:13:1858:16 | self | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1858:13:1858:18 | self.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1858:13:1858:26 | ... <<= ... |  | file://:0:0:0:0 | () |
+| main.rs:1858:24:1858:26 | rhs |  | {EXTERNAL LOCATION} | u32 |
 | main.rs:1859:13:1859:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:1859:13:1859:16 | self | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1859:13:1859:18 | self.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1859:13:1859:16 | self | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1859:13:1859:18 | self.y |  | {EXTERNAL LOCATION} | i64 |
 | main.rs:1859:13:1859:26 | ... <<= ... |  | file://:0:0:0:0 | () |
 | main.rs:1859:24:1859:26 | rhs |  | {EXTERNAL LOCATION} | u32 |
-| main.rs:1860:13:1860:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:1860:13:1860:16 | self | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1860:13:1860:18 | self.y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1860:13:1860:26 | ... <<= ... |  | file://:0:0:0:0 | () |
-| main.rs:1860:24:1860:26 | rhs |  | {EXTERNAL LOCATION} | u32 |
-| main.rs:1866:16:1866:19 | SelfParam |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1866:22:1866:24 | rhs |  | {EXTERNAL LOCATION} | u32 |
-| main.rs:1866:40:1871:9 | { ... } |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1867:13:1870:13 | Vec2 {...} |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1868:20:1868:23 | self |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1868:20:1868:25 | self.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1865:16:1865:19 | SelfParam |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1865:22:1865:24 | rhs |  | {EXTERNAL LOCATION} | u32 |
+| main.rs:1865:40:1870:9 | { ... } |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1866:13:1869:13 | Vec2 {...} |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1867:20:1867:23 | self |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1867:20:1867:25 | self.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1867:20:1867:32 | ... >> ... |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1867:30:1867:32 | rhs |  | {EXTERNAL LOCATION} | u32 |
+| main.rs:1868:20:1868:23 | self |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1868:20:1868:25 | self.y |  | {EXTERNAL LOCATION} | i64 |
 | main.rs:1868:20:1868:32 | ... >> ... |  | {EXTERNAL LOCATION} | i64 |
 | main.rs:1868:30:1868:32 | rhs |  | {EXTERNAL LOCATION} | u32 |
-| main.rs:1869:20:1869:23 | self |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1869:20:1869:25 | self.y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1869:20:1869:32 | ... >> ... |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1869:30:1869:32 | rhs |  | {EXTERNAL LOCATION} | u32 |
-| main.rs:1875:23:1875:31 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:1875:23:1875:31 | SelfParam | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1875:34:1875:36 | rhs |  | {EXTERNAL LOCATION} | u32 |
+| main.rs:1874:23:1874:31 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1874:23:1874:31 | SelfParam | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1874:34:1874:36 | rhs |  | {EXTERNAL LOCATION} | u32 |
+| main.rs:1875:13:1875:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1875:13:1875:16 | self | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1875:13:1875:18 | self.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1875:13:1875:26 | ... >>= ... |  | file://:0:0:0:0 | () |
+| main.rs:1875:24:1875:26 | rhs |  | {EXTERNAL LOCATION} | u32 |
 | main.rs:1876:13:1876:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:1876:13:1876:16 | self | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1876:13:1876:18 | self.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1876:13:1876:16 | self | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1876:13:1876:18 | self.y |  | {EXTERNAL LOCATION} | i64 |
 | main.rs:1876:13:1876:26 | ... >>= ... |  | file://:0:0:0:0 | () |
 | main.rs:1876:24:1876:26 | rhs |  | {EXTERNAL LOCATION} | u32 |
-| main.rs:1877:13:1877:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:1877:13:1877:16 | self | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1877:13:1877:18 | self.y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1877:13:1877:26 | ... >>= ... |  | file://:0:0:0:0 | () |
-| main.rs:1877:24:1877:26 | rhs |  | {EXTERNAL LOCATION} | u32 |
-| main.rs:1883:16:1883:19 | SelfParam |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1883:30:1888:9 | { ... } |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1884:13:1887:13 | Vec2 {...} |  | main.rs:1696:5:1701:5 | Vec2 |
+| main.rs:1882:16:1882:19 | SelfParam |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1882:30:1887:9 | { ... } |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1883:13:1886:13 | Vec2 {...} |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1884:20:1884:26 | - ... |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1884:21:1884:24 | self |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1884:21:1884:26 | self.x |  | {EXTERNAL LOCATION} | i64 |
 | main.rs:1885:20:1885:26 | - ... |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1885:21:1885:24 | self |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1885:21:1885:26 | self.x |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1886:20:1886:26 | - ... |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1886:21:1886:24 | self |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1886:21:1886:26 | self.y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1893:16:1893:19 | SelfParam |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1893:30:1898:9 | { ... } |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1894:13:1897:13 | Vec2 {...} |  | main.rs:1696:5:1701:5 | Vec2 |
+| main.rs:1885:21:1885:24 | self |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1885:21:1885:26 | self.y |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1892:16:1892:19 | SelfParam |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1892:30:1897:9 | { ... } |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1893:13:1896:13 | Vec2 {...} |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1894:20:1894:26 | ! ... |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1894:21:1894:24 | self |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1894:21:1894:26 | self.x |  | {EXTERNAL LOCATION} | i64 |
 | main.rs:1895:20:1895:26 | ! ... |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1895:21:1895:24 | self |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1895:21:1895:26 | self.x |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1896:20:1896:26 | ! ... |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1896:21:1896:24 | self |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1896:21:1896:26 | self.y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1902:15:1902:19 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:1902:15:1902:19 | SelfParam | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1902:22:1902:26 | other |  | file://:0:0:0:0 | & |
-| main.rs:1902:22:1902:26 | other | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1902:44:1904:9 | { ... } |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1903:13:1903:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:1903:13:1903:16 | self | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1903:13:1903:18 | self.x |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1903:13:1903:29 | ... == ... |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1903:13:1903:50 | ... && ... |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1903:23:1903:27 | other |  | file://:0:0:0:0 | & |
-| main.rs:1903:23:1903:27 | other | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1903:23:1903:29 | other.x |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1903:34:1903:37 | self |  | file://:0:0:0:0 | & |
-| main.rs:1903:34:1903:37 | self | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1903:34:1903:39 | self.y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1903:34:1903:50 | ... == ... |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1903:44:1903:48 | other |  | file://:0:0:0:0 | & |
-| main.rs:1903:44:1903:48 | other | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1903:44:1903:50 | other.y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1906:15:1906:19 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:1906:15:1906:19 | SelfParam | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1906:22:1906:26 | other |  | file://:0:0:0:0 | & |
-| main.rs:1906:22:1906:26 | other | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1906:44:1908:9 | { ... } |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1907:13:1907:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:1907:13:1907:16 | self | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1907:13:1907:18 | self.x |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1907:13:1907:29 | ... != ... |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1907:13:1907:50 | ... \|\| ... |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1907:23:1907:27 | other |  | file://:0:0:0:0 | & |
-| main.rs:1907:23:1907:27 | other | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1907:23:1907:29 | other.x |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1907:34:1907:37 | self |  | file://:0:0:0:0 | & |
-| main.rs:1907:34:1907:37 | self | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1907:34:1907:39 | self.y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1907:34:1907:50 | ... != ... |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1907:44:1907:48 | other |  | file://:0:0:0:0 | & |
-| main.rs:1907:44:1907:48 | other | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1907:44:1907:50 | other.y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1912:24:1912:28 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:1912:24:1912:28 | SelfParam | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1912:31:1912:35 | other |  | file://:0:0:0:0 | & |
-| main.rs:1912:31:1912:35 | other | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1912:75:1914:9 | { ... } |  | {EXTERNAL LOCATION} | Option |
-| main.rs:1912:75:1914:9 | { ... } | T | {EXTERNAL LOCATION} | Ordering |
-| main.rs:1913:13:1913:29 | (...) |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1913:13:1913:63 | ... .partial_cmp(...) |  | {EXTERNAL LOCATION} | Option |
-| main.rs:1913:13:1913:63 | ... .partial_cmp(...) | T | {EXTERNAL LOCATION} | Ordering |
-| main.rs:1913:14:1913:17 | self |  | file://:0:0:0:0 | & |
-| main.rs:1913:14:1913:17 | self | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1913:14:1913:19 | self.x |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1913:14:1913:28 | ... + ... |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1913:23:1913:26 | self |  | file://:0:0:0:0 | & |
-| main.rs:1913:23:1913:26 | self | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1913:23:1913:28 | self.y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1913:43:1913:62 | &... |  | file://:0:0:0:0 | & |
-| main.rs:1913:43:1913:62 | &... | &T | {EXTERNAL LOCATION} | i64 |
-| main.rs:1913:44:1913:62 | (...) |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1913:45:1913:49 | other |  | file://:0:0:0:0 | & |
-| main.rs:1913:45:1913:49 | other | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1913:45:1913:51 | other.x |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1913:45:1913:61 | ... + ... |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1913:55:1913:59 | other |  | file://:0:0:0:0 | & |
-| main.rs:1913:55:1913:59 | other | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1913:55:1913:61 | other.y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1916:15:1916:19 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:1916:15:1916:19 | SelfParam | &T | main.rs:1696:5:1701:5 | Vec2 |
+| main.rs:1895:21:1895:24 | self |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1895:21:1895:26 | self.y |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1901:15:1901:19 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1901:15:1901:19 | SelfParam | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1901:22:1901:26 | other |  | file://:0:0:0:0 | & |
+| main.rs:1901:22:1901:26 | other | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1901:44:1903:9 | { ... } |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1902:13:1902:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1902:13:1902:16 | self | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1902:13:1902:18 | self.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1902:13:1902:29 | ... == ... |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1902:13:1902:50 | ... && ... |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1902:23:1902:27 | other |  | file://:0:0:0:0 | & |
+| main.rs:1902:23:1902:27 | other | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1902:23:1902:29 | other.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1902:34:1902:37 | self |  | file://:0:0:0:0 | & |
+| main.rs:1902:34:1902:37 | self | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1902:34:1902:39 | self.y |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1902:34:1902:50 | ... == ... |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1902:44:1902:48 | other |  | file://:0:0:0:0 | & |
+| main.rs:1902:44:1902:48 | other | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1902:44:1902:50 | other.y |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1905:15:1905:19 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1905:15:1905:19 | SelfParam | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1905:22:1905:26 | other |  | file://:0:0:0:0 | & |
+| main.rs:1905:22:1905:26 | other | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1905:44:1907:9 | { ... } |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1906:13:1906:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1906:13:1906:16 | self | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1906:13:1906:18 | self.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1906:13:1906:29 | ... != ... |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1906:13:1906:50 | ... \|\| ... |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1906:23:1906:27 | other |  | file://:0:0:0:0 | & |
+| main.rs:1906:23:1906:27 | other | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1906:23:1906:29 | other.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1906:34:1906:37 | self |  | file://:0:0:0:0 | & |
+| main.rs:1906:34:1906:37 | self | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1906:34:1906:39 | self.y |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1906:34:1906:50 | ... != ... |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1906:44:1906:48 | other |  | file://:0:0:0:0 | & |
+| main.rs:1906:44:1906:48 | other | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1906:44:1906:50 | other.y |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1911:24:1911:28 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1911:24:1911:28 | SelfParam | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1911:31:1911:35 | other |  | file://:0:0:0:0 | & |
+| main.rs:1911:31:1911:35 | other | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1911:75:1913:9 | { ... } |  | {EXTERNAL LOCATION} | Option |
+| main.rs:1911:75:1913:9 | { ... } | T | {EXTERNAL LOCATION} | Ordering |
+| main.rs:1912:13:1912:29 | (...) |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1912:13:1912:63 | ... .partial_cmp(...) |  | {EXTERNAL LOCATION} | Option |
+| main.rs:1912:13:1912:63 | ... .partial_cmp(...) | T | {EXTERNAL LOCATION} | Ordering |
+| main.rs:1912:14:1912:17 | self |  | file://:0:0:0:0 | & |
+| main.rs:1912:14:1912:17 | self | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1912:14:1912:19 | self.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1912:14:1912:28 | ... + ... |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1912:23:1912:26 | self |  | file://:0:0:0:0 | & |
+| main.rs:1912:23:1912:26 | self | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1912:23:1912:28 | self.y |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1912:43:1912:62 | &... |  | file://:0:0:0:0 | & |
+| main.rs:1912:43:1912:62 | &... | &T | {EXTERNAL LOCATION} | i64 |
+| main.rs:1912:44:1912:62 | (...) |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1912:45:1912:49 | other |  | file://:0:0:0:0 | & |
+| main.rs:1912:45:1912:49 | other | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1912:45:1912:51 | other.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1912:45:1912:61 | ... + ... |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1912:55:1912:59 | other |  | file://:0:0:0:0 | & |
+| main.rs:1912:55:1912:59 | other | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1912:55:1912:61 | other.y |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1915:15:1915:19 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1915:15:1915:19 | SelfParam | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1915:22:1915:26 | other |  | file://:0:0:0:0 | & |
+| main.rs:1915:22:1915:26 | other | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1915:44:1917:9 | { ... } |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1916:13:1916:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1916:13:1916:16 | self | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1916:13:1916:18 | self.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1916:13:1916:28 | ... < ... |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1916:13:1916:48 | ... && ... |  | {EXTERNAL LOCATION} | bool |
 | main.rs:1916:22:1916:26 | other |  | file://:0:0:0:0 | & |
-| main.rs:1916:22:1916:26 | other | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1916:44:1918:9 | { ... } |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1917:13:1917:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:1917:13:1917:16 | self | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1917:13:1917:18 | self.x |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1917:13:1917:28 | ... < ... |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1917:13:1917:48 | ... && ... |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1917:22:1917:26 | other |  | file://:0:0:0:0 | & |
-| main.rs:1917:22:1917:26 | other | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1917:22:1917:28 | other.x |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1917:33:1917:36 | self |  | file://:0:0:0:0 | & |
-| main.rs:1917:33:1917:36 | self | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1917:33:1917:38 | self.y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1917:33:1917:48 | ... < ... |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1917:42:1917:46 | other |  | file://:0:0:0:0 | & |
-| main.rs:1917:42:1917:46 | other | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1917:42:1917:48 | other.y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1920:15:1920:19 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:1920:15:1920:19 | SelfParam | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1920:22:1920:26 | other |  | file://:0:0:0:0 | & |
-| main.rs:1920:22:1920:26 | other | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1920:44:1922:9 | { ... } |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1921:13:1921:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:1921:13:1921:16 | self | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1921:13:1921:18 | self.x |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1921:13:1921:29 | ... <= ... |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1921:13:1921:50 | ... && ... |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1921:23:1921:27 | other |  | file://:0:0:0:0 | & |
-| main.rs:1921:23:1921:27 | other | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1921:23:1921:29 | other.x |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1921:34:1921:37 | self |  | file://:0:0:0:0 | & |
-| main.rs:1921:34:1921:37 | self | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1921:34:1921:39 | self.y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1921:34:1921:50 | ... <= ... |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1921:44:1921:48 | other |  | file://:0:0:0:0 | & |
-| main.rs:1921:44:1921:48 | other | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1921:44:1921:50 | other.y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1924:15:1924:19 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:1924:15:1924:19 | SelfParam | &T | main.rs:1696:5:1701:5 | Vec2 |
+| main.rs:1916:22:1916:26 | other | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1916:22:1916:28 | other.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1916:33:1916:36 | self |  | file://:0:0:0:0 | & |
+| main.rs:1916:33:1916:36 | self | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1916:33:1916:38 | self.y |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1916:33:1916:48 | ... < ... |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1916:42:1916:46 | other |  | file://:0:0:0:0 | & |
+| main.rs:1916:42:1916:46 | other | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1916:42:1916:48 | other.y |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1919:15:1919:19 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1919:15:1919:19 | SelfParam | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1919:22:1919:26 | other |  | file://:0:0:0:0 | & |
+| main.rs:1919:22:1919:26 | other | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1919:44:1921:9 | { ... } |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1920:13:1920:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1920:13:1920:16 | self | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1920:13:1920:18 | self.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1920:13:1920:29 | ... <= ... |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1920:13:1920:50 | ... && ... |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1920:23:1920:27 | other |  | file://:0:0:0:0 | & |
+| main.rs:1920:23:1920:27 | other | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1920:23:1920:29 | other.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1920:34:1920:37 | self |  | file://:0:0:0:0 | & |
+| main.rs:1920:34:1920:37 | self | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1920:34:1920:39 | self.y |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1920:34:1920:50 | ... <= ... |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1920:44:1920:48 | other |  | file://:0:0:0:0 | & |
+| main.rs:1920:44:1920:48 | other | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1920:44:1920:50 | other.y |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1923:15:1923:19 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1923:15:1923:19 | SelfParam | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1923:22:1923:26 | other |  | file://:0:0:0:0 | & |
+| main.rs:1923:22:1923:26 | other | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1923:44:1925:9 | { ... } |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1924:13:1924:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1924:13:1924:16 | self | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1924:13:1924:18 | self.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1924:13:1924:28 | ... > ... |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1924:13:1924:48 | ... && ... |  | {EXTERNAL LOCATION} | bool |
 | main.rs:1924:22:1924:26 | other |  | file://:0:0:0:0 | & |
-| main.rs:1924:22:1924:26 | other | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1924:44:1926:9 | { ... } |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1925:13:1925:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:1925:13:1925:16 | self | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1925:13:1925:18 | self.x |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1925:13:1925:28 | ... > ... |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1925:13:1925:48 | ... && ... |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1925:22:1925:26 | other |  | file://:0:0:0:0 | & |
-| main.rs:1925:22:1925:26 | other | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1925:22:1925:28 | other.x |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1925:33:1925:36 | self |  | file://:0:0:0:0 | & |
-| main.rs:1925:33:1925:36 | self | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1925:33:1925:38 | self.y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1925:33:1925:48 | ... > ... |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1925:42:1925:46 | other |  | file://:0:0:0:0 | & |
-| main.rs:1925:42:1925:46 | other | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1925:42:1925:48 | other.y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1928:15:1928:19 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:1928:15:1928:19 | SelfParam | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1928:22:1928:26 | other |  | file://:0:0:0:0 | & |
-| main.rs:1928:22:1928:26 | other | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1928:44:1930:9 | { ... } |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1929:13:1929:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:1929:13:1929:16 | self | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1929:13:1929:18 | self.x |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1929:13:1929:29 | ... >= ... |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1929:13:1929:50 | ... && ... |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1929:23:1929:27 | other |  | file://:0:0:0:0 | & |
-| main.rs:1929:23:1929:27 | other | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1929:23:1929:29 | other.x |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1929:34:1929:37 | self |  | file://:0:0:0:0 | & |
-| main.rs:1929:34:1929:37 | self | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1929:34:1929:39 | self.y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1929:34:1929:50 | ... >= ... |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1929:44:1929:48 | other |  | file://:0:0:0:0 | & |
-| main.rs:1929:44:1929:48 | other | &T | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1929:44:1929:50 | other.y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1933:26:1933:26 | a |  | main.rs:1933:18:1933:23 | T |
-| main.rs:1933:32:1933:32 | b |  | main.rs:1933:18:1933:23 | T |
-| main.rs:1933:51:1935:5 | { ... } |  | {EXTERNAL LOCATION} | Output |
-| main.rs:1934:9:1934:9 | a |  | main.rs:1933:18:1933:23 | T |
-| main.rs:1934:9:1934:13 | ... + ... |  | {EXTERNAL LOCATION} | Output |
-| main.rs:1934:13:1934:13 | b |  | main.rs:1933:18:1933:23 | T |
-| main.rs:1941:13:1941:18 | i64_eq |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1924:22:1924:26 | other | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1924:22:1924:28 | other.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1924:33:1924:36 | self |  | file://:0:0:0:0 | & |
+| main.rs:1924:33:1924:36 | self | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1924:33:1924:38 | self.y |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1924:33:1924:48 | ... > ... |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1924:42:1924:46 | other |  | file://:0:0:0:0 | & |
+| main.rs:1924:42:1924:46 | other | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1924:42:1924:48 | other.y |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1927:15:1927:19 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:1927:15:1927:19 | SelfParam | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1927:22:1927:26 | other |  | file://:0:0:0:0 | & |
+| main.rs:1927:22:1927:26 | other | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1927:44:1929:9 | { ... } |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1928:13:1928:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:1928:13:1928:16 | self | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1928:13:1928:18 | self.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1928:13:1928:29 | ... >= ... |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1928:13:1928:50 | ... && ... |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1928:23:1928:27 | other |  | file://:0:0:0:0 | & |
+| main.rs:1928:23:1928:27 | other | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1928:23:1928:29 | other.x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1928:34:1928:37 | self |  | file://:0:0:0:0 | & |
+| main.rs:1928:34:1928:37 | self | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1928:34:1928:39 | self.y |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1928:34:1928:50 | ... >= ... |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1928:44:1928:48 | other |  | file://:0:0:0:0 | & |
+| main.rs:1928:44:1928:48 | other | &T | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1928:44:1928:50 | other.y |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1932:26:1932:26 | a |  | main.rs:1932:18:1932:23 | T |
+| main.rs:1932:32:1932:32 | b |  | main.rs:1932:18:1932:23 | T |
+| main.rs:1932:51:1934:5 | { ... } |  | {EXTERNAL LOCATION} | Output |
+| main.rs:1933:9:1933:9 | a |  | main.rs:1932:18:1932:23 | T |
+| main.rs:1933:9:1933:13 | ... + ... |  | {EXTERNAL LOCATION} | Output |
+| main.rs:1933:13:1933:13 | b |  | main.rs:1932:18:1932:23 | T |
+| main.rs:1940:13:1940:18 | i64_eq |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1940:22:1940:35 | (...) |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1940:23:1940:26 | 1i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1940:23:1940:34 | ... == ... |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1940:31:1940:34 | 2i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1941:13:1941:18 | i64_ne |  | {EXTERNAL LOCATION} | bool |
 | main.rs:1941:22:1941:35 | (...) |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1941:23:1941:26 | 1i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1941:23:1941:34 | ... == ... |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1941:31:1941:34 | 2i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1942:13:1942:18 | i64_ne |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1942:22:1942:35 | (...) |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1942:23:1942:26 | 3i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1942:23:1942:34 | ... != ... |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1942:31:1942:34 | 4i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1943:13:1943:18 | i64_lt |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1943:22:1943:34 | (...) |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1943:23:1943:26 | 5i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1943:23:1943:33 | ... < ... |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1943:30:1943:33 | 6i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1944:13:1944:18 | i64_le |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1941:23:1941:26 | 3i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1941:23:1941:34 | ... != ... |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1941:31:1941:34 | 4i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1942:13:1942:18 | i64_lt |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1942:22:1942:34 | (...) |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1942:23:1942:26 | 5i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1942:23:1942:33 | ... < ... |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1942:30:1942:33 | 6i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1943:13:1943:18 | i64_le |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1943:22:1943:35 | (...) |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1943:23:1943:26 | 7i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1943:23:1943:34 | ... <= ... |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1943:31:1943:34 | 8i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1944:13:1944:18 | i64_gt |  | {EXTERNAL LOCATION} | bool |
 | main.rs:1944:22:1944:35 | (...) |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1944:23:1944:26 | 7i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1944:23:1944:34 | ... <= ... |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1944:31:1944:34 | 8i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1945:13:1945:18 | i64_gt |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1945:22:1945:35 | (...) |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1945:23:1945:26 | 9i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1945:23:1945:34 | ... > ... |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1945:30:1945:34 | 10i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1946:13:1946:18 | i64_ge |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1946:22:1946:37 | (...) |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1946:23:1946:27 | 11i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1946:23:1946:36 | ... >= ... |  | {EXTERNAL LOCATION} | bool |
-| main.rs:1946:32:1946:36 | 12i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1949:13:1949:19 | i64_add |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1949:23:1949:27 | 13i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1949:23:1949:35 | ... + ... |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1949:31:1949:35 | 14i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1950:13:1950:19 | i64_sub |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1950:23:1950:27 | 15i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1950:23:1950:35 | ... - ... |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1950:31:1950:35 | 16i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1951:13:1951:19 | i64_mul |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1951:23:1951:27 | 17i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1951:23:1951:35 | ... * ... |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1951:31:1951:35 | 18i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1952:13:1952:19 | i64_div |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1952:23:1952:27 | 19i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1952:23:1952:35 | ... / ... |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1952:31:1952:35 | 20i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1953:13:1953:19 | i64_rem |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1953:23:1953:27 | 21i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1953:23:1953:35 | ... % ... |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1953:31:1953:35 | 22i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1954:39:1954:42 | 1i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1954:45:1954:48 | 2i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1957:17:1957:30 | i64_add_assign |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1957:34:1957:38 | 23i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1958:9:1958:22 | i64_add_assign |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1958:9:1958:31 | ... += ... |  | file://:0:0:0:0 | () |
-| main.rs:1958:27:1958:31 | 24i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1960:17:1960:30 | i64_sub_assign |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1960:34:1960:38 | 25i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1961:9:1961:22 | i64_sub_assign |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1961:9:1961:31 | ... -= ... |  | file://:0:0:0:0 | () |
-| main.rs:1961:27:1961:31 | 26i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1963:17:1963:30 | i64_mul_assign |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1963:34:1963:38 | 27i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1964:9:1964:22 | i64_mul_assign |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1964:9:1964:31 | ... *= ... |  | file://:0:0:0:0 | () |
-| main.rs:1964:27:1964:31 | 28i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1966:17:1966:30 | i64_div_assign |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1966:34:1966:38 | 29i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1967:9:1967:22 | i64_div_assign |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1967:9:1967:31 | ... /= ... |  | file://:0:0:0:0 | () |
-| main.rs:1967:27:1967:31 | 30i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1969:17:1969:30 | i64_rem_assign |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1969:34:1969:38 | 31i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1970:9:1970:22 | i64_rem_assign |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1970:9:1970:31 | ... %= ... |  | file://:0:0:0:0 | () |
-| main.rs:1970:27:1970:31 | 32i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1973:13:1973:22 | i64_bitand |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1973:26:1973:30 | 33i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1973:26:1973:38 | ... & ... |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1973:34:1973:38 | 34i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1974:13:1974:21 | i64_bitor |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1974:25:1974:29 | 35i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1974:25:1974:37 | ... \| ... |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1974:33:1974:37 | 36i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1975:13:1975:22 | i64_bitxor |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1975:26:1975:30 | 37i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1975:26:1975:38 | ... ^ ... |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1975:34:1975:38 | 38i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1976:13:1976:19 | i64_shl |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1976:23:1976:27 | 39i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1976:23:1976:36 | ... << ... |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1976:32:1976:36 | 40i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1977:13:1977:19 | i64_shr |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1977:23:1977:27 | 41i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1977:23:1977:36 | ... >> ... |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1977:32:1977:36 | 42i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1980:17:1980:33 | i64_bitand_assign |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1980:37:1980:41 | 43i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1981:9:1981:25 | i64_bitand_assign |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1981:9:1981:34 | ... &= ... |  | file://:0:0:0:0 | () |
-| main.rs:1981:30:1981:34 | 44i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1983:17:1983:32 | i64_bitor_assign |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1983:36:1983:40 | 45i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1984:9:1984:24 | i64_bitor_assign |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1984:9:1984:33 | ... \|= ... |  | file://:0:0:0:0 | () |
-| main.rs:1984:29:1984:33 | 46i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1986:17:1986:33 | i64_bitxor_assign |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1986:37:1986:41 | 47i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1987:9:1987:25 | i64_bitxor_assign |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1987:9:1987:34 | ... ^= ... |  | file://:0:0:0:0 | () |
-| main.rs:1987:30:1987:34 | 48i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1989:17:1989:30 | i64_shl_assign |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1989:34:1989:38 | 49i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1990:9:1990:22 | i64_shl_assign |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1990:9:1990:32 | ... <<= ... |  | file://:0:0:0:0 | () |
-| main.rs:1990:28:1990:32 | 50i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1992:17:1992:30 | i64_shr_assign |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1992:34:1992:38 | 51i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1993:9:1993:22 | i64_shr_assign |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1993:9:1993:32 | ... >>= ... |  | file://:0:0:0:0 | () |
-| main.rs:1993:28:1993:32 | 52i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1995:13:1995:19 | i64_neg |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1995:23:1995:28 | - ... |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1995:24:1995:28 | 53i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1996:13:1996:19 | i64_not |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1996:23:1996:28 | ! ... |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1996:24:1996:28 | 54i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1999:13:1999:14 | v1 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1999:18:1999:36 | Vec2 {...} |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:1999:28:1999:28 | 1 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:1999:28:1999:28 | 1 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:1999:34:1999:34 | 2 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:1999:34:1999:34 | 2 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2000:13:2000:14 | v2 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2000:18:2000:36 | Vec2 {...} |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2000:28:2000:28 | 3 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2000:28:2000:28 | 3 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2000:34:2000:34 | 4 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2000:34:2000:34 | 4 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2003:13:2003:19 | vec2_eq |  | {EXTERNAL LOCATION} | bool |
-| main.rs:2003:23:2003:24 | v1 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2003:23:2003:30 | ... == ... |  | {EXTERNAL LOCATION} | bool |
-| main.rs:2003:29:2003:30 | v2 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2004:13:2004:19 | vec2_ne |  | {EXTERNAL LOCATION} | bool |
-| main.rs:2004:23:2004:24 | v1 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2004:23:2004:30 | ... != ... |  | {EXTERNAL LOCATION} | bool |
-| main.rs:2004:29:2004:30 | v2 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2005:13:2005:19 | vec2_lt |  | {EXTERNAL LOCATION} | bool |
-| main.rs:2005:23:2005:24 | v1 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2005:23:2005:29 | ... < ... |  | {EXTERNAL LOCATION} | bool |
-| main.rs:2005:28:2005:29 | v2 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2006:13:2006:19 | vec2_le |  | {EXTERNAL LOCATION} | bool |
-| main.rs:2006:23:2006:24 | v1 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2006:23:2006:30 | ... <= ... |  | {EXTERNAL LOCATION} | bool |
-| main.rs:2006:29:2006:30 | v2 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2007:13:2007:19 | vec2_gt |  | {EXTERNAL LOCATION} | bool |
-| main.rs:2007:23:2007:24 | v1 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2007:23:2007:29 | ... > ... |  | {EXTERNAL LOCATION} | bool |
-| main.rs:2007:28:2007:29 | v2 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2008:13:2008:19 | vec2_ge |  | {EXTERNAL LOCATION} | bool |
-| main.rs:2008:23:2008:24 | v1 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2008:23:2008:30 | ... >= ... |  | {EXTERNAL LOCATION} | bool |
-| main.rs:2008:29:2008:30 | v2 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2011:13:2011:20 | vec2_add |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2011:24:2011:25 | v1 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2011:24:2011:30 | ... + ... |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2011:29:2011:30 | v2 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2012:13:2012:20 | vec2_sub |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2012:24:2012:25 | v1 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2012:24:2012:30 | ... - ... |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2012:29:2012:30 | v2 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2013:13:2013:20 | vec2_mul |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2013:24:2013:25 | v1 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2013:24:2013:30 | ... * ... |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2013:29:2013:30 | v2 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2014:13:2014:20 | vec2_div |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2014:24:2014:25 | v1 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2014:24:2014:30 | ... / ... |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2014:29:2014:30 | v2 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2015:13:2015:20 | vec2_rem |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2015:24:2015:25 | v1 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2015:24:2015:30 | ... % ... |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2015:29:2015:30 | v2 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2018:17:2018:31 | vec2_add_assign |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2018:35:2018:36 | v1 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2019:9:2019:23 | vec2_add_assign |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2019:9:2019:29 | ... += ... |  | file://:0:0:0:0 | () |
-| main.rs:2019:28:2019:29 | v2 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2021:17:2021:31 | vec2_sub_assign |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2021:35:2021:36 | v1 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2022:9:2022:23 | vec2_sub_assign |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2022:9:2022:29 | ... -= ... |  | file://:0:0:0:0 | () |
-| main.rs:2022:28:2022:29 | v2 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2024:17:2024:31 | vec2_mul_assign |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2024:35:2024:36 | v1 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2025:9:2025:23 | vec2_mul_assign |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2025:9:2025:29 | ... *= ... |  | file://:0:0:0:0 | () |
-| main.rs:2025:28:2025:29 | v2 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2027:17:2027:31 | vec2_div_assign |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2027:35:2027:36 | v1 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2028:9:2028:23 | vec2_div_assign |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2028:9:2028:29 | ... /= ... |  | file://:0:0:0:0 | () |
-| main.rs:2028:28:2028:29 | v2 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2030:17:2030:31 | vec2_rem_assign |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2030:35:2030:36 | v1 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2031:9:2031:23 | vec2_rem_assign |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2031:9:2031:29 | ... %= ... |  | file://:0:0:0:0 | () |
-| main.rs:2031:28:2031:29 | v2 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2034:13:2034:23 | vec2_bitand |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2034:27:2034:28 | v1 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2034:27:2034:33 | ... & ... |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2034:32:2034:33 | v2 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2035:13:2035:22 | vec2_bitor |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2035:26:2035:27 | v1 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2035:26:2035:32 | ... \| ... |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2035:31:2035:32 | v2 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2036:13:2036:23 | vec2_bitxor |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2036:27:2036:28 | v1 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2036:27:2036:33 | ... ^ ... |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2036:32:2036:33 | v2 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2037:13:2037:20 | vec2_shl |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2037:24:2037:25 | v1 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2037:24:2037:33 | ... << ... |  | main.rs:1696:5:1701:5 | Vec2 |
+| main.rs:1944:23:1944:26 | 9i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1944:23:1944:34 | ... > ... |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1944:30:1944:34 | 10i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1945:13:1945:18 | i64_ge |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1945:22:1945:37 | (...) |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1945:23:1945:27 | 11i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1945:23:1945:36 | ... >= ... |  | {EXTERNAL LOCATION} | bool |
+| main.rs:1945:32:1945:36 | 12i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1948:13:1948:19 | i64_add |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1948:23:1948:27 | 13i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1948:23:1948:35 | ... + ... |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1948:31:1948:35 | 14i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1949:13:1949:19 | i64_sub |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1949:23:1949:27 | 15i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1949:23:1949:35 | ... - ... |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1949:31:1949:35 | 16i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1950:13:1950:19 | i64_mul |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1950:23:1950:27 | 17i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1950:23:1950:35 | ... * ... |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1950:31:1950:35 | 18i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1951:13:1951:19 | i64_div |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1951:23:1951:27 | 19i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1951:23:1951:35 | ... / ... |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1951:31:1951:35 | 20i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1952:13:1952:19 | i64_rem |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1952:23:1952:27 | 21i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1952:23:1952:35 | ... % ... |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1952:31:1952:35 | 22i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1953:39:1953:42 | 1i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1953:45:1953:48 | 2i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1956:17:1956:30 | i64_add_assign |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1956:34:1956:38 | 23i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1957:9:1957:22 | i64_add_assign |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1957:9:1957:31 | ... += ... |  | file://:0:0:0:0 | () |
+| main.rs:1957:27:1957:31 | 24i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1959:17:1959:30 | i64_sub_assign |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1959:34:1959:38 | 25i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1960:9:1960:22 | i64_sub_assign |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1960:9:1960:31 | ... -= ... |  | file://:0:0:0:0 | () |
+| main.rs:1960:27:1960:31 | 26i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1962:17:1962:30 | i64_mul_assign |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1962:34:1962:38 | 27i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1963:9:1963:22 | i64_mul_assign |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1963:9:1963:31 | ... *= ... |  | file://:0:0:0:0 | () |
+| main.rs:1963:27:1963:31 | 28i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1965:17:1965:30 | i64_div_assign |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1965:34:1965:38 | 29i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1966:9:1966:22 | i64_div_assign |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1966:9:1966:31 | ... /= ... |  | file://:0:0:0:0 | () |
+| main.rs:1966:27:1966:31 | 30i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1968:17:1968:30 | i64_rem_assign |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1968:34:1968:38 | 31i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1969:9:1969:22 | i64_rem_assign |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1969:9:1969:31 | ... %= ... |  | file://:0:0:0:0 | () |
+| main.rs:1969:27:1969:31 | 32i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1972:13:1972:22 | i64_bitand |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1972:26:1972:30 | 33i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1972:26:1972:38 | ... & ... |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1972:34:1972:38 | 34i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1973:13:1973:21 | i64_bitor |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1973:25:1973:29 | 35i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1973:25:1973:37 | ... \| ... |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1973:33:1973:37 | 36i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1974:13:1974:22 | i64_bitxor |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1974:26:1974:30 | 37i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1974:26:1974:38 | ... ^ ... |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1974:34:1974:38 | 38i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1975:13:1975:19 | i64_shl |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1975:23:1975:27 | 39i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1975:23:1975:36 | ... << ... |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1975:32:1975:36 | 40i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1976:13:1976:19 | i64_shr |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1976:23:1976:27 | 41i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1976:23:1976:36 | ... >> ... |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1976:32:1976:36 | 42i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1979:17:1979:33 | i64_bitand_assign |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1979:37:1979:41 | 43i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1980:9:1980:25 | i64_bitand_assign |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1980:9:1980:34 | ... &= ... |  | file://:0:0:0:0 | () |
+| main.rs:1980:30:1980:34 | 44i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1982:17:1982:32 | i64_bitor_assign |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1982:36:1982:40 | 45i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1983:9:1983:24 | i64_bitor_assign |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1983:9:1983:33 | ... \|= ... |  | file://:0:0:0:0 | () |
+| main.rs:1983:29:1983:33 | 46i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1985:17:1985:33 | i64_bitxor_assign |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1985:37:1985:41 | 47i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1986:9:1986:25 | i64_bitxor_assign |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1986:9:1986:34 | ... ^= ... |  | file://:0:0:0:0 | () |
+| main.rs:1986:30:1986:34 | 48i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1988:17:1988:30 | i64_shl_assign |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1988:34:1988:38 | 49i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1989:9:1989:22 | i64_shl_assign |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1989:9:1989:32 | ... <<= ... |  | file://:0:0:0:0 | () |
+| main.rs:1989:28:1989:32 | 50i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1991:17:1991:30 | i64_shr_assign |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1991:34:1991:38 | 51i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1992:9:1992:22 | i64_shr_assign |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1992:9:1992:32 | ... >>= ... |  | file://:0:0:0:0 | () |
+| main.rs:1992:28:1992:32 | 52i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1994:13:1994:19 | i64_neg |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1994:23:1994:28 | - ... |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1994:24:1994:28 | 53i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1995:13:1995:19 | i64_not |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1995:23:1995:28 | ! ... |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1995:24:1995:28 | 54i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1998:13:1998:14 | v1 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1998:18:1998:36 | Vec2 {...} |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1998:28:1998:28 | 1 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:1998:28:1998:28 | 1 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1998:34:1998:34 | 2 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:1998:34:1998:34 | 2 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1999:13:1999:14 | v2 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1999:18:1999:36 | Vec2 {...} |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:1999:28:1999:28 | 3 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:1999:28:1999:28 | 3 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:1999:34:1999:34 | 4 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:1999:34:1999:34 | 4 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2002:13:2002:19 | vec2_eq |  | {EXTERNAL LOCATION} | bool |
+| main.rs:2002:23:2002:24 | v1 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2002:23:2002:30 | ... == ... |  | {EXTERNAL LOCATION} | bool |
+| main.rs:2002:29:2002:30 | v2 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2003:13:2003:19 | vec2_ne |  | {EXTERNAL LOCATION} | bool |
+| main.rs:2003:23:2003:24 | v1 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2003:23:2003:30 | ... != ... |  | {EXTERNAL LOCATION} | bool |
+| main.rs:2003:29:2003:30 | v2 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2004:13:2004:19 | vec2_lt |  | {EXTERNAL LOCATION} | bool |
+| main.rs:2004:23:2004:24 | v1 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2004:23:2004:29 | ... < ... |  | {EXTERNAL LOCATION} | bool |
+| main.rs:2004:28:2004:29 | v2 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2005:13:2005:19 | vec2_le |  | {EXTERNAL LOCATION} | bool |
+| main.rs:2005:23:2005:24 | v1 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2005:23:2005:30 | ... <= ... |  | {EXTERNAL LOCATION} | bool |
+| main.rs:2005:29:2005:30 | v2 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2006:13:2006:19 | vec2_gt |  | {EXTERNAL LOCATION} | bool |
+| main.rs:2006:23:2006:24 | v1 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2006:23:2006:29 | ... > ... |  | {EXTERNAL LOCATION} | bool |
+| main.rs:2006:28:2006:29 | v2 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2007:13:2007:19 | vec2_ge |  | {EXTERNAL LOCATION} | bool |
+| main.rs:2007:23:2007:24 | v1 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2007:23:2007:30 | ... >= ... |  | {EXTERNAL LOCATION} | bool |
+| main.rs:2007:29:2007:30 | v2 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2010:13:2010:20 | vec2_add |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2010:24:2010:25 | v1 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2010:24:2010:30 | ... + ... |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2010:29:2010:30 | v2 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2011:13:2011:20 | vec2_sub |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2011:24:2011:25 | v1 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2011:24:2011:30 | ... - ... |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2011:29:2011:30 | v2 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2012:13:2012:20 | vec2_mul |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2012:24:2012:25 | v1 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2012:24:2012:30 | ... * ... |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2012:29:2012:30 | v2 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2013:13:2013:20 | vec2_div |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2013:24:2013:25 | v1 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2013:24:2013:30 | ... / ... |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2013:29:2013:30 | v2 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2014:13:2014:20 | vec2_rem |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2014:24:2014:25 | v1 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2014:24:2014:30 | ... % ... |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2014:29:2014:30 | v2 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2017:17:2017:31 | vec2_add_assign |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2017:35:2017:36 | v1 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2018:9:2018:23 | vec2_add_assign |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2018:9:2018:29 | ... += ... |  | file://:0:0:0:0 | () |
+| main.rs:2018:28:2018:29 | v2 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2020:17:2020:31 | vec2_sub_assign |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2020:35:2020:36 | v1 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2021:9:2021:23 | vec2_sub_assign |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2021:9:2021:29 | ... -= ... |  | file://:0:0:0:0 | () |
+| main.rs:2021:28:2021:29 | v2 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2023:17:2023:31 | vec2_mul_assign |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2023:35:2023:36 | v1 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2024:9:2024:23 | vec2_mul_assign |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2024:9:2024:29 | ... *= ... |  | file://:0:0:0:0 | () |
+| main.rs:2024:28:2024:29 | v2 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2026:17:2026:31 | vec2_div_assign |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2026:35:2026:36 | v1 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2027:9:2027:23 | vec2_div_assign |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2027:9:2027:29 | ... /= ... |  | file://:0:0:0:0 | () |
+| main.rs:2027:28:2027:29 | v2 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2029:17:2029:31 | vec2_rem_assign |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2029:35:2029:36 | v1 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2030:9:2030:23 | vec2_rem_assign |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2030:9:2030:29 | ... %= ... |  | file://:0:0:0:0 | () |
+| main.rs:2030:28:2030:29 | v2 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2033:13:2033:23 | vec2_bitand |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2033:27:2033:28 | v1 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2033:27:2033:33 | ... & ... |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2033:32:2033:33 | v2 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2034:13:2034:22 | vec2_bitor |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2034:26:2034:27 | v1 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2034:26:2034:32 | ... \| ... |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2034:31:2034:32 | v2 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2035:13:2035:23 | vec2_bitxor |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2035:27:2035:28 | v1 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2035:27:2035:33 | ... ^ ... |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2035:32:2035:33 | v2 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2036:13:2036:20 | vec2_shl |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2036:24:2036:25 | v1 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2036:24:2036:33 | ... << ... |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2036:30:2036:33 | 1u32 |  | {EXTERNAL LOCATION} | u32 |
+| main.rs:2037:13:2037:20 | vec2_shr |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2037:24:2037:25 | v1 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2037:24:2037:33 | ... >> ... |  | main.rs:1695:5:1700:5 | Vec2 |
 | main.rs:2037:30:2037:33 | 1u32 |  | {EXTERNAL LOCATION} | u32 |
-| main.rs:2038:13:2038:20 | vec2_shr |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2038:24:2038:25 | v1 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2038:24:2038:33 | ... >> ... |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2038:30:2038:33 | 1u32 |  | {EXTERNAL LOCATION} | u32 |
-| main.rs:2041:17:2041:34 | vec2_bitand_assign |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2041:38:2041:39 | v1 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2042:9:2042:26 | vec2_bitand_assign |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2042:9:2042:32 | ... &= ... |  | file://:0:0:0:0 | () |
-| main.rs:2042:31:2042:32 | v2 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2044:17:2044:33 | vec2_bitor_assign |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2044:37:2044:38 | v1 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2045:9:2045:25 | vec2_bitor_assign |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2045:9:2045:31 | ... \|= ... |  | file://:0:0:0:0 | () |
-| main.rs:2045:30:2045:31 | v2 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2047:17:2047:34 | vec2_bitxor_assign |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2047:38:2047:39 | v1 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2048:9:2048:26 | vec2_bitxor_assign |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2048:9:2048:32 | ... ^= ... |  | file://:0:0:0:0 | () |
-| main.rs:2048:31:2048:32 | v2 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2050:17:2050:31 | vec2_shl_assign |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2050:35:2050:36 | v1 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2051:9:2051:23 | vec2_shl_assign |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2051:9:2051:32 | ... <<= ... |  | file://:0:0:0:0 | () |
-| main.rs:2051:29:2051:32 | 1u32 |  | {EXTERNAL LOCATION} | u32 |
-| main.rs:2053:17:2053:31 | vec2_shr_assign |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2053:35:2053:36 | v1 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2054:9:2054:23 | vec2_shr_assign |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2054:9:2054:32 | ... >>= ... |  | file://:0:0:0:0 | () |
-| main.rs:2054:29:2054:32 | 1u32 |  | {EXTERNAL LOCATION} | u32 |
-| main.rs:2057:13:2057:20 | vec2_neg |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2057:24:2057:26 | - ... |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2057:25:2057:26 | v1 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2058:13:2058:20 | vec2_not |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2058:24:2058:26 | ! ... |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2058:25:2058:26 | v1 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2061:13:2061:24 | default_vec2 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2061:28:2061:45 | ...::default(...) |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2062:13:2062:26 | vec2_zero_plus |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2062:30:2062:48 | Vec2 {...} |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2062:30:2062:63 | ... + ... |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2062:40:2062:40 | 0 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2062:40:2062:40 | 0 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2062:46:2062:46 | 0 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2062:46:2062:46 | 0 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2062:52:2062:63 | default_vec2 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2066:13:2066:24 | default_vec2 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2066:28:2066:45 | ...::default(...) |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2067:13:2067:26 | vec2_zero_plus |  | {EXTERNAL LOCATION} | bool |
-| main.rs:2067:30:2067:48 | Vec2 {...} |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2067:30:2067:64 | ... == ... |  | {EXTERNAL LOCATION} | bool |
-| main.rs:2067:40:2067:40 | 0 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2067:40:2067:40 | 0 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2067:46:2067:46 | 0 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2067:46:2067:46 | 0 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2067:53:2067:64 | default_vec2 |  | main.rs:1696:5:1701:5 | Vec2 |
-| main.rs:2077:18:2077:21 | SelfParam |  | main.rs:2074:5:2074:14 | S1 |
-| main.rs:2080:25:2082:5 | { ... } |  | main.rs:2074:5:2074:14 | S1 |
-| main.rs:2081:9:2081:10 | S1 |  | main.rs:2074:5:2074:14 | S1 |
-| main.rs:2084:41:2086:5 | { ... } |  | main.rs:2084:16:2084:39 | impl ... |
-| main.rs:2085:9:2085:20 | { ... } |  | {EXTERNAL LOCATION} | trait Future |
-| main.rs:2085:9:2085:20 | { ... } | Output | main.rs:2074:5:2074:14 | S1 |
-| main.rs:2085:17:2085:18 | S1 |  | main.rs:2074:5:2074:14 | S1 |
-| main.rs:2094:13:2094:42 | SelfParam |  | {EXTERNAL LOCATION} | Pin |
-| main.rs:2094:13:2094:42 | SelfParam | Ptr | file://:0:0:0:0 | & |
-| main.rs:2094:13:2094:42 | SelfParam | Ptr.&T | main.rs:2088:5:2088:14 | S2 |
-| main.rs:2095:13:2095:15 | _cx |  | file://:0:0:0:0 | & |
-| main.rs:2095:13:2095:15 | _cx | &T | {EXTERNAL LOCATION} | Context |
-| main.rs:2096:44:2098:9 | { ... } |  | {EXTERNAL LOCATION} | Poll |
-| main.rs:2096:44:2098:9 | { ... } | T | main.rs:2074:5:2074:14 | S1 |
-| main.rs:2097:13:2097:38 | ...::Ready(...) |  | {EXTERNAL LOCATION} | Poll |
-| main.rs:2097:13:2097:38 | ...::Ready(...) | T | main.rs:2074:5:2074:14 | S1 |
-| main.rs:2097:36:2097:37 | S1 |  | main.rs:2074:5:2074:14 | S1 |
-| main.rs:2101:41:2103:5 | { ... } |  | main.rs:2101:16:2101:39 | impl ... |
-| main.rs:2102:9:2102:10 | S2 |  | main.rs:2088:5:2088:14 | S2 |
-| main.rs:2102:9:2102:10 | S2 |  | main.rs:2101:16:2101:39 | impl ... |
-| main.rs:2106:9:2106:12 | f1(...) |  | {EXTERNAL LOCATION} | trait Future |
-| main.rs:2106:9:2106:12 | f1(...) | Output | main.rs:2074:5:2074:14 | S1 |
-| main.rs:2106:9:2106:18 | await ... |  | main.rs:2074:5:2074:14 | S1 |
-| main.rs:2107:9:2107:12 | f2(...) |  | main.rs:2084:16:2084:39 | impl ... |
-| main.rs:2107:9:2107:18 | await ... |  | main.rs:2074:5:2074:14 | S1 |
-| main.rs:2108:9:2108:12 | f3(...) |  | main.rs:2101:16:2101:39 | impl ... |
-| main.rs:2108:9:2108:18 | await ... |  | main.rs:2074:5:2074:14 | S1 |
-| main.rs:2109:9:2109:10 | S2 |  | main.rs:2088:5:2088:14 | S2 |
-| main.rs:2109:9:2109:16 | await S2 |  | main.rs:2074:5:2074:14 | S1 |
-| main.rs:2110:13:2110:13 | b |  | {EXTERNAL LOCATION} | trait Future |
-| main.rs:2110:13:2110:13 | b | Output | main.rs:2074:5:2074:14 | S1 |
-| main.rs:2110:17:2110:28 | { ... } |  | {EXTERNAL LOCATION} | trait Future |
-| main.rs:2110:17:2110:28 | { ... } | Output | main.rs:2074:5:2074:14 | S1 |
-| main.rs:2110:25:2110:26 | S1 |  | main.rs:2074:5:2074:14 | S1 |
-| main.rs:2111:9:2111:9 | b |  | {EXTERNAL LOCATION} | trait Future |
-| main.rs:2111:9:2111:9 | b | Output | main.rs:2074:5:2074:14 | S1 |
-| main.rs:2111:9:2111:15 | await b |  | main.rs:2074:5:2074:14 | S1 |
-| main.rs:2122:15:2122:19 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:2122:15:2122:19 | SelfParam | &T | main.rs:2121:5:2123:5 | Self [trait Trait1] |
-| main.rs:2126:15:2126:19 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:2126:15:2126:19 | SelfParam | &T | main.rs:2125:5:2127:5 | Self [trait Trait2] |
-| main.rs:2130:15:2130:19 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:2130:15:2130:19 | SelfParam | &T | main.rs:2116:5:2117:14 | S1 |
-| main.rs:2134:15:2134:19 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:2134:15:2134:19 | SelfParam | &T | main.rs:2116:5:2117:14 | S1 |
-| main.rs:2137:37:2139:5 | { ... } |  | main.rs:2137:16:2137:35 | impl ... + ... |
-| main.rs:2138:9:2138:10 | S1 |  | main.rs:2116:5:2117:14 | S1 |
-| main.rs:2138:9:2138:10 | S1 |  | main.rs:2137:16:2137:35 | impl ... + ... |
-| main.rs:2142:18:2142:22 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:2142:18:2142:22 | SelfParam | &T | main.rs:2141:5:2143:5 | Self [trait MyTrait] |
-| main.rs:2146:18:2146:22 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:2146:18:2146:22 | SelfParam | &T | main.rs:2116:5:2117:14 | S1 |
-| main.rs:2146:31:2148:9 | { ... } |  | main.rs:2118:5:2118:14 | S2 |
-| main.rs:2147:13:2147:14 | S2 |  | main.rs:2118:5:2118:14 | S2 |
-| main.rs:2152:18:2152:22 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:2152:18:2152:22 | SelfParam | &T | main.rs:2119:5:2119:22 | S3 |
-| main.rs:2152:18:2152:22 | SelfParam | &T.T3 | main.rs:2151:10:2151:17 | T |
-| main.rs:2152:30:2155:9 | { ... } |  | main.rs:2151:10:2151:17 | T |
-| main.rs:2153:17:2153:21 | S3(...) |  | file://:0:0:0:0 | & |
-| main.rs:2153:17:2153:21 | S3(...) |  | main.rs:2119:5:2119:22 | S3 |
-| main.rs:2153:17:2153:21 | S3(...) | &T | main.rs:2119:5:2119:22 | S3 |
-| main.rs:2153:17:2153:21 | S3(...) | &T.T3 | main.rs:2151:10:2151:17 | T |
-| main.rs:2153:25:2153:28 | self |  | file://:0:0:0:0 | & |
-| main.rs:2153:25:2153:28 | self | &T | main.rs:2119:5:2119:22 | S3 |
-| main.rs:2153:25:2153:28 | self | &T.T3 | main.rs:2151:10:2151:17 | T |
-| main.rs:2154:13:2154:21 | t.clone() |  | main.rs:2151:10:2151:17 | T |
-| main.rs:2158:45:2160:5 | { ... } |  | main.rs:2158:28:2158:43 | impl ... |
-| main.rs:2159:9:2159:10 | S1 |  | main.rs:2116:5:2117:14 | S1 |
-| main.rs:2159:9:2159:10 | S1 |  | main.rs:2158:28:2158:43 | impl ... |
-| main.rs:2162:41:2162:41 | t |  | main.rs:2162:26:2162:38 | B |
-| main.rs:2162:52:2164:5 | { ... } |  | main.rs:2162:23:2162:23 | A |
-| main.rs:2163:9:2163:9 | t |  | main.rs:2162:26:2162:38 | B |
-| main.rs:2163:9:2163:17 | t.get_a() |  | main.rs:2162:23:2162:23 | A |
-| main.rs:2166:34:2166:34 | x |  | main.rs:2166:24:2166:31 | T |
-| main.rs:2166:59:2168:5 | { ... } |  | main.rs:2166:43:2166:57 | impl ... |
-| main.rs:2166:59:2168:5 | { ... } | impl(T) | main.rs:2166:24:2166:31 | T |
-| main.rs:2167:9:2167:13 | S3(...) |  | main.rs:2119:5:2119:22 | S3 |
-| main.rs:2167:9:2167:13 | S3(...) |  | main.rs:2166:43:2166:57 | impl ... |
-| main.rs:2167:9:2167:13 | S3(...) | T3 | main.rs:2166:24:2166:31 | T |
-| main.rs:2167:9:2167:13 | S3(...) | impl(T) | main.rs:2166:24:2166:31 | T |
-| main.rs:2167:12:2167:12 | x |  | main.rs:2166:24:2166:31 | T |
-| main.rs:2170:34:2170:34 | x |  | main.rs:2170:24:2170:31 | T |
-| main.rs:2170:67:2172:5 | { ... } |  | {EXTERNAL LOCATION} | Option |
-| main.rs:2170:67:2172:5 | { ... } | T | main.rs:2170:50:2170:64 | impl ... |
-| main.rs:2170:67:2172:5 | { ... } | T.impl(T) | main.rs:2170:24:2170:31 | T |
-| main.rs:2171:9:2171:19 | Some(...) |  | {EXTERNAL LOCATION} | Option |
-| main.rs:2171:9:2171:19 | Some(...) | T | main.rs:2119:5:2119:22 | S3 |
-| main.rs:2171:9:2171:19 | Some(...) | T | main.rs:2170:50:2170:64 | impl ... |
-| main.rs:2171:9:2171:19 | Some(...) | T.T3 | main.rs:2170:24:2170:31 | T |
-| main.rs:2171:9:2171:19 | Some(...) | T.impl(T) | main.rs:2170:24:2170:31 | T |
-| main.rs:2171:14:2171:18 | S3(...) |  | main.rs:2119:5:2119:22 | S3 |
-| main.rs:2171:14:2171:18 | S3(...) |  | main.rs:2170:50:2170:64 | impl ... |
-| main.rs:2171:14:2171:18 | S3(...) | T3 | main.rs:2170:24:2170:31 | T |
-| main.rs:2171:14:2171:18 | S3(...) | impl(T) | main.rs:2170:24:2170:31 | T |
-| main.rs:2171:17:2171:17 | x |  | main.rs:2170:24:2170:31 | T |
-| main.rs:2174:34:2174:34 | x |  | main.rs:2174:24:2174:31 | T |
-| main.rs:2174:78:2176:5 | { ... } |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2174:78:2176:5 | { ... } | 0(2) | main.rs:2174:44:2174:58 | impl ... |
-| main.rs:2174:78:2176:5 | { ... } | 0(2).impl(T) | main.rs:2174:24:2174:31 | T |
-| main.rs:2174:78:2176:5 | { ... } | 1(2) | main.rs:2174:61:2174:75 | impl ... |
-| main.rs:2174:78:2176:5 | { ... } | 1(2).impl(T) | main.rs:2174:24:2174:31 | T |
-| main.rs:2175:9:2175:30 | TupleExpr |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2175:9:2175:30 | TupleExpr | 0(2) | main.rs:2119:5:2119:22 | S3 |
-| main.rs:2175:9:2175:30 | TupleExpr | 0(2) | main.rs:2174:44:2174:58 | impl ... |
-| main.rs:2175:9:2175:30 | TupleExpr | 0(2).T3 | main.rs:2174:24:2174:31 | T |
-| main.rs:2175:9:2175:30 | TupleExpr | 0(2).impl(T) | main.rs:2174:24:2174:31 | T |
-| main.rs:2175:9:2175:30 | TupleExpr | 1(2) | main.rs:2119:5:2119:22 | S3 |
-| main.rs:2175:9:2175:30 | TupleExpr | 1(2) | main.rs:2174:61:2174:75 | impl ... |
-| main.rs:2175:9:2175:30 | TupleExpr | 1(2).T3 | main.rs:2174:24:2174:31 | T |
-| main.rs:2175:9:2175:30 | TupleExpr | 1(2).impl(T) | main.rs:2174:24:2174:31 | T |
-| main.rs:2175:10:2175:22 | S3(...) |  | main.rs:2119:5:2119:22 | S3 |
-| main.rs:2175:10:2175:22 | S3(...) |  | main.rs:2174:44:2174:58 | impl ... |
-| main.rs:2175:10:2175:22 | S3(...) | T3 | main.rs:2174:24:2174:31 | T |
-| main.rs:2175:10:2175:22 | S3(...) | impl(T) | main.rs:2174:24:2174:31 | T |
-| main.rs:2175:13:2175:13 | x |  | main.rs:2174:24:2174:31 | T |
-| main.rs:2175:13:2175:21 | x.clone() |  | main.rs:2174:24:2174:31 | T |
-| main.rs:2175:25:2175:29 | S3(...) |  | main.rs:2119:5:2119:22 | S3 |
-| main.rs:2175:25:2175:29 | S3(...) |  | main.rs:2174:61:2174:75 | impl ... |
-| main.rs:2175:25:2175:29 | S3(...) | T3 | main.rs:2174:24:2174:31 | T |
-| main.rs:2175:25:2175:29 | S3(...) | impl(T) | main.rs:2174:24:2174:31 | T |
-| main.rs:2175:28:2175:28 | x |  | main.rs:2174:24:2174:31 | T |
-| main.rs:2178:26:2178:26 | t |  | main.rs:2178:29:2178:43 | impl ... |
-| main.rs:2178:51:2180:5 | { ... } |  | main.rs:2178:23:2178:23 | A |
-| main.rs:2179:9:2179:9 | t |  | main.rs:2178:29:2178:43 | impl ... |
-| main.rs:2179:9:2179:17 | t.get_a() |  | main.rs:2178:23:2178:23 | A |
-| main.rs:2183:13:2183:13 | x |  | main.rs:2137:16:2137:35 | impl ... + ... |
-| main.rs:2183:17:2183:20 | f1(...) |  | main.rs:2137:16:2137:35 | impl ... + ... |
-| main.rs:2184:9:2184:9 | x |  | main.rs:2137:16:2137:35 | impl ... + ... |
-| main.rs:2185:9:2185:9 | x |  | main.rs:2137:16:2137:35 | impl ... + ... |
-| main.rs:2186:13:2186:13 | a |  | main.rs:2158:28:2158:43 | impl ... |
-| main.rs:2186:17:2186:32 | get_a_my_trait(...) |  | main.rs:2158:28:2158:43 | impl ... |
-| main.rs:2187:13:2187:13 | b |  | main.rs:2118:5:2118:14 | S2 |
-| main.rs:2187:17:2187:33 | uses_my_trait1(...) |  | main.rs:2118:5:2118:14 | S2 |
-| main.rs:2187:32:2187:32 | a |  | main.rs:2158:28:2158:43 | impl ... |
-| main.rs:2188:13:2188:13 | a |  | main.rs:2158:28:2158:43 | impl ... |
-| main.rs:2188:17:2188:32 | get_a_my_trait(...) |  | main.rs:2158:28:2158:43 | impl ... |
-| main.rs:2189:13:2189:13 | c |  | main.rs:2118:5:2118:14 | S2 |
-| main.rs:2189:17:2189:33 | uses_my_trait2(...) |  | main.rs:2118:5:2118:14 | S2 |
-| main.rs:2189:32:2189:32 | a |  | main.rs:2158:28:2158:43 | impl ... |
-| main.rs:2190:13:2190:13 | d |  | main.rs:2118:5:2118:14 | S2 |
-| main.rs:2190:17:2190:34 | uses_my_trait2(...) |  | main.rs:2118:5:2118:14 | S2 |
-| main.rs:2190:32:2190:33 | S1 |  | main.rs:2116:5:2117:14 | S1 |
-| main.rs:2191:13:2191:13 | e |  | main.rs:2116:5:2117:14 | S1 |
-| main.rs:2191:17:2191:35 | get_a_my_trait2(...) |  | main.rs:2166:43:2166:57 | impl ... |
-| main.rs:2191:17:2191:35 | get_a_my_trait2(...) | impl(T) | main.rs:2116:5:2117:14 | S1 |
-| main.rs:2191:17:2191:43 | ... .get_a() |  | main.rs:2116:5:2117:14 | S1 |
-| main.rs:2191:33:2191:34 | S1 |  | main.rs:2116:5:2117:14 | S1 |
-| main.rs:2194:13:2194:13 | f |  | main.rs:2116:5:2117:14 | S1 |
-| main.rs:2194:17:2194:35 | get_a_my_trait3(...) |  | {EXTERNAL LOCATION} | Option |
-| main.rs:2194:17:2194:35 | get_a_my_trait3(...) | T | main.rs:2170:50:2170:64 | impl ... |
-| main.rs:2194:17:2194:35 | get_a_my_trait3(...) | T.impl(T) | main.rs:2116:5:2117:14 | S1 |
-| main.rs:2194:17:2194:44 | ... .unwrap() |  | main.rs:2170:50:2170:64 | impl ... |
-| main.rs:2194:17:2194:44 | ... .unwrap() | impl(T) | main.rs:2116:5:2117:14 | S1 |
-| main.rs:2194:17:2194:52 | ... .get_a() |  | main.rs:2116:5:2117:14 | S1 |
-| main.rs:2194:33:2194:34 | S1 |  | main.rs:2116:5:2117:14 | S1 |
-| main.rs:2195:13:2195:13 | g |  | main.rs:2116:5:2117:14 | S1 |
-| main.rs:2195:17:2195:35 | get_a_my_trait4(...) |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2195:17:2195:35 | get_a_my_trait4(...) | 0(2) | main.rs:2174:44:2174:58 | impl ... |
-| main.rs:2195:17:2195:35 | get_a_my_trait4(...) | 0(2).impl(T) | main.rs:2116:5:2117:14 | S1 |
-| main.rs:2195:17:2195:35 | get_a_my_trait4(...) | 1(2) | main.rs:2174:61:2174:75 | impl ... |
-| main.rs:2195:17:2195:35 | get_a_my_trait4(...) | 1(2).impl(T) | main.rs:2116:5:2117:14 | S1 |
-| main.rs:2195:17:2195:37 | ... .0 |  | main.rs:2174:44:2174:58 | impl ... |
-| main.rs:2195:17:2195:37 | ... .0 | impl(T) | main.rs:2116:5:2117:14 | S1 |
-| main.rs:2195:17:2195:45 | ... .get_a() |  | main.rs:2116:5:2117:14 | S1 |
-| main.rs:2195:33:2195:34 | S1 |  | main.rs:2116:5:2117:14 | S1 |
-| main.rs:2206:16:2206:20 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:2206:16:2206:20 | SelfParam | &T | main.rs:2202:5:2203:13 | S |
-| main.rs:2206:31:2208:9 | { ... } |  | main.rs:2202:5:2203:13 | S |
-| main.rs:2207:13:2207:13 | S |  | main.rs:2202:5:2203:13 | S |
-| main.rs:2217:26:2219:9 | { ... } |  | main.rs:2211:5:2214:5 | MyVec |
-| main.rs:2217:26:2219:9 | { ... } | T | main.rs:2216:10:2216:10 | T |
-| main.rs:2218:13:2218:38 | MyVec {...} |  | main.rs:2211:5:2214:5 | MyVec |
-| main.rs:2218:13:2218:38 | MyVec {...} | T | main.rs:2216:10:2216:10 | T |
-| main.rs:2218:27:2218:36 | ...::new(...) |  | {EXTERNAL LOCATION} | Vec |
-| main.rs:2218:27:2218:36 | ...::new(...) | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2218:27:2218:36 | ...::new(...) | T | main.rs:2216:10:2216:10 | T |
-| main.rs:2221:17:2221:25 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:2221:17:2221:25 | SelfParam | &T | main.rs:2211:5:2214:5 | MyVec |
-| main.rs:2221:17:2221:25 | SelfParam | &T.T | main.rs:2216:10:2216:10 | T |
-| main.rs:2221:28:2221:32 | value |  | main.rs:2216:10:2216:10 | T |
-| main.rs:2222:13:2222:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:2222:13:2222:16 | self | &T | main.rs:2211:5:2214:5 | MyVec |
-| main.rs:2222:13:2222:16 | self | &T.T | main.rs:2216:10:2216:10 | T |
-| main.rs:2222:13:2222:21 | self.data |  | {EXTERNAL LOCATION} | Vec |
-| main.rs:2222:13:2222:21 | self.data | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2222:13:2222:21 | self.data | T | main.rs:2216:10:2216:10 | T |
-| main.rs:2222:28:2222:32 | value |  | main.rs:2216:10:2216:10 | T |
-| main.rs:2230:18:2230:22 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:2230:18:2230:22 | SelfParam | &T | main.rs:2211:5:2214:5 | MyVec |
-| main.rs:2230:18:2230:22 | SelfParam | &T.T | main.rs:2226:10:2226:10 | T |
-| main.rs:2230:25:2230:29 | index |  | {EXTERNAL LOCATION} | usize |
-| main.rs:2230:56:2232:9 | { ... } |  | file://:0:0:0:0 | & |
-| main.rs:2230:56:2232:9 | { ... } | &T | main.rs:2226:10:2226:10 | T |
-| main.rs:2231:13:2231:29 | &... |  | file://:0:0:0:0 | & |
-| main.rs:2231:13:2231:29 | &... | &T | main.rs:2226:10:2226:10 | T |
-| main.rs:2231:14:2231:17 | self |  | file://:0:0:0:0 | & |
-| main.rs:2231:14:2231:17 | self | &T | main.rs:2211:5:2214:5 | MyVec |
-| main.rs:2231:14:2231:17 | self | &T.T | main.rs:2226:10:2226:10 | T |
-| main.rs:2231:14:2231:22 | self.data |  | {EXTERNAL LOCATION} | Vec |
-| main.rs:2231:14:2231:22 | self.data | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2231:14:2231:22 | self.data | T | main.rs:2226:10:2226:10 | T |
-| main.rs:2231:14:2231:29 | ...[index] |  | main.rs:2226:10:2226:10 | T |
-| main.rs:2231:24:2231:28 | index |  | {EXTERNAL LOCATION} | usize |
-| main.rs:2235:22:2235:26 | slice |  | file://:0:0:0:0 | & |
-| main.rs:2235:22:2235:26 | slice | &T | file://:0:0:0:0 | [] |
-| main.rs:2235:22:2235:26 | slice | &T.[T] | main.rs:2202:5:2203:13 | S |
-| main.rs:2236:13:2236:13 | x |  | main.rs:2202:5:2203:13 | S |
-| main.rs:2236:17:2236:21 | slice |  | file://:0:0:0:0 | & |
-| main.rs:2236:17:2236:21 | slice | &T | file://:0:0:0:0 | [] |
-| main.rs:2236:17:2236:21 | slice | &T.[T] | main.rs:2202:5:2203:13 | S |
-| main.rs:2236:17:2236:24 | slice[0] |  | main.rs:2202:5:2203:13 | S |
-| main.rs:2236:17:2236:30 | ... .foo() |  | main.rs:2202:5:2203:13 | S |
-| main.rs:2236:23:2236:23 | 0 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2239:37:2239:37 | a |  | main.rs:2239:20:2239:34 | T |
-| main.rs:2239:43:2239:43 | b |  | {EXTERNAL LOCATION} | usize |
-| main.rs:2242:5:2244:5 | { ... } |  | {EXTERNAL LOCATION} | Output |
-| main.rs:2243:9:2243:9 | a |  | main.rs:2239:20:2239:34 | T |
-| main.rs:2243:9:2243:12 | a[b] |  | {EXTERNAL LOCATION} | Output |
-| main.rs:2243:11:2243:11 | b |  | {EXTERNAL LOCATION} | usize |
-| main.rs:2247:17:2247:19 | vec |  | main.rs:2211:5:2214:5 | MyVec |
-| main.rs:2247:17:2247:19 | vec | T | main.rs:2202:5:2203:13 | S |
-| main.rs:2247:23:2247:34 | ...::new(...) |  | main.rs:2211:5:2214:5 | MyVec |
-| main.rs:2247:23:2247:34 | ...::new(...) | T | main.rs:2202:5:2203:13 | S |
-| main.rs:2248:9:2248:11 | vec |  | main.rs:2211:5:2214:5 | MyVec |
-| main.rs:2248:9:2248:11 | vec | T | main.rs:2202:5:2203:13 | S |
-| main.rs:2248:18:2248:18 | S |  | main.rs:2202:5:2203:13 | S |
-| main.rs:2249:9:2249:11 | vec |  | main.rs:2211:5:2214:5 | MyVec |
-| main.rs:2249:9:2249:11 | vec | T | main.rs:2202:5:2203:13 | S |
-| main.rs:2249:9:2249:14 | vec[0] |  | main.rs:2202:5:2203:13 | S |
-| main.rs:2249:9:2249:20 | ... .foo() |  | main.rs:2202:5:2203:13 | S |
-| main.rs:2249:13:2249:13 | 0 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2249:13:2249:13 | 0 |  | {EXTERNAL LOCATION} | usize |
-| main.rs:2251:13:2251:14 | xs |  | file://:0:0:0:0 | [] |
-| main.rs:2251:13:2251:14 | xs | [T;...] | main.rs:2202:5:2203:13 | S |
-| main.rs:2251:21:2251:21 | 1 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2251:26:2251:28 | [...] |  | file://:0:0:0:0 | [] |
-| main.rs:2251:26:2251:28 | [...] | [T;...] | main.rs:2202:5:2203:13 | S |
-| main.rs:2251:27:2251:27 | S |  | main.rs:2202:5:2203:13 | S |
-| main.rs:2252:13:2252:13 | x |  | main.rs:2202:5:2203:13 | S |
-| main.rs:2252:17:2252:18 | xs |  | file://:0:0:0:0 | [] |
-| main.rs:2252:17:2252:18 | xs | [T;...] | main.rs:2202:5:2203:13 | S |
-| main.rs:2252:17:2252:21 | xs[0] |  | main.rs:2202:5:2203:13 | S |
-| main.rs:2252:17:2252:27 | ... .foo() |  | main.rs:2202:5:2203:13 | S |
-| main.rs:2252:20:2252:20 | 0 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2254:29:2254:31 | vec |  | main.rs:2211:5:2214:5 | MyVec |
-| main.rs:2254:29:2254:31 | vec | T | main.rs:2202:5:2203:13 | S |
-| main.rs:2254:34:2254:34 | 0 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2254:34:2254:34 | 0 |  | {EXTERNAL LOCATION} | usize |
-| main.rs:2256:23:2256:25 | &xs |  | file://:0:0:0:0 | & |
-| main.rs:2256:23:2256:25 | &xs | &T | file://:0:0:0:0 | [] |
-| main.rs:2256:23:2256:25 | &xs | &T | file://:0:0:0:0 | [] |
-| main.rs:2256:23:2256:25 | &xs | &T.[T;...] | main.rs:2202:5:2203:13 | S |
-| main.rs:2256:23:2256:25 | &xs | &T.[T] | main.rs:2202:5:2203:13 | S |
-| main.rs:2256:24:2256:25 | xs |  | file://:0:0:0:0 | [] |
-| main.rs:2256:24:2256:25 | xs | [T;...] | main.rs:2202:5:2203:13 | S |
-| main.rs:2262:13:2262:13 | x |  | {EXTERNAL LOCATION} | String |
-| main.rs:2262:17:2262:46 | MacroExpr |  | {EXTERNAL LOCATION} | String |
-| main.rs:2262:25:2262:35 | "Hello, {}" |  | file://:0:0:0:0 | & |
-| main.rs:2262:25:2262:35 | "Hello, {}" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:2262:25:2262:45 | ...::format(...) |  | {EXTERNAL LOCATION} | String |
-| main.rs:2262:25:2262:45 | ...::must_use(...) |  | {EXTERNAL LOCATION} | String |
-| main.rs:2262:25:2262:45 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:2262:25:2262:45 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:2262:25:2262:45 | { ... } |  | {EXTERNAL LOCATION} | String |
-| main.rs:2262:38:2262:45 | "World!" |  | file://:0:0:0:0 | & |
-| main.rs:2262:38:2262:45 | "World!" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:2271:19:2271:22 | SelfParam |  | main.rs:2267:5:2272:5 | Self [trait MyAdd] |
-| main.rs:2271:25:2271:27 | rhs |  | main.rs:2267:17:2267:26 | Rhs |
-| main.rs:2278:19:2278:22 | SelfParam |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2278:25:2278:29 | value |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2278:45:2280:9 | { ... } |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2279:13:2279:17 | value |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2287:19:2287:22 | SelfParam |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2287:25:2287:29 | value |  | file://:0:0:0:0 | & |
-| main.rs:2287:25:2287:29 | value | &T | {EXTERNAL LOCATION} | i64 |
-| main.rs:2287:46:2289:9 | { ... } |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2288:13:2288:18 | * ... |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2288:14:2288:18 | value |  | file://:0:0:0:0 | & |
-| main.rs:2288:14:2288:18 | value | &T | {EXTERNAL LOCATION} | i64 |
-| main.rs:2296:19:2296:22 | SelfParam |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2296:25:2296:29 | value |  | {EXTERNAL LOCATION} | bool |
-| main.rs:2296:46:2302:9 | { ... } |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2297:13:2301:13 | if value {...} else {...} |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2297:13:2301:13 | if value {...} else {...} |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2297:16:2297:20 | value |  | {EXTERNAL LOCATION} | bool |
-| main.rs:2297:22:2299:13 | { ... } |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2297:22:2299:13 | { ... } |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2298:17:2298:17 | 1 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2298:17:2298:17 | 1 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2299:20:2301:13 | { ... } |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2299:20:2301:13 | { ... } |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2300:17:2300:17 | 0 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2300:17:2300:17 | 0 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2311:19:2311:22 | SelfParam |  | main.rs:2305:5:2305:19 | S |
-| main.rs:2311:19:2311:22 | SelfParam | T | main.rs:2307:10:2307:17 | T |
-| main.rs:2311:25:2311:29 | other |  | main.rs:2305:5:2305:19 | S |
-| main.rs:2311:25:2311:29 | other | T | main.rs:2307:10:2307:17 | T |
-| main.rs:2311:54:2313:9 | { ... } |  | main.rs:2305:5:2305:19 | S |
-| main.rs:2311:54:2313:9 | { ... } | T | main.rs:2268:9:2268:20 | Output |
-| main.rs:2312:13:2312:39 | S(...) |  | main.rs:2305:5:2305:19 | S |
-| main.rs:2312:13:2312:39 | S(...) | T | main.rs:2268:9:2268:20 | Output |
-| main.rs:2312:15:2312:22 | (...) |  | main.rs:2307:10:2307:17 | T |
-| main.rs:2312:15:2312:38 | ... .my_add(...) |  | main.rs:2268:9:2268:20 | Output |
-| main.rs:2312:16:2312:19 | self |  | main.rs:2305:5:2305:19 | S |
-| main.rs:2312:16:2312:19 | self | T | main.rs:2307:10:2307:17 | T |
-| main.rs:2312:16:2312:21 | self.0 |  | main.rs:2307:10:2307:17 | T |
-| main.rs:2312:31:2312:35 | other |  | main.rs:2305:5:2305:19 | S |
-| main.rs:2312:31:2312:35 | other | T | main.rs:2307:10:2307:17 | T |
-| main.rs:2312:31:2312:37 | other.0 |  | main.rs:2307:10:2307:17 | T |
-| main.rs:2320:19:2320:22 | SelfParam |  | main.rs:2305:5:2305:19 | S |
-| main.rs:2320:19:2320:22 | SelfParam | T | main.rs:2316:10:2316:17 | T |
-| main.rs:2320:25:2320:29 | other |  | main.rs:2316:10:2316:17 | T |
-| main.rs:2320:51:2322:9 | { ... } |  | main.rs:2305:5:2305:19 | S |
-| main.rs:2320:51:2322:9 | { ... } | T | main.rs:2268:9:2268:20 | Output |
-| main.rs:2321:13:2321:37 | S(...) |  | main.rs:2305:5:2305:19 | S |
-| main.rs:2321:13:2321:37 | S(...) | T | main.rs:2268:9:2268:20 | Output |
-| main.rs:2321:15:2321:22 | (...) |  | main.rs:2316:10:2316:17 | T |
-| main.rs:2321:15:2321:36 | ... .my_add(...) |  | main.rs:2268:9:2268:20 | Output |
-| main.rs:2321:16:2321:19 | self |  | main.rs:2305:5:2305:19 | S |
-| main.rs:2321:16:2321:19 | self | T | main.rs:2316:10:2316:17 | T |
-| main.rs:2321:16:2321:21 | self.0 |  | main.rs:2316:10:2316:17 | T |
-| main.rs:2321:31:2321:35 | other |  | main.rs:2316:10:2316:17 | T |
-| main.rs:2332:19:2332:22 | SelfParam |  | main.rs:2305:5:2305:19 | S |
-| main.rs:2332:19:2332:22 | SelfParam | T | main.rs:2325:14:2325:14 | T |
-| main.rs:2332:25:2332:29 | other |  | file://:0:0:0:0 | & |
-| main.rs:2332:25:2332:29 | other | &T | main.rs:2325:14:2325:14 | T |
-| main.rs:2332:55:2334:9 | { ... } |  | main.rs:2305:5:2305:19 | S |
-| main.rs:2333:13:2333:37 | S(...) |  | main.rs:2305:5:2305:19 | S |
-| main.rs:2333:15:2333:22 | (...) |  | main.rs:2325:14:2325:14 | T |
-| main.rs:2333:16:2333:19 | self |  | main.rs:2305:5:2305:19 | S |
-| main.rs:2333:16:2333:19 | self | T | main.rs:2325:14:2325:14 | T |
-| main.rs:2333:16:2333:21 | self.0 |  | main.rs:2325:14:2325:14 | T |
-| main.rs:2333:31:2333:35 | other |  | file://:0:0:0:0 | & |
-| main.rs:2333:31:2333:35 | other | &T | main.rs:2325:14:2325:14 | T |
-| main.rs:2339:20:2339:24 | value |  | main.rs:2337:18:2337:18 | T |
-| main.rs:2344:20:2344:24 | value |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2344:40:2346:9 | { ... } |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2345:13:2345:17 | value |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2351:20:2351:24 | value |  | {EXTERNAL LOCATION} | bool |
-| main.rs:2351:41:2357:9 | { ... } |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2352:13:2356:13 | if value {...} else {...} |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2352:13:2356:13 | if value {...} else {...} |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2352:16:2352:20 | value |  | {EXTERNAL LOCATION} | bool |
-| main.rs:2352:22:2354:13 | { ... } |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2352:22:2354:13 | { ... } |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2353:17:2353:17 | 1 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2353:17:2353:17 | 1 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2354:20:2356:13 | { ... } |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2354:20:2356:13 | { ... } |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2355:17:2355:17 | 0 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2355:17:2355:17 | 0 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2362:21:2362:25 | value |  | main.rs:2360:19:2360:19 | T |
-| main.rs:2362:31:2362:31 | x |  | main.rs:2360:5:2363:5 | Self [trait MyFrom2] |
-| main.rs:2367:21:2367:25 | value |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2367:33:2367:33 | _ |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2367:48:2369:9 | { ... } |  | file://:0:0:0:0 | () |
-| main.rs:2368:13:2368:17 | value |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2374:21:2374:25 | value |  | {EXTERNAL LOCATION} | bool |
-| main.rs:2374:34:2374:34 | _ |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2374:49:2380:9 | { ... } |  | file://:0:0:0:0 | () |
-| main.rs:2375:13:2379:13 | if value {...} else {...} |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2375:16:2375:20 | value |  | {EXTERNAL LOCATION} | bool |
-| main.rs:2375:22:2377:13 | { ... } |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2376:17:2376:17 | 1 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2377:20:2379:13 | { ... } |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2378:17:2378:17 | 0 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2385:15:2385:15 | x |  | main.rs:2383:5:2389:5 | Self [trait MySelfTrait] |
-| main.rs:2388:15:2388:15 | x |  | main.rs:2383:5:2389:5 | Self [trait MySelfTrait] |
-| main.rs:2393:15:2393:15 | x |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2393:31:2395:9 | { ... } |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2394:13:2394:13 | x |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2394:13:2394:17 | ... + ... |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2394:17:2394:17 | 1 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2398:15:2398:15 | x |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2398:32:2400:9 | { ... } |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2399:13:2399:13 | x |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2399:13:2399:17 | ... + ... |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2399:17:2399:17 | 1 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2405:15:2405:15 | x |  | {EXTERNAL LOCATION} | bool |
-| main.rs:2405:31:2407:9 | { ... } |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2406:13:2406:13 | 0 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2406:13:2406:13 | 0 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2410:15:2410:15 | x |  | {EXTERNAL LOCATION} | bool |
-| main.rs:2410:32:2412:9 | { ... } |  | {EXTERNAL LOCATION} | bool |
-| main.rs:2411:13:2411:13 | x |  | {EXTERNAL LOCATION} | bool |
-| main.rs:2416:13:2416:13 | x |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2416:22:2416:23 | 73 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2416:22:2416:23 | 73 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2040:17:2040:34 | vec2_bitand_assign |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2040:38:2040:39 | v1 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2041:9:2041:26 | vec2_bitand_assign |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2041:9:2041:32 | ... &= ... |  | file://:0:0:0:0 | () |
+| main.rs:2041:31:2041:32 | v2 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2043:17:2043:33 | vec2_bitor_assign |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2043:37:2043:38 | v1 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2044:9:2044:25 | vec2_bitor_assign |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2044:9:2044:31 | ... \|= ... |  | file://:0:0:0:0 | () |
+| main.rs:2044:30:2044:31 | v2 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2046:17:2046:34 | vec2_bitxor_assign |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2046:38:2046:39 | v1 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2047:9:2047:26 | vec2_bitxor_assign |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2047:9:2047:32 | ... ^= ... |  | file://:0:0:0:0 | () |
+| main.rs:2047:31:2047:32 | v2 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2049:17:2049:31 | vec2_shl_assign |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2049:35:2049:36 | v1 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2050:9:2050:23 | vec2_shl_assign |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2050:9:2050:32 | ... <<= ... |  | file://:0:0:0:0 | () |
+| main.rs:2050:29:2050:32 | 1u32 |  | {EXTERNAL LOCATION} | u32 |
+| main.rs:2052:17:2052:31 | vec2_shr_assign |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2052:35:2052:36 | v1 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2053:9:2053:23 | vec2_shr_assign |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2053:9:2053:32 | ... >>= ... |  | file://:0:0:0:0 | () |
+| main.rs:2053:29:2053:32 | 1u32 |  | {EXTERNAL LOCATION} | u32 |
+| main.rs:2056:13:2056:20 | vec2_neg |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2056:24:2056:26 | - ... |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2056:25:2056:26 | v1 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2057:13:2057:20 | vec2_not |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2057:24:2057:26 | ! ... |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2057:25:2057:26 | v1 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2060:13:2060:24 | default_vec2 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2060:28:2060:45 | ...::default(...) |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2061:13:2061:26 | vec2_zero_plus |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2061:30:2061:48 | Vec2 {...} |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2061:30:2061:63 | ... + ... |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2061:40:2061:40 | 0 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2061:40:2061:40 | 0 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2061:46:2061:46 | 0 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2061:46:2061:46 | 0 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2061:52:2061:63 | default_vec2 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2065:13:2065:24 | default_vec2 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2065:28:2065:45 | ...::default(...) |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2066:13:2066:26 | vec2_zero_plus |  | {EXTERNAL LOCATION} | bool |
+| main.rs:2066:30:2066:48 | Vec2 {...} |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2066:30:2066:64 | ... == ... |  | {EXTERNAL LOCATION} | bool |
+| main.rs:2066:40:2066:40 | 0 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2066:40:2066:40 | 0 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2066:46:2066:46 | 0 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2066:46:2066:46 | 0 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2066:53:2066:64 | default_vec2 |  | main.rs:1695:5:1700:5 | Vec2 |
+| main.rs:2076:18:2076:21 | SelfParam |  | main.rs:2073:5:2073:14 | S1 |
+| main.rs:2079:25:2081:5 | { ... } |  | main.rs:2073:5:2073:14 | S1 |
+| main.rs:2080:9:2080:10 | S1 |  | main.rs:2073:5:2073:14 | S1 |
+| main.rs:2083:41:2085:5 | { ... } |  | main.rs:2083:16:2083:39 | impl ... |
+| main.rs:2084:9:2084:20 | { ... } |  | {EXTERNAL LOCATION} | trait Future |
+| main.rs:2084:9:2084:20 | { ... } | Output | main.rs:2073:5:2073:14 | S1 |
+| main.rs:2084:17:2084:18 | S1 |  | main.rs:2073:5:2073:14 | S1 |
+| main.rs:2093:13:2093:42 | SelfParam |  | {EXTERNAL LOCATION} | Pin |
+| main.rs:2093:13:2093:42 | SelfParam | Ptr | file://:0:0:0:0 | & |
+| main.rs:2093:13:2093:42 | SelfParam | Ptr.&T | main.rs:2087:5:2087:14 | S2 |
+| main.rs:2094:13:2094:15 | _cx |  | file://:0:0:0:0 | & |
+| main.rs:2094:13:2094:15 | _cx | &T | {EXTERNAL LOCATION} | Context |
+| main.rs:2095:44:2097:9 | { ... } |  | {EXTERNAL LOCATION} | Poll |
+| main.rs:2095:44:2097:9 | { ... } | T | main.rs:2073:5:2073:14 | S1 |
+| main.rs:2096:13:2096:38 | ...::Ready(...) |  | {EXTERNAL LOCATION} | Poll |
+| main.rs:2096:13:2096:38 | ...::Ready(...) | T | main.rs:2073:5:2073:14 | S1 |
+| main.rs:2096:36:2096:37 | S1 |  | main.rs:2073:5:2073:14 | S1 |
+| main.rs:2100:41:2102:5 | { ... } |  | main.rs:2100:16:2100:39 | impl ... |
+| main.rs:2101:9:2101:10 | S2 |  | main.rs:2087:5:2087:14 | S2 |
+| main.rs:2101:9:2101:10 | S2 |  | main.rs:2100:16:2100:39 | impl ... |
+| main.rs:2105:9:2105:12 | f1(...) |  | {EXTERNAL LOCATION} | trait Future |
+| main.rs:2105:9:2105:12 | f1(...) | Output | main.rs:2073:5:2073:14 | S1 |
+| main.rs:2105:9:2105:18 | await ... |  | main.rs:2073:5:2073:14 | S1 |
+| main.rs:2106:9:2106:12 | f2(...) |  | main.rs:2083:16:2083:39 | impl ... |
+| main.rs:2106:9:2106:18 | await ... |  | main.rs:2073:5:2073:14 | S1 |
+| main.rs:2107:9:2107:12 | f3(...) |  | main.rs:2100:16:2100:39 | impl ... |
+| main.rs:2107:9:2107:18 | await ... |  | main.rs:2073:5:2073:14 | S1 |
+| main.rs:2108:9:2108:10 | S2 |  | main.rs:2087:5:2087:14 | S2 |
+| main.rs:2108:9:2108:16 | await S2 |  | main.rs:2073:5:2073:14 | S1 |
+| main.rs:2109:13:2109:13 | b |  | {EXTERNAL LOCATION} | trait Future |
+| main.rs:2109:13:2109:13 | b | Output | main.rs:2073:5:2073:14 | S1 |
+| main.rs:2109:17:2109:28 | { ... } |  | {EXTERNAL LOCATION} | trait Future |
+| main.rs:2109:17:2109:28 | { ... } | Output | main.rs:2073:5:2073:14 | S1 |
+| main.rs:2109:25:2109:26 | S1 |  | main.rs:2073:5:2073:14 | S1 |
+| main.rs:2110:9:2110:9 | b |  | {EXTERNAL LOCATION} | trait Future |
+| main.rs:2110:9:2110:9 | b | Output | main.rs:2073:5:2073:14 | S1 |
+| main.rs:2110:9:2110:15 | await b |  | main.rs:2073:5:2073:14 | S1 |
+| main.rs:2121:15:2121:19 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:2121:15:2121:19 | SelfParam | &T | main.rs:2120:5:2122:5 | Self [trait Trait1] |
+| main.rs:2125:15:2125:19 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:2125:15:2125:19 | SelfParam | &T | main.rs:2124:5:2126:5 | Self [trait Trait2] |
+| main.rs:2129:15:2129:19 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:2129:15:2129:19 | SelfParam | &T | main.rs:2115:5:2116:14 | S1 |
+| main.rs:2133:15:2133:19 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:2133:15:2133:19 | SelfParam | &T | main.rs:2115:5:2116:14 | S1 |
+| main.rs:2136:37:2138:5 | { ... } |  | main.rs:2136:16:2136:35 | impl ... + ... |
+| main.rs:2137:9:2137:10 | S1 |  | main.rs:2115:5:2116:14 | S1 |
+| main.rs:2137:9:2137:10 | S1 |  | main.rs:2136:16:2136:35 | impl ... + ... |
+| main.rs:2141:18:2141:22 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:2141:18:2141:22 | SelfParam | &T | main.rs:2140:5:2142:5 | Self [trait MyTrait] |
+| main.rs:2145:18:2145:22 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:2145:18:2145:22 | SelfParam | &T | main.rs:2115:5:2116:14 | S1 |
+| main.rs:2145:31:2147:9 | { ... } |  | main.rs:2117:5:2117:14 | S2 |
+| main.rs:2146:13:2146:14 | S2 |  | main.rs:2117:5:2117:14 | S2 |
+| main.rs:2151:18:2151:22 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:2151:18:2151:22 | SelfParam | &T | main.rs:2118:5:2118:22 | S3 |
+| main.rs:2151:18:2151:22 | SelfParam | &T.T3 | main.rs:2150:10:2150:17 | T |
+| main.rs:2151:30:2154:9 | { ... } |  | main.rs:2150:10:2150:17 | T |
+| main.rs:2152:17:2152:21 | S3(...) |  | file://:0:0:0:0 | & |
+| main.rs:2152:17:2152:21 | S3(...) |  | main.rs:2118:5:2118:22 | S3 |
+| main.rs:2152:17:2152:21 | S3(...) | &T | main.rs:2118:5:2118:22 | S3 |
+| main.rs:2152:17:2152:21 | S3(...) | &T.T3 | main.rs:2150:10:2150:17 | T |
+| main.rs:2152:25:2152:28 | self |  | file://:0:0:0:0 | & |
+| main.rs:2152:25:2152:28 | self | &T | main.rs:2118:5:2118:22 | S3 |
+| main.rs:2152:25:2152:28 | self | &T.T3 | main.rs:2150:10:2150:17 | T |
+| main.rs:2153:13:2153:21 | t.clone() |  | main.rs:2150:10:2150:17 | T |
+| main.rs:2157:45:2159:5 | { ... } |  | main.rs:2157:28:2157:43 | impl ... |
+| main.rs:2158:9:2158:10 | S1 |  | main.rs:2115:5:2116:14 | S1 |
+| main.rs:2158:9:2158:10 | S1 |  | main.rs:2157:28:2157:43 | impl ... |
+| main.rs:2161:41:2161:41 | t |  | main.rs:2161:26:2161:38 | B |
+| main.rs:2161:52:2163:5 | { ... } |  | main.rs:2161:23:2161:23 | A |
+| main.rs:2162:9:2162:9 | t |  | main.rs:2161:26:2161:38 | B |
+| main.rs:2162:9:2162:17 | t.get_a() |  | main.rs:2161:23:2161:23 | A |
+| main.rs:2165:34:2165:34 | x |  | main.rs:2165:24:2165:31 | T |
+| main.rs:2165:59:2167:5 | { ... } |  | main.rs:2165:43:2165:57 | impl ... |
+| main.rs:2165:59:2167:5 | { ... } | impl(T) | main.rs:2165:24:2165:31 | T |
+| main.rs:2166:9:2166:13 | S3(...) |  | main.rs:2118:5:2118:22 | S3 |
+| main.rs:2166:9:2166:13 | S3(...) |  | main.rs:2165:43:2165:57 | impl ... |
+| main.rs:2166:9:2166:13 | S3(...) | T3 | main.rs:2165:24:2165:31 | T |
+| main.rs:2166:9:2166:13 | S3(...) | impl(T) | main.rs:2165:24:2165:31 | T |
+| main.rs:2166:12:2166:12 | x |  | main.rs:2165:24:2165:31 | T |
+| main.rs:2169:34:2169:34 | x |  | main.rs:2169:24:2169:31 | T |
+| main.rs:2169:67:2171:5 | { ... } |  | {EXTERNAL LOCATION} | Option |
+| main.rs:2169:67:2171:5 | { ... } | T | main.rs:2169:50:2169:64 | impl ... |
+| main.rs:2169:67:2171:5 | { ... } | T.impl(T) | main.rs:2169:24:2169:31 | T |
+| main.rs:2170:9:2170:19 | Some(...) |  | {EXTERNAL LOCATION} | Option |
+| main.rs:2170:9:2170:19 | Some(...) | T | main.rs:2118:5:2118:22 | S3 |
+| main.rs:2170:9:2170:19 | Some(...) | T | main.rs:2169:50:2169:64 | impl ... |
+| main.rs:2170:9:2170:19 | Some(...) | T.T3 | main.rs:2169:24:2169:31 | T |
+| main.rs:2170:9:2170:19 | Some(...) | T.impl(T) | main.rs:2169:24:2169:31 | T |
+| main.rs:2170:14:2170:18 | S3(...) |  | main.rs:2118:5:2118:22 | S3 |
+| main.rs:2170:14:2170:18 | S3(...) |  | main.rs:2169:50:2169:64 | impl ... |
+| main.rs:2170:14:2170:18 | S3(...) | T3 | main.rs:2169:24:2169:31 | T |
+| main.rs:2170:14:2170:18 | S3(...) | impl(T) | main.rs:2169:24:2169:31 | T |
+| main.rs:2170:17:2170:17 | x |  | main.rs:2169:24:2169:31 | T |
+| main.rs:2173:34:2173:34 | x |  | main.rs:2173:24:2173:31 | T |
+| main.rs:2173:78:2175:5 | { ... } |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2173:78:2175:5 | { ... } | 0(2) | main.rs:2173:44:2173:58 | impl ... |
+| main.rs:2173:78:2175:5 | { ... } | 0(2).impl(T) | main.rs:2173:24:2173:31 | T |
+| main.rs:2173:78:2175:5 | { ... } | 1(2) | main.rs:2173:61:2173:75 | impl ... |
+| main.rs:2173:78:2175:5 | { ... } | 1(2).impl(T) | main.rs:2173:24:2173:31 | T |
+| main.rs:2174:9:2174:30 | TupleExpr |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2174:9:2174:30 | TupleExpr | 0(2) | main.rs:2118:5:2118:22 | S3 |
+| main.rs:2174:9:2174:30 | TupleExpr | 0(2) | main.rs:2173:44:2173:58 | impl ... |
+| main.rs:2174:9:2174:30 | TupleExpr | 0(2).T3 | main.rs:2173:24:2173:31 | T |
+| main.rs:2174:9:2174:30 | TupleExpr | 0(2).impl(T) | main.rs:2173:24:2173:31 | T |
+| main.rs:2174:9:2174:30 | TupleExpr | 1(2) | main.rs:2118:5:2118:22 | S3 |
+| main.rs:2174:9:2174:30 | TupleExpr | 1(2) | main.rs:2173:61:2173:75 | impl ... |
+| main.rs:2174:9:2174:30 | TupleExpr | 1(2).T3 | main.rs:2173:24:2173:31 | T |
+| main.rs:2174:9:2174:30 | TupleExpr | 1(2).impl(T) | main.rs:2173:24:2173:31 | T |
+| main.rs:2174:10:2174:22 | S3(...) |  | main.rs:2118:5:2118:22 | S3 |
+| main.rs:2174:10:2174:22 | S3(...) |  | main.rs:2173:44:2173:58 | impl ... |
+| main.rs:2174:10:2174:22 | S3(...) | T3 | main.rs:2173:24:2173:31 | T |
+| main.rs:2174:10:2174:22 | S3(...) | impl(T) | main.rs:2173:24:2173:31 | T |
+| main.rs:2174:13:2174:13 | x |  | main.rs:2173:24:2173:31 | T |
+| main.rs:2174:13:2174:21 | x.clone() |  | main.rs:2173:24:2173:31 | T |
+| main.rs:2174:25:2174:29 | S3(...) |  | main.rs:2118:5:2118:22 | S3 |
+| main.rs:2174:25:2174:29 | S3(...) |  | main.rs:2173:61:2173:75 | impl ... |
+| main.rs:2174:25:2174:29 | S3(...) | T3 | main.rs:2173:24:2173:31 | T |
+| main.rs:2174:25:2174:29 | S3(...) | impl(T) | main.rs:2173:24:2173:31 | T |
+| main.rs:2174:28:2174:28 | x |  | main.rs:2173:24:2173:31 | T |
+| main.rs:2177:26:2177:26 | t |  | main.rs:2177:29:2177:43 | impl ... |
+| main.rs:2177:51:2179:5 | { ... } |  | main.rs:2177:23:2177:23 | A |
+| main.rs:2178:9:2178:9 | t |  | main.rs:2177:29:2177:43 | impl ... |
+| main.rs:2178:9:2178:17 | t.get_a() |  | main.rs:2177:23:2177:23 | A |
+| main.rs:2182:13:2182:13 | x |  | main.rs:2136:16:2136:35 | impl ... + ... |
+| main.rs:2182:17:2182:20 | f1(...) |  | main.rs:2136:16:2136:35 | impl ... + ... |
+| main.rs:2183:9:2183:9 | x |  | main.rs:2136:16:2136:35 | impl ... + ... |
+| main.rs:2184:9:2184:9 | x |  | main.rs:2136:16:2136:35 | impl ... + ... |
+| main.rs:2185:13:2185:13 | a |  | main.rs:2157:28:2157:43 | impl ... |
+| main.rs:2185:17:2185:32 | get_a_my_trait(...) |  | main.rs:2157:28:2157:43 | impl ... |
+| main.rs:2186:13:2186:13 | b |  | main.rs:2117:5:2117:14 | S2 |
+| main.rs:2186:17:2186:33 | uses_my_trait1(...) |  | main.rs:2117:5:2117:14 | S2 |
+| main.rs:2186:32:2186:32 | a |  | main.rs:2157:28:2157:43 | impl ... |
+| main.rs:2187:13:2187:13 | a |  | main.rs:2157:28:2157:43 | impl ... |
+| main.rs:2187:17:2187:32 | get_a_my_trait(...) |  | main.rs:2157:28:2157:43 | impl ... |
+| main.rs:2188:13:2188:13 | c |  | main.rs:2117:5:2117:14 | S2 |
+| main.rs:2188:17:2188:33 | uses_my_trait2(...) |  | main.rs:2117:5:2117:14 | S2 |
+| main.rs:2188:32:2188:32 | a |  | main.rs:2157:28:2157:43 | impl ... |
+| main.rs:2189:13:2189:13 | d |  | main.rs:2117:5:2117:14 | S2 |
+| main.rs:2189:17:2189:34 | uses_my_trait2(...) |  | main.rs:2117:5:2117:14 | S2 |
+| main.rs:2189:32:2189:33 | S1 |  | main.rs:2115:5:2116:14 | S1 |
+| main.rs:2190:13:2190:13 | e |  | main.rs:2115:5:2116:14 | S1 |
+| main.rs:2190:17:2190:35 | get_a_my_trait2(...) |  | main.rs:2165:43:2165:57 | impl ... |
+| main.rs:2190:17:2190:35 | get_a_my_trait2(...) | impl(T) | main.rs:2115:5:2116:14 | S1 |
+| main.rs:2190:17:2190:43 | ... .get_a() |  | main.rs:2115:5:2116:14 | S1 |
+| main.rs:2190:33:2190:34 | S1 |  | main.rs:2115:5:2116:14 | S1 |
+| main.rs:2193:13:2193:13 | f |  | main.rs:2115:5:2116:14 | S1 |
+| main.rs:2193:17:2193:35 | get_a_my_trait3(...) |  | {EXTERNAL LOCATION} | Option |
+| main.rs:2193:17:2193:35 | get_a_my_trait3(...) | T | main.rs:2169:50:2169:64 | impl ... |
+| main.rs:2193:17:2193:35 | get_a_my_trait3(...) | T.impl(T) | main.rs:2115:5:2116:14 | S1 |
+| main.rs:2193:17:2193:44 | ... .unwrap() |  | main.rs:2169:50:2169:64 | impl ... |
+| main.rs:2193:17:2193:44 | ... .unwrap() | impl(T) | main.rs:2115:5:2116:14 | S1 |
+| main.rs:2193:17:2193:52 | ... .get_a() |  | main.rs:2115:5:2116:14 | S1 |
+| main.rs:2193:33:2193:34 | S1 |  | main.rs:2115:5:2116:14 | S1 |
+| main.rs:2194:13:2194:13 | g |  | main.rs:2115:5:2116:14 | S1 |
+| main.rs:2194:17:2194:35 | get_a_my_trait4(...) |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2194:17:2194:35 | get_a_my_trait4(...) | 0(2) | main.rs:2173:44:2173:58 | impl ... |
+| main.rs:2194:17:2194:35 | get_a_my_trait4(...) | 0(2).impl(T) | main.rs:2115:5:2116:14 | S1 |
+| main.rs:2194:17:2194:35 | get_a_my_trait4(...) | 1(2) | main.rs:2173:61:2173:75 | impl ... |
+| main.rs:2194:17:2194:35 | get_a_my_trait4(...) | 1(2).impl(T) | main.rs:2115:5:2116:14 | S1 |
+| main.rs:2194:17:2194:37 | ... .0 |  | main.rs:2173:44:2173:58 | impl ... |
+| main.rs:2194:17:2194:37 | ... .0 | impl(T) | main.rs:2115:5:2116:14 | S1 |
+| main.rs:2194:17:2194:45 | ... .get_a() |  | main.rs:2115:5:2116:14 | S1 |
+| main.rs:2194:33:2194:34 | S1 |  | main.rs:2115:5:2116:14 | S1 |
+| main.rs:2205:16:2205:20 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:2205:16:2205:20 | SelfParam | &T | main.rs:2201:5:2202:13 | S |
+| main.rs:2205:31:2207:9 | { ... } |  | main.rs:2201:5:2202:13 | S |
+| main.rs:2206:13:2206:13 | S |  | main.rs:2201:5:2202:13 | S |
+| main.rs:2216:26:2218:9 | { ... } |  | main.rs:2210:5:2213:5 | MyVec |
+| main.rs:2216:26:2218:9 | { ... } | T | main.rs:2215:10:2215:10 | T |
+| main.rs:2217:13:2217:38 | MyVec {...} |  | main.rs:2210:5:2213:5 | MyVec |
+| main.rs:2217:13:2217:38 | MyVec {...} | T | main.rs:2215:10:2215:10 | T |
+| main.rs:2217:27:2217:36 | ...::new(...) |  | {EXTERNAL LOCATION} | Vec |
+| main.rs:2217:27:2217:36 | ...::new(...) | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2217:27:2217:36 | ...::new(...) | T | main.rs:2215:10:2215:10 | T |
+| main.rs:2220:17:2220:25 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:2220:17:2220:25 | SelfParam | &T | main.rs:2210:5:2213:5 | MyVec |
+| main.rs:2220:17:2220:25 | SelfParam | &T.T | main.rs:2215:10:2215:10 | T |
+| main.rs:2220:28:2220:32 | value |  | main.rs:2215:10:2215:10 | T |
+| main.rs:2221:13:2221:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:2221:13:2221:16 | self | &T | main.rs:2210:5:2213:5 | MyVec |
+| main.rs:2221:13:2221:16 | self | &T.T | main.rs:2215:10:2215:10 | T |
+| main.rs:2221:13:2221:21 | self.data |  | {EXTERNAL LOCATION} | Vec |
+| main.rs:2221:13:2221:21 | self.data | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2221:13:2221:21 | self.data | T | main.rs:2215:10:2215:10 | T |
+| main.rs:2221:28:2221:32 | value |  | main.rs:2215:10:2215:10 | T |
+| main.rs:2229:18:2229:22 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:2229:18:2229:22 | SelfParam | &T | main.rs:2210:5:2213:5 | MyVec |
+| main.rs:2229:18:2229:22 | SelfParam | &T.T | main.rs:2225:10:2225:10 | T |
+| main.rs:2229:25:2229:29 | index |  | {EXTERNAL LOCATION} | usize |
+| main.rs:2229:56:2231:9 | { ... } |  | file://:0:0:0:0 | & |
+| main.rs:2229:56:2231:9 | { ... } | &T | main.rs:2225:10:2225:10 | T |
+| main.rs:2230:13:2230:29 | &... |  | file://:0:0:0:0 | & |
+| main.rs:2230:13:2230:29 | &... | &T | main.rs:2225:10:2225:10 | T |
+| main.rs:2230:14:2230:17 | self |  | file://:0:0:0:0 | & |
+| main.rs:2230:14:2230:17 | self | &T | main.rs:2210:5:2213:5 | MyVec |
+| main.rs:2230:14:2230:17 | self | &T.T | main.rs:2225:10:2225:10 | T |
+| main.rs:2230:14:2230:22 | self.data |  | {EXTERNAL LOCATION} | Vec |
+| main.rs:2230:14:2230:22 | self.data | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2230:14:2230:22 | self.data | T | main.rs:2225:10:2225:10 | T |
+| main.rs:2230:14:2230:29 | ...[index] |  | main.rs:2225:10:2225:10 | T |
+| main.rs:2230:24:2230:28 | index |  | {EXTERNAL LOCATION} | usize |
+| main.rs:2234:22:2234:26 | slice |  | file://:0:0:0:0 | & |
+| main.rs:2234:22:2234:26 | slice | &T | file://:0:0:0:0 | [] |
+| main.rs:2234:22:2234:26 | slice | &T.[T] | main.rs:2201:5:2202:13 | S |
+| main.rs:2235:13:2235:13 | x |  | main.rs:2201:5:2202:13 | S |
+| main.rs:2235:17:2235:21 | slice |  | file://:0:0:0:0 | & |
+| main.rs:2235:17:2235:21 | slice | &T | file://:0:0:0:0 | [] |
+| main.rs:2235:17:2235:21 | slice | &T.[T] | main.rs:2201:5:2202:13 | S |
+| main.rs:2235:17:2235:24 | slice[0] |  | main.rs:2201:5:2202:13 | S |
+| main.rs:2235:17:2235:30 | ... .foo() |  | main.rs:2201:5:2202:13 | S |
+| main.rs:2235:23:2235:23 | 0 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2238:37:2238:37 | a |  | main.rs:2238:20:2238:34 | T |
+| main.rs:2238:43:2238:43 | b |  | {EXTERNAL LOCATION} | usize |
+| main.rs:2241:5:2243:5 | { ... } |  | {EXTERNAL LOCATION} | Output |
+| main.rs:2242:9:2242:9 | a |  | main.rs:2238:20:2238:34 | T |
+| main.rs:2242:9:2242:12 | a[b] |  | {EXTERNAL LOCATION} | Output |
+| main.rs:2242:11:2242:11 | b |  | {EXTERNAL LOCATION} | usize |
+| main.rs:2246:17:2246:19 | vec |  | main.rs:2210:5:2213:5 | MyVec |
+| main.rs:2246:17:2246:19 | vec | T | main.rs:2201:5:2202:13 | S |
+| main.rs:2246:23:2246:34 | ...::new(...) |  | main.rs:2210:5:2213:5 | MyVec |
+| main.rs:2246:23:2246:34 | ...::new(...) | T | main.rs:2201:5:2202:13 | S |
+| main.rs:2247:9:2247:11 | vec |  | main.rs:2210:5:2213:5 | MyVec |
+| main.rs:2247:9:2247:11 | vec | T | main.rs:2201:5:2202:13 | S |
+| main.rs:2247:18:2247:18 | S |  | main.rs:2201:5:2202:13 | S |
+| main.rs:2248:9:2248:11 | vec |  | main.rs:2210:5:2213:5 | MyVec |
+| main.rs:2248:9:2248:11 | vec | T | main.rs:2201:5:2202:13 | S |
+| main.rs:2248:9:2248:14 | vec[0] |  | main.rs:2201:5:2202:13 | S |
+| main.rs:2248:9:2248:20 | ... .foo() |  | main.rs:2201:5:2202:13 | S |
+| main.rs:2248:13:2248:13 | 0 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2248:13:2248:13 | 0 |  | {EXTERNAL LOCATION} | usize |
+| main.rs:2250:13:2250:14 | xs |  | file://:0:0:0:0 | [] |
+| main.rs:2250:13:2250:14 | xs | [T;...] | main.rs:2201:5:2202:13 | S |
+| main.rs:2250:21:2250:21 | 1 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2250:26:2250:28 | [...] |  | file://:0:0:0:0 | [] |
+| main.rs:2250:26:2250:28 | [...] | [T;...] | main.rs:2201:5:2202:13 | S |
+| main.rs:2250:27:2250:27 | S |  | main.rs:2201:5:2202:13 | S |
+| main.rs:2251:13:2251:13 | x |  | main.rs:2201:5:2202:13 | S |
+| main.rs:2251:17:2251:18 | xs |  | file://:0:0:0:0 | [] |
+| main.rs:2251:17:2251:18 | xs | [T;...] | main.rs:2201:5:2202:13 | S |
+| main.rs:2251:17:2251:21 | xs[0] |  | main.rs:2201:5:2202:13 | S |
+| main.rs:2251:17:2251:27 | ... .foo() |  | main.rs:2201:5:2202:13 | S |
+| main.rs:2251:20:2251:20 | 0 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2253:29:2253:31 | vec |  | main.rs:2210:5:2213:5 | MyVec |
+| main.rs:2253:29:2253:31 | vec | T | main.rs:2201:5:2202:13 | S |
+| main.rs:2253:34:2253:34 | 0 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2253:34:2253:34 | 0 |  | {EXTERNAL LOCATION} | usize |
+| main.rs:2255:23:2255:25 | &xs |  | file://:0:0:0:0 | & |
+| main.rs:2255:23:2255:25 | &xs | &T | file://:0:0:0:0 | [] |
+| main.rs:2255:23:2255:25 | &xs | &T | file://:0:0:0:0 | [] |
+| main.rs:2255:23:2255:25 | &xs | &T.[T;...] | main.rs:2201:5:2202:13 | S |
+| main.rs:2255:23:2255:25 | &xs | &T.[T] | main.rs:2201:5:2202:13 | S |
+| main.rs:2255:24:2255:25 | xs |  | file://:0:0:0:0 | [] |
+| main.rs:2255:24:2255:25 | xs | [T;...] | main.rs:2201:5:2202:13 | S |
+| main.rs:2261:13:2261:13 | x |  | {EXTERNAL LOCATION} | String |
+| main.rs:2261:17:2261:46 | MacroExpr |  | {EXTERNAL LOCATION} | String |
+| main.rs:2261:25:2261:35 | "Hello, {}" |  | file://:0:0:0:0 | & |
+| main.rs:2261:25:2261:35 | "Hello, {}" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:2261:25:2261:45 | ...::format(...) |  | {EXTERNAL LOCATION} | String |
+| main.rs:2261:25:2261:45 | ...::must_use(...) |  | {EXTERNAL LOCATION} | String |
+| main.rs:2261:25:2261:45 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:2261:25:2261:45 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:2261:25:2261:45 | { ... } |  | {EXTERNAL LOCATION} | String |
+| main.rs:2261:38:2261:45 | "World!" |  | file://:0:0:0:0 | & |
+| main.rs:2261:38:2261:45 | "World!" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:2270:19:2270:22 | SelfParam |  | main.rs:2266:5:2271:5 | Self [trait MyAdd] |
+| main.rs:2270:25:2270:27 | rhs |  | main.rs:2266:17:2266:26 | Rhs |
+| main.rs:2277:19:2277:22 | SelfParam |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2277:25:2277:29 | value |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2277:45:2279:9 | { ... } |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2278:13:2278:17 | value |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2286:19:2286:22 | SelfParam |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2286:25:2286:29 | value |  | file://:0:0:0:0 | & |
+| main.rs:2286:25:2286:29 | value | &T | {EXTERNAL LOCATION} | i64 |
+| main.rs:2286:46:2288:9 | { ... } |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2287:13:2287:18 | * ... |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2287:14:2287:18 | value |  | file://:0:0:0:0 | & |
+| main.rs:2287:14:2287:18 | value | &T | {EXTERNAL LOCATION} | i64 |
+| main.rs:2295:19:2295:22 | SelfParam |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2295:25:2295:29 | value |  | {EXTERNAL LOCATION} | bool |
+| main.rs:2295:46:2301:9 | { ... } |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2296:13:2300:13 | if value {...} else {...} |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2296:13:2300:13 | if value {...} else {...} |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2296:16:2296:20 | value |  | {EXTERNAL LOCATION} | bool |
+| main.rs:2296:22:2298:13 | { ... } |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2296:22:2298:13 | { ... } |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2297:17:2297:17 | 1 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2297:17:2297:17 | 1 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2298:20:2300:13 | { ... } |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2298:20:2300:13 | { ... } |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2299:17:2299:17 | 0 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2299:17:2299:17 | 0 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2310:19:2310:22 | SelfParam |  | main.rs:2304:5:2304:19 | S |
+| main.rs:2310:19:2310:22 | SelfParam | T | main.rs:2306:10:2306:17 | T |
+| main.rs:2310:25:2310:29 | other |  | main.rs:2304:5:2304:19 | S |
+| main.rs:2310:25:2310:29 | other | T | main.rs:2306:10:2306:17 | T |
+| main.rs:2310:54:2312:9 | { ... } |  | main.rs:2304:5:2304:19 | S |
+| main.rs:2310:54:2312:9 | { ... } | T | main.rs:2267:9:2267:20 | Output |
+| main.rs:2311:13:2311:39 | S(...) |  | main.rs:2304:5:2304:19 | S |
+| main.rs:2311:13:2311:39 | S(...) | T | main.rs:2267:9:2267:20 | Output |
+| main.rs:2311:15:2311:22 | (...) |  | main.rs:2306:10:2306:17 | T |
+| main.rs:2311:15:2311:38 | ... .my_add(...) |  | main.rs:2267:9:2267:20 | Output |
+| main.rs:2311:16:2311:19 | self |  | main.rs:2304:5:2304:19 | S |
+| main.rs:2311:16:2311:19 | self | T | main.rs:2306:10:2306:17 | T |
+| main.rs:2311:16:2311:21 | self.0 |  | main.rs:2306:10:2306:17 | T |
+| main.rs:2311:31:2311:35 | other |  | main.rs:2304:5:2304:19 | S |
+| main.rs:2311:31:2311:35 | other | T | main.rs:2306:10:2306:17 | T |
+| main.rs:2311:31:2311:37 | other.0 |  | main.rs:2306:10:2306:17 | T |
+| main.rs:2319:19:2319:22 | SelfParam |  | main.rs:2304:5:2304:19 | S |
+| main.rs:2319:19:2319:22 | SelfParam | T | main.rs:2315:10:2315:17 | T |
+| main.rs:2319:25:2319:29 | other |  | main.rs:2315:10:2315:17 | T |
+| main.rs:2319:51:2321:9 | { ... } |  | main.rs:2304:5:2304:19 | S |
+| main.rs:2319:51:2321:9 | { ... } | T | main.rs:2267:9:2267:20 | Output |
+| main.rs:2320:13:2320:37 | S(...) |  | main.rs:2304:5:2304:19 | S |
+| main.rs:2320:13:2320:37 | S(...) | T | main.rs:2267:9:2267:20 | Output |
+| main.rs:2320:15:2320:22 | (...) |  | main.rs:2315:10:2315:17 | T |
+| main.rs:2320:15:2320:36 | ... .my_add(...) |  | main.rs:2267:9:2267:20 | Output |
+| main.rs:2320:16:2320:19 | self |  | main.rs:2304:5:2304:19 | S |
+| main.rs:2320:16:2320:19 | self | T | main.rs:2315:10:2315:17 | T |
+| main.rs:2320:16:2320:21 | self.0 |  | main.rs:2315:10:2315:17 | T |
+| main.rs:2320:31:2320:35 | other |  | main.rs:2315:10:2315:17 | T |
+| main.rs:2331:19:2331:22 | SelfParam |  | main.rs:2304:5:2304:19 | S |
+| main.rs:2331:19:2331:22 | SelfParam | T | main.rs:2324:14:2324:14 | T |
+| main.rs:2331:25:2331:29 | other |  | file://:0:0:0:0 | & |
+| main.rs:2331:25:2331:29 | other | &T | main.rs:2324:14:2324:14 | T |
+| main.rs:2331:55:2333:9 | { ... } |  | main.rs:2304:5:2304:19 | S |
+| main.rs:2332:13:2332:37 | S(...) |  | main.rs:2304:5:2304:19 | S |
+| main.rs:2332:15:2332:22 | (...) |  | main.rs:2324:14:2324:14 | T |
+| main.rs:2332:16:2332:19 | self |  | main.rs:2304:5:2304:19 | S |
+| main.rs:2332:16:2332:19 | self | T | main.rs:2324:14:2324:14 | T |
+| main.rs:2332:16:2332:21 | self.0 |  | main.rs:2324:14:2324:14 | T |
+| main.rs:2332:31:2332:35 | other |  | file://:0:0:0:0 | & |
+| main.rs:2332:31:2332:35 | other | &T | main.rs:2324:14:2324:14 | T |
+| main.rs:2338:20:2338:24 | value |  | main.rs:2336:18:2336:18 | T |
+| main.rs:2343:20:2343:24 | value |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2343:40:2345:9 | { ... } |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2344:13:2344:17 | value |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2350:20:2350:24 | value |  | {EXTERNAL LOCATION} | bool |
+| main.rs:2350:41:2356:9 | { ... } |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2351:13:2355:13 | if value {...} else {...} |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2351:13:2355:13 | if value {...} else {...} |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2351:16:2351:20 | value |  | {EXTERNAL LOCATION} | bool |
+| main.rs:2351:22:2353:13 | { ... } |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2351:22:2353:13 | { ... } |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2352:17:2352:17 | 1 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2352:17:2352:17 | 1 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2353:20:2355:13 | { ... } |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2353:20:2355:13 | { ... } |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2354:17:2354:17 | 0 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2354:17:2354:17 | 0 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2361:21:2361:25 | value |  | main.rs:2359:19:2359:19 | T |
+| main.rs:2361:31:2361:31 | x |  | main.rs:2359:5:2362:5 | Self [trait MyFrom2] |
+| main.rs:2366:21:2366:25 | value |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2366:33:2366:33 | _ |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2366:48:2368:9 | { ... } |  | file://:0:0:0:0 | () |
+| main.rs:2367:13:2367:17 | value |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2373:21:2373:25 | value |  | {EXTERNAL LOCATION} | bool |
+| main.rs:2373:34:2373:34 | _ |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2373:49:2379:9 | { ... } |  | file://:0:0:0:0 | () |
+| main.rs:2374:13:2378:13 | if value {...} else {...} |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2374:16:2374:20 | value |  | {EXTERNAL LOCATION} | bool |
+| main.rs:2374:22:2376:13 | { ... } |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2375:17:2375:17 | 1 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2376:20:2378:13 | { ... } |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2377:17:2377:17 | 0 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2384:15:2384:15 | x |  | main.rs:2382:5:2388:5 | Self [trait MySelfTrait] |
+| main.rs:2387:15:2387:15 | x |  | main.rs:2382:5:2388:5 | Self [trait MySelfTrait] |
+| main.rs:2392:15:2392:15 | x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2392:31:2394:9 | { ... } |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2393:13:2393:13 | x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2393:13:2393:17 | ... + ... |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2393:17:2393:17 | 1 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2397:15:2397:15 | x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2397:32:2399:9 | { ... } |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2398:13:2398:13 | x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2398:13:2398:17 | ... + ... |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2398:17:2398:17 | 1 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2404:15:2404:15 | x |  | {EXTERNAL LOCATION} | bool |
+| main.rs:2404:31:2406:9 | { ... } |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2405:13:2405:13 | 0 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2405:13:2405:13 | 0 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2409:15:2409:15 | x |  | {EXTERNAL LOCATION} | bool |
+| main.rs:2409:32:2411:9 | { ... } |  | {EXTERNAL LOCATION} | bool |
+| main.rs:2410:13:2410:13 | x |  | {EXTERNAL LOCATION} | bool |
+| main.rs:2415:13:2415:13 | x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2415:22:2415:23 | 73 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2415:22:2415:23 | 73 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2416:9:2416:9 | x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2416:9:2416:22 | x.my_add(...) |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2416:18:2416:21 | 5i64 |  | {EXTERNAL LOCATION} | i64 |
 | main.rs:2417:9:2417:9 | x |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2417:9:2417:22 | x.my_add(...) |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2417:18:2417:21 | 5i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2417:9:2417:23 | x.my_add(...) |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2417:18:2417:22 | &5i64 |  | file://:0:0:0:0 | & |
+| main.rs:2417:18:2417:22 | &5i64 | &T | {EXTERNAL LOCATION} | i64 |
+| main.rs:2417:19:2417:22 | 5i64 |  | {EXTERNAL LOCATION} | i64 |
 | main.rs:2418:9:2418:9 | x |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2418:9:2418:23 | x.my_add(...) |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2418:18:2418:22 | &5i64 |  | file://:0:0:0:0 | & |
-| main.rs:2418:18:2418:22 | &5i64 | &T | {EXTERNAL LOCATION} | i64 |
-| main.rs:2418:19:2418:22 | 5i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2419:9:2419:9 | x |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2419:9:2419:22 | x.my_add(...) |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2419:18:2419:21 | true |  | {EXTERNAL LOCATION} | bool |
-| main.rs:2421:9:2421:15 | S(...) |  | main.rs:2305:5:2305:19 | S |
+| main.rs:2418:9:2418:22 | x.my_add(...) |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2418:18:2418:21 | true |  | {EXTERNAL LOCATION} | bool |
+| main.rs:2420:9:2420:15 | S(...) |  | main.rs:2304:5:2304:19 | S |
+| main.rs:2420:9:2420:15 | S(...) | T | {EXTERNAL LOCATION} | i64 |
+| main.rs:2420:9:2420:31 | ... .my_add(...) |  | main.rs:2304:5:2304:19 | S |
+| main.rs:2420:11:2420:14 | 1i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2420:24:2420:30 | S(...) |  | main.rs:2304:5:2304:19 | S |
+| main.rs:2420:24:2420:30 | S(...) | T | {EXTERNAL LOCATION} | i64 |
+| main.rs:2420:26:2420:29 | 2i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2421:9:2421:15 | S(...) |  | main.rs:2304:5:2304:19 | S |
 | main.rs:2421:9:2421:15 | S(...) | T | {EXTERNAL LOCATION} | i64 |
-| main.rs:2421:9:2421:31 | ... .my_add(...) |  | main.rs:2305:5:2305:19 | S |
 | main.rs:2421:11:2421:14 | 1i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2421:24:2421:30 | S(...) |  | main.rs:2305:5:2305:19 | S |
-| main.rs:2421:24:2421:30 | S(...) | T | {EXTERNAL LOCATION} | i64 |
-| main.rs:2421:26:2421:29 | 2i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2422:9:2422:15 | S(...) |  | main.rs:2305:5:2305:19 | S |
+| main.rs:2421:24:2421:27 | 3i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2422:9:2422:15 | S(...) |  | main.rs:2304:5:2304:19 | S |
 | main.rs:2422:9:2422:15 | S(...) | T | {EXTERNAL LOCATION} | i64 |
+| main.rs:2422:9:2422:29 | ... .my_add(...) |  | main.rs:2304:5:2304:19 | S |
 | main.rs:2422:11:2422:14 | 1i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2422:24:2422:27 | 3i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2423:9:2423:15 | S(...) |  | main.rs:2305:5:2305:19 | S |
-| main.rs:2423:9:2423:15 | S(...) | T | {EXTERNAL LOCATION} | i64 |
-| main.rs:2423:9:2423:29 | ... .my_add(...) |  | main.rs:2305:5:2305:19 | S |
-| main.rs:2423:11:2423:14 | 1i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2423:24:2423:28 | &3i64 |  | file://:0:0:0:0 | & |
-| main.rs:2423:24:2423:28 | &3i64 | &T | {EXTERNAL LOCATION} | i64 |
-| main.rs:2423:25:2423:28 | 3i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2425:13:2425:13 | x |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2425:17:2425:35 | ...::my_from(...) |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2425:30:2425:34 | 73i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2426:13:2426:13 | y |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2426:17:2426:34 | ...::my_from(...) |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2426:30:2426:33 | true |  | {EXTERNAL LOCATION} | bool |
-| main.rs:2427:13:2427:13 | z |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2427:22:2427:43 | ...::my_from(...) |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2427:38:2427:42 | 73i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2428:9:2428:34 | ...::my_from2(...) |  | file://:0:0:0:0 | () |
-| main.rs:2428:23:2428:27 | 73i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2428:30:2428:33 | 0i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2429:9:2429:33 | ...::my_from2(...) |  | file://:0:0:0:0 | () |
-| main.rs:2429:23:2429:26 | true |  | {EXTERNAL LOCATION} | bool |
-| main.rs:2429:29:2429:32 | 0i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2430:9:2430:38 | ...::my_from2(...) |  | file://:0:0:0:0 | () |
-| main.rs:2430:27:2430:31 | 73i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2430:34:2430:37 | 0i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2432:9:2432:22 | ...::f1(...) |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2422:24:2422:28 | &3i64 |  | file://:0:0:0:0 | & |
+| main.rs:2422:24:2422:28 | &3i64 | &T | {EXTERNAL LOCATION} | i64 |
+| main.rs:2422:25:2422:28 | 3i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2424:13:2424:13 | x |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2424:17:2424:35 | ...::my_from(...) |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2424:30:2424:34 | 73i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2425:13:2425:13 | y |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2425:17:2425:34 | ...::my_from(...) |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2425:30:2425:33 | true |  | {EXTERNAL LOCATION} | bool |
+| main.rs:2426:13:2426:13 | z |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2426:22:2426:43 | ...::my_from(...) |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2426:38:2426:42 | 73i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2427:9:2427:34 | ...::my_from2(...) |  | file://:0:0:0:0 | () |
+| main.rs:2427:23:2427:27 | 73i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2427:30:2427:33 | 0i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2428:9:2428:33 | ...::my_from2(...) |  | file://:0:0:0:0 | () |
+| main.rs:2428:23:2428:26 | true |  | {EXTERNAL LOCATION} | bool |
+| main.rs:2428:29:2428:32 | 0i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2429:9:2429:38 | ...::my_from2(...) |  | file://:0:0:0:0 | () |
+| main.rs:2429:27:2429:31 | 73i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2429:34:2429:37 | 0i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2431:9:2431:22 | ...::f1(...) |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2431:17:2431:21 | 73i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2432:9:2432:22 | ...::f2(...) |  | {EXTERNAL LOCATION} | i64 |
 | main.rs:2432:17:2432:21 | 73i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2433:9:2433:22 | ...::f2(...) |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2433:17:2433:21 | 73i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2434:9:2434:22 | ...::f1(...) |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2433:9:2433:22 | ...::f1(...) |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2433:18:2433:21 | true |  | {EXTERNAL LOCATION} | bool |
+| main.rs:2434:9:2434:22 | ...::f2(...) |  | {EXTERNAL LOCATION} | bool |
 | main.rs:2434:18:2434:21 | true |  | {EXTERNAL LOCATION} | bool |
-| main.rs:2435:9:2435:22 | ...::f2(...) |  | {EXTERNAL LOCATION} | bool |
-| main.rs:2435:18:2435:21 | true |  | {EXTERNAL LOCATION} | bool |
-| main.rs:2436:9:2436:30 | ...::f1(...) |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2435:9:2435:30 | ...::f1(...) |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2435:25:2435:29 | 73i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2436:9:2436:30 | ...::f2(...) |  | {EXTERNAL LOCATION} | i64 |
 | main.rs:2436:25:2436:29 | 73i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2437:9:2437:30 | ...::f2(...) |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2437:25:2437:29 | 73i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2438:9:2438:29 | ...::f1(...) |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2437:9:2437:29 | ...::f1(...) |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2437:25:2437:28 | true |  | {EXTERNAL LOCATION} | bool |
+| main.rs:2438:9:2438:29 | ...::f2(...) |  | {EXTERNAL LOCATION} | bool |
 | main.rs:2438:25:2438:28 | true |  | {EXTERNAL LOCATION} | bool |
-| main.rs:2439:9:2439:29 | ...::f2(...) |  | {EXTERNAL LOCATION} | bool |
-| main.rs:2439:25:2439:28 | true |  | {EXTERNAL LOCATION} | bool |
-| main.rs:2447:26:2449:9 | { ... } |  | main.rs:2444:5:2444:24 | MyCallable |
-| main.rs:2448:13:2448:25 | MyCallable {...} |  | main.rs:2444:5:2444:24 | MyCallable |
-| main.rs:2451:17:2451:21 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:2451:17:2451:21 | SelfParam | &T | main.rs:2444:5:2444:24 | MyCallable |
-| main.rs:2451:31:2453:9 | { ... } |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2452:13:2452:13 | 1 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2452:13:2452:13 | 1 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2459:13:2459:13 | i |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2446:26:2448:9 | { ... } |  | main.rs:2443:5:2443:24 | MyCallable |
+| main.rs:2447:13:2447:25 | MyCallable {...} |  | main.rs:2443:5:2443:24 | MyCallable |
+| main.rs:2450:17:2450:21 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:2450:17:2450:21 | SelfParam | &T | main.rs:2443:5:2443:24 | MyCallable |
+| main.rs:2450:31:2452:9 | { ... } |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2451:13:2451:13 | 1 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2451:13:2451:13 | 1 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2458:13:2458:13 | i |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2458:18:2458:26 | [...] |  | file://:0:0:0:0 | [] |
+| main.rs:2458:18:2458:26 | [...] | [T;...] | {EXTERNAL LOCATION} | i32 |
+| main.rs:2458:19:2458:19 | 1 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2458:22:2458:22 | 2 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2458:25:2458:25 | 3 |  | {EXTERNAL LOCATION} | i32 |
 | main.rs:2459:18:2459:26 | [...] |  | file://:0:0:0:0 | [] |
 | main.rs:2459:18:2459:26 | [...] | [T;...] | {EXTERNAL LOCATION} | i32 |
+| main.rs:2459:18:2459:41 | ... .map(...) |  | file://:0:0:0:0 | [] |
 | main.rs:2459:19:2459:19 | 1 |  | {EXTERNAL LOCATION} | i32 |
 | main.rs:2459:22:2459:22 | 2 |  | {EXTERNAL LOCATION} | i32 |
 | main.rs:2459:25:2459:25 | 3 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2459:32:2459:40 | \|...\| ... |  | {EXTERNAL LOCATION} | dyn FnOnce |
+| main.rs:2459:32:2459:40 | \|...\| ... | dyn(Args) | file://:0:0:0:0 | (T_1) |
+| main.rs:2459:40:2459:40 | 1 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2460:13:2460:13 | i |  | {EXTERNAL LOCATION} | Item |
+| main.rs:2460:13:2460:13 | i |  | {EXTERNAL LOCATION} | i32 |
 | main.rs:2460:18:2460:26 | [...] |  | file://:0:0:0:0 | [] |
 | main.rs:2460:18:2460:26 | [...] | [T;...] | {EXTERNAL LOCATION} | i32 |
-| main.rs:2460:18:2460:41 | ... .map(...) |  | file://:0:0:0:0 | [] |
+| main.rs:2460:18:2460:38 | ... .into_iter() |  | {EXTERNAL LOCATION} | IntoIter |
+| main.rs:2460:18:2460:38 | ... .into_iter() | T | {EXTERNAL LOCATION} | i32 |
 | main.rs:2460:19:2460:19 | 1 |  | {EXTERNAL LOCATION} | i32 |
 | main.rs:2460:22:2460:22 | 2 |  | {EXTERNAL LOCATION} | i32 |
 | main.rs:2460:25:2460:25 | 3 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2460:32:2460:40 | \|...\| ... |  | {EXTERNAL LOCATION} | dyn FnOnce |
-| main.rs:2460:32:2460:40 | \|...\| ... | dyn(Args) | file://:0:0:0:0 | (T_1) |
-| main.rs:2460:40:2460:40 | 1 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2461:13:2461:13 | i |  | {EXTERNAL LOCATION} | Item |
-| main.rs:2461:13:2461:13 | i |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2461:18:2461:26 | [...] |  | file://:0:0:0:0 | [] |
-| main.rs:2461:18:2461:26 | [...] | [T;...] | {EXTERNAL LOCATION} | i32 |
-| main.rs:2461:18:2461:38 | ... .into_iter() |  | {EXTERNAL LOCATION} | IntoIter |
-| main.rs:2461:18:2461:38 | ... .into_iter() | T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2461:19:2461:19 | 1 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2461:22:2461:22 | 2 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2461:25:2461:25 | 3 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2463:13:2463:17 | vals1 |  | file://:0:0:0:0 | [] |
-| main.rs:2463:13:2463:17 | vals1 | [T;...] | {EXTERNAL LOCATION} | i32 |
-| main.rs:2463:13:2463:17 | vals1 | [T;...] | {EXTERNAL LOCATION} | u8 |
-| main.rs:2463:21:2463:31 | [...] |  | file://:0:0:0:0 | [] |
-| main.rs:2463:21:2463:31 | [...] | [T;...] | {EXTERNAL LOCATION} | i32 |
-| main.rs:2463:21:2463:31 | [...] | [T;...] | {EXTERNAL LOCATION} | u8 |
-| main.rs:2463:22:2463:24 | 1u8 |  | {EXTERNAL LOCATION} | u8 |
-| main.rs:2463:27:2463:27 | 2 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2463:27:2463:27 | 2 |  | {EXTERNAL LOCATION} | u8 |
-| main.rs:2463:30:2463:30 | 3 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2463:30:2463:30 | 3 |  | {EXTERNAL LOCATION} | u8 |
-| main.rs:2464:13:2464:13 | u |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2464:13:2464:13 | u |  | {EXTERNAL LOCATION} | u8 |
-| main.rs:2464:18:2464:22 | vals1 |  | file://:0:0:0:0 | [] |
-| main.rs:2464:18:2464:22 | vals1 | [T;...] | {EXTERNAL LOCATION} | i32 |
-| main.rs:2464:18:2464:22 | vals1 | [T;...] | {EXTERNAL LOCATION} | u8 |
-| main.rs:2466:13:2466:17 | vals2 |  | file://:0:0:0:0 | [] |
-| main.rs:2466:13:2466:17 | vals2 | [T;...] | {EXTERNAL LOCATION} | u16 |
-| main.rs:2466:21:2466:29 | [1u16; 3] |  | file://:0:0:0:0 | [] |
-| main.rs:2466:21:2466:29 | [1u16; 3] | [T;...] | {EXTERNAL LOCATION} | u16 |
-| main.rs:2466:22:2466:25 | 1u16 |  | {EXTERNAL LOCATION} | u16 |
-| main.rs:2466:28:2466:28 | 3 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2467:13:2467:13 | u |  | {EXTERNAL LOCATION} | u16 |
-| main.rs:2467:18:2467:22 | vals2 |  | file://:0:0:0:0 | [] |
-| main.rs:2467:18:2467:22 | vals2 | [T;...] | {EXTERNAL LOCATION} | u16 |
-| main.rs:2469:13:2469:17 | vals3 |  | file://:0:0:0:0 | [] |
-| main.rs:2469:13:2469:17 | vals3 | [T;...] | {EXTERNAL LOCATION} | u32 |
-| main.rs:2469:26:2469:26 | 3 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2469:31:2469:39 | [...] |  | file://:0:0:0:0 | [] |
-| main.rs:2469:31:2469:39 | [...] | [T;...] | {EXTERNAL LOCATION} | i32 |
-| main.rs:2469:31:2469:39 | [...] | [T;...] | {EXTERNAL LOCATION} | u32 |
-| main.rs:2469:32:2469:32 | 1 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2469:32:2469:32 | 1 |  | {EXTERNAL LOCATION} | u32 |
-| main.rs:2469:35:2469:35 | 2 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2469:35:2469:35 | 2 |  | {EXTERNAL LOCATION} | u32 |
-| main.rs:2469:38:2469:38 | 3 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2469:38:2469:38 | 3 |  | {EXTERNAL LOCATION} | u32 |
-| main.rs:2470:13:2470:13 | u |  | {EXTERNAL LOCATION} | u32 |
-| main.rs:2470:18:2470:22 | vals3 |  | file://:0:0:0:0 | [] |
-| main.rs:2470:18:2470:22 | vals3 | [T;...] | {EXTERNAL LOCATION} | u32 |
-| main.rs:2472:13:2472:17 | vals4 |  | file://:0:0:0:0 | [] |
-| main.rs:2472:13:2472:17 | vals4 | [T;...] | {EXTERNAL LOCATION} | u64 |
-| main.rs:2472:26:2472:26 | 3 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2472:31:2472:36 | [1; 3] |  | file://:0:0:0:0 | [] |
-| main.rs:2472:31:2472:36 | [1; 3] | [T;...] | {EXTERNAL LOCATION} | i32 |
-| main.rs:2472:31:2472:36 | [1; 3] | [T;...] | {EXTERNAL LOCATION} | u64 |
-| main.rs:2472:32:2472:32 | 1 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2472:32:2472:32 | 1 |  | {EXTERNAL LOCATION} | u64 |
-| main.rs:2472:35:2472:35 | 3 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2473:13:2473:13 | u |  | {EXTERNAL LOCATION} | u64 |
-| main.rs:2473:18:2473:22 | vals4 |  | file://:0:0:0:0 | [] |
-| main.rs:2473:18:2473:22 | vals4 | [T;...] | {EXTERNAL LOCATION} | u64 |
-| main.rs:2475:17:2475:24 | strings1 |  | file://:0:0:0:0 | [] |
-| main.rs:2475:17:2475:24 | strings1 | [T;...] | file://:0:0:0:0 | & |
-| main.rs:2475:17:2475:24 | strings1 | [T;...].&T | {EXTERNAL LOCATION} | str |
-| main.rs:2475:28:2475:48 | [...] |  | file://:0:0:0:0 | [] |
-| main.rs:2475:28:2475:48 | [...] | [T;...] | file://:0:0:0:0 | & |
-| main.rs:2475:28:2475:48 | [...] | [T;...].&T | {EXTERNAL LOCATION} | str |
-| main.rs:2475:29:2475:33 | "foo" |  | file://:0:0:0:0 | & |
-| main.rs:2475:29:2475:33 | "foo" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:2475:36:2475:40 | "bar" |  | file://:0:0:0:0 | & |
-| main.rs:2475:36:2475:40 | "bar" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:2475:43:2475:47 | "baz" |  | file://:0:0:0:0 | & |
-| main.rs:2475:43:2475:47 | "baz" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:2462:13:2462:17 | vals1 |  | file://:0:0:0:0 | [] |
+| main.rs:2462:13:2462:17 | vals1 | [T;...] | {EXTERNAL LOCATION} | i32 |
+| main.rs:2462:13:2462:17 | vals1 | [T;...] | {EXTERNAL LOCATION} | u8 |
+| main.rs:2462:21:2462:31 | [...] |  | file://:0:0:0:0 | [] |
+| main.rs:2462:21:2462:31 | [...] | [T;...] | {EXTERNAL LOCATION} | i32 |
+| main.rs:2462:21:2462:31 | [...] | [T;...] | {EXTERNAL LOCATION} | u8 |
+| main.rs:2462:22:2462:24 | 1u8 |  | {EXTERNAL LOCATION} | u8 |
+| main.rs:2462:27:2462:27 | 2 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2462:27:2462:27 | 2 |  | {EXTERNAL LOCATION} | u8 |
+| main.rs:2462:30:2462:30 | 3 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2462:30:2462:30 | 3 |  | {EXTERNAL LOCATION} | u8 |
+| main.rs:2463:13:2463:13 | u |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2463:13:2463:13 | u |  | {EXTERNAL LOCATION} | u8 |
+| main.rs:2463:18:2463:22 | vals1 |  | file://:0:0:0:0 | [] |
+| main.rs:2463:18:2463:22 | vals1 | [T;...] | {EXTERNAL LOCATION} | i32 |
+| main.rs:2463:18:2463:22 | vals1 | [T;...] | {EXTERNAL LOCATION} | u8 |
+| main.rs:2465:13:2465:17 | vals2 |  | file://:0:0:0:0 | [] |
+| main.rs:2465:13:2465:17 | vals2 | [T;...] | {EXTERNAL LOCATION} | u16 |
+| main.rs:2465:21:2465:29 | [1u16; 3] |  | file://:0:0:0:0 | [] |
+| main.rs:2465:21:2465:29 | [1u16; 3] | [T;...] | {EXTERNAL LOCATION} | u16 |
+| main.rs:2465:22:2465:25 | 1u16 |  | {EXTERNAL LOCATION} | u16 |
+| main.rs:2465:28:2465:28 | 3 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2466:13:2466:13 | u |  | {EXTERNAL LOCATION} | u16 |
+| main.rs:2466:18:2466:22 | vals2 |  | file://:0:0:0:0 | [] |
+| main.rs:2466:18:2466:22 | vals2 | [T;...] | {EXTERNAL LOCATION} | u16 |
+| main.rs:2468:13:2468:17 | vals3 |  | file://:0:0:0:0 | [] |
+| main.rs:2468:13:2468:17 | vals3 | [T;...] | {EXTERNAL LOCATION} | u32 |
+| main.rs:2468:26:2468:26 | 3 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2468:31:2468:39 | [...] |  | file://:0:0:0:0 | [] |
+| main.rs:2468:31:2468:39 | [...] | [T;...] | {EXTERNAL LOCATION} | i32 |
+| main.rs:2468:31:2468:39 | [...] | [T;...] | {EXTERNAL LOCATION} | u32 |
+| main.rs:2468:32:2468:32 | 1 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2468:32:2468:32 | 1 |  | {EXTERNAL LOCATION} | u32 |
+| main.rs:2468:35:2468:35 | 2 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2468:35:2468:35 | 2 |  | {EXTERNAL LOCATION} | u32 |
+| main.rs:2468:38:2468:38 | 3 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2468:38:2468:38 | 3 |  | {EXTERNAL LOCATION} | u32 |
+| main.rs:2469:13:2469:13 | u |  | {EXTERNAL LOCATION} | u32 |
+| main.rs:2469:18:2469:22 | vals3 |  | file://:0:0:0:0 | [] |
+| main.rs:2469:18:2469:22 | vals3 | [T;...] | {EXTERNAL LOCATION} | u32 |
+| main.rs:2471:13:2471:17 | vals4 |  | file://:0:0:0:0 | [] |
+| main.rs:2471:13:2471:17 | vals4 | [T;...] | {EXTERNAL LOCATION} | u64 |
+| main.rs:2471:26:2471:26 | 3 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2471:31:2471:36 | [1; 3] |  | file://:0:0:0:0 | [] |
+| main.rs:2471:31:2471:36 | [1; 3] | [T;...] | {EXTERNAL LOCATION} | i32 |
+| main.rs:2471:31:2471:36 | [1; 3] | [T;...] | {EXTERNAL LOCATION} | u64 |
+| main.rs:2471:32:2471:32 | 1 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2471:32:2471:32 | 1 |  | {EXTERNAL LOCATION} | u64 |
+| main.rs:2471:35:2471:35 | 3 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2472:13:2472:13 | u |  | {EXTERNAL LOCATION} | u64 |
+| main.rs:2472:18:2472:22 | vals4 |  | file://:0:0:0:0 | [] |
+| main.rs:2472:18:2472:22 | vals4 | [T;...] | {EXTERNAL LOCATION} | u64 |
+| main.rs:2474:17:2474:24 | strings1 |  | file://:0:0:0:0 | [] |
+| main.rs:2474:17:2474:24 | strings1 | [T;...] | file://:0:0:0:0 | & |
+| main.rs:2474:17:2474:24 | strings1 | [T;...].&T | {EXTERNAL LOCATION} | str |
+| main.rs:2474:28:2474:48 | [...] |  | file://:0:0:0:0 | [] |
+| main.rs:2474:28:2474:48 | [...] | [T;...] | file://:0:0:0:0 | & |
+| main.rs:2474:28:2474:48 | [...] | [T;...].&T | {EXTERNAL LOCATION} | str |
+| main.rs:2474:29:2474:33 | "foo" |  | file://:0:0:0:0 | & |
+| main.rs:2474:29:2474:33 | "foo" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:2474:36:2474:40 | "bar" |  | file://:0:0:0:0 | & |
+| main.rs:2474:36:2474:40 | "bar" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:2474:43:2474:47 | "baz" |  | file://:0:0:0:0 | & |
+| main.rs:2474:43:2474:47 | "baz" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:2475:13:2475:13 | s |  | {EXTERNAL LOCATION} | Item |
+| main.rs:2475:13:2475:13 | s |  | file://:0:0:0:0 | & |
+| main.rs:2475:13:2475:13 | s | &T | file://:0:0:0:0 | & |
+| main.rs:2475:13:2475:13 | s | &T.&T | {EXTERNAL LOCATION} | str |
+| main.rs:2475:18:2475:26 | &strings1 |  | file://:0:0:0:0 | & |
+| main.rs:2475:18:2475:26 | &strings1 | &T | file://:0:0:0:0 | [] |
+| main.rs:2475:18:2475:26 | &strings1 | &T.[T;...] | file://:0:0:0:0 | & |
+| main.rs:2475:18:2475:26 | &strings1 | &T.[T;...].&T | {EXTERNAL LOCATION} | str |
+| main.rs:2475:19:2475:26 | strings1 |  | file://:0:0:0:0 | [] |
+| main.rs:2475:19:2475:26 | strings1 | [T;...] | file://:0:0:0:0 | & |
+| main.rs:2475:19:2475:26 | strings1 | [T;...].&T | {EXTERNAL LOCATION} | str |
 | main.rs:2476:13:2476:13 | s |  | {EXTERNAL LOCATION} | Item |
 | main.rs:2476:13:2476:13 | s |  | file://:0:0:0:0 | & |
 | main.rs:2476:13:2476:13 | s | &T | file://:0:0:0:0 | & |
 | main.rs:2476:13:2476:13 | s | &T.&T | {EXTERNAL LOCATION} | str |
-| main.rs:2476:18:2476:26 | &strings1 |  | file://:0:0:0:0 | & |
-| main.rs:2476:18:2476:26 | &strings1 | &T | file://:0:0:0:0 | [] |
-| main.rs:2476:18:2476:26 | &strings1 | &T.[T;...] | file://:0:0:0:0 | & |
-| main.rs:2476:18:2476:26 | &strings1 | &T.[T;...].&T | {EXTERNAL LOCATION} | str |
-| main.rs:2476:19:2476:26 | strings1 |  | file://:0:0:0:0 | [] |
-| main.rs:2476:19:2476:26 | strings1 | [T;...] | file://:0:0:0:0 | & |
-| main.rs:2476:19:2476:26 | strings1 | [T;...].&T | {EXTERNAL LOCATION} | str |
-| main.rs:2477:13:2477:13 | s |  | {EXTERNAL LOCATION} | Item |
+| main.rs:2476:18:2476:30 | &mut strings1 |  | file://:0:0:0:0 | & |
+| main.rs:2476:18:2476:30 | &mut strings1 | &T | file://:0:0:0:0 | [] |
+| main.rs:2476:18:2476:30 | &mut strings1 | &T.[T;...] | file://:0:0:0:0 | & |
+| main.rs:2476:18:2476:30 | &mut strings1 | &T.[T;...].&T | {EXTERNAL LOCATION} | str |
+| main.rs:2476:23:2476:30 | strings1 |  | file://:0:0:0:0 | [] |
+| main.rs:2476:23:2476:30 | strings1 | [T;...] | file://:0:0:0:0 | & |
+| main.rs:2476:23:2476:30 | strings1 | [T;...].&T | {EXTERNAL LOCATION} | str |
 | main.rs:2477:13:2477:13 | s |  | file://:0:0:0:0 | & |
-| main.rs:2477:13:2477:13 | s | &T | file://:0:0:0:0 | & |
-| main.rs:2477:13:2477:13 | s | &T.&T | {EXTERNAL LOCATION} | str |
-| main.rs:2477:18:2477:30 | &mut strings1 |  | file://:0:0:0:0 | & |
-| main.rs:2477:18:2477:30 | &mut strings1 | &T | file://:0:0:0:0 | [] |
-| main.rs:2477:18:2477:30 | &mut strings1 | &T.[T;...] | file://:0:0:0:0 | & |
-| main.rs:2477:18:2477:30 | &mut strings1 | &T.[T;...].&T | {EXTERNAL LOCATION} | str |
-| main.rs:2477:23:2477:30 | strings1 |  | file://:0:0:0:0 | [] |
-| main.rs:2477:23:2477:30 | strings1 | [T;...] | file://:0:0:0:0 | & |
-| main.rs:2477:23:2477:30 | strings1 | [T;...].&T | {EXTERNAL LOCATION} | str |
-| main.rs:2478:13:2478:13 | s |  | file://:0:0:0:0 | & |
-| main.rs:2478:13:2478:13 | s | &T | {EXTERNAL LOCATION} | str |
-| main.rs:2478:18:2478:25 | strings1 |  | file://:0:0:0:0 | [] |
-| main.rs:2478:18:2478:25 | strings1 | [T;...] | file://:0:0:0:0 | & |
-| main.rs:2478:18:2478:25 | strings1 | [T;...].&T | {EXTERNAL LOCATION} | str |
-| main.rs:2480:13:2480:20 | strings2 |  | file://:0:0:0:0 | [] |
-| main.rs:2480:13:2480:20 | strings2 | [T;...] | {EXTERNAL LOCATION} | String |
-| main.rs:2481:9:2485:9 | [...] |  | file://:0:0:0:0 | [] |
-| main.rs:2481:9:2485:9 | [...] | [T;...] | {EXTERNAL LOCATION} | String |
+| main.rs:2477:13:2477:13 | s | &T | {EXTERNAL LOCATION} | str |
+| main.rs:2477:18:2477:25 | strings1 |  | file://:0:0:0:0 | [] |
+| main.rs:2477:18:2477:25 | strings1 | [T;...] | file://:0:0:0:0 | & |
+| main.rs:2477:18:2477:25 | strings1 | [T;...].&T | {EXTERNAL LOCATION} | str |
+| main.rs:2479:13:2479:20 | strings2 |  | file://:0:0:0:0 | [] |
+| main.rs:2479:13:2479:20 | strings2 | [T;...] | {EXTERNAL LOCATION} | String |
+| main.rs:2480:9:2484:9 | [...] |  | file://:0:0:0:0 | [] |
+| main.rs:2480:9:2484:9 | [...] | [T;...] | {EXTERNAL LOCATION} | String |
+| main.rs:2481:13:2481:31 | ...::from(...) |  | {EXTERNAL LOCATION} | String |
+| main.rs:2481:26:2481:30 | "foo" |  | file://:0:0:0:0 | & |
+| main.rs:2481:26:2481:30 | "foo" | &T | {EXTERNAL LOCATION} | str |
 | main.rs:2482:13:2482:31 | ...::from(...) |  | {EXTERNAL LOCATION} | String |
-| main.rs:2482:26:2482:30 | "foo" |  | file://:0:0:0:0 | & |
-| main.rs:2482:26:2482:30 | "foo" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:2482:26:2482:30 | "bar" |  | file://:0:0:0:0 | & |
+| main.rs:2482:26:2482:30 | "bar" | &T | {EXTERNAL LOCATION} | str |
 | main.rs:2483:13:2483:31 | ...::from(...) |  | {EXTERNAL LOCATION} | String |
-| main.rs:2483:26:2483:30 | "bar" |  | file://:0:0:0:0 | & |
-| main.rs:2483:26:2483:30 | "bar" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:2484:13:2484:31 | ...::from(...) |  | {EXTERNAL LOCATION} | String |
-| main.rs:2484:26:2484:30 | "baz" |  | file://:0:0:0:0 | & |
-| main.rs:2484:26:2484:30 | "baz" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:2486:13:2486:13 | s |  | {EXTERNAL LOCATION} | String |
-| main.rs:2486:18:2486:25 | strings2 |  | file://:0:0:0:0 | [] |
-| main.rs:2486:18:2486:25 | strings2 | [T;...] | {EXTERNAL LOCATION} | String |
-| main.rs:2488:13:2488:20 | strings3 |  | file://:0:0:0:0 | & |
-| main.rs:2488:13:2488:20 | strings3 | &T | file://:0:0:0:0 | [] |
-| main.rs:2488:13:2488:20 | strings3 | &T.[T;...] | {EXTERNAL LOCATION} | String |
-| main.rs:2489:9:2493:9 | &... |  | file://:0:0:0:0 | & |
-| main.rs:2489:9:2493:9 | &... | &T | file://:0:0:0:0 | [] |
-| main.rs:2489:9:2493:9 | &... | &T.[T;...] | {EXTERNAL LOCATION} | String |
-| main.rs:2489:10:2493:9 | [...] |  | file://:0:0:0:0 | [] |
-| main.rs:2489:10:2493:9 | [...] | [T;...] | {EXTERNAL LOCATION} | String |
+| main.rs:2483:26:2483:30 | "baz" |  | file://:0:0:0:0 | & |
+| main.rs:2483:26:2483:30 | "baz" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:2485:13:2485:13 | s |  | {EXTERNAL LOCATION} | String |
+| main.rs:2485:18:2485:25 | strings2 |  | file://:0:0:0:0 | [] |
+| main.rs:2485:18:2485:25 | strings2 | [T;...] | {EXTERNAL LOCATION} | String |
+| main.rs:2487:13:2487:20 | strings3 |  | file://:0:0:0:0 | & |
+| main.rs:2487:13:2487:20 | strings3 | &T | file://:0:0:0:0 | [] |
+| main.rs:2487:13:2487:20 | strings3 | &T.[T;...] | {EXTERNAL LOCATION} | String |
+| main.rs:2488:9:2492:9 | &... |  | file://:0:0:0:0 | & |
+| main.rs:2488:9:2492:9 | &... | &T | file://:0:0:0:0 | [] |
+| main.rs:2488:9:2492:9 | &... | &T.[T;...] | {EXTERNAL LOCATION} | String |
+| main.rs:2488:10:2492:9 | [...] |  | file://:0:0:0:0 | [] |
+| main.rs:2488:10:2492:9 | [...] | [T;...] | {EXTERNAL LOCATION} | String |
+| main.rs:2489:13:2489:31 | ...::from(...) |  | {EXTERNAL LOCATION} | String |
+| main.rs:2489:26:2489:30 | "foo" |  | file://:0:0:0:0 | & |
+| main.rs:2489:26:2489:30 | "foo" | &T | {EXTERNAL LOCATION} | str |
 | main.rs:2490:13:2490:31 | ...::from(...) |  | {EXTERNAL LOCATION} | String |
-| main.rs:2490:26:2490:30 | "foo" |  | file://:0:0:0:0 | & |
-| main.rs:2490:26:2490:30 | "foo" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:2490:26:2490:30 | "bar" |  | file://:0:0:0:0 | & |
+| main.rs:2490:26:2490:30 | "bar" | &T | {EXTERNAL LOCATION} | str |
 | main.rs:2491:13:2491:31 | ...::from(...) |  | {EXTERNAL LOCATION} | String |
-| main.rs:2491:26:2491:30 | "bar" |  | file://:0:0:0:0 | & |
-| main.rs:2491:26:2491:30 | "bar" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:2492:13:2492:31 | ...::from(...) |  | {EXTERNAL LOCATION} | String |
-| main.rs:2492:26:2492:30 | "baz" |  | file://:0:0:0:0 | & |
-| main.rs:2492:26:2492:30 | "baz" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:2494:13:2494:13 | s |  | {EXTERNAL LOCATION} | Item |
-| main.rs:2494:13:2494:13 | s |  | file://:0:0:0:0 | & |
-| main.rs:2494:13:2494:13 | s | &T | {EXTERNAL LOCATION} | String |
-| main.rs:2494:18:2494:25 | strings3 |  | file://:0:0:0:0 | & |
-| main.rs:2494:18:2494:25 | strings3 | &T | file://:0:0:0:0 | [] |
-| main.rs:2494:18:2494:25 | strings3 | &T.[T;...] | {EXTERNAL LOCATION} | String |
-| main.rs:2496:13:2496:21 | callables |  | file://:0:0:0:0 | [] |
-| main.rs:2496:13:2496:21 | callables | [T;...] | main.rs:2444:5:2444:24 | MyCallable |
-| main.rs:2496:25:2496:81 | [...] |  | file://:0:0:0:0 | [] |
-| main.rs:2496:25:2496:81 | [...] | [T;...] | main.rs:2444:5:2444:24 | MyCallable |
-| main.rs:2496:26:2496:42 | ...::new(...) |  | main.rs:2444:5:2444:24 | MyCallable |
-| main.rs:2496:45:2496:61 | ...::new(...) |  | main.rs:2444:5:2444:24 | MyCallable |
-| main.rs:2496:64:2496:80 | ...::new(...) |  | main.rs:2444:5:2444:24 | MyCallable |
-| main.rs:2497:13:2497:13 | c |  | main.rs:2444:5:2444:24 | MyCallable |
-| main.rs:2498:12:2498:20 | callables |  | file://:0:0:0:0 | [] |
-| main.rs:2498:12:2498:20 | callables | [T;...] | main.rs:2444:5:2444:24 | MyCallable |
-| main.rs:2500:17:2500:22 | result |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2500:26:2500:26 | c |  | main.rs:2444:5:2444:24 | MyCallable |
-| main.rs:2500:26:2500:33 | c.call() |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2505:13:2505:13 | i |  | {EXTERNAL LOCATION} | Item |
-| main.rs:2505:13:2505:13 | i |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2505:18:2505:18 | 0 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2505:18:2505:22 | 0..10 |  | {EXTERNAL LOCATION} | Range |
-| main.rs:2505:18:2505:22 | 0..10 | Idx | {EXTERNAL LOCATION} | i32 |
-| main.rs:2505:21:2505:22 | 10 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2506:13:2506:13 | u |  | {EXTERNAL LOCATION} | Range |
-| main.rs:2506:13:2506:13 | u | Idx | {EXTERNAL LOCATION} | i32 |
-| main.rs:2506:13:2506:13 | u | Idx | {EXTERNAL LOCATION} | u8 |
-| main.rs:2506:18:2506:26 | [...] |  | file://:0:0:0:0 | [] |
-| main.rs:2506:18:2506:26 | [...] | [T;...] | {EXTERNAL LOCATION} | Range |
-| main.rs:2506:18:2506:26 | [...] | [T;...].Idx | {EXTERNAL LOCATION} | i32 |
-| main.rs:2506:18:2506:26 | [...] | [T;...].Idx | {EXTERNAL LOCATION} | u8 |
-| main.rs:2506:19:2506:21 | 0u8 |  | {EXTERNAL LOCATION} | u8 |
-| main.rs:2506:19:2506:25 | 0u8..10 |  | {EXTERNAL LOCATION} | Range |
-| main.rs:2506:19:2506:25 | 0u8..10 | Idx | {EXTERNAL LOCATION} | i32 |
-| main.rs:2506:19:2506:25 | 0u8..10 | Idx | {EXTERNAL LOCATION} | u8 |
+| main.rs:2491:26:2491:30 | "baz" |  | file://:0:0:0:0 | & |
+| main.rs:2491:26:2491:30 | "baz" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:2493:13:2493:13 | s |  | {EXTERNAL LOCATION} | Item |
+| main.rs:2493:13:2493:13 | s |  | file://:0:0:0:0 | & |
+| main.rs:2493:13:2493:13 | s | &T | {EXTERNAL LOCATION} | String |
+| main.rs:2493:18:2493:25 | strings3 |  | file://:0:0:0:0 | & |
+| main.rs:2493:18:2493:25 | strings3 | &T | file://:0:0:0:0 | [] |
+| main.rs:2493:18:2493:25 | strings3 | &T.[T;...] | {EXTERNAL LOCATION} | String |
+| main.rs:2495:13:2495:21 | callables |  | file://:0:0:0:0 | [] |
+| main.rs:2495:13:2495:21 | callables | [T;...] | main.rs:2443:5:2443:24 | MyCallable |
+| main.rs:2495:25:2495:81 | [...] |  | file://:0:0:0:0 | [] |
+| main.rs:2495:25:2495:81 | [...] | [T;...] | main.rs:2443:5:2443:24 | MyCallable |
+| main.rs:2495:26:2495:42 | ...::new(...) |  | main.rs:2443:5:2443:24 | MyCallable |
+| main.rs:2495:45:2495:61 | ...::new(...) |  | main.rs:2443:5:2443:24 | MyCallable |
+| main.rs:2495:64:2495:80 | ...::new(...) |  | main.rs:2443:5:2443:24 | MyCallable |
+| main.rs:2496:13:2496:13 | c |  | main.rs:2443:5:2443:24 | MyCallable |
+| main.rs:2497:12:2497:20 | callables |  | file://:0:0:0:0 | [] |
+| main.rs:2497:12:2497:20 | callables | [T;...] | main.rs:2443:5:2443:24 | MyCallable |
+| main.rs:2499:17:2499:22 | result |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2499:26:2499:26 | c |  | main.rs:2443:5:2443:24 | MyCallable |
+| main.rs:2499:26:2499:33 | c.call() |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2504:13:2504:13 | i |  | {EXTERNAL LOCATION} | Item |
+| main.rs:2504:13:2504:13 | i |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2504:18:2504:18 | 0 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2504:18:2504:22 | 0..10 |  | {EXTERNAL LOCATION} | Range |
+| main.rs:2504:18:2504:22 | 0..10 | Idx | {EXTERNAL LOCATION} | i32 |
+| main.rs:2504:21:2504:22 | 10 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2505:13:2505:13 | u |  | {EXTERNAL LOCATION} | Range |
+| main.rs:2505:13:2505:13 | u | Idx | {EXTERNAL LOCATION} | i32 |
+| main.rs:2505:13:2505:13 | u | Idx | {EXTERNAL LOCATION} | u8 |
+| main.rs:2505:18:2505:26 | [...] |  | file://:0:0:0:0 | [] |
+| main.rs:2505:18:2505:26 | [...] | [T;...] | {EXTERNAL LOCATION} | Range |
+| main.rs:2505:18:2505:26 | [...] | [T;...].Idx | {EXTERNAL LOCATION} | i32 |
+| main.rs:2505:18:2505:26 | [...] | [T;...].Idx | {EXTERNAL LOCATION} | u8 |
+| main.rs:2505:19:2505:21 | 0u8 |  | {EXTERNAL LOCATION} | u8 |
+| main.rs:2505:19:2505:25 | 0u8..10 |  | {EXTERNAL LOCATION} | Range |
+| main.rs:2505:19:2505:25 | 0u8..10 | Idx | {EXTERNAL LOCATION} | i32 |
+| main.rs:2505:19:2505:25 | 0u8..10 | Idx | {EXTERNAL LOCATION} | u8 |
+| main.rs:2505:24:2505:25 | 10 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2505:24:2505:25 | 10 |  | {EXTERNAL LOCATION} | u8 |
+| main.rs:2506:13:2506:17 | range |  | {EXTERNAL LOCATION} | Range |
+| main.rs:2506:13:2506:17 | range | Idx | {EXTERNAL LOCATION} | i32 |
+| main.rs:2506:21:2506:21 | 0 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2506:21:2506:25 | 0..10 |  | {EXTERNAL LOCATION} | Range |
+| main.rs:2506:21:2506:25 | 0..10 | Idx | {EXTERNAL LOCATION} | i32 |
 | main.rs:2506:24:2506:25 | 10 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2506:24:2506:25 | 10 |  | {EXTERNAL LOCATION} | u8 |
-| main.rs:2507:13:2507:17 | range |  | {EXTERNAL LOCATION} | Range |
-| main.rs:2507:13:2507:17 | range | Idx | {EXTERNAL LOCATION} | i32 |
-| main.rs:2507:21:2507:21 | 0 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2507:21:2507:25 | 0..10 |  | {EXTERNAL LOCATION} | Range |
-| main.rs:2507:21:2507:25 | 0..10 | Idx | {EXTERNAL LOCATION} | i32 |
-| main.rs:2507:24:2507:25 | 10 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2508:13:2508:13 | i |  | {EXTERNAL LOCATION} | Item |
-| main.rs:2508:13:2508:13 | i |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2508:18:2508:22 | range |  | {EXTERNAL LOCATION} | Range |
-| main.rs:2508:18:2508:22 | range | Idx | {EXTERNAL LOCATION} | i32 |
-| main.rs:2509:13:2509:22 | range_full |  | {EXTERNAL LOCATION} | RangeFull |
-| main.rs:2509:26:2509:27 | .. |  | {EXTERNAL LOCATION} | RangeFull |
-| main.rs:2510:13:2510:13 | i |  | {EXTERNAL LOCATION} | Item |
-| main.rs:2510:18:2510:48 | &... |  | file://:0:0:0:0 | & |
-| main.rs:2510:19:2510:36 | [...] |  | file://:0:0:0:0 | [] |
-| main.rs:2510:19:2510:36 | [...] | [T;...] | {EXTERNAL LOCATION} | i64 |
-| main.rs:2510:20:2510:23 | 1i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2510:26:2510:29 | 2i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2510:32:2510:35 | 3i64 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2510:38:2510:47 | range_full |  | {EXTERNAL LOCATION} | RangeFull |
-| main.rs:2512:13:2512:18 | range1 |  | {EXTERNAL LOCATION} | Range |
-| main.rs:2512:13:2512:18 | range1 | Idx | {EXTERNAL LOCATION} | u16 |
-| main.rs:2513:9:2516:9 | ...::Range {...} |  | {EXTERNAL LOCATION} | Range |
-| main.rs:2513:9:2516:9 | ...::Range {...} | Idx | {EXTERNAL LOCATION} | u16 |
-| main.rs:2514:20:2514:23 | 0u16 |  | {EXTERNAL LOCATION} | u16 |
-| main.rs:2515:18:2515:22 | 10u16 |  | {EXTERNAL LOCATION} | u16 |
-| main.rs:2517:13:2517:13 | u |  | {EXTERNAL LOCATION} | Item |
-| main.rs:2517:13:2517:13 | u |  | {EXTERNAL LOCATION} | u16 |
-| main.rs:2517:18:2517:23 | range1 |  | {EXTERNAL LOCATION} | Range |
-| main.rs:2517:18:2517:23 | range1 | Idx | {EXTERNAL LOCATION} | u16 |
-| main.rs:2521:26:2521:26 | 1 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2521:29:2521:29 | 2 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2521:32:2521:32 | 3 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2524:13:2524:18 | vals4a |  | {EXTERNAL LOCATION} | Vec |
-| main.rs:2524:13:2524:18 | vals4a | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2524:13:2524:18 | vals4a | T | {EXTERNAL LOCATION} | u16 |
-| main.rs:2524:32:2524:43 | [...] |  | file://:0:0:0:0 | [] |
-| main.rs:2524:32:2524:43 | [...] | [T;...] | {EXTERNAL LOCATION} | i32 |
-| main.rs:2524:32:2524:43 | [...] | [T;...] | {EXTERNAL LOCATION} | u16 |
-| main.rs:2524:32:2524:52 | ... .to_vec() |  | {EXTERNAL LOCATION} | Vec |
-| main.rs:2524:32:2524:52 | ... .to_vec() | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2524:32:2524:52 | ... .to_vec() | T | {EXTERNAL LOCATION} | u16 |
-| main.rs:2524:33:2524:36 | 1u16 |  | {EXTERNAL LOCATION} | u16 |
-| main.rs:2524:39:2524:39 | 2 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2524:42:2524:42 | 3 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2525:13:2525:13 | u |  | {EXTERNAL LOCATION} | u16 |
-| main.rs:2525:13:2525:13 | u |  | file://:0:0:0:0 | & |
-| main.rs:2525:18:2525:23 | vals4a |  | {EXTERNAL LOCATION} | Vec |
-| main.rs:2525:18:2525:23 | vals4a | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2525:18:2525:23 | vals4a | T | {EXTERNAL LOCATION} | u16 |
-| main.rs:2527:22:2527:33 | [...] |  | file://:0:0:0:0 | [] |
-| main.rs:2527:22:2527:33 | [...] | [T;...] | {EXTERNAL LOCATION} | i32 |
-| main.rs:2527:22:2527:33 | [...] | [T;...] | {EXTERNAL LOCATION} | u16 |
-| main.rs:2527:23:2527:26 | 1u16 |  | {EXTERNAL LOCATION} | u16 |
-| main.rs:2527:29:2527:29 | 2 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2527:32:2527:32 | 3 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2530:13:2530:17 | vals5 |  | {EXTERNAL LOCATION} | Vec |
-| main.rs:2530:13:2530:17 | vals5 | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2530:13:2530:17 | vals5 | T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2530:13:2530:17 | vals5 | T | {EXTERNAL LOCATION} | u32 |
-| main.rs:2530:21:2530:43 | ...::from(...) |  | {EXTERNAL LOCATION} | Vec |
-| main.rs:2530:21:2530:43 | ...::from(...) | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2530:21:2530:43 | ...::from(...) | T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2530:21:2530:43 | ...::from(...) | T | {EXTERNAL LOCATION} | u32 |
-| main.rs:2530:31:2530:42 | [...] |  | file://:0:0:0:0 | [] |
-| main.rs:2530:31:2530:42 | [...] | [T;...] | {EXTERNAL LOCATION} | i32 |
-| main.rs:2530:31:2530:42 | [...] | [T;...] | {EXTERNAL LOCATION} | u32 |
-| main.rs:2530:32:2530:35 | 1u32 |  | {EXTERNAL LOCATION} | u32 |
-| main.rs:2530:38:2530:38 | 2 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2530:41:2530:41 | 3 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2531:13:2531:13 | u |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2531:13:2531:13 | u |  | {EXTERNAL LOCATION} | u32 |
-| main.rs:2531:13:2531:13 | u |  | file://:0:0:0:0 | & |
-| main.rs:2531:18:2531:22 | vals5 |  | {EXTERNAL LOCATION} | Vec |
-| main.rs:2531:18:2531:22 | vals5 | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2531:18:2531:22 | vals5 | T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2531:18:2531:22 | vals5 | T | {EXTERNAL LOCATION} | u32 |
-| main.rs:2533:13:2533:17 | vals6 |  | {EXTERNAL LOCATION} | Vec |
-| main.rs:2533:13:2533:17 | vals6 | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2533:13:2533:17 | vals6 | T | file://:0:0:0:0 | & |
-| main.rs:2533:13:2533:17 | vals6 | T.&T | {EXTERNAL LOCATION} | u64 |
-| main.rs:2533:32:2533:43 | [...] |  | file://:0:0:0:0 | [] |
-| main.rs:2533:32:2533:43 | [...] | [T;...] | {EXTERNAL LOCATION} | i32 |
-| main.rs:2533:32:2533:43 | [...] | [T;...] | {EXTERNAL LOCATION} | u64 |
-| main.rs:2533:32:2533:60 | ... .collect() |  | {EXTERNAL LOCATION} | Vec |
-| main.rs:2533:32:2533:60 | ... .collect() | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2533:32:2533:60 | ... .collect() | T | file://:0:0:0:0 | & |
-| main.rs:2533:32:2533:60 | ... .collect() | T.&T | {EXTERNAL LOCATION} | u64 |
-| main.rs:2533:33:2533:36 | 1u64 |  | {EXTERNAL LOCATION} | u64 |
-| main.rs:2533:39:2533:39 | 2 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2533:42:2533:42 | 3 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2534:13:2534:13 | u |  | file://:0:0:0:0 | & |
-| main.rs:2534:13:2534:13 | u | &T | {EXTERNAL LOCATION} | u64 |
-| main.rs:2534:18:2534:22 | vals6 |  | {EXTERNAL LOCATION} | Vec |
-| main.rs:2534:18:2534:22 | vals6 | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2534:18:2534:22 | vals6 | T | file://:0:0:0:0 | & |
-| main.rs:2534:18:2534:22 | vals6 | T.&T | {EXTERNAL LOCATION} | u64 |
-| main.rs:2536:17:2536:21 | vals7 |  | {EXTERNAL LOCATION} | Vec |
-| main.rs:2536:17:2536:21 | vals7 | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2536:17:2536:21 | vals7 | T | {EXTERNAL LOCATION} | u8 |
-| main.rs:2536:25:2536:34 | ...::new(...) |  | {EXTERNAL LOCATION} | Vec |
-| main.rs:2536:25:2536:34 | ...::new(...) | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2536:25:2536:34 | ...::new(...) | T | {EXTERNAL LOCATION} | u8 |
-| main.rs:2537:9:2537:13 | vals7 |  | {EXTERNAL LOCATION} | Vec |
-| main.rs:2537:9:2537:13 | vals7 | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2537:9:2537:13 | vals7 | T | {EXTERNAL LOCATION} | u8 |
-| main.rs:2537:20:2537:22 | 1u8 |  | {EXTERNAL LOCATION} | u8 |
-| main.rs:2538:13:2538:13 | u |  | {EXTERNAL LOCATION} | u8 |
-| main.rs:2538:13:2538:13 | u |  | file://:0:0:0:0 | & |
-| main.rs:2538:18:2538:22 | vals7 |  | {EXTERNAL LOCATION} | Vec |
-| main.rs:2538:18:2538:22 | vals7 | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2538:18:2538:22 | vals7 | T | {EXTERNAL LOCATION} | u8 |
-| main.rs:2540:33:2540:33 | 1 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2540:36:2540:36 | 2 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2540:45:2540:45 | 3 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2540:48:2540:48 | 4 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2547:17:2547:20 | map1 |  | {EXTERNAL LOCATION} | HashMap |
-| main.rs:2547:17:2547:20 | map1 | K | {EXTERNAL LOCATION} | i32 |
-| main.rs:2547:17:2547:20 | map1 | S | {EXTERNAL LOCATION} | RandomState |
-| main.rs:2547:17:2547:20 | map1 | V | {EXTERNAL LOCATION} | Box |
-| main.rs:2547:17:2547:20 | map1 | V.A | {EXTERNAL LOCATION} | Global |
-| main.rs:2547:17:2547:20 | map1 | V.T | file://:0:0:0:0 | & |
-| main.rs:2547:17:2547:20 | map1 | V.T.&T | {EXTERNAL LOCATION} | str |
-| main.rs:2547:24:2547:55 | ...::new(...) |  | {EXTERNAL LOCATION} | HashMap |
-| main.rs:2547:24:2547:55 | ...::new(...) | K | {EXTERNAL LOCATION} | i32 |
-| main.rs:2547:24:2547:55 | ...::new(...) | S | {EXTERNAL LOCATION} | RandomState |
-| main.rs:2547:24:2547:55 | ...::new(...) | V | {EXTERNAL LOCATION} | Box |
-| main.rs:2547:24:2547:55 | ...::new(...) | V.A | {EXTERNAL LOCATION} | Global |
-| main.rs:2547:24:2547:55 | ...::new(...) | V.T | file://:0:0:0:0 | & |
-| main.rs:2547:24:2547:55 | ...::new(...) | V.T.&T | {EXTERNAL LOCATION} | str |
+| main.rs:2507:13:2507:13 | i |  | {EXTERNAL LOCATION} | Item |
+| main.rs:2507:13:2507:13 | i |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2507:18:2507:22 | range |  | {EXTERNAL LOCATION} | Range |
+| main.rs:2507:18:2507:22 | range | Idx | {EXTERNAL LOCATION} | i32 |
+| main.rs:2508:13:2508:22 | range_full |  | {EXTERNAL LOCATION} | RangeFull |
+| main.rs:2508:26:2508:27 | .. |  | {EXTERNAL LOCATION} | RangeFull |
+| main.rs:2509:13:2509:13 | i |  | {EXTERNAL LOCATION} | Item |
+| main.rs:2509:18:2509:48 | &... |  | file://:0:0:0:0 | & |
+| main.rs:2509:19:2509:36 | [...] |  | file://:0:0:0:0 | [] |
+| main.rs:2509:19:2509:36 | [...] | [T;...] | {EXTERNAL LOCATION} | i64 |
+| main.rs:2509:20:2509:23 | 1i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2509:26:2509:29 | 2i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2509:32:2509:35 | 3i64 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2509:38:2509:47 | range_full |  | {EXTERNAL LOCATION} | RangeFull |
+| main.rs:2511:13:2511:18 | range1 |  | {EXTERNAL LOCATION} | Range |
+| main.rs:2511:13:2511:18 | range1 | Idx | {EXTERNAL LOCATION} | u16 |
+| main.rs:2512:9:2515:9 | ...::Range {...} |  | {EXTERNAL LOCATION} | Range |
+| main.rs:2512:9:2515:9 | ...::Range {...} | Idx | {EXTERNAL LOCATION} | u16 |
+| main.rs:2513:20:2513:23 | 0u16 |  | {EXTERNAL LOCATION} | u16 |
+| main.rs:2514:18:2514:22 | 10u16 |  | {EXTERNAL LOCATION} | u16 |
+| main.rs:2516:13:2516:13 | u |  | {EXTERNAL LOCATION} | Item |
+| main.rs:2516:13:2516:13 | u |  | {EXTERNAL LOCATION} | u16 |
+| main.rs:2516:18:2516:23 | range1 |  | {EXTERNAL LOCATION} | Range |
+| main.rs:2516:18:2516:23 | range1 | Idx | {EXTERNAL LOCATION} | u16 |
+| main.rs:2520:26:2520:26 | 1 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2520:29:2520:29 | 2 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2520:32:2520:32 | 3 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2523:13:2523:18 | vals4a |  | {EXTERNAL LOCATION} | Vec |
+| main.rs:2523:13:2523:18 | vals4a | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2523:13:2523:18 | vals4a | T | {EXTERNAL LOCATION} | u16 |
+| main.rs:2523:32:2523:43 | [...] |  | file://:0:0:0:0 | [] |
+| main.rs:2523:32:2523:43 | [...] | [T;...] | {EXTERNAL LOCATION} | i32 |
+| main.rs:2523:32:2523:43 | [...] | [T;...] | {EXTERNAL LOCATION} | u16 |
+| main.rs:2523:32:2523:52 | ... .to_vec() |  | {EXTERNAL LOCATION} | Vec |
+| main.rs:2523:32:2523:52 | ... .to_vec() | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2523:32:2523:52 | ... .to_vec() | T | {EXTERNAL LOCATION} | u16 |
+| main.rs:2523:33:2523:36 | 1u16 |  | {EXTERNAL LOCATION} | u16 |
+| main.rs:2523:39:2523:39 | 2 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2523:42:2523:42 | 3 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2524:13:2524:13 | u |  | {EXTERNAL LOCATION} | u16 |
+| main.rs:2524:13:2524:13 | u |  | file://:0:0:0:0 | & |
+| main.rs:2524:18:2524:23 | vals4a |  | {EXTERNAL LOCATION} | Vec |
+| main.rs:2524:18:2524:23 | vals4a | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2524:18:2524:23 | vals4a | T | {EXTERNAL LOCATION} | u16 |
+| main.rs:2526:22:2526:33 | [...] |  | file://:0:0:0:0 | [] |
+| main.rs:2526:22:2526:33 | [...] | [T;...] | {EXTERNAL LOCATION} | i32 |
+| main.rs:2526:22:2526:33 | [...] | [T;...] | {EXTERNAL LOCATION} | u16 |
+| main.rs:2526:23:2526:26 | 1u16 |  | {EXTERNAL LOCATION} | u16 |
+| main.rs:2526:29:2526:29 | 2 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2526:32:2526:32 | 3 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2529:13:2529:17 | vals5 |  | {EXTERNAL LOCATION} | Vec |
+| main.rs:2529:13:2529:17 | vals5 | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2529:13:2529:17 | vals5 | T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2529:13:2529:17 | vals5 | T | {EXTERNAL LOCATION} | u32 |
+| main.rs:2529:21:2529:43 | ...::from(...) |  | {EXTERNAL LOCATION} | Vec |
+| main.rs:2529:21:2529:43 | ...::from(...) | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2529:21:2529:43 | ...::from(...) | T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2529:21:2529:43 | ...::from(...) | T | {EXTERNAL LOCATION} | u32 |
+| main.rs:2529:31:2529:42 | [...] |  | file://:0:0:0:0 | [] |
+| main.rs:2529:31:2529:42 | [...] | [T;...] | {EXTERNAL LOCATION} | i32 |
+| main.rs:2529:31:2529:42 | [...] | [T;...] | {EXTERNAL LOCATION} | u32 |
+| main.rs:2529:32:2529:35 | 1u32 |  | {EXTERNAL LOCATION} | u32 |
+| main.rs:2529:38:2529:38 | 2 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2529:41:2529:41 | 3 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2530:13:2530:13 | u |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2530:13:2530:13 | u |  | {EXTERNAL LOCATION} | u32 |
+| main.rs:2530:13:2530:13 | u |  | file://:0:0:0:0 | & |
+| main.rs:2530:18:2530:22 | vals5 |  | {EXTERNAL LOCATION} | Vec |
+| main.rs:2530:18:2530:22 | vals5 | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2530:18:2530:22 | vals5 | T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2530:18:2530:22 | vals5 | T | {EXTERNAL LOCATION} | u32 |
+| main.rs:2532:13:2532:17 | vals6 |  | {EXTERNAL LOCATION} | Vec |
+| main.rs:2532:13:2532:17 | vals6 | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2532:13:2532:17 | vals6 | T | file://:0:0:0:0 | & |
+| main.rs:2532:13:2532:17 | vals6 | T.&T | {EXTERNAL LOCATION} | u64 |
+| main.rs:2532:32:2532:43 | [...] |  | file://:0:0:0:0 | [] |
+| main.rs:2532:32:2532:43 | [...] | [T;...] | {EXTERNAL LOCATION} | i32 |
+| main.rs:2532:32:2532:43 | [...] | [T;...] | {EXTERNAL LOCATION} | u64 |
+| main.rs:2532:32:2532:60 | ... .collect() |  | {EXTERNAL LOCATION} | Vec |
+| main.rs:2532:32:2532:60 | ... .collect() | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2532:32:2532:60 | ... .collect() | T | file://:0:0:0:0 | & |
+| main.rs:2532:32:2532:60 | ... .collect() | T.&T | {EXTERNAL LOCATION} | u64 |
+| main.rs:2532:33:2532:36 | 1u64 |  | {EXTERNAL LOCATION} | u64 |
+| main.rs:2532:39:2532:39 | 2 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2532:42:2532:42 | 3 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2533:13:2533:13 | u |  | file://:0:0:0:0 | & |
+| main.rs:2533:13:2533:13 | u | &T | {EXTERNAL LOCATION} | u64 |
+| main.rs:2533:18:2533:22 | vals6 |  | {EXTERNAL LOCATION} | Vec |
+| main.rs:2533:18:2533:22 | vals6 | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2533:18:2533:22 | vals6 | T | file://:0:0:0:0 | & |
+| main.rs:2533:18:2533:22 | vals6 | T.&T | {EXTERNAL LOCATION} | u64 |
+| main.rs:2535:17:2535:21 | vals7 |  | {EXTERNAL LOCATION} | Vec |
+| main.rs:2535:17:2535:21 | vals7 | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2535:17:2535:21 | vals7 | T | {EXTERNAL LOCATION} | u8 |
+| main.rs:2535:25:2535:34 | ...::new(...) |  | {EXTERNAL LOCATION} | Vec |
+| main.rs:2535:25:2535:34 | ...::new(...) | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2535:25:2535:34 | ...::new(...) | T | {EXTERNAL LOCATION} | u8 |
+| main.rs:2536:9:2536:13 | vals7 |  | {EXTERNAL LOCATION} | Vec |
+| main.rs:2536:9:2536:13 | vals7 | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2536:9:2536:13 | vals7 | T | {EXTERNAL LOCATION} | u8 |
+| main.rs:2536:20:2536:22 | 1u8 |  | {EXTERNAL LOCATION} | u8 |
+| main.rs:2537:13:2537:13 | u |  | {EXTERNAL LOCATION} | u8 |
+| main.rs:2537:13:2537:13 | u |  | file://:0:0:0:0 | & |
+| main.rs:2537:18:2537:22 | vals7 |  | {EXTERNAL LOCATION} | Vec |
+| main.rs:2537:18:2537:22 | vals7 | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2537:18:2537:22 | vals7 | T | {EXTERNAL LOCATION} | u8 |
+| main.rs:2539:33:2539:33 | 1 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2539:36:2539:36 | 2 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2539:45:2539:45 | 3 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2539:48:2539:48 | 4 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2546:17:2546:20 | map1 |  | {EXTERNAL LOCATION} | HashMap |
+| main.rs:2546:17:2546:20 | map1 | K | {EXTERNAL LOCATION} | i32 |
+| main.rs:2546:17:2546:20 | map1 | S | {EXTERNAL LOCATION} | RandomState |
+| main.rs:2546:17:2546:20 | map1 | V | {EXTERNAL LOCATION} | Box |
+| main.rs:2546:17:2546:20 | map1 | V.A | {EXTERNAL LOCATION} | Global |
+| main.rs:2546:17:2546:20 | map1 | V.T | file://:0:0:0:0 | & |
+| main.rs:2546:17:2546:20 | map1 | V.T.&T | {EXTERNAL LOCATION} | str |
+| main.rs:2546:24:2546:55 | ...::new(...) |  | {EXTERNAL LOCATION} | HashMap |
+| main.rs:2546:24:2546:55 | ...::new(...) | K | {EXTERNAL LOCATION} | i32 |
+| main.rs:2546:24:2546:55 | ...::new(...) | S | {EXTERNAL LOCATION} | RandomState |
+| main.rs:2546:24:2546:55 | ...::new(...) | V | {EXTERNAL LOCATION} | Box |
+| main.rs:2546:24:2546:55 | ...::new(...) | V.A | {EXTERNAL LOCATION} | Global |
+| main.rs:2546:24:2546:55 | ...::new(...) | V.T | file://:0:0:0:0 | & |
+| main.rs:2546:24:2546:55 | ...::new(...) | V.T.&T | {EXTERNAL LOCATION} | str |
+| main.rs:2547:9:2547:12 | map1 |  | {EXTERNAL LOCATION} | HashMap |
+| main.rs:2547:9:2547:12 | map1 | K | {EXTERNAL LOCATION} | i32 |
+| main.rs:2547:9:2547:12 | map1 | S | {EXTERNAL LOCATION} | RandomState |
+| main.rs:2547:9:2547:12 | map1 | V | {EXTERNAL LOCATION} | Box |
+| main.rs:2547:9:2547:12 | map1 | V.A | {EXTERNAL LOCATION} | Global |
+| main.rs:2547:9:2547:12 | map1 | V.T | file://:0:0:0:0 | & |
+| main.rs:2547:9:2547:12 | map1 | V.T.&T | {EXTERNAL LOCATION} | str |
+| main.rs:2547:9:2547:39 | map1.insert(...) |  | {EXTERNAL LOCATION} | Option |
+| main.rs:2547:9:2547:39 | map1.insert(...) | T | {EXTERNAL LOCATION} | Box |
+| main.rs:2547:9:2547:39 | map1.insert(...) | T.A | {EXTERNAL LOCATION} | Global |
+| main.rs:2547:9:2547:39 | map1.insert(...) | T.T | file://:0:0:0:0 | & |
+| main.rs:2547:9:2547:39 | map1.insert(...) | T.T.&T | {EXTERNAL LOCATION} | str |
+| main.rs:2547:21:2547:21 | 1 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2547:24:2547:38 | ...::new(...) |  | {EXTERNAL LOCATION} | Box |
+| main.rs:2547:24:2547:38 | ...::new(...) | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2547:24:2547:38 | ...::new(...) | T | file://:0:0:0:0 | & |
+| main.rs:2547:24:2547:38 | ...::new(...) | T.&T | {EXTERNAL LOCATION} | str |
+| main.rs:2547:33:2547:37 | "one" |  | file://:0:0:0:0 | & |
+| main.rs:2547:33:2547:37 | "one" | &T | {EXTERNAL LOCATION} | str |
 | main.rs:2548:9:2548:12 | map1 |  | {EXTERNAL LOCATION} | HashMap |
 | main.rs:2548:9:2548:12 | map1 | K | {EXTERNAL LOCATION} | i32 |
 | main.rs:2548:9:2548:12 | map1 | S | {EXTERNAL LOCATION} | RandomState |
@@ -5254,67 +5273,76 @@ inferType
 | main.rs:2548:9:2548:39 | map1.insert(...) | T.A | {EXTERNAL LOCATION} | Global |
 | main.rs:2548:9:2548:39 | map1.insert(...) | T.T | file://:0:0:0:0 | & |
 | main.rs:2548:9:2548:39 | map1.insert(...) | T.T.&T | {EXTERNAL LOCATION} | str |
-| main.rs:2548:21:2548:21 | 1 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2548:21:2548:21 | 2 |  | {EXTERNAL LOCATION} | i32 |
 | main.rs:2548:24:2548:38 | ...::new(...) |  | {EXTERNAL LOCATION} | Box |
 | main.rs:2548:24:2548:38 | ...::new(...) | A | {EXTERNAL LOCATION} | Global |
 | main.rs:2548:24:2548:38 | ...::new(...) | T | file://:0:0:0:0 | & |
 | main.rs:2548:24:2548:38 | ...::new(...) | T.&T | {EXTERNAL LOCATION} | str |
-| main.rs:2548:33:2548:37 | "one" |  | file://:0:0:0:0 | & |
-| main.rs:2548:33:2548:37 | "one" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:2549:9:2549:12 | map1 |  | {EXTERNAL LOCATION} | HashMap |
-| main.rs:2549:9:2549:12 | map1 | K | {EXTERNAL LOCATION} | i32 |
-| main.rs:2549:9:2549:12 | map1 | S | {EXTERNAL LOCATION} | RandomState |
-| main.rs:2549:9:2549:12 | map1 | V | {EXTERNAL LOCATION} | Box |
-| main.rs:2549:9:2549:12 | map1 | V.A | {EXTERNAL LOCATION} | Global |
-| main.rs:2549:9:2549:12 | map1 | V.T | file://:0:0:0:0 | & |
-| main.rs:2549:9:2549:12 | map1 | V.T.&T | {EXTERNAL LOCATION} | str |
-| main.rs:2549:9:2549:39 | map1.insert(...) |  | {EXTERNAL LOCATION} | Option |
-| main.rs:2549:9:2549:39 | map1.insert(...) | T | {EXTERNAL LOCATION} | Box |
-| main.rs:2549:9:2549:39 | map1.insert(...) | T.A | {EXTERNAL LOCATION} | Global |
-| main.rs:2549:9:2549:39 | map1.insert(...) | T.T | file://:0:0:0:0 | & |
-| main.rs:2549:9:2549:39 | map1.insert(...) | T.T.&T | {EXTERNAL LOCATION} | str |
-| main.rs:2549:21:2549:21 | 2 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2549:24:2549:38 | ...::new(...) |  | {EXTERNAL LOCATION} | Box |
-| main.rs:2549:24:2549:38 | ...::new(...) | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2549:24:2549:38 | ...::new(...) | T | file://:0:0:0:0 | & |
-| main.rs:2549:24:2549:38 | ...::new(...) | T.&T | {EXTERNAL LOCATION} | str |
-| main.rs:2549:33:2549:37 | "two" |  | file://:0:0:0:0 | & |
-| main.rs:2549:33:2549:37 | "two" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:2550:13:2550:15 | key |  | {EXTERNAL LOCATION} | Item |
-| main.rs:2550:13:2550:15 | key |  | file://:0:0:0:0 | & |
-| main.rs:2550:13:2550:15 | key | &T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2550:20:2550:23 | map1 |  | {EXTERNAL LOCATION} | HashMap |
-| main.rs:2550:20:2550:23 | map1 | K | {EXTERNAL LOCATION} | i32 |
-| main.rs:2550:20:2550:23 | map1 | S | {EXTERNAL LOCATION} | RandomState |
-| main.rs:2550:20:2550:23 | map1 | V | {EXTERNAL LOCATION} | Box |
-| main.rs:2550:20:2550:23 | map1 | V.A | {EXTERNAL LOCATION} | Global |
-| main.rs:2550:20:2550:23 | map1 | V.T | file://:0:0:0:0 | & |
-| main.rs:2550:20:2550:23 | map1 | V.T.&T | {EXTERNAL LOCATION} | str |
-| main.rs:2550:20:2550:30 | map1.keys() |  | {EXTERNAL LOCATION} | Keys |
-| main.rs:2550:20:2550:30 | map1.keys() | K | {EXTERNAL LOCATION} | i32 |
-| main.rs:2550:20:2550:30 | map1.keys() | V | {EXTERNAL LOCATION} | Box |
-| main.rs:2550:20:2550:30 | map1.keys() | V.A | {EXTERNAL LOCATION} | Global |
-| main.rs:2550:20:2550:30 | map1.keys() | V.T | file://:0:0:0:0 | & |
-| main.rs:2550:20:2550:30 | map1.keys() | V.T.&T | {EXTERNAL LOCATION} | str |
-| main.rs:2551:13:2551:17 | value |  | {EXTERNAL LOCATION} | Item |
-| main.rs:2551:13:2551:17 | value |  | file://:0:0:0:0 | & |
-| main.rs:2551:13:2551:17 | value | &T | {EXTERNAL LOCATION} | Box |
-| main.rs:2551:13:2551:17 | value | &T.A | {EXTERNAL LOCATION} | Global |
-| main.rs:2551:13:2551:17 | value | &T.T | file://:0:0:0:0 | & |
-| main.rs:2551:13:2551:17 | value | &T.T.&T | {EXTERNAL LOCATION} | str |
-| main.rs:2551:22:2551:25 | map1 |  | {EXTERNAL LOCATION} | HashMap |
-| main.rs:2551:22:2551:25 | map1 | K | {EXTERNAL LOCATION} | i32 |
-| main.rs:2551:22:2551:25 | map1 | S | {EXTERNAL LOCATION} | RandomState |
-| main.rs:2551:22:2551:25 | map1 | V | {EXTERNAL LOCATION} | Box |
-| main.rs:2551:22:2551:25 | map1 | V.A | {EXTERNAL LOCATION} | Global |
-| main.rs:2551:22:2551:25 | map1 | V.T | file://:0:0:0:0 | & |
-| main.rs:2551:22:2551:25 | map1 | V.T.&T | {EXTERNAL LOCATION} | str |
-| main.rs:2551:22:2551:34 | map1.values() |  | {EXTERNAL LOCATION} | Values |
-| main.rs:2551:22:2551:34 | map1.values() | K | {EXTERNAL LOCATION} | i32 |
-| main.rs:2551:22:2551:34 | map1.values() | V | {EXTERNAL LOCATION} | Box |
-| main.rs:2551:22:2551:34 | map1.values() | V.A | {EXTERNAL LOCATION} | Global |
-| main.rs:2551:22:2551:34 | map1.values() | V.T | file://:0:0:0:0 | & |
-| main.rs:2551:22:2551:34 | map1.values() | V.T.&T | {EXTERNAL LOCATION} | str |
+| main.rs:2548:33:2548:37 | "two" |  | file://:0:0:0:0 | & |
+| main.rs:2548:33:2548:37 | "two" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:2549:13:2549:15 | key |  | {EXTERNAL LOCATION} | Item |
+| main.rs:2549:13:2549:15 | key |  | file://:0:0:0:0 | & |
+| main.rs:2549:13:2549:15 | key | &T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2549:20:2549:23 | map1 |  | {EXTERNAL LOCATION} | HashMap |
+| main.rs:2549:20:2549:23 | map1 | K | {EXTERNAL LOCATION} | i32 |
+| main.rs:2549:20:2549:23 | map1 | S | {EXTERNAL LOCATION} | RandomState |
+| main.rs:2549:20:2549:23 | map1 | V | {EXTERNAL LOCATION} | Box |
+| main.rs:2549:20:2549:23 | map1 | V.A | {EXTERNAL LOCATION} | Global |
+| main.rs:2549:20:2549:23 | map1 | V.T | file://:0:0:0:0 | & |
+| main.rs:2549:20:2549:23 | map1 | V.T.&T | {EXTERNAL LOCATION} | str |
+| main.rs:2549:20:2549:30 | map1.keys() |  | {EXTERNAL LOCATION} | Keys |
+| main.rs:2549:20:2549:30 | map1.keys() | K | {EXTERNAL LOCATION} | i32 |
+| main.rs:2549:20:2549:30 | map1.keys() | V | {EXTERNAL LOCATION} | Box |
+| main.rs:2549:20:2549:30 | map1.keys() | V.A | {EXTERNAL LOCATION} | Global |
+| main.rs:2549:20:2549:30 | map1.keys() | V.T | file://:0:0:0:0 | & |
+| main.rs:2549:20:2549:30 | map1.keys() | V.T.&T | {EXTERNAL LOCATION} | str |
+| main.rs:2550:13:2550:17 | value |  | {EXTERNAL LOCATION} | Item |
+| main.rs:2550:13:2550:17 | value |  | file://:0:0:0:0 | & |
+| main.rs:2550:13:2550:17 | value | &T | {EXTERNAL LOCATION} | Box |
+| main.rs:2550:13:2550:17 | value | &T.A | {EXTERNAL LOCATION} | Global |
+| main.rs:2550:13:2550:17 | value | &T.T | file://:0:0:0:0 | & |
+| main.rs:2550:13:2550:17 | value | &T.T.&T | {EXTERNAL LOCATION} | str |
+| main.rs:2550:22:2550:25 | map1 |  | {EXTERNAL LOCATION} | HashMap |
+| main.rs:2550:22:2550:25 | map1 | K | {EXTERNAL LOCATION} | i32 |
+| main.rs:2550:22:2550:25 | map1 | S | {EXTERNAL LOCATION} | RandomState |
+| main.rs:2550:22:2550:25 | map1 | V | {EXTERNAL LOCATION} | Box |
+| main.rs:2550:22:2550:25 | map1 | V.A | {EXTERNAL LOCATION} | Global |
+| main.rs:2550:22:2550:25 | map1 | V.T | file://:0:0:0:0 | & |
+| main.rs:2550:22:2550:25 | map1 | V.T.&T | {EXTERNAL LOCATION} | str |
+| main.rs:2550:22:2550:34 | map1.values() |  | {EXTERNAL LOCATION} | Values |
+| main.rs:2550:22:2550:34 | map1.values() | K | {EXTERNAL LOCATION} | i32 |
+| main.rs:2550:22:2550:34 | map1.values() | V | {EXTERNAL LOCATION} | Box |
+| main.rs:2550:22:2550:34 | map1.values() | V.A | {EXTERNAL LOCATION} | Global |
+| main.rs:2550:22:2550:34 | map1.values() | V.T | file://:0:0:0:0 | & |
+| main.rs:2550:22:2550:34 | map1.values() | V.T.&T | {EXTERNAL LOCATION} | str |
+| main.rs:2551:13:2551:24 | TuplePat |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2551:13:2551:24 | TuplePat | 0(2) | file://:0:0:0:0 | & |
+| main.rs:2551:13:2551:24 | TuplePat | 0(2).&T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2551:13:2551:24 | TuplePat | 1(2) | file://:0:0:0:0 | & |
+| main.rs:2551:13:2551:24 | TuplePat | 1(2).&T | {EXTERNAL LOCATION} | Box |
+| main.rs:2551:13:2551:24 | TuplePat | 1(2).&T.A | {EXTERNAL LOCATION} | Global |
+| main.rs:2551:13:2551:24 | TuplePat | 1(2).&T.T | file://:0:0:0:0 | & |
+| main.rs:2551:13:2551:24 | TuplePat | 1(2).&T.T.&T | {EXTERNAL LOCATION} | str |
+| main.rs:2551:14:2551:16 | key |  | file://:0:0:0:0 | & |
+| main.rs:2551:14:2551:16 | key | &T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2551:19:2551:23 | value |  | file://:0:0:0:0 | & |
+| main.rs:2551:19:2551:23 | value | &T | {EXTERNAL LOCATION} | Box |
+| main.rs:2551:19:2551:23 | value | &T.A | {EXTERNAL LOCATION} | Global |
+| main.rs:2551:19:2551:23 | value | &T.T | file://:0:0:0:0 | & |
+| main.rs:2551:19:2551:23 | value | &T.T.&T | {EXTERNAL LOCATION} | str |
+| main.rs:2551:29:2551:32 | map1 |  | {EXTERNAL LOCATION} | HashMap |
+| main.rs:2551:29:2551:32 | map1 | K | {EXTERNAL LOCATION} | i32 |
+| main.rs:2551:29:2551:32 | map1 | S | {EXTERNAL LOCATION} | RandomState |
+| main.rs:2551:29:2551:32 | map1 | V | {EXTERNAL LOCATION} | Box |
+| main.rs:2551:29:2551:32 | map1 | V.A | {EXTERNAL LOCATION} | Global |
+| main.rs:2551:29:2551:32 | map1 | V.T | file://:0:0:0:0 | & |
+| main.rs:2551:29:2551:32 | map1 | V.T.&T | {EXTERNAL LOCATION} | str |
+| main.rs:2551:29:2551:39 | map1.iter() |  | {EXTERNAL LOCATION} | Iter |
+| main.rs:2551:29:2551:39 | map1.iter() | K | {EXTERNAL LOCATION} | i32 |
+| main.rs:2551:29:2551:39 | map1.iter() | V | {EXTERNAL LOCATION} | Box |
+| main.rs:2551:29:2551:39 | map1.iter() | V.A | {EXTERNAL LOCATION} | Global |
+| main.rs:2551:29:2551:39 | map1.iter() | V.T | file://:0:0:0:0 | & |
+| main.rs:2551:29:2551:39 | map1.iter() | V.T.&T | {EXTERNAL LOCATION} | str |
 | main.rs:2552:13:2552:24 | TuplePat |  | file://:0:0:0:0 | (T_2) |
 | main.rs:2552:13:2552:24 | TuplePat | 0(2) | file://:0:0:0:0 | & |
 | main.rs:2552:13:2552:24 | TuplePat | 0(2).&T | {EXTERNAL LOCATION} | i32 |
@@ -5330,515 +5358,487 @@ inferType
 | main.rs:2552:19:2552:23 | value | &T.A | {EXTERNAL LOCATION} | Global |
 | main.rs:2552:19:2552:23 | value | &T.T | file://:0:0:0:0 | & |
 | main.rs:2552:19:2552:23 | value | &T.T.&T | {EXTERNAL LOCATION} | str |
-| main.rs:2552:29:2552:32 | map1 |  | {EXTERNAL LOCATION} | HashMap |
-| main.rs:2552:29:2552:32 | map1 | K | {EXTERNAL LOCATION} | i32 |
-| main.rs:2552:29:2552:32 | map1 | S | {EXTERNAL LOCATION} | RandomState |
-| main.rs:2552:29:2552:32 | map1 | V | {EXTERNAL LOCATION} | Box |
-| main.rs:2552:29:2552:32 | map1 | V.A | {EXTERNAL LOCATION} | Global |
-| main.rs:2552:29:2552:32 | map1 | V.T | file://:0:0:0:0 | & |
-| main.rs:2552:29:2552:32 | map1 | V.T.&T | {EXTERNAL LOCATION} | str |
-| main.rs:2552:29:2552:39 | map1.iter() |  | {EXTERNAL LOCATION} | Iter |
-| main.rs:2552:29:2552:39 | map1.iter() | K | {EXTERNAL LOCATION} | i32 |
-| main.rs:2552:29:2552:39 | map1.iter() | V | {EXTERNAL LOCATION} | Box |
-| main.rs:2552:29:2552:39 | map1.iter() | V.A | {EXTERNAL LOCATION} | Global |
-| main.rs:2552:29:2552:39 | map1.iter() | V.T | file://:0:0:0:0 | & |
-| main.rs:2552:29:2552:39 | map1.iter() | V.T.&T | {EXTERNAL LOCATION} | str |
-| main.rs:2553:13:2553:24 | TuplePat |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2553:13:2553:24 | TuplePat | 0(2) | file://:0:0:0:0 | & |
-| main.rs:2553:13:2553:24 | TuplePat | 0(2).&T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2553:13:2553:24 | TuplePat | 1(2) | file://:0:0:0:0 | & |
-| main.rs:2553:13:2553:24 | TuplePat | 1(2).&T | {EXTERNAL LOCATION} | Box |
-| main.rs:2553:13:2553:24 | TuplePat | 1(2).&T.A | {EXTERNAL LOCATION} | Global |
-| main.rs:2553:13:2553:24 | TuplePat | 1(2).&T.T | file://:0:0:0:0 | & |
-| main.rs:2553:13:2553:24 | TuplePat | 1(2).&T.T.&T | {EXTERNAL LOCATION} | str |
-| main.rs:2553:14:2553:16 | key |  | file://:0:0:0:0 | & |
-| main.rs:2553:14:2553:16 | key | &T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2553:19:2553:23 | value |  | file://:0:0:0:0 | & |
-| main.rs:2553:19:2553:23 | value | &T | {EXTERNAL LOCATION} | Box |
-| main.rs:2553:19:2553:23 | value | &T.A | {EXTERNAL LOCATION} | Global |
-| main.rs:2553:19:2553:23 | value | &T.T | file://:0:0:0:0 | & |
-| main.rs:2553:19:2553:23 | value | &T.T.&T | {EXTERNAL LOCATION} | str |
-| main.rs:2553:29:2553:33 | &map1 |  | file://:0:0:0:0 | & |
-| main.rs:2553:29:2553:33 | &map1 | &T | {EXTERNAL LOCATION} | HashMap |
-| main.rs:2553:29:2553:33 | &map1 | &T.K | {EXTERNAL LOCATION} | i32 |
-| main.rs:2553:29:2553:33 | &map1 | &T.S | {EXTERNAL LOCATION} | RandomState |
-| main.rs:2553:29:2553:33 | &map1 | &T.V | {EXTERNAL LOCATION} | Box |
-| main.rs:2553:29:2553:33 | &map1 | &T.V.A | {EXTERNAL LOCATION} | Global |
-| main.rs:2553:29:2553:33 | &map1 | &T.V.T | file://:0:0:0:0 | & |
-| main.rs:2553:29:2553:33 | &map1 | &T.V.T.&T | {EXTERNAL LOCATION} | str |
-| main.rs:2553:30:2553:33 | map1 |  | {EXTERNAL LOCATION} | HashMap |
-| main.rs:2553:30:2553:33 | map1 | K | {EXTERNAL LOCATION} | i32 |
-| main.rs:2553:30:2553:33 | map1 | S | {EXTERNAL LOCATION} | RandomState |
-| main.rs:2553:30:2553:33 | map1 | V | {EXTERNAL LOCATION} | Box |
-| main.rs:2553:30:2553:33 | map1 | V.A | {EXTERNAL LOCATION} | Global |
-| main.rs:2553:30:2553:33 | map1 | V.T | file://:0:0:0:0 | & |
-| main.rs:2553:30:2553:33 | map1 | V.T.&T | {EXTERNAL LOCATION} | str |
-| main.rs:2557:17:2557:17 | a |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2557:26:2557:26 | 0 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2557:26:2557:26 | 0 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2559:23:2559:23 | a |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2559:23:2559:28 | ... < ... |  | {EXTERNAL LOCATION} | bool |
-| main.rs:2559:27:2559:28 | 10 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2559:27:2559:28 | 10 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2561:13:2561:13 | a |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2561:13:2561:18 | ... += ... |  | file://:0:0:0:0 | () |
-| main.rs:2561:18:2561:18 | 1 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2573:40:2575:9 | { ... } |  | {EXTERNAL LOCATION} | Option |
-| main.rs:2573:40:2575:9 | { ... } | T | main.rs:2567:5:2567:20 | S1 |
-| main.rs:2573:40:2575:9 | { ... } | T.T | main.rs:2572:10:2572:19 | T |
-| main.rs:2574:13:2574:16 | None |  | {EXTERNAL LOCATION} | Option |
-| main.rs:2574:13:2574:16 | None | T | main.rs:2567:5:2567:20 | S1 |
-| main.rs:2574:13:2574:16 | None | T.T | main.rs:2572:10:2572:19 | T |
-| main.rs:2577:30:2579:9 | { ... } |  | main.rs:2567:5:2567:20 | S1 |
-| main.rs:2577:30:2579:9 | { ... } | T | main.rs:2572:10:2572:19 | T |
-| main.rs:2578:13:2578:28 | S1(...) |  | main.rs:2567:5:2567:20 | S1 |
-| main.rs:2578:13:2578:28 | S1(...) | T | main.rs:2572:10:2572:19 | T |
-| main.rs:2578:16:2578:27 | ...::default(...) |  | main.rs:2572:10:2572:19 | T |
-| main.rs:2581:19:2581:22 | SelfParam |  | main.rs:2567:5:2567:20 | S1 |
-| main.rs:2581:19:2581:22 | SelfParam | T | main.rs:2572:10:2572:19 | T |
-| main.rs:2581:33:2583:9 | { ... } |  | main.rs:2567:5:2567:20 | S1 |
-| main.rs:2581:33:2583:9 | { ... } | T | main.rs:2572:10:2572:19 | T |
-| main.rs:2582:13:2582:16 | self |  | main.rs:2567:5:2567:20 | S1 |
-| main.rs:2582:13:2582:16 | self | T | main.rs:2572:10:2572:19 | T |
-| main.rs:2594:15:2594:15 | x |  | main.rs:2594:12:2594:12 | T |
-| main.rs:2594:26:2596:5 | { ... } |  | main.rs:2594:12:2594:12 | T |
-| main.rs:2595:9:2595:9 | x |  | main.rs:2594:12:2594:12 | T |
-| main.rs:2599:13:2599:14 | x1 |  | {EXTERNAL LOCATION} | Option |
-| main.rs:2599:13:2599:14 | x1 | T | main.rs:2567:5:2567:20 | S1 |
-| main.rs:2599:13:2599:14 | x1 | T.T | main.rs:2569:5:2570:14 | S2 |
-| main.rs:2599:34:2599:48 | ...::assoc_fun(...) |  | {EXTERNAL LOCATION} | Option |
-| main.rs:2599:34:2599:48 | ...::assoc_fun(...) | T | main.rs:2567:5:2567:20 | S1 |
-| main.rs:2599:34:2599:48 | ...::assoc_fun(...) | T.T | main.rs:2569:5:2570:14 | S2 |
-| main.rs:2600:13:2600:14 | x2 |  | {EXTERNAL LOCATION} | Option |
-| main.rs:2600:13:2600:14 | x2 | T | main.rs:2567:5:2567:20 | S1 |
-| main.rs:2600:13:2600:14 | x2 | T.T | main.rs:2569:5:2570:14 | S2 |
-| main.rs:2600:18:2600:38 | ...::assoc_fun(...) |  | {EXTERNAL LOCATION} | Option |
-| main.rs:2600:18:2600:38 | ...::assoc_fun(...) | T | main.rs:2567:5:2567:20 | S1 |
-| main.rs:2600:18:2600:38 | ...::assoc_fun(...) | T.T | main.rs:2569:5:2570:14 | S2 |
-| main.rs:2601:13:2601:14 | x3 |  | {EXTERNAL LOCATION} | Option |
-| main.rs:2601:13:2601:14 | x3 | T | main.rs:2567:5:2567:20 | S1 |
-| main.rs:2601:13:2601:14 | x3 | T.T | main.rs:2569:5:2570:14 | S2 |
-| main.rs:2601:18:2601:32 | ...::assoc_fun(...) |  | {EXTERNAL LOCATION} | Option |
-| main.rs:2601:18:2601:32 | ...::assoc_fun(...) | T | main.rs:2567:5:2567:20 | S1 |
-| main.rs:2601:18:2601:32 | ...::assoc_fun(...) | T.T | main.rs:2569:5:2570:14 | S2 |
-| main.rs:2602:13:2602:14 | x4 |  | main.rs:2567:5:2567:20 | S1 |
-| main.rs:2602:13:2602:14 | x4 | T | main.rs:2569:5:2570:14 | S2 |
-| main.rs:2602:18:2602:48 | ...::method(...) |  | main.rs:2567:5:2567:20 | S1 |
-| main.rs:2602:18:2602:48 | ...::method(...) | T | main.rs:2569:5:2570:14 | S2 |
-| main.rs:2602:35:2602:47 | ...::default(...) |  | main.rs:2567:5:2567:20 | S1 |
-| main.rs:2602:35:2602:47 | ...::default(...) | T | main.rs:2569:5:2570:14 | S2 |
-| main.rs:2603:13:2603:14 | x5 |  | main.rs:2567:5:2567:20 | S1 |
-| main.rs:2603:13:2603:14 | x5 | T | main.rs:2569:5:2570:14 | S2 |
-| main.rs:2603:18:2603:42 | ...::method(...) |  | main.rs:2567:5:2567:20 | S1 |
-| main.rs:2603:18:2603:42 | ...::method(...) | T | main.rs:2569:5:2570:14 | S2 |
-| main.rs:2603:29:2603:41 | ...::default(...) |  | main.rs:2567:5:2567:20 | S1 |
-| main.rs:2603:29:2603:41 | ...::default(...) | T | main.rs:2569:5:2570:14 | S2 |
-| main.rs:2604:13:2604:14 | x6 |  | main.rs:2588:5:2588:27 | S4 |
-| main.rs:2604:13:2604:14 | x6 | T4 | main.rs:2569:5:2570:14 | S2 |
-| main.rs:2604:18:2604:45 | S4::<...>(...) |  | main.rs:2588:5:2588:27 | S4 |
-| main.rs:2604:18:2604:45 | S4::<...>(...) | T4 | main.rs:2569:5:2570:14 | S2 |
-| main.rs:2604:27:2604:44 | ...::default(...) |  | main.rs:2569:5:2570:14 | S2 |
-| main.rs:2605:13:2605:14 | x7 |  | main.rs:2588:5:2588:27 | S4 |
-| main.rs:2605:13:2605:14 | x7 | T4 | main.rs:2569:5:2570:14 | S2 |
-| main.rs:2605:18:2605:23 | S4(...) |  | main.rs:2588:5:2588:27 | S4 |
-| main.rs:2605:18:2605:23 | S4(...) | T4 | main.rs:2569:5:2570:14 | S2 |
-| main.rs:2605:21:2605:22 | S2 |  | main.rs:2569:5:2570:14 | S2 |
-| main.rs:2606:13:2606:14 | x8 |  | main.rs:2588:5:2588:27 | S4 |
-| main.rs:2606:13:2606:14 | x8 | T4 | {EXTERNAL LOCATION} | i32 |
-| main.rs:2606:18:2606:22 | S4(...) |  | main.rs:2588:5:2588:27 | S4 |
-| main.rs:2606:18:2606:22 | S4(...) | T4 | {EXTERNAL LOCATION} | i32 |
-| main.rs:2606:21:2606:21 | 0 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2607:13:2607:14 | x9 |  | main.rs:2588:5:2588:27 | S4 |
-| main.rs:2607:13:2607:14 | x9 | T4 | main.rs:2569:5:2570:14 | S2 |
-| main.rs:2607:18:2607:34 | S4(...) |  | main.rs:2588:5:2588:27 | S4 |
-| main.rs:2607:18:2607:34 | S4(...) | T4 | main.rs:2569:5:2570:14 | S2 |
-| main.rs:2607:21:2607:33 | ...::default(...) |  | main.rs:2569:5:2570:14 | S2 |
-| main.rs:2608:13:2608:15 | x10 |  | main.rs:2590:5:2592:5 | S5 |
-| main.rs:2608:13:2608:15 | x10 | T5 | main.rs:2569:5:2570:14 | S2 |
-| main.rs:2608:19:2611:9 | S5::<...> {...} |  | main.rs:2590:5:2592:5 | S5 |
-| main.rs:2608:19:2611:9 | S5::<...> {...} | T5 | main.rs:2569:5:2570:14 | S2 |
-| main.rs:2610:20:2610:37 | ...::default(...) |  | main.rs:2569:5:2570:14 | S2 |
-| main.rs:2612:13:2612:15 | x11 |  | main.rs:2590:5:2592:5 | S5 |
-| main.rs:2612:13:2612:15 | x11 | T5 | main.rs:2569:5:2570:14 | S2 |
-| main.rs:2612:19:2612:34 | S5 {...} |  | main.rs:2590:5:2592:5 | S5 |
-| main.rs:2612:19:2612:34 | S5 {...} | T5 | main.rs:2569:5:2570:14 | S2 |
-| main.rs:2612:31:2612:32 | S2 |  | main.rs:2569:5:2570:14 | S2 |
-| main.rs:2613:13:2613:15 | x12 |  | main.rs:2590:5:2592:5 | S5 |
-| main.rs:2613:13:2613:15 | x12 | T5 | {EXTERNAL LOCATION} | i32 |
-| main.rs:2613:19:2613:33 | S5 {...} |  | main.rs:2590:5:2592:5 | S5 |
-| main.rs:2613:19:2613:33 | S5 {...} | T5 | {EXTERNAL LOCATION} | i32 |
-| main.rs:2613:31:2613:31 | 0 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2614:13:2614:15 | x13 |  | main.rs:2590:5:2592:5 | S5 |
-| main.rs:2614:13:2614:15 | x13 | T5 | main.rs:2569:5:2570:14 | S2 |
-| main.rs:2614:19:2617:9 | S5 {...} |  | main.rs:2590:5:2592:5 | S5 |
-| main.rs:2614:19:2617:9 | S5 {...} | T5 | main.rs:2569:5:2570:14 | S2 |
-| main.rs:2616:20:2616:32 | ...::default(...) |  | main.rs:2569:5:2570:14 | S2 |
-| main.rs:2618:13:2618:15 | x14 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2618:19:2618:48 | foo::<...>(...) |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2618:30:2618:47 | ...::default(...) |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2619:13:2619:15 | x15 |  | main.rs:2567:5:2567:20 | S1 |
-| main.rs:2619:13:2619:15 | x15 | T | main.rs:2569:5:2570:14 | S2 |
-| main.rs:2619:19:2619:37 | ...::default(...) |  | main.rs:2567:5:2567:20 | S1 |
-| main.rs:2619:19:2619:37 | ...::default(...) | T | main.rs:2569:5:2570:14 | S2 |
-| main.rs:2628:35:2630:9 | { ... } |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2628:35:2630:9 | { ... } | 0(2) | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2628:35:2630:9 | { ... } | 1(2) | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2629:13:2629:26 | TupleExpr |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2629:13:2629:26 | TupleExpr | 0(2) | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2629:13:2629:26 | TupleExpr | 1(2) | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2629:14:2629:18 | S1 {...} |  | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2629:21:2629:25 | S1 {...} |  | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2631:16:2631:19 | SelfParam |  | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2635:13:2635:13 | a |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2635:13:2635:13 | a | 0(2) | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2635:13:2635:13 | a | 1(2) | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2635:17:2635:30 | ...::get_pair(...) |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2635:17:2635:30 | ...::get_pair(...) | 0(2) | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2635:17:2635:30 | ...::get_pair(...) | 1(2) | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2636:17:2636:17 | b |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2636:17:2636:17 | b | 0(2) | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2636:17:2636:17 | b | 1(2) | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2636:21:2636:34 | ...::get_pair(...) |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2636:21:2636:34 | ...::get_pair(...) | 0(2) | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2636:21:2636:34 | ...::get_pair(...) | 1(2) | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2637:13:2637:18 | TuplePat |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2637:13:2637:18 | TuplePat | 0(2) | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2637:13:2637:18 | TuplePat | 1(2) | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2637:14:2637:14 | c |  | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2637:17:2637:17 | d |  | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2637:22:2637:35 | ...::get_pair(...) |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2637:22:2637:35 | ...::get_pair(...) | 0(2) | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2637:22:2637:35 | ...::get_pair(...) | 1(2) | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2638:13:2638:22 | TuplePat |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2638:13:2638:22 | TuplePat | 0(2) | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2638:13:2638:22 | TuplePat | 1(2) | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2638:18:2638:18 | e |  | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2638:21:2638:21 | f |  | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2638:26:2638:39 | ...::get_pair(...) |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2638:26:2638:39 | ...::get_pair(...) | 0(2) | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2638:26:2638:39 | ...::get_pair(...) | 1(2) | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2639:13:2639:26 | TuplePat |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2639:13:2639:26 | TuplePat | 0(2) | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2639:13:2639:26 | TuplePat | 1(2) | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2639:18:2639:18 | g |  | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2639:25:2639:25 | h |  | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2639:30:2639:43 | ...::get_pair(...) |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2639:30:2639:43 | ...::get_pair(...) | 0(2) | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2639:30:2639:43 | ...::get_pair(...) | 1(2) | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2641:9:2641:9 | a |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2641:9:2641:9 | a | 0(2) | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2641:9:2641:9 | a | 1(2) | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2641:9:2641:11 | a.0 |  | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2642:9:2642:9 | b |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2642:9:2642:9 | b | 0(2) | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2642:9:2642:9 | b | 1(2) | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2642:9:2642:11 | b.1 |  | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2643:9:2643:9 | c |  | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2644:9:2644:9 | d |  | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2645:9:2645:9 | e |  | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2646:9:2646:9 | f |  | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2647:9:2647:9 | g |  | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2648:9:2648:9 | h |  | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2653:13:2653:13 | a |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2653:17:2653:34 | ...::default(...) |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2654:13:2654:13 | b |  | {EXTERNAL LOCATION} | bool |
-| main.rs:2654:17:2654:34 | ...::default(...) |  | {EXTERNAL LOCATION} | bool |
-| main.rs:2655:13:2655:16 | pair |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2655:13:2655:16 | pair | 0(2) | {EXTERNAL LOCATION} | i64 |
-| main.rs:2655:13:2655:16 | pair | 1(2) | {EXTERNAL LOCATION} | bool |
-| main.rs:2655:20:2655:25 | TupleExpr |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2655:20:2655:25 | TupleExpr | 0(2) | {EXTERNAL LOCATION} | i64 |
-| main.rs:2655:20:2655:25 | TupleExpr | 1(2) | {EXTERNAL LOCATION} | bool |
-| main.rs:2655:21:2655:21 | a |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2655:24:2655:24 | b |  | {EXTERNAL LOCATION} | bool |
-| main.rs:2656:13:2656:13 | i |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2656:22:2656:25 | pair |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2656:22:2656:25 | pair | 0(2) | {EXTERNAL LOCATION} | i64 |
-| main.rs:2656:22:2656:25 | pair | 1(2) | {EXTERNAL LOCATION} | bool |
-| main.rs:2656:22:2656:27 | pair.0 |  | {EXTERNAL LOCATION} | i64 |
-| main.rs:2657:13:2657:13 | j |  | {EXTERNAL LOCATION} | bool |
-| main.rs:2657:23:2657:26 | pair |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2657:23:2657:26 | pair | 0(2) | {EXTERNAL LOCATION} | i64 |
-| main.rs:2657:23:2657:26 | pair | 1(2) | {EXTERNAL LOCATION} | bool |
-| main.rs:2657:23:2657:28 | pair.1 |  | {EXTERNAL LOCATION} | bool |
-| main.rs:2659:13:2659:16 | pair |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2659:13:2659:16 | pair | 0(2) | {EXTERNAL LOCATION} | i32 |
-| main.rs:2659:13:2659:16 | pair | 1(2) | {EXTERNAL LOCATION} | i32 |
-| main.rs:2659:20:2659:25 | [...] |  | file://:0:0:0:0 | [] |
-| main.rs:2659:20:2659:25 | [...] | [T;...] | {EXTERNAL LOCATION} | i32 |
-| main.rs:2659:20:2659:32 | ... .into() |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2659:20:2659:32 | ... .into() | 0(2) | {EXTERNAL LOCATION} | i32 |
-| main.rs:2659:20:2659:32 | ... .into() | 1(2) | {EXTERNAL LOCATION} | i32 |
-| main.rs:2659:21:2659:21 | 1 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2659:24:2659:24 | 1 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2660:15:2660:18 | pair |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2660:15:2660:18 | pair | 0(2) | {EXTERNAL LOCATION} | i32 |
-| main.rs:2660:15:2660:18 | pair | 1(2) | {EXTERNAL LOCATION} | i32 |
-| main.rs:2661:13:2661:18 | TuplePat |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2661:13:2661:18 | TuplePat | 0(2) | {EXTERNAL LOCATION} | i32 |
-| main.rs:2661:13:2661:18 | TuplePat | 1(2) | {EXTERNAL LOCATION} | i32 |
-| main.rs:2661:14:2661:14 | 0 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2661:17:2661:17 | 0 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2661:30:2661:41 | "unexpected" |  | file://:0:0:0:0 | & |
-| main.rs:2661:30:2661:41 | "unexpected" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:2661:30:2661:41 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:2661:30:2661:41 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:2662:13:2662:13 | _ |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2662:13:2662:13 | _ | 0(2) | {EXTERNAL LOCATION} | i32 |
-| main.rs:2662:13:2662:13 | _ | 1(2) | {EXTERNAL LOCATION} | i32 |
-| main.rs:2662:25:2662:34 | "expected" |  | file://:0:0:0:0 | & |
-| main.rs:2662:25:2662:34 | "expected" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:2662:25:2662:34 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:2662:25:2662:34 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:2664:13:2664:13 | x |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2664:17:2664:20 | pair |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2664:17:2664:20 | pair | 0(2) | {EXTERNAL LOCATION} | i32 |
-| main.rs:2664:17:2664:20 | pair | 1(2) | {EXTERNAL LOCATION} | i32 |
-| main.rs:2664:17:2664:22 | pair.0 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2666:13:2666:13 | y |  | file://:0:0:0:0 | & |
-| main.rs:2666:13:2666:13 | y | &T | file://:0:0:0:0 | (T_2) |
-| main.rs:2666:13:2666:13 | y | &T.0(2) | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2666:13:2666:13 | y | &T.1(2) | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2666:17:2666:31 | &... |  | file://:0:0:0:0 | & |
-| main.rs:2666:17:2666:31 | &... | &T | file://:0:0:0:0 | (T_2) |
-| main.rs:2666:17:2666:31 | &... | &T.0(2) | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2666:17:2666:31 | &... | &T.1(2) | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2666:18:2666:31 | ...::get_pair(...) |  | file://:0:0:0:0 | (T_2) |
-| main.rs:2666:18:2666:31 | ...::get_pair(...) | 0(2) | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2666:18:2666:31 | ...::get_pair(...) | 1(2) | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2667:9:2667:9 | y |  | file://:0:0:0:0 | & |
-| main.rs:2667:9:2667:9 | y | &T | file://:0:0:0:0 | (T_2) |
-| main.rs:2667:9:2667:9 | y | &T.0(2) | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2667:9:2667:9 | y | &T.1(2) | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2667:9:2667:11 | y.0 |  | main.rs:2624:5:2625:16 | S1 |
-| main.rs:2674:13:2674:23 | boxed_value |  | {EXTERNAL LOCATION} | Box |
-| main.rs:2674:13:2674:23 | boxed_value | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2674:13:2674:23 | boxed_value | T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2674:27:2674:42 | ...::new(...) |  | {EXTERNAL LOCATION} | Box |
-| main.rs:2674:27:2674:42 | ...::new(...) | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2674:27:2674:42 | ...::new(...) | T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2674:36:2674:41 | 100i32 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2677:15:2677:25 | boxed_value |  | {EXTERNAL LOCATION} | Box |
-| main.rs:2677:15:2677:25 | boxed_value | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2677:15:2677:25 | boxed_value | T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2678:13:2678:19 | box 100 |  | {EXTERNAL LOCATION} | Box |
-| main.rs:2678:13:2678:19 | box 100 | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2678:13:2678:19 | box 100 | T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2678:17:2678:19 | 100 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2679:26:2679:36 | "Boxed 100\\n" |  | file://:0:0:0:0 | & |
-| main.rs:2679:26:2679:36 | "Boxed 100\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:2679:26:2679:36 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:2679:26:2679:36 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:2681:13:2681:17 | box ... |  | {EXTERNAL LOCATION} | Box |
-| main.rs:2681:13:2681:17 | box ... | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2681:13:2681:17 | box ... | T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2683:26:2683:42 | "Boxed value: {}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:2683:26:2683:42 | "Boxed value: {}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:2683:26:2683:51 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:2683:26:2683:51 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:2688:13:2688:22 | nested_box |  | {EXTERNAL LOCATION} | Box |
-| main.rs:2688:13:2688:22 | nested_box | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2688:13:2688:22 | nested_box | T | {EXTERNAL LOCATION} | Box |
-| main.rs:2688:13:2688:22 | nested_box | T.A | {EXTERNAL LOCATION} | Global |
-| main.rs:2688:13:2688:22 | nested_box | T.T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2688:26:2688:50 | ...::new(...) |  | {EXTERNAL LOCATION} | Box |
-| main.rs:2688:26:2688:50 | ...::new(...) | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2688:26:2688:50 | ...::new(...) | T | {EXTERNAL LOCATION} | Box |
-| main.rs:2688:26:2688:50 | ...::new(...) | T.A | {EXTERNAL LOCATION} | Global |
-| main.rs:2688:26:2688:50 | ...::new(...) | T.T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2688:35:2688:49 | ...::new(...) |  | {EXTERNAL LOCATION} | Box |
-| main.rs:2688:35:2688:49 | ...::new(...) | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2688:35:2688:49 | ...::new(...) | T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2688:44:2688:48 | 42i32 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2689:15:2689:24 | nested_box |  | {EXTERNAL LOCATION} | Box |
-| main.rs:2689:15:2689:24 | nested_box | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2689:15:2689:24 | nested_box | T | {EXTERNAL LOCATION} | Box |
-| main.rs:2689:15:2689:24 | nested_box | T.A | {EXTERNAL LOCATION} | Global |
-| main.rs:2689:15:2689:24 | nested_box | T.T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2690:13:2690:21 | box ... |  | {EXTERNAL LOCATION} | Box |
-| main.rs:2690:13:2690:21 | box ... | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2690:13:2690:21 | box ... | T | {EXTERNAL LOCATION} | Box |
-| main.rs:2690:13:2690:21 | box ... | T.A | {EXTERNAL LOCATION} | Global |
-| main.rs:2690:13:2690:21 | box ... | T.T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2692:26:2692:43 | "Nested boxed: {}\\n" |  | file://:0:0:0:0 | & |
-| main.rs:2692:26:2692:43 | "Nested boxed: {}\\n" | &T | {EXTERNAL LOCATION} | str |
-| main.rs:2692:26:2692:59 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:2692:26:2692:59 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
-| main.rs:2704:36:2706:9 | { ... } |  | main.rs:2701:5:2701:22 | Path |
-| main.rs:2705:13:2705:19 | Path {...} |  | main.rs:2701:5:2701:22 | Path |
-| main.rs:2708:29:2708:33 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:2708:29:2708:33 | SelfParam | &T | main.rs:2701:5:2701:22 | Path |
-| main.rs:2708:59:2710:9 | { ... } |  | {EXTERNAL LOCATION} | Result |
-| main.rs:2708:59:2710:9 | { ... } | E | file://:0:0:0:0 | () |
-| main.rs:2708:59:2710:9 | { ... } | T | main.rs:2713:5:2713:25 | PathBuf |
-| main.rs:2709:13:2709:30 | Ok(...) |  | {EXTERNAL LOCATION} | Result |
-| main.rs:2709:13:2709:30 | Ok(...) | E | file://:0:0:0:0 | () |
-| main.rs:2709:13:2709:30 | Ok(...) | T | main.rs:2713:5:2713:25 | PathBuf |
-| main.rs:2709:16:2709:29 | ...::new(...) |  | main.rs:2713:5:2713:25 | PathBuf |
-| main.rs:2716:39:2718:9 | { ... } |  | main.rs:2713:5:2713:25 | PathBuf |
-| main.rs:2717:13:2717:22 | PathBuf {...} |  | main.rs:2713:5:2713:25 | PathBuf |
-| main.rs:2726:18:2726:22 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:2726:18:2726:22 | SelfParam | &T | main.rs:2713:5:2713:25 | PathBuf |
-| main.rs:2726:34:2730:9 | { ... } |  | file://:0:0:0:0 | & |
-| main.rs:2726:34:2730:9 | { ... } | &T | main.rs:2701:5:2701:22 | Path |
-| main.rs:2728:33:2728:43 | ...::new(...) |  | main.rs:2701:5:2701:22 | Path |
-| main.rs:2729:13:2729:17 | &path |  | file://:0:0:0:0 | & |
-| main.rs:2729:13:2729:17 | &path | &T | main.rs:2701:5:2701:22 | Path |
-| main.rs:2729:14:2729:17 | path |  | main.rs:2701:5:2701:22 | Path |
-| main.rs:2734:13:2734:17 | path1 |  | main.rs:2701:5:2701:22 | Path |
-| main.rs:2734:21:2734:31 | ...::new(...) |  | main.rs:2701:5:2701:22 | Path |
-| main.rs:2735:13:2735:17 | path2 |  | {EXTERNAL LOCATION} | Result |
-| main.rs:2735:13:2735:17 | path2 | E | file://:0:0:0:0 | () |
-| main.rs:2735:13:2735:17 | path2 | T | main.rs:2713:5:2713:25 | PathBuf |
-| main.rs:2735:21:2735:25 | path1 |  | main.rs:2701:5:2701:22 | Path |
-| main.rs:2735:21:2735:40 | path1.canonicalize() |  | {EXTERNAL LOCATION} | Result |
-| main.rs:2735:21:2735:40 | path1.canonicalize() | E | file://:0:0:0:0 | () |
-| main.rs:2735:21:2735:40 | path1.canonicalize() | T | main.rs:2713:5:2713:25 | PathBuf |
-| main.rs:2736:13:2736:17 | path3 |  | main.rs:2713:5:2713:25 | PathBuf |
-| main.rs:2736:21:2736:25 | path2 |  | {EXTERNAL LOCATION} | Result |
-| main.rs:2736:21:2736:25 | path2 | E | file://:0:0:0:0 | () |
-| main.rs:2736:21:2736:25 | path2 | T | main.rs:2713:5:2713:25 | PathBuf |
-| main.rs:2736:21:2736:34 | path2.unwrap() |  | main.rs:2713:5:2713:25 | PathBuf |
-| main.rs:2738:13:2738:20 | pathbuf1 |  | main.rs:2713:5:2713:25 | PathBuf |
-| main.rs:2738:24:2738:37 | ...::new(...) |  | main.rs:2713:5:2713:25 | PathBuf |
-| main.rs:2739:24:2739:31 | pathbuf1 |  | main.rs:2713:5:2713:25 | PathBuf |
-| main.rs:2746:14:2746:18 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:2746:14:2746:18 | SelfParam | &T | main.rs:2745:5:2747:5 | Self [trait MyTrait] |
-| main.rs:2753:14:2753:18 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:2753:14:2753:18 | SelfParam | &T | main.rs:2749:5:2750:19 | S |
-| main.rs:2753:14:2753:18 | SelfParam | &T.T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2753:28:2755:9 | { ... } |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2754:13:2754:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:2754:13:2754:16 | self | &T | main.rs:2749:5:2750:19 | S |
-| main.rs:2754:13:2754:16 | self | &T.T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2754:13:2754:18 | self.0 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2759:14:2759:18 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:2759:14:2759:18 | SelfParam | &T | main.rs:2749:5:2750:19 | S |
-| main.rs:2759:14:2759:18 | SelfParam | &T.T | main.rs:2749:5:2750:19 | S |
-| main.rs:2759:14:2759:18 | SelfParam | &T.T.T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2759:28:2761:9 | { ... } |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2760:13:2760:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:2760:13:2760:16 | self | &T | main.rs:2749:5:2750:19 | S |
-| main.rs:2760:13:2760:16 | self | &T.T | main.rs:2749:5:2750:19 | S |
-| main.rs:2760:13:2760:16 | self | &T.T.T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2760:13:2760:18 | self.0 |  | main.rs:2749:5:2750:19 | S |
-| main.rs:2760:13:2760:18 | self.0 | T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2760:13:2760:21 | ... .0 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2765:15:2765:19 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:2765:15:2765:19 | SelfParam | &T | main.rs:2749:5:2750:19 | S |
-| main.rs:2765:15:2765:19 | SelfParam | &T.T | main.rs:2764:10:2764:16 | T |
-| main.rs:2765:33:2767:9 | { ... } |  | main.rs:2749:5:2750:19 | S |
-| main.rs:2765:33:2767:9 | { ... } | T | main.rs:2749:5:2750:19 | S |
-| main.rs:2765:33:2767:9 | { ... } | T.T | main.rs:2764:10:2764:16 | T |
-| main.rs:2766:13:2766:24 | S(...) |  | main.rs:2749:5:2750:19 | S |
-| main.rs:2766:13:2766:24 | S(...) | T | main.rs:2749:5:2750:19 | S |
-| main.rs:2766:13:2766:24 | S(...) | T.T | main.rs:2764:10:2764:16 | T |
-| main.rs:2766:15:2766:23 | S(...) |  | main.rs:2749:5:2750:19 | S |
-| main.rs:2766:15:2766:23 | S(...) | T | main.rs:2764:10:2764:16 | T |
-| main.rs:2766:17:2766:20 | self |  | file://:0:0:0:0 | & |
-| main.rs:2766:17:2766:20 | self | &T | main.rs:2749:5:2750:19 | S |
-| main.rs:2766:17:2766:20 | self | &T.T | main.rs:2764:10:2764:16 | T |
-| main.rs:2766:17:2766:22 | self.0 |  | main.rs:2764:10:2764:16 | T |
-| main.rs:2770:14:2770:14 | b |  | {EXTERNAL LOCATION} | bool |
-| main.rs:2770:48:2787:5 | { ... } |  | {EXTERNAL LOCATION} | Box |
-| main.rs:2770:48:2787:5 | { ... } | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2770:48:2787:5 | { ... } | T | main.rs:2745:5:2747:5 | dyn MyTrait |
-| main.rs:2770:48:2787:5 | { ... } | T.dyn(T) | {EXTERNAL LOCATION} | i32 |
-| main.rs:2771:13:2771:13 | x |  | main.rs:2749:5:2750:19 | S |
-| main.rs:2771:13:2771:13 | x | T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2771:17:2776:9 | if b {...} else {...} |  | main.rs:2749:5:2750:19 | S |
-| main.rs:2771:17:2776:9 | if b {...} else {...} | T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2771:20:2771:20 | b |  | {EXTERNAL LOCATION} | bool |
-| main.rs:2771:22:2774:9 | { ... } |  | main.rs:2749:5:2750:19 | S |
-| main.rs:2771:22:2774:9 | { ... } | T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2772:17:2772:17 | y |  | main.rs:2749:5:2750:19 | S |
-| main.rs:2772:17:2772:17 | y | T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2772:21:2772:38 | ...::default(...) |  | main.rs:2749:5:2750:19 | S |
-| main.rs:2772:21:2772:38 | ...::default(...) | T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2773:13:2773:13 | y |  | main.rs:2749:5:2750:19 | S |
-| main.rs:2773:13:2773:13 | y | T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2774:16:2776:9 | { ... } |  | main.rs:2749:5:2750:19 | S |
-| main.rs:2774:16:2776:9 | { ... } | T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2775:13:2775:16 | S(...) |  | main.rs:2749:5:2750:19 | S |
-| main.rs:2775:13:2775:16 | S(...) | T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2775:15:2775:15 | 2 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2780:13:2780:13 | x |  | main.rs:2745:5:2747:5 | dyn MyTrait |
-| main.rs:2780:13:2780:13 | x |  | main.rs:2749:5:2750:19 | S |
-| main.rs:2780:13:2780:13 | x | T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2780:13:2780:13 | x | dyn(T) | {EXTERNAL LOCATION} | i32 |
-| main.rs:2780:17:2780:20 | S(...) |  | main.rs:2745:5:2747:5 | dyn MyTrait |
-| main.rs:2780:17:2780:20 | S(...) |  | main.rs:2749:5:2750:19 | S |
-| main.rs:2780:17:2780:20 | S(...) | T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2780:17:2780:20 | S(...) | dyn(T) | {EXTERNAL LOCATION} | i32 |
-| main.rs:2780:19:2780:19 | 1 |  | {EXTERNAL LOCATION} | i32 |
-| main.rs:2781:9:2786:9 | if b {...} else {...} |  | {EXTERNAL LOCATION} | Box |
-| main.rs:2781:9:2786:9 | if b {...} else {...} | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2781:9:2786:9 | if b {...} else {...} | T | main.rs:2745:5:2747:5 | dyn MyTrait |
-| main.rs:2781:9:2786:9 | if b {...} else {...} | T | main.rs:2749:5:2750:19 | S |
-| main.rs:2781:9:2786:9 | if b {...} else {...} | T.T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2781:9:2786:9 | if b {...} else {...} | T.T | main.rs:2749:5:2750:19 | S |
-| main.rs:2781:9:2786:9 | if b {...} else {...} | T.T.T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2781:9:2786:9 | if b {...} else {...} | T.dyn(T) | {EXTERNAL LOCATION} | i32 |
-| main.rs:2781:12:2781:12 | b |  | {EXTERNAL LOCATION} | bool |
-| main.rs:2781:14:2784:9 | { ... } |  | {EXTERNAL LOCATION} | Box |
-| main.rs:2781:14:2784:9 | { ... } | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2781:14:2784:9 | { ... } | T | main.rs:2745:5:2747:5 | dyn MyTrait |
-| main.rs:2781:14:2784:9 | { ... } | T | main.rs:2749:5:2750:19 | S |
-| main.rs:2781:14:2784:9 | { ... } | T.T | main.rs:2749:5:2750:19 | S |
-| main.rs:2781:14:2784:9 | { ... } | T.T.T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2781:14:2784:9 | { ... } | T.dyn(T) | {EXTERNAL LOCATION} | i32 |
-| main.rs:2782:17:2782:17 | x |  | main.rs:2745:5:2747:5 | dyn MyTrait |
-| main.rs:2782:17:2782:17 | x |  | main.rs:2749:5:2750:19 | S |
-| main.rs:2782:17:2782:17 | x | T | main.rs:2749:5:2750:19 | S |
-| main.rs:2782:17:2782:17 | x | T.T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2782:17:2782:17 | x | dyn(T) | {EXTERNAL LOCATION} | i32 |
-| main.rs:2782:21:2782:21 | x |  | main.rs:2745:5:2747:5 | dyn MyTrait |
-| main.rs:2782:21:2782:21 | x |  | main.rs:2749:5:2750:19 | S |
-| main.rs:2782:21:2782:21 | x | T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2782:21:2782:21 | x | dyn(T) | {EXTERNAL LOCATION} | i32 |
-| main.rs:2782:21:2782:26 | x.m2() |  | main.rs:2745:5:2747:5 | dyn MyTrait |
-| main.rs:2782:21:2782:26 | x.m2() |  | main.rs:2749:5:2750:19 | S |
-| main.rs:2782:21:2782:26 | x.m2() | T | main.rs:2749:5:2750:19 | S |
-| main.rs:2782:21:2782:26 | x.m2() | T.T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2782:21:2782:26 | x.m2() | dyn(T) | {EXTERNAL LOCATION} | i32 |
-| main.rs:2783:13:2783:23 | ...::new(...) |  | {EXTERNAL LOCATION} | Box |
-| main.rs:2783:13:2783:23 | ...::new(...) | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2783:13:2783:23 | ...::new(...) | T | main.rs:2745:5:2747:5 | dyn MyTrait |
-| main.rs:2783:13:2783:23 | ...::new(...) | T | main.rs:2749:5:2750:19 | S |
-| main.rs:2783:13:2783:23 | ...::new(...) | T.T | main.rs:2749:5:2750:19 | S |
-| main.rs:2783:13:2783:23 | ...::new(...) | T.T.T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2783:13:2783:23 | ...::new(...) | T.dyn(T) | {EXTERNAL LOCATION} | i32 |
-| main.rs:2783:22:2783:22 | x |  | main.rs:2745:5:2747:5 | dyn MyTrait |
-| main.rs:2783:22:2783:22 | x |  | main.rs:2749:5:2750:19 | S |
-| main.rs:2783:22:2783:22 | x | T | main.rs:2749:5:2750:19 | S |
-| main.rs:2783:22:2783:22 | x | T.T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2783:22:2783:22 | x | dyn(T) | {EXTERNAL LOCATION} | i32 |
-| main.rs:2784:16:2786:9 | { ... } |  | {EXTERNAL LOCATION} | Box |
-| main.rs:2784:16:2786:9 | { ... } | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2784:16:2786:9 | { ... } | T | main.rs:2745:5:2747:5 | dyn MyTrait |
-| main.rs:2784:16:2786:9 | { ... } | T | main.rs:2749:5:2750:19 | S |
-| main.rs:2784:16:2786:9 | { ... } | T.T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2784:16:2786:9 | { ... } | T.dyn(T) | {EXTERNAL LOCATION} | i32 |
-| main.rs:2785:13:2785:23 | ...::new(...) |  | {EXTERNAL LOCATION} | Box |
-| main.rs:2785:13:2785:23 | ...::new(...) | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2785:13:2785:23 | ...::new(...) | T | main.rs:2745:5:2747:5 | dyn MyTrait |
-| main.rs:2785:13:2785:23 | ...::new(...) | T | main.rs:2749:5:2750:19 | S |
-| main.rs:2785:13:2785:23 | ...::new(...) | T.T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2785:13:2785:23 | ...::new(...) | T.dyn(T) | {EXTERNAL LOCATION} | i32 |
-| main.rs:2785:22:2785:22 | x |  | main.rs:2745:5:2747:5 | dyn MyTrait |
-| main.rs:2785:22:2785:22 | x |  | main.rs:2749:5:2750:19 | S |
-| main.rs:2785:22:2785:22 | x | T | {EXTERNAL LOCATION} | i32 |
-| main.rs:2785:22:2785:22 | x | dyn(T) | {EXTERNAL LOCATION} | i32 |
-| main.rs:2797:5:2797:20 | ...::f(...) |  | main.rs:72:5:72:21 | Foo |
-| main.rs:2798:5:2798:60 | ...::g(...) |  | main.rs:72:5:72:21 | Foo |
-| main.rs:2798:20:2798:38 | ...::Foo {...} |  | main.rs:72:5:72:21 | Foo |
-| main.rs:2798:41:2798:59 | ...::Foo {...} |  | main.rs:72:5:72:21 | Foo |
-| main.rs:2815:5:2815:15 | ...::f(...) |  | {EXTERNAL LOCATION} | trait Future |
-| main.rs:2828:5:2828:20 | ...::f(...) |  | {EXTERNAL LOCATION} | Box |
-| main.rs:2828:5:2828:20 | ...::f(...) | A | {EXTERNAL LOCATION} | Global |
-| main.rs:2828:5:2828:20 | ...::f(...) | T | main.rs:2745:5:2747:5 | dyn MyTrait |
-| main.rs:2828:5:2828:20 | ...::f(...) | T.dyn(T) | {EXTERNAL LOCATION} | i32 |
-| main.rs:2828:16:2828:19 | true |  | {EXTERNAL LOCATION} | bool |
+| main.rs:2552:29:2552:33 | &map1 |  | file://:0:0:0:0 | & |
+| main.rs:2552:29:2552:33 | &map1 | &T | {EXTERNAL LOCATION} | HashMap |
+| main.rs:2552:29:2552:33 | &map1 | &T.K | {EXTERNAL LOCATION} | i32 |
+| main.rs:2552:29:2552:33 | &map1 | &T.S | {EXTERNAL LOCATION} | RandomState |
+| main.rs:2552:29:2552:33 | &map1 | &T.V | {EXTERNAL LOCATION} | Box |
+| main.rs:2552:29:2552:33 | &map1 | &T.V.A | {EXTERNAL LOCATION} | Global |
+| main.rs:2552:29:2552:33 | &map1 | &T.V.T | file://:0:0:0:0 | & |
+| main.rs:2552:29:2552:33 | &map1 | &T.V.T.&T | {EXTERNAL LOCATION} | str |
+| main.rs:2552:30:2552:33 | map1 |  | {EXTERNAL LOCATION} | HashMap |
+| main.rs:2552:30:2552:33 | map1 | K | {EXTERNAL LOCATION} | i32 |
+| main.rs:2552:30:2552:33 | map1 | S | {EXTERNAL LOCATION} | RandomState |
+| main.rs:2552:30:2552:33 | map1 | V | {EXTERNAL LOCATION} | Box |
+| main.rs:2552:30:2552:33 | map1 | V.A | {EXTERNAL LOCATION} | Global |
+| main.rs:2552:30:2552:33 | map1 | V.T | file://:0:0:0:0 | & |
+| main.rs:2552:30:2552:33 | map1 | V.T.&T | {EXTERNAL LOCATION} | str |
+| main.rs:2556:17:2556:17 | a |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2556:26:2556:26 | 0 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2556:26:2556:26 | 0 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2558:23:2558:23 | a |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2558:23:2558:28 | ... < ... |  | {EXTERNAL LOCATION} | bool |
+| main.rs:2558:27:2558:28 | 10 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2558:27:2558:28 | 10 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2560:13:2560:13 | a |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2560:13:2560:18 | ... += ... |  | file://:0:0:0:0 | () |
+| main.rs:2560:18:2560:18 | 1 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2572:40:2574:9 | { ... } |  | {EXTERNAL LOCATION} | Option |
+| main.rs:2572:40:2574:9 | { ... } | T | main.rs:2566:5:2566:20 | S1 |
+| main.rs:2572:40:2574:9 | { ... } | T.T | main.rs:2571:10:2571:19 | T |
+| main.rs:2573:13:2573:16 | None |  | {EXTERNAL LOCATION} | Option |
+| main.rs:2573:13:2573:16 | None | T | main.rs:2566:5:2566:20 | S1 |
+| main.rs:2573:13:2573:16 | None | T.T | main.rs:2571:10:2571:19 | T |
+| main.rs:2576:30:2578:9 | { ... } |  | main.rs:2566:5:2566:20 | S1 |
+| main.rs:2576:30:2578:9 | { ... } | T | main.rs:2571:10:2571:19 | T |
+| main.rs:2577:13:2577:28 | S1(...) |  | main.rs:2566:5:2566:20 | S1 |
+| main.rs:2577:13:2577:28 | S1(...) | T | main.rs:2571:10:2571:19 | T |
+| main.rs:2577:16:2577:27 | ...::default(...) |  | main.rs:2571:10:2571:19 | T |
+| main.rs:2580:19:2580:22 | SelfParam |  | main.rs:2566:5:2566:20 | S1 |
+| main.rs:2580:19:2580:22 | SelfParam | T | main.rs:2571:10:2571:19 | T |
+| main.rs:2580:33:2582:9 | { ... } |  | main.rs:2566:5:2566:20 | S1 |
+| main.rs:2580:33:2582:9 | { ... } | T | main.rs:2571:10:2571:19 | T |
+| main.rs:2581:13:2581:16 | self |  | main.rs:2566:5:2566:20 | S1 |
+| main.rs:2581:13:2581:16 | self | T | main.rs:2571:10:2571:19 | T |
+| main.rs:2593:15:2593:15 | x |  | main.rs:2593:12:2593:12 | T |
+| main.rs:2593:26:2595:5 | { ... } |  | main.rs:2593:12:2593:12 | T |
+| main.rs:2594:9:2594:9 | x |  | main.rs:2593:12:2593:12 | T |
+| main.rs:2598:13:2598:14 | x1 |  | {EXTERNAL LOCATION} | Option |
+| main.rs:2598:13:2598:14 | x1 | T | main.rs:2566:5:2566:20 | S1 |
+| main.rs:2598:13:2598:14 | x1 | T.T | main.rs:2568:5:2569:14 | S2 |
+| main.rs:2598:34:2598:48 | ...::assoc_fun(...) |  | {EXTERNAL LOCATION} | Option |
+| main.rs:2598:34:2598:48 | ...::assoc_fun(...) | T | main.rs:2566:5:2566:20 | S1 |
+| main.rs:2598:34:2598:48 | ...::assoc_fun(...) | T.T | main.rs:2568:5:2569:14 | S2 |
+| main.rs:2599:13:2599:14 | x2 |  | {EXTERNAL LOCATION} | Option |
+| main.rs:2599:13:2599:14 | x2 | T | main.rs:2566:5:2566:20 | S1 |
+| main.rs:2599:13:2599:14 | x2 | T.T | main.rs:2568:5:2569:14 | S2 |
+| main.rs:2599:18:2599:38 | ...::assoc_fun(...) |  | {EXTERNAL LOCATION} | Option |
+| main.rs:2599:18:2599:38 | ...::assoc_fun(...) | T | main.rs:2566:5:2566:20 | S1 |
+| main.rs:2599:18:2599:38 | ...::assoc_fun(...) | T.T | main.rs:2568:5:2569:14 | S2 |
+| main.rs:2600:13:2600:14 | x3 |  | {EXTERNAL LOCATION} | Option |
+| main.rs:2600:13:2600:14 | x3 | T | main.rs:2566:5:2566:20 | S1 |
+| main.rs:2600:13:2600:14 | x3 | T.T | main.rs:2568:5:2569:14 | S2 |
+| main.rs:2600:18:2600:32 | ...::assoc_fun(...) |  | {EXTERNAL LOCATION} | Option |
+| main.rs:2600:18:2600:32 | ...::assoc_fun(...) | T | main.rs:2566:5:2566:20 | S1 |
+| main.rs:2600:18:2600:32 | ...::assoc_fun(...) | T.T | main.rs:2568:5:2569:14 | S2 |
+| main.rs:2601:13:2601:14 | x4 |  | main.rs:2566:5:2566:20 | S1 |
+| main.rs:2601:13:2601:14 | x4 | T | main.rs:2568:5:2569:14 | S2 |
+| main.rs:2601:18:2601:48 | ...::method(...) |  | main.rs:2566:5:2566:20 | S1 |
+| main.rs:2601:18:2601:48 | ...::method(...) | T | main.rs:2568:5:2569:14 | S2 |
+| main.rs:2601:35:2601:47 | ...::default(...) |  | main.rs:2566:5:2566:20 | S1 |
+| main.rs:2601:35:2601:47 | ...::default(...) | T | main.rs:2568:5:2569:14 | S2 |
+| main.rs:2602:13:2602:14 | x5 |  | main.rs:2566:5:2566:20 | S1 |
+| main.rs:2602:13:2602:14 | x5 | T | main.rs:2568:5:2569:14 | S2 |
+| main.rs:2602:18:2602:42 | ...::method(...) |  | main.rs:2566:5:2566:20 | S1 |
+| main.rs:2602:18:2602:42 | ...::method(...) | T | main.rs:2568:5:2569:14 | S2 |
+| main.rs:2602:29:2602:41 | ...::default(...) |  | main.rs:2566:5:2566:20 | S1 |
+| main.rs:2602:29:2602:41 | ...::default(...) | T | main.rs:2568:5:2569:14 | S2 |
+| main.rs:2603:13:2603:14 | x6 |  | main.rs:2587:5:2587:27 | S4 |
+| main.rs:2603:13:2603:14 | x6 | T4 | main.rs:2568:5:2569:14 | S2 |
+| main.rs:2603:18:2603:45 | S4::<...>(...) |  | main.rs:2587:5:2587:27 | S4 |
+| main.rs:2603:18:2603:45 | S4::<...>(...) | T4 | main.rs:2568:5:2569:14 | S2 |
+| main.rs:2603:27:2603:44 | ...::default(...) |  | main.rs:2568:5:2569:14 | S2 |
+| main.rs:2604:13:2604:14 | x7 |  | main.rs:2587:5:2587:27 | S4 |
+| main.rs:2604:13:2604:14 | x7 | T4 | main.rs:2568:5:2569:14 | S2 |
+| main.rs:2604:18:2604:23 | S4(...) |  | main.rs:2587:5:2587:27 | S4 |
+| main.rs:2604:18:2604:23 | S4(...) | T4 | main.rs:2568:5:2569:14 | S2 |
+| main.rs:2604:21:2604:22 | S2 |  | main.rs:2568:5:2569:14 | S2 |
+| main.rs:2605:13:2605:14 | x8 |  | main.rs:2587:5:2587:27 | S4 |
+| main.rs:2605:13:2605:14 | x8 | T4 | {EXTERNAL LOCATION} | i32 |
+| main.rs:2605:18:2605:22 | S4(...) |  | main.rs:2587:5:2587:27 | S4 |
+| main.rs:2605:18:2605:22 | S4(...) | T4 | {EXTERNAL LOCATION} | i32 |
+| main.rs:2605:21:2605:21 | 0 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2606:13:2606:14 | x9 |  | main.rs:2587:5:2587:27 | S4 |
+| main.rs:2606:13:2606:14 | x9 | T4 | main.rs:2568:5:2569:14 | S2 |
+| main.rs:2606:18:2606:34 | S4(...) |  | main.rs:2587:5:2587:27 | S4 |
+| main.rs:2606:18:2606:34 | S4(...) | T4 | main.rs:2568:5:2569:14 | S2 |
+| main.rs:2606:21:2606:33 | ...::default(...) |  | main.rs:2568:5:2569:14 | S2 |
+| main.rs:2607:13:2607:15 | x10 |  | main.rs:2589:5:2591:5 | S5 |
+| main.rs:2607:13:2607:15 | x10 | T5 | main.rs:2568:5:2569:14 | S2 |
+| main.rs:2607:19:2610:9 | S5::<...> {...} |  | main.rs:2589:5:2591:5 | S5 |
+| main.rs:2607:19:2610:9 | S5::<...> {...} | T5 | main.rs:2568:5:2569:14 | S2 |
+| main.rs:2609:20:2609:37 | ...::default(...) |  | main.rs:2568:5:2569:14 | S2 |
+| main.rs:2611:13:2611:15 | x11 |  | main.rs:2589:5:2591:5 | S5 |
+| main.rs:2611:13:2611:15 | x11 | T5 | main.rs:2568:5:2569:14 | S2 |
+| main.rs:2611:19:2611:34 | S5 {...} |  | main.rs:2589:5:2591:5 | S5 |
+| main.rs:2611:19:2611:34 | S5 {...} | T5 | main.rs:2568:5:2569:14 | S2 |
+| main.rs:2611:31:2611:32 | S2 |  | main.rs:2568:5:2569:14 | S2 |
+| main.rs:2612:13:2612:15 | x12 |  | main.rs:2589:5:2591:5 | S5 |
+| main.rs:2612:13:2612:15 | x12 | T5 | {EXTERNAL LOCATION} | i32 |
+| main.rs:2612:19:2612:33 | S5 {...} |  | main.rs:2589:5:2591:5 | S5 |
+| main.rs:2612:19:2612:33 | S5 {...} | T5 | {EXTERNAL LOCATION} | i32 |
+| main.rs:2612:31:2612:31 | 0 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2613:13:2613:15 | x13 |  | main.rs:2589:5:2591:5 | S5 |
+| main.rs:2613:13:2613:15 | x13 | T5 | main.rs:2568:5:2569:14 | S2 |
+| main.rs:2613:19:2616:9 | S5 {...} |  | main.rs:2589:5:2591:5 | S5 |
+| main.rs:2613:19:2616:9 | S5 {...} | T5 | main.rs:2568:5:2569:14 | S2 |
+| main.rs:2615:20:2615:32 | ...::default(...) |  | main.rs:2568:5:2569:14 | S2 |
+| main.rs:2617:13:2617:15 | x14 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2617:19:2617:48 | foo::<...>(...) |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2617:30:2617:47 | ...::default(...) |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2618:13:2618:15 | x15 |  | main.rs:2566:5:2566:20 | S1 |
+| main.rs:2618:13:2618:15 | x15 | T | main.rs:2568:5:2569:14 | S2 |
+| main.rs:2618:19:2618:37 | ...::default(...) |  | main.rs:2566:5:2566:20 | S1 |
+| main.rs:2618:19:2618:37 | ...::default(...) | T | main.rs:2568:5:2569:14 | S2 |
+| main.rs:2627:35:2629:9 | { ... } |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2627:35:2629:9 | { ... } | 0(2) | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2627:35:2629:9 | { ... } | 1(2) | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2628:13:2628:26 | TupleExpr |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2628:13:2628:26 | TupleExpr | 0(2) | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2628:13:2628:26 | TupleExpr | 1(2) | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2628:14:2628:18 | S1 {...} |  | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2628:21:2628:25 | S1 {...} |  | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2630:16:2630:19 | SelfParam |  | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2634:13:2634:13 | a |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2634:13:2634:13 | a | 0(2) | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2634:13:2634:13 | a | 1(2) | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2634:17:2634:30 | ...::get_pair(...) |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2634:17:2634:30 | ...::get_pair(...) | 0(2) | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2634:17:2634:30 | ...::get_pair(...) | 1(2) | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2635:17:2635:17 | b |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2635:17:2635:17 | b | 0(2) | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2635:17:2635:17 | b | 1(2) | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2635:21:2635:34 | ...::get_pair(...) |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2635:21:2635:34 | ...::get_pair(...) | 0(2) | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2635:21:2635:34 | ...::get_pair(...) | 1(2) | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2636:13:2636:18 | TuplePat |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2636:13:2636:18 | TuplePat | 0(2) | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2636:13:2636:18 | TuplePat | 1(2) | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2636:14:2636:14 | c |  | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2636:17:2636:17 | d |  | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2636:22:2636:35 | ...::get_pair(...) |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2636:22:2636:35 | ...::get_pair(...) | 0(2) | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2636:22:2636:35 | ...::get_pair(...) | 1(2) | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2637:13:2637:22 | TuplePat |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2637:13:2637:22 | TuplePat | 0(2) | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2637:13:2637:22 | TuplePat | 1(2) | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2637:18:2637:18 | e |  | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2637:21:2637:21 | f |  | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2637:26:2637:39 | ...::get_pair(...) |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2637:26:2637:39 | ...::get_pair(...) | 0(2) | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2637:26:2637:39 | ...::get_pair(...) | 1(2) | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2638:13:2638:26 | TuplePat |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2638:13:2638:26 | TuplePat | 0(2) | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2638:13:2638:26 | TuplePat | 1(2) | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2638:18:2638:18 | g |  | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2638:25:2638:25 | h |  | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2638:30:2638:43 | ...::get_pair(...) |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2638:30:2638:43 | ...::get_pair(...) | 0(2) | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2638:30:2638:43 | ...::get_pair(...) | 1(2) | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2640:9:2640:9 | a |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2640:9:2640:9 | a | 0(2) | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2640:9:2640:9 | a | 1(2) | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2640:9:2640:11 | a.0 |  | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2641:9:2641:9 | b |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2641:9:2641:9 | b | 0(2) | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2641:9:2641:9 | b | 1(2) | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2641:9:2641:11 | b.1 |  | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2642:9:2642:9 | c |  | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2643:9:2643:9 | d |  | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2644:9:2644:9 | e |  | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2645:9:2645:9 | f |  | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2646:9:2646:9 | g |  | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2647:9:2647:9 | h |  | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2652:13:2652:13 | a |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2652:17:2652:34 | ...::default(...) |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2653:13:2653:13 | b |  | {EXTERNAL LOCATION} | bool |
+| main.rs:2653:17:2653:34 | ...::default(...) |  | {EXTERNAL LOCATION} | bool |
+| main.rs:2654:13:2654:16 | pair |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2654:13:2654:16 | pair | 0(2) | {EXTERNAL LOCATION} | i64 |
+| main.rs:2654:13:2654:16 | pair | 1(2) | {EXTERNAL LOCATION} | bool |
+| main.rs:2654:20:2654:25 | TupleExpr |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2654:20:2654:25 | TupleExpr | 0(2) | {EXTERNAL LOCATION} | i64 |
+| main.rs:2654:20:2654:25 | TupleExpr | 1(2) | {EXTERNAL LOCATION} | bool |
+| main.rs:2654:21:2654:21 | a |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2654:24:2654:24 | b |  | {EXTERNAL LOCATION} | bool |
+| main.rs:2655:13:2655:13 | i |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2655:22:2655:25 | pair |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2655:22:2655:25 | pair | 0(2) | {EXTERNAL LOCATION} | i64 |
+| main.rs:2655:22:2655:25 | pair | 1(2) | {EXTERNAL LOCATION} | bool |
+| main.rs:2655:22:2655:27 | pair.0 |  | {EXTERNAL LOCATION} | i64 |
+| main.rs:2656:13:2656:13 | j |  | {EXTERNAL LOCATION} | bool |
+| main.rs:2656:23:2656:26 | pair |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2656:23:2656:26 | pair | 0(2) | {EXTERNAL LOCATION} | i64 |
+| main.rs:2656:23:2656:26 | pair | 1(2) | {EXTERNAL LOCATION} | bool |
+| main.rs:2656:23:2656:28 | pair.1 |  | {EXTERNAL LOCATION} | bool |
+| main.rs:2658:13:2658:16 | pair |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2658:13:2658:16 | pair | 0(2) | {EXTERNAL LOCATION} | i32 |
+| main.rs:2658:13:2658:16 | pair | 1(2) | {EXTERNAL LOCATION} | i32 |
+| main.rs:2658:20:2658:25 | [...] |  | file://:0:0:0:0 | [] |
+| main.rs:2658:20:2658:25 | [...] | [T;...] | {EXTERNAL LOCATION} | i32 |
+| main.rs:2658:20:2658:32 | ... .into() |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2658:20:2658:32 | ... .into() | 0(2) | {EXTERNAL LOCATION} | i32 |
+| main.rs:2658:20:2658:32 | ... .into() | 1(2) | {EXTERNAL LOCATION} | i32 |
+| main.rs:2658:21:2658:21 | 1 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2658:24:2658:24 | 1 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2659:15:2659:18 | pair |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2659:15:2659:18 | pair | 0(2) | {EXTERNAL LOCATION} | i32 |
+| main.rs:2659:15:2659:18 | pair | 1(2) | {EXTERNAL LOCATION} | i32 |
+| main.rs:2660:13:2660:18 | TuplePat |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2660:13:2660:18 | TuplePat | 0(2) | {EXTERNAL LOCATION} | i32 |
+| main.rs:2660:13:2660:18 | TuplePat | 1(2) | {EXTERNAL LOCATION} | i32 |
+| main.rs:2660:14:2660:14 | 0 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2660:17:2660:17 | 0 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2660:30:2660:41 | "unexpected" |  | file://:0:0:0:0 | & |
+| main.rs:2660:30:2660:41 | "unexpected" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:2660:30:2660:41 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:2660:30:2660:41 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:2661:13:2661:13 | _ |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2661:13:2661:13 | _ | 0(2) | {EXTERNAL LOCATION} | i32 |
+| main.rs:2661:13:2661:13 | _ | 1(2) | {EXTERNAL LOCATION} | i32 |
+| main.rs:2661:25:2661:34 | "expected" |  | file://:0:0:0:0 | & |
+| main.rs:2661:25:2661:34 | "expected" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:2661:25:2661:34 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:2661:25:2661:34 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:2663:13:2663:13 | x |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2663:17:2663:20 | pair |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2663:17:2663:20 | pair | 0(2) | {EXTERNAL LOCATION} | i32 |
+| main.rs:2663:17:2663:20 | pair | 1(2) | {EXTERNAL LOCATION} | i32 |
+| main.rs:2663:17:2663:22 | pair.0 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2665:13:2665:13 | y |  | file://:0:0:0:0 | & |
+| main.rs:2665:13:2665:13 | y | &T | file://:0:0:0:0 | (T_2) |
+| main.rs:2665:13:2665:13 | y | &T.0(2) | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2665:13:2665:13 | y | &T.1(2) | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2665:17:2665:31 | &... |  | file://:0:0:0:0 | & |
+| main.rs:2665:17:2665:31 | &... | &T | file://:0:0:0:0 | (T_2) |
+| main.rs:2665:17:2665:31 | &... | &T.0(2) | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2665:17:2665:31 | &... | &T.1(2) | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2665:18:2665:31 | ...::get_pair(...) |  | file://:0:0:0:0 | (T_2) |
+| main.rs:2665:18:2665:31 | ...::get_pair(...) | 0(2) | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2665:18:2665:31 | ...::get_pair(...) | 1(2) | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2666:9:2666:9 | y |  | file://:0:0:0:0 | & |
+| main.rs:2666:9:2666:9 | y | &T | file://:0:0:0:0 | (T_2) |
+| main.rs:2666:9:2666:9 | y | &T.0(2) | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2666:9:2666:9 | y | &T.1(2) | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2666:9:2666:11 | y.0 |  | main.rs:2623:5:2624:16 | S1 |
+| main.rs:2673:13:2673:23 | boxed_value |  | {EXTERNAL LOCATION} | Box |
+| main.rs:2673:13:2673:23 | boxed_value | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2673:13:2673:23 | boxed_value | T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2673:27:2673:42 | ...::new(...) |  | {EXTERNAL LOCATION} | Box |
+| main.rs:2673:27:2673:42 | ...::new(...) | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2673:27:2673:42 | ...::new(...) | T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2673:36:2673:41 | 100i32 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2676:15:2676:25 | boxed_value |  | {EXTERNAL LOCATION} | Box |
+| main.rs:2676:15:2676:25 | boxed_value | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2676:15:2676:25 | boxed_value | T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2677:13:2677:19 | box 100 |  | {EXTERNAL LOCATION} | Box |
+| main.rs:2677:13:2677:19 | box 100 | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2677:13:2677:19 | box 100 | T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2677:17:2677:19 | 100 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2678:26:2678:36 | "Boxed 100\\n" |  | file://:0:0:0:0 | & |
+| main.rs:2678:26:2678:36 | "Boxed 100\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:2678:26:2678:36 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:2678:26:2678:36 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:2680:13:2680:17 | box ... |  | {EXTERNAL LOCATION} | Box |
+| main.rs:2680:13:2680:17 | box ... | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2680:13:2680:17 | box ... | T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2682:26:2682:42 | "Boxed value: {}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:2682:26:2682:42 | "Boxed value: {}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:2682:26:2682:51 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:2682:26:2682:51 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:2687:13:2687:22 | nested_box |  | {EXTERNAL LOCATION} | Box |
+| main.rs:2687:13:2687:22 | nested_box | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2687:13:2687:22 | nested_box | T | {EXTERNAL LOCATION} | Box |
+| main.rs:2687:13:2687:22 | nested_box | T.A | {EXTERNAL LOCATION} | Global |
+| main.rs:2687:13:2687:22 | nested_box | T.T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2687:26:2687:50 | ...::new(...) |  | {EXTERNAL LOCATION} | Box |
+| main.rs:2687:26:2687:50 | ...::new(...) | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2687:26:2687:50 | ...::new(...) | T | {EXTERNAL LOCATION} | Box |
+| main.rs:2687:26:2687:50 | ...::new(...) | T.A | {EXTERNAL LOCATION} | Global |
+| main.rs:2687:26:2687:50 | ...::new(...) | T.T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2687:35:2687:49 | ...::new(...) |  | {EXTERNAL LOCATION} | Box |
+| main.rs:2687:35:2687:49 | ...::new(...) | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2687:35:2687:49 | ...::new(...) | T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2687:44:2687:48 | 42i32 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2688:15:2688:24 | nested_box |  | {EXTERNAL LOCATION} | Box |
+| main.rs:2688:15:2688:24 | nested_box | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2688:15:2688:24 | nested_box | T | {EXTERNAL LOCATION} | Box |
+| main.rs:2688:15:2688:24 | nested_box | T.A | {EXTERNAL LOCATION} | Global |
+| main.rs:2688:15:2688:24 | nested_box | T.T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2689:13:2689:21 | box ... |  | {EXTERNAL LOCATION} | Box |
+| main.rs:2689:13:2689:21 | box ... | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2689:13:2689:21 | box ... | T | {EXTERNAL LOCATION} | Box |
+| main.rs:2689:13:2689:21 | box ... | T.A | {EXTERNAL LOCATION} | Global |
+| main.rs:2689:13:2689:21 | box ... | T.T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2691:26:2691:43 | "Nested boxed: {}\\n" |  | file://:0:0:0:0 | & |
+| main.rs:2691:26:2691:43 | "Nested boxed: {}\\n" | &T | {EXTERNAL LOCATION} | str |
+| main.rs:2691:26:2691:59 | FormatArgsExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:2691:26:2691:59 | MacroExpr |  | {EXTERNAL LOCATION} | Arguments |
+| main.rs:2703:36:2705:9 | { ... } |  | main.rs:2700:5:2700:22 | Path |
+| main.rs:2704:13:2704:19 | Path {...} |  | main.rs:2700:5:2700:22 | Path |
+| main.rs:2707:29:2707:33 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:2707:29:2707:33 | SelfParam | &T | main.rs:2700:5:2700:22 | Path |
+| main.rs:2707:59:2709:9 | { ... } |  | {EXTERNAL LOCATION} | Result |
+| main.rs:2707:59:2709:9 | { ... } | E | file://:0:0:0:0 | () |
+| main.rs:2707:59:2709:9 | { ... } | T | main.rs:2712:5:2712:25 | PathBuf |
+| main.rs:2708:13:2708:30 | Ok(...) |  | {EXTERNAL LOCATION} | Result |
+| main.rs:2708:13:2708:30 | Ok(...) | E | file://:0:0:0:0 | () |
+| main.rs:2708:13:2708:30 | Ok(...) | T | main.rs:2712:5:2712:25 | PathBuf |
+| main.rs:2708:16:2708:29 | ...::new(...) |  | main.rs:2712:5:2712:25 | PathBuf |
+| main.rs:2715:39:2717:9 | { ... } |  | main.rs:2712:5:2712:25 | PathBuf |
+| main.rs:2716:13:2716:22 | PathBuf {...} |  | main.rs:2712:5:2712:25 | PathBuf |
+| main.rs:2725:18:2725:22 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:2725:18:2725:22 | SelfParam | &T | main.rs:2712:5:2712:25 | PathBuf |
+| main.rs:2725:34:2729:9 | { ... } |  | file://:0:0:0:0 | & |
+| main.rs:2725:34:2729:9 | { ... } | &T | main.rs:2700:5:2700:22 | Path |
+| main.rs:2727:33:2727:43 | ...::new(...) |  | main.rs:2700:5:2700:22 | Path |
+| main.rs:2728:13:2728:17 | &path |  | file://:0:0:0:0 | & |
+| main.rs:2728:13:2728:17 | &path | &T | main.rs:2700:5:2700:22 | Path |
+| main.rs:2728:14:2728:17 | path |  | main.rs:2700:5:2700:22 | Path |
+| main.rs:2733:13:2733:17 | path1 |  | main.rs:2700:5:2700:22 | Path |
+| main.rs:2733:21:2733:31 | ...::new(...) |  | main.rs:2700:5:2700:22 | Path |
+| main.rs:2734:13:2734:17 | path2 |  | {EXTERNAL LOCATION} | Result |
+| main.rs:2734:13:2734:17 | path2 | E | file://:0:0:0:0 | () |
+| main.rs:2734:13:2734:17 | path2 | T | main.rs:2712:5:2712:25 | PathBuf |
+| main.rs:2734:21:2734:25 | path1 |  | main.rs:2700:5:2700:22 | Path |
+| main.rs:2734:21:2734:40 | path1.canonicalize() |  | {EXTERNAL LOCATION} | Result |
+| main.rs:2734:21:2734:40 | path1.canonicalize() | E | file://:0:0:0:0 | () |
+| main.rs:2734:21:2734:40 | path1.canonicalize() | T | main.rs:2712:5:2712:25 | PathBuf |
+| main.rs:2735:13:2735:17 | path3 |  | main.rs:2712:5:2712:25 | PathBuf |
+| main.rs:2735:21:2735:25 | path2 |  | {EXTERNAL LOCATION} | Result |
+| main.rs:2735:21:2735:25 | path2 | E | file://:0:0:0:0 | () |
+| main.rs:2735:21:2735:25 | path2 | T | main.rs:2712:5:2712:25 | PathBuf |
+| main.rs:2735:21:2735:34 | path2.unwrap() |  | main.rs:2712:5:2712:25 | PathBuf |
+| main.rs:2737:13:2737:20 | pathbuf1 |  | main.rs:2712:5:2712:25 | PathBuf |
+| main.rs:2737:24:2737:37 | ...::new(...) |  | main.rs:2712:5:2712:25 | PathBuf |
+| main.rs:2738:24:2738:31 | pathbuf1 |  | main.rs:2712:5:2712:25 | PathBuf |
+| main.rs:2745:14:2745:18 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:2745:14:2745:18 | SelfParam | &T | main.rs:2744:5:2746:5 | Self [trait MyTrait] |
+| main.rs:2752:14:2752:18 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:2752:14:2752:18 | SelfParam | &T | main.rs:2748:5:2749:19 | S |
+| main.rs:2752:14:2752:18 | SelfParam | &T.T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2752:28:2754:9 | { ... } |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2753:13:2753:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:2753:13:2753:16 | self | &T | main.rs:2748:5:2749:19 | S |
+| main.rs:2753:13:2753:16 | self | &T.T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2753:13:2753:18 | self.0 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2758:14:2758:18 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:2758:14:2758:18 | SelfParam | &T | main.rs:2748:5:2749:19 | S |
+| main.rs:2758:14:2758:18 | SelfParam | &T.T | main.rs:2748:5:2749:19 | S |
+| main.rs:2758:14:2758:18 | SelfParam | &T.T.T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2758:28:2760:9 | { ... } |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2759:13:2759:16 | self |  | file://:0:0:0:0 | & |
+| main.rs:2759:13:2759:16 | self | &T | main.rs:2748:5:2749:19 | S |
+| main.rs:2759:13:2759:16 | self | &T.T | main.rs:2748:5:2749:19 | S |
+| main.rs:2759:13:2759:16 | self | &T.T.T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2759:13:2759:18 | self.0 |  | main.rs:2748:5:2749:19 | S |
+| main.rs:2759:13:2759:18 | self.0 | T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2759:13:2759:21 | ... .0 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2764:15:2764:19 | SelfParam |  | file://:0:0:0:0 | & |
+| main.rs:2764:15:2764:19 | SelfParam | &T | main.rs:2748:5:2749:19 | S |
+| main.rs:2764:15:2764:19 | SelfParam | &T.T | main.rs:2763:10:2763:16 | T |
+| main.rs:2764:33:2766:9 | { ... } |  | main.rs:2748:5:2749:19 | S |
+| main.rs:2764:33:2766:9 | { ... } | T | main.rs:2748:5:2749:19 | S |
+| main.rs:2764:33:2766:9 | { ... } | T.T | main.rs:2763:10:2763:16 | T |
+| main.rs:2765:13:2765:24 | S(...) |  | main.rs:2748:5:2749:19 | S |
+| main.rs:2765:13:2765:24 | S(...) | T | main.rs:2748:5:2749:19 | S |
+| main.rs:2765:13:2765:24 | S(...) | T.T | main.rs:2763:10:2763:16 | T |
+| main.rs:2765:15:2765:23 | S(...) |  | main.rs:2748:5:2749:19 | S |
+| main.rs:2765:15:2765:23 | S(...) | T | main.rs:2763:10:2763:16 | T |
+| main.rs:2765:17:2765:20 | self |  | file://:0:0:0:0 | & |
+| main.rs:2765:17:2765:20 | self | &T | main.rs:2748:5:2749:19 | S |
+| main.rs:2765:17:2765:20 | self | &T.T | main.rs:2763:10:2763:16 | T |
+| main.rs:2765:17:2765:22 | self.0 |  | main.rs:2763:10:2763:16 | T |
+| main.rs:2769:14:2769:14 | b |  | {EXTERNAL LOCATION} | bool |
+| main.rs:2769:48:2786:5 | { ... } |  | {EXTERNAL LOCATION} | Box |
+| main.rs:2769:48:2786:5 | { ... } | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2769:48:2786:5 | { ... } | T | main.rs:2744:5:2746:5 | dyn MyTrait |
+| main.rs:2769:48:2786:5 | { ... } | T.dyn(T) | {EXTERNAL LOCATION} | i32 |
+| main.rs:2770:13:2770:13 | x |  | main.rs:2748:5:2749:19 | S |
+| main.rs:2770:13:2770:13 | x | T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2770:17:2775:9 | if b {...} else {...} |  | main.rs:2748:5:2749:19 | S |
+| main.rs:2770:17:2775:9 | if b {...} else {...} | T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2770:20:2770:20 | b |  | {EXTERNAL LOCATION} | bool |
+| main.rs:2770:22:2773:9 | { ... } |  | main.rs:2748:5:2749:19 | S |
+| main.rs:2770:22:2773:9 | { ... } | T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2771:17:2771:17 | y |  | main.rs:2748:5:2749:19 | S |
+| main.rs:2771:17:2771:17 | y | T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2771:21:2771:38 | ...::default(...) |  | main.rs:2748:5:2749:19 | S |
+| main.rs:2771:21:2771:38 | ...::default(...) | T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2772:13:2772:13 | y |  | main.rs:2748:5:2749:19 | S |
+| main.rs:2772:13:2772:13 | y | T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2773:16:2775:9 | { ... } |  | main.rs:2748:5:2749:19 | S |
+| main.rs:2773:16:2775:9 | { ... } | T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2774:13:2774:16 | S(...) |  | main.rs:2748:5:2749:19 | S |
+| main.rs:2774:13:2774:16 | S(...) | T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2774:15:2774:15 | 2 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2779:13:2779:13 | x |  | main.rs:2744:5:2746:5 | dyn MyTrait |
+| main.rs:2779:13:2779:13 | x |  | main.rs:2748:5:2749:19 | S |
+| main.rs:2779:13:2779:13 | x | T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2779:13:2779:13 | x | dyn(T) | {EXTERNAL LOCATION} | i32 |
+| main.rs:2779:17:2779:20 | S(...) |  | main.rs:2744:5:2746:5 | dyn MyTrait |
+| main.rs:2779:17:2779:20 | S(...) |  | main.rs:2748:5:2749:19 | S |
+| main.rs:2779:17:2779:20 | S(...) | T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2779:17:2779:20 | S(...) | dyn(T) | {EXTERNAL LOCATION} | i32 |
+| main.rs:2779:19:2779:19 | 1 |  | {EXTERNAL LOCATION} | i32 |
+| main.rs:2780:9:2785:9 | if b {...} else {...} |  | {EXTERNAL LOCATION} | Box |
+| main.rs:2780:9:2785:9 | if b {...} else {...} | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2780:9:2785:9 | if b {...} else {...} | T | main.rs:2744:5:2746:5 | dyn MyTrait |
+| main.rs:2780:9:2785:9 | if b {...} else {...} | T | main.rs:2748:5:2749:19 | S |
+| main.rs:2780:9:2785:9 | if b {...} else {...} | T.T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2780:9:2785:9 | if b {...} else {...} | T.T | main.rs:2748:5:2749:19 | S |
+| main.rs:2780:9:2785:9 | if b {...} else {...} | T.T.T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2780:9:2785:9 | if b {...} else {...} | T.dyn(T) | {EXTERNAL LOCATION} | i32 |
+| main.rs:2780:12:2780:12 | b |  | {EXTERNAL LOCATION} | bool |
+| main.rs:2780:14:2783:9 | { ... } |  | {EXTERNAL LOCATION} | Box |
+| main.rs:2780:14:2783:9 | { ... } | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2780:14:2783:9 | { ... } | T | main.rs:2744:5:2746:5 | dyn MyTrait |
+| main.rs:2780:14:2783:9 | { ... } | T | main.rs:2748:5:2749:19 | S |
+| main.rs:2780:14:2783:9 | { ... } | T.T | main.rs:2748:5:2749:19 | S |
+| main.rs:2780:14:2783:9 | { ... } | T.T.T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2780:14:2783:9 | { ... } | T.dyn(T) | {EXTERNAL LOCATION} | i32 |
+| main.rs:2781:17:2781:17 | x |  | main.rs:2744:5:2746:5 | dyn MyTrait |
+| main.rs:2781:17:2781:17 | x |  | main.rs:2748:5:2749:19 | S |
+| main.rs:2781:17:2781:17 | x | T | main.rs:2748:5:2749:19 | S |
+| main.rs:2781:17:2781:17 | x | T.T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2781:17:2781:17 | x | dyn(T) | {EXTERNAL LOCATION} | i32 |
+| main.rs:2781:21:2781:21 | x |  | main.rs:2744:5:2746:5 | dyn MyTrait |
+| main.rs:2781:21:2781:21 | x |  | main.rs:2748:5:2749:19 | S |
+| main.rs:2781:21:2781:21 | x | T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2781:21:2781:21 | x | dyn(T) | {EXTERNAL LOCATION} | i32 |
+| main.rs:2781:21:2781:26 | x.m2() |  | main.rs:2744:5:2746:5 | dyn MyTrait |
+| main.rs:2781:21:2781:26 | x.m2() |  | main.rs:2748:5:2749:19 | S |
+| main.rs:2781:21:2781:26 | x.m2() | T | main.rs:2748:5:2749:19 | S |
+| main.rs:2781:21:2781:26 | x.m2() | T.T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2781:21:2781:26 | x.m2() | dyn(T) | {EXTERNAL LOCATION} | i32 |
+| main.rs:2782:13:2782:23 | ...::new(...) |  | {EXTERNAL LOCATION} | Box |
+| main.rs:2782:13:2782:23 | ...::new(...) | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2782:13:2782:23 | ...::new(...) | T | main.rs:2744:5:2746:5 | dyn MyTrait |
+| main.rs:2782:13:2782:23 | ...::new(...) | T | main.rs:2748:5:2749:19 | S |
+| main.rs:2782:13:2782:23 | ...::new(...) | T.T | main.rs:2748:5:2749:19 | S |
+| main.rs:2782:13:2782:23 | ...::new(...) | T.T.T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2782:13:2782:23 | ...::new(...) | T.dyn(T) | {EXTERNAL LOCATION} | i32 |
+| main.rs:2782:22:2782:22 | x |  | main.rs:2744:5:2746:5 | dyn MyTrait |
+| main.rs:2782:22:2782:22 | x |  | main.rs:2748:5:2749:19 | S |
+| main.rs:2782:22:2782:22 | x | T | main.rs:2748:5:2749:19 | S |
+| main.rs:2782:22:2782:22 | x | T.T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2782:22:2782:22 | x | dyn(T) | {EXTERNAL LOCATION} | i32 |
+| main.rs:2783:16:2785:9 | { ... } |  | {EXTERNAL LOCATION} | Box |
+| main.rs:2783:16:2785:9 | { ... } | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2783:16:2785:9 | { ... } | T | main.rs:2744:5:2746:5 | dyn MyTrait |
+| main.rs:2783:16:2785:9 | { ... } | T | main.rs:2748:5:2749:19 | S |
+| main.rs:2783:16:2785:9 | { ... } | T.T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2783:16:2785:9 | { ... } | T.dyn(T) | {EXTERNAL LOCATION} | i32 |
+| main.rs:2784:13:2784:23 | ...::new(...) |  | {EXTERNAL LOCATION} | Box |
+| main.rs:2784:13:2784:23 | ...::new(...) | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2784:13:2784:23 | ...::new(...) | T | main.rs:2744:5:2746:5 | dyn MyTrait |
+| main.rs:2784:13:2784:23 | ...::new(...) | T | main.rs:2748:5:2749:19 | S |
+| main.rs:2784:13:2784:23 | ...::new(...) | T.T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2784:13:2784:23 | ...::new(...) | T.dyn(T) | {EXTERNAL LOCATION} | i32 |
+| main.rs:2784:22:2784:22 | x |  | main.rs:2744:5:2746:5 | dyn MyTrait |
+| main.rs:2784:22:2784:22 | x |  | main.rs:2748:5:2749:19 | S |
+| main.rs:2784:22:2784:22 | x | T | {EXTERNAL LOCATION} | i32 |
+| main.rs:2784:22:2784:22 | x | dyn(T) | {EXTERNAL LOCATION} | i32 |
+| main.rs:2796:5:2796:20 | ...::f(...) |  | main.rs:72:5:72:21 | Foo |
+| main.rs:2797:5:2797:60 | ...::g(...) |  | main.rs:72:5:72:21 | Foo |
+| main.rs:2797:20:2797:38 | ...::Foo {...} |  | main.rs:72:5:72:21 | Foo |
+| main.rs:2797:41:2797:59 | ...::Foo {...} |  | main.rs:72:5:72:21 | Foo |
+| main.rs:2814:5:2814:15 | ...::f(...) |  | {EXTERNAL LOCATION} | trait Future |
+| main.rs:2827:5:2827:20 | ...::f(...) |  | {EXTERNAL LOCATION} | Box |
+| main.rs:2827:5:2827:20 | ...::f(...) | A | {EXTERNAL LOCATION} | Global |
+| main.rs:2827:5:2827:20 | ...::f(...) | T | main.rs:2744:5:2746:5 | dyn MyTrait |
+| main.rs:2827:5:2827:20 | ...::f(...) | T.dyn(T) | {EXTERNAL LOCATION} | i32 |
+| main.rs:2827:16:2827:19 | true |  | {EXTERNAL LOCATION} | bool |
 | pattern_matching.rs:13:26:133:1 | { ... } |  | {EXTERNAL LOCATION} | Option |
 | pattern_matching.rs:13:26:133:1 | { ... } | T | file://:0:0:0:0 | () |
 | pattern_matching.rs:14:9:14:13 | value |  | {EXTERNAL LOCATION} | Option |


### PR DESCRIPTION
This PR fixes two issues in how we handle `Self` type parameters. They're separate but related issues, so I've bunched them into one PR. Together these fixes should address https://github.com/github/codeql/pull/20682/files#r2464739113.

#### 1/ `Self` in a default for a trait type parameter

If we have a default like this:
```rust
trait TraitWithSelfTp<A = Option<Self>> { ... }
```
Then, when `TraitWithSelfTp` is used as a trait bound, the meaning of the `Self` depends where that trait bound occurs. For instance, `T : TraitWithSelfTp` is the same as `T : TraitWithSelfTp<T>` and _not_ `T : TraitWithSelfTp<Self_TraitWithSelfTp>`

The type mention `Self` in the default refers to the the `Self` type parameter for `TraitWithSelfTp`, but this needs to be translated at trait bounds.

#### 2/ `Self` in supertraits

When `Self` occurs in the trait hierarchy
```rust
trait Sub: Super<Self> { ... }
trait SubSub : Sub { ... }
```
then those `Self` occurrences need to be instantiated such that the shared `conditionSatisfiesConstraintTypeAt` machinery calculates the correct trait hierarchy. Above, we should have that `SubSub` implements `Super<Self_SubSub>` and not some other `Self` parameter. To this end, the type mention for supertraits must instantiate the supertrait's `Self` type parameter.