### PR TITLE
Fix two `QualifiedName` join orders

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/internal/QualifiedName.qll
+++ b/cpp/ql/lib/semmle/code/cpp/internal/QualifiedName.qll
@@ -18,7 +18,7 @@ class Namespace extends @namespace {
     if namespacembrs(_, this)
     then
       exists(Namespace ns |
-        namespacembrs(ns, this) and
+        namespacembrs(ns, pragma[only_bind_out](this)) and
         result = ns.getQualifiedName() + "::" + this.getName()
       )
     else result = this.getName()
@@ -37,7 +37,7 @@ class Namespace extends @namespace {
   string getAQualifierForMembers() {
     if namespacembrs(_, this)
     then
-      exists(Namespace ns | namespacembrs(ns, this) |
+      exists(Namespace ns | namespacembrs(ns, pragma[only_bind_out](this)) |
         result = ns.getAQualifierForMembers() + "::" + this.getName()
         or
         // If this is an inline namespace, its members are also visible in any


### PR DESCRIPTION
Before on `StanfordLegion__legion` with `cpp/throwing-pointer`:
```
Pipeline standard for QualifiedName::Namespace.getQualifiedName/0#cbc0648a@7ff329j5 was evaluated in 2 iterations totaling 0ms (delta sizes total: 70).
        162061  ~0%    {2} r1 = JOIN `QualifiedName::Namespace.getQualifiedName/0#cbc0648a#prev_delta` WITH namespacembrs ON FIRST 1 OUTPUT Rhs.1, Lhs.1
            70  ~2%    {4}    | JOIN WITH namespaces ON FIRST 1 OUTPUT Lhs.0, _, Lhs.1, Rhs.1
            70  ~0%    {2}    | REWRITE WITH Tmp.1 := "::", Out.1 := (In.2 ++ Tmp.1 ++ In.3) KEEPING 2
            70  ~0%    {2}    | AND NOT `QualifiedName::Namespace.getQualifiedName/0#cbc0648a#prev`(FIRST 2)
                       return r1

Pipeline standard for QualifiedName::Namespace.getAQualifierForMembers/0#132b16e1@cfd47189 was evaluated in 2 iterations totaling 3ms (delta sizes total: 85).
            12   ~0%    {2} r1 = JOIN `QualifiedName::Namespace.getAQualifierForMembers/0#132b16e1#prev_delta` WITH _#namespace_inlineMerge_#namespacembrsMerge#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1

        162417   ~0%    {2} r2 = JOIN `QualifiedName::Namespace.getAQualifierForMembers/0#132b16e1#prev_delta` WITH namespacembrs ON FIRST 1 OUTPUT Rhs.1, Lhs.1
            73   ~1%    {4}    | JOIN WITH namespaces ON FIRST 1 OUTPUT Lhs.0, _, Lhs.1, Rhs.1
            73   ~0%    {2}    | REWRITE WITH Tmp.1 := "::", Out.1 := (In.2 ++ Tmp.1 ++ In.3) KEEPING 2

            85   ~0%    {2} r3 = r1 UNION r2
            85   ~0%    {2}    | AND NOT `QualifiedName::Namespace.getAQualifierForMembers/0#132b16e1#prev`(FIRST 2)
                        return r3
```

After:
```
Pipeline standard for QualifiedName::Namespace.getQualifiedName/0#cbc0648a@91677d3f was evaluated in 2 iterations totaling 0ms (delta sizes total: 70).
        70  ~0%    {4} r1 = JOIN `QualifiedName::Namespace.getQualifiedName/0#cbc0648a#prev_delta` WITH _#namespacembrsMerge_1#antijoin_rhs_#namespacembrsMerge_10#join_rhs_#namespacesMerge#join_rhs ON FIRST 1 OUTPUT Rhs.1, _, Lhs.1, Rhs.2
        70  ~0%    {2}    | REWRITE WITH Tmp.1 := "::", Out.1 := (In.2 ++ Tmp.1 ++ In.3) KEEPING 2
        70  ~0%    {2}    | AND NOT `QualifiedName::Namespace.getQualifiedName/0#cbc0648a#prev`(FIRST 2)
                   return r1

Pipeline standard for QualifiedName::Namespace.getAQualifierForMembers/0#132b16e1@3bbc99mb was evaluated in 2 iterations totaling 0ms (delta sizes total: 85).
        12   ~0%    {2} r1 = JOIN `QualifiedName::Namespace.getAQualifierForMembers/0#132b16e1#prev_delta` WITH _#namespace_inlineMerge_#namespacembrsMerge_1#antijoin_rhs__#namespacembrsMerge_#namespacembrsMerge___#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1

        73   ~0%    {4} r2 = JOIN `QualifiedName::Namespace.getAQualifierForMembers/0#132b16e1#prev_delta` WITH _#namespacembrsMerge_1#antijoin_rhs_#namespacesMerge__#namespacembrsMerge_#namespacembrsMerge_10#joi__#join_rhs ON FIRST 1 OUTPUT Rhs.1, _, Lhs.1, Rhs.2
        73   ~1%    {2}    | REWRITE WITH Tmp.1 := "::", Out.1 := (In.2 ++ Tmp.1 ++ In.3) KEEPING 2

        85   ~0%    {2} r3 = r1 UNION r2
        85   ~0%    {2}    | AND NOT `QualifiedName::Namespace.getAQualifierForMembers/0#132b16e1#prev`(FIRST 2)
                    return r3
```