### PR TITLE
Shared CFG: allow destructuring in ForeachStmt

### DIFF
--- a/shared/controlflow/codeql/controlflow/ControlFlowGraph.qll
+++ b/shared/controlflow/codeql/controlflow/ControlFlowGraph.qll
@@ -148,12 +148,38 @@ signature module AstSig<LocationSig Location> {
 
   /** A for-loop that iterates over the elements of a collection. */
   class ForeachStmt extends LoopStmt {
-    /** Gets the variable declaration of this `foreach` loop. */
+    /**
+     * Gets the variable declaration of this `foreach` loop, if any.
+     *
+     * A `foreach` loop that binds more than one variable per iteration (for
+     * example when destructuring is used, as in `for k, v := range m` in Go, or
+     * `for (a, b) in ...` in Rust/Python/Swift) should instead opt in to the
+     * synthesized per-iteration element node (see `foreachHasElementNode`) and
+     * destructure that element into its variables, in which case this predicate
+     * need not have a result.
+     */
     Expr getVariable();
 
     /** Gets the collection expression of this `foreach` loop. */
     Expr getCollection();
   }
+
+  /**
+   * Holds if `foreach` has a synthesized per-iteration "element" node, that is,
+   * an additional control flow node representing the element produced by each
+   * iteration of the loop.
+   *
+   * When this holds, the shared library routes control flow from the loop
+   * header (and from the non-empty collection) into the element node, but the
+   * language is then responsible for wiring control flow out of the element
+   * node and on to the loop body (typically destructuring the element into the
+   * loop variables). In this mode the shared `getVariable` routing is not used.
+   *
+   * This is useful for languages whose loop variables are bound by extracting
+   * components from an implicit "current element" value (as opposed to being
+   * evaluated as ordinary target expressions).
+   */
+  default predicate foreachHasElementNode(ForeachStmt foreach) { none() }
 
   /**
    * A `break` statement.
@@ -684,6 +710,8 @@ module Make0<LocationSig Location, AstSig<Location> Ast> {
 
     private string patternMatchTrueTag() { result = "[MatchTrue]" }
 
+    private string foreachElementTag() { result = "[ForeachElement]" }
+
     /**
      * Holds if an additional node tagged with `tag` should be created for
      * `n`. Edges targeting such nodes are labeled with `t` and therefore `t`
@@ -701,6 +729,10 @@ module Make0<LocationSig Location, AstSig<Location> Ast> {
       or
       n instanceof LoopStmt and
       tag = loopHeaderTag() and
+      t instanceof DirectSuccessor
+      or
+      foreachHasElementNode(n) and
+      tag = foreachElementTag() and
       t instanceof DirectSuccessor
       or
       n instanceof PatternMatchExpr and
@@ -1640,7 +1672,21 @@ module Make0<LocationSig Location, AstSig<Location> Ast> {
           n2.isAfter(loopstmt)
         )
         or
-        exists(ForeachStmt foreachstmt |
+        exists(ForeachStmt foreachstmt, PreControlFlowNode iterentry |
+          // `iterentry` is where each iteration begins, after the loop header
+          // (or after the collection is found to be non-empty): the element
+          // node if the language opts in, otherwise the loop variable, or the
+          // body directly if there is no variable.
+          foreachHasElementNode(foreachstmt) and
+          iterentry.isAdditional(foreachstmt, foreachElementTag())
+          or
+          not foreachHasElementNode(foreachstmt) and
+          (
+            iterentry.isBefore(foreachstmt.getVariable())
+            or
+            not exists(foreachstmt.getVariable()) and iterentry.isBefore(foreachstmt.getBody())
+          )
+        |
           n1.isBefore(foreachstmt) and
           n2.isBefore(foreachstmt.getCollection())
           or
@@ -1654,8 +1700,14 @@ module Make0<LocationSig Location, AstSig<Location> Ast> {
           or
           n1.isAfterValue(foreachstmt.getCollection(),
             any(EmptinessSuccessor t | t.getValue() = false)) and
-          n2.isBefore(foreachstmt.getVariable())
+          n2 = iterentry
           or
+          n1.isAdditional(foreachstmt, loopHeaderTag()) and
+          n2 = iterentry
+          or
+          // After the loop variable, enter the body. When the language opts in
+          // to the element node, it is instead responsible for wiring the
+          // element node through to the body itself.
           n1.isAfter(foreachstmt.getVariable()) and
           n2.isBefore(foreachstmt.getBody())
           or
@@ -1668,9 +1720,6 @@ module Make0<LocationSig Location, AstSig<Location> Ast> {
             or
             not exists(getLoopElse(foreachstmt)) and n2.isAfter(foreachstmt)
           )
-          or
-          n1.isAdditional(foreachstmt, loopHeaderTag()) and
-          n2.isBefore(foreachstmt.getVariable())
         )
         or
         exists(ForStmt forstmt, PreControlFlowNode condentry |


### PR DESCRIPTION
This commit is taken from https://github.com/github/codeql/pull/21614. The following commit in that PR shows how Go uses the changes in this commit to implement go's range statement using the shared library's `ForeachStmt`. Here are some examples showing the valid syntax for range statements:

```go
for key, value := range mymap {
  fmt.Printf("mymap[%s] = %d\n", key, value)
}

for _, value = range array {
  fmt.Printf("array contains: %d\n", value)
}

for index, _ := range str {
  fmt.Printf("str[%d] = ?\n", index)
}

for value = range ch {
  fmt.Printf("value from channel: %d\n", value)
}
``` 

### Design notes / alternatives considered
The shared library now lets a language opt in to a synthesized per-iteration `ForeachElement` node (`foreachHasElementNode`). The intended contract is:

> The shared library owns the loop skeleton — testing the collection for emptiness, the [LoopHeader] join/branch point, the loop exit, and delivering control into [ForeachElement] at the start of each iteration. The language owns everything from the element node to the body, i.e. destructuring the current element into the loop variables.

This is a deliberate extension point, not an omission: when a language opts in, the shared library intentionally does not emit the getVariable() → body edge and instead hands control to the language at [ForeachElement].

Two more conventional designs were considered and rejected:

1. Mirror C#: a single target node, with no change to the shared library.
C# already supports tuple foreach (`foreach (var (a, b) in xs)`) without special CFG machinery — `getVariable()` returns a single `VariableDeclTuple` node and the generic expression CFG flows through its children to destructure. The equivalent for Go would be to present a single "target"/"pattern" node as `getVariable()`. This doesn't transfer: Go's range bindings are not a single grouping AST node. `for k, v := range m` is two independent LHS expressions plus an implicit extraction from the iterator, so there is no existing node to hand to the shared library. The `ForeachElement` node fills exactly this gap.

2. Generalize `getVariable()` to an indexed `getVariable(int i)` and chain inside the shared library (variable 0 → variable 1 → … → body).
This keeps all wiring in the shared library and produces a complete CFG with no language patching. It was prototyped and then rejected: Go's loop variables are not ordinary target expressions that can be evaluated in sequence — each is bound by extracting a component from the implicit current element. That per-variable extraction is language-specific and is more naturally owned by Go than modelled as a generic chain in the shared library.

Hence the chosen design: the shared library provides the loop skeleton plus a single opt-in element node, and Go wires `ForeachElement` → extract/assign → body itself. Java and C# do not opt in, keep their single `getVariable()`, and their generated CFG is byte-identical.