### PR TITLE
C/C++ overlay: avoid massive cartesian product in overlay discardElement

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/internal/Overlay.qll
+++ b/cpp/ql/lib/semmle/code/cpp/internal/Overlay.qll
@@ -61,12 +61,13 @@ private predicate discardElement(@element e) {
   // particular, been deleted), or the overlay has redefined the TRAP
   // file or tag it is in, or the overlay runner has re-extracted the same
   // source file (e.g. because a header it includes has changed).
-  forall(@trap_or_tag t, string sourceFile |
+  not exists(@trap_or_tag t |
     locallyInTrapOrTag(false, e, t) and
-    locallyReachableTrapOrTag(false, sourceFile, t)
-  |
-    overlayChangedFiles(sourceFile) or
-    locallyReachableTrapOrTag(true, _, t) or
-    locallyReachableTrapOrTag(true, sourceFile, _)
+    not locallyReachableTrapOrTag(true, _, t) and
+    exists(string sourceFile |
+      locallyReachableTrapOrTag(false, sourceFile, t) and
+      not overlayChangedFiles(sourceFile) and
+      not locallyReachableTrapOrTag(true, sourceFile, _)
+    )
   )
 }


### PR DESCRIPTION
On [`mupen64/mupen64-rr-lua` PR #695](https://github.com/mupen64/mupen64-rr-lua/pull/695), overlay + diff-informed analysis takes ~660s vs ~45s standalone. The optimiser materialises a `@element × @trap_or_tag × string` join of **2 396 674 785 rows** from a `forall` in `Overlay.qll::discardElement`.

```
[2026-06-04 12:13:52] (568s)  >>> Created relation _#Overlay::locallyReachableTrapOrTag/3#11241854MergeNoDiscard_#Overlay::locallyReachableTrapOrTag/3#__#antijoin_rhs/3@e74ac3nt with 2396674785 rows and digest 002245oukoao3iug59rvgipruqe.
[2026-06-04 12:13:52] (568s) Starting to evaluate predicate _#Overlay::locallyReachableTrapOrTag/3#11241854MergeNoDiscard_021#join_rhs__#Overlay::locallyInTrapO__#antijoin_rhs/1@002e89t2
[2026-06-04 12:13:52] (568s)  >>> Created relation _#Overlay::locallyReachableTrapOrTag/3#11241854MergeNoDiscard_#Overlay::locallyReachableTrapOrTag/3#__#antijoin_rhs/3@17997dcp with 2396674785 rows and digest 002245oukoao3iug59rvgipruqe.
```


This PR rewrites that conjunct as nested existentials.

## Result

| Overlay + diff-informed | Wall time | Peak intermediate |
|---|---:|---:|
| Before | 660 s | 2 396 674 785 rows |
| After  | **198 s** | **31 071 598 rows** |
