### PR TITLE
Python: Port ShouldUseWithStatement.ql

### DIFF
--- a/python/ql/test/query-tests/Statements/general/ShouldUseWithStatement.expected
+++ b/python/ql/test/query-tests/Statements/general/ShouldUseWithStatement.expected
@@ -1,1 +1,1 @@
-| test.py:168:9:168:17 | Attribute() | Instance of context-manager class $@ is closed in a finally block. Consider using 'with' statement. | test.py:151:1:151:17 | class CM | CM |
+| test.py:168:9:168:17 | Attribute() | Instance of context-manager class $@ is closed in a finally block. Consider using 'with' statement. | test.py:151:1:151:17 | Class CM | CM |


### PR DESCRIPTION
Uses the (internal) class tracker from `DataFlowDispatch` as well as the new duck typing module.

Only trivial test changes.