### PR TITLE
Make alert coverage team the code owners for `/actions/`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,7 +2,7 @@
 * @github/code-scanning-alert-coverage
 
 # CodeQL language libraries
-/actions/ @github/codeql-dynamic
+/actions/ @github/code-scanning-alert-coverage
 /cpp/ @github/codeql-c-analysis
 /csharp/ @github/codeql-csharp
 /csharp/autobuilder/Semmle.Autobuild.Cpp @github/codeql-c-extractor @github/code-scanning-language-coverage


### PR DESCRIPTION
The responsibility has moved to a different team.