### PR TITLE
Rust: Change `getATypeParameterConstraint` to not require a `TypeMention`

### DIFF
--- a/rust/ql/lib/codeql/rust/internal/typeinference/TypeInference.qll
+++ b/rust/ql/lib/codeql/rust/internal/typeinference/TypeInference.qll
@@ -141,17 +141,17 @@ private module Input2 implements InputSig2 {
 
   TypeMention getABaseTypeMention(Type t) { none() }
 
-  TypeMention getATypeParameterConstraint(TypeParameter tp) {
-    result = tp.(TypeParamTypeParameter).getTypeParam().getATypeBound().getTypeRepr()
-    or
-    result = tp.(SelfTypeParameter).getTrait()
-    or
-    result =
-      tp.(ImplTraitTypeTypeParameter)
-          .getImplTraitTypeRepr()
-          .getTypeBoundList()
-          .getABound()
-          .getTypeRepr()
+  Type getATypeParameterConstraint(TypeParameter tp, TypePath path) {
+    exists(TypeMention tm | result = tm.resolveTypeAt(path) |
+      tm = tp.(TypeParamTypeParameter).getTypeParam().getATypeBound().getTypeRepr() or
+      tm = tp.(SelfTypeParameter).getTrait() or
+      tm =
+        tp.(ImplTraitTypeTypeParameter)
+            .getImplTraitTypeRepr()
+            .getTypeBoundList()
+            .getABound()
+            .getTypeRepr()
+    )
   }
 
   /**

--- a/shared/typeinference/codeql/typeinference/internal/TypeInference.qll
+++ b/shared/typeinference/codeql/typeinference/internal/TypeInference.qll
@@ -343,7 +343,7 @@ module Make1<LocationSig Location, InputSig1<Location> Input1> {
      * ```
      * the type parameter `T` has the constraint `IComparable<T>`.
      */
-    TypeMention getATypeParameterConstraint(TypeParameter tp);
+    Type getATypeParameterConstraint(TypeParameter tp, TypePath path);
 
     /**
      * Holds if
@@ -1451,13 +1451,10 @@ module Make1<LocationSig Location, InputSig1<Location> Input1> {
           accessDeclarationPositionMatch(apos, dpos) and
           constrainedTp = target.getTypeParameter(_) and
           tp = target.getTypeParameter(_) and
+          tp = getATypeParameterConstraint(constrainedTp, pathToTp) and
           constrainedTp != tp and
           constrainedTp = target.getDeclaredType(dpos, pathToConstrained) and
-          exists(TypeMention tm |
-            tm = getATypeParameterConstraint(constrainedTp) and
-            tm.resolveTypeAt(pathToTp) = tp and
-            constraint = resolveTypeMentionRoot(tm)
-          )
+          constraint = getATypeParameterConstraint(constrainedTp, TypePath::nil())
         )
       }
 


### PR DESCRIPTION
Changes the signature of `getATypeParameterConstraint` in the shared type inference library:
```diff
-  TypeMention getATypeParameterConstraint(TypeParameter tp);
+  Type getATypeParameterConstraint(TypeParameter tp, TypePath path);
```
The library does in fact not need a distinct value (instance of `TypeMention`) to represent the parameter constraint and the updated signature offers more flexibility to clients.