### PR TITLE
C#: Add diagnostic for private registry usage

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependencyManager.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependencyManager.cs
@@ -106,7 +106,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                 return BuildScript.Success;
             }).Run(SystemBuildActions.Instance, startCallback, exitCallback);
 
-            dependabotProxy = DependabotProxy.GetDependabotProxy(logger, tempWorkingDirectory);
+            dependabotProxy = DependabotProxy.GetDependabotProxy(logger, diagnosticsWriter, tempWorkingDirectory);
 
             try
             {


### PR DESCRIPTION
Mirrors the equivalent PR for Go: https://github.com/github/codeql/pull/21252

This PR adds a new diagnostic for when the C# extractor successfully discovers private registries. The goal of this is to make this easy to see on the Tool Status Page, rather than requiring users to follow the process in https://docs.github.com/en/code-security/how-tos/view-and-interpret-data/viewing-code-scanning-logs#determining-whether-code-scanning-default-setup-used-any-private-registries