### PR TITLE
Avoid inconsistent implicit `toString` on potential string subtypes

### DIFF
--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
@@ -112,7 +112,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
     final private class LangContentSet = Lang::ContentSet;
 
     class Content extends LangContentSet {
-      string toString() { result = "Content" }
+      string toString() { result = super.toString() }
     }
 
     class ContentFilter extends Unit {

--- a/shared/util/codeql/util/FileSystem.qll
+++ b/shared/util/codeql/util/FileSystem.qll
@@ -23,6 +23,13 @@ signature module InputSig {
      * Typically `containerparent(result, this)`.
      */
     ContainerBase getParentContainer();
+
+    /**
+     * Gets a textual representation of this container.
+     *
+     * Typically `result = this.getAbsolutePath()`.
+     */
+    string toString();
   }
 
   /**
@@ -206,7 +213,7 @@ module Make<InputSig Input> {
      *
      * This is the absolute path of the container.
      */
-    string toString() { result = this.getAbsolutePath() }
+    string toString() { result = super.toString() }
   }
 
   /** A folder. */


### PR DESCRIPTION
Fix cases where the compiler cannot prove types don't extend string:

1. **FileSystem.qll**: Add `toString()` to ContainerBase signature. The instantiation sites already provide toString(), so no changes needed there. `Container.toString()` now delegates to `super.toString()`. No behaviour change.

2. **DataFlowImplCommon.qll**: `Content.toString()` now delegates to `super.toString()` instead of returning the literal `"Content"`. This is a behaviour change: Content now displays its actual description (e.g. field names) rather than the generic `"Content"`.

See also https://github.com/github/codeql/pull/21306.