### PR TITLE
Rust: Fix performance issue associated with neutral models

### DIFF
--- a/rust/ql/lib/codeql/files/FileSystem.qll
+++ b/rust/ql/lib/codeql/files/FileSystem.qll
@@ -45,13 +45,16 @@ extensible predicate additionalExternalFile(string relativePath);
 
 /** A file. */
 class File extends Container, Impl::File {
+  pragma[nomagic]
+  private string getRelativePath0() { result = this.getRelativePath() }
+
   /**
    * Holds if this file was extracted from the source code of the target project
    * (rather than another location such as inside a dependency).
    */
   predicate fromSource() {
     exists(ExtractorStep s | s.getAction() = "Extract" and s.getFile() = this) and
-    not additionalExternalFile(this.getRelativePath())
+    not additionalExternalFile(this.getRelativePath0())
   }
 
   /**


### PR DESCRIPTION
Fix performance issue associated with the introduction of the `additionalExternalFile` predicate in the neutral models changes.

Draft: I'm unable to get reliable performance data for this locally, so a bit of iterating may be required.