### PR TITLE
Dependabot: ignore modules in our bazel registry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,3 +45,5 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    exclude-paths:
+      - "misc/bazel/registry/**"


### PR DESCRIPTION
These come from the upstream registry and should just be left alone.