### PR TITLE
Add `/rerun` slash command for failed internal checks

### DIFF
--- a/.github/commands/rerun.yml
+++ b/.github/commands/rerun.yml
@@ -1,0 +1,14 @@
+---
+trigger: rerun
+title: Rerun failed internal checks
+surfaces:
+  - pull_request
+description: >
+  Finds all failed internal CI checks for this PR and reruns their failed jobs.
+
+steps:
+  - type: repository_dispatch
+    eventType: rerun-workflow
+  - type: fill
+    submit_form: true
+    template: "Rerun has been triggered."


### PR DESCRIPTION
Adds a `/rerun` slash command. This requires internal changes to actually do something.

Only available on pull requests. Requires write access.