### PR TITLE
Java: add missing QLDoc

### DIFF
--- a/java/ql/lib/semmle/code/java/dataflow/internal/rangeanalysis/BoundSpecific.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/rangeanalysis/BoundSpecific.qll
@@ -9,6 +9,7 @@ private import semmle.code.java.dataflow.SSA as Ssa
 private import semmle.code.java.dataflow.RangeUtils as RU
 
 class SsaVariable extends Ssa::SsaDefinition {
+  /** Gets a use of this variable. */
   Expr getAUse() { result = super.getARead() }
 }
 


### PR DESCRIPTION
The check for QLDoc comments was unfortunately broken for some time, so we missed this.