### PR TITLE
Rust: Add `Result::Err` to `excludeFieldTaintStep`

### DIFF
--- a/rust/ql/lib/codeql/rust/frameworks/stdlib/core.model.yml
+++ b/rust/ql/lib/codeql/rust/frameworks/stdlib/core.model.yml
@@ -153,3 +153,4 @@ extensions:
     data:
       - ["core::ops::range::RangeInclusive::start"]
       - ["core::ops::range::RangeInclusive::end"]
+      - ["core::result::Result::Err(0)"]


### PR DESCRIPTION
The motivation here is that if a `Result` value is user-controllable, then it likely means that only the `Ok` branch is controllable. [DCA](https://github.com/github/codeql-dca-main/issues/33912) confirms that we have fewer results for `rust/log-injection` and `rust/cleartext-logging`.