### PR TITLE
C++: Model secure versions of `scanf` as flow sources

### DIFF
--- a/cpp/ql/lib/change-notes/2026-05-15-secure-scanf.md
+++ b/cpp/ql/lib/change-notes/2026-05-15-secure-scanf.md
@@ -1,0 +1,5 @@
+---
+category: minorAnalysis
+---
+* Added flow source models for `scanf_s` and related functions.
+* Added a `Call` column to `LocalFlowSourceFunction::hasLocalFlowSource` and `RemoteFlowSourceFunction::hasRemoteFlowSource`. The old predicates without a `Call` column continue to be supported.

--- a/cpp/ql/lib/semmle/code/cpp/commons/Scanf.qll
+++ b/cpp/ql/lib/semmle/code/cpp/commons/Scanf.qll
@@ -44,8 +44,11 @@ class Scanf extends ScanfFunction instanceof TopLevelFunction {
     this.hasGlobalOrStdOrBslName("scanf") or // scanf(format, args...)
     this.hasGlobalOrStdOrBslName("wscanf") or // wscanf(format, args...)
     this.hasGlobalOrStdOrBslName("scanf_s") or // scanf_s(format, args...)
+    this.hasGlobalOrStdOrBslName("wscanf_s") or // wscanf_s(format, args...)
     this.hasGlobalName("_scanf_l") or // _scanf_l(format, locale, args...)
-    this.hasGlobalName("_wscanf_l")
+    this.hasGlobalName("_wscanf_l") or // _wscanf_l(format, locale, args...)
+    this.hasGlobalName("_scanf_s_l") or // _scanf_s_l(format, locale, args...)
+    this.hasGlobalName("_wscanf_s_l") // _wscanf_s_l(format, locale, args...)
   }
 
   override int getInputParameterIndex() { none() }

--- a/cpp/ql/lib/semmle/code/cpp/commons/Scanf.qll
+++ b/cpp/ql/lib/semmle/code/cpp/commons/Scanf.qll
@@ -64,8 +64,11 @@ class Fscanf extends ScanfFunction instanceof TopLevelFunction {
     this.hasGlobalOrStdOrBslName("fscanf") or // fscanf(src_stream, format, args...)
     this.hasGlobalOrStdOrBslName("fwscanf") or // fwscanf(src_stream, format, args...)
     this.hasGlobalOrStdOrBslName("fscanf_s") or // fscanf_s(src_stream, format, args...)
+    this.hasGlobalOrStdOrBslName("fwscanf_s") or // fwscanf_s(src_stream, format, args...)
     this.hasGlobalName("_fscanf_l") or // _fscanf_l(src_stream, format, locale, args...)
-    this.hasGlobalName("_fwscanf_l")
+    this.hasGlobalName("_fwscanf_l") or // _fwscanf_l(src_stream, format, locale, args...)
+    this.hasGlobalName("_fscanf_s_l") or // _fscanf_s_l(src_stream, format, locale, args...)
+    this.hasGlobalName("_fwscanf_s_l") // _fwscanf_s_l(src_stream, format, locale, args...)
   }
 
   override int getInputParameterIndex() { result = 0 }

--- a/cpp/ql/lib/semmle/code/cpp/commons/Scanf.qll
+++ b/cpp/ql/lib/semmle/code/cpp/commons/Scanf.qll
@@ -34,6 +34,7 @@ class Scanf extends ScanfFunction instanceof TopLevelFunction {
   Scanf() {
     this.hasGlobalOrStdOrBslName("scanf") or // scanf(format, args...)
     this.hasGlobalOrStdOrBslName("wscanf") or // wscanf(format, args...)
+    this.hasGlobalOrStdOrBslName("scanf_s") or // scanf_s(format, args...)
     this.hasGlobalName("_scanf_l") or // _scanf_l(format, locale, args...)
     this.hasGlobalName("_wscanf_l")
   }
@@ -50,6 +51,7 @@ class Fscanf extends ScanfFunction instanceof TopLevelFunction {
   Fscanf() {
     this.hasGlobalOrStdOrBslName("fscanf") or // fscanf(src_stream, format, args...)
     this.hasGlobalOrStdOrBslName("fwscanf") or // fwscanf(src_stream, format, args...)
+    this.hasGlobalOrStdOrBslName("fscanf_s") or // fscanf_s(src_stream, format, args...)
     this.hasGlobalName("_fscanf_l") or // _fscanf_l(src_stream, format, locale, args...)
     this.hasGlobalName("_fwscanf_l")
   }
@@ -66,8 +68,12 @@ class Sscanf extends ScanfFunction instanceof TopLevelFunction {
   Sscanf() {
     this.hasGlobalOrStdOrBslName("sscanf") or // sscanf(src_stream, format, args...)
     this.hasGlobalOrStdOrBslName("swscanf") or // swscanf(src, format, args...)
+    this.hasGlobalOrStdOrBslName("sscanf_s") or // sscanf_s(src, format, args...)
+    this.hasGlobalOrStdOrBslName("swscanf_s") or // swscanf_s(src, format, args...)
     this.hasGlobalName("_sscanf_l") or // _sscanf_l(src, format, locale, args...)
-    this.hasGlobalName("_swscanf_l")
+    this.hasGlobalName("_swscanf_l") or // _swscanf_l(src, format, locale, args...)
+    this.hasGlobalName("_sscanf_s_l") or // _sscanf_s_l(src, format, locale, args...)
+    this.hasGlobalName("_swscanf_s_l") // _swscanf_s_l(src, format, locale, args...)
   }
 
   override int getInputParameterIndex() { result = 0 }

--- a/cpp/ql/lib/semmle/code/cpp/commons/Scanf.qll
+++ b/cpp/ql/lib/semmle/code/cpp/commons/Scanf.qll
@@ -25,6 +25,15 @@ abstract class ScanfFunction extends Function {
    * (rather than a `char*`).
    */
   predicate isWideCharDefault() { exists(this.getName().indexOf("wscanf")) }
+
+  /** Holds if this is one of the `scanf_s` variants. */
+  predicate isSVariant() {
+    exists(string name | name = this.getName() |
+      name.matches("%\\_s")
+      or
+      name.matches("%\\_s\\_l")
+    )
+  }
 }
 
 /**
@@ -103,6 +112,14 @@ class Snscanf extends ScanfFunction instanceof TopLevelFunction {
   int getInputLengthParameterIndex() { result = 1 }
 }
 
+private predicate isCharLike(Type t) { t instanceof CharType or t instanceof Wchar_t }
+
+private predicate isStringLike(Type t) {
+  isCharLike(t.(PointerType).getBaseType())
+  or
+  isCharLike(t.(ArrayType).getBaseType())
+}
+
 /**
  * A call to one of the `scanf` functions.
  */
@@ -136,14 +153,40 @@ class ScanfFunctionCall extends FunctionCall {
    */
   predicate isWideCharDefault() { this.getScanfFunction().isWideCharDefault() }
 
+  bindingset[this, k]
+  pragma[inline_late]
+  private predicate isSizeArgument(int k) {
+    // The first vararg is never the size argument since a size argument must
+    // always follow a string buffer argument.
+    k > 0 and
+    isStringLike(this.getArgument(this.getScanfFunction().getNumberOfParameters() + k - 1)
+          .getUnspecifiedType())
+  }
+
   /**
    * Gets the output argument at position `n` in the vararg list of this call.
    *
    * The range of `n` is from `0` to `this.getNumberOfOutputArguments() - 1`.
    */
   Expr getOutputArgument(int n) {
-    result = this.getArgument(this.getTarget().getNumberOfParameters() + n) and
-    n >= 0
+    exists(ScanfFunction target | target = this.getScanfFunction() |
+      // If this is an S variant then every string buffer argument has a
+      // corresponding size argument immediately following it, so we need to
+      // skip over those size arguments when counting the output arguments.
+      if target.isSVariant()
+      then
+        result =
+          rank[n + 1](Expr arg, int k |
+            k >= 0 and
+            arg = this.getArgument(target.getNumberOfParameters() + k) and
+            not this.isSizeArgument(k)
+          |
+            arg order by k
+          )
+      else (
+        n >= 0 and result = this.getArgument(target.getNumberOfParameters() + n)
+      )
+    )
   }
 
   /**

--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/Scanf.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/Scanf.qll
@@ -30,7 +30,10 @@ abstract private class ScanfFunctionModel extends ArrayFunction, TaintFunction, 
     (
       if exists(this.getLengthParameterIndex())
       then result = this.getLengthParameterIndex() + 2
-      else result = 2
+      else
+        if exists(this.(ScanfFunction).getInputParameterIndex())
+        then result = 2
+        else result = 1
     )
   }
 

--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/Scanf.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/Scanf.qll
@@ -69,13 +69,24 @@ abstract private class ScanfFunctionModel extends ArrayFunction, TaintFunction, 
   }
 }
 
+private predicate hasFlowSource(
+  ScanfFunction func, ScanfFunctionCall call, FunctionOutput output, string description
+) {
+  exists(int n, Expr arg |
+    call.getScanfFunction() = func and
+    call.getOutputArgument(_) = arg and
+    call.getArgument(n) = arg and
+    output.isParameterDeref(n) and
+    description = "value read by " + func.getName()
+  )
+}
+
 /**
  * The standard function `scanf` and its assorted variants
  */
 private class ScanfModel extends ScanfFunctionModel, LocalFlowSourceFunction instanceof Scanf {
-  override predicate hasLocalFlowSource(FunctionOutput output, string description) {
-    output.isParameterDeref(any(int i | i >= this.getArgsStartPosition())) and
-    description = "value read by " + this.getName()
+  override predicate hasLocalFlowSource(Call call, FunctionOutput output, string description) {
+    hasFlowSource(this, call, output, description)
   }
 }
 
@@ -83,9 +94,8 @@ private class ScanfModel extends ScanfFunctionModel, LocalFlowSourceFunction ins
  * The standard function `fscanf` and its assorted variants
  */
 private class FscanfModel extends ScanfFunctionModel, RemoteFlowSourceFunction instanceof Fscanf {
-  override predicate hasRemoteFlowSource(FunctionOutput output, string description) {
-    output.isParameterDeref(any(int i | i >= this.getArgsStartPosition())) and
-    description = "value read by " + this.getName()
+  override predicate hasRemoteFlowSource(Call call, FunctionOutput output, string description) {
+    hasFlowSource(this, call, output, description)
   }
 
   override predicate hasSocketInput(FunctionInput input) {

--- a/cpp/ql/lib/semmle/code/cpp/models/interfaces/FlowSource.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/interfaces/FlowSource.qll
@@ -18,7 +18,17 @@ abstract class RemoteFlowSourceFunction extends Function {
   /**
    * Holds if remote data described by `description` flows from `output` of a call to this function.
    */
-  abstract predicate hasRemoteFlowSource(FunctionOutput output, string description);
+  predicate hasRemoteFlowSource(FunctionOutput output, string description) {
+    this.hasRemoteFlowSource(_, output, description)
+  }
+
+  /**
+   * Holds if remote data described by `description` flows from `output` of `call` to this function.
+   */
+  predicate hasRemoteFlowSource(Call call, FunctionOutput output, string description) {
+    call.getTarget() = this and
+    this.hasRemoteFlowSource(output, description)
+  }
 
   /**
    * Holds if remote data from this source comes from a socket or stream
@@ -35,7 +45,17 @@ abstract class LocalFlowSourceFunction extends Function {
   /**
    * Holds if data described by `description` flows from `output` of a call to this function.
    */
-  abstract predicate hasLocalFlowSource(FunctionOutput output, string description);
+  predicate hasLocalFlowSource(FunctionOutput output, string description) {
+    this.hasLocalFlowSource(_, output, description)
+  }
+
+  /**
+   * Holds if data described by `description` flows from `output` of `call` to this function.
+   */
+  predicate hasLocalFlowSource(Call call, FunctionOutput output, string description) {
+    call.getTarget() = this and
+    this.hasLocalFlowSource(output, description)
+  }
 }
 
 /** A library function that sends data over a network connection. */

--- a/cpp/ql/lib/semmle/code/cpp/security/FlowSources.qll
+++ b/cpp/ql/lib/semmle/code/cpp/security/FlowSources.qll
@@ -28,8 +28,7 @@ private class RemoteModelSource extends RemoteFlowSource {
 
   RemoteModelSource() {
     exists(CallInstruction call, RemoteFlowSourceFunction func, FunctionOutput output |
-      call.getStaticCallTarget() = func and
-      func.hasRemoteFlowSource(output, sourceType) and
+      func.hasRemoteFlowSource(call.getConvertedResultExpression(), output, sourceType) and
       this = callOutput(call, output)
     )
   }
@@ -46,7 +45,7 @@ private class LocalModelSource extends LocalFlowSource {
   LocalModelSource() {
     exists(CallInstruction call, LocalFlowSourceFunction func, FunctionOutput output |
       call.getStaticCallTarget() = func and
-      func.hasLocalFlowSource(output, sourceType) and
+      func.hasLocalFlowSource(call.getConvertedResultExpression(), output, sourceType) and
       this = callOutput(call, output)
     )
   }

--- a/cpp/ql/src/Security/CWE/CWE-020/ExternalAPIsSpecific.qll
+++ b/cpp/ql/src/Security/CWE/CWE-020/ExternalAPIsSpecific.qll
@@ -44,10 +44,7 @@ class ExternalApiDataNode extends DataFlow::Node {
 /** A configuration for tracking flow from `RemoteFlowSource`s to `ExternalApiDataNode`s. */
 private module UntrustedDataToExternalApiConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) {
-    exists(RemoteFlowSourceFunction remoteFlow |
-      remoteFlow = source.asExpr().(Call).getTarget() and
-      remoteFlow.hasRemoteFlowSource(_, _)
-    )
+    any(RemoteFlowSourceFunction remoteFlow).hasRemoteFlowSource(source.asExpr(), _, _)
   }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof ExternalApiDataNode }

--- a/cpp/ql/src/Security/CWE/CWE-311/CleartextTransmission.ql
+++ b/cpp/ql/src/Security/CWE/CWE-311/CleartextTransmission.ql
@@ -94,9 +94,8 @@ class Recv extends SendRecv instanceof RemoteFlowSourceFunction {
   }
 
   override Expr getDataExpr(Call call) {
-    call.getTarget() = this and
     exists(FunctionOutput output, int arg |
-      super.hasRemoteFlowSource(output, _) and
+      super.hasRemoteFlowSource(call, output, _) and
       output.isParameterDeref(arg) and
       result = call.getArgument(arg)
     )

--- a/cpp/ql/test/library-tests/dataflow/source-sink-tests/sources-and-sinks.cpp
+++ b/cpp/ql/test/library-tests/dataflow/source-sink-tests/sources-and-sinks.cpp
@@ -140,32 +140,32 @@ void test_scanf_s(FILE *stream) {
   int n1, n2;
   scanf_s(
     "%d",
-    &n1, // $ MISSING: local_source
-    &n2); // $ MISSING: local_source
+    &n1, // $ local_source
+    &n2); // $ local_source
   }
 
   {
   int n;
-  fscanf_s(stream, "%d", &n); // $ MISSING: remote_source
+  fscanf_s(stream, "%d", &n); // $ remote_source
   }
 
   {
   int n1, n2;
   char buf[256];
   scanf_s("%d %s",
-    &n1, // $ MISSING: local_source
-    buf, // $ MISSING: local_source
+    &n1, // $ local_source
+    buf, // $ local_source
     256,
-    &n2); // $ MISSING: local_source
+    &n2); // $ local_source
   }
 
   {
   int n1, n2;
   char buf[256];
   fscanf_s(stream, "%d %s",
-    &n1, // $ MISSING: remote_source
-    buf, // $ MISSING: remote_source
+    &n1, // $ remote_source
+    buf, // $ remote_source
     256,
-    &n2); // $ MISSING: remote_source
+    &n2); // $ remote_source
   }
 }

--- a/cpp/ql/test/library-tests/dataflow/source-sink-tests/sources-and-sinks.cpp
+++ b/cpp/ql/test/library-tests/dataflow/source-sink-tests/sources-and-sinks.cpp
@@ -169,3 +169,41 @@ void test_scanf_s(FILE *stream) {
     &n2); // $ remote_source
   }
 }
+
+typedef void *locale_t;
+
+int wscanf_s(const wchar_t *format, ...);
+int _scanf_s_l(const char *format, locale_t locale, ...);
+int _wscanf_s_l(const wchar_t *format, locale_t locale, ...);
+
+void test_additional_scanf_s_variants(locale_t locale) {
+  {
+  int n1, n2;
+  wchar_t buf[256];
+  wscanf_s(L"%d %s %d",
+    &n1, // $ local_source
+    buf, // $ local_source
+    256,
+    &n2); // $ local_source
+  }
+
+  {
+  int n1, n2;
+  char buf[256];
+  _scanf_s_l("%d %s %d", locale,
+    &n1, // $ local_source
+    buf, // $ local_source
+    256,
+    &n2); // $ local_source
+  }
+
+  {
+  int n1, n2;
+  wchar_t buf[256];
+  _wscanf_s_l(L"%d %s %d", locale,
+    &n1, // $ local_source
+    buf, // $ local_source
+    256,
+    &n2); // $ local_source
+  }
+}

--- a/cpp/ql/test/library-tests/dataflow/source-sink-tests/sources-and-sinks.cpp
+++ b/cpp/ql/test/library-tests/dataflow/source-sink-tests/sources-and-sinks.cpp
@@ -139,7 +139,7 @@ void test_scanf_s(FILE *stream) {
   {
   int n1, n2;
   scanf_s(
-    "%d",
+    "%d %d",
     &n1, // $ local_source
     &n2); // $ local_source
   }
@@ -152,7 +152,7 @@ void test_scanf_s(FILE *stream) {
   {
   int n1, n2;
   char buf[256];
-  scanf_s("%d %s",
+  scanf_s("%d %s %d",
     &n1, // $ local_source
     buf, // $ local_source
     256,
@@ -162,7 +162,7 @@ void test_scanf_s(FILE *stream) {
   {
   int n1, n2;
   char buf[256];
-  fscanf_s(stream, "%d %s",
+  fscanf_s(stream, "%d %s %d",
     &n1, // $ remote_source
     buf, // $ remote_source
     256,

--- a/cpp/ql/test/library-tests/dataflow/source-sink-tests/sources-and-sinks.cpp
+++ b/cpp/ql/test/library-tests/dataflow/source-sink-tests/sources-and-sinks.cpp
@@ -131,3 +131,41 @@ void test_strsafe_gets() {
 		StringCchGetsExA(dest, sizeof(dest), &end, &remaining, 0); // $ local_source
 	}
 }
+
+int scanf_s(const char *format, ...);
+int fscanf_s(FILE *stream, const char *format, ...);
+
+void test_scanf_s(FILE *stream) {
+  {
+  int n1, n2;
+  scanf_s(
+    "%d",
+    &n1, // $ MISSING: local_source
+    &n2); // $ MISSING: local_source
+  }
+
+  {
+  int n;
+  fscanf_s(stream, "%d", &n); // $ MISSING: remote_source
+  }
+
+  {
+  int n1, n2;
+  char buf[256];
+  scanf_s("%d %s",
+    &n1, // $ MISSING: local_source
+    buf, // $ MISSING: local_source
+    256,
+    &n2); // $ MISSING: local_source
+  }
+
+  {
+  int n1, n2;
+  char buf[256];
+  fscanf_s(stream, "%d %s",
+    &n1, // $ MISSING: remote_source
+    buf, // $ MISSING: remote_source
+    256,
+    &n2); // $ MISSING: remote_source
+  }
+}

--- a/cpp/ql/test/library-tests/dataflow/source-sink-tests/sources-and-sinks.cpp
+++ b/cpp/ql/test/library-tests/dataflow/source-sink-tests/sources-and-sinks.cpp
@@ -175,8 +175,11 @@ typedef void *locale_t;
 int wscanf_s(const wchar_t *format, ...);
 int _scanf_s_l(const char *format, locale_t locale, ...);
 int _wscanf_s_l(const wchar_t *format, locale_t locale, ...);
+int fwscanf_s(FILE *stream, const wchar_t *format, ...);
+int _fscanf_s_l(FILE *stream, const char *format, locale_t locale, ...);
+int _fwscanf_s_l(FILE *stream, const wchar_t *format, locale_t locale, ...);
 
-void test_additional_scanf_s_variants(locale_t locale) {
+void test_additional_scanf_s_variants(FILE *stream, locale_t locale) {
   {
   int n1, n2;
   wchar_t buf[256];
@@ -205,5 +208,35 @@ void test_additional_scanf_s_variants(locale_t locale) {
     buf, // $ local_source
     256,
     &n2); // $ local_source
+  }
+
+  {
+  int n1, n2;
+  wchar_t buf[256];
+  fwscanf_s(stream, L"%d %s %d",
+    &n1, // $ remote_source
+    buf, // $ remote_source
+    256,
+    &n2); // $ remote_source
+  }
+
+  {
+  int n1, n2;
+  char buf[256];
+  _fscanf_s_l(stream, "%d %s %d", locale,
+    &n1, // $ remote_source
+    buf, // $ remote_source
+    256,
+    &n2); // $ remote_source
+  }
+
+  {
+  int n1, n2;
+  wchar_t buf[256];
+  _fwscanf_s_l(stream, L"%d %s %d", locale,
+    &n1, // $ remote_source
+    buf, // $ remote_source
+    256,
+    &n2); // $ remote_source
   }
 }

--- a/cpp/ql/test/library-tests/scanf/scanfFormatLiteral.expected
+++ b/cpp/ql/test/library-tests/scanf/scanfFormatLiteral.expected
@@ -3,3 +3,6 @@
 | test.c:20:2:20:7 | call to fscanf | 1 | i | 0 | 0 |
 | test.c:21:2:21:7 | call to sscanf | 0 | s | 0 | 0 |
 | test.c:22:2:22:8 | call to swscanf | 0 | s | 10 | 10 |
+| test.c:23:2:23:8 | call to scanf_s | 0 | d | 0 | 0 |
+| test.c:23:2:23:8 | call to scanf_s | 1 | s | 0 | 0 |
+| test.c:23:2:23:8 | call to scanf_s | 2 | d | 0 | 0 |

--- a/cpp/ql/test/library-tests/scanf/scanfFormatLiteral.expected
+++ b/cpp/ql/test/library-tests/scanf/scanfFormatLiteral.expected
@@ -1,5 +1,5 @@
-| test.c:18:2:18:6 | call to scanf | 0 | s | 0 | 0 |
-| test.c:19:2:19:7 | call to fscanf | 0 | s | 10 | 10 |
-| test.c:19:2:19:7 | call to fscanf | 1 | i | 0 | 0 |
-| test.c:20:2:20:7 | call to sscanf | 0 | s | 0 | 0 |
-| test.c:21:2:21:8 | call to swscanf | 0 | s | 10 | 10 |
+| test.c:19:2:19:6 | call to scanf | 0 | s | 0 | 0 |
+| test.c:20:2:20:7 | call to fscanf | 0 | s | 10 | 10 |
+| test.c:20:2:20:7 | call to fscanf | 1 | i | 0 | 0 |
+| test.c:21:2:21:7 | call to sscanf | 0 | s | 0 | 0 |
+| test.c:22:2:22:8 | call to swscanf | 0 | s | 10 | 10 |

--- a/cpp/ql/test/library-tests/scanf/scanfFunctionCall.expected
+++ b/cpp/ql/test/library-tests/scanf/scanfFunctionCall.expected
@@ -1,5 +1,5 @@
 | ms.cpp:17:3:17:8 | call to sscanf | 0 | 1 | ms.cpp:17:24:17:30 | %I64i | non-wide |
-| test.c:18:2:18:6 | call to scanf | 0 | 0 | test.c:18:8:18:11 | %s | non-wide |
-| test.c:19:2:19:7 | call to fscanf | 0 | 1 | test.c:19:15:19:23 | %10s %i | non-wide |
-| test.c:20:2:20:7 | call to sscanf | 0 | 1 | test.c:20:19:20:28 | %*i%s%*s | non-wide |
-| test.c:21:2:21:8 | call to swscanf | 0 | 1 | test.c:21:21:21:26 | %10s | wide |
+| test.c:19:2:19:6 | call to scanf | 0 | 0 | test.c:19:8:19:11 | %s | non-wide |
+| test.c:20:2:20:7 | call to fscanf | 0 | 1 | test.c:20:15:20:23 | %10s %i | non-wide |
+| test.c:21:2:21:7 | call to sscanf | 0 | 1 | test.c:21:19:21:28 | %*i%s%*s | non-wide |
+| test.c:22:2:22:8 | call to swscanf | 0 | 1 | test.c:22:21:22:26 | %10s | wide |

--- a/cpp/ql/test/library-tests/scanf/scanfFunctionCall.expected
+++ b/cpp/ql/test/library-tests/scanf/scanfFunctionCall.expected
@@ -3,3 +3,4 @@
 | test.c:20:2:20:7 | call to fscanf | 0 | 1 | test.c:20:15:20:23 | %10s %i | non-wide |
 | test.c:21:2:21:7 | call to sscanf | 0 | 1 | test.c:21:19:21:28 | %*i%s%*s | non-wide |
 | test.c:22:2:22:8 | call to swscanf | 0 | 1 | test.c:22:21:22:26 | %10s | wide |
+| test.c:23:2:23:8 | call to scanf_s | 0 | 0 | test.c:23:10:23:19 | %d %s %d | non-wide |

--- a/cpp/ql/test/library-tests/scanf/scanfFunctionCallOutput.expected
+++ b/cpp/ql/test/library-tests/scanf/scanfFunctionCallOutput.expected
@@ -4,3 +4,7 @@
 | test.c:20:2:20:7 | call to fscanf | test.c:20:34:20:34 | i | 1 |
 | test.c:21:2:21:7 | call to sscanf | test.c:21:31:21:36 | buffer | 0 |
 | test.c:22:2:22:8 | call to swscanf | test.c:22:29:22:35 | wbuffer | 0 |
+| test.c:23:2:23:8 | call to scanf_s | test.c:23:22:23:23 | & ... | 0 |
+| test.c:23:2:23:8 | call to scanf_s | test.c:23:26:23:31 | buffer | 1 |
+| test.c:23:2:23:8 | call to scanf_s | test.c:23:34:23:35 | 10 | 2 |
+| test.c:23:2:23:8 | call to scanf_s | test.c:23:38:23:40 | & ... | 3 |

--- a/cpp/ql/test/library-tests/scanf/scanfFunctionCallOutput.expected
+++ b/cpp/ql/test/library-tests/scanf/scanfFunctionCallOutput.expected
@@ -1,0 +1,6 @@
+| ms.cpp:17:3:17:8 | call to sscanf | ms.cpp:17:33:17:36 | & ... | 0 |
+| test.c:19:2:19:6 | call to scanf | test.c:19:14:19:19 | buffer | 0 |
+| test.c:20:2:20:7 | call to fscanf | test.c:20:26:20:31 | buffer | 0 |
+| test.c:20:2:20:7 | call to fscanf | test.c:20:34:20:34 | i | 1 |
+| test.c:21:2:21:7 | call to sscanf | test.c:21:31:21:36 | buffer | 0 |
+| test.c:22:2:22:8 | call to swscanf | test.c:22:29:22:35 | wbuffer | 0 |

--- a/cpp/ql/test/library-tests/scanf/scanfFunctionCallOutput.expected
+++ b/cpp/ql/test/library-tests/scanf/scanfFunctionCallOutput.expected
@@ -6,5 +6,4 @@
 | test.c:22:2:22:8 | call to swscanf | test.c:22:29:22:35 | wbuffer | 0 |
 | test.c:23:2:23:8 | call to scanf_s | test.c:23:22:23:23 | & ... | 0 |
 | test.c:23:2:23:8 | call to scanf_s | test.c:23:26:23:31 | buffer | 1 |
-| test.c:23:2:23:8 | call to scanf_s | test.c:23:34:23:35 | 10 | 2 |
-| test.c:23:2:23:8 | call to scanf_s | test.c:23:38:23:40 | & ... | 3 |
+| test.c:23:2:23:8 | call to scanf_s | test.c:23:38:23:40 | & ... | 2 |

--- a/cpp/ql/test/library-tests/scanf/scanfFunctionCallOutput.ql
+++ b/cpp/ql/test/library-tests/scanf/scanfFunctionCallOutput.ql
@@ -1,0 +1,5 @@
+import semmle.code.cpp.commons.Scanf
+
+from ScanfFunctionCall sfc, Expr e, int n
+where e = sfc.getOutputArgument(n)
+select sfc, e, n

--- a/cpp/ql/test/library-tests/scanf/test.c
+++ b/cpp/ql/test/library-tests/scanf/test.c
@@ -7,18 +7,20 @@ int scanf(const char *format, ...);
 int fscanf(FILE *stream, const char *format, ...);
 int sscanf(const char *s, const char *format, ...);
 int swscanf(const wchar_t* ws, const wchar_t* format, ...);
+int scanf_s(const char *format, ...);
 
 int main(int argc, char *argv[])
 {
 	char buffer[256];
 	wchar_t wbuffer[256];
 	FILE *file;
-	int i;
+	int i, i2;
 
 	scanf("%s", buffer);
 	fscanf(file, "%10s %i", buffer, i);
 	sscanf("Hello.", "%*i%s%*s", buffer);
 	swscanf(L"Hello.", "%10s", wbuffer);
+	scanf_s("%d %s %d", &i, buffer, 10, &i2);
 
 	return 0;
 }


### PR DESCRIPTION
Does what it says on the tin.

There are a couple of small details that need to be fixed in order to model these as flow sources: since every string-like output buffer is succeeded by a buffer size argument we cannot blindly mark all variadic argument as an output buffer.

To fix this I've added a new version of `hasLocalFlowSource` and `hasRemoteFlowSource` with a `Call` column. Using these new predicates the `scanf_s` variants can specify which output arguments _of that call_ are sources of flow instead of marking all of them.

Commit-by-commit review recommended.