### PR TITLE
Go: Make version parsing robust in the face of custom Go builds

### DIFF
--- a/go/extractor/toolchain/toolchain.go
+++ b/go/extractor/toolchain/toolchain.go
@@ -130,7 +130,13 @@ func parseGoVersion(data string) string {
 	for sc.Scan() {
 		lastLine = sc.Text()
 	}
-	return strings.Fields(lastLine)[2]
+
+	var goVersion = strings.Fields(lastLine)[2]
+
+	// Drop custom build suffixes.
+	goVersion, _, _ = strings.Cut(goVersion, "-")
+
+	return goVersion
 }
 
 // Returns a value indicating whether the system Go toolchain supports workspaces.

--- a/go/extractor/toolchain/toolchain_test.go
+++ b/go/extractor/toolchain/toolchain_test.go
@@ -8,7 +8,9 @@ import (
 
 func TestParseGoVersion(t *testing.T) {
 	tests := map[string]string{
-		"go version go1.18.9 linux/amd64": "go1.18.9",
+		"go version go1.18.9 linux/amd64":            "go1.18.9",
+		"go version go1.26.3-X:nodwarf5 linux/amd64": "go1.26.3",
+		"go version go1.26.3rc1 linux/amd64":         "go1.26.3rc1",
 		"warning: GOPATH set to GOROOT (/usr/local/go) has no effect\ngo version go1.18.9 linux/amd64": "go1.18.9",
 	}
 	for input, expected := range tests {


### PR DESCRIPTION
cf. https://github.com/golang/go/blob/afcf04cb6401b439ce9bdcd18448c512f5bfda77/src/go/version/version.go#L20