### PR TITLE
JavaScript: Add setHTMLUnsafe and parseHTMLUnsafe as XSS sinks

### DIFF
--- a/javascript/ql/lib/semmle/javascript/security/dataflow/DOM.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/DOM.qll
@@ -58,6 +58,8 @@ class DomMethodCallNode extends DataFlow::MethodCallNode {
       name = "createElement" and argPos = 0
       or
       name = "appendChild" and argPos = 0
+      or
+      name = "setHTMLUnsafe" and argPos = 0
     )
   }
 

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/DomBasedXssCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/DomBasedXssCustomizations.qll
@@ -196,6 +196,11 @@ module DomBasedXss {
         ccf.getMethodName() = "createContextualFragment" and
         this = ccf.getArgument(0)
       )
+      or
+      exists(DataFlow::GlobalVarRefNode doc |
+        doc.getName() = "Document" and
+        this = doc.getAMethodCall("parseHTMLUnsafe").getArgument(0)
+      )
     }
   }
 


### PR DESCRIPTION
## Summary

Add two new HTML Sanitizer API methods as DOM-based XSS sinks:

- **`Element.setHTMLUnsafe(html)`** — Added to `interpretsArgumentsAsHtml` in `DOM.qll`, following the same pattern as `insertAdjacentHTML` and `document.write`. Receiver validation via `isDomNode` is inherited from `DomMethodCallNode`.

- **`Document.parseHTMLUnsafe(html)`** — Added to `HtmlParserSink` in `DomBasedXssCustomizations.qll`, following the same `GlobalVarRefNode` pattern as `DOMParser.parseFromString`. This is a static method on the `Document` class.

Both methods are part of the [HTML Sanitizer API](https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API) and are shipping in browsers (Chrome 124+, Firefox 148+). Unlike their safe counterparts (`setHTML`, `parseHTML`), these methods do **not** sanitize input and are therefore XSS sinks.

## Changes

| File | Change |
|------|--------|
| `DOM.qll` | Add `setHTMLUnsafe` (arg 0) to `interpretsArgumentsAsHtml` |
| `DomBasedXssCustomizations.qll` | Add `Document.parseHTMLUnsafe` (arg 0) to `HtmlParserSink` |

## Design decisions

- **`setHTMLUnsafe` in `interpretsArgumentsAsHtml`**: This is a DOM element instance method (like `insertAdjacentHTML`, `write`), so `DomMethodCallNode` handles receiver validation via `isDomNode`.

- **`parseHTMLUnsafe` in `HtmlParserSink`**: This is a static method on the `Document` class (`Document.parseHTMLUnsafe(html)`). The `Document` class reference is not recognized by `isDomNode` (which tracks DOM node instances, not class constructors). We use `GlobalVarRefNode` to match the `Document` receiver, following the same pattern as `DOMParser.parseFromString`.

- **`ShadowRoot.setHTMLUnsafe`**: `ShadowRoot` is not currently tracked by `domValueRef()`, so `isDomNode` does not cover it. Adding ShadowRoot support to `domValueRef()` is a separate enhancement tracked independently.

## References

- [Element.setHTMLUnsafe() — MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/setHTMLUnsafe)
- [Document.parseHTMLUnsafe() — MDN](https://developer.mozilla.org/en-US/docs/Web/API/Document/parseHTMLUnsafe_static)
- [Chromium commit: Protect setHTMLUnsafe and parseHTMLUnsafe with Trusted Types](https://github.com/chromium/chromium/commit/5f9c98130587c76019cb2692d0c850e689b4b3d2)