### PR TITLE
Remove @RasmusWL from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -59,9 +59,5 @@ MODULE.bazel @github/codeql-ci-reviewers
 /.github/workflows/rust.yml @github/codeql-rust
 /.github/workflows/swift.yml @github/codeql-swift
 
-# Misc
-/misc/scripts/accept-expected-changes-from-ci.py @RasmusWL
-/misc/scripts/generate-code-scanning-query-list.py @RasmusWL
-
 # .devcontainer
 /.devcontainer/ @github/codeql-ci-reviewers


### PR DESCRIPTION
He hasn't worked on CodeQL for a few years now. He told me that he doesn't remember how these scripts work.