### PR TITLE
Fix issue with Python formatting and expand scope of python-tooling

### DIFF
--- a/.github/workflows/mad_modelDiff.yml
+++ b/.github/workflows/mad_modelDiff.yml
@@ -70,7 +70,7 @@ jobs:
             SHORTNAME=`basename $DATABASE`
             python misc/scripts/models-as-data/generate_mad.py --language java --with-summaries --with-sinks $DATABASE $SHORTNAME/$QL_VARIANT
             mkdir -p $MODELS/$SHORTNAME
-            mv java/ql/lib/ext/generated/$SHORTNAME/$QL_VARIANT $MODELS/$SHORTNAME
+            mv java/ql/lib/ext/generated/modelgenerator/$SHORTNAME/$QL_VARIANT $MODELS/$SHORTNAME
             cd ..
           }
 

--- a/.github/workflows/python-tooling.yml
+++ b/.github/workflows/python-tooling.yml
@@ -5,7 +5,7 @@ on:
     paths:
       - "misc/bazel/**"
       - "misc/codegen/**"
-      - "misc/scripts/models-as-data/bulk_generate_mad.py"
+      - "misc/scripts/models-as-data/*.py"
       - "*.bazel*"
       - .github/workflows/codegen.yml
       - .pre-commit-config.yaml

--- a/misc/scripts/models-as-data/generate_mad.py
+++ b/misc/scripts/models-as-data/generate_mad.py
@@ -67,7 +67,8 @@ class Generator:
         self.database = database or self.database
         self.folder = folder or self.folder
         self.generated_frameworks = os.path.join(
-            self.codeql_root, f"{self.language}/ql/lib/ext/generated/modelgenerator/{self.folder}"
+            self.codeql_root,
+            f"{self.language}/ql/lib/ext/generated/modelgenerator/{self.folder}",
         )
         self.workDir = tempfile.mkdtemp()
         if self.ram is None:


### PR DESCRIPTION
I changed some Python code in #21751. That code change was not run by the `check-python-tooling` workflow, because the triggers of that workflow does not include the Python script I changed. On an unrelated PR, it's now causing an error, see https://github.com/github/codeql/actions/runs/25377388307/job/74416070526?pr=21797#step:4:137.

1. Expand the workflow to include all Python scripts of the `models-as-data` folder.
2. Fix the issue in the Python script.
3. Fix an issue in the `mad_modelDiff` workflow - I am not sure why that did not run on #21751.

Assuming the CI uses the workflow definition of the PR branch, we should see the check passing here.