### PR TITLE
QL4QL: Use nightly CodeQL CLI

### DIFF
--- a/.github/workflows/ql-for-ql-build.yml
+++ b/.github/workflows/ql-for-ql-build.yml
@@ -27,6 +27,7 @@ jobs:
         uses: github/codeql-action/init@main
         with:
           languages: javascript # does not matter
+          tools: nightly
       - uses: ./.github/actions/os-version
         id: os_version
       ### Build the extractor ###

--- a/.github/workflows/ql-for-ql-tests.yml
+++ b/.github/workflows/ql-for-ql-tests.yml
@@ -30,6 +30,7 @@ jobs:
         uses: github/codeql-action/init@main
         with:
           languages: javascript # does not matter
+          tools: nightly
       - uses: ./.github/actions/os-version
         id: os_version
       - uses: actions/cache@v3
@@ -75,6 +76,7 @@ jobs:
         uses: github/codeql-action/init@main
         with:
           languages: javascript # does not matter
+          tools: nightly
       - uses: ./.github/actions/os-version
         id: os_version
       - uses: actions/cache@v3


### PR DESCRIPTION
We also use nightly CLI (in fact, we use latest internal `main`) for other languages, so it makes sense to do for QL as well.