### PR TITLE
Cfg: Distinguish parameters from their patterns.

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/controlflow/internal/ControlFlowGraph.qll
+++ b/csharp/ql/lib/semmle/code/csharp/controlflow/internal/ControlFlowGraph.qll
@@ -145,6 +145,8 @@ module Ast implements AstSig<Location> {
   final private class ParameterFinal = CS::Parameter;
 
   class Parameter extends ParameterFinal {
+    AstNode getPattern() { result = this }
+
     Expr getDefaultValue() {
       // Avoid combinatorial explosions for callables with multiple bodies
       result = unique( | | super.getDefaultValue())

--- a/java/ql/lib/semmle/code/java/ControlFlowGraph.qll
+++ b/java/ql/lib/semmle/code/java/ControlFlowGraph.qll
@@ -61,6 +61,8 @@ private module Ast implements AstSig<Location> {
   class Parameter extends AstNode {
     Parameter() { none() }
 
+    AstNode getPattern() { none() }
+
     Expr getDefaultValue() { none() }
   }
 

--- a/shared/controlflow/codeql/controlflow/ControlFlowGraph.qll
+++ b/shared/controlflow/codeql/controlflow/ControlFlowGraph.qll
@@ -52,6 +52,15 @@ signature module AstSig<LocationSig Location> {
 
   /** A parameter of a callable. */
   class Parameter extends AstNode {
+    /**
+     * Gets the pattern associated with this parameter.
+     *
+     * The pattern is included in the CFG while the parameter itself is not.
+     * Although, in simple cases that do not involve destructuring, it is
+     * allowed for the pattern to be equal to the parameter.
+     */
+    AstNode getPattern();
+
     /** Gets the default value of this parameter, if any. */
     Expr getDefaultValue();
   }
@@ -631,7 +640,7 @@ module Make0<LocationSig Location, AstSig<Location> Ast> {
         or
         n = any(Case case).getPattern(_)
         or
-        exists(n.(Parameter).getDefaultValue())
+        exists(Parameter p | exists(p.getDefaultValue()) and n = p.getPattern())
       )
     }
 
@@ -803,24 +812,27 @@ module Make0<LocationSig Location, AstSig<Location> Ast> {
       )
     }
 
+    private predicate hasCfg(AstNode n) {
+      exists(getEnclosingCallable(n)) and
+      (n instanceof Parameter implies n = n.(Parameter).getPattern())
+    }
+
     cached
     private newtype TNode =
-      TBeforeNode(AstNode n) { Input1::cfgCachedStageRef() and exists(getEnclosingCallable(n)) } or
-      TAstNode(AstNode n) { postOrInOrder(n) and exists(getEnclosingCallable(n)) } or
+      TBeforeNode(AstNode n) { Input1::cfgCachedStageRef() and hasCfg(n) } or
+      TAstNode(AstNode n) { postOrInOrder(n) and hasCfg(n) } or
       TAfterValueNode(AstNode n, ConditionalSuccessor t) {
         inConditionalContext(n, t.getKind()) and
-        exists(getEnclosingCallable(n)) and
+        hasCfg(n) and
         not constantCondition(n, t.getDual())
       } or
       TAfterNode(AstNode n) {
-        exists(getEnclosingCallable(n)) and
+        hasCfg(n) and
         not inConditionalContext(n, _) and
         not cannotTerminateNormally(n) and
         not simpleLeafNode(n)
       } or
-      TAdditionalNode(AstNode n, string tag) {
-        additionalNode(n, tag, _) and exists(getEnclosingCallable(n))
-      } or
+      TAdditionalNode(AstNode n, string tag) { additionalNode(n, tag, _) and hasCfg(n) } or
       TEntryNode(Callable c) { callableHasBodyPart(c, _) } or
       TAnnotatedExitNode(Callable c, Boolean normal) { callableHasBodyPart(c, _) } or
       TExitNode(Callable c) { callableHasBodyPart(c, _) }
@@ -1390,8 +1402,8 @@ module Make0<LocationSig Location, AstSig<Location> Ast> {
       }
 
       pragma[nomagic]
-      private AstNode getParameterOrBodyEntry(Callable c, CallableContextOption ctx, int i) {
-        result = getRankedParameter(c, ctx, i)
+      private AstNode getParameterPatternOrBodyEntry(Callable c, CallableContextOption ctx, int i) {
+        result = getRankedParameter(c, ctx, i).getPattern()
         or
         (
           not exists(getRankedParameter(c, _, _)) and
@@ -1409,18 +1421,18 @@ module Make0<LocationSig Location, AstSig<Location> Ast> {
         or
         exists(Callable c |
           n1.(EntryNodeImpl).getEnclosingCallable() = c and
-          n2.isBefore(getParameterOrBodyEntry(c, _, 1))
+          n2.isBefore(getParameterPatternOrBodyEntry(c, _, 1))
           or
           exists(CallableContextOption ctx, Parameter p, int i | p = getRankedParameter(c, ctx, i) |
             exists(MatchingSuccessor t |
-              n1.isAfterValue(p, t) and
+              n1.isAfterValue(p.getPattern(), t) and
               if t.isMatch()
-              then n2.isBefore(getParameterOrBodyEntry(c, ctx, i + 1))
+              then n2.isBefore(getParameterPatternOrBodyEntry(c, ctx, i + 1))
               else n2.isBefore(p.getDefaultValue())
             )
             or
             n1.isAfter(p.getDefaultValue()) and
-            n2.isBefore(getParameterOrBodyEntry(c, ctx, i + 1))
+            n2.isBefore(getParameterPatternOrBodyEntry(c, ctx, i + 1))
           )
           or
           exists(Input1::CallableContext ctx, int i |
@@ -1796,6 +1808,7 @@ module Make0<LocationSig Location, AstSig<Location> Ast> {
        * and therefore should use default left-to-right evaluation.
        */
       private predicate defaultCfg(AstNode ast) {
+        hasCfg(ast) and
         not explicitStep(any(PreControlFlowNode n | n.isBefore(ast)), _)
       }
 


### PR DESCRIPTION
This moves the AST signature for parameters in the CFG lib closer to the unified AST and fits more closely with Ruby.