### PR TITLE
Shared CFG: add defaulted getWhileElse/getForeachElse to AstSig

### DIFF
--- a/shared/controlflow/codeql/controlflow/ControlFlowGraph.qll
+++ b/shared/controlflow/codeql/controlflow/ControlFlowGraph.qll
@@ -1593,7 +1593,9 @@ module Make0<LocationSig Location, AstSig<Location> Ast> {
           or
           n1.isAfter(loopstmt.getBody()) and
           n2.isAdditional(loopstmt, loopHeaderTag())
-          or
+        )
+        or
+        exists(LoopStmt loopstmt |
           n1.isAfter(getLoopElse(loopstmt)) and
           n2.isAfter(loopstmt)
         )

--- a/shared/controlflow/codeql/controlflow/ControlFlowGraph.qll
+++ b/shared/controlflow/codeql/controlflow/ControlFlowGraph.qll
@@ -224,6 +224,13 @@ signature module AstSig<LocationSig Location> {
    */
   default AstNode getTryElse(TryStmt try) { none() }
 
+  /**
+   * Gets the `else` block of loop statement `loop`, if any.
+   *
+   * Only some languages (e.g. Python) support `for-else` constructs.
+   */
+  default AstNode getLoopElse(LoopStmt loop) { none() }
+
   /** A catch clause in a try statement. */
   class CatchClause extends AstNode {
     /** Gets the variable declared by this catch clause. */
@@ -1578,10 +1585,17 @@ module Make0<LocationSig Location, AstSig<Location> Ast> {
           n2.isBefore(loopstmt.getBody())
           or
           n1.isAfterValue(cond, any(BooleanSuccessor b | b.getValue() = while.booleanNot())) and
-          n2.isAfter(loopstmt)
+          (
+            n2.isBefore(getLoopElse(loopstmt))
+            or
+            not exists(getLoopElse(loopstmt)) and n2.isAfter(loopstmt)
+          )
           or
           n1.isAfter(loopstmt.getBody()) and
           n2.isAdditional(loopstmt, loopHeaderTag())
+          or
+          n1.isAfter(getLoopElse(loopstmt)) and
+          n2.isAfter(loopstmt)
         )
         or
         exists(ForeachStmt foreachstmt |
@@ -1590,7 +1604,11 @@ module Make0<LocationSig Location, AstSig<Location> Ast> {
           or
           n1.isAfterValue(foreachstmt.getCollection(),
             any(EmptinessSuccessor t | t.getValue() = true)) and
-          n2.isAfter(foreachstmt)
+          (
+            n2.isBefore(getLoopElse(foreachstmt))
+            or
+            not exists(getLoopElse(foreachstmt)) and n2.isAfter(foreachstmt)
+          )
           or
           n1.isAfterValue(foreachstmt.getCollection(),
             any(EmptinessSuccessor t | t.getValue() = false)) and
@@ -1603,7 +1621,11 @@ module Make0<LocationSig Location, AstSig<Location> Ast> {
           n2.isAdditional(foreachstmt, loopHeaderTag())
           or
           n1.isAdditional(foreachstmt, loopHeaderTag()) and
-          n2.isAfter(foreachstmt)
+          (
+            n2.isBefore(getLoopElse(foreachstmt))
+            or
+            not exists(getLoopElse(foreachstmt)) and n2.isAfter(foreachstmt)
+          )
           or
           n1.isAdditional(foreachstmt, loopHeaderTag()) and
           n2.isBefore(foreachstmt.getVariable())


### PR DESCRIPTION
Lifts the shared-controlflow changes out of #21921 so they can be reviewed independently. No behavioural change for existing languages (Java, C#, Ruby, Swift, Go, …) — both new predicates default to `none()` and the `Make0` loop-edge case extensions only fire when a language overrides them.

### Motivation

Python's upcoming new CFG library (#21921) needs to model `while-else` / `for-else`, where the `else` block runs when the loop condition becomes false (rather than via a `break`). The shared CFG didn't previously have predicates exposing those else blocks.

### Changes

- Adds defaulted `getLoopElse(LoopStmt)` to `AstSig` (`shared/controlflow/codeql/controlflow/ControlFlowGraph.qll`).
- Extends `Make0` to route through the else block if one exists.

### Verification

- `java/ql/test/library-tests/controlflow/` — all 12 tests pass (CFG output unchanged).
- The downstream Python PR (#21921) continues to depend on this content; it carries the same hunks inline today and will drop the duplicate when this PR merges and #21921 rebases.