### PR TITLE
C#: Ensure that `Folder` entities exist for `Compilation` entities

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Compilations/Compilation.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Compilations/Compilation.cs
@@ -32,8 +32,12 @@ namespace Semmle.Extraction.CSharp.Entities
         {
             var assembly = Assembly.CreateOutputAssembly(Context);
 
-            trapFile.compilations(this, FileUtils.ConvertToUnix(cwd));
+            var path = Context.ExtractionContext.PathTransformer.Transform(cwd);
+            trapFile.compilations(this, path.Value);
             trapFile.compilation_assembly(this, assembly);
+
+            // Ensure that a `Folder` entity exists
+            Folder.Create(Context, path);
 
             // Arguments
             var expandedIndex = 0;


### PR DESCRIPTION
Ensures that [`Compilation.getFolder`](https://github.com/github/codeql/blob/4b095f31297395756e6e2de5d7f50241143fed86/csharp/ql/lib/semmle/code/csharp/commons/Compilation.qll#L16) always has a result.