### PR TITLE
C++: Model formatting functions with a `va_list` parameter

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/Printf.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/Printf.qll
@@ -70,6 +70,38 @@ private class Fprintf extends FormattingFunction, NonCppThrowingFunction instanc
 }
 
 /**
+ * The standard functions `vprintf`, `vwprintf` and their Microsoft variants.
+ */
+private class Vprintf extends VaListFormattingFunction, NonCppThrowingFunction instanceof TopLevelFunction
+{
+  Vprintf() {
+    (
+      this.hasGlobalOrStdOrBslName(["vprintf", "vwprintf"]) or
+      this.hasGlobalName(["_vprintf_l", "_vwprintf_l"])
+    ) and
+    not exists(this.getDefinition().getFile().getRelativePath())
+  }
+
+  override predicate isOutputGlobal() { any() }
+}
+
+/**
+ * The standard functions `vfprintf`, `vfwprintf` and their Microsoft variants.
+ */
+private class Vfprintf extends VaListFormattingFunction, NonCppThrowingFunction instanceof TopLevelFunction
+{
+  Vfprintf() {
+    (
+      this.hasGlobalOrStdOrBslName(["vfprintf", "vfwprintf"]) or
+      this.hasGlobalName(["_vfprintf_l", "_vfwprintf_l"])
+    ) and
+    not exists(this.getDefinition().getFile().getRelativePath())
+  }
+
+  override int getOutputParameterIndex(boolean isStream) { result = 0 and isStream = true }
+}
+
+/**
  * The standard function `sprintf` and its Microsoft and glib variants.
  */
 private class Sprintf extends FormattingFunction, NonCppThrowingFunction instanceof TopLevelFunction
@@ -110,6 +142,25 @@ private class Sprintf extends FormattingFunction, NonCppThrowingFunction instanc
     then result = 4
     else result = super.getFirstFormatArgumentIndex()
   }
+}
+
+/**
+ * The standard function `vsprintf` and its Microsoft variants.
+ */
+private class Vsprintf extends VaListFormattingFunction, NonCppThrowingFunction instanceof TopLevelFunction
+{
+  Vsprintf() {
+    (
+      this.hasGlobalOrStdOrBslName("vsprintf") or // vsprintf(dst, format, va_list)
+      this.hasGlobalName([
+          "_vsprintf_l", // _vsprintf_l(dst, format, locale, va_list)
+          "__vswprintf_l" // __vswprintf_l(dst, format, locale, va_list)
+        ])
+    ) and
+    not exists(this.getDefinition().getFile().getRelativePath())
+  }
+
+  override int getOutputParameterIndex(boolean isStream) { result = 0 and isStream = false }
 }
 
 /**
@@ -182,6 +233,94 @@ private class SnprintfImpl extends Snprintf, AliasFunction, SideEffectFunction,
   override predicate hasSpecificReadSideEffect(ParameterIndex i, boolean buffer) {
     // We don't know how many parameters are passed to the function since it's varargs, but they also have read side effects.
     i = this.getFormatParameterIndex() and buffer = true
+  }
+}
+
+/**
+ * The standard function `vsnprintf`, and its Microsoft variants.
+ */
+private class VsnprintfImpl extends Snprintf, VaListFormattingFunction, AliasFunction,
+  SideEffectFunction, NonCppThrowingFunction instanceof TopLevelFunction
+{
+  VsnprintfImpl() {
+    (
+      this.hasGlobalOrStdOrBslName("vsnprintf") // vsnprintf(dst, count, format, va_list)
+      or
+      this.hasGlobalName([
+          "vsnprintf_s", // vsnprintf_s(dst, size, count, format, va_list)
+          "vsprintf_s", // vsprintf_s(dst, size, format, va_list)
+          "vswprintf_s", // vswprintf_s(dst, size, format, va_list)
+          "_vsnprintf", // _vsnprintf(dst, count, format, va_list)
+          "_vsnprintf_l", // _vsnprintf_l(dst, count, format, locale, va_list)
+          "_vsnprintf_s", // _vsnprintf_s(dst, size, count, format, va_list)
+          "_vsnprintf_s_l", // _vsnprintf_s_l(dst, size, count, format, locale, va_list)
+          "_vsnwprintf", // _vsnwprintf(dst, count, format, va_list)
+          "_vsnwprintf_l", // _vsnwprintf_l(dst, count, format, locale, va_list)
+          "_vsnwprintf_s", // _vsnwprintf_s(dst, size, count, format, va_list)
+          "_vsnwprintf_s_l", // _vsnwprintf_s_l(dst, size, count, format, locale, va_list)
+          "_vsprintf_p", // _vsprintf_p(dst, size, format, va_list)
+          "_vsprintf_p_l", // _vsprintf_p_l(dst, size, format, locale, va_list)
+          "_vsprintf_s_l", // _vsprintf_s_l(dst, size, format, locale, va_list)
+          "_vswprintf_p", // _vswprintf_p(dst, count, format, va_list)
+          "_vswprintf_p_l", // _vswprintf_p_l(dst, count, format, locale, va_list)
+          "_vswprintf_s_l" // _vswprintf_s_l(dst, size, format, locale, va_list)
+        ])
+      or
+      this.hasGlobalOrStdOrBslName("vswprintf") and this.getNumberOfParameters() = 4
+      or
+      this.hasGlobalName("_vswprintf_l") and this.getNumberOfParameters() = 5
+    ) and
+    not exists(this.getDefinition().getFile().getRelativePath())
+  }
+
+  override int getOutputParameterIndex(boolean isStream) { result = 0 and isStream = false }
+
+  override int getSizeParameterIndex() { result = 1 }
+
+  override predicate returnsFullFormatLength() { this.hasName(["vsnprintf", "vsnprintf_s"]) }
+
+  override predicate parameterNeverEscapes(int index) {
+    index =
+      [
+        this.getOutputParameterIndex(false), this.getFormatParameterIndex(),
+        this.getVaListParameterIndex()
+      ]
+  }
+
+  override predicate parameterEscapesOnlyViaReturn(int index) { none() }
+
+  override predicate parameterIsAlwaysReturned(int index) { none() }
+
+  override predicate hasOnlySpecificReadSideEffects() { any() }
+
+  override predicate hasOnlySpecificWriteSideEffects() { any() }
+
+  override predicate hasSpecificWriteSideEffect(ParameterIndex i, boolean buffer, boolean mustWrite) {
+    i = this.getOutputParameterIndex(false) and buffer = true and mustWrite = false
+    or
+    i = this.getVaListParameterIndex() and buffer = false and mustWrite = false
+  }
+
+  override predicate hasSpecificReadSideEffect(ParameterIndex i, boolean buffer) {
+    i = this.getFormatParameterIndex() and buffer = true
+    or
+    i = this.getVaListParameterIndex() and buffer = false
+  }
+}
+
+/**
+ * The Microsoft `_vscprintf_p` functions and variants.
+ */
+private class Vscprintf extends VaListFormattingFunction, NonCppThrowingFunction instanceof TopLevelFunction
+{
+  Vscprintf() {
+    this.hasGlobalName([
+        "_vscprintf_p", // _vscprintf_p(format, va_list)
+        "_vscprintf_p_l", // _vscprintf_p_l(format, locale, va_list)
+        "_vscwprintf_p", // _vscwprintf_p(format, va_list)
+        "_vscwprintf_p_l" // _vscwprintf_p_l(format, locale, va_list)
+      ]) and
+    not exists(this.getDefinition().getFile().getRelativePath())
   }
 }
 

--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/Printf.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/Printf.qll
@@ -11,6 +11,23 @@ import semmle.code.cpp.models.interfaces.SideEffect
 import semmle.code.cpp.models.interfaces.NonThrowing
 
 /**
+ * A formatting function that takes its format arguments through a `va_list` parameter.
+ */
+abstract private class VaListFormattingFunction extends FormattingFunction {
+  final override int getFirstFormatArgumentIndex() { none() }
+
+  final int getVaListParameterIndex() { result = this.getNumberOfParameters() - 1 }
+
+  private predicate hasLocaleParameter() { this.getName().matches("%\\_l") }
+
+  final override int getFormatParameterIndex() {
+    if this.hasLocaleParameter()
+    then result = this.getVaListParameterIndex() - 2
+    else result = this.getVaListParameterIndex() - 1
+  }
+}
+
+/**
  * The standard functions `printf`, `wprintf` and their glib variants.
  */
 private class Printf extends FormattingFunction, AliasFunction, NonCppThrowingFunction instanceof TopLevelFunction

--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/Printf.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/Printf.qll
@@ -13,9 +13,9 @@ import semmle.code.cpp.models.interfaces.NonThrowing
 /**
  * The standard functions `printf`, `wprintf` and their glib variants.
  */
-private class Printf extends FormattingFunction, AliasFunction, NonCppThrowingFunction {
+private class Printf extends FormattingFunction, AliasFunction, NonCppThrowingFunction instanceof TopLevelFunction
+{
   Printf() {
-    this instanceof TopLevelFunction and
     (
       this.hasGlobalOrStdOrBslName(["printf", "wprintf"]) or
       this.hasGlobalName(["printf_s", "wprintf_s", "g_printf"])
@@ -37,9 +37,9 @@ private class Printf extends FormattingFunction, AliasFunction, NonCppThrowingFu
 /**
  * The standard functions `fprintf`, `fwprintf` and their glib variants.
  */
-private class Fprintf extends FormattingFunction, NonCppThrowingFunction {
+private class Fprintf extends FormattingFunction, NonCppThrowingFunction instanceof TopLevelFunction
+{
   Fprintf() {
-    this instanceof TopLevelFunction and
     (
       this.hasGlobalOrStdOrBslName(["fprintf", "fwprintf"]) or
       this.hasGlobalName("g_fprintf")
@@ -55,9 +55,9 @@ private class Fprintf extends FormattingFunction, NonCppThrowingFunction {
 /**
  * The standard function `sprintf` and its Microsoft and glib variants.
  */
-private class Sprintf extends FormattingFunction, NonCppThrowingFunction {
+private class Sprintf extends FormattingFunction, NonCppThrowingFunction instanceof TopLevelFunction
+{
   Sprintf() {
-    this instanceof TopLevelFunction and
     (
       this.hasGlobalOrStdOrBslName([
           "sprintf", // sprintf(dst, format, args...)
@@ -99,10 +99,9 @@ private class Sprintf extends FormattingFunction, NonCppThrowingFunction {
  * Implements `Snprintf`.
  */
 private class SnprintfImpl extends Snprintf, AliasFunction, SideEffectFunction,
-  NonCppThrowingFunction
+  NonCppThrowingFunction instanceof TopLevelFunction
 {
   SnprintfImpl() {
-    this instanceof TopLevelFunction and
     (
       this.hasGlobalOrStdOrBslName([
           "snprintf", // C99 defines snprintf
@@ -175,9 +174,8 @@ private class SnprintfImpl extends Snprintf, AliasFunction, SideEffectFunction,
  *      and
  *      https://learn.microsoft.com/en-us/previous-versions/windows/embedded/ms860435(v=msdn.10)
  */
-private class StringCchPrintf extends FormattingFunction {
+private class StringCchPrintf extends FormattingFunction instanceof TopLevelFunction {
   StringCchPrintf() {
-    this instanceof TopLevelFunction and
     exists(string baseName |
       baseName in [
           "StringCchPrintf", //StringCchPrintf(pszDest, cchDest, pszFormat, ...)
@@ -207,9 +205,8 @@ private class StringCchPrintf extends FormattingFunction {
 /**
  * The standard function `syslog`.
  */
-private class Syslog extends FormattingFunction, NonCppThrowingFunction {
+private class Syslog extends FormattingFunction, NonCppThrowingFunction instanceof TopLevelFunction {
   Syslog() {
-    this instanceof TopLevelFunction and
     this.hasGlobalName("syslog") and
     not exists(this.getDefinition().getFile().getRelativePath())
   }

--- a/cpp/ql/lib/semmle/code/cpp/models/interfaces/FormattingFunction.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/interfaces/FormattingFunction.qll
@@ -42,21 +42,6 @@ private Type getAFormatterWideTypeOrDefault() {
  * A standard library function that uses a `printf`-like formatting string.
  */
 abstract class FormattingFunction extends ArrayFunction, TaintFunction {
-  int firstFormatArgumentIndex;
-
-  FormattingFunction() {
-    firstFormatArgumentIndex > 0 and
-    if this.hasDefinition()
-    then firstFormatArgumentIndex = this.getDefinition().getNumberOfParameters()
-    else
-      if this instanceof BuiltInFunction
-      then firstFormatArgumentIndex = this.getNumberOfParameters()
-      else
-        forex(FunctionDeclarationEntry fde | fde = this.getAnExplicitDeclarationEntry() |
-          firstFormatArgumentIndex = fde.getNumberOfParameters()
-        )
-  }
-
   /** Gets the position at which the format parameter occurs. */
   abstract int getFormatParameterIndex();
 
@@ -135,8 +120,21 @@ abstract class FormattingFunction extends ArrayFunction, TaintFunction {
    * Gets the position of the first format argument, corresponding with
    * the first format specifier in the format string. We ignore all
    * implicit function definitions.
+   *
+   * There is no result if the formatting function takes a `va_list` argument.
    */
-  int getFirstFormatArgumentIndex() { result = firstFormatArgumentIndex }
+  int getFirstFormatArgumentIndex() {
+    result > 0 and
+    if this.hasDefinition()
+    then result = this.getDefinition().getNumberOfParameters()
+    else
+      if this instanceof BuiltInFunction
+      then result = this.getNumberOfParameters()
+      else
+        forex(FunctionDeclarationEntry fde | fde = this.getAnExplicitDeclarationEntry() |
+          result = fde.getNumberOfParameters()
+        )
+  }
 
   /**
    * Gets the position of the buffer size argument, if any.

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/funcs/funcsLocal.c
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/funcs/funcsLocal.c
@@ -59,3 +59,70 @@ int main(int argc, char **argv) {
 
 	return 0;
 }
+
+typedef void *va_list;
+typedef void *_locale_t;
+
+int vprintf(const char *format, va_list argptr);
+int _vprintf_l(const char *format, _locale_t locale, va_list argptr);
+
+int vfprintf(FILE *stream, const char *format, va_list argptr);
+int _vfprintf_l(FILE *stream, const char *format, _locale_t locale, va_list argptr);
+
+int vsnprintf(char *buffer, size_t count, const char *format, va_list argptr);
+int _vsnprintf(char *buffer, size_t count, const char *format, va_list argptr);
+int _vsnprintf_l(char *buffer, size_t count, const char *format, _locale_t locale, va_list argptr);
+
+int vsnprintf_s(
+	char *buffer, size_t sizeOfBuffer, size_t count, const char *format, va_list argptr
+);
+int _vsnprintf_s(
+	char *buffer, size_t sizeOfBuffer, size_t count, const char *format, va_list argptr
+);
+int _vsnprintf_s_l(
+	char *buffer, size_t sizeOfBuffer, size_t count, const char *format, _locale_t locale,
+	va_list argptr
+);
+
+int vsprintf(char *buffer, const char *format, va_list argptr);
+int _vsprintf_l(char *buffer, const char *format, _locale_t locale, va_list argptr);
+
+int _vsprintf_p(char *buffer, size_t sizeInBytes, const char *format, va_list argptr);
+int _vsprintf_p_l(
+	char *buffer, size_t sizeInBytes, const char *format, _locale_t locale, va_list argptr
+);
+
+int vsprintf_s(char *buffer, size_t numberOfElements, const char *format, va_list argptr);
+int _vsprintf_s_l(
+	char *buffer, size_t numberOfElements, const char *format, _locale_t locale, va_list argptr
+);
+
+int _vscprintf_p(const char *format, va_list argptr);
+int _vscprintf_p_l(const char *format, _locale_t locale, va_list argptr);
+
+void test() {
+	// BAD: User input flowing to various printf-like functions.
+	char fmt[1024];
+	char out[1024];
+	va_list args = 0;
+	_locale_t locale = 0;
+	fread(fmt, sizeof(char), 1024, f);
+	vprintf(fmt, args); // BAD
+	_vprintf_l(fmt, locale, args); // BAD
+	vfprintf(f, fmt, args); // BAD
+	_vfprintf_l(f, fmt, locale, args); // BAD
+	vsnprintf(out, 1024, fmt, args); // BAD
+	_vsnprintf(out, 1024, fmt, args); // BAD
+	_vsnprintf_l(out, 1024, fmt, locale, args); // BAD
+	vsnprintf_s(out, 1024, 1024, fmt, args); // BAD
+	_vsnprintf_s(out, 1024, 1024, fmt, args); // BAD
+	_vsnprintf_s_l(out, 1024, 1024, fmt, locale, args); // BAD
+	vsprintf(out, fmt, args); // BAD
+	_vsprintf_l(out, fmt, locale, args); // BAD
+	_vsprintf_p(out, 1024, fmt, args); // BAD
+	_vsprintf_p_l(out, 1024, fmt, locale, args); // BAD
+	vsprintf_s(out, 1024, fmt, args); // BAD
+	_vsprintf_s_l(out, 1024, fmt, locale, args); // BAD
+	_vscprintf_p(fmt, args); // BAD
+	_vscprintf_p_l(fmt, locale, args); // BAD
+}

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/funcs/funcsLocal.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/funcs/funcsLocal.expected
@@ -11,6 +11,24 @@ edges
 | funcsLocal.c:52:2:52:16 | *... = ... | funcsLocal.c:53:9:53:11 | ** ... | provenance |  |
 | funcsLocal.c:52:8:52:11 | *call to gets | funcsLocal.c:52:2:52:16 | *... = ... | provenance |  |
 | funcsLocal.c:57:2:57:14 | ... = ... | funcsLocal.c:58:9:58:10 | *e1 | provenance |  |
+| funcsLocal.c:109:8:109:10 | fread output argument | funcsLocal.c:110:10:110:12 | *fmt | provenance |  |
+| funcsLocal.c:109:8:109:10 | fread output argument | funcsLocal.c:111:13:111:15 | *fmt | provenance |  |
+| funcsLocal.c:109:8:109:10 | fread output argument | funcsLocal.c:112:14:112:16 | *fmt | provenance |  |
+| funcsLocal.c:109:8:109:10 | fread output argument | funcsLocal.c:113:17:113:19 | *fmt | provenance |  |
+| funcsLocal.c:109:8:109:10 | fread output argument | funcsLocal.c:114:23:114:25 | *fmt | provenance |  |
+| funcsLocal.c:109:8:109:10 | fread output argument | funcsLocal.c:115:24:115:26 | *fmt | provenance |  |
+| funcsLocal.c:109:8:109:10 | fread output argument | funcsLocal.c:116:26:116:28 | *fmt | provenance |  |
+| funcsLocal.c:109:8:109:10 | fread output argument | funcsLocal.c:117:31:117:33 | *fmt | provenance |  |
+| funcsLocal.c:109:8:109:10 | fread output argument | funcsLocal.c:118:32:118:34 | *fmt | provenance |  |
+| funcsLocal.c:109:8:109:10 | fread output argument | funcsLocal.c:119:34:119:36 | *fmt | provenance |  |
+| funcsLocal.c:109:8:109:10 | fread output argument | funcsLocal.c:120:16:120:18 | *fmt | provenance |  |
+| funcsLocal.c:109:8:109:10 | fread output argument | funcsLocal.c:121:19:121:21 | *fmt | provenance |  |
+| funcsLocal.c:109:8:109:10 | fread output argument | funcsLocal.c:122:25:122:27 | *fmt | provenance |  |
+| funcsLocal.c:109:8:109:10 | fread output argument | funcsLocal.c:123:27:123:29 | *fmt | provenance |  |
+| funcsLocal.c:109:8:109:10 | fread output argument | funcsLocal.c:124:24:124:26 | *fmt | provenance |  |
+| funcsLocal.c:109:8:109:10 | fread output argument | funcsLocal.c:125:27:125:29 | *fmt | provenance |  |
+| funcsLocal.c:109:8:109:10 | fread output argument | funcsLocal.c:126:15:126:17 | *fmt | provenance |  |
+| funcsLocal.c:109:8:109:10 | fread output argument | funcsLocal.c:127:17:127:19 | *fmt | provenance |  |
 nodes
 | funcsLocal.c:16:8:16:9 | fread output argument | semmle.label | fread output argument |
 | funcsLocal.c:17:9:17:10 | *i1 | semmle.label | *i1 |
@@ -31,6 +49,25 @@ nodes
 | funcsLocal.c:53:9:53:11 | ** ... | semmle.label | ** ... |
 | funcsLocal.c:57:2:57:14 | ... = ... | semmle.label | ... = ... |
 | funcsLocal.c:58:9:58:10 | *e1 | semmle.label | *e1 |
+| funcsLocal.c:109:8:109:10 | fread output argument | semmle.label | fread output argument |
+| funcsLocal.c:110:10:110:12 | *fmt | semmle.label | *fmt |
+| funcsLocal.c:111:13:111:15 | *fmt | semmle.label | *fmt |
+| funcsLocal.c:112:14:112:16 | *fmt | semmle.label | *fmt |
+| funcsLocal.c:113:17:113:19 | *fmt | semmle.label | *fmt |
+| funcsLocal.c:114:23:114:25 | *fmt | semmle.label | *fmt |
+| funcsLocal.c:115:24:115:26 | *fmt | semmle.label | *fmt |
+| funcsLocal.c:116:26:116:28 | *fmt | semmle.label | *fmt |
+| funcsLocal.c:117:31:117:33 | *fmt | semmle.label | *fmt |
+| funcsLocal.c:118:32:118:34 | *fmt | semmle.label | *fmt |
+| funcsLocal.c:119:34:119:36 | *fmt | semmle.label | *fmt |
+| funcsLocal.c:120:16:120:18 | *fmt | semmle.label | *fmt |
+| funcsLocal.c:121:19:121:21 | *fmt | semmle.label | *fmt |
+| funcsLocal.c:122:25:122:27 | *fmt | semmle.label | *fmt |
+| funcsLocal.c:123:27:123:29 | *fmt | semmle.label | *fmt |
+| funcsLocal.c:124:24:124:26 | *fmt | semmle.label | *fmt |
+| funcsLocal.c:125:27:125:29 | *fmt | semmle.label | *fmt |
+| funcsLocal.c:126:15:126:17 | *fmt | semmle.label | *fmt |
+| funcsLocal.c:127:17:127:19 | *fmt | semmle.label | *fmt |
 subpaths
 #select
 | funcsLocal.c:17:9:17:10 | *i1 | funcsLocal.c:16:8:16:9 | fread output argument | funcsLocal.c:17:9:17:10 | *i1 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | funcsLocal.c:16:8:16:9 | fread output argument | string read by fread |
@@ -41,3 +78,21 @@ subpaths
 | funcsLocal.c:47:9:47:11 | ** ... | funcsLocal.c:46:7:46:9 | gets output argument | funcsLocal.c:47:9:47:11 | ** ... | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | funcsLocal.c:46:7:46:9 | gets output argument | string read by gets |
 | funcsLocal.c:53:9:53:11 | ** ... | funcsLocal.c:52:8:52:11 | *call to gets | funcsLocal.c:53:9:53:11 | ** ... | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | funcsLocal.c:52:8:52:11 | *call to gets | string read by gets |
 | funcsLocal.c:58:9:58:10 | *e1 | funcsLocal.c:16:8:16:9 | fread output argument | funcsLocal.c:58:9:58:10 | *e1 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | funcsLocal.c:16:8:16:9 | fread output argument | string read by fread |
+| funcsLocal.c:110:10:110:12 | *fmt | funcsLocal.c:109:8:109:10 | fread output argument | funcsLocal.c:110:10:110:12 | *fmt | The value of this argument may come from $@ and is being used as a formatting argument to vprintf(format). | funcsLocal.c:109:8:109:10 | fread output argument | string read by fread |
+| funcsLocal.c:111:13:111:15 | *fmt | funcsLocal.c:109:8:109:10 | fread output argument | funcsLocal.c:111:13:111:15 | *fmt | The value of this argument may come from $@ and is being used as a formatting argument to _vprintf_l(format). | funcsLocal.c:109:8:109:10 | fread output argument | string read by fread |
+| funcsLocal.c:112:14:112:16 | *fmt | funcsLocal.c:109:8:109:10 | fread output argument | funcsLocal.c:112:14:112:16 | *fmt | The value of this argument may come from $@ and is being used as a formatting argument to vfprintf(format). | funcsLocal.c:109:8:109:10 | fread output argument | string read by fread |
+| funcsLocal.c:113:17:113:19 | *fmt | funcsLocal.c:109:8:109:10 | fread output argument | funcsLocal.c:113:17:113:19 | *fmt | The value of this argument may come from $@ and is being used as a formatting argument to _vfprintf_l(format). | funcsLocal.c:109:8:109:10 | fread output argument | string read by fread |
+| funcsLocal.c:114:23:114:25 | *fmt | funcsLocal.c:109:8:109:10 | fread output argument | funcsLocal.c:114:23:114:25 | *fmt | The value of this argument may come from $@ and is being used as a formatting argument to vsnprintf(format). | funcsLocal.c:109:8:109:10 | fread output argument | string read by fread |
+| funcsLocal.c:115:24:115:26 | *fmt | funcsLocal.c:109:8:109:10 | fread output argument | funcsLocal.c:115:24:115:26 | *fmt | The value of this argument may come from $@ and is being used as a formatting argument to _vsnprintf(format). | funcsLocal.c:109:8:109:10 | fread output argument | string read by fread |
+| funcsLocal.c:116:26:116:28 | *fmt | funcsLocal.c:109:8:109:10 | fread output argument | funcsLocal.c:116:26:116:28 | *fmt | The value of this argument may come from $@ and is being used as a formatting argument to _vsnprintf_l(format). | funcsLocal.c:109:8:109:10 | fread output argument | string read by fread |
+| funcsLocal.c:117:31:117:33 | *fmt | funcsLocal.c:109:8:109:10 | fread output argument | funcsLocal.c:117:31:117:33 | *fmt | The value of this argument may come from $@ and is being used as a formatting argument to vsnprintf_s(format). | funcsLocal.c:109:8:109:10 | fread output argument | string read by fread |
+| funcsLocal.c:118:32:118:34 | *fmt | funcsLocal.c:109:8:109:10 | fread output argument | funcsLocal.c:118:32:118:34 | *fmt | The value of this argument may come from $@ and is being used as a formatting argument to _vsnprintf_s(format). | funcsLocal.c:109:8:109:10 | fread output argument | string read by fread |
+| funcsLocal.c:119:34:119:36 | *fmt | funcsLocal.c:109:8:109:10 | fread output argument | funcsLocal.c:119:34:119:36 | *fmt | The value of this argument may come from $@ and is being used as a formatting argument to _vsnprintf_s_l(format). | funcsLocal.c:109:8:109:10 | fread output argument | string read by fread |
+| funcsLocal.c:120:16:120:18 | *fmt | funcsLocal.c:109:8:109:10 | fread output argument | funcsLocal.c:120:16:120:18 | *fmt | The value of this argument may come from $@ and is being used as a formatting argument to vsprintf(format). | funcsLocal.c:109:8:109:10 | fread output argument | string read by fread |
+| funcsLocal.c:121:19:121:21 | *fmt | funcsLocal.c:109:8:109:10 | fread output argument | funcsLocal.c:121:19:121:21 | *fmt | The value of this argument may come from $@ and is being used as a formatting argument to _vsprintf_l(format). | funcsLocal.c:109:8:109:10 | fread output argument | string read by fread |
+| funcsLocal.c:122:25:122:27 | *fmt | funcsLocal.c:109:8:109:10 | fread output argument | funcsLocal.c:122:25:122:27 | *fmt | The value of this argument may come from $@ and is being used as a formatting argument to _vsprintf_p(format). | funcsLocal.c:109:8:109:10 | fread output argument | string read by fread |
+| funcsLocal.c:123:27:123:29 | *fmt | funcsLocal.c:109:8:109:10 | fread output argument | funcsLocal.c:123:27:123:29 | *fmt | The value of this argument may come from $@ and is being used as a formatting argument to _vsprintf_p_l(format). | funcsLocal.c:109:8:109:10 | fread output argument | string read by fread |
+| funcsLocal.c:124:24:124:26 | *fmt | funcsLocal.c:109:8:109:10 | fread output argument | funcsLocal.c:124:24:124:26 | *fmt | The value of this argument may come from $@ and is being used as a formatting argument to vsprintf_s(format). | funcsLocal.c:109:8:109:10 | fread output argument | string read by fread |
+| funcsLocal.c:125:27:125:29 | *fmt | funcsLocal.c:109:8:109:10 | fread output argument | funcsLocal.c:125:27:125:29 | *fmt | The value of this argument may come from $@ and is being used as a formatting argument to _vsprintf_s_l(format). | funcsLocal.c:109:8:109:10 | fread output argument | string read by fread |
+| funcsLocal.c:126:15:126:17 | *fmt | funcsLocal.c:109:8:109:10 | fread output argument | funcsLocal.c:126:15:126:17 | *fmt | The value of this argument may come from $@ and is being used as a formatting argument to _vscprintf_p(format). | funcsLocal.c:109:8:109:10 | fread output argument | string read by fread |
+| funcsLocal.c:127:17:127:19 | *fmt | funcsLocal.c:109:8:109:10 | fread output argument | funcsLocal.c:127:17:127:19 | *fmt | The value of this argument may come from $@ and is being used as a formatting argument to _vscprintf_p_l(format). | funcsLocal.c:109:8:109:10 | fread output argument | string read by fread |


### PR DESCRIPTION
This PR adds models for a bunch of formatting functions that take a `va_list` parameter rather than being defined using `...` varargs.

Commit-by-commit review recommended.