### PR TITLE
Go: fix tests with non-empty `testFailures`

### DIFF
--- a/go/ql/lib/semmle/go/security/StoredXssCustomizations.qll
+++ b/go/ql/lib/semmle/go/security/StoredXssCustomizations.qll
@@ -33,9 +33,11 @@ module StoredXss {
         walkFn.getACall().getArgument(1) = f.getASuccessor*()
       )
       or
-      // A call to os.FileInfo.Name
-      exists(Method m | m.implements("io/fs", "FileInfo", "Name") |
-        m = this.(DataFlow::CallNode).getTarget()
+      // The return value of a call to `os.DirEntry.Name`, `os.FileInfo.Name`
+      // or `os.File.ReadDirNames`.
+      exists(DataFlow::CallNode cn, Method m | m = cn.getTarget() and this = cn.getResult(0) |
+        m.implements("io/fs", ["DirEntry", "FileInfo"], "Name") or
+        m.hasQualifiedName("os", "File", "ReadDirNames")
       )
     }
   }

--- a/go/ql/test/query-tests/Security/CWE-079/ReflectedXss.expected
+++ b/go/ql/test/query-tests/Security/CWE-079/ReflectedXss.expected
@@ -156,12 +156,3 @@ nodes
 | websocketXss.go:54:3:54:38 | ... := ...[1] | semmle.label | ... := ...[1] |
 | websocketXss.go:55:24:55:31 | gorilla3 | semmle.label | gorilla3 |
 subpaths
-testFailures
-| websocketXss.go:30:32:30:60 | comment | Missing result: Source[go/reflected-xss] |
-| websocketXss.go:31:11:31:14 | xnet [postupdate] | Unexpected result: Source |
-| websocketXss.go:34:30:34:58 | comment | Missing result: Source[go/reflected-xss] |
-| websocketXss.go:35:21:35:25 | xnet2 [postupdate] | Unexpected result: Source |
-| websocketXss.go:46:38:46:66 | comment | Missing result: Source[go/reflected-xss] |
-| websocketXss.go:47:26:47:35 | gorillaMsg [postupdate] | Unexpected result: Source |
-| websocketXss.go:50:33:50:61 | comment | Missing result: Source[go/reflected-xss] |
-| websocketXss.go:51:17:51:24 | gorilla2 [postupdate] | Unexpected result: Source |

--- a/go/ql/test/query-tests/Security/CWE-079/StoredXss.expected
+++ b/go/ql/test/query-tests/Security/CWE-079/StoredXss.expected
@@ -1,7 +1,9 @@
 #select
+| StoredXss.go:13:21:13:36 | ...+... | StoredXss.go:13:21:13:31 | call to Name | StoredXss.go:13:21:13:36 | ...+... | Stored cross-site scripting vulnerability due to $@. | StoredXss.go:13:21:13:31 | call to Name | stored value |
 | stored.go:30:22:30:25 | name | stored.go:18:3:18:28 | ... := ...[0] | stored.go:30:22:30:25 | name | Stored cross-site scripting vulnerability due to $@. | stored.go:18:3:18:28 | ... := ...[0] | stored value |
 | stored.go:61:22:61:25 | path | stored.go:59:30:59:33 | SSA def(path) | stored.go:61:22:61:25 | path | Stored cross-site scripting vulnerability due to $@. | stored.go:59:30:59:33 | SSA def(path) | stored value |
 edges
+| StoredXss.go:13:21:13:31 | call to Name | StoredXss.go:13:21:13:36 | ...+... | provenance |  |
 | stored.go:18:3:18:28 | ... := ...[0] | stored.go:25:14:25:17 | rows | provenance | Src:MaD:1  |
 | stored.go:25:14:25:17 | rows | stored.go:25:29:25:33 | &... [postupdate] | provenance | FunctionModel |
 | stored.go:25:29:25:33 | &... [postupdate] | stored.go:30:22:30:25 | name | provenance |  |
@@ -9,6 +11,8 @@ edges
 models
 | 1 | Source: database/sql; DB; true; Query; ; ; ReturnValue[0]; database; manual |
 nodes
+| StoredXss.go:13:21:13:31 | call to Name | semmle.label | call to Name |
+| StoredXss.go:13:21:13:36 | ...+... | semmle.label | ...+... |
 | stored.go:18:3:18:28 | ... := ...[0] | semmle.label | ... := ...[0] |
 | stored.go:25:14:25:17 | rows | semmle.label | rows |
 | stored.go:25:29:25:33 | &... [postupdate] | semmle.label | &... [postupdate] |
@@ -16,5 +20,3 @@ nodes
 | stored.go:59:30:59:33 | SSA def(path) | semmle.label | SSA def(path) |
 | stored.go:61:22:61:25 | path | semmle.label | path |
 subpaths
-testFailures
-| StoredXss.go:13:39:13:63 | comment | Missing result: Alert[go/stored-xss] |

--- a/go/ql/test/query-tests/Security/CWE-079/websocketXss.go
+++ b/go/ql/test/query-tests/Security/CWE-079/websocketXss.go
@@ -27,12 +27,12 @@ func xss(w http.ResponseWriter, r *http.Request) {
 	origin := "test"
 	{
 		ws, _ := websocket.Dial(uri, "", origin)
-		var xnet = make([]byte, 512) // $ Source[go/reflected-xss]
-		ws.Read(xnet)
+		var xnet = make([]byte, 512)
+		ws.Read(xnet)              // $ Source[go/reflected-xss]
 		fmt.Fprintf(w, "%v", xnet) // $ Alert[go/reflected-xss]
 		codec := &websocket.Codec{Marshal: marshal, Unmarshal: unmarshal}
-		xnet2 := make([]byte, 512) // $ Source[go/reflected-xss]
-		codec.Receive(ws, xnet2)
+		xnet2 := make([]byte, 512)
+		codec.Receive(ws, xnet2)    // $ Source[go/reflected-xss]
 		fmt.Fprintf(w, "%v", xnet2) // $ Alert[go/reflected-xss]
 	}
 	{
@@ -43,12 +43,12 @@ func xss(w http.ResponseWriter, r *http.Request) {
 	{
 		dialer := gorilla.Dialer{}
 		conn, _, _ := dialer.Dial(uri, nil)
-		var gorillaMsg = make([]byte, 512) // $ Source[go/reflected-xss]
-		gorilla.ReadJSON(conn, gorillaMsg)
-		fmt.Fprintf(w, "%v", gorillaMsg) // $ Alert[go/reflected-xss]
+		var gorillaMsg = make([]byte, 512)
+		gorilla.ReadJSON(conn, gorillaMsg) // $ Source[go/reflected-xss]
+		fmt.Fprintf(w, "%v", gorillaMsg)   // $ Alert[go/reflected-xss]
 
-		gorilla2 := make([]byte, 512) // $ Source[go/reflected-xss]
-		conn.ReadJSON(gorilla2)
+		gorilla2 := make([]byte, 512)
+		conn.ReadJSON(gorilla2)        // $ Source[go/reflected-xss]
 		fmt.Fprintf(w, "%v", gorilla2) // $ Alert[go/reflected-xss]
 
 		_, gorilla3, _ := conn.ReadMessage() // $ Source[go/reflected-xss]


### PR DESCRIPTION
These were committed by mistake, and should have been fixed before being committed.

First commit: We just need to move the inline expectation test comments because moving to the shared SSA library changes the locations of various data flow nodes.

Second commit: In [this PR](https://github.com/github/codeql/pull/19386) to promote an experimental query I included [this commit](https://github.com/github/codeql/commit/e6c19b0cbd49793d7e6fd498da9533e05f9e6723), in which I changed `ioutil.ReadDir`, which has been deprecated for a long time, to its replacement, `os.ReadDir`. I didn't realise that they have different return types (`FileInfo` vs `DirEntry`), and the stored XSS query uses a list of functions that can return the name of a real file on the file system which only included `FileInfo.Name()`. In this PR I update that list to include `DirEntry.Name()`, which makes the test pass again.