### PR TITLE
C#, Go, Java: Use all path injection sinks when generating docs

### DIFF
--- a/java/documentation/library-coverage/cwe-sink.csv
+++ b/java/documentation/library-coverage/cwe-sink.csv
@@ -1,6 +1,6 @@
 CWE,Sink identifier,Label
 CWE‑089,sql-injection,SQL injection
-CWE‑022,path-injection,Path injection
+CWE‑022,path-injection path-injection[read],Path injection
 CWE‑094,bean-validation,Code injection
 CWE‑918,request-forgery,Request Forgery
 CWE‑079,html-injection js-injection,Cross-site scripting


### PR DESCRIPTION
This change is needed because of https://github.com/github/codeql/pull/21741. [This auto-generated PR](https://github.com/github/codeql/pull/21822) to update our framework coverage docs was reporting lower numbers, which made me realise it wasn't considering the new `path-injection[read]` sinks as path injection sinks.