### PR TITLE
JavaScript: Recognize Angular @HostListener('window:message') as a postMessage handler

### DIFF
--- a/javascript/ql/lib/change-notes/2026-06-22-angular-hostlistener-postmessage.md
+++ b/javascript/ql/lib/change-notes/2026-06-22-angular-hostlistener-postmessage.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added support for Angular's `@HostListener('window:message', ...)` and `@HostListener('document:message', ...)` decorators as `postMessage` event handlers. The decorated method's event parameter is now recognized as a client-side remote flow source, and is considered by the `js/missing-origin-check` query.

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/DOM.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/DOM.qll
@@ -195,6 +195,18 @@ class PostMessageEventHandler extends Function {
       rhs = DataFlow::globalObjectRef().getAPropertyWrite("onmessage").getRhs() and
       rhs.getABoundFunctionValue(paramIndex).getFunction() = this
     )
+    or
+    // Angular's `@HostListener('window:message', ['$event'])` decorator registers
+    // a method as a `message` event handler on the global `window`/`document`
+    // target.  The decorated method receives the `MessageEvent` as its first
+    // parameter, so it is equivalent to `window.addEventListener('message', ...)`.
+    exists(MethodDefinition method, DataFlow::CallNode decorator |
+      decorator = DataFlow::moduleMember("@angular/core", "HostListener").getACall() and
+      decorator = method.getADecorator().getExpression().flow() and
+      decorator.getArgument(0).mayHaveStringValue(["window:message", "document:message", "message"]) and
+      method.getBody() = this and
+      paramIndex = 0
+    )
   }
 
   /**

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/DOM.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/DOM.qll
@@ -197,13 +197,13 @@ class PostMessageEventHandler extends Function {
     )
     or
     // Angular's `@HostListener('window:message', ['$event'])` decorator registers
-    // a method as a `message` event handler on the global `window`/`document`
+    // a method as a `message` event handler on the global `window` or `document`
     // target.  The decorated method receives the `MessageEvent` as its first
     // parameter, so it is equivalent to `window.addEventListener('message', ...)`.
     exists(MethodDefinition method, DataFlow::CallNode decorator |
       decorator = DataFlow::moduleMember("@angular/core", "HostListener").getACall() and
       decorator = method.getADecorator().getExpression().flow() and
-      decorator.getArgument(0).mayHaveStringValue(["window:message", "document:message", "message"]) and
+      decorator.getArgument(0).mayHaveStringValue(["window:message", "document:message"]) and
       method.getBody() = this and
       paramIndex = 0
     )

--- a/javascript/ql/test/query-tests/Security/CWE-020/MissingOriginCheck/Angular.ts
+++ b/javascript/ql/test/query-tests/Security/CWE-020/MissingOriginCheck/Angular.ts
@@ -1,0 +1,29 @@
+import { Component, HostListener } from '@angular/core';
+
+@Component({ selector: 'app-root' })
+class AngularComponent {
+  // Angular registers this as a `window` message handler via the decorator,
+  // equivalent to `window.addEventListener('message', ...)`.
+  @HostListener('window:message', ['$event'])
+  onWindowMessage(event: MessageEvent): void { // $ Alert - no origin check
+    eval(event.data);
+  }
+
+  @HostListener('document:message', ['$event'])
+  onDocumentMessage(event: MessageEvent): void { // $ Alert - no origin check
+    eval(event.data);
+  }
+
+  @HostListener('window:message', ['$event'])
+  onCheckedMessage(event: MessageEvent): void { // OK - has an origin check
+    if (event.origin === 'https://www.example.com') {
+      eval(event.data);
+    }
+  }
+
+  // Not a message event, so it is not a postMessage handler.
+  @HostListener('window:resize', ['$event'])
+  onResize(event: MessageEvent): void { // OK - not a message handler
+    eval(event.data);
+  }
+}

--- a/javascript/ql/test/query-tests/Security/CWE-020/MissingOriginCheck/MissingOriginCheck.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-020/MissingOriginCheck/MissingOriginCheck.expected
@@ -1,3 +1,5 @@
+| Angular.ts:8:19:8:23 | event | Postmessage handler has no origin check. |
+| Angular.ts:13:21:13:25 | event | Postmessage handler has no origin check. |
 | tst.js:11:20:11:24 | event | Postmessage handler has no origin check. |
 | tst.js:24:27:24:27 | e | Postmessage handler has no origin check. |
 | tst.js:40:27:40:27 | e | Postmessage handler has no origin check. |


### PR DESCRIPTION
## Summary

Angular applications commonly receive cross-window ``postMessage`` data through a handler registered with the ``@HostListener('window:message', ['$event'])`` decorator rather than ``window.addEventListener('message', ...)``.

The ``PostMessageEventHandler`` class (in ``DOM.qll``) only modeled the ``addEventListener('message', ...)`` and ``window.onmessage = ...`` forms. As a result, the decorated handler's event parameter was **not** recognized as a message-event source, which meant:

- ``js/missing-origin-check`` produced no alert for the missing ``event.origin`` check, and
- the event was not a ``ClientSideRemoteFlowSource``, so downstream taint queries (e.g. ``js/client-side-unvalidated-url-redirection``) did not flag flows from the message payload to sinks such as ``window.open`` / ``window.location.href``.

## Change

Extend ``PostMessageEventHandler`` to also recognize a method decorated with ``@HostListener`` from ``@angular/core`` when the event name is ``'window:message'`` or ``'document:message'``. The decorated method's first parameter is the ``MessageEvent``, equivalent to the ``addEventListener('message', ...)`` form.

## Impact

On a sample Angular app where a ``@HostListener('window:message')`` handler forwards the payload to navigation / URL-opening logic without an origin check:

- ``js/missing-origin-check`` now reports the handler (previously missed).
- ``js/client-side-unvalidated-url-redirection`` now reports two flows from the message event to ``window.open(msg.url, ...)`` and ``window.location.href = msg.url`` (previously missed).

## Test

Added ``Angular.ts`` to the ``MissingOriginCheck`` query test covering:

- ``@HostListener('window:message', ...)`` without an origin check: alert
- ``@HostListener('document:message', ...)`` without an origin check: alert
- ``@HostListener('window:message', ...)`` with an ``event.origin`` equality check: no alert
- ``@HostListener('window:resize', ...)`` (not a message event): no alert
