### PR TITLE
Rust: Remove some redundant imports / casts

### DIFF
--- a/rust/ql/lib/codeql/rust/security/LogInjectionExtensions.qll
+++ b/rust/ql/lib/codeql/rust/security/LogInjectionExtensions.qll
@@ -8,7 +8,6 @@ private import codeql.rust.dataflow.DataFlow
 private import codeql.rust.dataflow.FlowBarrier
 private import codeql.rust.dataflow.FlowSink
 private import codeql.rust.Concepts
-private import codeql.util.Unit
 private import codeql.rust.security.Barriers as Barriers
 
 /**

--- a/rust/ql/lib/codeql/rust/security/SensitiveData.qll
+++ b/rust/ql/lib/codeql/rust/security/SensitiveData.qll
@@ -53,7 +53,6 @@ private class SensitiveVariableAccess extends SensitiveData {
     HeuristicNames::nameIndicatesSensitiveData(this.asExpr()
           .(VariableAccess)
           .getVariable()
-          .(Variable)
           .getText(), classification)
   }
 

--- a/rust/ql/lib/codeql/rust/security/SqlInjectionExtensions.qll
+++ b/rust/ql/lib/codeql/rust/security/SqlInjectionExtensions.qll
@@ -9,7 +9,6 @@ private import codeql.rust.dataflow.DataFlow
 private import codeql.rust.dataflow.FlowBarrier
 private import codeql.rust.dataflow.FlowSink
 private import codeql.rust.Concepts
-private import codeql.util.Unit
 private import codeql.rust.security.Barriers as Barriers
 
 /**

--- a/rust/ql/lib/codeql/rust/security/TaintedPathExtensions.qll
+++ b/rust/ql/lib/codeql/rust/security/TaintedPathExtensions.qll
@@ -1,13 +1,9 @@
 /** Provides classes and predicates to reason about path injection vulnerabilities. */
 
 import rust
-private import codeql.rust.controlflow.BasicBlocks
-private import codeql.rust.controlflow.ControlFlowGraph
 private import codeql.rust.dataflow.DataFlow
-private import codeql.rust.dataflow.TaintTracking
 private import codeql.rust.Concepts
 private import codeql.rust.dataflow.internal.DataFlowImpl
-private import codeql.rust.controlflow.ControlFlowGraph as Cfg
 
 /**
  * Provides default sources, sinks and barriers for detecting path injection

--- a/rust/ql/lib/codeql/rust/security/XssExtensions.qll
+++ b/rust/ql/lib/codeql/rust/security/XssExtensions.qll
@@ -8,7 +8,6 @@ private import codeql.rust.dataflow.DataFlow
 private import codeql.rust.dataflow.FlowBarrier
 private import codeql.rust.dataflow.FlowSink
 private import codeql.rust.Concepts
-private import codeql.util.Unit
 private import codeql.rust.security.Barriers as Barriers
 
 /**


### PR DESCRIPTION
Remove some redundant imports / casts.

There's no particular direction here, you're looking at leftovers after a (not especially successful) experiment at getting AI to improve code quality.