### PR TITLE
Ruby: Fix bug in `implicitAssignmentNode`

### DIFF
--- a/ruby/ql/lib/codeql/ruby/ast/internal/Variable.qll
+++ b/ruby/ql/lib/codeql/ruby/ast/internal/Variable.qll
@@ -11,6 +11,17 @@ private import codeql.ruby.ast.internal.Pattern
 private import codeql.ruby.ast.internal.Scope
 private import codeql.ruby.ast.internal.Synthesis
 
+private Ruby::AstNode getAssignmentParent(Ruby::AstNode n) {
+  result = n.getParent() and
+  (
+    result instanceof Ruby::DestructuredLeftAssignment
+    or
+    result instanceof Ruby::LeftAssignmentList
+    or
+    result instanceof Ruby::RestAssignment
+  )
+}
+
 /**
  * Holds if `n` is in the left-hand-side of an explicit assignment `assignment`.
  */
@@ -19,16 +30,7 @@ predicate explicitAssignmentNode(Ruby::AstNode n, Ruby::AstNode assignment) {
   or
   n = assignment.(Ruby::OperatorAssignment).getLeft()
   or
-  exists(Ruby::AstNode parent |
-    parent = n.getParent() and
-    explicitAssignmentNode(parent, assignment)
-  |
-    parent instanceof Ruby::DestructuredLeftAssignment
-    or
-    parent instanceof Ruby::LeftAssignmentList
-    or
-    parent instanceof Ruby::RestAssignment
-  )
+  explicitAssignmentNode(getAssignmentParent(n), assignment)
 }
 
 /** Holds if `n` is inside an implicit assignment. */
@@ -49,7 +51,7 @@ predicate implicitAssignmentNode(Ruby::AstNode n) {
   or
   n = any(Ruby::For for).getPattern()
   or
-  implicitAssignmentNode(n.getParent())
+  implicitAssignmentNode(getAssignmentParent(n))
 }
 
 /** Holds if `n` is inside a parameter. */

--- a/ruby/ql/test/library-tests/variables/parameter.expected
+++ b/ruby/ql/test/library-tests/variables/parameter.expected
@@ -29,6 +29,8 @@ parameterVariable
 | scopes.rb:2:14:2:14 | x | scopes.rb:2:14:2:14 | x |
 | scopes.rb:9:14:9:14 | x | scopes.rb:9:14:9:14 | x |
 | scopes.rb:69:15:69:15 | x | scopes.rb:69:15:69:15 | x |
+| scopes.rb:80:13:80:17 | value | scopes.rb:80:13:80:17 | value |
+| scopes.rb:84:11:84:13 | msg | scopes.rb:84:11:84:13 | msg |
 | ssa.rb:1:7:1:7 | b | ssa.rb:1:7:1:7 | b |
 | ssa.rb:18:8:18:8 | x | ssa.rb:18:8:18:8 | x |
 | ssa.rb:25:8:25:15 | elements | ssa.rb:25:8:25:15 | elements |

--- a/ruby/ql/test/library-tests/variables/scopes.rb
+++ b/ruby/ql/test/library-tests/variables/scopes.rb
@@ -71,3 +71,19 @@ module ParameterShadowing
   end
   puts x # prints `1`, not `3`
 end
+
+class RescueSetter
+  def name
+    @name
+  end
+
+  def name=(value)
+    @name = value
+  end
+
+  def foo(msg)
+    raise msg
+  rescue => self.name # calls `name=`
+    :caught
+  end
+end

--- a/ruby/ql/test/library-tests/variables/ssa.expected
+++ b/ruby/ql/test/library-tests/variables/ssa.expected
@@ -86,12 +86,12 @@ definition
 | parameters.rb:59:20:59:20 | a | parameters.rb:59:20:59:20 | a |
 | parameters.rb:59:23:59:23 | b | parameters.rb:59:23:59:23 | b |
 | parameters.rb:59:25:59:25 | c | parameters.rb:59:25:59:25 | c |
-| scopes.rb:1:1:73:3 | self (scopes.rb) | scopes.rb:1:1:73:3 | self |
-| scopes.rb:2:9:6:3 | <captured entry> self | scopes.rb:1:1:73:3 | self |
+| scopes.rb:1:1:89:4 | self (scopes.rb) | scopes.rb:1:1:89:4 | self |
+| scopes.rb:2:9:6:3 | <captured entry> self | scopes.rb:1:1:89:4 | self |
 | scopes.rb:4:4:4:4 | a | scopes.rb:4:4:4:4 | a |
 | scopes.rb:7:1:7:1 | a | scopes.rb:7:1:7:1 | a |
 | scopes.rb:9:9:18:3 | <captured entry> a | scopes.rb:7:1:7:1 | a |
-| scopes.rb:9:9:18:3 | <captured entry> self | scopes.rb:1:1:73:3 | self |
+| scopes.rb:9:9:18:3 | <captured entry> self | scopes.rb:1:1:89:4 | self |
 | scopes.rb:11:4:11:4 | a | scopes.rb:7:1:7:1 | a |
 | scopes.rb:13:4:13:4 | a | scopes.rb:7:1:7:1 | a |
 | scopes.rb:13:7:13:7 | b | scopes.rb:13:7:13:7 | b |
@@ -111,6 +111,12 @@ definition
 | scopes.rb:68:3:68:4 | xs | scopes.rb:68:3:68:4 | xs |
 | scopes.rb:69:11:71:5 | <captured entry> self | scopes.rb:66:1:73:3 | self |
 | scopes.rb:69:15:69:15 | x | scopes.rb:69:15:69:15 | x |
+| scopes.rb:75:1:89:3 | self (RescueSetter) | scopes.rb:75:1:89:3 | self |
+| scopes.rb:76:3:78:5 | self (name) | scopes.rb:76:3:78:5 | self |
+| scopes.rb:80:3:82:5 | self (name=) | scopes.rb:80:3:82:5 | self |
+| scopes.rb:80:13:80:17 | value | scopes.rb:80:13:80:17 | value |
+| scopes.rb:84:3:88:5 | self (foo) | scopes.rb:84:3:88:5 | self |
+| scopes.rb:84:11:84:13 | msg | scopes.rb:84:11:84:13 | msg |
 | ssa.rb:1:1:16:3 | self (m) | ssa.rb:1:1:16:3 | self |
 | ssa.rb:1:7:1:7 | b | ssa.rb:1:7:1:7 | b |
 | ssa.rb:2:3:2:3 | i | ssa.rb:2:3:2:3 | i |
@@ -267,20 +273,20 @@ read
 | parameters.rb:59:20:59:20 | a | parameters.rb:59:20:59:20 | a | parameters.rb:60:11:60:11 | a |
 | parameters.rb:59:23:59:23 | b | parameters.rb:59:23:59:23 | b | parameters.rb:60:16:60:16 | b |
 | parameters.rb:59:25:59:25 | c | parameters.rb:59:25:59:25 | c | parameters.rb:60:21:60:21 | c |
-| scopes.rb:1:1:73:3 | self (scopes.rb) | scopes.rb:1:1:73:3 | self | scopes.rb:8:1:8:6 | self |
-| scopes.rb:2:9:6:3 | <captured entry> self | scopes.rb:1:1:73:3 | self | scopes.rb:3:4:3:9 | self |
-| scopes.rb:2:9:6:3 | <captured entry> self | scopes.rb:1:1:73:3 | self | scopes.rb:3:9:3:9 | self |
-| scopes.rb:2:9:6:3 | <captured entry> self | scopes.rb:1:1:73:3 | self | scopes.rb:5:4:5:9 | self |
+| scopes.rb:1:1:89:4 | self (scopes.rb) | scopes.rb:1:1:89:4 | self | scopes.rb:8:1:8:6 | self |
+| scopes.rb:2:9:6:3 | <captured entry> self | scopes.rb:1:1:89:4 | self | scopes.rb:3:4:3:9 | self |
+| scopes.rb:2:9:6:3 | <captured entry> self | scopes.rb:1:1:89:4 | self | scopes.rb:3:9:3:9 | self |
+| scopes.rb:2:9:6:3 | <captured entry> self | scopes.rb:1:1:89:4 | self | scopes.rb:5:4:5:9 | self |
 | scopes.rb:4:4:4:4 | a | scopes.rb:4:4:4:4 | a | scopes.rb:5:9:5:9 | a |
 | scopes.rb:7:1:7:1 | a | scopes.rb:7:1:7:1 | a | scopes.rb:8:6:8:6 | a |
 | scopes.rb:9:9:18:3 | <captured entry> a | scopes.rb:7:1:7:1 | a | scopes.rb:10:9:10:9 | a |
 | scopes.rb:9:9:18:3 | <captured entry> a | scopes.rb:7:1:7:1 | a | scopes.rb:11:4:11:4 | a |
-| scopes.rb:9:9:18:3 | <captured entry> self | scopes.rb:1:1:73:3 | self | scopes.rb:10:4:10:9 | self |
-| scopes.rb:9:9:18:3 | <captured entry> self | scopes.rb:1:1:73:3 | self | scopes.rb:12:4:12:9 | self |
-| scopes.rb:9:9:18:3 | <captured entry> self | scopes.rb:1:1:73:3 | self | scopes.rb:14:4:14:9 | self |
-| scopes.rb:9:9:18:3 | <captured entry> self | scopes.rb:1:1:73:3 | self | scopes.rb:15:4:15:9 | self |
-| scopes.rb:9:9:18:3 | <captured entry> self | scopes.rb:1:1:73:3 | self | scopes.rb:16:4:16:9 | self |
-| scopes.rb:9:9:18:3 | <captured entry> self | scopes.rb:1:1:73:3 | self | scopes.rb:17:4:17:9 | self |
+| scopes.rb:9:9:18:3 | <captured entry> self | scopes.rb:1:1:89:4 | self | scopes.rb:10:4:10:9 | self |
+| scopes.rb:9:9:18:3 | <captured entry> self | scopes.rb:1:1:89:4 | self | scopes.rb:12:4:12:9 | self |
+| scopes.rb:9:9:18:3 | <captured entry> self | scopes.rb:1:1:89:4 | self | scopes.rb:14:4:14:9 | self |
+| scopes.rb:9:9:18:3 | <captured entry> self | scopes.rb:1:1:89:4 | self | scopes.rb:15:4:15:9 | self |
+| scopes.rb:9:9:18:3 | <captured entry> self | scopes.rb:1:1:89:4 | self | scopes.rb:16:4:16:9 | self |
+| scopes.rb:9:9:18:3 | <captured entry> self | scopes.rb:1:1:89:4 | self | scopes.rb:17:4:17:9 | self |
 | scopes.rb:11:4:11:4 | a | scopes.rb:7:1:7:1 | a | scopes.rb:12:9:12:9 | a |
 | scopes.rb:13:4:13:4 | a | scopes.rb:7:1:7:1 | a | scopes.rb:14:9:14:9 | a |
 | scopes.rb:13:7:13:7 | b | scopes.rb:13:7:13:7 | b | scopes.rb:15:9:15:9 | b |
@@ -311,6 +317,11 @@ read
 | scopes.rb:68:3:68:4 | xs | scopes.rb:68:3:68:4 | xs | scopes.rb:69:3:69:4 | xs |
 | scopes.rb:69:11:71:5 | <captured entry> self | scopes.rb:66:1:73:3 | self | scopes.rb:70:5:70:10 | self |
 | scopes.rb:69:15:69:15 | x | scopes.rb:69:15:69:15 | x | scopes.rb:70:10:70:10 | x |
+| scopes.rb:76:3:78:5 | self (name) | scopes.rb:76:3:78:5 | self | scopes.rb:77:5:77:9 | self |
+| scopes.rb:80:3:82:5 | self (name=) | scopes.rb:80:3:82:5 | self | scopes.rb:81:5:81:9 | self |
+| scopes.rb:80:13:80:17 | value | scopes.rb:80:13:80:17 | value | scopes.rb:81:13:81:17 | value |
+| scopes.rb:84:3:88:5 | self (foo) | scopes.rb:84:3:88:5 | self | scopes.rb:85:5:85:13 | self |
+| scopes.rb:84:11:84:13 | msg | scopes.rb:84:11:84:13 | msg | scopes.rb:85:11:85:13 | msg |
 | ssa.rb:1:1:16:3 | self (m) | ssa.rb:1:1:16:3 | self | ssa.rb:3:3:3:8 | self |
 | ssa.rb:1:1:16:3 | self (m) | ssa.rb:1:1:16:3 | self | ssa.rb:4:3:4:12 | self |
 | ssa.rb:1:1:16:3 | self (m) | ssa.rb:1:1:16:3 | self | ssa.rb:7:5:7:10 | self |
@@ -460,12 +471,12 @@ firstRead
 | parameters.rb:59:20:59:20 | a | parameters.rb:59:20:59:20 | a | parameters.rb:60:11:60:11 | a |
 | parameters.rb:59:23:59:23 | b | parameters.rb:59:23:59:23 | b | parameters.rb:60:16:60:16 | b |
 | parameters.rb:59:25:59:25 | c | parameters.rb:59:25:59:25 | c | parameters.rb:60:21:60:21 | c |
-| scopes.rb:1:1:73:3 | self (scopes.rb) | scopes.rb:1:1:73:3 | self | scopes.rb:8:1:8:6 | self |
-| scopes.rb:2:9:6:3 | <captured entry> self | scopes.rb:1:1:73:3 | self | scopes.rb:3:4:3:9 | self |
+| scopes.rb:1:1:89:4 | self (scopes.rb) | scopes.rb:1:1:89:4 | self | scopes.rb:8:1:8:6 | self |
+| scopes.rb:2:9:6:3 | <captured entry> self | scopes.rb:1:1:89:4 | self | scopes.rb:3:4:3:9 | self |
 | scopes.rb:4:4:4:4 | a | scopes.rb:4:4:4:4 | a | scopes.rb:5:9:5:9 | a |
 | scopes.rb:7:1:7:1 | a | scopes.rb:7:1:7:1 | a | scopes.rb:8:6:8:6 | a |
 | scopes.rb:9:9:18:3 | <captured entry> a | scopes.rb:7:1:7:1 | a | scopes.rb:10:9:10:9 | a |
-| scopes.rb:9:9:18:3 | <captured entry> self | scopes.rb:1:1:73:3 | self | scopes.rb:10:4:10:9 | self |
+| scopes.rb:9:9:18:3 | <captured entry> self | scopes.rb:1:1:89:4 | self | scopes.rb:10:4:10:9 | self |
 | scopes.rb:11:4:11:4 | a | scopes.rb:7:1:7:1 | a | scopes.rb:12:9:12:9 | a |
 | scopes.rb:13:4:13:4 | a | scopes.rb:7:1:7:1 | a | scopes.rb:14:9:14:9 | a |
 | scopes.rb:13:7:13:7 | b | scopes.rb:13:7:13:7 | b | scopes.rb:15:9:15:9 | b |
@@ -485,6 +496,11 @@ firstRead
 | scopes.rb:68:3:68:4 | xs | scopes.rb:68:3:68:4 | xs | scopes.rb:69:3:69:4 | xs |
 | scopes.rb:69:11:71:5 | <captured entry> self | scopes.rb:66:1:73:3 | self | scopes.rb:70:5:70:10 | self |
 | scopes.rb:69:15:69:15 | x | scopes.rb:69:15:69:15 | x | scopes.rb:70:10:70:10 | x |
+| scopes.rb:76:3:78:5 | self (name) | scopes.rb:76:3:78:5 | self | scopes.rb:77:5:77:9 | self |
+| scopes.rb:80:3:82:5 | self (name=) | scopes.rb:80:3:82:5 | self | scopes.rb:81:5:81:9 | self |
+| scopes.rb:80:13:80:17 | value | scopes.rb:80:13:80:17 | value | scopes.rb:81:13:81:17 | value |
+| scopes.rb:84:3:88:5 | self (foo) | scopes.rb:84:3:88:5 | self | scopes.rb:85:5:85:13 | self |
+| scopes.rb:84:11:84:13 | msg | scopes.rb:84:11:84:13 | msg | scopes.rb:85:11:85:13 | msg |
 | ssa.rb:1:1:16:3 | self (m) | ssa.rb:1:1:16:3 | self | ssa.rb:3:3:3:8 | self |
 | ssa.rb:1:7:1:7 | b | ssa.rb:1:7:1:7 | b | ssa.rb:5:6:5:6 | b |
 | ssa.rb:2:3:2:3 | i | ssa.rb:2:3:2:3 | i | ssa.rb:3:8:3:8 | i |
@@ -557,14 +573,14 @@ adjacentReads
 | parameters.rb:25:1:28:3 | self (opt_param) | parameters.rb:25:1:28:3 | self | parameters.rb:26:3:26:11 | self | parameters.rb:27:3:27:11 | self |
 | parameters.rb:25:15:25:18 | name | parameters.rb:25:15:25:18 | name | parameters.rb:25:40:25:43 | name | parameters.rb:26:8:26:11 | name |
 | parameters.rb:54:9:57:3 | <captured entry> self | parameters.rb:1:1:62:1 | self | parameters.rb:55:4:55:9 | self | parameters.rb:56:4:56:9 | self |
-| scopes.rb:2:9:6:3 | <captured entry> self | scopes.rb:1:1:73:3 | self | scopes.rb:3:4:3:9 | self | scopes.rb:3:9:3:9 | self |
-| scopes.rb:2:9:6:3 | <captured entry> self | scopes.rb:1:1:73:3 | self | scopes.rb:3:9:3:9 | self | scopes.rb:5:4:5:9 | self |
+| scopes.rb:2:9:6:3 | <captured entry> self | scopes.rb:1:1:89:4 | self | scopes.rb:3:4:3:9 | self | scopes.rb:3:9:3:9 | self |
+| scopes.rb:2:9:6:3 | <captured entry> self | scopes.rb:1:1:89:4 | self | scopes.rb:3:9:3:9 | self | scopes.rb:5:4:5:9 | self |
 | scopes.rb:9:9:18:3 | <captured entry> a | scopes.rb:7:1:7:1 | a | scopes.rb:10:9:10:9 | a | scopes.rb:11:4:11:4 | a |
-| scopes.rb:9:9:18:3 | <captured entry> self | scopes.rb:1:1:73:3 | self | scopes.rb:10:4:10:9 | self | scopes.rb:12:4:12:9 | self |
-| scopes.rb:9:9:18:3 | <captured entry> self | scopes.rb:1:1:73:3 | self | scopes.rb:12:4:12:9 | self | scopes.rb:14:4:14:9 | self |
-| scopes.rb:9:9:18:3 | <captured entry> self | scopes.rb:1:1:73:3 | self | scopes.rb:14:4:14:9 | self | scopes.rb:15:4:15:9 | self |
-| scopes.rb:9:9:18:3 | <captured entry> self | scopes.rb:1:1:73:3 | self | scopes.rb:15:4:15:9 | self | scopes.rb:16:4:16:9 | self |
-| scopes.rb:9:9:18:3 | <captured entry> self | scopes.rb:1:1:73:3 | self | scopes.rb:16:4:16:9 | self | scopes.rb:17:4:17:9 | self |
+| scopes.rb:9:9:18:3 | <captured entry> self | scopes.rb:1:1:89:4 | self | scopes.rb:10:4:10:9 | self | scopes.rb:12:4:12:9 | self |
+| scopes.rb:9:9:18:3 | <captured entry> self | scopes.rb:1:1:89:4 | self | scopes.rb:12:4:12:9 | self | scopes.rb:14:4:14:9 | self |
+| scopes.rb:9:9:18:3 | <captured entry> self | scopes.rb:1:1:89:4 | self | scopes.rb:14:4:14:9 | self | scopes.rb:15:4:15:9 | self |
+| scopes.rb:9:9:18:3 | <captured entry> self | scopes.rb:1:1:89:4 | self | scopes.rb:15:4:15:9 | self | scopes.rb:16:4:16:9 | self |
+| scopes.rb:9:9:18:3 | <captured entry> self | scopes.rb:1:1:89:4 | self | scopes.rb:16:4:16:9 | self | scopes.rb:17:4:17:9 | self |
 | scopes.rb:13:10:13:15 | __synth__2__1 | scopes.rb:13:10:13:15 | __synth__2__1 | scopes.rb:13:11:13:11 | __synth__2__1 | scopes.rb:13:14:13:14 | __synth__2__1 |
 | scopes.rb:13:19:13:32 | __synth__3 | scopes.rb:13:4:13:32 | __synth__3 | scopes.rb:13:4:13:4 | __synth__3 | scopes.rb:13:7:13:7 | __synth__3 |
 | scopes.rb:13:19:13:32 | __synth__3 | scopes.rb:13:4:13:32 | __synth__3 | scopes.rb:13:7:13:7 | __synth__3 | scopes.rb:13:10:13:15 | __synth__3 |

--- a/ruby/ql/test/library-tests/variables/ssa.expected
+++ b/ruby/ql/test/library-tests/variables/ssa.expected
@@ -321,6 +321,7 @@ read
 | scopes.rb:80:3:82:5 | self (name=) | scopes.rb:80:3:82:5 | self | scopes.rb:81:5:81:9 | self |
 | scopes.rb:80:13:80:17 | value | scopes.rb:80:13:80:17 | value | scopes.rb:81:13:81:17 | value |
 | scopes.rb:84:3:88:5 | self (foo) | scopes.rb:84:3:88:5 | self | scopes.rb:85:5:85:13 | self |
+| scopes.rb:84:3:88:5 | self (foo) | scopes.rb:84:3:88:5 | self | scopes.rb:86:13:86:16 | self |
 | scopes.rb:84:11:84:13 | msg | scopes.rb:84:11:84:13 | msg | scopes.rb:85:11:85:13 | msg |
 | ssa.rb:1:1:16:3 | self (m) | ssa.rb:1:1:16:3 | self | ssa.rb:3:3:3:8 | self |
 | ssa.rb:1:1:16:3 | self (m) | ssa.rb:1:1:16:3 | self | ssa.rb:4:3:4:12 | self |
@@ -592,6 +593,7 @@ adjacentReads
 | scopes.rb:51:1:64:3 | self (ExceptionVariable) | scopes.rb:51:1:64:3 | self | scopes.rb:59:5:59:21 | self | scopes.rb:61:5:61:10 | self |
 | scopes.rb:51:1:64:3 | self (ExceptionVariable) | scopes.rb:51:1:64:3 | self | scopes.rb:61:5:61:10 | self | scopes.rb:63:3:63:8 | self |
 | scopes.rb:60:25:60:25 | x | scopes.rb:55:3:55:3 | x | scopes.rb:61:10:61:10 | x | scopes.rb:63:8:63:8 | x |
+| scopes.rb:84:3:88:5 | self (foo) | scopes.rb:84:3:88:5 | self | scopes.rb:85:5:85:13 | self | scopes.rb:86:13:86:16 | self |
 | ssa.rb:1:1:16:3 | self (m) | ssa.rb:1:1:16:3 | self | ssa.rb:3:3:3:8 | self | ssa.rb:4:3:4:12 | self |
 | ssa.rb:1:1:16:3 | self (m) | ssa.rb:1:1:16:3 | self | ssa.rb:4:3:4:12 | self | ssa.rb:7:5:7:10 | self |
 | ssa.rb:1:1:16:3 | self (m) | ssa.rb:1:1:16:3 | self | ssa.rb:4:3:4:12 | self | ssa.rb:11:5:11:10 | self |

--- a/ruby/ql/test/library-tests/variables/varaccess.expected
+++ b/ruby/ql/test/library-tests/variables/varaccess.expected
@@ -155,43 +155,43 @@ variableAccess
 | parameters.rb:60:16:60:16 | b | parameters.rb:59:23:59:23 | b | parameters.rb:59:1:61:3 | tuples_nested |
 | parameters.rb:60:21:60:21 | c | parameters.rb:59:25:59:25 | c | parameters.rb:59:1:61:3 | tuples_nested |
 | scopes.rb:2:14:2:14 | x | scopes.rb:2:14:2:14 | x | scopes.rb:2:9:6:3 | do ... end |
-| scopes.rb:3:4:3:9 | self | scopes.rb:1:1:73:3 | self | scopes.rb:1:1:73:3 | scopes.rb |
-| scopes.rb:3:9:3:9 | self | scopes.rb:1:1:73:3 | self | scopes.rb:1:1:73:3 | scopes.rb |
+| scopes.rb:3:4:3:9 | self | scopes.rb:1:1:89:4 | self | scopes.rb:1:1:89:4 | scopes.rb |
+| scopes.rb:3:9:3:9 | self | scopes.rb:1:1:89:4 | self | scopes.rb:1:1:89:4 | scopes.rb |
 | scopes.rb:4:4:4:4 | a | scopes.rb:4:4:4:4 | a | scopes.rb:2:9:6:3 | do ... end |
-| scopes.rb:5:4:5:9 | self | scopes.rb:1:1:73:3 | self | scopes.rb:1:1:73:3 | scopes.rb |
+| scopes.rb:5:4:5:9 | self | scopes.rb:1:1:89:4 | self | scopes.rb:1:1:89:4 | scopes.rb |
 | scopes.rb:5:9:5:9 | a | scopes.rb:4:4:4:4 | a | scopes.rb:2:9:6:3 | do ... end |
-| scopes.rb:7:1:7:1 | a | scopes.rb:7:1:7:1 | a | scopes.rb:1:1:73:3 | scopes.rb |
-| scopes.rb:8:1:8:6 | self | scopes.rb:1:1:73:3 | self | scopes.rb:1:1:73:3 | scopes.rb |
-| scopes.rb:8:6:8:6 | a | scopes.rb:7:1:7:1 | a | scopes.rb:1:1:73:3 | scopes.rb |
+| scopes.rb:7:1:7:1 | a | scopes.rb:7:1:7:1 | a | scopes.rb:1:1:89:4 | scopes.rb |
+| scopes.rb:8:1:8:6 | self | scopes.rb:1:1:89:4 | self | scopes.rb:1:1:89:4 | scopes.rb |
+| scopes.rb:8:6:8:6 | a | scopes.rb:7:1:7:1 | a | scopes.rb:1:1:89:4 | scopes.rb |
 | scopes.rb:9:14:9:14 | x | scopes.rb:9:14:9:14 | x | scopes.rb:9:9:18:3 | do ... end |
-| scopes.rb:10:4:10:9 | self | scopes.rb:1:1:73:3 | self | scopes.rb:1:1:73:3 | scopes.rb |
-| scopes.rb:10:9:10:9 | a | scopes.rb:7:1:7:1 | a | scopes.rb:1:1:73:3 | scopes.rb |
-| scopes.rb:11:4:11:4 | a | scopes.rb:7:1:7:1 | a | scopes.rb:1:1:73:3 | scopes.rb |
-| scopes.rb:11:4:11:4 | a | scopes.rb:7:1:7:1 | a | scopes.rb:1:1:73:3 | scopes.rb |
-| scopes.rb:12:4:12:9 | self | scopes.rb:1:1:73:3 | self | scopes.rb:1:1:73:3 | scopes.rb |
-| scopes.rb:12:9:12:9 | a | scopes.rb:7:1:7:1 | a | scopes.rb:1:1:73:3 | scopes.rb |
-| scopes.rb:13:4:13:4 | a | scopes.rb:7:1:7:1 | a | scopes.rb:1:1:73:3 | scopes.rb |
+| scopes.rb:10:4:10:9 | self | scopes.rb:1:1:89:4 | self | scopes.rb:1:1:89:4 | scopes.rb |
+| scopes.rb:10:9:10:9 | a | scopes.rb:7:1:7:1 | a | scopes.rb:1:1:89:4 | scopes.rb |
+| scopes.rb:11:4:11:4 | a | scopes.rb:7:1:7:1 | a | scopes.rb:1:1:89:4 | scopes.rb |
+| scopes.rb:11:4:11:4 | a | scopes.rb:7:1:7:1 | a | scopes.rb:1:1:89:4 | scopes.rb |
+| scopes.rb:12:4:12:9 | self | scopes.rb:1:1:89:4 | self | scopes.rb:1:1:89:4 | scopes.rb |
+| scopes.rb:12:9:12:9 | a | scopes.rb:7:1:7:1 | a | scopes.rb:1:1:89:4 | scopes.rb |
+| scopes.rb:13:4:13:4 | a | scopes.rb:7:1:7:1 | a | scopes.rb:1:1:89:4 | scopes.rb |
 | scopes.rb:13:7:13:7 | b | scopes.rb:13:7:13:7 | b | scopes.rb:9:9:18:3 | do ... end |
 | scopes.rb:13:11:13:11 | c | scopes.rb:13:11:13:11 | c | scopes.rb:9:9:18:3 | do ... end |
 | scopes.rb:13:14:13:14 | d | scopes.rb:13:14:13:14 | d | scopes.rb:9:9:18:3 | do ... end |
-| scopes.rb:14:4:14:9 | self | scopes.rb:1:1:73:3 | self | scopes.rb:1:1:73:3 | scopes.rb |
-| scopes.rb:14:9:14:9 | a | scopes.rb:7:1:7:1 | a | scopes.rb:1:1:73:3 | scopes.rb |
-| scopes.rb:15:4:15:9 | self | scopes.rb:1:1:73:3 | self | scopes.rb:1:1:73:3 | scopes.rb |
+| scopes.rb:14:4:14:9 | self | scopes.rb:1:1:89:4 | self | scopes.rb:1:1:89:4 | scopes.rb |
+| scopes.rb:14:9:14:9 | a | scopes.rb:7:1:7:1 | a | scopes.rb:1:1:89:4 | scopes.rb |
+| scopes.rb:15:4:15:9 | self | scopes.rb:1:1:89:4 | self | scopes.rb:1:1:89:4 | scopes.rb |
 | scopes.rb:15:9:15:9 | b | scopes.rb:13:7:13:7 | b | scopes.rb:9:9:18:3 | do ... end |
-| scopes.rb:16:4:16:9 | self | scopes.rb:1:1:73:3 | self | scopes.rb:1:1:73:3 | scopes.rb |
+| scopes.rb:16:4:16:9 | self | scopes.rb:1:1:89:4 | self | scopes.rb:1:1:89:4 | scopes.rb |
 | scopes.rb:16:9:16:9 | c | scopes.rb:13:11:13:11 | c | scopes.rb:9:9:18:3 | do ... end |
-| scopes.rb:17:4:17:9 | self | scopes.rb:1:1:73:3 | self | scopes.rb:1:1:73:3 | scopes.rb |
+| scopes.rb:17:4:17:9 | self | scopes.rb:1:1:89:4 | self | scopes.rb:1:1:89:4 | scopes.rb |
 | scopes.rb:17:9:17:9 | d | scopes.rb:13:14:13:14 | d | scopes.rb:9:9:18:3 | do ... end |
-| scopes.rb:24:1:24:6 | script | scopes.rb:24:1:24:6 | script | scopes.rb:1:1:73:3 | scopes.rb |
-| scopes.rb:27:1:27:1 | x | scopes.rb:27:1:27:1 | x | scopes.rb:1:1:73:3 | scopes.rb |
-| scopes.rb:28:8:28:8 | x | scopes.rb:27:1:27:1 | x | scopes.rb:1:1:73:3 | scopes.rb |
+| scopes.rb:24:1:24:6 | script | scopes.rb:24:1:24:6 | script | scopes.rb:1:1:89:4 | scopes.rb |
+| scopes.rb:27:1:27:1 | x | scopes.rb:27:1:27:1 | x | scopes.rb:1:1:89:4 | scopes.rb |
+| scopes.rb:28:8:28:8 | x | scopes.rb:27:1:27:1 | x | scopes.rb:1:1:89:4 | scopes.rb |
 | scopes.rb:29:3:29:3 | x | scopes.rb:29:3:29:3 | x | scopes.rb:28:1:30:3 | B |
-| scopes.rb:31:10:31:10 | x | scopes.rb:27:1:27:1 | x | scopes.rb:1:1:73:3 | scopes.rb |
+| scopes.rb:31:10:31:10 | x | scopes.rb:27:1:27:1 | x | scopes.rb:1:1:89:4 | scopes.rb |
 | scopes.rb:32:3:32:3 | x | scopes.rb:32:3:32:3 | x | scopes.rb:31:1:33:3 | class << ... |
-| scopes.rb:34:7:34:7 | x | scopes.rb:27:1:27:1 | x | scopes.rb:1:1:73:3 | scopes.rb |
-| scopes.rb:34:14:34:14 | x | scopes.rb:27:1:27:1 | x | scopes.rb:1:1:73:3 | scopes.rb |
+| scopes.rb:34:7:34:7 | x | scopes.rb:27:1:27:1 | x | scopes.rb:1:1:89:4 | scopes.rb |
+| scopes.rb:34:14:34:14 | x | scopes.rb:27:1:27:1 | x | scopes.rb:1:1:89:4 | scopes.rb |
 | scopes.rb:35:3:35:3 | x | scopes.rb:35:3:35:3 | x | scopes.rb:34:1:36:3 | C |
-| scopes.rb:37:5:37:5 | x | scopes.rb:27:1:27:1 | x | scopes.rb:1:1:73:3 | scopes.rb |
+| scopes.rb:37:5:37:5 | x | scopes.rb:27:1:27:1 | x | scopes.rb:1:1:89:4 | scopes.rb |
 | scopes.rb:38:3:38:3 | x | scopes.rb:38:3:38:3 | x | scopes.rb:37:1:39:3 | foo |
 | scopes.rb:42:2:42:4 | var | scopes.rb:42:2:42:4 | var | scopes.rb:41:1:49:3 | M |
 | scopes.rb:43:2:43:4 | foo | scopes.rb:43:2:43:4 | foo | scopes.rb:41:1:49:3 | M |
@@ -216,6 +216,17 @@ variableAccess
 | scopes.rb:70:10:70:10 | x | scopes.rb:69:15:69:15 | x | scopes.rb:69:11:71:5 | do ... end |
 | scopes.rb:72:3:72:8 | self | scopes.rb:66:1:73:3 | self | scopes.rb:66:1:73:3 | ParameterShadowing |
 | scopes.rb:72:8:72:8 | x | scopes.rb:67:3:67:3 | x | scopes.rb:66:1:73:3 | ParameterShadowing |
+| scopes.rb:77:5:77:9 | @name | scopes.rb:77:5:77:9 | @name | scopes.rb:75:1:89:3 | RescueSetter |
+| scopes.rb:77:5:77:9 | self | scopes.rb:76:3:78:5 | self | scopes.rb:76:3:78:5 | name |
+| scopes.rb:80:13:80:17 | value | scopes.rb:80:13:80:17 | value | scopes.rb:80:3:82:5 | name= |
+| scopes.rb:81:5:81:9 | @name | scopes.rb:77:5:77:9 | @name | scopes.rb:75:1:89:3 | RescueSetter |
+| scopes.rb:81:5:81:9 | self | scopes.rb:80:3:82:5 | self | scopes.rb:80:3:82:5 | name= |
+| scopes.rb:81:13:81:17 | value | scopes.rb:80:13:80:17 | value | scopes.rb:80:3:82:5 | name= |
+| scopes.rb:84:11:84:13 | msg | scopes.rb:84:11:84:13 | msg | scopes.rb:84:3:88:5 | foo |
+| scopes.rb:85:5:85:13 | self | scopes.rb:84:3:88:5 | self | scopes.rb:84:3:88:5 | foo |
+| scopes.rb:85:11:85:13 | msg | scopes.rb:84:11:84:13 | msg | scopes.rb:84:3:88:5 | foo |
+| scopes.rb:86:13:86:16 | self | scopes.rb:84:3:88:5 | self | scopes.rb:84:3:88:5 | foo |
+| scopes.rb:86:18:86:21 | name | scopes.rb:86:18:86:21 | name | scopes.rb:84:3:88:5 | foo |
 | ssa.rb:1:7:1:7 | b | ssa.rb:1:7:1:7 | b | ssa.rb:1:1:16:3 | m |
 | ssa.rb:2:3:2:3 | i | ssa.rb:2:3:2:3 | i | ssa.rb:1:1:16:3 | m |
 | ssa.rb:3:3:3:8 | self | ssa.rb:1:1:16:3 | self | ssa.rb:1:1:16:3 | m |
@@ -370,6 +381,7 @@ explicitWrite
 | scopes.rb:55:3:55:3 | x | scopes.rb:55:3:55:7 | ... = ... |
 | scopes.rb:67:3:67:3 | x | scopes.rb:67:3:67:7 | ... = ... |
 | scopes.rb:68:3:68:4 | xs | scopes.rb:68:3:68:16 | ... = ... |
+| scopes.rb:81:5:81:9 | @name | scopes.rb:81:5:81:17 | ... = ... |
 | ssa.rb:2:3:2:3 | i | ssa.rb:2:3:2:7 | ... = ... |
 | ssa.rb:6:5:6:5 | i | ssa.rb:6:5:6:9 | ... = ... |
 | ssa.rb:10:5:10:5 | i | ssa.rb:10:5:10:9 | ... = ... |
@@ -422,6 +434,10 @@ implicitWrite
 | scopes.rb:9:14:9:14 | x |
 | scopes.rb:60:25:60:25 | x |
 | scopes.rb:69:15:69:15 | x |
+| scopes.rb:80:13:80:17 | value |
+| scopes.rb:84:11:84:13 | msg |
+| scopes.rb:86:13:86:16 | self |
+| scopes.rb:86:18:86:21 | name |
 | ssa.rb:1:7:1:7 | b |
 | ssa.rb:18:8:18:8 | x |
 | ssa.rb:25:8:25:15 | elements |
@@ -584,6 +600,12 @@ readAccess
 | scopes.rb:70:10:70:10 | x |
 | scopes.rb:72:3:72:8 | self |
 | scopes.rb:72:8:72:8 | x |
+| scopes.rb:77:5:77:9 | @name |
+| scopes.rb:77:5:77:9 | self |
+| scopes.rb:81:5:81:9 | self |
+| scopes.rb:81:13:81:17 | value |
+| scopes.rb:85:5:85:13 | self |
+| scopes.rb:85:11:85:13 | msg |
 | ssa.rb:3:3:3:8 | self |
 | ssa.rb:3:8:3:8 | i |
 | ssa.rb:4:3:4:12 | self |

--- a/ruby/ql/test/library-tests/variables/varaccess.expected
+++ b/ruby/ql/test/library-tests/variables/varaccess.expected
@@ -226,7 +226,6 @@ variableAccess
 | scopes.rb:85:5:85:13 | self | scopes.rb:84:3:88:5 | self | scopes.rb:84:3:88:5 | foo |
 | scopes.rb:85:11:85:13 | msg | scopes.rb:84:11:84:13 | msg | scopes.rb:84:3:88:5 | foo |
 | scopes.rb:86:13:86:16 | self | scopes.rb:84:3:88:5 | self | scopes.rb:84:3:88:5 | foo |
-| scopes.rb:86:18:86:21 | name | scopes.rb:86:18:86:21 | name | scopes.rb:84:3:88:5 | foo |
 | ssa.rb:1:7:1:7 | b | ssa.rb:1:7:1:7 | b | ssa.rb:1:1:16:3 | m |
 | ssa.rb:2:3:2:3 | i | ssa.rb:2:3:2:3 | i | ssa.rb:1:1:16:3 | m |
 | ssa.rb:3:3:3:8 | self | ssa.rb:1:1:16:3 | self | ssa.rb:1:1:16:3 | m |
@@ -436,8 +435,6 @@ implicitWrite
 | scopes.rb:69:15:69:15 | x |
 | scopes.rb:80:13:80:17 | value |
 | scopes.rb:84:11:84:13 | msg |
-| scopes.rb:86:13:86:16 | self |
-| scopes.rb:86:18:86:21 | name |
 | ssa.rb:1:7:1:7 | b |
 | ssa.rb:18:8:18:8 | x |
 | ssa.rb:25:8:25:15 | elements |
@@ -606,6 +603,7 @@ readAccess
 | scopes.rb:81:13:81:17 | value |
 | scopes.rb:85:5:85:13 | self |
 | scopes.rb:85:11:85:13 | msg |
+| scopes.rb:86:13:86:16 | self |
 | ssa.rb:3:3:3:8 | self |
 | ssa.rb:3:8:3:8 | i |
 | ssa.rb:4:3:4:12 | self |

--- a/ruby/ql/test/library-tests/variables/variable.expected
+++ b/ruby/ql/test/library-tests/variables/variable.expected
@@ -138,7 +138,6 @@
 | scopes.rb:80:13:80:17 | value |
 | scopes.rb:84:3:88:5 | self |
 | scopes.rb:84:11:84:13 | msg |
-| scopes.rb:86:18:86:21 | name |
 | ssa.rb:1:1:16:3 | self |
 | ssa.rb:1:1:103:3 | self |
 | ssa.rb:1:7:1:7 | b |

--- a/ruby/ql/test/library-tests/variables/variable.expected
+++ b/ruby/ql/test/library-tests/variables/variable.expected
@@ -94,7 +94,7 @@
 | parameters.rb:59:23:59:23 | b |
 | parameters.rb:59:25:59:25 | c |
 | scopes.rb:1:1:1:15 | self |
-| scopes.rb:1:1:73:3 | self |
+| scopes.rb:1:1:89:4 | self |
 | scopes.rb:2:14:2:14 | x |
 | scopes.rb:4:4:4:4 | a |
 | scopes.rb:7:1:7:1 | a |
@@ -131,6 +131,14 @@
 | scopes.rb:67:3:67:3 | x |
 | scopes.rb:68:3:68:4 | xs |
 | scopes.rb:69:15:69:15 | x |
+| scopes.rb:75:1:89:3 | self |
+| scopes.rb:76:3:78:5 | self |
+| scopes.rb:77:5:77:9 | @name |
+| scopes.rb:80:3:82:5 | self |
+| scopes.rb:80:13:80:17 | value |
+| scopes.rb:84:3:88:5 | self |
+| scopes.rb:84:11:84:13 | msg |
+| scopes.rb:86:18:86:21 | name |
 | ssa.rb:1:1:16:3 | self |
 | ssa.rb:1:1:103:3 | self |
 | ssa.rb:1:7:1:7 | b |

--- a/ruby/ql/test/library-tests/variables/varscopes.expected
+++ b/ruby/ql/test/library-tests/variables/varscopes.expected
@@ -47,7 +47,7 @@
 | parameters.rb:54:9:57:3 | do ... end |
 | parameters.rb:59:1:61:3 | tuples_nested |
 | scopes.rb:1:1:1:15 | a |
-| scopes.rb:1:1:73:3 | scopes.rb |
+| scopes.rb:1:1:89:4 | scopes.rb |
 | scopes.rb:2:9:6:3 | do ... end |
 | scopes.rb:9:9:18:3 | do ... end |
 | scopes.rb:26:1:26:12 | A |
@@ -60,6 +60,10 @@
 | scopes.rb:52:3:53:5 | MyException |
 | scopes.rb:66:1:73:3 | ParameterShadowing |
 | scopes.rb:69:11:71:5 | do ... end |
+| scopes.rb:75:1:89:3 | RescueSetter |
+| scopes.rb:76:3:78:5 | name |
+| scopes.rb:80:3:82:5 | name= |
+| scopes.rb:84:3:88:5 | foo |
 | ssa.rb:1:1:16:3 | m |
 | ssa.rb:1:1:103:3 | ssa.rb |
 | ssa.rb:18:1:23:3 | m1 |


### PR DESCRIPTION
A small bug fix where in cases like

```rb
class RescueSetter
  def name
    @name
  end

  def name=(value)
    @name = value
  end

  def foo(msg)
    raise msg
  rescue => self.name # calls `name=`
    :caught
  end
end
```

`self.name` was incorrectly marked as updating variables named `self` and `name`, instead of calling the `name=` setter.

[DCA](https://github.com/github/codeql-dca-main/issues/37115) confirms that we remove some `rb/useless-assignment-to-local` FPs.