### PR TITLE
Rust: Replace special handling of index expressions in type inference

### DIFF
--- a/rust/ql/lib/codeql/rust/frameworks/stdlib/Builtins.qll
+++ b/rust/ql/lib/codeql/rust/frameworks/stdlib/Builtins.qll
@@ -19,6 +19,13 @@ private class BuiltinsTypesFile extends File {
   }
 }
 
+private class BuiltinsImplsFile extends File {
+  BuiltinsImplsFile() {
+    this.getBaseName() = "impls.rs" and
+    this.getParentContainer() instanceof BuiltinsFolder
+  }
+}
+
 /**
  * A builtin type, such as `bool` and `i32`.
  *
@@ -220,4 +227,9 @@ class TupleType extends BuiltinType {
       result = "(" + commas + ")"
     )
   }
+}
+
+/** A builtin implementation. */
+class BuiltinImpl extends Impl {
+  BuiltinImpl() { this.getFile() instanceof BuiltinsImplsFile }
 }

--- a/rust/ql/lib/codeql/rust/internal/typeinference/FunctionOverloading.qll
+++ b/rust/ql/lib/codeql/rust/internal/typeinference/FunctionOverloading.qll
@@ -6,6 +6,8 @@
  */
 
 private import rust
+private import codeql.rust.frameworks.stdlib.Builtins as Builtins
+private import codeql.rust.frameworks.stdlib.Stdlib
 private import codeql.rust.internal.PathResolution
 private import Type
 private import TypeAbstraction
@@ -94,6 +96,14 @@ private module MkSiblingImpls<resolveTypeMentionAtSig/2 resolveTypeMentionAt> {
       not t1 instanceof TypeParameter or
       not t2 instanceof TypeParameter
     )
+    or
+    // todo: handle blanket/non-blanket siblings in `implSiblings`
+    trait =
+      any(IndexTrait it |
+        implSiblingCandidate(impl, it, _, _) and
+        impl instanceof Builtins::BuiltinImpl and
+        path = TypePath::singleton(TAssociatedTypeTypeParameter(trait, it.getOutputType()))
+      )
   }
 }
 

--- a/rust/ql/lib/codeql/rust/internal/typeinference/TypeInference.qll
+++ b/rust/ql/lib/codeql/rust/internal/typeinference/TypeInference.qll
@@ -3663,43 +3663,6 @@ private Type inferArrayExprType(ArrayExpr ae) { exists(ae) and result instanceof
 pragma[nomagic]
 private Type inferRangeExprType(RangeExpr re) { result = TDataType(getRangeType(re)) }
 
-/**
- * According to [the Rust reference][1]: _"array and slice-typed expressions
- * can be indexed with a `usize` index ... For other types an index expression
- * `a[b]` is equivalent to *std::ops::Index::index(&a, b)"_.
- *
- * The logic below handles array and slice indexing, but for other types it is
- * currently limited to `Vec`.
- *
- * [1]: https://doc.rust-lang.org/reference/expressions/array-expr.html#r-expr.array.index
- */
-pragma[nomagic]
-private Type inferIndexExprType(IndexExpr ie, TypePath path) {
-  // TODO: Method resolution to the `std::ops::Index` trait can handle the
-  // `Index` instances for slices and arrays.
-  exists(TypePath exprPath, Builtins::BuiltinType t |
-    TDataType(t) = inferType(ie.getIndex()) and
-    (
-      // also allow `i32`, since that is currently the type that we infer for
-      // integer literals like `0`
-      t instanceof Builtins::I32
-      or
-      t instanceof Builtins::Usize
-    ) and
-    result = inferType(ie.getBase(), exprPath)
-  |
-    // todo: remove?
-    exprPath.isCons(TTypeParamTypeParameter(any(Vec v).getElementTypeParam()), path)
-    or
-    exprPath.isCons(getArrayTypeParameter(), path)
-    or
-    exists(TypePath path0 |
-      exprPath.isCons(getRefTypeParameter(_), path0) and
-      path0.isCons(getSliceTypeParameter(), path)
-    )
-  )
-}
-
 pragma[nomagic]
 private Type getInferredDerefType(DerefExpr de, TypePath path) { result = inferType(de, path) }
 
@@ -3902,7 +3865,8 @@ private module Cached {
       i instanceof ImplItemNode and dispatch = false
     |
       result = call.(AssocFunctionResolution::AssocFunctionCall).resolveCallTarget(i, _, _, _) and
-      not call instanceof CallExprImpl::DynamicCallExpr
+      not call instanceof CallExprImpl::DynamicCallExpr and
+      not i instanceof Builtins::BuiltinImpl
     )
   }
 
@@ -4003,8 +3967,6 @@ private module Cached {
       result = inferLiteralType(n, path, false)
       or
       result = inferAwaitExprType(n, path)
-      or
-      result = inferIndexExprType(n, path)
       or
       result = inferDereferencedExprPtrType(n, path)
       or

--- a/rust/tools/builtins/impls.rs
+++ b/rust/tools/builtins/impls.rs
@@ -30,8 +30,8 @@
 /// }
 /// ```
 ///
-/// which the type inference library cannot currently handle (we fail
-/// to resolve the `Output` types).
+/// (as well as their `IndexMut` counterparts), which the type inference library
+/// cannot currently handle (we fail to resolve the `Output` types).
 mod index_impls {
     use std::alloc::Allocator;
     use std::ops::Index;
@@ -44,10 +44,26 @@ mod index_impls {
         }
     }
 
+    impl<T, const N: usize> IndexMut<i32> for [T; N] {
+        type Output = T;
+
+        fn index_mut(&mut self, index: i32) -> &mut Self::Output {
+            panic!()
+        }
+    }
+
     impl<T, const N: usize> Index<usize> for [T; N] {
         type Output = T;
 
         fn index(&self, index: usize) -> &Self::Output {
+            panic!()
+        }
+    }
+
+    impl<T, const N: usize> IndexMut<usize> for [T; N] {
+        type Output = T;
+
+        fn index_mut(&mut self, index: usize) -> &mut Self::Output {
             panic!()
         }
     }
@@ -60,10 +76,26 @@ mod index_impls {
         }
     }
 
+    impl<T> IndexMut<i32> for [T] {
+        type Output = T;
+
+        fn index_mut(&mut self, index: i32) -> &mut Self::Output {
+            panic!()
+        }
+    }
+
     impl<T> Index<usize> for [T] {
         type Output = T;
 
         fn index(&self, index: usize) -> &Self::Output {
+            panic!()
+        }
+    }
+
+    impl<T> IndexMut<usize> for [T] {
+        type Output = T;
+
+        fn index_mut(&mut self, index: usize) -> &mut Self::Output {
             panic!()
         }
     }
@@ -76,10 +108,26 @@ mod index_impls {
         }
     }
 
+    impl<T, A: Allocator> IndexMut<i32> for Vec<T, A> {
+        type Output = T;
+
+        fn index_mut(&mut self, index: i32) -> &mut Self::Output {
+            panic!()
+        }
+    }
+
     impl<T, A: Allocator> Index<usize> for Vec<T, A> {
         type Output = T;
 
         fn index(&self, index: usize) -> &Self::Output {
+            panic!()
+        }
+    }
+
+    impl<T, A: Allocator> IndexMut<usize> for Vec<T, A> {
+        type Output = T;
+
+        fn index_mut(&mut self, index: usize) -> &mut Self::Output {
             panic!()
         }
     }

--- a/rust/tools/builtins/impls.rs
+++ b/rust/tools/builtins/impls.rs
@@ -1,0 +1,86 @@
+/// Contains type-specialized versions of
+///
+/// ```
+/// impl<T, I, const N: usize> Index<I> for [T; N]
+/// where
+///     [T]: Index<I>,
+/// {
+///     type Output = <[T] as Index<I>>::Output;
+///     ...
+/// }
+/// ```
+///
+/// and
+///
+/// ```
+/// impl<T, I> ops::Index<I> for [T]
+/// where
+///     I: SliceIndex<[T]>,
+/// {
+///     type Output = I::Output;
+///     ...
+/// }
+/// ```
+///
+/// and
+/// ```
+/// impl<T, I: SliceIndex<[T]>, A: Allocator> Index<I> for Vec<T, A> {
+///     type Output = I::Output;
+///     ...
+/// }
+/// ```
+///
+/// which the type inference library cannot currently handle (we fail
+/// to resolve the `Output` types).
+mod index_impls {
+    use std::alloc::Allocator;
+    use std::ops::Index;
+
+    impl<T, const N: usize> Index<i32> for [T; N] {
+        type Output = T;
+
+        fn index(&self, index: i32) -> &Self::Output {
+            panic!()
+        }
+    }
+
+    impl<T, const N: usize> Index<usize> for [T; N] {
+        type Output = T;
+
+        fn index(&self, index: usize) -> &Self::Output {
+            panic!()
+        }
+    }
+
+    impl<T> Index<i32> for [T] {
+        type Output = T;
+
+        fn index(&self, index: i32) -> &Self::Output {
+            panic!()
+        }
+    }
+
+    impl<T> Index<usize> for [T] {
+        type Output = T;
+
+        fn index(&self, index: usize) -> &Self::Output {
+            panic!()
+        }
+    }
+
+    impl<T, A: Allocator> Index<i32> for Vec<T, A> {
+        type Output = T;
+
+        fn index(&self, index: i32) -> &Self::Output {
+            panic!()
+        }
+    }
+
+    impl<T, A: Allocator> Index<usize> for Vec<T, A> {
+        type Output = T;
+
+        fn index(&self, index: usize) -> &Self::Output {
+            panic!()
+        }
+    }
+}


### PR DESCRIPTION
We have special logic for handling type inference for index expressions `foo[bar]` where `bar` is an integer and `foo` is either an array, a slice, or a vector; in this case the type is whatever the element type is.

Special casing is needed because, even though we correctly see `foo[bar]` as syntactic sugar for `foo.index(bar)`, we cannot resolve the `Output` types in the `Index` implementations for [slices](https://doc.rust-lang.org/std/ops/trait.Index.html#impl-Index%3CI%3E-for-%5BT%5D), [arrays](https://doc.rust-lang.org/std/ops/trait.Index.html#impl-Index%3CI%3E-for-%5BT;+N%5D), and [vectors](https://doc.rust-lang.org/std/ops/trait.Index.html#impl-Index%3CI%3E-for-Vec%3CT,+A%3E). However, instead of having special logic in the type inference library, we can achieve the same effect by adding type-specialized implementations where we _can_ resolve the `Output` type, which is somewhat cleaner.

[DCA](https://github.com/github/codeql-dca-main/issues/35994) is mostly uneventful.