### PR TITLE
C++: Make 'getChildCount' more robust by counting indices instead of elements

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/TranslatedStmt.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/TranslatedStmt.qll
@@ -390,7 +390,7 @@ class TranslatedDeclStmt extends TranslatedStmt {
 
   override TranslatedElement getLastChild() { result = this.getChild(this.getChildCount() - 1) }
 
-  private int getChildCount() { result = count(this.getDeclarationEntry(_)) }
+  private int getChildCount() { result = count(int i | exists(this.getDeclarationEntry(i))) }
 
   IRDeclarationEntry getIRDeclarationEntry(int index) {
     result.hasIndex(index) and


### PR DESCRIPTION
In an ideal world counting elements should give the same as counting how many indices returns an element. However I noticed today that, on inconsistent databases, it is possible that a single index can return duplicated `getDeclarationEntry`s.

This meant that `getChildCount()` returned 2 (because there were two `getDeclarationEntry`s for index `0`). However, only `getDeclarationEntry(0)` had a result (in fact it had 2 results), and `getDeclarationEntry(1)` returned no results. This caused the control-flow graph abruptly stop.

By changing `getChildCount` to count indices instead we avoid a dead-end in the control-flow graph since `getChildCount()` now returns 1.