### PR TITLE
Swift: Disable stack protector pass

### DIFF
--- a/swift/extractor/main.cpp
+++ b/swift/extractor/main.cpp
@@ -76,7 +76,7 @@ static void processFrontendOptions(codeql::SwiftExtractorState& state,
   }
 }
 
-static void turnOffSilVerifications(swift::SILOptions& options) {
+static void turnOffSilVerificationsAndStackProtection(swift::SILOptions& options) {
   options.VerifyAll = false;
   options.VerifyExclusivity = false;
   options.VerifyNone = true;
@@ -99,7 +99,7 @@ class Observer : public swift::FrontendObserver {
     options.KeepASTContext = true;
     lockOutputSwiftModuleTraps(state, options);
     processFrontendOptions(state, options);
-    turnOffSilVerifications(invocation.getSILOptions());
+    turnOffSilVerificationsAndStackProtection(invocation.getSILOptions());
   }
 
   void configuredCompiler(swift::CompilerInstance& instance) override {


### PR DESCRIPTION
Although we do not have any Linux testing enabled, this works around crashes we were seeing on Linux with Swift.