### PR TITLE
Python: fix py/insecure-protocol false positive on ssl.create_default_context()

### DIFF
--- a/python/ql/src/Security/CWE-327/Ssl.qll
+++ b/python/ql/src/Security/CWE-327/Ssl.qll
@@ -33,9 +33,12 @@ class SslDefaultContextCreation extends ContextCreation {
     this = API::moduleImport("ssl").getMember("create_default_context").getACall()
   }
 
-  // Allowed insecure versions are "TLSv1" and "TLSv1_1"
+  // Since Python 3.10, `ssl.create_default_context` returns a context whose
+  // `minimum_version` defaults to `TLSVersion.TLSv1_2`, so TLSv1 and TLSv1_1 are not allowed.
+  // (Earlier Python versions also allowed TLSv1 and TLSv1_1.)
   // see https://docs.python.org/3/library/ssl.html#context-creation
-  override ProtocolVersion getProtocol() { result in ["TLSv1", "TLSv1_1", "TLSv1_2", "TLSv1_3"] }
+  // and https://docs.python.org/3/whatsnew/3.10.html#ssl
+  override ProtocolVersion getProtocol() { result in ["TLSv1_2", "TLSv1_3"] }
 }
 
 /** Gets a reference to an `ssl.Context` instance. */

--- a/python/ql/src/change-notes/2026-06-20-insecure-protocol-create-default-context.md
+++ b/python/ql/src/change-notes/2026-06-20-insecure-protocol-create-default-context.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The `py/insecure-protocol` query no longer reports `ssl.create_default_context` as allowing TLS 1.0 or TLS 1.1. Since Python 3.10, the context returned by `ssl.create_default_context` has its `minimum_version` set to `TLSVersion.TLSv1_2` by default, so these protocol versions are not allowed and the previous alerts were false positives.

--- a/python/ql/test/query-tests/Security/CWE-327-InsecureProtocol/InsecureProtocol.expected
+++ b/python/ql/test/query-tests/Security/CWE-327-InsecureProtocol/InsecureProtocol.expected
@@ -41,5 +41,3 @@
 | ssl_fluent.py:97:14:97:20 | ControlFlowNode for context | Insecure SSL/TLS protocol version TLSv1_1 allowed by $@. | ssl_fluent.py:65:15:65:46 | ControlFlowNode for Attribute() | call to ssl.SSLContext |
 | ssl_fluent.py:146:14:146:20 | ControlFlowNode for context | Insecure SSL/TLS protocol version TLSv1_1 allowed by $@. | ssl_fluent.py:142:15:142:46 | ControlFlowNode for Attribute() | call to ssl.SSLContext |
 | ssl_fluent.py:165:14:165:20 | ControlFlowNode for context | Insecure SSL/TLS protocol version SSLv3 allowed by $@. | ssl_fluent.py:161:15:161:65 | ControlFlowNode for Attribute() | call to ssl.create_default_context |
-| ssl_fluent.py:165:14:165:20 | ControlFlowNode for context | Insecure SSL/TLS protocol version TLSv1 allowed by $@. | ssl_fluent.py:161:15:161:65 | ControlFlowNode for Attribute() | call to ssl.create_default_context |
-| ssl_fluent.py:165:14:165:20 | ControlFlowNode for context | Insecure SSL/TLS protocol version TLSv1_1 allowed by $@. | ssl_fluent.py:161:15:161:65 | ControlFlowNode for Attribute() | call to ssl.create_default_context |

--- a/python/ql/test/query-tests/Security/CWE-327-InsecureProtocol/ssl_fluent.py
+++ b/python/ql/test/query-tests/Security/CWE-327-InsecureProtocol/ssl_fluent.py
@@ -164,3 +164,14 @@ def test_fluent_explicitly_unsafe():
     with socket.create_connection((hostname, 443)) as sock:
         with context.wrap_socket(sock, server_hostname=hostname) as ssock: # $ Alert
             print(ssock.version())
+
+# Since Python 3.10, `ssl.create_default_context` sets `minimum_version` to
+# `TLSVersion.TLSv1_2`, so TLSv1 and TLSv1_1 are not allowed.
+# see https://docs.python.org/3/library/ssl.html#context-creation
+def test_fluent_default_context_safe():
+    hostname = 'www.python.org'
+    context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
+
+    with socket.create_connection((hostname, 443)) as sock:
+        with context.wrap_socket(sock, server_hostname=hostname) as ssock: # No alert
+            print(ssock.version())


### PR DESCRIPTION
## Summary

The `py/insecure-protocol` query ("Use of insecure SSL/TLS version") flagged `ssl.create_default_context()` as allowing TLS 1.0 and TLS 1.1. On modern Python this is a false positive.

Since **Python 3.10**, `ssl.create_default_context()` returns a context whose `minimum_version` defaults to `ssl.TLSVersion.TLSv1_2`, so TLS 1.0 and TLS 1.1 are not allowed. The model in `Ssl.qll` encoded the pre-3.10 behavior.

Confirmed locally:

```
$ python3 -c 'import ssl; print(repr(ssl.create_default_context().minimum_version))'
<TLSVersion.TLSv1_2: 771>
```

Citations:
- *What's New In Python 3.10* — "The minimum TLS version is now 1.2 for `ssl.create_default_context()` and `ssl.SSLContext()`. TLS versions 1.0 and 1.1 are deprecated." <https://docs.python.org/3/whatsnew/3.10.html#ssl>
- `ssl.create_default_context()` docs <https://docs.python.org/3/library/ssl.html#ssl.create_default_context>

## Change

In `python/ql/src/Security/CWE-327/Ssl.qll`, `SslDefaultContextCreation.getProtocol()` now returns `["TLSv1_2", "TLSv1_3"]` instead of `["TLSv1", "TLSv1_1", "TLSv1_2", "TLSv1_3"]`, and the comment explains the Python 3.10 default `minimum_version = TLSv1_2`.

True positives are unaffected: explicit `ssl.PROTOCOL_TLSv1`, `ssl.SSLContext(...)` with an unspecific protocol, pyOpenSSL `TLSv1_METHOD`, and `wrap_socket(ssl_version=...)` are still flagged.

## Tests

- Updated `InsecureProtocol.expected`. The `test_fluent_explicitly_unsafe` case — `ssl.create_default_context(...)` followed by `context.options &= ~ssl.OP_NO_SSLv3` to deliberately re-enable SSLv3 — now alerts on **SSLv3 only**. With the new base allowed set `{TLSv1_2, TLSv1_3}`, the `options &=` unrestriction adds SSLv3 back and nothing else, so the previous `TLSv1` and `TLSv1_1` rows were removed.
- Added a regression test `test_fluent_default_context_safe`: a plain `ssl.create_default_context()` connection now produces no alert.
- Ran locally with CodeQL CLI 2.25.6: `codeql test run python/ql/test/query-tests/Security/CWE-327-InsecureProtocol/` → **all tests passed**. CI should re-validate.

## Tradeoff

The model now assumes the 3.10+ default (`minimum_version = TLSv1_2`). On pre-3.10 Python, `create_default_context()` did allow TLS 1.0/1.1, so this introduces a theoretical false negative there. That is acceptable: the last pre-3.10 release line, Python 3.9, reached end-of-life in October 2025.

Fixes github/codeql#21666
