### PR TITLE
Rust: Add models for `core::cmp::Ord::{min,max,clamp}`

### DIFF
--- a/rust/ql/lib/codeql/rust/frameworks/stdlib/core.model.yml
+++ b/rust/ql/lib/codeql/rust/frameworks/stdlib/core.model.yml
@@ -116,6 +116,10 @@ extensions:
       - ["<core::str>::parse", "Argument[self]", "ReturnValue.Field[core::result::Result::Ok(0)]", "taint", "manual"]
       - ["<core::str>::trim", "Argument[self]", "ReturnValue.Reference", "taint", "manual"]
       - ["<core::str>::to_string", "Argument[self]", "ReturnValue", "taint", "manual"]
+      # Ord
+      - ["<_ as core::cmp::Ord>::min", "Argument[self,0]", "ReturnValue", "value", "manual"]
+      - ["<_ as core::cmp::Ord>::max", "Argument[self,0]", "ReturnValue", "value", "manual"]
+      - ["<_ as core::cmp::Ord>::clamp", "Argument[self,0,1]", "ReturnValue", "value", "manual"]
   - addsTo:
       pack: codeql/rust-all
       extensible: sourceModel

--- a/rust/ql/test/library-tests/dataflow/global/CONSISTENCY/PathResolutionConsistency.expected
+++ b/rust/ql/test/library-tests/dataflow/global/CONSISTENCY/PathResolutionConsistency.expected
@@ -1,3 +1,3 @@
 multipleResolvedTargets
-| main.rs:236:11:236:15 | * ... |
-| main.rs:272:13:272:29 | * ... |
+| main.rs:252:11:252:15 | * ... |
+| main.rs:288:13:288:29 | * ... |

--- a/rust/ql/test/library-tests/dataflow/global/inline-flow.expected
+++ b/rust/ql/test/library-tests/dataflow/global/inline-flow.expected
@@ -49,176 +49,176 @@ edges
 | main.rs:86:26:86:26 | a | main.rs:82:21:82:26 | ...: i64 | provenance |  |
 | main.rs:86:26:86:26 | a | main.rs:86:13:86:27 | pass_through(...) | provenance |  |
 | main.rs:104:22:104:27 | ...: i64 | main.rs:105:14:105:14 | n | provenance |  |
-| main.rs:108:30:110:5 | { ... } | main.rs:138:13:138:25 | mn.get_data() | provenance |  |
-| main.rs:109:35:109:43 | source(...) | main.rs:108:30:110:5 | { ... } | provenance |  |
-| main.rs:112:27:112:32 | ...: i64 | main.rs:112:42:114:5 | { ... } | provenance |  |
-| main.rs:118:28:118:33 | ...: i64 | main.rs:119:14:119:14 | n | provenance |  |
-| main.rs:122:36:124:5 | { ... } | main.rs:132:13:132:30 | x.get_data_trait() | provenance |  |
-| main.rs:122:36:124:5 | { ... } | main.rs:142:13:142:31 | mn.get_data_trait() | provenance |  |
-| main.rs:123:35:123:44 | source(...) | main.rs:122:36:124:5 | { ... } | provenance |  |
-| main.rs:126:33:126:38 | ...: i64 | main.rs:126:48:128:5 | { ... } | provenance |  |
-| main.rs:132:9:132:9 | a | main.rs:133:10:133:10 | a | provenance |  |
-| main.rs:132:13:132:30 | x.get_data_trait() | main.rs:132:9:132:9 | a | provenance |  |
-| main.rs:138:9:138:9 | a | main.rs:139:10:139:10 | a | provenance |  |
-| main.rs:138:13:138:25 | mn.get_data() | main.rs:138:9:138:9 | a | provenance |  |
-| main.rs:142:9:142:9 | a | main.rs:143:10:143:10 | a | provenance |  |
-| main.rs:142:13:142:31 | mn.get_data_trait() | main.rs:142:9:142:9 | a | provenance |  |
-| main.rs:149:9:149:9 | a | main.rs:150:21:150:21 | a | provenance |  |
-| main.rs:149:13:149:22 | source(...) | main.rs:149:9:149:9 | a | provenance |  |
-| main.rs:150:21:150:21 | a | main.rs:118:28:118:33 | ...: i64 | provenance |  |
-| main.rs:155:9:155:9 | a | main.rs:156:16:156:16 | a | provenance |  |
-| main.rs:155:13:155:21 | source(...) | main.rs:155:9:155:9 | a | provenance |  |
-| main.rs:156:16:156:16 | a | main.rs:104:22:104:27 | ...: i64 | provenance |  |
-| main.rs:159:9:159:9 | a | main.rs:160:22:160:22 | a | provenance |  |
-| main.rs:159:13:159:22 | source(...) | main.rs:159:9:159:9 | a | provenance |  |
-| main.rs:160:22:160:22 | a | main.rs:118:28:118:33 | ...: i64 | provenance |  |
-| main.rs:166:9:166:9 | a | main.rs:167:34:167:34 | a | provenance |  |
-| main.rs:166:13:166:22 | source(...) | main.rs:166:9:166:9 | a | provenance |  |
-| main.rs:167:9:167:9 | b | main.rs:168:10:168:10 | b | provenance |  |
-| main.rs:167:13:167:35 | x.data_through_trait(...) | main.rs:167:9:167:9 | b | provenance |  |
-| main.rs:167:34:167:34 | a | main.rs:126:33:126:38 | ...: i64 | provenance |  |
-| main.rs:167:34:167:34 | a | main.rs:167:13:167:35 | x.data_through_trait(...) | provenance |  |
-| main.rs:173:9:173:9 | a | main.rs:174:29:174:29 | a | provenance |  |
-| main.rs:173:13:173:21 | source(...) | main.rs:173:9:173:9 | a | provenance |  |
-| main.rs:174:9:174:9 | b | main.rs:175:10:175:10 | b | provenance |  |
-| main.rs:174:13:174:30 | mn.data_through(...) | main.rs:174:9:174:9 | b | provenance |  |
-| main.rs:174:29:174:29 | a | main.rs:112:27:112:32 | ...: i64 | provenance |  |
-| main.rs:174:29:174:29 | a | main.rs:174:13:174:30 | mn.data_through(...) | provenance |  |
-| main.rs:178:9:178:9 | a | main.rs:179:35:179:35 | a | provenance |  |
-| main.rs:178:13:178:22 | source(...) | main.rs:178:9:178:9 | a | provenance |  |
-| main.rs:179:9:179:9 | b | main.rs:180:10:180:10 | b | provenance |  |
-| main.rs:179:13:179:36 | mn.data_through_trait(...) | main.rs:179:9:179:9 | b | provenance |  |
-| main.rs:179:35:179:35 | a | main.rs:126:33:126:38 | ...: i64 | provenance |  |
-| main.rs:179:35:179:35 | a | main.rs:179:13:179:36 | mn.data_through_trait(...) | provenance |  |
-| main.rs:187:9:187:9 | a | main.rs:188:25:188:25 | a | provenance |  |
-| main.rs:187:13:187:21 | source(...) | main.rs:187:9:187:9 | a | provenance |  |
-| main.rs:188:25:188:25 | a | main.rs:104:22:104:27 | ...: i64 | provenance |  |
-| main.rs:193:9:193:9 | a | main.rs:194:38:194:38 | a | provenance |  |
-| main.rs:193:13:193:22 | source(...) | main.rs:193:9:193:9 | a | provenance |  |
-| main.rs:194:9:194:9 | b | main.rs:195:10:195:10 | b | provenance |  |
-| main.rs:194:13:194:39 | ...::data_through(...) | main.rs:194:9:194:9 | b | provenance |  |
-| main.rs:194:38:194:38 | a | main.rs:112:27:112:32 | ...: i64 | provenance |  |
-| main.rs:194:38:194:38 | a | main.rs:194:13:194:39 | ...::data_through(...) | provenance |  |
-| main.rs:206:12:206:17 | ...: i64 | main.rs:207:24:207:24 | n | provenance |  |
-| main.rs:207:9:207:26 | MyInt {...} [MyInt] | main.rs:206:28:208:5 | { ... } [MyInt] | provenance |  |
-| main.rs:207:24:207:24 | n | main.rs:207:9:207:26 | MyInt {...} [MyInt] | provenance |  |
-| main.rs:212:9:212:9 | n [MyInt] | main.rs:213:9:213:26 | MyInt {...} [MyInt] | provenance |  |
-| main.rs:212:13:212:34 | ...::new(...) [MyInt] | main.rs:212:9:212:9 | n [MyInt] | provenance |  |
-| main.rs:212:24:212:33 | source(...) | main.rs:206:12:206:17 | ...: i64 | provenance |  |
-| main.rs:212:24:212:33 | source(...) | main.rs:212:13:212:34 | ...::new(...) [MyInt] | provenance |  |
-| main.rs:213:9:213:26 | MyInt {...} [MyInt] | main.rs:213:24:213:24 | m | provenance |  |
-| main.rs:213:24:213:24 | m | main.rs:214:10:214:10 | m | provenance |  |
-| main.rs:220:12:220:15 | SelfParam [MyInt] | main.rs:222:24:222:27 | self [MyInt] | provenance |  |
-| main.rs:222:9:222:35 | MyInt {...} [MyInt] | main.rs:220:42:223:5 | { ... } [MyInt] | provenance |  |
-| main.rs:222:24:222:27 | self [MyInt] | main.rs:222:24:222:33 | self.value | provenance |  |
-| main.rs:222:24:222:33 | self.value | main.rs:222:9:222:35 | MyInt {...} [MyInt] | provenance |  |
-| main.rs:227:30:227:39 | ...: MyInt [MyInt] | main.rs:228:22:228:24 | rhs [MyInt] | provenance |  |
-| main.rs:228:9:228:12 | [post] self [&ref, MyInt] | main.rs:227:19:227:27 | SelfParam [Return] [&ref, MyInt] | provenance |  |
-| main.rs:228:22:228:24 | rhs [MyInt] | main.rs:228:22:228:30 | rhs.value | provenance |  |
-| main.rs:228:22:228:30 | rhs.value | main.rs:228:9:228:12 | [post] self [&ref, MyInt] | provenance |  |
-| main.rs:235:14:235:18 | SelfParam [&ref, MyInt] | main.rs:236:12:236:15 | self [&ref, MyInt] | provenance |  |
-| main.rs:236:9:236:22 | &... [&ref] | main.rs:235:38:237:5 | { ... } [&ref] | provenance |  |
-| main.rs:236:10:236:22 | ... .value | main.rs:236:9:236:22 | &... [&ref] | provenance |  |
-| main.rs:236:11:236:15 | * ... [MyInt] | main.rs:236:10:236:22 | ... .value | provenance |  |
-| main.rs:236:12:236:15 | self [&ref, MyInt] | main.rs:236:11:236:15 | * ... [MyInt] | provenance | MaD:1 |
-| main.rs:242:9:242:9 | a [MyInt] | main.rs:244:13:244:13 | a [MyInt] | provenance |  |
-| main.rs:242:13:242:38 | MyInt {...} [MyInt] | main.rs:242:9:242:9 | a [MyInt] | provenance |  |
-| main.rs:242:28:242:36 | source(...) | main.rs:242:13:242:38 | MyInt {...} [MyInt] | provenance |  |
-| main.rs:244:9:244:9 | c [MyInt] | main.rs:245:10:245:10 | c [MyInt] | provenance |  |
-| main.rs:244:13:244:13 | a [MyInt] | main.rs:220:12:220:15 | SelfParam [MyInt] | provenance |  |
-| main.rs:244:13:244:13 | a [MyInt] | main.rs:244:13:244:17 | ... + ... [MyInt] | provenance |  |
-| main.rs:244:13:244:17 | ... + ... [MyInt] | main.rs:244:9:244:9 | c [MyInt] | provenance |  |
-| main.rs:245:10:245:10 | c [MyInt] | main.rs:245:10:245:16 | c.value | provenance |  |
-| main.rs:252:9:252:9 | a [MyInt] | main.rs:254:13:254:13 | a [MyInt] | provenance |  |
-| main.rs:252:13:252:38 | MyInt {...} [MyInt] | main.rs:252:9:252:9 | a [MyInt] | provenance |  |
-| main.rs:252:28:252:36 | source(...) | main.rs:252:13:252:38 | MyInt {...} [MyInt] | provenance |  |
-| main.rs:254:9:254:9 | d [MyInt] | main.rs:255:10:255:10 | d [MyInt] | provenance |  |
-| main.rs:254:13:254:13 | a [MyInt] | main.rs:220:12:220:15 | SelfParam [MyInt] | provenance |  |
-| main.rs:254:13:254:13 | a [MyInt] | main.rs:254:13:254:20 | a.add(...) [MyInt] | provenance |  |
-| main.rs:254:13:254:20 | a.add(...) [MyInt] | main.rs:254:9:254:9 | d [MyInt] | provenance |  |
-| main.rs:255:10:255:10 | d [MyInt] | main.rs:255:10:255:16 | d.value | provenance |  |
-| main.rs:259:9:259:9 | b [MyInt] | main.rs:261:35:261:35 | b [MyInt] | provenance |  |
-| main.rs:259:13:259:39 | MyInt {...} [MyInt] | main.rs:259:9:259:9 | b [MyInt] | provenance |  |
-| main.rs:259:28:259:37 | source(...) | main.rs:259:13:259:39 | MyInt {...} [MyInt] | provenance |  |
-| main.rs:261:27:261:32 | [post] &mut a [&ref, MyInt] | main.rs:261:32:261:32 | [post] a [MyInt] | provenance |  |
-| main.rs:261:32:261:32 | [post] a [MyInt] | main.rs:262:10:262:10 | a [MyInt] | provenance |  |
-| main.rs:261:35:261:35 | b [MyInt] | main.rs:227:30:227:39 | ...: MyInt [MyInt] | provenance |  |
-| main.rs:261:35:261:35 | b [MyInt] | main.rs:261:27:261:32 | [post] &mut a [&ref, MyInt] | provenance |  |
-| main.rs:262:10:262:10 | a [MyInt] | main.rs:262:10:262:16 | a.value | provenance |  |
-| main.rs:265:9:265:9 | b [MyInt] | main.rs:266:10:266:10 | b [MyInt] | provenance |  |
-| main.rs:265:13:265:39 | MyInt {...} [MyInt] | main.rs:265:9:265:9 | b [MyInt] | provenance |  |
-| main.rs:265:28:265:37 | source(...) | main.rs:265:13:265:39 | MyInt {...} [MyInt] | provenance |  |
-| main.rs:266:10:266:10 | b [MyInt] | main.rs:227:30:227:39 | ...: MyInt [MyInt] | provenance |  |
-| main.rs:266:10:266:10 | b [MyInt] | main.rs:267:10:267:10 | a [MyInt] | provenance |  |
-| main.rs:267:10:267:10 | a [MyInt] | main.rs:267:10:267:16 | a.value | provenance |  |
-| main.rs:270:9:270:9 | a [MyInt] | main.rs:272:28:272:28 | a [MyInt] | provenance |  |
-| main.rs:270:13:270:39 | MyInt {...} [MyInt] | main.rs:270:9:270:9 | a [MyInt] | provenance |  |
-| main.rs:270:28:270:37 | source(...) | main.rs:270:13:270:39 | MyInt {...} [MyInt] | provenance |  |
-| main.rs:272:9:272:9 | c | main.rs:273:10:273:10 | c | provenance |  |
-| main.rs:272:13:272:29 | * ... | main.rs:272:9:272:9 | c | provenance |  |
-| main.rs:272:14:272:29 | ...::deref(...) [&ref] | main.rs:272:13:272:29 | * ... | provenance | MaD:1 |
-| main.rs:272:27:272:28 | &a [&ref, MyInt] | main.rs:235:14:235:18 | SelfParam [&ref, MyInt] | provenance |  |
-| main.rs:272:27:272:28 | &a [&ref, MyInt] | main.rs:272:14:272:29 | ...::deref(...) [&ref] | provenance | MaD:1 |
-| main.rs:272:28:272:28 | a [MyInt] | main.rs:272:27:272:28 | &a [&ref, MyInt] | provenance |  |
-| main.rs:275:9:275:9 | a [MyInt] | main.rs:276:14:276:14 | a [MyInt] | provenance |  |
-| main.rs:275:13:275:39 | MyInt {...} [MyInt] | main.rs:275:9:275:9 | a [MyInt] | provenance |  |
+| main.rs:108:30:114:5 | { ... } | main.rs:154:13:154:25 | mn.get_data() | provenance |  |
+| main.rs:112:13:112:21 | source(...) | main.rs:108:30:114:5 | { ... } | provenance |  |
+| main.rs:116:27:116:32 | ...: i64 | main.rs:116:42:122:5 | { ... } | provenance |  |
+| main.rs:126:28:126:33 | ...: i64 | main.rs:127:14:127:14 | n | provenance |  |
+| main.rs:130:36:136:5 | { ... } | main.rs:148:13:148:30 | x.get_data_trait() | provenance |  |
+| main.rs:130:36:136:5 | { ... } | main.rs:158:13:158:31 | mn.get_data_trait() | provenance |  |
+| main.rs:134:13:134:22 | source(...) | main.rs:130:36:136:5 | { ... } | provenance |  |
+| main.rs:138:33:138:38 | ...: i64 | main.rs:138:48:144:5 | { ... } | provenance |  |
+| main.rs:148:9:148:9 | a | main.rs:149:10:149:10 | a | provenance |  |
+| main.rs:148:13:148:30 | x.get_data_trait() | main.rs:148:9:148:9 | a | provenance |  |
+| main.rs:154:9:154:9 | a | main.rs:155:10:155:10 | a | provenance |  |
+| main.rs:154:13:154:25 | mn.get_data() | main.rs:154:9:154:9 | a | provenance |  |
+| main.rs:158:9:158:9 | a | main.rs:159:10:159:10 | a | provenance |  |
+| main.rs:158:13:158:31 | mn.get_data_trait() | main.rs:158:9:158:9 | a | provenance |  |
+| main.rs:165:9:165:9 | a | main.rs:166:21:166:21 | a | provenance |  |
+| main.rs:165:13:165:22 | source(...) | main.rs:165:9:165:9 | a | provenance |  |
+| main.rs:166:21:166:21 | a | main.rs:126:28:126:33 | ...: i64 | provenance |  |
+| main.rs:171:9:171:9 | a | main.rs:172:16:172:16 | a | provenance |  |
+| main.rs:171:13:171:21 | source(...) | main.rs:171:9:171:9 | a | provenance |  |
+| main.rs:172:16:172:16 | a | main.rs:104:22:104:27 | ...: i64 | provenance |  |
+| main.rs:175:9:175:9 | a | main.rs:176:22:176:22 | a | provenance |  |
+| main.rs:175:13:175:22 | source(...) | main.rs:175:9:175:9 | a | provenance |  |
+| main.rs:176:22:176:22 | a | main.rs:126:28:126:33 | ...: i64 | provenance |  |
+| main.rs:182:9:182:9 | a | main.rs:183:34:183:34 | a | provenance |  |
+| main.rs:182:13:182:22 | source(...) | main.rs:182:9:182:9 | a | provenance |  |
+| main.rs:183:9:183:9 | b | main.rs:184:10:184:10 | b | provenance |  |
+| main.rs:183:13:183:35 | x.data_through_trait(...) | main.rs:183:9:183:9 | b | provenance |  |
+| main.rs:183:34:183:34 | a | main.rs:138:33:138:38 | ...: i64 | provenance |  |
+| main.rs:183:34:183:34 | a | main.rs:183:13:183:35 | x.data_through_trait(...) | provenance |  |
+| main.rs:189:9:189:9 | a | main.rs:190:29:190:29 | a | provenance |  |
+| main.rs:189:13:189:21 | source(...) | main.rs:189:9:189:9 | a | provenance |  |
+| main.rs:190:9:190:9 | b | main.rs:191:10:191:10 | b | provenance |  |
+| main.rs:190:13:190:30 | mn.data_through(...) | main.rs:190:9:190:9 | b | provenance |  |
+| main.rs:190:29:190:29 | a | main.rs:116:27:116:32 | ...: i64 | provenance |  |
+| main.rs:190:29:190:29 | a | main.rs:190:13:190:30 | mn.data_through(...) | provenance |  |
+| main.rs:194:9:194:9 | a | main.rs:195:35:195:35 | a | provenance |  |
+| main.rs:194:13:194:22 | source(...) | main.rs:194:9:194:9 | a | provenance |  |
+| main.rs:195:9:195:9 | b | main.rs:196:10:196:10 | b | provenance |  |
+| main.rs:195:13:195:36 | mn.data_through_trait(...) | main.rs:195:9:195:9 | b | provenance |  |
+| main.rs:195:35:195:35 | a | main.rs:138:33:138:38 | ...: i64 | provenance |  |
+| main.rs:195:35:195:35 | a | main.rs:195:13:195:36 | mn.data_through_trait(...) | provenance |  |
+| main.rs:203:9:203:9 | a | main.rs:204:25:204:25 | a | provenance |  |
+| main.rs:203:13:203:21 | source(...) | main.rs:203:9:203:9 | a | provenance |  |
+| main.rs:204:25:204:25 | a | main.rs:104:22:104:27 | ...: i64 | provenance |  |
+| main.rs:209:9:209:9 | a | main.rs:210:38:210:38 | a | provenance |  |
+| main.rs:209:13:209:22 | source(...) | main.rs:209:9:209:9 | a | provenance |  |
+| main.rs:210:9:210:9 | b | main.rs:211:10:211:10 | b | provenance |  |
+| main.rs:210:13:210:39 | ...::data_through(...) | main.rs:210:9:210:9 | b | provenance |  |
+| main.rs:210:38:210:38 | a | main.rs:116:27:116:32 | ...: i64 | provenance |  |
+| main.rs:210:38:210:38 | a | main.rs:210:13:210:39 | ...::data_through(...) | provenance |  |
+| main.rs:222:12:222:17 | ...: i64 | main.rs:223:24:223:24 | n | provenance |  |
+| main.rs:223:9:223:26 | MyInt {...} [MyInt] | main.rs:222:28:224:5 | { ... } [MyInt] | provenance |  |
+| main.rs:223:24:223:24 | n | main.rs:223:9:223:26 | MyInt {...} [MyInt] | provenance |  |
+| main.rs:228:9:228:9 | n [MyInt] | main.rs:229:9:229:26 | MyInt {...} [MyInt] | provenance |  |
+| main.rs:228:13:228:34 | ...::new(...) [MyInt] | main.rs:228:9:228:9 | n [MyInt] | provenance |  |
+| main.rs:228:24:228:33 | source(...) | main.rs:222:12:222:17 | ...: i64 | provenance |  |
+| main.rs:228:24:228:33 | source(...) | main.rs:228:13:228:34 | ...::new(...) [MyInt] | provenance |  |
+| main.rs:229:9:229:26 | MyInt {...} [MyInt] | main.rs:229:24:229:24 | m | provenance |  |
+| main.rs:229:24:229:24 | m | main.rs:230:10:230:10 | m | provenance |  |
+| main.rs:236:12:236:15 | SelfParam [MyInt] | main.rs:238:24:238:27 | self [MyInt] | provenance |  |
+| main.rs:238:9:238:35 | MyInt {...} [MyInt] | main.rs:236:42:239:5 | { ... } [MyInt] | provenance |  |
+| main.rs:238:24:238:27 | self [MyInt] | main.rs:238:24:238:33 | self.value | provenance |  |
+| main.rs:238:24:238:33 | self.value | main.rs:238:9:238:35 | MyInt {...} [MyInt] | provenance |  |
+| main.rs:243:30:243:39 | ...: MyInt [MyInt] | main.rs:244:22:244:24 | rhs [MyInt] | provenance |  |
+| main.rs:244:9:244:12 | [post] self [&ref, MyInt] | main.rs:243:19:243:27 | SelfParam [Return] [&ref, MyInt] | provenance |  |
+| main.rs:244:22:244:24 | rhs [MyInt] | main.rs:244:22:244:30 | rhs.value | provenance |  |
+| main.rs:244:22:244:30 | rhs.value | main.rs:244:9:244:12 | [post] self [&ref, MyInt] | provenance |  |
+| main.rs:251:14:251:18 | SelfParam [&ref, MyInt] | main.rs:252:12:252:15 | self [&ref, MyInt] | provenance |  |
+| main.rs:252:9:252:22 | &... [&ref] | main.rs:251:38:253:5 | { ... } [&ref] | provenance |  |
+| main.rs:252:10:252:22 | ... .value | main.rs:252:9:252:22 | &... [&ref] | provenance |  |
+| main.rs:252:11:252:15 | * ... [MyInt] | main.rs:252:10:252:22 | ... .value | provenance |  |
+| main.rs:252:12:252:15 | self [&ref, MyInt] | main.rs:252:11:252:15 | * ... [MyInt] | provenance | MaD:1 |
+| main.rs:258:9:258:9 | a [MyInt] | main.rs:260:13:260:13 | a [MyInt] | provenance |  |
+| main.rs:258:13:258:38 | MyInt {...} [MyInt] | main.rs:258:9:258:9 | a [MyInt] | provenance |  |
+| main.rs:258:28:258:36 | source(...) | main.rs:258:13:258:38 | MyInt {...} [MyInt] | provenance |  |
+| main.rs:260:9:260:9 | c [MyInt] | main.rs:261:10:261:10 | c [MyInt] | provenance |  |
+| main.rs:260:13:260:13 | a [MyInt] | main.rs:236:12:236:15 | SelfParam [MyInt] | provenance |  |
+| main.rs:260:13:260:13 | a [MyInt] | main.rs:260:13:260:17 | ... + ... [MyInt] | provenance |  |
+| main.rs:260:13:260:17 | ... + ... [MyInt] | main.rs:260:9:260:9 | c [MyInt] | provenance |  |
+| main.rs:261:10:261:10 | c [MyInt] | main.rs:261:10:261:16 | c.value | provenance |  |
+| main.rs:268:9:268:9 | a [MyInt] | main.rs:270:13:270:13 | a [MyInt] | provenance |  |
+| main.rs:268:13:268:38 | MyInt {...} [MyInt] | main.rs:268:9:268:9 | a [MyInt] | provenance |  |
+| main.rs:268:28:268:36 | source(...) | main.rs:268:13:268:38 | MyInt {...} [MyInt] | provenance |  |
+| main.rs:270:9:270:9 | d [MyInt] | main.rs:271:10:271:10 | d [MyInt] | provenance |  |
+| main.rs:270:13:270:13 | a [MyInt] | main.rs:236:12:236:15 | SelfParam [MyInt] | provenance |  |
+| main.rs:270:13:270:13 | a [MyInt] | main.rs:270:13:270:20 | a.add(...) [MyInt] | provenance |  |
+| main.rs:270:13:270:20 | a.add(...) [MyInt] | main.rs:270:9:270:9 | d [MyInt] | provenance |  |
+| main.rs:271:10:271:10 | d [MyInt] | main.rs:271:10:271:16 | d.value | provenance |  |
+| main.rs:275:9:275:9 | b [MyInt] | main.rs:277:35:277:35 | b [MyInt] | provenance |  |
+| main.rs:275:13:275:39 | MyInt {...} [MyInt] | main.rs:275:9:275:9 | b [MyInt] | provenance |  |
 | main.rs:275:28:275:37 | source(...) | main.rs:275:13:275:39 | MyInt {...} [MyInt] | provenance |  |
-| main.rs:276:9:276:9 | c | main.rs:277:10:277:10 | c | provenance |  |
-| main.rs:276:13:276:14 | * ... | main.rs:276:9:276:9 | c | provenance |  |
-| main.rs:276:14:276:14 | a [MyInt] | main.rs:235:14:235:18 | SelfParam [&ref, MyInt] | provenance |  |
-| main.rs:276:14:276:14 | a [MyInt] | main.rs:276:13:276:14 | * ... | provenance | MaD:1 |
-| main.rs:289:18:289:21 | SelfParam [MyInt] | main.rs:289:48:291:5 | { ... } [MyInt] | provenance |  |
-| main.rs:293:26:293:37 | ...: MyInt [MyInt] | main.rs:293:49:295:5 | { ... } [MyInt] | provenance |  |
-| main.rs:299:9:299:9 | a [MyInt] | main.rs:301:50:301:50 | a [MyInt] | provenance |  |
-| main.rs:299:13:299:38 | MyInt {...} [MyInt] | main.rs:299:9:299:9 | a [MyInt] | provenance |  |
-| main.rs:299:28:299:36 | source(...) | main.rs:299:13:299:38 | MyInt {...} [MyInt] | provenance |  |
-| main.rs:301:9:301:26 | MyInt {...} [MyInt] | main.rs:301:24:301:24 | c | provenance |  |
-| main.rs:301:24:301:24 | c | main.rs:302:10:302:10 | c | provenance |  |
-| main.rs:301:30:301:54 | ...::take_self(...) [MyInt] | main.rs:301:9:301:26 | MyInt {...} [MyInt] | provenance |  |
-| main.rs:301:50:301:50 | a [MyInt] | main.rs:289:18:289:21 | SelfParam [MyInt] | provenance |  |
-| main.rs:301:50:301:50 | a [MyInt] | main.rs:301:30:301:54 | ...::take_self(...) [MyInt] | provenance |  |
-| main.rs:305:9:305:9 | b [MyInt] | main.rs:306:55:306:55 | b [MyInt] | provenance |  |
-| main.rs:305:13:305:39 | MyInt {...} [MyInt] | main.rs:305:9:305:9 | b [MyInt] | provenance |  |
-| main.rs:305:28:305:37 | source(...) | main.rs:305:13:305:39 | MyInt {...} [MyInt] | provenance |  |
-| main.rs:306:9:306:26 | MyInt {...} [MyInt] | main.rs:306:24:306:24 | c | provenance |  |
-| main.rs:306:24:306:24 | c | main.rs:307:10:307:10 | c | provenance |  |
-| main.rs:306:30:306:56 | ...::take_second(...) [MyInt] | main.rs:306:9:306:26 | MyInt {...} [MyInt] | provenance |  |
-| main.rs:306:55:306:55 | b [MyInt] | main.rs:293:26:293:37 | ...: MyInt [MyInt] | provenance |  |
-| main.rs:306:55:306:55 | b [MyInt] | main.rs:306:30:306:56 | ...::take_second(...) [MyInt] | provenance |  |
-| main.rs:315:32:319:1 | { ... } | main.rs:322:13:322:26 | async_source(...) | provenance |  |
-| main.rs:315:32:319:1 | { ... } | main.rs:334:41:334:54 | async_source(...) | provenance |  |
-| main.rs:316:9:316:9 | a | main.rs:315:32:319:1 | { ... } | provenance |  |
-| main.rs:316:9:316:9 | a | main.rs:317:10:317:10 | a | provenance |  |
-| main.rs:316:13:316:21 | source(...) | main.rs:316:9:316:9 | a | provenance |  |
-| main.rs:322:9:322:9 | a | main.rs:323:10:323:10 | a | provenance |  |
-| main.rs:322:13:322:26 | async_source(...) | main.rs:322:9:322:9 | a | provenance |  |
-| main.rs:326:13:326:13 | c | main.rs:327:14:327:14 | c | provenance |  |
-| main.rs:326:17:326:25 | source(...) | main.rs:326:13:326:13 | c | provenance |  |
-| main.rs:334:9:334:9 | a | main.rs:335:10:335:10 | a | provenance |  |
-| main.rs:334:13:334:55 | ...::block_on(...) | main.rs:334:9:334:9 | a | provenance |  |
-| main.rs:334:41:334:54 | async_source(...) | main.rs:334:13:334:55 | ...::block_on(...) | provenance | MaD:3 |
-| main.rs:346:44:348:9 | { ... } | main.rs:383:18:383:38 | t.get_double_number() | provenance |  |
-| main.rs:346:44:348:9 | { ... } | main.rs:387:18:387:50 | ...::get_double_number(...) | provenance |  |
-| main.rs:347:13:347:29 | self.get_number() | main.rs:347:13:347:33 | ... * ... | provenance | MaD:2 |
-| main.rs:347:13:347:33 | ... * ... | main.rs:346:44:348:9 | { ... } | provenance |  |
-| main.rs:350:33:352:9 | { ... } | main.rs:391:18:391:37 | ...::get_default(...) | provenance |  |
-| main.rs:351:13:351:21 | source(...) | main.rs:350:33:352:9 | { ... } | provenance |  |
-| main.rs:358:37:360:9 | { ... } | main.rs:347:13:347:29 | self.get_number() | provenance |  |
-| main.rs:359:13:359:21 | source(...) | main.rs:358:37:360:9 | { ... } | provenance |  |
-| main.rs:370:44:372:9 | { ... } | main.rs:395:18:395:38 | i.get_double_number() | provenance |  |
-| main.rs:371:13:371:22 | source(...) | main.rs:370:44:372:9 | { ... } | provenance |  |
-| main.rs:374:33:376:9 | { ... } | main.rs:398:18:398:41 | ...::get_default(...) | provenance |  |
-| main.rs:375:13:375:21 | source(...) | main.rs:374:33:376:9 | { ... } | provenance |  |
-| main.rs:383:13:383:14 | n1 | main.rs:384:14:384:15 | n1 | provenance |  |
-| main.rs:383:18:383:38 | t.get_double_number() | main.rs:383:13:383:14 | n1 | provenance |  |
-| main.rs:387:13:387:14 | n2 | main.rs:388:14:388:15 | n2 | provenance |  |
-| main.rs:387:18:387:50 | ...::get_double_number(...) | main.rs:387:13:387:14 | n2 | provenance |  |
-| main.rs:391:13:391:14 | n3 | main.rs:392:14:392:15 | n3 | provenance |  |
-| main.rs:391:18:391:37 | ...::get_default(...) | main.rs:391:13:391:14 | n3 | provenance |  |
-| main.rs:395:13:395:14 | n4 | main.rs:396:14:396:15 | n4 | provenance |  |
-| main.rs:395:18:395:38 | i.get_double_number() | main.rs:395:13:395:14 | n4 | provenance |  |
-| main.rs:398:13:398:14 | n5 | main.rs:399:14:399:15 | n5 | provenance |  |
-| main.rs:398:18:398:41 | ...::get_default(...) | main.rs:398:13:398:14 | n5 | provenance |  |
+| main.rs:277:27:277:32 | [post] &mut a [&ref, MyInt] | main.rs:277:32:277:32 | [post] a [MyInt] | provenance |  |
+| main.rs:277:32:277:32 | [post] a [MyInt] | main.rs:278:10:278:10 | a [MyInt] | provenance |  |
+| main.rs:277:35:277:35 | b [MyInt] | main.rs:243:30:243:39 | ...: MyInt [MyInt] | provenance |  |
+| main.rs:277:35:277:35 | b [MyInt] | main.rs:277:27:277:32 | [post] &mut a [&ref, MyInt] | provenance |  |
+| main.rs:278:10:278:10 | a [MyInt] | main.rs:278:10:278:16 | a.value | provenance |  |
+| main.rs:281:9:281:9 | b [MyInt] | main.rs:282:10:282:10 | b [MyInt] | provenance |  |
+| main.rs:281:13:281:39 | MyInt {...} [MyInt] | main.rs:281:9:281:9 | b [MyInt] | provenance |  |
+| main.rs:281:28:281:37 | source(...) | main.rs:281:13:281:39 | MyInt {...} [MyInt] | provenance |  |
+| main.rs:282:10:282:10 | b [MyInt] | main.rs:243:30:243:39 | ...: MyInt [MyInt] | provenance |  |
+| main.rs:282:10:282:10 | b [MyInt] | main.rs:283:10:283:10 | a [MyInt] | provenance |  |
+| main.rs:283:10:283:10 | a [MyInt] | main.rs:283:10:283:16 | a.value | provenance |  |
+| main.rs:286:9:286:9 | a [MyInt] | main.rs:288:28:288:28 | a [MyInt] | provenance |  |
+| main.rs:286:13:286:39 | MyInt {...} [MyInt] | main.rs:286:9:286:9 | a [MyInt] | provenance |  |
+| main.rs:286:28:286:37 | source(...) | main.rs:286:13:286:39 | MyInt {...} [MyInt] | provenance |  |
+| main.rs:288:9:288:9 | c | main.rs:289:10:289:10 | c | provenance |  |
+| main.rs:288:13:288:29 | * ... | main.rs:288:9:288:9 | c | provenance |  |
+| main.rs:288:14:288:29 | ...::deref(...) [&ref] | main.rs:288:13:288:29 | * ... | provenance | MaD:1 |
+| main.rs:288:27:288:28 | &a [&ref, MyInt] | main.rs:251:14:251:18 | SelfParam [&ref, MyInt] | provenance |  |
+| main.rs:288:27:288:28 | &a [&ref, MyInt] | main.rs:288:14:288:29 | ...::deref(...) [&ref] | provenance | MaD:1 |
+| main.rs:288:28:288:28 | a [MyInt] | main.rs:288:27:288:28 | &a [&ref, MyInt] | provenance |  |
+| main.rs:291:9:291:9 | a [MyInt] | main.rs:292:14:292:14 | a [MyInt] | provenance |  |
+| main.rs:291:13:291:39 | MyInt {...} [MyInt] | main.rs:291:9:291:9 | a [MyInt] | provenance |  |
+| main.rs:291:28:291:37 | source(...) | main.rs:291:13:291:39 | MyInt {...} [MyInt] | provenance |  |
+| main.rs:292:9:292:9 | c | main.rs:293:10:293:10 | c | provenance |  |
+| main.rs:292:13:292:14 | * ... | main.rs:292:9:292:9 | c | provenance |  |
+| main.rs:292:14:292:14 | a [MyInt] | main.rs:251:14:251:18 | SelfParam [&ref, MyInt] | provenance |  |
+| main.rs:292:14:292:14 | a [MyInt] | main.rs:292:13:292:14 | * ... | provenance | MaD:1 |
+| main.rs:309:18:309:21 | SelfParam [MyInt] | main.rs:309:48:311:5 | { ... } [MyInt] | provenance |  |
+| main.rs:313:26:313:37 | ...: MyInt [MyInt] | main.rs:313:49:315:5 | { ... } [MyInt] | provenance |  |
+| main.rs:319:9:319:9 | a [MyInt] | main.rs:321:50:321:50 | a [MyInt] | provenance |  |
+| main.rs:319:13:319:38 | MyInt {...} [MyInt] | main.rs:319:9:319:9 | a [MyInt] | provenance |  |
+| main.rs:319:28:319:36 | source(...) | main.rs:319:13:319:38 | MyInt {...} [MyInt] | provenance |  |
+| main.rs:321:9:321:26 | MyInt {...} [MyInt] | main.rs:321:24:321:24 | c | provenance |  |
+| main.rs:321:24:321:24 | c | main.rs:322:10:322:10 | c | provenance |  |
+| main.rs:321:30:321:54 | ...::take_self(...) [MyInt] | main.rs:321:9:321:26 | MyInt {...} [MyInt] | provenance |  |
+| main.rs:321:50:321:50 | a [MyInt] | main.rs:309:18:309:21 | SelfParam [MyInt] | provenance |  |
+| main.rs:321:50:321:50 | a [MyInt] | main.rs:321:30:321:54 | ...::take_self(...) [MyInt] | provenance |  |
+| main.rs:325:9:325:9 | b [MyInt] | main.rs:326:55:326:55 | b [MyInt] | provenance |  |
+| main.rs:325:13:325:39 | MyInt {...} [MyInt] | main.rs:325:9:325:9 | b [MyInt] | provenance |  |
+| main.rs:325:28:325:37 | source(...) | main.rs:325:13:325:39 | MyInt {...} [MyInt] | provenance |  |
+| main.rs:326:9:326:26 | MyInt {...} [MyInt] | main.rs:326:24:326:24 | c | provenance |  |
+| main.rs:326:24:326:24 | c | main.rs:327:10:327:10 | c | provenance |  |
+| main.rs:326:30:326:56 | ...::take_second(...) [MyInt] | main.rs:326:9:326:26 | MyInt {...} [MyInt] | provenance |  |
+| main.rs:326:55:326:55 | b [MyInt] | main.rs:313:26:313:37 | ...: MyInt [MyInt] | provenance |  |
+| main.rs:326:55:326:55 | b [MyInt] | main.rs:326:30:326:56 | ...::take_second(...) [MyInt] | provenance |  |
+| main.rs:335:32:339:1 | { ... } | main.rs:342:13:342:26 | async_source(...) | provenance |  |
+| main.rs:335:32:339:1 | { ... } | main.rs:354:41:354:54 | async_source(...) | provenance |  |
+| main.rs:336:9:336:9 | a | main.rs:335:32:339:1 | { ... } | provenance |  |
+| main.rs:336:9:336:9 | a | main.rs:337:10:337:10 | a | provenance |  |
+| main.rs:336:13:336:21 | source(...) | main.rs:336:9:336:9 | a | provenance |  |
+| main.rs:342:9:342:9 | a | main.rs:343:10:343:10 | a | provenance |  |
+| main.rs:342:13:342:26 | async_source(...) | main.rs:342:9:342:9 | a | provenance |  |
+| main.rs:346:13:346:13 | c | main.rs:347:14:347:14 | c | provenance |  |
+| main.rs:346:17:346:25 | source(...) | main.rs:346:13:346:13 | c | provenance |  |
+| main.rs:354:9:354:9 | a | main.rs:355:10:355:10 | a | provenance |  |
+| main.rs:354:13:354:55 | ...::block_on(...) | main.rs:354:9:354:9 | a | provenance |  |
+| main.rs:354:41:354:54 | async_source(...) | main.rs:354:13:354:55 | ...::block_on(...) | provenance | MaD:3 |
+| main.rs:366:44:368:9 | { ... } | main.rs:403:18:403:38 | t.get_double_number() | provenance |  |
+| main.rs:366:44:368:9 | { ... } | main.rs:407:18:407:50 | ...::get_double_number(...) | provenance |  |
+| main.rs:367:13:367:29 | self.get_number() | main.rs:367:13:367:33 | ... * ... | provenance | MaD:2 |
+| main.rs:367:13:367:33 | ... * ... | main.rs:366:44:368:9 | { ... } | provenance |  |
+| main.rs:370:33:372:9 | { ... } | main.rs:411:18:411:37 | ...::get_default(...) | provenance |  |
+| main.rs:371:13:371:21 | source(...) | main.rs:370:33:372:9 | { ... } | provenance |  |
+| main.rs:378:37:380:9 | { ... } | main.rs:367:13:367:29 | self.get_number() | provenance |  |
+| main.rs:379:13:379:21 | source(...) | main.rs:378:37:380:9 | { ... } | provenance |  |
+| main.rs:390:44:392:9 | { ... } | main.rs:415:18:415:38 | i.get_double_number() | provenance |  |
+| main.rs:391:13:391:22 | source(...) | main.rs:390:44:392:9 | { ... } | provenance |  |
+| main.rs:394:33:396:9 | { ... } | main.rs:418:18:418:41 | ...::get_default(...) | provenance |  |
+| main.rs:395:13:395:21 | source(...) | main.rs:394:33:396:9 | { ... } | provenance |  |
+| main.rs:403:13:403:14 | n1 | main.rs:404:14:404:15 | n1 | provenance |  |
+| main.rs:403:18:403:38 | t.get_double_number() | main.rs:403:13:403:14 | n1 | provenance |  |
+| main.rs:407:13:407:14 | n2 | main.rs:408:14:408:15 | n2 | provenance |  |
+| main.rs:407:18:407:50 | ...::get_double_number(...) | main.rs:407:13:407:14 | n2 | provenance |  |
+| main.rs:411:13:411:14 | n3 | main.rs:412:14:412:15 | n3 | provenance |  |
+| main.rs:411:18:411:37 | ...::get_default(...) | main.rs:411:13:411:14 | n3 | provenance |  |
+| main.rs:415:13:415:14 | n4 | main.rs:416:14:416:15 | n4 | provenance |  |
+| main.rs:415:18:415:38 | i.get_double_number() | main.rs:415:13:415:14 | n4 | provenance |  |
+| main.rs:418:13:418:14 | n5 | main.rs:419:14:419:15 | n5 | provenance |  |
+| main.rs:418:18:418:41 | ...::get_default(...) | main.rs:418:13:418:14 | n5 | provenance |  |
 nodes
 | main.rs:12:28:14:1 | { ... } | semmle.label | { ... } |
 | main.rs:13:5:13:13 | source(...) | semmle.label | source(...) |
@@ -271,193 +271,193 @@ nodes
 | main.rs:87:10:87:10 | b | semmle.label | b |
 | main.rs:104:22:104:27 | ...: i64 | semmle.label | ...: i64 |
 | main.rs:105:14:105:14 | n | semmle.label | n |
-| main.rs:108:30:110:5 | { ... } | semmle.label | { ... } |
-| main.rs:109:35:109:43 | source(...) | semmle.label | source(...) |
-| main.rs:112:27:112:32 | ...: i64 | semmle.label | ...: i64 |
-| main.rs:112:42:114:5 | { ... } | semmle.label | { ... } |
-| main.rs:118:28:118:33 | ...: i64 | semmle.label | ...: i64 |
-| main.rs:119:14:119:14 | n | semmle.label | n |
-| main.rs:122:36:124:5 | { ... } | semmle.label | { ... } |
-| main.rs:123:35:123:44 | source(...) | semmle.label | source(...) |
-| main.rs:126:33:126:38 | ...: i64 | semmle.label | ...: i64 |
-| main.rs:126:48:128:5 | { ... } | semmle.label | { ... } |
-| main.rs:132:9:132:9 | a | semmle.label | a |
-| main.rs:132:13:132:30 | x.get_data_trait() | semmle.label | x.get_data_trait() |
-| main.rs:133:10:133:10 | a | semmle.label | a |
-| main.rs:138:9:138:9 | a | semmle.label | a |
-| main.rs:138:13:138:25 | mn.get_data() | semmle.label | mn.get_data() |
-| main.rs:139:10:139:10 | a | semmle.label | a |
-| main.rs:142:9:142:9 | a | semmle.label | a |
-| main.rs:142:13:142:31 | mn.get_data_trait() | semmle.label | mn.get_data_trait() |
-| main.rs:143:10:143:10 | a | semmle.label | a |
-| main.rs:149:9:149:9 | a | semmle.label | a |
-| main.rs:149:13:149:22 | source(...) | semmle.label | source(...) |
-| main.rs:150:21:150:21 | a | semmle.label | a |
-| main.rs:155:9:155:9 | a | semmle.label | a |
-| main.rs:155:13:155:21 | source(...) | semmle.label | source(...) |
-| main.rs:156:16:156:16 | a | semmle.label | a |
-| main.rs:159:9:159:9 | a | semmle.label | a |
-| main.rs:159:13:159:22 | source(...) | semmle.label | source(...) |
-| main.rs:160:22:160:22 | a | semmle.label | a |
-| main.rs:166:9:166:9 | a | semmle.label | a |
-| main.rs:166:13:166:22 | source(...) | semmle.label | source(...) |
-| main.rs:167:9:167:9 | b | semmle.label | b |
-| main.rs:167:13:167:35 | x.data_through_trait(...) | semmle.label | x.data_through_trait(...) |
-| main.rs:167:34:167:34 | a | semmle.label | a |
-| main.rs:168:10:168:10 | b | semmle.label | b |
-| main.rs:173:9:173:9 | a | semmle.label | a |
-| main.rs:173:13:173:21 | source(...) | semmle.label | source(...) |
-| main.rs:174:9:174:9 | b | semmle.label | b |
-| main.rs:174:13:174:30 | mn.data_through(...) | semmle.label | mn.data_through(...) |
-| main.rs:174:29:174:29 | a | semmle.label | a |
-| main.rs:175:10:175:10 | b | semmle.label | b |
-| main.rs:178:9:178:9 | a | semmle.label | a |
-| main.rs:178:13:178:22 | source(...) | semmle.label | source(...) |
-| main.rs:179:9:179:9 | b | semmle.label | b |
-| main.rs:179:13:179:36 | mn.data_through_trait(...) | semmle.label | mn.data_through_trait(...) |
-| main.rs:179:35:179:35 | a | semmle.label | a |
-| main.rs:180:10:180:10 | b | semmle.label | b |
-| main.rs:187:9:187:9 | a | semmle.label | a |
-| main.rs:187:13:187:21 | source(...) | semmle.label | source(...) |
-| main.rs:188:25:188:25 | a | semmle.label | a |
-| main.rs:193:9:193:9 | a | semmle.label | a |
-| main.rs:193:13:193:22 | source(...) | semmle.label | source(...) |
-| main.rs:194:9:194:9 | b | semmle.label | b |
-| main.rs:194:13:194:39 | ...::data_through(...) | semmle.label | ...::data_through(...) |
-| main.rs:194:38:194:38 | a | semmle.label | a |
-| main.rs:195:10:195:10 | b | semmle.label | b |
-| main.rs:206:12:206:17 | ...: i64 | semmle.label | ...: i64 |
-| main.rs:206:28:208:5 | { ... } [MyInt] | semmle.label | { ... } [MyInt] |
-| main.rs:207:9:207:26 | MyInt {...} [MyInt] | semmle.label | MyInt {...} [MyInt] |
-| main.rs:207:24:207:24 | n | semmle.label | n |
-| main.rs:212:9:212:9 | n [MyInt] | semmle.label | n [MyInt] |
-| main.rs:212:13:212:34 | ...::new(...) [MyInt] | semmle.label | ...::new(...) [MyInt] |
-| main.rs:212:24:212:33 | source(...) | semmle.label | source(...) |
-| main.rs:213:9:213:26 | MyInt {...} [MyInt] | semmle.label | MyInt {...} [MyInt] |
-| main.rs:213:24:213:24 | m | semmle.label | m |
-| main.rs:214:10:214:10 | m | semmle.label | m |
-| main.rs:220:12:220:15 | SelfParam [MyInt] | semmle.label | SelfParam [MyInt] |
-| main.rs:220:42:223:5 | { ... } [MyInt] | semmle.label | { ... } [MyInt] |
-| main.rs:222:9:222:35 | MyInt {...} [MyInt] | semmle.label | MyInt {...} [MyInt] |
-| main.rs:222:24:222:27 | self [MyInt] | semmle.label | self [MyInt] |
-| main.rs:222:24:222:33 | self.value | semmle.label | self.value |
-| main.rs:227:19:227:27 | SelfParam [Return] [&ref, MyInt] | semmle.label | SelfParam [Return] [&ref, MyInt] |
-| main.rs:227:30:227:39 | ...: MyInt [MyInt] | semmle.label | ...: MyInt [MyInt] |
-| main.rs:228:9:228:12 | [post] self [&ref, MyInt] | semmle.label | [post] self [&ref, MyInt] |
-| main.rs:228:22:228:24 | rhs [MyInt] | semmle.label | rhs [MyInt] |
-| main.rs:228:22:228:30 | rhs.value | semmle.label | rhs.value |
-| main.rs:235:14:235:18 | SelfParam [&ref, MyInt] | semmle.label | SelfParam [&ref, MyInt] |
-| main.rs:235:38:237:5 | { ... } [&ref] | semmle.label | { ... } [&ref] |
-| main.rs:236:9:236:22 | &... [&ref] | semmle.label | &... [&ref] |
-| main.rs:236:10:236:22 | ... .value | semmle.label | ... .value |
-| main.rs:236:11:236:15 | * ... [MyInt] | semmle.label | * ... [MyInt] |
-| main.rs:236:12:236:15 | self [&ref, MyInt] | semmle.label | self [&ref, MyInt] |
-| main.rs:242:9:242:9 | a [MyInt] | semmle.label | a [MyInt] |
-| main.rs:242:13:242:38 | MyInt {...} [MyInt] | semmle.label | MyInt {...} [MyInt] |
-| main.rs:242:28:242:36 | source(...) | semmle.label | source(...) |
-| main.rs:244:9:244:9 | c [MyInt] | semmle.label | c [MyInt] |
-| main.rs:244:13:244:13 | a [MyInt] | semmle.label | a [MyInt] |
-| main.rs:244:13:244:17 | ... + ... [MyInt] | semmle.label | ... + ... [MyInt] |
-| main.rs:245:10:245:10 | c [MyInt] | semmle.label | c [MyInt] |
-| main.rs:245:10:245:16 | c.value | semmle.label | c.value |
-| main.rs:252:9:252:9 | a [MyInt] | semmle.label | a [MyInt] |
-| main.rs:252:13:252:38 | MyInt {...} [MyInt] | semmle.label | MyInt {...} [MyInt] |
-| main.rs:252:28:252:36 | source(...) | semmle.label | source(...) |
-| main.rs:254:9:254:9 | d [MyInt] | semmle.label | d [MyInt] |
-| main.rs:254:13:254:13 | a [MyInt] | semmle.label | a [MyInt] |
-| main.rs:254:13:254:20 | a.add(...) [MyInt] | semmle.label | a.add(...) [MyInt] |
-| main.rs:255:10:255:10 | d [MyInt] | semmle.label | d [MyInt] |
-| main.rs:255:10:255:16 | d.value | semmle.label | d.value |
-| main.rs:259:9:259:9 | b [MyInt] | semmle.label | b [MyInt] |
-| main.rs:259:13:259:39 | MyInt {...} [MyInt] | semmle.label | MyInt {...} [MyInt] |
-| main.rs:259:28:259:37 | source(...) | semmle.label | source(...) |
-| main.rs:261:27:261:32 | [post] &mut a [&ref, MyInt] | semmle.label | [post] &mut a [&ref, MyInt] |
-| main.rs:261:32:261:32 | [post] a [MyInt] | semmle.label | [post] a [MyInt] |
-| main.rs:261:35:261:35 | b [MyInt] | semmle.label | b [MyInt] |
-| main.rs:262:10:262:10 | a [MyInt] | semmle.label | a [MyInt] |
-| main.rs:262:10:262:16 | a.value | semmle.label | a.value |
-| main.rs:265:9:265:9 | b [MyInt] | semmle.label | b [MyInt] |
-| main.rs:265:13:265:39 | MyInt {...} [MyInt] | semmle.label | MyInt {...} [MyInt] |
-| main.rs:265:28:265:37 | source(...) | semmle.label | source(...) |
-| main.rs:266:10:266:10 | b [MyInt] | semmle.label | b [MyInt] |
-| main.rs:267:10:267:10 | a [MyInt] | semmle.label | a [MyInt] |
-| main.rs:267:10:267:16 | a.value | semmle.label | a.value |
-| main.rs:270:9:270:9 | a [MyInt] | semmle.label | a [MyInt] |
-| main.rs:270:13:270:39 | MyInt {...} [MyInt] | semmle.label | MyInt {...} [MyInt] |
-| main.rs:270:28:270:37 | source(...) | semmle.label | source(...) |
-| main.rs:272:9:272:9 | c | semmle.label | c |
-| main.rs:272:13:272:29 | * ... | semmle.label | * ... |
-| main.rs:272:14:272:29 | ...::deref(...) [&ref] | semmle.label | ...::deref(...) [&ref] |
-| main.rs:272:27:272:28 | &a [&ref, MyInt] | semmle.label | &a [&ref, MyInt] |
-| main.rs:272:28:272:28 | a [MyInt] | semmle.label | a [MyInt] |
-| main.rs:273:10:273:10 | c | semmle.label | c |
-| main.rs:275:9:275:9 | a [MyInt] | semmle.label | a [MyInt] |
+| main.rs:108:30:114:5 | { ... } | semmle.label | { ... } |
+| main.rs:112:13:112:21 | source(...) | semmle.label | source(...) |
+| main.rs:116:27:116:32 | ...: i64 | semmle.label | ...: i64 |
+| main.rs:116:42:122:5 | { ... } | semmle.label | { ... } |
+| main.rs:126:28:126:33 | ...: i64 | semmle.label | ...: i64 |
+| main.rs:127:14:127:14 | n | semmle.label | n |
+| main.rs:130:36:136:5 | { ... } | semmle.label | { ... } |
+| main.rs:134:13:134:22 | source(...) | semmle.label | source(...) |
+| main.rs:138:33:138:38 | ...: i64 | semmle.label | ...: i64 |
+| main.rs:138:48:144:5 | { ... } | semmle.label | { ... } |
+| main.rs:148:9:148:9 | a | semmle.label | a |
+| main.rs:148:13:148:30 | x.get_data_trait() | semmle.label | x.get_data_trait() |
+| main.rs:149:10:149:10 | a | semmle.label | a |
+| main.rs:154:9:154:9 | a | semmle.label | a |
+| main.rs:154:13:154:25 | mn.get_data() | semmle.label | mn.get_data() |
+| main.rs:155:10:155:10 | a | semmle.label | a |
+| main.rs:158:9:158:9 | a | semmle.label | a |
+| main.rs:158:13:158:31 | mn.get_data_trait() | semmle.label | mn.get_data_trait() |
+| main.rs:159:10:159:10 | a | semmle.label | a |
+| main.rs:165:9:165:9 | a | semmle.label | a |
+| main.rs:165:13:165:22 | source(...) | semmle.label | source(...) |
+| main.rs:166:21:166:21 | a | semmle.label | a |
+| main.rs:171:9:171:9 | a | semmle.label | a |
+| main.rs:171:13:171:21 | source(...) | semmle.label | source(...) |
+| main.rs:172:16:172:16 | a | semmle.label | a |
+| main.rs:175:9:175:9 | a | semmle.label | a |
+| main.rs:175:13:175:22 | source(...) | semmle.label | source(...) |
+| main.rs:176:22:176:22 | a | semmle.label | a |
+| main.rs:182:9:182:9 | a | semmle.label | a |
+| main.rs:182:13:182:22 | source(...) | semmle.label | source(...) |
+| main.rs:183:9:183:9 | b | semmle.label | b |
+| main.rs:183:13:183:35 | x.data_through_trait(...) | semmle.label | x.data_through_trait(...) |
+| main.rs:183:34:183:34 | a | semmle.label | a |
+| main.rs:184:10:184:10 | b | semmle.label | b |
+| main.rs:189:9:189:9 | a | semmle.label | a |
+| main.rs:189:13:189:21 | source(...) | semmle.label | source(...) |
+| main.rs:190:9:190:9 | b | semmle.label | b |
+| main.rs:190:13:190:30 | mn.data_through(...) | semmle.label | mn.data_through(...) |
+| main.rs:190:29:190:29 | a | semmle.label | a |
+| main.rs:191:10:191:10 | b | semmle.label | b |
+| main.rs:194:9:194:9 | a | semmle.label | a |
+| main.rs:194:13:194:22 | source(...) | semmle.label | source(...) |
+| main.rs:195:9:195:9 | b | semmle.label | b |
+| main.rs:195:13:195:36 | mn.data_through_trait(...) | semmle.label | mn.data_through_trait(...) |
+| main.rs:195:35:195:35 | a | semmle.label | a |
+| main.rs:196:10:196:10 | b | semmle.label | b |
+| main.rs:203:9:203:9 | a | semmle.label | a |
+| main.rs:203:13:203:21 | source(...) | semmle.label | source(...) |
+| main.rs:204:25:204:25 | a | semmle.label | a |
+| main.rs:209:9:209:9 | a | semmle.label | a |
+| main.rs:209:13:209:22 | source(...) | semmle.label | source(...) |
+| main.rs:210:9:210:9 | b | semmle.label | b |
+| main.rs:210:13:210:39 | ...::data_through(...) | semmle.label | ...::data_through(...) |
+| main.rs:210:38:210:38 | a | semmle.label | a |
+| main.rs:211:10:211:10 | b | semmle.label | b |
+| main.rs:222:12:222:17 | ...: i64 | semmle.label | ...: i64 |
+| main.rs:222:28:224:5 | { ... } [MyInt] | semmle.label | { ... } [MyInt] |
+| main.rs:223:9:223:26 | MyInt {...} [MyInt] | semmle.label | MyInt {...} [MyInt] |
+| main.rs:223:24:223:24 | n | semmle.label | n |
+| main.rs:228:9:228:9 | n [MyInt] | semmle.label | n [MyInt] |
+| main.rs:228:13:228:34 | ...::new(...) [MyInt] | semmle.label | ...::new(...) [MyInt] |
+| main.rs:228:24:228:33 | source(...) | semmle.label | source(...) |
+| main.rs:229:9:229:26 | MyInt {...} [MyInt] | semmle.label | MyInt {...} [MyInt] |
+| main.rs:229:24:229:24 | m | semmle.label | m |
+| main.rs:230:10:230:10 | m | semmle.label | m |
+| main.rs:236:12:236:15 | SelfParam [MyInt] | semmle.label | SelfParam [MyInt] |
+| main.rs:236:42:239:5 | { ... } [MyInt] | semmle.label | { ... } [MyInt] |
+| main.rs:238:9:238:35 | MyInt {...} [MyInt] | semmle.label | MyInt {...} [MyInt] |
+| main.rs:238:24:238:27 | self [MyInt] | semmle.label | self [MyInt] |
+| main.rs:238:24:238:33 | self.value | semmle.label | self.value |
+| main.rs:243:19:243:27 | SelfParam [Return] [&ref, MyInt] | semmle.label | SelfParam [Return] [&ref, MyInt] |
+| main.rs:243:30:243:39 | ...: MyInt [MyInt] | semmle.label | ...: MyInt [MyInt] |
+| main.rs:244:9:244:12 | [post] self [&ref, MyInt] | semmle.label | [post] self [&ref, MyInt] |
+| main.rs:244:22:244:24 | rhs [MyInt] | semmle.label | rhs [MyInt] |
+| main.rs:244:22:244:30 | rhs.value | semmle.label | rhs.value |
+| main.rs:251:14:251:18 | SelfParam [&ref, MyInt] | semmle.label | SelfParam [&ref, MyInt] |
+| main.rs:251:38:253:5 | { ... } [&ref] | semmle.label | { ... } [&ref] |
+| main.rs:252:9:252:22 | &... [&ref] | semmle.label | &... [&ref] |
+| main.rs:252:10:252:22 | ... .value | semmle.label | ... .value |
+| main.rs:252:11:252:15 | * ... [MyInt] | semmle.label | * ... [MyInt] |
+| main.rs:252:12:252:15 | self [&ref, MyInt] | semmle.label | self [&ref, MyInt] |
+| main.rs:258:9:258:9 | a [MyInt] | semmle.label | a [MyInt] |
+| main.rs:258:13:258:38 | MyInt {...} [MyInt] | semmle.label | MyInt {...} [MyInt] |
+| main.rs:258:28:258:36 | source(...) | semmle.label | source(...) |
+| main.rs:260:9:260:9 | c [MyInt] | semmle.label | c [MyInt] |
+| main.rs:260:13:260:13 | a [MyInt] | semmle.label | a [MyInt] |
+| main.rs:260:13:260:17 | ... + ... [MyInt] | semmle.label | ... + ... [MyInt] |
+| main.rs:261:10:261:10 | c [MyInt] | semmle.label | c [MyInt] |
+| main.rs:261:10:261:16 | c.value | semmle.label | c.value |
+| main.rs:268:9:268:9 | a [MyInt] | semmle.label | a [MyInt] |
+| main.rs:268:13:268:38 | MyInt {...} [MyInt] | semmle.label | MyInt {...} [MyInt] |
+| main.rs:268:28:268:36 | source(...) | semmle.label | source(...) |
+| main.rs:270:9:270:9 | d [MyInt] | semmle.label | d [MyInt] |
+| main.rs:270:13:270:13 | a [MyInt] | semmle.label | a [MyInt] |
+| main.rs:270:13:270:20 | a.add(...) [MyInt] | semmle.label | a.add(...) [MyInt] |
+| main.rs:271:10:271:10 | d [MyInt] | semmle.label | d [MyInt] |
+| main.rs:271:10:271:16 | d.value | semmle.label | d.value |
+| main.rs:275:9:275:9 | b [MyInt] | semmle.label | b [MyInt] |
 | main.rs:275:13:275:39 | MyInt {...} [MyInt] | semmle.label | MyInt {...} [MyInt] |
 | main.rs:275:28:275:37 | source(...) | semmle.label | source(...) |
-| main.rs:276:9:276:9 | c | semmle.label | c |
-| main.rs:276:13:276:14 | * ... | semmle.label | * ... |
-| main.rs:276:14:276:14 | a [MyInt] | semmle.label | a [MyInt] |
-| main.rs:277:10:277:10 | c | semmle.label | c |
-| main.rs:289:18:289:21 | SelfParam [MyInt] | semmle.label | SelfParam [MyInt] |
-| main.rs:289:48:291:5 | { ... } [MyInt] | semmle.label | { ... } [MyInt] |
-| main.rs:293:26:293:37 | ...: MyInt [MyInt] | semmle.label | ...: MyInt [MyInt] |
-| main.rs:293:49:295:5 | { ... } [MyInt] | semmle.label | { ... } [MyInt] |
-| main.rs:299:9:299:9 | a [MyInt] | semmle.label | a [MyInt] |
-| main.rs:299:13:299:38 | MyInt {...} [MyInt] | semmle.label | MyInt {...} [MyInt] |
-| main.rs:299:28:299:36 | source(...) | semmle.label | source(...) |
-| main.rs:301:9:301:26 | MyInt {...} [MyInt] | semmle.label | MyInt {...} [MyInt] |
-| main.rs:301:24:301:24 | c | semmle.label | c |
-| main.rs:301:30:301:54 | ...::take_self(...) [MyInt] | semmle.label | ...::take_self(...) [MyInt] |
-| main.rs:301:50:301:50 | a [MyInt] | semmle.label | a [MyInt] |
-| main.rs:302:10:302:10 | c | semmle.label | c |
-| main.rs:305:9:305:9 | b [MyInt] | semmle.label | b [MyInt] |
-| main.rs:305:13:305:39 | MyInt {...} [MyInt] | semmle.label | MyInt {...} [MyInt] |
-| main.rs:305:28:305:37 | source(...) | semmle.label | source(...) |
-| main.rs:306:9:306:26 | MyInt {...} [MyInt] | semmle.label | MyInt {...} [MyInt] |
-| main.rs:306:24:306:24 | c | semmle.label | c |
-| main.rs:306:30:306:56 | ...::take_second(...) [MyInt] | semmle.label | ...::take_second(...) [MyInt] |
-| main.rs:306:55:306:55 | b [MyInt] | semmle.label | b [MyInt] |
-| main.rs:307:10:307:10 | c | semmle.label | c |
-| main.rs:315:32:319:1 | { ... } | semmle.label | { ... } |
-| main.rs:316:9:316:9 | a | semmle.label | a |
-| main.rs:316:13:316:21 | source(...) | semmle.label | source(...) |
-| main.rs:317:10:317:10 | a | semmle.label | a |
-| main.rs:322:9:322:9 | a | semmle.label | a |
-| main.rs:322:13:322:26 | async_source(...) | semmle.label | async_source(...) |
-| main.rs:323:10:323:10 | a | semmle.label | a |
-| main.rs:326:13:326:13 | c | semmle.label | c |
-| main.rs:326:17:326:25 | source(...) | semmle.label | source(...) |
-| main.rs:327:14:327:14 | c | semmle.label | c |
-| main.rs:334:9:334:9 | a | semmle.label | a |
-| main.rs:334:13:334:55 | ...::block_on(...) | semmle.label | ...::block_on(...) |
-| main.rs:334:41:334:54 | async_source(...) | semmle.label | async_source(...) |
-| main.rs:335:10:335:10 | a | semmle.label | a |
-| main.rs:346:44:348:9 | { ... } | semmle.label | { ... } |
-| main.rs:347:13:347:29 | self.get_number() | semmle.label | self.get_number() |
-| main.rs:347:13:347:33 | ... * ... | semmle.label | ... * ... |
-| main.rs:350:33:352:9 | { ... } | semmle.label | { ... } |
-| main.rs:351:13:351:21 | source(...) | semmle.label | source(...) |
-| main.rs:358:37:360:9 | { ... } | semmle.label | { ... } |
-| main.rs:359:13:359:21 | source(...) | semmle.label | source(...) |
-| main.rs:370:44:372:9 | { ... } | semmle.label | { ... } |
-| main.rs:371:13:371:22 | source(...) | semmle.label | source(...) |
-| main.rs:374:33:376:9 | { ... } | semmle.label | { ... } |
-| main.rs:375:13:375:21 | source(...) | semmle.label | source(...) |
-| main.rs:383:13:383:14 | n1 | semmle.label | n1 |
-| main.rs:383:18:383:38 | t.get_double_number() | semmle.label | t.get_double_number() |
-| main.rs:384:14:384:15 | n1 | semmle.label | n1 |
-| main.rs:387:13:387:14 | n2 | semmle.label | n2 |
-| main.rs:387:18:387:50 | ...::get_double_number(...) | semmle.label | ...::get_double_number(...) |
-| main.rs:388:14:388:15 | n2 | semmle.label | n2 |
-| main.rs:391:13:391:14 | n3 | semmle.label | n3 |
-| main.rs:391:18:391:37 | ...::get_default(...) | semmle.label | ...::get_default(...) |
-| main.rs:392:14:392:15 | n3 | semmle.label | n3 |
-| main.rs:395:13:395:14 | n4 | semmle.label | n4 |
-| main.rs:395:18:395:38 | i.get_double_number() | semmle.label | i.get_double_number() |
-| main.rs:396:14:396:15 | n4 | semmle.label | n4 |
-| main.rs:398:13:398:14 | n5 | semmle.label | n5 |
-| main.rs:398:18:398:41 | ...::get_default(...) | semmle.label | ...::get_default(...) |
-| main.rs:399:14:399:15 | n5 | semmle.label | n5 |
+| main.rs:277:27:277:32 | [post] &mut a [&ref, MyInt] | semmle.label | [post] &mut a [&ref, MyInt] |
+| main.rs:277:32:277:32 | [post] a [MyInt] | semmle.label | [post] a [MyInt] |
+| main.rs:277:35:277:35 | b [MyInt] | semmle.label | b [MyInt] |
+| main.rs:278:10:278:10 | a [MyInt] | semmle.label | a [MyInt] |
+| main.rs:278:10:278:16 | a.value | semmle.label | a.value |
+| main.rs:281:9:281:9 | b [MyInt] | semmle.label | b [MyInt] |
+| main.rs:281:13:281:39 | MyInt {...} [MyInt] | semmle.label | MyInt {...} [MyInt] |
+| main.rs:281:28:281:37 | source(...) | semmle.label | source(...) |
+| main.rs:282:10:282:10 | b [MyInt] | semmle.label | b [MyInt] |
+| main.rs:283:10:283:10 | a [MyInt] | semmle.label | a [MyInt] |
+| main.rs:283:10:283:16 | a.value | semmle.label | a.value |
+| main.rs:286:9:286:9 | a [MyInt] | semmle.label | a [MyInt] |
+| main.rs:286:13:286:39 | MyInt {...} [MyInt] | semmle.label | MyInt {...} [MyInt] |
+| main.rs:286:28:286:37 | source(...) | semmle.label | source(...) |
+| main.rs:288:9:288:9 | c | semmle.label | c |
+| main.rs:288:13:288:29 | * ... | semmle.label | * ... |
+| main.rs:288:14:288:29 | ...::deref(...) [&ref] | semmle.label | ...::deref(...) [&ref] |
+| main.rs:288:27:288:28 | &a [&ref, MyInt] | semmle.label | &a [&ref, MyInt] |
+| main.rs:288:28:288:28 | a [MyInt] | semmle.label | a [MyInt] |
+| main.rs:289:10:289:10 | c | semmle.label | c |
+| main.rs:291:9:291:9 | a [MyInt] | semmle.label | a [MyInt] |
+| main.rs:291:13:291:39 | MyInt {...} [MyInt] | semmle.label | MyInt {...} [MyInt] |
+| main.rs:291:28:291:37 | source(...) | semmle.label | source(...) |
+| main.rs:292:9:292:9 | c | semmle.label | c |
+| main.rs:292:13:292:14 | * ... | semmle.label | * ... |
+| main.rs:292:14:292:14 | a [MyInt] | semmle.label | a [MyInt] |
+| main.rs:293:10:293:10 | c | semmle.label | c |
+| main.rs:309:18:309:21 | SelfParam [MyInt] | semmle.label | SelfParam [MyInt] |
+| main.rs:309:48:311:5 | { ... } [MyInt] | semmle.label | { ... } [MyInt] |
+| main.rs:313:26:313:37 | ...: MyInt [MyInt] | semmle.label | ...: MyInt [MyInt] |
+| main.rs:313:49:315:5 | { ... } [MyInt] | semmle.label | { ... } [MyInt] |
+| main.rs:319:9:319:9 | a [MyInt] | semmle.label | a [MyInt] |
+| main.rs:319:13:319:38 | MyInt {...} [MyInt] | semmle.label | MyInt {...} [MyInt] |
+| main.rs:319:28:319:36 | source(...) | semmle.label | source(...) |
+| main.rs:321:9:321:26 | MyInt {...} [MyInt] | semmle.label | MyInt {...} [MyInt] |
+| main.rs:321:24:321:24 | c | semmle.label | c |
+| main.rs:321:30:321:54 | ...::take_self(...) [MyInt] | semmle.label | ...::take_self(...) [MyInt] |
+| main.rs:321:50:321:50 | a [MyInt] | semmle.label | a [MyInt] |
+| main.rs:322:10:322:10 | c | semmle.label | c |
+| main.rs:325:9:325:9 | b [MyInt] | semmle.label | b [MyInt] |
+| main.rs:325:13:325:39 | MyInt {...} [MyInt] | semmle.label | MyInt {...} [MyInt] |
+| main.rs:325:28:325:37 | source(...) | semmle.label | source(...) |
+| main.rs:326:9:326:26 | MyInt {...} [MyInt] | semmle.label | MyInt {...} [MyInt] |
+| main.rs:326:24:326:24 | c | semmle.label | c |
+| main.rs:326:30:326:56 | ...::take_second(...) [MyInt] | semmle.label | ...::take_second(...) [MyInt] |
+| main.rs:326:55:326:55 | b [MyInt] | semmle.label | b [MyInt] |
+| main.rs:327:10:327:10 | c | semmle.label | c |
+| main.rs:335:32:339:1 | { ... } | semmle.label | { ... } |
+| main.rs:336:9:336:9 | a | semmle.label | a |
+| main.rs:336:13:336:21 | source(...) | semmle.label | source(...) |
+| main.rs:337:10:337:10 | a | semmle.label | a |
+| main.rs:342:9:342:9 | a | semmle.label | a |
+| main.rs:342:13:342:26 | async_source(...) | semmle.label | async_source(...) |
+| main.rs:343:10:343:10 | a | semmle.label | a |
+| main.rs:346:13:346:13 | c | semmle.label | c |
+| main.rs:346:17:346:25 | source(...) | semmle.label | source(...) |
+| main.rs:347:14:347:14 | c | semmle.label | c |
+| main.rs:354:9:354:9 | a | semmle.label | a |
+| main.rs:354:13:354:55 | ...::block_on(...) | semmle.label | ...::block_on(...) |
+| main.rs:354:41:354:54 | async_source(...) | semmle.label | async_source(...) |
+| main.rs:355:10:355:10 | a | semmle.label | a |
+| main.rs:366:44:368:9 | { ... } | semmle.label | { ... } |
+| main.rs:367:13:367:29 | self.get_number() | semmle.label | self.get_number() |
+| main.rs:367:13:367:33 | ... * ... | semmle.label | ... * ... |
+| main.rs:370:33:372:9 | { ... } | semmle.label | { ... } |
+| main.rs:371:13:371:21 | source(...) | semmle.label | source(...) |
+| main.rs:378:37:380:9 | { ... } | semmle.label | { ... } |
+| main.rs:379:13:379:21 | source(...) | semmle.label | source(...) |
+| main.rs:390:44:392:9 | { ... } | semmle.label | { ... } |
+| main.rs:391:13:391:22 | source(...) | semmle.label | source(...) |
+| main.rs:394:33:396:9 | { ... } | semmle.label | { ... } |
+| main.rs:395:13:395:21 | source(...) | semmle.label | source(...) |
+| main.rs:403:13:403:14 | n1 | semmle.label | n1 |
+| main.rs:403:18:403:38 | t.get_double_number() | semmle.label | t.get_double_number() |
+| main.rs:404:14:404:15 | n1 | semmle.label | n1 |
+| main.rs:407:13:407:14 | n2 | semmle.label | n2 |
+| main.rs:407:18:407:50 | ...::get_double_number(...) | semmle.label | ...::get_double_number(...) |
+| main.rs:408:14:408:15 | n2 | semmle.label | n2 |
+| main.rs:411:13:411:14 | n3 | semmle.label | n3 |
+| main.rs:411:18:411:37 | ...::get_default(...) | semmle.label | ...::get_default(...) |
+| main.rs:412:14:412:15 | n3 | semmle.label | n3 |
+| main.rs:415:13:415:14 | n4 | semmle.label | n4 |
+| main.rs:415:18:415:38 | i.get_double_number() | semmle.label | i.get_double_number() |
+| main.rs:416:14:416:15 | n4 | semmle.label | n4 |
+| main.rs:418:13:418:14 | n5 | semmle.label | n5 |
+| main.rs:418:18:418:41 | ...::get_default(...) | semmle.label | ...::get_default(...) |
+| main.rs:419:14:419:15 | n5 | semmle.label | n5 |
 subpaths
 | main.rs:38:23:38:31 | source(...) | main.rs:26:28:26:33 | ...: i64 | main.rs:26:17:26:25 | SelfParam [Return] [&ref, MyStruct] | main.rs:38:6:38:11 | [post] &mut a [&ref, MyStruct] |
 | main.rs:39:10:39:10 | a [MyStruct] | main.rs:30:17:30:21 | SelfParam [&ref, MyStruct] | main.rs:30:31:32:5 | { ... } | main.rs:39:10:39:21 | a.get_data() |
@@ -466,19 +466,19 @@ subpaths
 | main.rs:67:26:67:26 | a | main.rs:61:17:61:22 | ...: i64 | main.rs:61:32:63:1 | { ... } | main.rs:67:13:67:27 | pass_through(...) |
 | main.rs:72:26:75:5 | { ... } | main.rs:61:17:61:22 | ...: i64 | main.rs:61:32:63:1 | { ... } | main.rs:72:13:75:6 | pass_through(...) |
 | main.rs:86:26:86:26 | a | main.rs:82:21:82:26 | ...: i64 | main.rs:82:36:84:5 | { ... } | main.rs:86:13:86:27 | pass_through(...) |
-| main.rs:167:34:167:34 | a | main.rs:126:33:126:38 | ...: i64 | main.rs:126:48:128:5 | { ... } | main.rs:167:13:167:35 | x.data_through_trait(...) |
-| main.rs:174:29:174:29 | a | main.rs:112:27:112:32 | ...: i64 | main.rs:112:42:114:5 | { ... } | main.rs:174:13:174:30 | mn.data_through(...) |
-| main.rs:179:35:179:35 | a | main.rs:126:33:126:38 | ...: i64 | main.rs:126:48:128:5 | { ... } | main.rs:179:13:179:36 | mn.data_through_trait(...) |
-| main.rs:194:38:194:38 | a | main.rs:112:27:112:32 | ...: i64 | main.rs:112:42:114:5 | { ... } | main.rs:194:13:194:39 | ...::data_through(...) |
-| main.rs:212:24:212:33 | source(...) | main.rs:206:12:206:17 | ...: i64 | main.rs:206:28:208:5 | { ... } [MyInt] | main.rs:212:13:212:34 | ...::new(...) [MyInt] |
-| main.rs:244:13:244:13 | a [MyInt] | main.rs:220:12:220:15 | SelfParam [MyInt] | main.rs:220:42:223:5 | { ... } [MyInt] | main.rs:244:13:244:17 | ... + ... [MyInt] |
-| main.rs:254:13:254:13 | a [MyInt] | main.rs:220:12:220:15 | SelfParam [MyInt] | main.rs:220:42:223:5 | { ... } [MyInt] | main.rs:254:13:254:20 | a.add(...) [MyInt] |
-| main.rs:261:35:261:35 | b [MyInt] | main.rs:227:30:227:39 | ...: MyInt [MyInt] | main.rs:227:19:227:27 | SelfParam [Return] [&ref, MyInt] | main.rs:261:27:261:32 | [post] &mut a [&ref, MyInt] |
-| main.rs:266:10:266:10 | b [MyInt] | main.rs:227:30:227:39 | ...: MyInt [MyInt] | main.rs:227:19:227:27 | SelfParam [Return] [&ref, MyInt] | main.rs:267:10:267:10 | a [MyInt] |
-| main.rs:272:27:272:28 | &a [&ref, MyInt] | main.rs:235:14:235:18 | SelfParam [&ref, MyInt] | main.rs:235:38:237:5 | { ... } [&ref] | main.rs:272:14:272:29 | ...::deref(...) [&ref] |
-| main.rs:276:14:276:14 | a [MyInt] | main.rs:235:14:235:18 | SelfParam [&ref, MyInt] | main.rs:235:38:237:5 | { ... } [&ref] | main.rs:276:13:276:14 | * ... |
-| main.rs:301:50:301:50 | a [MyInt] | main.rs:289:18:289:21 | SelfParam [MyInt] | main.rs:289:48:291:5 | { ... } [MyInt] | main.rs:301:30:301:54 | ...::take_self(...) [MyInt] |
-| main.rs:306:55:306:55 | b [MyInt] | main.rs:293:26:293:37 | ...: MyInt [MyInt] | main.rs:293:49:295:5 | { ... } [MyInt] | main.rs:306:30:306:56 | ...::take_second(...) [MyInt] |
+| main.rs:183:34:183:34 | a | main.rs:138:33:138:38 | ...: i64 | main.rs:138:48:144:5 | { ... } | main.rs:183:13:183:35 | x.data_through_trait(...) |
+| main.rs:190:29:190:29 | a | main.rs:116:27:116:32 | ...: i64 | main.rs:116:42:122:5 | { ... } | main.rs:190:13:190:30 | mn.data_through(...) |
+| main.rs:195:35:195:35 | a | main.rs:138:33:138:38 | ...: i64 | main.rs:138:48:144:5 | { ... } | main.rs:195:13:195:36 | mn.data_through_trait(...) |
+| main.rs:210:38:210:38 | a | main.rs:116:27:116:32 | ...: i64 | main.rs:116:42:122:5 | { ... } | main.rs:210:13:210:39 | ...::data_through(...) |
+| main.rs:228:24:228:33 | source(...) | main.rs:222:12:222:17 | ...: i64 | main.rs:222:28:224:5 | { ... } [MyInt] | main.rs:228:13:228:34 | ...::new(...) [MyInt] |
+| main.rs:260:13:260:13 | a [MyInt] | main.rs:236:12:236:15 | SelfParam [MyInt] | main.rs:236:42:239:5 | { ... } [MyInt] | main.rs:260:13:260:17 | ... + ... [MyInt] |
+| main.rs:270:13:270:13 | a [MyInt] | main.rs:236:12:236:15 | SelfParam [MyInt] | main.rs:236:42:239:5 | { ... } [MyInt] | main.rs:270:13:270:20 | a.add(...) [MyInt] |
+| main.rs:277:35:277:35 | b [MyInt] | main.rs:243:30:243:39 | ...: MyInt [MyInt] | main.rs:243:19:243:27 | SelfParam [Return] [&ref, MyInt] | main.rs:277:27:277:32 | [post] &mut a [&ref, MyInt] |
+| main.rs:282:10:282:10 | b [MyInt] | main.rs:243:30:243:39 | ...: MyInt [MyInt] | main.rs:243:19:243:27 | SelfParam [Return] [&ref, MyInt] | main.rs:283:10:283:10 | a [MyInt] |
+| main.rs:288:27:288:28 | &a [&ref, MyInt] | main.rs:251:14:251:18 | SelfParam [&ref, MyInt] | main.rs:251:38:253:5 | { ... } [&ref] | main.rs:288:14:288:29 | ...::deref(...) [&ref] |
+| main.rs:292:14:292:14 | a [MyInt] | main.rs:251:14:251:18 | SelfParam [&ref, MyInt] | main.rs:251:38:253:5 | { ... } [&ref] | main.rs:292:13:292:14 | * ... |
+| main.rs:321:50:321:50 | a [MyInt] | main.rs:309:18:309:21 | SelfParam [MyInt] | main.rs:309:48:311:5 | { ... } [MyInt] | main.rs:321:30:321:54 | ...::take_self(...) [MyInt] |
+| main.rs:326:55:326:55 | b [MyInt] | main.rs:313:26:313:37 | ...: MyInt [MyInt] | main.rs:313:49:315:5 | { ... } [MyInt] | main.rs:326:30:326:56 | ...::take_second(...) [MyInt] |
 testFailures
 #select
 | main.rs:18:10:18:10 | a | main.rs:13:5:13:13 | source(...) | main.rs:18:10:18:10 | a | $@ | main.rs:13:5:13:13 | source(...) | source(...) |
@@ -488,32 +488,32 @@ testFailures
 | main.rs:68:10:68:10 | b | main.rs:66:13:66:21 | source(...) | main.rs:68:10:68:10 | b | $@ | main.rs:66:13:66:21 | source(...) | source(...) |
 | main.rs:76:10:76:10 | a | main.rs:74:9:74:18 | source(...) | main.rs:76:10:76:10 | a | $@ | main.rs:74:9:74:18 | source(...) | source(...) |
 | main.rs:87:10:87:10 | b | main.rs:80:13:80:22 | source(...) | main.rs:87:10:87:10 | b | $@ | main.rs:80:13:80:22 | source(...) | source(...) |
-| main.rs:105:14:105:14 | n | main.rs:155:13:155:21 | source(...) | main.rs:105:14:105:14 | n | $@ | main.rs:155:13:155:21 | source(...) | source(...) |
-| main.rs:105:14:105:14 | n | main.rs:187:13:187:21 | source(...) | main.rs:105:14:105:14 | n | $@ | main.rs:187:13:187:21 | source(...) | source(...) |
-| main.rs:119:14:119:14 | n | main.rs:149:13:149:22 | source(...) | main.rs:119:14:119:14 | n | $@ | main.rs:149:13:149:22 | source(...) | source(...) |
-| main.rs:119:14:119:14 | n | main.rs:159:13:159:22 | source(...) | main.rs:119:14:119:14 | n | $@ | main.rs:159:13:159:22 | source(...) | source(...) |
-| main.rs:133:10:133:10 | a | main.rs:123:35:123:44 | source(...) | main.rs:133:10:133:10 | a | $@ | main.rs:123:35:123:44 | source(...) | source(...) |
-| main.rs:139:10:139:10 | a | main.rs:109:35:109:43 | source(...) | main.rs:139:10:139:10 | a | $@ | main.rs:109:35:109:43 | source(...) | source(...) |
-| main.rs:143:10:143:10 | a | main.rs:123:35:123:44 | source(...) | main.rs:143:10:143:10 | a | $@ | main.rs:123:35:123:44 | source(...) | source(...) |
-| main.rs:168:10:168:10 | b | main.rs:166:13:166:22 | source(...) | main.rs:168:10:168:10 | b | $@ | main.rs:166:13:166:22 | source(...) | source(...) |
-| main.rs:175:10:175:10 | b | main.rs:173:13:173:21 | source(...) | main.rs:175:10:175:10 | b | $@ | main.rs:173:13:173:21 | source(...) | source(...) |
-| main.rs:180:10:180:10 | b | main.rs:178:13:178:22 | source(...) | main.rs:180:10:180:10 | b | $@ | main.rs:178:13:178:22 | source(...) | source(...) |
-| main.rs:195:10:195:10 | b | main.rs:193:13:193:22 | source(...) | main.rs:195:10:195:10 | b | $@ | main.rs:193:13:193:22 | source(...) | source(...) |
-| main.rs:214:10:214:10 | m | main.rs:212:24:212:33 | source(...) | main.rs:214:10:214:10 | m | $@ | main.rs:212:24:212:33 | source(...) | source(...) |
-| main.rs:245:10:245:16 | c.value | main.rs:242:28:242:36 | source(...) | main.rs:245:10:245:16 | c.value | $@ | main.rs:242:28:242:36 | source(...) | source(...) |
-| main.rs:255:10:255:16 | d.value | main.rs:252:28:252:36 | source(...) | main.rs:255:10:255:16 | d.value | $@ | main.rs:252:28:252:36 | source(...) | source(...) |
-| main.rs:262:10:262:16 | a.value | main.rs:259:28:259:37 | source(...) | main.rs:262:10:262:16 | a.value | $@ | main.rs:259:28:259:37 | source(...) | source(...) |
-| main.rs:267:10:267:16 | a.value | main.rs:265:28:265:37 | source(...) | main.rs:267:10:267:16 | a.value | $@ | main.rs:265:28:265:37 | source(...) | source(...) |
-| main.rs:273:10:273:10 | c | main.rs:270:28:270:37 | source(...) | main.rs:273:10:273:10 | c | $@ | main.rs:270:28:270:37 | source(...) | source(...) |
-| main.rs:277:10:277:10 | c | main.rs:275:28:275:37 | source(...) | main.rs:277:10:277:10 | c | $@ | main.rs:275:28:275:37 | source(...) | source(...) |
-| main.rs:302:10:302:10 | c | main.rs:299:28:299:36 | source(...) | main.rs:302:10:302:10 | c | $@ | main.rs:299:28:299:36 | source(...) | source(...) |
-| main.rs:307:10:307:10 | c | main.rs:305:28:305:37 | source(...) | main.rs:307:10:307:10 | c | $@ | main.rs:305:28:305:37 | source(...) | source(...) |
-| main.rs:317:10:317:10 | a | main.rs:316:13:316:21 | source(...) | main.rs:317:10:317:10 | a | $@ | main.rs:316:13:316:21 | source(...) | source(...) |
-| main.rs:323:10:323:10 | a | main.rs:316:13:316:21 | source(...) | main.rs:323:10:323:10 | a | $@ | main.rs:316:13:316:21 | source(...) | source(...) |
-| main.rs:327:14:327:14 | c | main.rs:326:17:326:25 | source(...) | main.rs:327:14:327:14 | c | $@ | main.rs:326:17:326:25 | source(...) | source(...) |
-| main.rs:335:10:335:10 | a | main.rs:316:13:316:21 | source(...) | main.rs:335:10:335:10 | a | $@ | main.rs:316:13:316:21 | source(...) | source(...) |
-| main.rs:384:14:384:15 | n1 | main.rs:359:13:359:21 | source(...) | main.rs:384:14:384:15 | n1 | $@ | main.rs:359:13:359:21 | source(...) | source(...) |
-| main.rs:388:14:388:15 | n2 | main.rs:359:13:359:21 | source(...) | main.rs:388:14:388:15 | n2 | $@ | main.rs:359:13:359:21 | source(...) | source(...) |
-| main.rs:392:14:392:15 | n3 | main.rs:351:13:351:21 | source(...) | main.rs:392:14:392:15 | n3 | $@ | main.rs:351:13:351:21 | source(...) | source(...) |
-| main.rs:396:14:396:15 | n4 | main.rs:371:13:371:22 | source(...) | main.rs:396:14:396:15 | n4 | $@ | main.rs:371:13:371:22 | source(...) | source(...) |
-| main.rs:399:14:399:15 | n5 | main.rs:375:13:375:21 | source(...) | main.rs:399:14:399:15 | n5 | $@ | main.rs:375:13:375:21 | source(...) | source(...) |
+| main.rs:105:14:105:14 | n | main.rs:171:13:171:21 | source(...) | main.rs:105:14:105:14 | n | $@ | main.rs:171:13:171:21 | source(...) | source(...) |
+| main.rs:105:14:105:14 | n | main.rs:203:13:203:21 | source(...) | main.rs:105:14:105:14 | n | $@ | main.rs:203:13:203:21 | source(...) | source(...) |
+| main.rs:127:14:127:14 | n | main.rs:165:13:165:22 | source(...) | main.rs:127:14:127:14 | n | $@ | main.rs:165:13:165:22 | source(...) | source(...) |
+| main.rs:127:14:127:14 | n | main.rs:175:13:175:22 | source(...) | main.rs:127:14:127:14 | n | $@ | main.rs:175:13:175:22 | source(...) | source(...) |
+| main.rs:149:10:149:10 | a | main.rs:134:13:134:22 | source(...) | main.rs:149:10:149:10 | a | $@ | main.rs:134:13:134:22 | source(...) | source(...) |
+| main.rs:155:10:155:10 | a | main.rs:112:13:112:21 | source(...) | main.rs:155:10:155:10 | a | $@ | main.rs:112:13:112:21 | source(...) | source(...) |
+| main.rs:159:10:159:10 | a | main.rs:134:13:134:22 | source(...) | main.rs:159:10:159:10 | a | $@ | main.rs:134:13:134:22 | source(...) | source(...) |
+| main.rs:184:10:184:10 | b | main.rs:182:13:182:22 | source(...) | main.rs:184:10:184:10 | b | $@ | main.rs:182:13:182:22 | source(...) | source(...) |
+| main.rs:191:10:191:10 | b | main.rs:189:13:189:21 | source(...) | main.rs:191:10:191:10 | b | $@ | main.rs:189:13:189:21 | source(...) | source(...) |
+| main.rs:196:10:196:10 | b | main.rs:194:13:194:22 | source(...) | main.rs:196:10:196:10 | b | $@ | main.rs:194:13:194:22 | source(...) | source(...) |
+| main.rs:211:10:211:10 | b | main.rs:209:13:209:22 | source(...) | main.rs:211:10:211:10 | b | $@ | main.rs:209:13:209:22 | source(...) | source(...) |
+| main.rs:230:10:230:10 | m | main.rs:228:24:228:33 | source(...) | main.rs:230:10:230:10 | m | $@ | main.rs:228:24:228:33 | source(...) | source(...) |
+| main.rs:261:10:261:16 | c.value | main.rs:258:28:258:36 | source(...) | main.rs:261:10:261:16 | c.value | $@ | main.rs:258:28:258:36 | source(...) | source(...) |
+| main.rs:271:10:271:16 | d.value | main.rs:268:28:268:36 | source(...) | main.rs:271:10:271:16 | d.value | $@ | main.rs:268:28:268:36 | source(...) | source(...) |
+| main.rs:278:10:278:16 | a.value | main.rs:275:28:275:37 | source(...) | main.rs:278:10:278:16 | a.value | $@ | main.rs:275:28:275:37 | source(...) | source(...) |
+| main.rs:283:10:283:16 | a.value | main.rs:281:28:281:37 | source(...) | main.rs:283:10:283:16 | a.value | $@ | main.rs:281:28:281:37 | source(...) | source(...) |
+| main.rs:289:10:289:10 | c | main.rs:286:28:286:37 | source(...) | main.rs:289:10:289:10 | c | $@ | main.rs:286:28:286:37 | source(...) | source(...) |
+| main.rs:293:10:293:10 | c | main.rs:291:28:291:37 | source(...) | main.rs:293:10:293:10 | c | $@ | main.rs:291:28:291:37 | source(...) | source(...) |
+| main.rs:322:10:322:10 | c | main.rs:319:28:319:36 | source(...) | main.rs:322:10:322:10 | c | $@ | main.rs:319:28:319:36 | source(...) | source(...) |
+| main.rs:327:10:327:10 | c | main.rs:325:28:325:37 | source(...) | main.rs:327:10:327:10 | c | $@ | main.rs:325:28:325:37 | source(...) | source(...) |
+| main.rs:337:10:337:10 | a | main.rs:336:13:336:21 | source(...) | main.rs:337:10:337:10 | a | $@ | main.rs:336:13:336:21 | source(...) | source(...) |
+| main.rs:343:10:343:10 | a | main.rs:336:13:336:21 | source(...) | main.rs:343:10:343:10 | a | $@ | main.rs:336:13:336:21 | source(...) | source(...) |
+| main.rs:347:14:347:14 | c | main.rs:346:17:346:25 | source(...) | main.rs:347:14:347:14 | c | $@ | main.rs:346:17:346:25 | source(...) | source(...) |
+| main.rs:355:10:355:10 | a | main.rs:336:13:336:21 | source(...) | main.rs:355:10:355:10 | a | $@ | main.rs:336:13:336:21 | source(...) | source(...) |
+| main.rs:404:14:404:15 | n1 | main.rs:379:13:379:21 | source(...) | main.rs:404:14:404:15 | n1 | $@ | main.rs:379:13:379:21 | source(...) | source(...) |
+| main.rs:408:14:408:15 | n2 | main.rs:379:13:379:21 | source(...) | main.rs:408:14:408:15 | n2 | $@ | main.rs:379:13:379:21 | source(...) | source(...) |
+| main.rs:412:14:412:15 | n3 | main.rs:371:13:371:21 | source(...) | main.rs:412:14:412:15 | n3 | $@ | main.rs:371:13:371:21 | source(...) | source(...) |
+| main.rs:416:14:416:15 | n4 | main.rs:391:13:391:22 | source(...) | main.rs:416:14:416:15 | n4 | $@ | main.rs:391:13:391:22 | source(...) | source(...) |
+| main.rs:419:14:419:15 | n5 | main.rs:395:13:395:21 | source(...) | main.rs:419:14:419:15 | n5 | $@ | main.rs:395:13:395:21 | source(...) | source(...) |

--- a/rust/ql/test/library-tests/dataflow/global/main.rs
+++ b/rust/ql/test/library-tests/dataflow/global/main.rs
@@ -106,11 +106,19 @@ impl MyFlag {
     }
 
     fn get_data(self) -> i64 {
-        if self.flag { 0 } else { source(2) }
+        if self.flag {
+            0
+        } else {
+            source(2)
+        }
     }
 
     fn data_through(self, n: i64) -> i64 {
-        if self.flag { 0 } else { n }
+        if self.flag {
+            0
+        } else {
+            n
+        }
     }
 }
 
@@ -120,11 +128,19 @@ impl MyTrait for MyFlag {
     }
 
     fn get_data_trait(self) -> i64 {
-        if self.flag { 0 } else { source(21) }
+        if self.flag {
+            0
+        } else {
+            source(21)
+        }
     }
 
     fn data_through_trait(self, n: i64) -> i64 {
-        if self.flag { 0 } else { n }
+        if self.flag {
+            0
+        } else {
+            n
+        }
     }
 }
 
@@ -275,6 +291,10 @@ fn test_operator_overloading() {
     let a = MyInt { value: source(28) };
     let c = *a;
     sink(c); // $ hasValueFlow=28
+
+    let a = MyInt { value: source(29) };
+    let c = a.min(1042);
+    sink(c); // $ MISSING: hasValueFlow=29
 }
 
 trait MyTrait2 {

--- a/rust/ql/test/library-tests/dataflow/global/viableCallable.expected
+++ b/rust/ql/test/library-tests/dataflow/global/viableCallable.expected
@@ -25,112 +25,114 @@
 | main.rs:86:13:86:27 | pass_through(...) | main.rs:82:5:84:5 | fn pass_through |
 | main.rs:87:5:87:11 | sink(...) | main.rs:5:1:7:1 | fn sink |
 | main.rs:105:9:105:15 | sink(...) | main.rs:5:1:7:1 | fn sink |
-| main.rs:109:35:109:43 | source(...) | main.rs:1:1:3:1 | fn source |
-| main.rs:119:9:119:15 | sink(...) | main.rs:5:1:7:1 | fn sink |
-| main.rs:123:35:123:44 | source(...) | main.rs:1:1:3:1 | fn source |
-| main.rs:132:13:132:30 | x.get_data_trait() | main.rs:122:5:124:5 | fn get_data_trait |
-| main.rs:133:5:133:11 | sink(...) | main.rs:5:1:7:1 | fn sink |
-| main.rs:138:13:138:25 | mn.get_data() | main.rs:108:5:110:5 | fn get_data |
-| main.rs:139:5:139:11 | sink(...) | main.rs:5:1:7:1 | fn sink |
-| main.rs:142:13:142:31 | mn.get_data_trait() | main.rs:122:5:124:5 | fn get_data_trait |
-| main.rs:143:5:143:11 | sink(...) | main.rs:5:1:7:1 | fn sink |
-| main.rs:145:5:145:60 | data_out_of_method_trait_dispatch(...) | main.rs:131:1:134:1 | fn data_out_of_method_trait_dispatch |
-| main.rs:149:13:149:22 | source(...) | main.rs:1:1:3:1 | fn source |
-| main.rs:150:5:150:22 | x.data_in_trait(...) | main.rs:118:5:120:5 | fn data_in_trait |
-| main.rs:155:13:155:21 | source(...) | main.rs:1:1:3:1 | fn source |
-| main.rs:156:5:156:17 | mn.data_in(...) | main.rs:104:5:106:5 | fn data_in |
-| main.rs:159:13:159:22 | source(...) | main.rs:1:1:3:1 | fn source |
-| main.rs:160:5:160:23 | mn.data_in_trait(...) | main.rs:118:5:120:5 | fn data_in_trait |
-| main.rs:162:5:162:64 | data_in_to_method_call_trait_dispatch(...) | main.rs:148:1:151:1 | fn data_in_to_method_call_trait_dispatch |
-| main.rs:166:13:166:22 | source(...) | main.rs:1:1:3:1 | fn source |
-| main.rs:167:13:167:35 | x.data_through_trait(...) | main.rs:126:5:128:5 | fn data_through_trait |
-| main.rs:168:5:168:11 | sink(...) | main.rs:5:1:7:1 | fn sink |
-| main.rs:173:13:173:21 | source(...) | main.rs:1:1:3:1 | fn source |
-| main.rs:174:13:174:30 | mn.data_through(...) | main.rs:112:5:114:5 | fn data_through |
-| main.rs:175:5:175:11 | sink(...) | main.rs:5:1:7:1 | fn sink |
-| main.rs:178:13:178:22 | source(...) | main.rs:1:1:3:1 | fn source |
-| main.rs:179:13:179:36 | mn.data_through_trait(...) | main.rs:126:5:128:5 | fn data_through_trait |
-| main.rs:180:5:180:11 | sink(...) | main.rs:5:1:7:1 | fn sink |
-| main.rs:182:5:182:61 | data_through_method_trait_dispatch(...) | main.rs:165:1:169:1 | fn data_through_method_trait_dispatch |
-| main.rs:187:13:187:21 | source(...) | main.rs:1:1:3:1 | fn source |
-| main.rs:188:5:188:26 | ...::data_in(...) | main.rs:104:5:106:5 | fn data_in |
-| main.rs:193:13:193:22 | source(...) | main.rs:1:1:3:1 | fn source |
-| main.rs:194:13:194:39 | ...::data_through(...) | main.rs:112:5:114:5 | fn data_through |
-| main.rs:195:5:195:11 | sink(...) | main.rs:5:1:7:1 | fn sink |
-| main.rs:212:13:212:34 | ...::new(...) | main.rs:205:5:208:5 | fn new |
-| main.rs:212:24:212:33 | source(...) | main.rs:1:1:3:1 | fn source |
-| main.rs:214:5:214:11 | sink(...) | main.rs:5:1:7:1 | fn sink |
-| main.rs:236:11:236:15 | * ... | {EXTERNAL LOCATION} | fn deref |
-| main.rs:236:11:236:15 | * ... | {EXTERNAL LOCATION} | fn deref |
-| main.rs:242:28:242:36 | source(...) | main.rs:1:1:3:1 | fn source |
-| main.rs:244:13:244:17 | ... + ... | main.rs:220:5:223:5 | fn add |
-| main.rs:245:5:245:17 | sink(...) | main.rs:5:1:7:1 | fn sink |
-| main.rs:248:28:248:36 | source(...) | main.rs:1:1:3:1 | fn source |
-| main.rs:249:13:249:17 | ... + ... | main.rs:220:5:223:5 | fn add |
-| main.rs:250:5:250:17 | sink(...) | main.rs:5:1:7:1 | fn sink |
-| main.rs:252:28:252:36 | source(...) | main.rs:1:1:3:1 | fn source |
-| main.rs:254:13:254:20 | a.add(...) | main.rs:220:5:223:5 | fn add |
-| main.rs:255:5:255:17 | sink(...) | main.rs:5:1:7:1 | fn sink |
-| main.rs:259:28:259:37 | source(...) | main.rs:1:1:3:1 | fn source |
-| main.rs:261:5:261:36 | ...::mul_assign(...) | main.rs:227:5:229:5 | fn mul_assign |
-| main.rs:262:5:262:17 | sink(...) | main.rs:5:1:7:1 | fn sink |
-| main.rs:265:28:265:37 | source(...) | main.rs:1:1:3:1 | fn source |
-| main.rs:266:5:266:10 | ... *= ... | main.rs:227:5:229:5 | fn mul_assign |
-| main.rs:267:5:267:17 | sink(...) | main.rs:5:1:7:1 | fn sink |
-| main.rs:270:28:270:37 | source(...) | main.rs:1:1:3:1 | fn source |
-| main.rs:272:13:272:29 | * ... | {EXTERNAL LOCATION} | fn deref |
-| main.rs:272:13:272:29 | * ... | {EXTERNAL LOCATION} | fn deref |
-| main.rs:272:14:272:29 | ...::deref(...) | main.rs:235:5:237:5 | fn deref |
-| main.rs:273:5:273:11 | sink(...) | main.rs:5:1:7:1 | fn sink |
+| main.rs:112:13:112:21 | source(...) | main.rs:1:1:3:1 | fn source |
+| main.rs:127:9:127:15 | sink(...) | main.rs:5:1:7:1 | fn sink |
+| main.rs:134:13:134:22 | source(...) | main.rs:1:1:3:1 | fn source |
+| main.rs:148:13:148:30 | x.get_data_trait() | main.rs:130:5:136:5 | fn get_data_trait |
+| main.rs:149:5:149:11 | sink(...) | main.rs:5:1:7:1 | fn sink |
+| main.rs:154:13:154:25 | mn.get_data() | main.rs:108:5:114:5 | fn get_data |
+| main.rs:155:5:155:11 | sink(...) | main.rs:5:1:7:1 | fn sink |
+| main.rs:158:13:158:31 | mn.get_data_trait() | main.rs:130:5:136:5 | fn get_data_trait |
+| main.rs:159:5:159:11 | sink(...) | main.rs:5:1:7:1 | fn sink |
+| main.rs:161:5:161:60 | data_out_of_method_trait_dispatch(...) | main.rs:147:1:150:1 | fn data_out_of_method_trait_dispatch |
+| main.rs:165:13:165:22 | source(...) | main.rs:1:1:3:1 | fn source |
+| main.rs:166:5:166:22 | x.data_in_trait(...) | main.rs:126:5:128:5 | fn data_in_trait |
+| main.rs:171:13:171:21 | source(...) | main.rs:1:1:3:1 | fn source |
+| main.rs:172:5:172:17 | mn.data_in(...) | main.rs:104:5:106:5 | fn data_in |
+| main.rs:175:13:175:22 | source(...) | main.rs:1:1:3:1 | fn source |
+| main.rs:176:5:176:23 | mn.data_in_trait(...) | main.rs:126:5:128:5 | fn data_in_trait |
+| main.rs:178:5:178:64 | data_in_to_method_call_trait_dispatch(...) | main.rs:164:1:167:1 | fn data_in_to_method_call_trait_dispatch |
+| main.rs:182:13:182:22 | source(...) | main.rs:1:1:3:1 | fn source |
+| main.rs:183:13:183:35 | x.data_through_trait(...) | main.rs:138:5:144:5 | fn data_through_trait |
+| main.rs:184:5:184:11 | sink(...) | main.rs:5:1:7:1 | fn sink |
+| main.rs:189:13:189:21 | source(...) | main.rs:1:1:3:1 | fn source |
+| main.rs:190:13:190:30 | mn.data_through(...) | main.rs:116:5:122:5 | fn data_through |
+| main.rs:191:5:191:11 | sink(...) | main.rs:5:1:7:1 | fn sink |
+| main.rs:194:13:194:22 | source(...) | main.rs:1:1:3:1 | fn source |
+| main.rs:195:13:195:36 | mn.data_through_trait(...) | main.rs:138:5:144:5 | fn data_through_trait |
+| main.rs:196:5:196:11 | sink(...) | main.rs:5:1:7:1 | fn sink |
+| main.rs:198:5:198:61 | data_through_method_trait_dispatch(...) | main.rs:181:1:185:1 | fn data_through_method_trait_dispatch |
+| main.rs:203:13:203:21 | source(...) | main.rs:1:1:3:1 | fn source |
+| main.rs:204:5:204:26 | ...::data_in(...) | main.rs:104:5:106:5 | fn data_in |
+| main.rs:209:13:209:22 | source(...) | main.rs:1:1:3:1 | fn source |
+| main.rs:210:13:210:39 | ...::data_through(...) | main.rs:116:5:122:5 | fn data_through |
+| main.rs:211:5:211:11 | sink(...) | main.rs:5:1:7:1 | fn sink |
+| main.rs:228:13:228:34 | ...::new(...) | main.rs:221:5:224:5 | fn new |
+| main.rs:228:24:228:33 | source(...) | main.rs:1:1:3:1 | fn source |
+| main.rs:230:5:230:11 | sink(...) | main.rs:5:1:7:1 | fn sink |
+| main.rs:252:11:252:15 | * ... | {EXTERNAL LOCATION} | fn deref |
+| main.rs:252:11:252:15 | * ... | {EXTERNAL LOCATION} | fn deref |
+| main.rs:258:28:258:36 | source(...) | main.rs:1:1:3:1 | fn source |
+| main.rs:260:13:260:17 | ... + ... | main.rs:236:5:239:5 | fn add |
+| main.rs:261:5:261:17 | sink(...) | main.rs:5:1:7:1 | fn sink |
+| main.rs:264:28:264:36 | source(...) | main.rs:1:1:3:1 | fn source |
+| main.rs:265:13:265:17 | ... + ... | main.rs:236:5:239:5 | fn add |
+| main.rs:266:5:266:17 | sink(...) | main.rs:5:1:7:1 | fn sink |
+| main.rs:268:28:268:36 | source(...) | main.rs:1:1:3:1 | fn source |
+| main.rs:270:13:270:20 | a.add(...) | main.rs:236:5:239:5 | fn add |
+| main.rs:271:5:271:17 | sink(...) | main.rs:5:1:7:1 | fn sink |
 | main.rs:275:28:275:37 | source(...) | main.rs:1:1:3:1 | fn source |
-| main.rs:276:13:276:14 | * ... | main.rs:235:5:237:5 | fn deref |
-| main.rs:277:5:277:11 | sink(...) | main.rs:5:1:7:1 | fn sink |
-| main.rs:299:28:299:36 | source(...) | main.rs:1:1:3:1 | fn source |
-| main.rs:301:30:301:54 | ...::take_self(...) | main.rs:289:5:291:5 | fn take_self |
-| main.rs:302:5:302:11 | sink(...) | main.rs:5:1:7:1 | fn sink |
-| main.rs:305:28:305:37 | source(...) | main.rs:1:1:3:1 | fn source |
-| main.rs:306:30:306:56 | ...::take_second(...) | main.rs:293:5:295:5 | fn take_second |
-| main.rs:307:5:307:11 | sink(...) | main.rs:5:1:7:1 | fn sink |
-| main.rs:310:28:310:37 | source(...) | main.rs:1:1:3:1 | fn source |
-| main.rs:311:30:311:54 | ...::take_self(...) | main.rs:289:5:291:5 | fn take_self |
-| main.rs:312:5:312:11 | sink(...) | main.rs:5:1:7:1 | fn sink |
-| main.rs:316:13:316:21 | source(...) | main.rs:1:1:3:1 | fn source |
-| main.rs:317:5:317:11 | sink(...) | main.rs:5:1:7:1 | fn sink |
-| main.rs:322:13:322:26 | async_source(...) | main.rs:315:1:319:1 | fn async_source |
-| main.rs:323:5:323:11 | sink(...) | main.rs:5:1:7:1 | fn sink |
-| main.rs:326:17:326:25 | source(...) | main.rs:1:1:3:1 | fn source |
-| main.rs:327:9:327:15 | sink(...) | main.rs:5:1:7:1 | fn sink |
-| main.rs:330:5:330:17 | sink(...) | main.rs:5:1:7:1 | fn sink |
-| main.rs:334:13:334:55 | ...::block_on(...) | {EXTERNAL LOCATION} | fn block_on |
-| main.rs:334:41:334:54 | async_source(...) | main.rs:315:1:319:1 | fn async_source |
-| main.rs:335:5:335:11 | sink(...) | main.rs:5:1:7:1 | fn sink |
-| main.rs:337:5:337:62 | ...::block_on(...) | {EXTERNAL LOCATION} | fn block_on |
-| main.rs:337:33:337:61 | test_async_await_async_part(...) | main.rs:321:1:331:1 | fn test_async_await_async_part |
-| main.rs:347:13:347:29 | self.get_number() | main.rs:358:9:360:9 | fn get_number |
-| main.rs:347:13:347:29 | self.get_number() | main.rs:366:9:368:9 | fn get_number |
-| main.rs:347:13:347:33 | ... * ... | {EXTERNAL LOCATION} | fn mul |
-| main.rs:351:13:351:21 | source(...) | main.rs:1:1:3:1 | fn source |
-| main.rs:359:13:359:21 | source(...) | main.rs:1:1:3:1 | fn source |
-| main.rs:371:13:371:22 | source(...) | main.rs:1:1:3:1 | fn source |
-| main.rs:375:13:375:21 | source(...) | main.rs:1:1:3:1 | fn source |
-| main.rs:383:18:383:38 | t.get_double_number() | main.rs:346:9:348:9 | fn get_double_number |
-| main.rs:384:9:384:16 | sink(...) | main.rs:5:1:7:1 | fn sink |
-| main.rs:387:18:387:50 | ...::get_double_number(...) | main.rs:346:9:348:9 | fn get_double_number |
-| main.rs:388:9:388:16 | sink(...) | main.rs:5:1:7:1 | fn sink |
-| main.rs:391:18:391:37 | ...::get_default(...) | main.rs:350:9:352:9 | fn get_default |
-| main.rs:392:9:392:16 | sink(...) | main.rs:5:1:7:1 | fn sink |
-| main.rs:395:18:395:38 | i.get_double_number() | main.rs:370:9:372:9 | fn get_double_number |
-| main.rs:396:9:396:16 | sink(...) | main.rs:5:1:7:1 | fn sink |
-| main.rs:398:18:398:41 | ...::get_default(...) | main.rs:374:9:376:9 | fn get_default |
-| main.rs:399:9:399:16 | sink(...) | main.rs:5:1:7:1 | fn sink |
-| main.rs:404:5:404:22 | data_out_of_call(...) | main.rs:16:1:19:1 | fn data_out_of_call |
-| main.rs:405:5:405:35 | data_out_of_call_side_effect1(...) | main.rs:35:1:40:1 | fn data_out_of_call_side_effect1 |
-| main.rs:406:5:406:35 | data_out_of_call_side_effect2(...) | main.rs:42:1:50:1 | fn data_out_of_call_side_effect2 |
-| main.rs:407:5:407:21 | data_in_to_call(...) | main.rs:56:1:59:1 | fn data_in_to_call |
-| main.rs:408:5:408:23 | data_through_call(...) | main.rs:65:1:69:1 | fn data_through_call |
-| main.rs:409:5:409:34 | data_through_nested_function(...) | main.rs:79:1:88:1 | fn data_through_nested_function |
-| main.rs:411:5:411:24 | data_out_of_method(...) | main.rs:136:1:146:1 | fn data_out_of_method |
-| main.rs:412:5:412:28 | data_in_to_method_call(...) | main.rs:153:1:163:1 | fn data_in_to_method_call |
-| main.rs:413:5:413:25 | data_through_method(...) | main.rs:171:1:183:1 | fn data_through_method |
-| main.rs:415:5:415:31 | test_operator_overloading(...) | main.rs:240:1:278:1 | fn test_operator_overloading |
-| main.rs:416:5:416:22 | test_async_await(...) | main.rs:333:1:338:1 | fn test_async_await |
+| main.rs:277:5:277:36 | ...::mul_assign(...) | main.rs:243:5:245:5 | fn mul_assign |
+| main.rs:278:5:278:17 | sink(...) | main.rs:5:1:7:1 | fn sink |
+| main.rs:281:28:281:37 | source(...) | main.rs:1:1:3:1 | fn source |
+| main.rs:282:5:282:10 | ... *= ... | main.rs:243:5:245:5 | fn mul_assign |
+| main.rs:283:5:283:17 | sink(...) | main.rs:5:1:7:1 | fn sink |
+| main.rs:286:28:286:37 | source(...) | main.rs:1:1:3:1 | fn source |
+| main.rs:288:13:288:29 | * ... | {EXTERNAL LOCATION} | fn deref |
+| main.rs:288:13:288:29 | * ... | {EXTERNAL LOCATION} | fn deref |
+| main.rs:288:14:288:29 | ...::deref(...) | main.rs:251:5:253:5 | fn deref |
+| main.rs:289:5:289:11 | sink(...) | main.rs:5:1:7:1 | fn sink |
+| main.rs:291:28:291:37 | source(...) | main.rs:1:1:3:1 | fn source |
+| main.rs:292:13:292:14 | * ... | main.rs:251:5:253:5 | fn deref |
+| main.rs:293:5:293:11 | sink(...) | main.rs:5:1:7:1 | fn sink |
+| main.rs:295:28:295:37 | source(...) | main.rs:1:1:3:1 | fn source |
+| main.rs:297:5:297:11 | sink(...) | main.rs:5:1:7:1 | fn sink |
+| main.rs:319:28:319:36 | source(...) | main.rs:1:1:3:1 | fn source |
+| main.rs:321:30:321:54 | ...::take_self(...) | main.rs:309:5:311:5 | fn take_self |
+| main.rs:322:5:322:11 | sink(...) | main.rs:5:1:7:1 | fn sink |
+| main.rs:325:28:325:37 | source(...) | main.rs:1:1:3:1 | fn source |
+| main.rs:326:30:326:56 | ...::take_second(...) | main.rs:313:5:315:5 | fn take_second |
+| main.rs:327:5:327:11 | sink(...) | main.rs:5:1:7:1 | fn sink |
+| main.rs:330:28:330:37 | source(...) | main.rs:1:1:3:1 | fn source |
+| main.rs:331:30:331:54 | ...::take_self(...) | main.rs:309:5:311:5 | fn take_self |
+| main.rs:332:5:332:11 | sink(...) | main.rs:5:1:7:1 | fn sink |
+| main.rs:336:13:336:21 | source(...) | main.rs:1:1:3:1 | fn source |
+| main.rs:337:5:337:11 | sink(...) | main.rs:5:1:7:1 | fn sink |
+| main.rs:342:13:342:26 | async_source(...) | main.rs:335:1:339:1 | fn async_source |
+| main.rs:343:5:343:11 | sink(...) | main.rs:5:1:7:1 | fn sink |
+| main.rs:346:17:346:25 | source(...) | main.rs:1:1:3:1 | fn source |
+| main.rs:347:9:347:15 | sink(...) | main.rs:5:1:7:1 | fn sink |
+| main.rs:350:5:350:17 | sink(...) | main.rs:5:1:7:1 | fn sink |
+| main.rs:354:13:354:55 | ...::block_on(...) | {EXTERNAL LOCATION} | fn block_on |
+| main.rs:354:41:354:54 | async_source(...) | main.rs:335:1:339:1 | fn async_source |
+| main.rs:355:5:355:11 | sink(...) | main.rs:5:1:7:1 | fn sink |
+| main.rs:357:5:357:62 | ...::block_on(...) | {EXTERNAL LOCATION} | fn block_on |
+| main.rs:357:33:357:61 | test_async_await_async_part(...) | main.rs:341:1:351:1 | fn test_async_await_async_part |
+| main.rs:367:13:367:29 | self.get_number() | main.rs:378:9:380:9 | fn get_number |
+| main.rs:367:13:367:29 | self.get_number() | main.rs:386:9:388:9 | fn get_number |
+| main.rs:367:13:367:33 | ... * ... | {EXTERNAL LOCATION} | fn mul |
+| main.rs:371:13:371:21 | source(...) | main.rs:1:1:3:1 | fn source |
+| main.rs:379:13:379:21 | source(...) | main.rs:1:1:3:1 | fn source |
+| main.rs:391:13:391:22 | source(...) | main.rs:1:1:3:1 | fn source |
+| main.rs:395:13:395:21 | source(...) | main.rs:1:1:3:1 | fn source |
+| main.rs:403:18:403:38 | t.get_double_number() | main.rs:366:9:368:9 | fn get_double_number |
+| main.rs:404:9:404:16 | sink(...) | main.rs:5:1:7:1 | fn sink |
+| main.rs:407:18:407:50 | ...::get_double_number(...) | main.rs:366:9:368:9 | fn get_double_number |
+| main.rs:408:9:408:16 | sink(...) | main.rs:5:1:7:1 | fn sink |
+| main.rs:411:18:411:37 | ...::get_default(...) | main.rs:370:9:372:9 | fn get_default |
+| main.rs:412:9:412:16 | sink(...) | main.rs:5:1:7:1 | fn sink |
+| main.rs:415:18:415:38 | i.get_double_number() | main.rs:390:9:392:9 | fn get_double_number |
+| main.rs:416:9:416:16 | sink(...) | main.rs:5:1:7:1 | fn sink |
+| main.rs:418:18:418:41 | ...::get_default(...) | main.rs:394:9:396:9 | fn get_default |
+| main.rs:419:9:419:16 | sink(...) | main.rs:5:1:7:1 | fn sink |
+| main.rs:424:5:424:22 | data_out_of_call(...) | main.rs:16:1:19:1 | fn data_out_of_call |
+| main.rs:425:5:425:35 | data_out_of_call_side_effect1(...) | main.rs:35:1:40:1 | fn data_out_of_call_side_effect1 |
+| main.rs:426:5:426:35 | data_out_of_call_side_effect2(...) | main.rs:42:1:50:1 | fn data_out_of_call_side_effect2 |
+| main.rs:427:5:427:21 | data_in_to_call(...) | main.rs:56:1:59:1 | fn data_in_to_call |
+| main.rs:428:5:428:23 | data_through_call(...) | main.rs:65:1:69:1 | fn data_through_call |
+| main.rs:429:5:429:34 | data_through_nested_function(...) | main.rs:79:1:88:1 | fn data_through_nested_function |
+| main.rs:431:5:431:24 | data_out_of_method(...) | main.rs:152:1:162:1 | fn data_out_of_method |
+| main.rs:432:5:432:28 | data_in_to_method_call(...) | main.rs:169:1:179:1 | fn data_in_to_method_call |
+| main.rs:433:5:433:25 | data_through_method(...) | main.rs:187:1:199:1 | fn data_through_method |
+| main.rs:435:5:435:31 | test_operator_overloading(...) | main.rs:256:1:298:1 | fn test_operator_overloading |
+| main.rs:436:5:436:22 | test_async_await(...) | main.rs:353:1:358:1 | fn test_async_await |

--- a/rust/ql/test/library-tests/dataflow/modeled/inline-flow.expected
+++ b/rust/ql/test/library-tests/dataflow/modeled/inline-flow.expected
@@ -1,49 +1,52 @@
 models
 | 1 | Summary: <& as core::ops::deref::Deref>::deref; Argument[self].Reference; ReturnValue; value |
 | 2 | Summary: <_ as core::clone::Clone>::clone; Argument[self].Reference; ReturnValue; value |
-| 3 | Summary: <_ as core::ops::arith::Add>::add; Argument[0].Reference; ReturnValue; taint |
-| 4 | Summary: <_ as core::ops::arith::Add>::add; Argument[0]; ReturnValue; taint |
-| 5 | Summary: <alloc::boxed::Box>::into_pin; Argument[0]; ReturnValue.Field[core::pin::Pin::pointer]; value |
-| 6 | Summary: <alloc::boxed::Box>::new; Argument[0]; ReturnValue.Field[alloc::boxed::Box(0)]; value |
-| 7 | Summary: <alloc::boxed::Box>::pin; Argument[0]; ReturnValue.Field[core::pin::Pin::pointer].Field[alloc::boxed::Box(0)]; value |
-| 8 | Summary: <core::i64 as core::clone::Clone>::clone; Argument[self].Reference; ReturnValue; value |
-| 9 | Summary: <core::option::Option>::map_or; Argument[1].ReturnValue; ReturnValue; value |
-| 10 | Summary: <core::option::Option>::unwrap; Argument[self].Field[core::option::Option::Some(0)]; ReturnValue; value |
-| 11 | Summary: <core::option::Option>::zip; Argument[0].Field[core::option::Option::Some(0)]; ReturnValue.Field[core::option::Option::Some(0)].Field[1]; value |
-| 12 | Summary: <core::pin::Pin as core::ops::deref::Deref>::deref; Argument[self].Reference.Field[core::pin::Pin::pointer].Field[alloc::boxed::Box(0)]; ReturnValue.Reference; value |
-| 13 | Summary: <core::pin::Pin as core::ops::deref::Deref>::deref; Argument[self].Reference.Field[core::pin::Pin::pointer].Reference; ReturnValue.Reference; value |
-| 14 | Summary: <core::pin::Pin>::into_inner; Argument[0].Field[core::pin::Pin::pointer]; ReturnValue; value |
-| 15 | Summary: <core::pin::Pin>::into_inner_unchecked; Argument[0].Field[core::pin::Pin::pointer]; ReturnValue; value |
-| 16 | Summary: <core::pin::Pin>::new; Argument[0]; ReturnValue.Field[core::pin::Pin::pointer]; value |
-| 17 | Summary: <core::pin::Pin>::new_unchecked; Argument[0]; ReturnValue.Field[core::pin::Pin::pointer]; value |
-| 18 | Summary: <core::result::Result>::unwrap; Argument[self].Field[core::result::Result::Ok(0)]; ReturnValue; value |
-| 19 | Summary: core::ptr::read; Argument[0].Reference; ReturnValue; value |
-| 20 | Summary: core::ptr::write; Argument[1]; Argument[0].Reference; value |
+| 3 | Summary: <_ as core::cmp::Ord>::clamp; Argument[self,0,1]; ReturnValue; value |
+| 4 | Summary: <_ as core::cmp::Ord>::max; Argument[self,0]; ReturnValue; value |
+| 5 | Summary: <_ as core::cmp::Ord>::min; Argument[self,0]; ReturnValue; value |
+| 6 | Summary: <_ as core::ops::arith::Add>::add; Argument[0].Reference; ReturnValue; taint |
+| 7 | Summary: <_ as core::ops::arith::Add>::add; Argument[0]; ReturnValue; taint |
+| 8 | Summary: <alloc::boxed::Box>::into_pin; Argument[0]; ReturnValue.Field[core::pin::Pin::pointer]; value |
+| 9 | Summary: <alloc::boxed::Box>::new; Argument[0]; ReturnValue.Field[alloc::boxed::Box(0)]; value |
+| 10 | Summary: <alloc::boxed::Box>::pin; Argument[0]; ReturnValue.Field[core::pin::Pin::pointer].Field[alloc::boxed::Box(0)]; value |
+| 11 | Summary: <core::i64 as core::clone::Clone>::clone; Argument[self].Reference; ReturnValue; value |
+| 12 | Summary: <core::option::Option>::map_or; Argument[1].ReturnValue; ReturnValue; value |
+| 13 | Summary: <core::option::Option>::unwrap; Argument[self].Field[core::option::Option::Some(0)]; ReturnValue; value |
+| 14 | Summary: <core::option::Option>::zip; Argument[0].Field[core::option::Option::Some(0)]; ReturnValue.Field[core::option::Option::Some(0)].Field[1]; value |
+| 15 | Summary: <core::pin::Pin as core::ops::deref::Deref>::deref; Argument[self].Reference.Field[core::pin::Pin::pointer].Field[alloc::boxed::Box(0)]; ReturnValue.Reference; value |
+| 16 | Summary: <core::pin::Pin as core::ops::deref::Deref>::deref; Argument[self].Reference.Field[core::pin::Pin::pointer].Reference; ReturnValue.Reference; value |
+| 17 | Summary: <core::pin::Pin>::into_inner; Argument[0].Field[core::pin::Pin::pointer]; ReturnValue; value |
+| 18 | Summary: <core::pin::Pin>::into_inner_unchecked; Argument[0].Field[core::pin::Pin::pointer]; ReturnValue; value |
+| 19 | Summary: <core::pin::Pin>::new; Argument[0]; ReturnValue.Field[core::pin::Pin::pointer]; value |
+| 20 | Summary: <core::pin::Pin>::new_unchecked; Argument[0]; ReturnValue.Field[core::pin::Pin::pointer]; value |
+| 21 | Summary: <core::result::Result>::unwrap; Argument[self].Field[core::result::Result::Ok(0)]; ReturnValue; value |
+| 22 | Summary: core::ptr::read; Argument[0].Reference; ReturnValue; value |
+| 23 | Summary: core::ptr::write; Argument[1]; Argument[0].Reference; value |
 edges
 | main.rs:12:9:12:9 | a [Some] | main.rs:13:10:13:10 | a [Some] | provenance |  |
 | main.rs:12:9:12:9 | a [Some] | main.rs:14:13:14:13 | a [Some] | provenance |  |
 | main.rs:12:13:12:28 | Some(...) [Some] | main.rs:12:9:12:9 | a [Some] | provenance |  |
 | main.rs:12:18:12:27 | source(...) | main.rs:12:13:12:28 | Some(...) [Some] | provenance |  |
-| main.rs:13:10:13:10 | a [Some] | main.rs:13:10:13:19 | a.unwrap() | provenance | MaD:10 |
+| main.rs:13:10:13:10 | a [Some] | main.rs:13:10:13:19 | a.unwrap() | provenance | MaD:13 |
 | main.rs:14:9:14:9 | b [Some] | main.rs:15:10:15:10 | b [Some] | provenance |  |
 | main.rs:14:13:14:13 | a [Some] | main.rs:14:13:14:21 | a.clone() [Some] | provenance | MaD:2 |
 | main.rs:14:13:14:21 | a.clone() [Some] | main.rs:14:9:14:9 | b [Some] | provenance |  |
-| main.rs:15:10:15:10 | b [Some] | main.rs:15:10:15:19 | b.unwrap() | provenance | MaD:10 |
+| main.rs:15:10:15:10 | b [Some] | main.rs:15:10:15:19 | b.unwrap() | provenance | MaD:13 |
 | main.rs:19:9:19:9 | a [Ok] | main.rs:20:10:20:10 | a [Ok] | provenance |  |
 | main.rs:19:9:19:9 | a [Ok] | main.rs:21:13:21:13 | a [Ok] | provenance |  |
 | main.rs:19:31:19:44 | Ok(...) [Ok] | main.rs:19:9:19:9 | a [Ok] | provenance |  |
 | main.rs:19:34:19:43 | source(...) | main.rs:19:31:19:44 | Ok(...) [Ok] | provenance |  |
-| main.rs:20:10:20:10 | a [Ok] | main.rs:20:10:20:19 | a.unwrap() | provenance | MaD:18 |
+| main.rs:20:10:20:10 | a [Ok] | main.rs:20:10:20:19 | a.unwrap() | provenance | MaD:21 |
 | main.rs:21:9:21:9 | b [Ok] | main.rs:22:10:22:10 | b [Ok] | provenance |  |
 | main.rs:21:13:21:13 | a [Ok] | main.rs:21:13:21:21 | a.clone() [Ok] | provenance | MaD:2 |
 | main.rs:21:13:21:21 | a.clone() [Ok] | main.rs:21:9:21:9 | b [Ok] | provenance |  |
-| main.rs:22:10:22:10 | b [Ok] | main.rs:22:10:22:19 | b.unwrap() | provenance | MaD:18 |
+| main.rs:22:10:22:10 | b [Ok] | main.rs:22:10:22:19 | b.unwrap() | provenance | MaD:21 |
 | main.rs:26:9:26:9 | a | main.rs:27:10:27:10 | a | provenance |  |
 | main.rs:26:9:26:9 | a | main.rs:28:13:28:13 | a | provenance |  |
 | main.rs:26:13:26:22 | source(...) | main.rs:26:9:26:9 | a | provenance |  |
 | main.rs:28:9:28:9 | b | main.rs:29:10:29:10 | b | provenance |  |
 | main.rs:28:13:28:13 | a | main.rs:28:13:28:21 | a.clone() | provenance | MaD:2 |
-| main.rs:28:13:28:13 | a | main.rs:28:13:28:21 | a.clone() | provenance | MaD:8 |
+| main.rs:28:13:28:13 | a | main.rs:28:13:28:21 | a.clone() | provenance | MaD:11 |
 | main.rs:28:13:28:21 | a.clone() | main.rs:28:9:28:9 | b | provenance |  |
 | main.rs:43:18:43:22 | SelfParam [&ref, Wrapper] | main.rs:44:26:44:29 | self [&ref, Wrapper] | provenance |  |
 | main.rs:44:13:44:33 | Wrapper {...} [Wrapper] | main.rs:43:33:45:9 | { ... } [Wrapper] | provenance |  |
@@ -68,19 +71,19 @@ edges
 | main.rs:66:22:66:31 | source(...) | main.rs:66:17:66:32 | Some(...) [Some] | provenance |  |
 | main.rs:67:13:67:13 | z [Some, tuple.1] | main.rs:68:15:68:15 | z [Some, tuple.1] | provenance |  |
 | main.rs:67:17:67:24 | a.zip(...) [Some, tuple.1] | main.rs:67:13:67:13 | z [Some, tuple.1] | provenance |  |
-| main.rs:67:23:67:23 | b [Some] | main.rs:67:17:67:24 | a.zip(...) [Some, tuple.1] | provenance | MaD:11 |
+| main.rs:67:23:67:23 | b [Some] | main.rs:67:17:67:24 | a.zip(...) [Some, tuple.1] | provenance | MaD:14 |
 | main.rs:68:15:68:15 | z [Some, tuple.1] | main.rs:69:13:69:24 | Some(...) [Some, tuple.1] | provenance |  |
 | main.rs:69:13:69:24 | Some(...) [Some, tuple.1] | main.rs:69:18:69:23 | TuplePat [tuple.1] | provenance |  |
 | main.rs:69:18:69:23 | TuplePat [tuple.1] | main.rs:69:22:69:22 | m | provenance |  |
 | main.rs:69:22:69:22 | m | main.rs:71:22:71:22 | m | provenance |  |
 | main.rs:79:13:79:13 | b | main.rs:80:14:80:14 | b | provenance |  |
 | main.rs:79:17:79:47 | a.map_or(...) | main.rs:79:13:79:13 | b | provenance |  |
-| main.rs:79:33:79:46 | ... + ... | main.rs:79:17:79:47 | a.map_or(...) | provenance | MaD:9 |
-| main.rs:79:37:79:46 | source(...) | main.rs:79:33:79:46 | ... + ... | provenance | MaD:3 |
-| main.rs:79:37:79:46 | source(...) | main.rs:79:33:79:46 | ... + ... | provenance | MaD:4 |
+| main.rs:79:33:79:46 | ... + ... | main.rs:79:17:79:47 | a.map_or(...) | provenance | MaD:12 |
+| main.rs:79:37:79:46 | source(...) | main.rs:79:33:79:46 | ... + ... | provenance | MaD:6 |
+| main.rs:79:37:79:46 | source(...) | main.rs:79:33:79:46 | ... + ... | provenance | MaD:7 |
 | main.rs:92:29:92:29 | [post] y [&ref] | main.rs:93:33:93:33 | y [&ref] | provenance |  |
-| main.rs:92:32:92:41 | source(...) | main.rs:92:29:92:29 | [post] y [&ref] | provenance | MaD:20 |
-| main.rs:93:33:93:33 | y [&ref] | main.rs:93:18:93:34 | ...::read(...) | provenance | MaD:19 |
+| main.rs:92:32:92:41 | source(...) | main.rs:92:29:92:29 | [post] y [&ref] | provenance | MaD:23 |
+| main.rs:93:33:93:33 | y [&ref] | main.rs:93:18:93:34 | ...::read(...) | provenance | MaD:22 |
 | main.rs:108:13:108:17 | mut i | main.rs:109:34:109:34 | i | provenance |  |
 | main.rs:108:13:108:17 | mut i | main.rs:110:33:110:33 | i | provenance |  |
 | main.rs:108:13:108:17 | mut i | main.rs:111:47:111:47 | i | provenance |  |
@@ -90,46 +93,73 @@ edges
 | main.rs:109:13:109:20 | mut pin1 [Pin, &ref] | main.rs:114:15:114:18 | pin1 [Pin, &ref] | provenance |  |
 | main.rs:109:13:109:20 | mut pin1 [Pin, &ref] | main.rs:115:31:115:34 | pin1 [Pin, &ref] | provenance |  |
 | main.rs:109:24:109:35 | ...::new(...) [Pin, &ref] | main.rs:109:13:109:20 | mut pin1 [Pin, &ref] | provenance |  |
-| main.rs:109:33:109:34 | &i [&ref] | main.rs:109:24:109:35 | ...::new(...) [Pin, &ref] | provenance | MaD:16 |
+| main.rs:109:33:109:34 | &i [&ref] | main.rs:109:24:109:35 | ...::new(...) [Pin, &ref] | provenance | MaD:19 |
 | main.rs:109:34:109:34 | i | main.rs:109:33:109:34 | &i [&ref] | provenance |  |
 | main.rs:110:13:110:20 | mut pin2 [Pin, Box(0)] | main.rs:116:15:116:18 | pin2 [Pin, Box(0)] | provenance |  |
 | main.rs:110:24:110:34 | ...::pin(...) [Pin, Box(0)] | main.rs:110:13:110:20 | mut pin2 [Pin, Box(0)] | provenance |  |
-| main.rs:110:33:110:33 | i | main.rs:110:24:110:34 | ...::pin(...) [Pin, Box(0)] | provenance | MaD:7 |
+| main.rs:110:33:110:33 | i | main.rs:110:24:110:34 | ...::pin(...) [Pin, Box(0)] | provenance | MaD:10 |
 | main.rs:111:13:111:20 | mut pin3 [Pin, Box(0)] | main.rs:117:15:117:18 | pin3 [Pin, Box(0)] | provenance |  |
 | main.rs:111:24:111:49 | ...::into_pin(...) [Pin, Box(0)] | main.rs:111:13:111:20 | mut pin3 [Pin, Box(0)] | provenance |  |
-| main.rs:111:38:111:48 | ...::new(...) [Box(0)] | main.rs:111:24:111:49 | ...::into_pin(...) [Pin, Box(0)] | provenance | MaD:5 |
-| main.rs:111:47:111:47 | i | main.rs:111:38:111:48 | ...::new(...) [Box(0)] | provenance | MaD:6 |
+| main.rs:111:38:111:48 | ...::new(...) [Box(0)] | main.rs:111:24:111:49 | ...::into_pin(...) [Pin, Box(0)] | provenance | MaD:8 |
+| main.rs:111:47:111:47 | i | main.rs:111:38:111:48 | ...::new(...) [Box(0)] | provenance | MaD:9 |
 | main.rs:112:13:112:20 | mut pin4 [Pin, &ref] | main.rs:118:15:118:18 | pin4 [Pin, &ref] | provenance |  |
-| main.rs:112:24:112:27 | &mut pinned [&ref] | main.rs:112:24:112:27 | ...::new_unchecked(...) [Pin, &ref] | provenance | MaD:17 |
+| main.rs:112:24:112:27 | &mut pinned [&ref] | main.rs:112:24:112:27 | ...::new_unchecked(...) [Pin, &ref] | provenance | MaD:20 |
 | main.rs:112:24:112:27 | ...::new_unchecked(...) [Pin, &ref] | main.rs:112:13:112:20 | mut pin4 [Pin, &ref] | provenance |  |
 | main.rs:112:24:112:27 | mut pinned | main.rs:112:24:112:27 | pinned | provenance |  |
 | main.rs:112:24:112:27 | pinned | main.rs:112:24:112:27 | &mut pinned [&ref] | provenance |  |
-| main.rs:114:15:114:18 | pin1 [Pin, &ref] | main.rs:114:14:114:18 | * ... | provenance | MaD:13 |
+| main.rs:114:15:114:18 | pin1 [Pin, &ref] | main.rs:114:14:114:18 | * ... | provenance | MaD:16 |
 | main.rs:115:15:115:35 | ...::into_inner(...) [&ref] | main.rs:115:14:115:35 | * ... | provenance | MaD:1 |
-| main.rs:115:31:115:34 | pin1 [Pin, &ref] | main.rs:115:15:115:35 | ...::into_inner(...) [&ref] | provenance | MaD:14 |
-| main.rs:116:15:116:18 | pin2 [Pin, Box(0)] | main.rs:116:14:116:18 | * ... | provenance | MaD:12 |
-| main.rs:117:15:117:18 | pin3 [Pin, Box(0)] | main.rs:117:14:117:18 | * ... | provenance | MaD:12 |
-| main.rs:118:15:118:18 | pin4 [Pin, &ref] | main.rs:118:14:118:18 | * ... | provenance | MaD:13 |
+| main.rs:115:31:115:34 | pin1 [Pin, &ref] | main.rs:115:15:115:35 | ...::into_inner(...) [&ref] | provenance | MaD:17 |
+| main.rs:116:15:116:18 | pin2 [Pin, Box(0)] | main.rs:116:14:116:18 | * ... | provenance | MaD:15 |
+| main.rs:117:15:117:18 | pin3 [Pin, Box(0)] | main.rs:117:14:117:18 | * ... | provenance | MaD:15 |
+| main.rs:118:15:118:18 | pin4 [Pin, &ref] | main.rs:118:14:118:18 | * ... | provenance | MaD:16 |
 | main.rs:122:13:122:18 | mut ms [MyStruct] | main.rs:123:34:123:35 | ms [MyStruct] | provenance |  |
 | main.rs:122:13:122:18 | mut ms [MyStruct] | main.rs:127:14:127:15 | ms [MyStruct] | provenance |  |
 | main.rs:122:22:122:49 | MyStruct {...} [MyStruct] | main.rs:122:13:122:18 | mut ms [MyStruct] | provenance |  |
 | main.rs:122:38:122:47 | source(...) | main.rs:122:22:122:49 | MyStruct {...} [MyStruct] | provenance |  |
 | main.rs:123:13:123:20 | mut pin1 [Pin, &ref, MyStruct] | main.rs:129:30:129:33 | pin1 [Pin, &ref, MyStruct] | provenance |  |
 | main.rs:123:24:123:36 | ...::new(...) [Pin, &ref, MyStruct] | main.rs:123:13:123:20 | mut pin1 [Pin, &ref, MyStruct] | provenance |  |
-| main.rs:123:33:123:35 | &ms [&ref, MyStruct] | main.rs:123:24:123:36 | ...::new(...) [Pin, &ref, MyStruct] | provenance | MaD:16 |
+| main.rs:123:33:123:35 | &ms [&ref, MyStruct] | main.rs:123:24:123:36 | ...::new(...) [Pin, &ref, MyStruct] | provenance | MaD:19 |
 | main.rs:123:34:123:35 | ms [MyStruct] | main.rs:123:33:123:35 | &ms [&ref, MyStruct] | provenance |  |
 | main.rs:127:14:127:15 | ms [MyStruct] | main.rs:127:14:127:19 | ms.val | provenance |  |
 | main.rs:129:14:129:34 | ...::into_inner(...) [&ref, MyStruct] | main.rs:129:14:129:38 | ... .val | provenance |  |
-| main.rs:129:30:129:33 | pin1 [Pin, &ref, MyStruct] | main.rs:129:14:129:34 | ...::into_inner(...) [&ref, MyStruct] | provenance | MaD:14 |
+| main.rs:129:30:129:33 | pin1 [Pin, &ref, MyStruct] | main.rs:129:14:129:34 | ...::into_inner(...) [&ref, MyStruct] | provenance | MaD:17 |
 | main.rs:136:13:136:18 | mut ms [MyStruct] | main.rs:137:44:137:45 | ms [MyStruct] | provenance |  |
 | main.rs:136:22:136:49 | MyStruct {...} [MyStruct] | main.rs:136:13:136:18 | mut ms [MyStruct] | provenance |  |
 | main.rs:136:38:136:47 | source(...) | main.rs:136:22:136:49 | MyStruct {...} [MyStruct] | provenance |  |
 | main.rs:137:13:137:20 | mut pin5 [Pin, &ref, MyStruct] | main.rs:139:40:139:43 | pin5 [Pin, &ref, MyStruct] | provenance |  |
 | main.rs:137:24:137:46 | ...::new_unchecked(...) [Pin, &ref, MyStruct] | main.rs:137:13:137:20 | mut pin5 [Pin, &ref, MyStruct] | provenance |  |
-| main.rs:137:43:137:45 | &ms [&ref, MyStruct] | main.rs:137:24:137:46 | ...::new_unchecked(...) [Pin, &ref, MyStruct] | provenance | MaD:17 |
+| main.rs:137:43:137:45 | &ms [&ref, MyStruct] | main.rs:137:24:137:46 | ...::new_unchecked(...) [Pin, &ref, MyStruct] | provenance | MaD:20 |
 | main.rs:137:44:137:45 | ms [MyStruct] | main.rs:137:43:137:45 | &ms [&ref, MyStruct] | provenance |  |
 | main.rs:139:14:139:44 | ...::into_inner_unchecked(...) [&ref, MyStruct] | main.rs:139:14:139:48 | ... .val | provenance |  |
-| main.rs:139:40:139:43 | pin5 [Pin, &ref, MyStruct] | main.rs:139:14:139:44 | ...::into_inner_unchecked(...) [&ref, MyStruct] | provenance | MaD:15 |
+| main.rs:139:40:139:43 | pin5 [Pin, &ref, MyStruct] | main.rs:139:14:139:44 | ...::into_inner_unchecked(...) [&ref, MyStruct] | provenance | MaD:18 |
+| main.rs:153:9:153:9 | a | main.rs:155:13:155:13 | a | provenance |  |
+| main.rs:153:13:153:22 | source(...) | main.rs:153:9:153:9 | a | provenance |  |
+| main.rs:154:9:154:9 | b | main.rs:155:19:155:19 | b | provenance |  |
+| main.rs:154:13:154:22 | source(...) | main.rs:154:9:154:9 | b | provenance |  |
+| main.rs:155:9:155:9 | c | main.rs:156:10:156:10 | c | provenance |  |
+| main.rs:155:13:155:13 | a | main.rs:155:13:155:20 | a.min(...) | provenance | MaD:5 |
+| main.rs:155:13:155:20 | a.min(...) | main.rs:155:9:155:9 | c | provenance |  |
+| main.rs:155:19:155:19 | b | main.rs:155:13:155:20 | a.min(...) | provenance | MaD:5 |
+| main.rs:158:9:158:9 | d | main.rs:160:13:160:13 | d | provenance |  |
+| main.rs:158:13:158:22 | source(...) | main.rs:158:9:158:9 | d | provenance |  |
+| main.rs:159:9:159:9 | e | main.rs:160:19:160:19 | e | provenance |  |
+| main.rs:159:13:159:22 | source(...) | main.rs:159:9:159:9 | e | provenance |  |
+| main.rs:160:9:160:9 | f | main.rs:161:10:161:10 | f | provenance |  |
+| main.rs:160:13:160:13 | d | main.rs:160:13:160:20 | d.max(...) | provenance | MaD:4 |
+| main.rs:160:13:160:20 | d.max(...) | main.rs:160:9:160:9 | f | provenance |  |
+| main.rs:160:19:160:19 | e | main.rs:160:13:160:20 | d.max(...) | provenance | MaD:4 |
+| main.rs:163:9:163:9 | g | main.rs:166:13:166:13 | g | provenance |  |
+| main.rs:163:13:163:22 | source(...) | main.rs:163:9:163:9 | g | provenance |  |
+| main.rs:164:9:164:9 | h | main.rs:166:21:166:21 | h | provenance |  |
+| main.rs:164:13:164:22 | source(...) | main.rs:164:9:164:9 | h | provenance |  |
+| main.rs:165:9:165:9 | i | main.rs:166:24:166:24 | i | provenance |  |
+| main.rs:165:13:165:22 | source(...) | main.rs:165:9:165:9 | i | provenance |  |
+| main.rs:166:9:166:9 | j | main.rs:167:10:167:10 | j | provenance |  |
+| main.rs:166:13:166:13 | g | main.rs:166:13:166:25 | g.clamp(...) | provenance | MaD:3 |
+| main.rs:166:13:166:25 | g.clamp(...) | main.rs:166:9:166:9 | j | provenance |  |
+| main.rs:166:21:166:21 | h | main.rs:166:13:166:25 | g.clamp(...) | provenance | MaD:3 |
+| main.rs:166:24:166:24 | i | main.rs:166:13:166:25 | g.clamp(...) | provenance | MaD:3 |
 nodes
 | main.rs:12:9:12:9 | a [Some] | semmle.label | a [Some] |
 | main.rs:12:13:12:28 | Some(...) [Some] | semmle.label | Some(...) [Some] |
@@ -249,6 +279,36 @@ nodes
 | main.rs:139:14:139:44 | ...::into_inner_unchecked(...) [&ref, MyStruct] | semmle.label | ...::into_inner_unchecked(...) [&ref, MyStruct] |
 | main.rs:139:14:139:48 | ... .val | semmle.label | ... .val |
 | main.rs:139:40:139:43 | pin5 [Pin, &ref, MyStruct] | semmle.label | pin5 [Pin, &ref, MyStruct] |
+| main.rs:153:9:153:9 | a | semmle.label | a |
+| main.rs:153:13:153:22 | source(...) | semmle.label | source(...) |
+| main.rs:154:9:154:9 | b | semmle.label | b |
+| main.rs:154:13:154:22 | source(...) | semmle.label | source(...) |
+| main.rs:155:9:155:9 | c | semmle.label | c |
+| main.rs:155:13:155:13 | a | semmle.label | a |
+| main.rs:155:13:155:20 | a.min(...) | semmle.label | a.min(...) |
+| main.rs:155:19:155:19 | b | semmle.label | b |
+| main.rs:156:10:156:10 | c | semmle.label | c |
+| main.rs:158:9:158:9 | d | semmle.label | d |
+| main.rs:158:13:158:22 | source(...) | semmle.label | source(...) |
+| main.rs:159:9:159:9 | e | semmle.label | e |
+| main.rs:159:13:159:22 | source(...) | semmle.label | source(...) |
+| main.rs:160:9:160:9 | f | semmle.label | f |
+| main.rs:160:13:160:13 | d | semmle.label | d |
+| main.rs:160:13:160:20 | d.max(...) | semmle.label | d.max(...) |
+| main.rs:160:19:160:19 | e | semmle.label | e |
+| main.rs:161:10:161:10 | f | semmle.label | f |
+| main.rs:163:9:163:9 | g | semmle.label | g |
+| main.rs:163:13:163:22 | source(...) | semmle.label | source(...) |
+| main.rs:164:9:164:9 | h | semmle.label | h |
+| main.rs:164:13:164:22 | source(...) | semmle.label | source(...) |
+| main.rs:165:9:165:9 | i | semmle.label | i |
+| main.rs:165:13:165:22 | source(...) | semmle.label | source(...) |
+| main.rs:166:9:166:9 | j | semmle.label | j |
+| main.rs:166:13:166:13 | g | semmle.label | g |
+| main.rs:166:13:166:25 | g.clamp(...) | semmle.label | g.clamp(...) |
+| main.rs:166:21:166:21 | h | semmle.label | h |
+| main.rs:166:24:166:24 | i | semmle.label | i |
+| main.rs:167:10:167:10 | j | semmle.label | j |
 subpaths
 | main.rs:53:17:53:17 | w [Wrapper] | main.rs:43:18:43:22 | SelfParam [&ref, Wrapper] | main.rs:43:33:45:9 | { ... } [Wrapper] | main.rs:53:17:53:25 | w.clone() [Wrapper] |
 testFailures
@@ -273,3 +333,10 @@ testFailures
 | main.rs:127:14:127:19 | ms.val | main.rs:122:38:122:47 | source(...) | main.rs:127:14:127:19 | ms.val | $@ | main.rs:122:38:122:47 | source(...) | source(...) |
 | main.rs:129:14:129:38 | ... .val | main.rs:122:38:122:47 | source(...) | main.rs:129:14:129:38 | ... .val | $@ | main.rs:122:38:122:47 | source(...) | source(...) |
 | main.rs:139:14:139:48 | ... .val | main.rs:136:38:136:47 | source(...) | main.rs:139:14:139:48 | ... .val | $@ | main.rs:136:38:136:47 | source(...) | source(...) |
+| main.rs:156:10:156:10 | c | main.rs:153:13:153:22 | source(...) | main.rs:156:10:156:10 | c | $@ | main.rs:153:13:153:22 | source(...) | source(...) |
+| main.rs:156:10:156:10 | c | main.rs:154:13:154:22 | source(...) | main.rs:156:10:156:10 | c | $@ | main.rs:154:13:154:22 | source(...) | source(...) |
+| main.rs:161:10:161:10 | f | main.rs:158:13:158:22 | source(...) | main.rs:161:10:161:10 | f | $@ | main.rs:158:13:158:22 | source(...) | source(...) |
+| main.rs:161:10:161:10 | f | main.rs:159:13:159:22 | source(...) | main.rs:161:10:161:10 | f | $@ | main.rs:159:13:159:22 | source(...) | source(...) |
+| main.rs:167:10:167:10 | j | main.rs:163:13:163:22 | source(...) | main.rs:167:10:167:10 | j | $@ | main.rs:163:13:163:22 | source(...) | source(...) |
+| main.rs:167:10:167:10 | j | main.rs:164:13:164:22 | source(...) | main.rs:167:10:167:10 | j | $@ | main.rs:164:13:164:22 | source(...) | source(...) |
+| main.rs:167:10:167:10 | j | main.rs:165:13:165:22 | source(...) | main.rs:167:10:167:10 | j | $@ | main.rs:165:13:165:22 | source(...) | source(...) |

--- a/rust/ql/test/library-tests/dataflow/modeled/main.rs
+++ b/rust/ql/test/library-tests/dataflow/modeled/main.rs
@@ -149,10 +149,29 @@ fn test_pin() {
     }
 }
 
+fn test_ord() {
+    let a = source(50);
+    let b = source(51);
+    let c = a.min(b);
+    sink(c); // $ hasValueFlow=50 hasValueFlow=51
+
+    let d = source(52);
+    let e = source(53);
+    let f = d.max(e);
+    sink(f); // $ hasValueFlow=52 hasValueFlow=53
+
+    let g = source(54);
+    let h = source(55);
+    let i = source(56);
+    let j = g.clamp(h, i);
+    sink(j); // $ hasValueFlow=54 hasValueFlow=55 hasValueFlow=56
+}
+
 fn main() {
     option_clone();
     result_clone();
     i64_clone();
     my_clone::wrapper_clone();
     test_pin();
+    test_ord();
 }

--- a/rust/ql/test/library-tests/dataflow/models/models.expected
+++ b/rust/ql/test/library-tests/dataflow/models/models.expected
@@ -7,7 +7,7 @@ models
 | 6 | Source: main::enum_source; ReturnValue.Field[main::MyFieldEnum::D::field_d]; test-source |
 | 7 | Source: main::simple_source; ReturnValue; test-source |
 | 8 | Source: main::source_into_function::pass_source; Argument[1].Parameter[0]; test-source |
-| 9 | Summary: <_ as core::cmp::Ord>::max; Argument[self]; ReturnValue; value |
+| 9 | Summary: <_ as core::cmp::Ord>::max; Argument[self,0]; ReturnValue; value |
 | 10 | Summary: <_ as core::cmp::PartialOrd>::lt; Argument[self].Reference; ReturnValue; taint |
 | 11 | Summary: <_ as core::ops::index::Index>::index; Argument[self].Reference.Element; ReturnValue.Reference; value |
 | 12 | Summary: main::apply; Argument[0]; Argument[1].Parameter[0]; value |

--- a/rust/ql/test/library-tests/dataflow/models/models.ext.yml
+++ b/rust/ql/test/library-tests/dataflow/models/models.ext.yml
@@ -33,5 +33,4 @@ extensions:
       - ["main::apply", "Argument[0]", "Argument[1].Parameter[0]", "value", "manual"]
       - ["main::apply", "Argument[1].ReturnValue", "ReturnValue", "value", "manual"]
       - ["main::get_async_number", "Argument[0]", "ReturnValue.Future", "value", "manual"]
-      - ["<_ as core::cmp::Ord>::max", "Argument[self]", "ReturnValue", "value", "manual"]
       - ["<_ as core::cmp::PartialOrd>::lt", "Argument[self].Reference", "ReturnValue", "taint", "manual"]


### PR DESCRIPTION
As part of https://github.com/github/codeql/pull/20987, I wanted to write a data flow test using implicit custom dereferencing, and found out that we are lacking flow models for [`Ord` methods](https://doc.rust-lang.org/std/cmp/trait.Ord.html#provided-methods). This PR adds those models, as well as the test case.