### PR TITLE
Shared/Python: #21935 follow up

### DIFF
--- a/python/extractor/semmle/dbscheme.template
+++ b/python/extractor/semmle/dbscheme.template
@@ -272,13 +272,17 @@ yaml_scalars (unique int scalar: @yaml_scalar_node ref,
               int style: int ref,
               string value: string ref);
 
+yaml_comments (unique int id: @yaml_comment,
+               string text: string ref,
+               string tostring: string ref);
+
 yaml_errors (unique int id: @yaml_error,
              string message: string ref);
 
 yaml_locations(unique int locatable: @yaml_locatable ref,
              int location: @location_default ref);
 
-@yaml_locatable = @yaml_node | @yaml_error;
+@yaml_locatable = @yaml_node | @yaml_error | @yaml_comment;
 
 /*- Python dbscheme -*/
 

--- a/shared/tree-sitter-extractor/src/generator/prefix.dbscheme
+++ b/shared/tree-sitter-extractor/src/generator/prefix.dbscheme
@@ -97,13 +97,17 @@ yaml_scalars (unique int scalar: @yaml_scalar_node ref,
               int style: int ref,
               string value: string ref);
 
+yaml_comments (unique int id: @yaml_comment,
+               string text: string ref,
+               string tostring: string ref);
+
 yaml_errors (unique int id: @yaml_error,
              string message: string ref);
 
 yaml_locations(unique int locatable: @yaml_locatable ref,
              int location: @location_default ref);
 
-@yaml_locatable = @yaml_node | @yaml_error;
+@yaml_locatable = @yaml_node | @yaml_error | @yaml_comment;
 
 /*- Database metadata -*/
 


### PR DESCRIPTION
In #21935 we added support for YAML comment extraction for all languages which support extraction YAML. However, it turns out there some languages generate the dbscheme from other files which I missed in that PR.

This PR fixes up these issues.