### PR TITLE
Guards: Improve join-order for wrapper guards

### DIFF
--- a/shared/controlflow/codeql/controlflow/Guards.qll
+++ b/shared/controlflow/codeql/controlflow/Guards.qll
@@ -1114,6 +1114,11 @@ module Make<
       private predicate validReturnInCustomGuardToRank(
         int rnk, NonOverridableMethod m, ParameterPosition ppos, GuardValue retval, GuardValue val
       ) {
+        // The forall-range has been pushed all the way into
+        // `relevantReturnExprValue` and `validReturnInCustomGuard`. This means
+        // that this base case ensures that at least one return expression
+        // non-vacuously satisfies that it's a valid implication from return
+        // value to parameter value.
         validReturnInCustomGuard(_, _, m, ppos, retval, val) and rnk = 0
         or
         validReturnInCustomGuardToRank(rnk - 1, m, ppos, retval, val) and


### PR DESCRIPTION
Improves the asymptotic performance of wrapper guards by applying the usual rank-iteration tranformation to a recursive universal quantification.

An observed example of the form
```
int foo(string x) {
  switch(x) {
     case "1" : return 1;
     case "2" : return 2;
     ...
     case "1000" : return 1000;
     default: return 0;
  }
}
```
goes from `O(n^3)` to `O(n^2)` to evaluate the `O(n)` result (the set of implications from return value to parameter value seeded with return being zero or not-zero).