### PR TITLE
Actions: Update reference link

### DIFF
--- a/actions/ql/src/Security/CWE-275/MissingActionsPermissions.md
+++ b/actions/ql/src/Security/CWE-275/MissingActionsPermissions.md
@@ -38,4 +38,7 @@ jobs:
 
 ## References
 
-- GitHub Docs: [Assigning permissions to jobs](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/assigning-permissions-to-jobs).
+### GitHub Docs
+
+- [Modifying the permissions for the `GITHUB_TOKEN`](https://docs.github.com/en/actions/tutorials/authenticate-with-github_token#modifying-the-permissions-for-the-github_token).
+- [Workflow syntax for GitHub Actions: `permissions`](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions).


### PR DESCRIPTION
The tutorial ["Assigning permissions to jobs"](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/assigning-permissions-to-jobs), referenced in CWE-275's documentation, has been moved to ["Use GITHUB_TOKEN for authentication in workflows"](https://docs.github.com/en/actions/tutorials/authenticate-with-github_token). This PR updates the outdated link to point to the new location.

In addition, while the new tutorial is relevant for addressing this specific issue, [the `permissions` section of "Workflow syntax for GitHub Actions"](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions) is also linked. This page provides more comprehensive examples of `permissions` blocks and seems to more closely matches the scope and intent of the original article before it was moved (see the archived version: https://web.archive.org/web/20240807160500/https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/assigning-permissions-to-jobs).