### PR TITLE
Rust: Resolve `Self` paths in type definitions

### DIFF
--- a/rust/ql/lib/codeql/rust/internal/PathResolution.qll
+++ b/rust/ql/lib/codeql/rust/internal/PathResolution.qll
@@ -2135,7 +2135,7 @@ private predicate useImportEdge(Use use, string name, ItemNode item, SuccessorKi
         checkQualifiedVisibility(use, item, kind1, useOpt) and
         // glob imports can be shadowed
         not declares(encl, ns, name) and
-        not name = ["super", "self"]
+        not name = ["super", "self", "Self"]
       )
     else (
       item = used and

--- a/rust/ql/test/library-tests/path-resolution/CONSISTENCY/PathResolutionConsistency.expected
+++ b/rust/ql/test/library-tests/path-resolution/CONSISTENCY/PathResolutionConsistency.expected
@@ -7,5 +7,3 @@ multipleResolvedTargets
 | main.rs:565:9:566:15 | ...::Assoc(...) |
 | main.rs:568:9:569:12 | ...::f1(...) |
 | main.rs:571:9:572:12 | ...::f1(...) |
-multiplePathResolutions
-| main.rs:1075:13:1074:16 | Self |

--- a/rust/ql/test/library-tests/path-resolution/path-resolution.expected
+++ b/rust/ql/test/library-tests/path-resolution/path-resolution.expected
@@ -546,7 +546,6 @@ resolvePath
 | main.rs:1073:30:1073:32 | i32 | {EXTERNAL LOCATION} | struct i32 |
 | main.rs:1073:38:1073:41 | Self | main.rs:1066:5:1069:5 | enum NonEmptyListEnum |
 | main.rs:1074:17:1074:32 | NonEmptyListEnum | main.rs:1066:5:1069:5 | enum NonEmptyListEnum |
-| main.rs:1075:13:1075:16 | Self | main.rs:1066:5:1069:5 | enum NonEmptyListEnum |
 | main.rs:1075:13:1075:16 | Self | main.rs:1071:5:1077:5 | impl NonEmptyListEnum::<...> { ... } |
 | main.rs:1075:13:1075:24 | ...::Single | main.rs:1067:9:1067:17 | Single |
 | main.rs:1083:13:1083:16 | Copy | {EXTERNAL LOCATION} | trait Copy |


### PR DESCRIPTION
This PR:
- Implements path resolution for `Self` paths within type definitions.
- Slightly simplifies how `Self` is handled by avoiding the need for `getAnItemInSelfScope`. By handling `Self` in `getAChildSuccessor` it's automatically accounted for in `declaresDirectly` and `declares`.

The [DCA results](https://github.com/github/codeql-dca-main/issues/34464#issuecomment-3841375103) are uneventful.