### PR TITLE
Replace `jcenter()` and `mavenCentral()` with Maven Central mirror URL

### DIFF
--- a/java/ql/integration-tests/java/android-8-sample/settings.gradle
+++ b/java/ql/integration-tests/java/android-8-sample/settings.gradle
@@ -14,7 +14,9 @@ pluginManagement {
     repositories {
         gradlePluginPortal()
         google()
-        mavenCentral()
+        maven {
+            url = 'https://maven-central.storage-download.googleapis.com/maven2/'
+        }
     }
 }
 dependencyResolutionManagement {
@@ -33,7 +35,9 @@ dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         google()
-        mavenCentral()
+        maven {
+            url = 'https://maven-central.storage-download.googleapis.com/maven2/'
+        }
     }
 }
 rootProject.name = "Android Sample"

--- a/java/ql/integration-tests/java/android-sample-kotlin-build-script-no-wrapper/settings.gradle.kts
+++ b/java/ql/integration-tests/java/android-sample-kotlin-build-script-no-wrapper/settings.gradle.kts
@@ -14,7 +14,9 @@ pluginManagement {
     repositories {
         gradlePluginPortal()
         google()
-        mavenCentral()
+        maven {
+            url = uri("https://maven-central.storage-download.googleapis.com/maven2/")
+        }
     }
 }
 dependencyResolutionManagement {
@@ -33,7 +35,9 @@ dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         google()
-        mavenCentral()
+        maven {
+            url = uri("https://maven-central.storage-download.googleapis.com/maven2/")
+        }
     }
 }
 rootProject.name = "Android Sample"

--- a/java/ql/integration-tests/java/android-sample-kotlin-build-script/settings.gradle.kts
+++ b/java/ql/integration-tests/java/android-sample-kotlin-build-script/settings.gradle.kts
@@ -14,7 +14,9 @@ pluginManagement {
     repositories {
         gradlePluginPortal()
         google()
-        mavenCentral()
+        maven {
+            url = uri("https://maven-central.storage-download.googleapis.com/maven2/")
+        }
     }
 }
 dependencyResolutionManagement {
@@ -33,7 +35,9 @@ dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         google()
-        mavenCentral()
+        maven {
+            url = uri("https://maven-central.storage-download.googleapis.com/maven2/")
+        }
     }
 }
 rootProject.name = "Android Sample"

--- a/java/ql/integration-tests/java/android-sample-no-wrapper/settings.gradle
+++ b/java/ql/integration-tests/java/android-sample-no-wrapper/settings.gradle
@@ -14,7 +14,9 @@ pluginManagement {
     repositories {
         gradlePluginPortal()
         google()
-        mavenCentral()
+        maven {
+            url = 'https://maven-central.storage-download.googleapis.com/maven2/'
+        }
     }
 }
 dependencyResolutionManagement {
@@ -33,7 +35,9 @@ dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         google()
-        mavenCentral()
+        maven {
+            url = 'https://maven-central.storage-download.googleapis.com/maven2/'
+        }
     }
 }
 rootProject.name = "Android Sample"

--- a/java/ql/integration-tests/java/android-sample-old-style-kotlin-build-script-no-wrapper/build.gradle.kts
+++ b/java/ql/integration-tests/java/android-sample-old-style-kotlin-build-script-no-wrapper/build.gradle.kts
@@ -13,7 +13,9 @@ buildscript {
 
     repositories {
         google()
-        jcenter()
+        maven {
+            url = uri("https://maven-central.storage-download.googleapis.com/maven2/")
+        }
     }
 
     /**
@@ -39,6 +41,8 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        maven {
+            url = uri("https://maven-central.storage-download.googleapis.com/maven2/")
+        }
     }
 }

--- a/java/ql/integration-tests/java/android-sample-old-style-kotlin-build-script/build.gradle.kts
+++ b/java/ql/integration-tests/java/android-sample-old-style-kotlin-build-script/build.gradle.kts
@@ -13,7 +13,9 @@ buildscript {
 
     repositories {
         google()
-        jcenter()
+        maven {
+            url = uri("https://maven-central.storage-download.googleapis.com/maven2/")
+        }
     }
 
     /**
@@ -39,6 +41,8 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        maven {
+            url = uri("https://maven-central.storage-download.googleapis.com/maven2/")
+        }
     }
 }

--- a/java/ql/integration-tests/java/android-sample-old-style-no-wrapper/build.gradle
+++ b/java/ql/integration-tests/java/android-sample-old-style-no-wrapper/build.gradle
@@ -13,7 +13,9 @@ buildscript {
 
     repositories {
         google()
-        jcenter()
+        maven {
+            url = 'https://maven-central.storage-download.googleapis.com/maven2/'
+        }
     }
 
     /**
@@ -39,6 +41,8 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        maven {
+            url = 'https://maven-central.storage-download.googleapis.com/maven2/'
+        }
     }
 }

--- a/java/ql/integration-tests/java/android-sample-old-style/build.gradle
+++ b/java/ql/integration-tests/java/android-sample-old-style/build.gradle
@@ -13,7 +13,9 @@ buildscript {
 
     repositories {
         google()
-        jcenter()
+        maven {
+            url = 'https://maven-central.storage-download.googleapis.com/maven2/'
+        }
     }
 
     /**
@@ -32,13 +34,15 @@ buildscript {
  * dependencies used by all modules in your project, such as third-party plugins
  * or libraries. However, you should configure module-specific dependencies in
  * each module-level build.gradle file. For new projects, Android Studio
- * includes JCenter and Google's Maven repository by default, but it does not
+ * includes Maven Central and Google's Maven repository by default, but it does not
  * configure any dependencies (unless you select a template that requires some).
  */
 
 allprojects {
     repositories {
         google()
-        jcenter()
+        maven {
+            url = 'https://maven-central.storage-download.googleapis.com/maven2/'
+        }
     }
 }

--- a/java/ql/integration-tests/java/android-sample/settings.gradle
+++ b/java/ql/integration-tests/java/android-sample/settings.gradle
@@ -14,7 +14,9 @@ pluginManagement {
     repositories {
         gradlePluginPortal()
         google()
-        mavenCentral()
+        maven {
+            url = 'https://maven-central.storage-download.googleapis.com/maven2/'
+        }
     }
 }
 dependencyResolutionManagement {
@@ -33,7 +35,9 @@ dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         google()
-        mavenCentral()
+        maven {
+            url = 'https://maven-central.storage-download.googleapis.com/maven2/'
+        }
     }
 }
 rootProject.name = "Android Sample"

--- a/java/ql/integration-tests/java/buildless-gradle-boms/build.gradle
+++ b/java/ql/integration-tests/java/buildless-gradle-boms/build.gradle
@@ -8,7 +8,9 @@
 apply plugin: 'java-library'
 
 repositories {
-  mavenCentral()
+  maven {
+    url = 'https://maven-central.storage-download.googleapis.com/maven2/'
+  }
 }
 
 dependencies {

--- a/java/ql/integration-tests/java/buildless-gradle-boms/buildless-fetches.expected
+++ b/java/ql/integration-tests/java/buildless-gradle-boms/buildless-fetches.expected
@@ -1,5 +1,5 @@
-https://repo.maven.apache.org/maven2/org/apache/commons/commons-math3/3.6.1/commons-math3-3.6.1.jar
-https://repo.maven.apache.org/maven2/org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar
-https://repo.maven.apache.org/maven2/org/junit/jupiter/junit-jupiter-api/5.12.1/junit-jupiter-api-5.12.1.jar
-https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-commons/1.12.1/junit-platform-commons-1.12.1.jar
-https://repo.maven.apache.org/maven2/org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.jar
+https://maven-central.storage-download.googleapis.com/maven2/org/apache/commons/commons-math3/3.6.1/commons-math3-3.6.1.jar
+https://maven-central.storage-download.googleapis.com/maven2/org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar
+https://maven-central.storage-download.googleapis.com/maven2/org/junit/jupiter/junit-jupiter-api/5.12.1/junit-jupiter-api-5.12.1.jar
+https://maven-central.storage-download.googleapis.com/maven2/org/junit/platform/junit-platform-commons/1.12.1/junit-platform-commons-1.12.1.jar
+https://maven-central.storage-download.googleapis.com/maven2/org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.jar

--- a/java/ql/integration-tests/java/buildless-gradle-classifiers/build.gradle
+++ b/java/ql/integration-tests/java/buildless-gradle-classifiers/build.gradle
@@ -8,7 +8,9 @@
 apply plugin: 'java-library'
 
 repositories {
-  mavenCentral()
+  maven {
+    url = 'https://maven-central.storage-download.googleapis.com/maven2/'
+  }
 }
 
 dependencies {

--- a/java/ql/integration-tests/java/buildless-gradle-classifiers/buildless-fetches.expected
+++ b/java/ql/integration-tests/java/buildless-gradle-classifiers/buildless-fetches.expected
@@ -1,2 +1,2 @@
-https://repo.maven.apache.org/maven2/joda-time/joda-time/2.12.7/joda-time-2.12.7-no-tzdb.jar
-https://repo.maven.apache.org/maven2/org/apache/commons/commons-math3/3.6.1/commons-math3-3.6.1.jar
+https://maven-central.storage-download.googleapis.com/maven2/joda-time/joda-time/2.12.7/joda-time-2.12.7-no-tzdb.jar
+https://maven-central.storage-download.googleapis.com/maven2/org/apache/commons/commons-math3/3.6.1/commons-math3-3.6.1.jar

--- a/java/ql/integration-tests/java/buildless-gradle-timeout/build.gradle
+++ b/java/ql/integration-tests/java/buildless-gradle-timeout/build.gradle
@@ -12,9 +12,9 @@ apply plugin: 'java'
 
 // In this section you declare where to find the dependencies of your project
 repositories {
-    // Use 'jcenter' for resolving your dependencies.
-    // You can declare any Maven/Ivy/file repository here.
-    jcenter()
+    maven {
+        url = 'https://maven-central.storage-download.googleapis.com/maven2/'
+    }
 }
 
 // In this section you declare the dependencies for your production and test code

--- a/java/ql/integration-tests/java/buildless-gradle/build.gradle
+++ b/java/ql/integration-tests/java/buildless-gradle/build.gradle
@@ -8,7 +8,9 @@
 apply plugin: 'java-library'
 
 repositories {
-  mavenCentral()
+  maven {
+    url = 'https://maven-central.storage-download.googleapis.com/maven2/'
+  }
 }
 
 dependencies {

--- a/java/ql/integration-tests/java/buildless-gradle/buildless-fetches.expected
+++ b/java/ql/integration-tests/java/buildless-gradle/buildless-fetches.expected
@@ -1,1 +1,1 @@
-https://repo.maven.apache.org/maven2/org/apache/commons/commons-math3/3.6.1/commons-math3-3.6.1.jar
+https://maven-central.storage-download.googleapis.com/maven2/org/apache/commons/commons-math3/3.6.1/commons-math3-3.6.1.jar

--- a/java/ql/integration-tests/java/buildless-proxy-gradle/build.gradle
+++ b/java/ql/integration-tests/java/buildless-proxy-gradle/build.gradle
@@ -8,7 +8,9 @@
 apply plugin: 'java-library'
 
 repositories {
-  mavenCentral()
+  maven {
+    url = 'https://maven-central.storage-download.googleapis.com/maven2/'
+  }
 }
 
 dependencies {

--- a/java/ql/integration-tests/java/buildless-proxy-gradle/buildless-fetches.expected
+++ b/java/ql/integration-tests/java/buildless-proxy-gradle/buildless-fetches.expected
@@ -1,1 +1,1 @@
-https://repo.maven.apache.org/maven2/org/apache/commons/commons-math3/3.6.1/commons-math3-3.6.1.jar
+https://maven-central.storage-download.googleapis.com/maven2/org/apache/commons/commons-math3/3.6.1/commons-math3-3.6.1.jar

--- a/java/ql/integration-tests/java/buildless-sibling-projects/buildless-fetches.expected
+++ b/java/ql/integration-tests/java/buildless-sibling-projects/buildless-fetches.expected
@@ -1,7 +1,7 @@
+https://maven-central.storage-download.googleapis.com/maven2/junit/junit/4.11/junit-4.11.jar
 https://maven-central.storage-download.googleapis.com/maven2/junit/junit/4.12/junit-4.12.jar
 https://maven-central.storage-download.googleapis.com/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar
 https://maven-central.storage-download.googleapis.com/maven2/org/slf4j/slf4j-api/1.7.21/slf4j-api-1.7.21.jar
-https://maven-central.storage-download.googleapis.com/maven2/junit/junit/4.11/junit-4.11.jar
 https://repo.maven.apache.org/maven2/com/feiniaojin/naaf/naaf-graceful-response-example/1.0/naaf-graceful-response-example-1.0.jar
 https://repo.maven.apache.org/maven2/com/github/MoebiusSolutions/avro-registry-in-source/avro-registry-in-source-tests/1.8/avro-registry-in-source-tests-1.8.jar
 https://repo.maven.apache.org/maven2/com/github/MoebiusSolutions/avro-registry-in-source/example-project/1.5/example-project-1.5.jar

--- a/java/ql/integration-tests/java/buildless-sibling-projects/buildless-fetches.expected
+++ b/java/ql/integration-tests/java/buildless-sibling-projects/buildless-fetches.expected
@@ -1,6 +1,7 @@
 https://maven-central.storage-download.googleapis.com/maven2/junit/junit/4.12/junit-4.12.jar
 https://maven-central.storage-download.googleapis.com/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar
 https://maven-central.storage-download.googleapis.com/maven2/org/slf4j/slf4j-api/1.7.21/slf4j-api-1.7.21.jar
+https://maven-central.storage-download.googleapis.com/maven2/junit/junit/4.11/junit-4.11.jar
 https://repo.maven.apache.org/maven2/com/feiniaojin/naaf/naaf-graceful-response-example/1.0/naaf-graceful-response-example-1.0.jar
 https://repo.maven.apache.org/maven2/com/github/MoebiusSolutions/avro-registry-in-source/avro-registry-in-source-tests/1.8/avro-registry-in-source-tests-1.8.jar
 https://repo.maven.apache.org/maven2/com/github/MoebiusSolutions/avro-registry-in-source/example-project/1.5/example-project-1.5.jar
@@ -12,7 +13,6 @@ https://repo.maven.apache.org/maven2/de/knutwalker/rx-redis-example_2.11/0.1.2/r
 https://repo.maven.apache.org/maven2/de/knutwalker/rx-redis-java-example_2.11/0.1.2/rx-redis-java-example_2.11-0.1.2.jar
 https://repo.maven.apache.org/maven2/io/github/scrollsyou/example-spring-boot-starter/1.0.0/example-spring-boot-starter-1.0.0.jar
 https://repo.maven.apache.org/maven2/io/streamnative/com/example/maven-central-template/server/3.0.0/server-3.0.0.jar
-https://repo.maven.apache.org/maven2/junit/junit/4.11/junit-4.11.jar
 https://repo.maven.apache.org/maven2/no/nav/security/token-validation-ktor-demo/3.1.0/token-validation-ktor-demo-3.1.0.jar
 https://repo.maven.apache.org/maven2/org/minijax/minijax-example-fileupload/0.5.10/minijax-example-fileupload-0.5.10.jar
 https://repo.maven.apache.org/maven2/org/minijax/minijax-example-inject/0.5.10/minijax-example-inject-0.5.10.jar

--- a/java/ql/integration-tests/java/buildless-sibling-projects/buildless-fetches.expected
+++ b/java/ql/integration-tests/java/buildless-sibling-projects/buildless-fetches.expected
@@ -1,6 +1,6 @@
-https://jcenter.bintray.com/junit/junit/4.12/junit-4.12.jar
-https://jcenter.bintray.com/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar
-https://jcenter.bintray.com/org/slf4j/slf4j-api/1.7.21/slf4j-api-1.7.21.jar
+https://maven-central.storage-download.googleapis.com/maven2/junit/junit/4.12/junit-4.12.jar
+https://maven-central.storage-download.googleapis.com/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar
+https://maven-central.storage-download.googleapis.com/maven2/org/slf4j/slf4j-api/1.7.21/slf4j-api-1.7.21.jar
 https://repo.maven.apache.org/maven2/com/feiniaojin/naaf/naaf-graceful-response-example/1.0/naaf-graceful-response-example-1.0.jar
 https://repo.maven.apache.org/maven2/com/github/MoebiusSolutions/avro-registry-in-source/avro-registry-in-source-tests/1.8/avro-registry-in-source-tests-1.8.jar
 https://repo.maven.apache.org/maven2/com/github/MoebiusSolutions/avro-registry-in-source/example-project/1.5/example-project-1.5.jar

--- a/java/ql/integration-tests/java/buildless-sibling-projects/gradle-sample/build.gradle
+++ b/java/ql/integration-tests/java/buildless-sibling-projects/gradle-sample/build.gradle
@@ -12,9 +12,9 @@ apply plugin: 'java'
 
 // In this section you declare where to find the dependencies of your project
 repositories {
-    // Use 'jcenter' for resolving your dependencies.
-    // You can declare any Maven/Ivy/file repository here.
-    jcenter()
+    maven {
+        url = 'https://maven-central.storage-download.googleapis.com/maven2/'
+    }
 }
 
 // In this section you declare the dependencies for your production and test code

--- a/java/ql/integration-tests/java/buildless-sibling-projects/gradle-sample2/build.gradle
+++ b/java/ql/integration-tests/java/buildless-sibling-projects/gradle-sample2/build.gradle
@@ -12,9 +12,9 @@ apply plugin: 'java'
 
 // In this section you declare where to find the dependencies of your project
 repositories {
-    // Use 'jcenter' for resolving your dependencies.
-    // You can declare any Maven/Ivy/file repository here.
-    jcenter()
+    maven {
+        url = 'https://maven-central.storage-download.googleapis.com/maven2/'
+    }
 }
 
 // In this section you declare the dependencies for your production and test code

--- a/java/ql/integration-tests/java/buildless-sibling-projects/settings.xml
+++ b/java/ql/integration-tests/java/buildless-sibling-projects/settings.xml
@@ -1,0 +1,10 @@
+<settings>
+  <mirrors>
+    <mirror>
+      <id>google-maven-central</id>
+      <name>GCS Maven Central mirror</name>
+      <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+      <mirrorOf>central</mirrorOf>
+    </mirror>
+  </mirrors>
+</settings>

--- a/java/ql/integration-tests/java/buildless-sibling-projects/source_archive.expected
+++ b/java/ql/integration-tests/java/buildless-sibling-projects/source_archive.expected
@@ -26,4 +26,5 @@ maven-project-2/src/main/resources/my-app.properties
 maven-project-2/src/main/resources/page.xml
 maven-project-2/src/main/resources/struts.xml
 maven-project-2/src/test/java/com/example/AppTest4.java
+settings.xml
 test-db/working/settings.xml

--- a/java/ql/integration-tests/java/buildless-sibling-projects/test.py
+++ b/java/ql/integration-tests/java/buildless-sibling-projects/test.py
@@ -1,3 +1,5 @@
+import os
+
 def test(codeql, use_java_11, java, actions_toolchains_file, check_diagnostics_java):
     # The version of gradle used doesn't work on java 17
     codeql.database.create(
@@ -5,5 +7,6 @@ def test(codeql, use_java_11, java, actions_toolchains_file, check_diagnostics_j
             "CODEQL_EXTRACTOR_JAVA_OPTION_BUILDLESS": "true",
             "CODEQL_EXTRACTOR_JAVA_OPTION_BUILDLESS_CLASSPATH_FROM_BUILD_FILES": "true",
             "LGTM_INDEX_MAVEN_TOOLCHAINS_FILE": str(actions_toolchains_file),
+            "LGTM_INDEX_MAVEN_SETTINGS_FILE": os.path.join(os.path.dirname(os.path.realpath(__file__)), "settings.xml"),
         }
     )

--- a/java/ql/integration-tests/java/diagnostics/android-gradle-incompatibility/settings.gradle
+++ b/java/ql/integration-tests/java/diagnostics/android-gradle-incompatibility/settings.gradle
@@ -14,7 +14,9 @@ pluginManagement {
     repositories {
         gradlePluginPortal()
         google()
-        mavenCentral()
+        maven {
+            url = 'https://maven-central.storage-download.googleapis.com/maven2/'
+        }
     }
 }
 dependencyResolutionManagement {
@@ -33,7 +35,9 @@ dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         google()
-        mavenCentral()
+        maven {
+            url = 'https://maven-central.storage-download.googleapis.com/maven2/'
+        }
     }
 }
 rootProject.name = "Android Sample"

--- a/java/ql/integration-tests/java/diagnostics/java-version-too-old/build.gradle
+++ b/java/ql/integration-tests/java/diagnostics/java-version-too-old/build.gradle
@@ -12,9 +12,9 @@ apply plugin: 'java'
 
 // In this section you declare where to find the dependencies of your project
 repositories {
-    // Use 'jcenter' for resolving your dependencies.
-    // You can declare any Maven/Ivy/file repository here.
-    jcenter()
+    maven {
+        url = 'https://maven-central.storage-download.googleapis.com/maven2/'
+    }
 }
 
 // In this section you declare the dependencies for your production and test code

--- a/java/ql/integration-tests/java/diagnostics/no-gradle-wrapper/build.gradle
+++ b/java/ql/integration-tests/java/diagnostics/no-gradle-wrapper/build.gradle
@@ -12,9 +12,9 @@ apply plugin: 'java'
 
 // In this section you declare where to find the dependencies of your project
 repositories {
-    // Use 'jcenter' for resolving your dependencies.
-    // You can declare any Maven/Ivy/file repository here.
-    jcenter()
+    maven {
+        url = 'https://maven-central.storage-download.googleapis.com/maven2/'
+    }
 }
 
 // In this section you declare the dependencies for your production and test code

--- a/java/ql/integration-tests/java/gradle-sample-kotlin-script/app/build.gradle.kts
+++ b/java/ql/integration-tests/java/gradle-sample-kotlin-script/app/build.gradle.kts
@@ -12,8 +12,9 @@ plugins {
 }
 
 repositories {
-    // Use Maven Central for resolving dependencies.
-    mavenCentral()
+    maven {
+        url = uri("https://maven-central.storage-download.googleapis.com/maven2/")
+    }
 }
 
 dependencies {

--- a/java/ql/integration-tests/java/gradle-sample-without-wrapper-or-gradle-buildless/build.gradle
+++ b/java/ql/integration-tests/java/gradle-sample-without-wrapper-or-gradle-buildless/build.gradle
@@ -12,9 +12,9 @@ apply plugin: 'java'
 
 // In this section you declare where to find the dependencies of your project
 repositories {
-    // Use 'jcenter' for resolving your dependencies.
-    // You can declare any Maven/Ivy/file repository here.
-    jcenter()
+    maven {
+        url = 'https://maven-central.storage-download.googleapis.com/maven2/'
+    }
 }
 
 // In this section you declare the dependencies for your production and test code

--- a/java/ql/integration-tests/java/gradle-sample/build.gradle
+++ b/java/ql/integration-tests/java/gradle-sample/build.gradle
@@ -12,9 +12,9 @@ apply plugin: 'java'
 
 // In this section you declare where to find the dependencies of your project
 repositories {
-    // Use 'jcenter' for resolving your dependencies.
-    // You can declare any Maven/Ivy/file repository here.
-    jcenter()
+    maven {
+        url = 'https://maven-central.storage-download.googleapis.com/maven2/'
+    }
 }
 
 // In this section you declare the dependencies for your production and test code

--- a/java/ql/integration-tests/java/partial-gradle-sample-without-gradle/build.gradle
+++ b/java/ql/integration-tests/java/partial-gradle-sample-without-gradle/build.gradle
@@ -12,9 +12,9 @@ apply plugin: 'java'
 
 // In this section you declare where to find the dependencies of your project
 repositories {
-    // Use 'jcenter' for resolving your dependencies.
-    // You can declare any Maven/Ivy/file repository here.
-    jcenter()
+    maven {
+        url = 'https://maven-central.storage-download.googleapis.com/maven2/'
+    }
 }
 
 // In this section you declare the dependencies for your production and test code

--- a/java/ql/integration-tests/java/partial-gradle-sample/build.gradle
+++ b/java/ql/integration-tests/java/partial-gradle-sample/build.gradle
@@ -12,9 +12,9 @@ apply plugin: 'java'
 
 // In this section you declare where to find the dependencies of your project
 repositories {
-    // Use 'jcenter' for resolving your dependencies.
-    // You can declare any Maven/Ivy/file repository here.
-    jcenter()
+    maven {
+        url = 'https://maven-central.storage-download.googleapis.com/maven2/'
+    }
 }
 
 // In this section you declare the dependencies for your production and test code

--- a/java/ql/integration-tests/java/spring-boot-sample/build.gradle
+++ b/java/ql/integration-tests/java/spring-boot-sample/build.gradle
@@ -11,7 +11,9 @@ version = '0.0.1-SNAPSHOT'
 // but I omit it to test we recognise the Spring Boot plugin version.
 
 repositories {
-	mavenCentral()
+	maven {
+		url = 'https://maven-central.storage-download.googleapis.com/maven2/'
+	}
 }
 
 dependencies {

--- a/java/ql/integration-tests/kotlin/all-platforms/compiler_arguments/app/build.gradle
+++ b/java/ql/integration-tests/kotlin/all-platforms/compiler_arguments/app/build.gradle
@@ -15,8 +15,9 @@ plugins {
 }
 
 repositories {
-    // Use Maven Central for resolving dependencies.
-    mavenCentral()
+    maven {
+        url = 'https://maven-central.storage-download.googleapis.com/maven2/'
+    }
 }
 
 application {

--- a/java/ql/integration-tests/kotlin/all-platforms/gradle_groovy_app/app/build.gradle
+++ b/java/ql/integration-tests/kotlin/all-platforms/gradle_groovy_app/app/build.gradle
@@ -18,7 +18,6 @@ repositories {
     maven {
         url = 'https://maven-central.storage-download.googleapis.com/maven2/'
     }
-    
 }
 
 application {

--- a/java/ql/integration-tests/kotlin/all-platforms/gradle_groovy_app/app/build.gradle
+++ b/java/ql/integration-tests/kotlin/all-platforms/gradle_groovy_app/app/build.gradle
@@ -15,8 +15,10 @@ plugins {
 }
 
 repositories {
-    // Use Maven Central for resolving dependencies.
-    mavenCentral()
+    maven {
+        url = 'https://maven-central.storage-download.googleapis.com/maven2/'
+    }
+    
 }
 
 application {

--- a/java/ql/integration-tests/kotlin/all-platforms/gradle_kotlinx_serialization/app/build.gradle
+++ b/java/ql/integration-tests/kotlin/all-platforms/gradle_kotlinx_serialization/app/build.gradle
@@ -4,7 +4,9 @@ plugins {
 }
 
 repositories {
-    mavenCentral()
+    maven {
+        url = 'https://maven-central.storage-download.googleapis.com/maven2/'
+    }
 }
 
 dependencies {

--- a/java/ql/integration-tests/kotlin/all-platforms/kotlin_kfunction/app/build.gradle
+++ b/java/ql/integration-tests/kotlin/all-platforms/kotlin_kfunction/app/build.gradle
@@ -15,8 +15,9 @@ plugins {
 }
 
 repositories {
-    // Use Maven Central for resolving dependencies.
-    mavenCentral()
+    maven {
+        url = 'https://maven-central.storage-download.googleapis.com/maven2/'
+    }
 }
 
 application {


### PR DESCRIPTION
This pull request updates all Gradle `build.gradle` and `settings.gradle` files in the Java integration tests to use a Google Cloud Storage mirror of Maven Central instead of the default `mavenCentral()`. This change ensures consistent and reliable dependency resolution, for improved stability and performance in CI environments It also updates expected fetch URLs in test outputs to match the new repository location.

This PR also updates the use of `jcenter()`, because that repository has been [deprecated](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/) since May 1st, 2021.