### PR TITLE
Swift: Update the new metatype sinks

### DIFF
--- a/swift/ql/lib/codeql/swift/security/WeakPasswordHashingExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/WeakPasswordHashingExtensions.qll
@@ -121,12 +121,23 @@ private class WeakPasswordHashingMetatypeSink extends WeakPasswordHashingSink {
   string algorithm;
 
   WeakPasswordHashingMetatypeSink() {
-    exists(CallExpr c |
-      c.getAnArgument().getExpr() = this.asExpr() and
+    exists(CallExpr ce, Type t |
+      // call target
+      ce.getStaticTarget().getName() =
+        ["hash(data:)", "hash(bufferPointer:)", "update(data:)", "update(bufferPointer:)"] and
+      // argument
+      ce.getAnArgument().getExpr() = this.asExpr() and
+      // qualifier
+      t = ce.getQualifier().getType() and
       algorithm = ["SHA256", "SHA384", "SHA512"] and
-      c.getQualifier().getType().getFullName() = algorithm + ["", ".Type"] and
-      c.getStaticTarget().getName() =
-        ["hash(data:)", "hash(bufferPointer:)", "update(data:)", "update(bufferPointer:)"]
+      (
+        t.getFullName() = algorithm
+        or
+        exists(TypeDecl td |
+          td.getInterfaceType() = t and
+          td.getFullName() = algorithm
+        )
+      )
     )
   }
 

--- a/swift/ql/lib/codeql/swift/security/WeakSensitiveDataHashingExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/WeakSensitiveDataHashingExtensions.qll
@@ -86,12 +86,23 @@ private class WeakSensitiveDataHashingMetatypeSink extends WeakSensitiveDataHash
   string algorithm;
 
   WeakSensitiveDataHashingMetatypeSink() {
-    exists(CallExpr c |
-      c.getAnArgument().getExpr() = this.asExpr() and
+    exists(CallExpr ce, Type t |
+      // call target
+      ce.getStaticTarget().getName() =
+        ["hash(data:)", "hash(bufferPointer:)", "update(data:)", "update(bufferPointer:)"] and
+      // argument
+      ce.getAnArgument().getExpr() = this.asExpr() and
+      // qualifier
+      t = ce.getQualifier().getType() and
       algorithm = ["MD5", "SHA1"] and
-      c.getQualifier().getType().getFullName() = "Insecure." + algorithm + ["", ".Type"] and
-      c.getStaticTarget().getName() =
-        ["hash(data:)", "hash(bufferPointer:)", "update(data:)", "update(bufferPointer:)"]
+      (
+        t.getFullName() = "Insecure." + algorithm
+        or
+        exists(TypeDecl td |
+          td.getInterfaceType() = t and
+          td.getFullName() = "Insecure." + algorithm
+        )
+      )
     )
   }
 


### PR DESCRIPTION
Update the new metatype sinks to use `.getInterfaceType()` rather than relying on name matching (`".Type"`).

@jketema this is the best I could do without spending much too long on this.  I had a good look at how to generalize this to all Swift MaD sources and sinks - the issue being that `interpretElement0` only cares about functions, not calls, so there's no access to the call qualifier as the current solution uses.  A wider fix might need to be deeper in the dataflow wiring (perhaps somewhere in `DataFlowPrivate.qll`).

I do still need to look into the performance regression I saw on the last PR, whether it's real and whether this change makes it better or worse.