### PR TITLE
Fix formatting of Kotlin version ranges

### DIFF
--- a/java/ql/lib/CHANGELOG.md
+++ b/java/ql/lib/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### New Features
 
-* Kotlin versions up to 2.3.0\ *x* are now supported.
+* Kotlin versions up to 2.3.0*x* are now supported.
 
 ### Minor Analysis Improvements
 
@@ -98,7 +98,7 @@ No user-facing changes.
 
 ### New Features
 
-* Kotlin versions up to 2.2.2\ *x* are now supported.
+* Kotlin versions up to 2.2.2*x* are now supported.
 
 ## 7.4.0
 
@@ -139,7 +139,7 @@ No user-facing changes.
 
 ### New Features
 
-* Kotlin versions up to 2.2.0\ *x* are now supported. Support for the Kotlin 1.5.x series is dropped (so the minimum Kotlin version is now 1.6.0).
+* Kotlin versions up to 2.2.0*x* are now supported. Support for the Kotlin 1.5.x series is dropped (so the minimum Kotlin version is now 1.6.0).
 
 ## 7.1.4
 
@@ -276,7 +276,7 @@ No user-facing changes.
 ### New Features
 
 * The Java extractor and QL libraries now support Java 23.
-* Kotlin versions up to 2.1.0\ *x* are now supported.
+* Kotlin versions up to 2.1.0*x* are now supported.
 
 ## 4.0.0
 

--- a/java/ql/lib/change-notes/released/4.1.0.md
+++ b/java/ql/lib/change-notes/released/4.1.0.md
@@ -10,4 +10,4 @@
 ### New Features
 
 * The Java extractor and QL libraries now support Java 23.
-* Kotlin versions up to 2.1.0\ *x* are now supported.
+* Kotlin versions up to 2.1.0*x* are now supported.

--- a/java/ql/lib/change-notes/released/7.2.0.md
+++ b/java/ql/lib/change-notes/released/7.2.0.md
@@ -2,4 +2,4 @@
 
 ### New Features
 
-* Kotlin versions up to 2.2.0\ *x* are now supported. Support for the Kotlin 1.5.x series is dropped (so the minimum Kotlin version is now 1.6.0).
+* Kotlin versions up to 2.2.0*x* are now supported. Support for the Kotlin 1.5.x series is dropped (so the minimum Kotlin version is now 1.6.0).

--- a/java/ql/lib/change-notes/released/7.5.0.md
+++ b/java/ql/lib/change-notes/released/7.5.0.md
@@ -2,4 +2,4 @@
 
 ### New Features
 
-* Kotlin versions up to 2.2.2\ *x* are now supported.
+* Kotlin versions up to 2.2.2*x* are now supported.


### PR DESCRIPTION
The backslash is necessary for RST formatting but leads to incorrect Markdown formatting.