### PR TITLE
C#: Taint members of types in ASP.NET user context.

### DIFF
--- a/csharp/ql/lib/change-notes/2026-04-01-asp-remote-sources.md
+++ b/csharp/ql/lib/change-notes/2026-04-01-asp-remote-sources.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Expanded ASP and ASP.NET remote source modeling to cover additional sources, including fields of tainted parameters as well as properties and fields that become tainted transitively.

--- a/csharp/ql/lib/semmle/code/csharp/commons/Collections.qll
+++ b/csharp/ql/lib/semmle/code/csharp/commons/Collections.qll
@@ -54,20 +54,43 @@ private string genericCollectionTypeName() {
     ]
 }
 
-/** A collection type. */
-class CollectionType extends RefType {
-  CollectionType() {
-    exists(RefType base | base = this.getABaseType*() |
-      base.hasFullyQualifiedName(collectionNamespaceName(), collectionTypeName())
-      or
-      base.(ConstructedType)
-          .getUnboundGeneric()
-          .hasFullyQualifiedName(genericCollectionNamespaceName(), genericCollectionTypeName())
-    )
-    or
-    this instanceof ArrayType
+/** A collection type */
+abstract private class CollectionTypeImpl extends RefType {
+  /**
+   * Gets the element type of this collection, for example `int` in `List<int>`.
+   */
+  abstract Type getElementType();
+}
+
+private class GenericCollectionType extends CollectionTypeImpl {
+  private ConstructedType base;
+
+  GenericCollectionType() {
+    base = this.getABaseType*() and
+    base.getUnboundGeneric()
+        .hasFullyQualifiedName(genericCollectionNamespaceName(), genericCollectionTypeName())
+  }
+
+  override Type getElementType() {
+    result = base.getTypeArgument(0) and base.getNumberOfTypeArguments() = 1
   }
 }
+
+private class NonGenericCollectionType extends CollectionTypeImpl {
+  NonGenericCollectionType() {
+    exists(RefType base | base = this.getABaseType*() |
+      base.hasFullyQualifiedName(collectionNamespaceName(), collectionTypeName())
+    )
+  }
+
+  override Type getElementType() { none() }
+}
+
+private class ArrayCollectionType extends CollectionTypeImpl instanceof ArrayType {
+  override Type getElementType() { result = ArrayType.super.getElementType() }
+}
+
+final class CollectionType = CollectionTypeImpl;
 
 /**
  * A collection type that can be used as a `params` parameter type.

--- a/csharp/ql/lib/semmle/code/csharp/security/dataflow/flowsources/Remote.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/dataflow/flowsources/Remote.qll
@@ -115,6 +115,40 @@ class AspNetServiceRemoteFlowSource extends AspNetRemoteFlowSource, DataFlow::Pa
   override string getSourceType() { result = "ASP.NET web service input" }
 }
 
+/**
+ * Taint members (transitively) on types used in
+ * 1. Action method parameters.
+ * 2. WebMethod parameters.
+ *
+ * Note, that this also impacts uses of such types in other contexts.
+ */
+private class AspNetRemoteFlowSourceMember extends TaintTracking::TaintedMember {
+  AspNetRemoteFlowSourceMember() {
+    exists(Type t, Type t0 | t = this.getDeclaringType() |
+      (t = t0 or t = t0.(ArrayType).getElementType()) and
+      (
+        t0 = any(AspNetRemoteFlowSourceMember m).getType()
+        or
+        t0 = any(ActionMethodParameter p).getType()
+        or
+        t0 = any(AspNetServiceRemoteFlowSource source).getType()
+      )
+    ) and
+    this.isPublic() and
+    not this.isStatic() and
+    (
+      this =
+        any(Property p |
+          p.isAutoImplemented() and
+          p.getGetter().isPublic() and
+          p.getSetter().isPublic()
+        )
+      or
+      this = any(Field f | f.isPublic())
+    )
+  }
+}
+
 /** A data flow source of remote user input (ASP.NET request message). */
 class SystemNetHttpRequestMessageRemoteFlowSource extends AspNetRemoteFlowSource, DataFlow::ExprNode
 {

--- a/csharp/ql/lib/semmle/code/csharp/security/dataflow/flowsources/Remote.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/dataflow/flowsources/Remote.qll
@@ -115,25 +115,8 @@ class AspNetServiceRemoteFlowSource extends AspNetRemoteFlowSource, DataFlow::Pa
   override string getSourceType() { result = "ASP.NET web service input" }
 }
 
-/**
- * Taint members (transitively) on types used in
- * 1. Action method parameters.
- * 2. WebMethod parameters.
- *
- * Note, that this also impacts uses of such types in other contexts.
- */
-private class AspNetRemoteFlowSourceMember extends TaintTracking::TaintedMember {
-  AspNetRemoteFlowSourceMember() {
-    exists(Type t, Type t0 | t = this.getDeclaringType() |
-      (t = t0 or t = t0.(ArrayType).getElementType()) and
-      (
-        t0 = any(AspNetRemoteFlowSourceMember m).getType()
-        or
-        t0 = any(ActionMethodParameter p).getType()
-        or
-        t0 = any(AspNetServiceRemoteFlowSource source).getType()
-      )
-    ) and
+private class CandidateMembersToTaint extends Member {
+  CandidateMembersToTaint() {
     this.isPublic() and
     not this.isStatic() and
     (
@@ -145,6 +128,30 @@ private class AspNetRemoteFlowSourceMember extends TaintTracking::TaintedMember 
         )
       or
       this = any(Field f | f.isPublic())
+    )
+  }
+}
+
+/**
+ * Taint members (transitively) on types used in
+ * 1. Action method parameters.
+ * 2. WebMethod parameters.
+ *
+ * Note, that this also impacts uses of such types in other contexts.
+ */
+private class AspNetRemoteFlowSourceMember extends TaintTracking::TaintedMember,
+  CandidateMembersToTaint
+{
+  AspNetRemoteFlowSourceMember() {
+    exists(Type t, Type t0 | t = this.getDeclaringType() |
+      (t = t0 or t = t0.(ArrayType).getElementType()) and
+      (
+        t0 = any(AspNetRemoteFlowSourceMember m).getType()
+        or
+        t0 = any(ActionMethodParameter p).getType()
+        or
+        t0 = any(AspNetServiceRemoteFlowSource source).getType()
+      )
     )
   }
 }
@@ -253,14 +260,18 @@ class AspNetCoreRoutingMethodParameter extends AspNetCoreRemoteFlowSource, DataF
  * Flow is defined from any ASP.NET Core remote source object to any of its member
  * properties.
  */
-private class AspNetCoreRemoteFlowSourceMember extends TaintTracking::TaintedMember, Property {
+private class AspNetCoreRemoteFlowSourceMember extends TaintTracking::TaintedMember,
+  CandidateMembersToTaint
+{
   AspNetCoreRemoteFlowSourceMember() {
-    this.getDeclaringType() = any(AspNetCoreRemoteFlowSource source).getType() and
-    this.isPublic() and
-    not this.isStatic() and
-    this.isAutoImplemented() and
-    this.getGetter().isPublic() and
-    this.getSetter().isPublic()
+    exists(Type t, Type t0 | t = this.getDeclaringType() |
+      (t = t0 or t = t0.(ArrayType).getElementType()) and
+      (
+        t0 = any(AspNetCoreRemoteFlowSourceMember m).getType()
+        or
+        t0 = any(AspNetCoreRemoteFlowSource m).getType()
+      )
+    )
   }
 }
 

--- a/csharp/ql/lib/semmle/code/csharp/security/dataflow/flowsources/Remote.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/dataflow/flowsources/Remote.qll
@@ -3,6 +3,7 @@
  */
 
 import csharp
+private import semmle.code.csharp.commons.Collections
 private import semmle.code.csharp.frameworks.system.Net
 private import semmle.code.csharp.frameworks.system.Web
 private import semmle.code.csharp.frameworks.system.web.Http
@@ -115,8 +116,8 @@ class AspNetServiceRemoteFlowSource extends AspNetRemoteFlowSource, DataFlow::Pa
   override string getSourceType() { result = "ASP.NET web service input" }
 }
 
-private class CandidateMembersToTaint extends Member {
-  CandidateMembersToTaint() {
+private class CandidateMemberToTaint extends Member {
+  CandidateMemberToTaint() {
     this.isPublic() and
     not this.isStatic() and
     (
@@ -140,11 +141,11 @@ private class CandidateMembersToTaint extends Member {
  * Note that this also impacts uses of such types in other contexts.
  */
 private class AspNetRemoteFlowSourceMember extends TaintTracking::TaintedMember,
-  CandidateMembersToTaint
+  CandidateMemberToTaint
 {
   AspNetRemoteFlowSourceMember() {
     exists(Type t, Type t0 | t = this.getDeclaringType() |
-      (t = t0 or t = t0.(ArrayType).getElementType()) and
+      (t = t0 or t = t0.(CollectionType).getElementType()) and
       (
         t0 = any(AspNetRemoteFlowSourceMember m).getType()
         or
@@ -261,11 +262,11 @@ class AspNetCoreRoutingMethodParameter extends AspNetCoreRemoteFlowSource, DataF
  * properties.
  */
 private class AspNetCoreRemoteFlowSourceMember extends TaintTracking::TaintedMember,
-  CandidateMembersToTaint
+  CandidateMemberToTaint
 {
   AspNetCoreRemoteFlowSourceMember() {
     exists(Type t, Type t0 | t = this.getDeclaringType() |
-      (t = t0 or t = t0.(ArrayType).getElementType()) and
+      (t = t0 or t = t0.(CollectionType).getElementType()) and
       (
         t0 = any(AspNetCoreRemoteFlowSourceMember m).getType()
         or

--- a/csharp/ql/lib/semmle/code/csharp/security/dataflow/flowsources/Remote.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/dataflow/flowsources/Remote.qll
@@ -137,7 +137,7 @@ private class CandidateMembersToTaint extends Member {
  * 1. Action method parameters.
  * 2. WebMethod parameters.
  *
- * Note, that this also impacts uses of such types in other contexts.
+ * Note that this also impacts uses of such types in other contexts.
  */
 private class AspNetRemoteFlowSourceMember extends TaintTracking::TaintedMember,
   CandidateMembersToTaint

--- a/csharp/ql/lib/semmle/code/csharp/security/dataflow/flowsources/Remote.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/dataflow/flowsources/Remote.qll
@@ -104,7 +104,7 @@ class WcfRemoteFlowSource extends RemoteFlowSource, DataFlow::ParameterNode {
 }
 
 /** A data flow source of remote user input (ASP.NET web service). */
-class AspNetServiceRemoteFlowSource extends RemoteFlowSource, DataFlow::ParameterNode {
+class AspNetServiceRemoteFlowSource extends AspNetRemoteFlowSource, DataFlow::ParameterNode {
   AspNetServiceRemoteFlowSource() {
     exists(Method m |
       m.getAParameter() = this.getParameter() and
@@ -116,7 +116,8 @@ class AspNetServiceRemoteFlowSource extends RemoteFlowSource, DataFlow::Paramete
 }
 
 /** A data flow source of remote user input (ASP.NET request message). */
-class SystemNetHttpRequestMessageRemoteFlowSource extends RemoteFlowSource, DataFlow::ExprNode {
+class SystemNetHttpRequestMessageRemoteFlowSource extends AspNetRemoteFlowSource, DataFlow::ExprNode
+{
   SystemNetHttpRequestMessageRemoteFlowSource() {
     this.getType() instanceof SystemWebHttpRequestMessageClass
   }
@@ -166,7 +167,7 @@ class MicrosoftOwinRequestRemoteFlowSource extends RemoteFlowSource, DataFlow::E
 }
 
 /** A parameter to an Mvc controller action method, viewed as a source of remote user input. */
-class ActionMethodParameter extends RemoteFlowSource, DataFlow::ParameterNode {
+class ActionMethodParameter extends AspNetRemoteFlowSource, DataFlow::ParameterNode {
   ActionMethodParameter() {
     exists(Parameter p |
       p = this.getParameter() and

--- a/csharp/ql/test/library-tests/dataflow/flowsources/aspremote/AspRemoteFlowSource.cs
+++ b/csharp/ql/test/library-tests/dataflow/flowsources/aspremote/AspRemoteFlowSource.cs
@@ -8,7 +8,7 @@ namespace Testing
     public class ViewModel
     {
         public string RequestId { get; set; } // Considered tainted.
-        public object RequestIdField; // Not considered tainted as it is a field.
+        public object RequestIdField; // Considered tainted.
         public string RequestIdOnlyGet { get; } // Not considered tainted as there is no setter.
         public string RequestIdPrivateSet { get; private set; } // Not considered tainted as it has a private setter.
         public static object RequestIdStatic { get; set; } // Not considered tainted as it is static.

--- a/csharp/ql/test/library-tests/dataflow/flowsources/aspremote/aspRemoteFlowSource.expected
+++ b/csharp/ql/test/library-tests/dataflow/flowsources/aspremote/aspRemoteFlowSource.expected
@@ -1,5 +1,6 @@
 remoteFlowSourceMembers
 | AspRemoteFlowSource.cs:10:23:10:31 | RequestId |
+| AspRemoteFlowSource.cs:11:23:11:36 | RequestIdField |
 | AspRemoteFlowSource.cs:28:23:28:29 | Tainted |
 remoteFlowSources
 | AspRemoteFlowSource.cs:20:42:20:50 | viewModel |

--- a/csharp/ql/test/library-tests/dataflow/flowsources/remote/RemoteFlowSource.cs
+++ b/csharp/ql/test/library-tests/dataflow/flowsources/remote/RemoteFlowSource.cs
@@ -58,15 +58,21 @@ namespace RemoteFlowSource
 namespace AspRemoteFlowSource
 {
     using System.Web.Services;
+    using System.Collections.Generic;
 
     public class MySubData
     {
         public string SubDataProp { get; set; }
     }
 
-    public class MyElementSubData
+    public class ArrayElementData
     {
-        public string ElementSubDataProp { get; set; }
+        public string ArrayElementDataProp { get; set; }
+    }
+
+    public class ListElementData
+    {
+        public string ListElementDataProp { get; set; }
     }
 
     public class MyData
@@ -74,7 +80,8 @@ namespace AspRemoteFlowSource
         public string DataField;
         public string DataProp { get; set; }
         public MySubData SubData { get; set; }
-        public MyElementSubData[] Elements { get; set; }
+        public ArrayElementData[] Elements { get; set; }
+        public List<ListElementData> List;
     }
 
     public class MyDataElement
@@ -90,7 +97,8 @@ namespace AspRemoteFlowSource
         {
             Use(data.DataProp);
             Use(data.SubData.SubDataProp);
-            Use(data.Elements[0].ElementSubDataProp);
+            Use(data.Elements[0].ArrayElementDataProp);
+            Use(data.List[0].ListElementDataProp);
         }
 
         [WebMethod]

--- a/csharp/ql/test/library-tests/dataflow/flowsources/remote/RemoteFlowSource.cs
+++ b/csharp/ql/test/library-tests/dataflow/flowsources/remote/RemoteFlowSource.cs
@@ -54,3 +54,51 @@ namespace RemoteFlowSource
         }
     }
 }
+
+namespace AspRemoteFlowSource
+{
+    using System.Web.Services;
+
+    public class MySubData
+    {
+        public string SubDataProp { get; set; }
+    }
+
+    public class MyElementSubData
+    {
+        public string ElementSubDataProp { get; set; }
+    }
+
+    public class MyData
+    {
+        public string DataField;
+        public string DataProp { get; set; }
+        public MySubData SubData { get; set; }
+        public MyElementSubData[] Elements { get; set; }
+    }
+
+    public class MyDataElement
+    {
+        public string Prop { get; set; }
+    }
+
+
+    public class MyService
+    {
+        [WebMethod]
+        public void MyMethod(MyData data)
+        {
+            Use(data.DataProp);
+            Use(data.SubData.SubDataProp);
+            Use(data.Elements[0].ElementSubDataProp);
+        }
+
+        [WebMethod]
+        public void MyMethod2(MyDataElement[] data)
+        {
+            Use(data[0].Prop);
+        }
+
+        public static void Use(object o) { }
+    }
+}

--- a/csharp/ql/test/library-tests/dataflow/flowsources/remote/remoteFlowSource.expected
+++ b/csharp/ql/test/library-tests/dataflow/flowsources/remote/remoteFlowSource.expected
@@ -1,4 +1,12 @@
 remoteFlowSourceMembers
+| Controller.cs:6:19:6:25 | Tainted |
+| RemoteFlowSource.cs:64:23:64:33 | SubDataProp |
+| RemoteFlowSource.cs:69:23:69:40 | ElementSubDataProp |
+| RemoteFlowSource.cs:74:23:74:31 | DataField |
+| RemoteFlowSource.cs:75:23:75:30 | DataProp |
+| RemoteFlowSource.cs:76:26:76:32 | SubData |
+| RemoteFlowSource.cs:77:35:77:42 | Elements |
+| RemoteFlowSource.cs:82:23:82:26 | Prop |
 remoteFlowSources
 | Controller.cs:11:43:11:52 | sampleData | ASP.NET MVC action method parameter |
 | Controller.cs:11:62:11:66 | taint | ASP.NET MVC action method parameter |
@@ -12,3 +20,5 @@ remoteFlowSources
 | RemoteFlowSource.cs:45:17:45:23 | access to parameter request | ASP.NET query string |
 | RemoteFlowSource.cs:45:17:45:42 | access to property RawUrl | ASP.NET unvalidated request data |
 | RemoteFlowSource.cs:52:55:52:61 | [post] access to local variable segment | external |
+| RemoteFlowSource.cs:89:37:89:40 | data | ASP.NET web service input |
+| RemoteFlowSource.cs:97:47:97:50 | data | ASP.NET web service input |

--- a/csharp/ql/test/library-tests/dataflow/flowsources/remote/remoteFlowSource.expected
+++ b/csharp/ql/test/library-tests/dataflow/flowsources/remote/remoteFlowSource.expected
@@ -1,3 +1,5 @@
+remoteFlowSourceMembers
+remoteFlowSources
 | Controller.cs:11:43:11:52 | sampleData | ASP.NET MVC action method parameter |
 | Controller.cs:11:62:11:66 | taint | ASP.NET MVC action method parameter |
 | Controller.cs:16:43:16:52 | sampleData | ASP.NET MVC action method parameter |

--- a/csharp/ql/test/library-tests/dataflow/flowsources/remote/remoteFlowSource.expected
+++ b/csharp/ql/test/library-tests/dataflow/flowsources/remote/remoteFlowSource.expected
@@ -1,12 +1,14 @@
 remoteFlowSourceMembers
 | Controller.cs:6:19:6:25 | Tainted |
-| RemoteFlowSource.cs:64:23:64:33 | SubDataProp |
-| RemoteFlowSource.cs:69:23:69:40 | ElementSubDataProp |
-| RemoteFlowSource.cs:74:23:74:31 | DataField |
-| RemoteFlowSource.cs:75:23:75:30 | DataProp |
-| RemoteFlowSource.cs:76:26:76:32 | SubData |
-| RemoteFlowSource.cs:77:35:77:42 | Elements |
-| RemoteFlowSource.cs:82:23:82:26 | Prop |
+| RemoteFlowSource.cs:65:23:65:33 | SubDataProp |
+| RemoteFlowSource.cs:70:23:70:42 | ArrayElementDataProp |
+| RemoteFlowSource.cs:75:23:75:41 | ListElementDataProp |
+| RemoteFlowSource.cs:80:23:80:31 | DataField |
+| RemoteFlowSource.cs:81:23:81:30 | DataProp |
+| RemoteFlowSource.cs:82:26:82:32 | SubData |
+| RemoteFlowSource.cs:83:35:83:42 | Elements |
+| RemoteFlowSource.cs:84:38:84:41 | List |
+| RemoteFlowSource.cs:89:23:89:26 | Prop |
 remoteFlowSources
 | Controller.cs:11:43:11:52 | sampleData | ASP.NET MVC action method parameter |
 | Controller.cs:11:62:11:66 | taint | ASP.NET MVC action method parameter |
@@ -20,5 +22,5 @@ remoteFlowSources
 | RemoteFlowSource.cs:45:17:45:23 | access to parameter request | ASP.NET query string |
 | RemoteFlowSource.cs:45:17:45:42 | access to property RawUrl | ASP.NET unvalidated request data |
 | RemoteFlowSource.cs:52:55:52:61 | [post] access to local variable segment | external |
-| RemoteFlowSource.cs:89:37:89:40 | data | ASP.NET web service input |
-| RemoteFlowSource.cs:97:47:97:50 | data | ASP.NET web service input |
+| RemoteFlowSource.cs:96:37:96:40 | data | ASP.NET web service input |
+| RemoteFlowSource.cs:105:47:105:50 | data | ASP.NET web service input |

--- a/csharp/ql/test/library-tests/dataflow/flowsources/remote/remoteFlowSource.ql
+++ b/csharp/ql/test/library-tests/dataflow/flowsources/remote/remoteFlowSource.ql
@@ -1,5 +1,7 @@
 import semmle.code.csharp.security.dataflow.flowsources.Remote
 
-from RemoteFlowSource source
-where source.getLocation().getFile().fromSource()
-select source, source.getSourceType()
+query predicate remoteFlowSourceMembers(TaintTracking::TaintedMember m) { m.fromSource() }
+
+query predicate remoteFlowSources(RemoteFlowSource source, string type) {
+  source.getLocation().getFile().fromSource() and type = source.getSourceType()
+}

--- a/csharp/ql/test/resources/stubs/System.Web.cs
+++ b/csharp/ql/test/resources/stubs/System.Web.cs
@@ -454,3 +454,8 @@ namespace System.Web.Script.Serialization
         public SimpleTypeResolver() => throw null;
     }
 }
+
+namespace System.Web.Services
+{
+    public class WebMethodAttribute : Attribute { }
+}


### PR DESCRIPTION
The background of this PR is [this](https://github.com/github/codeql/discussions/21567) discussion.

In this PR we
- Taint members of types used in some of the legacy ASP contexts.
- Taint members transitively and include fields as well.
- Streamline the implementation for ASP.NET tainted members.

It is worth noting that tainting the members (for a given type) used in an ASP context also means that such members will be considered tainted (when the object is tainted) in other contexts. However, to streamline the approach of the legacy ASP with ASP.NET tainted members - this is the approach taken in the PR.

@hvitved : Do you believe this is still acceptable or should we strive for adding access of fields and properties as remote sources instead?