### PR TITLE
Swift: Fix typo

### DIFF
--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/Security.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/Security.qll
@@ -1,5 +1,5 @@
 /**
- * Provides models for standard library Swift classses related to security
+ * Provides models for standard library Swift classes related to security
  * (certificate, key and trust services).
  */
 


### PR DESCRIPTION
Real typo. Mostly to test whether CI still behaves as expected after the changes I made yesterday.