### PR TITLE
Go: Bump toolchain to `1.25.7`

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -254,11 +254,11 @@ use_repo(
 )
 
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
-go_sdk.download(version = "1.25.0")
+go_sdk.download(version = "1.25.7")
 
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//go/extractor:go.mod")
-use_repo(go_deps, "org_golang_x_mod", "org_golang_x_tools")
+use_repo(go_deps, "com_github_stretchr_testify", "org_golang_x_mod", "org_golang_x_tools")
 
 ripunzip_archive = use_repo_rule("//misc/ripunzip:ripunzip.bzl", "ripunzip_archive")
 

--- a/go/actions/test/action.yml
+++ b/go/actions/test/action.yml
@@ -4,7 +4,7 @@ inputs:
   go-test-version:
     description: Which Go version to use for running the tests
     required: false
-    default: "~1.25.0"
+    default: "~1.25.7"
   run-code-checks:
     description: Whether to run formatting, code and qhelp generation checks
     required: false

--- a/go/extractor/go.mod
+++ b/go/extractor/go.mod
@@ -2,7 +2,7 @@ module github.com/github/codeql-go/extractor
 
 go 1.25
 
-toolchain go1.25.0
+toolchain go1.25.7
 
 // when updating this, run
 //    bazel run @rules_go//go -- mod tidy


### PR DESCRIPTION
Updates the version of the Go toolchain we use for builds to `1.25.7`.

The addition of `com_github_stretchr_testify` as a dependency in `MODULE.bazel` was automatic when I ran Bazel, probably a result of that dependency getting promoted to an explicit dependency in https://github.com/github/codeql/pull/21300/