### PR TITLE
C++: Fix FP on `cpp/cleartext-transmission`

### DIFF
--- a/cpp/ql/lib/change-notes/2026-05-15-hasSocketInput-for-fscanf.md
+++ b/cpp/ql/lib/change-notes/2026-05-15-hasSocketInput-for-fscanf.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The `RemoteFlowSourceFunction` model for `fscanf` (and variants) now implements `hasSocketInput` to reflect that these functions may read from a socket.

--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/Scanf.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/Scanf.qll
@@ -87,6 +87,10 @@ private class FscanfModel extends ScanfFunctionModel, RemoteFlowSourceFunction i
     output.isParameterDeref(any(int i | i >= this.getArgsStartPosition())) and
     description = "value read by " + this.getName()
   }
+
+  override predicate hasSocketInput(FunctionInput input) {
+    input.isParameterDeref(super.getInputParameterIndex())
+  }
 }
 
 /**

--- a/cpp/ql/src/change-notes/2026-05-15-cleartext-transmission-fp.md
+++ b/cpp/ql/src/change-notes/2026-05-15-cleartext-transmission-fp.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The 'Cleartext transmission of sensitive information' query (`cpp/cleartext-transmission`) no longer raises an alert on calls to `fscanf` (and variants) when the call reads from an "obviously local" `FILE` stream such as `stdin`.

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
@@ -138,6 +138,7 @@ nodes
 | test3.cpp:577:2:577:25 | ... = ... | semmle.label | ... = ... |
 | test3.cpp:577:8:577:23 | call to get_home_address | semmle.label | call to get_home_address |
 | test3.cpp:578:14:578:16 | str | semmle.label | str |
+| test3.cpp:585:25:585:32 | password | semmle.label | password |
 subpaths
 | test3.cpp:138:24:138:32 | password1 | test3.cpp:117:28:117:33 | buffer | test3.cpp:117:13:117:14 | *id | test3.cpp:138:21:138:22 | call to id |
 #select
@@ -181,3 +182,4 @@ subpaths
 | test3.cpp:559:3:559:6 | call to send | test3.cpp:556:19:556:30 | salaryString | test3.cpp:559:15:559:20 | *buffer | This operation transmits '*buffer', which may contain unencrypted sensitive data from $@. | test3.cpp:556:19:556:30 | salaryString | salaryString |
 | test3.cpp:572:2:572:5 | call to send | test3.cpp:571:8:571:21 | call to get_home_phone | test3.cpp:572:14:572:16 | str | This operation transmits 'str', which may contain unencrypted sensitive data from $@. | test3.cpp:571:8:571:21 | call to get_home_phone | call to get_home_phone |
 | test3.cpp:578:2:578:5 | call to send | test3.cpp:577:8:577:23 | call to get_home_address | test3.cpp:578:14:578:16 | str | This operation transmits 'str', which may contain unencrypted sensitive data from $@. | test3.cpp:577:8:577:23 | call to get_home_address | call to get_home_address |
+| test3.cpp:585:2:585:7 | call to fscanf | test3.cpp:585:25:585:32 | password | test3.cpp:585:25:585:32 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@. | test3.cpp:585:25:585:32 | password | password |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
@@ -138,7 +138,6 @@ nodes
 | test3.cpp:577:2:577:25 | ... = ... | semmle.label | ... = ... |
 | test3.cpp:577:8:577:23 | call to get_home_address | semmle.label | call to get_home_address |
 | test3.cpp:578:14:578:16 | str | semmle.label | str |
-| test3.cpp:585:25:585:32 | password | semmle.label | password |
 subpaths
 | test3.cpp:138:24:138:32 | password1 | test3.cpp:117:28:117:33 | buffer | test3.cpp:117:13:117:14 | *id | test3.cpp:138:21:138:22 | call to id |
 #select
@@ -182,4 +181,3 @@ subpaths
 | test3.cpp:559:3:559:6 | call to send | test3.cpp:556:19:556:30 | salaryString | test3.cpp:559:15:559:20 | *buffer | This operation transmits '*buffer', which may contain unencrypted sensitive data from $@. | test3.cpp:556:19:556:30 | salaryString | salaryString |
 | test3.cpp:572:2:572:5 | call to send | test3.cpp:571:8:571:21 | call to get_home_phone | test3.cpp:572:14:572:16 | str | This operation transmits 'str', which may contain unencrypted sensitive data from $@. | test3.cpp:571:8:571:21 | call to get_home_phone | call to get_home_phone |
 | test3.cpp:578:2:578:5 | call to send | test3.cpp:577:8:577:23 | call to get_home_address | test3.cpp:578:14:578:16 | str | This operation transmits 'str', which may contain unencrypted sensitive data from $@. | test3.cpp:577:8:577:23 | call to get_home_address | call to get_home_address |
-| test3.cpp:585:2:585:7 | call to fscanf | test3.cpp:585:25:585:32 | password | test3.cpp:585:25:585:32 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@. | test3.cpp:585:25:585:32 | password | password |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test3.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test3.cpp
@@ -582,5 +582,5 @@ int fscanf(FILE* stream, const char* format, ... );
 
 void test_scanf() {
 	char password[256];
-	fscanf(stdin, "%255s", password); // GOOD [FALSE POSITIVE]: this is not a remote source
+	fscanf(stdin, "%255s", password); // GOOD: this is not a remote source
 }

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test3.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test3.cpp
@@ -577,3 +577,10 @@ void tests3()
 	str = get_home_address();
 	send(val(), str, strlen(str), val()); // BAD
 }
+
+int fscanf(FILE* stream, const char* format, ... );
+
+void test_scanf() {
+	char password[256];
+	fscanf(stdin, "%255s", password); // GOOD [FALSE POSITIVE]: this is not a remote source
+}


### PR DESCRIPTION
The query did not recognize that `fscanf` is potentially not a remote flow source because we didn't override the optional `hasSocketInput` predicate on `RemoteFlowSourceFunction`.

DCA shows lots of removed results in SAMATE. They're all instances of exactly the pattern I added in the query test: a `fscanf` call that writes to `stdin`.