### PR TITLE
C++: Add `Strsafe.h` models

### DIFF
--- a/cpp/ql/lib/change-notes/2026-04-28-strsafe.md
+++ b/cpp/ql/lib/change-notes/2026-04-28-strsafe.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added taint flow models for the `Strsafe.h` header from the Windows SDK.

--- a/cpp/ql/lib/ext/Strsafe.model.yml
+++ b/cpp/ql/lib/ext/Strsafe.model.yml
@@ -1,0 +1,94 @@
+# Models for strsafe.h safe string functions
+extensions:
+  - addsTo:
+      pack: codeql/cpp-all
+      extensible: sourceModel
+    data: # namespace, type, subtypes, name, signature, ext, output, kind, provenance
+      # StringCchGets: (pszDest, cchDest)
+      - ["", "", False, "StringCchGetsA", "", "", "Argument[*0]", "local", "manual"]
+      - ["", "", False, "StringCchGetsW", "", "", "Argument[*0]", "local", "manual"]
+      # StringCbGets: (pszDest, cbDest)
+      - ["", "", False, "StringCbGetsA", "", "", "Argument[*0]", "local", "manual"]
+      - ["", "", False, "StringCbGetsW", "", "", "Argument[*0]", "local", "manual"]
+      # StringCchGetsEx: (pszDest, cchDest, ppszDestEnd, pcchRemaining, dwFlags)
+      - ["", "", False, "StringCchGetsExA", "", "", "Argument[*0]", "local", "manual"]
+      - ["", "", False, "StringCchGetsExW", "", "", "Argument[*0]", "local", "manual"]
+      # StringCbGetsEx: (pszDest, cbDest, ppszDestEnd, pcbRemaining, dwFlags)
+      - ["", "", False, "StringCbGetsExA", "", "", "Argument[*0]", "local", "manual"]
+      - ["", "", False, "StringCbGetsExW", "", "", "Argument[*0]", "local", "manual"]
+  - addsTo:
+      pack: codeql/cpp-all
+      extensible: summaryModel
+    data: # namespace, type, subtypes, name, signature, ext, input, output, kind, provenance
+      # StringCchCopy: (pszDest, cchDest, pszSrc)
+      - ["", "", False, "StringCchCopyA", "", "", "Argument[*2]", "Argument[*0]", "taint", "manual"]
+      - ["", "", False, "StringCchCopyW", "", "", "Argument[*2]", "Argument[*0]", "taint", "manual"]
+      # StringCbCopy: (pszDest, cbDest, pszSrc)
+      - ["", "", False, "StringCbCopyA", "", "", "Argument[*2]", "Argument[*0]", "taint", "manual"]
+      - ["", "", False, "StringCbCopyW", "", "", "Argument[*2]", "Argument[*0]", "taint", "manual"]
+      # StringCchCopyEx: (pszDest, cchDest, pszSrc, ppszDestEnd, pcchRemaining, dwFlags)
+      - ["", "", False, "StringCchCopyExA", "", "", "Argument[*2]", "Argument[*0]", "taint", "manual"]
+      - ["", "", False, "StringCchCopyExW", "", "", "Argument[*2]", "Argument[*0]", "taint", "manual"]
+      # StringCbCopyEx: (pszDest, cbDest, pszSrc, ppszDestEnd, pcbRemaining, dwFlags)
+      - ["", "", False, "StringCbCopyExA", "", "", "Argument[*2]", "Argument[*0]", "taint", "manual"]
+      - ["", "", False, "StringCbCopyExW", "", "", "Argument[*2]", "Argument[*0]", "taint", "manual"]
+      # StringCchCopyN: (pszDest, cchDest, pszSrc, cchToCopy)
+      - ["", "", False, "StringCchCopyNA", "", "", "Argument[*2]", "Argument[*0]", "taint", "manual"]
+      - ["", "", False, "StringCchCopyNW", "", "", "Argument[*2]", "Argument[*0]", "taint", "manual"]
+      # StringCbCopyN: (pszDest, cbDest, pszSrc, cbToCopy)
+      - ["", "", False, "StringCbCopyNA", "", "", "Argument[*2]", "Argument[*0]", "taint", "manual"]
+      - ["", "", False, "StringCbCopyNW", "", "", "Argument[*2]", "Argument[*0]", "taint", "manual"]
+      # StringCchCopyNEx: (pszDest, cchDest, pszSrc, cchToCopy, ppszDestEnd, pcchRemaining, dwFlags)
+      - ["", "", False, "StringCchCopyNExA", "", "", "Argument[*2]", "Argument[*0]", "taint", "manual"]
+      - ["", "", False, "StringCchCopyNExW", "", "", "Argument[*2]", "Argument[*0]", "taint", "manual"]
+      # StringCbCopyNEx: (pszDest, cbDest, pszSrc, cbToCopy, ppszDestEnd, pcbRemaining, dwFlags)
+      - ["", "", False, "StringCbCopyNExA", "", "", "Argument[*2]", "Argument[*0]", "taint", "manual"]
+      - ["", "", False, "StringCbCopyNExW", "", "", "Argument[*2]", "Argument[*0]", "taint", "manual"]
+      # StringCchCat: (pszDest, cchDest, pszSrc)
+      - ["", "", False, "StringCchCatA", "", "", "Argument[*2]", "Argument[*0]", "taint", "manual"]
+      - ["", "", False, "StringCchCatW", "", "", "Argument[*2]", "Argument[*0]", "taint", "manual"]
+      # StringCbCat: (pszDest, cbDest, pszSrc)
+      - ["", "", False, "StringCbCatA", "", "", "Argument[*2]", "Argument[*0]", "taint", "manual"]
+      - ["", "", False, "StringCbCatW", "", "", "Argument[*2]", "Argument[*0]", "taint", "manual"]
+      # StringCchCatEx: (pszDest, cchDest, pszSrc, ppszDestEnd, pcchRemaining, dwFlags)
+      - ["", "", False, "StringCchCatExA", "", "", "Argument[*2]", "Argument[*0]", "taint", "manual"]
+      - ["", "", False, "StringCchCatExW", "", "", "Argument[*2]", "Argument[*0]", "taint", "manual"]
+      # StringCbCatEx: (pszDest, cbDest, pszSrc, ppszDestEnd, pcbRemaining, dwFlags)
+      - ["", "", False, "StringCbCatExA", "", "", "Argument[*2]", "Argument[*0]", "taint", "manual"]
+      - ["", "", False, "StringCbCatExW", "", "", "Argument[*2]", "Argument[*0]", "taint", "manual"]
+      # StringCchCatN: (pszDest, cchDest, pszSrc, cchToAppend)
+      - ["", "", False, "StringCchCatNA", "", "", "Argument[*2]", "Argument[*0]", "taint", "manual"]
+      - ["", "", False, "StringCchCatNW", "", "", "Argument[*2]", "Argument[*0]", "taint", "manual"]
+      # StringCbCatN: (pszDest, cbDest, pszSrc, cbToAppend)
+      - ["", "", False, "StringCbCatNA", "", "", "Argument[*2]", "Argument[*0]", "taint", "manual"]
+      - ["", "", False, "StringCbCatNW", "", "", "Argument[*2]", "Argument[*0]", "taint", "manual"]
+      # StringCchCatNEx: (pszDest, cchDest, pszSrc, cchToAppend, ppszDestEnd, pcchRemaining, dwFlags)
+      - ["", "", False, "StringCchCatNExA", "", "", "Argument[*2]", "Argument[*0]", "taint", "manual"]
+      - ["", "", False, "StringCchCatNExW", "", "", "Argument[*2]", "Argument[*0]", "taint", "manual"]
+      # StringCbCatNEx: (pszDest, cbDest, pszSrc, cbToAppend, ppszDestEnd, pcbRemaining, dwFlags)
+      - ["", "", False, "StringCbCatNExA", "", "", "Argument[*2]", "Argument[*0]", "taint", "manual"]
+      - ["", "", False, "StringCbCatNExW", "", "", "Argument[*2]", "Argument[*0]", "taint", "manual"]
+      # StringCchPrintf: (pszDest, cchDest, pszFormat, ...)
+      - ["", "", False, "StringCchPrintfA", "", "", "Argument[*2..8]", "Argument[*0]", "taint", "manual"]
+      - ["", "", False, "StringCchPrintfW", "", "", "Argument[*2..8]", "Argument[*0]", "taint", "manual"]
+      # StringCbPrintf: (pszDest, cbDest, pszFormat, ...)
+      - ["", "", False, "StringCbPrintfA", "", "", "Argument[*2..8]", "Argument[*0]", "taint", "manual"]
+      - ["", "", False, "StringCbPrintfW", "", "", "Argument[*2..8]", "Argument[*0]", "taint", "manual"]
+      # StringCchPrintfEx: (pszDest, cchDest, ppszDestEnd, pcchRemaining, dwFlags, pszFormat, ...)
+      - ["", "", False, "StringCchPrintfExA", "", "", "Argument[*5..11]", "Argument[*0]", "taint", "manual"]
+      - ["", "", False, "StringCchPrintfExW", "", "", "Argument[*5..11]", "Argument[*0]", "taint", "manual"]
+      # StringCbPrintfEx: (pszDest, cbDest, ppszDestEnd, pcbRemaining, dwFlags, pszFormat, ...)
+      - ["", "", False, "StringCbPrintfExA", "", "", "Argument[*5..11]", "Argument[*0]", "taint", "manual"]
+      - ["", "", False, "StringCbPrintfExW", "", "", "Argument[*5..11]", "Argument[*0]", "taint", "manual"]
+      # StringCchVPrintf: (pszDest, cchDest, pszFormat, argList)
+      - ["", "", False, "StringCchVPrintfA", "", "", "Argument[*2]", "Argument[*0]", "taint", "manual"]
+      - ["", "", False, "StringCchVPrintfW", "", "", "Argument[*2]", "Argument[*0]", "taint", "manual"]
+      # StringCbVPrintf: (pszDest, cbDest, pszFormat, argList)
+      - ["", "", False, "StringCbVPrintfA", "", "", "Argument[*2]", "Argument[*0]", "taint", "manual"]
+      - ["", "", False, "StringCbVPrintfW", "", "", "Argument[*2]", "Argument[*0]", "taint", "manual"]
+      # StringCchVPrintfEx: (pszDest, cchDest, ppszDestEnd, pcchRemaining, dwFlags, pszFormat, argList)
+      - ["", "", False, "StringCchVPrintfExA", "", "", "Argument[*5]", "Argument[*0]", "taint", "manual"]
+      - ["", "", False, "StringCchVPrintfExW", "", "", "Argument[*5]", "Argument[*0]", "taint", "manual"]
+      # StringCbVPrintfEx: (pszDest, cbDest, ppszDestEnd, pcbRemaining, dwFlags, pszFormat, argList)
+      - ["", "", False, "StringCbVPrintfExA", "", "", "Argument[*5]", "Argument[*0]", "taint", "manual"]
+      - ["", "", False, "StringCbVPrintfExW", "", "", "Argument[*5]", "Argument[*0]", "taint", "manual"]

--- a/cpp/ql/test/library-tests/dataflow/source-sink-tests/sources-and-sinks.cpp
+++ b/cpp/ql/test/library-tests/dataflow/source-sink-tests/sources-and-sinks.cpp
@@ -122,12 +122,12 @@ long StringCchGetsExA(char *, size_t, char **, size_t *, unsigned long);
 void test_strsafe_gets() {
 	{
 		char dest[256] = {0};
-		StringCchGetsA(dest, sizeof(dest)); // $ MISSING: local_source
+		StringCchGetsA(dest, sizeof(dest)); // $ local_source
 	}
 	{
 		char dest[256] = {0};
 		char *end;
 		size_t remaining;
-		StringCchGetsExA(dest, sizeof(dest), &end, &remaining, 0); // $ MISSING: local_source
+		StringCchGetsExA(dest, sizeof(dest), &end, &remaining, 0); // $ local_source
 	}
 }

--- a/cpp/ql/test/library-tests/dataflow/source-sink-tests/sources-and-sinks.cpp
+++ b/cpp/ql/test/library-tests/dataflow/source-sink-tests/sources-and-sinks.cpp
@@ -115,3 +115,19 @@ void test_zmc(void *socket) {
     // ...
   }
 }
+
+long StringCchGetsA(char *, size_t);
+long StringCchGetsExA(char *, size_t, char **, size_t *, unsigned long);
+
+void test_strsafe_gets() {
+	{
+		char dest[256] = {0};
+		StringCchGetsA(dest, sizeof(dest)); // $ MISSING: local_source
+	}
+	{
+		char dest[256] = {0};
+		char *end;
+		size_t remaining;
+		StringCchGetsExA(dest, sizeof(dest), &end, &remaining, 0); // $ MISSING: local_source
+	}
+}

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -8008,6 +8008,174 @@ WARNING: module 'TaintTracking' has been deprecated and may be removed in future
 | taint.cpp:866:26:866:34 | ref arg & ... | taint.cpp:866:27:866:34 | size_out [inner post update] |  |
 | taint.cpp:866:27:866:34 | size_out | taint.cpp:866:26:866:34 | & ... |  |
 | taint.cpp:867:8:867:8 | p | taint.cpp:867:7:867:8 | * ... | TAINT |
+| taint.cpp:892:17:892:31 | call to indirect_source | taint.cpp:897:38:897:43 | source |  |
+| taint.cpp:892:17:892:31 | call to indirect_source | taint.cpp:907:37:907:42 | source |  |
+| taint.cpp:892:17:892:31 | call to indirect_source | taint.cpp:914:40:914:45 | source |  |
+| taint.cpp:892:17:892:31 | call to indirect_source | taint.cpp:919:39:919:44 | source |  |
+| taint.cpp:892:17:892:31 | call to indirect_source | taint.cpp:926:41:926:46 | source |  |
+| taint.cpp:892:17:892:31 | call to indirect_source | taint.cpp:931:37:931:42 | source |  |
+| taint.cpp:892:17:892:31 | call to indirect_source | taint.cpp:941:36:941:41 | source |  |
+| taint.cpp:892:17:892:31 | call to indirect_source | taint.cpp:948:39:948:44 | source |  |
+| taint.cpp:892:17:892:31 | call to indirect_source | taint.cpp:953:38:953:43 | source |  |
+| taint.cpp:892:17:892:31 | call to indirect_source | taint.cpp:960:40:960:45 | source |  |
+| taint.cpp:892:17:892:31 | call to indirect_source | taint.cpp:965:46:965:51 | source |  |
+| taint.cpp:892:17:892:31 | call to indirect_source | taint.cpp:975:45:975:50 | source |  |
+| taint.cpp:892:17:892:31 | call to indirect_source | taint.cpp:982:69:982:74 | source |  |
+| taint.cpp:893:32:893:46 | call to indirect_source | taint.cpp:902:38:902:44 | wsource |  |
+| taint.cpp:893:32:893:46 | call to indirect_source | taint.cpp:936:37:936:43 | wsource |  |
+| taint.cpp:893:32:893:46 | call to indirect_source | taint.cpp:970:47:970:53 | wsource |  |
+| taint.cpp:896:19:896:22 | {...} | taint.cpp:897:18:897:21 | dest |  |
+| taint.cpp:896:19:896:22 | {...} | taint.cpp:897:31:897:34 | dest |  |
+| taint.cpp:896:19:896:22 | {...} | taint.cpp:898:9:898:12 | dest |  |
+| taint.cpp:896:21:896:21 | 0 | taint.cpp:896:19:896:22 | {...} | TAINT |
+| taint.cpp:897:18:897:21 | ref arg dest | taint.cpp:898:9:898:12 | dest |  |
+| taint.cpp:898:9:898:12 | dest | taint.cpp:898:8:898:12 | * ... |  |
+| taint.cpp:901:22:901:25 | {...} | taint.cpp:902:18:902:21 | dest |  |
+| taint.cpp:901:22:901:25 | {...} | taint.cpp:902:31:902:34 | dest |  |
+| taint.cpp:901:22:901:25 | {...} | taint.cpp:903:9:903:12 | dest |  |
+| taint.cpp:901:24:901:24 | 0 | taint.cpp:901:22:901:25 | {...} | TAINT |
+| taint.cpp:902:18:902:21 | ref arg dest | taint.cpp:903:9:903:12 | dest |  |
+| taint.cpp:903:9:903:12 | dest | taint.cpp:903:8:903:12 | * ... |  |
+| taint.cpp:906:19:906:22 | {...} | taint.cpp:907:17:907:20 | dest |  |
+| taint.cpp:906:19:906:22 | {...} | taint.cpp:907:30:907:33 | dest |  |
+| taint.cpp:906:19:906:22 | {...} | taint.cpp:908:9:908:12 | dest |  |
+| taint.cpp:906:21:906:21 | 0 | taint.cpp:906:19:906:22 | {...} | TAINT |
+| taint.cpp:907:17:907:20 | ref arg dest | taint.cpp:908:9:908:12 | dest |  |
+| taint.cpp:908:9:908:12 | dest | taint.cpp:908:8:908:12 | * ... |  |
+| taint.cpp:911:19:911:22 | {...} | taint.cpp:914:20:914:23 | dest |  |
+| taint.cpp:911:19:911:22 | {...} | taint.cpp:914:33:914:36 | dest |  |
+| taint.cpp:911:19:911:22 | {...} | taint.cpp:915:9:915:12 | dest |  |
+| taint.cpp:911:21:911:21 | 0 | taint.cpp:911:19:911:22 | {...} | TAINT |
+| taint.cpp:912:9:912:11 | end | taint.cpp:914:49:914:51 | end |  |
+| taint.cpp:913:10:913:18 | remaining | taint.cpp:914:55:914:63 | remaining |  |
+| taint.cpp:914:20:914:23 | ref arg dest | taint.cpp:915:9:915:12 | dest |  |
+| taint.cpp:914:48:914:51 | ref arg & ... | taint.cpp:914:49:914:51 | end [inner post update] |  |
+| taint.cpp:914:49:914:51 | end | taint.cpp:914:48:914:51 | & ... |  |
+| taint.cpp:914:54:914:63 | ref arg & ... | taint.cpp:914:55:914:63 | remaining [inner post update] |  |
+| taint.cpp:914:55:914:63 | remaining | taint.cpp:914:54:914:63 | & ... |  |
+| taint.cpp:915:9:915:12 | dest | taint.cpp:915:8:915:12 | * ... |  |
+| taint.cpp:918:19:918:22 | {...} | taint.cpp:919:19:919:22 | dest |  |
+| taint.cpp:918:19:918:22 | {...} | taint.cpp:919:32:919:35 | dest |  |
+| taint.cpp:918:19:918:22 | {...} | taint.cpp:920:9:920:12 | dest |  |
+| taint.cpp:918:21:918:21 | 0 | taint.cpp:918:19:918:22 | {...} | TAINT |
+| taint.cpp:919:19:919:22 | ref arg dest | taint.cpp:920:9:920:12 | dest |  |
+| taint.cpp:920:9:920:12 | dest | taint.cpp:920:8:920:12 | * ... |  |
+| taint.cpp:923:19:923:22 | {...} | taint.cpp:926:21:926:24 | dest |  |
+| taint.cpp:923:19:923:22 | {...} | taint.cpp:926:34:926:37 | dest |  |
+| taint.cpp:923:19:923:22 | {...} | taint.cpp:927:8:927:11 | dest |  |
+| taint.cpp:923:21:923:21 | 0 | taint.cpp:923:19:923:22 | {...} | TAINT |
+| taint.cpp:924:9:924:11 | end | taint.cpp:926:55:926:57 | end |  |
+| taint.cpp:925:10:925:18 | remaining | taint.cpp:926:61:926:69 | remaining |  |
+| taint.cpp:926:21:926:24 | ref arg dest | taint.cpp:927:8:927:11 | dest |  |
+| taint.cpp:926:54:926:57 | ref arg & ... | taint.cpp:926:55:926:57 | end [inner post update] |  |
+| taint.cpp:926:55:926:57 | end | taint.cpp:926:54:926:57 | & ... |  |
+| taint.cpp:926:60:926:69 | ref arg & ... | taint.cpp:926:61:926:69 | remaining [inner post update] |  |
+| taint.cpp:926:61:926:69 | remaining | taint.cpp:926:60:926:69 | & ... |  |
+| taint.cpp:930:20:930:27 | prefix | taint.cpp:931:17:931:20 | dest |  |
+| taint.cpp:930:20:930:27 | prefix | taint.cpp:931:30:931:33 | dest |  |
+| taint.cpp:930:20:930:27 | prefix | taint.cpp:932:9:932:12 | dest |  |
+| taint.cpp:931:17:931:20 | ref arg dest | taint.cpp:932:9:932:12 | dest |  |
+| taint.cpp:932:9:932:12 | dest | taint.cpp:932:8:932:12 | * ... |  |
+| taint.cpp:935:23:935:31 | prefix | taint.cpp:936:17:936:20 | dest |  |
+| taint.cpp:935:23:935:31 | prefix | taint.cpp:936:30:936:33 | dest |  |
+| taint.cpp:935:23:935:31 | prefix | taint.cpp:937:9:937:12 | dest |  |
+| taint.cpp:936:17:936:20 | ref arg dest | taint.cpp:937:9:937:12 | dest |  |
+| taint.cpp:937:9:937:12 | dest | taint.cpp:937:8:937:12 | * ... |  |
+| taint.cpp:940:20:940:27 | prefix | taint.cpp:941:16:941:19 | dest |  |
+| taint.cpp:940:20:940:27 | prefix | taint.cpp:941:29:941:32 | dest |  |
+| taint.cpp:940:20:940:27 | prefix | taint.cpp:942:9:942:12 | dest |  |
+| taint.cpp:941:16:941:19 | ref arg dest | taint.cpp:942:9:942:12 | dest |  |
+| taint.cpp:942:9:942:12 | dest | taint.cpp:942:8:942:12 | * ... |  |
+| taint.cpp:945:20:945:27 | prefix | taint.cpp:948:19:948:22 | dest |  |
+| taint.cpp:945:20:945:27 | prefix | taint.cpp:948:32:948:35 | dest |  |
+| taint.cpp:945:20:945:27 | prefix | taint.cpp:949:9:949:12 | dest |  |
+| taint.cpp:946:9:946:11 | end | taint.cpp:948:48:948:50 | end |  |
+| taint.cpp:947:10:947:18 | remaining | taint.cpp:948:54:948:62 | remaining |  |
+| taint.cpp:948:19:948:22 | ref arg dest | taint.cpp:949:9:949:12 | dest |  |
+| taint.cpp:948:47:948:50 | ref arg & ... | taint.cpp:948:48:948:50 | end [inner post update] |  |
+| taint.cpp:948:48:948:50 | end | taint.cpp:948:47:948:50 | & ... |  |
+| taint.cpp:948:53:948:62 | ref arg & ... | taint.cpp:948:54:948:62 | remaining [inner post update] |  |
+| taint.cpp:948:54:948:62 | remaining | taint.cpp:948:53:948:62 | & ... |  |
+| taint.cpp:949:9:949:12 | dest | taint.cpp:949:8:949:12 | * ... |  |
+| taint.cpp:952:20:952:27 | prefix | taint.cpp:953:18:953:21 | dest |  |
+| taint.cpp:952:20:952:27 | prefix | taint.cpp:953:31:953:34 | dest |  |
+| taint.cpp:952:20:952:27 | prefix | taint.cpp:954:9:954:12 | dest |  |
+| taint.cpp:953:18:953:21 | ref arg dest | taint.cpp:954:9:954:12 | dest |  |
+| taint.cpp:954:9:954:12 | dest | taint.cpp:954:8:954:12 | * ... |  |
+| taint.cpp:957:20:957:27 | prefix | taint.cpp:960:20:960:23 | dest |  |
+| taint.cpp:957:20:957:27 | prefix | taint.cpp:960:33:960:36 | dest |  |
+| taint.cpp:957:20:957:27 | prefix | taint.cpp:961:9:961:12 | dest |  |
+| taint.cpp:958:9:958:11 | end | taint.cpp:960:54:960:56 | end |  |
+| taint.cpp:959:10:959:18 | remaining | taint.cpp:960:60:960:68 | remaining |  |
+| taint.cpp:960:20:960:23 | ref arg dest | taint.cpp:961:9:961:12 | dest |  |
+| taint.cpp:960:53:960:56 | ref arg & ... | taint.cpp:960:54:960:56 | end [inner post update] |  |
+| taint.cpp:960:54:960:56 | end | taint.cpp:960:53:960:56 | & ... |  |
+| taint.cpp:960:59:960:68 | ref arg & ... | taint.cpp:960:60:960:68 | remaining [inner post update] |  |
+| taint.cpp:960:60:960:68 | remaining | taint.cpp:960:59:960:68 | & ... |  |
+| taint.cpp:961:9:961:12 | dest | taint.cpp:961:8:961:12 | * ... |  |
+| taint.cpp:964:19:964:22 | {...} | taint.cpp:965:20:965:23 | dest |  |
+| taint.cpp:964:19:964:22 | {...} | taint.cpp:965:33:965:36 | dest |  |
+| taint.cpp:964:19:964:22 | {...} | taint.cpp:966:9:966:12 | dest |  |
+| taint.cpp:964:21:964:21 | 0 | taint.cpp:964:19:964:22 | {...} | TAINT |
+| taint.cpp:965:20:965:23 | ref arg dest | taint.cpp:966:9:966:12 | dest |  |
+| taint.cpp:965:40:965:43 | %s | taint.cpp:965:20:965:23 | ref arg dest | TAINT |
+| taint.cpp:965:46:965:51 | ref arg source | taint.cpp:975:45:975:50 | source |  |
+| taint.cpp:965:46:965:51 | ref arg source | taint.cpp:982:69:982:74 | source |  |
+| taint.cpp:965:46:965:51 | source | taint.cpp:965:20:965:23 | ref arg dest | TAINT |
+| taint.cpp:966:9:966:12 | dest | taint.cpp:966:8:966:12 | * ... |  |
+| taint.cpp:969:22:969:25 | {...} | taint.cpp:970:20:970:23 | dest |  |
+| taint.cpp:969:22:969:25 | {...} | taint.cpp:970:33:970:36 | dest |  |
+| taint.cpp:969:22:969:25 | {...} | taint.cpp:971:9:971:12 | dest |  |
+| taint.cpp:969:24:969:24 | 0 | taint.cpp:969:22:969:25 | {...} | TAINT |
+| taint.cpp:970:20:970:23 | ref arg dest | taint.cpp:971:9:971:12 | dest |  |
+| taint.cpp:970:40:970:44 | %s | taint.cpp:970:20:970:23 | ref arg dest | TAINT |
+| taint.cpp:970:47:970:53 | wsource | taint.cpp:970:20:970:23 | ref arg dest | TAINT |
+| taint.cpp:971:9:971:12 | dest | taint.cpp:971:8:971:12 | * ... |  |
+| taint.cpp:974:19:974:22 | {...} | taint.cpp:975:19:975:22 | dest |  |
+| taint.cpp:974:19:974:22 | {...} | taint.cpp:975:32:975:35 | dest |  |
+| taint.cpp:974:19:974:22 | {...} | taint.cpp:976:9:976:12 | dest |  |
+| taint.cpp:974:21:974:21 | 0 | taint.cpp:974:19:974:22 | {...} | TAINT |
+| taint.cpp:975:19:975:22 | ref arg dest | taint.cpp:976:9:976:12 | dest |  |
+| taint.cpp:975:39:975:42 | %s | taint.cpp:975:19:975:22 | ref arg dest | TAINT |
+| taint.cpp:975:45:975:50 | ref arg source | taint.cpp:982:69:982:74 | source |  |
+| taint.cpp:975:45:975:50 | source | taint.cpp:975:19:975:22 | ref arg dest | TAINT |
+| taint.cpp:976:9:976:12 | dest | taint.cpp:976:8:976:12 | * ... |  |
+| taint.cpp:979:19:979:22 | {...} | taint.cpp:982:22:982:25 | dest |  |
+| taint.cpp:979:19:979:22 | {...} | taint.cpp:982:35:982:38 | dest |  |
+| taint.cpp:979:19:979:22 | {...} | taint.cpp:983:9:983:12 | dest |  |
+| taint.cpp:979:21:979:21 | 0 | taint.cpp:979:19:979:22 | {...} | TAINT |
+| taint.cpp:980:9:980:11 | end | taint.cpp:982:43:982:45 | end |  |
+| taint.cpp:981:10:981:18 | remaining | taint.cpp:982:49:982:57 | remaining |  |
+| taint.cpp:982:22:982:25 | ref arg dest | taint.cpp:983:9:983:12 | dest |  |
+| taint.cpp:982:42:982:45 | ref arg & ... | taint.cpp:982:43:982:45 | end [inner post update] |  |
+| taint.cpp:982:43:982:45 | end | taint.cpp:982:42:982:45 | & ... |  |
+| taint.cpp:982:48:982:57 | ref arg & ... | taint.cpp:982:49:982:57 | remaining [inner post update] |  |
+| taint.cpp:982:49:982:57 | remaining | taint.cpp:982:48:982:57 | & ... |  |
+| taint.cpp:982:63:982:66 | %s | taint.cpp:982:22:982:25 | ref arg dest | TAINT |
+| taint.cpp:982:69:982:74 | source | taint.cpp:982:22:982:25 | ref arg dest | TAINT |
+| taint.cpp:983:9:983:12 | dest | taint.cpp:983:8:983:12 | * ... |  |
+| taint.cpp:986:19:986:22 | {...} | taint.cpp:988:20:988:23 | dest |  |
+| taint.cpp:986:19:986:22 | {...} | taint.cpp:988:33:988:36 | dest |  |
+| taint.cpp:986:19:986:22 | {...} | taint.cpp:989:9:989:12 | dest |  |
+| taint.cpp:986:21:986:21 | 0 | taint.cpp:986:19:986:22 | {...} | TAINT |
+| taint.cpp:987:15:987:29 | call to indirect_source | taint.cpp:988:40:988:42 | fmt |  |
+| taint.cpp:988:20:988:23 | ref arg dest | taint.cpp:989:9:989:12 | dest |  |
+| taint.cpp:988:40:988:42 | fmt | taint.cpp:988:20:988:23 | ref arg dest | TAINT |
+| taint.cpp:989:9:989:12 | dest | taint.cpp:989:8:989:12 | * ... |  |
+| taint.cpp:992:19:992:22 | {...} | taint.cpp:993:20:993:23 | dest |  |
+| taint.cpp:992:19:992:22 | {...} | taint.cpp:993:33:993:36 | dest |  |
+| taint.cpp:992:19:992:22 | {...} | taint.cpp:994:9:994:12 | dest |  |
+| taint.cpp:992:21:992:21 | 0 | taint.cpp:992:19:992:22 | {...} | TAINT |
+| taint.cpp:993:20:993:23 | ref arg dest | taint.cpp:994:9:994:12 | dest |  |
+| taint.cpp:993:40:993:43 | %d | taint.cpp:993:20:993:23 | ref arg dest | TAINT |
+| taint.cpp:993:46:993:47 | 42 | taint.cpp:993:20:993:23 | ref arg dest | TAINT |
+| taint.cpp:994:9:994:12 | dest | taint.cpp:994:8:994:12 | * ... |  |
+| taint.cpp:997:19:997:22 | {...} | taint.cpp:998:18:998:21 | dest |  |
+| taint.cpp:997:19:997:22 | {...} | taint.cpp:998:31:998:34 | dest |  |
+| taint.cpp:997:19:997:22 | {...} | taint.cpp:999:9:999:12 | dest |  |
+| taint.cpp:997:21:997:21 | 0 | taint.cpp:997:19:997:22 | {...} | TAINT |
+| taint.cpp:998:18:998:21 | ref arg dest | taint.cpp:999:9:999:12 | dest |  |
+| taint.cpp:999:9:999:12 | dest | taint.cpp:999:8:999:12 | * ... |  |
 | thread.cpp:10:27:10:27 | s | thread.cpp:10:27:10:27 | s |  |
 | thread.cpp:10:27:10:27 | s | thread.cpp:11:8:11:8 | s |  |
 | thread.cpp:14:26:14:26 | s | thread.cpp:15:8:15:8 | s |  |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
@@ -866,3 +866,136 @@ void test_iconv(size_t size) {
 	iconv(0, &s, &size, &p, &size_out);
 	sink(*p); // $ ast,ir
 }
+
+using va_list = void*;
+
+long StringCchCopyA(char *, size_t, const char *);
+long StringCchCopyW(wchar_t *, size_t, const wchar_t *);
+long StringCbCopyA(char *, size_t, const char *);
+long StringCchCopyExA(char *, size_t, const char *, char **, size_t *, unsigned long);
+long StringCchCopyNA(char *, size_t, const char *, size_t);
+long StringCchCopyNExA(char *, size_t, const char *, size_t, char **, size_t *, unsigned long);
+long StringCchCatA(char *, size_t, const char *);
+long StringCchCatW(wchar_t *, size_t, const wchar_t *);
+long StringCbCatA(char *, size_t, const char *);
+long StringCchCatExA(char *, size_t, const char *, char **, size_t *, unsigned long);
+long StringCchCatNA(char *, size_t, const char *, size_t);
+long StringCchCatNExA(char *, size_t, const char *, size_t, char **, size_t *, unsigned long);
+long StringCchPrintfA(char *, size_t, const char *, ...);
+long StringCchPrintfW(wchar_t *, size_t, const wchar_t *, ...);
+long StringCbPrintfA(char *, size_t, const char *, ...);
+long StringCchPrintfExA(char *, size_t, char **, size_t *, unsigned long, const char *, ...);
+long StringCchVPrintfA(char *, size_t, const char *, va_list);
+long StringCchVPrintfExA(char *, size_t, char **, size_t *, unsigned long, const char *, va_list);
+
+void test_strsafe() {
+	char *source = indirect_source();
+	wchar_t *wsource = (wchar_t *)indirect_source();
+
+	{
+		char dest[256] = {0};
+		StringCchCopyA(dest, sizeof(dest), source);
+		sink(*dest); // $ MISSING: ir,ast
+	}
+	{
+		wchar_t dest[256] = {0};
+		StringCchCopyW(dest, sizeof(dest), wsource);
+		sink(*dest); // $ MISSING: ir,ast
+	}
+	{
+		char dest[256] = {0};
+		StringCbCopyA(dest, sizeof(dest), source);
+		sink(*dest); // $ MISSING: ir,ast
+	}
+	{
+		char dest[256] = {0};
+		char *end;
+		size_t remaining;
+		StringCchCopyExA(dest, sizeof(dest), source, &end, &remaining, 0);
+		sink(*dest); // $ MISSING: ir,ast
+	}
+	{
+		char dest[256] = {0};
+		StringCchCopyNA(dest, sizeof(dest), source, 128);
+		sink(*dest); // $ MISSING: ir,ast
+	}
+	{
+		char dest[256] = {0};
+		char *end;
+		size_t remaining;
+		StringCchCopyNExA(dest, sizeof(dest), source, 128, &end, &remaining, 0);
+		sink(dest); // $ MISSING: ir,ast
+	}
+	{
+		char dest[256] = "prefix";
+		StringCchCatA(dest, sizeof(dest), source);
+		sink(*dest); // $ MISSING: ir,ast
+	}
+	{
+		wchar_t dest[256] = L"prefix";
+		StringCchCatW(dest, sizeof(dest), wsource);
+		sink(*dest); // $ MISSING: ir,ast
+	}
+	{
+		char dest[256] = "prefix";
+		StringCbCatA(dest, sizeof(dest), source);
+		sink(*dest); // $ MISSING: ir,ast
+	}
+	{
+		char dest[256] = "prefix";
+		char *end;
+		size_t remaining;
+		StringCchCatExA(dest, sizeof(dest), source, &end, &remaining, 0);
+		sink(*dest); // $ MISSING: ir,ast
+	}
+	{
+		char dest[256] = "prefix";
+		StringCchCatNA(dest, sizeof(dest), source, 128);
+		sink(*dest); // $ MISSING: ir,ast
+	}
+	{
+		char dest[256] = "prefix";
+		char *end;
+		size_t remaining;
+		StringCchCatNExA(dest, sizeof(dest), source, 128, &end, &remaining, 0);
+		sink(*dest); // $ MISSING: ir,ast
+	}
+	{
+		char dest[256] = {0};
+		StringCchPrintfA(dest, sizeof(dest), "%s", source);
+		sink(*dest); // $ MISSING: ir,ast
+	}
+	{
+		wchar_t dest[256] = {0};
+		StringCchPrintfW(dest, sizeof(dest), L"%s", wsource);
+		sink(*dest); // $ MISSING: ir,ast
+	}
+	{
+		char dest[256] = {0};
+		StringCbPrintfA(dest, sizeof(dest), "%s", source);
+		sink(*dest); // $ MISSING: ir,ast
+	}
+	{
+		char dest[256] = {0};
+		char *end;
+		size_t remaining;
+		StringCchPrintfExA(dest, sizeof(dest), &end, &remaining, 0, "%s", source);
+		sink(*dest); // $ MISSING: ir,ast
+	}
+	{
+		char dest[256] = {0};
+		char *fmt = indirect_source();
+		StringCchPrintfA(dest, sizeof(dest), fmt);
+		sink(*dest); // $ MISSING: ir,ast
+	}
+	{
+		char dest[256] = {0};
+		StringCchPrintfA(dest, sizeof(dest), "%d", 42);
+		sink(*dest); // clean
+	}
+	{
+		char dest[256] = {0};
+		StringCchCopyA(dest, sizeof(dest), "hello");
+		sink(*dest); // clean
+	}
+}

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
@@ -895,98 +895,98 @@ void test_strsafe() {
 	{
 		char dest[256] = {0};
 		StringCchCopyA(dest, sizeof(dest), source);
-		sink(*dest); // $ MISSING: ir,ast
+		sink(*dest); // $ ir MISSING: ast
 	}
 	{
 		wchar_t dest[256] = {0};
 		StringCchCopyW(dest, sizeof(dest), wsource);
-		sink(*dest); // $ MISSING: ir,ast
+		sink(*dest); // $ ir MISSING: ast
 	}
 	{
 		char dest[256] = {0};
 		StringCbCopyA(dest, sizeof(dest), source);
-		sink(*dest); // $ MISSING: ir,ast
+		sink(*dest); // $ ir MISSING: ast
 	}
 	{
 		char dest[256] = {0};
 		char *end;
 		size_t remaining;
 		StringCchCopyExA(dest, sizeof(dest), source, &end, &remaining, 0);
-		sink(*dest); // $ MISSING: ir,ast
+		sink(*dest); // $ ir MISSING: ast
 	}
 	{
 		char dest[256] = {0};
 		StringCchCopyNA(dest, sizeof(dest), source, 128);
-		sink(*dest); // $ MISSING: ir,ast
+		sink(*dest); // $ ir MISSING: ast
 	}
 	{
 		char dest[256] = {0};
 		char *end;
 		size_t remaining;
 		StringCchCopyNExA(dest, sizeof(dest), source, 128, &end, &remaining, 0);
-		sink(dest); // $ MISSING: ir,ast
+		sink(dest); // $ ir MISSING: ast
 	}
 	{
 		char dest[256] = "prefix";
 		StringCchCatA(dest, sizeof(dest), source);
-		sink(*dest); // $ MISSING: ir,ast
+		sink(*dest); // $ ir MISSING: ast
 	}
 	{
 		wchar_t dest[256] = L"prefix";
 		StringCchCatW(dest, sizeof(dest), wsource);
-		sink(*dest); // $ MISSING: ir,ast
+		sink(*dest); // $ ir MISSING: ast
 	}
 	{
 		char dest[256] = "prefix";
 		StringCbCatA(dest, sizeof(dest), source);
-		sink(*dest); // $ MISSING: ir,ast
+		sink(*dest); // $ ir MISSING: ast
 	}
 	{
 		char dest[256] = "prefix";
 		char *end;
 		size_t remaining;
 		StringCchCatExA(dest, sizeof(dest), source, &end, &remaining, 0);
-		sink(*dest); // $ MISSING: ir,ast
+		sink(*dest); // $ ir MISSING: ast
 	}
 	{
 		char dest[256] = "prefix";
 		StringCchCatNA(dest, sizeof(dest), source, 128);
-		sink(*dest); // $ MISSING: ir,ast
+		sink(*dest); // $ ir MISSING: ast
 	}
 	{
 		char dest[256] = "prefix";
 		char *end;
 		size_t remaining;
 		StringCchCatNExA(dest, sizeof(dest), source, 128, &end, &remaining, 0);
-		sink(*dest); // $ MISSING: ir,ast
+		sink(*dest); // $ ir MISSING: ast
 	}
 	{
 		char dest[256] = {0};
 		StringCchPrintfA(dest, sizeof(dest), "%s", source);
-		sink(*dest); // $ MISSING: ir,ast
+		sink(*dest); // $ ir MISSING: ast
 	}
 	{
 		wchar_t dest[256] = {0};
 		StringCchPrintfW(dest, sizeof(dest), L"%s", wsource);
-		sink(*dest); // $ MISSING: ir,ast
+		sink(*dest); // $ ir MISSING: ast
 	}
 	{
 		char dest[256] = {0};
 		StringCbPrintfA(dest, sizeof(dest), "%s", source);
-		sink(*dest); // $ MISSING: ir,ast
+		sink(*dest); // $ ir MISSING: ast
 	}
 	{
 		char dest[256] = {0};
 		char *end;
 		size_t remaining;
 		StringCchPrintfExA(dest, sizeof(dest), &end, &remaining, 0, "%s", source);
-		sink(*dest); // $ MISSING: ir,ast
+		sink(*dest); // $ ir MISSING: ast
 	}
 	{
 		char dest[256] = {0};
 		char *fmt = indirect_source();
 		StringCchPrintfA(dest, sizeof(dest), fmt);
-		sink(*dest); // $ MISSING: ir,ast
+		sink(*dest); // $ ir MISSING: ast
 	}
 	{
 		char dest[256] = {0};

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/test_mad-signatures.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/test_mad-signatures.expected
@@ -28044,6 +28044,118 @@ getParameterTypeName
 | taint.cpp:859:8:859:12 | iconv | 4 | unsigned long * |
 | taint.cpp:861:6:861:15 | test_iconv | 0 | size_t |
 | taint.cpp:861:6:861:15 | test_iconv | 0 | unsigned long |
+| taint.cpp:872:6:872:19 | StringCchCopyA | 0 | char * |
+| taint.cpp:872:6:872:19 | StringCchCopyA | 1 | size_t |
+| taint.cpp:872:6:872:19 | StringCchCopyA | 1 | unsigned long |
+| taint.cpp:872:6:872:19 | StringCchCopyA | 2 | const char * |
+| taint.cpp:873:6:873:19 | StringCchCopyW | 0 | wchar_t * |
+| taint.cpp:873:6:873:19 | StringCchCopyW | 1 | size_t |
+| taint.cpp:873:6:873:19 | StringCchCopyW | 1 | unsigned long |
+| taint.cpp:873:6:873:19 | StringCchCopyW | 2 | const wchar_t * |
+| taint.cpp:874:6:874:18 | StringCbCopyA | 0 | char * |
+| taint.cpp:874:6:874:18 | StringCbCopyA | 1 | size_t |
+| taint.cpp:874:6:874:18 | StringCbCopyA | 1 | unsigned long |
+| taint.cpp:874:6:874:18 | StringCbCopyA | 2 | const char * |
+| taint.cpp:875:6:875:21 | StringCchCopyExA | 0 | char * |
+| taint.cpp:875:6:875:21 | StringCchCopyExA | 1 | size_t |
+| taint.cpp:875:6:875:21 | StringCchCopyExA | 1 | unsigned long |
+| taint.cpp:875:6:875:21 | StringCchCopyExA | 2 | const char * |
+| taint.cpp:875:6:875:21 | StringCchCopyExA | 3 | char ** |
+| taint.cpp:875:6:875:21 | StringCchCopyExA | 4 | size_t * |
+| taint.cpp:875:6:875:21 | StringCchCopyExA | 4 | unsigned long * |
+| taint.cpp:875:6:875:21 | StringCchCopyExA | 5 | unsigned long |
+| taint.cpp:876:6:876:20 | StringCchCopyNA | 0 | char * |
+| taint.cpp:876:6:876:20 | StringCchCopyNA | 1 | size_t |
+| taint.cpp:876:6:876:20 | StringCchCopyNA | 1 | unsigned long |
+| taint.cpp:876:6:876:20 | StringCchCopyNA | 2 | const char * |
+| taint.cpp:876:6:876:20 | StringCchCopyNA | 3 | size_t |
+| taint.cpp:876:6:876:20 | StringCchCopyNA | 3 | unsigned long |
+| taint.cpp:877:6:877:22 | StringCchCopyNExA | 0 | char * |
+| taint.cpp:877:6:877:22 | StringCchCopyNExA | 1 | size_t |
+| taint.cpp:877:6:877:22 | StringCchCopyNExA | 1 | unsigned long |
+| taint.cpp:877:6:877:22 | StringCchCopyNExA | 2 | const char * |
+| taint.cpp:877:6:877:22 | StringCchCopyNExA | 3 | size_t |
+| taint.cpp:877:6:877:22 | StringCchCopyNExA | 3 | unsigned long |
+| taint.cpp:877:6:877:22 | StringCchCopyNExA | 4 | char ** |
+| taint.cpp:877:6:877:22 | StringCchCopyNExA | 5 | size_t * |
+| taint.cpp:877:6:877:22 | StringCchCopyNExA | 5 | unsigned long * |
+| taint.cpp:877:6:877:22 | StringCchCopyNExA | 6 | unsigned long |
+| taint.cpp:878:6:878:18 | StringCchCatA | 0 | char * |
+| taint.cpp:878:6:878:18 | StringCchCatA | 1 | size_t |
+| taint.cpp:878:6:878:18 | StringCchCatA | 1 | unsigned long |
+| taint.cpp:878:6:878:18 | StringCchCatA | 2 | const char * |
+| taint.cpp:879:6:879:18 | StringCchCatW | 0 | wchar_t * |
+| taint.cpp:879:6:879:18 | StringCchCatW | 1 | size_t |
+| taint.cpp:879:6:879:18 | StringCchCatW | 1 | unsigned long |
+| taint.cpp:879:6:879:18 | StringCchCatW | 2 | const wchar_t * |
+| taint.cpp:880:6:880:17 | StringCbCatA | 0 | char * |
+| taint.cpp:880:6:880:17 | StringCbCatA | 1 | size_t |
+| taint.cpp:880:6:880:17 | StringCbCatA | 1 | unsigned long |
+| taint.cpp:880:6:880:17 | StringCbCatA | 2 | const char * |
+| taint.cpp:881:6:881:20 | StringCchCatExA | 0 | char * |
+| taint.cpp:881:6:881:20 | StringCchCatExA | 1 | size_t |
+| taint.cpp:881:6:881:20 | StringCchCatExA | 1 | unsigned long |
+| taint.cpp:881:6:881:20 | StringCchCatExA | 2 | const char * |
+| taint.cpp:881:6:881:20 | StringCchCatExA | 3 | char ** |
+| taint.cpp:881:6:881:20 | StringCchCatExA | 4 | size_t * |
+| taint.cpp:881:6:881:20 | StringCchCatExA | 4 | unsigned long * |
+| taint.cpp:881:6:881:20 | StringCchCatExA | 5 | unsigned long |
+| taint.cpp:882:6:882:19 | StringCchCatNA | 0 | char * |
+| taint.cpp:882:6:882:19 | StringCchCatNA | 1 | size_t |
+| taint.cpp:882:6:882:19 | StringCchCatNA | 1 | unsigned long |
+| taint.cpp:882:6:882:19 | StringCchCatNA | 2 | const char * |
+| taint.cpp:882:6:882:19 | StringCchCatNA | 3 | size_t |
+| taint.cpp:882:6:882:19 | StringCchCatNA | 3 | unsigned long |
+| taint.cpp:883:6:883:21 | StringCchCatNExA | 0 | char * |
+| taint.cpp:883:6:883:21 | StringCchCatNExA | 1 | size_t |
+| taint.cpp:883:6:883:21 | StringCchCatNExA | 1 | unsigned long |
+| taint.cpp:883:6:883:21 | StringCchCatNExA | 2 | const char * |
+| taint.cpp:883:6:883:21 | StringCchCatNExA | 3 | size_t |
+| taint.cpp:883:6:883:21 | StringCchCatNExA | 3 | unsigned long |
+| taint.cpp:883:6:883:21 | StringCchCatNExA | 4 | char ** |
+| taint.cpp:883:6:883:21 | StringCchCatNExA | 5 | size_t * |
+| taint.cpp:883:6:883:21 | StringCchCatNExA | 5 | unsigned long * |
+| taint.cpp:883:6:883:21 | StringCchCatNExA | 6 | unsigned long |
+| taint.cpp:884:6:884:21 | StringCchPrintfA | 0 | char * |
+| taint.cpp:884:6:884:21 | StringCchPrintfA | 1 | size_t |
+| taint.cpp:884:6:884:21 | StringCchPrintfA | 1 | unsigned long |
+| taint.cpp:884:6:884:21 | StringCchPrintfA | 2 | const char * |
+| taint.cpp:884:6:884:21 | StringCchPrintfA | 3 | ... |
+| taint.cpp:885:6:885:21 | StringCchPrintfW | 0 | wchar_t * |
+| taint.cpp:885:6:885:21 | StringCchPrintfW | 1 | size_t |
+| taint.cpp:885:6:885:21 | StringCchPrintfW | 1 | unsigned long |
+| taint.cpp:885:6:885:21 | StringCchPrintfW | 2 | const wchar_t * |
+| taint.cpp:885:6:885:21 | StringCchPrintfW | 3 | ... |
+| taint.cpp:886:6:886:20 | StringCbPrintfA | 0 | char * |
+| taint.cpp:886:6:886:20 | StringCbPrintfA | 1 | size_t |
+| taint.cpp:886:6:886:20 | StringCbPrintfA | 1 | unsigned long |
+| taint.cpp:886:6:886:20 | StringCbPrintfA | 2 | const char * |
+| taint.cpp:886:6:886:20 | StringCbPrintfA | 3 | ... |
+| taint.cpp:887:6:887:23 | StringCchPrintfExA | 0 | char * |
+| taint.cpp:887:6:887:23 | StringCchPrintfExA | 1 | size_t |
+| taint.cpp:887:6:887:23 | StringCchPrintfExA | 1 | unsigned long |
+| taint.cpp:887:6:887:23 | StringCchPrintfExA | 2 | char ** |
+| taint.cpp:887:6:887:23 | StringCchPrintfExA | 3 | size_t * |
+| taint.cpp:887:6:887:23 | StringCchPrintfExA | 3 | unsigned long * |
+| taint.cpp:887:6:887:23 | StringCchPrintfExA | 4 | unsigned long |
+| taint.cpp:887:6:887:23 | StringCchPrintfExA | 5 | const char * |
+| taint.cpp:887:6:887:23 | StringCchPrintfExA | 6 | ... |
+| taint.cpp:888:6:888:22 | StringCchVPrintfA | 0 | char * |
+| taint.cpp:888:6:888:22 | StringCchVPrintfA | 1 | size_t |
+| taint.cpp:888:6:888:22 | StringCchVPrintfA | 1 | unsigned long |
+| taint.cpp:888:6:888:22 | StringCchVPrintfA | 2 | const char * |
+| taint.cpp:888:6:888:22 | StringCchVPrintfA | 3 | va_list |
+| taint.cpp:888:6:888:22 | StringCchVPrintfA | 3 | void * |
+| taint.cpp:889:6:889:24 | StringCchVPrintfExA | 0 | char * |
+| taint.cpp:889:6:889:24 | StringCchVPrintfExA | 1 | size_t |
+| taint.cpp:889:6:889:24 | StringCchVPrintfExA | 1 | unsigned long |
+| taint.cpp:889:6:889:24 | StringCchVPrintfExA | 2 | char ** |
+| taint.cpp:889:6:889:24 | StringCchVPrintfExA | 3 | size_t * |
+| taint.cpp:889:6:889:24 | StringCchVPrintfExA | 3 | unsigned long * |
+| taint.cpp:889:6:889:24 | StringCchVPrintfExA | 4 | unsigned long |
+| taint.cpp:889:6:889:24 | StringCchVPrintfExA | 5 | const char * |
+| taint.cpp:889:6:889:24 | StringCchVPrintfExA | 6 | va_list |
+| taint.cpp:889:6:889:24 | StringCchVPrintfExA | 6 | void * |
 | thread.cpp:4:6:4:9 | sink | 0 | int |
 | thread.cpp:6:8:6:8 | operator= | 0 | S && |
 | thread.cpp:6:8:6:8 | operator= | 0 | const S & |

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/NonConstantFormat/NonConstantFormat.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/NonConstantFormat/NonConstantFormat.expected
@@ -11,8 +11,13 @@ edges
 | nested.cpp:86:19:86:46 | *call to __builtin_alloca | nested.cpp:87:18:87:20 | *fmt | provenance |  |
 | test.cpp:46:27:46:30 | **argv | test.cpp:130:20:130:26 | *access to array | provenance |  |
 | test.cpp:167:31:167:34 | *data | test.cpp:170:12:170:14 | *res | provenance | DataFlowFunction |
+| test.cpp:179:6:179:21 | [summary param] *2 in StringCchPrintfW | test.cpp:179:6:179:21 | [summary param] *0 in StringCchPrintfW [Return] | provenance | MaD:403 |
+| test.cpp:193:32:193:34 | *str | test.cpp:195:31:195:33 | *str | provenance |  |
 | test.cpp:193:32:193:34 | *str | test.cpp:195:31:195:33 | *str | provenance |  |
 | test.cpp:193:32:193:34 | *str | test.cpp:197:11:197:14 | *wstr | provenance | TaintFunction |
+| test.cpp:195:20:195:23 | StringCchPrintfW output argument | test.cpp:197:11:197:14 | *wstr | provenance |  |
+| test.cpp:195:31:195:33 | *str | test.cpp:179:6:179:21 | [summary param] *2 in StringCchPrintfW | provenance |  |
+| test.cpp:195:31:195:33 | *str | test.cpp:195:20:195:23 | StringCchPrintfW output argument | provenance | MaD:403 |
 | test.cpp:204:25:204:36 | *call to get_string | test.cpp:204:25:204:36 | *call to get_string | provenance |  |
 | test.cpp:204:25:204:36 | *call to get_string | test.cpp:205:12:205:20 | *... + ... | provenance |  |
 | test.cpp:204:25:204:36 | *call to get_string | test.cpp:206:12:206:16 | *hello | provenance |  |
@@ -55,7 +60,11 @@ nodes
 | test.cpp:130:20:130:26 | *access to array | semmle.label | *access to array |
 | test.cpp:167:31:167:34 | *data | semmle.label | *data |
 | test.cpp:170:12:170:14 | *res | semmle.label | *res |
+| test.cpp:179:6:179:21 | [summary param] *0 in StringCchPrintfW [Return] | semmle.label | [summary param] *0 in StringCchPrintfW [Return] |
+| test.cpp:179:6:179:21 | [summary param] *2 in StringCchPrintfW | semmle.label | [summary param] *2 in StringCchPrintfW |
 | test.cpp:193:32:193:34 | *str | semmle.label | *str |
+| test.cpp:195:20:195:23 | StringCchPrintfW output argument | semmle.label | StringCchPrintfW output argument |
+| test.cpp:195:31:195:33 | *str | semmle.label | *str |
 | test.cpp:195:31:195:33 | *str | semmle.label | *str |
 | test.cpp:197:11:197:14 | *wstr | semmle.label | *wstr |
 | test.cpp:204:25:204:36 | *call to get_string | semmle.label | *call to get_string |
@@ -88,6 +97,7 @@ nodes
 | test.cpp:245:25:245:36 | *call to get_string | semmle.label | *call to get_string |
 | test.cpp:247:12:247:16 | *hello | semmle.label | *hello |
 subpaths
+| test.cpp:195:31:195:33 | *str | test.cpp:179:6:179:21 | [summary param] *2 in StringCchPrintfW | test.cpp:179:6:179:21 | [summary param] *0 in StringCchPrintfW [Return] | test.cpp:195:20:195:23 | StringCchPrintfW output argument |
 #select
 | NonConstantFormat.c:30:10:30:16 | *access to array | NonConstantFormat.c:28:27:28:30 | **argv | NonConstantFormat.c:30:10:30:16 | *access to array | The format string argument to $@ has a source which cannot be verified to originate from a string literal. | NonConstantFormat.c:30:3:30:8 | call to printf | printf |
 | NonConstantFormat.c:41:9:41:45 | *call to any_random_function | NonConstantFormat.c:41:9:41:45 | *call to any_random_function | NonConstantFormat.c:41:9:41:45 | *call to any_random_function | The format string argument to $@ has a source which cannot be verified to originate from a string literal. | NonConstantFormat.c:41:2:41:7 | call to printf | printf |


### PR DESCRIPTION
Pretty simple stuff. We just add source and flow summary models for https://learn.microsoft.com/en-us/windows/win32/menurc/strsafe-ovw