### PR TITLE
C#: Use the feed manager in the `NugetExeWrapper`.

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/FeedManager.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/FeedManager.cs
@@ -88,12 +88,12 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         private IEnumerable<string> GetFeedsFromNugetConfig(string nugetConfigPath) =>
             GetFeeds(() => dotnet.GetNugetFeeds(nugetConfigPath));
 
-        private string FeedsToRestoreArgument(IEnumerable<string> feeds)
+        public string FeedsToRestoreArgument(IEnumerable<string> feeds, string sourceArgumentPrefix)
         {
             // If there are no feeds, we want to override any default feeds that `dotnet restore` would use by passing a dummy source argument.
             if (!feeds.Any())
             {
-                return $" -s \"{emptyPackageDirectory.DirInfo.FullName}\"";
+                return $" {sourceArgumentPrefix} \"{emptyPackageDirectory.DirInfo.FullName}\"";
             }
 
             // Add package sources. If any are present, they override all sources specified in
@@ -101,7 +101,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             var feedArgs = new StringBuilder();
             foreach (var feed in feeds)
             {
-                feedArgs.Append($" -s \"{feed}\"");
+                feedArgs.Append($" {sourceArgumentPrefix} \"{feed}\"");
             }
 
             return feedArgs.ToString();
@@ -114,15 +114,9 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         /// </summary>
         /// <param name="path">Path to project/solution</param>
         /// <param name="reachableFeeds">The set of reachable NuGet feeds.</param>
-        /// <returns>A string representing the NuGet sources argument for the restore command.</returns>
-        public string? MakeRestoreSourcesArgument(string path, HashSet<string> reachableFeeds)
+        /// <returns>The list of NuGet feeds to use for this restore.</returns>
+        public IEnumerable<string> FeedsToUse(string path, HashSet<string> reachableFeeds)
         {
-            // Do not construct a set of explicit NuGet sources to use for restore.
-            if (!CheckNugetFeedResponsiveness && !HasPrivateRegistryFeeds)
-            {
-                return null;
-            }
-
             // Find the path specific feeds.
             var folder = GetDirectoryName(path);
             var feedsToConsider = folder is not null ? GetFeedsFromFolder(folder).ToHashSet() : new HashSet<string>();
@@ -136,7 +130,28 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                 ? feedsToConsider.Where(reachableFeeds.Contains)
                 : feedsToConsider;
 
-            return FeedsToRestoreArgument(feedsToUse);
+            return feedsToUse;
+        }
+
+        /// <summary>
+        /// Constructs the list of NuGet sources to use for dotnet restore.
+        /// (1) Use the feeds we get from `dotnet nuget list source`
+        /// (2) Use private registries, if they are configured
+        /// </summary>
+        /// <param name="path">Path to project/solution</param>
+        /// <param name="reachableFeeds">The set of reachable NuGet feeds.</param>
+        /// <returns>A string representing the NuGet sources argument for the restore command.</returns>
+        public string? MakeDotnetRestoreSourcesArgument(string path, HashSet<string> reachableFeeds)
+        {
+            // Do not construct a set of explicit NuGet sources to use for restore.
+            if (!CheckNugetFeedResponsiveness && !HasPrivateRegistryFeeds)
+            {
+                return null;
+            }
+
+            var feedsToUse = FeedsToUse(path, reachableFeeds);
+
+            return FeedsToRestoreArgument(feedsToUse, "-s");
         }
 
         private (int initialTimeout, int tryCount) GetFeedRequestSettings(bool isFallback)

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/FeedManager.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/FeedManager.cs
@@ -90,7 +90,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
 
         public string FeedsToRestoreArgument(IEnumerable<string> feeds, string sourceArgumentPrefix)
         {
-            // If there are no feeds, we want to override any default feeds that `dotnet restore` would use by passing a dummy source argument.
+            // If there are no feeds, we want to override any default feeds that `restore` would use by passing a dummy source argument.
             if (!feeds.Any())
             {
                 return $" {sourceArgumentPrefix} \"{emptyPackageDirectory.DirInfo.FullName}\"";
@@ -112,7 +112,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         /// (1) Use the feeds we get from `dotnet nuget list source`
         /// (2) Use private registries, if they are configured
         /// </summary>
-        /// <param name="path">Path to project/solution</param>
+        /// <param name="path">Path to project/solution/packages.config</param>
         /// <param name="reachableFeeds">The set of reachable NuGet feeds.</param>
         /// <returns>The list of NuGet feeds to use for this restore.</returns>
         public IEnumerable<string> FeedsToUse(string path, HashSet<string> reachableFeeds)

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/NugetPackageRestorer.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/NugetPackageRestorer.cs
@@ -151,16 +151,14 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
 
             try
             {
-                using (var packagesConfigRestore = PackagesConfigRestoreFactory.Create(fileProvider, legacyPackageDirectory, logger, feedManager))
+                var packagesConfigRestore = PackagesConfigRestoreFactory.Create(fileProvider, legacyPackageDirectory, logger, feedManager, reachableFeeds);
+                var count = packagesConfigRestore.InstallPackages();
+                if (packagesConfigRestore.PackageCount > 0)
                 {
-                    var count = packagesConfigRestore.InstallPackages();
-
-                    if (packagesConfigRestore.PackageCount > 0)
-                    {
-                        compilationInfoContainer.CompilationInfos.Add(("packages.config files", packagesConfigRestore.PackageCount.ToString()));
-                        compilationInfoContainer.CompilationInfos.Add(("Successfully restored packages.config files", count.ToString()));
-                    }
+                    compilationInfoContainer.CompilationInfos.Add(("packages.config files", packagesConfigRestore.PackageCount.ToString()));
+                    compilationInfoContainer.CompilationInfos.Add(("Successfully restored packages.config files", count.ToString()));
                 }
+
 
                 var nugetPackageDlls = legacyPackageDirectory.DirInfo.GetFiles("*.dll", new EnumerationOptions { RecurseSubdirectories = true });
                 var nugetPackageDllPaths = nugetPackageDlls.Select(f => f.FullName).ToHashSet();
@@ -238,7 +236,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             var projects = fileProvider.Solutions.SelectMany(solution =>
                 {
                     logger.LogInfo($"Restoring solution {solution}...");
-                    var nugetSources = feedManager.MakeRestoreSourcesArgument(solution, reachableFeeds);
+                    var nugetSources = feedManager.MakeDotnetRestoreSourcesArgument(solution, reachableFeeds);
                     var res = dotnet.Restore(new(solution, PackageDirectory.DirInfo.FullName, ForceDotnetRefAssemblyFetching: true, NugetSources: nugetSources, TargetWindows: isWindows));
                     if (res.Success)
                     {
@@ -287,7 +285,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                 foreach (var project in projectGroup)
                 {
                     logger.LogInfo($"Restoring project {project}...");
-                    var nugetSources = feedManager.MakeRestoreSourcesArgument(project, reachableFeeds);
+                    var nugetSources = feedManager.MakeDotnetRestoreSourcesArgument(project, reachableFeeds);
                     var res = dotnet.Restore(new(project, PackageDirectory.DirInfo.FullName, ForceDotnetRefAssemblyFetching: true, NugetSources: nugetSources, TargetWindows: isWindows));
                     assets.AddDependenciesRange(res.AssetsFilePaths);
                     lock (sync)

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/NugetPackageRestorer.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/NugetPackageRestorer.cs
@@ -151,7 +151,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
 
             try
             {
-                using (var packagesConfigRestore = PackagesConfigRestoreFactory.Create(fileProvider, legacyPackageDirectory, logger, feedManager.IsDefaultFeedReachable))
+                using (var packagesConfigRestore = PackagesConfigRestoreFactory.Create(fileProvider, legacyPackageDirectory, logger, feedManager))
                 {
                     var count = packagesConfigRestore.InstallPackages();
 

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/NugetPackageRestorer.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/NugetPackageRestorer.cs
@@ -110,48 +110,47 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             logger.LogInfo($"Checking NuGet feed responsiveness: {feedManager.CheckNugetFeedResponsiveness}");
             compilationInfoContainer.CompilationInfos.Add(("NuGet feed responsiveness checked", feedManager.CheckNugetFeedResponsiveness ? "1" : "0"));
 
-            HashSet<string> explicitFeeds = [];
             HashSet<string> reachableFeeds = [];
+
+            EmitNugetConfigDiagnostics();
+
+            // Find feeds that are configured in NuGet.config files and divide them into ones that
+            // are explicitly configured for the project or by a private registry, and "all feeds"
+            // (including inherited ones) from other locations on the host outside of the working directory.
+            (var explicitFeeds, var allFeeds) = feedManager.GetAllFeeds();
+
+            if (feedManager.CheckNugetFeedResponsiveness)
+            {
+                var inheritedFeeds = allFeeds.Except(explicitFeeds).ToHashSet();
+
+                if (inheritedFeeds.Count > 0)
+                {
+                    compilationInfoContainer.CompilationInfos.Add(("Inherited NuGet feed count", inheritedFeeds.Count.ToString()));
+                }
+
+                var timeout = feedManager.CheckSpecifiedFeeds(explicitFeeds, out var reachableExplicitFeeds);
+                reachableFeeds.UnionWith(reachableExplicitFeeds);
+
+                var allExplicitReachable = explicitFeeds.Count == reachableExplicitFeeds.Count;
+                EmitUnreachableFeedsDiagnostics(allExplicitReachable);
+
+                if (timeout)
+                {
+                    // If we experience a timeout, we use this fallback.
+                    // todo: we could also check the reachability of the inherited nuget feeds, but to use those in the fallback we would need to handle authentication too.
+                    var unresponsiveMissingPackageLocation = DownloadMissingPackagesFromSpecificFeeds([], explicitFeeds);
+                    return unresponsiveMissingPackageLocation is null
+                        ? []
+                        : [unresponsiveMissingPackageLocation];
+                }
+
+                // Inherited feeds should only be used, if they are indeed reachable (as they may be environment specific).
+                feedManager.CheckSpecifiedFeeds(inheritedFeeds, out var reachableInheritedFeeds);
+                reachableFeeds.UnionWith(reachableInheritedFeeds);
+            }
 
             try
             {
-                EmitNugetConfigDiagnostics();
-
-                // Find feeds that are configured in NuGet.config files and divide them into ones that
-                // are explicitly configured for the project or by a private registry, and "all feeds"
-                // (including inherited ones) from other locations on the host outside of the working directory.
-                (explicitFeeds, var allFeeds) = feedManager.GetAllFeeds();
-
-                if (feedManager.CheckNugetFeedResponsiveness)
-                {
-                    var inheritedFeeds = allFeeds.Except(explicitFeeds).ToHashSet();
-
-                    if (inheritedFeeds.Count > 0)
-                    {
-                        compilationInfoContainer.CompilationInfos.Add(("Inherited NuGet feed count", inheritedFeeds.Count.ToString()));
-                    }
-
-                    var timeout = feedManager.CheckSpecifiedFeeds(explicitFeeds, out var reachableExplicitFeeds);
-                    reachableFeeds.UnionWith(reachableExplicitFeeds);
-
-                    var allExplicitReachable = explicitFeeds.Count == reachableExplicitFeeds.Count;
-                    EmitUnreachableFeedsDiagnostics(allExplicitReachable);
-
-                    if (timeout)
-                    {
-                        // If we experience a timeout, we use this fallback.
-                        // todo: we could also check the reachability of the inherited nuget feeds, but to use those in the fallback we would need to handle authentication too.
-                        var unresponsiveMissingPackageLocation = DownloadMissingPackagesFromSpecificFeeds([], explicitFeeds);
-                        return unresponsiveMissingPackageLocation is null
-                            ? []
-                            : [unresponsiveMissingPackageLocation];
-                    }
-
-                    // Inherited feeds should only be used, if they are indeed reachable (as they may be environment specific).
-                    feedManager.CheckSpecifiedFeeds(inheritedFeeds, out var reachableInheritedFeeds);
-                    reachableFeeds.UnionWith(reachableInheritedFeeds);
-                }
-
                 using (var packagesConfigRestore = PackagesConfigRestoreFactory.Create(fileProvider, legacyPackageDirectory, logger, feedManager.IsDefaultFeedReachable))
                 {
                     var count = packagesConfigRestore.InstallPackages();

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/PackagesConfigRestorer.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/PackagesConfigRestorer.cs
@@ -72,8 +72,6 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             private bool IsDefaultFeedReachable =>
                 isDefaultFeedReachable ??= feedManager.IsDefaultFeedReachable();
 
-
-
             /// <summary>
             /// Create the package manager for a specified source tree.
             /// </summary>
@@ -175,7 +173,8 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                 var feedsToUse = feedManager.FeedsToUse(packagesConfig, reachableFeeds).ToList();
                 var useDefaultFeed = feedsToUse.Count == 0 && IsDefaultFeedReachable;
 
-                // Explicitly construct the sources to be used for the restore command if any of the following is true:
+                // Explicitly construct the sources to be used for the restore command when checking feed
+                // responsiveness, using private registries, or falling back to nuget.org.
                 if (feedManager.CheckNugetFeedResponsiveness || feedManager.HasPrivateRegistryFeeds || useDefaultFeed)
                 {
                     if (useDefaultFeed)

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/PackagesConfigRestorer.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/PackagesConfigRestorer.cs
@@ -33,11 +33,11 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
     /// </summary>
     internal class PackagesConfigRestoreFactory
     {
-        public static IPackagesConfigRestore Create(FileProvider fileProvider, DependencyDirectory packageDirectory, Semmle.Util.Logging.ILogger logger, Func<bool> useDefaultFeed)
+        public static IPackagesConfigRestore Create(FileProvider fileProvider, DependencyDirectory packageDirectory, Semmle.Util.Logging.ILogger logger, FeedManager feedManager)
         {
             if (SystemBuildActions.Instance.IsWindows() || SystemBuildActions.Instance.IsMonoInstalled())
             {
-                return new NugetExeWrapper(fileProvider, packageDirectory, logger, useDefaultFeed);
+                return new NugetExeWrapper(fileProvider, packageDirectory, logger, feedManager);
             }
 
             return new NoOpPackagesConfig(fileProvider.PackagesConfigs, logger);
@@ -65,23 +65,25 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             /// so as to not trample the source tree.
             /// </summary>
             private readonly DependencyDirectory packageDirectory;
+            private readonly FeedManager feedManager;
 
             private bool IsWindows => SystemBuildActions.Instance.IsWindows();
 
             /// <summary>
             /// Create the package manager for a specified source tree.
             /// </summary>
-            public NugetExeWrapper(FileProvider fileProvider, DependencyDirectory packageDirectory, Semmle.Util.Logging.ILogger logger, Func<bool> useDefaultFeed)
+            public NugetExeWrapper(FileProvider fileProvider, DependencyDirectory packageDirectory, Semmle.Util.Logging.ILogger logger, FeedManager feedManager)
             {
                 this.fileProvider = fileProvider;
                 this.packageDirectory = packageDirectory;
                 this.logger = logger;
+                this.feedManager = feedManager;
 
                 if (fileProvider.PackagesConfigs.Count > 0)
                 {
                     logger.LogInfo($"Found packages.config files, trying to use nuget.exe for package restore");
                     nugetExe = ResolveNugetExe();
-                    if (!HasPackageSource() && useDefaultFeed())
+                    if (!HasPackageSource() && feedManager.IsDefaultFeedReachable())
                     {
                         // We only modify or add a top level nuget.config file
                         nugetConfigPath = Path.Join(fileProvider.SourceDir.FullName, "nuget.config");

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/PackagesConfigRestorer.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/PackagesConfigRestorer.cs
@@ -7,7 +7,7 @@ using Semmle.Util;
 
 namespace Semmle.Extraction.CSharp.DependencyFetching
 {
-    internal interface IPackagesConfigRestore : IDisposable
+    internal interface IPackagesConfigRestore
     {
         /// <summary>
         /// The number of packages.config files found in the source tree.
@@ -33,11 +33,11 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
     /// </summary>
     internal class PackagesConfigRestoreFactory
     {
-        public static IPackagesConfigRestore Create(FileProvider fileProvider, DependencyDirectory packageDirectory, Semmle.Util.Logging.ILogger logger, FeedManager feedManager)
+        public static IPackagesConfigRestore Create(FileProvider fileProvider, DependencyDirectory packageDirectory, Semmle.Util.Logging.ILogger logger, FeedManager feedManager, HashSet<string> reachableFeeds)
         {
             if (SystemBuildActions.Instance.IsWindows() || SystemBuildActions.Instance.IsMonoInstalled())
             {
-                return new NugetExeWrapper(fileProvider, packageDirectory, logger, feedManager);
+                return new NugetExeWrapper(fileProvider, packageDirectory, logger, feedManager, reachableFeeds);
             }
 
             return new NoOpPackagesConfig(fileProvider.PackagesConfigs, logger);
@@ -55,8 +55,6 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
 
             public int PackageCount => fileProvider.PackagesConfigs.Count;
 
-            private readonly string? backupNugetConfig;
-            private readonly string? nugetConfigPath;
             private readonly FileProvider fileProvider;
 
             /// <summary>
@@ -66,58 +64,31 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             /// </summary>
             private readonly DependencyDirectory packageDirectory;
             private readonly FeedManager feedManager;
+            private readonly HashSet<string> reachableFeeds;
 
             private bool IsWindows => SystemBuildActions.Instance.IsWindows();
+
+            private bool? isDefaultFeedReachable;
+            private bool IsDefaultFeedReachable =>
+                isDefaultFeedReachable ??= feedManager.IsDefaultFeedReachable();
+
+
 
             /// <summary>
             /// Create the package manager for a specified source tree.
             /// </summary>
-            public NugetExeWrapper(FileProvider fileProvider, DependencyDirectory packageDirectory, Semmle.Util.Logging.ILogger logger, FeedManager feedManager)
+            public NugetExeWrapper(FileProvider fileProvider, DependencyDirectory packageDirectory, Semmle.Util.Logging.ILogger logger, FeedManager feedManager, HashSet<string> reachableFeeds)
             {
                 this.fileProvider = fileProvider;
                 this.packageDirectory = packageDirectory;
                 this.logger = logger;
                 this.feedManager = feedManager;
+                this.reachableFeeds = reachableFeeds;
 
                 if (fileProvider.PackagesConfigs.Count > 0)
                 {
                     logger.LogInfo($"Found packages.config files, trying to use nuget.exe for package restore");
                     nugetExe = ResolveNugetExe();
-                    if (!HasPackageSource() && feedManager.IsDefaultFeedReachable())
-                    {
-                        // We only modify or add a top level nuget.config file
-                        nugetConfigPath = Path.Join(fileProvider.SourceDir.FullName, "nuget.config");
-                        try
-                        {
-                            if (File.Exists(nugetConfigPath))
-                            {
-                                var tempFolderPath = FileUtils.GetTemporaryWorkingDirectory(out _);
-
-                                do
-                                {
-                                    backupNugetConfig = Path.Join(tempFolderPath, Path.GetRandomFileName());
-                                }
-                                while (File.Exists(backupNugetConfig));
-                                File.Copy(nugetConfigPath, backupNugetConfig, true);
-                            }
-                            else
-                            {
-                                File.WriteAllText(nugetConfigPath,
-                                    """
-                                <?xml version="1.0" encoding="utf-8"?>
-                                <configuration>
-                                  <packageSources>
-                                  </packageSources>
-                                </configuration>
-                                """);
-                            }
-                            AddDefaultPackageSource(nugetConfigPath);
-                        }
-                        catch (Exception e)
-                        {
-                            logger.LogError($"Failed to add default package source to {nugetConfigPath}: {e}");
-                        }
-                    }
                 }
             }
 
@@ -200,6 +171,20 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             {
                 logger.LogInfo($"Restoring file \"{packagesConfig}\"...");
 
+                var sourcesArgument = "";
+                var feedsToUse = feedManager.FeedsToUse(packagesConfig, reachableFeeds).ToList();
+                var useDefaultFeed = feedsToUse.Count == 0 && IsDefaultFeedReachable;
+
+                // Explicitly construct the sources to be used for the restore command if any of the following is true:
+                if (feedManager.CheckNugetFeedResponsiveness || feedManager.HasPrivateRegistryFeeds || useDefaultFeed)
+                {
+                    if (useDefaultFeed)
+                    {
+                        feedsToUse.Add(FeedManager.PublicNugetOrgFeed);
+                    }
+                    sourcesArgument = feedManager.FeedsToRestoreArgument(feedsToUse, "-Source");
+                }
+
                 /* Use nuget.exe to install a package.
                  * Note that there is a clutch of NuGet assemblies which could be used to
                  * invoke this directly, which would arguably be nicer. However they are
@@ -210,12 +195,12 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                 if (RunWithMono)
                 {
                     exe = "mono";
-                    args = $"\"{nugetExe}\" install -OutputDirectory \"{packageDirectory}\" \"{packagesConfig}\"";
+                    args = $"\"{nugetExe}\" install -OutputDirectory \"{packageDirectory}\" {sourcesArgument} \"{packagesConfig}\"";
                 }
                 else
                 {
                     exe = nugetExe!;
-                    args = $"install -OutputDirectory \"{packageDirectory}\" \"{packagesConfig}\"";
+                    args = $"install -OutputDirectory \"{packageDirectory}\" {sourcesArgument} \"{packagesConfig}\"";
                 }
 
                 var pi = new ProcessStartInfo(exe, args)
@@ -248,98 +233,6 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             {
                 return fileProvider.PackagesConfigs.Count(TryRestoreNugetPackage);
             }
-
-            private bool HasPackageSource()
-            {
-                if (IsWindows)
-                {
-                    return true;
-                }
-
-                try
-                {
-                    logger.LogInfo("Checking if default package source is available...");
-                    RunMonoNugetCommand("sources list -ForceEnglishOutput", out var stdout);
-                    if (stdout.All(line => line != "No sources found."))
-                    {
-                        return true;
-                    }
-
-                    return false;
-                }
-                catch (Exception e)
-                {
-                    logger.LogWarning($"Failed to check if default package source is added: {e}");
-                    return true;
-                }
-            }
-
-            private void RunMonoNugetCommand(string command, out IList<string> stdout)
-            {
-                string exe, args;
-                if (RunWithMono)
-                {
-                    exe = "mono";
-                    args = $"\"{nugetExe}\" {command}";
-                }
-                else
-                {
-                    exe = nugetExe!;
-                    args = command;
-                }
-
-                var pi = new ProcessStartInfo(exe, args)
-                {
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    UseShellExecute = false
-                };
-
-                var threadId = Environment.CurrentManagedThreadId;
-                void onOut(string s) => logger.LogDebug(s, threadId);
-                void onError(string s) => logger.LogError(s, threadId);
-                pi.ReadOutput(out stdout, onOut, onError);
-            }
-
-            private void AddDefaultPackageSource(string nugetConfig)
-            {
-                logger.LogInfo("Adding default package source...");
-                RunMonoNugetCommand($"sources add -Name DefaultNugetOrg -Source {FeedManager.PublicNugetOrgFeed} -ConfigFile \"{nugetConfig}\"", out _);
-            }
-
-            public void Dispose()
-            {
-                if (nugetConfigPath is null)
-                {
-                    return;
-                }
-
-                try
-                {
-                    if (backupNugetConfig is null)
-                    {
-                        logger.LogInfo("Removing nuget.config file");
-                        File.Delete(nugetConfigPath);
-                        return;
-                    }
-
-                    logger.LogInfo("Reverting nuget.config file content");
-                    // The content of the original nuget.config file is reverted without changing the file's attributes or casing:
-                    using (var backup = File.OpenRead(backupNugetConfig))
-                    using (var current = File.OpenWrite(nugetConfigPath))
-                    {
-                        current.SetLength(0);   // Truncate file
-                        backup.CopyTo(current); // Restore original content
-                    }
-
-                    logger.LogInfo("Deleting backup nuget.config file");
-                    File.Delete(backupNugetConfig);
-                }
-                catch (Exception exc)
-                {
-                    logger.LogError($"Failed to restore original nuget.config file: {exc}");
-                }
-            }
         }
 
         private class NoOpPackagesConfig : IPackagesConfigRestore
@@ -363,8 +256,6 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                 }
                 return 0;
             }
-
-            public void Dispose() { }
         }
     }
 }

--- a/csharp/ql/lib/change-notes/2026-06-24-nuget-packages-config.md
+++ b/csharp/ql/lib/change-notes/2026-06-24-nuget-packages-config.md
@@ -1,0 +1,4 @@
+---
+category: majorAnalysis
+---
+* Simplified and streamlined the use of NuGet sources when downloading dependencies via `[mono] nuget.exe` in `build-mode: none`: NuGet sources are now supplied via the `-Source` flag instead of moving or creating `nuget.config` files in the checked-out repository, private registries are used if configured, and only reachable feeds are used when NuGet feed checking is enabled (the default).


### PR DESCRIPTION
Just like for `dotnet restore` is it possible to specify the NuGet sources directly when using the `nuget.exe` CLI. The documentation for the NuGet CLI can be seen [here](https://learn.microsoft.com/en-us/nuget/reference/cli-reference/cli-ref-list) and it states that it is possible to add (multiple) *sources* by providing (multiple) `-Source` arguments.

In this PR we *simplify* and *streamline* the use *nuget* *sources* when downloading dependencies using `[mono] nuget.exe`. That is, we
- No longer attempt to move/create `nuget.config` files in the checked out repo. Instead we supply the sources with the `-Source`.
- Make use of private registries if such are configured.
- Only use reachable feeds in case NuGet feed checking is enabled (which it is by default).

It is worth noting that we start to use `dotnet nuget` to detect the sources needed for the restore.

Both DCA and QA look good for this PR. It is unclear how many of the QA test repos are affected by the `nuget.exe` wrapper changes (it is also somewhat being out-phased as it requires a windows runner or a linux/macOS image with `mono` installed and a repo that uses the legacy `packages.config` files). However, QA and DCA at least verifies that the re-factorings in PR appear to be semantics preserving. Furthermore, it is worth noting that the `nuget.exe` wrapper is tested reasonably well with our integration tests and they appear to be stable.
