### PR TITLE
Rust: Fix FPs in rust/hard-coded-cryptographic-value

### DIFF
--- a/rust/ql/lib/codeql/rust/security/HardcodedCryptographicValueExtensions.qll
+++ b/rust/ql/lib/codeql/rust/security/HardcodedCryptographicValueExtensions.qll
@@ -62,24 +62,27 @@ module HardcodedCryptographicValue {
   abstract class Barrier extends DataFlow::Node { }
 
   /**
-   * A literal, considered as a flow source.
+   * Holds if `e` is a literal or a combination of literals that is constant.
    */
-  private class LiteralSource extends Source {
-    LiteralSource() { this.asExpr() instanceof LiteralExpr }
+  private predicate isConstant(Expr e) {
+    e instanceof LiteralExpr // e.g. `0`
+    or
+    e.(ArrayListExpr).getExpr(_) instanceof LiteralExpr // e.g. `[0, 0, 0, 0]`
+    or
+    e.(ArrayRepeatExpr).getRepeatOperand() instanceof LiteralExpr // e.g. `[0; 10]`
+    or
+    e instanceof ConstAccess // e.g. `u64::MAX`
+    or
+    // e.g. `1 << 4`
+    isConstant(e.(BinaryExpr).getLhs()) and
+    isConstant(e.(BinaryExpr).getRhs())
   }
 
   /**
-   * An array initialized from a list of literals, considered as a single flow source. For example:
-   * ```
-   * [0, 0, 0, 0]
-   * [0; 10]
-   * ```
+   * A constant, considered as a flow source.
    */
-  private class ArrayListSource extends Source {
-    ArrayListSource() {
-      this.asExpr().(ArrayListExpr).getExpr(_) instanceof LiteralExpr or
-      this.asExpr().(ArrayRepeatExpr).getRepeatOperand() instanceof LiteralExpr
-    }
+  private class ConstantSource extends Source {
+    ConstantSource() { isConstant(this.asExpr()) }
   }
 
   /**
@@ -165,9 +168,9 @@ module HardcodedCryptographicValue {
   private class ArithmeticOperationBarrier extends Barrier {
     ArithmeticOperationBarrier() {
       // binary operations (e.g. `a + b`, `a ^ b`)
-      this.asExpr() instanceof BinaryArithmeticOperation
+      this.asExpr() = any(BinaryArithmeticOperation a).getAnOperand()
       or
-      this.asExpr() instanceof BinaryBitwiseOperation
+      this.asExpr() = any(BinaryBitwiseOperation a).getAnOperand()
       or
       // compound assignments (e.g. `a += b`, `a ^= b`)
       this.asExpr() = any(AssignArithmeticOperation a).getAnOperand()

--- a/rust/ql/lib/codeql/rust/security/HardcodedCryptographicValueExtensions.qll
+++ b/rust/ql/lib/codeql/rust/security/HardcodedCryptographicValueExtensions.qll
@@ -170,9 +170,9 @@ module HardcodedCryptographicValue {
       this.asExpr() instanceof BinaryBitwiseOperation
       or
       // compound assignments (e.g. `a += b`, `a ^= b`)
-      this.asExpr() = any(AssignArithmeticOperation a | | a.getAnOperand())
+      this.asExpr() = any(AssignArithmeticOperation a).getAnOperand()
       or
-      this.asExpr() = any(AssignBitwiseOperation a | | a.getAnOperand())
+      this.asExpr() = any(AssignBitwiseOperation a).getAnOperand()
     }
   }
 }

--- a/rust/ql/lib/codeql/rust/security/HardcodedCryptographicValueExtensions.qll
+++ b/rust/ql/lib/codeql/rust/security/HardcodedCryptographicValueExtensions.qll
@@ -160,7 +160,7 @@ module HardcodedCryptographicValue {
    * An arithmetic or bitwise operation that acts as a barrier.
    *
    * This prevents false positives where a hard-coded value is combined with
-   * non-constant data through operations like `+`, `^`, or `+=`.
+   * non-constant data through operations like `+`, `^`, or `+=` (including string concatenation).
    */
   private class ArithmeticOperationBarrier extends Barrier {
     ArithmeticOperationBarrier() {

--- a/rust/ql/lib/codeql/rust/security/HardcodedCryptographicValueExtensions.qll
+++ b/rust/ql/lib/codeql/rust/security/HardcodedCryptographicValueExtensions.qll
@@ -155,4 +155,24 @@ module HardcodedCryptographicValue {
       )
     }
   }
+
+  /**
+   * An arithmetic or bitwise operation that acts as a barrier.
+   *
+   * This prevents false positives where a hard-coded value is combined with
+   * non-constant data through operations like `+`, `^`, or `+=`.
+   */
+  private class ArithmeticOperationBarrier extends Barrier {
+    ArithmeticOperationBarrier() {
+      // binary operations (e.g. `a + b`, `a ^ b`)
+      this.asExpr() instanceof BinaryArithmeticOperation
+      or
+      this.asExpr() instanceof BinaryBitwiseOperation
+      or
+      // compound assignments (e.g. `a += b`, `a ^= b`)
+      this.asExpr() = any(AssignArithmeticOperation a | | a.getAnOperand())
+      or
+      this.asExpr() = any(AssignBitwiseOperation a | | a.getAnOperand())
+    }
+  }
 }

--- a/rust/ql/lib/codeql/rust/security/HardcodedCryptographicValueExtensions.qll
+++ b/rust/ql/lib/codeql/rust/security/HardcodedCryptographicValueExtensions.qll
@@ -72,9 +72,11 @@ module HardcodedCryptographicValue {
     isConstant(e.(ArrayRepeatExpr).getRepeatOperand()) // e.g. `[0; 10]`
     or
     // e.g. `const MY_CONST: u64 = ...`
+    // the constant initializer / body is the preferred source location for flow paths, when available.
     e = any(Const c).getBody()
     or
     // e.g. `u64::MAX`
+    // when the constant initializer is not available as a source location (case above), use the access instead.
     e instanceof ConstAccess and
     not exists(e.(ConstAccess).getConst().getBody())
     or

--- a/rust/ql/lib/codeql/rust/security/HardcodedCryptographicValueExtensions.qll
+++ b/rust/ql/lib/codeql/rust/security/HardcodedCryptographicValueExtensions.qll
@@ -67,9 +67,9 @@ module HardcodedCryptographicValue {
   private predicate isConstant(Expr e) {
     e instanceof LiteralExpr // e.g. `0`
     or
-    e.(ArrayListExpr).getExpr(_) instanceof LiteralExpr // e.g. `[0, 0, 0, 0]`
+    forex(Expr elem | elem = e.(ArrayListExpr).getExpr(_) | isConstant(elem)) // e.g. `[0, 0, 0, 0]`
     or
-    e.(ArrayRepeatExpr).getRepeatOperand() instanceof LiteralExpr // e.g. `[0; 10]`
+    isConstant(e.(ArrayRepeatExpr).getRepeatOperand()) // e.g. `[0; 10]`
     or
     // e.g. `const MY_CONST: u64 = ...`
     e = any(Const c).getBody()

--- a/rust/ql/lib/codeql/rust/security/HardcodedCryptographicValueExtensions.qll
+++ b/rust/ql/lib/codeql/rust/security/HardcodedCryptographicValueExtensions.qll
@@ -74,6 +74,10 @@ module HardcodedCryptographicValue {
     // e.g. `const MY_CONST: u64 = ...`
     e = any(Const c).getBody()
     or
+    // e.g. `u64::MAX`
+    e instanceof ConstAccess and
+    not exists(e.(ConstAccess).getConst().getBody())
+    or
     // e.g. `1 << 4`
     isConstant(e.(BinaryExpr).getLhs()) and
     isConstant(e.(BinaryExpr).getRhs())

--- a/rust/ql/lib/codeql/rust/security/HardcodedCryptographicValueExtensions.qll
+++ b/rust/ql/lib/codeql/rust/security/HardcodedCryptographicValueExtensions.qll
@@ -71,7 +71,8 @@ module HardcodedCryptographicValue {
     or
     e.(ArrayRepeatExpr).getRepeatOperand() instanceof LiteralExpr // e.g. `[0; 10]`
     or
-    e instanceof ConstAccess // e.g. `u64::MAX`
+    // e.g. `const MY_CONST: u64 = ...`
+    e = any(Const c).getBody()
     or
     // e.g. `1 << 4`
     isConstant(e.(BinaryExpr).getLhs()) and

--- a/rust/ql/src/change-notes/2026-06-25-hard-coded-cryptographic-value-arithmetic-barrier.md
+++ b/rust/ql/src/change-notes/2026-06-25-hard-coded-cryptographic-value-arithmetic-barrier.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The `rust/hard-coded-cryptographic-value` query now treats arithmetic and bitwise operations, including string append operations, as barriers. This addresses false positive results where hard-coded constants are combined with non-constant data, such as incrementing a nonce or appending variable data to a constant prefix.

--- a/rust/ql/test/query-tests/security/CWE-798/HardcodedCryptographicValue.expected
+++ b/rust/ql/test/query-tests/security/CWE-798/HardcodedCryptographicValue.expected
@@ -15,43 +15,37 @@
 | test_heuristic.rs:64:20:64:27 | [0u8; 16] | test_heuristic.rs:64:20:64:27 | [0u8; 16] | test_heuristic.rs:64:19:64:27 | &... | This hard-coded value is used as $@. | test_heuristic.rs:64:19:64:27 | &... | a nonce |
 | test_heuristic.rs:65:31:65:38 | [0u8; 16] | test_heuristic.rs:65:31:65:38 | [0u8; 16] | test_heuristic.rs:65:30:65:38 | &... | This hard-coded value is used as $@. | test_heuristic.rs:65:30:65:38 | &... | a salt |
 | test_heuristic.rs:67:22:67:22 | 0 | test_heuristic.rs:67:22:67:22 | 0 | test_heuristic.rs:67:22:67:22 | 0 | This hard-coded value is used as $@. | test_heuristic.rs:67:22:67:22 | 0 | a salt |
-| test_heuristic.rs:69:32:69:32 | 1 | test_heuristic.rs:69:32:69:32 | 1 | test_heuristic.rs:69:22:69:32 | ... + ... | This hard-coded value is used as $@. | test_heuristic.rs:69:22:69:32 | ... + ... | a salt |
-| test_heuristic.rs:70:34:70:35 | 32 | test_heuristic.rs:70:34:70:35 | 32 | test_heuristic.rs:70:22:70:62 | ... ^ ... | This hard-coded value is used as $@. | test_heuristic.rs:70:22:70:62 | ... ^ ... | a salt |
-| test_heuristic.rs:70:52:70:61 | 0xFFFFFFFF | test_heuristic.rs:70:52:70:61 | 0xFFFFFFFF | test_heuristic.rs:70:22:70:62 | ... ^ ... | This hard-coded value is used as $@. | test_heuristic.rs:70:22:70:62 | ... ^ ... | a salt |
-| test_heuristic.rs:72:20:72:24 | "foo" | test_heuristic.rs:72:20:72:24 | "foo" | test_heuristic.rs:74:28:74:32 | &key1 | This hard-coded value is used as $@. | test_heuristic.rs:74:28:74:32 | &key1 | a password |
-| test_heuristic.rs:73:13:73:17 | "bar" | test_heuristic.rs:73:13:73:17 | "bar" | test_heuristic.rs:74:28:74:32 | &key1 | This hard-coded value is used as $@. | test_heuristic.rs:74:28:74:32 | &key1 | a password |
-| test_heuristic.rs:76:20:76:24 | "foo" | test_heuristic.rs:76:20:76:24 | "foo" | test_heuristic.rs:78:28:78:32 | &key2 | This hard-coded value is used as $@. | test_heuristic.rs:78:28:78:32 | &key2 | a password |
 edges
 | test_cipher.rs:18:9:18:14 | const1 [&ref] | test_cipher.rs:19:73:19:78 | const1 [&ref] | provenance |  |
 | test_cipher.rs:18:28:18:36 | &... [&ref] | test_cipher.rs:18:9:18:14 | const1 [&ref] | provenance |  |
 | test_cipher.rs:18:29:18:36 | [0u8; 16] | test_cipher.rs:18:28:18:36 | &... [&ref] | provenance |  |
 | test_cipher.rs:19:49:19:79 | ...::from_slice(...) [&ref] | test_cipher.rs:19:30:19:47 | ...::new | provenance | MaD:3 Sink:MaD:3 |
-| test_cipher.rs:19:73:19:78 | const1 [&ref] | test_cipher.rs:19:49:19:79 | ...::from_slice(...) [&ref] | provenance | MaD:20 |
+| test_cipher.rs:19:73:19:78 | const1 [&ref] | test_cipher.rs:19:49:19:79 | ...::from_slice(...) [&ref] | provenance | MaD:13 |
 | test_cipher.rs:25:9:25:14 | const4 [&ref] | test_cipher.rs:26:66:26:71 | const4 [&ref] | provenance |  |
 | test_cipher.rs:25:28:25:36 | &... [&ref] | test_cipher.rs:25:9:25:14 | const4 [&ref] | provenance |  |
 | test_cipher.rs:25:29:25:36 | [0u8; 16] | test_cipher.rs:25:28:25:36 | &... [&ref] | provenance |  |
 | test_cipher.rs:26:42:26:72 | ...::from_slice(...) [&ref] | test_cipher.rs:26:30:26:40 | ...::new | provenance | MaD:4 Sink:MaD:4 |
-| test_cipher.rs:26:66:26:71 | const4 [&ref] | test_cipher.rs:26:42:26:72 | ...::from_slice(...) [&ref] | provenance | MaD:20 |
+| test_cipher.rs:26:66:26:71 | const4 [&ref] | test_cipher.rs:26:42:26:72 | ...::from_slice(...) [&ref] | provenance | MaD:13 |
 | test_cipher.rs:29:9:29:14 | const5 [&ref] | test_cipher.rs:30:95:30:100 | const5 [&ref] | provenance |  |
 | test_cipher.rs:29:28:29:36 | &... [&ref] | test_cipher.rs:29:9:29:14 | const5 [&ref] | provenance |  |
 | test_cipher.rs:29:29:29:36 | [0u8; 16] | test_cipher.rs:29:28:29:36 | &... [&ref] | provenance |  |
 | test_cipher.rs:30:72:30:101 | ...::from_slice(...) [&ref] | test_cipher.rs:30:30:30:40 | ...::new | provenance | MaD:5 Sink:MaD:5 |
-| test_cipher.rs:30:95:30:100 | const5 [&ref] | test_cipher.rs:30:72:30:101 | ...::from_slice(...) [&ref] | provenance | MaD:20 |
+| test_cipher.rs:30:95:30:100 | const5 [&ref] | test_cipher.rs:30:72:30:101 | ...::from_slice(...) [&ref] | provenance | MaD:13 |
 | test_cipher.rs:37:9:37:14 | const7 | test_cipher.rs:38:74:38:79 | const7 | provenance |  |
 | test_cipher.rs:37:27:37:74 | [...] | test_cipher.rs:37:9:37:14 | const7 | provenance |  |
 | test_cipher.rs:38:49:38:80 | ...::from_slice(...) [&ref] | test_cipher.rs:38:30:38:47 | ...::new | provenance | MaD:3 Sink:MaD:3 |
-| test_cipher.rs:38:73:38:79 | &const7 [&ref] | test_cipher.rs:38:49:38:80 | ...::from_slice(...) [&ref] | provenance | MaD:20 |
+| test_cipher.rs:38:73:38:79 | &const7 [&ref] | test_cipher.rs:38:49:38:80 | ...::from_slice(...) [&ref] | provenance | MaD:13 |
 | test_cipher.rs:38:74:38:79 | const7 | test_cipher.rs:38:73:38:79 | &const7 [&ref] | provenance |  |
 | test_cipher.rs:41:9:41:14 | const8 [&ref] | test_cipher.rs:42:73:42:78 | const8 [&ref] | provenance |  |
 | test_cipher.rs:41:28:41:76 | &... [&ref] | test_cipher.rs:41:9:41:14 | const8 [&ref] | provenance |  |
 | test_cipher.rs:41:29:41:76 | [...] | test_cipher.rs:41:28:41:76 | &... [&ref] | provenance |  |
 | test_cipher.rs:42:49:42:79 | ...::from_slice(...) [&ref] | test_cipher.rs:42:30:42:47 | ...::new | provenance | MaD:3 Sink:MaD:3 |
-| test_cipher.rs:42:73:42:78 | const8 [&ref] | test_cipher.rs:42:49:42:79 | ...::from_slice(...) [&ref] | provenance | MaD:20 |
+| test_cipher.rs:42:73:42:78 | const8 [&ref] | test_cipher.rs:42:49:42:79 | ...::from_slice(...) [&ref] | provenance | MaD:13 |
 | test_cipher.rs:50:9:50:15 | const10 [element] | test_cipher.rs:51:75:51:81 | const10 [element] | provenance |  |
 | test_cipher.rs:50:37:50:52 | ...::zeroed | test_cipher.rs:50:37:50:54 | ...::zeroed(...) [element] | provenance | Src:MaD:7  |
 | test_cipher.rs:50:37:50:54 | ...::zeroed(...) [element] | test_cipher.rs:50:9:50:15 | const10 [element] | provenance |  |
 | test_cipher.rs:51:50:51:82 | ...::from_slice(...) [&ref, element] | test_cipher.rs:51:31:51:48 | ...::new | provenance | MaD:3 Sink:MaD:3 Sink:MaD:3 |
-| test_cipher.rs:51:74:51:81 | &const10 [&ref, element] | test_cipher.rs:51:50:51:82 | ...::from_slice(...) [&ref, element] | provenance | MaD:20 |
+| test_cipher.rs:51:74:51:81 | &const10 [&ref, element] | test_cipher.rs:51:50:51:82 | ...::from_slice(...) [&ref, element] | provenance | MaD:13 |
 | test_cipher.rs:51:75:51:81 | const10 [element] | test_cipher.rs:51:74:51:81 | &const10 [&ref, element] | provenance |  |
 | test_cipher.rs:73:9:73:14 | const2 [&ref] | test_cipher.rs:74:46:74:51 | const2 [&ref] | provenance |  |
 | test_cipher.rs:73:18:73:26 | &... [&ref] | test_cipher.rs:73:9:73:14 | const2 [&ref] | provenance |  |
@@ -67,14 +61,14 @@ edges
 | test_cookie.rs:22:27:22:32 | array2 | test_cookie.rs:22:26:22:32 | &array2 [&ref] | provenance |  |
 | test_cookie.rs:38:9:38:14 | array2 | test_cookie.rs:42:34:42:39 | array2 | provenance |  |
 | test_cookie.rs:38:18:38:37 | ...::from(...) | test_cookie.rs:38:9:38:14 | array2 | provenance |  |
-| test_cookie.rs:38:28:38:36 | [0u8; 64] | test_cookie.rs:38:18:38:37 | ...::from(...) | provenance | MaD:15 |
-| test_cookie.rs:38:28:38:36 | [0u8; 64] | test_cookie.rs:38:18:38:37 | ...::from(...) | provenance | MaD:16 |
-| test_cookie.rs:38:28:38:36 | [0u8; 64] | test_cookie.rs:38:18:38:37 | ...::from(...) | provenance | MaD:17 |
-| test_cookie.rs:38:28:38:36 | [0u8; 64] | test_cookie.rs:38:18:38:37 | ...::from(...) | provenance | MaD:18 |
-| test_cookie.rs:38:28:38:36 | [0u8; 64] | test_cookie.rs:38:18:38:37 | ...::from(...) | provenance | MaD:19 |
+| test_cookie.rs:38:28:38:36 | [0u8; 64] | test_cookie.rs:38:18:38:37 | ...::from(...) | provenance | MaD:8 |
+| test_cookie.rs:38:28:38:36 | [0u8; 64] | test_cookie.rs:38:18:38:37 | ...::from(...) | provenance | MaD:9 |
+| test_cookie.rs:38:28:38:36 | [0u8; 64] | test_cookie.rs:38:18:38:37 | ...::from(...) | provenance | MaD:10 |
+| test_cookie.rs:38:28:38:36 | [0u8; 64] | test_cookie.rs:38:18:38:37 | ...::from(...) | provenance | MaD:11 |
+| test_cookie.rs:38:28:38:36 | [0u8; 64] | test_cookie.rs:38:18:38:37 | ...::from(...) | provenance | MaD:12 |
 | test_cookie.rs:42:34:42:39 | array2 | test_cookie.rs:42:14:42:32 | ...::from | provenance | MaD:2 Sink:MaD:2 |
 | test_cookie.rs:49:9:49:14 | array3 [element] | test_cookie.rs:53:34:53:39 | array3 [element] | provenance |  |
-| test_cookie.rs:49:23:49:25 | 0u8 | test_cookie.rs:49:23:49:29 | ...::from_elem(...) [element] | provenance | MaD:21 |
+| test_cookie.rs:49:23:49:25 | 0u8 | test_cookie.rs:49:23:49:29 | ...::from_elem(...) [element] | provenance | MaD:14 |
 | test_cookie.rs:49:23:49:29 | ...::from_elem(...) [element] | test_cookie.rs:49:9:49:14 | array3 [element] | provenance |  |
 | test_cookie.rs:53:34:53:39 | array3 [element] | test_cookie.rs:53:14:53:32 | ...::from | provenance | MaD:2 Sink:MaD:2 |
 | test_heuristic.rs:44:9:44:16 | const_iv [&ref] | test_heuristic.rs:45:41:45:48 | const_iv | provenance |  |
@@ -82,22 +76,6 @@ edges
 | test_heuristic.rs:44:31:44:38 | [0u8; 16] | test_heuristic.rs:44:30:44:38 | &... [&ref] | provenance |  |
 | test_heuristic.rs:64:20:64:27 | [0u8; 16] | test_heuristic.rs:64:19:64:27 | &... | provenance |  |
 | test_heuristic.rs:65:31:65:38 | [0u8; 16] | test_heuristic.rs:65:30:65:38 | &... | provenance |  |
-| test_heuristic.rs:69:32:69:32 | 1 | test_heuristic.rs:69:22:69:32 | ... + ... | provenance | MaD:9 |
-| test_heuristic.rs:70:23:70:35 | ... << ... | test_heuristic.rs:70:22:70:62 | ... ^ ... | provenance | MaD:13 |
-| test_heuristic.rs:70:34:70:35 | 32 | test_heuristic.rs:70:23:70:35 | ... << ... | provenance | MaD:14 |
-| test_heuristic.rs:70:41:70:61 | ... & ... | test_heuristic.rs:70:22:70:62 | ... ^ ... | provenance | MaD:13 |
-| test_heuristic.rs:70:52:70:61 | 0xFFFFFFFF | test_heuristic.rs:70:41:70:61 | ... & ... | provenance | MaD:12 |
-| test_heuristic.rs:72:9:72:16 | mut key1 | test_heuristic.rs:73:5:73:8 | key1 | provenance |  |
-| test_heuristic.rs:72:20:72:24 | "foo" | test_heuristic.rs:72:20:72:36 | "foo".to_string() | provenance | MaD:8 |
-| test_heuristic.rs:72:20:72:36 | "foo".to_string() | test_heuristic.rs:72:9:72:16 | mut key1 | provenance |  |
-| test_heuristic.rs:73:5:73:8 | key1 | test_heuristic.rs:74:29:74:32 | key1 | provenance | MaD:11 |
-| test_heuristic.rs:73:13:73:17 | "bar" | test_heuristic.rs:74:29:74:32 | key1 | provenance | MaD:10 |
-| test_heuristic.rs:74:29:74:32 | key1 | test_heuristic.rs:74:28:74:32 | &key1 | provenance |  |
-| test_heuristic.rs:76:9:76:16 | mut key2 | test_heuristic.rs:77:5:77:8 | key2 | provenance |  |
-| test_heuristic.rs:76:20:76:24 | "foo" | test_heuristic.rs:76:20:76:36 | "foo".to_string() | provenance | MaD:8 |
-| test_heuristic.rs:76:20:76:36 | "foo".to_string() | test_heuristic.rs:76:9:76:16 | mut key2 | provenance |  |
-| test_heuristic.rs:77:5:77:8 | key2 | test_heuristic.rs:78:29:78:32 | key2 | provenance | MaD:11 |
-| test_heuristic.rs:78:29:78:32 | key2 | test_heuristic.rs:78:28:78:32 | &key2 | provenance |  |
 models
 | 1 | Sink: <_ as crypto_common::KeyInit>::new_from_slice; Argument[0]; credentials-key |
 | 2 | Sink: <biscotti::crypto::master::Key>::from; Argument[0]; credentials-key |
@@ -106,20 +84,13 @@ models
 | 5 | Sink: <cipher::stream_wrapper::StreamCipherCoreWrapper as crypto_common::KeyIvInit>::new; Argument[1]; credentials-iv |
 | 6 | Sink: <cookie::secure::key::Key>::from; Argument[0].Reference; credentials-key |
 | 7 | Source: core::mem::zeroed; ReturnValue.Element; constant-source |
-| 8 | Summary: <_ as alloc::string::ToString>::to_string; Argument[self].Reference; ReturnValue; taint |
-| 9 | Summary: <_ as core::ops::arith::Add>::add; Argument[self,0]; ReturnValue; taint |
-| 10 | Summary: <_ as core::ops::arith::AddAssign>::add_assign; Argument[0]; Argument[self].Reference; taint |
-| 11 | Summary: <_ as core::ops::arith::AddAssign>::add_assign; Argument[self].Reference; Argument[self].Reference; taint |
-| 12 | Summary: <_ as core::ops::bit::BitAnd>::bitand; Argument[self,0]; ReturnValue; taint |
-| 13 | Summary: <_ as core::ops::bit::BitXor>::bitxor; Argument[self,0]; ReturnValue; taint |
-| 14 | Summary: <_ as core::ops::bit::Shl>::shl; Argument[self,0]; ReturnValue; taint |
-| 15 | Summary: <alloc::vec::Vec as core::convert::From>::from; Argument[0].Field[alloc::borrow::Cow::Owned(0)]; ReturnValue; value |
-| 16 | Summary: <alloc::vec::Vec as core::convert::From>::from; Argument[0].Field[alloc::bstr::ByteString(0)]; ReturnValue; value |
-| 17 | Summary: <alloc::vec::Vec as core::convert::From>::from; Argument[0].Field[alloc::collections::binary_heap::BinaryHeap::data]; ReturnValue; value |
-| 18 | Summary: <alloc::vec::Vec as core::convert::From>::from; Argument[0].Field[alloc::string::String::vec]; ReturnValue; value |
-| 19 | Summary: <alloc::vec::Vec as core::convert::From>::from; Argument[0]; ReturnValue; taint |
-| 20 | Summary: <generic_array::GenericArray>::from_slice; Argument[0].Reference; ReturnValue.Reference; value |
-| 21 | Summary: alloc::vec::from_elem; Argument[0]; ReturnValue.Element; value |
+| 8 | Summary: <alloc::vec::Vec as core::convert::From>::from; Argument[0].Field[alloc::borrow::Cow::Owned(0)]; ReturnValue; value |
+| 9 | Summary: <alloc::vec::Vec as core::convert::From>::from; Argument[0].Field[alloc::bstr::ByteString(0)]; ReturnValue; value |
+| 10 | Summary: <alloc::vec::Vec as core::convert::From>::from; Argument[0].Field[alloc::collections::binary_heap::BinaryHeap::data]; ReturnValue; value |
+| 11 | Summary: <alloc::vec::Vec as core::convert::From>::from; Argument[0].Field[alloc::string::String::vec]; ReturnValue; value |
+| 12 | Summary: <alloc::vec::Vec as core::convert::From>::from; Argument[0]; ReturnValue; taint |
+| 13 | Summary: <generic_array::GenericArray>::from_slice; Argument[0].Reference; ReturnValue.Reference; value |
+| 14 | Summary: alloc::vec::from_elem; Argument[0]; ReturnValue.Element; value |
 nodes
 | test_cipher.rs:18:9:18:14 | const1 [&ref] | semmle.label | const1 [&ref] |
 | test_cipher.rs:18:28:18:36 | &... [&ref] | semmle.label | &... [&ref] |
@@ -193,24 +164,4 @@ nodes
 | test_heuristic.rs:65:30:65:38 | &... | semmle.label | &... |
 | test_heuristic.rs:65:31:65:38 | [0u8; 16] | semmle.label | [0u8; 16] |
 | test_heuristic.rs:67:22:67:22 | 0 | semmle.label | 0 |
-| test_heuristic.rs:69:22:69:32 | ... + ... | semmle.label | ... + ... |
-| test_heuristic.rs:69:32:69:32 | 1 | semmle.label | 1 |
-| test_heuristic.rs:70:22:70:62 | ... ^ ... | semmle.label | ... ^ ... |
-| test_heuristic.rs:70:23:70:35 | ... << ... | semmle.label | ... << ... |
-| test_heuristic.rs:70:34:70:35 | 32 | semmle.label | 32 |
-| test_heuristic.rs:70:41:70:61 | ... & ... | semmle.label | ... & ... |
-| test_heuristic.rs:70:52:70:61 | 0xFFFFFFFF | semmle.label | 0xFFFFFFFF |
-| test_heuristic.rs:72:9:72:16 | mut key1 | semmle.label | mut key1 |
-| test_heuristic.rs:72:20:72:24 | "foo" | semmle.label | "foo" |
-| test_heuristic.rs:72:20:72:36 | "foo".to_string() | semmle.label | "foo".to_string() |
-| test_heuristic.rs:73:5:73:8 | key1 | semmle.label | key1 |
-| test_heuristic.rs:73:13:73:17 | "bar" | semmle.label | "bar" |
-| test_heuristic.rs:74:28:74:32 | &key1 | semmle.label | &key1 |
-| test_heuristic.rs:74:29:74:32 | key1 | semmle.label | key1 |
-| test_heuristic.rs:76:9:76:16 | mut key2 | semmle.label | mut key2 |
-| test_heuristic.rs:76:20:76:24 | "foo" | semmle.label | "foo" |
-| test_heuristic.rs:76:20:76:36 | "foo".to_string() | semmle.label | "foo".to_string() |
-| test_heuristic.rs:77:5:77:8 | key2 | semmle.label | key2 |
-| test_heuristic.rs:78:28:78:32 | &key2 | semmle.label | &key2 |
-| test_heuristic.rs:78:29:78:32 | key2 | semmle.label | key2 |
 subpaths

--- a/rust/ql/test/query-tests/security/CWE-798/HardcodedCryptographicValue.expected
+++ b/rust/ql/test/query-tests/security/CWE-798/HardcodedCryptographicValue.expected
@@ -18,37 +18,40 @@
 | test_heuristic.rs:69:32:69:32 | 1 | test_heuristic.rs:69:32:69:32 | 1 | test_heuristic.rs:69:22:69:32 | ... + ... | This hard-coded value is used as $@. | test_heuristic.rs:69:22:69:32 | ... + ... | a salt |
 | test_heuristic.rs:70:34:70:35 | 32 | test_heuristic.rs:70:34:70:35 | 32 | test_heuristic.rs:70:22:70:62 | ... ^ ... | This hard-coded value is used as $@. | test_heuristic.rs:70:22:70:62 | ... ^ ... | a salt |
 | test_heuristic.rs:70:52:70:61 | 0xFFFFFFFF | test_heuristic.rs:70:52:70:61 | 0xFFFFFFFF | test_heuristic.rs:70:22:70:62 | ... ^ ... | This hard-coded value is used as $@. | test_heuristic.rs:70:22:70:62 | ... ^ ... | a salt |
+| test_heuristic.rs:72:20:72:24 | "foo" | test_heuristic.rs:72:20:72:24 | "foo" | test_heuristic.rs:74:28:74:32 | &key1 | This hard-coded value is used as $@. | test_heuristic.rs:74:28:74:32 | &key1 | a password |
+| test_heuristic.rs:73:13:73:17 | "bar" | test_heuristic.rs:73:13:73:17 | "bar" | test_heuristic.rs:74:28:74:32 | &key1 | This hard-coded value is used as $@. | test_heuristic.rs:74:28:74:32 | &key1 | a password |
+| test_heuristic.rs:76:20:76:24 | "foo" | test_heuristic.rs:76:20:76:24 | "foo" | test_heuristic.rs:78:28:78:32 | &key2 | This hard-coded value is used as $@. | test_heuristic.rs:78:28:78:32 | &key2 | a password |
 edges
 | test_cipher.rs:18:9:18:14 | const1 [&ref] | test_cipher.rs:19:73:19:78 | const1 [&ref] | provenance |  |
 | test_cipher.rs:18:28:18:36 | &... [&ref] | test_cipher.rs:18:9:18:14 | const1 [&ref] | provenance |  |
 | test_cipher.rs:18:29:18:36 | [0u8; 16] | test_cipher.rs:18:28:18:36 | &... [&ref] | provenance |  |
 | test_cipher.rs:19:49:19:79 | ...::from_slice(...) [&ref] | test_cipher.rs:19:30:19:47 | ...::new | provenance | MaD:3 Sink:MaD:3 |
-| test_cipher.rs:19:73:19:78 | const1 [&ref] | test_cipher.rs:19:49:19:79 | ...::from_slice(...) [&ref] | provenance | MaD:17 |
+| test_cipher.rs:19:73:19:78 | const1 [&ref] | test_cipher.rs:19:49:19:79 | ...::from_slice(...) [&ref] | provenance | MaD:20 |
 | test_cipher.rs:25:9:25:14 | const4 [&ref] | test_cipher.rs:26:66:26:71 | const4 [&ref] | provenance |  |
 | test_cipher.rs:25:28:25:36 | &... [&ref] | test_cipher.rs:25:9:25:14 | const4 [&ref] | provenance |  |
 | test_cipher.rs:25:29:25:36 | [0u8; 16] | test_cipher.rs:25:28:25:36 | &... [&ref] | provenance |  |
 | test_cipher.rs:26:42:26:72 | ...::from_slice(...) [&ref] | test_cipher.rs:26:30:26:40 | ...::new | provenance | MaD:4 Sink:MaD:4 |
-| test_cipher.rs:26:66:26:71 | const4 [&ref] | test_cipher.rs:26:42:26:72 | ...::from_slice(...) [&ref] | provenance | MaD:17 |
+| test_cipher.rs:26:66:26:71 | const4 [&ref] | test_cipher.rs:26:42:26:72 | ...::from_slice(...) [&ref] | provenance | MaD:20 |
 | test_cipher.rs:29:9:29:14 | const5 [&ref] | test_cipher.rs:30:95:30:100 | const5 [&ref] | provenance |  |
 | test_cipher.rs:29:28:29:36 | &... [&ref] | test_cipher.rs:29:9:29:14 | const5 [&ref] | provenance |  |
 | test_cipher.rs:29:29:29:36 | [0u8; 16] | test_cipher.rs:29:28:29:36 | &... [&ref] | provenance |  |
 | test_cipher.rs:30:72:30:101 | ...::from_slice(...) [&ref] | test_cipher.rs:30:30:30:40 | ...::new | provenance | MaD:5 Sink:MaD:5 |
-| test_cipher.rs:30:95:30:100 | const5 [&ref] | test_cipher.rs:30:72:30:101 | ...::from_slice(...) [&ref] | provenance | MaD:17 |
+| test_cipher.rs:30:95:30:100 | const5 [&ref] | test_cipher.rs:30:72:30:101 | ...::from_slice(...) [&ref] | provenance | MaD:20 |
 | test_cipher.rs:37:9:37:14 | const7 | test_cipher.rs:38:74:38:79 | const7 | provenance |  |
 | test_cipher.rs:37:27:37:74 | [...] | test_cipher.rs:37:9:37:14 | const7 | provenance |  |
 | test_cipher.rs:38:49:38:80 | ...::from_slice(...) [&ref] | test_cipher.rs:38:30:38:47 | ...::new | provenance | MaD:3 Sink:MaD:3 |
-| test_cipher.rs:38:73:38:79 | &const7 [&ref] | test_cipher.rs:38:49:38:80 | ...::from_slice(...) [&ref] | provenance | MaD:17 |
+| test_cipher.rs:38:73:38:79 | &const7 [&ref] | test_cipher.rs:38:49:38:80 | ...::from_slice(...) [&ref] | provenance | MaD:20 |
 | test_cipher.rs:38:74:38:79 | const7 | test_cipher.rs:38:73:38:79 | &const7 [&ref] | provenance |  |
 | test_cipher.rs:41:9:41:14 | const8 [&ref] | test_cipher.rs:42:73:42:78 | const8 [&ref] | provenance |  |
 | test_cipher.rs:41:28:41:76 | &... [&ref] | test_cipher.rs:41:9:41:14 | const8 [&ref] | provenance |  |
 | test_cipher.rs:41:29:41:76 | [...] | test_cipher.rs:41:28:41:76 | &... [&ref] | provenance |  |
 | test_cipher.rs:42:49:42:79 | ...::from_slice(...) [&ref] | test_cipher.rs:42:30:42:47 | ...::new | provenance | MaD:3 Sink:MaD:3 |
-| test_cipher.rs:42:73:42:78 | const8 [&ref] | test_cipher.rs:42:49:42:79 | ...::from_slice(...) [&ref] | provenance | MaD:17 |
+| test_cipher.rs:42:73:42:78 | const8 [&ref] | test_cipher.rs:42:49:42:79 | ...::from_slice(...) [&ref] | provenance | MaD:20 |
 | test_cipher.rs:50:9:50:15 | const10 [element] | test_cipher.rs:51:75:51:81 | const10 [element] | provenance |  |
 | test_cipher.rs:50:37:50:52 | ...::zeroed | test_cipher.rs:50:37:50:54 | ...::zeroed(...) [element] | provenance | Src:MaD:7  |
 | test_cipher.rs:50:37:50:54 | ...::zeroed(...) [element] | test_cipher.rs:50:9:50:15 | const10 [element] | provenance |  |
 | test_cipher.rs:51:50:51:82 | ...::from_slice(...) [&ref, element] | test_cipher.rs:51:31:51:48 | ...::new | provenance | MaD:3 Sink:MaD:3 Sink:MaD:3 |
-| test_cipher.rs:51:74:51:81 | &const10 [&ref, element] | test_cipher.rs:51:50:51:82 | ...::from_slice(...) [&ref, element] | provenance | MaD:17 |
+| test_cipher.rs:51:74:51:81 | &const10 [&ref, element] | test_cipher.rs:51:50:51:82 | ...::from_slice(...) [&ref, element] | provenance | MaD:20 |
 | test_cipher.rs:51:75:51:81 | const10 [element] | test_cipher.rs:51:74:51:81 | &const10 [&ref, element] | provenance |  |
 | test_cipher.rs:73:9:73:14 | const2 [&ref] | test_cipher.rs:74:46:74:51 | const2 [&ref] | provenance |  |
 | test_cipher.rs:73:18:73:26 | &... [&ref] | test_cipher.rs:73:9:73:14 | const2 [&ref] | provenance |  |
@@ -64,14 +67,14 @@ edges
 | test_cookie.rs:22:27:22:32 | array2 | test_cookie.rs:22:26:22:32 | &array2 [&ref] | provenance |  |
 | test_cookie.rs:38:9:38:14 | array2 | test_cookie.rs:42:34:42:39 | array2 | provenance |  |
 | test_cookie.rs:38:18:38:37 | ...::from(...) | test_cookie.rs:38:9:38:14 | array2 | provenance |  |
-| test_cookie.rs:38:28:38:36 | [0u8; 64] | test_cookie.rs:38:18:38:37 | ...::from(...) | provenance | MaD:12 |
-| test_cookie.rs:38:28:38:36 | [0u8; 64] | test_cookie.rs:38:18:38:37 | ...::from(...) | provenance | MaD:13 |
-| test_cookie.rs:38:28:38:36 | [0u8; 64] | test_cookie.rs:38:18:38:37 | ...::from(...) | provenance | MaD:14 |
 | test_cookie.rs:38:28:38:36 | [0u8; 64] | test_cookie.rs:38:18:38:37 | ...::from(...) | provenance | MaD:15 |
 | test_cookie.rs:38:28:38:36 | [0u8; 64] | test_cookie.rs:38:18:38:37 | ...::from(...) | provenance | MaD:16 |
+| test_cookie.rs:38:28:38:36 | [0u8; 64] | test_cookie.rs:38:18:38:37 | ...::from(...) | provenance | MaD:17 |
+| test_cookie.rs:38:28:38:36 | [0u8; 64] | test_cookie.rs:38:18:38:37 | ...::from(...) | provenance | MaD:18 |
+| test_cookie.rs:38:28:38:36 | [0u8; 64] | test_cookie.rs:38:18:38:37 | ...::from(...) | provenance | MaD:19 |
 | test_cookie.rs:42:34:42:39 | array2 | test_cookie.rs:42:14:42:32 | ...::from | provenance | MaD:2 Sink:MaD:2 |
 | test_cookie.rs:49:9:49:14 | array3 [element] | test_cookie.rs:53:34:53:39 | array3 [element] | provenance |  |
-| test_cookie.rs:49:23:49:25 | 0u8 | test_cookie.rs:49:23:49:29 | ...::from_elem(...) [element] | provenance | MaD:18 |
+| test_cookie.rs:49:23:49:25 | 0u8 | test_cookie.rs:49:23:49:29 | ...::from_elem(...) [element] | provenance | MaD:21 |
 | test_cookie.rs:49:23:49:29 | ...::from_elem(...) [element] | test_cookie.rs:49:9:49:14 | array3 [element] | provenance |  |
 | test_cookie.rs:53:34:53:39 | array3 [element] | test_cookie.rs:53:14:53:32 | ...::from | provenance | MaD:2 Sink:MaD:2 |
 | test_heuristic.rs:44:9:44:16 | const_iv [&ref] | test_heuristic.rs:45:41:45:48 | const_iv | provenance |  |
@@ -79,11 +82,22 @@ edges
 | test_heuristic.rs:44:31:44:38 | [0u8; 16] | test_heuristic.rs:44:30:44:38 | &... [&ref] | provenance |  |
 | test_heuristic.rs:64:20:64:27 | [0u8; 16] | test_heuristic.rs:64:19:64:27 | &... | provenance |  |
 | test_heuristic.rs:65:31:65:38 | [0u8; 16] | test_heuristic.rs:65:30:65:38 | &... | provenance |  |
-| test_heuristic.rs:69:32:69:32 | 1 | test_heuristic.rs:69:22:69:32 | ... + ... | provenance | MaD:8 |
-| test_heuristic.rs:70:23:70:35 | ... << ... | test_heuristic.rs:70:22:70:62 | ... ^ ... | provenance | MaD:10 |
-| test_heuristic.rs:70:34:70:35 | 32 | test_heuristic.rs:70:23:70:35 | ... << ... | provenance | MaD:11 |
-| test_heuristic.rs:70:41:70:61 | ... & ... | test_heuristic.rs:70:22:70:62 | ... ^ ... | provenance | MaD:10 |
-| test_heuristic.rs:70:52:70:61 | 0xFFFFFFFF | test_heuristic.rs:70:41:70:61 | ... & ... | provenance | MaD:9 |
+| test_heuristic.rs:69:32:69:32 | 1 | test_heuristic.rs:69:22:69:32 | ... + ... | provenance | MaD:9 |
+| test_heuristic.rs:70:23:70:35 | ... << ... | test_heuristic.rs:70:22:70:62 | ... ^ ... | provenance | MaD:13 |
+| test_heuristic.rs:70:34:70:35 | 32 | test_heuristic.rs:70:23:70:35 | ... << ... | provenance | MaD:14 |
+| test_heuristic.rs:70:41:70:61 | ... & ... | test_heuristic.rs:70:22:70:62 | ... ^ ... | provenance | MaD:13 |
+| test_heuristic.rs:70:52:70:61 | 0xFFFFFFFF | test_heuristic.rs:70:41:70:61 | ... & ... | provenance | MaD:12 |
+| test_heuristic.rs:72:9:72:16 | mut key1 | test_heuristic.rs:73:5:73:8 | key1 | provenance |  |
+| test_heuristic.rs:72:20:72:24 | "foo" | test_heuristic.rs:72:20:72:36 | "foo".to_string() | provenance | MaD:8 |
+| test_heuristic.rs:72:20:72:36 | "foo".to_string() | test_heuristic.rs:72:9:72:16 | mut key1 | provenance |  |
+| test_heuristic.rs:73:5:73:8 | key1 | test_heuristic.rs:74:29:74:32 | key1 | provenance | MaD:11 |
+| test_heuristic.rs:73:13:73:17 | "bar" | test_heuristic.rs:74:29:74:32 | key1 | provenance | MaD:10 |
+| test_heuristic.rs:74:29:74:32 | key1 | test_heuristic.rs:74:28:74:32 | &key1 | provenance |  |
+| test_heuristic.rs:76:9:76:16 | mut key2 | test_heuristic.rs:77:5:77:8 | key2 | provenance |  |
+| test_heuristic.rs:76:20:76:24 | "foo" | test_heuristic.rs:76:20:76:36 | "foo".to_string() | provenance | MaD:8 |
+| test_heuristic.rs:76:20:76:36 | "foo".to_string() | test_heuristic.rs:76:9:76:16 | mut key2 | provenance |  |
+| test_heuristic.rs:77:5:77:8 | key2 | test_heuristic.rs:78:29:78:32 | key2 | provenance | MaD:11 |
+| test_heuristic.rs:78:29:78:32 | key2 | test_heuristic.rs:78:28:78:32 | &key2 | provenance |  |
 models
 | 1 | Sink: <_ as crypto_common::KeyInit>::new_from_slice; Argument[0]; credentials-key |
 | 2 | Sink: <biscotti::crypto::master::Key>::from; Argument[0]; credentials-key |
@@ -92,17 +106,20 @@ models
 | 5 | Sink: <cipher::stream_wrapper::StreamCipherCoreWrapper as crypto_common::KeyIvInit>::new; Argument[1]; credentials-iv |
 | 6 | Sink: <cookie::secure::key::Key>::from; Argument[0].Reference; credentials-key |
 | 7 | Source: core::mem::zeroed; ReturnValue.Element; constant-source |
-| 8 | Summary: <_ as core::ops::arith::Add>::add; Argument[self,0]; ReturnValue; taint |
-| 9 | Summary: <_ as core::ops::bit::BitAnd>::bitand; Argument[self,0]; ReturnValue; taint |
-| 10 | Summary: <_ as core::ops::bit::BitXor>::bitxor; Argument[self,0]; ReturnValue; taint |
-| 11 | Summary: <_ as core::ops::bit::Shl>::shl; Argument[self,0]; ReturnValue; taint |
-| 12 | Summary: <alloc::vec::Vec as core::convert::From>::from; Argument[0].Field[alloc::borrow::Cow::Owned(0)]; ReturnValue; value |
-| 13 | Summary: <alloc::vec::Vec as core::convert::From>::from; Argument[0].Field[alloc::bstr::ByteString(0)]; ReturnValue; value |
-| 14 | Summary: <alloc::vec::Vec as core::convert::From>::from; Argument[0].Field[alloc::collections::binary_heap::BinaryHeap::data]; ReturnValue; value |
-| 15 | Summary: <alloc::vec::Vec as core::convert::From>::from; Argument[0].Field[alloc::string::String::vec]; ReturnValue; value |
-| 16 | Summary: <alloc::vec::Vec as core::convert::From>::from; Argument[0]; ReturnValue; taint |
-| 17 | Summary: <generic_array::GenericArray>::from_slice; Argument[0].Reference; ReturnValue.Reference; value |
-| 18 | Summary: alloc::vec::from_elem; Argument[0]; ReturnValue.Element; value |
+| 8 | Summary: <_ as alloc::string::ToString>::to_string; Argument[self].Reference; ReturnValue; taint |
+| 9 | Summary: <_ as core::ops::arith::Add>::add; Argument[self,0]; ReturnValue; taint |
+| 10 | Summary: <_ as core::ops::arith::AddAssign>::add_assign; Argument[0]; Argument[self].Reference; taint |
+| 11 | Summary: <_ as core::ops::arith::AddAssign>::add_assign; Argument[self].Reference; Argument[self].Reference; taint |
+| 12 | Summary: <_ as core::ops::bit::BitAnd>::bitand; Argument[self,0]; ReturnValue; taint |
+| 13 | Summary: <_ as core::ops::bit::BitXor>::bitxor; Argument[self,0]; ReturnValue; taint |
+| 14 | Summary: <_ as core::ops::bit::Shl>::shl; Argument[self,0]; ReturnValue; taint |
+| 15 | Summary: <alloc::vec::Vec as core::convert::From>::from; Argument[0].Field[alloc::borrow::Cow::Owned(0)]; ReturnValue; value |
+| 16 | Summary: <alloc::vec::Vec as core::convert::From>::from; Argument[0].Field[alloc::bstr::ByteString(0)]; ReturnValue; value |
+| 17 | Summary: <alloc::vec::Vec as core::convert::From>::from; Argument[0].Field[alloc::collections::binary_heap::BinaryHeap::data]; ReturnValue; value |
+| 18 | Summary: <alloc::vec::Vec as core::convert::From>::from; Argument[0].Field[alloc::string::String::vec]; ReturnValue; value |
+| 19 | Summary: <alloc::vec::Vec as core::convert::From>::from; Argument[0]; ReturnValue; taint |
+| 20 | Summary: <generic_array::GenericArray>::from_slice; Argument[0].Reference; ReturnValue.Reference; value |
+| 21 | Summary: alloc::vec::from_elem; Argument[0]; ReturnValue.Element; value |
 nodes
 | test_cipher.rs:18:9:18:14 | const1 [&ref] | semmle.label | const1 [&ref] |
 | test_cipher.rs:18:28:18:36 | &... [&ref] | semmle.label | &... [&ref] |
@@ -183,4 +200,17 @@ nodes
 | test_heuristic.rs:70:34:70:35 | 32 | semmle.label | 32 |
 | test_heuristic.rs:70:41:70:61 | ... & ... | semmle.label | ... & ... |
 | test_heuristic.rs:70:52:70:61 | 0xFFFFFFFF | semmle.label | 0xFFFFFFFF |
+| test_heuristic.rs:72:9:72:16 | mut key1 | semmle.label | mut key1 |
+| test_heuristic.rs:72:20:72:24 | "foo" | semmle.label | "foo" |
+| test_heuristic.rs:72:20:72:36 | "foo".to_string() | semmle.label | "foo".to_string() |
+| test_heuristic.rs:73:5:73:8 | key1 | semmle.label | key1 |
+| test_heuristic.rs:73:13:73:17 | "bar" | semmle.label | "bar" |
+| test_heuristic.rs:74:28:74:32 | &key1 | semmle.label | &key1 |
+| test_heuristic.rs:74:29:74:32 | key1 | semmle.label | key1 |
+| test_heuristic.rs:76:9:76:16 | mut key2 | semmle.label | mut key2 |
+| test_heuristic.rs:76:20:76:24 | "foo" | semmle.label | "foo" |
+| test_heuristic.rs:76:20:76:36 | "foo".to_string() | semmle.label | "foo".to_string() |
+| test_heuristic.rs:77:5:77:8 | key2 | semmle.label | key2 |
+| test_heuristic.rs:78:28:78:32 | &key2 | semmle.label | &key2 |
+| test_heuristic.rs:78:29:78:32 | key2 | semmle.label | key2 |
 subpaths

--- a/rust/ql/test/query-tests/security/CWE-798/HardcodedCryptographicValue.expected
+++ b/rust/ql/test/query-tests/security/CWE-798/HardcodedCryptographicValue.expected
@@ -15,6 +15,9 @@
 | test_heuristic.rs:64:20:64:27 | [0u8; 16] | test_heuristic.rs:64:20:64:27 | [0u8; 16] | test_heuristic.rs:64:19:64:27 | &... | This hard-coded value is used as $@. | test_heuristic.rs:64:19:64:27 | &... | a nonce |
 | test_heuristic.rs:65:31:65:38 | [0u8; 16] | test_heuristic.rs:65:31:65:38 | [0u8; 16] | test_heuristic.rs:65:30:65:38 | &... | This hard-coded value is used as $@. | test_heuristic.rs:65:30:65:38 | &... | a salt |
 | test_heuristic.rs:67:22:67:22 | 0 | test_heuristic.rs:67:22:67:22 | 0 | test_heuristic.rs:67:22:67:22 | 0 | This hard-coded value is used as $@. | test_heuristic.rs:67:22:67:22 | 0 | a salt |
+| test_heuristic.rs:71:22:71:27 | ... << ... | test_heuristic.rs:71:22:71:27 | ... << ... | test_heuristic.rs:71:22:71:27 | ... << ... | This hard-coded value is used as $@. | test_heuristic.rs:71:22:71:27 | ... << ... | a salt |
+| test_heuristic.rs:72:22:72:29 | ...::MAX | test_heuristic.rs:72:22:72:29 | ...::MAX | test_heuristic.rs:72:22:72:29 | ...::MAX | This hard-coded value is used as $@. | test_heuristic.rs:72:22:72:29 | ...::MAX | a salt |
+| test_heuristic.rs:73:22:73:33 | ... / ... | test_heuristic.rs:73:22:73:33 | ... / ... | test_heuristic.rs:73:22:73:33 | ... / ... | This hard-coded value is used as $@. | test_heuristic.rs:73:22:73:33 | ... / ... | a salt |
 edges
 | test_cipher.rs:18:9:18:14 | const1 [&ref] | test_cipher.rs:19:73:19:78 | const1 [&ref] | provenance |  |
 | test_cipher.rs:18:28:18:36 | &... [&ref] | test_cipher.rs:18:9:18:14 | const1 [&ref] | provenance |  |
@@ -164,4 +167,7 @@ nodes
 | test_heuristic.rs:65:30:65:38 | &... | semmle.label | &... |
 | test_heuristic.rs:65:31:65:38 | [0u8; 16] | semmle.label | [0u8; 16] |
 | test_heuristic.rs:67:22:67:22 | 0 | semmle.label | 0 |
+| test_heuristic.rs:71:22:71:27 | ... << ... | semmle.label | ... << ... |
+| test_heuristic.rs:72:22:72:29 | ...::MAX | semmle.label | ...::MAX |
+| test_heuristic.rs:73:22:73:33 | ... / ... | semmle.label | ... / ... |
 subpaths

--- a/rust/ql/test/query-tests/security/CWE-798/HardcodedCryptographicValue.expected
+++ b/rust/ql/test/query-tests/security/CWE-798/HardcodedCryptographicValue.expected
@@ -19,6 +19,8 @@
 | test_heuristic.rs:70:31:70:38 | [0u8; 16] | test_heuristic.rs:70:31:70:38 | [0u8; 16] | test_heuristic.rs:70:30:70:38 | &... | This hard-coded value is used as $@. | test_heuristic.rs:70:30:70:38 | &... | a salt |
 | test_heuristic.rs:72:22:72:22 | 0 | test_heuristic.rs:72:22:72:22 | 0 | test_heuristic.rs:72:22:72:22 | 0 | This hard-coded value is used as $@. | test_heuristic.rs:72:22:72:22 | 0 | a salt |
 | test_heuristic.rs:76:22:76:27 | ... << ... | test_heuristic.rs:76:22:76:27 | ... << ... | test_heuristic.rs:76:22:76:27 | ... << ... | This hard-coded value is used as $@. | test_heuristic.rs:76:22:76:27 | ... << ... | a salt |
+| test_heuristic.rs:78:22:78:29 | ...::MAX | test_heuristic.rs:78:22:78:29 | ...::MAX | test_heuristic.rs:78:22:78:29 | ...::MAX | This hard-coded value is used as $@. | test_heuristic.rs:78:22:78:29 | ...::MAX | a salt |
+| test_heuristic.rs:79:22:79:33 | ... / ... | test_heuristic.rs:79:22:79:33 | ... / ... | test_heuristic.rs:79:22:79:33 | ... / ... | This hard-coded value is used as $@. | test_heuristic.rs:79:22:79:33 | ... / ... | a salt |
 | test_heuristic.rs:86:29:86:32 | 1u64 | test_heuristic.rs:86:29:86:32 | 1u64 | test_heuristic.rs:87:22:87:31 | MY_CONST_5 | This hard-coded value is used as $@. | test_heuristic.rs:87:22:87:31 | MY_CONST_5 | a salt |
 | test_heuristic.rs:88:29:88:33 | ... + ... | test_heuristic.rs:88:29:88:33 | ... + ... | test_heuristic.rs:89:22:89:31 | MY_CONST_6 | This hard-coded value is used as $@. | test_heuristic.rs:89:22:89:31 | MY_CONST_6 | a salt |
 edges
@@ -181,6 +183,8 @@ nodes
 | test_heuristic.rs:70:31:70:38 | [0u8; 16] | semmle.label | [0u8; 16] |
 | test_heuristic.rs:72:22:72:22 | 0 | semmle.label | 0 |
 | test_heuristic.rs:76:22:76:27 | ... << ... | semmle.label | ... << ... |
+| test_heuristic.rs:78:22:78:29 | ...::MAX | semmle.label | ...::MAX |
+| test_heuristic.rs:79:22:79:33 | ... / ... | semmle.label | ... / ... |
 | test_heuristic.rs:81:22:81:31 | MY_CONST_1 | semmle.label | MY_CONST_1 |
 | test_heuristic.rs:82:22:82:31 | MY_CONST_2 | semmle.label | MY_CONST_2 |
 | test_heuristic.rs:83:22:83:32 | MY_STATIC_3 | semmle.label | MY_STATIC_3 |

--- a/rust/ql/test/query-tests/security/CWE-798/HardcodedCryptographicValue.expected
+++ b/rust/ql/test/query-tests/security/CWE-798/HardcodedCryptographicValue.expected
@@ -10,6 +10,8 @@
 | test_cookie.rs:21:28:21:34 | [0; 64] | test_cookie.rs:21:28:21:34 | [0; 64] | test_cookie.rs:22:16:22:24 | ...::from | This hard-coded value is used as $@. | test_cookie.rs:22:16:22:24 | ...::from | a key |
 | test_cookie.rs:38:28:38:36 | [0u8; 64] | test_cookie.rs:38:28:38:36 | [0u8; 64] | test_cookie.rs:42:14:42:32 | ...::from | This hard-coded value is used as $@. | test_cookie.rs:42:14:42:32 | ...::from | a key |
 | test_cookie.rs:49:23:49:25 | 0u8 | test_cookie.rs:49:23:49:25 | 0u8 | test_cookie.rs:53:14:53:32 | ...::from | This hard-coded value is used as $@. | test_cookie.rs:53:14:53:32 | ...::from | a key |
+| test_heuristic.rs:38:25:38:30 | 0xFFFF | test_heuristic.rs:38:25:38:30 | 0xFFFF | test_heuristic.rs:81:22:81:31 | MY_CONST_1 | This hard-coded value is used as $@. | test_heuristic.rs:81:22:81:31 | MY_CONST_1 | a salt |
+| test_heuristic.rs:39:25:39:59 | ... as u64 | test_heuristic.rs:39:25:39:59 | ... as u64 | test_heuristic.rs:82:22:82:31 | MY_CONST_2 | This hard-coded value is used as $@. | test_heuristic.rs:82:22:82:31 | MY_CONST_2 | a salt |
 | test_heuristic.rs:40:27:40:32 | 0xFFFF | test_heuristic.rs:40:27:40:32 | 0xFFFF | test_heuristic.rs:83:22:83:32 | MY_STATIC_3 | This hard-coded value is used as $@. | test_heuristic.rs:83:22:83:32 | MY_STATIC_3 | a salt |
 | test_heuristic.rs:49:31:49:38 | [0u8; 16] | test_heuristic.rs:49:31:49:38 | [0u8; 16] | test_heuristic.rs:50:41:50:48 | const_iv | This hard-coded value is used as $@. | test_heuristic.rs:50:41:50:48 | const_iv | an initialization vector |
 | test_heuristic.rs:68:30:68:37 | "secret" | test_heuristic.rs:68:30:68:37 | "secret" | test_heuristic.rs:68:30:68:37 | "secret" | This hard-coded value is used as $@. | test_heuristic.rs:68:30:68:37 | "secret" | a password |
@@ -17,12 +19,8 @@
 | test_heuristic.rs:70:31:70:38 | [0u8; 16] | test_heuristic.rs:70:31:70:38 | [0u8; 16] | test_heuristic.rs:70:30:70:38 | &... | This hard-coded value is used as $@. | test_heuristic.rs:70:30:70:38 | &... | a salt |
 | test_heuristic.rs:72:22:72:22 | 0 | test_heuristic.rs:72:22:72:22 | 0 | test_heuristic.rs:72:22:72:22 | 0 | This hard-coded value is used as $@. | test_heuristic.rs:72:22:72:22 | 0 | a salt |
 | test_heuristic.rs:76:22:76:27 | ... << ... | test_heuristic.rs:76:22:76:27 | ... << ... | test_heuristic.rs:76:22:76:27 | ... << ... | This hard-coded value is used as $@. | test_heuristic.rs:76:22:76:27 | ... << ... | a salt |
-| test_heuristic.rs:78:22:78:29 | ...::MAX | test_heuristic.rs:78:22:78:29 | ...::MAX | test_heuristic.rs:78:22:78:29 | ...::MAX | This hard-coded value is used as $@. | test_heuristic.rs:78:22:78:29 | ...::MAX | a salt |
-| test_heuristic.rs:79:22:79:33 | ... / ... | test_heuristic.rs:79:22:79:33 | ... / ... | test_heuristic.rs:79:22:79:33 | ... / ... | This hard-coded value is used as $@. | test_heuristic.rs:79:22:79:33 | ... / ... | a salt |
-| test_heuristic.rs:81:22:81:31 | MY_CONST_1 | test_heuristic.rs:81:22:81:31 | MY_CONST_1 | test_heuristic.rs:81:22:81:31 | MY_CONST_1 | This hard-coded value is used as $@. | test_heuristic.rs:81:22:81:31 | MY_CONST_1 | a salt |
-| test_heuristic.rs:82:22:82:31 | MY_CONST_2 | test_heuristic.rs:82:22:82:31 | MY_CONST_2 | test_heuristic.rs:82:22:82:31 | MY_CONST_2 | This hard-coded value is used as $@. | test_heuristic.rs:82:22:82:31 | MY_CONST_2 | a salt |
-| test_heuristic.rs:87:22:87:31 | MY_CONST_5 | test_heuristic.rs:87:22:87:31 | MY_CONST_5 | test_heuristic.rs:87:22:87:31 | MY_CONST_5 | This hard-coded value is used as $@. | test_heuristic.rs:87:22:87:31 | MY_CONST_5 | a salt |
-| test_heuristic.rs:89:22:89:31 | MY_CONST_6 | test_heuristic.rs:89:22:89:31 | MY_CONST_6 | test_heuristic.rs:89:22:89:31 | MY_CONST_6 | This hard-coded value is used as $@. | test_heuristic.rs:89:22:89:31 | MY_CONST_6 | a salt |
+| test_heuristic.rs:86:29:86:32 | 1u64 | test_heuristic.rs:86:29:86:32 | 1u64 | test_heuristic.rs:87:22:87:31 | MY_CONST_5 | This hard-coded value is used as $@. | test_heuristic.rs:87:22:87:31 | MY_CONST_5 | a salt |
+| test_heuristic.rs:88:29:88:33 | ... + ... | test_heuristic.rs:88:29:88:33 | ... + ... | test_heuristic.rs:89:22:89:31 | MY_CONST_6 | This hard-coded value is used as $@. | test_heuristic.rs:89:22:89:31 | MY_CONST_6 | a salt |
 edges
 | test_cipher.rs:18:9:18:14 | const1 [&ref] | test_cipher.rs:19:73:19:78 | const1 [&ref] | provenance |  |
 | test_cipher.rs:18:28:18:36 | &... [&ref] | test_cipher.rs:18:9:18:14 | const1 [&ref] | provenance |  |
@@ -79,13 +77,17 @@ edges
 | test_cookie.rs:49:23:49:25 | 0u8 | test_cookie.rs:49:23:49:29 | ...::from_elem(...) [element] | provenance | MaD:14 |
 | test_cookie.rs:49:23:49:29 | ...::from_elem(...) [element] | test_cookie.rs:49:9:49:14 | array3 [element] | provenance |  |
 | test_cookie.rs:53:34:53:39 | array3 [element] | test_cookie.rs:53:14:53:32 | ...::from | provenance | MaD:2 Sink:MaD:2 |
-| test_heuristic.rs:40:1:40:33 | static MY_STATIC_3 | test_heuristic.rs:83:22:83:32 | MY_STATIC_3 | provenance |  |
-| test_heuristic.rs:40:27:40:32 | 0xFFFF | test_heuristic.rs:40:1:40:33 | static MY_STATIC_3 | provenance |  |
+| test_heuristic.rs:38:25:38:30 | 0xFFFF | test_heuristic.rs:81:22:81:31 | MY_CONST_1 | provenance |  |
+| test_heuristic.rs:39:25:39:59 | ... as u64 | test_heuristic.rs:82:22:82:31 | MY_CONST_2 | provenance |  |
+| test_heuristic.rs:39:62:40:33 | static MY_STATIC_3 | test_heuristic.rs:83:22:83:32 | MY_STATIC_3 | provenance |  |
+| test_heuristic.rs:40:27:40:32 | 0xFFFF | test_heuristic.rs:39:62:40:33 | static MY_STATIC_3 | provenance |  |
 | test_heuristic.rs:49:9:49:16 | const_iv [&ref] | test_heuristic.rs:50:41:50:48 | const_iv | provenance |  |
 | test_heuristic.rs:49:30:49:38 | &... [&ref] | test_heuristic.rs:49:9:49:16 | const_iv [&ref] | provenance |  |
 | test_heuristic.rs:49:31:49:38 | [0u8; 16] | test_heuristic.rs:49:30:49:38 | &... [&ref] | provenance |  |
 | test_heuristic.rs:69:20:69:27 | [0u8; 16] | test_heuristic.rs:69:19:69:27 | &... | provenance |  |
 | test_heuristic.rs:70:31:70:38 | [0u8; 16] | test_heuristic.rs:70:30:70:38 | &... | provenance |  |
+| test_heuristic.rs:86:29:86:32 | 1u64 | test_heuristic.rs:87:22:87:31 | MY_CONST_5 | provenance |  |
+| test_heuristic.rs:88:29:88:33 | ... + ... | test_heuristic.rs:89:22:89:31 | MY_CONST_6 | provenance |  |
 models
 | 1 | Sink: <_ as crypto_common::KeyInit>::new_from_slice; Argument[0]; credentials-key |
 | 2 | Sink: <biscotti::crypto::master::Key>::from; Argument[0]; credentials-key |
@@ -164,7 +166,9 @@ nodes
 | test_cookie.rs:49:23:49:29 | ...::from_elem(...) [element] | semmle.label | ...::from_elem(...) [element] |
 | test_cookie.rs:53:14:53:32 | ...::from | semmle.label | ...::from |
 | test_cookie.rs:53:34:53:39 | array3 [element] | semmle.label | array3 [element] |
-| test_heuristic.rs:40:1:40:33 | static MY_STATIC_3 | semmle.label | static MY_STATIC_3 |
+| test_heuristic.rs:38:25:38:30 | 0xFFFF | semmle.label | 0xFFFF |
+| test_heuristic.rs:39:25:39:59 | ... as u64 | semmle.label | ... as u64 |
+| test_heuristic.rs:39:62:40:33 | static MY_STATIC_3 | semmle.label | static MY_STATIC_3 |
 | test_heuristic.rs:40:27:40:32 | 0xFFFF | semmle.label | 0xFFFF |
 | test_heuristic.rs:49:9:49:16 | const_iv [&ref] | semmle.label | const_iv [&ref] |
 | test_heuristic.rs:49:30:49:38 | &... [&ref] | semmle.label | &... [&ref] |
@@ -177,11 +181,11 @@ nodes
 | test_heuristic.rs:70:31:70:38 | [0u8; 16] | semmle.label | [0u8; 16] |
 | test_heuristic.rs:72:22:72:22 | 0 | semmle.label | 0 |
 | test_heuristic.rs:76:22:76:27 | ... << ... | semmle.label | ... << ... |
-| test_heuristic.rs:78:22:78:29 | ...::MAX | semmle.label | ...::MAX |
-| test_heuristic.rs:79:22:79:33 | ... / ... | semmle.label | ... / ... |
 | test_heuristic.rs:81:22:81:31 | MY_CONST_1 | semmle.label | MY_CONST_1 |
 | test_heuristic.rs:82:22:82:31 | MY_CONST_2 | semmle.label | MY_CONST_2 |
 | test_heuristic.rs:83:22:83:32 | MY_STATIC_3 | semmle.label | MY_STATIC_3 |
+| test_heuristic.rs:86:29:86:32 | 1u64 | semmle.label | 1u64 |
 | test_heuristic.rs:87:22:87:31 | MY_CONST_5 | semmle.label | MY_CONST_5 |
+| test_heuristic.rs:88:29:88:33 | ... + ... | semmle.label | ... + ... |
 | test_heuristic.rs:89:22:89:31 | MY_CONST_6 | semmle.label | MY_CONST_6 |
 subpaths

--- a/rust/ql/test/query-tests/security/CWE-798/HardcodedCryptographicValue.expected
+++ b/rust/ql/test/query-tests/security/CWE-798/HardcodedCryptographicValue.expected
@@ -10,14 +10,19 @@
 | test_cookie.rs:21:28:21:34 | [0; 64] | test_cookie.rs:21:28:21:34 | [0; 64] | test_cookie.rs:22:16:22:24 | ...::from | This hard-coded value is used as $@. | test_cookie.rs:22:16:22:24 | ...::from | a key |
 | test_cookie.rs:38:28:38:36 | [0u8; 64] | test_cookie.rs:38:28:38:36 | [0u8; 64] | test_cookie.rs:42:14:42:32 | ...::from | This hard-coded value is used as $@. | test_cookie.rs:42:14:42:32 | ...::from | a key |
 | test_cookie.rs:49:23:49:25 | 0u8 | test_cookie.rs:49:23:49:25 | 0u8 | test_cookie.rs:53:14:53:32 | ...::from | This hard-coded value is used as $@. | test_cookie.rs:53:14:53:32 | ...::from | a key |
-| test_heuristic.rs:44:31:44:38 | [0u8; 16] | test_heuristic.rs:44:31:44:38 | [0u8; 16] | test_heuristic.rs:45:41:45:48 | const_iv | This hard-coded value is used as $@. | test_heuristic.rs:45:41:45:48 | const_iv | an initialization vector |
-| test_heuristic.rs:63:30:63:37 | "secret" | test_heuristic.rs:63:30:63:37 | "secret" | test_heuristic.rs:63:30:63:37 | "secret" | This hard-coded value is used as $@. | test_heuristic.rs:63:30:63:37 | "secret" | a password |
-| test_heuristic.rs:64:20:64:27 | [0u8; 16] | test_heuristic.rs:64:20:64:27 | [0u8; 16] | test_heuristic.rs:64:19:64:27 | &... | This hard-coded value is used as $@. | test_heuristic.rs:64:19:64:27 | &... | a nonce |
-| test_heuristic.rs:65:31:65:38 | [0u8; 16] | test_heuristic.rs:65:31:65:38 | [0u8; 16] | test_heuristic.rs:65:30:65:38 | &... | This hard-coded value is used as $@. | test_heuristic.rs:65:30:65:38 | &... | a salt |
-| test_heuristic.rs:67:22:67:22 | 0 | test_heuristic.rs:67:22:67:22 | 0 | test_heuristic.rs:67:22:67:22 | 0 | This hard-coded value is used as $@. | test_heuristic.rs:67:22:67:22 | 0 | a salt |
-| test_heuristic.rs:71:22:71:27 | ... << ... | test_heuristic.rs:71:22:71:27 | ... << ... | test_heuristic.rs:71:22:71:27 | ... << ... | This hard-coded value is used as $@. | test_heuristic.rs:71:22:71:27 | ... << ... | a salt |
-| test_heuristic.rs:72:22:72:29 | ...::MAX | test_heuristic.rs:72:22:72:29 | ...::MAX | test_heuristic.rs:72:22:72:29 | ...::MAX | This hard-coded value is used as $@. | test_heuristic.rs:72:22:72:29 | ...::MAX | a salt |
-| test_heuristic.rs:73:22:73:33 | ... / ... | test_heuristic.rs:73:22:73:33 | ... / ... | test_heuristic.rs:73:22:73:33 | ... / ... | This hard-coded value is used as $@. | test_heuristic.rs:73:22:73:33 | ... / ... | a salt |
+| test_heuristic.rs:40:27:40:32 | 0xFFFF | test_heuristic.rs:40:27:40:32 | 0xFFFF | test_heuristic.rs:83:22:83:32 | MY_STATIC_3 | This hard-coded value is used as $@. | test_heuristic.rs:83:22:83:32 | MY_STATIC_3 | a salt |
+| test_heuristic.rs:49:31:49:38 | [0u8; 16] | test_heuristic.rs:49:31:49:38 | [0u8; 16] | test_heuristic.rs:50:41:50:48 | const_iv | This hard-coded value is used as $@. | test_heuristic.rs:50:41:50:48 | const_iv | an initialization vector |
+| test_heuristic.rs:68:30:68:37 | "secret" | test_heuristic.rs:68:30:68:37 | "secret" | test_heuristic.rs:68:30:68:37 | "secret" | This hard-coded value is used as $@. | test_heuristic.rs:68:30:68:37 | "secret" | a password |
+| test_heuristic.rs:69:20:69:27 | [0u8; 16] | test_heuristic.rs:69:20:69:27 | [0u8; 16] | test_heuristic.rs:69:19:69:27 | &... | This hard-coded value is used as $@. | test_heuristic.rs:69:19:69:27 | &... | a nonce |
+| test_heuristic.rs:70:31:70:38 | [0u8; 16] | test_heuristic.rs:70:31:70:38 | [0u8; 16] | test_heuristic.rs:70:30:70:38 | &... | This hard-coded value is used as $@. | test_heuristic.rs:70:30:70:38 | &... | a salt |
+| test_heuristic.rs:72:22:72:22 | 0 | test_heuristic.rs:72:22:72:22 | 0 | test_heuristic.rs:72:22:72:22 | 0 | This hard-coded value is used as $@. | test_heuristic.rs:72:22:72:22 | 0 | a salt |
+| test_heuristic.rs:76:22:76:27 | ... << ... | test_heuristic.rs:76:22:76:27 | ... << ... | test_heuristic.rs:76:22:76:27 | ... << ... | This hard-coded value is used as $@. | test_heuristic.rs:76:22:76:27 | ... << ... | a salt |
+| test_heuristic.rs:78:22:78:29 | ...::MAX | test_heuristic.rs:78:22:78:29 | ...::MAX | test_heuristic.rs:78:22:78:29 | ...::MAX | This hard-coded value is used as $@. | test_heuristic.rs:78:22:78:29 | ...::MAX | a salt |
+| test_heuristic.rs:79:22:79:33 | ... / ... | test_heuristic.rs:79:22:79:33 | ... / ... | test_heuristic.rs:79:22:79:33 | ... / ... | This hard-coded value is used as $@. | test_heuristic.rs:79:22:79:33 | ... / ... | a salt |
+| test_heuristic.rs:81:22:81:31 | MY_CONST_1 | test_heuristic.rs:81:22:81:31 | MY_CONST_1 | test_heuristic.rs:81:22:81:31 | MY_CONST_1 | This hard-coded value is used as $@. | test_heuristic.rs:81:22:81:31 | MY_CONST_1 | a salt |
+| test_heuristic.rs:82:22:82:31 | MY_CONST_2 | test_heuristic.rs:82:22:82:31 | MY_CONST_2 | test_heuristic.rs:82:22:82:31 | MY_CONST_2 | This hard-coded value is used as $@. | test_heuristic.rs:82:22:82:31 | MY_CONST_2 | a salt |
+| test_heuristic.rs:87:22:87:31 | MY_CONST_5 | test_heuristic.rs:87:22:87:31 | MY_CONST_5 | test_heuristic.rs:87:22:87:31 | MY_CONST_5 | This hard-coded value is used as $@. | test_heuristic.rs:87:22:87:31 | MY_CONST_5 | a salt |
+| test_heuristic.rs:89:22:89:31 | MY_CONST_6 | test_heuristic.rs:89:22:89:31 | MY_CONST_6 | test_heuristic.rs:89:22:89:31 | MY_CONST_6 | This hard-coded value is used as $@. | test_heuristic.rs:89:22:89:31 | MY_CONST_6 | a salt |
 edges
 | test_cipher.rs:18:9:18:14 | const1 [&ref] | test_cipher.rs:19:73:19:78 | const1 [&ref] | provenance |  |
 | test_cipher.rs:18:28:18:36 | &... [&ref] | test_cipher.rs:18:9:18:14 | const1 [&ref] | provenance |  |
@@ -74,11 +79,13 @@ edges
 | test_cookie.rs:49:23:49:25 | 0u8 | test_cookie.rs:49:23:49:29 | ...::from_elem(...) [element] | provenance | MaD:14 |
 | test_cookie.rs:49:23:49:29 | ...::from_elem(...) [element] | test_cookie.rs:49:9:49:14 | array3 [element] | provenance |  |
 | test_cookie.rs:53:34:53:39 | array3 [element] | test_cookie.rs:53:14:53:32 | ...::from | provenance | MaD:2 Sink:MaD:2 |
-| test_heuristic.rs:44:9:44:16 | const_iv [&ref] | test_heuristic.rs:45:41:45:48 | const_iv | provenance |  |
-| test_heuristic.rs:44:30:44:38 | &... [&ref] | test_heuristic.rs:44:9:44:16 | const_iv [&ref] | provenance |  |
-| test_heuristic.rs:44:31:44:38 | [0u8; 16] | test_heuristic.rs:44:30:44:38 | &... [&ref] | provenance |  |
-| test_heuristic.rs:64:20:64:27 | [0u8; 16] | test_heuristic.rs:64:19:64:27 | &... | provenance |  |
-| test_heuristic.rs:65:31:65:38 | [0u8; 16] | test_heuristic.rs:65:30:65:38 | &... | provenance |  |
+| test_heuristic.rs:40:1:40:33 | static MY_STATIC_3 | test_heuristic.rs:83:22:83:32 | MY_STATIC_3 | provenance |  |
+| test_heuristic.rs:40:27:40:32 | 0xFFFF | test_heuristic.rs:40:1:40:33 | static MY_STATIC_3 | provenance |  |
+| test_heuristic.rs:49:9:49:16 | const_iv [&ref] | test_heuristic.rs:50:41:50:48 | const_iv | provenance |  |
+| test_heuristic.rs:49:30:49:38 | &... [&ref] | test_heuristic.rs:49:9:49:16 | const_iv [&ref] | provenance |  |
+| test_heuristic.rs:49:31:49:38 | [0u8; 16] | test_heuristic.rs:49:30:49:38 | &... [&ref] | provenance |  |
+| test_heuristic.rs:69:20:69:27 | [0u8; 16] | test_heuristic.rs:69:19:69:27 | &... | provenance |  |
+| test_heuristic.rs:70:31:70:38 | [0u8; 16] | test_heuristic.rs:70:30:70:38 | &... | provenance |  |
 models
 | 1 | Sink: <_ as crypto_common::KeyInit>::new_from_slice; Argument[0]; credentials-key |
 | 2 | Sink: <biscotti::crypto::master::Key>::from; Argument[0]; credentials-key |
@@ -157,17 +164,24 @@ nodes
 | test_cookie.rs:49:23:49:29 | ...::from_elem(...) [element] | semmle.label | ...::from_elem(...) [element] |
 | test_cookie.rs:53:14:53:32 | ...::from | semmle.label | ...::from |
 | test_cookie.rs:53:34:53:39 | array3 [element] | semmle.label | array3 [element] |
-| test_heuristic.rs:44:9:44:16 | const_iv [&ref] | semmle.label | const_iv [&ref] |
-| test_heuristic.rs:44:30:44:38 | &... [&ref] | semmle.label | &... [&ref] |
-| test_heuristic.rs:44:31:44:38 | [0u8; 16] | semmle.label | [0u8; 16] |
-| test_heuristic.rs:45:41:45:48 | const_iv | semmle.label | const_iv |
-| test_heuristic.rs:63:30:63:37 | "secret" | semmle.label | "secret" |
-| test_heuristic.rs:64:19:64:27 | &... | semmle.label | &... |
-| test_heuristic.rs:64:20:64:27 | [0u8; 16] | semmle.label | [0u8; 16] |
-| test_heuristic.rs:65:30:65:38 | &... | semmle.label | &... |
-| test_heuristic.rs:65:31:65:38 | [0u8; 16] | semmle.label | [0u8; 16] |
-| test_heuristic.rs:67:22:67:22 | 0 | semmle.label | 0 |
-| test_heuristic.rs:71:22:71:27 | ... << ... | semmle.label | ... << ... |
-| test_heuristic.rs:72:22:72:29 | ...::MAX | semmle.label | ...::MAX |
-| test_heuristic.rs:73:22:73:33 | ... / ... | semmle.label | ... / ... |
+| test_heuristic.rs:40:1:40:33 | static MY_STATIC_3 | semmle.label | static MY_STATIC_3 |
+| test_heuristic.rs:40:27:40:32 | 0xFFFF | semmle.label | 0xFFFF |
+| test_heuristic.rs:49:9:49:16 | const_iv [&ref] | semmle.label | const_iv [&ref] |
+| test_heuristic.rs:49:30:49:38 | &... [&ref] | semmle.label | &... [&ref] |
+| test_heuristic.rs:49:31:49:38 | [0u8; 16] | semmle.label | [0u8; 16] |
+| test_heuristic.rs:50:41:50:48 | const_iv | semmle.label | const_iv |
+| test_heuristic.rs:68:30:68:37 | "secret" | semmle.label | "secret" |
+| test_heuristic.rs:69:19:69:27 | &... | semmle.label | &... |
+| test_heuristic.rs:69:20:69:27 | [0u8; 16] | semmle.label | [0u8; 16] |
+| test_heuristic.rs:70:30:70:38 | &... | semmle.label | &... |
+| test_heuristic.rs:70:31:70:38 | [0u8; 16] | semmle.label | [0u8; 16] |
+| test_heuristic.rs:72:22:72:22 | 0 | semmle.label | 0 |
+| test_heuristic.rs:76:22:76:27 | ... << ... | semmle.label | ... << ... |
+| test_heuristic.rs:78:22:78:29 | ...::MAX | semmle.label | ...::MAX |
+| test_heuristic.rs:79:22:79:33 | ... / ... | semmle.label | ... / ... |
+| test_heuristic.rs:81:22:81:31 | MY_CONST_1 | semmle.label | MY_CONST_1 |
+| test_heuristic.rs:82:22:82:31 | MY_CONST_2 | semmle.label | MY_CONST_2 |
+| test_heuristic.rs:83:22:83:32 | MY_STATIC_3 | semmle.label | MY_STATIC_3 |
+| test_heuristic.rs:87:22:87:31 | MY_CONST_5 | semmle.label | MY_CONST_5 |
+| test_heuristic.rs:89:22:89:31 | MY_CONST_6 | semmle.label | MY_CONST_6 |
 subpaths

--- a/rust/ql/test/query-tests/security/CWE-798/test_heuristic.rs
+++ b/rust/ql/test/query-tests/security/CWE-798/test_heuristic.rs
@@ -66,14 +66,14 @@ fn test(var_string: &str, var_data: &[u8;16], var_u64: u64) {
 
     mc2.set_salt_u64(0); // $ Alert[rust/hard-coded-cryptographic-value]
     mc2.set_salt_u64(var_u64);
-    mc2.set_salt_u64(var_u64 + 1); // $ SPURIOUS: Alert[rust/hard-coded-cryptographic-value]
-    mc2.set_salt_u64((var_u64 << 32) ^ (var_u64  & 0xFFFFFFFF)); // $ SPURIOUS: Alert[rust/hard-coded-cryptographic-value]
+    mc2.set_salt_u64(var_u64 + 1);
+    mc2.set_salt_u64((var_u64 << 32) ^ (var_u64  & 0xFFFFFFFF));
 
-    let mut key1 = "foo".to_string(); // $ Alert[rust/hard-coded-cryptographic-value]
-    key1 += "bar"; // $ Alert[rust/hard-coded-cryptographic-value]
-    let _ = MyCryptor::new(&key1); // $ Sink
+    let mut key1 = "foo".to_string(); // $ MISSING: Alert[rust/hard-coded-cryptographic-value]
+    key1 += "bar"; // $ MISSING: Alert[rust/hard-coded-cryptographic-value]
+    let _ = MyCryptor::new(&key1);
 
-    let mut key2 = "foo".to_string(); // $ SPURIOUS: Alert[rust/hard-coded-cryptographic-value]
+    let mut key2 = "foo".to_string();
     key2 += var_string;
-    let _ = MyCryptor::new(&key2); // $ Sink
+    let _ = MyCryptor::new(&key2);
 }

--- a/rust/ql/test/query-tests/security/CWE-798/test_heuristic.rs
+++ b/rust/ql/test/query-tests/security/CWE-798/test_heuristic.rs
@@ -68,9 +68,9 @@ fn test(var_string: &str, var_data: &[u8;16], var_u64: u64) {
     mc2.set_salt_u64(var_u64);
     mc2.set_salt_u64(var_u64 + 1);
     mc2.set_salt_u64((var_u64 << 32) ^ (var_u64  & 0xFFFFFFFF));
-    mc2.set_salt_u64(1 << 4); // $ MISSING: Alert[rust/hard-coded-cryptographic-value]
-    mc2.set_salt_u64(u64::MAX); // $ MISSING: Alert[rust/hard-coded-cryptographic-value]
-    mc2.set_salt_u64(u64::MAX / 4); // $ MISSING: Alert[rust/hard-coded-cryptographic-value]
+    mc2.set_salt_u64(1 << 4); // $ Alert[rust/hard-coded-cryptographic-value]
+    mc2.set_salt_u64(u64::MAX); // $ Alert[rust/hard-coded-cryptographic-value]
+    mc2.set_salt_u64(u64::MAX / 4); // $ Alert[rust/hard-coded-cryptographic-value]
 
     let mut key1 = "foo".to_string(); // $ MISSING: Alert[rust/hard-coded-cryptographic-value]
     key1 += "bar"; // $ MISSING: Alert[rust/hard-coded-cryptographic-value]

--- a/rust/ql/test/query-tests/security/CWE-798/test_heuristic.rs
+++ b/rust/ql/test/query-tests/security/CWE-798/test_heuristic.rs
@@ -68,4 +68,12 @@ fn test(var_string: &str, var_data: &[u8;16], var_u64: u64) {
     mc2.set_salt_u64(var_u64);
     mc2.set_salt_u64(var_u64 + 1); // $ SPURIOUS: Alert[rust/hard-coded-cryptographic-value]
     mc2.set_salt_u64((var_u64 << 32) ^ (var_u64  & 0xFFFFFFFF)); // $ SPURIOUS: Alert[rust/hard-coded-cryptographic-value]
+
+    let mut key1 = "foo".to_string(); // $ Alert[rust/hard-coded-cryptographic-value]
+    key1 += "bar"; // $ Alert[rust/hard-coded-cryptographic-value]
+    let _ = MyCryptor::new(&key1); // $ Sink
+
+    let mut key2 = "foo".to_string(); // $ SPURIOUS: Alert[rust/hard-coded-cryptographic-value]
+    key2 += var_string;
+    let _ = MyCryptor::new(&key2); // $ Sink
 }

--- a/rust/ql/test/query-tests/security/CWE-798/test_heuristic.rs
+++ b/rust/ql/test/query-tests/security/CWE-798/test_heuristic.rs
@@ -68,6 +68,9 @@ fn test(var_string: &str, var_data: &[u8;16], var_u64: u64) {
     mc2.set_salt_u64(var_u64);
     mc2.set_salt_u64(var_u64 + 1);
     mc2.set_salt_u64((var_u64 << 32) ^ (var_u64  & 0xFFFFFFFF));
+    mc2.set_salt_u64(1 << 4); // $ MISSING: Alert[rust/hard-coded-cryptographic-value]
+    mc2.set_salt_u64(u64::MAX); // $ MISSING: Alert[rust/hard-coded-cryptographic-value]
+    mc2.set_salt_u64(u64::MAX / 4); // $ MISSING: Alert[rust/hard-coded-cryptographic-value]
 
     let mut key1 = "foo".to_string(); // $ MISSING: Alert[rust/hard-coded-cryptographic-value]
     key1 += "bar"; // $ MISSING: Alert[rust/hard-coded-cryptographic-value]
@@ -76,4 +79,8 @@ fn test(var_string: &str, var_data: &[u8;16], var_u64: u64) {
     let mut key2 = "foo".to_string();
     key2 += var_string;
     let _ = MyCryptor::new(&key2);
+
+    let mut key3 = var_string.to_string();
+    key3 += "bar";
+    let _ = MyCryptor::new(&key3);
 }

--- a/rust/ql/test/query-tests/security/CWE-798/test_heuristic.rs
+++ b/rust/ql/test/query-tests/security/CWE-798/test_heuristic.rs
@@ -75,8 +75,8 @@ fn test(var_string: &str, var_data: &[u8;16], var_u64: u64) {
     mc2.set_salt_u64((var_u64 << 32) ^ (var_u64  & 0xFFFFFFFF));
     mc2.set_salt_u64(1 << 4); // $ Alert[rust/hard-coded-cryptographic-value]
 
-    mc2.set_salt_u64(u64::MAX); // $ MISSING: Alert[rust/hard-coded-cryptographic-value]
-    mc2.set_salt_u64(u64::MAX / 4); // $ MISSING: Alert[rust/hard-coded-cryptographic-value]
+    mc2.set_salt_u64(u64::MAX); // $ Alert[rust/hard-coded-cryptographic-value]
+    mc2.set_salt_u64(u64::MAX / 4); // $ Alert[rust/hard-coded-cryptographic-value]
 
     mc2.set_salt_u64(MY_CONST_1); // $ Sink[rust/hard-coded-cryptographic-value]
     mc2.set_salt_u64(MY_CONST_2); // $ Sink[rust/hard-coded-cryptographic-value]

--- a/rust/ql/test/query-tests/security/CWE-798/test_heuristic.rs
+++ b/rust/ql/test/query-tests/security/CWE-798/test_heuristic.rs
@@ -35,8 +35,8 @@ impl MyCryptor {
     }
 }
 
-const MY_CONST_1: u64 = 0xFFFF;
-const MY_CONST_2: u64 = std::env::consts::ARCH.len() as u64;
+const MY_CONST_1: u64 = 0xFFFF; // $ Alert[rust/hard-coded-cryptographic-value]
+const MY_CONST_2: u64 = std::env::consts::ARCH.len() as u64; // $ Alert[rust/hard-coded-cryptographic-value]
 static MY_STATIC_3: u64 = 0xFFFF; // $ Alert[rust/hard-coded-cryptographic-value]
 static MY_STATIC_4: u64 = std::env::consts::ARCH.len() as u64;
 
@@ -75,18 +75,18 @@ fn test(var_string: &str, var_data: &[u8;16], var_u64: u64) {
     mc2.set_salt_u64((var_u64 << 32) ^ (var_u64  & 0xFFFFFFFF));
     mc2.set_salt_u64(1 << 4); // $ Alert[rust/hard-coded-cryptographic-value]
 
-    mc2.set_salt_u64(u64::MAX); // $ Alert[rust/hard-coded-cryptographic-value]
-    mc2.set_salt_u64(u64::MAX / 4); // $ Alert[rust/hard-coded-cryptographic-value]
+    mc2.set_salt_u64(u64::MAX); // $ MISSING: Alert[rust/hard-coded-cryptographic-value]
+    mc2.set_salt_u64(u64::MAX / 4); // $ MISSING: Alert[rust/hard-coded-cryptographic-value]
 
-    mc2.set_salt_u64(MY_CONST_1); // $ Alert[rust/hard-coded-cryptographic-value]
-    mc2.set_salt_u64(MY_CONST_2); // $ Alert[rust/hard-coded-cryptographic-value]
+    mc2.set_salt_u64(MY_CONST_1); // $ Sink[rust/hard-coded-cryptographic-value]
+    mc2.set_salt_u64(MY_CONST_2); // $ Sink[rust/hard-coded-cryptographic-value]
     mc2.set_salt_u64(MY_STATIC_3); // $ Sink[rust/hard-coded-cryptographic-value]
     mc2.set_salt_u64(MY_STATIC_4);
 
-    const MY_CONST_5: u64 = 1u64;
-    mc2.set_salt_u64(MY_CONST_5); // $ Alert[rust/hard-coded-cryptographic-value]
-    const MY_CONST_6: u64 = 2 + 3;
-    mc2.set_salt_u64(MY_CONST_6); // $ Alert[rust/hard-coded-cryptographic-value]
+    const MY_CONST_5: u64 = 1u64; // $ Alert[rust/hard-coded-cryptographic-value]
+    mc2.set_salt_u64(MY_CONST_5); // $ Sink[rust/hard-coded-cryptographic-value]
+    const MY_CONST_6: u64 = 2 + 3; // $ Alert[rust/hard-coded-cryptographic-value]
+    mc2.set_salt_u64(MY_CONST_6); // $ Sink[rust/hard-coded-cryptographic-value]
 
     let mut key1 = "foo".to_string(); // $ MISSING: Alert[rust/hard-coded-cryptographic-value]
     key1 += "bar"; // $ MISSING: Alert[rust/hard-coded-cryptographic-value]

--- a/rust/ql/test/query-tests/security/CWE-798/test_heuristic.rs
+++ b/rust/ql/test/query-tests/security/CWE-798/test_heuristic.rs
@@ -35,6 +35,11 @@ impl MyCryptor {
     }
 }
 
+const MY_CONST_1: u64 = 0xFFFF;
+const MY_CONST_2: u64 = std::env::consts::ARCH.len() as u64;
+static MY_STATIC_3: u64 = 0xFFFF; // $ Alert[rust/hard-coded-cryptographic-value]
+static MY_STATIC_4: u64 = std::env::consts::ARCH.len() as u64;
+
 fn test(var_string: &str, var_data: &[u8;16], var_u64: u64) {
     encrypt_with("plaintext", var_data, var_data);
 
@@ -69,8 +74,19 @@ fn test(var_string: &str, var_data: &[u8;16], var_u64: u64) {
     mc2.set_salt_u64(var_u64 + 1);
     mc2.set_salt_u64((var_u64 << 32) ^ (var_u64  & 0xFFFFFFFF));
     mc2.set_salt_u64(1 << 4); // $ Alert[rust/hard-coded-cryptographic-value]
+
     mc2.set_salt_u64(u64::MAX); // $ Alert[rust/hard-coded-cryptographic-value]
     mc2.set_salt_u64(u64::MAX / 4); // $ Alert[rust/hard-coded-cryptographic-value]
+
+    mc2.set_salt_u64(MY_CONST_1); // $ Alert[rust/hard-coded-cryptographic-value]
+    mc2.set_salt_u64(MY_CONST_2); // $ Alert[rust/hard-coded-cryptographic-value]
+    mc2.set_salt_u64(MY_STATIC_3); // $ Sink[rust/hard-coded-cryptographic-value]
+    mc2.set_salt_u64(MY_STATIC_4);
+
+    const MY_CONST_5: u64 = 1u64;
+    mc2.set_salt_u64(MY_CONST_5); // $ Alert[rust/hard-coded-cryptographic-value]
+    const MY_CONST_6: u64 = 2 + 3;
+    mc2.set_salt_u64(MY_CONST_6); // $ Alert[rust/hard-coded-cryptographic-value]
 
     let mut key1 = "foo".to_string(); // $ MISSING: Alert[rust/hard-coded-cryptographic-value]
     key1 += "bar"; // $ MISSING: Alert[rust/hard-coded-cryptographic-value]


### PR DESCRIPTION
Addresses a common source of false positive results in `rust/hard-coded-cryptographic-value` where arithmetic involves constants but the result is not constant.  For example:
```
nonce += 1; // this is acceptable
encryption_routine(..., nonce);
```