### PR TITLE
Kotlin: Fix findTopLevelPropertyOrWarn for K2 compiler

### DIFF
--- a/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
@@ -3903,7 +3903,12 @@ open class KotlinFileExtractor(
 
         val prop =
             getPropertiesByFqName(pluginContext, propertyPkg, propertyName)
-                .firstOrNull { it.owner.parentClassOrNull?.fqNameWhenAvailable?.asString() == type }
+                .firstOrNull {
+                    val owner = it.owner
+                    owner.parentClassOrNull?.fqNameWhenAvailable?.asString() == type ||
+                        (owner.parent is IrExternalPackageFragment &&
+                            getFileClassFqName(owner)?.asString() == type)
+                }
                 ?.owner
 
         if (prop != null) {

--- a/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
@@ -3905,7 +3905,14 @@ open class KotlinFileExtractor(
 
         val prop =
             getPropertiesByFqName(pluginContext, propertyPkg, propertyName)
-                .firstOrNull { it.owner.parentClassOrNull?.fqNameWhenAvailable?.asString() == type }
+                .firstOrNull {
+                    val owner = it.owner
+                    when (val parent = owner.parent) {
+                        is IrClass -> parent.fqNameWhenAvailable?.asString()
+                        is IrExternalPackageFragment -> getFileClassFqName(owner)?.asString()
+                        else -> null
+                    } == type
+                }
                 ?.owner
 
         if (prop != null) {

--- a/java/ql/lib/change-notes/2026-05-30-kclass-java-arg-k2-fix.md
+++ b/java/ql/lib/change-notes/2026-05-30-kclass-java-arg-k2-fix.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Fixed an issue where `Foo::class.java` arguments were dropped during extraction under the Kotlin K2 compiler, which could cause false positives in queries such as `java/android/implicit-pendingintents`.

--- a/java/ql/test-kotlin1/library-tests/kclass-java-arg/test.expected
+++ b/java/ql/test-kotlin1/library-tests/kclass-java-arg/test.expected
@@ -1,0 +1,1 @@
+| consume | Class<Target> |

--- a/java/ql/test-kotlin1/library-tests/kclass-java-arg/test.kt
+++ b/java/ql/test-kotlin1/library-tests/kclass-java-arg/test.kt
@@ -1,0 +1,10 @@
+class Target
+
+class KClassJavaArg {
+    fun consume(c: Class<*>) {}
+
+    fun test() {
+        // `Target::class.java` must be extracted as the argument to `consume`.
+        consume(Target::class.java)
+    }
+}

--- a/java/ql/test-kotlin1/library-tests/kclass-java-arg/test.ql
+++ b/java/ql/test-kotlin1/library-tests/kclass-java-arg/test.ql
@@ -1,0 +1,5 @@
+import java
+
+from MethodCall mc, Argument arg
+where mc.getMethod().hasName("consume") and arg = mc.getAnArgument()
+select mc.getMethod().getName(), arg.getType().getName()

--- a/java/ql/test-kotlin2/library-tests/kclass-java-arg/test.expected
+++ b/java/ql/test-kotlin2/library-tests/kclass-java-arg/test.expected
@@ -1,0 +1,1 @@
+| consume | Class<Target> |

--- a/java/ql/test-kotlin2/library-tests/kclass-java-arg/test.kt
+++ b/java/ql/test-kotlin2/library-tests/kclass-java-arg/test.kt
@@ -1,0 +1,10 @@
+class Target
+
+class KClassJavaArg {
+    fun consume(c: Class<*>) {}
+
+    fun test() {
+        // `Target::class.java` must be extracted as the argument to `consume`.
+        consume(Target::class.java)
+    }
+}

--- a/java/ql/test-kotlin2/library-tests/kclass-java-arg/test.ql
+++ b/java/ql/test-kotlin2/library-tests/kclass-java-arg/test.ql
@@ -1,0 +1,5 @@
+import java
+
+from MethodCall mc, Argument arg
+where mc.getMethod().hasName("consume") and arg = mc.getAnArgument()
+select mc.getMethod().getName(), arg.getType().getName()


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.8 - diagnostics & initial fix

* Fixes #20153 (1/2 bugs)
  * Either bugfix fix would close the issue
  * K2 also broke `or PendingIntent.FLAG_IMMUTABLE` - see the issue for more details
* Fixes https://github.com/ankidroid/Anki-Android/security/code-scanning/35
* Mirrors https://github.com/github/codeql/pull/14835

----

`Receiver::class.java` resolves differently from K1:

- K1: `getJavaClass(KClass)` - value argument
- K2: `KClass.<get-java>() `- property receiver

This caused the lookup to fail, so `Intent(context, Receiver::class.java)` dropped the second argument.

> "Couldn't find JVM intrinsic property kotlin.jvm java in kotlin.jvm.JvmClassMappingKt"

This caused false positives in `java/android/implicit-pendingintents`
