### PR TITLE
C/C++ overlay: use files table instead of `overlayChangedFiles` for overlay discard

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/internal/Overlay.qll
+++ b/cpp/ql/lib/semmle/code/cpp/internal/Overlay.qll
@@ -65,16 +65,26 @@ overlay[local]
 private predicate isBase() { not isOverlay() }
 
 /**
+ * Holds if `path` was extracted in the overlay database.
+ */
+overlay[local]
+private predicate overlayHasFile(string path) {
+  isOverlay() and
+  files(_, path) and
+  path != ""
+}
+
+/**
  * Discards an element from the base variant if:
- * - It has a single location in a changed file, or
- * - All of its locations are in changed files.
+ * - It has a single location in a file extracted in the overlay, or
+ * - All of its locations are in files extracted in the overlay.
  */
 overlay[discard_entity]
 private predicate discardElement(@element e) {
   isBase() and
   (
-    overlayChangedFiles(getSingleLocationFilePath(e))
+    overlayHasFile(getSingleLocationFilePath(e))
     or
-    forex(string path | path = getMultiLocationFilePath(e) | overlayChangedFiles(path))
+    forex(string path | path = getMultiLocationFilePath(e) | overlayHasFile(path))
   )
 }


### PR DESCRIPTION
Changes the C++ overlay discard logic to query extracted files directly from the overlay database instead of relying on `overlayChangedFiles` populated by the CLI.


See internal PR. 