### PR TITLE
C#: Fix inconsistent casing of Cs/CS.

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -274,7 +274,7 @@ module VariableCapture {
   }
 
   private module CaptureInput implements Shared::InputSig<Location, BasicBlocks::BasicBlock> {
-    private import csharp as Cs
+    private import csharp as CS
     private import semmle.code.csharp.controlflow.ControlFlowGraph as Cfg
     private import TaintTrackingPrivate as TaintTrackingPrivate
 
@@ -391,7 +391,7 @@ module VariableCapture {
       }
     }
 
-    class Callable extends Cs::Callable {
+    class Callable extends CS::Callable {
       predicate isConstructor() { this instanceof Constructor }
     }
   }

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImpl.qll
@@ -215,9 +215,9 @@ private module StepsInput implements Impl::Private::StepsInputSig {
 module SourceSinkInterpretationInput implements
   Impl::Private::External::SourceSinkInterpretationInputSig
 {
-  private import csharp as Cs
+  private import csharp as CS
 
-  class Element = Cs::Element;
+  class Element = CS::Element;
 
   predicate sourceElement(
     Element e, string output, string kind, Public::Provenance provenance, string model

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/SsaImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/SsaImpl.qll
@@ -1042,7 +1042,6 @@ string getToStringPrefix(Definition def) {
 }
 
 private module DataFlowIntegrationInput implements Impl::DataFlowIntegrationInputSig {
-  private import csharp as Cs
   private import semmle.code.csharp.controlflow.BasicBlocks
   private import codeql.util.Boolean
 

--- a/csharp/ql/lib/utils/test/InlineMadTest.qll
+++ b/csharp/ql/lib/utils/test/InlineMadTest.qll
@@ -1,14 +1,14 @@
-private import csharp as Cs
+private import csharp as CS
 private import codeql.mad.test.InlineMadTest
 
 private module InlineMadTestLang implements InlineMadTestLangSig {
-  class Callable = Cs::Callable;
+  class Callable = CS::Callable;
 
   string getComment(Callable c) {
-    exists(Cs::CommentBlock block, Cs::Element after | after = block.getAfter() |
+    exists(CS::CommentBlock block, CS::Element after | after = block.getAfter() |
       (
         after = c or
-        after = c.(Cs::Accessor).getDeclaration()
+        after = c.(CS::Accessor).getDeclaration()
       ) and
       result = block.getALine()
     )


### PR DESCRIPTION
Flagged by ql-for-ql. `CS` was more common so I went with that.