### PR TITLE
Go: fix standalone build of the Go extractor

### DIFF
--- a/go/extractor/BUILD.bazel
+++ b/go/extractor/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_go//go:def.bzl", "go_library")
+load("@rules_java//java:defs.bzl", "java_library")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 
 # gazelle:prefix github.com/github/codeql-go/extractor


### PR DESCRIPTION
https://github.com/github/codeql/pull/21276 worked together with the internal changes but broke the standalone build of the Go extractor of this repo in isolation.

The root cause was the lack of an auto-loaded `java_library` rule definition. This fixes it.

I also checked this doesn't happen anywhere else.