### PR TITLE
unified: Make build work in Bazel again

### DIFF
--- a/unified/extractor/BUILD.bazel
+++ b/unified/extractor/BUILD.bazel
@@ -7,6 +7,7 @@ codeql_rust_binary(
     name = "extractor",
     srcs = glob(["src/**/*.rs"]),
     aliases = aliases(),
+    compile_data = ["ast_types.yml"],
     proc_macro_deps = all_crate_deps(
         proc_macro = True,
     ),

--- a/unified/extractor/tree-sitter-swift/bindings/rust/build.rs
+++ b/unified/extractor/tree-sitter-swift/bindings/rust/build.rs
@@ -16,7 +16,9 @@ fn main() {
         Some(&grammar_js),
         tree_sitter_generate::ABI_VERSION_MAX,
         None,
-        None,
+        // Evaluate grammar.js with the embedded QuickJS runtime instead of
+        // spawning `node`, which isn't available inside Bazel's sandbox.
+        Some("native"),
         true,
         tree_sitter_generate::OptLevel::default(),
     )


### PR DESCRIPTION
Makes `bazel build //unified` work again