### PR TITLE
GitHub: Add workflow_dispatch trigger to compile-queries.yml

### DIFF
--- a/.github/workflows/compile-queries.yml
+++ b/.github/workflows/compile-queries.yml
@@ -1,6 +1,7 @@
 name: "Compile all queries using the latest stable CodeQL CLI"
 
 on:
+  workflow_dispatch:
   push:
     branches:  # makes sure the cache gets populated - running on the branches people tend to merge into.
       - main


### PR DESCRIPTION

This change adds a workflow_dispatch trigger to the
compile-queries.yml GitHub Actions workflow, allowing
manual triggering of the query compilation test.
