### PR TITLE
Rust: Add `telemtry` tags to queries

### DIFF
--- a/rust/ql/src/queries/summary/NodesWithTypeAtLengthLimit.ql
+++ b/rust/ql/src/queries/summary/NodesWithTypeAtLengthLimit.ql
@@ -3,7 +3,7 @@
  * @description Counts the number of AST nodes with a type at the type path length limit.
  * @kind metric
  * @id rust/summary/nodes-at-type-path-length-limit
- * @tags summary
+ * @tags summary telemetry
  */
 
 import rust

--- a/rust/ql/src/queries/summary/QuerySinkCounts.ql
+++ b/rust/ql/src/queries/summary/QuerySinkCounts.ql
@@ -5,7 +5,7 @@
  *              operations are excluded.
  * @kind metric
  * @id rust/summary/query-sink-counts
- * @tags summary
+ * @tags summary telemetry
  */
 
 import rust

--- a/rust/ql/src/queries/summary/SummaryStats.ql
+++ b/rust/ql/src/queries/summary/SummaryStats.ql
@@ -3,7 +3,7 @@
  * @description A table of summary statistics about a database.
  * @kind metric
  * @id rust/summary/summary-statistics
- * @tags summary
+ * @tags summary telemetry
  */
 
 import rust

--- a/rust/ql/src/queries/summary/SummaryStatsReduced.ql
+++ b/rust/ql/src/queries/summary/SummaryStatsReduced.ql
@@ -4,7 +4,7 @@
  *              has been found to be noisy on tests removed.
  * @kind metric
  * @id rust/summary/reduced-summary-statistics
- * @tags summary
+ * @tags summary telemetry
  */
 
 import rust


### PR DESCRIPTION
Before this PR, each scan would end with a summary like
```text
|                            Metric                            |    Value     |
+--------------------------------------------------------------+--------------+
| Total number of Rust files that were extracted without error |           50 |
| Summary Statistics                                           | (28 results) |
| Nodes With Type At Length Limit                              |            4 |
| Summary Statistics Reduced                                   | (16 results) |
| Total number of Rust files that were extracted with errors   |            0 |
| Query Sink Counts                                            |  (5 results) |
```

Now, it instead ends with
```text
|                            Metric                            | Value |
+--------------------------------------------------------------+-------+
| Total number of Rust files that were extracted without error |    50 |
| Total number of Rust files that were extracted with errors   |     0 |
```

I don't think the removed rows provide any relevant information, hence this PR. I'm unsure, though, whether this will break something in the tool status page?