### PR TITLE
JS: Split module exports into a local and global variant

### DIFF
--- a/javascript/ql/lib/semmle/javascript/ES2015Modules.qll
+++ b/javascript/ql/lib/semmle/javascript/ES2015Modules.qll
@@ -782,7 +782,7 @@ abstract class ReExportDeclaration extends ExportDeclaration {
   }
 
   /**
-   * Holds if this re-export destination ultimately re-exports `v` (from another module)
+   * Holds if this re-export declaration ultimately re-exports `v` (from another module)
    * under the given `name`.
    */
   overlay[global]


### PR DESCRIPTION
`ExportDeclaration.getSourceNode` and `.exportsAs` were global because they look through re-exports.

This PR splits these into a "direct" version that is local and ignores re-exports, and a non-direct version that is global and looks through re-exports.

One of the use-cases for the direct version is for API graphs to make a local over-approximation of the set of def-nodes we need, so that `API::Node` can become local.