### PR TITLE
Python: Fix bad join in method call order computation

### DIFF
--- a/python/ql/src/Classes/CallsToInitDel/MethodCallOrder.qll
+++ b/python/ql/src/Classes/CallsToInitDel/MethodCallOrder.qll
@@ -152,16 +152,21 @@ predicate missingCallToSuperclassMethod(Class base, Function shouldCall, string 
  */
 predicate missingCallToSuperclassMethodRestricted(Class base, Function shouldCall, string name) {
   missingCallToSuperclassMethod(base, shouldCall, name) and
-  not exists(Class superBase |
-    // Alert only on the highest base class that has the issue
-    superBase = getADirectSuperclass+(base) and
-    missingCallToSuperclassMethod(superBase, shouldCall, name)
-  ) and
+  not superclassAlsoMissesCall(base, shouldCall, name) and
   not exists(Function subShouldCall |
     // Mention in the alert only the lowest method we're missing the call to
     subShouldCall.getScope() = getADirectSubclass+(shouldCall.getScope()) and
     missingCallToSuperclassMethod(base, subShouldCall, name)
   )
+}
+
+/**
+ * Holds if a strict superclass of `base` is also missing a call to `shouldCall` named `name`,
+ * indicating that `base` is not the highest class in the hierarchy with this issue.
+ */
+pragma[nomagic]
+private predicate superclassAlsoMissesCall(Class base, Function shouldCall, string name) {
+  missingCallToSuperclassMethod(getADirectSuperclass+(base), shouldCall, name)
 }
 
 /**


### PR DESCRIPTION
This join had badness 1127 on the project FiacreT/M-moire, producing ~31 million tuples in order to end up with only ~27k tuples later in the pipeline. With the fix, we reduce this by roughly the full 31 million (the new materialised helper predicate accounting for roughly 130k tuples on its own).