### PR TITLE
C++: Fix `isCompiledAsC` join order

### DIFF
--- a/cpp/ql/src/Likely Bugs/Underspecified Functions/MistypedFunctionArguments.qll
+++ b/cpp/ql/src/Likely Bugs/Underspecified Functions/MistypedFunctionArguments.qll
@@ -79,9 +79,7 @@ private predicate hasZeroParamDecl(Function f) {
 
 // True if this file (or header) was compiled as a C file
 private predicate isCompiledAsC(File f) {
-  f.compiledAsC()
-  or
-  exists(File src | isCompiledAsC(src) | src.getAnIncludedFile() = f)
+  exists(File src | src.compiledAsC() | src.getAnIncludedFile*() = f)
 }
 
 predicate mistypedFunctionArguments(FunctionCall fc, Function f, Parameter p) {

--- a/cpp/ql/src/Likely Bugs/Underspecified Functions/TooFewArguments.qll
+++ b/cpp/ql/src/Likely Bugs/Underspecified Functions/TooFewArguments.qll
@@ -28,9 +28,7 @@ private predicate hasZeroParamDecl(Function f) {
 
 /* Holds if this file (or header) was compiled as a C file. */
 private predicate isCompiledAsC(File f) {
-  f.compiledAsC()
-  or
-  exists(File src | isCompiledAsC(src) | src.getAnIncludedFile() = f)
+  exists(File src | src.compiledAsC() | src.getAnIncludedFile*() = f)
 }
 
 /** Holds if `fc` is a call to `f` with too few arguments. */

--- a/cpp/ql/src/Likely Bugs/Underspecified Functions/TooManyArguments.qll
+++ b/cpp/ql/src/Likely Bugs/Underspecified Functions/TooManyArguments.qll
@@ -19,9 +19,7 @@ private predicate hasZeroParamDecl(Function f) {
 
 // True if this file (or header) was compiled as a C file
 private predicate isCompiledAsC(File f) {
-  f.compiledAsC()
-  or
-  exists(File src | isCompiledAsC(src) | src.getAnIncludedFile() = f)
+  exists(File src | src.compiledAsC() | src.getAnIncludedFile*() = f)
 }
 
 predicate tooManyArguments(FunctionCall fc, Function f) {


### PR DESCRIPTION
This is one of the predicates showing up in the "Stable join-order badness, per source and predicate" table in our nightly experiments.

Before on Abseil Windows for `cpp/too-few-arguments:`:
```
Pipeline standard for TooFewArguments::isCompiledAsC/1#52fe29e8@994f9bgp was evaluated in 12 iterations totaling 2ms (delta sizes total: 50).
        1198778   ~3%    {1} r1 = JOIN `TooFewArguments::isCompiledAsC/1#52fe29e8#prev_delta` WITH `Element::Element.getFile/0#2b8c8740_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1
             83  ~26%    {1}    | JOIN WITH includes ON FIRST 1 OUTPUT Rhs.1
             50   ~4%    {1}    | AND NOT `TooFewArguments::isCompiledAsC/1#52fe29e8#prev`(FIRST 1)
                         return r1
```

After:
```
Pipeline standard for #File::File.getAnIncludedFile/0#dispred#e8d44cd1Plus#bf@b8d290i6 was evaluated in 11 iterations totaling 0ms (delta sizes total: 43).
        47   ~0%    {2} r1 = SCAN `#File::File.getAnIncludedFile/0#dispred#e8d44cd1Plus#bf#prev_delta` OUTPUT In.1, In.0
        78  ~28%    {2}    | JOIN WITH `File::File.getAnIncludedFile/0#dispred#e8d44cd1` ON FIRST 1 OUTPUT Lhs.1, Rhs.1
        43   ~0%    {2}    | AND NOT `#File::File.getAnIncludedFile/0#dispred#e8d44cd1Plus#bf#prev`(FIRST 2)
                    return r1

[2026-04-13 11:05:25] Evaluated non-recursive predicate TooFewArguments::isCompiledAsC/1#52fe29e8@4a3eb9jk in 0ms (size: 49).
Evaluated relational algebra for predicate TooFewArguments::isCompiledAsC/1#52fe29e8@4a3eb9jk with tuple counts:
         1   ~0%    {3} r1 = CONSTANT(unique int, unique string, unique string)[1,"compiled as c","1"]
         1   ~0%    {1}    | JOIN WITH #fileannotationsMerge_1230#join_rhs ON FIRST 3 OUTPUT Rhs.3

        48   ~0%    {1} r2 = JOIN r1 WITH `#File::File.getAnIncludedFile/0#dispred#e8d44cd1Plus#bf` ON FIRST 1 OUTPUT Rhs.1

        49   ~0%    {1} r3 = r1 UNION r2
                    return r3
```