### PR TITLE
Actions: Removed a false positive injection sink model for the`veracode/veracode-sca` action.

### DIFF
--- a/actions/ql/lib/ext/manual/veracode_veracode-sca.model.yml
+++ b/actions/ql/lib/ext/manual/veracode_veracode-sca.model.yml
@@ -5,5 +5,4 @@ extensions:
     data:
       - ["veracode/veracode-sca", "*", "input.url", "command-injection", "manual"]
       - ["veracode/veracode-sca", "*", "input.path", "command-injection", "manual"]
-      - ["veracode/veracode-sca", "*", "input.skip-collectors", "command-injection", "manual"]
       - ["veracode/veracode-sca", "*", "input.url", "command-injection", "manual"]

--- a/actions/ql/src/change-notes/2026-03-27-veracode#veracode-sca.md
+++ b/actions/ql/src/change-notes/2026-03-27-veracode#veracode-sca.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Removed false positive injection sink models for the `skip-collectors` input of `veracode/veracode-sca`.


### PR DESCRIPTION
## Summary
Remove the command-injection sink model for the `skip-collectors` input of `veracode/veracode-sca`, as the input is sanitized before reaching the shell command.

### Data flow analysis

Reference: https://github.com/veracode/veracode-sca/blob/main/src/srcclr.ts

The `skip-collectors` input flows through the `cleanCollectors()` function before being interpolated into a shell command. `cleanCollectors()` filters each value against a hardcoded allowlist of known collector names. Since the allowlist contains only safe, simple identifiers with no shell-special characters, attacker-controlled input cannot survive the filter. This makes `skip-collectors` not a viable command-injection sink, and the previous model produced false positives.

