### PR TITLE
Python: Compiler crash

### DIFF
--- a/python/ql/lib/analysis/DefinitionTracking.qll
+++ b/python/ql/lib/analysis/DefinitionTracking.qll
@@ -471,11 +471,10 @@ Definition getUniqueDefinition(Expr use) {
   not result = TLocalDefinition(use)
 }
 
-/** A helper class to get suitable locations for attributes */
-class NiceLocationExpr extends Expr {
-  /** Gets a textual representation of this element. */
-  override string toString() { result = this.(Expr).toString() }
+final class FinalExpr = Expr;
 
+/** A helper class to get suitable locations for attributes */
+class NiceLocationExpr extends FinalExpr {
   /**
    * Holds if this element is at the specified location.
    * The location spans column `bc` of line `bl` to

--- a/python/ql/src/Variables/LoopVariableCapture/LoopVariableCaptureQuery.qll
+++ b/python/ql/src/Variables/LoopVariableCapture/LoopVariableCaptureQuery.qll
@@ -3,8 +3,10 @@
 import python
 import semmle.python.dataflow.new.DataFlow
 
+final class FinalAstNode = AstNode;
+
 /** A looping construct. */
-abstract class Loop extends AstNode {
+abstract class Loop extends FinalAstNode {
   /**
    * Gets a loop variable of this loop.
    * For example, `x` and `y` in `for x,y in pairs: print(x+y)`
@@ -13,9 +15,9 @@ abstract class Loop extends AstNode {
 }
 
 /** A `for` loop. */
-private class ForLoop extends Loop, For {
+private class ForLoop extends Loop instanceof For {
   override Variable getALoopVariable() {
-    this.getTarget() = result.getAnAccess().getParentNode*() and
+    this.(For).getTarget() = result.getAnAccess().getParentNode*() and
     result.getScope() = this.getScope()
   }
 }

--- a/python/ql/src/analysis/ImportFailure.ql
+++ b/python/ql/src/analysis/ImportFailure.ql
@@ -59,7 +59,9 @@ predicate ok_to_fail(ImportExpr ie) {
   os_specific_import(ie) != get_os()
 }
 
-class VersionTest extends ControlFlowNode {
+final class FinalControlFlowNode = ControlFlowNode;
+
+class VersionTest extends FinalControlFlowNode {
   VersionTest() {
     exists(string name |
       name.matches("%version%") and
@@ -70,7 +72,7 @@ class VersionTest extends ControlFlowNode {
     )
   }
 
-  override string toString() { result = "VersionTest" }
+  string toString() { result = "VersionTest" }
 }
 
 /** A guard on the version of the Python interpreter */


### PR DESCRIPTION
To reproduce the crash reported in https://github.com/github/codeql-core/issues/5150.
`codeql test run python/ql/test/query-tests/Variables/capture/`