### PR TITLE
Java: model LDAP bind-DN sinks for java/ldap-injection

### DIFF
--- a/java/ql/lib/change-notes/2026-06-18-ldap-bind-dn-sinks.md
+++ b/java/ql/lib/change-notes/2026-06-18-ldap-bind-dn-sinks.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added LDAP bind-DN sinks to the `java/ldap-injection` query: the `String name` argument of `javax.naming.Context` / `javax.naming.directory.DirContext` `bind`, `rebind`, `lookup`, `lookupLink`, and `createSubcontext`; the `java.naming.security.principal` JNDI environment value; and the `principal` argument of Apache Shiro `LdapContextFactory.getLdapContext`. The query now detects LDAP distinguished-name injection (CWE-90) into a bind DN, not just into a search filter or search base. `new javax.naming.ldap.LdapName(String)` is deliberately not modelled as a sink, as it commonly parses an existing certificate or principal DN rather than constructing one for a bind.

--- a/java/ql/lib/ext/javax.naming.directory.model.yml
+++ b/java/ql/lib/ext/javax.naming.directory.model.yml
@@ -17,3 +17,10 @@ extensions:
       extensible: sinkModel
     data:
       - ["javax.naming.directory", "DirContext", True, "search", "", "", "Argument[0..1]", "ldap-injection", "manual"]
+      # The `String name` argument is interpreted as a (distinguished) name; an
+      # unescaped, attacker-controlled value lets the caller manipulate the bind DN
+      # (LDAP DN injection, CWE-90). Only the `(String,...)` overloads matter -- the
+      # `(Name,...)` overloads take a structured, already-parsed name.
+      - ["javax.naming.directory", "DirContext", True, "bind", "(String,Object,Attributes)", "", "Argument[0]", "ldap-injection", "manual"]
+      - ["javax.naming.directory", "DirContext", True, "rebind", "(String,Object,Attributes)", "", "Argument[0]", "ldap-injection", "manual"]
+      - ["javax.naming.directory", "DirContext", True, "createSubcontext", "(String,Attributes)", "", "Argument[0]", "ldap-injection", "manual"]

--- a/java/ql/lib/ext/javax.naming.model.yml
+++ b/java/ql/lib/ext/javax.naming.model.yml
@@ -9,6 +9,17 @@ extensions:
       - ["javax.naming", "Context", True, "lookupLink", "", "", "Argument[0]", "jndi-injection", "manual"]
       - ["javax.naming", "Context", True, "rename", "", "", "Argument[0]", "jndi-injection", "manual"]
       - ["javax.naming", "InitialContext", True, "doLookup", "", "", "Argument[0]", "jndi-injection", "manual"]
+      # The `String name` argument of these methods is interpreted as a (distinguished)
+      # name; an unescaped, attacker-controlled value lets the caller manipulate the
+      # bind DN (LDAP DN injection, CWE-90). `bind`/`rebind`/`createSubcontext` create
+      # an entry at the given DN; `lookup`/`lookupLink` resolve it (e.g. to authenticate
+      # a bind DN). Only the `(String,...)` overloads matter -- the `(Name,...)`
+      # overloads take a structured, already-parsed name.
+      - ["javax.naming", "Context", True, "bind", "(String,Object)", "", "Argument[0]", "ldap-injection", "manual"]
+      - ["javax.naming", "Context", True, "rebind", "(String,Object)", "", "Argument[0]", "ldap-injection", "manual"]
+      - ["javax.naming", "Context", True, "createSubcontext", "(String)", "", "Argument[0]", "ldap-injection", "manual"]
+      - ["javax.naming", "Context", True, "lookup", "(String)", "", "Argument[0]", "ldap-injection", "manual"]
+      - ["javax.naming", "Context", True, "lookupLink", "(String)", "", "Argument[0]", "ldap-injection", "manual"]
 
   - addsTo:
       pack: codeql/java-all

--- a/java/ql/lib/ext/org.apache.shiro.realm.ldap.model.yml
+++ b/java/ql/lib/ext/org.apache.shiro.realm.ldap.model.yml
@@ -1,0 +1,12 @@
+extensions:
+  - addsTo:
+      pack: codeql/java-all
+      extensible: sinkModel
+    data:
+      # `LdapContextFactory.getLdapContext(principal, credentials)` binds to the
+      # directory using `principal` as the bind DN. An unescaped, attacker-controlled
+      # principal lets the caller manipulate the DN structure (LDAP DN injection,
+      # CWE-90). This is the sink in Apache Shiro CVE-2026-49268, where
+      # `DefaultLdapRealm.getUserDn` / `ActiveDirectoryRealm.getUsernameWithSuffix`
+      # concatenated the login username into the bind DN with no `Rdn.escapeValue`.
+      - ["org.apache.shiro.realm.ldap", "LdapContextFactory", True, "getLdapContext", "(Object,Object)", "", "Argument[0]", "ldap-injection", "manual"]

--- a/java/ql/lib/semmle/code/java/security/LdapInjection.qll
+++ b/java/ql/lib/semmle/code/java/security/LdapInjection.qll
@@ -35,6 +35,39 @@ private class DefaultLdapInjectionSink extends LdapInjectionSink {
   DefaultLdapInjectionSink() { sinkNode(this, "ldap-injection") }
 }
 
+/**
+ * The value of a `java.naming.security.principal` JNDI environment entry, i.e. the
+ * `value` argument of a `Hashtable`/`Map.put(key, value)` whose key is the
+ * `javax.naming.Context.SECURITY_PRINCIPAL` constant or the literal string
+ * `"java.naming.security.principal"`.
+ *
+ * This entry is the bind DN used to authenticate the directory connection. An
+ * unescaped, attacker-controlled value lets the caller manipulate the DN structure
+ * (LDAP DN injection, CWE-90). This pattern cannot be expressed as a Models-as-Data
+ * sink because it depends on the value of the `key` argument rather than the method
+ * signature.
+ *
+ * Note: `new javax.naming.ldap.LdapName(String)` is deliberately not modelled as a
+ * sink. It over-fires on the benign idiom of parsing an existing certificate or
+ * principal DN to read its RDNs (e.g.
+ * `new LdapName(cert.getSubjectX500Principal().getName()).getRdns()`), which is not
+ * injection. The injection sinks are the positions where a DN string is used to bind,
+ * look up, or authenticate.
+ */
+private class SecurityPrincipalEnvSink extends LdapInjectionSink {
+  SecurityPrincipalEnvSink() {
+    exists(MethodCall ma |
+      ma.getMethod().hasName("put") and
+      this.asExpr() = ma.getArgument(1)
+    |
+      ma.getArgument(0).(FieldRead).getField().hasName("SECURITY_PRINCIPAL")
+      or
+      ma.getArgument(0).(CompileTimeConstantExpr).getStringValue() =
+        "java.naming.security.principal"
+    )
+  }
+}
+
 /** A sanitizer that clears the taint on (boxed) primitive types. */
 private class DefaultLdapSanitizer extends LdapInjectionSanitizer instanceof SimpleTypeSanitizer { }
 

--- a/java/ql/test/query-tests/security/CWE-090/LdapInjection.expected
+++ b/java/ql/test/query-tests/security/CWE-090/LdapInjection.expected
@@ -1,216 +1,227 @@
 #select
-| LdapInjection.java:47:16:47:35 | ... + ... | LdapInjection.java:45:55:45:81 | jBadDN : String | LdapInjection.java:47:16:47:35 | ... + ... | This LDAP query depends on a $@. | LdapInjection.java:45:55:45:81 | jBadDN | user-provided value |
-| LdapInjection.java:47:38:47:57 | ... + ... | LdapInjection.java:45:28:45:52 | jBad : String | LdapInjection.java:47:38:47:57 | ... + ... | This LDAP query depends on a $@. | LdapInjection.java:45:28:45:52 | jBad | user-provided value |
-| LdapInjection.java:53:16:53:53 | new LdapName(...) | LdapInjection.java:51:55:51:85 | jBadDNName : String | LdapInjection.java:53:16:53:53 | new LdapName(...) | This LDAP query depends on a $@. | LdapInjection.java:51:55:51:85 | jBadDNName | user-provided value |
-| LdapInjection.java:53:56:53:75 | ... + ... | LdapInjection.java:51:28:51:52 | jBad : String | LdapInjection.java:53:56:53:75 | ... + ... | This LDAP query depends on a $@. | LdapInjection.java:51:28:51:52 | jBad | user-provided value |
-| LdapInjection.java:59:63:59:82 | ... + ... | LdapInjection.java:57:28:57:52 | jBad : String | LdapInjection.java:59:63:59:82 | ... + ... | This LDAP query depends on a $@. | LdapInjection.java:57:28:57:52 | jBad | user-provided value |
-| LdapInjection.java:65:29:65:55 | ... + ... | LdapInjection.java:63:28:63:59 | jBadInitial : String | LdapInjection.java:65:29:65:55 | ... + ... | This LDAP query depends on a $@. | LdapInjection.java:63:28:63:59 | jBadInitial | user-provided value |
-| LdapInjection.java:71:16:71:81 | addAll(...) | LdapInjection.java:69:55:69:88 | jBadDNNameAdd : String | LdapInjection.java:71:16:71:81 | addAll(...) | This LDAP query depends on a $@. | LdapInjection.java:69:55:69:88 | jBadDNNameAdd | user-provided value |
-| LdapInjection.java:71:84:71:103 | ... + ... | LdapInjection.java:69:28:69:52 | jBad : String | LdapInjection.java:71:84:71:103 | ... + ... | This LDAP query depends on a $@. | LdapInjection.java:69:28:69:52 | jBad | user-provided value |
-| LdapInjection.java:79:16:79:44 | addAll(...) | LdapInjection.java:75:55:75:89 | jBadDNNameAdd2 : String | LdapInjection.java:79:16:79:44 | addAll(...) | This LDAP query depends on a $@. | LdapInjection.java:75:55:75:89 | jBadDNNameAdd2 | user-provided value |
-| LdapInjection.java:79:47:79:66 | ... + ... | LdapInjection.java:75:28:75:52 | jBad : String | LdapInjection.java:79:47:79:66 | ... + ... | This LDAP query depends on a $@. | LdapInjection.java:75:28:75:52 | jBad | user-provided value |
-| LdapInjection.java:85:16:85:72 | toString(...) | LdapInjection.java:83:55:83:93 | jBadDNNameToString : String | LdapInjection.java:85:16:85:72 | toString(...) | This LDAP query depends on a $@. | LdapInjection.java:83:55:83:93 | jBadDNNameToString | user-provided value |
-| LdapInjection.java:85:75:85:94 | ... + ... | LdapInjection.java:83:28:83:52 | jBad : String | LdapInjection.java:85:75:85:94 | ... + ... | This LDAP query depends on a $@. | LdapInjection.java:83:28:83:52 | jBad | user-provided value |
-| LdapInjection.java:91:16:91:73 | (...)... | LdapInjection.java:89:55:89:90 | jBadDNNameClone : String | LdapInjection.java:91:16:91:73 | (...)... | This LDAP query depends on a $@. | LdapInjection.java:89:55:89:90 | jBadDNNameClone | user-provided value |
-| LdapInjection.java:91:76:91:95 | ... + ... | LdapInjection.java:89:28:89:52 | jBad : String | LdapInjection.java:91:76:91:95 | ... + ... | This LDAP query depends on a $@. | LdapInjection.java:89:28:89:52 | jBad | user-provided value |
-| LdapInjection.java:101:29:101:75 | new BasicAttributes(...) | LdapInjection.java:100:27:100:59 | jOkAttribute : String | LdapInjection.java:101:29:101:75 | new BasicAttributes(...) | This LDAP query depends on a $@. | LdapInjection.java:100:27:100:59 | jOkAttribute | user-provided value |
-| LdapInjection.java:108:20:108:39 | ... + ... | LdapInjection.java:106:58:106:84 | uBadDN : String | LdapInjection.java:108:20:108:39 | ... + ... | This LDAP query depends on a $@. | LdapInjection.java:106:58:106:84 | uBadDN | user-provided value |
-| LdapInjection.java:108:67:108:86 | ... + ... | LdapInjection.java:106:31:106:55 | uBad : String | LdapInjection.java:108:67:108:86 | ... + ... | This LDAP query depends on a $@. | LdapInjection.java:106:31:106:55 | uBad | user-provided value |
-| LdapInjection.java:113:58:113:88 | create(...) | LdapInjection.java:112:31:112:67 | uBadFilterCreate : String | LdapInjection.java:113:58:113:88 | create(...) | This LDAP query depends on a $@. | LdapInjection.java:112:31:112:67 | uBadFilterCreate | user-provided value |
-| LdapInjection.java:121:14:121:14 | s | LdapInjection.java:117:31:117:70 | uBadROSearchRequest : String | LdapInjection.java:121:14:121:14 | s | This LDAP query depends on a $@. | LdapInjection.java:117:31:117:70 | uBadROSearchRequest | user-provided value |
-| LdapInjection.java:121:14:121:14 | s | LdapInjection.java:117:73:117:103 | uBadROSRDN : String | LdapInjection.java:121:14:121:14 | s | This LDAP query depends on a $@. | LdapInjection.java:117:73:117:103 | uBadROSRDN | user-provided value |
-| LdapInjection.java:129:14:129:14 | s | LdapInjection.java:125:31:125:68 | uBadSearchRequest : String | LdapInjection.java:129:14:129:14 | s | This LDAP query depends on a $@. | LdapInjection.java:125:31:125:68 | uBadSearchRequest | user-provided value |
-| LdapInjection.java:129:14:129:14 | s | LdapInjection.java:125:71:125:99 | uBadSRDN : String | LdapInjection.java:129:14:129:14 | s | This LDAP query depends on a $@. | LdapInjection.java:125:71:125:99 | uBadSRDN | user-provided value |
-| LdapInjection.java:135:22:135:44 | ... + ... | LdapInjection.java:133:58:133:87 | uBadDNSFR : String | LdapInjection.java:135:22:135:44 | ... + ... | This LDAP query depends on a $@. | LdapInjection.java:133:58:133:87 | uBadDNSFR | user-provided value |
-| LdapInjection.java:135:69:135:88 | ... + ... | LdapInjection.java:133:31:133:55 | uBad : String | LdapInjection.java:135:69:135:88 | ... + ... | This LDAP query depends on a $@. | LdapInjection.java:133:31:133:55 | uBad | user-provided value |
-| LdapInjection.java:143:19:143:19 | s | LdapInjection.java:139:31:139:75 | uBadROSearchRequestAsync : String | LdapInjection.java:143:19:143:19 | s | This LDAP query depends on a $@. | LdapInjection.java:139:31:139:75 | uBadROSearchRequestAsync | user-provided value |
-| LdapInjection.java:143:19:143:19 | s | LdapInjection.java:139:78:139:113 | uBadROSRDNAsync : String | LdapInjection.java:143:19:143:19 | s | This LDAP query depends on a $@. | LdapInjection.java:139:78:139:113 | uBadROSRDNAsync | user-provided value |
-| LdapInjection.java:151:19:151:19 | s | LdapInjection.java:147:31:147:73 | uBadSearchRequestAsync : String | LdapInjection.java:151:19:151:19 | s | This LDAP query depends on a $@. | LdapInjection.java:147:31:147:73 | uBadSearchRequestAsync | user-provided value |
-| LdapInjection.java:151:19:151:19 | s | LdapInjection.java:147:76:147:109 | uBadSRDNAsync : String | LdapInjection.java:151:19:151:19 | s | This LDAP query depends on a $@. | LdapInjection.java:147:76:147:109 | uBadSRDNAsync | user-provided value |
-| LdapInjection.java:156:58:156:115 | createNOTFilter(...) | LdapInjection.java:155:31:155:70 | uBadFilterCreateNOT : String | LdapInjection.java:156:58:156:115 | createNOTFilter(...) | This LDAP query depends on a $@. | LdapInjection.java:155:31:155:70 | uBadFilterCreateNOT | user-provided value |
-| LdapInjection.java:161:58:161:107 | toString(...) | LdapInjection.java:160:31:160:75 | uBadFilterCreateToString : String | LdapInjection.java:161:58:161:107 | toString(...) | This LDAP query depends on a $@. | LdapInjection.java:160:31:160:75 | uBadFilterCreateToString | user-provided value |
-| LdapInjection.java:168:58:168:69 | toString(...) | LdapInjection.java:165:32:165:82 | uBadFilterCreateToStringBuffer : String | LdapInjection.java:168:58:168:69 | toString(...) | This LDAP query depends on a $@. | LdapInjection.java:165:32:165:82 | uBadFilterCreateToStringBuffer | user-provided value |
-| LdapInjection.java:176:14:176:26 | duplicate(...) | LdapInjection.java:172:32:172:78 | uBadSearchRequestDuplicate : String | LdapInjection.java:176:14:176:26 | duplicate(...) | This LDAP query depends on a $@. | LdapInjection.java:172:32:172:78 | uBadSearchRequestDuplicate | user-provided value |
-| LdapInjection.java:184:14:184:26 | duplicate(...) | LdapInjection.java:180:32:180:80 | uBadROSearchRequestDuplicate : String | LdapInjection.java:184:14:184:26 | duplicate(...) | This LDAP query depends on a $@. | LdapInjection.java:180:32:180:80 | uBadROSearchRequestDuplicate | user-provided value |
-| LdapInjection.java:192:14:192:14 | s | LdapInjection.java:188:32:188:74 | uBadSearchRequestSetDN : String | LdapInjection.java:192:14:192:14 | s | This LDAP query depends on a $@. | LdapInjection.java:188:32:188:74 | uBadSearchRequestSetDN | user-provided value |
-| LdapInjection.java:200:14:200:14 | s | LdapInjection.java:196:32:196:78 | uBadSearchRequestSetFilter : String | LdapInjection.java:200:14:200:14 | s | This LDAP query depends on a $@. | LdapInjection.java:196:32:196:78 | uBadSearchRequestSetFilter | user-provided value |
-| LdapInjection.java:230:14:230:33 | ... + ... | LdapInjection.java:229:57:229:83 | sBadDN : String | LdapInjection.java:230:14:230:33 | ... + ... | This LDAP query depends on a $@. | LdapInjection.java:229:57:229:83 | sBadDN | user-provided value |
-| LdapInjection.java:230:36:230:55 | ... + ... | LdapInjection.java:229:30:229:54 | sBad : String | LdapInjection.java:230:36:230:55 | ... + ... | This LDAP query depends on a $@. | LdapInjection.java:229:30:229:54 | sBad | user-provided value |
-| LdapInjection.java:235:20:235:85 | build(...) | LdapInjection.java:234:57:234:92 | sBadDNLNBuilder : String | LdapInjection.java:235:20:235:85 | build(...) | This LDAP query depends on a $@. | LdapInjection.java:234:57:234:92 | sBadDNLNBuilder | user-provided value |
-| LdapInjection.java:235:88:235:107 | ... + ... | LdapInjection.java:234:30:234:54 | sBad : String | LdapInjection.java:235:88:235:107 | ... + ... | This LDAP query depends on a $@. | LdapInjection.java:234:30:234:54 | sBad | user-provided value |
-| LdapInjection.java:240:23:240:97 | build(...) | LdapInjection.java:239:57:239:95 | sBadDNLNBuilderAdd : String | LdapInjection.java:240:23:240:97 | build(...) | This LDAP query depends on a $@. | LdapInjection.java:239:57:239:95 | sBadDNLNBuilderAdd | user-provided value |
-| LdapInjection.java:240:100:240:119 | ... + ... | LdapInjection.java:239:30:239:54 | sBad : String | LdapInjection.java:240:100:240:119 | ... + ... | This LDAP query depends on a $@. | LdapInjection.java:239:30:239:54 | sBad | user-provided value |
-| LdapInjection.java:245:15:245:76 | filter(...) | LdapInjection.java:244:30:244:63 | sBadLdapQuery : String | LdapInjection.java:245:15:245:76 | filter(...) | This LDAP query depends on a $@. | LdapInjection.java:244:30:244:63 | sBadLdapQuery | user-provided value |
-| LdapInjection.java:250:12:250:63 | newLdapName(...) | LdapInjection.java:249:63:249:98 | sBadDNLdapUtils : String | LdapInjection.java:250:12:250:63 | newLdapName(...) | This LDAP query depends on a $@. | LdapInjection.java:249:63:249:98 | sBadDNLdapUtils | user-provided value |
-| LdapInjection.java:250:66:250:112 | new HardcodedFilter(...) | LdapInjection.java:249:30:249:60 | sBadFilter : String | LdapInjection.java:250:66:250:112 | new HardcodedFilter(...) | This LDAP query depends on a $@. | LdapInjection.java:249:30:249:60 | sBadFilter | user-provided value |
-| LdapInjection.java:255:24:255:85 | filter(...) | LdapInjection.java:254:30:254:63 | sBadLdapQuery : String | LdapInjection.java:255:24:255:85 | filter(...) | This LDAP query depends on a $@. | LdapInjection.java:254:30:254:63 | sBadLdapQuery | user-provided value |
-| LdapInjection.java:261:24:261:24 | q | LdapInjection.java:259:30:259:64 | sBadLdapQuery2 : String | LdapInjection.java:261:24:261:24 | q | This LDAP query depends on a $@. | LdapInjection.java:259:30:259:64 | sBadLdapQuery2 | user-provided value |
-| LdapInjection.java:266:24:266:116 | filter(...) | LdapInjection.java:265:30:265:73 | sBadLdapQueryWithFilter : String | LdapInjection.java:266:24:266:116 | filter(...) | This LDAP query depends on a $@. | LdapInjection.java:265:30:265:73 | sBadLdapQueryWithFilter | user-provided value |
-| LdapInjection.java:272:24:272:57 | filter(...) | LdapInjection.java:270:30:270:74 | sBadLdapQueryWithFilter2 : String | LdapInjection.java:272:24:272:57 | filter(...) | This LDAP query depends on a $@. | LdapInjection.java:270:30:270:74 | sBadLdapQueryWithFilter2 | user-provided value |
-| LdapInjection.java:277:12:277:66 | base(...) | LdapInjection.java:276:31:276:68 | sBadLdapQueryBase : String | LdapInjection.java:277:12:277:66 | base(...) | This LDAP query depends on a $@. | LdapInjection.java:276:31:276:68 | sBadLdapQueryBase | user-provided value |
-| LdapInjection.java:282:24:282:98 | is(...) | LdapInjection.java:281:31:281:71 | sBadLdapQueryComplex : String | LdapInjection.java:282:24:282:98 | is(...) | This LDAP query depends on a $@. | LdapInjection.java:281:31:281:71 | sBadLdapQueryComplex | user-provided value |
-| LdapInjection.java:287:18:287:83 | toString(...) | LdapInjection.java:286:31:286:69 | sBadFilterToString : String | LdapInjection.java:287:18:287:83 | toString(...) | This LDAP query depends on a $@. | LdapInjection.java:286:31:286:69 | sBadFilterToString | user-provided value |
-| LdapInjection.java:294:18:294:29 | toString(...) | LdapInjection.java:291:31:291:67 | sBadFilterEncode : String | LdapInjection.java:294:18:294:29 | toString(...) | This LDAP query depends on a $@. | LdapInjection.java:291:31:291:67 | sBadFilterEncode | user-provided value |
-| LdapInjection.java:316:14:316:33 | ... + ... | LdapInjection.java:314:57:314:83 | aBadDN : String | LdapInjection.java:316:14:316:33 | ... + ... | This LDAP query depends on a $@. | LdapInjection.java:314:57:314:83 | aBadDN | user-provided value |
-| LdapInjection.java:316:36:316:55 | ... + ... | LdapInjection.java:314:30:314:54 | aBad : String | LdapInjection.java:316:36:316:55 | ... + ... | This LDAP query depends on a $@. | LdapInjection.java:314:30:314:54 | aBad | user-provided value |
-| LdapInjection.java:322:14:322:62 | getName(...) | LdapInjection.java:320:57:320:94 | aBadDNObjToString : String | LdapInjection.java:322:14:322:62 | getName(...) | This LDAP query depends on a $@. | LdapInjection.java:320:57:320:94 | aBadDNObjToString | user-provided value |
-| LdapInjection.java:322:65:322:84 | ... + ... | LdapInjection.java:320:30:320:54 | aBad : String | LdapInjection.java:322:65:322:84 | ... + ... | This LDAP query depends on a $@. | LdapInjection.java:320:30:320:54 | aBad | user-provided value |
-| LdapInjection.java:330:14:330:14 | s | LdapInjection.java:326:30:326:67 | aBadSearchRequest : String | LdapInjection.java:330:14:330:14 | s | This LDAP query depends on a $@. | LdapInjection.java:326:30:326:67 | aBadSearchRequest | user-provided value |
-| LdapInjection.java:338:14:338:14 | s | LdapInjection.java:334:74:334:103 | aBadDNObj : String | LdapInjection.java:338:14:338:14 | s | This LDAP query depends on a $@. | LdapInjection.java:334:74:334:103 | aBadDNObj | user-provided value |
-| LdapInjection.java:346:14:346:24 | getBase(...) | LdapInjection.java:342:30:342:72 | aBadDNSearchRequestGet : String | LdapInjection.java:346:14:346:24 | getBase(...) | This LDAP query depends on a $@. | LdapInjection.java:342:30:342:72 | aBadDNSearchRequestGet | user-provided value |
+| LdapInjection.java:52:16:52:35 | ... + ... | LdapInjection.java:50:55:50:81 | jBadDN : String | LdapInjection.java:52:16:52:35 | ... + ... | This LDAP query depends on a $@. | LdapInjection.java:50:55:50:81 | jBadDN | user-provided value |
+| LdapInjection.java:52:38:52:57 | ... + ... | LdapInjection.java:50:28:50:52 | jBad : String | LdapInjection.java:52:38:52:57 | ... + ... | This LDAP query depends on a $@. | LdapInjection.java:50:28:50:52 | jBad | user-provided value |
+| LdapInjection.java:58:16:58:53 | new LdapName(...) | LdapInjection.java:56:55:56:85 | jBadDNName : String | LdapInjection.java:58:16:58:53 | new LdapName(...) | This LDAP query depends on a $@. | LdapInjection.java:56:55:56:85 | jBadDNName | user-provided value |
+| LdapInjection.java:58:56:58:75 | ... + ... | LdapInjection.java:56:28:56:52 | jBad : String | LdapInjection.java:58:56:58:75 | ... + ... | This LDAP query depends on a $@. | LdapInjection.java:56:28:56:52 | jBad | user-provided value |
+| LdapInjection.java:64:63:64:82 | ... + ... | LdapInjection.java:62:28:62:52 | jBad : String | LdapInjection.java:64:63:64:82 | ... + ... | This LDAP query depends on a $@. | LdapInjection.java:62:28:62:52 | jBad | user-provided value |
+| LdapInjection.java:70:29:70:55 | ... + ... | LdapInjection.java:68:28:68:59 | jBadInitial : String | LdapInjection.java:70:29:70:55 | ... + ... | This LDAP query depends on a $@. | LdapInjection.java:68:28:68:59 | jBadInitial | user-provided value |
+| LdapInjection.java:76:16:76:81 | addAll(...) | LdapInjection.java:74:55:74:88 | jBadDNNameAdd : String | LdapInjection.java:76:16:76:81 | addAll(...) | This LDAP query depends on a $@. | LdapInjection.java:74:55:74:88 | jBadDNNameAdd | user-provided value |
+| LdapInjection.java:76:84:76:103 | ... + ... | LdapInjection.java:74:28:74:52 | jBad : String | LdapInjection.java:76:84:76:103 | ... + ... | This LDAP query depends on a $@. | LdapInjection.java:74:28:74:52 | jBad | user-provided value |
+| LdapInjection.java:84:16:84:44 | addAll(...) | LdapInjection.java:80:55:80:89 | jBadDNNameAdd2 : String | LdapInjection.java:84:16:84:44 | addAll(...) | This LDAP query depends on a $@. | LdapInjection.java:80:55:80:89 | jBadDNNameAdd2 | user-provided value |
+| LdapInjection.java:84:47:84:66 | ... + ... | LdapInjection.java:80:28:80:52 | jBad : String | LdapInjection.java:84:47:84:66 | ... + ... | This LDAP query depends on a $@. | LdapInjection.java:80:28:80:52 | jBad | user-provided value |
+| LdapInjection.java:90:16:90:72 | toString(...) | LdapInjection.java:88:55:88:93 | jBadDNNameToString : String | LdapInjection.java:90:16:90:72 | toString(...) | This LDAP query depends on a $@. | LdapInjection.java:88:55:88:93 | jBadDNNameToString | user-provided value |
+| LdapInjection.java:90:75:90:94 | ... + ... | LdapInjection.java:88:28:88:52 | jBad : String | LdapInjection.java:90:75:90:94 | ... + ... | This LDAP query depends on a $@. | LdapInjection.java:88:28:88:52 | jBad | user-provided value |
+| LdapInjection.java:96:16:96:73 | (...)... | LdapInjection.java:94:55:94:90 | jBadDNNameClone : String | LdapInjection.java:96:16:96:73 | (...)... | This LDAP query depends on a $@. | LdapInjection.java:94:55:94:90 | jBadDNNameClone | user-provided value |
+| LdapInjection.java:96:76:96:95 | ... + ... | LdapInjection.java:94:28:94:52 | jBad : String | LdapInjection.java:96:76:96:95 | ... + ... | This LDAP query depends on a $@. | LdapInjection.java:94:28:94:52 | jBad | user-provided value |
+| LdapInjection.java:106:29:106:75 | new BasicAttributes(...) | LdapInjection.java:105:27:105:59 | jOkAttribute : String | LdapInjection.java:106:29:106:75 | new BasicAttributes(...) | This LDAP query depends on a $@. | LdapInjection.java:105:27:105:59 | jOkAttribute | user-provided value |
+| LdapInjection.java:113:20:113:39 | ... + ... | LdapInjection.java:111:58:111:84 | uBadDN : String | LdapInjection.java:113:20:113:39 | ... + ... | This LDAP query depends on a $@. | LdapInjection.java:111:58:111:84 | uBadDN | user-provided value |
+| LdapInjection.java:113:67:113:86 | ... + ... | LdapInjection.java:111:31:111:55 | uBad : String | LdapInjection.java:113:67:113:86 | ... + ... | This LDAP query depends on a $@. | LdapInjection.java:111:31:111:55 | uBad | user-provided value |
+| LdapInjection.java:118:58:118:88 | create(...) | LdapInjection.java:117:31:117:67 | uBadFilterCreate : String | LdapInjection.java:118:58:118:88 | create(...) | This LDAP query depends on a $@. | LdapInjection.java:117:31:117:67 | uBadFilterCreate | user-provided value |
+| LdapInjection.java:126:14:126:14 | s | LdapInjection.java:122:31:122:70 | uBadROSearchRequest : String | LdapInjection.java:126:14:126:14 | s | This LDAP query depends on a $@. | LdapInjection.java:122:31:122:70 | uBadROSearchRequest | user-provided value |
+| LdapInjection.java:126:14:126:14 | s | LdapInjection.java:122:73:122:103 | uBadROSRDN : String | LdapInjection.java:126:14:126:14 | s | This LDAP query depends on a $@. | LdapInjection.java:122:73:122:103 | uBadROSRDN | user-provided value |
+| LdapInjection.java:134:14:134:14 | s | LdapInjection.java:130:31:130:68 | uBadSearchRequest : String | LdapInjection.java:134:14:134:14 | s | This LDAP query depends on a $@. | LdapInjection.java:130:31:130:68 | uBadSearchRequest | user-provided value |
+| LdapInjection.java:134:14:134:14 | s | LdapInjection.java:130:71:130:99 | uBadSRDN : String | LdapInjection.java:134:14:134:14 | s | This LDAP query depends on a $@. | LdapInjection.java:130:71:130:99 | uBadSRDN | user-provided value |
+| LdapInjection.java:140:22:140:44 | ... + ... | LdapInjection.java:138:58:138:87 | uBadDNSFR : String | LdapInjection.java:140:22:140:44 | ... + ... | This LDAP query depends on a $@. | LdapInjection.java:138:58:138:87 | uBadDNSFR | user-provided value |
+| LdapInjection.java:140:69:140:88 | ... + ... | LdapInjection.java:138:31:138:55 | uBad : String | LdapInjection.java:140:69:140:88 | ... + ... | This LDAP query depends on a $@. | LdapInjection.java:138:31:138:55 | uBad | user-provided value |
+| LdapInjection.java:148:19:148:19 | s | LdapInjection.java:144:31:144:75 | uBadROSearchRequestAsync : String | LdapInjection.java:148:19:148:19 | s | This LDAP query depends on a $@. | LdapInjection.java:144:31:144:75 | uBadROSearchRequestAsync | user-provided value |
+| LdapInjection.java:148:19:148:19 | s | LdapInjection.java:144:78:144:113 | uBadROSRDNAsync : String | LdapInjection.java:148:19:148:19 | s | This LDAP query depends on a $@. | LdapInjection.java:144:78:144:113 | uBadROSRDNAsync | user-provided value |
+| LdapInjection.java:156:19:156:19 | s | LdapInjection.java:152:31:152:73 | uBadSearchRequestAsync : String | LdapInjection.java:156:19:156:19 | s | This LDAP query depends on a $@. | LdapInjection.java:152:31:152:73 | uBadSearchRequestAsync | user-provided value |
+| LdapInjection.java:156:19:156:19 | s | LdapInjection.java:152:76:152:109 | uBadSRDNAsync : String | LdapInjection.java:156:19:156:19 | s | This LDAP query depends on a $@. | LdapInjection.java:152:76:152:109 | uBadSRDNAsync | user-provided value |
+| LdapInjection.java:161:58:161:115 | createNOTFilter(...) | LdapInjection.java:160:31:160:70 | uBadFilterCreateNOT : String | LdapInjection.java:161:58:161:115 | createNOTFilter(...) | This LDAP query depends on a $@. | LdapInjection.java:160:31:160:70 | uBadFilterCreateNOT | user-provided value |
+| LdapInjection.java:166:58:166:107 | toString(...) | LdapInjection.java:165:31:165:75 | uBadFilterCreateToString : String | LdapInjection.java:166:58:166:107 | toString(...) | This LDAP query depends on a $@. | LdapInjection.java:165:31:165:75 | uBadFilterCreateToString | user-provided value |
+| LdapInjection.java:173:58:173:69 | toString(...) | LdapInjection.java:170:32:170:82 | uBadFilterCreateToStringBuffer : String | LdapInjection.java:173:58:173:69 | toString(...) | This LDAP query depends on a $@. | LdapInjection.java:170:32:170:82 | uBadFilterCreateToStringBuffer | user-provided value |
+| LdapInjection.java:181:14:181:26 | duplicate(...) | LdapInjection.java:177:32:177:78 | uBadSearchRequestDuplicate : String | LdapInjection.java:181:14:181:26 | duplicate(...) | This LDAP query depends on a $@. | LdapInjection.java:177:32:177:78 | uBadSearchRequestDuplicate | user-provided value |
+| LdapInjection.java:189:14:189:26 | duplicate(...) | LdapInjection.java:185:32:185:80 | uBadROSearchRequestDuplicate : String | LdapInjection.java:189:14:189:26 | duplicate(...) | This LDAP query depends on a $@. | LdapInjection.java:185:32:185:80 | uBadROSearchRequestDuplicate | user-provided value |
+| LdapInjection.java:197:14:197:14 | s | LdapInjection.java:193:32:193:74 | uBadSearchRequestSetDN : String | LdapInjection.java:197:14:197:14 | s | This LDAP query depends on a $@. | LdapInjection.java:193:32:193:74 | uBadSearchRequestSetDN | user-provided value |
+| LdapInjection.java:205:14:205:14 | s | LdapInjection.java:201:32:201:78 | uBadSearchRequestSetFilter : String | LdapInjection.java:205:14:205:14 | s | This LDAP query depends on a $@. | LdapInjection.java:201:32:201:78 | uBadSearchRequestSetFilter | user-provided value |
+| LdapInjection.java:235:14:235:33 | ... + ... | LdapInjection.java:234:57:234:83 | sBadDN : String | LdapInjection.java:235:14:235:33 | ... + ... | This LDAP query depends on a $@. | LdapInjection.java:234:57:234:83 | sBadDN | user-provided value |
+| LdapInjection.java:235:36:235:55 | ... + ... | LdapInjection.java:234:30:234:54 | sBad : String | LdapInjection.java:235:36:235:55 | ... + ... | This LDAP query depends on a $@. | LdapInjection.java:234:30:234:54 | sBad | user-provided value |
+| LdapInjection.java:240:20:240:85 | build(...) | LdapInjection.java:239:57:239:92 | sBadDNLNBuilder : String | LdapInjection.java:240:20:240:85 | build(...) | This LDAP query depends on a $@. | LdapInjection.java:239:57:239:92 | sBadDNLNBuilder | user-provided value |
+| LdapInjection.java:240:88:240:107 | ... + ... | LdapInjection.java:239:30:239:54 | sBad : String | LdapInjection.java:240:88:240:107 | ... + ... | This LDAP query depends on a $@. | LdapInjection.java:239:30:239:54 | sBad | user-provided value |
+| LdapInjection.java:245:23:245:97 | build(...) | LdapInjection.java:244:57:244:95 | sBadDNLNBuilderAdd : String | LdapInjection.java:245:23:245:97 | build(...) | This LDAP query depends on a $@. | LdapInjection.java:244:57:244:95 | sBadDNLNBuilderAdd | user-provided value |
+| LdapInjection.java:245:100:245:119 | ... + ... | LdapInjection.java:244:30:244:54 | sBad : String | LdapInjection.java:245:100:245:119 | ... + ... | This LDAP query depends on a $@. | LdapInjection.java:244:30:244:54 | sBad | user-provided value |
+| LdapInjection.java:250:15:250:76 | filter(...) | LdapInjection.java:249:30:249:63 | sBadLdapQuery : String | LdapInjection.java:250:15:250:76 | filter(...) | This LDAP query depends on a $@. | LdapInjection.java:249:30:249:63 | sBadLdapQuery | user-provided value |
+| LdapInjection.java:255:12:255:63 | newLdapName(...) | LdapInjection.java:254:63:254:98 | sBadDNLdapUtils : String | LdapInjection.java:255:12:255:63 | newLdapName(...) | This LDAP query depends on a $@. | LdapInjection.java:254:63:254:98 | sBadDNLdapUtils | user-provided value |
+| LdapInjection.java:255:66:255:112 | new HardcodedFilter(...) | LdapInjection.java:254:30:254:60 | sBadFilter : String | LdapInjection.java:255:66:255:112 | new HardcodedFilter(...) | This LDAP query depends on a $@. | LdapInjection.java:254:30:254:60 | sBadFilter | user-provided value |
+| LdapInjection.java:260:24:260:85 | filter(...) | LdapInjection.java:259:30:259:63 | sBadLdapQuery : String | LdapInjection.java:260:24:260:85 | filter(...) | This LDAP query depends on a $@. | LdapInjection.java:259:30:259:63 | sBadLdapQuery | user-provided value |
+| LdapInjection.java:266:24:266:24 | q | LdapInjection.java:264:30:264:64 | sBadLdapQuery2 : String | LdapInjection.java:266:24:266:24 | q | This LDAP query depends on a $@. | LdapInjection.java:264:30:264:64 | sBadLdapQuery2 | user-provided value |
+| LdapInjection.java:271:24:271:116 | filter(...) | LdapInjection.java:270:30:270:73 | sBadLdapQueryWithFilter : String | LdapInjection.java:271:24:271:116 | filter(...) | This LDAP query depends on a $@. | LdapInjection.java:270:30:270:73 | sBadLdapQueryWithFilter | user-provided value |
+| LdapInjection.java:277:24:277:57 | filter(...) | LdapInjection.java:275:30:275:74 | sBadLdapQueryWithFilter2 : String | LdapInjection.java:277:24:277:57 | filter(...) | This LDAP query depends on a $@. | LdapInjection.java:275:30:275:74 | sBadLdapQueryWithFilter2 | user-provided value |
+| LdapInjection.java:282:12:282:66 | base(...) | LdapInjection.java:281:31:281:68 | sBadLdapQueryBase : String | LdapInjection.java:282:12:282:66 | base(...) | This LDAP query depends on a $@. | LdapInjection.java:281:31:281:68 | sBadLdapQueryBase | user-provided value |
+| LdapInjection.java:287:24:287:98 | is(...) | LdapInjection.java:286:31:286:71 | sBadLdapQueryComplex : String | LdapInjection.java:287:24:287:98 | is(...) | This LDAP query depends on a $@. | LdapInjection.java:286:31:286:71 | sBadLdapQueryComplex | user-provided value |
+| LdapInjection.java:292:18:292:83 | toString(...) | LdapInjection.java:291:31:291:69 | sBadFilterToString : String | LdapInjection.java:292:18:292:83 | toString(...) | This LDAP query depends on a $@. | LdapInjection.java:291:31:291:69 | sBadFilterToString | user-provided value |
+| LdapInjection.java:299:18:299:29 | toString(...) | LdapInjection.java:296:31:296:67 | sBadFilterEncode : String | LdapInjection.java:299:18:299:29 | toString(...) | This LDAP query depends on a $@. | LdapInjection.java:296:31:296:67 | sBadFilterEncode | user-provided value |
+| LdapInjection.java:321:14:321:33 | ... + ... | LdapInjection.java:319:57:319:83 | aBadDN : String | LdapInjection.java:321:14:321:33 | ... + ... | This LDAP query depends on a $@. | LdapInjection.java:319:57:319:83 | aBadDN | user-provided value |
+| LdapInjection.java:321:36:321:55 | ... + ... | LdapInjection.java:319:30:319:54 | aBad : String | LdapInjection.java:321:36:321:55 | ... + ... | This LDAP query depends on a $@. | LdapInjection.java:319:30:319:54 | aBad | user-provided value |
+| LdapInjection.java:327:14:327:62 | getName(...) | LdapInjection.java:325:57:325:94 | aBadDNObjToString : String | LdapInjection.java:327:14:327:62 | getName(...) | This LDAP query depends on a $@. | LdapInjection.java:325:57:325:94 | aBadDNObjToString | user-provided value |
+| LdapInjection.java:327:65:327:84 | ... + ... | LdapInjection.java:325:30:325:54 | aBad : String | LdapInjection.java:327:65:327:84 | ... + ... | This LDAP query depends on a $@. | LdapInjection.java:325:30:325:54 | aBad | user-provided value |
+| LdapInjection.java:335:14:335:14 | s | LdapInjection.java:331:30:331:67 | aBadSearchRequest : String | LdapInjection.java:335:14:335:14 | s | This LDAP query depends on a $@. | LdapInjection.java:331:30:331:67 | aBadSearchRequest | user-provided value |
+| LdapInjection.java:343:14:343:14 | s | LdapInjection.java:339:74:339:103 | aBadDNObj : String | LdapInjection.java:343:14:343:14 | s | This LDAP query depends on a $@. | LdapInjection.java:339:74:339:103 | aBadDNObj | user-provided value |
+| LdapInjection.java:351:14:351:24 | getBase(...) | LdapInjection.java:347:30:347:72 | aBadDNSearchRequestGet : String | LdapInjection.java:351:14:351:24 | getBase(...) | This LDAP query depends on a $@. | LdapInjection.java:347:30:347:72 | aBadDNSearchRequestGet | user-provided value |
+| LdapInjection.java:398:41:398:95 | ... + ... | LdapInjection.java:395:30:395:63 | bBadPrincipal : String | LdapInjection.java:398:41:398:95 | ... + ... | This LDAP query depends on a $@. | LdapInjection.java:395:30:395:63 | bBadPrincipal | user-provided value |
+| LdapInjection.java:407:47:407:98 | ... + ... | LdapInjection.java:404:30:404:70 | bBadPrincipalLiteral : String | LdapInjection.java:407:47:407:98 | ... + ... | This LDAP query depends on a $@. | LdapInjection.java:404:30:404:70 | bBadPrincipalLiteral | user-provided value |
+| LdapInjection.java:415:14:415:45 | ... + ... | LdapInjection.java:413:30:413:58 | bBadBind : String | LdapInjection.java:415:14:415:45 | ... + ... | This LDAP query depends on a $@. | LdapInjection.java:413:30:413:58 | bBadBind | user-provided value |
+| LdapInjection.java:422:16:422:49 | ... + ... | LdapInjection.java:420:30:420:60 | bBadLookup : String | LdapInjection.java:422:16:422:49 | ... + ... | This LDAP query depends on a $@. | LdapInjection.java:420:30:420:60 | bBadLookup | user-provided value |
+| LdapInjection.java:429:35:429:67 | ... + ... | LdapInjection.java:427:37:427:66 | bBadShiro : String | LdapInjection.java:429:35:429:67 | ... + ... | This LDAP query depends on a $@. | LdapInjection.java:427:37:427:66 | bBadShiro | user-provided value |
 edges
-| LdapInjection.java:45:28:45:52 | jBad : String | LdapInjection.java:47:38:47:57 | ... + ... | provenance | Sink:MaD:7 |
-| LdapInjection.java:45:55:45:81 | jBadDN : String | LdapInjection.java:47:16:47:35 | ... + ... | provenance | Sink:MaD:7 |
-| LdapInjection.java:51:28:51:52 | jBad : String | LdapInjection.java:53:56:53:75 | ... + ... | provenance | Sink:MaD:7 |
-| LdapInjection.java:51:55:51:85 | jBadDNName : String | LdapInjection.java:53:29:53:52 | ... + ... : String | provenance |  |
-| LdapInjection.java:53:29:53:52 | ... + ... : String | LdapInjection.java:53:16:53:53 | new LdapName(...) | provenance | Config Sink:MaD:7 |
-| LdapInjection.java:53:29:53:52 | ... + ... : String | LdapInjection.java:53:16:53:53 | new LdapName(...) | provenance | MaD:18 Sink:MaD:7 |
-| LdapInjection.java:57:28:57:52 | jBad : String | LdapInjection.java:59:63:59:82 | ... + ... | provenance | Sink:MaD:7 |
-| LdapInjection.java:63:28:63:59 | jBadInitial : String | LdapInjection.java:65:29:65:55 | ... + ... | provenance | Sink:MaD:7 |
-| LdapInjection.java:69:28:69:52 | jBad : String | LdapInjection.java:71:84:71:103 | ... + ... | provenance | Sink:MaD:7 |
-| LdapInjection.java:69:55:69:88 | jBadDNNameAdd : String | LdapInjection.java:71:53:71:79 | ... + ... : String | provenance |  |
-| LdapInjection.java:71:16:71:31 | new LdapName(...) : LdapName | LdapInjection.java:71:16:71:81 | addAll(...) | provenance | MaD:19 Sink:MaD:7 |
-| LdapInjection.java:71:40:71:80 | new LdapName(...) : LdapName | LdapInjection.java:71:16:71:31 | new LdapName(...) : LdapName | provenance | Config |
-| LdapInjection.java:71:40:71:80 | new LdapName(...) : LdapName | LdapInjection.java:71:16:71:81 | addAll(...) | provenance | Config Sink:MaD:7 |
-| LdapInjection.java:71:53:71:79 | ... + ... : String | LdapInjection.java:71:40:71:80 | new LdapName(...) : LdapName | provenance | Config |
-| LdapInjection.java:71:53:71:79 | ... + ... : String | LdapInjection.java:71:40:71:80 | new LdapName(...) : LdapName | provenance | MaD:18 |
-| LdapInjection.java:75:28:75:52 | jBad : String | LdapInjection.java:79:47:79:66 | ... + ... | provenance | Sink:MaD:7 |
-| LdapInjection.java:75:55:75:89 | jBadDNNameAdd2 : String | LdapInjection.java:78:30:78:57 | ... + ... : String | provenance |  |
-| LdapInjection.java:78:5:78:8 | name : LdapName | LdapInjection.java:79:40:79:43 | name : LdapName | provenance |  |
-| LdapInjection.java:78:17:78:58 | new LdapName(...) : LdapName | LdapInjection.java:78:17:78:68 | getRdns(...) : List | provenance | Config |
-| LdapInjection.java:78:17:78:68 | getRdns(...) : List | LdapInjection.java:78:5:78:8 | name : LdapName | provenance | Config |
-| LdapInjection.java:78:30:78:57 | ... + ... : String | LdapInjection.java:78:17:78:58 | new LdapName(...) : LdapName | provenance | Config |
-| LdapInjection.java:78:30:78:57 | ... + ... : String | LdapInjection.java:78:17:78:58 | new LdapName(...) : LdapName | provenance | MaD:18 |
-| LdapInjection.java:79:16:79:31 | new LdapName(...) : LdapName | LdapInjection.java:79:16:79:44 | addAll(...) | provenance | MaD:19 Sink:MaD:7 |
-| LdapInjection.java:79:40:79:43 | name : LdapName | LdapInjection.java:79:16:79:31 | new LdapName(...) : LdapName | provenance | Config |
-| LdapInjection.java:79:40:79:43 | name : LdapName | LdapInjection.java:79:16:79:44 | addAll(...) | provenance | Config Sink:MaD:7 |
-| LdapInjection.java:83:28:83:52 | jBad : String | LdapInjection.java:85:75:85:94 | ... + ... | provenance | Sink:MaD:7 |
-| LdapInjection.java:83:55:83:93 | jBadDNNameToString : String | LdapInjection.java:85:29:85:60 | ... + ... : String | provenance |  |
-| LdapInjection.java:85:16:85:61 | new LdapName(...) : LdapName | LdapInjection.java:85:16:85:72 | toString(...) | provenance | Config Sink:MaD:7 |
-| LdapInjection.java:85:29:85:60 | ... + ... : String | LdapInjection.java:85:16:85:61 | new LdapName(...) : LdapName | provenance | Config |
-| LdapInjection.java:85:29:85:60 | ... + ... : String | LdapInjection.java:85:16:85:61 | new LdapName(...) : LdapName | provenance | MaD:18 |
-| LdapInjection.java:89:28:89:52 | jBad : String | LdapInjection.java:91:76:91:95 | ... + ... | provenance | Sink:MaD:7 |
-| LdapInjection.java:89:55:89:90 | jBadDNNameClone : String | LdapInjection.java:91:36:91:64 | ... + ... : String | provenance |  |
-| LdapInjection.java:91:23:91:65 | new LdapName(...) : LdapName | LdapInjection.java:91:16:91:73 | (...)... | provenance | CloneStep Sink:MaD:7 |
-| LdapInjection.java:91:36:91:64 | ... + ... : String | LdapInjection.java:91:23:91:65 | new LdapName(...) : LdapName | provenance | Config |
-| LdapInjection.java:91:36:91:64 | ... + ... : String | LdapInjection.java:91:23:91:65 | new LdapName(...) : LdapName | provenance | MaD:18 |
-| LdapInjection.java:100:27:100:59 | jOkAttribute : String | LdapInjection.java:101:49:101:60 | jOkAttribute : String | provenance |  |
-| LdapInjection.java:100:27:100:59 | jOkAttribute : String | LdapInjection.java:101:63:101:74 | jOkAttribute : String | provenance |  |
-| LdapInjection.java:101:49:101:60 | jOkAttribute : String | LdapInjection.java:101:29:101:75 | new BasicAttributes(...) | provenance | MaD:17 Sink:MaD:7 |
-| LdapInjection.java:101:63:101:74 | jOkAttribute : String | LdapInjection.java:101:29:101:75 | new BasicAttributes(...) | provenance | MaD:17 Sink:MaD:7 |
-| LdapInjection.java:106:31:106:55 | uBad : String | LdapInjection.java:108:67:108:86 | ... + ... | provenance | Sink:MaD:5 |
-| LdapInjection.java:106:58:106:84 | uBadDN : String | LdapInjection.java:108:20:108:39 | ... + ... | provenance | Sink:MaD:5 |
-| LdapInjection.java:112:31:112:67 | uBadFilterCreate : String | LdapInjection.java:113:72:113:87 | uBadFilterCreate : String | provenance |  |
-| LdapInjection.java:113:72:113:87 | uBadFilterCreate : String | LdapInjection.java:113:58:113:88 | create(...) | provenance | Config Sink:MaD:4 |
-| LdapInjection.java:117:31:117:70 | uBadROSearchRequest : String | LdapInjection.java:120:9:120:43 | ... + ... : String | provenance |  |
-| LdapInjection.java:117:73:117:103 | uBadROSRDN : String | LdapInjection.java:119:55:119:78 | ... + ... : String | provenance |  |
-| LdapInjection.java:119:31:120:44 | new SearchRequest(...) : SearchRequest | LdapInjection.java:121:14:121:14 | s | provenance | Sink:MaD:2 |
-| LdapInjection.java:119:55:119:78 | ... + ... : String | LdapInjection.java:119:31:120:44 | new SearchRequest(...) : SearchRequest | provenance | Config |
-| LdapInjection.java:120:9:120:43 | ... + ... : String | LdapInjection.java:119:31:120:44 | new SearchRequest(...) : SearchRequest | provenance | Config |
-| LdapInjection.java:125:31:125:68 | uBadSearchRequest : String | LdapInjection.java:128:9:128:41 | ... + ... : String | provenance |  |
-| LdapInjection.java:125:71:125:99 | uBadSRDN : String | LdapInjection.java:127:47:127:68 | ... + ... : String | provenance |  |
-| LdapInjection.java:127:23:128:42 | new SearchRequest(...) : SearchRequest | LdapInjection.java:129:14:129:14 | s | provenance | Sink:MaD:3 |
-| LdapInjection.java:127:47:127:68 | ... + ... : String | LdapInjection.java:127:23:128:42 | new SearchRequest(...) : SearchRequest | provenance | Config |
-| LdapInjection.java:128:9:128:41 | ... + ... : String | LdapInjection.java:127:23:128:42 | new SearchRequest(...) : SearchRequest | provenance | Config |
-| LdapInjection.java:133:31:133:55 | uBad : String | LdapInjection.java:135:69:135:88 | ... + ... | provenance | Sink:MaD:6 |
-| LdapInjection.java:133:58:133:87 | uBadDNSFR : String | LdapInjection.java:135:22:135:44 | ... + ... | provenance | Sink:MaD:6 |
-| LdapInjection.java:139:31:139:75 | uBadROSearchRequestAsync : String | LdapInjection.java:142:9:142:48 | ... + ... : String | provenance |  |
-| LdapInjection.java:139:78:139:113 | uBadROSRDNAsync : String | LdapInjection.java:141:55:141:83 | ... + ... : String | provenance |  |
-| LdapInjection.java:141:31:142:49 | new SearchRequest(...) : SearchRequest | LdapInjection.java:143:19:143:19 | s | provenance | Sink:MaD:1 |
-| LdapInjection.java:141:55:141:83 | ... + ... : String | LdapInjection.java:141:31:142:49 | new SearchRequest(...) : SearchRequest | provenance | Config |
-| LdapInjection.java:142:9:142:48 | ... + ... : String | LdapInjection.java:141:31:142:49 | new SearchRequest(...) : SearchRequest | provenance | Config |
-| LdapInjection.java:147:31:147:73 | uBadSearchRequestAsync : String | LdapInjection.java:150:9:150:46 | ... + ... : String | provenance |  |
-| LdapInjection.java:147:76:147:109 | uBadSRDNAsync : String | LdapInjection.java:149:47:149:73 | ... + ... : String | provenance |  |
-| LdapInjection.java:149:23:150:47 | new SearchRequest(...) : SearchRequest | LdapInjection.java:151:19:151:19 | s | provenance | Sink:MaD:1 |
-| LdapInjection.java:149:47:149:73 | ... + ... : String | LdapInjection.java:149:23:150:47 | new SearchRequest(...) : SearchRequest | provenance | Config |
-| LdapInjection.java:150:9:150:46 | ... + ... : String | LdapInjection.java:149:23:150:47 | new SearchRequest(...) : SearchRequest | provenance | Config |
-| LdapInjection.java:155:31:155:70 | uBadFilterCreateNOT : String | LdapInjection.java:156:95:156:113 | uBadFilterCreateNOT : String | provenance |  |
-| LdapInjection.java:156:81:156:114 | create(...) : Filter | LdapInjection.java:156:58:156:115 | createNOTFilter(...) | provenance | Config Sink:MaD:4 |
-| LdapInjection.java:156:95:156:113 | uBadFilterCreateNOT : String | LdapInjection.java:156:81:156:114 | create(...) : Filter | provenance | Config |
-| LdapInjection.java:160:31:160:75 | uBadFilterCreateToString : String | LdapInjection.java:161:72:161:95 | uBadFilterCreateToString : String | provenance |  |
-| LdapInjection.java:161:58:161:96 | create(...) : Filter | LdapInjection.java:161:58:161:107 | toString(...) | provenance | Config Sink:MaD:5 |
-| LdapInjection.java:161:72:161:95 | uBadFilterCreateToString : String | LdapInjection.java:161:58:161:96 | create(...) : Filter | provenance | Config |
-| LdapInjection.java:165:32:165:82 | uBadFilterCreateToStringBuffer : String | LdapInjection.java:167:19:167:48 | uBadFilterCreateToStringBuffer : String | provenance |  |
-| LdapInjection.java:167:5:167:49 | create(...) : Filter | LdapInjection.java:167:70:167:70 | b : StringBuilder | provenance | Config |
-| LdapInjection.java:167:19:167:48 | uBadFilterCreateToStringBuffer : String | LdapInjection.java:167:5:167:49 | create(...) : Filter | provenance | Config |
-| LdapInjection.java:167:70:167:70 | b : StringBuilder | LdapInjection.java:168:58:168:58 | b : StringBuilder | provenance |  |
-| LdapInjection.java:168:58:168:58 | b : StringBuilder | LdapInjection.java:168:58:168:69 | toString(...) | provenance | MaD:16 Sink:MaD:5 |
-| LdapInjection.java:172:32:172:78 | uBadSearchRequestDuplicate : String | LdapInjection.java:175:9:175:50 | ... + ... : String | provenance |  |
-| LdapInjection.java:174:23:175:51 | new SearchRequest(...) : SearchRequest | LdapInjection.java:176:14:176:14 | s : SearchRequest | provenance |  |
-| LdapInjection.java:175:9:175:50 | ... + ... : String | LdapInjection.java:174:23:175:51 | new SearchRequest(...) : SearchRequest | provenance | Config |
-| LdapInjection.java:176:14:176:14 | s : SearchRequest | LdapInjection.java:176:14:176:26 | duplicate(...) | provenance | Config Sink:MaD:3 |
-| LdapInjection.java:180:32:180:80 | uBadROSearchRequestDuplicate : String | LdapInjection.java:183:9:183:52 | ... + ... : String | provenance |  |
-| LdapInjection.java:182:31:183:53 | new SearchRequest(...) : SearchRequest | LdapInjection.java:184:14:184:14 | s : SearchRequest | provenance |  |
-| LdapInjection.java:183:9:183:52 | ... + ... : String | LdapInjection.java:182:31:183:53 | new SearchRequest(...) : SearchRequest | provenance | Config |
-| LdapInjection.java:184:14:184:14 | s : SearchRequest | LdapInjection.java:184:14:184:26 | duplicate(...) | provenance | Config Sink:MaD:3 |
-| LdapInjection.java:188:32:188:74 | uBadSearchRequestSetDN : String | LdapInjection.java:191:17:191:38 | uBadSearchRequestSetDN : String | provenance |  |
-| LdapInjection.java:191:5:191:5 | s : SearchRequest | LdapInjection.java:192:14:192:14 | s | provenance | Sink:MaD:3 |
-| LdapInjection.java:191:17:191:38 | uBadSearchRequestSetDN : String | LdapInjection.java:191:5:191:5 | s : SearchRequest | provenance | Config |
-| LdapInjection.java:196:32:196:78 | uBadSearchRequestSetFilter : String | LdapInjection.java:199:17:199:42 | uBadSearchRequestSetFilter : String | provenance |  |
-| LdapInjection.java:199:5:199:5 | s : SearchRequest | LdapInjection.java:200:14:200:14 | s | provenance | Sink:MaD:3 |
-| LdapInjection.java:199:17:199:42 | uBadSearchRequestSetFilter : String | LdapInjection.java:199:5:199:5 | s : SearchRequest | provenance | Config |
-| LdapInjection.java:229:30:229:54 | sBad : String | LdapInjection.java:230:36:230:55 | ... + ... | provenance | Sink:MaD:13 |
-| LdapInjection.java:229:57:229:83 | sBadDN : String | LdapInjection.java:230:14:230:33 | ... + ... | provenance | Sink:MaD:13 |
-| LdapInjection.java:234:30:234:54 | sBad : String | LdapInjection.java:235:88:235:107 | ... + ... | provenance | Sink:MaD:10 |
-| LdapInjection.java:234:57:234:92 | sBadDNLNBuilder : String | LdapInjection.java:235:48:235:76 | ... + ... : String | provenance |  |
-| LdapInjection.java:235:20:235:77 | newInstance(...) : LdapNameBuilder | LdapInjection.java:235:20:235:85 | build(...) | provenance | Config Sink:MaD:10 |
-| LdapInjection.java:235:48:235:76 | ... + ... : String | LdapInjection.java:235:20:235:77 | newInstance(...) : LdapNameBuilder | provenance | Config |
-| LdapInjection.java:239:30:239:54 | sBad : String | LdapInjection.java:240:100:240:119 | ... + ... | provenance | Sink:MaD:15 |
-| LdapInjection.java:239:57:239:95 | sBadDNLNBuilderAdd : String | LdapInjection.java:240:57:240:88 | ... + ... : String | provenance |  |
-| LdapInjection.java:240:23:240:89 | add(...) : LdapNameBuilder | LdapInjection.java:240:23:240:97 | build(...) | provenance | Config Sink:MaD:9 |
-| LdapInjection.java:240:23:240:89 | add(...) : LdapNameBuilder | LdapInjection.java:240:23:240:97 | build(...) | provenance | Config Sink:MaD:15 |
-| LdapInjection.java:240:57:240:88 | ... + ... : String | LdapInjection.java:240:23:240:89 | add(...) : LdapNameBuilder | provenance | Config |
-| LdapInjection.java:244:30:244:63 | sBadLdapQuery : String | LdapInjection.java:245:47:245:75 | ... + ... : String | provenance |  |
-| LdapInjection.java:245:47:245:75 | ... + ... : String | LdapInjection.java:245:15:245:76 | filter(...) | provenance | Config Sink:MaD:12 |
-| LdapInjection.java:249:30:249:60 | sBadFilter : String | LdapInjection.java:250:86:250:111 | ... + ... : String | provenance |  |
-| LdapInjection.java:249:63:249:98 | sBadDNLdapUtils : String | LdapInjection.java:250:34:250:62 | ... + ... : String | provenance |  |
-| LdapInjection.java:250:34:250:62 | ... + ... : String | LdapInjection.java:250:12:250:63 | newLdapName(...) | provenance | Config Sink:MaD:11 |
-| LdapInjection.java:250:86:250:111 | ... + ... : String | LdapInjection.java:250:66:250:112 | new HardcodedFilter(...) | provenance | Config Sink:MaD:11 |
-| LdapInjection.java:254:30:254:63 | sBadLdapQuery : String | LdapInjection.java:255:56:255:84 | ... + ... : String | provenance |  |
-| LdapInjection.java:255:56:255:84 | ... + ... : String | LdapInjection.java:255:24:255:85 | filter(...) | provenance | Config Sink:MaD:14 |
-| LdapInjection.java:259:30:259:64 | sBadLdapQuery2 : String | LdapInjection.java:260:51:260:80 | ... + ... : String | provenance |  |
-| LdapInjection.java:260:19:260:81 | filter(...) : LdapQuery | LdapInjection.java:261:24:261:24 | q | provenance | Sink:MaD:14 |
-| LdapInjection.java:260:51:260:80 | ... + ... : String | LdapInjection.java:260:19:260:81 | filter(...) : LdapQuery | provenance | Config |
-| LdapInjection.java:265:30:265:73 | sBadLdapQueryWithFilter : String | LdapInjection.java:266:76:266:114 | ... + ... : String | provenance |  |
-| LdapInjection.java:266:56:266:115 | new HardcodedFilter(...) : HardcodedFilter | LdapInjection.java:266:24:266:116 | filter(...) | provenance | Config Sink:MaD:14 |
-| LdapInjection.java:266:76:266:114 | ... + ... : String | LdapInjection.java:266:56:266:115 | new HardcodedFilter(...) : HardcodedFilter | provenance | Config |
-| LdapInjection.java:270:30:270:74 | sBadLdapQueryWithFilter2 : String | LdapInjection.java:271:68:271:107 | ... + ... : String | provenance |  |
-| LdapInjection.java:271:48:271:108 | new HardcodedFilter(...) : HardcodedFilter | LdapInjection.java:272:56:272:56 | f : HardcodedFilter | provenance |  |
-| LdapInjection.java:271:68:271:107 | ... + ... : String | LdapInjection.java:271:48:271:108 | new HardcodedFilter(...) : HardcodedFilter | provenance | Config |
-| LdapInjection.java:272:56:272:56 | f : HardcodedFilter | LdapInjection.java:272:24:272:57 | filter(...) | provenance | Config Sink:MaD:14 |
-| LdapInjection.java:276:31:276:68 | sBadLdapQueryBase : String | LdapInjection.java:277:42:277:58 | sBadLdapQueryBase : String | provenance |  |
-| LdapInjection.java:277:12:277:59 | base(...) : LdapQueryBuilder | LdapInjection.java:277:12:277:66 | base(...) | provenance | Config Sink:MaD:11 |
-| LdapInjection.java:277:42:277:58 | sBadLdapQueryBase : String | LdapInjection.java:277:12:277:59 | base(...) : LdapQueryBuilder | provenance | Config |
-| LdapInjection.java:281:31:281:71 | sBadLdapQueryComplex : String | LdapInjection.java:282:54:282:73 | sBadLdapQueryComplex : String | provenance |  |
-| LdapInjection.java:282:24:282:74 | base(...) : LdapQueryBuilder | LdapInjection.java:282:24:282:87 | where(...) : ConditionCriteria | provenance | Config |
-| LdapInjection.java:282:24:282:87 | where(...) : ConditionCriteria | LdapInjection.java:282:24:282:98 | is(...) | provenance | Config Sink:MaD:14 |
-| LdapInjection.java:282:54:282:73 | sBadLdapQueryComplex : String | LdapInjection.java:282:24:282:74 | base(...) : LdapQueryBuilder | provenance | Config |
-| LdapInjection.java:286:31:286:69 | sBadFilterToString : String | LdapInjection.java:287:38:287:71 | ... + ... : String | provenance |  |
-| LdapInjection.java:287:18:287:72 | new HardcodedFilter(...) : HardcodedFilter | LdapInjection.java:287:18:287:83 | toString(...) | provenance | Config Sink:MaD:13 |
-| LdapInjection.java:287:38:287:71 | ... + ... : String | LdapInjection.java:287:18:287:72 | new HardcodedFilter(...) : HardcodedFilter | provenance | Config |
-| LdapInjection.java:291:31:291:67 | sBadFilterEncode : String | LdapInjection.java:293:25:293:56 | ... + ... : String | provenance |  |
-| LdapInjection.java:293:5:293:57 | new HardcodedFilter(...) : HardcodedFilter | LdapInjection.java:293:66:293:66 | s : StringBuffer | provenance | Config |
-| LdapInjection.java:293:25:293:56 | ... + ... : String | LdapInjection.java:293:5:293:57 | new HardcodedFilter(...) : HardcodedFilter | provenance | Config |
-| LdapInjection.java:293:66:293:66 | s : StringBuffer | LdapInjection.java:294:18:294:18 | s : StringBuffer | provenance |  |
-| LdapInjection.java:294:18:294:18 | s : StringBuffer | LdapInjection.java:294:18:294:29 | toString(...) | provenance | MaD:16 Sink:MaD:13 |
-| LdapInjection.java:314:30:314:54 | aBad : String | LdapInjection.java:316:36:316:55 | ... + ... | provenance | Sink:MaD:8 |
-| LdapInjection.java:314:57:314:83 | aBadDN : String | LdapInjection.java:316:14:316:33 | ... + ... | provenance | Sink:MaD:8 |
-| LdapInjection.java:320:30:320:54 | aBad : String | LdapInjection.java:322:65:322:84 | ... + ... | provenance | Sink:MaD:8 |
-| LdapInjection.java:320:57:320:94 | aBadDNObjToString : String | LdapInjection.java:322:21:322:51 | ... + ... : String | provenance |  |
-| LdapInjection.java:322:14:322:52 | new Dn(...) : Dn | LdapInjection.java:322:14:322:62 | getName(...) | provenance | Config Sink:MaD:8 |
-| LdapInjection.java:322:21:322:51 | ... + ... : String | LdapInjection.java:322:14:322:52 | new Dn(...) : Dn | provenance | Config |
-| LdapInjection.java:326:30:326:67 | aBadSearchRequest : String | LdapInjection.java:329:17:329:49 | ... + ... : String | provenance |  |
-| LdapInjection.java:329:5:329:5 | s : SearchRequestImpl | LdapInjection.java:330:14:330:14 | s | provenance | Sink:MaD:8 |
-| LdapInjection.java:329:17:329:49 | ... + ... : String | LdapInjection.java:329:5:329:5 | s : SearchRequestImpl | provenance | Config |
-| LdapInjection.java:334:74:334:103 | aBadDNObj : String | LdapInjection.java:337:22:337:44 | ... + ... : String | provenance |  |
-| LdapInjection.java:337:5:337:5 | s : SearchRequestImpl | LdapInjection.java:338:14:338:14 | s | provenance | Sink:MaD:8 |
-| LdapInjection.java:337:15:337:45 | new Dn(...) : Dn | LdapInjection.java:337:5:337:5 | s : SearchRequestImpl | provenance | Config |
-| LdapInjection.java:337:22:337:44 | ... + ... : String | LdapInjection.java:337:15:337:45 | new Dn(...) : Dn | provenance | Config |
-| LdapInjection.java:342:30:342:72 | aBadDNSearchRequestGet : String | LdapInjection.java:345:22:345:57 | ... + ... : String | provenance |  |
-| LdapInjection.java:345:5:345:5 | s : SearchRequestImpl | LdapInjection.java:346:14:346:14 | s : SearchRequestImpl | provenance |  |
-| LdapInjection.java:345:15:345:58 | new Dn(...) : Dn | LdapInjection.java:345:5:345:5 | s : SearchRequestImpl | provenance | Config |
-| LdapInjection.java:345:22:345:57 | ... + ... : String | LdapInjection.java:345:15:345:58 | new Dn(...) : Dn | provenance | Config |
-| LdapInjection.java:346:14:346:14 | s : SearchRequestImpl | LdapInjection.java:346:14:346:24 | getBase(...) | provenance | Config Sink:MaD:8 |
+| LdapInjection.java:50:28:50:52 | jBad : String | LdapInjection.java:52:38:52:57 | ... + ... | provenance | Sink:MaD:8 |
+| LdapInjection.java:50:55:50:81 | jBadDN : String | LdapInjection.java:52:16:52:35 | ... + ... | provenance | Sink:MaD:8 |
+| LdapInjection.java:56:28:56:52 | jBad : String | LdapInjection.java:58:56:58:75 | ... + ... | provenance | Sink:MaD:8 |
+| LdapInjection.java:56:55:56:85 | jBadDNName : String | LdapInjection.java:58:29:58:52 | ... + ... : String | provenance |  |
+| LdapInjection.java:58:29:58:52 | ... + ... : String | LdapInjection.java:58:16:58:53 | new LdapName(...) | provenance | Config Sink:MaD:8 |
+| LdapInjection.java:58:29:58:52 | ... + ... : String | LdapInjection.java:58:16:58:53 | new LdapName(...) | provenance | MaD:22 Sink:MaD:8 |
+| LdapInjection.java:62:28:62:52 | jBad : String | LdapInjection.java:64:63:64:82 | ... + ... | provenance | Sink:MaD:8 |
+| LdapInjection.java:68:28:68:59 | jBadInitial : String | LdapInjection.java:70:29:70:55 | ... + ... | provenance | Sink:MaD:8 |
+| LdapInjection.java:74:28:74:52 | jBad : String | LdapInjection.java:76:84:76:103 | ... + ... | provenance | Sink:MaD:8 |
+| LdapInjection.java:74:55:74:88 | jBadDNNameAdd : String | LdapInjection.java:76:53:76:79 | ... + ... : String | provenance |  |
+| LdapInjection.java:76:16:76:31 | new LdapName(...) : LdapName | LdapInjection.java:76:16:76:81 | addAll(...) | provenance | MaD:23 Sink:MaD:8 |
+| LdapInjection.java:76:40:76:80 | new LdapName(...) : LdapName | LdapInjection.java:76:16:76:31 | new LdapName(...) : LdapName | provenance | Config |
+| LdapInjection.java:76:40:76:80 | new LdapName(...) : LdapName | LdapInjection.java:76:16:76:81 | addAll(...) | provenance | Config Sink:MaD:8 |
+| LdapInjection.java:76:53:76:79 | ... + ... : String | LdapInjection.java:76:40:76:80 | new LdapName(...) : LdapName | provenance | Config |
+| LdapInjection.java:76:53:76:79 | ... + ... : String | LdapInjection.java:76:40:76:80 | new LdapName(...) : LdapName | provenance | MaD:22 |
+| LdapInjection.java:80:28:80:52 | jBad : String | LdapInjection.java:84:47:84:66 | ... + ... | provenance | Sink:MaD:8 |
+| LdapInjection.java:80:55:80:89 | jBadDNNameAdd2 : String | LdapInjection.java:83:30:83:57 | ... + ... : String | provenance |  |
+| LdapInjection.java:83:5:83:8 | name : LdapName | LdapInjection.java:84:40:84:43 | name : LdapName | provenance |  |
+| LdapInjection.java:83:17:83:58 | new LdapName(...) : LdapName | LdapInjection.java:83:17:83:68 | getRdns(...) : List | provenance | Config |
+| LdapInjection.java:83:17:83:68 | getRdns(...) : List | LdapInjection.java:83:5:83:8 | name : LdapName | provenance | Config |
+| LdapInjection.java:83:30:83:57 | ... + ... : String | LdapInjection.java:83:17:83:58 | new LdapName(...) : LdapName | provenance | Config |
+| LdapInjection.java:83:30:83:57 | ... + ... : String | LdapInjection.java:83:17:83:58 | new LdapName(...) : LdapName | provenance | MaD:22 |
+| LdapInjection.java:84:16:84:31 | new LdapName(...) : LdapName | LdapInjection.java:84:16:84:44 | addAll(...) | provenance | MaD:23 Sink:MaD:8 |
+| LdapInjection.java:84:40:84:43 | name : LdapName | LdapInjection.java:84:16:84:31 | new LdapName(...) : LdapName | provenance | Config |
+| LdapInjection.java:84:40:84:43 | name : LdapName | LdapInjection.java:84:16:84:44 | addAll(...) | provenance | Config Sink:MaD:8 |
+| LdapInjection.java:88:28:88:52 | jBad : String | LdapInjection.java:90:75:90:94 | ... + ... | provenance | Sink:MaD:8 |
+| LdapInjection.java:88:55:88:93 | jBadDNNameToString : String | LdapInjection.java:90:29:90:60 | ... + ... : String | provenance |  |
+| LdapInjection.java:90:16:90:61 | new LdapName(...) : LdapName | LdapInjection.java:90:16:90:72 | toString(...) | provenance | Config Sink:MaD:8 |
+| LdapInjection.java:90:29:90:60 | ... + ... : String | LdapInjection.java:90:16:90:61 | new LdapName(...) : LdapName | provenance | Config |
+| LdapInjection.java:90:29:90:60 | ... + ... : String | LdapInjection.java:90:16:90:61 | new LdapName(...) : LdapName | provenance | MaD:22 |
+| LdapInjection.java:94:28:94:52 | jBad : String | LdapInjection.java:96:76:96:95 | ... + ... | provenance | Sink:MaD:8 |
+| LdapInjection.java:94:55:94:90 | jBadDNNameClone : String | LdapInjection.java:96:36:96:64 | ... + ... : String | provenance |  |
+| LdapInjection.java:96:23:96:65 | new LdapName(...) : LdapName | LdapInjection.java:96:16:96:73 | (...)... | provenance | CloneStep Sink:MaD:8 |
+| LdapInjection.java:96:36:96:64 | ... + ... : String | LdapInjection.java:96:23:96:65 | new LdapName(...) : LdapName | provenance | Config |
+| LdapInjection.java:96:36:96:64 | ... + ... : String | LdapInjection.java:96:23:96:65 | new LdapName(...) : LdapName | provenance | MaD:22 |
+| LdapInjection.java:105:27:105:59 | jOkAttribute : String | LdapInjection.java:106:49:106:60 | jOkAttribute : String | provenance |  |
+| LdapInjection.java:105:27:105:59 | jOkAttribute : String | LdapInjection.java:106:63:106:74 | jOkAttribute : String | provenance |  |
+| LdapInjection.java:106:49:106:60 | jOkAttribute : String | LdapInjection.java:106:29:106:75 | new BasicAttributes(...) | provenance | MaD:21 Sink:MaD:8 |
+| LdapInjection.java:106:63:106:74 | jOkAttribute : String | LdapInjection.java:106:29:106:75 | new BasicAttributes(...) | provenance | MaD:21 Sink:MaD:8 |
+| LdapInjection.java:111:31:111:55 | uBad : String | LdapInjection.java:113:67:113:86 | ... + ... | provenance | Sink:MaD:5 |
+| LdapInjection.java:111:58:111:84 | uBadDN : String | LdapInjection.java:113:20:113:39 | ... + ... | provenance | Sink:MaD:5 |
+| LdapInjection.java:117:31:117:67 | uBadFilterCreate : String | LdapInjection.java:118:72:118:87 | uBadFilterCreate : String | provenance |  |
+| LdapInjection.java:118:72:118:87 | uBadFilterCreate : String | LdapInjection.java:118:58:118:88 | create(...) | provenance | Config Sink:MaD:4 |
+| LdapInjection.java:122:31:122:70 | uBadROSearchRequest : String | LdapInjection.java:125:9:125:43 | ... + ... : String | provenance |  |
+| LdapInjection.java:122:73:122:103 | uBadROSRDN : String | LdapInjection.java:124:55:124:78 | ... + ... : String | provenance |  |
+| LdapInjection.java:124:31:125:44 | new SearchRequest(...) : SearchRequest | LdapInjection.java:126:14:126:14 | s | provenance | Sink:MaD:2 |
+| LdapInjection.java:124:55:124:78 | ... + ... : String | LdapInjection.java:124:31:125:44 | new SearchRequest(...) : SearchRequest | provenance | Config |
+| LdapInjection.java:125:9:125:43 | ... + ... : String | LdapInjection.java:124:31:125:44 | new SearchRequest(...) : SearchRequest | provenance | Config |
+| LdapInjection.java:130:31:130:68 | uBadSearchRequest : String | LdapInjection.java:133:9:133:41 | ... + ... : String | provenance |  |
+| LdapInjection.java:130:71:130:99 | uBadSRDN : String | LdapInjection.java:132:47:132:68 | ... + ... : String | provenance |  |
+| LdapInjection.java:132:23:133:42 | new SearchRequest(...) : SearchRequest | LdapInjection.java:134:14:134:14 | s | provenance | Sink:MaD:3 |
+| LdapInjection.java:132:47:132:68 | ... + ... : String | LdapInjection.java:132:23:133:42 | new SearchRequest(...) : SearchRequest | provenance | Config |
+| LdapInjection.java:133:9:133:41 | ... + ... : String | LdapInjection.java:132:23:133:42 | new SearchRequest(...) : SearchRequest | provenance | Config |
+| LdapInjection.java:138:31:138:55 | uBad : String | LdapInjection.java:140:69:140:88 | ... + ... | provenance | Sink:MaD:6 |
+| LdapInjection.java:138:58:138:87 | uBadDNSFR : String | LdapInjection.java:140:22:140:44 | ... + ... | provenance | Sink:MaD:6 |
+| LdapInjection.java:144:31:144:75 | uBadROSearchRequestAsync : String | LdapInjection.java:147:9:147:48 | ... + ... : String | provenance |  |
+| LdapInjection.java:144:78:144:113 | uBadROSRDNAsync : String | LdapInjection.java:146:55:146:83 | ... + ... : String | provenance |  |
+| LdapInjection.java:146:31:147:49 | new SearchRequest(...) : SearchRequest | LdapInjection.java:148:19:148:19 | s | provenance | Sink:MaD:1 |
+| LdapInjection.java:146:55:146:83 | ... + ... : String | LdapInjection.java:146:31:147:49 | new SearchRequest(...) : SearchRequest | provenance | Config |
+| LdapInjection.java:147:9:147:48 | ... + ... : String | LdapInjection.java:146:31:147:49 | new SearchRequest(...) : SearchRequest | provenance | Config |
+| LdapInjection.java:152:31:152:73 | uBadSearchRequestAsync : String | LdapInjection.java:155:9:155:46 | ... + ... : String | provenance |  |
+| LdapInjection.java:152:76:152:109 | uBadSRDNAsync : String | LdapInjection.java:154:47:154:73 | ... + ... : String | provenance |  |
+| LdapInjection.java:154:23:155:47 | new SearchRequest(...) : SearchRequest | LdapInjection.java:156:19:156:19 | s | provenance | Sink:MaD:1 |
+| LdapInjection.java:154:47:154:73 | ... + ... : String | LdapInjection.java:154:23:155:47 | new SearchRequest(...) : SearchRequest | provenance | Config |
+| LdapInjection.java:155:9:155:46 | ... + ... : String | LdapInjection.java:154:23:155:47 | new SearchRequest(...) : SearchRequest | provenance | Config |
+| LdapInjection.java:160:31:160:70 | uBadFilterCreateNOT : String | LdapInjection.java:161:95:161:113 | uBadFilterCreateNOT : String | provenance |  |
+| LdapInjection.java:161:81:161:114 | create(...) : Filter | LdapInjection.java:161:58:161:115 | createNOTFilter(...) | provenance | Config Sink:MaD:4 |
+| LdapInjection.java:161:95:161:113 | uBadFilterCreateNOT : String | LdapInjection.java:161:81:161:114 | create(...) : Filter | provenance | Config |
+| LdapInjection.java:165:31:165:75 | uBadFilterCreateToString : String | LdapInjection.java:166:72:166:95 | uBadFilterCreateToString : String | provenance |  |
+| LdapInjection.java:166:58:166:96 | create(...) : Filter | LdapInjection.java:166:58:166:107 | toString(...) | provenance | Config Sink:MaD:5 |
+| LdapInjection.java:166:72:166:95 | uBadFilterCreateToString : String | LdapInjection.java:166:58:166:96 | create(...) : Filter | provenance | Config |
+| LdapInjection.java:170:32:170:82 | uBadFilterCreateToStringBuffer : String | LdapInjection.java:172:19:172:48 | uBadFilterCreateToStringBuffer : String | provenance |  |
+| LdapInjection.java:172:5:172:49 | create(...) : Filter | LdapInjection.java:172:70:172:70 | b : StringBuilder | provenance | Config |
+| LdapInjection.java:172:19:172:48 | uBadFilterCreateToStringBuffer : String | LdapInjection.java:172:5:172:49 | create(...) : Filter | provenance | Config |
+| LdapInjection.java:172:70:172:70 | b : StringBuilder | LdapInjection.java:173:58:173:58 | b : StringBuilder | provenance |  |
+| LdapInjection.java:173:58:173:58 | b : StringBuilder | LdapInjection.java:173:58:173:69 | toString(...) | provenance | MaD:20 Sink:MaD:5 |
+| LdapInjection.java:177:32:177:78 | uBadSearchRequestDuplicate : String | LdapInjection.java:180:9:180:50 | ... + ... : String | provenance |  |
+| LdapInjection.java:179:23:180:51 | new SearchRequest(...) : SearchRequest | LdapInjection.java:181:14:181:14 | s : SearchRequest | provenance |  |
+| LdapInjection.java:180:9:180:50 | ... + ... : String | LdapInjection.java:179:23:180:51 | new SearchRequest(...) : SearchRequest | provenance | Config |
+| LdapInjection.java:181:14:181:14 | s : SearchRequest | LdapInjection.java:181:14:181:26 | duplicate(...) | provenance | Config Sink:MaD:3 |
+| LdapInjection.java:185:32:185:80 | uBadROSearchRequestDuplicate : String | LdapInjection.java:188:9:188:52 | ... + ... : String | provenance |  |
+| LdapInjection.java:187:31:188:53 | new SearchRequest(...) : SearchRequest | LdapInjection.java:189:14:189:14 | s : SearchRequest | provenance |  |
+| LdapInjection.java:188:9:188:52 | ... + ... : String | LdapInjection.java:187:31:188:53 | new SearchRequest(...) : SearchRequest | provenance | Config |
+| LdapInjection.java:189:14:189:14 | s : SearchRequest | LdapInjection.java:189:14:189:26 | duplicate(...) | provenance | Config Sink:MaD:3 |
+| LdapInjection.java:193:32:193:74 | uBadSearchRequestSetDN : String | LdapInjection.java:196:17:196:38 | uBadSearchRequestSetDN : String | provenance |  |
+| LdapInjection.java:196:5:196:5 | s : SearchRequest | LdapInjection.java:197:14:197:14 | s | provenance | Sink:MaD:3 |
+| LdapInjection.java:196:17:196:38 | uBadSearchRequestSetDN : String | LdapInjection.java:196:5:196:5 | s : SearchRequest | provenance | Config |
+| LdapInjection.java:201:32:201:78 | uBadSearchRequestSetFilter : String | LdapInjection.java:204:17:204:42 | uBadSearchRequestSetFilter : String | provenance |  |
+| LdapInjection.java:204:5:204:5 | s : SearchRequest | LdapInjection.java:205:14:205:14 | s | provenance | Sink:MaD:3 |
+| LdapInjection.java:204:17:204:42 | uBadSearchRequestSetFilter : String | LdapInjection.java:204:5:204:5 | s : SearchRequest | provenance | Config |
+| LdapInjection.java:234:30:234:54 | sBad : String | LdapInjection.java:235:36:235:55 | ... + ... | provenance | Sink:MaD:17 |
+| LdapInjection.java:234:57:234:83 | sBadDN : String | LdapInjection.java:235:14:235:33 | ... + ... | provenance | Sink:MaD:17 |
+| LdapInjection.java:239:30:239:54 | sBad : String | LdapInjection.java:240:88:240:107 | ... + ... | provenance | Sink:MaD:14 |
+| LdapInjection.java:239:57:239:92 | sBadDNLNBuilder : String | LdapInjection.java:240:48:240:76 | ... + ... : String | provenance |  |
+| LdapInjection.java:240:20:240:77 | newInstance(...) : LdapNameBuilder | LdapInjection.java:240:20:240:85 | build(...) | provenance | Config Sink:MaD:14 |
+| LdapInjection.java:240:48:240:76 | ... + ... : String | LdapInjection.java:240:20:240:77 | newInstance(...) : LdapNameBuilder | provenance | Config |
+| LdapInjection.java:244:30:244:54 | sBad : String | LdapInjection.java:245:100:245:119 | ... + ... | provenance | Sink:MaD:19 |
+| LdapInjection.java:244:57:244:95 | sBadDNLNBuilderAdd : String | LdapInjection.java:245:57:245:88 | ... + ... : String | provenance |  |
+| LdapInjection.java:245:23:245:89 | add(...) : LdapNameBuilder | LdapInjection.java:245:23:245:97 | build(...) | provenance | Config Sink:MaD:13 |
+| LdapInjection.java:245:23:245:89 | add(...) : LdapNameBuilder | LdapInjection.java:245:23:245:97 | build(...) | provenance | Config Sink:MaD:19 |
+| LdapInjection.java:245:57:245:88 | ... + ... : String | LdapInjection.java:245:23:245:89 | add(...) : LdapNameBuilder | provenance | Config |
+| LdapInjection.java:249:30:249:63 | sBadLdapQuery : String | LdapInjection.java:250:47:250:75 | ... + ... : String | provenance |  |
+| LdapInjection.java:250:47:250:75 | ... + ... : String | LdapInjection.java:250:15:250:76 | filter(...) | provenance | Config Sink:MaD:16 |
+| LdapInjection.java:254:30:254:60 | sBadFilter : String | LdapInjection.java:255:86:255:111 | ... + ... : String | provenance |  |
+| LdapInjection.java:254:63:254:98 | sBadDNLdapUtils : String | LdapInjection.java:255:34:255:62 | ... + ... : String | provenance |  |
+| LdapInjection.java:255:34:255:62 | ... + ... : String | LdapInjection.java:255:12:255:63 | newLdapName(...) | provenance | Config Sink:MaD:15 |
+| LdapInjection.java:255:86:255:111 | ... + ... : String | LdapInjection.java:255:66:255:112 | new HardcodedFilter(...) | provenance | Config Sink:MaD:15 |
+| LdapInjection.java:259:30:259:63 | sBadLdapQuery : String | LdapInjection.java:260:56:260:84 | ... + ... : String | provenance |  |
+| LdapInjection.java:260:56:260:84 | ... + ... : String | LdapInjection.java:260:24:260:85 | filter(...) | provenance | Config Sink:MaD:18 |
+| LdapInjection.java:264:30:264:64 | sBadLdapQuery2 : String | LdapInjection.java:265:51:265:80 | ... + ... : String | provenance |  |
+| LdapInjection.java:265:19:265:81 | filter(...) : LdapQuery | LdapInjection.java:266:24:266:24 | q | provenance | Sink:MaD:18 |
+| LdapInjection.java:265:51:265:80 | ... + ... : String | LdapInjection.java:265:19:265:81 | filter(...) : LdapQuery | provenance | Config |
+| LdapInjection.java:270:30:270:73 | sBadLdapQueryWithFilter : String | LdapInjection.java:271:76:271:114 | ... + ... : String | provenance |  |
+| LdapInjection.java:271:56:271:115 | new HardcodedFilter(...) : HardcodedFilter | LdapInjection.java:271:24:271:116 | filter(...) | provenance | Config Sink:MaD:18 |
+| LdapInjection.java:271:76:271:114 | ... + ... : String | LdapInjection.java:271:56:271:115 | new HardcodedFilter(...) : HardcodedFilter | provenance | Config |
+| LdapInjection.java:275:30:275:74 | sBadLdapQueryWithFilter2 : String | LdapInjection.java:276:68:276:107 | ... + ... : String | provenance |  |
+| LdapInjection.java:276:48:276:108 | new HardcodedFilter(...) : HardcodedFilter | LdapInjection.java:277:56:277:56 | f : HardcodedFilter | provenance |  |
+| LdapInjection.java:276:68:276:107 | ... + ... : String | LdapInjection.java:276:48:276:108 | new HardcodedFilter(...) : HardcodedFilter | provenance | Config |
+| LdapInjection.java:277:56:277:56 | f : HardcodedFilter | LdapInjection.java:277:24:277:57 | filter(...) | provenance | Config Sink:MaD:18 |
+| LdapInjection.java:281:31:281:68 | sBadLdapQueryBase : String | LdapInjection.java:282:42:282:58 | sBadLdapQueryBase : String | provenance |  |
+| LdapInjection.java:282:12:282:59 | base(...) : LdapQueryBuilder | LdapInjection.java:282:12:282:66 | base(...) | provenance | Config Sink:MaD:15 |
+| LdapInjection.java:282:42:282:58 | sBadLdapQueryBase : String | LdapInjection.java:282:12:282:59 | base(...) : LdapQueryBuilder | provenance | Config |
+| LdapInjection.java:286:31:286:71 | sBadLdapQueryComplex : String | LdapInjection.java:287:54:287:73 | sBadLdapQueryComplex : String | provenance |  |
+| LdapInjection.java:287:24:287:74 | base(...) : LdapQueryBuilder | LdapInjection.java:287:24:287:87 | where(...) : ConditionCriteria | provenance | Config |
+| LdapInjection.java:287:24:287:87 | where(...) : ConditionCriteria | LdapInjection.java:287:24:287:98 | is(...) | provenance | Config Sink:MaD:18 |
+| LdapInjection.java:287:54:287:73 | sBadLdapQueryComplex : String | LdapInjection.java:287:24:287:74 | base(...) : LdapQueryBuilder | provenance | Config |
+| LdapInjection.java:291:31:291:69 | sBadFilterToString : String | LdapInjection.java:292:38:292:71 | ... + ... : String | provenance |  |
+| LdapInjection.java:292:18:292:72 | new HardcodedFilter(...) : HardcodedFilter | LdapInjection.java:292:18:292:83 | toString(...) | provenance | Config Sink:MaD:17 |
+| LdapInjection.java:292:38:292:71 | ... + ... : String | LdapInjection.java:292:18:292:72 | new HardcodedFilter(...) : HardcodedFilter | provenance | Config |
+| LdapInjection.java:296:31:296:67 | sBadFilterEncode : String | LdapInjection.java:298:25:298:56 | ... + ... : String | provenance |  |
+| LdapInjection.java:298:5:298:57 | new HardcodedFilter(...) : HardcodedFilter | LdapInjection.java:298:66:298:66 | s : StringBuffer | provenance | Config |
+| LdapInjection.java:298:25:298:56 | ... + ... : String | LdapInjection.java:298:5:298:57 | new HardcodedFilter(...) : HardcodedFilter | provenance | Config |
+| LdapInjection.java:298:66:298:66 | s : StringBuffer | LdapInjection.java:299:18:299:18 | s : StringBuffer | provenance |  |
+| LdapInjection.java:299:18:299:18 | s : StringBuffer | LdapInjection.java:299:18:299:29 | toString(...) | provenance | MaD:20 Sink:MaD:17 |
+| LdapInjection.java:319:30:319:54 | aBad : String | LdapInjection.java:321:36:321:55 | ... + ... | provenance | Sink:MaD:11 |
+| LdapInjection.java:319:57:319:83 | aBadDN : String | LdapInjection.java:321:14:321:33 | ... + ... | provenance | Sink:MaD:11 |
+| LdapInjection.java:325:30:325:54 | aBad : String | LdapInjection.java:327:65:327:84 | ... + ... | provenance | Sink:MaD:11 |
+| LdapInjection.java:325:57:325:94 | aBadDNObjToString : String | LdapInjection.java:327:21:327:51 | ... + ... : String | provenance |  |
+| LdapInjection.java:327:14:327:52 | new Dn(...) : Dn | LdapInjection.java:327:14:327:62 | getName(...) | provenance | Config Sink:MaD:11 |
+| LdapInjection.java:327:21:327:51 | ... + ... : String | LdapInjection.java:327:14:327:52 | new Dn(...) : Dn | provenance | Config |
+| LdapInjection.java:331:30:331:67 | aBadSearchRequest : String | LdapInjection.java:334:17:334:49 | ... + ... : String | provenance |  |
+| LdapInjection.java:334:5:334:5 | s : SearchRequestImpl | LdapInjection.java:335:14:335:14 | s | provenance | Sink:MaD:11 |
+| LdapInjection.java:334:17:334:49 | ... + ... : String | LdapInjection.java:334:5:334:5 | s : SearchRequestImpl | provenance | Config |
+| LdapInjection.java:339:74:339:103 | aBadDNObj : String | LdapInjection.java:342:22:342:44 | ... + ... : String | provenance |  |
+| LdapInjection.java:342:5:342:5 | s : SearchRequestImpl | LdapInjection.java:343:14:343:14 | s | provenance | Sink:MaD:11 |
+| LdapInjection.java:342:15:342:45 | new Dn(...) : Dn | LdapInjection.java:342:5:342:5 | s : SearchRequestImpl | provenance | Config |
+| LdapInjection.java:342:22:342:44 | ... + ... : String | LdapInjection.java:342:15:342:45 | new Dn(...) : Dn | provenance | Config |
+| LdapInjection.java:347:30:347:72 | aBadDNSearchRequestGet : String | LdapInjection.java:350:22:350:57 | ... + ... : String | provenance |  |
+| LdapInjection.java:350:5:350:5 | s : SearchRequestImpl | LdapInjection.java:351:14:351:14 | s : SearchRequestImpl | provenance |  |
+| LdapInjection.java:350:15:350:58 | new Dn(...) : Dn | LdapInjection.java:350:5:350:5 | s : SearchRequestImpl | provenance | Config |
+| LdapInjection.java:350:22:350:57 | ... + ... : String | LdapInjection.java:350:15:350:58 | new Dn(...) : Dn | provenance | Config |
+| LdapInjection.java:351:14:351:14 | s : SearchRequestImpl | LdapInjection.java:351:14:351:24 | getBase(...) | provenance | Config Sink:MaD:11 |
+| LdapInjection.java:395:30:395:63 | bBadPrincipal : String | LdapInjection.java:398:41:398:95 | ... + ... | provenance |  |
+| LdapInjection.java:404:30:404:70 | bBadPrincipalLiteral : String | LdapInjection.java:407:47:407:98 | ... + ... | provenance |  |
+| LdapInjection.java:413:30:413:58 | bBadBind : String | LdapInjection.java:415:14:415:45 | ... + ... | provenance | Sink:MaD:7 |
+| LdapInjection.java:420:30:420:60 | bBadLookup : String | LdapInjection.java:422:16:422:49 | ... + ... | provenance | Sink:MaD:10 |
+| LdapInjection.java:420:30:420:60 | bBadLookup : String | LdapInjection.java:422:16:422:49 | ... + ... | provenance | Sink:MaD:9 |
+| LdapInjection.java:427:37:427:66 | bBadShiro : String | LdapInjection.java:429:35:429:67 | ... + ... | provenance | Sink:MaD:12 |
 models
 | 1 | Sink: com.unboundid.ldap.sdk; LDAPConnection; false; asyncSearch; ; ; Argument[0]; ldap-injection; manual |
 | 2 | Sink: com.unboundid.ldap.sdk; LDAPConnection; false; search; (ReadOnlySearchRequest); ; Argument[0]; ldap-injection; manual |
@@ -218,216 +229,230 @@ models
 | 4 | Sink: com.unboundid.ldap.sdk; LDAPConnection; false; search; (SearchResultListener,String,SearchScope,DereferencePolicy,int,int,boolean,Filter,String[]); ; Argument[0..7]; ldap-injection; manual |
 | 5 | Sink: com.unboundid.ldap.sdk; LDAPConnection; false; search; (SearchResultListener,String,SearchScope,DereferencePolicy,int,int,boolean,String,String[]); ; Argument[0..7]; ldap-injection; manual |
 | 6 | Sink: com.unboundid.ldap.sdk; LDAPConnection; false; searchForEntry; (String,SearchScope,DereferencePolicy,int,boolean,String,String[]); ; Argument[0..5]; ldap-injection; manual |
-| 7 | Sink: javax.naming.directory; DirContext; true; search; ; ; Argument[0..1]; ldap-injection; manual |
-| 8 | Sink: org.apache.directory.ldap.client.api; LdapConnection; true; search; ; ; Argument[0..2]; ldap-injection; manual |
-| 9 | Sink: org.springframework.ldap.core; LdapOperations; true; searchForObject; (Name,String,ContextMapper); ; Argument[0]; jndi-injection; manual |
-| 10 | Sink: org.springframework.ldap.core; LdapTemplate; false; authenticate; (Name,String,String); ; Argument[0..1]; ldap-injection; manual |
-| 11 | Sink: org.springframework.ldap.core; LdapTemplate; false; find; ; ; Argument[0..1]; ldap-injection; manual |
-| 12 | Sink: org.springframework.ldap.core; LdapTemplate; false; findOne; ; ; Argument[0..1]; ldap-injection; manual |
-| 13 | Sink: org.springframework.ldap.core; LdapTemplate; false; search; ; ; Argument[0..1]; ldap-injection; manual |
-| 14 | Sink: org.springframework.ldap.core; LdapTemplate; false; searchForContext; ; ; Argument[0..1]; ldap-injection; manual |
-| 15 | Sink: org.springframework.ldap.core; LdapTemplate; false; searchForObject; ; ; Argument[0..1]; ldap-injection; manual |
-| 16 | Summary: java.lang; CharSequence; true; toString; ; ; Argument[this]; ReturnValue; taint; manual |
-| 17 | Summary: javax.naming.directory; BasicAttributes; true; BasicAttributes; (String,Object); ; Argument[0..1]; Argument[this]; taint; manual |
-| 18 | Summary: javax.naming.ldap; LdapName; true; LdapName; (String); ; Argument[0]; Argument[this]; taint; df-generated |
-| 19 | Summary: javax.naming; Name; true; addAll; (Name); ; Argument[this]; ReturnValue; value; dfc-generated |
+| 7 | Sink: javax.naming.directory; DirContext; true; bind; (String,Object,Attributes); ; Argument[0]; ldap-injection; manual |
+| 8 | Sink: javax.naming.directory; DirContext; true; search; ; ; Argument[0..1]; ldap-injection; manual |
+| 9 | Sink: javax.naming; Context; true; lookup; (String); ; Argument[0]; ldap-injection; manual |
+| 10 | Sink: javax.naming; Context; true; lookup; ; ; Argument[0]; jndi-injection; manual |
+| 11 | Sink: org.apache.directory.ldap.client.api; LdapConnection; true; search; ; ; Argument[0..2]; ldap-injection; manual |
+| 12 | Sink: org.apache.shiro.realm.ldap; LdapContextFactory; true; getLdapContext; (Object,Object); ; Argument[0]; ldap-injection; manual |
+| 13 | Sink: org.springframework.ldap.core; LdapOperations; true; searchForObject; (Name,String,ContextMapper); ; Argument[0]; jndi-injection; manual |
+| 14 | Sink: org.springframework.ldap.core; LdapTemplate; false; authenticate; (Name,String,String); ; Argument[0..1]; ldap-injection; manual |
+| 15 | Sink: org.springframework.ldap.core; LdapTemplate; false; find; ; ; Argument[0..1]; ldap-injection; manual |
+| 16 | Sink: org.springframework.ldap.core; LdapTemplate; false; findOne; ; ; Argument[0..1]; ldap-injection; manual |
+| 17 | Sink: org.springframework.ldap.core; LdapTemplate; false; search; ; ; Argument[0..1]; ldap-injection; manual |
+| 18 | Sink: org.springframework.ldap.core; LdapTemplate; false; searchForContext; ; ; Argument[0..1]; ldap-injection; manual |
+| 19 | Sink: org.springframework.ldap.core; LdapTemplate; false; searchForObject; ; ; Argument[0..1]; ldap-injection; manual |
+| 20 | Summary: java.lang; CharSequence; true; toString; ; ; Argument[this]; ReturnValue; taint; manual |
+| 21 | Summary: javax.naming.directory; BasicAttributes; true; BasicAttributes; (String,Object); ; Argument[0..1]; Argument[this]; taint; manual |
+| 22 | Summary: javax.naming.ldap; LdapName; true; LdapName; (String); ; Argument[0]; Argument[this]; taint; df-generated |
+| 23 | Summary: javax.naming; Name; true; addAll; (Name); ; Argument[this]; ReturnValue; value; dfc-generated |
 nodes
-| LdapInjection.java:45:28:45:52 | jBad : String | semmle.label | jBad : String |
-| LdapInjection.java:45:55:45:81 | jBadDN : String | semmle.label | jBadDN : String |
-| LdapInjection.java:47:16:47:35 | ... + ... | semmle.label | ... + ... |
-| LdapInjection.java:47:38:47:57 | ... + ... | semmle.label | ... + ... |
-| LdapInjection.java:51:28:51:52 | jBad : String | semmle.label | jBad : String |
-| LdapInjection.java:51:55:51:85 | jBadDNName : String | semmle.label | jBadDNName : String |
-| LdapInjection.java:53:16:53:53 | new LdapName(...) | semmle.label | new LdapName(...) |
-| LdapInjection.java:53:29:53:52 | ... + ... : String | semmle.label | ... + ... : String |
-| LdapInjection.java:53:56:53:75 | ... + ... | semmle.label | ... + ... |
-| LdapInjection.java:57:28:57:52 | jBad : String | semmle.label | jBad : String |
-| LdapInjection.java:59:63:59:82 | ... + ... | semmle.label | ... + ... |
-| LdapInjection.java:63:28:63:59 | jBadInitial : String | semmle.label | jBadInitial : String |
-| LdapInjection.java:65:29:65:55 | ... + ... | semmle.label | ... + ... |
-| LdapInjection.java:69:28:69:52 | jBad : String | semmle.label | jBad : String |
-| LdapInjection.java:69:55:69:88 | jBadDNNameAdd : String | semmle.label | jBadDNNameAdd : String |
-| LdapInjection.java:71:16:71:31 | new LdapName(...) : LdapName | semmle.label | new LdapName(...) : LdapName |
-| LdapInjection.java:71:16:71:81 | addAll(...) | semmle.label | addAll(...) |
-| LdapInjection.java:71:40:71:80 | new LdapName(...) : LdapName | semmle.label | new LdapName(...) : LdapName |
-| LdapInjection.java:71:53:71:79 | ... + ... : String | semmle.label | ... + ... : String |
-| LdapInjection.java:71:84:71:103 | ... + ... | semmle.label | ... + ... |
-| LdapInjection.java:75:28:75:52 | jBad : String | semmle.label | jBad : String |
-| LdapInjection.java:75:55:75:89 | jBadDNNameAdd2 : String | semmle.label | jBadDNNameAdd2 : String |
-| LdapInjection.java:78:5:78:8 | name : LdapName | semmle.label | name : LdapName |
-| LdapInjection.java:78:17:78:58 | new LdapName(...) : LdapName | semmle.label | new LdapName(...) : LdapName |
-| LdapInjection.java:78:17:78:68 | getRdns(...) : List | semmle.label | getRdns(...) : List |
-| LdapInjection.java:78:30:78:57 | ... + ... : String | semmle.label | ... + ... : String |
-| LdapInjection.java:79:16:79:31 | new LdapName(...) : LdapName | semmle.label | new LdapName(...) : LdapName |
-| LdapInjection.java:79:16:79:44 | addAll(...) | semmle.label | addAll(...) |
-| LdapInjection.java:79:40:79:43 | name : LdapName | semmle.label | name : LdapName |
-| LdapInjection.java:79:47:79:66 | ... + ... | semmle.label | ... + ... |
-| LdapInjection.java:83:28:83:52 | jBad : String | semmle.label | jBad : String |
-| LdapInjection.java:83:55:83:93 | jBadDNNameToString : String | semmle.label | jBadDNNameToString : String |
-| LdapInjection.java:85:16:85:61 | new LdapName(...) : LdapName | semmle.label | new LdapName(...) : LdapName |
-| LdapInjection.java:85:16:85:72 | toString(...) | semmle.label | toString(...) |
-| LdapInjection.java:85:29:85:60 | ... + ... : String | semmle.label | ... + ... : String |
-| LdapInjection.java:85:75:85:94 | ... + ... | semmle.label | ... + ... |
-| LdapInjection.java:89:28:89:52 | jBad : String | semmle.label | jBad : String |
-| LdapInjection.java:89:55:89:90 | jBadDNNameClone : String | semmle.label | jBadDNNameClone : String |
-| LdapInjection.java:91:16:91:73 | (...)... | semmle.label | (...)... |
-| LdapInjection.java:91:23:91:65 | new LdapName(...) : LdapName | semmle.label | new LdapName(...) : LdapName |
-| LdapInjection.java:91:36:91:64 | ... + ... : String | semmle.label | ... + ... : String |
-| LdapInjection.java:91:76:91:95 | ... + ... | semmle.label | ... + ... |
-| LdapInjection.java:100:27:100:59 | jOkAttribute : String | semmle.label | jOkAttribute : String |
-| LdapInjection.java:101:29:101:75 | new BasicAttributes(...) | semmle.label | new BasicAttributes(...) |
-| LdapInjection.java:101:49:101:60 | jOkAttribute : String | semmle.label | jOkAttribute : String |
-| LdapInjection.java:101:63:101:74 | jOkAttribute : String | semmle.label | jOkAttribute : String |
-| LdapInjection.java:106:31:106:55 | uBad : String | semmle.label | uBad : String |
-| LdapInjection.java:106:58:106:84 | uBadDN : String | semmle.label | uBadDN : String |
-| LdapInjection.java:108:20:108:39 | ... + ... | semmle.label | ... + ... |
-| LdapInjection.java:108:67:108:86 | ... + ... | semmle.label | ... + ... |
-| LdapInjection.java:112:31:112:67 | uBadFilterCreate : String | semmle.label | uBadFilterCreate : String |
-| LdapInjection.java:113:58:113:88 | create(...) | semmle.label | create(...) |
-| LdapInjection.java:113:72:113:87 | uBadFilterCreate : String | semmle.label | uBadFilterCreate : String |
-| LdapInjection.java:117:31:117:70 | uBadROSearchRequest : String | semmle.label | uBadROSearchRequest : String |
-| LdapInjection.java:117:73:117:103 | uBadROSRDN : String | semmle.label | uBadROSRDN : String |
-| LdapInjection.java:119:31:120:44 | new SearchRequest(...) : SearchRequest | semmle.label | new SearchRequest(...) : SearchRequest |
-| LdapInjection.java:119:55:119:78 | ... + ... : String | semmle.label | ... + ... : String |
-| LdapInjection.java:120:9:120:43 | ... + ... : String | semmle.label | ... + ... : String |
-| LdapInjection.java:121:14:121:14 | s | semmle.label | s |
-| LdapInjection.java:125:31:125:68 | uBadSearchRequest : String | semmle.label | uBadSearchRequest : String |
-| LdapInjection.java:125:71:125:99 | uBadSRDN : String | semmle.label | uBadSRDN : String |
-| LdapInjection.java:127:23:128:42 | new SearchRequest(...) : SearchRequest | semmle.label | new SearchRequest(...) : SearchRequest |
-| LdapInjection.java:127:47:127:68 | ... + ... : String | semmle.label | ... + ... : String |
-| LdapInjection.java:128:9:128:41 | ... + ... : String | semmle.label | ... + ... : String |
-| LdapInjection.java:129:14:129:14 | s | semmle.label | s |
-| LdapInjection.java:133:31:133:55 | uBad : String | semmle.label | uBad : String |
-| LdapInjection.java:133:58:133:87 | uBadDNSFR : String | semmle.label | uBadDNSFR : String |
-| LdapInjection.java:135:22:135:44 | ... + ... | semmle.label | ... + ... |
-| LdapInjection.java:135:69:135:88 | ... + ... | semmle.label | ... + ... |
-| LdapInjection.java:139:31:139:75 | uBadROSearchRequestAsync : String | semmle.label | uBadROSearchRequestAsync : String |
-| LdapInjection.java:139:78:139:113 | uBadROSRDNAsync : String | semmle.label | uBadROSRDNAsync : String |
-| LdapInjection.java:141:31:142:49 | new SearchRequest(...) : SearchRequest | semmle.label | new SearchRequest(...) : SearchRequest |
-| LdapInjection.java:141:55:141:83 | ... + ... : String | semmle.label | ... + ... : String |
-| LdapInjection.java:142:9:142:48 | ... + ... : String | semmle.label | ... + ... : String |
-| LdapInjection.java:143:19:143:19 | s | semmle.label | s |
-| LdapInjection.java:147:31:147:73 | uBadSearchRequestAsync : String | semmle.label | uBadSearchRequestAsync : String |
-| LdapInjection.java:147:76:147:109 | uBadSRDNAsync : String | semmle.label | uBadSRDNAsync : String |
-| LdapInjection.java:149:23:150:47 | new SearchRequest(...) : SearchRequest | semmle.label | new SearchRequest(...) : SearchRequest |
-| LdapInjection.java:149:47:149:73 | ... + ... : String | semmle.label | ... + ... : String |
-| LdapInjection.java:150:9:150:46 | ... + ... : String | semmle.label | ... + ... : String |
-| LdapInjection.java:151:19:151:19 | s | semmle.label | s |
-| LdapInjection.java:155:31:155:70 | uBadFilterCreateNOT : String | semmle.label | uBadFilterCreateNOT : String |
-| LdapInjection.java:156:58:156:115 | createNOTFilter(...) | semmle.label | createNOTFilter(...) |
-| LdapInjection.java:156:81:156:114 | create(...) : Filter | semmle.label | create(...) : Filter |
-| LdapInjection.java:156:95:156:113 | uBadFilterCreateNOT : String | semmle.label | uBadFilterCreateNOT : String |
-| LdapInjection.java:160:31:160:75 | uBadFilterCreateToString : String | semmle.label | uBadFilterCreateToString : String |
-| LdapInjection.java:161:58:161:96 | create(...) : Filter | semmle.label | create(...) : Filter |
-| LdapInjection.java:161:58:161:107 | toString(...) | semmle.label | toString(...) |
-| LdapInjection.java:161:72:161:95 | uBadFilterCreateToString : String | semmle.label | uBadFilterCreateToString : String |
-| LdapInjection.java:165:32:165:82 | uBadFilterCreateToStringBuffer : String | semmle.label | uBadFilterCreateToStringBuffer : String |
-| LdapInjection.java:167:5:167:49 | create(...) : Filter | semmle.label | create(...) : Filter |
-| LdapInjection.java:167:19:167:48 | uBadFilterCreateToStringBuffer : String | semmle.label | uBadFilterCreateToStringBuffer : String |
-| LdapInjection.java:167:70:167:70 | b : StringBuilder | semmle.label | b : StringBuilder |
-| LdapInjection.java:168:58:168:58 | b : StringBuilder | semmle.label | b : StringBuilder |
-| LdapInjection.java:168:58:168:69 | toString(...) | semmle.label | toString(...) |
-| LdapInjection.java:172:32:172:78 | uBadSearchRequestDuplicate : String | semmle.label | uBadSearchRequestDuplicate : String |
-| LdapInjection.java:174:23:175:51 | new SearchRequest(...) : SearchRequest | semmle.label | new SearchRequest(...) : SearchRequest |
-| LdapInjection.java:175:9:175:50 | ... + ... : String | semmle.label | ... + ... : String |
-| LdapInjection.java:176:14:176:14 | s : SearchRequest | semmle.label | s : SearchRequest |
-| LdapInjection.java:176:14:176:26 | duplicate(...) | semmle.label | duplicate(...) |
-| LdapInjection.java:180:32:180:80 | uBadROSearchRequestDuplicate : String | semmle.label | uBadROSearchRequestDuplicate : String |
-| LdapInjection.java:182:31:183:53 | new SearchRequest(...) : SearchRequest | semmle.label | new SearchRequest(...) : SearchRequest |
-| LdapInjection.java:183:9:183:52 | ... + ... : String | semmle.label | ... + ... : String |
-| LdapInjection.java:184:14:184:14 | s : SearchRequest | semmle.label | s : SearchRequest |
-| LdapInjection.java:184:14:184:26 | duplicate(...) | semmle.label | duplicate(...) |
-| LdapInjection.java:188:32:188:74 | uBadSearchRequestSetDN : String | semmle.label | uBadSearchRequestSetDN : String |
-| LdapInjection.java:191:5:191:5 | s : SearchRequest | semmle.label | s : SearchRequest |
-| LdapInjection.java:191:17:191:38 | uBadSearchRequestSetDN : String | semmle.label | uBadSearchRequestSetDN : String |
-| LdapInjection.java:192:14:192:14 | s | semmle.label | s |
-| LdapInjection.java:196:32:196:78 | uBadSearchRequestSetFilter : String | semmle.label | uBadSearchRequestSetFilter : String |
-| LdapInjection.java:199:5:199:5 | s : SearchRequest | semmle.label | s : SearchRequest |
-| LdapInjection.java:199:17:199:42 | uBadSearchRequestSetFilter : String | semmle.label | uBadSearchRequestSetFilter : String |
-| LdapInjection.java:200:14:200:14 | s | semmle.label | s |
-| LdapInjection.java:229:30:229:54 | sBad : String | semmle.label | sBad : String |
-| LdapInjection.java:229:57:229:83 | sBadDN : String | semmle.label | sBadDN : String |
-| LdapInjection.java:230:14:230:33 | ... + ... | semmle.label | ... + ... |
-| LdapInjection.java:230:36:230:55 | ... + ... | semmle.label | ... + ... |
+| LdapInjection.java:50:28:50:52 | jBad : String | semmle.label | jBad : String |
+| LdapInjection.java:50:55:50:81 | jBadDN : String | semmle.label | jBadDN : String |
+| LdapInjection.java:52:16:52:35 | ... + ... | semmle.label | ... + ... |
+| LdapInjection.java:52:38:52:57 | ... + ... | semmle.label | ... + ... |
+| LdapInjection.java:56:28:56:52 | jBad : String | semmle.label | jBad : String |
+| LdapInjection.java:56:55:56:85 | jBadDNName : String | semmle.label | jBadDNName : String |
+| LdapInjection.java:58:16:58:53 | new LdapName(...) | semmle.label | new LdapName(...) |
+| LdapInjection.java:58:29:58:52 | ... + ... : String | semmle.label | ... + ... : String |
+| LdapInjection.java:58:56:58:75 | ... + ... | semmle.label | ... + ... |
+| LdapInjection.java:62:28:62:52 | jBad : String | semmle.label | jBad : String |
+| LdapInjection.java:64:63:64:82 | ... + ... | semmle.label | ... + ... |
+| LdapInjection.java:68:28:68:59 | jBadInitial : String | semmle.label | jBadInitial : String |
+| LdapInjection.java:70:29:70:55 | ... + ... | semmle.label | ... + ... |
+| LdapInjection.java:74:28:74:52 | jBad : String | semmle.label | jBad : String |
+| LdapInjection.java:74:55:74:88 | jBadDNNameAdd : String | semmle.label | jBadDNNameAdd : String |
+| LdapInjection.java:76:16:76:31 | new LdapName(...) : LdapName | semmle.label | new LdapName(...) : LdapName |
+| LdapInjection.java:76:16:76:81 | addAll(...) | semmle.label | addAll(...) |
+| LdapInjection.java:76:40:76:80 | new LdapName(...) : LdapName | semmle.label | new LdapName(...) : LdapName |
+| LdapInjection.java:76:53:76:79 | ... + ... : String | semmle.label | ... + ... : String |
+| LdapInjection.java:76:84:76:103 | ... + ... | semmle.label | ... + ... |
+| LdapInjection.java:80:28:80:52 | jBad : String | semmle.label | jBad : String |
+| LdapInjection.java:80:55:80:89 | jBadDNNameAdd2 : String | semmle.label | jBadDNNameAdd2 : String |
+| LdapInjection.java:83:5:83:8 | name : LdapName | semmle.label | name : LdapName |
+| LdapInjection.java:83:17:83:58 | new LdapName(...) : LdapName | semmle.label | new LdapName(...) : LdapName |
+| LdapInjection.java:83:17:83:68 | getRdns(...) : List | semmle.label | getRdns(...) : List |
+| LdapInjection.java:83:30:83:57 | ... + ... : String | semmle.label | ... + ... : String |
+| LdapInjection.java:84:16:84:31 | new LdapName(...) : LdapName | semmle.label | new LdapName(...) : LdapName |
+| LdapInjection.java:84:16:84:44 | addAll(...) | semmle.label | addAll(...) |
+| LdapInjection.java:84:40:84:43 | name : LdapName | semmle.label | name : LdapName |
+| LdapInjection.java:84:47:84:66 | ... + ... | semmle.label | ... + ... |
+| LdapInjection.java:88:28:88:52 | jBad : String | semmle.label | jBad : String |
+| LdapInjection.java:88:55:88:93 | jBadDNNameToString : String | semmle.label | jBadDNNameToString : String |
+| LdapInjection.java:90:16:90:61 | new LdapName(...) : LdapName | semmle.label | new LdapName(...) : LdapName |
+| LdapInjection.java:90:16:90:72 | toString(...) | semmle.label | toString(...) |
+| LdapInjection.java:90:29:90:60 | ... + ... : String | semmle.label | ... + ... : String |
+| LdapInjection.java:90:75:90:94 | ... + ... | semmle.label | ... + ... |
+| LdapInjection.java:94:28:94:52 | jBad : String | semmle.label | jBad : String |
+| LdapInjection.java:94:55:94:90 | jBadDNNameClone : String | semmle.label | jBadDNNameClone : String |
+| LdapInjection.java:96:16:96:73 | (...)... | semmle.label | (...)... |
+| LdapInjection.java:96:23:96:65 | new LdapName(...) : LdapName | semmle.label | new LdapName(...) : LdapName |
+| LdapInjection.java:96:36:96:64 | ... + ... : String | semmle.label | ... + ... : String |
+| LdapInjection.java:96:76:96:95 | ... + ... | semmle.label | ... + ... |
+| LdapInjection.java:105:27:105:59 | jOkAttribute : String | semmle.label | jOkAttribute : String |
+| LdapInjection.java:106:29:106:75 | new BasicAttributes(...) | semmle.label | new BasicAttributes(...) |
+| LdapInjection.java:106:49:106:60 | jOkAttribute : String | semmle.label | jOkAttribute : String |
+| LdapInjection.java:106:63:106:74 | jOkAttribute : String | semmle.label | jOkAttribute : String |
+| LdapInjection.java:111:31:111:55 | uBad : String | semmle.label | uBad : String |
+| LdapInjection.java:111:58:111:84 | uBadDN : String | semmle.label | uBadDN : String |
+| LdapInjection.java:113:20:113:39 | ... + ... | semmle.label | ... + ... |
+| LdapInjection.java:113:67:113:86 | ... + ... | semmle.label | ... + ... |
+| LdapInjection.java:117:31:117:67 | uBadFilterCreate : String | semmle.label | uBadFilterCreate : String |
+| LdapInjection.java:118:58:118:88 | create(...) | semmle.label | create(...) |
+| LdapInjection.java:118:72:118:87 | uBadFilterCreate : String | semmle.label | uBadFilterCreate : String |
+| LdapInjection.java:122:31:122:70 | uBadROSearchRequest : String | semmle.label | uBadROSearchRequest : String |
+| LdapInjection.java:122:73:122:103 | uBadROSRDN : String | semmle.label | uBadROSRDN : String |
+| LdapInjection.java:124:31:125:44 | new SearchRequest(...) : SearchRequest | semmle.label | new SearchRequest(...) : SearchRequest |
+| LdapInjection.java:124:55:124:78 | ... + ... : String | semmle.label | ... + ... : String |
+| LdapInjection.java:125:9:125:43 | ... + ... : String | semmle.label | ... + ... : String |
+| LdapInjection.java:126:14:126:14 | s | semmle.label | s |
+| LdapInjection.java:130:31:130:68 | uBadSearchRequest : String | semmle.label | uBadSearchRequest : String |
+| LdapInjection.java:130:71:130:99 | uBadSRDN : String | semmle.label | uBadSRDN : String |
+| LdapInjection.java:132:23:133:42 | new SearchRequest(...) : SearchRequest | semmle.label | new SearchRequest(...) : SearchRequest |
+| LdapInjection.java:132:47:132:68 | ... + ... : String | semmle.label | ... + ... : String |
+| LdapInjection.java:133:9:133:41 | ... + ... : String | semmle.label | ... + ... : String |
+| LdapInjection.java:134:14:134:14 | s | semmle.label | s |
+| LdapInjection.java:138:31:138:55 | uBad : String | semmle.label | uBad : String |
+| LdapInjection.java:138:58:138:87 | uBadDNSFR : String | semmle.label | uBadDNSFR : String |
+| LdapInjection.java:140:22:140:44 | ... + ... | semmle.label | ... + ... |
+| LdapInjection.java:140:69:140:88 | ... + ... | semmle.label | ... + ... |
+| LdapInjection.java:144:31:144:75 | uBadROSearchRequestAsync : String | semmle.label | uBadROSearchRequestAsync : String |
+| LdapInjection.java:144:78:144:113 | uBadROSRDNAsync : String | semmle.label | uBadROSRDNAsync : String |
+| LdapInjection.java:146:31:147:49 | new SearchRequest(...) : SearchRequest | semmle.label | new SearchRequest(...) : SearchRequest |
+| LdapInjection.java:146:55:146:83 | ... + ... : String | semmle.label | ... + ... : String |
+| LdapInjection.java:147:9:147:48 | ... + ... : String | semmle.label | ... + ... : String |
+| LdapInjection.java:148:19:148:19 | s | semmle.label | s |
+| LdapInjection.java:152:31:152:73 | uBadSearchRequestAsync : String | semmle.label | uBadSearchRequestAsync : String |
+| LdapInjection.java:152:76:152:109 | uBadSRDNAsync : String | semmle.label | uBadSRDNAsync : String |
+| LdapInjection.java:154:23:155:47 | new SearchRequest(...) : SearchRequest | semmle.label | new SearchRequest(...) : SearchRequest |
+| LdapInjection.java:154:47:154:73 | ... + ... : String | semmle.label | ... + ... : String |
+| LdapInjection.java:155:9:155:46 | ... + ... : String | semmle.label | ... + ... : String |
+| LdapInjection.java:156:19:156:19 | s | semmle.label | s |
+| LdapInjection.java:160:31:160:70 | uBadFilterCreateNOT : String | semmle.label | uBadFilterCreateNOT : String |
+| LdapInjection.java:161:58:161:115 | createNOTFilter(...) | semmle.label | createNOTFilter(...) |
+| LdapInjection.java:161:81:161:114 | create(...) : Filter | semmle.label | create(...) : Filter |
+| LdapInjection.java:161:95:161:113 | uBadFilterCreateNOT : String | semmle.label | uBadFilterCreateNOT : String |
+| LdapInjection.java:165:31:165:75 | uBadFilterCreateToString : String | semmle.label | uBadFilterCreateToString : String |
+| LdapInjection.java:166:58:166:96 | create(...) : Filter | semmle.label | create(...) : Filter |
+| LdapInjection.java:166:58:166:107 | toString(...) | semmle.label | toString(...) |
+| LdapInjection.java:166:72:166:95 | uBadFilterCreateToString : String | semmle.label | uBadFilterCreateToString : String |
+| LdapInjection.java:170:32:170:82 | uBadFilterCreateToStringBuffer : String | semmle.label | uBadFilterCreateToStringBuffer : String |
+| LdapInjection.java:172:5:172:49 | create(...) : Filter | semmle.label | create(...) : Filter |
+| LdapInjection.java:172:19:172:48 | uBadFilterCreateToStringBuffer : String | semmle.label | uBadFilterCreateToStringBuffer : String |
+| LdapInjection.java:172:70:172:70 | b : StringBuilder | semmle.label | b : StringBuilder |
+| LdapInjection.java:173:58:173:58 | b : StringBuilder | semmle.label | b : StringBuilder |
+| LdapInjection.java:173:58:173:69 | toString(...) | semmle.label | toString(...) |
+| LdapInjection.java:177:32:177:78 | uBadSearchRequestDuplicate : String | semmle.label | uBadSearchRequestDuplicate : String |
+| LdapInjection.java:179:23:180:51 | new SearchRequest(...) : SearchRequest | semmle.label | new SearchRequest(...) : SearchRequest |
+| LdapInjection.java:180:9:180:50 | ... + ... : String | semmle.label | ... + ... : String |
+| LdapInjection.java:181:14:181:14 | s : SearchRequest | semmle.label | s : SearchRequest |
+| LdapInjection.java:181:14:181:26 | duplicate(...) | semmle.label | duplicate(...) |
+| LdapInjection.java:185:32:185:80 | uBadROSearchRequestDuplicate : String | semmle.label | uBadROSearchRequestDuplicate : String |
+| LdapInjection.java:187:31:188:53 | new SearchRequest(...) : SearchRequest | semmle.label | new SearchRequest(...) : SearchRequest |
+| LdapInjection.java:188:9:188:52 | ... + ... : String | semmle.label | ... + ... : String |
+| LdapInjection.java:189:14:189:14 | s : SearchRequest | semmle.label | s : SearchRequest |
+| LdapInjection.java:189:14:189:26 | duplicate(...) | semmle.label | duplicate(...) |
+| LdapInjection.java:193:32:193:74 | uBadSearchRequestSetDN : String | semmle.label | uBadSearchRequestSetDN : String |
+| LdapInjection.java:196:5:196:5 | s : SearchRequest | semmle.label | s : SearchRequest |
+| LdapInjection.java:196:17:196:38 | uBadSearchRequestSetDN : String | semmle.label | uBadSearchRequestSetDN : String |
+| LdapInjection.java:197:14:197:14 | s | semmle.label | s |
+| LdapInjection.java:201:32:201:78 | uBadSearchRequestSetFilter : String | semmle.label | uBadSearchRequestSetFilter : String |
+| LdapInjection.java:204:5:204:5 | s : SearchRequest | semmle.label | s : SearchRequest |
+| LdapInjection.java:204:17:204:42 | uBadSearchRequestSetFilter : String | semmle.label | uBadSearchRequestSetFilter : String |
+| LdapInjection.java:205:14:205:14 | s | semmle.label | s |
 | LdapInjection.java:234:30:234:54 | sBad : String | semmle.label | sBad : String |
-| LdapInjection.java:234:57:234:92 | sBadDNLNBuilder : String | semmle.label | sBadDNLNBuilder : String |
-| LdapInjection.java:235:20:235:77 | newInstance(...) : LdapNameBuilder | semmle.label | newInstance(...) : LdapNameBuilder |
-| LdapInjection.java:235:20:235:85 | build(...) | semmle.label | build(...) |
-| LdapInjection.java:235:48:235:76 | ... + ... : String | semmle.label | ... + ... : String |
-| LdapInjection.java:235:88:235:107 | ... + ... | semmle.label | ... + ... |
+| LdapInjection.java:234:57:234:83 | sBadDN : String | semmle.label | sBadDN : String |
+| LdapInjection.java:235:14:235:33 | ... + ... | semmle.label | ... + ... |
+| LdapInjection.java:235:36:235:55 | ... + ... | semmle.label | ... + ... |
 | LdapInjection.java:239:30:239:54 | sBad : String | semmle.label | sBad : String |
-| LdapInjection.java:239:57:239:95 | sBadDNLNBuilderAdd : String | semmle.label | sBadDNLNBuilderAdd : String |
-| LdapInjection.java:240:23:240:89 | add(...) : LdapNameBuilder | semmle.label | add(...) : LdapNameBuilder |
-| LdapInjection.java:240:23:240:97 | build(...) | semmle.label | build(...) |
-| LdapInjection.java:240:57:240:88 | ... + ... : String | semmle.label | ... + ... : String |
-| LdapInjection.java:240:100:240:119 | ... + ... | semmle.label | ... + ... |
-| LdapInjection.java:244:30:244:63 | sBadLdapQuery : String | semmle.label | sBadLdapQuery : String |
-| LdapInjection.java:245:15:245:76 | filter(...) | semmle.label | filter(...) |
-| LdapInjection.java:245:47:245:75 | ... + ... : String | semmle.label | ... + ... : String |
-| LdapInjection.java:249:30:249:60 | sBadFilter : String | semmle.label | sBadFilter : String |
-| LdapInjection.java:249:63:249:98 | sBadDNLdapUtils : String | semmle.label | sBadDNLdapUtils : String |
-| LdapInjection.java:250:12:250:63 | newLdapName(...) | semmle.label | newLdapName(...) |
-| LdapInjection.java:250:34:250:62 | ... + ... : String | semmle.label | ... + ... : String |
-| LdapInjection.java:250:66:250:112 | new HardcodedFilter(...) | semmle.label | new HardcodedFilter(...) |
-| LdapInjection.java:250:86:250:111 | ... + ... : String | semmle.label | ... + ... : String |
-| LdapInjection.java:254:30:254:63 | sBadLdapQuery : String | semmle.label | sBadLdapQuery : String |
-| LdapInjection.java:255:24:255:85 | filter(...) | semmle.label | filter(...) |
-| LdapInjection.java:255:56:255:84 | ... + ... : String | semmle.label | ... + ... : String |
-| LdapInjection.java:259:30:259:64 | sBadLdapQuery2 : String | semmle.label | sBadLdapQuery2 : String |
-| LdapInjection.java:260:19:260:81 | filter(...) : LdapQuery | semmle.label | filter(...) : LdapQuery |
-| LdapInjection.java:260:51:260:80 | ... + ... : String | semmle.label | ... + ... : String |
-| LdapInjection.java:261:24:261:24 | q | semmle.label | q |
-| LdapInjection.java:265:30:265:73 | sBadLdapQueryWithFilter : String | semmle.label | sBadLdapQueryWithFilter : String |
-| LdapInjection.java:266:24:266:116 | filter(...) | semmle.label | filter(...) |
-| LdapInjection.java:266:56:266:115 | new HardcodedFilter(...) : HardcodedFilter | semmle.label | new HardcodedFilter(...) : HardcodedFilter |
-| LdapInjection.java:266:76:266:114 | ... + ... : String | semmle.label | ... + ... : String |
-| LdapInjection.java:270:30:270:74 | sBadLdapQueryWithFilter2 : String | semmle.label | sBadLdapQueryWithFilter2 : String |
-| LdapInjection.java:271:48:271:108 | new HardcodedFilter(...) : HardcodedFilter | semmle.label | new HardcodedFilter(...) : HardcodedFilter |
-| LdapInjection.java:271:68:271:107 | ... + ... : String | semmle.label | ... + ... : String |
-| LdapInjection.java:272:24:272:57 | filter(...) | semmle.label | filter(...) |
-| LdapInjection.java:272:56:272:56 | f : HardcodedFilter | semmle.label | f : HardcodedFilter |
-| LdapInjection.java:276:31:276:68 | sBadLdapQueryBase : String | semmle.label | sBadLdapQueryBase : String |
-| LdapInjection.java:277:12:277:59 | base(...) : LdapQueryBuilder | semmle.label | base(...) : LdapQueryBuilder |
-| LdapInjection.java:277:12:277:66 | base(...) | semmle.label | base(...) |
-| LdapInjection.java:277:42:277:58 | sBadLdapQueryBase : String | semmle.label | sBadLdapQueryBase : String |
-| LdapInjection.java:281:31:281:71 | sBadLdapQueryComplex : String | semmle.label | sBadLdapQueryComplex : String |
-| LdapInjection.java:282:24:282:74 | base(...) : LdapQueryBuilder | semmle.label | base(...) : LdapQueryBuilder |
-| LdapInjection.java:282:24:282:87 | where(...) : ConditionCriteria | semmle.label | where(...) : ConditionCriteria |
-| LdapInjection.java:282:24:282:98 | is(...) | semmle.label | is(...) |
-| LdapInjection.java:282:54:282:73 | sBadLdapQueryComplex : String | semmle.label | sBadLdapQueryComplex : String |
-| LdapInjection.java:286:31:286:69 | sBadFilterToString : String | semmle.label | sBadFilterToString : String |
-| LdapInjection.java:287:18:287:72 | new HardcodedFilter(...) : HardcodedFilter | semmle.label | new HardcodedFilter(...) : HardcodedFilter |
-| LdapInjection.java:287:18:287:83 | toString(...) | semmle.label | toString(...) |
-| LdapInjection.java:287:38:287:71 | ... + ... : String | semmle.label | ... + ... : String |
-| LdapInjection.java:291:31:291:67 | sBadFilterEncode : String | semmle.label | sBadFilterEncode : String |
-| LdapInjection.java:293:5:293:57 | new HardcodedFilter(...) : HardcodedFilter | semmle.label | new HardcodedFilter(...) : HardcodedFilter |
-| LdapInjection.java:293:25:293:56 | ... + ... : String | semmle.label | ... + ... : String |
-| LdapInjection.java:293:66:293:66 | s : StringBuffer | semmle.label | s : StringBuffer |
-| LdapInjection.java:294:18:294:18 | s : StringBuffer | semmle.label | s : StringBuffer |
-| LdapInjection.java:294:18:294:29 | toString(...) | semmle.label | toString(...) |
-| LdapInjection.java:314:30:314:54 | aBad : String | semmle.label | aBad : String |
-| LdapInjection.java:314:57:314:83 | aBadDN : String | semmle.label | aBadDN : String |
-| LdapInjection.java:316:14:316:33 | ... + ... | semmle.label | ... + ... |
-| LdapInjection.java:316:36:316:55 | ... + ... | semmle.label | ... + ... |
-| LdapInjection.java:320:30:320:54 | aBad : String | semmle.label | aBad : String |
-| LdapInjection.java:320:57:320:94 | aBadDNObjToString : String | semmle.label | aBadDNObjToString : String |
-| LdapInjection.java:322:14:322:52 | new Dn(...) : Dn | semmle.label | new Dn(...) : Dn |
-| LdapInjection.java:322:14:322:62 | getName(...) | semmle.label | getName(...) |
-| LdapInjection.java:322:21:322:51 | ... + ... : String | semmle.label | ... + ... : String |
-| LdapInjection.java:322:65:322:84 | ... + ... | semmle.label | ... + ... |
-| LdapInjection.java:326:30:326:67 | aBadSearchRequest : String | semmle.label | aBadSearchRequest : String |
-| LdapInjection.java:329:5:329:5 | s : SearchRequestImpl | semmle.label | s : SearchRequestImpl |
-| LdapInjection.java:329:17:329:49 | ... + ... : String | semmle.label | ... + ... : String |
-| LdapInjection.java:330:14:330:14 | s | semmle.label | s |
-| LdapInjection.java:334:74:334:103 | aBadDNObj : String | semmle.label | aBadDNObj : String |
-| LdapInjection.java:337:5:337:5 | s : SearchRequestImpl | semmle.label | s : SearchRequestImpl |
-| LdapInjection.java:337:15:337:45 | new Dn(...) : Dn | semmle.label | new Dn(...) : Dn |
-| LdapInjection.java:337:22:337:44 | ... + ... : String | semmle.label | ... + ... : String |
-| LdapInjection.java:338:14:338:14 | s | semmle.label | s |
-| LdapInjection.java:342:30:342:72 | aBadDNSearchRequestGet : String | semmle.label | aBadDNSearchRequestGet : String |
-| LdapInjection.java:345:5:345:5 | s : SearchRequestImpl | semmle.label | s : SearchRequestImpl |
-| LdapInjection.java:345:15:345:58 | new Dn(...) : Dn | semmle.label | new Dn(...) : Dn |
-| LdapInjection.java:345:22:345:57 | ... + ... : String | semmle.label | ... + ... : String |
-| LdapInjection.java:346:14:346:14 | s : SearchRequestImpl | semmle.label | s : SearchRequestImpl |
-| LdapInjection.java:346:14:346:24 | getBase(...) | semmle.label | getBase(...) |
+| LdapInjection.java:239:57:239:92 | sBadDNLNBuilder : String | semmle.label | sBadDNLNBuilder : String |
+| LdapInjection.java:240:20:240:77 | newInstance(...) : LdapNameBuilder | semmle.label | newInstance(...) : LdapNameBuilder |
+| LdapInjection.java:240:20:240:85 | build(...) | semmle.label | build(...) |
+| LdapInjection.java:240:48:240:76 | ... + ... : String | semmle.label | ... + ... : String |
+| LdapInjection.java:240:88:240:107 | ... + ... | semmle.label | ... + ... |
+| LdapInjection.java:244:30:244:54 | sBad : String | semmle.label | sBad : String |
+| LdapInjection.java:244:57:244:95 | sBadDNLNBuilderAdd : String | semmle.label | sBadDNLNBuilderAdd : String |
+| LdapInjection.java:245:23:245:89 | add(...) : LdapNameBuilder | semmle.label | add(...) : LdapNameBuilder |
+| LdapInjection.java:245:23:245:97 | build(...) | semmle.label | build(...) |
+| LdapInjection.java:245:57:245:88 | ... + ... : String | semmle.label | ... + ... : String |
+| LdapInjection.java:245:100:245:119 | ... + ... | semmle.label | ... + ... |
+| LdapInjection.java:249:30:249:63 | sBadLdapQuery : String | semmle.label | sBadLdapQuery : String |
+| LdapInjection.java:250:15:250:76 | filter(...) | semmle.label | filter(...) |
+| LdapInjection.java:250:47:250:75 | ... + ... : String | semmle.label | ... + ... : String |
+| LdapInjection.java:254:30:254:60 | sBadFilter : String | semmle.label | sBadFilter : String |
+| LdapInjection.java:254:63:254:98 | sBadDNLdapUtils : String | semmle.label | sBadDNLdapUtils : String |
+| LdapInjection.java:255:12:255:63 | newLdapName(...) | semmle.label | newLdapName(...) |
+| LdapInjection.java:255:34:255:62 | ... + ... : String | semmle.label | ... + ... : String |
+| LdapInjection.java:255:66:255:112 | new HardcodedFilter(...) | semmle.label | new HardcodedFilter(...) |
+| LdapInjection.java:255:86:255:111 | ... + ... : String | semmle.label | ... + ... : String |
+| LdapInjection.java:259:30:259:63 | sBadLdapQuery : String | semmle.label | sBadLdapQuery : String |
+| LdapInjection.java:260:24:260:85 | filter(...) | semmle.label | filter(...) |
+| LdapInjection.java:260:56:260:84 | ... + ... : String | semmle.label | ... + ... : String |
+| LdapInjection.java:264:30:264:64 | sBadLdapQuery2 : String | semmle.label | sBadLdapQuery2 : String |
+| LdapInjection.java:265:19:265:81 | filter(...) : LdapQuery | semmle.label | filter(...) : LdapQuery |
+| LdapInjection.java:265:51:265:80 | ... + ... : String | semmle.label | ... + ... : String |
+| LdapInjection.java:266:24:266:24 | q | semmle.label | q |
+| LdapInjection.java:270:30:270:73 | sBadLdapQueryWithFilter : String | semmle.label | sBadLdapQueryWithFilter : String |
+| LdapInjection.java:271:24:271:116 | filter(...) | semmle.label | filter(...) |
+| LdapInjection.java:271:56:271:115 | new HardcodedFilter(...) : HardcodedFilter | semmle.label | new HardcodedFilter(...) : HardcodedFilter |
+| LdapInjection.java:271:76:271:114 | ... + ... : String | semmle.label | ... + ... : String |
+| LdapInjection.java:275:30:275:74 | sBadLdapQueryWithFilter2 : String | semmle.label | sBadLdapQueryWithFilter2 : String |
+| LdapInjection.java:276:48:276:108 | new HardcodedFilter(...) : HardcodedFilter | semmle.label | new HardcodedFilter(...) : HardcodedFilter |
+| LdapInjection.java:276:68:276:107 | ... + ... : String | semmle.label | ... + ... : String |
+| LdapInjection.java:277:24:277:57 | filter(...) | semmle.label | filter(...) |
+| LdapInjection.java:277:56:277:56 | f : HardcodedFilter | semmle.label | f : HardcodedFilter |
+| LdapInjection.java:281:31:281:68 | sBadLdapQueryBase : String | semmle.label | sBadLdapQueryBase : String |
+| LdapInjection.java:282:12:282:59 | base(...) : LdapQueryBuilder | semmle.label | base(...) : LdapQueryBuilder |
+| LdapInjection.java:282:12:282:66 | base(...) | semmle.label | base(...) |
+| LdapInjection.java:282:42:282:58 | sBadLdapQueryBase : String | semmle.label | sBadLdapQueryBase : String |
+| LdapInjection.java:286:31:286:71 | sBadLdapQueryComplex : String | semmle.label | sBadLdapQueryComplex : String |
+| LdapInjection.java:287:24:287:74 | base(...) : LdapQueryBuilder | semmle.label | base(...) : LdapQueryBuilder |
+| LdapInjection.java:287:24:287:87 | where(...) : ConditionCriteria | semmle.label | where(...) : ConditionCriteria |
+| LdapInjection.java:287:24:287:98 | is(...) | semmle.label | is(...) |
+| LdapInjection.java:287:54:287:73 | sBadLdapQueryComplex : String | semmle.label | sBadLdapQueryComplex : String |
+| LdapInjection.java:291:31:291:69 | sBadFilterToString : String | semmle.label | sBadFilterToString : String |
+| LdapInjection.java:292:18:292:72 | new HardcodedFilter(...) : HardcodedFilter | semmle.label | new HardcodedFilter(...) : HardcodedFilter |
+| LdapInjection.java:292:18:292:83 | toString(...) | semmle.label | toString(...) |
+| LdapInjection.java:292:38:292:71 | ... + ... : String | semmle.label | ... + ... : String |
+| LdapInjection.java:296:31:296:67 | sBadFilterEncode : String | semmle.label | sBadFilterEncode : String |
+| LdapInjection.java:298:5:298:57 | new HardcodedFilter(...) : HardcodedFilter | semmle.label | new HardcodedFilter(...) : HardcodedFilter |
+| LdapInjection.java:298:25:298:56 | ... + ... : String | semmle.label | ... + ... : String |
+| LdapInjection.java:298:66:298:66 | s : StringBuffer | semmle.label | s : StringBuffer |
+| LdapInjection.java:299:18:299:18 | s : StringBuffer | semmle.label | s : StringBuffer |
+| LdapInjection.java:299:18:299:29 | toString(...) | semmle.label | toString(...) |
+| LdapInjection.java:319:30:319:54 | aBad : String | semmle.label | aBad : String |
+| LdapInjection.java:319:57:319:83 | aBadDN : String | semmle.label | aBadDN : String |
+| LdapInjection.java:321:14:321:33 | ... + ... | semmle.label | ... + ... |
+| LdapInjection.java:321:36:321:55 | ... + ... | semmle.label | ... + ... |
+| LdapInjection.java:325:30:325:54 | aBad : String | semmle.label | aBad : String |
+| LdapInjection.java:325:57:325:94 | aBadDNObjToString : String | semmle.label | aBadDNObjToString : String |
+| LdapInjection.java:327:14:327:52 | new Dn(...) : Dn | semmle.label | new Dn(...) : Dn |
+| LdapInjection.java:327:14:327:62 | getName(...) | semmle.label | getName(...) |
+| LdapInjection.java:327:21:327:51 | ... + ... : String | semmle.label | ... + ... : String |
+| LdapInjection.java:327:65:327:84 | ... + ... | semmle.label | ... + ... |
+| LdapInjection.java:331:30:331:67 | aBadSearchRequest : String | semmle.label | aBadSearchRequest : String |
+| LdapInjection.java:334:5:334:5 | s : SearchRequestImpl | semmle.label | s : SearchRequestImpl |
+| LdapInjection.java:334:17:334:49 | ... + ... : String | semmle.label | ... + ... : String |
+| LdapInjection.java:335:14:335:14 | s | semmle.label | s |
+| LdapInjection.java:339:74:339:103 | aBadDNObj : String | semmle.label | aBadDNObj : String |
+| LdapInjection.java:342:5:342:5 | s : SearchRequestImpl | semmle.label | s : SearchRequestImpl |
+| LdapInjection.java:342:15:342:45 | new Dn(...) : Dn | semmle.label | new Dn(...) : Dn |
+| LdapInjection.java:342:22:342:44 | ... + ... : String | semmle.label | ... + ... : String |
+| LdapInjection.java:343:14:343:14 | s | semmle.label | s |
+| LdapInjection.java:347:30:347:72 | aBadDNSearchRequestGet : String | semmle.label | aBadDNSearchRequestGet : String |
+| LdapInjection.java:350:5:350:5 | s : SearchRequestImpl | semmle.label | s : SearchRequestImpl |
+| LdapInjection.java:350:15:350:58 | new Dn(...) : Dn | semmle.label | new Dn(...) : Dn |
+| LdapInjection.java:350:22:350:57 | ... + ... : String | semmle.label | ... + ... : String |
+| LdapInjection.java:351:14:351:14 | s : SearchRequestImpl | semmle.label | s : SearchRequestImpl |
+| LdapInjection.java:351:14:351:24 | getBase(...) | semmle.label | getBase(...) |
+| LdapInjection.java:395:30:395:63 | bBadPrincipal : String | semmle.label | bBadPrincipal : String |
+| LdapInjection.java:398:41:398:95 | ... + ... | semmle.label | ... + ... |
+| LdapInjection.java:404:30:404:70 | bBadPrincipalLiteral : String | semmle.label | bBadPrincipalLiteral : String |
+| LdapInjection.java:407:47:407:98 | ... + ... | semmle.label | ... + ... |
+| LdapInjection.java:413:30:413:58 | bBadBind : String | semmle.label | bBadBind : String |
+| LdapInjection.java:415:14:415:45 | ... + ... | semmle.label | ... + ... |
+| LdapInjection.java:420:30:420:60 | bBadLookup : String | semmle.label | bBadLookup : String |
+| LdapInjection.java:422:16:422:49 | ... + ... | semmle.label | ... + ... |
+| LdapInjection.java:427:37:427:66 | bBadShiro : String | semmle.label | bBadShiro : String |
+| LdapInjection.java:429:35:429:67 | ... + ... | semmle.label | ... + ... |
 subpaths

--- a/java/ql/test/query-tests/security/CWE-090/LdapInjection.java
+++ b/java/ql/test/query-tests/security/CWE-090/LdapInjection.java
@@ -1,7 +1,10 @@
+import java.util.Hashtable;
 import java.util.List;
 
+import javax.naming.Context;
 import javax.naming.Name;
 import javax.naming.NamingException;
+import javax.naming.directory.Attributes;
 import javax.naming.directory.BasicAttributes;
 import javax.naming.directory.DirContext;
 import javax.naming.directory.InitialDirContext;
@@ -10,6 +13,8 @@ import javax.naming.ldap.InitialLdapContext;
 import javax.naming.ldap.LdapContext;
 import javax.naming.ldap.LdapName;
 import javax.naming.ldap.Rdn;
+
+import org.apache.shiro.realm.ldap.LdapContextFactory;
 
 import com.unboundid.ldap.sdk.Filter;
 import com.unboundid.ldap.sdk.LDAPConnection;
@@ -379,5 +384,63 @@ public class LdapInjection {
   @RequestMapping
   public void testOk5(@RequestParam String okUnboundEncodeValue, DirContext ctx) throws NamingException {
     ctx.search("ou=system", "(uid=" + Filter.encodeValue(okUnboundEncodeValue) + ")", new SearchControls());
+  }
+
+  // Bind DN injection (CWE-90, RFC 2253). The DN escape set differs from the search
+  // filter escape set, so a DN sink needs a DN escaper (Rdn.escapeValue); a filter
+  // escaper (e.g. LdapEncoder.filterEncode) does NOT sanitize a DN.
+
+  // Context.SECURITY_PRINCIPAL environment value (the bind DN).
+  @RequestMapping
+  public void testBindDnBad1(@RequestParam String bBadPrincipal) // $ Source
+      throws NamingException {
+    Hashtable<String, Object> env = new Hashtable<String, Object>();
+    env.put(Context.SECURITY_PRINCIPAL, "uid=" + bBadPrincipal + ",ou=people,dc=example,dc=com"); // $ Alert
+    new InitialDirContext(env);
+  }
+
+  // Same sink via the literal property key.
+  @RequestMapping
+  public void testBindDnBad2(@RequestParam String bBadPrincipalLiteral) // $ Source
+      throws NamingException {
+    Hashtable<String, Object> env = new Hashtable<String, Object>();
+    env.put("java.naming.security.principal", "uid=" + bBadPrincipalLiteral + ",dc=example,dc=com"); // $ Alert
+    new InitialDirContext(env);
+  }
+
+  // DirContext.bind name argument is interpreted as a DN.
+  @RequestMapping
+  public void testBindDnBad3(@RequestParam String bBadBind, DirContext ctx) // $ Source
+      throws NamingException {
+    ctx.bind("uid=" + bBadBind + ",ou=people", null, new BasicAttributes()); // $ Alert
+  }
+
+  // Context.lookup name argument is interpreted as a DN (also a jndi-injection sink).
+  @RequestMapping
+  public void testBindDnBad4(@RequestParam String bBadLookup, Context ctx) // $ Source
+      throws NamingException {
+    ctx.lookup("uid=" + bBadLookup + ",ou=people"); // $ Alert
+  }
+
+  // Shiro LdapContextFactory.getLdapContext principal argument (CVE-2026-49268 sink).
+  @RequestMapping
+  public LdapContext testBindDnBad5(@RequestParam String bBadShiro, LdapContextFactory factory) // $ Source
+      throws NamingException {
+    return factory.getLdapContext("uid=" + bBadShiro + ",ou=people", "secret"); // $ Alert
+  }
+
+  // GOOD: the principal is escaped with Rdn.escapeValue (the canonical 2.2.1 fix).
+  @RequestMapping
+  public void testBindDnOk1(@RequestParam String bOkPrincipal) throws NamingException {
+    Hashtable<String, Object> env = new Hashtable<String, Object>();
+    env.put(Context.SECURITY_PRINCIPAL,
+        "uid=" + Rdn.escapeValue(bOkPrincipal) + ",ou=people,dc=example,dc=com"); // safe
+    new InitialDirContext(env);
+  }
+
+  // GOOD: bind DN escaped with Rdn.escapeValue.
+  @RequestMapping
+  public void testBindDnOk2(@RequestParam String bOkBind, DirContext ctx) throws NamingException {
+    ctx.bind("uid=" + Rdn.escapeValue(bOkBind) + ",ou=people", null, new BasicAttributes()); // safe
   }
 }

--- a/java/ql/test/query-tests/security/CWE-090/options
+++ b/java/ql/test/query-tests/security/CWE-090/options
@@ -1,1 +1,1 @@
-//semmle-extractor-options: --javac-args -cp ${testdir}/../../../stubs/springframework-5.8.x:${testdir}/../../../stubs/spring-ldap-2.3.2:${testdir}/../../../stubs/unboundid-ldap-4.0.14:${testdir}/../../../stubs/esapi-2.0.1:${testdir}/../../../stubs/apache-ldap-1.0.2
+//semmle-extractor-options: --javac-args -cp ${testdir}/../../../stubs/springframework-5.8.x:${testdir}/../../../stubs/spring-ldap-2.3.2:${testdir}/../../../stubs/unboundid-ldap-4.0.14:${testdir}/../../../stubs/esapi-2.0.1:${testdir}/../../../stubs/apache-ldap-1.0.2:${testdir}/../../../stubs/shiro-core-1.5.2

--- a/java/ql/test/stubs/shiro-core-1.5.2/org/apache/shiro/realm/ldap/LdapContextFactory.java
+++ b/java/ql/test/stubs/shiro-core-1.5.2/org/apache/shiro/realm/ldap/LdapContextFactory.java
@@ -1,0 +1,13 @@
+// Generated automatically from org.apache.shiro.realm.ldap.LdapContextFactory for testing purposes
+
+package org.apache.shiro.realm.ldap;
+
+import javax.naming.NamingException;
+import javax.naming.ldap.LdapContext;
+
+public interface LdapContextFactory
+{
+    LdapContext getSystemLdapContext() throws NamingException;
+
+    LdapContext getLdapContext(Object principal, Object credentials) throws NamingException;
+}


### PR DESCRIPTION
### What

`java/ldap-injection` models LDAP search sinks (the filter and base of a directory
search) but not the bind-DN path, where LDAP distinguished-name injection
(CWE-90, RFC 2253) actually lands. This PR adds the bind-DN sinks:

- **Models-as-Data** sink rows (`ldap-injection`):
  - `javax.naming.Context` `bind` / `rebind` / `createSubcontext` / `lookup` /
    `lookupLink` — the `String name` argument (`javax.naming.model.yml`).
  - `javax.naming.directory.DirContext` `bind` / `rebind` / `createSubcontext` — the
    `String name` argument (`javax.naming.directory.model.yml`).
  - `org.apache.shiro.realm.ldap.LdapContextFactory.getLdapContext` — the `principal`
    argument (new `org.apache.shiro.realm.ldap.model.yml`). This is the exact sink in
    Apache Shiro CVE-2026-49268.
- A hand-written `LdapInjectionSink` for the `java.naming.security.principal` JNDI
  environment value (`env.put(Context.SECURITY_PRINCIPAL, dn)` and the literal-key
  form). This cannot be a MaD sink because it keys off the `put` *key* argument, not
  the method signature.

When given a `String`, all of these positions interpret the argument as a
(distinguished) name; an unescaped, attacker-controlled value lets the caller
manipulate the DN structure used to authenticate, which can bypass authentication or
impersonate another principal.

### Deliberately not modeled

`new javax.naming.ldap.LdapName(String)` is **not** added as a sink. It commonly
parses an *existing* certificate or principal DN to read its RDNs (for example
`new LdapName(cert.getSubjectX500Principal().getName()).getRdns()`), which is not
injection. Modeling it as a sink would over-fire on that benign idiom. This is noted
in a code comment and in the change note. (The DN-string positions where a DN is used
to bind/look up/authenticate are the real sinks.)

### DN escaping vs filter escaping

DN escaping (RFC 2253) uses a different escape set from search-filter escaping
(RFC 4515). `Rdn.escapeValue` neutralizes DN metacharacters (`, + " \ < > ; =`,
leading `#`, leading/trailing space) but not filter metacharacters (`* ( )`). The
existing model already treats `Rdn.escapeValue` as flow-stopping (neutral model in
`ext/generated/modelgenerator/javax.naming.ldap.model.yml`), so the canonical Shiro
2.2.1 fix is correctly recognized as safe; the added test confirms this.

### Evidence (Apache Shiro CVE-2026-49268)

CVE-2026-49268 (fixed 2.2.1 / 3.0.0-alpha-2). `DefaultLdapRealm.getUserDn` and
`ActiveDirectoryRealm.getUsernameWithSuffix` concatenated the login username into the
bind DN with no escaping. Running a 3-way comparison on a database built from
`apache/shiro@shiro-root-2.2.0`:

| Query | Hits on Shiro 2.2.0 |
|---|---:|
| stock `java/ldap-injection` (before this PR) | 0 |
| `java/ldap-injection` with these bind-DN sinks | 0 (library has no remote flow source — see the companion experimental PR) |

The zero here is expected and is exactly the point: Shiro is an authentication
*library*, so there is no remote flow source for the app-mode query to start from. This
PR makes the query catch the same bind-DN construction in **downstream applications**
where the username crosses an HTTP boundary; catching the framework itself is the job
of the companion experimental query (`java/ldap-dn-injection-library-mode`).

### Tests

The CWE-090 query test gains bind-DN true positives for each new sink
(`Context.SECURITY_PRINCIPAL` via the constant and the literal key, `DirContext.bind`,
`Context.lookup`, `Shiro getLdapContext`) and `Rdn.escapeValue` true negatives.
`codeql test run` is green, and the query compiles with `--warnings=error`.
