### PR TITLE
Rust: Also lift read steps in summaries as taint steps

### DIFF
--- a/rust/ql/lib/codeql/rust/dataflow/internal/TaintTrackingImpl.qll
+++ b/rust/ql/lib/codeql/rust/dataflow/internal/TaintTrackingImpl.qll
@@ -52,18 +52,9 @@ module RustTaintTracking implements InputSig<Location, RustDataFlow> {
       // Read steps give rise to taint steps. This has the effect that if `foo`
       // is tainted and an operation reads from `foo` (e.g., `foo.bar`) then
       // taint is propagated.
-      exists(Content c |
-        RustDataFlow::readContentStep(pred, c, succ) and
-        not excludedTaintStepContent(c)
-      )
-      or
-      // In addition to the above, for element and reference content we let
-      // _all_ read steps (including those from flow summaries and those that
-      // result in small primitive types) give rise to taint steps.
-      exists(SingletonContentSet cs | RustDataFlow::readStep(pred, cs, succ) |
-        cs.getContent() instanceof ElementContent
-        or
-        cs.getContent() instanceof ReferenceContent
+      exists(ContentSet cs |
+        RustDataFlow::readStep(pred, cs, succ) and
+        not excludedTaintStepContent(cs.getAReadContent())
       )
       or
       exists(FormatArgsExpr format | succ.asExpr() = format |

--- a/rust/ql/test/library-tests/dataflow/modeled/inline-flow.expected
+++ b/rust/ql/test/library-tests/dataflow/modeled/inline-flow.expected
@@ -17,11 +17,12 @@ models
 | 16 | Summary: <core::pin::Pin as core::ops::deref::Deref>::deref; Argument[self].Reference.Field[core::pin::Pin::pointer].Reference; ReturnValue.Reference; value |
 | 17 | Summary: <core::pin::Pin>::into_inner; Argument[0].Field[core::pin::Pin::pointer]; ReturnValue; value |
 | 18 | Summary: <core::pin::Pin>::into_inner_unchecked; Argument[0].Field[core::pin::Pin::pointer]; ReturnValue; value |
-| 19 | Summary: <core::pin::Pin>::new; Argument[0]; ReturnValue.Field[core::pin::Pin::pointer]; value |
-| 20 | Summary: <core::pin::Pin>::new_unchecked; Argument[0]; ReturnValue.Field[core::pin::Pin::pointer]; value |
-| 21 | Summary: <core::result::Result>::unwrap; Argument[self].Field[core::result::Result::Ok(0)]; ReturnValue; value |
-| 22 | Summary: core::ptr::read; Argument[0].Reference; ReturnValue; value |
-| 23 | Summary: core::ptr::write; Argument[1]; Argument[0].Reference; value |
+| 19 | Summary: <core::pin::Pin>::new; Argument[0].Reference; ReturnValue; value |
+| 20 | Summary: <core::pin::Pin>::new; Argument[0]; ReturnValue.Field[core::pin::Pin::pointer]; value |
+| 21 | Summary: <core::pin::Pin>::new_unchecked; Argument[0]; ReturnValue.Field[core::pin::Pin::pointer]; value |
+| 22 | Summary: <core::result::Result>::unwrap; Argument[self].Field[core::result::Result::Ok(0)]; ReturnValue; value |
+| 23 | Summary: core::ptr::read; Argument[0].Reference; ReturnValue; value |
+| 24 | Summary: core::ptr::write; Argument[1]; Argument[0].Reference; value |
 edges
 | main.rs:12:9:12:9 | a [Some] | main.rs:13:10:13:10 | a [Some] | provenance |  |
 | main.rs:12:9:12:9 | a [Some] | main.rs:14:13:14:13 | a [Some] | provenance |  |
@@ -36,11 +37,11 @@ edges
 | main.rs:19:9:19:9 | a [Ok] | main.rs:21:13:21:13 | a [Ok] | provenance |  |
 | main.rs:19:31:19:44 | Ok(...) [Ok] | main.rs:19:9:19:9 | a [Ok] | provenance |  |
 | main.rs:19:34:19:43 | source(...) | main.rs:19:31:19:44 | Ok(...) [Ok] | provenance |  |
-| main.rs:20:10:20:10 | a [Ok] | main.rs:20:10:20:19 | a.unwrap() | provenance | MaD:21 |
+| main.rs:20:10:20:10 | a [Ok] | main.rs:20:10:20:19 | a.unwrap() | provenance | MaD:22 |
 | main.rs:21:9:21:9 | b [Ok] | main.rs:22:10:22:10 | b [Ok] | provenance |  |
 | main.rs:21:13:21:13 | a [Ok] | main.rs:21:13:21:21 | a.clone() [Ok] | provenance | MaD:2 |
 | main.rs:21:13:21:21 | a.clone() [Ok] | main.rs:21:9:21:9 | b [Ok] | provenance |  |
-| main.rs:22:10:22:10 | b [Ok] | main.rs:22:10:22:19 | b.unwrap() | provenance | MaD:21 |
+| main.rs:22:10:22:10 | b [Ok] | main.rs:22:10:22:19 | b.unwrap() | provenance | MaD:22 |
 | main.rs:26:9:26:9 | a | main.rs:27:10:27:10 | a | provenance |  |
 | main.rs:26:9:26:9 | a | main.rs:28:13:28:13 | a | provenance |  |
 | main.rs:26:13:26:22 | source(...) | main.rs:26:9:26:9 | a | provenance |  |
@@ -81,18 +82,22 @@ edges
 | main.rs:79:37:79:46 | source(...) | main.rs:79:33:79:46 | ... + ... | provenance | MaD:6 |
 | main.rs:79:37:79:46 | source(...) | main.rs:79:33:79:46 | ... + ... | provenance | MaD:7 |
 | main.rs:92:29:92:29 | [post] y [&ref] | main.rs:93:33:93:33 | y [&ref] | provenance |  |
-| main.rs:92:32:92:41 | source(...) | main.rs:92:29:92:29 | [post] y [&ref] | provenance | MaD:23 |
-| main.rs:93:33:93:33 | y [&ref] | main.rs:93:18:93:34 | ...::read(...) | provenance | MaD:22 |
+| main.rs:92:32:92:41 | source(...) | main.rs:92:29:92:29 | [post] y [&ref] | provenance | MaD:24 |
+| main.rs:93:33:93:33 | y [&ref] | main.rs:93:18:93:34 | ...::read(...) | provenance | MaD:23 |
 | main.rs:108:13:108:17 | mut i | main.rs:109:34:109:34 | i | provenance |  |
 | main.rs:108:13:108:17 | mut i | main.rs:110:33:110:33 | i | provenance |  |
 | main.rs:108:13:108:17 | mut i | main.rs:111:47:111:47 | i | provenance |  |
 | main.rs:108:13:108:17 | mut i | main.rs:112:24:112:27 | mut pinned | provenance |  |
 | main.rs:108:13:108:17 | mut i | main.rs:113:14:113:14 | i | provenance |  |
 | main.rs:108:21:108:30 | source(...) | main.rs:108:13:108:17 | mut i | provenance |  |
+| main.rs:109:13:109:20 | mut pin1 | main.rs:114:15:114:18 | pin1 | provenance |  |
+| main.rs:109:13:109:20 | mut pin1 | main.rs:115:31:115:34 | pin1 | provenance |  |
 | main.rs:109:13:109:20 | mut pin1 [Pin, &ref] | main.rs:114:15:114:18 | pin1 [Pin, &ref] | provenance |  |
 | main.rs:109:13:109:20 | mut pin1 [Pin, &ref] | main.rs:115:31:115:34 | pin1 [Pin, &ref] | provenance |  |
+| main.rs:109:24:109:35 | ...::new(...) | main.rs:109:13:109:20 | mut pin1 | provenance |  |
 | main.rs:109:24:109:35 | ...::new(...) [Pin, &ref] | main.rs:109:13:109:20 | mut pin1 [Pin, &ref] | provenance |  |
-| main.rs:109:33:109:34 | &i [&ref] | main.rs:109:24:109:35 | ...::new(...) [Pin, &ref] | provenance | MaD:19 |
+| main.rs:109:33:109:34 | &i [&ref] | main.rs:109:24:109:35 | ...::new(...) | provenance | MaD:19 |
+| main.rs:109:33:109:34 | &i [&ref] | main.rs:109:24:109:35 | ...::new(...) [Pin, &ref] | provenance | MaD:20 |
 | main.rs:109:34:109:34 | i | main.rs:109:33:109:34 | &i [&ref] | provenance |  |
 | main.rs:110:13:110:20 | mut pin2 [Pin, Box(0)] | main.rs:116:15:116:18 | pin2 [Pin, Box(0)] | provenance |  |
 | main.rs:110:24:110:34 | ...::pin(...) [Pin, Box(0)] | main.rs:110:13:110:20 | mut pin2 [Pin, Box(0)] | provenance |  |
@@ -102,12 +107,16 @@ edges
 | main.rs:111:38:111:48 | ...::new(...) [Box(0)] | main.rs:111:24:111:49 | ...::into_pin(...) [Pin, Box(0)] | provenance | MaD:8 |
 | main.rs:111:47:111:47 | i | main.rs:111:38:111:48 | ...::new(...) [Box(0)] | provenance | MaD:9 |
 | main.rs:112:13:112:20 | mut pin4 [Pin, &ref] | main.rs:118:15:118:18 | pin4 [Pin, &ref] | provenance |  |
-| main.rs:112:24:112:27 | &mut pinned [&ref] | main.rs:112:24:112:27 | ...::new_unchecked(...) [Pin, &ref] | provenance | MaD:20 |
+| main.rs:112:24:112:27 | &mut pinned [&ref] | main.rs:112:24:112:27 | ...::new_unchecked(...) [Pin, &ref] | provenance | MaD:21 |
 | main.rs:112:24:112:27 | ...::new_unchecked(...) [Pin, &ref] | main.rs:112:13:112:20 | mut pin4 [Pin, &ref] | provenance |  |
 | main.rs:112:24:112:27 | mut pinned | main.rs:112:24:112:27 | pinned | provenance |  |
 | main.rs:112:24:112:27 | pinned | main.rs:112:24:112:27 | &mut pinned [&ref] | provenance |  |
+| main.rs:114:15:114:18 | pin1 | main.rs:114:14:114:18 | * ... | provenance | MaD:15 |
+| main.rs:114:15:114:18 | pin1 | main.rs:114:14:114:18 | * ... | provenance | MaD:16 |
 | main.rs:114:15:114:18 | pin1 [Pin, &ref] | main.rs:114:14:114:18 | * ... | provenance | MaD:16 |
+| main.rs:115:15:115:35 | ...::into_inner(...) | main.rs:115:14:115:35 | * ... | provenance | MaD:1 |
 | main.rs:115:15:115:35 | ...::into_inner(...) [&ref] | main.rs:115:14:115:35 | * ... | provenance | MaD:1 |
+| main.rs:115:31:115:34 | pin1 | main.rs:115:15:115:35 | ...::into_inner(...) | provenance | MaD:17 |
 | main.rs:115:31:115:34 | pin1 [Pin, &ref] | main.rs:115:15:115:35 | ...::into_inner(...) [&ref] | provenance | MaD:17 |
 | main.rs:116:15:116:18 | pin2 [Pin, Box(0)] | main.rs:116:14:116:18 | * ... | provenance | MaD:15 |
 | main.rs:117:15:117:18 | pin3 [Pin, Box(0)] | main.rs:117:14:117:18 | * ... | provenance | MaD:15 |
@@ -118,7 +127,7 @@ edges
 | main.rs:122:38:122:47 | source(...) | main.rs:122:22:122:49 | MyStruct {...} [MyStruct] | provenance |  |
 | main.rs:123:13:123:20 | mut pin1 [Pin, &ref, MyStruct] | main.rs:129:30:129:33 | pin1 [Pin, &ref, MyStruct] | provenance |  |
 | main.rs:123:24:123:36 | ...::new(...) [Pin, &ref, MyStruct] | main.rs:123:13:123:20 | mut pin1 [Pin, &ref, MyStruct] | provenance |  |
-| main.rs:123:33:123:35 | &ms [&ref, MyStruct] | main.rs:123:24:123:36 | ...::new(...) [Pin, &ref, MyStruct] | provenance | MaD:19 |
+| main.rs:123:33:123:35 | &ms [&ref, MyStruct] | main.rs:123:24:123:36 | ...::new(...) [Pin, &ref, MyStruct] | provenance | MaD:20 |
 | main.rs:123:34:123:35 | ms [MyStruct] | main.rs:123:33:123:35 | &ms [&ref, MyStruct] | provenance |  |
 | main.rs:127:14:127:15 | ms [MyStruct] | main.rs:127:14:127:19 | ms.val | provenance |  |
 | main.rs:129:14:129:34 | ...::into_inner(...) [&ref, MyStruct] | main.rs:129:14:129:38 | ... .val | provenance |  |
@@ -128,7 +137,7 @@ edges
 | main.rs:136:38:136:47 | source(...) | main.rs:136:22:136:49 | MyStruct {...} [MyStruct] | provenance |  |
 | main.rs:137:13:137:20 | mut pin5 [Pin, &ref, MyStruct] | main.rs:139:40:139:43 | pin5 [Pin, &ref, MyStruct] | provenance |  |
 | main.rs:137:24:137:46 | ...::new_unchecked(...) [Pin, &ref, MyStruct] | main.rs:137:13:137:20 | mut pin5 [Pin, &ref, MyStruct] | provenance |  |
-| main.rs:137:43:137:45 | &ms [&ref, MyStruct] | main.rs:137:24:137:46 | ...::new_unchecked(...) [Pin, &ref, MyStruct] | provenance | MaD:20 |
+| main.rs:137:43:137:45 | &ms [&ref, MyStruct] | main.rs:137:24:137:46 | ...::new_unchecked(...) [Pin, &ref, MyStruct] | provenance | MaD:21 |
 | main.rs:137:44:137:45 | ms [MyStruct] | main.rs:137:43:137:45 | &ms [&ref, MyStruct] | provenance |  |
 | main.rs:139:14:139:44 | ...::into_inner_unchecked(...) [&ref, MyStruct] | main.rs:139:14:139:48 | ... .val | provenance |  |
 | main.rs:139:40:139:43 | pin5 [Pin, &ref, MyStruct] | main.rs:139:14:139:44 | ...::into_inner_unchecked(...) [&ref, MyStruct] | provenance | MaD:18 |
@@ -227,7 +236,9 @@ nodes
 | main.rs:93:33:93:33 | y [&ref] | semmle.label | y [&ref] |
 | main.rs:108:13:108:17 | mut i | semmle.label | mut i |
 | main.rs:108:21:108:30 | source(...) | semmle.label | source(...) |
+| main.rs:109:13:109:20 | mut pin1 | semmle.label | mut pin1 |
 | main.rs:109:13:109:20 | mut pin1 [Pin, &ref] | semmle.label | mut pin1 [Pin, &ref] |
+| main.rs:109:24:109:35 | ...::new(...) | semmle.label | ...::new(...) |
 | main.rs:109:24:109:35 | ...::new(...) [Pin, &ref] | semmle.label | ...::new(...) [Pin, &ref] |
 | main.rs:109:33:109:34 | &i [&ref] | semmle.label | &i [&ref] |
 | main.rs:109:34:109:34 | i | semmle.label | i |
@@ -245,9 +256,12 @@ nodes
 | main.rs:112:24:112:27 | pinned | semmle.label | pinned |
 | main.rs:113:14:113:14 | i | semmle.label | i |
 | main.rs:114:14:114:18 | * ... | semmle.label | * ... |
+| main.rs:114:15:114:18 | pin1 | semmle.label | pin1 |
 | main.rs:114:15:114:18 | pin1 [Pin, &ref] | semmle.label | pin1 [Pin, &ref] |
 | main.rs:115:14:115:35 | * ... | semmle.label | * ... |
+| main.rs:115:15:115:35 | ...::into_inner(...) | semmle.label | ...::into_inner(...) |
 | main.rs:115:15:115:35 | ...::into_inner(...) [&ref] | semmle.label | ...::into_inner(...) [&ref] |
+| main.rs:115:31:115:34 | pin1 | semmle.label | pin1 |
 | main.rs:115:31:115:34 | pin1 [Pin, &ref] | semmle.label | pin1 [Pin, &ref] |
 | main.rs:116:14:116:18 | * ... | semmle.label | * ... |
 | main.rs:116:15:116:18 | pin2 [Pin, Box(0)] | semmle.label | pin2 [Pin, Box(0)] |

--- a/rust/ql/test/library-tests/dataflow/sources/file/InlineFlow.expected
+++ b/rust/ql/test/library-tests/dataflow/sources/file/InlineFlow.expected
@@ -36,7 +36,8 @@ models
 | 35 | Summary: <_ as tokio::io::util::async_read_ext::AsyncReadExt>::read_to_string; Argument[self].Reference; Argument[0].Reference; taint |
 | 36 | Summary: <_ as tokio::io::util::async_read_ext::AsyncReadExt>::read_u8; Argument[self].Reference; ReturnValue.Future.Field[core::result::Result::Ok(0)]; taint |
 | 37 | Summary: <core::result::Result>::unwrap; Argument[self].Field[core::result::Result::Ok(0)]; ReturnValue; value |
-| 38 | Summary: <std::path::PathBuf>::as_path; Argument[self].Reference; ReturnValue.Reference; value |
+| 38 | Summary: <std::ffi::os_str::OsString>::into_string; Argument[self].Field[std::ffi::os_str::OsString::inner].Field[std::sys::os_str::bytes::Buf::inner]; ReturnValue.Field[core::result::Result::Ok(0)].Field[alloc::string::String::vec]; value |
+| 39 | Summary: <std::path::PathBuf>::as_path; Argument[self].Reference; ReturnValue.Reference; value |
 edges
 | test.rs:12:13:12:18 | buffer | test.rs:13:14:13:19 | buffer | provenance |  |
 | test.rs:12:31:12:43 | ...::read | test.rs:12:31:12:55 | ...::read(...) [Ok] | provenance | Src:MaD:11  |
@@ -58,14 +59,18 @@ edges
 | test.rs:29:22:29:25 | path | test.rs:29:20:29:27 | e.path() | provenance | Src:MaD:4 MaD:4 |
 | test.rs:30:14:30:17 | path | test.rs:30:14:30:25 | path.clone() | provenance | MaD:18 |
 | test.rs:31:14:31:17 | path | test.rs:31:14:31:25 | path.clone() | provenance | MaD:18 |
-| test.rs:31:14:31:25 | path.clone() | test.rs:31:14:31:35 | ... .as_path() | provenance | MaD:38 |
+| test.rs:31:14:31:25 | path.clone() | test.rs:31:14:31:35 | ... .as_path() | provenance | MaD:39 |
 | test.rs:40:14:40:17 | path | test.rs:40:14:40:32 | path.canonicalize() [Ok] | provenance | MaD:19 |
 | test.rs:40:14:40:32 | path.canonicalize() [Ok] | test.rs:40:14:40:41 | ... .unwrap() | provenance | MaD:37 |
 | test.rs:43:13:43:21 | file_name | test.rs:44:14:44:22 | file_name | provenance |  |
+| test.rs:43:13:43:21 | file_name | test.rs:45:14:45:22 | file_name | provenance |  |
 | test.rs:43:13:43:21 | file_name | test.rs:49:14:49:22 | file_name | provenance |  |
 | test.rs:43:25:43:37 | e.file_name() | test.rs:43:13:43:21 | file_name | provenance |  |
 | test.rs:43:27:43:35 | file_name | test.rs:43:25:43:37 | e.file_name() | provenance | Src:MaD:3 MaD:3 |
 | test.rs:44:14:44:22 | file_name | test.rs:44:14:44:30 | file_name.clone() | provenance | MaD:18 |
+| test.rs:45:14:45:22 | file_name | test.rs:45:14:45:30 | file_name.clone() | provenance | MaD:18 |
+| test.rs:45:14:45:30 | file_name.clone() | test.rs:45:14:45:44 | ... .into_string() [Ok, String] | provenance | MaD:38 |
+| test.rs:45:14:45:44 | ... .into_string() [Ok, String] | test.rs:45:14:45:53 | ... .unwrap() | provenance | MaD:37 |
 | test.rs:65:13:65:18 | target | test.rs:66:14:66:19 | target | provenance |  |
 | test.rs:65:22:65:34 | ...::read_link | test.rs:65:22:65:49 | ...::read_link(...) [Ok] | provenance | Src:MaD:12  |
 | test.rs:65:22:65:49 | ...::read_link(...) [Ok] | test.rs:65:22:65:50 | TryExpr | provenance |  |
@@ -286,6 +291,10 @@ nodes
 | test.rs:43:27:43:35 | file_name | semmle.label | file_name |
 | test.rs:44:14:44:22 | file_name | semmle.label | file_name |
 | test.rs:44:14:44:30 | file_name.clone() | semmle.label | file_name.clone() |
+| test.rs:45:14:45:22 | file_name | semmle.label | file_name |
+| test.rs:45:14:45:30 | file_name.clone() | semmle.label | file_name.clone() |
+| test.rs:45:14:45:44 | ... .into_string() [Ok, String] | semmle.label | ... .into_string() [Ok, String] |
+| test.rs:45:14:45:53 | ... .unwrap() | semmle.label | ... .unwrap() |
 | test.rs:49:14:49:22 | file_name | semmle.label | file_name |
 | test.rs:65:13:65:18 | target | semmle.label | target |
 | test.rs:65:22:65:34 | ...::read_link | semmle.label | ...::read_link |
@@ -502,6 +511,7 @@ testFailures
 | test.rs:40:14:40:41 | ... .unwrap() | test.rs:29:22:29:25 | path | test.rs:40:14:40:41 | ... .unwrap() | $@ | test.rs:29:22:29:25 | path | path |
 | test.rs:41:14:41:17 | path | test.rs:29:22:29:25 | path | test.rs:41:14:41:17 | path | $@ | test.rs:29:22:29:25 | path | path |
 | test.rs:44:14:44:30 | file_name.clone() | test.rs:43:27:43:35 | file_name | test.rs:44:14:44:30 | file_name.clone() | $@ | test.rs:43:27:43:35 | file_name | file_name |
+| test.rs:45:14:45:53 | ... .unwrap() | test.rs:43:27:43:35 | file_name | test.rs:45:14:45:53 | ... .unwrap() | $@ | test.rs:43:27:43:35 | file_name | file_name |
 | test.rs:49:14:49:22 | file_name | test.rs:43:27:43:35 | file_name | test.rs:49:14:49:22 | file_name | $@ | test.rs:43:27:43:35 | file_name | file_name |
 | test.rs:66:14:66:19 | target | test.rs:65:22:65:34 | ...::read_link | test.rs:66:14:66:19 | target | $@ | test.rs:65:22:65:34 | ...::read_link | ...::read_link |
 | test.rs:75:14:75:19 | buffer | test.rs:74:31:74:45 | ...::read | test.rs:75:14:75:19 | buffer | $@ | test.rs:74:31:74:45 | ...::read | ...::read |

--- a/rust/ql/test/library-tests/dataflow/sources/file/test.rs
+++ b/rust/ql/test/library-tests/dataflow/sources/file/test.rs
@@ -42,7 +42,7 @@ fn test_fs() -> Result<(), Box<dyn std::error::Error>> {
 
         let file_name = e.file_name(); // $ Alert[rust/summary/taint-sources]
         sink(file_name.clone()); // $ hasTaintFlow
-        sink(file_name.clone().into_string().unwrap()); // $ MISSING: hasTaintFlow
+        sink(file_name.clone().into_string().unwrap()); // $ hasTaintFlow
         sink(file_name.to_str().unwrap()); // $ MISSING: hasTaintFlow
         sink(file_name.to_string_lossy().to_mut()); // $ MISSING: hasTaintFlow
         sink(file_name.clone().as_encoded_bytes()); // $ MISSING: hasTaintFlow

--- a/rust/ql/test/library-tests/dataflow/sources/stdin/InlineFlow.expected
+++ b/rust/ql/test/library-tests/dataflow/sources/stdin/InlineFlow.expected
@@ -1,151 +1,164 @@
 models
 | 1 | Source: std::io::stdio::stdin; ReturnValue; stdin |
 | 2 | Source: tokio::io::stdin::stdin; ReturnValue; stdin |
-| 3 | Summary: <_ as core::ops::index::Index>::index; Argument[self].Reference.Element; ReturnValue.Reference; value |
-| 4 | Summary: <_ as std::io::BufRead>::fill_buf; Argument[self].Reference; ReturnValue.Field[core::result::Result::Ok(0)]; taint |
-| 5 | Summary: <_ as std::io::BufRead>::lines; Argument[self]; ReturnValue; taint |
-| 6 | Summary: <_ as std::io::BufRead>::read_line; Argument[self].Reference; Argument[0].Reference; taint |
-| 7 | Summary: <_ as std::io::BufRead>::read_until; Argument[self].Reference; Argument[1].Reference; taint |
-| 8 | Summary: <_ as std::io::BufRead>::split; Argument[self]; ReturnValue; taint |
-| 9 | Summary: <_ as std::io::Read>::bytes; Argument[self]; ReturnValue; taint |
-| 10 | Summary: <_ as std::io::Read>::read; Argument[self].Reference; Argument[0].Reference; taint |
-| 11 | Summary: <_ as std::io::Read>::read_exact; Argument[self].Reference; Argument[0].Reference; taint |
-| 12 | Summary: <_ as std::io::Read>::read_to_end; Argument[self].Reference; Argument[0].Reference; taint |
-| 13 | Summary: <_ as std::io::Read>::read_to_string; Argument[self].Reference; Argument[0].Reference; taint |
-| 14 | Summary: <_ as tokio::io::util::async_buf_read_ext::AsyncBufReadExt>::fill_buf; Argument[self].Reference; ReturnValue.Future.Field[core::result::Result::Ok(0)]; taint |
-| 15 | Summary: <_ as tokio::io::util::async_buf_read_ext::AsyncBufReadExt>::lines; Argument[self]; ReturnValue; taint |
-| 16 | Summary: <_ as tokio::io::util::async_buf_read_ext::AsyncBufReadExt>::read_line; Argument[self].Reference; Argument[0].Reference; taint |
-| 17 | Summary: <_ as tokio::io::util::async_buf_read_ext::AsyncBufReadExt>::read_until; Argument[self].Reference; Argument[1].Reference; taint |
-| 18 | Summary: <_ as tokio::io::util::async_buf_read_ext::AsyncBufReadExt>::split; Argument[self]; ReturnValue; taint |
-| 19 | Summary: <_ as tokio::io::util::async_read_ext::AsyncReadExt>::read; Argument[self].Reference; Argument[0].Reference; taint |
-| 20 | Summary: <_ as tokio::io::util::async_read_ext::AsyncReadExt>::read_buf; Argument[self].Reference; Argument[0].Reference; taint |
-| 21 | Summary: <_ as tokio::io::util::async_read_ext::AsyncReadExt>::read_exact; Argument[self].Reference; Argument[0].Reference; taint |
-| 22 | Summary: <_ as tokio::io::util::async_read_ext::AsyncReadExt>::read_f32; Argument[self].Reference; ReturnValue.Future.Field[core::result::Result::Ok(0)]; taint |
-| 23 | Summary: <_ as tokio::io::util::async_read_ext::AsyncReadExt>::read_i16; Argument[self].Reference; ReturnValue.Future.Field[core::result::Result::Ok(0)]; taint |
-| 24 | Summary: <_ as tokio::io::util::async_read_ext::AsyncReadExt>::read_i64_le; Argument[self].Reference; ReturnValue.Future.Field[core::result::Result::Ok(0)]; taint |
-| 25 | Summary: <_ as tokio::io::util::async_read_ext::AsyncReadExt>::read_to_end; Argument[self].Reference; Argument[0].Reference; taint |
-| 26 | Summary: <_ as tokio::io::util::async_read_ext::AsyncReadExt>::read_to_string; Argument[self].Reference; Argument[0].Reference; taint |
-| 27 | Summary: <_ as tokio::io::util::async_read_ext::AsyncReadExt>::read_u8; Argument[self].Reference; ReturnValue.Future.Field[core::result::Result::Ok(0)]; taint |
-| 28 | Summary: <core::option::Option>::unwrap; Argument[self].Field[core::option::Option::Some(0)]; ReturnValue; value |
-| 29 | Summary: <core::result::Result>::unwrap; Argument[self].Field[core::result::Result::Ok(0)]; ReturnValue; value |
-| 30 | Summary: <std::io::Split as core::iter::traits::iterator::Iterator>::next; Argument[self].Reference.Element; ReturnValue.Field[core::option::Option::Some(0)].Field[core::result::Result::Ok(0)]; value |
-| 31 | Summary: <std::io::buffered::bufreader::BufReader>::buffer; Argument[self].Reference; ReturnValue.Reference; taint |
-| 32 | Summary: <std::io::buffered::bufreader::BufReader>::new; Argument[0]; ReturnValue; taint |
-| 33 | Summary: <std::io::stdio::Stdin>::lock; Argument[self].Reference; ReturnValue; taint |
-| 34 | Summary: <tokio::io::util::buf_reader::BufReader>::buffer; Argument[self].Reference; ReturnValue.Reference; taint |
-| 35 | Summary: <tokio::io::util::buf_reader::BufReader>::new; Argument[0]; ReturnValue; taint |
-| 36 | Summary: <tokio::io::util::lines::Lines>::next_line; Argument[self].Reference; ReturnValue.Future.Field[core::result::Result::Ok(0)].Field[core::option::Option::Some(0)]; taint |
-| 37 | Summary: <tokio::io::util::split::Split>::next_segment; Argument[self].Reference; ReturnValue.Future.Field[core::result::Result::Ok(0)].Field[core::option::Option::Some(0)]; taint |
+| 3 | Summary: <_ as core::clone::Clone>::clone; Argument[self].Reference; ReturnValue; value |
+| 4 | Summary: <_ as core::iter::traits::iterator::Iterator>::nth; Argument[self].Reference.Element; ReturnValue.Field[core::option::Option::Some(0)]; value |
+| 5 | Summary: <_ as core::ops::index::Index>::index; Argument[self].Reference.Element; ReturnValue.Reference; value |
+| 6 | Summary: <_ as std::io::BufRead>::fill_buf; Argument[self].Reference; ReturnValue.Field[core::result::Result::Ok(0)]; taint |
+| 7 | Summary: <_ as std::io::BufRead>::lines; Argument[self]; ReturnValue; taint |
+| 8 | Summary: <_ as std::io::BufRead>::read_line; Argument[self].Reference; Argument[0].Reference; taint |
+| 9 | Summary: <_ as std::io::BufRead>::read_until; Argument[self].Reference; Argument[1].Reference; taint |
+| 10 | Summary: <_ as std::io::BufRead>::split; Argument[self]; ReturnValue; taint |
+| 11 | Summary: <_ as std::io::Read>::bytes; Argument[self]; ReturnValue; taint |
+| 12 | Summary: <_ as std::io::Read>::read; Argument[self].Reference; Argument[0].Reference; taint |
+| 13 | Summary: <_ as std::io::Read>::read_exact; Argument[self].Reference; Argument[0].Reference; taint |
+| 14 | Summary: <_ as std::io::Read>::read_to_end; Argument[self].Reference; Argument[0].Reference; taint |
+| 15 | Summary: <_ as std::io::Read>::read_to_string; Argument[self].Reference; Argument[0].Reference; taint |
+| 16 | Summary: <_ as tokio::io::util::async_buf_read_ext::AsyncBufReadExt>::fill_buf; Argument[self].Reference; ReturnValue.Future.Field[core::result::Result::Ok(0)]; taint |
+| 17 | Summary: <_ as tokio::io::util::async_buf_read_ext::AsyncBufReadExt>::lines; Argument[self]; ReturnValue; taint |
+| 18 | Summary: <_ as tokio::io::util::async_buf_read_ext::AsyncBufReadExt>::read_line; Argument[self].Reference; Argument[0].Reference; taint |
+| 19 | Summary: <_ as tokio::io::util::async_buf_read_ext::AsyncBufReadExt>::read_until; Argument[self].Reference; Argument[1].Reference; taint |
+| 20 | Summary: <_ as tokio::io::util::async_buf_read_ext::AsyncBufReadExt>::split; Argument[self]; ReturnValue; taint |
+| 21 | Summary: <_ as tokio::io::util::async_read_ext::AsyncReadExt>::read; Argument[self].Reference; Argument[0].Reference; taint |
+| 22 | Summary: <_ as tokio::io::util::async_read_ext::AsyncReadExt>::read_buf; Argument[self].Reference; Argument[0].Reference; taint |
+| 23 | Summary: <_ as tokio::io::util::async_read_ext::AsyncReadExt>::read_exact; Argument[self].Reference; Argument[0].Reference; taint |
+| 24 | Summary: <_ as tokio::io::util::async_read_ext::AsyncReadExt>::read_f32; Argument[self].Reference; ReturnValue.Future.Field[core::result::Result::Ok(0)]; taint |
+| 25 | Summary: <_ as tokio::io::util::async_read_ext::AsyncReadExt>::read_i16; Argument[self].Reference; ReturnValue.Future.Field[core::result::Result::Ok(0)]; taint |
+| 26 | Summary: <_ as tokio::io::util::async_read_ext::AsyncReadExt>::read_i64_le; Argument[self].Reference; ReturnValue.Future.Field[core::result::Result::Ok(0)]; taint |
+| 27 | Summary: <_ as tokio::io::util::async_read_ext::AsyncReadExt>::read_to_end; Argument[self].Reference; Argument[0].Reference; taint |
+| 28 | Summary: <_ as tokio::io::util::async_read_ext::AsyncReadExt>::read_to_string; Argument[self].Reference; Argument[0].Reference; taint |
+| 29 | Summary: <_ as tokio::io::util::async_read_ext::AsyncReadExt>::read_u8; Argument[self].Reference; ReturnValue.Future.Field[core::result::Result::Ok(0)]; taint |
+| 30 | Summary: <core::option::Option>::unwrap; Argument[self].Field[core::option::Option::Some(0)]; ReturnValue; value |
+| 31 | Summary: <core::result::Result>::unwrap; Argument[self].Field[core::result::Result::Ok(0)]; ReturnValue; value |
+| 32 | Summary: <std::io::Split as core::iter::traits::iterator::Iterator>::next; Argument[self].Reference.Element; ReturnValue.Field[core::option::Option::Some(0)].Field[core::result::Result::Ok(0)]; value |
+| 33 | Summary: <std::io::buffered::bufreader::BufReader>::buffer; Argument[self].Reference; ReturnValue.Reference; taint |
+| 34 | Summary: <std::io::buffered::bufreader::BufReader>::new; Argument[0]; ReturnValue; taint |
+| 35 | Summary: <std::io::stdio::Stdin>::lock; Argument[self].Reference; ReturnValue; taint |
+| 36 | Summary: <tokio::io::util::buf_reader::BufReader>::buffer; Argument[self].Reference; ReturnValue.Reference; taint |
+| 37 | Summary: <tokio::io::util::buf_reader::BufReader>::new; Argument[0]; ReturnValue; taint |
+| 38 | Summary: <tokio::io::util::lines::Lines>::next_line; Argument[self].Reference; ReturnValue.Future.Field[core::result::Result::Ok(0)].Field[core::option::Option::Some(0)]; taint |
+| 39 | Summary: <tokio::io::util::split::Split>::next_segment; Argument[self].Reference; ReturnValue.Future.Field[core::result::Result::Ok(0)].Field[core::option::Option::Some(0)]; taint |
 edges
 | test.rs:13:22:13:35 | ...::stdin | test.rs:13:22:13:37 | ...::stdin(...) | provenance | Src:MaD:1 MaD:1 |
-| test.rs:13:22:13:37 | ...::stdin(...) | test.rs:13:44:13:54 | [post] &mut buffer [&ref] | provenance | MaD:10 |
+| test.rs:13:22:13:37 | ...::stdin(...) | test.rs:13:44:13:54 | [post] &mut buffer [&ref] | provenance | MaD:12 |
 | test.rs:13:44:13:54 | [post] &mut buffer [&ref] | test.rs:13:49:13:54 | [post] buffer | provenance |  |
 | test.rs:13:49:13:54 | [post] buffer | test.rs:14:15:14:20 | buffer | provenance |  |
 | test.rs:14:15:14:20 | buffer | test.rs:14:14:14:20 | &buffer | provenance |  |
 | test.rs:19:22:19:35 | ...::stdin | test.rs:19:22:19:37 | ...::stdin(...) | provenance | Src:MaD:1 MaD:1 |
-| test.rs:19:22:19:37 | ...::stdin(...) | test.rs:19:51:19:61 | [post] &mut buffer [&ref] | provenance | MaD:12 |
+| test.rs:19:22:19:37 | ...::stdin(...) | test.rs:19:51:19:61 | [post] &mut buffer [&ref] | provenance | MaD:14 |
 | test.rs:19:51:19:61 | [post] &mut buffer [&ref] | test.rs:19:56:19:61 | [post] buffer | provenance |  |
 | test.rs:19:56:19:61 | [post] buffer | test.rs:20:15:20:20 | buffer | provenance |  |
 | test.rs:20:15:20:20 | buffer | test.rs:20:14:20:20 | &buffer | provenance |  |
 | test.rs:25:22:25:35 | ...::stdin | test.rs:25:22:25:37 | ...::stdin(...) | provenance | Src:MaD:1 MaD:1 |
-| test.rs:25:22:25:37 | ...::stdin(...) | test.rs:25:54:25:64 | [post] &mut buffer [&ref] | provenance | MaD:13 |
+| test.rs:25:22:25:37 | ...::stdin(...) | test.rs:25:54:25:64 | [post] &mut buffer [&ref] | provenance | MaD:15 |
 | test.rs:25:54:25:64 | [post] &mut buffer [&ref] | test.rs:25:59:25:64 | [post] buffer | provenance |  |
 | test.rs:25:59:25:64 | [post] buffer | test.rs:26:15:26:20 | buffer | provenance |  |
 | test.rs:26:15:26:20 | buffer | test.rs:26:14:26:20 | &buffer | provenance |  |
 | test.rs:31:22:31:35 | ...::stdin | test.rs:31:22:31:37 | ...::stdin(...) | provenance | Src:MaD:1 MaD:1 |
-| test.rs:31:22:31:37 | ...::stdin(...) | test.rs:31:22:31:44 | ... .lock() | provenance | MaD:33 |
-| test.rs:31:22:31:44 | ... .lock() | test.rs:31:61:31:71 | [post] &mut buffer [&ref] | provenance | MaD:13 |
+| test.rs:31:22:31:37 | ...::stdin(...) | test.rs:31:22:31:44 | ... .lock() | provenance | MaD:35 |
+| test.rs:31:22:31:44 | ... .lock() | test.rs:31:61:31:71 | [post] &mut buffer [&ref] | provenance | MaD:15 |
 | test.rs:31:61:31:71 | [post] &mut buffer [&ref] | test.rs:31:66:31:71 | [post] buffer | provenance |  |
 | test.rs:31:66:31:71 | [post] buffer | test.rs:32:15:32:20 | buffer | provenance |  |
 | test.rs:32:15:32:20 | buffer | test.rs:32:14:32:20 | &buffer | provenance |  |
 | test.rs:37:9:37:22 | ...::stdin | test.rs:37:9:37:24 | ...::stdin(...) | provenance | Src:MaD:1 MaD:1 |
-| test.rs:37:9:37:24 | ...::stdin(...) | test.rs:37:37:37:47 | [post] &mut buffer [&ref] | provenance | MaD:11 |
+| test.rs:37:9:37:24 | ...::stdin(...) | test.rs:37:37:37:47 | [post] &mut buffer [&ref] | provenance | MaD:13 |
 | test.rs:37:37:37:47 | [post] &mut buffer [&ref] | test.rs:37:42:37:47 | [post] buffer | provenance |  |
 | test.rs:37:42:37:47 | [post] buffer | test.rs:38:15:38:20 | buffer | provenance |  |
 | test.rs:38:15:38:20 | buffer | test.rs:38:14:38:20 | &buffer | provenance |  |
 | test.rs:41:17:41:30 | ...::stdin | test.rs:41:17:41:32 | ...::stdin(...) | provenance | Src:MaD:1 MaD:1 |
-| test.rs:41:17:41:32 | ...::stdin(...) | test.rs:41:17:41:40 | ... .bytes() | provenance | MaD:9 |
+| test.rs:41:17:41:32 | ...::stdin(...) | test.rs:41:17:41:40 | ... .bytes() | provenance | MaD:11 |
 | test.rs:41:17:41:40 | ... .bytes() | test.rs:42:14:42:17 | byte | provenance |  |
 | test.rs:48:13:48:22 | mut reader | test.rs:49:20:49:25 | reader | provenance |  |
 | test.rs:48:26:48:66 | ...::new(...) | test.rs:48:13:48:22 | mut reader | provenance |  |
 | test.rs:48:50:48:63 | ...::stdin | test.rs:48:50:48:65 | ...::stdin(...) | provenance | Src:MaD:1 MaD:1 |
-| test.rs:48:50:48:65 | ...::stdin(...) | test.rs:48:26:48:66 | ...::new(...) | provenance | MaD:32 |
+| test.rs:48:50:48:65 | ...::stdin(...) | test.rs:48:26:48:66 | ...::new(...) | provenance | MaD:34 |
 | test.rs:49:13:49:16 | data | test.rs:50:15:50:18 | data | provenance |  |
-| test.rs:49:20:49:25 | reader | test.rs:49:20:49:36 | reader.fill_buf() [Ok] | provenance | MaD:4 |
+| test.rs:49:20:49:25 | reader | test.rs:49:20:49:36 | reader.fill_buf() [Ok] | provenance | MaD:6 |
 | test.rs:49:20:49:36 | reader.fill_buf() [Ok] | test.rs:49:20:49:37 | TryExpr | provenance |  |
 | test.rs:49:20:49:37 | TryExpr | test.rs:49:13:49:16 | data | provenance |  |
 | test.rs:50:15:50:18 | data | test.rs:50:14:50:18 | &data | provenance |  |
 | test.rs:54:13:54:18 | reader | test.rs:55:20:55:25 | reader | provenance |  |
 | test.rs:54:22:54:62 | ...::new(...) | test.rs:54:13:54:18 | reader | provenance |  |
 | test.rs:54:46:54:59 | ...::stdin | test.rs:54:46:54:61 | ...::stdin(...) | provenance | Src:MaD:1 MaD:1 |
-| test.rs:54:46:54:61 | ...::stdin(...) | test.rs:54:22:54:62 | ...::new(...) | provenance | MaD:32 |
+| test.rs:54:46:54:61 | ...::stdin(...) | test.rs:54:22:54:62 | ...::new(...) | provenance | MaD:34 |
 | test.rs:55:13:55:16 | data [&ref] | test.rs:56:15:56:18 | data [&ref] | provenance |  |
-| test.rs:55:20:55:25 | reader | test.rs:55:20:55:34 | reader.buffer() [&ref] | provenance | MaD:31 |
+| test.rs:55:20:55:25 | reader | test.rs:55:20:55:34 | reader.buffer() [&ref] | provenance | MaD:33 |
 | test.rs:55:20:55:34 | reader.buffer() [&ref] | test.rs:55:13:55:16 | data [&ref] | provenance |  |
 | test.rs:56:15:56:18 | data [&ref] | test.rs:56:14:56:18 | &data | provenance |  |
 | test.rs:61:13:61:22 | mut reader | test.rs:62:9:62:14 | reader | provenance |  |
 | test.rs:61:26:61:66 | ...::new(...) | test.rs:61:13:61:22 | mut reader | provenance |  |
 | test.rs:61:50:61:63 | ...::stdin | test.rs:61:50:61:65 | ...::stdin(...) | provenance | Src:MaD:1 MaD:1 |
-| test.rs:61:50:61:65 | ...::stdin(...) | test.rs:61:26:61:66 | ...::new(...) | provenance | MaD:32 |
-| test.rs:62:9:62:14 | reader | test.rs:62:26:62:36 | [post] &mut buffer [&ref] | provenance | MaD:6 |
+| test.rs:61:50:61:65 | ...::stdin(...) | test.rs:61:26:61:66 | ...::new(...) | provenance | MaD:34 |
+| test.rs:62:9:62:14 | reader | test.rs:62:26:62:36 | [post] &mut buffer [&ref] | provenance | MaD:8 |
 | test.rs:62:26:62:36 | [post] &mut buffer [&ref] | test.rs:62:31:62:36 | [post] buffer | provenance |  |
 | test.rs:62:31:62:36 | [post] buffer | test.rs:63:15:63:20 | buffer | provenance |  |
 | test.rs:63:15:63:20 | buffer | test.rs:63:14:63:20 | &buffer | provenance |  |
 | test.rs:68:13:68:22 | mut reader | test.rs:69:9:69:14 | reader | provenance |  |
 | test.rs:68:26:68:66 | ...::new(...) | test.rs:68:13:68:22 | mut reader | provenance |  |
 | test.rs:68:50:68:63 | ...::stdin | test.rs:68:50:68:65 | ...::stdin(...) | provenance | Src:MaD:1 MaD:1 |
-| test.rs:68:50:68:65 | ...::stdin(...) | test.rs:68:26:68:66 | ...::new(...) | provenance | MaD:32 |
-| test.rs:69:9:69:14 | reader | test.rs:69:33:69:43 | [post] &mut buffer [&ref] | provenance | MaD:7 |
+| test.rs:68:50:68:65 | ...::stdin(...) | test.rs:68:26:68:66 | ...::new(...) | provenance | MaD:34 |
+| test.rs:69:9:69:14 | reader | test.rs:69:33:69:43 | [post] &mut buffer [&ref] | provenance | MaD:9 |
 | test.rs:69:33:69:43 | [post] &mut buffer [&ref] | test.rs:69:38:69:43 | [post] buffer | provenance |  |
 | test.rs:69:38:69:43 | [post] buffer | test.rs:70:15:70:20 | buffer | provenance |  |
 | test.rs:69:38:69:43 | [post] buffer | test.rs:71:14:71:19 | buffer | provenance |  |
 | test.rs:70:15:70:20 | buffer | test.rs:70:14:70:20 | &buffer | provenance |  |
-| test.rs:71:14:71:19 | buffer | test.rs:71:14:71:22 | buffer[0] | provenance | MaD:3 |
+| test.rs:71:14:71:19 | buffer | test.rs:71:14:71:22 | buffer[0] | provenance | MaD:5 |
 | test.rs:75:13:75:28 | mut reader_split | test.rs:76:14:76:25 | reader_split | provenance |  |
 | test.rs:75:13:75:28 | mut reader_split | test.rs:77:33:77:44 | reader_split | provenance |  |
-| test.rs:75:32:75:72 | ...::new(...) | test.rs:75:32:75:84 | ... .split(...) | provenance | MaD:8 |
+| test.rs:75:32:75:72 | ...::new(...) | test.rs:75:32:75:84 | ... .split(...) | provenance | MaD:10 |
 | test.rs:75:32:75:84 | ... .split(...) | test.rs:75:13:75:28 | mut reader_split | provenance |  |
 | test.rs:75:56:75:69 | ...::stdin | test.rs:75:56:75:71 | ...::stdin(...) | provenance | Src:MaD:1 MaD:1 |
-| test.rs:75:56:75:71 | ...::stdin(...) | test.rs:75:32:75:72 | ...::new(...) | provenance | MaD:32 |
-| test.rs:76:14:76:25 | reader_split | test.rs:76:14:76:32 | reader_split.next() [Some, Ok] | provenance | MaD:30 |
-| test.rs:76:14:76:32 | reader_split.next() [Some, Ok] | test.rs:76:14:76:41 | ... .unwrap() [Ok] | provenance | MaD:28 |
-| test.rs:76:14:76:41 | ... .unwrap() [Ok] | test.rs:76:14:76:50 | ... .unwrap() | provenance | MaD:29 |
+| test.rs:75:56:75:71 | ...::stdin(...) | test.rs:75:32:75:72 | ...::new(...) | provenance | MaD:34 |
+| test.rs:76:14:76:25 | reader_split | test.rs:76:14:76:32 | reader_split.next() [Some, Ok] | provenance | MaD:32 |
+| test.rs:76:14:76:32 | reader_split.next() [Some, Ok] | test.rs:76:14:76:41 | ... .unwrap() [Ok] | provenance | MaD:30 |
+| test.rs:76:14:76:41 | ... .unwrap() [Ok] | test.rs:76:14:76:50 | ... .unwrap() | provenance | MaD:31 |
 | test.rs:77:19:77:29 | Some(...) [Some, Ok] | test.rs:77:24:77:28 | chunk [Ok] | provenance |  |
 | test.rs:77:24:77:28 | chunk [Ok] | test.rs:78:18:78:22 | chunk [Ok] | provenance |  |
-| test.rs:77:33:77:44 | reader_split | test.rs:77:33:77:51 | reader_split.next() [Some, Ok] | provenance | MaD:30 |
+| test.rs:77:33:77:44 | reader_split | test.rs:77:33:77:51 | reader_split.next() [Some, Ok] | provenance | MaD:32 |
 | test.rs:77:33:77:51 | reader_split.next() [Some, Ok] | test.rs:77:19:77:29 | Some(...) [Some, Ok] | provenance |  |
-| test.rs:78:18:78:22 | chunk [Ok] | test.rs:78:18:78:31 | chunk.unwrap() | provenance | MaD:29 |
+| test.rs:78:18:78:22 | chunk [Ok] | test.rs:78:18:78:31 | chunk.unwrap() | provenance | MaD:31 |
 | test.rs:83:13:83:18 | reader | test.rs:84:21:84:26 | reader | provenance |  |
 | test.rs:83:22:83:62 | ...::new(...) | test.rs:83:13:83:18 | reader | provenance |  |
 | test.rs:83:46:83:59 | ...::stdin | test.rs:83:46:83:61 | ...::stdin(...) | provenance | Src:MaD:1 MaD:1 |
-| test.rs:83:46:83:61 | ...::stdin(...) | test.rs:83:22:83:62 | ...::new(...) | provenance | MaD:32 |
-| test.rs:84:21:84:26 | reader | test.rs:84:21:84:34 | reader.lines() | provenance | MaD:5 |
+| test.rs:83:46:83:61 | ...::stdin(...) | test.rs:83:22:83:62 | ...::new(...) | provenance | MaD:34 |
+| test.rs:84:21:84:26 | reader | test.rs:84:21:84:34 | reader.lines() | provenance | MaD:7 |
 | test.rs:84:21:84:34 | reader.lines() | test.rs:85:18:85:21 | line | provenance |  |
+| test.rs:90:13:90:18 | reader | test.rs:91:20:91:25 | reader | provenance |  |
+| test.rs:90:22:90:62 | ...::new(...) | test.rs:90:13:90:18 | reader | provenance |  |
+| test.rs:90:46:90:59 | ...::stdin | test.rs:90:46:90:61 | ...::stdin(...) | provenance | Src:MaD:1 MaD:1 |
+| test.rs:90:46:90:61 | ...::stdin(...) | test.rs:90:22:90:62 | ...::new(...) | provenance | MaD:34 |
+| test.rs:91:13:91:16 | line | test.rs:92:14:92:17 | line | provenance |  |
+| test.rs:91:20:91:25 | reader | test.rs:91:20:91:33 | reader.lines() | provenance | MaD:7 |
+| test.rs:91:20:91:33 | reader.lines() | test.rs:91:20:91:40 | ... .nth(...) [Some] | provenance | MaD:4 |
+| test.rs:91:20:91:40 | ... .nth(...) [Some] | test.rs:91:20:91:49 | ... .unwrap() | provenance | MaD:30 |
+| test.rs:91:20:91:49 | ... .unwrap() | test.rs:91:13:91:16 | line | provenance |  |
+| test.rs:92:14:92:17 | line | test.rs:92:14:92:26 | line.unwrap() | provenance | MaD:31 |
+| test.rs:92:14:92:26 | line.unwrap() | test.rs:92:14:92:34 | ... .clone() | provenance | MaD:3 |
 | test.rs:109:13:109:21 | mut stdin | test.rs:111:22:111:26 | stdin | provenance |  |
 | test.rs:109:25:109:40 | ...::stdin | test.rs:109:25:109:42 | ...::stdin(...) | provenance | Src:MaD:2 MaD:2 |
 | test.rs:109:25:109:42 | ...::stdin(...) | test.rs:109:13:109:21 | mut stdin | provenance |  |
-| test.rs:111:22:111:26 | stdin | test.rs:111:33:111:43 | [post] &mut buffer [&ref] | provenance | MaD:19 |
+| test.rs:111:22:111:26 | stdin | test.rs:111:33:111:43 | [post] &mut buffer [&ref] | provenance | MaD:21 |
 | test.rs:111:33:111:43 | [post] &mut buffer [&ref] | test.rs:111:38:111:43 | [post] buffer | provenance |  |
 | test.rs:111:38:111:43 | [post] buffer | test.rs:112:15:112:20 | buffer | provenance |  |
 | test.rs:112:15:112:20 | buffer | test.rs:112:14:112:20 | &buffer | provenance |  |
 | test.rs:116:13:116:21 | mut stdin | test.rs:118:22:118:26 | stdin | provenance |  |
 | test.rs:116:25:116:40 | ...::stdin | test.rs:116:25:116:42 | ...::stdin(...) | provenance | Src:MaD:2 MaD:2 |
 | test.rs:116:25:116:42 | ...::stdin(...) | test.rs:116:13:116:21 | mut stdin | provenance |  |
-| test.rs:118:22:118:26 | stdin | test.rs:118:40:118:50 | [post] &mut buffer [&ref] | provenance | MaD:25 |
+| test.rs:118:22:118:26 | stdin | test.rs:118:40:118:50 | [post] &mut buffer [&ref] | provenance | MaD:27 |
 | test.rs:118:40:118:50 | [post] &mut buffer [&ref] | test.rs:118:45:118:50 | [post] buffer | provenance |  |
 | test.rs:118:45:118:50 | [post] buffer | test.rs:119:15:119:20 | buffer | provenance |  |
 | test.rs:119:15:119:20 | buffer | test.rs:119:14:119:20 | &buffer | provenance |  |
 | test.rs:123:13:123:21 | mut stdin | test.rs:125:22:125:26 | stdin | provenance |  |
 | test.rs:123:25:123:40 | ...::stdin | test.rs:123:25:123:42 | ...::stdin(...) | provenance | Src:MaD:2 MaD:2 |
 | test.rs:123:25:123:42 | ...::stdin(...) | test.rs:123:13:123:21 | mut stdin | provenance |  |
-| test.rs:125:22:125:26 | stdin | test.rs:125:43:125:53 | [post] &mut buffer [&ref] | provenance | MaD:26 |
+| test.rs:125:22:125:26 | stdin | test.rs:125:43:125:53 | [post] &mut buffer [&ref] | provenance | MaD:28 |
 | test.rs:125:43:125:53 | [post] &mut buffer [&ref] | test.rs:125:48:125:53 | [post] buffer | provenance |  |
 | test.rs:125:48:125:53 | [post] buffer | test.rs:126:15:126:20 | buffer | provenance |  |
 | test.rs:126:15:126:20 | buffer | test.rs:126:14:126:20 | &buffer | provenance |  |
 | test.rs:130:13:130:21 | mut stdin | test.rs:132:9:132:13 | stdin | provenance |  |
 | test.rs:130:25:130:40 | ...::stdin | test.rs:130:25:130:42 | ...::stdin(...) | provenance | Src:MaD:2 MaD:2 |
 | test.rs:130:25:130:42 | ...::stdin(...) | test.rs:130:13:130:21 | mut stdin | provenance |  |
-| test.rs:132:9:132:13 | stdin | test.rs:132:26:132:36 | [post] &mut buffer [&ref] | provenance | MaD:21 |
+| test.rs:132:9:132:13 | stdin | test.rs:132:26:132:36 | [post] &mut buffer [&ref] | provenance | MaD:23 |
 | test.rs:132:26:132:36 | [post] &mut buffer [&ref] | test.rs:132:31:132:36 | [post] buffer | provenance |  |
 | test.rs:132:31:132:36 | [post] buffer | test.rs:133:15:133:20 | buffer | provenance |  |
 | test.rs:133:15:133:20 | buffer | test.rs:133:14:133:20 | &buffer | provenance |  |
@@ -156,38 +169,38 @@ edges
 | test.rs:137:25:137:40 | ...::stdin | test.rs:137:25:137:42 | ...::stdin(...) | provenance | Src:MaD:2 MaD:2 |
 | test.rs:137:25:137:42 | ...::stdin(...) | test.rs:137:13:137:21 | mut stdin | provenance |  |
 | test.rs:138:13:138:14 | v1 | test.rs:142:14:142:15 | v1 | provenance |  |
-| test.rs:138:18:138:22 | stdin | test.rs:138:18:138:32 | stdin.read_u8() [future, Ok] | provenance | MaD:27 |
+| test.rs:138:18:138:22 | stdin | test.rs:138:18:138:32 | stdin.read_u8() [future, Ok] | provenance | MaD:29 |
 | test.rs:138:18:138:32 | stdin.read_u8() [future, Ok] | test.rs:138:18:138:38 | await ... [Ok] | provenance |  |
 | test.rs:138:18:138:38 | await ... [Ok] | test.rs:138:18:138:39 | TryExpr | provenance |  |
 | test.rs:138:18:138:39 | TryExpr | test.rs:138:13:138:14 | v1 | provenance |  |
 | test.rs:139:13:139:14 | v2 | test.rs:143:14:143:15 | v2 | provenance |  |
-| test.rs:139:18:139:22 | stdin | test.rs:139:18:139:33 | stdin.read_i16() [future, Ok] | provenance | MaD:23 |
+| test.rs:139:18:139:22 | stdin | test.rs:139:18:139:33 | stdin.read_i16() [future, Ok] | provenance | MaD:25 |
 | test.rs:139:18:139:33 | stdin.read_i16() [future, Ok] | test.rs:139:18:139:39 | await ... [Ok] | provenance |  |
 | test.rs:139:18:139:39 | await ... [Ok] | test.rs:139:18:139:40 | TryExpr | provenance |  |
 | test.rs:139:18:139:40 | TryExpr | test.rs:139:13:139:14 | v2 | provenance |  |
 | test.rs:140:13:140:14 | v3 | test.rs:144:14:144:15 | v3 | provenance |  |
-| test.rs:140:18:140:22 | stdin | test.rs:140:18:140:33 | stdin.read_f32() [future, Ok] | provenance | MaD:22 |
+| test.rs:140:18:140:22 | stdin | test.rs:140:18:140:33 | stdin.read_f32() [future, Ok] | provenance | MaD:24 |
 | test.rs:140:18:140:33 | stdin.read_f32() [future, Ok] | test.rs:140:18:140:39 | await ... [Ok] | provenance |  |
 | test.rs:140:18:140:39 | await ... [Ok] | test.rs:140:18:140:40 | TryExpr | provenance |  |
 | test.rs:140:18:140:40 | TryExpr | test.rs:140:13:140:14 | v3 | provenance |  |
 | test.rs:141:13:141:14 | v4 | test.rs:145:14:145:15 | v4 | provenance |  |
-| test.rs:141:18:141:22 | stdin | test.rs:141:18:141:36 | stdin.read_i64_le() [future, Ok] | provenance | MaD:24 |
+| test.rs:141:18:141:22 | stdin | test.rs:141:18:141:36 | stdin.read_i64_le() [future, Ok] | provenance | MaD:26 |
 | test.rs:141:18:141:36 | stdin.read_i64_le() [future, Ok] | test.rs:141:18:141:42 | await ... [Ok] | provenance |  |
 | test.rs:141:18:141:42 | await ... [Ok] | test.rs:141:18:141:43 | TryExpr | provenance |  |
 | test.rs:141:18:141:43 | TryExpr | test.rs:141:13:141:14 | v4 | provenance |  |
 | test.rs:149:13:149:21 | mut stdin | test.rs:151:9:151:13 | stdin | provenance |  |
 | test.rs:149:25:149:40 | ...::stdin | test.rs:149:25:149:42 | ...::stdin(...) | provenance | Src:MaD:2 MaD:2 |
 | test.rs:149:25:149:42 | ...::stdin(...) | test.rs:149:13:149:21 | mut stdin | provenance |  |
-| test.rs:151:9:151:13 | stdin | test.rs:151:24:151:34 | [post] &mut buffer [&ref] | provenance | MaD:20 |
+| test.rs:151:9:151:13 | stdin | test.rs:151:24:151:34 | [post] &mut buffer [&ref] | provenance | MaD:22 |
 | test.rs:151:24:151:34 | [post] &mut buffer [&ref] | test.rs:151:29:151:34 | [post] buffer | provenance |  |
 | test.rs:151:29:151:34 | [post] buffer | test.rs:152:15:152:20 | buffer | provenance |  |
 | test.rs:152:15:152:20 | buffer | test.rs:152:14:152:20 | &buffer | provenance |  |
 | test.rs:158:13:158:22 | mut reader | test.rs:159:20:159:25 | reader | provenance |  |
 | test.rs:158:26:158:70 | ...::new(...) | test.rs:158:13:158:22 | mut reader | provenance |  |
 | test.rs:158:52:158:67 | ...::stdin | test.rs:158:52:158:69 | ...::stdin(...) | provenance | Src:MaD:2 MaD:2 |
-| test.rs:158:52:158:69 | ...::stdin(...) | test.rs:158:26:158:70 | ...::new(...) | provenance | MaD:35 |
+| test.rs:158:52:158:69 | ...::stdin(...) | test.rs:158:26:158:70 | ...::new(...) | provenance | MaD:37 |
 | test.rs:159:13:159:16 | data | test.rs:160:15:160:18 | data | provenance |  |
-| test.rs:159:20:159:25 | reader | test.rs:159:20:159:36 | reader.fill_buf() [future, Ok] | provenance | MaD:14 |
+| test.rs:159:20:159:25 | reader | test.rs:159:20:159:36 | reader.fill_buf() [future, Ok] | provenance | MaD:16 |
 | test.rs:159:20:159:36 | reader.fill_buf() [future, Ok] | test.rs:159:20:159:42 | await ... [Ok] | provenance |  |
 | test.rs:159:20:159:42 | await ... [Ok] | test.rs:159:20:159:43 | TryExpr | provenance |  |
 | test.rs:159:20:159:43 | TryExpr | test.rs:159:13:159:16 | data | provenance |  |
@@ -195,60 +208,60 @@ edges
 | test.rs:164:13:164:18 | reader | test.rs:165:20:165:25 | reader | provenance |  |
 | test.rs:164:22:164:66 | ...::new(...) | test.rs:164:13:164:18 | reader | provenance |  |
 | test.rs:164:48:164:63 | ...::stdin | test.rs:164:48:164:65 | ...::stdin(...) | provenance | Src:MaD:2 MaD:2 |
-| test.rs:164:48:164:65 | ...::stdin(...) | test.rs:164:22:164:66 | ...::new(...) | provenance | MaD:35 |
+| test.rs:164:48:164:65 | ...::stdin(...) | test.rs:164:22:164:66 | ...::new(...) | provenance | MaD:37 |
 | test.rs:165:13:165:16 | data [&ref] | test.rs:166:15:166:18 | data [&ref] | provenance |  |
-| test.rs:165:20:165:25 | reader | test.rs:165:20:165:34 | reader.buffer() [&ref] | provenance | MaD:34 |
+| test.rs:165:20:165:25 | reader | test.rs:165:20:165:34 | reader.buffer() [&ref] | provenance | MaD:36 |
 | test.rs:165:20:165:34 | reader.buffer() [&ref] | test.rs:165:13:165:16 | data [&ref] | provenance |  |
 | test.rs:166:15:166:18 | data [&ref] | test.rs:166:14:166:18 | &data | provenance |  |
 | test.rs:171:13:171:22 | mut reader | test.rs:172:9:172:14 | reader | provenance |  |
 | test.rs:171:26:171:70 | ...::new(...) | test.rs:171:13:171:22 | mut reader | provenance |  |
 | test.rs:171:52:171:67 | ...::stdin | test.rs:171:52:171:69 | ...::stdin(...) | provenance | Src:MaD:2 MaD:2 |
-| test.rs:171:52:171:69 | ...::stdin(...) | test.rs:171:26:171:70 | ...::new(...) | provenance | MaD:35 |
-| test.rs:172:9:172:14 | reader | test.rs:172:26:172:36 | [post] &mut buffer [&ref] | provenance | MaD:16 |
+| test.rs:171:52:171:69 | ...::stdin(...) | test.rs:171:26:171:70 | ...::new(...) | provenance | MaD:37 |
+| test.rs:172:9:172:14 | reader | test.rs:172:26:172:36 | [post] &mut buffer [&ref] | provenance | MaD:18 |
 | test.rs:172:26:172:36 | [post] &mut buffer [&ref] | test.rs:172:31:172:36 | [post] buffer | provenance |  |
 | test.rs:172:31:172:36 | [post] buffer | test.rs:173:15:173:20 | buffer | provenance |  |
 | test.rs:173:15:173:20 | buffer | test.rs:173:14:173:20 | &buffer | provenance |  |
 | test.rs:178:13:178:22 | mut reader | test.rs:179:9:179:14 | reader | provenance |  |
 | test.rs:178:26:178:70 | ...::new(...) | test.rs:178:13:178:22 | mut reader | provenance |  |
 | test.rs:178:52:178:67 | ...::stdin | test.rs:178:52:178:69 | ...::stdin(...) | provenance | Src:MaD:2 MaD:2 |
-| test.rs:178:52:178:69 | ...::stdin(...) | test.rs:178:26:178:70 | ...::new(...) | provenance | MaD:35 |
-| test.rs:179:9:179:14 | reader | test.rs:179:33:179:43 | [post] &mut buffer [&ref] | provenance | MaD:17 |
+| test.rs:178:52:178:69 | ...::stdin(...) | test.rs:178:26:178:70 | ...::new(...) | provenance | MaD:37 |
+| test.rs:179:9:179:14 | reader | test.rs:179:33:179:43 | [post] &mut buffer [&ref] | provenance | MaD:19 |
 | test.rs:179:33:179:43 | [post] &mut buffer [&ref] | test.rs:179:38:179:43 | [post] buffer | provenance |  |
 | test.rs:179:38:179:43 | [post] buffer | test.rs:180:15:180:20 | buffer | provenance |  |
 | test.rs:179:38:179:43 | [post] buffer | test.rs:181:14:181:19 | buffer | provenance |  |
 | test.rs:180:15:180:20 | buffer | test.rs:180:14:180:20 | &buffer | provenance |  |
-| test.rs:181:14:181:19 | buffer | test.rs:181:14:181:22 | buffer[0] | provenance | MaD:3 |
+| test.rs:181:14:181:19 | buffer | test.rs:181:14:181:22 | buffer[0] | provenance | MaD:5 |
 | test.rs:185:13:185:28 | mut reader_split | test.rs:186:14:186:25 | reader_split | provenance |  |
 | test.rs:185:13:185:28 | mut reader_split | test.rs:187:33:187:44 | reader_split | provenance |  |
-| test.rs:185:32:185:76 | ...::new(...) | test.rs:185:32:185:88 | ... .split(...) | provenance | MaD:18 |
+| test.rs:185:32:185:76 | ...::new(...) | test.rs:185:32:185:88 | ... .split(...) | provenance | MaD:20 |
 | test.rs:185:32:185:88 | ... .split(...) | test.rs:185:13:185:28 | mut reader_split | provenance |  |
 | test.rs:185:58:185:73 | ...::stdin | test.rs:185:58:185:75 | ...::stdin(...) | provenance | Src:MaD:2 MaD:2 |
-| test.rs:185:58:185:75 | ...::stdin(...) | test.rs:185:32:185:76 | ...::new(...) | provenance | MaD:35 |
-| test.rs:186:14:186:25 | reader_split | test.rs:186:14:186:40 | reader_split.next_segment() [future, Ok, Some] | provenance | MaD:37 |
+| test.rs:185:58:185:75 | ...::stdin(...) | test.rs:185:32:185:76 | ...::new(...) | provenance | MaD:37 |
+| test.rs:186:14:186:25 | reader_split | test.rs:186:14:186:40 | reader_split.next_segment() [future, Ok, Some] | provenance | MaD:39 |
 | test.rs:186:14:186:40 | reader_split.next_segment() [future, Ok, Some] | test.rs:186:14:186:46 | await ... [Ok, Some] | provenance |  |
 | test.rs:186:14:186:46 | await ... [Ok, Some] | test.rs:186:14:186:47 | TryExpr [Some] | provenance |  |
-| test.rs:186:14:186:47 | TryExpr [Some] | test.rs:186:14:186:56 | ... .unwrap() | provenance | MaD:28 |
+| test.rs:186:14:186:47 | TryExpr [Some] | test.rs:186:14:186:56 | ... .unwrap() | provenance | MaD:30 |
 | test.rs:187:19:187:29 | Some(...) [Some] | test.rs:187:24:187:28 | chunk | provenance |  |
 | test.rs:187:24:187:28 | chunk | test.rs:188:18:188:22 | chunk | provenance |  |
-| test.rs:187:33:187:44 | reader_split | test.rs:187:33:187:59 | reader_split.next_segment() [future, Ok, Some] | provenance | MaD:37 |
+| test.rs:187:33:187:44 | reader_split | test.rs:187:33:187:59 | reader_split.next_segment() [future, Ok, Some] | provenance | MaD:39 |
 | test.rs:187:33:187:59 | reader_split.next_segment() [future, Ok, Some] | test.rs:187:33:187:65 | await ... [Ok, Some] | provenance |  |
 | test.rs:187:33:187:65 | await ... [Ok, Some] | test.rs:187:33:187:66 | TryExpr [Some] | provenance |  |
 | test.rs:187:33:187:66 | TryExpr [Some] | test.rs:187:19:187:29 | Some(...) [Some] | provenance |  |
 | test.rs:193:13:193:18 | reader | test.rs:194:25:194:30 | reader | provenance |  |
 | test.rs:193:22:193:66 | ...::new(...) | test.rs:193:13:193:18 | reader | provenance |  |
 | test.rs:193:48:193:63 | ...::stdin | test.rs:193:48:193:65 | ...::stdin(...) | provenance | Src:MaD:2 MaD:2 |
-| test.rs:193:48:193:65 | ...::stdin(...) | test.rs:193:22:193:66 | ...::new(...) | provenance | MaD:35 |
+| test.rs:193:48:193:65 | ...::stdin(...) | test.rs:193:22:193:66 | ...::new(...) | provenance | MaD:37 |
 | test.rs:194:13:194:21 | mut lines | test.rs:195:14:195:18 | lines | provenance |  |
 | test.rs:194:13:194:21 | mut lines | test.rs:196:32:196:36 | lines | provenance |  |
-| test.rs:194:25:194:30 | reader | test.rs:194:25:194:38 | reader.lines() | provenance | MaD:15 |
+| test.rs:194:25:194:30 | reader | test.rs:194:25:194:38 | reader.lines() | provenance | MaD:17 |
 | test.rs:194:25:194:38 | reader.lines() | test.rs:194:13:194:21 | mut lines | provenance |  |
-| test.rs:195:14:195:18 | lines | test.rs:195:14:195:30 | lines.next_line() [future, Ok, Some] | provenance | MaD:36 |
+| test.rs:195:14:195:18 | lines | test.rs:195:14:195:30 | lines.next_line() [future, Ok, Some] | provenance | MaD:38 |
 | test.rs:195:14:195:30 | lines.next_line() [future, Ok, Some] | test.rs:195:14:195:36 | await ... [Ok, Some] | provenance |  |
 | test.rs:195:14:195:36 | await ... [Ok, Some] | test.rs:195:14:195:37 | TryExpr [Some] | provenance |  |
-| test.rs:195:14:195:37 | TryExpr [Some] | test.rs:195:14:195:46 | ... .unwrap() | provenance | MaD:28 |
+| test.rs:195:14:195:37 | TryExpr [Some] | test.rs:195:14:195:46 | ... .unwrap() | provenance | MaD:30 |
 | test.rs:196:19:196:28 | Some(...) [Some] | test.rs:196:24:196:27 | line | provenance |  |
 | test.rs:196:24:196:27 | line | test.rs:197:18:197:21 | line | provenance |  |
-| test.rs:196:32:196:36 | lines | test.rs:196:32:196:48 | lines.next_line() [future, Ok, Some] | provenance | MaD:36 |
+| test.rs:196:32:196:36 | lines | test.rs:196:32:196:48 | lines.next_line() [future, Ok, Some] | provenance | MaD:38 |
 | test.rs:196:32:196:48 | lines.next_line() [future, Ok, Some] | test.rs:196:32:196:54 | await ... [Ok, Some] | provenance |  |
 | test.rs:196:32:196:54 | await ... [Ok, Some] | test.rs:196:32:196:55 | TryExpr [Some] | provenance |  |
 | test.rs:196:32:196:55 | TryExpr [Some] | test.rs:196:19:196:28 | Some(...) [Some] | provenance |  |
@@ -349,6 +362,18 @@ nodes
 | test.rs:84:21:84:26 | reader | semmle.label | reader |
 | test.rs:84:21:84:34 | reader.lines() | semmle.label | reader.lines() |
 | test.rs:85:18:85:21 | line | semmle.label | line |
+| test.rs:90:13:90:18 | reader | semmle.label | reader |
+| test.rs:90:22:90:62 | ...::new(...) | semmle.label | ...::new(...) |
+| test.rs:90:46:90:59 | ...::stdin | semmle.label | ...::stdin |
+| test.rs:90:46:90:61 | ...::stdin(...) | semmle.label | ...::stdin(...) |
+| test.rs:91:13:91:16 | line | semmle.label | line |
+| test.rs:91:20:91:25 | reader | semmle.label | reader |
+| test.rs:91:20:91:33 | reader.lines() | semmle.label | reader.lines() |
+| test.rs:91:20:91:40 | ... .nth(...) [Some] | semmle.label | ... .nth(...) [Some] |
+| test.rs:91:20:91:49 | ... .unwrap() | semmle.label | ... .unwrap() |
+| test.rs:92:14:92:17 | line | semmle.label | line |
+| test.rs:92:14:92:26 | line.unwrap() | semmle.label | line.unwrap() |
+| test.rs:92:14:92:34 | ... .clone() | semmle.label | ... .clone() |
 | test.rs:109:13:109:21 | mut stdin | semmle.label | mut stdin |
 | test.rs:109:25:109:40 | ...::stdin | semmle.label | ...::stdin |
 | test.rs:109:25:109:42 | ...::stdin(...) | semmle.label | ...::stdin(...) |
@@ -509,6 +534,7 @@ testFailures
 | test.rs:76:14:76:50 | ... .unwrap() | test.rs:75:56:75:69 | ...::stdin | test.rs:76:14:76:50 | ... .unwrap() | $@ | test.rs:75:56:75:69 | ...::stdin | ...::stdin |
 | test.rs:78:18:78:31 | chunk.unwrap() | test.rs:75:56:75:69 | ...::stdin | test.rs:78:18:78:31 | chunk.unwrap() | $@ | test.rs:75:56:75:69 | ...::stdin | ...::stdin |
 | test.rs:85:18:85:21 | line | test.rs:83:46:83:59 | ...::stdin | test.rs:85:18:85:21 | line | $@ | test.rs:83:46:83:59 | ...::stdin | ...::stdin |
+| test.rs:92:14:92:34 | ... .clone() | test.rs:90:46:90:59 | ...::stdin | test.rs:92:14:92:34 | ... .clone() | $@ | test.rs:90:46:90:59 | ...::stdin | ...::stdin |
 | test.rs:112:14:112:20 | &buffer | test.rs:109:25:109:40 | ...::stdin | test.rs:112:14:112:20 | &buffer | $@ | test.rs:109:25:109:40 | ...::stdin | ...::stdin |
 | test.rs:119:14:119:20 | &buffer | test.rs:116:25:116:40 | ...::stdin | test.rs:119:14:119:20 | &buffer | $@ | test.rs:116:25:116:40 | ...::stdin | ...::stdin |
 | test.rs:126:14:126:20 | &buffer | test.rs:123:25:123:40 | ...::stdin | test.rs:126:14:126:20 | &buffer | $@ | test.rs:123:25:123:40 | ...::stdin | ...::stdin |

--- a/rust/ql/test/library-tests/dataflow/sources/stdin/test.rs
+++ b/rust/ql/test/library-tests/dataflow/sources/stdin/test.rs
@@ -89,7 +89,7 @@ fn test_io_stdin() -> std::io::Result<()> {
     {
         let reader = std::io::BufReader::new(std::io::stdin()); // $ Alert[rust/summary/taint-sources]
         let line = reader.lines().nth(1).unwrap();
-        sink(line.unwrap().clone()); // $ MISSING: hasTaintFlow
+        sink(line.unwrap().clone()); // $ hasTaintFlow
     }
 
     {

--- a/rust/ql/test/library-tests/dataflow/strings/inline-taint-flow.expected
+++ b/rust/ql/test/library-tests/dataflow/strings/inline-taint-flow.expected
@@ -2,12 +2,13 @@ models
 | 1 | Summary: <_ as alloc::string::ToString>::to_string; Argument[self].Reference; ReturnValue; taint |
 | 2 | Summary: <_ as core::convert::From>::from; Argument[0]; ReturnValue; taint |
 | 3 | Summary: <_ as core::ops::index::Index>::index; Argument[self].Reference.Element; ReturnValue.Reference; value |
-| 4 | Summary: <alloc::string::String as core::convert::From>::from; Argument[0].Reference; ReturnValue; value |
-| 5 | Summary: <alloc::string::String as core::ops::arith::Add>::add; Argument[0].Reference; ReturnValue; taint |
-| 6 | Summary: <alloc::string::String as core::ops::arith::Add>::add; Argument[self,0]; ReturnValue; taint |
-| 7 | Summary: <alloc::string::String>::as_str; Argument[self]; ReturnValue; value |
-| 8 | Summary: alloc::fmt::format; Argument[0]; ReturnValue; taint |
-| 9 | Summary: core::hint::must_use; Argument[0]; ReturnValue; value |
+| 4 | Summary: <alloc::string::String as core::convert::From>::from; Argument[0].Field[alloc::borrow::Cow::Owned(0)]; ReturnValue; value |
+| 5 | Summary: <alloc::string::String as core::convert::From>::from; Argument[0].Reference; ReturnValue; value |
+| 6 | Summary: <alloc::string::String as core::ops::arith::Add>::add; Argument[0].Reference; ReturnValue; taint |
+| 7 | Summary: <alloc::string::String as core::ops::arith::Add>::add; Argument[self,0]; ReturnValue; taint |
+| 8 | Summary: <alloc::string::String>::as_str; Argument[self]; ReturnValue; value |
+| 9 | Summary: alloc::fmt::format; Argument[0]; ReturnValue; taint |
+| 10 | Summary: core::hint::must_use; Argument[0]; ReturnValue; value |
 edges
 | main.rs:26:9:26:9 | s | main.rs:27:19:27:19 | s | provenance |  |
 | main.rs:26:9:26:9 | s | main.rs:27:19:27:25 | s[...] | provenance |  |
@@ -19,11 +20,11 @@ edges
 | main.rs:32:9:32:10 | s1 | main.rs:35:14:35:15 | s1 | provenance |  |
 | main.rs:32:14:32:23 | source(...) | main.rs:32:9:32:10 | s1 | provenance |  |
 | main.rs:35:9:35:10 | s4 | main.rs:38:10:38:11 | s4 | provenance |  |
-| main.rs:35:14:35:15 | s1 | main.rs:35:14:35:20 | ... + ... | provenance | MaD:6 |
+| main.rs:35:14:35:15 | s1 | main.rs:35:14:35:20 | ... + ... | provenance | MaD:7 |
 | main.rs:35:14:35:20 | ... + ... | main.rs:35:9:35:10 | s4 | provenance |  |
 | main.rs:43:9:43:10 | s1 | main.rs:46:34:46:35 | s1 | provenance |  |
 | main.rs:43:14:43:23 | source(...) | main.rs:43:9:43:10 | s1 | provenance |  |
-| main.rs:46:33:46:35 | &s1 [&ref] | main.rs:46:10:46:35 | ... + ... | provenance | MaD:5 |
+| main.rs:46:33:46:35 | &s1 [&ref] | main.rs:46:10:46:35 | ... + ... | provenance | MaD:6 |
 | main.rs:46:34:46:35 | s1 | main.rs:46:33:46:35 | &s1 [&ref] | provenance |  |
 | main.rs:51:9:51:10 | s1 | main.rs:52:27:52:28 | s1 | provenance |  |
 | main.rs:51:14:51:29 | source_slice(...) | main.rs:51:9:51:10 | s1 | provenance |  |
@@ -31,6 +32,7 @@ edges
 | main.rs:52:14:52:29 | ...::from(...) | main.rs:52:9:52:10 | s2 | provenance |  |
 | main.rs:52:27:52:28 | s1 | main.rs:52:14:52:29 | ...::from(...) | provenance | MaD:2 |
 | main.rs:52:27:52:28 | s1 | main.rs:52:14:52:29 | ...::from(...) | provenance | MaD:4 |
+| main.rs:52:27:52:28 | s1 | main.rs:52:14:52:29 | ...::from(...) | provenance | MaD:5 |
 | main.rs:57:9:57:10 | s1 | main.rs:58:14:58:15 | s1 | provenance |  |
 | main.rs:57:14:57:29 | source_slice(...) | main.rs:57:9:57:10 | s1 | provenance |  |
 | main.rs:58:9:58:10 | s2 | main.rs:59:10:59:11 | s2 | provenance |  |
@@ -38,32 +40,32 @@ edges
 | main.rs:58:14:58:27 | s1.to_string() | main.rs:58:9:58:10 | s2 | provenance |  |
 | main.rs:63:9:63:9 | s | main.rs:64:16:64:16 | s | provenance |  |
 | main.rs:63:13:63:22 | source(...) | main.rs:63:9:63:9 | s | provenance |  |
-| main.rs:64:16:64:16 | s | main.rs:64:16:64:25 | s.as_str() | provenance | MaD:7 |
+| main.rs:64:16:64:16 | s | main.rs:64:16:64:25 | s.as_str() | provenance | MaD:8 |
 | main.rs:68:9:68:9 | s | main.rs:70:34:70:61 | MacroExpr | provenance |  |
 | main.rs:68:9:68:9 | s | main.rs:73:34:73:59 | MacroExpr | provenance |  |
 | main.rs:68:13:68:22 | source(...) | main.rs:68:9:68:9 | s | provenance |  |
 | main.rs:70:9:70:18 | formatted1 | main.rs:71:10:71:19 | formatted1 | provenance |  |
 | main.rs:70:22:70:62 | ...::format(...) | main.rs:70:9:70:18 | formatted1 | provenance |  |
-| main.rs:70:34:70:61 | MacroExpr | main.rs:70:22:70:62 | ...::format(...) | provenance | MaD:8 |
+| main.rs:70:34:70:61 | MacroExpr | main.rs:70:22:70:62 | ...::format(...) | provenance | MaD:9 |
 | main.rs:73:9:73:18 | formatted2 | main.rs:74:10:74:19 | formatted2 | provenance |  |
 | main.rs:73:22:73:60 | ...::format(...) | main.rs:73:9:73:18 | formatted2 | provenance |  |
-| main.rs:73:34:73:59 | MacroExpr | main.rs:73:22:73:60 | ...::format(...) | provenance | MaD:8 |
+| main.rs:73:34:73:59 | MacroExpr | main.rs:73:22:73:60 | ...::format(...) | provenance | MaD:9 |
 | main.rs:76:9:76:13 | width | main.rs:77:34:77:74 | MacroExpr | provenance |  |
 | main.rs:76:17:76:32 | source_usize(...) | main.rs:76:9:76:13 | width | provenance |  |
 | main.rs:77:9:77:18 | formatted3 | main.rs:78:10:78:19 | formatted3 | provenance |  |
 | main.rs:77:22:77:75 | ...::format(...) | main.rs:77:9:77:18 | formatted3 | provenance |  |
-| main.rs:77:34:77:74 | MacroExpr | main.rs:77:22:77:75 | ...::format(...) | provenance | MaD:8 |
+| main.rs:77:34:77:74 | MacroExpr | main.rs:77:22:77:75 | ...::format(...) | provenance | MaD:9 |
 | main.rs:82:9:82:10 | s1 | main.rs:86:18:86:25 | MacroExpr | provenance |  |
 | main.rs:82:9:82:10 | s1 | main.rs:87:18:87:32 | MacroExpr | provenance |  |
 | main.rs:82:14:82:23 | source(...) | main.rs:82:9:82:10 | s1 | provenance |  |
 | main.rs:86:18:86:25 | ...::format(...) | main.rs:86:18:86:25 | { ... } | provenance |  |
 | main.rs:86:18:86:25 | ...::must_use(...) | main.rs:86:10:86:26 | MacroExpr | provenance |  |
-| main.rs:86:18:86:25 | MacroExpr | main.rs:86:18:86:25 | ...::format(...) | provenance | MaD:8 |
-| main.rs:86:18:86:25 | { ... } | main.rs:86:18:86:25 | ...::must_use(...) | provenance | MaD:9 |
+| main.rs:86:18:86:25 | MacroExpr | main.rs:86:18:86:25 | ...::format(...) | provenance | MaD:9 |
+| main.rs:86:18:86:25 | { ... } | main.rs:86:18:86:25 | ...::must_use(...) | provenance | MaD:10 |
 | main.rs:87:18:87:32 | ...::format(...) | main.rs:87:18:87:32 | { ... } | provenance |  |
 | main.rs:87:18:87:32 | ...::must_use(...) | main.rs:87:10:87:33 | MacroExpr | provenance |  |
-| main.rs:87:18:87:32 | MacroExpr | main.rs:87:18:87:32 | ...::format(...) | provenance | MaD:8 |
-| main.rs:87:18:87:32 | { ... } | main.rs:87:18:87:32 | ...::must_use(...) | provenance | MaD:9 |
+| main.rs:87:18:87:32 | MacroExpr | main.rs:87:18:87:32 | ...::format(...) | provenance | MaD:9 |
+| main.rs:87:18:87:32 | { ... } | main.rs:87:18:87:32 | ...::must_use(...) | provenance | MaD:10 |
 nodes
 | main.rs:26:9:26:9 | s | semmle.label | s |
 | main.rs:26:13:26:22 | source(...) | semmle.label | source(...) |

--- a/rust/ql/test/query-tests/security/CWE-022/TaintedPath.expected
+++ b/rust/ql/test/query-tests/security/CWE-022/TaintedPath.expected
@@ -21,6 +21,7 @@ edges
 | src/main.rs:9:21:9:44 | ...::from(...) | src/main.rs:9:9:9:17 | file_path | provenance |  |
 | src/main.rs:9:35:9:43 | file_name | src/main.rs:9:21:9:44 | ...::from(...) | provenance | MaD:9 |
 | src/main.rs:9:35:9:43 | file_name | src/main.rs:9:21:9:44 | ...::from(...) | provenance | MaD:16 |
+| src/main.rs:9:35:9:43 | file_name | src/main.rs:9:21:9:44 | ...::from(...) | provenance | MaD:17 |
 | src/main.rs:11:24:11:32 | file_path | src/main.rs:11:5:11:22 | ...::read_to_string | provenance | MaD:6 Sink:MaD:6 |
 | src/main.rs:38:11:38:19 | file_path | src/main.rs:41:52:41:60 | file_path | provenance |  |
 | src/main.rs:41:9:41:17 | file_path | src/main.rs:46:24:46:32 | file_path | provenance |  |
@@ -28,6 +29,7 @@ edges
 | src/main.rs:41:38:41:61 | ...::from(...) | src/main.rs:41:21:41:62 | public_path.join(...) | provenance | MaD:14 |
 | src/main.rs:41:52:41:60 | file_path | src/main.rs:41:38:41:61 | ...::from(...) | provenance | MaD:9 |
 | src/main.rs:41:52:41:60 | file_path | src/main.rs:41:38:41:61 | ...::from(...) | provenance | MaD:16 |
+| src/main.rs:41:52:41:60 | file_path | src/main.rs:41:38:41:61 | ...::from(...) | provenance | MaD:17 |
 | src/main.rs:46:24:46:32 | file_path | src/main.rs:46:5:46:22 | ...::read_to_string | provenance | MaD:6 Sink:MaD:6 |
 | src/main.rs:63:11:63:19 | file_path | src/main.rs:66:32:66:40 | file_path | provenance |  |
 | src/main.rs:66:9:66:17 | file_path [&ref] | src/main.rs:71:24:71:32 | file_path [&ref] | provenance |  |
@@ -41,6 +43,7 @@ edges
 | src/main.rs:79:38:79:61 | ...::from(...) | src/main.rs:79:21:79:62 | public_path.join(...) | provenance | MaD:14 |
 | src/main.rs:79:52:79:60 | file_path | src/main.rs:79:38:79:61 | ...::from(...) | provenance | MaD:9 |
 | src/main.rs:79:52:79:60 | file_path | src/main.rs:79:38:79:61 | ...::from(...) | provenance | MaD:16 |
+| src/main.rs:79:52:79:60 | file_path | src/main.rs:79:38:79:61 | ...::from(...) | provenance | MaD:17 |
 | src/main.rs:80:9:80:17 | file_path | src/main.rs:85:24:85:32 | file_path | provenance |  |
 | src/main.rs:80:21:80:29 | file_path | src/main.rs:80:21:80:44 | file_path.canonicalize() [Ok] | provenance | MaD:11 |
 | src/main.rs:80:21:80:44 | file_path.canonicalize() [Ok] | src/main.rs:80:21:80:53 | ... .unwrap() | provenance | MaD:13 |
@@ -136,7 +139,8 @@ models
 | 13 | Summary: <core::result::Result>::unwrap; Argument[self].Field[core::result::Result::Ok(0)]; ReturnValue; value |
 | 14 | Summary: <std::path::Path>::join; Argument[0]; ReturnValue; taint |
 | 15 | Summary: <std::path::Path>::new; Argument[0].Reference; ReturnValue.Reference; value |
-| 16 | Summary: <std::path::PathBuf as core::convert::From>::from; Argument[0]; ReturnValue; taint |
+| 16 | Summary: <std::path::PathBuf as core::convert::From>::from; Argument[0].Field[alloc::borrow::Cow::Owned(0)]; ReturnValue; value |
+| 17 | Summary: <std::path::PathBuf as core::convert::From>::from; Argument[0]; ReturnValue; taint |
 nodes
 | src/main.rs:7:11:7:19 | file_name | semmle.label | file_name |
 | src/main.rs:9:9:9:17 | file_path | semmle.label | file_path |

--- a/rust/ql/test/query-tests/security/CWE-798/HardcodedCryptographicValue.expected
+++ b/rust/ql/test/query-tests/security/CWE-798/HardcodedCryptographicValue.expected
@@ -23,32 +23,32 @@ edges
 | test_cipher.rs:18:28:18:36 | &... [&ref] | test_cipher.rs:18:9:18:14 | const1 [&ref] | provenance |  |
 | test_cipher.rs:18:29:18:36 | [0u8; 16] | test_cipher.rs:18:28:18:36 | &... [&ref] | provenance |  |
 | test_cipher.rs:19:49:19:79 | ...::from_slice(...) [&ref] | test_cipher.rs:19:30:19:47 | ...::new | provenance | MaD:3 Sink:MaD:3 |
-| test_cipher.rs:19:73:19:78 | const1 [&ref] | test_cipher.rs:19:49:19:79 | ...::from_slice(...) [&ref] | provenance | MaD:19 |
+| test_cipher.rs:19:73:19:78 | const1 [&ref] | test_cipher.rs:19:49:19:79 | ...::from_slice(...) [&ref] | provenance | MaD:24 |
 | test_cipher.rs:25:9:25:14 | const4 [&ref] | test_cipher.rs:26:66:26:71 | const4 [&ref] | provenance |  |
 | test_cipher.rs:25:28:25:36 | &... [&ref] | test_cipher.rs:25:9:25:14 | const4 [&ref] | provenance |  |
 | test_cipher.rs:25:29:25:36 | [0u8; 16] | test_cipher.rs:25:28:25:36 | &... [&ref] | provenance |  |
 | test_cipher.rs:26:42:26:72 | ...::from_slice(...) [&ref] | test_cipher.rs:26:30:26:40 | ...::new | provenance | MaD:4 Sink:MaD:4 |
-| test_cipher.rs:26:66:26:71 | const4 [&ref] | test_cipher.rs:26:42:26:72 | ...::from_slice(...) [&ref] | provenance | MaD:19 |
+| test_cipher.rs:26:66:26:71 | const4 [&ref] | test_cipher.rs:26:42:26:72 | ...::from_slice(...) [&ref] | provenance | MaD:24 |
 | test_cipher.rs:29:9:29:14 | const5 [&ref] | test_cipher.rs:30:95:30:100 | const5 [&ref] | provenance |  |
 | test_cipher.rs:29:28:29:36 | &... [&ref] | test_cipher.rs:29:9:29:14 | const5 [&ref] | provenance |  |
 | test_cipher.rs:29:29:29:36 | [0u8; 16] | test_cipher.rs:29:28:29:36 | &... [&ref] | provenance |  |
 | test_cipher.rs:30:72:30:101 | ...::from_slice(...) [&ref] | test_cipher.rs:30:30:30:40 | ...::new | provenance | MaD:5 Sink:MaD:5 |
-| test_cipher.rs:30:95:30:100 | const5 [&ref] | test_cipher.rs:30:72:30:101 | ...::from_slice(...) [&ref] | provenance | MaD:19 |
+| test_cipher.rs:30:95:30:100 | const5 [&ref] | test_cipher.rs:30:72:30:101 | ...::from_slice(...) [&ref] | provenance | MaD:24 |
 | test_cipher.rs:37:9:37:14 | const7 | test_cipher.rs:38:74:38:79 | const7 | provenance |  |
 | test_cipher.rs:37:27:37:74 | [...] | test_cipher.rs:37:9:37:14 | const7 | provenance |  |
 | test_cipher.rs:38:49:38:80 | ...::from_slice(...) [&ref] | test_cipher.rs:38:30:38:47 | ...::new | provenance | MaD:3 Sink:MaD:3 |
-| test_cipher.rs:38:73:38:79 | &const7 [&ref] | test_cipher.rs:38:49:38:80 | ...::from_slice(...) [&ref] | provenance | MaD:19 |
+| test_cipher.rs:38:73:38:79 | &const7 [&ref] | test_cipher.rs:38:49:38:80 | ...::from_slice(...) [&ref] | provenance | MaD:24 |
 | test_cipher.rs:38:74:38:79 | const7 | test_cipher.rs:38:73:38:79 | &const7 [&ref] | provenance |  |
 | test_cipher.rs:41:9:41:14 | const8 [&ref] | test_cipher.rs:42:73:42:78 | const8 [&ref] | provenance |  |
 | test_cipher.rs:41:28:41:76 | &... [&ref] | test_cipher.rs:41:9:41:14 | const8 [&ref] | provenance |  |
 | test_cipher.rs:41:29:41:76 | [...] | test_cipher.rs:41:28:41:76 | &... [&ref] | provenance |  |
 | test_cipher.rs:42:49:42:79 | ...::from_slice(...) [&ref] | test_cipher.rs:42:30:42:47 | ...::new | provenance | MaD:3 Sink:MaD:3 |
-| test_cipher.rs:42:73:42:78 | const8 [&ref] | test_cipher.rs:42:49:42:79 | ...::from_slice(...) [&ref] | provenance | MaD:19 |
+| test_cipher.rs:42:73:42:78 | const8 [&ref] | test_cipher.rs:42:49:42:79 | ...::from_slice(...) [&ref] | provenance | MaD:24 |
 | test_cipher.rs:50:9:50:15 | const10 [element] | test_cipher.rs:51:75:51:81 | const10 [element] | provenance |  |
 | test_cipher.rs:50:37:50:52 | ...::zeroed | test_cipher.rs:50:37:50:54 | ...::zeroed(...) [element] | provenance | Src:MaD:7  |
 | test_cipher.rs:50:37:50:54 | ...::zeroed(...) [element] | test_cipher.rs:50:9:50:15 | const10 [element] | provenance |  |
 | test_cipher.rs:51:50:51:82 | ...::from_slice(...) [&ref, element] | test_cipher.rs:51:31:51:48 | ...::new | provenance | MaD:3 Sink:MaD:3 Sink:MaD:3 |
-| test_cipher.rs:51:74:51:81 | &const10 [&ref, element] | test_cipher.rs:51:50:51:82 | ...::from_slice(...) [&ref, element] | provenance | MaD:19 |
+| test_cipher.rs:51:74:51:81 | &const10 [&ref, element] | test_cipher.rs:51:50:51:82 | ...::from_slice(...) [&ref, element] | provenance | MaD:24 |
 | test_cipher.rs:51:75:51:81 | const10 [element] | test_cipher.rs:51:74:51:81 | &const10 [&ref, element] | provenance |  |
 | test_cipher.rs:73:9:73:14 | const2 [&ref] | test_cipher.rs:74:46:74:51 | const2 [&ref] | provenance |  |
 | test_cipher.rs:73:18:73:26 | &... [&ref] | test_cipher.rs:73:9:73:14 | const2 [&ref] | provenance |  |
@@ -65,9 +65,14 @@ edges
 | test_cookie.rs:38:9:38:14 | array2 | test_cookie.rs:42:34:42:39 | array2 | provenance |  |
 | test_cookie.rs:38:18:38:37 | ...::from(...) | test_cookie.rs:38:9:38:14 | array2 | provenance |  |
 | test_cookie.rs:38:28:38:36 | [0u8; 64] | test_cookie.rs:38:18:38:37 | ...::from(...) | provenance | MaD:8 |
+| test_cookie.rs:38:28:38:36 | [0u8; 64] | test_cookie.rs:38:18:38:37 | ...::from(...) | provenance | MaD:18 |
+| test_cookie.rs:38:28:38:36 | [0u8; 64] | test_cookie.rs:38:18:38:37 | ...::from(...) | provenance | MaD:19 |
+| test_cookie.rs:38:28:38:36 | [0u8; 64] | test_cookie.rs:38:18:38:37 | ...::from(...) | provenance | MaD:20 |
+| test_cookie.rs:38:28:38:36 | [0u8; 64] | test_cookie.rs:38:18:38:37 | ...::from(...) | provenance | MaD:21 |
+| test_cookie.rs:38:28:38:36 | [0u8; 64] | test_cookie.rs:38:18:38:37 | ...::from(...) | provenance | MaD:22 |
 | test_cookie.rs:42:34:42:39 | array2 | test_cookie.rs:42:14:42:32 | ...::from | provenance | MaD:2 Sink:MaD:2 |
 | test_cookie.rs:49:9:49:14 | array3 [element] | test_cookie.rs:53:34:53:39 | array3 [element] | provenance |  |
-| test_cookie.rs:49:23:49:25 | 0u8 | test_cookie.rs:49:23:49:29 | ...::from_elem(...) [element] | provenance | MaD:20 |
+| test_cookie.rs:49:23:49:25 | 0u8 | test_cookie.rs:49:23:49:29 | ...::from_elem(...) [element] | provenance | MaD:25 |
 | test_cookie.rs:49:23:49:29 | ...::from_elem(...) [element] | test_cookie.rs:49:9:49:14 | array3 [element] | provenance |  |
 | test_cookie.rs:53:34:53:39 | array3 [element] | test_cookie.rs:53:14:53:32 | ...::from | provenance | MaD:2 Sink:MaD:2 |
 | test_heuristic.rs:44:9:44:16 | const_iv [&ref] | test_heuristic.rs:45:41:45:48 | const_iv | provenance |  |
@@ -80,7 +85,7 @@ edges
 | test_heuristic.rs:70:23:70:35 | ... << ... | test_heuristic.rs:70:22:70:62 | ... ^ ... | provenance | MaD:15 |
 | test_heuristic.rs:70:34:70:35 | 32 | test_heuristic.rs:70:23:70:35 | ... << ... | provenance | MaD:17 |
 | test_heuristic.rs:70:34:70:35 | 32 | test_heuristic.rs:70:23:70:35 | ... << ... | provenance | MaD:16 |
-| test_heuristic.rs:70:34:70:35 | 32 | test_heuristic.rs:70:23:70:35 | ... << ... | provenance | MaD:18 |
+| test_heuristic.rs:70:34:70:35 | 32 | test_heuristic.rs:70:23:70:35 | ... << ... | provenance | MaD:23 |
 | test_heuristic.rs:70:41:70:61 | ... & ... | test_heuristic.rs:70:22:70:62 | ... ^ ... | provenance | MaD:14 |
 | test_heuristic.rs:70:41:70:61 | ... & ... | test_heuristic.rs:70:22:70:62 | ... ^ ... | provenance | MaD:13 |
 | test_heuristic.rs:70:52:70:61 | 0xFFFFFFFF | test_heuristic.rs:70:41:70:61 | ... & ... | provenance | MaD:12 |
@@ -103,9 +108,14 @@ models
 | 15 | Summary: <_ as core::ops::bit::BitXor>::bitxor; Argument[self]; ReturnValue; taint |
 | 16 | Summary: <_ as core::ops::bit::Shl>::shl; Argument[0].Reference; ReturnValue; taint |
 | 17 | Summary: <_ as core::ops::bit::Shl>::shl; Argument[0]; ReturnValue; taint |
-| 18 | Summary: <core::u64 as core::ops::bit::Shl>::shl; Argument[0]; ReturnValue; taint |
-| 19 | Summary: <generic_array::GenericArray>::from_slice; Argument[0].Reference; ReturnValue.Reference; value |
-| 20 | Summary: alloc::vec::from_elem; Argument[0]; ReturnValue.Element; value |
+| 18 | Summary: <alloc::vec::Vec as core::convert::From>::from; Argument[0].Field[0]; ReturnValue; value |
+| 19 | Summary: <alloc::vec::Vec as core::convert::From>::from; Argument[0].Field[alloc::borrow::Cow::Owned(0)]; ReturnValue; value |
+| 20 | Summary: <alloc::vec::Vec as core::convert::From>::from; Argument[0].Field[alloc::bstr::ByteString(0)]; ReturnValue; value |
+| 21 | Summary: <alloc::vec::Vec as core::convert::From>::from; Argument[0].Field[alloc::collections::binary_heap::BinaryHeap::data]; ReturnValue; value |
+| 22 | Summary: <alloc::vec::Vec as core::convert::From>::from; Argument[0].Field[alloc::string::String::vec]; ReturnValue; value |
+| 23 | Summary: <core::u64 as core::ops::bit::Shl>::shl; Argument[0]; ReturnValue; taint |
+| 24 | Summary: <generic_array::GenericArray>::from_slice; Argument[0].Reference; ReturnValue.Reference; value |
+| 25 | Summary: alloc::vec::from_elem; Argument[0]; ReturnValue.Element; value |
 nodes
 | test_cipher.rs:18:9:18:14 | const1 [&ref] | semmle.label | const1 [&ref] |
 | test_cipher.rs:18:28:18:36 | &... [&ref] | semmle.label | &... [&ref] |


### PR DESCRIPTION
Does what the title says.

[DCA](https://github.com/github/codeql-dca-main/issues/33969) looks good: A good number of new alerts, and no performance regressions.