### PR TITLE
Add MaDs for Apache Avro

### DIFF
--- a/java/ql/lib/change-notes/2026-05-19-avro-mads.md
+++ b/java/ql/lib/change-notes/2026-05-19-avro-mads.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added LLM-generated source and sink models for `org.apache.avro`.

--- a/java/ql/lib/ext/generated/llmgenerator/org.apache.avro.file.model.yml
+++ b/java/ql/lib/ext/generated/llmgenerator/org.apache.avro.file.model.yml
@@ -1,0 +1,29 @@
+# THIS FILE IS AN AUTO-GENERATED MODELS AS DATA FILE. DO NOT EDIT.
+# Generated from https://github.com/apache/avro.git#68da8fb99da5c482f17853e01e79f714e3717b42 by codeql-mads-via-llm
+extensions:
+  - addsTo:
+      pack: codeql/java-all
+      extensible: sinkModel
+    data:
+      - ["org.apache.avro.file", "DataFileReader", True, "openReader", "(File,DatumReader)", "", "Argument[0]", "path-injection", "ai-generated"]
+      - ["org.apache.avro.file", "DataFileWriter", True, "appendTo", "(File)", "", "Argument[0]", "path-injection", "ai-generated"]
+      - ["org.apache.avro.file", "DataFileWriter", True, "create", "(Schema,File)", "", "Argument[1]", "path-injection", "ai-generated"]
+      - ["org.apache.avro.file", "SeekableFileInput", True, "SeekableFileInput", "(File)", "", "Argument[0]", "path-injection", "ai-generated"]
+      - ["org.apache.avro.file", "SyncableFileOutputStream", True, "SyncableFileOutputStream", "(File)", "", "Argument[0]", "path-injection", "ai-generated"]
+      - ["org.apache.avro.file", "SyncableFileOutputStream", True, "SyncableFileOutputStream", "(File,boolean)", "", "Argument[0]", "path-injection", "ai-generated"]
+      - ["org.apache.avro.file", "SyncableFileOutputStream", True, "SyncableFileOutputStream", "(String)", "", "Argument[0]", "path-injection", "ai-generated"]
+      - ["org.apache.avro.file", "SyncableFileOutputStream", True, "SyncableFileOutputStream", "(String,boolean)", "", "Argument[0]", "path-injection", "ai-generated"]
+  - addsTo:
+      pack: codeql/java-all
+      extensible: sourceModel
+    data:
+      - ["org.apache.avro.file", "DataFileReader12", True, "getMeta", "(String)", "", "ReturnValue", "file", "ai-generated"]
+      - ["org.apache.avro.file", "DataFileReader12", True, "getMetaString", "(String)", "", "ReturnValue", "file", "ai-generated"]
+      - ["org.apache.avro.file", "DataFileReader12", True, "next", "()", "", "ReturnValue", "file", "ai-generated"]
+      - ["org.apache.avro.file", "DataFileReader12", True, "next", "(Object)", "", "ReturnValue", "file", "ai-generated"]
+      - ["org.apache.avro.file", "DataFileStream", True, "getMeta", "(String)", "", "ReturnValue", "file", "ai-generated"]
+      - ["org.apache.avro.file", "DataFileStream", True, "getMetaString", "(String)", "", "ReturnValue", "file", "ai-generated"]
+      - ["org.apache.avro.file", "DataFileStream", True, "next", "()", "", "ReturnValue", "file", "ai-generated"]
+      - ["org.apache.avro.file", "DataFileStream", True, "next", "(Object)", "", "ReturnValue", "file", "ai-generated"]
+      - ["org.apache.avro.file", "DataFileStream", True, "nextBlock", "()", "", "ReturnValue", "file", "ai-generated"]
+      - ["org.apache.avro.file", "FileReader", True, "next", "(Object)", "", "ReturnValue", "file", "ai-generated"]

--- a/java/ql/lib/ext/generated/llmgenerator/org.apache.avro.model.yml
+++ b/java/ql/lib/ext/generated/llmgenerator/org.apache.avro.model.yml
@@ -1,0 +1,29 @@
+# THIS FILE IS AN AUTO-GENERATED MODELS AS DATA FILE. DO NOT EDIT.
+# Generated from https://github.com/apache/avro.git#68da8fb99da5c482f17853e01e79f714e3717b42 by codeql-mads-via-llm
+extensions:
+  - addsTo:
+      pack: codeql/java-all
+      extensible: sinkModel
+    data:
+      - ["org.apache.avro", "Protocol", True, "parse", "(File)", "", "Argument[0]", "path-injection", "ai-generated"]
+      - ["org.apache.avro", "Schema", True, "parse", "(File)", "", "Argument[0]", "path-injection", "ai-generated"]
+      - ["org.apache.avro", "Schema$Parser", True, "parse", "(File)", "", "Argument[0]", "path-injection", "ai-generated"]
+      - ["org.apache.avro", "SchemaParser", True, "parse", "(File)", "", "Argument[0]", "path-injection", "ai-generated"]
+      - ["org.apache.avro", "SchemaParser", True, "parse", "(File,Charset)", "", "Argument[0]", "path-injection", "ai-generated"]
+      - ["org.apache.avro", "SchemaParser", True, "parse", "(Path)", "", "Argument[0]", "path-injection", "ai-generated"]
+      - ["org.apache.avro", "SchemaParser", True, "parse", "(Path,Charset)", "", "Argument[0]", "path-injection", "ai-generated"]
+      - ["org.apache.avro", "SchemaParser", True, "parse", "(URI,Charset)", "", "Argument[0]", "path-injection", "ai-generated"]
+      - ["org.apache.avro", "SchemaParser", True, "parse", "(URI,Charset)", "", "Argument[0]", "request-forgery", "ai-generated"]
+      - ["org.apache.avro", "SchemaParser", True, "parseSingle", "(Path)", "", "Argument[0]", "path-injection", "ai-generated"]
+  - addsTo:
+      pack: codeql/java-all
+      extensible: sourceModel
+    data:
+      - ["org.apache.avro", "Protocol", True, "parse", "(File)", "", "ReturnValue", "file", "ai-generated"]
+      - ["org.apache.avro", "Schema", True, "parse", "(File)", "", "ReturnValue", "file", "ai-generated"]
+      - ["org.apache.avro", "SchemaParser", True, "parse", "(File)", "", "ReturnValue", "file", "ai-generated"]
+      - ["org.apache.avro", "SchemaParser", True, "parse", "(File,Charset)", "", "ReturnValue", "file", "ai-generated"]
+      - ["org.apache.avro", "SchemaParser", True, "parse", "(Path)", "", "ReturnValue", "file", "ai-generated"]
+      - ["org.apache.avro", "SchemaParser", True, "parse", "(Path,Charset)", "", "ReturnValue", "file", "ai-generated"]
+      - ["org.apache.avro", "SchemaParser", True, "parse", "(URI,Charset)", "", "ReturnValue", "remote", "ai-generated"]
+      - ["org.apache.avro", "SchemaParser", True, "parseSingle", "(Path)", "", "ReturnValue", "file", "ai-generated"]

--- a/java/ql/lib/ext/generated/llmgenerator/org.apache.avro.util.model.yml
+++ b/java/ql/lib/ext/generated/llmgenerator/org.apache.avro.util.model.yml
@@ -1,0 +1,8 @@
+# THIS FILE IS AN AUTO-GENERATED MODELS AS DATA FILE. DO NOT EDIT.
+# Generated from https://github.com/apache/avro.git#68da8fb99da5c482f17853e01e79f714e3717b42 by codeql-mads-via-llm
+extensions:
+  - addsTo:
+      pack: codeql/java-all
+      extensible: sourceModel
+    data:
+      - ["org.apache.avro.util", "RandomData", True, "main", "(String[])", "", "Argument[0]", "commandargs", "ai-generated"]


### PR DESCRIPTION
Add Models as Data for the Java version of [Apache Avro](https://avro.apache.org/). This is based on this [subfolder/commit](https://github.com/apache/avro/tree/68da8fb99da5c482f17853e01e79f714e3717b42/lang/java/avro/src/main/java).

This is entirely LLM-generated and is _not_ meant to fully cover the library. I am curious for any feedback on this. We also need to decide if the provenance is OK or if there is a better name.