### PR TITLE
Vendor `PicoSHA2` into LFS

### DIFF
--- a/swift/third_party/load.bzl
+++ b/swift/third_party/load.bzl
@@ -81,12 +81,13 @@ def load_dependencies(module_ctx):
         _load_prebuilt(plat)
         _load_resource_dir(plat)
 
-    _github_archive(
+    # Vendored from okdshin/PicoSHA2 (personal account).
+    # To update (from the internal repo): resources/third_party/vendor.sh -o ql/swift/third_party/resources okdshin/PicoSHA2 <new_commit>
+    lfs_archive(
         name = "picosha2",
+        src = "//swift/third_party/resources:PicoSHA2-27fcf6979298949e8a462e16d09a0351c18fcaf2.tar.zst",
+        strip_prefix = "PicoSHA2-27fcf6979298949e8a462e16d09a0351c18fcaf2",
         build_file = _build % "picosha2",
-        repository = "okdshin/PicoSHA2",
-        commit = "27fcf6979298949e8a462e16d09a0351c18fcaf2",
-        sha256 = "d6647ca45a8b7bdaf027ecb68d041b22a899a0218b7206dee755c558a2725abb",
     )
 
     _github_archive(

--- a/swift/third_party/resources/PicoSHA2-27fcf6979298949e8a462e16d09a0351c18fcaf2.tar.zst
+++ b/swift/third_party/resources/PicoSHA2-27fcf6979298949e8a462e16d09a0351c18fcaf2.tar.zst
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3082b319e6281be54b77b7619a38e5718266fca5e693bc4e23dd76bb17bc6420
+size 8159


### PR DESCRIPTION
The upstream repo (`okdshin/PicoSHA2`) is a personal GitHub account, so it's better to vendor it to avoid any risk of our build failing because it becomes unavailable for some reaons.

## Changes

- **Vendored archive** into `swift/third_party/resources/` as `.tar.zst` (LFS-tracked)
- **Updated `swift/third_party/load.bzl`**: switched from `_github_archive` → `lfs_archive`