### PR TITLE
Fix header link color and hover effect in query help documentation

### DIFF
--- a/docs/codeql/_static/custom.css_t
+++ b/docs/codeql/_static/custom.css_t
@@ -14,6 +14,18 @@ code {
     font-size: 0.9em !important; /* makes code snippets in headings the correct size */
 }
 
+/* -- HEADER ------------------------------------------------------------------------------- */
+
+/* Override alabaster.css purple link color for header links to match the rest of the site */
+.Header .Header-link {
+    color: #fff;
+}
+
+.Header .Header-link:hover,
+.Header .Header-link:focus {
+    color: rgba(255, 255, 255, 0.7);
+}
+
 /* -- MAIN BODY ---------------------------------------------------------------------------- */
 
 main {


### PR DESCRIPTION
Fix from @oscarsj, who wrote:

The Alabaster theme's global `a { color: #2F1695 }` rule was overriding header link colors, rendering them purple instead of white.