### PR TITLE
Go: Reinstate dummy test so consistency tests are run

### DIFF
--- a/go/ql/test/consistency/dummy.expected
+++ b/go/ql/test/consistency/dummy.expected
@@ -1,0 +1,1 @@
+| This is a dummy query which is only needed so that the consistency tests will run |

--- a/go/ql/test/consistency/dummy.ql
+++ b/go/ql/test/consistency/dummy.ql
@@ -1,0 +1,1 @@
+select "This is a dummy query which is only needed so that the consistency tests will run"


### PR DESCRIPTION
This reverts commit 38cb6e5a006c5bd9bf4e1758a607e6af5d385d5a.

This is needed so that the consistency checks are run on `go/ql/test/consistency/`, otherwise we don't check that `go/ql/test/consistency/CONSISTENCY/UnexpectedFrontendErrors.expected` is correct.