### PR TITLE
Rust: Add placeholder declarations for `&mut` and `*mut`

### DIFF
--- a/rust/ql/test/library-tests/elements/builtintypes/BuiltinTypes.expected
+++ b/rust/ql/test/library-tests/elements/builtintypes/BuiltinTypes.expected
@@ -1,6 +1,8 @@
 | struct Array |  |
 | struct Ptr |  |
+| struct PtrMut |  |
 | struct Ref |  |
+| struct RefMut |  |
 | struct Slice |  |
 | struct Tuple0 |  |
 | struct Tuple1 |  |

--- a/rust/tools/builtins/types.rs
+++ b/rust/tools/builtins/types.rs
@@ -26,8 +26,10 @@ pub struct f64;
 
 struct Slice<TSlice>;
 struct Array<TArray, const N: usize>;
-struct Ref<TRef>; // todo: add mut variant
-struct Ptr<TPtr>; // todo: add mut variant
+struct Ref<TRef>;
+struct RefMut<TRefMut>;
+struct Ptr<TPtr>;
+struct PtrMut<TPtrMut>;
 
 // tuples
 struct Tuple0;


### PR DESCRIPTION
Adding these declarations now mean we will already have DBs with those entities available once we implement support for distinguishing `mut`/`const` types.