### PR TITLE
Rust: pin integration test toolchain to 1.94.1

### DIFF
--- a/rust/ql/integration-tests/conftest.py
+++ b/rust/ql/integration-tests/conftest.py
@@ -1,8 +1,33 @@
+import textwrap
+
 import pytest
 import json
 import commands
 import pathlib
 import tomllib
+
+# Last known Rust version that doesn't cause integration test failures.
+# TODO: remove this pinning once we figure out what's going wrong with newer versions.
+_PINNED_TOOLCHAIN = "1.94.1"
+
+
+@pytest.fixture(autouse=True)
+def _pin_rust_toolchain(cwd):
+    """Pin the Rust toolchain for integration tests.
+
+    Integration tests run from temporary directories, so they don't pick up
+    rust-toolchain.toml via rustup's file-based resolution. Writing the file
+    into the test's working directory ensures a consistent toolchain version
+    regardless of what is pre-installed on the runner image.
+
+    The toolchain must be pre-installed by the CI prepare action to avoid
+    concurrent rustup installs from parallel pytest-xdist workers.
+    """
+    (cwd / "rust-toolchain.toml").write_text(textwrap.dedent(f"""\
+        [toolchain]
+        channel = "{_PINNED_TOOLCHAIN}"
+        components = ["rust-src"]
+    """))
 
 
 @pytest.fixture(params=[2018, 2021, 2024])
@@ -33,7 +58,7 @@ def cargo(cwd, rust_edition):
 
 @pytest.fixture(scope="session")
 def rust_sysroot_src() -> str:
-    rust_sysroot = pathlib.Path(commands.run("rustc --print sysroot", _capture=True))
+    rust_sysroot = pathlib.Path(commands.run(f"rustc +{_PINNED_TOOLCHAIN} --print sysroot", _capture=True))
     ret = rust_sysroot.joinpath("lib", "rustlib", "src", "rust", "library")
     assert ret.exists()
     return str(ret)


### PR DESCRIPTION
Pin the Rust toolchain used by integration tests to 1.94.1 to prevent breakage from runner images that ship newer versions.

### Changes

- **`rust/ql/integration-tests/conftest.py`**:
  - Add autouse `_pin_rust_toolchain` fixture that writes a `rust-toolchain.toml` (pinned to 1.94.1 with `rust-src` component) into each test's working directory
  - Update `rust_sysroot_src` to use `rustc +1.94.1` and explicitly ensure `rust-src` is installed

No changes to `rust/ql/test/rust-toolchain.toml` — QL language tests are unaffected.