### PR TITLE
C++: Add `nomagic` to `Function::getParameter`

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/Function.qll
+++ b/cpp/ql/lib/semmle/code/cpp/Function.qll
@@ -171,12 +171,14 @@ class Function extends Declaration, ControlFlowNode, AccessHolder, @function {
    * Gets the nth parameter of this function. There is no result for the
    * implicit `this` parameter, and there is no `...` varargs pseudo-parameter.
    */
+  pragma[nomagic]
   Parameter getParameter(int n) { params(unresolveElement(result), underlyingElement(this), n, _) }
 
   /**
    * Gets a parameter of this function. There is no result for the implicit
    * `this` parameter, and there is no `...` varargs pseudo-parameter.
    */
+  pragma[nomagic]
   Parameter getAParameter() { params(unresolveElement(result), underlyingElement(this), _, _) }
 
   /**


### PR DESCRIPTION
Magic was giving us the dreaded join-on-index in `Function::getParameter`. Sadly, the person who was getting this issue didn't save an evaluator log for me, but they did manage to share this very useful screenshot 😅

<img width="1348" height="224" alt="image (6)" src="https://github.com/user-attachments/assets/6d2b32f4-3127-443c-a0db-11cd95b06b11" />