### PR TITLE
C#: Extract `.Slice` method call when using a span in conjunction with a range.

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/ElementAccess.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/ElementAccess.cs
@@ -123,7 +123,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
         {
             if (range is not null)
             {
-                // Populate the call arguments in case
+                // Populate the call arguments
                 var left = range.LeftOperand is ExpressionSyntax lsyntax
                     ? MakeFromRangeEndpoint(lsyntax, this, 0)
                     : MakeZeroLiteral(this, 0);

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/ElementAccess.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/ElementAccess.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -67,10 +66,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
         /// <returns>An expression representing the endpoint of a range to be used in conjunction with a slice operation.</returns>
         private Expression MakeFromRangeEndpoint(ExpressionSyntax syntax, IExpressionParentEntity parent, int child)
         {
-            var info = new ExpressionNodeInfo(Context, syntax, parent, child)
-            {
-                IsCompilerGenerated = true
-            };
+            var info = new ExpressionNodeInfo(Context, syntax, parent, child);
 
             return syntax.Kind() == SyntaxKind.IndexExpression
                 ? PrefixUnary.Create(info.SetKind(ExprKind.INDEX))

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/ElementAccess.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/ElementAccess.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/ElementAccess.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/ElementAccess.cs
@@ -47,7 +47,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
             return new Expression(info);
         }
 
-        private void MakeLengthPropertyCall(TextWriter trapFile, IPropertySymbol lengthPropertySymbol, IExpressionParentEntity parent, int child)
+        private Expression MakeLengthPropertyCall(TextWriter trapFile, IPropertySymbol lengthPropertySymbol, IExpressionParentEntity parent, int child)
         {
             var lengthInfo = new ExpressionInfo(
                     Context,
@@ -63,6 +63,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
 
             var lengthProp = Property.Create(Context, lengthPropertySymbol);
             trapFile.expr_access(length, lengthProp);
+            return length;
         }
 
         private Expression CreateFromIndexExpression(TextWriter trapFile, IPropertySymbol lengthPropertySymbol, IExpressionParentEntity parent, int child, PrefixUnaryExpressionSyntax index)
@@ -137,6 +138,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
             // 1. s[a..b] -> s.Slice(a, b - a)
             // 2. s[..b] -> s.Slice(0, b)
             // 3. s[a..] -> s.Slice(a, s.Length - a)
+            // 4. s[..] -> s.Slice(0, s.Length)
             // Furthermore, note that uses of index expressions (e.g. s[2..^1]) within the range 
             // get translated to length - index, so we need to handle this as well.
             switch (range.LeftOperand, range.RightOperand)
@@ -165,6 +167,13 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
                         var right = MakeSubtractionExpression(this, 1);
                         MakeLengthPropertyCall(trapFile, lengthPropertySymbol, right, 0);
                         CreateFromRangeEndpoint(trapFile, lengthPropertySymbol, lsyntax, right, 1);
+                        SetExprArgument(trapFile, left, right);
+                        break;
+                    }
+                case (null, null):
+                    {
+                        var left = Literal.CreateGenerated(Context, this, 0, Context.Compilation.GetSpecialType(SpecialType.System_Int32), 0, Location);
+                        var right = MakeLengthPropertyCall(trapFile, lengthPropertySymbol, this, 1);
                         SetExprArgument(trapFile, left, right);
                         break;
                     }

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/ElementAccess.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/ElementAccess.cs
@@ -103,9 +103,10 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
 
         /// <summary>
         /// Determines whether the given method is a slice method, which is defined as a method with
-        /// the name "Slice" or "SubString" and two parameters.
-        /// </summary> <param name="method">The method symbol to check.</param>
-        /// <returns>True if the method is a slice method, false otherwise.</returns>
+        /// the name "Slice" or "Substring" and two parameters.
+        /// </summary>
+        /// <param name="method">The method symbol to check.</param>
+        /// <returns>True if the method is a slice method; false otherwise.</returns>
         private bool IsSliceWithRange(IMethodSymbol method, [NotNullWhen(true)] out IPropertySymbol? lengthPropertySymbol, [NotNullWhen(true)] out RangeExpressionSyntax? range)
         {
             range = null;

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/ElementAccess.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/ElementAccess.cs
@@ -79,7 +79,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
         /// </summary>
         /// <param name="method">The method symbol to check.</param>
         /// <returns>True if the method is a slice method; false otherwise.</returns>
-        private bool IsSliceWithRange(IMethodSymbol method, [NotNullWhen(true)] out RangeExpressionSyntax? range)
+        private bool IsSlice(IMethodSymbol method, out RangeExpressionSyntax? range)
         {
             range = null;
 
@@ -89,8 +89,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
             }
 
             return (method.Name == "Slice" || method.Name == "Substring")
-                && method.Parameters.Length == 2
-                && range is not null;
+                && method.Parameters.Length == 2;
         }
 
         /// <summary>
@@ -111,21 +110,31 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
         /// 
         /// Even though index expressions can't technically be used in this way, they signal that we
         /// could perceive ^b as "length - b".
+        ///
+        /// Call arguments are only populated when a range expression is directly available in
+        /// the list of arguments.
+        /// This means that cases like below are not handled.
+        /// System.Range x = 1..3;
+        /// s[x]
         /// </summary>
         /// <param name="trapFile">The trap file to write to.</param>
         /// <param name="slice">The slice method symbol.</param>
         /// <param name="range">The range expression syntax.</param>
-        private void PopulateSlice(TextWriter trapFile, IMethodSymbol slice, RangeExpressionSyntax range)
+        private void PopulateSlice(TextWriter trapFile, IMethodSymbol slice, RangeExpressionSyntax? range)
         {
-            var left = range.LeftOperand is ExpressionSyntax lsyntax
-                ? MakeFromRangeEndpoint(lsyntax, this, 0)
-                : MakeZeroLiteral(this, 0);
+            if (range is not null)
+            {
+                // Populate the call arguments in case
+                var left = range.LeftOperand is ExpressionSyntax lsyntax
+                    ? MakeFromRangeEndpoint(lsyntax, this, 0)
+                    : MakeZeroLiteral(this, 0);
 
-            var right = range.RightOperand is ExpressionSyntax rsyntax
-                ? MakeFromRangeEndpoint(rsyntax, this, 1)
-                : MakeZeroFromEndExpression(this, 1);
+                var right = range.RightOperand is ExpressionSyntax rsyntax
+                    ? MakeFromRangeEndpoint(rsyntax, this, 1)
+                    : MakeZeroFromEndExpression(this, 1);
 
-            SetExprArgument(trapFile, left, right);
+                SetExprArgument(trapFile, left, right);
+            }
             trapFile.expr_call(this, Method.Create(Context, slice));
         }
 
@@ -144,7 +153,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
                 Create(Context, qualifier, this, -1);
 
                 var target = GetTargetSymbol();
-                if (target is IMethodSymbol method && IsSliceWithRange(method, out var range))
+                if (target is IMethodSymbol method && IsSlice(method, out var range))
                 {
                     // When an indexer on a span or string is used in conjunction with a range expression, the compiler translates
                     // this into a call to the "Slice" or "Substring" method.

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/ElementAccess.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/ElementAccess.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.Kinds;
@@ -17,6 +18,35 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
         private readonly ExpressionSyntax qualifier;
         private readonly BracketedArgumentListSyntax argumentList;
 
+
+        private IPropertySymbol? GetIndexerSymbol()
+        {
+            var symbol = Context.GetSymbolInfo(base.Syntax).Symbol;
+
+            if (symbol is IPropertySymbol { IsIndexer: true } indexer)
+                return indexer;
+
+            // In some cases, Roslyn translates the use of range expressions directly into method calls.
+            // E.g. `a[0..3]` is translated into `a.Slice(0, 3)`, if `a` is a `Span<T>`.
+            // In this case, we want to populate the indexer access as normal (as this reflects the source code more accurately).
+            if (symbol is IMethodSymbol method)
+            {
+                var indexers = method
+                    .ContainingType
+                    .GetMembers()
+                    .OfType<IPropertySymbol>()
+                    .Where(p => p.IsIndexer);
+
+                var intIndexer = indexers
+                    .Where(i => i.Parameters.Length == 1 && i.Parameters[0].Type.SpecialType == SpecialType.System_Int32)
+                    .FirstOrDefault();
+
+                return intIndexer;
+            }
+
+            return null;
+        }
+
         protected override void PopulateExpression(TextWriter trapFile)
         {
             if (Kind == ExprKind.POINTER_INDIRECTION)
@@ -32,9 +62,8 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
                 Create(Context, qualifier, this, -1);
                 PopulateArguments(trapFile, argumentList, 0);
 
-                var symbolInfo = Context.GetSymbolInfo(base.Syntax);
-
-                if (symbolInfo.Symbol is IPropertySymbol indexer)
+                var indexer = GetIndexerSymbol();
+                if (indexer is not null)
                 {
                     trapFile.expr_access(this, Indexer.Create(Context, indexer));
                 }

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/ElementAccess.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/ElementAccess.cs
@@ -32,51 +32,29 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
             trapFile.expr_argument(right, 0);
         }
 
-        private Expression MakeSubtractionExpression(IExpressionParentEntity parent, int child)
+        private Expression MakeZeroFromEndExpression(IExpressionParentEntity parent, int child)
         {
             var info = new ExpressionInfo(
                                 Context,
                                 AnnotatedTypeSymbol.CreateNotAnnotated(Context.Compilation.GetSpecialType(SpecialType.System_Int32)),
                                 Location,
-                                ExprKind.SUB,
+                                ExprKind.INDEX,
                                 parent,
                                 child,
                                 isCompilerGenerated: true,
                                 null);
 
-            return new Expression(info);
+            var index = new Expression(info);
+
+            MakeZeroLiteral(index, 0);
+            return index;
         }
 
-        private Expression MakeLengthPropertyCall(TextWriter trapFile, IPropertySymbol lengthPropertySymbol, IExpressionParentEntity parent, int child)
+        private Expression MakeZeroLiteral(IExpressionParentEntity parent, int child)
         {
-            var lengthInfo = new ExpressionInfo(
-                    Context,
-                    AnnotatedTypeSymbol.CreateNotAnnotated(Context.Compilation.GetSpecialType(SpecialType.System_Int32)),
-                    Location,
-                    ExprKind.PROPERTY_ACCESS,
-                    parent,
-                    child,
-                    isCompilerGenerated: true,
-                    null);
-            var length = new Expression(lengthInfo);
-            Create(Context, qualifier, length, -1);
-
-            var lengthProp = Property.Create(Context, lengthPropertySymbol);
-            trapFile.expr_access(length, lengthProp);
-            return length;
+            return Literal.CreateGenerated(Context, parent, child, Context.Compilation.GetSpecialType(SpecialType.System_Int32), 0, Location);
         }
 
-        private Expression CreateFromIndexExpression(TextWriter trapFile, IPropertySymbol lengthPropertySymbol, IExpressionParentEntity parent, int child, PrefixUnaryExpressionSyntax index)
-        {
-            var sub = MakeSubtractionExpression(parent, child);
-            MakeLengthPropertyCall(trapFile, lengthPropertySymbol, sub, 0);
-            var info = new ExpressionNodeInfo(Context, index.Operand, sub, 1)
-            {
-                IsCompilerGenerated = true
-            };
-            Factory.Create(info);
-            return sub;
-        }
 
         /// <summary>
         /// It is assumed that either the input is
@@ -87,18 +65,16 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
         /// <param name="parent">The parent expression entity.</param>
         /// <param name="child">The child index within the parent.</param>
         /// <returns>An expression representing the endpoint of a range to be used in conjunction with a slice operation.</returns>
-        private Expression CreateFromRangeEndpoint(TextWriter trapFile, IPropertySymbol lengthPropertySymbol, ExpressionSyntax syntax, IExpressionParentEntity parent, int child)
+        private Expression MakeFromRangeEndpoint(ExpressionSyntax syntax, IExpressionParentEntity parent, int child)
         {
-            if (syntax.Kind() == SyntaxKind.IndexExpression && syntax is PrefixUnaryExpressionSyntax index)
-            {
-                return CreateFromIndexExpression(trapFile, lengthPropertySymbol, parent, child, index);
-            }
-
             var info = new ExpressionNodeInfo(Context, syntax, parent, child)
             {
                 IsCompilerGenerated = true
             };
-            return Factory.Create(info);
+
+            return syntax.Kind() == SyntaxKind.IndexExpression
+                ? PrefixUnary.Create(info.SetKind(ExprKind.INDEX))
+                : Factory.Create(info);
         }
 
         /// <summary>
@@ -107,14 +83,9 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
         /// </summary>
         /// <param name="method">The method symbol to check.</param>
         /// <returns>True if the method is a slice method; false otherwise.</returns>
-        private bool IsSliceWithRange(IMethodSymbol method, [NotNullWhen(true)] out IPropertySymbol? lengthPropertySymbol, [NotNullWhen(true)] out RangeExpressionSyntax? range)
+        private bool IsSliceWithRange(IMethodSymbol method, [NotNullWhen(true)] out RangeExpressionSyntax? range)
         {
             range = null;
-            lengthPropertySymbol = method
-                .ContainingType
-                .GetMembers("Length")
-                .OfType<IPropertySymbol>()
-                .FirstOrDefault();
 
             if (argumentList.Arguments.Count == 1)
             {
@@ -123,63 +94,42 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
 
             return (method.Name == "Slice" || method.Name == "Substring")
                 && method.Parameters.Length == 2
-                && lengthPropertySymbol is not null
                 && range is not null;
         }
 
         /// <summary>
-        /// Populates a slice method call based on the given range and length property symbol.
+        /// Populates a slice method call based on the given range.
+        /// Roslyn translates indexer accesses with range expressions in the following way.
+        ///   1. s[a..b] -> s.Slice(a, b - a)
+        ///   2. s[..b] -> s.Slice(0, b)
+        ///   3. s[a..] -> s.Slice(a, s.Length - a)
+        ///   4. s[..] -> s.Slice(0, s.Length)
+        /// However, it is possible that both the qualifier or the index endpoints may contain method calls.
+        /// If we want to translate this accurately, we would need to introduce synthetic statements for qualifier and 
+        /// the endpoints, which should then be used in the slice method call.
+        /// To avoid this, we translate as follows.
+        /// 1. s[a..b] -> s.Slice(a, b)
+        /// 2. s[..b] -> s.Slice(0, b)
+        /// 3. s[a..] -> s.Slice(a, ^0)
+        /// 4. s[..] -> s.Slice(0, ^0)
+        /// 
+        /// Even though index expressions can't technically be used in this way, they signal that we
+        /// could perceive ^b as "length - b".
         /// </summary>
         /// <param name="trapFile">The trap file to write to.</param>
-        /// <param name="lengthPropertySymbol">The length property symbol.</param>
         /// <param name="slice">The slice method symbol.</param>
         /// <param name="range">The range expression syntax.</param>
-        private void PopulateSlice(TextWriter trapFile, IPropertySymbol lengthPropertySymbol, IMethodSymbol slice, RangeExpressionSyntax range)
+        private void PopulateSlice(TextWriter trapFile, IMethodSymbol slice, RangeExpressionSyntax range)
         {
-            // 1. s[a..b] -> s.Slice(a, b - a)
-            // 2. s[..b] -> s.Slice(0, b)
-            // 3. s[a..] -> s.Slice(a, s.Length - a)
-            // 4. s[..] -> s.Slice(0, s.Length)
-            // Furthermore, note that uses of index expressions (e.g. s[2..^1]) within the range 
-            // get translated to length - index, so we need to handle this as well.
-            switch (range.LeftOperand, range.RightOperand)
-            {
-                case (ExpressionSyntax lsyntax, ExpressionSyntax rsyntax):
-                    {
-                        var left = CreateFromRangeEndpoint(trapFile, lengthPropertySymbol, lsyntax, this, 0);
-                        var right = MakeSubtractionExpression(this, 1);
+            var left = range.LeftOperand is ExpressionSyntax lsyntax
+                ? MakeFromRangeEndpoint(lsyntax, this, 0)
+                : MakeZeroLiteral(this, 0);
 
-                        CreateFromRangeEndpoint(trapFile, lengthPropertySymbol, rsyntax, right, 0);
-                        CreateFromRangeEndpoint(trapFile, lengthPropertySymbol, lsyntax, right, 1);
-                        SetExprArgument(trapFile, left, right);
-                        break;
-                    }
-                case (null, ExpressionSyntax rsyntax):
-                    {
-                        var left = Literal.CreateGenerated(Context, this, 0, Context.Compilation.GetSpecialType(SpecialType.System_Int32), 0, Location);
-                        var right = CreateFromRangeEndpoint(trapFile, lengthPropertySymbol, rsyntax, this, 1);
-                        SetExprArgument(trapFile, left, right);
-                        break;
-                    }
-                case (ExpressionSyntax lsyntax, null):
-                    {
+            var right = range.RightOperand is ExpressionSyntax rsyntax
+                ? MakeFromRangeEndpoint(rsyntax, this, 1)
+                : MakeZeroFromEndExpression(this, 1);
 
-                        var left = CreateFromRangeEndpoint(trapFile, lengthPropertySymbol, lsyntax, this, 0);
-                        var right = MakeSubtractionExpression(this, 1);
-                        MakeLengthPropertyCall(trapFile, lengthPropertySymbol, right, 0);
-                        CreateFromRangeEndpoint(trapFile, lengthPropertySymbol, lsyntax, right, 1);
-                        SetExprArgument(trapFile, left, right);
-                        break;
-                    }
-                case (null, null):
-                    {
-                        var left = Literal.CreateGenerated(Context, this, 0, Context.Compilation.GetSpecialType(SpecialType.System_Int32), 0, Location);
-                        var right = MakeLengthPropertyCall(trapFile, lengthPropertySymbol, this, 1);
-                        SetExprArgument(trapFile, left, right);
-                        break;
-                    }
-            }
-
+            SetExprArgument(trapFile, left, right);
             trapFile.expr_call(this, Method.Create(Context, slice));
         }
 
@@ -198,13 +148,12 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
                 Create(Context, qualifier, this, -1);
 
                 var target = GetTargetSymbol();
-                if (target is IMethodSymbol method && IsSliceWithRange(method, out var lengthPropertySymbol, out var range))
+                if (target is IMethodSymbol method && IsSliceWithRange(method, out var range))
                 {
                     // When an indexer on a span or string is used in conjunction with a range expression, the compiler translates
                     // this into a call to the "Slice" or "Substring" method.
                     // In this case, we want to populate a slice/substring method call instead of an indexer access.
-                    // E.g s[1..4] gets translated to s.Slice(1, 4 - 1) if s is a span.
-                    PopulateSlice(trapFile, lengthPropertySymbol, method, range);
+                    PopulateSlice(trapFile, method, range);
                     return;
                 }
 

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/ElementAccess.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/ElementAccess.cs
@@ -1,6 +1,8 @@
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.Kinds;
 
@@ -9,7 +11,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
     internal abstract class ElementAccess : Expression<ExpressionSyntax>
     {
         protected ElementAccess(ExpressionNodeInfo info, ExpressionSyntax qualifier, BracketedArgumentListSyntax argumentList)
-            : base(info.SetKind(GetKind(info.Context, qualifier)))
+            : base(info.SetKind(GetKind(info.Context, info.Node, qualifier)))
         {
             this.qualifier = qualifier;
             this.argumentList = argumentList;
@@ -19,32 +21,156 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
         private readonly BracketedArgumentListSyntax argumentList;
 
 
-        private IPropertySymbol? GetIndexerSymbol()
+        private ISymbol? GetTargetSymbol()
         {
-            var symbol = Context.GetSymbolInfo(base.Syntax).Symbol;
+            return Context.GetSymbolInfo(base.Syntax).Symbol;
+        }
 
-            if (symbol is IPropertySymbol { IsIndexer: true } indexer)
-                return indexer;
+        private static void SetExprArgument(TextWriter trapFile, Expression left, Expression right)
+        {
+            trapFile.expr_argument(left, 0);
+            trapFile.expr_argument(right, 0);
+        }
 
-            // In some cases, Roslyn translates the use of range expressions directly into method calls.
-            // E.g. `a[0..3]` is translated into `a.Slice(0, 3)`, if `a` is a `Span<T>`.
-            // In this case, we want to populate the indexer access as normal (as this reflects the source code more accurately).
-            if (symbol is IMethodSymbol method)
+        private Expression MakeSubtractionExpression(IExpressionParentEntity parent, int child)
+        {
+            var info = new ExpressionInfo(
+                                Context,
+                                AnnotatedTypeSymbol.CreateNotAnnotated(Context.Compilation.GetSpecialType(SpecialType.System_Int32)),
+                                Location,
+                                ExprKind.SUB,
+                                parent,
+                                child,
+                                isCompilerGenerated: true,
+                                null);
+
+            return new Expression(info);
+        }
+
+        private void MakeLengthPropertyCall(TextWriter trapFile, IPropertySymbol lengthPropertySymbol, IExpressionParentEntity parent, int child)
+        {
+            var lengthInfo = new ExpressionInfo(
+                    Context,
+                    AnnotatedTypeSymbol.CreateNotAnnotated(Context.Compilation.GetSpecialType(SpecialType.System_Int32)),
+                    Location,
+                    ExprKind.PROPERTY_ACCESS,
+                    parent,
+                    child,
+                    isCompilerGenerated: true,
+                    null);
+            var length = new Expression(lengthInfo);
+            Create(Context, qualifier, length, -1);
+
+            var lengthProp = Property.Create(Context, lengthPropertySymbol);
+            trapFile.expr_access(length, lengthProp);
+        }
+
+        private Expression CreateFromIndexExpression(TextWriter trapFile, IPropertySymbol lengthPropertySymbol, IExpressionParentEntity parent, int child, PrefixUnaryExpressionSyntax index)
+        {
+            var sub = MakeSubtractionExpression(parent, child);
+            MakeLengthPropertyCall(trapFile, lengthPropertySymbol, sub, 0);
+            var info = new ExpressionNodeInfo(Context, index.Operand, sub, 1)
             {
-                var indexers = method
-                    .ContainingType
-                    .GetMembers()
-                    .OfType<IPropertySymbol>()
-                    .Where(p => p.IsIndexer);
+                IsCompilerGenerated = true
+            };
+            Factory.Create(info);
+            return sub;
+        }
 
-                var intIndexer = indexers
-                    .Where(i => i.Parameters.Length == 1 && i.Parameters[0].Type.SpecialType == SpecialType.System_Int32)
-                    .FirstOrDefault();
-
-                return intIndexer;
+        /// <summary>
+        /// It is assumed that either the input is
+        /// 1. A normal expression that can be used as endpoint (e.g a constant like "3").
+        /// 2. An index expression indicating that we should read from the end (e.g "^1").
+        /// </summary>
+        /// <param name="syntax">The syntax node representing the range endpoint.</param>
+        /// <param name="parent">The parent expression entity.</param>
+        /// <param name="child">The child index within the parent.</param>
+        /// <returns>An expression representing the endpoint of a range to be used in conjunction with a slice operation.</returns>
+        private Expression CreateFromRangeEndpoint(TextWriter trapFile, IPropertySymbol lengthPropertySymbol, ExpressionSyntax syntax, IExpressionParentEntity parent, int child)
+        {
+            if (syntax.Kind() == SyntaxKind.IndexExpression && syntax is PrefixUnaryExpressionSyntax index)
+            {
+                return CreateFromIndexExpression(trapFile, lengthPropertySymbol, parent, child, index);
             }
 
-            return null;
+            var info = new ExpressionNodeInfo(Context, syntax, parent, child)
+            {
+                IsCompilerGenerated = true
+            };
+            return Factory.Create(info);
+        }
+
+        /// <summary>
+        /// Determines whether the given method is a slice method, which is defined as a method with
+        /// the name "Slice" or "SubString" and two parameters.
+        /// </summary> <param name="method">The method symbol to check.</param>
+        /// <returns>True if the method is a slice method, false otherwise.</returns>
+        private bool IsSliceWithRange(IMethodSymbol method, [NotNullWhen(true)] out IPropertySymbol? lengthPropertySymbol, [NotNullWhen(true)] out RangeExpressionSyntax? range)
+        {
+            range = null;
+            lengthPropertySymbol = method
+                .ContainingType
+                .GetMembers("Length")
+                .OfType<IPropertySymbol>()
+                .FirstOrDefault();
+
+            if (argumentList.Arguments.Count == 1)
+            {
+                range = argumentList.Arguments[0].Expression as RangeExpressionSyntax;
+            }
+
+            return (method.Name == "Slice" || method.Name == "Substring")
+                && method.Parameters.Length == 2
+                && lengthPropertySymbol is not null
+                && range is not null;
+        }
+
+        /// <summary>
+        /// Populates a slice method call based on the given range and length property symbol.
+        /// </summary>
+        /// <param name="trapFile">The trap file to write to.</param>
+        /// <param name="lengthPropertySymbol">The length property symbol.</param>
+        /// <param name="slice">The slice method symbol.</param>
+        /// <param name="range">The range expression syntax.</param>
+        private void PopulateSlice(TextWriter trapFile, IPropertySymbol lengthPropertySymbol, IMethodSymbol slice, RangeExpressionSyntax range)
+        {
+            // 1. s[a..b] -> s.Slice(a, b - a)
+            // 2. s[..b] -> s.Slice(0, b)
+            // 3. s[a..] -> s.Slice(a, s.Length - a)
+            // Furthermore, note that uses of index expressions (e.g. s[2..^1]) within the range 
+            // get translated to length - index, so we need to handle this as well.
+            switch (range.LeftOperand, range.RightOperand)
+            {
+                case (ExpressionSyntax lsyntax, ExpressionSyntax rsyntax):
+                    {
+                        var left = CreateFromRangeEndpoint(trapFile, lengthPropertySymbol, lsyntax, this, 0);
+                        var right = MakeSubtractionExpression(this, 1);
+
+                        CreateFromRangeEndpoint(trapFile, lengthPropertySymbol, rsyntax, right, 0);
+                        CreateFromRangeEndpoint(trapFile, lengthPropertySymbol, lsyntax, right, 1);
+                        SetExprArgument(trapFile, left, right);
+                        break;
+                    }
+                case (null, ExpressionSyntax rsyntax):
+                    {
+                        var left = Literal.CreateGenerated(Context, this, 0, Context.Compilation.GetSpecialType(SpecialType.System_Int32), 0, Location);
+                        var right = CreateFromRangeEndpoint(trapFile, lengthPropertySymbol, rsyntax, this, 1);
+                        SetExprArgument(trapFile, left, right);
+                        break;
+                    }
+                case (ExpressionSyntax lsyntax, null):
+                    {
+
+                        var left = CreateFromRangeEndpoint(trapFile, lengthPropertySymbol, lsyntax, this, 0);
+                        var right = MakeSubtractionExpression(this, 1);
+                        MakeLengthPropertyCall(trapFile, lengthPropertySymbol, right, 0);
+                        CreateFromRangeEndpoint(trapFile, lengthPropertySymbol, lsyntax, right, 1);
+                        SetExprArgument(trapFile, left, right);
+                        break;
+                    }
+            }
+
+            trapFile.expr_call(this, Method.Create(Context, slice));
         }
 
         protected override void PopulateExpression(TextWriter trapFile)
@@ -60,10 +186,20 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
             else
             {
                 Create(Context, qualifier, this, -1);
-                PopulateArguments(trapFile, argumentList, 0);
 
-                var indexer = GetIndexerSymbol();
-                if (indexer is not null)
+                var target = GetTargetSymbol();
+                if (target is IMethodSymbol method && IsSliceWithRange(method, out var lengthPropertySymbol, out var range))
+                {
+                    // When an indexer on a span or string is used in conjunction with a range expression, the compiler translates
+                    // this into a call to the "Slice" or "Substring" method.
+                    // In this case, we want to populate a slice/substring method call instead of an indexer access.
+                    // E.g s[1..4] gets translated to s.Slice(1, 4 - 1) if s is a span.
+                    PopulateSlice(trapFile, lengthPropertySymbol, method, range);
+                    return;
+                }
+
+                PopulateArguments(trapFile, argumentList, 0);
+                if (target is IPropertySymbol { IsIndexer: true } indexer)
                 {
                     trapFile.expr_access(this, Indexer.Create(Context, indexer));
                 }
@@ -75,8 +211,11 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
         private static bool IsArray(ITypeSymbol symbol) =>
             symbol.TypeKind == Microsoft.CodeAnalysis.TypeKind.Array || symbol.IsInlineArray();
 
-        private static ExprKind GetKind(Context cx, ExpressionSyntax qualifier)
+        private static ExprKind GetKind(Context cx, ExpressionSyntax syntax, ExpressionSyntax qualifier)
         {
+            if (cx.GetSymbolInfo(syntax).Symbol is IMethodSymbol)
+                return ExprKind.METHOD_INVOCATION;
+
             var qualifierType = cx.GetType(qualifier);
 
             // This is a compilation error, so make a guess and continue.

--- a/csharp/ql/lib/change-notes/2026-05-21-spanaccess-range.md
+++ b/csharp/ql/lib/change-notes/2026-05-21-spanaccess-range.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Improved extraction of span range-access expressions (for example, `a[0..3]`) so the indexer is recorded as the call target.

--- a/csharp/ql/lib/change-notes/2026-05-21-spanaccess-range.md
+++ b/csharp/ql/lib/change-notes/2026-05-21-spanaccess-range.md
@@ -1,4 +1,4 @@
 ---
 category: minorAnalysis
 ---
-* Improved extraction of span range-access expressions (for example, `a[0..3]`) so the indexer is recorded as the call target.
+* Improved extraction of span range-access expressions (for example, `a[0..3]`). These expressions are now extracted as span `Slice` calls.

--- a/csharp/ql/lib/change-notes/2026-05-21-spanaccess-range.md
+++ b/csharp/ql/lib/change-notes/2026-05-21-spanaccess-range.md
@@ -1,4 +1,4 @@
 ---
 category: minorAnalysis
 ---
-* Improved extraction of span range-access expressions (for example, `a[0..3]`). These expressions are now extracted as span `Slice` calls.
+* Improved extraction of range-access expressions on spans and strings (for example, `a[0..3]`). These expressions are now extracted as `Slice` (span) or `Substring` (string) calls.

--- a/csharp/ql/test/library-tests/spans/Slice.cs
+++ b/csharp/ql/test/library-tests/spans/Slice.cs
@@ -1,0 +1,19 @@
+using System;
+
+public class C
+{
+    public void M(int a)
+    {
+        var s = "hello world";
+        var sub1 = s[1..a];
+        var sub2 = s[..2];
+        var sub3 = s[3..];
+        var sub4 = s[..^4];
+
+        Span<int> sp = null;
+        var slice1 = sp[5..a];
+        var slice2 = sp[..6];
+        var slice3 = sp[7..];
+        var slice4 = sp[..^8];
+    }
+}

--- a/csharp/ql/test/library-tests/spans/Slice.cs
+++ b/csharp/ql/test/library-tests/spans/Slice.cs
@@ -2,18 +2,20 @@ using System;
 
 public class C
 {
-    public void M(int a)
+    public void M(int a, int b)
     {
         var s = "hello world";
         var sub1 = s[1..a];
         var sub2 = s[..2];
         var sub3 = s[3..];
         var sub4 = s[..^4];
+        var sub5 = s[a..^b];
 
         Span<int> sp = null;
         var slice1 = sp[5..a];
         var slice2 = sp[..6];
         var slice3 = sp[7..];
         var slice4 = sp[..^8];
+        var slice5 = sp[a..^b];
     }
 }

--- a/csharp/ql/test/library-tests/spans/Slice.cs
+++ b/csharp/ql/test/library-tests/spans/Slice.cs
@@ -10,6 +10,7 @@ public class C
         var sub3 = s[3..];
         var sub4 = s[..^4];
         var sub5 = s[a..^b];
+        var sub6 = s[..];
 
         Span<int> sp = null;
         var slice1 = sp[5..a];
@@ -17,5 +18,6 @@ public class C
         var slice3 = sp[7..];
         var slice4 = sp[..^8];
         var slice5 = sp[a..^b];
+        var slice6 = sp[..];
     }
 }

--- a/csharp/ql/test/library-tests/spans/Slice.cs
+++ b/csharp/ql/test/library-tests/spans/Slice.cs
@@ -12,6 +12,9 @@ public class C
         var sub5 = s[a..^b];
         var sub6 = s[..];
 
+        Range range = 1..a;
+        var sub7 = s[range];
+
         Span<int> sp = null;
         var slice1 = sp[5..a];
         var slice2 = sp[..6];
@@ -19,5 +22,8 @@ public class C
         var slice4 = sp[..^8];
         var slice5 = sp[a..^b];
         var slice6 = sp[..];
+
+        Range range2 = 1..a;
+        var slice7 = sp[range2];
     }
 }

--- a/csharp/ql/test/library-tests/spans/slice.expected
+++ b/csharp/ql/test/library-tests/spans/slice.expected
@@ -9,20 +9,26 @@ methodCalls
 | Slice.cs:11:20:11:26 | call to method Substring | Substring(int, int) | 1 | access to property Length - 4 |
 | Slice.cs:12:20:12:27 | call to method Substring | Substring(int, int) | 0 | access to parameter a |
 | Slice.cs:12:20:12:27 | call to method Substring | Substring(int, int) | 1 | access to property Length - access to parameter b - access to parameter a |
-| Slice.cs:15:22:15:29 | call to method Slice | Slice(int, int) | 0 | 5 |
-| Slice.cs:15:22:15:29 | call to method Slice | Slice(int, int) | 1 | access to parameter a - 5 |
-| Slice.cs:16:22:16:28 | call to method Slice | Slice(int, int) | 0 | 0 |
-| Slice.cs:16:22:16:28 | call to method Slice | Slice(int, int) | 1 | 6 |
-| Slice.cs:17:22:17:28 | call to method Slice | Slice(int, int) | 0 | 7 |
-| Slice.cs:17:22:17:28 | call to method Slice | Slice(int, int) | 1 | access to property Length - 7 |
-| Slice.cs:18:22:18:29 | call to method Slice | Slice(int, int) | 0 | 0 |
-| Slice.cs:18:22:18:29 | call to method Slice | Slice(int, int) | 1 | access to property Length - 8 |
-| Slice.cs:19:22:19:30 | call to method Slice | Slice(int, int) | 0 | access to parameter a |
-| Slice.cs:19:22:19:30 | call to method Slice | Slice(int, int) | 1 | access to property Length - access to parameter b - access to parameter a |
+| Slice.cs:13:20:13:24 | call to method Substring | Substring(int, int) | 0 | 0 |
+| Slice.cs:13:20:13:24 | call to method Substring | Substring(int, int) | 1 | access to property Length |
+| Slice.cs:16:22:16:29 | call to method Slice | Slice(int, int) | 0 | 5 |
+| Slice.cs:16:22:16:29 | call to method Slice | Slice(int, int) | 1 | access to parameter a - 5 |
+| Slice.cs:17:22:17:28 | call to method Slice | Slice(int, int) | 0 | 0 |
+| Slice.cs:17:22:17:28 | call to method Slice | Slice(int, int) | 1 | 6 |
+| Slice.cs:18:22:18:28 | call to method Slice | Slice(int, int) | 0 | 7 |
+| Slice.cs:18:22:18:28 | call to method Slice | Slice(int, int) | 1 | access to property Length - 7 |
+| Slice.cs:19:22:19:29 | call to method Slice | Slice(int, int) | 0 | 0 |
+| Slice.cs:19:22:19:29 | call to method Slice | Slice(int, int) | 1 | access to property Length - 8 |
+| Slice.cs:20:22:20:30 | call to method Slice | Slice(int, int) | 0 | access to parameter a |
+| Slice.cs:20:22:20:30 | call to method Slice | Slice(int, int) | 1 | access to property Length - access to parameter b - access to parameter a |
+| Slice.cs:21:22:21:27 | call to method Slice | Slice(int, int) | 0 | 0 |
+| Slice.cs:21:22:21:27 | call to method Slice | Slice(int, int) | 1 | access to property Length |
 propertyCalls
 | Slice.cs:10:20:10:25 | access to property Length | Slice.cs:10:20:10:20 | access to local variable s |
 | Slice.cs:11:20:11:26 | access to property Length | Slice.cs:11:20:11:20 | access to local variable s |
 | Slice.cs:12:20:12:27 | access to property Length | Slice.cs:12:20:12:20 | access to local variable s |
-| Slice.cs:17:22:17:28 | access to property Length | Slice.cs:17:22:17:23 | access to local variable sp |
-| Slice.cs:18:22:18:29 | access to property Length | Slice.cs:18:22:18:23 | access to local variable sp |
-| Slice.cs:19:22:19:30 | access to property Length | Slice.cs:19:22:19:23 | access to local variable sp |
+| Slice.cs:13:20:13:24 | access to property Length | Slice.cs:13:20:13:20 | access to local variable s |
+| Slice.cs:18:22:18:28 | access to property Length | Slice.cs:18:22:18:23 | access to local variable sp |
+| Slice.cs:19:22:19:29 | access to property Length | Slice.cs:19:22:19:23 | access to local variable sp |
+| Slice.cs:20:22:20:30 | access to property Length | Slice.cs:20:22:20:23 | access to local variable sp |
+| Slice.cs:21:22:21:27 | access to property Length | Slice.cs:21:22:21:23 | access to local variable sp |

--- a/csharp/ql/test/library-tests/spans/slice.expected
+++ b/csharp/ql/test/library-tests/spans/slice.expected
@@ -1,34 +1,24 @@
-methodCalls
 | Slice.cs:8:20:8:26 | call to method Substring | Substring(int, int) | 0 | 1 |
-| Slice.cs:8:20:8:26 | call to method Substring | Substring(int, int) | 1 | access to parameter a - 1 |
+| Slice.cs:8:20:8:26 | call to method Substring | Substring(int, int) | 1 | access to parameter a |
 | Slice.cs:9:20:9:25 | call to method Substring | Substring(int, int) | 0 | 0 |
 | Slice.cs:9:20:9:25 | call to method Substring | Substring(int, int) | 1 | 2 |
 | Slice.cs:10:20:10:25 | call to method Substring | Substring(int, int) | 0 | 3 |
-| Slice.cs:10:20:10:25 | call to method Substring | Substring(int, int) | 1 | access to property Length - 3 |
+| Slice.cs:10:20:10:25 | call to method Substring | Substring(int, int) | 1 | ^0 |
 | Slice.cs:11:20:11:26 | call to method Substring | Substring(int, int) | 0 | 0 |
-| Slice.cs:11:20:11:26 | call to method Substring | Substring(int, int) | 1 | access to property Length - 4 |
+| Slice.cs:11:20:11:26 | call to method Substring | Substring(int, int) | 1 | ^4 |
 | Slice.cs:12:20:12:27 | call to method Substring | Substring(int, int) | 0 | access to parameter a |
-| Slice.cs:12:20:12:27 | call to method Substring | Substring(int, int) | 1 | access to property Length - access to parameter b - access to parameter a |
+| Slice.cs:12:20:12:27 | call to method Substring | Substring(int, int) | 1 | ^access to parameter b |
 | Slice.cs:13:20:13:24 | call to method Substring | Substring(int, int) | 0 | 0 |
-| Slice.cs:13:20:13:24 | call to method Substring | Substring(int, int) | 1 | access to property Length |
+| Slice.cs:13:20:13:24 | call to method Substring | Substring(int, int) | 1 | ^0 |
 | Slice.cs:16:22:16:29 | call to method Slice | Slice(int, int) | 0 | 5 |
-| Slice.cs:16:22:16:29 | call to method Slice | Slice(int, int) | 1 | access to parameter a - 5 |
+| Slice.cs:16:22:16:29 | call to method Slice | Slice(int, int) | 1 | access to parameter a |
 | Slice.cs:17:22:17:28 | call to method Slice | Slice(int, int) | 0 | 0 |
 | Slice.cs:17:22:17:28 | call to method Slice | Slice(int, int) | 1 | 6 |
 | Slice.cs:18:22:18:28 | call to method Slice | Slice(int, int) | 0 | 7 |
-| Slice.cs:18:22:18:28 | call to method Slice | Slice(int, int) | 1 | access to property Length - 7 |
+| Slice.cs:18:22:18:28 | call to method Slice | Slice(int, int) | 1 | ^0 |
 | Slice.cs:19:22:19:29 | call to method Slice | Slice(int, int) | 0 | 0 |
-| Slice.cs:19:22:19:29 | call to method Slice | Slice(int, int) | 1 | access to property Length - 8 |
+| Slice.cs:19:22:19:29 | call to method Slice | Slice(int, int) | 1 | ^8 |
 | Slice.cs:20:22:20:30 | call to method Slice | Slice(int, int) | 0 | access to parameter a |
-| Slice.cs:20:22:20:30 | call to method Slice | Slice(int, int) | 1 | access to property Length - access to parameter b - access to parameter a |
+| Slice.cs:20:22:20:30 | call to method Slice | Slice(int, int) | 1 | ^access to parameter b |
 | Slice.cs:21:22:21:27 | call to method Slice | Slice(int, int) | 0 | 0 |
-| Slice.cs:21:22:21:27 | call to method Slice | Slice(int, int) | 1 | access to property Length |
-propertyCalls
-| Slice.cs:10:20:10:25 | access to property Length | Slice.cs:10:20:10:20 | access to local variable s |
-| Slice.cs:11:20:11:26 | access to property Length | Slice.cs:11:20:11:20 | access to local variable s |
-| Slice.cs:12:20:12:27 | access to property Length | Slice.cs:12:20:12:20 | access to local variable s |
-| Slice.cs:13:20:13:24 | access to property Length | Slice.cs:13:20:13:20 | access to local variable s |
-| Slice.cs:18:22:18:28 | access to property Length | Slice.cs:18:22:18:23 | access to local variable sp |
-| Slice.cs:19:22:19:29 | access to property Length | Slice.cs:19:22:19:23 | access to local variable sp |
-| Slice.cs:20:22:20:30 | access to property Length | Slice.cs:20:22:20:23 | access to local variable sp |
-| Slice.cs:21:22:21:27 | access to property Length | Slice.cs:21:22:21:23 | access to local variable sp |
+| Slice.cs:21:22:21:27 | call to method Slice | Slice(int, int) | 1 | ^0 |

--- a/csharp/ql/test/library-tests/spans/slice.expected
+++ b/csharp/ql/test/library-tests/spans/slice.expected
@@ -1,0 +1,22 @@
+methodCalls
+| Slice.cs:8:20:8:26 | call to method Substring | Substring(int, int) | 0 | 1 |
+| Slice.cs:8:20:8:26 | call to method Substring | Substring(int, int) | 1 | access to parameter a - 1 |
+| Slice.cs:9:20:9:25 | call to method Substring | Substring(int, int) | 0 | 0 |
+| Slice.cs:9:20:9:25 | call to method Substring | Substring(int, int) | 1 | 2 |
+| Slice.cs:10:20:10:25 | call to method Substring | Substring(int, int) | 0 | 3 |
+| Slice.cs:10:20:10:25 | call to method Substring | Substring(int, int) | 1 | access to property Length - 3 |
+| Slice.cs:11:20:11:26 | call to method Substring | Substring(int, int) | 0 | 0 |
+| Slice.cs:11:20:11:26 | call to method Substring | Substring(int, int) | 1 | access to property Length - 4 |
+| Slice.cs:14:22:14:29 | call to method Slice | Slice(int, int) | 0 | 5 |
+| Slice.cs:14:22:14:29 | call to method Slice | Slice(int, int) | 1 | access to parameter a - 5 |
+| Slice.cs:15:22:15:28 | call to method Slice | Slice(int, int) | 0 | 0 |
+| Slice.cs:15:22:15:28 | call to method Slice | Slice(int, int) | 1 | 6 |
+| Slice.cs:16:22:16:28 | call to method Slice | Slice(int, int) | 0 | 7 |
+| Slice.cs:16:22:16:28 | call to method Slice | Slice(int, int) | 1 | access to property Length - 7 |
+| Slice.cs:17:22:17:29 | call to method Slice | Slice(int, int) | 0 | 0 |
+| Slice.cs:17:22:17:29 | call to method Slice | Slice(int, int) | 1 | access to property Length - 8 |
+propertyCalls
+| Slice.cs:10:20:10:25 | access to property Length | Slice.cs:10:20:10:20 | access to local variable s |
+| Slice.cs:11:20:11:26 | access to property Length | Slice.cs:11:20:11:20 | access to local variable s |
+| Slice.cs:16:22:16:28 | access to property Length | Slice.cs:16:22:16:23 | access to local variable sp |
+| Slice.cs:17:22:17:29 | access to property Length | Slice.cs:17:22:17:23 | access to local variable sp |

--- a/csharp/ql/test/library-tests/spans/slice.expected
+++ b/csharp/ql/test/library-tests/spans/slice.expected
@@ -1,3 +1,4 @@
+methodArguments
 | Slice.cs:8:20:8:26 | call to method Substring | Substring(int, int) | 0 | 1 |
 | Slice.cs:8:20:8:26 | call to method Substring | Substring(int, int) | 1 | access to parameter a |
 | Slice.cs:9:20:9:25 | call to method Substring | Substring(int, int) | 0 | 0 |
@@ -10,15 +11,29 @@
 | Slice.cs:12:20:12:27 | call to method Substring | Substring(int, int) | 1 | ^access to parameter b |
 | Slice.cs:13:20:13:24 | call to method Substring | Substring(int, int) | 0 | 0 |
 | Slice.cs:13:20:13:24 | call to method Substring | Substring(int, int) | 1 | ^0 |
-| Slice.cs:16:22:16:29 | call to method Slice | Slice(int, int) | 0 | 5 |
-| Slice.cs:16:22:16:29 | call to method Slice | Slice(int, int) | 1 | access to parameter a |
-| Slice.cs:17:22:17:28 | call to method Slice | Slice(int, int) | 0 | 0 |
-| Slice.cs:17:22:17:28 | call to method Slice | Slice(int, int) | 1 | 6 |
-| Slice.cs:18:22:18:28 | call to method Slice | Slice(int, int) | 0 | 7 |
-| Slice.cs:18:22:18:28 | call to method Slice | Slice(int, int) | 1 | ^0 |
-| Slice.cs:19:22:19:29 | call to method Slice | Slice(int, int) | 0 | 0 |
-| Slice.cs:19:22:19:29 | call to method Slice | Slice(int, int) | 1 | ^8 |
-| Slice.cs:20:22:20:30 | call to method Slice | Slice(int, int) | 0 | access to parameter a |
-| Slice.cs:20:22:20:30 | call to method Slice | Slice(int, int) | 1 | ^access to parameter b |
-| Slice.cs:21:22:21:27 | call to method Slice | Slice(int, int) | 0 | 0 |
-| Slice.cs:21:22:21:27 | call to method Slice | Slice(int, int) | 1 | ^0 |
+| Slice.cs:19:22:19:29 | call to method Slice | Slice(int, int) | 0 | 5 |
+| Slice.cs:19:22:19:29 | call to method Slice | Slice(int, int) | 1 | access to parameter a |
+| Slice.cs:20:22:20:28 | call to method Slice | Slice(int, int) | 0 | 0 |
+| Slice.cs:20:22:20:28 | call to method Slice | Slice(int, int) | 1 | 6 |
+| Slice.cs:21:22:21:28 | call to method Slice | Slice(int, int) | 0 | 7 |
+| Slice.cs:21:22:21:28 | call to method Slice | Slice(int, int) | 1 | ^0 |
+| Slice.cs:22:22:22:29 | call to method Slice | Slice(int, int) | 0 | 0 |
+| Slice.cs:22:22:22:29 | call to method Slice | Slice(int, int) | 1 | ^8 |
+| Slice.cs:23:22:23:30 | call to method Slice | Slice(int, int) | 0 | access to parameter a |
+| Slice.cs:23:22:23:30 | call to method Slice | Slice(int, int) | 1 | ^access to parameter b |
+| Slice.cs:24:22:24:27 | call to method Slice | Slice(int, int) | 0 | 0 |
+| Slice.cs:24:22:24:27 | call to method Slice | Slice(int, int) | 1 | ^0 |
+methodCalls
+| Slice.cs:3:14:3:14 | call to method <object initializer> | <object initializer>() |
+| Slice.cs:8:20:8:26 | call to method Substring | Substring(int, int) |
+| Slice.cs:9:20:9:25 | call to method Substring | Substring(int, int) |
+| Slice.cs:10:20:10:25 | call to method Substring | Substring(int, int) |
+| Slice.cs:11:20:11:26 | call to method Substring | Substring(int, int) |
+| Slice.cs:12:20:12:27 | call to method Substring | Substring(int, int) |
+| Slice.cs:13:20:13:24 | call to method Substring | Substring(int, int) |
+| Slice.cs:19:22:19:29 | call to method Slice | Slice(int, int) |
+| Slice.cs:20:22:20:28 | call to method Slice | Slice(int, int) |
+| Slice.cs:21:22:21:28 | call to method Slice | Slice(int, int) |
+| Slice.cs:22:22:22:29 | call to method Slice | Slice(int, int) |
+| Slice.cs:23:22:23:30 | call to method Slice | Slice(int, int) |
+| Slice.cs:24:22:24:27 | call to method Slice | Slice(int, int) |

--- a/csharp/ql/test/library-tests/spans/slice.expected
+++ b/csharp/ql/test/library-tests/spans/slice.expected
@@ -7,16 +7,22 @@ methodCalls
 | Slice.cs:10:20:10:25 | call to method Substring | Substring(int, int) | 1 | access to property Length - 3 |
 | Slice.cs:11:20:11:26 | call to method Substring | Substring(int, int) | 0 | 0 |
 | Slice.cs:11:20:11:26 | call to method Substring | Substring(int, int) | 1 | access to property Length - 4 |
-| Slice.cs:14:22:14:29 | call to method Slice | Slice(int, int) | 0 | 5 |
-| Slice.cs:14:22:14:29 | call to method Slice | Slice(int, int) | 1 | access to parameter a - 5 |
-| Slice.cs:15:22:15:28 | call to method Slice | Slice(int, int) | 0 | 0 |
-| Slice.cs:15:22:15:28 | call to method Slice | Slice(int, int) | 1 | 6 |
-| Slice.cs:16:22:16:28 | call to method Slice | Slice(int, int) | 0 | 7 |
-| Slice.cs:16:22:16:28 | call to method Slice | Slice(int, int) | 1 | access to property Length - 7 |
-| Slice.cs:17:22:17:29 | call to method Slice | Slice(int, int) | 0 | 0 |
-| Slice.cs:17:22:17:29 | call to method Slice | Slice(int, int) | 1 | access to property Length - 8 |
+| Slice.cs:12:20:12:27 | call to method Substring | Substring(int, int) | 0 | access to parameter a |
+| Slice.cs:12:20:12:27 | call to method Substring | Substring(int, int) | 1 | access to property Length - access to parameter b - access to parameter a |
+| Slice.cs:15:22:15:29 | call to method Slice | Slice(int, int) | 0 | 5 |
+| Slice.cs:15:22:15:29 | call to method Slice | Slice(int, int) | 1 | access to parameter a - 5 |
+| Slice.cs:16:22:16:28 | call to method Slice | Slice(int, int) | 0 | 0 |
+| Slice.cs:16:22:16:28 | call to method Slice | Slice(int, int) | 1 | 6 |
+| Slice.cs:17:22:17:28 | call to method Slice | Slice(int, int) | 0 | 7 |
+| Slice.cs:17:22:17:28 | call to method Slice | Slice(int, int) | 1 | access to property Length - 7 |
+| Slice.cs:18:22:18:29 | call to method Slice | Slice(int, int) | 0 | 0 |
+| Slice.cs:18:22:18:29 | call to method Slice | Slice(int, int) | 1 | access to property Length - 8 |
+| Slice.cs:19:22:19:30 | call to method Slice | Slice(int, int) | 0 | access to parameter a |
+| Slice.cs:19:22:19:30 | call to method Slice | Slice(int, int) | 1 | access to property Length - access to parameter b - access to parameter a |
 propertyCalls
 | Slice.cs:10:20:10:25 | access to property Length | Slice.cs:10:20:10:20 | access to local variable s |
 | Slice.cs:11:20:11:26 | access to property Length | Slice.cs:11:20:11:20 | access to local variable s |
-| Slice.cs:16:22:16:28 | access to property Length | Slice.cs:16:22:16:23 | access to local variable sp |
-| Slice.cs:17:22:17:29 | access to property Length | Slice.cs:17:22:17:23 | access to local variable sp |
+| Slice.cs:12:20:12:27 | access to property Length | Slice.cs:12:20:12:20 | access to local variable s |
+| Slice.cs:17:22:17:28 | access to property Length | Slice.cs:17:22:17:23 | access to local variable sp |
+| Slice.cs:18:22:18:29 | access to property Length | Slice.cs:18:22:18:23 | access to local variable sp |
+| Slice.cs:19:22:19:30 | access to property Length | Slice.cs:19:22:19:23 | access to local variable sp |

--- a/csharp/ql/test/library-tests/spans/slice.expected
+++ b/csharp/ql/test/library-tests/spans/slice.expected
@@ -31,9 +31,11 @@ methodCalls
 | Slice.cs:11:20:11:26 | call to method Substring | Substring(int, int) |
 | Slice.cs:12:20:12:27 | call to method Substring | Substring(int, int) |
 | Slice.cs:13:20:13:24 | call to method Substring | Substring(int, int) |
+| Slice.cs:16:20:16:27 | call to method Substring | Substring(int, int) |
 | Slice.cs:19:22:19:29 | call to method Slice | Slice(int, int) |
 | Slice.cs:20:22:20:28 | call to method Slice | Slice(int, int) |
 | Slice.cs:21:22:21:28 | call to method Slice | Slice(int, int) |
 | Slice.cs:22:22:22:29 | call to method Slice | Slice(int, int) |
 | Slice.cs:23:22:23:30 | call to method Slice | Slice(int, int) |
 | Slice.cs:24:22:24:27 | call to method Slice | Slice(int, int) |
+| Slice.cs:27:22:27:31 | call to method Slice | Slice(int, int) |

--- a/csharp/ql/test/library-tests/spans/slice.ql
+++ b/csharp/ql/test/library-tests/spans/slice.ql
@@ -3,7 +3,7 @@ import csharp
 private string printExpr(Expr e) {
   e =
     any(SubExpr sub |
-      result = sub.getLeftOperand().toString() + " - " + sub.getRightOperand().toString()
+      result = printExpr(sub.getLeftOperand()) + " - " + printExpr(sub.getRightOperand())
     )
   or
   not e instanceof SubExpr and

--- a/csharp/ql/test/library-tests/spans/slice.ql
+++ b/csharp/ql/test/library-tests/spans/slice.ql
@@ -7,7 +7,11 @@ private string printExpr(Expr e) {
   result = e.toString()
 }
 
-query predicate methodCalls(MethodCall mc, string m, int i, string arg) {
-  m = mc.getTarget().toStringWithTypes() and
+query predicate methodArguments(MethodCall mc, string target, int i, string arg) {
+  target = mc.getTarget().toStringWithTypes() and
   arg = printExpr(mc.getArgument(i))
+}
+
+query predicate methodCalls(MethodCall mc, string target) {
+  target = mc.getTarget().toStringWithTypes()
 }

--- a/csharp/ql/test/library-tests/spans/slice.ql
+++ b/csharp/ql/test/library-tests/spans/slice.ql
@@ -1,0 +1,18 @@
+import csharp
+
+private string printExpr(Expr e) {
+  e =
+    any(SubExpr sub |
+      result = sub.getLeftOperand().toString() + " - " + sub.getRightOperand().toString()
+    )
+  or
+  not e instanceof SubExpr and
+  result = e.toString()
+}
+
+query predicate methodCalls(MethodCall mc, string m, int i, string arg) {
+  m = mc.getTarget().toStringWithTypes() and
+  arg = printExpr(mc.getArgument(i))
+}
+
+query predicate propertyCalls(PropertyCall p, Expr qualifier) { qualifier = p.getQualifier() }

--- a/csharp/ql/test/library-tests/spans/slice.ql
+++ b/csharp/ql/test/library-tests/spans/slice.ql
@@ -1,12 +1,9 @@
 import csharp
 
 private string printExpr(Expr e) {
-  e =
-    any(SubExpr sub |
-      result = printExpr(sub.getLeftOperand()) + " - " + printExpr(sub.getRightOperand())
-    )
+  e = any(IndexExpr index | result = "^" + index.getExpr().toString())
   or
-  not e instanceof SubExpr and
+  not e instanceof IndexExpr and
   result = e.toString()
 }
 
@@ -14,5 +11,3 @@ query predicate methodCalls(MethodCall mc, string m, int i, string arg) {
   m = mc.getTarget().toStringWithTypes() and
   arg = printExpr(mc.getArgument(i))
 }
-
-query predicate propertyCalls(PropertyCall p, Expr qualifier) { qualifier = p.getQualifier() }

--- a/csharp/ql/test/query-tests/Telemetry/DatabaseQuality/IsNotOkayCall.expected
+++ b/csharp/ql/test/query-tests/Telemetry/DatabaseQuality/IsNotOkayCall.expected
@@ -1,2 +1,0 @@
-| Quality.cs:26:19:26:26 | access to indexer | Call without target $@. | Quality.cs:26:19:26:26 | access to indexer | access to indexer |
-| Quality.cs:29:21:29:27 | access to indexer | Call without target $@. | Quality.cs:29:21:29:27 | access to indexer | access to indexer |

--- a/csharp/ql/test/query-tests/Telemetry/DatabaseQuality/NoTarget.expected
+++ b/csharp/ql/test/query-tests/Telemetry/DatabaseQuality/NoTarget.expected
@@ -7,7 +7,5 @@
 | Quality.cs:20:13:20:23 | access to property MyProperty6 | Call without target $@. | Quality.cs:20:13:20:23 | access to property MyProperty6 | access to property MyProperty6 |
 | Quality.cs:23:9:23:14 | access to event Event1 | Call without target $@. | Quality.cs:23:9:23:14 | access to event Event1 | access to event Event1 |
 | Quality.cs:23:9:23:30 | delegate call | Call without target $@. | Quality.cs:23:9:23:30 | delegate call | delegate call |
-| Quality.cs:26:19:26:26 | access to indexer | Call without target $@. | Quality.cs:26:19:26:26 | access to indexer | access to indexer |
-| Quality.cs:29:21:29:27 | access to indexer | Call without target $@. | Quality.cs:29:21:29:27 | access to indexer | access to indexer |
 | Quality.cs:38:16:38:26 | access to property MyProperty2 | Call without target $@. | Quality.cs:38:16:38:26 | access to property MyProperty2 | access to property MyProperty2 |
 | Quality.cs:50:20:50:26 | object creation of type T | Call without target $@. | Quality.cs:50:20:50:26 | object creation of type T | object creation of type T |

--- a/csharp/ql/test/query-tests/Telemetry/DatabaseQuality/Quality.cs
+++ b/csharp/ql/test/query-tests/Telemetry/DatabaseQuality/Quality.cs
@@ -23,10 +23,10 @@ public class Test
         Event1.Invoke(this, 5);
 
         var str = "abcd";
-        var sub = str[..3];         // TODO: this is not an indexer call, but rather a `str.Substring(0, 3)` call.
+        var sub = str[..3];
 
         Span<int> sp = null;
-        var slice = sp[..3];        // TODO: this is not an indexer call, but rather a `sp.Slice(0, 3)` call.
+        var slice = sp[..3];
 
         Span<byte> guidBytes = stackalloc byte[16];
         guidBytes[08] = 1;


### PR DESCRIPTION
Improves the extraction of span access with range expressions (such as `a[1..3]`).

Roslyn translates `a[1..3]` into `a.Slice(1,3 - 1)` for spans (and something similar for strings).
In this PR we introduce some special handling in the extractor for such cases
- Instead of extracting an indexer access on `a` we extract a `a.Slice` method call.
- Instead of extracting the range expression, we use the range expression to synthesize call arguments for `a.Slice`.

Roslyn translates as follows
- `a[x..y]` is translated to `a.Slice(x, y - x)`.
- `a[..y]` is translated to `a.Slice(0, y)`
- `a[x..]` is translated to `a.Slice(x, a.Length - x)`.
- `a[..]` is translated to `a.Slice(0, a.Length)`.

It is also possible to use *read* *from* *the* *end* as well (e.g. `^2`).
- `a[x..^y]` translates into `a.Slice(x, a.Length - y - x)`.

Furthermore, it is worth noting that the range endpoints could be the result of a method call.
This means that if we want to fully synthesize `var a = f()[m() .. ^3]`, we would need to synthesize
```csharp
var q = f();
var x = m();
var a = q.Slice(x, q.Length - 3 - x);
```

For simplicity reasons, we choose to extract as follows
- `a[x..y]` is translated to `a.Slice(x, y)`.
- `a[..y]` is translated to `a.Slice(0, y)`
- `a[x..]` is translated to `a.Slice(x, ^0)`.
- `a[..]` is translated to `a.Slice(0, ^0)`.

This will make it possible to calculate the correct start index and length arguments in the QL side (if needed).

Similar to span access with range expressions, it is also possible to use range expressions in conjunction with strings. If `s` is a string, then `s[1..3]` translates into `s.Substring(1, 3 - 1)`. This is also handled in this PR.

Note, that ranges are only extracted as call arguments in case the range expression is present in conjunction with the indexer. For cases where the range argument is in e.g. a local variable - no call arguments are extracted. However, in practice it seems that mostly ranges are used directly with the indexer.
That is, for cases like the one below we are not extracting any call arguments.
```csharp
System.Range r;
var y = s[r]
```