### PR TITLE
Python: Port InconsistentMRO.ql

### DIFF
--- a/python/ql/src/Classes/InconsistentMRO.ql
+++ b/python/ql/src/Classes/InconsistentMRO.ql
@@ -17,7 +17,10 @@ private import semmle.python.dataflow.new.internal.DataFlowDispatch
 /**
  * Gets the `i`th base class of `cls`, if it can be resolved to a user-defined class.
  */
-Class getBaseType(Class cls, int i) { cls.getBase(i) = classTracker(result).asExpr() }
+Class getBaseType(Class cls, int i) {
+  cls.getBase(i) = classTracker(result).asExpr() and
+  result != cls
+}
 
 Class left_base(Class type, Class base) {
   exists(int i | i > 0 and getBaseType(type, i) = base and result = getBaseType(type, i - 1))

--- a/python/ql/test/2/query-tests/Classes/inconsistent-mro/InconsistentMRO.expected
+++ b/python/ql/test/2/query-tests/Classes/inconsistent-mro/InconsistentMRO.expected
@@ -1,1 +1,1 @@
-| inconsistent_mro.py:9:1:9:14 | class Z | Construction of class Z can fail due to invalid method resolution order(MRO) for bases $@ and $@. | inconsistent_mro.py:3:1:3:16 | class X | X | inconsistent_mro.py:6:1:6:11 | class Y | Y |
+| inconsistent_mro.py:9:1:9:14 | Class Z | Construction of class Z can fail due to invalid method resolution order(MRO) for bases $@ and $@. | inconsistent_mro.py:3:1:3:16 | Class X | X | inconsistent_mro.py:6:1:6:11 | Class Y | Y |

--- a/python/ql/test/3/query-tests/Classes/inconsistent-mro/InconsistentMRO.expected
+++ b/python/ql/test/3/query-tests/Classes/inconsistent-mro/InconsistentMRO.expected
@@ -1,2 +1,1 @@
-| inconsistent_mro.py:9:1:9:14 | class Z | Construction of class Z can fail due to invalid method resolution order(MRO) for bases $@ and $@. | inconsistent_mro.py:3:1:3:16 | class X | X | inconsistent_mro.py:6:1:6:11 | class Y | Y |
-| inconsistent_mro.py:16:1:16:19 | class N | Construction of class N can fail due to invalid method resolution order(MRO) for bases $@ and $@. | file://:Compiled Code:0:0:0:0 | builtin-class object | object | inconsistent_mro.py:12:1:12:8 | class O | O |
+| inconsistent_mro.py:9:1:9:14 | Class Z | Construction of class Z can fail due to invalid method resolution order(MRO) for bases $@ and $@. | inconsistent_mro.py:3:1:3:16 | Class X | X | inconsistent_mro.py:6:1:6:11 | Class Y | Y |


### PR DESCRIPTION
For this one we actually lose a test result. However, this is kind of to
be expected since we no longer have the "precise" MRO that the points-to
analysis computes.

Honestly, I'm on the fence about even keeping this query at all. It
seems like it might be superfluous in a world with good Python type
checking.