### PR TITLE
Shared: Make UniversalFlow overlay-aware.

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/TypeFlow.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/TypeFlow.qll
@@ -206,6 +206,9 @@ private module Input implements TypeFlowInput<Location> {
 
   predicate isNullValue(TypeFlowNode n) { n.isNullValue() }
 
+  overlay[local]
+  predicate isEvaluatingInOverlay() { none() }
+
   private newtype TType =
     TSingle() or
     TBuffer()

--- a/java/ql/lib/semmle/code/java/dataflow/TypeFlow.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/TypeFlow.qll
@@ -25,6 +25,7 @@ private RefType boxIfNeeded(J::Type t) {
 
 /** Provides the input types and predicates for instantiation of `UniversalFlow`. */
 module FlowStepsInput implements UniversalFlow::UniversalFlowInput<Location> {
+  overlay[local]
   private newtype TFlowNode =
     TField(Field f) { not f.getType() instanceof PrimitiveType } or
     TSsa(Base::SsaDefinition ssa) { not ssa.getSourceVariable().getType() instanceof PrimitiveType } or
@@ -34,6 +35,7 @@ module FlowStepsInput implements UniversalFlow::UniversalFlowInput<Location> {
   /**
    * A `Field`, `BaseSsaVariable`, `Expr`, or `Method`.
    */
+  overlay[local]
   class FlowNode extends TFlowNode {
     /** Gets a textual representation of this element. */
     string toString() {
@@ -158,6 +160,11 @@ module FlowStepsInput implements UniversalFlow::UniversalFlowInput<Location> {
     // reflection and are thus not always null.
     exists(n.asField())
   }
+
+  private import semmle.code.java.Overlay as Overlay
+
+  overlay[local]
+  predicate isEvaluatingInOverlay() { Overlay::isOverlay() }
 }
 
 private module Input implements TypeFlowInput<Location> {

--- a/shared/typeflow/codeql/typeflow/TypeFlow.qll
+++ b/shared/typeflow/codeql/typeflow/TypeFlow.qll
@@ -45,6 +45,18 @@ signature module TypeFlowInput<LocationSig Location> {
    */
   default predicate isExcludedFromNullAnalysis(TypeFlowNode n) { none() }
 
+  /**
+   * Holds if the evaluator is currently evaluating with an overlay. The
+   * implementation of this predicate needs to be `overlay[local]`. For a
+   * language with no overlay support, `none()` is a valid implementation.
+   *
+   * When called from a local predicate, this predicate holds if we are in the
+   * overlay-only local evaluation. When called from a global predicate, this
+   * predicate holds if we are evaluating globally with overlay and base both
+   * visible.
+   */
+  predicate isEvaluatingInOverlay();
+
   /** A type. */
   class Type {
     /** Gets a textual representation of this type. */

--- a/shared/typeflow/codeql/typeflow/internal/TypeFlowImpl.qll
+++ b/shared/typeflow/codeql/typeflow/internal/TypeFlowImpl.qll
@@ -17,6 +17,8 @@ module TypeFlow<LocationSig Location, TypeFlowInput<Location> I> {
     predicate isNullValue = I::isNullValue/1;
 
     predicate isExcludedFromNullAnalysis = I::isExcludedFromNullAnalysis/1;
+
+    predicate isEvaluatingInOverlay = I::isEvaluatingInOverlay/0;
   }
 
   private module UnivFlow = UniversalFlow::Make<Location, UfInput>;


### PR DESCRIPTION
This updates the UniversalFlow library to be overlay-aware. Since the output is semantically local, the library can restrict the global computation to target the overlay and thereby become much more incremental in nature. The local output is tagged `overlay[local?]` in order to also support C++, for which the node type is global and hence cannot currently use incremental computation. So only Java gets the incremental computation for now.