### PR TITLE
C#: Unary expression cleanup in the extractor.

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Factory.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Factory.cs
@@ -109,10 +109,10 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
                         return MemberAccess.Create(info, (MemberAccessExpressionSyntax)info.Node);
 
                     case SyntaxKind.UnaryMinusExpression:
-                        return Unary.Create(info.SetKind(ExprKind.MINUS));
+                        return PrefixUnary.Create(info.SetKind(ExprKind.MINUS));
 
                     case SyntaxKind.UnaryPlusExpression:
-                        return Unary.Create(info.SetKind(ExprKind.PLUS));
+                        return PrefixUnary.Create(info.SetKind(ExprKind.PLUS));
 
                     case SyntaxKind.SimpleLambdaExpression:
                         return Lambda.Create(info, (SimpleLambdaExpressionSyntax)info.Node);
@@ -146,16 +146,16 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
                         return Name.Create(info);
 
                     case SyntaxKind.LogicalNotExpression:
-                        return Unary.Create(info.SetKind(ExprKind.LOG_NOT));
+                        return PrefixUnary.Create(info.SetKind(ExprKind.LOG_NOT));
 
                     case SyntaxKind.BitwiseNotExpression:
-                        return Unary.Create(info.SetKind(ExprKind.BIT_NOT));
+                        return PrefixUnary.Create(info.SetKind(ExprKind.BIT_NOT));
 
                     case SyntaxKind.PreIncrementExpression:
-                        return Unary.Create(info.SetKind(ExprKind.PRE_INCR));
+                        return PrefixUnary.Create(info.SetKind(ExprKind.PRE_INCR));
 
                     case SyntaxKind.PreDecrementExpression:
-                        return Unary.Create(info.SetKind(ExprKind.PRE_DECR));
+                        return PrefixUnary.Create(info.SetKind(ExprKind.PRE_DECR));
 
                     case SyntaxKind.ThisExpression:
                         return This.CreateExplicit(info);
@@ -164,10 +164,10 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
                         return PropertyFieldAccess.Create(info);
 
                     case SyntaxKind.AddressOfExpression:
-                        return Unary.Create(info.SetKind(ExprKind.ADDRESS_OF));
+                        return PrefixUnary.Create(info.SetKind(ExprKind.ADDRESS_OF));
 
                     case SyntaxKind.PointerIndirectionExpression:
-                        return Unary.Create(info.SetKind(ExprKind.POINTER_INDIRECTION));
+                        return PrefixUnary.Create(info.SetKind(ExprKind.POINTER_INDIRECTION));
 
                     case SyntaxKind.DefaultExpression:
                         return Default.Create(info);
@@ -248,7 +248,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
                         return RangeExpression.Create(info);
 
                     case SyntaxKind.IndexExpression:
-                        return Unary.Create(info.SetKind(ExprKind.INDEX));
+                        return PrefixUnary.Create(info.SetKind(ExprKind.INDEX));
 
                     case SyntaxKind.SwitchExpression:
                         return Switch.Create(info);

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Factory.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Factory.cs
@@ -58,10 +58,10 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
                         return Invocation.Create(info);
 
                     case SyntaxKind.PostIncrementExpression:
-                        return PostfixUnary.Create(info.SetKind(ExprKind.POST_INCR), ((PostfixUnaryExpressionSyntax)info.Node).Operand);
+                        return PostfixUnary.Create(info.SetKind(ExprKind.POST_INCR));
 
                     case SyntaxKind.PostDecrementExpression:
-                        return PostfixUnary.Create(info.SetKind(ExprKind.POST_DECR), ((PostfixUnaryExpressionSyntax)info.Node).Operand);
+                        return PostfixUnary.Create(info.SetKind(ExprKind.POST_DECR));
 
                     case SyntaxKind.AwaitExpression:
                         return Await.Create(info);
@@ -254,7 +254,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
                         return Switch.Create(info);
 
                     case SyntaxKind.SuppressNullableWarningExpression:
-                        return PostfixUnary.Create(info.SetKind(ExprKind.SUPPRESS_NULLABLE_WARNING), ((PostfixUnaryExpressionSyntax)info.Node).Operand);
+                        return PostfixUnary.Create(info.SetKind(ExprKind.SUPPRESS_NULLABLE_WARNING));
 
                     case SyntaxKind.WithExpression:
                         return WithExpression.Create(info);

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/PostfixUnary.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/PostfixUnary.cs
@@ -4,23 +4,21 @@ using Semmle.Extraction.Kinds;
 
 namespace Semmle.Extraction.CSharp.Entities.Expressions
 {
-    internal class PostfixUnary : Expression<ExpressionSyntax>
+    internal class PostfixUnary : Expression<PostfixUnaryExpressionSyntax>
     {
-        private PostfixUnary(ExpressionNodeInfo info, ExprKind kind, ExpressionSyntax operand)
+        private PostfixUnary(ExpressionNodeInfo info, ExprKind kind)
             : base(info.SetKind(UnaryOperatorKind(info.Context, kind, info.Node)))
         {
-            this.operand = operand;
             operatorKind = kind;
         }
 
-        private readonly ExpressionSyntax operand;
         private readonly ExprKind operatorKind;
 
-        public static Expression Create(ExpressionNodeInfo info, ExpressionSyntax operand) => new PostfixUnary(info, info.Kind, operand).TryPopulate();
+        public static Expression Create(ExpressionNodeInfo info) => new PostfixUnary(info, info.Kind).TryPopulate();
 
         protected override void PopulateExpression(TextWriter trapFile)
         {
-            Create(Context, operand, this, 0);
+            Create(Context, Syntax.Operand, this, 0);
 
             if (Kind == ExprKind.OPERATOR_INVOCATION)
             {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/PostfixUnary.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/PostfixUnary.cs
@@ -22,11 +22,14 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
         {
             Create(Context, operand, this, 0);
 
-            if ((operatorKind == ExprKind.POST_INCR || operatorKind == ExprKind.POST_DECR) &&
-                Kind == ExprKind.OPERATOR_INVOCATION)
+            if (Kind == ExprKind.OPERATOR_INVOCATION)
             {
                 AddOperatorCall(trapFile, Syntax);
-                trapFile.mutator_invocation_mode(this, 2);
+
+                if (operatorKind == ExprKind.POST_INCR || operatorKind == ExprKind.POST_DECR)
+                {
+                    trapFile.mutator_invocation_mode(this, 2);
+                }
             }
         }
     }

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/PrefixUnary.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/PrefixUnary.cs
@@ -4,9 +4,9 @@ using Semmle.Extraction.Kinds;
 
 namespace Semmle.Extraction.CSharp.Entities.Expressions
 {
-    internal class Unary : Expression<PrefixUnaryExpressionSyntax>
+    internal class PrefixUnary : Expression<PrefixUnaryExpressionSyntax>
     {
-        private Unary(ExpressionNodeInfo info, ExprKind kind)
+        private PrefixUnary(ExpressionNodeInfo info, ExprKind kind)
             : base(info.SetKind(UnaryOperatorKind(info.Context, info.Kind, info.Node)))
         {
             operatorKind = kind;
@@ -14,9 +14,9 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
 
         private readonly ExprKind operatorKind;
 
-        public static Unary Create(ExpressionNodeInfo info)
+        public static PrefixUnary Create(ExpressionNodeInfo info)
         {
-            var ret = new Unary(info, info.Kind);
+            var ret = new PrefixUnary(info, info.Kind);
             ret.TryPopulate();
             return ret;
         }

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/PrefixUnary.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/PrefixUnary.cs
@@ -14,12 +14,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
 
         private readonly ExprKind operatorKind;
 
-        public static PrefixUnary Create(ExpressionNodeInfo info)
-        {
-            var ret = new PrefixUnary(info, info.Kind);
-            ret.TryPopulate();
-            return ret;
-        }
+        public static Expression Create(ExpressionNodeInfo info) => new PrefixUnary(info, info.Kind).TryPopulate();
 
         protected override void PopulateExpression(TextWriter trapFile)
         {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Unary.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Unary.cs
@@ -24,12 +24,15 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
         protected override void PopulateExpression(TextWriter trapFile)
         {
             Create(Context, Syntax.Operand, this, 0);
-            AddOperatorCall(trapFile, Syntax);
 
-            if ((operatorKind == ExprKind.PRE_INCR || operatorKind == ExprKind.PRE_DECR) &&
-                Kind == ExprKind.OPERATOR_INVOCATION)
+            if (Kind == ExprKind.OPERATOR_INVOCATION)
             {
-                trapFile.mutator_invocation_mode(this, 1);
+                AddOperatorCall(trapFile, Syntax);
+
+                if (operatorKind == ExprKind.PRE_INCR || operatorKind == ExprKind.PRE_DECR)
+                {
+                    trapFile.mutator_invocation_mode(this, 1);
+                }
             }
         }
     }


### PR DESCRIPTION
In this PR we
- Only extract operator calls in prefix unary expressions when they are needed.
- Re-factor and simplify the implementation of Pre-and Postfix unary expressions in the extractor.

DCA
- Performance looks good.
- It appears that a false positive is introduced for `cs/invalid-dynamic-call`. However, in https://github.com/github/codeql/pull/21839 we saw that a similar result was removed. I suspect this is due to wobliness.