### PR TITLE
Java: Propagate taint through field reads

### DIFF
--- a/java/ql/lib/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
@@ -141,6 +141,8 @@ private module Cached {
       (
         containerContent(f)
         or
+        f instanceof DataFlow::FieldContent
+        or
         f instanceof TaintInheritingContent
       )
     )


### PR DESCRIPTION
Currently Go and Javascript have this behaviour without any problems, but we have to check that it doesn't lead to FPs (or at least that they're balanced out by enough TPs) or any performance problems.