### PR TITLE
Cfg: Rework CFG for switch case patterns.

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/controlflow/Guards.qll
+++ b/csharp/ql/lib/semmle/code/csharp/controlflow/Guards.qll
@@ -85,12 +85,12 @@ private module GuardsInput implements SharedGuards::InputSig<Location, ControlFl
 
     predicate matchEdge(BasicBlock bb1, BasicBlock bb2) {
       bb1.getASuccessor(any(MatchingSuccessor s | s.getValue() = true)) = bb2 and
-      bb1.getLastNode() = AstNode.super.getControlFlowNode()
+      bb1.getLastNode() = super.getPattern().getControlFlowNode()
     }
 
     predicate nonMatchEdge(BasicBlock bb1, BasicBlock bb2) {
       bb1.getASuccessor(any(MatchingSuccessor s | s.getValue() = false)) = bb2 and
-      bb1.getLastNode() = AstNode.super.getControlFlowNode()
+      bb1.getLastNode() = super.getPattern().getControlFlowNode()
     }
   }
 

--- a/csharp/ql/lib/semmle/code/csharp/controlflow/internal/ControlFlowGraph.qll
+++ b/csharp/ql/lib/semmle/code/csharp/controlflow/internal/ControlFlowGraph.qll
@@ -229,7 +229,7 @@ module Ast implements AstSig<Location> {
   final private class FinalCase = CS::Case;
 
   class Case extends FinalCase {
-    AstNode getAPattern() { result = this.getPattern() }
+    AstNode getPattern(int index) { result = this.getPattern() and index = 0 }
 
     Expr getGuard() { result = this.getCondition() }
 

--- a/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
@@ -912,7 +912,7 @@
 | PartialImplementationB.cs:4:12:4:18 | Entry | PartialImplementationB.cs:4:12:4:18 | Exit | 11 |
 | Patterns.cs:3:7:3:14 | Entry | Patterns.cs:3:7:3:14 | Exit | 11 |
 | Patterns.cs:5:10:5:11 | Entry | Patterns.cs:8:13:8:23 | ... is ... | 13 |
-| Patterns.cs:8:9:18:9 | After if (...) ... | Patterns.cs:22:13:22:23 | case ...: | 4 |
+| Patterns.cs:8:9:18:9 | After if (...) ... | Patterns.cs:22:18:22:22 | "xyz" | 5 |
 | Patterns.cs:8:13:8:23 | After ... is ... [false] | Patterns.cs:12:18:12:31 | ... is ... | 5 |
 | Patterns.cs:8:13:8:23 | [MatchTrue] ... is ... | Patterns.cs:9:9:11:9 | After {...} | 18 |
 | Patterns.cs:12:14:18:9 | After if (...) ... | Patterns.cs:12:14:18:9 | After if (...) ... | 1 |
@@ -922,19 +922,19 @@
 | Patterns.cs:16:18:16:28 | After ... is ... [false] | Patterns.cs:16:18:16:28 | After ... is ... [false] | 1 |
 | Patterns.cs:16:18:16:28 | [MatchTrue] ... is ... | Patterns.cs:17:9:18:9 | {...} | 4 |
 | Patterns.cs:20:9:38:9 | After switch (...) {...} | Patterns.cs:5:10:5:11 | Exit | 7 |
-| Patterns.cs:22:13:22:23 | After case ...: [match] | Patterns.cs:23:17:23:22 | break; | 4 |
-| Patterns.cs:22:13:22:23 | After case ...: [no-match] | Patterns.cs:24:13:24:36 | case ...: | 2 |
-| Patterns.cs:24:13:24:36 | After case ...: [match] | Patterns.cs:24:30:24:35 | ... > ... | 6 |
-| Patterns.cs:24:13:24:36 | After case ...: [no-match] | Patterns.cs:24:13:24:36 | After case ...: [no-match] | 1 |
+| Patterns.cs:22:18:22:22 | After "xyz" [match] | Patterns.cs:23:17:23:22 | break; | 4 |
+| Patterns.cs:22:18:22:22 | After "xyz" [no-match] | Patterns.cs:24:18:24:23 | Int32 i2 | 4 |
+| Patterns.cs:24:18:24:23 | After Int32 i2 [match] | Patterns.cs:24:30:24:35 | ... > ... | 6 |
+| Patterns.cs:24:18:24:23 | After Int32 i2 [no-match] | Patterns.cs:24:13:24:36 | After case ...: [no-match] | 2 |
 | Patterns.cs:24:30:24:35 | After ... > ... [false] | Patterns.cs:24:30:24:35 | After ... > ... [false] | 1 |
 | Patterns.cs:24:30:24:35 | After ... > ... [true] | Patterns.cs:26:17:26:22 | break; | 16 |
-| Patterns.cs:27:13:27:24 | After case ...: [match] | Patterns.cs:29:17:29:22 | break; | 17 |
-| Patterns.cs:27:13:27:24 | After case ...: [no-match] | Patterns.cs:30:13:30:27 | case ...: | 2 |
-| Patterns.cs:27:13:27:24 | case ...: | Patterns.cs:27:13:27:24 | case ...: | 1 |
-| Patterns.cs:30:13:30:27 | After case ...: [match] | Patterns.cs:32:17:32:22 | break; | 17 |
-| Patterns.cs:30:13:30:27 | After case ...: [no-match] | Patterns.cs:33:13:33:24 | case ...: | 2 |
-| Patterns.cs:33:13:33:24 | After case ...: [match] | Patterns.cs:34:17:34:22 | break; | 4 |
-| Patterns.cs:33:13:33:24 | After case ...: [no-match] | Patterns.cs:37:17:37:22 | break; | 11 |
+| Patterns.cs:27:13:27:24 | case ...: | Patterns.cs:27:18:27:23 | Int32 i3 | 2 |
+| Patterns.cs:27:18:27:23 | After Int32 i3 [match] | Patterns.cs:29:17:29:22 | break; | 17 |
+| Patterns.cs:27:18:27:23 | After Int32 i3 [no-match] | Patterns.cs:30:18:30:26 | String s2 | 4 |
+| Patterns.cs:30:18:30:26 | After String s2 [match] | Patterns.cs:32:17:32:22 | break; | 17 |
+| Patterns.cs:30:18:30:26 | After String s2 [no-match] | Patterns.cs:33:18:33:23 | Object v2 | 4 |
+| Patterns.cs:33:18:33:23 | After Object v2 [match] | Patterns.cs:34:17:34:22 | break; | 4 |
+| Patterns.cs:33:18:33:23 | After Object v2 [no-match] | Patterns.cs:37:17:37:22 | break; | 12 |
 | Patterns.cs:47:24:47:25 | Entry | Patterns.cs:48:9:48:20 | ... is ... | 5 |
 | Patterns.cs:48:9:48:20 | After ... is ... | Patterns.cs:47:24:47:25 | Exit | 3 |
 | Patterns.cs:48:9:48:20 | [MatchTrue] ... is ... | Patterns.cs:48:14:48:20 | After not ... | 5 |
@@ -949,24 +949,24 @@
 | Patterns.cs:53:24:53:25 | Entry | Patterns.cs:54:9:54:37 | ... is ... | 5 |
 | Patterns.cs:54:9:54:37 | After ... is ... | Patterns.cs:53:24:53:25 | Exit | 3 |
 | Patterns.cs:54:9:54:37 | [MatchTrue] ... is ... | Patterns.cs:54:14:54:37 | After not ... | 13 |
-| Patterns.cs:56:26:56:27 | Entry | Patterns.cs:60:13:60:28 | ... => ... | 7 |
+| Patterns.cs:56:26:56:27 | Entry | Patterns.cs:60:13:60:17 | not ... | 10 |
 | Patterns.cs:58:16:62:9 | After ... switch { ... } | Patterns.cs:56:26:56:27 | Exit | 4 |
-| Patterns.cs:60:13:60:28 | After ... => ... [match] | Patterns.cs:60:22:60:28 | "not 1" | 6 |
-| Patterns.cs:60:13:60:28 | After ... => ... [no-match] | Patterns.cs:61:18:61:24 | "other" | 5 |
-| Patterns.cs:65:26:65:27 | Entry | Patterns.cs:69:13:69:33 | ... => ... | 6 |
+| Patterns.cs:60:13:60:17 | After not ... [match] | Patterns.cs:60:22:60:28 | "not 1" | 3 |
+| Patterns.cs:60:13:60:17 | After not ... [no-match] | Patterns.cs:61:18:61:24 | "other" | 7 |
+| Patterns.cs:65:26:65:27 | Entry | Patterns.cs:69:13:69:17 | not ... | 9 |
 | Patterns.cs:67:16:71:9 | After ... switch { ... } | Patterns.cs:65:26:65:27 | Exit | 4 |
-| Patterns.cs:69:13:69:33 | After ... => ... [match] | Patterns.cs:69:22:69:33 | "impossible" | 6 |
-| Patterns.cs:69:13:69:33 | After ... => ... [no-match] | Patterns.cs:70:13:70:27 | ... => ... | 2 |
-| Patterns.cs:70:13:70:27 | After ... => ... [match] | Patterns.cs:70:18:70:27 | "possible" | 3 |
-| Patterns.cs:70:13:70:27 | After ... => ... [no-match] | Patterns.cs:70:13:70:27 | After ... => ... [no-match] | 1 |
-| Patterns.cs:74:26:74:27 | Entry | Patterns.cs:78:13:78:24 | ... => ... | 7 |
+| Patterns.cs:69:13:69:17 | After not ... [match] | Patterns.cs:69:22:69:33 | "impossible" | 3 |
+| Patterns.cs:69:13:69:17 | After not ... [no-match] | Patterns.cs:70:13:70:13 | 2 | 4 |
+| Patterns.cs:70:13:70:13 | After 2 [match] | Patterns.cs:70:18:70:27 | "possible" | 3 |
+| Patterns.cs:70:13:70:13 | After 2 [no-match] | Patterns.cs:70:13:70:27 | After ... => ... [no-match] | 2 |
+| Patterns.cs:74:26:74:27 | Entry | Patterns.cs:78:13:78:15 | > ... | 10 |
 | Patterns.cs:76:16:82:9 | After ... switch { ... } | Patterns.cs:74:26:74:27 | Exit | 4 |
-| Patterns.cs:78:13:78:24 | After ... => ... [match] | Patterns.cs:78:20:78:24 | "> 1" | 6 |
-| Patterns.cs:78:13:78:24 | After ... => ... [no-match] | Patterns.cs:79:13:79:24 | ... => ... | 2 |
-| Patterns.cs:79:13:79:24 | After ... => ... [match] | Patterns.cs:79:20:79:24 | "< 0" | 6 |
-| Patterns.cs:79:13:79:24 | After ... => ... [no-match] | Patterns.cs:80:13:80:20 | ... => ... | 2 |
-| Patterns.cs:80:13:80:20 | After ... => ... [match] | Patterns.cs:80:18:80:20 | "1" | 3 |
-| Patterns.cs:80:13:80:20 | After ... => ... [no-match] | Patterns.cs:81:18:81:20 | "0" | 5 |
+| Patterns.cs:78:13:78:15 | After > ... [match] | Patterns.cs:78:20:78:24 | "> 1" | 3 |
+| Patterns.cs:78:13:78:15 | After > ... [no-match] | Patterns.cs:79:13:79:15 | < ... | 6 |
+| Patterns.cs:79:13:79:15 | After < ... [match] | Patterns.cs:79:20:79:24 | "< 0" | 3 |
+| Patterns.cs:79:13:79:15 | After < ... [no-match] | Patterns.cs:80:13:80:13 | 1 | 4 |
+| Patterns.cs:80:13:80:13 | After 1 [match] | Patterns.cs:80:18:80:20 | "1" | 3 |
+| Patterns.cs:80:13:80:13 | After 1 [no-match] | Patterns.cs:81:18:81:20 | "0" | 7 |
 | Patterns.cs:85:26:85:27 | Entry | Patterns.cs:85:39:85:53 | ... is ... | 6 |
 | Patterns.cs:85:39:85:53 | After ... is ... [false] | Patterns.cs:85:67:85:69 | "2" | 2 |
 | Patterns.cs:85:39:85:53 | [MatchTrue] ... is ... | Patterns.cs:85:57:85:63 | "not 2" | 11 |
@@ -995,129 +995,130 @@
 | Qualifiers.cs:10:10:10:10 | Entry | Qualifiers.cs:10:10:10:10 | Exit | 149 |
 | Switch.cs:3:7:3:12 | Entry | Switch.cs:3:7:3:12 | Exit | 11 |
 | Switch.cs:5:10:5:11 | Entry | Switch.cs:5:10:5:11 | Exit | 9 |
-| Switch.cs:10:10:10:11 | Entry | Switch.cs:14:13:14:21 | case ...: | 6 |
+| Switch.cs:10:10:10:11 | Entry | Switch.cs:14:18:14:20 | "a" | 7 |
 | Switch.cs:10:10:10:11 | Exceptional Exit | Switch.cs:10:10:10:11 | Exceptional Exit | 1 |
 | Switch.cs:10:10:10:11 | Exit | Switch.cs:10:10:10:11 | Exit | 1 |
 | Switch.cs:10:10:10:11 | Normal Exit | Switch.cs:10:10:10:11 | Normal Exit | 1 |
-| Switch.cs:14:13:14:21 | After case ...: [match] | Switch.cs:15:17:15:23 | return ...; | 4 |
-| Switch.cs:14:13:14:21 | After case ...: [no-match] | Switch.cs:16:13:16:19 | case ...: | 2 |
-| Switch.cs:16:13:16:19 | After case ...: [match] | Switch.cs:17:17:17:38 | throw ...; | 7 |
-| Switch.cs:16:13:16:19 | After case ...: [no-match] | Switch.cs:18:13:18:22 | case ...: | 2 |
-| Switch.cs:18:13:18:22 | After case ...: [match] | Switch.cs:19:17:19:29 | goto default; | 4 |
-| Switch.cs:18:13:18:22 | After case ...: [no-match] | Switch.cs:20:13:20:23 | case ...: | 2 |
-| Switch.cs:20:13:20:23 | After case ...: [match] | Switch.cs:21:21:21:29 | ... == ... | 7 |
-| Switch.cs:20:13:20:23 | After case ...: [no-match] | Switch.cs:24:13:24:56 | case ...: | 2 |
+| Switch.cs:14:18:14:20 | After "a" [match] | Switch.cs:15:17:15:23 | return ...; | 4 |
+| Switch.cs:14:18:14:20 | After "a" [no-match] | Switch.cs:16:18:16:18 | 0 | 4 |
+| Switch.cs:16:13:16:19 | After case ...: [match] | Switch.cs:17:17:17:38 | throw ...; | 6 |
+| Switch.cs:16:18:16:18 | After 0 [match] | Switch.cs:16:18:16:18 | After 0 [match] | 1 |
+| Switch.cs:16:18:16:18 | After 0 [no-match] | Switch.cs:18:18:18:21 | null | 4 |
+| Switch.cs:18:18:18:21 | After null [match] | Switch.cs:19:17:19:29 | goto default; | 4 |
+| Switch.cs:18:18:18:21 | After null [no-match] | Switch.cs:20:18:20:22 | Int32 i | 4 |
+| Switch.cs:20:18:20:22 | After Int32 i [match] | Switch.cs:21:21:21:29 | ... == ... | 7 |
+| Switch.cs:20:18:20:22 | After Int32 i [no-match] | Switch.cs:24:18:24:25 | String s | 4 |
 | Switch.cs:21:21:21:29 | After ... == ... [false] | Switch.cs:23:17:23:28 | goto case ...; | 5 |
 | Switch.cs:21:21:21:29 | After ... == ... [true] | Switch.cs:22:21:22:27 | return ...; | 3 |
-| Switch.cs:24:13:24:56 | After case ...: [match] | Switch.cs:24:32:24:43 | ... > ... | 10 |
-| Switch.cs:24:13:24:56 | After case ...: [no-match] | Switch.cs:24:13:24:56 | After case ...: [no-match] | 1 |
+| Switch.cs:24:18:24:25 | After String s [match] | Switch.cs:24:32:24:43 | ... > ... | 10 |
+| Switch.cs:24:18:24:25 | After String s [no-match] | Switch.cs:24:13:24:56 | After case ...: [no-match] | 2 |
 | Switch.cs:24:32:24:43 | After ... > ... [false] | Switch.cs:24:32:24:43 | After ... > ... [false] | 1 |
 | Switch.cs:24:32:24:43 | After ... > ... [true] | Switch.cs:24:48:24:55 | ... != ... | 5 |
 | Switch.cs:24:32:24:55 | After ... && ... [false] | Switch.cs:24:32:24:55 | After ... && ... [false] | 1 |
 | Switch.cs:24:48:24:55 | After ... != ... [false] | Switch.cs:24:48:24:55 | After ... != ... [false] | 1 |
 | Switch.cs:24:48:24:55 | After ... != ... [true] | Switch.cs:26:17:26:23 | return ...; | 10 |
-| Switch.cs:27:13:27:39 | After case ...: [match] | Switch.cs:27:32:27:38 | call to method Throw | 4 |
-| Switch.cs:27:13:27:39 | After case ...: [no-match] | Switch.cs:30:13:30:20 | default: | 2 |
-| Switch.cs:27:13:27:39 | case ...: | Switch.cs:27:13:27:39 | case ...: | 1 |
+| Switch.cs:27:13:27:39 | case ...: | Switch.cs:27:18:27:25 | Double d | 2 |
+| Switch.cs:27:18:27:25 | After Double d [match] | Switch.cs:27:32:27:38 | call to method Throw | 4 |
+| Switch.cs:27:18:27:25 | After Double d [no-match] | Switch.cs:30:13:30:20 | default: | 3 |
 | Switch.cs:30:13:30:20 | After default: [match] | Switch.cs:29:17:29:23 | return ...; | 6 |
 | Switch.cs:35:10:35:11 | Entry | Switch.cs:35:10:35:11 | Exit | 7 |
-| Switch.cs:44:10:44:11 | Entry | Switch.cs:48:13:48:23 | case ...: | 6 |
+| Switch.cs:44:10:44:11 | Entry | Switch.cs:48:18:48:20 | access to type Int32 | 7 |
 | Switch.cs:46:9:52:9 | After switch (...) {...} | Switch.cs:44:10:44:11 | Exit | 4 |
-| Switch.cs:48:13:48:23 | After case ...: [match] | Switch.cs:49:17:49:22 | break; | 4 |
-| Switch.cs:48:13:48:23 | After case ...: [no-match] | Switch.cs:50:13:50:39 | case ...: | 2 |
-| Switch.cs:50:13:50:39 | After case ...: [match] | Switch.cs:50:30:50:38 | ... != ... | 6 |
-| Switch.cs:50:13:50:39 | After case ...: [no-match] | Switch.cs:50:13:50:39 | After case ...: [no-match] | 1 |
+| Switch.cs:48:18:48:20 | After access to type Int32 [match] | Switch.cs:49:17:49:22 | break; | 4 |
+| Switch.cs:48:18:48:20 | After access to type Int32 [no-match] | Switch.cs:50:18:50:21 | access to type Boolean | 4 |
+| Switch.cs:50:18:50:21 | After access to type Boolean [match] | Switch.cs:50:30:50:38 | ... != ... | 6 |
+| Switch.cs:50:18:50:21 | After access to type Boolean [no-match] | Switch.cs:50:13:50:39 | After case ...: [no-match] | 2 |
 | Switch.cs:50:30:50:38 | After ... != ... [false] | Switch.cs:50:30:50:38 | After ... != ... [false] | 1 |
 | Switch.cs:50:30:50:38 | After ... != ... [true] | Switch.cs:51:17:51:22 | break; | 3 |
-| Switch.cs:55:10:55:11 | Entry | Switch.cs:59:13:59:19 | case ...: | 9 |
+| Switch.cs:55:10:55:11 | Entry | Switch.cs:59:18:59:18 | 2 | 10 |
 | Switch.cs:57:9:63:9 | After switch (...) {...} | Switch.cs:55:10:55:11 | Exit | 4 |
-| Switch.cs:59:13:59:19 | After case ...: [match] | Switch.cs:60:17:60:22 | break; | 4 |
-| Switch.cs:59:13:59:19 | After case ...: [no-match] | Switch.cs:61:13:61:19 | case ...: | 2 |
-| Switch.cs:61:13:61:19 | After case ...: [match] | Switch.cs:62:17:62:22 | break; | 4 |
-| Switch.cs:61:13:61:19 | After case ...: [no-match] | Switch.cs:61:13:61:19 | After case ...: [no-match] | 1 |
-| Switch.cs:66:10:66:11 | Entry | Switch.cs:70:13:70:23 | case ...: | 9 |
+| Switch.cs:59:18:59:18 | After 2 [match] | Switch.cs:60:17:60:22 | break; | 4 |
+| Switch.cs:59:18:59:18 | After 2 [no-match] | Switch.cs:61:18:61:18 | 3 | 4 |
+| Switch.cs:61:18:61:18 | After 3 [match] | Switch.cs:62:17:62:22 | break; | 4 |
+| Switch.cs:61:18:61:18 | After 3 [no-match] | Switch.cs:61:13:61:19 | After case ...: [no-match] | 2 |
+| Switch.cs:66:10:66:11 | Entry | Switch.cs:70:18:70:20 | access to type Int32 | 10 |
 | Switch.cs:68:9:74:9 | After switch (...) {...} | Switch.cs:66:10:66:11 | Exit | 4 |
-| Switch.cs:70:13:70:23 | After case ...: [match] | Switch.cs:71:17:71:22 | break; | 4 |
-| Switch.cs:70:13:70:23 | After case ...: [no-match] | Switch.cs:72:13:72:20 | case ...: | 2 |
-| Switch.cs:72:13:72:20 | After case ...: [match] | Switch.cs:73:17:73:22 | break; | 4 |
-| Switch.cs:72:13:72:20 | After case ...: [no-match] | Switch.cs:72:13:72:20 | After case ...: [no-match] | 1 |
-| Switch.cs:77:10:77:11 | Entry | Switch.cs:81:13:81:19 | case ...: | 7 |
+| Switch.cs:70:18:70:20 | After access to type Int32 [match] | Switch.cs:71:17:71:22 | break; | 4 |
+| Switch.cs:70:18:70:20 | After access to type Int32 [no-match] | Switch.cs:72:18:72:19 | "" | 4 |
+| Switch.cs:72:18:72:19 | After "" [match] | Switch.cs:73:17:73:22 | break; | 4 |
+| Switch.cs:72:18:72:19 | After "" [no-match] | Switch.cs:72:13:72:20 | After case ...: [no-match] | 2 |
+| Switch.cs:77:10:77:11 | Entry | Switch.cs:81:18:81:18 | 1 | 8 |
 | Switch.cs:77:10:77:11 | Normal Exit | Switch.cs:77:10:77:11 | Exit | 2 |
 | Switch.cs:79:9:87:9 | After switch (...) {...} | Switch.cs:88:9:88:21 | return ...; | 4 |
-| Switch.cs:81:13:81:19 | After case ...: [match] | Switch.cs:82:17:82:28 | return ...; | 5 |
-| Switch.cs:81:13:81:19 | After case ...: [no-match] | Switch.cs:83:13:83:19 | case ...: | 2 |
-| Switch.cs:83:13:83:19 | After case ...: [match] | Switch.cs:84:21:84:25 | ... > ... | 7 |
-| Switch.cs:83:13:83:19 | After case ...: [no-match] | Switch.cs:83:13:83:19 | After case ...: [no-match] | 1 |
+| Switch.cs:81:18:81:18 | After 1 [match] | Switch.cs:82:17:82:28 | return ...; | 5 |
+| Switch.cs:81:18:81:18 | After 1 [no-match] | Switch.cs:83:18:83:18 | 2 | 4 |
+| Switch.cs:83:18:83:18 | After 2 [match] | Switch.cs:84:21:84:25 | ... > ... | 7 |
+| Switch.cs:83:18:83:18 | After 2 [no-match] | Switch.cs:83:13:83:19 | After case ...: [no-match] | 2 |
 | Switch.cs:84:21:84:25 | After ... > ... [false] | Switch.cs:86:17:86:28 | return ...; | 5 |
 | Switch.cs:84:21:84:25 | After ... > ... [true] | Switch.cs:85:21:85:26 | break; | 3 |
-| Switch.cs:91:10:91:11 | Entry | Switch.cs:95:13:95:23 | case ...: | 6 |
+| Switch.cs:91:10:91:11 | Entry | Switch.cs:95:18:95:20 | access to type Int32 | 7 |
 | Switch.cs:91:10:91:11 | Normal Exit | Switch.cs:91:10:91:11 | Exit | 2 |
-| Switch.cs:95:13:95:23 | After case ...: [match] | Switch.cs:96:17:96:28 | return ...; | 5 |
-| Switch.cs:95:13:95:23 | After case ...: [no-match] | Switch.cs:98:9:98:21 | return ...; | 5 |
+| Switch.cs:95:18:95:20 | After access to type Int32 [match] | Switch.cs:96:17:96:28 | return ...; | 5 |
+| Switch.cs:95:18:95:20 | After access to type Int32 [no-match] | Switch.cs:98:9:98:21 | return ...; | 6 |
 | Switch.cs:101:9:101:10 | Entry | Switch.cs:103:17:103:17 | access to parameter s | 6 |
 | Switch.cs:101:9:101:10 | Normal Exit | Switch.cs:101:9:101:10 | Exit | 2 |
 | Switch.cs:103:17:103:17 | After access to parameter s [non-null] | Switch.cs:103:17:103:25 | access to property Length | 2 |
 | Switch.cs:103:17:103:17 | After access to parameter s [null] | Switch.cs:103:17:103:17 | After access to parameter s [null] | 1 |
-| Switch.cs:103:17:103:25 | After access to property Length | Switch.cs:105:13:105:19 | case ...: | 2 |
-| Switch.cs:105:13:105:19 | After case ...: [match] | Switch.cs:105:21:105:29 | return ...; | 5 |
-| Switch.cs:105:13:105:19 | After case ...: [no-match] | Switch.cs:106:13:106:19 | case ...: | 2 |
-| Switch.cs:106:13:106:19 | After case ...: [match] | Switch.cs:106:21:106:29 | return ...; | 5 |
-| Switch.cs:106:13:106:19 | After case ...: [no-match] | Switch.cs:108:9:108:18 | return ...; | 8 |
+| Switch.cs:103:17:103:25 | After access to property Length | Switch.cs:105:18:105:18 | 0 | 3 |
+| Switch.cs:105:18:105:18 | After 0 [match] | Switch.cs:105:21:105:29 | return ...; | 5 |
+| Switch.cs:105:18:105:18 | After 0 [no-match] | Switch.cs:106:18:106:18 | 1 | 4 |
+| Switch.cs:106:18:106:18 | After 1 [match] | Switch.cs:106:21:106:29 | return ...; | 5 |
+| Switch.cs:106:18:106:18 | After 1 [no-match] | Switch.cs:108:9:108:18 | return ...; | 9 |
 | Switch.cs:111:17:111:21 | Entry | Switch.cs:111:17:111:21 | Exit | 8 |
-| Switch.cs:113:9:113:11 | Entry | Switch.cs:117:13:117:35 | case ...: | 9 |
+| Switch.cs:113:9:113:11 | Entry | Switch.cs:117:18:117:18 | 3 | 10 |
 | Switch.cs:113:9:113:11 | Normal Exit | Switch.cs:113:9:113:11 | Exit | 2 |
 | Switch.cs:115:9:119:9 | After switch (...) {...} | Switch.cs:120:9:120:18 | return ...; | 7 |
-| Switch.cs:117:13:117:35 | After case ...: [match] | Switch.cs:117:25:117:34 | ... == ... | 6 |
-| Switch.cs:117:13:117:35 | After case ...: [no-match] | Switch.cs:117:13:117:35 | After case ...: [no-match] | 1 |
+| Switch.cs:117:18:117:18 | After 3 [match] | Switch.cs:117:25:117:34 | ... == ... | 6 |
+| Switch.cs:117:18:117:18 | After 3 [no-match] | Switch.cs:117:13:117:35 | After case ...: [no-match] | 2 |
 | Switch.cs:117:25:117:34 | After ... == ... [false] | Switch.cs:117:25:117:34 | After ... == ... [false] | 1 |
 | Switch.cs:117:25:117:34 | After ... == ... [true] | Switch.cs:117:37:117:45 | return ...; | 4 |
-| Switch.cs:118:13:118:34 | After case ...: [match] | Switch.cs:118:25:118:33 | ... == ... | 6 |
-| Switch.cs:118:13:118:34 | After case ...: [no-match] | Switch.cs:118:13:118:34 | After case ...: [no-match] | 1 |
-| Switch.cs:118:13:118:34 | case ...: | Switch.cs:118:13:118:34 | case ...: | 1 |
+| Switch.cs:118:13:118:34 | case ...: | Switch.cs:118:18:118:18 | 2 | 2 |
+| Switch.cs:118:18:118:18 | After 2 [match] | Switch.cs:118:25:118:33 | ... == ... | 6 |
+| Switch.cs:118:18:118:18 | After 2 [no-match] | Switch.cs:118:13:118:34 | After case ...: [no-match] | 2 |
 | Switch.cs:118:25:118:33 | After ... == ... [false] | Switch.cs:118:25:118:33 | After ... == ... [false] | 1 |
 | Switch.cs:118:25:118:33 | After ... == ... [true] | Switch.cs:118:36:118:44 | return ...; | 4 |
-| Switch.cs:123:10:123:12 | Entry | Switch.cs:125:24:125:34 | ... => ... | 7 |
+| Switch.cs:123:10:123:12 | Entry | Switch.cs:125:24:125:29 | Boolean b | 8 |
 | Switch.cs:123:10:123:12 | Normal Exit | Switch.cs:123:10:123:12 | Exit | 2 |
 | Switch.cs:125:13:125:48 | After ... switch { ... } [false] | Switch.cs:124:5:127:5 | After {...} | 3 |
 | Switch.cs:125:13:125:48 | After ... switch { ... } [true] | Switch.cs:126:13:126:19 | return ...; | 3 |
-| Switch.cs:125:24:125:34 | After ... => ... [match] | Switch.cs:125:34:125:34 | access to local variable b | 3 |
-| Switch.cs:125:24:125:34 | After ... => ... [no-match] | Switch.cs:125:42:125:46 | false | 5 |
-| Switch.cs:129:12:129:14 | Entry | Switch.cs:131:28:131:40 | ... => ... | 8 |
+| Switch.cs:125:24:125:29 | After Boolean b [match] | Switch.cs:125:34:125:34 | access to local variable b | 3 |
+| Switch.cs:125:24:125:29 | After Boolean b [no-match] | Switch.cs:125:42:125:46 | false | 7 |
+| Switch.cs:129:12:129:14 | Entry | Switch.cs:131:28:131:35 | String s | 9 |
 | Switch.cs:131:16:131:66 | After call to method ToString | Switch.cs:129:12:129:14 | Exit | 4 |
 | Switch.cs:131:17:131:53 | After ... switch { ... } [non-null] | Switch.cs:131:16:131:66 | call to method ToString | 2 |
 | Switch.cs:131:17:131:53 | After ... switch { ... } [null] | Switch.cs:131:17:131:53 | After ... switch { ... } [null] | 1 |
-| Switch.cs:131:28:131:40 | After ... => ... [match] | Switch.cs:131:40:131:40 | access to local variable s | 3 |
-| Switch.cs:131:28:131:40 | After ... => ... [no-match] | Switch.cs:131:48:131:51 | null | 5 |
-| Switch.cs:134:9:134:11 | Entry | Switch.cs:139:13:139:19 | case ...: | 6 |
+| Switch.cs:131:28:131:35 | After String s [match] | Switch.cs:131:40:131:40 | access to local variable s | 3 |
+| Switch.cs:131:28:131:35 | After String s [no-match] | Switch.cs:131:48:131:51 | null | 7 |
+| Switch.cs:134:9:134:11 | Entry | Switch.cs:139:18:139:18 | 1 | 7 |
 | Switch.cs:134:9:134:11 | Normal Exit | Switch.cs:134:9:134:11 | Exit | 2 |
-| Switch.cs:139:13:139:19 | After case ...: [match] | Switch.cs:139:21:139:29 | return ...; | 5 |
-| Switch.cs:139:13:139:19 | After case ...: [no-match] | Switch.cs:140:13:140:19 | case ...: | 2 |
-| Switch.cs:140:13:140:19 | After case ...: [match] | Switch.cs:140:21:140:29 | return ...; | 5 |
-| Switch.cs:140:13:140:19 | After case ...: [no-match] | Switch.cs:138:22:138:31 | return ...; | 9 |
-| Switch.cs:144:9:144:11 | Entry | Switch.cs:148:13:148:19 | case ...: | 6 |
+| Switch.cs:139:18:139:18 | After 1 [match] | Switch.cs:139:21:139:29 | return ...; | 5 |
+| Switch.cs:139:18:139:18 | After 1 [no-match] | Switch.cs:140:18:140:18 | 2 | 4 |
+| Switch.cs:140:18:140:18 | After 2 [match] | Switch.cs:140:21:140:29 | return ...; | 5 |
+| Switch.cs:140:18:140:18 | After 2 [no-match] | Switch.cs:138:22:138:31 | return ...; | 10 |
+| Switch.cs:144:9:144:11 | Entry | Switch.cs:148:18:148:18 | 1 | 7 |
 | Switch.cs:144:9:144:11 | Normal Exit | Switch.cs:144:9:144:11 | Exit | 2 |
-| Switch.cs:148:13:148:19 | After case ...: [match] | Switch.cs:148:21:148:29 | return ...; | 5 |
-| Switch.cs:148:13:148:19 | After case ...: [no-match] | Switch.cs:150:13:150:19 | case ...: | 2 |
-| Switch.cs:150:13:150:19 | After case ...: [match] | Switch.cs:150:21:150:29 | return ...; | 5 |
-| Switch.cs:150:13:150:19 | After case ...: [no-match] | Switch.cs:149:22:149:31 | return ...; | 9 |
-| Switch.cs:154:10:154:12 | Entry | Switch.cs:156:28:156:38 | ... => ... | 9 |
+| Switch.cs:148:18:148:18 | After 1 [match] | Switch.cs:148:21:148:29 | return ...; | 5 |
+| Switch.cs:148:18:148:18 | After 1 [no-match] | Switch.cs:150:18:150:18 | 2 | 4 |
+| Switch.cs:150:18:150:18 | After 2 [match] | Switch.cs:150:21:150:29 | return ...; | 5 |
+| Switch.cs:150:18:150:18 | After 2 [no-match] | Switch.cs:149:22:149:31 | return ...; | 10 |
+| Switch.cs:154:10:154:12 | Entry | Switch.cs:156:28:156:31 | true | 10 |
 | Switch.cs:156:17:156:54 | After ... switch { ... } | Switch.cs:157:13:157:13 | access to parameter b | 6 |
-| Switch.cs:156:28:156:38 | After ... => ... [match] | Switch.cs:156:36:156:38 | "a" | 3 |
-| Switch.cs:156:28:156:38 | After ... => ... [no-match] | Switch.cs:156:41:156:52 | ... => ... | 2 |
-| Switch.cs:156:41:156:52 | After ... => ... [match] | Switch.cs:156:50:156:52 | "b" | 3 |
-| Switch.cs:156:41:156:52 | After ... => ... [no-match] | Switch.cs:156:41:156:52 | After ... => ... [no-match] | 1 |
+| Switch.cs:156:28:156:31 | After true [match] | Switch.cs:156:36:156:38 | "a" | 3 |
+| Switch.cs:156:28:156:31 | After true [no-match] | Switch.cs:156:41:156:45 | false | 4 |
+| Switch.cs:156:41:156:45 | After false [match] | Switch.cs:156:50:156:52 | "b" | 3 |
+| Switch.cs:156:41:156:45 | After false [no-match] | Switch.cs:156:41:156:52 | After ... => ... [no-match] | 2 |
 | Switch.cs:157:9:160:49 | After if (...) ... | Switch.cs:154:10:154:12 | Exit | 4 |
 | Switch.cs:157:13:157:13 | After access to parameter b [false] | Switch.cs:160:13:160:49 | After ...; | 14 |
 | Switch.cs:157:13:157:13 | After access to parameter b [true] | Switch.cs:158:13:158:49 | After ...; | 14 |
-| Switch.cs:163:10:163:12 | Entry | Switch.cs:167:13:167:19 | case ...: | 6 |
+| Switch.cs:163:10:163:12 | Entry | Switch.cs:167:18:167:18 | 1 | 7 |
 | Switch.cs:165:9:177:9 | After switch (...) {...} | Switch.cs:163:10:163:12 | Exit | 4 |
-| Switch.cs:167:13:167:19 | After case ...: [match] | Switch.cs:167:18:167:18 | 1 | 2 |
-| Switch.cs:167:13:167:19 | After case ...: [no-match] | Switch.cs:168:13:168:19 | case ...: | 2 |
-| Switch.cs:168:13:168:19 | After case ...: [match] | Switch.cs:168:18:168:18 | 2 | 2 |
-| Switch.cs:168:13:168:19 | After case ...: [no-match] | Switch.cs:171:13:171:19 | case ...: | 2 |
+| Switch.cs:167:18:167:18 | After 1 [match] | Switch.cs:167:13:167:19 | After case ...: [match] | 2 |
+| Switch.cs:167:18:167:18 | After 1 [no-match] | Switch.cs:168:18:168:18 | 2 | 4 |
+| Switch.cs:168:18:168:18 | After 2 [match] | Switch.cs:168:13:168:19 | After case ...: [match] | 2 |
+| Switch.cs:168:18:168:18 | After 2 [no-match] | Switch.cs:171:18:171:18 | 3 | 4 |
 | Switch.cs:169:17:169:51 | ...; | Switch.cs:170:17:170:22 | break; | 8 |
-| Switch.cs:171:13:171:19 | After case ...: [match] | Switch.cs:173:17:173:22 | break; | 10 |
-| Switch.cs:171:13:171:19 | After case ...: [no-match] | Switch.cs:176:17:176:22 | break; | 11 |
+| Switch.cs:171:18:171:18 | After 3 [match] | Switch.cs:173:17:173:22 | break; | 10 |
+| Switch.cs:171:18:171:18 | After 3 [no-match] | Switch.cs:176:17:176:22 | break; | 12 |
 | TypeAccesses.cs:1:7:1:18 | Entry | TypeAccesses.cs:1:7:1:18 | Exit | 11 |
 | TypeAccesses.cs:3:10:3:10 | Entry | TypeAccesses.cs:7:13:7:22 | ... is ... | 27 |
 | TypeAccesses.cs:7:9:7:25 | After if (...) ... | TypeAccesses.cs:3:10:3:10 | Exit | 11 |
@@ -1157,21 +1158,23 @@
 | cflow.cs:30:18:33:37 | After if (...) ... | cflow.cs:30:18:33:37 | After if (...) ... | 1 |
 | cflow.cs:30:22:30:31 | After ... == ... [false] | cflow.cs:33:17:33:37 | After ...; | 7 |
 | cflow.cs:30:22:30:31 | After ... == ... [true] | cflow.cs:31:17:31:42 | After ...; | 7 |
-| cflow.cs:37:17:37:22 | Entry | cflow.cs:41:13:41:19 | case ...: | 6 |
+| cflow.cs:37:17:37:22 | Entry | cflow.cs:41:18:41:18 | 1 | 7 |
 | cflow.cs:37:17:37:22 | Exit | cflow.cs:37:17:37:22 | Exit | 1 |
-| cflow.cs:39:9:50:9 | After switch (...) {...} | cflow.cs:53:13:53:20 | case ...: | 4 |
-| cflow.cs:41:13:41:19 | After case ...: [match] | cflow.cs:43:17:43:28 | goto case ...; | 11 |
-| cflow.cs:41:13:41:19 | After case ...: [no-match] | cflow.cs:44:13:44:19 | case ...: | 2 |
-| cflow.cs:44:13:44:19 | After case ...: [match] | cflow.cs:46:17:46:28 | goto case ...; | 11 |
-| cflow.cs:44:13:44:19 | After case ...: [no-match] | cflow.cs:47:13:47:19 | case ...: | 2 |
-| cflow.cs:47:13:47:19 | After case ...: [match] | cflow.cs:49:17:49:22 | break; | 10 |
-| cflow.cs:47:13:47:19 | After case ...: [no-match] | cflow.cs:47:13:47:19 | After case ...: [no-match] | 1 |
-| cflow.cs:51:9:59:9 | After switch (...) {...} | cflow.cs:62:13:62:19 | case ...: | 10 |
-| cflow.cs:53:13:53:20 | After case ...: [match] | cflow.cs:55:17:55:22 | break; | 10 |
-| cflow.cs:53:13:53:20 | After case ...: [no-match] | cflow.cs:58:17:58:22 | break; | 11 |
+| cflow.cs:39:9:50:9 | After switch (...) {...} | cflow.cs:53:18:53:19 | 42 | 5 |
+| cflow.cs:41:13:41:19 | After case ...: [match] | cflow.cs:43:17:43:28 | goto case ...; | 10 |
+| cflow.cs:41:18:41:18 | After 1 [match] | cflow.cs:41:18:41:18 | After 1 [match] | 1 |
+| cflow.cs:41:18:41:18 | After 1 [no-match] | cflow.cs:44:18:44:18 | 2 | 4 |
+| cflow.cs:44:13:44:19 | After case ...: [match] | cflow.cs:46:17:46:28 | goto case ...; | 10 |
+| cflow.cs:44:18:44:18 | After 2 [match] | cflow.cs:44:18:44:18 | After 2 [match] | 1 |
+| cflow.cs:44:18:44:18 | After 2 [no-match] | cflow.cs:47:18:47:18 | 3 | 4 |
+| cflow.cs:47:18:47:18 | After 3 [match] | cflow.cs:49:17:49:22 | break; | 10 |
+| cflow.cs:47:18:47:18 | After 3 [no-match] | cflow.cs:47:13:47:19 | After case ...: [no-match] | 2 |
+| cflow.cs:51:9:59:9 | After switch (...) {...} | cflow.cs:62:18:62:18 | 0 | 11 |
+| cflow.cs:53:18:53:19 | After 42 [match] | cflow.cs:55:17:55:22 | break; | 10 |
+| cflow.cs:53:18:53:19 | After 42 [no-match] | cflow.cs:58:17:58:22 | break; | 12 |
 | cflow.cs:60:9:66:9 | After switch (...) {...} | cflow.cs:37:17:37:22 | Normal Exit | 5 |
-| cflow.cs:62:13:62:19 | After case ...: [match] | cflow.cs:63:23:63:33 | ... == ... | 11 |
-| cflow.cs:62:13:62:19 | After case ...: [no-match] | cflow.cs:62:13:62:19 | After case ...: [no-match] | 1 |
+| cflow.cs:62:18:62:18 | After 0 [match] | cflow.cs:63:23:63:33 | ... == ... | 11 |
+| cflow.cs:62:18:62:18 | After 0 [no-match] | cflow.cs:62:13:62:19 | After case ...: [no-match] | 2 |
 | cflow.cs:63:23:63:33 | After ... == ... [false] | cflow.cs:37:17:37:22 | Exceptional Exit | 8 |
 | cflow.cs:63:23:63:33 | After ... == ... [true] | cflow.cs:65:17:65:22 | break; | 5 |
 | cflow.cs:70:18:70:18 | Entry | cflow.cs:72:13:72:21 | ... == ... | 8 |
@@ -1293,15 +1296,15 @@
 | cflow.cs:242:12:242:41 | After if (...) ... | cflow.cs:244:13:244:28 | ... > ... | 12 |
 | cflow.cs:242:19:242:35 | After ... == ... [false] | cflow.cs:242:16:242:36 | After !... [false] | 3 |
 | cflow.cs:242:19:242:35 | After ... == ... [true] | cflow.cs:242:39:242:41 | {...} | 4 |
-| cflow.cs:244:13:244:28 | After ... > ... [false] | cflow.cs:248:13:248:19 | case ...: | 15 |
+| cflow.cs:244:13:244:28 | After ... > ... [false] | cflow.cs:248:18:248:18 | 0 | 16 |
 | cflow.cs:244:13:244:28 | After ... > ... [true] | cflow.cs:244:31:244:41 | goto ...; | 3 |
 | cflow.cs:246:9:258:9 | After switch (...) {...} | cflow.cs:240:10:240:13 | Exit | 4 |
-| cflow.cs:248:13:248:19 | After case ...: [match] | cflow.cs:249:17:249:29 | goto default; | 4 |
-| cflow.cs:248:13:248:19 | After case ...: [no-match] | cflow.cs:250:13:250:19 | case ...: | 2 |
-| cflow.cs:250:13:250:19 | After case ...: [match] | cflow.cs:252:17:252:22 | break; | 10 |
-| cflow.cs:250:13:250:19 | After case ...: [no-match] | cflow.cs:253:13:253:19 | case ...: | 2 |
-| cflow.cs:253:13:253:19 | After case ...: [match] | cflow.cs:254:17:254:27 | goto ...; | 4 |
-| cflow.cs:253:13:253:19 | After case ...: [no-match] | cflow.cs:255:13:255:20 | default: | 2 |
+| cflow.cs:248:18:248:18 | After 0 [match] | cflow.cs:249:17:249:29 | goto default; | 4 |
+| cflow.cs:248:18:248:18 | After 0 [no-match] | cflow.cs:250:18:250:18 | 1 | 4 |
+| cflow.cs:250:18:250:18 | After 1 [match] | cflow.cs:252:17:252:22 | break; | 10 |
+| cflow.cs:250:18:250:18 | After 1 [no-match] | cflow.cs:253:18:253:18 | 2 | 4 |
+| cflow.cs:253:18:253:18 | After 2 [match] | cflow.cs:254:17:254:27 | goto ...; | 4 |
+| cflow.cs:253:18:253:18 | After 2 [no-match] | cflow.cs:255:13:255:20 | default: | 3 |
 | cflow.cs:255:13:255:20 | After default: [match] | cflow.cs:257:17:257:22 | break; | 9 |
 | cflow.cs:261:49:261:53 | Entry | cflow.cs:264:18:264:22 | After Int32 i = ... | 12 |
 | cflow.cs:261:49:261:53 | Exceptional Exit | cflow.cs:261:49:261:53 | Exceptional Exit | 1 |

--- a/csharp/ql/test/library-tests/controlflow/graph/Condition.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Condition.expected
@@ -541,19 +541,19 @@ conditionBlock
 | Patterns.cs:5:10:5:11 | Entry | Patterns.cs:16:14:18:9 | After if (...) ... | false |
 | Patterns.cs:5:10:5:11 | Entry | Patterns.cs:16:18:16:28 | After ... is ... [false] | false |
 | Patterns.cs:5:10:5:11 | Entry | Patterns.cs:16:18:16:28 | [MatchTrue] ... is ... | false |
-| Patterns.cs:8:9:18:9 | After if (...) ... | Patterns.cs:22:13:22:23 | After case ...: [match] | true |
-| Patterns.cs:8:9:18:9 | After if (...) ... | Patterns.cs:22:13:22:23 | After case ...: [no-match] | false |
-| Patterns.cs:8:9:18:9 | After if (...) ... | Patterns.cs:24:13:24:36 | After case ...: [match] | false |
-| Patterns.cs:8:9:18:9 | After if (...) ... | Patterns.cs:24:13:24:36 | After case ...: [no-match] | false |
+| Patterns.cs:8:9:18:9 | After if (...) ... | Patterns.cs:22:18:22:22 | After "xyz" [match] | true |
+| Patterns.cs:8:9:18:9 | After if (...) ... | Patterns.cs:22:18:22:22 | After "xyz" [no-match] | false |
+| Patterns.cs:8:9:18:9 | After if (...) ... | Patterns.cs:24:18:24:23 | After Int32 i2 [match] | false |
+| Patterns.cs:8:9:18:9 | After if (...) ... | Patterns.cs:24:18:24:23 | After Int32 i2 [no-match] | false |
 | Patterns.cs:8:9:18:9 | After if (...) ... | Patterns.cs:24:30:24:35 | After ... > ... [false] | false |
 | Patterns.cs:8:9:18:9 | After if (...) ... | Patterns.cs:24:30:24:35 | After ... > ... [true] | false |
-| Patterns.cs:8:9:18:9 | After if (...) ... | Patterns.cs:27:13:27:24 | After case ...: [match] | false |
-| Patterns.cs:8:9:18:9 | After if (...) ... | Patterns.cs:27:13:27:24 | After case ...: [no-match] | false |
 | Patterns.cs:8:9:18:9 | After if (...) ... | Patterns.cs:27:13:27:24 | case ...: | false |
-| Patterns.cs:8:9:18:9 | After if (...) ... | Patterns.cs:30:13:30:27 | After case ...: [match] | false |
-| Patterns.cs:8:9:18:9 | After if (...) ... | Patterns.cs:30:13:30:27 | After case ...: [no-match] | false |
-| Patterns.cs:8:9:18:9 | After if (...) ... | Patterns.cs:33:13:33:24 | After case ...: [match] | false |
-| Patterns.cs:8:9:18:9 | After if (...) ... | Patterns.cs:33:13:33:24 | After case ...: [no-match] | false |
+| Patterns.cs:8:9:18:9 | After if (...) ... | Patterns.cs:27:18:27:23 | After Int32 i3 [match] | false |
+| Patterns.cs:8:9:18:9 | After if (...) ... | Patterns.cs:27:18:27:23 | After Int32 i3 [no-match] | false |
+| Patterns.cs:8:9:18:9 | After if (...) ... | Patterns.cs:30:18:30:26 | After String s2 [match] | false |
+| Patterns.cs:8:9:18:9 | After if (...) ... | Patterns.cs:30:18:30:26 | After String s2 [no-match] | false |
+| Patterns.cs:8:9:18:9 | After if (...) ... | Patterns.cs:33:18:33:23 | After Object v2 [match] | false |
+| Patterns.cs:8:9:18:9 | After if (...) ... | Patterns.cs:33:18:33:23 | After Object v2 [no-match] | false |
 | Patterns.cs:8:13:8:23 | After ... is ... [false] | Patterns.cs:12:18:12:31 | After ... is ... [false] | false |
 | Patterns.cs:8:13:8:23 | After ... is ... [false] | Patterns.cs:12:18:12:31 | [MatchTrue] ... is ... | true |
 | Patterns.cs:8:13:8:23 | After ... is ... [false] | Patterns.cs:16:14:18:9 | After if (...) ... | false |
@@ -561,24 +561,24 @@ conditionBlock
 | Patterns.cs:8:13:8:23 | After ... is ... [false] | Patterns.cs:16:18:16:28 | [MatchTrue] ... is ... | false |
 | Patterns.cs:12:18:12:31 | After ... is ... [false] | Patterns.cs:16:18:16:28 | After ... is ... [false] | false |
 | Patterns.cs:12:18:12:31 | After ... is ... [false] | Patterns.cs:16:18:16:28 | [MatchTrue] ... is ... | true |
-| Patterns.cs:22:13:22:23 | After case ...: [no-match] | Patterns.cs:24:13:24:36 | After case ...: [match] | true |
-| Patterns.cs:22:13:22:23 | After case ...: [no-match] | Patterns.cs:24:13:24:36 | After case ...: [no-match] | false |
-| Patterns.cs:22:13:22:23 | After case ...: [no-match] | Patterns.cs:24:30:24:35 | After ... > ... [false] | true |
-| Patterns.cs:22:13:22:23 | After case ...: [no-match] | Patterns.cs:24:30:24:35 | After ... > ... [true] | true |
-| Patterns.cs:24:13:24:36 | After case ...: [match] | Patterns.cs:24:30:24:35 | After ... > ... [false] | false |
-| Patterns.cs:24:13:24:36 | After case ...: [match] | Patterns.cs:24:30:24:35 | After ... > ... [true] | true |
-| Patterns.cs:27:13:27:24 | After case ...: [no-match] | Patterns.cs:30:13:30:27 | After case ...: [match] | true |
-| Patterns.cs:27:13:27:24 | After case ...: [no-match] | Patterns.cs:30:13:30:27 | After case ...: [no-match] | false |
-| Patterns.cs:27:13:27:24 | After case ...: [no-match] | Patterns.cs:33:13:33:24 | After case ...: [match] | false |
-| Patterns.cs:27:13:27:24 | After case ...: [no-match] | Patterns.cs:33:13:33:24 | After case ...: [no-match] | false |
-| Patterns.cs:27:13:27:24 | case ...: | Patterns.cs:27:13:27:24 | After case ...: [match] | true |
-| Patterns.cs:27:13:27:24 | case ...: | Patterns.cs:27:13:27:24 | After case ...: [no-match] | false |
-| Patterns.cs:27:13:27:24 | case ...: | Patterns.cs:30:13:30:27 | After case ...: [match] | false |
-| Patterns.cs:27:13:27:24 | case ...: | Patterns.cs:30:13:30:27 | After case ...: [no-match] | false |
-| Patterns.cs:27:13:27:24 | case ...: | Patterns.cs:33:13:33:24 | After case ...: [match] | false |
-| Patterns.cs:27:13:27:24 | case ...: | Patterns.cs:33:13:33:24 | After case ...: [no-match] | false |
-| Patterns.cs:30:13:30:27 | After case ...: [no-match] | Patterns.cs:33:13:33:24 | After case ...: [match] | true |
-| Patterns.cs:30:13:30:27 | After case ...: [no-match] | Patterns.cs:33:13:33:24 | After case ...: [no-match] | false |
+| Patterns.cs:22:18:22:22 | After "xyz" [no-match] | Patterns.cs:24:18:24:23 | After Int32 i2 [match] | true |
+| Patterns.cs:22:18:22:22 | After "xyz" [no-match] | Patterns.cs:24:18:24:23 | After Int32 i2 [no-match] | false |
+| Patterns.cs:22:18:22:22 | After "xyz" [no-match] | Patterns.cs:24:30:24:35 | After ... > ... [false] | true |
+| Patterns.cs:22:18:22:22 | After "xyz" [no-match] | Patterns.cs:24:30:24:35 | After ... > ... [true] | true |
+| Patterns.cs:24:18:24:23 | After Int32 i2 [match] | Patterns.cs:24:30:24:35 | After ... > ... [false] | false |
+| Patterns.cs:24:18:24:23 | After Int32 i2 [match] | Patterns.cs:24:30:24:35 | After ... > ... [true] | true |
+| Patterns.cs:27:13:27:24 | case ...: | Patterns.cs:27:18:27:23 | After Int32 i3 [match] | true |
+| Patterns.cs:27:13:27:24 | case ...: | Patterns.cs:27:18:27:23 | After Int32 i3 [no-match] | false |
+| Patterns.cs:27:13:27:24 | case ...: | Patterns.cs:30:18:30:26 | After String s2 [match] | false |
+| Patterns.cs:27:13:27:24 | case ...: | Patterns.cs:30:18:30:26 | After String s2 [no-match] | false |
+| Patterns.cs:27:13:27:24 | case ...: | Patterns.cs:33:18:33:23 | After Object v2 [match] | false |
+| Patterns.cs:27:13:27:24 | case ...: | Patterns.cs:33:18:33:23 | After Object v2 [no-match] | false |
+| Patterns.cs:27:18:27:23 | After Int32 i3 [no-match] | Patterns.cs:30:18:30:26 | After String s2 [match] | true |
+| Patterns.cs:27:18:27:23 | After Int32 i3 [no-match] | Patterns.cs:30:18:30:26 | After String s2 [no-match] | false |
+| Patterns.cs:27:18:27:23 | After Int32 i3 [no-match] | Patterns.cs:33:18:33:23 | After Object v2 [match] | false |
+| Patterns.cs:27:18:27:23 | After Int32 i3 [no-match] | Patterns.cs:33:18:33:23 | After Object v2 [no-match] | false |
+| Patterns.cs:30:18:30:26 | After String s2 [no-match] | Patterns.cs:33:18:33:23 | After Object v2 [match] | true |
+| Patterns.cs:30:18:30:26 | After String s2 [no-match] | Patterns.cs:33:18:33:23 | After Object v2 [no-match] | false |
 | Patterns.cs:47:24:47:25 | Entry | Patterns.cs:48:9:48:20 | [MatchTrue] ... is ... | true |
 | Patterns.cs:50:24:50:25 | Entry | Patterns.cs:51:9:51:21 | After ... is ... [false] | false |
 | Patterns.cs:50:24:50:25 | Entry | Patterns.cs:51:9:51:21 | [MatchTrue] ... is ... | true |
@@ -589,26 +589,26 @@ conditionBlock
 | Patterns.cs:51:9:51:21 | After ... is ... [false] | Patterns.cs:51:34:51:39 | [MatchTrue] ... is ... | true |
 | Patterns.cs:51:9:51:21 | [MatchTrue] ... is ... | Patterns.cs:51:25:51:30 | [MatchTrue] ... is ... | true |
 | Patterns.cs:53:24:53:25 | Entry | Patterns.cs:54:9:54:37 | [MatchTrue] ... is ... | true |
-| Patterns.cs:56:26:56:27 | Entry | Patterns.cs:60:13:60:28 | After ... => ... [match] | true |
-| Patterns.cs:56:26:56:27 | Entry | Patterns.cs:60:13:60:28 | After ... => ... [no-match] | false |
-| Patterns.cs:65:26:65:27 | Entry | Patterns.cs:69:13:69:33 | After ... => ... [match] | true |
-| Patterns.cs:65:26:65:27 | Entry | Patterns.cs:69:13:69:33 | After ... => ... [no-match] | false |
-| Patterns.cs:65:26:65:27 | Entry | Patterns.cs:70:13:70:27 | After ... => ... [match] | false |
-| Patterns.cs:65:26:65:27 | Entry | Patterns.cs:70:13:70:27 | After ... => ... [no-match] | false |
-| Patterns.cs:69:13:69:33 | After ... => ... [no-match] | Patterns.cs:70:13:70:27 | After ... => ... [match] | true |
-| Patterns.cs:69:13:69:33 | After ... => ... [no-match] | Patterns.cs:70:13:70:27 | After ... => ... [no-match] | false |
-| Patterns.cs:74:26:74:27 | Entry | Patterns.cs:78:13:78:24 | After ... => ... [match] | true |
-| Patterns.cs:74:26:74:27 | Entry | Patterns.cs:78:13:78:24 | After ... => ... [no-match] | false |
-| Patterns.cs:74:26:74:27 | Entry | Patterns.cs:79:13:79:24 | After ... => ... [match] | false |
-| Patterns.cs:74:26:74:27 | Entry | Patterns.cs:79:13:79:24 | After ... => ... [no-match] | false |
-| Patterns.cs:74:26:74:27 | Entry | Patterns.cs:80:13:80:20 | After ... => ... [match] | false |
-| Patterns.cs:74:26:74:27 | Entry | Patterns.cs:80:13:80:20 | After ... => ... [no-match] | false |
-| Patterns.cs:78:13:78:24 | After ... => ... [no-match] | Patterns.cs:79:13:79:24 | After ... => ... [match] | true |
-| Patterns.cs:78:13:78:24 | After ... => ... [no-match] | Patterns.cs:79:13:79:24 | After ... => ... [no-match] | false |
-| Patterns.cs:78:13:78:24 | After ... => ... [no-match] | Patterns.cs:80:13:80:20 | After ... => ... [match] | false |
-| Patterns.cs:78:13:78:24 | After ... => ... [no-match] | Patterns.cs:80:13:80:20 | After ... => ... [no-match] | false |
-| Patterns.cs:79:13:79:24 | After ... => ... [no-match] | Patterns.cs:80:13:80:20 | After ... => ... [match] | true |
-| Patterns.cs:79:13:79:24 | After ... => ... [no-match] | Patterns.cs:80:13:80:20 | After ... => ... [no-match] | false |
+| Patterns.cs:56:26:56:27 | Entry | Patterns.cs:60:13:60:17 | After not ... [match] | true |
+| Patterns.cs:56:26:56:27 | Entry | Patterns.cs:60:13:60:17 | After not ... [no-match] | false |
+| Patterns.cs:65:26:65:27 | Entry | Patterns.cs:69:13:69:17 | After not ... [match] | true |
+| Patterns.cs:65:26:65:27 | Entry | Patterns.cs:69:13:69:17 | After not ... [no-match] | false |
+| Patterns.cs:65:26:65:27 | Entry | Patterns.cs:70:13:70:13 | After 2 [match] | false |
+| Patterns.cs:65:26:65:27 | Entry | Patterns.cs:70:13:70:13 | After 2 [no-match] | false |
+| Patterns.cs:69:13:69:17 | After not ... [no-match] | Patterns.cs:70:13:70:13 | After 2 [match] | true |
+| Patterns.cs:69:13:69:17 | After not ... [no-match] | Patterns.cs:70:13:70:13 | After 2 [no-match] | false |
+| Patterns.cs:74:26:74:27 | Entry | Patterns.cs:78:13:78:15 | After > ... [match] | true |
+| Patterns.cs:74:26:74:27 | Entry | Patterns.cs:78:13:78:15 | After > ... [no-match] | false |
+| Patterns.cs:74:26:74:27 | Entry | Patterns.cs:79:13:79:15 | After < ... [match] | false |
+| Patterns.cs:74:26:74:27 | Entry | Patterns.cs:79:13:79:15 | After < ... [no-match] | false |
+| Patterns.cs:74:26:74:27 | Entry | Patterns.cs:80:13:80:13 | After 1 [match] | false |
+| Patterns.cs:74:26:74:27 | Entry | Patterns.cs:80:13:80:13 | After 1 [no-match] | false |
+| Patterns.cs:78:13:78:15 | After > ... [no-match] | Patterns.cs:79:13:79:15 | After < ... [match] | true |
+| Patterns.cs:78:13:78:15 | After > ... [no-match] | Patterns.cs:79:13:79:15 | After < ... [no-match] | false |
+| Patterns.cs:78:13:78:15 | After > ... [no-match] | Patterns.cs:80:13:80:13 | After 1 [match] | false |
+| Patterns.cs:78:13:78:15 | After > ... [no-match] | Patterns.cs:80:13:80:13 | After 1 [no-match] | false |
+| Patterns.cs:79:13:79:15 | After < ... [no-match] | Patterns.cs:80:13:80:13 | After 1 [match] | true |
+| Patterns.cs:79:13:79:15 | After < ... [no-match] | Patterns.cs:80:13:80:13 | After 1 [no-match] | false |
 | Patterns.cs:85:26:85:27 | Entry | Patterns.cs:85:39:85:53 | After ... is ... [false] | false |
 | Patterns.cs:85:26:85:27 | Entry | Patterns.cs:85:39:85:53 | [MatchTrue] ... is ... | true |
 | Patterns.cs:87:26:87:27 | Entry | Patterns.cs:87:39:87:54 | After ... is ... [false] | false |
@@ -620,187 +620,189 @@ conditionBlock
 | PostDominance.cs:17:10:17:11 | Entry | PostDominance.cs:19:13:19:21 | After ... is ... [false] | false |
 | PostDominance.cs:17:10:17:11 | Entry | PostDominance.cs:19:13:19:21 | [MatchTrue] ... is ... | true |
 | Switch.cs:10:10:10:11 | Entry | Switch.cs:10:10:10:11 | Exceptional Exit | false |
-| Switch.cs:10:10:10:11 | Entry | Switch.cs:14:13:14:21 | After case ...: [match] | true |
-| Switch.cs:10:10:10:11 | Entry | Switch.cs:14:13:14:21 | After case ...: [no-match] | false |
+| Switch.cs:10:10:10:11 | Entry | Switch.cs:14:18:14:20 | After "a" [match] | true |
+| Switch.cs:10:10:10:11 | Entry | Switch.cs:14:18:14:20 | After "a" [no-match] | false |
 | Switch.cs:10:10:10:11 | Entry | Switch.cs:16:13:16:19 | After case ...: [match] | false |
-| Switch.cs:10:10:10:11 | Entry | Switch.cs:16:13:16:19 | After case ...: [no-match] | false |
-| Switch.cs:10:10:10:11 | Entry | Switch.cs:18:13:18:22 | After case ...: [match] | false |
-| Switch.cs:10:10:10:11 | Entry | Switch.cs:18:13:18:22 | After case ...: [no-match] | false |
-| Switch.cs:10:10:10:11 | Entry | Switch.cs:20:13:20:23 | After case ...: [match] | false |
-| Switch.cs:10:10:10:11 | Entry | Switch.cs:20:13:20:23 | After case ...: [no-match] | false |
+| Switch.cs:10:10:10:11 | Entry | Switch.cs:16:18:16:18 | After 0 [match] | false |
+| Switch.cs:10:10:10:11 | Entry | Switch.cs:16:18:16:18 | After 0 [no-match] | false |
+| Switch.cs:10:10:10:11 | Entry | Switch.cs:18:18:18:21 | After null [match] | false |
+| Switch.cs:10:10:10:11 | Entry | Switch.cs:18:18:18:21 | After null [no-match] | false |
+| Switch.cs:10:10:10:11 | Entry | Switch.cs:20:18:20:22 | After Int32 i [match] | false |
+| Switch.cs:10:10:10:11 | Entry | Switch.cs:20:18:20:22 | After Int32 i [no-match] | false |
 | Switch.cs:10:10:10:11 | Entry | Switch.cs:21:21:21:29 | After ... == ... [false] | false |
 | Switch.cs:10:10:10:11 | Entry | Switch.cs:21:21:21:29 | After ... == ... [true] | false |
-| Switch.cs:10:10:10:11 | Entry | Switch.cs:24:13:24:56 | After case ...: [match] | false |
-| Switch.cs:10:10:10:11 | Entry | Switch.cs:24:13:24:56 | After case ...: [no-match] | false |
+| Switch.cs:10:10:10:11 | Entry | Switch.cs:24:18:24:25 | After String s [match] | false |
+| Switch.cs:10:10:10:11 | Entry | Switch.cs:24:18:24:25 | After String s [no-match] | false |
 | Switch.cs:10:10:10:11 | Entry | Switch.cs:24:32:24:43 | After ... > ... [false] | false |
 | Switch.cs:10:10:10:11 | Entry | Switch.cs:24:32:24:43 | After ... > ... [true] | false |
 | Switch.cs:10:10:10:11 | Entry | Switch.cs:24:32:24:55 | After ... && ... [false] | false |
 | Switch.cs:10:10:10:11 | Entry | Switch.cs:24:48:24:55 | After ... != ... [false] | false |
 | Switch.cs:10:10:10:11 | Entry | Switch.cs:24:48:24:55 | After ... != ... [true] | false |
-| Switch.cs:10:10:10:11 | Entry | Switch.cs:27:13:27:39 | After case ...: [match] | false |
-| Switch.cs:10:10:10:11 | Entry | Switch.cs:27:13:27:39 | After case ...: [no-match] | false |
 | Switch.cs:10:10:10:11 | Entry | Switch.cs:27:13:27:39 | case ...: | false |
+| Switch.cs:10:10:10:11 | Entry | Switch.cs:27:18:27:25 | After Double d [match] | false |
+| Switch.cs:10:10:10:11 | Entry | Switch.cs:27:18:27:25 | After Double d [no-match] | false |
 | Switch.cs:10:10:10:11 | Entry | Switch.cs:30:13:30:20 | After default: [match] | false |
-| Switch.cs:14:13:14:21 | After case ...: [no-match] | Switch.cs:16:13:16:19 | After case ...: [no-match] | false |
-| Switch.cs:14:13:14:21 | After case ...: [no-match] | Switch.cs:18:13:18:22 | After case ...: [match] | false |
-| Switch.cs:14:13:14:21 | After case ...: [no-match] | Switch.cs:18:13:18:22 | After case ...: [no-match] | false |
-| Switch.cs:14:13:14:21 | After case ...: [no-match] | Switch.cs:20:13:20:23 | After case ...: [match] | false |
-| Switch.cs:14:13:14:21 | After case ...: [no-match] | Switch.cs:20:13:20:23 | After case ...: [no-match] | false |
-| Switch.cs:14:13:14:21 | After case ...: [no-match] | Switch.cs:21:21:21:29 | After ... == ... [false] | false |
-| Switch.cs:14:13:14:21 | After case ...: [no-match] | Switch.cs:21:21:21:29 | After ... == ... [true] | false |
-| Switch.cs:14:13:14:21 | After case ...: [no-match] | Switch.cs:24:13:24:56 | After case ...: [match] | false |
-| Switch.cs:14:13:14:21 | After case ...: [no-match] | Switch.cs:24:13:24:56 | After case ...: [no-match] | false |
-| Switch.cs:14:13:14:21 | After case ...: [no-match] | Switch.cs:24:32:24:43 | After ... > ... [false] | false |
-| Switch.cs:14:13:14:21 | After case ...: [no-match] | Switch.cs:24:32:24:43 | After ... > ... [true] | false |
-| Switch.cs:14:13:14:21 | After case ...: [no-match] | Switch.cs:24:32:24:55 | After ... && ... [false] | false |
-| Switch.cs:14:13:14:21 | After case ...: [no-match] | Switch.cs:24:48:24:55 | After ... != ... [false] | false |
-| Switch.cs:14:13:14:21 | After case ...: [no-match] | Switch.cs:24:48:24:55 | After ... != ... [true] | false |
-| Switch.cs:14:13:14:21 | After case ...: [no-match] | Switch.cs:27:13:27:39 | After case ...: [match] | false |
-| Switch.cs:14:13:14:21 | After case ...: [no-match] | Switch.cs:27:13:27:39 | After case ...: [no-match] | false |
-| Switch.cs:14:13:14:21 | After case ...: [no-match] | Switch.cs:27:13:27:39 | case ...: | false |
-| Switch.cs:14:13:14:21 | After case ...: [no-match] | Switch.cs:30:13:30:20 | After default: [match] | false |
-| Switch.cs:16:13:16:19 | After case ...: [no-match] | Switch.cs:18:13:18:22 | After case ...: [match] | true |
-| Switch.cs:16:13:16:19 | After case ...: [no-match] | Switch.cs:18:13:18:22 | After case ...: [no-match] | false |
-| Switch.cs:16:13:16:19 | After case ...: [no-match] | Switch.cs:20:13:20:23 | After case ...: [match] | false |
-| Switch.cs:16:13:16:19 | After case ...: [no-match] | Switch.cs:20:13:20:23 | After case ...: [no-match] | false |
-| Switch.cs:16:13:16:19 | After case ...: [no-match] | Switch.cs:21:21:21:29 | After ... == ... [false] | false |
-| Switch.cs:16:13:16:19 | After case ...: [no-match] | Switch.cs:21:21:21:29 | After ... == ... [true] | false |
-| Switch.cs:16:13:16:19 | After case ...: [no-match] | Switch.cs:24:13:24:56 | After case ...: [match] | false |
-| Switch.cs:16:13:16:19 | After case ...: [no-match] | Switch.cs:24:13:24:56 | After case ...: [no-match] | false |
-| Switch.cs:16:13:16:19 | After case ...: [no-match] | Switch.cs:24:32:24:43 | After ... > ... [false] | false |
-| Switch.cs:16:13:16:19 | After case ...: [no-match] | Switch.cs:24:32:24:43 | After ... > ... [true] | false |
-| Switch.cs:16:13:16:19 | After case ...: [no-match] | Switch.cs:24:32:24:55 | After ... && ... [false] | false |
-| Switch.cs:16:13:16:19 | After case ...: [no-match] | Switch.cs:24:48:24:55 | After ... != ... [false] | false |
-| Switch.cs:16:13:16:19 | After case ...: [no-match] | Switch.cs:24:48:24:55 | After ... != ... [true] | false |
-| Switch.cs:16:13:16:19 | After case ...: [no-match] | Switch.cs:27:13:27:39 | After case ...: [match] | false |
-| Switch.cs:16:13:16:19 | After case ...: [no-match] | Switch.cs:27:13:27:39 | After case ...: [no-match] | false |
-| Switch.cs:16:13:16:19 | After case ...: [no-match] | Switch.cs:27:13:27:39 | case ...: | false |
-| Switch.cs:18:13:18:22 | After case ...: [no-match] | Switch.cs:20:13:20:23 | After case ...: [match] | true |
-| Switch.cs:18:13:18:22 | After case ...: [no-match] | Switch.cs:20:13:20:23 | After case ...: [no-match] | false |
-| Switch.cs:18:13:18:22 | After case ...: [no-match] | Switch.cs:21:21:21:29 | After ... == ... [false] | true |
-| Switch.cs:18:13:18:22 | After case ...: [no-match] | Switch.cs:21:21:21:29 | After ... == ... [true] | true |
-| Switch.cs:18:13:18:22 | After case ...: [no-match] | Switch.cs:24:13:24:56 | After case ...: [match] | false |
-| Switch.cs:18:13:18:22 | After case ...: [no-match] | Switch.cs:24:13:24:56 | After case ...: [no-match] | false |
-| Switch.cs:18:13:18:22 | After case ...: [no-match] | Switch.cs:24:32:24:43 | After ... > ... [false] | false |
-| Switch.cs:18:13:18:22 | After case ...: [no-match] | Switch.cs:24:32:24:43 | After ... > ... [true] | false |
-| Switch.cs:18:13:18:22 | After case ...: [no-match] | Switch.cs:24:32:24:55 | After ... && ... [false] | false |
-| Switch.cs:18:13:18:22 | After case ...: [no-match] | Switch.cs:24:48:24:55 | After ... != ... [false] | false |
-| Switch.cs:18:13:18:22 | After case ...: [no-match] | Switch.cs:24:48:24:55 | After ... != ... [true] | false |
-| Switch.cs:18:13:18:22 | After case ...: [no-match] | Switch.cs:27:13:27:39 | After case ...: [match] | false |
-| Switch.cs:18:13:18:22 | After case ...: [no-match] | Switch.cs:27:13:27:39 | After case ...: [no-match] | false |
-| Switch.cs:18:13:18:22 | After case ...: [no-match] | Switch.cs:27:13:27:39 | case ...: | false |
-| Switch.cs:20:13:20:23 | After case ...: [match] | Switch.cs:21:21:21:29 | After ... == ... [false] | false |
-| Switch.cs:20:13:20:23 | After case ...: [match] | Switch.cs:21:21:21:29 | After ... == ... [true] | true |
-| Switch.cs:20:13:20:23 | After case ...: [no-match] | Switch.cs:24:13:24:56 | After case ...: [match] | true |
-| Switch.cs:20:13:20:23 | After case ...: [no-match] | Switch.cs:24:13:24:56 | After case ...: [no-match] | false |
-| Switch.cs:20:13:20:23 | After case ...: [no-match] | Switch.cs:24:32:24:43 | After ... > ... [false] | true |
-| Switch.cs:20:13:20:23 | After case ...: [no-match] | Switch.cs:24:32:24:43 | After ... > ... [true] | true |
-| Switch.cs:20:13:20:23 | After case ...: [no-match] | Switch.cs:24:32:24:55 | After ... && ... [false] | true |
-| Switch.cs:20:13:20:23 | After case ...: [no-match] | Switch.cs:24:48:24:55 | After ... != ... [false] | true |
-| Switch.cs:20:13:20:23 | After case ...: [no-match] | Switch.cs:24:48:24:55 | After ... != ... [true] | true |
-| Switch.cs:24:13:24:56 | After case ...: [match] | Switch.cs:24:32:24:43 | After ... > ... [false] | false |
-| Switch.cs:24:13:24:56 | After case ...: [match] | Switch.cs:24:32:24:43 | After ... > ... [true] | true |
-| Switch.cs:24:13:24:56 | After case ...: [match] | Switch.cs:24:48:24:55 | After ... != ... [false] | true |
-| Switch.cs:24:13:24:56 | After case ...: [match] | Switch.cs:24:48:24:55 | After ... != ... [true] | true |
+| Switch.cs:14:18:14:20 | After "a" [no-match] | Switch.cs:16:18:16:18 | After 0 [match] | true |
+| Switch.cs:14:18:14:20 | After "a" [no-match] | Switch.cs:16:18:16:18 | After 0 [no-match] | false |
+| Switch.cs:14:18:14:20 | After "a" [no-match] | Switch.cs:18:18:18:21 | After null [match] | false |
+| Switch.cs:14:18:14:20 | After "a" [no-match] | Switch.cs:18:18:18:21 | After null [no-match] | false |
+| Switch.cs:14:18:14:20 | After "a" [no-match] | Switch.cs:20:18:20:22 | After Int32 i [match] | false |
+| Switch.cs:14:18:14:20 | After "a" [no-match] | Switch.cs:20:18:20:22 | After Int32 i [no-match] | false |
+| Switch.cs:14:18:14:20 | After "a" [no-match] | Switch.cs:21:21:21:29 | After ... == ... [false] | false |
+| Switch.cs:14:18:14:20 | After "a" [no-match] | Switch.cs:21:21:21:29 | After ... == ... [true] | false |
+| Switch.cs:14:18:14:20 | After "a" [no-match] | Switch.cs:24:18:24:25 | After String s [match] | false |
+| Switch.cs:14:18:14:20 | After "a" [no-match] | Switch.cs:24:18:24:25 | After String s [no-match] | false |
+| Switch.cs:14:18:14:20 | After "a" [no-match] | Switch.cs:24:32:24:43 | After ... > ... [false] | false |
+| Switch.cs:14:18:14:20 | After "a" [no-match] | Switch.cs:24:32:24:43 | After ... > ... [true] | false |
+| Switch.cs:14:18:14:20 | After "a" [no-match] | Switch.cs:24:32:24:55 | After ... && ... [false] | false |
+| Switch.cs:14:18:14:20 | After "a" [no-match] | Switch.cs:24:48:24:55 | After ... != ... [false] | false |
+| Switch.cs:14:18:14:20 | After "a" [no-match] | Switch.cs:24:48:24:55 | After ... != ... [true] | false |
+| Switch.cs:14:18:14:20 | After "a" [no-match] | Switch.cs:27:13:27:39 | case ...: | false |
+| Switch.cs:14:18:14:20 | After "a" [no-match] | Switch.cs:27:18:27:25 | After Double d [match] | false |
+| Switch.cs:14:18:14:20 | After "a" [no-match] | Switch.cs:27:18:27:25 | After Double d [no-match] | false |
+| Switch.cs:14:18:14:20 | After "a" [no-match] | Switch.cs:30:13:30:20 | After default: [match] | false |
+| Switch.cs:16:18:16:18 | After 0 [no-match] | Switch.cs:18:18:18:21 | After null [match] | true |
+| Switch.cs:16:18:16:18 | After 0 [no-match] | Switch.cs:18:18:18:21 | After null [no-match] | false |
+| Switch.cs:16:18:16:18 | After 0 [no-match] | Switch.cs:20:18:20:22 | After Int32 i [match] | false |
+| Switch.cs:16:18:16:18 | After 0 [no-match] | Switch.cs:20:18:20:22 | After Int32 i [no-match] | false |
+| Switch.cs:16:18:16:18 | After 0 [no-match] | Switch.cs:21:21:21:29 | After ... == ... [false] | false |
+| Switch.cs:16:18:16:18 | After 0 [no-match] | Switch.cs:21:21:21:29 | After ... == ... [true] | false |
+| Switch.cs:16:18:16:18 | After 0 [no-match] | Switch.cs:24:18:24:25 | After String s [match] | false |
+| Switch.cs:16:18:16:18 | After 0 [no-match] | Switch.cs:24:18:24:25 | After String s [no-match] | false |
+| Switch.cs:16:18:16:18 | After 0 [no-match] | Switch.cs:24:32:24:43 | After ... > ... [false] | false |
+| Switch.cs:16:18:16:18 | After 0 [no-match] | Switch.cs:24:32:24:43 | After ... > ... [true] | false |
+| Switch.cs:16:18:16:18 | After 0 [no-match] | Switch.cs:24:32:24:55 | After ... && ... [false] | false |
+| Switch.cs:16:18:16:18 | After 0 [no-match] | Switch.cs:24:48:24:55 | After ... != ... [false] | false |
+| Switch.cs:16:18:16:18 | After 0 [no-match] | Switch.cs:24:48:24:55 | After ... != ... [true] | false |
+| Switch.cs:16:18:16:18 | After 0 [no-match] | Switch.cs:27:13:27:39 | case ...: | false |
+| Switch.cs:16:18:16:18 | After 0 [no-match] | Switch.cs:27:18:27:25 | After Double d [match] | false |
+| Switch.cs:16:18:16:18 | After 0 [no-match] | Switch.cs:27:18:27:25 | After Double d [no-match] | false |
+| Switch.cs:18:18:18:21 | After null [no-match] | Switch.cs:20:18:20:22 | After Int32 i [match] | true |
+| Switch.cs:18:18:18:21 | After null [no-match] | Switch.cs:20:18:20:22 | After Int32 i [no-match] | false |
+| Switch.cs:18:18:18:21 | After null [no-match] | Switch.cs:21:21:21:29 | After ... == ... [false] | true |
+| Switch.cs:18:18:18:21 | After null [no-match] | Switch.cs:21:21:21:29 | After ... == ... [true] | true |
+| Switch.cs:18:18:18:21 | After null [no-match] | Switch.cs:24:18:24:25 | After String s [match] | false |
+| Switch.cs:18:18:18:21 | After null [no-match] | Switch.cs:24:18:24:25 | After String s [no-match] | false |
+| Switch.cs:18:18:18:21 | After null [no-match] | Switch.cs:24:32:24:43 | After ... > ... [false] | false |
+| Switch.cs:18:18:18:21 | After null [no-match] | Switch.cs:24:32:24:43 | After ... > ... [true] | false |
+| Switch.cs:18:18:18:21 | After null [no-match] | Switch.cs:24:32:24:55 | After ... && ... [false] | false |
+| Switch.cs:18:18:18:21 | After null [no-match] | Switch.cs:24:48:24:55 | After ... != ... [false] | false |
+| Switch.cs:18:18:18:21 | After null [no-match] | Switch.cs:24:48:24:55 | After ... != ... [true] | false |
+| Switch.cs:18:18:18:21 | After null [no-match] | Switch.cs:27:13:27:39 | case ...: | false |
+| Switch.cs:18:18:18:21 | After null [no-match] | Switch.cs:27:18:27:25 | After Double d [match] | false |
+| Switch.cs:18:18:18:21 | After null [no-match] | Switch.cs:27:18:27:25 | After Double d [no-match] | false |
+| Switch.cs:20:18:20:22 | After Int32 i [match] | Switch.cs:21:21:21:29 | After ... == ... [false] | false |
+| Switch.cs:20:18:20:22 | After Int32 i [match] | Switch.cs:21:21:21:29 | After ... == ... [true] | true |
+| Switch.cs:20:18:20:22 | After Int32 i [no-match] | Switch.cs:24:18:24:25 | After String s [match] | true |
+| Switch.cs:20:18:20:22 | After Int32 i [no-match] | Switch.cs:24:18:24:25 | After String s [no-match] | false |
+| Switch.cs:20:18:20:22 | After Int32 i [no-match] | Switch.cs:24:32:24:43 | After ... > ... [false] | true |
+| Switch.cs:20:18:20:22 | After Int32 i [no-match] | Switch.cs:24:32:24:43 | After ... > ... [true] | true |
+| Switch.cs:20:18:20:22 | After Int32 i [no-match] | Switch.cs:24:32:24:55 | After ... && ... [false] | true |
+| Switch.cs:20:18:20:22 | After Int32 i [no-match] | Switch.cs:24:48:24:55 | After ... != ... [false] | true |
+| Switch.cs:20:18:20:22 | After Int32 i [no-match] | Switch.cs:24:48:24:55 | After ... != ... [true] | true |
+| Switch.cs:24:18:24:25 | After String s [match] | Switch.cs:24:32:24:43 | After ... > ... [false] | false |
+| Switch.cs:24:18:24:25 | After String s [match] | Switch.cs:24:32:24:43 | After ... > ... [true] | true |
+| Switch.cs:24:18:24:25 | After String s [match] | Switch.cs:24:48:24:55 | After ... != ... [false] | true |
+| Switch.cs:24:18:24:25 | After String s [match] | Switch.cs:24:48:24:55 | After ... != ... [true] | true |
 | Switch.cs:24:32:24:43 | After ... > ... [true] | Switch.cs:24:48:24:55 | After ... != ... [false] | false |
 | Switch.cs:24:32:24:43 | After ... > ... [true] | Switch.cs:24:48:24:55 | After ... != ... [true] | true |
-| Switch.cs:27:13:27:39 | case ...: | Switch.cs:27:13:27:39 | After case ...: [match] | true |
-| Switch.cs:27:13:27:39 | case ...: | Switch.cs:27:13:27:39 | After case ...: [no-match] | false |
-| Switch.cs:44:10:44:11 | Entry | Switch.cs:48:13:48:23 | After case ...: [match] | true |
-| Switch.cs:44:10:44:11 | Entry | Switch.cs:48:13:48:23 | After case ...: [no-match] | false |
-| Switch.cs:44:10:44:11 | Entry | Switch.cs:50:13:50:39 | After case ...: [match] | false |
-| Switch.cs:44:10:44:11 | Entry | Switch.cs:50:13:50:39 | After case ...: [no-match] | false |
+| Switch.cs:27:13:27:39 | case ...: | Switch.cs:27:18:27:25 | After Double d [match] | true |
+| Switch.cs:27:13:27:39 | case ...: | Switch.cs:27:18:27:25 | After Double d [no-match] | false |
+| Switch.cs:44:10:44:11 | Entry | Switch.cs:48:18:48:20 | After access to type Int32 [match] | true |
+| Switch.cs:44:10:44:11 | Entry | Switch.cs:48:18:48:20 | After access to type Int32 [no-match] | false |
+| Switch.cs:44:10:44:11 | Entry | Switch.cs:50:18:50:21 | After access to type Boolean [match] | false |
+| Switch.cs:44:10:44:11 | Entry | Switch.cs:50:18:50:21 | After access to type Boolean [no-match] | false |
 | Switch.cs:44:10:44:11 | Entry | Switch.cs:50:30:50:38 | After ... != ... [false] | false |
 | Switch.cs:44:10:44:11 | Entry | Switch.cs:50:30:50:38 | After ... != ... [true] | false |
-| Switch.cs:48:13:48:23 | After case ...: [no-match] | Switch.cs:50:13:50:39 | After case ...: [match] | true |
-| Switch.cs:48:13:48:23 | After case ...: [no-match] | Switch.cs:50:13:50:39 | After case ...: [no-match] | false |
-| Switch.cs:48:13:48:23 | After case ...: [no-match] | Switch.cs:50:30:50:38 | After ... != ... [false] | true |
-| Switch.cs:48:13:48:23 | After case ...: [no-match] | Switch.cs:50:30:50:38 | After ... != ... [true] | true |
-| Switch.cs:50:13:50:39 | After case ...: [match] | Switch.cs:50:30:50:38 | After ... != ... [false] | false |
-| Switch.cs:50:13:50:39 | After case ...: [match] | Switch.cs:50:30:50:38 | After ... != ... [true] | true |
-| Switch.cs:55:10:55:11 | Entry | Switch.cs:59:13:59:19 | After case ...: [match] | true |
-| Switch.cs:55:10:55:11 | Entry | Switch.cs:59:13:59:19 | After case ...: [no-match] | false |
-| Switch.cs:55:10:55:11 | Entry | Switch.cs:61:13:61:19 | After case ...: [match] | false |
-| Switch.cs:55:10:55:11 | Entry | Switch.cs:61:13:61:19 | After case ...: [no-match] | false |
-| Switch.cs:59:13:59:19 | After case ...: [no-match] | Switch.cs:61:13:61:19 | After case ...: [match] | true |
-| Switch.cs:59:13:59:19 | After case ...: [no-match] | Switch.cs:61:13:61:19 | After case ...: [no-match] | false |
-| Switch.cs:66:10:66:11 | Entry | Switch.cs:70:13:70:23 | After case ...: [match] | true |
-| Switch.cs:66:10:66:11 | Entry | Switch.cs:70:13:70:23 | After case ...: [no-match] | false |
-| Switch.cs:66:10:66:11 | Entry | Switch.cs:72:13:72:20 | After case ...: [match] | false |
-| Switch.cs:66:10:66:11 | Entry | Switch.cs:72:13:72:20 | After case ...: [no-match] | false |
-| Switch.cs:70:13:70:23 | After case ...: [no-match] | Switch.cs:72:13:72:20 | After case ...: [match] | true |
-| Switch.cs:70:13:70:23 | After case ...: [no-match] | Switch.cs:72:13:72:20 | After case ...: [no-match] | false |
+| Switch.cs:48:18:48:20 | After access to type Int32 [no-match] | Switch.cs:50:18:50:21 | After access to type Boolean [match] | true |
+| Switch.cs:48:18:48:20 | After access to type Int32 [no-match] | Switch.cs:50:18:50:21 | After access to type Boolean [no-match] | false |
+| Switch.cs:48:18:48:20 | After access to type Int32 [no-match] | Switch.cs:50:30:50:38 | After ... != ... [false] | true |
+| Switch.cs:48:18:48:20 | After access to type Int32 [no-match] | Switch.cs:50:30:50:38 | After ... != ... [true] | true |
+| Switch.cs:50:18:50:21 | After access to type Boolean [match] | Switch.cs:50:30:50:38 | After ... != ... [false] | false |
+| Switch.cs:50:18:50:21 | After access to type Boolean [match] | Switch.cs:50:30:50:38 | After ... != ... [true] | true |
+| Switch.cs:55:10:55:11 | Entry | Switch.cs:59:18:59:18 | After 2 [match] | true |
+| Switch.cs:55:10:55:11 | Entry | Switch.cs:59:18:59:18 | After 2 [no-match] | false |
+| Switch.cs:55:10:55:11 | Entry | Switch.cs:61:18:61:18 | After 3 [match] | false |
+| Switch.cs:55:10:55:11 | Entry | Switch.cs:61:18:61:18 | After 3 [no-match] | false |
+| Switch.cs:59:18:59:18 | After 2 [no-match] | Switch.cs:61:18:61:18 | After 3 [match] | true |
+| Switch.cs:59:18:59:18 | After 2 [no-match] | Switch.cs:61:18:61:18 | After 3 [no-match] | false |
+| Switch.cs:66:10:66:11 | Entry | Switch.cs:70:18:70:20 | After access to type Int32 [match] | true |
+| Switch.cs:66:10:66:11 | Entry | Switch.cs:70:18:70:20 | After access to type Int32 [no-match] | false |
+| Switch.cs:66:10:66:11 | Entry | Switch.cs:72:18:72:19 | After "" [match] | false |
+| Switch.cs:66:10:66:11 | Entry | Switch.cs:72:18:72:19 | After "" [no-match] | false |
+| Switch.cs:70:18:70:20 | After access to type Int32 [no-match] | Switch.cs:72:18:72:19 | After "" [match] | true |
+| Switch.cs:70:18:70:20 | After access to type Int32 [no-match] | Switch.cs:72:18:72:19 | After "" [no-match] | false |
 | Switch.cs:77:10:77:11 | Entry | Switch.cs:79:9:87:9 | After switch (...) {...} | false |
-| Switch.cs:77:10:77:11 | Entry | Switch.cs:81:13:81:19 | After case ...: [match] | true |
-| Switch.cs:77:10:77:11 | Entry | Switch.cs:81:13:81:19 | After case ...: [no-match] | false |
-| Switch.cs:77:10:77:11 | Entry | Switch.cs:83:13:83:19 | After case ...: [match] | false |
-| Switch.cs:77:10:77:11 | Entry | Switch.cs:83:13:83:19 | After case ...: [no-match] | false |
+| Switch.cs:77:10:77:11 | Entry | Switch.cs:81:18:81:18 | After 1 [match] | true |
+| Switch.cs:77:10:77:11 | Entry | Switch.cs:81:18:81:18 | After 1 [no-match] | false |
+| Switch.cs:77:10:77:11 | Entry | Switch.cs:83:18:83:18 | After 2 [match] | false |
+| Switch.cs:77:10:77:11 | Entry | Switch.cs:83:18:83:18 | After 2 [no-match] | false |
 | Switch.cs:77:10:77:11 | Entry | Switch.cs:84:21:84:25 | After ... > ... [false] | false |
 | Switch.cs:77:10:77:11 | Entry | Switch.cs:84:21:84:25 | After ... > ... [true] | false |
-| Switch.cs:81:13:81:19 | After case ...: [no-match] | Switch.cs:83:13:83:19 | After case ...: [match] | true |
-| Switch.cs:81:13:81:19 | After case ...: [no-match] | Switch.cs:83:13:83:19 | After case ...: [no-match] | false |
-| Switch.cs:81:13:81:19 | After case ...: [no-match] | Switch.cs:84:21:84:25 | After ... > ... [false] | true |
-| Switch.cs:81:13:81:19 | After case ...: [no-match] | Switch.cs:84:21:84:25 | After ... > ... [true] | true |
-| Switch.cs:83:13:83:19 | After case ...: [match] | Switch.cs:84:21:84:25 | After ... > ... [false] | false |
-| Switch.cs:83:13:83:19 | After case ...: [match] | Switch.cs:84:21:84:25 | After ... > ... [true] | true |
-| Switch.cs:91:10:91:11 | Entry | Switch.cs:95:13:95:23 | After case ...: [match] | true |
-| Switch.cs:91:10:91:11 | Entry | Switch.cs:95:13:95:23 | After case ...: [no-match] | false |
+| Switch.cs:81:18:81:18 | After 1 [no-match] | Switch.cs:83:18:83:18 | After 2 [match] | true |
+| Switch.cs:81:18:81:18 | After 1 [no-match] | Switch.cs:83:18:83:18 | After 2 [no-match] | false |
+| Switch.cs:81:18:81:18 | After 1 [no-match] | Switch.cs:84:21:84:25 | After ... > ... [false] | true |
+| Switch.cs:81:18:81:18 | After 1 [no-match] | Switch.cs:84:21:84:25 | After ... > ... [true] | true |
+| Switch.cs:83:18:83:18 | After 2 [match] | Switch.cs:84:21:84:25 | After ... > ... [false] | false |
+| Switch.cs:83:18:83:18 | After 2 [match] | Switch.cs:84:21:84:25 | After ... > ... [true] | true |
+| Switch.cs:91:10:91:11 | Entry | Switch.cs:95:18:95:20 | After access to type Int32 [match] | true |
+| Switch.cs:91:10:91:11 | Entry | Switch.cs:95:18:95:20 | After access to type Int32 [no-match] | false |
 | Switch.cs:101:9:101:10 | Entry | Switch.cs:103:17:103:17 | After access to parameter s [non-null] | false |
 | Switch.cs:101:9:101:10 | Entry | Switch.cs:103:17:103:17 | After access to parameter s [null] | true |
-| Switch.cs:103:17:103:25 | After access to property Length | Switch.cs:105:13:105:19 | After case ...: [match] | true |
-| Switch.cs:103:17:103:25 | After access to property Length | Switch.cs:105:13:105:19 | After case ...: [no-match] | false |
-| Switch.cs:103:17:103:25 | After access to property Length | Switch.cs:106:13:106:19 | After case ...: [match] | false |
-| Switch.cs:103:17:103:25 | After access to property Length | Switch.cs:106:13:106:19 | After case ...: [no-match] | false |
-| Switch.cs:105:13:105:19 | After case ...: [no-match] | Switch.cs:106:13:106:19 | After case ...: [match] | true |
-| Switch.cs:105:13:105:19 | After case ...: [no-match] | Switch.cs:106:13:106:19 | After case ...: [no-match] | false |
-| Switch.cs:113:9:113:11 | Entry | Switch.cs:117:13:117:35 | After case ...: [match] | true |
-| Switch.cs:113:9:113:11 | Entry | Switch.cs:117:13:117:35 | After case ...: [no-match] | false |
+| Switch.cs:103:17:103:25 | After access to property Length | Switch.cs:105:18:105:18 | After 0 [match] | true |
+| Switch.cs:103:17:103:25 | After access to property Length | Switch.cs:105:18:105:18 | After 0 [no-match] | false |
+| Switch.cs:103:17:103:25 | After access to property Length | Switch.cs:106:18:106:18 | After 1 [match] | false |
+| Switch.cs:103:17:103:25 | After access to property Length | Switch.cs:106:18:106:18 | After 1 [no-match] | false |
+| Switch.cs:105:18:105:18 | After 0 [no-match] | Switch.cs:106:18:106:18 | After 1 [match] | true |
+| Switch.cs:105:18:105:18 | After 0 [no-match] | Switch.cs:106:18:106:18 | After 1 [no-match] | false |
+| Switch.cs:113:9:113:11 | Entry | Switch.cs:117:18:117:18 | After 3 [match] | true |
+| Switch.cs:113:9:113:11 | Entry | Switch.cs:117:18:117:18 | After 3 [no-match] | false |
 | Switch.cs:113:9:113:11 | Entry | Switch.cs:117:25:117:34 | After ... == ... [false] | true |
 | Switch.cs:113:9:113:11 | Entry | Switch.cs:117:25:117:34 | After ... == ... [true] | true |
-| Switch.cs:117:13:117:35 | After case ...: [match] | Switch.cs:117:25:117:34 | After ... == ... [false] | false |
-| Switch.cs:117:13:117:35 | After case ...: [match] | Switch.cs:117:25:117:34 | After ... == ... [true] | true |
-| Switch.cs:118:13:118:34 | After case ...: [match] | Switch.cs:118:25:118:33 | After ... == ... [false] | false |
-| Switch.cs:118:13:118:34 | After case ...: [match] | Switch.cs:118:25:118:33 | After ... == ... [true] | true |
-| Switch.cs:118:13:118:34 | case ...: | Switch.cs:118:13:118:34 | After case ...: [match] | true |
-| Switch.cs:118:13:118:34 | case ...: | Switch.cs:118:13:118:34 | After case ...: [no-match] | false |
+| Switch.cs:117:18:117:18 | After 3 [match] | Switch.cs:117:25:117:34 | After ... == ... [false] | false |
+| Switch.cs:117:18:117:18 | After 3 [match] | Switch.cs:117:25:117:34 | After ... == ... [true] | true |
+| Switch.cs:118:13:118:34 | case ...: | Switch.cs:118:18:118:18 | After 2 [match] | true |
+| Switch.cs:118:13:118:34 | case ...: | Switch.cs:118:18:118:18 | After 2 [no-match] | false |
 | Switch.cs:118:13:118:34 | case ...: | Switch.cs:118:25:118:33 | After ... == ... [false] | true |
 | Switch.cs:118:13:118:34 | case ...: | Switch.cs:118:25:118:33 | After ... == ... [true] | true |
-| Switch.cs:123:10:123:12 | Entry | Switch.cs:125:24:125:34 | After ... => ... [match] | true |
-| Switch.cs:123:10:123:12 | Entry | Switch.cs:125:24:125:34 | After ... => ... [no-match] | false |
-| Switch.cs:129:12:129:14 | Entry | Switch.cs:131:28:131:40 | After ... => ... [match] | true |
-| Switch.cs:129:12:129:14 | Entry | Switch.cs:131:28:131:40 | After ... => ... [no-match] | false |
-| Switch.cs:134:9:134:11 | Entry | Switch.cs:139:13:139:19 | After case ...: [match] | true |
-| Switch.cs:134:9:134:11 | Entry | Switch.cs:139:13:139:19 | After case ...: [no-match] | false |
-| Switch.cs:134:9:134:11 | Entry | Switch.cs:140:13:140:19 | After case ...: [match] | false |
-| Switch.cs:134:9:134:11 | Entry | Switch.cs:140:13:140:19 | After case ...: [no-match] | false |
-| Switch.cs:139:13:139:19 | After case ...: [no-match] | Switch.cs:140:13:140:19 | After case ...: [match] | true |
-| Switch.cs:139:13:139:19 | After case ...: [no-match] | Switch.cs:140:13:140:19 | After case ...: [no-match] | false |
-| Switch.cs:144:9:144:11 | Entry | Switch.cs:148:13:148:19 | After case ...: [match] | true |
-| Switch.cs:144:9:144:11 | Entry | Switch.cs:148:13:148:19 | After case ...: [no-match] | false |
-| Switch.cs:144:9:144:11 | Entry | Switch.cs:150:13:150:19 | After case ...: [match] | false |
-| Switch.cs:144:9:144:11 | Entry | Switch.cs:150:13:150:19 | After case ...: [no-match] | false |
-| Switch.cs:148:13:148:19 | After case ...: [no-match] | Switch.cs:150:13:150:19 | After case ...: [match] | true |
-| Switch.cs:148:13:148:19 | After case ...: [no-match] | Switch.cs:150:13:150:19 | After case ...: [no-match] | false |
-| Switch.cs:154:10:154:12 | Entry | Switch.cs:156:28:156:38 | After ... => ... [match] | true |
-| Switch.cs:154:10:154:12 | Entry | Switch.cs:156:28:156:38 | After ... => ... [no-match] | false |
-| Switch.cs:154:10:154:12 | Entry | Switch.cs:156:41:156:52 | After ... => ... [match] | false |
-| Switch.cs:154:10:154:12 | Entry | Switch.cs:156:41:156:52 | After ... => ... [no-match] | false |
+| Switch.cs:118:18:118:18 | After 2 [match] | Switch.cs:118:25:118:33 | After ... == ... [false] | false |
+| Switch.cs:118:18:118:18 | After 2 [match] | Switch.cs:118:25:118:33 | After ... == ... [true] | true |
+| Switch.cs:123:10:123:12 | Entry | Switch.cs:125:24:125:29 | After Boolean b [match] | true |
+| Switch.cs:123:10:123:12 | Entry | Switch.cs:125:24:125:29 | After Boolean b [no-match] | false |
+| Switch.cs:129:12:129:14 | Entry | Switch.cs:131:28:131:35 | After String s [match] | true |
+| Switch.cs:129:12:129:14 | Entry | Switch.cs:131:28:131:35 | After String s [no-match] | false |
+| Switch.cs:134:9:134:11 | Entry | Switch.cs:139:18:139:18 | After 1 [match] | true |
+| Switch.cs:134:9:134:11 | Entry | Switch.cs:139:18:139:18 | After 1 [no-match] | false |
+| Switch.cs:134:9:134:11 | Entry | Switch.cs:140:18:140:18 | After 2 [match] | false |
+| Switch.cs:134:9:134:11 | Entry | Switch.cs:140:18:140:18 | After 2 [no-match] | false |
+| Switch.cs:139:18:139:18 | After 1 [no-match] | Switch.cs:140:18:140:18 | After 2 [match] | true |
+| Switch.cs:139:18:139:18 | After 1 [no-match] | Switch.cs:140:18:140:18 | After 2 [no-match] | false |
+| Switch.cs:144:9:144:11 | Entry | Switch.cs:148:18:148:18 | After 1 [match] | true |
+| Switch.cs:144:9:144:11 | Entry | Switch.cs:148:18:148:18 | After 1 [no-match] | false |
+| Switch.cs:144:9:144:11 | Entry | Switch.cs:150:18:150:18 | After 2 [match] | false |
+| Switch.cs:144:9:144:11 | Entry | Switch.cs:150:18:150:18 | After 2 [no-match] | false |
+| Switch.cs:148:18:148:18 | After 1 [no-match] | Switch.cs:150:18:150:18 | After 2 [match] | true |
+| Switch.cs:148:18:148:18 | After 1 [no-match] | Switch.cs:150:18:150:18 | After 2 [no-match] | false |
+| Switch.cs:154:10:154:12 | Entry | Switch.cs:156:28:156:31 | After true [match] | true |
+| Switch.cs:154:10:154:12 | Entry | Switch.cs:156:28:156:31 | After true [no-match] | false |
+| Switch.cs:154:10:154:12 | Entry | Switch.cs:156:41:156:45 | After false [match] | false |
+| Switch.cs:154:10:154:12 | Entry | Switch.cs:156:41:156:45 | After false [no-match] | false |
 | Switch.cs:156:17:156:54 | After ... switch { ... } | Switch.cs:157:13:157:13 | After access to parameter b [false] | false |
 | Switch.cs:156:17:156:54 | After ... switch { ... } | Switch.cs:157:13:157:13 | After access to parameter b [true] | true |
-| Switch.cs:156:28:156:38 | After ... => ... [no-match] | Switch.cs:156:41:156:52 | After ... => ... [match] | true |
-| Switch.cs:156:28:156:38 | After ... => ... [no-match] | Switch.cs:156:41:156:52 | After ... => ... [no-match] | false |
-| Switch.cs:163:10:163:12 | Entry | Switch.cs:167:13:167:19 | After case ...: [match] | true |
-| Switch.cs:163:10:163:12 | Entry | Switch.cs:167:13:167:19 | After case ...: [no-match] | false |
-| Switch.cs:163:10:163:12 | Entry | Switch.cs:168:13:168:19 | After case ...: [match] | false |
-| Switch.cs:163:10:163:12 | Entry | Switch.cs:168:13:168:19 | After case ...: [no-match] | false |
-| Switch.cs:163:10:163:12 | Entry | Switch.cs:171:13:171:19 | After case ...: [match] | false |
-| Switch.cs:163:10:163:12 | Entry | Switch.cs:171:13:171:19 | After case ...: [no-match] | false |
-| Switch.cs:167:13:167:19 | After case ...: [no-match] | Switch.cs:168:13:168:19 | After case ...: [match] | true |
-| Switch.cs:167:13:167:19 | After case ...: [no-match] | Switch.cs:168:13:168:19 | After case ...: [no-match] | false |
-| Switch.cs:167:13:167:19 | After case ...: [no-match] | Switch.cs:171:13:171:19 | After case ...: [match] | false |
-| Switch.cs:167:13:167:19 | After case ...: [no-match] | Switch.cs:171:13:171:19 | After case ...: [no-match] | false |
-| Switch.cs:168:13:168:19 | After case ...: [no-match] | Switch.cs:171:13:171:19 | After case ...: [match] | true |
-| Switch.cs:168:13:168:19 | After case ...: [no-match] | Switch.cs:171:13:171:19 | After case ...: [no-match] | false |
+| Switch.cs:156:28:156:31 | After true [no-match] | Switch.cs:156:41:156:45 | After false [match] | true |
+| Switch.cs:156:28:156:31 | After true [no-match] | Switch.cs:156:41:156:45 | After false [no-match] | false |
+| Switch.cs:163:10:163:12 | Entry | Switch.cs:167:18:167:18 | After 1 [match] | true |
+| Switch.cs:163:10:163:12 | Entry | Switch.cs:167:18:167:18 | After 1 [no-match] | false |
+| Switch.cs:163:10:163:12 | Entry | Switch.cs:168:18:168:18 | After 2 [match] | false |
+| Switch.cs:163:10:163:12 | Entry | Switch.cs:168:18:168:18 | After 2 [no-match] | false |
+| Switch.cs:163:10:163:12 | Entry | Switch.cs:171:18:171:18 | After 3 [match] | false |
+| Switch.cs:163:10:163:12 | Entry | Switch.cs:171:18:171:18 | After 3 [no-match] | false |
+| Switch.cs:167:18:167:18 | After 1 [no-match] | Switch.cs:168:18:168:18 | After 2 [match] | true |
+| Switch.cs:167:18:167:18 | After 1 [no-match] | Switch.cs:168:18:168:18 | After 2 [no-match] | false |
+| Switch.cs:167:18:167:18 | After 1 [no-match] | Switch.cs:171:18:171:18 | After 3 [match] | false |
+| Switch.cs:167:18:167:18 | After 1 [no-match] | Switch.cs:171:18:171:18 | After 3 [no-match] | false |
+| Switch.cs:168:18:168:18 | After 2 [no-match] | Switch.cs:171:18:171:18 | After 3 [match] | true |
+| Switch.cs:168:18:168:18 | After 2 [no-match] | Switch.cs:171:18:171:18 | After 3 [no-match] | false |
 | TypeAccesses.cs:3:10:3:10 | Entry | TypeAccesses.cs:7:13:7:22 | After ... is ... [false] | false |
 | TypeAccesses.cs:3:10:3:10 | Entry | TypeAccesses.cs:7:13:7:22 | [MatchTrue] ... is ... | true |
 | VarDecls.cs:19:7:19:8 | Entry | VarDecls.cs:25:20:25:20 | After access to parameter b [false] | false |
@@ -873,41 +875,44 @@ conditionBlock
 | cflow.cs:28:22:28:31 | After ... == ... [false] | cflow.cs:30:22:30:31 | After ... == ... [true] | true |
 | cflow.cs:37:17:37:22 | Entry | cflow.cs:37:17:37:22 | Exit | false |
 | cflow.cs:37:17:37:22 | Entry | cflow.cs:39:9:50:9 | After switch (...) {...} | false |
-| cflow.cs:37:17:37:22 | Entry | cflow.cs:41:13:41:19 | After case ...: [no-match] | false |
-| cflow.cs:37:17:37:22 | Entry | cflow.cs:44:13:44:19 | After case ...: [no-match] | false |
-| cflow.cs:37:17:37:22 | Entry | cflow.cs:47:13:47:19 | After case ...: [match] | false |
-| cflow.cs:37:17:37:22 | Entry | cflow.cs:47:13:47:19 | After case ...: [no-match] | false |
+| cflow.cs:37:17:37:22 | Entry | cflow.cs:41:18:41:18 | After 1 [match] | true |
+| cflow.cs:37:17:37:22 | Entry | cflow.cs:41:18:41:18 | After 1 [no-match] | false |
+| cflow.cs:37:17:37:22 | Entry | cflow.cs:44:18:44:18 | After 2 [match] | false |
+| cflow.cs:37:17:37:22 | Entry | cflow.cs:44:18:44:18 | After 2 [no-match] | false |
+| cflow.cs:37:17:37:22 | Entry | cflow.cs:47:18:47:18 | After 3 [match] | false |
+| cflow.cs:37:17:37:22 | Entry | cflow.cs:47:18:47:18 | After 3 [no-match] | false |
 | cflow.cs:37:17:37:22 | Entry | cflow.cs:51:9:59:9 | After switch (...) {...} | false |
-| cflow.cs:37:17:37:22 | Entry | cflow.cs:53:13:53:20 | After case ...: [match] | false |
-| cflow.cs:37:17:37:22 | Entry | cflow.cs:53:13:53:20 | After case ...: [no-match] | false |
+| cflow.cs:37:17:37:22 | Entry | cflow.cs:53:18:53:19 | After 42 [match] | false |
+| cflow.cs:37:17:37:22 | Entry | cflow.cs:53:18:53:19 | After 42 [no-match] | false |
 | cflow.cs:37:17:37:22 | Entry | cflow.cs:60:9:66:9 | After switch (...) {...} | false |
-| cflow.cs:37:17:37:22 | Entry | cflow.cs:62:13:62:19 | After case ...: [match] | false |
-| cflow.cs:37:17:37:22 | Entry | cflow.cs:62:13:62:19 | After case ...: [no-match] | false |
+| cflow.cs:37:17:37:22 | Entry | cflow.cs:62:18:62:18 | After 0 [match] | false |
+| cflow.cs:37:17:37:22 | Entry | cflow.cs:62:18:62:18 | After 0 [no-match] | false |
 | cflow.cs:37:17:37:22 | Entry | cflow.cs:63:23:63:33 | After ... == ... [false] | false |
 | cflow.cs:37:17:37:22 | Entry | cflow.cs:63:23:63:33 | After ... == ... [true] | false |
-| cflow.cs:39:9:50:9 | After switch (...) {...} | cflow.cs:53:13:53:20 | After case ...: [match] | true |
-| cflow.cs:39:9:50:9 | After switch (...) {...} | cflow.cs:53:13:53:20 | After case ...: [no-match] | false |
-| cflow.cs:41:13:41:19 | After case ...: [no-match] | cflow.cs:37:17:37:22 | Exit | false |
-| cflow.cs:41:13:41:19 | After case ...: [no-match] | cflow.cs:39:9:50:9 | After switch (...) {...} | false |
-| cflow.cs:41:13:41:19 | After case ...: [no-match] | cflow.cs:44:13:44:19 | After case ...: [no-match] | false |
-| cflow.cs:41:13:41:19 | After case ...: [no-match] | cflow.cs:47:13:47:19 | After case ...: [match] | false |
-| cflow.cs:41:13:41:19 | After case ...: [no-match] | cflow.cs:47:13:47:19 | After case ...: [no-match] | false |
-| cflow.cs:41:13:41:19 | After case ...: [no-match] | cflow.cs:51:9:59:9 | After switch (...) {...} | false |
-| cflow.cs:41:13:41:19 | After case ...: [no-match] | cflow.cs:53:13:53:20 | After case ...: [match] | false |
-| cflow.cs:41:13:41:19 | After case ...: [no-match] | cflow.cs:53:13:53:20 | After case ...: [no-match] | false |
-| cflow.cs:41:13:41:19 | After case ...: [no-match] | cflow.cs:60:9:66:9 | After switch (...) {...} | false |
-| cflow.cs:41:13:41:19 | After case ...: [no-match] | cflow.cs:62:13:62:19 | After case ...: [match] | false |
-| cflow.cs:41:13:41:19 | After case ...: [no-match] | cflow.cs:62:13:62:19 | After case ...: [no-match] | false |
-| cflow.cs:41:13:41:19 | After case ...: [no-match] | cflow.cs:63:23:63:33 | After ... == ... [false] | false |
-| cflow.cs:41:13:41:19 | After case ...: [no-match] | cflow.cs:63:23:63:33 | After ... == ... [true] | false |
-| cflow.cs:44:13:44:19 | After case ...: [no-match] | cflow.cs:47:13:47:19 | After case ...: [match] | true |
-| cflow.cs:44:13:44:19 | After case ...: [no-match] | cflow.cs:47:13:47:19 | After case ...: [no-match] | false |
-| cflow.cs:51:9:59:9 | After switch (...) {...} | cflow.cs:62:13:62:19 | After case ...: [match] | true |
-| cflow.cs:51:9:59:9 | After switch (...) {...} | cflow.cs:62:13:62:19 | After case ...: [no-match] | false |
+| cflow.cs:39:9:50:9 | After switch (...) {...} | cflow.cs:53:18:53:19 | After 42 [match] | true |
+| cflow.cs:39:9:50:9 | After switch (...) {...} | cflow.cs:53:18:53:19 | After 42 [no-match] | false |
+| cflow.cs:41:18:41:18 | After 1 [no-match] | cflow.cs:37:17:37:22 | Exit | false |
+| cflow.cs:41:18:41:18 | After 1 [no-match] | cflow.cs:39:9:50:9 | After switch (...) {...} | false |
+| cflow.cs:41:18:41:18 | After 1 [no-match] | cflow.cs:44:18:44:18 | After 2 [match] | true |
+| cflow.cs:41:18:41:18 | After 1 [no-match] | cflow.cs:44:18:44:18 | After 2 [no-match] | false |
+| cflow.cs:41:18:41:18 | After 1 [no-match] | cflow.cs:47:18:47:18 | After 3 [match] | false |
+| cflow.cs:41:18:41:18 | After 1 [no-match] | cflow.cs:47:18:47:18 | After 3 [no-match] | false |
+| cflow.cs:41:18:41:18 | After 1 [no-match] | cflow.cs:51:9:59:9 | After switch (...) {...} | false |
+| cflow.cs:41:18:41:18 | After 1 [no-match] | cflow.cs:53:18:53:19 | After 42 [match] | false |
+| cflow.cs:41:18:41:18 | After 1 [no-match] | cflow.cs:53:18:53:19 | After 42 [no-match] | false |
+| cflow.cs:41:18:41:18 | After 1 [no-match] | cflow.cs:60:9:66:9 | After switch (...) {...} | false |
+| cflow.cs:41:18:41:18 | After 1 [no-match] | cflow.cs:62:18:62:18 | After 0 [match] | false |
+| cflow.cs:41:18:41:18 | After 1 [no-match] | cflow.cs:62:18:62:18 | After 0 [no-match] | false |
+| cflow.cs:41:18:41:18 | After 1 [no-match] | cflow.cs:63:23:63:33 | After ... == ... [false] | false |
+| cflow.cs:41:18:41:18 | After 1 [no-match] | cflow.cs:63:23:63:33 | After ... == ... [true] | false |
+| cflow.cs:44:18:44:18 | After 2 [no-match] | cflow.cs:47:18:47:18 | After 3 [match] | true |
+| cflow.cs:44:18:44:18 | After 2 [no-match] | cflow.cs:47:18:47:18 | After 3 [no-match] | false |
+| cflow.cs:51:9:59:9 | After switch (...) {...} | cflow.cs:62:18:62:18 | After 0 [match] | true |
+| cflow.cs:51:9:59:9 | After switch (...) {...} | cflow.cs:62:18:62:18 | After 0 [no-match] | false |
 | cflow.cs:51:9:59:9 | After switch (...) {...} | cflow.cs:63:23:63:33 | After ... == ... [false] | true |
 | cflow.cs:51:9:59:9 | After switch (...) {...} | cflow.cs:63:23:63:33 | After ... == ... [true] | true |
-| cflow.cs:62:13:62:19 | After case ...: [match] | cflow.cs:63:23:63:33 | After ... == ... [false] | false |
-| cflow.cs:62:13:62:19 | After case ...: [match] | cflow.cs:63:23:63:33 | After ... == ... [true] | true |
+| cflow.cs:62:18:62:18 | After 0 [match] | cflow.cs:63:23:63:33 | After ... == ... [false] | false |
+| cflow.cs:62:18:62:18 | After 0 [match] | cflow.cs:63:23:63:33 | After ... == ... [true] | true |
 | cflow.cs:70:18:70:18 | Entry | cflow.cs:72:13:72:21 | After ... == ... [false] | false |
 | cflow.cs:70:18:70:18 | Entry | cflow.cs:72:13:72:21 | After ... == ... [true] | true |
 | cflow.cs:70:18:70:18 | Entry | cflow.cs:74:9:81:9 | After if (...) ... | false |
@@ -1054,25 +1059,25 @@ conditionBlock
 | cflow.cs:242:12:242:41 | After if (...) ... | cflow.cs:244:13:244:28 | After ... > ... [false] | false |
 | cflow.cs:242:12:242:41 | After if (...) ... | cflow.cs:244:13:244:28 | After ... > ... [true] | true |
 | cflow.cs:242:12:242:41 | After if (...) ... | cflow.cs:246:9:258:9 | After switch (...) {...} | false |
-| cflow.cs:242:12:242:41 | After if (...) ... | cflow.cs:248:13:248:19 | After case ...: [match] | false |
-| cflow.cs:242:12:242:41 | After if (...) ... | cflow.cs:248:13:248:19 | After case ...: [no-match] | false |
-| cflow.cs:242:12:242:41 | After if (...) ... | cflow.cs:250:13:250:19 | After case ...: [match] | false |
-| cflow.cs:242:12:242:41 | After if (...) ... | cflow.cs:250:13:250:19 | After case ...: [no-match] | false |
-| cflow.cs:242:12:242:41 | After if (...) ... | cflow.cs:253:13:253:19 | After case ...: [match] | false |
-| cflow.cs:242:12:242:41 | After if (...) ... | cflow.cs:253:13:253:19 | After case ...: [no-match] | false |
+| cflow.cs:242:12:242:41 | After if (...) ... | cflow.cs:248:18:248:18 | After 0 [match] | false |
+| cflow.cs:242:12:242:41 | After if (...) ... | cflow.cs:248:18:248:18 | After 0 [no-match] | false |
+| cflow.cs:242:12:242:41 | After if (...) ... | cflow.cs:250:18:250:18 | After 1 [match] | false |
+| cflow.cs:242:12:242:41 | After if (...) ... | cflow.cs:250:18:250:18 | After 1 [no-match] | false |
+| cflow.cs:242:12:242:41 | After if (...) ... | cflow.cs:253:18:253:18 | After 2 [match] | false |
+| cflow.cs:242:12:242:41 | After if (...) ... | cflow.cs:253:18:253:18 | After 2 [no-match] | false |
 | cflow.cs:242:12:242:41 | After if (...) ... | cflow.cs:255:13:255:20 | After default: [match] | false |
-| cflow.cs:244:13:244:28 | After ... > ... [false] | cflow.cs:248:13:248:19 | After case ...: [match] | true |
-| cflow.cs:244:13:244:28 | After ... > ... [false] | cflow.cs:248:13:248:19 | After case ...: [no-match] | false |
-| cflow.cs:244:13:244:28 | After ... > ... [false] | cflow.cs:250:13:250:19 | After case ...: [match] | false |
-| cflow.cs:244:13:244:28 | After ... > ... [false] | cflow.cs:250:13:250:19 | After case ...: [no-match] | false |
-| cflow.cs:244:13:244:28 | After ... > ... [false] | cflow.cs:253:13:253:19 | After case ...: [match] | false |
-| cflow.cs:244:13:244:28 | After ... > ... [false] | cflow.cs:253:13:253:19 | After case ...: [no-match] | false |
-| cflow.cs:248:13:248:19 | After case ...: [no-match] | cflow.cs:250:13:250:19 | After case ...: [match] | true |
-| cflow.cs:248:13:248:19 | After case ...: [no-match] | cflow.cs:250:13:250:19 | After case ...: [no-match] | false |
-| cflow.cs:248:13:248:19 | After case ...: [no-match] | cflow.cs:253:13:253:19 | After case ...: [match] | false |
-| cflow.cs:248:13:248:19 | After case ...: [no-match] | cflow.cs:253:13:253:19 | After case ...: [no-match] | false |
-| cflow.cs:250:13:250:19 | After case ...: [no-match] | cflow.cs:253:13:253:19 | After case ...: [match] | true |
-| cflow.cs:250:13:250:19 | After case ...: [no-match] | cflow.cs:253:13:253:19 | After case ...: [no-match] | false |
+| cflow.cs:244:13:244:28 | After ... > ... [false] | cflow.cs:248:18:248:18 | After 0 [match] | true |
+| cflow.cs:244:13:244:28 | After ... > ... [false] | cflow.cs:248:18:248:18 | After 0 [no-match] | false |
+| cflow.cs:244:13:244:28 | After ... > ... [false] | cflow.cs:250:18:250:18 | After 1 [match] | false |
+| cflow.cs:244:13:244:28 | After ... > ... [false] | cflow.cs:250:18:250:18 | After 1 [no-match] | false |
+| cflow.cs:244:13:244:28 | After ... > ... [false] | cflow.cs:253:18:253:18 | After 2 [match] | false |
+| cflow.cs:244:13:244:28 | After ... > ... [false] | cflow.cs:253:18:253:18 | After 2 [no-match] | false |
+| cflow.cs:248:18:248:18 | After 0 [no-match] | cflow.cs:250:18:250:18 | After 1 [match] | true |
+| cflow.cs:248:18:248:18 | After 0 [no-match] | cflow.cs:250:18:250:18 | After 1 [no-match] | false |
+| cflow.cs:248:18:248:18 | After 0 [no-match] | cflow.cs:253:18:253:18 | After 2 [match] | false |
+| cflow.cs:248:18:248:18 | After 0 [no-match] | cflow.cs:253:18:253:18 | After 2 [no-match] | false |
+| cflow.cs:250:18:250:18 | After 1 [no-match] | cflow.cs:253:18:253:18 | After 2 [match] | true |
+| cflow.cs:250:18:250:18 | After 1 [no-match] | cflow.cs:253:18:253:18 | After 2 [no-match] | false |
 | cflow.cs:264:25:264:30 | Before ... < ... | cflow.cs:261:49:261:53 | Exceptional Exit | false |
 | cflow.cs:264:25:264:30 | Before ... < ... | cflow.cs:261:49:261:53 | Exit | false |
 | cflow.cs:264:25:264:30 | Before ... < ... | cflow.cs:261:49:261:53 | Normal Exit | false |

--- a/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
@@ -5212,16 +5212,20 @@ dominance
 | Patterns.cs:20:9:38:9 | After switch (...) {...} | Patterns.cs:40:9:42:9 | switch (...) {...} |
 | Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:20:17:20:17 | access to local variable o |
 | Patterns.cs:20:17:20:17 | access to local variable o | Patterns.cs:22:13:22:23 | case ...: |
-| Patterns.cs:22:13:22:23 | After case ...: [match] | Patterns.cs:22:18:22:22 | "xyz" |
+| Patterns.cs:22:13:22:23 | After case ...: [match] | Patterns.cs:23:17:23:22 | Before break; |
 | Patterns.cs:22:13:22:23 | After case ...: [no-match] | Patterns.cs:24:13:24:36 | case ...: |
-| Patterns.cs:22:13:22:23 | case ...: | Patterns.cs:22:13:22:23 | After case ...: [match] |
-| Patterns.cs:22:13:22:23 | case ...: | Patterns.cs:22:13:22:23 | After case ...: [no-match] |
-| Patterns.cs:22:18:22:22 | "xyz" | Patterns.cs:23:17:23:22 | Before break; |
+| Patterns.cs:22:13:22:23 | case ...: | Patterns.cs:22:18:22:22 | "xyz" |
+| Patterns.cs:22:18:22:22 | "xyz" | Patterns.cs:22:18:22:22 | After "xyz" [match] |
+| Patterns.cs:22:18:22:22 | "xyz" | Patterns.cs:22:18:22:22 | After "xyz" [no-match] |
+| Patterns.cs:22:18:22:22 | After "xyz" [match] | Patterns.cs:22:13:22:23 | After case ...: [match] |
+| Patterns.cs:22:18:22:22 | After "xyz" [no-match] | Patterns.cs:22:13:22:23 | After case ...: [no-match] |
 | Patterns.cs:23:17:23:22 | Before break; | Patterns.cs:23:17:23:22 | break; |
-| Patterns.cs:24:13:24:36 | After case ...: [match] | Patterns.cs:24:18:24:23 | Int32 i2 |
-| Patterns.cs:24:13:24:36 | case ...: | Patterns.cs:24:13:24:36 | After case ...: [match] |
-| Patterns.cs:24:13:24:36 | case ...: | Patterns.cs:24:13:24:36 | After case ...: [no-match] |
-| Patterns.cs:24:18:24:23 | Int32 i2 | Patterns.cs:24:30:24:35 | Before ... > ... |
+| Patterns.cs:24:13:24:36 | After case ...: [match] | Patterns.cs:24:30:24:35 | Before ... > ... |
+| Patterns.cs:24:13:24:36 | case ...: | Patterns.cs:24:18:24:23 | Int32 i2 |
+| Patterns.cs:24:18:24:23 | After Int32 i2 [match] | Patterns.cs:24:13:24:36 | After case ...: [match] |
+| Patterns.cs:24:18:24:23 | After Int32 i2 [no-match] | Patterns.cs:24:13:24:36 | After case ...: [no-match] |
+| Patterns.cs:24:18:24:23 | Int32 i2 | Patterns.cs:24:18:24:23 | After Int32 i2 [match] |
+| Patterns.cs:24:18:24:23 | Int32 i2 | Patterns.cs:24:18:24:23 | After Int32 i2 [no-match] |
 | Patterns.cs:24:30:24:31 | access to local variable i2 | Patterns.cs:24:35:24:35 | 0 |
 | Patterns.cs:24:30:24:35 | ... > ... | Patterns.cs:24:30:24:35 | After ... > ... [false] |
 | Patterns.cs:24:30:24:35 | ... > ... | Patterns.cs:24:30:24:35 | After ... > ... [true] |
@@ -5242,11 +5246,13 @@ dominance
 | Patterns.cs:25:46:25:49 | {...} | Patterns.cs:25:46:25:49 | After {...} |
 | Patterns.cs:25:47:25:48 | access to local variable i2 | Patterns.cs:25:46:25:49 | {...} |
 | Patterns.cs:26:17:26:22 | Before break; | Patterns.cs:26:17:26:22 | break; |
-| Patterns.cs:27:13:27:24 | After case ...: [match] | Patterns.cs:27:18:27:23 | Int32 i3 |
+| Patterns.cs:27:13:27:24 | After case ...: [match] | Patterns.cs:28:17:28:47 | ...; |
 | Patterns.cs:27:13:27:24 | After case ...: [no-match] | Patterns.cs:30:13:30:27 | case ...: |
-| Patterns.cs:27:13:27:24 | case ...: | Patterns.cs:27:13:27:24 | After case ...: [match] |
-| Patterns.cs:27:13:27:24 | case ...: | Patterns.cs:27:13:27:24 | After case ...: [no-match] |
-| Patterns.cs:27:18:27:23 | Int32 i3 | Patterns.cs:28:17:28:47 | ...; |
+| Patterns.cs:27:13:27:24 | case ...: | Patterns.cs:27:18:27:23 | Int32 i3 |
+| Patterns.cs:27:18:27:23 | After Int32 i3 [match] | Patterns.cs:27:13:27:24 | After case ...: [match] |
+| Patterns.cs:27:18:27:23 | After Int32 i3 [no-match] | Patterns.cs:27:13:27:24 | After case ...: [no-match] |
+| Patterns.cs:27:18:27:23 | Int32 i3 | Patterns.cs:27:18:27:23 | After Int32 i3 [match] |
+| Patterns.cs:27:18:27:23 | Int32 i3 | Patterns.cs:27:18:27:23 | After Int32 i3 [no-match] |
 | Patterns.cs:28:17:28:46 | After call to method WriteLine | Patterns.cs:28:17:28:47 | After ...; |
 | Patterns.cs:28:17:28:46 | Before call to method WriteLine | Patterns.cs:28:35:28:45 | Before $"..." |
 | Patterns.cs:28:17:28:46 | call to method WriteLine | Patterns.cs:28:17:28:46 | After call to method WriteLine |
@@ -5261,11 +5267,13 @@ dominance
 | Patterns.cs:28:41:28:44 | {...} | Patterns.cs:28:41:28:44 | After {...} |
 | Patterns.cs:28:42:28:43 | access to local variable i3 | Patterns.cs:28:41:28:44 | {...} |
 | Patterns.cs:29:17:29:22 | Before break; | Patterns.cs:29:17:29:22 | break; |
-| Patterns.cs:30:13:30:27 | After case ...: [match] | Patterns.cs:30:18:30:26 | String s2 |
+| Patterns.cs:30:13:30:27 | After case ...: [match] | Patterns.cs:31:17:31:50 | ...; |
 | Patterns.cs:30:13:30:27 | After case ...: [no-match] | Patterns.cs:33:13:33:24 | case ...: |
-| Patterns.cs:30:13:30:27 | case ...: | Patterns.cs:30:13:30:27 | After case ...: [match] |
-| Patterns.cs:30:13:30:27 | case ...: | Patterns.cs:30:13:30:27 | After case ...: [no-match] |
-| Patterns.cs:30:18:30:26 | String s2 | Patterns.cs:31:17:31:50 | ...; |
+| Patterns.cs:30:13:30:27 | case ...: | Patterns.cs:30:18:30:26 | String s2 |
+| Patterns.cs:30:18:30:26 | After String s2 [match] | Patterns.cs:30:13:30:27 | After case ...: [match] |
+| Patterns.cs:30:18:30:26 | After String s2 [no-match] | Patterns.cs:30:13:30:27 | After case ...: [no-match] |
+| Patterns.cs:30:18:30:26 | String s2 | Patterns.cs:30:18:30:26 | After String s2 [match] |
+| Patterns.cs:30:18:30:26 | String s2 | Patterns.cs:30:18:30:26 | After String s2 [no-match] |
 | Patterns.cs:31:17:31:49 | After call to method WriteLine | Patterns.cs:31:17:31:50 | After ...; |
 | Patterns.cs:31:17:31:49 | Before call to method WriteLine | Patterns.cs:31:35:31:48 | Before $"..." |
 | Patterns.cs:31:17:31:49 | call to method WriteLine | Patterns.cs:31:17:31:49 | After call to method WriteLine |
@@ -5280,11 +5288,13 @@ dominance
 | Patterns.cs:31:44:31:47 | {...} | Patterns.cs:31:44:31:47 | After {...} |
 | Patterns.cs:31:45:31:46 | access to local variable s2 | Patterns.cs:31:44:31:47 | {...} |
 | Patterns.cs:32:17:32:22 | Before break; | Patterns.cs:32:17:32:22 | break; |
-| Patterns.cs:33:13:33:24 | After case ...: [match] | Patterns.cs:33:18:33:23 | Object v2 |
+| Patterns.cs:33:13:33:24 | After case ...: [match] | Patterns.cs:34:17:34:22 | Before break; |
 | Patterns.cs:33:13:33:24 | After case ...: [no-match] | Patterns.cs:35:13:35:20 | default: |
-| Patterns.cs:33:13:33:24 | case ...: | Patterns.cs:33:13:33:24 | After case ...: [match] |
-| Patterns.cs:33:13:33:24 | case ...: | Patterns.cs:33:13:33:24 | After case ...: [no-match] |
-| Patterns.cs:33:18:33:23 | Object v2 | Patterns.cs:34:17:34:22 | Before break; |
+| Patterns.cs:33:13:33:24 | case ...: | Patterns.cs:33:18:33:23 | Object v2 |
+| Patterns.cs:33:18:33:23 | After Object v2 [match] | Patterns.cs:33:13:33:24 | After case ...: [match] |
+| Patterns.cs:33:18:33:23 | After Object v2 [no-match] | Patterns.cs:33:13:33:24 | After case ...: [no-match] |
+| Patterns.cs:33:18:33:23 | Object v2 | Patterns.cs:33:18:33:23 | After Object v2 [match] |
+| Patterns.cs:33:18:33:23 | Object v2 | Patterns.cs:33:18:33:23 | After Object v2 [no-match] |
 | Patterns.cs:34:17:34:22 | Before break; | Patterns.cs:34:17:34:22 | break; |
 | Patterns.cs:35:13:35:20 | After default: [match] | Patterns.cs:36:17:36:52 | ...; |
 | Patterns.cs:35:13:35:20 | default: | Patterns.cs:35:13:35:20 | After default: [match] |
@@ -5365,17 +5375,19 @@ dominance
 | Patterns.cs:58:16:58:16 | access to parameter i | Patterns.cs:60:13:60:28 | ... => ... |
 | Patterns.cs:58:16:62:9 | ... switch { ... } | Patterns.cs:58:16:58:16 | access to parameter i |
 | Patterns.cs:58:16:62:9 | After ... switch { ... } | Patterns.cs:58:9:62:10 | return ...; |
-| Patterns.cs:60:13:60:17 | After not ... | Patterns.cs:60:22:60:28 | "not 1" |
+| Patterns.cs:60:13:60:17 | After not ... [match] | Patterns.cs:60:13:60:28 | After ... => ... [match] |
+| Patterns.cs:60:13:60:17 | After not ... [no-match] | Patterns.cs:60:13:60:28 | After ... => ... [no-match] |
 | Patterns.cs:60:13:60:17 | Before not ... | Patterns.cs:60:17:60:17 | 1 |
-| Patterns.cs:60:13:60:17 | not ... | Patterns.cs:60:13:60:17 | After not ... |
-| Patterns.cs:60:13:60:28 | ... => ... | Patterns.cs:60:13:60:28 | After ... => ... [match] |
-| Patterns.cs:60:13:60:28 | ... => ... | Patterns.cs:60:13:60:28 | After ... => ... [no-match] |
-| Patterns.cs:60:13:60:28 | After ... => ... [match] | Patterns.cs:60:13:60:17 | Before not ... |
+| Patterns.cs:60:13:60:17 | not ... | Patterns.cs:60:13:60:17 | After not ... [match] |
+| Patterns.cs:60:13:60:17 | not ... | Patterns.cs:60:13:60:17 | After not ... [no-match] |
+| Patterns.cs:60:13:60:28 | ... => ... | Patterns.cs:60:13:60:17 | Before not ... |
+| Patterns.cs:60:13:60:28 | After ... => ... [match] | Patterns.cs:60:22:60:28 | "not 1" |
 | Patterns.cs:60:13:60:28 | After ... => ... [no-match] | Patterns.cs:61:13:61:24 | ... => ... |
 | Patterns.cs:60:17:60:17 | 1 | Patterns.cs:60:13:60:17 | not ... |
-| Patterns.cs:61:13:61:13 | _ | Patterns.cs:61:18:61:24 | "other" |
-| Patterns.cs:61:13:61:24 | ... => ... | Patterns.cs:61:13:61:24 | After ... => ... [match] |
-| Patterns.cs:61:13:61:24 | After ... => ... [match] | Patterns.cs:61:13:61:13 | _ |
+| Patterns.cs:61:13:61:13 | After _ [match] | Patterns.cs:61:13:61:24 | After ... => ... [match] |
+| Patterns.cs:61:13:61:13 | _ | Patterns.cs:61:13:61:13 | After _ [match] |
+| Patterns.cs:61:13:61:24 | ... => ... | Patterns.cs:61:13:61:13 | _ |
+| Patterns.cs:61:13:61:24 | After ... => ... [match] | Patterns.cs:61:18:61:24 | "other" |
 | Patterns.cs:65:26:65:27 | Entry | Patterns.cs:66:5:72:5 | {...} |
 | Patterns.cs:65:26:65:27 | Normal Exit | Patterns.cs:65:26:65:27 | Exit |
 | Patterns.cs:66:5:72:5 | {...} | Patterns.cs:67:9:71:10 | Before return ...; |
@@ -5384,18 +5396,21 @@ dominance
 | Patterns.cs:67:16:67:16 | 2 | Patterns.cs:69:13:69:33 | ... => ... |
 | Patterns.cs:67:16:71:9 | ... switch { ... } | Patterns.cs:67:16:67:16 | 2 |
 | Patterns.cs:67:16:71:9 | After ... switch { ... } | Patterns.cs:67:9:71:10 | return ...; |
-| Patterns.cs:69:13:69:17 | After not ... | Patterns.cs:69:22:69:33 | "impossible" |
+| Patterns.cs:69:13:69:17 | After not ... [match] | Patterns.cs:69:13:69:33 | After ... => ... [match] |
+| Patterns.cs:69:13:69:17 | After not ... [no-match] | Patterns.cs:69:13:69:33 | After ... => ... [no-match] |
 | Patterns.cs:69:13:69:17 | Before not ... | Patterns.cs:69:17:69:17 | 2 |
-| Patterns.cs:69:13:69:17 | not ... | Patterns.cs:69:13:69:17 | After not ... |
-| Patterns.cs:69:13:69:33 | ... => ... | Patterns.cs:69:13:69:33 | After ... => ... [match] |
-| Patterns.cs:69:13:69:33 | ... => ... | Patterns.cs:69:13:69:33 | After ... => ... [no-match] |
-| Patterns.cs:69:13:69:33 | After ... => ... [match] | Patterns.cs:69:13:69:17 | Before not ... |
+| Patterns.cs:69:13:69:17 | not ... | Patterns.cs:69:13:69:17 | After not ... [match] |
+| Patterns.cs:69:13:69:17 | not ... | Patterns.cs:69:13:69:17 | After not ... [no-match] |
+| Patterns.cs:69:13:69:33 | ... => ... | Patterns.cs:69:13:69:17 | Before not ... |
+| Patterns.cs:69:13:69:33 | After ... => ... [match] | Patterns.cs:69:22:69:33 | "impossible" |
 | Patterns.cs:69:13:69:33 | After ... => ... [no-match] | Patterns.cs:70:13:70:27 | ... => ... |
 | Patterns.cs:69:17:69:17 | 2 | Patterns.cs:69:13:69:17 | not ... |
-| Patterns.cs:70:13:70:13 | 2 | Patterns.cs:70:18:70:27 | "possible" |
-| Patterns.cs:70:13:70:27 | ... => ... | Patterns.cs:70:13:70:27 | After ... => ... [match] |
-| Patterns.cs:70:13:70:27 | ... => ... | Patterns.cs:70:13:70:27 | After ... => ... [no-match] |
-| Patterns.cs:70:13:70:27 | After ... => ... [match] | Patterns.cs:70:13:70:13 | 2 |
+| Patterns.cs:70:13:70:13 | 2 | Patterns.cs:70:13:70:13 | After 2 [match] |
+| Patterns.cs:70:13:70:13 | 2 | Patterns.cs:70:13:70:13 | After 2 [no-match] |
+| Patterns.cs:70:13:70:13 | After 2 [match] | Patterns.cs:70:13:70:27 | After ... => ... [match] |
+| Patterns.cs:70:13:70:13 | After 2 [no-match] | Patterns.cs:70:13:70:27 | After ... => ... [no-match] |
+| Patterns.cs:70:13:70:27 | ... => ... | Patterns.cs:70:13:70:13 | 2 |
+| Patterns.cs:70:13:70:27 | After ... => ... [match] | Patterns.cs:70:18:70:27 | "possible" |
 | Patterns.cs:74:26:74:27 | Entry | Patterns.cs:74:33:74:33 | i |
 | Patterns.cs:74:26:74:27 | Normal Exit | Patterns.cs:74:26:74:27 | Exit |
 | Patterns.cs:74:33:74:33 | i | Patterns.cs:75:5:83:5 | {...} |
@@ -5405,30 +5420,35 @@ dominance
 | Patterns.cs:76:16:76:16 | access to parameter i | Patterns.cs:78:13:78:24 | ... => ... |
 | Patterns.cs:76:16:82:9 | ... switch { ... } | Patterns.cs:76:16:76:16 | access to parameter i |
 | Patterns.cs:76:16:82:9 | After ... switch { ... } | Patterns.cs:76:9:82:10 | return ...; |
-| Patterns.cs:78:13:78:15 | > ... | Patterns.cs:78:13:78:15 | After > ... |
-| Patterns.cs:78:13:78:15 | After > ... | Patterns.cs:78:20:78:24 | "> 1" |
+| Patterns.cs:78:13:78:15 | > ... | Patterns.cs:78:13:78:15 | After > ... [match] |
+| Patterns.cs:78:13:78:15 | > ... | Patterns.cs:78:13:78:15 | After > ... [no-match] |
+| Patterns.cs:78:13:78:15 | After > ... [match] | Patterns.cs:78:13:78:24 | After ... => ... [match] |
+| Patterns.cs:78:13:78:15 | After > ... [no-match] | Patterns.cs:78:13:78:24 | After ... => ... [no-match] |
 | Patterns.cs:78:13:78:15 | Before > ... | Patterns.cs:78:15:78:15 | 1 |
-| Patterns.cs:78:13:78:24 | ... => ... | Patterns.cs:78:13:78:24 | After ... => ... [match] |
-| Patterns.cs:78:13:78:24 | ... => ... | Patterns.cs:78:13:78:24 | After ... => ... [no-match] |
-| Patterns.cs:78:13:78:24 | After ... => ... [match] | Patterns.cs:78:13:78:15 | Before > ... |
+| Patterns.cs:78:13:78:24 | ... => ... | Patterns.cs:78:13:78:15 | Before > ... |
+| Patterns.cs:78:13:78:24 | After ... => ... [match] | Patterns.cs:78:20:78:24 | "> 1" |
 | Patterns.cs:78:13:78:24 | After ... => ... [no-match] | Patterns.cs:79:13:79:24 | ... => ... |
 | Patterns.cs:78:15:78:15 | 1 | Patterns.cs:78:13:78:15 | > ... |
-| Patterns.cs:79:13:79:15 | < ... | Patterns.cs:79:13:79:15 | After < ... |
-| Patterns.cs:79:13:79:15 | After < ... | Patterns.cs:79:20:79:24 | "< 0" |
+| Patterns.cs:79:13:79:15 | < ... | Patterns.cs:79:13:79:15 | After < ... [match] |
+| Patterns.cs:79:13:79:15 | < ... | Patterns.cs:79:13:79:15 | After < ... [no-match] |
+| Patterns.cs:79:13:79:15 | After < ... [match] | Patterns.cs:79:13:79:24 | After ... => ... [match] |
+| Patterns.cs:79:13:79:15 | After < ... [no-match] | Patterns.cs:79:13:79:24 | After ... => ... [no-match] |
 | Patterns.cs:79:13:79:15 | Before < ... | Patterns.cs:79:15:79:15 | 0 |
-| Patterns.cs:79:13:79:24 | ... => ... | Patterns.cs:79:13:79:24 | After ... => ... [match] |
-| Patterns.cs:79:13:79:24 | ... => ... | Patterns.cs:79:13:79:24 | After ... => ... [no-match] |
-| Patterns.cs:79:13:79:24 | After ... => ... [match] | Patterns.cs:79:13:79:15 | Before < ... |
+| Patterns.cs:79:13:79:24 | ... => ... | Patterns.cs:79:13:79:15 | Before < ... |
+| Patterns.cs:79:13:79:24 | After ... => ... [match] | Patterns.cs:79:20:79:24 | "< 0" |
 | Patterns.cs:79:13:79:24 | After ... => ... [no-match] | Patterns.cs:80:13:80:20 | ... => ... |
 | Patterns.cs:79:15:79:15 | 0 | Patterns.cs:79:13:79:15 | < ... |
-| Patterns.cs:80:13:80:13 | 1 | Patterns.cs:80:18:80:20 | "1" |
-| Patterns.cs:80:13:80:20 | ... => ... | Patterns.cs:80:13:80:20 | After ... => ... [match] |
-| Patterns.cs:80:13:80:20 | ... => ... | Patterns.cs:80:13:80:20 | After ... => ... [no-match] |
-| Patterns.cs:80:13:80:20 | After ... => ... [match] | Patterns.cs:80:13:80:13 | 1 |
+| Patterns.cs:80:13:80:13 | 1 | Patterns.cs:80:13:80:13 | After 1 [match] |
+| Patterns.cs:80:13:80:13 | 1 | Patterns.cs:80:13:80:13 | After 1 [no-match] |
+| Patterns.cs:80:13:80:13 | After 1 [match] | Patterns.cs:80:13:80:20 | After ... => ... [match] |
+| Patterns.cs:80:13:80:13 | After 1 [no-match] | Patterns.cs:80:13:80:20 | After ... => ... [no-match] |
+| Patterns.cs:80:13:80:20 | ... => ... | Patterns.cs:80:13:80:13 | 1 |
+| Patterns.cs:80:13:80:20 | After ... => ... [match] | Patterns.cs:80:18:80:20 | "1" |
 | Patterns.cs:80:13:80:20 | After ... => ... [no-match] | Patterns.cs:81:13:81:20 | ... => ... |
-| Patterns.cs:81:13:81:13 | _ | Patterns.cs:81:18:81:20 | "0" |
-| Patterns.cs:81:13:81:20 | ... => ... | Patterns.cs:81:13:81:20 | After ... => ... [match] |
-| Patterns.cs:81:13:81:20 | After ... => ... [match] | Patterns.cs:81:13:81:13 | _ |
+| Patterns.cs:81:13:81:13 | After _ [match] | Patterns.cs:81:13:81:20 | After ... => ... [match] |
+| Patterns.cs:81:13:81:13 | _ | Patterns.cs:81:13:81:13 | After _ [match] |
+| Patterns.cs:81:13:81:20 | ... => ... | Patterns.cs:81:13:81:13 | _ |
+| Patterns.cs:81:13:81:20 | After ... => ... [match] | Patterns.cs:81:18:81:20 | "0" |
 | Patterns.cs:85:26:85:27 | Entry | Patterns.cs:85:33:85:33 | i |
 | Patterns.cs:85:26:85:27 | Normal Exit | Patterns.cs:85:26:85:27 | Exit |
 | Patterns.cs:85:33:85:33 | i | Patterns.cs:85:39:85:69 | ... ? ... : ... |
@@ -5754,32 +5774,39 @@ dominance
 | Switch.cs:11:5:33:5 | {...} | Switch.cs:12:9:32:9 | switch (...) {...} |
 | Switch.cs:12:9:32:9 | switch (...) {...} | Switch.cs:12:17:12:17 | access to parameter o |
 | Switch.cs:12:17:12:17 | access to parameter o | Switch.cs:14:13:14:21 | case ...: |
-| Switch.cs:14:13:14:21 | After case ...: [match] | Switch.cs:14:18:14:20 | "a" |
+| Switch.cs:14:13:14:21 | After case ...: [match] | Switch.cs:15:17:15:23 | Before return ...; |
 | Switch.cs:14:13:14:21 | After case ...: [no-match] | Switch.cs:16:13:16:19 | case ...: |
-| Switch.cs:14:13:14:21 | case ...: | Switch.cs:14:13:14:21 | After case ...: [match] |
-| Switch.cs:14:13:14:21 | case ...: | Switch.cs:14:13:14:21 | After case ...: [no-match] |
-| Switch.cs:14:18:14:20 | "a" | Switch.cs:15:17:15:23 | Before return ...; |
+| Switch.cs:14:13:14:21 | case ...: | Switch.cs:14:18:14:20 | "a" |
+| Switch.cs:14:18:14:20 | "a" | Switch.cs:14:18:14:20 | After "a" [match] |
+| Switch.cs:14:18:14:20 | "a" | Switch.cs:14:18:14:20 | After "a" [no-match] |
+| Switch.cs:14:18:14:20 | After "a" [match] | Switch.cs:14:13:14:21 | After case ...: [match] |
+| Switch.cs:14:18:14:20 | After "a" [no-match] | Switch.cs:14:13:14:21 | After case ...: [no-match] |
 | Switch.cs:15:17:15:23 | Before return ...; | Switch.cs:15:17:15:23 | return ...; |
-| Switch.cs:16:13:16:19 | After case ...: [match] | Switch.cs:16:18:16:18 | 0 |
+| Switch.cs:16:13:16:19 | After case ...: [match] | Switch.cs:17:17:17:38 | Before throw ...; |
 | Switch.cs:16:13:16:19 | After case ...: [no-match] | Switch.cs:18:13:18:22 | case ...: |
-| Switch.cs:16:13:16:19 | case ...: | Switch.cs:16:13:16:19 | After case ...: [match] |
-| Switch.cs:16:13:16:19 | case ...: | Switch.cs:16:13:16:19 | After case ...: [no-match] |
-| Switch.cs:16:18:16:18 | 0 | Switch.cs:17:17:17:38 | Before throw ...; |
+| Switch.cs:16:13:16:19 | case ...: | Switch.cs:16:18:16:18 | 0 |
+| Switch.cs:16:18:16:18 | 0 | Switch.cs:16:18:16:18 | After 0 [match] |
+| Switch.cs:16:18:16:18 | 0 | Switch.cs:16:18:16:18 | After 0 [no-match] |
+| Switch.cs:16:18:16:18 | After 0 [no-match] | Switch.cs:16:13:16:19 | After case ...: [no-match] |
 | Switch.cs:17:17:17:38 | Before throw ...; | Switch.cs:17:23:17:37 | Before object creation of type Exception |
 | Switch.cs:17:23:17:37 | After object creation of type Exception | Switch.cs:17:17:17:38 | throw ...; |
 | Switch.cs:17:23:17:37 | Before object creation of type Exception | Switch.cs:17:23:17:37 | object creation of type Exception |
 | Switch.cs:17:23:17:37 | object creation of type Exception | Switch.cs:17:23:17:37 | After object creation of type Exception |
-| Switch.cs:18:13:18:22 | After case ...: [match] | Switch.cs:18:18:18:21 | null |
+| Switch.cs:18:13:18:22 | After case ...: [match] | Switch.cs:19:17:19:29 | Before goto default; |
 | Switch.cs:18:13:18:22 | After case ...: [no-match] | Switch.cs:20:13:20:23 | case ...: |
-| Switch.cs:18:13:18:22 | case ...: | Switch.cs:18:13:18:22 | After case ...: [match] |
-| Switch.cs:18:13:18:22 | case ...: | Switch.cs:18:13:18:22 | After case ...: [no-match] |
-| Switch.cs:18:18:18:21 | null | Switch.cs:19:17:19:29 | Before goto default; |
+| Switch.cs:18:13:18:22 | case ...: | Switch.cs:18:18:18:21 | null |
+| Switch.cs:18:18:18:21 | After null [match] | Switch.cs:18:13:18:22 | After case ...: [match] |
+| Switch.cs:18:18:18:21 | After null [no-match] | Switch.cs:18:13:18:22 | After case ...: [no-match] |
+| Switch.cs:18:18:18:21 | null | Switch.cs:18:18:18:21 | After null [match] |
+| Switch.cs:18:18:18:21 | null | Switch.cs:18:18:18:21 | After null [no-match] |
 | Switch.cs:19:17:19:29 | Before goto default; | Switch.cs:19:17:19:29 | goto default; |
-| Switch.cs:20:13:20:23 | After case ...: [match] | Switch.cs:20:18:20:22 | Int32 i |
+| Switch.cs:20:13:20:23 | After case ...: [match] | Switch.cs:21:17:22:27 | if (...) ... |
 | Switch.cs:20:13:20:23 | After case ...: [no-match] | Switch.cs:24:13:24:56 | case ...: |
-| Switch.cs:20:13:20:23 | case ...: | Switch.cs:20:13:20:23 | After case ...: [match] |
-| Switch.cs:20:13:20:23 | case ...: | Switch.cs:20:13:20:23 | After case ...: [no-match] |
-| Switch.cs:20:18:20:22 | Int32 i | Switch.cs:21:17:22:27 | if (...) ... |
+| Switch.cs:20:13:20:23 | case ...: | Switch.cs:20:18:20:22 | Int32 i |
+| Switch.cs:20:18:20:22 | After Int32 i [match] | Switch.cs:20:13:20:23 | After case ...: [match] |
+| Switch.cs:20:18:20:22 | After Int32 i [no-match] | Switch.cs:20:13:20:23 | After case ...: [no-match] |
+| Switch.cs:20:18:20:22 | Int32 i | Switch.cs:20:18:20:22 | After Int32 i [match] |
+| Switch.cs:20:18:20:22 | Int32 i | Switch.cs:20:18:20:22 | After Int32 i [no-match] |
 | Switch.cs:21:17:22:27 | After if (...) ... | Switch.cs:23:17:23:28 | Before goto case ...; |
 | Switch.cs:21:17:22:27 | if (...) ... | Switch.cs:21:21:21:29 | Before ... == ... |
 | Switch.cs:21:21:21:21 | access to parameter o | Switch.cs:21:26:21:29 | null |
@@ -5792,10 +5819,12 @@ dominance
 | Switch.cs:22:21:22:27 | Before return ...; | Switch.cs:22:21:22:27 | return ...; |
 | Switch.cs:23:17:23:28 | Before goto case ...; | Switch.cs:23:27:23:27 | 0 |
 | Switch.cs:23:27:23:27 | 0 | Switch.cs:23:17:23:28 | goto case ...; |
-| Switch.cs:24:13:24:56 | After case ...: [match] | Switch.cs:24:18:24:25 | String s |
-| Switch.cs:24:13:24:56 | case ...: | Switch.cs:24:13:24:56 | After case ...: [match] |
-| Switch.cs:24:13:24:56 | case ...: | Switch.cs:24:13:24:56 | After case ...: [no-match] |
-| Switch.cs:24:18:24:25 | String s | Switch.cs:24:32:24:55 | ... && ... |
+| Switch.cs:24:13:24:56 | After case ...: [match] | Switch.cs:24:32:24:55 | ... && ... |
+| Switch.cs:24:13:24:56 | case ...: | Switch.cs:24:18:24:25 | String s |
+| Switch.cs:24:18:24:25 | After String s [match] | Switch.cs:24:13:24:56 | After case ...: [match] |
+| Switch.cs:24:18:24:25 | After String s [no-match] | Switch.cs:24:13:24:56 | After case ...: [no-match] |
+| Switch.cs:24:18:24:25 | String s | Switch.cs:24:18:24:25 | After String s [match] |
+| Switch.cs:24:18:24:25 | String s | Switch.cs:24:18:24:25 | After String s [no-match] |
 | Switch.cs:24:32:24:32 | access to local variable s | Switch.cs:24:32:24:39 | access to property Length |
 | Switch.cs:24:32:24:39 | After access to property Length | Switch.cs:24:43:24:43 | 0 |
 | Switch.cs:24:32:24:39 | Before access to property Length | Switch.cs:24:32:24:32 | access to local variable s |
@@ -5820,11 +5849,13 @@ dominance
 | Switch.cs:25:17:25:37 | After ...; | Switch.cs:26:17:26:23 | Before return ...; |
 | Switch.cs:25:35:25:35 | access to local variable s | Switch.cs:25:17:25:36 | call to method WriteLine |
 | Switch.cs:26:17:26:23 | Before return ...; | Switch.cs:26:17:26:23 | return ...; |
-| Switch.cs:27:13:27:39 | After case ...: [match] | Switch.cs:27:18:27:25 | Double d |
+| Switch.cs:27:13:27:39 | After case ...: [match] | Switch.cs:27:32:27:38 | Before call to method Throw |
 | Switch.cs:27:13:27:39 | After case ...: [no-match] | Switch.cs:30:13:30:20 | default: |
-| Switch.cs:27:13:27:39 | case ...: | Switch.cs:27:13:27:39 | After case ...: [match] |
-| Switch.cs:27:13:27:39 | case ...: | Switch.cs:27:13:27:39 | After case ...: [no-match] |
-| Switch.cs:27:18:27:25 | Double d | Switch.cs:27:32:27:38 | Before call to method Throw |
+| Switch.cs:27:13:27:39 | case ...: | Switch.cs:27:18:27:25 | Double d |
+| Switch.cs:27:18:27:25 | After Double d [match] | Switch.cs:27:13:27:39 | After case ...: [match] |
+| Switch.cs:27:18:27:25 | After Double d [no-match] | Switch.cs:27:13:27:39 | After case ...: [no-match] |
+| Switch.cs:27:18:27:25 | Double d | Switch.cs:27:18:27:25 | After Double d [match] |
+| Switch.cs:27:18:27:25 | Double d | Switch.cs:27:18:27:25 | After Double d [no-match] |
 | Switch.cs:27:32:27:38 | Before call to method Throw | Switch.cs:27:32:27:38 | call to method Throw |
 | Switch.cs:28:13:28:17 | Label: | Switch.cs:29:17:29:23 | Before return ...; |
 | Switch.cs:29:17:29:23 | Before return ...; | Switch.cs:29:17:29:23 | return ...; |
@@ -5845,16 +5876,20 @@ dominance
 | Switch.cs:46:9:52:9 | After switch (...) {...} | Switch.cs:45:5:53:5 | After {...} |
 | Switch.cs:46:9:52:9 | switch (...) {...} | Switch.cs:46:17:46:17 | access to parameter o |
 | Switch.cs:46:17:46:17 | access to parameter o | Switch.cs:48:13:48:23 | case ...: |
-| Switch.cs:48:13:48:23 | After case ...: [match] | Switch.cs:48:18:48:20 | access to type Int32 |
+| Switch.cs:48:13:48:23 | After case ...: [match] | Switch.cs:49:17:49:22 | Before break; |
 | Switch.cs:48:13:48:23 | After case ...: [no-match] | Switch.cs:50:13:50:39 | case ...: |
-| Switch.cs:48:13:48:23 | case ...: | Switch.cs:48:13:48:23 | After case ...: [match] |
-| Switch.cs:48:13:48:23 | case ...: | Switch.cs:48:13:48:23 | After case ...: [no-match] |
-| Switch.cs:48:18:48:20 | access to type Int32 | Switch.cs:49:17:49:22 | Before break; |
+| Switch.cs:48:13:48:23 | case ...: | Switch.cs:48:18:48:20 | access to type Int32 |
+| Switch.cs:48:18:48:20 | After access to type Int32 [match] | Switch.cs:48:13:48:23 | After case ...: [match] |
+| Switch.cs:48:18:48:20 | After access to type Int32 [no-match] | Switch.cs:48:13:48:23 | After case ...: [no-match] |
+| Switch.cs:48:18:48:20 | access to type Int32 | Switch.cs:48:18:48:20 | After access to type Int32 [match] |
+| Switch.cs:48:18:48:20 | access to type Int32 | Switch.cs:48:18:48:20 | After access to type Int32 [no-match] |
 | Switch.cs:49:17:49:22 | Before break; | Switch.cs:49:17:49:22 | break; |
-| Switch.cs:50:13:50:39 | After case ...: [match] | Switch.cs:50:18:50:21 | access to type Boolean |
-| Switch.cs:50:13:50:39 | case ...: | Switch.cs:50:13:50:39 | After case ...: [match] |
-| Switch.cs:50:13:50:39 | case ...: | Switch.cs:50:13:50:39 | After case ...: [no-match] |
-| Switch.cs:50:18:50:21 | access to type Boolean | Switch.cs:50:30:50:38 | Before ... != ... |
+| Switch.cs:50:13:50:39 | After case ...: [match] | Switch.cs:50:30:50:38 | Before ... != ... |
+| Switch.cs:50:13:50:39 | case ...: | Switch.cs:50:18:50:21 | access to type Boolean |
+| Switch.cs:50:18:50:21 | After access to type Boolean [match] | Switch.cs:50:13:50:39 | After case ...: [match] |
+| Switch.cs:50:18:50:21 | After access to type Boolean [no-match] | Switch.cs:50:13:50:39 | After case ...: [no-match] |
+| Switch.cs:50:18:50:21 | access to type Boolean | Switch.cs:50:18:50:21 | After access to type Boolean [match] |
+| Switch.cs:50:18:50:21 | access to type Boolean | Switch.cs:50:18:50:21 | After access to type Boolean [no-match] |
 | Switch.cs:50:30:50:30 | access to parameter o | Switch.cs:50:35:50:38 | null |
 | Switch.cs:50:30:50:38 | ... != ... | Switch.cs:50:30:50:38 | After ... != ... [false] |
 | Switch.cs:50:30:50:38 | ... != ... | Switch.cs:50:30:50:38 | After ... != ... [true] |
@@ -5873,16 +5908,20 @@ dominance
 | Switch.cs:57:17:57:21 | After ... + ... | Switch.cs:59:13:59:19 | case ...: |
 | Switch.cs:57:17:57:21 | Before ... + ... | Switch.cs:57:17:57:17 | 1 |
 | Switch.cs:57:21:57:21 | 2 | Switch.cs:57:17:57:21 | ... + ... |
-| Switch.cs:59:13:59:19 | After case ...: [match] | Switch.cs:59:18:59:18 | 2 |
+| Switch.cs:59:13:59:19 | After case ...: [match] | Switch.cs:60:17:60:22 | Before break; |
 | Switch.cs:59:13:59:19 | After case ...: [no-match] | Switch.cs:61:13:61:19 | case ...: |
-| Switch.cs:59:13:59:19 | case ...: | Switch.cs:59:13:59:19 | After case ...: [match] |
-| Switch.cs:59:13:59:19 | case ...: | Switch.cs:59:13:59:19 | After case ...: [no-match] |
-| Switch.cs:59:18:59:18 | 2 | Switch.cs:60:17:60:22 | Before break; |
+| Switch.cs:59:13:59:19 | case ...: | Switch.cs:59:18:59:18 | 2 |
+| Switch.cs:59:18:59:18 | 2 | Switch.cs:59:18:59:18 | After 2 [match] |
+| Switch.cs:59:18:59:18 | 2 | Switch.cs:59:18:59:18 | After 2 [no-match] |
+| Switch.cs:59:18:59:18 | After 2 [match] | Switch.cs:59:13:59:19 | After case ...: [match] |
+| Switch.cs:59:18:59:18 | After 2 [no-match] | Switch.cs:59:13:59:19 | After case ...: [no-match] |
 | Switch.cs:60:17:60:22 | Before break; | Switch.cs:60:17:60:22 | break; |
-| Switch.cs:61:13:61:19 | After case ...: [match] | Switch.cs:61:18:61:18 | 3 |
-| Switch.cs:61:13:61:19 | case ...: | Switch.cs:61:13:61:19 | After case ...: [match] |
-| Switch.cs:61:13:61:19 | case ...: | Switch.cs:61:13:61:19 | After case ...: [no-match] |
-| Switch.cs:61:18:61:18 | 3 | Switch.cs:62:17:62:22 | Before break; |
+| Switch.cs:61:13:61:19 | After case ...: [match] | Switch.cs:62:17:62:22 | Before break; |
+| Switch.cs:61:13:61:19 | case ...: | Switch.cs:61:18:61:18 | 3 |
+| Switch.cs:61:18:61:18 | 3 | Switch.cs:61:18:61:18 | After 3 [match] |
+| Switch.cs:61:18:61:18 | 3 | Switch.cs:61:18:61:18 | After 3 [no-match] |
+| Switch.cs:61:18:61:18 | After 3 [match] | Switch.cs:61:13:61:19 | After case ...: [match] |
+| Switch.cs:61:18:61:18 | After 3 [no-match] | Switch.cs:61:13:61:19 | After case ...: [no-match] |
 | Switch.cs:62:17:62:22 | Before break; | Switch.cs:62:17:62:22 | break; |
 | Switch.cs:66:10:66:11 | Entry | Switch.cs:66:20:66:20 | s |
 | Switch.cs:66:10:66:11 | Normal Exit | Switch.cs:66:10:66:11 | Exit |
@@ -5895,16 +5934,20 @@ dominance
 | Switch.cs:68:17:68:25 | After (...) ... | Switch.cs:70:13:70:23 | case ...: |
 | Switch.cs:68:17:68:25 | Before (...) ... | Switch.cs:68:25:68:25 | access to parameter s |
 | Switch.cs:68:25:68:25 | access to parameter s | Switch.cs:68:17:68:25 | (...) ... |
-| Switch.cs:70:13:70:23 | After case ...: [match] | Switch.cs:70:18:70:20 | access to type Int32 |
+| Switch.cs:70:13:70:23 | After case ...: [match] | Switch.cs:71:17:71:22 | Before break; |
 | Switch.cs:70:13:70:23 | After case ...: [no-match] | Switch.cs:72:13:72:20 | case ...: |
-| Switch.cs:70:13:70:23 | case ...: | Switch.cs:70:13:70:23 | After case ...: [match] |
-| Switch.cs:70:13:70:23 | case ...: | Switch.cs:70:13:70:23 | After case ...: [no-match] |
-| Switch.cs:70:18:70:20 | access to type Int32 | Switch.cs:71:17:71:22 | Before break; |
+| Switch.cs:70:13:70:23 | case ...: | Switch.cs:70:18:70:20 | access to type Int32 |
+| Switch.cs:70:18:70:20 | After access to type Int32 [match] | Switch.cs:70:13:70:23 | After case ...: [match] |
+| Switch.cs:70:18:70:20 | After access to type Int32 [no-match] | Switch.cs:70:13:70:23 | After case ...: [no-match] |
+| Switch.cs:70:18:70:20 | access to type Int32 | Switch.cs:70:18:70:20 | After access to type Int32 [match] |
+| Switch.cs:70:18:70:20 | access to type Int32 | Switch.cs:70:18:70:20 | After access to type Int32 [no-match] |
 | Switch.cs:71:17:71:22 | Before break; | Switch.cs:71:17:71:22 | break; |
-| Switch.cs:72:13:72:20 | After case ...: [match] | Switch.cs:72:18:72:19 | "" |
-| Switch.cs:72:13:72:20 | case ...: | Switch.cs:72:13:72:20 | After case ...: [match] |
-| Switch.cs:72:13:72:20 | case ...: | Switch.cs:72:13:72:20 | After case ...: [no-match] |
-| Switch.cs:72:18:72:19 | "" | Switch.cs:73:17:73:22 | Before break; |
+| Switch.cs:72:13:72:20 | After case ...: [match] | Switch.cs:73:17:73:22 | Before break; |
+| Switch.cs:72:13:72:20 | case ...: | Switch.cs:72:18:72:19 | "" |
+| Switch.cs:72:18:72:19 | "" | Switch.cs:72:18:72:19 | After "" [match] |
+| Switch.cs:72:18:72:19 | "" | Switch.cs:72:18:72:19 | After "" [no-match] |
+| Switch.cs:72:18:72:19 | After "" [match] | Switch.cs:72:13:72:20 | After case ...: [match] |
+| Switch.cs:72:18:72:19 | After "" [no-match] | Switch.cs:72:13:72:20 | After case ...: [no-match] |
 | Switch.cs:73:17:73:22 | Before break; | Switch.cs:73:17:73:22 | break; |
 | Switch.cs:77:10:77:11 | Entry | Switch.cs:77:17:77:17 | i |
 | Switch.cs:77:10:77:11 | Normal Exit | Switch.cs:77:10:77:11 | Exit |
@@ -5914,17 +5957,21 @@ dominance
 | Switch.cs:79:9:87:9 | After switch (...) {...} | Switch.cs:88:9:88:21 | Before return ...; |
 | Switch.cs:79:9:87:9 | switch (...) {...} | Switch.cs:79:17:79:17 | access to parameter i |
 | Switch.cs:79:17:79:17 | access to parameter i | Switch.cs:81:13:81:19 | case ...: |
-| Switch.cs:81:13:81:19 | After case ...: [match] | Switch.cs:81:18:81:18 | 1 |
+| Switch.cs:81:13:81:19 | After case ...: [match] | Switch.cs:82:17:82:28 | Before return ...; |
 | Switch.cs:81:13:81:19 | After case ...: [no-match] | Switch.cs:83:13:83:19 | case ...: |
-| Switch.cs:81:13:81:19 | case ...: | Switch.cs:81:13:81:19 | After case ...: [match] |
-| Switch.cs:81:13:81:19 | case ...: | Switch.cs:81:13:81:19 | After case ...: [no-match] |
-| Switch.cs:81:18:81:18 | 1 | Switch.cs:82:17:82:28 | Before return ...; |
+| Switch.cs:81:13:81:19 | case ...: | Switch.cs:81:18:81:18 | 1 |
+| Switch.cs:81:18:81:18 | 1 | Switch.cs:81:18:81:18 | After 1 [match] |
+| Switch.cs:81:18:81:18 | 1 | Switch.cs:81:18:81:18 | After 1 [no-match] |
+| Switch.cs:81:18:81:18 | After 1 [match] | Switch.cs:81:13:81:19 | After case ...: [match] |
+| Switch.cs:81:18:81:18 | After 1 [no-match] | Switch.cs:81:13:81:19 | After case ...: [no-match] |
 | Switch.cs:82:17:82:28 | Before return ...; | Switch.cs:82:24:82:27 | true |
 | Switch.cs:82:24:82:27 | true | Switch.cs:82:17:82:28 | return ...; |
-| Switch.cs:83:13:83:19 | After case ...: [match] | Switch.cs:83:18:83:18 | 2 |
-| Switch.cs:83:13:83:19 | case ...: | Switch.cs:83:13:83:19 | After case ...: [match] |
-| Switch.cs:83:13:83:19 | case ...: | Switch.cs:83:13:83:19 | After case ...: [no-match] |
-| Switch.cs:83:18:83:18 | 2 | Switch.cs:84:17:85:26 | if (...) ... |
+| Switch.cs:83:13:83:19 | After case ...: [match] | Switch.cs:84:17:85:26 | if (...) ... |
+| Switch.cs:83:13:83:19 | case ...: | Switch.cs:83:18:83:18 | 2 |
+| Switch.cs:83:18:83:18 | 2 | Switch.cs:83:18:83:18 | After 2 [match] |
+| Switch.cs:83:18:83:18 | 2 | Switch.cs:83:18:83:18 | After 2 [no-match] |
+| Switch.cs:83:18:83:18 | After 2 [match] | Switch.cs:83:13:83:19 | After case ...: [match] |
+| Switch.cs:83:18:83:18 | After 2 [no-match] | Switch.cs:83:13:83:19 | After case ...: [no-match] |
 | Switch.cs:84:17:85:26 | After if (...) ... | Switch.cs:86:17:86:28 | Before return ...; |
 | Switch.cs:84:17:85:26 | if (...) ... | Switch.cs:84:21:84:25 | Before ... > ... |
 | Switch.cs:84:21:84:21 | access to parameter j | Switch.cs:84:25:84:25 | 2 |
@@ -5946,11 +5993,13 @@ dominance
 | Switch.cs:93:9:97:9 | After switch (...) {...} | Switch.cs:98:9:98:21 | Before return ...; |
 | Switch.cs:93:9:97:9 | switch (...) {...} | Switch.cs:93:17:93:17 | access to parameter o |
 | Switch.cs:93:17:93:17 | access to parameter o | Switch.cs:95:13:95:23 | case ...: |
-| Switch.cs:95:13:95:23 | After case ...: [match] | Switch.cs:95:18:95:20 | access to type Int32 |
+| Switch.cs:95:13:95:23 | After case ...: [match] | Switch.cs:96:17:96:28 | Before return ...; |
 | Switch.cs:95:13:95:23 | After case ...: [no-match] | Switch.cs:93:9:97:9 | After switch (...) {...} |
-| Switch.cs:95:13:95:23 | case ...: | Switch.cs:95:13:95:23 | After case ...: [match] |
-| Switch.cs:95:13:95:23 | case ...: | Switch.cs:95:13:95:23 | After case ...: [no-match] |
-| Switch.cs:95:18:95:20 | access to type Int32 | Switch.cs:96:17:96:28 | Before return ...; |
+| Switch.cs:95:13:95:23 | case ...: | Switch.cs:95:18:95:20 | access to type Int32 |
+| Switch.cs:95:18:95:20 | After access to type Int32 [match] | Switch.cs:95:13:95:23 | After case ...: [match] |
+| Switch.cs:95:18:95:20 | After access to type Int32 [no-match] | Switch.cs:95:13:95:23 | After case ...: [no-match] |
+| Switch.cs:95:18:95:20 | access to type Int32 | Switch.cs:95:18:95:20 | After access to type Int32 [match] |
+| Switch.cs:95:18:95:20 | access to type Int32 | Switch.cs:95:18:95:20 | After access to type Int32 [no-match] |
 | Switch.cs:96:17:96:28 | Before return ...; | Switch.cs:96:24:96:27 | true |
 | Switch.cs:96:24:96:27 | true | Switch.cs:96:17:96:28 | return ...; |
 | Switch.cs:98:9:98:21 | Before return ...; | Switch.cs:98:16:98:20 | false |
@@ -5966,18 +6015,22 @@ dominance
 | Switch.cs:103:17:103:17 | access to parameter s | Switch.cs:103:17:103:17 | After access to parameter s [null] |
 | Switch.cs:103:17:103:25 | After access to property Length | Switch.cs:105:13:105:19 | case ...: |
 | Switch.cs:103:17:103:25 | Before access to property Length | Switch.cs:103:17:103:17 | access to parameter s |
-| Switch.cs:105:13:105:19 | After case ...: [match] | Switch.cs:105:18:105:18 | 0 |
+| Switch.cs:105:13:105:19 | After case ...: [match] | Switch.cs:105:21:105:29 | Before return ...; |
 | Switch.cs:105:13:105:19 | After case ...: [no-match] | Switch.cs:106:13:106:19 | case ...: |
-| Switch.cs:105:13:105:19 | case ...: | Switch.cs:105:13:105:19 | After case ...: [match] |
-| Switch.cs:105:13:105:19 | case ...: | Switch.cs:105:13:105:19 | After case ...: [no-match] |
-| Switch.cs:105:18:105:18 | 0 | Switch.cs:105:21:105:29 | Before return ...; |
+| Switch.cs:105:13:105:19 | case ...: | Switch.cs:105:18:105:18 | 0 |
+| Switch.cs:105:18:105:18 | 0 | Switch.cs:105:18:105:18 | After 0 [match] |
+| Switch.cs:105:18:105:18 | 0 | Switch.cs:105:18:105:18 | After 0 [no-match] |
+| Switch.cs:105:18:105:18 | After 0 [match] | Switch.cs:105:13:105:19 | After case ...: [match] |
+| Switch.cs:105:18:105:18 | After 0 [no-match] | Switch.cs:105:13:105:19 | After case ...: [no-match] |
 | Switch.cs:105:21:105:29 | Before return ...; | Switch.cs:105:28:105:28 | 0 |
 | Switch.cs:105:28:105:28 | 0 | Switch.cs:105:21:105:29 | return ...; |
-| Switch.cs:106:13:106:19 | After case ...: [match] | Switch.cs:106:18:106:18 | 1 |
+| Switch.cs:106:13:106:19 | After case ...: [match] | Switch.cs:106:21:106:29 | Before return ...; |
 | Switch.cs:106:13:106:19 | After case ...: [no-match] | Switch.cs:103:9:107:9 | After switch (...) {...} |
-| Switch.cs:106:13:106:19 | case ...: | Switch.cs:106:13:106:19 | After case ...: [match] |
-| Switch.cs:106:13:106:19 | case ...: | Switch.cs:106:13:106:19 | After case ...: [no-match] |
-| Switch.cs:106:18:106:18 | 1 | Switch.cs:106:21:106:29 | Before return ...; |
+| Switch.cs:106:13:106:19 | case ...: | Switch.cs:106:18:106:18 | 1 |
+| Switch.cs:106:18:106:18 | 1 | Switch.cs:106:18:106:18 | After 1 [match] |
+| Switch.cs:106:18:106:18 | 1 | Switch.cs:106:18:106:18 | After 1 [no-match] |
+| Switch.cs:106:18:106:18 | After 1 [match] | Switch.cs:106:13:106:19 | After case ...: [match] |
+| Switch.cs:106:18:106:18 | After 1 [no-match] | Switch.cs:106:13:106:19 | After case ...: [no-match] |
 | Switch.cs:106:21:106:29 | Before return ...; | Switch.cs:106:28:106:28 | 1 |
 | Switch.cs:106:28:106:28 | 1 | Switch.cs:106:21:106:29 | return ...; |
 | Switch.cs:108:9:108:18 | Before return ...; | Switch.cs:108:16:108:17 | Before -... |
@@ -6002,10 +6055,12 @@ dominance
 | Switch.cs:115:17:115:24 | After access to property Length | Switch.cs:117:13:117:35 | case ...: |
 | Switch.cs:115:17:115:24 | Before access to property Length | Switch.cs:115:17:115:17 | access to parameter s |
 | Switch.cs:115:17:115:24 | access to property Length | Switch.cs:115:17:115:24 | After access to property Length |
-| Switch.cs:117:13:117:35 | After case ...: [match] | Switch.cs:117:18:117:18 | 3 |
-| Switch.cs:117:13:117:35 | case ...: | Switch.cs:117:13:117:35 | After case ...: [match] |
-| Switch.cs:117:13:117:35 | case ...: | Switch.cs:117:13:117:35 | After case ...: [no-match] |
-| Switch.cs:117:18:117:18 | 3 | Switch.cs:117:25:117:34 | Before ... == ... |
+| Switch.cs:117:13:117:35 | After case ...: [match] | Switch.cs:117:25:117:34 | Before ... == ... |
+| Switch.cs:117:13:117:35 | case ...: | Switch.cs:117:18:117:18 | 3 |
+| Switch.cs:117:18:117:18 | 3 | Switch.cs:117:18:117:18 | After 3 [match] |
+| Switch.cs:117:18:117:18 | 3 | Switch.cs:117:18:117:18 | After 3 [no-match] |
+| Switch.cs:117:18:117:18 | After 3 [match] | Switch.cs:117:13:117:35 | After case ...: [match] |
+| Switch.cs:117:18:117:18 | After 3 [no-match] | Switch.cs:117:13:117:35 | After case ...: [no-match] |
 | Switch.cs:117:25:117:25 | access to parameter s | Switch.cs:117:30:117:34 | "foo" |
 | Switch.cs:117:25:117:34 | ... == ... | Switch.cs:117:25:117:34 | After ... == ... [false] |
 | Switch.cs:117:25:117:34 | ... == ... | Switch.cs:117:25:117:34 | After ... == ... [true] |
@@ -6014,10 +6069,12 @@ dominance
 | Switch.cs:117:30:117:34 | "foo" | Switch.cs:117:25:117:34 | ... == ... |
 | Switch.cs:117:37:117:45 | Before return ...; | Switch.cs:117:44:117:44 | 1 |
 | Switch.cs:117:44:117:44 | 1 | Switch.cs:117:37:117:45 | return ...; |
-| Switch.cs:118:13:118:34 | After case ...: [match] | Switch.cs:118:18:118:18 | 2 |
-| Switch.cs:118:13:118:34 | case ...: | Switch.cs:118:13:118:34 | After case ...: [match] |
-| Switch.cs:118:13:118:34 | case ...: | Switch.cs:118:13:118:34 | After case ...: [no-match] |
-| Switch.cs:118:18:118:18 | 2 | Switch.cs:118:25:118:33 | Before ... == ... |
+| Switch.cs:118:13:118:34 | After case ...: [match] | Switch.cs:118:25:118:33 | Before ... == ... |
+| Switch.cs:118:13:118:34 | case ...: | Switch.cs:118:18:118:18 | 2 |
+| Switch.cs:118:18:118:18 | 2 | Switch.cs:118:18:118:18 | After 2 [match] |
+| Switch.cs:118:18:118:18 | 2 | Switch.cs:118:18:118:18 | After 2 [no-match] |
+| Switch.cs:118:18:118:18 | After 2 [match] | Switch.cs:118:13:118:34 | After case ...: [match] |
+| Switch.cs:118:18:118:18 | After 2 [no-match] | Switch.cs:118:13:118:34 | After case ...: [no-match] |
 | Switch.cs:118:25:118:25 | access to parameter s | Switch.cs:118:30:118:33 | "fu" |
 | Switch.cs:118:25:118:33 | ... == ... | Switch.cs:118:25:118:33 | After ... == ... [false] |
 | Switch.cs:118:25:118:33 | ... == ... | Switch.cs:118:25:118:33 | After ... == ... [true] |
@@ -6041,14 +6098,17 @@ dominance
 | Switch.cs:125:13:125:48 | ... switch { ... } | Switch.cs:125:13:125:13 | access to parameter o |
 | Switch.cs:125:13:125:48 | After ... switch { ... } [false] | Switch.cs:125:9:126:19 | After if (...) ... |
 | Switch.cs:125:13:125:48 | After ... switch { ... } [true] | Switch.cs:126:13:126:19 | Before return ...; |
-| Switch.cs:125:24:125:29 | Boolean b | Switch.cs:125:34:125:34 | access to local variable b |
-| Switch.cs:125:24:125:34 | ... => ... | Switch.cs:125:24:125:34 | After ... => ... [match] |
-| Switch.cs:125:24:125:34 | ... => ... | Switch.cs:125:24:125:34 | After ... => ... [no-match] |
-| Switch.cs:125:24:125:34 | After ... => ... [match] | Switch.cs:125:24:125:29 | Boolean b |
+| Switch.cs:125:24:125:29 | After Boolean b [match] | Switch.cs:125:24:125:34 | After ... => ... [match] |
+| Switch.cs:125:24:125:29 | After Boolean b [no-match] | Switch.cs:125:24:125:34 | After ... => ... [no-match] |
+| Switch.cs:125:24:125:29 | Boolean b | Switch.cs:125:24:125:29 | After Boolean b [match] |
+| Switch.cs:125:24:125:29 | Boolean b | Switch.cs:125:24:125:29 | After Boolean b [no-match] |
+| Switch.cs:125:24:125:34 | ... => ... | Switch.cs:125:24:125:29 | Boolean b |
+| Switch.cs:125:24:125:34 | After ... => ... [match] | Switch.cs:125:34:125:34 | access to local variable b |
 | Switch.cs:125:24:125:34 | After ... => ... [no-match] | Switch.cs:125:37:125:46 | ... => ... |
-| Switch.cs:125:37:125:37 | _ | Switch.cs:125:42:125:46 | false |
-| Switch.cs:125:37:125:46 | ... => ... | Switch.cs:125:37:125:46 | After ... => ... [match] |
-| Switch.cs:125:37:125:46 | After ... => ... [match] | Switch.cs:125:37:125:37 | _ |
+| Switch.cs:125:37:125:37 | After _ [match] | Switch.cs:125:37:125:46 | After ... => ... [match] |
+| Switch.cs:125:37:125:37 | _ | Switch.cs:125:37:125:37 | After _ [match] |
+| Switch.cs:125:37:125:46 | ... => ... | Switch.cs:125:37:125:37 | _ |
+| Switch.cs:125:37:125:46 | After ... => ... [match] | Switch.cs:125:42:125:46 | false |
 | Switch.cs:126:13:126:19 | Before return ...; | Switch.cs:126:13:126:19 | return ...; |
 | Switch.cs:129:12:129:14 | Entry | Switch.cs:129:23:129:23 | o |
 | Switch.cs:129:12:129:14 | Normal Exit | Switch.cs:129:12:129:14 | Exit |
@@ -6061,14 +6121,17 @@ dominance
 | Switch.cs:131:17:131:17 | access to parameter o | Switch.cs:131:28:131:40 | ... => ... |
 | Switch.cs:131:17:131:53 | ... switch { ... } | Switch.cs:131:17:131:17 | access to parameter o |
 | Switch.cs:131:17:131:53 | After ... switch { ... } [non-null] | Switch.cs:131:16:131:66 | call to method ToString |
-| Switch.cs:131:28:131:35 | String s | Switch.cs:131:40:131:40 | access to local variable s |
-| Switch.cs:131:28:131:40 | ... => ... | Switch.cs:131:28:131:40 | After ... => ... [match] |
-| Switch.cs:131:28:131:40 | ... => ... | Switch.cs:131:28:131:40 | After ... => ... [no-match] |
-| Switch.cs:131:28:131:40 | After ... => ... [match] | Switch.cs:131:28:131:35 | String s |
+| Switch.cs:131:28:131:35 | After String s [match] | Switch.cs:131:28:131:40 | After ... => ... [match] |
+| Switch.cs:131:28:131:35 | After String s [no-match] | Switch.cs:131:28:131:40 | After ... => ... [no-match] |
+| Switch.cs:131:28:131:35 | String s | Switch.cs:131:28:131:35 | After String s [match] |
+| Switch.cs:131:28:131:35 | String s | Switch.cs:131:28:131:35 | After String s [no-match] |
+| Switch.cs:131:28:131:40 | ... => ... | Switch.cs:131:28:131:35 | String s |
+| Switch.cs:131:28:131:40 | After ... => ... [match] | Switch.cs:131:40:131:40 | access to local variable s |
 | Switch.cs:131:28:131:40 | After ... => ... [no-match] | Switch.cs:131:43:131:51 | ... => ... |
-| Switch.cs:131:43:131:43 | _ | Switch.cs:131:48:131:51 | null |
-| Switch.cs:131:43:131:51 | ... => ... | Switch.cs:131:43:131:51 | After ... => ... [match] |
-| Switch.cs:131:43:131:51 | After ... => ... [match] | Switch.cs:131:43:131:43 | _ |
+| Switch.cs:131:43:131:43 | After _ [match] | Switch.cs:131:43:131:51 | After ... => ... [match] |
+| Switch.cs:131:43:131:43 | _ | Switch.cs:131:43:131:43 | After _ [match] |
+| Switch.cs:131:43:131:51 | ... => ... | Switch.cs:131:43:131:43 | _ |
+| Switch.cs:131:43:131:51 | After ... => ... [match] | Switch.cs:131:48:131:51 | null |
 | Switch.cs:134:9:134:11 | Entry | Switch.cs:134:17:134:17 | i |
 | Switch.cs:134:9:134:11 | Normal Exit | Switch.cs:134:9:134:11 | Exit |
 | Switch.cs:134:17:134:17 | i | Switch.cs:135:5:142:5 | {...} |
@@ -6082,18 +6145,22 @@ dominance
 | Switch.cs:138:29:138:30 | After -... | Switch.cs:138:22:138:31 | return ...; |
 | Switch.cs:138:29:138:30 | Before -... | Switch.cs:138:30:138:30 | 1 |
 | Switch.cs:138:30:138:30 | 1 | Switch.cs:138:29:138:30 | -... |
-| Switch.cs:139:13:139:19 | After case ...: [match] | Switch.cs:139:18:139:18 | 1 |
+| Switch.cs:139:13:139:19 | After case ...: [match] | Switch.cs:139:21:139:29 | Before return ...; |
 | Switch.cs:139:13:139:19 | After case ...: [no-match] | Switch.cs:140:13:140:19 | case ...: |
-| Switch.cs:139:13:139:19 | case ...: | Switch.cs:139:13:139:19 | After case ...: [match] |
-| Switch.cs:139:13:139:19 | case ...: | Switch.cs:139:13:139:19 | After case ...: [no-match] |
-| Switch.cs:139:18:139:18 | 1 | Switch.cs:139:21:139:29 | Before return ...; |
+| Switch.cs:139:13:139:19 | case ...: | Switch.cs:139:18:139:18 | 1 |
+| Switch.cs:139:18:139:18 | 1 | Switch.cs:139:18:139:18 | After 1 [match] |
+| Switch.cs:139:18:139:18 | 1 | Switch.cs:139:18:139:18 | After 1 [no-match] |
+| Switch.cs:139:18:139:18 | After 1 [match] | Switch.cs:139:13:139:19 | After case ...: [match] |
+| Switch.cs:139:18:139:18 | After 1 [no-match] | Switch.cs:139:13:139:19 | After case ...: [no-match] |
 | Switch.cs:139:21:139:29 | Before return ...; | Switch.cs:139:28:139:28 | 1 |
 | Switch.cs:139:28:139:28 | 1 | Switch.cs:139:21:139:29 | return ...; |
-| Switch.cs:140:13:140:19 | After case ...: [match] | Switch.cs:140:18:140:18 | 2 |
+| Switch.cs:140:13:140:19 | After case ...: [match] | Switch.cs:140:21:140:29 | Before return ...; |
 | Switch.cs:140:13:140:19 | After case ...: [no-match] | Switch.cs:138:13:138:20 | default: |
-| Switch.cs:140:13:140:19 | case ...: | Switch.cs:140:13:140:19 | After case ...: [match] |
-| Switch.cs:140:13:140:19 | case ...: | Switch.cs:140:13:140:19 | After case ...: [no-match] |
-| Switch.cs:140:18:140:18 | 2 | Switch.cs:140:21:140:29 | Before return ...; |
+| Switch.cs:140:13:140:19 | case ...: | Switch.cs:140:18:140:18 | 2 |
+| Switch.cs:140:18:140:18 | 2 | Switch.cs:140:18:140:18 | After 2 [match] |
+| Switch.cs:140:18:140:18 | 2 | Switch.cs:140:18:140:18 | After 2 [no-match] |
+| Switch.cs:140:18:140:18 | After 2 [match] | Switch.cs:140:13:140:19 | After case ...: [match] |
+| Switch.cs:140:18:140:18 | After 2 [no-match] | Switch.cs:140:13:140:19 | After case ...: [no-match] |
 | Switch.cs:140:21:140:29 | Before return ...; | Switch.cs:140:28:140:28 | 2 |
 | Switch.cs:140:28:140:28 | 2 | Switch.cs:140:21:140:29 | return ...; |
 | Switch.cs:144:9:144:11 | Entry | Switch.cs:144:17:144:17 | i |
@@ -6102,11 +6169,13 @@ dominance
 | Switch.cs:145:5:152:5 | {...} | Switch.cs:146:9:151:9 | switch (...) {...} |
 | Switch.cs:146:9:151:9 | switch (...) {...} | Switch.cs:146:17:146:17 | access to parameter i |
 | Switch.cs:146:17:146:17 | access to parameter i | Switch.cs:148:13:148:19 | case ...: |
-| Switch.cs:148:13:148:19 | After case ...: [match] | Switch.cs:148:18:148:18 | 1 |
+| Switch.cs:148:13:148:19 | After case ...: [match] | Switch.cs:148:21:148:29 | Before return ...; |
 | Switch.cs:148:13:148:19 | After case ...: [no-match] | Switch.cs:150:13:150:19 | case ...: |
-| Switch.cs:148:13:148:19 | case ...: | Switch.cs:148:13:148:19 | After case ...: [match] |
-| Switch.cs:148:13:148:19 | case ...: | Switch.cs:148:13:148:19 | After case ...: [no-match] |
-| Switch.cs:148:18:148:18 | 1 | Switch.cs:148:21:148:29 | Before return ...; |
+| Switch.cs:148:13:148:19 | case ...: | Switch.cs:148:18:148:18 | 1 |
+| Switch.cs:148:18:148:18 | 1 | Switch.cs:148:18:148:18 | After 1 [match] |
+| Switch.cs:148:18:148:18 | 1 | Switch.cs:148:18:148:18 | After 1 [no-match] |
+| Switch.cs:148:18:148:18 | After 1 [match] | Switch.cs:148:13:148:19 | After case ...: [match] |
+| Switch.cs:148:18:148:18 | After 1 [no-match] | Switch.cs:148:13:148:19 | After case ...: [no-match] |
 | Switch.cs:148:21:148:29 | Before return ...; | Switch.cs:148:28:148:28 | 1 |
 | Switch.cs:148:28:148:28 | 1 | Switch.cs:148:21:148:29 | return ...; |
 | Switch.cs:149:13:149:20 | After default: [match] | Switch.cs:149:22:149:31 | Before return ...; |
@@ -6116,11 +6185,13 @@ dominance
 | Switch.cs:149:29:149:30 | After -... | Switch.cs:149:22:149:31 | return ...; |
 | Switch.cs:149:29:149:30 | Before -... | Switch.cs:149:30:149:30 | 1 |
 | Switch.cs:149:30:149:30 | 1 | Switch.cs:149:29:149:30 | -... |
-| Switch.cs:150:13:150:19 | After case ...: [match] | Switch.cs:150:18:150:18 | 2 |
+| Switch.cs:150:13:150:19 | After case ...: [match] | Switch.cs:150:21:150:29 | Before return ...; |
 | Switch.cs:150:13:150:19 | After case ...: [no-match] | Switch.cs:149:13:149:20 | default: |
-| Switch.cs:150:13:150:19 | case ...: | Switch.cs:150:13:150:19 | After case ...: [match] |
-| Switch.cs:150:13:150:19 | case ...: | Switch.cs:150:13:150:19 | After case ...: [no-match] |
-| Switch.cs:150:18:150:18 | 2 | Switch.cs:150:21:150:29 | Before return ...; |
+| Switch.cs:150:13:150:19 | case ...: | Switch.cs:150:18:150:18 | 2 |
+| Switch.cs:150:18:150:18 | 2 | Switch.cs:150:18:150:18 | After 2 [match] |
+| Switch.cs:150:18:150:18 | 2 | Switch.cs:150:18:150:18 | After 2 [no-match] |
+| Switch.cs:150:18:150:18 | After 2 [match] | Switch.cs:150:13:150:19 | After case ...: [match] |
+| Switch.cs:150:18:150:18 | After 2 [no-match] | Switch.cs:150:13:150:19 | After case ...: [no-match] |
 | Switch.cs:150:21:150:29 | Before return ...; | Switch.cs:150:28:150:28 | 2 |
 | Switch.cs:150:28:150:28 | 2 | Switch.cs:150:21:150:29 | return ...; |
 | Switch.cs:154:10:154:12 | Entry | Switch.cs:154:19:154:19 | b |
@@ -6137,15 +6208,19 @@ dominance
 | Switch.cs:156:17:156:17 | access to parameter b | Switch.cs:156:28:156:38 | ... => ... |
 | Switch.cs:156:17:156:54 | ... switch { ... } | Switch.cs:156:17:156:17 | access to parameter b |
 | Switch.cs:156:17:156:54 | After ... switch { ... } | Switch.cs:156:13:156:54 | String s = ... |
-| Switch.cs:156:28:156:31 | true | Switch.cs:156:36:156:38 | "a" |
-| Switch.cs:156:28:156:38 | ... => ... | Switch.cs:156:28:156:38 | After ... => ... [match] |
-| Switch.cs:156:28:156:38 | ... => ... | Switch.cs:156:28:156:38 | After ... => ... [no-match] |
-| Switch.cs:156:28:156:38 | After ... => ... [match] | Switch.cs:156:28:156:31 | true |
+| Switch.cs:156:28:156:31 | After true [match] | Switch.cs:156:28:156:38 | After ... => ... [match] |
+| Switch.cs:156:28:156:31 | After true [no-match] | Switch.cs:156:28:156:38 | After ... => ... [no-match] |
+| Switch.cs:156:28:156:31 | true | Switch.cs:156:28:156:31 | After true [match] |
+| Switch.cs:156:28:156:31 | true | Switch.cs:156:28:156:31 | After true [no-match] |
+| Switch.cs:156:28:156:38 | ... => ... | Switch.cs:156:28:156:31 | true |
+| Switch.cs:156:28:156:38 | After ... => ... [match] | Switch.cs:156:36:156:38 | "a" |
 | Switch.cs:156:28:156:38 | After ... => ... [no-match] | Switch.cs:156:41:156:52 | ... => ... |
-| Switch.cs:156:41:156:45 | false | Switch.cs:156:50:156:52 | "b" |
-| Switch.cs:156:41:156:52 | ... => ... | Switch.cs:156:41:156:52 | After ... => ... [match] |
-| Switch.cs:156:41:156:52 | ... => ... | Switch.cs:156:41:156:52 | After ... => ... [no-match] |
-| Switch.cs:156:41:156:52 | After ... => ... [match] | Switch.cs:156:41:156:45 | false |
+| Switch.cs:156:41:156:45 | After false [match] | Switch.cs:156:41:156:52 | After ... => ... [match] |
+| Switch.cs:156:41:156:45 | After false [no-match] | Switch.cs:156:41:156:52 | After ... => ... [no-match] |
+| Switch.cs:156:41:156:45 | false | Switch.cs:156:41:156:45 | After false [match] |
+| Switch.cs:156:41:156:45 | false | Switch.cs:156:41:156:45 | After false [no-match] |
+| Switch.cs:156:41:156:52 | ... => ... | Switch.cs:156:41:156:45 | false |
+| Switch.cs:156:41:156:52 | After ... => ... [match] | Switch.cs:156:50:156:52 | "b" |
 | Switch.cs:157:9:160:49 | After if (...) ... | Switch.cs:155:5:161:5 | After {...} |
 | Switch.cs:157:9:160:49 | if (...) ... | Switch.cs:157:13:157:13 | access to parameter b |
 | Switch.cs:157:13:157:13 | After access to parameter b [false] | Switch.cs:160:13:160:49 | ...; |
@@ -6184,14 +6259,18 @@ dominance
 | Switch.cs:165:9:177:9 | After switch (...) {...} | Switch.cs:164:5:178:5 | After {...} |
 | Switch.cs:165:9:177:9 | switch (...) {...} | Switch.cs:165:17:165:17 | access to parameter i |
 | Switch.cs:165:17:165:17 | access to parameter i | Switch.cs:167:13:167:19 | case ...: |
-| Switch.cs:167:13:167:19 | After case ...: [match] | Switch.cs:167:18:167:18 | 1 |
 | Switch.cs:167:13:167:19 | After case ...: [no-match] | Switch.cs:168:13:168:19 | case ...: |
-| Switch.cs:167:13:167:19 | case ...: | Switch.cs:167:13:167:19 | After case ...: [match] |
-| Switch.cs:167:13:167:19 | case ...: | Switch.cs:167:13:167:19 | After case ...: [no-match] |
-| Switch.cs:168:13:168:19 | After case ...: [match] | Switch.cs:168:18:168:18 | 2 |
+| Switch.cs:167:13:167:19 | case ...: | Switch.cs:167:18:167:18 | 1 |
+| Switch.cs:167:18:167:18 | 1 | Switch.cs:167:18:167:18 | After 1 [match] |
+| Switch.cs:167:18:167:18 | 1 | Switch.cs:167:18:167:18 | After 1 [no-match] |
+| Switch.cs:167:18:167:18 | After 1 [match] | Switch.cs:167:13:167:19 | After case ...: [match] |
+| Switch.cs:167:18:167:18 | After 1 [no-match] | Switch.cs:167:13:167:19 | After case ...: [no-match] |
 | Switch.cs:168:13:168:19 | After case ...: [no-match] | Switch.cs:171:13:171:19 | case ...: |
-| Switch.cs:168:13:168:19 | case ...: | Switch.cs:168:13:168:19 | After case ...: [match] |
-| Switch.cs:168:13:168:19 | case ...: | Switch.cs:168:13:168:19 | After case ...: [no-match] |
+| Switch.cs:168:13:168:19 | case ...: | Switch.cs:168:18:168:18 | 2 |
+| Switch.cs:168:18:168:18 | 2 | Switch.cs:168:18:168:18 | After 2 [match] |
+| Switch.cs:168:18:168:18 | 2 | Switch.cs:168:18:168:18 | After 2 [no-match] |
+| Switch.cs:168:18:168:18 | After 2 [match] | Switch.cs:168:13:168:19 | After case ...: [match] |
+| Switch.cs:168:18:168:18 | After 2 [no-match] | Switch.cs:168:13:168:19 | After case ...: [no-match] |
 | Switch.cs:169:17:169:50 | After call to method WriteLine | Switch.cs:169:17:169:51 | After ...; |
 | Switch.cs:169:17:169:50 | Before call to method WriteLine | Switch.cs:169:42:169:49 | "1 or 2" |
 | Switch.cs:169:17:169:50 | call to method WriteLine | Switch.cs:169:17:169:50 | After call to method WriteLine |
@@ -6199,11 +6278,13 @@ dominance
 | Switch.cs:169:17:169:51 | After ...; | Switch.cs:170:17:170:22 | Before break; |
 | Switch.cs:169:42:169:49 | "1 or 2" | Switch.cs:169:17:169:50 | call to method WriteLine |
 | Switch.cs:170:17:170:22 | Before break; | Switch.cs:170:17:170:22 | break; |
-| Switch.cs:171:13:171:19 | After case ...: [match] | Switch.cs:171:18:171:18 | 3 |
+| Switch.cs:171:13:171:19 | After case ...: [match] | Switch.cs:172:17:172:46 | ...; |
 | Switch.cs:171:13:171:19 | After case ...: [no-match] | Switch.cs:174:13:174:20 | default: |
-| Switch.cs:171:13:171:19 | case ...: | Switch.cs:171:13:171:19 | After case ...: [match] |
-| Switch.cs:171:13:171:19 | case ...: | Switch.cs:171:13:171:19 | After case ...: [no-match] |
-| Switch.cs:171:18:171:18 | 3 | Switch.cs:172:17:172:46 | ...; |
+| Switch.cs:171:13:171:19 | case ...: | Switch.cs:171:18:171:18 | 3 |
+| Switch.cs:171:18:171:18 | 3 | Switch.cs:171:18:171:18 | After 3 [match] |
+| Switch.cs:171:18:171:18 | 3 | Switch.cs:171:18:171:18 | After 3 [no-match] |
+| Switch.cs:171:18:171:18 | After 3 [match] | Switch.cs:171:13:171:19 | After case ...: [match] |
+| Switch.cs:171:18:171:18 | After 3 [no-match] | Switch.cs:171:13:171:19 | After case ...: [no-match] |
 | Switch.cs:172:17:172:45 | After call to method WriteLine | Switch.cs:172:17:172:46 | After ...; |
 | Switch.cs:172:17:172:45 | Before call to method WriteLine | Switch.cs:172:42:172:44 | "3" |
 | Switch.cs:172:17:172:45 | call to method WriteLine | Switch.cs:172:17:172:45 | After call to method WriteLine |
@@ -6569,11 +6650,12 @@ dominance
 | cflow.cs:39:9:50:9 | After switch (...) {...} | cflow.cs:51:9:59:9 | switch (...) {...} |
 | cflow.cs:39:9:50:9 | switch (...) {...} | cflow.cs:39:17:39:17 | access to parameter a |
 | cflow.cs:39:17:39:17 | access to parameter a | cflow.cs:41:13:41:19 | case ...: |
-| cflow.cs:41:13:41:19 | After case ...: [match] | cflow.cs:41:18:41:18 | 1 |
+| cflow.cs:41:13:41:19 | After case ...: [match] | cflow.cs:42:17:42:39 | ...; |
 | cflow.cs:41:13:41:19 | After case ...: [no-match] | cflow.cs:44:13:44:19 | case ...: |
-| cflow.cs:41:13:41:19 | case ...: | cflow.cs:41:13:41:19 | After case ...: [match] |
-| cflow.cs:41:13:41:19 | case ...: | cflow.cs:41:13:41:19 | After case ...: [no-match] |
-| cflow.cs:41:18:41:18 | 1 | cflow.cs:42:17:42:39 | ...; |
+| cflow.cs:41:13:41:19 | case ...: | cflow.cs:41:18:41:18 | 1 |
+| cflow.cs:41:18:41:18 | 1 | cflow.cs:41:18:41:18 | After 1 [match] |
+| cflow.cs:41:18:41:18 | 1 | cflow.cs:41:18:41:18 | After 1 [no-match] |
+| cflow.cs:41:18:41:18 | After 1 [no-match] | cflow.cs:41:13:41:19 | After case ...: [no-match] |
 | cflow.cs:42:17:42:38 | After call to method WriteLine | cflow.cs:42:17:42:39 | After ...; |
 | cflow.cs:42:17:42:38 | Before call to method WriteLine | cflow.cs:42:35:42:37 | "1" |
 | cflow.cs:42:17:42:38 | call to method WriteLine | cflow.cs:42:17:42:38 | After call to method WriteLine |
@@ -6582,10 +6664,12 @@ dominance
 | cflow.cs:42:35:42:37 | "1" | cflow.cs:42:17:42:38 | call to method WriteLine |
 | cflow.cs:43:17:43:28 | Before goto case ...; | cflow.cs:43:27:43:27 | 2 |
 | cflow.cs:43:27:43:27 | 2 | cflow.cs:43:17:43:28 | goto case ...; |
-| cflow.cs:44:13:44:19 | After case ...: [match] | cflow.cs:44:18:44:18 | 2 |
+| cflow.cs:44:13:44:19 | After case ...: [match] | cflow.cs:45:17:45:39 | ...; |
 | cflow.cs:44:13:44:19 | After case ...: [no-match] | cflow.cs:47:13:47:19 | case ...: |
-| cflow.cs:44:13:44:19 | case ...: | cflow.cs:44:13:44:19 | After case ...: [no-match] |
-| cflow.cs:44:18:44:18 | 2 | cflow.cs:45:17:45:39 | ...; |
+| cflow.cs:44:13:44:19 | case ...: | cflow.cs:44:18:44:18 | 2 |
+| cflow.cs:44:18:44:18 | 2 | cflow.cs:44:18:44:18 | After 2 [match] |
+| cflow.cs:44:18:44:18 | 2 | cflow.cs:44:18:44:18 | After 2 [no-match] |
+| cflow.cs:44:18:44:18 | After 2 [no-match] | cflow.cs:44:13:44:19 | After case ...: [no-match] |
 | cflow.cs:45:17:45:38 | After call to method WriteLine | cflow.cs:45:17:45:39 | After ...; |
 | cflow.cs:45:17:45:38 | Before call to method WriteLine | cflow.cs:45:35:45:37 | "2" |
 | cflow.cs:45:17:45:38 | call to method WriteLine | cflow.cs:45:17:45:38 | After call to method WriteLine |
@@ -6594,10 +6678,12 @@ dominance
 | cflow.cs:45:35:45:37 | "2" | cflow.cs:45:17:45:38 | call to method WriteLine |
 | cflow.cs:46:17:46:28 | Before goto case ...; | cflow.cs:46:27:46:27 | 1 |
 | cflow.cs:46:27:46:27 | 1 | cflow.cs:46:17:46:28 | goto case ...; |
-| cflow.cs:47:13:47:19 | After case ...: [match] | cflow.cs:47:18:47:18 | 3 |
-| cflow.cs:47:13:47:19 | case ...: | cflow.cs:47:13:47:19 | After case ...: [match] |
-| cflow.cs:47:13:47:19 | case ...: | cflow.cs:47:13:47:19 | After case ...: [no-match] |
-| cflow.cs:47:18:47:18 | 3 | cflow.cs:48:17:48:39 | ...; |
+| cflow.cs:47:13:47:19 | After case ...: [match] | cflow.cs:48:17:48:39 | ...; |
+| cflow.cs:47:13:47:19 | case ...: | cflow.cs:47:18:47:18 | 3 |
+| cflow.cs:47:18:47:18 | 3 | cflow.cs:47:18:47:18 | After 3 [match] |
+| cflow.cs:47:18:47:18 | 3 | cflow.cs:47:18:47:18 | After 3 [no-match] |
+| cflow.cs:47:18:47:18 | After 3 [match] | cflow.cs:47:13:47:19 | After case ...: [match] |
+| cflow.cs:47:18:47:18 | After 3 [no-match] | cflow.cs:47:13:47:19 | After case ...: [no-match] |
 | cflow.cs:48:17:48:38 | After call to method WriteLine | cflow.cs:48:17:48:39 | After ...; |
 | cflow.cs:48:17:48:38 | Before call to method WriteLine | cflow.cs:48:35:48:37 | "3" |
 | cflow.cs:48:17:48:38 | call to method WriteLine | cflow.cs:48:17:48:38 | After call to method WriteLine |
@@ -6608,11 +6694,13 @@ dominance
 | cflow.cs:51:9:59:9 | After switch (...) {...} | cflow.cs:60:9:66:9 | switch (...) {...} |
 | cflow.cs:51:9:59:9 | switch (...) {...} | cflow.cs:51:17:51:17 | access to parameter a |
 | cflow.cs:51:17:51:17 | access to parameter a | cflow.cs:53:13:53:20 | case ...: |
-| cflow.cs:53:13:53:20 | After case ...: [match] | cflow.cs:53:18:53:19 | 42 |
+| cflow.cs:53:13:53:20 | After case ...: [match] | cflow.cs:54:17:54:48 | ...; |
 | cflow.cs:53:13:53:20 | After case ...: [no-match] | cflow.cs:56:13:56:20 | default: |
-| cflow.cs:53:13:53:20 | case ...: | cflow.cs:53:13:53:20 | After case ...: [match] |
-| cflow.cs:53:13:53:20 | case ...: | cflow.cs:53:13:53:20 | After case ...: [no-match] |
-| cflow.cs:53:18:53:19 | 42 | cflow.cs:54:17:54:48 | ...; |
+| cflow.cs:53:13:53:20 | case ...: | cflow.cs:53:18:53:19 | 42 |
+| cflow.cs:53:18:53:19 | 42 | cflow.cs:53:18:53:19 | After 42 [match] |
+| cflow.cs:53:18:53:19 | 42 | cflow.cs:53:18:53:19 | After 42 [no-match] |
+| cflow.cs:53:18:53:19 | After 42 [match] | cflow.cs:53:13:53:20 | After case ...: [match] |
+| cflow.cs:53:18:53:19 | After 42 [no-match] | cflow.cs:53:13:53:20 | After case ...: [no-match] |
 | cflow.cs:54:17:54:47 | After call to method WriteLine | cflow.cs:54:17:54:48 | After ...; |
 | cflow.cs:54:17:54:47 | Before call to method WriteLine | cflow.cs:54:35:54:46 | "The answer" |
 | cflow.cs:54:17:54:47 | call to method WriteLine | cflow.cs:54:17:54:47 | After call to method WriteLine |
@@ -6638,10 +6726,12 @@ dominance
 | cflow.cs:60:27:60:31 | Before access to field Field | cflow.cs:60:27:60:31 | this access |
 | cflow.cs:60:27:60:31 | access to field Field | cflow.cs:60:27:60:31 | After access to field Field |
 | cflow.cs:60:27:60:31 | this access | cflow.cs:60:27:60:31 | access to field Field |
-| cflow.cs:62:13:62:19 | After case ...: [match] | cflow.cs:62:18:62:18 | 0 |
-| cflow.cs:62:13:62:19 | case ...: | cflow.cs:62:13:62:19 | After case ...: [match] |
-| cflow.cs:62:13:62:19 | case ...: | cflow.cs:62:13:62:19 | After case ...: [no-match] |
-| cflow.cs:62:18:62:18 | 0 | cflow.cs:63:17:64:55 | if (...) ... |
+| cflow.cs:62:13:62:19 | After case ...: [match] | cflow.cs:63:17:64:55 | if (...) ... |
+| cflow.cs:62:13:62:19 | case ...: | cflow.cs:62:18:62:18 | 0 |
+| cflow.cs:62:18:62:18 | 0 | cflow.cs:62:18:62:18 | After 0 [match] |
+| cflow.cs:62:18:62:18 | 0 | cflow.cs:62:18:62:18 | After 0 [no-match] |
+| cflow.cs:62:18:62:18 | After 0 [match] | cflow.cs:62:13:62:19 | After case ...: [match] |
+| cflow.cs:62:18:62:18 | After 0 [no-match] | cflow.cs:62:13:62:19 | After case ...: [no-match] |
 | cflow.cs:63:17:64:55 | After if (...) ... | cflow.cs:65:17:65:22 | Before break; |
 | cflow.cs:63:17:64:55 | if (...) ... | cflow.cs:63:21:63:34 | !... |
 | cflow.cs:63:21:63:34 | !... | cflow.cs:63:23:63:33 | Before ... == ... |
@@ -7528,17 +7618,21 @@ dominance
 | cflow.cs:246:17:246:32 | After ... + ... | cflow.cs:248:13:248:19 | case ...: |
 | cflow.cs:246:17:246:32 | Before ... + ... | cflow.cs:246:17:246:28 | Before access to property Length |
 | cflow.cs:246:32:246:32 | 3 | cflow.cs:246:17:246:32 | ... + ... |
-| cflow.cs:248:13:248:19 | After case ...: [match] | cflow.cs:248:18:248:18 | 0 |
+| cflow.cs:248:13:248:19 | After case ...: [match] | cflow.cs:249:17:249:29 | Before goto default; |
 | cflow.cs:248:13:248:19 | After case ...: [no-match] | cflow.cs:250:13:250:19 | case ...: |
-| cflow.cs:248:13:248:19 | case ...: | cflow.cs:248:13:248:19 | After case ...: [match] |
-| cflow.cs:248:13:248:19 | case ...: | cflow.cs:248:13:248:19 | After case ...: [no-match] |
-| cflow.cs:248:18:248:18 | 0 | cflow.cs:249:17:249:29 | Before goto default; |
+| cflow.cs:248:13:248:19 | case ...: | cflow.cs:248:18:248:18 | 0 |
+| cflow.cs:248:18:248:18 | 0 | cflow.cs:248:18:248:18 | After 0 [match] |
+| cflow.cs:248:18:248:18 | 0 | cflow.cs:248:18:248:18 | After 0 [no-match] |
+| cflow.cs:248:18:248:18 | After 0 [match] | cflow.cs:248:13:248:19 | After case ...: [match] |
+| cflow.cs:248:18:248:18 | After 0 [no-match] | cflow.cs:248:13:248:19 | After case ...: [no-match] |
 | cflow.cs:249:17:249:29 | Before goto default; | cflow.cs:249:17:249:29 | goto default; |
-| cflow.cs:250:13:250:19 | After case ...: [match] | cflow.cs:250:18:250:18 | 1 |
+| cflow.cs:250:13:250:19 | After case ...: [match] | cflow.cs:251:17:251:37 | ...; |
 | cflow.cs:250:13:250:19 | After case ...: [no-match] | cflow.cs:253:13:253:19 | case ...: |
-| cflow.cs:250:13:250:19 | case ...: | cflow.cs:250:13:250:19 | After case ...: [match] |
-| cflow.cs:250:13:250:19 | case ...: | cflow.cs:250:13:250:19 | After case ...: [no-match] |
-| cflow.cs:250:18:250:18 | 1 | cflow.cs:251:17:251:37 | ...; |
+| cflow.cs:250:13:250:19 | case ...: | cflow.cs:250:18:250:18 | 1 |
+| cflow.cs:250:18:250:18 | 1 | cflow.cs:250:18:250:18 | After 1 [match] |
+| cflow.cs:250:18:250:18 | 1 | cflow.cs:250:18:250:18 | After 1 [no-match] |
+| cflow.cs:250:18:250:18 | After 1 [match] | cflow.cs:250:13:250:19 | After case ...: [match] |
+| cflow.cs:250:18:250:18 | After 1 [no-match] | cflow.cs:250:13:250:19 | After case ...: [no-match] |
 | cflow.cs:251:17:251:36 | After call to method WriteLine | cflow.cs:251:17:251:37 | After ...; |
 | cflow.cs:251:17:251:36 | Before call to method WriteLine | cflow.cs:251:35:251:35 | 1 |
 | cflow.cs:251:17:251:36 | call to method WriteLine | cflow.cs:251:17:251:36 | After call to method WriteLine |
@@ -7546,11 +7640,13 @@ dominance
 | cflow.cs:251:17:251:37 | After ...; | cflow.cs:252:17:252:22 | Before break; |
 | cflow.cs:251:35:251:35 | 1 | cflow.cs:251:17:251:36 | call to method WriteLine |
 | cflow.cs:252:17:252:22 | Before break; | cflow.cs:252:17:252:22 | break; |
-| cflow.cs:253:13:253:19 | After case ...: [match] | cflow.cs:253:18:253:18 | 2 |
+| cflow.cs:253:13:253:19 | After case ...: [match] | cflow.cs:254:17:254:27 | Before goto ...; |
 | cflow.cs:253:13:253:19 | After case ...: [no-match] | cflow.cs:255:13:255:20 | default: |
-| cflow.cs:253:13:253:19 | case ...: | cflow.cs:253:13:253:19 | After case ...: [match] |
-| cflow.cs:253:13:253:19 | case ...: | cflow.cs:253:13:253:19 | After case ...: [no-match] |
-| cflow.cs:253:18:253:18 | 2 | cflow.cs:254:17:254:27 | Before goto ...; |
+| cflow.cs:253:13:253:19 | case ...: | cflow.cs:253:18:253:18 | 2 |
+| cflow.cs:253:18:253:18 | 2 | cflow.cs:253:18:253:18 | After 2 [match] |
+| cflow.cs:253:18:253:18 | 2 | cflow.cs:253:18:253:18 | After 2 [no-match] |
+| cflow.cs:253:18:253:18 | After 2 [match] | cflow.cs:253:13:253:19 | After case ...: [match] |
+| cflow.cs:253:18:253:18 | After 2 [no-match] | cflow.cs:253:13:253:19 | After case ...: [no-match] |
 | cflow.cs:254:17:254:27 | Before goto ...; | cflow.cs:254:17:254:27 | goto ...; |
 | cflow.cs:255:13:255:20 | After default: [match] | cflow.cs:256:17:256:37 | ...; |
 | cflow.cs:256:17:256:36 | After call to method WriteLine | cflow.cs:256:17:256:37 | After ...; |
@@ -12871,15 +12967,19 @@ postDominance
 | Patterns.cs:20:9:38:9 | After switch (...) {...} | Patterns.cs:37:17:37:22 | break; |
 | Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:8:9:18:9 | After if (...) ... |
 | Patterns.cs:20:17:20:17 | access to local variable o | Patterns.cs:20:9:38:9 | switch (...) {...} |
+| Patterns.cs:22:13:22:23 | After case ...: [match] | Patterns.cs:22:18:22:22 | After "xyz" [match] |
+| Patterns.cs:22:13:22:23 | After case ...: [no-match] | Patterns.cs:22:18:22:22 | After "xyz" [no-match] |
 | Patterns.cs:22:13:22:23 | case ...: | Patterns.cs:20:17:20:17 | access to local variable o |
-| Patterns.cs:22:18:22:22 | "xyz" | Patterns.cs:22:13:22:23 | After case ...: [match] |
-| Patterns.cs:23:17:23:22 | Before break; | Patterns.cs:22:18:22:22 | "xyz" |
+| Patterns.cs:22:18:22:22 | "xyz" | Patterns.cs:22:13:22:23 | case ...: |
+| Patterns.cs:23:17:23:22 | Before break; | Patterns.cs:22:13:22:23 | After case ...: [match] |
 | Patterns.cs:23:17:23:22 | break; | Patterns.cs:23:17:23:22 | Before break; |
+| Patterns.cs:24:13:24:36 | After case ...: [match] | Patterns.cs:24:18:24:23 | After Int32 i2 [match] |
+| Patterns.cs:24:13:24:36 | After case ...: [no-match] | Patterns.cs:24:18:24:23 | After Int32 i2 [no-match] |
 | Patterns.cs:24:13:24:36 | case ...: | Patterns.cs:22:13:22:23 | After case ...: [no-match] |
-| Patterns.cs:24:18:24:23 | Int32 i2 | Patterns.cs:24:13:24:36 | After case ...: [match] |
+| Patterns.cs:24:18:24:23 | Int32 i2 | Patterns.cs:24:13:24:36 | case ...: |
 | Patterns.cs:24:30:24:31 | access to local variable i2 | Patterns.cs:24:30:24:35 | Before ... > ... |
 | Patterns.cs:24:30:24:35 | ... > ... | Patterns.cs:24:35:24:35 | 0 |
-| Patterns.cs:24:30:24:35 | Before ... > ... | Patterns.cs:24:18:24:23 | Int32 i2 |
+| Patterns.cs:24:30:24:35 | Before ... > ... | Patterns.cs:24:13:24:36 | After case ...: [match] |
 | Patterns.cs:24:35:24:35 | 0 | Patterns.cs:24:30:24:31 | access to local variable i2 |
 | Patterns.cs:25:17:25:51 | After call to method WriteLine | Patterns.cs:25:17:25:51 | call to method WriteLine |
 | Patterns.cs:25:17:25:51 | Before call to method WriteLine | Patterns.cs:25:17:25:52 | ...; |
@@ -12896,13 +12996,15 @@ postDominance
 | Patterns.cs:25:47:25:48 | access to local variable i2 | Patterns.cs:25:46:25:49 | Before {...} |
 | Patterns.cs:26:17:26:22 | Before break; | Patterns.cs:25:17:25:52 | After ...; |
 | Patterns.cs:26:17:26:22 | break; | Patterns.cs:26:17:26:22 | Before break; |
+| Patterns.cs:27:13:27:24 | After case ...: [match] | Patterns.cs:27:18:27:23 | After Int32 i3 [match] |
+| Patterns.cs:27:13:27:24 | After case ...: [no-match] | Patterns.cs:27:18:27:23 | After Int32 i3 [no-match] |
 | Patterns.cs:27:13:27:24 | case ...: | Patterns.cs:24:13:24:36 | After case ...: [no-match] |
 | Patterns.cs:27:13:27:24 | case ...: | Patterns.cs:24:30:24:35 | After ... > ... [false] |
-| Patterns.cs:27:18:27:23 | Int32 i3 | Patterns.cs:27:13:27:24 | After case ...: [match] |
+| Patterns.cs:27:18:27:23 | Int32 i3 | Patterns.cs:27:13:27:24 | case ...: |
 | Patterns.cs:28:17:28:46 | After call to method WriteLine | Patterns.cs:28:17:28:46 | call to method WriteLine |
 | Patterns.cs:28:17:28:46 | Before call to method WriteLine | Patterns.cs:28:17:28:47 | ...; |
 | Patterns.cs:28:17:28:46 | call to method WriteLine | Patterns.cs:28:35:28:45 | After $"..." |
-| Patterns.cs:28:17:28:47 | ...; | Patterns.cs:27:18:27:23 | Int32 i3 |
+| Patterns.cs:28:17:28:47 | ...; | Patterns.cs:27:13:27:24 | After case ...: [match] |
 | Patterns.cs:28:17:28:47 | After ...; | Patterns.cs:28:17:28:46 | After call to method WriteLine |
 | Patterns.cs:28:35:28:45 | $"..." | Patterns.cs:28:41:28:44 | After {...} |
 | Patterns.cs:28:35:28:45 | After $"..." | Patterns.cs:28:35:28:45 | $"..." |
@@ -12914,12 +13016,14 @@ postDominance
 | Patterns.cs:28:42:28:43 | access to local variable i3 | Patterns.cs:28:41:28:44 | Before {...} |
 | Patterns.cs:29:17:29:22 | Before break; | Patterns.cs:28:17:28:47 | After ...; |
 | Patterns.cs:29:17:29:22 | break; | Patterns.cs:29:17:29:22 | Before break; |
+| Patterns.cs:30:13:30:27 | After case ...: [match] | Patterns.cs:30:18:30:26 | After String s2 [match] |
+| Patterns.cs:30:13:30:27 | After case ...: [no-match] | Patterns.cs:30:18:30:26 | After String s2 [no-match] |
 | Patterns.cs:30:13:30:27 | case ...: | Patterns.cs:27:13:27:24 | After case ...: [no-match] |
-| Patterns.cs:30:18:30:26 | String s2 | Patterns.cs:30:13:30:27 | After case ...: [match] |
+| Patterns.cs:30:18:30:26 | String s2 | Patterns.cs:30:13:30:27 | case ...: |
 | Patterns.cs:31:17:31:49 | After call to method WriteLine | Patterns.cs:31:17:31:49 | call to method WriteLine |
 | Patterns.cs:31:17:31:49 | Before call to method WriteLine | Patterns.cs:31:17:31:50 | ...; |
 | Patterns.cs:31:17:31:49 | call to method WriteLine | Patterns.cs:31:35:31:48 | After $"..." |
-| Patterns.cs:31:17:31:50 | ...; | Patterns.cs:30:18:30:26 | String s2 |
+| Patterns.cs:31:17:31:50 | ...; | Patterns.cs:30:13:30:27 | After case ...: [match] |
 | Patterns.cs:31:17:31:50 | After ...; | Patterns.cs:31:17:31:49 | After call to method WriteLine |
 | Patterns.cs:31:35:31:48 | $"..." | Patterns.cs:31:44:31:47 | After {...} |
 | Patterns.cs:31:35:31:48 | After $"..." | Patterns.cs:31:35:31:48 | $"..." |
@@ -12931,9 +13035,11 @@ postDominance
 | Patterns.cs:31:45:31:46 | access to local variable s2 | Patterns.cs:31:44:31:47 | Before {...} |
 | Patterns.cs:32:17:32:22 | Before break; | Patterns.cs:31:17:31:50 | After ...; |
 | Patterns.cs:32:17:32:22 | break; | Patterns.cs:32:17:32:22 | Before break; |
+| Patterns.cs:33:13:33:24 | After case ...: [match] | Patterns.cs:33:18:33:23 | After Object v2 [match] |
+| Patterns.cs:33:13:33:24 | After case ...: [no-match] | Patterns.cs:33:18:33:23 | After Object v2 [no-match] |
 | Patterns.cs:33:13:33:24 | case ...: | Patterns.cs:30:13:30:27 | After case ...: [no-match] |
-| Patterns.cs:33:18:33:23 | Object v2 | Patterns.cs:33:13:33:24 | After case ...: [match] |
-| Patterns.cs:34:17:34:22 | Before break; | Patterns.cs:33:18:33:23 | Object v2 |
+| Patterns.cs:33:18:33:23 | Object v2 | Patterns.cs:33:13:33:24 | case ...: |
+| Patterns.cs:34:17:34:22 | Before break; | Patterns.cs:33:13:33:24 | After case ...: [match] |
 | Patterns.cs:34:17:34:22 | break; | Patterns.cs:34:17:34:22 | Before break; |
 | Patterns.cs:35:13:35:20 | After default: [match] | Patterns.cs:35:13:35:20 | default: |
 | Patterns.cs:35:13:35:20 | default: | Patterns.cs:33:13:33:24 | After case ...: [no-match] |
@@ -13016,16 +13122,18 @@ postDominance
 | Patterns.cs:58:16:62:9 | ... switch { ... } | Patterns.cs:58:9:62:10 | Before return ...; |
 | Patterns.cs:58:16:62:9 | After ... switch { ... } | Patterns.cs:60:22:60:28 | "not 1" |
 | Patterns.cs:58:16:62:9 | After ... switch { ... } | Patterns.cs:61:18:61:24 | "other" |
-| Patterns.cs:60:13:60:17 | After not ... | Patterns.cs:60:13:60:17 | not ... |
-| Patterns.cs:60:13:60:17 | Before not ... | Patterns.cs:60:13:60:28 | After ... => ... [match] |
+| Patterns.cs:60:13:60:17 | Before not ... | Patterns.cs:60:13:60:28 | ... => ... |
 | Patterns.cs:60:13:60:17 | not ... | Patterns.cs:60:17:60:17 | 1 |
 | Patterns.cs:60:13:60:28 | ... => ... | Patterns.cs:58:16:58:16 | access to parameter i |
+| Patterns.cs:60:13:60:28 | After ... => ... [match] | Patterns.cs:60:13:60:17 | After not ... [match] |
+| Patterns.cs:60:13:60:28 | After ... => ... [no-match] | Patterns.cs:60:13:60:17 | After not ... [no-match] |
 | Patterns.cs:60:17:60:17 | 1 | Patterns.cs:60:13:60:17 | Before not ... |
-| Patterns.cs:60:22:60:28 | "not 1" | Patterns.cs:60:13:60:17 | After not ... |
-| Patterns.cs:61:13:61:13 | _ | Patterns.cs:61:13:61:24 | After ... => ... [match] |
+| Patterns.cs:60:22:60:28 | "not 1" | Patterns.cs:60:13:60:28 | After ... => ... [match] |
+| Patterns.cs:61:13:61:13 | After _ [match] | Patterns.cs:61:13:61:13 | _ |
+| Patterns.cs:61:13:61:13 | _ | Patterns.cs:61:13:61:24 | ... => ... |
 | Patterns.cs:61:13:61:24 | ... => ... | Patterns.cs:60:13:60:28 | After ... => ... [no-match] |
-| Patterns.cs:61:13:61:24 | After ... => ... [match] | Patterns.cs:61:13:61:24 | ... => ... |
-| Patterns.cs:61:18:61:24 | "other" | Patterns.cs:61:13:61:13 | _ |
+| Patterns.cs:61:13:61:24 | After ... => ... [match] | Patterns.cs:61:13:61:13 | After _ [match] |
+| Patterns.cs:61:18:61:24 | "other" | Patterns.cs:61:13:61:24 | After ... => ... [match] |
 | Patterns.cs:65:26:65:27 | Exit | Patterns.cs:65:26:65:27 | Normal Exit |
 | Patterns.cs:65:26:65:27 | Normal Exit | Patterns.cs:67:9:71:10 | return ...; |
 | Patterns.cs:66:5:72:5 | {...} | Patterns.cs:65:26:65:27 | Entry |
@@ -13036,15 +13144,18 @@ postDominance
 | Patterns.cs:67:16:71:9 | After ... switch { ... } | Patterns.cs:69:22:69:33 | "impossible" |
 | Patterns.cs:67:16:71:9 | After ... switch { ... } | Patterns.cs:70:13:70:27 | After ... => ... [no-match] |
 | Patterns.cs:67:16:71:9 | After ... switch { ... } | Patterns.cs:70:18:70:27 | "possible" |
-| Patterns.cs:69:13:69:17 | After not ... | Patterns.cs:69:13:69:17 | not ... |
-| Patterns.cs:69:13:69:17 | Before not ... | Patterns.cs:69:13:69:33 | After ... => ... [match] |
+| Patterns.cs:69:13:69:17 | Before not ... | Patterns.cs:69:13:69:33 | ... => ... |
 | Patterns.cs:69:13:69:17 | not ... | Patterns.cs:69:17:69:17 | 2 |
 | Patterns.cs:69:13:69:33 | ... => ... | Patterns.cs:67:16:67:16 | 2 |
+| Patterns.cs:69:13:69:33 | After ... => ... [match] | Patterns.cs:69:13:69:17 | After not ... [match] |
+| Patterns.cs:69:13:69:33 | After ... => ... [no-match] | Patterns.cs:69:13:69:17 | After not ... [no-match] |
 | Patterns.cs:69:17:69:17 | 2 | Patterns.cs:69:13:69:17 | Before not ... |
-| Patterns.cs:69:22:69:33 | "impossible" | Patterns.cs:69:13:69:17 | After not ... |
-| Patterns.cs:70:13:70:13 | 2 | Patterns.cs:70:13:70:27 | After ... => ... [match] |
+| Patterns.cs:69:22:69:33 | "impossible" | Patterns.cs:69:13:69:33 | After ... => ... [match] |
+| Patterns.cs:70:13:70:13 | 2 | Patterns.cs:70:13:70:27 | ... => ... |
 | Patterns.cs:70:13:70:27 | ... => ... | Patterns.cs:69:13:69:33 | After ... => ... [no-match] |
-| Patterns.cs:70:18:70:27 | "possible" | Patterns.cs:70:13:70:13 | 2 |
+| Patterns.cs:70:13:70:27 | After ... => ... [match] | Patterns.cs:70:13:70:13 | After 2 [match] |
+| Patterns.cs:70:13:70:27 | After ... => ... [no-match] | Patterns.cs:70:13:70:13 | After 2 [no-match] |
+| Patterns.cs:70:18:70:27 | "possible" | Patterns.cs:70:13:70:27 | After ... => ... [match] |
 | Patterns.cs:74:26:74:27 | Exit | Patterns.cs:74:26:74:27 | Normal Exit |
 | Patterns.cs:74:26:74:27 | Normal Exit | Patterns.cs:76:9:82:10 | return ...; |
 | Patterns.cs:74:33:74:33 | i | Patterns.cs:74:26:74:27 | Entry |
@@ -13058,24 +13169,29 @@ postDominance
 | Patterns.cs:76:16:82:9 | After ... switch { ... } | Patterns.cs:80:18:80:20 | "1" |
 | Patterns.cs:76:16:82:9 | After ... switch { ... } | Patterns.cs:81:18:81:20 | "0" |
 | Patterns.cs:78:13:78:15 | > ... | Patterns.cs:78:15:78:15 | 1 |
-| Patterns.cs:78:13:78:15 | After > ... | Patterns.cs:78:13:78:15 | > ... |
-| Patterns.cs:78:13:78:15 | Before > ... | Patterns.cs:78:13:78:24 | After ... => ... [match] |
+| Patterns.cs:78:13:78:15 | Before > ... | Patterns.cs:78:13:78:24 | ... => ... |
 | Patterns.cs:78:13:78:24 | ... => ... | Patterns.cs:76:16:76:16 | access to parameter i |
+| Patterns.cs:78:13:78:24 | After ... => ... [match] | Patterns.cs:78:13:78:15 | After > ... [match] |
+| Patterns.cs:78:13:78:24 | After ... => ... [no-match] | Patterns.cs:78:13:78:15 | After > ... [no-match] |
 | Patterns.cs:78:15:78:15 | 1 | Patterns.cs:78:13:78:15 | Before > ... |
-| Patterns.cs:78:20:78:24 | "> 1" | Patterns.cs:78:13:78:15 | After > ... |
+| Patterns.cs:78:20:78:24 | "> 1" | Patterns.cs:78:13:78:24 | After ... => ... [match] |
 | Patterns.cs:79:13:79:15 | < ... | Patterns.cs:79:15:79:15 | 0 |
-| Patterns.cs:79:13:79:15 | After < ... | Patterns.cs:79:13:79:15 | < ... |
-| Patterns.cs:79:13:79:15 | Before < ... | Patterns.cs:79:13:79:24 | After ... => ... [match] |
+| Patterns.cs:79:13:79:15 | Before < ... | Patterns.cs:79:13:79:24 | ... => ... |
 | Patterns.cs:79:13:79:24 | ... => ... | Patterns.cs:78:13:78:24 | After ... => ... [no-match] |
+| Patterns.cs:79:13:79:24 | After ... => ... [match] | Patterns.cs:79:13:79:15 | After < ... [match] |
+| Patterns.cs:79:13:79:24 | After ... => ... [no-match] | Patterns.cs:79:13:79:15 | After < ... [no-match] |
 | Patterns.cs:79:15:79:15 | 0 | Patterns.cs:79:13:79:15 | Before < ... |
-| Patterns.cs:79:20:79:24 | "< 0" | Patterns.cs:79:13:79:15 | After < ... |
-| Patterns.cs:80:13:80:13 | 1 | Patterns.cs:80:13:80:20 | After ... => ... [match] |
+| Patterns.cs:79:20:79:24 | "< 0" | Patterns.cs:79:13:79:24 | After ... => ... [match] |
+| Patterns.cs:80:13:80:13 | 1 | Patterns.cs:80:13:80:20 | ... => ... |
 | Patterns.cs:80:13:80:20 | ... => ... | Patterns.cs:79:13:79:24 | After ... => ... [no-match] |
-| Patterns.cs:80:18:80:20 | "1" | Patterns.cs:80:13:80:13 | 1 |
-| Patterns.cs:81:13:81:13 | _ | Patterns.cs:81:13:81:20 | After ... => ... [match] |
+| Patterns.cs:80:13:80:20 | After ... => ... [match] | Patterns.cs:80:13:80:13 | After 1 [match] |
+| Patterns.cs:80:13:80:20 | After ... => ... [no-match] | Patterns.cs:80:13:80:13 | After 1 [no-match] |
+| Patterns.cs:80:18:80:20 | "1" | Patterns.cs:80:13:80:20 | After ... => ... [match] |
+| Patterns.cs:81:13:81:13 | After _ [match] | Patterns.cs:81:13:81:13 | _ |
+| Patterns.cs:81:13:81:13 | _ | Patterns.cs:81:13:81:20 | ... => ... |
 | Patterns.cs:81:13:81:20 | ... => ... | Patterns.cs:80:13:80:20 | After ... => ... [no-match] |
-| Patterns.cs:81:13:81:20 | After ... => ... [match] | Patterns.cs:81:13:81:20 | ... => ... |
-| Patterns.cs:81:18:81:20 | "0" | Patterns.cs:81:13:81:13 | _ |
+| Patterns.cs:81:13:81:20 | After ... => ... [match] | Patterns.cs:81:13:81:13 | After _ [match] |
+| Patterns.cs:81:18:81:20 | "0" | Patterns.cs:81:13:81:20 | After ... => ... [match] |
 | Patterns.cs:85:26:85:27 | Exit | Patterns.cs:85:26:85:27 | Normal Exit |
 | Patterns.cs:85:26:85:27 | Normal Exit | Patterns.cs:85:39:85:69 | After ... ? ... : ... |
 | Patterns.cs:85:33:85:33 | i | Patterns.cs:85:26:85:27 | Entry |
@@ -13403,26 +13519,33 @@ postDominance
 | Switch.cs:11:5:33:5 | {...} | Switch.cs:10:20:10:20 | o |
 | Switch.cs:12:9:32:9 | switch (...) {...} | Switch.cs:11:5:33:5 | {...} |
 | Switch.cs:12:17:12:17 | access to parameter o | Switch.cs:12:9:32:9 | switch (...) {...} |
+| Switch.cs:14:13:14:21 | After case ...: [match] | Switch.cs:14:18:14:20 | After "a" [match] |
+| Switch.cs:14:13:14:21 | After case ...: [no-match] | Switch.cs:14:18:14:20 | After "a" [no-match] |
 | Switch.cs:14:13:14:21 | case ...: | Switch.cs:12:17:12:17 | access to parameter o |
-| Switch.cs:14:18:14:20 | "a" | Switch.cs:14:13:14:21 | After case ...: [match] |
-| Switch.cs:15:17:15:23 | Before return ...; | Switch.cs:14:18:14:20 | "a" |
+| Switch.cs:14:18:14:20 | "a" | Switch.cs:14:13:14:21 | case ...: |
+| Switch.cs:15:17:15:23 | Before return ...; | Switch.cs:14:13:14:21 | After case ...: [match] |
 | Switch.cs:15:17:15:23 | return ...; | Switch.cs:15:17:15:23 | Before return ...; |
-| Switch.cs:16:13:16:19 | After case ...: [no-match] | Switch.cs:16:13:16:19 | case ...: |
+| Switch.cs:16:13:16:19 | After case ...: [no-match] | Switch.cs:16:18:16:18 | After 0 [no-match] |
 | Switch.cs:16:13:16:19 | case ...: | Switch.cs:14:13:14:21 | After case ...: [no-match] |
-| Switch.cs:16:18:16:18 | 0 | Switch.cs:16:13:16:19 | After case ...: [match] |
-| Switch.cs:17:17:17:38 | Before throw ...; | Switch.cs:16:18:16:18 | 0 |
+| Switch.cs:16:18:16:18 | 0 | Switch.cs:16:13:16:19 | case ...: |
+| Switch.cs:16:18:16:18 | After 0 [no-match] | Switch.cs:16:18:16:18 | 0 |
+| Switch.cs:17:17:17:38 | Before throw ...; | Switch.cs:16:13:16:19 | After case ...: [match] |
 | Switch.cs:17:17:17:38 | throw ...; | Switch.cs:17:23:17:37 | After object creation of type Exception |
 | Switch.cs:17:23:17:37 | After object creation of type Exception | Switch.cs:17:23:17:37 | object creation of type Exception |
 | Switch.cs:17:23:17:37 | Before object creation of type Exception | Switch.cs:17:17:17:38 | Before throw ...; |
 | Switch.cs:17:23:17:37 | object creation of type Exception | Switch.cs:17:23:17:37 | Before object creation of type Exception |
+| Switch.cs:18:13:18:22 | After case ...: [match] | Switch.cs:18:18:18:21 | After null [match] |
+| Switch.cs:18:13:18:22 | After case ...: [no-match] | Switch.cs:18:18:18:21 | After null [no-match] |
 | Switch.cs:18:13:18:22 | case ...: | Switch.cs:16:13:16:19 | After case ...: [no-match] |
-| Switch.cs:18:18:18:21 | null | Switch.cs:18:13:18:22 | After case ...: [match] |
-| Switch.cs:19:17:19:29 | Before goto default; | Switch.cs:18:18:18:21 | null |
+| Switch.cs:18:18:18:21 | null | Switch.cs:18:13:18:22 | case ...: |
+| Switch.cs:19:17:19:29 | Before goto default; | Switch.cs:18:13:18:22 | After case ...: [match] |
 | Switch.cs:19:17:19:29 | goto default; | Switch.cs:19:17:19:29 | Before goto default; |
+| Switch.cs:20:13:20:23 | After case ...: [match] | Switch.cs:20:18:20:22 | After Int32 i [match] |
+| Switch.cs:20:13:20:23 | After case ...: [no-match] | Switch.cs:20:18:20:22 | After Int32 i [no-match] |
 | Switch.cs:20:13:20:23 | case ...: | Switch.cs:18:13:18:22 | After case ...: [no-match] |
-| Switch.cs:20:18:20:22 | Int32 i | Switch.cs:20:13:20:23 | After case ...: [match] |
+| Switch.cs:20:18:20:22 | Int32 i | Switch.cs:20:13:20:23 | case ...: |
 | Switch.cs:21:17:22:27 | After if (...) ... | Switch.cs:21:21:21:29 | After ... == ... [false] |
-| Switch.cs:21:17:22:27 | if (...) ... | Switch.cs:20:18:20:22 | Int32 i |
+| Switch.cs:21:17:22:27 | if (...) ... | Switch.cs:20:13:20:23 | After case ...: [match] |
 | Switch.cs:21:21:21:21 | access to parameter o | Switch.cs:21:21:21:29 | Before ... == ... |
 | Switch.cs:21:21:21:29 | ... == ... | Switch.cs:21:26:21:29 | null |
 | Switch.cs:21:21:21:29 | After ... == ... [true] | Switch.cs:21:21:21:29 | ... == ... |
@@ -13433,15 +13556,17 @@ postDominance
 | Switch.cs:23:17:23:28 | Before goto case ...; | Switch.cs:21:17:22:27 | After if (...) ... |
 | Switch.cs:23:17:23:28 | goto case ...; | Switch.cs:23:27:23:27 | 0 |
 | Switch.cs:23:27:23:27 | 0 | Switch.cs:23:17:23:28 | Before goto case ...; |
+| Switch.cs:24:13:24:56 | After case ...: [match] | Switch.cs:24:18:24:25 | After String s [match] |
+| Switch.cs:24:13:24:56 | After case ...: [no-match] | Switch.cs:24:18:24:25 | After String s [no-match] |
 | Switch.cs:24:13:24:56 | case ...: | Switch.cs:20:13:20:23 | After case ...: [no-match] |
-| Switch.cs:24:18:24:25 | String s | Switch.cs:24:13:24:56 | After case ...: [match] |
+| Switch.cs:24:18:24:25 | String s | Switch.cs:24:13:24:56 | case ...: |
 | Switch.cs:24:32:24:32 | access to local variable s | Switch.cs:24:32:24:39 | Before access to property Length |
 | Switch.cs:24:32:24:39 | After access to property Length | Switch.cs:24:32:24:39 | access to property Length |
 | Switch.cs:24:32:24:39 | Before access to property Length | Switch.cs:24:32:24:43 | Before ... > ... |
 | Switch.cs:24:32:24:39 | access to property Length | Switch.cs:24:32:24:32 | access to local variable s |
 | Switch.cs:24:32:24:43 | ... > ... | Switch.cs:24:43:24:43 | 0 |
 | Switch.cs:24:32:24:43 | Before ... > ... | Switch.cs:24:32:24:55 | ... && ... |
-| Switch.cs:24:32:24:55 | ... && ... | Switch.cs:24:18:24:25 | String s |
+| Switch.cs:24:32:24:55 | ... && ... | Switch.cs:24:13:24:56 | After case ...: [match] |
 | Switch.cs:24:32:24:55 | After ... && ... [false] | Switch.cs:24:32:24:43 | After ... > ... [false] |
 | Switch.cs:24:32:24:55 | After ... && ... [false] | Switch.cs:24:48:24:55 | After ... != ... [false] |
 | Switch.cs:24:32:24:55 | After ... && ... [true] | Switch.cs:24:48:24:55 | After ... != ... [true] |
@@ -13458,11 +13583,13 @@ postDominance
 | Switch.cs:25:35:25:35 | access to local variable s | Switch.cs:25:17:25:36 | Before call to method WriteLine |
 | Switch.cs:26:17:26:23 | Before return ...; | Switch.cs:25:17:25:37 | After ...; |
 | Switch.cs:26:17:26:23 | return ...; | Switch.cs:26:17:26:23 | Before return ...; |
-| Switch.cs:27:13:27:39 | After case ...: [no-match] | Switch.cs:27:13:27:39 | case ...: |
+| Switch.cs:27:13:27:39 | After case ...: [match] | Switch.cs:27:18:27:25 | After Double d [match] |
+| Switch.cs:27:13:27:39 | After case ...: [no-match] | Switch.cs:27:18:27:25 | After Double d [no-match] |
 | Switch.cs:27:13:27:39 | case ...: | Switch.cs:24:13:24:56 | After case ...: [no-match] |
 | Switch.cs:27:13:27:39 | case ...: | Switch.cs:24:32:24:55 | After ... && ... [false] |
-| Switch.cs:27:18:27:25 | Double d | Switch.cs:27:13:27:39 | After case ...: [match] |
-| Switch.cs:27:32:27:38 | Before call to method Throw | Switch.cs:27:18:27:25 | Double d |
+| Switch.cs:27:18:27:25 | After Double d [no-match] | Switch.cs:27:18:27:25 | Double d |
+| Switch.cs:27:18:27:25 | Double d | Switch.cs:27:13:27:39 | case ...: |
+| Switch.cs:27:32:27:38 | Before call to method Throw | Switch.cs:27:13:27:39 | After case ...: [match] |
 | Switch.cs:27:32:27:38 | call to method Throw | Switch.cs:27:32:27:38 | Before call to method Throw |
 | Switch.cs:28:13:28:17 | Label: | Switch.cs:31:17:31:27 | goto ...; |
 | Switch.cs:29:17:29:23 | Before return ...; | Switch.cs:28:13:28:17 | Label: |
@@ -13489,15 +13616,19 @@ postDominance
 | Switch.cs:46:9:52:9 | After switch (...) {...} | Switch.cs:51:17:51:22 | break; |
 | Switch.cs:46:9:52:9 | switch (...) {...} | Switch.cs:45:5:53:5 | {...} |
 | Switch.cs:46:17:46:17 | access to parameter o | Switch.cs:46:9:52:9 | switch (...) {...} |
+| Switch.cs:48:13:48:23 | After case ...: [match] | Switch.cs:48:18:48:20 | After access to type Int32 [match] |
+| Switch.cs:48:13:48:23 | After case ...: [no-match] | Switch.cs:48:18:48:20 | After access to type Int32 [no-match] |
 | Switch.cs:48:13:48:23 | case ...: | Switch.cs:46:17:46:17 | access to parameter o |
-| Switch.cs:48:18:48:20 | access to type Int32 | Switch.cs:48:13:48:23 | After case ...: [match] |
-| Switch.cs:49:17:49:22 | Before break; | Switch.cs:48:18:48:20 | access to type Int32 |
+| Switch.cs:48:18:48:20 | access to type Int32 | Switch.cs:48:13:48:23 | case ...: |
+| Switch.cs:49:17:49:22 | Before break; | Switch.cs:48:13:48:23 | After case ...: [match] |
 | Switch.cs:49:17:49:22 | break; | Switch.cs:49:17:49:22 | Before break; |
+| Switch.cs:50:13:50:39 | After case ...: [match] | Switch.cs:50:18:50:21 | After access to type Boolean [match] |
+| Switch.cs:50:13:50:39 | After case ...: [no-match] | Switch.cs:50:18:50:21 | After access to type Boolean [no-match] |
 | Switch.cs:50:13:50:39 | case ...: | Switch.cs:48:13:48:23 | After case ...: [no-match] |
-| Switch.cs:50:18:50:21 | access to type Boolean | Switch.cs:50:13:50:39 | After case ...: [match] |
+| Switch.cs:50:18:50:21 | access to type Boolean | Switch.cs:50:13:50:39 | case ...: |
 | Switch.cs:50:30:50:30 | access to parameter o | Switch.cs:50:30:50:38 | Before ... != ... |
 | Switch.cs:50:30:50:38 | ... != ... | Switch.cs:50:35:50:38 | null |
-| Switch.cs:50:30:50:38 | Before ... != ... | Switch.cs:50:18:50:21 | access to type Boolean |
+| Switch.cs:50:30:50:38 | Before ... != ... | Switch.cs:50:13:50:39 | After case ...: [match] |
 | Switch.cs:50:35:50:38 | null | Switch.cs:50:30:50:30 | access to parameter o |
 | Switch.cs:51:17:51:22 | Before break; | Switch.cs:50:30:50:38 | After ... != ... [true] |
 | Switch.cs:51:17:51:22 | break; | Switch.cs:51:17:51:22 | Before break; |
@@ -13514,13 +13645,17 @@ postDominance
 | Switch.cs:57:17:57:21 | After ... + ... | Switch.cs:57:17:57:21 | ... + ... |
 | Switch.cs:57:17:57:21 | Before ... + ... | Switch.cs:57:9:63:9 | switch (...) {...} |
 | Switch.cs:57:21:57:21 | 2 | Switch.cs:57:17:57:17 | 1 |
+| Switch.cs:59:13:59:19 | After case ...: [match] | Switch.cs:59:18:59:18 | After 2 [match] |
+| Switch.cs:59:13:59:19 | After case ...: [no-match] | Switch.cs:59:18:59:18 | After 2 [no-match] |
 | Switch.cs:59:13:59:19 | case ...: | Switch.cs:57:17:57:21 | After ... + ... |
-| Switch.cs:59:18:59:18 | 2 | Switch.cs:59:13:59:19 | After case ...: [match] |
-| Switch.cs:60:17:60:22 | Before break; | Switch.cs:59:18:59:18 | 2 |
+| Switch.cs:59:18:59:18 | 2 | Switch.cs:59:13:59:19 | case ...: |
+| Switch.cs:60:17:60:22 | Before break; | Switch.cs:59:13:59:19 | After case ...: [match] |
 | Switch.cs:60:17:60:22 | break; | Switch.cs:60:17:60:22 | Before break; |
+| Switch.cs:61:13:61:19 | After case ...: [match] | Switch.cs:61:18:61:18 | After 3 [match] |
+| Switch.cs:61:13:61:19 | After case ...: [no-match] | Switch.cs:61:18:61:18 | After 3 [no-match] |
 | Switch.cs:61:13:61:19 | case ...: | Switch.cs:59:13:59:19 | After case ...: [no-match] |
-| Switch.cs:61:18:61:18 | 3 | Switch.cs:61:13:61:19 | After case ...: [match] |
-| Switch.cs:62:17:62:22 | Before break; | Switch.cs:61:18:61:18 | 3 |
+| Switch.cs:61:18:61:18 | 3 | Switch.cs:61:13:61:19 | case ...: |
+| Switch.cs:62:17:62:22 | Before break; | Switch.cs:61:13:61:19 | After case ...: [match] |
 | Switch.cs:62:17:62:22 | break; | Switch.cs:62:17:62:22 | Before break; |
 | Switch.cs:66:10:66:11 | Exit | Switch.cs:66:10:66:11 | Normal Exit |
 | Switch.cs:66:10:66:11 | Normal Exit | Switch.cs:67:5:75:5 | After {...} |
@@ -13535,13 +13670,17 @@ postDominance
 | Switch.cs:68:17:68:25 | After (...) ... | Switch.cs:68:17:68:25 | (...) ... |
 | Switch.cs:68:17:68:25 | Before (...) ... | Switch.cs:68:9:74:9 | switch (...) {...} |
 | Switch.cs:68:25:68:25 | access to parameter s | Switch.cs:68:17:68:25 | Before (...) ... |
+| Switch.cs:70:13:70:23 | After case ...: [match] | Switch.cs:70:18:70:20 | After access to type Int32 [match] |
+| Switch.cs:70:13:70:23 | After case ...: [no-match] | Switch.cs:70:18:70:20 | After access to type Int32 [no-match] |
 | Switch.cs:70:13:70:23 | case ...: | Switch.cs:68:17:68:25 | After (...) ... |
-| Switch.cs:70:18:70:20 | access to type Int32 | Switch.cs:70:13:70:23 | After case ...: [match] |
-| Switch.cs:71:17:71:22 | Before break; | Switch.cs:70:18:70:20 | access to type Int32 |
+| Switch.cs:70:18:70:20 | access to type Int32 | Switch.cs:70:13:70:23 | case ...: |
+| Switch.cs:71:17:71:22 | Before break; | Switch.cs:70:13:70:23 | After case ...: [match] |
 | Switch.cs:71:17:71:22 | break; | Switch.cs:71:17:71:22 | Before break; |
+| Switch.cs:72:13:72:20 | After case ...: [match] | Switch.cs:72:18:72:19 | After "" [match] |
+| Switch.cs:72:13:72:20 | After case ...: [no-match] | Switch.cs:72:18:72:19 | After "" [no-match] |
 | Switch.cs:72:13:72:20 | case ...: | Switch.cs:70:13:70:23 | After case ...: [no-match] |
-| Switch.cs:72:18:72:19 | "" | Switch.cs:72:13:72:20 | After case ...: [match] |
-| Switch.cs:73:17:73:22 | Before break; | Switch.cs:72:18:72:19 | "" |
+| Switch.cs:72:18:72:19 | "" | Switch.cs:72:13:72:20 | case ...: |
+| Switch.cs:73:17:73:22 | Before break; | Switch.cs:72:13:72:20 | After case ...: [match] |
 | Switch.cs:73:17:73:22 | break; | Switch.cs:73:17:73:22 | Before break; |
 | Switch.cs:77:10:77:11 | Exit | Switch.cs:77:10:77:11 | Normal Exit |
 | Switch.cs:77:10:77:11 | Normal Exit | Switch.cs:82:17:82:28 | return ...; |
@@ -13554,15 +13693,19 @@ postDominance
 | Switch.cs:79:9:87:9 | After switch (...) {...} | Switch.cs:85:21:85:26 | break; |
 | Switch.cs:79:9:87:9 | switch (...) {...} | Switch.cs:78:5:89:5 | {...} |
 | Switch.cs:79:17:79:17 | access to parameter i | Switch.cs:79:9:87:9 | switch (...) {...} |
+| Switch.cs:81:13:81:19 | After case ...: [match] | Switch.cs:81:18:81:18 | After 1 [match] |
+| Switch.cs:81:13:81:19 | After case ...: [no-match] | Switch.cs:81:18:81:18 | After 1 [no-match] |
 | Switch.cs:81:13:81:19 | case ...: | Switch.cs:79:17:79:17 | access to parameter i |
-| Switch.cs:81:18:81:18 | 1 | Switch.cs:81:13:81:19 | After case ...: [match] |
-| Switch.cs:82:17:82:28 | Before return ...; | Switch.cs:81:18:81:18 | 1 |
+| Switch.cs:81:18:81:18 | 1 | Switch.cs:81:13:81:19 | case ...: |
+| Switch.cs:82:17:82:28 | Before return ...; | Switch.cs:81:13:81:19 | After case ...: [match] |
 | Switch.cs:82:17:82:28 | return ...; | Switch.cs:82:24:82:27 | true |
 | Switch.cs:82:24:82:27 | true | Switch.cs:82:17:82:28 | Before return ...; |
+| Switch.cs:83:13:83:19 | After case ...: [match] | Switch.cs:83:18:83:18 | After 2 [match] |
+| Switch.cs:83:13:83:19 | After case ...: [no-match] | Switch.cs:83:18:83:18 | After 2 [no-match] |
 | Switch.cs:83:13:83:19 | case ...: | Switch.cs:81:13:81:19 | After case ...: [no-match] |
-| Switch.cs:83:18:83:18 | 2 | Switch.cs:83:13:83:19 | After case ...: [match] |
+| Switch.cs:83:18:83:18 | 2 | Switch.cs:83:13:83:19 | case ...: |
 | Switch.cs:84:17:85:26 | After if (...) ... | Switch.cs:84:21:84:25 | After ... > ... [false] |
-| Switch.cs:84:17:85:26 | if (...) ... | Switch.cs:83:18:83:18 | 2 |
+| Switch.cs:84:17:85:26 | if (...) ... | Switch.cs:83:13:83:19 | After case ...: [match] |
 | Switch.cs:84:21:84:21 | access to parameter j | Switch.cs:84:21:84:25 | Before ... > ... |
 | Switch.cs:84:21:84:25 | ... > ... | Switch.cs:84:25:84:25 | 2 |
 | Switch.cs:84:21:84:25 | Before ... > ... | Switch.cs:84:17:85:26 | if (...) ... |
@@ -13583,9 +13726,11 @@ postDominance
 | Switch.cs:93:9:97:9 | After switch (...) {...} | Switch.cs:95:13:95:23 | After case ...: [no-match] |
 | Switch.cs:93:9:97:9 | switch (...) {...} | Switch.cs:92:5:99:5 | {...} |
 | Switch.cs:93:17:93:17 | access to parameter o | Switch.cs:93:9:97:9 | switch (...) {...} |
+| Switch.cs:95:13:95:23 | After case ...: [match] | Switch.cs:95:18:95:20 | After access to type Int32 [match] |
+| Switch.cs:95:13:95:23 | After case ...: [no-match] | Switch.cs:95:18:95:20 | After access to type Int32 [no-match] |
 | Switch.cs:95:13:95:23 | case ...: | Switch.cs:93:17:93:17 | access to parameter o |
-| Switch.cs:95:18:95:20 | access to type Int32 | Switch.cs:95:13:95:23 | After case ...: [match] |
-| Switch.cs:96:17:96:28 | Before return ...; | Switch.cs:95:18:95:20 | access to type Int32 |
+| Switch.cs:95:18:95:20 | access to type Int32 | Switch.cs:95:13:95:23 | case ...: |
+| Switch.cs:96:17:96:28 | Before return ...; | Switch.cs:95:13:95:23 | After case ...: [match] |
 | Switch.cs:96:17:96:28 | return ...; | Switch.cs:96:24:96:27 | true |
 | Switch.cs:96:24:96:27 | true | Switch.cs:96:17:96:28 | Before return ...; |
 | Switch.cs:98:9:98:21 | Before return ...; | Switch.cs:93:9:97:9 | After switch (...) {...} |
@@ -13604,14 +13749,18 @@ postDominance
 | Switch.cs:103:17:103:25 | After access to property Length | Switch.cs:103:17:103:25 | access to property Length |
 | Switch.cs:103:17:103:25 | Before access to property Length | Switch.cs:103:9:107:9 | switch (...) {...} |
 | Switch.cs:103:17:103:25 | access to property Length | Switch.cs:103:17:103:17 | After access to parameter s [non-null] |
+| Switch.cs:105:13:105:19 | After case ...: [match] | Switch.cs:105:18:105:18 | After 0 [match] |
+| Switch.cs:105:13:105:19 | After case ...: [no-match] | Switch.cs:105:18:105:18 | After 0 [no-match] |
 | Switch.cs:105:13:105:19 | case ...: | Switch.cs:103:17:103:25 | After access to property Length |
-| Switch.cs:105:18:105:18 | 0 | Switch.cs:105:13:105:19 | After case ...: [match] |
-| Switch.cs:105:21:105:29 | Before return ...; | Switch.cs:105:18:105:18 | 0 |
+| Switch.cs:105:18:105:18 | 0 | Switch.cs:105:13:105:19 | case ...: |
+| Switch.cs:105:21:105:29 | Before return ...; | Switch.cs:105:13:105:19 | After case ...: [match] |
 | Switch.cs:105:21:105:29 | return ...; | Switch.cs:105:28:105:28 | 0 |
 | Switch.cs:105:28:105:28 | 0 | Switch.cs:105:21:105:29 | Before return ...; |
+| Switch.cs:106:13:106:19 | After case ...: [match] | Switch.cs:106:18:106:18 | After 1 [match] |
+| Switch.cs:106:13:106:19 | After case ...: [no-match] | Switch.cs:106:18:106:18 | After 1 [no-match] |
 | Switch.cs:106:13:106:19 | case ...: | Switch.cs:105:13:105:19 | After case ...: [no-match] |
-| Switch.cs:106:18:106:18 | 1 | Switch.cs:106:13:106:19 | After case ...: [match] |
-| Switch.cs:106:21:106:29 | Before return ...; | Switch.cs:106:18:106:18 | 1 |
+| Switch.cs:106:18:106:18 | 1 | Switch.cs:106:13:106:19 | case ...: |
+| Switch.cs:106:21:106:29 | Before return ...; | Switch.cs:106:13:106:19 | After case ...: [match] |
 | Switch.cs:106:21:106:29 | return ...; | Switch.cs:106:28:106:28 | 1 |
 | Switch.cs:106:28:106:28 | 1 | Switch.cs:106:21:106:29 | Before return ...; |
 | Switch.cs:108:9:108:18 | Before return ...; | Switch.cs:103:9:107:9 | After switch (...) {...} |
@@ -13640,21 +13789,25 @@ postDominance
 | Switch.cs:115:17:115:24 | After access to property Length | Switch.cs:115:17:115:24 | access to property Length |
 | Switch.cs:115:17:115:24 | Before access to property Length | Switch.cs:115:9:119:9 | switch (...) {...} |
 | Switch.cs:115:17:115:24 | access to property Length | Switch.cs:115:17:115:17 | access to parameter s |
+| Switch.cs:117:13:117:35 | After case ...: [match] | Switch.cs:117:18:117:18 | After 3 [match] |
+| Switch.cs:117:13:117:35 | After case ...: [no-match] | Switch.cs:117:18:117:18 | After 3 [no-match] |
 | Switch.cs:117:13:117:35 | case ...: | Switch.cs:115:17:115:24 | After access to property Length |
-| Switch.cs:117:18:117:18 | 3 | Switch.cs:117:13:117:35 | After case ...: [match] |
+| Switch.cs:117:18:117:18 | 3 | Switch.cs:117:13:117:35 | case ...: |
 | Switch.cs:117:25:117:25 | access to parameter s | Switch.cs:117:25:117:34 | Before ... == ... |
 | Switch.cs:117:25:117:34 | ... == ... | Switch.cs:117:30:117:34 | "foo" |
-| Switch.cs:117:25:117:34 | Before ... == ... | Switch.cs:117:18:117:18 | 3 |
+| Switch.cs:117:25:117:34 | Before ... == ... | Switch.cs:117:13:117:35 | After case ...: [match] |
 | Switch.cs:117:30:117:34 | "foo" | Switch.cs:117:25:117:25 | access to parameter s |
 | Switch.cs:117:37:117:45 | Before return ...; | Switch.cs:117:25:117:34 | After ... == ... [true] |
 | Switch.cs:117:37:117:45 | return ...; | Switch.cs:117:44:117:44 | 1 |
 | Switch.cs:117:44:117:44 | 1 | Switch.cs:117:37:117:45 | Before return ...; |
+| Switch.cs:118:13:118:34 | After case ...: [match] | Switch.cs:118:18:118:18 | After 2 [match] |
+| Switch.cs:118:13:118:34 | After case ...: [no-match] | Switch.cs:118:18:118:18 | After 2 [no-match] |
 | Switch.cs:118:13:118:34 | case ...: | Switch.cs:117:13:117:35 | After case ...: [no-match] |
 | Switch.cs:118:13:118:34 | case ...: | Switch.cs:117:25:117:34 | After ... == ... [false] |
-| Switch.cs:118:18:118:18 | 2 | Switch.cs:118:13:118:34 | After case ...: [match] |
+| Switch.cs:118:18:118:18 | 2 | Switch.cs:118:13:118:34 | case ...: |
 | Switch.cs:118:25:118:25 | access to parameter s | Switch.cs:118:25:118:33 | Before ... == ... |
 | Switch.cs:118:25:118:33 | ... == ... | Switch.cs:118:30:118:33 | "fu" |
-| Switch.cs:118:25:118:33 | Before ... == ... | Switch.cs:118:18:118:18 | 2 |
+| Switch.cs:118:25:118:33 | Before ... == ... | Switch.cs:118:13:118:34 | After case ...: [match] |
 | Switch.cs:118:30:118:33 | "fu" | Switch.cs:118:25:118:25 | access to parameter s |
 | Switch.cs:118:36:118:44 | Before return ...; | Switch.cs:118:25:118:33 | After ... == ... [true] |
 | Switch.cs:118:36:118:44 | return ...; | Switch.cs:118:43:118:43 | 2 |
@@ -13675,13 +13828,16 @@ postDominance
 | Switch.cs:125:9:126:19 | if (...) ... | Switch.cs:124:5:127:5 | {...} |
 | Switch.cs:125:13:125:13 | access to parameter o | Switch.cs:125:13:125:48 | ... switch { ... } |
 | Switch.cs:125:13:125:48 | ... switch { ... } | Switch.cs:125:9:126:19 | if (...) ... |
-| Switch.cs:125:24:125:29 | Boolean b | Switch.cs:125:24:125:34 | After ... => ... [match] |
+| Switch.cs:125:24:125:29 | Boolean b | Switch.cs:125:24:125:34 | ... => ... |
 | Switch.cs:125:24:125:34 | ... => ... | Switch.cs:125:13:125:13 | access to parameter o |
-| Switch.cs:125:34:125:34 | access to local variable b | Switch.cs:125:24:125:29 | Boolean b |
-| Switch.cs:125:37:125:37 | _ | Switch.cs:125:37:125:46 | After ... => ... [match] |
+| Switch.cs:125:24:125:34 | After ... => ... [match] | Switch.cs:125:24:125:29 | After Boolean b [match] |
+| Switch.cs:125:24:125:34 | After ... => ... [no-match] | Switch.cs:125:24:125:29 | After Boolean b [no-match] |
+| Switch.cs:125:34:125:34 | access to local variable b | Switch.cs:125:24:125:34 | After ... => ... [match] |
+| Switch.cs:125:37:125:37 | After _ [match] | Switch.cs:125:37:125:37 | _ |
+| Switch.cs:125:37:125:37 | _ | Switch.cs:125:37:125:46 | ... => ... |
 | Switch.cs:125:37:125:46 | ... => ... | Switch.cs:125:24:125:34 | After ... => ... [no-match] |
-| Switch.cs:125:37:125:46 | After ... => ... [match] | Switch.cs:125:37:125:46 | ... => ... |
-| Switch.cs:125:42:125:46 | false | Switch.cs:125:37:125:37 | _ |
+| Switch.cs:125:37:125:46 | After ... => ... [match] | Switch.cs:125:37:125:37 | After _ [match] |
+| Switch.cs:125:42:125:46 | false | Switch.cs:125:37:125:46 | After ... => ... [match] |
 | Switch.cs:126:13:126:19 | Before return ...; | Switch.cs:125:13:125:48 | After ... switch { ... } [true] |
 | Switch.cs:126:13:126:19 | return ...; | Switch.cs:126:13:126:19 | Before return ...; |
 | Switch.cs:129:12:129:14 | Exit | Switch.cs:129:12:129:14 | Normal Exit |
@@ -13696,13 +13852,16 @@ postDominance
 | Switch.cs:131:16:131:66 | call to method ToString | Switch.cs:131:17:131:53 | After ... switch { ... } [non-null] |
 | Switch.cs:131:17:131:17 | access to parameter o | Switch.cs:131:17:131:53 | ... switch { ... } |
 | Switch.cs:131:17:131:53 | ... switch { ... } | Switch.cs:131:16:131:66 | Before call to method ToString |
-| Switch.cs:131:28:131:35 | String s | Switch.cs:131:28:131:40 | After ... => ... [match] |
+| Switch.cs:131:28:131:35 | String s | Switch.cs:131:28:131:40 | ... => ... |
 | Switch.cs:131:28:131:40 | ... => ... | Switch.cs:131:17:131:17 | access to parameter o |
-| Switch.cs:131:40:131:40 | access to local variable s | Switch.cs:131:28:131:35 | String s |
-| Switch.cs:131:43:131:43 | _ | Switch.cs:131:43:131:51 | After ... => ... [match] |
+| Switch.cs:131:28:131:40 | After ... => ... [match] | Switch.cs:131:28:131:35 | After String s [match] |
+| Switch.cs:131:28:131:40 | After ... => ... [no-match] | Switch.cs:131:28:131:35 | After String s [no-match] |
+| Switch.cs:131:40:131:40 | access to local variable s | Switch.cs:131:28:131:40 | After ... => ... [match] |
+| Switch.cs:131:43:131:43 | After _ [match] | Switch.cs:131:43:131:43 | _ |
+| Switch.cs:131:43:131:43 | _ | Switch.cs:131:43:131:51 | ... => ... |
 | Switch.cs:131:43:131:51 | ... => ... | Switch.cs:131:28:131:40 | After ... => ... [no-match] |
-| Switch.cs:131:43:131:51 | After ... => ... [match] | Switch.cs:131:43:131:51 | ... => ... |
-| Switch.cs:131:48:131:51 | null | Switch.cs:131:43:131:43 | _ |
+| Switch.cs:131:43:131:51 | After ... => ... [match] | Switch.cs:131:43:131:43 | After _ [match] |
+| Switch.cs:131:48:131:51 | null | Switch.cs:131:43:131:51 | After ... => ... [match] |
 | Switch.cs:134:9:134:11 | Exit | Switch.cs:134:9:134:11 | Normal Exit |
 | Switch.cs:134:9:134:11 | Normal Exit | Switch.cs:138:22:138:31 | return ...; |
 | Switch.cs:134:9:134:11 | Normal Exit | Switch.cs:139:21:139:29 | return ...; |
@@ -13719,14 +13878,18 @@ postDominance
 | Switch.cs:138:29:138:30 | After -... | Switch.cs:138:29:138:30 | -... |
 | Switch.cs:138:29:138:30 | Before -... | Switch.cs:138:22:138:31 | Before return ...; |
 | Switch.cs:138:30:138:30 | 1 | Switch.cs:138:29:138:30 | Before -... |
+| Switch.cs:139:13:139:19 | After case ...: [match] | Switch.cs:139:18:139:18 | After 1 [match] |
+| Switch.cs:139:13:139:19 | After case ...: [no-match] | Switch.cs:139:18:139:18 | After 1 [no-match] |
 | Switch.cs:139:13:139:19 | case ...: | Switch.cs:136:17:136:17 | access to parameter i |
-| Switch.cs:139:18:139:18 | 1 | Switch.cs:139:13:139:19 | After case ...: [match] |
-| Switch.cs:139:21:139:29 | Before return ...; | Switch.cs:139:18:139:18 | 1 |
+| Switch.cs:139:18:139:18 | 1 | Switch.cs:139:13:139:19 | case ...: |
+| Switch.cs:139:21:139:29 | Before return ...; | Switch.cs:139:13:139:19 | After case ...: [match] |
 | Switch.cs:139:21:139:29 | return ...; | Switch.cs:139:28:139:28 | 1 |
 | Switch.cs:139:28:139:28 | 1 | Switch.cs:139:21:139:29 | Before return ...; |
+| Switch.cs:140:13:140:19 | After case ...: [match] | Switch.cs:140:18:140:18 | After 2 [match] |
+| Switch.cs:140:13:140:19 | After case ...: [no-match] | Switch.cs:140:18:140:18 | After 2 [no-match] |
 | Switch.cs:140:13:140:19 | case ...: | Switch.cs:139:13:139:19 | After case ...: [no-match] |
-| Switch.cs:140:18:140:18 | 2 | Switch.cs:140:13:140:19 | After case ...: [match] |
-| Switch.cs:140:21:140:29 | Before return ...; | Switch.cs:140:18:140:18 | 2 |
+| Switch.cs:140:18:140:18 | 2 | Switch.cs:140:13:140:19 | case ...: |
+| Switch.cs:140:21:140:29 | Before return ...; | Switch.cs:140:13:140:19 | After case ...: [match] |
 | Switch.cs:140:21:140:29 | return ...; | Switch.cs:140:28:140:28 | 2 |
 | Switch.cs:140:28:140:28 | 2 | Switch.cs:140:21:140:29 | Before return ...; |
 | Switch.cs:144:9:144:11 | Exit | Switch.cs:144:9:144:11 | Normal Exit |
@@ -13737,9 +13900,11 @@ postDominance
 | Switch.cs:145:5:152:5 | {...} | Switch.cs:144:17:144:17 | i |
 | Switch.cs:146:9:151:9 | switch (...) {...} | Switch.cs:145:5:152:5 | {...} |
 | Switch.cs:146:17:146:17 | access to parameter i | Switch.cs:146:9:151:9 | switch (...) {...} |
+| Switch.cs:148:13:148:19 | After case ...: [match] | Switch.cs:148:18:148:18 | After 1 [match] |
+| Switch.cs:148:13:148:19 | After case ...: [no-match] | Switch.cs:148:18:148:18 | After 1 [no-match] |
 | Switch.cs:148:13:148:19 | case ...: | Switch.cs:146:17:146:17 | access to parameter i |
-| Switch.cs:148:18:148:18 | 1 | Switch.cs:148:13:148:19 | After case ...: [match] |
-| Switch.cs:148:21:148:29 | Before return ...; | Switch.cs:148:18:148:18 | 1 |
+| Switch.cs:148:18:148:18 | 1 | Switch.cs:148:13:148:19 | case ...: |
+| Switch.cs:148:21:148:29 | Before return ...; | Switch.cs:148:13:148:19 | After case ...: [match] |
 | Switch.cs:148:21:148:29 | return ...; | Switch.cs:148:28:148:28 | 1 |
 | Switch.cs:148:28:148:28 | 1 | Switch.cs:148:21:148:29 | Before return ...; |
 | Switch.cs:149:13:149:20 | After default: [match] | Switch.cs:149:13:149:20 | default: |
@@ -13750,9 +13915,11 @@ postDominance
 | Switch.cs:149:29:149:30 | After -... | Switch.cs:149:29:149:30 | -... |
 | Switch.cs:149:29:149:30 | Before -... | Switch.cs:149:22:149:31 | Before return ...; |
 | Switch.cs:149:30:149:30 | 1 | Switch.cs:149:29:149:30 | Before -... |
+| Switch.cs:150:13:150:19 | After case ...: [match] | Switch.cs:150:18:150:18 | After 2 [match] |
+| Switch.cs:150:13:150:19 | After case ...: [no-match] | Switch.cs:150:18:150:18 | After 2 [no-match] |
 | Switch.cs:150:13:150:19 | case ...: | Switch.cs:148:13:148:19 | After case ...: [no-match] |
-| Switch.cs:150:18:150:18 | 2 | Switch.cs:150:13:150:19 | After case ...: [match] |
-| Switch.cs:150:21:150:29 | Before return ...; | Switch.cs:150:18:150:18 | 2 |
+| Switch.cs:150:18:150:18 | 2 | Switch.cs:150:13:150:19 | case ...: |
+| Switch.cs:150:21:150:29 | Before return ...; | Switch.cs:150:13:150:19 | After case ...: [match] |
 | Switch.cs:150:21:150:29 | return ...; | Switch.cs:150:28:150:28 | 2 |
 | Switch.cs:150:28:150:28 | 2 | Switch.cs:150:21:150:29 | Before return ...; |
 | Switch.cs:154:10:154:12 | Exit | Switch.cs:154:10:154:12 | Normal Exit |
@@ -13771,12 +13938,16 @@ postDominance
 | Switch.cs:156:17:156:54 | After ... switch { ... } | Switch.cs:156:36:156:38 | "a" |
 | Switch.cs:156:17:156:54 | After ... switch { ... } | Switch.cs:156:41:156:52 | After ... => ... [no-match] |
 | Switch.cs:156:17:156:54 | After ... switch { ... } | Switch.cs:156:50:156:52 | "b" |
-| Switch.cs:156:28:156:31 | true | Switch.cs:156:28:156:38 | After ... => ... [match] |
+| Switch.cs:156:28:156:31 | true | Switch.cs:156:28:156:38 | ... => ... |
 | Switch.cs:156:28:156:38 | ... => ... | Switch.cs:156:17:156:17 | access to parameter b |
-| Switch.cs:156:36:156:38 | "a" | Switch.cs:156:28:156:31 | true |
-| Switch.cs:156:41:156:45 | false | Switch.cs:156:41:156:52 | After ... => ... [match] |
+| Switch.cs:156:28:156:38 | After ... => ... [match] | Switch.cs:156:28:156:31 | After true [match] |
+| Switch.cs:156:28:156:38 | After ... => ... [no-match] | Switch.cs:156:28:156:31 | After true [no-match] |
+| Switch.cs:156:36:156:38 | "a" | Switch.cs:156:28:156:38 | After ... => ... [match] |
+| Switch.cs:156:41:156:45 | false | Switch.cs:156:41:156:52 | ... => ... |
 | Switch.cs:156:41:156:52 | ... => ... | Switch.cs:156:28:156:38 | After ... => ... [no-match] |
-| Switch.cs:156:50:156:52 | "b" | Switch.cs:156:41:156:45 | false |
+| Switch.cs:156:41:156:52 | After ... => ... [match] | Switch.cs:156:41:156:45 | After false [match] |
+| Switch.cs:156:41:156:52 | After ... => ... [no-match] | Switch.cs:156:41:156:45 | After false [no-match] |
+| Switch.cs:156:50:156:52 | "b" | Switch.cs:156:41:156:52 | After ... => ... [match] |
 | Switch.cs:157:9:160:49 | After if (...) ... | Switch.cs:158:13:158:49 | After ...; |
 | Switch.cs:157:9:160:49 | After if (...) ... | Switch.cs:160:13:160:49 | After ...; |
 | Switch.cs:157:9:160:49 | if (...) ... | Switch.cs:156:9:156:55 | After ... ...; |
@@ -13817,25 +13988,31 @@ postDominance
 | Switch.cs:165:9:177:9 | After switch (...) {...} | Switch.cs:176:17:176:22 | break; |
 | Switch.cs:165:9:177:9 | switch (...) {...} | Switch.cs:164:5:178:5 | {...} |
 | Switch.cs:165:17:165:17 | access to parameter i | Switch.cs:165:9:177:9 | switch (...) {...} |
+| Switch.cs:167:13:167:19 | After case ...: [match] | Switch.cs:167:18:167:18 | After 1 [match] |
+| Switch.cs:167:13:167:19 | After case ...: [no-match] | Switch.cs:167:18:167:18 | After 1 [no-match] |
 | Switch.cs:167:13:167:19 | case ...: | Switch.cs:165:17:165:17 | access to parameter i |
-| Switch.cs:167:18:167:18 | 1 | Switch.cs:167:13:167:19 | After case ...: [match] |
+| Switch.cs:167:18:167:18 | 1 | Switch.cs:167:13:167:19 | case ...: |
+| Switch.cs:168:13:168:19 | After case ...: [match] | Switch.cs:168:18:168:18 | After 2 [match] |
+| Switch.cs:168:13:168:19 | After case ...: [no-match] | Switch.cs:168:18:168:18 | After 2 [no-match] |
 | Switch.cs:168:13:168:19 | case ...: | Switch.cs:167:13:167:19 | After case ...: [no-match] |
-| Switch.cs:168:18:168:18 | 2 | Switch.cs:168:13:168:19 | After case ...: [match] |
+| Switch.cs:168:18:168:18 | 2 | Switch.cs:168:13:168:19 | case ...: |
 | Switch.cs:169:17:169:50 | After call to method WriteLine | Switch.cs:169:17:169:50 | call to method WriteLine |
 | Switch.cs:169:17:169:50 | Before call to method WriteLine | Switch.cs:169:17:169:51 | ...; |
 | Switch.cs:169:17:169:50 | call to method WriteLine | Switch.cs:169:42:169:49 | "1 or 2" |
-| Switch.cs:169:17:169:51 | ...; | Switch.cs:167:18:167:18 | 1 |
-| Switch.cs:169:17:169:51 | ...; | Switch.cs:168:18:168:18 | 2 |
+| Switch.cs:169:17:169:51 | ...; | Switch.cs:167:13:167:19 | After case ...: [match] |
+| Switch.cs:169:17:169:51 | ...; | Switch.cs:168:13:168:19 | After case ...: [match] |
 | Switch.cs:169:17:169:51 | After ...; | Switch.cs:169:17:169:50 | After call to method WriteLine |
 | Switch.cs:169:42:169:49 | "1 or 2" | Switch.cs:169:17:169:50 | Before call to method WriteLine |
 | Switch.cs:170:17:170:22 | Before break; | Switch.cs:169:17:169:51 | After ...; |
 | Switch.cs:170:17:170:22 | break; | Switch.cs:170:17:170:22 | Before break; |
+| Switch.cs:171:13:171:19 | After case ...: [match] | Switch.cs:171:18:171:18 | After 3 [match] |
+| Switch.cs:171:13:171:19 | After case ...: [no-match] | Switch.cs:171:18:171:18 | After 3 [no-match] |
 | Switch.cs:171:13:171:19 | case ...: | Switch.cs:168:13:168:19 | After case ...: [no-match] |
-| Switch.cs:171:18:171:18 | 3 | Switch.cs:171:13:171:19 | After case ...: [match] |
+| Switch.cs:171:18:171:18 | 3 | Switch.cs:171:13:171:19 | case ...: |
 | Switch.cs:172:17:172:45 | After call to method WriteLine | Switch.cs:172:17:172:45 | call to method WriteLine |
 | Switch.cs:172:17:172:45 | Before call to method WriteLine | Switch.cs:172:17:172:46 | ...; |
 | Switch.cs:172:17:172:45 | call to method WriteLine | Switch.cs:172:42:172:44 | "3" |
-| Switch.cs:172:17:172:46 | ...; | Switch.cs:171:18:171:18 | 3 |
+| Switch.cs:172:17:172:46 | ...; | Switch.cs:171:13:171:19 | After case ...: [match] |
 | Switch.cs:172:17:172:46 | After ...; | Switch.cs:172:17:172:45 | After call to method WriteLine |
 | Switch.cs:172:42:172:44 | "3" | Switch.cs:172:17:172:45 | Before call to method WriteLine |
 | Switch.cs:173:17:173:22 | Before break; | Switch.cs:172:17:172:46 | After ...; |
@@ -14201,36 +14378,40 @@ postDominance
 | cflow.cs:39:9:50:9 | After switch (...) {...} | cflow.cs:49:17:49:22 | break; |
 | cflow.cs:39:9:50:9 | switch (...) {...} | cflow.cs:38:5:68:5 | {...} |
 | cflow.cs:39:17:39:17 | access to parameter a | cflow.cs:39:9:50:9 | switch (...) {...} |
-| cflow.cs:41:13:41:19 | After case ...: [no-match] | cflow.cs:41:13:41:19 | case ...: |
+| cflow.cs:41:13:41:19 | After case ...: [no-match] | cflow.cs:41:18:41:18 | After 1 [no-match] |
 | cflow.cs:41:13:41:19 | case ...: | cflow.cs:39:17:39:17 | access to parameter a |
-| cflow.cs:41:18:41:18 | 1 | cflow.cs:41:13:41:19 | After case ...: [match] |
+| cflow.cs:41:18:41:18 | 1 | cflow.cs:41:13:41:19 | case ...: |
+| cflow.cs:41:18:41:18 | After 1 [no-match] | cflow.cs:41:18:41:18 | 1 |
 | cflow.cs:42:17:42:38 | After call to method WriteLine | cflow.cs:42:17:42:38 | call to method WriteLine |
 | cflow.cs:42:17:42:38 | Before call to method WriteLine | cflow.cs:42:17:42:39 | ...; |
 | cflow.cs:42:17:42:38 | call to method WriteLine | cflow.cs:42:35:42:37 | "1" |
-| cflow.cs:42:17:42:39 | ...; | cflow.cs:41:18:41:18 | 1 |
+| cflow.cs:42:17:42:39 | ...; | cflow.cs:41:13:41:19 | After case ...: [match] |
 | cflow.cs:42:17:42:39 | After ...; | cflow.cs:42:17:42:38 | After call to method WriteLine |
 | cflow.cs:42:35:42:37 | "1" | cflow.cs:42:17:42:38 | Before call to method WriteLine |
 | cflow.cs:43:17:43:28 | Before goto case ...; | cflow.cs:42:17:42:39 | After ...; |
 | cflow.cs:43:17:43:28 | goto case ...; | cflow.cs:43:27:43:27 | 2 |
 | cflow.cs:43:27:43:27 | 2 | cflow.cs:43:17:43:28 | Before goto case ...; |
-| cflow.cs:44:13:44:19 | After case ...: [no-match] | cflow.cs:44:13:44:19 | case ...: |
+| cflow.cs:44:13:44:19 | After case ...: [no-match] | cflow.cs:44:18:44:18 | After 2 [no-match] |
 | cflow.cs:44:13:44:19 | case ...: | cflow.cs:41:13:41:19 | After case ...: [no-match] |
-| cflow.cs:44:18:44:18 | 2 | cflow.cs:44:13:44:19 | After case ...: [match] |
+| cflow.cs:44:18:44:18 | 2 | cflow.cs:44:13:44:19 | case ...: |
+| cflow.cs:44:18:44:18 | After 2 [no-match] | cflow.cs:44:18:44:18 | 2 |
 | cflow.cs:45:17:45:38 | After call to method WriteLine | cflow.cs:45:17:45:38 | call to method WriteLine |
 | cflow.cs:45:17:45:38 | Before call to method WriteLine | cflow.cs:45:17:45:39 | ...; |
 | cflow.cs:45:17:45:38 | call to method WriteLine | cflow.cs:45:35:45:37 | "2" |
-| cflow.cs:45:17:45:39 | ...; | cflow.cs:44:18:44:18 | 2 |
+| cflow.cs:45:17:45:39 | ...; | cflow.cs:44:13:44:19 | After case ...: [match] |
 | cflow.cs:45:17:45:39 | After ...; | cflow.cs:45:17:45:38 | After call to method WriteLine |
 | cflow.cs:45:35:45:37 | "2" | cflow.cs:45:17:45:38 | Before call to method WriteLine |
 | cflow.cs:46:17:46:28 | Before goto case ...; | cflow.cs:45:17:45:39 | After ...; |
 | cflow.cs:46:17:46:28 | goto case ...; | cflow.cs:46:27:46:27 | 1 |
 | cflow.cs:46:27:46:27 | 1 | cflow.cs:46:17:46:28 | Before goto case ...; |
+| cflow.cs:47:13:47:19 | After case ...: [match] | cflow.cs:47:18:47:18 | After 3 [match] |
+| cflow.cs:47:13:47:19 | After case ...: [no-match] | cflow.cs:47:18:47:18 | After 3 [no-match] |
 | cflow.cs:47:13:47:19 | case ...: | cflow.cs:44:13:44:19 | After case ...: [no-match] |
-| cflow.cs:47:18:47:18 | 3 | cflow.cs:47:13:47:19 | After case ...: [match] |
+| cflow.cs:47:18:47:18 | 3 | cflow.cs:47:13:47:19 | case ...: |
 | cflow.cs:48:17:48:38 | After call to method WriteLine | cflow.cs:48:17:48:38 | call to method WriteLine |
 | cflow.cs:48:17:48:38 | Before call to method WriteLine | cflow.cs:48:17:48:39 | ...; |
 | cflow.cs:48:17:48:38 | call to method WriteLine | cflow.cs:48:35:48:37 | "3" |
-| cflow.cs:48:17:48:39 | ...; | cflow.cs:47:18:47:18 | 3 |
+| cflow.cs:48:17:48:39 | ...; | cflow.cs:47:13:47:19 | After case ...: [match] |
 | cflow.cs:48:17:48:39 | After ...; | cflow.cs:48:17:48:38 | After call to method WriteLine |
 | cflow.cs:48:35:48:37 | "3" | cflow.cs:48:17:48:38 | Before call to method WriteLine |
 | cflow.cs:49:17:49:22 | Before break; | cflow.cs:48:17:48:39 | After ...; |
@@ -14239,12 +14420,14 @@ postDominance
 | cflow.cs:51:9:59:9 | After switch (...) {...} | cflow.cs:58:17:58:22 | break; |
 | cflow.cs:51:9:59:9 | switch (...) {...} | cflow.cs:39:9:50:9 | After switch (...) {...} |
 | cflow.cs:51:17:51:17 | access to parameter a | cflow.cs:51:9:59:9 | switch (...) {...} |
+| cflow.cs:53:13:53:20 | After case ...: [match] | cflow.cs:53:18:53:19 | After 42 [match] |
+| cflow.cs:53:13:53:20 | After case ...: [no-match] | cflow.cs:53:18:53:19 | After 42 [no-match] |
 | cflow.cs:53:13:53:20 | case ...: | cflow.cs:51:17:51:17 | access to parameter a |
-| cflow.cs:53:18:53:19 | 42 | cflow.cs:53:13:53:20 | After case ...: [match] |
+| cflow.cs:53:18:53:19 | 42 | cflow.cs:53:13:53:20 | case ...: |
 | cflow.cs:54:17:54:47 | After call to method WriteLine | cflow.cs:54:17:54:47 | call to method WriteLine |
 | cflow.cs:54:17:54:47 | Before call to method WriteLine | cflow.cs:54:17:54:48 | ...; |
 | cflow.cs:54:17:54:47 | call to method WriteLine | cflow.cs:54:35:54:46 | "The answer" |
-| cflow.cs:54:17:54:48 | ...; | cflow.cs:53:18:53:19 | 42 |
+| cflow.cs:54:17:54:48 | ...; | cflow.cs:53:13:53:20 | After case ...: [match] |
 | cflow.cs:54:17:54:48 | After ...; | cflow.cs:54:17:54:47 | After call to method WriteLine |
 | cflow.cs:54:35:54:46 | "The answer" | cflow.cs:54:17:54:47 | Before call to method WriteLine |
 | cflow.cs:55:17:55:22 | Before break; | cflow.cs:54:17:54:48 | After ...; |
@@ -14269,10 +14452,12 @@ postDominance
 | cflow.cs:60:27:60:31 | Before access to field Field | cflow.cs:60:17:60:32 | Before call to method Parse |
 | cflow.cs:60:27:60:31 | access to field Field | cflow.cs:60:27:60:31 | this access |
 | cflow.cs:60:27:60:31 | this access | cflow.cs:60:27:60:31 | Before access to field Field |
+| cflow.cs:62:13:62:19 | After case ...: [match] | cflow.cs:62:18:62:18 | After 0 [match] |
+| cflow.cs:62:13:62:19 | After case ...: [no-match] | cflow.cs:62:18:62:18 | After 0 [no-match] |
 | cflow.cs:62:13:62:19 | case ...: | cflow.cs:60:17:60:32 | After call to method Parse |
-| cflow.cs:62:18:62:18 | 0 | cflow.cs:62:13:62:19 | After case ...: [match] |
+| cflow.cs:62:18:62:18 | 0 | cflow.cs:62:13:62:19 | case ...: |
 | cflow.cs:63:17:64:55 | After if (...) ... | cflow.cs:63:21:63:34 | After !... [false] |
-| cflow.cs:63:17:64:55 | if (...) ... | cflow.cs:62:18:62:18 | 0 |
+| cflow.cs:63:17:64:55 | if (...) ... | cflow.cs:62:13:62:19 | After case ...: [match] |
 | cflow.cs:63:21:63:34 | !... | cflow.cs:63:17:64:55 | if (...) ... |
 | cflow.cs:63:21:63:34 | After !... [false] | cflow.cs:63:23:63:33 | After ... == ... [true] |
 | cflow.cs:63:21:63:34 | After !... [true] | cflow.cs:63:23:63:33 | After ... == ... [false] |
@@ -15151,23 +15336,29 @@ postDominance
 | cflow.cs:246:17:246:32 | After ... + ... | cflow.cs:246:17:246:32 | ... + ... |
 | cflow.cs:246:17:246:32 | Before ... + ... | cflow.cs:246:9:258:9 | switch (...) {...} |
 | cflow.cs:246:32:246:32 | 3 | cflow.cs:246:17:246:28 | After access to property Length |
+| cflow.cs:248:13:248:19 | After case ...: [match] | cflow.cs:248:18:248:18 | After 0 [match] |
+| cflow.cs:248:13:248:19 | After case ...: [no-match] | cflow.cs:248:18:248:18 | After 0 [no-match] |
 | cflow.cs:248:13:248:19 | case ...: | cflow.cs:246:17:246:32 | After ... + ... |
-| cflow.cs:248:18:248:18 | 0 | cflow.cs:248:13:248:19 | After case ...: [match] |
-| cflow.cs:249:17:249:29 | Before goto default; | cflow.cs:248:18:248:18 | 0 |
+| cflow.cs:248:18:248:18 | 0 | cflow.cs:248:13:248:19 | case ...: |
+| cflow.cs:249:17:249:29 | Before goto default; | cflow.cs:248:13:248:19 | After case ...: [match] |
 | cflow.cs:249:17:249:29 | goto default; | cflow.cs:249:17:249:29 | Before goto default; |
+| cflow.cs:250:13:250:19 | After case ...: [match] | cflow.cs:250:18:250:18 | After 1 [match] |
+| cflow.cs:250:13:250:19 | After case ...: [no-match] | cflow.cs:250:18:250:18 | After 1 [no-match] |
 | cflow.cs:250:13:250:19 | case ...: | cflow.cs:248:13:248:19 | After case ...: [no-match] |
-| cflow.cs:250:18:250:18 | 1 | cflow.cs:250:13:250:19 | After case ...: [match] |
+| cflow.cs:250:18:250:18 | 1 | cflow.cs:250:13:250:19 | case ...: |
 | cflow.cs:251:17:251:36 | After call to method WriteLine | cflow.cs:251:17:251:36 | call to method WriteLine |
 | cflow.cs:251:17:251:36 | Before call to method WriteLine | cflow.cs:251:17:251:37 | ...; |
 | cflow.cs:251:17:251:36 | call to method WriteLine | cflow.cs:251:35:251:35 | 1 |
-| cflow.cs:251:17:251:37 | ...; | cflow.cs:250:18:250:18 | 1 |
+| cflow.cs:251:17:251:37 | ...; | cflow.cs:250:13:250:19 | After case ...: [match] |
 | cflow.cs:251:17:251:37 | After ...; | cflow.cs:251:17:251:36 | After call to method WriteLine |
 | cflow.cs:251:35:251:35 | 1 | cflow.cs:251:17:251:36 | Before call to method WriteLine |
 | cflow.cs:252:17:252:22 | Before break; | cflow.cs:251:17:251:37 | After ...; |
 | cflow.cs:252:17:252:22 | break; | cflow.cs:252:17:252:22 | Before break; |
+| cflow.cs:253:13:253:19 | After case ...: [match] | cflow.cs:253:18:253:18 | After 2 [match] |
+| cflow.cs:253:13:253:19 | After case ...: [no-match] | cflow.cs:253:18:253:18 | After 2 [no-match] |
 | cflow.cs:253:13:253:19 | case ...: | cflow.cs:250:13:250:19 | After case ...: [no-match] |
-| cflow.cs:253:18:253:18 | 2 | cflow.cs:253:13:253:19 | After case ...: [match] |
-| cflow.cs:254:17:254:27 | Before goto ...; | cflow.cs:253:18:253:18 | 2 |
+| cflow.cs:253:18:253:18 | 2 | cflow.cs:253:13:253:19 | case ...: |
+| cflow.cs:254:17:254:27 | Before goto ...; | cflow.cs:253:13:253:19 | After case ...: [match] |
 | cflow.cs:254:17:254:27 | goto ...; | cflow.cs:254:17:254:27 | Before goto ...; |
 | cflow.cs:255:13:255:20 | After default: [match] | cflow.cs:249:17:249:29 | goto default; |
 | cflow.cs:255:13:255:20 | After default: [match] | cflow.cs:255:13:255:20 | default: |
@@ -18387,34 +18578,34 @@ blockDominance
 | Patterns.cs:5:10:5:11 | Entry | Patterns.cs:16:18:16:28 | After ... is ... [false] |
 | Patterns.cs:5:10:5:11 | Entry | Patterns.cs:16:18:16:28 | [MatchTrue] ... is ... |
 | Patterns.cs:5:10:5:11 | Entry | Patterns.cs:20:9:38:9 | After switch (...) {...} |
-| Patterns.cs:5:10:5:11 | Entry | Patterns.cs:22:13:22:23 | After case ...: [match] |
-| Patterns.cs:5:10:5:11 | Entry | Patterns.cs:22:13:22:23 | After case ...: [no-match] |
-| Patterns.cs:5:10:5:11 | Entry | Patterns.cs:24:13:24:36 | After case ...: [match] |
-| Patterns.cs:5:10:5:11 | Entry | Patterns.cs:24:13:24:36 | After case ...: [no-match] |
+| Patterns.cs:5:10:5:11 | Entry | Patterns.cs:22:18:22:22 | After "xyz" [match] |
+| Patterns.cs:5:10:5:11 | Entry | Patterns.cs:22:18:22:22 | After "xyz" [no-match] |
+| Patterns.cs:5:10:5:11 | Entry | Patterns.cs:24:18:24:23 | After Int32 i2 [match] |
+| Patterns.cs:5:10:5:11 | Entry | Patterns.cs:24:18:24:23 | After Int32 i2 [no-match] |
 | Patterns.cs:5:10:5:11 | Entry | Patterns.cs:24:30:24:35 | After ... > ... [false] |
 | Patterns.cs:5:10:5:11 | Entry | Patterns.cs:24:30:24:35 | After ... > ... [true] |
-| Patterns.cs:5:10:5:11 | Entry | Patterns.cs:27:13:27:24 | After case ...: [match] |
-| Patterns.cs:5:10:5:11 | Entry | Patterns.cs:27:13:27:24 | After case ...: [no-match] |
 | Patterns.cs:5:10:5:11 | Entry | Patterns.cs:27:13:27:24 | case ...: |
-| Patterns.cs:5:10:5:11 | Entry | Patterns.cs:30:13:30:27 | After case ...: [match] |
-| Patterns.cs:5:10:5:11 | Entry | Patterns.cs:30:13:30:27 | After case ...: [no-match] |
-| Patterns.cs:5:10:5:11 | Entry | Patterns.cs:33:13:33:24 | After case ...: [match] |
-| Patterns.cs:5:10:5:11 | Entry | Patterns.cs:33:13:33:24 | After case ...: [no-match] |
+| Patterns.cs:5:10:5:11 | Entry | Patterns.cs:27:18:27:23 | After Int32 i3 [match] |
+| Patterns.cs:5:10:5:11 | Entry | Patterns.cs:27:18:27:23 | After Int32 i3 [no-match] |
+| Patterns.cs:5:10:5:11 | Entry | Patterns.cs:30:18:30:26 | After String s2 [match] |
+| Patterns.cs:5:10:5:11 | Entry | Patterns.cs:30:18:30:26 | After String s2 [no-match] |
+| Patterns.cs:5:10:5:11 | Entry | Patterns.cs:33:18:33:23 | After Object v2 [match] |
+| Patterns.cs:5:10:5:11 | Entry | Patterns.cs:33:18:33:23 | After Object v2 [no-match] |
 | Patterns.cs:8:9:18:9 | After if (...) ... | Patterns.cs:8:9:18:9 | After if (...) ... |
 | Patterns.cs:8:9:18:9 | After if (...) ... | Patterns.cs:20:9:38:9 | After switch (...) {...} |
-| Patterns.cs:8:9:18:9 | After if (...) ... | Patterns.cs:22:13:22:23 | After case ...: [match] |
-| Patterns.cs:8:9:18:9 | After if (...) ... | Patterns.cs:22:13:22:23 | After case ...: [no-match] |
-| Patterns.cs:8:9:18:9 | After if (...) ... | Patterns.cs:24:13:24:36 | After case ...: [match] |
-| Patterns.cs:8:9:18:9 | After if (...) ... | Patterns.cs:24:13:24:36 | After case ...: [no-match] |
+| Patterns.cs:8:9:18:9 | After if (...) ... | Patterns.cs:22:18:22:22 | After "xyz" [match] |
+| Patterns.cs:8:9:18:9 | After if (...) ... | Patterns.cs:22:18:22:22 | After "xyz" [no-match] |
+| Patterns.cs:8:9:18:9 | After if (...) ... | Patterns.cs:24:18:24:23 | After Int32 i2 [match] |
+| Patterns.cs:8:9:18:9 | After if (...) ... | Patterns.cs:24:18:24:23 | After Int32 i2 [no-match] |
 | Patterns.cs:8:9:18:9 | After if (...) ... | Patterns.cs:24:30:24:35 | After ... > ... [false] |
 | Patterns.cs:8:9:18:9 | After if (...) ... | Patterns.cs:24:30:24:35 | After ... > ... [true] |
-| Patterns.cs:8:9:18:9 | After if (...) ... | Patterns.cs:27:13:27:24 | After case ...: [match] |
-| Patterns.cs:8:9:18:9 | After if (...) ... | Patterns.cs:27:13:27:24 | After case ...: [no-match] |
 | Patterns.cs:8:9:18:9 | After if (...) ... | Patterns.cs:27:13:27:24 | case ...: |
-| Patterns.cs:8:9:18:9 | After if (...) ... | Patterns.cs:30:13:30:27 | After case ...: [match] |
-| Patterns.cs:8:9:18:9 | After if (...) ... | Patterns.cs:30:13:30:27 | After case ...: [no-match] |
-| Patterns.cs:8:9:18:9 | After if (...) ... | Patterns.cs:33:13:33:24 | After case ...: [match] |
-| Patterns.cs:8:9:18:9 | After if (...) ... | Patterns.cs:33:13:33:24 | After case ...: [no-match] |
+| Patterns.cs:8:9:18:9 | After if (...) ... | Patterns.cs:27:18:27:23 | After Int32 i3 [match] |
+| Patterns.cs:8:9:18:9 | After if (...) ... | Patterns.cs:27:18:27:23 | After Int32 i3 [no-match] |
+| Patterns.cs:8:9:18:9 | After if (...) ... | Patterns.cs:30:18:30:26 | After String s2 [match] |
+| Patterns.cs:8:9:18:9 | After if (...) ... | Patterns.cs:30:18:30:26 | After String s2 [no-match] |
+| Patterns.cs:8:9:18:9 | After if (...) ... | Patterns.cs:33:18:33:23 | After Object v2 [match] |
+| Patterns.cs:8:9:18:9 | After if (...) ... | Patterns.cs:33:18:33:23 | After Object v2 [no-match] |
 | Patterns.cs:8:13:8:23 | After ... is ... [false] | Patterns.cs:8:13:8:23 | After ... is ... [false] |
 | Patterns.cs:8:13:8:23 | After ... is ... [false] | Patterns.cs:12:14:18:9 | After if (...) ... |
 | Patterns.cs:8:13:8:23 | After ... is ... [false] | Patterns.cs:12:18:12:31 | After ... is ... [false] |
@@ -18433,44 +18624,44 @@ blockDominance
 | Patterns.cs:16:18:16:28 | After ... is ... [false] | Patterns.cs:16:18:16:28 | After ... is ... [false] |
 | Patterns.cs:16:18:16:28 | [MatchTrue] ... is ... | Patterns.cs:16:18:16:28 | [MatchTrue] ... is ... |
 | Patterns.cs:20:9:38:9 | After switch (...) {...} | Patterns.cs:20:9:38:9 | After switch (...) {...} |
-| Patterns.cs:22:13:22:23 | After case ...: [match] | Patterns.cs:22:13:22:23 | After case ...: [match] |
-| Patterns.cs:22:13:22:23 | After case ...: [no-match] | Patterns.cs:22:13:22:23 | After case ...: [no-match] |
-| Patterns.cs:22:13:22:23 | After case ...: [no-match] | Patterns.cs:24:13:24:36 | After case ...: [match] |
-| Patterns.cs:22:13:22:23 | After case ...: [no-match] | Patterns.cs:24:13:24:36 | After case ...: [no-match] |
-| Patterns.cs:22:13:22:23 | After case ...: [no-match] | Patterns.cs:24:30:24:35 | After ... > ... [false] |
-| Patterns.cs:22:13:22:23 | After case ...: [no-match] | Patterns.cs:24:30:24:35 | After ... > ... [true] |
-| Patterns.cs:22:13:22:23 | After case ...: [no-match] | Patterns.cs:27:13:27:24 | After case ...: [match] |
-| Patterns.cs:22:13:22:23 | After case ...: [no-match] | Patterns.cs:27:13:27:24 | After case ...: [no-match] |
-| Patterns.cs:22:13:22:23 | After case ...: [no-match] | Patterns.cs:27:13:27:24 | case ...: |
-| Patterns.cs:22:13:22:23 | After case ...: [no-match] | Patterns.cs:30:13:30:27 | After case ...: [match] |
-| Patterns.cs:22:13:22:23 | After case ...: [no-match] | Patterns.cs:30:13:30:27 | After case ...: [no-match] |
-| Patterns.cs:22:13:22:23 | After case ...: [no-match] | Patterns.cs:33:13:33:24 | After case ...: [match] |
-| Patterns.cs:22:13:22:23 | After case ...: [no-match] | Patterns.cs:33:13:33:24 | After case ...: [no-match] |
-| Patterns.cs:24:13:24:36 | After case ...: [match] | Patterns.cs:24:13:24:36 | After case ...: [match] |
-| Patterns.cs:24:13:24:36 | After case ...: [match] | Patterns.cs:24:30:24:35 | After ... > ... [false] |
-| Patterns.cs:24:13:24:36 | After case ...: [match] | Patterns.cs:24:30:24:35 | After ... > ... [true] |
-| Patterns.cs:24:13:24:36 | After case ...: [no-match] | Patterns.cs:24:13:24:36 | After case ...: [no-match] |
+| Patterns.cs:22:18:22:22 | After "xyz" [match] | Patterns.cs:22:18:22:22 | After "xyz" [match] |
+| Patterns.cs:22:18:22:22 | After "xyz" [no-match] | Patterns.cs:22:18:22:22 | After "xyz" [no-match] |
+| Patterns.cs:22:18:22:22 | After "xyz" [no-match] | Patterns.cs:24:18:24:23 | After Int32 i2 [match] |
+| Patterns.cs:22:18:22:22 | After "xyz" [no-match] | Patterns.cs:24:18:24:23 | After Int32 i2 [no-match] |
+| Patterns.cs:22:18:22:22 | After "xyz" [no-match] | Patterns.cs:24:30:24:35 | After ... > ... [false] |
+| Patterns.cs:22:18:22:22 | After "xyz" [no-match] | Patterns.cs:24:30:24:35 | After ... > ... [true] |
+| Patterns.cs:22:18:22:22 | After "xyz" [no-match] | Patterns.cs:27:13:27:24 | case ...: |
+| Patterns.cs:22:18:22:22 | After "xyz" [no-match] | Patterns.cs:27:18:27:23 | After Int32 i3 [match] |
+| Patterns.cs:22:18:22:22 | After "xyz" [no-match] | Patterns.cs:27:18:27:23 | After Int32 i3 [no-match] |
+| Patterns.cs:22:18:22:22 | After "xyz" [no-match] | Patterns.cs:30:18:30:26 | After String s2 [match] |
+| Patterns.cs:22:18:22:22 | After "xyz" [no-match] | Patterns.cs:30:18:30:26 | After String s2 [no-match] |
+| Patterns.cs:22:18:22:22 | After "xyz" [no-match] | Patterns.cs:33:18:33:23 | After Object v2 [match] |
+| Patterns.cs:22:18:22:22 | After "xyz" [no-match] | Patterns.cs:33:18:33:23 | After Object v2 [no-match] |
+| Patterns.cs:24:18:24:23 | After Int32 i2 [match] | Patterns.cs:24:18:24:23 | After Int32 i2 [match] |
+| Patterns.cs:24:18:24:23 | After Int32 i2 [match] | Patterns.cs:24:30:24:35 | After ... > ... [false] |
+| Patterns.cs:24:18:24:23 | After Int32 i2 [match] | Patterns.cs:24:30:24:35 | After ... > ... [true] |
+| Patterns.cs:24:18:24:23 | After Int32 i2 [no-match] | Patterns.cs:24:18:24:23 | After Int32 i2 [no-match] |
 | Patterns.cs:24:30:24:35 | After ... > ... [false] | Patterns.cs:24:30:24:35 | After ... > ... [false] |
 | Patterns.cs:24:30:24:35 | After ... > ... [true] | Patterns.cs:24:30:24:35 | After ... > ... [true] |
-| Patterns.cs:27:13:27:24 | After case ...: [match] | Patterns.cs:27:13:27:24 | After case ...: [match] |
-| Patterns.cs:27:13:27:24 | After case ...: [no-match] | Patterns.cs:27:13:27:24 | After case ...: [no-match] |
-| Patterns.cs:27:13:27:24 | After case ...: [no-match] | Patterns.cs:30:13:30:27 | After case ...: [match] |
-| Patterns.cs:27:13:27:24 | After case ...: [no-match] | Patterns.cs:30:13:30:27 | After case ...: [no-match] |
-| Patterns.cs:27:13:27:24 | After case ...: [no-match] | Patterns.cs:33:13:33:24 | After case ...: [match] |
-| Patterns.cs:27:13:27:24 | After case ...: [no-match] | Patterns.cs:33:13:33:24 | After case ...: [no-match] |
-| Patterns.cs:27:13:27:24 | case ...: | Patterns.cs:27:13:27:24 | After case ...: [match] |
-| Patterns.cs:27:13:27:24 | case ...: | Patterns.cs:27:13:27:24 | After case ...: [no-match] |
 | Patterns.cs:27:13:27:24 | case ...: | Patterns.cs:27:13:27:24 | case ...: |
-| Patterns.cs:27:13:27:24 | case ...: | Patterns.cs:30:13:30:27 | After case ...: [match] |
-| Patterns.cs:27:13:27:24 | case ...: | Patterns.cs:30:13:30:27 | After case ...: [no-match] |
-| Patterns.cs:27:13:27:24 | case ...: | Patterns.cs:33:13:33:24 | After case ...: [match] |
-| Patterns.cs:27:13:27:24 | case ...: | Patterns.cs:33:13:33:24 | After case ...: [no-match] |
-| Patterns.cs:30:13:30:27 | After case ...: [match] | Patterns.cs:30:13:30:27 | After case ...: [match] |
-| Patterns.cs:30:13:30:27 | After case ...: [no-match] | Patterns.cs:30:13:30:27 | After case ...: [no-match] |
-| Patterns.cs:30:13:30:27 | After case ...: [no-match] | Patterns.cs:33:13:33:24 | After case ...: [match] |
-| Patterns.cs:30:13:30:27 | After case ...: [no-match] | Patterns.cs:33:13:33:24 | After case ...: [no-match] |
-| Patterns.cs:33:13:33:24 | After case ...: [match] | Patterns.cs:33:13:33:24 | After case ...: [match] |
-| Patterns.cs:33:13:33:24 | After case ...: [no-match] | Patterns.cs:33:13:33:24 | After case ...: [no-match] |
+| Patterns.cs:27:13:27:24 | case ...: | Patterns.cs:27:18:27:23 | After Int32 i3 [match] |
+| Patterns.cs:27:13:27:24 | case ...: | Patterns.cs:27:18:27:23 | After Int32 i3 [no-match] |
+| Patterns.cs:27:13:27:24 | case ...: | Patterns.cs:30:18:30:26 | After String s2 [match] |
+| Patterns.cs:27:13:27:24 | case ...: | Patterns.cs:30:18:30:26 | After String s2 [no-match] |
+| Patterns.cs:27:13:27:24 | case ...: | Patterns.cs:33:18:33:23 | After Object v2 [match] |
+| Patterns.cs:27:13:27:24 | case ...: | Patterns.cs:33:18:33:23 | After Object v2 [no-match] |
+| Patterns.cs:27:18:27:23 | After Int32 i3 [match] | Patterns.cs:27:18:27:23 | After Int32 i3 [match] |
+| Patterns.cs:27:18:27:23 | After Int32 i3 [no-match] | Patterns.cs:27:18:27:23 | After Int32 i3 [no-match] |
+| Patterns.cs:27:18:27:23 | After Int32 i3 [no-match] | Patterns.cs:30:18:30:26 | After String s2 [match] |
+| Patterns.cs:27:18:27:23 | After Int32 i3 [no-match] | Patterns.cs:30:18:30:26 | After String s2 [no-match] |
+| Patterns.cs:27:18:27:23 | After Int32 i3 [no-match] | Patterns.cs:33:18:33:23 | After Object v2 [match] |
+| Patterns.cs:27:18:27:23 | After Int32 i3 [no-match] | Patterns.cs:33:18:33:23 | After Object v2 [no-match] |
+| Patterns.cs:30:18:30:26 | After String s2 [match] | Patterns.cs:30:18:30:26 | After String s2 [match] |
+| Patterns.cs:30:18:30:26 | After String s2 [no-match] | Patterns.cs:30:18:30:26 | After String s2 [no-match] |
+| Patterns.cs:30:18:30:26 | After String s2 [no-match] | Patterns.cs:33:18:33:23 | After Object v2 [match] |
+| Patterns.cs:30:18:30:26 | After String s2 [no-match] | Patterns.cs:33:18:33:23 | After Object v2 [no-match] |
+| Patterns.cs:33:18:33:23 | After Object v2 [match] | Patterns.cs:33:18:33:23 | After Object v2 [match] |
+| Patterns.cs:33:18:33:23 | After Object v2 [no-match] | Patterns.cs:33:18:33:23 | After Object v2 [no-match] |
 | Patterns.cs:47:24:47:25 | Entry | Patterns.cs:47:24:47:25 | Entry |
 | Patterns.cs:47:24:47:25 | Entry | Patterns.cs:48:9:48:20 | After ... is ... |
 | Patterns.cs:47:24:47:25 | Entry | Patterns.cs:48:9:48:20 | [MatchTrue] ... is ... |
@@ -18502,45 +18693,45 @@ blockDominance
 | Patterns.cs:54:9:54:37 | [MatchTrue] ... is ... | Patterns.cs:54:9:54:37 | [MatchTrue] ... is ... |
 | Patterns.cs:56:26:56:27 | Entry | Patterns.cs:56:26:56:27 | Entry |
 | Patterns.cs:56:26:56:27 | Entry | Patterns.cs:58:16:62:9 | After ... switch { ... } |
-| Patterns.cs:56:26:56:27 | Entry | Patterns.cs:60:13:60:28 | After ... => ... [match] |
-| Patterns.cs:56:26:56:27 | Entry | Patterns.cs:60:13:60:28 | After ... => ... [no-match] |
+| Patterns.cs:56:26:56:27 | Entry | Patterns.cs:60:13:60:17 | After not ... [match] |
+| Patterns.cs:56:26:56:27 | Entry | Patterns.cs:60:13:60:17 | After not ... [no-match] |
 | Patterns.cs:58:16:62:9 | After ... switch { ... } | Patterns.cs:58:16:62:9 | After ... switch { ... } |
-| Patterns.cs:60:13:60:28 | After ... => ... [match] | Patterns.cs:60:13:60:28 | After ... => ... [match] |
-| Patterns.cs:60:13:60:28 | After ... => ... [no-match] | Patterns.cs:60:13:60:28 | After ... => ... [no-match] |
+| Patterns.cs:60:13:60:17 | After not ... [match] | Patterns.cs:60:13:60:17 | After not ... [match] |
+| Patterns.cs:60:13:60:17 | After not ... [no-match] | Patterns.cs:60:13:60:17 | After not ... [no-match] |
 | Patterns.cs:65:26:65:27 | Entry | Patterns.cs:65:26:65:27 | Entry |
 | Patterns.cs:65:26:65:27 | Entry | Patterns.cs:67:16:71:9 | After ... switch { ... } |
-| Patterns.cs:65:26:65:27 | Entry | Patterns.cs:69:13:69:33 | After ... => ... [match] |
-| Patterns.cs:65:26:65:27 | Entry | Patterns.cs:69:13:69:33 | After ... => ... [no-match] |
-| Patterns.cs:65:26:65:27 | Entry | Patterns.cs:70:13:70:27 | After ... => ... [match] |
-| Patterns.cs:65:26:65:27 | Entry | Patterns.cs:70:13:70:27 | After ... => ... [no-match] |
+| Patterns.cs:65:26:65:27 | Entry | Patterns.cs:69:13:69:17 | After not ... [match] |
+| Patterns.cs:65:26:65:27 | Entry | Patterns.cs:69:13:69:17 | After not ... [no-match] |
+| Patterns.cs:65:26:65:27 | Entry | Patterns.cs:70:13:70:13 | After 2 [match] |
+| Patterns.cs:65:26:65:27 | Entry | Patterns.cs:70:13:70:13 | After 2 [no-match] |
 | Patterns.cs:67:16:71:9 | After ... switch { ... } | Patterns.cs:67:16:71:9 | After ... switch { ... } |
-| Patterns.cs:69:13:69:33 | After ... => ... [match] | Patterns.cs:69:13:69:33 | After ... => ... [match] |
-| Patterns.cs:69:13:69:33 | After ... => ... [no-match] | Patterns.cs:69:13:69:33 | After ... => ... [no-match] |
-| Patterns.cs:69:13:69:33 | After ... => ... [no-match] | Patterns.cs:70:13:70:27 | After ... => ... [match] |
-| Patterns.cs:69:13:69:33 | After ... => ... [no-match] | Patterns.cs:70:13:70:27 | After ... => ... [no-match] |
-| Patterns.cs:70:13:70:27 | After ... => ... [match] | Patterns.cs:70:13:70:27 | After ... => ... [match] |
-| Patterns.cs:70:13:70:27 | After ... => ... [no-match] | Patterns.cs:70:13:70:27 | After ... => ... [no-match] |
+| Patterns.cs:69:13:69:17 | After not ... [match] | Patterns.cs:69:13:69:17 | After not ... [match] |
+| Patterns.cs:69:13:69:17 | After not ... [no-match] | Patterns.cs:69:13:69:17 | After not ... [no-match] |
+| Patterns.cs:69:13:69:17 | After not ... [no-match] | Patterns.cs:70:13:70:13 | After 2 [match] |
+| Patterns.cs:69:13:69:17 | After not ... [no-match] | Patterns.cs:70:13:70:13 | After 2 [no-match] |
+| Patterns.cs:70:13:70:13 | After 2 [match] | Patterns.cs:70:13:70:13 | After 2 [match] |
+| Patterns.cs:70:13:70:13 | After 2 [no-match] | Patterns.cs:70:13:70:13 | After 2 [no-match] |
 | Patterns.cs:74:26:74:27 | Entry | Patterns.cs:74:26:74:27 | Entry |
 | Patterns.cs:74:26:74:27 | Entry | Patterns.cs:76:16:82:9 | After ... switch { ... } |
-| Patterns.cs:74:26:74:27 | Entry | Patterns.cs:78:13:78:24 | After ... => ... [match] |
-| Patterns.cs:74:26:74:27 | Entry | Patterns.cs:78:13:78:24 | After ... => ... [no-match] |
-| Patterns.cs:74:26:74:27 | Entry | Patterns.cs:79:13:79:24 | After ... => ... [match] |
-| Patterns.cs:74:26:74:27 | Entry | Patterns.cs:79:13:79:24 | After ... => ... [no-match] |
-| Patterns.cs:74:26:74:27 | Entry | Patterns.cs:80:13:80:20 | After ... => ... [match] |
-| Patterns.cs:74:26:74:27 | Entry | Patterns.cs:80:13:80:20 | After ... => ... [no-match] |
+| Patterns.cs:74:26:74:27 | Entry | Patterns.cs:78:13:78:15 | After > ... [match] |
+| Patterns.cs:74:26:74:27 | Entry | Patterns.cs:78:13:78:15 | After > ... [no-match] |
+| Patterns.cs:74:26:74:27 | Entry | Patterns.cs:79:13:79:15 | After < ... [match] |
+| Patterns.cs:74:26:74:27 | Entry | Patterns.cs:79:13:79:15 | After < ... [no-match] |
+| Patterns.cs:74:26:74:27 | Entry | Patterns.cs:80:13:80:13 | After 1 [match] |
+| Patterns.cs:74:26:74:27 | Entry | Patterns.cs:80:13:80:13 | After 1 [no-match] |
 | Patterns.cs:76:16:82:9 | After ... switch { ... } | Patterns.cs:76:16:82:9 | After ... switch { ... } |
-| Patterns.cs:78:13:78:24 | After ... => ... [match] | Patterns.cs:78:13:78:24 | After ... => ... [match] |
-| Patterns.cs:78:13:78:24 | After ... => ... [no-match] | Patterns.cs:78:13:78:24 | After ... => ... [no-match] |
-| Patterns.cs:78:13:78:24 | After ... => ... [no-match] | Patterns.cs:79:13:79:24 | After ... => ... [match] |
-| Patterns.cs:78:13:78:24 | After ... => ... [no-match] | Patterns.cs:79:13:79:24 | After ... => ... [no-match] |
-| Patterns.cs:78:13:78:24 | After ... => ... [no-match] | Patterns.cs:80:13:80:20 | After ... => ... [match] |
-| Patterns.cs:78:13:78:24 | After ... => ... [no-match] | Patterns.cs:80:13:80:20 | After ... => ... [no-match] |
-| Patterns.cs:79:13:79:24 | After ... => ... [match] | Patterns.cs:79:13:79:24 | After ... => ... [match] |
-| Patterns.cs:79:13:79:24 | After ... => ... [no-match] | Patterns.cs:79:13:79:24 | After ... => ... [no-match] |
-| Patterns.cs:79:13:79:24 | After ... => ... [no-match] | Patterns.cs:80:13:80:20 | After ... => ... [match] |
-| Patterns.cs:79:13:79:24 | After ... => ... [no-match] | Patterns.cs:80:13:80:20 | After ... => ... [no-match] |
-| Patterns.cs:80:13:80:20 | After ... => ... [match] | Patterns.cs:80:13:80:20 | After ... => ... [match] |
-| Patterns.cs:80:13:80:20 | After ... => ... [no-match] | Patterns.cs:80:13:80:20 | After ... => ... [no-match] |
+| Patterns.cs:78:13:78:15 | After > ... [match] | Patterns.cs:78:13:78:15 | After > ... [match] |
+| Patterns.cs:78:13:78:15 | After > ... [no-match] | Patterns.cs:78:13:78:15 | After > ... [no-match] |
+| Patterns.cs:78:13:78:15 | After > ... [no-match] | Patterns.cs:79:13:79:15 | After < ... [match] |
+| Patterns.cs:78:13:78:15 | After > ... [no-match] | Patterns.cs:79:13:79:15 | After < ... [no-match] |
+| Patterns.cs:78:13:78:15 | After > ... [no-match] | Patterns.cs:80:13:80:13 | After 1 [match] |
+| Patterns.cs:78:13:78:15 | After > ... [no-match] | Patterns.cs:80:13:80:13 | After 1 [no-match] |
+| Patterns.cs:79:13:79:15 | After < ... [match] | Patterns.cs:79:13:79:15 | After < ... [match] |
+| Patterns.cs:79:13:79:15 | After < ... [no-match] | Patterns.cs:79:13:79:15 | After < ... [no-match] |
+| Patterns.cs:79:13:79:15 | After < ... [no-match] | Patterns.cs:80:13:80:13 | After 1 [match] |
+| Patterns.cs:79:13:79:15 | After < ... [no-match] | Patterns.cs:80:13:80:13 | After 1 [no-match] |
+| Patterns.cs:80:13:80:13 | After 1 [match] | Patterns.cs:80:13:80:13 | After 1 [match] |
+| Patterns.cs:80:13:80:13 | After 1 [no-match] | Patterns.cs:80:13:80:13 | After 1 [no-match] |
 | Patterns.cs:85:26:85:27 | Entry | Patterns.cs:85:26:85:27 | Entry |
 | Patterns.cs:85:26:85:27 | Entry | Patterns.cs:85:39:85:53 | After ... is ... [false] |
 | Patterns.cs:85:26:85:27 | Entry | Patterns.cs:85:39:85:53 | [MatchTrue] ... is ... |
@@ -18588,110 +18779,113 @@ blockDominance
 | Switch.cs:10:10:10:11 | Entry | Switch.cs:10:10:10:11 | Exceptional Exit |
 | Switch.cs:10:10:10:11 | Entry | Switch.cs:10:10:10:11 | Exit |
 | Switch.cs:10:10:10:11 | Entry | Switch.cs:10:10:10:11 | Normal Exit |
-| Switch.cs:10:10:10:11 | Entry | Switch.cs:14:13:14:21 | After case ...: [match] |
-| Switch.cs:10:10:10:11 | Entry | Switch.cs:14:13:14:21 | After case ...: [no-match] |
+| Switch.cs:10:10:10:11 | Entry | Switch.cs:14:18:14:20 | After "a" [match] |
+| Switch.cs:10:10:10:11 | Entry | Switch.cs:14:18:14:20 | After "a" [no-match] |
 | Switch.cs:10:10:10:11 | Entry | Switch.cs:16:13:16:19 | After case ...: [match] |
-| Switch.cs:10:10:10:11 | Entry | Switch.cs:16:13:16:19 | After case ...: [no-match] |
-| Switch.cs:10:10:10:11 | Entry | Switch.cs:18:13:18:22 | After case ...: [match] |
-| Switch.cs:10:10:10:11 | Entry | Switch.cs:18:13:18:22 | After case ...: [no-match] |
-| Switch.cs:10:10:10:11 | Entry | Switch.cs:20:13:20:23 | After case ...: [match] |
-| Switch.cs:10:10:10:11 | Entry | Switch.cs:20:13:20:23 | After case ...: [no-match] |
+| Switch.cs:10:10:10:11 | Entry | Switch.cs:16:18:16:18 | After 0 [match] |
+| Switch.cs:10:10:10:11 | Entry | Switch.cs:16:18:16:18 | After 0 [no-match] |
+| Switch.cs:10:10:10:11 | Entry | Switch.cs:18:18:18:21 | After null [match] |
+| Switch.cs:10:10:10:11 | Entry | Switch.cs:18:18:18:21 | After null [no-match] |
+| Switch.cs:10:10:10:11 | Entry | Switch.cs:20:18:20:22 | After Int32 i [match] |
+| Switch.cs:10:10:10:11 | Entry | Switch.cs:20:18:20:22 | After Int32 i [no-match] |
 | Switch.cs:10:10:10:11 | Entry | Switch.cs:21:21:21:29 | After ... == ... [false] |
 | Switch.cs:10:10:10:11 | Entry | Switch.cs:21:21:21:29 | After ... == ... [true] |
-| Switch.cs:10:10:10:11 | Entry | Switch.cs:24:13:24:56 | After case ...: [match] |
-| Switch.cs:10:10:10:11 | Entry | Switch.cs:24:13:24:56 | After case ...: [no-match] |
+| Switch.cs:10:10:10:11 | Entry | Switch.cs:24:18:24:25 | After String s [match] |
+| Switch.cs:10:10:10:11 | Entry | Switch.cs:24:18:24:25 | After String s [no-match] |
 | Switch.cs:10:10:10:11 | Entry | Switch.cs:24:32:24:43 | After ... > ... [false] |
 | Switch.cs:10:10:10:11 | Entry | Switch.cs:24:32:24:43 | After ... > ... [true] |
 | Switch.cs:10:10:10:11 | Entry | Switch.cs:24:32:24:55 | After ... && ... [false] |
 | Switch.cs:10:10:10:11 | Entry | Switch.cs:24:48:24:55 | After ... != ... [false] |
 | Switch.cs:10:10:10:11 | Entry | Switch.cs:24:48:24:55 | After ... != ... [true] |
-| Switch.cs:10:10:10:11 | Entry | Switch.cs:27:13:27:39 | After case ...: [match] |
-| Switch.cs:10:10:10:11 | Entry | Switch.cs:27:13:27:39 | After case ...: [no-match] |
 | Switch.cs:10:10:10:11 | Entry | Switch.cs:27:13:27:39 | case ...: |
+| Switch.cs:10:10:10:11 | Entry | Switch.cs:27:18:27:25 | After Double d [match] |
+| Switch.cs:10:10:10:11 | Entry | Switch.cs:27:18:27:25 | After Double d [no-match] |
 | Switch.cs:10:10:10:11 | Entry | Switch.cs:30:13:30:20 | After default: [match] |
 | Switch.cs:10:10:10:11 | Exceptional Exit | Switch.cs:10:10:10:11 | Exceptional Exit |
 | Switch.cs:10:10:10:11 | Exit | Switch.cs:10:10:10:11 | Exit |
 | Switch.cs:10:10:10:11 | Normal Exit | Switch.cs:10:10:10:11 | Normal Exit |
-| Switch.cs:14:13:14:21 | After case ...: [match] | Switch.cs:14:13:14:21 | After case ...: [match] |
-| Switch.cs:14:13:14:21 | After case ...: [no-match] | Switch.cs:10:10:10:11 | Exceptional Exit |
-| Switch.cs:14:13:14:21 | After case ...: [no-match] | Switch.cs:14:13:14:21 | After case ...: [no-match] |
-| Switch.cs:14:13:14:21 | After case ...: [no-match] | Switch.cs:16:13:16:19 | After case ...: [match] |
-| Switch.cs:14:13:14:21 | After case ...: [no-match] | Switch.cs:16:13:16:19 | After case ...: [no-match] |
-| Switch.cs:14:13:14:21 | After case ...: [no-match] | Switch.cs:18:13:18:22 | After case ...: [match] |
-| Switch.cs:14:13:14:21 | After case ...: [no-match] | Switch.cs:18:13:18:22 | After case ...: [no-match] |
-| Switch.cs:14:13:14:21 | After case ...: [no-match] | Switch.cs:20:13:20:23 | After case ...: [match] |
-| Switch.cs:14:13:14:21 | After case ...: [no-match] | Switch.cs:20:13:20:23 | After case ...: [no-match] |
-| Switch.cs:14:13:14:21 | After case ...: [no-match] | Switch.cs:21:21:21:29 | After ... == ... [false] |
-| Switch.cs:14:13:14:21 | After case ...: [no-match] | Switch.cs:21:21:21:29 | After ... == ... [true] |
-| Switch.cs:14:13:14:21 | After case ...: [no-match] | Switch.cs:24:13:24:56 | After case ...: [match] |
-| Switch.cs:14:13:14:21 | After case ...: [no-match] | Switch.cs:24:13:24:56 | After case ...: [no-match] |
-| Switch.cs:14:13:14:21 | After case ...: [no-match] | Switch.cs:24:32:24:43 | After ... > ... [false] |
-| Switch.cs:14:13:14:21 | After case ...: [no-match] | Switch.cs:24:32:24:43 | After ... > ... [true] |
-| Switch.cs:14:13:14:21 | After case ...: [no-match] | Switch.cs:24:32:24:55 | After ... && ... [false] |
-| Switch.cs:14:13:14:21 | After case ...: [no-match] | Switch.cs:24:48:24:55 | After ... != ... [false] |
-| Switch.cs:14:13:14:21 | After case ...: [no-match] | Switch.cs:24:48:24:55 | After ... != ... [true] |
-| Switch.cs:14:13:14:21 | After case ...: [no-match] | Switch.cs:27:13:27:39 | After case ...: [match] |
-| Switch.cs:14:13:14:21 | After case ...: [no-match] | Switch.cs:27:13:27:39 | After case ...: [no-match] |
-| Switch.cs:14:13:14:21 | After case ...: [no-match] | Switch.cs:27:13:27:39 | case ...: |
-| Switch.cs:14:13:14:21 | After case ...: [no-match] | Switch.cs:30:13:30:20 | After default: [match] |
+| Switch.cs:14:18:14:20 | After "a" [match] | Switch.cs:14:18:14:20 | After "a" [match] |
+| Switch.cs:14:18:14:20 | After "a" [no-match] | Switch.cs:10:10:10:11 | Exceptional Exit |
+| Switch.cs:14:18:14:20 | After "a" [no-match] | Switch.cs:14:18:14:20 | After "a" [no-match] |
+| Switch.cs:14:18:14:20 | After "a" [no-match] | Switch.cs:16:13:16:19 | After case ...: [match] |
+| Switch.cs:14:18:14:20 | After "a" [no-match] | Switch.cs:16:18:16:18 | After 0 [match] |
+| Switch.cs:14:18:14:20 | After "a" [no-match] | Switch.cs:16:18:16:18 | After 0 [no-match] |
+| Switch.cs:14:18:14:20 | After "a" [no-match] | Switch.cs:18:18:18:21 | After null [match] |
+| Switch.cs:14:18:14:20 | After "a" [no-match] | Switch.cs:18:18:18:21 | After null [no-match] |
+| Switch.cs:14:18:14:20 | After "a" [no-match] | Switch.cs:20:18:20:22 | After Int32 i [match] |
+| Switch.cs:14:18:14:20 | After "a" [no-match] | Switch.cs:20:18:20:22 | After Int32 i [no-match] |
+| Switch.cs:14:18:14:20 | After "a" [no-match] | Switch.cs:21:21:21:29 | After ... == ... [false] |
+| Switch.cs:14:18:14:20 | After "a" [no-match] | Switch.cs:21:21:21:29 | After ... == ... [true] |
+| Switch.cs:14:18:14:20 | After "a" [no-match] | Switch.cs:24:18:24:25 | After String s [match] |
+| Switch.cs:14:18:14:20 | After "a" [no-match] | Switch.cs:24:18:24:25 | After String s [no-match] |
+| Switch.cs:14:18:14:20 | After "a" [no-match] | Switch.cs:24:32:24:43 | After ... > ... [false] |
+| Switch.cs:14:18:14:20 | After "a" [no-match] | Switch.cs:24:32:24:43 | After ... > ... [true] |
+| Switch.cs:14:18:14:20 | After "a" [no-match] | Switch.cs:24:32:24:55 | After ... && ... [false] |
+| Switch.cs:14:18:14:20 | After "a" [no-match] | Switch.cs:24:48:24:55 | After ... != ... [false] |
+| Switch.cs:14:18:14:20 | After "a" [no-match] | Switch.cs:24:48:24:55 | After ... != ... [true] |
+| Switch.cs:14:18:14:20 | After "a" [no-match] | Switch.cs:27:13:27:39 | case ...: |
+| Switch.cs:14:18:14:20 | After "a" [no-match] | Switch.cs:27:18:27:25 | After Double d [match] |
+| Switch.cs:14:18:14:20 | After "a" [no-match] | Switch.cs:27:18:27:25 | After Double d [no-match] |
+| Switch.cs:14:18:14:20 | After "a" [no-match] | Switch.cs:30:13:30:20 | After default: [match] |
 | Switch.cs:16:13:16:19 | After case ...: [match] | Switch.cs:16:13:16:19 | After case ...: [match] |
-| Switch.cs:16:13:16:19 | After case ...: [no-match] | Switch.cs:16:13:16:19 | After case ...: [no-match] |
-| Switch.cs:16:13:16:19 | After case ...: [no-match] | Switch.cs:18:13:18:22 | After case ...: [match] |
-| Switch.cs:16:13:16:19 | After case ...: [no-match] | Switch.cs:18:13:18:22 | After case ...: [no-match] |
-| Switch.cs:16:13:16:19 | After case ...: [no-match] | Switch.cs:20:13:20:23 | After case ...: [match] |
-| Switch.cs:16:13:16:19 | After case ...: [no-match] | Switch.cs:20:13:20:23 | After case ...: [no-match] |
-| Switch.cs:16:13:16:19 | After case ...: [no-match] | Switch.cs:21:21:21:29 | After ... == ... [false] |
-| Switch.cs:16:13:16:19 | After case ...: [no-match] | Switch.cs:21:21:21:29 | After ... == ... [true] |
-| Switch.cs:16:13:16:19 | After case ...: [no-match] | Switch.cs:24:13:24:56 | After case ...: [match] |
-| Switch.cs:16:13:16:19 | After case ...: [no-match] | Switch.cs:24:13:24:56 | After case ...: [no-match] |
-| Switch.cs:16:13:16:19 | After case ...: [no-match] | Switch.cs:24:32:24:43 | After ... > ... [false] |
-| Switch.cs:16:13:16:19 | After case ...: [no-match] | Switch.cs:24:32:24:43 | After ... > ... [true] |
-| Switch.cs:16:13:16:19 | After case ...: [no-match] | Switch.cs:24:32:24:55 | After ... && ... [false] |
-| Switch.cs:16:13:16:19 | After case ...: [no-match] | Switch.cs:24:48:24:55 | After ... != ... [false] |
-| Switch.cs:16:13:16:19 | After case ...: [no-match] | Switch.cs:24:48:24:55 | After ... != ... [true] |
-| Switch.cs:16:13:16:19 | After case ...: [no-match] | Switch.cs:27:13:27:39 | After case ...: [match] |
-| Switch.cs:16:13:16:19 | After case ...: [no-match] | Switch.cs:27:13:27:39 | After case ...: [no-match] |
-| Switch.cs:16:13:16:19 | After case ...: [no-match] | Switch.cs:27:13:27:39 | case ...: |
-| Switch.cs:16:13:16:19 | After case ...: [no-match] | Switch.cs:30:13:30:20 | After default: [match] |
-| Switch.cs:18:13:18:22 | After case ...: [match] | Switch.cs:18:13:18:22 | After case ...: [match] |
-| Switch.cs:18:13:18:22 | After case ...: [no-match] | Switch.cs:18:13:18:22 | After case ...: [no-match] |
-| Switch.cs:18:13:18:22 | After case ...: [no-match] | Switch.cs:20:13:20:23 | After case ...: [match] |
-| Switch.cs:18:13:18:22 | After case ...: [no-match] | Switch.cs:20:13:20:23 | After case ...: [no-match] |
-| Switch.cs:18:13:18:22 | After case ...: [no-match] | Switch.cs:21:21:21:29 | After ... == ... [false] |
-| Switch.cs:18:13:18:22 | After case ...: [no-match] | Switch.cs:21:21:21:29 | After ... == ... [true] |
-| Switch.cs:18:13:18:22 | After case ...: [no-match] | Switch.cs:24:13:24:56 | After case ...: [match] |
-| Switch.cs:18:13:18:22 | After case ...: [no-match] | Switch.cs:24:13:24:56 | After case ...: [no-match] |
-| Switch.cs:18:13:18:22 | After case ...: [no-match] | Switch.cs:24:32:24:43 | After ... > ... [false] |
-| Switch.cs:18:13:18:22 | After case ...: [no-match] | Switch.cs:24:32:24:43 | After ... > ... [true] |
-| Switch.cs:18:13:18:22 | After case ...: [no-match] | Switch.cs:24:32:24:55 | After ... && ... [false] |
-| Switch.cs:18:13:18:22 | After case ...: [no-match] | Switch.cs:24:48:24:55 | After ... != ... [false] |
-| Switch.cs:18:13:18:22 | After case ...: [no-match] | Switch.cs:24:48:24:55 | After ... != ... [true] |
-| Switch.cs:18:13:18:22 | After case ...: [no-match] | Switch.cs:27:13:27:39 | After case ...: [match] |
-| Switch.cs:18:13:18:22 | After case ...: [no-match] | Switch.cs:27:13:27:39 | After case ...: [no-match] |
-| Switch.cs:18:13:18:22 | After case ...: [no-match] | Switch.cs:27:13:27:39 | case ...: |
-| Switch.cs:20:13:20:23 | After case ...: [match] | Switch.cs:20:13:20:23 | After case ...: [match] |
-| Switch.cs:20:13:20:23 | After case ...: [match] | Switch.cs:21:21:21:29 | After ... == ... [false] |
-| Switch.cs:20:13:20:23 | After case ...: [match] | Switch.cs:21:21:21:29 | After ... == ... [true] |
-| Switch.cs:20:13:20:23 | After case ...: [no-match] | Switch.cs:20:13:20:23 | After case ...: [no-match] |
-| Switch.cs:20:13:20:23 | After case ...: [no-match] | Switch.cs:24:13:24:56 | After case ...: [match] |
-| Switch.cs:20:13:20:23 | After case ...: [no-match] | Switch.cs:24:13:24:56 | After case ...: [no-match] |
-| Switch.cs:20:13:20:23 | After case ...: [no-match] | Switch.cs:24:32:24:43 | After ... > ... [false] |
-| Switch.cs:20:13:20:23 | After case ...: [no-match] | Switch.cs:24:32:24:43 | After ... > ... [true] |
-| Switch.cs:20:13:20:23 | After case ...: [no-match] | Switch.cs:24:32:24:55 | After ... && ... [false] |
-| Switch.cs:20:13:20:23 | After case ...: [no-match] | Switch.cs:24:48:24:55 | After ... != ... [false] |
-| Switch.cs:20:13:20:23 | After case ...: [no-match] | Switch.cs:24:48:24:55 | After ... != ... [true] |
-| Switch.cs:20:13:20:23 | After case ...: [no-match] | Switch.cs:27:13:27:39 | After case ...: [match] |
-| Switch.cs:20:13:20:23 | After case ...: [no-match] | Switch.cs:27:13:27:39 | After case ...: [no-match] |
-| Switch.cs:20:13:20:23 | After case ...: [no-match] | Switch.cs:27:13:27:39 | case ...: |
+| Switch.cs:16:18:16:18 | After 0 [match] | Switch.cs:16:18:16:18 | After 0 [match] |
+| Switch.cs:16:18:16:18 | After 0 [no-match] | Switch.cs:16:18:16:18 | After 0 [no-match] |
+| Switch.cs:16:18:16:18 | After 0 [no-match] | Switch.cs:18:18:18:21 | After null [match] |
+| Switch.cs:16:18:16:18 | After 0 [no-match] | Switch.cs:18:18:18:21 | After null [no-match] |
+| Switch.cs:16:18:16:18 | After 0 [no-match] | Switch.cs:20:18:20:22 | After Int32 i [match] |
+| Switch.cs:16:18:16:18 | After 0 [no-match] | Switch.cs:20:18:20:22 | After Int32 i [no-match] |
+| Switch.cs:16:18:16:18 | After 0 [no-match] | Switch.cs:21:21:21:29 | After ... == ... [false] |
+| Switch.cs:16:18:16:18 | After 0 [no-match] | Switch.cs:21:21:21:29 | After ... == ... [true] |
+| Switch.cs:16:18:16:18 | After 0 [no-match] | Switch.cs:24:18:24:25 | After String s [match] |
+| Switch.cs:16:18:16:18 | After 0 [no-match] | Switch.cs:24:18:24:25 | After String s [no-match] |
+| Switch.cs:16:18:16:18 | After 0 [no-match] | Switch.cs:24:32:24:43 | After ... > ... [false] |
+| Switch.cs:16:18:16:18 | After 0 [no-match] | Switch.cs:24:32:24:43 | After ... > ... [true] |
+| Switch.cs:16:18:16:18 | After 0 [no-match] | Switch.cs:24:32:24:55 | After ... && ... [false] |
+| Switch.cs:16:18:16:18 | After 0 [no-match] | Switch.cs:24:48:24:55 | After ... != ... [false] |
+| Switch.cs:16:18:16:18 | After 0 [no-match] | Switch.cs:24:48:24:55 | After ... != ... [true] |
+| Switch.cs:16:18:16:18 | After 0 [no-match] | Switch.cs:27:13:27:39 | case ...: |
+| Switch.cs:16:18:16:18 | After 0 [no-match] | Switch.cs:27:18:27:25 | After Double d [match] |
+| Switch.cs:16:18:16:18 | After 0 [no-match] | Switch.cs:27:18:27:25 | After Double d [no-match] |
+| Switch.cs:16:18:16:18 | After 0 [no-match] | Switch.cs:30:13:30:20 | After default: [match] |
+| Switch.cs:18:18:18:21 | After null [match] | Switch.cs:18:18:18:21 | After null [match] |
+| Switch.cs:18:18:18:21 | After null [no-match] | Switch.cs:18:18:18:21 | After null [no-match] |
+| Switch.cs:18:18:18:21 | After null [no-match] | Switch.cs:20:18:20:22 | After Int32 i [match] |
+| Switch.cs:18:18:18:21 | After null [no-match] | Switch.cs:20:18:20:22 | After Int32 i [no-match] |
+| Switch.cs:18:18:18:21 | After null [no-match] | Switch.cs:21:21:21:29 | After ... == ... [false] |
+| Switch.cs:18:18:18:21 | After null [no-match] | Switch.cs:21:21:21:29 | After ... == ... [true] |
+| Switch.cs:18:18:18:21 | After null [no-match] | Switch.cs:24:18:24:25 | After String s [match] |
+| Switch.cs:18:18:18:21 | After null [no-match] | Switch.cs:24:18:24:25 | After String s [no-match] |
+| Switch.cs:18:18:18:21 | After null [no-match] | Switch.cs:24:32:24:43 | After ... > ... [false] |
+| Switch.cs:18:18:18:21 | After null [no-match] | Switch.cs:24:32:24:43 | After ... > ... [true] |
+| Switch.cs:18:18:18:21 | After null [no-match] | Switch.cs:24:32:24:55 | After ... && ... [false] |
+| Switch.cs:18:18:18:21 | After null [no-match] | Switch.cs:24:48:24:55 | After ... != ... [false] |
+| Switch.cs:18:18:18:21 | After null [no-match] | Switch.cs:24:48:24:55 | After ... != ... [true] |
+| Switch.cs:18:18:18:21 | After null [no-match] | Switch.cs:27:13:27:39 | case ...: |
+| Switch.cs:18:18:18:21 | After null [no-match] | Switch.cs:27:18:27:25 | After Double d [match] |
+| Switch.cs:18:18:18:21 | After null [no-match] | Switch.cs:27:18:27:25 | After Double d [no-match] |
+| Switch.cs:20:18:20:22 | After Int32 i [match] | Switch.cs:20:18:20:22 | After Int32 i [match] |
+| Switch.cs:20:18:20:22 | After Int32 i [match] | Switch.cs:21:21:21:29 | After ... == ... [false] |
+| Switch.cs:20:18:20:22 | After Int32 i [match] | Switch.cs:21:21:21:29 | After ... == ... [true] |
+| Switch.cs:20:18:20:22 | After Int32 i [no-match] | Switch.cs:20:18:20:22 | After Int32 i [no-match] |
+| Switch.cs:20:18:20:22 | After Int32 i [no-match] | Switch.cs:24:18:24:25 | After String s [match] |
+| Switch.cs:20:18:20:22 | After Int32 i [no-match] | Switch.cs:24:18:24:25 | After String s [no-match] |
+| Switch.cs:20:18:20:22 | After Int32 i [no-match] | Switch.cs:24:32:24:43 | After ... > ... [false] |
+| Switch.cs:20:18:20:22 | After Int32 i [no-match] | Switch.cs:24:32:24:43 | After ... > ... [true] |
+| Switch.cs:20:18:20:22 | After Int32 i [no-match] | Switch.cs:24:32:24:55 | After ... && ... [false] |
+| Switch.cs:20:18:20:22 | After Int32 i [no-match] | Switch.cs:24:48:24:55 | After ... != ... [false] |
+| Switch.cs:20:18:20:22 | After Int32 i [no-match] | Switch.cs:24:48:24:55 | After ... != ... [true] |
+| Switch.cs:20:18:20:22 | After Int32 i [no-match] | Switch.cs:27:13:27:39 | case ...: |
+| Switch.cs:20:18:20:22 | After Int32 i [no-match] | Switch.cs:27:18:27:25 | After Double d [match] |
+| Switch.cs:20:18:20:22 | After Int32 i [no-match] | Switch.cs:27:18:27:25 | After Double d [no-match] |
 | Switch.cs:21:21:21:29 | After ... == ... [false] | Switch.cs:21:21:21:29 | After ... == ... [false] |
 | Switch.cs:21:21:21:29 | After ... == ... [true] | Switch.cs:21:21:21:29 | After ... == ... [true] |
-| Switch.cs:24:13:24:56 | After case ...: [match] | Switch.cs:24:13:24:56 | After case ...: [match] |
-| Switch.cs:24:13:24:56 | After case ...: [match] | Switch.cs:24:32:24:43 | After ... > ... [false] |
-| Switch.cs:24:13:24:56 | After case ...: [match] | Switch.cs:24:32:24:43 | After ... > ... [true] |
-| Switch.cs:24:13:24:56 | After case ...: [match] | Switch.cs:24:32:24:55 | After ... && ... [false] |
-| Switch.cs:24:13:24:56 | After case ...: [match] | Switch.cs:24:48:24:55 | After ... != ... [false] |
-| Switch.cs:24:13:24:56 | After case ...: [match] | Switch.cs:24:48:24:55 | After ... != ... [true] |
-| Switch.cs:24:13:24:56 | After case ...: [no-match] | Switch.cs:24:13:24:56 | After case ...: [no-match] |
+| Switch.cs:24:18:24:25 | After String s [match] | Switch.cs:24:18:24:25 | After String s [match] |
+| Switch.cs:24:18:24:25 | After String s [match] | Switch.cs:24:32:24:43 | After ... > ... [false] |
+| Switch.cs:24:18:24:25 | After String s [match] | Switch.cs:24:32:24:43 | After ... > ... [true] |
+| Switch.cs:24:18:24:25 | After String s [match] | Switch.cs:24:32:24:55 | After ... && ... [false] |
+| Switch.cs:24:18:24:25 | After String s [match] | Switch.cs:24:48:24:55 | After ... != ... [false] |
+| Switch.cs:24:18:24:25 | After String s [match] | Switch.cs:24:48:24:55 | After ... != ... [true] |
+| Switch.cs:24:18:24:25 | After String s [no-match] | Switch.cs:24:18:24:25 | After String s [no-match] |
 | Switch.cs:24:32:24:43 | After ... > ... [false] | Switch.cs:24:32:24:43 | After ... > ... [false] |
 | Switch.cs:24:32:24:43 | After ... > ... [true] | Switch.cs:24:32:24:43 | After ... > ... [true] |
 | Switch.cs:24:32:24:43 | After ... > ... [true] | Switch.cs:24:48:24:55 | After ... != ... [false] |
@@ -18699,202 +18893,202 @@ blockDominance
 | Switch.cs:24:32:24:55 | After ... && ... [false] | Switch.cs:24:32:24:55 | After ... && ... [false] |
 | Switch.cs:24:48:24:55 | After ... != ... [false] | Switch.cs:24:48:24:55 | After ... != ... [false] |
 | Switch.cs:24:48:24:55 | After ... != ... [true] | Switch.cs:24:48:24:55 | After ... != ... [true] |
-| Switch.cs:27:13:27:39 | After case ...: [match] | Switch.cs:27:13:27:39 | After case ...: [match] |
-| Switch.cs:27:13:27:39 | After case ...: [no-match] | Switch.cs:27:13:27:39 | After case ...: [no-match] |
-| Switch.cs:27:13:27:39 | case ...: | Switch.cs:27:13:27:39 | After case ...: [match] |
-| Switch.cs:27:13:27:39 | case ...: | Switch.cs:27:13:27:39 | After case ...: [no-match] |
 | Switch.cs:27:13:27:39 | case ...: | Switch.cs:27:13:27:39 | case ...: |
+| Switch.cs:27:13:27:39 | case ...: | Switch.cs:27:18:27:25 | After Double d [match] |
+| Switch.cs:27:13:27:39 | case ...: | Switch.cs:27:18:27:25 | After Double d [no-match] |
+| Switch.cs:27:18:27:25 | After Double d [match] | Switch.cs:27:18:27:25 | After Double d [match] |
+| Switch.cs:27:18:27:25 | After Double d [no-match] | Switch.cs:27:18:27:25 | After Double d [no-match] |
 | Switch.cs:30:13:30:20 | After default: [match] | Switch.cs:30:13:30:20 | After default: [match] |
 | Switch.cs:35:10:35:11 | Entry | Switch.cs:35:10:35:11 | Entry |
 | Switch.cs:44:10:44:11 | Entry | Switch.cs:44:10:44:11 | Entry |
 | Switch.cs:44:10:44:11 | Entry | Switch.cs:46:9:52:9 | After switch (...) {...} |
-| Switch.cs:44:10:44:11 | Entry | Switch.cs:48:13:48:23 | After case ...: [match] |
-| Switch.cs:44:10:44:11 | Entry | Switch.cs:48:13:48:23 | After case ...: [no-match] |
-| Switch.cs:44:10:44:11 | Entry | Switch.cs:50:13:50:39 | After case ...: [match] |
-| Switch.cs:44:10:44:11 | Entry | Switch.cs:50:13:50:39 | After case ...: [no-match] |
+| Switch.cs:44:10:44:11 | Entry | Switch.cs:48:18:48:20 | After access to type Int32 [match] |
+| Switch.cs:44:10:44:11 | Entry | Switch.cs:48:18:48:20 | After access to type Int32 [no-match] |
+| Switch.cs:44:10:44:11 | Entry | Switch.cs:50:18:50:21 | After access to type Boolean [match] |
+| Switch.cs:44:10:44:11 | Entry | Switch.cs:50:18:50:21 | After access to type Boolean [no-match] |
 | Switch.cs:44:10:44:11 | Entry | Switch.cs:50:30:50:38 | After ... != ... [false] |
 | Switch.cs:44:10:44:11 | Entry | Switch.cs:50:30:50:38 | After ... != ... [true] |
 | Switch.cs:46:9:52:9 | After switch (...) {...} | Switch.cs:46:9:52:9 | After switch (...) {...} |
-| Switch.cs:48:13:48:23 | After case ...: [match] | Switch.cs:48:13:48:23 | After case ...: [match] |
-| Switch.cs:48:13:48:23 | After case ...: [no-match] | Switch.cs:48:13:48:23 | After case ...: [no-match] |
-| Switch.cs:48:13:48:23 | After case ...: [no-match] | Switch.cs:50:13:50:39 | After case ...: [match] |
-| Switch.cs:48:13:48:23 | After case ...: [no-match] | Switch.cs:50:13:50:39 | After case ...: [no-match] |
-| Switch.cs:48:13:48:23 | After case ...: [no-match] | Switch.cs:50:30:50:38 | After ... != ... [false] |
-| Switch.cs:48:13:48:23 | After case ...: [no-match] | Switch.cs:50:30:50:38 | After ... != ... [true] |
-| Switch.cs:50:13:50:39 | After case ...: [match] | Switch.cs:50:13:50:39 | After case ...: [match] |
-| Switch.cs:50:13:50:39 | After case ...: [match] | Switch.cs:50:30:50:38 | After ... != ... [false] |
-| Switch.cs:50:13:50:39 | After case ...: [match] | Switch.cs:50:30:50:38 | After ... != ... [true] |
-| Switch.cs:50:13:50:39 | After case ...: [no-match] | Switch.cs:50:13:50:39 | After case ...: [no-match] |
+| Switch.cs:48:18:48:20 | After access to type Int32 [match] | Switch.cs:48:18:48:20 | After access to type Int32 [match] |
+| Switch.cs:48:18:48:20 | After access to type Int32 [no-match] | Switch.cs:48:18:48:20 | After access to type Int32 [no-match] |
+| Switch.cs:48:18:48:20 | After access to type Int32 [no-match] | Switch.cs:50:18:50:21 | After access to type Boolean [match] |
+| Switch.cs:48:18:48:20 | After access to type Int32 [no-match] | Switch.cs:50:18:50:21 | After access to type Boolean [no-match] |
+| Switch.cs:48:18:48:20 | After access to type Int32 [no-match] | Switch.cs:50:30:50:38 | After ... != ... [false] |
+| Switch.cs:48:18:48:20 | After access to type Int32 [no-match] | Switch.cs:50:30:50:38 | After ... != ... [true] |
+| Switch.cs:50:18:50:21 | After access to type Boolean [match] | Switch.cs:50:18:50:21 | After access to type Boolean [match] |
+| Switch.cs:50:18:50:21 | After access to type Boolean [match] | Switch.cs:50:30:50:38 | After ... != ... [false] |
+| Switch.cs:50:18:50:21 | After access to type Boolean [match] | Switch.cs:50:30:50:38 | After ... != ... [true] |
+| Switch.cs:50:18:50:21 | After access to type Boolean [no-match] | Switch.cs:50:18:50:21 | After access to type Boolean [no-match] |
 | Switch.cs:50:30:50:38 | After ... != ... [false] | Switch.cs:50:30:50:38 | After ... != ... [false] |
 | Switch.cs:50:30:50:38 | After ... != ... [true] | Switch.cs:50:30:50:38 | After ... != ... [true] |
 | Switch.cs:55:10:55:11 | Entry | Switch.cs:55:10:55:11 | Entry |
 | Switch.cs:55:10:55:11 | Entry | Switch.cs:57:9:63:9 | After switch (...) {...} |
-| Switch.cs:55:10:55:11 | Entry | Switch.cs:59:13:59:19 | After case ...: [match] |
-| Switch.cs:55:10:55:11 | Entry | Switch.cs:59:13:59:19 | After case ...: [no-match] |
-| Switch.cs:55:10:55:11 | Entry | Switch.cs:61:13:61:19 | After case ...: [match] |
-| Switch.cs:55:10:55:11 | Entry | Switch.cs:61:13:61:19 | After case ...: [no-match] |
+| Switch.cs:55:10:55:11 | Entry | Switch.cs:59:18:59:18 | After 2 [match] |
+| Switch.cs:55:10:55:11 | Entry | Switch.cs:59:18:59:18 | After 2 [no-match] |
+| Switch.cs:55:10:55:11 | Entry | Switch.cs:61:18:61:18 | After 3 [match] |
+| Switch.cs:55:10:55:11 | Entry | Switch.cs:61:18:61:18 | After 3 [no-match] |
 | Switch.cs:57:9:63:9 | After switch (...) {...} | Switch.cs:57:9:63:9 | After switch (...) {...} |
-| Switch.cs:59:13:59:19 | After case ...: [match] | Switch.cs:59:13:59:19 | After case ...: [match] |
-| Switch.cs:59:13:59:19 | After case ...: [no-match] | Switch.cs:59:13:59:19 | After case ...: [no-match] |
-| Switch.cs:59:13:59:19 | After case ...: [no-match] | Switch.cs:61:13:61:19 | After case ...: [match] |
-| Switch.cs:59:13:59:19 | After case ...: [no-match] | Switch.cs:61:13:61:19 | After case ...: [no-match] |
-| Switch.cs:61:13:61:19 | After case ...: [match] | Switch.cs:61:13:61:19 | After case ...: [match] |
-| Switch.cs:61:13:61:19 | After case ...: [no-match] | Switch.cs:61:13:61:19 | After case ...: [no-match] |
+| Switch.cs:59:18:59:18 | After 2 [match] | Switch.cs:59:18:59:18 | After 2 [match] |
+| Switch.cs:59:18:59:18 | After 2 [no-match] | Switch.cs:59:18:59:18 | After 2 [no-match] |
+| Switch.cs:59:18:59:18 | After 2 [no-match] | Switch.cs:61:18:61:18 | After 3 [match] |
+| Switch.cs:59:18:59:18 | After 2 [no-match] | Switch.cs:61:18:61:18 | After 3 [no-match] |
+| Switch.cs:61:18:61:18 | After 3 [match] | Switch.cs:61:18:61:18 | After 3 [match] |
+| Switch.cs:61:18:61:18 | After 3 [no-match] | Switch.cs:61:18:61:18 | After 3 [no-match] |
 | Switch.cs:66:10:66:11 | Entry | Switch.cs:66:10:66:11 | Entry |
 | Switch.cs:66:10:66:11 | Entry | Switch.cs:68:9:74:9 | After switch (...) {...} |
-| Switch.cs:66:10:66:11 | Entry | Switch.cs:70:13:70:23 | After case ...: [match] |
-| Switch.cs:66:10:66:11 | Entry | Switch.cs:70:13:70:23 | After case ...: [no-match] |
-| Switch.cs:66:10:66:11 | Entry | Switch.cs:72:13:72:20 | After case ...: [match] |
-| Switch.cs:66:10:66:11 | Entry | Switch.cs:72:13:72:20 | After case ...: [no-match] |
+| Switch.cs:66:10:66:11 | Entry | Switch.cs:70:18:70:20 | After access to type Int32 [match] |
+| Switch.cs:66:10:66:11 | Entry | Switch.cs:70:18:70:20 | After access to type Int32 [no-match] |
+| Switch.cs:66:10:66:11 | Entry | Switch.cs:72:18:72:19 | After "" [match] |
+| Switch.cs:66:10:66:11 | Entry | Switch.cs:72:18:72:19 | After "" [no-match] |
 | Switch.cs:68:9:74:9 | After switch (...) {...} | Switch.cs:68:9:74:9 | After switch (...) {...} |
-| Switch.cs:70:13:70:23 | After case ...: [match] | Switch.cs:70:13:70:23 | After case ...: [match] |
-| Switch.cs:70:13:70:23 | After case ...: [no-match] | Switch.cs:70:13:70:23 | After case ...: [no-match] |
-| Switch.cs:70:13:70:23 | After case ...: [no-match] | Switch.cs:72:13:72:20 | After case ...: [match] |
-| Switch.cs:70:13:70:23 | After case ...: [no-match] | Switch.cs:72:13:72:20 | After case ...: [no-match] |
-| Switch.cs:72:13:72:20 | After case ...: [match] | Switch.cs:72:13:72:20 | After case ...: [match] |
-| Switch.cs:72:13:72:20 | After case ...: [no-match] | Switch.cs:72:13:72:20 | After case ...: [no-match] |
+| Switch.cs:70:18:70:20 | After access to type Int32 [match] | Switch.cs:70:18:70:20 | After access to type Int32 [match] |
+| Switch.cs:70:18:70:20 | After access to type Int32 [no-match] | Switch.cs:70:18:70:20 | After access to type Int32 [no-match] |
+| Switch.cs:70:18:70:20 | After access to type Int32 [no-match] | Switch.cs:72:18:72:19 | After "" [match] |
+| Switch.cs:70:18:70:20 | After access to type Int32 [no-match] | Switch.cs:72:18:72:19 | After "" [no-match] |
+| Switch.cs:72:18:72:19 | After "" [match] | Switch.cs:72:18:72:19 | After "" [match] |
+| Switch.cs:72:18:72:19 | After "" [no-match] | Switch.cs:72:18:72:19 | After "" [no-match] |
 | Switch.cs:77:10:77:11 | Entry | Switch.cs:77:10:77:11 | Entry |
 | Switch.cs:77:10:77:11 | Entry | Switch.cs:77:10:77:11 | Normal Exit |
 | Switch.cs:77:10:77:11 | Entry | Switch.cs:79:9:87:9 | After switch (...) {...} |
-| Switch.cs:77:10:77:11 | Entry | Switch.cs:81:13:81:19 | After case ...: [match] |
-| Switch.cs:77:10:77:11 | Entry | Switch.cs:81:13:81:19 | After case ...: [no-match] |
-| Switch.cs:77:10:77:11 | Entry | Switch.cs:83:13:83:19 | After case ...: [match] |
-| Switch.cs:77:10:77:11 | Entry | Switch.cs:83:13:83:19 | After case ...: [no-match] |
+| Switch.cs:77:10:77:11 | Entry | Switch.cs:81:18:81:18 | After 1 [match] |
+| Switch.cs:77:10:77:11 | Entry | Switch.cs:81:18:81:18 | After 1 [no-match] |
+| Switch.cs:77:10:77:11 | Entry | Switch.cs:83:18:83:18 | After 2 [match] |
+| Switch.cs:77:10:77:11 | Entry | Switch.cs:83:18:83:18 | After 2 [no-match] |
 | Switch.cs:77:10:77:11 | Entry | Switch.cs:84:21:84:25 | After ... > ... [false] |
 | Switch.cs:77:10:77:11 | Entry | Switch.cs:84:21:84:25 | After ... > ... [true] |
 | Switch.cs:77:10:77:11 | Normal Exit | Switch.cs:77:10:77:11 | Normal Exit |
 | Switch.cs:79:9:87:9 | After switch (...) {...} | Switch.cs:79:9:87:9 | After switch (...) {...} |
-| Switch.cs:81:13:81:19 | After case ...: [match] | Switch.cs:81:13:81:19 | After case ...: [match] |
-| Switch.cs:81:13:81:19 | After case ...: [no-match] | Switch.cs:79:9:87:9 | After switch (...) {...} |
-| Switch.cs:81:13:81:19 | After case ...: [no-match] | Switch.cs:81:13:81:19 | After case ...: [no-match] |
-| Switch.cs:81:13:81:19 | After case ...: [no-match] | Switch.cs:83:13:83:19 | After case ...: [match] |
-| Switch.cs:81:13:81:19 | After case ...: [no-match] | Switch.cs:83:13:83:19 | After case ...: [no-match] |
-| Switch.cs:81:13:81:19 | After case ...: [no-match] | Switch.cs:84:21:84:25 | After ... > ... [false] |
-| Switch.cs:81:13:81:19 | After case ...: [no-match] | Switch.cs:84:21:84:25 | After ... > ... [true] |
-| Switch.cs:83:13:83:19 | After case ...: [match] | Switch.cs:83:13:83:19 | After case ...: [match] |
-| Switch.cs:83:13:83:19 | After case ...: [match] | Switch.cs:84:21:84:25 | After ... > ... [false] |
-| Switch.cs:83:13:83:19 | After case ...: [match] | Switch.cs:84:21:84:25 | After ... > ... [true] |
-| Switch.cs:83:13:83:19 | After case ...: [no-match] | Switch.cs:83:13:83:19 | After case ...: [no-match] |
+| Switch.cs:81:18:81:18 | After 1 [match] | Switch.cs:81:18:81:18 | After 1 [match] |
+| Switch.cs:81:18:81:18 | After 1 [no-match] | Switch.cs:79:9:87:9 | After switch (...) {...} |
+| Switch.cs:81:18:81:18 | After 1 [no-match] | Switch.cs:81:18:81:18 | After 1 [no-match] |
+| Switch.cs:81:18:81:18 | After 1 [no-match] | Switch.cs:83:18:83:18 | After 2 [match] |
+| Switch.cs:81:18:81:18 | After 1 [no-match] | Switch.cs:83:18:83:18 | After 2 [no-match] |
+| Switch.cs:81:18:81:18 | After 1 [no-match] | Switch.cs:84:21:84:25 | After ... > ... [false] |
+| Switch.cs:81:18:81:18 | After 1 [no-match] | Switch.cs:84:21:84:25 | After ... > ... [true] |
+| Switch.cs:83:18:83:18 | After 2 [match] | Switch.cs:83:18:83:18 | After 2 [match] |
+| Switch.cs:83:18:83:18 | After 2 [match] | Switch.cs:84:21:84:25 | After ... > ... [false] |
+| Switch.cs:83:18:83:18 | After 2 [match] | Switch.cs:84:21:84:25 | After ... > ... [true] |
+| Switch.cs:83:18:83:18 | After 2 [no-match] | Switch.cs:83:18:83:18 | After 2 [no-match] |
 | Switch.cs:84:21:84:25 | After ... > ... [false] | Switch.cs:84:21:84:25 | After ... > ... [false] |
 | Switch.cs:84:21:84:25 | After ... > ... [true] | Switch.cs:84:21:84:25 | After ... > ... [true] |
 | Switch.cs:91:10:91:11 | Entry | Switch.cs:91:10:91:11 | Entry |
 | Switch.cs:91:10:91:11 | Entry | Switch.cs:91:10:91:11 | Normal Exit |
-| Switch.cs:91:10:91:11 | Entry | Switch.cs:95:13:95:23 | After case ...: [match] |
-| Switch.cs:91:10:91:11 | Entry | Switch.cs:95:13:95:23 | After case ...: [no-match] |
+| Switch.cs:91:10:91:11 | Entry | Switch.cs:95:18:95:20 | After access to type Int32 [match] |
+| Switch.cs:91:10:91:11 | Entry | Switch.cs:95:18:95:20 | After access to type Int32 [no-match] |
 | Switch.cs:91:10:91:11 | Normal Exit | Switch.cs:91:10:91:11 | Normal Exit |
-| Switch.cs:95:13:95:23 | After case ...: [match] | Switch.cs:95:13:95:23 | After case ...: [match] |
-| Switch.cs:95:13:95:23 | After case ...: [no-match] | Switch.cs:95:13:95:23 | After case ...: [no-match] |
+| Switch.cs:95:18:95:20 | After access to type Int32 [match] | Switch.cs:95:18:95:20 | After access to type Int32 [match] |
+| Switch.cs:95:18:95:20 | After access to type Int32 [no-match] | Switch.cs:95:18:95:20 | After access to type Int32 [no-match] |
 | Switch.cs:101:9:101:10 | Entry | Switch.cs:101:9:101:10 | Entry |
 | Switch.cs:101:9:101:10 | Entry | Switch.cs:101:9:101:10 | Normal Exit |
 | Switch.cs:101:9:101:10 | Entry | Switch.cs:103:17:103:17 | After access to parameter s [non-null] |
 | Switch.cs:101:9:101:10 | Entry | Switch.cs:103:17:103:17 | After access to parameter s [null] |
 | Switch.cs:101:9:101:10 | Entry | Switch.cs:103:17:103:25 | After access to property Length |
-| Switch.cs:101:9:101:10 | Entry | Switch.cs:105:13:105:19 | After case ...: [match] |
-| Switch.cs:101:9:101:10 | Entry | Switch.cs:105:13:105:19 | After case ...: [no-match] |
-| Switch.cs:101:9:101:10 | Entry | Switch.cs:106:13:106:19 | After case ...: [match] |
-| Switch.cs:101:9:101:10 | Entry | Switch.cs:106:13:106:19 | After case ...: [no-match] |
+| Switch.cs:101:9:101:10 | Entry | Switch.cs:105:18:105:18 | After 0 [match] |
+| Switch.cs:101:9:101:10 | Entry | Switch.cs:105:18:105:18 | After 0 [no-match] |
+| Switch.cs:101:9:101:10 | Entry | Switch.cs:106:18:106:18 | After 1 [match] |
+| Switch.cs:101:9:101:10 | Entry | Switch.cs:106:18:106:18 | After 1 [no-match] |
 | Switch.cs:101:9:101:10 | Normal Exit | Switch.cs:101:9:101:10 | Normal Exit |
 | Switch.cs:103:17:103:17 | After access to parameter s [non-null] | Switch.cs:103:17:103:17 | After access to parameter s [non-null] |
 | Switch.cs:103:17:103:17 | After access to parameter s [null] | Switch.cs:103:17:103:17 | After access to parameter s [null] |
 | Switch.cs:103:17:103:25 | After access to property Length | Switch.cs:101:9:101:10 | Normal Exit |
 | Switch.cs:103:17:103:25 | After access to property Length | Switch.cs:103:17:103:25 | After access to property Length |
-| Switch.cs:103:17:103:25 | After access to property Length | Switch.cs:105:13:105:19 | After case ...: [match] |
-| Switch.cs:103:17:103:25 | After access to property Length | Switch.cs:105:13:105:19 | After case ...: [no-match] |
-| Switch.cs:103:17:103:25 | After access to property Length | Switch.cs:106:13:106:19 | After case ...: [match] |
-| Switch.cs:103:17:103:25 | After access to property Length | Switch.cs:106:13:106:19 | After case ...: [no-match] |
-| Switch.cs:105:13:105:19 | After case ...: [match] | Switch.cs:105:13:105:19 | After case ...: [match] |
-| Switch.cs:105:13:105:19 | After case ...: [no-match] | Switch.cs:105:13:105:19 | After case ...: [no-match] |
-| Switch.cs:105:13:105:19 | After case ...: [no-match] | Switch.cs:106:13:106:19 | After case ...: [match] |
-| Switch.cs:105:13:105:19 | After case ...: [no-match] | Switch.cs:106:13:106:19 | After case ...: [no-match] |
-| Switch.cs:106:13:106:19 | After case ...: [match] | Switch.cs:106:13:106:19 | After case ...: [match] |
-| Switch.cs:106:13:106:19 | After case ...: [no-match] | Switch.cs:106:13:106:19 | After case ...: [no-match] |
+| Switch.cs:103:17:103:25 | After access to property Length | Switch.cs:105:18:105:18 | After 0 [match] |
+| Switch.cs:103:17:103:25 | After access to property Length | Switch.cs:105:18:105:18 | After 0 [no-match] |
+| Switch.cs:103:17:103:25 | After access to property Length | Switch.cs:106:18:106:18 | After 1 [match] |
+| Switch.cs:103:17:103:25 | After access to property Length | Switch.cs:106:18:106:18 | After 1 [no-match] |
+| Switch.cs:105:18:105:18 | After 0 [match] | Switch.cs:105:18:105:18 | After 0 [match] |
+| Switch.cs:105:18:105:18 | After 0 [no-match] | Switch.cs:105:18:105:18 | After 0 [no-match] |
+| Switch.cs:105:18:105:18 | After 0 [no-match] | Switch.cs:106:18:106:18 | After 1 [match] |
+| Switch.cs:105:18:105:18 | After 0 [no-match] | Switch.cs:106:18:106:18 | After 1 [no-match] |
+| Switch.cs:106:18:106:18 | After 1 [match] | Switch.cs:106:18:106:18 | After 1 [match] |
+| Switch.cs:106:18:106:18 | After 1 [no-match] | Switch.cs:106:18:106:18 | After 1 [no-match] |
 | Switch.cs:111:17:111:21 | Entry | Switch.cs:111:17:111:21 | Entry |
 | Switch.cs:113:9:113:11 | Entry | Switch.cs:113:9:113:11 | Entry |
 | Switch.cs:113:9:113:11 | Entry | Switch.cs:113:9:113:11 | Normal Exit |
 | Switch.cs:113:9:113:11 | Entry | Switch.cs:115:9:119:9 | After switch (...) {...} |
-| Switch.cs:113:9:113:11 | Entry | Switch.cs:117:13:117:35 | After case ...: [match] |
-| Switch.cs:113:9:113:11 | Entry | Switch.cs:117:13:117:35 | After case ...: [no-match] |
+| Switch.cs:113:9:113:11 | Entry | Switch.cs:117:18:117:18 | After 3 [match] |
+| Switch.cs:113:9:113:11 | Entry | Switch.cs:117:18:117:18 | After 3 [no-match] |
 | Switch.cs:113:9:113:11 | Entry | Switch.cs:117:25:117:34 | After ... == ... [false] |
 | Switch.cs:113:9:113:11 | Entry | Switch.cs:117:25:117:34 | After ... == ... [true] |
-| Switch.cs:113:9:113:11 | Entry | Switch.cs:118:13:118:34 | After case ...: [match] |
-| Switch.cs:113:9:113:11 | Entry | Switch.cs:118:13:118:34 | After case ...: [no-match] |
 | Switch.cs:113:9:113:11 | Entry | Switch.cs:118:13:118:34 | case ...: |
+| Switch.cs:113:9:113:11 | Entry | Switch.cs:118:18:118:18 | After 2 [match] |
+| Switch.cs:113:9:113:11 | Entry | Switch.cs:118:18:118:18 | After 2 [no-match] |
 | Switch.cs:113:9:113:11 | Entry | Switch.cs:118:25:118:33 | After ... == ... [false] |
 | Switch.cs:113:9:113:11 | Entry | Switch.cs:118:25:118:33 | After ... == ... [true] |
 | Switch.cs:113:9:113:11 | Normal Exit | Switch.cs:113:9:113:11 | Normal Exit |
 | Switch.cs:115:9:119:9 | After switch (...) {...} | Switch.cs:115:9:119:9 | After switch (...) {...} |
-| Switch.cs:117:13:117:35 | After case ...: [match] | Switch.cs:117:13:117:35 | After case ...: [match] |
-| Switch.cs:117:13:117:35 | After case ...: [match] | Switch.cs:117:25:117:34 | After ... == ... [false] |
-| Switch.cs:117:13:117:35 | After case ...: [match] | Switch.cs:117:25:117:34 | After ... == ... [true] |
-| Switch.cs:117:13:117:35 | After case ...: [no-match] | Switch.cs:117:13:117:35 | After case ...: [no-match] |
+| Switch.cs:117:18:117:18 | After 3 [match] | Switch.cs:117:18:117:18 | After 3 [match] |
+| Switch.cs:117:18:117:18 | After 3 [match] | Switch.cs:117:25:117:34 | After ... == ... [false] |
+| Switch.cs:117:18:117:18 | After 3 [match] | Switch.cs:117:25:117:34 | After ... == ... [true] |
+| Switch.cs:117:18:117:18 | After 3 [no-match] | Switch.cs:117:18:117:18 | After 3 [no-match] |
 | Switch.cs:117:25:117:34 | After ... == ... [false] | Switch.cs:117:25:117:34 | After ... == ... [false] |
 | Switch.cs:117:25:117:34 | After ... == ... [true] | Switch.cs:117:25:117:34 | After ... == ... [true] |
-| Switch.cs:118:13:118:34 | After case ...: [match] | Switch.cs:118:13:118:34 | After case ...: [match] |
-| Switch.cs:118:13:118:34 | After case ...: [match] | Switch.cs:118:25:118:33 | After ... == ... [false] |
-| Switch.cs:118:13:118:34 | After case ...: [match] | Switch.cs:118:25:118:33 | After ... == ... [true] |
-| Switch.cs:118:13:118:34 | After case ...: [no-match] | Switch.cs:118:13:118:34 | After case ...: [no-match] |
 | Switch.cs:118:13:118:34 | case ...: | Switch.cs:115:9:119:9 | After switch (...) {...} |
-| Switch.cs:118:13:118:34 | case ...: | Switch.cs:118:13:118:34 | After case ...: [match] |
-| Switch.cs:118:13:118:34 | case ...: | Switch.cs:118:13:118:34 | After case ...: [no-match] |
 | Switch.cs:118:13:118:34 | case ...: | Switch.cs:118:13:118:34 | case ...: |
+| Switch.cs:118:13:118:34 | case ...: | Switch.cs:118:18:118:18 | After 2 [match] |
+| Switch.cs:118:13:118:34 | case ...: | Switch.cs:118:18:118:18 | After 2 [no-match] |
 | Switch.cs:118:13:118:34 | case ...: | Switch.cs:118:25:118:33 | After ... == ... [false] |
 | Switch.cs:118:13:118:34 | case ...: | Switch.cs:118:25:118:33 | After ... == ... [true] |
+| Switch.cs:118:18:118:18 | After 2 [match] | Switch.cs:118:18:118:18 | After 2 [match] |
+| Switch.cs:118:18:118:18 | After 2 [match] | Switch.cs:118:25:118:33 | After ... == ... [false] |
+| Switch.cs:118:18:118:18 | After 2 [match] | Switch.cs:118:25:118:33 | After ... == ... [true] |
+| Switch.cs:118:18:118:18 | After 2 [no-match] | Switch.cs:118:18:118:18 | After 2 [no-match] |
 | Switch.cs:118:25:118:33 | After ... == ... [false] | Switch.cs:118:25:118:33 | After ... == ... [false] |
 | Switch.cs:118:25:118:33 | After ... == ... [true] | Switch.cs:118:25:118:33 | After ... == ... [true] |
 | Switch.cs:123:10:123:12 | Entry | Switch.cs:123:10:123:12 | Entry |
 | Switch.cs:123:10:123:12 | Entry | Switch.cs:123:10:123:12 | Normal Exit |
 | Switch.cs:123:10:123:12 | Entry | Switch.cs:125:13:125:48 | After ... switch { ... } [false] |
 | Switch.cs:123:10:123:12 | Entry | Switch.cs:125:13:125:48 | After ... switch { ... } [true] |
-| Switch.cs:123:10:123:12 | Entry | Switch.cs:125:24:125:34 | After ... => ... [match] |
-| Switch.cs:123:10:123:12 | Entry | Switch.cs:125:24:125:34 | After ... => ... [no-match] |
+| Switch.cs:123:10:123:12 | Entry | Switch.cs:125:24:125:29 | After Boolean b [match] |
+| Switch.cs:123:10:123:12 | Entry | Switch.cs:125:24:125:29 | After Boolean b [no-match] |
 | Switch.cs:123:10:123:12 | Normal Exit | Switch.cs:123:10:123:12 | Normal Exit |
 | Switch.cs:125:13:125:48 | After ... switch { ... } [false] | Switch.cs:125:13:125:48 | After ... switch { ... } [false] |
 | Switch.cs:125:13:125:48 | After ... switch { ... } [true] | Switch.cs:125:13:125:48 | After ... switch { ... } [true] |
-| Switch.cs:125:24:125:34 | After ... => ... [match] | Switch.cs:125:24:125:34 | After ... => ... [match] |
-| Switch.cs:125:24:125:34 | After ... => ... [no-match] | Switch.cs:125:24:125:34 | After ... => ... [no-match] |
+| Switch.cs:125:24:125:29 | After Boolean b [match] | Switch.cs:125:24:125:29 | After Boolean b [match] |
+| Switch.cs:125:24:125:29 | After Boolean b [no-match] | Switch.cs:125:24:125:29 | After Boolean b [no-match] |
 | Switch.cs:129:12:129:14 | Entry | Switch.cs:129:12:129:14 | Entry |
 | Switch.cs:129:12:129:14 | Entry | Switch.cs:131:16:131:66 | After call to method ToString |
 | Switch.cs:129:12:129:14 | Entry | Switch.cs:131:17:131:53 | After ... switch { ... } [non-null] |
 | Switch.cs:129:12:129:14 | Entry | Switch.cs:131:17:131:53 | After ... switch { ... } [null] |
-| Switch.cs:129:12:129:14 | Entry | Switch.cs:131:28:131:40 | After ... => ... [match] |
-| Switch.cs:129:12:129:14 | Entry | Switch.cs:131:28:131:40 | After ... => ... [no-match] |
+| Switch.cs:129:12:129:14 | Entry | Switch.cs:131:28:131:35 | After String s [match] |
+| Switch.cs:129:12:129:14 | Entry | Switch.cs:131:28:131:35 | After String s [no-match] |
 | Switch.cs:131:16:131:66 | After call to method ToString | Switch.cs:131:16:131:66 | After call to method ToString |
 | Switch.cs:131:17:131:53 | After ... switch { ... } [non-null] | Switch.cs:131:17:131:53 | After ... switch { ... } [non-null] |
 | Switch.cs:131:17:131:53 | After ... switch { ... } [null] | Switch.cs:131:17:131:53 | After ... switch { ... } [null] |
-| Switch.cs:131:28:131:40 | After ... => ... [match] | Switch.cs:131:28:131:40 | After ... => ... [match] |
-| Switch.cs:131:28:131:40 | After ... => ... [no-match] | Switch.cs:131:28:131:40 | After ... => ... [no-match] |
+| Switch.cs:131:28:131:35 | After String s [match] | Switch.cs:131:28:131:35 | After String s [match] |
+| Switch.cs:131:28:131:35 | After String s [no-match] | Switch.cs:131:28:131:35 | After String s [no-match] |
 | Switch.cs:134:9:134:11 | Entry | Switch.cs:134:9:134:11 | Entry |
 | Switch.cs:134:9:134:11 | Entry | Switch.cs:134:9:134:11 | Normal Exit |
-| Switch.cs:134:9:134:11 | Entry | Switch.cs:139:13:139:19 | After case ...: [match] |
-| Switch.cs:134:9:134:11 | Entry | Switch.cs:139:13:139:19 | After case ...: [no-match] |
-| Switch.cs:134:9:134:11 | Entry | Switch.cs:140:13:140:19 | After case ...: [match] |
-| Switch.cs:134:9:134:11 | Entry | Switch.cs:140:13:140:19 | After case ...: [no-match] |
+| Switch.cs:134:9:134:11 | Entry | Switch.cs:139:18:139:18 | After 1 [match] |
+| Switch.cs:134:9:134:11 | Entry | Switch.cs:139:18:139:18 | After 1 [no-match] |
+| Switch.cs:134:9:134:11 | Entry | Switch.cs:140:18:140:18 | After 2 [match] |
+| Switch.cs:134:9:134:11 | Entry | Switch.cs:140:18:140:18 | After 2 [no-match] |
 | Switch.cs:134:9:134:11 | Normal Exit | Switch.cs:134:9:134:11 | Normal Exit |
-| Switch.cs:139:13:139:19 | After case ...: [match] | Switch.cs:139:13:139:19 | After case ...: [match] |
-| Switch.cs:139:13:139:19 | After case ...: [no-match] | Switch.cs:139:13:139:19 | After case ...: [no-match] |
-| Switch.cs:139:13:139:19 | After case ...: [no-match] | Switch.cs:140:13:140:19 | After case ...: [match] |
-| Switch.cs:139:13:139:19 | After case ...: [no-match] | Switch.cs:140:13:140:19 | After case ...: [no-match] |
-| Switch.cs:140:13:140:19 | After case ...: [match] | Switch.cs:140:13:140:19 | After case ...: [match] |
-| Switch.cs:140:13:140:19 | After case ...: [no-match] | Switch.cs:140:13:140:19 | After case ...: [no-match] |
+| Switch.cs:139:18:139:18 | After 1 [match] | Switch.cs:139:18:139:18 | After 1 [match] |
+| Switch.cs:139:18:139:18 | After 1 [no-match] | Switch.cs:139:18:139:18 | After 1 [no-match] |
+| Switch.cs:139:18:139:18 | After 1 [no-match] | Switch.cs:140:18:140:18 | After 2 [match] |
+| Switch.cs:139:18:139:18 | After 1 [no-match] | Switch.cs:140:18:140:18 | After 2 [no-match] |
+| Switch.cs:140:18:140:18 | After 2 [match] | Switch.cs:140:18:140:18 | After 2 [match] |
+| Switch.cs:140:18:140:18 | After 2 [no-match] | Switch.cs:140:18:140:18 | After 2 [no-match] |
 | Switch.cs:144:9:144:11 | Entry | Switch.cs:144:9:144:11 | Entry |
 | Switch.cs:144:9:144:11 | Entry | Switch.cs:144:9:144:11 | Normal Exit |
-| Switch.cs:144:9:144:11 | Entry | Switch.cs:148:13:148:19 | After case ...: [match] |
-| Switch.cs:144:9:144:11 | Entry | Switch.cs:148:13:148:19 | After case ...: [no-match] |
-| Switch.cs:144:9:144:11 | Entry | Switch.cs:150:13:150:19 | After case ...: [match] |
-| Switch.cs:144:9:144:11 | Entry | Switch.cs:150:13:150:19 | After case ...: [no-match] |
+| Switch.cs:144:9:144:11 | Entry | Switch.cs:148:18:148:18 | After 1 [match] |
+| Switch.cs:144:9:144:11 | Entry | Switch.cs:148:18:148:18 | After 1 [no-match] |
+| Switch.cs:144:9:144:11 | Entry | Switch.cs:150:18:150:18 | After 2 [match] |
+| Switch.cs:144:9:144:11 | Entry | Switch.cs:150:18:150:18 | After 2 [no-match] |
 | Switch.cs:144:9:144:11 | Normal Exit | Switch.cs:144:9:144:11 | Normal Exit |
-| Switch.cs:148:13:148:19 | After case ...: [match] | Switch.cs:148:13:148:19 | After case ...: [match] |
-| Switch.cs:148:13:148:19 | After case ...: [no-match] | Switch.cs:148:13:148:19 | After case ...: [no-match] |
-| Switch.cs:148:13:148:19 | After case ...: [no-match] | Switch.cs:150:13:150:19 | After case ...: [match] |
-| Switch.cs:148:13:148:19 | After case ...: [no-match] | Switch.cs:150:13:150:19 | After case ...: [no-match] |
-| Switch.cs:150:13:150:19 | After case ...: [match] | Switch.cs:150:13:150:19 | After case ...: [match] |
-| Switch.cs:150:13:150:19 | After case ...: [no-match] | Switch.cs:150:13:150:19 | After case ...: [no-match] |
+| Switch.cs:148:18:148:18 | After 1 [match] | Switch.cs:148:18:148:18 | After 1 [match] |
+| Switch.cs:148:18:148:18 | After 1 [no-match] | Switch.cs:148:18:148:18 | After 1 [no-match] |
+| Switch.cs:148:18:148:18 | After 1 [no-match] | Switch.cs:150:18:150:18 | After 2 [match] |
+| Switch.cs:148:18:148:18 | After 1 [no-match] | Switch.cs:150:18:150:18 | After 2 [no-match] |
+| Switch.cs:150:18:150:18 | After 2 [match] | Switch.cs:150:18:150:18 | After 2 [match] |
+| Switch.cs:150:18:150:18 | After 2 [no-match] | Switch.cs:150:18:150:18 | After 2 [no-match] |
 | Switch.cs:154:10:154:12 | Entry | Switch.cs:154:10:154:12 | Entry |
 | Switch.cs:154:10:154:12 | Entry | Switch.cs:156:17:156:54 | After ... switch { ... } |
-| Switch.cs:154:10:154:12 | Entry | Switch.cs:156:28:156:38 | After ... => ... [match] |
-| Switch.cs:154:10:154:12 | Entry | Switch.cs:156:28:156:38 | After ... => ... [no-match] |
-| Switch.cs:154:10:154:12 | Entry | Switch.cs:156:41:156:52 | After ... => ... [match] |
-| Switch.cs:154:10:154:12 | Entry | Switch.cs:156:41:156:52 | After ... => ... [no-match] |
+| Switch.cs:154:10:154:12 | Entry | Switch.cs:156:28:156:31 | After true [match] |
+| Switch.cs:154:10:154:12 | Entry | Switch.cs:156:28:156:31 | After true [no-match] |
+| Switch.cs:154:10:154:12 | Entry | Switch.cs:156:41:156:45 | After false [match] |
+| Switch.cs:154:10:154:12 | Entry | Switch.cs:156:41:156:45 | After false [no-match] |
 | Switch.cs:154:10:154:12 | Entry | Switch.cs:157:9:160:49 | After if (...) ... |
 | Switch.cs:154:10:154:12 | Entry | Switch.cs:157:13:157:13 | After access to parameter b [false] |
 | Switch.cs:154:10:154:12 | Entry | Switch.cs:157:13:157:13 | After access to parameter b [true] |
@@ -18902,38 +19096,38 @@ blockDominance
 | Switch.cs:156:17:156:54 | After ... switch { ... } | Switch.cs:157:9:160:49 | After if (...) ... |
 | Switch.cs:156:17:156:54 | After ... switch { ... } | Switch.cs:157:13:157:13 | After access to parameter b [false] |
 | Switch.cs:156:17:156:54 | After ... switch { ... } | Switch.cs:157:13:157:13 | After access to parameter b [true] |
-| Switch.cs:156:28:156:38 | After ... => ... [match] | Switch.cs:156:28:156:38 | After ... => ... [match] |
-| Switch.cs:156:28:156:38 | After ... => ... [no-match] | Switch.cs:156:28:156:38 | After ... => ... [no-match] |
-| Switch.cs:156:28:156:38 | After ... => ... [no-match] | Switch.cs:156:41:156:52 | After ... => ... [match] |
-| Switch.cs:156:28:156:38 | After ... => ... [no-match] | Switch.cs:156:41:156:52 | After ... => ... [no-match] |
-| Switch.cs:156:41:156:52 | After ... => ... [match] | Switch.cs:156:41:156:52 | After ... => ... [match] |
-| Switch.cs:156:41:156:52 | After ... => ... [no-match] | Switch.cs:156:41:156:52 | After ... => ... [no-match] |
+| Switch.cs:156:28:156:31 | After true [match] | Switch.cs:156:28:156:31 | After true [match] |
+| Switch.cs:156:28:156:31 | After true [no-match] | Switch.cs:156:28:156:31 | After true [no-match] |
+| Switch.cs:156:28:156:31 | After true [no-match] | Switch.cs:156:41:156:45 | After false [match] |
+| Switch.cs:156:28:156:31 | After true [no-match] | Switch.cs:156:41:156:45 | After false [no-match] |
+| Switch.cs:156:41:156:45 | After false [match] | Switch.cs:156:41:156:45 | After false [match] |
+| Switch.cs:156:41:156:45 | After false [no-match] | Switch.cs:156:41:156:45 | After false [no-match] |
 | Switch.cs:157:9:160:49 | After if (...) ... | Switch.cs:157:9:160:49 | After if (...) ... |
 | Switch.cs:157:13:157:13 | After access to parameter b [false] | Switch.cs:157:13:157:13 | After access to parameter b [false] |
 | Switch.cs:157:13:157:13 | After access to parameter b [true] | Switch.cs:157:13:157:13 | After access to parameter b [true] |
 | Switch.cs:163:10:163:12 | Entry | Switch.cs:163:10:163:12 | Entry |
 | Switch.cs:163:10:163:12 | Entry | Switch.cs:165:9:177:9 | After switch (...) {...} |
-| Switch.cs:163:10:163:12 | Entry | Switch.cs:167:13:167:19 | After case ...: [match] |
-| Switch.cs:163:10:163:12 | Entry | Switch.cs:167:13:167:19 | After case ...: [no-match] |
-| Switch.cs:163:10:163:12 | Entry | Switch.cs:168:13:168:19 | After case ...: [match] |
-| Switch.cs:163:10:163:12 | Entry | Switch.cs:168:13:168:19 | After case ...: [no-match] |
+| Switch.cs:163:10:163:12 | Entry | Switch.cs:167:18:167:18 | After 1 [match] |
+| Switch.cs:163:10:163:12 | Entry | Switch.cs:167:18:167:18 | After 1 [no-match] |
+| Switch.cs:163:10:163:12 | Entry | Switch.cs:168:18:168:18 | After 2 [match] |
+| Switch.cs:163:10:163:12 | Entry | Switch.cs:168:18:168:18 | After 2 [no-match] |
 | Switch.cs:163:10:163:12 | Entry | Switch.cs:169:17:169:51 | ...; |
-| Switch.cs:163:10:163:12 | Entry | Switch.cs:171:13:171:19 | After case ...: [match] |
-| Switch.cs:163:10:163:12 | Entry | Switch.cs:171:13:171:19 | After case ...: [no-match] |
+| Switch.cs:163:10:163:12 | Entry | Switch.cs:171:18:171:18 | After 3 [match] |
+| Switch.cs:163:10:163:12 | Entry | Switch.cs:171:18:171:18 | After 3 [no-match] |
 | Switch.cs:165:9:177:9 | After switch (...) {...} | Switch.cs:165:9:177:9 | After switch (...) {...} |
-| Switch.cs:167:13:167:19 | After case ...: [match] | Switch.cs:167:13:167:19 | After case ...: [match] |
-| Switch.cs:167:13:167:19 | After case ...: [no-match] | Switch.cs:167:13:167:19 | After case ...: [no-match] |
-| Switch.cs:167:13:167:19 | After case ...: [no-match] | Switch.cs:168:13:168:19 | After case ...: [match] |
-| Switch.cs:167:13:167:19 | After case ...: [no-match] | Switch.cs:168:13:168:19 | After case ...: [no-match] |
-| Switch.cs:167:13:167:19 | After case ...: [no-match] | Switch.cs:171:13:171:19 | After case ...: [match] |
-| Switch.cs:167:13:167:19 | After case ...: [no-match] | Switch.cs:171:13:171:19 | After case ...: [no-match] |
-| Switch.cs:168:13:168:19 | After case ...: [match] | Switch.cs:168:13:168:19 | After case ...: [match] |
-| Switch.cs:168:13:168:19 | After case ...: [no-match] | Switch.cs:168:13:168:19 | After case ...: [no-match] |
-| Switch.cs:168:13:168:19 | After case ...: [no-match] | Switch.cs:171:13:171:19 | After case ...: [match] |
-| Switch.cs:168:13:168:19 | After case ...: [no-match] | Switch.cs:171:13:171:19 | After case ...: [no-match] |
+| Switch.cs:167:18:167:18 | After 1 [match] | Switch.cs:167:18:167:18 | After 1 [match] |
+| Switch.cs:167:18:167:18 | After 1 [no-match] | Switch.cs:167:18:167:18 | After 1 [no-match] |
+| Switch.cs:167:18:167:18 | After 1 [no-match] | Switch.cs:168:18:168:18 | After 2 [match] |
+| Switch.cs:167:18:167:18 | After 1 [no-match] | Switch.cs:168:18:168:18 | After 2 [no-match] |
+| Switch.cs:167:18:167:18 | After 1 [no-match] | Switch.cs:171:18:171:18 | After 3 [match] |
+| Switch.cs:167:18:167:18 | After 1 [no-match] | Switch.cs:171:18:171:18 | After 3 [no-match] |
+| Switch.cs:168:18:168:18 | After 2 [match] | Switch.cs:168:18:168:18 | After 2 [match] |
+| Switch.cs:168:18:168:18 | After 2 [no-match] | Switch.cs:168:18:168:18 | After 2 [no-match] |
+| Switch.cs:168:18:168:18 | After 2 [no-match] | Switch.cs:171:18:171:18 | After 3 [match] |
+| Switch.cs:168:18:168:18 | After 2 [no-match] | Switch.cs:171:18:171:18 | After 3 [no-match] |
 | Switch.cs:169:17:169:51 | ...; | Switch.cs:169:17:169:51 | ...; |
-| Switch.cs:171:13:171:19 | After case ...: [match] | Switch.cs:171:13:171:19 | After case ...: [match] |
-| Switch.cs:171:13:171:19 | After case ...: [no-match] | Switch.cs:171:13:171:19 | After case ...: [no-match] |
+| Switch.cs:171:18:171:18 | After 3 [match] | Switch.cs:171:18:171:18 | After 3 [match] |
+| Switch.cs:171:18:171:18 | After 3 [no-match] | Switch.cs:171:18:171:18 | After 3 [no-match] |
 | TypeAccesses.cs:1:7:1:18 | Entry | TypeAccesses.cs:1:7:1:18 | Entry |
 | TypeAccesses.cs:3:10:3:10 | Entry | TypeAccesses.cs:3:10:3:10 | Entry |
 | TypeAccesses.cs:3:10:3:10 | Entry | TypeAccesses.cs:7:9:7:25 | After if (...) ... |
@@ -19135,75 +19329,80 @@ blockDominance
 | cflow.cs:37:17:37:22 | Entry | cflow.cs:37:17:37:22 | Exit |
 | cflow.cs:37:17:37:22 | Entry | cflow.cs:39:9:50:9 | After switch (...) {...} |
 | cflow.cs:37:17:37:22 | Entry | cflow.cs:41:13:41:19 | After case ...: [match] |
-| cflow.cs:37:17:37:22 | Entry | cflow.cs:41:13:41:19 | After case ...: [no-match] |
+| cflow.cs:37:17:37:22 | Entry | cflow.cs:41:18:41:18 | After 1 [match] |
+| cflow.cs:37:17:37:22 | Entry | cflow.cs:41:18:41:18 | After 1 [no-match] |
 | cflow.cs:37:17:37:22 | Entry | cflow.cs:44:13:44:19 | After case ...: [match] |
-| cflow.cs:37:17:37:22 | Entry | cflow.cs:44:13:44:19 | After case ...: [no-match] |
-| cflow.cs:37:17:37:22 | Entry | cflow.cs:47:13:47:19 | After case ...: [match] |
-| cflow.cs:37:17:37:22 | Entry | cflow.cs:47:13:47:19 | After case ...: [no-match] |
+| cflow.cs:37:17:37:22 | Entry | cflow.cs:44:18:44:18 | After 2 [match] |
+| cflow.cs:37:17:37:22 | Entry | cflow.cs:44:18:44:18 | After 2 [no-match] |
+| cflow.cs:37:17:37:22 | Entry | cflow.cs:47:18:47:18 | After 3 [match] |
+| cflow.cs:37:17:37:22 | Entry | cflow.cs:47:18:47:18 | After 3 [no-match] |
 | cflow.cs:37:17:37:22 | Entry | cflow.cs:51:9:59:9 | After switch (...) {...} |
-| cflow.cs:37:17:37:22 | Entry | cflow.cs:53:13:53:20 | After case ...: [match] |
-| cflow.cs:37:17:37:22 | Entry | cflow.cs:53:13:53:20 | After case ...: [no-match] |
+| cflow.cs:37:17:37:22 | Entry | cflow.cs:53:18:53:19 | After 42 [match] |
+| cflow.cs:37:17:37:22 | Entry | cflow.cs:53:18:53:19 | After 42 [no-match] |
 | cflow.cs:37:17:37:22 | Entry | cflow.cs:60:9:66:9 | After switch (...) {...} |
-| cflow.cs:37:17:37:22 | Entry | cflow.cs:62:13:62:19 | After case ...: [match] |
-| cflow.cs:37:17:37:22 | Entry | cflow.cs:62:13:62:19 | After case ...: [no-match] |
+| cflow.cs:37:17:37:22 | Entry | cflow.cs:62:18:62:18 | After 0 [match] |
+| cflow.cs:37:17:37:22 | Entry | cflow.cs:62:18:62:18 | After 0 [no-match] |
 | cflow.cs:37:17:37:22 | Entry | cflow.cs:63:23:63:33 | After ... == ... [false] |
 | cflow.cs:37:17:37:22 | Entry | cflow.cs:63:23:63:33 | After ... == ... [true] |
 | cflow.cs:37:17:37:22 | Exit | cflow.cs:37:17:37:22 | Exit |
 | cflow.cs:39:9:50:9 | After switch (...) {...} | cflow.cs:37:17:37:22 | Exit |
 | cflow.cs:39:9:50:9 | After switch (...) {...} | cflow.cs:39:9:50:9 | After switch (...) {...} |
 | cflow.cs:39:9:50:9 | After switch (...) {...} | cflow.cs:51:9:59:9 | After switch (...) {...} |
-| cflow.cs:39:9:50:9 | After switch (...) {...} | cflow.cs:53:13:53:20 | After case ...: [match] |
-| cflow.cs:39:9:50:9 | After switch (...) {...} | cflow.cs:53:13:53:20 | After case ...: [no-match] |
+| cflow.cs:39:9:50:9 | After switch (...) {...} | cflow.cs:53:18:53:19 | After 42 [match] |
+| cflow.cs:39:9:50:9 | After switch (...) {...} | cflow.cs:53:18:53:19 | After 42 [no-match] |
 | cflow.cs:39:9:50:9 | After switch (...) {...} | cflow.cs:60:9:66:9 | After switch (...) {...} |
-| cflow.cs:39:9:50:9 | After switch (...) {...} | cflow.cs:62:13:62:19 | After case ...: [match] |
-| cflow.cs:39:9:50:9 | After switch (...) {...} | cflow.cs:62:13:62:19 | After case ...: [no-match] |
+| cflow.cs:39:9:50:9 | After switch (...) {...} | cflow.cs:62:18:62:18 | After 0 [match] |
+| cflow.cs:39:9:50:9 | After switch (...) {...} | cflow.cs:62:18:62:18 | After 0 [no-match] |
 | cflow.cs:39:9:50:9 | After switch (...) {...} | cflow.cs:63:23:63:33 | After ... == ... [false] |
 | cflow.cs:39:9:50:9 | After switch (...) {...} | cflow.cs:63:23:63:33 | After ... == ... [true] |
 | cflow.cs:41:13:41:19 | After case ...: [match] | cflow.cs:41:13:41:19 | After case ...: [match] |
-| cflow.cs:41:13:41:19 | After case ...: [no-match] | cflow.cs:37:17:37:22 | Exit |
-| cflow.cs:41:13:41:19 | After case ...: [no-match] | cflow.cs:39:9:50:9 | After switch (...) {...} |
-| cflow.cs:41:13:41:19 | After case ...: [no-match] | cflow.cs:41:13:41:19 | After case ...: [no-match] |
-| cflow.cs:41:13:41:19 | After case ...: [no-match] | cflow.cs:44:13:44:19 | After case ...: [no-match] |
-| cflow.cs:41:13:41:19 | After case ...: [no-match] | cflow.cs:47:13:47:19 | After case ...: [match] |
-| cflow.cs:41:13:41:19 | After case ...: [no-match] | cflow.cs:47:13:47:19 | After case ...: [no-match] |
-| cflow.cs:41:13:41:19 | After case ...: [no-match] | cflow.cs:51:9:59:9 | After switch (...) {...} |
-| cflow.cs:41:13:41:19 | After case ...: [no-match] | cflow.cs:53:13:53:20 | After case ...: [match] |
-| cflow.cs:41:13:41:19 | After case ...: [no-match] | cflow.cs:53:13:53:20 | After case ...: [no-match] |
-| cflow.cs:41:13:41:19 | After case ...: [no-match] | cflow.cs:60:9:66:9 | After switch (...) {...} |
-| cflow.cs:41:13:41:19 | After case ...: [no-match] | cflow.cs:62:13:62:19 | After case ...: [match] |
-| cflow.cs:41:13:41:19 | After case ...: [no-match] | cflow.cs:62:13:62:19 | After case ...: [no-match] |
-| cflow.cs:41:13:41:19 | After case ...: [no-match] | cflow.cs:63:23:63:33 | After ... == ... [false] |
-| cflow.cs:41:13:41:19 | After case ...: [no-match] | cflow.cs:63:23:63:33 | After ... == ... [true] |
+| cflow.cs:41:18:41:18 | After 1 [match] | cflow.cs:41:18:41:18 | After 1 [match] |
+| cflow.cs:41:18:41:18 | After 1 [no-match] | cflow.cs:37:17:37:22 | Exit |
+| cflow.cs:41:18:41:18 | After 1 [no-match] | cflow.cs:39:9:50:9 | After switch (...) {...} |
+| cflow.cs:41:18:41:18 | After 1 [no-match] | cflow.cs:41:18:41:18 | After 1 [no-match] |
+| cflow.cs:41:18:41:18 | After 1 [no-match] | cflow.cs:44:18:44:18 | After 2 [match] |
+| cflow.cs:41:18:41:18 | After 1 [no-match] | cflow.cs:44:18:44:18 | After 2 [no-match] |
+| cflow.cs:41:18:41:18 | After 1 [no-match] | cflow.cs:47:18:47:18 | After 3 [match] |
+| cflow.cs:41:18:41:18 | After 1 [no-match] | cflow.cs:47:18:47:18 | After 3 [no-match] |
+| cflow.cs:41:18:41:18 | After 1 [no-match] | cflow.cs:51:9:59:9 | After switch (...) {...} |
+| cflow.cs:41:18:41:18 | After 1 [no-match] | cflow.cs:53:18:53:19 | After 42 [match] |
+| cflow.cs:41:18:41:18 | After 1 [no-match] | cflow.cs:53:18:53:19 | After 42 [no-match] |
+| cflow.cs:41:18:41:18 | After 1 [no-match] | cflow.cs:60:9:66:9 | After switch (...) {...} |
+| cflow.cs:41:18:41:18 | After 1 [no-match] | cflow.cs:62:18:62:18 | After 0 [match] |
+| cflow.cs:41:18:41:18 | After 1 [no-match] | cflow.cs:62:18:62:18 | After 0 [no-match] |
+| cflow.cs:41:18:41:18 | After 1 [no-match] | cflow.cs:63:23:63:33 | After ... == ... [false] |
+| cflow.cs:41:18:41:18 | After 1 [no-match] | cflow.cs:63:23:63:33 | After ... == ... [true] |
 | cflow.cs:44:13:44:19 | After case ...: [match] | cflow.cs:44:13:44:19 | After case ...: [match] |
-| cflow.cs:44:13:44:19 | After case ...: [no-match] | cflow.cs:37:17:37:22 | Exit |
-| cflow.cs:44:13:44:19 | After case ...: [no-match] | cflow.cs:39:9:50:9 | After switch (...) {...} |
-| cflow.cs:44:13:44:19 | After case ...: [no-match] | cflow.cs:44:13:44:19 | After case ...: [no-match] |
-| cflow.cs:44:13:44:19 | After case ...: [no-match] | cflow.cs:47:13:47:19 | After case ...: [match] |
-| cflow.cs:44:13:44:19 | After case ...: [no-match] | cflow.cs:47:13:47:19 | After case ...: [no-match] |
-| cflow.cs:44:13:44:19 | After case ...: [no-match] | cflow.cs:51:9:59:9 | After switch (...) {...} |
-| cflow.cs:44:13:44:19 | After case ...: [no-match] | cflow.cs:53:13:53:20 | After case ...: [match] |
-| cflow.cs:44:13:44:19 | After case ...: [no-match] | cflow.cs:53:13:53:20 | After case ...: [no-match] |
-| cflow.cs:44:13:44:19 | After case ...: [no-match] | cflow.cs:60:9:66:9 | After switch (...) {...} |
-| cflow.cs:44:13:44:19 | After case ...: [no-match] | cflow.cs:62:13:62:19 | After case ...: [match] |
-| cflow.cs:44:13:44:19 | After case ...: [no-match] | cflow.cs:62:13:62:19 | After case ...: [no-match] |
-| cflow.cs:44:13:44:19 | After case ...: [no-match] | cflow.cs:63:23:63:33 | After ... == ... [false] |
-| cflow.cs:44:13:44:19 | After case ...: [no-match] | cflow.cs:63:23:63:33 | After ... == ... [true] |
-| cflow.cs:47:13:47:19 | After case ...: [match] | cflow.cs:47:13:47:19 | After case ...: [match] |
-| cflow.cs:47:13:47:19 | After case ...: [no-match] | cflow.cs:47:13:47:19 | After case ...: [no-match] |
+| cflow.cs:44:18:44:18 | After 2 [match] | cflow.cs:44:18:44:18 | After 2 [match] |
+| cflow.cs:44:18:44:18 | After 2 [no-match] | cflow.cs:37:17:37:22 | Exit |
+| cflow.cs:44:18:44:18 | After 2 [no-match] | cflow.cs:39:9:50:9 | After switch (...) {...} |
+| cflow.cs:44:18:44:18 | After 2 [no-match] | cflow.cs:44:18:44:18 | After 2 [no-match] |
+| cflow.cs:44:18:44:18 | After 2 [no-match] | cflow.cs:47:18:47:18 | After 3 [match] |
+| cflow.cs:44:18:44:18 | After 2 [no-match] | cflow.cs:47:18:47:18 | After 3 [no-match] |
+| cflow.cs:44:18:44:18 | After 2 [no-match] | cflow.cs:51:9:59:9 | After switch (...) {...} |
+| cflow.cs:44:18:44:18 | After 2 [no-match] | cflow.cs:53:18:53:19 | After 42 [match] |
+| cflow.cs:44:18:44:18 | After 2 [no-match] | cflow.cs:53:18:53:19 | After 42 [no-match] |
+| cflow.cs:44:18:44:18 | After 2 [no-match] | cflow.cs:60:9:66:9 | After switch (...) {...} |
+| cflow.cs:44:18:44:18 | After 2 [no-match] | cflow.cs:62:18:62:18 | After 0 [match] |
+| cflow.cs:44:18:44:18 | After 2 [no-match] | cflow.cs:62:18:62:18 | After 0 [no-match] |
+| cflow.cs:44:18:44:18 | After 2 [no-match] | cflow.cs:63:23:63:33 | After ... == ... [false] |
+| cflow.cs:44:18:44:18 | After 2 [no-match] | cflow.cs:63:23:63:33 | After ... == ... [true] |
+| cflow.cs:47:18:47:18 | After 3 [match] | cflow.cs:47:18:47:18 | After 3 [match] |
+| cflow.cs:47:18:47:18 | After 3 [no-match] | cflow.cs:47:18:47:18 | After 3 [no-match] |
 | cflow.cs:51:9:59:9 | After switch (...) {...} | cflow.cs:37:17:37:22 | Exit |
 | cflow.cs:51:9:59:9 | After switch (...) {...} | cflow.cs:51:9:59:9 | After switch (...) {...} |
 | cflow.cs:51:9:59:9 | After switch (...) {...} | cflow.cs:60:9:66:9 | After switch (...) {...} |
-| cflow.cs:51:9:59:9 | After switch (...) {...} | cflow.cs:62:13:62:19 | After case ...: [match] |
-| cflow.cs:51:9:59:9 | After switch (...) {...} | cflow.cs:62:13:62:19 | After case ...: [no-match] |
+| cflow.cs:51:9:59:9 | After switch (...) {...} | cflow.cs:62:18:62:18 | After 0 [match] |
+| cflow.cs:51:9:59:9 | After switch (...) {...} | cflow.cs:62:18:62:18 | After 0 [no-match] |
 | cflow.cs:51:9:59:9 | After switch (...) {...} | cflow.cs:63:23:63:33 | After ... == ... [false] |
 | cflow.cs:51:9:59:9 | After switch (...) {...} | cflow.cs:63:23:63:33 | After ... == ... [true] |
-| cflow.cs:53:13:53:20 | After case ...: [match] | cflow.cs:53:13:53:20 | After case ...: [match] |
-| cflow.cs:53:13:53:20 | After case ...: [no-match] | cflow.cs:53:13:53:20 | After case ...: [no-match] |
+| cflow.cs:53:18:53:19 | After 42 [match] | cflow.cs:53:18:53:19 | After 42 [match] |
+| cflow.cs:53:18:53:19 | After 42 [no-match] | cflow.cs:53:18:53:19 | After 42 [no-match] |
 | cflow.cs:60:9:66:9 | After switch (...) {...} | cflow.cs:60:9:66:9 | After switch (...) {...} |
-| cflow.cs:62:13:62:19 | After case ...: [match] | cflow.cs:62:13:62:19 | After case ...: [match] |
-| cflow.cs:62:13:62:19 | After case ...: [match] | cflow.cs:63:23:63:33 | After ... == ... [false] |
-| cflow.cs:62:13:62:19 | After case ...: [match] | cflow.cs:63:23:63:33 | After ... == ... [true] |
-| cflow.cs:62:13:62:19 | After case ...: [no-match] | cflow.cs:62:13:62:19 | After case ...: [no-match] |
+| cflow.cs:62:18:62:18 | After 0 [match] | cflow.cs:62:18:62:18 | After 0 [match] |
+| cflow.cs:62:18:62:18 | After 0 [match] | cflow.cs:63:23:63:33 | After ... == ... [false] |
+| cflow.cs:62:18:62:18 | After 0 [match] | cflow.cs:63:23:63:33 | After ... == ... [true] |
+| cflow.cs:62:18:62:18 | After 0 [no-match] | cflow.cs:62:18:62:18 | After 0 [no-match] |
 | cflow.cs:63:23:63:33 | After ... == ... [false] | cflow.cs:63:23:63:33 | After ... == ... [false] |
 | cflow.cs:63:23:63:33 | After ... == ... [true] | cflow.cs:63:23:63:33 | After ... == ... [true] |
 | cflow.cs:70:18:70:18 | Entry | cflow.cs:70:18:70:18 | Entry |
@@ -19588,12 +19787,12 @@ blockDominance
 | cflow.cs:240:10:240:13 | Entry | cflow.cs:244:13:244:28 | After ... > ... [false] |
 | cflow.cs:240:10:240:13 | Entry | cflow.cs:244:13:244:28 | After ... > ... [true] |
 | cflow.cs:240:10:240:13 | Entry | cflow.cs:246:9:258:9 | After switch (...) {...} |
-| cflow.cs:240:10:240:13 | Entry | cflow.cs:248:13:248:19 | After case ...: [match] |
-| cflow.cs:240:10:240:13 | Entry | cflow.cs:248:13:248:19 | After case ...: [no-match] |
-| cflow.cs:240:10:240:13 | Entry | cflow.cs:250:13:250:19 | After case ...: [match] |
-| cflow.cs:240:10:240:13 | Entry | cflow.cs:250:13:250:19 | After case ...: [no-match] |
-| cflow.cs:240:10:240:13 | Entry | cflow.cs:253:13:253:19 | After case ...: [match] |
-| cflow.cs:240:10:240:13 | Entry | cflow.cs:253:13:253:19 | After case ...: [no-match] |
+| cflow.cs:240:10:240:13 | Entry | cflow.cs:248:18:248:18 | After 0 [match] |
+| cflow.cs:240:10:240:13 | Entry | cflow.cs:248:18:248:18 | After 0 [no-match] |
+| cflow.cs:240:10:240:13 | Entry | cflow.cs:250:18:250:18 | After 1 [match] |
+| cflow.cs:240:10:240:13 | Entry | cflow.cs:250:18:250:18 | After 1 [no-match] |
+| cflow.cs:240:10:240:13 | Entry | cflow.cs:253:18:253:18 | After 2 [match] |
+| cflow.cs:240:10:240:13 | Entry | cflow.cs:253:18:253:18 | After 2 [no-match] |
 | cflow.cs:240:10:240:13 | Entry | cflow.cs:255:13:255:20 | After default: [match] |
 | cflow.cs:242:5:242:9 | Label: | cflow.cs:242:5:242:9 | Label: |
 | cflow.cs:242:5:242:9 | Label: | cflow.cs:242:12:242:41 | After if (...) ... |
@@ -19602,49 +19801,49 @@ blockDominance
 | cflow.cs:242:5:242:9 | Label: | cflow.cs:244:13:244:28 | After ... > ... [false] |
 | cflow.cs:242:5:242:9 | Label: | cflow.cs:244:13:244:28 | After ... > ... [true] |
 | cflow.cs:242:5:242:9 | Label: | cflow.cs:246:9:258:9 | After switch (...) {...} |
-| cflow.cs:242:5:242:9 | Label: | cflow.cs:248:13:248:19 | After case ...: [match] |
-| cflow.cs:242:5:242:9 | Label: | cflow.cs:248:13:248:19 | After case ...: [no-match] |
-| cflow.cs:242:5:242:9 | Label: | cflow.cs:250:13:250:19 | After case ...: [match] |
-| cflow.cs:242:5:242:9 | Label: | cflow.cs:250:13:250:19 | After case ...: [no-match] |
-| cflow.cs:242:5:242:9 | Label: | cflow.cs:253:13:253:19 | After case ...: [match] |
-| cflow.cs:242:5:242:9 | Label: | cflow.cs:253:13:253:19 | After case ...: [no-match] |
+| cflow.cs:242:5:242:9 | Label: | cflow.cs:248:18:248:18 | After 0 [match] |
+| cflow.cs:242:5:242:9 | Label: | cflow.cs:248:18:248:18 | After 0 [no-match] |
+| cflow.cs:242:5:242:9 | Label: | cflow.cs:250:18:250:18 | After 1 [match] |
+| cflow.cs:242:5:242:9 | Label: | cflow.cs:250:18:250:18 | After 1 [no-match] |
+| cflow.cs:242:5:242:9 | Label: | cflow.cs:253:18:253:18 | After 2 [match] |
+| cflow.cs:242:5:242:9 | Label: | cflow.cs:253:18:253:18 | After 2 [no-match] |
 | cflow.cs:242:5:242:9 | Label: | cflow.cs:255:13:255:20 | After default: [match] |
 | cflow.cs:242:12:242:41 | After if (...) ... | cflow.cs:242:12:242:41 | After if (...) ... |
 | cflow.cs:242:12:242:41 | After if (...) ... | cflow.cs:244:13:244:28 | After ... > ... [false] |
 | cflow.cs:242:12:242:41 | After if (...) ... | cflow.cs:244:13:244:28 | After ... > ... [true] |
 | cflow.cs:242:12:242:41 | After if (...) ... | cflow.cs:246:9:258:9 | After switch (...) {...} |
-| cflow.cs:242:12:242:41 | After if (...) ... | cflow.cs:248:13:248:19 | After case ...: [match] |
-| cflow.cs:242:12:242:41 | After if (...) ... | cflow.cs:248:13:248:19 | After case ...: [no-match] |
-| cflow.cs:242:12:242:41 | After if (...) ... | cflow.cs:250:13:250:19 | After case ...: [match] |
-| cflow.cs:242:12:242:41 | After if (...) ... | cflow.cs:250:13:250:19 | After case ...: [no-match] |
-| cflow.cs:242:12:242:41 | After if (...) ... | cflow.cs:253:13:253:19 | After case ...: [match] |
-| cflow.cs:242:12:242:41 | After if (...) ... | cflow.cs:253:13:253:19 | After case ...: [no-match] |
+| cflow.cs:242:12:242:41 | After if (...) ... | cflow.cs:248:18:248:18 | After 0 [match] |
+| cflow.cs:242:12:242:41 | After if (...) ... | cflow.cs:248:18:248:18 | After 0 [no-match] |
+| cflow.cs:242:12:242:41 | After if (...) ... | cflow.cs:250:18:250:18 | After 1 [match] |
+| cflow.cs:242:12:242:41 | After if (...) ... | cflow.cs:250:18:250:18 | After 1 [no-match] |
+| cflow.cs:242:12:242:41 | After if (...) ... | cflow.cs:253:18:253:18 | After 2 [match] |
+| cflow.cs:242:12:242:41 | After if (...) ... | cflow.cs:253:18:253:18 | After 2 [no-match] |
 | cflow.cs:242:12:242:41 | After if (...) ... | cflow.cs:255:13:255:20 | After default: [match] |
 | cflow.cs:242:19:242:35 | After ... == ... [false] | cflow.cs:242:19:242:35 | After ... == ... [false] |
 | cflow.cs:242:19:242:35 | After ... == ... [true] | cflow.cs:242:19:242:35 | After ... == ... [true] |
 | cflow.cs:244:13:244:28 | After ... > ... [false] | cflow.cs:244:13:244:28 | After ... > ... [false] |
 | cflow.cs:244:13:244:28 | After ... > ... [false] | cflow.cs:246:9:258:9 | After switch (...) {...} |
-| cflow.cs:244:13:244:28 | After ... > ... [false] | cflow.cs:248:13:248:19 | After case ...: [match] |
-| cflow.cs:244:13:244:28 | After ... > ... [false] | cflow.cs:248:13:248:19 | After case ...: [no-match] |
-| cflow.cs:244:13:244:28 | After ... > ... [false] | cflow.cs:250:13:250:19 | After case ...: [match] |
-| cflow.cs:244:13:244:28 | After ... > ... [false] | cflow.cs:250:13:250:19 | After case ...: [no-match] |
-| cflow.cs:244:13:244:28 | After ... > ... [false] | cflow.cs:253:13:253:19 | After case ...: [match] |
-| cflow.cs:244:13:244:28 | After ... > ... [false] | cflow.cs:253:13:253:19 | After case ...: [no-match] |
+| cflow.cs:244:13:244:28 | After ... > ... [false] | cflow.cs:248:18:248:18 | After 0 [match] |
+| cflow.cs:244:13:244:28 | After ... > ... [false] | cflow.cs:248:18:248:18 | After 0 [no-match] |
+| cflow.cs:244:13:244:28 | After ... > ... [false] | cflow.cs:250:18:250:18 | After 1 [match] |
+| cflow.cs:244:13:244:28 | After ... > ... [false] | cflow.cs:250:18:250:18 | After 1 [no-match] |
+| cflow.cs:244:13:244:28 | After ... > ... [false] | cflow.cs:253:18:253:18 | After 2 [match] |
+| cflow.cs:244:13:244:28 | After ... > ... [false] | cflow.cs:253:18:253:18 | After 2 [no-match] |
 | cflow.cs:244:13:244:28 | After ... > ... [false] | cflow.cs:255:13:255:20 | After default: [match] |
 | cflow.cs:244:13:244:28 | After ... > ... [true] | cflow.cs:244:13:244:28 | After ... > ... [true] |
 | cflow.cs:246:9:258:9 | After switch (...) {...} | cflow.cs:246:9:258:9 | After switch (...) {...} |
-| cflow.cs:248:13:248:19 | After case ...: [match] | cflow.cs:248:13:248:19 | After case ...: [match] |
-| cflow.cs:248:13:248:19 | After case ...: [no-match] | cflow.cs:248:13:248:19 | After case ...: [no-match] |
-| cflow.cs:248:13:248:19 | After case ...: [no-match] | cflow.cs:250:13:250:19 | After case ...: [match] |
-| cflow.cs:248:13:248:19 | After case ...: [no-match] | cflow.cs:250:13:250:19 | After case ...: [no-match] |
-| cflow.cs:248:13:248:19 | After case ...: [no-match] | cflow.cs:253:13:253:19 | After case ...: [match] |
-| cflow.cs:248:13:248:19 | After case ...: [no-match] | cflow.cs:253:13:253:19 | After case ...: [no-match] |
-| cflow.cs:250:13:250:19 | After case ...: [match] | cflow.cs:250:13:250:19 | After case ...: [match] |
-| cflow.cs:250:13:250:19 | After case ...: [no-match] | cflow.cs:250:13:250:19 | After case ...: [no-match] |
-| cflow.cs:250:13:250:19 | After case ...: [no-match] | cflow.cs:253:13:253:19 | After case ...: [match] |
-| cflow.cs:250:13:250:19 | After case ...: [no-match] | cflow.cs:253:13:253:19 | After case ...: [no-match] |
-| cflow.cs:253:13:253:19 | After case ...: [match] | cflow.cs:253:13:253:19 | After case ...: [match] |
-| cflow.cs:253:13:253:19 | After case ...: [no-match] | cflow.cs:253:13:253:19 | After case ...: [no-match] |
+| cflow.cs:248:18:248:18 | After 0 [match] | cflow.cs:248:18:248:18 | After 0 [match] |
+| cflow.cs:248:18:248:18 | After 0 [no-match] | cflow.cs:248:18:248:18 | After 0 [no-match] |
+| cflow.cs:248:18:248:18 | After 0 [no-match] | cflow.cs:250:18:250:18 | After 1 [match] |
+| cflow.cs:248:18:248:18 | After 0 [no-match] | cflow.cs:250:18:250:18 | After 1 [no-match] |
+| cflow.cs:248:18:248:18 | After 0 [no-match] | cflow.cs:253:18:253:18 | After 2 [match] |
+| cflow.cs:248:18:248:18 | After 0 [no-match] | cflow.cs:253:18:253:18 | After 2 [no-match] |
+| cflow.cs:250:18:250:18 | After 1 [match] | cflow.cs:250:18:250:18 | After 1 [match] |
+| cflow.cs:250:18:250:18 | After 1 [no-match] | cflow.cs:250:18:250:18 | After 1 [no-match] |
+| cflow.cs:250:18:250:18 | After 1 [no-match] | cflow.cs:253:18:253:18 | After 2 [match] |
+| cflow.cs:250:18:250:18 | After 1 [no-match] | cflow.cs:253:18:253:18 | After 2 [no-match] |
+| cflow.cs:253:18:253:18 | After 2 [match] | cflow.cs:253:18:253:18 | After 2 [match] |
+| cflow.cs:253:18:253:18 | After 2 [no-match] | cflow.cs:253:18:253:18 | After 2 [no-match] |
 | cflow.cs:255:13:255:20 | After default: [match] | cflow.cs:255:13:255:20 | After default: [match] |
 | cflow.cs:261:49:261:53 | Entry | cflow.cs:261:49:261:53 | Entry |
 | cflow.cs:261:49:261:53 | Entry | cflow.cs:261:49:261:53 | Exceptional Exit |
@@ -22546,34 +22745,34 @@ postBlockDominance
 | Patterns.cs:20:9:38:9 | After switch (...) {...} | Patterns.cs:16:18:16:28 | After ... is ... [false] |
 | Patterns.cs:20:9:38:9 | After switch (...) {...} | Patterns.cs:16:18:16:28 | [MatchTrue] ... is ... |
 | Patterns.cs:20:9:38:9 | After switch (...) {...} | Patterns.cs:20:9:38:9 | After switch (...) {...} |
-| Patterns.cs:20:9:38:9 | After switch (...) {...} | Patterns.cs:22:13:22:23 | After case ...: [match] |
-| Patterns.cs:20:9:38:9 | After switch (...) {...} | Patterns.cs:22:13:22:23 | After case ...: [no-match] |
-| Patterns.cs:20:9:38:9 | After switch (...) {...} | Patterns.cs:24:13:24:36 | After case ...: [match] |
-| Patterns.cs:20:9:38:9 | After switch (...) {...} | Patterns.cs:24:13:24:36 | After case ...: [no-match] |
+| Patterns.cs:20:9:38:9 | After switch (...) {...} | Patterns.cs:22:18:22:22 | After "xyz" [match] |
+| Patterns.cs:20:9:38:9 | After switch (...) {...} | Patterns.cs:22:18:22:22 | After "xyz" [no-match] |
+| Patterns.cs:20:9:38:9 | After switch (...) {...} | Patterns.cs:24:18:24:23 | After Int32 i2 [match] |
+| Patterns.cs:20:9:38:9 | After switch (...) {...} | Patterns.cs:24:18:24:23 | After Int32 i2 [no-match] |
 | Patterns.cs:20:9:38:9 | After switch (...) {...} | Patterns.cs:24:30:24:35 | After ... > ... [false] |
 | Patterns.cs:20:9:38:9 | After switch (...) {...} | Patterns.cs:24:30:24:35 | After ... > ... [true] |
-| Patterns.cs:20:9:38:9 | After switch (...) {...} | Patterns.cs:27:13:27:24 | After case ...: [match] |
-| Patterns.cs:20:9:38:9 | After switch (...) {...} | Patterns.cs:27:13:27:24 | After case ...: [no-match] |
 | Patterns.cs:20:9:38:9 | After switch (...) {...} | Patterns.cs:27:13:27:24 | case ...: |
-| Patterns.cs:20:9:38:9 | After switch (...) {...} | Patterns.cs:30:13:30:27 | After case ...: [match] |
-| Patterns.cs:20:9:38:9 | After switch (...) {...} | Patterns.cs:30:13:30:27 | After case ...: [no-match] |
-| Patterns.cs:20:9:38:9 | After switch (...) {...} | Patterns.cs:33:13:33:24 | After case ...: [match] |
-| Patterns.cs:20:9:38:9 | After switch (...) {...} | Patterns.cs:33:13:33:24 | After case ...: [no-match] |
-| Patterns.cs:22:13:22:23 | After case ...: [match] | Patterns.cs:22:13:22:23 | After case ...: [match] |
-| Patterns.cs:22:13:22:23 | After case ...: [no-match] | Patterns.cs:22:13:22:23 | After case ...: [no-match] |
-| Patterns.cs:24:13:24:36 | After case ...: [match] | Patterns.cs:24:13:24:36 | After case ...: [match] |
-| Patterns.cs:24:13:24:36 | After case ...: [no-match] | Patterns.cs:24:13:24:36 | After case ...: [no-match] |
+| Patterns.cs:20:9:38:9 | After switch (...) {...} | Patterns.cs:27:18:27:23 | After Int32 i3 [match] |
+| Patterns.cs:20:9:38:9 | After switch (...) {...} | Patterns.cs:27:18:27:23 | After Int32 i3 [no-match] |
+| Patterns.cs:20:9:38:9 | After switch (...) {...} | Patterns.cs:30:18:30:26 | After String s2 [match] |
+| Patterns.cs:20:9:38:9 | After switch (...) {...} | Patterns.cs:30:18:30:26 | After String s2 [no-match] |
+| Patterns.cs:20:9:38:9 | After switch (...) {...} | Patterns.cs:33:18:33:23 | After Object v2 [match] |
+| Patterns.cs:20:9:38:9 | After switch (...) {...} | Patterns.cs:33:18:33:23 | After Object v2 [no-match] |
+| Patterns.cs:22:18:22:22 | After "xyz" [match] | Patterns.cs:22:18:22:22 | After "xyz" [match] |
+| Patterns.cs:22:18:22:22 | After "xyz" [no-match] | Patterns.cs:22:18:22:22 | After "xyz" [no-match] |
+| Patterns.cs:24:18:24:23 | After Int32 i2 [match] | Patterns.cs:24:18:24:23 | After Int32 i2 [match] |
+| Patterns.cs:24:18:24:23 | After Int32 i2 [no-match] | Patterns.cs:24:18:24:23 | After Int32 i2 [no-match] |
 | Patterns.cs:24:30:24:35 | After ... > ... [false] | Patterns.cs:24:30:24:35 | After ... > ... [false] |
 | Patterns.cs:24:30:24:35 | After ... > ... [true] | Patterns.cs:24:30:24:35 | After ... > ... [true] |
-| Patterns.cs:27:13:27:24 | After case ...: [match] | Patterns.cs:27:13:27:24 | After case ...: [match] |
-| Patterns.cs:27:13:27:24 | After case ...: [no-match] | Patterns.cs:27:13:27:24 | After case ...: [no-match] |
-| Patterns.cs:27:13:27:24 | case ...: | Patterns.cs:24:13:24:36 | After case ...: [no-match] |
+| Patterns.cs:27:13:27:24 | case ...: | Patterns.cs:24:18:24:23 | After Int32 i2 [no-match] |
 | Patterns.cs:27:13:27:24 | case ...: | Patterns.cs:24:30:24:35 | After ... > ... [false] |
 | Patterns.cs:27:13:27:24 | case ...: | Patterns.cs:27:13:27:24 | case ...: |
-| Patterns.cs:30:13:30:27 | After case ...: [match] | Patterns.cs:30:13:30:27 | After case ...: [match] |
-| Patterns.cs:30:13:30:27 | After case ...: [no-match] | Patterns.cs:30:13:30:27 | After case ...: [no-match] |
-| Patterns.cs:33:13:33:24 | After case ...: [match] | Patterns.cs:33:13:33:24 | After case ...: [match] |
-| Patterns.cs:33:13:33:24 | After case ...: [no-match] | Patterns.cs:33:13:33:24 | After case ...: [no-match] |
+| Patterns.cs:27:18:27:23 | After Int32 i3 [match] | Patterns.cs:27:18:27:23 | After Int32 i3 [match] |
+| Patterns.cs:27:18:27:23 | After Int32 i3 [no-match] | Patterns.cs:27:18:27:23 | After Int32 i3 [no-match] |
+| Patterns.cs:30:18:30:26 | After String s2 [match] | Patterns.cs:30:18:30:26 | After String s2 [match] |
+| Patterns.cs:30:18:30:26 | After String s2 [no-match] | Patterns.cs:30:18:30:26 | After String s2 [no-match] |
+| Patterns.cs:33:18:33:23 | After Object v2 [match] | Patterns.cs:33:18:33:23 | After Object v2 [match] |
+| Patterns.cs:33:18:33:23 | After Object v2 [no-match] | Patterns.cs:33:18:33:23 | After Object v2 [no-match] |
 | Patterns.cs:47:24:47:25 | Entry | Patterns.cs:47:24:47:25 | Entry |
 | Patterns.cs:48:9:48:20 | After ... is ... | Patterns.cs:47:24:47:25 | Entry |
 | Patterns.cs:48:9:48:20 | After ... is ... | Patterns.cs:48:9:48:20 | After ... is ... |
@@ -22606,36 +22805,36 @@ postBlockDominance
 | Patterns.cs:56:26:56:27 | Entry | Patterns.cs:56:26:56:27 | Entry |
 | Patterns.cs:58:16:62:9 | After ... switch { ... } | Patterns.cs:56:26:56:27 | Entry |
 | Patterns.cs:58:16:62:9 | After ... switch { ... } | Patterns.cs:58:16:62:9 | After ... switch { ... } |
-| Patterns.cs:58:16:62:9 | After ... switch { ... } | Patterns.cs:60:13:60:28 | After ... => ... [match] |
-| Patterns.cs:58:16:62:9 | After ... switch { ... } | Patterns.cs:60:13:60:28 | After ... => ... [no-match] |
-| Patterns.cs:60:13:60:28 | After ... => ... [match] | Patterns.cs:60:13:60:28 | After ... => ... [match] |
-| Patterns.cs:60:13:60:28 | After ... => ... [no-match] | Patterns.cs:60:13:60:28 | After ... => ... [no-match] |
+| Patterns.cs:58:16:62:9 | After ... switch { ... } | Patterns.cs:60:13:60:17 | After not ... [match] |
+| Patterns.cs:58:16:62:9 | After ... switch { ... } | Patterns.cs:60:13:60:17 | After not ... [no-match] |
+| Patterns.cs:60:13:60:17 | After not ... [match] | Patterns.cs:60:13:60:17 | After not ... [match] |
+| Patterns.cs:60:13:60:17 | After not ... [no-match] | Patterns.cs:60:13:60:17 | After not ... [no-match] |
 | Patterns.cs:65:26:65:27 | Entry | Patterns.cs:65:26:65:27 | Entry |
 | Patterns.cs:67:16:71:9 | After ... switch { ... } | Patterns.cs:65:26:65:27 | Entry |
 | Patterns.cs:67:16:71:9 | After ... switch { ... } | Patterns.cs:67:16:71:9 | After ... switch { ... } |
-| Patterns.cs:67:16:71:9 | After ... switch { ... } | Patterns.cs:69:13:69:33 | After ... => ... [match] |
-| Patterns.cs:67:16:71:9 | After ... switch { ... } | Patterns.cs:69:13:69:33 | After ... => ... [no-match] |
-| Patterns.cs:67:16:71:9 | After ... switch { ... } | Patterns.cs:70:13:70:27 | After ... => ... [match] |
-| Patterns.cs:67:16:71:9 | After ... switch { ... } | Patterns.cs:70:13:70:27 | After ... => ... [no-match] |
-| Patterns.cs:69:13:69:33 | After ... => ... [match] | Patterns.cs:69:13:69:33 | After ... => ... [match] |
-| Patterns.cs:69:13:69:33 | After ... => ... [no-match] | Patterns.cs:69:13:69:33 | After ... => ... [no-match] |
-| Patterns.cs:70:13:70:27 | After ... => ... [match] | Patterns.cs:70:13:70:27 | After ... => ... [match] |
-| Patterns.cs:70:13:70:27 | After ... => ... [no-match] | Patterns.cs:70:13:70:27 | After ... => ... [no-match] |
+| Patterns.cs:67:16:71:9 | After ... switch { ... } | Patterns.cs:69:13:69:17 | After not ... [match] |
+| Patterns.cs:67:16:71:9 | After ... switch { ... } | Patterns.cs:69:13:69:17 | After not ... [no-match] |
+| Patterns.cs:67:16:71:9 | After ... switch { ... } | Patterns.cs:70:13:70:13 | After 2 [match] |
+| Patterns.cs:67:16:71:9 | After ... switch { ... } | Patterns.cs:70:13:70:13 | After 2 [no-match] |
+| Patterns.cs:69:13:69:17 | After not ... [match] | Patterns.cs:69:13:69:17 | After not ... [match] |
+| Patterns.cs:69:13:69:17 | After not ... [no-match] | Patterns.cs:69:13:69:17 | After not ... [no-match] |
+| Patterns.cs:70:13:70:13 | After 2 [match] | Patterns.cs:70:13:70:13 | After 2 [match] |
+| Patterns.cs:70:13:70:13 | After 2 [no-match] | Patterns.cs:70:13:70:13 | After 2 [no-match] |
 | Patterns.cs:74:26:74:27 | Entry | Patterns.cs:74:26:74:27 | Entry |
 | Patterns.cs:76:16:82:9 | After ... switch { ... } | Patterns.cs:74:26:74:27 | Entry |
 | Patterns.cs:76:16:82:9 | After ... switch { ... } | Patterns.cs:76:16:82:9 | After ... switch { ... } |
-| Patterns.cs:76:16:82:9 | After ... switch { ... } | Patterns.cs:78:13:78:24 | After ... => ... [match] |
-| Patterns.cs:76:16:82:9 | After ... switch { ... } | Patterns.cs:78:13:78:24 | After ... => ... [no-match] |
-| Patterns.cs:76:16:82:9 | After ... switch { ... } | Patterns.cs:79:13:79:24 | After ... => ... [match] |
-| Patterns.cs:76:16:82:9 | After ... switch { ... } | Patterns.cs:79:13:79:24 | After ... => ... [no-match] |
-| Patterns.cs:76:16:82:9 | After ... switch { ... } | Patterns.cs:80:13:80:20 | After ... => ... [match] |
-| Patterns.cs:76:16:82:9 | After ... switch { ... } | Patterns.cs:80:13:80:20 | After ... => ... [no-match] |
-| Patterns.cs:78:13:78:24 | After ... => ... [match] | Patterns.cs:78:13:78:24 | After ... => ... [match] |
-| Patterns.cs:78:13:78:24 | After ... => ... [no-match] | Patterns.cs:78:13:78:24 | After ... => ... [no-match] |
-| Patterns.cs:79:13:79:24 | After ... => ... [match] | Patterns.cs:79:13:79:24 | After ... => ... [match] |
-| Patterns.cs:79:13:79:24 | After ... => ... [no-match] | Patterns.cs:79:13:79:24 | After ... => ... [no-match] |
-| Patterns.cs:80:13:80:20 | After ... => ... [match] | Patterns.cs:80:13:80:20 | After ... => ... [match] |
-| Patterns.cs:80:13:80:20 | After ... => ... [no-match] | Patterns.cs:80:13:80:20 | After ... => ... [no-match] |
+| Patterns.cs:76:16:82:9 | After ... switch { ... } | Patterns.cs:78:13:78:15 | After > ... [match] |
+| Patterns.cs:76:16:82:9 | After ... switch { ... } | Patterns.cs:78:13:78:15 | After > ... [no-match] |
+| Patterns.cs:76:16:82:9 | After ... switch { ... } | Patterns.cs:79:13:79:15 | After < ... [match] |
+| Patterns.cs:76:16:82:9 | After ... switch { ... } | Patterns.cs:79:13:79:15 | After < ... [no-match] |
+| Patterns.cs:76:16:82:9 | After ... switch { ... } | Patterns.cs:80:13:80:13 | After 1 [match] |
+| Patterns.cs:76:16:82:9 | After ... switch { ... } | Patterns.cs:80:13:80:13 | After 1 [no-match] |
+| Patterns.cs:78:13:78:15 | After > ... [match] | Patterns.cs:78:13:78:15 | After > ... [match] |
+| Patterns.cs:78:13:78:15 | After > ... [no-match] | Patterns.cs:78:13:78:15 | After > ... [no-match] |
+| Patterns.cs:79:13:79:15 | After < ... [match] | Patterns.cs:79:13:79:15 | After < ... [match] |
+| Patterns.cs:79:13:79:15 | After < ... [no-match] | Patterns.cs:79:13:79:15 | After < ... [no-match] |
+| Patterns.cs:80:13:80:13 | After 1 [match] | Patterns.cs:80:13:80:13 | After 1 [match] |
+| Patterns.cs:80:13:80:13 | After 1 [no-match] | Patterns.cs:80:13:80:13 | After 1 [no-match] |
 | Patterns.cs:85:26:85:27 | Entry | Patterns.cs:85:26:85:27 | Entry |
 | Patterns.cs:85:39:85:53 | After ... is ... [false] | Patterns.cs:85:39:85:53 | After ... is ... [false] |
 | Patterns.cs:85:39:85:53 | [MatchTrue] ... is ... | Patterns.cs:85:39:85:53 | [MatchTrue] ... is ... |
@@ -22682,38 +22881,39 @@ postBlockDominance
 | Switch.cs:10:10:10:11 | Exit | Switch.cs:10:10:10:11 | Exit |
 | Switch.cs:10:10:10:11 | Normal Exit | Switch.cs:10:10:10:11 | Entry |
 | Switch.cs:10:10:10:11 | Normal Exit | Switch.cs:10:10:10:11 | Normal Exit |
-| Switch.cs:10:10:10:11 | Normal Exit | Switch.cs:14:13:14:21 | After case ...: [match] |
-| Switch.cs:10:10:10:11 | Normal Exit | Switch.cs:14:13:14:21 | After case ...: [no-match] |
-| Switch.cs:10:10:10:11 | Normal Exit | Switch.cs:16:13:16:19 | After case ...: [no-match] |
-| Switch.cs:10:10:10:11 | Normal Exit | Switch.cs:18:13:18:22 | After case ...: [match] |
-| Switch.cs:10:10:10:11 | Normal Exit | Switch.cs:18:13:18:22 | After case ...: [no-match] |
-| Switch.cs:10:10:10:11 | Normal Exit | Switch.cs:20:13:20:23 | After case ...: [match] |
-| Switch.cs:10:10:10:11 | Normal Exit | Switch.cs:20:13:20:23 | After case ...: [no-match] |
+| Switch.cs:10:10:10:11 | Normal Exit | Switch.cs:14:18:14:20 | After "a" [match] |
+| Switch.cs:10:10:10:11 | Normal Exit | Switch.cs:14:18:14:20 | After "a" [no-match] |
+| Switch.cs:10:10:10:11 | Normal Exit | Switch.cs:16:18:16:18 | After 0 [no-match] |
+| Switch.cs:10:10:10:11 | Normal Exit | Switch.cs:18:18:18:21 | After null [match] |
+| Switch.cs:10:10:10:11 | Normal Exit | Switch.cs:18:18:18:21 | After null [no-match] |
+| Switch.cs:10:10:10:11 | Normal Exit | Switch.cs:20:18:20:22 | After Int32 i [match] |
+| Switch.cs:10:10:10:11 | Normal Exit | Switch.cs:20:18:20:22 | After Int32 i [no-match] |
 | Switch.cs:10:10:10:11 | Normal Exit | Switch.cs:21:21:21:29 | After ... == ... [true] |
-| Switch.cs:10:10:10:11 | Normal Exit | Switch.cs:24:13:24:56 | After case ...: [match] |
-| Switch.cs:10:10:10:11 | Normal Exit | Switch.cs:24:13:24:56 | After case ...: [no-match] |
+| Switch.cs:10:10:10:11 | Normal Exit | Switch.cs:24:18:24:25 | After String s [match] |
+| Switch.cs:10:10:10:11 | Normal Exit | Switch.cs:24:18:24:25 | After String s [no-match] |
 | Switch.cs:10:10:10:11 | Normal Exit | Switch.cs:24:32:24:43 | After ... > ... [false] |
 | Switch.cs:10:10:10:11 | Normal Exit | Switch.cs:24:32:24:43 | After ... > ... [true] |
 | Switch.cs:10:10:10:11 | Normal Exit | Switch.cs:24:32:24:55 | After ... && ... [false] |
 | Switch.cs:10:10:10:11 | Normal Exit | Switch.cs:24:48:24:55 | After ... != ... [false] |
 | Switch.cs:10:10:10:11 | Normal Exit | Switch.cs:24:48:24:55 | After ... != ... [true] |
-| Switch.cs:10:10:10:11 | Normal Exit | Switch.cs:27:13:27:39 | After case ...: [no-match] |
 | Switch.cs:10:10:10:11 | Normal Exit | Switch.cs:27:13:27:39 | case ...: |
+| Switch.cs:10:10:10:11 | Normal Exit | Switch.cs:27:18:27:25 | After Double d [no-match] |
 | Switch.cs:10:10:10:11 | Normal Exit | Switch.cs:30:13:30:20 | After default: [match] |
-| Switch.cs:14:13:14:21 | After case ...: [match] | Switch.cs:14:13:14:21 | After case ...: [match] |
-| Switch.cs:14:13:14:21 | After case ...: [no-match] | Switch.cs:14:13:14:21 | After case ...: [no-match] |
+| Switch.cs:14:18:14:20 | After "a" [match] | Switch.cs:14:18:14:20 | After "a" [match] |
+| Switch.cs:14:18:14:20 | After "a" [no-match] | Switch.cs:14:18:14:20 | After "a" [no-match] |
 | Switch.cs:16:13:16:19 | After case ...: [match] | Switch.cs:16:13:16:19 | After case ...: [match] |
-| Switch.cs:16:13:16:19 | After case ...: [no-match] | Switch.cs:14:13:14:21 | After case ...: [no-match] |
-| Switch.cs:16:13:16:19 | After case ...: [no-match] | Switch.cs:16:13:16:19 | After case ...: [no-match] |
-| Switch.cs:18:13:18:22 | After case ...: [match] | Switch.cs:18:13:18:22 | After case ...: [match] |
-| Switch.cs:18:13:18:22 | After case ...: [no-match] | Switch.cs:18:13:18:22 | After case ...: [no-match] |
-| Switch.cs:20:13:20:23 | After case ...: [match] | Switch.cs:20:13:20:23 | After case ...: [match] |
-| Switch.cs:20:13:20:23 | After case ...: [no-match] | Switch.cs:20:13:20:23 | After case ...: [no-match] |
+| Switch.cs:16:18:16:18 | After 0 [match] | Switch.cs:16:18:16:18 | After 0 [match] |
+| Switch.cs:16:18:16:18 | After 0 [no-match] | Switch.cs:14:18:14:20 | After "a" [no-match] |
+| Switch.cs:16:18:16:18 | After 0 [no-match] | Switch.cs:16:18:16:18 | After 0 [no-match] |
+| Switch.cs:18:18:18:21 | After null [match] | Switch.cs:18:18:18:21 | After null [match] |
+| Switch.cs:18:18:18:21 | After null [no-match] | Switch.cs:18:18:18:21 | After null [no-match] |
+| Switch.cs:20:18:20:22 | After Int32 i [match] | Switch.cs:20:18:20:22 | After Int32 i [match] |
+| Switch.cs:20:18:20:22 | After Int32 i [no-match] | Switch.cs:20:18:20:22 | After Int32 i [no-match] |
 | Switch.cs:21:21:21:29 | After ... == ... [false] | Switch.cs:21:21:21:29 | After ... == ... [false] |
-| Switch.cs:21:21:21:29 | After ... == ... [true] | Switch.cs:20:13:20:23 | After case ...: [match] |
+| Switch.cs:21:21:21:29 | After ... == ... [true] | Switch.cs:20:18:20:22 | After Int32 i [match] |
 | Switch.cs:21:21:21:29 | After ... == ... [true] | Switch.cs:21:21:21:29 | After ... == ... [true] |
-| Switch.cs:24:13:24:56 | After case ...: [match] | Switch.cs:24:13:24:56 | After case ...: [match] |
-| Switch.cs:24:13:24:56 | After case ...: [no-match] | Switch.cs:24:13:24:56 | After case ...: [no-match] |
+| Switch.cs:24:18:24:25 | After String s [match] | Switch.cs:24:18:24:25 | After String s [match] |
+| Switch.cs:24:18:24:25 | After String s [no-match] | Switch.cs:24:18:24:25 | After String s [no-match] |
 | Switch.cs:24:32:24:43 | After ... > ... [false] | Switch.cs:24:32:24:43 | After ... > ... [false] |
 | Switch.cs:24:32:24:43 | After ... > ... [true] | Switch.cs:24:32:24:43 | After ... > ... [true] |
 | Switch.cs:24:32:24:55 | After ... && ... [false] | Switch.cs:24:32:24:43 | After ... > ... [false] |
@@ -22721,136 +22921,136 @@ postBlockDominance
 | Switch.cs:24:32:24:55 | After ... && ... [false] | Switch.cs:24:48:24:55 | After ... != ... [false] |
 | Switch.cs:24:48:24:55 | After ... != ... [false] | Switch.cs:24:48:24:55 | After ... != ... [false] |
 | Switch.cs:24:48:24:55 | After ... != ... [true] | Switch.cs:24:48:24:55 | After ... != ... [true] |
-| Switch.cs:27:13:27:39 | After case ...: [match] | Switch.cs:27:13:27:39 | After case ...: [match] |
-| Switch.cs:27:13:27:39 | After case ...: [no-match] | Switch.cs:24:13:24:56 | After case ...: [no-match] |
-| Switch.cs:27:13:27:39 | After case ...: [no-match] | Switch.cs:24:32:24:43 | After ... > ... [false] |
-| Switch.cs:27:13:27:39 | After case ...: [no-match] | Switch.cs:24:32:24:55 | After ... && ... [false] |
-| Switch.cs:27:13:27:39 | After case ...: [no-match] | Switch.cs:24:48:24:55 | After ... != ... [false] |
-| Switch.cs:27:13:27:39 | After case ...: [no-match] | Switch.cs:27:13:27:39 | After case ...: [no-match] |
-| Switch.cs:27:13:27:39 | After case ...: [no-match] | Switch.cs:27:13:27:39 | case ...: |
-| Switch.cs:27:13:27:39 | case ...: | Switch.cs:24:13:24:56 | After case ...: [no-match] |
+| Switch.cs:27:13:27:39 | case ...: | Switch.cs:24:18:24:25 | After String s [no-match] |
 | Switch.cs:27:13:27:39 | case ...: | Switch.cs:24:32:24:43 | After ... > ... [false] |
 | Switch.cs:27:13:27:39 | case ...: | Switch.cs:24:32:24:55 | After ... && ... [false] |
 | Switch.cs:27:13:27:39 | case ...: | Switch.cs:24:48:24:55 | After ... != ... [false] |
 | Switch.cs:27:13:27:39 | case ...: | Switch.cs:27:13:27:39 | case ...: |
-| Switch.cs:30:13:30:20 | After default: [match] | Switch.cs:18:13:18:22 | After case ...: [match] |
-| Switch.cs:30:13:30:20 | After default: [match] | Switch.cs:24:13:24:56 | After case ...: [no-match] |
+| Switch.cs:27:18:27:25 | After Double d [match] | Switch.cs:27:18:27:25 | After Double d [match] |
+| Switch.cs:27:18:27:25 | After Double d [no-match] | Switch.cs:24:18:24:25 | After String s [no-match] |
+| Switch.cs:27:18:27:25 | After Double d [no-match] | Switch.cs:24:32:24:43 | After ... > ... [false] |
+| Switch.cs:27:18:27:25 | After Double d [no-match] | Switch.cs:24:32:24:55 | After ... && ... [false] |
+| Switch.cs:27:18:27:25 | After Double d [no-match] | Switch.cs:24:48:24:55 | After ... != ... [false] |
+| Switch.cs:27:18:27:25 | After Double d [no-match] | Switch.cs:27:13:27:39 | case ...: |
+| Switch.cs:27:18:27:25 | After Double d [no-match] | Switch.cs:27:18:27:25 | After Double d [no-match] |
+| Switch.cs:30:13:30:20 | After default: [match] | Switch.cs:18:18:18:21 | After null [match] |
+| Switch.cs:30:13:30:20 | After default: [match] | Switch.cs:24:18:24:25 | After String s [no-match] |
 | Switch.cs:30:13:30:20 | After default: [match] | Switch.cs:24:32:24:43 | After ... > ... [false] |
 | Switch.cs:30:13:30:20 | After default: [match] | Switch.cs:24:32:24:55 | After ... && ... [false] |
 | Switch.cs:30:13:30:20 | After default: [match] | Switch.cs:24:48:24:55 | After ... != ... [false] |
-| Switch.cs:30:13:30:20 | After default: [match] | Switch.cs:27:13:27:39 | After case ...: [no-match] |
 | Switch.cs:30:13:30:20 | After default: [match] | Switch.cs:27:13:27:39 | case ...: |
+| Switch.cs:30:13:30:20 | After default: [match] | Switch.cs:27:18:27:25 | After Double d [no-match] |
 | Switch.cs:30:13:30:20 | After default: [match] | Switch.cs:30:13:30:20 | After default: [match] |
 | Switch.cs:35:10:35:11 | Entry | Switch.cs:35:10:35:11 | Entry |
 | Switch.cs:44:10:44:11 | Entry | Switch.cs:44:10:44:11 | Entry |
 | Switch.cs:46:9:52:9 | After switch (...) {...} | Switch.cs:44:10:44:11 | Entry |
 | Switch.cs:46:9:52:9 | After switch (...) {...} | Switch.cs:46:9:52:9 | After switch (...) {...} |
-| Switch.cs:46:9:52:9 | After switch (...) {...} | Switch.cs:48:13:48:23 | After case ...: [match] |
-| Switch.cs:46:9:52:9 | After switch (...) {...} | Switch.cs:48:13:48:23 | After case ...: [no-match] |
-| Switch.cs:46:9:52:9 | After switch (...) {...} | Switch.cs:50:13:50:39 | After case ...: [match] |
-| Switch.cs:46:9:52:9 | After switch (...) {...} | Switch.cs:50:13:50:39 | After case ...: [no-match] |
+| Switch.cs:46:9:52:9 | After switch (...) {...} | Switch.cs:48:18:48:20 | After access to type Int32 [match] |
+| Switch.cs:46:9:52:9 | After switch (...) {...} | Switch.cs:48:18:48:20 | After access to type Int32 [no-match] |
+| Switch.cs:46:9:52:9 | After switch (...) {...} | Switch.cs:50:18:50:21 | After access to type Boolean [match] |
+| Switch.cs:46:9:52:9 | After switch (...) {...} | Switch.cs:50:18:50:21 | After access to type Boolean [no-match] |
 | Switch.cs:46:9:52:9 | After switch (...) {...} | Switch.cs:50:30:50:38 | After ... != ... [false] |
 | Switch.cs:46:9:52:9 | After switch (...) {...} | Switch.cs:50:30:50:38 | After ... != ... [true] |
-| Switch.cs:48:13:48:23 | After case ...: [match] | Switch.cs:48:13:48:23 | After case ...: [match] |
-| Switch.cs:48:13:48:23 | After case ...: [no-match] | Switch.cs:48:13:48:23 | After case ...: [no-match] |
-| Switch.cs:50:13:50:39 | After case ...: [match] | Switch.cs:50:13:50:39 | After case ...: [match] |
-| Switch.cs:50:13:50:39 | After case ...: [no-match] | Switch.cs:50:13:50:39 | After case ...: [no-match] |
+| Switch.cs:48:18:48:20 | After access to type Int32 [match] | Switch.cs:48:18:48:20 | After access to type Int32 [match] |
+| Switch.cs:48:18:48:20 | After access to type Int32 [no-match] | Switch.cs:48:18:48:20 | After access to type Int32 [no-match] |
+| Switch.cs:50:18:50:21 | After access to type Boolean [match] | Switch.cs:50:18:50:21 | After access to type Boolean [match] |
+| Switch.cs:50:18:50:21 | After access to type Boolean [no-match] | Switch.cs:50:18:50:21 | After access to type Boolean [no-match] |
 | Switch.cs:50:30:50:38 | After ... != ... [false] | Switch.cs:50:30:50:38 | After ... != ... [false] |
 | Switch.cs:50:30:50:38 | After ... != ... [true] | Switch.cs:50:30:50:38 | After ... != ... [true] |
 | Switch.cs:55:10:55:11 | Entry | Switch.cs:55:10:55:11 | Entry |
 | Switch.cs:57:9:63:9 | After switch (...) {...} | Switch.cs:55:10:55:11 | Entry |
 | Switch.cs:57:9:63:9 | After switch (...) {...} | Switch.cs:57:9:63:9 | After switch (...) {...} |
-| Switch.cs:57:9:63:9 | After switch (...) {...} | Switch.cs:59:13:59:19 | After case ...: [match] |
-| Switch.cs:57:9:63:9 | After switch (...) {...} | Switch.cs:59:13:59:19 | After case ...: [no-match] |
-| Switch.cs:57:9:63:9 | After switch (...) {...} | Switch.cs:61:13:61:19 | After case ...: [match] |
-| Switch.cs:57:9:63:9 | After switch (...) {...} | Switch.cs:61:13:61:19 | After case ...: [no-match] |
-| Switch.cs:59:13:59:19 | After case ...: [match] | Switch.cs:59:13:59:19 | After case ...: [match] |
-| Switch.cs:59:13:59:19 | After case ...: [no-match] | Switch.cs:59:13:59:19 | After case ...: [no-match] |
-| Switch.cs:61:13:61:19 | After case ...: [match] | Switch.cs:61:13:61:19 | After case ...: [match] |
-| Switch.cs:61:13:61:19 | After case ...: [no-match] | Switch.cs:61:13:61:19 | After case ...: [no-match] |
+| Switch.cs:57:9:63:9 | After switch (...) {...} | Switch.cs:59:18:59:18 | After 2 [match] |
+| Switch.cs:57:9:63:9 | After switch (...) {...} | Switch.cs:59:18:59:18 | After 2 [no-match] |
+| Switch.cs:57:9:63:9 | After switch (...) {...} | Switch.cs:61:18:61:18 | After 3 [match] |
+| Switch.cs:57:9:63:9 | After switch (...) {...} | Switch.cs:61:18:61:18 | After 3 [no-match] |
+| Switch.cs:59:18:59:18 | After 2 [match] | Switch.cs:59:18:59:18 | After 2 [match] |
+| Switch.cs:59:18:59:18 | After 2 [no-match] | Switch.cs:59:18:59:18 | After 2 [no-match] |
+| Switch.cs:61:18:61:18 | After 3 [match] | Switch.cs:61:18:61:18 | After 3 [match] |
+| Switch.cs:61:18:61:18 | After 3 [no-match] | Switch.cs:61:18:61:18 | After 3 [no-match] |
 | Switch.cs:66:10:66:11 | Entry | Switch.cs:66:10:66:11 | Entry |
 | Switch.cs:68:9:74:9 | After switch (...) {...} | Switch.cs:66:10:66:11 | Entry |
 | Switch.cs:68:9:74:9 | After switch (...) {...} | Switch.cs:68:9:74:9 | After switch (...) {...} |
-| Switch.cs:68:9:74:9 | After switch (...) {...} | Switch.cs:70:13:70:23 | After case ...: [match] |
-| Switch.cs:68:9:74:9 | After switch (...) {...} | Switch.cs:70:13:70:23 | After case ...: [no-match] |
-| Switch.cs:68:9:74:9 | After switch (...) {...} | Switch.cs:72:13:72:20 | After case ...: [match] |
-| Switch.cs:68:9:74:9 | After switch (...) {...} | Switch.cs:72:13:72:20 | After case ...: [no-match] |
-| Switch.cs:70:13:70:23 | After case ...: [match] | Switch.cs:70:13:70:23 | After case ...: [match] |
-| Switch.cs:70:13:70:23 | After case ...: [no-match] | Switch.cs:70:13:70:23 | After case ...: [no-match] |
-| Switch.cs:72:13:72:20 | After case ...: [match] | Switch.cs:72:13:72:20 | After case ...: [match] |
-| Switch.cs:72:13:72:20 | After case ...: [no-match] | Switch.cs:72:13:72:20 | After case ...: [no-match] |
+| Switch.cs:68:9:74:9 | After switch (...) {...} | Switch.cs:70:18:70:20 | After access to type Int32 [match] |
+| Switch.cs:68:9:74:9 | After switch (...) {...} | Switch.cs:70:18:70:20 | After access to type Int32 [no-match] |
+| Switch.cs:68:9:74:9 | After switch (...) {...} | Switch.cs:72:18:72:19 | After "" [match] |
+| Switch.cs:68:9:74:9 | After switch (...) {...} | Switch.cs:72:18:72:19 | After "" [no-match] |
+| Switch.cs:70:18:70:20 | After access to type Int32 [match] | Switch.cs:70:18:70:20 | After access to type Int32 [match] |
+| Switch.cs:70:18:70:20 | After access to type Int32 [no-match] | Switch.cs:70:18:70:20 | After access to type Int32 [no-match] |
+| Switch.cs:72:18:72:19 | After "" [match] | Switch.cs:72:18:72:19 | After "" [match] |
+| Switch.cs:72:18:72:19 | After "" [no-match] | Switch.cs:72:18:72:19 | After "" [no-match] |
 | Switch.cs:77:10:77:11 | Entry | Switch.cs:77:10:77:11 | Entry |
 | Switch.cs:77:10:77:11 | Normal Exit | Switch.cs:77:10:77:11 | Entry |
 | Switch.cs:77:10:77:11 | Normal Exit | Switch.cs:77:10:77:11 | Normal Exit |
 | Switch.cs:77:10:77:11 | Normal Exit | Switch.cs:79:9:87:9 | After switch (...) {...} |
-| Switch.cs:77:10:77:11 | Normal Exit | Switch.cs:81:13:81:19 | After case ...: [match] |
-| Switch.cs:77:10:77:11 | Normal Exit | Switch.cs:81:13:81:19 | After case ...: [no-match] |
-| Switch.cs:77:10:77:11 | Normal Exit | Switch.cs:83:13:83:19 | After case ...: [match] |
-| Switch.cs:77:10:77:11 | Normal Exit | Switch.cs:83:13:83:19 | After case ...: [no-match] |
+| Switch.cs:77:10:77:11 | Normal Exit | Switch.cs:81:18:81:18 | After 1 [match] |
+| Switch.cs:77:10:77:11 | Normal Exit | Switch.cs:81:18:81:18 | After 1 [no-match] |
+| Switch.cs:77:10:77:11 | Normal Exit | Switch.cs:83:18:83:18 | After 2 [match] |
+| Switch.cs:77:10:77:11 | Normal Exit | Switch.cs:83:18:83:18 | After 2 [no-match] |
 | Switch.cs:77:10:77:11 | Normal Exit | Switch.cs:84:21:84:25 | After ... > ... [false] |
 | Switch.cs:77:10:77:11 | Normal Exit | Switch.cs:84:21:84:25 | After ... > ... [true] |
 | Switch.cs:79:9:87:9 | After switch (...) {...} | Switch.cs:79:9:87:9 | After switch (...) {...} |
-| Switch.cs:79:9:87:9 | After switch (...) {...} | Switch.cs:83:13:83:19 | After case ...: [no-match] |
+| Switch.cs:79:9:87:9 | After switch (...) {...} | Switch.cs:83:18:83:18 | After 2 [no-match] |
 | Switch.cs:79:9:87:9 | After switch (...) {...} | Switch.cs:84:21:84:25 | After ... > ... [true] |
-| Switch.cs:81:13:81:19 | After case ...: [match] | Switch.cs:81:13:81:19 | After case ...: [match] |
-| Switch.cs:81:13:81:19 | After case ...: [no-match] | Switch.cs:81:13:81:19 | After case ...: [no-match] |
-| Switch.cs:83:13:83:19 | After case ...: [match] | Switch.cs:83:13:83:19 | After case ...: [match] |
-| Switch.cs:83:13:83:19 | After case ...: [no-match] | Switch.cs:83:13:83:19 | After case ...: [no-match] |
+| Switch.cs:81:18:81:18 | After 1 [match] | Switch.cs:81:18:81:18 | After 1 [match] |
+| Switch.cs:81:18:81:18 | After 1 [no-match] | Switch.cs:81:18:81:18 | After 1 [no-match] |
+| Switch.cs:83:18:83:18 | After 2 [match] | Switch.cs:83:18:83:18 | After 2 [match] |
+| Switch.cs:83:18:83:18 | After 2 [no-match] | Switch.cs:83:18:83:18 | After 2 [no-match] |
 | Switch.cs:84:21:84:25 | After ... > ... [false] | Switch.cs:84:21:84:25 | After ... > ... [false] |
 | Switch.cs:84:21:84:25 | After ... > ... [true] | Switch.cs:84:21:84:25 | After ... > ... [true] |
 | Switch.cs:91:10:91:11 | Entry | Switch.cs:91:10:91:11 | Entry |
 | Switch.cs:91:10:91:11 | Normal Exit | Switch.cs:91:10:91:11 | Entry |
 | Switch.cs:91:10:91:11 | Normal Exit | Switch.cs:91:10:91:11 | Normal Exit |
-| Switch.cs:91:10:91:11 | Normal Exit | Switch.cs:95:13:95:23 | After case ...: [match] |
-| Switch.cs:91:10:91:11 | Normal Exit | Switch.cs:95:13:95:23 | After case ...: [no-match] |
-| Switch.cs:95:13:95:23 | After case ...: [match] | Switch.cs:95:13:95:23 | After case ...: [match] |
-| Switch.cs:95:13:95:23 | After case ...: [no-match] | Switch.cs:95:13:95:23 | After case ...: [no-match] |
+| Switch.cs:91:10:91:11 | Normal Exit | Switch.cs:95:18:95:20 | After access to type Int32 [match] |
+| Switch.cs:91:10:91:11 | Normal Exit | Switch.cs:95:18:95:20 | After access to type Int32 [no-match] |
+| Switch.cs:95:18:95:20 | After access to type Int32 [match] | Switch.cs:95:18:95:20 | After access to type Int32 [match] |
+| Switch.cs:95:18:95:20 | After access to type Int32 [no-match] | Switch.cs:95:18:95:20 | After access to type Int32 [no-match] |
 | Switch.cs:101:9:101:10 | Entry | Switch.cs:101:9:101:10 | Entry |
 | Switch.cs:101:9:101:10 | Normal Exit | Switch.cs:101:9:101:10 | Entry |
 | Switch.cs:101:9:101:10 | Normal Exit | Switch.cs:101:9:101:10 | Normal Exit |
 | Switch.cs:101:9:101:10 | Normal Exit | Switch.cs:103:17:103:17 | After access to parameter s [non-null] |
 | Switch.cs:101:9:101:10 | Normal Exit | Switch.cs:103:17:103:17 | After access to parameter s [null] |
 | Switch.cs:101:9:101:10 | Normal Exit | Switch.cs:103:17:103:25 | After access to property Length |
-| Switch.cs:101:9:101:10 | Normal Exit | Switch.cs:105:13:105:19 | After case ...: [match] |
-| Switch.cs:101:9:101:10 | Normal Exit | Switch.cs:105:13:105:19 | After case ...: [no-match] |
-| Switch.cs:101:9:101:10 | Normal Exit | Switch.cs:106:13:106:19 | After case ...: [match] |
-| Switch.cs:101:9:101:10 | Normal Exit | Switch.cs:106:13:106:19 | After case ...: [no-match] |
+| Switch.cs:101:9:101:10 | Normal Exit | Switch.cs:105:18:105:18 | After 0 [match] |
+| Switch.cs:101:9:101:10 | Normal Exit | Switch.cs:105:18:105:18 | After 0 [no-match] |
+| Switch.cs:101:9:101:10 | Normal Exit | Switch.cs:106:18:106:18 | After 1 [match] |
+| Switch.cs:101:9:101:10 | Normal Exit | Switch.cs:106:18:106:18 | After 1 [no-match] |
 | Switch.cs:103:17:103:17 | After access to parameter s [non-null] | Switch.cs:103:17:103:17 | After access to parameter s [non-null] |
 | Switch.cs:103:17:103:17 | After access to parameter s [null] | Switch.cs:103:17:103:17 | After access to parameter s [null] |
 | Switch.cs:103:17:103:25 | After access to property Length | Switch.cs:101:9:101:10 | Entry |
 | Switch.cs:103:17:103:25 | After access to property Length | Switch.cs:103:17:103:17 | After access to parameter s [non-null] |
 | Switch.cs:103:17:103:25 | After access to property Length | Switch.cs:103:17:103:17 | After access to parameter s [null] |
 | Switch.cs:103:17:103:25 | After access to property Length | Switch.cs:103:17:103:25 | After access to property Length |
-| Switch.cs:105:13:105:19 | After case ...: [match] | Switch.cs:105:13:105:19 | After case ...: [match] |
-| Switch.cs:105:13:105:19 | After case ...: [no-match] | Switch.cs:105:13:105:19 | After case ...: [no-match] |
-| Switch.cs:106:13:106:19 | After case ...: [match] | Switch.cs:106:13:106:19 | After case ...: [match] |
-| Switch.cs:106:13:106:19 | After case ...: [no-match] | Switch.cs:106:13:106:19 | After case ...: [no-match] |
+| Switch.cs:105:18:105:18 | After 0 [match] | Switch.cs:105:18:105:18 | After 0 [match] |
+| Switch.cs:105:18:105:18 | After 0 [no-match] | Switch.cs:105:18:105:18 | After 0 [no-match] |
+| Switch.cs:106:18:106:18 | After 1 [match] | Switch.cs:106:18:106:18 | After 1 [match] |
+| Switch.cs:106:18:106:18 | After 1 [no-match] | Switch.cs:106:18:106:18 | After 1 [no-match] |
 | Switch.cs:111:17:111:21 | Entry | Switch.cs:111:17:111:21 | Entry |
 | Switch.cs:113:9:113:11 | Entry | Switch.cs:113:9:113:11 | Entry |
 | Switch.cs:113:9:113:11 | Normal Exit | Switch.cs:113:9:113:11 | Entry |
 | Switch.cs:113:9:113:11 | Normal Exit | Switch.cs:113:9:113:11 | Normal Exit |
 | Switch.cs:113:9:113:11 | Normal Exit | Switch.cs:115:9:119:9 | After switch (...) {...} |
-| Switch.cs:113:9:113:11 | Normal Exit | Switch.cs:117:13:117:35 | After case ...: [match] |
-| Switch.cs:113:9:113:11 | Normal Exit | Switch.cs:117:13:117:35 | After case ...: [no-match] |
+| Switch.cs:113:9:113:11 | Normal Exit | Switch.cs:117:18:117:18 | After 3 [match] |
+| Switch.cs:113:9:113:11 | Normal Exit | Switch.cs:117:18:117:18 | After 3 [no-match] |
 | Switch.cs:113:9:113:11 | Normal Exit | Switch.cs:117:25:117:34 | After ... == ... [false] |
 | Switch.cs:113:9:113:11 | Normal Exit | Switch.cs:117:25:117:34 | After ... == ... [true] |
-| Switch.cs:113:9:113:11 | Normal Exit | Switch.cs:118:13:118:34 | After case ...: [match] |
-| Switch.cs:113:9:113:11 | Normal Exit | Switch.cs:118:13:118:34 | After case ...: [no-match] |
 | Switch.cs:113:9:113:11 | Normal Exit | Switch.cs:118:13:118:34 | case ...: |
+| Switch.cs:113:9:113:11 | Normal Exit | Switch.cs:118:18:118:18 | After 2 [match] |
+| Switch.cs:113:9:113:11 | Normal Exit | Switch.cs:118:18:118:18 | After 2 [no-match] |
 | Switch.cs:113:9:113:11 | Normal Exit | Switch.cs:118:25:118:33 | After ... == ... [false] |
 | Switch.cs:113:9:113:11 | Normal Exit | Switch.cs:118:25:118:33 | After ... == ... [true] |
 | Switch.cs:115:9:119:9 | After switch (...) {...} | Switch.cs:115:9:119:9 | After switch (...) {...} |
-| Switch.cs:115:9:119:9 | After switch (...) {...} | Switch.cs:118:13:118:34 | After case ...: [no-match] |
+| Switch.cs:115:9:119:9 | After switch (...) {...} | Switch.cs:118:18:118:18 | After 2 [no-match] |
 | Switch.cs:115:9:119:9 | After switch (...) {...} | Switch.cs:118:25:118:33 | After ... == ... [false] |
-| Switch.cs:117:13:117:35 | After case ...: [match] | Switch.cs:117:13:117:35 | After case ...: [match] |
-| Switch.cs:117:13:117:35 | After case ...: [no-match] | Switch.cs:117:13:117:35 | After case ...: [no-match] |
+| Switch.cs:117:18:117:18 | After 3 [match] | Switch.cs:117:18:117:18 | After 3 [match] |
+| Switch.cs:117:18:117:18 | After 3 [no-match] | Switch.cs:117:18:117:18 | After 3 [no-match] |
 | Switch.cs:117:25:117:34 | After ... == ... [false] | Switch.cs:117:25:117:34 | After ... == ... [false] |
 | Switch.cs:117:25:117:34 | After ... == ... [true] | Switch.cs:117:25:117:34 | After ... == ... [true] |
-| Switch.cs:118:13:118:34 | After case ...: [match] | Switch.cs:118:13:118:34 | After case ...: [match] |
-| Switch.cs:118:13:118:34 | After case ...: [no-match] | Switch.cs:118:13:118:34 | After case ...: [no-match] |
-| Switch.cs:118:13:118:34 | case ...: | Switch.cs:117:13:117:35 | After case ...: [no-match] |
+| Switch.cs:118:13:118:34 | case ...: | Switch.cs:117:18:117:18 | After 3 [no-match] |
 | Switch.cs:118:13:118:34 | case ...: | Switch.cs:117:25:117:34 | After ... == ... [false] |
 | Switch.cs:118:13:118:34 | case ...: | Switch.cs:118:13:118:34 | case ...: |
+| Switch.cs:118:18:118:18 | After 2 [match] | Switch.cs:118:18:118:18 | After 2 [match] |
+| Switch.cs:118:18:118:18 | After 2 [no-match] | Switch.cs:118:18:118:18 | After 2 [no-match] |
 | Switch.cs:118:25:118:33 | After ... == ... [false] | Switch.cs:118:25:118:33 | After ... == ... [false] |
 | Switch.cs:118:25:118:33 | After ... == ... [true] | Switch.cs:118:25:118:33 | After ... == ... [true] |
 | Switch.cs:123:10:123:12 | Entry | Switch.cs:123:10:123:12 | Entry |
@@ -22858,62 +23058,62 @@ postBlockDominance
 | Switch.cs:123:10:123:12 | Normal Exit | Switch.cs:123:10:123:12 | Normal Exit |
 | Switch.cs:123:10:123:12 | Normal Exit | Switch.cs:125:13:125:48 | After ... switch { ... } [false] |
 | Switch.cs:123:10:123:12 | Normal Exit | Switch.cs:125:13:125:48 | After ... switch { ... } [true] |
-| Switch.cs:123:10:123:12 | Normal Exit | Switch.cs:125:24:125:34 | After ... => ... [match] |
-| Switch.cs:123:10:123:12 | Normal Exit | Switch.cs:125:24:125:34 | After ... => ... [no-match] |
+| Switch.cs:123:10:123:12 | Normal Exit | Switch.cs:125:24:125:29 | After Boolean b [match] |
+| Switch.cs:123:10:123:12 | Normal Exit | Switch.cs:125:24:125:29 | After Boolean b [no-match] |
 | Switch.cs:125:13:125:48 | After ... switch { ... } [false] | Switch.cs:125:13:125:48 | After ... switch { ... } [false] |
 | Switch.cs:125:13:125:48 | After ... switch { ... } [true] | Switch.cs:125:13:125:48 | After ... switch { ... } [true] |
-| Switch.cs:125:24:125:34 | After ... => ... [match] | Switch.cs:125:24:125:34 | After ... => ... [match] |
-| Switch.cs:125:24:125:34 | After ... => ... [no-match] | Switch.cs:125:24:125:34 | After ... => ... [no-match] |
+| Switch.cs:125:24:125:29 | After Boolean b [match] | Switch.cs:125:24:125:29 | After Boolean b [match] |
+| Switch.cs:125:24:125:29 | After Boolean b [no-match] | Switch.cs:125:24:125:29 | After Boolean b [no-match] |
 | Switch.cs:129:12:129:14 | Entry | Switch.cs:129:12:129:14 | Entry |
 | Switch.cs:131:16:131:66 | After call to method ToString | Switch.cs:129:12:129:14 | Entry |
 | Switch.cs:131:16:131:66 | After call to method ToString | Switch.cs:131:16:131:66 | After call to method ToString |
 | Switch.cs:131:16:131:66 | After call to method ToString | Switch.cs:131:17:131:53 | After ... switch { ... } [non-null] |
 | Switch.cs:131:16:131:66 | After call to method ToString | Switch.cs:131:17:131:53 | After ... switch { ... } [null] |
-| Switch.cs:131:16:131:66 | After call to method ToString | Switch.cs:131:28:131:40 | After ... => ... [match] |
-| Switch.cs:131:16:131:66 | After call to method ToString | Switch.cs:131:28:131:40 | After ... => ... [no-match] |
+| Switch.cs:131:16:131:66 | After call to method ToString | Switch.cs:131:28:131:35 | After String s [match] |
+| Switch.cs:131:16:131:66 | After call to method ToString | Switch.cs:131:28:131:35 | After String s [no-match] |
 | Switch.cs:131:17:131:53 | After ... switch { ... } [non-null] | Switch.cs:131:17:131:53 | After ... switch { ... } [non-null] |
 | Switch.cs:131:17:131:53 | After ... switch { ... } [null] | Switch.cs:131:17:131:53 | After ... switch { ... } [null] |
-| Switch.cs:131:28:131:40 | After ... => ... [match] | Switch.cs:131:28:131:40 | After ... => ... [match] |
-| Switch.cs:131:28:131:40 | After ... => ... [no-match] | Switch.cs:131:28:131:40 | After ... => ... [no-match] |
+| Switch.cs:131:28:131:35 | After String s [match] | Switch.cs:131:28:131:35 | After String s [match] |
+| Switch.cs:131:28:131:35 | After String s [no-match] | Switch.cs:131:28:131:35 | After String s [no-match] |
 | Switch.cs:134:9:134:11 | Entry | Switch.cs:134:9:134:11 | Entry |
 | Switch.cs:134:9:134:11 | Normal Exit | Switch.cs:134:9:134:11 | Entry |
 | Switch.cs:134:9:134:11 | Normal Exit | Switch.cs:134:9:134:11 | Normal Exit |
-| Switch.cs:134:9:134:11 | Normal Exit | Switch.cs:139:13:139:19 | After case ...: [match] |
-| Switch.cs:134:9:134:11 | Normal Exit | Switch.cs:139:13:139:19 | After case ...: [no-match] |
-| Switch.cs:134:9:134:11 | Normal Exit | Switch.cs:140:13:140:19 | After case ...: [match] |
-| Switch.cs:134:9:134:11 | Normal Exit | Switch.cs:140:13:140:19 | After case ...: [no-match] |
-| Switch.cs:139:13:139:19 | After case ...: [match] | Switch.cs:139:13:139:19 | After case ...: [match] |
-| Switch.cs:139:13:139:19 | After case ...: [no-match] | Switch.cs:139:13:139:19 | After case ...: [no-match] |
-| Switch.cs:140:13:140:19 | After case ...: [match] | Switch.cs:140:13:140:19 | After case ...: [match] |
-| Switch.cs:140:13:140:19 | After case ...: [no-match] | Switch.cs:140:13:140:19 | After case ...: [no-match] |
+| Switch.cs:134:9:134:11 | Normal Exit | Switch.cs:139:18:139:18 | After 1 [match] |
+| Switch.cs:134:9:134:11 | Normal Exit | Switch.cs:139:18:139:18 | After 1 [no-match] |
+| Switch.cs:134:9:134:11 | Normal Exit | Switch.cs:140:18:140:18 | After 2 [match] |
+| Switch.cs:134:9:134:11 | Normal Exit | Switch.cs:140:18:140:18 | After 2 [no-match] |
+| Switch.cs:139:18:139:18 | After 1 [match] | Switch.cs:139:18:139:18 | After 1 [match] |
+| Switch.cs:139:18:139:18 | After 1 [no-match] | Switch.cs:139:18:139:18 | After 1 [no-match] |
+| Switch.cs:140:18:140:18 | After 2 [match] | Switch.cs:140:18:140:18 | After 2 [match] |
+| Switch.cs:140:18:140:18 | After 2 [no-match] | Switch.cs:140:18:140:18 | After 2 [no-match] |
 | Switch.cs:144:9:144:11 | Entry | Switch.cs:144:9:144:11 | Entry |
 | Switch.cs:144:9:144:11 | Normal Exit | Switch.cs:144:9:144:11 | Entry |
 | Switch.cs:144:9:144:11 | Normal Exit | Switch.cs:144:9:144:11 | Normal Exit |
-| Switch.cs:144:9:144:11 | Normal Exit | Switch.cs:148:13:148:19 | After case ...: [match] |
-| Switch.cs:144:9:144:11 | Normal Exit | Switch.cs:148:13:148:19 | After case ...: [no-match] |
-| Switch.cs:144:9:144:11 | Normal Exit | Switch.cs:150:13:150:19 | After case ...: [match] |
-| Switch.cs:144:9:144:11 | Normal Exit | Switch.cs:150:13:150:19 | After case ...: [no-match] |
-| Switch.cs:148:13:148:19 | After case ...: [match] | Switch.cs:148:13:148:19 | After case ...: [match] |
-| Switch.cs:148:13:148:19 | After case ...: [no-match] | Switch.cs:148:13:148:19 | After case ...: [no-match] |
-| Switch.cs:150:13:150:19 | After case ...: [match] | Switch.cs:150:13:150:19 | After case ...: [match] |
-| Switch.cs:150:13:150:19 | After case ...: [no-match] | Switch.cs:150:13:150:19 | After case ...: [no-match] |
+| Switch.cs:144:9:144:11 | Normal Exit | Switch.cs:148:18:148:18 | After 1 [match] |
+| Switch.cs:144:9:144:11 | Normal Exit | Switch.cs:148:18:148:18 | After 1 [no-match] |
+| Switch.cs:144:9:144:11 | Normal Exit | Switch.cs:150:18:150:18 | After 2 [match] |
+| Switch.cs:144:9:144:11 | Normal Exit | Switch.cs:150:18:150:18 | After 2 [no-match] |
+| Switch.cs:148:18:148:18 | After 1 [match] | Switch.cs:148:18:148:18 | After 1 [match] |
+| Switch.cs:148:18:148:18 | After 1 [no-match] | Switch.cs:148:18:148:18 | After 1 [no-match] |
+| Switch.cs:150:18:150:18 | After 2 [match] | Switch.cs:150:18:150:18 | After 2 [match] |
+| Switch.cs:150:18:150:18 | After 2 [no-match] | Switch.cs:150:18:150:18 | After 2 [no-match] |
 | Switch.cs:154:10:154:12 | Entry | Switch.cs:154:10:154:12 | Entry |
 | Switch.cs:156:17:156:54 | After ... switch { ... } | Switch.cs:154:10:154:12 | Entry |
 | Switch.cs:156:17:156:54 | After ... switch { ... } | Switch.cs:156:17:156:54 | After ... switch { ... } |
-| Switch.cs:156:17:156:54 | After ... switch { ... } | Switch.cs:156:28:156:38 | After ... => ... [match] |
-| Switch.cs:156:17:156:54 | After ... switch { ... } | Switch.cs:156:28:156:38 | After ... => ... [no-match] |
-| Switch.cs:156:17:156:54 | After ... switch { ... } | Switch.cs:156:41:156:52 | After ... => ... [match] |
-| Switch.cs:156:17:156:54 | After ... switch { ... } | Switch.cs:156:41:156:52 | After ... => ... [no-match] |
-| Switch.cs:156:28:156:38 | After ... => ... [match] | Switch.cs:156:28:156:38 | After ... => ... [match] |
-| Switch.cs:156:28:156:38 | After ... => ... [no-match] | Switch.cs:156:28:156:38 | After ... => ... [no-match] |
-| Switch.cs:156:41:156:52 | After ... => ... [match] | Switch.cs:156:41:156:52 | After ... => ... [match] |
-| Switch.cs:156:41:156:52 | After ... => ... [no-match] | Switch.cs:156:41:156:52 | After ... => ... [no-match] |
+| Switch.cs:156:17:156:54 | After ... switch { ... } | Switch.cs:156:28:156:31 | After true [match] |
+| Switch.cs:156:17:156:54 | After ... switch { ... } | Switch.cs:156:28:156:31 | After true [no-match] |
+| Switch.cs:156:17:156:54 | After ... switch { ... } | Switch.cs:156:41:156:45 | After false [match] |
+| Switch.cs:156:17:156:54 | After ... switch { ... } | Switch.cs:156:41:156:45 | After false [no-match] |
+| Switch.cs:156:28:156:31 | After true [match] | Switch.cs:156:28:156:31 | After true [match] |
+| Switch.cs:156:28:156:31 | After true [no-match] | Switch.cs:156:28:156:31 | After true [no-match] |
+| Switch.cs:156:41:156:45 | After false [match] | Switch.cs:156:41:156:45 | After false [match] |
+| Switch.cs:156:41:156:45 | After false [no-match] | Switch.cs:156:41:156:45 | After false [no-match] |
 | Switch.cs:157:9:160:49 | After if (...) ... | Switch.cs:154:10:154:12 | Entry |
 | Switch.cs:157:9:160:49 | After if (...) ... | Switch.cs:156:17:156:54 | After ... switch { ... } |
-| Switch.cs:157:9:160:49 | After if (...) ... | Switch.cs:156:28:156:38 | After ... => ... [match] |
-| Switch.cs:157:9:160:49 | After if (...) ... | Switch.cs:156:28:156:38 | After ... => ... [no-match] |
-| Switch.cs:157:9:160:49 | After if (...) ... | Switch.cs:156:41:156:52 | After ... => ... [match] |
-| Switch.cs:157:9:160:49 | After if (...) ... | Switch.cs:156:41:156:52 | After ... => ... [no-match] |
+| Switch.cs:157:9:160:49 | After if (...) ... | Switch.cs:156:28:156:31 | After true [match] |
+| Switch.cs:157:9:160:49 | After if (...) ... | Switch.cs:156:28:156:31 | After true [no-match] |
+| Switch.cs:157:9:160:49 | After if (...) ... | Switch.cs:156:41:156:45 | After false [match] |
+| Switch.cs:157:9:160:49 | After if (...) ... | Switch.cs:156:41:156:45 | After false [no-match] |
 | Switch.cs:157:9:160:49 | After if (...) ... | Switch.cs:157:9:160:49 | After if (...) ... |
 | Switch.cs:157:9:160:49 | After if (...) ... | Switch.cs:157:13:157:13 | After access to parameter b [false] |
 | Switch.cs:157:9:160:49 | After if (...) ... | Switch.cs:157:13:157:13 | After access to parameter b [true] |
@@ -22922,22 +23122,22 @@ postBlockDominance
 | Switch.cs:163:10:163:12 | Entry | Switch.cs:163:10:163:12 | Entry |
 | Switch.cs:165:9:177:9 | After switch (...) {...} | Switch.cs:163:10:163:12 | Entry |
 | Switch.cs:165:9:177:9 | After switch (...) {...} | Switch.cs:165:9:177:9 | After switch (...) {...} |
-| Switch.cs:165:9:177:9 | After switch (...) {...} | Switch.cs:167:13:167:19 | After case ...: [match] |
-| Switch.cs:165:9:177:9 | After switch (...) {...} | Switch.cs:167:13:167:19 | After case ...: [no-match] |
-| Switch.cs:165:9:177:9 | After switch (...) {...} | Switch.cs:168:13:168:19 | After case ...: [match] |
-| Switch.cs:165:9:177:9 | After switch (...) {...} | Switch.cs:168:13:168:19 | After case ...: [no-match] |
+| Switch.cs:165:9:177:9 | After switch (...) {...} | Switch.cs:167:18:167:18 | After 1 [match] |
+| Switch.cs:165:9:177:9 | After switch (...) {...} | Switch.cs:167:18:167:18 | After 1 [no-match] |
+| Switch.cs:165:9:177:9 | After switch (...) {...} | Switch.cs:168:18:168:18 | After 2 [match] |
+| Switch.cs:165:9:177:9 | After switch (...) {...} | Switch.cs:168:18:168:18 | After 2 [no-match] |
 | Switch.cs:165:9:177:9 | After switch (...) {...} | Switch.cs:169:17:169:51 | ...; |
-| Switch.cs:165:9:177:9 | After switch (...) {...} | Switch.cs:171:13:171:19 | After case ...: [match] |
-| Switch.cs:165:9:177:9 | After switch (...) {...} | Switch.cs:171:13:171:19 | After case ...: [no-match] |
-| Switch.cs:167:13:167:19 | After case ...: [match] | Switch.cs:167:13:167:19 | After case ...: [match] |
-| Switch.cs:167:13:167:19 | After case ...: [no-match] | Switch.cs:167:13:167:19 | After case ...: [no-match] |
-| Switch.cs:168:13:168:19 | After case ...: [match] | Switch.cs:168:13:168:19 | After case ...: [match] |
-| Switch.cs:168:13:168:19 | After case ...: [no-match] | Switch.cs:168:13:168:19 | After case ...: [no-match] |
-| Switch.cs:169:17:169:51 | ...; | Switch.cs:167:13:167:19 | After case ...: [match] |
-| Switch.cs:169:17:169:51 | ...; | Switch.cs:168:13:168:19 | After case ...: [match] |
+| Switch.cs:165:9:177:9 | After switch (...) {...} | Switch.cs:171:18:171:18 | After 3 [match] |
+| Switch.cs:165:9:177:9 | After switch (...) {...} | Switch.cs:171:18:171:18 | After 3 [no-match] |
+| Switch.cs:167:18:167:18 | After 1 [match] | Switch.cs:167:18:167:18 | After 1 [match] |
+| Switch.cs:167:18:167:18 | After 1 [no-match] | Switch.cs:167:18:167:18 | After 1 [no-match] |
+| Switch.cs:168:18:168:18 | After 2 [match] | Switch.cs:168:18:168:18 | After 2 [match] |
+| Switch.cs:168:18:168:18 | After 2 [no-match] | Switch.cs:168:18:168:18 | After 2 [no-match] |
+| Switch.cs:169:17:169:51 | ...; | Switch.cs:167:18:167:18 | After 1 [match] |
+| Switch.cs:169:17:169:51 | ...; | Switch.cs:168:18:168:18 | After 2 [match] |
 | Switch.cs:169:17:169:51 | ...; | Switch.cs:169:17:169:51 | ...; |
-| Switch.cs:171:13:171:19 | After case ...: [match] | Switch.cs:171:13:171:19 | After case ...: [match] |
-| Switch.cs:171:13:171:19 | After case ...: [no-match] | Switch.cs:171:13:171:19 | After case ...: [no-match] |
+| Switch.cs:171:18:171:18 | After 3 [match] | Switch.cs:171:18:171:18 | After 3 [match] |
+| Switch.cs:171:18:171:18 | After 3 [no-match] | Switch.cs:171:18:171:18 | After 3 [no-match] |
 | TypeAccesses.cs:1:7:1:18 | Entry | TypeAccesses.cs:1:7:1:18 | Entry |
 | TypeAccesses.cs:3:10:3:10 | Entry | TypeAccesses.cs:3:10:3:10 | Entry |
 | TypeAccesses.cs:7:9:7:25 | After if (...) ... | TypeAccesses.cs:3:10:3:10 | Entry |
@@ -23090,47 +23290,49 @@ postBlockDominance
 | cflow.cs:37:17:37:22 | Exit | cflow.cs:37:17:37:22 | Exit |
 | cflow.cs:39:9:50:9 | After switch (...) {...} | cflow.cs:37:17:37:22 | Entry |
 | cflow.cs:39:9:50:9 | After switch (...) {...} | cflow.cs:39:9:50:9 | After switch (...) {...} |
-| cflow.cs:39:9:50:9 | After switch (...) {...} | cflow.cs:41:13:41:19 | After case ...: [no-match] |
-| cflow.cs:39:9:50:9 | After switch (...) {...} | cflow.cs:44:13:44:19 | After case ...: [no-match] |
-| cflow.cs:39:9:50:9 | After switch (...) {...} | cflow.cs:47:13:47:19 | After case ...: [match] |
-| cflow.cs:39:9:50:9 | After switch (...) {...} | cflow.cs:47:13:47:19 | After case ...: [no-match] |
+| cflow.cs:39:9:50:9 | After switch (...) {...} | cflow.cs:41:18:41:18 | After 1 [no-match] |
+| cflow.cs:39:9:50:9 | After switch (...) {...} | cflow.cs:44:18:44:18 | After 2 [no-match] |
+| cflow.cs:39:9:50:9 | After switch (...) {...} | cflow.cs:47:18:47:18 | After 3 [match] |
+| cflow.cs:39:9:50:9 | After switch (...) {...} | cflow.cs:47:18:47:18 | After 3 [no-match] |
 | cflow.cs:41:13:41:19 | After case ...: [match] | cflow.cs:41:13:41:19 | After case ...: [match] |
-| cflow.cs:41:13:41:19 | After case ...: [no-match] | cflow.cs:37:17:37:22 | Entry |
-| cflow.cs:41:13:41:19 | After case ...: [no-match] | cflow.cs:41:13:41:19 | After case ...: [no-match] |
+| cflow.cs:41:18:41:18 | After 1 [match] | cflow.cs:41:18:41:18 | After 1 [match] |
+| cflow.cs:41:18:41:18 | After 1 [no-match] | cflow.cs:37:17:37:22 | Entry |
+| cflow.cs:41:18:41:18 | After 1 [no-match] | cflow.cs:41:18:41:18 | After 1 [no-match] |
 | cflow.cs:44:13:44:19 | After case ...: [match] | cflow.cs:44:13:44:19 | After case ...: [match] |
-| cflow.cs:44:13:44:19 | After case ...: [no-match] | cflow.cs:37:17:37:22 | Entry |
-| cflow.cs:44:13:44:19 | After case ...: [no-match] | cflow.cs:41:13:41:19 | After case ...: [no-match] |
-| cflow.cs:44:13:44:19 | After case ...: [no-match] | cflow.cs:44:13:44:19 | After case ...: [no-match] |
-| cflow.cs:47:13:47:19 | After case ...: [match] | cflow.cs:47:13:47:19 | After case ...: [match] |
-| cflow.cs:47:13:47:19 | After case ...: [no-match] | cflow.cs:47:13:47:19 | After case ...: [no-match] |
+| cflow.cs:44:18:44:18 | After 2 [match] | cflow.cs:44:18:44:18 | After 2 [match] |
+| cflow.cs:44:18:44:18 | After 2 [no-match] | cflow.cs:37:17:37:22 | Entry |
+| cflow.cs:44:18:44:18 | After 2 [no-match] | cflow.cs:41:18:41:18 | After 1 [no-match] |
+| cflow.cs:44:18:44:18 | After 2 [no-match] | cflow.cs:44:18:44:18 | After 2 [no-match] |
+| cflow.cs:47:18:47:18 | After 3 [match] | cflow.cs:47:18:47:18 | After 3 [match] |
+| cflow.cs:47:18:47:18 | After 3 [no-match] | cflow.cs:47:18:47:18 | After 3 [no-match] |
 | cflow.cs:51:9:59:9 | After switch (...) {...} | cflow.cs:37:17:37:22 | Entry |
 | cflow.cs:51:9:59:9 | After switch (...) {...} | cflow.cs:39:9:50:9 | After switch (...) {...} |
-| cflow.cs:51:9:59:9 | After switch (...) {...} | cflow.cs:41:13:41:19 | After case ...: [no-match] |
-| cflow.cs:51:9:59:9 | After switch (...) {...} | cflow.cs:44:13:44:19 | After case ...: [no-match] |
-| cflow.cs:51:9:59:9 | After switch (...) {...} | cflow.cs:47:13:47:19 | After case ...: [match] |
-| cflow.cs:51:9:59:9 | After switch (...) {...} | cflow.cs:47:13:47:19 | After case ...: [no-match] |
+| cflow.cs:51:9:59:9 | After switch (...) {...} | cflow.cs:41:18:41:18 | After 1 [no-match] |
+| cflow.cs:51:9:59:9 | After switch (...) {...} | cflow.cs:44:18:44:18 | After 2 [no-match] |
+| cflow.cs:51:9:59:9 | After switch (...) {...} | cflow.cs:47:18:47:18 | After 3 [match] |
+| cflow.cs:51:9:59:9 | After switch (...) {...} | cflow.cs:47:18:47:18 | After 3 [no-match] |
 | cflow.cs:51:9:59:9 | After switch (...) {...} | cflow.cs:51:9:59:9 | After switch (...) {...} |
-| cflow.cs:51:9:59:9 | After switch (...) {...} | cflow.cs:53:13:53:20 | After case ...: [match] |
-| cflow.cs:51:9:59:9 | After switch (...) {...} | cflow.cs:53:13:53:20 | After case ...: [no-match] |
-| cflow.cs:53:13:53:20 | After case ...: [match] | cflow.cs:53:13:53:20 | After case ...: [match] |
-| cflow.cs:53:13:53:20 | After case ...: [no-match] | cflow.cs:53:13:53:20 | After case ...: [no-match] |
+| cflow.cs:51:9:59:9 | After switch (...) {...} | cflow.cs:53:18:53:19 | After 42 [match] |
+| cflow.cs:51:9:59:9 | After switch (...) {...} | cflow.cs:53:18:53:19 | After 42 [no-match] |
+| cflow.cs:53:18:53:19 | After 42 [match] | cflow.cs:53:18:53:19 | After 42 [match] |
+| cflow.cs:53:18:53:19 | After 42 [no-match] | cflow.cs:53:18:53:19 | After 42 [no-match] |
 | cflow.cs:60:9:66:9 | After switch (...) {...} | cflow.cs:37:17:37:22 | Entry |
 | cflow.cs:60:9:66:9 | After switch (...) {...} | cflow.cs:39:9:50:9 | After switch (...) {...} |
-| cflow.cs:60:9:66:9 | After switch (...) {...} | cflow.cs:41:13:41:19 | After case ...: [no-match] |
-| cflow.cs:60:9:66:9 | After switch (...) {...} | cflow.cs:44:13:44:19 | After case ...: [no-match] |
-| cflow.cs:60:9:66:9 | After switch (...) {...} | cflow.cs:47:13:47:19 | After case ...: [match] |
-| cflow.cs:60:9:66:9 | After switch (...) {...} | cflow.cs:47:13:47:19 | After case ...: [no-match] |
+| cflow.cs:60:9:66:9 | After switch (...) {...} | cflow.cs:41:18:41:18 | After 1 [no-match] |
+| cflow.cs:60:9:66:9 | After switch (...) {...} | cflow.cs:44:18:44:18 | After 2 [no-match] |
+| cflow.cs:60:9:66:9 | After switch (...) {...} | cflow.cs:47:18:47:18 | After 3 [match] |
+| cflow.cs:60:9:66:9 | After switch (...) {...} | cflow.cs:47:18:47:18 | After 3 [no-match] |
 | cflow.cs:60:9:66:9 | After switch (...) {...} | cflow.cs:51:9:59:9 | After switch (...) {...} |
-| cflow.cs:60:9:66:9 | After switch (...) {...} | cflow.cs:53:13:53:20 | After case ...: [match] |
-| cflow.cs:60:9:66:9 | After switch (...) {...} | cflow.cs:53:13:53:20 | After case ...: [no-match] |
+| cflow.cs:60:9:66:9 | After switch (...) {...} | cflow.cs:53:18:53:19 | After 42 [match] |
+| cflow.cs:60:9:66:9 | After switch (...) {...} | cflow.cs:53:18:53:19 | After 42 [no-match] |
 | cflow.cs:60:9:66:9 | After switch (...) {...} | cflow.cs:60:9:66:9 | After switch (...) {...} |
-| cflow.cs:60:9:66:9 | After switch (...) {...} | cflow.cs:62:13:62:19 | After case ...: [match] |
-| cflow.cs:60:9:66:9 | After switch (...) {...} | cflow.cs:62:13:62:19 | After case ...: [no-match] |
+| cflow.cs:60:9:66:9 | After switch (...) {...} | cflow.cs:62:18:62:18 | After 0 [match] |
+| cflow.cs:60:9:66:9 | After switch (...) {...} | cflow.cs:62:18:62:18 | After 0 [no-match] |
 | cflow.cs:60:9:66:9 | After switch (...) {...} | cflow.cs:63:23:63:33 | After ... == ... [true] |
-| cflow.cs:62:13:62:19 | After case ...: [match] | cflow.cs:62:13:62:19 | After case ...: [match] |
-| cflow.cs:62:13:62:19 | After case ...: [no-match] | cflow.cs:62:13:62:19 | After case ...: [no-match] |
+| cflow.cs:62:18:62:18 | After 0 [match] | cflow.cs:62:18:62:18 | After 0 [match] |
+| cflow.cs:62:18:62:18 | After 0 [no-match] | cflow.cs:62:18:62:18 | After 0 [no-match] |
 | cflow.cs:63:23:63:33 | After ... == ... [false] | cflow.cs:63:23:63:33 | After ... == ... [false] |
-| cflow.cs:63:23:63:33 | After ... == ... [true] | cflow.cs:62:13:62:19 | After case ...: [match] |
+| cflow.cs:63:23:63:33 | After ... == ... [true] | cflow.cs:62:18:62:18 | After 0 [match] |
 | cflow.cs:63:23:63:33 | After ... == ... [true] | cflow.cs:63:23:63:33 | After ... == ... [true] |
 | cflow.cs:70:18:70:18 | Entry | cflow.cs:70:18:70:18 | Entry |
 | cflow.cs:70:18:70:18 | Normal Exit | cflow.cs:70:18:70:18 | Entry |
@@ -23463,14 +23665,14 @@ postBlockDominance
 | cflow.cs:242:5:242:9 | Label: | cflow.cs:240:10:240:13 | Entry |
 | cflow.cs:242:5:242:9 | Label: | cflow.cs:242:5:242:9 | Label: |
 | cflow.cs:242:5:242:9 | Label: | cflow.cs:244:13:244:28 | After ... > ... [true] |
-| cflow.cs:242:5:242:9 | Label: | cflow.cs:253:13:253:19 | After case ...: [match] |
+| cflow.cs:242:5:242:9 | Label: | cflow.cs:253:18:253:18 | After 2 [match] |
 | cflow.cs:242:12:242:41 | After if (...) ... | cflow.cs:240:10:240:13 | Entry |
 | cflow.cs:242:12:242:41 | After if (...) ... | cflow.cs:242:5:242:9 | Label: |
 | cflow.cs:242:12:242:41 | After if (...) ... | cflow.cs:242:12:242:41 | After if (...) ... |
 | cflow.cs:242:12:242:41 | After if (...) ... | cflow.cs:242:19:242:35 | After ... == ... [false] |
 | cflow.cs:242:12:242:41 | After if (...) ... | cflow.cs:242:19:242:35 | After ... == ... [true] |
 | cflow.cs:242:12:242:41 | After if (...) ... | cflow.cs:244:13:244:28 | After ... > ... [true] |
-| cflow.cs:242:12:242:41 | After if (...) ... | cflow.cs:253:13:253:19 | After case ...: [match] |
+| cflow.cs:242:12:242:41 | After if (...) ... | cflow.cs:253:18:253:18 | After 2 [match] |
 | cflow.cs:242:19:242:35 | After ... == ... [false] | cflow.cs:242:19:242:35 | After ... == ... [false] |
 | cflow.cs:242:19:242:35 | After ... == ... [true] | cflow.cs:242:19:242:35 | After ... == ... [true] |
 | cflow.cs:244:13:244:28 | After ... > ... [false] | cflow.cs:240:10:240:13 | Entry |
@@ -23480,7 +23682,7 @@ postBlockDominance
 | cflow.cs:244:13:244:28 | After ... > ... [false] | cflow.cs:242:19:242:35 | After ... == ... [true] |
 | cflow.cs:244:13:244:28 | After ... > ... [false] | cflow.cs:244:13:244:28 | After ... > ... [false] |
 | cflow.cs:244:13:244:28 | After ... > ... [false] | cflow.cs:244:13:244:28 | After ... > ... [true] |
-| cflow.cs:244:13:244:28 | After ... > ... [false] | cflow.cs:253:13:253:19 | After case ...: [match] |
+| cflow.cs:244:13:244:28 | After ... > ... [false] | cflow.cs:253:18:253:18 | After 2 [match] |
 | cflow.cs:244:13:244:28 | After ... > ... [true] | cflow.cs:244:13:244:28 | After ... > ... [true] |
 | cflow.cs:246:9:258:9 | After switch (...) {...} | cflow.cs:240:10:240:13 | Entry |
 | cflow.cs:246:9:258:9 | After switch (...) {...} | cflow.cs:242:5:242:9 | Label: |
@@ -23490,21 +23692,21 @@ postBlockDominance
 | cflow.cs:246:9:258:9 | After switch (...) {...} | cflow.cs:244:13:244:28 | After ... > ... [false] |
 | cflow.cs:246:9:258:9 | After switch (...) {...} | cflow.cs:244:13:244:28 | After ... > ... [true] |
 | cflow.cs:246:9:258:9 | After switch (...) {...} | cflow.cs:246:9:258:9 | After switch (...) {...} |
-| cflow.cs:246:9:258:9 | After switch (...) {...} | cflow.cs:248:13:248:19 | After case ...: [match] |
-| cflow.cs:246:9:258:9 | After switch (...) {...} | cflow.cs:248:13:248:19 | After case ...: [no-match] |
-| cflow.cs:246:9:258:9 | After switch (...) {...} | cflow.cs:250:13:250:19 | After case ...: [match] |
-| cflow.cs:246:9:258:9 | After switch (...) {...} | cflow.cs:250:13:250:19 | After case ...: [no-match] |
-| cflow.cs:246:9:258:9 | After switch (...) {...} | cflow.cs:253:13:253:19 | After case ...: [match] |
-| cflow.cs:246:9:258:9 | After switch (...) {...} | cflow.cs:253:13:253:19 | After case ...: [no-match] |
+| cflow.cs:246:9:258:9 | After switch (...) {...} | cflow.cs:248:18:248:18 | After 0 [match] |
+| cflow.cs:246:9:258:9 | After switch (...) {...} | cflow.cs:248:18:248:18 | After 0 [no-match] |
+| cflow.cs:246:9:258:9 | After switch (...) {...} | cflow.cs:250:18:250:18 | After 1 [match] |
+| cflow.cs:246:9:258:9 | After switch (...) {...} | cflow.cs:250:18:250:18 | After 1 [no-match] |
+| cflow.cs:246:9:258:9 | After switch (...) {...} | cflow.cs:253:18:253:18 | After 2 [match] |
+| cflow.cs:246:9:258:9 | After switch (...) {...} | cflow.cs:253:18:253:18 | After 2 [no-match] |
 | cflow.cs:246:9:258:9 | After switch (...) {...} | cflow.cs:255:13:255:20 | After default: [match] |
-| cflow.cs:248:13:248:19 | After case ...: [match] | cflow.cs:248:13:248:19 | After case ...: [match] |
-| cflow.cs:248:13:248:19 | After case ...: [no-match] | cflow.cs:248:13:248:19 | After case ...: [no-match] |
-| cflow.cs:250:13:250:19 | After case ...: [match] | cflow.cs:250:13:250:19 | After case ...: [match] |
-| cflow.cs:250:13:250:19 | After case ...: [no-match] | cflow.cs:250:13:250:19 | After case ...: [no-match] |
-| cflow.cs:253:13:253:19 | After case ...: [match] | cflow.cs:253:13:253:19 | After case ...: [match] |
-| cflow.cs:253:13:253:19 | After case ...: [no-match] | cflow.cs:253:13:253:19 | After case ...: [no-match] |
-| cflow.cs:255:13:255:20 | After default: [match] | cflow.cs:248:13:248:19 | After case ...: [match] |
-| cflow.cs:255:13:255:20 | After default: [match] | cflow.cs:253:13:253:19 | After case ...: [no-match] |
+| cflow.cs:248:18:248:18 | After 0 [match] | cflow.cs:248:18:248:18 | After 0 [match] |
+| cflow.cs:248:18:248:18 | After 0 [no-match] | cflow.cs:248:18:248:18 | After 0 [no-match] |
+| cflow.cs:250:18:250:18 | After 1 [match] | cflow.cs:250:18:250:18 | After 1 [match] |
+| cflow.cs:250:18:250:18 | After 1 [no-match] | cflow.cs:250:18:250:18 | After 1 [no-match] |
+| cflow.cs:253:18:253:18 | After 2 [match] | cflow.cs:253:18:253:18 | After 2 [match] |
+| cflow.cs:253:18:253:18 | After 2 [no-match] | cflow.cs:253:18:253:18 | After 2 [no-match] |
+| cflow.cs:255:13:255:20 | After default: [match] | cflow.cs:248:18:248:18 | After 0 [match] |
+| cflow.cs:255:13:255:20 | After default: [match] | cflow.cs:253:18:253:18 | After 2 [no-match] |
 | cflow.cs:255:13:255:20 | After default: [match] | cflow.cs:255:13:255:20 | After default: [match] |
 | cflow.cs:261:49:261:53 | Entry | cflow.cs:261:49:261:53 | Entry |
 | cflow.cs:261:49:261:53 | Exceptional Exit | cflow.cs:261:49:261:53 | Exceptional Exit |

--- a/csharp/ql/test/library-tests/controlflow/graph/EnclosingCallable.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/EnclosingCallable.expected
@@ -5616,11 +5616,15 @@ nodeEnclosing
 | Patterns.cs:22:13:22:23 | After case ...: [no-match] | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:22:13:22:23 | case ...: | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:22:18:22:22 | "xyz" | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:22:18:22:22 | After "xyz" [match] | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:22:18:22:22 | After "xyz" [no-match] | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:23:17:23:22 | Before break; | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:23:17:23:22 | break; | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:24:13:24:36 | After case ...: [match] | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:24:13:24:36 | After case ...: [no-match] | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:24:13:24:36 | case ...: | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:24:18:24:23 | After Int32 i2 [match] | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:24:18:24:23 | After Int32 i2 [no-match] | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:24:18:24:23 | Int32 i2 | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:24:30:24:31 | access to local variable i2 | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:24:30:24:35 | ... > ... | Patterns.cs:5:10:5:11 | M1 |
@@ -5646,6 +5650,8 @@ nodeEnclosing
 | Patterns.cs:27:13:27:24 | After case ...: [match] | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:27:13:27:24 | After case ...: [no-match] | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:27:13:27:24 | case ...: | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:27:18:27:23 | After Int32 i3 [match] | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:27:18:27:23 | After Int32 i3 [no-match] | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:27:18:27:23 | Int32 i3 | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:28:17:28:46 | After call to method WriteLine | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:28:17:28:46 | Before call to method WriteLine | Patterns.cs:5:10:5:11 | M1 |
@@ -5665,6 +5671,8 @@ nodeEnclosing
 | Patterns.cs:30:13:30:27 | After case ...: [match] | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:30:13:30:27 | After case ...: [no-match] | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:30:13:30:27 | case ...: | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:30:18:30:26 | After String s2 [match] | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:30:18:30:26 | After String s2 [no-match] | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:30:18:30:26 | String s2 | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:31:17:31:49 | After call to method WriteLine | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:31:17:31:49 | Before call to method WriteLine | Patterns.cs:5:10:5:11 | M1 |
@@ -5684,6 +5692,8 @@ nodeEnclosing
 | Patterns.cs:33:13:33:24 | After case ...: [match] | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:33:13:33:24 | After case ...: [no-match] | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:33:13:33:24 | case ...: | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:33:18:33:23 | After Object v2 [match] | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:33:18:33:23 | After Object v2 [no-match] | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:33:18:33:23 | Object v2 | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:34:17:34:22 | Before break; | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:34:17:34:22 | break; | Patterns.cs:5:10:5:11 | M1 |
@@ -5772,7 +5782,8 @@ nodeEnclosing
 | Patterns.cs:58:16:58:16 | access to parameter i | Patterns.cs:56:26:56:27 | M5 |
 | Patterns.cs:58:16:62:9 | ... switch { ... } | Patterns.cs:56:26:56:27 | M5 |
 | Patterns.cs:58:16:62:9 | After ... switch { ... } | Patterns.cs:56:26:56:27 | M5 |
-| Patterns.cs:60:13:60:17 | After not ... | Patterns.cs:56:26:56:27 | M5 |
+| Patterns.cs:60:13:60:17 | After not ... [match] | Patterns.cs:56:26:56:27 | M5 |
+| Patterns.cs:60:13:60:17 | After not ... [no-match] | Patterns.cs:56:26:56:27 | M5 |
 | Patterns.cs:60:13:60:17 | Before not ... | Patterns.cs:56:26:56:27 | M5 |
 | Patterns.cs:60:13:60:17 | not ... | Patterns.cs:56:26:56:27 | M5 |
 | Patterns.cs:60:13:60:28 | ... => ... | Patterns.cs:56:26:56:27 | M5 |
@@ -5780,6 +5791,7 @@ nodeEnclosing
 | Patterns.cs:60:13:60:28 | After ... => ... [no-match] | Patterns.cs:56:26:56:27 | M5 |
 | Patterns.cs:60:17:60:17 | 1 | Patterns.cs:56:26:56:27 | M5 |
 | Patterns.cs:60:22:60:28 | "not 1" | Patterns.cs:56:26:56:27 | M5 |
+| Patterns.cs:61:13:61:13 | After _ [match] | Patterns.cs:56:26:56:27 | M5 |
 | Patterns.cs:61:13:61:13 | _ | Patterns.cs:56:26:56:27 | M5 |
 | Patterns.cs:61:13:61:24 | ... => ... | Patterns.cs:56:26:56:27 | M5 |
 | Patterns.cs:61:13:61:24 | After ... => ... [match] | Patterns.cs:56:26:56:27 | M5 |
@@ -5793,7 +5805,8 @@ nodeEnclosing
 | Patterns.cs:67:16:67:16 | 2 | Patterns.cs:65:26:65:27 | M6 |
 | Patterns.cs:67:16:71:9 | ... switch { ... } | Patterns.cs:65:26:65:27 | M6 |
 | Patterns.cs:67:16:71:9 | After ... switch { ... } | Patterns.cs:65:26:65:27 | M6 |
-| Patterns.cs:69:13:69:17 | After not ... | Patterns.cs:65:26:65:27 | M6 |
+| Patterns.cs:69:13:69:17 | After not ... [match] | Patterns.cs:65:26:65:27 | M6 |
+| Patterns.cs:69:13:69:17 | After not ... [no-match] | Patterns.cs:65:26:65:27 | M6 |
 | Patterns.cs:69:13:69:17 | Before not ... | Patterns.cs:65:26:65:27 | M6 |
 | Patterns.cs:69:13:69:17 | not ... | Patterns.cs:65:26:65:27 | M6 |
 | Patterns.cs:69:13:69:33 | ... => ... | Patterns.cs:65:26:65:27 | M6 |
@@ -5802,6 +5815,8 @@ nodeEnclosing
 | Patterns.cs:69:17:69:17 | 2 | Patterns.cs:65:26:65:27 | M6 |
 | Patterns.cs:69:22:69:33 | "impossible" | Patterns.cs:65:26:65:27 | M6 |
 | Patterns.cs:70:13:70:13 | 2 | Patterns.cs:65:26:65:27 | M6 |
+| Patterns.cs:70:13:70:13 | After 2 [match] | Patterns.cs:65:26:65:27 | M6 |
+| Patterns.cs:70:13:70:13 | After 2 [no-match] | Patterns.cs:65:26:65:27 | M6 |
 | Patterns.cs:70:13:70:27 | ... => ... | Patterns.cs:65:26:65:27 | M6 |
 | Patterns.cs:70:13:70:27 | After ... => ... [match] | Patterns.cs:65:26:65:27 | M6 |
 | Patterns.cs:70:13:70:27 | After ... => ... [no-match] | Patterns.cs:65:26:65:27 | M6 |
@@ -5817,7 +5832,8 @@ nodeEnclosing
 | Patterns.cs:76:16:82:9 | ... switch { ... } | Patterns.cs:74:26:74:27 | M7 |
 | Patterns.cs:76:16:82:9 | After ... switch { ... } | Patterns.cs:74:26:74:27 | M7 |
 | Patterns.cs:78:13:78:15 | > ... | Patterns.cs:74:26:74:27 | M7 |
-| Patterns.cs:78:13:78:15 | After > ... | Patterns.cs:74:26:74:27 | M7 |
+| Patterns.cs:78:13:78:15 | After > ... [match] | Patterns.cs:74:26:74:27 | M7 |
+| Patterns.cs:78:13:78:15 | After > ... [no-match] | Patterns.cs:74:26:74:27 | M7 |
 | Patterns.cs:78:13:78:15 | Before > ... | Patterns.cs:74:26:74:27 | M7 |
 | Patterns.cs:78:13:78:24 | ... => ... | Patterns.cs:74:26:74:27 | M7 |
 | Patterns.cs:78:13:78:24 | After ... => ... [match] | Patterns.cs:74:26:74:27 | M7 |
@@ -5825,7 +5841,8 @@ nodeEnclosing
 | Patterns.cs:78:15:78:15 | 1 | Patterns.cs:74:26:74:27 | M7 |
 | Patterns.cs:78:20:78:24 | "> 1" | Patterns.cs:74:26:74:27 | M7 |
 | Patterns.cs:79:13:79:15 | < ... | Patterns.cs:74:26:74:27 | M7 |
-| Patterns.cs:79:13:79:15 | After < ... | Patterns.cs:74:26:74:27 | M7 |
+| Patterns.cs:79:13:79:15 | After < ... [match] | Patterns.cs:74:26:74:27 | M7 |
+| Patterns.cs:79:13:79:15 | After < ... [no-match] | Patterns.cs:74:26:74:27 | M7 |
 | Patterns.cs:79:13:79:15 | Before < ... | Patterns.cs:74:26:74:27 | M7 |
 | Patterns.cs:79:13:79:24 | ... => ... | Patterns.cs:74:26:74:27 | M7 |
 | Patterns.cs:79:13:79:24 | After ... => ... [match] | Patterns.cs:74:26:74:27 | M7 |
@@ -5833,10 +5850,13 @@ nodeEnclosing
 | Patterns.cs:79:15:79:15 | 0 | Patterns.cs:74:26:74:27 | M7 |
 | Patterns.cs:79:20:79:24 | "< 0" | Patterns.cs:74:26:74:27 | M7 |
 | Patterns.cs:80:13:80:13 | 1 | Patterns.cs:74:26:74:27 | M7 |
+| Patterns.cs:80:13:80:13 | After 1 [match] | Patterns.cs:74:26:74:27 | M7 |
+| Patterns.cs:80:13:80:13 | After 1 [no-match] | Patterns.cs:74:26:74:27 | M7 |
 | Patterns.cs:80:13:80:20 | ... => ... | Patterns.cs:74:26:74:27 | M7 |
 | Patterns.cs:80:13:80:20 | After ... => ... [match] | Patterns.cs:74:26:74:27 | M7 |
 | Patterns.cs:80:13:80:20 | After ... => ... [no-match] | Patterns.cs:74:26:74:27 | M7 |
 | Patterns.cs:80:18:80:20 | "1" | Patterns.cs:74:26:74:27 | M7 |
+| Patterns.cs:81:13:81:13 | After _ [match] | Patterns.cs:74:26:74:27 | M7 |
 | Patterns.cs:81:13:81:13 | _ | Patterns.cs:74:26:74:27 | M7 |
 | Patterns.cs:81:13:81:20 | ... => ... | Patterns.cs:74:26:74:27 | M7 |
 | Patterns.cs:81:13:81:20 | After ... => ... [match] | Patterns.cs:74:26:74:27 | M7 |
@@ -6191,12 +6211,16 @@ nodeEnclosing
 | Switch.cs:14:13:14:21 | After case ...: [no-match] | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:14:13:14:21 | case ...: | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:14:18:14:20 | "a" | Switch.cs:10:10:10:11 | M2 |
+| Switch.cs:14:18:14:20 | After "a" [match] | Switch.cs:10:10:10:11 | M2 |
+| Switch.cs:14:18:14:20 | After "a" [no-match] | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:15:17:15:23 | Before return ...; | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:15:17:15:23 | return ...; | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:16:13:16:19 | After case ...: [match] | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:16:13:16:19 | After case ...: [no-match] | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:16:13:16:19 | case ...: | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:16:18:16:18 | 0 | Switch.cs:10:10:10:11 | M2 |
+| Switch.cs:16:18:16:18 | After 0 [match] | Switch.cs:10:10:10:11 | M2 |
+| Switch.cs:16:18:16:18 | After 0 [no-match] | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:17:17:17:38 | Before throw ...; | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:17:17:17:38 | throw ...; | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:17:23:17:37 | After object creation of type Exception | Switch.cs:10:10:10:11 | M2 |
@@ -6205,12 +6229,16 @@ nodeEnclosing
 | Switch.cs:18:13:18:22 | After case ...: [match] | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:18:13:18:22 | After case ...: [no-match] | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:18:13:18:22 | case ...: | Switch.cs:10:10:10:11 | M2 |
+| Switch.cs:18:18:18:21 | After null [match] | Switch.cs:10:10:10:11 | M2 |
+| Switch.cs:18:18:18:21 | After null [no-match] | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:18:18:18:21 | null | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:19:17:19:29 | Before goto default; | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:19:17:19:29 | goto default; | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:20:13:20:23 | After case ...: [match] | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:20:13:20:23 | After case ...: [no-match] | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:20:13:20:23 | case ...: | Switch.cs:10:10:10:11 | M2 |
+| Switch.cs:20:18:20:22 | After Int32 i [match] | Switch.cs:10:10:10:11 | M2 |
+| Switch.cs:20:18:20:22 | After Int32 i [no-match] | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:20:18:20:22 | Int32 i | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:21:17:22:27 | After if (...) ... | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:21:17:22:27 | if (...) ... | Switch.cs:10:10:10:11 | M2 |
@@ -6228,6 +6256,8 @@ nodeEnclosing
 | Switch.cs:24:13:24:56 | After case ...: [match] | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:24:13:24:56 | After case ...: [no-match] | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:24:13:24:56 | case ...: | Switch.cs:10:10:10:11 | M2 |
+| Switch.cs:24:18:24:25 | After String s [match] | Switch.cs:10:10:10:11 | M2 |
+| Switch.cs:24:18:24:25 | After String s [no-match] | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:24:18:24:25 | String s | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:24:32:24:32 | access to local variable s | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:24:32:24:39 | After access to property Length | Switch.cs:10:10:10:11 | M2 |
@@ -6258,6 +6288,8 @@ nodeEnclosing
 | Switch.cs:27:13:27:39 | After case ...: [match] | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:27:13:27:39 | After case ...: [no-match] | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:27:13:27:39 | case ...: | Switch.cs:10:10:10:11 | M2 |
+| Switch.cs:27:18:27:25 | After Double d [match] | Switch.cs:10:10:10:11 | M2 |
+| Switch.cs:27:18:27:25 | After Double d [no-match] | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:27:18:27:25 | Double d | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:27:32:27:38 | Before call to method Throw | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:27:32:27:38 | call to method Throw | Switch.cs:10:10:10:11 | M2 |
@@ -6287,12 +6319,16 @@ nodeEnclosing
 | Switch.cs:48:13:48:23 | After case ...: [match] | Switch.cs:44:10:44:11 | M4 |
 | Switch.cs:48:13:48:23 | After case ...: [no-match] | Switch.cs:44:10:44:11 | M4 |
 | Switch.cs:48:13:48:23 | case ...: | Switch.cs:44:10:44:11 | M4 |
+| Switch.cs:48:18:48:20 | After access to type Int32 [match] | Switch.cs:44:10:44:11 | M4 |
+| Switch.cs:48:18:48:20 | After access to type Int32 [no-match] | Switch.cs:44:10:44:11 | M4 |
 | Switch.cs:48:18:48:20 | access to type Int32 | Switch.cs:44:10:44:11 | M4 |
 | Switch.cs:49:17:49:22 | Before break; | Switch.cs:44:10:44:11 | M4 |
 | Switch.cs:49:17:49:22 | break; | Switch.cs:44:10:44:11 | M4 |
 | Switch.cs:50:13:50:39 | After case ...: [match] | Switch.cs:44:10:44:11 | M4 |
 | Switch.cs:50:13:50:39 | After case ...: [no-match] | Switch.cs:44:10:44:11 | M4 |
 | Switch.cs:50:13:50:39 | case ...: | Switch.cs:44:10:44:11 | M4 |
+| Switch.cs:50:18:50:21 | After access to type Boolean [match] | Switch.cs:44:10:44:11 | M4 |
+| Switch.cs:50:18:50:21 | After access to type Boolean [no-match] | Switch.cs:44:10:44:11 | M4 |
 | Switch.cs:50:18:50:21 | access to type Boolean | Switch.cs:44:10:44:11 | M4 |
 | Switch.cs:50:30:50:30 | access to parameter o | Switch.cs:44:10:44:11 | M4 |
 | Switch.cs:50:30:50:38 | ... != ... | Switch.cs:44:10:44:11 | M4 |
@@ -6318,12 +6354,16 @@ nodeEnclosing
 | Switch.cs:59:13:59:19 | After case ...: [no-match] | Switch.cs:55:10:55:11 | M5 |
 | Switch.cs:59:13:59:19 | case ...: | Switch.cs:55:10:55:11 | M5 |
 | Switch.cs:59:18:59:18 | 2 | Switch.cs:55:10:55:11 | M5 |
+| Switch.cs:59:18:59:18 | After 2 [match] | Switch.cs:55:10:55:11 | M5 |
+| Switch.cs:59:18:59:18 | After 2 [no-match] | Switch.cs:55:10:55:11 | M5 |
 | Switch.cs:60:17:60:22 | Before break; | Switch.cs:55:10:55:11 | M5 |
 | Switch.cs:60:17:60:22 | break; | Switch.cs:55:10:55:11 | M5 |
 | Switch.cs:61:13:61:19 | After case ...: [match] | Switch.cs:55:10:55:11 | M5 |
 | Switch.cs:61:13:61:19 | After case ...: [no-match] | Switch.cs:55:10:55:11 | M5 |
 | Switch.cs:61:13:61:19 | case ...: | Switch.cs:55:10:55:11 | M5 |
 | Switch.cs:61:18:61:18 | 3 | Switch.cs:55:10:55:11 | M5 |
+| Switch.cs:61:18:61:18 | After 3 [match] | Switch.cs:55:10:55:11 | M5 |
+| Switch.cs:61:18:61:18 | After 3 [no-match] | Switch.cs:55:10:55:11 | M5 |
 | Switch.cs:62:17:62:22 | Before break; | Switch.cs:55:10:55:11 | M5 |
 | Switch.cs:62:17:62:22 | break; | Switch.cs:55:10:55:11 | M5 |
 | Switch.cs:66:10:66:11 | Entry | Switch.cs:66:10:66:11 | M6 |
@@ -6341,6 +6381,8 @@ nodeEnclosing
 | Switch.cs:70:13:70:23 | After case ...: [match] | Switch.cs:66:10:66:11 | M6 |
 | Switch.cs:70:13:70:23 | After case ...: [no-match] | Switch.cs:66:10:66:11 | M6 |
 | Switch.cs:70:13:70:23 | case ...: | Switch.cs:66:10:66:11 | M6 |
+| Switch.cs:70:18:70:20 | After access to type Int32 [match] | Switch.cs:66:10:66:11 | M6 |
+| Switch.cs:70:18:70:20 | After access to type Int32 [no-match] | Switch.cs:66:10:66:11 | M6 |
 | Switch.cs:70:18:70:20 | access to type Int32 | Switch.cs:66:10:66:11 | M6 |
 | Switch.cs:71:17:71:22 | Before break; | Switch.cs:66:10:66:11 | M6 |
 | Switch.cs:71:17:71:22 | break; | Switch.cs:66:10:66:11 | M6 |
@@ -6348,6 +6390,8 @@ nodeEnclosing
 | Switch.cs:72:13:72:20 | After case ...: [no-match] | Switch.cs:66:10:66:11 | M6 |
 | Switch.cs:72:13:72:20 | case ...: | Switch.cs:66:10:66:11 | M6 |
 | Switch.cs:72:18:72:19 | "" | Switch.cs:66:10:66:11 | M6 |
+| Switch.cs:72:18:72:19 | After "" [match] | Switch.cs:66:10:66:11 | M6 |
+| Switch.cs:72:18:72:19 | After "" [no-match] | Switch.cs:66:10:66:11 | M6 |
 | Switch.cs:73:17:73:22 | Before break; | Switch.cs:66:10:66:11 | M6 |
 | Switch.cs:73:17:73:22 | break; | Switch.cs:66:10:66:11 | M6 |
 | Switch.cs:77:10:77:11 | Entry | Switch.cs:77:10:77:11 | M7 |
@@ -6363,6 +6407,8 @@ nodeEnclosing
 | Switch.cs:81:13:81:19 | After case ...: [no-match] | Switch.cs:77:10:77:11 | M7 |
 | Switch.cs:81:13:81:19 | case ...: | Switch.cs:77:10:77:11 | M7 |
 | Switch.cs:81:18:81:18 | 1 | Switch.cs:77:10:77:11 | M7 |
+| Switch.cs:81:18:81:18 | After 1 [match] | Switch.cs:77:10:77:11 | M7 |
+| Switch.cs:81:18:81:18 | After 1 [no-match] | Switch.cs:77:10:77:11 | M7 |
 | Switch.cs:82:17:82:28 | Before return ...; | Switch.cs:77:10:77:11 | M7 |
 | Switch.cs:82:17:82:28 | return ...; | Switch.cs:77:10:77:11 | M7 |
 | Switch.cs:82:24:82:27 | true | Switch.cs:77:10:77:11 | M7 |
@@ -6370,6 +6416,8 @@ nodeEnclosing
 | Switch.cs:83:13:83:19 | After case ...: [no-match] | Switch.cs:77:10:77:11 | M7 |
 | Switch.cs:83:13:83:19 | case ...: | Switch.cs:77:10:77:11 | M7 |
 | Switch.cs:83:18:83:18 | 2 | Switch.cs:77:10:77:11 | M7 |
+| Switch.cs:83:18:83:18 | After 2 [match] | Switch.cs:77:10:77:11 | M7 |
+| Switch.cs:83:18:83:18 | After 2 [no-match] | Switch.cs:77:10:77:11 | M7 |
 | Switch.cs:84:17:85:26 | After if (...) ... | Switch.cs:77:10:77:11 | M7 |
 | Switch.cs:84:17:85:26 | if (...) ... | Switch.cs:77:10:77:11 | M7 |
 | Switch.cs:84:21:84:21 | access to parameter j | Switch.cs:77:10:77:11 | M7 |
@@ -6397,6 +6445,8 @@ nodeEnclosing
 | Switch.cs:95:13:95:23 | After case ...: [match] | Switch.cs:91:10:91:11 | M8 |
 | Switch.cs:95:13:95:23 | After case ...: [no-match] | Switch.cs:91:10:91:11 | M8 |
 | Switch.cs:95:13:95:23 | case ...: | Switch.cs:91:10:91:11 | M8 |
+| Switch.cs:95:18:95:20 | After access to type Int32 [match] | Switch.cs:91:10:91:11 | M8 |
+| Switch.cs:95:18:95:20 | After access to type Int32 [no-match] | Switch.cs:91:10:91:11 | M8 |
 | Switch.cs:95:18:95:20 | access to type Int32 | Switch.cs:91:10:91:11 | M8 |
 | Switch.cs:96:17:96:28 | Before return ...; | Switch.cs:91:10:91:11 | M8 |
 | Switch.cs:96:17:96:28 | return ...; | Switch.cs:91:10:91:11 | M8 |
@@ -6421,6 +6471,8 @@ nodeEnclosing
 | Switch.cs:105:13:105:19 | After case ...: [no-match] | Switch.cs:101:9:101:10 | M9 |
 | Switch.cs:105:13:105:19 | case ...: | Switch.cs:101:9:101:10 | M9 |
 | Switch.cs:105:18:105:18 | 0 | Switch.cs:101:9:101:10 | M9 |
+| Switch.cs:105:18:105:18 | After 0 [match] | Switch.cs:101:9:101:10 | M9 |
+| Switch.cs:105:18:105:18 | After 0 [no-match] | Switch.cs:101:9:101:10 | M9 |
 | Switch.cs:105:21:105:29 | Before return ...; | Switch.cs:101:9:101:10 | M9 |
 | Switch.cs:105:21:105:29 | return ...; | Switch.cs:101:9:101:10 | M9 |
 | Switch.cs:105:28:105:28 | 0 | Switch.cs:101:9:101:10 | M9 |
@@ -6428,6 +6480,8 @@ nodeEnclosing
 | Switch.cs:106:13:106:19 | After case ...: [no-match] | Switch.cs:101:9:101:10 | M9 |
 | Switch.cs:106:13:106:19 | case ...: | Switch.cs:101:9:101:10 | M9 |
 | Switch.cs:106:18:106:18 | 1 | Switch.cs:101:9:101:10 | M9 |
+| Switch.cs:106:18:106:18 | After 1 [match] | Switch.cs:101:9:101:10 | M9 |
+| Switch.cs:106:18:106:18 | After 1 [no-match] | Switch.cs:101:9:101:10 | M9 |
 | Switch.cs:106:21:106:29 | Before return ...; | Switch.cs:101:9:101:10 | M9 |
 | Switch.cs:106:21:106:29 | return ...; | Switch.cs:101:9:101:10 | M9 |
 | Switch.cs:106:28:106:28 | 1 | Switch.cs:101:9:101:10 | M9 |
@@ -6460,6 +6514,8 @@ nodeEnclosing
 | Switch.cs:117:13:117:35 | After case ...: [no-match] | Switch.cs:113:9:113:11 | M10 |
 | Switch.cs:117:13:117:35 | case ...: | Switch.cs:113:9:113:11 | M10 |
 | Switch.cs:117:18:117:18 | 3 | Switch.cs:113:9:113:11 | M10 |
+| Switch.cs:117:18:117:18 | After 3 [match] | Switch.cs:113:9:113:11 | M10 |
+| Switch.cs:117:18:117:18 | After 3 [no-match] | Switch.cs:113:9:113:11 | M10 |
 | Switch.cs:117:25:117:25 | access to parameter s | Switch.cs:113:9:113:11 | M10 |
 | Switch.cs:117:25:117:34 | ... == ... | Switch.cs:113:9:113:11 | M10 |
 | Switch.cs:117:25:117:34 | After ... == ... [false] | Switch.cs:113:9:113:11 | M10 |
@@ -6473,6 +6529,8 @@ nodeEnclosing
 | Switch.cs:118:13:118:34 | After case ...: [no-match] | Switch.cs:113:9:113:11 | M10 |
 | Switch.cs:118:13:118:34 | case ...: | Switch.cs:113:9:113:11 | M10 |
 | Switch.cs:118:18:118:18 | 2 | Switch.cs:113:9:113:11 | M10 |
+| Switch.cs:118:18:118:18 | After 2 [match] | Switch.cs:113:9:113:11 | M10 |
+| Switch.cs:118:18:118:18 | After 2 [no-match] | Switch.cs:113:9:113:11 | M10 |
 | Switch.cs:118:25:118:25 | access to parameter s | Switch.cs:113:9:113:11 | M10 |
 | Switch.cs:118:25:118:33 | ... == ... | Switch.cs:113:9:113:11 | M10 |
 | Switch.cs:118:25:118:33 | After ... == ... [false] | Switch.cs:113:9:113:11 | M10 |
@@ -6500,11 +6558,14 @@ nodeEnclosing
 | Switch.cs:125:13:125:48 | ... switch { ... } | Switch.cs:123:10:123:12 | M11 |
 | Switch.cs:125:13:125:48 | After ... switch { ... } [false] | Switch.cs:123:10:123:12 | M11 |
 | Switch.cs:125:13:125:48 | After ... switch { ... } [true] | Switch.cs:123:10:123:12 | M11 |
+| Switch.cs:125:24:125:29 | After Boolean b [match] | Switch.cs:123:10:123:12 | M11 |
+| Switch.cs:125:24:125:29 | After Boolean b [no-match] | Switch.cs:123:10:123:12 | M11 |
 | Switch.cs:125:24:125:29 | Boolean b | Switch.cs:123:10:123:12 | M11 |
 | Switch.cs:125:24:125:34 | ... => ... | Switch.cs:123:10:123:12 | M11 |
 | Switch.cs:125:24:125:34 | After ... => ... [match] | Switch.cs:123:10:123:12 | M11 |
 | Switch.cs:125:24:125:34 | After ... => ... [no-match] | Switch.cs:123:10:123:12 | M11 |
 | Switch.cs:125:34:125:34 | access to local variable b | Switch.cs:123:10:123:12 | M11 |
+| Switch.cs:125:37:125:37 | After _ [match] | Switch.cs:123:10:123:12 | M11 |
 | Switch.cs:125:37:125:37 | _ | Switch.cs:123:10:123:12 | M11 |
 | Switch.cs:125:37:125:46 | ... => ... | Switch.cs:123:10:123:12 | M11 |
 | Switch.cs:125:37:125:46 | After ... => ... [match] | Switch.cs:123:10:123:12 | M11 |
@@ -6525,11 +6586,14 @@ nodeEnclosing
 | Switch.cs:131:17:131:53 | ... switch { ... } | Switch.cs:129:12:129:14 | M12 |
 | Switch.cs:131:17:131:53 | After ... switch { ... } [non-null] | Switch.cs:129:12:129:14 | M12 |
 | Switch.cs:131:17:131:53 | After ... switch { ... } [null] | Switch.cs:129:12:129:14 | M12 |
+| Switch.cs:131:28:131:35 | After String s [match] | Switch.cs:129:12:129:14 | M12 |
+| Switch.cs:131:28:131:35 | After String s [no-match] | Switch.cs:129:12:129:14 | M12 |
 | Switch.cs:131:28:131:35 | String s | Switch.cs:129:12:129:14 | M12 |
 | Switch.cs:131:28:131:40 | ... => ... | Switch.cs:129:12:129:14 | M12 |
 | Switch.cs:131:28:131:40 | After ... => ... [match] | Switch.cs:129:12:129:14 | M12 |
 | Switch.cs:131:28:131:40 | After ... => ... [no-match] | Switch.cs:129:12:129:14 | M12 |
 | Switch.cs:131:40:131:40 | access to local variable s | Switch.cs:129:12:129:14 | M12 |
+| Switch.cs:131:43:131:43 | After _ [match] | Switch.cs:129:12:129:14 | M12 |
 | Switch.cs:131:43:131:43 | _ | Switch.cs:129:12:129:14 | M12 |
 | Switch.cs:131:43:131:51 | ... => ... | Switch.cs:129:12:129:14 | M12 |
 | Switch.cs:131:43:131:51 | After ... => ... [match] | Switch.cs:129:12:129:14 | M12 |
@@ -6553,6 +6617,8 @@ nodeEnclosing
 | Switch.cs:139:13:139:19 | After case ...: [no-match] | Switch.cs:134:9:134:11 | M13 |
 | Switch.cs:139:13:139:19 | case ...: | Switch.cs:134:9:134:11 | M13 |
 | Switch.cs:139:18:139:18 | 1 | Switch.cs:134:9:134:11 | M13 |
+| Switch.cs:139:18:139:18 | After 1 [match] | Switch.cs:134:9:134:11 | M13 |
+| Switch.cs:139:18:139:18 | After 1 [no-match] | Switch.cs:134:9:134:11 | M13 |
 | Switch.cs:139:21:139:29 | Before return ...; | Switch.cs:134:9:134:11 | M13 |
 | Switch.cs:139:21:139:29 | return ...; | Switch.cs:134:9:134:11 | M13 |
 | Switch.cs:139:28:139:28 | 1 | Switch.cs:134:9:134:11 | M13 |
@@ -6560,6 +6626,8 @@ nodeEnclosing
 | Switch.cs:140:13:140:19 | After case ...: [no-match] | Switch.cs:134:9:134:11 | M13 |
 | Switch.cs:140:13:140:19 | case ...: | Switch.cs:134:9:134:11 | M13 |
 | Switch.cs:140:18:140:18 | 2 | Switch.cs:134:9:134:11 | M13 |
+| Switch.cs:140:18:140:18 | After 2 [match] | Switch.cs:134:9:134:11 | M13 |
+| Switch.cs:140:18:140:18 | After 2 [no-match] | Switch.cs:134:9:134:11 | M13 |
 | Switch.cs:140:21:140:29 | Before return ...; | Switch.cs:134:9:134:11 | M13 |
 | Switch.cs:140:21:140:29 | return ...; | Switch.cs:134:9:134:11 | M13 |
 | Switch.cs:140:28:140:28 | 2 | Switch.cs:134:9:134:11 | M13 |
@@ -6574,6 +6642,8 @@ nodeEnclosing
 | Switch.cs:148:13:148:19 | After case ...: [no-match] | Switch.cs:144:9:144:11 | M14 |
 | Switch.cs:148:13:148:19 | case ...: | Switch.cs:144:9:144:11 | M14 |
 | Switch.cs:148:18:148:18 | 1 | Switch.cs:144:9:144:11 | M14 |
+| Switch.cs:148:18:148:18 | After 1 [match] | Switch.cs:144:9:144:11 | M14 |
+| Switch.cs:148:18:148:18 | After 1 [no-match] | Switch.cs:144:9:144:11 | M14 |
 | Switch.cs:148:21:148:29 | Before return ...; | Switch.cs:144:9:144:11 | M14 |
 | Switch.cs:148:21:148:29 | return ...; | Switch.cs:144:9:144:11 | M14 |
 | Switch.cs:148:28:148:28 | 1 | Switch.cs:144:9:144:11 | M14 |
@@ -6589,6 +6659,8 @@ nodeEnclosing
 | Switch.cs:150:13:150:19 | After case ...: [no-match] | Switch.cs:144:9:144:11 | M14 |
 | Switch.cs:150:13:150:19 | case ...: | Switch.cs:144:9:144:11 | M14 |
 | Switch.cs:150:18:150:18 | 2 | Switch.cs:144:9:144:11 | M14 |
+| Switch.cs:150:18:150:18 | After 2 [match] | Switch.cs:144:9:144:11 | M14 |
+| Switch.cs:150:18:150:18 | After 2 [no-match] | Switch.cs:144:9:144:11 | M14 |
 | Switch.cs:150:21:150:29 | Before return ...; | Switch.cs:144:9:144:11 | M14 |
 | Switch.cs:150:21:150:29 | return ...; | Switch.cs:144:9:144:11 | M14 |
 | Switch.cs:150:28:150:28 | 2 | Switch.cs:144:9:144:11 | M14 |
@@ -6607,11 +6679,15 @@ nodeEnclosing
 | Switch.cs:156:17:156:17 | access to parameter b | Switch.cs:154:10:154:12 | M15 |
 | Switch.cs:156:17:156:54 | ... switch { ... } | Switch.cs:154:10:154:12 | M15 |
 | Switch.cs:156:17:156:54 | After ... switch { ... } | Switch.cs:154:10:154:12 | M15 |
+| Switch.cs:156:28:156:31 | After true [match] | Switch.cs:154:10:154:12 | M15 |
+| Switch.cs:156:28:156:31 | After true [no-match] | Switch.cs:154:10:154:12 | M15 |
 | Switch.cs:156:28:156:31 | true | Switch.cs:154:10:154:12 | M15 |
 | Switch.cs:156:28:156:38 | ... => ... | Switch.cs:154:10:154:12 | M15 |
 | Switch.cs:156:28:156:38 | After ... => ... [match] | Switch.cs:154:10:154:12 | M15 |
 | Switch.cs:156:28:156:38 | After ... => ... [no-match] | Switch.cs:154:10:154:12 | M15 |
 | Switch.cs:156:36:156:38 | "a" | Switch.cs:154:10:154:12 | M15 |
+| Switch.cs:156:41:156:45 | After false [match] | Switch.cs:154:10:154:12 | M15 |
+| Switch.cs:156:41:156:45 | After false [no-match] | Switch.cs:154:10:154:12 | M15 |
 | Switch.cs:156:41:156:45 | false | Switch.cs:154:10:154:12 | M15 |
 | Switch.cs:156:41:156:52 | ... => ... | Switch.cs:154:10:154:12 | M15 |
 | Switch.cs:156:41:156:52 | After ... => ... [match] | Switch.cs:154:10:154:12 | M15 |
@@ -6661,10 +6737,14 @@ nodeEnclosing
 | Switch.cs:167:13:167:19 | After case ...: [no-match] | Switch.cs:163:10:163:12 | M16 |
 | Switch.cs:167:13:167:19 | case ...: | Switch.cs:163:10:163:12 | M16 |
 | Switch.cs:167:18:167:18 | 1 | Switch.cs:163:10:163:12 | M16 |
+| Switch.cs:167:18:167:18 | After 1 [match] | Switch.cs:163:10:163:12 | M16 |
+| Switch.cs:167:18:167:18 | After 1 [no-match] | Switch.cs:163:10:163:12 | M16 |
 | Switch.cs:168:13:168:19 | After case ...: [match] | Switch.cs:163:10:163:12 | M16 |
 | Switch.cs:168:13:168:19 | After case ...: [no-match] | Switch.cs:163:10:163:12 | M16 |
 | Switch.cs:168:13:168:19 | case ...: | Switch.cs:163:10:163:12 | M16 |
 | Switch.cs:168:18:168:18 | 2 | Switch.cs:163:10:163:12 | M16 |
+| Switch.cs:168:18:168:18 | After 2 [match] | Switch.cs:163:10:163:12 | M16 |
+| Switch.cs:168:18:168:18 | After 2 [no-match] | Switch.cs:163:10:163:12 | M16 |
 | Switch.cs:169:17:169:50 | After call to method WriteLine | Switch.cs:163:10:163:12 | M16 |
 | Switch.cs:169:17:169:50 | Before call to method WriteLine | Switch.cs:163:10:163:12 | M16 |
 | Switch.cs:169:17:169:50 | call to method WriteLine | Switch.cs:163:10:163:12 | M16 |
@@ -6677,6 +6757,8 @@ nodeEnclosing
 | Switch.cs:171:13:171:19 | After case ...: [no-match] | Switch.cs:163:10:163:12 | M16 |
 | Switch.cs:171:13:171:19 | case ...: | Switch.cs:163:10:163:12 | M16 |
 | Switch.cs:171:18:171:18 | 3 | Switch.cs:163:10:163:12 | M16 |
+| Switch.cs:171:18:171:18 | After 3 [match] | Switch.cs:163:10:163:12 | M16 |
+| Switch.cs:171:18:171:18 | After 3 [no-match] | Switch.cs:163:10:163:12 | M16 |
 | Switch.cs:172:17:172:45 | After call to method WriteLine | Switch.cs:163:10:163:12 | M16 |
 | Switch.cs:172:17:172:45 | Before call to method WriteLine | Switch.cs:163:10:163:12 | M16 |
 | Switch.cs:172:17:172:45 | call to method WriteLine | Switch.cs:163:10:163:12 | M16 |
@@ -7067,6 +7149,8 @@ nodeEnclosing
 | cflow.cs:41:13:41:19 | After case ...: [no-match] | cflow.cs:37:17:37:22 | Switch |
 | cflow.cs:41:13:41:19 | case ...: | cflow.cs:37:17:37:22 | Switch |
 | cflow.cs:41:18:41:18 | 1 | cflow.cs:37:17:37:22 | Switch |
+| cflow.cs:41:18:41:18 | After 1 [match] | cflow.cs:37:17:37:22 | Switch |
+| cflow.cs:41:18:41:18 | After 1 [no-match] | cflow.cs:37:17:37:22 | Switch |
 | cflow.cs:42:17:42:38 | After call to method WriteLine | cflow.cs:37:17:37:22 | Switch |
 | cflow.cs:42:17:42:38 | Before call to method WriteLine | cflow.cs:37:17:37:22 | Switch |
 | cflow.cs:42:17:42:38 | call to method WriteLine | cflow.cs:37:17:37:22 | Switch |
@@ -7080,6 +7164,8 @@ nodeEnclosing
 | cflow.cs:44:13:44:19 | After case ...: [no-match] | cflow.cs:37:17:37:22 | Switch |
 | cflow.cs:44:13:44:19 | case ...: | cflow.cs:37:17:37:22 | Switch |
 | cflow.cs:44:18:44:18 | 2 | cflow.cs:37:17:37:22 | Switch |
+| cflow.cs:44:18:44:18 | After 2 [match] | cflow.cs:37:17:37:22 | Switch |
+| cflow.cs:44:18:44:18 | After 2 [no-match] | cflow.cs:37:17:37:22 | Switch |
 | cflow.cs:45:17:45:38 | After call to method WriteLine | cflow.cs:37:17:37:22 | Switch |
 | cflow.cs:45:17:45:38 | Before call to method WriteLine | cflow.cs:37:17:37:22 | Switch |
 | cflow.cs:45:17:45:38 | call to method WriteLine | cflow.cs:37:17:37:22 | Switch |
@@ -7093,6 +7179,8 @@ nodeEnclosing
 | cflow.cs:47:13:47:19 | After case ...: [no-match] | cflow.cs:37:17:37:22 | Switch |
 | cflow.cs:47:13:47:19 | case ...: | cflow.cs:37:17:37:22 | Switch |
 | cflow.cs:47:18:47:18 | 3 | cflow.cs:37:17:37:22 | Switch |
+| cflow.cs:47:18:47:18 | After 3 [match] | cflow.cs:37:17:37:22 | Switch |
+| cflow.cs:47:18:47:18 | After 3 [no-match] | cflow.cs:37:17:37:22 | Switch |
 | cflow.cs:48:17:48:38 | After call to method WriteLine | cflow.cs:37:17:37:22 | Switch |
 | cflow.cs:48:17:48:38 | Before call to method WriteLine | cflow.cs:37:17:37:22 | Switch |
 | cflow.cs:48:17:48:38 | call to method WriteLine | cflow.cs:37:17:37:22 | Switch |
@@ -7108,6 +7196,8 @@ nodeEnclosing
 | cflow.cs:53:13:53:20 | After case ...: [no-match] | cflow.cs:37:17:37:22 | Switch |
 | cflow.cs:53:13:53:20 | case ...: | cflow.cs:37:17:37:22 | Switch |
 | cflow.cs:53:18:53:19 | 42 | cflow.cs:37:17:37:22 | Switch |
+| cflow.cs:53:18:53:19 | After 42 [match] | cflow.cs:37:17:37:22 | Switch |
+| cflow.cs:53:18:53:19 | After 42 [no-match] | cflow.cs:37:17:37:22 | Switch |
 | cflow.cs:54:17:54:47 | After call to method WriteLine | cflow.cs:37:17:37:22 | Switch |
 | cflow.cs:54:17:54:47 | Before call to method WriteLine | cflow.cs:37:17:37:22 | Switch |
 | cflow.cs:54:17:54:47 | call to method WriteLine | cflow.cs:37:17:37:22 | Switch |
@@ -7139,6 +7229,8 @@ nodeEnclosing
 | cflow.cs:62:13:62:19 | After case ...: [no-match] | cflow.cs:37:17:37:22 | Switch |
 | cflow.cs:62:13:62:19 | case ...: | cflow.cs:37:17:37:22 | Switch |
 | cflow.cs:62:18:62:18 | 0 | cflow.cs:37:17:37:22 | Switch |
+| cflow.cs:62:18:62:18 | After 0 [match] | cflow.cs:37:17:37:22 | Switch |
+| cflow.cs:62:18:62:18 | After 0 [no-match] | cflow.cs:37:17:37:22 | Switch |
 | cflow.cs:63:17:64:55 | After if (...) ... | cflow.cs:37:17:37:22 | Switch |
 | cflow.cs:63:17:64:55 | if (...) ... | cflow.cs:37:17:37:22 | Switch |
 | cflow.cs:63:21:63:34 | !... | cflow.cs:37:17:37:22 | Switch |
@@ -8075,12 +8167,16 @@ nodeEnclosing
 | cflow.cs:248:13:248:19 | After case ...: [no-match] | cflow.cs:240:10:240:13 | Goto |
 | cflow.cs:248:13:248:19 | case ...: | cflow.cs:240:10:240:13 | Goto |
 | cflow.cs:248:18:248:18 | 0 | cflow.cs:240:10:240:13 | Goto |
+| cflow.cs:248:18:248:18 | After 0 [match] | cflow.cs:240:10:240:13 | Goto |
+| cflow.cs:248:18:248:18 | After 0 [no-match] | cflow.cs:240:10:240:13 | Goto |
 | cflow.cs:249:17:249:29 | Before goto default; | cflow.cs:240:10:240:13 | Goto |
 | cflow.cs:249:17:249:29 | goto default; | cflow.cs:240:10:240:13 | Goto |
 | cflow.cs:250:13:250:19 | After case ...: [match] | cflow.cs:240:10:240:13 | Goto |
 | cflow.cs:250:13:250:19 | After case ...: [no-match] | cflow.cs:240:10:240:13 | Goto |
 | cflow.cs:250:13:250:19 | case ...: | cflow.cs:240:10:240:13 | Goto |
 | cflow.cs:250:18:250:18 | 1 | cflow.cs:240:10:240:13 | Goto |
+| cflow.cs:250:18:250:18 | After 1 [match] | cflow.cs:240:10:240:13 | Goto |
+| cflow.cs:250:18:250:18 | After 1 [no-match] | cflow.cs:240:10:240:13 | Goto |
 | cflow.cs:251:17:251:36 | After call to method WriteLine | cflow.cs:240:10:240:13 | Goto |
 | cflow.cs:251:17:251:36 | Before call to method WriteLine | cflow.cs:240:10:240:13 | Goto |
 | cflow.cs:251:17:251:36 | call to method WriteLine | cflow.cs:240:10:240:13 | Goto |
@@ -8093,6 +8189,8 @@ nodeEnclosing
 | cflow.cs:253:13:253:19 | After case ...: [no-match] | cflow.cs:240:10:240:13 | Goto |
 | cflow.cs:253:13:253:19 | case ...: | cflow.cs:240:10:240:13 | Goto |
 | cflow.cs:253:18:253:18 | 2 | cflow.cs:240:10:240:13 | Goto |
+| cflow.cs:253:18:253:18 | After 2 [match] | cflow.cs:240:10:240:13 | Goto |
+| cflow.cs:253:18:253:18 | After 2 [no-match] | cflow.cs:240:10:240:13 | Goto |
 | cflow.cs:254:17:254:27 | Before goto ...; | cflow.cs:240:10:240:13 | Goto |
 | cflow.cs:254:17:254:27 | goto ...; | cflow.cs:240:10:240:13 | Goto |
 | cflow.cs:255:13:255:20 | After default: [match] | cflow.cs:240:10:240:13 | Goto |
@@ -9204,19 +9302,19 @@ blockEnclosing
 | Patterns.cs:16:18:16:28 | After ... is ... [false] | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:16:18:16:28 | [MatchTrue] ... is ... | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:20:9:38:9 | After switch (...) {...} | Patterns.cs:5:10:5:11 | M1 |
-| Patterns.cs:22:13:22:23 | After case ...: [match] | Patterns.cs:5:10:5:11 | M1 |
-| Patterns.cs:22:13:22:23 | After case ...: [no-match] | Patterns.cs:5:10:5:11 | M1 |
-| Patterns.cs:24:13:24:36 | After case ...: [match] | Patterns.cs:5:10:5:11 | M1 |
-| Patterns.cs:24:13:24:36 | After case ...: [no-match] | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:22:18:22:22 | After "xyz" [match] | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:22:18:22:22 | After "xyz" [no-match] | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:24:18:24:23 | After Int32 i2 [match] | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:24:18:24:23 | After Int32 i2 [no-match] | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:24:30:24:35 | After ... > ... [false] | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:24:30:24:35 | After ... > ... [true] | Patterns.cs:5:10:5:11 | M1 |
-| Patterns.cs:27:13:27:24 | After case ...: [match] | Patterns.cs:5:10:5:11 | M1 |
-| Patterns.cs:27:13:27:24 | After case ...: [no-match] | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:27:13:27:24 | case ...: | Patterns.cs:5:10:5:11 | M1 |
-| Patterns.cs:30:13:30:27 | After case ...: [match] | Patterns.cs:5:10:5:11 | M1 |
-| Patterns.cs:30:13:30:27 | After case ...: [no-match] | Patterns.cs:5:10:5:11 | M1 |
-| Patterns.cs:33:13:33:24 | After case ...: [match] | Patterns.cs:5:10:5:11 | M1 |
-| Patterns.cs:33:13:33:24 | After case ...: [no-match] | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:27:18:27:23 | After Int32 i3 [match] | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:27:18:27:23 | After Int32 i3 [no-match] | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:30:18:30:26 | After String s2 [match] | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:30:18:30:26 | After String s2 [no-match] | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:33:18:33:23 | After Object v2 [match] | Patterns.cs:5:10:5:11 | M1 |
+| Patterns.cs:33:18:33:23 | After Object v2 [no-match] | Patterns.cs:5:10:5:11 | M1 |
 | Patterns.cs:47:24:47:25 | Entry | Patterns.cs:47:24:47:25 | M2 |
 | Patterns.cs:48:9:48:20 | After ... is ... | Patterns.cs:47:24:47:25 | M2 |
 | Patterns.cs:48:9:48:20 | [MatchTrue] ... is ... | Patterns.cs:47:24:47:25 | M2 |
@@ -9233,22 +9331,22 @@ blockEnclosing
 | Patterns.cs:54:9:54:37 | [MatchTrue] ... is ... | Patterns.cs:53:24:53:25 | M4 |
 | Patterns.cs:56:26:56:27 | Entry | Patterns.cs:56:26:56:27 | M5 |
 | Patterns.cs:58:16:62:9 | After ... switch { ... } | Patterns.cs:56:26:56:27 | M5 |
-| Patterns.cs:60:13:60:28 | After ... => ... [match] | Patterns.cs:56:26:56:27 | M5 |
-| Patterns.cs:60:13:60:28 | After ... => ... [no-match] | Patterns.cs:56:26:56:27 | M5 |
+| Patterns.cs:60:13:60:17 | After not ... [match] | Patterns.cs:56:26:56:27 | M5 |
+| Patterns.cs:60:13:60:17 | After not ... [no-match] | Patterns.cs:56:26:56:27 | M5 |
 | Patterns.cs:65:26:65:27 | Entry | Patterns.cs:65:26:65:27 | M6 |
 | Patterns.cs:67:16:71:9 | After ... switch { ... } | Patterns.cs:65:26:65:27 | M6 |
-| Patterns.cs:69:13:69:33 | After ... => ... [match] | Patterns.cs:65:26:65:27 | M6 |
-| Patterns.cs:69:13:69:33 | After ... => ... [no-match] | Patterns.cs:65:26:65:27 | M6 |
-| Patterns.cs:70:13:70:27 | After ... => ... [match] | Patterns.cs:65:26:65:27 | M6 |
-| Patterns.cs:70:13:70:27 | After ... => ... [no-match] | Patterns.cs:65:26:65:27 | M6 |
+| Patterns.cs:69:13:69:17 | After not ... [match] | Patterns.cs:65:26:65:27 | M6 |
+| Patterns.cs:69:13:69:17 | After not ... [no-match] | Patterns.cs:65:26:65:27 | M6 |
+| Patterns.cs:70:13:70:13 | After 2 [match] | Patterns.cs:65:26:65:27 | M6 |
+| Patterns.cs:70:13:70:13 | After 2 [no-match] | Patterns.cs:65:26:65:27 | M6 |
 | Patterns.cs:74:26:74:27 | Entry | Patterns.cs:74:26:74:27 | M7 |
 | Patterns.cs:76:16:82:9 | After ... switch { ... } | Patterns.cs:74:26:74:27 | M7 |
-| Patterns.cs:78:13:78:24 | After ... => ... [match] | Patterns.cs:74:26:74:27 | M7 |
-| Patterns.cs:78:13:78:24 | After ... => ... [no-match] | Patterns.cs:74:26:74:27 | M7 |
-| Patterns.cs:79:13:79:24 | After ... => ... [match] | Patterns.cs:74:26:74:27 | M7 |
-| Patterns.cs:79:13:79:24 | After ... => ... [no-match] | Patterns.cs:74:26:74:27 | M7 |
-| Patterns.cs:80:13:80:20 | After ... => ... [match] | Patterns.cs:74:26:74:27 | M7 |
-| Patterns.cs:80:13:80:20 | After ... => ... [no-match] | Patterns.cs:74:26:74:27 | M7 |
+| Patterns.cs:78:13:78:15 | After > ... [match] | Patterns.cs:74:26:74:27 | M7 |
+| Patterns.cs:78:13:78:15 | After > ... [no-match] | Patterns.cs:74:26:74:27 | M7 |
+| Patterns.cs:79:13:79:15 | After < ... [match] | Patterns.cs:74:26:74:27 | M7 |
+| Patterns.cs:79:13:79:15 | After < ... [no-match] | Patterns.cs:74:26:74:27 | M7 |
+| Patterns.cs:80:13:80:13 | After 1 [match] | Patterns.cs:74:26:74:27 | M7 |
+| Patterns.cs:80:13:80:13 | After 1 [no-match] | Patterns.cs:74:26:74:27 | M7 |
 | Patterns.cs:85:26:85:27 | Entry | Patterns.cs:85:26:85:27 | M8 |
 | Patterns.cs:85:39:85:53 | After ... is ... [false] | Patterns.cs:85:26:85:27 | M8 |
 | Patterns.cs:85:39:85:53 | [MatchTrue] ... is ... | Patterns.cs:85:26:85:27 | M8 |
@@ -9281,125 +9379,126 @@ blockEnclosing
 | Switch.cs:10:10:10:11 | Exceptional Exit | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:10:10:10:11 | Exit | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:10:10:10:11 | Normal Exit | Switch.cs:10:10:10:11 | M2 |
-| Switch.cs:14:13:14:21 | After case ...: [match] | Switch.cs:10:10:10:11 | M2 |
-| Switch.cs:14:13:14:21 | After case ...: [no-match] | Switch.cs:10:10:10:11 | M2 |
+| Switch.cs:14:18:14:20 | After "a" [match] | Switch.cs:10:10:10:11 | M2 |
+| Switch.cs:14:18:14:20 | After "a" [no-match] | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:16:13:16:19 | After case ...: [match] | Switch.cs:10:10:10:11 | M2 |
-| Switch.cs:16:13:16:19 | After case ...: [no-match] | Switch.cs:10:10:10:11 | M2 |
-| Switch.cs:18:13:18:22 | After case ...: [match] | Switch.cs:10:10:10:11 | M2 |
-| Switch.cs:18:13:18:22 | After case ...: [no-match] | Switch.cs:10:10:10:11 | M2 |
-| Switch.cs:20:13:20:23 | After case ...: [match] | Switch.cs:10:10:10:11 | M2 |
-| Switch.cs:20:13:20:23 | After case ...: [no-match] | Switch.cs:10:10:10:11 | M2 |
+| Switch.cs:16:18:16:18 | After 0 [match] | Switch.cs:10:10:10:11 | M2 |
+| Switch.cs:16:18:16:18 | After 0 [no-match] | Switch.cs:10:10:10:11 | M2 |
+| Switch.cs:18:18:18:21 | After null [match] | Switch.cs:10:10:10:11 | M2 |
+| Switch.cs:18:18:18:21 | After null [no-match] | Switch.cs:10:10:10:11 | M2 |
+| Switch.cs:20:18:20:22 | After Int32 i [match] | Switch.cs:10:10:10:11 | M2 |
+| Switch.cs:20:18:20:22 | After Int32 i [no-match] | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:21:21:21:29 | After ... == ... [false] | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:21:21:21:29 | After ... == ... [true] | Switch.cs:10:10:10:11 | M2 |
-| Switch.cs:24:13:24:56 | After case ...: [match] | Switch.cs:10:10:10:11 | M2 |
-| Switch.cs:24:13:24:56 | After case ...: [no-match] | Switch.cs:10:10:10:11 | M2 |
+| Switch.cs:24:18:24:25 | After String s [match] | Switch.cs:10:10:10:11 | M2 |
+| Switch.cs:24:18:24:25 | After String s [no-match] | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:24:32:24:43 | After ... > ... [false] | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:24:32:24:43 | After ... > ... [true] | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:24:32:24:55 | After ... && ... [false] | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:24:48:24:55 | After ... != ... [false] | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:24:48:24:55 | After ... != ... [true] | Switch.cs:10:10:10:11 | M2 |
-| Switch.cs:27:13:27:39 | After case ...: [match] | Switch.cs:10:10:10:11 | M2 |
-| Switch.cs:27:13:27:39 | After case ...: [no-match] | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:27:13:27:39 | case ...: | Switch.cs:10:10:10:11 | M2 |
+| Switch.cs:27:18:27:25 | After Double d [match] | Switch.cs:10:10:10:11 | M2 |
+| Switch.cs:27:18:27:25 | After Double d [no-match] | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:30:13:30:20 | After default: [match] | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:35:10:35:11 | Entry | Switch.cs:35:10:35:11 | M3 |
 | Switch.cs:44:10:44:11 | Entry | Switch.cs:44:10:44:11 | M4 |
 | Switch.cs:46:9:52:9 | After switch (...) {...} | Switch.cs:44:10:44:11 | M4 |
-| Switch.cs:48:13:48:23 | After case ...: [match] | Switch.cs:44:10:44:11 | M4 |
-| Switch.cs:48:13:48:23 | After case ...: [no-match] | Switch.cs:44:10:44:11 | M4 |
-| Switch.cs:50:13:50:39 | After case ...: [match] | Switch.cs:44:10:44:11 | M4 |
-| Switch.cs:50:13:50:39 | After case ...: [no-match] | Switch.cs:44:10:44:11 | M4 |
+| Switch.cs:48:18:48:20 | After access to type Int32 [match] | Switch.cs:44:10:44:11 | M4 |
+| Switch.cs:48:18:48:20 | After access to type Int32 [no-match] | Switch.cs:44:10:44:11 | M4 |
+| Switch.cs:50:18:50:21 | After access to type Boolean [match] | Switch.cs:44:10:44:11 | M4 |
+| Switch.cs:50:18:50:21 | After access to type Boolean [no-match] | Switch.cs:44:10:44:11 | M4 |
 | Switch.cs:50:30:50:38 | After ... != ... [false] | Switch.cs:44:10:44:11 | M4 |
 | Switch.cs:50:30:50:38 | After ... != ... [true] | Switch.cs:44:10:44:11 | M4 |
 | Switch.cs:55:10:55:11 | Entry | Switch.cs:55:10:55:11 | M5 |
 | Switch.cs:57:9:63:9 | After switch (...) {...} | Switch.cs:55:10:55:11 | M5 |
-| Switch.cs:59:13:59:19 | After case ...: [match] | Switch.cs:55:10:55:11 | M5 |
-| Switch.cs:59:13:59:19 | After case ...: [no-match] | Switch.cs:55:10:55:11 | M5 |
-| Switch.cs:61:13:61:19 | After case ...: [match] | Switch.cs:55:10:55:11 | M5 |
-| Switch.cs:61:13:61:19 | After case ...: [no-match] | Switch.cs:55:10:55:11 | M5 |
+| Switch.cs:59:18:59:18 | After 2 [match] | Switch.cs:55:10:55:11 | M5 |
+| Switch.cs:59:18:59:18 | After 2 [no-match] | Switch.cs:55:10:55:11 | M5 |
+| Switch.cs:61:18:61:18 | After 3 [match] | Switch.cs:55:10:55:11 | M5 |
+| Switch.cs:61:18:61:18 | After 3 [no-match] | Switch.cs:55:10:55:11 | M5 |
 | Switch.cs:66:10:66:11 | Entry | Switch.cs:66:10:66:11 | M6 |
 | Switch.cs:68:9:74:9 | After switch (...) {...} | Switch.cs:66:10:66:11 | M6 |
-| Switch.cs:70:13:70:23 | After case ...: [match] | Switch.cs:66:10:66:11 | M6 |
-| Switch.cs:70:13:70:23 | After case ...: [no-match] | Switch.cs:66:10:66:11 | M6 |
-| Switch.cs:72:13:72:20 | After case ...: [match] | Switch.cs:66:10:66:11 | M6 |
-| Switch.cs:72:13:72:20 | After case ...: [no-match] | Switch.cs:66:10:66:11 | M6 |
+| Switch.cs:70:18:70:20 | After access to type Int32 [match] | Switch.cs:66:10:66:11 | M6 |
+| Switch.cs:70:18:70:20 | After access to type Int32 [no-match] | Switch.cs:66:10:66:11 | M6 |
+| Switch.cs:72:18:72:19 | After "" [match] | Switch.cs:66:10:66:11 | M6 |
+| Switch.cs:72:18:72:19 | After "" [no-match] | Switch.cs:66:10:66:11 | M6 |
 | Switch.cs:77:10:77:11 | Entry | Switch.cs:77:10:77:11 | M7 |
 | Switch.cs:77:10:77:11 | Normal Exit | Switch.cs:77:10:77:11 | M7 |
 | Switch.cs:79:9:87:9 | After switch (...) {...} | Switch.cs:77:10:77:11 | M7 |
-| Switch.cs:81:13:81:19 | After case ...: [match] | Switch.cs:77:10:77:11 | M7 |
-| Switch.cs:81:13:81:19 | After case ...: [no-match] | Switch.cs:77:10:77:11 | M7 |
-| Switch.cs:83:13:83:19 | After case ...: [match] | Switch.cs:77:10:77:11 | M7 |
-| Switch.cs:83:13:83:19 | After case ...: [no-match] | Switch.cs:77:10:77:11 | M7 |
+| Switch.cs:81:18:81:18 | After 1 [match] | Switch.cs:77:10:77:11 | M7 |
+| Switch.cs:81:18:81:18 | After 1 [no-match] | Switch.cs:77:10:77:11 | M7 |
+| Switch.cs:83:18:83:18 | After 2 [match] | Switch.cs:77:10:77:11 | M7 |
+| Switch.cs:83:18:83:18 | After 2 [no-match] | Switch.cs:77:10:77:11 | M7 |
 | Switch.cs:84:21:84:25 | After ... > ... [false] | Switch.cs:77:10:77:11 | M7 |
 | Switch.cs:84:21:84:25 | After ... > ... [true] | Switch.cs:77:10:77:11 | M7 |
 | Switch.cs:91:10:91:11 | Entry | Switch.cs:91:10:91:11 | M8 |
 | Switch.cs:91:10:91:11 | Normal Exit | Switch.cs:91:10:91:11 | M8 |
-| Switch.cs:95:13:95:23 | After case ...: [match] | Switch.cs:91:10:91:11 | M8 |
-| Switch.cs:95:13:95:23 | After case ...: [no-match] | Switch.cs:91:10:91:11 | M8 |
+| Switch.cs:95:18:95:20 | After access to type Int32 [match] | Switch.cs:91:10:91:11 | M8 |
+| Switch.cs:95:18:95:20 | After access to type Int32 [no-match] | Switch.cs:91:10:91:11 | M8 |
 | Switch.cs:101:9:101:10 | Entry | Switch.cs:101:9:101:10 | M9 |
 | Switch.cs:101:9:101:10 | Normal Exit | Switch.cs:101:9:101:10 | M9 |
 | Switch.cs:103:17:103:17 | After access to parameter s [non-null] | Switch.cs:101:9:101:10 | M9 |
 | Switch.cs:103:17:103:17 | After access to parameter s [null] | Switch.cs:101:9:101:10 | M9 |
 | Switch.cs:103:17:103:25 | After access to property Length | Switch.cs:101:9:101:10 | M9 |
-| Switch.cs:105:13:105:19 | After case ...: [match] | Switch.cs:101:9:101:10 | M9 |
-| Switch.cs:105:13:105:19 | After case ...: [no-match] | Switch.cs:101:9:101:10 | M9 |
-| Switch.cs:106:13:106:19 | After case ...: [match] | Switch.cs:101:9:101:10 | M9 |
-| Switch.cs:106:13:106:19 | After case ...: [no-match] | Switch.cs:101:9:101:10 | M9 |
+| Switch.cs:105:18:105:18 | After 0 [match] | Switch.cs:101:9:101:10 | M9 |
+| Switch.cs:105:18:105:18 | After 0 [no-match] | Switch.cs:101:9:101:10 | M9 |
+| Switch.cs:106:18:106:18 | After 1 [match] | Switch.cs:101:9:101:10 | M9 |
+| Switch.cs:106:18:106:18 | After 1 [no-match] | Switch.cs:101:9:101:10 | M9 |
 | Switch.cs:111:17:111:21 | Entry | Switch.cs:111:17:111:21 | Throw |
 | Switch.cs:113:9:113:11 | Entry | Switch.cs:113:9:113:11 | M10 |
 | Switch.cs:113:9:113:11 | Normal Exit | Switch.cs:113:9:113:11 | M10 |
 | Switch.cs:115:9:119:9 | After switch (...) {...} | Switch.cs:113:9:113:11 | M10 |
-| Switch.cs:117:13:117:35 | After case ...: [match] | Switch.cs:113:9:113:11 | M10 |
-| Switch.cs:117:13:117:35 | After case ...: [no-match] | Switch.cs:113:9:113:11 | M10 |
+| Switch.cs:117:18:117:18 | After 3 [match] | Switch.cs:113:9:113:11 | M10 |
+| Switch.cs:117:18:117:18 | After 3 [no-match] | Switch.cs:113:9:113:11 | M10 |
 | Switch.cs:117:25:117:34 | After ... == ... [false] | Switch.cs:113:9:113:11 | M10 |
 | Switch.cs:117:25:117:34 | After ... == ... [true] | Switch.cs:113:9:113:11 | M10 |
-| Switch.cs:118:13:118:34 | After case ...: [match] | Switch.cs:113:9:113:11 | M10 |
-| Switch.cs:118:13:118:34 | After case ...: [no-match] | Switch.cs:113:9:113:11 | M10 |
 | Switch.cs:118:13:118:34 | case ...: | Switch.cs:113:9:113:11 | M10 |
+| Switch.cs:118:18:118:18 | After 2 [match] | Switch.cs:113:9:113:11 | M10 |
+| Switch.cs:118:18:118:18 | After 2 [no-match] | Switch.cs:113:9:113:11 | M10 |
 | Switch.cs:118:25:118:33 | After ... == ... [false] | Switch.cs:113:9:113:11 | M10 |
 | Switch.cs:118:25:118:33 | After ... == ... [true] | Switch.cs:113:9:113:11 | M10 |
 | Switch.cs:123:10:123:12 | Entry | Switch.cs:123:10:123:12 | M11 |
 | Switch.cs:123:10:123:12 | Normal Exit | Switch.cs:123:10:123:12 | M11 |
 | Switch.cs:125:13:125:48 | After ... switch { ... } [false] | Switch.cs:123:10:123:12 | M11 |
 | Switch.cs:125:13:125:48 | After ... switch { ... } [true] | Switch.cs:123:10:123:12 | M11 |
-| Switch.cs:125:24:125:34 | After ... => ... [match] | Switch.cs:123:10:123:12 | M11 |
-| Switch.cs:125:24:125:34 | After ... => ... [no-match] | Switch.cs:123:10:123:12 | M11 |
+| Switch.cs:125:24:125:29 | After Boolean b [match] | Switch.cs:123:10:123:12 | M11 |
+| Switch.cs:125:24:125:29 | After Boolean b [no-match] | Switch.cs:123:10:123:12 | M11 |
 | Switch.cs:129:12:129:14 | Entry | Switch.cs:129:12:129:14 | M12 |
 | Switch.cs:131:16:131:66 | After call to method ToString | Switch.cs:129:12:129:14 | M12 |
 | Switch.cs:131:17:131:53 | After ... switch { ... } [non-null] | Switch.cs:129:12:129:14 | M12 |
 | Switch.cs:131:17:131:53 | After ... switch { ... } [null] | Switch.cs:129:12:129:14 | M12 |
-| Switch.cs:131:28:131:40 | After ... => ... [match] | Switch.cs:129:12:129:14 | M12 |
-| Switch.cs:131:28:131:40 | After ... => ... [no-match] | Switch.cs:129:12:129:14 | M12 |
+| Switch.cs:131:28:131:35 | After String s [match] | Switch.cs:129:12:129:14 | M12 |
+| Switch.cs:131:28:131:35 | After String s [no-match] | Switch.cs:129:12:129:14 | M12 |
 | Switch.cs:134:9:134:11 | Entry | Switch.cs:134:9:134:11 | M13 |
 | Switch.cs:134:9:134:11 | Normal Exit | Switch.cs:134:9:134:11 | M13 |
-| Switch.cs:139:13:139:19 | After case ...: [match] | Switch.cs:134:9:134:11 | M13 |
-| Switch.cs:139:13:139:19 | After case ...: [no-match] | Switch.cs:134:9:134:11 | M13 |
-| Switch.cs:140:13:140:19 | After case ...: [match] | Switch.cs:134:9:134:11 | M13 |
-| Switch.cs:140:13:140:19 | After case ...: [no-match] | Switch.cs:134:9:134:11 | M13 |
+| Switch.cs:139:18:139:18 | After 1 [match] | Switch.cs:134:9:134:11 | M13 |
+| Switch.cs:139:18:139:18 | After 1 [no-match] | Switch.cs:134:9:134:11 | M13 |
+| Switch.cs:140:18:140:18 | After 2 [match] | Switch.cs:134:9:134:11 | M13 |
+| Switch.cs:140:18:140:18 | After 2 [no-match] | Switch.cs:134:9:134:11 | M13 |
 | Switch.cs:144:9:144:11 | Entry | Switch.cs:144:9:144:11 | M14 |
 | Switch.cs:144:9:144:11 | Normal Exit | Switch.cs:144:9:144:11 | M14 |
-| Switch.cs:148:13:148:19 | After case ...: [match] | Switch.cs:144:9:144:11 | M14 |
-| Switch.cs:148:13:148:19 | After case ...: [no-match] | Switch.cs:144:9:144:11 | M14 |
-| Switch.cs:150:13:150:19 | After case ...: [match] | Switch.cs:144:9:144:11 | M14 |
-| Switch.cs:150:13:150:19 | After case ...: [no-match] | Switch.cs:144:9:144:11 | M14 |
+| Switch.cs:148:18:148:18 | After 1 [match] | Switch.cs:144:9:144:11 | M14 |
+| Switch.cs:148:18:148:18 | After 1 [no-match] | Switch.cs:144:9:144:11 | M14 |
+| Switch.cs:150:18:150:18 | After 2 [match] | Switch.cs:144:9:144:11 | M14 |
+| Switch.cs:150:18:150:18 | After 2 [no-match] | Switch.cs:144:9:144:11 | M14 |
 | Switch.cs:154:10:154:12 | Entry | Switch.cs:154:10:154:12 | M15 |
 | Switch.cs:156:17:156:54 | After ... switch { ... } | Switch.cs:154:10:154:12 | M15 |
-| Switch.cs:156:28:156:38 | After ... => ... [match] | Switch.cs:154:10:154:12 | M15 |
-| Switch.cs:156:28:156:38 | After ... => ... [no-match] | Switch.cs:154:10:154:12 | M15 |
-| Switch.cs:156:41:156:52 | After ... => ... [match] | Switch.cs:154:10:154:12 | M15 |
-| Switch.cs:156:41:156:52 | After ... => ... [no-match] | Switch.cs:154:10:154:12 | M15 |
+| Switch.cs:156:28:156:31 | After true [match] | Switch.cs:154:10:154:12 | M15 |
+| Switch.cs:156:28:156:31 | After true [no-match] | Switch.cs:154:10:154:12 | M15 |
+| Switch.cs:156:41:156:45 | After false [match] | Switch.cs:154:10:154:12 | M15 |
+| Switch.cs:156:41:156:45 | After false [no-match] | Switch.cs:154:10:154:12 | M15 |
 | Switch.cs:157:9:160:49 | After if (...) ... | Switch.cs:154:10:154:12 | M15 |
 | Switch.cs:157:13:157:13 | After access to parameter b [false] | Switch.cs:154:10:154:12 | M15 |
 | Switch.cs:157:13:157:13 | After access to parameter b [true] | Switch.cs:154:10:154:12 | M15 |
 | Switch.cs:163:10:163:12 | Entry | Switch.cs:163:10:163:12 | M16 |
 | Switch.cs:165:9:177:9 | After switch (...) {...} | Switch.cs:163:10:163:12 | M16 |
-| Switch.cs:167:13:167:19 | After case ...: [match] | Switch.cs:163:10:163:12 | M16 |
-| Switch.cs:167:13:167:19 | After case ...: [no-match] | Switch.cs:163:10:163:12 | M16 |
-| Switch.cs:168:13:168:19 | After case ...: [match] | Switch.cs:163:10:163:12 | M16 |
-| Switch.cs:168:13:168:19 | After case ...: [no-match] | Switch.cs:163:10:163:12 | M16 |
+| Switch.cs:167:18:167:18 | After 1 [match] | Switch.cs:163:10:163:12 | M16 |
+| Switch.cs:167:18:167:18 | After 1 [no-match] | Switch.cs:163:10:163:12 | M16 |
+| Switch.cs:168:18:168:18 | After 2 [match] | Switch.cs:163:10:163:12 | M16 |
+| Switch.cs:168:18:168:18 | After 2 [no-match] | Switch.cs:163:10:163:12 | M16 |
 | Switch.cs:169:17:169:51 | ...; | Switch.cs:163:10:163:12 | M16 |
-| Switch.cs:171:13:171:19 | After case ...: [match] | Switch.cs:163:10:163:12 | M16 |
-| Switch.cs:171:13:171:19 | After case ...: [no-match] | Switch.cs:163:10:163:12 | M16 |
+| Switch.cs:171:18:171:18 | After 3 [match] | Switch.cs:163:10:163:12 | M16 |
+| Switch.cs:171:18:171:18 | After 3 [no-match] | Switch.cs:163:10:163:12 | M16 |
 | TypeAccesses.cs:1:7:1:18 | Entry | TypeAccesses.cs:1:7:1:18 | TypeAccesses |
 | TypeAccesses.cs:3:10:3:10 | Entry | TypeAccesses.cs:3:10:3:10 | M |
 | TypeAccesses.cs:7:9:7:25 | After if (...) ... | TypeAccesses.cs:3:10:3:10 | M |
@@ -9443,17 +9542,19 @@ blockEnclosing
 | cflow.cs:37:17:37:22 | Exit | cflow.cs:37:17:37:22 | Switch |
 | cflow.cs:39:9:50:9 | After switch (...) {...} | cflow.cs:37:17:37:22 | Switch |
 | cflow.cs:41:13:41:19 | After case ...: [match] | cflow.cs:37:17:37:22 | Switch |
-| cflow.cs:41:13:41:19 | After case ...: [no-match] | cflow.cs:37:17:37:22 | Switch |
+| cflow.cs:41:18:41:18 | After 1 [match] | cflow.cs:37:17:37:22 | Switch |
+| cflow.cs:41:18:41:18 | After 1 [no-match] | cflow.cs:37:17:37:22 | Switch |
 | cflow.cs:44:13:44:19 | After case ...: [match] | cflow.cs:37:17:37:22 | Switch |
-| cflow.cs:44:13:44:19 | After case ...: [no-match] | cflow.cs:37:17:37:22 | Switch |
-| cflow.cs:47:13:47:19 | After case ...: [match] | cflow.cs:37:17:37:22 | Switch |
-| cflow.cs:47:13:47:19 | After case ...: [no-match] | cflow.cs:37:17:37:22 | Switch |
+| cflow.cs:44:18:44:18 | After 2 [match] | cflow.cs:37:17:37:22 | Switch |
+| cflow.cs:44:18:44:18 | After 2 [no-match] | cflow.cs:37:17:37:22 | Switch |
+| cflow.cs:47:18:47:18 | After 3 [match] | cflow.cs:37:17:37:22 | Switch |
+| cflow.cs:47:18:47:18 | After 3 [no-match] | cflow.cs:37:17:37:22 | Switch |
 | cflow.cs:51:9:59:9 | After switch (...) {...} | cflow.cs:37:17:37:22 | Switch |
-| cflow.cs:53:13:53:20 | After case ...: [match] | cflow.cs:37:17:37:22 | Switch |
-| cflow.cs:53:13:53:20 | After case ...: [no-match] | cflow.cs:37:17:37:22 | Switch |
+| cflow.cs:53:18:53:19 | After 42 [match] | cflow.cs:37:17:37:22 | Switch |
+| cflow.cs:53:18:53:19 | After 42 [no-match] | cflow.cs:37:17:37:22 | Switch |
 | cflow.cs:60:9:66:9 | After switch (...) {...} | cflow.cs:37:17:37:22 | Switch |
-| cflow.cs:62:13:62:19 | After case ...: [match] | cflow.cs:37:17:37:22 | Switch |
-| cflow.cs:62:13:62:19 | After case ...: [no-match] | cflow.cs:37:17:37:22 | Switch |
+| cflow.cs:62:18:62:18 | After 0 [match] | cflow.cs:37:17:37:22 | Switch |
+| cflow.cs:62:18:62:18 | After 0 [no-match] | cflow.cs:37:17:37:22 | Switch |
 | cflow.cs:63:23:63:33 | After ... == ... [false] | cflow.cs:37:17:37:22 | Switch |
 | cflow.cs:63:23:63:33 | After ... == ... [true] | cflow.cs:37:17:37:22 | Switch |
 | cflow.cs:70:18:70:18 | Entry | cflow.cs:70:18:70:18 | M |
@@ -9578,12 +9679,12 @@ blockEnclosing
 | cflow.cs:244:13:244:28 | After ... > ... [false] | cflow.cs:240:10:240:13 | Goto |
 | cflow.cs:244:13:244:28 | After ... > ... [true] | cflow.cs:240:10:240:13 | Goto |
 | cflow.cs:246:9:258:9 | After switch (...) {...} | cflow.cs:240:10:240:13 | Goto |
-| cflow.cs:248:13:248:19 | After case ...: [match] | cflow.cs:240:10:240:13 | Goto |
-| cflow.cs:248:13:248:19 | After case ...: [no-match] | cflow.cs:240:10:240:13 | Goto |
-| cflow.cs:250:13:250:19 | After case ...: [match] | cflow.cs:240:10:240:13 | Goto |
-| cflow.cs:250:13:250:19 | After case ...: [no-match] | cflow.cs:240:10:240:13 | Goto |
-| cflow.cs:253:13:253:19 | After case ...: [match] | cflow.cs:240:10:240:13 | Goto |
-| cflow.cs:253:13:253:19 | After case ...: [no-match] | cflow.cs:240:10:240:13 | Goto |
+| cflow.cs:248:18:248:18 | After 0 [match] | cflow.cs:240:10:240:13 | Goto |
+| cflow.cs:248:18:248:18 | After 0 [no-match] | cflow.cs:240:10:240:13 | Goto |
+| cflow.cs:250:18:250:18 | After 1 [match] | cflow.cs:240:10:240:13 | Goto |
+| cflow.cs:250:18:250:18 | After 1 [no-match] | cflow.cs:240:10:240:13 | Goto |
+| cflow.cs:253:18:253:18 | After 2 [match] | cflow.cs:240:10:240:13 | Goto |
+| cflow.cs:253:18:253:18 | After 2 [no-match] | cflow.cs:240:10:240:13 | Goto |
 | cflow.cs:255:13:255:20 | After default: [match] | cflow.cs:240:10:240:13 | Goto |
 | cflow.cs:261:49:261:53 | Entry | cflow.cs:261:49:261:53 | Yield |
 | cflow.cs:261:49:261:53 | Exceptional Exit | cflow.cs:261:49:261:53 | Yield |

--- a/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
@@ -5714,18 +5714,22 @@
 | Patterns.cs:20:9:38:9 | After switch (...) {...} | Patterns.cs:40:9:42:9 | switch (...) {...} |  |
 | Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:20:17:20:17 | access to local variable o |  |
 | Patterns.cs:20:17:20:17 | access to local variable o | Patterns.cs:22:13:22:23 | case ...: |  |
-| Patterns.cs:22:13:22:23 | After case ...: [match] | Patterns.cs:22:18:22:22 | "xyz" |  |
+| Patterns.cs:22:13:22:23 | After case ...: [match] | Patterns.cs:23:17:23:22 | Before break; |  |
 | Patterns.cs:22:13:22:23 | After case ...: [no-match] | Patterns.cs:24:13:24:36 | case ...: |  |
-| Patterns.cs:22:13:22:23 | case ...: | Patterns.cs:22:13:22:23 | After case ...: [match] | match |
-| Patterns.cs:22:13:22:23 | case ...: | Patterns.cs:22:13:22:23 | After case ...: [no-match] | no-match |
-| Patterns.cs:22:18:22:22 | "xyz" | Patterns.cs:23:17:23:22 | Before break; |  |
+| Patterns.cs:22:13:22:23 | case ...: | Patterns.cs:22:18:22:22 | "xyz" |  |
+| Patterns.cs:22:18:22:22 | "xyz" | Patterns.cs:22:18:22:22 | After "xyz" [match] | match |
+| Patterns.cs:22:18:22:22 | "xyz" | Patterns.cs:22:18:22:22 | After "xyz" [no-match] | no-match |
+| Patterns.cs:22:18:22:22 | After "xyz" [match] | Patterns.cs:22:13:22:23 | After case ...: [match] | match |
+| Patterns.cs:22:18:22:22 | After "xyz" [no-match] | Patterns.cs:22:13:22:23 | After case ...: [no-match] | no-match |
 | Patterns.cs:23:17:23:22 | Before break; | Patterns.cs:23:17:23:22 | break; |  |
 | Patterns.cs:23:17:23:22 | break; | Patterns.cs:20:9:38:9 | After switch (...) {...} | break |
-| Patterns.cs:24:13:24:36 | After case ...: [match] | Patterns.cs:24:18:24:23 | Int32 i2 |  |
+| Patterns.cs:24:13:24:36 | After case ...: [match] | Patterns.cs:24:30:24:35 | Before ... > ... |  |
 | Patterns.cs:24:13:24:36 | After case ...: [no-match] | Patterns.cs:27:13:27:24 | case ...: |  |
-| Patterns.cs:24:13:24:36 | case ...: | Patterns.cs:24:13:24:36 | After case ...: [match] | match |
-| Patterns.cs:24:13:24:36 | case ...: | Patterns.cs:24:13:24:36 | After case ...: [no-match] | no-match |
-| Patterns.cs:24:18:24:23 | Int32 i2 | Patterns.cs:24:30:24:35 | Before ... > ... |  |
+| Patterns.cs:24:13:24:36 | case ...: | Patterns.cs:24:18:24:23 | Int32 i2 |  |
+| Patterns.cs:24:18:24:23 | After Int32 i2 [match] | Patterns.cs:24:13:24:36 | After case ...: [match] | match |
+| Patterns.cs:24:18:24:23 | After Int32 i2 [no-match] | Patterns.cs:24:13:24:36 | After case ...: [no-match] | no-match |
+| Patterns.cs:24:18:24:23 | Int32 i2 | Patterns.cs:24:18:24:23 | After Int32 i2 [match] | match |
+| Patterns.cs:24:18:24:23 | Int32 i2 | Patterns.cs:24:18:24:23 | After Int32 i2 [no-match] | no-match |
 | Patterns.cs:24:30:24:31 | access to local variable i2 | Patterns.cs:24:35:24:35 | 0 |  |
 | Patterns.cs:24:30:24:35 | ... > ... | Patterns.cs:24:30:24:35 | After ... > ... [false] | false |
 | Patterns.cs:24:30:24:35 | ... > ... | Patterns.cs:24:30:24:35 | After ... > ... [true] | true |
@@ -5748,11 +5752,13 @@
 | Patterns.cs:25:47:25:48 | access to local variable i2 | Patterns.cs:25:46:25:49 | {...} |  |
 | Patterns.cs:26:17:26:22 | Before break; | Patterns.cs:26:17:26:22 | break; |  |
 | Patterns.cs:26:17:26:22 | break; | Patterns.cs:20:9:38:9 | After switch (...) {...} | break |
-| Patterns.cs:27:13:27:24 | After case ...: [match] | Patterns.cs:27:18:27:23 | Int32 i3 |  |
+| Patterns.cs:27:13:27:24 | After case ...: [match] | Patterns.cs:28:17:28:47 | ...; |  |
 | Patterns.cs:27:13:27:24 | After case ...: [no-match] | Patterns.cs:30:13:30:27 | case ...: |  |
-| Patterns.cs:27:13:27:24 | case ...: | Patterns.cs:27:13:27:24 | After case ...: [match] | match |
-| Patterns.cs:27:13:27:24 | case ...: | Patterns.cs:27:13:27:24 | After case ...: [no-match] | no-match |
-| Patterns.cs:27:18:27:23 | Int32 i3 | Patterns.cs:28:17:28:47 | ...; |  |
+| Patterns.cs:27:13:27:24 | case ...: | Patterns.cs:27:18:27:23 | Int32 i3 |  |
+| Patterns.cs:27:18:27:23 | After Int32 i3 [match] | Patterns.cs:27:13:27:24 | After case ...: [match] | match |
+| Patterns.cs:27:18:27:23 | After Int32 i3 [no-match] | Patterns.cs:27:13:27:24 | After case ...: [no-match] | no-match |
+| Patterns.cs:27:18:27:23 | Int32 i3 | Patterns.cs:27:18:27:23 | After Int32 i3 [match] | match |
+| Patterns.cs:27:18:27:23 | Int32 i3 | Patterns.cs:27:18:27:23 | After Int32 i3 [no-match] | no-match |
 | Patterns.cs:28:17:28:46 | After call to method WriteLine | Patterns.cs:28:17:28:47 | After ...; |  |
 | Patterns.cs:28:17:28:46 | Before call to method WriteLine | Patterns.cs:28:35:28:45 | Before $"..." |  |
 | Patterns.cs:28:17:28:46 | call to method WriteLine | Patterns.cs:28:17:28:46 | After call to method WriteLine |  |
@@ -5768,11 +5774,13 @@
 | Patterns.cs:28:42:28:43 | access to local variable i3 | Patterns.cs:28:41:28:44 | {...} |  |
 | Patterns.cs:29:17:29:22 | Before break; | Patterns.cs:29:17:29:22 | break; |  |
 | Patterns.cs:29:17:29:22 | break; | Patterns.cs:20:9:38:9 | After switch (...) {...} | break |
-| Patterns.cs:30:13:30:27 | After case ...: [match] | Patterns.cs:30:18:30:26 | String s2 |  |
+| Patterns.cs:30:13:30:27 | After case ...: [match] | Patterns.cs:31:17:31:50 | ...; |  |
 | Patterns.cs:30:13:30:27 | After case ...: [no-match] | Patterns.cs:33:13:33:24 | case ...: |  |
-| Patterns.cs:30:13:30:27 | case ...: | Patterns.cs:30:13:30:27 | After case ...: [match] | match |
-| Patterns.cs:30:13:30:27 | case ...: | Patterns.cs:30:13:30:27 | After case ...: [no-match] | no-match |
-| Patterns.cs:30:18:30:26 | String s2 | Patterns.cs:31:17:31:50 | ...; |  |
+| Patterns.cs:30:13:30:27 | case ...: | Patterns.cs:30:18:30:26 | String s2 |  |
+| Patterns.cs:30:18:30:26 | After String s2 [match] | Patterns.cs:30:13:30:27 | After case ...: [match] | match |
+| Patterns.cs:30:18:30:26 | After String s2 [no-match] | Patterns.cs:30:13:30:27 | After case ...: [no-match] | no-match |
+| Patterns.cs:30:18:30:26 | String s2 | Patterns.cs:30:18:30:26 | After String s2 [match] | match |
+| Patterns.cs:30:18:30:26 | String s2 | Patterns.cs:30:18:30:26 | After String s2 [no-match] | no-match |
 | Patterns.cs:31:17:31:49 | After call to method WriteLine | Patterns.cs:31:17:31:50 | After ...; |  |
 | Patterns.cs:31:17:31:49 | Before call to method WriteLine | Patterns.cs:31:35:31:48 | Before $"..." |  |
 | Patterns.cs:31:17:31:49 | call to method WriteLine | Patterns.cs:31:17:31:49 | After call to method WriteLine |  |
@@ -5788,11 +5796,13 @@
 | Patterns.cs:31:45:31:46 | access to local variable s2 | Patterns.cs:31:44:31:47 | {...} |  |
 | Patterns.cs:32:17:32:22 | Before break; | Patterns.cs:32:17:32:22 | break; |  |
 | Patterns.cs:32:17:32:22 | break; | Patterns.cs:20:9:38:9 | After switch (...) {...} | break |
-| Patterns.cs:33:13:33:24 | After case ...: [match] | Patterns.cs:33:18:33:23 | Object v2 |  |
+| Patterns.cs:33:13:33:24 | After case ...: [match] | Patterns.cs:34:17:34:22 | Before break; |  |
 | Patterns.cs:33:13:33:24 | After case ...: [no-match] | Patterns.cs:35:13:35:20 | default: |  |
-| Patterns.cs:33:13:33:24 | case ...: | Patterns.cs:33:13:33:24 | After case ...: [match] | match |
-| Patterns.cs:33:13:33:24 | case ...: | Patterns.cs:33:13:33:24 | After case ...: [no-match] | no-match |
-| Patterns.cs:33:18:33:23 | Object v2 | Patterns.cs:34:17:34:22 | Before break; |  |
+| Patterns.cs:33:13:33:24 | case ...: | Patterns.cs:33:18:33:23 | Object v2 |  |
+| Patterns.cs:33:18:33:23 | After Object v2 [match] | Patterns.cs:33:13:33:24 | After case ...: [match] | match |
+| Patterns.cs:33:18:33:23 | After Object v2 [no-match] | Patterns.cs:33:13:33:24 | After case ...: [no-match] | no-match |
+| Patterns.cs:33:18:33:23 | Object v2 | Patterns.cs:33:18:33:23 | After Object v2 [match] | match |
+| Patterns.cs:33:18:33:23 | Object v2 | Patterns.cs:33:18:33:23 | After Object v2 [no-match] | no-match |
 | Patterns.cs:34:17:34:22 | Before break; | Patterns.cs:34:17:34:22 | break; |  |
 | Patterns.cs:34:17:34:22 | break; | Patterns.cs:20:9:38:9 | After switch (...) {...} | break |
 | Patterns.cs:35:13:35:20 | After default: [match] | Patterns.cs:36:17:36:52 | ...; |  |
@@ -5881,18 +5891,20 @@
 | Patterns.cs:58:16:58:16 | access to parameter i | Patterns.cs:60:13:60:28 | ... => ... |  |
 | Patterns.cs:58:16:62:9 | ... switch { ... } | Patterns.cs:58:16:58:16 | access to parameter i |  |
 | Patterns.cs:58:16:62:9 | After ... switch { ... } | Patterns.cs:58:9:62:10 | return ...; |  |
-| Patterns.cs:60:13:60:17 | After not ... | Patterns.cs:60:22:60:28 | "not 1" |  |
+| Patterns.cs:60:13:60:17 | After not ... [match] | Patterns.cs:60:13:60:28 | After ... => ... [match] | match |
+| Patterns.cs:60:13:60:17 | After not ... [no-match] | Patterns.cs:60:13:60:28 | After ... => ... [no-match] | no-match |
 | Patterns.cs:60:13:60:17 | Before not ... | Patterns.cs:60:17:60:17 | 1 |  |
-| Patterns.cs:60:13:60:17 | not ... | Patterns.cs:60:13:60:17 | After not ... |  |
-| Patterns.cs:60:13:60:28 | ... => ... | Patterns.cs:60:13:60:28 | After ... => ... [match] | match |
-| Patterns.cs:60:13:60:28 | ... => ... | Patterns.cs:60:13:60:28 | After ... => ... [no-match] | no-match |
-| Patterns.cs:60:13:60:28 | After ... => ... [match] | Patterns.cs:60:13:60:17 | Before not ... |  |
+| Patterns.cs:60:13:60:17 | not ... | Patterns.cs:60:13:60:17 | After not ... [match] | match |
+| Patterns.cs:60:13:60:17 | not ... | Patterns.cs:60:13:60:17 | After not ... [no-match] | no-match |
+| Patterns.cs:60:13:60:28 | ... => ... | Patterns.cs:60:13:60:17 | Before not ... |  |
+| Patterns.cs:60:13:60:28 | After ... => ... [match] | Patterns.cs:60:22:60:28 | "not 1" |  |
 | Patterns.cs:60:13:60:28 | After ... => ... [no-match] | Patterns.cs:61:13:61:24 | ... => ... |  |
 | Patterns.cs:60:17:60:17 | 1 | Patterns.cs:60:13:60:17 | not ... |  |
 | Patterns.cs:60:22:60:28 | "not 1" | Patterns.cs:58:16:62:9 | After ... switch { ... } |  |
-| Patterns.cs:61:13:61:13 | _ | Patterns.cs:61:18:61:24 | "other" |  |
-| Patterns.cs:61:13:61:24 | ... => ... | Patterns.cs:61:13:61:24 | After ... => ... [match] | match |
-| Patterns.cs:61:13:61:24 | After ... => ... [match] | Patterns.cs:61:13:61:13 | _ |  |
+| Patterns.cs:61:13:61:13 | After _ [match] | Patterns.cs:61:13:61:24 | After ... => ... [match] | match |
+| Patterns.cs:61:13:61:13 | _ | Patterns.cs:61:13:61:13 | After _ [match] | match |
+| Patterns.cs:61:13:61:24 | ... => ... | Patterns.cs:61:13:61:13 | _ |  |
+| Patterns.cs:61:13:61:24 | After ... => ... [match] | Patterns.cs:61:18:61:24 | "other" |  |
 | Patterns.cs:61:18:61:24 | "other" | Patterns.cs:58:16:62:9 | After ... switch { ... } |  |
 | Patterns.cs:65:26:65:27 | Entry | Patterns.cs:66:5:72:5 | {...} |  |
 | Patterns.cs:65:26:65:27 | Normal Exit | Patterns.cs:65:26:65:27 | Exit |  |
@@ -5902,19 +5914,22 @@
 | Patterns.cs:67:16:67:16 | 2 | Patterns.cs:69:13:69:33 | ... => ... |  |
 | Patterns.cs:67:16:71:9 | ... switch { ... } | Patterns.cs:67:16:67:16 | 2 |  |
 | Patterns.cs:67:16:71:9 | After ... switch { ... } | Patterns.cs:67:9:71:10 | return ...; |  |
-| Patterns.cs:69:13:69:17 | After not ... | Patterns.cs:69:22:69:33 | "impossible" |  |
+| Patterns.cs:69:13:69:17 | After not ... [match] | Patterns.cs:69:13:69:33 | After ... => ... [match] | match |
+| Patterns.cs:69:13:69:17 | After not ... [no-match] | Patterns.cs:69:13:69:33 | After ... => ... [no-match] | no-match |
 | Patterns.cs:69:13:69:17 | Before not ... | Patterns.cs:69:17:69:17 | 2 |  |
-| Patterns.cs:69:13:69:17 | not ... | Patterns.cs:69:13:69:17 | After not ... |  |
-| Patterns.cs:69:13:69:33 | ... => ... | Patterns.cs:69:13:69:33 | After ... => ... [match] | match |
-| Patterns.cs:69:13:69:33 | ... => ... | Patterns.cs:69:13:69:33 | After ... => ... [no-match] | no-match |
-| Patterns.cs:69:13:69:33 | After ... => ... [match] | Patterns.cs:69:13:69:17 | Before not ... |  |
+| Patterns.cs:69:13:69:17 | not ... | Patterns.cs:69:13:69:17 | After not ... [match] | match |
+| Patterns.cs:69:13:69:17 | not ... | Patterns.cs:69:13:69:17 | After not ... [no-match] | no-match |
+| Patterns.cs:69:13:69:33 | ... => ... | Patterns.cs:69:13:69:17 | Before not ... |  |
+| Patterns.cs:69:13:69:33 | After ... => ... [match] | Patterns.cs:69:22:69:33 | "impossible" |  |
 | Patterns.cs:69:13:69:33 | After ... => ... [no-match] | Patterns.cs:70:13:70:27 | ... => ... |  |
 | Patterns.cs:69:17:69:17 | 2 | Patterns.cs:69:13:69:17 | not ... |  |
 | Patterns.cs:69:22:69:33 | "impossible" | Patterns.cs:67:16:71:9 | After ... switch { ... } |  |
-| Patterns.cs:70:13:70:13 | 2 | Patterns.cs:70:18:70:27 | "possible" |  |
-| Patterns.cs:70:13:70:27 | ... => ... | Patterns.cs:70:13:70:27 | After ... => ... [match] | match |
-| Patterns.cs:70:13:70:27 | ... => ... | Patterns.cs:70:13:70:27 | After ... => ... [no-match] | no-match |
-| Patterns.cs:70:13:70:27 | After ... => ... [match] | Patterns.cs:70:13:70:13 | 2 |  |
+| Patterns.cs:70:13:70:13 | 2 | Patterns.cs:70:13:70:13 | After 2 [match] | match |
+| Patterns.cs:70:13:70:13 | 2 | Patterns.cs:70:13:70:13 | After 2 [no-match] | no-match |
+| Patterns.cs:70:13:70:13 | After 2 [match] | Patterns.cs:70:13:70:27 | After ... => ... [match] | match |
+| Patterns.cs:70:13:70:13 | After 2 [no-match] | Patterns.cs:70:13:70:27 | After ... => ... [no-match] | no-match |
+| Patterns.cs:70:13:70:27 | ... => ... | Patterns.cs:70:13:70:13 | 2 |  |
+| Patterns.cs:70:13:70:27 | After ... => ... [match] | Patterns.cs:70:18:70:27 | "possible" |  |
 | Patterns.cs:70:13:70:27 | After ... => ... [no-match] | Patterns.cs:67:16:71:9 | After ... switch { ... } |  |
 | Patterns.cs:70:18:70:27 | "possible" | Patterns.cs:67:16:71:9 | After ... switch { ... } |  |
 | Patterns.cs:74:26:74:27 | Entry | Patterns.cs:74:33:74:33 | i |  |
@@ -5926,33 +5941,38 @@
 | Patterns.cs:76:16:76:16 | access to parameter i | Patterns.cs:78:13:78:24 | ... => ... |  |
 | Patterns.cs:76:16:82:9 | ... switch { ... } | Patterns.cs:76:16:76:16 | access to parameter i |  |
 | Patterns.cs:76:16:82:9 | After ... switch { ... } | Patterns.cs:76:9:82:10 | return ...; |  |
-| Patterns.cs:78:13:78:15 | > ... | Patterns.cs:78:13:78:15 | After > ... |  |
-| Patterns.cs:78:13:78:15 | After > ... | Patterns.cs:78:20:78:24 | "> 1" |  |
+| Patterns.cs:78:13:78:15 | > ... | Patterns.cs:78:13:78:15 | After > ... [match] | match |
+| Patterns.cs:78:13:78:15 | > ... | Patterns.cs:78:13:78:15 | After > ... [no-match] | no-match |
+| Patterns.cs:78:13:78:15 | After > ... [match] | Patterns.cs:78:13:78:24 | After ... => ... [match] | match |
+| Patterns.cs:78:13:78:15 | After > ... [no-match] | Patterns.cs:78:13:78:24 | After ... => ... [no-match] | no-match |
 | Patterns.cs:78:13:78:15 | Before > ... | Patterns.cs:78:15:78:15 | 1 |  |
-| Patterns.cs:78:13:78:24 | ... => ... | Patterns.cs:78:13:78:24 | After ... => ... [match] | match |
-| Patterns.cs:78:13:78:24 | ... => ... | Patterns.cs:78:13:78:24 | After ... => ... [no-match] | no-match |
-| Patterns.cs:78:13:78:24 | After ... => ... [match] | Patterns.cs:78:13:78:15 | Before > ... |  |
+| Patterns.cs:78:13:78:24 | ... => ... | Patterns.cs:78:13:78:15 | Before > ... |  |
+| Patterns.cs:78:13:78:24 | After ... => ... [match] | Patterns.cs:78:20:78:24 | "> 1" |  |
 | Patterns.cs:78:13:78:24 | After ... => ... [no-match] | Patterns.cs:79:13:79:24 | ... => ... |  |
 | Patterns.cs:78:15:78:15 | 1 | Patterns.cs:78:13:78:15 | > ... |  |
 | Patterns.cs:78:20:78:24 | "> 1" | Patterns.cs:76:16:82:9 | After ... switch { ... } |  |
-| Patterns.cs:79:13:79:15 | < ... | Patterns.cs:79:13:79:15 | After < ... |  |
-| Patterns.cs:79:13:79:15 | After < ... | Patterns.cs:79:20:79:24 | "< 0" |  |
+| Patterns.cs:79:13:79:15 | < ... | Patterns.cs:79:13:79:15 | After < ... [match] | match |
+| Patterns.cs:79:13:79:15 | < ... | Patterns.cs:79:13:79:15 | After < ... [no-match] | no-match |
+| Patterns.cs:79:13:79:15 | After < ... [match] | Patterns.cs:79:13:79:24 | After ... => ... [match] | match |
+| Patterns.cs:79:13:79:15 | After < ... [no-match] | Patterns.cs:79:13:79:24 | After ... => ... [no-match] | no-match |
 | Patterns.cs:79:13:79:15 | Before < ... | Patterns.cs:79:15:79:15 | 0 |  |
-| Patterns.cs:79:13:79:24 | ... => ... | Patterns.cs:79:13:79:24 | After ... => ... [match] | match |
-| Patterns.cs:79:13:79:24 | ... => ... | Patterns.cs:79:13:79:24 | After ... => ... [no-match] | no-match |
-| Patterns.cs:79:13:79:24 | After ... => ... [match] | Patterns.cs:79:13:79:15 | Before < ... |  |
+| Patterns.cs:79:13:79:24 | ... => ... | Patterns.cs:79:13:79:15 | Before < ... |  |
+| Patterns.cs:79:13:79:24 | After ... => ... [match] | Patterns.cs:79:20:79:24 | "< 0" |  |
 | Patterns.cs:79:13:79:24 | After ... => ... [no-match] | Patterns.cs:80:13:80:20 | ... => ... |  |
 | Patterns.cs:79:15:79:15 | 0 | Patterns.cs:79:13:79:15 | < ... |  |
 | Patterns.cs:79:20:79:24 | "< 0" | Patterns.cs:76:16:82:9 | After ... switch { ... } |  |
-| Patterns.cs:80:13:80:13 | 1 | Patterns.cs:80:18:80:20 | "1" |  |
-| Patterns.cs:80:13:80:20 | ... => ... | Patterns.cs:80:13:80:20 | After ... => ... [match] | match |
-| Patterns.cs:80:13:80:20 | ... => ... | Patterns.cs:80:13:80:20 | After ... => ... [no-match] | no-match |
-| Patterns.cs:80:13:80:20 | After ... => ... [match] | Patterns.cs:80:13:80:13 | 1 |  |
+| Patterns.cs:80:13:80:13 | 1 | Patterns.cs:80:13:80:13 | After 1 [match] | match |
+| Patterns.cs:80:13:80:13 | 1 | Patterns.cs:80:13:80:13 | After 1 [no-match] | no-match |
+| Patterns.cs:80:13:80:13 | After 1 [match] | Patterns.cs:80:13:80:20 | After ... => ... [match] | match |
+| Patterns.cs:80:13:80:13 | After 1 [no-match] | Patterns.cs:80:13:80:20 | After ... => ... [no-match] | no-match |
+| Patterns.cs:80:13:80:20 | ... => ... | Patterns.cs:80:13:80:13 | 1 |  |
+| Patterns.cs:80:13:80:20 | After ... => ... [match] | Patterns.cs:80:18:80:20 | "1" |  |
 | Patterns.cs:80:13:80:20 | After ... => ... [no-match] | Patterns.cs:81:13:81:20 | ... => ... |  |
 | Patterns.cs:80:18:80:20 | "1" | Patterns.cs:76:16:82:9 | After ... switch { ... } |  |
-| Patterns.cs:81:13:81:13 | _ | Patterns.cs:81:18:81:20 | "0" |  |
-| Patterns.cs:81:13:81:20 | ... => ... | Patterns.cs:81:13:81:20 | After ... => ... [match] | match |
-| Patterns.cs:81:13:81:20 | After ... => ... [match] | Patterns.cs:81:13:81:13 | _ |  |
+| Patterns.cs:81:13:81:13 | After _ [match] | Patterns.cs:81:13:81:20 | After ... => ... [match] | match |
+| Patterns.cs:81:13:81:13 | _ | Patterns.cs:81:13:81:13 | After _ [match] | match |
+| Patterns.cs:81:13:81:20 | ... => ... | Patterns.cs:81:13:81:13 | _ |  |
+| Patterns.cs:81:13:81:20 | After ... => ... [match] | Patterns.cs:81:18:81:20 | "0" |  |
 | Patterns.cs:81:18:81:20 | "0" | Patterns.cs:76:16:82:9 | After ... switch { ... } |  |
 | Patterns.cs:85:26:85:27 | Entry | Patterns.cs:85:33:85:33 | i |  |
 | Patterns.cs:85:26:85:27 | Normal Exit | Patterns.cs:85:26:85:27 | Exit |  |
@@ -6291,35 +6311,43 @@
 | Switch.cs:11:5:33:5 | {...} | Switch.cs:12:9:32:9 | switch (...) {...} |  |
 | Switch.cs:12:9:32:9 | switch (...) {...} | Switch.cs:12:17:12:17 | access to parameter o |  |
 | Switch.cs:12:17:12:17 | access to parameter o | Switch.cs:14:13:14:21 | case ...: |  |
-| Switch.cs:14:13:14:21 | After case ...: [match] | Switch.cs:14:18:14:20 | "a" |  |
+| Switch.cs:14:13:14:21 | After case ...: [match] | Switch.cs:15:17:15:23 | Before return ...; |  |
 | Switch.cs:14:13:14:21 | After case ...: [no-match] | Switch.cs:16:13:16:19 | case ...: |  |
-| Switch.cs:14:13:14:21 | case ...: | Switch.cs:14:13:14:21 | After case ...: [match] | match |
-| Switch.cs:14:13:14:21 | case ...: | Switch.cs:14:13:14:21 | After case ...: [no-match] | no-match |
-| Switch.cs:14:18:14:20 | "a" | Switch.cs:15:17:15:23 | Before return ...; |  |
+| Switch.cs:14:13:14:21 | case ...: | Switch.cs:14:18:14:20 | "a" |  |
+| Switch.cs:14:18:14:20 | "a" | Switch.cs:14:18:14:20 | After "a" [match] | match |
+| Switch.cs:14:18:14:20 | "a" | Switch.cs:14:18:14:20 | After "a" [no-match] | no-match |
+| Switch.cs:14:18:14:20 | After "a" [match] | Switch.cs:14:13:14:21 | After case ...: [match] | match |
+| Switch.cs:14:18:14:20 | After "a" [no-match] | Switch.cs:14:13:14:21 | After case ...: [no-match] | no-match |
 | Switch.cs:15:17:15:23 | Before return ...; | Switch.cs:15:17:15:23 | return ...; |  |
 | Switch.cs:15:17:15:23 | return ...; | Switch.cs:10:10:10:11 | Normal Exit | return |
-| Switch.cs:16:13:16:19 | After case ...: [match] | Switch.cs:16:18:16:18 | 0 |  |
+| Switch.cs:16:13:16:19 | After case ...: [match] | Switch.cs:17:17:17:38 | Before throw ...; |  |
 | Switch.cs:16:13:16:19 | After case ...: [no-match] | Switch.cs:18:13:18:22 | case ...: |  |
-| Switch.cs:16:13:16:19 | case ...: | Switch.cs:16:13:16:19 | After case ...: [match] | match |
-| Switch.cs:16:13:16:19 | case ...: | Switch.cs:16:13:16:19 | After case ...: [no-match] | no-match |
-| Switch.cs:16:18:16:18 | 0 | Switch.cs:17:17:17:38 | Before throw ...; |  |
+| Switch.cs:16:13:16:19 | case ...: | Switch.cs:16:18:16:18 | 0 |  |
+| Switch.cs:16:18:16:18 | 0 | Switch.cs:16:18:16:18 | After 0 [match] | match |
+| Switch.cs:16:18:16:18 | 0 | Switch.cs:16:18:16:18 | After 0 [no-match] | no-match |
+| Switch.cs:16:18:16:18 | After 0 [match] | Switch.cs:16:13:16:19 | After case ...: [match] | match |
+| Switch.cs:16:18:16:18 | After 0 [no-match] | Switch.cs:16:13:16:19 | After case ...: [no-match] | no-match |
 | Switch.cs:17:17:17:38 | Before throw ...; | Switch.cs:17:23:17:37 | Before object creation of type Exception |  |
 | Switch.cs:17:17:17:38 | throw ...; | Switch.cs:10:10:10:11 | Exceptional Exit | exception |
 | Switch.cs:17:23:17:37 | After object creation of type Exception | Switch.cs:17:17:17:38 | throw ...; |  |
 | Switch.cs:17:23:17:37 | Before object creation of type Exception | Switch.cs:17:23:17:37 | object creation of type Exception |  |
 | Switch.cs:17:23:17:37 | object creation of type Exception | Switch.cs:17:23:17:37 | After object creation of type Exception |  |
-| Switch.cs:18:13:18:22 | After case ...: [match] | Switch.cs:18:18:18:21 | null |  |
+| Switch.cs:18:13:18:22 | After case ...: [match] | Switch.cs:19:17:19:29 | Before goto default; |  |
 | Switch.cs:18:13:18:22 | After case ...: [no-match] | Switch.cs:20:13:20:23 | case ...: |  |
-| Switch.cs:18:13:18:22 | case ...: | Switch.cs:18:13:18:22 | After case ...: [match] | match |
-| Switch.cs:18:13:18:22 | case ...: | Switch.cs:18:13:18:22 | After case ...: [no-match] | no-match |
-| Switch.cs:18:18:18:21 | null | Switch.cs:19:17:19:29 | Before goto default; |  |
+| Switch.cs:18:13:18:22 | case ...: | Switch.cs:18:18:18:21 | null |  |
+| Switch.cs:18:18:18:21 | After null [match] | Switch.cs:18:13:18:22 | After case ...: [match] | match |
+| Switch.cs:18:18:18:21 | After null [no-match] | Switch.cs:18:13:18:22 | After case ...: [no-match] | no-match |
+| Switch.cs:18:18:18:21 | null | Switch.cs:18:18:18:21 | After null [match] | match |
+| Switch.cs:18:18:18:21 | null | Switch.cs:18:18:18:21 | After null [no-match] | no-match |
 | Switch.cs:19:17:19:29 | Before goto default; | Switch.cs:19:17:19:29 | goto default; |  |
 | Switch.cs:19:17:19:29 | goto default; | Switch.cs:30:13:30:20 | After default: [match] | goto |
-| Switch.cs:20:13:20:23 | After case ...: [match] | Switch.cs:20:18:20:22 | Int32 i |  |
+| Switch.cs:20:13:20:23 | After case ...: [match] | Switch.cs:21:17:22:27 | if (...) ... |  |
 | Switch.cs:20:13:20:23 | After case ...: [no-match] | Switch.cs:24:13:24:56 | case ...: |  |
-| Switch.cs:20:13:20:23 | case ...: | Switch.cs:20:13:20:23 | After case ...: [match] | match |
-| Switch.cs:20:13:20:23 | case ...: | Switch.cs:20:13:20:23 | After case ...: [no-match] | no-match |
-| Switch.cs:20:18:20:22 | Int32 i | Switch.cs:21:17:22:27 | if (...) ... |  |
+| Switch.cs:20:13:20:23 | case ...: | Switch.cs:20:18:20:22 | Int32 i |  |
+| Switch.cs:20:18:20:22 | After Int32 i [match] | Switch.cs:20:13:20:23 | After case ...: [match] | match |
+| Switch.cs:20:18:20:22 | After Int32 i [no-match] | Switch.cs:20:13:20:23 | After case ...: [no-match] | no-match |
+| Switch.cs:20:18:20:22 | Int32 i | Switch.cs:20:18:20:22 | After Int32 i [match] | match |
+| Switch.cs:20:18:20:22 | Int32 i | Switch.cs:20:18:20:22 | After Int32 i [no-match] | no-match |
 | Switch.cs:21:17:22:27 | After if (...) ... | Switch.cs:23:17:23:28 | Before goto case ...; |  |
 | Switch.cs:21:17:22:27 | if (...) ... | Switch.cs:21:21:21:29 | Before ... == ... |  |
 | Switch.cs:21:21:21:21 | access to parameter o | Switch.cs:21:26:21:29 | null |  |
@@ -6334,11 +6362,13 @@
 | Switch.cs:23:17:23:28 | Before goto case ...; | Switch.cs:23:27:23:27 | 0 |  |
 | Switch.cs:23:17:23:28 | goto case ...; | Switch.cs:16:13:16:19 | After case ...: [match] | goto |
 | Switch.cs:23:27:23:27 | 0 | Switch.cs:23:17:23:28 | goto case ...; |  |
-| Switch.cs:24:13:24:56 | After case ...: [match] | Switch.cs:24:18:24:25 | String s |  |
+| Switch.cs:24:13:24:56 | After case ...: [match] | Switch.cs:24:32:24:55 | ... && ... |  |
 | Switch.cs:24:13:24:56 | After case ...: [no-match] | Switch.cs:27:13:27:39 | case ...: |  |
-| Switch.cs:24:13:24:56 | case ...: | Switch.cs:24:13:24:56 | After case ...: [match] | match |
-| Switch.cs:24:13:24:56 | case ...: | Switch.cs:24:13:24:56 | After case ...: [no-match] | no-match |
-| Switch.cs:24:18:24:25 | String s | Switch.cs:24:32:24:55 | ... && ... |  |
+| Switch.cs:24:13:24:56 | case ...: | Switch.cs:24:18:24:25 | String s |  |
+| Switch.cs:24:18:24:25 | After String s [match] | Switch.cs:24:13:24:56 | After case ...: [match] | match |
+| Switch.cs:24:18:24:25 | After String s [no-match] | Switch.cs:24:13:24:56 | After case ...: [no-match] | no-match |
+| Switch.cs:24:18:24:25 | String s | Switch.cs:24:18:24:25 | After String s [match] | match |
+| Switch.cs:24:18:24:25 | String s | Switch.cs:24:18:24:25 | After String s [no-match] | no-match |
 | Switch.cs:24:32:24:32 | access to local variable s | Switch.cs:24:32:24:39 | access to property Length |  |
 | Switch.cs:24:32:24:39 | After access to property Length | Switch.cs:24:43:24:43 | 0 |  |
 | Switch.cs:24:32:24:39 | Before access to property Length | Switch.cs:24:32:24:32 | access to local variable s |  |
@@ -6367,11 +6397,13 @@
 | Switch.cs:25:35:25:35 | access to local variable s | Switch.cs:25:17:25:36 | call to method WriteLine |  |
 | Switch.cs:26:17:26:23 | Before return ...; | Switch.cs:26:17:26:23 | return ...; |  |
 | Switch.cs:26:17:26:23 | return ...; | Switch.cs:10:10:10:11 | Normal Exit | return |
-| Switch.cs:27:13:27:39 | After case ...: [match] | Switch.cs:27:18:27:25 | Double d |  |
+| Switch.cs:27:13:27:39 | After case ...: [match] | Switch.cs:27:32:27:38 | Before call to method Throw |  |
 | Switch.cs:27:13:27:39 | After case ...: [no-match] | Switch.cs:30:13:30:20 | default: |  |
-| Switch.cs:27:13:27:39 | case ...: | Switch.cs:27:13:27:39 | After case ...: [match] | match |
-| Switch.cs:27:13:27:39 | case ...: | Switch.cs:27:13:27:39 | After case ...: [no-match] | no-match |
-| Switch.cs:27:18:27:25 | Double d | Switch.cs:27:32:27:38 | Before call to method Throw |  |
+| Switch.cs:27:13:27:39 | case ...: | Switch.cs:27:18:27:25 | Double d |  |
+| Switch.cs:27:18:27:25 | After Double d [match] | Switch.cs:27:13:27:39 | After case ...: [match] | match |
+| Switch.cs:27:18:27:25 | After Double d [no-match] | Switch.cs:27:13:27:39 | After case ...: [no-match] | no-match |
+| Switch.cs:27:18:27:25 | Double d | Switch.cs:27:18:27:25 | After Double d [match] | match |
+| Switch.cs:27:18:27:25 | Double d | Switch.cs:27:18:27:25 | After Double d [no-match] | no-match |
 | Switch.cs:27:32:27:38 | Before call to method Throw | Switch.cs:27:32:27:38 | call to method Throw |  |
 | Switch.cs:27:32:27:38 | call to method Throw | Switch.cs:10:10:10:11 | Exceptional Exit | exception |
 | Switch.cs:28:13:28:17 | Label: | Switch.cs:29:17:29:23 | Before return ...; |  |
@@ -6395,18 +6427,22 @@
 | Switch.cs:46:9:52:9 | After switch (...) {...} | Switch.cs:45:5:53:5 | After {...} |  |
 | Switch.cs:46:9:52:9 | switch (...) {...} | Switch.cs:46:17:46:17 | access to parameter o |  |
 | Switch.cs:46:17:46:17 | access to parameter o | Switch.cs:48:13:48:23 | case ...: |  |
-| Switch.cs:48:13:48:23 | After case ...: [match] | Switch.cs:48:18:48:20 | access to type Int32 |  |
+| Switch.cs:48:13:48:23 | After case ...: [match] | Switch.cs:49:17:49:22 | Before break; |  |
 | Switch.cs:48:13:48:23 | After case ...: [no-match] | Switch.cs:50:13:50:39 | case ...: |  |
-| Switch.cs:48:13:48:23 | case ...: | Switch.cs:48:13:48:23 | After case ...: [match] | match |
-| Switch.cs:48:13:48:23 | case ...: | Switch.cs:48:13:48:23 | After case ...: [no-match] | no-match |
-| Switch.cs:48:18:48:20 | access to type Int32 | Switch.cs:49:17:49:22 | Before break; |  |
+| Switch.cs:48:13:48:23 | case ...: | Switch.cs:48:18:48:20 | access to type Int32 |  |
+| Switch.cs:48:18:48:20 | After access to type Int32 [match] | Switch.cs:48:13:48:23 | After case ...: [match] | match |
+| Switch.cs:48:18:48:20 | After access to type Int32 [no-match] | Switch.cs:48:13:48:23 | After case ...: [no-match] | no-match |
+| Switch.cs:48:18:48:20 | access to type Int32 | Switch.cs:48:18:48:20 | After access to type Int32 [match] | match |
+| Switch.cs:48:18:48:20 | access to type Int32 | Switch.cs:48:18:48:20 | After access to type Int32 [no-match] | no-match |
 | Switch.cs:49:17:49:22 | Before break; | Switch.cs:49:17:49:22 | break; |  |
 | Switch.cs:49:17:49:22 | break; | Switch.cs:46:9:52:9 | After switch (...) {...} | break |
-| Switch.cs:50:13:50:39 | After case ...: [match] | Switch.cs:50:18:50:21 | access to type Boolean |  |
+| Switch.cs:50:13:50:39 | After case ...: [match] | Switch.cs:50:30:50:38 | Before ... != ... |  |
 | Switch.cs:50:13:50:39 | After case ...: [no-match] | Switch.cs:46:9:52:9 | After switch (...) {...} |  |
-| Switch.cs:50:13:50:39 | case ...: | Switch.cs:50:13:50:39 | After case ...: [match] | match |
-| Switch.cs:50:13:50:39 | case ...: | Switch.cs:50:13:50:39 | After case ...: [no-match] | no-match |
-| Switch.cs:50:18:50:21 | access to type Boolean | Switch.cs:50:30:50:38 | Before ... != ... |  |
+| Switch.cs:50:13:50:39 | case ...: | Switch.cs:50:18:50:21 | access to type Boolean |  |
+| Switch.cs:50:18:50:21 | After access to type Boolean [match] | Switch.cs:50:13:50:39 | After case ...: [match] | match |
+| Switch.cs:50:18:50:21 | After access to type Boolean [no-match] | Switch.cs:50:13:50:39 | After case ...: [no-match] | no-match |
+| Switch.cs:50:18:50:21 | access to type Boolean | Switch.cs:50:18:50:21 | After access to type Boolean [match] | match |
+| Switch.cs:50:18:50:21 | access to type Boolean | Switch.cs:50:18:50:21 | After access to type Boolean [no-match] | no-match |
 | Switch.cs:50:30:50:30 | access to parameter o | Switch.cs:50:35:50:38 | null |  |
 | Switch.cs:50:30:50:38 | ... != ... | Switch.cs:50:30:50:38 | After ... != ... [false] | false |
 | Switch.cs:50:30:50:38 | ... != ... | Switch.cs:50:30:50:38 | After ... != ... [true] | true |
@@ -6427,18 +6463,22 @@
 | Switch.cs:57:17:57:21 | After ... + ... | Switch.cs:59:13:59:19 | case ...: |  |
 | Switch.cs:57:17:57:21 | Before ... + ... | Switch.cs:57:17:57:17 | 1 |  |
 | Switch.cs:57:21:57:21 | 2 | Switch.cs:57:17:57:21 | ... + ... |  |
-| Switch.cs:59:13:59:19 | After case ...: [match] | Switch.cs:59:18:59:18 | 2 |  |
+| Switch.cs:59:13:59:19 | After case ...: [match] | Switch.cs:60:17:60:22 | Before break; |  |
 | Switch.cs:59:13:59:19 | After case ...: [no-match] | Switch.cs:61:13:61:19 | case ...: |  |
-| Switch.cs:59:13:59:19 | case ...: | Switch.cs:59:13:59:19 | After case ...: [match] | match |
-| Switch.cs:59:13:59:19 | case ...: | Switch.cs:59:13:59:19 | After case ...: [no-match] | no-match |
-| Switch.cs:59:18:59:18 | 2 | Switch.cs:60:17:60:22 | Before break; |  |
+| Switch.cs:59:13:59:19 | case ...: | Switch.cs:59:18:59:18 | 2 |  |
+| Switch.cs:59:18:59:18 | 2 | Switch.cs:59:18:59:18 | After 2 [match] | match |
+| Switch.cs:59:18:59:18 | 2 | Switch.cs:59:18:59:18 | After 2 [no-match] | no-match |
+| Switch.cs:59:18:59:18 | After 2 [match] | Switch.cs:59:13:59:19 | After case ...: [match] | match |
+| Switch.cs:59:18:59:18 | After 2 [no-match] | Switch.cs:59:13:59:19 | After case ...: [no-match] | no-match |
 | Switch.cs:60:17:60:22 | Before break; | Switch.cs:60:17:60:22 | break; |  |
 | Switch.cs:60:17:60:22 | break; | Switch.cs:57:9:63:9 | After switch (...) {...} | break |
-| Switch.cs:61:13:61:19 | After case ...: [match] | Switch.cs:61:18:61:18 | 3 |  |
+| Switch.cs:61:13:61:19 | After case ...: [match] | Switch.cs:62:17:62:22 | Before break; |  |
 | Switch.cs:61:13:61:19 | After case ...: [no-match] | Switch.cs:57:9:63:9 | After switch (...) {...} |  |
-| Switch.cs:61:13:61:19 | case ...: | Switch.cs:61:13:61:19 | After case ...: [match] | match |
-| Switch.cs:61:13:61:19 | case ...: | Switch.cs:61:13:61:19 | After case ...: [no-match] | no-match |
-| Switch.cs:61:18:61:18 | 3 | Switch.cs:62:17:62:22 | Before break; |  |
+| Switch.cs:61:13:61:19 | case ...: | Switch.cs:61:18:61:18 | 3 |  |
+| Switch.cs:61:18:61:18 | 3 | Switch.cs:61:18:61:18 | After 3 [match] | match |
+| Switch.cs:61:18:61:18 | 3 | Switch.cs:61:18:61:18 | After 3 [no-match] | no-match |
+| Switch.cs:61:18:61:18 | After 3 [match] | Switch.cs:61:13:61:19 | After case ...: [match] | match |
+| Switch.cs:61:18:61:18 | After 3 [no-match] | Switch.cs:61:13:61:19 | After case ...: [no-match] | no-match |
 | Switch.cs:62:17:62:22 | Before break; | Switch.cs:62:17:62:22 | break; |  |
 | Switch.cs:62:17:62:22 | break; | Switch.cs:57:9:63:9 | After switch (...) {...} | break |
 | Switch.cs:66:10:66:11 | Entry | Switch.cs:66:20:66:20 | s |  |
@@ -6452,18 +6492,22 @@
 | Switch.cs:68:17:68:25 | After (...) ... | Switch.cs:70:13:70:23 | case ...: |  |
 | Switch.cs:68:17:68:25 | Before (...) ... | Switch.cs:68:25:68:25 | access to parameter s |  |
 | Switch.cs:68:25:68:25 | access to parameter s | Switch.cs:68:17:68:25 | (...) ... |  |
-| Switch.cs:70:13:70:23 | After case ...: [match] | Switch.cs:70:18:70:20 | access to type Int32 |  |
+| Switch.cs:70:13:70:23 | After case ...: [match] | Switch.cs:71:17:71:22 | Before break; |  |
 | Switch.cs:70:13:70:23 | After case ...: [no-match] | Switch.cs:72:13:72:20 | case ...: |  |
-| Switch.cs:70:13:70:23 | case ...: | Switch.cs:70:13:70:23 | After case ...: [match] | match |
-| Switch.cs:70:13:70:23 | case ...: | Switch.cs:70:13:70:23 | After case ...: [no-match] | no-match |
-| Switch.cs:70:18:70:20 | access to type Int32 | Switch.cs:71:17:71:22 | Before break; |  |
+| Switch.cs:70:13:70:23 | case ...: | Switch.cs:70:18:70:20 | access to type Int32 |  |
+| Switch.cs:70:18:70:20 | After access to type Int32 [match] | Switch.cs:70:13:70:23 | After case ...: [match] | match |
+| Switch.cs:70:18:70:20 | After access to type Int32 [no-match] | Switch.cs:70:13:70:23 | After case ...: [no-match] | no-match |
+| Switch.cs:70:18:70:20 | access to type Int32 | Switch.cs:70:18:70:20 | After access to type Int32 [match] | match |
+| Switch.cs:70:18:70:20 | access to type Int32 | Switch.cs:70:18:70:20 | After access to type Int32 [no-match] | no-match |
 | Switch.cs:71:17:71:22 | Before break; | Switch.cs:71:17:71:22 | break; |  |
 | Switch.cs:71:17:71:22 | break; | Switch.cs:68:9:74:9 | After switch (...) {...} | break |
-| Switch.cs:72:13:72:20 | After case ...: [match] | Switch.cs:72:18:72:19 | "" |  |
+| Switch.cs:72:13:72:20 | After case ...: [match] | Switch.cs:73:17:73:22 | Before break; |  |
 | Switch.cs:72:13:72:20 | After case ...: [no-match] | Switch.cs:68:9:74:9 | After switch (...) {...} |  |
-| Switch.cs:72:13:72:20 | case ...: | Switch.cs:72:13:72:20 | After case ...: [match] | match |
-| Switch.cs:72:13:72:20 | case ...: | Switch.cs:72:13:72:20 | After case ...: [no-match] | no-match |
-| Switch.cs:72:18:72:19 | "" | Switch.cs:73:17:73:22 | Before break; |  |
+| Switch.cs:72:13:72:20 | case ...: | Switch.cs:72:18:72:19 | "" |  |
+| Switch.cs:72:18:72:19 | "" | Switch.cs:72:18:72:19 | After "" [match] | match |
+| Switch.cs:72:18:72:19 | "" | Switch.cs:72:18:72:19 | After "" [no-match] | no-match |
+| Switch.cs:72:18:72:19 | After "" [match] | Switch.cs:72:13:72:20 | After case ...: [match] | match |
+| Switch.cs:72:18:72:19 | After "" [no-match] | Switch.cs:72:13:72:20 | After case ...: [no-match] | no-match |
 | Switch.cs:73:17:73:22 | Before break; | Switch.cs:73:17:73:22 | break; |  |
 | Switch.cs:73:17:73:22 | break; | Switch.cs:68:9:74:9 | After switch (...) {...} | break |
 | Switch.cs:77:10:77:11 | Entry | Switch.cs:77:17:77:17 | i |  |
@@ -6474,19 +6518,23 @@
 | Switch.cs:79:9:87:9 | After switch (...) {...} | Switch.cs:88:9:88:21 | Before return ...; |  |
 | Switch.cs:79:9:87:9 | switch (...) {...} | Switch.cs:79:17:79:17 | access to parameter i |  |
 | Switch.cs:79:17:79:17 | access to parameter i | Switch.cs:81:13:81:19 | case ...: |  |
-| Switch.cs:81:13:81:19 | After case ...: [match] | Switch.cs:81:18:81:18 | 1 |  |
+| Switch.cs:81:13:81:19 | After case ...: [match] | Switch.cs:82:17:82:28 | Before return ...; |  |
 | Switch.cs:81:13:81:19 | After case ...: [no-match] | Switch.cs:83:13:83:19 | case ...: |  |
-| Switch.cs:81:13:81:19 | case ...: | Switch.cs:81:13:81:19 | After case ...: [match] | match |
-| Switch.cs:81:13:81:19 | case ...: | Switch.cs:81:13:81:19 | After case ...: [no-match] | no-match |
-| Switch.cs:81:18:81:18 | 1 | Switch.cs:82:17:82:28 | Before return ...; |  |
+| Switch.cs:81:13:81:19 | case ...: | Switch.cs:81:18:81:18 | 1 |  |
+| Switch.cs:81:18:81:18 | 1 | Switch.cs:81:18:81:18 | After 1 [match] | match |
+| Switch.cs:81:18:81:18 | 1 | Switch.cs:81:18:81:18 | After 1 [no-match] | no-match |
+| Switch.cs:81:18:81:18 | After 1 [match] | Switch.cs:81:13:81:19 | After case ...: [match] | match |
+| Switch.cs:81:18:81:18 | After 1 [no-match] | Switch.cs:81:13:81:19 | After case ...: [no-match] | no-match |
 | Switch.cs:82:17:82:28 | Before return ...; | Switch.cs:82:24:82:27 | true |  |
 | Switch.cs:82:17:82:28 | return ...; | Switch.cs:77:10:77:11 | Normal Exit | return |
 | Switch.cs:82:24:82:27 | true | Switch.cs:82:17:82:28 | return ...; |  |
-| Switch.cs:83:13:83:19 | After case ...: [match] | Switch.cs:83:18:83:18 | 2 |  |
+| Switch.cs:83:13:83:19 | After case ...: [match] | Switch.cs:84:17:85:26 | if (...) ... |  |
 | Switch.cs:83:13:83:19 | After case ...: [no-match] | Switch.cs:79:9:87:9 | After switch (...) {...} |  |
-| Switch.cs:83:13:83:19 | case ...: | Switch.cs:83:13:83:19 | After case ...: [match] | match |
-| Switch.cs:83:13:83:19 | case ...: | Switch.cs:83:13:83:19 | After case ...: [no-match] | no-match |
-| Switch.cs:83:18:83:18 | 2 | Switch.cs:84:17:85:26 | if (...) ... |  |
+| Switch.cs:83:13:83:19 | case ...: | Switch.cs:83:18:83:18 | 2 |  |
+| Switch.cs:83:18:83:18 | 2 | Switch.cs:83:18:83:18 | After 2 [match] | match |
+| Switch.cs:83:18:83:18 | 2 | Switch.cs:83:18:83:18 | After 2 [no-match] | no-match |
+| Switch.cs:83:18:83:18 | After 2 [match] | Switch.cs:83:13:83:19 | After case ...: [match] | match |
+| Switch.cs:83:18:83:18 | After 2 [no-match] | Switch.cs:83:13:83:19 | After case ...: [no-match] | no-match |
 | Switch.cs:84:17:85:26 | After if (...) ... | Switch.cs:86:17:86:28 | Before return ...; |  |
 | Switch.cs:84:17:85:26 | if (...) ... | Switch.cs:84:21:84:25 | Before ... > ... |  |
 | Switch.cs:84:21:84:21 | access to parameter j | Switch.cs:84:25:84:25 | 2 |  |
@@ -6511,11 +6559,13 @@
 | Switch.cs:93:9:97:9 | After switch (...) {...} | Switch.cs:98:9:98:21 | Before return ...; |  |
 | Switch.cs:93:9:97:9 | switch (...) {...} | Switch.cs:93:17:93:17 | access to parameter o |  |
 | Switch.cs:93:17:93:17 | access to parameter o | Switch.cs:95:13:95:23 | case ...: |  |
-| Switch.cs:95:13:95:23 | After case ...: [match] | Switch.cs:95:18:95:20 | access to type Int32 |  |
+| Switch.cs:95:13:95:23 | After case ...: [match] | Switch.cs:96:17:96:28 | Before return ...; |  |
 | Switch.cs:95:13:95:23 | After case ...: [no-match] | Switch.cs:93:9:97:9 | After switch (...) {...} |  |
-| Switch.cs:95:13:95:23 | case ...: | Switch.cs:95:13:95:23 | After case ...: [match] | match |
-| Switch.cs:95:13:95:23 | case ...: | Switch.cs:95:13:95:23 | After case ...: [no-match] | no-match |
-| Switch.cs:95:18:95:20 | access to type Int32 | Switch.cs:96:17:96:28 | Before return ...; |  |
+| Switch.cs:95:13:95:23 | case ...: | Switch.cs:95:18:95:20 | access to type Int32 |  |
+| Switch.cs:95:18:95:20 | After access to type Int32 [match] | Switch.cs:95:13:95:23 | After case ...: [match] | match |
+| Switch.cs:95:18:95:20 | After access to type Int32 [no-match] | Switch.cs:95:13:95:23 | After case ...: [no-match] | no-match |
+| Switch.cs:95:18:95:20 | access to type Int32 | Switch.cs:95:18:95:20 | After access to type Int32 [match] | match |
+| Switch.cs:95:18:95:20 | access to type Int32 | Switch.cs:95:18:95:20 | After access to type Int32 [no-match] | no-match |
 | Switch.cs:96:17:96:28 | Before return ...; | Switch.cs:96:24:96:27 | true |  |
 | Switch.cs:96:17:96:28 | return ...; | Switch.cs:91:10:91:11 | Normal Exit | return |
 | Switch.cs:96:24:96:27 | true | Switch.cs:96:17:96:28 | return ...; |  |
@@ -6535,19 +6585,23 @@
 | Switch.cs:103:17:103:25 | After access to property Length | Switch.cs:105:13:105:19 | case ...: |  |
 | Switch.cs:103:17:103:25 | Before access to property Length | Switch.cs:103:17:103:17 | access to parameter s |  |
 | Switch.cs:103:17:103:25 | access to property Length | Switch.cs:103:17:103:25 | After access to property Length |  |
-| Switch.cs:105:13:105:19 | After case ...: [match] | Switch.cs:105:18:105:18 | 0 |  |
+| Switch.cs:105:13:105:19 | After case ...: [match] | Switch.cs:105:21:105:29 | Before return ...; |  |
 | Switch.cs:105:13:105:19 | After case ...: [no-match] | Switch.cs:106:13:106:19 | case ...: |  |
-| Switch.cs:105:13:105:19 | case ...: | Switch.cs:105:13:105:19 | After case ...: [match] | match |
-| Switch.cs:105:13:105:19 | case ...: | Switch.cs:105:13:105:19 | After case ...: [no-match] | no-match |
-| Switch.cs:105:18:105:18 | 0 | Switch.cs:105:21:105:29 | Before return ...; |  |
+| Switch.cs:105:13:105:19 | case ...: | Switch.cs:105:18:105:18 | 0 |  |
+| Switch.cs:105:18:105:18 | 0 | Switch.cs:105:18:105:18 | After 0 [match] | match |
+| Switch.cs:105:18:105:18 | 0 | Switch.cs:105:18:105:18 | After 0 [no-match] | no-match |
+| Switch.cs:105:18:105:18 | After 0 [match] | Switch.cs:105:13:105:19 | After case ...: [match] | match |
+| Switch.cs:105:18:105:18 | After 0 [no-match] | Switch.cs:105:13:105:19 | After case ...: [no-match] | no-match |
 | Switch.cs:105:21:105:29 | Before return ...; | Switch.cs:105:28:105:28 | 0 |  |
 | Switch.cs:105:21:105:29 | return ...; | Switch.cs:101:9:101:10 | Normal Exit | return |
 | Switch.cs:105:28:105:28 | 0 | Switch.cs:105:21:105:29 | return ...; |  |
-| Switch.cs:106:13:106:19 | After case ...: [match] | Switch.cs:106:18:106:18 | 1 |  |
+| Switch.cs:106:13:106:19 | After case ...: [match] | Switch.cs:106:21:106:29 | Before return ...; |  |
 | Switch.cs:106:13:106:19 | After case ...: [no-match] | Switch.cs:103:9:107:9 | After switch (...) {...} |  |
-| Switch.cs:106:13:106:19 | case ...: | Switch.cs:106:13:106:19 | After case ...: [match] | match |
-| Switch.cs:106:13:106:19 | case ...: | Switch.cs:106:13:106:19 | After case ...: [no-match] | no-match |
-| Switch.cs:106:18:106:18 | 1 | Switch.cs:106:21:106:29 | Before return ...; |  |
+| Switch.cs:106:13:106:19 | case ...: | Switch.cs:106:18:106:18 | 1 |  |
+| Switch.cs:106:18:106:18 | 1 | Switch.cs:106:18:106:18 | After 1 [match] | match |
+| Switch.cs:106:18:106:18 | 1 | Switch.cs:106:18:106:18 | After 1 [no-match] | no-match |
+| Switch.cs:106:18:106:18 | After 1 [match] | Switch.cs:106:13:106:19 | After case ...: [match] | match |
+| Switch.cs:106:18:106:18 | After 1 [no-match] | Switch.cs:106:13:106:19 | After case ...: [no-match] | no-match |
 | Switch.cs:106:21:106:29 | Before return ...; | Switch.cs:106:28:106:28 | 1 |  |
 | Switch.cs:106:21:106:29 | return ...; | Switch.cs:101:9:101:10 | Normal Exit | return |
 | Switch.cs:106:28:106:28 | 1 | Switch.cs:106:21:106:29 | return ...; |  |
@@ -6574,11 +6628,13 @@
 | Switch.cs:115:17:115:24 | After access to property Length | Switch.cs:117:13:117:35 | case ...: |  |
 | Switch.cs:115:17:115:24 | Before access to property Length | Switch.cs:115:17:115:17 | access to parameter s |  |
 | Switch.cs:115:17:115:24 | access to property Length | Switch.cs:115:17:115:24 | After access to property Length |  |
-| Switch.cs:117:13:117:35 | After case ...: [match] | Switch.cs:117:18:117:18 | 3 |  |
+| Switch.cs:117:13:117:35 | After case ...: [match] | Switch.cs:117:25:117:34 | Before ... == ... |  |
 | Switch.cs:117:13:117:35 | After case ...: [no-match] | Switch.cs:118:13:118:34 | case ...: |  |
-| Switch.cs:117:13:117:35 | case ...: | Switch.cs:117:13:117:35 | After case ...: [match] | match |
-| Switch.cs:117:13:117:35 | case ...: | Switch.cs:117:13:117:35 | After case ...: [no-match] | no-match |
-| Switch.cs:117:18:117:18 | 3 | Switch.cs:117:25:117:34 | Before ... == ... |  |
+| Switch.cs:117:13:117:35 | case ...: | Switch.cs:117:18:117:18 | 3 |  |
+| Switch.cs:117:18:117:18 | 3 | Switch.cs:117:18:117:18 | After 3 [match] | match |
+| Switch.cs:117:18:117:18 | 3 | Switch.cs:117:18:117:18 | After 3 [no-match] | no-match |
+| Switch.cs:117:18:117:18 | After 3 [match] | Switch.cs:117:13:117:35 | After case ...: [match] | match |
+| Switch.cs:117:18:117:18 | After 3 [no-match] | Switch.cs:117:13:117:35 | After case ...: [no-match] | no-match |
 | Switch.cs:117:25:117:25 | access to parameter s | Switch.cs:117:30:117:34 | "foo" |  |
 | Switch.cs:117:25:117:34 | ... == ... | Switch.cs:117:25:117:34 | After ... == ... [false] | false |
 | Switch.cs:117:25:117:34 | ... == ... | Switch.cs:117:25:117:34 | After ... == ... [true] | true |
@@ -6589,11 +6645,13 @@
 | Switch.cs:117:37:117:45 | Before return ...; | Switch.cs:117:44:117:44 | 1 |  |
 | Switch.cs:117:37:117:45 | return ...; | Switch.cs:113:9:113:11 | Normal Exit | return |
 | Switch.cs:117:44:117:44 | 1 | Switch.cs:117:37:117:45 | return ...; |  |
-| Switch.cs:118:13:118:34 | After case ...: [match] | Switch.cs:118:18:118:18 | 2 |  |
+| Switch.cs:118:13:118:34 | After case ...: [match] | Switch.cs:118:25:118:33 | Before ... == ... |  |
 | Switch.cs:118:13:118:34 | After case ...: [no-match] | Switch.cs:115:9:119:9 | After switch (...) {...} |  |
-| Switch.cs:118:13:118:34 | case ...: | Switch.cs:118:13:118:34 | After case ...: [match] | match |
-| Switch.cs:118:13:118:34 | case ...: | Switch.cs:118:13:118:34 | After case ...: [no-match] | no-match |
-| Switch.cs:118:18:118:18 | 2 | Switch.cs:118:25:118:33 | Before ... == ... |  |
+| Switch.cs:118:13:118:34 | case ...: | Switch.cs:118:18:118:18 | 2 |  |
+| Switch.cs:118:18:118:18 | 2 | Switch.cs:118:18:118:18 | After 2 [match] | match |
+| Switch.cs:118:18:118:18 | 2 | Switch.cs:118:18:118:18 | After 2 [no-match] | no-match |
+| Switch.cs:118:18:118:18 | After 2 [match] | Switch.cs:118:13:118:34 | After case ...: [match] | match |
+| Switch.cs:118:18:118:18 | After 2 [no-match] | Switch.cs:118:13:118:34 | After case ...: [no-match] | no-match |
 | Switch.cs:118:25:118:25 | access to parameter s | Switch.cs:118:30:118:33 | "fu" |  |
 | Switch.cs:118:25:118:33 | ... == ... | Switch.cs:118:25:118:33 | After ... == ... [false] | false |
 | Switch.cs:118:25:118:33 | ... == ... | Switch.cs:118:25:118:33 | After ... == ... [true] | true |
@@ -6621,16 +6679,19 @@
 | Switch.cs:125:13:125:48 | ... switch { ... } | Switch.cs:125:13:125:13 | access to parameter o |  |
 | Switch.cs:125:13:125:48 | After ... switch { ... } [false] | Switch.cs:125:9:126:19 | After if (...) ... |  |
 | Switch.cs:125:13:125:48 | After ... switch { ... } [true] | Switch.cs:126:13:126:19 | Before return ...; |  |
-| Switch.cs:125:24:125:29 | Boolean b | Switch.cs:125:34:125:34 | access to local variable b |  |
-| Switch.cs:125:24:125:34 | ... => ... | Switch.cs:125:24:125:34 | After ... => ... [match] | match |
-| Switch.cs:125:24:125:34 | ... => ... | Switch.cs:125:24:125:34 | After ... => ... [no-match] | no-match |
-| Switch.cs:125:24:125:34 | After ... => ... [match] | Switch.cs:125:24:125:29 | Boolean b |  |
+| Switch.cs:125:24:125:29 | After Boolean b [match] | Switch.cs:125:24:125:34 | After ... => ... [match] | match |
+| Switch.cs:125:24:125:29 | After Boolean b [no-match] | Switch.cs:125:24:125:34 | After ... => ... [no-match] | no-match |
+| Switch.cs:125:24:125:29 | Boolean b | Switch.cs:125:24:125:29 | After Boolean b [match] | match |
+| Switch.cs:125:24:125:29 | Boolean b | Switch.cs:125:24:125:29 | After Boolean b [no-match] | no-match |
+| Switch.cs:125:24:125:34 | ... => ... | Switch.cs:125:24:125:29 | Boolean b |  |
+| Switch.cs:125:24:125:34 | After ... => ... [match] | Switch.cs:125:34:125:34 | access to local variable b |  |
 | Switch.cs:125:24:125:34 | After ... => ... [no-match] | Switch.cs:125:37:125:46 | ... => ... |  |
 | Switch.cs:125:34:125:34 | access to local variable b | Switch.cs:125:13:125:48 | After ... switch { ... } [false] | false |
 | Switch.cs:125:34:125:34 | access to local variable b | Switch.cs:125:13:125:48 | After ... switch { ... } [true] | true |
-| Switch.cs:125:37:125:37 | _ | Switch.cs:125:42:125:46 | false |  |
-| Switch.cs:125:37:125:46 | ... => ... | Switch.cs:125:37:125:46 | After ... => ... [match] | match |
-| Switch.cs:125:37:125:46 | After ... => ... [match] | Switch.cs:125:37:125:37 | _ |  |
+| Switch.cs:125:37:125:37 | After _ [match] | Switch.cs:125:37:125:46 | After ... => ... [match] | match |
+| Switch.cs:125:37:125:37 | _ | Switch.cs:125:37:125:37 | After _ [match] | match |
+| Switch.cs:125:37:125:46 | ... => ... | Switch.cs:125:37:125:37 | _ |  |
+| Switch.cs:125:37:125:46 | After ... => ... [match] | Switch.cs:125:42:125:46 | false |  |
 | Switch.cs:125:42:125:46 | false | Switch.cs:125:13:125:48 | After ... switch { ... } [false] | false |
 | Switch.cs:125:42:125:46 | false | Switch.cs:125:13:125:48 | After ... switch { ... } [true] | true |
 | Switch.cs:126:13:126:19 | Before return ...; | Switch.cs:126:13:126:19 | return ...; |  |
@@ -6648,16 +6709,19 @@
 | Switch.cs:131:17:131:53 | ... switch { ... } | Switch.cs:131:17:131:17 | access to parameter o |  |
 | Switch.cs:131:17:131:53 | After ... switch { ... } [non-null] | Switch.cs:131:16:131:66 | call to method ToString |  |
 | Switch.cs:131:17:131:53 | After ... switch { ... } [null] | Switch.cs:131:16:131:66 | After call to method ToString |  |
-| Switch.cs:131:28:131:35 | String s | Switch.cs:131:40:131:40 | access to local variable s |  |
-| Switch.cs:131:28:131:40 | ... => ... | Switch.cs:131:28:131:40 | After ... => ... [match] | match |
-| Switch.cs:131:28:131:40 | ... => ... | Switch.cs:131:28:131:40 | After ... => ... [no-match] | no-match |
-| Switch.cs:131:28:131:40 | After ... => ... [match] | Switch.cs:131:28:131:35 | String s |  |
+| Switch.cs:131:28:131:35 | After String s [match] | Switch.cs:131:28:131:40 | After ... => ... [match] | match |
+| Switch.cs:131:28:131:35 | After String s [no-match] | Switch.cs:131:28:131:40 | After ... => ... [no-match] | no-match |
+| Switch.cs:131:28:131:35 | String s | Switch.cs:131:28:131:35 | After String s [match] | match |
+| Switch.cs:131:28:131:35 | String s | Switch.cs:131:28:131:35 | After String s [no-match] | no-match |
+| Switch.cs:131:28:131:40 | ... => ... | Switch.cs:131:28:131:35 | String s |  |
+| Switch.cs:131:28:131:40 | After ... => ... [match] | Switch.cs:131:40:131:40 | access to local variable s |  |
 | Switch.cs:131:28:131:40 | After ... => ... [no-match] | Switch.cs:131:43:131:51 | ... => ... |  |
 | Switch.cs:131:40:131:40 | access to local variable s | Switch.cs:131:17:131:53 | After ... switch { ... } [non-null] | non-null |
 | Switch.cs:131:40:131:40 | access to local variable s | Switch.cs:131:17:131:53 | After ... switch { ... } [null] | null |
-| Switch.cs:131:43:131:43 | _ | Switch.cs:131:48:131:51 | null |  |
-| Switch.cs:131:43:131:51 | ... => ... | Switch.cs:131:43:131:51 | After ... => ... [match] | match |
-| Switch.cs:131:43:131:51 | After ... => ... [match] | Switch.cs:131:43:131:43 | _ |  |
+| Switch.cs:131:43:131:43 | After _ [match] | Switch.cs:131:43:131:51 | After ... => ... [match] | match |
+| Switch.cs:131:43:131:43 | _ | Switch.cs:131:43:131:43 | After _ [match] | match |
+| Switch.cs:131:43:131:51 | ... => ... | Switch.cs:131:43:131:43 | _ |  |
+| Switch.cs:131:43:131:51 | After ... => ... [match] | Switch.cs:131:48:131:51 | null |  |
 | Switch.cs:131:48:131:51 | null | Switch.cs:131:17:131:53 | After ... switch { ... } [non-null] | non-null |
 | Switch.cs:131:48:131:51 | null | Switch.cs:131:17:131:53 | After ... switch { ... } [null] | null |
 | Switch.cs:134:9:134:11 | Entry | Switch.cs:134:17:134:17 | i |  |
@@ -6674,19 +6738,23 @@
 | Switch.cs:138:29:138:30 | After -... | Switch.cs:138:22:138:31 | return ...; |  |
 | Switch.cs:138:29:138:30 | Before -... | Switch.cs:138:30:138:30 | 1 |  |
 | Switch.cs:138:30:138:30 | 1 | Switch.cs:138:29:138:30 | -... |  |
-| Switch.cs:139:13:139:19 | After case ...: [match] | Switch.cs:139:18:139:18 | 1 |  |
+| Switch.cs:139:13:139:19 | After case ...: [match] | Switch.cs:139:21:139:29 | Before return ...; |  |
 | Switch.cs:139:13:139:19 | After case ...: [no-match] | Switch.cs:140:13:140:19 | case ...: |  |
-| Switch.cs:139:13:139:19 | case ...: | Switch.cs:139:13:139:19 | After case ...: [match] | match |
-| Switch.cs:139:13:139:19 | case ...: | Switch.cs:139:13:139:19 | After case ...: [no-match] | no-match |
-| Switch.cs:139:18:139:18 | 1 | Switch.cs:139:21:139:29 | Before return ...; |  |
+| Switch.cs:139:13:139:19 | case ...: | Switch.cs:139:18:139:18 | 1 |  |
+| Switch.cs:139:18:139:18 | 1 | Switch.cs:139:18:139:18 | After 1 [match] | match |
+| Switch.cs:139:18:139:18 | 1 | Switch.cs:139:18:139:18 | After 1 [no-match] | no-match |
+| Switch.cs:139:18:139:18 | After 1 [match] | Switch.cs:139:13:139:19 | After case ...: [match] | match |
+| Switch.cs:139:18:139:18 | After 1 [no-match] | Switch.cs:139:13:139:19 | After case ...: [no-match] | no-match |
 | Switch.cs:139:21:139:29 | Before return ...; | Switch.cs:139:28:139:28 | 1 |  |
 | Switch.cs:139:21:139:29 | return ...; | Switch.cs:134:9:134:11 | Normal Exit | return |
 | Switch.cs:139:28:139:28 | 1 | Switch.cs:139:21:139:29 | return ...; |  |
-| Switch.cs:140:13:140:19 | After case ...: [match] | Switch.cs:140:18:140:18 | 2 |  |
+| Switch.cs:140:13:140:19 | After case ...: [match] | Switch.cs:140:21:140:29 | Before return ...; |  |
 | Switch.cs:140:13:140:19 | After case ...: [no-match] | Switch.cs:138:13:138:20 | default: |  |
-| Switch.cs:140:13:140:19 | case ...: | Switch.cs:140:13:140:19 | After case ...: [match] | match |
-| Switch.cs:140:13:140:19 | case ...: | Switch.cs:140:13:140:19 | After case ...: [no-match] | no-match |
-| Switch.cs:140:18:140:18 | 2 | Switch.cs:140:21:140:29 | Before return ...; |  |
+| Switch.cs:140:13:140:19 | case ...: | Switch.cs:140:18:140:18 | 2 |  |
+| Switch.cs:140:18:140:18 | 2 | Switch.cs:140:18:140:18 | After 2 [match] | match |
+| Switch.cs:140:18:140:18 | 2 | Switch.cs:140:18:140:18 | After 2 [no-match] | no-match |
+| Switch.cs:140:18:140:18 | After 2 [match] | Switch.cs:140:13:140:19 | After case ...: [match] | match |
+| Switch.cs:140:18:140:18 | After 2 [no-match] | Switch.cs:140:13:140:19 | After case ...: [no-match] | no-match |
 | Switch.cs:140:21:140:29 | Before return ...; | Switch.cs:140:28:140:28 | 2 |  |
 | Switch.cs:140:21:140:29 | return ...; | Switch.cs:134:9:134:11 | Normal Exit | return |
 | Switch.cs:140:28:140:28 | 2 | Switch.cs:140:21:140:29 | return ...; |  |
@@ -6696,11 +6764,13 @@
 | Switch.cs:145:5:152:5 | {...} | Switch.cs:146:9:151:9 | switch (...) {...} |  |
 | Switch.cs:146:9:151:9 | switch (...) {...} | Switch.cs:146:17:146:17 | access to parameter i |  |
 | Switch.cs:146:17:146:17 | access to parameter i | Switch.cs:148:13:148:19 | case ...: |  |
-| Switch.cs:148:13:148:19 | After case ...: [match] | Switch.cs:148:18:148:18 | 1 |  |
+| Switch.cs:148:13:148:19 | After case ...: [match] | Switch.cs:148:21:148:29 | Before return ...; |  |
 | Switch.cs:148:13:148:19 | After case ...: [no-match] | Switch.cs:150:13:150:19 | case ...: |  |
-| Switch.cs:148:13:148:19 | case ...: | Switch.cs:148:13:148:19 | After case ...: [match] | match |
-| Switch.cs:148:13:148:19 | case ...: | Switch.cs:148:13:148:19 | After case ...: [no-match] | no-match |
-| Switch.cs:148:18:148:18 | 1 | Switch.cs:148:21:148:29 | Before return ...; |  |
+| Switch.cs:148:13:148:19 | case ...: | Switch.cs:148:18:148:18 | 1 |  |
+| Switch.cs:148:18:148:18 | 1 | Switch.cs:148:18:148:18 | After 1 [match] | match |
+| Switch.cs:148:18:148:18 | 1 | Switch.cs:148:18:148:18 | After 1 [no-match] | no-match |
+| Switch.cs:148:18:148:18 | After 1 [match] | Switch.cs:148:13:148:19 | After case ...: [match] | match |
+| Switch.cs:148:18:148:18 | After 1 [no-match] | Switch.cs:148:13:148:19 | After case ...: [no-match] | no-match |
 | Switch.cs:148:21:148:29 | Before return ...; | Switch.cs:148:28:148:28 | 1 |  |
 | Switch.cs:148:21:148:29 | return ...; | Switch.cs:144:9:144:11 | Normal Exit | return |
 | Switch.cs:148:28:148:28 | 1 | Switch.cs:148:21:148:29 | return ...; |  |
@@ -6712,11 +6782,13 @@
 | Switch.cs:149:29:149:30 | After -... | Switch.cs:149:22:149:31 | return ...; |  |
 | Switch.cs:149:29:149:30 | Before -... | Switch.cs:149:30:149:30 | 1 |  |
 | Switch.cs:149:30:149:30 | 1 | Switch.cs:149:29:149:30 | -... |  |
-| Switch.cs:150:13:150:19 | After case ...: [match] | Switch.cs:150:18:150:18 | 2 |  |
+| Switch.cs:150:13:150:19 | After case ...: [match] | Switch.cs:150:21:150:29 | Before return ...; |  |
 | Switch.cs:150:13:150:19 | After case ...: [no-match] | Switch.cs:149:13:149:20 | default: |  |
-| Switch.cs:150:13:150:19 | case ...: | Switch.cs:150:13:150:19 | After case ...: [match] | match |
-| Switch.cs:150:13:150:19 | case ...: | Switch.cs:150:13:150:19 | After case ...: [no-match] | no-match |
-| Switch.cs:150:18:150:18 | 2 | Switch.cs:150:21:150:29 | Before return ...; |  |
+| Switch.cs:150:13:150:19 | case ...: | Switch.cs:150:18:150:18 | 2 |  |
+| Switch.cs:150:18:150:18 | 2 | Switch.cs:150:18:150:18 | After 2 [match] | match |
+| Switch.cs:150:18:150:18 | 2 | Switch.cs:150:18:150:18 | After 2 [no-match] | no-match |
+| Switch.cs:150:18:150:18 | After 2 [match] | Switch.cs:150:13:150:19 | After case ...: [match] | match |
+| Switch.cs:150:18:150:18 | After 2 [no-match] | Switch.cs:150:13:150:19 | After case ...: [no-match] | no-match |
 | Switch.cs:150:21:150:29 | Before return ...; | Switch.cs:150:28:150:28 | 2 |  |
 | Switch.cs:150:21:150:29 | return ...; | Switch.cs:144:9:144:11 | Normal Exit | return |
 | Switch.cs:150:28:150:28 | 2 | Switch.cs:150:21:150:29 | return ...; |  |
@@ -6734,16 +6806,20 @@
 | Switch.cs:156:17:156:17 | access to parameter b | Switch.cs:156:28:156:38 | ... => ... |  |
 | Switch.cs:156:17:156:54 | ... switch { ... } | Switch.cs:156:17:156:17 | access to parameter b |  |
 | Switch.cs:156:17:156:54 | After ... switch { ... } | Switch.cs:156:13:156:54 | String s = ... |  |
-| Switch.cs:156:28:156:31 | true | Switch.cs:156:36:156:38 | "a" |  |
-| Switch.cs:156:28:156:38 | ... => ... | Switch.cs:156:28:156:38 | After ... => ... [match] | match |
-| Switch.cs:156:28:156:38 | ... => ... | Switch.cs:156:28:156:38 | After ... => ... [no-match] | no-match |
-| Switch.cs:156:28:156:38 | After ... => ... [match] | Switch.cs:156:28:156:31 | true |  |
+| Switch.cs:156:28:156:31 | After true [match] | Switch.cs:156:28:156:38 | After ... => ... [match] | match |
+| Switch.cs:156:28:156:31 | After true [no-match] | Switch.cs:156:28:156:38 | After ... => ... [no-match] | no-match |
+| Switch.cs:156:28:156:31 | true | Switch.cs:156:28:156:31 | After true [match] | match |
+| Switch.cs:156:28:156:31 | true | Switch.cs:156:28:156:31 | After true [no-match] | no-match |
+| Switch.cs:156:28:156:38 | ... => ... | Switch.cs:156:28:156:31 | true |  |
+| Switch.cs:156:28:156:38 | After ... => ... [match] | Switch.cs:156:36:156:38 | "a" |  |
 | Switch.cs:156:28:156:38 | After ... => ... [no-match] | Switch.cs:156:41:156:52 | ... => ... |  |
 | Switch.cs:156:36:156:38 | "a" | Switch.cs:156:17:156:54 | After ... switch { ... } |  |
-| Switch.cs:156:41:156:45 | false | Switch.cs:156:50:156:52 | "b" |  |
-| Switch.cs:156:41:156:52 | ... => ... | Switch.cs:156:41:156:52 | After ... => ... [match] | match |
-| Switch.cs:156:41:156:52 | ... => ... | Switch.cs:156:41:156:52 | After ... => ... [no-match] | no-match |
-| Switch.cs:156:41:156:52 | After ... => ... [match] | Switch.cs:156:41:156:45 | false |  |
+| Switch.cs:156:41:156:45 | After false [match] | Switch.cs:156:41:156:52 | After ... => ... [match] | match |
+| Switch.cs:156:41:156:45 | After false [no-match] | Switch.cs:156:41:156:52 | After ... => ... [no-match] | no-match |
+| Switch.cs:156:41:156:45 | false | Switch.cs:156:41:156:45 | After false [match] | match |
+| Switch.cs:156:41:156:45 | false | Switch.cs:156:41:156:45 | After false [no-match] | no-match |
+| Switch.cs:156:41:156:52 | ... => ... | Switch.cs:156:41:156:45 | false |  |
+| Switch.cs:156:41:156:52 | After ... => ... [match] | Switch.cs:156:50:156:52 | "b" |  |
 | Switch.cs:156:41:156:52 | After ... => ... [no-match] | Switch.cs:156:17:156:54 | After ... switch { ... } |  |
 | Switch.cs:156:50:156:52 | "b" | Switch.cs:156:17:156:54 | After ... switch { ... } |  |
 | Switch.cs:157:9:160:49 | After if (...) ... | Switch.cs:155:5:161:5 | After {...} |  |
@@ -6786,16 +6862,20 @@
 | Switch.cs:165:9:177:9 | After switch (...) {...} | Switch.cs:164:5:178:5 | After {...} |  |
 | Switch.cs:165:9:177:9 | switch (...) {...} | Switch.cs:165:17:165:17 | access to parameter i |  |
 | Switch.cs:165:17:165:17 | access to parameter i | Switch.cs:167:13:167:19 | case ...: |  |
-| Switch.cs:167:13:167:19 | After case ...: [match] | Switch.cs:167:18:167:18 | 1 |  |
+| Switch.cs:167:13:167:19 | After case ...: [match] | Switch.cs:169:17:169:51 | ...; |  |
 | Switch.cs:167:13:167:19 | After case ...: [no-match] | Switch.cs:168:13:168:19 | case ...: |  |
-| Switch.cs:167:13:167:19 | case ...: | Switch.cs:167:13:167:19 | After case ...: [match] | match |
-| Switch.cs:167:13:167:19 | case ...: | Switch.cs:167:13:167:19 | After case ...: [no-match] | no-match |
-| Switch.cs:167:18:167:18 | 1 | Switch.cs:169:17:169:51 | ...; |  |
-| Switch.cs:168:13:168:19 | After case ...: [match] | Switch.cs:168:18:168:18 | 2 |  |
+| Switch.cs:167:13:167:19 | case ...: | Switch.cs:167:18:167:18 | 1 |  |
+| Switch.cs:167:18:167:18 | 1 | Switch.cs:167:18:167:18 | After 1 [match] | match |
+| Switch.cs:167:18:167:18 | 1 | Switch.cs:167:18:167:18 | After 1 [no-match] | no-match |
+| Switch.cs:167:18:167:18 | After 1 [match] | Switch.cs:167:13:167:19 | After case ...: [match] | match |
+| Switch.cs:167:18:167:18 | After 1 [no-match] | Switch.cs:167:13:167:19 | After case ...: [no-match] | no-match |
+| Switch.cs:168:13:168:19 | After case ...: [match] | Switch.cs:169:17:169:51 | ...; |  |
 | Switch.cs:168:13:168:19 | After case ...: [no-match] | Switch.cs:171:13:171:19 | case ...: |  |
-| Switch.cs:168:13:168:19 | case ...: | Switch.cs:168:13:168:19 | After case ...: [match] | match |
-| Switch.cs:168:13:168:19 | case ...: | Switch.cs:168:13:168:19 | After case ...: [no-match] | no-match |
-| Switch.cs:168:18:168:18 | 2 | Switch.cs:169:17:169:51 | ...; |  |
+| Switch.cs:168:13:168:19 | case ...: | Switch.cs:168:18:168:18 | 2 |  |
+| Switch.cs:168:18:168:18 | 2 | Switch.cs:168:18:168:18 | After 2 [match] | match |
+| Switch.cs:168:18:168:18 | 2 | Switch.cs:168:18:168:18 | After 2 [no-match] | no-match |
+| Switch.cs:168:18:168:18 | After 2 [match] | Switch.cs:168:13:168:19 | After case ...: [match] | match |
+| Switch.cs:168:18:168:18 | After 2 [no-match] | Switch.cs:168:13:168:19 | After case ...: [no-match] | no-match |
 | Switch.cs:169:17:169:50 | After call to method WriteLine | Switch.cs:169:17:169:51 | After ...; |  |
 | Switch.cs:169:17:169:50 | Before call to method WriteLine | Switch.cs:169:42:169:49 | "1 or 2" |  |
 | Switch.cs:169:17:169:50 | call to method WriteLine | Switch.cs:169:17:169:50 | After call to method WriteLine |  |
@@ -6804,11 +6884,13 @@
 | Switch.cs:169:42:169:49 | "1 or 2" | Switch.cs:169:17:169:50 | call to method WriteLine |  |
 | Switch.cs:170:17:170:22 | Before break; | Switch.cs:170:17:170:22 | break; |  |
 | Switch.cs:170:17:170:22 | break; | Switch.cs:165:9:177:9 | After switch (...) {...} | break |
-| Switch.cs:171:13:171:19 | After case ...: [match] | Switch.cs:171:18:171:18 | 3 |  |
+| Switch.cs:171:13:171:19 | After case ...: [match] | Switch.cs:172:17:172:46 | ...; |  |
 | Switch.cs:171:13:171:19 | After case ...: [no-match] | Switch.cs:174:13:174:20 | default: |  |
-| Switch.cs:171:13:171:19 | case ...: | Switch.cs:171:13:171:19 | After case ...: [match] | match |
-| Switch.cs:171:13:171:19 | case ...: | Switch.cs:171:13:171:19 | After case ...: [no-match] | no-match |
-| Switch.cs:171:18:171:18 | 3 | Switch.cs:172:17:172:46 | ...; |  |
+| Switch.cs:171:13:171:19 | case ...: | Switch.cs:171:18:171:18 | 3 |  |
+| Switch.cs:171:18:171:18 | 3 | Switch.cs:171:18:171:18 | After 3 [match] | match |
+| Switch.cs:171:18:171:18 | 3 | Switch.cs:171:18:171:18 | After 3 [no-match] | no-match |
+| Switch.cs:171:18:171:18 | After 3 [match] | Switch.cs:171:13:171:19 | After case ...: [match] | match |
+| Switch.cs:171:18:171:18 | After 3 [no-match] | Switch.cs:171:13:171:19 | After case ...: [no-match] | no-match |
 | Switch.cs:172:17:172:45 | After call to method WriteLine | Switch.cs:172:17:172:46 | After ...; |  |
 | Switch.cs:172:17:172:45 | Before call to method WriteLine | Switch.cs:172:42:172:44 | "3" |  |
 | Switch.cs:172:17:172:45 | call to method WriteLine | Switch.cs:172:17:172:45 | After call to method WriteLine |  |
@@ -7195,11 +7277,13 @@
 | cflow.cs:39:9:50:9 | After switch (...) {...} | cflow.cs:51:9:59:9 | switch (...) {...} |  |
 | cflow.cs:39:9:50:9 | switch (...) {...} | cflow.cs:39:17:39:17 | access to parameter a |  |
 | cflow.cs:39:17:39:17 | access to parameter a | cflow.cs:41:13:41:19 | case ...: |  |
-| cflow.cs:41:13:41:19 | After case ...: [match] | cflow.cs:41:18:41:18 | 1 |  |
+| cflow.cs:41:13:41:19 | After case ...: [match] | cflow.cs:42:17:42:39 | ...; |  |
 | cflow.cs:41:13:41:19 | After case ...: [no-match] | cflow.cs:44:13:44:19 | case ...: |  |
-| cflow.cs:41:13:41:19 | case ...: | cflow.cs:41:13:41:19 | After case ...: [match] | match |
-| cflow.cs:41:13:41:19 | case ...: | cflow.cs:41:13:41:19 | After case ...: [no-match] | no-match |
-| cflow.cs:41:18:41:18 | 1 | cflow.cs:42:17:42:39 | ...; |  |
+| cflow.cs:41:13:41:19 | case ...: | cflow.cs:41:18:41:18 | 1 |  |
+| cflow.cs:41:18:41:18 | 1 | cflow.cs:41:18:41:18 | After 1 [match] | match |
+| cflow.cs:41:18:41:18 | 1 | cflow.cs:41:18:41:18 | After 1 [no-match] | no-match |
+| cflow.cs:41:18:41:18 | After 1 [match] | cflow.cs:41:13:41:19 | After case ...: [match] | match |
+| cflow.cs:41:18:41:18 | After 1 [no-match] | cflow.cs:41:13:41:19 | After case ...: [no-match] | no-match |
 | cflow.cs:42:17:42:38 | After call to method WriteLine | cflow.cs:42:17:42:39 | After ...; |  |
 | cflow.cs:42:17:42:38 | Before call to method WriteLine | cflow.cs:42:35:42:37 | "1" |  |
 | cflow.cs:42:17:42:38 | call to method WriteLine | cflow.cs:42:17:42:38 | After call to method WriteLine |  |
@@ -7209,11 +7293,13 @@
 | cflow.cs:43:17:43:28 | Before goto case ...; | cflow.cs:43:27:43:27 | 2 |  |
 | cflow.cs:43:17:43:28 | goto case ...; | cflow.cs:44:13:44:19 | After case ...: [match] | goto |
 | cflow.cs:43:27:43:27 | 2 | cflow.cs:43:17:43:28 | goto case ...; |  |
-| cflow.cs:44:13:44:19 | After case ...: [match] | cflow.cs:44:18:44:18 | 2 |  |
+| cflow.cs:44:13:44:19 | After case ...: [match] | cflow.cs:45:17:45:39 | ...; |  |
 | cflow.cs:44:13:44:19 | After case ...: [no-match] | cflow.cs:47:13:47:19 | case ...: |  |
-| cflow.cs:44:13:44:19 | case ...: | cflow.cs:44:13:44:19 | After case ...: [match] | match |
-| cflow.cs:44:13:44:19 | case ...: | cflow.cs:44:13:44:19 | After case ...: [no-match] | no-match |
-| cflow.cs:44:18:44:18 | 2 | cflow.cs:45:17:45:39 | ...; |  |
+| cflow.cs:44:13:44:19 | case ...: | cflow.cs:44:18:44:18 | 2 |  |
+| cflow.cs:44:18:44:18 | 2 | cflow.cs:44:18:44:18 | After 2 [match] | match |
+| cflow.cs:44:18:44:18 | 2 | cflow.cs:44:18:44:18 | After 2 [no-match] | no-match |
+| cflow.cs:44:18:44:18 | After 2 [match] | cflow.cs:44:13:44:19 | After case ...: [match] | match |
+| cflow.cs:44:18:44:18 | After 2 [no-match] | cflow.cs:44:13:44:19 | After case ...: [no-match] | no-match |
 | cflow.cs:45:17:45:38 | After call to method WriteLine | cflow.cs:45:17:45:39 | After ...; |  |
 | cflow.cs:45:17:45:38 | Before call to method WriteLine | cflow.cs:45:35:45:37 | "2" |  |
 | cflow.cs:45:17:45:38 | call to method WriteLine | cflow.cs:45:17:45:38 | After call to method WriteLine |  |
@@ -7223,11 +7309,13 @@
 | cflow.cs:46:17:46:28 | Before goto case ...; | cflow.cs:46:27:46:27 | 1 |  |
 | cflow.cs:46:17:46:28 | goto case ...; | cflow.cs:41:13:41:19 | After case ...: [match] | goto |
 | cflow.cs:46:27:46:27 | 1 | cflow.cs:46:17:46:28 | goto case ...; |  |
-| cflow.cs:47:13:47:19 | After case ...: [match] | cflow.cs:47:18:47:18 | 3 |  |
+| cflow.cs:47:13:47:19 | After case ...: [match] | cflow.cs:48:17:48:39 | ...; |  |
 | cflow.cs:47:13:47:19 | After case ...: [no-match] | cflow.cs:39:9:50:9 | After switch (...) {...} |  |
-| cflow.cs:47:13:47:19 | case ...: | cflow.cs:47:13:47:19 | After case ...: [match] | match |
-| cflow.cs:47:13:47:19 | case ...: | cflow.cs:47:13:47:19 | After case ...: [no-match] | no-match |
-| cflow.cs:47:18:47:18 | 3 | cflow.cs:48:17:48:39 | ...; |  |
+| cflow.cs:47:13:47:19 | case ...: | cflow.cs:47:18:47:18 | 3 |  |
+| cflow.cs:47:18:47:18 | 3 | cflow.cs:47:18:47:18 | After 3 [match] | match |
+| cflow.cs:47:18:47:18 | 3 | cflow.cs:47:18:47:18 | After 3 [no-match] | no-match |
+| cflow.cs:47:18:47:18 | After 3 [match] | cflow.cs:47:13:47:19 | After case ...: [match] | match |
+| cflow.cs:47:18:47:18 | After 3 [no-match] | cflow.cs:47:13:47:19 | After case ...: [no-match] | no-match |
 | cflow.cs:48:17:48:38 | After call to method WriteLine | cflow.cs:48:17:48:39 | After ...; |  |
 | cflow.cs:48:17:48:38 | Before call to method WriteLine | cflow.cs:48:35:48:37 | "3" |  |
 | cflow.cs:48:17:48:38 | call to method WriteLine | cflow.cs:48:17:48:38 | After call to method WriteLine |  |
@@ -7239,11 +7327,13 @@
 | cflow.cs:51:9:59:9 | After switch (...) {...} | cflow.cs:60:9:66:9 | switch (...) {...} |  |
 | cflow.cs:51:9:59:9 | switch (...) {...} | cflow.cs:51:17:51:17 | access to parameter a |  |
 | cflow.cs:51:17:51:17 | access to parameter a | cflow.cs:53:13:53:20 | case ...: |  |
-| cflow.cs:53:13:53:20 | After case ...: [match] | cflow.cs:53:18:53:19 | 42 |  |
+| cflow.cs:53:13:53:20 | After case ...: [match] | cflow.cs:54:17:54:48 | ...; |  |
 | cflow.cs:53:13:53:20 | After case ...: [no-match] | cflow.cs:56:13:56:20 | default: |  |
-| cflow.cs:53:13:53:20 | case ...: | cflow.cs:53:13:53:20 | After case ...: [match] | match |
-| cflow.cs:53:13:53:20 | case ...: | cflow.cs:53:13:53:20 | After case ...: [no-match] | no-match |
-| cflow.cs:53:18:53:19 | 42 | cflow.cs:54:17:54:48 | ...; |  |
+| cflow.cs:53:13:53:20 | case ...: | cflow.cs:53:18:53:19 | 42 |  |
+| cflow.cs:53:18:53:19 | 42 | cflow.cs:53:18:53:19 | After 42 [match] | match |
+| cflow.cs:53:18:53:19 | 42 | cflow.cs:53:18:53:19 | After 42 [no-match] | no-match |
+| cflow.cs:53:18:53:19 | After 42 [match] | cflow.cs:53:13:53:20 | After case ...: [match] | match |
+| cflow.cs:53:18:53:19 | After 42 [no-match] | cflow.cs:53:13:53:20 | After case ...: [no-match] | no-match |
 | cflow.cs:54:17:54:47 | After call to method WriteLine | cflow.cs:54:17:54:48 | After ...; |  |
 | cflow.cs:54:17:54:47 | Before call to method WriteLine | cflow.cs:54:35:54:46 | "The answer" |  |
 | cflow.cs:54:17:54:47 | call to method WriteLine | cflow.cs:54:17:54:47 | After call to method WriteLine |  |
@@ -7271,11 +7361,13 @@
 | cflow.cs:60:27:60:31 | Before access to field Field | cflow.cs:60:27:60:31 | this access |  |
 | cflow.cs:60:27:60:31 | access to field Field | cflow.cs:60:27:60:31 | After access to field Field |  |
 | cflow.cs:60:27:60:31 | this access | cflow.cs:60:27:60:31 | access to field Field |  |
-| cflow.cs:62:13:62:19 | After case ...: [match] | cflow.cs:62:18:62:18 | 0 |  |
+| cflow.cs:62:13:62:19 | After case ...: [match] | cflow.cs:63:17:64:55 | if (...) ... |  |
 | cflow.cs:62:13:62:19 | After case ...: [no-match] | cflow.cs:60:9:66:9 | After switch (...) {...} |  |
-| cflow.cs:62:13:62:19 | case ...: | cflow.cs:62:13:62:19 | After case ...: [match] | match |
-| cflow.cs:62:13:62:19 | case ...: | cflow.cs:62:13:62:19 | After case ...: [no-match] | no-match |
-| cflow.cs:62:18:62:18 | 0 | cflow.cs:63:17:64:55 | if (...) ... |  |
+| cflow.cs:62:13:62:19 | case ...: | cflow.cs:62:18:62:18 | 0 |  |
+| cflow.cs:62:18:62:18 | 0 | cflow.cs:62:18:62:18 | After 0 [match] | match |
+| cflow.cs:62:18:62:18 | 0 | cflow.cs:62:18:62:18 | After 0 [no-match] | no-match |
+| cflow.cs:62:18:62:18 | After 0 [match] | cflow.cs:62:13:62:19 | After case ...: [match] | match |
+| cflow.cs:62:18:62:18 | After 0 [no-match] | cflow.cs:62:13:62:19 | After case ...: [no-match] | no-match |
 | cflow.cs:63:17:64:55 | After if (...) ... | cflow.cs:65:17:65:22 | Before break; |  |
 | cflow.cs:63:17:64:55 | if (...) ... | cflow.cs:63:21:63:34 | !... |  |
 | cflow.cs:63:21:63:34 | !... | cflow.cs:63:23:63:33 | Before ... == ... |  |
@@ -8221,18 +8313,22 @@
 | cflow.cs:246:17:246:32 | After ... + ... | cflow.cs:248:13:248:19 | case ...: |  |
 | cflow.cs:246:17:246:32 | Before ... + ... | cflow.cs:246:17:246:28 | Before access to property Length |  |
 | cflow.cs:246:32:246:32 | 3 | cflow.cs:246:17:246:32 | ... + ... |  |
-| cflow.cs:248:13:248:19 | After case ...: [match] | cflow.cs:248:18:248:18 | 0 |  |
+| cflow.cs:248:13:248:19 | After case ...: [match] | cflow.cs:249:17:249:29 | Before goto default; |  |
 | cflow.cs:248:13:248:19 | After case ...: [no-match] | cflow.cs:250:13:250:19 | case ...: |  |
-| cflow.cs:248:13:248:19 | case ...: | cflow.cs:248:13:248:19 | After case ...: [match] | match |
-| cflow.cs:248:13:248:19 | case ...: | cflow.cs:248:13:248:19 | After case ...: [no-match] | no-match |
-| cflow.cs:248:18:248:18 | 0 | cflow.cs:249:17:249:29 | Before goto default; |  |
+| cflow.cs:248:13:248:19 | case ...: | cflow.cs:248:18:248:18 | 0 |  |
+| cflow.cs:248:18:248:18 | 0 | cflow.cs:248:18:248:18 | After 0 [match] | match |
+| cflow.cs:248:18:248:18 | 0 | cflow.cs:248:18:248:18 | After 0 [no-match] | no-match |
+| cflow.cs:248:18:248:18 | After 0 [match] | cflow.cs:248:13:248:19 | After case ...: [match] | match |
+| cflow.cs:248:18:248:18 | After 0 [no-match] | cflow.cs:248:13:248:19 | After case ...: [no-match] | no-match |
 | cflow.cs:249:17:249:29 | Before goto default; | cflow.cs:249:17:249:29 | goto default; |  |
 | cflow.cs:249:17:249:29 | goto default; | cflow.cs:255:13:255:20 | After default: [match] | goto |
-| cflow.cs:250:13:250:19 | After case ...: [match] | cflow.cs:250:18:250:18 | 1 |  |
+| cflow.cs:250:13:250:19 | After case ...: [match] | cflow.cs:251:17:251:37 | ...; |  |
 | cflow.cs:250:13:250:19 | After case ...: [no-match] | cflow.cs:253:13:253:19 | case ...: |  |
-| cflow.cs:250:13:250:19 | case ...: | cflow.cs:250:13:250:19 | After case ...: [match] | match |
-| cflow.cs:250:13:250:19 | case ...: | cflow.cs:250:13:250:19 | After case ...: [no-match] | no-match |
-| cflow.cs:250:18:250:18 | 1 | cflow.cs:251:17:251:37 | ...; |  |
+| cflow.cs:250:13:250:19 | case ...: | cflow.cs:250:18:250:18 | 1 |  |
+| cflow.cs:250:18:250:18 | 1 | cflow.cs:250:18:250:18 | After 1 [match] | match |
+| cflow.cs:250:18:250:18 | 1 | cflow.cs:250:18:250:18 | After 1 [no-match] | no-match |
+| cflow.cs:250:18:250:18 | After 1 [match] | cflow.cs:250:13:250:19 | After case ...: [match] | match |
+| cflow.cs:250:18:250:18 | After 1 [no-match] | cflow.cs:250:13:250:19 | After case ...: [no-match] | no-match |
 | cflow.cs:251:17:251:36 | After call to method WriteLine | cflow.cs:251:17:251:37 | After ...; |  |
 | cflow.cs:251:17:251:36 | Before call to method WriteLine | cflow.cs:251:35:251:35 | 1 |  |
 | cflow.cs:251:17:251:36 | call to method WriteLine | cflow.cs:251:17:251:36 | After call to method WriteLine |  |
@@ -8241,11 +8337,13 @@
 | cflow.cs:251:35:251:35 | 1 | cflow.cs:251:17:251:36 | call to method WriteLine |  |
 | cflow.cs:252:17:252:22 | Before break; | cflow.cs:252:17:252:22 | break; |  |
 | cflow.cs:252:17:252:22 | break; | cflow.cs:246:9:258:9 | After switch (...) {...} | break |
-| cflow.cs:253:13:253:19 | After case ...: [match] | cflow.cs:253:18:253:18 | 2 |  |
+| cflow.cs:253:13:253:19 | After case ...: [match] | cflow.cs:254:17:254:27 | Before goto ...; |  |
 | cflow.cs:253:13:253:19 | After case ...: [no-match] | cflow.cs:255:13:255:20 | default: |  |
-| cflow.cs:253:13:253:19 | case ...: | cflow.cs:253:13:253:19 | After case ...: [match] | match |
-| cflow.cs:253:13:253:19 | case ...: | cflow.cs:253:13:253:19 | After case ...: [no-match] | no-match |
-| cflow.cs:253:18:253:18 | 2 | cflow.cs:254:17:254:27 | Before goto ...; |  |
+| cflow.cs:253:13:253:19 | case ...: | cflow.cs:253:18:253:18 | 2 |  |
+| cflow.cs:253:18:253:18 | 2 | cflow.cs:253:18:253:18 | After 2 [match] | match |
+| cflow.cs:253:18:253:18 | 2 | cflow.cs:253:18:253:18 | After 2 [no-match] | no-match |
+| cflow.cs:253:18:253:18 | After 2 [match] | cflow.cs:253:13:253:19 | After case ...: [match] | match |
+| cflow.cs:253:18:253:18 | After 2 [no-match] | cflow.cs:253:13:253:19 | After case ...: [no-match] | no-match |
 | cflow.cs:254:17:254:27 | Before goto ...; | cflow.cs:254:17:254:27 | goto ...; |  |
 | cflow.cs:254:17:254:27 | goto ...; | cflow.cs:242:5:242:9 | Label: | goto |
 | cflow.cs:255:13:255:20 | After default: [match] | cflow.cs:256:17:256:37 | ...; |  |

--- a/csharp/ql/test/library-tests/controlflow/guards/BooleanGuardedExpr.expected
+++ b/csharp/ql/test/library-tests/controlflow/guards/BooleanGuardedExpr.expected
@@ -79,7 +79,6 @@
 | Guards.cs:287:17:287:17 | access to parameter o | Guards.cs:278:13:279:28 | ... => ... | Guards.cs:279:17:279:17 | access to parameter o | false |
 | Guards.cs:287:17:287:17 | access to parameter o | Guards.cs:282:13:283:28 | ... => ... | Guards.cs:283:17:283:17 | access to parameter o | false |
 | Guards.cs:287:17:287:17 | access to parameter o | Guards.cs:284:13:285:28 | ... => ... | Guards.cs:285:17:285:17 | access to parameter o | false |
-| Guards.cs:334:13:334:15 | access to constant B | Guards.cs:334:13:334:20 | ... => ... | Guards.cs:334:13:334:15 | access to constant B | true |
 | Guards.cs:342:27:342:27 | access to parameter b | Guards.cs:341:20:341:20 | access to parameter b | Guards.cs:341:20:341:20 | access to parameter b | false |
 | Guards.cs:343:31:343:31 | access to local variable s | Guards.cs:342:13:342:21 | ... != ... | Guards.cs:342:13:342:13 | access to local variable s | true |
 | Guards.cs:349:13:349:13 | access to parameter o | Guards.cs:348:13:348:25 | ... is ... | Guards.cs:348:13:348:13 | access to parameter o | true |

--- a/csharp/ql/test/library-tests/controlflow/guards/GuardedControlFlowNode.expected
+++ b/csharp/ql/test/library-tests/controlflow/guards/GuardedControlFlowNode.expected
@@ -202,7 +202,6 @@
 | Guards.cs:287:17:287:28 | call to method ToString | Guards.cs:278:13:279:28 | ... => ... | Guards.cs:279:17:279:28 | call to method ToString | false |
 | Guards.cs:287:17:287:28 | call to method ToString | Guards.cs:282:13:283:28 | ... => ... | Guards.cs:283:17:283:28 | call to method ToString | false |
 | Guards.cs:287:17:287:28 | call to method ToString | Guards.cs:284:13:285:28 | ... => ... | Guards.cs:285:17:285:28 | call to method ToString | false |
-| Guards.cs:334:13:334:15 | access to constant B | Guards.cs:334:13:334:20 | ... => ... | Guards.cs:334:13:334:15 | access to constant B | true |
 | Guards.cs:342:27:342:27 | access to parameter b | Guards.cs:341:20:341:20 | access to parameter b | Guards.cs:341:20:341:20 | access to parameter b | false |
 | Guards.cs:342:27:342:27 | access to parameter b | Guards.cs:341:20:341:32 | ... ? ... : ... | Guards.cs:341:20:341:20 | access to parameter b | not null |
 | Guards.cs:343:31:343:31 | access to local variable s | Guards.cs:342:13:342:13 | access to local variable s | Guards.cs:342:13:342:13 | access to local variable s | not null |

--- a/csharp/ql/test/library-tests/controlflow/guards/GuardedExpr.expected
+++ b/csharp/ql/test/library-tests/controlflow/guards/GuardedExpr.expected
@@ -202,7 +202,6 @@
 | Guards.cs:287:17:287:28 | call to method ToString | Guards.cs:278:13:279:28 | ... => ... | Guards.cs:279:17:279:28 | call to method ToString | false |
 | Guards.cs:287:17:287:28 | call to method ToString | Guards.cs:282:13:283:28 | ... => ... | Guards.cs:283:17:283:28 | call to method ToString | false |
 | Guards.cs:287:17:287:28 | call to method ToString | Guards.cs:284:13:285:28 | ... => ... | Guards.cs:285:17:285:28 | call to method ToString | false |
-| Guards.cs:334:13:334:15 | access to constant B | Guards.cs:334:13:334:20 | ... => ... | Guards.cs:334:13:334:15 | access to constant B | true |
 | Guards.cs:342:27:342:27 | access to parameter b | Guards.cs:341:20:341:20 | access to parameter b | Guards.cs:341:20:341:20 | access to parameter b | false |
 | Guards.cs:342:27:342:27 | access to parameter b | Guards.cs:341:20:341:32 | ... ? ... : ... | Guards.cs:341:20:341:20 | access to parameter b | not null |
 | Guards.cs:343:31:343:31 | access to local variable s | Guards.cs:342:13:342:13 | access to local variable s | Guards.cs:342:13:342:13 | access to local variable s | not null |

--- a/csharp/ql/test/library-tests/csharp7/IsFlow.expected
+++ b/csharp/ql/test/library-tests/csharp7/IsFlow.expected
@@ -3,18 +3,22 @@
 | CSharp7.cs:248:9:274:9 | After switch (...) {...} | CSharp7.cs:231:5:275:5 | After {...} | semmle.label | successor |
 | CSharp7.cs:248:9:274:9 | switch (...) {...} | CSharp7.cs:248:17:248:17 | access to local variable o | semmle.label | successor |
 | CSharp7.cs:248:17:248:17 | access to local variable o | CSharp7.cs:250:13:250:23 | case ...: | semmle.label | successor |
-| CSharp7.cs:250:13:250:23 | After case ...: [match] | CSharp7.cs:250:18:250:22 | "xyz" | semmle.label | successor |
+| CSharp7.cs:250:13:250:23 | After case ...: [match] | CSharp7.cs:251:17:251:22 | Before break; | semmle.label | successor |
 | CSharp7.cs:250:13:250:23 | After case ...: [no-match] | CSharp7.cs:252:13:252:31 | case ...: | semmle.label | successor |
-| CSharp7.cs:250:13:250:23 | case ...: | CSharp7.cs:250:13:250:23 | After case ...: [match] | semmle.label | match |
-| CSharp7.cs:250:13:250:23 | case ...: | CSharp7.cs:250:13:250:23 | After case ...: [no-match] | semmle.label | no-match |
-| CSharp7.cs:250:18:250:22 | "xyz" | CSharp7.cs:251:17:251:22 | Before break; | semmle.label | successor |
+| CSharp7.cs:250:13:250:23 | case ...: | CSharp7.cs:250:18:250:22 | "xyz" | semmle.label | successor |
+| CSharp7.cs:250:18:250:22 | "xyz" | CSharp7.cs:250:18:250:22 | After "xyz" [match] | semmle.label | match |
+| CSharp7.cs:250:18:250:22 | "xyz" | CSharp7.cs:250:18:250:22 | After "xyz" [no-match] | semmle.label | no-match |
+| CSharp7.cs:250:18:250:22 | After "xyz" [match] | CSharp7.cs:250:13:250:23 | After case ...: [match] | semmle.label | match |
+| CSharp7.cs:250:18:250:22 | After "xyz" [no-match] | CSharp7.cs:250:13:250:23 | After case ...: [no-match] | semmle.label | no-match |
 | CSharp7.cs:251:17:251:22 | Before break; | CSharp7.cs:251:17:251:22 | break; | semmle.label | successor |
 | CSharp7.cs:251:17:251:22 | break; | CSharp7.cs:248:9:274:9 | After switch (...) {...} | semmle.label | break |
-| CSharp7.cs:252:13:252:31 | After case ...: [match] | CSharp7.cs:252:18:252:19 | "" | semmle.label | successor |
+| CSharp7.cs:252:13:252:31 | After case ...: [match] | CSharp7.cs:252:26:252:30 | Before ... < ... | semmle.label | successor |
 | CSharp7.cs:252:13:252:31 | After case ...: [no-match] | CSharp7.cs:254:13:254:41 | case ...: | semmle.label | successor |
-| CSharp7.cs:252:13:252:31 | case ...: | CSharp7.cs:252:13:252:31 | After case ...: [match] | semmle.label | match |
-| CSharp7.cs:252:13:252:31 | case ...: | CSharp7.cs:252:13:252:31 | After case ...: [no-match] | semmle.label | no-match |
-| CSharp7.cs:252:18:252:19 | "" | CSharp7.cs:252:26:252:30 | Before ... < ... | semmle.label | successor |
+| CSharp7.cs:252:13:252:31 | case ...: | CSharp7.cs:252:18:252:19 | "" | semmle.label | successor |
+| CSharp7.cs:252:18:252:19 | "" | CSharp7.cs:252:18:252:19 | After "" [match] | semmle.label | match |
+| CSharp7.cs:252:18:252:19 | "" | CSharp7.cs:252:18:252:19 | After "" [no-match] | semmle.label | no-match |
+| CSharp7.cs:252:18:252:19 | After "" [match] | CSharp7.cs:252:13:252:31 | After case ...: [match] | semmle.label | match |
+| CSharp7.cs:252:18:252:19 | After "" [no-match] | CSharp7.cs:252:13:252:31 | After case ...: [no-match] | semmle.label | no-match |
 | CSharp7.cs:252:26:252:26 | 1 | CSharp7.cs:252:30:252:30 | 2 | semmle.label | successor |
 | CSharp7.cs:252:26:252:30 | ... < ... | CSharp7.cs:252:26:252:30 | After ... < ... [false] | semmle.label | false |
 | CSharp7.cs:252:26:252:30 | ... < ... | CSharp7.cs:252:26:252:30 | After ... < ... [true] | semmle.label | true |
@@ -24,11 +28,13 @@
 | CSharp7.cs:252:30:252:30 | 2 | CSharp7.cs:252:26:252:30 | ... < ... | semmle.label | successor |
 | CSharp7.cs:253:17:253:22 | Before break; | CSharp7.cs:253:17:253:22 | break; | semmle.label | successor |
 | CSharp7.cs:253:17:253:22 | break; | CSharp7.cs:248:9:274:9 | After switch (...) {...} | semmle.label | break |
-| CSharp7.cs:254:13:254:41 | After case ...: [match] | CSharp7.cs:254:18:254:20 | "x" | semmle.label | successor |
+| CSharp7.cs:254:13:254:41 | After case ...: [match] | CSharp7.cs:254:27:254:40 | Before ... is ... | semmle.label | successor |
 | CSharp7.cs:254:13:254:41 | After case ...: [no-match] | CSharp7.cs:257:13:257:36 | case ...: | semmle.label | successor |
-| CSharp7.cs:254:13:254:41 | case ...: | CSharp7.cs:254:13:254:41 | After case ...: [match] | semmle.label | match |
-| CSharp7.cs:254:13:254:41 | case ...: | CSharp7.cs:254:13:254:41 | After case ...: [no-match] | semmle.label | no-match |
-| CSharp7.cs:254:18:254:20 | "x" | CSharp7.cs:254:27:254:40 | Before ... is ... | semmle.label | successor |
+| CSharp7.cs:254:13:254:41 | case ...: | CSharp7.cs:254:18:254:20 | "x" | semmle.label | successor |
+| CSharp7.cs:254:18:254:20 | "x" | CSharp7.cs:254:18:254:20 | After "x" [match] | semmle.label | match |
+| CSharp7.cs:254:18:254:20 | "x" | CSharp7.cs:254:18:254:20 | After "x" [no-match] | semmle.label | no-match |
+| CSharp7.cs:254:18:254:20 | After "x" [match] | CSharp7.cs:254:13:254:41 | After case ...: [match] | semmle.label | match |
+| CSharp7.cs:254:18:254:20 | After "x" [no-match] | CSharp7.cs:254:13:254:41 | After case ...: [no-match] | semmle.label | no-match |
 | CSharp7.cs:254:27:254:27 | access to local variable o | CSharp7.cs:254:27:254:40 | ... is ... | semmle.label | successor |
 | CSharp7.cs:254:27:254:40 | ... is ... | CSharp7.cs:254:27:254:40 | After ... is ... [false] | semmle.label | false |
 | CSharp7.cs:254:27:254:40 | ... is ... | CSharp7.cs:254:27:254:40 | [MatchTrue] ... is ... | semmle.label | true |
@@ -52,11 +58,13 @@
 | CSharp7.cs:255:40:255:41 | access to local variable s4 | CSharp7.cs:255:39:255:42 | {...} | semmle.label | successor |
 | CSharp7.cs:256:17:256:22 | Before break; | CSharp7.cs:256:17:256:22 | break; | semmle.label | successor |
 | CSharp7.cs:256:17:256:22 | break; | CSharp7.cs:248:9:274:9 | After switch (...) {...} | semmle.label | break |
-| CSharp7.cs:257:13:257:36 | After case ...: [match] | CSharp7.cs:257:18:257:23 | Int32 i2 | semmle.label | successor |
+| CSharp7.cs:257:13:257:36 | After case ...: [match] | CSharp7.cs:257:30:257:35 | Before ... > ... | semmle.label | successor |
 | CSharp7.cs:257:13:257:36 | After case ...: [no-match] | CSharp7.cs:260:13:260:24 | case ...: | semmle.label | successor |
-| CSharp7.cs:257:13:257:36 | case ...: | CSharp7.cs:257:13:257:36 | After case ...: [match] | semmle.label | match |
-| CSharp7.cs:257:13:257:36 | case ...: | CSharp7.cs:257:13:257:36 | After case ...: [no-match] | semmle.label | no-match |
-| CSharp7.cs:257:18:257:23 | Int32 i2 | CSharp7.cs:257:30:257:35 | Before ... > ... | semmle.label | successor |
+| CSharp7.cs:257:13:257:36 | case ...: | CSharp7.cs:257:18:257:23 | Int32 i2 | semmle.label | successor |
+| CSharp7.cs:257:18:257:23 | After Int32 i2 [match] | CSharp7.cs:257:13:257:36 | After case ...: [match] | semmle.label | match |
+| CSharp7.cs:257:18:257:23 | After Int32 i2 [no-match] | CSharp7.cs:257:13:257:36 | After case ...: [no-match] | semmle.label | no-match |
+| CSharp7.cs:257:18:257:23 | Int32 i2 | CSharp7.cs:257:18:257:23 | After Int32 i2 [match] | semmle.label | match |
+| CSharp7.cs:257:18:257:23 | Int32 i2 | CSharp7.cs:257:18:257:23 | After Int32 i2 [no-match] | semmle.label | no-match |
 | CSharp7.cs:257:30:257:31 | access to local variable i2 | CSharp7.cs:257:35:257:35 | 0 | semmle.label | successor |
 | CSharp7.cs:257:30:257:35 | ... > ... | CSharp7.cs:257:30:257:35 | After ... > ... [false] | semmle.label | false |
 | CSharp7.cs:257:30:257:35 | ... > ... | CSharp7.cs:257:30:257:35 | After ... > ... [true] | semmle.label | true |
@@ -79,11 +87,13 @@
 | CSharp7.cs:258:47:258:48 | access to local variable i2 | CSharp7.cs:258:46:258:49 | {...} | semmle.label | successor |
 | CSharp7.cs:259:17:259:22 | Before break; | CSharp7.cs:259:17:259:22 | break; | semmle.label | successor |
 | CSharp7.cs:259:17:259:22 | break; | CSharp7.cs:248:9:274:9 | After switch (...) {...} | semmle.label | break |
-| CSharp7.cs:260:13:260:24 | After case ...: [match] | CSharp7.cs:260:18:260:23 | Int32 i3 | semmle.label | successor |
+| CSharp7.cs:260:13:260:24 | After case ...: [match] | CSharp7.cs:261:17:261:47 | ...; | semmle.label | successor |
 | CSharp7.cs:260:13:260:24 | After case ...: [no-match] | CSharp7.cs:263:13:263:27 | case ...: | semmle.label | successor |
-| CSharp7.cs:260:13:260:24 | case ...: | CSharp7.cs:260:13:260:24 | After case ...: [match] | semmle.label | match |
-| CSharp7.cs:260:13:260:24 | case ...: | CSharp7.cs:260:13:260:24 | After case ...: [no-match] | semmle.label | no-match |
-| CSharp7.cs:260:18:260:23 | Int32 i3 | CSharp7.cs:261:17:261:47 | ...; | semmle.label | successor |
+| CSharp7.cs:260:13:260:24 | case ...: | CSharp7.cs:260:18:260:23 | Int32 i3 | semmle.label | successor |
+| CSharp7.cs:260:18:260:23 | After Int32 i3 [match] | CSharp7.cs:260:13:260:24 | After case ...: [match] | semmle.label | match |
+| CSharp7.cs:260:18:260:23 | After Int32 i3 [no-match] | CSharp7.cs:260:13:260:24 | After case ...: [no-match] | semmle.label | no-match |
+| CSharp7.cs:260:18:260:23 | Int32 i3 | CSharp7.cs:260:18:260:23 | After Int32 i3 [match] | semmle.label | match |
+| CSharp7.cs:260:18:260:23 | Int32 i3 | CSharp7.cs:260:18:260:23 | After Int32 i3 [no-match] | semmle.label | no-match |
 | CSharp7.cs:261:17:261:46 | After call to method WriteLine | CSharp7.cs:261:17:261:47 | After ...; | semmle.label | successor |
 | CSharp7.cs:261:17:261:46 | Before call to method WriteLine | CSharp7.cs:261:35:261:45 | Before $"..." | semmle.label | successor |
 | CSharp7.cs:261:17:261:46 | call to method WriteLine | CSharp7.cs:261:17:261:46 | After call to method WriteLine | semmle.label | successor |
@@ -99,11 +109,13 @@
 | CSharp7.cs:261:42:261:43 | access to local variable i3 | CSharp7.cs:261:41:261:44 | {...} | semmle.label | successor |
 | CSharp7.cs:262:17:262:22 | Before break; | CSharp7.cs:262:17:262:22 | break; | semmle.label | successor |
 | CSharp7.cs:262:17:262:22 | break; | CSharp7.cs:248:9:274:9 | After switch (...) {...} | semmle.label | break |
-| CSharp7.cs:263:13:263:27 | After case ...: [match] | CSharp7.cs:263:18:263:26 | String s2 | semmle.label | successor |
+| CSharp7.cs:263:13:263:27 | After case ...: [match] | CSharp7.cs:264:17:264:50 | ...; | semmle.label | successor |
 | CSharp7.cs:263:13:263:27 | After case ...: [no-match] | CSharp7.cs:266:13:266:26 | case ...: | semmle.label | successor |
-| CSharp7.cs:263:13:263:27 | case ...: | CSharp7.cs:263:13:263:27 | After case ...: [match] | semmle.label | match |
-| CSharp7.cs:263:13:263:27 | case ...: | CSharp7.cs:263:13:263:27 | After case ...: [no-match] | semmle.label | no-match |
-| CSharp7.cs:263:18:263:26 | String s2 | CSharp7.cs:264:17:264:50 | ...; | semmle.label | successor |
+| CSharp7.cs:263:13:263:27 | case ...: | CSharp7.cs:263:18:263:26 | String s2 | semmle.label | successor |
+| CSharp7.cs:263:18:263:26 | After String s2 [match] | CSharp7.cs:263:13:263:27 | After case ...: [match] | semmle.label | match |
+| CSharp7.cs:263:18:263:26 | After String s2 [no-match] | CSharp7.cs:263:13:263:27 | After case ...: [no-match] | semmle.label | no-match |
+| CSharp7.cs:263:18:263:26 | String s2 | CSharp7.cs:263:18:263:26 | After String s2 [match] | semmle.label | match |
+| CSharp7.cs:263:18:263:26 | String s2 | CSharp7.cs:263:18:263:26 | After String s2 [no-match] | semmle.label | no-match |
 | CSharp7.cs:264:17:264:49 | After call to method WriteLine | CSharp7.cs:264:17:264:50 | After ...; | semmle.label | successor |
 | CSharp7.cs:264:17:264:49 | Before call to method WriteLine | CSharp7.cs:264:35:264:48 | Before $"..." | semmle.label | successor |
 | CSharp7.cs:264:17:264:49 | call to method WriteLine | CSharp7.cs:264:17:264:49 | After call to method WriteLine | semmle.label | successor |
@@ -119,11 +131,13 @@
 | CSharp7.cs:264:45:264:46 | access to local variable s2 | CSharp7.cs:264:44:264:47 | {...} | semmle.label | successor |
 | CSharp7.cs:265:17:265:22 | Before break; | CSharp7.cs:265:17:265:22 | break; | semmle.label | successor |
 | CSharp7.cs:265:17:265:22 | break; | CSharp7.cs:248:9:274:9 | After switch (...) {...} | semmle.label | break |
-| CSharp7.cs:266:13:266:26 | After case ...: [match] | CSharp7.cs:266:18:266:23 | access to type Double | semmle.label | successor |
+| CSharp7.cs:266:13:266:26 | After case ...: [match] | CSharp7.cs:267:17:267:44 | ...; | semmle.label | successor |
 | CSharp7.cs:266:13:266:26 | After case ...: [no-match] | CSharp7.cs:269:13:269:24 | case ...: | semmle.label | successor |
-| CSharp7.cs:266:13:266:26 | case ...: | CSharp7.cs:266:13:266:26 | After case ...: [match] | semmle.label | match |
-| CSharp7.cs:266:13:266:26 | case ...: | CSharp7.cs:266:13:266:26 | After case ...: [no-match] | semmle.label | no-match |
-| CSharp7.cs:266:18:266:23 | access to type Double | CSharp7.cs:267:17:267:44 | ...; | semmle.label | successor |
+| CSharp7.cs:266:13:266:26 | case ...: | CSharp7.cs:266:18:266:23 | access to type Double | semmle.label | successor |
+| CSharp7.cs:266:18:266:23 | After access to type Double [match] | CSharp7.cs:266:13:266:26 | After case ...: [match] | semmle.label | match |
+| CSharp7.cs:266:18:266:23 | After access to type Double [no-match] | CSharp7.cs:266:13:266:26 | After case ...: [no-match] | semmle.label | no-match |
+| CSharp7.cs:266:18:266:23 | access to type Double | CSharp7.cs:266:18:266:23 | After access to type Double [match] | semmle.label | match |
+| CSharp7.cs:266:18:266:23 | access to type Double | CSharp7.cs:266:18:266:23 | After access to type Double [no-match] | semmle.label | no-match |
 | CSharp7.cs:267:17:267:43 | After call to method WriteLine | CSharp7.cs:267:17:267:44 | After ...; | semmle.label | successor |
 | CSharp7.cs:267:17:267:43 | Before call to method WriteLine | CSharp7.cs:267:35:267:42 | "Double" | semmle.label | successor |
 | CSharp7.cs:267:17:267:43 | call to method WriteLine | CSharp7.cs:267:17:267:43 | After call to method WriteLine | semmle.label | successor |
@@ -132,11 +146,13 @@
 | CSharp7.cs:267:35:267:42 | "Double" | CSharp7.cs:267:17:267:43 | call to method WriteLine | semmle.label | successor |
 | CSharp7.cs:268:17:268:22 | Before break; | CSharp7.cs:268:17:268:22 | break; | semmle.label | successor |
 | CSharp7.cs:268:17:268:22 | break; | CSharp7.cs:248:9:274:9 | After switch (...) {...} | semmle.label | break |
-| CSharp7.cs:269:13:269:24 | After case ...: [match] | CSharp7.cs:269:18:269:23 | Object v2 | semmle.label | successor |
+| CSharp7.cs:269:13:269:24 | After case ...: [match] | CSharp7.cs:270:17:270:22 | Before break; | semmle.label | successor |
 | CSharp7.cs:269:13:269:24 | After case ...: [no-match] | CSharp7.cs:271:13:271:20 | default: | semmle.label | successor |
-| CSharp7.cs:269:13:269:24 | case ...: | CSharp7.cs:269:13:269:24 | After case ...: [match] | semmle.label | match |
-| CSharp7.cs:269:13:269:24 | case ...: | CSharp7.cs:269:13:269:24 | After case ...: [no-match] | semmle.label | no-match |
-| CSharp7.cs:269:18:269:23 | Object v2 | CSharp7.cs:270:17:270:22 | Before break; | semmle.label | successor |
+| CSharp7.cs:269:13:269:24 | case ...: | CSharp7.cs:269:18:269:23 | Object v2 | semmle.label | successor |
+| CSharp7.cs:269:18:269:23 | After Object v2 [match] | CSharp7.cs:269:13:269:24 | After case ...: [match] | semmle.label | match |
+| CSharp7.cs:269:18:269:23 | After Object v2 [no-match] | CSharp7.cs:269:13:269:24 | After case ...: [no-match] | semmle.label | no-match |
+| CSharp7.cs:269:18:269:23 | Object v2 | CSharp7.cs:269:18:269:23 | After Object v2 [match] | semmle.label | match |
+| CSharp7.cs:269:18:269:23 | Object v2 | CSharp7.cs:269:18:269:23 | After Object v2 [no-match] | semmle.label | no-match |
 | CSharp7.cs:270:17:270:22 | Before break; | CSharp7.cs:270:17:270:22 | break; | semmle.label | successor |
 | CSharp7.cs:270:17:270:22 | break; | CSharp7.cs:248:9:274:9 | After switch (...) {...} | semmle.label | break |
 | CSharp7.cs:271:13:271:20 | After default: [match] | CSharp7.cs:272:17:272:52 | ...; | semmle.label | successor |

--- a/csharp/ql/test/library-tests/csharp8/switchexprcontrolflow.expected
+++ b/csharp/ql/test/library-tests/csharp8/switchexprcontrolflow.expected
@@ -12,10 +12,12 @@
 | patterns.cs:100:20:100:20 | access to parameter x | patterns.cs:101:13:101:40 | ... => ... | semmle.label | successor |
 | patterns.cs:100:20:103:9 | ... switch { ... } | patterns.cs:100:20:100:20 | access to parameter x | semmle.label | successor |
 | patterns.cs:100:20:103:9 | After ... switch { ... } | patterns.cs:100:13:103:9 | String size = ... | semmle.label | successor |
-| patterns.cs:101:13:101:17 | Int32 y | patterns.cs:101:24:101:29 | Before ... > ... | semmle.label | successor |
-| patterns.cs:101:13:101:40 | ... => ... | patterns.cs:101:13:101:40 | After ... => ... [match] | semmle.label | match |
-| patterns.cs:101:13:101:40 | ... => ... | patterns.cs:101:13:101:40 | After ... => ... [no-match] | semmle.label | no-match |
-| patterns.cs:101:13:101:40 | After ... => ... [match] | patterns.cs:101:13:101:17 | Int32 y | semmle.label | successor |
+| patterns.cs:101:13:101:17 | After Int32 y [match] | patterns.cs:101:13:101:40 | After ... => ... [match] | semmle.label | match |
+| patterns.cs:101:13:101:17 | After Int32 y [no-match] | patterns.cs:101:13:101:40 | After ... => ... [no-match] | semmle.label | no-match |
+| patterns.cs:101:13:101:17 | Int32 y | patterns.cs:101:13:101:17 | After Int32 y [match] | semmle.label | match |
+| patterns.cs:101:13:101:17 | Int32 y | patterns.cs:101:13:101:17 | After Int32 y [no-match] | semmle.label | no-match |
+| patterns.cs:101:13:101:40 | ... => ... | patterns.cs:101:13:101:17 | Int32 y | semmle.label | successor |
+| patterns.cs:101:13:101:40 | After ... => ... [match] | patterns.cs:101:24:101:29 | Before ... > ... | semmle.label | successor |
 | patterns.cs:101:13:101:40 | After ... => ... [no-match] | patterns.cs:102:13:102:24 | ... => ... | semmle.label | successor |
 | patterns.cs:101:24:101:24 | access to local variable y | patterns.cs:101:28:101:29 | 10 | semmle.label | successor |
 | patterns.cs:101:24:101:29 | ... > ... | patterns.cs:101:24:101:29 | After ... > ... [false] | semmle.label | false |
@@ -25,9 +27,10 @@
 | patterns.cs:101:24:101:29 | Before ... > ... | patterns.cs:101:24:101:24 | access to local variable y | semmle.label | successor |
 | patterns.cs:101:28:101:29 | 10 | patterns.cs:101:24:101:29 | ... > ... | semmle.label | successor |
 | patterns.cs:101:34:101:40 | "large" | patterns.cs:100:20:103:9 | After ... switch { ... } | semmle.label | successor |
-| patterns.cs:102:13:102:13 | _ | patterns.cs:102:18:102:24 | "small" | semmle.label | successor |
-| patterns.cs:102:13:102:24 | ... => ... | patterns.cs:102:13:102:24 | After ... => ... [match] | semmle.label | match |
-| patterns.cs:102:13:102:24 | After ... => ... [match] | patterns.cs:102:13:102:13 | _ | semmle.label | successor |
+| patterns.cs:102:13:102:13 | After _ [match] | patterns.cs:102:13:102:24 | After ... => ... [match] | semmle.label | match |
+| patterns.cs:102:13:102:13 | _ | patterns.cs:102:13:102:13 | After _ [match] | semmle.label | match |
+| patterns.cs:102:13:102:24 | ... => ... | patterns.cs:102:13:102:13 | _ | semmle.label | successor |
+| patterns.cs:102:13:102:24 | After ... => ... [match] | patterns.cs:102:18:102:24 | "small" | semmle.label | successor |
 | patterns.cs:102:18:102:24 | "small" | patterns.cs:100:20:103:9 | After ... switch { ... } | semmle.label | successor |
 | patterns.cs:105:9:105:27 | ... ...; | patterns.cs:105:13:105:18 | Before Int32 x0 = ... | semmle.label | successor |
 | patterns.cs:105:9:105:27 | After ... ...; | patterns.cs:108:9:112:10 | ...; | semmle.label | successor |
@@ -60,13 +63,14 @@
 | patterns.cs:108:29:108:30 | access to local variable y0 | patterns.cs:108:24:108:31 | (..., ...) | semmle.label | successor |
 | patterns.cs:110:13:110:17 | ( ... ) | patterns.cs:110:13:110:17 | After ( ... ) | semmle.label | successor |
 | patterns.cs:110:13:110:17 | After ( ... ) | patterns.cs:110:13:110:17 | { ... } | semmle.label | successor |
-| patterns.cs:110:13:110:17 | After { ... } | patterns.cs:110:22:110:26 | Before (..., ...) | semmle.label | successor |
+| patterns.cs:110:13:110:17 | After { ... } [match] | patterns.cs:110:13:110:26 | After ... => ... [match] | semmle.label | match |
+| patterns.cs:110:13:110:17 | After { ... } [no-match] | patterns.cs:110:13:110:26 | After ... => ... [no-match] | semmle.label | no-match |
 | patterns.cs:110:13:110:17 | Before ( ... ) | patterns.cs:110:14:110:14 | 0 | semmle.label | successor |
 | patterns.cs:110:13:110:17 | Before { ... } | patterns.cs:110:13:110:17 | Before ( ... ) | semmle.label | successor |
-| patterns.cs:110:13:110:17 | { ... } | patterns.cs:110:13:110:17 | After { ... } | semmle.label | successor |
-| patterns.cs:110:13:110:26 | ... => ... | patterns.cs:110:13:110:26 | After ... => ... [match] | semmle.label | match |
-| patterns.cs:110:13:110:26 | ... => ... | patterns.cs:110:13:110:26 | After ... => ... [no-match] | semmle.label | no-match |
-| patterns.cs:110:13:110:26 | After ... => ... [match] | patterns.cs:110:13:110:17 | Before { ... } | semmle.label | successor |
+| patterns.cs:110:13:110:17 | { ... } | patterns.cs:110:13:110:17 | After { ... } [match] | semmle.label | match |
+| patterns.cs:110:13:110:17 | { ... } | patterns.cs:110:13:110:17 | After { ... } [no-match] | semmle.label | no-match |
+| patterns.cs:110:13:110:26 | ... => ... | patterns.cs:110:13:110:17 | Before { ... } | semmle.label | successor |
+| patterns.cs:110:13:110:26 | After ... => ... [match] | patterns.cs:110:22:110:26 | Before (..., ...) | semmle.label | successor |
 | patterns.cs:110:13:110:26 | After ... => ... [no-match] | patterns.cs:111:13:111:26 | ... => ... | semmle.label | successor |
 | patterns.cs:110:14:110:14 | 0 | patterns.cs:110:16:110:16 | 1 | semmle.label | successor |
 | patterns.cs:110:16:110:16 | 1 | patterns.cs:110:13:110:17 | ( ... ) | semmle.label | successor |
@@ -77,13 +81,14 @@
 | patterns.cs:110:25:110:25 | 0 | patterns.cs:110:22:110:26 | (..., ...) | semmle.label | successor |
 | patterns.cs:111:13:111:17 | ( ... ) | patterns.cs:111:13:111:17 | After ( ... ) | semmle.label | successor |
 | patterns.cs:111:13:111:17 | After ( ... ) | patterns.cs:111:13:111:17 | { ... } | semmle.label | successor |
-| patterns.cs:111:13:111:17 | After { ... } | patterns.cs:111:22:111:26 | Before (..., ...) | semmle.label | successor |
+| patterns.cs:111:13:111:17 | After { ... } [match] | patterns.cs:111:13:111:26 | After ... => ... [match] | semmle.label | match |
+| patterns.cs:111:13:111:17 | After { ... } [no-match] | patterns.cs:111:13:111:26 | After ... => ... [no-match] | semmle.label | no-match |
 | patterns.cs:111:13:111:17 | Before ( ... ) | patterns.cs:111:14:111:14 | 1 | semmle.label | successor |
 | patterns.cs:111:13:111:17 | Before { ... } | patterns.cs:111:13:111:17 | Before ( ... ) | semmle.label | successor |
-| patterns.cs:111:13:111:17 | { ... } | patterns.cs:111:13:111:17 | After { ... } | semmle.label | successor |
-| patterns.cs:111:13:111:26 | ... => ... | patterns.cs:111:13:111:26 | After ... => ... [match] | semmle.label | match |
-| patterns.cs:111:13:111:26 | ... => ... | patterns.cs:111:13:111:26 | After ... => ... [no-match] | semmle.label | no-match |
-| patterns.cs:111:13:111:26 | After ... => ... [match] | patterns.cs:111:13:111:17 | Before { ... } | semmle.label | successor |
+| patterns.cs:111:13:111:17 | { ... } | patterns.cs:111:13:111:17 | After { ... } [match] | semmle.label | match |
+| patterns.cs:111:13:111:17 | { ... } | patterns.cs:111:13:111:17 | After { ... } [no-match] | semmle.label | no-match |
+| patterns.cs:111:13:111:26 | ... => ... | patterns.cs:111:13:111:17 | Before { ... } | semmle.label | successor |
+| patterns.cs:111:13:111:26 | After ... => ... [match] | patterns.cs:111:22:111:26 | Before (..., ...) | semmle.label | successor |
 | patterns.cs:111:13:111:26 | After ... => ... [no-match] | patterns.cs:108:24:112:9 | After ... switch { ... } | semmle.label | successor |
 | patterns.cs:111:14:111:14 | 1 | patterns.cs:111:16:111:16 | 0 | semmle.label | successor |
 | patterns.cs:111:16:111:16 | 0 | patterns.cs:111:13:111:17 | ( ... ) | semmle.label | successor |
@@ -111,13 +116,14 @@
 | patterns.cs:115:25:115:26 | access to local variable y0 | patterns.cs:115:20:115:27 | (..., ...) | semmle.label | successor |
 | patterns.cs:117:13:117:22 | ( ... ) | patterns.cs:117:13:117:22 | After ( ... ) | semmle.label | successor |
 | patterns.cs:117:13:117:22 | After ( ... ) | patterns.cs:117:13:117:22 | { ... } | semmle.label | successor |
-| patterns.cs:117:13:117:22 | After { ... } | patterns.cs:117:27:117:33 | Before (..., ...) | semmle.label | successor |
+| patterns.cs:117:13:117:22 | After { ... } [match] | patterns.cs:117:13:117:33 | After ... => ... [match] | semmle.label | match |
+| patterns.cs:117:13:117:22 | After { ... } [no-match] | patterns.cs:117:13:117:33 | After ... => ... [no-match] | semmle.label | no-match |
 | patterns.cs:117:13:117:22 | Before ( ... ) | patterns.cs:117:14:117:14 | 0 | semmle.label | successor |
 | patterns.cs:117:13:117:22 | Before { ... } | patterns.cs:117:13:117:22 | Before ( ... ) | semmle.label | successor |
-| patterns.cs:117:13:117:22 | { ... } | patterns.cs:117:13:117:22 | After { ... } | semmle.label | successor |
-| patterns.cs:117:13:117:33 | ... => ... | patterns.cs:117:13:117:33 | After ... => ... [match] | semmle.label | match |
-| patterns.cs:117:13:117:33 | ... => ... | patterns.cs:117:13:117:33 | After ... => ... [no-match] | semmle.label | no-match |
-| patterns.cs:117:13:117:33 | After ... => ... [match] | patterns.cs:117:13:117:22 | Before { ... } | semmle.label | successor |
+| patterns.cs:117:13:117:22 | { ... } | patterns.cs:117:13:117:22 | After { ... } [match] | semmle.label | match |
+| patterns.cs:117:13:117:22 | { ... } | patterns.cs:117:13:117:22 | After { ... } [no-match] | semmle.label | no-match |
+| patterns.cs:117:13:117:33 | ... => ... | patterns.cs:117:13:117:22 | Before { ... } | semmle.label | successor |
+| patterns.cs:117:13:117:33 | After ... => ... [match] | patterns.cs:117:27:117:33 | Before (..., ...) | semmle.label | successor |
 | patterns.cs:117:13:117:33 | After ... => ... [no-match] | patterns.cs:118:13:118:34 | ... => ... | semmle.label | successor |
 | patterns.cs:117:14:117:14 | 0 | patterns.cs:117:16:117:21 | Int32 y2 | semmle.label | successor |
 | patterns.cs:117:16:117:21 | Int32 y2 | patterns.cs:117:13:117:22 | ( ... ) | semmle.label | successor |
@@ -128,13 +134,14 @@
 | patterns.cs:117:32:117:32 | 0 | patterns.cs:117:27:117:33 | (..., ...) | semmle.label | successor |
 | patterns.cs:118:13:118:23 | ( ... ) | patterns.cs:118:13:118:23 | After ( ... ) | semmle.label | successor |
 | patterns.cs:118:13:118:23 | After ( ... ) | patterns.cs:118:13:118:23 | { ... } | semmle.label | successor |
-| patterns.cs:118:13:118:23 | After { ... } | patterns.cs:118:28:118:34 | Before (..., ...) | semmle.label | successor |
+| patterns.cs:118:13:118:23 | After { ... } [match] | patterns.cs:118:13:118:34 | After ... => ... [match] | semmle.label | match |
+| patterns.cs:118:13:118:23 | After { ... } [no-match] | patterns.cs:118:13:118:34 | After ... => ... [no-match] | semmle.label | no-match |
 | patterns.cs:118:13:118:23 | Before ( ... ) | patterns.cs:118:14:118:19 | Int32 x2 | semmle.label | successor |
 | patterns.cs:118:13:118:23 | Before { ... } | patterns.cs:118:13:118:23 | Before ( ... ) | semmle.label | successor |
-| patterns.cs:118:13:118:23 | { ... } | patterns.cs:118:13:118:23 | After { ... } | semmle.label | successor |
-| patterns.cs:118:13:118:34 | ... => ... | patterns.cs:118:13:118:34 | After ... => ... [match] | semmle.label | match |
-| patterns.cs:118:13:118:34 | ... => ... | patterns.cs:118:13:118:34 | After ... => ... [no-match] | semmle.label | no-match |
-| patterns.cs:118:13:118:34 | After ... => ... [match] | patterns.cs:118:13:118:23 | Before { ... } | semmle.label | successor |
+| patterns.cs:118:13:118:23 | { ... } | patterns.cs:118:13:118:23 | After { ... } [match] | semmle.label | match |
+| patterns.cs:118:13:118:23 | { ... } | patterns.cs:118:13:118:23 | After { ... } [no-match] | semmle.label | no-match |
+| patterns.cs:118:13:118:34 | ... => ... | patterns.cs:118:13:118:23 | Before { ... } | semmle.label | successor |
+| patterns.cs:118:13:118:34 | After ... => ... [match] | patterns.cs:118:28:118:34 | Before (..., ...) | semmle.label | successor |
 | patterns.cs:118:13:118:34 | After ... => ... [no-match] | patterns.cs:119:13:119:38 | ... => ... | semmle.label | successor |
 | patterns.cs:118:14:118:19 | Int32 x2 | patterns.cs:118:22:118:22 | 0 | semmle.label | successor |
 | patterns.cs:118:22:118:22 | 0 | patterns.cs:118:13:118:23 | ( ... ) | semmle.label | successor |
@@ -145,13 +152,14 @@
 | patterns.cs:118:32:118:33 | access to local variable x2 | patterns.cs:118:28:118:34 | (..., ...) | semmle.label | successor |
 | patterns.cs:119:13:119:28 | ( ... ) | patterns.cs:119:13:119:28 | After ( ... ) | semmle.label | successor |
 | patterns.cs:119:13:119:28 | After ( ... ) | patterns.cs:119:13:119:28 | { ... } | semmle.label | successor |
-| patterns.cs:119:13:119:28 | After { ... } | patterns.cs:119:33:119:38 | Before (..., ...) | semmle.label | successor |
+| patterns.cs:119:13:119:28 | After { ... } [match] | patterns.cs:119:13:119:38 | After ... => ... [match] | semmle.label | match |
+| patterns.cs:119:13:119:28 | After { ... } [no-match] | patterns.cs:119:13:119:38 | After ... => ... [no-match] | semmle.label | no-match |
 | patterns.cs:119:13:119:28 | Before ( ... ) | patterns.cs:119:14:119:19 | Int32 x2 | semmle.label | successor |
 | patterns.cs:119:13:119:28 | Before { ... } | patterns.cs:119:13:119:28 | Before ( ... ) | semmle.label | successor |
-| patterns.cs:119:13:119:28 | { ... } | patterns.cs:119:13:119:28 | After { ... } | semmle.label | successor |
-| patterns.cs:119:13:119:38 | ... => ... | patterns.cs:119:13:119:38 | After ... => ... [match] | semmle.label | match |
-| patterns.cs:119:13:119:38 | ... => ... | patterns.cs:119:13:119:38 | After ... => ... [no-match] | semmle.label | no-match |
-| patterns.cs:119:13:119:38 | After ... => ... [match] | patterns.cs:119:13:119:28 | Before { ... } | semmle.label | successor |
+| patterns.cs:119:13:119:28 | { ... } | patterns.cs:119:13:119:28 | After { ... } [match] | semmle.label | match |
+| patterns.cs:119:13:119:28 | { ... } | patterns.cs:119:13:119:28 | After { ... } [no-match] | semmle.label | no-match |
+| patterns.cs:119:13:119:38 | ... => ... | patterns.cs:119:13:119:28 | Before { ... } | semmle.label | successor |
+| patterns.cs:119:13:119:38 | After ... => ... [match] | patterns.cs:119:33:119:38 | Before (..., ...) | semmle.label | successor |
 | patterns.cs:119:13:119:38 | After ... => ... [no-match] | patterns.cs:115:20:120:9 | After ... switch { ... } | semmle.label | successor |
 | patterns.cs:119:14:119:19 | Int32 x2 | patterns.cs:119:22:119:27 | Int32 y2 | semmle.label | successor |
 | patterns.cs:119:22:119:27 | Int32 y2 | patterns.cs:119:13:119:28 | ( ... ) | semmle.label | successor |
@@ -193,12 +201,13 @@
 | patterns.cs:126:17:132:9 | ... switch { ... } | patterns.cs:126:17:126:17 | access to local variable s | semmle.label | successor |
 | patterns.cs:126:17:132:9 | After ... switch { ... } | patterns.cs:126:13:132:9 | Int32 r = ... | semmle.label | successor |
 | patterns.cs:128:13:128:20 | access to type MyStruct | patterns.cs:128:22:128:33 | Before { ... } | semmle.label | successor |
-| patterns.cs:128:13:128:33 | After { ... } | patterns.cs:128:40:128:44 | Before ... > ... | semmle.label | successor |
+| patterns.cs:128:13:128:33 | After { ... } [match] | patterns.cs:128:13:128:49 | After ... => ... [match] | semmle.label | match |
+| patterns.cs:128:13:128:33 | After { ... } [no-match] | patterns.cs:128:13:128:49 | After ... => ... [no-match] | semmle.label | no-match |
 | patterns.cs:128:13:128:33 | Before { ... } | patterns.cs:128:13:128:20 | access to type MyStruct | semmle.label | successor |
-| patterns.cs:128:13:128:33 | { ... } | patterns.cs:128:13:128:33 | After { ... } | semmle.label | successor |
-| patterns.cs:128:13:128:49 | ... => ... | patterns.cs:128:13:128:49 | After ... => ... [match] | semmle.label | match |
-| patterns.cs:128:13:128:49 | ... => ... | patterns.cs:128:13:128:49 | After ... => ... [no-match] | semmle.label | no-match |
-| patterns.cs:128:13:128:49 | After ... => ... [match] | patterns.cs:128:13:128:33 | Before { ... } | semmle.label | successor |
+| patterns.cs:128:13:128:33 | { ... } | patterns.cs:128:13:128:33 | After { ... } [match] | semmle.label | match |
+| patterns.cs:128:13:128:33 | { ... } | patterns.cs:128:13:128:33 | After { ... } [no-match] | semmle.label | no-match |
+| patterns.cs:128:13:128:49 | ... => ... | patterns.cs:128:13:128:33 | Before { ... } | semmle.label | successor |
+| patterns.cs:128:13:128:49 | After ... => ... [match] | patterns.cs:128:40:128:44 | Before ... > ... | semmle.label | successor |
 | patterns.cs:128:13:128:49 | After ... => ... [no-match] | patterns.cs:129:13:129:38 | ... => ... | semmle.label | successor |
 | patterns.cs:128:22:128:33 | After { ... } | patterns.cs:128:13:128:33 | { ... } | semmle.label | successor |
 | patterns.cs:128:22:128:33 | Before { ... } | patterns.cs:128:27:128:31 | Int32 x | semmle.label | successor |
@@ -213,13 +222,14 @@
 | patterns.cs:128:44:128:44 | 2 | patterns.cs:128:40:128:44 | ... > ... | semmle.label | successor |
 | patterns.cs:128:49:128:49 | 0 | patterns.cs:126:17:132:9 | After ... switch { ... } | semmle.label | successor |
 | patterns.cs:129:13:129:20 | access to type MyStruct | patterns.cs:129:22:129:30 | Before { ... } | semmle.label | successor |
-| patterns.cs:129:13:129:33 | After { ... } | patterns.cs:129:38:129:38 | 1 | semmle.label | successor |
+| patterns.cs:129:13:129:33 | After { ... } [match] | patterns.cs:129:13:129:38 | After ... => ... [match] | semmle.label | match |
+| patterns.cs:129:13:129:33 | After { ... } [no-match] | patterns.cs:129:13:129:38 | After ... => ... [no-match] | semmle.label | no-match |
 | patterns.cs:129:13:129:33 | Before { ... } | patterns.cs:129:13:129:33 | MyStruct ms | semmle.label | successor |
 | patterns.cs:129:13:129:33 | MyStruct ms | patterns.cs:129:13:129:20 | access to type MyStruct | semmle.label | successor |
-| patterns.cs:129:13:129:33 | { ... } | patterns.cs:129:13:129:33 | After { ... } | semmle.label | successor |
-| patterns.cs:129:13:129:38 | ... => ... | patterns.cs:129:13:129:38 | After ... => ... [match] | semmle.label | match |
-| patterns.cs:129:13:129:38 | ... => ... | patterns.cs:129:13:129:38 | After ... => ... [no-match] | semmle.label | no-match |
-| patterns.cs:129:13:129:38 | After ... => ... [match] | patterns.cs:129:13:129:33 | Before { ... } | semmle.label | successor |
+| patterns.cs:129:13:129:33 | { ... } | patterns.cs:129:13:129:33 | After { ... } [match] | semmle.label | match |
+| patterns.cs:129:13:129:33 | { ... } | patterns.cs:129:13:129:33 | After { ... } [no-match] | semmle.label | no-match |
+| patterns.cs:129:13:129:38 | ... => ... | patterns.cs:129:13:129:33 | Before { ... } | semmle.label | successor |
+| patterns.cs:129:13:129:38 | After ... => ... [match] | patterns.cs:129:38:129:38 | 1 | semmle.label | successor |
 | patterns.cs:129:13:129:38 | After ... => ... [no-match] | patterns.cs:130:13:130:23 | ... => ... | semmle.label | successor |
 | patterns.cs:129:22:129:30 | After { ... } | patterns.cs:129:13:129:33 | { ... } | semmle.label | successor |
 | patterns.cs:129:22:129:30 | Before { ... } | patterns.cs:129:27:129:28 | 10 | semmle.label | successor |
@@ -228,23 +238,25 @@
 | patterns.cs:129:38:129:38 | 1 | patterns.cs:126:17:132:9 | After ... switch { ... } | semmle.label | successor |
 | patterns.cs:130:13:130:18 | ( ... ) | patterns.cs:130:13:130:18 | After ( ... ) | semmle.label | successor |
 | patterns.cs:130:13:130:18 | After ( ... ) | patterns.cs:130:13:130:18 | { ... } | semmle.label | successor |
-| patterns.cs:130:13:130:18 | After { ... } | patterns.cs:130:23:130:23 | 2 | semmle.label | successor |
+| patterns.cs:130:13:130:18 | After { ... } [match] | patterns.cs:130:13:130:23 | After ... => ... [match] | semmle.label | match |
+| patterns.cs:130:13:130:18 | After { ... } [no-match] | patterns.cs:130:13:130:23 | After ... => ... [no-match] | semmle.label | no-match |
 | patterns.cs:130:13:130:18 | Before ( ... ) | patterns.cs:130:14:130:14 | 1 | semmle.label | successor |
 | patterns.cs:130:13:130:18 | Before { ... } | patterns.cs:130:13:130:18 | Before ( ... ) | semmle.label | successor |
-| patterns.cs:130:13:130:18 | { ... } | patterns.cs:130:13:130:18 | After { ... } | semmle.label | successor |
-| patterns.cs:130:13:130:23 | ... => ... | patterns.cs:130:13:130:23 | After ... => ... [match] | semmle.label | match |
-| patterns.cs:130:13:130:23 | ... => ... | patterns.cs:130:13:130:23 | After ... => ... [no-match] | semmle.label | no-match |
-| patterns.cs:130:13:130:23 | After ... => ... [match] | patterns.cs:130:13:130:18 | Before { ... } | semmle.label | successor |
+| patterns.cs:130:13:130:18 | { ... } | patterns.cs:130:13:130:18 | After { ... } [match] | semmle.label | match |
+| patterns.cs:130:13:130:18 | { ... } | patterns.cs:130:13:130:18 | After { ... } [no-match] | semmle.label | no-match |
+| patterns.cs:130:13:130:23 | ... => ... | patterns.cs:130:13:130:18 | Before { ... } | semmle.label | successor |
+| patterns.cs:130:13:130:23 | After ... => ... [match] | patterns.cs:130:23:130:23 | 2 | semmle.label | successor |
 | patterns.cs:130:13:130:23 | After ... => ... [no-match] | patterns.cs:131:13:131:27 | ... => ... | semmle.label | successor |
 | patterns.cs:130:14:130:14 | 1 | patterns.cs:130:17:130:17 | 2 | semmle.label | successor |
 | patterns.cs:130:17:130:17 | 2 | patterns.cs:130:13:130:18 | ( ... ) | semmle.label | successor |
 | patterns.cs:130:23:130:23 | 2 | patterns.cs:126:17:132:9 | After ... switch { ... } | semmle.label | successor |
-| patterns.cs:131:13:131:22 | (..., ...) | patterns.cs:131:13:131:22 | After (..., ...) | semmle.label | successor |
-| patterns.cs:131:13:131:22 | After (..., ...) | patterns.cs:131:27:131:27 | 3 | semmle.label | successor |
+| patterns.cs:131:13:131:22 | (..., ...) | patterns.cs:131:13:131:22 | After (..., ...) [match] | semmle.label | match |
+| patterns.cs:131:13:131:22 | (..., ...) | patterns.cs:131:13:131:22 | After (..., ...) [no-match] | semmle.label | no-match |
+| patterns.cs:131:13:131:22 | After (..., ...) [match] | patterns.cs:131:13:131:27 | After ... => ... [match] | semmle.label | match |
+| patterns.cs:131:13:131:22 | After (..., ...) [no-match] | patterns.cs:131:13:131:27 | After ... => ... [no-match] | semmle.label | no-match |
 | patterns.cs:131:13:131:22 | Before (..., ...) | patterns.cs:131:18:131:18 | Int32 x | semmle.label | successor |
-| patterns.cs:131:13:131:27 | ... => ... | patterns.cs:131:13:131:27 | After ... => ... [match] | semmle.label | match |
-| patterns.cs:131:13:131:27 | ... => ... | patterns.cs:131:13:131:27 | After ... => ... [no-match] | semmle.label | no-match |
-| patterns.cs:131:13:131:27 | After ... => ... [match] | patterns.cs:131:13:131:22 | Before (..., ...) | semmle.label | successor |
+| patterns.cs:131:13:131:27 | ... => ... | patterns.cs:131:13:131:22 | Before (..., ...) | semmle.label | successor |
+| patterns.cs:131:13:131:27 | After ... => ... [match] | patterns.cs:131:27:131:27 | 3 | semmle.label | successor |
 | patterns.cs:131:13:131:27 | After ... => ... [no-match] | patterns.cs:126:17:132:9 | After ... switch { ... } | semmle.label | successor |
 | patterns.cs:131:18:131:18 | Int32 x | patterns.cs:131:21:131:21 | _ | semmle.label | successor |
 | patterns.cs:131:21:131:21 | _ | patterns.cs:131:13:131:22 | (..., ...) | semmle.label | successor |
@@ -262,10 +274,12 @@
 | patterns.cs:136:17:136:17 | access to parameter o | patterns.cs:138:17:138:50 | ... => ... | semmle.label | successor |
 | patterns.cs:136:17:143:13 | ... switch { ... } | patterns.cs:136:17:136:17 | access to parameter o | semmle.label | successor |
 | patterns.cs:136:17:143:13 | After ... switch { ... } | patterns.cs:136:13:143:13 | ... = ... | semmle.label | successor |
-| patterns.cs:138:17:138:17 | 1 | patterns.cs:138:22:138:50 | Before throw ... | semmle.label | successor |
-| patterns.cs:138:17:138:50 | ... => ... | patterns.cs:138:17:138:50 | After ... => ... [match] | semmle.label | match |
-| patterns.cs:138:17:138:50 | ... => ... | patterns.cs:138:17:138:50 | After ... => ... [no-match] | semmle.label | no-match |
-| patterns.cs:138:17:138:50 | After ... => ... [match] | patterns.cs:138:17:138:17 | 1 | semmle.label | successor |
+| patterns.cs:138:17:138:17 | 1 | patterns.cs:138:17:138:17 | After 1 [match] | semmle.label | match |
+| patterns.cs:138:17:138:17 | 1 | patterns.cs:138:17:138:17 | After 1 [no-match] | semmle.label | no-match |
+| patterns.cs:138:17:138:17 | After 1 [match] | patterns.cs:138:17:138:50 | After ... => ... [match] | semmle.label | match |
+| patterns.cs:138:17:138:17 | After 1 [no-match] | patterns.cs:138:17:138:50 | After ... => ... [no-match] | semmle.label | no-match |
+| patterns.cs:138:17:138:50 | ... => ... | patterns.cs:138:17:138:17 | 1 | semmle.label | successor |
+| patterns.cs:138:17:138:50 | After ... => ... [match] | patterns.cs:138:22:138:50 | Before throw ... | semmle.label | successor |
 | patterns.cs:138:17:138:50 | After ... => ... [no-match] | patterns.cs:139:17:139:22 | ... => ... | semmle.label | successor |
 | patterns.cs:138:22:138:50 | Before throw ... | patterns.cs:138:28:138:50 | Before object creation of type ArgumentException | semmle.label | successor |
 | patterns.cs:138:22:138:50 | throw ... | patterns.cs:145:9:148:9 | catch (...) {...} | semmle.label | exception |
@@ -273,16 +287,20 @@
 | patterns.cs:138:28:138:50 | Before object creation of type ArgumentException | patterns.cs:138:28:138:50 | object creation of type ArgumentException | semmle.label | successor |
 | patterns.cs:138:28:138:50 | object creation of type ArgumentException | patterns.cs:138:28:138:50 | After object creation of type ArgumentException | semmle.label | successor |
 | patterns.cs:138:28:138:50 | object creation of type ArgumentException | patterns.cs:145:9:148:9 | catch (...) {...} | semmle.label | exception |
-| patterns.cs:139:17:139:17 | 2 | patterns.cs:139:22:139:22 | 3 | semmle.label | successor |
-| patterns.cs:139:17:139:22 | ... => ... | patterns.cs:139:17:139:22 | After ... => ... [match] | semmle.label | match |
-| patterns.cs:139:17:139:22 | ... => ... | patterns.cs:139:17:139:22 | After ... => ... [no-match] | semmle.label | no-match |
-| patterns.cs:139:17:139:22 | After ... => ... [match] | patterns.cs:139:17:139:17 | 2 | semmle.label | successor |
+| patterns.cs:139:17:139:17 | 2 | patterns.cs:139:17:139:17 | After 2 [match] | semmle.label | match |
+| patterns.cs:139:17:139:17 | 2 | patterns.cs:139:17:139:17 | After 2 [no-match] | semmle.label | no-match |
+| patterns.cs:139:17:139:17 | After 2 [match] | patterns.cs:139:17:139:22 | After ... => ... [match] | semmle.label | match |
+| patterns.cs:139:17:139:17 | After 2 [no-match] | patterns.cs:139:17:139:22 | After ... => ... [no-match] | semmle.label | no-match |
+| patterns.cs:139:17:139:22 | ... => ... | patterns.cs:139:17:139:17 | 2 | semmle.label | successor |
+| patterns.cs:139:17:139:22 | After ... => ... [match] | patterns.cs:139:22:139:22 | 3 | semmle.label | successor |
 | patterns.cs:139:17:139:22 | After ... => ... [no-match] | patterns.cs:140:17:140:42 | ... => ... | semmle.label | successor |
 | patterns.cs:139:22:139:22 | 3 | patterns.cs:136:17:143:13 | After ... switch { ... } | semmle.label | successor |
-| patterns.cs:140:17:140:24 | Object y | patterns.cs:140:31:140:37 | Before ... is ... | semmle.label | successor |
-| patterns.cs:140:17:140:42 | ... => ... | patterns.cs:140:17:140:42 | After ... => ... [match] | semmle.label | match |
-| patterns.cs:140:17:140:42 | ... => ... | patterns.cs:140:17:140:42 | After ... => ... [no-match] | semmle.label | no-match |
-| patterns.cs:140:17:140:42 | After ... => ... [match] | patterns.cs:140:17:140:24 | Object y | semmle.label | successor |
+| patterns.cs:140:17:140:24 | After Object y [match] | patterns.cs:140:17:140:42 | After ... => ... [match] | semmle.label | match |
+| patterns.cs:140:17:140:24 | After Object y [no-match] | patterns.cs:140:17:140:42 | After ... => ... [no-match] | semmle.label | no-match |
+| patterns.cs:140:17:140:24 | Object y | patterns.cs:140:17:140:24 | After Object y [match] | semmle.label | match |
+| patterns.cs:140:17:140:24 | Object y | patterns.cs:140:17:140:24 | After Object y [no-match] | semmle.label | no-match |
+| patterns.cs:140:17:140:42 | ... => ... | patterns.cs:140:17:140:24 | Object y | semmle.label | successor |
+| patterns.cs:140:17:140:42 | After ... => ... [match] | patterns.cs:140:31:140:37 | Before ... is ... | semmle.label | successor |
 | patterns.cs:140:17:140:42 | After ... => ... [no-match] | patterns.cs:141:17:141:29 | ... => ... | semmle.label | successor |
 | patterns.cs:140:31:140:31 | access to local variable y | patterns.cs:140:31:140:37 | ... is ... | semmle.label | successor |
 | patterns.cs:140:31:140:37 | ... is ... | patterns.cs:140:31:140:37 | After ... is ... [false] | semmle.label | false |
@@ -296,19 +314,22 @@
 | patterns.cs:140:36:140:37 | { ... } | patterns.cs:140:36:140:37 | After { ... } | semmle.label | successor |
 | patterns.cs:140:36:140:37 | { ... } | patterns.cs:140:36:140:37 | { ... } | semmle.label | successor |
 | patterns.cs:140:42:140:42 | 4 | patterns.cs:136:17:143:13 | After ... switch { ... } | semmle.label | successor |
-| patterns.cs:141:17:141:22 | access to type String | patterns.cs:141:29:141:29 | 5 | semmle.label | successor |
-| patterns.cs:141:17:141:29 | ... => ... | patterns.cs:141:17:141:29 | After ... => ... [match] | semmle.label | match |
-| patterns.cs:141:17:141:29 | ... => ... | patterns.cs:141:17:141:29 | After ... => ... [no-match] | semmle.label | no-match |
-| patterns.cs:141:17:141:29 | After ... => ... [match] | patterns.cs:141:17:141:22 | access to type String | semmle.label | successor |
+| patterns.cs:141:17:141:22 | After access to type String [match] | patterns.cs:141:17:141:29 | After ... => ... [match] | semmle.label | match |
+| patterns.cs:141:17:141:22 | After access to type String [no-match] | patterns.cs:141:17:141:29 | After ... => ... [no-match] | semmle.label | no-match |
+| patterns.cs:141:17:141:22 | access to type String | patterns.cs:141:17:141:22 | After access to type String [match] | semmle.label | match |
+| patterns.cs:141:17:141:22 | access to type String | patterns.cs:141:17:141:22 | After access to type String [no-match] | semmle.label | no-match |
+| patterns.cs:141:17:141:29 | ... => ... | patterns.cs:141:17:141:22 | access to type String | semmle.label | successor |
+| patterns.cs:141:17:141:29 | After ... => ... [match] | patterns.cs:141:29:141:29 | 5 | semmle.label | successor |
 | patterns.cs:141:17:141:29 | After ... => ... [no-match] | patterns.cs:142:17:142:41 | ... => ... | semmle.label | successor |
 | patterns.cs:141:29:141:29 | 5 | patterns.cs:136:17:143:13 | After ... switch { ... } | semmle.label | successor |
 | patterns.cs:142:17:142:24 | access to type MyStruct | patterns.cs:142:26:142:34 | Before { ... } | semmle.label | successor |
-| patterns.cs:142:17:142:36 | After { ... } | patterns.cs:142:41:142:41 | 6 | semmle.label | successor |
+| patterns.cs:142:17:142:36 | After { ... } [match] | patterns.cs:142:17:142:41 | After ... => ... [match] | semmle.label | match |
+| patterns.cs:142:17:142:36 | After { ... } [no-match] | patterns.cs:142:17:142:41 | After ... => ... [no-match] | semmle.label | no-match |
 | patterns.cs:142:17:142:36 | Before { ... } | patterns.cs:142:17:142:24 | access to type MyStruct | semmle.label | successor |
-| patterns.cs:142:17:142:36 | { ... } | patterns.cs:142:17:142:36 | After { ... } | semmle.label | successor |
-| patterns.cs:142:17:142:41 | ... => ... | patterns.cs:142:17:142:41 | After ... => ... [match] | semmle.label | match |
-| patterns.cs:142:17:142:41 | ... => ... | patterns.cs:142:17:142:41 | After ... => ... [no-match] | semmle.label | no-match |
-| patterns.cs:142:17:142:41 | After ... => ... [match] | patterns.cs:142:17:142:36 | Before { ... } | semmle.label | successor |
+| patterns.cs:142:17:142:36 | { ... } | patterns.cs:142:17:142:36 | After { ... } [match] | semmle.label | match |
+| patterns.cs:142:17:142:36 | { ... } | patterns.cs:142:17:142:36 | After { ... } [no-match] | semmle.label | no-match |
+| patterns.cs:142:17:142:41 | ... => ... | patterns.cs:142:17:142:36 | Before { ... } | semmle.label | successor |
+| patterns.cs:142:17:142:41 | After ... => ... [match] | patterns.cs:142:41:142:41 | 6 | semmle.label | successor |
 | patterns.cs:142:17:142:41 | After ... => ... [no-match] | patterns.cs:136:17:143:13 | After ... switch { ... } | semmle.label | successor |
 | patterns.cs:142:26:142:34 | After { ... } | patterns.cs:142:17:142:36 | { ... } | semmle.label | successor |
 | patterns.cs:142:26:142:34 | Before { ... } | patterns.cs:142:31:142:32 | 10 | semmle.label | successor |

--- a/csharp/ql/test/library-tests/csharp8/switchstmtctrlflow.expected
+++ b/csharp/ql/test/library-tests/csharp8/switchstmtctrlflow.expected
@@ -22,11 +22,13 @@
 | patterns.cs:36:9:44:9 | After switch (...) {...} | patterns.cs:46:9:63:9 | switch (...) {...} | semmle.label | successor |
 | patterns.cs:36:9:44:9 | switch (...) {...} | patterns.cs:36:17:36:17 | access to local variable s | semmle.label | successor |
 | patterns.cs:36:17:36:17 | access to local variable s | patterns.cs:38:13:38:47 | case ...: | semmle.label | successor |
-| patterns.cs:38:13:38:47 | After case ...: [match] | patterns.cs:38:18:38:29 | MyStruct ms1 | semmle.label | successor |
+| patterns.cs:38:13:38:47 | After case ...: [match] | patterns.cs:38:36:38:46 | Before ... == ... | semmle.label | successor |
 | patterns.cs:38:13:38:47 | After case ...: [no-match] | patterns.cs:41:13:41:46 | case ...: | semmle.label | successor |
-| patterns.cs:38:13:38:47 | case ...: | patterns.cs:38:13:38:47 | After case ...: [match] | semmle.label | match |
-| patterns.cs:38:13:38:47 | case ...: | patterns.cs:38:13:38:47 | After case ...: [no-match] | semmle.label | no-match |
-| patterns.cs:38:18:38:29 | MyStruct ms1 | patterns.cs:38:36:38:46 | Before ... == ... | semmle.label | successor |
+| patterns.cs:38:13:38:47 | case ...: | patterns.cs:38:18:38:29 | MyStruct ms1 | semmle.label | successor |
+| patterns.cs:38:18:38:29 | After MyStruct ms1 [match] | patterns.cs:38:13:38:47 | After case ...: [match] | semmle.label | match |
+| patterns.cs:38:18:38:29 | After MyStruct ms1 [no-match] | patterns.cs:38:13:38:47 | After case ...: [no-match] | semmle.label | no-match |
+| patterns.cs:38:18:38:29 | MyStruct ms1 | patterns.cs:38:18:38:29 | After MyStruct ms1 [match] | semmle.label | match |
+| patterns.cs:38:18:38:29 | MyStruct ms1 | patterns.cs:38:18:38:29 | After MyStruct ms1 [no-match] | semmle.label | no-match |
 | patterns.cs:38:36:38:38 | access to local variable ms1 | patterns.cs:38:36:38:40 | access to field X | semmle.label | successor |
 | patterns.cs:38:36:38:40 | After access to field X | patterns.cs:38:45:38:46 | 10 | semmle.label | successor |
 | patterns.cs:38:36:38:40 | Before access to field X | patterns.cs:38:36:38:38 | access to local variable ms1 | semmle.label | successor |
@@ -45,11 +47,13 @@
 | patterns.cs:39:35:39:54 | "Hit the breakpoint" | patterns.cs:39:17:39:55 | call to method WriteLine | semmle.label | successor |
 | patterns.cs:40:17:40:22 | Before break; | patterns.cs:40:17:40:22 | break; | semmle.label | successor |
 | patterns.cs:40:17:40:22 | break; | patterns.cs:36:9:44:9 | After switch (...) {...} | semmle.label | break |
-| patterns.cs:41:13:41:46 | After case ...: [match] | patterns.cs:41:18:41:29 | MyStruct ms2 | semmle.label | successor |
+| patterns.cs:41:13:41:46 | After case ...: [match] | patterns.cs:41:36:41:45 | Before ... < ... | semmle.label | successor |
 | patterns.cs:41:13:41:46 | After case ...: [no-match] | patterns.cs:36:9:44:9 | After switch (...) {...} | semmle.label | successor |
-| patterns.cs:41:13:41:46 | case ...: | patterns.cs:41:13:41:46 | After case ...: [match] | semmle.label | match |
-| patterns.cs:41:13:41:46 | case ...: | patterns.cs:41:13:41:46 | After case ...: [no-match] | semmle.label | no-match |
-| patterns.cs:41:18:41:29 | MyStruct ms2 | patterns.cs:41:36:41:45 | Before ... < ... | semmle.label | successor |
+| patterns.cs:41:13:41:46 | case ...: | patterns.cs:41:18:41:29 | MyStruct ms2 | semmle.label | successor |
+| patterns.cs:41:18:41:29 | After MyStruct ms2 [match] | patterns.cs:41:13:41:46 | After case ...: [match] | semmle.label | match |
+| patterns.cs:41:18:41:29 | After MyStruct ms2 [no-match] | patterns.cs:41:13:41:46 | After case ...: [no-match] | semmle.label | no-match |
+| patterns.cs:41:18:41:29 | MyStruct ms2 | patterns.cs:41:18:41:29 | After MyStruct ms2 [match] | semmle.label | match |
+| patterns.cs:41:18:41:29 | MyStruct ms2 | patterns.cs:41:18:41:29 | After MyStruct ms2 [no-match] | semmle.label | no-match |
 | patterns.cs:41:36:41:38 | access to local variable ms2 | patterns.cs:41:36:41:40 | access to field X | semmle.label | successor |
 | patterns.cs:41:36:41:40 | After access to field X | patterns.cs:41:44:41:45 | 10 | semmle.label | successor |
 | patterns.cs:41:36:41:40 | Before access to field X | patterns.cs:41:36:41:38 | access to local variable ms2 | semmle.label | successor |
@@ -71,14 +75,15 @@
 | patterns.cs:46:9:63:9 | After switch (...) {...} | patterns.cs:65:9:73:9 | switch (...) {...} | semmle.label | successor |
 | patterns.cs:46:9:63:9 | switch (...) {...} | patterns.cs:46:17:46:17 | access to local variable s | semmle.label | successor |
 | patterns.cs:46:17:46:17 | access to local variable s | patterns.cs:48:13:48:50 | case ...: | semmle.label | successor |
-| patterns.cs:48:13:48:50 | After case ...: [match] | patterns.cs:48:18:48:38 | Before { ... } | semmle.label | successor |
+| patterns.cs:48:13:48:50 | After case ...: [match] | patterns.cs:48:45:48:49 | Before ... > ... | semmle.label | successor |
 | patterns.cs:48:13:48:50 | After case ...: [no-match] | patterns.cs:51:13:51:39 | case ...: | semmle.label | successor |
-| patterns.cs:48:13:48:50 | case ...: | patterns.cs:48:13:48:50 | After case ...: [match] | semmle.label | match |
-| patterns.cs:48:13:48:50 | case ...: | patterns.cs:48:13:48:50 | After case ...: [no-match] | semmle.label | no-match |
+| patterns.cs:48:13:48:50 | case ...: | patterns.cs:48:18:48:38 | Before { ... } | semmle.label | successor |
 | patterns.cs:48:18:48:25 | access to type MyStruct | patterns.cs:48:27:48:38 | Before { ... } | semmle.label | successor |
-| patterns.cs:48:18:48:38 | After { ... } | patterns.cs:48:45:48:49 | Before ... > ... | semmle.label | successor |
+| patterns.cs:48:18:48:38 | After { ... } [match] | patterns.cs:48:13:48:50 | After case ...: [match] | semmle.label | match |
+| patterns.cs:48:18:48:38 | After { ... } [no-match] | patterns.cs:48:13:48:50 | After case ...: [no-match] | semmle.label | no-match |
 | patterns.cs:48:18:48:38 | Before { ... } | patterns.cs:48:18:48:25 | access to type MyStruct | semmle.label | successor |
-| patterns.cs:48:18:48:38 | { ... } | patterns.cs:48:18:48:38 | After { ... } | semmle.label | successor |
+| patterns.cs:48:18:48:38 | { ... } | patterns.cs:48:18:48:38 | After { ... } [match] | semmle.label | match |
+| patterns.cs:48:18:48:38 | { ... } | patterns.cs:48:18:48:38 | After { ... } [no-match] | semmle.label | no-match |
 | patterns.cs:48:27:48:38 | After { ... } | patterns.cs:48:18:48:38 | { ... } | semmle.label | successor |
 | patterns.cs:48:27:48:38 | Before { ... } | patterns.cs:48:32:48:36 | Int32 x | semmle.label | successor |
 | patterns.cs:48:27:48:38 | { ... } | patterns.cs:48:27:48:38 | After { ... } | semmle.label | successor |
@@ -98,15 +103,16 @@
 | patterns.cs:49:35:49:35 | access to local variable x | patterns.cs:49:17:49:36 | call to method WriteLine | semmle.label | successor |
 | patterns.cs:50:17:50:22 | Before break; | patterns.cs:50:17:50:22 | break; | semmle.label | successor |
 | patterns.cs:50:17:50:22 | break; | patterns.cs:46:9:63:9 | After switch (...) {...} | semmle.label | break |
-| patterns.cs:51:13:51:39 | After case ...: [match] | patterns.cs:51:18:51:38 | Before { ... } | semmle.label | successor |
+| patterns.cs:51:13:51:39 | After case ...: [match] | patterns.cs:52:17:52:56 | ...; | semmle.label | successor |
 | patterns.cs:51:13:51:39 | After case ...: [no-match] | patterns.cs:54:13:54:43 | case ...: | semmle.label | successor |
-| patterns.cs:51:13:51:39 | case ...: | patterns.cs:51:13:51:39 | After case ...: [match] | semmle.label | match |
-| patterns.cs:51:13:51:39 | case ...: | patterns.cs:51:13:51:39 | After case ...: [no-match] | semmle.label | no-match |
+| patterns.cs:51:13:51:39 | case ...: | patterns.cs:51:18:51:38 | Before { ... } | semmle.label | successor |
 | patterns.cs:51:18:51:25 | access to type MyStruct | patterns.cs:51:27:51:35 | Before { ... } | semmle.label | successor |
-| patterns.cs:51:18:51:38 | After { ... } | patterns.cs:52:17:52:56 | ...; | semmle.label | successor |
+| patterns.cs:51:18:51:38 | After { ... } [match] | patterns.cs:51:13:51:39 | After case ...: [match] | semmle.label | match |
+| patterns.cs:51:18:51:38 | After { ... } [no-match] | patterns.cs:51:13:51:39 | After case ...: [no-match] | semmle.label | no-match |
 | patterns.cs:51:18:51:38 | Before { ... } | patterns.cs:51:18:51:38 | MyStruct ms | semmle.label | successor |
 | patterns.cs:51:18:51:38 | MyStruct ms | patterns.cs:51:18:51:25 | access to type MyStruct | semmle.label | successor |
-| patterns.cs:51:18:51:38 | { ... } | patterns.cs:51:18:51:38 | After { ... } | semmle.label | successor |
+| patterns.cs:51:18:51:38 | { ... } | patterns.cs:51:18:51:38 | After { ... } [match] | semmle.label | match |
+| patterns.cs:51:18:51:38 | { ... } | patterns.cs:51:18:51:38 | After { ... } [no-match] | semmle.label | no-match |
 | patterns.cs:51:27:51:35 | After { ... } | patterns.cs:51:18:51:38 | { ... } | semmle.label | successor |
 | patterns.cs:51:27:51:35 | Before { ... } | patterns.cs:51:32:51:33 | 10 | semmle.label | successor |
 | patterns.cs:51:27:51:35 | { ... } | patterns.cs:51:27:51:35 | After { ... } | semmle.label | successor |
@@ -119,16 +125,17 @@
 | patterns.cs:52:35:52:54 | "Hit the breakpoint" | patterns.cs:52:17:52:55 | call to method WriteLine | semmle.label | successor |
 | patterns.cs:53:17:53:22 | Before break; | patterns.cs:53:17:53:22 | break; | semmle.label | successor |
 | patterns.cs:53:17:53:22 | break; | patterns.cs:46:9:63:9 | After switch (...) {...} | semmle.label | break |
-| patterns.cs:54:13:54:43 | After case ...: [match] | patterns.cs:54:18:54:30 | Before { ... } | semmle.label | successor |
+| patterns.cs:54:13:54:43 | After case ...: [match] | patterns.cs:54:37:54:42 | Before ... > ... | semmle.label | successor |
 | patterns.cs:54:13:54:43 | After case ...: [no-match] | patterns.cs:57:13:57:24 | case ...: | semmle.label | successor |
-| patterns.cs:54:13:54:43 | case ...: | patterns.cs:54:13:54:43 | After case ...: [match] | semmle.label | match |
-| patterns.cs:54:13:54:43 | case ...: | patterns.cs:54:13:54:43 | After case ...: [no-match] | semmle.label | no-match |
+| patterns.cs:54:13:54:43 | case ...: | patterns.cs:54:18:54:30 | Before { ... } | semmle.label | successor |
 | patterns.cs:54:18:54:30 | After { ... } | patterns.cs:54:18:54:30 | { ... } | semmle.label | successor |
-| patterns.cs:54:18:54:30 | After { ... } | patterns.cs:54:37:54:42 | Before ... > ... | semmle.label | successor |
+| patterns.cs:54:18:54:30 | After { ... } [match] | patterns.cs:54:13:54:43 | After case ...: [match] | semmle.label | match |
+| patterns.cs:54:18:54:30 | After { ... } [no-match] | patterns.cs:54:13:54:43 | After case ...: [no-match] | semmle.label | no-match |
 | patterns.cs:54:18:54:30 | Before { ... } | patterns.cs:54:18:54:30 | Before { ... } | semmle.label | successor |
 | patterns.cs:54:18:54:30 | Before { ... } | patterns.cs:54:23:54:28 | Int32 x2 | semmle.label | successor |
 | patterns.cs:54:18:54:30 | { ... } | patterns.cs:54:18:54:30 | After { ... } | semmle.label | successor |
-| patterns.cs:54:18:54:30 | { ... } | patterns.cs:54:18:54:30 | After { ... } | semmle.label | successor |
+| patterns.cs:54:18:54:30 | { ... } | patterns.cs:54:18:54:30 | After { ... } [match] | semmle.label | match |
+| patterns.cs:54:18:54:30 | { ... } | patterns.cs:54:18:54:30 | After { ... } [no-match] | semmle.label | no-match |
 | patterns.cs:54:23:54:28 | Int32 x2 | patterns.cs:54:18:54:30 | { ... } | semmle.label | successor |
 | patterns.cs:54:37:54:38 | access to local variable x2 | patterns.cs:54:42:54:42 | 2 | semmle.label | successor |
 | patterns.cs:54:37:54:42 | ... > ... | patterns.cs:54:37:54:42 | After ... > ... [false] | semmle.label | false |
@@ -145,26 +152,28 @@
 | patterns.cs:55:35:55:36 | access to local variable x2 | patterns.cs:55:17:55:37 | call to method WriteLine | semmle.label | successor |
 | patterns.cs:56:17:56:22 | Before break; | patterns.cs:56:17:56:22 | break; | semmle.label | successor |
 | patterns.cs:56:17:56:22 | break; | patterns.cs:46:9:63:9 | After switch (...) {...} | semmle.label | break |
-| patterns.cs:57:13:57:24 | After case ...: [match] | patterns.cs:57:18:57:23 | Before { ... } | semmle.label | successor |
+| patterns.cs:57:13:57:24 | After case ...: [match] | patterns.cs:58:17:58:22 | Before break; | semmle.label | successor |
 | patterns.cs:57:13:57:24 | After case ...: [no-match] | patterns.cs:59:13:59:28 | case ...: | semmle.label | successor |
-| patterns.cs:57:13:57:24 | case ...: | patterns.cs:57:13:57:24 | After case ...: [match] | semmle.label | match |
-| patterns.cs:57:13:57:24 | case ...: | patterns.cs:57:13:57:24 | After case ...: [no-match] | semmle.label | no-match |
+| patterns.cs:57:13:57:24 | case ...: | patterns.cs:57:18:57:23 | Before { ... } | semmle.label | successor |
 | patterns.cs:57:18:57:23 | ( ... ) | patterns.cs:57:18:57:23 | After ( ... ) | semmle.label | successor |
 | patterns.cs:57:18:57:23 | After ( ... ) | patterns.cs:57:18:57:23 | { ... } | semmle.label | successor |
-| patterns.cs:57:18:57:23 | After { ... } | patterns.cs:58:17:58:22 | Before break; | semmle.label | successor |
+| patterns.cs:57:18:57:23 | After { ... } [match] | patterns.cs:57:13:57:24 | After case ...: [match] | semmle.label | match |
+| patterns.cs:57:18:57:23 | After { ... } [no-match] | patterns.cs:57:13:57:24 | After case ...: [no-match] | semmle.label | no-match |
 | patterns.cs:57:18:57:23 | Before ( ... ) | patterns.cs:57:19:57:19 | 1 | semmle.label | successor |
 | patterns.cs:57:18:57:23 | Before { ... } | patterns.cs:57:18:57:23 | Before ( ... ) | semmle.label | successor |
-| patterns.cs:57:18:57:23 | { ... } | patterns.cs:57:18:57:23 | After { ... } | semmle.label | successor |
+| patterns.cs:57:18:57:23 | { ... } | patterns.cs:57:18:57:23 | After { ... } [match] | semmle.label | match |
+| patterns.cs:57:18:57:23 | { ... } | patterns.cs:57:18:57:23 | After { ... } [no-match] | semmle.label | no-match |
 | patterns.cs:57:19:57:19 | 1 | patterns.cs:57:22:57:22 | 2 | semmle.label | successor |
 | patterns.cs:57:22:57:22 | 2 | patterns.cs:57:18:57:23 | ( ... ) | semmle.label | successor |
 | patterns.cs:58:17:58:22 | Before break; | patterns.cs:58:17:58:22 | break; | semmle.label | successor |
 | patterns.cs:58:17:58:22 | break; | patterns.cs:46:9:63:9 | After switch (...) {...} | semmle.label | break |
-| patterns.cs:59:13:59:28 | After case ...: [match] | patterns.cs:59:18:59:27 | Before (..., ...) | semmle.label | successor |
+| patterns.cs:59:13:59:28 | After case ...: [match] | patterns.cs:60:17:60:22 | Before break; | semmle.label | successor |
 | patterns.cs:59:13:59:28 | After case ...: [no-match] | patterns.cs:61:13:61:20 | default: | semmle.label | successor |
-| patterns.cs:59:13:59:28 | case ...: | patterns.cs:59:13:59:28 | After case ...: [match] | semmle.label | match |
-| patterns.cs:59:13:59:28 | case ...: | patterns.cs:59:13:59:28 | After case ...: [no-match] | semmle.label | no-match |
-| patterns.cs:59:18:59:27 | (..., ...) | patterns.cs:59:18:59:27 | After (..., ...) | semmle.label | successor |
-| patterns.cs:59:18:59:27 | After (..., ...) | patterns.cs:60:17:60:22 | Before break; | semmle.label | successor |
+| patterns.cs:59:13:59:28 | case ...: | patterns.cs:59:18:59:27 | Before (..., ...) | semmle.label | successor |
+| patterns.cs:59:18:59:27 | (..., ...) | patterns.cs:59:18:59:27 | After (..., ...) [match] | semmle.label | match |
+| patterns.cs:59:18:59:27 | (..., ...) | patterns.cs:59:18:59:27 | After (..., ...) [no-match] | semmle.label | no-match |
+| patterns.cs:59:18:59:27 | After (..., ...) [match] | patterns.cs:59:13:59:28 | After case ...: [match] | semmle.label | match |
+| patterns.cs:59:18:59:27 | After (..., ...) [no-match] | patterns.cs:59:13:59:28 | After case ...: [no-match] | semmle.label | no-match |
 | patterns.cs:59:18:59:27 | Before (..., ...) | patterns.cs:59:23:59:23 | Int32 x | semmle.label | successor |
 | patterns.cs:59:23:59:23 | Int32 x | patterns.cs:59:26:59:26 | Int32 y | semmle.label | successor |
 | patterns.cs:59:26:59:26 | Int32 y | patterns.cs:59:18:59:27 | (..., ...) | semmle.label | successor |
@@ -177,14 +186,15 @@
 | patterns.cs:65:9:73:9 | After switch (...) {...} | patterns.cs:76:9:84:9 | switch (...) {...} | semmle.label | successor |
 | patterns.cs:65:9:73:9 | switch (...) {...} | patterns.cs:65:17:65:17 | access to local variable s | semmle.label | successor |
 | patterns.cs:65:17:65:17 | access to local variable s | patterns.cs:67:13:67:50 | case ...: | semmle.label | successor |
-| patterns.cs:67:13:67:50 | After case ...: [match] | patterns.cs:67:18:67:38 | Before { ... } | semmle.label | successor |
+| patterns.cs:67:13:67:50 | After case ...: [match] | patterns.cs:67:45:67:49 | Before ... > ... | semmle.label | successor |
 | patterns.cs:67:13:67:50 | After case ...: [no-match] | patterns.cs:70:13:70:51 | case ...: | semmle.label | successor |
-| patterns.cs:67:13:67:50 | case ...: | patterns.cs:67:13:67:50 | After case ...: [match] | semmle.label | match |
-| patterns.cs:67:13:67:50 | case ...: | patterns.cs:67:13:67:50 | After case ...: [no-match] | semmle.label | no-match |
+| patterns.cs:67:13:67:50 | case ...: | patterns.cs:67:18:67:38 | Before { ... } | semmle.label | successor |
 | patterns.cs:67:18:67:25 | access to type MyStruct | patterns.cs:67:27:67:38 | Before { ... } | semmle.label | successor |
-| patterns.cs:67:18:67:38 | After { ... } | patterns.cs:67:45:67:49 | Before ... > ... | semmle.label | successor |
+| patterns.cs:67:18:67:38 | After { ... } [match] | patterns.cs:67:13:67:50 | After case ...: [match] | semmle.label | match |
+| patterns.cs:67:18:67:38 | After { ... } [no-match] | patterns.cs:67:13:67:50 | After case ...: [no-match] | semmle.label | no-match |
 | patterns.cs:67:18:67:38 | Before { ... } | patterns.cs:67:18:67:25 | access to type MyStruct | semmle.label | successor |
-| patterns.cs:67:18:67:38 | { ... } | patterns.cs:67:18:67:38 | After { ... } | semmle.label | successor |
+| patterns.cs:67:18:67:38 | { ... } | patterns.cs:67:18:67:38 | After { ... } [match] | semmle.label | match |
+| patterns.cs:67:18:67:38 | { ... } | patterns.cs:67:18:67:38 | After { ... } [no-match] | semmle.label | no-match |
 | patterns.cs:67:27:67:38 | After { ... } | patterns.cs:67:18:67:38 | { ... } | semmle.label | successor |
 | patterns.cs:67:27:67:38 | Before { ... } | patterns.cs:67:32:67:36 | Int32 x | semmle.label | successor |
 | patterns.cs:67:27:67:38 | { ... } | patterns.cs:67:27:67:38 | After { ... } | semmle.label | successor |
@@ -204,15 +214,16 @@
 | patterns.cs:68:35:68:35 | access to local variable x | patterns.cs:68:17:68:36 | call to method WriteLine | semmle.label | successor |
 | patterns.cs:69:17:69:22 | Before break; | patterns.cs:69:17:69:22 | break; | semmle.label | successor |
 | patterns.cs:69:17:69:22 | break; | patterns.cs:65:9:73:9 | After switch (...) {...} | semmle.label | break |
-| patterns.cs:70:13:70:51 | After case ...: [match] | patterns.cs:70:18:70:38 | Before { ... } | semmle.label | successor |
+| patterns.cs:70:13:70:51 | After case ...: [match] | patterns.cs:70:45:70:50 | Before ... == ... | semmle.label | successor |
 | patterns.cs:70:13:70:51 | After case ...: [no-match] | patterns.cs:65:9:73:9 | After switch (...) {...} | semmle.label | successor |
-| patterns.cs:70:13:70:51 | case ...: | patterns.cs:70:13:70:51 | After case ...: [match] | semmle.label | match |
-| patterns.cs:70:13:70:51 | case ...: | patterns.cs:70:13:70:51 | After case ...: [no-match] | semmle.label | no-match |
+| patterns.cs:70:13:70:51 | case ...: | patterns.cs:70:18:70:38 | Before { ... } | semmle.label | successor |
 | patterns.cs:70:18:70:25 | access to type MyStruct | patterns.cs:70:27:70:35 | Before { ... } | semmle.label | successor |
-| patterns.cs:70:18:70:38 | After { ... } | patterns.cs:70:45:70:50 | Before ... == ... | semmle.label | successor |
+| patterns.cs:70:18:70:38 | After { ... } [match] | patterns.cs:70:13:70:51 | After case ...: [match] | semmle.label | match |
+| patterns.cs:70:18:70:38 | After { ... } [no-match] | patterns.cs:70:13:70:51 | After case ...: [no-match] | semmle.label | no-match |
 | patterns.cs:70:18:70:38 | Before { ... } | patterns.cs:70:18:70:38 | MyStruct ms | semmle.label | successor |
 | patterns.cs:70:18:70:38 | MyStruct ms | patterns.cs:70:18:70:25 | access to type MyStruct | semmle.label | successor |
-| patterns.cs:70:18:70:38 | { ... } | patterns.cs:70:18:70:38 | After { ... } | semmle.label | successor |
+| patterns.cs:70:18:70:38 | { ... } | patterns.cs:70:18:70:38 | After { ... } [match] | semmle.label | match |
+| patterns.cs:70:18:70:38 | { ... } | patterns.cs:70:18:70:38 | After { ... } [no-match] | semmle.label | no-match |
 | patterns.cs:70:27:70:35 | After { ... } | patterns.cs:70:18:70:38 | { ... } | semmle.label | successor |
 | patterns.cs:70:27:70:35 | Before { ... } | patterns.cs:70:32:70:33 | 10 | semmle.label | successor |
 | patterns.cs:70:27:70:35 | { ... } | patterns.cs:70:27:70:35 | After { ... } | semmle.label | successor |
@@ -240,16 +251,17 @@
 | patterns.cs:76:17:76:28 | After object creation of type Object | patterns.cs:78:13:78:43 | case ...: | semmle.label | successor |
 | patterns.cs:76:17:76:28 | Before object creation of type Object | patterns.cs:76:17:76:28 | object creation of type Object | semmle.label | successor |
 | patterns.cs:76:17:76:28 | object creation of type Object | patterns.cs:76:17:76:28 | After object creation of type Object | semmle.label | successor |
-| patterns.cs:78:13:78:43 | After case ...: [match] | patterns.cs:78:18:78:33 | Before { ... } | semmle.label | successor |
+| patterns.cs:78:13:78:43 | After case ...: [match] | patterns.cs:78:40:78:42 | Before ... < ... | semmle.label | successor |
 | patterns.cs:78:13:78:43 | After case ...: [no-match] | patterns.cs:80:13:80:20 | case ...: | semmle.label | successor |
-| patterns.cs:78:13:78:43 | case ...: | patterns.cs:78:13:78:43 | After case ...: [match] | semmle.label | match |
-| patterns.cs:78:13:78:43 | case ...: | patterns.cs:78:13:78:43 | After case ...: [no-match] | semmle.label | no-match |
+| patterns.cs:78:13:78:43 | case ...: | patterns.cs:78:18:78:33 | Before { ... } | semmle.label | successor |
 | patterns.cs:78:18:78:33 | ( ... ) | patterns.cs:78:18:78:33 | After ( ... ) | semmle.label | successor |
 | patterns.cs:78:18:78:33 | After ( ... ) | patterns.cs:78:18:78:33 | { ... } | semmle.label | successor |
-| patterns.cs:78:18:78:33 | After { ... } | patterns.cs:78:40:78:42 | Before ... < ... | semmle.label | successor |
+| patterns.cs:78:18:78:33 | After { ... } [match] | patterns.cs:78:13:78:43 | After case ...: [match] | semmle.label | match |
+| patterns.cs:78:18:78:33 | After { ... } [no-match] | patterns.cs:78:13:78:43 | After case ...: [no-match] | semmle.label | no-match |
 | patterns.cs:78:18:78:33 | Before ( ... ) | patterns.cs:78:19:78:23 | Int32 x | semmle.label | successor |
 | patterns.cs:78:18:78:33 | Before { ... } | patterns.cs:78:18:78:33 | Before ( ... ) | semmle.label | successor |
-| patterns.cs:78:18:78:33 | { ... } | patterns.cs:78:18:78:33 | After { ... } | semmle.label | successor |
+| patterns.cs:78:18:78:33 | { ... } | patterns.cs:78:18:78:33 | After { ... } [match] | semmle.label | match |
+| patterns.cs:78:18:78:33 | { ... } | patterns.cs:78:18:78:33 | After { ... } [no-match] | semmle.label | no-match |
 | patterns.cs:78:19:78:23 | Int32 x | patterns.cs:78:26:78:32 | Single y | semmle.label | successor |
 | patterns.cs:78:26:78:32 | Single y | patterns.cs:78:18:78:33 | ( ... ) | semmle.label | successor |
 | patterns.cs:78:40:78:40 | (...) ... | patterns.cs:78:40:78:40 | After (...) ... | semmle.label | successor |
@@ -264,23 +276,25 @@
 | patterns.cs:78:42:78:42 | access to local variable y | patterns.cs:78:40:78:42 | ... < ... | semmle.label | successor |
 | patterns.cs:79:17:79:22 | Before break; | patterns.cs:79:17:79:22 | break; | semmle.label | successor |
 | patterns.cs:79:17:79:22 | break; | patterns.cs:76:9:84:9 | After switch (...) {...} | semmle.label | break |
-| patterns.cs:80:13:80:20 | After case ...: [match] | patterns.cs:80:18:80:19 | Before { ... } | semmle.label | successor |
+| patterns.cs:80:13:80:20 | After case ...: [match] | patterns.cs:81:17:81:22 | Before break; | semmle.label | successor |
 | patterns.cs:80:13:80:20 | After case ...: [no-match] | patterns.cs:82:13:82:20 | case ...: | semmle.label | successor |
-| patterns.cs:80:13:80:20 | case ...: | patterns.cs:80:13:80:20 | After case ...: [match] | semmle.label | match |
-| patterns.cs:80:13:80:20 | case ...: | patterns.cs:80:13:80:20 | After case ...: [no-match] | semmle.label | no-match |
+| patterns.cs:80:13:80:20 | case ...: | patterns.cs:80:18:80:19 | Before { ... } | semmle.label | successor |
 | patterns.cs:80:18:80:19 | ( ... ) | patterns.cs:80:18:80:19 | { ... } | semmle.label | successor |
-| patterns.cs:80:18:80:19 | After { ... } | patterns.cs:81:17:81:22 | Before break; | semmle.label | successor |
+| patterns.cs:80:18:80:19 | After { ... } [match] | patterns.cs:80:13:80:20 | After case ...: [match] | semmle.label | match |
+| patterns.cs:80:18:80:19 | After { ... } [no-match] | patterns.cs:80:13:80:20 | After case ...: [no-match] | semmle.label | no-match |
 | patterns.cs:80:18:80:19 | Before { ... } | patterns.cs:80:18:80:19 | ( ... ) | semmle.label | successor |
-| patterns.cs:80:18:80:19 | { ... } | patterns.cs:80:18:80:19 | After { ... } | semmle.label | successor |
+| patterns.cs:80:18:80:19 | { ... } | patterns.cs:80:18:80:19 | After { ... } [match] | semmle.label | match |
+| patterns.cs:80:18:80:19 | { ... } | patterns.cs:80:18:80:19 | After { ... } [no-match] | semmle.label | no-match |
 | patterns.cs:81:17:81:22 | Before break; | patterns.cs:81:17:81:22 | break; | semmle.label | successor |
 | patterns.cs:81:17:81:22 | break; | patterns.cs:76:9:84:9 | After switch (...) {...} | semmle.label | break |
-| patterns.cs:82:13:82:20 | After case ...: [match] | patterns.cs:82:18:82:19 | Before { ... } | semmle.label | successor |
+| patterns.cs:82:13:82:20 | After case ...: [match] | patterns.cs:83:17:83:22 | Before break; | semmle.label | successor |
 | patterns.cs:82:13:82:20 | After case ...: [no-match] | patterns.cs:76:9:84:9 | After switch (...) {...} | semmle.label | successor |
-| patterns.cs:82:13:82:20 | case ...: | patterns.cs:82:13:82:20 | After case ...: [match] | semmle.label | match |
-| patterns.cs:82:13:82:20 | case ...: | patterns.cs:82:13:82:20 | After case ...: [no-match] | semmle.label | no-match |
-| patterns.cs:82:18:82:19 | After { ... } | patterns.cs:83:17:83:22 | Before break; | semmle.label | successor |
+| patterns.cs:82:13:82:20 | case ...: | patterns.cs:82:18:82:19 | Before { ... } | semmle.label | successor |
+| patterns.cs:82:18:82:19 | After { ... } [match] | patterns.cs:82:13:82:20 | After case ...: [match] | semmle.label | match |
+| patterns.cs:82:18:82:19 | After { ... } [no-match] | patterns.cs:82:13:82:20 | After case ...: [no-match] | semmle.label | no-match |
 | patterns.cs:82:18:82:19 | Before { ... } | patterns.cs:82:18:82:19 | { ... } | semmle.label | successor |
-| patterns.cs:82:18:82:19 | { ... } | patterns.cs:82:18:82:19 | After { ... } | semmle.label | successor |
+| patterns.cs:82:18:82:19 | { ... } | patterns.cs:82:18:82:19 | After { ... } [match] | semmle.label | match |
+| patterns.cs:82:18:82:19 | { ... } | patterns.cs:82:18:82:19 | After { ... } [no-match] | semmle.label | no-match |
 | patterns.cs:82:18:82:19 | { ... } | patterns.cs:82:18:82:19 | { ... } | semmle.label | successor |
 | patterns.cs:83:17:83:22 | Before break; | patterns.cs:83:17:83:22 | break; | semmle.label | successor |
 | patterns.cs:83:17:83:22 | break; | patterns.cs:76:9:84:9 | After switch (...) {...} | semmle.label | break |
@@ -291,16 +305,17 @@
 | patterns.cs:86:15:86:19 | Before (..., ...) | patterns.cs:86:16:86:16 | 1 | semmle.label | successor |
 | patterns.cs:86:16:86:16 | 1 | patterns.cs:86:18:86:18 | 2 | semmle.label | successor |
 | patterns.cs:86:18:86:18 | 2 | patterns.cs:86:15:86:19 | (..., ...) | semmle.label | successor |
-| patterns.cs:88:13:88:24 | After case ...: [match] | patterns.cs:88:18:88:23 | Before { ... } | semmle.label | successor |
+| patterns.cs:88:13:88:24 | After case ...: [match] | patterns.cs:88:26:88:31 | Before break; | semmle.label | successor |
 | patterns.cs:88:13:88:24 | After case ...: [no-match] | patterns.cs:86:9:89:9 | After switch (...) {...} | semmle.label | successor |
-| patterns.cs:88:13:88:24 | case ...: | patterns.cs:88:13:88:24 | After case ...: [match] | semmle.label | match |
-| patterns.cs:88:13:88:24 | case ...: | patterns.cs:88:13:88:24 | After case ...: [no-match] | semmle.label | no-match |
+| patterns.cs:88:13:88:24 | case ...: | patterns.cs:88:18:88:23 | Before { ... } | semmle.label | successor |
 | patterns.cs:88:18:88:23 | ( ... ) | patterns.cs:88:18:88:23 | After ( ... ) | semmle.label | successor |
 | patterns.cs:88:18:88:23 | After ( ... ) | patterns.cs:88:18:88:23 | { ... } | semmle.label | successor |
-| patterns.cs:88:18:88:23 | After { ... } | patterns.cs:88:26:88:31 | Before break; | semmle.label | successor |
+| patterns.cs:88:18:88:23 | After { ... } [match] | patterns.cs:88:13:88:24 | After case ...: [match] | semmle.label | match |
+| patterns.cs:88:18:88:23 | After { ... } [no-match] | patterns.cs:88:13:88:24 | After case ...: [no-match] | semmle.label | no-match |
 | patterns.cs:88:18:88:23 | Before ( ... ) | patterns.cs:88:19:88:19 | 1 | semmle.label | successor |
 | patterns.cs:88:18:88:23 | Before { ... } | patterns.cs:88:18:88:23 | Before ( ... ) | semmle.label | successor |
-| patterns.cs:88:18:88:23 | { ... } | patterns.cs:88:18:88:23 | After { ... } | semmle.label | successor |
+| patterns.cs:88:18:88:23 | { ... } | patterns.cs:88:18:88:23 | After { ... } [match] | semmle.label | match |
+| patterns.cs:88:18:88:23 | { ... } | patterns.cs:88:18:88:23 | After { ... } [no-match] | semmle.label | no-match |
 | patterns.cs:88:19:88:19 | 1 | patterns.cs:88:22:88:22 | 2 | semmle.label | successor |
 | patterns.cs:88:22:88:22 | 2 | patterns.cs:88:18:88:23 | ( ... ) | semmle.label | successor |
 | patterns.cs:88:26:88:31 | Before break; | patterns.cs:88:26:88:31 | break; | semmle.label | successor |
@@ -312,30 +327,32 @@
 | patterns.cs:91:16:91:20 | Before (..., ...) | patterns.cs:91:17:91:17 | 1 | semmle.label | successor |
 | patterns.cs:91:17:91:17 | 1 | patterns.cs:91:19:91:19 | 2 | semmle.label | successor |
 | patterns.cs:91:19:91:19 | 2 | patterns.cs:91:16:91:20 | (..., ...) | semmle.label | successor |
-| patterns.cs:93:13:93:28 | After case ...: [match] | patterns.cs:93:18:93:27 | Before { ... } | semmle.label | successor |
+| patterns.cs:93:13:93:28 | After case ...: [match] | patterns.cs:93:30:93:35 | Before break; | semmle.label | successor |
 | patterns.cs:93:13:93:28 | After case ...: [no-match] | patterns.cs:94:13:94:24 | case ...: | semmle.label | successor |
-| patterns.cs:93:13:93:28 | case ...: | patterns.cs:93:13:93:28 | After case ...: [match] | semmle.label | match |
-| patterns.cs:93:13:93:28 | case ...: | patterns.cs:93:13:93:28 | After case ...: [no-match] | semmle.label | no-match |
+| patterns.cs:93:13:93:28 | case ...: | patterns.cs:93:18:93:27 | Before { ... } | semmle.label | successor |
 | patterns.cs:93:18:93:27 | ( ... ) | patterns.cs:93:18:93:27 | After ( ... ) | semmle.label | successor |
 | patterns.cs:93:18:93:27 | After ( ... ) | patterns.cs:93:18:93:27 | { ... } | semmle.label | successor |
-| patterns.cs:93:18:93:27 | After { ... } | patterns.cs:93:30:93:35 | Before break; | semmle.label | successor |
+| patterns.cs:93:18:93:27 | After { ... } [match] | patterns.cs:93:13:93:28 | After case ...: [match] | semmle.label | match |
+| patterns.cs:93:18:93:27 | After { ... } [no-match] | patterns.cs:93:13:93:28 | After case ...: [no-match] | semmle.label | no-match |
 | patterns.cs:93:18:93:27 | Before ( ... ) | patterns.cs:93:19:93:19 | 1 | semmle.label | successor |
 | patterns.cs:93:18:93:27 | Before { ... } | patterns.cs:93:18:93:27 | Before ( ... ) | semmle.label | successor |
-| patterns.cs:93:18:93:27 | { ... } | patterns.cs:93:18:93:27 | After { ... } | semmle.label | successor |
+| patterns.cs:93:18:93:27 | { ... } | patterns.cs:93:18:93:27 | After { ... } [match] | semmle.label | match |
+| patterns.cs:93:18:93:27 | { ... } | patterns.cs:93:18:93:27 | After { ... } [no-match] | semmle.label | no-match |
 | patterns.cs:93:19:93:19 | 1 | patterns.cs:93:22:93:26 | Int32 x | semmle.label | successor |
 | patterns.cs:93:22:93:26 | Int32 x | patterns.cs:93:18:93:27 | ( ... ) | semmle.label | successor |
 | patterns.cs:93:30:93:35 | Before break; | patterns.cs:93:30:93:35 | break; | semmle.label | successor |
 | patterns.cs:93:30:93:35 | break; | patterns.cs:91:9:95:9 | After switch (...) {...} | semmle.label | break |
-| patterns.cs:94:13:94:24 | After case ...: [match] | patterns.cs:94:18:94:23 | Before { ... } | semmle.label | successor |
+| patterns.cs:94:13:94:24 | After case ...: [match] | patterns.cs:94:26:94:31 | Before break; | semmle.label | successor |
 | patterns.cs:94:13:94:24 | After case ...: [no-match] | patterns.cs:91:9:95:9 | After switch (...) {...} | semmle.label | successor |
-| patterns.cs:94:13:94:24 | case ...: | patterns.cs:94:13:94:24 | After case ...: [match] | semmle.label | match |
-| patterns.cs:94:13:94:24 | case ...: | patterns.cs:94:13:94:24 | After case ...: [no-match] | semmle.label | no-match |
+| patterns.cs:94:13:94:24 | case ...: | patterns.cs:94:18:94:23 | Before { ... } | semmle.label | successor |
 | patterns.cs:94:18:94:23 | ( ... ) | patterns.cs:94:18:94:23 | After ( ... ) | semmle.label | successor |
 | patterns.cs:94:18:94:23 | After ( ... ) | patterns.cs:94:18:94:23 | { ... } | semmle.label | successor |
-| patterns.cs:94:18:94:23 | After { ... } | patterns.cs:94:26:94:31 | Before break; | semmle.label | successor |
+| patterns.cs:94:18:94:23 | After { ... } [match] | patterns.cs:94:13:94:24 | After case ...: [match] | semmle.label | match |
+| patterns.cs:94:18:94:23 | After { ... } [no-match] | patterns.cs:94:13:94:24 | After case ...: [no-match] | semmle.label | no-match |
 | patterns.cs:94:18:94:23 | Before ( ... ) | patterns.cs:94:19:94:19 | 2 | semmle.label | successor |
 | patterns.cs:94:18:94:23 | Before { ... } | patterns.cs:94:18:94:23 | Before ( ... ) | semmle.label | successor |
-| patterns.cs:94:18:94:23 | { ... } | patterns.cs:94:18:94:23 | After { ... } | semmle.label | successor |
+| patterns.cs:94:18:94:23 | { ... } | patterns.cs:94:18:94:23 | After { ... } [match] | semmle.label | match |
+| patterns.cs:94:18:94:23 | { ... } | patterns.cs:94:18:94:23 | After { ... } [no-match] | semmle.label | no-match |
 | patterns.cs:94:19:94:19 | 2 | patterns.cs:94:22:94:22 | _ | semmle.label | successor |
 | patterns.cs:94:22:94:22 | _ | patterns.cs:94:18:94:23 | ( ... ) | semmle.label | successor |
 | patterns.cs:94:26:94:31 | Before break; | patterns.cs:94:26:94:31 | break; | semmle.label | successor |

--- a/csharp/ql/test/library-tests/goto/Goto1.expected
+++ b/csharp/ql/test/library-tests/goto/Goto1.expected
@@ -27,45 +27,55 @@
 | goto.cs:10:9:18:9 | After switch (...) {...} | goto.cs:19:9:19:10 | s9: | semmle.label | successor |
 | goto.cs:10:9:18:9 | switch (...) {...} | goto.cs:10:17:10:17 | access to local variable s | semmle.label | successor |
 | goto.cs:10:17:10:17 | access to local variable s | goto.cs:12:13:12:22 | case ...: | semmle.label | successor |
-| goto.cs:12:13:12:22 | After case ...: [match] | goto.cs:12:18:12:21 | null | semmle.label | successor |
+| goto.cs:12:13:12:22 | After case ...: [match] | goto.cs:12:24:12:25 | s3: | semmle.label | successor |
 | goto.cs:12:13:12:22 | After case ...: [no-match] | goto.cs:13:13:13:21 | case ...: | semmle.label | successor |
-| goto.cs:12:13:12:22 | case ...: | goto.cs:12:13:12:22 | After case ...: [match] | semmle.label | match |
-| goto.cs:12:13:12:22 | case ...: | goto.cs:12:13:12:22 | After case ...: [no-match] | semmle.label | no-match |
-| goto.cs:12:18:12:21 | null | goto.cs:12:24:12:25 | s3: | semmle.label | successor |
+| goto.cs:12:13:12:22 | case ...: | goto.cs:12:18:12:21 | null | semmle.label | successor |
+| goto.cs:12:18:12:21 | After null [match] | goto.cs:12:13:12:22 | After case ...: [match] | semmle.label | match |
+| goto.cs:12:18:12:21 | After null [no-match] | goto.cs:12:13:12:22 | After case ...: [no-match] | semmle.label | no-match |
+| goto.cs:12:18:12:21 | null | goto.cs:12:18:12:21 | After null [match] | semmle.label | match |
+| goto.cs:12:18:12:21 | null | goto.cs:12:18:12:21 | After null [no-match] | semmle.label | no-match |
 | goto.cs:12:24:12:25 | s3: | goto.cs:12:28:12:41 | Before goto case ...; | semmle.label | successor |
 | goto.cs:12:28:12:41 | Before goto case ...; | goto.cs:12:38:12:40 | "1" | semmle.label | successor |
 | goto.cs:12:28:12:41 | goto case ...; | goto.cs:13:13:13:21 | After case ...: [match] | semmle.label | goto |
 | goto.cs:12:38:12:40 | "1" | goto.cs:12:28:12:41 | goto case ...; | semmle.label | successor |
-| goto.cs:13:13:13:21 | After case ...: [match] | goto.cs:13:18:13:20 | "1" | semmle.label | successor |
+| goto.cs:13:13:13:21 | After case ...: [match] | goto.cs:13:23:13:24 | s4: | semmle.label | successor |
 | goto.cs:13:13:13:21 | After case ...: [no-match] | goto.cs:14:13:14:21 | case ...: | semmle.label | successor |
-| goto.cs:13:13:13:21 | case ...: | goto.cs:13:13:13:21 | After case ...: [match] | semmle.label | match |
-| goto.cs:13:13:13:21 | case ...: | goto.cs:13:13:13:21 | After case ...: [no-match] | semmle.label | no-match |
-| goto.cs:13:18:13:20 | "1" | goto.cs:13:23:13:24 | s4: | semmle.label | successor |
+| goto.cs:13:13:13:21 | case ...: | goto.cs:13:18:13:20 | "1" | semmle.label | successor |
+| goto.cs:13:18:13:20 | "1" | goto.cs:13:18:13:20 | After "1" [match] | semmle.label | match |
+| goto.cs:13:18:13:20 | "1" | goto.cs:13:18:13:20 | After "1" [no-match] | semmle.label | no-match |
+| goto.cs:13:18:13:20 | After "1" [match] | goto.cs:13:13:13:21 | After case ...: [match] | semmle.label | match |
+| goto.cs:13:18:13:20 | After "1" [no-match] | goto.cs:13:13:13:21 | After case ...: [no-match] | semmle.label | no-match |
 | goto.cs:13:23:13:24 | s4: | goto.cs:13:27:13:40 | Before goto case ...; | semmle.label | successor |
 | goto.cs:13:27:13:40 | Before goto case ...; | goto.cs:13:37:13:39 | "2" | semmle.label | successor |
 | goto.cs:13:27:13:40 | goto case ...; | goto.cs:14:13:14:21 | After case ...: [match] | semmle.label | goto |
 | goto.cs:13:37:13:39 | "2" | goto.cs:13:27:13:40 | goto case ...; | semmle.label | successor |
-| goto.cs:14:13:14:21 | After case ...: [match] | goto.cs:14:18:14:20 | "2" | semmle.label | successor |
+| goto.cs:14:13:14:21 | After case ...: [match] | goto.cs:14:23:14:24 | s5: | semmle.label | successor |
 | goto.cs:14:13:14:21 | After case ...: [no-match] | goto.cs:15:13:15:21 | case ...: | semmle.label | successor |
-| goto.cs:14:13:14:21 | case ...: | goto.cs:14:13:14:21 | After case ...: [match] | semmle.label | match |
-| goto.cs:14:13:14:21 | case ...: | goto.cs:14:13:14:21 | After case ...: [no-match] | semmle.label | no-match |
-| goto.cs:14:18:14:20 | "2" | goto.cs:14:23:14:24 | s5: | semmle.label | successor |
+| goto.cs:14:13:14:21 | case ...: | goto.cs:14:18:14:20 | "2" | semmle.label | successor |
+| goto.cs:14:18:14:20 | "2" | goto.cs:14:18:14:20 | After "2" [match] | semmle.label | match |
+| goto.cs:14:18:14:20 | "2" | goto.cs:14:18:14:20 | After "2" [no-match] | semmle.label | no-match |
+| goto.cs:14:18:14:20 | After "2" [match] | goto.cs:14:13:14:21 | After case ...: [match] | semmle.label | match |
+| goto.cs:14:18:14:20 | After "2" [no-match] | goto.cs:14:13:14:21 | After case ...: [no-match] | semmle.label | no-match |
 | goto.cs:14:23:14:24 | s5: | goto.cs:14:27:14:34 | Before goto ...; | semmle.label | successor |
 | goto.cs:14:27:14:34 | Before goto ...; | goto.cs:14:27:14:34 | goto ...; | semmle.label | successor |
 | goto.cs:14:27:14:34 | goto ...; | goto.cs:9:9:9:10 | s2: | semmle.label | goto |
-| goto.cs:15:13:15:21 | After case ...: [match] | goto.cs:15:18:15:20 | "3" | semmle.label | successor |
+| goto.cs:15:13:15:21 | After case ...: [match] | goto.cs:15:23:15:24 | s6: | semmle.label | successor |
 | goto.cs:15:13:15:21 | After case ...: [no-match] | goto.cs:16:13:16:21 | case ...: | semmle.label | successor |
-| goto.cs:15:13:15:21 | case ...: | goto.cs:15:13:15:21 | After case ...: [match] | semmle.label | match |
-| goto.cs:15:13:15:21 | case ...: | goto.cs:15:13:15:21 | After case ...: [no-match] | semmle.label | no-match |
-| goto.cs:15:18:15:20 | "3" | goto.cs:15:23:15:24 | s6: | semmle.label | successor |
+| goto.cs:15:13:15:21 | case ...: | goto.cs:15:18:15:20 | "3" | semmle.label | successor |
+| goto.cs:15:18:15:20 | "3" | goto.cs:15:18:15:20 | After "3" [match] | semmle.label | match |
+| goto.cs:15:18:15:20 | "3" | goto.cs:15:18:15:20 | After "3" [no-match] | semmle.label | no-match |
+| goto.cs:15:18:15:20 | After "3" [match] | goto.cs:15:13:15:21 | After case ...: [match] | semmle.label | match |
+| goto.cs:15:18:15:20 | After "3" [no-match] | goto.cs:15:13:15:21 | After case ...: [no-match] | semmle.label | no-match |
 | goto.cs:15:23:15:24 | s6: | goto.cs:15:27:15:39 | Before goto default; | semmle.label | successor |
 | goto.cs:15:27:15:39 | Before goto default; | goto.cs:15:27:15:39 | goto default; | semmle.label | successor |
 | goto.cs:15:27:15:39 | goto default; | goto.cs:17:13:17:20 | After default: [match] | semmle.label | goto |
-| goto.cs:16:13:16:21 | After case ...: [match] | goto.cs:16:18:16:20 | "4" | semmle.label | successor |
+| goto.cs:16:13:16:21 | After case ...: [match] | goto.cs:16:23:16:24 | s7: | semmle.label | successor |
 | goto.cs:16:13:16:21 | After case ...: [no-match] | goto.cs:17:13:17:20 | default: | semmle.label | successor |
-| goto.cs:16:13:16:21 | case ...: | goto.cs:16:13:16:21 | After case ...: [match] | semmle.label | match |
-| goto.cs:16:13:16:21 | case ...: | goto.cs:16:13:16:21 | After case ...: [no-match] | semmle.label | no-match |
-| goto.cs:16:18:16:20 | "4" | goto.cs:16:23:16:24 | s7: | semmle.label | successor |
+| goto.cs:16:13:16:21 | case ...: | goto.cs:16:18:16:20 | "4" | semmle.label | successor |
+| goto.cs:16:18:16:20 | "4" | goto.cs:16:18:16:20 | After "4" [match] | semmle.label | match |
+| goto.cs:16:18:16:20 | "4" | goto.cs:16:18:16:20 | After "4" [no-match] | semmle.label | no-match |
+| goto.cs:16:18:16:20 | After "4" [match] | goto.cs:16:13:16:21 | After case ...: [match] | semmle.label | match |
+| goto.cs:16:18:16:20 | After "4" [no-match] | goto.cs:16:13:16:21 | After case ...: [no-match] | semmle.label | no-match |
 | goto.cs:16:23:16:24 | s7: | goto.cs:16:27:16:32 | Before break; | semmle.label | successor |
 | goto.cs:16:27:16:32 | Before break; | goto.cs:16:27:16:32 | break; | semmle.label | successor |
 | goto.cs:16:27:16:32 | break; | goto.cs:10:9:18:9 | After switch (...) {...} | semmle.label | break |

--- a/java/ql/lib/semmle/code/java/ControlFlowGraph.qll
+++ b/java/ql/lib/semmle/code/java/ControlFlowGraph.qll
@@ -153,10 +153,10 @@ private module Ast implements AstSig<Location> {
   }
 
   class Case extends AstNode instanceof J::SwitchCase {
-    /** Gets a pattern being matched by this case. */
-    AstNode getAPattern() {
-      result = this.(PatternCase).getAPattern() or
-      result = this.(ConstCase).getValue(_)
+    /** Gets the pattern being matched by this case at the specified (zero-based) `index`. */
+    AstNode getPattern(int index) {
+      result = this.(PatternCase).getPattern(index) or
+      result = this.(ConstCase).getValue(index)
     }
 
     /** Gets the guard expression of this case, if any. */

--- a/java/ql/lib/semmle/code/java/controlflow/Guards.qll
+++ b/java/ql/lib/semmle/code/java/controlflow/Guards.qll
@@ -168,14 +168,20 @@ private module GuardsInput implements SharedGuards::InputSig<Location, ControlFl
       )
     }
 
+    private ControlFlowNode getPatternNode() {
+      result = this.(J::PatternCase).getUniquePattern().getControlFlowNode()
+      or
+      result = unique(Expr e | this.(J::ConstCase).getValue(_) = e).getControlFlowNode()
+    }
+
     predicate matchEdge(BasicBlock bb1, BasicBlock bb2) {
       bb1.getASuccessor(any(MatchingSuccessor s | s.getValue() = true)) = bb2 and
-      bb1.getLastNode() = super.getControlFlowNode()
+      bb1.getLastNode() = this.getPatternNode()
     }
 
     predicate nonMatchEdge(BasicBlock bb1, BasicBlock bb2) {
       bb1.getASuccessor(any(MatchingSuccessor s | s.getValue() = false)) = bb2 and
-      bb1.getLastNode() = super.getControlFlowNode()
+      bb1.getLastNode() = this.getPatternNode()
     }
   }
 

--- a/java/ql/test/library-tests/guards/guardslogic.expected
+++ b/java/ql/test/library-tests/guards/guardslogic.expected
@@ -19,15 +19,15 @@
 | Logic.java:17:11:17:15 | ... > ... | false | Logic.java:15:29:15:29 | i |
 | Logic.java:17:11:17:15 | ... > ... | true | Logic.java:17:18:17:23 | break |
 | Logic.java:19:9:19:12 | g(...) | false | Logic.java:24:7:24:17 | case ... |
-| Logic.java:19:9:19:12 | g(...) | false | Logic.java:24:12:24:16 | "foo" |
+| Logic.java:19:9:19:12 | g(...) | false | Logic.java:25:9:25:14 | break |
 | Logic.java:19:9:19:12 | g(...) | false | Logic.java:26:7:26:14 | default |
 | Logic.java:19:9:19:12 | g(...) | true | Logic.java:20:7:20:16 | <Expr>; |
 | Logic.java:22:7:22:17 | case ... | false | Logic.java:24:7:24:17 | case ... |
-| Logic.java:22:7:22:17 | case ... | false | Logic.java:24:12:24:16 | "foo" |
+| Logic.java:22:7:22:17 | case ... | false | Logic.java:25:9:25:14 | break |
 | Logic.java:22:7:22:17 | case ... | false | Logic.java:26:7:26:14 | default |
-| Logic.java:22:7:22:17 | case ... | true | Logic.java:22:12:22:16 | "bar" |
+| Logic.java:22:7:22:17 | case ... | true | Logic.java:23:9:23:14 | break |
 | Logic.java:24:7:24:17 | case ... | false | Logic.java:26:7:26:14 | default |
-| Logic.java:24:7:24:17 | case ... | true | Logic.java:24:12:24:16 | "foo" |
+| Logic.java:24:7:24:17 | case ... | true | Logic.java:25:9:25:14 | break |
 | Logic.java:29:16:29:19 | g(...) | false | Logic.java:29:30:29:30 | s |
 | Logic.java:29:16:29:19 | g(...) | false | Logic.java:30:30:31:5 | { ... } |
 | Logic.java:29:16:29:19 | g(...) | true | Logic.java:29:23:29:26 | null |

--- a/java/ql/test/library-tests/guards12/guard.expected
+++ b/java/ql/test/library-tests/guards12/guard.expected
@@ -1,80 +1,76 @@
 hasBranchEdge
-| Test.java:4:7:4:22 | case ... | Test.java:2:39:36:3 | { ... } | Test.java:4:7:4:22 | After case ... [match] | true |
-| Test.java:4:7:4:22 | case ... | Test.java:2:39:36:3 | { ... } | Test.java:5:7:5:17 | case ... | false |
-| Test.java:5:7:5:17 | case ... | Test.java:5:7:5:17 | case ... | Test.java:5:12:5:14 | "c" | true |
+| Test.java:5:7:5:17 | case ... | Test.java:5:7:5:17 | case ... | Test.java:5:19:5:19 | 2 | true |
 | Test.java:5:7:5:17 | case ... | Test.java:5:7:5:17 | case ... | Test.java:6:7:6:17 | case ... | false |
-| Test.java:6:7:6:17 | case ... | Test.java:6:7:6:17 | case ... | Test.java:6:12:6:14 | "d" | true |
+| Test.java:6:7:6:17 | case ... | Test.java:6:7:6:17 | case ... | Test.java:6:19:6:19 | 2 | true |
 | Test.java:6:7:6:17 | case ... | Test.java:6:7:6:17 | case ... | Test.java:7:7:7:16 | default | false |
-| Test.java:10:7:10:22 | case ... | Test.java:3:9:3:21 | x | Test.java:10:7:10:22 | After case ... [match] | true |
-| Test.java:10:7:10:22 | case ... | Test.java:3:9:3:21 | x | Test.java:11:7:11:17 | case ... | false |
-| Test.java:11:7:11:17 | case ... | Test.java:11:7:11:17 | case ... | Test.java:11:12:11:14 | "c" | true |
+| Test.java:11:7:11:17 | case ... | Test.java:11:7:11:17 | case ... | Test.java:11:19:11:21 | { ... } | true |
 | Test.java:11:7:11:17 | case ... | Test.java:11:7:11:17 | case ... | Test.java:12:7:12:17 | case ... | false |
-| Test.java:12:7:12:17 | case ... | Test.java:12:7:12:17 | case ... | Test.java:12:12:12:14 | "d" | true |
+| Test.java:12:7:12:17 | case ... | Test.java:12:7:12:17 | case ... | Test.java:12:19:12:21 | { ... } | true |
 | Test.java:12:7:12:17 | case ... | Test.java:12:7:12:17 | case ... | Test.java:13:7:13:16 | default | false |
-| Test.java:17:7:17:36 | case <Pattern> | Test.java:15:5:15:25 | var ...; | Test.java:17:7:17:36 | After case <Pattern> [no-match] | false |
-| Test.java:17:7:17:36 | case <Pattern> | Test.java:15:5:15:25 | var ...; | Test.java:17:19:17:19 | <anonymous local variable> | true |
-| Test.java:17:26:17:33 | ... == ... | Test.java:17:19:17:19 | <anonymous local variable> | Test.java:17:26:17:33 | After ... == ... [false] | false |
-| Test.java:17:26:17:33 | ... == ... | Test.java:17:19:17:19 | <anonymous local variable> | Test.java:17:38:17:40 | { ... } | true |
-| Test.java:18:7:18:17 | case ... | Test.java:18:7:18:17 | case ... | Test.java:18:12:18:14 | "e" | true |
+| Test.java:17:7:17:36 | case <Pattern> | Test.java:15:5:15:25 | var ...; | Test.java:17:19:17:19 | After <anonymous local variable> [no-match] | false |
+| Test.java:17:7:17:36 | case <Pattern> | Test.java:15:5:15:25 | var ...; | Test.java:17:26:17:28 | len | true |
+| Test.java:17:26:17:33 | ... == ... | Test.java:17:26:17:28 | len | Test.java:17:26:17:33 | After ... == ... [false] | false |
+| Test.java:17:26:17:33 | ... == ... | Test.java:17:26:17:28 | len | Test.java:17:38:17:40 | { ... } | true |
+| Test.java:18:7:18:17 | case ... | Test.java:18:7:18:17 | case ... | Test.java:18:19:18:21 | { ... } | true |
 | Test.java:18:7:18:17 | case ... | Test.java:18:7:18:17 | case ... | Test.java:19:7:19:16 | default | false |
 | Test.java:21:13:21:19 | unknown | Test.java:21:5:21:42 | switch (...) | Test.java:21:23:21:23 | s | true |
 | Test.java:21:13:21:19 | unknown | Test.java:21:5:21:42 | switch (...) | Test.java:21:27:21:27 | s | false |
-| Test.java:22:7:22:17 | case ... | Test.java:22:7:22:17 | case ... | Test.java:22:12:22:14 | "f" | true |
+| Test.java:22:7:22:17 | case ... | Test.java:22:7:22:17 | case ... | Test.java:22:19:22:21 | { ... } | true |
 | Test.java:22:7:22:17 | case ... | Test.java:22:7:22:17 | case ... | Test.java:23:7:23:37 | case <Pattern> | false |
-| Test.java:23:7:23:37 | case <Pattern> | Test.java:23:7:23:37 | case <Pattern> | Test.java:23:7:23:37 | After case <Pattern> [no-match] | false |
-| Test.java:23:7:23:37 | case <Pattern> | Test.java:23:7:23:37 | case <Pattern> | Test.java:23:19:23:20 | s2 | true |
-| Test.java:23:27:23:34 | ... == ... | Test.java:23:19:23:20 | s2 | Test.java:23:27:23:34 | After ... == ... [false] | false |
-| Test.java:23:27:23:34 | ... == ... | Test.java:23:19:23:20 | s2 | Test.java:23:39:23:41 | { ... } | true |
-| Test.java:24:7:24:17 | case ... | Test.java:24:7:24:17 | case ... | Test.java:24:12:24:14 | "g" | true |
+| Test.java:23:7:23:37 | case <Pattern> | Test.java:23:7:23:37 | case <Pattern> | Test.java:23:19:23:20 | After s2 [no-match] | false |
+| Test.java:23:7:23:37 | case <Pattern> | Test.java:23:7:23:37 | case <Pattern> | Test.java:23:27:23:29 | len | true |
+| Test.java:23:27:23:34 | ... == ... | Test.java:23:27:23:29 | len | Test.java:23:27:23:34 | After ... == ... [false] | false |
+| Test.java:23:27:23:34 | ... == ... | Test.java:23:27:23:29 | len | Test.java:23:39:23:41 | { ... } | true |
+| Test.java:24:7:24:17 | case ... | Test.java:24:7:24:17 | case ... | Test.java:24:19:24:21 | { ... } | true |
 | Test.java:24:7:24:17 | case ... | Test.java:24:7:24:17 | case ... | Test.java:25:7:25:16 | default | false |
-| Test.java:28:7:28:15 | case ... | Test.java:27:5:27:14 | switch (...) | Test.java:28:12:28:14 | "h" | true |
+| Test.java:28:7:28:15 | case ... | Test.java:27:5:27:14 | switch (...) | Test.java:28:12:28:14 | After "h" [match] | true |
 | Test.java:28:7:28:15 | case ... | Test.java:27:5:27:14 | switch (...) | Test.java:29:7:29:34 | case <Pattern> | false |
-| Test.java:29:7:29:34 | case <Pattern> | Test.java:29:7:29:34 | case <Pattern> | Test.java:29:7:29:34 | After case <Pattern> [no-match] | false |
-| Test.java:29:7:29:34 | case <Pattern> | Test.java:29:7:29:34 | case <Pattern> | Test.java:29:19:29:19 | <anonymous local variable> | true |
-| Test.java:29:26:29:33 | ... == ... | Test.java:29:19:29:19 | <anonymous local variable> | Test.java:29:26:29:33 | After ... == ... [false] | false |
-| Test.java:29:26:29:33 | ... == ... | Test.java:29:19:29:19 | <anonymous local variable> | Test.java:29:26:29:33 | After ... == ... [true] | true |
-| Test.java:30:7:30:15 | case ... | Test.java:30:7:30:15 | case ... | Test.java:30:12:30:14 | "i" | true |
+| Test.java:29:7:29:34 | case <Pattern> | Test.java:29:7:29:34 | case <Pattern> | Test.java:29:19:29:19 | After <anonymous local variable> [no-match] | false |
+| Test.java:29:7:29:34 | case <Pattern> | Test.java:29:7:29:34 | case <Pattern> | Test.java:29:26:29:28 | len | true |
+| Test.java:29:26:29:33 | ... == ... | Test.java:29:26:29:28 | len | Test.java:29:26:29:33 | After ... == ... [false] | false |
+| Test.java:29:26:29:33 | ... == ... | Test.java:29:26:29:28 | len | Test.java:29:26:29:33 | After ... == ... [true] | true |
+| Test.java:30:7:30:15 | case ... | Test.java:30:7:30:15 | case ... | Test.java:30:12:30:14 | After "i" [match] | true |
 | Test.java:30:7:30:15 | case ... | Test.java:30:7:30:15 | case ... | Test.java:33:7:33:14 | default | false |
 #select
 | Test.java:5:7:5:17 | case ... | Test.java:3:20:3:20 | s | Test.java:5:12:5:14 | "c" | true | false | Test.java:6:7:6:17 | case ... |
-| Test.java:5:7:5:17 | case ... | Test.java:3:20:3:20 | s | Test.java:5:12:5:14 | "c" | true | false | Test.java:6:12:6:14 | "d" |
+| Test.java:5:7:5:17 | case ... | Test.java:3:20:3:20 | s | Test.java:5:12:5:14 | "c" | true | false | Test.java:6:19:6:19 | 2 |
 | Test.java:5:7:5:17 | case ... | Test.java:3:20:3:20 | s | Test.java:5:12:5:14 | "c" | true | false | Test.java:7:7:7:16 | default |
-| Test.java:5:7:5:17 | case ... | Test.java:3:20:3:20 | s | Test.java:5:12:5:14 | "c" | true | true | Test.java:5:12:5:14 | "c" |
+| Test.java:5:7:5:17 | case ... | Test.java:3:20:3:20 | s | Test.java:5:12:5:14 | "c" | true | true | Test.java:5:19:5:19 | 2 |
 | Test.java:6:7:6:17 | case ... | Test.java:3:20:3:20 | s | Test.java:6:12:6:14 | "d" | true | false | Test.java:7:7:7:16 | default |
-| Test.java:6:7:6:17 | case ... | Test.java:3:20:3:20 | s | Test.java:6:12:6:14 | "d" | true | true | Test.java:6:12:6:14 | "d" |
+| Test.java:6:7:6:17 | case ... | Test.java:3:20:3:20 | s | Test.java:6:12:6:14 | "d" | true | true | Test.java:6:19:6:19 | 2 |
 | Test.java:11:7:11:17 | case ... | Test.java:9:13:9:13 | s | Test.java:11:12:11:14 | "c" | true | false | Test.java:12:7:12:17 | case ... |
-| Test.java:11:7:11:17 | case ... | Test.java:9:13:9:13 | s | Test.java:11:12:11:14 | "c" | true | false | Test.java:12:12:12:14 | "d" |
+| Test.java:11:7:11:17 | case ... | Test.java:9:13:9:13 | s | Test.java:11:12:11:14 | "c" | true | false | Test.java:12:19:12:21 | { ... } |
 | Test.java:11:7:11:17 | case ... | Test.java:9:13:9:13 | s | Test.java:11:12:11:14 | "c" | true | false | Test.java:13:7:13:16 | default |
-| Test.java:11:7:11:17 | case ... | Test.java:9:13:9:13 | s | Test.java:11:12:11:14 | "c" | true | true | Test.java:11:12:11:14 | "c" |
+| Test.java:11:7:11:17 | case ... | Test.java:9:13:9:13 | s | Test.java:11:12:11:14 | "c" | true | true | Test.java:11:19:11:21 | { ... } |
 | Test.java:12:7:12:17 | case ... | Test.java:9:13:9:13 | s | Test.java:12:12:12:14 | "d" | true | false | Test.java:13:7:13:16 | default |
-| Test.java:12:7:12:17 | case ... | Test.java:9:13:9:13 | s | Test.java:12:12:12:14 | "d" | true | true | Test.java:12:12:12:14 | "d" |
+| Test.java:12:7:12:17 | case ... | Test.java:9:13:9:13 | s | Test.java:12:12:12:14 | "d" | true | true | Test.java:12:19:12:21 | { ... } |
 | Test.java:17:26:17:33 | ... == ... | Test.java:17:26:17:28 | len | Test.java:17:33:17:33 | 4 | true | false | Test.java:17:26:17:33 | After ... == ... [false] |
 | Test.java:17:26:17:33 | ... == ... | Test.java:17:26:17:28 | len | Test.java:17:33:17:33 | 4 | true | true | Test.java:17:38:17:40 | { ... } |
 | Test.java:18:7:18:17 | case ... | Test.java:16:13:16:13 | s | Test.java:18:12:18:14 | "e" | true | false | Test.java:19:7:19:16 | default |
-| Test.java:18:7:18:17 | case ... | Test.java:16:13:16:13 | s | Test.java:18:12:18:14 | "e" | true | true | Test.java:18:12:18:14 | "e" |
-| Test.java:22:7:22:17 | case ... | Test.java:21:13:21:41 | ...?...:... | Test.java:22:12:22:14 | "f" | true | false | Test.java:23:7:23:37 | After case <Pattern> [no-match] |
+| Test.java:18:7:18:17 | case ... | Test.java:16:13:16:13 | s | Test.java:18:12:18:14 | "e" | true | true | Test.java:18:19:18:21 | { ... } |
 | Test.java:22:7:22:17 | case ... | Test.java:21:13:21:41 | ...?...:... | Test.java:22:12:22:14 | "f" | true | false | Test.java:23:7:23:37 | case <Pattern> |
-| Test.java:22:7:22:17 | case ... | Test.java:21:13:21:41 | ...?...:... | Test.java:22:12:22:14 | "f" | true | false | Test.java:23:19:23:20 | s2 |
+| Test.java:22:7:22:17 | case ... | Test.java:21:13:21:41 | ...?...:... | Test.java:22:12:22:14 | "f" | true | false | Test.java:23:19:23:20 | After s2 [no-match] |
+| Test.java:22:7:22:17 | case ... | Test.java:21:13:21:41 | ...?...:... | Test.java:22:12:22:14 | "f" | true | false | Test.java:23:27:23:29 | len |
 | Test.java:22:7:22:17 | case ... | Test.java:21:13:21:41 | ...?...:... | Test.java:22:12:22:14 | "f" | true | false | Test.java:23:27:23:34 | After ... == ... [false] |
 | Test.java:22:7:22:17 | case ... | Test.java:21:13:21:41 | ...?...:... | Test.java:22:12:22:14 | "f" | true | false | Test.java:23:39:23:41 | { ... } |
 | Test.java:22:7:22:17 | case ... | Test.java:21:13:21:41 | ...?...:... | Test.java:22:12:22:14 | "f" | true | false | Test.java:24:7:24:17 | case ... |
-| Test.java:22:7:22:17 | case ... | Test.java:21:13:21:41 | ...?...:... | Test.java:22:12:22:14 | "f" | true | false | Test.java:24:12:24:14 | "g" |
+| Test.java:22:7:22:17 | case ... | Test.java:21:13:21:41 | ...?...:... | Test.java:22:12:22:14 | "f" | true | false | Test.java:24:19:24:21 | { ... } |
 | Test.java:22:7:22:17 | case ... | Test.java:21:13:21:41 | ...?...:... | Test.java:22:12:22:14 | "f" | true | false | Test.java:25:7:25:16 | default |
-| Test.java:22:7:22:17 | case ... | Test.java:21:13:21:41 | ...?...:... | Test.java:22:12:22:14 | "f" | true | true | Test.java:22:12:22:14 | "f" |
+| Test.java:22:7:22:17 | case ... | Test.java:21:13:21:41 | ...?...:... | Test.java:22:12:22:14 | "f" | true | true | Test.java:22:19:22:21 | { ... } |
 | Test.java:23:27:23:34 | ... == ... | Test.java:23:27:23:29 | len | Test.java:23:34:23:34 | 4 | true | false | Test.java:23:27:23:34 | After ... == ... [false] |
 | Test.java:23:27:23:34 | ... == ... | Test.java:23:27:23:29 | len | Test.java:23:34:23:34 | 4 | true | true | Test.java:23:39:23:41 | { ... } |
 | Test.java:24:7:24:17 | case ... | Test.java:21:13:21:41 | ...?...:... | Test.java:24:12:24:14 | "g" | true | false | Test.java:25:7:25:16 | default |
-| Test.java:24:7:24:17 | case ... | Test.java:21:13:21:41 | ...?...:... | Test.java:24:12:24:14 | "g" | true | true | Test.java:24:12:24:14 | "g" |
-| Test.java:28:7:28:15 | case ... | Test.java:27:13:27:13 | s | Test.java:28:12:28:14 | "h" | true | false | Test.java:29:7:29:34 | After case <Pattern> [no-match] |
+| Test.java:24:7:24:17 | case ... | Test.java:21:13:21:41 | ...?...:... | Test.java:24:12:24:14 | "g" | true | true | Test.java:24:19:24:21 | { ... } |
 | Test.java:28:7:28:15 | case ... | Test.java:27:13:27:13 | s | Test.java:28:12:28:14 | "h" | true | false | Test.java:29:7:29:34 | case <Pattern> |
-| Test.java:28:7:28:15 | case ... | Test.java:27:13:27:13 | s | Test.java:28:12:28:14 | "h" | true | false | Test.java:29:19:29:19 | <anonymous local variable> |
+| Test.java:28:7:28:15 | case ... | Test.java:27:13:27:13 | s | Test.java:28:12:28:14 | "h" | true | false | Test.java:29:19:29:19 | After <anonymous local variable> [no-match] |
+| Test.java:28:7:28:15 | case ... | Test.java:27:13:27:13 | s | Test.java:28:12:28:14 | "h" | true | false | Test.java:29:26:29:28 | len |
 | Test.java:28:7:28:15 | case ... | Test.java:27:13:27:13 | s | Test.java:28:12:28:14 | "h" | true | false | Test.java:29:26:29:33 | After ... == ... [false] |
 | Test.java:28:7:28:15 | case ... | Test.java:27:13:27:13 | s | Test.java:28:12:28:14 | "h" | true | false | Test.java:29:26:29:33 | After ... == ... [true] |
 | Test.java:28:7:28:15 | case ... | Test.java:27:13:27:13 | s | Test.java:28:12:28:14 | "h" | true | false | Test.java:30:7:30:15 | case ... |
-| Test.java:28:7:28:15 | case ... | Test.java:27:13:27:13 | s | Test.java:28:12:28:14 | "h" | true | false | Test.java:30:12:30:14 | "i" |
+| Test.java:28:7:28:15 | case ... | Test.java:27:13:27:13 | s | Test.java:28:12:28:14 | "h" | true | false | Test.java:30:12:30:14 | After "i" [match] |
 | Test.java:28:7:28:15 | case ... | Test.java:27:13:27:13 | s | Test.java:28:12:28:14 | "h" | true | false | Test.java:33:7:33:14 | default |
-| Test.java:28:7:28:15 | case ... | Test.java:27:13:27:13 | s | Test.java:28:12:28:14 | "h" | true | true | Test.java:28:12:28:14 | "h" |
+| Test.java:28:7:28:15 | case ... | Test.java:27:13:27:13 | s | Test.java:28:12:28:14 | "h" | true | true | Test.java:28:12:28:14 | After "h" [match] |
 | Test.java:29:26:29:33 | ... == ... | Test.java:29:26:29:28 | len | Test.java:29:33:29:33 | 4 | true | false | Test.java:29:26:29:33 | After ... == ... [false] |
 | Test.java:29:26:29:33 | ... == ... | Test.java:29:26:29:28 | len | Test.java:29:33:29:33 | 4 | true | true | Test.java:29:26:29:33 | After ... == ... [true] |
 | Test.java:30:7:30:15 | case ... | Test.java:27:13:27:13 | s | Test.java:30:12:30:14 | "i" | true | false | Test.java:33:7:33:14 | default |
-| Test.java:30:7:30:15 | case ... | Test.java:27:13:27:13 | s | Test.java:30:12:30:14 | "i" | true | true | Test.java:30:12:30:14 | "i" |
+| Test.java:30:7:30:15 | case ... | Test.java:27:13:27:13 | s | Test.java:30:12:30:14 | "i" | true | true | Test.java:30:12:30:14 | After "i" [match] |

--- a/java/ql/test/library-tests/pattern-switch/cfg/test.expected
+++ b/java/ql/test/library-tests/pattern-switch/cfg/test.expected
@@ -35,8 +35,8 @@
 | Exhaustive.java:11:5:11:14 | switch (...) | Exhaustive.java:11:13:11:13 | o |
 | Exhaustive.java:11:13:11:13 | o | Exhaustive.java:12:7:12:22 | case <Pattern> |
 | Exhaustive.java:12:7:12:22 | case <Pattern> | Exhaustive.java:12:19:12:19 | s |
-| Exhaustive.java:12:7:12:22 | case <Pattern> | Exhaustive.java:13:7:13:23 | case <Pattern> |
 | Exhaustive.java:12:19:12:19 | s | Exhaustive.java:12:24:12:26 | { ... } |
+| Exhaustive.java:12:19:12:19 | s | Exhaustive.java:13:7:13:23 | case <Pattern> |
 | Exhaustive.java:12:24:12:26 | { ... } | Exhaustive.java:18:5:18:14 | switch (...) |
 | Exhaustive.java:13:7:13:23 | case <Pattern> | Exhaustive.java:13:19:13:20 | o2 |
 | Exhaustive.java:13:19:13:20 | o2 | Exhaustive.java:13:25:13:27 | { ... } |
@@ -44,22 +44,22 @@
 | Exhaustive.java:18:5:18:14 | switch (...) | Exhaustive.java:18:13:18:13 | e |
 | Exhaustive.java:18:13:18:13 | e | Exhaustive.java:19:7:19:15 | case ... |
 | Exhaustive.java:19:7:19:15 | case ... | Exhaustive.java:19:12:19:12 | A |
-| Exhaustive.java:19:7:19:15 | case ... | Exhaustive.java:20:7:20:15 | case ... |
 | Exhaustive.java:19:12:19:12 | A | Exhaustive.java:19:17:19:19 | { ... } |
+| Exhaustive.java:19:12:19:12 | A | Exhaustive.java:20:7:20:15 | case ... |
 | Exhaustive.java:19:17:19:19 | { ... } | Exhaustive.java:24:5:24:14 | switch (...) |
 | Exhaustive.java:20:7:20:15 | case ... | Exhaustive.java:20:12:20:12 | B |
-| Exhaustive.java:20:7:20:15 | case ... | Exhaustive.java:21:7:21:15 | case ... |
 | Exhaustive.java:20:12:20:12 | B | Exhaustive.java:20:17:20:19 | { ... } |
+| Exhaustive.java:20:12:20:12 | B | Exhaustive.java:21:7:21:15 | case ... |
 | Exhaustive.java:20:17:20:19 | { ... } | Exhaustive.java:24:5:24:14 | switch (...) |
 | Exhaustive.java:21:7:21:15 | case ... | Exhaustive.java:21:12:21:12 | C |
-| Exhaustive.java:21:7:21:15 | case ... | Exhaustive.java:24:5:24:14 | switch (...) |
 | Exhaustive.java:21:12:21:12 | C | Exhaustive.java:21:17:21:19 | { ... } |
+| Exhaustive.java:21:12:21:12 | C | Exhaustive.java:24:5:24:14 | switch (...) |
 | Exhaustive.java:21:17:21:19 | { ... } | Exhaustive.java:24:5:24:14 | switch (...) |
 | Exhaustive.java:24:5:24:14 | switch (...) | Exhaustive.java:24:13:24:13 | i |
 | Exhaustive.java:24:13:24:13 | i | Exhaustive.java:25:7:25:17 | case <Pattern> |
 | Exhaustive.java:25:7:25:17 | case <Pattern> | Exhaustive.java:25:14:25:14 | x |
-| Exhaustive.java:25:7:25:17 | case <Pattern> | Exhaustive.java:26:7:26:17 | case <Pattern> |
 | Exhaustive.java:25:14:25:14 | x | Exhaustive.java:25:19:25:21 | { ... } |
+| Exhaustive.java:25:14:25:14 | x | Exhaustive.java:26:7:26:17 | case <Pattern> |
 | Exhaustive.java:25:19:25:21 | { ... } | Exhaustive.java:30:5:30:14 | switch (...) |
 | Exhaustive.java:26:7:26:17 | case <Pattern> | Exhaustive.java:26:14:26:14 | y |
 | Exhaustive.java:26:14:26:14 | y | Exhaustive.java:26:19:26:21 | { ... } |
@@ -67,8 +67,8 @@
 | Exhaustive.java:30:5:30:14 | switch (...) | Exhaustive.java:30:13:30:13 | i |
 | Exhaustive.java:30:13:30:13 | i | Exhaustive.java:31:7:31:15 | case <Pattern> |
 | Exhaustive.java:31:7:31:15 | case <Pattern> | Exhaustive.java:31:14:31:14 | <anonymous local variable> |
-| Exhaustive.java:31:7:31:15 | case <Pattern> | Exhaustive.java:32:7:32:15 | case <Pattern> |
 | Exhaustive.java:31:14:31:14 | <anonymous local variable> | Exhaustive.java:8:22:8:25 | Normal Exit |
+| Exhaustive.java:31:14:31:14 | <anonymous local variable> | Exhaustive.java:32:7:32:15 | case <Pattern> |
 | Exhaustive.java:32:7:32:15 | case <Pattern> | Exhaustive.java:32:14:32:14 | <anonymous local variable> |
 | Exhaustive.java:32:14:32:14 | <anonymous local variable> | Exhaustive.java:8:22:8:25 | Normal Exit |
 | Test.java:1:14:1:17 | Entry | Test.java:1:14:1:17 | { ... } |
@@ -81,14 +81,14 @@
 | Test.java:5:6:5:19 | switch (...) | Test.java:5:14:5:18 | thing |
 | Test.java:5:14:5:18 | thing | Test.java:6:8:6:23 | case <Pattern> |
 | Test.java:6:8:6:23 | case <Pattern> | Test.java:6:20:6:20 | s |
-| Test.java:6:8:6:23 | case <Pattern> | Test.java:7:8:7:24 | case <Pattern> |
 | Test.java:6:20:6:20 | s | Test.java:6:25:6:34 | System.out |
+| Test.java:6:20:6:20 | s | Test.java:7:8:7:24 | case <Pattern> |
 | Test.java:6:25:6:34 | System.out | Test.java:6:44:6:44 | s |
 | Test.java:6:25:6:45 | println(...) | Test.java:11:6:11:19 | switch (...) |
 | Test.java:6:44:6:44 | s | Test.java:6:25:6:45 | println(...) |
 | Test.java:7:8:7:24 | case <Pattern> | Test.java:7:21:7:21 | i |
-| Test.java:7:8:7:24 | case <Pattern> | Test.java:8:8:8:17 | default |
 | Test.java:7:21:7:21 | i | Test.java:7:26:7:35 | System.out |
+| Test.java:7:21:7:21 | i | Test.java:8:8:8:17 | default |
 | Test.java:7:26:7:35 | System.out | Test.java:7:45:7:58 | "An integer: " |
 | Test.java:7:26:7:63 | println(...) | Test.java:11:6:11:19 | switch (...) |
 | Test.java:7:45:7:58 | "An integer: " | Test.java:7:62:7:62 | i |
@@ -99,16 +99,16 @@
 | Test.java:11:6:11:19 | switch (...) | Test.java:11:14:11:18 | thing |
 | Test.java:11:14:11:18 | thing | Test.java:12:8:12:21 | case <Pattern> |
 | Test.java:12:8:12:21 | case <Pattern> | Test.java:12:20:12:20 | s |
-| Test.java:12:8:12:21 | case <Pattern> | Test.java:15:8:15:22 | case <Pattern> |
 | Test.java:12:20:12:20 | s | Test.java:13:10:13:31 | <Expr>; |
+| Test.java:12:20:12:20 | s | Test.java:15:8:15:22 | case <Pattern> |
 | Test.java:13:10:13:19 | System.out | Test.java:13:29:13:29 | s |
 | Test.java:13:10:13:30 | println(...) | Test.java:14:10:14:15 | break |
 | Test.java:13:10:13:31 | <Expr>; | Test.java:13:10:13:19 | System.out |
 | Test.java:13:29:13:29 | s | Test.java:13:10:13:30 | println(...) |
 | Test.java:14:10:14:15 | break | Test.java:22:6:26:7 | var ...; |
 | Test.java:15:8:15:22 | case <Pattern> | Test.java:15:21:15:21 | i |
-| Test.java:15:8:15:22 | case <Pattern> | Test.java:18:8:18:15 | default |
 | Test.java:15:21:15:21 | i | Test.java:16:10:16:47 | <Expr>; |
+| Test.java:15:21:15:21 | i | Test.java:18:8:18:15 | default |
 | Test.java:16:10:16:19 | System.out | Test.java:16:29:16:41 | "An integer:" |
 | Test.java:16:10:16:46 | println(...) | Test.java:17:10:17:15 | break |
 | Test.java:16:10:16:47 | <Expr>; | Test.java:16:10:16:19 | System.out |
@@ -123,12 +123,12 @@
 | Test.java:22:26:22:38 | switch (...) | Test.java:22:33:22:37 | thing |
 | Test.java:22:33:22:37 | thing | Test.java:23:8:23:23 | case <Pattern> |
 | Test.java:23:8:23:23 | case <Pattern> | Test.java:23:20:23:20 | s |
-| Test.java:23:8:23:23 | case <Pattern> | Test.java:24:8:24:24 | case <Pattern> |
 | Test.java:23:20:23:20 | s | Test.java:23:25:23:25 | s |
+| Test.java:23:20:23:20 | s | Test.java:24:8:24:24 | case <Pattern> |
 | Test.java:23:25:23:25 | s | Test.java:22:10:22:38 | thingAsString |
 | Test.java:24:8:24:24 | case <Pattern> | Test.java:24:21:24:21 | i |
-| Test.java:24:8:24:24 | case <Pattern> | Test.java:25:8:25:17 | default |
 | Test.java:24:21:24:21 | i | Test.java:24:26:24:39 | "An integer: " |
+| Test.java:24:21:24:21 | i | Test.java:25:8:25:17 | default |
 | Test.java:24:26:24:39 | "An integer: " | Test.java:24:43:24:43 | i |
 | Test.java:24:26:24:43 | ... + ... | Test.java:22:10:22:38 | thingAsString |
 | Test.java:24:43:24:43 | i | Test.java:24:26:24:43 | ... + ... |
@@ -139,13 +139,13 @@
 | Test.java:28:27:28:39 | switch (...) | Test.java:28:34:28:38 | thing |
 | Test.java:28:34:28:38 | thing | Test.java:29:8:29:21 | case <Pattern> |
 | Test.java:29:8:29:21 | case <Pattern> | Test.java:29:20:29:20 | s |
-| Test.java:29:8:29:21 | case <Pattern> | Test.java:31:8:31:22 | case <Pattern> |
 | Test.java:29:20:29:20 | s | Test.java:30:16:30:16 | s |
+| Test.java:29:20:29:20 | s | Test.java:31:8:31:22 | case <Pattern> |
 | Test.java:30:10:30:17 | yield ... | Test.java:28:10:28:39 | thingAsString2 |
 | Test.java:30:16:30:16 | s | Test.java:30:10:30:17 | yield ... |
 | Test.java:31:8:31:22 | case <Pattern> | Test.java:31:21:31:21 | i |
-| Test.java:31:8:31:22 | case <Pattern> | Test.java:33:8:33:15 | default |
 | Test.java:31:21:31:21 | i | Test.java:32:16:32:29 | "An integer: " |
+| Test.java:31:21:31:21 | i | Test.java:33:8:33:15 | default |
 | Test.java:32:10:32:34 | yield ... | Test.java:28:10:28:39 | thingAsString2 |
 | Test.java:32:16:32:29 | "An integer: " | Test.java:32:33:32:33 | i |
 | Test.java:32:16:32:33 | ... + ... | Test.java:32:10:32:34 | yield ... |
@@ -156,8 +156,8 @@
 | Test.java:37:6:37:18 | switch (...) | Test.java:37:13:37:17 | thing |
 | Test.java:37:13:37:17 | thing | Test.java:38:8:38:42 | case <Pattern> |
 | Test.java:38:8:38:42 | case <Pattern> | Test.java:38:20:38:20 | s |
-| Test.java:38:8:38:42 | case <Pattern> | Test.java:41:8:41:42 | case <Pattern> |
 | Test.java:38:20:38:20 | s | Test.java:38:27:38:27 | s |
+| Test.java:38:20:38:20 | s | Test.java:41:8:41:42 | case <Pattern> |
 | Test.java:38:27:38:27 | s | Test.java:38:27:38:36 | length(...) |
 | Test.java:38:27:38:36 | length(...) | Test.java:38:41:38:41 | 3 |
 | Test.java:38:27:38:41 | ... == ... | Test.java:39:10:39:40 | <Expr>; |
@@ -169,8 +169,8 @@
 | Test.java:39:29:39:38 | "Length 3" | Test.java:39:10:39:39 | println(...) |
 | Test.java:40:10:40:15 | break | Test.java:49:6:49:18 | switch (...) |
 | Test.java:41:8:41:42 | case <Pattern> | Test.java:41:20:41:20 | s |
-| Test.java:41:8:41:42 | case <Pattern> | Test.java:44:8:44:15 | default |
 | Test.java:41:20:41:20 | s | Test.java:41:27:41:27 | s |
+| Test.java:41:20:41:20 | s | Test.java:44:8:44:15 | default |
 | Test.java:41:27:41:27 | s | Test.java:41:27:41:36 | length(...) |
 | Test.java:41:27:41:36 | length(...) | Test.java:41:41:41:41 | 5 |
 | Test.java:41:27:41:41 | ... == ... | Test.java:42:10:42:40 | <Expr>; |
@@ -190,8 +190,8 @@
 | Test.java:49:6:49:18 | switch (...) | Test.java:49:13:49:17 | thing |
 | Test.java:49:13:49:17 | thing | Test.java:50:8:50:44 | case <Pattern> |
 | Test.java:50:8:50:44 | case <Pattern> | Test.java:50:20:50:20 | s |
-| Test.java:50:8:50:44 | case <Pattern> | Test.java:51:8:51:44 | case <Pattern> |
 | Test.java:50:20:50:20 | s | Test.java:50:27:50:27 | s |
+| Test.java:50:20:50:20 | s | Test.java:51:8:51:44 | case <Pattern> |
 | Test.java:50:27:50:27 | s | Test.java:50:27:50:36 | length(...) |
 | Test.java:50:27:50:36 | length(...) | Test.java:50:41:50:41 | 3 |
 | Test.java:50:27:50:41 | ... == ... | Test.java:50:46:50:55 | System.out |
@@ -201,8 +201,8 @@
 | Test.java:50:46:50:75 | println(...) | Test.java:55:6:55:26 | switch (...) |
 | Test.java:50:65:50:74 | "Length 3" | Test.java:50:46:50:75 | println(...) |
 | Test.java:51:8:51:44 | case <Pattern> | Test.java:51:20:51:20 | s |
-| Test.java:51:8:51:44 | case <Pattern> | Test.java:52:8:52:17 | default |
 | Test.java:51:20:51:20 | s | Test.java:51:27:51:27 | s |
+| Test.java:51:20:51:20 | s | Test.java:52:8:52:17 | default |
 | Test.java:51:27:51:27 | s | Test.java:51:27:51:36 | length(...) |
 | Test.java:51:27:51:36 | length(...) | Test.java:51:41:51:41 | 5 |
 | Test.java:51:27:51:41 | ... == ... | Test.java:51:46:51:55 | System.out |
@@ -217,23 +217,23 @@
 | Test.java:55:13:55:25 | (...)... | Test.java:56:8:56:21 | case ... |
 | Test.java:55:21:55:25 | thing | Test.java:55:13:55:25 | (...)... |
 | Test.java:56:8:56:21 | case ... | Test.java:56:13:56:20 | "Const1" |
-| Test.java:56:8:56:21 | case ... | Test.java:58:8:58:21 | case ... |
 | Test.java:56:13:56:20 | "Const1" | Test.java:57:10:57:44 | <Expr>; |
+| Test.java:56:13:56:20 | "Const1" | Test.java:58:8:58:21 | case ... |
 | Test.java:57:10:57:19 | System.out | Test.java:57:29:57:42 | "It's Const1!" |
 | Test.java:57:10:57:43 | println(...) | Test.java:59:10:59:54 | <Expr>; |
 | Test.java:57:10:57:44 | <Expr>; | Test.java:57:10:57:19 | System.out |
 | Test.java:57:29:57:42 | "It's Const1!" | Test.java:57:10:57:43 | println(...) |
 | Test.java:58:8:58:21 | case ... | Test.java:58:13:58:20 | "Const2" |
-| Test.java:58:8:58:21 | case ... | Test.java:61:8:61:42 | case <Pattern> |
 | Test.java:58:13:58:20 | "Const2" | Test.java:59:10:59:54 | <Expr>; |
+| Test.java:58:13:58:20 | "Const2" | Test.java:61:8:61:42 | case <Pattern> |
 | Test.java:59:10:59:19 | System.out | Test.java:59:29:59:52 | "It's Const1 or Const2!" |
 | Test.java:59:10:59:53 | println(...) | Test.java:60:10:60:15 | break |
 | Test.java:59:10:59:54 | <Expr>; | Test.java:59:10:59:19 | System.out |
 | Test.java:59:29:59:52 | "It's Const1 or Const2!" | Test.java:59:10:59:53 | println(...) |
 | Test.java:60:10:60:15 | break | Test.java:73:6:73:18 | switch (...) |
 | Test.java:61:8:61:42 | case <Pattern> | Test.java:61:20:61:20 | s |
-| Test.java:61:8:61:42 | case <Pattern> | Test.java:63:8:63:21 | case ... |
 | Test.java:61:20:61:20 | s | Test.java:61:27:61:27 | s |
+| Test.java:61:20:61:20 | s | Test.java:63:8:63:21 | case ... |
 | Test.java:61:27:61:27 | s | Test.java:61:27:61:36 | length(...) |
 | Test.java:61:27:61:36 | length(...) | Test.java:61:41:61:41 | 6 |
 | Test.java:61:27:61:41 | ... <= ... | Test.java:62:10:62:83 | <Expr>; |
@@ -244,16 +244,16 @@
 | Test.java:62:10:62:83 | <Expr>; | Test.java:62:10:62:19 | System.out |
 | Test.java:62:29:62:81 | "It's <= 6 chars long, and neither Const1 nor Const2" | Test.java:62:10:62:82 | println(...) |
 | Test.java:63:8:63:21 | case ... | Test.java:63:13:63:20 | "Const3" |
-| Test.java:63:8:63:21 | case ... | Test.java:66:8:66:22 | case ... |
 | Test.java:63:13:63:20 | "Const3" | Test.java:64:10:64:96 | <Expr>; |
+| Test.java:63:13:63:20 | "Const3" | Test.java:66:8:66:22 | case ... |
 | Test.java:64:10:64:19 | System.out | Test.java:64:29:64:94 | "It's (<= 6 chars long, and neither Const1 nor Const2), or Const3" |
 | Test.java:64:10:64:95 | println(...) | Test.java:65:10:65:15 | break |
 | Test.java:64:10:64:96 | <Expr>; | Test.java:64:10:64:19 | System.out |
 | Test.java:64:29:64:94 | "It's (<= 6 chars long, and neither Const1 nor Const2), or Const3" | Test.java:64:10:64:95 | println(...) |
 | Test.java:65:10:65:15 | break | Test.java:73:6:73:18 | switch (...) |
 | Test.java:66:8:66:22 | case ... | Test.java:66:13:66:21 | "Const30" |
-| Test.java:66:8:66:22 | case ... | Test.java:69:8:69:26 | case null, default |
 | Test.java:66:13:66:21 | "Const30" | Test.java:67:10:67:44 | <Expr>; |
+| Test.java:66:13:66:21 | "Const30" | Test.java:69:8:69:26 | case null, default |
 | Test.java:67:10:67:19 | System.out | Test.java:67:29:67:42 | "It's Const30" |
 | Test.java:67:10:67:43 | println(...) | Test.java:68:10:68:15 | break |
 | Test.java:67:10:67:44 | <Expr>; | Test.java:67:10:67:19 | System.out |
@@ -267,24 +267,24 @@
 | Test.java:73:6:73:18 | switch (...) | Test.java:73:13:73:17 | thing |
 | Test.java:73:13:73:17 | thing | Test.java:74:8:74:21 | case <Pattern> |
 | Test.java:74:8:74:21 | case <Pattern> | Test.java:74:20:74:20 | s |
-| Test.java:74:8:74:21 | case <Pattern> | Test.java:77:8:77:17 | case ... |
 | Test.java:74:20:74:20 | s | Test.java:75:10:75:31 | <Expr>; |
+| Test.java:74:20:74:20 | s | Test.java:77:8:77:17 | case ... |
 | Test.java:75:10:75:19 | System.out | Test.java:75:29:75:29 | s |
 | Test.java:75:10:75:30 | println(...) | Test.java:76:10:76:15 | break |
 | Test.java:75:10:75:31 | <Expr>; | Test.java:75:10:75:19 | System.out |
 | Test.java:75:29:75:29 | s | Test.java:75:10:75:30 | println(...) |
 | Test.java:76:10:76:15 | break | Test.java:87:6:87:18 | switch (...) |
 | Test.java:77:8:77:17 | case ... | Test.java:77:13:77:16 | null |
-| Test.java:77:8:77:17 | case ... | Test.java:80:8:80:22 | case <Pattern> |
 | Test.java:77:13:77:16 | null | Test.java:78:10:78:41 | <Expr>; |
+| Test.java:77:13:77:16 | null | Test.java:80:8:80:22 | case <Pattern> |
 | Test.java:78:10:78:19 | System.out | Test.java:78:29:78:39 | "It's null" |
 | Test.java:78:10:78:40 | println(...) | Test.java:79:10:79:15 | break |
 | Test.java:78:10:78:41 | <Expr>; | Test.java:78:10:78:19 | System.out |
 | Test.java:78:29:78:39 | "It's null" | Test.java:78:10:78:40 | println(...) |
 | Test.java:79:10:79:15 | break | Test.java:87:6:87:18 | switch (...) |
 | Test.java:80:8:80:22 | case <Pattern> | Test.java:80:21:80:21 | i |
-| Test.java:80:8:80:22 | case <Pattern> | Test.java:83:8:83:15 | default |
 | Test.java:80:21:80:21 | i | Test.java:81:10:81:47 | <Expr>; |
+| Test.java:80:21:80:21 | i | Test.java:83:8:83:15 | default |
 | Test.java:81:10:81:19 | System.out | Test.java:81:29:81:41 | "An integer:" |
 | Test.java:81:10:81:46 | println(...) | Test.java:82:10:82:15 | break |
 | Test.java:81:10:81:47 | <Expr>; | Test.java:81:10:81:19 | System.out |
@@ -297,8 +297,8 @@
 | Test.java:87:6:87:18 | switch (...) | Test.java:87:13:87:17 | thing |
 | Test.java:87:13:87:17 | thing | Test.java:88:8:88:43 | case <Pattern> |
 | Test.java:88:8:88:43 | case <Pattern> | Test.java:88:21:88:21 | x |
-| Test.java:88:8:88:43 | case <Pattern> | Test.java:90:8:90:15 | default |
 | Test.java:88:13:88:42 | A(...) | Test.java:89:10:89:15 | break |
+| Test.java:88:13:88:42 | A(...) | Test.java:90:8:90:15 | default |
 | Test.java:88:15:88:32 | B(...) | Test.java:88:41:88:41 | z |
 | Test.java:88:21:88:21 | x | Test.java:88:31:88:31 | y |
 | Test.java:88:31:88:31 | y | Test.java:88:15:88:32 | B(...) |
@@ -309,8 +309,8 @@
 | Test.java:94:6:94:18 | switch (...) | Test.java:94:13:94:17 | thing |
 | Test.java:94:13:94:17 | thing | Test.java:95:8:95:38 | case <Pattern> |
 | Test.java:95:8:95:38 | case <Pattern> | Test.java:95:21:95:21 | x |
-| Test.java:95:8:95:38 | case <Pattern> | Test.java:97:8:97:15 | default |
 | Test.java:95:13:95:37 | A(...) | Test.java:96:10:96:15 | break |
+| Test.java:95:13:95:37 | A(...) | Test.java:97:8:97:15 | default |
 | Test.java:95:15:95:29 | B(...) | Test.java:95:36:95:36 | z |
 | Test.java:95:21:95:21 | x | Test.java:95:28:95:28 | y |
 | Test.java:95:28:95:28 | y | Test.java:95:15:95:29 | B(...) |
@@ -321,17 +321,17 @@
 | Test.java:101:6:101:18 | switch (...) | Test.java:101:13:101:17 | thing |
 | Test.java:101:13:101:17 | thing | Test.java:102:8:102:20 | case <Pattern> |
 | Test.java:102:8:102:20 | case <Pattern> | Test.java:102:15:102:15 | <anonymous local variable> |
-| Test.java:102:8:102:20 | case <Pattern> | Test.java:103:8:103:77 | case <Pattern> |
+| Test.java:102:13:102:19 | B(...) | Test.java:103:8:103:77 | case <Pattern> |
 | Test.java:102:13:102:19 | B(...) | Test.java:105:10:105:15 | break |
 | Test.java:102:15:102:15 | <anonymous local variable> | Test.java:102:18:102:18 | <anonymous local variable> |
 | Test.java:102:18:102:18 | <anonymous local variable> | Test.java:102:13:102:19 | B(...) |
 | Test.java:103:8:103:77 | case <Pattern> | Test.java:103:21:103:21 | <anonymous local variable> |
-| Test.java:103:8:103:77 | case <Pattern> | Test.java:103:31:103:31 | <anonymous local variable> |
-| Test.java:103:8:103:77 | case <Pattern> | Test.java:103:36:103:36 | <anonymous local variable> |
-| Test.java:103:8:103:77 | case <Pattern> | Test.java:104:8:104:20 | case <Pattern> |
+| Test.java:103:21:103:21 | <anonymous local variable> | Test.java:103:31:103:31 | <anonymous local variable> |
 | Test.java:103:21:103:21 | <anonymous local variable> | Test.java:103:47:103:51 | thing |
+| Test.java:103:31:103:31 | <anonymous local variable> | Test.java:103:36:103:36 | <anonymous local variable> |
 | Test.java:103:31:103:31 | <anonymous local variable> | Test.java:103:47:103:51 | thing |
 | Test.java:103:34:103:40 | A(...) | Test.java:103:47:103:51 | thing |
+| Test.java:103:34:103:40 | A(...) | Test.java:104:8:104:20 | case <Pattern> |
 | Test.java:103:36:103:36 | <anonymous local variable> | Test.java:103:39:103:39 | <anonymous local variable> |
 | Test.java:103:39:103:39 | <anonymous local variable> | Test.java:103:34:103:40 | A(...) |
 | Test.java:103:47:103:51 | thing | Test.java:103:47:103:62 | toString(...) |
@@ -340,8 +340,8 @@
 | Test.java:103:47:103:76 | equals(...) | Test.java:105:10:105:15 | break |
 | Test.java:103:71:103:75 | "abc" | Test.java:103:47:103:76 | equals(...) |
 | Test.java:104:8:104:20 | case <Pattern> | Test.java:104:19:104:19 | <anonymous local variable> |
-| Test.java:104:8:104:20 | case <Pattern> | Test.java:106:8:106:15 | default |
 | Test.java:104:19:104:19 | <anonymous local variable> | Test.java:105:10:105:15 | break |
+| Test.java:104:19:104:19 | <anonymous local variable> | Test.java:106:8:106:15 | default |
 | Test.java:105:10:105:15 | break | Test.java:110:6:117:7 | var ...; |
 | Test.java:106:8:106:15 | default | Test.java:107:10:107:15 | break |
 | Test.java:107:10:107:15 | break | Test.java:110:6:117:7 | var ...; |
@@ -350,17 +350,17 @@
 | Test.java:110:19:110:31 | switch (...) | Test.java:110:26:110:30 | thing |
 | Test.java:110:26:110:30 | thing | Test.java:111:8:111:20 | case <Pattern> |
 | Test.java:111:8:111:20 | case <Pattern> | Test.java:111:15:111:15 | <anonymous local variable> |
-| Test.java:111:8:111:20 | case <Pattern> | Test.java:112:8:112:77 | case <Pattern> |
+| Test.java:111:13:111:19 | B(...) | Test.java:112:8:112:77 | case <Pattern> |
 | Test.java:111:13:111:19 | B(...) | Test.java:114:16:114:16 | 1 |
 | Test.java:111:15:111:15 | <anonymous local variable> | Test.java:111:18:111:18 | <anonymous local variable> |
 | Test.java:111:18:111:18 | <anonymous local variable> | Test.java:111:13:111:19 | B(...) |
 | Test.java:112:8:112:77 | case <Pattern> | Test.java:112:21:112:21 | <anonymous local variable> |
-| Test.java:112:8:112:77 | case <Pattern> | Test.java:112:31:112:31 | <anonymous local variable> |
-| Test.java:112:8:112:77 | case <Pattern> | Test.java:112:36:112:36 | <anonymous local variable> |
-| Test.java:112:8:112:77 | case <Pattern> | Test.java:113:8:113:20 | case <Pattern> |
+| Test.java:112:21:112:21 | <anonymous local variable> | Test.java:112:31:112:31 | <anonymous local variable> |
 | Test.java:112:21:112:21 | <anonymous local variable> | Test.java:112:47:112:51 | thing |
+| Test.java:112:31:112:31 | <anonymous local variable> | Test.java:112:36:112:36 | <anonymous local variable> |
 | Test.java:112:31:112:31 | <anonymous local variable> | Test.java:112:47:112:51 | thing |
 | Test.java:112:34:112:40 | A(...) | Test.java:112:47:112:51 | thing |
+| Test.java:112:34:112:40 | A(...) | Test.java:113:8:113:20 | case <Pattern> |
 | Test.java:112:36:112:36 | <anonymous local variable> | Test.java:112:39:112:39 | <anonymous local variable> |
 | Test.java:112:39:112:39 | <anonymous local variable> | Test.java:112:34:112:40 | A(...) |
 | Test.java:112:47:112:51 | thing | Test.java:112:47:112:62 | toString(...) |
@@ -369,8 +369,8 @@
 | Test.java:112:47:112:76 | equals(...) | Test.java:114:16:114:16 | 1 |
 | Test.java:112:71:112:75 | "abc" | Test.java:112:47:112:76 | equals(...) |
 | Test.java:113:8:113:20 | case <Pattern> | Test.java:113:19:113:19 | <anonymous local variable> |
-| Test.java:113:8:113:20 | case <Pattern> | Test.java:115:8:115:15 | default |
 | Test.java:113:19:113:19 | <anonymous local variable> | Test.java:114:16:114:16 | 1 |
+| Test.java:113:19:113:19 | <anonymous local variable> | Test.java:115:8:115:15 | default |
 | Test.java:114:10:114:17 | yield ... | Test.java:110:10:110:31 | result |
 | Test.java:114:16:114:16 | 1 | Test.java:114:10:114:17 | yield ... |
 | Test.java:115:8:115:15 | default | Test.java:116:16:116:16 | 2 |
@@ -380,11 +380,11 @@
 | Test.java:119:14:119:26 | (...)... | Test.java:120:8:120:16 | case ... |
 | Test.java:119:22:119:26 | thing | Test.java:119:14:119:26 | (...)... |
 | Test.java:120:8:120:16 | case ... | Test.java:120:13:120:15 | "a" |
-| Test.java:120:8:120:16 | case ... | Test.java:121:8:121:56 | case <Pattern> |
+| Test.java:120:13:120:15 | "a" | Test.java:121:8:121:56 | case <Pattern> |
 | Test.java:120:13:120:15 | "a" | Test.java:123:10:123:15 | break |
 | Test.java:121:8:121:56 | case <Pattern> | Test.java:121:20:121:20 | <anonymous local variable> |
-| Test.java:121:8:121:56 | case <Pattern> | Test.java:122:8:122:16 | case ... |
 | Test.java:121:20:121:20 | <anonymous local variable> | Test.java:121:36:121:40 | thing |
+| Test.java:121:20:121:20 | <anonymous local variable> | Test.java:122:8:122:16 | case ... |
 | Test.java:121:27:121:50 | length(...) | Test.java:121:55:121:55 | 5 |
 | Test.java:121:27:121:55 | ... == ... | Test.java:122:8:122:16 | case ... |
 | Test.java:121:27:121:55 | ... == ... | Test.java:123:10:123:15 | break |
@@ -392,16 +392,16 @@
 | Test.java:121:36:121:40 | thing | Test.java:121:28:121:40 | (...)... |
 | Test.java:121:55:121:55 | 5 | Test.java:121:27:121:55 | ... == ... |
 | Test.java:122:8:122:16 | case ... | Test.java:122:13:122:15 | "b" |
-| Test.java:122:8:122:16 | case ... | Test.java:124:8:124:15 | default |
 | Test.java:122:13:122:15 | "b" | Test.java:123:10:123:15 | break |
+| Test.java:122:13:122:15 | "b" | Test.java:124:8:124:15 | default |
 | Test.java:123:10:123:15 | break | Test.java:129:6:129:18 | switch (...) |
 | Test.java:124:8:124:15 | default | Test.java:125:10:125:15 | break |
 | Test.java:125:10:125:15 | break | Test.java:129:6:129:18 | switch (...) |
 | Test.java:129:6:129:18 | switch (...) | Test.java:129:13:129:17 | thing |
 | Test.java:129:13:129:17 | thing | Test.java:130:8:130:21 | case <Pattern> |
 | Test.java:130:8:130:21 | case <Pattern> | Test.java:130:20:130:20 | <anonymous local variable> |
-| Test.java:130:8:130:21 | case <Pattern> | Test.java:131:8:131:15 | default |
 | Test.java:130:20:130:20 | <anonymous local variable> | Test.java:3:22:3:25 | Normal Exit |
+| Test.java:130:20:130:20 | <anonymous local variable> | Test.java:131:8:131:15 | default |
 | Test.java:131:8:131:15 | default | Test.java:3:22:3:25 | Normal Exit |
 | Test.java:138:8:138:8 | ...=... | Test.java:138:8:138:8 | <Expr>; |
 | Test.java:138:8:138:8 | ...=... | Test.java:138:8:138:8 | Normal Exit |

--- a/java/ql/test/library-tests/successors/TestBreak/TestSucc.expected
+++ b/java/ql/test/library-tests/successors/TestBreak/TestSucc.expected
@@ -87,8 +87,8 @@
 | TestBreak.java:52:3:52:12 | switch (...) | TestBreak.java:52:11:52:11 | x |
 | TestBreak.java:52:11:52:11 | x | TestBreak.java:54:3:54:9 | case ... |
 | TestBreak.java:54:3:54:9 | case ... | TestBreak.java:54:8:54:8 | 1 |
-| TestBreak.java:54:3:54:9 | case ... | TestBreak.java:57:3:57:9 | case ... |
 | TestBreak.java:54:8:54:8 | 1 | TestBreak.java:55:4:55:13 | <Expr>; |
+| TestBreak.java:54:8:54:8 | 1 | TestBreak.java:57:3:57:9 | case ... |
 | TestBreak.java:55:4:55:4 | x | TestBreak.java:55:8:55:8 | x |
 | TestBreak.java:55:4:55:12 | ...=... | TestBreak.java:56:4:56:13 | <Expr>; |
 | TestBreak.java:55:4:55:13 | <Expr>; | TestBreak.java:55:4:55:4 | x |
@@ -102,8 +102,8 @@
 | TestBreak.java:56:8:56:12 | ... + ... | TestBreak.java:56:4:56:12 | ...=... |
 | TestBreak.java:56:12:56:12 | 1 | TestBreak.java:56:8:56:12 | ... + ... |
 | TestBreak.java:57:3:57:9 | case ... | TestBreak.java:57:8:57:8 | 2 |
-| TestBreak.java:57:3:57:9 | case ... | TestBreak.java:61:3:61:9 | case ... |
 | TestBreak.java:57:8:57:8 | 2 | TestBreak.java:58:4:58:13 | <Expr>; |
+| TestBreak.java:57:8:57:8 | 2 | TestBreak.java:61:3:61:9 | case ... |
 | TestBreak.java:58:4:58:4 | x | TestBreak.java:58:8:58:8 | x |
 | TestBreak.java:58:4:58:12 | ...=... | TestBreak.java:59:4:59:13 | <Expr>; |
 | TestBreak.java:58:4:58:13 | <Expr>; | TestBreak.java:58:4:58:4 | x |
@@ -118,11 +118,11 @@
 | TestBreak.java:59:12:59:12 | 2 | TestBreak.java:59:8:59:12 | ... + ... |
 | TestBreak.java:60:4:60:9 | break | TestBreak.java:76:3:76:11 | switch (...) |
 | TestBreak.java:61:3:61:9 | case ... | TestBreak.java:61:8:61:8 | 3 |
-| TestBreak.java:61:3:61:9 | case ... | TestBreak.java:62:3:62:9 | case ... |
+| TestBreak.java:61:8:61:8 | 3 | TestBreak.java:62:3:62:9 | case ... |
 | TestBreak.java:61:8:61:8 | 3 | TestBreak.java:63:4:63:13 | <Expr>; |
 | TestBreak.java:62:3:62:9 | case ... | TestBreak.java:62:8:62:8 | 4 |
-| TestBreak.java:62:3:62:9 | case ... | TestBreak.java:66:3:66:9 | case ... |
 | TestBreak.java:62:8:62:8 | 4 | TestBreak.java:63:4:63:13 | <Expr>; |
+| TestBreak.java:62:8:62:8 | 4 | TestBreak.java:66:3:66:9 | case ... |
 | TestBreak.java:63:4:63:4 | x | TestBreak.java:63:8:63:8 | x |
 | TestBreak.java:63:4:63:12 | ...=... | TestBreak.java:64:4:64:13 | <Expr>; |
 | TestBreak.java:63:4:63:13 | <Expr>; | TestBreak.java:63:4:63:4 | x |
@@ -137,11 +137,11 @@
 | TestBreak.java:64:12:64:12 | 4 | TestBreak.java:64:8:64:12 | ... + ... |
 | TestBreak.java:65:4:65:9 | break | TestBreak.java:76:3:76:11 | switch (...) |
 | TestBreak.java:66:3:66:9 | case ... | TestBreak.java:66:8:66:8 | 5 |
-| TestBreak.java:66:3:66:9 | case ... | TestBreak.java:67:3:67:9 | case ... |
+| TestBreak.java:66:8:66:8 | 5 | TestBreak.java:67:3:67:9 | case ... |
 | TestBreak.java:66:8:66:8 | 5 | TestBreak.java:68:4:68:13 | <Expr>; |
 | TestBreak.java:67:3:67:9 | case ... | TestBreak.java:67:8:67:8 | 6 |
-| TestBreak.java:67:3:67:9 | case ... | TestBreak.java:70:3:70:10 | default |
 | TestBreak.java:67:8:67:8 | 6 | TestBreak.java:68:4:68:13 | <Expr>; |
+| TestBreak.java:67:8:67:8 | 6 | TestBreak.java:70:3:70:10 | default |
 | TestBreak.java:68:4:68:4 | x | TestBreak.java:68:8:68:8 | x |
 | TestBreak.java:68:4:68:12 | ...=... | TestBreak.java:69:4:69:13 | <Expr>; |
 | TestBreak.java:68:4:68:13 | <Expr>; | TestBreak.java:68:4:68:4 | x |
@@ -166,15 +166,15 @@
 | TestBreak.java:76:3:76:11 | switch (...) | TestBreak.java:76:10:76:10 | x |
 | TestBreak.java:76:10:76:10 | x | TestBreak.java:78:3:78:9 | case ... |
 | TestBreak.java:78:3:78:9 | case ... | TestBreak.java:78:8:78:8 | 1 |
-| TestBreak.java:78:3:78:9 | case ... | TestBreak.java:81:3:81:9 | case ... |
 | TestBreak.java:78:8:78:8 | 1 | TestBreak.java:79:4:79:9 | <Expr>; |
+| TestBreak.java:78:8:78:8 | 1 | TestBreak.java:81:3:81:9 | case ... |
 | TestBreak.java:79:4:79:4 | x | TestBreak.java:79:8:79:8 | 1 |
 | TestBreak.java:79:4:79:8 | ...=... | TestBreak.java:80:4:80:9 | break |
 | TestBreak.java:79:4:79:9 | <Expr>; | TestBreak.java:79:4:79:4 | x |
 | TestBreak.java:79:8:79:8 | 1 | TestBreak.java:79:4:79:8 | ...=... |
 | TestBreak.java:80:4:80:9 | break | TestBreak.java:4:14:4:14 | Normal Exit |
-| TestBreak.java:81:3:81:9 | case ... | TestBreak.java:4:14:4:14 | Normal Exit |
 | TestBreak.java:81:3:81:9 | case ... | TestBreak.java:81:8:81:8 | 2 |
+| TestBreak.java:81:8:81:8 | 2 | TestBreak.java:4:14:4:14 | Normal Exit |
 | TestBreak.java:81:8:81:8 | 2 | TestBreak.java:82:4:82:9 | <Expr>; |
 | TestBreak.java:82:4:82:4 | x | TestBreak.java:82:8:82:8 | 2 |
 | TestBreak.java:82:4:82:8 | ...=... | TestBreak.java:83:4:83:9 | break |

--- a/java/ql/test/library-tests/successors/TestLoopBranch/TestSucc.expected
+++ b/java/ql/test/library-tests/successors/TestLoopBranch/TestSucc.expected
@@ -148,8 +148,8 @@
 | TestLoopBranch.java:62:3:62:12 | switch (...) | TestLoopBranch.java:62:11:62:11 | x |
 | TestLoopBranch.java:62:11:62:11 | x | TestLoopBranch.java:64:3:64:9 | case ... |
 | TestLoopBranch.java:64:3:64:9 | case ... | TestLoopBranch.java:64:8:64:8 | 1 |
-| TestLoopBranch.java:64:3:64:9 | case ... | TestLoopBranch.java:67:3:67:9 | case ... |
 | TestLoopBranch.java:64:8:64:8 | 1 | TestLoopBranch.java:65:4:65:13 | <Expr>; |
+| TestLoopBranch.java:64:8:64:8 | 1 | TestLoopBranch.java:67:3:67:9 | case ... |
 | TestLoopBranch.java:65:4:65:4 | x | TestLoopBranch.java:65:8:65:8 | x |
 | TestLoopBranch.java:65:4:65:12 | ...=... | TestLoopBranch.java:66:4:66:13 | <Expr>; |
 | TestLoopBranch.java:65:4:65:13 | <Expr>; | TestLoopBranch.java:65:4:65:4 | x |
@@ -163,8 +163,8 @@
 | TestLoopBranch.java:66:8:66:12 | ... + ... | TestLoopBranch.java:66:4:66:12 | ...=... |
 | TestLoopBranch.java:66:12:66:12 | 1 | TestLoopBranch.java:66:8:66:12 | ... + ... |
 | TestLoopBranch.java:67:3:67:9 | case ... | TestLoopBranch.java:67:8:67:8 | 2 |
-| TestLoopBranch.java:67:3:67:9 | case ... | TestLoopBranch.java:71:3:71:9 | case ... |
 | TestLoopBranch.java:67:8:67:8 | 2 | TestLoopBranch.java:68:4:68:13 | <Expr>; |
+| TestLoopBranch.java:67:8:67:8 | 2 | TestLoopBranch.java:71:3:71:9 | case ... |
 | TestLoopBranch.java:68:4:68:4 | x | TestLoopBranch.java:68:8:68:8 | x |
 | TestLoopBranch.java:68:4:68:12 | ...=... | TestLoopBranch.java:69:4:69:13 | <Expr>; |
 | TestLoopBranch.java:68:4:68:13 | <Expr>; | TestLoopBranch.java:68:4:68:4 | x |
@@ -179,11 +179,11 @@
 | TestLoopBranch.java:69:12:69:12 | 2 | TestLoopBranch.java:69:8:69:12 | ... + ... |
 | TestLoopBranch.java:70:4:70:9 | break | TestLoopBranch.java:86:3:86:11 | switch (...) |
 | TestLoopBranch.java:71:3:71:9 | case ... | TestLoopBranch.java:71:8:71:8 | 3 |
-| TestLoopBranch.java:71:3:71:9 | case ... | TestLoopBranch.java:72:3:72:9 | case ... |
+| TestLoopBranch.java:71:8:71:8 | 3 | TestLoopBranch.java:72:3:72:9 | case ... |
 | TestLoopBranch.java:71:8:71:8 | 3 | TestLoopBranch.java:73:4:73:13 | <Expr>; |
 | TestLoopBranch.java:72:3:72:9 | case ... | TestLoopBranch.java:72:8:72:8 | 4 |
-| TestLoopBranch.java:72:3:72:9 | case ... | TestLoopBranch.java:76:3:76:9 | case ... |
 | TestLoopBranch.java:72:8:72:8 | 4 | TestLoopBranch.java:73:4:73:13 | <Expr>; |
+| TestLoopBranch.java:72:8:72:8 | 4 | TestLoopBranch.java:76:3:76:9 | case ... |
 | TestLoopBranch.java:73:4:73:4 | x | TestLoopBranch.java:73:8:73:8 | x |
 | TestLoopBranch.java:73:4:73:12 | ...=... | TestLoopBranch.java:74:4:74:13 | <Expr>; |
 | TestLoopBranch.java:73:4:73:13 | <Expr>; | TestLoopBranch.java:73:4:73:4 | x |
@@ -198,11 +198,11 @@
 | TestLoopBranch.java:74:12:74:12 | 4 | TestLoopBranch.java:74:8:74:12 | ... + ... |
 | TestLoopBranch.java:75:4:75:9 | break | TestLoopBranch.java:86:3:86:11 | switch (...) |
 | TestLoopBranch.java:76:3:76:9 | case ... | TestLoopBranch.java:76:8:76:8 | 5 |
-| TestLoopBranch.java:76:3:76:9 | case ... | TestLoopBranch.java:77:3:77:9 | case ... |
+| TestLoopBranch.java:76:8:76:8 | 5 | TestLoopBranch.java:77:3:77:9 | case ... |
 | TestLoopBranch.java:76:8:76:8 | 5 | TestLoopBranch.java:78:4:78:13 | <Expr>; |
 | TestLoopBranch.java:77:3:77:9 | case ... | TestLoopBranch.java:77:8:77:8 | 6 |
-| TestLoopBranch.java:77:3:77:9 | case ... | TestLoopBranch.java:80:3:80:10 | default |
 | TestLoopBranch.java:77:8:77:8 | 6 | TestLoopBranch.java:78:4:78:13 | <Expr>; |
+| TestLoopBranch.java:77:8:77:8 | 6 | TestLoopBranch.java:80:3:80:10 | default |
 | TestLoopBranch.java:78:4:78:4 | x | TestLoopBranch.java:78:8:78:8 | x |
 | TestLoopBranch.java:78:4:78:12 | ...=... | TestLoopBranch.java:79:4:79:13 | <Expr>; |
 | TestLoopBranch.java:78:4:78:13 | <Expr>; | TestLoopBranch.java:78:4:78:4 | x |
@@ -227,16 +227,16 @@
 | TestLoopBranch.java:86:3:86:11 | switch (...) | TestLoopBranch.java:86:10:86:10 | x |
 | TestLoopBranch.java:86:10:86:10 | x | TestLoopBranch.java:88:3:88:9 | case ... |
 | TestLoopBranch.java:88:3:88:9 | case ... | TestLoopBranch.java:88:8:88:8 | 1 |
-| TestLoopBranch.java:88:3:88:9 | case ... | TestLoopBranch.java:91:3:91:9 | case ... |
 | TestLoopBranch.java:88:8:88:8 | 1 | TestLoopBranch.java:89:4:89:9 | <Expr>; |
+| TestLoopBranch.java:88:8:88:8 | 1 | TestLoopBranch.java:91:3:91:9 | case ... |
 | TestLoopBranch.java:89:4:89:4 | x | TestLoopBranch.java:89:8:89:8 | 1 |
 | TestLoopBranch.java:89:4:89:8 | ...=... | TestLoopBranch.java:90:4:90:9 | break |
 | TestLoopBranch.java:89:4:89:9 | <Expr>; | TestLoopBranch.java:89:4:89:4 | x |
 | TestLoopBranch.java:89:8:89:8 | 1 | TestLoopBranch.java:89:4:89:8 | ...=... |
 | TestLoopBranch.java:90:4:90:9 | break | TestLoopBranch.java:96:3:102:4 | var ...; |
 | TestLoopBranch.java:91:3:91:9 | case ... | TestLoopBranch.java:91:8:91:8 | 2 |
-| TestLoopBranch.java:91:3:91:9 | case ... | TestLoopBranch.java:96:3:102:4 | var ...; |
 | TestLoopBranch.java:91:8:91:8 | 2 | TestLoopBranch.java:92:4:92:9 | <Expr>; |
+| TestLoopBranch.java:91:8:91:8 | 2 | TestLoopBranch.java:96:3:102:4 | var ...; |
 | TestLoopBranch.java:92:4:92:4 | x | TestLoopBranch.java:92:8:92:8 | 2 |
 | TestLoopBranch.java:92:4:92:8 | ...=... | TestLoopBranch.java:93:4:93:9 | break |
 | TestLoopBranch.java:92:4:92:9 | <Expr>; | TestLoopBranch.java:92:4:92:4 | x |

--- a/shared/controlflow/codeql/controlflow/ControlFlowGraph.qll
+++ b/shared/controlflow/codeql/controlflow/ControlFlowGraph.qll
@@ -255,8 +255,8 @@ signature module AstSig<LocationSig Location> {
 
   /** A case in a switch. */
   class Case extends AstNode {
-    /** Gets a pattern being matched by this case. */
-    AstNode getAPattern();
+    /** Gets the pattern being matched by this case at the specified (zero-based) `index`. */
+    AstNode getPattern(int index);
 
     /** Gets the guard expression of this case, if any. */
     Expr getGuard();
@@ -489,6 +489,18 @@ module Make0<LocationSig Location, AstSig<Location> Ast> {
      * need to be consecutive nor start from a specific index.
      */
     default Parameter callableGetParameter(Callable c, CallableContext ctx, int index) { none() }
+
+    /** Holds if this catch clause catches all exceptions. */
+    default predicate catchAll(CatchClause catch) { none() }
+
+    /**
+     * Holds if this case matches all possible values, for example, if it is a
+     * `default` case or a match-all pattern like `Object o` or if it is the
+     * final case in a switch that is known to be exhaustive.
+     *
+     * A match-all case can still ultimately fail to match if it has a guard.
+     */
+    default predicate matchAll(Case c) { c instanceof DefaultCase }
   }
 
   /**
@@ -611,6 +623,8 @@ module Make0<LocationSig Location, AstSig<Location> Ast> {
         n instanceof CatchClause
         or
         n instanceof Case
+        or
+        n = any(Case case).getPattern(_)
         or
         exists(n.(Parameter).getDefaultValue())
       )
@@ -772,12 +786,25 @@ module Make0<LocationSig Location, AstSig<Location> Ast> {
       result = DenseRank2<ParameterCtxDenseRankInput>::denseRank(c, ctx.asSome(), rnk)
     }
 
+    private predicate constantCondition(AstNode n, ConditionalSuccessor t) {
+      n.(BooleanLiteral).getValue() = t.(BooleanSuccessor).getValue()
+      or
+      exists(Case c, int i |
+        Input1::matchAll(c) and
+        c.getPattern(i) = n and
+        not exists(c.getPattern(i + 1)) and
+        t.(MatchingSuccessor).getValue() = true
+      )
+    }
+
     cached
     private newtype TNode =
       TBeforeNode(AstNode n) { Input1::cfgCachedStageRef() and exists(getEnclosingCallable(n)) } or
       TAstNode(AstNode n) { postOrInOrder(n) and exists(getEnclosingCallable(n)) } or
       TAfterValueNode(AstNode n, ConditionalSuccessor t) {
-        inConditionalContext(n, t.getKind()) and exists(getEnclosingCallable(n))
+        inConditionalContext(n, t.getKind()) and
+        exists(getEnclosingCallable(n)) and
+        not constantCondition(n, t.getDual())
       } or
       TAfterNode(AstNode n) {
         exists(getEnclosingCallable(n)) and
@@ -1105,18 +1132,6 @@ module Make0<LocationSig Location, AstSig<Location> Ast> {
     }
 
     signature module InputSig2 {
-      /** Holds if this catch clause catches all exceptions. */
-      default predicate catchAll(CatchClause catch) { none() }
-
-      /**
-       * Holds if this case matches all possible values, for example, if it is a
-       * `default` case or a match-all pattern like `Object o` or if it is the
-       * final case in a switch that is known to be exhaustive.
-       *
-       * A match-all case can still ultimately fail to match if it has a guard.
-       */
-      default predicate matchAll(Case c) { c instanceof DefaultCase }
-
       /**
        * Holds if `ast` may result in an abrupt completion `c` originating at
        * `n`. The boolean `always`  indicates whether the abrupt completion
@@ -1471,12 +1486,6 @@ module Make0<LocationSig Location, AstSig<Location> Ast> {
           n2.isBefore(condexpr.getElse())
         )
         or
-        exists(BooleanLiteral boollit |
-          inConditionalContext(boollit, _) and
-          n1.isBefore(boollit) and
-          n2.isAfterValue(boollit, any(BooleanSuccessor t | t.getValue() = boollit.getValue()))
-        )
-        or
         exists(PatternMatchExpr pme |
           n1.isBefore(pme) and
           n2.isBefore(pme.getExpr())
@@ -1662,7 +1671,7 @@ module Make0<LocationSig Location, AstSig<Location> Ast> {
           exists(MatchingSuccessor t |
             n1.isBefore(catchclause) and
             n2.isAfterValue(catchclause, t) and
-            if Input2::catchAll(catchclause) then t.getValue() = true else any()
+            if Input1::catchAll(catchclause) then t.getValue() = true else any()
           )
           or
           exists(PreControlFlowNode beforeVar, PreControlFlowNode beforeCond |
@@ -1720,21 +1729,22 @@ module Make0<LocationSig Location, AstSig<Location> Ast> {
         )
         or
         exists(Case case |
-          exists(MatchingSuccessor t |
-            n1.isBefore(case) and
-            n2.isAfterValue(case, t) and
-            if Input2::matchAll(case) then t.getValue() = true else any()
+          n1.isBefore(case) and
+          (
+            if exists(case.getPattern(_))
+            then n2.isBefore(case.getPattern(0))
+            else n2.isAfterValue(case, any(MatchingSuccessor t | t.getValue() = true))
           )
           or
-          exists(
-            PreControlFlowNode beforePattern, PreControlFlowNode beforeGuard,
-            PreControlFlowNode beforeBody
-          |
-            (
-              beforePattern.isBefore(case.getAPattern())
-              or
-              not exists(case.getAPattern()) and beforePattern = beforeGuard
-            ) and
+          exists(int i, MatchingSuccessor ms | n1.isAfterValue(case.getPattern(i), ms) |
+            ms.getValue() = false and
+            n2.isBefore(case.getPattern(i + 1))
+            or
+            (ms.getValue() = true or not exists(case.getPattern(i + 1))) and
+            n2.isAfterValue(case, ms)
+          )
+          or
+          exists(PreControlFlowNode beforeGuard, PreControlFlowNode beforeBody |
             (
               beforeGuard.isBefore(case.getGuard())
               or
@@ -1748,9 +1758,6 @@ module Make0<LocationSig Location, AstSig<Location> Ast> {
             )
           |
             n1.isAfterValue(case, any(MatchingSuccessor t | t.getValue() = true)) and
-            n2 = beforePattern
-            or
-            n1.isAfter(case.getAPattern()) and
             n2 = beforeGuard
             or
             n1.isAfterTrue(case.getGuard()) and
@@ -2224,12 +2231,6 @@ module Make0<LocationSig Location, AstSig<Location> Ast> {
             not (
               t instanceof DirectSuccessor and
               node.isAdditional(any(ForeachStmt foreach), loopHeaderTag())
-            ) and
-            // allow for disjunctive patterns (e.g. `case "foo", "bar":`)
-            not (
-              t instanceof DirectSuccessor and
-              node.isAfterValue(any(Case c | 2 <= strictcount(c.getAPattern())),
-                any(MatchingSuccessor m | m.getValue() = true))
             ) and
             // allow for functions with multiple bodies
             not exists(Callable c |

--- a/shared/controlflow/codeql/controlflow/ControlFlowGraph.qll
+++ b/shared/controlflow/codeql/controlflow/ControlFlowGraph.qll
@@ -490,11 +490,11 @@ module Make0<LocationSig Location, AstSig<Location> Ast> {
      */
     default Parameter callableGetParameter(Callable c, CallableContext ctx, int index) { none() }
 
-    /** Holds if this catch clause catches all exceptions. */
+    /** Holds if catch clause `catch` catches all exceptions. */
     default predicate catchAll(CatchClause catch) { none() }
 
     /**
-     * Holds if this case matches all possible values, for example, if it is a
+     * Holds if case `c` matches all possible values, for example, if it is a
      * `default` case or a match-all pattern like `Object o` or if it is the
      * final case in a switch that is known to be exhaustive.
      *


### PR DESCRIPTION
This updates the shared CFG to treat patterns in switch cases as tests that either match or not instead of treating them purely as binders to be executed once the case was determined to match.

This should set us up better for supporting e.g. Ruby.