### PR TITLE
C# 14: [TEST ONLY] Test for `nameof` generic type.

### DIFF
--- a/csharp/ql/test/library-tests/nameof/NameOf.cs
+++ b/csharp/ql/test/library-tests/nameof/NameOf.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+
+class Program
+{
+    public void M(int x)
+    {
+        var test1 = nameof(x);
+        var test2 = nameof(M);
+        var test3 = nameof(Program);
+        var test4 = nameof(String);
+        var test5 = nameof(List<int>);
+        var test6 = nameof(List<>);
+    }
+}

--- a/csharp/ql/test/library-tests/nameof/PrintAst.expected
+++ b/csharp/ql/test/library-tests/nameof/PrintAst.expected
@@ -1,0 +1,50 @@
+NameOf.cs:
+#    4| [Class] Program
+#    6|   6: [Method] M
+#    6|     -1: [TypeMention] Void
+#-----|     2: (Parameters)
+#    6|       0: [Parameter] x
+#    6|         -1: [TypeMention] int
+#    7|     4: [BlockStmt] {...}
+#    8|       0: [LocalVariableDeclStmt] ... ...;
+#    8|         0: [LocalVariableDeclAndInitExpr] String test1 = ...
+#    8|           -1: [TypeMention] string
+#    8|           0: [LocalVariableAccess] access to local variable test1
+#    8|           1: [NameOfExpr] nameof(...)
+#    8|             0: [ParameterAccess] access to parameter x
+#    9|       1: [LocalVariableDeclStmt] ... ...;
+#    9|         0: [LocalVariableDeclAndInitExpr] String test2 = ...
+#    9|           -1: [TypeMention] string
+#    9|           0: [LocalVariableAccess] access to local variable test2
+#    9|           1: [NameOfExpr] nameof(...)
+#    9|             0: [MethodAccess] access to method M
+#   10|       2: [LocalVariableDeclStmt] ... ...;
+#   10|         0: [LocalVariableDeclAndInitExpr] String test3 = ...
+#   10|           -1: [TypeMention] string
+#   10|           0: [LocalVariableAccess] access to local variable test3
+#   10|           1: [NameOfExpr] nameof(...)
+#   10|             0: [TypeAccess] access to type Program
+#   10|               0: [TypeMention] Program
+#   11|       3: [LocalVariableDeclStmt] ... ...;
+#   11|         0: [LocalVariableDeclAndInitExpr] String test4 = ...
+#   11|           -1: [TypeMention] string
+#   11|           0: [LocalVariableAccess] access to local variable test4
+#   11|           1: [NameOfExpr] nameof(...)
+#   11|             0: [TypeAccess] access to type String
+#   11|               0: [TypeMention] string
+#   12|       4: [LocalVariableDeclStmt] ... ...;
+#   12|         0: [LocalVariableDeclAndInitExpr] String test5 = ...
+#   12|           -1: [TypeMention] string
+#   12|           0: [LocalVariableAccess] access to local variable test5
+#   12|           1: [NameOfExpr] nameof(...)
+#   12|             0: [TypeAccess] access to type List<Int32>
+#   12|               0: [TypeMention] List<int>
+#   12|                 1: [TypeMention] int
+#   13|       5: [LocalVariableDeclStmt] ... ...;
+#   13|         0: [LocalVariableDeclAndInitExpr] String test6 = ...
+#   13|           -1: [TypeMention] string
+#   13|           0: [LocalVariableAccess] access to local variable test6
+#   13|           1: [NameOfExpr] nameof(...)
+#   13|             0: [TypeAccess] access to type List`1
+#   13|               0: [TypeMention] List<T>
+#   13|                 1: [TypeMention] T

--- a/csharp/ql/test/library-tests/nameof/PrintAst.qlref
+++ b/csharp/ql/test/library-tests/nameof/PrintAst.qlref
@@ -1,0 +1,1 @@
+shared/PrintAst.ql

--- a/csharp/ql/test/library-tests/nameof/nameof.expected
+++ b/csharp/ql/test/library-tests/nameof/nameof.expected
@@ -1,0 +1,6 @@
+| NameOf.cs:8:21:8:29 | nameof(...) | NameOf.cs:8:28:8:28 | access to parameter x |
+| NameOf.cs:9:21:9:29 | nameof(...) | NameOf.cs:9:28:9:28 | access to method M |
+| NameOf.cs:10:21:10:35 | nameof(...) | NameOf.cs:10:28:10:34 | access to type Program |
+| NameOf.cs:11:21:11:34 | nameof(...) | NameOf.cs:11:28:11:33 | access to type String |
+| NameOf.cs:12:21:12:37 | nameof(...) | NameOf.cs:12:28:12:36 | access to type List<Int32> |
+| NameOf.cs:13:21:13:34 | nameof(...) | NameOf.cs:13:28:13:33 | access to type List`1 |

--- a/csharp/ql/test/library-tests/nameof/nameof.ql
+++ b/csharp/ql/test/library-tests/nameof/nameof.ql
@@ -1,0 +1,4 @@
+import csharp
+
+from NameOfExpr e
+select e, e.getAccess()

--- a/csharp/ql/test/library-tests/nameof/options
+++ b/csharp/ql/test/library-tests/nameof/options
@@ -1,0 +1,2 @@
+semmle-extractor-options: /nostdlib /noconfig
+semmle-extractor-options: --load-sources-from-project:${testdir}/../../resources/stubs/_frameworks/Microsoft.NETCore.App/Microsoft.NETCore.App.csproj


### PR DESCRIPTION
In this PR we add a test for `nameof` applied to a generic type (previously this only worked for constructed types). This works out of the box in the extractor and QL library.