### PR TITLE
Shared CFG: update `simpleLeafNode` to exclude those with additional leaf nodes

### DIFF
--- a/shared/controlflow/codeql/controlflow/ControlFlowGraph.qll
+++ b/shared/controlflow/codeql/controlflow/ControlFlowGraph.qll
@@ -640,6 +640,7 @@ module Make0<LocationSig Location, AstSig<Location> Ast> {
       Input1::cfgCachedStageRef() and
       not exists(getChild(n, _)) and
       not postOrInOrder(n) and
+      not additionalNode(n, _, _) and
       not inConditionalContext(n, _)
     }
 


### PR DESCRIPTION
This was motivated by go code like `var myvar int` which adds a zero-init node and an assignment node writing 0 to the variable.