### PR TITLE
C#: Remove redundant code from `DeadStoreOfLocal.ql`

### DIFF
--- a/csharp/ql/src/Dead Code/DeadStoreOfLocal.ql
+++ b/csharp/ql/src/Dead Code/DeadStoreOfLocal.ql
@@ -14,54 +14,6 @@
 
 import csharp
 
-/**
- * Gets a callable that either directly captures local variable `v`, or which
- * is enclosed by the callable that declares `v` and encloses a callable that
- * captures `v`.
- */
-Callable getACapturingCallableAncestor(LocalVariable v) {
-  result = v.getACapturingCallable()
-  or
-  exists(Callable mid | mid = getACapturingCallableAncestor(v) |
-    result = mid.getEnclosingCallable() and
-    not v.getEnclosingCallable() = result
-  )
-}
-
-Expr getADelegateExpr(Callable c) {
-  c = result.(CallableAccess).getTarget()
-  or
-  result = c.(AnonymousFunctionExpr)
-}
-
-/**
- * Holds if `c` is a call where any delegate argument is evaluated immediately.
- */
-predicate nonEscapingCall(Call c) {
-  exists(string name | c.getTarget().hasName(name) |
-    name =
-      [
-        "ForEach", "Count", "Any", "All", "Average", "Aggregate", "First", "Last", "FirstOrDefault",
-        "LastOrDefault", "LongCount", "Max", "Single", "SingleOrDefault", "Sum"
-      ]
-  )
-}
-
-/**
- * Holds if `v` is a captured local variable, and one of the callables capturing
- * `v` may escape the local scope.
- */
-predicate mayEscape(LocalVariable v) {
-  exists(Callable c, Expr e, Expr succ | c = getACapturingCallableAncestor(v) |
-    e = getADelegateExpr(c) and
-    DataFlow::localExprFlow(e, succ) and
-    not succ = any(DelegateCall dc).getExpr() and
-    not succ = any(Cast cast).getExpr() and
-    not succ = any(Call call | nonEscapingCall(call)).getAnArgument() and
-    not succ = any(AssignableDefinition ad | ad.getTarget() instanceof LocalVariable).getSource()
-  )
-}
-
 class RelevantDefinition extends AssignableDefinition {
   RelevantDefinition() {
     this.(AssignableDefinitions::AssignmentDefinition).getAssignment() =
@@ -93,8 +45,6 @@ class RelevantDefinition extends AssignableDefinition {
     exists(LocalVariable v | v = this.getTarget() |
       // SSA definitions are only created for live variables
       this = any(SsaExplicitWrite ssaDef).getDefinition()
-      or
-      mayEscape(v)
       or
       v.isCaptured()
     )


### PR DESCRIPTION
The removed code was redundant since we filter away results for all captured variables.