### PR TITLE
Revert "Bump rules_android from 0.6.4 to 0.7.1"

### DIFF
--- a/misc/bazel/registry/modules/rules_kotlin/2.2.2-codeql.1/MODULE.bazel
+++ b/misc/bazel/registry/modules/rules_kotlin/2.2.2-codeql.1/MODULE.bazel
@@ -8,7 +8,7 @@ module(
 bazel_dep(name = "platforms", version = "0.0.11")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "rules_java", version = "8.9.0")
-bazel_dep(name = "rules_android", version = "0.7.1")
+bazel_dep(name = "rules_android", version = "0.6.4")
 bazel_dep(name = "bazel_features", version = "1.25.0")
 bazel_dep(name = "protobuf", version = "29.0", repo_name = "com_google_protobuf")
 bazel_dep(name = "rules_proto", version = "6.0.2", repo_name = "rules_proto")


### PR DESCRIPTION
This reverts commit c7349740f089e97b61d985f3add7a60db4dcc2b9.

It was making the build fail