### PR TITLE
C++: Simplify `cpp/sql-injection` barrier

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-089/SqlTainted.ql
+++ b/cpp/ql/src/Security/CWE/CWE-089/SqlTainted.ql
@@ -45,9 +45,7 @@ module SqlTaintedConfig implements DataFlow::ConfigSig {
 
   predicate isBarrier(DataFlow::Node node) {
     node.asExpr().getUnspecifiedType() instanceof IntegralType
-  }
-
-  predicate isBarrierIn(DataFlow::Node node) {
+    or
     exists(SqlBarrierFunction sql, int arg, FunctionInput input |
       node.asIndirectArgument() = sql.getACallToThisFunction().getArgument(arg) and
       input.isParameterDeref(arg) and


### PR DESCRIPTION
SQL sanitizers will not likely also be sources, so using `isBarrierIn` here does not make a lot of sense.

I ran with and without this change on MRVA and got identical results.