### PR TITLE
Rust: Make path resolution robust against invalid code with conflicting declarations

### DIFF
--- a/rust/ql/test/library-tests/path-resolution/invalid/main.rs
+++ b/rust/ql/test/library-tests/path-resolution/invalid/main.rs
@@ -1,0 +1,6 @@
+// The code in this file is not valid Rust code
+
+struct A; // A1
+struct A; // A2
+
+fn f(x: A) {} // $ item=A2 (the latter occurence takes precedence)

--- a/rust/ql/test/library-tests/path-resolution/invalid/options.yml
+++ b/rust/ql/test/library-tests/path-resolution/invalid/options.yml
@@ -1,0 +1,1 @@
+qltest_cargo_check: false

--- a/rust/ql/test/library-tests/path-resolution/path-resolution.expected
+++ b/rust/ql/test/library-tests/path-resolution/path-resolution.expected
@@ -51,6 +51,7 @@ mod
 | my/nested.rs:1:1:17:1 | mod nested1 |
 | my/nested.rs:2:5:11:5 | mod nested2 |
 resolvePath
+| invalid/main.rs:6:9:6:9 | A | invalid/main.rs:3:11:4:9 | struct A |
 | main.rs:4:8:4:9 | my | main.rs:1:1:1:7 | mod my |
 | main.rs:4:14:4:17 | self | main.rs:1:1:1:7 | mod my |
 | main.rs:6:5:6:6 | my | main.rs:1:1:1:7 | mod my |


### PR DESCRIPTION
Fixes performance on `edl-lang/edl`, which contains e.g. https://github.com/edl-lang/edl/blob/main/tests/ui/impl-trait/impl-trait-plus-priority.rs.

[DCA](https://github.com/github/codeql-dca-main/issues/34763) looks good; a modest performance improvement and slight decrease in inconstencies.