### PR TITLE
CI: make `build-ripunzip.yml` auto-create update PR

### DIFF
--- a/.github/workflows/build-ripunzip.yml
+++ b/.github/workflows/build-ripunzip.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Archive
         shell: bash
         run: |
-          tar acf ripunzip-$RUNNER_OS.tar.zst ripunzip-${RUNNER_OS,,}
+          tar acf ripunzip-$RUNNER_OS.tar.zst ripunzip-$(echo $RUNNER_OS | tr '[:upper:]' '[:lower:]')
       - name: Upload built binary
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Also made it use latest versions of `ripunzip` and `openssl` by default.

Example auto-opened PR [here](https://github.com/github/codeql/pull/20801) (which includes these changes because ran on this branch).