### PR TITLE
Go: fix bad join order

### DIFF
--- a/go/ql/lib/semmle/go/DiagnosticsReporting.qll
+++ b/go/ql/lib/semmle/go/DiagnosticsReporting.qll
@@ -21,7 +21,7 @@ private class Diagnostic extends @diagnostic {
   string getMessage() { diagnostics(this, _, _, result, _, _) }
 
   /** Gets the file that this error is associated with, if any. */
-  File getFile() { result = pragma[only_bind_into](this).getLocation().getFile() }
+  File getFile() { result = pragma[only_bind_out](this.getLocation()).getFile() }
 
   /** Gets the location for this error. */
   Location getLocation() { diagnostics(this, _, _, _, _, result) }


### PR DESCRIPTION
Previously the optimizer was, in some cases, making a table of the file corresponding to all locations and only then limiting to locations corresponding to diagnostics. This pragma forces it to start from a list of diagnostics, get the locations and then the files.