### PR TITLE
C++: Use new `getConvSpecString` instead of `getConvSpecOffset` and `substring`

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/commons/Printf.qll
+++ b/cpp/ql/lib/semmle/code/cpp/commons/Printf.qll
@@ -459,6 +459,13 @@ class FormatLiteral extends Literal instanceof StringLiteral {
    */
   int getConvSpecOffset(int n) { result = this.getFormat().indexOf("%", n, 0) }
 
+  /**
+   * Gets the nth conversion specifier string.
+   */
+  private string getConvSpecString(int n) {
+    n >= 0 and result = "%" + this.getFormat().splitAt("%", n + 1)
+  }
+
   /*
    * Each of these predicates gets a regular expressions to match each individual
    * parts of a conversion specifier.
@@ -524,10 +531,8 @@ class FormatLiteral extends Literal instanceof StringLiteral {
     int n, string spec, string params, string flags, string width, string prec, string len,
     string conv
   ) {
-    exists(int offset, string fmt, string rst, string regexp |
-      offset = this.getConvSpecOffset(n) and
-      fmt = this.getFormat() and
-      rst = fmt.substring(offset, fmt.length()) and
+    exists(string rst, string regexp |
+      rst = this.getConvSpecString(n) and
       regexp = this.getConvSpecRegexp() and
       (
         spec = rst.regexpCapture(regexp, 1) and
@@ -554,10 +559,8 @@ class FormatLiteral extends Literal instanceof StringLiteral {
    * Gets the nth conversion specifier (including the initial `%`).
    */
   string getConvSpec(int n) {
-    exists(int offset, string fmt, string rst, string regexp |
-      offset = this.getConvSpecOffset(n) and
-      fmt = this.getFormat() and
-      rst = fmt.substring(offset, fmt.length()) and
+    exists(string rst, string regexp |
+      rst = this.getConvSpecString(n) and
       regexp = this.getConvSpecRegexp() and
       result = rst.regexpCapture(regexp, 1)
     )

--- a/cpp/ql/lib/semmle/code/cpp/commons/Printf.qll
+++ b/cpp/ql/lib/semmle/code/cpp/commons/Printf.qll
@@ -531,20 +531,20 @@ class FormatLiteral extends Literal instanceof StringLiteral {
     int n, string spec, string params, string flags, string width, string prec, string len,
     string conv
   ) {
-    exists(string rst, string regexp |
-      rst = this.getConvSpecString(n) and
+    exists(string convSpec, string regexp |
+      convSpec = this.getConvSpecString(n) and
       regexp = this.getConvSpecRegexp() and
       (
-        spec = rst.regexpCapture(regexp, 1) and
-        params = rst.regexpCapture(regexp, 2) and
-        flags = rst.regexpCapture(regexp, 3) and
-        width = rst.regexpCapture(regexp, 4) and
-        prec = rst.regexpCapture(regexp, 5) and
-        len = rst.regexpCapture(regexp, 6) and
-        conv = rst.regexpCapture(regexp, 7)
+        spec = convSpec.regexpCapture(regexp, 1) and
+        params = convSpec.regexpCapture(regexp, 2) and
+        flags = convSpec.regexpCapture(regexp, 3) and
+        width = convSpec.regexpCapture(regexp, 4) and
+        prec = convSpec.regexpCapture(regexp, 5) and
+        len = convSpec.regexpCapture(regexp, 6) and
+        conv = convSpec.regexpCapture(regexp, 7)
         or
-        spec = rst.regexpCapture(regexp, 1) and
-        not exists(rst.regexpCapture(regexp, 2)) and
+        spec = convSpec.regexpCapture(regexp, 1) and
+        not exists(convSpec.regexpCapture(regexp, 2)) and
         params = "" and
         flags = "" and
         width = "" and
@@ -559,10 +559,10 @@ class FormatLiteral extends Literal instanceof StringLiteral {
    * Gets the nth conversion specifier (including the initial `%`).
    */
   string getConvSpec(int n) {
-    exists(string rst, string regexp |
-      rst = this.getConvSpecString(n) and
+    exists(string convSpec, string regexp |
+      convSpec = this.getConvSpecString(n) and
       regexp = this.getConvSpecRegexp() and
-      result = rst.regexpCapture(regexp, 1)
+      result = convSpec.regexpCapture(regexp, 1)
     )
   }
 

--- a/cpp/ql/lib/semmle/code/cpp/commons/Scanf.qll
+++ b/cpp/ql/lib/semmle/code/cpp/commons/Scanf.qll
@@ -195,6 +195,13 @@ class ScanfFormatLiteral extends Expr {
   }
 
   /**
+   * Gets the nth conversion specifier string.
+   */
+  private string getConvSpecString(int n) {
+    n >= 0 and result = "%" + this.getFormat().splitAt("%", n + 1)
+  }
+
+  /**
    * Gets the regular expression to match each individual part of a conversion specifier.
    */
   private string getMaxWidthRegexp() { result = "(?:[1-9][0-9]*)?" }
@@ -227,10 +234,8 @@ class ScanfFormatLiteral extends Expr {
    * specifier.
    */
   predicate parseConvSpec(int n, string spec, string width, string len, string conv) {
-    exists(int offset, string fmt, string rst, string regexp |
-      offset = this.getConvSpecOffset(n) and
-      fmt = this.getFormat() and
-      rst = fmt.substring(offset, fmt.length()) and
+    exists(string rst, string regexp |
+      rst = this.getConvSpecString(n) and
       regexp = this.getConvSpecRegexp() and
       (
         spec = rst.regexpCapture(regexp, 1) and

--- a/cpp/ql/lib/semmle/code/cpp/commons/Scanf.qll
+++ b/cpp/ql/lib/semmle/code/cpp/commons/Scanf.qll
@@ -234,14 +234,14 @@ class ScanfFormatLiteral extends Expr {
    * specifier.
    */
   predicate parseConvSpec(int n, string spec, string width, string len, string conv) {
-    exists(string rst, string regexp |
-      rst = this.getConvSpecString(n) and
+    exists(string convSpec, string regexp |
+      convSpec = this.getConvSpecString(n) and
       regexp = this.getConvSpecRegexp() and
       (
-        spec = rst.regexpCapture(regexp, 1) and
-        width = rst.regexpCapture(regexp, 2) and
-        len = rst.regexpCapture(regexp, 3) and
-        conv = rst.regexpCapture(regexp, 4)
+        spec = convSpec.regexpCapture(regexp, 1) and
+        width = convSpec.regexpCapture(regexp, 2) and
+        len = convSpec.regexpCapture(regexp, 3) and
+        conv = convSpec.regexpCapture(regexp, 4)
       )
     )
   }


### PR DESCRIPTION
Should address `glibc` timeout in BMN DCA.

Three DCA experiments in order of occurrence (of open issues):
* BMN using the last known working nightly SHA-pair as a base: has a lot of changes, but shows that glibc is working again,
* BMN with just the change: glibc obviously fails, these experiments seem quite noisy, but I see no reason for concern that this PR regresses anything
* Traced: looks good, I do see that I did not quite manage to stabilize nmap; the tinyxml2 analysis time difference we've only seen in nightlies, so is not an immediate reason for concern.

Please ignore the Custom Sources DCA experiment(s), and other closed experiment issues.