### PR TITLE
C++: Add `isLiveAtEndOfBlock` predicate to `Ssa::Definition`

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaImpl.qll
@@ -941,6 +941,11 @@ module SsaCached {
   }
 
   cached
+  predicate uncertainWriteDefinitionInput(Definition uncertain, Definition inp) {
+    SsaImpl::uncertainWriteDefinitionInput(uncertain, inp)
+  }
+
+  cached
   predicate ssaDefReachesEndOfBlock(IRBlock bb, Definition def) {
     SsaImpl::ssaDefReachesEndOfBlock(bb, def, _)
   }
@@ -1178,7 +1183,7 @@ class Definition extends SsaImpl::Definition {
   private Definition getAPhiInputOrPriorDefinition() {
     result = this.(PhiNode).getAnInput()
     or
-    SsaImpl::uncertainWriteDefinitionInput(this, result)
+    uncertainWriteDefinitionInput(this, result)
   }
 
   /**


### PR DESCRIPTION
Other languages have this predicate exposed on their version of `Ssa::Definition` so we might as well do so as well.

This predicate was necessary in a recent Microsoft query we were writing.

I also did a drive-by fix in 60ee92d8346b2efc91e513cd16103ca34f258eab. I'll run DCA to make sure I didn't mess up any caching.