### PR TITLE
Rust: Add missing `.Reference` in various models

### DIFF
--- a/rust/ql/lib/codeql/rust/dataflow/internal/ModelsAsData.qll
+++ b/rust/ql/lib/codeql/rust/dataflow/internal/ModelsAsData.qll
@@ -128,38 +128,35 @@ private predicate summaryModel(
 }
 
 private predicate summaryModelRelevant(
-  Function f, string input, string output, string kind, Provenance provenance,
+  Function f, string input, string output, string kind, Provenance provenance, boolean isInherited,
   QlBuiltins::ExtensionId madId
 ) {
-  exists(boolean isInherited |
-    summaryModel(f, input, output, kind, provenance, isInherited, madId)
-  |
-    // Only apply generated or inherited models to functions in library code and
-    // when no strictly better model exists
-    if provenance.isGenerated() or isInherited = true
-    then
-      not f.fromSource() and
-      not exists(Provenance other | summaryModel(f, _, _, _, other, false, _) |
-        provenance.isGenerated() and other.isManual()
-        or
-        provenance = other and isInherited = true
-      )
-    else any()
-  )
+  summaryModel(f, input, output, kind, provenance, isInherited, madId) and
+  // Only apply generated or inherited models to functions in library code and
+  // when no strictly better model exists
+  if provenance.isGenerated() or isInherited = true
+  then
+    not f.fromSource() and
+    not exists(Provenance other | summaryModel(f, _, _, _, other, false, _) |
+      provenance.isGenerated() and other.isManual()
+      or
+      provenance = other and isInherited = true
+    )
+  else any()
 }
 
 private class SummarizedCallableFromModel extends SummarizedCallable::Range {
-  SummarizedCallableFromModel() { summaryModelRelevant(this, _, _, _, _, _) }
+  SummarizedCallableFromModel() { summaryModelRelevant(this, _, _, _, _, _, _) }
 
   override predicate hasProvenance(Provenance provenance) {
-    summaryModelRelevant(this, _, _, _, provenance, _)
+    summaryModelRelevant(this, _, _, _, provenance, _, _)
   }
 
   override predicate propagatesFlow(
     string input, string output, boolean preservesValue, string model
   ) {
     exists(string kind, QlBuiltins::ExtensionId madId |
-      summaryModelRelevant(this, input, output, kind, _, madId) and
+      summaryModelRelevant(this, input, output, kind, _, _, madId) and
       model = "MaD:" + madId.toString()
     |
       kind = "value" and
@@ -199,6 +196,59 @@ private class FlowSinkFromModel extends FlowSink::Range {
     exists(QlBuiltins::ExtensionId madId |
       sinkModel(path, input, kind, provenance, madId) and
       model = "MaD:" + madId.toString()
+    )
+  }
+}
+
+private module Debug {
+  private import FlowSummaryImpl
+  private import Private
+  private import Content
+  private import codeql.rust.dataflow.internal.DataFlowImpl
+  private import codeql.rust.internal.TypeMention
+  private import codeql.rust.internal.Type
+
+  private predicate relevantManualModel(SummarizedCallableImpl sc, string can) {
+    exists(Provenance manual |
+      can = sc.getCanonicalPath() and
+      summaryModelRelevant(sc, _, _, _, manual, false, _) and
+      manual.isManual()
+    )
+  }
+
+  predicate manualModelMissingParameterReference(
+    SummarizedCallableImpl sc, string can, SummaryComponentStack input, ParamBase p
+  ) {
+    exists(RustDataFlow::ParameterPosition pos, TypeMention tm |
+      relevantManualModel(sc, can) and
+      sc.propagatesFlow(input, _, _, _) and
+      input.head() = SummaryComponent::argument(pos) and
+      p = pos.getParameterIn(sc.getParamList()) and
+      tm.resolveType() instanceof RefType and
+      not input.tail().head() = SummaryComponent::content(TSingletonContentSet(TReferenceContent()))
+    |
+      tm = p.getTypeRepr()
+      or
+      tm = getSelfParamTypeMention(p)
+    )
+  }
+
+  predicate manualModelMissingReturnReference(
+    SummarizedCallableImpl sc, string can, SummaryComponentStack output
+  ) {
+    exists(TypeMention tm |
+      relevantManualModel(sc, can) and
+      sc.propagatesFlow(_, output, _, _) and
+      tm.resolveType() instanceof RefType and
+      output.head() = SummaryComponent::return(_) and
+      not output.tail().head() =
+        SummaryComponent::content(TSingletonContentSet(TReferenceContent())) and
+      tm = getReturnTypeMention(sc) and
+      not can =
+        [
+          "<& as core::ops::deref::Deref>::deref",
+          "<&mut as core::ops::deref::Deref>::deref"
+        ]
     )
   }
 }

--- a/rust/ql/lib/codeql/rust/frameworks/futures.model.yml
+++ b/rust/ql/lib/codeql/rust/frameworks/futures.model.yml
@@ -5,7 +5,6 @@ extensions:
     data:
       - ["futures_executor::local_pool::block_on", "Argument[0]", "ReturnValue", "value", "manual"]
       - ["<futures_util::io::buf_reader::BufReader>::new", "Argument[0]", "ReturnValue", "taint", "manual"]
-      - ["<_ as futures_util::io::AsyncReadExt>::read", "Argument[self]", "Argument[0].Reference", "taint", "manual"]
       - ["<_ as futures_util::io::AsyncReadExt>::read", "Argument[self].Reference", "Argument[0].Reference", "taint", "manual"]
       - ["<_ as futures_util::io::AsyncReadExt>::read_to_end", "Argument[self].Reference", "Argument[0].Reference", "taint", "manual"]
       - ["<_ as futures_util::io::AsyncBufReadExt>::read_line", "Argument[self].Reference", "Argument[0].Reference", "taint", "manual"]

--- a/rust/ql/lib/codeql/rust/frameworks/stdlib/alloc.model.yml
+++ b/rust/ql/lib/codeql/rust/frameworks/stdlib/alloc.model.yml
@@ -47,11 +47,11 @@ extensions:
       - ["<core::alloc::layout::Layout>::pad_to_align", "Argument[self].Reference", "ReturnValue", "taint", "manual"]
       - ["<core::alloc::layout::Layout>::size", "Argument[self].Reference", "ReturnValue", "taint", "manual"]
       # String
-      - ["<alloc::string::String>::as_str", "Argument[self]", "ReturnValue", "value", "manual"]
-      - ["<alloc::string::String>::as_bytes", "Argument[self]", "ReturnValue", "value", "manual"]
+      - ["<alloc::string::String>::as_str", "Argument[self].Reference", "ReturnValue.Reference", "taint", "manual"]
+      - ["<alloc::string::String>::as_bytes", "Argument[self].Reference", "ReturnValue.Reference.Element", "taint", "manual"]
       - ["<_ as alloc::string::ToString>::to_string", "Argument[self].Reference", "ReturnValue", "taint", "manual"]
         # Overwrite generated model
-      - ["<alloc::string::String as core::ops::arith::Add>::add", "Argument[self,0]", "ReturnValue", "taint", "manual"]
+      - ["<alloc::string::String as core::ops::arith::Add>::add", "Argument[self]", "ReturnValue", "taint", "manual"]
       - ["<alloc::string::String as core::ops::arith::Add>::add", "Argument[0].Reference", "ReturnValue", "taint", "manual"]
       # Vec
       - ["alloc::vec::from_elem", "Argument[0]", "ReturnValue.Element", "value", "manual"]

--- a/rust/ql/lib/codeql/rust/frameworks/stdlib/core.model.yml
+++ b/rust/ql/lib/codeql/rust/frameworks/stdlib/core.model.yml
@@ -114,7 +114,7 @@ extensions:
       - ["<core::pin::Pin as core::ops::deref::Deref>::deref", "Argument[self].Reference.Field[core::pin::Pin::pointer].Reference", "ReturnValue.Reference", "value", "manual"]
       - ["<core::pin::Pin as core::ops::deref::Deref>::deref", "Argument[self].Reference.Field[core::pin::Pin::pointer].Field[alloc::boxed::Box(0)]", "ReturnValue.Reference", "value", "manual"]
       # Str
-      - ["<core::str>::as_str", "Argument[self]", "ReturnValue", "value", "manual"]
+      - ["<core::str>::as_str", "Argument[self].Reference", "ReturnValue.Reference", "taint", "manual"]
       - ["<core::str>::as_bytes", "Argument[self].Reference", "ReturnValue.Reference", "taint", "manual"]
       - ["<core::str>::parse", "Argument[self].Reference", "ReturnValue.Field[core::result::Result::Ok(0)]", "taint", "manual"]
       - ["<core::str>::trim", "Argument[self].Reference", "ReturnValue.Reference", "taint", "manual"]

--- a/rust/ql/lib/codeql/rust/frameworks/stdlib/fs.model.yml
+++ b/rust/ql/lib/codeql/rust/frameworks/stdlib/fs.model.yml
@@ -61,7 +61,7 @@ extensions:
       - ["<std::path::PathBuf>::as_path", "Argument[self].Reference", "ReturnValue.Reference", "value", "manual"]
       - ["<std::path::PathBuf>::into_boxed_path", "Argument[self]", "ReturnValue.Field[alloc::boxed::Box(0)]", "taint", "manual"]
       - ["<std::path::Path>::new", "Argument[0].Reference", "ReturnValue.Reference", "value", "manual"]
-      - ["<std::path::Path>::join", "Argument[self]", "ReturnValue", "taint", "manual"]
+      - ["<std::path::Path>::join", "Argument[self].Reference", "ReturnValue", "taint", "manual"]
       - ["<std::path::Path>::join", "Argument[0]", "ReturnValue", "taint", "manual"]
       - ["<std::path::Path>::as_os_str", "Argument[self].Reference.Field[std::path::Path::inner]", "ReturnValue.Reference", "value", "manual"]
       - ["<std::path::Path>::as_mut_os_str", "Argument[self].Reference.Field[std::path::Path::inner]", "ReturnValue.Reference", "value", "manual"]

--- a/rust/ql/lib/codeql/rust/frameworks/stdlib/net.model.yml
+++ b/rust/ql/lib/codeql/rust/frameworks/stdlib/net.model.yml
@@ -9,4 +9,4 @@ extensions:
       pack: codeql/rust-all
       extensible: summaryModel
     data:
-      - ["<std::net::tcp::TcpStream>::try_clone", "Argument[self]", "ReturnValue.Field[core::result::Result::Ok(0)]", "taint", "manual"]
+      - ["<std::net::tcp::TcpStream>::try_clone", "Argument[self].Reference", "ReturnValue.Field[core::result::Result::Ok(0)]", "taint", "manual"]

--- a/rust/ql/test/library-tests/dataflow/sources/net/InlineFlow.expected
+++ b/rust/ql/test/library-tests/dataflow/sources/net/InlineFlow.expected
@@ -16,61 +16,63 @@ models
 | 15 | Summary: <_ as futures_util::io::AsyncBufReadExt>::read_until; Argument[self].Reference; Argument[1].Reference; taint |
 | 16 | Summary: <_ as futures_util::io::AsyncReadExt>::read; Argument[self].Reference; Argument[0].Reference; taint |
 | 17 | Summary: <_ as futures_util::io::AsyncReadExt>::read_to_end; Argument[self].Reference; Argument[0].Reference; taint |
-| 18 | Summary: <_ as std::io::BufRead>::read_line; Argument[self].Reference; Argument[0].Reference; taint |
-| 19 | Summary: <_ as std::io::Read>::read; Argument[self].Reference; Argument[0].Reference; taint |
-| 20 | Summary: <_ as std::io::Read>::read_to_end; Argument[self].Reference; Argument[0].Reference; taint |
-| 21 | Summary: <_ as std::io::Read>::read_to_string; Argument[self].Reference; Argument[0].Reference; taint |
-| 22 | Summary: <_ as std::io::Read>::take; Argument[self]; ReturnValue; taint |
-| 23 | Summary: <_ as tokio::io::util::async_read_ext::AsyncReadExt>::read; Argument[self].Reference; Argument[0].Reference; taint |
-| 24 | Summary: <core::option::Option>::unwrap; Argument[self].Field[core::option::Option::Some(0)]; ReturnValue; value |
-| 25 | Summary: <core::pin::Pin>::new; Argument[0].Reference; ReturnValue; value |
-| 26 | Summary: <core::pin::Pin>::new; Argument[0]; ReturnValue.Field[core::pin::Pin::pointer]; value |
-| 27 | Summary: <core::result::Result>::unwrap; Argument[self].Field[core::result::Result::Ok(0)]; ReturnValue; value |
-| 28 | Summary: <futures_rustls::TlsConnector>::connect; Argument[1]; ReturnValue.Future.Field[core::result::Result::Ok(0)]; taint |
-| 29 | Summary: <futures_util::io::buf_reader::BufReader>::new; Argument[0]; ReturnValue; taint |
-| 30 | Summary: <http::response::Response>::body; Argument[self].Reference.Field[http::response::Response::body]; ReturnValue.Reference; value |
-| 31 | Summary: <http::response::Response>::body_mut; Argument[self].Reference.Field[http::response::Response::body]; ReturnValue.Reference; value |
-| 32 | Summary: <http::response::Response>::into_body; Argument[self].Field[http::response::Response::body]; ReturnValue; value |
-| 33 | Summary: <reqwest::async_impl::response::Response>::bytes; Argument[self]; ReturnValue.Future.Field[core::result::Result::Ok(0)]; taint |
-| 34 | Summary: <reqwest::async_impl::response::Response>::chunk; Argument[self].Reference; ReturnValue.Future.Field[core::result::Result::Ok(0)].Field[core::option::Option::Some(0)]; taint |
-| 35 | Summary: <reqwest::async_impl::response::Response>::text; Argument[self]; ReturnValue.Future.Field[core::result::Result::Ok(0)]; taint |
-| 36 | Summary: <reqwest::blocking::response::Response>::bytes; Argument[self]; ReturnValue.Field[core::result::Result::Ok(0)]; taint |
-| 37 | Summary: <reqwest::blocking::response::Response>::text; Argument[self]; ReturnValue.Field[core::result::Result::Ok(0)]; taint |
-| 38 | Summary: <reqwest::blocking::response::Response>::text_with_charset; Argument[self]; ReturnValue.Field[core::result::Result::Ok(0)]; taint |
-| 39 | Summary: <std::io::buffered::bufreader::BufReader>::new; Argument[0]; ReturnValue; taint |
-| 40 | Summary: <tokio::net::tcp::stream::TcpStream>::peek; Argument[self].Reference; Argument[0].Reference; taint |
-| 41 | Summary: <tokio::net::tcp::stream::TcpStream>::try_read; Argument[self].Reference; Argument[0].Reference; taint |
-| 42 | Summary: <tokio::net::tcp::stream::TcpStream>::try_read_buf; Argument[self].Reference; Argument[0].Reference; taint |
+| 18 | Summary: <_ as std::io::BufRead>::lines; Argument[self]; ReturnValue; taint |
+| 19 | Summary: <_ as std::io::BufRead>::read_line; Argument[self].Reference; Argument[0].Reference; taint |
+| 20 | Summary: <_ as std::io::Read>::read; Argument[self].Reference; Argument[0].Reference; taint |
+| 21 | Summary: <_ as std::io::Read>::read_to_end; Argument[self].Reference; Argument[0].Reference; taint |
+| 22 | Summary: <_ as std::io::Read>::read_to_string; Argument[self].Reference; Argument[0].Reference; taint |
+| 23 | Summary: <_ as std::io::Read>::take; Argument[self]; ReturnValue; taint |
+| 24 | Summary: <_ as tokio::io::util::async_read_ext::AsyncReadExt>::read; Argument[self].Reference; Argument[0].Reference; taint |
+| 25 | Summary: <core::option::Option>::unwrap; Argument[self].Field[core::option::Option::Some(0)]; ReturnValue; value |
+| 26 | Summary: <core::pin::Pin>::new; Argument[0].Reference; ReturnValue; value |
+| 27 | Summary: <core::pin::Pin>::new; Argument[0]; ReturnValue.Field[core::pin::Pin::pointer]; value |
+| 28 | Summary: <core::result::Result>::unwrap; Argument[self].Field[core::result::Result::Ok(0)]; ReturnValue; value |
+| 29 | Summary: <futures_rustls::TlsConnector>::connect; Argument[1]; ReturnValue.Future.Field[core::result::Result::Ok(0)]; taint |
+| 30 | Summary: <futures_util::io::buf_reader::BufReader>::new; Argument[0]; ReturnValue; taint |
+| 31 | Summary: <http::response::Response>::body; Argument[self].Reference.Field[http::response::Response::body]; ReturnValue.Reference; value |
+| 32 | Summary: <http::response::Response>::body_mut; Argument[self].Reference.Field[http::response::Response::body]; ReturnValue.Reference; value |
+| 33 | Summary: <http::response::Response>::into_body; Argument[self].Field[http::response::Response::body]; ReturnValue; value |
+| 34 | Summary: <reqwest::async_impl::response::Response>::bytes; Argument[self]; ReturnValue.Future.Field[core::result::Result::Ok(0)]; taint |
+| 35 | Summary: <reqwest::async_impl::response::Response>::chunk; Argument[self].Reference; ReturnValue.Future.Field[core::result::Result::Ok(0)].Field[core::option::Option::Some(0)]; taint |
+| 36 | Summary: <reqwest::async_impl::response::Response>::text; Argument[self]; ReturnValue.Future.Field[core::result::Result::Ok(0)]; taint |
+| 37 | Summary: <reqwest::blocking::response::Response>::bytes; Argument[self]; ReturnValue.Field[core::result::Result::Ok(0)]; taint |
+| 38 | Summary: <reqwest::blocking::response::Response>::text; Argument[self]; ReturnValue.Field[core::result::Result::Ok(0)]; taint |
+| 39 | Summary: <reqwest::blocking::response::Response>::text_with_charset; Argument[self]; ReturnValue.Field[core::result::Result::Ok(0)]; taint |
+| 40 | Summary: <std::io::buffered::bufreader::BufReader>::new; Argument[0]; ReturnValue; taint |
+| 41 | Summary: <std::net::tcp::TcpStream>::try_clone; Argument[self].Reference; ReturnValue.Field[core::result::Result::Ok(0)]; taint |
+| 42 | Summary: <tokio::net::tcp::stream::TcpStream>::peek; Argument[self].Reference; Argument[0].Reference; taint |
+| 43 | Summary: <tokio::net::tcp::stream::TcpStream>::try_read; Argument[self].Reference; Argument[0].Reference; taint |
+| 44 | Summary: <tokio::net::tcp::stream::TcpStream>::try_read_buf; Argument[self].Reference; Argument[0].Reference; taint |
 edges
 | test.rs:11:9:11:22 | remote_string1 | test.rs:12:10:12:23 | remote_string1 | provenance |  |
 | test.rs:11:26:11:47 | ...::get | test.rs:11:26:11:62 | ...::get(...) [Ok] | provenance | Src:MaD:7  |
 | test.rs:11:26:11:62 | ...::get(...) [Ok] | test.rs:11:26:11:63 | TryExpr | provenance |  |
-| test.rs:11:26:11:63 | TryExpr | test.rs:11:26:11:70 | ... .text() [Ok] | provenance | MaD:37 |
+| test.rs:11:26:11:63 | TryExpr | test.rs:11:26:11:70 | ... .text() [Ok] | provenance | MaD:38 |
 | test.rs:11:26:11:70 | ... .text() [Ok] | test.rs:11:26:11:71 | TryExpr | provenance |  |
 | test.rs:11:26:11:71 | TryExpr | test.rs:11:9:11:22 | remote_string1 | provenance |  |
 | test.rs:14:9:14:22 | remote_string2 | test.rs:15:10:15:23 | remote_string2 | provenance |  |
 | test.rs:14:26:14:47 | ...::get | test.rs:14:26:14:62 | ...::get(...) [Ok] | provenance | Src:MaD:7  |
-| test.rs:14:26:14:62 | ...::get(...) [Ok] | test.rs:14:26:14:71 | ... .unwrap() | provenance | MaD:27 |
-| test.rs:14:26:14:71 | ... .unwrap() | test.rs:14:26:14:78 | ... .text() [Ok] | provenance | MaD:37 |
-| test.rs:14:26:14:78 | ... .text() [Ok] | test.rs:14:26:14:87 | ... .unwrap() | provenance | MaD:27 |
+| test.rs:14:26:14:62 | ...::get(...) [Ok] | test.rs:14:26:14:71 | ... .unwrap() | provenance | MaD:28 |
+| test.rs:14:26:14:71 | ... .unwrap() | test.rs:14:26:14:78 | ... .text() [Ok] | provenance | MaD:38 |
+| test.rs:14:26:14:78 | ... .text() [Ok] | test.rs:14:26:14:87 | ... .unwrap() | provenance | MaD:28 |
 | test.rs:14:26:14:87 | ... .unwrap() | test.rs:14:9:14:22 | remote_string2 | provenance |  |
 | test.rs:17:9:17:22 | remote_string3 | test.rs:18:10:18:23 | remote_string3 | provenance |  |
 | test.rs:17:26:17:47 | ...::get | test.rs:17:26:17:62 | ...::get(...) [Ok] | provenance | Src:MaD:7  |
-| test.rs:17:26:17:62 | ...::get(...) [Ok] | test.rs:17:26:17:71 | ... .unwrap() | provenance | MaD:27 |
-| test.rs:17:26:17:71 | ... .unwrap() | test.rs:17:26:17:98 | ... .text_with_charset(...) [Ok] | provenance | MaD:38 |
-| test.rs:17:26:17:98 | ... .text_with_charset(...) [Ok] | test.rs:17:26:17:107 | ... .unwrap() | provenance | MaD:27 |
+| test.rs:17:26:17:62 | ...::get(...) [Ok] | test.rs:17:26:17:71 | ... .unwrap() | provenance | MaD:28 |
+| test.rs:17:26:17:71 | ... .unwrap() | test.rs:17:26:17:98 | ... .text_with_charset(...) [Ok] | provenance | MaD:39 |
+| test.rs:17:26:17:98 | ... .text_with_charset(...) [Ok] | test.rs:17:26:17:107 | ... .unwrap() | provenance | MaD:28 |
 | test.rs:17:26:17:107 | ... .unwrap() | test.rs:17:9:17:22 | remote_string3 | provenance |  |
 | test.rs:20:9:20:22 | remote_string4 | test.rs:21:10:21:23 | remote_string4 | provenance |  |
 | test.rs:20:26:20:47 | ...::get | test.rs:20:26:20:62 | ...::get(...) [Ok] | provenance | Src:MaD:7  |
-| test.rs:20:26:20:62 | ...::get(...) [Ok] | test.rs:20:26:20:71 | ... .unwrap() | provenance | MaD:27 |
-| test.rs:20:26:20:71 | ... .unwrap() | test.rs:20:26:20:79 | ... .bytes() [Ok] | provenance | MaD:36 |
-| test.rs:20:26:20:79 | ... .bytes() [Ok] | test.rs:20:26:20:88 | ... .unwrap() | provenance | MaD:27 |
+| test.rs:20:26:20:62 | ...::get(...) [Ok] | test.rs:20:26:20:71 | ... .unwrap() | provenance | MaD:28 |
+| test.rs:20:26:20:71 | ... .unwrap() | test.rs:20:26:20:79 | ... .bytes() [Ok] | provenance | MaD:37 |
+| test.rs:20:26:20:79 | ... .bytes() [Ok] | test.rs:20:26:20:88 | ... .unwrap() | provenance | MaD:28 |
 | test.rs:20:26:20:88 | ... .unwrap() | test.rs:20:9:20:22 | remote_string4 | provenance |  |
 | test.rs:23:9:23:22 | remote_string5 | test.rs:24:10:24:23 | remote_string5 | provenance |  |
 | test.rs:23:26:23:37 | ...::get | test.rs:23:26:23:52 | ...::get(...) [future, Ok] | provenance | Src:MaD:8  |
 | test.rs:23:26:23:52 | ...::get(...) [future, Ok] | test.rs:23:26:23:58 | await ... [Ok] | provenance |  |
 | test.rs:23:26:23:58 | await ... [Ok] | test.rs:23:26:23:59 | TryExpr | provenance |  |
-| test.rs:23:26:23:59 | TryExpr | test.rs:23:26:23:66 | ... .text() [future, Ok] | provenance | MaD:35 |
+| test.rs:23:26:23:59 | TryExpr | test.rs:23:26:23:66 | ... .text() [future, Ok] | provenance | MaD:36 |
 | test.rs:23:26:23:66 | ... .text() [future, Ok] | test.rs:23:26:23:72 | await ... [Ok] | provenance |  |
 | test.rs:23:26:23:72 | await ... [Ok] | test.rs:23:26:23:73 | TryExpr | provenance |  |
 | test.rs:23:26:23:73 | TryExpr | test.rs:23:9:23:22 | remote_string5 | provenance |  |
@@ -78,7 +80,7 @@ edges
 | test.rs:26:26:26:37 | ...::get | test.rs:26:26:26:52 | ...::get(...) [future, Ok] | provenance | Src:MaD:8  |
 | test.rs:26:26:26:52 | ...::get(...) [future, Ok] | test.rs:26:26:26:58 | await ... [Ok] | provenance |  |
 | test.rs:26:26:26:58 | await ... [Ok] | test.rs:26:26:26:59 | TryExpr | provenance |  |
-| test.rs:26:26:26:59 | TryExpr | test.rs:26:26:26:67 | ... .bytes() [future, Ok] | provenance | MaD:33 |
+| test.rs:26:26:26:59 | TryExpr | test.rs:26:26:26:67 | ... .bytes() [future, Ok] | provenance | MaD:34 |
 | test.rs:26:26:26:67 | ... .bytes() [future, Ok] | test.rs:26:26:26:73 | await ... [Ok] | provenance |  |
 | test.rs:26:26:26:73 | await ... [Ok] | test.rs:26:26:26:74 | TryExpr | provenance |  |
 | test.rs:26:26:26:74 | TryExpr | test.rs:26:9:26:22 | remote_string6 | provenance |  |
@@ -88,13 +90,13 @@ edges
 | test.rs:29:24:29:50 | ...::get(...) [future, Ok] | test.rs:29:24:29:56 | await ... [Ok] | provenance |  |
 | test.rs:29:24:29:56 | await ... [Ok] | test.rs:29:24:29:57 | TryExpr | provenance |  |
 | test.rs:29:24:29:57 | TryExpr | test.rs:29:9:29:20 | mut request1 | provenance |  |
-| test.rs:30:10:30:17 | request1 | test.rs:30:10:30:25 | request1.chunk() [future, Ok, Some] | provenance | MaD:34 |
+| test.rs:30:10:30:17 | request1 | test.rs:30:10:30:25 | request1.chunk() [future, Ok, Some] | provenance | MaD:35 |
 | test.rs:30:10:30:25 | request1.chunk() [future, Ok, Some] | test.rs:30:10:30:31 | await ... [Ok, Some] | provenance |  |
 | test.rs:30:10:30:31 | await ... [Ok, Some] | test.rs:30:10:30:32 | TryExpr [Some] | provenance |  |
-| test.rs:30:10:30:32 | TryExpr [Some] | test.rs:30:10:30:41 | ... .unwrap() | provenance | MaD:24 |
+| test.rs:30:10:30:32 | TryExpr [Some] | test.rs:30:10:30:41 | ... .unwrap() | provenance | MaD:25 |
 | test.rs:31:15:31:25 | Some(...) [Some] | test.rs:31:20:31:24 | chunk | provenance |  |
 | test.rs:31:20:31:24 | chunk | test.rs:32:14:32:18 | chunk | provenance |  |
-| test.rs:31:29:31:36 | request1 | test.rs:31:29:31:44 | request1.chunk() [future, Ok, Some] | provenance | MaD:34 |
+| test.rs:31:29:31:36 | request1 | test.rs:31:29:31:44 | request1.chunk() [future, Ok, Some] | provenance | MaD:35 |
 | test.rs:31:29:31:44 | request1.chunk() [future, Ok, Some] | test.rs:31:29:31:50 | await ... [Ok, Some] | provenance |  |
 | test.rs:31:29:31:50 | await ... [Ok, Some] | test.rs:31:29:31:51 | TryExpr [Some] | provenance |  |
 | test.rs:31:29:31:51 | TryExpr [Some] | test.rs:31:15:31:25 | Some(...) [Some] | provenance |  |
@@ -114,34 +116,44 @@ edges
 | test.rs:67:24:67:58 | TryExpr | test.rs:67:9:67:20 | mut response | provenance |  |
 | test.rs:67:31:67:42 | send_request | test.rs:67:24:67:51 | sender.send_request(...) [future, Ok] | provenance | Src:MaD:2  |
 | test.rs:68:11:68:18 | response | test.rs:68:10:68:18 | &response | provenance |  |
-| test.rs:76:18:76:25 | response | test.rs:76:18:76:32 | response.body() | provenance | MaD:30 |
-| test.rs:77:18:77:25 | response | test.rs:77:18:77:36 | response.body_mut() | provenance | MaD:31 |
+| test.rs:76:18:76:25 | response | test.rs:76:18:76:32 | response.body() | provenance | MaD:31 |
+| test.rs:77:18:77:25 | response | test.rs:77:18:77:36 | response.body_mut() | provenance | MaD:32 |
 | test.rs:79:17:79:20 | body | test.rs:80:19:80:22 | body | provenance |  |
-| test.rs:79:24:79:31 | response | test.rs:79:24:79:43 | response.into_body() | provenance | MaD:32 |
+| test.rs:79:24:79:31 | response | test.rs:79:24:79:43 | response.into_body() | provenance | MaD:33 |
 | test.rs:79:24:79:43 | response.into_body() | test.rs:79:17:79:20 | body | provenance |  |
 | test.rs:80:19:80:22 | body | test.rs:80:18:80:22 | &body | provenance |  |
 | test.rs:155:13:155:22 | mut stream | test.rs:162:17:162:22 | stream | provenance |  |
 | test.rs:155:26:155:53 | ...::connect | test.rs:155:26:155:62 | ...::connect(...) [Ok] | provenance | Src:MaD:4  |
 | test.rs:155:26:155:62 | ...::connect(...) [Ok] | test.rs:155:26:155:63 | TryExpr | provenance |  |
 | test.rs:155:26:155:63 | TryExpr | test.rs:155:13:155:22 | mut stream | provenance |  |
-| test.rs:162:17:162:22 | stream | test.rs:162:29:162:39 | [post] &mut buffer [&ref] | provenance | MaD:19 |
+| test.rs:162:17:162:22 | stream | test.rs:162:29:162:39 | [post] &mut buffer [&ref] | provenance | MaD:20 |
 | test.rs:162:29:162:39 | [post] &mut buffer [&ref] | test.rs:162:34:162:39 | [post] buffer | provenance |  |
 | test.rs:162:34:162:39 | [post] buffer | test.rs:165:15:165:20 | buffer | provenance |  |
 | test.rs:162:34:162:39 | [post] buffer | test.rs:166:14:166:19 | buffer | provenance |  |
 | test.rs:165:15:165:20 | buffer | test.rs:165:14:165:20 | &buffer | provenance |  |
 | test.rs:166:14:166:19 | buffer | test.rs:166:14:166:22 | buffer[0] | provenance | MaD:10 |
 | test.rs:174:13:174:22 | mut stream | test.rs:182:58:182:63 | stream | provenance |  |
+| test.rs:174:13:174:22 | mut stream | test.rs:203:54:203:59 | stream | provenance |  |
 | test.rs:174:26:174:61 | ...::connect_timeout | test.rs:174:26:174:105 | ...::connect_timeout(...) [Ok] | provenance | Src:MaD:5  |
 | test.rs:174:26:174:105 | ...::connect_timeout(...) [Ok] | test.rs:174:26:174:106 | TryExpr | provenance |  |
 | test.rs:174:26:174:106 | TryExpr | test.rs:174:13:174:22 | mut stream | provenance |  |
 | test.rs:182:21:182:30 | mut reader | test.rs:185:27:185:32 | reader | provenance |  |
-| test.rs:182:34:182:64 | ...::new(...) | test.rs:182:34:182:74 | ... .take(...) | provenance | MaD:22 |
+| test.rs:182:34:182:64 | ...::new(...) | test.rs:182:34:182:74 | ... .take(...) | provenance | MaD:23 |
 | test.rs:182:34:182:74 | ... .take(...) | test.rs:182:21:182:30 | mut reader | provenance |  |
-| test.rs:182:58:182:63 | stream | test.rs:182:34:182:64 | ...::new(...) | provenance | MaD:39 |
-| test.rs:185:27:185:32 | reader | test.rs:185:44:185:52 | [post] &mut line [&ref] | provenance | MaD:18 |
+| test.rs:182:58:182:63 | stream | test.rs:182:34:182:64 | ...::new(...) | provenance | MaD:40 |
+| test.rs:185:27:185:32 | reader | test.rs:185:44:185:52 | [post] &mut line [&ref] | provenance | MaD:19 |
 | test.rs:185:44:185:52 | [post] &mut line [&ref] | test.rs:185:49:185:52 | [post] line | provenance |  |
 | test.rs:185:49:185:52 | [post] line | test.rs:192:35:192:38 | line | provenance |  |
 | test.rs:192:35:192:38 | line | test.rs:192:34:192:38 | &line | provenance |  |
+| test.rs:203:21:203:26 | reader | test.rs:204:29:204:34 | reader | provenance |  |
+| test.rs:203:30:203:73 | ...::new(...) | test.rs:203:30:203:83 | ... .take(...) | provenance | MaD:23 |
+| test.rs:203:30:203:83 | ... .take(...) | test.rs:203:21:203:26 | reader | provenance |  |
+| test.rs:203:54:203:59 | stream | test.rs:203:54:203:71 | stream.try_clone() [Ok] | provenance | MaD:41 |
+| test.rs:203:54:203:71 | stream.try_clone() [Ok] | test.rs:203:54:203:72 | TryExpr | provenance |  |
+| test.rs:203:54:203:72 | TryExpr | test.rs:203:30:203:73 | ...::new(...) | provenance | MaD:40 |
+| test.rs:204:29:204:34 | reader | test.rs:204:29:204:42 | reader.lines() | provenance | MaD:18 |
+| test.rs:204:29:204:42 | reader.lines() | test.rs:205:28:205:37 | Ok(...) | provenance |  |
+| test.rs:205:28:205:37 | Ok(...) | test.rs:207:30:207:35 | string | provenance |  |
 | test.rs:224:9:224:24 | mut tokio_stream | test.rs:232:17:232:28 | tokio_stream | provenance |  |
 | test.rs:224:9:224:24 | mut tokio_stream | test.rs:236:18:236:29 | tokio_stream | provenance |  |
 | test.rs:224:9:224:24 | mut tokio_stream | test.rs:252:19:252:30 | tokio_stream | provenance |  |
@@ -150,11 +162,11 @@ edges
 | test.rs:224:28:224:66 | ...::connect(...) [future, Ok] | test.rs:224:28:224:72 | await ... [Ok] | provenance |  |
 | test.rs:224:28:224:72 | await ... [Ok] | test.rs:224:28:224:73 | TryExpr | provenance |  |
 | test.rs:224:28:224:73 | TryExpr | test.rs:224:9:224:24 | mut tokio_stream | provenance |  |
-| test.rs:232:17:232:28 | tokio_stream | test.rs:232:35:232:46 | [post] &mut buffer1 [&ref] | provenance | MaD:40 |
+| test.rs:232:17:232:28 | tokio_stream | test.rs:232:35:232:46 | [post] &mut buffer1 [&ref] | provenance | MaD:42 |
 | test.rs:232:35:232:46 | [post] &mut buffer1 [&ref] | test.rs:232:40:232:46 | [post] buffer1 | provenance |  |
 | test.rs:232:40:232:46 | [post] buffer1 | test.rs:239:15:239:21 | buffer1 | provenance |  |
 | test.rs:232:40:232:46 | [post] buffer1 | test.rs:240:14:240:20 | buffer1 | provenance |  |
-| test.rs:236:18:236:29 | tokio_stream | test.rs:236:36:236:47 | [post] &mut buffer2 [&ref] | provenance | MaD:23 |
+| test.rs:236:18:236:29 | tokio_stream | test.rs:236:36:236:47 | [post] &mut buffer2 [&ref] | provenance | MaD:24 |
 | test.rs:236:36:236:47 | [post] &mut buffer2 [&ref] | test.rs:236:41:236:47 | [post] buffer2 | provenance |  |
 | test.rs:236:41:236:47 | [post] buffer2 | test.rs:243:15:243:21 | buffer2 | provenance |  |
 | test.rs:236:41:236:47 | [post] buffer2 | test.rs:244:14:244:20 | buffer2 | provenance |  |
@@ -162,17 +174,17 @@ edges
 | test.rs:240:14:240:20 | buffer1 | test.rs:240:14:240:23 | buffer1[0] | provenance | MaD:10 |
 | test.rs:243:15:243:21 | buffer2 | test.rs:243:14:243:21 | &buffer2 | provenance |  |
 | test.rs:244:14:244:20 | buffer2 | test.rs:244:14:244:23 | buffer2[0] | provenance | MaD:10 |
-| test.rs:252:19:252:30 | tokio_stream | test.rs:252:41:252:51 | [post] &mut buffer [&ref] | provenance | MaD:41 |
+| test.rs:252:19:252:30 | tokio_stream | test.rs:252:41:252:51 | [post] &mut buffer [&ref] | provenance | MaD:43 |
 | test.rs:252:41:252:51 | [post] &mut buffer [&ref] | test.rs:252:46:252:51 | [post] buffer | provenance |  |
 | test.rs:252:46:252:51 | [post] buffer | test.rs:259:27:259:32 | buffer | provenance |  |
 | test.rs:259:27:259:32 | buffer | test.rs:259:26:259:32 | &buffer | provenance |  |
-| test.rs:275:19:275:30 | tokio_stream | test.rs:275:45:275:55 | [post] &mut buffer [&ref] | provenance | MaD:42 |
+| test.rs:275:19:275:30 | tokio_stream | test.rs:275:45:275:55 | [post] &mut buffer [&ref] | provenance | MaD:44 |
 | test.rs:275:45:275:55 | [post] &mut buffer [&ref] | test.rs:275:50:275:55 | [post] buffer | provenance |  |
 | test.rs:275:50:275:55 | [post] buffer | test.rs:282:27:282:32 | buffer | provenance |  |
 | test.rs:282:27:282:32 | buffer | test.rs:282:26:282:32 | &buffer | provenance |  |
 | test.rs:332:9:332:18 | mut client | test.rs:333:22:333:27 | client | provenance |  |
 | test.rs:332:22:332:50 | ...::new | test.rs:332:22:332:75 | ...::new(...) [Ok] | provenance | Src:MaD:3  |
-| test.rs:332:22:332:75 | ...::new(...) [Ok] | test.rs:332:22:332:84 | ... .unwrap() | provenance | MaD:27 |
+| test.rs:332:22:332:75 | ...::new(...) [Ok] | test.rs:332:22:332:84 | ... .unwrap() | provenance | MaD:28 |
 | test.rs:332:22:332:84 | ... .unwrap() | test.rs:332:9:332:18 | mut client | provenance |  |
 | test.rs:333:9:333:18 | mut reader | test.rs:334:11:334:16 | reader | provenance |  |
 | test.rs:333:9:333:18 | mut reader | test.rs:338:22:338:27 | reader | provenance |  |
@@ -181,15 +193,15 @@ edges
 | test.rs:333:22:333:27 | client | test.rs:333:22:333:36 | client.reader() | provenance | MaD:9 |
 | test.rs:333:22:333:36 | client.reader() | test.rs:333:9:333:18 | mut reader | provenance |  |
 | test.rs:334:11:334:16 | reader | test.rs:334:10:334:16 | &reader | provenance |  |
-| test.rs:338:22:338:27 | reader | test.rs:338:34:338:44 | [post] &mut buffer [&ref] | provenance | MaD:19 |
+| test.rs:338:22:338:27 | reader | test.rs:338:34:338:44 | [post] &mut buffer [&ref] | provenance | MaD:20 |
 | test.rs:338:34:338:44 | [post] &mut buffer [&ref] | test.rs:338:39:338:44 | [post] buffer | provenance |  |
 | test.rs:338:39:338:44 | [post] buffer | test.rs:339:15:339:20 | buffer | provenance |  |
 | test.rs:339:15:339:20 | buffer | test.rs:339:14:339:20 | &buffer | provenance |  |
-| test.rs:344:22:344:27 | reader | test.rs:344:41:344:51 | [post] &mut buffer [&ref] | provenance | MaD:20 |
+| test.rs:344:22:344:27 | reader | test.rs:344:41:344:51 | [post] &mut buffer [&ref] | provenance | MaD:21 |
 | test.rs:344:41:344:51 | [post] &mut buffer [&ref] | test.rs:344:46:344:51 | [post] buffer | provenance |  |
 | test.rs:344:46:344:51 | [post] buffer | test.rs:345:15:345:20 | buffer | provenance |  |
 | test.rs:345:15:345:20 | buffer | test.rs:345:14:345:20 | &buffer | provenance |  |
-| test.rs:350:22:350:27 | reader | test.rs:350:44:350:54 | [post] &mut buffer [&ref] | provenance | MaD:21 |
+| test.rs:350:22:350:27 | reader | test.rs:350:44:350:54 | [post] &mut buffer [&ref] | provenance | MaD:22 |
 | test.rs:350:44:350:54 | [post] &mut buffer [&ref] | test.rs:350:49:350:54 | [post] buffer | provenance |  |
 | test.rs:350:49:350:54 | [post] buffer | test.rs:351:15:351:20 | buffer | provenance |  |
 | test.rs:351:15:351:20 | buffer | test.rs:351:14:351:20 | &buffer | provenance |  |
@@ -208,15 +220,15 @@ edges
 | test.rs:380:26:380:60 | connector.connect(...) [future, Ok] | test.rs:380:26:380:66 | await ... [Ok] | provenance |  |
 | test.rs:380:26:380:66 | await ... [Ok] | test.rs:380:26:380:67 | TryExpr | provenance |  |
 | test.rs:380:26:380:67 | TryExpr | test.rs:380:13:380:22 | mut reader | provenance |  |
-| test.rs:380:57:380:59 | tcp | test.rs:380:26:380:60 | connector.connect(...) [future, Ok] | provenance | MaD:28 |
+| test.rs:380:57:380:59 | tcp | test.rs:380:26:380:60 | connector.connect(...) [future, Ok] | provenance | MaD:29 |
 | test.rs:381:15:381:20 | reader | test.rs:381:14:381:20 | &reader | provenance |  |
 | test.rs:386:17:386:26 | mut pinned | test.rs:387:19:387:24 | pinned | provenance |  |
 | test.rs:386:17:386:26 | mut pinned | test.rs:389:30:389:35 | pinned | provenance |  |
 | test.rs:386:17:386:26 | mut pinned [Pin, &ref] | test.rs:387:19:387:24 | pinned [Pin, &ref] | provenance |  |
 | test.rs:386:30:386:50 | ...::new(...) | test.rs:386:17:386:26 | mut pinned | provenance |  |
 | test.rs:386:30:386:50 | ...::new(...) [Pin, &ref] | test.rs:386:17:386:26 | mut pinned [Pin, &ref] | provenance |  |
-| test.rs:386:39:386:49 | &mut reader [&ref] | test.rs:386:30:386:50 | ...::new(...) | provenance | MaD:25 |
-| test.rs:386:39:386:49 | &mut reader [&ref] | test.rs:386:30:386:50 | ...::new(...) [Pin, &ref] | provenance | MaD:26 |
+| test.rs:386:39:386:49 | &mut reader [&ref] | test.rs:386:30:386:50 | ...::new(...) | provenance | MaD:26 |
+| test.rs:386:39:386:49 | &mut reader [&ref] | test.rs:386:30:386:50 | ...::new(...) [Pin, &ref] | provenance | MaD:27 |
 | test.rs:386:44:386:49 | reader | test.rs:386:39:386:49 | &mut reader [&ref] | provenance |  |
 | test.rs:387:19:387:24 | pinned | test.rs:387:18:387:24 | &pinned | provenance |  |
 | test.rs:387:19:387:24 | pinned [Pin, &ref] | test.rs:387:18:387:24 | &pinned | provenance |  |
@@ -254,15 +266,15 @@ edges
 | test.rs:408:13:408:23 | mut reader2 | test.rs:493:31:493:37 | reader2 | provenance |  |
 | test.rs:408:13:408:23 | mut reader2 | test.rs:500:31:500:37 | reader2 | provenance |  |
 | test.rs:408:27:408:61 | ...::new(...) | test.rs:408:13:408:23 | mut reader2 | provenance |  |
-| test.rs:408:55:408:60 | reader | test.rs:408:27:408:61 | ...::new(...) | provenance | MaD:29 |
+| test.rs:408:55:408:60 | reader | test.rs:408:27:408:61 | ...::new(...) | provenance | MaD:30 |
 | test.rs:409:15:409:21 | reader2 | test.rs:409:14:409:21 | &reader2 | provenance |  |
 | test.rs:413:17:413:26 | mut pinned | test.rs:414:19:414:24 | pinned | provenance |  |
 | test.rs:413:17:413:26 | mut pinned | test.rs:416:26:416:31 | pinned | provenance |  |
 | test.rs:413:17:413:26 | mut pinned [Pin, &ref] | test.rs:414:19:414:24 | pinned [Pin, &ref] | provenance |  |
 | test.rs:413:30:413:51 | ...::new(...) | test.rs:413:17:413:26 | mut pinned | provenance |  |
 | test.rs:413:30:413:51 | ...::new(...) [Pin, &ref] | test.rs:413:17:413:26 | mut pinned [Pin, &ref] | provenance |  |
-| test.rs:413:39:413:50 | &mut reader2 [&ref] | test.rs:413:30:413:51 | ...::new(...) | provenance | MaD:25 |
-| test.rs:413:39:413:50 | &mut reader2 [&ref] | test.rs:413:30:413:51 | ...::new(...) [Pin, &ref] | provenance | MaD:26 |
+| test.rs:413:39:413:50 | &mut reader2 [&ref] | test.rs:413:30:413:51 | ...::new(...) | provenance | MaD:26 |
+| test.rs:413:39:413:50 | &mut reader2 [&ref] | test.rs:413:30:413:51 | ...::new(...) [Pin, &ref] | provenance | MaD:27 |
 | test.rs:413:44:413:50 | reader2 | test.rs:413:39:413:50 | &mut reader2 [&ref] | provenance |  |
 | test.rs:414:19:414:24 | pinned | test.rs:414:18:414:24 | &pinned | provenance |  |
 | test.rs:414:19:414:24 | pinned [Pin, &ref] | test.rs:414:18:414:24 | &pinned | provenance |  |
@@ -277,7 +289,7 @@ edges
 | test.rs:423:17:423:23 | buffer2 [Ready, Ok] | test.rs:424:20:424:26 | buffer2 [Ready, Ok] | provenance |  |
 | test.rs:423:27:423:48 | ...::new(...) | test.rs:423:27:423:71 | ... .poll_fill_buf(...) [Ready, Ok] | provenance | MaD:11 |
 | test.rs:423:27:423:71 | ... .poll_fill_buf(...) [Ready, Ok] | test.rs:423:17:423:23 | buffer2 [Ready, Ok] | provenance |  |
-| test.rs:423:36:423:47 | &mut reader2 [&ref] | test.rs:423:27:423:48 | ...::new(...) | provenance | MaD:25 |
+| test.rs:423:36:423:47 | &mut reader2 [&ref] | test.rs:423:27:423:48 | ...::new(...) | provenance | MaD:26 |
 | test.rs:423:41:423:47 | reader2 | test.rs:423:36:423:47 | &mut reader2 [&ref] | provenance |  |
 | test.rs:424:20:424:26 | buffer2 [Ready, Ok] | test.rs:425:17:425:36 | ...::Ready(...) [Ready, Ok] | provenance |  |
 | test.rs:424:20:424:26 | buffer2 [Ready, Ok] | test.rs:426:27:426:33 | buffer2 [Ready, Ok] | provenance |  |
@@ -295,8 +307,8 @@ edges
 | test.rs:444:17:444:26 | mut pinned [Pin, &ref] | test.rs:445:19:445:24 | pinned [Pin, &ref] | provenance |  |
 | test.rs:444:30:444:51 | ...::new(...) | test.rs:444:17:444:26 | mut pinned | provenance |  |
 | test.rs:444:30:444:51 | ...::new(...) [Pin, &ref] | test.rs:444:17:444:26 | mut pinned [Pin, &ref] | provenance |  |
-| test.rs:444:39:444:50 | &mut reader2 [&ref] | test.rs:444:30:444:51 | ...::new(...) | provenance | MaD:25 |
-| test.rs:444:39:444:50 | &mut reader2 [&ref] | test.rs:444:30:444:51 | ...::new(...) [Pin, &ref] | provenance | MaD:26 |
+| test.rs:444:39:444:50 | &mut reader2 [&ref] | test.rs:444:30:444:51 | ...::new(...) | provenance | MaD:26 |
+| test.rs:444:39:444:50 | &mut reader2 [&ref] | test.rs:444:30:444:51 | ...::new(...) [Pin, &ref] | provenance | MaD:27 |
 | test.rs:444:44:444:50 | reader2 | test.rs:444:39:444:50 | &mut reader2 [&ref] | provenance |  |
 | test.rs:445:19:445:24 | pinned | test.rs:445:18:445:24 | &pinned | provenance |  |
 | test.rs:445:19:445:24 | pinned [Pin, &ref] | test.rs:445:18:445:24 | &pinned | provenance |  |
@@ -326,8 +338,8 @@ edges
 | test.rs:467:17:467:26 | mut pinned [Pin, &ref] | test.rs:468:19:468:24 | pinned [Pin, &ref] | provenance |  |
 | test.rs:467:30:467:51 | ...::new(...) | test.rs:467:17:467:26 | mut pinned | provenance |  |
 | test.rs:467:30:467:51 | ...::new(...) [Pin, &ref] | test.rs:467:17:467:26 | mut pinned [Pin, &ref] | provenance |  |
-| test.rs:467:39:467:50 | &mut reader2 [&ref] | test.rs:467:30:467:51 | ...::new(...) | provenance | MaD:25 |
-| test.rs:467:39:467:50 | &mut reader2 [&ref] | test.rs:467:30:467:51 | ...::new(...) [Pin, &ref] | provenance | MaD:26 |
+| test.rs:467:39:467:50 | &mut reader2 [&ref] | test.rs:467:30:467:51 | ...::new(...) | provenance | MaD:26 |
+| test.rs:467:39:467:50 | &mut reader2 [&ref] | test.rs:467:30:467:51 | ...::new(...) [Pin, &ref] | provenance | MaD:27 |
 | test.rs:467:44:467:50 | reader2 | test.rs:467:39:467:50 | &mut reader2 [&ref] | provenance |  |
 | test.rs:468:19:468:24 | pinned | test.rs:468:18:468:24 | &pinned | provenance |  |
 | test.rs:468:19:468:24 | pinned [Pin, &ref] | test.rs:468:18:468:24 | &pinned | provenance |  |
@@ -468,6 +480,16 @@ nodes
 | test.rs:185:49:185:52 | [post] line | semmle.label | [post] line |
 | test.rs:192:34:192:38 | &line | semmle.label | &line |
 | test.rs:192:35:192:38 | line | semmle.label | line |
+| test.rs:203:21:203:26 | reader | semmle.label | reader |
+| test.rs:203:30:203:73 | ...::new(...) | semmle.label | ...::new(...) |
+| test.rs:203:30:203:83 | ... .take(...) | semmle.label | ... .take(...) |
+| test.rs:203:54:203:59 | stream | semmle.label | stream |
+| test.rs:203:54:203:71 | stream.try_clone() [Ok] | semmle.label | stream.try_clone() [Ok] |
+| test.rs:203:54:203:72 | TryExpr | semmle.label | TryExpr |
+| test.rs:204:29:204:34 | reader | semmle.label | reader |
+| test.rs:204:29:204:42 | reader.lines() | semmle.label | reader.lines() |
+| test.rs:205:28:205:37 | Ok(...) | semmle.label | Ok(...) |
+| test.rs:207:30:207:35 | string | semmle.label | string |
 | test.rs:224:9:224:24 | mut tokio_stream | semmle.label | mut tokio_stream |
 | test.rs:224:28:224:57 | ...::connect | semmle.label | ...::connect |
 | test.rs:224:28:224:66 | ...::connect(...) [future, Ok] | semmle.label | ...::connect(...) [future, Ok] |
@@ -695,6 +717,7 @@ testFailures
 | test.rs:165:14:165:20 | &buffer | test.rs:155:26:155:53 | ...::connect | test.rs:165:14:165:20 | &buffer | $@ | test.rs:155:26:155:53 | ...::connect | ...::connect |
 | test.rs:166:14:166:22 | buffer[0] | test.rs:155:26:155:53 | ...::connect | test.rs:166:14:166:22 | buffer[0] | $@ | test.rs:155:26:155:53 | ...::connect | ...::connect |
 | test.rs:192:34:192:38 | &line | test.rs:174:26:174:61 | ...::connect_timeout | test.rs:192:34:192:38 | &line | $@ | test.rs:174:26:174:61 | ...::connect_timeout | ...::connect_timeout |
+| test.rs:207:30:207:35 | string | test.rs:174:26:174:61 | ...::connect_timeout | test.rs:207:30:207:35 | string | $@ | test.rs:174:26:174:61 | ...::connect_timeout | ...::connect_timeout |
 | test.rs:239:14:239:21 | &buffer1 | test.rs:224:28:224:57 | ...::connect | test.rs:239:14:239:21 | &buffer1 | $@ | test.rs:224:28:224:57 | ...::connect | ...::connect |
 | test.rs:240:14:240:23 | buffer1[0] | test.rs:224:28:224:57 | ...::connect | test.rs:240:14:240:23 | buffer1[0] | $@ | test.rs:224:28:224:57 | ...::connect | ...::connect |
 | test.rs:243:14:243:21 | &buffer2 | test.rs:224:28:224:57 | ...::connect | test.rs:243:14:243:21 | &buffer2 | $@ | test.rs:224:28:224:57 | ...::connect | ...::connect |

--- a/rust/ql/test/library-tests/dataflow/sources/net/test.rs
+++ b/rust/ql/test/library-tests/dataflow/sources/net/test.rs
@@ -204,7 +204,7 @@ async fn test_std_tcpstream(case: i64) -> std::io::Result<()> {
                 for line in reader.lines() { // $ MISSING: Alert[rust/summary/taint-sources]
                     if let Ok(string) = line {
                         println!("line = {}", string);
-                        sink(string); // $ MISSING: hasTaintFlow=&sock_addr
+                        sink(string); // $ hasTaintFlow=&sock_addr
                     }
                 }
             }

--- a/rust/ql/test/library-tests/dataflow/sources/web_frameworks/InlineFlow.expected
+++ b/rust/ql/test/library-tests/dataflow/sources/web_frameworks/InlineFlow.expected
@@ -10,8 +10,8 @@ models
 | 9 | Source: axum::routing::method_routing::post; Argument[0].Parameter[0..7]; remote |
 | 10 | Source: axum::routing::method_routing::put; Argument[0].Parameter[0..7]; remote |
 | 11 | Summary: <actix_web::types::path::Path>::into_inner; Argument[self]; ReturnValue; taint |
-| 12 | Summary: <alloc::string::String>::as_bytes; Argument[self]; ReturnValue; value |
-| 13 | Summary: <alloc::string::String>::as_str; Argument[self]; ReturnValue; value |
+| 12 | Summary: <alloc::string::String>::as_bytes; Argument[self].Reference; ReturnValue.Reference.Element; taint |
+| 13 | Summary: <alloc::string::String>::as_str; Argument[self].Reference; ReturnValue.Reference; taint |
 edges
 | test.rs:11:31:11:31 | a | test.rs:13:14:13:14 | a | provenance |  |
 | test.rs:11:31:11:31 | a | test.rs:14:14:14:14 | a | provenance |  |

--- a/rust/ql/test/library-tests/dataflow/strings/inline-taint-flow.expected
+++ b/rust/ql/test/library-tests/dataflow/strings/inline-taint-flow.expected
@@ -5,8 +5,8 @@ models
 | 4 | Summary: <alloc::string::String as core::convert::From>::from; Argument[0].Field[alloc::borrow::Cow::Owned(0)]; ReturnValue; value |
 | 5 | Summary: <alloc::string::String as core::convert::From>::from; Argument[0].Reference; ReturnValue; value |
 | 6 | Summary: <alloc::string::String as core::ops::arith::Add>::add; Argument[0].Reference; ReturnValue; taint |
-| 7 | Summary: <alloc::string::String as core::ops::arith::Add>::add; Argument[self,0]; ReturnValue; taint |
-| 8 | Summary: <alloc::string::String>::as_str; Argument[self]; ReturnValue; value |
+| 7 | Summary: <alloc::string::String as core::ops::arith::Add>::add; Argument[self]; ReturnValue; taint |
+| 8 | Summary: <alloc::string::String>::as_str; Argument[self].Reference; ReturnValue.Reference; taint |
 | 9 | Summary: alloc::fmt::format; Argument[0]; ReturnValue; taint |
 | 10 | Summary: core::hint::must_use; Argument[0]; ReturnValue; value |
 edges

--- a/rust/ql/test/query-tests/security/CWE-089/SqlInjection.expected
+++ b/rust/ql/test/query-tests/security/CWE-089/SqlInjection.expected
@@ -224,8 +224,8 @@ models
 | 24 | Source: std::env::args; ReturnValue.Element; commandargs |
 | 25 | Summary: <_ as core::iter::traits::iterator::Iterator>::nth; Argument[self].Reference.Element; ReturnValue.Field[core::option::Option::Some(0)]; value |
 | 26 | Summary: <alloc::string::String as core::ops::arith::Add>::add; Argument[0].Reference; ReturnValue; taint |
-| 27 | Summary: <alloc::string::String as core::ops::arith::Add>::add; Argument[self,0]; ReturnValue; taint |
-| 28 | Summary: <alloc::string::String>::as_str; Argument[self]; ReturnValue; value |
+| 27 | Summary: <alloc::string::String as core::ops::arith::Add>::add; Argument[self]; ReturnValue; taint |
+| 28 | Summary: <alloc::string::String>::as_str; Argument[self].Reference; ReturnValue.Reference; taint |
 | 29 | Summary: <core::option::Option>::unwrap_or; Argument[self].Field[core::option::Option::Some(0)]; ReturnValue; value |
 | 30 | Summary: <core::result::Result>::unwrap; Argument[self].Field[core::result::Result::Ok(0)]; ReturnValue; value |
 | 31 | Summary: <core::result::Result>::unwrap_or; Argument[self].Field[core::result::Result::Ok(0)]; ReturnValue; value |

--- a/rust/ql/test/query-tests/security/CWE-312/CleartextLogging.expected
+++ b/rust/ql/test/query-tests/security/CWE-312/CleartextLogging.expected
@@ -136,7 +136,6 @@ edges
 | test_logging.rs:94:11:94:28 | MacroExpr | test_logging.rs:94:5:94:9 | ...::log | provenance | MaD:11 Sink:MaD:11 |
 | test_logging.rs:96:9:96:10 | m2 | test_logging.rs:97:11:97:18 | MacroExpr | provenance |  |
 | test_logging.rs:96:14:96:49 | ... + ... | test_logging.rs:96:9:96:10 | m2 | provenance |  |
-| test_logging.rs:96:41:96:49 | &password | test_logging.rs:96:14:96:49 | ... + ... | provenance | MaD:17 |
 | test_logging.rs:96:41:96:49 | &password | test_logging.rs:96:14:96:49 | ... + ... | provenance | MaD:16 |
 | test_logging.rs:96:41:96:49 | &password [&ref] | test_logging.rs:96:14:96:49 | ... + ... | provenance | MaD:16 |
 | test_logging.rs:96:42:96:49 | password | test_logging.rs:96:41:96:49 | &password | provenance | Config |
@@ -145,8 +144,8 @@ edges
 | test_logging.rs:99:9:99:10 | m3 | test_logging.rs:100:11:100:18 | MacroExpr | provenance |  |
 | test_logging.rs:99:22:99:45 | ...::format(...) | test_logging.rs:99:22:99:45 | { ... } | provenance |  |
 | test_logging.rs:99:22:99:45 | ...::must_use(...) | test_logging.rs:99:9:99:10 | m3 | provenance |  |
-| test_logging.rs:99:22:99:45 | MacroExpr | test_logging.rs:99:22:99:45 | ...::format(...) | provenance | MaD:20 |
-| test_logging.rs:99:22:99:45 | { ... } | test_logging.rs:99:22:99:45 | ...::must_use(...) | provenance | MaD:21 |
+| test_logging.rs:99:22:99:45 | MacroExpr | test_logging.rs:99:22:99:45 | ...::format(...) | provenance | MaD:19 |
+| test_logging.rs:99:22:99:45 | { ... } | test_logging.rs:99:22:99:45 | ...::must_use(...) | provenance | MaD:20 |
 | test_logging.rs:99:38:99:45 | password | test_logging.rs:99:22:99:45 | MacroExpr | provenance |  |
 | test_logging.rs:100:11:100:18 | MacroExpr | test_logging.rs:100:5:100:9 | ...::log | provenance | MaD:11 Sink:MaD:11 |
 | test_logging.rs:118:12:118:41 | MacroExpr | test_logging.rs:118:5:118:10 | ...::log | provenance | MaD:11 Sink:MaD:11 |
@@ -167,8 +166,8 @@ edges
 | test_logging.rs:176:34:176:79 | MacroExpr | test_logging.rs:176:33:176:79 | &... [&ref] | provenance |  |
 | test_logging.rs:176:42:176:78 | ...::format(...) | test_logging.rs:176:42:176:78 | { ... } | provenance |  |
 | test_logging.rs:176:42:176:78 | ...::must_use(...) | test_logging.rs:176:34:176:79 | MacroExpr | provenance |  |
-| test_logging.rs:176:42:176:78 | MacroExpr | test_logging.rs:176:42:176:78 | ...::format(...) | provenance | MaD:20 |
-| test_logging.rs:176:42:176:78 | { ... } | test_logging.rs:176:42:176:78 | ...::must_use(...) | provenance | MaD:21 |
+| test_logging.rs:176:42:176:78 | MacroExpr | test_logging.rs:176:42:176:78 | ...::format(...) | provenance | MaD:19 |
+| test_logging.rs:176:42:176:78 | { ... } | test_logging.rs:176:42:176:78 | ...::must_use(...) | provenance | MaD:20 |
 | test_logging.rs:176:70:176:78 | password2 | test_logging.rs:176:42:176:78 | MacroExpr | provenance |  |
 | test_logging.rs:180:35:180:81 | &... | test_logging.rs:180:24:180:33 | log_expect | provenance | MaD:3 Sink:MaD:3 |
 | test_logging.rs:180:35:180:81 | &... [&ref] | test_logging.rs:180:24:180:33 | log_expect | provenance | MaD:3 Sink:MaD:3 |
@@ -176,8 +175,8 @@ edges
 | test_logging.rs:180:36:180:81 | MacroExpr | test_logging.rs:180:35:180:81 | &... [&ref] | provenance |  |
 | test_logging.rs:180:44:180:80 | ...::format(...) | test_logging.rs:180:44:180:80 | { ... } | provenance |  |
 | test_logging.rs:180:44:180:80 | ...::must_use(...) | test_logging.rs:180:36:180:81 | MacroExpr | provenance |  |
-| test_logging.rs:180:44:180:80 | MacroExpr | test_logging.rs:180:44:180:80 | ...::format(...) | provenance | MaD:20 |
-| test_logging.rs:180:44:180:80 | { ... } | test_logging.rs:180:44:180:80 | ...::must_use(...) | provenance | MaD:21 |
+| test_logging.rs:180:44:180:80 | MacroExpr | test_logging.rs:180:44:180:80 | ...::format(...) | provenance | MaD:19 |
+| test_logging.rs:180:44:180:80 | { ... } | test_logging.rs:180:44:180:80 | ...::must_use(...) | provenance | MaD:20 |
 | test_logging.rs:180:72:180:80 | password2 | test_logging.rs:180:44:180:80 | MacroExpr | provenance |  |
 | test_logging.rs:183:9:183:19 | err_result2 [Err] | test_logging.rs:184:13:184:23 | err_result2 [Err] | provenance |  |
 | test_logging.rs:183:47:183:68 | Err(...) [Err] | test_logging.rs:183:9:183:19 | err_result2 [Err] | provenance |  |
@@ -220,40 +219,40 @@ edges
 | test_logging.rs:226:36:226:59 | ...::Some(...) [Some] | test_logging.rs:226:13:226:28 | ...::assert_failed | provenance | MaD:9 Sink:MaD:9 |
 | test_logging.rs:226:36:226:59 | MacroExpr | test_logging.rs:226:36:226:59 | ...::Some(...) [Some] | provenance |  |
 | test_logging.rs:226:52:226:59 | password | test_logging.rs:226:36:226:59 | MacroExpr | provenance |  |
-| test_logging.rs:229:30:229:62 | MacroExpr | test_logging.rs:229:30:229:71 | ... .as_str() [&ref] | provenance | MaD:19 |
+| test_logging.rs:229:30:229:62 | MacroExpr | test_logging.rs:229:30:229:71 | ... .as_str() [&ref] | provenance | MaD:18 |
 | test_logging.rs:229:30:229:71 | ... .as_str() [&ref] | test_logging.rs:229:23:229:28 | expect | provenance | MaD:2 Sink:MaD:2 |
 | test_logging.rs:229:38:229:61 | ...::format(...) | test_logging.rs:229:38:229:61 | { ... } | provenance |  |
 | test_logging.rs:229:38:229:61 | ...::must_use(...) | test_logging.rs:229:30:229:62 | MacroExpr | provenance |  |
-| test_logging.rs:229:38:229:61 | MacroExpr | test_logging.rs:229:38:229:61 | ...::format(...) | provenance | MaD:20 |
-| test_logging.rs:229:38:229:61 | { ... } | test_logging.rs:229:38:229:61 | ...::must_use(...) | provenance | MaD:21 |
+| test_logging.rs:229:38:229:61 | MacroExpr | test_logging.rs:229:38:229:61 | ...::format(...) | provenance | MaD:19 |
+| test_logging.rs:229:38:229:61 | { ... } | test_logging.rs:229:38:229:61 | ...::must_use(...) | provenance | MaD:20 |
 | test_logging.rs:229:54:229:61 | password | test_logging.rs:229:38:229:61 | MacroExpr | provenance |  |
-| test_logging.rs:242:16:242:50 | MacroExpr | test_logging.rs:242:16:242:61 | ... .as_bytes() [&ref] | provenance | MaD:18 |
-| test_logging.rs:242:16:242:61 | ... .as_bytes() [&ref] | test_logging.rs:242:10:242:14 | write | provenance | MaD:7 Sink:MaD:7 |
+| test_logging.rs:242:16:242:50 | MacroExpr | test_logging.rs:242:16:242:61 | ... .as_bytes() [&ref, element] | provenance | MaD:17 |
+| test_logging.rs:242:16:242:61 | ... .as_bytes() [&ref, element] | test_logging.rs:242:10:242:14 | write | provenance | MaD:7 Sink:MaD:7 Sink:MaD:7 |
 | test_logging.rs:242:24:242:49 | ...::format(...) | test_logging.rs:242:24:242:49 | { ... } | provenance |  |
 | test_logging.rs:242:24:242:49 | ...::must_use(...) | test_logging.rs:242:16:242:50 | MacroExpr | provenance |  |
-| test_logging.rs:242:24:242:49 | MacroExpr | test_logging.rs:242:24:242:49 | ...::format(...) | provenance | MaD:20 |
-| test_logging.rs:242:24:242:49 | { ... } | test_logging.rs:242:24:242:49 | ...::must_use(...) | provenance | MaD:21 |
+| test_logging.rs:242:24:242:49 | MacroExpr | test_logging.rs:242:24:242:49 | ...::format(...) | provenance | MaD:19 |
+| test_logging.rs:242:24:242:49 | { ... } | test_logging.rs:242:24:242:49 | ...::must_use(...) | provenance | MaD:20 |
 | test_logging.rs:242:42:242:49 | password | test_logging.rs:242:24:242:49 | MacroExpr | provenance |  |
-| test_logging.rs:245:20:245:54 | MacroExpr | test_logging.rs:245:20:245:65 | ... .as_bytes() [&ref] | provenance | MaD:18 |
-| test_logging.rs:245:20:245:65 | ... .as_bytes() [&ref] | test_logging.rs:245:10:245:18 | write_all | provenance | MaD:8 Sink:MaD:8 |
+| test_logging.rs:245:20:245:54 | MacroExpr | test_logging.rs:245:20:245:65 | ... .as_bytes() [&ref, element] | provenance | MaD:17 |
+| test_logging.rs:245:20:245:65 | ... .as_bytes() [&ref, element] | test_logging.rs:245:10:245:18 | write_all | provenance | MaD:8 Sink:MaD:8 Sink:MaD:8 |
 | test_logging.rs:245:28:245:53 | ...::format(...) | test_logging.rs:245:28:245:53 | { ... } | provenance |  |
 | test_logging.rs:245:28:245:53 | ...::must_use(...) | test_logging.rs:245:20:245:54 | MacroExpr | provenance |  |
-| test_logging.rs:245:28:245:53 | MacroExpr | test_logging.rs:245:28:245:53 | ...::format(...) | provenance | MaD:20 |
-| test_logging.rs:245:28:245:53 | { ... } | test_logging.rs:245:28:245:53 | ...::must_use(...) | provenance | MaD:21 |
+| test_logging.rs:245:28:245:53 | MacroExpr | test_logging.rs:245:28:245:53 | ...::format(...) | provenance | MaD:19 |
+| test_logging.rs:245:28:245:53 | { ... } | test_logging.rs:245:28:245:53 | ...::must_use(...) | provenance | MaD:20 |
 | test_logging.rs:245:46:245:53 | password | test_logging.rs:245:28:245:53 | MacroExpr | provenance |  |
-| test_logging.rs:248:15:248:49 | MacroExpr | test_logging.rs:248:15:248:60 | ... .as_bytes() [&ref] | provenance | MaD:18 |
-| test_logging.rs:248:15:248:60 | ... .as_bytes() [&ref] | test_logging.rs:248:9:248:13 | write | provenance | MaD:7 Sink:MaD:7 |
+| test_logging.rs:248:15:248:49 | MacroExpr | test_logging.rs:248:15:248:60 | ... .as_bytes() [&ref, element] | provenance | MaD:17 |
+| test_logging.rs:248:15:248:60 | ... .as_bytes() [&ref, element] | test_logging.rs:248:9:248:13 | write | provenance | MaD:7 Sink:MaD:7 Sink:MaD:7 |
 | test_logging.rs:248:23:248:48 | ...::format(...) | test_logging.rs:248:23:248:48 | { ... } | provenance |  |
 | test_logging.rs:248:23:248:48 | ...::must_use(...) | test_logging.rs:248:15:248:49 | MacroExpr | provenance |  |
-| test_logging.rs:248:23:248:48 | MacroExpr | test_logging.rs:248:23:248:48 | ...::format(...) | provenance | MaD:20 |
-| test_logging.rs:248:23:248:48 | { ... } | test_logging.rs:248:23:248:48 | ...::must_use(...) | provenance | MaD:21 |
+| test_logging.rs:248:23:248:48 | MacroExpr | test_logging.rs:248:23:248:48 | ...::format(...) | provenance | MaD:19 |
+| test_logging.rs:248:23:248:48 | { ... } | test_logging.rs:248:23:248:48 | ...::must_use(...) | provenance | MaD:20 |
 | test_logging.rs:248:41:248:48 | password | test_logging.rs:248:23:248:48 | MacroExpr | provenance |  |
-| test_logging.rs:251:15:251:49 | MacroExpr | test_logging.rs:251:15:251:60 | ... .as_bytes() [&ref] | provenance | MaD:18 |
-| test_logging.rs:251:15:251:60 | ... .as_bytes() [&ref] | test_logging.rs:251:9:251:13 | write | provenance | MaD:6 Sink:MaD:6 |
+| test_logging.rs:251:15:251:49 | MacroExpr | test_logging.rs:251:15:251:60 | ... .as_bytes() [&ref, element] | provenance | MaD:17 |
+| test_logging.rs:251:15:251:60 | ... .as_bytes() [&ref, element] | test_logging.rs:251:9:251:13 | write | provenance | MaD:6 Sink:MaD:6 Sink:MaD:6 |
 | test_logging.rs:251:23:251:48 | ...::format(...) | test_logging.rs:251:23:251:48 | { ... } | provenance |  |
 | test_logging.rs:251:23:251:48 | ...::must_use(...) | test_logging.rs:251:15:251:49 | MacroExpr | provenance |  |
-| test_logging.rs:251:23:251:48 | MacroExpr | test_logging.rs:251:23:251:48 | ...::format(...) | provenance | MaD:20 |
-| test_logging.rs:251:23:251:48 | { ... } | test_logging.rs:251:23:251:48 | ...::must_use(...) | provenance | MaD:21 |
+| test_logging.rs:251:23:251:48 | MacroExpr | test_logging.rs:251:23:251:48 | ...::format(...) | provenance | MaD:19 |
+| test_logging.rs:251:23:251:48 | { ... } | test_logging.rs:251:23:251:48 | ...::must_use(...) | provenance | MaD:20 |
 | test_logging.rs:251:41:251:48 | password | test_logging.rs:251:23:251:48 | MacroExpr | provenance |  |
 models
 | 1 | Sink: <core::option::Option as log_err::LogErrOption>::log_expect; Argument[0]; log-injection |
@@ -272,11 +271,10 @@ models
 | 14 | Sink: std::io::stdio::_print; Argument[0]; log-injection |
 | 15 | Summary: <_ as core::clone::Clone>::clone; Argument[self].Reference; ReturnValue; value |
 | 16 | Summary: <alloc::string::String as core::ops::arith::Add>::add; Argument[0].Reference; ReturnValue; taint |
-| 17 | Summary: <alloc::string::String as core::ops::arith::Add>::add; Argument[self,0]; ReturnValue; taint |
-| 18 | Summary: <alloc::string::String>::as_bytes; Argument[self]; ReturnValue; value |
-| 19 | Summary: <alloc::string::String>::as_str; Argument[self]; ReturnValue; value |
-| 20 | Summary: alloc::fmt::format; Argument[0]; ReturnValue; taint |
-| 21 | Summary: core::hint::must_use; Argument[0]; ReturnValue; value |
+| 17 | Summary: <alloc::string::String>::as_bytes; Argument[self].Reference; ReturnValue.Reference.Element; taint |
+| 18 | Summary: <alloc::string::String>::as_str; Argument[self].Reference; ReturnValue.Reference; taint |
+| 19 | Summary: alloc::fmt::format; Argument[0]; ReturnValue; taint |
+| 20 | Summary: core::hint::must_use; Argument[0]; ReturnValue; value |
 nodes
 | test_logging.rs:42:5:42:10 | ...::log | semmle.label | ...::log |
 | test_logging.rs:42:12:42:35 | MacroExpr | semmle.label | MacroExpr |
@@ -491,7 +489,7 @@ nodes
 | test_logging.rs:229:54:229:61 | password | semmle.label | password |
 | test_logging.rs:242:10:242:14 | write | semmle.label | write |
 | test_logging.rs:242:16:242:50 | MacroExpr | semmle.label | MacroExpr |
-| test_logging.rs:242:16:242:61 | ... .as_bytes() [&ref] | semmle.label | ... .as_bytes() [&ref] |
+| test_logging.rs:242:16:242:61 | ... .as_bytes() [&ref, element] | semmle.label | ... .as_bytes() [&ref, element] |
 | test_logging.rs:242:24:242:49 | ...::format(...) | semmle.label | ...::format(...) |
 | test_logging.rs:242:24:242:49 | ...::must_use(...) | semmle.label | ...::must_use(...) |
 | test_logging.rs:242:24:242:49 | MacroExpr | semmle.label | MacroExpr |
@@ -499,7 +497,7 @@ nodes
 | test_logging.rs:242:42:242:49 | password | semmle.label | password |
 | test_logging.rs:245:10:245:18 | write_all | semmle.label | write_all |
 | test_logging.rs:245:20:245:54 | MacroExpr | semmle.label | MacroExpr |
-| test_logging.rs:245:20:245:65 | ... .as_bytes() [&ref] | semmle.label | ... .as_bytes() [&ref] |
+| test_logging.rs:245:20:245:65 | ... .as_bytes() [&ref, element] | semmle.label | ... .as_bytes() [&ref, element] |
 | test_logging.rs:245:28:245:53 | ...::format(...) | semmle.label | ...::format(...) |
 | test_logging.rs:245:28:245:53 | ...::must_use(...) | semmle.label | ...::must_use(...) |
 | test_logging.rs:245:28:245:53 | MacroExpr | semmle.label | MacroExpr |
@@ -507,7 +505,7 @@ nodes
 | test_logging.rs:245:46:245:53 | password | semmle.label | password |
 | test_logging.rs:248:9:248:13 | write | semmle.label | write |
 | test_logging.rs:248:15:248:49 | MacroExpr | semmle.label | MacroExpr |
-| test_logging.rs:248:15:248:60 | ... .as_bytes() [&ref] | semmle.label | ... .as_bytes() [&ref] |
+| test_logging.rs:248:15:248:60 | ... .as_bytes() [&ref, element] | semmle.label | ... .as_bytes() [&ref, element] |
 | test_logging.rs:248:23:248:48 | ...::format(...) | semmle.label | ...::format(...) |
 | test_logging.rs:248:23:248:48 | ...::must_use(...) | semmle.label | ...::must_use(...) |
 | test_logging.rs:248:23:248:48 | MacroExpr | semmle.label | MacroExpr |
@@ -515,7 +513,7 @@ nodes
 | test_logging.rs:248:41:248:48 | password | semmle.label | password |
 | test_logging.rs:251:9:251:13 | write | semmle.label | write |
 | test_logging.rs:251:15:251:49 | MacroExpr | semmle.label | MacroExpr |
-| test_logging.rs:251:15:251:60 | ... .as_bytes() [&ref] | semmle.label | ... .as_bytes() [&ref] |
+| test_logging.rs:251:15:251:60 | ... .as_bytes() [&ref, element] | semmle.label | ... .as_bytes() [&ref, element] |
 | test_logging.rs:251:23:251:48 | ...::format(...) | semmle.label | ...::format(...) |
 | test_logging.rs:251:23:251:48 | ...::must_use(...) | semmle.label | ...::must_use(...) |
 | test_logging.rs:251:23:251:48 | MacroExpr | semmle.label | MacroExpr |

--- a/rust/ql/test/query-tests/security/CWE-312/CleartextStorageDatabase.expected
+++ b/rust/ql/test/query-tests/security/CWE-312/CleartextStorageDatabase.expected
@@ -15,7 +15,6 @@ edges
 | test_storage.rs:71:9:71:21 | insert_query2 | test_storage.rs:139:25:139:37 | insert_query2 | provenance |  |
 | test_storage.rs:71:25:71:114 | ... + ... | test_storage.rs:71:25:71:121 | ... + ... | provenance | MaD:7 |
 | test_storage.rs:71:25:71:121 | ... + ... | test_storage.rs:71:9:71:21 | insert_query2 | provenance |  |
-| test_storage.rs:71:96:71:114 | &... | test_storage.rs:71:25:71:114 | ... + ... | provenance | MaD:7 |
 | test_storage.rs:71:96:71:114 | &... | test_storage.rs:71:25:71:114 | ... + ... | provenance | MaD:6 |
 | test_storage.rs:71:96:71:114 | &... [&ref] | test_storage.rs:71:25:71:114 | ... + ... | provenance | MaD:6 |
 | test_storage.rs:71:97:71:114 | get_phone_number(...) | test_storage.rs:71:96:71:114 | &... | provenance | Config |
@@ -33,7 +32,6 @@ edges
 | test_storage.rs:189:9:189:24 | insert_query_bad | test_storage.rs:194:25:194:40 | insert_query_bad | provenance |  |
 | test_storage.rs:189:28:189:117 | ... + ... | test_storage.rs:189:28:189:124 | ... + ... | provenance | MaD:7 |
 | test_storage.rs:189:28:189:124 | ... + ... | test_storage.rs:189:9:189:24 | insert_query_bad | provenance |  |
-| test_storage.rs:189:99:189:117 | &... | test_storage.rs:189:28:189:117 | ... + ... | provenance | MaD:7 |
 | test_storage.rs:189:99:189:117 | &... | test_storage.rs:189:28:189:117 | ... + ... | provenance | MaD:6 |
 | test_storage.rs:189:99:189:117 | &... [&ref] | test_storage.rs:189:28:189:117 | ... + ... | provenance | MaD:6 |
 | test_storage.rs:189:100:189:117 | get_phone_number(...) | test_storage.rs:189:99:189:117 | &... | provenance | Config |
@@ -41,7 +39,6 @@ edges
 | test_storage.rs:190:9:190:24 | select_query_bad | test_storage.rs:196:35:196:50 | select_query_bad | provenance |  |
 | test_storage.rs:190:28:190:103 | ... + ... | test_storage.rs:190:28:190:109 | ... + ... | provenance | MaD:7 |
 | test_storage.rs:190:28:190:109 | ... + ... | test_storage.rs:190:9:190:24 | select_query_bad | provenance |  |
-| test_storage.rs:190:85:190:103 | &... | test_storage.rs:190:28:190:103 | ... + ... | provenance | MaD:7 |
 | test_storage.rs:190:85:190:103 | &... | test_storage.rs:190:28:190:103 | ... + ... | provenance | MaD:6 |
 | test_storage.rs:190:85:190:103 | &... [&ref] | test_storage.rs:190:28:190:103 | ... + ... | provenance | MaD:6 |
 | test_storage.rs:190:86:190:103 | get_phone_number(...) | test_storage.rs:190:85:190:103 | &... | provenance | Config |
@@ -66,8 +63,8 @@ models
 | 4 | Sink: sqlx_core::query::query; Argument[0]; sql-injection |
 | 5 | Sink: sqlx_core::raw_sql::raw_sql; Argument[0]; sql-injection |
 | 6 | Summary: <alloc::string::String as core::ops::arith::Add>::add; Argument[0].Reference; ReturnValue; taint |
-| 7 | Summary: <alloc::string::String as core::ops::arith::Add>::add; Argument[self,0]; ReturnValue; taint |
-| 8 | Summary: <alloc::string::String>::as_str; Argument[self]; ReturnValue; value |
+| 7 | Summary: <alloc::string::String as core::ops::arith::Add>::add; Argument[self]; ReturnValue; taint |
+| 8 | Summary: <alloc::string::String>::as_str; Argument[self].Reference; ReturnValue.Reference; taint |
 nodes
 | test_storage.rs:71:9:71:21 | insert_query2 | semmle.label | insert_query2 |
 | test_storage.rs:71:25:71:114 | ... + ... | semmle.label | ... + ... |


### PR DESCRIPTION
Wrote some logic for identifying missing `.Reference` tokens, which is also included with this PR.

[DCA](https://github.com/github/codeql-dca-main/issues/34023) is fine.