### PR TITLE
Swift: Extend swift/weak-sensitive-data-hashing, swift/weak-password-hashing sinks

### DIFF
--- a/swift/ql/lib/codeql/swift/security/WeakPasswordHashingExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/WeakPasswordHashingExtensions.qll
@@ -121,7 +121,7 @@ private class WeakPasswordHashingMetatypeSink extends WeakPasswordHashingSink {
     exists(CallExpr c |
       c.getAnArgument().getExpr() = this.asExpr() and
       algorithm = ["SHA256", "SHA384", "SHA512"] and
-      c.getQualifier().getType().getFullName() = algorithm + ".Type" and
+      c.getQualifier().getType().getFullName() = algorithm + ["", ".Type"] and
       c.getStaticTarget().getName() = ["hash(data:)", "update(data:)", "update(bufferPointer:)"]
     )
   }

--- a/swift/ql/lib/codeql/swift/security/WeakPasswordHashingExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/WeakPasswordHashingExtensions.qll
@@ -112,6 +112,24 @@ private class DefaultWeakPasswordHashingSink extends WeakPasswordHashingSink {
 }
 
 /**
+ * A sink for weak password hashing through a call with a metatype qualifier.
+ */
+private class WeakPasswordHashingMetatypeSink extends WeakPasswordHashingSink {
+  string algorithm;
+
+  WeakPasswordHashingMetatypeSink() {
+    exists(CallExpr c |
+      c.getAnArgument().getExpr() = this.asExpr() and
+      algorithm = ["SHA256", "SHA384", "SHA512"] and
+      c.getQualifier().getType().getFullName() = algorithm + ".Type" and
+      c.getStaticTarget().getName() = ["hash(data:)", "update(data:)", "update(bufferPointer:)"]
+    )
+  }
+
+  override string getAlgorithm() { result = algorithm }
+}
+
+/**
  * A barrier for weak password hashing, when it occurs inside of
  * certain cryptographic algorithms as part of their design.
  */

--- a/swift/ql/lib/codeql/swift/security/WeakPasswordHashingExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/WeakPasswordHashingExtensions.qll
@@ -125,7 +125,8 @@ private class WeakPasswordHashingMetatypeSink extends WeakPasswordHashingSink {
       c.getAnArgument().getExpr() = this.asExpr() and
       algorithm = ["SHA256", "SHA384", "SHA512"] and
       c.getQualifier().getType().getFullName() = algorithm + ["", ".Type"] and
-      c.getStaticTarget().getName() = ["hash(data:)", "hash(bufferPointer:)", "update(data:)", "update(bufferPointer:)"]
+      c.getStaticTarget().getName() =
+        ["hash(data:)", "hash(bufferPointer:)", "update(data:)", "update(bufferPointer:)"]
     )
   }
 

--- a/swift/ql/lib/codeql/swift/security/WeakPasswordHashingExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/WeakPasswordHashingExtensions.qll
@@ -54,12 +54,15 @@ private class WeakSensitiveDataHashingSinks extends SinkModelCsv {
         // CryptoKit
         // (SHA-256, SHA-384 and SHA-512 are all variants of the SHA-2 algorithm)
         ";SHA256;true;hash(data:);;;Argument[0];weak-password-hash-input-SHA256",
+        ";SHA256;true;hash(bufferPointer:);;;Argument[0];weak-password-hash-input-SHA256",
         ";SHA256;true;update(data:);;;Argument[0];weak-password-hash-input-SHA256",
         ";SHA256;true;update(bufferPointer:);;;Argument[0];weak-password-hash-input-SHA256",
         ";SHA384;true;hash(data:);;;Argument[0];weak-password-hash-input-SHA384",
+        ";SHA384;true;hash(bufferPointer:);;;Argument[0];weak-password-hash-input-SHA384",
         ";SHA384;true;update(data:);;;Argument[0];weak-password-hash-input-SHA384",
         ";SHA384;true;update(bufferPointer:);;;Argument[0];weak-password-hash-input-SHA384",
         ";SHA512;true;hash(data:);;;Argument[0];weak-password-hash-input-SHA512",
+        ";SHA512;true;hash(bufferPointer:);;;Argument[0];weak-password-hash-input-SHA512",
         ";SHA512;true;update(data:);;;Argument[0];weak-password-hash-input-SHA512",
         ";SHA512;true;update(bufferPointer:);;;Argument[0];weak-password-hash-input-SHA512",
         // CryptoSwift
@@ -122,7 +125,7 @@ private class WeakPasswordHashingMetatypeSink extends WeakPasswordHashingSink {
       c.getAnArgument().getExpr() = this.asExpr() and
       algorithm = ["SHA256", "SHA384", "SHA512"] and
       c.getQualifier().getType().getFullName() = algorithm + ["", ".Type"] and
-      c.getStaticTarget().getName() = ["hash(data:)", "update(data:)", "update(bufferPointer:)"]
+      c.getStaticTarget().getName() = ["hash(data:)", "hash(bufferPointer:)", "update(data:)", "update(bufferPointer:)"]
     )
   }
 

--- a/swift/ql/lib/codeql/swift/security/WeakSensitiveDataHashingExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/WeakSensitiveDataHashingExtensions.qll
@@ -90,7 +90,8 @@ private class WeakSenitiveDataHashingMetatypeSink extends WeakSensitiveDataHashi
       c.getAnArgument().getExpr() = this.asExpr() and
       algorithm = ["MD5", "SHA1"] and
       c.getQualifier().getType().getFullName() = "Insecure." + algorithm + ["", ".Type"] and
-      c.getStaticTarget().getName() = ["hash(data:)", "hash(bufferPointer:)", "update(data:)", "update(bufferPointer:)"]
+      c.getStaticTarget().getName() =
+        ["hash(data:)", "hash(bufferPointer:)", "update(data:)", "update(bufferPointer:)"]
     )
   }
 

--- a/swift/ql/lib/codeql/swift/security/WeakSensitiveDataHashingExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/WeakSensitiveDataHashingExtensions.qll
@@ -76,3 +76,21 @@ private class DefaultWeakSenitiveDataHashingSink extends WeakSensitiveDataHashin
 
   override string getAlgorithm() { result = algorithm }
 }
+
+/**
+ * A sink for weak sensitive data hashing through a call with a metatype qualifier.
+ */
+private class WeakSenitiveDataHashingMetatypeSink extends WeakSensitiveDataHashingSink {
+  string algorithm;
+
+  WeakSenitiveDataHashingMetatypeSink() {
+    exists(CallExpr c |
+      c.getAnArgument().getExpr() = this.asExpr() and
+      algorithm = ["MD5", "SHA1"] and
+      c.getQualifier().getType().getFullName() = "Insecure." + algorithm + ".Type" and
+      c.getStaticTarget().getName() = ["hash(data:)", "update(data:)", "update(bufferPointer:)"]
+    )
+  }
+
+  override string getAlgorithm() { result = algorithm }
+}

--- a/swift/ql/lib/codeql/swift/security/WeakSensitiveDataHashingExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/WeakSensitiveDataHashingExtensions.qll
@@ -87,7 +87,7 @@ private class WeakSenitiveDataHashingMetatypeSink extends WeakSensitiveDataHashi
     exists(CallExpr c |
       c.getAnArgument().getExpr() = this.asExpr() and
       algorithm = ["MD5", "SHA1"] and
-      c.getQualifier().getType().getFullName() = "Insecure." + algorithm + ".Type" and
+      c.getQualifier().getType().getFullName() = "Insecure." + algorithm + ["", ".Type"] and
       c.getStaticTarget().getName() = ["hash(data:)", "update(data:)", "update(bufferPointer:)"]
     )
   }

--- a/swift/ql/lib/codeql/swift/security/WeakSensitiveDataHashingExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/WeakSensitiveDataHashingExtensions.qll
@@ -40,9 +40,11 @@ private class WeakSensitiveDataHashingSinks extends SinkModelCsv {
       [
         // CryptoKit
         ";Insecure.MD5;true;hash(data:);;;Argument[0];weak-hash-input-MD5",
+        ";Insecure.MD5;true;hash(bufferPointer:);;;Argument[0];weak-hash-input-MD5",
         ";Insecure.MD5;true;update(data:);;;Argument[0];weak-hash-input-MD5",
         ";Insecure.MD5;true;update(bufferPointer:);;;Argument[0];weak-hash-input-MD5",
         ";Insecure.SHA1;true;hash(data:);;;Argument[0];weak-hash-input-SHA1",
+        ";Insecure.SHA1;true;hash(bufferPointer:);;;Argument[0];weak-hash-input-SHA1",
         ";Insecure.SHA1;true;update(data:);;;Argument[0];weak-hash-input-SHA1",
         ";Insecure.SHA1;true;update(bufferPointer:);;;Argument[0];weak-hash-input-SHA1",
         // CryptoSwift
@@ -88,7 +90,7 @@ private class WeakSenitiveDataHashingMetatypeSink extends WeakSensitiveDataHashi
       c.getAnArgument().getExpr() = this.asExpr() and
       algorithm = ["MD5", "SHA1"] and
       c.getQualifier().getType().getFullName() = "Insecure." + algorithm + ["", ".Type"] and
-      c.getStaticTarget().getName() = ["hash(data:)", "update(data:)", "update(bufferPointer:)"]
+      c.getStaticTarget().getName() = ["hash(data:)", "hash(bufferPointer:)", "update(data:)", "update(bufferPointer:)"]
     )
   }
 

--- a/swift/ql/lib/codeql/swift/security/WeakSensitiveDataHashingExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/WeakSensitiveDataHashingExtensions.qll
@@ -71,10 +71,10 @@ private class WeakSensitiveDataHashingSinks extends SinkModelCsv {
 /**
  * A sink defined in a CSV model.
  */
-private class DefaultWeakSenitiveDataHashingSink extends WeakSensitiveDataHashingSink {
+private class DefaultWeakSensitiveDataHashingSink extends WeakSensitiveDataHashingSink {
   string algorithm;
 
-  DefaultWeakSenitiveDataHashingSink() { sinkNode(this, "weak-hash-input-" + algorithm) }
+  DefaultWeakSensitiveDataHashingSink() { sinkNode(this, "weak-hash-input-" + algorithm) }
 
   override string getAlgorithm() { result = algorithm }
 }
@@ -82,10 +82,10 @@ private class DefaultWeakSenitiveDataHashingSink extends WeakSensitiveDataHashin
 /**
  * A sink for weak sensitive data hashing through a call with a metatype qualifier.
  */
-private class WeakSenitiveDataHashingMetatypeSink extends WeakSensitiveDataHashingSink {
+private class WeakSensitiveDataHashingMetatypeSink extends WeakSensitiveDataHashingSink {
   string algorithm;
 
-  WeakSenitiveDataHashingMetatypeSink() {
+  WeakSensitiveDataHashingMetatypeSink() {
     exists(CallExpr c |
       c.getAnArgument().getExpr() = this.asExpr() and
       algorithm = ["MD5", "SHA1"] and

--- a/swift/ql/src/change-notes/2026-05-26-hashing-sinks.md
+++ b/swift/ql/src/change-notes/2026-05-26-hashing-sinks.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Fixed an issue where common usage patterns for `CryptoKit` weren't being recognized as hashing sinks for the `swift/weak-sensitive-data-hashing` and `swift/weak-password-hashing` queries. These queries may find additional results after this change.

--- a/swift/ql/test/query-tests/Security/CWE-328/WeakPasswordHashing.expected
+++ b/swift/ql/test/query-tests/Security/CWE-328/WeakPasswordHashing.expected
@@ -1,27 +1,27 @@
 edges
-| testCryptoKit.swift:218:38:218:38 | passwordString | testCryptoKit.swift:218:38:218:53 | .utf8 | provenance |  |
-| testCryptoKit.swift:218:38:218:53 | .utf8 | testCryptoKit.swift:218:33:218:57 | call to Data.init(_:) | provenance |  |
+| testCryptoKit.swift:224:38:224:38 | passwordString | testCryptoKit.swift:224:38:224:53 | .utf8 | provenance |  |
+| testCryptoKit.swift:224:38:224:53 | .utf8 | testCryptoKit.swift:224:33:224:57 | call to Data.init(_:) | provenance |  |
 nodes
 | testCryptoKit.swift:84:47:84:47 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:90:36:90:36 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:96:44:96:44 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:102:37:102:37 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:108:37:108:37 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:114:37:114:37 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:123:23:123:23 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:132:23:132:23 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:141:23:141:23 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:150:23:150:23 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:159:23:159:23 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:168:32:168:32 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:177:32:177:32 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:186:32:186:32 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:195:32:195:32 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:204:32:204:32 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:214:49:214:49 | passwordData | semmle.label | passwordData |
-| testCryptoKit.swift:218:33:218:57 | call to Data.init(_:) | semmle.label | call to Data.init(_:) |
-| testCryptoKit.swift:218:38:218:38 | passwordString | semmle.label | passwordString |
-| testCryptoKit.swift:218:38:218:53 | .utf8 | semmle.label | .utf8 |
+| testCryptoKit.swift:91:36:91:36 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:98:44:98:44 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:105:37:105:37 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:112:37:112:37 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:119:37:119:37 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:129:23:129:23 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:138:23:138:23 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:147:23:147:23 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:156:23:156:23 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:165:23:165:23 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:174:32:174:32 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:183:32:183:32 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:192:32:192:32 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:201:32:201:32 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:210:32:210:32 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:220:49:220:49 | passwordData | semmle.label | passwordData |
+| testCryptoKit.swift:224:33:224:57 | call to Data.init(_:) | semmle.label | call to Data.init(_:) |
+| testCryptoKit.swift:224:38:224:38 | passwordString | semmle.label | passwordString |
+| testCryptoKit.swift:224:38:224:53 | .utf8 | semmle.label | .utf8 |
 | testCryptoSwift.swift:154:30:154:30 | passwdArray | semmle.label | passwdArray |
 | testCryptoSwift.swift:157:31:157:31 | passwdArray | semmle.label | passwdArray |
 | testCryptoSwift.swift:160:47:160:47 | passwdArray | semmle.label | passwdArray |
@@ -49,23 +49,23 @@ nodes
 subpaths
 #select
 | testCryptoKit.swift:84:47:84:47 | passwd | testCryptoKit.swift:84:47:84:47 | passwd | testCryptoKit.swift:84:47:84:47 | passwd | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:84:47:84:47 | passwd | password (passwd) |
-| testCryptoKit.swift:90:36:90:36 | passwd | testCryptoKit.swift:90:36:90:36 | passwd | testCryptoKit.swift:90:36:90:36 | passwd | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:90:36:90:36 | passwd | password (passwd) |
-| testCryptoKit.swift:96:44:96:44 | passwd | testCryptoKit.swift:96:44:96:44 | passwd | testCryptoKit.swift:96:44:96:44 | passwd | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:96:44:96:44 | passwd | password (passwd) |
-| testCryptoKit.swift:102:37:102:37 | passwd | testCryptoKit.swift:102:37:102:37 | passwd | testCryptoKit.swift:102:37:102:37 | passwd | Insecure hashing algorithm (SHA256) depends on $@. | testCryptoKit.swift:102:37:102:37 | passwd | password (passwd) |
-| testCryptoKit.swift:108:37:108:37 | passwd | testCryptoKit.swift:108:37:108:37 | passwd | testCryptoKit.swift:108:37:108:37 | passwd | Insecure hashing algorithm (SHA384) depends on $@. | testCryptoKit.swift:108:37:108:37 | passwd | password (passwd) |
-| testCryptoKit.swift:114:37:114:37 | passwd | testCryptoKit.swift:114:37:114:37 | passwd | testCryptoKit.swift:114:37:114:37 | passwd | Insecure hashing algorithm (SHA512) depends on $@. | testCryptoKit.swift:114:37:114:37 | passwd | password (passwd) |
-| testCryptoKit.swift:123:23:123:23 | passwd | testCryptoKit.swift:123:23:123:23 | passwd | testCryptoKit.swift:123:23:123:23 | passwd | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:123:23:123:23 | passwd | password (passwd) |
-| testCryptoKit.swift:132:23:132:23 | passwd | testCryptoKit.swift:132:23:132:23 | passwd | testCryptoKit.swift:132:23:132:23 | passwd | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:132:23:132:23 | passwd | password (passwd) |
-| testCryptoKit.swift:141:23:141:23 | passwd | testCryptoKit.swift:141:23:141:23 | passwd | testCryptoKit.swift:141:23:141:23 | passwd | Insecure hashing algorithm (SHA256) depends on $@. | testCryptoKit.swift:141:23:141:23 | passwd | password (passwd) |
-| testCryptoKit.swift:150:23:150:23 | passwd | testCryptoKit.swift:150:23:150:23 | passwd | testCryptoKit.swift:150:23:150:23 | passwd | Insecure hashing algorithm (SHA384) depends on $@. | testCryptoKit.swift:150:23:150:23 | passwd | password (passwd) |
-| testCryptoKit.swift:159:23:159:23 | passwd | testCryptoKit.swift:159:23:159:23 | passwd | testCryptoKit.swift:159:23:159:23 | passwd | Insecure hashing algorithm (SHA512) depends on $@. | testCryptoKit.swift:159:23:159:23 | passwd | password (passwd) |
-| testCryptoKit.swift:168:32:168:32 | passwd | testCryptoKit.swift:168:32:168:32 | passwd | testCryptoKit.swift:168:32:168:32 | passwd | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:168:32:168:32 | passwd | password (passwd) |
-| testCryptoKit.swift:177:32:177:32 | passwd | testCryptoKit.swift:177:32:177:32 | passwd | testCryptoKit.swift:177:32:177:32 | passwd | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:177:32:177:32 | passwd | password (passwd) |
-| testCryptoKit.swift:186:32:186:32 | passwd | testCryptoKit.swift:186:32:186:32 | passwd | testCryptoKit.swift:186:32:186:32 | passwd | Insecure hashing algorithm (SHA256) depends on $@. | testCryptoKit.swift:186:32:186:32 | passwd | password (passwd) |
-| testCryptoKit.swift:195:32:195:32 | passwd | testCryptoKit.swift:195:32:195:32 | passwd | testCryptoKit.swift:195:32:195:32 | passwd | Insecure hashing algorithm (SHA384) depends on $@. | testCryptoKit.swift:195:32:195:32 | passwd | password (passwd) |
-| testCryptoKit.swift:204:32:204:32 | passwd | testCryptoKit.swift:204:32:204:32 | passwd | testCryptoKit.swift:204:32:204:32 | passwd | Insecure hashing algorithm (SHA512) depends on $@. | testCryptoKit.swift:204:32:204:32 | passwd | password (passwd) |
-| testCryptoKit.swift:214:49:214:49 | passwordData | testCryptoKit.swift:214:49:214:49 | passwordData | testCryptoKit.swift:214:49:214:49 | passwordData | Insecure hashing algorithm (SHA512) depends on $@. | testCryptoKit.swift:214:49:214:49 | passwordData | password (passwordData) |
-| testCryptoKit.swift:218:33:218:57 | call to Data.init(_:) | testCryptoKit.swift:218:38:218:38 | passwordString | testCryptoKit.swift:218:33:218:57 | call to Data.init(_:) | Insecure hashing algorithm (SHA512) depends on $@. | testCryptoKit.swift:218:38:218:38 | passwordString | password (passwordString) |
+| testCryptoKit.swift:91:36:91:36 | passwd | testCryptoKit.swift:91:36:91:36 | passwd | testCryptoKit.swift:91:36:91:36 | passwd | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:91:36:91:36 | passwd | password (passwd) |
+| testCryptoKit.swift:98:44:98:44 | passwd | testCryptoKit.swift:98:44:98:44 | passwd | testCryptoKit.swift:98:44:98:44 | passwd | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:98:44:98:44 | passwd | password (passwd) |
+| testCryptoKit.swift:105:37:105:37 | passwd | testCryptoKit.swift:105:37:105:37 | passwd | testCryptoKit.swift:105:37:105:37 | passwd | Insecure hashing algorithm (SHA256) depends on $@. | testCryptoKit.swift:105:37:105:37 | passwd | password (passwd) |
+| testCryptoKit.swift:112:37:112:37 | passwd | testCryptoKit.swift:112:37:112:37 | passwd | testCryptoKit.swift:112:37:112:37 | passwd | Insecure hashing algorithm (SHA384) depends on $@. | testCryptoKit.swift:112:37:112:37 | passwd | password (passwd) |
+| testCryptoKit.swift:119:37:119:37 | passwd | testCryptoKit.swift:119:37:119:37 | passwd | testCryptoKit.swift:119:37:119:37 | passwd | Insecure hashing algorithm (SHA512) depends on $@. | testCryptoKit.swift:119:37:119:37 | passwd | password (passwd) |
+| testCryptoKit.swift:129:23:129:23 | passwd | testCryptoKit.swift:129:23:129:23 | passwd | testCryptoKit.swift:129:23:129:23 | passwd | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:129:23:129:23 | passwd | password (passwd) |
+| testCryptoKit.swift:138:23:138:23 | passwd | testCryptoKit.swift:138:23:138:23 | passwd | testCryptoKit.swift:138:23:138:23 | passwd | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:138:23:138:23 | passwd | password (passwd) |
+| testCryptoKit.swift:147:23:147:23 | passwd | testCryptoKit.swift:147:23:147:23 | passwd | testCryptoKit.swift:147:23:147:23 | passwd | Insecure hashing algorithm (SHA256) depends on $@. | testCryptoKit.swift:147:23:147:23 | passwd | password (passwd) |
+| testCryptoKit.swift:156:23:156:23 | passwd | testCryptoKit.swift:156:23:156:23 | passwd | testCryptoKit.swift:156:23:156:23 | passwd | Insecure hashing algorithm (SHA384) depends on $@. | testCryptoKit.swift:156:23:156:23 | passwd | password (passwd) |
+| testCryptoKit.swift:165:23:165:23 | passwd | testCryptoKit.swift:165:23:165:23 | passwd | testCryptoKit.swift:165:23:165:23 | passwd | Insecure hashing algorithm (SHA512) depends on $@. | testCryptoKit.swift:165:23:165:23 | passwd | password (passwd) |
+| testCryptoKit.swift:174:32:174:32 | passwd | testCryptoKit.swift:174:32:174:32 | passwd | testCryptoKit.swift:174:32:174:32 | passwd | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:174:32:174:32 | passwd | password (passwd) |
+| testCryptoKit.swift:183:32:183:32 | passwd | testCryptoKit.swift:183:32:183:32 | passwd | testCryptoKit.swift:183:32:183:32 | passwd | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:183:32:183:32 | passwd | password (passwd) |
+| testCryptoKit.swift:192:32:192:32 | passwd | testCryptoKit.swift:192:32:192:32 | passwd | testCryptoKit.swift:192:32:192:32 | passwd | Insecure hashing algorithm (SHA256) depends on $@. | testCryptoKit.swift:192:32:192:32 | passwd | password (passwd) |
+| testCryptoKit.swift:201:32:201:32 | passwd | testCryptoKit.swift:201:32:201:32 | passwd | testCryptoKit.swift:201:32:201:32 | passwd | Insecure hashing algorithm (SHA384) depends on $@. | testCryptoKit.swift:201:32:201:32 | passwd | password (passwd) |
+| testCryptoKit.swift:210:32:210:32 | passwd | testCryptoKit.swift:210:32:210:32 | passwd | testCryptoKit.swift:210:32:210:32 | passwd | Insecure hashing algorithm (SHA512) depends on $@. | testCryptoKit.swift:210:32:210:32 | passwd | password (passwd) |
+| testCryptoKit.swift:220:49:220:49 | passwordData | testCryptoKit.swift:220:49:220:49 | passwordData | testCryptoKit.swift:220:49:220:49 | passwordData | Insecure hashing algorithm (SHA512) depends on $@. | testCryptoKit.swift:220:49:220:49 | passwordData | password (passwordData) |
+| testCryptoKit.swift:224:33:224:57 | call to Data.init(_:) | testCryptoKit.swift:224:38:224:38 | passwordString | testCryptoKit.swift:224:33:224:57 | call to Data.init(_:) | Insecure hashing algorithm (SHA512) depends on $@. | testCryptoKit.swift:224:38:224:38 | passwordString | password (passwordString) |
 | testCryptoSwift.swift:154:30:154:30 | passwdArray | testCryptoSwift.swift:154:30:154:30 | passwdArray | testCryptoSwift.swift:154:30:154:30 | passwdArray | Insecure hashing algorithm (MD5) depends on $@. | testCryptoSwift.swift:154:30:154:30 | passwdArray | password (passwdArray) |
 | testCryptoSwift.swift:157:31:157:31 | passwdArray | testCryptoSwift.swift:157:31:157:31 | passwdArray | testCryptoSwift.swift:157:31:157:31 | passwdArray | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoSwift.swift:157:31:157:31 | passwdArray | password (passwdArray) |
 | testCryptoSwift.swift:160:47:160:47 | passwdArray | testCryptoSwift.swift:160:47:160:47 | passwdArray | testCryptoSwift.swift:160:47:160:47 | passwdArray | Insecure hashing algorithm (SHA2) depends on $@. | testCryptoSwift.swift:160:47:160:47 | passwdArray | password (passwdArray) |

--- a/swift/ql/test/query-tests/Security/CWE-328/WeakPasswordHashing.expected
+++ b/swift/ql/test/query-tests/Security/CWE-328/WeakPasswordHashing.expected
@@ -3,11 +3,17 @@ edges
 | testCryptoKit.swift:224:38:224:53 | .utf8 | testCryptoKit.swift:224:33:224:57 | call to Data.init(_:) | provenance |  |
 nodes
 | testCryptoKit.swift:84:47:84:47 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:85:52:85:52 | passwd | semmle.label | passwd |
 | testCryptoKit.swift:91:36:91:36 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:92:45:92:45 | passwd | semmle.label | passwd |
 | testCryptoKit.swift:98:44:98:44 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:99:53:99:53 | passwd | semmle.label | passwd |
 | testCryptoKit.swift:105:37:105:37 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:106:46:106:46 | passwd | semmle.label | passwd |
 | testCryptoKit.swift:112:37:112:37 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:113:46:113:46 | passwd | semmle.label | passwd |
 | testCryptoKit.swift:119:37:119:37 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:120:46:120:46 | passwd | semmle.label | passwd |
 | testCryptoKit.swift:129:23:129:23 | passwd | semmle.label | passwd |
 | testCryptoKit.swift:138:23:138:23 | passwd | semmle.label | passwd |
 | testCryptoKit.swift:147:23:147:23 | passwd | semmle.label | passwd |
@@ -49,11 +55,17 @@ nodes
 subpaths
 #select
 | testCryptoKit.swift:84:47:84:47 | passwd | testCryptoKit.swift:84:47:84:47 | passwd | testCryptoKit.swift:84:47:84:47 | passwd | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:84:47:84:47 | passwd | password (passwd) |
+| testCryptoKit.swift:85:52:85:52 | passwd | testCryptoKit.swift:85:52:85:52 | passwd | testCryptoKit.swift:85:52:85:52 | passwd | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:85:52:85:52 | passwd | password (passwd) |
 | testCryptoKit.swift:91:36:91:36 | passwd | testCryptoKit.swift:91:36:91:36 | passwd | testCryptoKit.swift:91:36:91:36 | passwd | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:91:36:91:36 | passwd | password (passwd) |
+| testCryptoKit.swift:92:45:92:45 | passwd | testCryptoKit.swift:92:45:92:45 | passwd | testCryptoKit.swift:92:45:92:45 | passwd | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:92:45:92:45 | passwd | password (passwd) |
 | testCryptoKit.swift:98:44:98:44 | passwd | testCryptoKit.swift:98:44:98:44 | passwd | testCryptoKit.swift:98:44:98:44 | passwd | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:98:44:98:44 | passwd | password (passwd) |
+| testCryptoKit.swift:99:53:99:53 | passwd | testCryptoKit.swift:99:53:99:53 | passwd | testCryptoKit.swift:99:53:99:53 | passwd | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:99:53:99:53 | passwd | password (passwd) |
 | testCryptoKit.swift:105:37:105:37 | passwd | testCryptoKit.swift:105:37:105:37 | passwd | testCryptoKit.swift:105:37:105:37 | passwd | Insecure hashing algorithm (SHA256) depends on $@. | testCryptoKit.swift:105:37:105:37 | passwd | password (passwd) |
+| testCryptoKit.swift:106:46:106:46 | passwd | testCryptoKit.swift:106:46:106:46 | passwd | testCryptoKit.swift:106:46:106:46 | passwd | Insecure hashing algorithm (SHA256) depends on $@. | testCryptoKit.swift:106:46:106:46 | passwd | password (passwd) |
 | testCryptoKit.swift:112:37:112:37 | passwd | testCryptoKit.swift:112:37:112:37 | passwd | testCryptoKit.swift:112:37:112:37 | passwd | Insecure hashing algorithm (SHA384) depends on $@. | testCryptoKit.swift:112:37:112:37 | passwd | password (passwd) |
+| testCryptoKit.swift:113:46:113:46 | passwd | testCryptoKit.swift:113:46:113:46 | passwd | testCryptoKit.swift:113:46:113:46 | passwd | Insecure hashing algorithm (SHA384) depends on $@. | testCryptoKit.swift:113:46:113:46 | passwd | password (passwd) |
 | testCryptoKit.swift:119:37:119:37 | passwd | testCryptoKit.swift:119:37:119:37 | passwd | testCryptoKit.swift:119:37:119:37 | passwd | Insecure hashing algorithm (SHA512) depends on $@. | testCryptoKit.swift:119:37:119:37 | passwd | password (passwd) |
+| testCryptoKit.swift:120:46:120:46 | passwd | testCryptoKit.swift:120:46:120:46 | passwd | testCryptoKit.swift:120:46:120:46 | passwd | Insecure hashing algorithm (SHA512) depends on $@. | testCryptoKit.swift:120:46:120:46 | passwd | password (passwd) |
 | testCryptoKit.swift:129:23:129:23 | passwd | testCryptoKit.swift:129:23:129:23 | passwd | testCryptoKit.swift:129:23:129:23 | passwd | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:129:23:129:23 | passwd | password (passwd) |
 | testCryptoKit.swift:138:23:138:23 | passwd | testCryptoKit.swift:138:23:138:23 | passwd | testCryptoKit.swift:138:23:138:23 | passwd | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:138:23:138:23 | passwd | password (passwd) |
 | testCryptoKit.swift:147:23:147:23 | passwd | testCryptoKit.swift:147:23:147:23 | passwd | testCryptoKit.swift:147:23:147:23 | passwd | Insecure hashing algorithm (SHA256) depends on $@. | testCryptoKit.swift:147:23:147:23 | passwd | password (passwd) |

--- a/swift/ql/test/query-tests/Security/CWE-328/WeakPasswordHashing.expected
+++ b/swift/ql/test/query-tests/Security/CWE-328/WeakPasswordHashing.expected
@@ -1,5 +1,8 @@
 edges
 nodes
+| testCryptoKit.swift:84:47:84:47 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:90:36:90:36 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:96:44:96:44 | passwd | semmle.label | passwd |
 | testCryptoKit.swift:168:32:168:32 | passwd | semmle.label | passwd |
 | testCryptoKit.swift:177:32:177:32 | passwd | semmle.label | passwd |
 | testCryptoKit.swift:186:32:186:32 | passwd | semmle.label | passwd |
@@ -31,6 +34,9 @@ nodes
 | testCryptoSwift.swift:231:9:231:9 | passwd | semmle.label | passwd |
 subpaths
 #select
+| testCryptoKit.swift:84:47:84:47 | passwd | testCryptoKit.swift:84:47:84:47 | passwd | testCryptoKit.swift:84:47:84:47 | passwd | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:84:47:84:47 | passwd | password (passwd) |
+| testCryptoKit.swift:90:36:90:36 | passwd | testCryptoKit.swift:90:36:90:36 | passwd | testCryptoKit.swift:90:36:90:36 | passwd | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:90:36:90:36 | passwd | password (passwd) |
+| testCryptoKit.swift:96:44:96:44 | passwd | testCryptoKit.swift:96:44:96:44 | passwd | testCryptoKit.swift:96:44:96:44 | passwd | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:96:44:96:44 | passwd | password (passwd) |
 | testCryptoKit.swift:168:32:168:32 | passwd | testCryptoKit.swift:168:32:168:32 | passwd | testCryptoKit.swift:168:32:168:32 | passwd | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:168:32:168:32 | passwd | password (passwd) |
 | testCryptoKit.swift:177:32:177:32 | passwd | testCryptoKit.swift:177:32:177:32 | passwd | testCryptoKit.swift:177:32:177:32 | passwd | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:177:32:177:32 | passwd | password (passwd) |
 | testCryptoKit.swift:186:32:186:32 | passwd | testCryptoKit.swift:186:32:186:32 | passwd | testCryptoKit.swift:186:32:186:32 | passwd | Insecure hashing algorithm (SHA256) depends on $@. | testCryptoKit.swift:186:32:186:32 | passwd | password (passwd) |

--- a/swift/ql/test/query-tests/Security/CWE-328/WeakPasswordHashing.expected
+++ b/swift/ql/test/query-tests/Security/CWE-328/WeakPasswordHashing.expected
@@ -8,6 +8,11 @@ nodes
 | testCryptoKit.swift:102:37:102:37 | passwd | semmle.label | passwd |
 | testCryptoKit.swift:108:37:108:37 | passwd | semmle.label | passwd |
 | testCryptoKit.swift:114:37:114:37 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:123:23:123:23 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:132:23:132:23 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:141:23:141:23 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:150:23:150:23 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:159:23:159:23 | passwd | semmle.label | passwd |
 | testCryptoKit.swift:168:32:168:32 | passwd | semmle.label | passwd |
 | testCryptoKit.swift:177:32:177:32 | passwd | semmle.label | passwd |
 | testCryptoKit.swift:186:32:186:32 | passwd | semmle.label | passwd |
@@ -49,6 +54,11 @@ subpaths
 | testCryptoKit.swift:102:37:102:37 | passwd | testCryptoKit.swift:102:37:102:37 | passwd | testCryptoKit.swift:102:37:102:37 | passwd | Insecure hashing algorithm (SHA256) depends on $@. | testCryptoKit.swift:102:37:102:37 | passwd | password (passwd) |
 | testCryptoKit.swift:108:37:108:37 | passwd | testCryptoKit.swift:108:37:108:37 | passwd | testCryptoKit.swift:108:37:108:37 | passwd | Insecure hashing algorithm (SHA384) depends on $@. | testCryptoKit.swift:108:37:108:37 | passwd | password (passwd) |
 | testCryptoKit.swift:114:37:114:37 | passwd | testCryptoKit.swift:114:37:114:37 | passwd | testCryptoKit.swift:114:37:114:37 | passwd | Insecure hashing algorithm (SHA512) depends on $@. | testCryptoKit.swift:114:37:114:37 | passwd | password (passwd) |
+| testCryptoKit.swift:123:23:123:23 | passwd | testCryptoKit.swift:123:23:123:23 | passwd | testCryptoKit.swift:123:23:123:23 | passwd | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:123:23:123:23 | passwd | password (passwd) |
+| testCryptoKit.swift:132:23:132:23 | passwd | testCryptoKit.swift:132:23:132:23 | passwd | testCryptoKit.swift:132:23:132:23 | passwd | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:132:23:132:23 | passwd | password (passwd) |
+| testCryptoKit.swift:141:23:141:23 | passwd | testCryptoKit.swift:141:23:141:23 | passwd | testCryptoKit.swift:141:23:141:23 | passwd | Insecure hashing algorithm (SHA256) depends on $@. | testCryptoKit.swift:141:23:141:23 | passwd | password (passwd) |
+| testCryptoKit.swift:150:23:150:23 | passwd | testCryptoKit.swift:150:23:150:23 | passwd | testCryptoKit.swift:150:23:150:23 | passwd | Insecure hashing algorithm (SHA384) depends on $@. | testCryptoKit.swift:150:23:150:23 | passwd | password (passwd) |
+| testCryptoKit.swift:159:23:159:23 | passwd | testCryptoKit.swift:159:23:159:23 | passwd | testCryptoKit.swift:159:23:159:23 | passwd | Insecure hashing algorithm (SHA512) depends on $@. | testCryptoKit.swift:159:23:159:23 | passwd | password (passwd) |
 | testCryptoKit.swift:168:32:168:32 | passwd | testCryptoKit.swift:168:32:168:32 | passwd | testCryptoKit.swift:168:32:168:32 | passwd | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:168:32:168:32 | passwd | password (passwd) |
 | testCryptoKit.swift:177:32:177:32 | passwd | testCryptoKit.swift:177:32:177:32 | passwd | testCryptoKit.swift:177:32:177:32 | passwd | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:177:32:177:32 | passwd | password (passwd) |
 | testCryptoKit.swift:186:32:186:32 | passwd | testCryptoKit.swift:186:32:186:32 | passwd | testCryptoKit.swift:186:32:186:32 | passwd | Insecure hashing algorithm (SHA256) depends on $@. | testCryptoKit.swift:186:32:186:32 | passwd | password (passwd) |

--- a/swift/ql/test/query-tests/Security/CWE-328/WeakPasswordHashing.expected
+++ b/swift/ql/test/query-tests/Security/CWE-328/WeakPasswordHashing.expected
@@ -1,13 +1,22 @@
 edges
+| testCryptoKit.swift:218:38:218:38 | passwordString | testCryptoKit.swift:218:38:218:53 | .utf8 | provenance |  |
+| testCryptoKit.swift:218:38:218:53 | .utf8 | testCryptoKit.swift:218:33:218:57 | call to Data.init(_:) | provenance |  |
 nodes
 | testCryptoKit.swift:84:47:84:47 | passwd | semmle.label | passwd |
 | testCryptoKit.swift:90:36:90:36 | passwd | semmle.label | passwd |
 | testCryptoKit.swift:96:44:96:44 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:102:37:102:37 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:108:37:108:37 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:114:37:114:37 | passwd | semmle.label | passwd |
 | testCryptoKit.swift:168:32:168:32 | passwd | semmle.label | passwd |
 | testCryptoKit.swift:177:32:177:32 | passwd | semmle.label | passwd |
 | testCryptoKit.swift:186:32:186:32 | passwd | semmle.label | passwd |
 | testCryptoKit.swift:195:32:195:32 | passwd | semmle.label | passwd |
 | testCryptoKit.swift:204:32:204:32 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:214:49:214:49 | passwordData | semmle.label | passwordData |
+| testCryptoKit.swift:218:33:218:57 | call to Data.init(_:) | semmle.label | call to Data.init(_:) |
+| testCryptoKit.swift:218:38:218:38 | passwordString | semmle.label | passwordString |
+| testCryptoKit.swift:218:38:218:53 | .utf8 | semmle.label | .utf8 |
 | testCryptoSwift.swift:154:30:154:30 | passwdArray | semmle.label | passwdArray |
 | testCryptoSwift.swift:157:31:157:31 | passwdArray | semmle.label | passwdArray |
 | testCryptoSwift.swift:160:47:160:47 | passwdArray | semmle.label | passwdArray |
@@ -37,11 +46,16 @@ subpaths
 | testCryptoKit.swift:84:47:84:47 | passwd | testCryptoKit.swift:84:47:84:47 | passwd | testCryptoKit.swift:84:47:84:47 | passwd | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:84:47:84:47 | passwd | password (passwd) |
 | testCryptoKit.swift:90:36:90:36 | passwd | testCryptoKit.swift:90:36:90:36 | passwd | testCryptoKit.swift:90:36:90:36 | passwd | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:90:36:90:36 | passwd | password (passwd) |
 | testCryptoKit.swift:96:44:96:44 | passwd | testCryptoKit.swift:96:44:96:44 | passwd | testCryptoKit.swift:96:44:96:44 | passwd | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:96:44:96:44 | passwd | password (passwd) |
+| testCryptoKit.swift:102:37:102:37 | passwd | testCryptoKit.swift:102:37:102:37 | passwd | testCryptoKit.swift:102:37:102:37 | passwd | Insecure hashing algorithm (SHA256) depends on $@. | testCryptoKit.swift:102:37:102:37 | passwd | password (passwd) |
+| testCryptoKit.swift:108:37:108:37 | passwd | testCryptoKit.swift:108:37:108:37 | passwd | testCryptoKit.swift:108:37:108:37 | passwd | Insecure hashing algorithm (SHA384) depends on $@. | testCryptoKit.swift:108:37:108:37 | passwd | password (passwd) |
+| testCryptoKit.swift:114:37:114:37 | passwd | testCryptoKit.swift:114:37:114:37 | passwd | testCryptoKit.swift:114:37:114:37 | passwd | Insecure hashing algorithm (SHA512) depends on $@. | testCryptoKit.swift:114:37:114:37 | passwd | password (passwd) |
 | testCryptoKit.swift:168:32:168:32 | passwd | testCryptoKit.swift:168:32:168:32 | passwd | testCryptoKit.swift:168:32:168:32 | passwd | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:168:32:168:32 | passwd | password (passwd) |
 | testCryptoKit.swift:177:32:177:32 | passwd | testCryptoKit.swift:177:32:177:32 | passwd | testCryptoKit.swift:177:32:177:32 | passwd | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:177:32:177:32 | passwd | password (passwd) |
 | testCryptoKit.swift:186:32:186:32 | passwd | testCryptoKit.swift:186:32:186:32 | passwd | testCryptoKit.swift:186:32:186:32 | passwd | Insecure hashing algorithm (SHA256) depends on $@. | testCryptoKit.swift:186:32:186:32 | passwd | password (passwd) |
 | testCryptoKit.swift:195:32:195:32 | passwd | testCryptoKit.swift:195:32:195:32 | passwd | testCryptoKit.swift:195:32:195:32 | passwd | Insecure hashing algorithm (SHA384) depends on $@. | testCryptoKit.swift:195:32:195:32 | passwd | password (passwd) |
 | testCryptoKit.swift:204:32:204:32 | passwd | testCryptoKit.swift:204:32:204:32 | passwd | testCryptoKit.swift:204:32:204:32 | passwd | Insecure hashing algorithm (SHA512) depends on $@. | testCryptoKit.swift:204:32:204:32 | passwd | password (passwd) |
+| testCryptoKit.swift:214:49:214:49 | passwordData | testCryptoKit.swift:214:49:214:49 | passwordData | testCryptoKit.swift:214:49:214:49 | passwordData | Insecure hashing algorithm (SHA512) depends on $@. | testCryptoKit.swift:214:49:214:49 | passwordData | password (passwordData) |
+| testCryptoKit.swift:218:33:218:57 | call to Data.init(_:) | testCryptoKit.swift:218:38:218:38 | passwordString | testCryptoKit.swift:218:33:218:57 | call to Data.init(_:) | Insecure hashing algorithm (SHA512) depends on $@. | testCryptoKit.swift:218:38:218:38 | passwordString | password (passwordString) |
 | testCryptoSwift.swift:154:30:154:30 | passwdArray | testCryptoSwift.swift:154:30:154:30 | passwdArray | testCryptoSwift.swift:154:30:154:30 | passwdArray | Insecure hashing algorithm (MD5) depends on $@. | testCryptoSwift.swift:154:30:154:30 | passwdArray | password (passwdArray) |
 | testCryptoSwift.swift:157:31:157:31 | passwdArray | testCryptoSwift.swift:157:31:157:31 | passwdArray | testCryptoSwift.swift:157:31:157:31 | passwdArray | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoSwift.swift:157:31:157:31 | passwdArray | password (passwdArray) |
 | testCryptoSwift.swift:160:47:160:47 | passwdArray | testCryptoSwift.swift:160:47:160:47 | passwdArray | testCryptoSwift.swift:160:47:160:47 | passwdArray | Insecure hashing algorithm (SHA2) depends on $@. | testCryptoSwift.swift:160:47:160:47 | passwdArray | password (passwdArray) |

--- a/swift/ql/test/query-tests/Security/CWE-328/WeakPasswordHashing.expected
+++ b/swift/ql/test/query-tests/Security/CWE-328/WeakPasswordHashing.expected
@@ -1,27 +1,10 @@
 edges
-| testCryptoKit.swift:199:38:199:38 | passwordString | testCryptoKit.swift:199:38:199:53 | .utf8 | provenance |  |
-| testCryptoKit.swift:199:38:199:53 | .utf8 | testCryptoKit.swift:199:33:199:57 | call to Data.init(_:) | provenance |  |
 nodes
-| testCryptoKit.swift:65:47:65:47 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:71:36:71:36 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:77:44:77:44 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:83:37:83:37 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:89:37:89:37 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:95:37:95:37 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:104:23:104:23 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:113:23:113:23 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:122:23:122:23 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:131:23:131:23 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:140:23:140:23 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:149:32:149:32 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:158:32:158:32 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:167:32:167:32 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:176:32:176:32 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:185:32:185:32 | passwd | semmle.label | passwd |
-| testCryptoKit.swift:195:49:195:49 | passwordData | semmle.label | passwordData |
-| testCryptoKit.swift:199:33:199:57 | call to Data.init(_:) | semmle.label | call to Data.init(_:) |
-| testCryptoKit.swift:199:38:199:38 | passwordString | semmle.label | passwordString |
-| testCryptoKit.swift:199:38:199:53 | .utf8 | semmle.label | .utf8 |
+| testCryptoKit.swift:168:32:168:32 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:177:32:177:32 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:186:32:186:32 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:195:32:195:32 | passwd | semmle.label | passwd |
+| testCryptoKit.swift:204:32:204:32 | passwd | semmle.label | passwd |
 | testCryptoSwift.swift:154:30:154:30 | passwdArray | semmle.label | passwdArray |
 | testCryptoSwift.swift:157:31:157:31 | passwdArray | semmle.label | passwdArray |
 | testCryptoSwift.swift:160:47:160:47 | passwdArray | semmle.label | passwdArray |
@@ -48,24 +31,11 @@ nodes
 | testCryptoSwift.swift:231:9:231:9 | passwd | semmle.label | passwd |
 subpaths
 #select
-| testCryptoKit.swift:65:47:65:47 | passwd | testCryptoKit.swift:65:47:65:47 | passwd | testCryptoKit.swift:65:47:65:47 | passwd | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:65:47:65:47 | passwd | password (passwd) |
-| testCryptoKit.swift:71:36:71:36 | passwd | testCryptoKit.swift:71:36:71:36 | passwd | testCryptoKit.swift:71:36:71:36 | passwd | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:71:36:71:36 | passwd | password (passwd) |
-| testCryptoKit.swift:77:44:77:44 | passwd | testCryptoKit.swift:77:44:77:44 | passwd | testCryptoKit.swift:77:44:77:44 | passwd | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:77:44:77:44 | passwd | password (passwd) |
-| testCryptoKit.swift:83:37:83:37 | passwd | testCryptoKit.swift:83:37:83:37 | passwd | testCryptoKit.swift:83:37:83:37 | passwd | Insecure hashing algorithm (SHA256) depends on $@. | testCryptoKit.swift:83:37:83:37 | passwd | password (passwd) |
-| testCryptoKit.swift:89:37:89:37 | passwd | testCryptoKit.swift:89:37:89:37 | passwd | testCryptoKit.swift:89:37:89:37 | passwd | Insecure hashing algorithm (SHA384) depends on $@. | testCryptoKit.swift:89:37:89:37 | passwd | password (passwd) |
-| testCryptoKit.swift:95:37:95:37 | passwd | testCryptoKit.swift:95:37:95:37 | passwd | testCryptoKit.swift:95:37:95:37 | passwd | Insecure hashing algorithm (SHA512) depends on $@. | testCryptoKit.swift:95:37:95:37 | passwd | password (passwd) |
-| testCryptoKit.swift:104:23:104:23 | passwd | testCryptoKit.swift:104:23:104:23 | passwd | testCryptoKit.swift:104:23:104:23 | passwd | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:104:23:104:23 | passwd | password (passwd) |
-| testCryptoKit.swift:113:23:113:23 | passwd | testCryptoKit.swift:113:23:113:23 | passwd | testCryptoKit.swift:113:23:113:23 | passwd | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:113:23:113:23 | passwd | password (passwd) |
-| testCryptoKit.swift:122:23:122:23 | passwd | testCryptoKit.swift:122:23:122:23 | passwd | testCryptoKit.swift:122:23:122:23 | passwd | Insecure hashing algorithm (SHA256) depends on $@. | testCryptoKit.swift:122:23:122:23 | passwd | password (passwd) |
-| testCryptoKit.swift:131:23:131:23 | passwd | testCryptoKit.swift:131:23:131:23 | passwd | testCryptoKit.swift:131:23:131:23 | passwd | Insecure hashing algorithm (SHA384) depends on $@. | testCryptoKit.swift:131:23:131:23 | passwd | password (passwd) |
-| testCryptoKit.swift:140:23:140:23 | passwd | testCryptoKit.swift:140:23:140:23 | passwd | testCryptoKit.swift:140:23:140:23 | passwd | Insecure hashing algorithm (SHA512) depends on $@. | testCryptoKit.swift:140:23:140:23 | passwd | password (passwd) |
-| testCryptoKit.swift:149:32:149:32 | passwd | testCryptoKit.swift:149:32:149:32 | passwd | testCryptoKit.swift:149:32:149:32 | passwd | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:149:32:149:32 | passwd | password (passwd) |
-| testCryptoKit.swift:158:32:158:32 | passwd | testCryptoKit.swift:158:32:158:32 | passwd | testCryptoKit.swift:158:32:158:32 | passwd | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:158:32:158:32 | passwd | password (passwd) |
-| testCryptoKit.swift:167:32:167:32 | passwd | testCryptoKit.swift:167:32:167:32 | passwd | testCryptoKit.swift:167:32:167:32 | passwd | Insecure hashing algorithm (SHA256) depends on $@. | testCryptoKit.swift:167:32:167:32 | passwd | password (passwd) |
-| testCryptoKit.swift:176:32:176:32 | passwd | testCryptoKit.swift:176:32:176:32 | passwd | testCryptoKit.swift:176:32:176:32 | passwd | Insecure hashing algorithm (SHA384) depends on $@. | testCryptoKit.swift:176:32:176:32 | passwd | password (passwd) |
-| testCryptoKit.swift:185:32:185:32 | passwd | testCryptoKit.swift:185:32:185:32 | passwd | testCryptoKit.swift:185:32:185:32 | passwd | Insecure hashing algorithm (SHA512) depends on $@. | testCryptoKit.swift:185:32:185:32 | passwd | password (passwd) |
-| testCryptoKit.swift:195:49:195:49 | passwordData | testCryptoKit.swift:195:49:195:49 | passwordData | testCryptoKit.swift:195:49:195:49 | passwordData | Insecure hashing algorithm (SHA512) depends on $@. | testCryptoKit.swift:195:49:195:49 | passwordData | password (passwordData) |
-| testCryptoKit.swift:199:33:199:57 | call to Data.init(_:) | testCryptoKit.swift:199:38:199:38 | passwordString | testCryptoKit.swift:199:33:199:57 | call to Data.init(_:) | Insecure hashing algorithm (SHA512) depends on $@. | testCryptoKit.swift:199:38:199:38 | passwordString | password (passwordString) |
+| testCryptoKit.swift:168:32:168:32 | passwd | testCryptoKit.swift:168:32:168:32 | passwd | testCryptoKit.swift:168:32:168:32 | passwd | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:168:32:168:32 | passwd | password (passwd) |
+| testCryptoKit.swift:177:32:177:32 | passwd | testCryptoKit.swift:177:32:177:32 | passwd | testCryptoKit.swift:177:32:177:32 | passwd | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:177:32:177:32 | passwd | password (passwd) |
+| testCryptoKit.swift:186:32:186:32 | passwd | testCryptoKit.swift:186:32:186:32 | passwd | testCryptoKit.swift:186:32:186:32 | passwd | Insecure hashing algorithm (SHA256) depends on $@. | testCryptoKit.swift:186:32:186:32 | passwd | password (passwd) |
+| testCryptoKit.swift:195:32:195:32 | passwd | testCryptoKit.swift:195:32:195:32 | passwd | testCryptoKit.swift:195:32:195:32 | passwd | Insecure hashing algorithm (SHA384) depends on $@. | testCryptoKit.swift:195:32:195:32 | passwd | password (passwd) |
+| testCryptoKit.swift:204:32:204:32 | passwd | testCryptoKit.swift:204:32:204:32 | passwd | testCryptoKit.swift:204:32:204:32 | passwd | Insecure hashing algorithm (SHA512) depends on $@. | testCryptoKit.swift:204:32:204:32 | passwd | password (passwd) |
 | testCryptoSwift.swift:154:30:154:30 | passwdArray | testCryptoSwift.swift:154:30:154:30 | passwdArray | testCryptoSwift.swift:154:30:154:30 | passwdArray | Insecure hashing algorithm (MD5) depends on $@. | testCryptoSwift.swift:154:30:154:30 | passwdArray | password (passwdArray) |
 | testCryptoSwift.swift:157:31:157:31 | passwdArray | testCryptoSwift.swift:157:31:157:31 | passwdArray | testCryptoSwift.swift:157:31:157:31 | passwdArray | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoSwift.swift:157:31:157:31 | passwdArray | password (passwdArray) |
 | testCryptoSwift.swift:160:47:160:47 | passwdArray | testCryptoSwift.swift:160:47:160:47 | passwdArray | testCryptoSwift.swift:160:47:160:47 | passwdArray | Insecure hashing algorithm (SHA2) depends on $@. | testCryptoSwift.swift:160:47:160:47 | passwdArray | password (passwdArray) |

--- a/swift/ql/test/query-tests/Security/CWE-328/WeakSensitiveDataHashing.expected
+++ b/swift/ql/test/query-tests/Security/CWE-328/WeakSensitiveDataHashing.expected
@@ -1,11 +1,63 @@
 edges
+| testCryptoKit.swift:224:18:224:38 | call to Data.init(_:) | testCryptoKit.swift:225:44:225:44 | value1 | provenance |  |
+| testCryptoKit.swift:224:23:224:23 | cardNumber | testCryptoKit.swift:224:23:224:34 | .utf8 | provenance |  |
+| testCryptoKit.swift:224:23:224:34 | .utf8 | testCryptoKit.swift:224:18:224:38 | call to Data.init(_:) | provenance |  |
+| testCryptoKit.swift:227:18:227:38 | call to Data.init(_:) | testCryptoKit.swift:229:39:229:39 | value2 | provenance |  |
+| testCryptoKit.swift:227:23:227:23 | cardNumber | testCryptoKit.swift:227:23:227:34 | .utf8 | provenance |  |
+| testCryptoKit.swift:227:23:227:34 | .utf8 | testCryptoKit.swift:227:18:227:38 | call to Data.init(_:) | provenance |  |
+| testCryptoKit.swift:231:18:231:38 | call to Data.init(_:) | testCryptoKit.swift:232:51:232:51 | value3 | provenance |  |
+| testCryptoKit.swift:231:23:231:23 | cardNumber | testCryptoKit.swift:231:23:231:34 | .utf8 | provenance |  |
+| testCryptoKit.swift:231:23:231:34 | .utf8 | testCryptoKit.swift:231:18:231:38 | call to Data.init(_:) | provenance |  |
+| testCryptoKit.swift:234:18:234:38 | call to Data.init(_:) | testCryptoKit.swift:235:26:235:26 | value4 | provenance |  |
+| testCryptoKit.swift:234:23:234:23 | cardNumber | testCryptoKit.swift:234:23:234:34 | .utf8 | provenance |  |
+| testCryptoKit.swift:234:23:234:34 | .utf8 | testCryptoKit.swift:234:18:234:38 | call to Data.init(_:) | provenance |  |
+| testCryptoKit.swift:235:26:235:26 | value4 | testCryptoKit.swift:244:20:244:27 | value | provenance |  |
+| testCryptoKit.swift:237:18:237:38 | call to Data.init(_:) | testCryptoKit.swift:238:53:238:53 | value5 | provenance |  |
+| testCryptoKit.swift:237:23:237:23 | cardNumber | testCryptoKit.swift:237:23:237:34 | .utf8 | provenance |  |
+| testCryptoKit.swift:237:23:237:34 | .utf8 | testCryptoKit.swift:237:18:237:38 | call to Data.init(_:) | provenance |  |
+| testCryptoKit.swift:238:53:238:53 | value5 | testCryptoKit.swift:248:47:248:54 | value | provenance |  |
+| testCryptoKit.swift:244:20:244:27 | value | testCryptoKit.swift:245:43:245:43 | value | provenance |  |
+| testCryptoKit.swift:248:47:248:54 | value | testCryptoKit.swift:249:37:249:37 | value | provenance |  |
 nodes
+| testCryptoKit.swift:85:43:85:43 | cert | semmle.label | cert |
+| testCryptoKit.swift:87:43:87:43 | account_no | semmle.label | account_no |
+| testCryptoKit.swift:88:43:88:43 | credit_card_no | semmle.label | credit_card_no |
+| testCryptoKit.swift:91:36:91:36 | cert | semmle.label | cert |
+| testCryptoKit.swift:93:36:93:36 | account_no | semmle.label | account_no |
+| testCryptoKit.swift:94:36:94:36 | credit_card_no | semmle.label | credit_card_no |
+| testCryptoKit.swift:97:44:97:44 | cert | semmle.label | cert |
+| testCryptoKit.swift:99:44:99:44 | account_no | semmle.label | account_no |
+| testCryptoKit.swift:100:44:100:44 | credit_card_no | semmle.label | credit_card_no |
 | testCryptoKit.swift:169:32:169:32 | cert | semmle.label | cert |
 | testCryptoKit.swift:171:32:171:32 | account_no | semmle.label | account_no |
 | testCryptoKit.swift:172:32:172:32 | credit_card_no | semmle.label | credit_card_no |
 | testCryptoKit.swift:178:32:178:32 | cert | semmle.label | cert |
 | testCryptoKit.swift:180:32:180:32 | account_no | semmle.label | account_no |
 | testCryptoKit.swift:181:32:181:32 | credit_card_no | semmle.label | credit_card_no |
+| testCryptoKit.swift:224:18:224:38 | call to Data.init(_:) | semmle.label | call to Data.init(_:) |
+| testCryptoKit.swift:224:23:224:23 | cardNumber | semmle.label | cardNumber |
+| testCryptoKit.swift:224:23:224:34 | .utf8 | semmle.label | .utf8 |
+| testCryptoKit.swift:225:44:225:44 | value1 | semmle.label | value1 |
+| testCryptoKit.swift:227:18:227:38 | call to Data.init(_:) | semmle.label | call to Data.init(_:) |
+| testCryptoKit.swift:227:23:227:23 | cardNumber | semmle.label | cardNumber |
+| testCryptoKit.swift:227:23:227:34 | .utf8 | semmle.label | .utf8 |
+| testCryptoKit.swift:229:39:229:39 | value2 | semmle.label | value2 |
+| testCryptoKit.swift:231:18:231:38 | call to Data.init(_:) | semmle.label | call to Data.init(_:) |
+| testCryptoKit.swift:231:23:231:23 | cardNumber | semmle.label | cardNumber |
+| testCryptoKit.swift:231:23:231:34 | .utf8 | semmle.label | .utf8 |
+| testCryptoKit.swift:232:51:232:51 | value3 | semmle.label | value3 |
+| testCryptoKit.swift:234:18:234:38 | call to Data.init(_:) | semmle.label | call to Data.init(_:) |
+| testCryptoKit.swift:234:23:234:23 | cardNumber | semmle.label | cardNumber |
+| testCryptoKit.swift:234:23:234:34 | .utf8 | semmle.label | .utf8 |
+| testCryptoKit.swift:235:26:235:26 | value4 | semmle.label | value4 |
+| testCryptoKit.swift:237:18:237:38 | call to Data.init(_:) | semmle.label | call to Data.init(_:) |
+| testCryptoKit.swift:237:23:237:23 | cardNumber | semmle.label | cardNumber |
+| testCryptoKit.swift:237:23:237:34 | .utf8 | semmle.label | .utf8 |
+| testCryptoKit.swift:238:53:238:53 | value5 | semmle.label | value5 |
+| testCryptoKit.swift:244:20:244:27 | value | semmle.label | value |
+| testCryptoKit.swift:245:43:245:43 | value | semmle.label | value |
+| testCryptoKit.swift:248:47:248:54 | value | semmle.label | value |
+| testCryptoKit.swift:249:37:249:37 | value | semmle.label | value |
 | testCryptoSwift.swift:153:30:153:30 | phoneNumberArray | semmle.label | phoneNumberArray |
 | testCryptoSwift.swift:156:31:156:31 | phoneNumberArray | semmle.label | phoneNumberArray |
 | testCryptoSwift.swift:166:20:166:20 | phoneNumberArray | semmle.label | phoneNumberArray |
@@ -18,12 +70,26 @@ nodes
 | testCryptoSwift.swift:221:9:221:9 | creditCardNumber | semmle.label | creditCardNumber |
 subpaths
 #select
+| testCryptoKit.swift:85:43:85:43 | cert | testCryptoKit.swift:85:43:85:43 | cert | testCryptoKit.swift:85:43:85:43 | cert | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:85:43:85:43 | cert | sensitive data (credential cert) |
+| testCryptoKit.swift:87:43:87:43 | account_no | testCryptoKit.swift:87:43:87:43 | account_no | testCryptoKit.swift:87:43:87:43 | account_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:87:43:87:43 | account_no | sensitive data (private information account_no) |
+| testCryptoKit.swift:88:43:88:43 | credit_card_no | testCryptoKit.swift:88:43:88:43 | credit_card_no | testCryptoKit.swift:88:43:88:43 | credit_card_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:88:43:88:43 | credit_card_no | sensitive data (private information credit_card_no) |
+| testCryptoKit.swift:91:36:91:36 | cert | testCryptoKit.swift:91:36:91:36 | cert | testCryptoKit.swift:91:36:91:36 | cert | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:91:36:91:36 | cert | sensitive data (credential cert) |
+| testCryptoKit.swift:93:36:93:36 | account_no | testCryptoKit.swift:93:36:93:36 | account_no | testCryptoKit.swift:93:36:93:36 | account_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:93:36:93:36 | account_no | sensitive data (private information account_no) |
+| testCryptoKit.swift:94:36:94:36 | credit_card_no | testCryptoKit.swift:94:36:94:36 | credit_card_no | testCryptoKit.swift:94:36:94:36 | credit_card_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:94:36:94:36 | credit_card_no | sensitive data (private information credit_card_no) |
+| testCryptoKit.swift:97:44:97:44 | cert | testCryptoKit.swift:97:44:97:44 | cert | testCryptoKit.swift:97:44:97:44 | cert | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:97:44:97:44 | cert | sensitive data (credential cert) |
+| testCryptoKit.swift:99:44:99:44 | account_no | testCryptoKit.swift:99:44:99:44 | account_no | testCryptoKit.swift:99:44:99:44 | account_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:99:44:99:44 | account_no | sensitive data (private information account_no) |
+| testCryptoKit.swift:100:44:100:44 | credit_card_no | testCryptoKit.swift:100:44:100:44 | credit_card_no | testCryptoKit.swift:100:44:100:44 | credit_card_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:100:44:100:44 | credit_card_no | sensitive data (private information credit_card_no) |
 | testCryptoKit.swift:169:32:169:32 | cert | testCryptoKit.swift:169:32:169:32 | cert | testCryptoKit.swift:169:32:169:32 | cert | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:169:32:169:32 | cert | sensitive data (credential cert) |
 | testCryptoKit.swift:171:32:171:32 | account_no | testCryptoKit.swift:171:32:171:32 | account_no | testCryptoKit.swift:171:32:171:32 | account_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:171:32:171:32 | account_no | sensitive data (private information account_no) |
 | testCryptoKit.swift:172:32:172:32 | credit_card_no | testCryptoKit.swift:172:32:172:32 | credit_card_no | testCryptoKit.swift:172:32:172:32 | credit_card_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:172:32:172:32 | credit_card_no | sensitive data (private information credit_card_no) |
 | testCryptoKit.swift:178:32:178:32 | cert | testCryptoKit.swift:178:32:178:32 | cert | testCryptoKit.swift:178:32:178:32 | cert | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:178:32:178:32 | cert | sensitive data (credential cert) |
 | testCryptoKit.swift:180:32:180:32 | account_no | testCryptoKit.swift:180:32:180:32 | account_no | testCryptoKit.swift:180:32:180:32 | account_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:180:32:180:32 | account_no | sensitive data (private information account_no) |
 | testCryptoKit.swift:181:32:181:32 | credit_card_no | testCryptoKit.swift:181:32:181:32 | credit_card_no | testCryptoKit.swift:181:32:181:32 | credit_card_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:181:32:181:32 | credit_card_no | sensitive data (private information credit_card_no) |
+| testCryptoKit.swift:225:44:225:44 | value1 | testCryptoKit.swift:224:23:224:23 | cardNumber | testCryptoKit.swift:225:44:225:44 | value1 | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:224:23:224:23 | cardNumber | sensitive data (private information cardNumber) |
+| testCryptoKit.swift:229:39:229:39 | value2 | testCryptoKit.swift:227:23:227:23 | cardNumber | testCryptoKit.swift:229:39:229:39 | value2 | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:227:23:227:23 | cardNumber | sensitive data (private information cardNumber) |
+| testCryptoKit.swift:232:51:232:51 | value3 | testCryptoKit.swift:231:23:231:23 | cardNumber | testCryptoKit.swift:232:51:232:51 | value3 | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:231:23:231:23 | cardNumber | sensitive data (private information cardNumber) |
+| testCryptoKit.swift:245:43:245:43 | value | testCryptoKit.swift:234:23:234:23 | cardNumber | testCryptoKit.swift:245:43:245:43 | value | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:234:23:234:23 | cardNumber | sensitive data (private information cardNumber) |
+| testCryptoKit.swift:249:37:249:37 | value | testCryptoKit.swift:237:23:237:23 | cardNumber | testCryptoKit.swift:249:37:249:37 | value | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:237:23:237:23 | cardNumber | sensitive data (private information cardNumber) |
 | testCryptoSwift.swift:153:30:153:30 | phoneNumberArray | testCryptoSwift.swift:153:30:153:30 | phoneNumberArray | testCryptoSwift.swift:153:30:153:30 | phoneNumberArray | Insecure hashing algorithm (MD5) depends on $@. | testCryptoSwift.swift:153:30:153:30 | phoneNumberArray | sensitive data (private information phoneNumberArray) |
 | testCryptoSwift.swift:156:31:156:31 | phoneNumberArray | testCryptoSwift.swift:156:31:156:31 | phoneNumberArray | testCryptoSwift.swift:156:31:156:31 | phoneNumberArray | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoSwift.swift:156:31:156:31 | phoneNumberArray | sensitive data (private information phoneNumberArray) |
 | testCryptoSwift.swift:166:20:166:20 | phoneNumberArray | testCryptoSwift.swift:166:20:166:20 | phoneNumberArray | testCryptoSwift.swift:166:20:166:20 | phoneNumberArray | Insecure hashing algorithm (MD5) depends on $@. | testCryptoSwift.swift:166:20:166:20 | phoneNumberArray | sensitive data (private information phoneNumberArray) |

--- a/swift/ql/test/query-tests/Security/CWE-328/WeakSensitiveDataHashing.expected
+++ b/swift/ql/test/query-tests/Security/CWE-328/WeakSensitiveDataHashing.expected
@@ -1,26 +1,11 @@
 edges
 nodes
-| testCryptoKit.swift:66:43:66:43 | cert | semmle.label | cert |
-| testCryptoKit.swift:68:43:68:43 | account_no | semmle.label | account_no |
-| testCryptoKit.swift:69:43:69:43 | credit_card_no | semmle.label | credit_card_no |
-| testCryptoKit.swift:72:36:72:36 | cert | semmle.label | cert |
-| testCryptoKit.swift:74:36:74:36 | account_no | semmle.label | account_no |
-| testCryptoKit.swift:75:36:75:36 | credit_card_no | semmle.label | credit_card_no |
-| testCryptoKit.swift:78:44:78:44 | cert | semmle.label | cert |
-| testCryptoKit.swift:80:44:80:44 | account_no | semmle.label | account_no |
-| testCryptoKit.swift:81:44:81:44 | credit_card_no | semmle.label | credit_card_no |
-| testCryptoKit.swift:105:23:105:23 | cert | semmle.label | cert |
-| testCryptoKit.swift:107:23:107:23 | account_no | semmle.label | account_no |
-| testCryptoKit.swift:108:23:108:23 | credit_card_no | semmle.label | credit_card_no |
-| testCryptoKit.swift:114:23:114:23 | cert | semmle.label | cert |
-| testCryptoKit.swift:116:23:116:23 | account_no | semmle.label | account_no |
-| testCryptoKit.swift:117:23:117:23 | credit_card_no | semmle.label | credit_card_no |
-| testCryptoKit.swift:150:32:150:32 | cert | semmle.label | cert |
-| testCryptoKit.swift:152:32:152:32 | account_no | semmle.label | account_no |
-| testCryptoKit.swift:153:32:153:32 | credit_card_no | semmle.label | credit_card_no |
-| testCryptoKit.swift:159:32:159:32 | cert | semmle.label | cert |
-| testCryptoKit.swift:161:32:161:32 | account_no | semmle.label | account_no |
-| testCryptoKit.swift:162:32:162:32 | credit_card_no | semmle.label | credit_card_no |
+| testCryptoKit.swift:169:32:169:32 | cert | semmle.label | cert |
+| testCryptoKit.swift:171:32:171:32 | account_no | semmle.label | account_no |
+| testCryptoKit.swift:172:32:172:32 | credit_card_no | semmle.label | credit_card_no |
+| testCryptoKit.swift:178:32:178:32 | cert | semmle.label | cert |
+| testCryptoKit.swift:180:32:180:32 | account_no | semmle.label | account_no |
+| testCryptoKit.swift:181:32:181:32 | credit_card_no | semmle.label | credit_card_no |
 | testCryptoSwift.swift:153:30:153:30 | phoneNumberArray | semmle.label | phoneNumberArray |
 | testCryptoSwift.swift:156:31:156:31 | phoneNumberArray | semmle.label | phoneNumberArray |
 | testCryptoSwift.swift:166:20:166:20 | phoneNumberArray | semmle.label | phoneNumberArray |
@@ -33,27 +18,12 @@ nodes
 | testCryptoSwift.swift:221:9:221:9 | creditCardNumber | semmle.label | creditCardNumber |
 subpaths
 #select
-| testCryptoKit.swift:66:43:66:43 | cert | testCryptoKit.swift:66:43:66:43 | cert | testCryptoKit.swift:66:43:66:43 | cert | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:66:43:66:43 | cert | sensitive data (credential cert) |
-| testCryptoKit.swift:68:43:68:43 | account_no | testCryptoKit.swift:68:43:68:43 | account_no | testCryptoKit.swift:68:43:68:43 | account_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:68:43:68:43 | account_no | sensitive data (private information account_no) |
-| testCryptoKit.swift:69:43:69:43 | credit_card_no | testCryptoKit.swift:69:43:69:43 | credit_card_no | testCryptoKit.swift:69:43:69:43 | credit_card_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:69:43:69:43 | credit_card_no | sensitive data (private information credit_card_no) |
-| testCryptoKit.swift:72:36:72:36 | cert | testCryptoKit.swift:72:36:72:36 | cert | testCryptoKit.swift:72:36:72:36 | cert | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:72:36:72:36 | cert | sensitive data (credential cert) |
-| testCryptoKit.swift:74:36:74:36 | account_no | testCryptoKit.swift:74:36:74:36 | account_no | testCryptoKit.swift:74:36:74:36 | account_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:74:36:74:36 | account_no | sensitive data (private information account_no) |
-| testCryptoKit.swift:75:36:75:36 | credit_card_no | testCryptoKit.swift:75:36:75:36 | credit_card_no | testCryptoKit.swift:75:36:75:36 | credit_card_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:75:36:75:36 | credit_card_no | sensitive data (private information credit_card_no) |
-| testCryptoKit.swift:78:44:78:44 | cert | testCryptoKit.swift:78:44:78:44 | cert | testCryptoKit.swift:78:44:78:44 | cert | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:78:44:78:44 | cert | sensitive data (credential cert) |
-| testCryptoKit.swift:80:44:80:44 | account_no | testCryptoKit.swift:80:44:80:44 | account_no | testCryptoKit.swift:80:44:80:44 | account_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:80:44:80:44 | account_no | sensitive data (private information account_no) |
-| testCryptoKit.swift:81:44:81:44 | credit_card_no | testCryptoKit.swift:81:44:81:44 | credit_card_no | testCryptoKit.swift:81:44:81:44 | credit_card_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:81:44:81:44 | credit_card_no | sensitive data (private information credit_card_no) |
-| testCryptoKit.swift:105:23:105:23 | cert | testCryptoKit.swift:105:23:105:23 | cert | testCryptoKit.swift:105:23:105:23 | cert | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:105:23:105:23 | cert | sensitive data (credential cert) |
-| testCryptoKit.swift:107:23:107:23 | account_no | testCryptoKit.swift:107:23:107:23 | account_no | testCryptoKit.swift:107:23:107:23 | account_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:107:23:107:23 | account_no | sensitive data (private information account_no) |
-| testCryptoKit.swift:108:23:108:23 | credit_card_no | testCryptoKit.swift:108:23:108:23 | credit_card_no | testCryptoKit.swift:108:23:108:23 | credit_card_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:108:23:108:23 | credit_card_no | sensitive data (private information credit_card_no) |
-| testCryptoKit.swift:114:23:114:23 | cert | testCryptoKit.swift:114:23:114:23 | cert | testCryptoKit.swift:114:23:114:23 | cert | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:114:23:114:23 | cert | sensitive data (credential cert) |
-| testCryptoKit.swift:116:23:116:23 | account_no | testCryptoKit.swift:116:23:116:23 | account_no | testCryptoKit.swift:116:23:116:23 | account_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:116:23:116:23 | account_no | sensitive data (private information account_no) |
-| testCryptoKit.swift:117:23:117:23 | credit_card_no | testCryptoKit.swift:117:23:117:23 | credit_card_no | testCryptoKit.swift:117:23:117:23 | credit_card_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:117:23:117:23 | credit_card_no | sensitive data (private information credit_card_no) |
-| testCryptoKit.swift:150:32:150:32 | cert | testCryptoKit.swift:150:32:150:32 | cert | testCryptoKit.swift:150:32:150:32 | cert | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:150:32:150:32 | cert | sensitive data (credential cert) |
-| testCryptoKit.swift:152:32:152:32 | account_no | testCryptoKit.swift:152:32:152:32 | account_no | testCryptoKit.swift:152:32:152:32 | account_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:152:32:152:32 | account_no | sensitive data (private information account_no) |
-| testCryptoKit.swift:153:32:153:32 | credit_card_no | testCryptoKit.swift:153:32:153:32 | credit_card_no | testCryptoKit.swift:153:32:153:32 | credit_card_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:153:32:153:32 | credit_card_no | sensitive data (private information credit_card_no) |
-| testCryptoKit.swift:159:32:159:32 | cert | testCryptoKit.swift:159:32:159:32 | cert | testCryptoKit.swift:159:32:159:32 | cert | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:159:32:159:32 | cert | sensitive data (credential cert) |
-| testCryptoKit.swift:161:32:161:32 | account_no | testCryptoKit.swift:161:32:161:32 | account_no | testCryptoKit.swift:161:32:161:32 | account_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:161:32:161:32 | account_no | sensitive data (private information account_no) |
-| testCryptoKit.swift:162:32:162:32 | credit_card_no | testCryptoKit.swift:162:32:162:32 | credit_card_no | testCryptoKit.swift:162:32:162:32 | credit_card_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:162:32:162:32 | credit_card_no | sensitive data (private information credit_card_no) |
+| testCryptoKit.swift:169:32:169:32 | cert | testCryptoKit.swift:169:32:169:32 | cert | testCryptoKit.swift:169:32:169:32 | cert | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:169:32:169:32 | cert | sensitive data (credential cert) |
+| testCryptoKit.swift:171:32:171:32 | account_no | testCryptoKit.swift:171:32:171:32 | account_no | testCryptoKit.swift:171:32:171:32 | account_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:171:32:171:32 | account_no | sensitive data (private information account_no) |
+| testCryptoKit.swift:172:32:172:32 | credit_card_no | testCryptoKit.swift:172:32:172:32 | credit_card_no | testCryptoKit.swift:172:32:172:32 | credit_card_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:172:32:172:32 | credit_card_no | sensitive data (private information credit_card_no) |
+| testCryptoKit.swift:178:32:178:32 | cert | testCryptoKit.swift:178:32:178:32 | cert | testCryptoKit.swift:178:32:178:32 | cert | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:178:32:178:32 | cert | sensitive data (credential cert) |
+| testCryptoKit.swift:180:32:180:32 | account_no | testCryptoKit.swift:180:32:180:32 | account_no | testCryptoKit.swift:180:32:180:32 | account_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:180:32:180:32 | account_no | sensitive data (private information account_no) |
+| testCryptoKit.swift:181:32:181:32 | credit_card_no | testCryptoKit.swift:181:32:181:32 | credit_card_no | testCryptoKit.swift:181:32:181:32 | credit_card_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:181:32:181:32 | credit_card_no | sensitive data (private information credit_card_no) |
 | testCryptoSwift.swift:153:30:153:30 | phoneNumberArray | testCryptoSwift.swift:153:30:153:30 | phoneNumberArray | testCryptoSwift.swift:153:30:153:30 | phoneNumberArray | Insecure hashing algorithm (MD5) depends on $@. | testCryptoSwift.swift:153:30:153:30 | phoneNumberArray | sensitive data (private information phoneNumberArray) |
 | testCryptoSwift.swift:156:31:156:31 | phoneNumberArray | testCryptoSwift.swift:156:31:156:31 | phoneNumberArray | testCryptoSwift.swift:156:31:156:31 | phoneNumberArray | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoSwift.swift:156:31:156:31 | phoneNumberArray | sensitive data (private information phoneNumberArray) |
 | testCryptoSwift.swift:166:20:166:20 | phoneNumberArray | testCryptoSwift.swift:166:20:166:20 | phoneNumberArray | testCryptoSwift.swift:166:20:166:20 | phoneNumberArray | Insecure hashing algorithm (MD5) depends on $@. | testCryptoSwift.swift:166:20:166:20 | phoneNumberArray | sensitive data (private information phoneNumberArray) |

--- a/swift/ql/test/query-tests/Security/CWE-328/WeakSensitiveDataHashing.expected
+++ b/swift/ql/test/query-tests/Security/CWE-328/WeakSensitiveDataHashing.expected
@@ -28,6 +28,12 @@ nodes
 | testCryptoKit.swift:97:44:97:44 | cert | semmle.label | cert |
 | testCryptoKit.swift:99:44:99:44 | account_no | semmle.label | account_no |
 | testCryptoKit.swift:100:44:100:44 | credit_card_no | semmle.label | credit_card_no |
+| testCryptoKit.swift:124:23:124:23 | cert | semmle.label | cert |
+| testCryptoKit.swift:126:23:126:23 | account_no | semmle.label | account_no |
+| testCryptoKit.swift:127:23:127:23 | credit_card_no | semmle.label | credit_card_no |
+| testCryptoKit.swift:133:23:133:23 | cert | semmle.label | cert |
+| testCryptoKit.swift:135:23:135:23 | account_no | semmle.label | account_no |
+| testCryptoKit.swift:136:23:136:23 | credit_card_no | semmle.label | credit_card_no |
 | testCryptoKit.swift:169:32:169:32 | cert | semmle.label | cert |
 | testCryptoKit.swift:171:32:171:32 | account_no | semmle.label | account_no |
 | testCryptoKit.swift:172:32:172:32 | credit_card_no | semmle.label | credit_card_no |
@@ -79,6 +85,12 @@ subpaths
 | testCryptoKit.swift:97:44:97:44 | cert | testCryptoKit.swift:97:44:97:44 | cert | testCryptoKit.swift:97:44:97:44 | cert | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:97:44:97:44 | cert | sensitive data (credential cert) |
 | testCryptoKit.swift:99:44:99:44 | account_no | testCryptoKit.swift:99:44:99:44 | account_no | testCryptoKit.swift:99:44:99:44 | account_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:99:44:99:44 | account_no | sensitive data (private information account_no) |
 | testCryptoKit.swift:100:44:100:44 | credit_card_no | testCryptoKit.swift:100:44:100:44 | credit_card_no | testCryptoKit.swift:100:44:100:44 | credit_card_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:100:44:100:44 | credit_card_no | sensitive data (private information credit_card_no) |
+| testCryptoKit.swift:124:23:124:23 | cert | testCryptoKit.swift:124:23:124:23 | cert | testCryptoKit.swift:124:23:124:23 | cert | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:124:23:124:23 | cert | sensitive data (credential cert) |
+| testCryptoKit.swift:126:23:126:23 | account_no | testCryptoKit.swift:126:23:126:23 | account_no | testCryptoKit.swift:126:23:126:23 | account_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:126:23:126:23 | account_no | sensitive data (private information account_no) |
+| testCryptoKit.swift:127:23:127:23 | credit_card_no | testCryptoKit.swift:127:23:127:23 | credit_card_no | testCryptoKit.swift:127:23:127:23 | credit_card_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:127:23:127:23 | credit_card_no | sensitive data (private information credit_card_no) |
+| testCryptoKit.swift:133:23:133:23 | cert | testCryptoKit.swift:133:23:133:23 | cert | testCryptoKit.swift:133:23:133:23 | cert | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:133:23:133:23 | cert | sensitive data (credential cert) |
+| testCryptoKit.swift:135:23:135:23 | account_no | testCryptoKit.swift:135:23:135:23 | account_no | testCryptoKit.swift:135:23:135:23 | account_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:135:23:135:23 | account_no | sensitive data (private information account_no) |
+| testCryptoKit.swift:136:23:136:23 | credit_card_no | testCryptoKit.swift:136:23:136:23 | credit_card_no | testCryptoKit.swift:136:23:136:23 | credit_card_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:136:23:136:23 | credit_card_no | sensitive data (private information credit_card_no) |
 | testCryptoKit.swift:169:32:169:32 | cert | testCryptoKit.swift:169:32:169:32 | cert | testCryptoKit.swift:169:32:169:32 | cert | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:169:32:169:32 | cert | sensitive data (credential cert) |
 | testCryptoKit.swift:171:32:171:32 | account_no | testCryptoKit.swift:171:32:171:32 | account_no | testCryptoKit.swift:171:32:171:32 | account_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:171:32:171:32 | account_no | sensitive data (private information account_no) |
 | testCryptoKit.swift:172:32:172:32 | credit_card_no | testCryptoKit.swift:172:32:172:32 | credit_card_no | testCryptoKit.swift:172:32:172:32 | credit_card_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:172:32:172:32 | credit_card_no | sensitive data (private information credit_card_no) |

--- a/swift/ql/test/query-tests/Security/CWE-328/WeakSensitiveDataHashing.expected
+++ b/swift/ql/test/query-tests/Security/CWE-328/WeakSensitiveDataHashing.expected
@@ -1,69 +1,69 @@
 edges
-| testCryptoKit.swift:224:18:224:38 | call to Data.init(_:) | testCryptoKit.swift:225:44:225:44 | value1 | provenance |  |
-| testCryptoKit.swift:224:23:224:23 | cardNumber | testCryptoKit.swift:224:23:224:34 | .utf8 | provenance |  |
-| testCryptoKit.swift:224:23:224:34 | .utf8 | testCryptoKit.swift:224:18:224:38 | call to Data.init(_:) | provenance |  |
-| testCryptoKit.swift:227:18:227:38 | call to Data.init(_:) | testCryptoKit.swift:229:39:229:39 | value2 | provenance |  |
-| testCryptoKit.swift:227:23:227:23 | cardNumber | testCryptoKit.swift:227:23:227:34 | .utf8 | provenance |  |
-| testCryptoKit.swift:227:23:227:34 | .utf8 | testCryptoKit.swift:227:18:227:38 | call to Data.init(_:) | provenance |  |
-| testCryptoKit.swift:231:18:231:38 | call to Data.init(_:) | testCryptoKit.swift:232:51:232:51 | value3 | provenance |  |
-| testCryptoKit.swift:231:23:231:23 | cardNumber | testCryptoKit.swift:231:23:231:34 | .utf8 | provenance |  |
-| testCryptoKit.swift:231:23:231:34 | .utf8 | testCryptoKit.swift:231:18:231:38 | call to Data.init(_:) | provenance |  |
-| testCryptoKit.swift:234:18:234:38 | call to Data.init(_:) | testCryptoKit.swift:235:26:235:26 | value4 | provenance |  |
-| testCryptoKit.swift:234:23:234:23 | cardNumber | testCryptoKit.swift:234:23:234:34 | .utf8 | provenance |  |
-| testCryptoKit.swift:234:23:234:34 | .utf8 | testCryptoKit.swift:234:18:234:38 | call to Data.init(_:) | provenance |  |
-| testCryptoKit.swift:235:26:235:26 | value4 | testCryptoKit.swift:244:20:244:27 | value | provenance |  |
-| testCryptoKit.swift:237:18:237:38 | call to Data.init(_:) | testCryptoKit.swift:238:53:238:53 | value5 | provenance |  |
+| testCryptoKit.swift:230:18:230:38 | call to Data.init(_:) | testCryptoKit.swift:231:44:231:44 | value1 | provenance |  |
+| testCryptoKit.swift:230:23:230:23 | cardNumber | testCryptoKit.swift:230:23:230:34 | .utf8 | provenance |  |
+| testCryptoKit.swift:230:23:230:34 | .utf8 | testCryptoKit.swift:230:18:230:38 | call to Data.init(_:) | provenance |  |
+| testCryptoKit.swift:233:18:233:38 | call to Data.init(_:) | testCryptoKit.swift:235:39:235:39 | value2 | provenance |  |
+| testCryptoKit.swift:233:23:233:23 | cardNumber | testCryptoKit.swift:233:23:233:34 | .utf8 | provenance |  |
+| testCryptoKit.swift:233:23:233:34 | .utf8 | testCryptoKit.swift:233:18:233:38 | call to Data.init(_:) | provenance |  |
+| testCryptoKit.swift:237:18:237:38 | call to Data.init(_:) | testCryptoKit.swift:238:51:238:51 | value3 | provenance |  |
 | testCryptoKit.swift:237:23:237:23 | cardNumber | testCryptoKit.swift:237:23:237:34 | .utf8 | provenance |  |
 | testCryptoKit.swift:237:23:237:34 | .utf8 | testCryptoKit.swift:237:18:237:38 | call to Data.init(_:) | provenance |  |
-| testCryptoKit.swift:238:53:238:53 | value5 | testCryptoKit.swift:248:47:248:54 | value | provenance |  |
-| testCryptoKit.swift:244:20:244:27 | value | testCryptoKit.swift:245:43:245:43 | value | provenance |  |
-| testCryptoKit.swift:248:47:248:54 | value | testCryptoKit.swift:249:37:249:37 | value | provenance |  |
+| testCryptoKit.swift:240:18:240:38 | call to Data.init(_:) | testCryptoKit.swift:241:26:241:26 | value4 | provenance |  |
+| testCryptoKit.swift:240:23:240:23 | cardNumber | testCryptoKit.swift:240:23:240:34 | .utf8 | provenance |  |
+| testCryptoKit.swift:240:23:240:34 | .utf8 | testCryptoKit.swift:240:18:240:38 | call to Data.init(_:) | provenance |  |
+| testCryptoKit.swift:241:26:241:26 | value4 | testCryptoKit.swift:250:20:250:27 | value | provenance |  |
+| testCryptoKit.swift:243:18:243:38 | call to Data.init(_:) | testCryptoKit.swift:244:53:244:53 | value5 | provenance |  |
+| testCryptoKit.swift:243:23:243:23 | cardNumber | testCryptoKit.swift:243:23:243:34 | .utf8 | provenance |  |
+| testCryptoKit.swift:243:23:243:34 | .utf8 | testCryptoKit.swift:243:18:243:38 | call to Data.init(_:) | provenance |  |
+| testCryptoKit.swift:244:53:244:53 | value5 | testCryptoKit.swift:254:47:254:54 | value | provenance |  |
+| testCryptoKit.swift:250:20:250:27 | value | testCryptoKit.swift:251:43:251:43 | value | provenance |  |
+| testCryptoKit.swift:254:47:254:54 | value | testCryptoKit.swift:255:37:255:37 | value | provenance |  |
 nodes
-| testCryptoKit.swift:85:43:85:43 | cert | semmle.label | cert |
-| testCryptoKit.swift:87:43:87:43 | account_no | semmle.label | account_no |
-| testCryptoKit.swift:88:43:88:43 | credit_card_no | semmle.label | credit_card_no |
-| testCryptoKit.swift:91:36:91:36 | cert | semmle.label | cert |
-| testCryptoKit.swift:93:36:93:36 | account_no | semmle.label | account_no |
-| testCryptoKit.swift:94:36:94:36 | credit_card_no | semmle.label | credit_card_no |
-| testCryptoKit.swift:97:44:97:44 | cert | semmle.label | cert |
-| testCryptoKit.swift:99:44:99:44 | account_no | semmle.label | account_no |
-| testCryptoKit.swift:100:44:100:44 | credit_card_no | semmle.label | credit_card_no |
-| testCryptoKit.swift:124:23:124:23 | cert | semmle.label | cert |
-| testCryptoKit.swift:126:23:126:23 | account_no | semmle.label | account_no |
-| testCryptoKit.swift:127:23:127:23 | credit_card_no | semmle.label | credit_card_no |
-| testCryptoKit.swift:133:23:133:23 | cert | semmle.label | cert |
-| testCryptoKit.swift:135:23:135:23 | account_no | semmle.label | account_no |
-| testCryptoKit.swift:136:23:136:23 | credit_card_no | semmle.label | credit_card_no |
-| testCryptoKit.swift:169:32:169:32 | cert | semmle.label | cert |
-| testCryptoKit.swift:171:32:171:32 | account_no | semmle.label | account_no |
-| testCryptoKit.swift:172:32:172:32 | credit_card_no | semmle.label | credit_card_no |
-| testCryptoKit.swift:178:32:178:32 | cert | semmle.label | cert |
-| testCryptoKit.swift:180:32:180:32 | account_no | semmle.label | account_no |
-| testCryptoKit.swift:181:32:181:32 | credit_card_no | semmle.label | credit_card_no |
-| testCryptoKit.swift:224:18:224:38 | call to Data.init(_:) | semmle.label | call to Data.init(_:) |
-| testCryptoKit.swift:224:23:224:23 | cardNumber | semmle.label | cardNumber |
-| testCryptoKit.swift:224:23:224:34 | .utf8 | semmle.label | .utf8 |
-| testCryptoKit.swift:225:44:225:44 | value1 | semmle.label | value1 |
-| testCryptoKit.swift:227:18:227:38 | call to Data.init(_:) | semmle.label | call to Data.init(_:) |
-| testCryptoKit.swift:227:23:227:23 | cardNumber | semmle.label | cardNumber |
-| testCryptoKit.swift:227:23:227:34 | .utf8 | semmle.label | .utf8 |
-| testCryptoKit.swift:229:39:229:39 | value2 | semmle.label | value2 |
-| testCryptoKit.swift:231:18:231:38 | call to Data.init(_:) | semmle.label | call to Data.init(_:) |
-| testCryptoKit.swift:231:23:231:23 | cardNumber | semmle.label | cardNumber |
-| testCryptoKit.swift:231:23:231:34 | .utf8 | semmle.label | .utf8 |
-| testCryptoKit.swift:232:51:232:51 | value3 | semmle.label | value3 |
-| testCryptoKit.swift:234:18:234:38 | call to Data.init(_:) | semmle.label | call to Data.init(_:) |
-| testCryptoKit.swift:234:23:234:23 | cardNumber | semmle.label | cardNumber |
-| testCryptoKit.swift:234:23:234:34 | .utf8 | semmle.label | .utf8 |
-| testCryptoKit.swift:235:26:235:26 | value4 | semmle.label | value4 |
+| testCryptoKit.swift:86:43:86:43 | cert | semmle.label | cert |
+| testCryptoKit.swift:88:43:88:43 | account_no | semmle.label | account_no |
+| testCryptoKit.swift:89:43:89:43 | credit_card_no | semmle.label | credit_card_no |
+| testCryptoKit.swift:93:36:93:36 | cert | semmle.label | cert |
+| testCryptoKit.swift:95:36:95:36 | account_no | semmle.label | account_no |
+| testCryptoKit.swift:96:36:96:36 | credit_card_no | semmle.label | credit_card_no |
+| testCryptoKit.swift:100:44:100:44 | cert | semmle.label | cert |
+| testCryptoKit.swift:102:44:102:44 | account_no | semmle.label | account_no |
+| testCryptoKit.swift:103:44:103:44 | credit_card_no | semmle.label | credit_card_no |
+| testCryptoKit.swift:130:23:130:23 | cert | semmle.label | cert |
+| testCryptoKit.swift:132:23:132:23 | account_no | semmle.label | account_no |
+| testCryptoKit.swift:133:23:133:23 | credit_card_no | semmle.label | credit_card_no |
+| testCryptoKit.swift:139:23:139:23 | cert | semmle.label | cert |
+| testCryptoKit.swift:141:23:141:23 | account_no | semmle.label | account_no |
+| testCryptoKit.swift:142:23:142:23 | credit_card_no | semmle.label | credit_card_no |
+| testCryptoKit.swift:175:32:175:32 | cert | semmle.label | cert |
+| testCryptoKit.swift:177:32:177:32 | account_no | semmle.label | account_no |
+| testCryptoKit.swift:178:32:178:32 | credit_card_no | semmle.label | credit_card_no |
+| testCryptoKit.swift:184:32:184:32 | cert | semmle.label | cert |
+| testCryptoKit.swift:186:32:186:32 | account_no | semmle.label | account_no |
+| testCryptoKit.swift:187:32:187:32 | credit_card_no | semmle.label | credit_card_no |
+| testCryptoKit.swift:230:18:230:38 | call to Data.init(_:) | semmle.label | call to Data.init(_:) |
+| testCryptoKit.swift:230:23:230:23 | cardNumber | semmle.label | cardNumber |
+| testCryptoKit.swift:230:23:230:34 | .utf8 | semmle.label | .utf8 |
+| testCryptoKit.swift:231:44:231:44 | value1 | semmle.label | value1 |
+| testCryptoKit.swift:233:18:233:38 | call to Data.init(_:) | semmle.label | call to Data.init(_:) |
+| testCryptoKit.swift:233:23:233:23 | cardNumber | semmle.label | cardNumber |
+| testCryptoKit.swift:233:23:233:34 | .utf8 | semmle.label | .utf8 |
+| testCryptoKit.swift:235:39:235:39 | value2 | semmle.label | value2 |
 | testCryptoKit.swift:237:18:237:38 | call to Data.init(_:) | semmle.label | call to Data.init(_:) |
 | testCryptoKit.swift:237:23:237:23 | cardNumber | semmle.label | cardNumber |
 | testCryptoKit.swift:237:23:237:34 | .utf8 | semmle.label | .utf8 |
-| testCryptoKit.swift:238:53:238:53 | value5 | semmle.label | value5 |
-| testCryptoKit.swift:244:20:244:27 | value | semmle.label | value |
-| testCryptoKit.swift:245:43:245:43 | value | semmle.label | value |
-| testCryptoKit.swift:248:47:248:54 | value | semmle.label | value |
-| testCryptoKit.swift:249:37:249:37 | value | semmle.label | value |
+| testCryptoKit.swift:238:51:238:51 | value3 | semmle.label | value3 |
+| testCryptoKit.swift:240:18:240:38 | call to Data.init(_:) | semmle.label | call to Data.init(_:) |
+| testCryptoKit.swift:240:23:240:23 | cardNumber | semmle.label | cardNumber |
+| testCryptoKit.swift:240:23:240:34 | .utf8 | semmle.label | .utf8 |
+| testCryptoKit.swift:241:26:241:26 | value4 | semmle.label | value4 |
+| testCryptoKit.swift:243:18:243:38 | call to Data.init(_:) | semmle.label | call to Data.init(_:) |
+| testCryptoKit.swift:243:23:243:23 | cardNumber | semmle.label | cardNumber |
+| testCryptoKit.swift:243:23:243:34 | .utf8 | semmle.label | .utf8 |
+| testCryptoKit.swift:244:53:244:53 | value5 | semmle.label | value5 |
+| testCryptoKit.swift:250:20:250:27 | value | semmle.label | value |
+| testCryptoKit.swift:251:43:251:43 | value | semmle.label | value |
+| testCryptoKit.swift:254:47:254:54 | value | semmle.label | value |
+| testCryptoKit.swift:255:37:255:37 | value | semmle.label | value |
 | testCryptoSwift.swift:153:30:153:30 | phoneNumberArray | semmle.label | phoneNumberArray |
 | testCryptoSwift.swift:156:31:156:31 | phoneNumberArray | semmle.label | phoneNumberArray |
 | testCryptoSwift.swift:166:20:166:20 | phoneNumberArray | semmle.label | phoneNumberArray |
@@ -76,32 +76,32 @@ nodes
 | testCryptoSwift.swift:221:9:221:9 | creditCardNumber | semmle.label | creditCardNumber |
 subpaths
 #select
-| testCryptoKit.swift:85:43:85:43 | cert | testCryptoKit.swift:85:43:85:43 | cert | testCryptoKit.swift:85:43:85:43 | cert | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:85:43:85:43 | cert | sensitive data (credential cert) |
-| testCryptoKit.swift:87:43:87:43 | account_no | testCryptoKit.swift:87:43:87:43 | account_no | testCryptoKit.swift:87:43:87:43 | account_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:87:43:87:43 | account_no | sensitive data (private information account_no) |
-| testCryptoKit.swift:88:43:88:43 | credit_card_no | testCryptoKit.swift:88:43:88:43 | credit_card_no | testCryptoKit.swift:88:43:88:43 | credit_card_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:88:43:88:43 | credit_card_no | sensitive data (private information credit_card_no) |
-| testCryptoKit.swift:91:36:91:36 | cert | testCryptoKit.swift:91:36:91:36 | cert | testCryptoKit.swift:91:36:91:36 | cert | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:91:36:91:36 | cert | sensitive data (credential cert) |
-| testCryptoKit.swift:93:36:93:36 | account_no | testCryptoKit.swift:93:36:93:36 | account_no | testCryptoKit.swift:93:36:93:36 | account_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:93:36:93:36 | account_no | sensitive data (private information account_no) |
-| testCryptoKit.swift:94:36:94:36 | credit_card_no | testCryptoKit.swift:94:36:94:36 | credit_card_no | testCryptoKit.swift:94:36:94:36 | credit_card_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:94:36:94:36 | credit_card_no | sensitive data (private information credit_card_no) |
-| testCryptoKit.swift:97:44:97:44 | cert | testCryptoKit.swift:97:44:97:44 | cert | testCryptoKit.swift:97:44:97:44 | cert | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:97:44:97:44 | cert | sensitive data (credential cert) |
-| testCryptoKit.swift:99:44:99:44 | account_no | testCryptoKit.swift:99:44:99:44 | account_no | testCryptoKit.swift:99:44:99:44 | account_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:99:44:99:44 | account_no | sensitive data (private information account_no) |
-| testCryptoKit.swift:100:44:100:44 | credit_card_no | testCryptoKit.swift:100:44:100:44 | credit_card_no | testCryptoKit.swift:100:44:100:44 | credit_card_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:100:44:100:44 | credit_card_no | sensitive data (private information credit_card_no) |
-| testCryptoKit.swift:124:23:124:23 | cert | testCryptoKit.swift:124:23:124:23 | cert | testCryptoKit.swift:124:23:124:23 | cert | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:124:23:124:23 | cert | sensitive data (credential cert) |
-| testCryptoKit.swift:126:23:126:23 | account_no | testCryptoKit.swift:126:23:126:23 | account_no | testCryptoKit.swift:126:23:126:23 | account_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:126:23:126:23 | account_no | sensitive data (private information account_no) |
-| testCryptoKit.swift:127:23:127:23 | credit_card_no | testCryptoKit.swift:127:23:127:23 | credit_card_no | testCryptoKit.swift:127:23:127:23 | credit_card_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:127:23:127:23 | credit_card_no | sensitive data (private information credit_card_no) |
-| testCryptoKit.swift:133:23:133:23 | cert | testCryptoKit.swift:133:23:133:23 | cert | testCryptoKit.swift:133:23:133:23 | cert | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:133:23:133:23 | cert | sensitive data (credential cert) |
-| testCryptoKit.swift:135:23:135:23 | account_no | testCryptoKit.swift:135:23:135:23 | account_no | testCryptoKit.swift:135:23:135:23 | account_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:135:23:135:23 | account_no | sensitive data (private information account_no) |
-| testCryptoKit.swift:136:23:136:23 | credit_card_no | testCryptoKit.swift:136:23:136:23 | credit_card_no | testCryptoKit.swift:136:23:136:23 | credit_card_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:136:23:136:23 | credit_card_no | sensitive data (private information credit_card_no) |
-| testCryptoKit.swift:169:32:169:32 | cert | testCryptoKit.swift:169:32:169:32 | cert | testCryptoKit.swift:169:32:169:32 | cert | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:169:32:169:32 | cert | sensitive data (credential cert) |
-| testCryptoKit.swift:171:32:171:32 | account_no | testCryptoKit.swift:171:32:171:32 | account_no | testCryptoKit.swift:171:32:171:32 | account_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:171:32:171:32 | account_no | sensitive data (private information account_no) |
-| testCryptoKit.swift:172:32:172:32 | credit_card_no | testCryptoKit.swift:172:32:172:32 | credit_card_no | testCryptoKit.swift:172:32:172:32 | credit_card_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:172:32:172:32 | credit_card_no | sensitive data (private information credit_card_no) |
-| testCryptoKit.swift:178:32:178:32 | cert | testCryptoKit.swift:178:32:178:32 | cert | testCryptoKit.swift:178:32:178:32 | cert | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:178:32:178:32 | cert | sensitive data (credential cert) |
-| testCryptoKit.swift:180:32:180:32 | account_no | testCryptoKit.swift:180:32:180:32 | account_no | testCryptoKit.swift:180:32:180:32 | account_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:180:32:180:32 | account_no | sensitive data (private information account_no) |
-| testCryptoKit.swift:181:32:181:32 | credit_card_no | testCryptoKit.swift:181:32:181:32 | credit_card_no | testCryptoKit.swift:181:32:181:32 | credit_card_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:181:32:181:32 | credit_card_no | sensitive data (private information credit_card_no) |
-| testCryptoKit.swift:225:44:225:44 | value1 | testCryptoKit.swift:224:23:224:23 | cardNumber | testCryptoKit.swift:225:44:225:44 | value1 | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:224:23:224:23 | cardNumber | sensitive data (private information cardNumber) |
-| testCryptoKit.swift:229:39:229:39 | value2 | testCryptoKit.swift:227:23:227:23 | cardNumber | testCryptoKit.swift:229:39:229:39 | value2 | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:227:23:227:23 | cardNumber | sensitive data (private information cardNumber) |
-| testCryptoKit.swift:232:51:232:51 | value3 | testCryptoKit.swift:231:23:231:23 | cardNumber | testCryptoKit.swift:232:51:232:51 | value3 | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:231:23:231:23 | cardNumber | sensitive data (private information cardNumber) |
-| testCryptoKit.swift:245:43:245:43 | value | testCryptoKit.swift:234:23:234:23 | cardNumber | testCryptoKit.swift:245:43:245:43 | value | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:234:23:234:23 | cardNumber | sensitive data (private information cardNumber) |
-| testCryptoKit.swift:249:37:249:37 | value | testCryptoKit.swift:237:23:237:23 | cardNumber | testCryptoKit.swift:249:37:249:37 | value | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:237:23:237:23 | cardNumber | sensitive data (private information cardNumber) |
+| testCryptoKit.swift:86:43:86:43 | cert | testCryptoKit.swift:86:43:86:43 | cert | testCryptoKit.swift:86:43:86:43 | cert | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:86:43:86:43 | cert | sensitive data (credential cert) |
+| testCryptoKit.swift:88:43:88:43 | account_no | testCryptoKit.swift:88:43:88:43 | account_no | testCryptoKit.swift:88:43:88:43 | account_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:88:43:88:43 | account_no | sensitive data (private information account_no) |
+| testCryptoKit.swift:89:43:89:43 | credit_card_no | testCryptoKit.swift:89:43:89:43 | credit_card_no | testCryptoKit.swift:89:43:89:43 | credit_card_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:89:43:89:43 | credit_card_no | sensitive data (private information credit_card_no) |
+| testCryptoKit.swift:93:36:93:36 | cert | testCryptoKit.swift:93:36:93:36 | cert | testCryptoKit.swift:93:36:93:36 | cert | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:93:36:93:36 | cert | sensitive data (credential cert) |
+| testCryptoKit.swift:95:36:95:36 | account_no | testCryptoKit.swift:95:36:95:36 | account_no | testCryptoKit.swift:95:36:95:36 | account_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:95:36:95:36 | account_no | sensitive data (private information account_no) |
+| testCryptoKit.swift:96:36:96:36 | credit_card_no | testCryptoKit.swift:96:36:96:36 | credit_card_no | testCryptoKit.swift:96:36:96:36 | credit_card_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:96:36:96:36 | credit_card_no | sensitive data (private information credit_card_no) |
+| testCryptoKit.swift:100:44:100:44 | cert | testCryptoKit.swift:100:44:100:44 | cert | testCryptoKit.swift:100:44:100:44 | cert | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:100:44:100:44 | cert | sensitive data (credential cert) |
+| testCryptoKit.swift:102:44:102:44 | account_no | testCryptoKit.swift:102:44:102:44 | account_no | testCryptoKit.swift:102:44:102:44 | account_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:102:44:102:44 | account_no | sensitive data (private information account_no) |
+| testCryptoKit.swift:103:44:103:44 | credit_card_no | testCryptoKit.swift:103:44:103:44 | credit_card_no | testCryptoKit.swift:103:44:103:44 | credit_card_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:103:44:103:44 | credit_card_no | sensitive data (private information credit_card_no) |
+| testCryptoKit.swift:130:23:130:23 | cert | testCryptoKit.swift:130:23:130:23 | cert | testCryptoKit.swift:130:23:130:23 | cert | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:130:23:130:23 | cert | sensitive data (credential cert) |
+| testCryptoKit.swift:132:23:132:23 | account_no | testCryptoKit.swift:132:23:132:23 | account_no | testCryptoKit.swift:132:23:132:23 | account_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:132:23:132:23 | account_no | sensitive data (private information account_no) |
+| testCryptoKit.swift:133:23:133:23 | credit_card_no | testCryptoKit.swift:133:23:133:23 | credit_card_no | testCryptoKit.swift:133:23:133:23 | credit_card_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:133:23:133:23 | credit_card_no | sensitive data (private information credit_card_no) |
+| testCryptoKit.swift:139:23:139:23 | cert | testCryptoKit.swift:139:23:139:23 | cert | testCryptoKit.swift:139:23:139:23 | cert | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:139:23:139:23 | cert | sensitive data (credential cert) |
+| testCryptoKit.swift:141:23:141:23 | account_no | testCryptoKit.swift:141:23:141:23 | account_no | testCryptoKit.swift:141:23:141:23 | account_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:141:23:141:23 | account_no | sensitive data (private information account_no) |
+| testCryptoKit.swift:142:23:142:23 | credit_card_no | testCryptoKit.swift:142:23:142:23 | credit_card_no | testCryptoKit.swift:142:23:142:23 | credit_card_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:142:23:142:23 | credit_card_no | sensitive data (private information credit_card_no) |
+| testCryptoKit.swift:175:32:175:32 | cert | testCryptoKit.swift:175:32:175:32 | cert | testCryptoKit.swift:175:32:175:32 | cert | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:175:32:175:32 | cert | sensitive data (credential cert) |
+| testCryptoKit.swift:177:32:177:32 | account_no | testCryptoKit.swift:177:32:177:32 | account_no | testCryptoKit.swift:177:32:177:32 | account_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:177:32:177:32 | account_no | sensitive data (private information account_no) |
+| testCryptoKit.swift:178:32:178:32 | credit_card_no | testCryptoKit.swift:178:32:178:32 | credit_card_no | testCryptoKit.swift:178:32:178:32 | credit_card_no | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:178:32:178:32 | credit_card_no | sensitive data (private information credit_card_no) |
+| testCryptoKit.swift:184:32:184:32 | cert | testCryptoKit.swift:184:32:184:32 | cert | testCryptoKit.swift:184:32:184:32 | cert | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:184:32:184:32 | cert | sensitive data (credential cert) |
+| testCryptoKit.swift:186:32:186:32 | account_no | testCryptoKit.swift:186:32:186:32 | account_no | testCryptoKit.swift:186:32:186:32 | account_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:186:32:186:32 | account_no | sensitive data (private information account_no) |
+| testCryptoKit.swift:187:32:187:32 | credit_card_no | testCryptoKit.swift:187:32:187:32 | credit_card_no | testCryptoKit.swift:187:32:187:32 | credit_card_no | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoKit.swift:187:32:187:32 | credit_card_no | sensitive data (private information credit_card_no) |
+| testCryptoKit.swift:231:44:231:44 | value1 | testCryptoKit.swift:230:23:230:23 | cardNumber | testCryptoKit.swift:231:44:231:44 | value1 | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:230:23:230:23 | cardNumber | sensitive data (private information cardNumber) |
+| testCryptoKit.swift:235:39:235:39 | value2 | testCryptoKit.swift:233:23:233:23 | cardNumber | testCryptoKit.swift:235:39:235:39 | value2 | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:233:23:233:23 | cardNumber | sensitive data (private information cardNumber) |
+| testCryptoKit.swift:238:51:238:51 | value3 | testCryptoKit.swift:237:23:237:23 | cardNumber | testCryptoKit.swift:238:51:238:51 | value3 | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:237:23:237:23 | cardNumber | sensitive data (private information cardNumber) |
+| testCryptoKit.swift:251:43:251:43 | value | testCryptoKit.swift:240:23:240:23 | cardNumber | testCryptoKit.swift:251:43:251:43 | value | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:240:23:240:23 | cardNumber | sensitive data (private information cardNumber) |
+| testCryptoKit.swift:255:37:255:37 | value | testCryptoKit.swift:243:23:243:23 | cardNumber | testCryptoKit.swift:255:37:255:37 | value | Insecure hashing algorithm (MD5) depends on $@. | testCryptoKit.swift:243:23:243:23 | cardNumber | sensitive data (private information cardNumber) |
 | testCryptoSwift.swift:153:30:153:30 | phoneNumberArray | testCryptoSwift.swift:153:30:153:30 | phoneNumberArray | testCryptoSwift.swift:153:30:153:30 | phoneNumberArray | Insecure hashing algorithm (MD5) depends on $@. | testCryptoSwift.swift:153:30:153:30 | phoneNumberArray | sensitive data (private information phoneNumberArray) |
 | testCryptoSwift.swift:156:31:156:31 | phoneNumberArray | testCryptoSwift.swift:156:31:156:31 | phoneNumberArray | testCryptoSwift.swift:156:31:156:31 | phoneNumberArray | Insecure hashing algorithm (SHA1) depends on $@. | testCryptoSwift.swift:156:31:156:31 | phoneNumberArray | sensitive data (private information phoneNumberArray) |
 | testCryptoSwift.swift:166:20:166:20 | phoneNumberArray | testCryptoSwift.swift:166:20:166:20 | phoneNumberArray | testCryptoSwift.swift:166:20:166:20 | phoneNumberArray | Insecure hashing algorithm (MD5) depends on $@. | testCryptoSwift.swift:166:20:166:20 | phoneNumberArray | sensitive data (private information phoneNumberArray) |

--- a/swift/ql/test/query-tests/Security/CWE-328/testCryptoKit.swift
+++ b/swift/ql/test/query-tests/Security/CWE-328/testCryptoKit.swift
@@ -219,3 +219,36 @@ func testBadExample(passwordString: String) {
 	    // ...
     }
 }
+
+func testWithFlowAndMetatypes(cardNumber: String) {
+    let value1 = Data(cardNumber.utf8);
+    let _digest1 = Insecure.MD5.hash(data: value1); // BAD [NOT DETECTED]
+
+    let value2 = Data(cardNumber.utf8);
+    let hasher2 = Insecure.MD5.self; // metatype
+    let _digest2 = hasher2.hash(data: value2); // BAD [NOT DETECTED]
+
+    let value3 = Data(cardNumber.utf8);
+    let _digest3 = (Insecure.MD5.self).hash(data: value3); // BAD [NOT DETECTED]
+
+    let value4 = Data(cardNumber.utf8);
+    testReceiver1(value: value4);
+
+    let value5 = Data(cardNumber.utf8);
+    testReceiver2(hasher: Insecure.MD5.self, value: value5);
+
+    let value6 = Data(cardNumber.utf8);
+    testReceiver3(hasher: Insecure.MD5.self, value: value6);
+}
+
+func testReceiver1(value: Data) {
+    let _digest = Insecure.MD5.hash(data: value); // BAD [NOT DETECTED]
+}
+
+func testReceiver2(hasher: Insecure.MD5.Type, value: Data) {
+    let _digest = hasher.hash(data: value); // BAD [NOT DETECTED]
+}
+
+func testReceiver3<H: HashFunction>(hasher: H.Type, value: Data) {
+    let _digest = hasher.hash(data: value); // BAD [NOT DETECTED]
+}

--- a/swift/ql/test/query-tests/Security/CWE-328/testCryptoKit.swift
+++ b/swift/ql/test/query-tests/Security/CWE-328/testCryptoKit.swift
@@ -120,25 +120,25 @@ func testHashMethods(passwd : UnsafeRawBufferPointer, cert: String, encrypted_pa
 
 func testMD5UpdateWithData(passwd : String, cert: String, encrypted_passwd : String, account_no : String, credit_card_no : String) {
     var hash = Crypto.Insecure.MD5()
-    hash.update(data: passwd)  // BAD [NOT DETECTED]
-    hash.update(data: cert)  // BAD [NOT DETECTED]
+    hash.update(data: passwd)  // BAD
+    hash.update(data: cert)  // BAD
     hash.update(data: encrypted_passwd)  // GOOD  (not sensitive)
-    hash.update(data: account_no)   // BAD [NOT DETECTED]
-    hash.update(data: credit_card_no)   // BAD [NOT DETECTED]
+    hash.update(data: account_no)   // BAD
+    hash.update(data: credit_card_no)   // BAD
 }
 
 func testSHA1UpdateWithData(passwd : String, cert: String, encrypted_passwd : String, account_no : String, credit_card_no : String) {
     var hash = Crypto.Insecure.SHA1()
-    hash.update(data: passwd)  // BAD [NOT DETECTED]
-    hash.update(data: cert)  // BAD [NOT DETECTED]
+    hash.update(data: passwd)  // BAD
+    hash.update(data: cert)  // BAD
     hash.update(data: encrypted_passwd)  // GOOD  (not sensitive)
-    hash.update(data: account_no)   // BAD [NOT DETECTED]
-    hash.update(data: credit_card_no)   // BAD [NOT DETECTED]
+    hash.update(data: account_no)   // BAD
+    hash.update(data: credit_card_no)   // BAD
 }
 
 func testSHA256UpdateWithData(passwd : String, cert: String, encrypted_passwd : String, account_no : String, credit_card_no : String) {
     var hash = Crypto.SHA256()
-    hash.update(data: passwd)  // BAD, not a computationally expensive hash [NOT DETECTED]
+    hash.update(data: passwd)  // BAD, not a computationally expensive hash
     hash.update(data: cert)  // GOOD
     hash.update(data: encrypted_passwd)   // GOOD  (not sensitive)
     hash.update(data: account_no)   // GOOD
@@ -147,7 +147,7 @@ func testSHA256UpdateWithData(passwd : String, cert: String, encrypted_passwd : 
 
 func testSHA384UpdateWithData(passwd : String, cert: String, encrypted_passwd : String, account_no : String, credit_card_no : String) {
     var hash = Crypto.SHA384()
-    hash.update(data: passwd)  // BAD, not a computationally expensive hash [NOT DETECTED]
+    hash.update(data: passwd)  // BAD, not a computationally expensive hash
     hash.update(data: cert)  // GOOD
     hash.update(data: encrypted_passwd)   // GOOD  (not sensitive)
     hash.update(data: account_no)   // GOOD
@@ -156,7 +156,7 @@ func testSHA384UpdateWithData(passwd : String, cert: String, encrypted_passwd : 
 
 func testSHA512UpdateWithData(passwd : String, cert: String, encrypted_passwd : String, account_no : String, credit_card_no : String) {
     var hash = Crypto.SHA512()
-    hash.update(data: passwd)  // BAD, not a computationally expensive hash [NOT DETECTED]
+    hash.update(data: passwd)  // BAD, not a computationally expensive hash
     hash.update(data: cert)  // GOOD
     hash.update(data: encrypted_passwd)   // GOOD  (not sensitive)
     hash.update(data: account_no)   // GOOD

--- a/swift/ql/test/query-tests/Security/CWE-328/testCryptoKit.swift
+++ b/swift/ql/test/query-tests/Security/CWE-328/testCryptoKit.swift
@@ -82,42 +82,42 @@ enum Insecure {
 
 func testHashMethods(passwd : UnsafeRawBufferPointer, cert: String, encrypted_passwd : String, account_no : String, credit_card_no : String) {
     var hash = Crypto.Insecure.MD5.hash(data: passwd)  // BAD
-    hash = Crypto.Insecure.MD5.hash(bufferPointer: passwd)  // BAD [NOT DETECTED]
+    hash = Crypto.Insecure.MD5.hash(bufferPointer: passwd)  // BAD
     hash = Crypto.Insecure.MD5.hash(data: cert)   // BAD
     hash = Crypto.Insecure.MD5.hash(data: encrypted_passwd)  // GOOD  (not sensitive)
     hash = Crypto.Insecure.MD5.hash(data: account_no)   // BAD
     hash = Crypto.Insecure.MD5.hash(data: credit_card_no)   // BAD
 
     hash = Insecure.MD5.hash(data: passwd)  // BAD
-    hash = Insecure.MD5.hash(bufferPointer: passwd)  // BAD [NOT DETECTED]
+    hash = Insecure.MD5.hash(bufferPointer: passwd)  // BAD
     hash = Insecure.MD5.hash(data: cert)   // BAD
     hash = Insecure.MD5.hash(data: encrypted_passwd)  // GOOD  (not sensitive)
     hash = Insecure.MD5.hash(data: account_no)   // BAD
     hash = Insecure.MD5.hash(data: credit_card_no)   // BAD
 
     hash = Crypto.Insecure.SHA1.hash(data: passwd)  // BAD
-    hash = Crypto.Insecure.SHA1.hash(bufferPointer: passwd)  // BAD [NOT DETECTED]
+    hash = Crypto.Insecure.SHA1.hash(bufferPointer: passwd)  // BAD
     hash = Crypto.Insecure.SHA1.hash(data: cert)   // BAD
     hash = Crypto.Insecure.SHA1.hash(data: encrypted_passwd)  // GOOD  (not sensitive)
     hash = Crypto.Insecure.SHA1.hash(data: account_no)   // BAD
     hash = Crypto.Insecure.SHA1.hash(data: credit_card_no)   // BAD
 
     hash = Crypto.SHA256.hash(data: passwd)   // BAD, not a computationally expensive hash
-    hash = Crypto.SHA256.hash(bufferPointer: passwd)   // BAD, not a computationally expensive hash [NOT DETECTED]
+    hash = Crypto.SHA256.hash(bufferPointer: passwd)   // BAD, not a computationally expensive hash
     hash = Crypto.SHA256.hash(data: cert)   // GOOD, computationally expensive hash not required
     hash = Crypto.SHA256.hash(data: encrypted_passwd)   // GOOD, not sensitive
     hash = Crypto.SHA256.hash(data: account_no)   // GOOD, computationally expensive hash not required
     hash = Crypto.SHA256.hash(data: credit_card_no)   // GOOD, computationally expensive hash not required
 
     hash = Crypto.SHA384.hash(data: passwd)   // BAD, not a computationally expensive hash
-    hash = Crypto.SHA384.hash(bufferPointer: passwd)   // BAD, not a computationally expensive hash [NOT DETECTED]
+    hash = Crypto.SHA384.hash(bufferPointer: passwd)   // BAD, not a computationally expensive hash
     hash = Crypto.SHA384.hash(data: cert)   // GOOD, computationally expensive hash not required
     hash = Crypto.SHA384.hash(data: encrypted_passwd)   // GOOD, not sensitive
     hash = Crypto.SHA384.hash(data: account_no)   // GOOD, computationally expensive hash not required
     hash = Crypto.SHA384.hash(data: credit_card_no)   // GOOD, computationally expensive hash not required
 
     hash = Crypto.SHA512.hash(data: passwd)   // BAD, not a computationally expensive hash
-    hash = Crypto.SHA512.hash(bufferPointer: passwd)   // BAD, not a computationally expensive hash [NOT DETECTED]
+    hash = Crypto.SHA512.hash(bufferPointer: passwd)   // BAD, not a computationally expensive hash
     hash = Crypto.SHA512.hash(data: cert)   // GOOD, computationally expensive hash not required
     hash = Crypto.SHA512.hash(data: encrypted_passwd)   // GOOD, not sensitive
     hash = Crypto.SHA512.hash(data: account_no)   // GOOD, computationally expensive hash not required

--- a/swift/ql/test/query-tests/Security/CWE-328/testCryptoKit.swift
+++ b/swift/ql/test/query-tests/Security/CWE-328/testCryptoKit.swift
@@ -82,36 +82,42 @@ enum Insecure {
 
 func testHashMethods(passwd : UnsafeRawBufferPointer, cert: String, encrypted_passwd : String, account_no : String, credit_card_no : String) {
     var hash = Crypto.Insecure.MD5.hash(data: passwd)  // BAD
+    hash = Crypto.Insecure.MD5.hash(bufferPointer: passwd)  // BAD [NOT DETECTED]
     hash = Crypto.Insecure.MD5.hash(data: cert)   // BAD
     hash = Crypto.Insecure.MD5.hash(data: encrypted_passwd)  // GOOD  (not sensitive)
     hash = Crypto.Insecure.MD5.hash(data: account_no)   // BAD
     hash = Crypto.Insecure.MD5.hash(data: credit_card_no)   // BAD
 
     hash = Insecure.MD5.hash(data: passwd)  // BAD
+    hash = Insecure.MD5.hash(bufferPointer: passwd)  // BAD [NOT DETECTED]
     hash = Insecure.MD5.hash(data: cert)   // BAD
     hash = Insecure.MD5.hash(data: encrypted_passwd)  // GOOD  (not sensitive)
     hash = Insecure.MD5.hash(data: account_no)   // BAD
     hash = Insecure.MD5.hash(data: credit_card_no)   // BAD
 
     hash = Crypto.Insecure.SHA1.hash(data: passwd)  // BAD
+    hash = Crypto.Insecure.SHA1.hash(bufferPointer: passwd)  // BAD [NOT DETECTED]
     hash = Crypto.Insecure.SHA1.hash(data: cert)   // BAD
     hash = Crypto.Insecure.SHA1.hash(data: encrypted_passwd)  // GOOD  (not sensitive)
     hash = Crypto.Insecure.SHA1.hash(data: account_no)   // BAD
     hash = Crypto.Insecure.SHA1.hash(data: credit_card_no)   // BAD
 
     hash = Crypto.SHA256.hash(data: passwd)   // BAD, not a computationally expensive hash
+    hash = Crypto.SHA256.hash(bufferPointer: passwd)   // BAD, not a computationally expensive hash [NOT DETECTED]
     hash = Crypto.SHA256.hash(data: cert)   // GOOD, computationally expensive hash not required
     hash = Crypto.SHA256.hash(data: encrypted_passwd)   // GOOD, not sensitive
     hash = Crypto.SHA256.hash(data: account_no)   // GOOD, computationally expensive hash not required
     hash = Crypto.SHA256.hash(data: credit_card_no)   // GOOD, computationally expensive hash not required
 
     hash = Crypto.SHA384.hash(data: passwd)   // BAD, not a computationally expensive hash
+    hash = Crypto.SHA384.hash(bufferPointer: passwd)   // BAD, not a computationally expensive hash [NOT DETECTED]
     hash = Crypto.SHA384.hash(data: cert)   // GOOD, computationally expensive hash not required
     hash = Crypto.SHA384.hash(data: encrypted_passwd)   // GOOD, not sensitive
     hash = Crypto.SHA384.hash(data: account_no)   // GOOD, computationally expensive hash not required
     hash = Crypto.SHA384.hash(data: credit_card_no)   // GOOD, computationally expensive hash not required
 
     hash = Crypto.SHA512.hash(data: passwd)   // BAD, not a computationally expensive hash
+    hash = Crypto.SHA512.hash(bufferPointer: passwd)   // BAD, not a computationally expensive hash [NOT DETECTED]
     hash = Crypto.SHA512.hash(data: cert)   // GOOD, computationally expensive hash not required
     hash = Crypto.SHA512.hash(data: encrypted_passwd)   // GOOD, not sensitive
     hash = Crypto.SHA512.hash(data: account_no)   // GOOD, computationally expensive hash not required

--- a/swift/ql/test/query-tests/Security/CWE-328/testCryptoKit.swift
+++ b/swift/ql/test/query-tests/Security/CWE-328/testCryptoKit.swift
@@ -81,23 +81,23 @@ enum Insecure {
 // --- tests ---
 
 func testHashMethods(passwd : UnsafeRawBufferPointer, cert: String, encrypted_passwd : String, account_no : String, credit_card_no : String) {
-    var hash = Crypto.Insecure.MD5.hash(data: passwd)  // BAD [NOT DETECTED]
-    hash = Crypto.Insecure.MD5.hash(data: cert)   // BAD [NOT DETECTED]
+    var hash = Crypto.Insecure.MD5.hash(data: passwd)  // BAD
+    hash = Crypto.Insecure.MD5.hash(data: cert)   // BAD
     hash = Crypto.Insecure.MD5.hash(data: encrypted_passwd)  // GOOD  (not sensitive)
-    hash = Crypto.Insecure.MD5.hash(data: account_no)   // BAD [NOT DETECTED]
-    hash = Crypto.Insecure.MD5.hash(data: credit_card_no)   // BAD [NOT DETECTED]
+    hash = Crypto.Insecure.MD5.hash(data: account_no)   // BAD
+    hash = Crypto.Insecure.MD5.hash(data: credit_card_no)   // BAD
 
-    hash = Insecure.MD5.hash(data: passwd)  // BAD [NOT DETECTED]
-    hash = Insecure.MD5.hash(data: cert)   // BAD [NOT DETECTED]
+    hash = Insecure.MD5.hash(data: passwd)  // BAD
+    hash = Insecure.MD5.hash(data: cert)   // BAD
     hash = Insecure.MD5.hash(data: encrypted_passwd)  // GOOD  (not sensitive)
-    hash = Insecure.MD5.hash(data: account_no)   // BAD [NOT DETECTED]
-    hash = Insecure.MD5.hash(data: credit_card_no)   // BAD [NOT DETECTED]
+    hash = Insecure.MD5.hash(data: account_no)   // BAD
+    hash = Insecure.MD5.hash(data: credit_card_no)   // BAD
 
-    hash = Crypto.Insecure.SHA1.hash(data: passwd)  // BAD [NOT DETECTED]
-    hash = Crypto.Insecure.SHA1.hash(data: cert)   // BAD [NOT DETECTED]
+    hash = Crypto.Insecure.SHA1.hash(data: passwd)  // BAD
+    hash = Crypto.Insecure.SHA1.hash(data: cert)   // BAD
     hash = Crypto.Insecure.SHA1.hash(data: encrypted_passwd)  // GOOD  (not sensitive)
-    hash = Crypto.Insecure.SHA1.hash(data: account_no)   // BAD [NOT DETECTED]
-    hash = Crypto.Insecure.SHA1.hash(data: credit_card_no)   // BAD [NOT DETECTED]
+    hash = Crypto.Insecure.SHA1.hash(data: account_no)   // BAD
+    hash = Crypto.Insecure.SHA1.hash(data: credit_card_no)   // BAD
 
     hash = Crypto.SHA256.hash(data: passwd)   // BAD, not a computationally expensive hash [NOT DETECTED]
     hash = Crypto.SHA256.hash(data: cert)   // GOOD, computationally expensive hash not required
@@ -222,14 +222,14 @@ func testBadExample(passwordString: String) {
 
 func testWithFlowAndMetatypes(cardNumber: String) {
     let value1 = Data(cardNumber.utf8);
-    let _digest1 = Insecure.MD5.hash(data: value1); // BAD [NOT DETECTED]
+    let _digest1 = Insecure.MD5.hash(data: value1); // BAD
 
     let value2 = Data(cardNumber.utf8);
     let hasher2 = Insecure.MD5.self; // metatype
-    let _digest2 = hasher2.hash(data: value2); // BAD [NOT DETECTED]
+    let _digest2 = hasher2.hash(data: value2); // BAD
 
     let value3 = Data(cardNumber.utf8);
-    let _digest3 = (Insecure.MD5.self).hash(data: value3); // BAD [NOT DETECTED]
+    let _digest3 = (Insecure.MD5.self).hash(data: value3); // BAD
 
     let value4 = Data(cardNumber.utf8);
     testReceiver1(value: value4);
@@ -242,11 +242,11 @@ func testWithFlowAndMetatypes(cardNumber: String) {
 }
 
 func testReceiver1(value: Data) {
-    let _digest = Insecure.MD5.hash(data: value); // BAD [NOT DETECTED]
+    let _digest = Insecure.MD5.hash(data: value); // BAD
 }
 
 func testReceiver2(hasher: Insecure.MD5.Type, value: Data) {
-    let _digest = hasher.hash(data: value); // BAD [NOT DETECTED]
+    let _digest = hasher.hash(data: value); // BAD
 }
 
 func testReceiver3<H: HashFunction>(hasher: H.Type, value: Data) {

--- a/swift/ql/test/query-tests/Security/CWE-328/testCryptoKit.swift
+++ b/swift/ql/test/query-tests/Security/CWE-328/testCryptoKit.swift
@@ -7,92 +7,111 @@ class Data
     init<S>(_ elements: S) {}
 }
 
-struct SHA256 {
-    static func hash<D>(data: D) -> [UInt8] {
-        return []
-    }
+public protocol HashFunction {
+    associatedtype Digest
 
-    func update<D>(data: D) {}
-    func update(bufferPointer: UnsafeRawBufferPointer) {}
-    func finalize() -> [UInt8] { return [] }
+    init()
+    mutating func update(bufferPointer: UnsafeRawBufferPointer)
+    func finalize() -> Digest
 }
 
-struct SHA384 {
-    static func hash<D>(data: D) -> [UInt8] {
-        return []
+extension HashFunction {
+    @inlinable
+    public static func hash(bufferPointer: UnsafeRawBufferPointer) -> Digest {
+        var hasher = Self()
+        hasher.update(bufferPointer: bufferPointer)
+        return hasher.finalize()
     }
 
-    func update<D>(data: D) {}
-    func update(bufferPointer: UnsafeRawBufferPointer) {}
-    func finalize() -> [UInt8] { return [] }
-}
-
-struct SHA512 {
-    static func hash<D>(data: D) -> [UInt8] {
-        return []
+    @inlinable
+    public static func hash<D>(data: D) -> Self.Digest {
+        var hasher = Self()
+        hasher.update(data: data)
+        return hasher.finalize()
     }
 
-    func update<D>(data: D) {}
-    func update(bufferPointer: UnsafeRawBufferPointer) {}
-    func finalize() -> [UInt8] { return [] }
+    @inlinable
+    public mutating func update<D>(data: D) {
+        // ...
+    }
 }
 
+public struct SHA256: HashFunction {
+    public typealias Digest = [UInt8]
+
+    public init() {}
+    public mutating func update(bufferPointer: UnsafeRawBufferPointer) {}
+    public func finalize() -> Digest { return [] }
+}
+
+public struct SHA384: HashFunction {
+    public typealias Digest = [UInt8]
+
+    public init() {}
+    public mutating func update(bufferPointer: UnsafeRawBufferPointer) {}
+    public func finalize() -> Digest { return [] }
+}
+
+public struct SHA512: HashFunction {
+    public typealias Digest = [UInt8]
+
+    public init() {}
+    public mutating func update(bufferPointer: UnsafeRawBufferPointer) {}
+    public func finalize() -> Digest { return [] }
+}
 
 enum Insecure {
-    struct MD5 {
-        static func hash<D>(data: D) -> [UInt8] {
-            return []
-        }
+    public struct MD5: HashFunction {
+        public typealias Digest = [UInt8]
 
-        func update<D>(data: D) {}
-        func update(bufferPointer: UnsafeRawBufferPointer) {}
-        func finalize() -> [UInt8] { return [] }
+        public init() {}
+        public mutating func update(bufferPointer: UnsafeRawBufferPointer) {}
+        public func finalize() -> Digest { return [] }
     }
-    struct SHA1 {
-        static func hash<D>(data: D) -> [UInt8] {
-            return []
-        }
 
-        func update<D>(data: D) {}
-        func update(bufferPointer: UnsafeRawBufferPointer) {}
-        func finalize() -> [UInt8] { return [] }
+    public struct SHA1: HashFunction {
+        public typealias Digest = [UInt8]
+
+        public init() {}
+        public mutating func update(bufferPointer: UnsafeRawBufferPointer) {}
+        public func finalize() -> Digest { return [] }
     }
 }
 
 // --- tests ---
 
 func testHashMethods(passwd : UnsafeRawBufferPointer, cert: String, encrypted_passwd : String, account_no : String, credit_card_no : String) {
-    var hash = Crypto.Insecure.MD5.hash(data: passwd)  // BAD
-    hash = Crypto.Insecure.MD5.hash(data: cert)   // BAD
+    var hash = Crypto.Insecure.MD5.hash(data: passwd)  // BAD [NOT DETECTED]
+    hash = Crypto.Insecure.MD5.hash(data: cert)   // BAD [NOT DETECTED]
     hash = Crypto.Insecure.MD5.hash(data: encrypted_passwd)  // GOOD  (not sensitive)
-    hash = Crypto.Insecure.MD5.hash(data: account_no)   // BAD
-    hash = Crypto.Insecure.MD5.hash(data: credit_card_no)   // BAD
+    hash = Crypto.Insecure.MD5.hash(data: account_no)   // BAD [NOT DETECTED]
+    hash = Crypto.Insecure.MD5.hash(data: credit_card_no)   // BAD [NOT DETECTED]
 
-    hash = Insecure.MD5.hash(data: passwd)  // BAD
-    hash = Insecure.MD5.hash(data: cert)   // BAD
+    hash = Insecure.MD5.hash(data: passwd)  // BAD [NOT DETECTED]
+    hash = Insecure.MD5.hash(data: cert)   // BAD [NOT DETECTED]
     hash = Insecure.MD5.hash(data: encrypted_passwd)  // GOOD  (not sensitive)
-    hash = Insecure.MD5.hash(data: account_no)   // BAD
-    hash = Insecure.MD5.hash(data: credit_card_no)   // BAD
+    hash = Insecure.MD5.hash(data: account_no)   // BAD [NOT DETECTED]
+    hash = Insecure.MD5.hash(data: credit_card_no)   // BAD [NOT DETECTED]
 
-    hash = Crypto.Insecure.SHA1.hash(data: passwd)  // BAD
-    hash = Crypto.Insecure.SHA1.hash(data: cert)   // BAD
+    hash = Crypto.Insecure.SHA1.hash(data: passwd)  // BAD [NOT DETECTED]
+    hash = Crypto.Insecure.SHA1.hash(data: cert)   // BAD [NOT DETECTED]
     hash = Crypto.Insecure.SHA1.hash(data: encrypted_passwd)  // GOOD  (not sensitive)
-    hash = Crypto.Insecure.SHA1.hash(data: account_no)   // BAD
-    hash = Crypto.Insecure.SHA1.hash(data: credit_card_no)   // BAD
+    hash = Crypto.Insecure.SHA1.hash(data: account_no)   // BAD [NOT DETECTED]
+    hash = Crypto.Insecure.SHA1.hash(data: credit_card_no)   // BAD [NOT DETECTED]
 
-    hash = Crypto.SHA256.hash(data: passwd)   // BAD, not a computationally expensive hash
+    hash = Crypto.SHA256.hash(data: passwd)   // BAD, not a computationally expensive hash [NOT DETECTED]
     hash = Crypto.SHA256.hash(data: cert)   // GOOD, computationally expensive hash not required
     hash = Crypto.SHA256.hash(data: encrypted_passwd)   // GOOD, not sensitive
     hash = Crypto.SHA256.hash(data: account_no)   // GOOD, computationally expensive hash not required
     hash = Crypto.SHA256.hash(data: credit_card_no)   // GOOD, computationally expensive hash not required
 
-    hash = Crypto.SHA384.hash(data: passwd)   // BAD, not a computationally expensive hash
+    hash = Crypto.SHA384.hash(data: passwd)   // BAD, not a computationally expensive hash [NOT DETECTED]
     hash = Crypto.SHA384.hash(data: cert)   // GOOD, computationally expensive hash not required
     hash = Crypto.SHA384.hash(data: encrypted_passwd)   // GOOD, not sensitive
     hash = Crypto.SHA384.hash(data: account_no)   // GOOD, computationally expensive hash not required
     hash = Crypto.SHA384.hash(data: credit_card_no)   // GOOD, computationally expensive hash not required
 
-    hash = Crypto.SHA512.hash(data: passwd)   // BAD, not a computationally expensive hash
+    hash = Crypto.SHA512.hash(data: passwd)   // BAD, not a computationally expensive hash [NOT DETECTED]
     hash = Crypto.SHA512.hash(data: cert)   // GOOD, computationally expensive hash not required
     hash = Crypto.SHA512.hash(data: encrypted_passwd)   // GOOD, not sensitive
     hash = Crypto.SHA512.hash(data: account_no)   // GOOD, computationally expensive hash not required
@@ -101,25 +120,25 @@ func testHashMethods(passwd : UnsafeRawBufferPointer, cert: String, encrypted_pa
 
 func testMD5UpdateWithData(passwd : String, cert: String, encrypted_passwd : String, account_no : String, credit_card_no : String) {
     var hash = Crypto.Insecure.MD5()
-    hash.update(data: passwd)  // BAD
-    hash.update(data: cert)  // BAD
+    hash.update(data: passwd)  // BAD [NOT DETECTED]
+    hash.update(data: cert)  // BAD [NOT DETECTED]
     hash.update(data: encrypted_passwd)  // GOOD  (not sensitive)
-    hash.update(data: account_no)   // BAD
-    hash.update(data: credit_card_no)   // BAD
+    hash.update(data: account_no)   // BAD [NOT DETECTED]
+    hash.update(data: credit_card_no)   // BAD [NOT DETECTED]
 }
 
 func testSHA1UpdateWithData(passwd : String, cert: String, encrypted_passwd : String, account_no : String, credit_card_no : String) {
     var hash = Crypto.Insecure.SHA1()
-    hash.update(data: passwd)  // BAD
-    hash.update(data: cert)  // BAD
+    hash.update(data: passwd)  // BAD [NOT DETECTED]
+    hash.update(data: cert)  // BAD [NOT DETECTED]
     hash.update(data: encrypted_passwd)  // GOOD  (not sensitive)
-    hash.update(data: account_no)   // BAD
-    hash.update(data: credit_card_no)   // BAD
+    hash.update(data: account_no)   // BAD [NOT DETECTED]
+    hash.update(data: credit_card_no)   // BAD [NOT DETECTED]
 }
 
 func testSHA256UpdateWithData(passwd : String, cert: String, encrypted_passwd : String, account_no : String, credit_card_no : String) {
     var hash = Crypto.SHA256()
-    hash.update(data: passwd)  // BAD, not a computationally expensive hash
+    hash.update(data: passwd)  // BAD, not a computationally expensive hash [NOT DETECTED]
     hash.update(data: cert)  // GOOD
     hash.update(data: encrypted_passwd)   // GOOD  (not sensitive)
     hash.update(data: account_no)   // GOOD
@@ -128,7 +147,7 @@ func testSHA256UpdateWithData(passwd : String, cert: String, encrypted_passwd : 
 
 func testSHA384UpdateWithData(passwd : String, cert: String, encrypted_passwd : String, account_no : String, credit_card_no : String) {
     var hash = Crypto.SHA384()
-    hash.update(data: passwd)  // BAD, not a computationally expensive hash
+    hash.update(data: passwd)  // BAD, not a computationally expensive hash [NOT DETECTED]
     hash.update(data: cert)  // GOOD
     hash.update(data: encrypted_passwd)   // GOOD  (not sensitive)
     hash.update(data: account_no)   // GOOD
@@ -137,7 +156,7 @@ func testSHA384UpdateWithData(passwd : String, cert: String, encrypted_passwd : 
 
 func testSHA512UpdateWithData(passwd : String, cert: String, encrypted_passwd : String, account_no : String, credit_card_no : String) {
     var hash = Crypto.SHA512()
-    hash.update(data: passwd)  // BAD, not a computationally expensive hash
+    hash.update(data: passwd)  // BAD, not a computationally expensive hash [NOT DETECTED]
     hash.update(data: cert)  // GOOD
     hash.update(data: encrypted_passwd)   // GOOD  (not sensitive)
     hash.update(data: account_no)   // GOOD
@@ -189,14 +208,14 @@ func testSHA512UpdateWithUnsafeRawBufferPointer(passwd : UnsafeRawBufferPointer,
     hash.update(bufferPointer: credit_card_no)   // GOOD
 }
 
-func tesBadExample(passwordString: String) {
+func testBadExample(passwordString: String) {
     // this is the "bad" example from the .qhelp
     let passwordData = Data(passwordString.utf8)
-    let passwordHash = Crypto.SHA512.hash(data: passwordData) // BAD, not a computationally expensive hash
+    let passwordHash = Crypto.SHA512.hash(data: passwordData) // BAD, not a computationally expensive hash [NOT DETECTED]
 
     // ...
 
-    if Crypto.SHA512.hash(data: Data(passwordString.utf8)) == passwordHash { // BAD, not a computationally expensive hash
+    if Crypto.SHA512.hash(data: Data(passwordString.utf8)) == passwordHash { // BAD, not a computationally expensive hash [NOT DETECTED]
 	    // ...
     }
 }

--- a/swift/ql/test/query-tests/Security/CWE-328/testCryptoKit.swift
+++ b/swift/ql/test/query-tests/Security/CWE-328/testCryptoKit.swift
@@ -99,19 +99,19 @@ func testHashMethods(passwd : UnsafeRawBufferPointer, cert: String, encrypted_pa
     hash = Crypto.Insecure.SHA1.hash(data: account_no)   // BAD
     hash = Crypto.Insecure.SHA1.hash(data: credit_card_no)   // BAD
 
-    hash = Crypto.SHA256.hash(data: passwd)   // BAD, not a computationally expensive hash [NOT DETECTED]
+    hash = Crypto.SHA256.hash(data: passwd)   // BAD, not a computationally expensive hash
     hash = Crypto.SHA256.hash(data: cert)   // GOOD, computationally expensive hash not required
     hash = Crypto.SHA256.hash(data: encrypted_passwd)   // GOOD, not sensitive
     hash = Crypto.SHA256.hash(data: account_no)   // GOOD, computationally expensive hash not required
     hash = Crypto.SHA256.hash(data: credit_card_no)   // GOOD, computationally expensive hash not required
 
-    hash = Crypto.SHA384.hash(data: passwd)   // BAD, not a computationally expensive hash [NOT DETECTED]
+    hash = Crypto.SHA384.hash(data: passwd)   // BAD, not a computationally expensive hash
     hash = Crypto.SHA384.hash(data: cert)   // GOOD, computationally expensive hash not required
     hash = Crypto.SHA384.hash(data: encrypted_passwd)   // GOOD, not sensitive
     hash = Crypto.SHA384.hash(data: account_no)   // GOOD, computationally expensive hash not required
     hash = Crypto.SHA384.hash(data: credit_card_no)   // GOOD, computationally expensive hash not required
 
-    hash = Crypto.SHA512.hash(data: passwd)   // BAD, not a computationally expensive hash [NOT DETECTED]
+    hash = Crypto.SHA512.hash(data: passwd)   // BAD, not a computationally expensive hash
     hash = Crypto.SHA512.hash(data: cert)   // GOOD, computationally expensive hash not required
     hash = Crypto.SHA512.hash(data: encrypted_passwd)   // GOOD, not sensitive
     hash = Crypto.SHA512.hash(data: account_no)   // GOOD, computationally expensive hash not required
@@ -211,11 +211,11 @@ func testSHA512UpdateWithUnsafeRawBufferPointer(passwd : UnsafeRawBufferPointer,
 func testBadExample(passwordString: String) {
     // this is the "bad" example from the .qhelp
     let passwordData = Data(passwordString.utf8)
-    let passwordHash = Crypto.SHA512.hash(data: passwordData) // BAD, not a computationally expensive hash [NOT DETECTED]
+    let passwordHash = Crypto.SHA512.hash(data: passwordData) // BAD, not a computationally expensive hash
 
     // ...
 
-    if Crypto.SHA512.hash(data: Data(passwordString.utf8)) == passwordHash { // BAD, not a computationally expensive hash [NOT DETECTED]
+    if Crypto.SHA512.hash(data: Data(passwordString.utf8)) == passwordHash { // BAD, not a computationally expensive hash
 	    // ...
     }
 }


### PR DESCRIPTION
Extend sinks for `swift/weak-sensitive-data-hashing` and `swift/weak-password-hashing`, specifically the sinks that model `CryptoKit`.  It turns out many calls to these functions are (implicitly) made with a metatype as the qualifier (e.g. `Insecure.MD5.Type` rather than `Insecure.MD5`), which the models-as-data sinks don't match (reliably?).  The new sinks added here accept calls that have the metatype as qualifier.

This was seen in the wild but I had to make the tests more realistic before it affected tests - see commit-by-commit, where you can see many results lost when I made the tests closer to reality, then gained back with the new models.  On the real world database we simply gain a result that was previously missed.

MRVA also shows a handful of new results (for `swift/weak-sensitive-data-hashing`); I'll start a DCA run shortly as well.

---

It seems likely we miss other sources / sinks besides these ones due to similar patterns involving metatypes.  There's an opportunity to improve modelling here - but a better solution would be to resolve metatypes for models-as-data, so that these new models are not required.  This is left as future work.