### PR TITLE
QL-for-QL: Add up- and downgrade scripts

### DIFF
--- a/misc/scripts/prepare-db-upgrade.sh
+++ b/misc/scripts/prepare-db-upgrade.sh
@@ -89,6 +89,9 @@ case "${lang}" in
   go | ruby | rust | swift)
     scheme_file="${lang}/ql/lib/${lang}.dbscheme"
     ;;
+  ql)
+    scheme_file="${lang}/ql/src/${lang}.dbscheme"
+    ;;
   *)
     usage 2 "Unrecognised language: ${lang}"
     ;;

--- a/ql/downgrades/87c1125b41a68de7353f538cd7fb73bd0f18bfe0/old.dbscheme
+++ b/ql/downgrades/87c1125b41a68de7353f538cd7fb73bd0f18bfe0/old.dbscheme
@@ -1,0 +1,1356 @@
+// CodeQL database schema for QL
+// Automatically generated from the tree-sitter grammar; do not edit
+// To regenerate, run 'scripts/create-extractor-pack.sh' in ql/
+
+/*- Files and folders -*/
+
+/**
+ * The location of an element.
+ * The location spans column `startcolumn` of line `startline` to
+ * column `endcolumn` of line `endline` in file `file`.
+ * For more information, see
+ * [Locations](https://codeql.github.com/docs/writing-codeql-queries/providing-locations-in-codeql-queries/).
+ */
+locations_default(
+  unique int id: @location_default,
+  int file: @file ref,
+  int beginLine: int ref,
+  int beginColumn: int ref,
+  int endLine: int ref,
+  int endColumn: int ref
+);
+
+files(
+  unique int id: @file,
+  string name: string ref
+);
+
+folders(
+  unique int id: @folder,
+  string name: string ref
+);
+
+@container = @file | @folder
+
+containerparent(
+  int parent: @container ref,
+  unique int child: @container ref
+);
+
+/*- Empty location -*/
+
+empty_location(
+  int location: @location_default ref
+);
+
+/*- Source location prefix -*/
+
+/**
+ * The source location of the snapshot.
+ */
+sourceLocationPrefix(string prefix : string ref);
+
+/*- Diagnostic messages -*/
+
+diagnostics(
+  unique int id: @diagnostic,
+  int severity: int ref,
+  string error_tag: string ref,
+  string error_message: string ref,
+  string full_error_message: string ref,
+  int location: @location_default ref
+);
+
+/*- Diagnostic messages: severity -*/
+
+case @diagnostic.severity of
+  10 = @diagnostic_debug
+| 20 = @diagnostic_info
+| 30 = @diagnostic_warning
+| 40 = @diagnostic_error
+;
+
+/*- YAML -*/
+
+#keyset[parent, idx]
+yaml (unique int id: @yaml_node,
+      int kind: int ref,
+      int parent: @yaml_node_parent ref,
+      int idx: int ref,
+      string tag: string ref,
+      string tostring: string ref);
+
+case @yaml_node.kind of
+  0 = @yaml_scalar_node
+| 1 = @yaml_mapping_node
+| 2 = @yaml_sequence_node
+| 3 = @yaml_alias_node
+;
+
+@yaml_collection_node = @yaml_mapping_node | @yaml_sequence_node;
+
+@yaml_node_parent = @yaml_collection_node | @file;
+
+yaml_anchors (unique int node: @yaml_node ref,
+              string anchor: string ref);
+
+yaml_aliases (unique int alias: @yaml_alias_node ref,
+              string target: string ref);
+
+yaml_scalars (unique int scalar: @yaml_scalar_node ref,
+              int style: int ref,
+              string value: string ref);
+
+yaml_errors (unique int id: @yaml_error,
+             string message: string ref);
+
+yaml_locations(unique int locatable: @yaml_locatable ref,
+             int location: @location_default ref);
+
+@yaml_locatable = @yaml_node | @yaml_error;
+
+/*- Database metadata -*/
+
+/**
+ * The CLI will automatically emit applicable tuples for this table,
+ * such as `databaseMetadata("isOverlay", "true")` when building an
+ * overlay database.
+ */
+databaseMetadata(
+  string metadataKey: string ref,
+  string value: string ref
+);
+
+/*- Overlay support -*/
+
+/**
+ * The CLI will automatically emit tuples for each new/modified/deleted file
+ * when building an overlay database.
+ */
+overlayChangedFiles(
+  string path: string ref
+);
+
+/*- QL dbscheme -*/
+@ql_add_expr_left_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+@ql_add_expr_right_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_add_expr_def(
+  unique int id: @ql_add_expr,
+  int left: @ql_add_expr_left_type ref,
+  int right: @ql_add_expr_right_type ref,
+  int child: @ql_token_addop ref
+);
+
+@ql_aggregate_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_aggregate_body | @ql_expr_annotation | @ql_full_aggregate_body | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_token_agg_id | @ql_unary_expr | @ql_variable
+
+#keyset[ql_aggregate, index]
+ql_aggregate_child(
+  int ql_aggregate: @ql_aggregate ref,
+  int index: int ref,
+  unique int child: @ql_aggregate_child_type ref
+);
+
+ql_aggregate_def(
+  unique int id: @ql_aggregate
+);
+
+@ql_annotArg_child_type = @ql_token_result | @ql_token_simple_id | @ql_token_this
+
+ql_annot_arg_def(
+  unique int id: @ql_annot_arg,
+  int child: @ql_annotArg_child_type ref
+);
+
+@ql_annotation_args_type = @ql_annot_arg | @ql_reserved_word
+
+#keyset[ql_annotation, index]
+ql_annotation_args(
+  int ql_annotation: @ql_annotation ref,
+  int index: int ref,
+  unique int args: @ql_annotation_args_type ref
+);
+
+ql_annotation_def(
+  unique int id: @ql_annotation,
+  int name: @ql_token_annot_name ref
+);
+
+ql_arityless_predicate_expr_qualifier(
+  unique int ql_arityless_predicate_expr: @ql_arityless_predicate_expr ref,
+  unique int qualifier: @ql_module_expr ref
+);
+
+ql_arityless_predicate_expr_def(
+  unique int id: @ql_arityless_predicate_expr,
+  int name: @ql_token_literal_id ref
+);
+
+@ql_asExpr_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_var_name | @ql_variable
+
+#keyset[ql_as_expr, index]
+ql_as_expr_child(
+  int ql_as_expr: @ql_as_expr ref,
+  int index: int ref,
+  unique int child: @ql_asExpr_child_type ref
+);
+
+ql_as_expr_def(
+  unique int id: @ql_as_expr
+);
+
+#keyset[ql_as_exprs, index]
+ql_as_exprs_child(
+  int ql_as_exprs: @ql_as_exprs ref,
+  int index: int ref,
+  unique int child: @ql_as_expr ref
+);
+
+ql_as_exprs_def(
+  unique int id: @ql_as_exprs
+);
+
+@ql_body_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_body_def(
+  unique int id: @ql_body,
+  int child: @ql_body_child_type ref
+);
+
+@ql_bool_child_type = @ql_token_false | @ql_token_true
+
+ql_bool_def(
+  unique int id: @ql_bool,
+  int child: @ql_bool_child_type ref
+);
+
+@ql_call_body_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_token_underscore | @ql_unary_expr | @ql_variable
+
+#keyset[ql_call_body, index]
+ql_call_body_child(
+  int ql_call_body: @ql_call_body ref,
+  int index: int ref,
+  unique int child: @ql_call_body_child_type ref
+);
+
+ql_call_body_def(
+  unique int id: @ql_call_body
+);
+
+@ql_call_or_unqual_agg_expr_child_type = @ql_arityless_predicate_expr | @ql_call_body | @ql_token_closure | @ql_unqual_agg_body
+
+#keyset[ql_call_or_unqual_agg_expr, index]
+ql_call_or_unqual_agg_expr_child(
+  int ql_call_or_unqual_agg_expr: @ql_call_or_unqual_agg_expr ref,
+  int index: int ref,
+  unique int child: @ql_call_or_unqual_agg_expr_child_type ref
+);
+
+ql_call_or_unqual_agg_expr_def(
+  unique int id: @ql_call_or_unqual_agg_expr
+);
+
+@ql_charpred_body_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_charpred_def(
+  unique int id: @ql_charpred,
+  int body: @ql_charpred_body_type ref,
+  int child: @ql_token_class_name ref
+);
+
+@ql_classMember_child_type = @ql_annotation | @ql_charpred | @ql_field | @ql_member_predicate | @ql_token_qldoc
+
+#keyset[ql_class_member, index]
+ql_class_member_child(
+  int ql_class_member: @ql_class_member ref,
+  int index: int ref,
+  unique int child: @ql_classMember_child_type ref
+);
+
+ql_class_member_def(
+  unique int id: @ql_class_member
+);
+
+@ql_classlessPredicate_returnType_type = @ql_token_predicate | @ql_type_expr
+
+@ql_classlessPredicate_child_type = @ql_body | @ql_higher_order_term | @ql_predicate_alias_body | @ql_token_empty | @ql_var_decl
+
+#keyset[ql_classless_predicate, index]
+ql_classless_predicate_child(
+  int ql_classless_predicate: @ql_classless_predicate ref,
+  int index: int ref,
+  unique int child: @ql_classlessPredicate_child_type ref
+);
+
+ql_classless_predicate_def(
+  unique int id: @ql_classless_predicate,
+  int name: @ql_token_predicate_name ref,
+  int return_type: @ql_classlessPredicate_returnType_type ref
+);
+
+@ql_comp_term_left_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+@ql_comp_term_right_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_comp_term_def(
+  unique int id: @ql_comp_term,
+  int left: @ql_comp_term_left_type ref,
+  int right: @ql_comp_term_right_type ref,
+  int child: @ql_token_compop ref
+);
+
+@ql_conjunction_left_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+@ql_conjunction_right_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_conjunction_def(
+  unique int id: @ql_conjunction,
+  int left: @ql_conjunction_left_type ref,
+  int right: @ql_conjunction_right_type ref
+);
+
+@ql_dataclass_extends_type = @ql_reserved_word | @ql_type_expr
+
+#keyset[ql_dataclass, index]
+ql_dataclass_extends(
+  int ql_dataclass: @ql_dataclass ref,
+  int index: int ref,
+  unique int extends: @ql_dataclass_extends_type ref
+);
+
+@ql_dataclass_instanceof_type = @ql_reserved_word | @ql_type_expr
+
+#keyset[ql_dataclass, index]
+ql_dataclass_instanceof(
+  int ql_dataclass: @ql_dataclass ref,
+  int index: int ref,
+  unique int instanceof: @ql_dataclass_instanceof_type ref
+);
+
+@ql_dataclass_child_type = @ql_class_member | @ql_type_alias_body | @ql_type_union_body
+
+#keyset[ql_dataclass, index]
+ql_dataclass_child(
+  int ql_dataclass: @ql_dataclass ref,
+  int index: int ref,
+  unique int child: @ql_dataclass_child_type ref
+);
+
+ql_dataclass_def(
+  unique int id: @ql_dataclass,
+  int name: @ql_token_class_name ref
+);
+
+ql_datatype_def(
+  unique int id: @ql_datatype,
+  int name: @ql_token_class_name ref,
+  int child: @ql_datatype_branches ref
+);
+
+@ql_datatypeBranch_child_type = @ql_annotation | @ql_body | @ql_token_qldoc | @ql_var_decl
+
+#keyset[ql_datatype_branch, index]
+ql_datatype_branch_child(
+  int ql_datatype_branch: @ql_datatype_branch ref,
+  int index: int ref,
+  unique int child: @ql_datatypeBranch_child_type ref
+);
+
+ql_datatype_branch_def(
+  unique int id: @ql_datatype_branch,
+  int name: @ql_token_class_name ref
+);
+
+#keyset[ql_datatype_branches, index]
+ql_datatype_branches_child(
+  int ql_datatype_branches: @ql_datatype_branches ref,
+  int index: int ref,
+  unique int child: @ql_datatype_branch ref
+);
+
+ql_datatype_branches_def(
+  unique int id: @ql_datatype_branches
+);
+
+@ql_disjunction_left_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+@ql_disjunction_right_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_disjunction_def(
+  unique int id: @ql_disjunction,
+  int left: @ql_disjunction_left_type ref,
+  int right: @ql_disjunction_right_type ref
+);
+
+ql_expr_aggregate_body_order_bys(
+  unique int ql_expr_aggregate_body: @ql_expr_aggregate_body ref,
+  unique int order_bys: @ql_order_bys ref
+);
+
+ql_expr_aggregate_body_def(
+  unique int id: @ql_expr_aggregate_body,
+  int as_exprs: @ql_as_exprs ref
+);
+
+@ql_expr_annotation_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_expr_annotation_def(
+  unique int id: @ql_expr_annotation,
+  int annot_arg: @ql_token_annot_name ref,
+  int name: @ql_token_annot_name ref,
+  int child: @ql_expr_annotation_child_type ref
+);
+
+ql_field_def(
+  unique int id: @ql_field,
+  int child: @ql_var_decl ref
+);
+
+ql_full_aggregate_body_as_exprs(
+  unique int ql_full_aggregate_body: @ql_full_aggregate_body ref,
+  unique int as_exprs: @ql_as_exprs ref
+);
+
+@ql_full_aggregate_body_guard_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_full_aggregate_body_guard(
+  unique int ql_full_aggregate_body: @ql_full_aggregate_body ref,
+  unique int guard: @ql_full_aggregate_body_guard_type ref
+);
+
+ql_full_aggregate_body_order_bys(
+  unique int ql_full_aggregate_body: @ql_full_aggregate_body ref,
+  unique int order_bys: @ql_order_bys ref
+);
+
+#keyset[ql_full_aggregate_body, index]
+ql_full_aggregate_body_child(
+  int ql_full_aggregate_body: @ql_full_aggregate_body ref,
+  int index: int ref,
+  unique int child: @ql_var_decl ref
+);
+
+ql_full_aggregate_body_def(
+  unique int id: @ql_full_aggregate_body
+);
+
+@ql_higherOrderTerm_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_predicate_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_token_underscore | @ql_unary_expr | @ql_variable
+
+#keyset[ql_higher_order_term, index]
+ql_higher_order_term_child(
+  int ql_higher_order_term: @ql_higher_order_term ref,
+  int index: int ref,
+  unique int child: @ql_higherOrderTerm_child_type ref
+);
+
+ql_higher_order_term_def(
+  unique int id: @ql_higher_order_term,
+  int name: @ql_token_literal_id ref
+);
+
+@ql_if_term_cond_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+@ql_if_term_first_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+@ql_if_term_second_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_if_term_def(
+  unique int id: @ql_if_term,
+  int cond: @ql_if_term_cond_type ref,
+  int first: @ql_if_term_first_type ref,
+  int second: @ql_if_term_second_type ref
+);
+
+@ql_implication_left_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+@ql_implication_right_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_implication_def(
+  unique int id: @ql_implication,
+  int left: @ql_implication_left_type ref,
+  int right: @ql_implication_right_type ref
+);
+
+@ql_importDirective_child_type = @ql_import_module_expr | @ql_module_name
+
+#keyset[ql_import_directive, index]
+ql_import_directive_child(
+  int ql_import_directive: @ql_import_directive ref,
+  int index: int ref,
+  unique int child: @ql_importDirective_child_type ref
+);
+
+ql_import_directive_def(
+  unique int id: @ql_import_directive
+);
+
+#keyset[ql_import_module_expr, index]
+ql_import_module_expr_qual_name(
+  int ql_import_module_expr: @ql_import_module_expr ref,
+  int index: int ref,
+  unique int qual_name: @ql_token_simple_id ref
+);
+
+ql_import_module_expr_def(
+  unique int id: @ql_import_module_expr,
+  int child: @ql_module_expr ref
+);
+
+@ql_in_expr_left_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+@ql_in_expr_right_type = @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_expr_annotation | @ql_literal | @ql_par_expr | @ql_qualified_expr | @ql_range | @ql_set_literal | @ql_super_ref | @ql_variable
+
+ql_in_expr_def(
+  unique int id: @ql_in_expr,
+  int left: @ql_in_expr_left_type ref,
+  int right: @ql_in_expr_right_type ref
+);
+
+@ql_instance_of_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_type_expr | @ql_unary_expr | @ql_variable
+
+#keyset[ql_instance_of, index]
+ql_instance_of_child(
+  int ql_instance_of: @ql_instance_of ref,
+  int index: int ref,
+  unique int child: @ql_instance_of_child_type ref
+);
+
+ql_instance_of_def(
+  unique int id: @ql_instance_of
+);
+
+@ql_literal_child_type = @ql_bool | @ql_token_float | @ql_token_integer | @ql_token_string
+
+ql_literal_def(
+  unique int id: @ql_literal,
+  int child: @ql_literal_child_type ref
+);
+
+@ql_memberPredicate_returnType_type = @ql_token_predicate | @ql_type_expr
+
+@ql_memberPredicate_child_type = @ql_body | @ql_higher_order_term | @ql_token_empty | @ql_var_decl
+
+#keyset[ql_member_predicate, index]
+ql_member_predicate_child(
+  int ql_member_predicate: @ql_member_predicate ref,
+  int index: int ref,
+  unique int child: @ql_memberPredicate_child_type ref
+);
+
+ql_member_predicate_def(
+  unique int id: @ql_member_predicate,
+  int name: @ql_token_predicate_name ref,
+  int return_type: @ql_memberPredicate_returnType_type ref
+);
+
+#keyset[ql_module, index]
+ql_module_implements(
+  int ql_module: @ql_module ref,
+  int index: int ref,
+  unique int implements: @ql_signature_expr ref
+);
+
+#keyset[ql_module, index]
+ql_module_parameter(
+  int ql_module: @ql_module ref,
+  int index: int ref,
+  unique int parameter: @ql_module_param ref
+);
+
+@ql_module_child_type = @ql_module_alias_body | @ql_module_member
+
+#keyset[ql_module, index]
+ql_module_child(
+  int ql_module: @ql_module ref,
+  int index: int ref,
+  unique int child: @ql_module_child_type ref
+);
+
+ql_module_def(
+  unique int id: @ql_module,
+  int name: @ql_module_name ref
+);
+
+ql_module_alias_body_def(
+  unique int id: @ql_module_alias_body,
+  int child: @ql_module_expr ref
+);
+
+@ql_moduleExpr_name_type = @ql_module_instantiation | @ql_token_simple_id
+
+ql_module_expr_name(
+  unique int ql_module_expr: @ql_module_expr ref,
+  unique int name: @ql_moduleExpr_name_type ref
+);
+
+@ql_moduleExpr_child_type = @ql_module_expr | @ql_module_instantiation | @ql_token_simple_id
+
+ql_module_expr_def(
+  unique int id: @ql_module_expr,
+  int child: @ql_moduleExpr_child_type ref
+);
+
+#keyset[ql_module_instantiation, index]
+ql_module_instantiation_child(
+  int ql_module_instantiation: @ql_module_instantiation ref,
+  int index: int ref,
+  unique int child: @ql_signature_expr ref
+);
+
+ql_module_instantiation_def(
+  unique int id: @ql_module_instantiation,
+  int name: @ql_module_name ref
+);
+
+@ql_moduleMember_child_type = @ql_annotation | @ql_classless_predicate | @ql_dataclass | @ql_datatype | @ql_import_directive | @ql_module | @ql_select | @ql_token_qldoc
+
+#keyset[ql_module_member, index]
+ql_module_member_child(
+  int ql_module_member: @ql_module_member ref,
+  int index: int ref,
+  unique int child: @ql_moduleMember_child_type ref
+);
+
+ql_module_member_def(
+  unique int id: @ql_module_member
+);
+
+ql_module_name_def(
+  unique int id: @ql_module_name,
+  int child: @ql_token_simple_id ref
+);
+
+ql_module_param_def(
+  unique int id: @ql_module_param,
+  int parameter: @ql_token_simple_id ref,
+  int signature: @ql_signature_expr ref
+);
+
+@ql_mul_expr_left_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+@ql_mul_expr_right_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_mul_expr_def(
+  unique int id: @ql_mul_expr,
+  int left: @ql_mul_expr_left_type ref,
+  int right: @ql_mul_expr_right_type ref,
+  int child: @ql_token_mulop ref
+);
+
+@ql_negation_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_negation_def(
+  unique int id: @ql_negation,
+  int child: @ql_negation_child_type ref
+);
+
+@ql_orderBy_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_token_direction | @ql_unary_expr | @ql_variable
+
+#keyset[ql_order_by, index]
+ql_order_by_child(
+  int ql_order_by: @ql_order_by ref,
+  int index: int ref,
+  unique int child: @ql_orderBy_child_type ref
+);
+
+ql_order_by_def(
+  unique int id: @ql_order_by
+);
+
+#keyset[ql_order_bys, index]
+ql_order_bys_child(
+  int ql_order_bys: @ql_order_bys ref,
+  int index: int ref,
+  unique int child: @ql_order_by ref
+);
+
+ql_order_bys_def(
+  unique int id: @ql_order_bys
+);
+
+@ql_par_expr_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_par_expr_def(
+  unique int id: @ql_par_expr,
+  int child: @ql_par_expr_child_type ref
+);
+
+ql_predicate_alias_body_def(
+  unique int id: @ql_predicate_alias_body,
+  int child: @ql_predicate_expr ref
+);
+
+@ql_predicateExpr_child_type = @ql_arityless_predicate_expr | @ql_token_integer
+
+#keyset[ql_predicate_expr, index]
+ql_predicate_expr_child(
+  int ql_predicate_expr: @ql_predicate_expr ref,
+  int index: int ref,
+  unique int child: @ql_predicateExpr_child_type ref
+);
+
+ql_predicate_expr_def(
+  unique int id: @ql_predicate_expr
+);
+
+@ql_prefix_cast_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_type_expr | @ql_unary_expr | @ql_variable
+
+#keyset[ql_prefix_cast, index]
+ql_prefix_cast_child(
+  int ql_prefix_cast: @ql_prefix_cast ref,
+  int index: int ref,
+  unique int child: @ql_prefix_cast_child_type ref
+);
+
+ql_prefix_cast_def(
+  unique int id: @ql_prefix_cast
+);
+
+#keyset[ql_ql, index]
+ql_ql_child(
+  int ql_ql: @ql_ql ref,
+  int index: int ref,
+  unique int child: @ql_module_member ref
+);
+
+ql_ql_def(
+  unique int id: @ql_ql
+);
+
+ql_qualified_rhs_name(
+  unique int ql_qualified_rhs: @ql_qualified_rhs ref,
+  unique int name: @ql_token_predicate_name ref
+);
+
+@ql_qualifiedRhs_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_token_closure | @ql_token_underscore | @ql_type_expr | @ql_unary_expr | @ql_variable
+
+#keyset[ql_qualified_rhs, index]
+ql_qualified_rhs_child(
+  int ql_qualified_rhs: @ql_qualified_rhs ref,
+  int index: int ref,
+  unique int child: @ql_qualifiedRhs_child_type ref
+);
+
+ql_qualified_rhs_def(
+  unique int id: @ql_qualified_rhs
+);
+
+@ql_qualified_expr_child_type = @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_expr_annotation | @ql_literal | @ql_par_expr | @ql_qualified_expr | @ql_qualified_rhs | @ql_range | @ql_set_literal | @ql_super_ref | @ql_variable
+
+#keyset[ql_qualified_expr, index]
+ql_qualified_expr_child(
+  int ql_qualified_expr: @ql_qualified_expr ref,
+  int index: int ref,
+  unique int child: @ql_qualified_expr_child_type ref
+);
+
+ql_qualified_expr_def(
+  unique int id: @ql_qualified_expr
+);
+
+@ql_quantified_expr_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_quantified_expr(
+  unique int ql_quantified: @ql_quantified ref,
+  unique int expr: @ql_quantified_expr_type ref
+);
+
+@ql_quantified_formula_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_quantified_formula(
+  unique int ql_quantified: @ql_quantified ref,
+  unique int formula: @ql_quantified_formula_type ref
+);
+
+@ql_quantified_range_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_quantified_range(
+  unique int ql_quantified: @ql_quantified ref,
+  unique int range: @ql_quantified_range_type ref
+);
+
+@ql_quantified_child_type = @ql_token_quantifier | @ql_var_decl
+
+#keyset[ql_quantified, index]
+ql_quantified_child(
+  int ql_quantified: @ql_quantified ref,
+  int index: int ref,
+  unique int child: @ql_quantified_child_type ref
+);
+
+ql_quantified_def(
+  unique int id: @ql_quantified
+);
+
+@ql_range_lower_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+@ql_range_upper_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_range_def(
+  unique int id: @ql_range,
+  int lower: @ql_range_lower_type ref,
+  int upper: @ql_range_upper_type ref
+);
+
+@ql_select_child_type = @ql_add_expr | @ql_aggregate | @ql_as_exprs | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_order_bys | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_var_decl | @ql_variable
+
+#keyset[ql_select, index]
+ql_select_child(
+  int ql_select: @ql_select ref,
+  int index: int ref,
+  unique int child: @ql_select_child_type ref
+);
+
+ql_select_def(
+  unique int id: @ql_select
+);
+
+@ql_set_literal_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+#keyset[ql_set_literal, index]
+ql_set_literal_child(
+  int ql_set_literal: @ql_set_literal ref,
+  int index: int ref,
+  unique int child: @ql_set_literal_child_type ref
+);
+
+ql_set_literal_def(
+  unique int id: @ql_set_literal
+);
+
+ql_signature_expr_mod_expr(
+  unique int ql_signature_expr: @ql_signature_expr ref,
+  unique int mod_expr: @ql_module_expr ref
+);
+
+ql_signature_expr_predicate(
+  unique int ql_signature_expr: @ql_signature_expr ref,
+  unique int predicate: @ql_predicate_expr ref
+);
+
+ql_signature_expr_type_expr(
+  unique int ql_signature_expr: @ql_signature_expr ref,
+  unique int type_expr: @ql_type_expr ref
+);
+
+ql_signature_expr_def(
+  unique int id: @ql_signature_expr
+);
+
+ql_special_call_def(
+  unique int id: @ql_special_call,
+  int child: @ql_token_special_id ref
+);
+
+@ql_super_ref_child_type = @ql_token_super | @ql_type_expr
+
+#keyset[ql_super_ref, index]
+ql_super_ref_child(
+  int ql_super_ref: @ql_super_ref ref,
+  int index: int ref,
+  unique int child: @ql_super_ref_child_type ref
+);
+
+ql_super_ref_def(
+  unique int id: @ql_super_ref
+);
+
+ql_type_alias_body_def(
+  unique int id: @ql_type_alias_body,
+  int child: @ql_type_expr ref
+);
+
+ql_type_expr_name(
+  unique int ql_type_expr: @ql_type_expr ref,
+  unique int name: @ql_token_class_name ref
+);
+
+ql_type_expr_qualifier(
+  unique int ql_type_expr: @ql_type_expr ref,
+  unique int qualifier: @ql_module_expr ref
+);
+
+@ql_typeExpr_child_type = @ql_token_dbtype | @ql_token_primitive_type
+
+ql_type_expr_child(
+  unique int ql_type_expr: @ql_type_expr ref,
+  unique int child: @ql_typeExpr_child_type ref
+);
+
+ql_type_expr_def(
+  unique int id: @ql_type_expr
+);
+
+#keyset[ql_type_union_body, index]
+ql_type_union_body_child(
+  int ql_type_union_body: @ql_type_union_body ref,
+  int index: int ref,
+  unique int child: @ql_type_expr ref
+);
+
+ql_type_union_body_def(
+  unique int id: @ql_type_union_body
+);
+
+@ql_unary_expr_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_token_unop | @ql_unary_expr | @ql_variable
+
+#keyset[ql_unary_expr, index]
+ql_unary_expr_child(
+  int ql_unary_expr: @ql_unary_expr ref,
+  int index: int ref,
+  unique int child: @ql_unary_expr_child_type ref
+);
+
+ql_unary_expr_def(
+  unique int id: @ql_unary_expr
+);
+
+@ql_unqual_agg_body_asExprs_type = @ql_as_exprs | @ql_reserved_word
+
+#keyset[ql_unqual_agg_body, index]
+ql_unqual_agg_body_as_exprs(
+  int ql_unqual_agg_body: @ql_unqual_agg_body ref,
+  int index: int ref,
+  unique int as_exprs: @ql_unqual_agg_body_asExprs_type ref
+);
+
+@ql_unqual_agg_body_guard_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_unqual_agg_body_guard(
+  unique int ql_unqual_agg_body: @ql_unqual_agg_body ref,
+  unique int guard: @ql_unqual_agg_body_guard_type ref
+);
+
+#keyset[ql_unqual_agg_body, index]
+ql_unqual_agg_body_child(
+  int ql_unqual_agg_body: @ql_unqual_agg_body ref,
+  int index: int ref,
+  unique int child: @ql_var_decl ref
+);
+
+ql_unqual_agg_body_def(
+  unique int id: @ql_unqual_agg_body
+);
+
+@ql_varDecl_child_type = @ql_type_expr | @ql_var_name
+
+#keyset[ql_var_decl, index]
+ql_var_decl_child(
+  int ql_var_decl: @ql_var_decl ref,
+  int index: int ref,
+  unique int child: @ql_varDecl_child_type ref
+);
+
+ql_var_decl_def(
+  unique int id: @ql_var_decl
+);
+
+ql_var_name_def(
+  unique int id: @ql_var_name,
+  int child: @ql_token_simple_id ref
+);
+
+@ql_variable_child_type = @ql_token_result | @ql_token_this | @ql_var_name
+
+ql_variable_def(
+  unique int id: @ql_variable,
+  int child: @ql_variable_child_type ref
+);
+
+ql_tokeninfo(
+  unique int id: @ql_token,
+  int kind: int ref,
+  string value: string ref
+);
+
+case @ql_token.kind of
+  0 = @ql_reserved_word
+| 1 = @ql_token_addop
+| 2 = @ql_token_agg_id
+| 3 = @ql_token_annot_name
+| 4 = @ql_token_block_comment
+| 5 = @ql_token_class_name
+| 6 = @ql_token_closure
+| 7 = @ql_token_compop
+| 8 = @ql_token_dbtype
+| 9 = @ql_token_direction
+| 10 = @ql_token_empty
+| 11 = @ql_token_false
+| 12 = @ql_token_float
+| 13 = @ql_token_integer
+| 14 = @ql_token_line_comment
+| 15 = @ql_token_literal_id
+| 16 = @ql_token_mulop
+| 17 = @ql_token_predicate
+| 18 = @ql_token_predicate_name
+| 19 = @ql_token_primitive_type
+| 20 = @ql_token_qldoc
+| 21 = @ql_token_quantifier
+| 22 = @ql_token_result
+| 23 = @ql_token_simple_id
+| 24 = @ql_token_special_id
+| 25 = @ql_token_string
+| 26 = @ql_token_super
+| 27 = @ql_token_this
+| 28 = @ql_token_true
+| 29 = @ql_token_underscore
+| 30 = @ql_token_unop
+;
+
+
+@ql_ast_node = @ql_add_expr | @ql_aggregate | @ql_annot_arg | @ql_annotation | @ql_arityless_predicate_expr | @ql_as_expr | @ql_as_exprs | @ql_body | @ql_bool | @ql_call_body | @ql_call_or_unqual_agg_expr | @ql_charpred | @ql_class_member | @ql_classless_predicate | @ql_comp_term | @ql_conjunction | @ql_dataclass | @ql_datatype | @ql_datatype_branch | @ql_datatype_branches | @ql_disjunction | @ql_expr_aggregate_body | @ql_expr_annotation | @ql_field | @ql_full_aggregate_body | @ql_higher_order_term | @ql_if_term | @ql_implication | @ql_import_directive | @ql_import_module_expr | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_member_predicate | @ql_module | @ql_module_alias_body | @ql_module_expr | @ql_module_instantiation | @ql_module_member | @ql_module_name | @ql_module_param | @ql_mul_expr | @ql_negation | @ql_order_by | @ql_order_bys | @ql_par_expr | @ql_predicate_alias_body | @ql_predicate_expr | @ql_prefix_cast | @ql_ql | @ql_qualified_expr | @ql_qualified_rhs | @ql_quantified | @ql_range | @ql_select | @ql_set_literal | @ql_signature_expr | @ql_special_call | @ql_super_ref | @ql_token | @ql_type_alias_body | @ql_type_expr | @ql_type_union_body | @ql_unary_expr | @ql_unqual_agg_body | @ql_var_decl | @ql_var_name | @ql_variable
+
+ql_ast_node_location(
+  unique int node: @ql_ast_node ref,
+  int loc: @location_default ref
+);
+
+#keyset[parent, parent_index]
+ql_ast_node_parent(
+  unique int node: @ql_ast_node ref,
+  int parent: @ql_ast_node ref,
+  int parent_index: int ref
+);
+
+/*- Dbscheme dbscheme -*/
+dbscheme_annotation_args_annotation(
+  unique int dbscheme_annotation: @dbscheme_annotation ref,
+  unique int args_annotation: @dbscheme_args_annotation ref
+);
+
+dbscheme_annotation_simple_annotation(
+  unique int dbscheme_annotation: @dbscheme_annotation ref,
+  unique int simple_annotation: @dbscheme_token_annot_name ref
+);
+
+dbscheme_annotation_def(
+  unique int id: @dbscheme_annotation
+);
+
+#keyset[dbscheme_args_annotation, index]
+dbscheme_args_annotation_child(
+  int dbscheme_args_annotation: @dbscheme_args_annotation ref,
+  int index: int ref,
+  unique int child: @dbscheme_token_simple_id ref
+);
+
+dbscheme_args_annotation_def(
+  unique int id: @dbscheme_args_annotation,
+  int name: @dbscheme_token_annot_name ref
+);
+
+dbscheme_branch_qldoc(
+  unique int dbscheme_branch: @dbscheme_branch ref,
+  unique int qldoc: @dbscheme_token_qldoc ref
+);
+
+@dbscheme_branch_child_type = @dbscheme_token_dbtype | @dbscheme_token_integer
+
+#keyset[dbscheme_branch, index]
+dbscheme_branch_child(
+  int dbscheme_branch: @dbscheme_branch ref,
+  int index: int ref,
+  unique int child: @dbscheme_branch_child_type ref
+);
+
+dbscheme_branch_def(
+  unique int id: @dbscheme_branch
+);
+
+#keyset[dbscheme_case_decl, index]
+dbscheme_case_decl_child(
+  int dbscheme_case_decl: @dbscheme_case_decl ref,
+  int index: int ref,
+  unique int child: @dbscheme_branch ref
+);
+
+dbscheme_case_decl_def(
+  unique int id: @dbscheme_case_decl,
+  int base: @dbscheme_token_dbtype ref,
+  int discriminator: @dbscheme_token_simple_id ref
+);
+
+@dbscheme_colType_child_type = @dbscheme_token_boolean | @dbscheme_token_date | @dbscheme_token_dbtype | @dbscheme_token_float | @dbscheme_token_int | @dbscheme_token_string
+
+dbscheme_col_type_def(
+  unique int id: @dbscheme_col_type,
+  int child: @dbscheme_colType_child_type ref
+);
+
+dbscheme_column_is_ref(
+  unique int dbscheme_column: @dbscheme_column ref,
+  unique int is_ref: @dbscheme_token_ref ref
+);
+
+dbscheme_column_is_unique(
+  unique int dbscheme_column: @dbscheme_column ref,
+  unique int is_unique: @dbscheme_token_unique ref
+);
+
+dbscheme_column_qldoc(
+  unique int dbscheme_column: @dbscheme_column ref,
+  unique int qldoc: @dbscheme_token_qldoc ref
+);
+
+dbscheme_column_def(
+  unique int id: @dbscheme_column,
+  int col_name: @dbscheme_token_simple_id ref,
+  int col_type: @dbscheme_col_type ref,
+  int repr_type: @dbscheme_repr_type ref
+);
+
+#keyset[dbscheme_dbscheme, index]
+dbscheme_dbscheme_child(
+  int dbscheme_dbscheme: @dbscheme_dbscheme ref,
+  int index: int ref,
+  unique int child: @dbscheme_entry ref
+);
+
+dbscheme_dbscheme_def(
+  unique int id: @dbscheme_dbscheme
+);
+
+@dbscheme_entry_child_type = @dbscheme_case_decl | @dbscheme_table | @dbscheme_token_qldoc | @dbscheme_union_decl
+
+dbscheme_entry_def(
+  unique int id: @dbscheme_entry,
+  int child: @dbscheme_entry_child_type ref
+);
+
+@dbscheme_reprType_child_type = @dbscheme_token_boolean | @dbscheme_token_date | @dbscheme_token_float | @dbscheme_token_int | @dbscheme_token_integer | @dbscheme_token_string | @dbscheme_token_varchar
+
+#keyset[dbscheme_repr_type, index]
+dbscheme_repr_type_child(
+  int dbscheme_repr_type: @dbscheme_repr_type ref,
+  int index: int ref,
+  unique int child: @dbscheme_reprType_child_type ref
+);
+
+dbscheme_repr_type_def(
+  unique int id: @dbscheme_repr_type
+);
+
+@dbscheme_table_child_type = @dbscheme_annotation | @dbscheme_column
+
+#keyset[dbscheme_table, index]
+dbscheme_table_child(
+  int dbscheme_table: @dbscheme_table ref,
+  int index: int ref,
+  unique int child: @dbscheme_table_child_type ref
+);
+
+dbscheme_table_def(
+  unique int id: @dbscheme_table,
+  int table_name: @dbscheme_table_name ref
+);
+
+dbscheme_table_name_def(
+  unique int id: @dbscheme_table_name,
+  int child: @dbscheme_token_simple_id ref
+);
+
+#keyset[dbscheme_union_decl, index]
+dbscheme_union_decl_child(
+  int dbscheme_union_decl: @dbscheme_union_decl ref,
+  int index: int ref,
+  unique int child: @dbscheme_token_dbtype ref
+);
+
+dbscheme_union_decl_def(
+  unique int id: @dbscheme_union_decl,
+  int base: @dbscheme_token_dbtype ref
+);
+
+dbscheme_tokeninfo(
+  unique int id: @dbscheme_token,
+  int kind: int ref,
+  string value: string ref
+);
+
+case @dbscheme_token.kind of
+  0 = @dbscheme_reserved_word
+| 1 = @dbscheme_token_annot_name
+| 2 = @dbscheme_token_block_comment
+| 3 = @dbscheme_token_boolean
+| 4 = @dbscheme_token_date
+| 5 = @dbscheme_token_dbtype
+| 6 = @dbscheme_token_float
+| 7 = @dbscheme_token_int
+| 8 = @dbscheme_token_integer
+| 9 = @dbscheme_token_line_comment
+| 10 = @dbscheme_token_qldoc
+| 11 = @dbscheme_token_ref
+| 12 = @dbscheme_token_simple_id
+| 13 = @dbscheme_token_string
+| 14 = @dbscheme_token_unique
+| 15 = @dbscheme_token_varchar
+;
+
+
+@dbscheme_ast_node = @dbscheme_annotation | @dbscheme_args_annotation | @dbscheme_branch | @dbscheme_case_decl | @dbscheme_col_type | @dbscheme_column | @dbscheme_dbscheme | @dbscheme_entry | @dbscheme_repr_type | @dbscheme_table | @dbscheme_table_name | @dbscheme_token | @dbscheme_union_decl
+
+dbscheme_ast_node_location(
+  unique int node: @dbscheme_ast_node ref,
+  int loc: @location_default ref
+);
+
+#keyset[parent, parent_index]
+dbscheme_ast_node_parent(
+  unique int node: @dbscheme_ast_node ref,
+  int parent: @dbscheme_ast_node ref,
+  int parent_index: int ref
+);
+
+/*- Blame dbscheme -*/
+#keyset[blame_blame_entry, index]
+blame_blame_entry_line(
+  int blame_blame_entry: @blame_blame_entry ref,
+  int index: int ref,
+  unique int line: @blame_token_number ref
+);
+
+blame_blame_entry_def(
+  unique int id: @blame_blame_entry,
+  int date__: @blame_token_date ref
+);
+
+#keyset[blame_blame_info, index]
+blame_blame_info_file_entry(
+  int blame_blame_info: @blame_blame_info ref,
+  int index: int ref,
+  unique int file_entry: @blame_file_entry ref
+);
+
+blame_blame_info_def(
+  unique int id: @blame_blame_info,
+  int today: @blame_token_date ref
+);
+
+#keyset[blame_file_entry, index]
+blame_file_entry_blame_entry(
+  int blame_file_entry: @blame_file_entry ref,
+  int index: int ref,
+  unique int blame_entry: @blame_blame_entry ref
+);
+
+blame_file_entry_def(
+  unique int id: @blame_file_entry,
+  int file_name: @blame_token_filename ref
+);
+
+blame_tokeninfo(
+  unique int id: @blame_token,
+  int kind: int ref,
+  string value: string ref
+);
+
+case @blame_token.kind of
+  0 = @blame_reserved_word
+| 1 = @blame_token_date
+| 2 = @blame_token_filename
+| 3 = @blame_token_number
+;
+
+
+@blame_ast_node = @blame_blame_entry | @blame_blame_info | @blame_file_entry | @blame_token
+
+blame_ast_node_location(
+  unique int node: @blame_ast_node ref,
+  int loc: @location_default ref
+);
+
+#keyset[parent, parent_index]
+blame_ast_node_parent(
+  unique int node: @blame_ast_node ref,
+  int parent: @blame_ast_node ref,
+  int parent_index: int ref
+);
+
+/*- JSON dbscheme -*/
+@json_underscore_value = @json_array | @json_object | @json_string__ | @json_token_false | @json_token_null | @json_token_number | @json_token_true
+
+#keyset[json_array, index]
+json_array_child(
+  int json_array: @json_array ref,
+  int index: int ref,
+  unique int child: @json_underscore_value ref
+);
+
+json_array_def(
+  unique int id: @json_array
+);
+
+#keyset[json_document, index]
+json_document_child(
+  int json_document: @json_document ref,
+  int index: int ref,
+  unique int child: @json_underscore_value ref
+);
+
+json_document_def(
+  unique int id: @json_document
+);
+
+#keyset[json_object, index]
+json_object_child(
+  int json_object: @json_object ref,
+  int index: int ref,
+  unique int child: @json_pair ref
+);
+
+json_object_def(
+  unique int id: @json_object
+);
+
+json_pair_def(
+  unique int id: @json_pair,
+  int key__: @json_string__ ref,
+  int value: @json_underscore_value ref
+);
+
+@json_string_child_type = @json_token_escape_sequence | @json_token_string_content
+
+#keyset[json_string__, index]
+json_string_child(
+  int json_string__: @json_string__ ref,
+  int index: int ref,
+  unique int child: @json_string_child_type ref
+);
+
+json_string_def(
+  unique int id: @json_string__
+);
+
+json_tokeninfo(
+  unique int id: @json_token,
+  int kind: int ref,
+  string value: string ref
+);
+
+case @json_token.kind of
+  0 = @json_reserved_word
+| 1 = @json_token_comment
+| 2 = @json_token_escape_sequence
+| 3 = @json_token_false
+| 4 = @json_token_null
+| 5 = @json_token_number
+| 6 = @json_token_string_content
+| 7 = @json_token_true
+;
+
+
+@json_ast_node = @json_array | @json_document | @json_object | @json_pair | @json_string__ | @json_token
+
+json_ast_node_location(
+  unique int node: @json_ast_node ref,
+  int loc: @location_default ref
+);
+
+#keyset[parent, parent_index]
+json_ast_node_parent(
+  unique int node: @json_ast_node ref,
+  int parent: @json_ast_node ref,
+  int parent_index: int ref
+);
+

--- a/ql/downgrades/87c1125b41a68de7353f538cd7fb73bd0f18bfe0/ql.dbscheme
+++ b/ql/downgrades/87c1125b41a68de7353f538cd7fb73bd0f18bfe0/ql.dbscheme
@@ -1,0 +1,1360 @@
+// CodeQL database schema for QL
+// Automatically generated from the tree-sitter grammar; do not edit
+// To regenerate, run 'scripts/create-extractor-pack.sh' in ql/
+
+/*- Files and folders -*/
+
+/**
+ * The location of an element.
+ * The location spans column `startcolumn` of line `startline` to
+ * column `endcolumn` of line `endline` in file `file`.
+ * For more information, see
+ * [Locations](https://codeql.github.com/docs/writing-codeql-queries/providing-locations-in-codeql-queries/).
+ */
+locations_default(
+  unique int id: @location_default,
+  int file: @file ref,
+  int beginLine: int ref,
+  int beginColumn: int ref,
+  int endLine: int ref,
+  int endColumn: int ref
+);
+
+files(
+  unique int id: @file,
+  string name: string ref
+);
+
+folders(
+  unique int id: @folder,
+  string name: string ref
+);
+
+@container = @file | @folder
+
+containerparent(
+  int parent: @container ref,
+  unique int child: @container ref
+);
+
+/*- Empty location -*/
+
+empty_location(
+  int location: @location_default ref
+);
+
+/*- Source location prefix -*/
+
+/**
+ * The source location of the snapshot.
+ */
+sourceLocationPrefix(string prefix : string ref);
+
+/*- Diagnostic messages -*/
+
+diagnostics(
+  unique int id: @diagnostic,
+  int severity: int ref,
+  string error_tag: string ref,
+  string error_message: string ref,
+  string full_error_message: string ref,
+  int location: @location_default ref
+);
+
+/*- Diagnostic messages: severity -*/
+
+case @diagnostic.severity of
+  10 = @diagnostic_debug
+| 20 = @diagnostic_info
+| 30 = @diagnostic_warning
+| 40 = @diagnostic_error
+;
+
+/*- YAML -*/
+
+#keyset[parent, idx]
+yaml (unique int id: @yaml_node,
+      int kind: int ref,
+      int parent: @yaml_node_parent ref,
+      int idx: int ref,
+      string tag: string ref,
+      string tostring: string ref);
+
+case @yaml_node.kind of
+  0 = @yaml_scalar_node
+| 1 = @yaml_mapping_node
+| 2 = @yaml_sequence_node
+| 3 = @yaml_alias_node
+;
+
+@yaml_collection_node = @yaml_mapping_node | @yaml_sequence_node;
+
+@yaml_node_parent = @yaml_collection_node | @file;
+
+yaml_anchors (unique int node: @yaml_node ref,
+              string anchor: string ref);
+
+yaml_aliases (unique int alias: @yaml_alias_node ref,
+              string target: string ref);
+
+yaml_scalars (unique int scalar: @yaml_scalar_node ref,
+              int style: int ref,
+              string value: string ref);
+
+yaml_comments (unique int id: @yaml_comment,
+               string text: string ref,
+               string tostring: string ref);
+
+yaml_errors (unique int id: @yaml_error,
+             string message: string ref);
+
+yaml_locations(unique int locatable: @yaml_locatable ref,
+             int location: @location_default ref);
+
+@yaml_locatable = @yaml_node | @yaml_error | @yaml_comment;
+
+/*- Database metadata -*/
+
+/**
+ * The CLI will automatically emit applicable tuples for this table,
+ * such as `databaseMetadata("isOverlay", "true")` when building an
+ * overlay database.
+ */
+databaseMetadata(
+  string metadataKey: string ref,
+  string value: string ref
+);
+
+/*- Overlay support -*/
+
+/**
+ * The CLI will automatically emit tuples for each new/modified/deleted file
+ * when building an overlay database.
+ */
+overlayChangedFiles(
+  string path: string ref
+);
+
+/*- QL dbscheme -*/
+@ql_add_expr_left_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+@ql_add_expr_right_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_add_expr_def(
+  unique int id: @ql_add_expr,
+  int left: @ql_add_expr_left_type ref,
+  int right: @ql_add_expr_right_type ref,
+  int child: @ql_token_addop ref
+);
+
+@ql_aggregate_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_aggregate_body | @ql_expr_annotation | @ql_full_aggregate_body | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_token_agg_id | @ql_unary_expr | @ql_variable
+
+#keyset[ql_aggregate, index]
+ql_aggregate_child(
+  int ql_aggregate: @ql_aggregate ref,
+  int index: int ref,
+  unique int child: @ql_aggregate_child_type ref
+);
+
+ql_aggregate_def(
+  unique int id: @ql_aggregate
+);
+
+@ql_annotArg_child_type = @ql_token_result | @ql_token_simple_id | @ql_token_this
+
+ql_annot_arg_def(
+  unique int id: @ql_annot_arg,
+  int child: @ql_annotArg_child_type ref
+);
+
+@ql_annotation_args_type = @ql_annot_arg | @ql_reserved_word
+
+#keyset[ql_annotation, index]
+ql_annotation_args(
+  int ql_annotation: @ql_annotation ref,
+  int index: int ref,
+  unique int args: @ql_annotation_args_type ref
+);
+
+ql_annotation_def(
+  unique int id: @ql_annotation,
+  int name: @ql_token_annot_name ref
+);
+
+ql_arityless_predicate_expr_qualifier(
+  unique int ql_arityless_predicate_expr: @ql_arityless_predicate_expr ref,
+  unique int qualifier: @ql_module_expr ref
+);
+
+ql_arityless_predicate_expr_def(
+  unique int id: @ql_arityless_predicate_expr,
+  int name: @ql_token_literal_id ref
+);
+
+@ql_asExpr_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_var_name | @ql_variable
+
+#keyset[ql_as_expr, index]
+ql_as_expr_child(
+  int ql_as_expr: @ql_as_expr ref,
+  int index: int ref,
+  unique int child: @ql_asExpr_child_type ref
+);
+
+ql_as_expr_def(
+  unique int id: @ql_as_expr
+);
+
+#keyset[ql_as_exprs, index]
+ql_as_exprs_child(
+  int ql_as_exprs: @ql_as_exprs ref,
+  int index: int ref,
+  unique int child: @ql_as_expr ref
+);
+
+ql_as_exprs_def(
+  unique int id: @ql_as_exprs
+);
+
+@ql_body_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_body_def(
+  unique int id: @ql_body,
+  int child: @ql_body_child_type ref
+);
+
+@ql_bool_child_type = @ql_token_false | @ql_token_true
+
+ql_bool_def(
+  unique int id: @ql_bool,
+  int child: @ql_bool_child_type ref
+);
+
+@ql_call_body_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_token_underscore | @ql_unary_expr | @ql_variable
+
+#keyset[ql_call_body, index]
+ql_call_body_child(
+  int ql_call_body: @ql_call_body ref,
+  int index: int ref,
+  unique int child: @ql_call_body_child_type ref
+);
+
+ql_call_body_def(
+  unique int id: @ql_call_body
+);
+
+@ql_call_or_unqual_agg_expr_child_type = @ql_arityless_predicate_expr | @ql_call_body | @ql_token_closure | @ql_unqual_agg_body
+
+#keyset[ql_call_or_unqual_agg_expr, index]
+ql_call_or_unqual_agg_expr_child(
+  int ql_call_or_unqual_agg_expr: @ql_call_or_unqual_agg_expr ref,
+  int index: int ref,
+  unique int child: @ql_call_or_unqual_agg_expr_child_type ref
+);
+
+ql_call_or_unqual_agg_expr_def(
+  unique int id: @ql_call_or_unqual_agg_expr
+);
+
+@ql_charpred_body_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_charpred_def(
+  unique int id: @ql_charpred,
+  int body: @ql_charpred_body_type ref,
+  int child: @ql_token_class_name ref
+);
+
+@ql_classMember_child_type = @ql_annotation | @ql_charpred | @ql_field | @ql_member_predicate | @ql_token_qldoc
+
+#keyset[ql_class_member, index]
+ql_class_member_child(
+  int ql_class_member: @ql_class_member ref,
+  int index: int ref,
+  unique int child: @ql_classMember_child_type ref
+);
+
+ql_class_member_def(
+  unique int id: @ql_class_member
+);
+
+@ql_classlessPredicate_returnType_type = @ql_token_predicate | @ql_type_expr
+
+@ql_classlessPredicate_child_type = @ql_body | @ql_higher_order_term | @ql_predicate_alias_body | @ql_token_empty | @ql_var_decl
+
+#keyset[ql_classless_predicate, index]
+ql_classless_predicate_child(
+  int ql_classless_predicate: @ql_classless_predicate ref,
+  int index: int ref,
+  unique int child: @ql_classlessPredicate_child_type ref
+);
+
+ql_classless_predicate_def(
+  unique int id: @ql_classless_predicate,
+  int name: @ql_token_predicate_name ref,
+  int return_type: @ql_classlessPredicate_returnType_type ref
+);
+
+@ql_comp_term_left_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+@ql_comp_term_right_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_comp_term_def(
+  unique int id: @ql_comp_term,
+  int left: @ql_comp_term_left_type ref,
+  int right: @ql_comp_term_right_type ref,
+  int child: @ql_token_compop ref
+);
+
+@ql_conjunction_left_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+@ql_conjunction_right_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_conjunction_def(
+  unique int id: @ql_conjunction,
+  int left: @ql_conjunction_left_type ref,
+  int right: @ql_conjunction_right_type ref
+);
+
+@ql_dataclass_extends_type = @ql_reserved_word | @ql_type_expr
+
+#keyset[ql_dataclass, index]
+ql_dataclass_extends(
+  int ql_dataclass: @ql_dataclass ref,
+  int index: int ref,
+  unique int extends: @ql_dataclass_extends_type ref
+);
+
+@ql_dataclass_instanceof_type = @ql_reserved_word | @ql_type_expr
+
+#keyset[ql_dataclass, index]
+ql_dataclass_instanceof(
+  int ql_dataclass: @ql_dataclass ref,
+  int index: int ref,
+  unique int instanceof: @ql_dataclass_instanceof_type ref
+);
+
+@ql_dataclass_child_type = @ql_class_member | @ql_type_alias_body | @ql_type_union_body
+
+#keyset[ql_dataclass, index]
+ql_dataclass_child(
+  int ql_dataclass: @ql_dataclass ref,
+  int index: int ref,
+  unique int child: @ql_dataclass_child_type ref
+);
+
+ql_dataclass_def(
+  unique int id: @ql_dataclass,
+  int name: @ql_token_class_name ref
+);
+
+ql_datatype_def(
+  unique int id: @ql_datatype,
+  int name: @ql_token_class_name ref,
+  int child: @ql_datatype_branches ref
+);
+
+@ql_datatypeBranch_child_type = @ql_annotation | @ql_body | @ql_token_qldoc | @ql_var_decl
+
+#keyset[ql_datatype_branch, index]
+ql_datatype_branch_child(
+  int ql_datatype_branch: @ql_datatype_branch ref,
+  int index: int ref,
+  unique int child: @ql_datatypeBranch_child_type ref
+);
+
+ql_datatype_branch_def(
+  unique int id: @ql_datatype_branch,
+  int name: @ql_token_class_name ref
+);
+
+#keyset[ql_datatype_branches, index]
+ql_datatype_branches_child(
+  int ql_datatype_branches: @ql_datatype_branches ref,
+  int index: int ref,
+  unique int child: @ql_datatype_branch ref
+);
+
+ql_datatype_branches_def(
+  unique int id: @ql_datatype_branches
+);
+
+@ql_disjunction_left_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+@ql_disjunction_right_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_disjunction_def(
+  unique int id: @ql_disjunction,
+  int left: @ql_disjunction_left_type ref,
+  int right: @ql_disjunction_right_type ref
+);
+
+ql_expr_aggregate_body_order_bys(
+  unique int ql_expr_aggregate_body: @ql_expr_aggregate_body ref,
+  unique int order_bys: @ql_order_bys ref
+);
+
+ql_expr_aggregate_body_def(
+  unique int id: @ql_expr_aggregate_body,
+  int as_exprs: @ql_as_exprs ref
+);
+
+@ql_expr_annotation_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_expr_annotation_def(
+  unique int id: @ql_expr_annotation,
+  int annot_arg: @ql_token_annot_name ref,
+  int name: @ql_token_annot_name ref,
+  int child: @ql_expr_annotation_child_type ref
+);
+
+ql_field_def(
+  unique int id: @ql_field,
+  int child: @ql_var_decl ref
+);
+
+ql_full_aggregate_body_as_exprs(
+  unique int ql_full_aggregate_body: @ql_full_aggregate_body ref,
+  unique int as_exprs: @ql_as_exprs ref
+);
+
+@ql_full_aggregate_body_guard_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_full_aggregate_body_guard(
+  unique int ql_full_aggregate_body: @ql_full_aggregate_body ref,
+  unique int guard: @ql_full_aggregate_body_guard_type ref
+);
+
+ql_full_aggregate_body_order_bys(
+  unique int ql_full_aggregate_body: @ql_full_aggregate_body ref,
+  unique int order_bys: @ql_order_bys ref
+);
+
+#keyset[ql_full_aggregate_body, index]
+ql_full_aggregate_body_child(
+  int ql_full_aggregate_body: @ql_full_aggregate_body ref,
+  int index: int ref,
+  unique int child: @ql_var_decl ref
+);
+
+ql_full_aggregate_body_def(
+  unique int id: @ql_full_aggregate_body
+);
+
+@ql_higherOrderTerm_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_predicate_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_token_underscore | @ql_unary_expr | @ql_variable
+
+#keyset[ql_higher_order_term, index]
+ql_higher_order_term_child(
+  int ql_higher_order_term: @ql_higher_order_term ref,
+  int index: int ref,
+  unique int child: @ql_higherOrderTerm_child_type ref
+);
+
+ql_higher_order_term_def(
+  unique int id: @ql_higher_order_term,
+  int name: @ql_token_literal_id ref
+);
+
+@ql_if_term_cond_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+@ql_if_term_first_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+@ql_if_term_second_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_if_term_def(
+  unique int id: @ql_if_term,
+  int cond: @ql_if_term_cond_type ref,
+  int first: @ql_if_term_first_type ref,
+  int second: @ql_if_term_second_type ref
+);
+
+@ql_implication_left_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+@ql_implication_right_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_implication_def(
+  unique int id: @ql_implication,
+  int left: @ql_implication_left_type ref,
+  int right: @ql_implication_right_type ref
+);
+
+@ql_importDirective_child_type = @ql_import_module_expr | @ql_module_name
+
+#keyset[ql_import_directive, index]
+ql_import_directive_child(
+  int ql_import_directive: @ql_import_directive ref,
+  int index: int ref,
+  unique int child: @ql_importDirective_child_type ref
+);
+
+ql_import_directive_def(
+  unique int id: @ql_import_directive
+);
+
+#keyset[ql_import_module_expr, index]
+ql_import_module_expr_qual_name(
+  int ql_import_module_expr: @ql_import_module_expr ref,
+  int index: int ref,
+  unique int qual_name: @ql_token_simple_id ref
+);
+
+ql_import_module_expr_def(
+  unique int id: @ql_import_module_expr,
+  int child: @ql_module_expr ref
+);
+
+@ql_in_expr_left_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+@ql_in_expr_right_type = @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_expr_annotation | @ql_literal | @ql_par_expr | @ql_qualified_expr | @ql_range | @ql_set_literal | @ql_super_ref | @ql_variable
+
+ql_in_expr_def(
+  unique int id: @ql_in_expr,
+  int left: @ql_in_expr_left_type ref,
+  int right: @ql_in_expr_right_type ref
+);
+
+@ql_instance_of_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_type_expr | @ql_unary_expr | @ql_variable
+
+#keyset[ql_instance_of, index]
+ql_instance_of_child(
+  int ql_instance_of: @ql_instance_of ref,
+  int index: int ref,
+  unique int child: @ql_instance_of_child_type ref
+);
+
+ql_instance_of_def(
+  unique int id: @ql_instance_of
+);
+
+@ql_literal_child_type = @ql_bool | @ql_token_float | @ql_token_integer | @ql_token_string
+
+ql_literal_def(
+  unique int id: @ql_literal,
+  int child: @ql_literal_child_type ref
+);
+
+@ql_memberPredicate_returnType_type = @ql_token_predicate | @ql_type_expr
+
+@ql_memberPredicate_child_type = @ql_body | @ql_higher_order_term | @ql_token_empty | @ql_var_decl
+
+#keyset[ql_member_predicate, index]
+ql_member_predicate_child(
+  int ql_member_predicate: @ql_member_predicate ref,
+  int index: int ref,
+  unique int child: @ql_memberPredicate_child_type ref
+);
+
+ql_member_predicate_def(
+  unique int id: @ql_member_predicate,
+  int name: @ql_token_predicate_name ref,
+  int return_type: @ql_memberPredicate_returnType_type ref
+);
+
+#keyset[ql_module, index]
+ql_module_implements(
+  int ql_module: @ql_module ref,
+  int index: int ref,
+  unique int implements: @ql_signature_expr ref
+);
+
+#keyset[ql_module, index]
+ql_module_parameter(
+  int ql_module: @ql_module ref,
+  int index: int ref,
+  unique int parameter: @ql_module_param ref
+);
+
+@ql_module_child_type = @ql_module_alias_body | @ql_module_member
+
+#keyset[ql_module, index]
+ql_module_child(
+  int ql_module: @ql_module ref,
+  int index: int ref,
+  unique int child: @ql_module_child_type ref
+);
+
+ql_module_def(
+  unique int id: @ql_module,
+  int name: @ql_module_name ref
+);
+
+ql_module_alias_body_def(
+  unique int id: @ql_module_alias_body,
+  int child: @ql_module_expr ref
+);
+
+@ql_moduleExpr_name_type = @ql_module_instantiation | @ql_token_simple_id
+
+ql_module_expr_name(
+  unique int ql_module_expr: @ql_module_expr ref,
+  unique int name: @ql_moduleExpr_name_type ref
+);
+
+@ql_moduleExpr_child_type = @ql_module_expr | @ql_module_instantiation | @ql_token_simple_id
+
+ql_module_expr_def(
+  unique int id: @ql_module_expr,
+  int child: @ql_moduleExpr_child_type ref
+);
+
+#keyset[ql_module_instantiation, index]
+ql_module_instantiation_child(
+  int ql_module_instantiation: @ql_module_instantiation ref,
+  int index: int ref,
+  unique int child: @ql_signature_expr ref
+);
+
+ql_module_instantiation_def(
+  unique int id: @ql_module_instantiation,
+  int name: @ql_module_name ref
+);
+
+@ql_moduleMember_child_type = @ql_annotation | @ql_classless_predicate | @ql_dataclass | @ql_datatype | @ql_import_directive | @ql_module | @ql_select | @ql_token_qldoc
+
+#keyset[ql_module_member, index]
+ql_module_member_child(
+  int ql_module_member: @ql_module_member ref,
+  int index: int ref,
+  unique int child: @ql_moduleMember_child_type ref
+);
+
+ql_module_member_def(
+  unique int id: @ql_module_member
+);
+
+ql_module_name_def(
+  unique int id: @ql_module_name,
+  int child: @ql_token_simple_id ref
+);
+
+ql_module_param_def(
+  unique int id: @ql_module_param,
+  int parameter: @ql_token_simple_id ref,
+  int signature: @ql_signature_expr ref
+);
+
+@ql_mul_expr_left_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+@ql_mul_expr_right_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_mul_expr_def(
+  unique int id: @ql_mul_expr,
+  int left: @ql_mul_expr_left_type ref,
+  int right: @ql_mul_expr_right_type ref,
+  int child: @ql_token_mulop ref
+);
+
+@ql_negation_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_negation_def(
+  unique int id: @ql_negation,
+  int child: @ql_negation_child_type ref
+);
+
+@ql_orderBy_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_token_direction | @ql_unary_expr | @ql_variable
+
+#keyset[ql_order_by, index]
+ql_order_by_child(
+  int ql_order_by: @ql_order_by ref,
+  int index: int ref,
+  unique int child: @ql_orderBy_child_type ref
+);
+
+ql_order_by_def(
+  unique int id: @ql_order_by
+);
+
+#keyset[ql_order_bys, index]
+ql_order_bys_child(
+  int ql_order_bys: @ql_order_bys ref,
+  int index: int ref,
+  unique int child: @ql_order_by ref
+);
+
+ql_order_bys_def(
+  unique int id: @ql_order_bys
+);
+
+@ql_par_expr_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_par_expr_def(
+  unique int id: @ql_par_expr,
+  int child: @ql_par_expr_child_type ref
+);
+
+ql_predicate_alias_body_def(
+  unique int id: @ql_predicate_alias_body,
+  int child: @ql_predicate_expr ref
+);
+
+@ql_predicateExpr_child_type = @ql_arityless_predicate_expr | @ql_token_integer
+
+#keyset[ql_predicate_expr, index]
+ql_predicate_expr_child(
+  int ql_predicate_expr: @ql_predicate_expr ref,
+  int index: int ref,
+  unique int child: @ql_predicateExpr_child_type ref
+);
+
+ql_predicate_expr_def(
+  unique int id: @ql_predicate_expr
+);
+
+@ql_prefix_cast_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_type_expr | @ql_unary_expr | @ql_variable
+
+#keyset[ql_prefix_cast, index]
+ql_prefix_cast_child(
+  int ql_prefix_cast: @ql_prefix_cast ref,
+  int index: int ref,
+  unique int child: @ql_prefix_cast_child_type ref
+);
+
+ql_prefix_cast_def(
+  unique int id: @ql_prefix_cast
+);
+
+#keyset[ql_ql, index]
+ql_ql_child(
+  int ql_ql: @ql_ql ref,
+  int index: int ref,
+  unique int child: @ql_module_member ref
+);
+
+ql_ql_def(
+  unique int id: @ql_ql
+);
+
+ql_qualified_rhs_name(
+  unique int ql_qualified_rhs: @ql_qualified_rhs ref,
+  unique int name: @ql_token_predicate_name ref
+);
+
+@ql_qualifiedRhs_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_token_closure | @ql_token_underscore | @ql_type_expr | @ql_unary_expr | @ql_variable
+
+#keyset[ql_qualified_rhs, index]
+ql_qualified_rhs_child(
+  int ql_qualified_rhs: @ql_qualified_rhs ref,
+  int index: int ref,
+  unique int child: @ql_qualifiedRhs_child_type ref
+);
+
+ql_qualified_rhs_def(
+  unique int id: @ql_qualified_rhs
+);
+
+@ql_qualified_expr_child_type = @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_expr_annotation | @ql_literal | @ql_par_expr | @ql_qualified_expr | @ql_qualified_rhs | @ql_range | @ql_set_literal | @ql_super_ref | @ql_variable
+
+#keyset[ql_qualified_expr, index]
+ql_qualified_expr_child(
+  int ql_qualified_expr: @ql_qualified_expr ref,
+  int index: int ref,
+  unique int child: @ql_qualified_expr_child_type ref
+);
+
+ql_qualified_expr_def(
+  unique int id: @ql_qualified_expr
+);
+
+@ql_quantified_expr_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_quantified_expr(
+  unique int ql_quantified: @ql_quantified ref,
+  unique int expr: @ql_quantified_expr_type ref
+);
+
+@ql_quantified_formula_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_quantified_formula(
+  unique int ql_quantified: @ql_quantified ref,
+  unique int formula: @ql_quantified_formula_type ref
+);
+
+@ql_quantified_range_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_quantified_range(
+  unique int ql_quantified: @ql_quantified ref,
+  unique int range: @ql_quantified_range_type ref
+);
+
+@ql_quantified_child_type = @ql_token_quantifier | @ql_var_decl
+
+#keyset[ql_quantified, index]
+ql_quantified_child(
+  int ql_quantified: @ql_quantified ref,
+  int index: int ref,
+  unique int child: @ql_quantified_child_type ref
+);
+
+ql_quantified_def(
+  unique int id: @ql_quantified
+);
+
+@ql_range_lower_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+@ql_range_upper_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_range_def(
+  unique int id: @ql_range,
+  int lower: @ql_range_lower_type ref,
+  int upper: @ql_range_upper_type ref
+);
+
+@ql_select_child_type = @ql_add_expr | @ql_aggregate | @ql_as_exprs | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_order_bys | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_var_decl | @ql_variable
+
+#keyset[ql_select, index]
+ql_select_child(
+  int ql_select: @ql_select ref,
+  int index: int ref,
+  unique int child: @ql_select_child_type ref
+);
+
+ql_select_def(
+  unique int id: @ql_select
+);
+
+@ql_set_literal_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+#keyset[ql_set_literal, index]
+ql_set_literal_child(
+  int ql_set_literal: @ql_set_literal ref,
+  int index: int ref,
+  unique int child: @ql_set_literal_child_type ref
+);
+
+ql_set_literal_def(
+  unique int id: @ql_set_literal
+);
+
+ql_signature_expr_mod_expr(
+  unique int ql_signature_expr: @ql_signature_expr ref,
+  unique int mod_expr: @ql_module_expr ref
+);
+
+ql_signature_expr_predicate(
+  unique int ql_signature_expr: @ql_signature_expr ref,
+  unique int predicate: @ql_predicate_expr ref
+);
+
+ql_signature_expr_type_expr(
+  unique int ql_signature_expr: @ql_signature_expr ref,
+  unique int type_expr: @ql_type_expr ref
+);
+
+ql_signature_expr_def(
+  unique int id: @ql_signature_expr
+);
+
+ql_special_call_def(
+  unique int id: @ql_special_call,
+  int child: @ql_token_special_id ref
+);
+
+@ql_super_ref_child_type = @ql_token_super | @ql_type_expr
+
+#keyset[ql_super_ref, index]
+ql_super_ref_child(
+  int ql_super_ref: @ql_super_ref ref,
+  int index: int ref,
+  unique int child: @ql_super_ref_child_type ref
+);
+
+ql_super_ref_def(
+  unique int id: @ql_super_ref
+);
+
+ql_type_alias_body_def(
+  unique int id: @ql_type_alias_body,
+  int child: @ql_type_expr ref
+);
+
+ql_type_expr_name(
+  unique int ql_type_expr: @ql_type_expr ref,
+  unique int name: @ql_token_class_name ref
+);
+
+ql_type_expr_qualifier(
+  unique int ql_type_expr: @ql_type_expr ref,
+  unique int qualifier: @ql_module_expr ref
+);
+
+@ql_typeExpr_child_type = @ql_token_dbtype | @ql_token_primitive_type
+
+ql_type_expr_child(
+  unique int ql_type_expr: @ql_type_expr ref,
+  unique int child: @ql_typeExpr_child_type ref
+);
+
+ql_type_expr_def(
+  unique int id: @ql_type_expr
+);
+
+#keyset[ql_type_union_body, index]
+ql_type_union_body_child(
+  int ql_type_union_body: @ql_type_union_body ref,
+  int index: int ref,
+  unique int child: @ql_type_expr ref
+);
+
+ql_type_union_body_def(
+  unique int id: @ql_type_union_body
+);
+
+@ql_unary_expr_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_token_unop | @ql_unary_expr | @ql_variable
+
+#keyset[ql_unary_expr, index]
+ql_unary_expr_child(
+  int ql_unary_expr: @ql_unary_expr ref,
+  int index: int ref,
+  unique int child: @ql_unary_expr_child_type ref
+);
+
+ql_unary_expr_def(
+  unique int id: @ql_unary_expr
+);
+
+@ql_unqual_agg_body_asExprs_type = @ql_as_exprs | @ql_reserved_word
+
+#keyset[ql_unqual_agg_body, index]
+ql_unqual_agg_body_as_exprs(
+  int ql_unqual_agg_body: @ql_unqual_agg_body ref,
+  int index: int ref,
+  unique int as_exprs: @ql_unqual_agg_body_asExprs_type ref
+);
+
+@ql_unqual_agg_body_guard_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_unqual_agg_body_guard(
+  unique int ql_unqual_agg_body: @ql_unqual_agg_body ref,
+  unique int guard: @ql_unqual_agg_body_guard_type ref
+);
+
+#keyset[ql_unqual_agg_body, index]
+ql_unqual_agg_body_child(
+  int ql_unqual_agg_body: @ql_unqual_agg_body ref,
+  int index: int ref,
+  unique int child: @ql_var_decl ref
+);
+
+ql_unqual_agg_body_def(
+  unique int id: @ql_unqual_agg_body
+);
+
+@ql_varDecl_child_type = @ql_type_expr | @ql_var_name
+
+#keyset[ql_var_decl, index]
+ql_var_decl_child(
+  int ql_var_decl: @ql_var_decl ref,
+  int index: int ref,
+  unique int child: @ql_varDecl_child_type ref
+);
+
+ql_var_decl_def(
+  unique int id: @ql_var_decl
+);
+
+ql_var_name_def(
+  unique int id: @ql_var_name,
+  int child: @ql_token_simple_id ref
+);
+
+@ql_variable_child_type = @ql_token_result | @ql_token_this | @ql_var_name
+
+ql_variable_def(
+  unique int id: @ql_variable,
+  int child: @ql_variable_child_type ref
+);
+
+ql_tokeninfo(
+  unique int id: @ql_token,
+  int kind: int ref,
+  string value: string ref
+);
+
+case @ql_token.kind of
+  0 = @ql_reserved_word
+| 1 = @ql_token_addop
+| 2 = @ql_token_agg_id
+| 3 = @ql_token_annot_name
+| 4 = @ql_token_block_comment
+| 5 = @ql_token_class_name
+| 6 = @ql_token_closure
+| 7 = @ql_token_compop
+| 8 = @ql_token_dbtype
+| 9 = @ql_token_direction
+| 10 = @ql_token_empty
+| 11 = @ql_token_false
+| 12 = @ql_token_float
+| 13 = @ql_token_integer
+| 14 = @ql_token_line_comment
+| 15 = @ql_token_literal_id
+| 16 = @ql_token_mulop
+| 17 = @ql_token_predicate
+| 18 = @ql_token_predicate_name
+| 19 = @ql_token_primitive_type
+| 20 = @ql_token_qldoc
+| 21 = @ql_token_quantifier
+| 22 = @ql_token_result
+| 23 = @ql_token_simple_id
+| 24 = @ql_token_special_id
+| 25 = @ql_token_string
+| 26 = @ql_token_super
+| 27 = @ql_token_this
+| 28 = @ql_token_true
+| 29 = @ql_token_underscore
+| 30 = @ql_token_unop
+;
+
+
+@ql_ast_node = @ql_add_expr | @ql_aggregate | @ql_annot_arg | @ql_annotation | @ql_arityless_predicate_expr | @ql_as_expr | @ql_as_exprs | @ql_body | @ql_bool | @ql_call_body | @ql_call_or_unqual_agg_expr | @ql_charpred | @ql_class_member | @ql_classless_predicate | @ql_comp_term | @ql_conjunction | @ql_dataclass | @ql_datatype | @ql_datatype_branch | @ql_datatype_branches | @ql_disjunction | @ql_expr_aggregate_body | @ql_expr_annotation | @ql_field | @ql_full_aggregate_body | @ql_higher_order_term | @ql_if_term | @ql_implication | @ql_import_directive | @ql_import_module_expr | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_member_predicate | @ql_module | @ql_module_alias_body | @ql_module_expr | @ql_module_instantiation | @ql_module_member | @ql_module_name | @ql_module_param | @ql_mul_expr | @ql_negation | @ql_order_by | @ql_order_bys | @ql_par_expr | @ql_predicate_alias_body | @ql_predicate_expr | @ql_prefix_cast | @ql_ql | @ql_qualified_expr | @ql_qualified_rhs | @ql_quantified | @ql_range | @ql_select | @ql_set_literal | @ql_signature_expr | @ql_special_call | @ql_super_ref | @ql_token | @ql_type_alias_body | @ql_type_expr | @ql_type_union_body | @ql_unary_expr | @ql_unqual_agg_body | @ql_var_decl | @ql_var_name | @ql_variable
+
+ql_ast_node_location(
+  unique int node: @ql_ast_node ref,
+  int loc: @location_default ref
+);
+
+#keyset[parent, parent_index]
+ql_ast_node_parent(
+  unique int node: @ql_ast_node ref,
+  int parent: @ql_ast_node ref,
+  int parent_index: int ref
+);
+
+/*- Dbscheme dbscheme -*/
+dbscheme_annotation_args_annotation(
+  unique int dbscheme_annotation: @dbscheme_annotation ref,
+  unique int args_annotation: @dbscheme_args_annotation ref
+);
+
+dbscheme_annotation_simple_annotation(
+  unique int dbscheme_annotation: @dbscheme_annotation ref,
+  unique int simple_annotation: @dbscheme_token_annot_name ref
+);
+
+dbscheme_annotation_def(
+  unique int id: @dbscheme_annotation
+);
+
+#keyset[dbscheme_args_annotation, index]
+dbscheme_args_annotation_child(
+  int dbscheme_args_annotation: @dbscheme_args_annotation ref,
+  int index: int ref,
+  unique int child: @dbscheme_token_simple_id ref
+);
+
+dbscheme_args_annotation_def(
+  unique int id: @dbscheme_args_annotation,
+  int name: @dbscheme_token_annot_name ref
+);
+
+dbscheme_branch_qldoc(
+  unique int dbscheme_branch: @dbscheme_branch ref,
+  unique int qldoc: @dbscheme_token_qldoc ref
+);
+
+@dbscheme_branch_child_type = @dbscheme_token_dbtype | @dbscheme_token_integer
+
+#keyset[dbscheme_branch, index]
+dbscheme_branch_child(
+  int dbscheme_branch: @dbscheme_branch ref,
+  int index: int ref,
+  unique int child: @dbscheme_branch_child_type ref
+);
+
+dbscheme_branch_def(
+  unique int id: @dbscheme_branch
+);
+
+#keyset[dbscheme_case_decl, index]
+dbscheme_case_decl_child(
+  int dbscheme_case_decl: @dbscheme_case_decl ref,
+  int index: int ref,
+  unique int child: @dbscheme_branch ref
+);
+
+dbscheme_case_decl_def(
+  unique int id: @dbscheme_case_decl,
+  int base: @dbscheme_token_dbtype ref,
+  int discriminator: @dbscheme_token_simple_id ref
+);
+
+@dbscheme_colType_child_type = @dbscheme_token_boolean | @dbscheme_token_date | @dbscheme_token_dbtype | @dbscheme_token_float | @dbscheme_token_int | @dbscheme_token_string
+
+dbscheme_col_type_def(
+  unique int id: @dbscheme_col_type,
+  int child: @dbscheme_colType_child_type ref
+);
+
+dbscheme_column_is_ref(
+  unique int dbscheme_column: @dbscheme_column ref,
+  unique int is_ref: @dbscheme_token_ref ref
+);
+
+dbscheme_column_is_unique(
+  unique int dbscheme_column: @dbscheme_column ref,
+  unique int is_unique: @dbscheme_token_unique ref
+);
+
+dbscheme_column_qldoc(
+  unique int dbscheme_column: @dbscheme_column ref,
+  unique int qldoc: @dbscheme_token_qldoc ref
+);
+
+dbscheme_column_def(
+  unique int id: @dbscheme_column,
+  int col_name: @dbscheme_token_simple_id ref,
+  int col_type: @dbscheme_col_type ref,
+  int repr_type: @dbscheme_repr_type ref
+);
+
+#keyset[dbscheme_dbscheme, index]
+dbscheme_dbscheme_child(
+  int dbscheme_dbscheme: @dbscheme_dbscheme ref,
+  int index: int ref,
+  unique int child: @dbscheme_entry ref
+);
+
+dbscheme_dbscheme_def(
+  unique int id: @dbscheme_dbscheme
+);
+
+@dbscheme_entry_child_type = @dbscheme_case_decl | @dbscheme_table | @dbscheme_token_qldoc | @dbscheme_union_decl
+
+dbscheme_entry_def(
+  unique int id: @dbscheme_entry,
+  int child: @dbscheme_entry_child_type ref
+);
+
+@dbscheme_reprType_child_type = @dbscheme_token_boolean | @dbscheme_token_date | @dbscheme_token_float | @dbscheme_token_int | @dbscheme_token_integer | @dbscheme_token_string | @dbscheme_token_varchar
+
+#keyset[dbscheme_repr_type, index]
+dbscheme_repr_type_child(
+  int dbscheme_repr_type: @dbscheme_repr_type ref,
+  int index: int ref,
+  unique int child: @dbscheme_reprType_child_type ref
+);
+
+dbscheme_repr_type_def(
+  unique int id: @dbscheme_repr_type
+);
+
+@dbscheme_table_child_type = @dbscheme_annotation | @dbscheme_column
+
+#keyset[dbscheme_table, index]
+dbscheme_table_child(
+  int dbscheme_table: @dbscheme_table ref,
+  int index: int ref,
+  unique int child: @dbscheme_table_child_type ref
+);
+
+dbscheme_table_def(
+  unique int id: @dbscheme_table,
+  int table_name: @dbscheme_table_name ref
+);
+
+dbscheme_table_name_def(
+  unique int id: @dbscheme_table_name,
+  int child: @dbscheme_token_simple_id ref
+);
+
+#keyset[dbscheme_union_decl, index]
+dbscheme_union_decl_child(
+  int dbscheme_union_decl: @dbscheme_union_decl ref,
+  int index: int ref,
+  unique int child: @dbscheme_token_dbtype ref
+);
+
+dbscheme_union_decl_def(
+  unique int id: @dbscheme_union_decl,
+  int base: @dbscheme_token_dbtype ref
+);
+
+dbscheme_tokeninfo(
+  unique int id: @dbscheme_token,
+  int kind: int ref,
+  string value: string ref
+);
+
+case @dbscheme_token.kind of
+  0 = @dbscheme_reserved_word
+| 1 = @dbscheme_token_annot_name
+| 2 = @dbscheme_token_block_comment
+| 3 = @dbscheme_token_boolean
+| 4 = @dbscheme_token_date
+| 5 = @dbscheme_token_dbtype
+| 6 = @dbscheme_token_float
+| 7 = @dbscheme_token_int
+| 8 = @dbscheme_token_integer
+| 9 = @dbscheme_token_line_comment
+| 10 = @dbscheme_token_qldoc
+| 11 = @dbscheme_token_ref
+| 12 = @dbscheme_token_simple_id
+| 13 = @dbscheme_token_string
+| 14 = @dbscheme_token_unique
+| 15 = @dbscheme_token_varchar
+;
+
+
+@dbscheme_ast_node = @dbscheme_annotation | @dbscheme_args_annotation | @dbscheme_branch | @dbscheme_case_decl | @dbscheme_col_type | @dbscheme_column | @dbscheme_dbscheme | @dbscheme_entry | @dbscheme_repr_type | @dbscheme_table | @dbscheme_table_name | @dbscheme_token | @dbscheme_union_decl
+
+dbscheme_ast_node_location(
+  unique int node: @dbscheme_ast_node ref,
+  int loc: @location_default ref
+);
+
+#keyset[parent, parent_index]
+dbscheme_ast_node_parent(
+  unique int node: @dbscheme_ast_node ref,
+  int parent: @dbscheme_ast_node ref,
+  int parent_index: int ref
+);
+
+/*- Blame dbscheme -*/
+#keyset[blame_blame_entry, index]
+blame_blame_entry_line(
+  int blame_blame_entry: @blame_blame_entry ref,
+  int index: int ref,
+  unique int line: @blame_token_number ref
+);
+
+blame_blame_entry_def(
+  unique int id: @blame_blame_entry,
+  int date__: @blame_token_date ref
+);
+
+#keyset[blame_blame_info, index]
+blame_blame_info_file_entry(
+  int blame_blame_info: @blame_blame_info ref,
+  int index: int ref,
+  unique int file_entry: @blame_file_entry ref
+);
+
+blame_blame_info_def(
+  unique int id: @blame_blame_info,
+  int today: @blame_token_date ref
+);
+
+#keyset[blame_file_entry, index]
+blame_file_entry_blame_entry(
+  int blame_file_entry: @blame_file_entry ref,
+  int index: int ref,
+  unique int blame_entry: @blame_blame_entry ref
+);
+
+blame_file_entry_def(
+  unique int id: @blame_file_entry,
+  int file_name: @blame_token_filename ref
+);
+
+blame_tokeninfo(
+  unique int id: @blame_token,
+  int kind: int ref,
+  string value: string ref
+);
+
+case @blame_token.kind of
+  0 = @blame_reserved_word
+| 1 = @blame_token_date
+| 2 = @blame_token_filename
+| 3 = @blame_token_number
+;
+
+
+@blame_ast_node = @blame_blame_entry | @blame_blame_info | @blame_file_entry | @blame_token
+
+blame_ast_node_location(
+  unique int node: @blame_ast_node ref,
+  int loc: @location_default ref
+);
+
+#keyset[parent, parent_index]
+blame_ast_node_parent(
+  unique int node: @blame_ast_node ref,
+  int parent: @blame_ast_node ref,
+  int parent_index: int ref
+);
+
+/*- JSON dbscheme -*/
+@json_underscore_value = @json_array | @json_object | @json_string__ | @json_token_false | @json_token_null | @json_token_number | @json_token_true
+
+#keyset[json_array, index]
+json_array_child(
+  int json_array: @json_array ref,
+  int index: int ref,
+  unique int child: @json_underscore_value ref
+);
+
+json_array_def(
+  unique int id: @json_array
+);
+
+#keyset[json_document, index]
+json_document_child(
+  int json_document: @json_document ref,
+  int index: int ref,
+  unique int child: @json_underscore_value ref
+);
+
+json_document_def(
+  unique int id: @json_document
+);
+
+#keyset[json_object, index]
+json_object_child(
+  int json_object: @json_object ref,
+  int index: int ref,
+  unique int child: @json_pair ref
+);
+
+json_object_def(
+  unique int id: @json_object
+);
+
+json_pair_def(
+  unique int id: @json_pair,
+  int key__: @json_string__ ref,
+  int value: @json_underscore_value ref
+);
+
+@json_string_child_type = @json_token_escape_sequence | @json_token_string_content
+
+#keyset[json_string__, index]
+json_string_child(
+  int json_string__: @json_string__ ref,
+  int index: int ref,
+  unique int child: @json_string_child_type ref
+);
+
+json_string_def(
+  unique int id: @json_string__
+);
+
+json_tokeninfo(
+  unique int id: @json_token,
+  int kind: int ref,
+  string value: string ref
+);
+
+case @json_token.kind of
+  0 = @json_reserved_word
+| 1 = @json_token_comment
+| 2 = @json_token_escape_sequence
+| 3 = @json_token_false
+| 4 = @json_token_null
+| 5 = @json_token_number
+| 6 = @json_token_string_content
+| 7 = @json_token_true
+;
+
+
+@json_ast_node = @json_array | @json_document | @json_object | @json_pair | @json_string__ | @json_token
+
+json_ast_node_location(
+  unique int node: @json_ast_node ref,
+  int loc: @location_default ref
+);
+
+#keyset[parent, parent_index]
+json_ast_node_parent(
+  unique int node: @json_ast_node ref,
+  int parent: @json_ast_node ref,
+  int parent_index: int ref
+);
+

--- a/ql/downgrades/87c1125b41a68de7353f538cd7fb73bd0f18bfe0/upgrade.properties
+++ b/ql/downgrades/87c1125b41a68de7353f538cd7fb73bd0f18bfe0/upgrade.properties
@@ -1,0 +1,3 @@
+description: Extract YAML comments
+compatibility: full
+yaml_comments.rel: delete

--- a/ql/ql/lib/upgrades/c50cdd7429a4598cd95f75c82b4ba453007159d9/old.dbscheme
+++ b/ql/ql/lib/upgrades/c50cdd7429a4598cd95f75c82b4ba453007159d9/old.dbscheme
@@ -1,0 +1,1360 @@
+// CodeQL database schema for QL
+// Automatically generated from the tree-sitter grammar; do not edit
+// To regenerate, run 'scripts/create-extractor-pack.sh' in ql/
+
+/*- Files and folders -*/
+
+/**
+ * The location of an element.
+ * The location spans column `startcolumn` of line `startline` to
+ * column `endcolumn` of line `endline` in file `file`.
+ * For more information, see
+ * [Locations](https://codeql.github.com/docs/writing-codeql-queries/providing-locations-in-codeql-queries/).
+ */
+locations_default(
+  unique int id: @location_default,
+  int file: @file ref,
+  int beginLine: int ref,
+  int beginColumn: int ref,
+  int endLine: int ref,
+  int endColumn: int ref
+);
+
+files(
+  unique int id: @file,
+  string name: string ref
+);
+
+folders(
+  unique int id: @folder,
+  string name: string ref
+);
+
+@container = @file | @folder
+
+containerparent(
+  int parent: @container ref,
+  unique int child: @container ref
+);
+
+/*- Empty location -*/
+
+empty_location(
+  int location: @location_default ref
+);
+
+/*- Source location prefix -*/
+
+/**
+ * The source location of the snapshot.
+ */
+sourceLocationPrefix(string prefix : string ref);
+
+/*- Diagnostic messages -*/
+
+diagnostics(
+  unique int id: @diagnostic,
+  int severity: int ref,
+  string error_tag: string ref,
+  string error_message: string ref,
+  string full_error_message: string ref,
+  int location: @location_default ref
+);
+
+/*- Diagnostic messages: severity -*/
+
+case @diagnostic.severity of
+  10 = @diagnostic_debug
+| 20 = @diagnostic_info
+| 30 = @diagnostic_warning
+| 40 = @diagnostic_error
+;
+
+/*- YAML -*/
+
+#keyset[parent, idx]
+yaml (unique int id: @yaml_node,
+      int kind: int ref,
+      int parent: @yaml_node_parent ref,
+      int idx: int ref,
+      string tag: string ref,
+      string tostring: string ref);
+
+case @yaml_node.kind of
+  0 = @yaml_scalar_node
+| 1 = @yaml_mapping_node
+| 2 = @yaml_sequence_node
+| 3 = @yaml_alias_node
+;
+
+@yaml_collection_node = @yaml_mapping_node | @yaml_sequence_node;
+
+@yaml_node_parent = @yaml_collection_node | @file;
+
+yaml_anchors (unique int node: @yaml_node ref,
+              string anchor: string ref);
+
+yaml_aliases (unique int alias: @yaml_alias_node ref,
+              string target: string ref);
+
+yaml_scalars (unique int scalar: @yaml_scalar_node ref,
+              int style: int ref,
+              string value: string ref);
+
+yaml_comments (unique int id: @yaml_comment,
+               string text: string ref,
+               string tostring: string ref);
+
+yaml_errors (unique int id: @yaml_error,
+             string message: string ref);
+
+yaml_locations(unique int locatable: @yaml_locatable ref,
+             int location: @location_default ref);
+
+@yaml_locatable = @yaml_node | @yaml_error | @yaml_comment;
+
+/*- Database metadata -*/
+
+/**
+ * The CLI will automatically emit applicable tuples for this table,
+ * such as `databaseMetadata("isOverlay", "true")` when building an
+ * overlay database.
+ */
+databaseMetadata(
+  string metadataKey: string ref,
+  string value: string ref
+);
+
+/*- Overlay support -*/
+
+/**
+ * The CLI will automatically emit tuples for each new/modified/deleted file
+ * when building an overlay database.
+ */
+overlayChangedFiles(
+  string path: string ref
+);
+
+/*- QL dbscheme -*/
+@ql_add_expr_left_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+@ql_add_expr_right_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_add_expr_def(
+  unique int id: @ql_add_expr,
+  int left: @ql_add_expr_left_type ref,
+  int right: @ql_add_expr_right_type ref,
+  int child: @ql_token_addop ref
+);
+
+@ql_aggregate_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_aggregate_body | @ql_expr_annotation | @ql_full_aggregate_body | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_token_agg_id | @ql_unary_expr | @ql_variable
+
+#keyset[ql_aggregate, index]
+ql_aggregate_child(
+  int ql_aggregate: @ql_aggregate ref,
+  int index: int ref,
+  unique int child: @ql_aggregate_child_type ref
+);
+
+ql_aggregate_def(
+  unique int id: @ql_aggregate
+);
+
+@ql_annotArg_child_type = @ql_token_result | @ql_token_simple_id | @ql_token_this
+
+ql_annot_arg_def(
+  unique int id: @ql_annot_arg,
+  int child: @ql_annotArg_child_type ref
+);
+
+@ql_annotation_args_type = @ql_annot_arg | @ql_reserved_word
+
+#keyset[ql_annotation, index]
+ql_annotation_args(
+  int ql_annotation: @ql_annotation ref,
+  int index: int ref,
+  unique int args: @ql_annotation_args_type ref
+);
+
+ql_annotation_def(
+  unique int id: @ql_annotation,
+  int name: @ql_token_annot_name ref
+);
+
+ql_arityless_predicate_expr_qualifier(
+  unique int ql_arityless_predicate_expr: @ql_arityless_predicate_expr ref,
+  unique int qualifier: @ql_module_expr ref
+);
+
+ql_arityless_predicate_expr_def(
+  unique int id: @ql_arityless_predicate_expr,
+  int name: @ql_token_literal_id ref
+);
+
+@ql_asExpr_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_var_name | @ql_variable
+
+#keyset[ql_as_expr, index]
+ql_as_expr_child(
+  int ql_as_expr: @ql_as_expr ref,
+  int index: int ref,
+  unique int child: @ql_asExpr_child_type ref
+);
+
+ql_as_expr_def(
+  unique int id: @ql_as_expr
+);
+
+#keyset[ql_as_exprs, index]
+ql_as_exprs_child(
+  int ql_as_exprs: @ql_as_exprs ref,
+  int index: int ref,
+  unique int child: @ql_as_expr ref
+);
+
+ql_as_exprs_def(
+  unique int id: @ql_as_exprs
+);
+
+@ql_body_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_body_def(
+  unique int id: @ql_body,
+  int child: @ql_body_child_type ref
+);
+
+@ql_bool_child_type = @ql_token_false | @ql_token_true
+
+ql_bool_def(
+  unique int id: @ql_bool,
+  int child: @ql_bool_child_type ref
+);
+
+@ql_call_body_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_token_underscore | @ql_unary_expr | @ql_variable
+
+#keyset[ql_call_body, index]
+ql_call_body_child(
+  int ql_call_body: @ql_call_body ref,
+  int index: int ref,
+  unique int child: @ql_call_body_child_type ref
+);
+
+ql_call_body_def(
+  unique int id: @ql_call_body
+);
+
+@ql_call_or_unqual_agg_expr_child_type = @ql_arityless_predicate_expr | @ql_call_body | @ql_token_closure | @ql_unqual_agg_body
+
+#keyset[ql_call_or_unqual_agg_expr, index]
+ql_call_or_unqual_agg_expr_child(
+  int ql_call_or_unqual_agg_expr: @ql_call_or_unqual_agg_expr ref,
+  int index: int ref,
+  unique int child: @ql_call_or_unqual_agg_expr_child_type ref
+);
+
+ql_call_or_unqual_agg_expr_def(
+  unique int id: @ql_call_or_unqual_agg_expr
+);
+
+@ql_charpred_body_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_charpred_def(
+  unique int id: @ql_charpred,
+  int body: @ql_charpred_body_type ref,
+  int child: @ql_token_class_name ref
+);
+
+@ql_classMember_child_type = @ql_annotation | @ql_charpred | @ql_field | @ql_member_predicate | @ql_token_qldoc
+
+#keyset[ql_class_member, index]
+ql_class_member_child(
+  int ql_class_member: @ql_class_member ref,
+  int index: int ref,
+  unique int child: @ql_classMember_child_type ref
+);
+
+ql_class_member_def(
+  unique int id: @ql_class_member
+);
+
+@ql_classlessPredicate_returnType_type = @ql_token_predicate | @ql_type_expr
+
+@ql_classlessPredicate_child_type = @ql_body | @ql_higher_order_term | @ql_predicate_alias_body | @ql_token_empty | @ql_var_decl
+
+#keyset[ql_classless_predicate, index]
+ql_classless_predicate_child(
+  int ql_classless_predicate: @ql_classless_predicate ref,
+  int index: int ref,
+  unique int child: @ql_classlessPredicate_child_type ref
+);
+
+ql_classless_predicate_def(
+  unique int id: @ql_classless_predicate,
+  int name: @ql_token_predicate_name ref,
+  int return_type: @ql_classlessPredicate_returnType_type ref
+);
+
+@ql_comp_term_left_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+@ql_comp_term_right_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_comp_term_def(
+  unique int id: @ql_comp_term,
+  int left: @ql_comp_term_left_type ref,
+  int right: @ql_comp_term_right_type ref,
+  int child: @ql_token_compop ref
+);
+
+@ql_conjunction_left_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+@ql_conjunction_right_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_conjunction_def(
+  unique int id: @ql_conjunction,
+  int left: @ql_conjunction_left_type ref,
+  int right: @ql_conjunction_right_type ref
+);
+
+@ql_dataclass_extends_type = @ql_reserved_word | @ql_type_expr
+
+#keyset[ql_dataclass, index]
+ql_dataclass_extends(
+  int ql_dataclass: @ql_dataclass ref,
+  int index: int ref,
+  unique int extends: @ql_dataclass_extends_type ref
+);
+
+@ql_dataclass_instanceof_type = @ql_reserved_word | @ql_type_expr
+
+#keyset[ql_dataclass, index]
+ql_dataclass_instanceof(
+  int ql_dataclass: @ql_dataclass ref,
+  int index: int ref,
+  unique int instanceof: @ql_dataclass_instanceof_type ref
+);
+
+@ql_dataclass_child_type = @ql_class_member | @ql_type_alias_body | @ql_type_union_body
+
+#keyset[ql_dataclass, index]
+ql_dataclass_child(
+  int ql_dataclass: @ql_dataclass ref,
+  int index: int ref,
+  unique int child: @ql_dataclass_child_type ref
+);
+
+ql_dataclass_def(
+  unique int id: @ql_dataclass,
+  int name: @ql_token_class_name ref
+);
+
+ql_datatype_def(
+  unique int id: @ql_datatype,
+  int name: @ql_token_class_name ref,
+  int child: @ql_datatype_branches ref
+);
+
+@ql_datatypeBranch_child_type = @ql_annotation | @ql_body | @ql_token_qldoc | @ql_var_decl
+
+#keyset[ql_datatype_branch, index]
+ql_datatype_branch_child(
+  int ql_datatype_branch: @ql_datatype_branch ref,
+  int index: int ref,
+  unique int child: @ql_datatypeBranch_child_type ref
+);
+
+ql_datatype_branch_def(
+  unique int id: @ql_datatype_branch,
+  int name: @ql_token_class_name ref
+);
+
+#keyset[ql_datatype_branches, index]
+ql_datatype_branches_child(
+  int ql_datatype_branches: @ql_datatype_branches ref,
+  int index: int ref,
+  unique int child: @ql_datatype_branch ref
+);
+
+ql_datatype_branches_def(
+  unique int id: @ql_datatype_branches
+);
+
+@ql_disjunction_left_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+@ql_disjunction_right_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_disjunction_def(
+  unique int id: @ql_disjunction,
+  int left: @ql_disjunction_left_type ref,
+  int right: @ql_disjunction_right_type ref
+);
+
+ql_expr_aggregate_body_order_bys(
+  unique int ql_expr_aggregate_body: @ql_expr_aggregate_body ref,
+  unique int order_bys: @ql_order_bys ref
+);
+
+ql_expr_aggregate_body_def(
+  unique int id: @ql_expr_aggregate_body,
+  int as_exprs: @ql_as_exprs ref
+);
+
+@ql_expr_annotation_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_expr_annotation_def(
+  unique int id: @ql_expr_annotation,
+  int annot_arg: @ql_token_annot_name ref,
+  int name: @ql_token_annot_name ref,
+  int child: @ql_expr_annotation_child_type ref
+);
+
+ql_field_def(
+  unique int id: @ql_field,
+  int child: @ql_var_decl ref
+);
+
+ql_full_aggregate_body_as_exprs(
+  unique int ql_full_aggregate_body: @ql_full_aggregate_body ref,
+  unique int as_exprs: @ql_as_exprs ref
+);
+
+@ql_full_aggregate_body_guard_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_full_aggregate_body_guard(
+  unique int ql_full_aggregate_body: @ql_full_aggregate_body ref,
+  unique int guard: @ql_full_aggregate_body_guard_type ref
+);
+
+ql_full_aggregate_body_order_bys(
+  unique int ql_full_aggregate_body: @ql_full_aggregate_body ref,
+  unique int order_bys: @ql_order_bys ref
+);
+
+#keyset[ql_full_aggregate_body, index]
+ql_full_aggregate_body_child(
+  int ql_full_aggregate_body: @ql_full_aggregate_body ref,
+  int index: int ref,
+  unique int child: @ql_var_decl ref
+);
+
+ql_full_aggregate_body_def(
+  unique int id: @ql_full_aggregate_body
+);
+
+@ql_higherOrderTerm_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_predicate_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_token_underscore | @ql_unary_expr | @ql_variable
+
+#keyset[ql_higher_order_term, index]
+ql_higher_order_term_child(
+  int ql_higher_order_term: @ql_higher_order_term ref,
+  int index: int ref,
+  unique int child: @ql_higherOrderTerm_child_type ref
+);
+
+ql_higher_order_term_def(
+  unique int id: @ql_higher_order_term,
+  int name: @ql_token_literal_id ref
+);
+
+@ql_if_term_cond_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+@ql_if_term_first_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+@ql_if_term_second_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_if_term_def(
+  unique int id: @ql_if_term,
+  int cond: @ql_if_term_cond_type ref,
+  int first: @ql_if_term_first_type ref,
+  int second: @ql_if_term_second_type ref
+);
+
+@ql_implication_left_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+@ql_implication_right_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_implication_def(
+  unique int id: @ql_implication,
+  int left: @ql_implication_left_type ref,
+  int right: @ql_implication_right_type ref
+);
+
+@ql_importDirective_child_type = @ql_import_module_expr | @ql_module_name
+
+#keyset[ql_import_directive, index]
+ql_import_directive_child(
+  int ql_import_directive: @ql_import_directive ref,
+  int index: int ref,
+  unique int child: @ql_importDirective_child_type ref
+);
+
+ql_import_directive_def(
+  unique int id: @ql_import_directive
+);
+
+#keyset[ql_import_module_expr, index]
+ql_import_module_expr_qual_name(
+  int ql_import_module_expr: @ql_import_module_expr ref,
+  int index: int ref,
+  unique int qual_name: @ql_token_simple_id ref
+);
+
+ql_import_module_expr_def(
+  unique int id: @ql_import_module_expr,
+  int child: @ql_module_expr ref
+);
+
+@ql_in_expr_left_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+@ql_in_expr_right_type = @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_expr_annotation | @ql_literal | @ql_par_expr | @ql_qualified_expr | @ql_range | @ql_set_literal | @ql_super_ref | @ql_variable
+
+ql_in_expr_def(
+  unique int id: @ql_in_expr,
+  int left: @ql_in_expr_left_type ref,
+  int right: @ql_in_expr_right_type ref
+);
+
+@ql_instance_of_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_type_expr | @ql_unary_expr | @ql_variable
+
+#keyset[ql_instance_of, index]
+ql_instance_of_child(
+  int ql_instance_of: @ql_instance_of ref,
+  int index: int ref,
+  unique int child: @ql_instance_of_child_type ref
+);
+
+ql_instance_of_def(
+  unique int id: @ql_instance_of
+);
+
+@ql_literal_child_type = @ql_bool | @ql_token_float | @ql_token_integer | @ql_token_string
+
+ql_literal_def(
+  unique int id: @ql_literal,
+  int child: @ql_literal_child_type ref
+);
+
+@ql_memberPredicate_returnType_type = @ql_token_predicate | @ql_type_expr
+
+@ql_memberPredicate_child_type = @ql_body | @ql_higher_order_term | @ql_token_empty | @ql_var_decl
+
+#keyset[ql_member_predicate, index]
+ql_member_predicate_child(
+  int ql_member_predicate: @ql_member_predicate ref,
+  int index: int ref,
+  unique int child: @ql_memberPredicate_child_type ref
+);
+
+ql_member_predicate_def(
+  unique int id: @ql_member_predicate,
+  int name: @ql_token_predicate_name ref,
+  int return_type: @ql_memberPredicate_returnType_type ref
+);
+
+#keyset[ql_module, index]
+ql_module_implements(
+  int ql_module: @ql_module ref,
+  int index: int ref,
+  unique int implements: @ql_signature_expr ref
+);
+
+#keyset[ql_module, index]
+ql_module_parameter(
+  int ql_module: @ql_module ref,
+  int index: int ref,
+  unique int parameter: @ql_module_param ref
+);
+
+@ql_module_child_type = @ql_module_alias_body | @ql_module_member
+
+#keyset[ql_module, index]
+ql_module_child(
+  int ql_module: @ql_module ref,
+  int index: int ref,
+  unique int child: @ql_module_child_type ref
+);
+
+ql_module_def(
+  unique int id: @ql_module,
+  int name: @ql_module_name ref
+);
+
+ql_module_alias_body_def(
+  unique int id: @ql_module_alias_body,
+  int child: @ql_module_expr ref
+);
+
+@ql_moduleExpr_name_type = @ql_module_instantiation | @ql_token_simple_id
+
+ql_module_expr_name(
+  unique int ql_module_expr: @ql_module_expr ref,
+  unique int name: @ql_moduleExpr_name_type ref
+);
+
+@ql_moduleExpr_child_type = @ql_module_expr | @ql_module_instantiation | @ql_token_simple_id
+
+ql_module_expr_def(
+  unique int id: @ql_module_expr,
+  int child: @ql_moduleExpr_child_type ref
+);
+
+#keyset[ql_module_instantiation, index]
+ql_module_instantiation_child(
+  int ql_module_instantiation: @ql_module_instantiation ref,
+  int index: int ref,
+  unique int child: @ql_signature_expr ref
+);
+
+ql_module_instantiation_def(
+  unique int id: @ql_module_instantiation,
+  int name: @ql_module_name ref
+);
+
+@ql_moduleMember_child_type = @ql_annotation | @ql_classless_predicate | @ql_dataclass | @ql_datatype | @ql_import_directive | @ql_module | @ql_select | @ql_token_qldoc
+
+#keyset[ql_module_member, index]
+ql_module_member_child(
+  int ql_module_member: @ql_module_member ref,
+  int index: int ref,
+  unique int child: @ql_moduleMember_child_type ref
+);
+
+ql_module_member_def(
+  unique int id: @ql_module_member
+);
+
+ql_module_name_def(
+  unique int id: @ql_module_name,
+  int child: @ql_token_simple_id ref
+);
+
+ql_module_param_def(
+  unique int id: @ql_module_param,
+  int parameter: @ql_token_simple_id ref,
+  int signature: @ql_signature_expr ref
+);
+
+@ql_mul_expr_left_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+@ql_mul_expr_right_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_mul_expr_def(
+  unique int id: @ql_mul_expr,
+  int left: @ql_mul_expr_left_type ref,
+  int right: @ql_mul_expr_right_type ref,
+  int child: @ql_token_mulop ref
+);
+
+@ql_negation_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_negation_def(
+  unique int id: @ql_negation,
+  int child: @ql_negation_child_type ref
+);
+
+@ql_orderBy_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_token_direction | @ql_unary_expr | @ql_variable
+
+#keyset[ql_order_by, index]
+ql_order_by_child(
+  int ql_order_by: @ql_order_by ref,
+  int index: int ref,
+  unique int child: @ql_orderBy_child_type ref
+);
+
+ql_order_by_def(
+  unique int id: @ql_order_by
+);
+
+#keyset[ql_order_bys, index]
+ql_order_bys_child(
+  int ql_order_bys: @ql_order_bys ref,
+  int index: int ref,
+  unique int child: @ql_order_by ref
+);
+
+ql_order_bys_def(
+  unique int id: @ql_order_bys
+);
+
+@ql_par_expr_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_par_expr_def(
+  unique int id: @ql_par_expr,
+  int child: @ql_par_expr_child_type ref
+);
+
+ql_predicate_alias_body_def(
+  unique int id: @ql_predicate_alias_body,
+  int child: @ql_predicate_expr ref
+);
+
+@ql_predicateExpr_child_type = @ql_arityless_predicate_expr | @ql_token_integer
+
+#keyset[ql_predicate_expr, index]
+ql_predicate_expr_child(
+  int ql_predicate_expr: @ql_predicate_expr ref,
+  int index: int ref,
+  unique int child: @ql_predicateExpr_child_type ref
+);
+
+ql_predicate_expr_def(
+  unique int id: @ql_predicate_expr
+);
+
+@ql_prefix_cast_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_type_expr | @ql_unary_expr | @ql_variable
+
+#keyset[ql_prefix_cast, index]
+ql_prefix_cast_child(
+  int ql_prefix_cast: @ql_prefix_cast ref,
+  int index: int ref,
+  unique int child: @ql_prefix_cast_child_type ref
+);
+
+ql_prefix_cast_def(
+  unique int id: @ql_prefix_cast
+);
+
+#keyset[ql_ql, index]
+ql_ql_child(
+  int ql_ql: @ql_ql ref,
+  int index: int ref,
+  unique int child: @ql_module_member ref
+);
+
+ql_ql_def(
+  unique int id: @ql_ql
+);
+
+ql_qualified_rhs_name(
+  unique int ql_qualified_rhs: @ql_qualified_rhs ref,
+  unique int name: @ql_token_predicate_name ref
+);
+
+@ql_qualifiedRhs_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_token_closure | @ql_token_underscore | @ql_type_expr | @ql_unary_expr | @ql_variable
+
+#keyset[ql_qualified_rhs, index]
+ql_qualified_rhs_child(
+  int ql_qualified_rhs: @ql_qualified_rhs ref,
+  int index: int ref,
+  unique int child: @ql_qualifiedRhs_child_type ref
+);
+
+ql_qualified_rhs_def(
+  unique int id: @ql_qualified_rhs
+);
+
+@ql_qualified_expr_child_type = @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_expr_annotation | @ql_literal | @ql_par_expr | @ql_qualified_expr | @ql_qualified_rhs | @ql_range | @ql_set_literal | @ql_super_ref | @ql_variable
+
+#keyset[ql_qualified_expr, index]
+ql_qualified_expr_child(
+  int ql_qualified_expr: @ql_qualified_expr ref,
+  int index: int ref,
+  unique int child: @ql_qualified_expr_child_type ref
+);
+
+ql_qualified_expr_def(
+  unique int id: @ql_qualified_expr
+);
+
+@ql_quantified_expr_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_quantified_expr(
+  unique int ql_quantified: @ql_quantified ref,
+  unique int expr: @ql_quantified_expr_type ref
+);
+
+@ql_quantified_formula_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_quantified_formula(
+  unique int ql_quantified: @ql_quantified ref,
+  unique int formula: @ql_quantified_formula_type ref
+);
+
+@ql_quantified_range_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_quantified_range(
+  unique int ql_quantified: @ql_quantified ref,
+  unique int range: @ql_quantified_range_type ref
+);
+
+@ql_quantified_child_type = @ql_token_quantifier | @ql_var_decl
+
+#keyset[ql_quantified, index]
+ql_quantified_child(
+  int ql_quantified: @ql_quantified ref,
+  int index: int ref,
+  unique int child: @ql_quantified_child_type ref
+);
+
+ql_quantified_def(
+  unique int id: @ql_quantified
+);
+
+@ql_range_lower_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+@ql_range_upper_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_range_def(
+  unique int id: @ql_range,
+  int lower: @ql_range_lower_type ref,
+  int upper: @ql_range_upper_type ref
+);
+
+@ql_select_child_type = @ql_add_expr | @ql_aggregate | @ql_as_exprs | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_order_bys | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_var_decl | @ql_variable
+
+#keyset[ql_select, index]
+ql_select_child(
+  int ql_select: @ql_select ref,
+  int index: int ref,
+  unique int child: @ql_select_child_type ref
+);
+
+ql_select_def(
+  unique int id: @ql_select
+);
+
+@ql_set_literal_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+#keyset[ql_set_literal, index]
+ql_set_literal_child(
+  int ql_set_literal: @ql_set_literal ref,
+  int index: int ref,
+  unique int child: @ql_set_literal_child_type ref
+);
+
+ql_set_literal_def(
+  unique int id: @ql_set_literal
+);
+
+ql_signature_expr_mod_expr(
+  unique int ql_signature_expr: @ql_signature_expr ref,
+  unique int mod_expr: @ql_module_expr ref
+);
+
+ql_signature_expr_predicate(
+  unique int ql_signature_expr: @ql_signature_expr ref,
+  unique int predicate: @ql_predicate_expr ref
+);
+
+ql_signature_expr_type_expr(
+  unique int ql_signature_expr: @ql_signature_expr ref,
+  unique int type_expr: @ql_type_expr ref
+);
+
+ql_signature_expr_def(
+  unique int id: @ql_signature_expr
+);
+
+ql_special_call_def(
+  unique int id: @ql_special_call,
+  int child: @ql_token_special_id ref
+);
+
+@ql_super_ref_child_type = @ql_token_super | @ql_type_expr
+
+#keyset[ql_super_ref, index]
+ql_super_ref_child(
+  int ql_super_ref: @ql_super_ref ref,
+  int index: int ref,
+  unique int child: @ql_super_ref_child_type ref
+);
+
+ql_super_ref_def(
+  unique int id: @ql_super_ref
+);
+
+ql_type_alias_body_def(
+  unique int id: @ql_type_alias_body,
+  int child: @ql_type_expr ref
+);
+
+ql_type_expr_name(
+  unique int ql_type_expr: @ql_type_expr ref,
+  unique int name: @ql_token_class_name ref
+);
+
+ql_type_expr_qualifier(
+  unique int ql_type_expr: @ql_type_expr ref,
+  unique int qualifier: @ql_module_expr ref
+);
+
+@ql_typeExpr_child_type = @ql_token_dbtype | @ql_token_primitive_type
+
+ql_type_expr_child(
+  unique int ql_type_expr: @ql_type_expr ref,
+  unique int child: @ql_typeExpr_child_type ref
+);
+
+ql_type_expr_def(
+  unique int id: @ql_type_expr
+);
+
+#keyset[ql_type_union_body, index]
+ql_type_union_body_child(
+  int ql_type_union_body: @ql_type_union_body ref,
+  int index: int ref,
+  unique int child: @ql_type_expr ref
+);
+
+ql_type_union_body_def(
+  unique int id: @ql_type_union_body
+);
+
+@ql_unary_expr_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_token_unop | @ql_unary_expr | @ql_variable
+
+#keyset[ql_unary_expr, index]
+ql_unary_expr_child(
+  int ql_unary_expr: @ql_unary_expr ref,
+  int index: int ref,
+  unique int child: @ql_unary_expr_child_type ref
+);
+
+ql_unary_expr_def(
+  unique int id: @ql_unary_expr
+);
+
+@ql_unqual_agg_body_asExprs_type = @ql_as_exprs | @ql_reserved_word
+
+#keyset[ql_unqual_agg_body, index]
+ql_unqual_agg_body_as_exprs(
+  int ql_unqual_agg_body: @ql_unqual_agg_body ref,
+  int index: int ref,
+  unique int as_exprs: @ql_unqual_agg_body_asExprs_type ref
+);
+
+@ql_unqual_agg_body_guard_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_unqual_agg_body_guard(
+  unique int ql_unqual_agg_body: @ql_unqual_agg_body ref,
+  unique int guard: @ql_unqual_agg_body_guard_type ref
+);
+
+#keyset[ql_unqual_agg_body, index]
+ql_unqual_agg_body_child(
+  int ql_unqual_agg_body: @ql_unqual_agg_body ref,
+  int index: int ref,
+  unique int child: @ql_var_decl ref
+);
+
+ql_unqual_agg_body_def(
+  unique int id: @ql_unqual_agg_body
+);
+
+@ql_varDecl_child_type = @ql_type_expr | @ql_var_name
+
+#keyset[ql_var_decl, index]
+ql_var_decl_child(
+  int ql_var_decl: @ql_var_decl ref,
+  int index: int ref,
+  unique int child: @ql_varDecl_child_type ref
+);
+
+ql_var_decl_def(
+  unique int id: @ql_var_decl
+);
+
+ql_var_name_def(
+  unique int id: @ql_var_name,
+  int child: @ql_token_simple_id ref
+);
+
+@ql_variable_child_type = @ql_token_result | @ql_token_this | @ql_var_name
+
+ql_variable_def(
+  unique int id: @ql_variable,
+  int child: @ql_variable_child_type ref
+);
+
+ql_tokeninfo(
+  unique int id: @ql_token,
+  int kind: int ref,
+  string value: string ref
+);
+
+case @ql_token.kind of
+  0 = @ql_reserved_word
+| 1 = @ql_token_addop
+| 2 = @ql_token_agg_id
+| 3 = @ql_token_annot_name
+| 4 = @ql_token_block_comment
+| 5 = @ql_token_class_name
+| 6 = @ql_token_closure
+| 7 = @ql_token_compop
+| 8 = @ql_token_dbtype
+| 9 = @ql_token_direction
+| 10 = @ql_token_empty
+| 11 = @ql_token_false
+| 12 = @ql_token_float
+| 13 = @ql_token_integer
+| 14 = @ql_token_line_comment
+| 15 = @ql_token_literal_id
+| 16 = @ql_token_mulop
+| 17 = @ql_token_predicate
+| 18 = @ql_token_predicate_name
+| 19 = @ql_token_primitive_type
+| 20 = @ql_token_qldoc
+| 21 = @ql_token_quantifier
+| 22 = @ql_token_result
+| 23 = @ql_token_simple_id
+| 24 = @ql_token_special_id
+| 25 = @ql_token_string
+| 26 = @ql_token_super
+| 27 = @ql_token_this
+| 28 = @ql_token_true
+| 29 = @ql_token_underscore
+| 30 = @ql_token_unop
+;
+
+
+@ql_ast_node = @ql_add_expr | @ql_aggregate | @ql_annot_arg | @ql_annotation | @ql_arityless_predicate_expr | @ql_as_expr | @ql_as_exprs | @ql_body | @ql_bool | @ql_call_body | @ql_call_or_unqual_agg_expr | @ql_charpred | @ql_class_member | @ql_classless_predicate | @ql_comp_term | @ql_conjunction | @ql_dataclass | @ql_datatype | @ql_datatype_branch | @ql_datatype_branches | @ql_disjunction | @ql_expr_aggregate_body | @ql_expr_annotation | @ql_field | @ql_full_aggregate_body | @ql_higher_order_term | @ql_if_term | @ql_implication | @ql_import_directive | @ql_import_module_expr | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_member_predicate | @ql_module | @ql_module_alias_body | @ql_module_expr | @ql_module_instantiation | @ql_module_member | @ql_module_name | @ql_module_param | @ql_mul_expr | @ql_negation | @ql_order_by | @ql_order_bys | @ql_par_expr | @ql_predicate_alias_body | @ql_predicate_expr | @ql_prefix_cast | @ql_ql | @ql_qualified_expr | @ql_qualified_rhs | @ql_quantified | @ql_range | @ql_select | @ql_set_literal | @ql_signature_expr | @ql_special_call | @ql_super_ref | @ql_token | @ql_type_alias_body | @ql_type_expr | @ql_type_union_body | @ql_unary_expr | @ql_unqual_agg_body | @ql_var_decl | @ql_var_name | @ql_variable
+
+ql_ast_node_location(
+  unique int node: @ql_ast_node ref,
+  int loc: @location_default ref
+);
+
+#keyset[parent, parent_index]
+ql_ast_node_parent(
+  unique int node: @ql_ast_node ref,
+  int parent: @ql_ast_node ref,
+  int parent_index: int ref
+);
+
+/*- Dbscheme dbscheme -*/
+dbscheme_annotation_args_annotation(
+  unique int dbscheme_annotation: @dbscheme_annotation ref,
+  unique int args_annotation: @dbscheme_args_annotation ref
+);
+
+dbscheme_annotation_simple_annotation(
+  unique int dbscheme_annotation: @dbscheme_annotation ref,
+  unique int simple_annotation: @dbscheme_token_annot_name ref
+);
+
+dbscheme_annotation_def(
+  unique int id: @dbscheme_annotation
+);
+
+#keyset[dbscheme_args_annotation, index]
+dbscheme_args_annotation_child(
+  int dbscheme_args_annotation: @dbscheme_args_annotation ref,
+  int index: int ref,
+  unique int child: @dbscheme_token_simple_id ref
+);
+
+dbscheme_args_annotation_def(
+  unique int id: @dbscheme_args_annotation,
+  int name: @dbscheme_token_annot_name ref
+);
+
+dbscheme_branch_qldoc(
+  unique int dbscheme_branch: @dbscheme_branch ref,
+  unique int qldoc: @dbscheme_token_qldoc ref
+);
+
+@dbscheme_branch_child_type = @dbscheme_token_dbtype | @dbscheme_token_integer
+
+#keyset[dbscheme_branch, index]
+dbscheme_branch_child(
+  int dbscheme_branch: @dbscheme_branch ref,
+  int index: int ref,
+  unique int child: @dbscheme_branch_child_type ref
+);
+
+dbscheme_branch_def(
+  unique int id: @dbscheme_branch
+);
+
+#keyset[dbscheme_case_decl, index]
+dbscheme_case_decl_child(
+  int dbscheme_case_decl: @dbscheme_case_decl ref,
+  int index: int ref,
+  unique int child: @dbscheme_branch ref
+);
+
+dbscheme_case_decl_def(
+  unique int id: @dbscheme_case_decl,
+  int base: @dbscheme_token_dbtype ref,
+  int discriminator: @dbscheme_token_simple_id ref
+);
+
+@dbscheme_colType_child_type = @dbscheme_token_boolean | @dbscheme_token_date | @dbscheme_token_dbtype | @dbscheme_token_float | @dbscheme_token_int | @dbscheme_token_string
+
+dbscheme_col_type_def(
+  unique int id: @dbscheme_col_type,
+  int child: @dbscheme_colType_child_type ref
+);
+
+dbscheme_column_is_ref(
+  unique int dbscheme_column: @dbscheme_column ref,
+  unique int is_ref: @dbscheme_token_ref ref
+);
+
+dbscheme_column_is_unique(
+  unique int dbscheme_column: @dbscheme_column ref,
+  unique int is_unique: @dbscheme_token_unique ref
+);
+
+dbscheme_column_qldoc(
+  unique int dbscheme_column: @dbscheme_column ref,
+  unique int qldoc: @dbscheme_token_qldoc ref
+);
+
+dbscheme_column_def(
+  unique int id: @dbscheme_column,
+  int col_name: @dbscheme_token_simple_id ref,
+  int col_type: @dbscheme_col_type ref,
+  int repr_type: @dbscheme_repr_type ref
+);
+
+#keyset[dbscheme_dbscheme, index]
+dbscheme_dbscheme_child(
+  int dbscheme_dbscheme: @dbscheme_dbscheme ref,
+  int index: int ref,
+  unique int child: @dbscheme_entry ref
+);
+
+dbscheme_dbscheme_def(
+  unique int id: @dbscheme_dbscheme
+);
+
+@dbscheme_entry_child_type = @dbscheme_case_decl | @dbscheme_table | @dbscheme_token_qldoc | @dbscheme_union_decl
+
+dbscheme_entry_def(
+  unique int id: @dbscheme_entry,
+  int child: @dbscheme_entry_child_type ref
+);
+
+@dbscheme_reprType_child_type = @dbscheme_token_boolean | @dbscheme_token_date | @dbscheme_token_float | @dbscheme_token_int | @dbscheme_token_integer | @dbscheme_token_string | @dbscheme_token_varchar
+
+#keyset[dbscheme_repr_type, index]
+dbscheme_repr_type_child(
+  int dbscheme_repr_type: @dbscheme_repr_type ref,
+  int index: int ref,
+  unique int child: @dbscheme_reprType_child_type ref
+);
+
+dbscheme_repr_type_def(
+  unique int id: @dbscheme_repr_type
+);
+
+@dbscheme_table_child_type = @dbscheme_annotation | @dbscheme_column
+
+#keyset[dbscheme_table, index]
+dbscheme_table_child(
+  int dbscheme_table: @dbscheme_table ref,
+  int index: int ref,
+  unique int child: @dbscheme_table_child_type ref
+);
+
+dbscheme_table_def(
+  unique int id: @dbscheme_table,
+  int table_name: @dbscheme_table_name ref
+);
+
+dbscheme_table_name_def(
+  unique int id: @dbscheme_table_name,
+  int child: @dbscheme_token_simple_id ref
+);
+
+#keyset[dbscheme_union_decl, index]
+dbscheme_union_decl_child(
+  int dbscheme_union_decl: @dbscheme_union_decl ref,
+  int index: int ref,
+  unique int child: @dbscheme_token_dbtype ref
+);
+
+dbscheme_union_decl_def(
+  unique int id: @dbscheme_union_decl,
+  int base: @dbscheme_token_dbtype ref
+);
+
+dbscheme_tokeninfo(
+  unique int id: @dbscheme_token,
+  int kind: int ref,
+  string value: string ref
+);
+
+case @dbscheme_token.kind of
+  0 = @dbscheme_reserved_word
+| 1 = @dbscheme_token_annot_name
+| 2 = @dbscheme_token_block_comment
+| 3 = @dbscheme_token_boolean
+| 4 = @dbscheme_token_date
+| 5 = @dbscheme_token_dbtype
+| 6 = @dbscheme_token_float
+| 7 = @dbscheme_token_int
+| 8 = @dbscheme_token_integer
+| 9 = @dbscheme_token_line_comment
+| 10 = @dbscheme_token_qldoc
+| 11 = @dbscheme_token_ref
+| 12 = @dbscheme_token_simple_id
+| 13 = @dbscheme_token_string
+| 14 = @dbscheme_token_unique
+| 15 = @dbscheme_token_varchar
+;
+
+
+@dbscheme_ast_node = @dbscheme_annotation | @dbscheme_args_annotation | @dbscheme_branch | @dbscheme_case_decl | @dbscheme_col_type | @dbscheme_column | @dbscheme_dbscheme | @dbscheme_entry | @dbscheme_repr_type | @dbscheme_table | @dbscheme_table_name | @dbscheme_token | @dbscheme_union_decl
+
+dbscheme_ast_node_location(
+  unique int node: @dbscheme_ast_node ref,
+  int loc: @location_default ref
+);
+
+#keyset[parent, parent_index]
+dbscheme_ast_node_parent(
+  unique int node: @dbscheme_ast_node ref,
+  int parent: @dbscheme_ast_node ref,
+  int parent_index: int ref
+);
+
+/*- Blame dbscheme -*/
+#keyset[blame_blame_entry, index]
+blame_blame_entry_line(
+  int blame_blame_entry: @blame_blame_entry ref,
+  int index: int ref,
+  unique int line: @blame_token_number ref
+);
+
+blame_blame_entry_def(
+  unique int id: @blame_blame_entry,
+  int date__: @blame_token_date ref
+);
+
+#keyset[blame_blame_info, index]
+blame_blame_info_file_entry(
+  int blame_blame_info: @blame_blame_info ref,
+  int index: int ref,
+  unique int file_entry: @blame_file_entry ref
+);
+
+blame_blame_info_def(
+  unique int id: @blame_blame_info,
+  int today: @blame_token_date ref
+);
+
+#keyset[blame_file_entry, index]
+blame_file_entry_blame_entry(
+  int blame_file_entry: @blame_file_entry ref,
+  int index: int ref,
+  unique int blame_entry: @blame_blame_entry ref
+);
+
+blame_file_entry_def(
+  unique int id: @blame_file_entry,
+  int file_name: @blame_token_filename ref
+);
+
+blame_tokeninfo(
+  unique int id: @blame_token,
+  int kind: int ref,
+  string value: string ref
+);
+
+case @blame_token.kind of
+  0 = @blame_reserved_word
+| 1 = @blame_token_date
+| 2 = @blame_token_filename
+| 3 = @blame_token_number
+;
+
+
+@blame_ast_node = @blame_blame_entry | @blame_blame_info | @blame_file_entry | @blame_token
+
+blame_ast_node_location(
+  unique int node: @blame_ast_node ref,
+  int loc: @location_default ref
+);
+
+#keyset[parent, parent_index]
+blame_ast_node_parent(
+  unique int node: @blame_ast_node ref,
+  int parent: @blame_ast_node ref,
+  int parent_index: int ref
+);
+
+/*- JSON dbscheme -*/
+@json_underscore_value = @json_array | @json_object | @json_string__ | @json_token_false | @json_token_null | @json_token_number | @json_token_true
+
+#keyset[json_array, index]
+json_array_child(
+  int json_array: @json_array ref,
+  int index: int ref,
+  unique int child: @json_underscore_value ref
+);
+
+json_array_def(
+  unique int id: @json_array
+);
+
+#keyset[json_document, index]
+json_document_child(
+  int json_document: @json_document ref,
+  int index: int ref,
+  unique int child: @json_underscore_value ref
+);
+
+json_document_def(
+  unique int id: @json_document
+);
+
+#keyset[json_object, index]
+json_object_child(
+  int json_object: @json_object ref,
+  int index: int ref,
+  unique int child: @json_pair ref
+);
+
+json_object_def(
+  unique int id: @json_object
+);
+
+json_pair_def(
+  unique int id: @json_pair,
+  int key__: @json_string__ ref,
+  int value: @json_underscore_value ref
+);
+
+@json_string_child_type = @json_token_escape_sequence | @json_token_string_content
+
+#keyset[json_string__, index]
+json_string_child(
+  int json_string__: @json_string__ ref,
+  int index: int ref,
+  unique int child: @json_string_child_type ref
+);
+
+json_string_def(
+  unique int id: @json_string__
+);
+
+json_tokeninfo(
+  unique int id: @json_token,
+  int kind: int ref,
+  string value: string ref
+);
+
+case @json_token.kind of
+  0 = @json_reserved_word
+| 1 = @json_token_comment
+| 2 = @json_token_escape_sequence
+| 3 = @json_token_false
+| 4 = @json_token_null
+| 5 = @json_token_number
+| 6 = @json_token_string_content
+| 7 = @json_token_true
+;
+
+
+@json_ast_node = @json_array | @json_document | @json_object | @json_pair | @json_string__ | @json_token
+
+json_ast_node_location(
+  unique int node: @json_ast_node ref,
+  int loc: @location_default ref
+);
+
+#keyset[parent, parent_index]
+json_ast_node_parent(
+  unique int node: @json_ast_node ref,
+  int parent: @json_ast_node ref,
+  int parent_index: int ref
+);
+

--- a/ql/ql/lib/upgrades/c50cdd7429a4598cd95f75c82b4ba453007159d9/ql.dbscheme
+++ b/ql/ql/lib/upgrades/c50cdd7429a4598cd95f75c82b4ba453007159d9/ql.dbscheme
@@ -1,0 +1,1356 @@
+// CodeQL database schema for QL
+// Automatically generated from the tree-sitter grammar; do not edit
+// To regenerate, run 'scripts/create-extractor-pack.sh' in ql/
+
+/*- Files and folders -*/
+
+/**
+ * The location of an element.
+ * The location spans column `startcolumn` of line `startline` to
+ * column `endcolumn` of line `endline` in file `file`.
+ * For more information, see
+ * [Locations](https://codeql.github.com/docs/writing-codeql-queries/providing-locations-in-codeql-queries/).
+ */
+locations_default(
+  unique int id: @location_default,
+  int file: @file ref,
+  int beginLine: int ref,
+  int beginColumn: int ref,
+  int endLine: int ref,
+  int endColumn: int ref
+);
+
+files(
+  unique int id: @file,
+  string name: string ref
+);
+
+folders(
+  unique int id: @folder,
+  string name: string ref
+);
+
+@container = @file | @folder
+
+containerparent(
+  int parent: @container ref,
+  unique int child: @container ref
+);
+
+/*- Empty location -*/
+
+empty_location(
+  int location: @location_default ref
+);
+
+/*- Source location prefix -*/
+
+/**
+ * The source location of the snapshot.
+ */
+sourceLocationPrefix(string prefix : string ref);
+
+/*- Diagnostic messages -*/
+
+diagnostics(
+  unique int id: @diagnostic,
+  int severity: int ref,
+  string error_tag: string ref,
+  string error_message: string ref,
+  string full_error_message: string ref,
+  int location: @location_default ref
+);
+
+/*- Diagnostic messages: severity -*/
+
+case @diagnostic.severity of
+  10 = @diagnostic_debug
+| 20 = @diagnostic_info
+| 30 = @diagnostic_warning
+| 40 = @diagnostic_error
+;
+
+/*- YAML -*/
+
+#keyset[parent, idx]
+yaml (unique int id: @yaml_node,
+      int kind: int ref,
+      int parent: @yaml_node_parent ref,
+      int idx: int ref,
+      string tag: string ref,
+      string tostring: string ref);
+
+case @yaml_node.kind of
+  0 = @yaml_scalar_node
+| 1 = @yaml_mapping_node
+| 2 = @yaml_sequence_node
+| 3 = @yaml_alias_node
+;
+
+@yaml_collection_node = @yaml_mapping_node | @yaml_sequence_node;
+
+@yaml_node_parent = @yaml_collection_node | @file;
+
+yaml_anchors (unique int node: @yaml_node ref,
+              string anchor: string ref);
+
+yaml_aliases (unique int alias: @yaml_alias_node ref,
+              string target: string ref);
+
+yaml_scalars (unique int scalar: @yaml_scalar_node ref,
+              int style: int ref,
+              string value: string ref);
+
+yaml_errors (unique int id: @yaml_error,
+             string message: string ref);
+
+yaml_locations(unique int locatable: @yaml_locatable ref,
+             int location: @location_default ref);
+
+@yaml_locatable = @yaml_node | @yaml_error;
+
+/*- Database metadata -*/
+
+/**
+ * The CLI will automatically emit applicable tuples for this table,
+ * such as `databaseMetadata("isOverlay", "true")` when building an
+ * overlay database.
+ */
+databaseMetadata(
+  string metadataKey: string ref,
+  string value: string ref
+);
+
+/*- Overlay support -*/
+
+/**
+ * The CLI will automatically emit tuples for each new/modified/deleted file
+ * when building an overlay database.
+ */
+overlayChangedFiles(
+  string path: string ref
+);
+
+/*- QL dbscheme -*/
+@ql_add_expr_left_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+@ql_add_expr_right_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_add_expr_def(
+  unique int id: @ql_add_expr,
+  int left: @ql_add_expr_left_type ref,
+  int right: @ql_add_expr_right_type ref,
+  int child: @ql_token_addop ref
+);
+
+@ql_aggregate_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_aggregate_body | @ql_expr_annotation | @ql_full_aggregate_body | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_token_agg_id | @ql_unary_expr | @ql_variable
+
+#keyset[ql_aggregate, index]
+ql_aggregate_child(
+  int ql_aggregate: @ql_aggregate ref,
+  int index: int ref,
+  unique int child: @ql_aggregate_child_type ref
+);
+
+ql_aggregate_def(
+  unique int id: @ql_aggregate
+);
+
+@ql_annotArg_child_type = @ql_token_result | @ql_token_simple_id | @ql_token_this
+
+ql_annot_arg_def(
+  unique int id: @ql_annot_arg,
+  int child: @ql_annotArg_child_type ref
+);
+
+@ql_annotation_args_type = @ql_annot_arg | @ql_reserved_word
+
+#keyset[ql_annotation, index]
+ql_annotation_args(
+  int ql_annotation: @ql_annotation ref,
+  int index: int ref,
+  unique int args: @ql_annotation_args_type ref
+);
+
+ql_annotation_def(
+  unique int id: @ql_annotation,
+  int name: @ql_token_annot_name ref
+);
+
+ql_arityless_predicate_expr_qualifier(
+  unique int ql_arityless_predicate_expr: @ql_arityless_predicate_expr ref,
+  unique int qualifier: @ql_module_expr ref
+);
+
+ql_arityless_predicate_expr_def(
+  unique int id: @ql_arityless_predicate_expr,
+  int name: @ql_token_literal_id ref
+);
+
+@ql_asExpr_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_var_name | @ql_variable
+
+#keyset[ql_as_expr, index]
+ql_as_expr_child(
+  int ql_as_expr: @ql_as_expr ref,
+  int index: int ref,
+  unique int child: @ql_asExpr_child_type ref
+);
+
+ql_as_expr_def(
+  unique int id: @ql_as_expr
+);
+
+#keyset[ql_as_exprs, index]
+ql_as_exprs_child(
+  int ql_as_exprs: @ql_as_exprs ref,
+  int index: int ref,
+  unique int child: @ql_as_expr ref
+);
+
+ql_as_exprs_def(
+  unique int id: @ql_as_exprs
+);
+
+@ql_body_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_body_def(
+  unique int id: @ql_body,
+  int child: @ql_body_child_type ref
+);
+
+@ql_bool_child_type = @ql_token_false | @ql_token_true
+
+ql_bool_def(
+  unique int id: @ql_bool,
+  int child: @ql_bool_child_type ref
+);
+
+@ql_call_body_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_token_underscore | @ql_unary_expr | @ql_variable
+
+#keyset[ql_call_body, index]
+ql_call_body_child(
+  int ql_call_body: @ql_call_body ref,
+  int index: int ref,
+  unique int child: @ql_call_body_child_type ref
+);
+
+ql_call_body_def(
+  unique int id: @ql_call_body
+);
+
+@ql_call_or_unqual_agg_expr_child_type = @ql_arityless_predicate_expr | @ql_call_body | @ql_token_closure | @ql_unqual_agg_body
+
+#keyset[ql_call_or_unqual_agg_expr, index]
+ql_call_or_unqual_agg_expr_child(
+  int ql_call_or_unqual_agg_expr: @ql_call_or_unqual_agg_expr ref,
+  int index: int ref,
+  unique int child: @ql_call_or_unqual_agg_expr_child_type ref
+);
+
+ql_call_or_unqual_agg_expr_def(
+  unique int id: @ql_call_or_unqual_agg_expr
+);
+
+@ql_charpred_body_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_charpred_def(
+  unique int id: @ql_charpred,
+  int body: @ql_charpred_body_type ref,
+  int child: @ql_token_class_name ref
+);
+
+@ql_classMember_child_type = @ql_annotation | @ql_charpred | @ql_field | @ql_member_predicate | @ql_token_qldoc
+
+#keyset[ql_class_member, index]
+ql_class_member_child(
+  int ql_class_member: @ql_class_member ref,
+  int index: int ref,
+  unique int child: @ql_classMember_child_type ref
+);
+
+ql_class_member_def(
+  unique int id: @ql_class_member
+);
+
+@ql_classlessPredicate_returnType_type = @ql_token_predicate | @ql_type_expr
+
+@ql_classlessPredicate_child_type = @ql_body | @ql_higher_order_term | @ql_predicate_alias_body | @ql_token_empty | @ql_var_decl
+
+#keyset[ql_classless_predicate, index]
+ql_classless_predicate_child(
+  int ql_classless_predicate: @ql_classless_predicate ref,
+  int index: int ref,
+  unique int child: @ql_classlessPredicate_child_type ref
+);
+
+ql_classless_predicate_def(
+  unique int id: @ql_classless_predicate,
+  int name: @ql_token_predicate_name ref,
+  int return_type: @ql_classlessPredicate_returnType_type ref
+);
+
+@ql_comp_term_left_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+@ql_comp_term_right_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_comp_term_def(
+  unique int id: @ql_comp_term,
+  int left: @ql_comp_term_left_type ref,
+  int right: @ql_comp_term_right_type ref,
+  int child: @ql_token_compop ref
+);
+
+@ql_conjunction_left_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+@ql_conjunction_right_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_conjunction_def(
+  unique int id: @ql_conjunction,
+  int left: @ql_conjunction_left_type ref,
+  int right: @ql_conjunction_right_type ref
+);
+
+@ql_dataclass_extends_type = @ql_reserved_word | @ql_type_expr
+
+#keyset[ql_dataclass, index]
+ql_dataclass_extends(
+  int ql_dataclass: @ql_dataclass ref,
+  int index: int ref,
+  unique int extends: @ql_dataclass_extends_type ref
+);
+
+@ql_dataclass_instanceof_type = @ql_reserved_word | @ql_type_expr
+
+#keyset[ql_dataclass, index]
+ql_dataclass_instanceof(
+  int ql_dataclass: @ql_dataclass ref,
+  int index: int ref,
+  unique int instanceof: @ql_dataclass_instanceof_type ref
+);
+
+@ql_dataclass_child_type = @ql_class_member | @ql_type_alias_body | @ql_type_union_body
+
+#keyset[ql_dataclass, index]
+ql_dataclass_child(
+  int ql_dataclass: @ql_dataclass ref,
+  int index: int ref,
+  unique int child: @ql_dataclass_child_type ref
+);
+
+ql_dataclass_def(
+  unique int id: @ql_dataclass,
+  int name: @ql_token_class_name ref
+);
+
+ql_datatype_def(
+  unique int id: @ql_datatype,
+  int name: @ql_token_class_name ref,
+  int child: @ql_datatype_branches ref
+);
+
+@ql_datatypeBranch_child_type = @ql_annotation | @ql_body | @ql_token_qldoc | @ql_var_decl
+
+#keyset[ql_datatype_branch, index]
+ql_datatype_branch_child(
+  int ql_datatype_branch: @ql_datatype_branch ref,
+  int index: int ref,
+  unique int child: @ql_datatypeBranch_child_type ref
+);
+
+ql_datatype_branch_def(
+  unique int id: @ql_datatype_branch,
+  int name: @ql_token_class_name ref
+);
+
+#keyset[ql_datatype_branches, index]
+ql_datatype_branches_child(
+  int ql_datatype_branches: @ql_datatype_branches ref,
+  int index: int ref,
+  unique int child: @ql_datatype_branch ref
+);
+
+ql_datatype_branches_def(
+  unique int id: @ql_datatype_branches
+);
+
+@ql_disjunction_left_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+@ql_disjunction_right_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_disjunction_def(
+  unique int id: @ql_disjunction,
+  int left: @ql_disjunction_left_type ref,
+  int right: @ql_disjunction_right_type ref
+);
+
+ql_expr_aggregate_body_order_bys(
+  unique int ql_expr_aggregate_body: @ql_expr_aggregate_body ref,
+  unique int order_bys: @ql_order_bys ref
+);
+
+ql_expr_aggregate_body_def(
+  unique int id: @ql_expr_aggregate_body,
+  int as_exprs: @ql_as_exprs ref
+);
+
+@ql_expr_annotation_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_expr_annotation_def(
+  unique int id: @ql_expr_annotation,
+  int annot_arg: @ql_token_annot_name ref,
+  int name: @ql_token_annot_name ref,
+  int child: @ql_expr_annotation_child_type ref
+);
+
+ql_field_def(
+  unique int id: @ql_field,
+  int child: @ql_var_decl ref
+);
+
+ql_full_aggregate_body_as_exprs(
+  unique int ql_full_aggregate_body: @ql_full_aggregate_body ref,
+  unique int as_exprs: @ql_as_exprs ref
+);
+
+@ql_full_aggregate_body_guard_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_full_aggregate_body_guard(
+  unique int ql_full_aggregate_body: @ql_full_aggregate_body ref,
+  unique int guard: @ql_full_aggregate_body_guard_type ref
+);
+
+ql_full_aggregate_body_order_bys(
+  unique int ql_full_aggregate_body: @ql_full_aggregate_body ref,
+  unique int order_bys: @ql_order_bys ref
+);
+
+#keyset[ql_full_aggregate_body, index]
+ql_full_aggregate_body_child(
+  int ql_full_aggregate_body: @ql_full_aggregate_body ref,
+  int index: int ref,
+  unique int child: @ql_var_decl ref
+);
+
+ql_full_aggregate_body_def(
+  unique int id: @ql_full_aggregate_body
+);
+
+@ql_higherOrderTerm_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_predicate_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_token_underscore | @ql_unary_expr | @ql_variable
+
+#keyset[ql_higher_order_term, index]
+ql_higher_order_term_child(
+  int ql_higher_order_term: @ql_higher_order_term ref,
+  int index: int ref,
+  unique int child: @ql_higherOrderTerm_child_type ref
+);
+
+ql_higher_order_term_def(
+  unique int id: @ql_higher_order_term,
+  int name: @ql_token_literal_id ref
+);
+
+@ql_if_term_cond_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+@ql_if_term_first_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+@ql_if_term_second_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_if_term_def(
+  unique int id: @ql_if_term,
+  int cond: @ql_if_term_cond_type ref,
+  int first: @ql_if_term_first_type ref,
+  int second: @ql_if_term_second_type ref
+);
+
+@ql_implication_left_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+@ql_implication_right_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_implication_def(
+  unique int id: @ql_implication,
+  int left: @ql_implication_left_type ref,
+  int right: @ql_implication_right_type ref
+);
+
+@ql_importDirective_child_type = @ql_import_module_expr | @ql_module_name
+
+#keyset[ql_import_directive, index]
+ql_import_directive_child(
+  int ql_import_directive: @ql_import_directive ref,
+  int index: int ref,
+  unique int child: @ql_importDirective_child_type ref
+);
+
+ql_import_directive_def(
+  unique int id: @ql_import_directive
+);
+
+#keyset[ql_import_module_expr, index]
+ql_import_module_expr_qual_name(
+  int ql_import_module_expr: @ql_import_module_expr ref,
+  int index: int ref,
+  unique int qual_name: @ql_token_simple_id ref
+);
+
+ql_import_module_expr_def(
+  unique int id: @ql_import_module_expr,
+  int child: @ql_module_expr ref
+);
+
+@ql_in_expr_left_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+@ql_in_expr_right_type = @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_expr_annotation | @ql_literal | @ql_par_expr | @ql_qualified_expr | @ql_range | @ql_set_literal | @ql_super_ref | @ql_variable
+
+ql_in_expr_def(
+  unique int id: @ql_in_expr,
+  int left: @ql_in_expr_left_type ref,
+  int right: @ql_in_expr_right_type ref
+);
+
+@ql_instance_of_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_type_expr | @ql_unary_expr | @ql_variable
+
+#keyset[ql_instance_of, index]
+ql_instance_of_child(
+  int ql_instance_of: @ql_instance_of ref,
+  int index: int ref,
+  unique int child: @ql_instance_of_child_type ref
+);
+
+ql_instance_of_def(
+  unique int id: @ql_instance_of
+);
+
+@ql_literal_child_type = @ql_bool | @ql_token_float | @ql_token_integer | @ql_token_string
+
+ql_literal_def(
+  unique int id: @ql_literal,
+  int child: @ql_literal_child_type ref
+);
+
+@ql_memberPredicate_returnType_type = @ql_token_predicate | @ql_type_expr
+
+@ql_memberPredicate_child_type = @ql_body | @ql_higher_order_term | @ql_token_empty | @ql_var_decl
+
+#keyset[ql_member_predicate, index]
+ql_member_predicate_child(
+  int ql_member_predicate: @ql_member_predicate ref,
+  int index: int ref,
+  unique int child: @ql_memberPredicate_child_type ref
+);
+
+ql_member_predicate_def(
+  unique int id: @ql_member_predicate,
+  int name: @ql_token_predicate_name ref,
+  int return_type: @ql_memberPredicate_returnType_type ref
+);
+
+#keyset[ql_module, index]
+ql_module_implements(
+  int ql_module: @ql_module ref,
+  int index: int ref,
+  unique int implements: @ql_signature_expr ref
+);
+
+#keyset[ql_module, index]
+ql_module_parameter(
+  int ql_module: @ql_module ref,
+  int index: int ref,
+  unique int parameter: @ql_module_param ref
+);
+
+@ql_module_child_type = @ql_module_alias_body | @ql_module_member
+
+#keyset[ql_module, index]
+ql_module_child(
+  int ql_module: @ql_module ref,
+  int index: int ref,
+  unique int child: @ql_module_child_type ref
+);
+
+ql_module_def(
+  unique int id: @ql_module,
+  int name: @ql_module_name ref
+);
+
+ql_module_alias_body_def(
+  unique int id: @ql_module_alias_body,
+  int child: @ql_module_expr ref
+);
+
+@ql_moduleExpr_name_type = @ql_module_instantiation | @ql_token_simple_id
+
+ql_module_expr_name(
+  unique int ql_module_expr: @ql_module_expr ref,
+  unique int name: @ql_moduleExpr_name_type ref
+);
+
+@ql_moduleExpr_child_type = @ql_module_expr | @ql_module_instantiation | @ql_token_simple_id
+
+ql_module_expr_def(
+  unique int id: @ql_module_expr,
+  int child: @ql_moduleExpr_child_type ref
+);
+
+#keyset[ql_module_instantiation, index]
+ql_module_instantiation_child(
+  int ql_module_instantiation: @ql_module_instantiation ref,
+  int index: int ref,
+  unique int child: @ql_signature_expr ref
+);
+
+ql_module_instantiation_def(
+  unique int id: @ql_module_instantiation,
+  int name: @ql_module_name ref
+);
+
+@ql_moduleMember_child_type = @ql_annotation | @ql_classless_predicate | @ql_dataclass | @ql_datatype | @ql_import_directive | @ql_module | @ql_select | @ql_token_qldoc
+
+#keyset[ql_module_member, index]
+ql_module_member_child(
+  int ql_module_member: @ql_module_member ref,
+  int index: int ref,
+  unique int child: @ql_moduleMember_child_type ref
+);
+
+ql_module_member_def(
+  unique int id: @ql_module_member
+);
+
+ql_module_name_def(
+  unique int id: @ql_module_name,
+  int child: @ql_token_simple_id ref
+);
+
+ql_module_param_def(
+  unique int id: @ql_module_param,
+  int parameter: @ql_token_simple_id ref,
+  int signature: @ql_signature_expr ref
+);
+
+@ql_mul_expr_left_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+@ql_mul_expr_right_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_mul_expr_def(
+  unique int id: @ql_mul_expr,
+  int left: @ql_mul_expr_left_type ref,
+  int right: @ql_mul_expr_right_type ref,
+  int child: @ql_token_mulop ref
+);
+
+@ql_negation_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_negation_def(
+  unique int id: @ql_negation,
+  int child: @ql_negation_child_type ref
+);
+
+@ql_orderBy_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_token_direction | @ql_unary_expr | @ql_variable
+
+#keyset[ql_order_by, index]
+ql_order_by_child(
+  int ql_order_by: @ql_order_by ref,
+  int index: int ref,
+  unique int child: @ql_orderBy_child_type ref
+);
+
+ql_order_by_def(
+  unique int id: @ql_order_by
+);
+
+#keyset[ql_order_bys, index]
+ql_order_bys_child(
+  int ql_order_bys: @ql_order_bys ref,
+  int index: int ref,
+  unique int child: @ql_order_by ref
+);
+
+ql_order_bys_def(
+  unique int id: @ql_order_bys
+);
+
+@ql_par_expr_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_par_expr_def(
+  unique int id: @ql_par_expr,
+  int child: @ql_par_expr_child_type ref
+);
+
+ql_predicate_alias_body_def(
+  unique int id: @ql_predicate_alias_body,
+  int child: @ql_predicate_expr ref
+);
+
+@ql_predicateExpr_child_type = @ql_arityless_predicate_expr | @ql_token_integer
+
+#keyset[ql_predicate_expr, index]
+ql_predicate_expr_child(
+  int ql_predicate_expr: @ql_predicate_expr ref,
+  int index: int ref,
+  unique int child: @ql_predicateExpr_child_type ref
+);
+
+ql_predicate_expr_def(
+  unique int id: @ql_predicate_expr
+);
+
+@ql_prefix_cast_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_type_expr | @ql_unary_expr | @ql_variable
+
+#keyset[ql_prefix_cast, index]
+ql_prefix_cast_child(
+  int ql_prefix_cast: @ql_prefix_cast ref,
+  int index: int ref,
+  unique int child: @ql_prefix_cast_child_type ref
+);
+
+ql_prefix_cast_def(
+  unique int id: @ql_prefix_cast
+);
+
+#keyset[ql_ql, index]
+ql_ql_child(
+  int ql_ql: @ql_ql ref,
+  int index: int ref,
+  unique int child: @ql_module_member ref
+);
+
+ql_ql_def(
+  unique int id: @ql_ql
+);
+
+ql_qualified_rhs_name(
+  unique int ql_qualified_rhs: @ql_qualified_rhs ref,
+  unique int name: @ql_token_predicate_name ref
+);
+
+@ql_qualifiedRhs_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_token_closure | @ql_token_underscore | @ql_type_expr | @ql_unary_expr | @ql_variable
+
+#keyset[ql_qualified_rhs, index]
+ql_qualified_rhs_child(
+  int ql_qualified_rhs: @ql_qualified_rhs ref,
+  int index: int ref,
+  unique int child: @ql_qualifiedRhs_child_type ref
+);
+
+ql_qualified_rhs_def(
+  unique int id: @ql_qualified_rhs
+);
+
+@ql_qualified_expr_child_type = @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_expr_annotation | @ql_literal | @ql_par_expr | @ql_qualified_expr | @ql_qualified_rhs | @ql_range | @ql_set_literal | @ql_super_ref | @ql_variable
+
+#keyset[ql_qualified_expr, index]
+ql_qualified_expr_child(
+  int ql_qualified_expr: @ql_qualified_expr ref,
+  int index: int ref,
+  unique int child: @ql_qualified_expr_child_type ref
+);
+
+ql_qualified_expr_def(
+  unique int id: @ql_qualified_expr
+);
+
+@ql_quantified_expr_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_quantified_expr(
+  unique int ql_quantified: @ql_quantified ref,
+  unique int expr: @ql_quantified_expr_type ref
+);
+
+@ql_quantified_formula_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_quantified_formula(
+  unique int ql_quantified: @ql_quantified ref,
+  unique int formula: @ql_quantified_formula_type ref
+);
+
+@ql_quantified_range_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_quantified_range(
+  unique int ql_quantified: @ql_quantified ref,
+  unique int range: @ql_quantified_range_type ref
+);
+
+@ql_quantified_child_type = @ql_token_quantifier | @ql_var_decl
+
+#keyset[ql_quantified, index]
+ql_quantified_child(
+  int ql_quantified: @ql_quantified ref,
+  int index: int ref,
+  unique int child: @ql_quantified_child_type ref
+);
+
+ql_quantified_def(
+  unique int id: @ql_quantified
+);
+
+@ql_range_lower_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+@ql_range_upper_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_range_def(
+  unique int id: @ql_range,
+  int lower: @ql_range_lower_type ref,
+  int upper: @ql_range_upper_type ref
+);
+
+@ql_select_child_type = @ql_add_expr | @ql_aggregate | @ql_as_exprs | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_order_bys | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_var_decl | @ql_variable
+
+#keyset[ql_select, index]
+ql_select_child(
+  int ql_select: @ql_select ref,
+  int index: int ref,
+  unique int child: @ql_select_child_type ref
+);
+
+ql_select_def(
+  unique int id: @ql_select
+);
+
+@ql_set_literal_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+#keyset[ql_set_literal, index]
+ql_set_literal_child(
+  int ql_set_literal: @ql_set_literal ref,
+  int index: int ref,
+  unique int child: @ql_set_literal_child_type ref
+);
+
+ql_set_literal_def(
+  unique int id: @ql_set_literal
+);
+
+ql_signature_expr_mod_expr(
+  unique int ql_signature_expr: @ql_signature_expr ref,
+  unique int mod_expr: @ql_module_expr ref
+);
+
+ql_signature_expr_predicate(
+  unique int ql_signature_expr: @ql_signature_expr ref,
+  unique int predicate: @ql_predicate_expr ref
+);
+
+ql_signature_expr_type_expr(
+  unique int ql_signature_expr: @ql_signature_expr ref,
+  unique int type_expr: @ql_type_expr ref
+);
+
+ql_signature_expr_def(
+  unique int id: @ql_signature_expr
+);
+
+ql_special_call_def(
+  unique int id: @ql_special_call,
+  int child: @ql_token_special_id ref
+);
+
+@ql_super_ref_child_type = @ql_token_super | @ql_type_expr
+
+#keyset[ql_super_ref, index]
+ql_super_ref_child(
+  int ql_super_ref: @ql_super_ref ref,
+  int index: int ref,
+  unique int child: @ql_super_ref_child_type ref
+);
+
+ql_super_ref_def(
+  unique int id: @ql_super_ref
+);
+
+ql_type_alias_body_def(
+  unique int id: @ql_type_alias_body,
+  int child: @ql_type_expr ref
+);
+
+ql_type_expr_name(
+  unique int ql_type_expr: @ql_type_expr ref,
+  unique int name: @ql_token_class_name ref
+);
+
+ql_type_expr_qualifier(
+  unique int ql_type_expr: @ql_type_expr ref,
+  unique int qualifier: @ql_module_expr ref
+);
+
+@ql_typeExpr_child_type = @ql_token_dbtype | @ql_token_primitive_type
+
+ql_type_expr_child(
+  unique int ql_type_expr: @ql_type_expr ref,
+  unique int child: @ql_typeExpr_child_type ref
+);
+
+ql_type_expr_def(
+  unique int id: @ql_type_expr
+);
+
+#keyset[ql_type_union_body, index]
+ql_type_union_body_child(
+  int ql_type_union_body: @ql_type_union_body ref,
+  int index: int ref,
+  unique int child: @ql_type_expr ref
+);
+
+ql_type_union_body_def(
+  unique int id: @ql_type_union_body
+);
+
+@ql_unary_expr_child_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_token_unop | @ql_unary_expr | @ql_variable
+
+#keyset[ql_unary_expr, index]
+ql_unary_expr_child(
+  int ql_unary_expr: @ql_unary_expr ref,
+  int index: int ref,
+  unique int child: @ql_unary_expr_child_type ref
+);
+
+ql_unary_expr_def(
+  unique int id: @ql_unary_expr
+);
+
+@ql_unqual_agg_body_asExprs_type = @ql_as_exprs | @ql_reserved_word
+
+#keyset[ql_unqual_agg_body, index]
+ql_unqual_agg_body_as_exprs(
+  int ql_unqual_agg_body: @ql_unqual_agg_body ref,
+  int index: int ref,
+  unique int as_exprs: @ql_unqual_agg_body_asExprs_type ref
+);
+
+@ql_unqual_agg_body_guard_type = @ql_add_expr | @ql_aggregate | @ql_call_or_unqual_agg_expr | @ql_comp_term | @ql_conjunction | @ql_disjunction | @ql_expr_annotation | @ql_if_term | @ql_implication | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_mul_expr | @ql_negation | @ql_par_expr | @ql_prefix_cast | @ql_qualified_expr | @ql_quantified | @ql_range | @ql_set_literal | @ql_special_call | @ql_super_ref | @ql_unary_expr | @ql_variable
+
+ql_unqual_agg_body_guard(
+  unique int ql_unqual_agg_body: @ql_unqual_agg_body ref,
+  unique int guard: @ql_unqual_agg_body_guard_type ref
+);
+
+#keyset[ql_unqual_agg_body, index]
+ql_unqual_agg_body_child(
+  int ql_unqual_agg_body: @ql_unqual_agg_body ref,
+  int index: int ref,
+  unique int child: @ql_var_decl ref
+);
+
+ql_unqual_agg_body_def(
+  unique int id: @ql_unqual_agg_body
+);
+
+@ql_varDecl_child_type = @ql_type_expr | @ql_var_name
+
+#keyset[ql_var_decl, index]
+ql_var_decl_child(
+  int ql_var_decl: @ql_var_decl ref,
+  int index: int ref,
+  unique int child: @ql_varDecl_child_type ref
+);
+
+ql_var_decl_def(
+  unique int id: @ql_var_decl
+);
+
+ql_var_name_def(
+  unique int id: @ql_var_name,
+  int child: @ql_token_simple_id ref
+);
+
+@ql_variable_child_type = @ql_token_result | @ql_token_this | @ql_var_name
+
+ql_variable_def(
+  unique int id: @ql_variable,
+  int child: @ql_variable_child_type ref
+);
+
+ql_tokeninfo(
+  unique int id: @ql_token,
+  int kind: int ref,
+  string value: string ref
+);
+
+case @ql_token.kind of
+  0 = @ql_reserved_word
+| 1 = @ql_token_addop
+| 2 = @ql_token_agg_id
+| 3 = @ql_token_annot_name
+| 4 = @ql_token_block_comment
+| 5 = @ql_token_class_name
+| 6 = @ql_token_closure
+| 7 = @ql_token_compop
+| 8 = @ql_token_dbtype
+| 9 = @ql_token_direction
+| 10 = @ql_token_empty
+| 11 = @ql_token_false
+| 12 = @ql_token_float
+| 13 = @ql_token_integer
+| 14 = @ql_token_line_comment
+| 15 = @ql_token_literal_id
+| 16 = @ql_token_mulop
+| 17 = @ql_token_predicate
+| 18 = @ql_token_predicate_name
+| 19 = @ql_token_primitive_type
+| 20 = @ql_token_qldoc
+| 21 = @ql_token_quantifier
+| 22 = @ql_token_result
+| 23 = @ql_token_simple_id
+| 24 = @ql_token_special_id
+| 25 = @ql_token_string
+| 26 = @ql_token_super
+| 27 = @ql_token_this
+| 28 = @ql_token_true
+| 29 = @ql_token_underscore
+| 30 = @ql_token_unop
+;
+
+
+@ql_ast_node = @ql_add_expr | @ql_aggregate | @ql_annot_arg | @ql_annotation | @ql_arityless_predicate_expr | @ql_as_expr | @ql_as_exprs | @ql_body | @ql_bool | @ql_call_body | @ql_call_or_unqual_agg_expr | @ql_charpred | @ql_class_member | @ql_classless_predicate | @ql_comp_term | @ql_conjunction | @ql_dataclass | @ql_datatype | @ql_datatype_branch | @ql_datatype_branches | @ql_disjunction | @ql_expr_aggregate_body | @ql_expr_annotation | @ql_field | @ql_full_aggregate_body | @ql_higher_order_term | @ql_if_term | @ql_implication | @ql_import_directive | @ql_import_module_expr | @ql_in_expr | @ql_instance_of | @ql_literal | @ql_member_predicate | @ql_module | @ql_module_alias_body | @ql_module_expr | @ql_module_instantiation | @ql_module_member | @ql_module_name | @ql_module_param | @ql_mul_expr | @ql_negation | @ql_order_by | @ql_order_bys | @ql_par_expr | @ql_predicate_alias_body | @ql_predicate_expr | @ql_prefix_cast | @ql_ql | @ql_qualified_expr | @ql_qualified_rhs | @ql_quantified | @ql_range | @ql_select | @ql_set_literal | @ql_signature_expr | @ql_special_call | @ql_super_ref | @ql_token | @ql_type_alias_body | @ql_type_expr | @ql_type_union_body | @ql_unary_expr | @ql_unqual_agg_body | @ql_var_decl | @ql_var_name | @ql_variable
+
+ql_ast_node_location(
+  unique int node: @ql_ast_node ref,
+  int loc: @location_default ref
+);
+
+#keyset[parent, parent_index]
+ql_ast_node_parent(
+  unique int node: @ql_ast_node ref,
+  int parent: @ql_ast_node ref,
+  int parent_index: int ref
+);
+
+/*- Dbscheme dbscheme -*/
+dbscheme_annotation_args_annotation(
+  unique int dbscheme_annotation: @dbscheme_annotation ref,
+  unique int args_annotation: @dbscheme_args_annotation ref
+);
+
+dbscheme_annotation_simple_annotation(
+  unique int dbscheme_annotation: @dbscheme_annotation ref,
+  unique int simple_annotation: @dbscheme_token_annot_name ref
+);
+
+dbscheme_annotation_def(
+  unique int id: @dbscheme_annotation
+);
+
+#keyset[dbscheme_args_annotation, index]
+dbscheme_args_annotation_child(
+  int dbscheme_args_annotation: @dbscheme_args_annotation ref,
+  int index: int ref,
+  unique int child: @dbscheme_token_simple_id ref
+);
+
+dbscheme_args_annotation_def(
+  unique int id: @dbscheme_args_annotation,
+  int name: @dbscheme_token_annot_name ref
+);
+
+dbscheme_branch_qldoc(
+  unique int dbscheme_branch: @dbscheme_branch ref,
+  unique int qldoc: @dbscheme_token_qldoc ref
+);
+
+@dbscheme_branch_child_type = @dbscheme_token_dbtype | @dbscheme_token_integer
+
+#keyset[dbscheme_branch, index]
+dbscheme_branch_child(
+  int dbscheme_branch: @dbscheme_branch ref,
+  int index: int ref,
+  unique int child: @dbscheme_branch_child_type ref
+);
+
+dbscheme_branch_def(
+  unique int id: @dbscheme_branch
+);
+
+#keyset[dbscheme_case_decl, index]
+dbscheme_case_decl_child(
+  int dbscheme_case_decl: @dbscheme_case_decl ref,
+  int index: int ref,
+  unique int child: @dbscheme_branch ref
+);
+
+dbscheme_case_decl_def(
+  unique int id: @dbscheme_case_decl,
+  int base: @dbscheme_token_dbtype ref,
+  int discriminator: @dbscheme_token_simple_id ref
+);
+
+@dbscheme_colType_child_type = @dbscheme_token_boolean | @dbscheme_token_date | @dbscheme_token_dbtype | @dbscheme_token_float | @dbscheme_token_int | @dbscheme_token_string
+
+dbscheme_col_type_def(
+  unique int id: @dbscheme_col_type,
+  int child: @dbscheme_colType_child_type ref
+);
+
+dbscheme_column_is_ref(
+  unique int dbscheme_column: @dbscheme_column ref,
+  unique int is_ref: @dbscheme_token_ref ref
+);
+
+dbscheme_column_is_unique(
+  unique int dbscheme_column: @dbscheme_column ref,
+  unique int is_unique: @dbscheme_token_unique ref
+);
+
+dbscheme_column_qldoc(
+  unique int dbscheme_column: @dbscheme_column ref,
+  unique int qldoc: @dbscheme_token_qldoc ref
+);
+
+dbscheme_column_def(
+  unique int id: @dbscheme_column,
+  int col_name: @dbscheme_token_simple_id ref,
+  int col_type: @dbscheme_col_type ref,
+  int repr_type: @dbscheme_repr_type ref
+);
+
+#keyset[dbscheme_dbscheme, index]
+dbscheme_dbscheme_child(
+  int dbscheme_dbscheme: @dbscheme_dbscheme ref,
+  int index: int ref,
+  unique int child: @dbscheme_entry ref
+);
+
+dbscheme_dbscheme_def(
+  unique int id: @dbscheme_dbscheme
+);
+
+@dbscheme_entry_child_type = @dbscheme_case_decl | @dbscheme_table | @dbscheme_token_qldoc | @dbscheme_union_decl
+
+dbscheme_entry_def(
+  unique int id: @dbscheme_entry,
+  int child: @dbscheme_entry_child_type ref
+);
+
+@dbscheme_reprType_child_type = @dbscheme_token_boolean | @dbscheme_token_date | @dbscheme_token_float | @dbscheme_token_int | @dbscheme_token_integer | @dbscheme_token_string | @dbscheme_token_varchar
+
+#keyset[dbscheme_repr_type, index]
+dbscheme_repr_type_child(
+  int dbscheme_repr_type: @dbscheme_repr_type ref,
+  int index: int ref,
+  unique int child: @dbscheme_reprType_child_type ref
+);
+
+dbscheme_repr_type_def(
+  unique int id: @dbscheme_repr_type
+);
+
+@dbscheme_table_child_type = @dbscheme_annotation | @dbscheme_column
+
+#keyset[dbscheme_table, index]
+dbscheme_table_child(
+  int dbscheme_table: @dbscheme_table ref,
+  int index: int ref,
+  unique int child: @dbscheme_table_child_type ref
+);
+
+dbscheme_table_def(
+  unique int id: @dbscheme_table,
+  int table_name: @dbscheme_table_name ref
+);
+
+dbscheme_table_name_def(
+  unique int id: @dbscheme_table_name,
+  int child: @dbscheme_token_simple_id ref
+);
+
+#keyset[dbscheme_union_decl, index]
+dbscheme_union_decl_child(
+  int dbscheme_union_decl: @dbscheme_union_decl ref,
+  int index: int ref,
+  unique int child: @dbscheme_token_dbtype ref
+);
+
+dbscheme_union_decl_def(
+  unique int id: @dbscheme_union_decl,
+  int base: @dbscheme_token_dbtype ref
+);
+
+dbscheme_tokeninfo(
+  unique int id: @dbscheme_token,
+  int kind: int ref,
+  string value: string ref
+);
+
+case @dbscheme_token.kind of
+  0 = @dbscheme_reserved_word
+| 1 = @dbscheme_token_annot_name
+| 2 = @dbscheme_token_block_comment
+| 3 = @dbscheme_token_boolean
+| 4 = @dbscheme_token_date
+| 5 = @dbscheme_token_dbtype
+| 6 = @dbscheme_token_float
+| 7 = @dbscheme_token_int
+| 8 = @dbscheme_token_integer
+| 9 = @dbscheme_token_line_comment
+| 10 = @dbscheme_token_qldoc
+| 11 = @dbscheme_token_ref
+| 12 = @dbscheme_token_simple_id
+| 13 = @dbscheme_token_string
+| 14 = @dbscheme_token_unique
+| 15 = @dbscheme_token_varchar
+;
+
+
+@dbscheme_ast_node = @dbscheme_annotation | @dbscheme_args_annotation | @dbscheme_branch | @dbscheme_case_decl | @dbscheme_col_type | @dbscheme_column | @dbscheme_dbscheme | @dbscheme_entry | @dbscheme_repr_type | @dbscheme_table | @dbscheme_table_name | @dbscheme_token | @dbscheme_union_decl
+
+dbscheme_ast_node_location(
+  unique int node: @dbscheme_ast_node ref,
+  int loc: @location_default ref
+);
+
+#keyset[parent, parent_index]
+dbscheme_ast_node_parent(
+  unique int node: @dbscheme_ast_node ref,
+  int parent: @dbscheme_ast_node ref,
+  int parent_index: int ref
+);
+
+/*- Blame dbscheme -*/
+#keyset[blame_blame_entry, index]
+blame_blame_entry_line(
+  int blame_blame_entry: @blame_blame_entry ref,
+  int index: int ref,
+  unique int line: @blame_token_number ref
+);
+
+blame_blame_entry_def(
+  unique int id: @blame_blame_entry,
+  int date__: @blame_token_date ref
+);
+
+#keyset[blame_blame_info, index]
+blame_blame_info_file_entry(
+  int blame_blame_info: @blame_blame_info ref,
+  int index: int ref,
+  unique int file_entry: @blame_file_entry ref
+);
+
+blame_blame_info_def(
+  unique int id: @blame_blame_info,
+  int today: @blame_token_date ref
+);
+
+#keyset[blame_file_entry, index]
+blame_file_entry_blame_entry(
+  int blame_file_entry: @blame_file_entry ref,
+  int index: int ref,
+  unique int blame_entry: @blame_blame_entry ref
+);
+
+blame_file_entry_def(
+  unique int id: @blame_file_entry,
+  int file_name: @blame_token_filename ref
+);
+
+blame_tokeninfo(
+  unique int id: @blame_token,
+  int kind: int ref,
+  string value: string ref
+);
+
+case @blame_token.kind of
+  0 = @blame_reserved_word
+| 1 = @blame_token_date
+| 2 = @blame_token_filename
+| 3 = @blame_token_number
+;
+
+
+@blame_ast_node = @blame_blame_entry | @blame_blame_info | @blame_file_entry | @blame_token
+
+blame_ast_node_location(
+  unique int node: @blame_ast_node ref,
+  int loc: @location_default ref
+);
+
+#keyset[parent, parent_index]
+blame_ast_node_parent(
+  unique int node: @blame_ast_node ref,
+  int parent: @blame_ast_node ref,
+  int parent_index: int ref
+);
+
+/*- JSON dbscheme -*/
+@json_underscore_value = @json_array | @json_object | @json_string__ | @json_token_false | @json_token_null | @json_token_number | @json_token_true
+
+#keyset[json_array, index]
+json_array_child(
+  int json_array: @json_array ref,
+  int index: int ref,
+  unique int child: @json_underscore_value ref
+);
+
+json_array_def(
+  unique int id: @json_array
+);
+
+#keyset[json_document, index]
+json_document_child(
+  int json_document: @json_document ref,
+  int index: int ref,
+  unique int child: @json_underscore_value ref
+);
+
+json_document_def(
+  unique int id: @json_document
+);
+
+#keyset[json_object, index]
+json_object_child(
+  int json_object: @json_object ref,
+  int index: int ref,
+  unique int child: @json_pair ref
+);
+
+json_object_def(
+  unique int id: @json_object
+);
+
+json_pair_def(
+  unique int id: @json_pair,
+  int key__: @json_string__ ref,
+  int value: @json_underscore_value ref
+);
+
+@json_string_child_type = @json_token_escape_sequence | @json_token_string_content
+
+#keyset[json_string__, index]
+json_string_child(
+  int json_string__: @json_string__ ref,
+  int index: int ref,
+  unique int child: @json_string_child_type ref
+);
+
+json_string_def(
+  unique int id: @json_string__
+);
+
+json_tokeninfo(
+  unique int id: @json_token,
+  int kind: int ref,
+  string value: string ref
+);
+
+case @json_token.kind of
+  0 = @json_reserved_word
+| 1 = @json_token_comment
+| 2 = @json_token_escape_sequence
+| 3 = @json_token_false
+| 4 = @json_token_null
+| 5 = @json_token_number
+| 6 = @json_token_string_content
+| 7 = @json_token_true
+;
+
+
+@json_ast_node = @json_array | @json_document | @json_object | @json_pair | @json_string__ | @json_token
+
+json_ast_node_location(
+  unique int node: @json_ast_node ref,
+  int loc: @location_default ref
+);
+
+#keyset[parent, parent_index]
+json_ast_node_parent(
+  unique int node: @json_ast_node ref,
+  int parent: @json_ast_node ref,
+  int parent_index: int ref
+);
+

--- a/ql/ql/lib/upgrades/c50cdd7429a4598cd95f75c82b4ba453007159d9/upgrade.properties
+++ b/ql/ql/lib/upgrades/c50cdd7429a4598cd95f75c82b4ba453007159d9/upgrade.properties
@@ -1,0 +1,2 @@
+description: Extract YAML comments
+compatibility: backwards


### PR DESCRIPTION
In https://github.com/github/codeql/pull/21935 we added support for extraction YAML comments and provided upgrade and downgrade scripts for all languages except for QL.

The lack of upgrade and downgrade scripts is now causing CI failures. This PR adds QL to the list of languages for which the `misc/scripts/prepare-db-upgrade.sh` works and runs it to generate the upgrade and downgrade scripts that would have been generated if it had been run prior to merging https://github.com/github/codeql/pull/21935.