### PR TITLE
C#: Allow nullness sources with SSA at entry.

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/dataflow/Nullness.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/Nullness.qll
@@ -197,7 +197,6 @@ private predicate defMaybeNull(
       msg = "as suggested by $@ null check" and
       node = def.getControlFlowNode() and
       not de = any(Ssa::PhiNode phi).getARead() and
-      strictcount(Element e | e = any(Ssa::Definition def0 | de = def0.getARead()).getElement()) = 1 and
       // Don't use a check as reason if there is a `null` assignment
       // or argument
       not def.(Ssa::ExplicitDefinition).getADefinition().getSource() instanceof MaybeNullExpr and


### PR DESCRIPTION
Now that splitting is reduced, this particular condition only serves to rule out SSA entry definitions, since they don't have an associated AST element, and I don't _think_ those sources should be excluded.

Looking through some of the dca result diffs all of the new results look like TPs to me.