### PR TITLE
Shared: Nicer panic message if node kind is missing

### DIFF
--- a/shared/tree-sitter-extractor/src/extractor/mod.rs
+++ b/shared/tree-sitter-extractor/src/extractor/mod.rs
@@ -486,7 +486,7 @@ impl<'a> Visitor<'a> {
         let table = self
             .schema
             .get(&type_name)
-            .unwrap_or_else(|| panic!("missing extractor schema entry for {:?}", type_name));
+            .unwrap_or_else(|| panic!("missing extractor schema entry for {type_name:?}"));
         let mut valid = true;
         let parent_info = match self.stack.last_mut() {
             Some(p) if !node.is_extra() => {

--- a/shared/tree-sitter-extractor/src/extractor/mod.rs
+++ b/shared/tree-sitter-extractor/src/extractor/mod.rs
@@ -479,13 +479,14 @@ impl<'a> Visitor<'a> {
         let (id, _, child_nodes) = self.stack.pop().expect("Vistor: empty stack");
         let loc = location_for(self, self.file_label, node);
         let loc_label = location_label(self.trap_writer, loc);
+        let type_name = TypeName {
+            kind: node.kind().to_owned(),
+            named: node.is_named(),
+        };
         let table = self
             .schema
-            .get(&TypeName {
-                kind: node.kind().to_owned(),
-                named: node.is_named(),
-            })
-            .unwrap();
+            .get(&type_name)
+            .unwrap_or_else(|| panic!("missing extractor schema entry for {:?}", type_name));
         let mut valid = true;
         let parent_info = match self.stack.last_mut() {
             Some(p) if !node.is_extra() => {


### PR DESCRIPTION
In the shared tree-sitter extractor, a panic is raised if we encounter a node that is not present in the target schema. The message is just a generic failure from calling `None.unwrap()` however, so it's not very helpful. This PR replaces it with a more helpful panic message.
