### PR TITLE
Java: Improve inline expectations test comments

### DIFF
--- a/java/ql/test/query-tests/Nullness/B.java
+++ b/java/ql/test/query-tests/Nullness/B.java
@@ -331,7 +331,7 @@ public class B {
       x = new Object();
     }
     if(y instanceof String) {
-      x.hashCode(); // $ Alert[java/dereferenced-value-may-be-null] // Spurious NPE - false positive
+      x.hashCode(); // $ SPURIOUS: Alert[java/dereferenced-value-may-be-null] // Spurious NPE - false positive
     }
   }
 
@@ -341,7 +341,7 @@ public class B {
       x = new Object();
     }
     if(!(y instanceof String)) {
-      x.hashCode(); // $ Alert[java/dereferenced-value-may-be-null] // Spurious NPE - false positive
+      x.hashCode(); // $ SPURIOUS: Alert[java/dereferenced-value-may-be-null] // Spurious NPE - false positive
     }
   }
 
@@ -351,7 +351,7 @@ public class B {
       x = new Object();
     }
     if(y == z) {
-      x.hashCode(); // $ Alert[java/dereferenced-value-may-be-null] // Spurious NPE - false positive
+      x.hashCode(); // $ SPURIOUS: Alert[java/dereferenced-value-may-be-null] // Spurious NPE - false positive
     }
 
     Object x2 = null;
@@ -359,7 +359,7 @@ public class B {
       x2 = new Object();
     }
     if(y != z) {
-      x2.hashCode(); // $ Alert[java/dereferenced-value-may-be-null] // Spurious NPE - false positive
+      x2.hashCode(); // $ SPURIOUS: Alert[java/dereferenced-value-may-be-null] // Spurious NPE - false positive
     }
 
     Object x3 = null;
@@ -367,7 +367,7 @@ public class B {
       x3 = new Object();
     }
     if(!(y == z)) {
-      x3.hashCode(); // $ Alert[java/dereferenced-value-may-be-null] // Spurious NPE - false positive
+      x3.hashCode(); // $ SPURIOUS: Alert[java/dereferenced-value-may-be-null] // Spurious NPE - false positive
     }
   }
 
@@ -462,7 +462,7 @@ public class B {
       cur = a[i];
       if (!prev) {
         // correctly guarded by !cur from the _previous_ iteration
-        x.hashCode(); // $ Alert[java/dereferenced-value-may-be-null] // Spurious NPE - false positive
+        x.hashCode(); // $ SPURIOUS: Alert[java/dereferenced-value-may-be-null] // Spurious NPE - false positive
       } else {
         x = new Object();
       }
@@ -484,7 +484,7 @@ public class B {
           t = new Object();
         }
         // correctly guarded by t: null -> String -> Object
-        x.hashCode(); // $ Alert[java/dereferenced-value-may-be-null] // Spurious NPE - false positive
+        x.hashCode(); // $ SPURIOUS: Alert[java/dereferenced-value-may-be-null] // Spurious NPE - false positive
       }
     }
   }
@@ -573,7 +573,7 @@ public class B {
       } finally {
       }
     }
-    s.hashCode(); // $ Alert[java/dereferenced-value-may-be-null] // Spurious NPE - false positive
+    s.hashCode(); // $ SPURIOUS: Alert[java/dereferenced-value-may-be-null] // Spurious NPE - false positive
     // CFG reachability does not distinguish abrupt successors
   }
 }

--- a/java/ql/test/query-tests/Nullness/C.java
+++ b/java/ql/test/query-tests/Nullness/C.java
@@ -6,8 +6,8 @@ public class C {
     long[][] a2 = null;
     boolean haveA2 = ix < len && (a2 = a1[ix]) != null;
     long[] a3 = null;
-    final boolean haveA3 = haveA2 && (a3 = a2[ix]) != null; // $ Alert[java/dereferenced-value-may-be-null] // NPE - false positive
-    if (haveA3) a3[0] = 0; // $ Alert[java/dereferenced-value-may-be-null] // NPE - false positive
+    final boolean haveA3 = haveA2 && (a3 = a2[ix]) != null; // $ SPURIOUS: Alert[java/dereferenced-value-may-be-null] // NPE - false positive
+    if (haveA3) a3[0] = 0; // $ SPURIOUS: Alert[java/dereferenced-value-may-be-null] // NPE - false positive
   }
 
   public void ex2(boolean x, boolean y) {
@@ -18,7 +18,7 @@ public class C {
       s2 = (s1 == null) ? null : "";
     }
     if (s2 != null)
-      s1.hashCode(); // $ Alert[java/dereferenced-value-may-be-null] // NPE - false positive
+      s1.hashCode(); // $ SPURIOUS: Alert[java/dereferenced-value-may-be-null] // NPE - false positive
   }
 
   public void ex3(List<String> ss) {
@@ -48,7 +48,7 @@ public class C {
         slice = new ArrayList<>();
         result.add(slice);
       }
-      slice.add(str); // $ Alert[java/dereferenced-value-may-be-null] // NPE - false positive
+      slice.add(str); // $ SPURIOUS: Alert[java/dereferenced-value-may-be-null] // NPE - false positive
       ++index;
       iter.remove();
     }
@@ -141,7 +141,7 @@ public class C {
   public void ex10(int[] a) {
     int n = a == null ? 0 : a.length;
     for (int i = 0; i < n; i++) {
-      int x = a[i]; // $ Alert[java/dereferenced-value-may-be-null] // NPE - false positive
+      int x = a[i]; // $ SPURIOUS: Alert[java/dereferenced-value-may-be-null] // NPE - false positive
       if (x > 7)
         a = new int[n];
     }
@@ -216,7 +216,7 @@ public class C {
     if (o1 == o2) {
       return;
     }
-    if (o1.equals(o2)) { // $ Alert[java/dereferenced-value-may-be-null] // NPE - false positive
+    if (o1.equals(o2)) { // $ SPURIOUS: Alert[java/dereferenced-value-may-be-null] // NPE - false positive
       return;
     }
   }
@@ -230,7 +230,7 @@ public class C {
   public static void ex16(C c) {
     int[] xs = c.getFoo16() != null ? new int[5] : null;
     if (c.getFoo16() != null) {
-      xs[0]++; // $ Alert[java/dereferenced-value-may-be-null] // NPE - false positive
+      xs[0]++; // $ SPURIOUS: Alert[java/dereferenced-value-may-be-null] // NPE - false positive
     }
   }
 

--- a/java/ql/test/query-tests/UseBraces/UseBraces.java
+++ b/java/ql/test/query-tests/UseBraces/UseBraces.java
@@ -26,10 +26,10 @@ class UseBraces
 
 		if(1==1)
 			f(); // $ Alert
-			g();	// Alert
+			g();
 
 		if(1==1)
-			f();	g();	// $ Alert // Alert
+			f();	g();	// $ Alert
 
 		// If-then-else statement
 
@@ -56,14 +56,14 @@ class UseBraces
 		}
 		else
 			f(); // $ Alert
-			g();	// Alert
+			g();
 
 		if(true)
 		{
 			f();
 		}
 		else
-			f();  g();	// $ Alert // Alert
+			f();  g();	// $ Alert
 
 		// While statement
 
@@ -80,11 +80,11 @@ class UseBraces
 
 		while(bb   )
 			f(); // $ Alert
-			g();		// Alert
+			g();
 			g();		// No alert
 
 		while(bb   )
-			f();	g();		// $ Alert // Alert
+			f();	g();		// $ Alert
 
 
 		while(bb)
@@ -110,10 +110,10 @@ class UseBraces
 
 		for(int i=0; i<10; ++i)
 			f(); // $ Alert
-			g();				// Alert
+			g();
 
 		for(int i=0; i<10; ++i)
-			f(); g();			// $ Alert // Alert
+			f(); g();			// $ Alert
 
 
 		// Foreach statement
@@ -130,10 +130,10 @@ class UseBraces
 
 		for( int b : branches)
 			f(); // $ Alert
-			g();			// Alert
+			g();
 
 		for( int b : branches)
-			f(); g();		// $ Alert // Alert
+			f(); g();		// $ Alert
 
 		// Nested ifs
 		if( true )
@@ -144,7 +144,7 @@ class UseBraces
 		if( true )
 			if(false) // $ Alert
 				f();
-			g();	// Alert
+			g();
 
 		if( true )
 			;
@@ -164,7 +164,7 @@ class UseBraces
 			;
 		else if (false)
 			f();  // $ Alert
-			g();	// Alert
+			g();
 
 		// Nested combinations
 		if (true)
@@ -175,7 +175,7 @@ class UseBraces
 		if (true)
 			while (x<10) // $ Alert
 				f();
-			g();	// Alert
+			g();
 
 		while (x<10)
 		if (true)
@@ -185,7 +185,7 @@ class UseBraces
 		while (x<10)
 			if (true) // $ Alert
 				f();
-			g();	// Alert
+			g();
 
 		if (true)
 			f();

--- a/java/ql/test/query-tests/UseBraces/UseBraces.java
+++ b/java/ql/test/query-tests/UseBraces/UseBraces.java
@@ -11,23 +11,23 @@ class UseBraces
 	{
 		int x = 0, y;
 		int[] branches = new int[10];
-		
+
 		// If-then statement
-		
+
 		if(1==1)
 		{
 			f();
 		}
 			g();	// No alert
-			
-		if(1==1)	
+
+		if(1==1)
 			f();
 		g();		// No alert
-		
+
 		if(1==1)
 			f(); // $ Alert
 			g();	// Alert
-			
+
 		if(1==1)
 			f();	g();	// $ Alert // Alert
 
@@ -41,15 +41,15 @@ class UseBraces
 		{
 			g();
 		}
-		
+
 			g();	// No alert
-			
+
 		if(1==2)
 			f();
 		else
 			g();
 		f();		// No alert
-			
+
 		if(true)
 		{
 			f();
@@ -57,7 +57,7 @@ class UseBraces
 		else
 			f(); // $ Alert
 			g();	// Alert
-			
+
 		if(true)
 		{
 			f();
@@ -91,23 +91,23 @@ class UseBraces
 			if (x != 0) x = 1;
 
 		// Do-while statement
-		
+
 		do
 			f();
 		while(false);
 			g();	// No alert
-		
+
 		// For statement
 		for(int i=0; i<10; ++i)
 		{
 			f();
 		}
 			g();
-			
+
 		for(int i=0; i<10; ++i)
 			f();
 		g();
-		
+
 		for(int i=0; i<10; ++i)
 			f(); // $ Alert
 			g();				// Alert
@@ -115,9 +115,9 @@ class UseBraces
 		for(int i=0; i<10; ++i)
 			f(); g();			// $ Alert // Alert
 
-		
+
 		// Foreach statement
-		
+
 		for( int b : branches)
 			x += b;
 		f();
@@ -140,32 +140,32 @@ class UseBraces
 		if(false)
 			f();
 		g();	// No alert
-		
+
 		if( true )
 			if(false) // $ Alert
 				f();
 			g();	// Alert
-		
+
 		if( true )
 			;
-		else 
+		else
 		if (false)
 			f();
 		g();	// No alert
 
 		if( true )
 			;
-		else 
+		else
 			if (false)
 				f();
-			g();	// false negative
+			g();  // $ MISSING: Alert // false negative
 
 		if( true )
 			;
 		else if (false)
 			f();  // $ Alert
 			g();	// Alert
-		
+
 		// Nested combinations
 		if (true)
 		while (x<10)

--- a/java/ql/test/query-tests/security/CWE-113/semmle/tests/ResponseSplitting.java
+++ b/java/ql/test/query-tests/security/CWE-113/semmle/tests/ResponseSplitting.java
@@ -62,10 +62,10 @@ public class ResponseSplitting extends HttpServlet {
 		response.setHeader("h", t.replace('\n', ' ').replace('\r', ' '));
 
 		// FALSE NEGATIVE: replace only some line breaks
-		response.setHeader("h", t.replace('\n', ' '));
+		response.setHeader("h", t.replace('\n', ' ')); // $ MISSING: Alert
 
 		// FALSE NEGATIVE: replace only some line breaks
-		response.setHeader("h", t.replaceAll("\r", ""));
+		response.setHeader("h", t.replaceAll("\r", "")); // $ MISSING: Alert
 
 		// GOOD: replace all linebreaks with a simple regex
 		response.setHeader("h", t.replaceAll("\n", "").replaceAll("\r", ""));

--- a/java/ql/test/query-tests/security/CWE-190/semmle/tests/ArithmeticTainted.java
+++ b/java/ql/test/query-tests/security/CWE-190/semmle/tests/ArithmeticTainted.java
@@ -78,7 +78,7 @@ public class ArithmeticTainted {
 				// FALSE NEGATIVE: stillTainted could still be very large, even
 				// after
 				// it has had arithmetic done on it
-				int output = stillTainted + 100;
+				int output = stillTainted + 100; // $ MISSING: Alert[java/tainted-arithmetic]
 			}
 		}
 
@@ -107,7 +107,7 @@ public class ArithmeticTainted {
 			}
 			int output = data + 1;
 		}
-		
+
 		{
 			double x= Double.MAX_VALUE;
 			// OK: CWE-190 only pertains to integer arithmetic

--- a/java/ql/test/query-tests/security/CWE-190/semmle/tests/Test.java
+++ b/java/ql/test/query-tests/security/CWE-190/semmle/tests/Test.java
@@ -84,7 +84,7 @@ class Test {
 			// FALSE POSITIVE: the query check purely based on the type, it
 			// can't try to
 			// determine whether the value may in fact always be in bounds
-			i += j; // $ Alert[java/implicit-cast-in-compound-assignment]
+			i += j; // $ SPURIOUS: Alert[java/implicit-cast-in-compound-assignment]
 		}
 
 		// ArithmeticWithExtremeValues
@@ -224,7 +224,7 @@ class Test {
 				// FALSE NEGATIVE: stillLarge could still be very large, even
 				// after
 				// it has had arithmetic done on it
-				int output = stillLarge + 100;
+				int output = stillLarge + 100; // $ MISSING: Alert[java/uncontrolled-arithmetic]
 			}
 		}
 
@@ -263,7 +263,7 @@ class Test {
 				// FALSE NEGATIVE: stillLarge could still be very large, even
 				// after
 				// it has had arithmetic done on it
-				int output = stillLarge + 100;
+				int output = stillLarge + 100; // $ MISSING: Alert[java/uncontrolled-arithmetic]
 			}
 		}
 

--- a/java/ql/test/query-tests/security/CWE-311/CWE-319/HttpsUrlsTest.java
+++ b/java/ql/test/query-tests/security/CWE-311/CWE-319/HttpsUrlsTest.java
@@ -17,7 +17,7 @@ interface Hello extends java.rmi.Remote {
 
 class HelloImpl implements Hello {
 	public static void main(String[] args) {
-		try {	
+		try {
 			// HttpsUrls
 			{
 				String protocol = "http://"; // $ Source[java/non-https-url]
@@ -31,7 +31,7 @@ class HelloImpl implements Hello {
 				OutputStream os = hu.getOutputStream();
 				hu.disconnect();
 			}
-			
+
 			{
 				String protocol = "http"; // $ Source[java/non-https-url]
 				URL u = new URL(protocol, "www.secret.example.org", "foo");
@@ -44,7 +44,7 @@ class HelloImpl implements Hello {
 				OutputStream os = hu.getOutputStream();
 				hu.disconnect();
 			}
-			
+
 			{
 				String protocol = "http://"; // $ Source[java/non-https-url]
 				// the second URL overwrites the first, as it has a protocol
@@ -58,7 +58,7 @@ class HelloImpl implements Hello {
 				OutputStream os = hu.getOutputStream();
 				hu.disconnect();
 			}
-			
+
 			{
 				String protocol = "https://";
 				URL u = new URL(protocol + "www.secret.example.org/");
@@ -70,7 +70,7 @@ class HelloImpl implements Hello {
 				OutputStream os = hu.getOutputStream();
 				hu.disconnect();
 			}
-			
+
 			{
 				String protocol = "https";
 				URL u = new URL(protocol, "www.secret.example.org", "foo");
@@ -82,27 +82,27 @@ class HelloImpl implements Hello {
 				OutputStream os = hu.getOutputStream();
 				hu.disconnect();
 			}
-			
+
 			{
-				String protocol = "http"; // $ Source[java/non-https-url]
+				String protocol = "http"; // $ SPURIOUS: Source[java/non-https-url]
 				URL u = new URL(protocol, "internal-url", "foo");
 				// FALSE POSITIVE: the query has no way of knowing whether the url will
 				// resolve to somewhere outside the internal network, where there
 				// are unlikely to be interception attempts
-				HttpsURLConnection hu = (HttpsURLConnection) u.openConnection(); // $ Alert[java/non-https-url]
+				HttpsURLConnection hu = (HttpsURLConnection) u.openConnection(); // $ SPURIOUS: Alert[java/non-https-url]
 				hu.setRequestMethod("PUT");
 				hu.connect();
 				OutputStream os = hu.getOutputStream();
 				hu.disconnect();
 			}
-			
+
 			{
 				String input = "URL is: http://www.secret-example.org";
 				String url = input.substring(8);
 				URL u = new URL(url);
 				// FALSE NEGATIVE: we cannot tell that the substring results in a url
 				// string
-				HttpsURLConnection hu = (HttpsURLConnection) u.openConnection();
+				HttpsURLConnection hu = (HttpsURLConnection) u.openConnection(); // $ MISSING: Alert[java/non-https-url]
 				hu.setRequestMethod("PUT");
 				hu.connect();
 				OutputStream os = hu.getOutputStream();


### PR DESCRIPTION
A small follow-up to https://github.com/github/codeql/pull/21966 fixing some things I noticed after merging. Mostly that some tests have comments indication false positive and false negatives, which should correspond to MISSING or SPURIOUS inline expectations test comments.