### PR TITLE
C#: Connect shared Guards to SSA BarrierGuards.

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/SsaImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/SsaImpl.qll
@@ -967,18 +967,22 @@ private module Cached {
 
     cached // nothing is actually cached
     module BarrierGuard<guardChecksSig/3 guardChecks> {
-      private predicate guardChecksAdjTypes(
-        DataFlowIntegrationInput::Guard g, DataFlowIntegrationInput::Expr e,
-        DataFlowIntegrationInput::GuardValue branch
+      private import codeql.util.Unit
+
+      private predicate guardChecksAdjTypes(Guards::Guards::Guard g, Expr e, Guards::GuardValue v) {
+        guardChecks(g, e, v)
+      }
+
+      private predicate guardChecksWithWrappers(
+        Guards::Guard g, Definition def, Guards::GuardValue val, Unit state
       ) {
-        exists(Guards::GuardValue v |
-          guardChecks(g, e.getAstNode(), v) and
-          branch = v.asBooleanValue()
-        )
+        Guards::Guards::ValidationWrapper<guardChecksAdjTypes/3>::guardChecksDef(g, def, val) and
+        exists(state)
       }
 
       private Node getABarrierNodeImpl() {
-        result = DataFlowIntegrationImpl::BarrierGuard<guardChecksAdjTypes/3>::getABarrierNode()
+        result =
+          DataFlowIntegrationImpl::BarrierGuardDefWithState<Unit, guardChecksWithWrappers/4>::getABarrierNode(_)
       }
 
       predicate getABarrierNode = getABarrierNodeImpl/0;
@@ -1037,38 +1041,18 @@ private module DataFlowIntegrationInput implements Impl::DataFlowIntegrationInpu
       )
   }
 
-  class GuardValue = Boolean;
+  class GuardValue = Guards::GuardValue;
 
-  class Guard extends Guards::Guard {
-    /**
-     * Holds if the evaluation of this guard to `branch` corresponds to the edge
-     * from `bb1` to `bb2`.
-     */
-    predicate hasValueBranchEdge(BasicBlock bb1, BasicBlock bb2, GuardValue branch) {
-      exists(ControlFlow::ConditionalSuccessor s |
-        this.getAControlFlowNode() = bb1.getLastNode() and
-        bb2 = bb1.getASuccessor(s) and
-        s.getValue() = branch
-      )
-    }
+  class Guard = Guards::Guard;
 
-    /**
-     * Holds if this guard evaluating to `branch` controls the control-flow
-     * branch edge from `bb1` to `bb2`. That is, following the edge from
-     * `bb1` to `bb2` implies that this guard evaluated to `branch`.
-     */
-    predicate valueControlsBranchEdge(BasicBlock bb1, BasicBlock bb2, GuardValue branch) {
-      this.hasValueBranchEdge(bb1, bb2, branch)
-    }
+  /** Holds if the guard `guard` directly controls block `bb` upon evaluating to `val`. */
+  predicate guardDirectlyControlsBlock(Guard guard, BasicBlock bb, GuardValue val) {
+    guard.directlyValueControls(bb, val)
   }
 
-  /** Holds if the guard `guard` controls block `bb` upon evaluating to `branch`. */
-  predicate guardDirectlyControlsBlock(Guard guard, ControlFlow::BasicBlock bb, GuardValue branch) {
-    exists(ConditionBlock conditionBlock, ControlFlow::ConditionalSuccessor s |
-      guard.getAControlFlowNode() = conditionBlock.getLastNode() and
-      s.getValue() = branch and
-      conditionBlock.edgeDominates(bb, s)
-    )
+  /** Holds if the guard `guard` controls block `bb` upon evaluating to `val`. */
+  predicate guardControlsBlock(Guard guard, BasicBlock bb, GuardValue val) {
+    guard.valueControls(bb, val)
   }
 }
 


### PR DESCRIPTION
This adds support for guard wrappers and BarrierGuards that test on GuardValues instead of just booleans.