### PR TITLE
C++: Fix join in `TranslatedAssertion::getVariable`

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/TranslatedAssertion.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/TranslatedAssertion.qll
@@ -114,6 +114,7 @@ private predicate parseArgument(string arg, string s, int i, Opcode opcode) {
 
 private Element getAChildScope(Element scope) { result.getParentScope() = scope }
 
+pragma[nomagic]
 private predicate hasAVariable(MacroInvocation mi, Stmt s, Element scope) {
   assertion0(mi, s, _) and
   s.getParent() = scope
@@ -121,15 +122,32 @@ private predicate hasAVariable(MacroInvocation mi, Stmt s, Element scope) {
   hasAVariable(mi, s, getAChildScope(scope))
 }
 
-private LocalScopeVariable getVariable(MacroInvocation mi, int i) {
-  exists(string operand, string arg, Stmt s |
+private predicate hasParentScope(Variable v, Element scope) { v.getParentScope() = scope }
+
+pragma[nomagic]
+private predicate hasAssertionOperand(MacroInvocation mi, int i, Stmt s, string operand) {
+  exists(string arg |
     assertion0(mi, s, arg) and
-    parseArgument(arg, operand, i, _) and
+    parseArgument(arg, operand, i, _)
+  )
+}
+
+pragma[nomagic]
+private predicate hasNameAndParentScope(string name, Element scope, Variable v) {
+  v.hasName(name) and
+  hasParentScope(v, scope)
+}
+
+pragma[nomagic]
+private LocalScopeVariable getVariable(MacroInvocation mi, int i) {
+  exists(string name, Stmt s |
+    hasAssertionOperand(mi, i, s, name) and
     result =
-      unique(Variable v |
+      unique(Variable v, Element parentScope |
+        hasAssertionOperand(mi, _, s, name) and
         v.getLocation().getStartLine() < s.getLocation().getStartLine() and
-        hasAVariable(mi, s, v.getParentScope()) and
-        v.hasName(operand)
+        hasAVariable(mi, s, parentScope) and
+        hasNameAndParentScope(name, parentScope, v)
       |
         v
       )


### PR DESCRIPTION
Before (on boost):
```ql
[2026-04-23 10:13:26] Evaluated non-recursive predicate _#stmtsMerge_Element::Element.getParentScope/0#dispred#b0dbb25c_10#join_rhs_Location::Location.getSt__#shared@b90e68i7 in 161ms (size: 520213).
Evaluated relational algebra for predicate _#stmtsMerge_Element::Element.getParentScope/0#dispred#b0dbb25c_10#join_rhs_Location::Location.getSt__#shared@b90e68i7 with tuple counts:
          523974   ~3%    {2} r1 = SCAN stmts OUTPUT In.2, In.0
          523974   ~0%    {2}    | JOIN WITH `Location::Location.getStartLine/0#d54f9e6c` ON FIRST 1 OUTPUT Lhs.1, Rhs.1
           13494   ~0%    {4}    | JOIN WITH `TranslatedAssertion::hasAVariable/3#76a1d6b7#bbf_102#join_rhs` ON FIRST 1 OUTPUT Rhs.2, Lhs.0, Lhs.1, Rhs.1
        77064501   ~0%    {4}    | JOIN WITH `Element::Element.getParentScope/0#dispred#b0dbb25c_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3
          603448   ~1%    {5}    | JOIN WITH `Variable::Variable.getLocation/0#dispred#ffcb49bd` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.0
          603448   ~0%    {5}    | JOIN WITH `Location::Location.getStartLine/0#d54f9e6c` ON FIRST 1 OUTPUT Lhs.1, Lhs.2, Lhs.3, Lhs.4, Rhs.1
                          {5}    | REWRITE WITH TEST InOut.4 < InOut.1
          520916   ~0%    {3}    | SCAN OUTPUT In.3, In.0, In.2
                          return r1

[2026-04-23 10:13:26] Evaluated non-recursive predicate _Declaration::Declaration.hasName/1#dispred#ea371278#fb__#stmtsMerge_Element::Element.getParentScope__#unique_range@b5fca76q in 26ms (size: 520213).
Evaluated relational algebra for predicate _Declaration::Declaration.hasName/1#dispred#ea371278#fb__#stmtsMerge_Element::Element.getParentScope__#unique_range@b5fca76q with tuple counts:
        520213  ~0%    {4} r1 = JOIN `_#stmtsMerge_Element::Element.getParentScope/0#dispred#b0dbb25c_10#join_rhs_Location::Location.getSt__#shared` WITH `Declaration::Declaration.hasName/1#dispred#ea371278#fb` ON FIRST 1 OUTPUT Lhs.1, Lhs.2, Rhs.1, Lhs.0
                       return r1

[2026-04-23 10:13:26] Evaluated non-recursive predicate _Declaration::Declaration.hasName/1#dispred#ea371278#fb__#stmtsMerge_Element::Element.getParentScope__#unique_term@255cb1v4 in 40ms (size: 520213).
Evaluated relational algebra for predicate _Declaration::Declaration.hasName/1#dispred#ea371278#fb__#stmtsMerge_Element::Element.getParentScope__#unique_term@255cb1v4 with tuple counts:
        520213  ~0%    {5} r1 = JOIN `_#stmtsMerge_Element::Element.getParentScope/0#dispred#b0dbb25c_10#join_rhs_Location::Location.getSt__#shared` WITH `Declaration::Declaration.hasName/1#dispred#ea371278#fb` ON FIRST 1 OUTPUT Lhs.1, Lhs.2, Rhs.1, Lhs.0, Lhs.0
                       return r1

[2026-04-23 10:13:26] Evaluated non-recursive predicate TranslatedAssertion::getVariable/2#f24612a9#bbf@207815ik in 106ms (size: 466).
Evaluated relational algebra for predicate TranslatedAssertion::getVariable/2#f24612a9#bbf@207815ik with tuple counts:
        515953   ~0%    {4} r1 = AGGREGATE `_Declaration::Declaration.hasName/1#dispred#ea371278#fb__#stmtsMerge_Element::Element.getParentScope__#unique_range`, `_Declaration::Declaration.hasName/1#dispred#ea371278#fb__#stmtsMerge_Element::Element.getParentScope__#unique_term` ON In.4 WITH UNIQUE OUTPUT In.0, In.1, In.2, Agg.0
        515953   ~0%    {4}    | SCAN OUTPUT In.3, In.0, In.1, In.2
          7063   ~4%    {4}    | JOIN WITH Variable::LocalScopeVariable#3aae4a09 ON FIRST 1 OUTPUT Lhs.2, Lhs.1, Lhs.0, Lhs.3
                    
          7063   ~5%    {5} r2 = JOIN r1 WITH `TranslatedAssertion::assertion0/3#fd23c70e` ON FIRST 2 OUTPUT Lhs.2, Lhs.0, Lhs.3, Rhs.2, _
          7063   ~0%    {5}    | REWRITE WITH Out.4 := "([a-zA-Z_][a-zA-Z_0-9]*|[0-9]+)\\s?<\\s?([a-zA-Z_][a-zA-Z_0-9]*|[0-9]+)"
           726   ~0%    {7}    | JOIN WITH PRIMITIVE regexpCapture#bbff ON Lhs.3,Lhs.4
                        {7}    | REWRITE WITH TEST InOut.2 = InOut.6
            77   ~5%    {4}    | SCAN OUTPUT In.1, _, In.0, In.5
            77   ~3%    {3}    | REWRITE WITH Tmp.1 := 1, Out.1 := (In.3 - Tmp.1) KEEPING 3
                    
          7063   ~5%    {5} r3 = JOIN r1 WITH `TranslatedAssertion::assertion0/3#fd23c70e` ON FIRST 2 OUTPUT Lhs.2, Lhs.0, Lhs.3, Rhs.2, _
          7063   ~0%    {5}    | REWRITE WITH Out.4 := "([a-zA-Z_][a-zA-Z_0-9]*|[0-9]+)\\s?>\\s?([a-zA-Z_][a-zA-Z_0-9]*|[0-9]+)"
           558   ~0%    {7}    | JOIN WITH PRIMITIVE regexpCapture#bbff ON Lhs.3,Lhs.4
                        {7}    | REWRITE WITH TEST InOut.2 = InOut.6
            40   ~0%    {4}    | SCAN OUTPUT In.1, _, In.0, In.5
            40   ~0%    {3}    | REWRITE WITH Tmp.1 := 1, Out.1 := (In.3 - Tmp.1) KEEPING 3
                    
          7063   ~5%    {5} r4 = JOIN r1 WITH `TranslatedAssertion::assertion0/3#fd23c70e` ON FIRST 2 OUTPUT Lhs.2, Lhs.0, Lhs.3, Rhs.2, _
          7063   ~0%    {5}    | REWRITE WITH Out.4 := "([a-zA-Z_][a-zA-Z_0-9]*|[0-9]+)\\s?!=\\s?([a-zA-Z_][a-zA-Z_0-9]*|[0-9]+)"
          1304   ~0%    {7}    | JOIN WITH PRIMITIVE regexpCapture#bbff ON Lhs.3,Lhs.4
                        {7}    | REWRITE WITH TEST InOut.2 = InOut.6
           156   ~8%    {4}    | SCAN OUTPUT In.1, _, In.0, In.5
           156   ~0%    {3}    | REWRITE WITH Tmp.1 := 1, Out.1 := (In.3 - Tmp.1) KEEPING 3
                    
          7063   ~5%    {5} r5 = JOIN r1 WITH `TranslatedAssertion::assertion0/3#fd23c70e` ON FIRST 2 OUTPUT Lhs.2, Lhs.0, Lhs.3, Rhs.2, _
          7063   ~0%    {5}    | REWRITE WITH Out.4 := "([a-zA-Z_][a-zA-Z_0-9]*|[0-9]+)\\s?<=\\s?([a-zA-Z_][a-zA-Z_0-9]*|[0-9]+)"
           312   ~1%    {7}    | JOIN WITH PRIMITIVE regexpCapture#bbff ON Lhs.3,Lhs.4
                        {7}    | REWRITE WITH TEST InOut.2 = InOut.6
            48   ~0%    {4}    | SCAN OUTPUT In.1, _, In.0, In.5
            48   ~0%    {3}    | REWRITE WITH Tmp.1 := 1, Out.1 := (In.3 - Tmp.1) KEEPING 3
                    
          7063   ~5%    {5} r6 = JOIN r1 WITH `TranslatedAssertion::assertion0/3#fd23c70e` ON FIRST 2 OUTPUT Lhs.2, Lhs.0, Lhs.3, Rhs.2, _
          7063   ~0%    {5}    | REWRITE WITH Out.4 := "([a-zA-Z_][a-zA-Z_0-9]*|[0-9]+)\\s?==\\s?([a-zA-Z_][a-zA-Z_0-9]*|[0-9]+)"
           442   ~0%    {7}    | JOIN WITH PRIMITIVE regexpCapture#bbff ON Lhs.3,Lhs.4
                        {7}    | REWRITE WITH TEST InOut.2 = InOut.6
            77   ~0%    {4}    | SCAN OUTPUT In.1, _, In.0, In.5
            77   ~0%    {3}    | REWRITE WITH Tmp.1 := 1, Out.1 := (In.3 - Tmp.1) KEEPING 3
                    
          7063   ~5%    {5} r7 = JOIN r1 WITH `TranslatedAssertion::assertion0/3#fd23c70e` ON FIRST 2 OUTPUT Lhs.2, Lhs.0, Lhs.3, Rhs.2, _
          7063   ~2%    {5}    | REWRITE WITH Out.4 := "([a-zA-Z_][a-zA-Z_0-9]*|[0-9]+)\\s?>=\\s?([a-zA-Z_][a-zA-Z_0-9]*|[0-9]+)"
           762   ~0%    {7}    | JOIN WITH PRIMITIVE regexpCapture#bbff ON Lhs.3,Lhs.4
                        {7}    | REWRITE WITH TEST InOut.2 = InOut.6
            68   ~0%    {4}    | SCAN OUTPUT In.1, _, In.0, In.5
            68   ~0%    {3}    | REWRITE WITH Tmp.1 := 1, Out.1 := (In.3 - Tmp.1) KEEPING 3
                    
           466   ~0%    {3} r8 = r2 UNION r3 UNION r4 UNION r5 UNION r6 UNION r7
                        return r8

[2026-04-23 10:13:26] Evaluated non-recursive predicate project#TranslatedAssertion::getVariable/2#f24612a9#bbf@0cd8edj8 in 0ms (size: 466).
Evaluated relational algebra for predicate project#TranslatedAssertion::getVariable/2#f24612a9#bbf@0cd8edj8 with tuple counts:
        466  ~1%    {2} r1 = SCAN `TranslatedAssertion::getVariable/2#f24612a9#bbf` OUTPUT In.0, In.1
        466  ~1%    {2}    | STREAM DEDUP
                    return r1
```
After:
```ql
[2026-04-23 12:03:17] Evaluated non-recursive predicate _#stmtsMerge_Location::Location.getStartLine/0#d54f9e6c_TranslatedAssertion::hasAVariable/3#76a1d6b7__#shared@4cb5aa3e in 66ms (size: 715).
Evaluated relational algebra for predicate _#stmtsMerge_Location::Location.getStartLine/0#d54f9e6c_TranslatedAssertion::hasAVariable/3#76a1d6b7__#shared@4cb5aa3e with tuple counts:
        523974  ~3%    {2} r1 = SCAN stmts OUTPUT In.2, In.0
        523974  ~0%    {2}    | JOIN WITH `Location::Location.getStartLine/0#d54f9e6c` ON FIRST 1 OUTPUT Lhs.1, Rhs.1
          1320  ~0%    {4}    | JOIN WITH `project#TranslatedAssertion::foo/4#c1510ca9_102#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.0, Lhs.1, Rhs.2
          8454  ~3%    {5}    | JOIN WITH `TranslatedAssertion::hasAVariable/3#76a1d6b7` ON FIRST 2 OUTPUT Lhs.3, Rhs.2, Lhs.1, Lhs.2, Lhs.0
           863  ~0%    {6}    | JOIN WITH `TranslatedAssertion::hasNameAndParentScope/3#9c2e3c4b` ON FIRST 2 OUTPUT Rhs.2, Lhs.2, Lhs.3, Lhs.4, Lhs.0, Lhs.1
           863  ~0%    {7}    | JOIN WITH `Variable::Variable.getLocation/0#dispred#ffcb49bd` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5, Lhs.0
           863  ~2%    {7}    | JOIN WITH `Location::Location.getStartLine/0#d54f9e6c` ON FIRST 1 OUTPUT Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5, Lhs.6, Rhs.1
           715  ~2%    {7}    | REWRITE WITH TEST InOut.6 < InOut.1
                       return r1

[2026-04-23 12:03:17] Evaluated non-recursive predicate __#stmtsMerge_Location::Location.getStartLine/0#d54f9e6c_TranslatedAssertion::hasAVariable/3#76a1d6b__#unique_range@03333d50 in 0ms (size: 715).
Evaluated relational algebra for predicate __#stmtsMerge_Location::Location.getStartLine/0#d54f9e6c_TranslatedAssertion::hasAVariable/3#76a1d6b__#unique_range@03333d50 with tuple counts:
        715  ~0%    {5} r1 = SCAN `_#stmtsMerge_Location::Location.getStartLine/0#d54f9e6c_TranslatedAssertion::hasAVariable/3#76a1d6b7__#shared` OUTPUT In.0, In.2, In.3, In.5, In.4
                    return r1

[2026-04-23 12:03:17] Evaluated non-recursive predicate __#stmtsMerge_Location::Location.getStartLine/0#d54f9e6c_TranslatedAssertion::hasAVariable/3#76a1d6b__#unique_term@2cb192ht in 0ms (size: 715).
Evaluated relational algebra for predicate __#stmtsMerge_Location::Location.getStartLine/0#d54f9e6c_TranslatedAssertion::hasAVariable/3#76a1d6b__#unique_term@2cb192ht with tuple counts:
        715  ~0%    {6} r1 = SCAN `_#stmtsMerge_Location::Location.getStartLine/0#d54f9e6c_TranslatedAssertion::hasAVariable/3#76a1d6b7__#shared` OUTPUT In.0, In.2, In.3, In.5, In.4, In.5
                    return r1

[2026-04-23 12:03:17] Evaluated non-recursive predicate TranslatedAssertion::foo/4#c1510ca9_0231#join_rhs@38b0d20b in 0ms (size: 1320).
Evaluated relational algebra for predicate TranslatedAssertion::foo/4#c1510ca9_0231#join_rhs@38b0d20b with tuple counts:
        1320  ~0%    {4} r1 = SCAN `TranslatedAssertion::foo/4#c1510ca9` OUTPUT In.0, In.2, In.3, In.1
                     return r1

[2026-04-23 12:03:17] Found predicate Variable::LocalScopeVariable#3aae4a09@f207e3e9 in the relation cache (size: 380828)
[2026-04-23 12:03:17] Evaluated non-recursive predicate TranslatedAssertion::getVariable/2#f24612a9@3cd966nd in 0ms (size: 466).
Evaluated relational algebra for predicate TranslatedAssertion::getVariable/2#f24612a9@3cd966nd with tuple counts:
        709  ~3%    {4} r1 = AGGREGATE `__#stmtsMerge_Location::Location.getStartLine/0#d54f9e6c_TranslatedAssertion::hasAVariable/3#76a1d6b__#unique_range`, `__#stmtsMerge_Location::Location.getStartLine/0#d54f9e6c_TranslatedAssertion::hasAVariable/3#76a1d6b__#unique_term` ON In.5 WITH UNIQUE OUTPUT In.0, In.1, In.2, Agg.0
        709  ~3%    {4}    | SCAN OUTPUT In.3, In.0, In.1, In.2
        466  ~0%    {4}    | JOIN WITH Variable::LocalScopeVariable#3aae4a09 ON FIRST 1 OUTPUT Lhs.2, Lhs.1, Lhs.3, Lhs.0
        466  ~0%    {3}    | JOIN WITH `TranslatedAssertion::foo/4#c1510ca9_0231#join_rhs` ON FIRST 3 OUTPUT Lhs.0, Rhs.3, Lhs.3
                    return r1
```