### PR TITLE
Go: Add `AstNode.getEnclosingBlock()`

### DIFF
--- a/go/ql/lib/semmle/go/AST.qll
+++ b/go/ql/lib/semmle/go/AST.qll
@@ -84,6 +84,16 @@ class AstNode extends @node, Locatable {
   pragma[nomagic]
   FuncDef getEnclosingFunction() { result = this.getParent().parentInSameFunction*() }
 
+  /** Gets the innermost block statement to which this AST node belongs, if any. */
+  BlockStmt getEnclosingBlock() {
+    exists(AstNode p | p = this.getParent() |
+      result = p
+      or
+      not p instanceof BlockStmt and
+      result = p.getEnclosingBlock()
+    )
+  }
+
   /**
    * Gets a comma-separated list of the names of the primary CodeQL classes to which this element belongs.
    */


### PR DESCRIPTION
This predicate already exists for cpp and rust. It was requested [here](https://github.com/github/codeql/discussions/21089).