### PR TITLE
Go: fix dataset check errors

### DIFF
--- a/go/extractor/extractor.go
+++ b/go/extractor/extractor.go
@@ -815,12 +815,12 @@ func (extraction *Extraction) extractFileInfo(tw *trap.Writer, file string, isDu
 			displayPath = rawPath
 		}
 		if i == len(components)-1 {
-			lbl := tw.Labeler.FileLabelFor(path)
+			lbl := tw.Labeler.FileLabelFor(file)
 			dbscheme.FilesTable.Emit(tw, lbl, displayPath)
 			dbscheme.ContainerParentTable.Emit(tw, parentLbl, lbl)
 			dbscheme.HasLocationTable.Emit(tw, lbl, emitLocation(tw, lbl, 0, 0, 0, 0))
 			extraction.Lock.Lock()
-			slbl := extraction.StatWriter.Labeler.FileLabelFor(path)
+			slbl := extraction.StatWriter.Labeler.FileLabelFor(file)
 			if !isDummy {
 				dbscheme.CompilationCompilingFilesTable.Emit(extraction.StatWriter, extraction.Label, extraction.GetFileIdx(file), slbl)
 			}

--- a/go/extractor/trap/labels.go
+++ b/go/extractor/trap/labels.go
@@ -69,14 +69,14 @@ func (l *Labeler) GlobalID(key string) Label {
 // FileLabel returns the label for a file with path `path`.
 func (l *Labeler) FileLabel() Label {
 	if l.fileLabel == InvalidLabel {
-		l.fileLabel = l.FileLabelFor(srcarchive.TransformPath(l.tw.path))
+		l.fileLabel = l.FileLabelFor(l.tw.path)
 	}
 	return l.fileLabel
 }
 
 // FileLabelFor returns the label for the file for which the trap writer `tw` is associated
 func (l *Labeler) FileLabelFor(path string) Label {
-	return l.GlobalID(util.EscapeTrapSpecialChars(filepath.ToSlash(path)) + ";sourcefile")
+	return l.GlobalID(util.EscapeTrapSpecialChars(filepath.ToSlash(srcarchive.TransformPath(path))) + ";sourcefile")
 }
 
 // LocalID associates a label with the given AST node `nd` and returns it


### PR DESCRIPTION
These errors were accidentally introduced in https://github.com/github/codeql/pull/20623 . We can't reproduce them locally and we don't know why. The cause seems to be that the path transformer isn't used in one place where a label for a file is used. I have moved the use of the path transformer into the function that makes file labels so we don't have to remember to transform it at all call sites.

Note: this is mostly a reversion of [this commit](https://github.com/github/codeql/pull/20623/commits/dd4f27868e7f5ba51d7b5694c93bf1962d8f9507) from that PR, and then a different way of achieving the same thing. It would have been better if I'd done an explicit revert commit and then put the `TransformPath` call in a different place. But I don't want to change it now, since then it's not totally clear that the DCA run is for the code that will be merged.