### PR TITLE
C++: Remove redundant transitive closure

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -1726,9 +1726,7 @@ private module Cached {
       SsaImpl::ssaFlow(n, succ) and
       bb1 = n.getBasicBlock() and
       bb2 = succ.getBasicBlock() and
-      bb1 != bb2 and
-      bb2.dominates(bb1) and
-      bb1.getASuccessor+() = bb2
+      bb2.strictlyDominates(bb1)
     )
   }
 


### PR DESCRIPTION
The `doublyBoundedFastTC` produced by the compiler for this transitive closure was too large and failed with `caught com.semmle.util.exception.CatastrophicError: Failed to expand RoaringCharList of size 2147483638 to make space for 3 more elements while evaluating` on a very large Microsoft repository.

This makes sense as the end-points for this transitive closure aren't really very restricted. However, luckily this whole transitive closure should be redundant since we have SSA flow from an element in `bb1` to another element in `bb2`, and so `bb2` should be a control-flow successor of `bb2` by the correctness of SSA.
