### PR TITLE
Actions: Add `examples` qlpack

### DIFF
--- a/actions/ql/examples/codeql-pack.lock.yml
+++ b/actions/ql/examples/codeql-pack.lock.yml
@@ -1,0 +1,4 @@
+---
+lockVersion: 1.0.0
+dependencies: {}
+compiled: false

--- a/actions/ql/examples/qlpack.yml
+++ b/actions/ql/examples/qlpack.yml
@@ -1,0 +1,7 @@
+name: codeql/actions-examples
+groups:
+  - actions
+  - examples
+dependencies:
+  codeql/actions-all: ${workspace}
+warnOnImplicitThis: true

--- a/actions/ql/examples/snippets/uses_pinned_sha.ql
+++ b/actions/ql/examples/snippets/uses_pinned_sha.ql
@@ -1,0 +1,12 @@
+/**
+ * @name Uses step with pinned SHA
+ * @description Finds 'uses' steps where the version is a pinned SHA.
+ * @id actions/examples/uses-pinned-sha
+ * @tags example
+ */
+
+import actions
+
+from UsesStep uses
+where uses.getVersion().regexpMatch("^[A-Fa-f0-9]{40}$")
+select uses, "This 'uses' step has a pinned SHA version."


### PR DESCRIPTION
https://github.com/github/codeql/pull/21169 follow-up: The check now assumes that an `examples` folder exists, so instead of special-casing `actions` in the check, I thought it was easier to simply add an `examples` folder.