### PR TITLE
Rust: Fix bad join

### DIFF
--- a/rust/ql/lib/codeql/rust/internal/TypeMention.qll
+++ b/rust/ql/lib/codeql/rust/internal/TypeMention.qll
@@ -207,6 +207,11 @@ class NonAliasPathTypeMention extends PathTypeMention {
     )
   }
 
+  pragma[nomagic]
+  private TypeAlias getResolvedAlias(string name) {
+    result = resolved.(TraitItemNode).getAssocItem(name)
+  }
+
   /** Gets the type mention in this path for the type parameter `tp`, if any. */
   pragma[nomagic]
   private TypeMention getTypeMentionForTypeParameter(TypeParameter tp) {
@@ -228,16 +233,11 @@ class NonAliasPathTypeMention extends PathTypeMention {
     // }
     // ```
     // the rhs. of the type alias is a type argument to the trait.
-    exists(ImplItemNode impl, AssociatedTypeTypeParameter param, TypeAlias alias, string name |
+    exists(ImplItemNode impl, TypeAlias alias, string name |
       this = impl.getTraitPath() and
-      param.getTrait() = resolved and
-      name = param.getTypeAlias().getName().getText() and
       alias = impl.getASuccessor(pragma[only_bind_into](name)) and
       result = alias.getTypeRepr() and
-      tp =
-        TAssociatedTypeTypeParameter(resolved
-              .(TraitItemNode)
-              .getAssocItem(pragma[only_bind_into](name)))
+      tp = TAssociatedTypeTypeParameter(this.getResolvedAlias(pragma[only_bind_into](name)))
     )
     or
     // Handle the special syntactic sugar for function traits. For now we only


### PR DESCRIPTION
Before
```
Evaluated relational algebra for predicate TypeMention::NonAliasPathTypeMention.getTypeMentionForTypeParameter/1#f0c507c8@d7d71dnu with tuple counts:
            12496   ~2%    {3} r1 = SCAN `TypeMention::NonAliasPathTypeMention.getAnAssocTypeArgument/1#c61d1deb` OUTPUT In.2, In.0, In.1
            12421   ~0%    {3}    | JOIN WITH TypeMention::TypeMention#3ab935d1 ON FIRST 1 OUTPUT Lhs.1, Lhs.2, Lhs.0
            12421   ~0%    {3}    | JOIN WITH TypeMention::NonAliasPathTypeMention#9123dc7e ON FIRST 1 OUTPUT Lhs.1, Lhs.0, Lhs.2
            12421   ~0%    {3}    | JOIN WITH cached_Type::TAssociatedTypeTypeParameter#14a276f6 ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
            12421   ~0%    {3}    | JOIN WITH Type::TypeParameter#f85657da ON FIRST 1 OUTPUT Lhs.1, Lhs.0, Lhs.2

                1   ~0%    {2} r2 = SCAN `Stdlib::FnOnceTrait.getTypeParam/0#dispred#93f20bbc` OUTPUT In.1, In.0
                1   ~0%    {2}    | JOIN WITH cached_Type::TTypeParamTypeParameter#868c69a5 ON FIRST 1 OUTPUT Rhs.1, Lhs.1
                1   ~0%    {2}    | JOIN WITH Type::TypeParameter#f85657da ON FIRST 1 OUTPUT Lhs.1, Lhs.0
             3216   ~0%    {2}    | JOIN WITH TypeMention::NonAliasPathTypeMention#9123dc7e_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1
             3216   ~0%    {3}    | JOIN WITH `Path::Generated::Path.getSegment/0#dispred#1c7ef50f` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.0
             3201   ~0%    {3}    | JOIN WITH `PathSegment::Generated::PathSegment.getParenthesizedArgList/0#dispred#cd573956` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
             3201   ~0%    {3}    | JOIN WITH TypeMention::TypeMention#3ab935d1 ON FIRST 1 OUTPUT Lhs.2, Lhs.1, Lhs.0

                1   ~0%    {2} r3 = SCAN `Stdlib::FnOnceTrait.getOutputType/0#0d2e9ef1` OUTPUT In.1, In.0
                1   ~0%    {2}    | JOIN WITH cached_Type::TAssociatedTypeTypeParameter#14a276f6 ON FIRST 1 OUTPUT Rhs.1, Lhs.1
                1   ~0%    {2}    | JOIN WITH Type::TypeParameter#f85657da ON FIRST 1 OUTPUT Lhs.1, Lhs.0
             3216   ~3%    {2}    | JOIN WITH TypeMention::NonAliasPathTypeMention#9123dc7e_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1
             3216   ~0%    {3}    | JOIN WITH `Path::Generated::Path.getSegment/0#dispred#1c7ef50f` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.0
             2958   ~0%    {3}    | JOIN WITH `PathSegment::Generated::PathSegment.getRetType/0#dispred#9d400241` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
             2958   ~0%    {3}    | JOIN WITH `RetTypeRepr::Generated::RetTypeRepr.getTypeRepr/0#dispred#fd85a980` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
             2944   ~0%    {3}    | JOIN WITH TypeMention::TypeMention#3ab935d1 ON FIRST 1 OUTPUT Lhs.2, Lhs.1, Lhs.0

            54186   ~3%    {2} r4 = JOIN `TypeAlias::Generated::TypeAlias.getTypeRepr/0#dispred#5fd7e521_10#join_rhs` WITH TypeMention::TypeMention#3ab935d1 ON FIRST 1 OUTPUT Lhs.1, Lhs.0
          1446369  ~12%    {3}    | JOIN WITH `PathResolution::ItemNode.getASuccessor/1#8f430f71_201#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Rhs.2
            36945   ~0%    {3}    | JOIN WITH `PathResolution::ImplItemNode.getTraitPath/0#dispred#3b7d1cb6` ON FIRST 1 OUTPUT Lhs.2, Lhs.1, Rhs.1
        377232832   ~1%    {4}    | JOIN WITH `Name::Generated::Name.getText/0#dispred#107a5a39_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.0
        370815806   ~5%    {4}    | JOIN WITH `TypeAlias::Generated::TypeAlias.getName/0#dispred#bf886045_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3
          1490317   ~0%    {4}    | JOIN WITH cached_Type::TAssociatedTypeTypeParameter#14a276f6 ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3
          1490317   ~0%    {4}    | JOIN WITH `Type::AssociatedTypeTypeParameter.getTrait/0#dispred#41eb3020` ON FIRST 1 OUTPUT Lhs.2, Rhs.1, Lhs.1, Lhs.3
            36413   ~1%    {4}    | JOIN WITH TypeMention::NonAliasPathTypeMention#9123dc7e ON FIRST 2 OUTPUT Lhs.1, Lhs.3, Lhs.2, Lhs.0
            36413   ~1%    {3}    | JOIN WITH `PathResolution::ImplOrTraitItemNode.getAssocItem/1#f77bb9ed` ON FIRST 2 OUTPUT Rhs.2, Lhs.2, Lhs.3
            36413   ~0%    {3}    | JOIN WITH cached_Type::TAssociatedTypeTypeParameter#14a276f6 ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
            36413   ~0%    {3}    | JOIN WITH Type::TypeParameter#f85657da ON FIRST 1 OUTPUT Lhs.2, Lhs.0, Lhs.1

            54979   ~3%    {3} r5 = r1 UNION r2 UNION r3 UNION r4
                           return r5
```

After
```
Evaluated relational algebra for predicate TypeMention::NonAliasPathTypeMention.getTypeMentionForTypeParameter/1#f0c507c8@a37ac19m with tuple counts:
          12496   ~2%    {3} r1 = SCAN `TypeMention::NonAliasPathTypeMention.getAnAssocTypeArgument/1#c61d1deb` OUTPUT In.2, In.0, In.1
          12421   ~0%    {3}    | JOIN WITH TypeMention::TypeMention#3ab935d1 ON FIRST 1 OUTPUT Lhs.1, Lhs.2, Lhs.0
          12421   ~0%    {3}    | JOIN WITH TypeMention::NonAliasPathTypeMention#9123dc7e ON FIRST 1 OUTPUT Lhs.1, Lhs.0, Lhs.2
          12421   ~0%    {3}    | JOIN WITH Type::TAssociatedTypeTypeParameter#14a276f6 ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
          12421   ~0%    {3}    | JOIN WITH Type::TypeParameter#f85657da ON FIRST 1 OUTPUT Lhs.1, Lhs.0, Lhs.2

              1   ~0%    {2} r2 = SCAN `Stdlib::FnOnceTrait.getTypeParam/0#dispred#93f20bbc` OUTPUT In.1, In.0
              1   ~0%    {2}    | JOIN WITH Type::TTypeParamTypeParameter#868c69a5 ON FIRST 1 OUTPUT Rhs.1, Lhs.1
              1   ~0%    {2}    | JOIN WITH Type::TypeParameter#f85657da ON FIRST 1 OUTPUT Lhs.1, Lhs.0
           3216   ~0%    {2}    | JOIN WITH TypeMention::NonAliasPathTypeMention#9123dc7e_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1
           3216   ~0%    {3}    | JOIN WITH `Path::Generated::Path.getSegment/0#dispred#1c7ef50f` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.0
           3201   ~0%    {3}    | JOIN WITH `PathSegment::Generated::PathSegment.getParenthesizedArgList/0#dispred#cd573956` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
           3201   ~0%    {3}    | JOIN WITH TypeMention::TypeMention#3ab935d1 ON FIRST 1 OUTPUT Lhs.2, Lhs.1, Lhs.0

              1   ~0%    {2} r3 = SCAN `Stdlib::FnOnceTrait.getOutputType/0#0d2e9ef1` OUTPUT In.1, In.0
              1   ~0%    {2}    | JOIN WITH Type::TAssociatedTypeTypeParameter#14a276f6 ON FIRST 1 OUTPUT Rhs.1, Lhs.1
              1   ~0%    {2}    | JOIN WITH Type::TypeParameter#f85657da ON FIRST 1 OUTPUT Lhs.1, Lhs.0
           3216   ~3%    {2}    | JOIN WITH TypeMention::NonAliasPathTypeMention#9123dc7e_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1
           3216   ~0%    {3}    | JOIN WITH `Path::Generated::Path.getSegment/0#dispred#1c7ef50f` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.0
           2958   ~0%    {3}    | JOIN WITH `PathSegment::Generated::PathSegment.getRetType/0#dispred#9d400241` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
           2958   ~0%    {3}    | JOIN WITH `RetTypeRepr::Generated::RetTypeRepr.getTypeRepr/0#dispred#fd85a980` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
           2944   ~0%    {3}    | JOIN WITH TypeMention::TypeMention#3ab935d1 ON FIRST 1 OUTPUT Lhs.2, Lhs.1, Lhs.0

          54186   ~3%    {2} r4 = JOIN `TypeAlias::Generated::TypeAlias.getTypeRepr/0#dispred#5fd7e521_10#join_rhs` WITH TypeMention::TypeMention#3ab935d1 ON FIRST 1 OUTPUT Lhs.1, Lhs.0
        1446369  ~12%    {3}    | JOIN WITH `PathResolution::ItemNode.getASuccessor/1#8f430f71_201#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Rhs.2
          36945   ~2%    {3}    | JOIN WITH `PathResolution::ImplItemNode.getTraitPath/0#dispred#3b7d1cb6` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
          36398   ~3%    {3}    | JOIN WITH TypeMention::NonAliasPathTypeMention#9123dc7e ON FIRST 1 OUTPUT Lhs.0, Lhs.2, Lhs.1
          36413   ~1%    {3}    | JOIN WITH `TypeMention::NonAliasPathTypeMention.getResolvedAlias/1#c48b878e` ON FIRST 2 OUTPUT Rhs.2, Lhs.2, Lhs.0
          36413   ~0%    {3}    | JOIN WITH Type::TAssociatedTypeTypeParameter#14a276f6 ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
          36413   ~0%    {3}    | JOIN WITH Type::TypeParameter#f85657da ON FIRST 1 OUTPUT Lhs.2, Lhs.0, Lhs.1

          54979   ~3%    {3} r5 = r1 UNION r2 UNION r3 UNION r4
                         return r5
```