### PR TITLE
CI: update images in `build-ripunzip.yml`

### DIFF
--- a/.github/workflows/build-ripunzip.yml
+++ b/.github/workflows/build-ripunzip.yml
@@ -6,14 +6,15 @@ on:
       ripunzip-version:
         description: "what reference to checktout from google/runzip"
         required: false
-        default: v2.0.3
       openssl-version:
         description: "what reference to checkout from openssl/openssl for Linux"
         required: false
-        default: openssl-3.6.0
   pull_request:
     paths:
       - .github/workflows/build-ripunzip.yml
+env:
+  RIPUNZIP_DEFAULT: v2.0.3
+  OPENSSL_DEFAULT: openssl-3.6.0
 
 jobs:
   build:
@@ -26,7 +27,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           repository: google/ripunzip
-          ref: ${{ inputs.ripunzip-version }}
+          ref: ${{ inputs.ripunzip-version || env.RIPUNZIP_DEFAULT }}
       # we need to avoid ripunzip dynamically linking into libssl
       # see https://github.com/sfackler/rust-openssl/issues/183
       - if: runner.os == 'Linux'
@@ -35,7 +36,7 @@ jobs:
         with:
           repository: openssl/openssl
           path: openssl
-          ref: ${{ inputs.openssl-version }}
+          ref: ${{ inputs.openssl-version || env.OPENSSL_DEFAULT }}
       - if: runner.os == 'Linux'
         name: build and install openssl with fPIC
         shell: bash


### PR DESCRIPTION
In particular the `macos-13` image is undergoing brownout, but we can update all images here while we're at it.