### PR TITLE
Add models of various `aligned_alloc`s

### DIFF
--- a/cpp/ql/lib/ext/allocation/Std.allocation.model.yml
+++ b/cpp/ql/lib/ext/allocation/Std.allocation.model.yml
@@ -13,3 +13,6 @@ extensions:
       - ["", "", False, "calloc", "1", "0", "", True]
       - ["std", "", False, "calloc", "1", "0", "", True]
       - ["bsl", "", False, "calloc", "1", "0", "", True]
+      - ["", "", False, "aligned_alloc", "1", "", "", True]
+      - ["std", "", False, "aligned_alloc", "1", "", "", True]
+      - ["bsl", "", False, "aligned_alloc", "1", "", "", True]

--- a/cpp/ql/src/change-notes/2026-04-16-add-model-for-aligned-alloc.md
+++ b/cpp/ql/src/change-notes/2026-04-16-add-model-for-aligned-alloc.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added models for `::aligned_alloc`, `std::aligned_alloc`, and `bsl::aligned_alloc`. These will now be recognized as `AllocationFunction`.

--- a/cpp/ql/src/change-notes/2026-04-16-add-model-for-aligned-alloc.md
+++ b/cpp/ql/src/change-notes/2026-04-16-add-model-for-aligned-alloc.md
@@ -1,4 +1,4 @@
 ---
 category: minorAnalysis
 ---
-* Added models for `::aligned_alloc`, `std::aligned_alloc`, and `bsl::aligned_alloc`. These will now be recognized as `AllocationFunction`.
+* Added `AllocationFunction` models for `aligned_alloc`, `std::aligned_alloc`, and `bsl::aligned_alloc`.


### PR DESCRIPTION
Add models of `aligned_alloc`, available in several ways:
1. `::aligned_alloc`, defined in `stdlib.h`: [reference](https://en.cppreference.com/w/c/memory/aligned_alloc)
2. `std::aligned_alloc`, defined in `cstdlib`: [reference](https://en.cppreference.com/w/cpp/memory/c/aligned_alloc)
3. `bsl::aligned_alloc`, defined [here](https://github.com/bloomberg/bde/blob/main/groups/bsl/bsl%2Bbslhdrs/bsl_cstdlib.h#L77).