### PR TITLE
C#: Delete CFG for static assignables.

### DIFF
--- a/csharp/ql/consistency-queries/DataFlowConsistency.ql
+++ b/csharp/ql/consistency-queries/DataFlowConsistency.ql
@@ -1,25 +1,10 @@
 import csharp
-private import semmle.code.csharp.controlflow.internal.ControlFlowGraphImpl as ControlFlowGraphImpl
 private import semmle.code.csharp.dataflow.internal.DataFlowImplSpecific
 private import semmle.code.csharp.dataflow.internal.TaintTrackingImplSpecific
 private import codeql.dataflow.internal.DataFlowImplConsistency
 
 private module Input implements InputSig<Location, CsharpDataFlow> {
   private import CsharpDataFlow
-
-  private predicate isStaticAssignable(Assignable a) { a.(Modifiable).isStatic() }
-
-  predicate uniqueEnclosingCallableExclude(Node node) {
-    // TODO: Remove once static initializers are folded into the
-    // static constructors
-    isStaticAssignable(ControlFlowGraphImpl::getNodeCfgScope(node.getControlFlowNode()))
-  }
-
-  predicate uniqueCallEnclosingCallableExclude(DataFlowCall call) {
-    // TODO: Remove once static initializers are folded into the
-    // static constructors
-    isStaticAssignable(ControlFlowGraphImpl::getNodeCfgScope(call.getControlFlowNode()))
-  }
 
   predicate uniqueNodeLocationExclude(Node n) {
     // Methods with multiple implementations

--- a/csharp/ql/consistency-queries/VariableCaptureConsistency.ql
+++ b/csharp/ql/consistency-queries/VariableCaptureConsistency.ql
@@ -2,11 +2,9 @@ import csharp
 import semmle.code.csharp.dataflow.internal.DataFlowPrivate::VariableCapture::Flow::ConsistencyChecks
 private import semmle.code.csharp.dataflow.internal.DataFlowPrivate::VariableCapture::Flow::ConsistencyChecks as ConsistencyChecks
 private import semmle.code.csharp.controlflow.BasicBlocks
-private import semmle.code.csharp.controlflow.internal.ControlFlowGraphImpl
 
 query predicate uniqueEnclosingCallable(BasicBlock bb, string msg) {
-  ConsistencyChecks::uniqueEnclosingCallable(bb, msg) and
-  getNodeCfgScope(bb.getFirstNode()) instanceof Callable
+  ConsistencyChecks::uniqueEnclosingCallable(bb, msg)
 }
 
 query predicate consistencyOverview(string msg, int n) { none() }

--- a/csharp/ql/lib/printCfg.ql
+++ b/csharp/ql/lib/printCfg.ql
@@ -36,13 +36,8 @@ module ViewCfgQueryInput implements ViewCfgQueryInputSig<File> {
     scope.getLocation().getStartColumn() = startColumn and
     exists(Location loc |
       loc.getEndLine() = endLine and
-      loc.getEndColumn() = endColumn
-    |
-      loc = scope.(Callable).getBody().getLocation()
-      or
-      loc = scope.(Field).getInitializer().getLocation()
-      or
-      loc = scope.(Property).getInitializer().getLocation()
+      loc.getEndColumn() = endColumn and
+      loc = scope.getBody().getLocation()
     )
   }
 }

--- a/csharp/ql/lib/semmle/code/csharp/controlflow/internal/ControlFlowGraphImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/controlflow/internal/ControlFlowGraphImpl.qll
@@ -66,23 +66,15 @@ private module Initializers {
 }
 
 /** An element that defines a new CFG scope. */
-class CfgScope extends Element, @top_level_exprorstmt_parent {
+class CfgScope extends Callable {
   CfgScope() {
     this.getFile().fromSource() and
     (
-      this =
-        any(Callable c |
-          c.(Constructor).hasInitializer()
-          or
-          Initializers::obinitInitializes(c, _)
-          or
-          c.hasBody()
-        )
+      this.(Constructor).hasInitializer()
       or
-      // For now, static initializer values have their own scope. Eventually, they
-      // should be treated like instance initializers.
-      this.(Assignable).(Modifiable).isStatic() and
-      expr_parent_top_level_adjusted2(_, _, this)
+      Initializers::obinitInitializes(this, _)
+      or
+      this.hasBody()
     )
   }
 }
@@ -189,24 +181,6 @@ CompilationExt getCompilation(File f) {
   result = TBuildless()
 }
 
-/**
- * The `expr_parent_top_level_adjusted()` relation restricted to exclude relations
- * between properties and their getters' expression bodies in properties such as
- * `int P => 0`.
- *
- * This is in order to only associate the expression body with one CFG scope, namely
- * the getter (and not the declaration itself).
- */
-private predicate expr_parent_top_level_adjusted2(
-  Expr child, int i, @top_level_exprorstmt_parent parent
-) {
-  expr_parent_top_level_adjusted(child, i, parent) and
-  not exists(Getter g |
-    g.getDeclaration() = parent and
-    i = 0
-  )
-}
-
 /** Holds if `first` is first executed when entering `scope`. */
 predicate scopeFirst(CfgScope scope, AstNode first) {
   scope =
@@ -220,9 +194,6 @@ predicate scopeFirst(CfgScope scope, AstNode first) {
     )
   or
   first(Initializers::initializedInstanceMemberOrder(scope, _, 0), first)
-  or
-  expr_parent_top_level_adjusted2(any(Expr e | first(e, first)), _, scope) and
-  not scope instanceof Callable
 }
 
 /** Holds if `scope` is exited when `last` finishes with completion `c`. */
@@ -244,9 +215,6 @@ predicate scopeLast(CfgScope scope, AstNode last, Completion c) {
     )
   or
   last(Initializers::lastInitializer(scope, _), last, c)
-  or
-  expr_parent_top_level_adjusted2(any(Expr e | last(e, last, c)), _, scope) and
-  not scope instanceof Callable
 }
 
 private class ObjectInitTree extends ControlFlowTree instanceof ObjectInitMethod {

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/rangeanalysis/ModulusAnalysisSpecific.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/rangeanalysis/ModulusAnalysisSpecific.qll
@@ -4,7 +4,6 @@ module Private {
   private import semmle.code.csharp.dataflow.internal.rangeanalysis.RangeUtils as RU
   private import SsaUtils as SU
   private import SsaReadPositionCommon
-  private import semmle.code.csharp.controlflow.internal.ControlFlowGraphImpl as CfgImpl
 
   class BasicBlock = CS::ControlFlow::BasicBlock;
 


### PR DESCRIPTION
Initializers for static assignables currently have "free-standing" CFG snippets instead of existing within a callable. Ideally we'd introduce a callable in the extractor to wrap them and their CFG, but let's first see if we can simply get rid of those small CFG snippets.

This is motivated by the shift to the shared CFG library where we need CFG scopes to be Callables.