### PR TITLE
Python: Support Flask subclasses

### DIFF
--- a/python/ql/lib/change-notes/2026-05-19-flask-subclasses.md
+++ b/python/ql/lib/change-notes/2026-05-19-flask-subclasses.md
@@ -1,4 +1,4 @@
 ---
 category: minorAnalysis
 ---
-* `Flask::instance` will now also return instances of subclasses defined in te source tree. Previously, these were filtered out. `Flask::classRef` has been deprecated in favor of `Flask::subclassRef` since it already returned some subclasses.
+* `Flask::FlaskApp::instance()` will now also return instances of subclasses defined in the source tree. Previously, these were filtered out. `Flask::FlaskApp::classRef()` has been deprecated in favor of `Flask::FlaskApp::subclassRef()` since it already returned some subclasses.

--- a/python/ql/lib/change-notes/2026-05-19-flask-subclasses.md
+++ b/python/ql/lib/change-notes/2026-05-19-flask-subclasses.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* `Flask::instance` will now also return instances of subclasses defined in te source tree. Previously, these were filtered out. `Flask::classRef` has been deprecated in favor of `Flask::subclassRef` since it already returned some subclasses.

--- a/python/ql/lib/semmle/python/frameworks/Flask.qll
+++ b/python/ql/lib/semmle/python/frameworks/Flask.qll
@@ -71,14 +71,21 @@ module Flask {
    * See https://flask.palletsprojects.com/en/1.1.x/api/#flask.Flask.
    */
   module FlaskApp {
-    /** Gets a reference to the `flask.Flask` class. */
-    API::Node classRef() {
-      result = API::moduleImport("flask").getMember("Flask") or
+    /**
+     * Gets a reference to the `flask.Flask` class or any subclass.
+     *
+     * Deprecated: Use `subclassRef()` instead, this predicate always returned some subclasses.
+     */
+    deprecated API::Node classRef() { result = subclassRef() }
+
+    /** Gets a reference to the `flask.Flask` class or any subclass. */
+    API::Node subclassRef() {
+      result = API::moduleImport("flask").getMember("Flask").getASubclass*() or
       result = ModelOutput::getATypeNode("flask.Flask~Subclass").getASubclass*()
     }
 
     /** Gets a reference to an instance of `flask.Flask` (a flask application). */
-    API::Node instance() { result = classRef().getReturn() }
+    API::Node instance() { result = subclassRef().getReturn() }
   }
 
   /**
@@ -132,7 +139,7 @@ module Flask {
     API::Node classRef() {
       result = API::moduleImport("flask").getMember("Response")
       or
-      result = [FlaskApp::classRef(), FlaskApp::instance()].getMember("response_class")
+      result = [FlaskApp::subclassRef(), FlaskApp::instance()].getMember("response_class")
       or
       result = ModelOutput::getATypeNode("flask.Response~Subclass").getASubclass*()
     }

--- a/python/ql/src/meta/ClassHierarchy/Find.ql
+++ b/python/ql/src/meta/ClassHierarchy/Find.ql
@@ -351,7 +351,7 @@ class DjangoHttpRequest extends FindSubclassesSpec {
 class FlaskClass extends FindSubclassesSpec {
   FlaskClass() { this = "flask.Flask~Subclass" }
 
-  override API::Node getAlreadyModeledClass() { result = Flask::FlaskApp::classRef() }
+  override API::Node getAlreadyModeledClass() { result = Flask::FlaskApp::subclassRef() }
 }
 
 class FlaskBlueprint extends FindSubclassesSpec {

--- a/python/ql/test/experimental/meta/InlineInstanceTest.qll
+++ b/python/ql/test/experimental/meta/InlineInstanceTest.qll
@@ -1,5 +1,5 @@
 /**
- * Defines a InlineExpectationsTest for class instances, that is,
+ * Defines an InlineExpectationsTest for class instances, that is,
  * for any API::Node that is an instance of a class (e.g. `Flask`).
  */
 

--- a/python/ql/test/experimental/meta/InlineInstanceTest.qll
+++ b/python/ql/test/experimental/meta/InlineInstanceTest.qll
@@ -1,0 +1,29 @@
+/**
+ * Defines a InlineExpectationsTest for class instances, that is,
+ * for any API::Node that is an instance of a class (e.g. `Flask`).
+ */
+
+import python
+import semmle.python.ApiGraphs
+import utils.test.InlineExpectationsTest
+private import semmle.python.dataflow.new.internal.PrintNode
+
+signature API::Node getInstanceSig();
+
+module MakeInlineInstanceTest<getInstanceSig/0 getInstance> {
+  private module InlineInstanceTest implements TestSig {
+    string getARelevantTag() { result = "instance" }
+
+    predicate hasActualResult(Location location, string element, string tag, string value) {
+      exists(location.getFile().getRelativePath()) and
+      exists(API::Node instance | instance = getInstance() |
+        location = instance.getLocation() and
+        element = prettyNode(instance.asSource()) and
+        value = "" and
+        tag = "instance"
+      )
+    }
+  }
+
+  import MakeTest<InlineInstanceTest>
+}

--- a/python/ql/test/library-tests/frameworks/flask/InlineInstanceTest.ql
+++ b/python/ql/test/library-tests/frameworks/flask/InlineInstanceTest.ql
@@ -1,0 +1,8 @@
+import python
+import semmle.python.frameworks.Flask
+import semmle.python.ApiGraphs
+import experimental.meta.InlineInstanceTest
+
+API::Node getInstance() { result = Flask::FlaskApp::instance() }
+
+import MakeInlineInstanceTest<getInstance/0>

--- a/python/ql/test/library-tests/frameworks/flask/flask_subclass.py
+++ b/python/ql/test/library-tests/frameworks/flask/flask_subclass.py
@@ -1,0 +1,14 @@
+from flask import Flask
+
+
+class Sub(Flask):
+    def __init__(self, *args, **kwargs):
+        Flask.__init__(self, *args, **kwargs)
+
+
+app = Sub(__name__) # $ MISSING: instance
+
+
+@app.route("/")
+def hello():
+    return "world"

--- a/python/ql/test/library-tests/frameworks/flask/flask_subclass.py
+++ b/python/ql/test/library-tests/frameworks/flask/flask_subclass.py
@@ -6,9 +6,9 @@ class Sub(Flask):
         Flask.__init__(self, *args, **kwargs)
 
 
-app = Sub(__name__) # $ MISSING: instance
+app = Sub(__name__) # $ instance
 
 
-@app.route("/")
-def hello():
-    return "world"
+@app.route("/") # $ routeSetup="/"
+def hello(): # $ requestHandler
+    return "world" # $ HttpResponse

--- a/python/ql/test/library-tests/frameworks/flask/old_test.py
+++ b/python/ql/test/library-tests/frameworks/flask/old_test.py
@@ -1,7 +1,7 @@
 import flask
 
 from flask import Flask, request, make_response
-app = Flask(__name__)
+app = Flask(__name__) # $ instance
 
 @app.route("/")  # $ routeSetup="/"
 def hello_world():  # $ requestHandler

--- a/python/ql/test/library-tests/frameworks/flask/response_test.py
+++ b/python/ql/test/library-tests/frameworks/flask/response_test.py
@@ -3,7 +3,7 @@ import json
 from flask import Flask, make_response, jsonify, Response, request, redirect
 from werkzeug.datastructures import Headers
 
-app = Flask(__name__)
+app = Flask(__name__) # $ instance
 
 
 @app.route("/html1")  # $ routeSetup="/html1"

--- a/python/ql/test/library-tests/frameworks/flask/routing_test.py
+++ b/python/ql/test/library-tests/frameworks/flask/routing_test.py
@@ -1,7 +1,7 @@
 import flask
 
 from flask import Flask, make_response
-app = Flask(__name__)
+app = Flask(__name__) # $ instance
 
 
 SOME_ROUTE = "/some/route"

--- a/python/ql/test/library-tests/frameworks/flask/save_uploaded_file.py
+++ b/python/ql/test/library-tests/frameworks/flask/save_uploaded_file.py
@@ -1,5 +1,5 @@
 from flask import Flask, request
-app = Flask(__name__)
+app = Flask(__name__) # $ instance
 
 @app.route("/save-uploaded-file")  # $ routeSetup="/save-uploaded-file"
 def test_taint():  # $ requestHandler

--- a/python/ql/test/library-tests/frameworks/flask/taint_test.py
+++ b/python/ql/test/library-tests/frameworks/flask/taint_test.py
@@ -1,5 +1,5 @@
 from flask import Flask, request, render_template_string, stream_template_string
-app = Flask(__name__)
+app = Flask(__name__) # $ instance
 
 @app.route("/test_taint/<name>/<int:number>")  # $ routeSetup="/test_taint/<name>/<int:number>"
 def test_taint(name = "World!", number="0", foo="foo"):  # $ requestHandler routedParameter=name routedParameter=number

--- a/python/ql/test/library-tests/frameworks/flask/template_test.py
+++ b/python/ql/test/library-tests/frameworks/flask/template_test.py
@@ -1,5 +1,5 @@
 from flask import Flask, Response, stream_with_context, render_template_string, stream_template_string
-app = Flask(__name__)
+app = Flask(__name__) # $ instance
 
 @app.route("/a")  # $ routeSetup="/a"
 def a():  # $ requestHandler


### PR DESCRIPTION
The pattern
```ql
result = API::moduleImport("flask").getMember("Flask") or
result = ModelOutput::getATypeNode("flask.Flask~Subclass").getASubclass*()
```
already returns all the subclasses for which we have MaD models, so we may as well replace it with
```
result = API::moduleImport("flask").getMember("Flask").getASubclass*() or
result = ModelOutput::getATypeNode("flask.Flask~Subclass").getASubclass*()
```
The predicate has been renamed from `classRef` to `subclassRef` with a deprecated alias.

This solves https://github.com/github/codeql/issues/21854