### PR TITLE
Rust: Fix a few comments.

### DIFF
--- a/rust/ql/lib/codeql/rust/security/LogInjectionExtensions.qll
+++ b/rust/ql/lib/codeql/rust/security/LogInjectionExtensions.qll
@@ -46,7 +46,7 @@ module LogInjection {
 
   /**
    * A barrier for log injection vulnerabilities for nodes whose type is a
-   * numeric or boolean type, which is unlikely to expose any vulnerability.
+   * numeric type, which is unlikely to expose any vulnerability.
    */
   private class NumericTypeBarrier extends Barrier instanceof Barriers::NumericTypeBarrier { }
 

--- a/rust/ql/lib/codeql/rust/security/SqlInjectionExtensions.qll
+++ b/rust/ql/lib/codeql/rust/security/SqlInjectionExtensions.qll
@@ -60,8 +60,8 @@ module SqlInjection {
   }
 
   /**
-   * A barrier for SQL injection vulnerabilities for nodes whose type is a numeric or
-   * boolean type, which is unlikely to expose any vulnerability.
+   * A barrier for SQL injection vulnerabilities for nodes whose type is a numeric
+   * type, which is unlikely to expose any vulnerability.
    */
   private class NumericTypeBarrier extends Barrier instanceof Barriers::NumericTypeBarrier { }
 

--- a/rust/ql/lib/codeql/rust/security/regex/RegexInjectionExtensions.qll
+++ b/rust/ql/lib/codeql/rust/security/regex/RegexInjectionExtensions.qll
@@ -89,7 +89,7 @@ module RegexInjection {
 
   /**
    * A barrier for regular expression injection vulnerabilities for nodes whose
-   * type is an integral or boolean type, which is unlikely to expose any vulnerability.
+   * type is an integral type, which is unlikely to expose any vulnerability.
    *
    * We don't include floating point types in this barrier, as `.` is a special character
    * in regular expressions.


### PR DESCRIPTION
Quick fix for documentation being out of sync following https://github.com/github/codeql/pull/20921 .

We _could_ comment the other barrier uses, but to be honest I think the intent is very obvious.

@paldepind