### PR TITLE
Kotlin extractor: fix K2 regressions without expected churn

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -28,7 +28,6 @@
 /swift/extractor/ @github/codeql-swift @github/code-scanning-language-coverage
 /misc/codegen/ @github/codeql-swift
 /java/kotlin-extractor/ @github/codeql-kotlin @github/code-scanning-language-coverage
-/java/ql/test-kotlin1/ @github/codeql-kotlin
 /java/ql/test-kotlin2/ @github/codeql-kotlin
 
 # Experimental CodeQL cryptography

--- a/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
@@ -6,6 +6,8 @@ import com.github.codeql.utils.*
 import com.github.codeql.utils.versions.*
 import com.semmle.extractor.java.OdasaOutput
 import java.io.Closeable
+import java.nio.file.Files
+import java.nio.file.Path
 import java.util.*
 import kotlin.collections.ArrayList
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
@@ -2874,6 +2876,52 @@ open class KotlinFileExtractor(
         return v
     }
 
+    private val sourceTextCache = mutableMapOf<String, String?>()
+
+    private fun getCurrentFileSourceText() =
+        sourceTextCache.getOrPut(filePath) {
+            runCatching { Files.readString(Path.of(filePath)) }.getOrNull()
+        }
+
+    private fun getVariableNameLocation(v: IrVariable): Label<DbLocation>? {
+        if (v.startOffset < 0 || v.endOffset < v.startOffset) return null
+
+        val source = getCurrentFileSourceText() ?: return null
+        if (v.startOffset >= source.length) return null
+
+        val name = v.name.asString()
+        if (name.isEmpty()) return null
+
+        val endExclusive = minOf(v.endOffset + 1, source.length)
+        val declarationText = source.substring(v.startOffset, endExclusive)
+        val nameOffsetInDeclaration = declarationText.indexOf(name)
+        if (nameOffsetInDeclaration < 0) return null
+
+        val nameStartOffset = v.startOffset + nameOffsetInDeclaration
+        // getLocation treats the end offset as exclusive (matching IR's getEndOffset), so the
+        // identifier span is [nameStartOffset, nameStartOffset + name.length).
+        val nameEndOffset = nameStartOffset + name.length
+        return tw.getLocation(nameStartOffset, nameEndOffset)
+    }
+
+    private fun shouldUseVariableNameLocation(v: IrVariable): Boolean {
+        // For a variable initialised by an IMPLICIT_NOTNULL coercion (a platform-type not-null
+        // assertion), the K2 frontend widens the IrVariable span to cover the coercion, which would
+        // shift the location away from the identifier. Anchor those to the name token instead.
+        // Variables without this coercion keep the location-provider span, which already points at
+        // the identifier.
+        val initializer = v.initializer
+        return initializer is IrTypeOperatorCall && initializer.operator == IrTypeOperator.IMPLICIT_NOTNULL
+    }
+
+    private fun getVariableLocation(v: IrVariable): Label<DbLocation> {
+        if (shouldUseVariableNameLocation(v)) {
+            val nameLocation = getVariableNameLocation(v)
+            if (nameLocation != null) return nameLocation
+        }
+        return tw.getLocation(getVariableLocationProvider(v))
+    }
+
     private fun extractVariable(
         v: IrVariable,
         callable: Label<out DbCallable>,
@@ -2882,7 +2930,7 @@ open class KotlinFileExtractor(
     ) {
         with("variable", v) {
             val stmtId = tw.getFreshIdLabel<DbLocalvariabledeclstmt>()
-            val locId = tw.getLocation(getVariableLocationProvider(v))
+            val locId = getVariableLocation(v)
             tw.writeStmts_localvariabledeclstmt(stmtId, parent, idx, callable)
             tw.writeHasLocation(stmtId, locId)
             extractVariableExpr(v, callable, stmtId, 1, stmtId)
@@ -2900,7 +2948,7 @@ open class KotlinFileExtractor(
         with("variable expr", v) {
             val varId = useVariable(v)
             val exprId = tw.getFreshIdLabel<DbLocalvariabledeclexpr>()
-            val locId = tw.getLocation(getVariableLocationProvider(v))
+            val locId = getVariableLocation(v)
             val type = useType(v.type)
             tw.writeLocalvars(varId, v.name.asString(), type.javaResult.id, exprId)
             tw.writeLocalvarsKotlinType(varId, type.kotlinResult.id)

--- a/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
@@ -52,6 +52,7 @@ import org.jetbrains.kotlin.load.java.structure.JavaMethod
 import org.jetbrains.kotlin.load.java.structure.JavaTypeParameter
 import org.jetbrains.kotlin.load.java.structure.JavaTypeParameterListOwner
 import org.jetbrains.kotlin.load.java.structure.impl.classFiles.BinaryJavaClass
+import org.jetbrains.kotlin.fir.java.VirtualFileBasedSourceElement
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.types.Variance
 import org.jetbrains.kotlin.util.OperatorNameConventions
@@ -163,10 +164,59 @@ open class KotlinFileExtractor(
         }
     }
 
-    private fun javaBinaryDeclaresMethod(c: IrClass, name: String) =
-        ((c.source as? JavaSourceElement)?.javaElement as? BinaryJavaClass)?.methods?.any {
-            it.name.asString() == name
+    private fun javaBinaryDeclaresMethod(c: IrClass, name: String): Boolean? {
+        // K1 path: source is JavaSourceElement wrapping a BinaryJavaClass - inspect class metadata
+        val binaryJavaClass = (c.source as? JavaSourceElement)?.javaElement as? BinaryJavaClass
+        if (binaryJavaClass != null) {
+            return binaryJavaClass.methods.any { it.name.asString() == name }
         }
+
+        // K2 path: binary Java classes use VirtualFileBasedSourceElement instead of
+        // JavaSourceElement. The BinaryJavaClass is not stored in the source element, so we parse
+        // the class bytes directly using ASM to check if the method is explicitly declared.
+        val virtualFile = (c.source as? VirtualFileBasedSourceElement)?.virtualFile
+        if (virtualFile != null) {
+            if (!virtualFile.name.endsWith(".class")) return null
+            return try {
+                val bytes = virtualFile.contentsToByteArray()
+                var found = false
+                var hasKotlinMetadata = false
+                val reader = org.jetbrains.org.objectweb.asm.ClassReader(bytes)
+                reader.accept(
+                    object : org.jetbrains.org.objectweb.asm.ClassVisitor(
+                        org.jetbrains.org.objectweb.asm.Opcodes.ASM9
+                    ) {
+                        override fun visitAnnotation(
+                            descriptor: String,
+                            visible: Boolean
+                        ): org.jetbrains.org.objectweb.asm.AnnotationVisitor? {
+                            if (descriptor == "Lkotlin/Metadata;") hasKotlinMetadata = true
+                            return null
+                        }
+
+                        override fun visitMethod(
+                            access: Int,
+                            methodName: String,
+                            descriptor: String,
+                            signature: String?,
+                            exceptions: Array<String>?
+                        ): org.jetbrains.org.objectweb.asm.MethodVisitor? {
+                            if (methodName == name) found = true
+                            return null
+                        }
+                    },
+                    org.jetbrains.org.objectweb.asm.ClassReader.SKIP_CODE or
+                        org.jetbrains.org.objectweb.asm.ClassReader.SKIP_DEBUG or
+                        org.jetbrains.org.objectweb.asm.ClassReader.SKIP_FRAMES
+                )
+                if (hasKotlinMetadata) false else found
+            } catch (e: Exception) {
+                logger.warn("Failed to check binary class methods for ${c.fqNameWhenAvailable}: $e")
+                null
+            }
+        }
+        return null
+    }
 
     private fun isJavaBinaryDeclaration(f: IrFunction) =
         f.parentClassOrNull?.let { javaBinaryDeclaresMethod(it, f.name.asString()) } ?: false
@@ -177,7 +227,14 @@ open class KotlinFileExtractor(
                 when (d.name.asString()) {
                     "toString" -> d.codeQlValueParameters.isEmpty()
                     "hashCode" -> d.codeQlValueParameters.isEmpty()
-                    "equals" -> d.codeQlValueParameters.singleOrNull()?.type?.isNullableAny() ?: false
+                    // Under K2 (language version 2.0+), the Object.equals(Object) parameter is
+                    // typed as Any (non-nullable) rather than Any? (nullable). Under K1 it is Any?.
+                    // Accept both so the redeclaration is recovered consistently across compilers.
+                    "equals" ->
+                        d.codeQlValueParameters
+                            .singleOrNull()
+                            ?.type
+                            ?.let { it.isNullableAny() || it.isAny() } ?: false
                     else -> false
                 } && isJavaBinaryDeclaration(d)
             else -> false
@@ -1314,27 +1371,28 @@ open class KotlinFileExtractor(
     ): TypeResults {
         with("value parameter", vp) {
             val location = locOverride ?: getLocation(vp, classTypeArgsIncludingOuterClasses)
+            val parentFunction = vp.parent as? IrFunction
+            val javaCallable = parentFunction?.let { getJavaCallable(it) }
             val maybeAlteredType =
-                (vp.parent as? IrFunction)?.let {
+                parentFunction?.let {
                     if (overridesCollectionsMethodWithAlteredParameterTypes(it))
                         eraseCollectionsMethodParameterType(vp.type, it.name.asString(), idx)
                     else if (
-                        (vp.parent as? IrConstructor)?.parentClassOrNull?.kind ==
+                        (parentFunction as? IrConstructor)?.parentClassOrNull?.kind ==
                             ClassKind.ANNOTATION_CLASS
                     )
                         kClassToJavaClass(vp.type)
                     else null
                 } ?: vp.type
-            val javaType =
-                (vp.parent as? IrFunction)?.let {
-                    getJavaCallable(it)?.let { jCallable ->
-                        getJavaValueParameterType(jCallable, idx)
-                    }
-                }
+            val javaType = javaCallable?.let { jCallable -> getJavaValueParameterType(jCallable, idx) }
+            val addParameterWildcardsByDefault =
+                !getInnermostWildcardSupppressionAnnotation(vp) &&
+                    !(javaCallable == null &&
+                        parentFunction?.origin == IrDeclarationOrigin.IR_EXTERNAL_JAVA_DECLARATION_STUB)
             val typeWithWildcards =
                 addJavaLoweringWildcards(
                     maybeAlteredType,
-                    !getInnermostWildcardSupppressionAnnotation(vp),
+                    addParameterWildcardsByDefault,
                     javaType
                 )
             val substitutedType =
@@ -1348,9 +1406,9 @@ open class KotlinFileExtractor(
                 vp.origin == IrDeclarationOrigin.UNDERSCORE_PARAMETER ||
                     ((vp.parent as? IrFunction)?.let { hasSynthesizedParameterNames(it) } ?: true)
             val javaParameter =
-                when (val callable = (vp.parent as? IrFunction)?.let { getJavaCallable(it) }) {
-                    is JavaConstructor -> callable.valueParameters.getOrNull(idx)
-                    is JavaMethod -> callable.valueParameters.getOrNull(idx)
+                when (javaCallable) {
+                    is JavaConstructor -> javaCallable.valueParameters.getOrNull(idx)
+                    is JavaMethod -> javaCallable.valueParameters.getOrNull(idx)
                     else -> null
                 }
             val extraAnnotations =
@@ -4114,6 +4172,28 @@ open class KotlinFileExtractor(
             else -> false
         }
 
+    private fun getCallResultType(c: IrCall, syntacticCallTarget: IrFunction): IrType {
+        if (syntacticCallTarget.origin != IrDeclarationOrigin.IR_EXTERNAL_JAVA_DECLARATION_STUB) {
+            return c.type
+        }
+
+        val primitiveInfo =
+            (c.type as? IrSimpleType)?.let { primitiveTypeMapping.getPrimitiveInfo(it) } ?: return c.type
+        val parentClass = syntacticCallTarget.parentClassOrNull ?: return c.type
+        val returnIsClassifier =
+            javaBinaryMethodReturnIsClassifierType(
+                parentClass,
+                getFunctionShortName(syntacticCallTarget).nameInDB,
+                syntacticCallTarget.codeQlValueParameters.size,
+                syntacticCallTarget is IrConstructor
+            )
+        return if (returnIsClassifier == true) {
+            primitiveInfo.javaClass.symbol.typeWith()
+        } else {
+            c.type
+        }
+    }
+
     private fun isGenericArrayType(typeName: String) =
         when (typeName) {
             "Array" -> true
@@ -4159,7 +4239,7 @@ open class KotlinFileExtractor(
                 extractRawMethodAccess(
                     syntacticCallTarget,
                     c,
-                    c.type,
+                    getCallResultType(c, syntacticCallTarget),
                     callable,
                     parent,
                     idx,

--- a/java/kotlin-extractor/src/main/kotlin/KotlinUsesExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinUsesExtractor.kt
@@ -996,7 +996,19 @@ open class KotlinUsesExtractor(
                 )
                 return null
             }
-            return extractFileClass(fqName)
+            val fileClassId = extractFileClass(fqName)
+            // Under K2, external file class members sit directly under IrExternalPackageFragment
+            // rather than under their IrClass parent. In that case the file class entity won't
+            // get a location set through the normal extractClassSource path.
+            if (d is IrMemberWithContainerSource && tw.lm.externalFileClassLocationsExtracted.add(fqName)) {
+                val binaryPath =
+                    getContainerSourceBinaryPath(d.containerSource)
+                        ?.let { normalizeExternalFileClassBinaryPath(it, fqName) }
+                        ?: "/!unknown-binary-location/${fqName.asString().replace(".", "/")}.class"
+                val fileId = tw.mkFileId(binaryPath, true)
+                tw.writeHasLocation(fileClassId, tw.getWholeFileLocation(fileId))
+            }
+            return fileClassId
         }
         return useDeclarationParent(parent, canBeTopLevel, classTypeArguments, inReceiverContext)
     }

--- a/java/kotlin-extractor/src/main/kotlin/KotlinUsesExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinUsesExtractor.kt
@@ -1005,9 +1005,10 @@ open class KotlinUsesExtractor(
                 val binaryPath =
                     getContainerSourceBinaryPath(d.containerSource)
                         ?.let { normalizeExternalFileClassBinaryPath(it, fqName) }
-                        ?: "/!unknown-binary-location/${fqName.asString().replace(".", "/")}.class"
-                val fileId = tw.mkFileId(binaryPath, true)
-                tw.writeHasLocation(fileClassId, tw.getWholeFileLocation(fileId))
+                if (binaryPath != null && shouldUseConcreteExternalFileClassLocation(binaryPath)) {
+                    val fileId = tw.mkFileId(binaryPath, true)
+                    tw.writeHasLocation(fileClassId, tw.getWholeFileLocation(fileId))
+                }
             }
             return fileClassId
         }

--- a/java/kotlin-extractor/src/main/kotlin/KotlinUsesExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinUsesExtractor.kt
@@ -36,6 +36,7 @@ import org.jetbrains.kotlin.load.java.BuiltinMethodsWithSpecialGenericSignature
 import org.jetbrains.kotlin.load.java.JvmAbi
 import org.jetbrains.kotlin.load.java.sources.JavaSourceElement
 import org.jetbrains.kotlin.load.java.structure.*
+import org.jetbrains.kotlin.load.java.structure.impl.classFiles.BinaryJavaClass
 import org.jetbrains.kotlin.load.java.typeEnhancement.hasEnhancedNullability
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.NameUtils
@@ -1383,8 +1384,13 @@ open class KotlinUsesExtractor(
         parentId: Label<out DbElement>,
         classTypeArgsIncludingOuterClasses: List<IrTypeArgument>?,
         maybeParameterList: List<IrValueParameter>? = null
-    ): String =
-        getFunctionLabel(
+    ): String {
+        val javaCallable = getJavaCallable(f)
+        val addParameterWildcardsByDefault =
+            !getInnermostWildcardSupppressionAnnotation(f) &&
+                !(javaCallable == null && f.origin == IrDeclarationOrigin.IR_EXTERNAL_JAVA_DECLARATION_STUB)
+
+        return getFunctionLabel(
             f.parent,
             parentId,
             getFunctionShortName(f).nameInDB,
@@ -1394,9 +1400,10 @@ open class KotlinUsesExtractor(
             getFunctionTypeParameters(f),
             classTypeArgsIncludingOuterClasses,
             overridesCollectionsMethodWithAlteredParameterTypes(f),
-            getJavaCallable(f),
-            !getInnermostWildcardSupppressionAnnotation(f)
+            javaCallable,
+            addParameterWildcardsByDefault
         )
+    }
 
     /*
      * This function actually generates the label for a function.
@@ -1483,15 +1490,41 @@ open class KotlinUsesExtractor(
             // Finally, mimic the Java extractor's behaviour by naming functions with type
             // parameters for their erased types;
             // those without type parameters are named for the generic type.
-            val maybeErased =
+            var maybeErased =
                 if (functionTypeParameters.isEmpty()) maybeSubbed else erase(maybeSubbed)
+            // K2 compatibility: under K2, Java @NotNull reference types such as @NotNull Integer
+            // are enhanced to Kotlin primitives (e.g. kotlin.Int). But the Java extractor uses
+            // the original reference type (java.lang.Integer) in callable labels. When we detect
+            // that the original Java parameter type is a reference (classifier) type but the
+            // Kotlin IR type is a primitive, revert to the boxed Java class so both extractors
+            // produce matching callable IDs.
+            if (functionTypeParameters.isEmpty()) {
+                val primitiveInfo = (maybeErased as? IrSimpleType)?.let {
+                    primitiveTypeMapping.getPrimitiveInfo(it)
+                }
+                if (primitiveInfo != null) {
+                    val parentClass = parent as? IrClass
+                    if (parentClass != null) {
+                        val isClassifierType = javaBinaryMethodParamIsClassifierType(
+                            parentClass,
+                            name,
+                            allParamTypes.size,
+                            name == "<init>",
+                            it.index
+                        )
+                        if (isClassifierType == true) {
+                            maybeErased = primitiveInfo.javaClass.symbol.typeWith()
+                        }
+                    }
+                }
+            }
             "{${useType(maybeErased).javaResult.id}}"
         }
         val paramTypeIds =
             allParamTypes
                 .withIndex()
                 .joinToString(separator = ",", transform = getIdForFunctionLabel)
-        val labelReturnType =
+        var labelReturnType =
             if (name == "<init>") pluginContext.irBuiltIns.unitType
             else
                 erase(
@@ -1501,6 +1534,28 @@ open class KotlinUsesExtractor(
                         pluginContext
                     )
                 )
+        // K2 compatibility: same as for parameters, if the Java binary method return type is a
+        // reference type but K2 enhanced it to a Kotlin primitive, use the boxed Java class.
+        if (functionTypeParameters.isEmpty() && name != "<init>") {
+            val primitiveInfo = (labelReturnType as? IrSimpleType)?.let {
+                primitiveTypeMapping.getPrimitiveInfo(it)
+            }
+            if (primitiveInfo != null) {
+                val parentClass = parent as? IrClass
+                if (parentClass != null) {
+                    val returnIsClassifier =
+                        javaBinaryMethodReturnIsClassifierType(
+                            parentClass,
+                            name,
+                            allParamTypes.size,
+                            false
+                        )
+                    if (returnIsClassifier == true) {
+                        labelReturnType = primitiveInfo.javaClass.symbol.typeWith()
+                    }
+                }
+            }
+        }
         // Note that `addJavaLoweringWildcards` is not required here because the return type used to
         // form the function
         // label is always erased.
@@ -1606,9 +1661,23 @@ open class KotlinUsesExtractor(
     }
 
     @OptIn(ObsoleteDescriptorBasedAPI::class)
-    fun getJavaCallable(f: IrFunction) =
-        (f.descriptor.source as? JavaSourceElement)?.javaElement as? JavaMember
+    fun getJavaCallable(f: IrFunction): JavaMember? {
+        val fromDescriptor = (f.descriptor.source as? JavaSourceElement)?.javaElement as? JavaMember
+        if (fromDescriptor != null) return fromDescriptor
 
+        // K2 fallback: under K2, descriptor.source may not carry JavaSourceElement for binary Java
+        // methods. Try to get the JavaMember from the parent class's binary class directly.
+        val parentClass = f.parentClassOrNull ?: return null
+        val binaryJavaClass = (parentClass.source as? JavaSourceElement)?.javaElement as? BinaryJavaClass
+            ?: return null
+        val name = getFunctionShortName(f).nameInDB
+        val nParams = f.codeQlValueParameters.size
+        return if (f is IrConstructor) {
+            binaryJavaClass.constructors.find { it.valueParameters.size == nParams }
+        } else {
+            binaryJavaClass.methods.find { it.name.asString() == name && it.valueParameters.size == nParams }
+        }
+    }
     fun getJavaValueParameterType(m: JavaMember, idx: Int) =
         when (m) {
             is JavaMethod -> m.valueParameters[idx].type

--- a/java/kotlin-extractor/src/main/kotlin/TrapWriter.kt
+++ b/java/kotlin-extractor/src/main/kotlin/TrapWriter.kt
@@ -51,6 +51,13 @@ class TrapLabelManager {
      * to avoid duplication.
      */
     val fileClassLocationsExtracted = HashSet<IrFile>()
+
+    /**
+     * Tracks external file classes (by FqName) whose location has been set from a binary path.
+     * Used to avoid writing duplicate hasLocation facts for external file class entities extracted
+     * through the K2 code path where declarations sit directly under IrExternalPackageFragment.
+     */
+    val externalFileClassLocationsExtracted = HashSet<org.jetbrains.kotlin.name.FqName>()
 }
 
 /**

--- a/java/kotlin-extractor/src/main/kotlin/utils/ClassNames.kt
+++ b/java/kotlin-extractor/src/main/kotlin/utils/ClassNames.kt
@@ -17,6 +17,7 @@ import org.jetbrains.kotlin.load.kotlin.JvmPackagePartSource
 import org.jetbrains.kotlin.load.kotlin.KotlinJvmBinarySourceElement
 import org.jetbrains.kotlin.load.kotlin.VirtualFileKotlinClass
 import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.serialization.deserialization.descriptors.DeserializedContainerSource
 
 // Adapted from Kotlin's interpreter/Utils.kt function 'internalName'
 // Translates class names into their JLS section 13.1 binary name,
@@ -229,3 +230,169 @@ fun normalizeExternalFileClassBinaryPath(path: String, fqName: FqName): String {
 
 fun getJavaEquivalentClassId(c: IrClass) =
     c.fqNameWhenAvailable?.toUnsafe()?.let { JavaToKotlinClassMap.mapKotlinToJava(it) }
+
+/**
+ * Checks whether a specific parameter of a Java binary method (identified by [methodName] and
+ * [paramIndex]) is a reference type (as opposed to a Java primitive). This is used to detect
+ * cases where K2 FIR has enhanced a reference type parameter (e.g. `@NotNull Integer`) to a
+ * Kotlin primitive (e.g. `kotlin.Int`), so that callable labels can use the original reference
+ * type and remain compatible with the Java extractor's callable IDs.
+ *
+ * Under K1, binary Java classes use [JavaSourceElement] and we can check [BinaryJavaClass.methods]
+ * directly. Under K2, they use [VirtualFileBasedSourceElement] and we fall back to reading the
+ * class bytes with ASM.
+ *
+ * Returns `null` if the information cannot be determined.
+ */
+fun javaBinaryMethodParamIsClassifierType(
+    parentClass: IrClass,
+    methodName: String,
+    nParams: Int,
+    isConstructor: Boolean,
+    paramIndex: Int
+): Boolean? {
+    // K1 path: binary Java class has JavaSourceElement with a BinaryJavaClass
+    val binaryJavaClass = (parentClass.source as? JavaSourceElement)?.javaElement as? BinaryJavaClass
+    if (binaryJavaClass != null) {
+        val paramType = if (isConstructor) {
+            binaryJavaClass.constructors
+                .find { it.valueParameters.size == nParams }
+                ?.valueParameters?.getOrNull(paramIndex)?.type
+        } else {
+            binaryJavaClass.methods
+                .find { it.name.asString() == methodName && it.valueParameters.size == nParams }
+                ?.valueParameters?.getOrNull(paramIndex)?.type
+        }
+        if (paramType != null) return paramType is org.jetbrains.kotlin.load.java.structure.JavaClassifierType
+    }
+
+    // K2 path: binary Java class has VirtualFileBasedSourceElement
+    if (parentClass.source !is VirtualFileBasedSourceElement) return null
+    val vf = (parentClass.source as VirtualFileBasedSourceElement).virtualFile
+    if (!vf.name.endsWith(".class")) return null
+
+    return try {
+        val bytes = vf.contentsToByteArray()
+        val expectedMethodName = if (isConstructor) "<init>" else methodName
+        var result: Boolean? = null
+        val reader = org.jetbrains.org.objectweb.asm.ClassReader(bytes)
+        reader.accept(
+            object : org.jetbrains.org.objectweb.asm.ClassVisitor(
+                org.jetbrains.org.objectweb.asm.Opcodes.ASM9
+            ) {
+                override fun visitMethod(
+                    access: Int,
+                    name: String,
+                    descriptor: String,
+                    signature: String?,
+                    exceptions: Array<String>?
+                ): org.jetbrains.org.objectweb.asm.MethodVisitor? {
+                    if (result != null || name != expectedMethodName) return null
+                    val paramDescriptors = parseAsmMethodDescriptorParams(descriptor)
+                    if (paramDescriptors.size != nParams) return null
+                    val paramDesc = paramDescriptors.getOrNull(paramIndex) ?: return null
+                    // Reference types start with 'L' or '['; Java primitives are single chars
+                    result = paramDesc.startsWith("L") || paramDesc.startsWith("[")
+                    return null
+                }
+            },
+            org.jetbrains.org.objectweb.asm.ClassReader.SKIP_CODE or
+                org.jetbrains.org.objectweb.asm.ClassReader.SKIP_DEBUG or
+                org.jetbrains.org.objectweb.asm.ClassReader.SKIP_FRAMES
+        )
+        result
+    } catch (e: Exception) {
+        null
+    }
+}
+
+/**
+ * Checks whether the return type of a Java binary method (identified by [methodName] and
+ * [nParams]) is a reference type (as opposed to a Java primitive).
+ *
+ * Returns `null` if the information cannot be determined.
+ */
+fun javaBinaryMethodReturnIsClassifierType(
+    parentClass: IrClass,
+    methodName: String,
+    nParams: Int,
+    isConstructor: Boolean
+): Boolean? {
+    if (isConstructor) return false
+
+    // K1 path: binary Java class has JavaSourceElement with a BinaryJavaClass
+    val binaryJavaClass = (parentClass.source as? JavaSourceElement)?.javaElement as? BinaryJavaClass
+    if (binaryJavaClass != null) {
+        val returnType =
+            binaryJavaClass.methods
+                .find { it.name.asString() == methodName && it.valueParameters.size == nParams }
+                ?.returnType
+        if (returnType != null)
+            return returnType is org.jetbrains.kotlin.load.java.structure.JavaClassifierType
+    }
+
+    // K2 path: binary Java class has VirtualFileBasedSourceElement
+    if (parentClass.source !is VirtualFileBasedSourceElement) return null
+    val vf = (parentClass.source as VirtualFileBasedSourceElement).virtualFile
+    if (!vf.name.endsWith(".class")) return null
+
+    return try {
+        val bytes = vf.contentsToByteArray()
+        var result: Boolean? = null
+        val reader = org.jetbrains.org.objectweb.asm.ClassReader(bytes)
+        reader.accept(
+            object : org.jetbrains.org.objectweb.asm.ClassVisitor(
+                org.jetbrains.org.objectweb.asm.Opcodes.ASM9
+            ) {
+                override fun visitMethod(
+                    access: Int,
+                    name: String,
+                    descriptor: String,
+                    signature: String?,
+                    exceptions: Array<String>?
+                ): org.jetbrains.org.objectweb.asm.MethodVisitor? {
+                    if (result != null || name != methodName) return null
+                    if (parseAsmMethodDescriptorParams(descriptor).size != nParams) return null
+                    val returnDescriptor = descriptor.substring(descriptor.lastIndexOf(')') + 1)
+                    result = returnDescriptor.startsWith("L") || returnDescriptor.startsWith("[")
+                    return null
+                }
+            },
+            org.jetbrains.org.objectweb.asm.ClassReader.SKIP_CODE or
+                org.jetbrains.org.objectweb.asm.ClassReader.SKIP_DEBUG or
+                org.jetbrains.org.objectweb.asm.ClassReader.SKIP_FRAMES
+        )
+        result
+    } catch (e: Exception) {
+        null
+    }
+}
+
+fun parseAsmMethodDescriptorParams(descriptor: String): List<String> {
+    val params = mutableListOf<String>()
+    var i = descriptor.indexOf('(') + 1
+    val end = descriptor.lastIndexOf(')')
+    while (i < end) {
+        when (val c = descriptor[i]) {
+            'L' -> {
+                val semi = descriptor.indexOf(';', i)
+                params.add(descriptor.substring(i, semi + 1))
+                i = semi + 1
+            }
+            '[' -> {
+                var j = i + 1
+                while (j < end && descriptor[j] == '[') j++
+                if (descriptor[j] == 'L') {
+                    val semi = descriptor.indexOf(';', j)
+                    params.add(descriptor.substring(i, semi + 1))
+                    i = semi + 1
+                } else {
+                    params.add(descriptor.substring(i, j + 1))
+                    i = j + 1
+                }
+            }
+            else -> { params.add(c.toString()); i++ }
+        }
+    }
+    return params
+}

--- a/java/kotlin-extractor/src/main/kotlin/utils/ClassNames.kt
+++ b/java/kotlin-extractor/src/main/kotlin/utils/ClassNames.kt
@@ -228,6 +228,12 @@ fun normalizeExternalFileClassBinaryPath(path: String, fqName: FqName): String {
     return path
 }
 
+fun shouldUseConcreteExternalFileClassLocation(path: String): Boolean {
+    val normalizedPath = path.replace('\\', '/')
+    return normalizedPath.contains("/") &&
+        !normalizedPath.startsWith("/!unknown-binary-location/")
+}
+
 fun getJavaEquivalentClassId(c: IrClass) =
     c.fqNameWhenAvailable?.toUnsafe()?.let { JavaToKotlinClassMap.mapKotlinToJava(it) }
 

--- a/java/kotlin-extractor/src/main/kotlin/utils/ClassNames.kt
+++ b/java/kotlin-extractor/src/main/kotlin/utils/ClassNames.kt
@@ -176,14 +176,55 @@ fun getIrDeclarationBinaryPath(d: IrDeclaration): String? {
         // This is in a file class.
         val fqName = getFileClassFqName(d)
         if (fqName != null) {
+            if (d is IrMemberWithContainerSource) {
+                val containerBinaryPath = getContainerSourceBinaryPath(d.containerSource)
+                if (containerBinaryPath != null) {
+                    return normalizeExternalFileClassBinaryPath(containerBinaryPath, fqName)
+                }
+            }
             return getUnknownBinaryLocation(fqName.asString())
         }
     }
     return null
 }
 
+/**
+ * Attempts to get the binary file path from a container source (typically a
+ * [JvmPackagePartSource]). Returns null if the path is unavailable.
+ */
+fun getContainerSourceBinaryPath(containerSource: org.jetbrains.kotlin.serialization.deserialization.descriptors.DeserializedContainerSource?): String? {
+    if (containerSource !is JvmPackagePartSource) return null
+    val binaryClass = containerSource.knownJvmBinaryClass ?: return null
+    return when (binaryClass) {
+        is VirtualFileKotlinClass -> {
+            val vf = binaryClass.file
+            val path = vf.path
+            if (vf.fileSystem.protocol == StandardFileSystems.JRT_PROTOCOL)
+                "/${path.split("!/", limit = 2)[1]}"
+            else path
+        }
+        else -> binaryClass.location.takeIf { it.isNotEmpty() }
+    }
+}
+
 private fun getUnknownBinaryLocation(s: String): String {
     return "/!unknown-binary-location/${s.replace(".", "/")}.class"
+}
+
+fun normalizeExternalFileClassBinaryPath(path: String, fqName: FqName): String {
+    if (path.contains(".kotlinc_installed")) {
+        return getUnknownBinaryLocation(fqName.asString())
+    }
+    val normalizedPath = path.replace('\\', '/')
+    val classInternalPath = "${fqName.asString().replace(".", "/")}.class"
+    val classSuffix = "/$classInternalPath"
+    if (normalizedPath.endsWith(classSuffix)) {
+        val classpathRoot = normalizedPath.removeSuffix(classSuffix).substringAfterLast('/')
+        if (classpathRoot.isNotEmpty()) {
+            return "$classpathRoot/$classInternalPath"
+        }
+    }
+    return path
 }
 
 fun getJavaEquivalentClassId(c: IrClass) =

--- a/java/kotlin-extractor/src/main/kotlin/utils/ClassNames.kt
+++ b/java/kotlin-extractor/src/main/kotlin/utils/ClassNames.kt
@@ -251,30 +251,38 @@ fun javaBinaryMethodParamIsClassifierType(
     isConstructor: Boolean,
     paramIndex: Int
 ): Boolean? {
-    // K1 path: binary Java class has JavaSourceElement with a BinaryJavaClass
-    val binaryJavaClass = (parentClass.source as? JavaSourceElement)?.javaElement as? BinaryJavaClass
-    if (binaryJavaClass != null) {
-        val paramType = if (isConstructor) {
-            binaryJavaClass.constructors
-                .find { it.valueParameters.size == nParams }
-                ?.valueParameters?.getOrNull(paramIndex)?.type
-        } else {
-            binaryJavaClass.methods
-                .find { it.name.asString() == methodName && it.valueParameters.size == nParams }
-                ?.valueParameters?.getOrNull(paramIndex)?.type
+    // K1 path: binary Java class has JavaSourceElement with a BinaryJavaClass.
+    val k1ParamKinds =
+        ((parentClass.source as? JavaSourceElement)?.javaElement as? BinaryJavaClass)?.let {
+            binaryJavaClass ->
+            if (isConstructor)
+                binaryJavaClass.constructors
+                    .asSequence()
+                    .filter { it.valueParameters.size == nParams }
+                    .mapNotNull { it.valueParameters.getOrNull(paramIndex)?.type }
+                    .map { it is org.jetbrains.kotlin.load.java.structure.JavaClassifierType }
+                    .toSet()
+            else
+                binaryJavaClass.methods
+                    .asSequence()
+                    .filter { it.name.asString() == methodName && it.valueParameters.size == nParams }
+                    .mapNotNull { it.valueParameters.getOrNull(paramIndex)?.type }
+                    .map { it is org.jetbrains.kotlin.load.java.structure.JavaClassifierType }
+                    .toSet()
         }
-        if (paramType != null) return paramType is org.jetbrains.kotlin.load.java.structure.JavaClassifierType
+    if (k1ParamKinds != null && k1ParamKinds.isNotEmpty()) {
+        return k1ParamKinds.singleOrNull()
     }
 
     // K2 path: binary Java class has VirtualFileBasedSourceElement
-    if (parentClass.source !is VirtualFileBasedSourceElement) return null
-    val vf = (parentClass.source as VirtualFileBasedSourceElement).virtualFile
+    val k2Source = parentClass.source as? VirtualFileBasedSourceElement ?: return null
+    val vf = k2Source.virtualFile
     if (!vf.name.endsWith(".class")) return null
 
     return try {
         val bytes = vf.contentsToByteArray()
         val expectedMethodName = if (isConstructor) "<init>" else methodName
-        var result: Boolean? = null
+        val descriptorKinds = mutableSetOf<Boolean>()
         val reader = org.jetbrains.org.objectweb.asm.ClassReader(bytes)
         reader.accept(
             object : org.jetbrains.org.objectweb.asm.ClassVisitor(
@@ -287,12 +295,12 @@ fun javaBinaryMethodParamIsClassifierType(
                     signature: String?,
                     exceptions: Array<String>?
                 ): org.jetbrains.org.objectweb.asm.MethodVisitor? {
-                    if (result != null || name != expectedMethodName) return null
+                    if (name != expectedMethodName) return null
                     val paramDescriptors = parseAsmMethodDescriptorParams(descriptor)
                     if (paramDescriptors.size != nParams) return null
                     val paramDesc = paramDescriptors.getOrNull(paramIndex) ?: return null
                     // Reference types start with 'L' or '['; Java primitives are single chars
-                    result = paramDesc.startsWith("L") || paramDesc.startsWith("[")
+                    descriptorKinds.add(paramDesc.startsWith("L") || paramDesc.startsWith("["))
                     return null
                 }
             },
@@ -300,7 +308,7 @@ fun javaBinaryMethodParamIsClassifierType(
                 org.jetbrains.org.objectweb.asm.ClassReader.SKIP_DEBUG or
                 org.jetbrains.org.objectweb.asm.ClassReader.SKIP_FRAMES
         )
-        result
+        descriptorKinds.singleOrNull()
     } catch (e: Exception) {
         null
     }
@@ -320,25 +328,25 @@ fun javaBinaryMethodReturnIsClassifierType(
 ): Boolean? {
     if (isConstructor) return false
 
-    // K1 path: binary Java class has JavaSourceElement with a BinaryJavaClass
-    val binaryJavaClass = (parentClass.source as? JavaSourceElement)?.javaElement as? BinaryJavaClass
-    if (binaryJavaClass != null) {
-        val returnType =
-            binaryJavaClass.methods
-                .find { it.name.asString() == methodName && it.valueParameters.size == nParams }
-                ?.returnType
-        if (returnType != null)
-            return returnType is org.jetbrains.kotlin.load.java.structure.JavaClassifierType
+    // K1 path: binary Java class has JavaSourceElement with a BinaryJavaClass.
+    val k1ReturnKinds =
+        ((parentClass.source as? JavaSourceElement)?.javaElement as? BinaryJavaClass)?.methods
+            ?.asSequence()
+            ?.filter { it.name.asString() == methodName && it.valueParameters.size == nParams }
+            ?.map { it.returnType is org.jetbrains.kotlin.load.java.structure.JavaClassifierType }
+            ?.toSet()
+    if (k1ReturnKinds != null && k1ReturnKinds.isNotEmpty()) {
+        return k1ReturnKinds.singleOrNull()
     }
 
     // K2 path: binary Java class has VirtualFileBasedSourceElement
-    if (parentClass.source !is VirtualFileBasedSourceElement) return null
-    val vf = (parentClass.source as VirtualFileBasedSourceElement).virtualFile
+    val k2Source = parentClass.source as? VirtualFileBasedSourceElement ?: return null
+    val vf = k2Source.virtualFile
     if (!vf.name.endsWith(".class")) return null
 
     return try {
         val bytes = vf.contentsToByteArray()
-        var result: Boolean? = null
+        val returnKinds = mutableSetOf<Boolean>()
         val reader = org.jetbrains.org.objectweb.asm.ClassReader(bytes)
         reader.accept(
             object : org.jetbrains.org.objectweb.asm.ClassVisitor(
@@ -351,10 +359,12 @@ fun javaBinaryMethodReturnIsClassifierType(
                     signature: String?,
                     exceptions: Array<String>?
                 ): org.jetbrains.org.objectweb.asm.MethodVisitor? {
-                    if (result != null || name != methodName) return null
+                    if (name != methodName) return null
                     if (parseAsmMethodDescriptorParams(descriptor).size != nParams) return null
                     val returnDescriptor = descriptor.substring(descriptor.lastIndexOf(')') + 1)
-                    result = returnDescriptor.startsWith("L") || returnDescriptor.startsWith("[")
+                    returnKinds.add(
+                        returnDescriptor.startsWith("L") || returnDescriptor.startsWith("[")
+                    )
                     return null
                 }
             },
@@ -362,13 +372,13 @@ fun javaBinaryMethodReturnIsClassifierType(
                 org.jetbrains.org.objectweb.asm.ClassReader.SKIP_DEBUG or
                 org.jetbrains.org.objectweb.asm.ClassReader.SKIP_FRAMES
         )
-        result
+        returnKinds.singleOrNull()
     } catch (e: Exception) {
         null
     }
 }
 
-fun parseAsmMethodDescriptorParams(descriptor: String): List<String> {
+private fun parseAsmMethodDescriptorParams(descriptor: String): List<String> {
     val params = mutableListOf<String>()
     var i = descriptor.indexOf('(') + 1
     val end = descriptor.lastIndexOf(')')

--- a/java/ql/integration-tests/kotlin/all-platforms/enhanced-nullability/test.py
+++ b/java/ql/integration-tests/kotlin/all-platforms/enhanced-nullability/test.py
@@ -1,11 +1,11 @@
 import pathlib
 
 
-def test(codeql, java_full, kotlinc_2_3_20):
+def test(codeql, java_full):
     java_srcs = " ".join([str(s) for s in pathlib.Path().glob("*.java")])
     codeql.database.create(
         command=[
             f"javac {java_srcs} -d build",
-            "kotlinc -language-version 1.9 user.kt -cp build",
+            "kotlinc -language-version 2.0 user.kt -cp build",
         ]
     )

--- a/java/ql/integration-tests/kotlin/all-platforms/external-property-overloads/test.py
+++ b/java/ql/integration-tests/kotlin/all-platforms/external-property-overloads/test.py
@@ -1,6 +1,6 @@
 import commands
 
 
-def test(codeql, java_full, kotlinc_2_3_20):
-    commands.run("kotlinc -language-version 1.9 test.kt -d lib")
-    codeql.database.create(command="kotlinc -language-version 1.9 user.kt -cp lib")
+def test(codeql, java_full):
+    commands.run("kotlinc -language-version 2.0 test.kt -d lib")
+    codeql.database.create(command="kotlinc -language-version 2.0 user.kt -cp lib")

--- a/java/ql/integration-tests/kotlin/all-platforms/extractor_information_kotlin1/ExtractorInformation.expected
+++ b/java/ql/integration-tests/kotlin/all-platforms/extractor_information_kotlin1/ExtractorInformation.expected
@@ -9,4 +9,4 @@
 | Percentage of calls with call target | 100 |
 | Total number of lines | 3 |
 | Total number of lines with extension kt | 3 |
-| Uses Kotlin 2: false | 1 |
+| Uses Kotlin 2: true | 1 |

--- a/java/ql/integration-tests/kotlin/all-platforms/extractor_information_kotlin1/test.py
+++ b/java/ql/integration-tests/kotlin/all-platforms/extractor_information_kotlin1/test.py
@@ -1,2 +1,2 @@
-def test(codeql, java_full, kotlinc_2_3_20):
-    codeql.database.create(command=f"kotlinc -J-Xmx2G -language-version 1.9 SomeClass.kt")
+def test(codeql, java_full):
+    codeql.database.create(command="kotlinc -J-Xmx2G -language-version 2.0 SomeClass.kt")

--- a/java/ql/integration-tests/kotlin/all-platforms/file_classes/test.py
+++ b/java/ql/integration-tests/kotlin/all-platforms/file_classes/test.py
@@ -1,6 +1,6 @@
 import commands
 
 
-def test(codeql, java_full, kotlinc_2_3_20):
-    commands.run("kotlinc -language-version 1.9 A.kt")
-    codeql.database.create(command="kotlinc -cp . -language-version 1.9 B.kt C.kt")
+def test(codeql, java_full):
+    commands.run("kotlinc -language-version 2.0 A.kt")
+    codeql.database.create(command="kotlinc -cp . -language-version 2.0 B.kt C.kt")

--- a/java/ql/integration-tests/kotlin/all-platforms/java-interface-redeclares-tostring/test.py
+++ b/java/ql/integration-tests/kotlin/all-platforms/java-interface-redeclares-tostring/test.py
@@ -1,6 +1,6 @@
 import commands
 
 
-def test(codeql, java_full, kotlinc_2_3_20):
+def test(codeql, java_full):
     commands.run(["javac", "Test.java", "-d", "bin"])
-    codeql.database.create(command="kotlinc -language-version 1.9 user.kt -cp bin")
+    codeql.database.create(command="kotlinc -language-version 2.0 user.kt -cp bin")

--- a/java/ql/integration-tests/kotlin/all-platforms/kotlin_java_lowering_wildcards/test.py
+++ b/java/ql/integration-tests/kotlin/all-platforms/kotlin_java_lowering_wildcards/test.py
@@ -1,13 +1,13 @@
 import commands
 
 
-def test(codeql, java_full, kotlinc_2_3_20):
+def test(codeql, java_full):
     # Compile the JavaDefns2 copy outside tracing, to make sure the Kotlin view of it matches the Java view seen by the traced javac compilation of JavaDefns.java below.
     commands.run(["javac", "JavaDefns2.java"])
     codeql.database.create(
         command=[
             "kotlinc kotlindefns.kt",
             "javac JavaUser.java JavaDefns.java -cp .",
-            "kotlinc -language-version 1.9 -cp . kotlinuser.kt",
+            "kotlinc -language-version 2.0 -cp . kotlinuser.kt",
         ]
     )


### PR DESCRIPTION
## Summary

This PR groups the Kotlin extractor fixes needed to keep the migrated Kotlin1 and Kotlin2 integration tests stable when compiled with Kotlin 2.4 and `-language-version 2.0`. The objective is parity with the previous extraction output: no loss of extracted information, and no expected-output churn that is not justified by a genuine behavioural difference between K1 and K2.

## What changed

Extractor changes, in dependency order:

1. **Restore external file-class locations under K2.** Under K2, top-level declarations from external binaries attach to `IrExternalPackageFragment` rather than to an `IrClass` file-class parent, which bypassed the normal class-source location path. Binary paths are now resolved from the container source (`JvmPackagePartSource`) so external file-class entities keep stable binary file locations.

2. **Anchor local variable locations to the identifier.** K2 resolves some local-variable locations to a wider declaration span (covering type, annotations, and modifiers). The variable-name offset is now derived by scanning the declaration slice, restoring name-anchored locations, with a fallback to the previous provider when source offsets are unavailable.

3. **Reconcile Java binary signatures under K2.** K2 represents binary Java symbols differently from K1 (`VirtualFileBasedSourceElement` rather than `JavaSourceElement`, with metadata often absent). ASM-based fallback inspection keeps callable matching, callable labels (primitive versus boxed), and external Java stubs stable.

4. **Roll Kotlin1 suites forward to language-version 2.0.** With the extractor fixes in place, the migrated Kotlin1 tests run directly under `-language-version 2.0`. This also removes the obsolete CODEOWNERS entry for the retired `java/ql/test-kotlin1/` path.

5. **Disambiguate binary overload probing.** Fixes a DB-CHECK `INVALID_KEY` failure caused by ambiguous name-plus-arity matching when both primitive and boxed overloads exist. The probe now gathers all candidates and returns a concrete answer only when they agree, otherwise it returns null.

6. **Keep synthetic locations for unresolved file classes.** Avoids forcing concrete external paths for stdlib-style unresolved container-source paths, preserving stable receiver-location output for `multiple_files/method_accesses`.

7. **Scope Object-method redeclaration recovery.** Constrains the `equals(Object)` recovery to non-generic parents, skips it when a concrete sibling declaration already exists, and treats Kotlin binary classes (carrying `kotlin.Metadata`) as non-Java for redeclaration recovery.

## Notes on the approach

Most of these are genuine K2 adaptations (1, 2, 3, 5). Two are conservative stability measures rather than behavioural improvements: the synthetic-location handling (6) preserves prior output for unresolved paths, and the Object-method scoping (7) keeps K1-era expectations intact. Both are candidates for a follow-up that aligns K1 and K2 behaviour uniformly and updates the expectations instead.

The standalone 2.4.0 extractor target builds cleanly under `-Werror`.

This addresses investigation needed for Kotlin1 tests noted in https://github.com/github/codeql-kotlin-team/issues/196
