### PR TITLE
Python: inline init_module_submodule_defn into ImportResolution

### DIFF
--- a/python/ql/lib/semmle/python/dataflow/new/internal/ImportResolution.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/ImportResolution.qll
@@ -9,7 +9,19 @@ private import semmle.python.dataflow.new.DataFlow
 private import semmle.python.dataflow.new.internal.ImportStar
 private import semmle.python.dataflow.new.TypeTracking
 private import semmle.python.dataflow.new.internal.DataFlowPrivate
-private import semmle.python.essa.SsaDefinitions
+
+/**
+ * Holds if `init` is a package's `__init__.py` and `var` is a global variable in
+ * `init` whose name matches a submodule of the package.
+ *
+ * Inlined from `SsaSource::init_module_submodule_defn` to avoid pulling
+ * `semmle.python.essa.SsaDefinitions` into the new dataflow stack.
+ */
+private predicate initModuleSubmoduleDefn(GlobalVariable var, Module init) {
+  init.isPackageInit() and
+  exists(init.getPackage().getSubModule(var.getId())) and
+  var.getScope() = init
+}
 
 /**
  * Python modules and the way imports are resolved are... complicated. Here's a crash course in how
@@ -326,7 +338,7 @@ module ImportResolution {
     // imported yet.
     exists(string submodule, Module package, EssaVariable var |
       submodule = var.getName() and
-      SsaSource::init_module_submodule_defn(var.getSourceVariable(), package.getEntryNode()) and
+      initModuleSubmoduleDefn(var.getSourceVariable(), package) and
       m = getModuleFromName(package.getPackageName() + "." + submodule) and
       result.asCfgNode() = var.getDefinition().(EssaNodeDefinition).getDefiningNode()
     )


### PR DESCRIPTION
Factored out of #21925 (shared-CFG migration).

The new-dataflow `ImportResolution` module only imported `semmle.python.essa.SsaDefinitions` to call the 5-line helper `SsaSource::init_module_submodule_defn`. Inlining it locally drops the dependency on legacy SSA definitions — making `new/internal/ImportResolution.qll` independent of `essa/`.

### Semantic-noop argument

- `SsaSourceVariable.getName()` and `Variable.getId()` both project the same DB column `variable(_, _, result)`, so the rename in the inlined body is safe.
- The old call `init_module_submodule_defn(var.getSourceVariable(), package.getEntryNode())` constrained `init = package` via the join `init.getEntryNode() = package.getEntryNode()` plus `var.getScope() = init`. With `Scope.getEntryNode()` being functional, this is equivalent to passing `package` directly.
- The `var instanceof GlobalVariable` check in the old body is now expressed via the parameter type.

### Verification

- RA dump of `python/ql/test/library-tests/dataflow/global-flow/accesses.ql` shows only the expected predicate-rename shuffle (no semantic shape change in any other predicate).
- All 70 tests under `python/ql/test/library-tests/dataflow` and `python/ql/test/library-tests/ApiGraphs` pass without reblessing.

### Investigation note (negative result worth recording)

I had originally hoped to fold two other ESSA-bypass rewrites into this PR — switching `definitionFlowStep` from `AssignmentDefinition` to `DefinitionNode + NameNode`, and switching `ModuleVariableNode.getAWrite` from `EssaNodeDefinition.definedBy` to `NameNode.defines` — but they are **not** semantic noops on `main`. Old ESSA's `EssaNodeDefinition` (and hence `AssignmentDefinition`) is liveness-pruned at `SsaCompute.qll:108-113`, so bypassing it reintroduces dead writes. `accesses.ql` immediately picks up the dead `g_mod = []` line. Those rewrites have to stay on the flip PR (#21925) where they're justified by the shared-SSA prune semantics.

Stacked under #21926.