### PR TITLE
Python: simplify decorator-detection predicates to pure AST match

### DIFF
--- a/python/ql/lib/change-notes/2026-06-01-decorator-predicate-simplification.md
+++ b/python/ql/lib/change-notes/2026-06-01-decorator-predicate-simplification.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Simplified the internal predicates that detect `@staticmethod`, `@classmethod` and `@property` decorators to match the decorator's AST `Name` directly, rather than going through the CFG and requiring the name to resolve globally. Code that shadows these three builtin decorators at the module-scope will now be classified by the decorator name alone; in practice, shadowing these names is extremely rare and the call-graph results are unchanged.

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowDispatch.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowDispatch.qll
@@ -256,9 +256,12 @@ predicate parameterMatch(ParameterPosition ppos, ArgumentPosition apos) {
  */
 overlay[local]
 predicate isStaticmethod(Function func) {
-  exists(NameNode id | id.getId() = "staticmethod" and id.isGlobal() |
-    func.getADecorator() = id.getNode()
-  )
+  // The decorator is *syntactically* a `Name` "staticmethod" — we don't
+  // care which variable it resolves to. `staticmethod` is a builtin and
+  // is almost never shadowed in a module-level scope; even if a class
+  // redefines `staticmethod` in its body, the class body has not started
+  // executing yet at the decorator position, so Python uses the builtin.
+  func.getADecorator().(Name).getId() = "staticmethod"
 }
 
 /**
@@ -268,9 +271,9 @@ predicate isStaticmethod(Function func) {
  */
 overlay[local]
 predicate isClassmethod(Function func) {
-  exists(NameNode id | id.getId() = "classmethod" and id.isGlobal() |
-    func.getADecorator() = id.getNode()
-  )
+  // See `isStaticmethod` for the rationale for matching on the AST `Name`
+  // rather than going via the CFG and `isGlobal()`.
+  func.getADecorator().(Name).getId() = "classmethod"
   or
   exists(Class cls |
     cls.getAMethod() = func and
@@ -285,9 +288,8 @@ predicate isClassmethod(Function func) {
 /** Holds if the function `func` has a `property` decorator. */
 overlay[local]
 predicate hasPropertyDecorator(Function func) {
-  exists(NameNode id | id.getId() = "property" and id.isGlobal() |
-    func.getADecorator() = id.getNode()
-  )
+  // See `isStaticmethod` for the rationale for matching on the AST `Name`.
+  func.getADecorator().(Name).getId() = "property"
 }
 
 /**


### PR DESCRIPTION
Factor-out from the Python shared-CFG dataflow migration stack (#21919/#21920/#21921/#21923/#21925).

The internal predicates `isStaticmethod`, `isClassmethod`, and `hasPropertyDecorator` (in `DataFlowDispatch.qll`) previously required the decorator's `NameNode` to satisfy `isGlobal()` — i.e. no SSA definition reaches the name use. That filter was correct but unnecessarily indirect:

- `staticmethod`, `classmethod`, and `property` are builtins.
- Even when a class body redefines one (`staticmethod = ...` inside the class), the class body has not started executing yet at the decorator position, so Python uses the builtin at that point.

This PR matches the decorator's AST `Name` directly instead, dropping the CFG/SSA detour.

### Semantic change

There is a small behavioural difference. The previous `isGlobal()` check rejected module-level shadowing of these builtins, e.g.:

```python
def staticmethod(x): ...  # shadows the builtin in this module

class C:
    @staticmethod
    def foo(): ...  # at the decorator position, `staticmethod` is the local one
```

With the previous code, `foo` was *not* classified as a staticmethod. With the new code, it is. Shadowing these three names at module scope is essentially never seen in practice, so this is a negligible false-positive risk in exchange for much cleaner code. Documented in a change note.

### Why not `hasContextmanagerDecorator` / `hasOverloadDecorator` too?

Those predicates also use the `NameNode.isGlobal()` pattern, but their target names (`contextmanager` from `contextlib`, `overload` from `typing`) are **imported**, not builtin. The `isGlobal()` check legitimately filters out cases where these names refer to a local variable rather than the imported one, which is a more realistic shadowing scenario. So they stay as-is.

### Verification

- All 361 `python/ql/{src,lib}` queries compile.
- All 88 tests in `library-tests/dataflow`, `library-tests/PointsTo/general`, and `query-tests/Functions` pass.

This PR has no dependencies on the rest of the migration stack and can land independently. After it merges, the corresponding predicate changes in `yoff/python-shared-cfg-dataflow-flip` (#21925) collapse to a noop (just the `Cfg::` qualification on the two remaining contextmanager/overload predicates).