### PR TITLE
C#: Add model validation for constructor summary models

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/ExternalFlow.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/ExternalFlow.qll
@@ -241,8 +241,10 @@ module ModelValidation {
 
   string getIncorrectConstructorSummaryOutput() {
     exists(string namespace, string type, string name, string output |
+      type = name or
+      type = name + "<" + any(string s)
+    |
       summaryModel(namespace, type, _, name, _, _, _, output, _, _, _) and
-      type = name and
       output.matches("ReturnValue%") and
       result =
         "Constructor model for " + namespace + "." + type +


### PR DESCRIPTION
The output column of a summary model for a constructor should use `Argument[this]` instead of `ReturnValue`.

This didn't find anything, but it did for java (https://github.com/github/codeql/pull/21415). I also manually tested it by changing a constructor summary model to use `ReturnValue` and it was correctly identified when I ran `csharp/ql/test/library-tests/dataflow/external-models/validatemodels.ql`.