### PR TITLE
C++: Fix bad magic in `IRGuards`

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/controlflow/IRGuards.qll
+++ b/cpp/ql/lib/semmle/code/cpp/controlflow/IRGuards.qll
@@ -703,6 +703,7 @@ private class GuardConditionFromBinaryLogicalOperator extends GuardConditionImpl
     )
   }
 
+  pragma[nomagic]
   override predicate comparesLt(
     Cpp::Expr left, Cpp::Expr right, int k, boolean isLessThan, boolean testIsTrue
   ) {
@@ -713,6 +714,7 @@ private class GuardConditionFromBinaryLogicalOperator extends GuardConditionImpl
     )
   }
 
+  pragma[nomagic]
   override predicate comparesLt(Cpp::Expr e, int k, boolean isLessThan, GuardValue value) {
     exists(GuardValue partValue, GuardCondition part |
       this.(Cpp::BinaryLogicalOperation)
@@ -738,6 +740,7 @@ private class GuardConditionFromBinaryLogicalOperator extends GuardConditionImpl
     )
   }
 
+  pragma[nomagic]
   override predicate comparesEq(
     Cpp::Expr left, Cpp::Expr right, int k, boolean areEqual, boolean testIsTrue
   ) {
@@ -757,6 +760,7 @@ private class GuardConditionFromBinaryLogicalOperator extends GuardConditionImpl
     )
   }
 
+  pragma[nomagic]
   override predicate comparesEq(Cpp::Expr e, int k, boolean areEqual, GuardValue value) {
     exists(GuardValue partValue, GuardCondition part |
       this.(Cpp::BinaryLogicalOperation)


### PR DESCRIPTION
I don't have tuple counts for when this went wrong, but I do have this lovely table row from someone at Microsoft:

```
1096m19s |     1 | 1096m19s @ 1    | IRGuards::GuardConditionFromBinaryLogicalOperator.comparesEq/4#749f53a9#ffbff@5d4f1frn
```

... Yes, that's 18 hours 😂 I guessed that the 2nd (3rd) parameter being bound by magic had something to do with it, and the end-to-end time went down to 2 hours after these changes 🎉