### PR TITLE
C#: Report more timing metrics to the console logger.

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp.Standalone/Extractor.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.Standalone/Extractor.cs
@@ -154,7 +154,8 @@ namespace Semmle.Extraction.CSharp.Standalone
                 fileLogger.LogError($"  Unhandled exception: {ex}");
             }
 
-            logger.Log(Severity.Info, $"Extraction completed in {overallStopwatch.Elapsed}");
+            logger.Log(Severity.Info, $"Extraction completed in {analyzerStopwatch.Elapsed}");
+            logger.Log(Severity.Info, $"Total time: {overallStopwatch.Elapsed}");
 
             return ExitCode.Ok;
         }


### PR DESCRIPTION
With this change it will be easier to see from the console log
- How much time we spend in the dependency fetcher (including running source code generators).
- How much time we spend in compilation + TRAP generation. This is the extraction phase.
- How much time we spend in total.

With this change it will be easier to inspect the impact of Incremental CodeQL and dependency caching.
Note, that this also changes the meaning of "Extraction completed in..". As this number now only measures, how long the extraction took and not including the dependency fetching.