### PR TITLE
Go: improve accuracy of overlay annotations

### DIFF
--- a/go/ql/lib/semmle/go/Decls.qll
+++ b/go/ql/lib/semmle/go/Decls.qll
@@ -1,7 +1,7 @@
 /**
  * Provides classes for working with declarations.
  */
-overlay[local]
+overlay[local?]
 module;
 
 import go
@@ -137,6 +137,7 @@ class FuncDef extends @funcdef, StmtParent, ExprParent {
   /**
    * Gets a call to this function.
    */
+  overlay[global]
   DataFlow::CallNode getACall() { result.getACallee() = this }
 
   /** Holds if this function is variadic. */

--- a/go/ql/lib/semmle/go/Scopes.qll
+++ b/go/ql/lib/semmle/go/Scopes.qll
@@ -1,7 +1,7 @@
 /**
  * Provides classes for working with scopes and declared objects.
  */
-overlay[local]
+overlay[local?]
 module;
 
 import go
@@ -418,6 +418,7 @@ class Function extends ValueEntity, @functionobject {
    * This includes calls that target this function indirectly, by calling an
    * interface method that this function implements.
    */
+  overlay[global]
   pragma[nomagic]
   DataFlow::CallNode getACall() { this = result.getACalleeIncludingExternals().asFunction() }
 

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowNodes.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowNodes.qll
@@ -1,4 +1,4 @@
-overlay[local]
+overlay[local?]
 module;
 
 private import go
@@ -488,6 +488,7 @@ module Public {
      * For virtual calls, we look up possible targets in all types that implement the receiver
      * interface type.
      */
+    overlay[global]
     Callable getACalleeIncludingExternals() {
       result = this.getACalleeWithoutVirtualDispatch()
       or
@@ -504,6 +505,7 @@ module Public {
      * As `getACalleeIncludingExternals`, except excluding external functions (those for which
      * we lack a definition, such as standard library functions).
      */
+    overlay[global]
     pragma[nomagic]
     FuncDef getACallee() { result = this.getACalleeIncludingExternals().getFuncDef() }
 


### PR DESCRIPTION
`FuncDef.getACall()` should be `overlay[global]`. This reduces the number of alerts that we miss in overlay mode.

I did 4 DCA runs, but only runs 3 and 4 need to be considered.
1. Run 1 failed because of a latent performance issue, fixed in https://github.com/github/codeql/pull/21745.
2. Run 2 was on a subset of one of the standard source suites, and therefore is not directly comparable with previous runs.
3. Run 3 was on the source suite aimed at checking that we do not lose two many results. It shows that we now only have 2 missing results, which is an improvement on the 9 missing results previously. (Side note: the 2 results are not a subset of the previous 9, which I do not understand.)
4. Run 4 was on the source suite aimed at testing performance. This showed a 31% reduction in analysis time. However, this is source suite is full of sources that take a very long time. The source suite used for run 3 contains mostly small repos, which are more representative. The reduction in analysis time in run 3 was 14%.