### PR TITLE
C/C++ overlay: Add multiloc declaration to Overlay.qll

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/internal/Overlay.qll
+++ b/cpp/ql/lib/semmle/code/cpp/internal/Overlay.qll
@@ -28,6 +28,10 @@ private string getSingleLocationFilePath(@element e) {
     type_decls(e, _, loc)
     or
     namespace_decls(e, _, loc, _)
+    or
+    macroinvocations(e, _, loc, _)
+    or
+    preprocdirects(e, _, loc)
   |
     result = getLocationFilePath(loc)
   )


### PR DESCRIPTION
This PR extends the C++ overlay discard predicates in `Overlay.qll` to handle multi-location entities correctly.