### PR TITLE
Actions: Add taint summary for suisei-cn/actions-download-file url input

### DIFF
--- a/actions/ql/lib/ext/manual/suisei-cn_actions-download-file.model.yml
+++ b/actions/ql/lib/ext/manual/suisei-cn_actions-download-file.model.yml
@@ -4,3 +4,4 @@ extensions:
       extensible: actionsSummaryModel
     data:
       - ["suisei-cn/actions-download-file", "*", "input.filename", "output.filename", "taint", "manual"]
+      - ["suisei-cn/actions-download-file", "*", "input.url", "output.filename", "taint", "manual"]

--- a/actions/ql/src/change-notes/2026-03-27-suisei-cn#actions-download-file.md
+++ b/actions/ql/src/change-notes/2026-03-27-suisei-cn#actions-download-file.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added taint flow model for `suisei-cn/actions-download-file` action.


### PR DESCRIPTION
## Summary
- Add a taint flow summary from `input.url` to `output.filename` for `suisei-cn/actions-download-file`
- The existing model already tracks `input.filename` → `output.filename`; this adds coverage for the `url` input, which can also influence the downloaded filename

### Data flow analysis

Reference: https://github.com/suisei-cn/actions-download-file/blob/master/index.js

**`input.url` → `output.filename`:**
1. `text = core.getInput("url")` reads the `url` input
2. `url` is derived from `text` 
3. When the `filename` input is not provided, `finalFilename = getFilenameFromUrl(url)` extracts the filename from the URL path
4. `core.setOutput("filename", finalFilename)` writes to the `filename` output

**`input.filename` → `output.filename` (existing):**
1. `filename = core.getInput("filename")` reads the `filename` input
2. When provided, `finalFilename = filename ? String(filename) : getFilenameFromUrl(url)` takes the `filename` value directly
3. `core.setOutput("filename", finalFilename)` writes to the `filename` output
