### PR TITLE
Rust: Fix bad join

### DIFF
--- a/rust/ql/lib/codeql/rust/internal/typeinference/TypeMention.qll
+++ b/rust/ql/lib/codeql/rust/internal/typeinference/TypeMention.qll
@@ -323,7 +323,7 @@ private module MkTypeMention<getAdditionalPathTypeAtSig/2 getAdditionalPathTypeA
         this = impl.getTraitPath() and
         alias = impl.getASuccessor(name) and
         result = alias.getTypeRepr() and
-        tp = TAssociatedTypeTypeParameter(resolved, getTraitAssocType(resolved, name))
+        tp = TAssociatedTypeTypeParameter(resolved, resolved.(TraitItemNode).getAssocItem(name))
       )
     }
 


### PR DESCRIPTION
https://github.com/github/codeql/pull/21188 follow-up.

Before
```
Evaluated relational algebra for predicate _PathResolution::ImplItemNode.getTraitPath/0#dispred#3b7d1cb6_PathResolution::ImplOrTraitItemNode.ge__#shared@0d3de6d9 with tuple counts:
         395360270  ~2%    {5} r1 = JOIN Type::TAssociatedTypeTypeParameter#6da9e52a WITH `PathResolution::ImplItemNode.getTraitPath/0#dispred#3b7d1cb6` CARTESIAN PRODUCT OUTPUT Rhs.0, Lhs.0, Lhs.1, Lhs.2, Rhs.1
        1274237644  ~0%    {6}    | JOIN WITH `PathResolution::ItemNode.getASuccessor/1#8f430f71` ON FIRST 1 OUTPUT Lhs.1, Lhs.2, Lhs.3, Lhs.4, Rhs.1, Rhs.2
        1274237644  ~0%    {6}    | JOIN WITH PathResolution::TraitItemNode#8d4ce62d ON FIRST 1 OUTPUT Lhs.0, Lhs.4, Lhs.1, Lhs.2, Lhs.3, Lhs.5
           6984871  ~0%    {5}    | JOIN WITH `PathResolution::ImplOrTraitItemNode.getAssocItem/1#f77bb9ed` ON FIRST 3 OUTPUT Lhs.2, Lhs.0, Lhs.3, Lhs.4, Lhs.5
           6984871  ~0%    {4}    | JOIN WITH TypeAlias::Generated::TypeAlias#1ca97780 ON FIRST 1 OUTPUT Lhs.4, Lhs.1, Lhs.2, Lhs.3
           6076675  ~0%    {4}    | JOIN WITH `TypeAlias::Generated::TypeAlias.getTypeRepr/0#dispred#5fd7e521` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3
                           return r1
```

After
```
Evaluated relational algebra for predicate _PathResolution::ImplItemNode.getTraitPath/0#dispred#3b7d1cb6_PathResolution::ImplOrTraitItemNode.ge__#shared@760e0499 with tuple counts:
          443292  ~2%    {3} r1 = SCAN `PathResolution::ImplOrTraitItemNode.getAssocItem/1#f77bb9ed` OUTPUT In.0, In.2, In.1
            1258  ~1%    {3}    | JOIN WITH Type::TAssociatedTypeTypeParameter#6da9e52a ON FIRST 2 OUTPUT Lhs.2, Lhs.0, Rhs.2
        13656944  ~3%    {4}    | JOIN WITH `PathResolution::ItemNode.getASuccessor/1#8f430f71_102#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Rhs.2
         6984871  ~0%    {4}    | JOIN WITH `PathResolution::ImplItemNode.getTraitPath/0#dispred#3b7d1cb6` ON FIRST 1 OUTPUT Lhs.3, Lhs.1, Lhs.2, Rhs.1
         6076675  ~0%    {4}    | JOIN WITH `TypeAlias::Generated::TypeAlias.getTypeRepr/0#dispred#5fd7e521` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3
                         return r1
```