### PR TITLE
C# 14: User increment/decrement support.

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp.Util/SymbolExtensions.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.Util/SymbolExtensions.cs
@@ -53,11 +53,11 @@ namespace Semmle.Extraction.CSharp.Util
         });
 
         /// <summary>
-        /// The operatorname for user-defined increment and decrement operators are "op_IncrementAssignment" and
+        /// The operatorname for user-defined instance increment- and decrement operators are "op_IncrementAssignment" and
         /// "op_DecrementAssignment" respectively.
         /// Thus we need to handle this explicitly to avoid postfixing them with an "=".
         /// </summary>
-        private static bool isIncrementOrDecrement(string operatorName) => operatorName == "++" || operatorName == "--";
+        private static bool IsIncrementOrDecrement(string operatorName) => operatorName == "++" || operatorName == "--";
 
         /// <summary>
         /// Convert an operator method name in to a symbolic name.
@@ -79,7 +79,7 @@ namespace Semmle.Extraction.CSharp.Util
             if (match.Success && methodToOperator.TryGetValue($"op_{match.Groups[2]}", out var rawOperatorName))
             {
                 var prefix = match.Groups[1].Success ? "checked " : "";
-                var postfix = match.Groups[3].Success && !isIncrementOrDecrement(rawOperatorName) ? "=" : "";
+                var postfix = match.Groups[3].Success && !IsIncrementOrDecrement(rawOperatorName) ? "=" : "";
                 operatorName = $"{prefix}{rawOperatorName}{postfix}";
                 return true;
             }

--- a/csharp/extractor/Semmle.Extraction.CSharp.Util/SymbolExtensions.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.Util/SymbolExtensions.cs
@@ -53,6 +53,13 @@ namespace Semmle.Extraction.CSharp.Util
         });
 
         /// <summary>
+        /// The operatorname for user-defined increment and decrement operators are "op_IncrementAssignment" and
+        /// "op_DecrementAssignment" respectively.
+        /// Thus we need to handle this explicitly to avoid postfixing them with an "=".
+        /// </summary>
+        private static bool isIncrementOrDecrement(string operatorName) => operatorName == "++" || operatorName == "--";
+
+        /// <summary>
         /// Convert an operator method name in to a symbolic name.
         /// A return value indicates whether the conversion succeeded.
         /// </summary>
@@ -72,7 +79,7 @@ namespace Semmle.Extraction.CSharp.Util
             if (match.Success && methodToOperator.TryGetValue($"op_{match.Groups[2]}", out var rawOperatorName))
             {
                 var prefix = match.Groups[1].Success ? "checked " : "";
-                var postfix = match.Groups[3].Success ? "=" : "";
+                var postfix = match.Groups[3].Success && !isIncrementOrDecrement(rawOperatorName) ? "=" : "";
                 operatorName = $"{prefix}{rawOperatorName}{postfix}";
                 return true;
             }

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expression.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expression.cs
@@ -234,9 +234,9 @@ namespace Semmle.Extraction.CSharp.Entities
         /// </summary>
         /// <param name="node">The expression syntax node.</param>
         /// <returns>Returns the target method symbol, or null if it cannot be resolved.</returns>
-        protected IMethodSymbol? GetTargetSymbol(ExpressionSyntax node)
+        protected static IMethodSymbol? GetTargetSymbol(Context cx, ExpressionSyntax node)
         {
-            var si = Context.GetSymbolInfo(node);
+            var si = cx.GetSymbolInfo(node);
             if (si.Symbol is ISymbol symbol)
             {
                 var method = symbol as IMethodSymbol;
@@ -255,7 +255,7 @@ namespace Semmle.Extraction.CSharp.Entities
                     .Where(method => method.Parameters.Length >= syntax.ArgumentList.Arguments.Count)
                     .Where(method => method.Parameters.Count(p => !p.HasExplicitDefaultValue) <= syntax.ArgumentList.Arguments.Count);
 
-                return Context.ExtractionContext.IsStandalone ?
+                return cx.ExtractionContext.IsStandalone ?
                     candidates.FirstOrDefault() :
                     candidates.SingleOrDefault();
             }
@@ -281,7 +281,7 @@ namespace Semmle.Extraction.CSharp.Entities
         /// <param name="node">The expression.</param>
         public void AddOperatorCall(TextWriter trapFile, ExpressionSyntax node)
         {
-            var @operator = GetTargetSymbol(node);
+            var @operator = GetTargetSymbol(Context, node);
             if (@operator is IMethodSymbol method)
             {
                 var callType = GetCallType(Context, node);
@@ -312,9 +312,9 @@ namespace Semmle.Extraction.CSharp.Entities
         /// <returns>The call type.</returns>
         public static CallType GetCallType(Context cx, ExpressionSyntax node)
         {
-            var @operator = cx.GetSymbolInfo(node);
+            var @operator = GetTargetSymbol(cx, node);
 
-            if (@operator.Symbol is IMethodSymbol method)
+            if (@operator is IMethodSymbol method)
             {
                 if (method.ContainingSymbol is ITypeSymbol containingSymbol && containingSymbol.TypeKind == Microsoft.CodeAnalysis.TypeKind.Dynamic)
                 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Invocation.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Invocation.cs
@@ -44,7 +44,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
 
             var child = -1;
             string? memberName = null;
-            var target = GetTargetSymbol(Syntax);
+            var target = GetTargetSymbol(Context, Syntax);
             switch (Syntax.Expression)
             {
                 case MemberAccessExpressionSyntax memberAccess when IsValidMemberAccessKind():

--- a/csharp/ql/lib/change-notes/2026-05-12-user-increment-decrement.md
+++ b/csharp/ql/lib/change-notes/2026-05-12-user-increment-decrement.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* C# 14: Added support for user-defined instance increment/decrement operators.

--- a/csharp/ql/lib/semmle/code/csharp/Callable.qll
+++ b/csharp/ql/lib/semmle/code/csharp/Callable.qll
@@ -613,6 +613,9 @@ class UnaryOperator extends Operator {
     this.getNumberOfParameters() = 1 and
     not this instanceof ConversionOperator and
     not this instanceof CompoundAssignmentOperator
+    or
+    // Instance increment and decrement operators don't have a parameter (only a qualifier).
+    this.getNumberOfParameters() = 0 and not this.isStatic()
   }
 }
 

--- a/csharp/ql/lib/semmle/code/csharp/dispatch/Dispatch.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dispatch/Dispatch.qll
@@ -116,7 +116,7 @@ private module Internal {
         not oc.isLateBound() and
         not oc instanceof InstanceOperatorCall
       } or
-      TDispatchInstanceOperatorCall(InstanceOperatorCall caoc) or
+      TDispatchInstanceOperatorCall(InstanceOperatorCall ioc) or
       TDispatchReflectionCall(MethodCall mc, string name, Expr object, Expr qualifier, int args) {
         isReflectionCall(mc, name, object, qualifier, args)
       } or

--- a/csharp/ql/lib/semmle/code/csharp/dispatch/Dispatch.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dispatch/Dispatch.qll
@@ -73,6 +73,19 @@ class DispatchCall extends Internal::TDispatchCall {
   }
 }
 
+abstract private class InstanceOperatorCall extends OperatorCall {
+  abstract Expr getQualifier();
+}
+
+private class InstanceCompoundAssignment extends InstanceOperatorCall instanceof CompoundAssignmentOperatorCall
+{
+  override Expr getQualifier() { result = CompoundAssignmentOperatorCall.super.getQualifier() }
+}
+
+private class InstanceMutator extends InstanceOperatorCall instanceof InstanceMutatorOperatorCall {
+  override Expr getQualifier() { result = InstanceMutatorOperatorCall.super.getQualifier() }
+}
+
 /** Internal implementation details. */
 private module Internal {
   private import OverridableCallable
@@ -101,9 +114,9 @@ private module Internal {
       } or
       TDispatchOperatorCall(OperatorCall oc) {
         not oc.isLateBound() and
-        not oc instanceof CompoundAssignmentOperatorCall
+        not oc instanceof InstanceOperatorCall
       } or
-      TDispatchCompoundAssignmentOperatorCall(CompoundAssignmentOperatorCall caoc) or
+      TDispatchInstanceOperatorCall(InstanceOperatorCall caoc) or
       TDispatchReflectionCall(MethodCall mc, string name, Expr object, Expr qualifier, int args) {
         isReflectionCall(mc, name, object, qualifier, args)
       } or
@@ -890,12 +903,10 @@ private module Internal {
     override Operator getAStaticTarget() { result = this.getCall().getTarget() }
   }
 
-  private class DispatchCompoundAssignmentOperatorCall extends DispatchOverridableCall,
-    TDispatchCompoundAssignmentOperatorCall
+  private class DispatchInstanceOperatorCall extends DispatchOverridableCall,
+    TDispatchInstanceOperatorCall
   {
-    override CompoundAssignmentOperatorCall getCall() {
-      this = TDispatchCompoundAssignmentOperatorCall(result)
-    }
+    override InstanceOperatorCall getCall() { this = TDispatchInstanceOperatorCall(result) }
 
     override Expr getArgument(int i) { result = this.getCall().getArgument(i) }
 

--- a/csharp/ql/lib/semmle/code/csharp/exprs/Call.qll
+++ b/csharp/ql/lib/semmle/code/csharp/exprs/Call.qll
@@ -571,6 +571,29 @@ class MutatorOperatorCall extends OperatorCall {
 }
 
 /**
+ * A call to an instance mutator operator, for example `a++` on
+ * line 5 in
+ *
+ * ```csharp
+ * class A {
+ *   public void operator++() { ... }
+ *
+ *   public static void Increment(A a) {
+ *     a++;
+ *   }
+ * }
+ * ```
+ */
+class InstanceMutatorOperatorCall extends MutatorOperatorCall {
+  InstanceMutatorOperatorCall() { this.getTarget().getNumberOfParameters() = 0 }
+
+  /** Gets the qualifier of this instance mutator operator call. */
+  Expr getQualifier() { result = this.getChildExpr(0) }
+
+  override Expr getArgument(int i) { none() }
+}
+
+/**
  * A call to a compound assignment operator, for example `this += other`
  * on line 7 in
  *

--- a/csharp/ql/lib/semmle/code/csharp/exprs/Call.qll
+++ b/csharp/ql/lib/semmle/code/csharp/exprs/Call.qll
@@ -576,7 +576,7 @@ class MutatorOperatorCall extends OperatorCall {
  *
  * ```csharp
  * class A {
- *   public void operator++() { ... }
+ *   public void operator ++() { ... }
  *
  *   public static void Increment(A a) {
  *     a++;

--- a/csharp/ql/test/library-tests/dataflow/operators/Operator.cs
+++ b/csharp/ql/test/library-tests/dataflow/operators/Operator.cs
@@ -120,3 +120,36 @@ public class CompoundAssignmentOperators
         Sink(x.Field); // $ hasValueFlow=1
     }
 }
+
+public class MutatorOperators
+{
+    static void Sink(object o) { }
+    static T Source<T>(object source) => throw null;
+
+    public class C1
+    {
+        public object Field { get; private set; }
+
+        public C1()
+        {
+            Field = new object();
+        }
+
+        public C1(object o)
+        {
+            Field = o;
+        }
+
+        public void operator ++()
+        {
+            Field = Source<object>(1);
+        }
+
+        public void M1()
+        {
+            var x = new C1();
+            x++;
+            Sink(x.Field); // $ hasValueFlow=1
+        }
+    }
+}

--- a/csharp/ql/test/library-tests/dataflow/operators/operatorFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/operators/operatorFlow.expected
@@ -130,6 +130,16 @@ edges
 | Operator.cs:119:14:119:14 | access to local variable y : C [property Field] : Object | Operator.cs:119:9:119:9 | [post] access to local variable x : C [property Field] : Object | provenance |  |
 | Operator.cs:120:14:120:14 | access to local variable x : C [property Field] : Object | Operator.cs:120:14:120:20 | access to property Field | provenance |  |
 | Operator.cs:120:14:120:14 | access to local variable x : C [property Field] : Object | Operator.cs:120:14:120:20 | access to property Field | provenance |  |
+| Operator.cs:143:30:143:31 | this [Return] : C1 [property Field] : Object | Operator.cs:151:13:151:13 | [post] access to local variable x : C1 [property Field] : Object | provenance |  |
+| Operator.cs:143:30:143:31 | this [Return] : C1 [property Field] : Object | Operator.cs:151:13:151:13 | [post] access to local variable x : C1 [property Field] : Object | provenance |  |
+| Operator.cs:145:13:145:17 | [post] this access : C1 [property Field] : Object | Operator.cs:143:30:143:31 | this [Return] : C1 [property Field] : Object | provenance |  |
+| Operator.cs:145:13:145:17 | [post] this access : C1 [property Field] : Object | Operator.cs:143:30:143:31 | this [Return] : C1 [property Field] : Object | provenance |  |
+| Operator.cs:145:21:145:37 | call to method Source<Object> : Object | Operator.cs:145:13:145:17 | [post] this access : C1 [property Field] : Object | provenance |  |
+| Operator.cs:145:21:145:37 | call to method Source<Object> : Object | Operator.cs:145:13:145:17 | [post] this access : C1 [property Field] : Object | provenance |  |
+| Operator.cs:151:13:151:13 | [post] access to local variable x : C1 [property Field] : Object | Operator.cs:152:18:152:18 | access to local variable x : C1 [property Field] : Object | provenance |  |
+| Operator.cs:151:13:151:13 | [post] access to local variable x : C1 [property Field] : Object | Operator.cs:152:18:152:18 | access to local variable x : C1 [property Field] : Object | provenance |  |
+| Operator.cs:152:18:152:18 | access to local variable x : C1 [property Field] : Object | Operator.cs:152:18:152:24 | access to property Field | provenance |  |
+| Operator.cs:152:18:152:18 | access to local variable x : C1 [property Field] : Object | Operator.cs:152:18:152:24 | access to property Field | provenance |  |
 nodes
 | Operator.cs:9:39:9:39 | x : C | semmle.label | x : C |
 | Operator.cs:9:39:9:39 | x : C | semmle.label | x : C |
@@ -275,6 +285,18 @@ nodes
 | Operator.cs:120:14:120:14 | access to local variable x : C [property Field] : Object | semmle.label | access to local variable x : C [property Field] : Object |
 | Operator.cs:120:14:120:20 | access to property Field | semmle.label | access to property Field |
 | Operator.cs:120:14:120:20 | access to property Field | semmle.label | access to property Field |
+| Operator.cs:143:30:143:31 | this [Return] : C1 [property Field] : Object | semmle.label | this [Return] : C1 [property Field] : Object |
+| Operator.cs:143:30:143:31 | this [Return] : C1 [property Field] : Object | semmle.label | this [Return] : C1 [property Field] : Object |
+| Operator.cs:145:13:145:17 | [post] this access : C1 [property Field] : Object | semmle.label | [post] this access : C1 [property Field] : Object |
+| Operator.cs:145:13:145:17 | [post] this access : C1 [property Field] : Object | semmle.label | [post] this access : C1 [property Field] : Object |
+| Operator.cs:145:21:145:37 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| Operator.cs:145:21:145:37 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| Operator.cs:151:13:151:13 | [post] access to local variable x : C1 [property Field] : Object | semmle.label | [post] access to local variable x : C1 [property Field] : Object |
+| Operator.cs:151:13:151:13 | [post] access to local variable x : C1 [property Field] : Object | semmle.label | [post] access to local variable x : C1 [property Field] : Object |
+| Operator.cs:152:18:152:18 | access to local variable x : C1 [property Field] : Object | semmle.label | access to local variable x : C1 [property Field] : Object |
+| Operator.cs:152:18:152:18 | access to local variable x : C1 [property Field] : Object | semmle.label | access to local variable x : C1 [property Field] : Object |
+| Operator.cs:152:18:152:24 | access to property Field | semmle.label | access to property Field |
+| Operator.cs:152:18:152:24 | access to property Field | semmle.label | access to property Field |
 subpaths
 | Operator.cs:29:17:29:17 | access to local variable x : C | Operator.cs:16:38:16:38 | x : C | Operator.cs:16:49:16:49 | access to parameter x : C | Operator.cs:29:17:29:21 | call to operator + : C |
 | Operator.cs:29:17:29:17 | access to local variable x : C | Operator.cs:16:38:16:38 | x : C | Operator.cs:16:49:16:49 | access to parameter x : C | Operator.cs:29:17:29:21 | call to operator + : C |
@@ -308,3 +330,5 @@ testFailures
 | Operator.cs:78:14:78:14 | (...) ... | Operator.cs:84:17:84:29 | call to method Source<C> : C | Operator.cs:78:14:78:14 | (...) ... | $@ | Operator.cs:84:17:84:29 | call to method Source<C> : C | call to method Source<C> : C |
 | Operator.cs:120:14:120:20 | access to property Field | Operator.cs:116:23:116:39 | call to method Source<Object> : Object | Operator.cs:120:14:120:20 | access to property Field | $@ | Operator.cs:116:23:116:39 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | Operator.cs:120:14:120:20 | access to property Field | Operator.cs:116:23:116:39 | call to method Source<Object> : Object | Operator.cs:120:14:120:20 | access to property Field | $@ | Operator.cs:116:23:116:39 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| Operator.cs:152:18:152:24 | access to property Field | Operator.cs:145:21:145:37 | call to method Source<Object> : Object | Operator.cs:152:18:152:24 | access to property Field | $@ | Operator.cs:145:21:145:37 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| Operator.cs:152:18:152:24 | access to property Field | Operator.cs:145:21:145:37 | call to method Source<Object> : Object | Operator.cs:152:18:152:24 | access to property Field | $@ | Operator.cs:145:21:145:37 | call to method Source<Object> : Object | call to method Source<Object> : Object |

--- a/csharp/ql/test/library-tests/extension/PrintAst.expected
+++ b/csharp/ql/test/library-tests/extension/PrintAst.expected
@@ -171,311 +171,341 @@ extensions.cs:
 #   16|       4: [BlockStmt] {...}
 #   16|         0: [ReturnStmt] return ...;
 #   16|           0: [ParameterAccess] access to parameter t
-#   19|   5: [ExtensionType] extension(Object)
-#   21|     4: [ExtensionMethod] StaticObjectM1
-#   21|       -1: [TypeMention] int
-#   21|       4: [BlockStmt] {...}
-#   21|         0: [ReturnStmt] return ...;
-#   21|           0: [IntLiteral] 0
-#   22|     5: [ExtensionMethod] StaticObjectM2
-#   22|       -1: [TypeMention] int
+#   17|     15: [ExtensionCallable,IncrementOperator] ++
+#   17|       -1: [TypeMention] Void
 #-----|       2: (Parameters)
-#   22|         0: [Parameter] s
-#   22|           -1: [TypeMention] string
-#   22|       4: [BlockStmt] {...}
-#   22|         0: [ReturnStmt] return ...;
-#   22|           0: [PropertyCall] access to property Length
-#   22|             -1: [ParameterAccess] access to parameter s
-#   23|     6: [Property] StaticProp
-#   23|       -1: [TypeMention] bool
-#   23|       3: [ExtensionCallable,Getter] get_StaticProp
-#   23|         4: [BoolLiteral] true
-#   26|   8: [ExtensionType] extension(T)`1
+#    6|         0: [Parameter] s
+#    6|           -1: [TypeMention] string
+#   17|       4: [BlockStmt] {...}
+#   18|     16: [DecrementOperator,ExtensionCallable] --
+#   18|       -1: [TypeMention] string
+#-----|       2: (Parameters)
+#   18|         0: [Parameter] o
+#   18|           -1: [TypeMention] string
+#   18|       4: [BlockStmt] {...}
+#   18|         0: [ReturnStmt] return ...;
+#   18|           0: [ParameterAccess] access to parameter o
+#   21|   5: [ExtensionType] extension(Object)
+#   23|     4: [ExtensionMethod] StaticObjectM1
+#   23|       -1: [TypeMention] int
+#   23|       4: [BlockStmt] {...}
+#   23|         0: [ReturnStmt] return ...;
+#   23|           0: [IntLiteral] 0
+#   24|     5: [ExtensionMethod] StaticObjectM2
+#   24|       -1: [TypeMention] int
+#-----|       2: (Parameters)
+#   24|         0: [Parameter] s
+#   24|           -1: [TypeMention] string
+#   24|       4: [BlockStmt] {...}
+#   24|         0: [ReturnStmt] return ...;
+#   24|           0: [PropertyCall] access to property Length
+#   24|             -1: [ParameterAccess] access to parameter s
+#   25|     6: [Property] StaticProp
+#   25|       -1: [TypeMention] bool
+#   25|       3: [ExtensionCallable,Getter] get_StaticProp
+#   25|         4: [BoolLiteral] true
+#   28|   8: [ExtensionType] extension(T)`1
 #-----|     1: (Type parameters)
-#   26|       0: [TypeParameter] T
+#   28|       0: [TypeParameter] T
 #-----|     2: (Parameters)
-#   26|       0: [Parameter] t
-#   26|         -1: [TypeMention] T
-#   28|     4: [Property] GenericProp1
-#   28|       -1: [TypeMention] bool
-#   28|       3: [ExtensionCallable,Getter] get_GenericProp1
-#-----|         2: (Parameters)
-#   26|           0: [Parameter] t
-#   26|             -1: [TypeMention] T
-#   28|         4: [IsExpr] ... is ...
-#   28|           0: [SyntheticExtensionParameterAccess] access to extension synthetic parameter t
-#   28|           1: [NotPatternExpr] not ...
-#   28|             0: [ConstantPatternExpr,NullLiteral] null
-#   29|     5: [Property] GenericProp2
-#   29|       -1: [TypeMention] bool
-#   29|       3: [ExtensionCallable,Getter] get_GenericProp2
-#-----|         2: (Parameters)
-#   26|           0: [Parameter] t
-#   26|             -1: [TypeMention] T
-#   29|         4: [BlockStmt] {...}
-#   29|           0: [ReturnStmt] return ...;
-#   29|             0: [BoolLiteral] true
-#   29|       4: [ExtensionCallable,Setter] set_GenericProp2
-#-----|         2: (Parameters)
-#   26|           0: [Parameter] t
-#   26|             -1: [TypeMention] T
-#   29|           1: [Parameter] value
-#   29|         4: [BlockStmt] {...}
-#   30|     6: [ExtensionMethod] GenericM1
+#   28|       0: [Parameter] t
+#   28|         -1: [TypeMention] T
+#   30|     4: [Property] GenericProp1
 #   30|       -1: [TypeMention] bool
+#   30|       3: [ExtensionCallable,Getter] get_GenericProp1
+#-----|         2: (Parameters)
+#   28|           0: [Parameter] t
+#   28|             -1: [TypeMention] T
+#   30|         4: [IsExpr] ... is ...
+#   30|           0: [SyntheticExtensionParameterAccess] access to extension synthetic parameter t
+#   30|           1: [NotPatternExpr] not ...
+#   30|             0: [ConstantPatternExpr,NullLiteral] null
+#   31|     5: [Property] GenericProp2
+#   31|       -1: [TypeMention] bool
+#   31|       3: [ExtensionCallable,Getter] get_GenericProp2
+#-----|         2: (Parameters)
+#   28|           0: [Parameter] t
+#   28|             -1: [TypeMention] T
+#   31|         4: [BlockStmt] {...}
+#   31|           0: [ReturnStmt] return ...;
+#   31|             0: [BoolLiteral] true
+#   31|       4: [ExtensionCallable,Setter] set_GenericProp2
+#-----|         2: (Parameters)
+#   28|           0: [Parameter] t
+#   28|             -1: [TypeMention] T
+#   31|           1: [Parameter] value
+#   31|         4: [BlockStmt] {...}
+#   32|     6: [ExtensionMethod] GenericM1
+#   32|       -1: [TypeMention] bool
 #-----|       2: (Parameters)
-#   26|         0: [Parameter] t
-#   26|           -1: [TypeMention] T
-#   30|       4: [IsExpr] ... is ...
-#   30|         0: [SyntheticExtensionParameterAccess] access to extension synthetic parameter t
-#   30|         1: [NotPatternExpr] not ...
-#   30|           0: [ConstantPatternExpr,NullLiteral] null
-#   31|     7: [ExtensionMethod] GenericM2`1
-#   31|       -1: [TypeMention] Void
-#-----|       1: (Type parameters)
-#   31|         0: [TypeParameter] S
-#-----|       2: (Parameters)
-#   26|         0: [Parameter] t
-#   26|           -1: [TypeMention] T
-#   31|         1: [Parameter] other
-#   31|           -1: [TypeMention] S
-#   31|       4: [BlockStmt] {...}
-#   32|     8: [ExtensionMethod] GenericStaticM1
-#   32|       -1: [TypeMention] Void
-#-----|       2: (Parameters)
-#   26|         0: [Parameter] t
-#   26|           -1: [TypeMention] T
-#   32|       4: [BlockStmt] {...}
-#   33|     9: [ExtensionMethod] GenericStaticM2`1
+#   28|         0: [Parameter] t
+#   28|           -1: [TypeMention] T
+#   32|       4: [IsExpr] ... is ...
+#   32|         0: [SyntheticExtensionParameterAccess] access to extension synthetic parameter t
+#   32|         1: [NotPatternExpr] not ...
+#   32|           0: [ConstantPatternExpr,NullLiteral] null
+#   33|     7: [ExtensionMethod] GenericM2`1
 #   33|       -1: [TypeMention] Void
 #-----|       1: (Type parameters)
 #   33|         0: [TypeParameter] S
 #-----|       2: (Parameters)
-#   33|         0: [Parameter] other
+#   28|         0: [Parameter] t
+#   28|           -1: [TypeMention] T
+#   33|         1: [Parameter] other
 #   33|           -1: [TypeMention] S
 #   33|       4: [BlockStmt] {...}
-#   34|     10: [AddOperator,ExtensionCallable] +
-#   34|       -1: [TypeMention] T
+#   34|     8: [ExtensionMethod] GenericStaticM1
+#   34|       -1: [TypeMention] Void
 #-----|       2: (Parameters)
-#   34|         0: [Parameter] a
-#   34|           -1: [TypeMention] T
-#   34|         1: [Parameter] b
-#   34|           -1: [TypeMention] T
+#   28|         0: [Parameter] t
+#   28|           -1: [TypeMention] T
 #   34|       4: [BlockStmt] {...}
-#   34|         0: [ReturnStmt] return ...;
-#   34|           0: [NullLiteral] null
-#   38| [Class] ClassicExtensions
-#   40|   4: [ExtensionMethod] M3
-#   40|     -1: [TypeMention] bool
+#   35|     9: [ExtensionMethod] GenericStaticM2`1
+#   35|       -1: [TypeMention] Void
+#-----|       1: (Type parameters)
+#   35|         0: [TypeParameter] S
+#-----|       2: (Parameters)
+#   35|         0: [Parameter] other
+#   35|           -1: [TypeMention] S
+#   35|       4: [BlockStmt] {...}
+#   36|     10: [AddOperator,ExtensionCallable] +
+#   36|       -1: [TypeMention] T
+#-----|       2: (Parameters)
+#   36|         0: [Parameter] a
+#   36|           -1: [TypeMention] T
+#   36|         1: [Parameter] b
+#   36|           -1: [TypeMention] T
+#   36|       4: [BlockStmt] {...}
+#   36|         0: [ReturnStmt] return ...;
+#   36|           0: [NullLiteral] null
+#   40| [Class] ClassicExtensions
+#   42|   4: [ExtensionMethod] M3
+#   42|     -1: [TypeMention] bool
 #-----|     2: (Parameters)
-#   40|       0: [Parameter] s
-#   40|         -1: [TypeMention] string
-#   40|     4: [IsExpr] ... is ...
-#   40|       0: [ParameterAccess] access to parameter s
-#   40|       1: [NotPatternExpr] not ...
-#   40|         0: [ConstantPatternExpr,NullLiteral] null
-#   43| [Class] C
-#   45|   6: [Method] CallingExtensions
-#   45|     -1: [TypeMention] Void
-#   46|     4: [BlockStmt] {...}
-#   47|       0: [LocalVariableDeclStmt] ... ...;
-#   47|         0: [LocalVariableDeclAndInitExpr] String s = ...
-#   47|           -1: [TypeMention] string
-#   47|           0: [LocalVariableAccess] access to local variable s
-#   47|           1: [StringLiteralUtf16] "Hello World."
-#   50|       1: [LocalVariableDeclStmt] ... ...;
-#   50|         0: [LocalVariableDeclAndInitExpr] Boolean x11 = ...
-#   50|           -1: [TypeMention] bool
-#   50|           0: [LocalVariableAccess] access to local variable x11
-#   50|           1: [ExtensionPropertyCall] access to property Prop1
-#   50|             -1: [LocalVariableAccess] access to local variable s
-#   51|       2: [LocalVariableDeclStmt] ... ...;
-#   51|         0: [LocalVariableDeclAndInitExpr] Boolean x12 = ...
-#   51|           -1: [TypeMention] bool
-#   51|           0: [LocalVariableAccess] access to local variable x12
-#   51|           1: [ExtensionPropertyCall] access to property Prop2
-#   51|             -1: [LocalVariableAccess] access to local variable s
-#   52|       3: [ExprStmt] ...;
-#   52|         0: [AssignExpr] ... = ...
-#   52|           0: [ExtensionPropertyCall] access to property Prop2
+#   42|       0: [Parameter] s
+#   42|         -1: [TypeMention] string
+#   42|     4: [IsExpr] ... is ...
+#   42|       0: [ParameterAccess] access to parameter s
+#   42|       1: [NotPatternExpr] not ...
+#   42|         0: [ConstantPatternExpr,NullLiteral] null
+#   45| [Class] C
+#   47|   6: [Method] CallingExtensions
+#   47|     -1: [TypeMention] Void
+#   48|     4: [BlockStmt] {...}
+#   49|       0: [LocalVariableDeclStmt] ... ...;
+#   49|         0: [LocalVariableDeclAndInitExpr] String s = ...
+#   49|           -1: [TypeMention] string
+#   49|           0: [LocalVariableAccess] access to local variable s
+#   49|           1: [StringLiteralUtf16] "Hello World."
+#   52|       1: [LocalVariableDeclStmt] ... ...;
+#   52|         0: [LocalVariableDeclAndInitExpr] Boolean x11 = ...
+#   52|           -1: [TypeMention] bool
+#   52|           0: [LocalVariableAccess] access to local variable x11
+#   52|           1: [ExtensionPropertyCall] access to property Prop1
 #   52|             -1: [LocalVariableAccess] access to local variable s
-#   52|           1: [BoolLiteral] true
-#   53|       4: [LocalVariableDeclStmt] ... ...;
-#   53|         0: [LocalVariableDeclAndInitExpr] Boolean x13 = ...
+#   53|       2: [LocalVariableDeclStmt] ... ...;
+#   53|         0: [LocalVariableDeclAndInitExpr] Boolean x12 = ...
 #   53|           -1: [TypeMention] bool
-#   53|           0: [LocalVariableAccess] access to local variable x13
-#   53|           1: [ExtensionPropertyCall] access to property StaticProp1
-#   53|             -1: [TypeAccess] access to type String
-#   53|               0: [TypeMention] string
-#   54|       5: [LocalVariableDeclStmt] ... ...;
-#   54|         0: [LocalVariableDeclAndInitExpr] Boolean x14 = ...
-#   54|           -1: [TypeMention] bool
-#   54|           0: [LocalVariableAccess] access to local variable x14
-#   54|           1: [ExtensionPropertyCall] access to property StaticProp
-#   54|             -1: [TypeAccess] access to type Object
-#   54|               0: [TypeMention] object
-#   57|       6: [LocalVariableDeclStmt] ... ...;
-#   57|         0: [LocalVariableDeclAndInitExpr] Boolean x21 = ...
-#   57|           -1: [TypeMention] bool
-#   57|           0: [LocalVariableAccess] access to local variable x21
-#   57|           1: [MethodCall] call to method M1
-#   57|             -1: [LocalVariableAccess] access to local variable s
-#   58|       7: [LocalVariableDeclStmt] ... ...;
-#   58|         0: [LocalVariableDeclAndInitExpr] String x22 = ...
-#   58|           -1: [TypeMention] string
-#   58|           0: [LocalVariableAccess] access to local variable x22
-#   58|           1: [MethodCall] call to method M2
-#   58|             -1: [LocalVariableAccess] access to local variable s
-#   58|             0: [StringLiteralUtf16] "!!!"
-#   59|       8: [LocalVariableDeclStmt] ... ...;
-#   59|         0: [LocalVariableDeclAndInitExpr] Int32 x23 = ...
-#   59|           -1: [TypeMention] int
-#   59|           0: [LocalVariableAccess] access to local variable x23
-#   59|           1: [MethodCall] call to method StaticM1
-#   59|             -1: [TypeAccess] access to type String
-#   59|               0: [TypeMention] string
-#   60|       9: [LocalVariableDeclStmt] ... ...;
-#   60|         0: [LocalVariableDeclAndInitExpr] Int32 x24 = ...
-#   60|           -1: [TypeMention] int
-#   60|           0: [LocalVariableAccess] access to local variable x24
-#   60|           1: [MethodCall] call to method StaticM2
-#   60|             -1: [TypeAccess] access to type String
-#   60|               0: [TypeMention] string
-#   60|             0: [LocalVariableAccess] access to local variable s
-#   61|       10: [LocalVariableDeclStmt] ... ...;
-#   61|         0: [LocalVariableDeclAndInitExpr] Int32 x25 = ...
+#   53|           0: [LocalVariableAccess] access to local variable x12
+#   53|           1: [ExtensionPropertyCall] access to property Prop2
+#   53|             -1: [LocalVariableAccess] access to local variable s
+#   54|       3: [ExprStmt] ...;
+#   54|         0: [AssignExpr] ... = ...
+#   54|           0: [ExtensionPropertyCall] access to property Prop2
+#   54|             -1: [LocalVariableAccess] access to local variable s
+#   54|           1: [BoolLiteral] true
+#   55|       4: [LocalVariableDeclStmt] ... ...;
+#   55|         0: [LocalVariableDeclAndInitExpr] Boolean x13 = ...
+#   55|           -1: [TypeMention] bool
+#   55|           0: [LocalVariableAccess] access to local variable x13
+#   55|           1: [ExtensionPropertyCall] access to property StaticProp1
+#   55|             -1: [TypeAccess] access to type String
+#   55|               0: [TypeMention] string
+#   56|       5: [LocalVariableDeclStmt] ... ...;
+#   56|         0: [LocalVariableDeclAndInitExpr] Boolean x14 = ...
+#   56|           -1: [TypeMention] bool
+#   56|           0: [LocalVariableAccess] access to local variable x14
+#   56|           1: [ExtensionPropertyCall] access to property StaticProp
+#   56|             -1: [TypeAccess] access to type Object
+#   56|               0: [TypeMention] object
+#   59|       6: [LocalVariableDeclStmt] ... ...;
+#   59|         0: [LocalVariableDeclAndInitExpr] Boolean x21 = ...
+#   59|           -1: [TypeMention] bool
+#   59|           0: [LocalVariableAccess] access to local variable x21
+#   59|           1: [MethodCall] call to method M1
+#   59|             -1: [LocalVariableAccess] access to local variable s
+#   60|       7: [LocalVariableDeclStmt] ... ...;
+#   60|         0: [LocalVariableDeclAndInitExpr] String x22 = ...
+#   60|           -1: [TypeMention] string
+#   60|           0: [LocalVariableAccess] access to local variable x22
+#   60|           1: [MethodCall] call to method M2
+#   60|             -1: [LocalVariableAccess] access to local variable s
+#   60|             0: [StringLiteralUtf16] "!!!"
+#   61|       8: [LocalVariableDeclStmt] ... ...;
+#   61|         0: [LocalVariableDeclAndInitExpr] Int32 x23 = ...
 #   61|           -1: [TypeMention] int
-#   61|           0: [LocalVariableAccess] access to local variable x25
-#   61|           1: [MethodCall] call to method StaticObjectM1
-#   61|             -1: [TypeAccess] access to type Object
-#   61|               0: [TypeMention] object
-#   62|       11: [LocalVariableDeclStmt] ... ...;
-#   62|         0: [LocalVariableDeclAndInitExpr] Int32 x26 = ...
+#   61|           0: [LocalVariableAccess] access to local variable x23
+#   61|           1: [MethodCall] call to method StaticM1
+#   61|             -1: [TypeAccess] access to type String
+#   61|               0: [TypeMention] string
+#   62|       9: [LocalVariableDeclStmt] ... ...;
+#   62|         0: [LocalVariableDeclAndInitExpr] Int32 x24 = ...
 #   62|           -1: [TypeMention] int
-#   62|           0: [LocalVariableAccess] access to local variable x26
-#   62|           1: [MethodCall] call to method StaticObjectM2
-#   62|             -1: [TypeAccess] access to type Object
-#   62|               0: [TypeMention] object
+#   62|           0: [LocalVariableAccess] access to local variable x24
+#   62|           1: [MethodCall] call to method StaticM2
+#   62|             -1: [TypeAccess] access to type String
+#   62|               0: [TypeMention] string
 #   62|             0: [LocalVariableAccess] access to local variable s
-#   65|       12: [LocalVariableDeclStmt] ... ...;
-#   65|         0: [LocalVariableDeclAndInitExpr] String x30 = ...
-#   65|           -1: [TypeMention] string
-#   65|           0: [LocalVariableAccess] access to local variable x30
-#   65|           1: [ExtensionOperatorCall] call to operator *
-#   65|             0: [IntLiteral] 3
-#   65|             1: [LocalVariableAccess] access to local variable s
-#   68|       13: [LocalVariableDeclStmt] ... ...;
-#   68|         0: [LocalVariableDeclAndInitExpr] Boolean y = ...
-#   68|           -1: [TypeMention] bool
-#   68|           0: [LocalVariableAccess] access to local variable y
-#   68|           1: [MethodCall] call to method M3
-#   68|             -1: [LocalVariableAccess] access to local variable s
-#   71|       14: [ExprStmt] ...;
-#   71|         0: [MethodCall] call to method M1
-#   71|           -1: [TypeAccess] access to type MyExtensions
-#   71|             0: [TypeMention] MyExtensions
-#   71|           0: [LocalVariableAccess] access to local variable s
-#   72|       15: [ExprStmt] ...;
-#   72|         0: [MethodCall] call to method M2
-#   72|           -1: [TypeAccess] access to type MyExtensions
-#   72|             0: [TypeMention] MyExtensions
-#   72|           0: [LocalVariableAccess] access to local variable s
-#   72|           1: [StringLiteralUtf16] "!!!"
-#   73|       16: [ExprStmt] ...;
-#   73|         0: [MethodCall] call to method StaticM1
-#   73|           -1: [TypeAccess] access to type MyExtensions
-#   73|             0: [TypeMention] MyExtensions
-#   74|       17: [ExprStmt] ...;
-#   74|         0: [MethodCall] call to method StaticM2
-#   74|           -1: [TypeAccess] access to type MyExtensions
-#   74|             0: [TypeMention] MyExtensions
-#   74|           0: [LocalVariableAccess] access to local variable s
-#   75|       18: [ExprStmt] ...;
-#   75|         0: [MethodCall] call to method StaticObjectM1
+#   63|       10: [LocalVariableDeclStmt] ... ...;
+#   63|         0: [LocalVariableDeclAndInitExpr] Int32 x25 = ...
+#   63|           -1: [TypeMention] int
+#   63|           0: [LocalVariableAccess] access to local variable x25
+#   63|           1: [MethodCall] call to method StaticObjectM1
+#   63|             -1: [TypeAccess] access to type Object
+#   63|               0: [TypeMention] object
+#   64|       11: [LocalVariableDeclStmt] ... ...;
+#   64|         0: [LocalVariableDeclAndInitExpr] Int32 x26 = ...
+#   64|           -1: [TypeMention] int
+#   64|           0: [LocalVariableAccess] access to local variable x26
+#   64|           1: [MethodCall] call to method StaticObjectM2
+#   64|             -1: [TypeAccess] access to type Object
+#   64|               0: [TypeMention] object
+#   64|             0: [LocalVariableAccess] access to local variable s
+#   67|       12: [LocalVariableDeclStmt] ... ...;
+#   67|         0: [LocalVariableDeclAndInitExpr] String x30 = ...
+#   67|           -1: [TypeMention] string
+#   67|           0: [LocalVariableAccess] access to local variable x30
+#   67|           1: [ExtensionOperatorCall] call to operator *
+#   67|             0: [IntLiteral] 3
+#   67|             1: [LocalVariableAccess] access to local variable s
+#   68|       13: [ExprStmt] ...;
+#   68|         0: [ExtensionOperatorCall] call to operator ++
+#   68|           0: [LocalVariableAccess] access to local variable s
+#   69|       14: [ExprStmt] ...;
+#   69|         0: [ExtensionOperatorCall] call to operator --
+#   69|           0: [LocalVariableAccess] access to local variable s
+#   72|       15: [LocalVariableDeclStmt] ... ...;
+#   72|         0: [LocalVariableDeclAndInitExpr] Boolean y = ...
+#   72|           -1: [TypeMention] bool
+#   72|           0: [LocalVariableAccess] access to local variable y
+#   72|           1: [MethodCall] call to method M3
+#   72|             -1: [LocalVariableAccess] access to local variable s
+#   75|       16: [ExprStmt] ...;
+#   75|         0: [MethodCall] call to method M1
 #   75|           -1: [TypeAccess] access to type MyExtensions
 #   75|             0: [TypeMention] MyExtensions
-#   76|       19: [ExprStmt] ...;
-#   76|         0: [MethodCall] call to method StaticObjectM2
+#   75|           0: [LocalVariableAccess] access to local variable s
+#   76|       17: [ExprStmt] ...;
+#   76|         0: [MethodCall] call to method M2
 #   76|           -1: [TypeAccess] access to type MyExtensions
 #   76|             0: [TypeMention] MyExtensions
 #   76|           0: [LocalVariableAccess] access to local variable s
+#   76|           1: [StringLiteralUtf16] "!!!"
+#   77|       18: [ExprStmt] ...;
+#   77|         0: [MethodCall] call to method StaticM1
+#   77|           -1: [TypeAccess] access to type MyExtensions
+#   77|             0: [TypeMention] MyExtensions
+#   78|       19: [ExprStmt] ...;
+#   78|         0: [MethodCall] call to method StaticM2
+#   78|           -1: [TypeAccess] access to type MyExtensions
+#   78|             0: [TypeMention] MyExtensions
+#   78|           0: [LocalVariableAccess] access to local variable s
 #   79|       20: [ExprStmt] ...;
-#   79|         0: [ExtensionOperatorCall] call to operator *
+#   79|         0: [MethodCall] call to method StaticObjectM1
 #   79|           -1: [TypeAccess] access to type MyExtensions
 #   79|             0: [TypeMention] MyExtensions
-#   79|           0: [IntLiteral] 3
-#   79|           1: [LocalVariableAccess] access to local variable s
-#   82|       21: [ExprStmt] ...;
-#   82|         0: [MethodCall] call to extension accessor get_Prop1
-#   82|           -1: [TypeAccess] access to type MyExtensions
-#   82|             0: [TypeMention] MyExtensions
-#   82|           0: [LocalVariableAccess] access to local variable s
+#   80|       21: [ExprStmt] ...;
+#   80|         0: [MethodCall] call to method StaticObjectM2
+#   80|           -1: [TypeAccess] access to type MyExtensions
+#   80|             0: [TypeMention] MyExtensions
+#   80|           0: [LocalVariableAccess] access to local variable s
 #   83|       22: [ExprStmt] ...;
-#   83|         0: [MethodCall] call to extension accessor get_Prop2
+#   83|         0: [ExtensionOperatorCall] call to operator *
 #   83|           -1: [TypeAccess] access to type MyExtensions
 #   83|             0: [TypeMention] MyExtensions
-#   83|           0: [LocalVariableAccess] access to local variable s
+#   83|           0: [IntLiteral] 3
+#   83|           1: [LocalVariableAccess] access to local variable s
 #   84|       23: [ExprStmt] ...;
-#   84|         0: [MethodCall] call to extension accessor set_Prop2
+#   84|         0: [ExtensionOperatorCall] call to operator ++
 #   84|           -1: [TypeAccess] access to type MyExtensions
 #   84|             0: [TypeMention] MyExtensions
 #   84|           0: [LocalVariableAccess] access to local variable s
-#   84|           1: [BoolLiteral] false
 #   85|       24: [ExprStmt] ...;
-#   85|         0: [MethodCall] call to extension accessor get_StaticProp
+#   85|         0: [ExtensionOperatorCall] call to operator --
 #   85|           -1: [TypeAccess] access to type MyExtensions
 #   85|             0: [TypeMention] MyExtensions
-#   88|   7: [Method] CallingGenericExtensions
-#   88|     -1: [TypeMention] Void
-#   89|     4: [BlockStmt] {...}
-#   90|       0: [LocalVariableDeclStmt] ... ...;
-#   90|         0: [LocalVariableDeclAndInitExpr] String s = ...
-#   90|           -1: [TypeMention] string
+#   85|           0: [LocalVariableAccess] access to local variable s
+#   88|       25: [ExprStmt] ...;
+#   88|         0: [MethodCall] call to extension accessor get_Prop1
+#   88|           -1: [TypeAccess] access to type MyExtensions
+#   88|             0: [TypeMention] MyExtensions
+#   88|           0: [LocalVariableAccess] access to local variable s
+#   89|       26: [ExprStmt] ...;
+#   89|         0: [MethodCall] call to extension accessor get_Prop2
+#   89|           -1: [TypeAccess] access to type MyExtensions
+#   89|             0: [TypeMention] MyExtensions
+#   89|           0: [LocalVariableAccess] access to local variable s
+#   90|       27: [ExprStmt] ...;
+#   90|         0: [MethodCall] call to extension accessor set_Prop2
+#   90|           -1: [TypeAccess] access to type MyExtensions
+#   90|             0: [TypeMention] MyExtensions
 #   90|           0: [LocalVariableAccess] access to local variable s
-#   90|           1: [StringLiteralUtf16] "Hello Generic World."
-#   91|       1: [LocalVariableDeclStmt] ... ...;
-#   91|         0: [LocalVariableDeclAndInitExpr] Object o = ...
-#   91|           -1: [TypeMention] object
-#   91|           0: [LocalVariableAccess] access to local variable o
-#   91|           1: [ObjectCreation] object creation of type Object
-#   91|             0: [TypeMention] object
-#   94|       2: [ExprStmt] ...;
-#   94|         0: [MethodCall] call to method GenericM1
-#   94|           -1: [LocalVariableAccess] access to local variable o
-#   95|       3: [ExprStmt] ...;
-#   95|         0: [MethodCall] call to method GenericM1
-#   95|           -1: [LocalVariableAccess] access to local variable s
-#   98|       4: [ExprStmt] ...;
-#   98|         0: [MethodCall] call to method GenericM1
-#   98|           -1: [TypeAccess] access to type MyExtensions
-#   98|             0: [TypeMention] MyExtensions
-#   98|           0: [LocalVariableAccess] access to local variable o
-#   99|       5: [ExprStmt] ...;
-#   99|         0: [MethodCall] call to method GenericM1
-#   99|           -1: [TypeAccess] access to type MyExtensions
-#   99|             0: [TypeMention] MyExtensions
-#   99|           0: [LocalVariableAccess] access to local variable s
-#  101|       6: [ExprStmt] ...;
-#  101|         0: [MethodCall] call to method GenericM2<Int32>
-#  101|           -1: [LocalVariableAccess] access to local variable o
-#  101|           0: [IntLiteral] 42
-#  102|       7: [ExprStmt] ...;
-#  102|         0: [MethodCall] call to method GenericM2<Int32>
-#  102|           -1: [TypeAccess] access to type MyExtensions
-#  102|             0: [TypeMention] MyExtensions
-#  102|           0: [LocalVariableAccess] access to local variable o
-#  102|           1: [IntLiteral] 42
-#  104|       8: [ExprStmt] ...;
-#  104|         0: [MethodCall] call to method StringGenericM1<Int32>
-#  104|           -1: [LocalVariableAccess] access to local variable s
-#  104|           0: [IntLiteral] 7
-#  104|           1: [ObjectCreation] object creation of type Object
-#  104|             0: [TypeMention] object
-#  105|       9: [ExprStmt] ...;
-#  105|         0: [MethodCall] call to method StringGenericM1<String>
+#   90|           1: [BoolLiteral] false
+#   91|       28: [ExprStmt] ...;
+#   91|         0: [MethodCall] call to extension accessor get_StaticProp
+#   91|           -1: [TypeAccess] access to type MyExtensions
+#   91|             0: [TypeMention] MyExtensions
+#   94|   7: [Method] CallingGenericExtensions
+#   94|     -1: [TypeMention] Void
+#   95|     4: [BlockStmt] {...}
+#   96|       0: [LocalVariableDeclStmt] ... ...;
+#   96|         0: [LocalVariableDeclAndInitExpr] String s = ...
+#   96|           -1: [TypeMention] string
+#   96|           0: [LocalVariableAccess] access to local variable s
+#   96|           1: [StringLiteralUtf16] "Hello Generic World."
+#   97|       1: [LocalVariableDeclStmt] ... ...;
+#   97|         0: [LocalVariableDeclAndInitExpr] Object o = ...
+#   97|           -1: [TypeMention] object
+#   97|           0: [LocalVariableAccess] access to local variable o
+#   97|           1: [ObjectCreation] object creation of type Object
+#   97|             0: [TypeMention] object
+#  100|       2: [ExprStmt] ...;
+#  100|         0: [MethodCall] call to method GenericM1
+#  100|           -1: [LocalVariableAccess] access to local variable o
+#  101|       3: [ExprStmt] ...;
+#  101|         0: [MethodCall] call to method GenericM1
+#  101|           -1: [LocalVariableAccess] access to local variable s
+#  104|       4: [ExprStmt] ...;
+#  104|         0: [MethodCall] call to method GenericM1
+#  104|           -1: [TypeAccess] access to type MyExtensions
+#  104|             0: [TypeMention] MyExtensions
+#  104|           0: [LocalVariableAccess] access to local variable o
+#  105|       5: [ExprStmt] ...;
+#  105|         0: [MethodCall] call to method GenericM1
 #  105|           -1: [TypeAccess] access to type MyExtensions
 #  105|             0: [TypeMention] MyExtensions
 #  105|           0: [LocalVariableAccess] access to local variable s
-#  105|           1: [StringLiteralUtf16] "test"
-#  105|           2: [ObjectCreation] object creation of type Object
-#  105|             0: [TypeMention] object
+#  107|       6: [ExprStmt] ...;
+#  107|         0: [MethodCall] call to method GenericM2<Int32>
+#  107|           -1: [LocalVariableAccess] access to local variable o
+#  107|           0: [IntLiteral] 42
+#  108|       7: [ExprStmt] ...;
+#  108|         0: [MethodCall] call to method GenericM2<Int32>
+#  108|           -1: [TypeAccess] access to type MyExtensions
+#  108|             0: [TypeMention] MyExtensions
+#  108|           0: [LocalVariableAccess] access to local variable o
+#  108|           1: [IntLiteral] 42
+#  110|       8: [ExprStmt] ...;
+#  110|         0: [MethodCall] call to method StringGenericM1<Int32>
+#  110|           -1: [LocalVariableAccess] access to local variable s
+#  110|           0: [IntLiteral] 7
+#  110|           1: [ObjectCreation] object creation of type Object
+#  110|             0: [TypeMention] object
+#  111|       9: [ExprStmt] ...;
+#  111|         0: [MethodCall] call to method StringGenericM1<String>
+#  111|           -1: [TypeAccess] access to type MyExtensions
+#  111|             0: [TypeMention] MyExtensions
+#  111|           0: [LocalVariableAccess] access to local variable s
+#  111|           1: [StringLiteralUtf16] "test"
+#  111|           2: [ObjectCreation] object creation of type Object
+#  111|             0: [TypeMention] object

--- a/csharp/ql/test/library-tests/extension/extensionTypes.expected
+++ b/csharp/ql/test/library-tests/extension/extensionTypes.expected
@@ -5,10 +5,10 @@ extensionTypeReceiverParameter
 | extensionTypes.cs:18:5:21:5 | extension(Int32) | extensionTypes.cs:18:23:18:24 | i3 |
 | extensionTypes.cs:22:5:25:5 | extension(String) | extensionTypes.cs:22:23:22:23 | s |
 | extensionTypes.cs:26:5:29:5 | extension(T1)`1 | extensionTypes.cs:26:42:26:43 | t1 |
-| extensions.cs:6:5:17:5 | extension(String) | extensions.cs:6:22:6:22 | s |
-| extensions.cs:26:5:35:5 | extension(Object)<Object> | extensions.cs:26:20:26:20 | t |
-| extensions.cs:26:5:35:5 | extension(String)<String> | extensions.cs:26:20:26:20 | t |
-| extensions.cs:26:5:35:5 | extension(T)`1 | extensions.cs:26:20:26:20 | t |
+| extensions.cs:6:5:19:5 | extension(String) | extensions.cs:6:22:6:22 | s |
+| extensions.cs:28:5:37:5 | extension(Object)<Object> | extensions.cs:28:20:28:20 | t |
+| extensions.cs:28:5:37:5 | extension(String)<String> | extensions.cs:28:20:28:20 | t |
+| extensions.cs:28:5:37:5 | extension(T)`1 | extensions.cs:28:20:28:20 | t |
 extensionTypeExtendedType
 | extensionTypes.cs:6:5:9:5 | extension(String) | string |
 | extensionTypes.cs:10:5:13:5 | extension(Int32) | int |
@@ -16,11 +16,11 @@ extensionTypeExtendedType
 | extensionTypes.cs:18:5:21:5 | extension(Int32) | int |
 | extensionTypes.cs:22:5:25:5 | extension(String) | string |
 | extensionTypes.cs:26:5:29:5 | extension(T1)`1 | T1 |
-| extensions.cs:6:5:17:5 | extension(String) | string |
-| extensions.cs:19:5:24:5 | extension(Object) | object |
-| extensions.cs:26:5:35:5 | extension(Object)<Object> | object |
-| extensions.cs:26:5:35:5 | extension(String)<String> | string |
-| extensions.cs:26:5:35:5 | extension(T)`1 | T |
+| extensions.cs:6:5:19:5 | extension(String) | string |
+| extensions.cs:21:5:26:5 | extension(Object) | object |
+| extensions.cs:28:5:37:5 | extension(Object)<Object> | object |
+| extensions.cs:28:5:37:5 | extension(String)<String> | string |
+| extensions.cs:28:5:37:5 | extension(T)`1 | T |
 extensionTypeReceiverParameterAttribute
 | extensionTypes.cs:6:5:9:5 | extension(String) | extensionTypes.cs:6:32:6:32 | s | extensionTypes.cs:6:16:6:22 | [NotNull(...)] |
 | extensionTypes.cs:26:5:29:5 | extension(T1)`1 | extensionTypes.cs:26:42:26:43 | t1 | extensionTypes.cs:26:20:26:30 | [NotNullWhen(...)] |
@@ -30,7 +30,7 @@ extensionTypeReceiverParameterModifier
 | extensionTypes.cs:18:5:21:5 | extension(Int32) | extensionTypes.cs:18:23:18:24 | i3 | ref |
 extensionTypeParameterConstraints
 | extensionTypes.cs:26:5:29:5 | extension(T1)`1 | extensionTypes.cs:26:15:26:16 | T1 | file://:0:0:0:0 | where T1: ... |
-| extensions.cs:26:5:35:5 | extension(T)`1 | extensions.cs:26:15:26:15 | T | file://:0:0:0:0 | where T: ... |
+| extensions.cs:28:5:37:5 | extension(T)`1 | extensions.cs:28:15:28:15 | T | file://:0:0:0:0 | where T: ... |
 syntheticParameterModifier
 | extensionTypes.cs:10:5:13:5 | extension(Int32) | extensionTypes.cs:12:21:12:23 | M21 | extensionTypes.cs:10:32:10:33 | i1 | ref readonly |
 | extensionTypes.cs:14:5:17:5 | extension(Int32) | extensionTypes.cs:16:21:16:23 | M31 | extensionTypes.cs:14:22:14:23 | i2 | in |

--- a/csharp/ql/test/library-tests/extension/extensions.cs
+++ b/csharp/ql/test/library-tests/extension/extensions.cs
@@ -14,6 +14,8 @@ public static class MyExtensions
         public static int StaticM2(string x) { return x.Length; }
         public static string operator *(int a, string b) { return ""; }
         public T StringGenericM1<T>(T t, object o) { return t; }
+        public void operator ++() { }
+        public static string operator --(string o) { return o; }
     }
 
     extension(object)
@@ -61,8 +63,10 @@ public class C
         var x25 = object.StaticObjectM1();
         var x26 = object.StaticObjectM2(s);
 
-        // Calling the extension operator.
+        // Calling the extension operators.
         var x30 = 3 * s;
+        s++;
+        s--;
 
         // Calling the classic extension method.
         var y = s.M3();
@@ -77,6 +81,8 @@ public class C
 
         // Calling the compiler generated operator method.
         MyExtensions.op_Multiply(3, s);
+        MyExtensions.op_IncrementAssignment(s);
+        MyExtensions.op_Decrement(s);
 
         // Calling the compiler generated methods used by the extension property accessors.
         MyExtensions.get_Prop1(s);

--- a/csharp/ql/test/library-tests/extension/extensions.expected
+++ b/csharp/ql/test/library-tests/extension/extensions.expected
@@ -1,51 +1,51 @@
 extensionMethodCallArgument
-| extensions.cs:57:19:57:24 | call to method M1 | extensions.cs:11:21:11:22 | M1 | extensions.cs:6:22:6:22 | s | 0 | extensions.cs:57:19:57:19 | access to local variable s |
-| extensions.cs:58:19:58:29 | call to method M2 | extensions.cs:12:23:12:24 | M2 | extensions.cs:6:22:6:22 | s | 0 | extensions.cs:58:19:58:19 | access to local variable s |
-| extensions.cs:58:19:58:29 | call to method M2 | extensions.cs:12:23:12:24 | M2 | extensions.cs:12:33:12:37 | other | 1 | extensions.cs:58:24:58:28 | "!!!" |
-| extensions.cs:60:19:60:36 | call to method StaticM2 | extensions.cs:14:27:14:34 | StaticM2 | extensions.cs:14:43:14:43 | x | 0 | extensions.cs:60:35:60:35 | access to local variable s |
-| extensions.cs:62:19:62:42 | call to method StaticObjectM2 | extensions.cs:22:27:22:40 | StaticObjectM2 | extensions.cs:22:49:22:49 | s | 0 | extensions.cs:62:41:62:41 | access to local variable s |
-| extensions.cs:68:17:68:22 | call to method M3 | extensions.cs:40:24:40:25 | M3 | extensions.cs:40:39:40:39 | s | 0 | extensions.cs:68:17:68:17 | access to local variable s |
-| extensions.cs:71:9:71:26 | call to method M1 | extensions.cs:11:21:11:22 | M1 | extensions.cs:6:22:6:22 | s | 0 | extensions.cs:71:25:71:25 | access to local variable s |
-| extensions.cs:72:9:72:33 | call to method M2 | extensions.cs:12:23:12:24 | M2 | extensions.cs:6:22:6:22 | s | 0 | extensions.cs:72:25:72:25 | access to local variable s |
-| extensions.cs:72:9:72:33 | call to method M2 | extensions.cs:12:23:12:24 | M2 | extensions.cs:12:33:12:37 | other | 1 | extensions.cs:72:28:72:32 | "!!!" |
-| extensions.cs:74:9:74:32 | call to method StaticM2 | extensions.cs:14:27:14:34 | StaticM2 | extensions.cs:14:43:14:43 | x | 0 | extensions.cs:74:31:74:31 | access to local variable s |
-| extensions.cs:76:9:76:38 | call to method StaticObjectM2 | extensions.cs:22:27:22:40 | StaticObjectM2 | extensions.cs:22:49:22:49 | s | 0 | extensions.cs:76:37:76:37 | access to local variable s |
-| extensions.cs:94:9:94:21 | call to method GenericM1 | extensions.cs:30:21:30:29 | GenericM1 | extensions.cs:26:20:26:20 | t | 0 | extensions.cs:94:9:94:9 | access to local variable o |
-| extensions.cs:95:9:95:21 | call to method GenericM1 | extensions.cs:30:21:30:29 | GenericM1 | extensions.cs:26:20:26:20 | t | 0 | extensions.cs:95:9:95:9 | access to local variable s |
-| extensions.cs:98:9:98:33 | call to method GenericM1 | extensions.cs:30:21:30:29 | GenericM1 | extensions.cs:26:20:26:20 | t | 0 | extensions.cs:98:32:98:32 | access to local variable o |
-| extensions.cs:99:9:99:33 | call to method GenericM1 | extensions.cs:30:21:30:29 | GenericM1 | extensions.cs:26:20:26:20 | t | 0 | extensions.cs:99:32:99:32 | access to local variable s |
-| extensions.cs:101:9:101:23 | call to method GenericM2<Int32> | extensions.cs:31:21:31:32 | GenericM2<Int32> | extensions.cs:26:20:26:20 | t | 0 | extensions.cs:101:9:101:9 | access to local variable o |
-| extensions.cs:101:9:101:23 | call to method GenericM2<Int32> | extensions.cs:31:21:31:32 | GenericM2<Int32> | extensions.cs:31:36:31:40 | other | 1 | extensions.cs:101:21:101:22 | 42 |
-| extensions.cs:102:9:102:37 | call to method GenericM2<Int32> | extensions.cs:31:21:31:32 | GenericM2<Int32> | extensions.cs:26:20:26:20 | t | 0 | extensions.cs:102:32:102:32 | access to local variable o |
-| extensions.cs:102:9:102:37 | call to method GenericM2<Int32> | extensions.cs:31:21:31:32 | GenericM2<Int32> | extensions.cs:31:36:31:40 | other | 1 | extensions.cs:102:35:102:36 | 42 |
-| extensions.cs:104:9:104:47 | call to method StringGenericM1<Int32> | extensions.cs:16:18:16:35 | StringGenericM1<Int32> | extensions.cs:6:22:6:22 | s | 0 | extensions.cs:104:9:104:9 | access to local variable s |
-| extensions.cs:104:9:104:47 | call to method StringGenericM1<Int32> | extensions.cs:16:18:16:35 | StringGenericM1<Int32> | extensions.cs:16:39:16:39 | t | 1 | extensions.cs:104:32:104:32 | 7 |
-| extensions.cs:104:9:104:47 | call to method StringGenericM1<Int32> | extensions.cs:16:18:16:35 | StringGenericM1<Int32> | extensions.cs:16:49:16:49 | o | 2 | extensions.cs:104:35:104:46 | object creation of type Object |
-| extensions.cs:105:9:105:69 | call to method StringGenericM1<String> | extensions.cs:16:18:16:35 | StringGenericM1<String> | extensions.cs:6:22:6:22 | s | 0 | extensions.cs:105:46:105:46 | access to local variable s |
-| extensions.cs:105:9:105:69 | call to method StringGenericM1<String> | extensions.cs:16:18:16:35 | StringGenericM1<String> | extensions.cs:16:39:16:39 | t | 1 | extensions.cs:105:49:105:54 | "test" |
-| extensions.cs:105:9:105:69 | call to method StringGenericM1<String> | extensions.cs:16:18:16:35 | StringGenericM1<String> | extensions.cs:16:49:16:49 | o | 2 | extensions.cs:105:57:105:68 | object creation of type Object |
+| extensions.cs:59:19:59:24 | call to method M1 | extensions.cs:11:21:11:22 | M1 | extensions.cs:6:22:6:22 | s | 0 | extensions.cs:59:19:59:19 | access to local variable s |
+| extensions.cs:60:19:60:29 | call to method M2 | extensions.cs:12:23:12:24 | M2 | extensions.cs:6:22:6:22 | s | 0 | extensions.cs:60:19:60:19 | access to local variable s |
+| extensions.cs:60:19:60:29 | call to method M2 | extensions.cs:12:23:12:24 | M2 | extensions.cs:12:33:12:37 | other | 1 | extensions.cs:60:24:60:28 | "!!!" |
+| extensions.cs:62:19:62:36 | call to method StaticM2 | extensions.cs:14:27:14:34 | StaticM2 | extensions.cs:14:43:14:43 | x | 0 | extensions.cs:62:35:62:35 | access to local variable s |
+| extensions.cs:64:19:64:42 | call to method StaticObjectM2 | extensions.cs:24:27:24:40 | StaticObjectM2 | extensions.cs:24:49:24:49 | s | 0 | extensions.cs:64:41:64:41 | access to local variable s |
+| extensions.cs:72:17:72:22 | call to method M3 | extensions.cs:42:24:42:25 | M3 | extensions.cs:42:39:42:39 | s | 0 | extensions.cs:72:17:72:17 | access to local variable s |
+| extensions.cs:75:9:75:26 | call to method M1 | extensions.cs:11:21:11:22 | M1 | extensions.cs:6:22:6:22 | s | 0 | extensions.cs:75:25:75:25 | access to local variable s |
+| extensions.cs:76:9:76:33 | call to method M2 | extensions.cs:12:23:12:24 | M2 | extensions.cs:6:22:6:22 | s | 0 | extensions.cs:76:25:76:25 | access to local variable s |
+| extensions.cs:76:9:76:33 | call to method M2 | extensions.cs:12:23:12:24 | M2 | extensions.cs:12:33:12:37 | other | 1 | extensions.cs:76:28:76:32 | "!!!" |
+| extensions.cs:78:9:78:32 | call to method StaticM2 | extensions.cs:14:27:14:34 | StaticM2 | extensions.cs:14:43:14:43 | x | 0 | extensions.cs:78:31:78:31 | access to local variable s |
+| extensions.cs:80:9:80:38 | call to method StaticObjectM2 | extensions.cs:24:27:24:40 | StaticObjectM2 | extensions.cs:24:49:24:49 | s | 0 | extensions.cs:80:37:80:37 | access to local variable s |
+| extensions.cs:100:9:100:21 | call to method GenericM1 | extensions.cs:32:21:32:29 | GenericM1 | extensions.cs:28:20:28:20 | t | 0 | extensions.cs:100:9:100:9 | access to local variable o |
+| extensions.cs:101:9:101:21 | call to method GenericM1 | extensions.cs:32:21:32:29 | GenericM1 | extensions.cs:28:20:28:20 | t | 0 | extensions.cs:101:9:101:9 | access to local variable s |
+| extensions.cs:104:9:104:33 | call to method GenericM1 | extensions.cs:32:21:32:29 | GenericM1 | extensions.cs:28:20:28:20 | t | 0 | extensions.cs:104:32:104:32 | access to local variable o |
+| extensions.cs:105:9:105:33 | call to method GenericM1 | extensions.cs:32:21:32:29 | GenericM1 | extensions.cs:28:20:28:20 | t | 0 | extensions.cs:105:32:105:32 | access to local variable s |
+| extensions.cs:107:9:107:23 | call to method GenericM2<Int32> | extensions.cs:33:21:33:32 | GenericM2<Int32> | extensions.cs:28:20:28:20 | t | 0 | extensions.cs:107:9:107:9 | access to local variable o |
+| extensions.cs:107:9:107:23 | call to method GenericM2<Int32> | extensions.cs:33:21:33:32 | GenericM2<Int32> | extensions.cs:33:36:33:40 | other | 1 | extensions.cs:107:21:107:22 | 42 |
+| extensions.cs:108:9:108:37 | call to method GenericM2<Int32> | extensions.cs:33:21:33:32 | GenericM2<Int32> | extensions.cs:28:20:28:20 | t | 0 | extensions.cs:108:32:108:32 | access to local variable o |
+| extensions.cs:108:9:108:37 | call to method GenericM2<Int32> | extensions.cs:33:21:33:32 | GenericM2<Int32> | extensions.cs:33:36:33:40 | other | 1 | extensions.cs:108:35:108:36 | 42 |
+| extensions.cs:110:9:110:47 | call to method StringGenericM1<Int32> | extensions.cs:16:18:16:35 | StringGenericM1<Int32> | extensions.cs:6:22:6:22 | s | 0 | extensions.cs:110:9:110:9 | access to local variable s |
+| extensions.cs:110:9:110:47 | call to method StringGenericM1<Int32> | extensions.cs:16:18:16:35 | StringGenericM1<Int32> | extensions.cs:16:39:16:39 | t | 1 | extensions.cs:110:32:110:32 | 7 |
+| extensions.cs:110:9:110:47 | call to method StringGenericM1<Int32> | extensions.cs:16:18:16:35 | StringGenericM1<Int32> | extensions.cs:16:49:16:49 | o | 2 | extensions.cs:110:35:110:46 | object creation of type Object |
+| extensions.cs:111:9:111:69 | call to method StringGenericM1<String> | extensions.cs:16:18:16:35 | StringGenericM1<String> | extensions.cs:6:22:6:22 | s | 0 | extensions.cs:111:46:111:46 | access to local variable s |
+| extensions.cs:111:9:111:69 | call to method StringGenericM1<String> | extensions.cs:16:18:16:35 | StringGenericM1<String> | extensions.cs:16:39:16:39 | t | 1 | extensions.cs:111:49:111:54 | "test" |
+| extensions.cs:111:9:111:69 | call to method StringGenericM1<String> | extensions.cs:16:18:16:35 | StringGenericM1<String> | extensions.cs:16:49:16:49 | o | 2 | extensions.cs:111:57:111:68 | object creation of type Object |
 extensionMethodCalls
-| extensions.cs:57:19:57:24 | call to method M1 | extensions.cs:11:21:11:22 | M1 | extensions.cs:6:5:17:5 | extension(String) | MyExtensions+extension(System.String).M1 |
-| extensions.cs:58:19:58:29 | call to method M2 | extensions.cs:12:23:12:24 | M2 | extensions.cs:6:5:17:5 | extension(String) | MyExtensions+extension(System.String).M2 |
-| extensions.cs:59:19:59:35 | call to method StaticM1 | extensions.cs:13:27:13:34 | StaticM1 | extensions.cs:6:5:17:5 | extension(String) | MyExtensions+extension(System.String).StaticM1 |
-| extensions.cs:60:19:60:36 | call to method StaticM2 | extensions.cs:14:27:14:34 | StaticM2 | extensions.cs:6:5:17:5 | extension(String) | MyExtensions+extension(System.String).StaticM2 |
-| extensions.cs:61:19:61:41 | call to method StaticObjectM1 | extensions.cs:21:27:21:40 | StaticObjectM1 | extensions.cs:19:5:24:5 | extension(Object) | MyExtensions+extension(System.Object).StaticObjectM1 |
-| extensions.cs:62:19:62:42 | call to method StaticObjectM2 | extensions.cs:22:27:22:40 | StaticObjectM2 | extensions.cs:19:5:24:5 | extension(Object) | MyExtensions+extension(System.Object).StaticObjectM2 |
-| extensions.cs:68:17:68:22 | call to method M3 | extensions.cs:40:24:40:25 | M3 | extensions.cs:38:21:38:37 | ClassicExtensions | ClassicExtensions.M3 |
-| extensions.cs:71:9:71:26 | call to method M1 | extensions.cs:11:21:11:22 | M1 | extensions.cs:6:5:17:5 | extension(String) | MyExtensions+extension(System.String).M1 |
-| extensions.cs:72:9:72:33 | call to method M2 | extensions.cs:12:23:12:24 | M2 | extensions.cs:6:5:17:5 | extension(String) | MyExtensions+extension(System.String).M2 |
-| extensions.cs:73:9:73:31 | call to method StaticM1 | extensions.cs:13:27:13:34 | StaticM1 | extensions.cs:6:5:17:5 | extension(String) | MyExtensions+extension(System.String).StaticM1 |
-| extensions.cs:74:9:74:32 | call to method StaticM2 | extensions.cs:14:27:14:34 | StaticM2 | extensions.cs:6:5:17:5 | extension(String) | MyExtensions+extension(System.String).StaticM2 |
-| extensions.cs:75:9:75:37 | call to method StaticObjectM1 | extensions.cs:21:27:21:40 | StaticObjectM1 | extensions.cs:19:5:24:5 | extension(Object) | MyExtensions+extension(System.Object).StaticObjectM1 |
-| extensions.cs:76:9:76:38 | call to method StaticObjectM2 | extensions.cs:22:27:22:40 | StaticObjectM2 | extensions.cs:19:5:24:5 | extension(Object) | MyExtensions+extension(System.Object).StaticObjectM2 |
-| extensions.cs:94:9:94:21 | call to method GenericM1 | extensions.cs:30:21:30:29 | GenericM1 | extensions.cs:26:5:35:5 | extension(Object)<Object> | MyExtensions+extension(System.Object)<System.Object>.GenericM1 |
-| extensions.cs:95:9:95:21 | call to method GenericM1 | extensions.cs:30:21:30:29 | GenericM1 | extensions.cs:26:5:35:5 | extension(String)<String> | MyExtensions+extension(System.String)<System.String>.GenericM1 |
-| extensions.cs:98:9:98:33 | call to method GenericM1 | extensions.cs:30:21:30:29 | GenericM1 | extensions.cs:26:5:35:5 | extension(Object)<Object> | MyExtensions+extension(System.Object)<System.Object>.GenericM1 |
-| extensions.cs:99:9:99:33 | call to method GenericM1 | extensions.cs:30:21:30:29 | GenericM1 | extensions.cs:26:5:35:5 | extension(String)<String> | MyExtensions+extension(System.String)<System.String>.GenericM1 |
-| extensions.cs:101:9:101:23 | call to method GenericM2<Int32> | extensions.cs:31:21:31:32 | GenericM2<Int32> | extensions.cs:26:5:35:5 | extension(Object)<Object> | MyExtensions+extension(System.Object)<System.Object>.GenericM2<Int32> |
-| extensions.cs:102:9:102:37 | call to method GenericM2<Int32> | extensions.cs:31:21:31:32 | GenericM2<Int32> | extensions.cs:26:5:35:5 | extension(Object)<Object> | MyExtensions+extension(System.Object)<System.Object>.GenericM2<Int32> |
-| extensions.cs:104:9:104:47 | call to method StringGenericM1<Int32> | extensions.cs:16:18:16:35 | StringGenericM1<Int32> | extensions.cs:6:5:17:5 | extension(String) | MyExtensions+extension(System.String).StringGenericM1<Int32> |
-| extensions.cs:105:9:105:69 | call to method StringGenericM1<String> | extensions.cs:16:18:16:35 | StringGenericM1<String> | extensions.cs:6:5:17:5 | extension(String) | MyExtensions+extension(System.String).StringGenericM1<String> |
+| extensions.cs:59:19:59:24 | call to method M1 | extensions.cs:11:21:11:22 | M1 | extensions.cs:6:5:19:5 | extension(String) | MyExtensions+extension(System.String).M1 |
+| extensions.cs:60:19:60:29 | call to method M2 | extensions.cs:12:23:12:24 | M2 | extensions.cs:6:5:19:5 | extension(String) | MyExtensions+extension(System.String).M2 |
+| extensions.cs:61:19:61:35 | call to method StaticM1 | extensions.cs:13:27:13:34 | StaticM1 | extensions.cs:6:5:19:5 | extension(String) | MyExtensions+extension(System.String).StaticM1 |
+| extensions.cs:62:19:62:36 | call to method StaticM2 | extensions.cs:14:27:14:34 | StaticM2 | extensions.cs:6:5:19:5 | extension(String) | MyExtensions+extension(System.String).StaticM2 |
+| extensions.cs:63:19:63:41 | call to method StaticObjectM1 | extensions.cs:23:27:23:40 | StaticObjectM1 | extensions.cs:21:5:26:5 | extension(Object) | MyExtensions+extension(System.Object).StaticObjectM1 |
+| extensions.cs:64:19:64:42 | call to method StaticObjectM2 | extensions.cs:24:27:24:40 | StaticObjectM2 | extensions.cs:21:5:26:5 | extension(Object) | MyExtensions+extension(System.Object).StaticObjectM2 |
+| extensions.cs:72:17:72:22 | call to method M3 | extensions.cs:42:24:42:25 | M3 | extensions.cs:40:21:40:37 | ClassicExtensions | ClassicExtensions.M3 |
+| extensions.cs:75:9:75:26 | call to method M1 | extensions.cs:11:21:11:22 | M1 | extensions.cs:6:5:19:5 | extension(String) | MyExtensions+extension(System.String).M1 |
+| extensions.cs:76:9:76:33 | call to method M2 | extensions.cs:12:23:12:24 | M2 | extensions.cs:6:5:19:5 | extension(String) | MyExtensions+extension(System.String).M2 |
+| extensions.cs:77:9:77:31 | call to method StaticM1 | extensions.cs:13:27:13:34 | StaticM1 | extensions.cs:6:5:19:5 | extension(String) | MyExtensions+extension(System.String).StaticM1 |
+| extensions.cs:78:9:78:32 | call to method StaticM2 | extensions.cs:14:27:14:34 | StaticM2 | extensions.cs:6:5:19:5 | extension(String) | MyExtensions+extension(System.String).StaticM2 |
+| extensions.cs:79:9:79:37 | call to method StaticObjectM1 | extensions.cs:23:27:23:40 | StaticObjectM1 | extensions.cs:21:5:26:5 | extension(Object) | MyExtensions+extension(System.Object).StaticObjectM1 |
+| extensions.cs:80:9:80:38 | call to method StaticObjectM2 | extensions.cs:24:27:24:40 | StaticObjectM2 | extensions.cs:21:5:26:5 | extension(Object) | MyExtensions+extension(System.Object).StaticObjectM2 |
+| extensions.cs:100:9:100:21 | call to method GenericM1 | extensions.cs:32:21:32:29 | GenericM1 | extensions.cs:28:5:37:5 | extension(Object)<Object> | MyExtensions+extension(System.Object)<System.Object>.GenericM1 |
+| extensions.cs:101:9:101:21 | call to method GenericM1 | extensions.cs:32:21:32:29 | GenericM1 | extensions.cs:28:5:37:5 | extension(String)<String> | MyExtensions+extension(System.String)<System.String>.GenericM1 |
+| extensions.cs:104:9:104:33 | call to method GenericM1 | extensions.cs:32:21:32:29 | GenericM1 | extensions.cs:28:5:37:5 | extension(Object)<Object> | MyExtensions+extension(System.Object)<System.Object>.GenericM1 |
+| extensions.cs:105:9:105:33 | call to method GenericM1 | extensions.cs:32:21:32:29 | GenericM1 | extensions.cs:28:5:37:5 | extension(String)<String> | MyExtensions+extension(System.String)<System.String>.GenericM1 |
+| extensions.cs:107:9:107:23 | call to method GenericM2<Int32> | extensions.cs:33:21:33:32 | GenericM2<Int32> | extensions.cs:28:5:37:5 | extension(Object)<Object> | MyExtensions+extension(System.Object)<System.Object>.GenericM2<Int32> |
+| extensions.cs:108:9:108:37 | call to method GenericM2<Int32> | extensions.cs:33:21:33:32 | GenericM2<Int32> | extensions.cs:28:5:37:5 | extension(Object)<Object> | MyExtensions+extension(System.Object)<System.Object>.GenericM2<Int32> |
+| extensions.cs:110:9:110:47 | call to method StringGenericM1<Int32> | extensions.cs:16:18:16:35 | StringGenericM1<Int32> | extensions.cs:6:5:19:5 | extension(String) | MyExtensions+extension(System.String).StringGenericM1<Int32> |
+| extensions.cs:111:9:111:69 | call to method StringGenericM1<String> | extensions.cs:16:18:16:35 | StringGenericM1<String> | extensions.cs:6:5:19:5 | extension(String) | MyExtensions+extension(System.String).StringGenericM1<String> |
 extensionParameter
 | extensions.cs:11:21:11:22 | M1 | extensions.cs:6:22:6:22 | s | 0 | string | extensions.cs:6:22:6:22 | s |
 | extensions.cs:12:23:12:24 | M2 | extensions.cs:6:22:6:22 | s | 0 | string | extensions.cs:6:22:6:22 | s |
@@ -60,52 +60,60 @@ extensionParameter
 | extensions.cs:16:18:16:35 | StringGenericM1`1 | extensions.cs:6:22:6:22 | s | 0 | string | extensions.cs:6:22:6:22 | s |
 | extensions.cs:16:18:16:35 | StringGenericM1`1 | extensions.cs:16:39:16:39 | t | 1 | T | extensions.cs:16:39:16:39 | t |
 | extensions.cs:16:18:16:35 | StringGenericM1`1 | extensions.cs:16:49:16:49 | o | 2 | object | extensions.cs:16:49:16:49 | o |
-| extensions.cs:22:27:22:40 | StaticObjectM2 | extensions.cs:22:49:22:49 | s | 0 | string | extensions.cs:22:49:22:49 | s |
-| extensions.cs:30:21:30:29 | GenericM1 | extensions.cs:26:20:26:20 | t | 0 | T | extensions.cs:26:20:26:20 | t |
-| extensions.cs:30:21:30:29 | GenericM1 | extensions.cs:26:20:26:20 | t | 0 | object | extensions.cs:26:20:26:20 | t |
-| extensions.cs:30:21:30:29 | GenericM1 | extensions.cs:26:20:26:20 | t | 0 | string | extensions.cs:26:20:26:20 | t |
-| extensions.cs:31:21:31:32 | GenericM2<Int32> | extensions.cs:26:20:26:20 | t | 0 | object | extensions.cs:26:20:26:20 | t |
-| extensions.cs:31:21:31:32 | GenericM2<Int32> | extensions.cs:31:36:31:40 | other | 1 | int | extensions.cs:31:36:31:40 | other |
-| extensions.cs:31:21:31:32 | GenericM2`1 | extensions.cs:26:20:26:20 | t | 0 | T | extensions.cs:26:20:26:20 | t |
-| extensions.cs:31:21:31:32 | GenericM2`1 | extensions.cs:26:20:26:20 | t | 0 | object | extensions.cs:26:20:26:20 | t |
-| extensions.cs:31:21:31:32 | GenericM2`1 | extensions.cs:26:20:26:20 | t | 0 | string | extensions.cs:26:20:26:20 | t |
-| extensions.cs:31:21:31:32 | GenericM2`1 | extensions.cs:31:36:31:40 | other | 1 | S | extensions.cs:31:36:31:40 | other |
-| extensions.cs:31:21:31:32 | GenericM2`1 | extensions.cs:31:36:31:40 | other | 1 | S | extensions.cs:31:36:31:40 | other |
-| extensions.cs:31:21:31:32 | GenericM2`1 | extensions.cs:31:36:31:40 | other | 1 | S | extensions.cs:31:36:31:40 | other |
-| extensions.cs:32:21:32:35 | GenericStaticM1 | extensions.cs:26:20:26:20 | t | 0 | T | extensions.cs:26:20:26:20 | t |
-| extensions.cs:32:21:32:35 | GenericStaticM1 | extensions.cs:26:20:26:20 | t | 0 | object | extensions.cs:26:20:26:20 | t |
-| extensions.cs:32:21:32:35 | GenericStaticM1 | extensions.cs:26:20:26:20 | t | 0 | string | extensions.cs:26:20:26:20 | t |
-| extensions.cs:33:28:33:45 | GenericStaticM2`1 | extensions.cs:33:49:33:53 | other | 0 | S | extensions.cs:33:49:33:53 | other |
-| extensions.cs:33:28:33:45 | GenericStaticM2`1 | extensions.cs:33:49:33:53 | other | 0 | S | extensions.cs:33:49:33:53 | other |
-| extensions.cs:33:28:33:45 | GenericStaticM2`1 | extensions.cs:33:49:33:53 | other | 0 | S | extensions.cs:33:49:33:53 | other |
-| extensions.cs:40:24:40:25 | M3 | extensions.cs:40:39:40:39 | s | 0 | string | extensions.cs:40:39:40:39 | s |
+| extensions.cs:24:27:24:40 | StaticObjectM2 | extensions.cs:24:49:24:49 | s | 0 | string | extensions.cs:24:49:24:49 | s |
+| extensions.cs:32:21:32:29 | GenericM1 | extensions.cs:28:20:28:20 | t | 0 | T | extensions.cs:28:20:28:20 | t |
+| extensions.cs:32:21:32:29 | GenericM1 | extensions.cs:28:20:28:20 | t | 0 | object | extensions.cs:28:20:28:20 | t |
+| extensions.cs:32:21:32:29 | GenericM1 | extensions.cs:28:20:28:20 | t | 0 | string | extensions.cs:28:20:28:20 | t |
+| extensions.cs:33:21:33:32 | GenericM2<Int32> | extensions.cs:28:20:28:20 | t | 0 | object | extensions.cs:28:20:28:20 | t |
+| extensions.cs:33:21:33:32 | GenericM2<Int32> | extensions.cs:33:36:33:40 | other | 1 | int | extensions.cs:33:36:33:40 | other |
+| extensions.cs:33:21:33:32 | GenericM2`1 | extensions.cs:28:20:28:20 | t | 0 | T | extensions.cs:28:20:28:20 | t |
+| extensions.cs:33:21:33:32 | GenericM2`1 | extensions.cs:28:20:28:20 | t | 0 | object | extensions.cs:28:20:28:20 | t |
+| extensions.cs:33:21:33:32 | GenericM2`1 | extensions.cs:28:20:28:20 | t | 0 | string | extensions.cs:28:20:28:20 | t |
+| extensions.cs:33:21:33:32 | GenericM2`1 | extensions.cs:33:36:33:40 | other | 1 | S | extensions.cs:33:36:33:40 | other |
+| extensions.cs:33:21:33:32 | GenericM2`1 | extensions.cs:33:36:33:40 | other | 1 | S | extensions.cs:33:36:33:40 | other |
+| extensions.cs:33:21:33:32 | GenericM2`1 | extensions.cs:33:36:33:40 | other | 1 | S | extensions.cs:33:36:33:40 | other |
+| extensions.cs:34:21:34:35 | GenericStaticM1 | extensions.cs:28:20:28:20 | t | 0 | T | extensions.cs:28:20:28:20 | t |
+| extensions.cs:34:21:34:35 | GenericStaticM1 | extensions.cs:28:20:28:20 | t | 0 | object | extensions.cs:28:20:28:20 | t |
+| extensions.cs:34:21:34:35 | GenericStaticM1 | extensions.cs:28:20:28:20 | t | 0 | string | extensions.cs:28:20:28:20 | t |
+| extensions.cs:35:28:35:45 | GenericStaticM2`1 | extensions.cs:35:49:35:53 | other | 0 | S | extensions.cs:35:49:35:53 | other |
+| extensions.cs:35:28:35:45 | GenericStaticM2`1 | extensions.cs:35:49:35:53 | other | 0 | S | extensions.cs:35:49:35:53 | other |
+| extensions.cs:35:28:35:45 | GenericStaticM2`1 | extensions.cs:35:49:35:53 | other | 0 | S | extensions.cs:35:49:35:53 | other |
+| extensions.cs:42:24:42:25 | M3 | extensions.cs:42:39:42:39 | s | 0 | string | extensions.cs:42:39:42:39 | s |
 extensionOperatorCallArgument
-| extensions.cs:15:39:15:39 | * | extensions.cs:65:19:65:23 | call to operator * | extensions.cs:15:45:15:45 | a | 0 | extensions.cs:65:19:65:19 | 3 |
-| extensions.cs:15:39:15:39 | * | extensions.cs:65:19:65:23 | call to operator * | extensions.cs:15:55:15:55 | b | 1 | extensions.cs:65:23:65:23 | access to local variable s |
-| extensions.cs:15:39:15:39 | * | extensions.cs:79:9:79:38 | call to operator * | extensions.cs:15:45:15:45 | a | 0 | extensions.cs:79:34:79:34 | 3 |
-| extensions.cs:15:39:15:39 | * | extensions.cs:79:9:79:38 | call to operator * | extensions.cs:15:55:15:55 | b | 1 | extensions.cs:79:37:79:37 | access to local variable s |
+| extensions.cs:15:39:15:39 | * | extensions.cs:67:19:67:23 | call to operator * | extensions.cs:15:45:15:45 | a | 0 | extensions.cs:67:19:67:19 | 3 |
+| extensions.cs:15:39:15:39 | * | extensions.cs:67:19:67:23 | call to operator * | extensions.cs:15:55:15:55 | b | 1 | extensions.cs:67:23:67:23 | access to local variable s |
+| extensions.cs:15:39:15:39 | * | extensions.cs:83:9:83:38 | call to operator * | extensions.cs:15:45:15:45 | a | 0 | extensions.cs:83:34:83:34 | 3 |
+| extensions.cs:15:39:15:39 | * | extensions.cs:83:9:83:38 | call to operator * | extensions.cs:15:55:15:55 | b | 1 | extensions.cs:83:37:83:37 | access to local variable s |
+| extensions.cs:17:30:17:31 | ++ | extensions.cs:68:9:68:11 | call to operator ++ | extensions.cs:6:22:6:22 | s | 0 | extensions.cs:68:9:68:9 | access to local variable s |
+| extensions.cs:17:30:17:31 | ++ | extensions.cs:84:9:84:46 | call to operator ++ | extensions.cs:6:22:6:22 | s | 0 | extensions.cs:84:45:84:45 | access to local variable s |
+| extensions.cs:18:39:18:40 | -- | extensions.cs:69:9:69:11 | call to operator -- | extensions.cs:18:49:18:49 | o | 0 | extensions.cs:69:9:69:9 | access to local variable s |
+| extensions.cs:18:39:18:40 | -- | extensions.cs:85:9:85:36 | call to operator -- | extensions.cs:18:49:18:49 | o | 0 | extensions.cs:85:35:85:35 | access to local variable s |
 extensionOperatorCalls
-| extensions.cs:65:19:65:23 | call to operator * | extensions.cs:15:39:15:39 | * | extensions.cs:6:5:17:5 | extension(String) | MyExtensions+extension(System.String).op_Multiply |
-| extensions.cs:79:9:79:38 | call to operator * | extensions.cs:15:39:15:39 | * | extensions.cs:6:5:17:5 | extension(String) | MyExtensions+extension(System.String).op_Multiply |
+| extensions.cs:67:19:67:23 | call to operator * | extensions.cs:15:39:15:39 | * | extensions.cs:6:5:19:5 | extension(String) | MyExtensions+extension(System.String).op_Multiply |
+| extensions.cs:68:9:68:11 | call to operator ++ | extensions.cs:17:30:17:31 | ++ | extensions.cs:6:5:19:5 | extension(String) | MyExtensions+extension(System.String).op_IncrementAssignment |
+| extensions.cs:69:9:69:11 | call to operator -- | extensions.cs:18:39:18:40 | -- | extensions.cs:6:5:19:5 | extension(String) | MyExtensions+extension(System.String).op_Decrement |
+| extensions.cs:83:9:83:38 | call to operator * | extensions.cs:15:39:15:39 | * | extensions.cs:6:5:19:5 | extension(String) | MyExtensions+extension(System.String).op_Multiply |
+| extensions.cs:84:9:84:46 | call to operator ++ | extensions.cs:17:30:17:31 | ++ | extensions.cs:6:5:19:5 | extension(String) | MyExtensions+extension(System.String).op_IncrementAssignment |
+| extensions.cs:85:9:85:36 | call to operator -- | extensions.cs:18:39:18:40 | -- | extensions.cs:6:5:19:5 | extension(String) | MyExtensions+extension(System.String).op_Decrement |
 extensionProperty
-| extensions.cs:8:21:8:25 | Prop1 | extensions.cs:6:5:17:5 | extension(String) |
-| extensions.cs:9:21:9:25 | Prop2 | extensions.cs:6:5:17:5 | extension(String) |
-| extensions.cs:10:28:10:38 | StaticProp1 | extensions.cs:6:5:17:5 | extension(String) |
-| extensions.cs:23:28:23:37 | StaticProp | extensions.cs:19:5:24:5 | extension(Object) |
-| extensions.cs:28:21:28:32 | GenericProp1 | extensions.cs:26:5:35:5 | extension(Object)<Object> |
-| extensions.cs:28:21:28:32 | GenericProp1 | extensions.cs:26:5:35:5 | extension(String)<String> |
-| extensions.cs:28:21:28:32 | GenericProp1 | extensions.cs:26:5:35:5 | extension(T)`1 |
-| extensions.cs:29:21:29:32 | GenericProp2 | extensions.cs:26:5:35:5 | extension(Object)<Object> |
-| extensions.cs:29:21:29:32 | GenericProp2 | extensions.cs:26:5:35:5 | extension(String)<String> |
-| extensions.cs:29:21:29:32 | GenericProp2 | extensions.cs:26:5:35:5 | extension(T)`1 |
+| extensions.cs:8:21:8:25 | Prop1 | extensions.cs:6:5:19:5 | extension(String) |
+| extensions.cs:9:21:9:25 | Prop2 | extensions.cs:6:5:19:5 | extension(String) |
+| extensions.cs:10:28:10:38 | StaticProp1 | extensions.cs:6:5:19:5 | extension(String) |
+| extensions.cs:25:28:25:37 | StaticProp | extensions.cs:21:5:26:5 | extension(Object) |
+| extensions.cs:30:21:30:32 | GenericProp1 | extensions.cs:28:5:37:5 | extension(Object)<Object> |
+| extensions.cs:30:21:30:32 | GenericProp1 | extensions.cs:28:5:37:5 | extension(String)<String> |
+| extensions.cs:30:21:30:32 | GenericProp1 | extensions.cs:28:5:37:5 | extension(T)`1 |
+| extensions.cs:31:21:31:32 | GenericProp2 | extensions.cs:28:5:37:5 | extension(Object)<Object> |
+| extensions.cs:31:21:31:32 | GenericProp2 | extensions.cs:28:5:37:5 | extension(String)<String> |
+| extensions.cs:31:21:31:32 | GenericProp2 | extensions.cs:28:5:37:5 | extension(T)`1 |
 extensionPropertyCall
-| extensions.cs:50:19:50:25 | access to property Prop1 | extensions.cs:8:21:8:25 | Prop1 | extensions.cs:6:5:17:5 | extension(String) | MyExtensions+extension(System.String).Prop1 |
-| extensions.cs:51:19:51:25 | access to property Prop2 | extensions.cs:9:21:9:25 | Prop2 | extensions.cs:6:5:17:5 | extension(String) | MyExtensions+extension(System.String).Prop2 |
-| extensions.cs:52:9:52:15 | access to property Prop2 | extensions.cs:9:21:9:25 | Prop2 | extensions.cs:6:5:17:5 | extension(String) | MyExtensions+extension(System.String).Prop2 |
-| extensions.cs:53:19:53:36 | access to property StaticProp1 | extensions.cs:10:28:10:38 | StaticProp1 | extensions.cs:6:5:17:5 | extension(String) | MyExtensions+extension(System.String).StaticProp1 |
-| extensions.cs:54:19:54:35 | access to property StaticProp | extensions.cs:23:28:23:37 | StaticProp | extensions.cs:19:5:24:5 | extension(Object) | MyExtensions+extension(System.Object).StaticProp |
+| extensions.cs:52:19:52:25 | access to property Prop1 | extensions.cs:8:21:8:25 | Prop1 | extensions.cs:6:5:19:5 | extension(String) | MyExtensions+extension(System.String).Prop1 |
+| extensions.cs:53:19:53:25 | access to property Prop2 | extensions.cs:9:21:9:25 | Prop2 | extensions.cs:6:5:19:5 | extension(String) | MyExtensions+extension(System.String).Prop2 |
+| extensions.cs:54:9:54:15 | access to property Prop2 | extensions.cs:9:21:9:25 | Prop2 | extensions.cs:6:5:19:5 | extension(String) | MyExtensions+extension(System.String).Prop2 |
+| extensions.cs:55:19:55:36 | access to property StaticProp1 | extensions.cs:10:28:10:38 | StaticProp1 | extensions.cs:6:5:19:5 | extension(String) | MyExtensions+extension(System.String).StaticProp1 |
+| extensions.cs:56:19:56:35 | access to property StaticProp | extensions.cs:25:28:25:37 | StaticProp | extensions.cs:21:5:26:5 | extension(Object) | MyExtensions+extension(System.Object).StaticProp |
 extensionAccessorCall
-| extensions.cs:82:9:82:33 | call to extension accessor get_Prop1 | extensions.cs:8:30:8:41 | get_Prop1 | extensions.cs:8:21:8:25 | Prop1 | MyExtensions+extension(System.String).get_Prop1 |
-| extensions.cs:83:9:83:33 | call to extension accessor get_Prop2 | extensions.cs:9:29:9:31 | get_Prop2 | extensions.cs:9:21:9:25 | Prop2 | MyExtensions+extension(System.String).get_Prop2 |
-| extensions.cs:84:9:84:40 | call to extension accessor set_Prop2 | extensions.cs:9:50:9:52 | set_Prop2 | extensions.cs:9:21:9:25 | Prop2 | MyExtensions+extension(System.String).set_Prop2 |
-| extensions.cs:85:9:85:37 | call to extension accessor get_StaticProp | extensions.cs:23:42:23:45 | get_StaticProp | extensions.cs:23:28:23:37 | StaticProp | MyExtensions+extension(System.Object).get_StaticProp |
+| extensions.cs:88:9:88:33 | call to extension accessor get_Prop1 | extensions.cs:8:30:8:41 | get_Prop1 | extensions.cs:8:21:8:25 | Prop1 | MyExtensions+extension(System.String).get_Prop1 |
+| extensions.cs:89:9:89:33 | call to extension accessor get_Prop2 | extensions.cs:9:29:9:31 | get_Prop2 | extensions.cs:9:21:9:25 | Prop2 | MyExtensions+extension(System.String).get_Prop2 |
+| extensions.cs:90:9:90:40 | call to extension accessor set_Prop2 | extensions.cs:9:50:9:52 | set_Prop2 | extensions.cs:9:21:9:25 | Prop2 | MyExtensions+extension(System.String).set_Prop2 |
+| extensions.cs:91:9:91:37 | call to extension accessor get_StaticProp | extensions.cs:25:42:25:45 | get_StaticProp | extensions.cs:25:28:25:37 | StaticProp | MyExtensions+extension(System.Object).get_StaticProp |

--- a/csharp/ql/test/library-tests/operators/Operators3.expected
+++ b/csharp/ql/test/library-tests/operators/Operators3.expected
@@ -1,1 +1,1 @@
-| operators.cs:96:32:96:39 | implicit conversion |
+| operators.cs:118:36:118:43 | implicit conversion |

--- a/csharp/ql/test/library-tests/operators/Operators4.expected
+++ b/csharp/ql/test/library-tests/operators/Operators4.expected
@@ -1,1 +1,1 @@
-| operators.cs:101:32:101:39 | explicit conversion |
+| operators.cs:123:36:123:43 | explicit conversion |

--- a/csharp/ql/test/library-tests/operators/Operators5.expected
+++ b/csharp/ql/test/library-tests/operators/Operators5.expected
@@ -1,15 +1,15 @@
-| operators.cs:23:30:23:31 | += | operators.cs:61:13:61:22 | ... += ... |
-| operators.cs:31:38:31:39 | checked += | operators.cs:77:17:77:26 | ... += ... |
-| operators.cs:33:38:33:39 | checked -= | operators.cs:78:17:78:26 | ... -= ... |
-| operators.cs:34:30:34:31 | -= | operators.cs:64:13:64:22 | ... -= ... |
-| operators.cs:36:38:36:39 | checked *= | operators.cs:79:17:79:26 | ... *= ... |
-| operators.cs:37:30:37:31 | *= | operators.cs:65:13:65:22 | ... *= ... |
-| operators.cs:39:38:39:39 | checked /= | operators.cs:80:17:80:26 | ... /= ... |
-| operators.cs:40:30:40:31 | /= | operators.cs:66:13:66:22 | ... /= ... |
-| operators.cs:42:30:42:31 | %= | operators.cs:67:13:67:22 | ... %= ... |
-| operators.cs:43:30:43:31 | &= | operators.cs:68:13:68:22 | ... &= ... |
-| operators.cs:44:30:44:31 | \|= | operators.cs:69:13:69:22 | ... \|= ... |
-| operators.cs:45:30:45:31 | ^= | operators.cs:70:13:70:22 | ... ^= ... |
-| operators.cs:46:30:46:32 | <<= | operators.cs:71:13:71:23 | ... <<= ... |
-| operators.cs:47:30:47:32 | >>= | operators.cs:72:13:72:23 | ... >>= ... |
-| operators.cs:48:30:48:33 | >>>= | operators.cs:73:13:73:24 | ... >>>= ... |
+| operators.cs:23:30:23:31 | += | operators.cs:70:13:70:22 | ... += ... |
+| operators.cs:31:38:31:39 | checked += | operators.cs:86:17:86:26 | ... += ... |
+| operators.cs:33:38:33:39 | checked -= | operators.cs:87:17:87:26 | ... -= ... |
+| operators.cs:34:30:34:31 | -= | operators.cs:73:13:73:22 | ... -= ... |
+| operators.cs:36:38:36:39 | checked *= | operators.cs:88:17:88:26 | ... *= ... |
+| operators.cs:37:30:37:31 | *= | operators.cs:74:13:74:22 | ... *= ... |
+| operators.cs:39:38:39:39 | checked /= | operators.cs:89:17:89:26 | ... /= ... |
+| operators.cs:40:30:40:31 | /= | operators.cs:75:13:75:22 | ... /= ... |
+| operators.cs:42:30:42:31 | %= | operators.cs:76:13:76:22 | ... %= ... |
+| operators.cs:43:30:43:31 | &= | operators.cs:77:13:77:22 | ... &= ... |
+| operators.cs:44:30:44:31 | \|= | operators.cs:78:13:78:22 | ... \|= ... |
+| operators.cs:45:30:45:31 | ^= | operators.cs:79:13:79:22 | ... ^= ... |
+| operators.cs:46:30:46:32 | <<= | operators.cs:80:13:80:23 | ... <<= ... |
+| operators.cs:47:30:47:32 | >>= | operators.cs:81:13:81:23 | ... >>= ... |
+| operators.cs:48:30:48:33 | >>>= | operators.cs:82:13:82:24 | ... >>>= ... |

--- a/csharp/ql/test/library-tests/operators/Operators6.expected
+++ b/csharp/ql/test/library-tests/operators/Operators6.expected
@@ -1,0 +1,10 @@
+| operators.cs:15:42:15:43 | ++ | operators.cs:66:19:66:23 | call to operator ++ |
+| operators.cs:15:42:15:43 | ++ | operators.cs:67:19:67:23 | call to operator ++ |
+| operators.cs:54:38:54:39 | checked ++ | operators.cs:100:17:100:19 | call to operator checked ++ |
+| operators.cs:54:38:54:39 | checked ++ | operators.cs:101:17:101:19 | call to operator checked ++ |
+| operators.cs:55:30:55:31 | ++ | operators.cs:93:13:93:15 | call to operator ++ |
+| operators.cs:55:30:55:31 | ++ | operators.cs:94:13:94:15 | call to operator ++ |
+| operators.cs:56:38:56:39 | checked -- | operators.cs:102:17:102:19 | call to operator checked -- |
+| operators.cs:56:38:56:39 | checked -- | operators.cs:103:17:103:19 | call to operator checked -- |
+| operators.cs:57:30:57:31 | -- | operators.cs:95:13:95:15 | call to operator -- |
+| operators.cs:57:30:57:31 | -- | operators.cs:96:13:96:15 | call to operator -- |

--- a/csharp/ql/test/library-tests/operators/Operators6.ql
+++ b/csharp/ql/test/library-tests/operators/Operators6.ql
@@ -1,0 +1,17 @@
+/**
+ * @name Test for operators
+ */
+
+import csharp
+
+from Operator op, OperatorCall call
+where
+  op.fromSource() and
+  (
+    op instanceof IncrementOperator or
+    op instanceof CheckedIncrementOperator or
+    op instanceof DecrementOperator or
+    op instanceof CheckedDecrementOperator
+  ) and
+  call.getTarget() = op
+select op, call

--- a/csharp/ql/test/library-tests/operators/PrintAst.expected
+++ b/csharp/ql/test/library-tests/operators/PrintAst.expected
@@ -181,159 +181,204 @@ operators.cs:
 #   48|         0: [Parameter] n
 #   48|           -1: [TypeMention] IntVector
 #   48|       4: [BlockStmt] {...}
-#   51|   2: [Class] TestOperator
-#   53|     6: [Method] Main
-#   53|       -1: [TypeMention] Void
+#   51|   2: [Class] C
+#   54|     6: [???] checked ++=
+#   54|       -1: [TypeMention] Void
 #   54|       4: [BlockStmt] {...}
-#   55|         0: [LocalVariableDeclStmt] ... ...;
-#   55|           0: [LocalVariableDeclAndInitExpr] IntVector iv1 = ...
-#   55|             -1: [TypeMention] IntVector
-#   55|             0: [LocalVariableAccess] access to local variable iv1
-#   55|             1: [ObjectCreation] object creation of type IntVector
-#   55|               -1: [TypeMention] IntVector
-#   55|               0: [IntLiteral] 4
-#   56|         1: [LocalVariableDeclStmt] ... ...;
-#   56|           0: [LocalVariableDeclExpr] IntVector iv2
-#   56|             0: [TypeMention] IntVector
-#   57|         2: [ExprStmt] ...;
-#   57|           0: [AssignExpr] ... = ...
-#   57|             0: [LocalVariableAccess] access to local variable iv2
-#   57|             1: [OperatorCall] call to operator ++
-#   57|               0: [LocalVariableAccess] access to local variable iv1
-#   58|         3: [ExprStmt] ...;
-#   58|           0: [AssignExpr] ... = ...
-#   58|             0: [LocalVariableAccess] access to local variable iv2
-#   58|             1: [OperatorCall] call to operator ++
-#   58|               0: [LocalVariableAccess] access to local variable iv1
-#   60|         4: [LocalVariableDeclStmt] ... ...;
-#   60|           0: [LocalVariableDeclAndInitExpr] IntVector iv3 = ...
-#   60|             -1: [TypeMention] IntVector
-#   60|             0: [LocalVariableAccess] access to local variable iv3
-#   60|             1: [ObjectCreation] object creation of type IntVector
-#   60|               -1: [TypeMention] IntVector
-#   60|               0: [IntLiteral] 4
-#   61|         5: [ExprStmt] ...;
-#   61|           0: [AssignAddExpr] ... += ...
-#   61|             0: [LocalVariableAccess] access to local variable iv3
-#   61|             1: [LocalVariableAccess] access to local variable iv2
-#   64|         6: [ExprStmt] ...;
-#   64|           0: [AssignSubExpr] ... -= ...
-#   64|             0: [LocalVariableAccess] access to local variable iv3
-#   64|             1: [LocalVariableAccess] access to local variable iv2
-#   65|         7: [ExprStmt] ...;
-#   65|           0: [AssignMulExpr] ... *= ...
-#   65|             0: [LocalVariableAccess] access to local variable iv3
-#   65|             1: [LocalVariableAccess] access to local variable iv2
-#   66|         8: [ExprStmt] ...;
-#   66|           0: [AssignDivExpr] ... /= ...
-#   66|             0: [LocalVariableAccess] access to local variable iv3
-#   66|             1: [LocalVariableAccess] access to local variable iv2
-#   67|         9: [ExprStmt] ...;
-#   67|           0: [AssignRemExpr] ... %= ...
-#   67|             0: [LocalVariableAccess] access to local variable iv3
-#   67|             1: [LocalVariableAccess] access to local variable iv2
-#   68|         10: [ExprStmt] ...;
-#   68|           0: [AssignAndExpr] ... &= ...
-#   68|             0: [LocalVariableAccess] access to local variable iv3
-#   68|             1: [LocalVariableAccess] access to local variable iv2
-#   69|         11: [ExprStmt] ...;
-#   69|           0: [AssignOrExpr] ... |= ...
+#   55|     7: [???] ++=
+#   55|       -1: [TypeMention] Void
+#   55|       4: [BlockStmt] {...}
+#   56|     8: [???] checked --=
+#   56|       -1: [TypeMention] Void
+#   56|       4: [BlockStmt] {...}
+#   57|     9: [???] --=
+#   57|       -1: [TypeMention] Void
+#   57|       4: [BlockStmt] {...}
+#   60|   3: [Class] TestOperator
+#   62|     6: [Method] Main
+#   62|       -1: [TypeMention] Void
+#   63|       4: [BlockStmt] {...}
+#   64|         0: [LocalVariableDeclStmt] ... ...;
+#   64|           0: [LocalVariableDeclAndInitExpr] IntVector iv1 = ...
+#   64|             -1: [TypeMention] IntVector
+#   64|             0: [LocalVariableAccess] access to local variable iv1
+#   64|             1: [ObjectCreation] object creation of type IntVector
+#   64|               -1: [TypeMention] IntVector
+#   64|               0: [IntLiteral] 4
+#   65|         1: [LocalVariableDeclStmt] ... ...;
+#   65|           0: [LocalVariableDeclExpr] IntVector iv2
+#   65|             0: [TypeMention] IntVector
+#   66|         2: [ExprStmt] ...;
+#   66|           0: [AssignExpr] ... = ...
+#   66|             0: [LocalVariableAccess] access to local variable iv2
+#   66|             1: [OperatorCall] call to operator ++
+#   66|               0: [LocalVariableAccess] access to local variable iv1
+#   67|         3: [ExprStmt] ...;
+#   67|           0: [AssignExpr] ... = ...
+#   67|             0: [LocalVariableAccess] access to local variable iv2
+#   67|             1: [OperatorCall] call to operator ++
+#   67|               0: [LocalVariableAccess] access to local variable iv1
+#   69|         4: [LocalVariableDeclStmt] ... ...;
+#   69|           0: [LocalVariableDeclAndInitExpr] IntVector iv3 = ...
+#   69|             -1: [TypeMention] IntVector
 #   69|             0: [LocalVariableAccess] access to local variable iv3
-#   69|             1: [LocalVariableAccess] access to local variable iv2
-#   70|         12: [ExprStmt] ...;
-#   70|           0: [AssignXorExpr] ... ^= ...
+#   69|             1: [ObjectCreation] object creation of type IntVector
+#   69|               -1: [TypeMention] IntVector
+#   69|               0: [IntLiteral] 4
+#   70|         5: [ExprStmt] ...;
+#   70|           0: [AssignAddExpr] ... += ...
 #   70|             0: [LocalVariableAccess] access to local variable iv3
 #   70|             1: [LocalVariableAccess] access to local variable iv2
-#   71|         13: [ExprStmt] ...;
-#   71|           0: [AssignLeftShiftExpr] ... <<= ...
-#   71|             0: [LocalVariableAccess] access to local variable iv3
-#   71|             1: [LocalVariableAccess] access to local variable iv2
-#   72|         14: [ExprStmt] ...;
-#   72|           0: [AssignRightShiftExpr] ... >>= ...
-#   72|             0: [LocalVariableAccess] access to local variable iv3
-#   72|             1: [LocalVariableAccess] access to local variable iv2
-#   73|         15: [ExprStmt] ...;
-#   73|           0: [AssignUnsignedRightShiftExpr] ... >>>= ...
+#   73|         6: [ExprStmt] ...;
+#   73|           0: [AssignSubExpr] ... -= ...
 #   73|             0: [LocalVariableAccess] access to local variable iv3
 #   73|             1: [LocalVariableAccess] access to local variable iv2
-#   75|         16: [CheckedStmt] checked {...}
-#   76|           0: [BlockStmt] {...}
-#   77|             0: [ExprStmt] ...;
-#   77|               0: [AssignAddExpr] ... += ...
-#   77|                 0: [LocalVariableAccess] access to local variable iv3
-#   77|                 1: [LocalVariableAccess] access to local variable iv2
-#   78|             1: [ExprStmt] ...;
-#   78|               0: [AssignSubExpr] ... -= ...
-#   78|                 0: [LocalVariableAccess] access to local variable iv3
-#   78|                 1: [LocalVariableAccess] access to local variable iv2
-#   79|             2: [ExprStmt] ...;
-#   79|               0: [AssignMulExpr] ... *= ...
-#   79|                 0: [LocalVariableAccess] access to local variable iv3
-#   79|                 1: [LocalVariableAccess] access to local variable iv2
-#   80|             3: [ExprStmt] ...;
-#   80|               0: [AssignDivExpr] ... /= ...
-#   80|                 0: [LocalVariableAccess] access to local variable iv3
-#   80|                 1: [LocalVariableAccess] access to local variable iv2
-#   85|   3: [Struct] Digit
-#   87|     6: [Field] value
-#   87|       -1: [TypeMention] byte
-#   89|     7: [InstanceConstructor] Digit
-#-----|       2: (Parameters)
-#   89|         0: [Parameter] value
-#   89|           -1: [TypeMention] byte
-#   90|       4: [BlockStmt] {...}
-#   91|         0: [IfStmt] if (...) ...
-#   91|           0: [LogicalOrExpr] ... || ...
-#   91|             0: [LTExpr] ... < ...
-#   91|               0: [CastExpr] (...) ...
-#   91|                 1: [ParameterAccess] access to parameter value
-#   91|               1: [IntLiteral] 0
-#   91|             1: [GTExpr] ... > ...
-#   91|               0: [CastExpr] (...) ...
-#   91|                 1: [ParameterAccess] access to parameter value
-#   91|               1: [IntLiteral] 9
-#   92|           1: [ThrowStmt] throw ...;
-#   92|             0: [ObjectCreation] object creation of type ArgumentException
-#   92|               0: [TypeMention] ArgumentException
-#   93|         1: [ExprStmt] ...;
-#   93|           0: [AssignExpr] ... = ...
-#   93|             0: [FieldAccess] access to field value
-#   93|               -1: [ThisAccess] this access
-#   93|             1: [ParameterAccess] access to parameter value
-#   96|     8: [ImplicitConversionOperator] implicit conversion
-#   96|       -1: [TypeMention] byte
-#-----|       2: (Parameters)
-#   96|         0: [Parameter] d
-#   96|           -1: [TypeMention] Digit
-#   97|       4: [BlockStmt] {...}
-#   98|         0: [ReturnStmt] return ...;
-#   98|           0: [FieldAccess] access to field value
-#   98|             -1: [ParameterAccess] access to parameter d
-#  101|     9: [ExplicitConversionOperator] explicit conversion
-#  101|       -1: [TypeMention] Digit
-#-----|       2: (Parameters)
-#  101|         0: [Parameter] b
-#  101|           -1: [TypeMention] byte
-#  102|       4: [BlockStmt] {...}
-#  103|         0: [ReturnStmt] return ...;
-#  103|           0: [ObjectCreation] object creation of type Digit
-#  103|             -1: [TypeMention] Digit
-#  103|             0: [ParameterAccess] access to parameter b
-#  108|   4: [Class] TestConversionOperator
-#  111|     6: [Method] Main
-#  111|       -1: [TypeMention] Void
-#  112|       4: [BlockStmt] {...}
-#  113|         0: [LocalVariableDeclStmt] ... ...;
-#  113|           0: [LocalVariableDeclAndInitExpr] Digit d = ...
-#  113|             -1: [TypeMention] Digit
-#  113|             0: [LocalVariableAccess] access to local variable d
-#  113|             1: [OperatorCall] call to operator explicit conversion
-#  113|               -1: [TypeMention] Digit
-#  113|               0: [CastExpr] (...) ...
-#  113|                 1: [IntLiteral] 8
-#  114|         1: [LocalVariableDeclStmt] ... ...;
-#  114|           0: [LocalVariableDeclAndInitExpr] Byte b = ...
-#  114|             -1: [TypeMention] byte
-#  114|             0: [LocalVariableAccess] access to local variable b
-#  114|             1: [OperatorCall] call to operator implicit conversion
-#  114|               0: [LocalVariableAccess] access to local variable d
+#   74|         7: [ExprStmt] ...;
+#   74|           0: [AssignMulExpr] ... *= ...
+#   74|             0: [LocalVariableAccess] access to local variable iv3
+#   74|             1: [LocalVariableAccess] access to local variable iv2
+#   75|         8: [ExprStmt] ...;
+#   75|           0: [AssignDivExpr] ... /= ...
+#   75|             0: [LocalVariableAccess] access to local variable iv3
+#   75|             1: [LocalVariableAccess] access to local variable iv2
+#   76|         9: [ExprStmt] ...;
+#   76|           0: [AssignRemExpr] ... %= ...
+#   76|             0: [LocalVariableAccess] access to local variable iv3
+#   76|             1: [LocalVariableAccess] access to local variable iv2
+#   77|         10: [ExprStmt] ...;
+#   77|           0: [AssignAndExpr] ... &= ...
+#   77|             0: [LocalVariableAccess] access to local variable iv3
+#   77|             1: [LocalVariableAccess] access to local variable iv2
+#   78|         11: [ExprStmt] ...;
+#   78|           0: [AssignOrExpr] ... |= ...
+#   78|             0: [LocalVariableAccess] access to local variable iv3
+#   78|             1: [LocalVariableAccess] access to local variable iv2
+#   79|         12: [ExprStmt] ...;
+#   79|           0: [AssignXorExpr] ... ^= ...
+#   79|             0: [LocalVariableAccess] access to local variable iv3
+#   79|             1: [LocalVariableAccess] access to local variable iv2
+#   80|         13: [ExprStmt] ...;
+#   80|           0: [AssignLeftShiftExpr] ... <<= ...
+#   80|             0: [LocalVariableAccess] access to local variable iv3
+#   80|             1: [LocalVariableAccess] access to local variable iv2
+#   81|         14: [ExprStmt] ...;
+#   81|           0: [AssignRightShiftExpr] ... >>= ...
+#   81|             0: [LocalVariableAccess] access to local variable iv3
+#   81|             1: [LocalVariableAccess] access to local variable iv2
+#   82|         15: [ExprStmt] ...;
+#   82|           0: [AssignUnsignedRightShiftExpr] ... >>>= ...
+#   82|             0: [LocalVariableAccess] access to local variable iv3
+#   82|             1: [LocalVariableAccess] access to local variable iv2
+#   84|         16: [CheckedStmt] checked {...}
+#   85|           0: [BlockStmt] {...}
+#   86|             0: [ExprStmt] ...;
+#   86|               0: [AssignAddExpr] ... += ...
+#   86|                 0: [LocalVariableAccess] access to local variable iv3
+#   86|                 1: [LocalVariableAccess] access to local variable iv2
+#   87|             1: [ExprStmt] ...;
+#   87|               0: [AssignSubExpr] ... -= ...
+#   87|                 0: [LocalVariableAccess] access to local variable iv3
+#   87|                 1: [LocalVariableAccess] access to local variable iv2
+#   88|             2: [ExprStmt] ...;
+#   88|               0: [AssignMulExpr] ... *= ...
+#   88|                 0: [LocalVariableAccess] access to local variable iv3
+#   88|                 1: [LocalVariableAccess] access to local variable iv2
+#   89|             3: [ExprStmt] ...;
+#   89|               0: [AssignDivExpr] ... /= ...
+#   89|                 0: [LocalVariableAccess] access to local variable iv3
+#   89|                 1: [LocalVariableAccess] access to local variable iv2
+#   92|         17: [LocalVariableDeclStmt] ... ...;
+#   92|           0: [LocalVariableDeclAndInitExpr] C c = ...
+#   92|             -1: [TypeMention] C
+#   92|             0: [LocalVariableAccess] access to local variable c
+#   92|             1: [ObjectCreation] object creation of type C
+#   92|               0: [TypeMention] C
+#   93|         18: [ExprStmt] ...;
+#   93|           0: [OperatorCall] call to operator ++=
+#   93|             0: [LocalVariableAccess] access to local variable c
+#   94|         19: [ExprStmt] ...;
+#   94|           0: [OperatorCall] call to operator ++=
+#   94|             0: [LocalVariableAccess] access to local variable c
+#   95|         20: [ExprStmt] ...;
+#   95|           0: [OperatorCall] call to operator --=
+#   95|             0: [LocalVariableAccess] access to local variable c
+#   96|         21: [ExprStmt] ...;
+#   96|           0: [OperatorCall] call to operator --=
+#   96|             0: [LocalVariableAccess] access to local variable c
+#   98|         22: [CheckedStmt] checked {...}
+#   99|           0: [BlockStmt] {...}
+#  100|             0: [ExprStmt] ...;
+#  100|               0: [OperatorCall] call to operator checked ++=
+#  100|                 0: [LocalVariableAccess] access to local variable c
+#  101|             1: [ExprStmt] ...;
+#  101|               0: [OperatorCall] call to operator checked ++=
+#  101|                 0: [LocalVariableAccess] access to local variable c
+#  102|             2: [ExprStmt] ...;
+#  102|               0: [OperatorCall] call to operator checked --=
+#  102|                 0: [LocalVariableAccess] access to local variable c
+#  103|             3: [ExprStmt] ...;
+#  103|               0: [OperatorCall] call to operator checked --=
+#  103|                 0: [LocalVariableAccess] access to local variable c
+#  107|     7: [Struct] Digit
+#  109|       6: [Field] value
+#  109|         -1: [TypeMention] byte
+#  111|       7: [InstanceConstructor] Digit
+#-----|         2: (Parameters)
+#  111|           0: [Parameter] value
+#  111|             -1: [TypeMention] byte
+#  112|         4: [BlockStmt] {...}
+#  113|           0: [IfStmt] if (...) ...
+#  113|             0: [LogicalOrExpr] ... || ...
+#  113|               0: [LTExpr] ... < ...
+#  113|                 0: [CastExpr] (...) ...
+#  113|                   1: [ParameterAccess] access to parameter value
+#  113|                 1: [IntLiteral] 0
+#  113|               1: [GTExpr] ... > ...
+#  113|                 0: [CastExpr] (...) ...
+#  113|                   1: [ParameterAccess] access to parameter value
+#  113|                 1: [IntLiteral] 9
+#  114|             1: [ThrowStmt] throw ...;
+#  114|               0: [ObjectCreation] object creation of type ArgumentException
+#  114|                 0: [TypeMention] ArgumentException
+#  115|           1: [ExprStmt] ...;
+#  115|             0: [AssignExpr] ... = ...
+#  115|               0: [FieldAccess] access to field value
+#  115|                 -1: [ThisAccess] this access
+#  115|               1: [ParameterAccess] access to parameter value
+#  118|       8: [ImplicitConversionOperator] implicit conversion
+#  118|         -1: [TypeMention] byte
+#-----|         2: (Parameters)
+#  118|           0: [Parameter] d
+#  118|             -1: [TypeMention] Digit
+#  119|         4: [BlockStmt] {...}
+#  120|           0: [ReturnStmt] return ...;
+#  120|             0: [FieldAccess] access to field value
+#  120|               -1: [ParameterAccess] access to parameter d
+#  123|       9: [ExplicitConversionOperator] explicit conversion
+#  123|         -1: [TypeMention] Digit
+#-----|         2: (Parameters)
+#  123|           0: [Parameter] b
+#  123|             -1: [TypeMention] byte
+#  124|         4: [BlockStmt] {...}
+#  125|           0: [ReturnStmt] return ...;
+#  125|             0: [ObjectCreation] object creation of type Digit
+#  125|               -1: [TypeMention] Digit
+#  125|               0: [ParameterAccess] access to parameter b
+#  130|     8: [Class] TestConversionOperator
+#  133|       6: [Method] Main
+#  133|         -1: [TypeMention] Void
+#  134|         4: [BlockStmt] {...}
+#  135|           0: [LocalVariableDeclStmt] ... ...;
+#  135|             0: [LocalVariableDeclAndInitExpr] Digit d = ...
+#  135|               -1: [TypeMention] Digit
+#  135|               0: [LocalVariableAccess] access to local variable d
+#  135|               1: [OperatorCall] call to operator explicit conversion
+#  135|                 -1: [TypeMention] Digit
+#  135|                 0: [CastExpr] (...) ...
+#  135|                   1: [IntLiteral] 8
+#  136|           1: [LocalVariableDeclStmt] ... ...;
+#  136|             0: [LocalVariableDeclAndInitExpr] Byte b = ...
+#  136|               -1: [TypeMention] byte
+#  136|               0: [LocalVariableAccess] access to local variable b
+#  136|               1: [OperatorCall] call to operator implicit conversion
+#  136|                 0: [LocalVariableAccess] access to local variable d

--- a/csharp/ql/test/library-tests/operators/PrintAst.expected
+++ b/csharp/ql/test/library-tests/operators/PrintAst.expected
@@ -182,16 +182,16 @@ operators.cs:
 #   48|           -1: [TypeMention] IntVector
 #   48|       4: [BlockStmt] {...}
 #   51|   2: [Class] C
-#   54|     6: [???] checked ++=
+#   54|     6: [CheckedIncrementOperator] checked ++
 #   54|       -1: [TypeMention] Void
 #   54|       4: [BlockStmt] {...}
-#   55|     7: [???] ++=
+#   55|     7: [IncrementOperator] ++
 #   55|       -1: [TypeMention] Void
 #   55|       4: [BlockStmt] {...}
-#   56|     8: [???] checked --=
+#   56|     8: [CheckedDecrementOperator] checked --
 #   56|       -1: [TypeMention] Void
 #   56|       4: [BlockStmt] {...}
-#   57|     9: [???] --=
+#   57|     9: [DecrementOperator] --
 #   57|       -1: [TypeMention] Void
 #   57|       4: [BlockStmt] {...}
 #   60|   3: [Class] TestOperator
@@ -294,30 +294,30 @@ operators.cs:
 #   92|             1: [ObjectCreation] object creation of type C
 #   92|               0: [TypeMention] C
 #   93|         18: [ExprStmt] ...;
-#   93|           0: [OperatorCall] call to operator ++=
+#   93|           0: [OperatorCall] call to operator ++
 #   93|             0: [LocalVariableAccess] access to local variable c
 #   94|         19: [ExprStmt] ...;
-#   94|           0: [OperatorCall] call to operator ++=
+#   94|           0: [OperatorCall] call to operator ++
 #   94|             0: [LocalVariableAccess] access to local variable c
 #   95|         20: [ExprStmt] ...;
-#   95|           0: [OperatorCall] call to operator --=
+#   95|           0: [OperatorCall] call to operator --
 #   95|             0: [LocalVariableAccess] access to local variable c
 #   96|         21: [ExprStmt] ...;
-#   96|           0: [OperatorCall] call to operator --=
+#   96|           0: [OperatorCall] call to operator --
 #   96|             0: [LocalVariableAccess] access to local variable c
 #   98|         22: [CheckedStmt] checked {...}
 #   99|           0: [BlockStmt] {...}
 #  100|             0: [ExprStmt] ...;
-#  100|               0: [OperatorCall] call to operator checked ++=
+#  100|               0: [OperatorCall] call to operator checked ++
 #  100|                 0: [LocalVariableAccess] access to local variable c
 #  101|             1: [ExprStmt] ...;
-#  101|               0: [OperatorCall] call to operator checked ++=
+#  101|               0: [OperatorCall] call to operator checked ++
 #  101|                 0: [LocalVariableAccess] access to local variable c
 #  102|             2: [ExprStmt] ...;
-#  102|               0: [OperatorCall] call to operator checked --=
+#  102|               0: [OperatorCall] call to operator checked --
 #  102|                 0: [LocalVariableAccess] access to local variable c
 #  103|             3: [ExprStmt] ...;
-#  103|               0: [OperatorCall] call to operator checked --=
+#  103|               0: [OperatorCall] call to operator checked --
 #  103|                 0: [LocalVariableAccess] access to local variable c
 #  107|     7: [Struct] Digit
 #  109|       6: [Field] value

--- a/csharp/ql/test/library-tests/operators/operators.cs
+++ b/csharp/ql/test/library-tests/operators/operators.cs
@@ -48,6 +48,15 @@ namespace Operators
         public void operator >>>=(IntVector n) { }
     }
 
+    public class C
+    {
+        // Unary instance operators.
+        public void operator checked ++() { }
+        public void operator ++() { }
+        public void operator checked --() { }
+        public void operator --() { }
+    }
+
     class TestOperator
     {
         void Main()
@@ -79,41 +88,55 @@ namespace Operators
                 iv3 *= iv2;
                 iv3 /= iv2;
             }
+
+            var c = new C();
+            c++;
+            ++c;
+            c--;
+            --c;
+
+            checked
+            {
+                c++;
+                ++c;
+                c--;
+                --c;
+            }
         }
+
+        public struct Digit
+        {
+            byte value;
+
+            public Digit(byte value)
+            {
+                if (value < 0 || value > 9)
+                    throw new ArgumentException();
+                this.value = value;
+            }
+
+            public static implicit operator byte(Digit d)
+            {
+                return d.value;
+            }
+
+            public static explicit operator Digit(byte b)
+            {
+                return new Digit(b);
+            }
+
+        }
+
+        class TestConversionOperator
+        {
+
+            void Main()
+            {
+                Digit d = (Digit)8;
+                byte b = d;
+            }
+
+        }
+
     }
-
-    public struct Digit
-    {
-        byte value;
-
-        public Digit(byte value)
-        {
-            if (value < 0 || value > 9)
-                throw new ArgumentException();
-            this.value = value;
-        }
-
-        public static implicit operator byte(Digit d)
-        {
-            return d.value;
-        }
-
-        public static explicit operator Digit(byte b)
-        {
-            return new Digit(b);
-        }
-
-    }
-
-    class TestConversionOperator
-    {
-
-        void Main()
-        {
-            Digit d = (Digit)8;
-            byte b = d;
-        }
-
-    }
-
 }


### PR DESCRIPTION
In this PR we add support for *user* *defined* *instance* *decrement/increment* operators.

Example:
```csharp
public class C
{
    public int Value { get; private set; }

    public C(int value)
    {
        Value = value;
    }

    public void operator ++()
    {
        Value++;
    }
}
```

Similar to user defined compound assignment operators, the increment/decrement operators manipulates the *instance* they are applied to. This requires changes to the *dispatch* logic for such operator calls.