### PR TITLE
C++: Upgrade all 5 queries that were downgraded for BMN

### DIFF
--- a/cpp/ql/src/Likely Bugs/Arithmetic/IntMultToLong.ql
+++ b/cpp/ql/src/Likely Bugs/Arithmetic/IntMultToLong.ql
@@ -5,7 +5,7 @@
  * @kind problem
  * @problem.severity warning
  * @security-severity 8.1
- * @precision medium
+ * @precision high
  * @id cpp/integer-multiplication-cast-to-long
  * @tags reliability
  *       security

--- a/cpp/ql/src/Likely Bugs/Format/WrongTypeFormatArguments.ql
+++ b/cpp/ql/src/Likely Bugs/Format/WrongTypeFormatArguments.ql
@@ -5,7 +5,7 @@
  * @kind problem
  * @problem.severity error
  * @security-severity 7.5
- * @precision medium
+ * @precision high
  * @id cpp/wrong-type-format-argument
  * @tags reliability
  *       correctness

--- a/cpp/ql/src/Likely Bugs/Underspecified Functions/ImplicitFunctionDeclaration.ql
+++ b/cpp/ql/src/Likely Bugs/Underspecified Functions/ImplicitFunctionDeclaration.ql
@@ -5,7 +5,7 @@
  * may lead to unpredictable behavior.
  * @kind problem
  * @problem.severity warning
- * @precision medium
+ * @precision high
  * @id cpp/implicit-function-declaration
  * @tags correctness
  *       maintainability

--- a/cpp/ql/src/Security/CWE/CWE-190/ComparisonWithWiderType.ql
+++ b/cpp/ql/src/Security/CWE/CWE-190/ComparisonWithWiderType.ql
@@ -6,7 +6,7 @@
  * @kind problem
  * @problem.severity warning
  * @security-severity 7.8
- * @precision medium
+ * @precision high
  * @tags reliability
  *       security
  *       external/cwe/cwe-190

--- a/cpp/ql/src/Security/CWE/CWE-468/SuspiciousAddWithSizeof.ql
+++ b/cpp/ql/src/Security/CWE/CWE-468/SuspiciousAddWithSizeof.ql
@@ -6,7 +6,7 @@
  * @kind problem
  * @problem.severity warning
  * @security-severity 8.8
- * @precision medium
+ * @precision high
  * @id cpp/suspicious-add-sizeof
  * @tags security
  *       external/cwe/cwe-468


### PR DESCRIPTION
Upgrade all 5 queries that were downgraded for BMN back to `@precision high`.  This is for testing (e.g. DCA run) and potentially discussion - I have no intent to merge this in its current form.