### PR TITLE
Avoid non-trivially shadowing `string.toString()`

### DIFF
--- a/shared/regex/codeql/regex/nfa/ExponentialBackTracking.qll
+++ b/shared/regex/codeql/regex/nfa/ExponentialBackTracking.qll
@@ -95,7 +95,7 @@ module Make<RegexTreeViewSig TreeImpl> {
       )
     }
 
-    string toString() { result = this.(InfiniteRepetitionQuantifier).toString() }
+    string toString() { result = super.toString() }
   }
 
   /**

--- a/shared/regex/codeql/regex/nfa/NfaUtils.qll
+++ b/shared/regex/codeql/regex/nfa/NfaUtils.qll
@@ -104,11 +104,11 @@ module Make<RegexTreeViewSig TreeImpl> {
   private class RegexpCharacterConstant instanceof RegExpConstant {
     RegexpCharacterConstant() { this.isCharacter() }
 
-    string toString() { result = this.(RegExpConstant).toString() }
+    string toString() { result = super.toString() }
 
-    RegExpTerm getRootTerm() { result = this.(RegExpConstant).getRootTerm() }
+    RegExpTerm getRootTerm() { result = super.getRootTerm() }
 
-    string getValue() { result = this.(RegExpConstant).getValue() }
+    string getValue() { result = super.getValue() }
   }
 
   /**
@@ -578,11 +578,11 @@ module Make<RegexTreeViewSig TreeImpl> {
       )
     }
 
-    string toString() { result = this.(RegExpTerm).toString() }
+    string toString() { result = super.toString() }
 
-    RegExpTerm getAChild() { result = this.(RegExpTerm).getChild(_) }
+    RegExpTerm getAChild() { result = super.getChild(_) }
 
-    RegExpTerm getChild(int i) { result = this.(RegExpTerm).getChild(i) }
+    RegExpTerm getChild(int i) { result = super.getChild(i) }
   }
 
   /**
@@ -601,11 +601,11 @@ module Make<RegexTreeViewSig TreeImpl> {
       )
     }
 
-    string toString() { result = this.(RegExpTerm).toString() }
+    string toString() { result = super.toString() }
 
-    RegExpTerm getAChild() { result = this.(RegExpTerm).getAChild() }
+    RegExpTerm getAChild() { result = super.getAChild() }
 
-    RegExpTerm getChild(int i) { result = this.(RegExpTerm).getChild(i) }
+    RegExpTerm getChild(int i) { result = super.getChild(i) }
   }
 
   /**
@@ -621,11 +621,11 @@ module Make<RegexTreeViewSig TreeImpl> {
       )
     }
 
-    string toString() { result = this.(RegExpTerm).toString() }
+    string toString() { result = super.toString() }
 
-    RegExpTerm getAChild() { result = this.(RegExpTerm).getAChild() }
+    RegExpTerm getAChild() { result = super.getAChild() }
 
-    RegExpTerm getChild(int i) { result = this.(RegExpTerm).getChild(i) }
+    RegExpTerm getChild(int i) { result = super.getChild(i) }
   }
 
   /**


### PR DESCRIPTION
Prepare libraries for a possible deprecation warning on shadowing `string.toString()`, which currently can expose inconsistent behaviour (implicit `toString` insertion on string subclasses is problematic).

These instanceof classes were using `this.(Type).method()` to call supertype methods, but `super.method()` is clearer and equivalent for instanceof supertypes.