### PR TITLE
Go: Remove toolchain directive from `go/extractor/go.mod`

### DIFF
--- a/go/extractor/go.mod
+++ b/go/extractor/go.mod
@@ -2,8 +2,6 @@ module github.com/github/codeql-go/extractor
 
 go 1.26
 
-toolchain go1.26.0
-
 // when updating this, run
 //    bazel run @rules_go//go -- mod tidy
 // when adding or removing dependencies, run


### PR DESCRIPTION
Currently the toolchain directive (`toolchain go1.26.0`) has no effect, but when the next patch release 1.26.1 comes out I think it will actually keep us using 1.26.0. I have a plan to make sure we always use the latest patch release for the language version specified in the go directive (`go 1.26`), and it requires that this toolchain directive is removed.