### PR TITLE
Rust: Fix bad join

### DIFF
--- a/rust/ql/lib/codeql/rust/elements/internal/ElementImpl.qll
+++ b/rust/ql/lib/codeql/rust/elements/internal/ElementImpl.qll
@@ -99,10 +99,11 @@ module Impl {
      */
     cached
     predicate isFromMacroExpansion(AstNode n) {
-      exists(AstNode macro |
+      exists(AstNode macro, Location l |
         macro = getImmediatelyEnclosingMacroInvocation(n) and
         not n = getATokenTreeNode(macro) and
-        not isAttributeMacroExpansionSourceLocation(macro, n.getLocation())
+        l = n.getLocation() and
+        not isAttributeMacroExpansionSourceLocation(macro, l)
       )
       or
       isFromMacroExpansion(pragma[only_bind_into](getImmediatelyEnclosingMacroInvocation(n)))


### PR DESCRIPTION
Before
```
Evaluated relational algebra for predicate _ElementImpl::Impl::MacroExpansion::isAttributeMacroExpansionSourceLocation/2#3429148c_Locatable::Lo__#antijoin_rhs@9f4aa4rk with tuple counts:
        5127263380  ~4%    {3} r1 = JOIN `_AstNodeImpl::Impl::AstNode#22e758cf_ElementImpl::Impl::MacroExpansion::getATokenTreeNode/1#a2df59a3__#shared` WITH `ElementImpl::Impl::MacroExpansion::isAttributeMacroExpansionSourceLocation/2#3429148c` ON FIRST 1 OUTPUT Lhs.1, Rhs.1, Lhs.0
            305226  ~0%    {2}    | JOIN WITH `Locatable::Locatable.getLocation/0#dispred#f3f7e2b2` ON FIRST 2 OUTPUT Lhs.0, Lhs.2
                           return r1
```

(No After; the predicate is no longer generated)