### PR TITLE
Rust: Fix bad join

### DIFF
--- a/rust/ql/lib/codeql/rust/internal/typeinference/FunctionType.qll
+++ b/rust/ql/lib/codeql/rust/internal/typeinference/FunctionType.qll
@@ -420,13 +420,20 @@ module ArgsAreInstantiationsOf<ArgsAreInstantiationsOfInputSig Input> {
     ArgIsInstantiationOf<CallAndPos, ArgIsInstantiationOfToIndexInput>;
 
   pragma[nomagic]
+  private predicate argIsInstantiationOf(
+    Input::Call call, FunctionPosition pos, ImplOrTraitItemNode i, Function f, int rnk
+  ) {
+    ArgIsInstantiationOfToIndex::argIsInstantiationOf(MkCallAndPos(call, pos), i, _) and
+    toCheckRanked(i, f, _, pos, rnk)
+  }
+
+  pragma[nomagic]
   private predicate argsAreInstantiationsOfToIndex(
     Input::Call call, ImplOrTraitItemNode i, Function f, int rnk
   ) {
     exists(FunctionPosition pos |
-      ArgIsInstantiationOfToIndex::argIsInstantiationOf(MkCallAndPos(call, pos), i, _) and
-      call.hasTargetCand(i, f) and
-      toCheckRanked(i, f, _, pos, rnk)
+      argIsInstantiationOf(call, pos, i, f, rnk) and
+      call.hasTargetCand(i, f)
     |
       rnk = 0
       or


### PR DESCRIPTION
Before
```
Pipeline standard for TypeInference::NonMethodResolution::NonMethodArgsAreInstantiationsOfBlanket::argsAreInstantiationsOfToIndex/4#f6ff35dc@be110b6w was evaluated in 512 iterations totaling 114ms (delta sizes total: 10942).
            8395   ~0%    {5} r1 = JOIN `TypeInference::NonMethodResolution::NonMethodArgsAreInstantiationsOfBlanket::argsAreInstantiationsOfToIndex/4#f6ff35dc#prev_delta` WITH `TypeInference::NonMethodResolution::NonMethodCall.resolveCallTargetBlanketCand/1#dispred#f8b86f2d#prev` ON FIRST 3 OUTPUT Lhs.1, Lhs.2, _, Lhs.0, Lhs.3
            8395   ~0%    {4}    | REWRITE WITH Tmp.2 := 1, Out.2 := (Tmp.2 + In.4) KEEPING 4
            8448   ~0%    {5}    | JOIN WITH `project#TypeInference::NonMethodResolution::NonMethodArgsAreInstantiationsOfBlanket::toCheckRanked/5#52f6d5e0#2_0132#join_rhs` ON FIRST 3 OUTPUT Lhs.3, Rhs.3, Lhs.0, Lhs.1, Lhs.2
            7440   ~0%    {5}    | JOIN WITH TypeInference::NonMethodResolution::NonMethodArgsAreInstantiationsOfBlanket::MkCallAndPos#53e3fb94#prev ON FIRST 2 OUTPUT Rhs.2, Lhs.2, Lhs.0, Lhs.3, Lhs.4
               0   ~0%    {4}    | JOIN WITH `TypeInference::NonMethodResolution::NonMethodArgsAreInstantiationsOfBlanket::ArgIsInstantiationOfToIndex::ArgSubstIsInstantiationOf::isInstantiationOf/3#5154f0d6#prev` ON FIRST 2 OUTPUT Lhs.2, Lhs.1, Lhs.3, Lhs.4

            2937   ~0%    {5} r2 = JOIN TypeInference::NonMethodResolution::NonMethodArgsAreInstantiationsOfBlanket::MkCallAndPos#53e3fb94#prev_delta WITH `TypeInference::NonMethodResolution::NonMethodCall.resolveCallTargetBlanketCand/1#dispred#f8b86f2d#prev` ON FIRST 1 OUTPUT Lhs.2, Rhs.1, Lhs.0, Lhs.1, Rhs.2
               0   ~0%    {4}    | JOIN WITH `TypeInference::NonMethodResolution::NonMethodArgsAreInstantiationsOfBlanket::ArgIsInstantiationOfToIndex::ArgSubstIsInstantiationOf::isInstantiationOf/3#5154f0d6#prev` ON FIRST 2 OUTPUT Lhs.1, Lhs.4, Lhs.3, Lhs.2

               0   ~0%    {6} r3 = JOIN r2 WITH `project#TypeInference::NonMethodResolution::NonMethodArgsAreInstantiationsOfBlanket::toCheckRanked/5#52f6d5e0#2` ON FIRST 3 OUTPUT Lhs.3, Lhs.2, Lhs.0, Lhs.1, Rhs.3, _
                          {5}    | REWRITE WITH Tmp.5 := 0, TEST InOut.4 = Tmp.5 KEEPING 5
               0   ~0%    {5}    | SCAN OUTPUT In.2, In.3, In.1, _, In.0
               0   ~0%    {5}    | REWRITE WITH Out.3 := 0
               0   ~0%    {4}    | JOIN WITH `project#TypeInference::NonMethodResolution::NonMethodArgsAreInstantiationsOfBlanket::toCheckRanked/5#52f6d5e0#2` ON FIRST 4 OUTPUT Lhs.4, Lhs.0, Lhs.1, _
               0   ~0%    {4}    | REWRITE WITH Out.3 := 0

           12463   ~0%    {2} r4 = SCAN `TypeInference::NonMethodResolution::NonMethodArgsAreInstantiationsOfBlanket::ArgIsInstantiationOfToIndex::ArgSubstIsInstantiationOf::isInstantiationOf/3#5154f0d6#prev_delta` OUTPUT In.1, In.0
        22532135   ~0%    {4}    | JOIN WITH `TypeInference::NonMethodResolution::NonMethodCall.resolveCallTargetBlanketCand/1#dispred#f8b86f2d#reorder_1_0_2#prev` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.0, Rhs.2
           12463   ~0%    {4}    | JOIN WITH TypeInference::NonMethodResolution::NonMethodArgsAreInstantiationsOfBlanket::MkCallAndPos#53e3fb94#reorder_0_2_1#prev ON FIRST 2 OUTPUT Lhs.2, Lhs.3, Rhs.2, Lhs.0

           12463   ~2%    {6} r5 = JOIN r4 WITH `project#TypeInference::NonMethodResolution::NonMethodArgsAreInstantiationsOfBlanket::toCheckRanked/5#52f6d5e0#2` ON FIRST 3 OUTPUT Lhs.0, Lhs.3, Lhs.1, Lhs.2, Rhs.3, _
                          {5}    | REWRITE WITH Tmp.5 := 0, TEST InOut.4 = Tmp.5 KEEPING 5
            4285   ~0%    {5}    | SCAN OUTPUT In.0, In.2, In.3, _, In.1
            4285   ~0%    {5}    | REWRITE WITH Out.3 := 0
            4285   ~1%    {4}    | JOIN WITH `project#TypeInference::NonMethodResolution::NonMethodArgsAreInstantiationsOfBlanket::toCheckRanked/5#52f6d5e0#2` ON FIRST 4 OUTPUT Lhs.4, Lhs.0, Lhs.1, _
            4285   ~1%    {4}    | REWRITE WITH Out.3 := 0

               0   ~0%    {4} r6 = JOIN r2 WITH `project#TypeInference::NonMethodResolution::NonMethodArgsAreInstantiationsOfBlanket::toCheckRanked/5#52f6d5e0#2` ON FIRST 3 OUTPUT Lhs.3, Lhs.0, Lhs.1, Rhs.3
               0   ~0%    {6}    | JOIN WITH `TypeInference::NonMethodResolution::NonMethodArgsAreInstantiationsOfBlanket::argsAreInstantiationsOfToIndex/4#f6ff35dc#prev` ON FIRST 3 OUTPUT Lhs.0, Lhs.1, Lhs.2, Lhs.3, Rhs.3, _
                          {6}    | REWRITE WITH Tmp.5 := 1, Out.5 := (InOut.3 - Tmp.5), TEST Out.5 = InOut.4
               0   ~0%    {4}    | SCAN OUTPUT In.0, In.1, In.2, In.3

           12463  ~45%    {4} r7 = JOIN r4 WITH `project#TypeInference::NonMethodResolution::NonMethodArgsAreInstantiationsOfBlanket::toCheckRanked/5#52f6d5e0#2` ON FIRST 3 OUTPUT Lhs.3, Lhs.0, Lhs.1, Rhs.3
            8178  ~50%    {6}    | JOIN WITH `TypeInference::NonMethodResolution::NonMethodArgsAreInstantiationsOfBlanket::argsAreInstantiationsOfToIndex/4#f6ff35dc#prev` ON FIRST 3 OUTPUT Lhs.1, Lhs.0, Lhs.2, Lhs.3, Rhs.3, _
                          {6}    | REWRITE WITH Tmp.5 := 1, Out.5 := (InOut.3 - Tmp.5), TEST Out.5 = InOut.4
            7428  ~58%    {4}    | SCAN OUTPUT In.1, In.0, In.2, In.3

            4264   ~0%    {3} r8 = SCAN `TypeInference::NonMethodResolution::NonMethodCall.resolveCallTargetBlanketCand/1#dispred#f8b86f2d#prev_delta` OUTPUT In.1, In.2, In.0

            4312   ~0%    {5} r9 = JOIN r8 WITH `_project#TypeInference::NonMethodResolution::NonMethodArgsAreInstantiationsOfBlanket::toCheckRanked/__#join_rhs#1` ON FIRST 2 OUTPUT Lhs.0, Lhs.1, Rhs.2, _, Lhs.2
            4312   ~0%    {5}    | REWRITE WITH Out.3 := 0
            4312   ~0%    {5}    | JOIN WITH `project#TypeInference::NonMethodResolution::NonMethodArgsAreInstantiationsOfBlanket::toCheckRanked/5#52f6d5e0#2` ON FIRST 4 OUTPUT Lhs.4, Lhs.2, Lhs.0, Lhs.1, _
            4312   ~0%    {5}    | REWRITE WITH Out.4 := 0

           12760   ~0%    {5} r10 = JOIN r8 WITH `project#TypeInference::NonMethodResolution::NonMethodArgsAreInstantiationsOfBlanket::toCheckRanked/5#52f6d5e0#2` ON FIRST 2 OUTPUT Lhs.2, Lhs.0, Lhs.1, Rhs.2, Rhs.3
               0   ~0%    {7}    | JOIN WITH `TypeInference::NonMethodResolution::NonMethodArgsAreInstantiationsOfBlanket::argsAreInstantiationsOfToIndex/4#f6ff35dc#prev` ON FIRST 3 OUTPUT Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.0, Rhs.3, _
                          {7}    | REWRITE WITH Tmp.6 := 1, Out.6 := (InOut.3 - Tmp.6), TEST Out.6 = InOut.5
               0   ~0%    {5}    | SCAN OUTPUT In.4, In.2, In.0, In.1, In.3

            4312   ~0%    {5} r11 = r9 UNION r10
            4288   ~0%    {5}    | JOIN WITH TypeInference::NonMethodResolution::NonMethodArgsAreInstantiationsOfBlanket::MkCallAndPos#53e3fb94#prev ON FIRST 2 OUTPUT Rhs.2, Lhs.2, Lhs.3, Lhs.4, Lhs.0
               0   ~0%    {4}    | JOIN WITH `TypeInference::NonMethodResolution::NonMethodArgsAreInstantiationsOfBlanket::ArgIsInstantiationOfToIndex::ArgSubstIsInstantiationOf::isInstantiationOf/3#5154f0d6#prev` ON FIRST 2 OUTPUT Lhs.4, Lhs.1, Lhs.2, Lhs.3

           11713  ~36%    {4} r12 = r1 UNION r3 UNION r5 UNION r6 UNION r7 UNION r11
           10942  ~39%    {4}    | AND NOT `TypeInference::NonMethodResolution::NonMethodArgsAreInstantiationsOfBlanket::argsAreInstantiationsOfToIndex/4#f6ff35dc#prev`(FIRST 4)
                          return r12
```

After
```
Pipeline standard for TypeInference::NonMethodResolution::NonMethodArgsAreInstantiationsOfBlanket::argsAreInstantiationsOfToIndex/4#f6ff35dc@07309ry7 was evaluated in 168 iterations totaling 145ms (delta sizes total: 8395).
        12517   ~0%    {6} r1 = SCAN `TypeInference::NonMethodResolution::NonMethodArgsAreInstantiationsOfBlanket::argIsInstantiationOf/5#efdc1fbb#reorder_0_2_3_4_1#prev_delta` OUTPUT In.0, In.1, In.2, In.3, In.4, _
         4337   ~0%    {5}    | REWRITE WITH Tmp.5 := 0, TEST InOut.3 = Tmp.5 KEEPING 5
         4285   ~1%    {4}    | JOIN WITH `TypeInference::NonMethodResolution::NonMethodCall.resolveCallTargetBlanketCand/1#dispred#f8b86f2d#prev` ON FIRST 3 OUTPUT Lhs.0, Lhs.1, Lhs.2, _
         4285   ~1%    {4}    | REWRITE WITH Out.3 := 0

            0   ~0%    {4} r2 = JOIN `TypeInference::NonMethodResolution::NonMethodCall.resolveCallTargetBlanketCand/1#dispred#f8b86f2d#prev_delta` WITH `TypeInference::NonMethodResolution::NonMethodArgsAreInstantiationsOfBlanket::argIsInstantiationOf/5#efdc1fbb#reorder_0_2_3_4_1#prev` ON FIRST 3 OUTPUT Lhs.0, Lhs.1, Lhs.2, Rhs.3

            0   ~0%    {5} r3 = SCAN r2 OUTPUT In.0, In.1, In.2, In.3, _
                       {4}    | REWRITE WITH Tmp.4 := 0, TEST InOut.3 = Tmp.4 KEEPING 4
            0   ~0%    {4}    | SCAN OUTPUT In.0, In.1, In.2, _
            0   ~0%    {4}    | REWRITE WITH Out.3 := 0

         8395   ~0%    {5} r4 = JOIN `TypeInference::NonMethodResolution::NonMethodArgsAreInstantiationsOfBlanket::argsAreInstantiationsOfToIndex/4#f6ff35dc#prev_delta` WITH `TypeInference::NonMethodResolution::NonMethodCall.resolveCallTargetBlanketCand/1#dispred#f8b86f2d#prev` ON FIRST 3 OUTPUT Lhs.0, Lhs.1, Lhs.2, _, Lhs.3
         8395   ~0%    {4}    | REWRITE WITH Tmp.3 := 1, Out.3 := (Tmp.3 + In.4) KEEPING 4
            0   ~0%    {4}    | JOIN WITH `TypeInference::NonMethodResolution::NonMethodArgsAreInstantiationsOfBlanket::argIsInstantiationOf/5#efdc1fbb#reorder_0_2_3_4_1#prev` ON FIRST 4 OUTPUT Lhs.0, Lhs.1, Lhs.2, Lhs.3

            0   ~0%    {6} r5 = JOIN r2 WITH `TypeInference::NonMethodResolution::NonMethodArgsAreInstantiationsOfBlanket::argsAreInstantiationsOfToIndex/4#f6ff35dc#prev` ON FIRST 3 OUTPUT Lhs.0, Lhs.1, Lhs.2, Lhs.3, Rhs.3, _
                       {6}    | REWRITE WITH Tmp.5 := 1, Out.5 := (InOut.3 - Tmp.5), TEST Out.5 = InOut.4
            0   ~0%    {4}    | SCAN OUTPUT In.0, In.1, In.2, In.3

        12517  ~18%    {4} r6 = SCAN `TypeInference::NonMethodResolution::NonMethodArgsAreInstantiationsOfBlanket::argIsInstantiationOf/5#efdc1fbb#reorder_0_2_3_4_1#prev_delta` OUTPUT In.0, In.1, In.2, In.3
        11759  ~12%    {4}    | JOIN WITH `TypeInference::NonMethodResolution::NonMethodCall.resolveCallTargetBlanketCand/1#dispred#f8b86f2d#prev` ON FIRST 3 OUTPUT Lhs.0, Lhs.1, Lhs.2, Lhs.3
         9874  ~12%    {6}    | JOIN WITH `TypeInference::NonMethodResolution::NonMethodArgsAreInstantiationsOfBlanket::argsAreInstantiationsOfToIndex/4#f6ff35dc#prev` ON FIRST 3 OUTPUT Lhs.0, Lhs.1, Lhs.2, Lhs.3, Rhs.3, _
                       {6}    | REWRITE WITH Tmp.5 := 1, Out.5 := (InOut.3 - Tmp.5), TEST Out.5 = InOut.4
         7476  ~18%    {4}    | SCAN OUTPUT In.0, In.1, In.2, In.3

        11761  ~12%    {4} r7 = r1 UNION r3 UNION r4 UNION r5 UNION r6
         8395   ~0%    {4}    | AND NOT `TypeInference::NonMethodResolution::NonMethodArgsAreInstantiationsOfBlanket::argsAreInstantiationsOfToIndex/4#f6ff35dc#prev`(FIRST 4)
                       return r7
```

[DCA](https://github.com/github/codeql-dca-main/issues/34733) looks fine.