### PR TITLE
Rust: Fix bad join

### DIFF
--- a/rust/ql/lib/codeql/rust/elements/internal/ElementImpl.qll
+++ b/rust/ql/lib/codeql/rust/elements/internal/ElementImpl.qll
@@ -105,7 +105,7 @@ module Impl {
         not isAttributeMacroExpansionSourceLocation(macro, n.getLocation())
       )
       or
-      isFromMacroExpansion(getImmediatelyEnclosingMacroInvocation(n))
+      isFromMacroExpansion(pragma[only_bind_into](getImmediatelyEnclosingMacroInvocation(n)))
     }
 
     cached


### PR DESCRIPTION
Before
```
Pipeline standard for ElementImpl::Impl::MacroExpansion::isFromMacroExpansion/1#69965d18@7580bdbj was evaluated in 205 iterations totaling 49106ms (delta sizes total: 1254645).
        8014745124  ~4%    {1} r1 = AstNodeImpl::Impl::AstNode#22e758cf AND NOT `ElementImpl::Impl::MacroExpansion::isFromMacroExpansion/1#69965d18#prev`(FIRST 1)
         822416474  ~0%    {2}    | JOIN WITH `ElementImpl::Impl::MacroExpansion::getImmediatelyEnclosingMacroInvocation/1#1eb32ecc` ON FIRST 1 OUTPUT Rhs.1, Lhs.0
           1254645  ~0%    {1}    | JOIN WITH `ElementImpl::Impl::MacroExpansion::isFromMacroExpansion/1#69965d18#prev_delta` ON FIRST 1 OUTPUT Lhs.1
                           return r1
```

After
```
Pipeline standard for ElementImpl::Impl::MacroExpansion::isFromMacroExpansion/1#69965d18@f39b84ka was evaluated in 205 iterations totaling 138ms (delta sizes total: 1254645).
        4675568  ~0%    {1} r1 = JOIN `ElementImpl::Impl::MacroExpansion::isFromMacroExpansion/1#69965d18#prev_delta` WITH `ElementImpl::Impl::MacroExpansion::getImmediatelyEnclosingMacroInvocation/1#1eb32ecc_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1
        4672186  ~0%    {1}    | JOIN WITH AstNodeImpl::Impl::AstNode#22e758cf ON FIRST 1 OUTPUT Lhs.0
        1254645  ~0%    {1}    | AND NOT `ElementImpl::Impl::MacroExpansion::isFromMacroExpansion/1#69965d18#prev`(FIRST 1)
                        return r1
```

[DCA](https://github.com/github/codeql-dca-main/issues/32901) looks good.