### PR TITLE
Go: improve detection of type expressions when database is missing some type information

### DIFF
--- a/go/ql/lib/semmle/go/Expr.qll
+++ b/go/ql/lib/semmle/go/Expr.qll
@@ -829,7 +829,7 @@ class ConversionExpr extends CallOrConversionExpr {
 /**
  * A function call expression.
  *
- * On snapshots with incomplete type information, type conversions may be misclassified
+ * On databases with incomplete type information, type conversions may be misclassified
  * as function call expressions.
  *
  * Examples:
@@ -2093,7 +2093,7 @@ class LabelName extends Name {
  * Holds if `e` is a type expression, as determined by a bottom-up syntactic
  * analysis starting with `TypeName`s.
  *
- * On a snapshot with full type information, this predicate covers all type
+ * On a database with full type information, this predicate covers all type
  * expressions. However, if type information is missing then not all type names
  * may be identified as such, so not all type expressions can be determined by
  * a bottom-up analysis. In such cases, `isTypeExprTopDown` below is useful.

--- a/go/ql/lib/semmle/go/controlflow/IR.qll
+++ b/go/ql/lib/semmle/go/controlflow/IR.qll
@@ -294,7 +294,7 @@ module IR {
   /**
    * An IR instruction that reads the value of a field.
    *
-   * On snapshots with incomplete type information, method expressions may sometimes be
+   * On databases with incomplete type information, method expressions may sometimes be
    * misclassified as field reads.
    */
   class FieldReadInstruction extends ComponentReadInstruction {

--- a/go/ql/src/filters/ClassifyFiles.ql
+++ b/go/ql/src/filters/ClassifyFiles.ql
@@ -1,6 +1,6 @@
 /**
  * @name Classify files
- * @description This query produces a list of all files in a snapshot that are classified as
+ * @description This query produces a list of all files in a database that are classified as
  *              generated code, test code or vendored-in library code.
  * @kind file-classifier
  * @id go/file-classifier


### PR DESCRIPTION
`isTypeExprTopDown` has no effect when the database contains full type information. However, when some type information is missing, for example because a dependency was not available during extraction, it helps to recognise more type expressions. This PR expands it by including more places where we know the expression represents a type.

`FieldBase` is the class used for all places where we extract something of the form `<type> <name>`. For example: a field in a struct (including embedded fields, with an empty name), a function parameter, or a method in an interface declaration (where the type is a signature type). In all cases we know that one of the sub-expressions represents a type, so we want to include it in `isTypeExprTopDown`. Previously we had been individually listing some subclasses, which meant that we were missing some type expressions. In a limited investigation I also found that this helped with performance, as using the whole `FieldBase` class rather than several subclasses was simpler. But I expect that the effect is too small to show up in DCA.

I do not think that this needs a change note. We will still have degraded analysis when type information is incomplete.