### PR TITLE
Rust: Fix bad join

### DIFF
--- a/rust/ql/lib/codeql/rust/internal/typeinference/Type.qll
+++ b/rust/ql/lib/codeql/rust/internal/typeinference/Type.qll
@@ -96,6 +96,7 @@ abstract class Type extends TType {
 class TupleType extends StructType {
   private int arity;
 
+  pragma[nomagic]
   TupleType() { arity = this.getTypeItem().(Builtins::TupleType).getArity() }
 
   /** Gets the arity of this tuple type. */
@@ -203,6 +204,7 @@ class TraitType extends Type, TTrait {
  * Array types like `[i64; 5]` are modeled as normal generic types.
  */
 class ArrayType extends StructType {
+  pragma[nomagic]
   ArrayType() { this.getTypeItem() instanceof Builtins::ArrayType }
 
   override string toString() { result = "[;]" }
@@ -216,12 +218,14 @@ TypeParamTypeParameter getArrayTypeParameter() {
 abstract class RefType extends StructType { }
 
 class RefMutType extends RefType {
+  pragma[nomagic]
   RefMutType() { this.getTypeItem() instanceof Builtins::RefMutType }
 
   override string toString() { result = "&mut" }
 }
 
 class RefSharedType extends RefType {
+  pragma[nomagic]
   RefSharedType() { this.getTypeItem() instanceof Builtins::RefSharedType }
 
   override string toString() { result = "&" }
@@ -312,6 +316,7 @@ class ImplTraitReturnType extends ImplTraitType {
  * with a single type argument.
  */
 class SliceType extends StructType {
+  pragma[nomagic]
   SliceType() { this.getTypeItem() instanceof Builtins::SliceType }
 
   override string toString() { result = "[]" }
@@ -338,12 +343,14 @@ TypeParamTypeParameter getPtrTypeParameter() {
 }
 
 class PtrMutType extends PtrType {
+  pragma[nomagic]
   PtrMutType() { this.getTypeItem() instanceof Builtins::PtrMutType }
 
   override string toString() { result = "*mut" }
 }
 
 class PtrConstType extends PtrType {
+  pragma[nomagic]
   PtrConstType() { this.getTypeItem() instanceof Builtins::PtrConstType }
 
   override string toString() { result = "*const" }


### PR DESCRIPTION
Before
```
Evaluated relational algebra for predicate TypeMention::RefTypeReprMention.resolveRootType/0#dispred#091b949a#fb@4bd8a49g with tuple counts:
            124419   ~0%    {1} r1 = RefTypeRepr::Generated::RefTypeRepr#422893fa AND NOT `RefTypeRepr::Generated::RefTypeRepr.isMut/0#dispred#e2b9988f`(FIRST 1)
        6621454761   ~1%    {3}    | JOIN WITH `Type::DataType.getTypeItem/0#dispred#83467854` CARTESIAN PRODUCT OUTPUT Rhs.0, Lhs.0, Rhs.1
         915101745   ~0%    {4}    | JOIN WITH `project#Type::DataType.getPositionalTypeParameter/1#dispred#3bf49cbe` ON FIRST 1 OUTPUT Lhs.2, _, Lhs.1, Lhs.0
         915101745   ~3%    {4}    | REWRITE WITH Out.1 := "Ref"
            124419   ~0%    {2}    | JOIN WITH `Builtins::BuiltinType.getName/0#dispred#8f62ab0a` ON FIRST 2 OUTPUT Lhs.2, Lhs.3

             76728   ~0%    {1} r2 = JOIN RefTypeRepr::Generated::RefTypeRepr#422893fa WITH `RefTypeRepr::Generated::RefTypeRepr.isMut/0#dispred#e2b9988f` ON FIRST 1 OUTPUT Lhs.0
        4083387432   ~1%    {3}    | JOIN WITH `Type::DataType.getTypeItem/0#dispred#83467854` CARTESIAN PRODUCT OUTPUT Rhs.0, Lhs.0, Rhs.1
         564334440   ~3%    {4}    | JOIN WITH `project#Type::DataType.getPositionalTypeParameter/1#dispred#3bf49cbe` ON FIRST 1 OUTPUT Lhs.2, _, Lhs.1, Lhs.0
         564334440   ~0%    {4}    | REWRITE WITH Out.1 := "RefMut"
             76728   ~2%    {2}    | JOIN WITH `Builtins::BuiltinType.getName/0#dispred#8f62ab0a` ON FIRST 2 OUTPUT Lhs.2, Lhs.3

            201147   ~1%    {2} r3 = r1 UNION r2
                            return r3
```

After
```
Evaluated relational algebra for predicate TypeMention::RefTypeReprMention.resolveRootType/0#dispred#091b949a#fb@8f12aa2a with tuple counts:
        124419   ~0%    {1} r1 = RefTypeRepr::Generated::RefTypeRepr#422893fa AND NOT `RefTypeRepr::Generated::RefTypeRepr.isMut/0#dispred#e2b9988f`(FIRST 1)
        124419   ~0%    {2}    | JOIN WITH Type::RefSharedType#090df68e CARTESIAN PRODUCT OUTPUT Rhs.0, Lhs.0
        124419   ~0%    {2}    | JOIN WITH `project#Type::DataType.getPositionalTypeParameter/1#dispred#3bf49cbe` ON FIRST 1 OUTPUT Lhs.1, Lhs.0

         76728   ~0%    {1} r2 = JOIN RefTypeRepr::Generated::RefTypeRepr#422893fa WITH `RefTypeRepr::Generated::RefTypeRepr.isMut/0#dispred#e2b9988f` ON FIRST 1 OUTPUT Lhs.0
         76728   ~0%    {2}    | JOIN WITH Type::RefMutType#c67a1837 CARTESIAN PRODUCT OUTPUT Rhs.0, Lhs.0
         76728   ~2%    {2}    | JOIN WITH `project#Type::DataType.getPositionalTypeParameter/1#dispred#3bf49cbe` ON FIRST 1 OUTPUT Lhs.1, Lhs.0

        201147   ~1%    {2} r3 = r1 UNION r2
                        return r3
```