### PR TITLE
Java: Address testFailures in inline expectations tests

### DIFF
--- a/java/ql/test/experimental/query-tests/quantum/examples/BadMacUse/BadMacOrderDecryptThenMac.expected
+++ b/java/ql/test/experimental/query-tests/quantum/examples/BadMacUse/BadMacOrderDecryptThenMac.expected
@@ -29,6 +29,3 @@ nodes
 | BadMacUse.java:146:48:146:57 | ciphertext : byte[] | semmle.label | ciphertext : byte[] |
 | BadMacUse.java:152:42:152:51 | ciphertext | semmle.label | ciphertext |
 subpaths
-testFailures
-| BadMacUse.java:92:31:92:35 | bytes : byte[] | Unexpected result: Source |
-| BadMacUse.java:146:95:146:159 | // $ Source[java/quantum/examples/bad-mac-order-decrypt-then-mac] | Missing result: Source[java/quantum/examples/bad-mac-order-decrypt-then-mac] |

--- a/java/ql/test/experimental/query-tests/quantum/examples/BadMacUse/BadMacOrderDecryptThenMac.expected
+++ b/java/ql/test/experimental/query-tests/quantum/examples/BadMacUse/BadMacOrderDecryptThenMac.expected
@@ -30,7 +30,5 @@ nodes
 | BadMacUse.java:152:42:152:51 | ciphertext | semmle.label | ciphertext |
 subpaths
 testFailures
-| BadMacUse.java:50:56:50:66 | // $ Source | Missing result: Source |
-| BadMacUse.java:63:118:63:128 | // $ Source | Missing result: Source |
 | BadMacUse.java:92:31:92:35 | bytes : byte[] | Unexpected result: Source |
-| BadMacUse.java:146:95:146:105 | // $ Source | Missing result: Source |
+| BadMacUse.java:146:95:146:159 | // $ Source[java/quantum/examples/bad-mac-order-decrypt-then-mac] | Missing result: Source[java/quantum/examples/bad-mac-order-decrypt-then-mac] |

--- a/java/ql/test/experimental/query-tests/quantum/examples/BadMacUse/BadMacOrderDecryptToMac.expected
+++ b/java/ql/test/experimental/query-tests/quantum/examples/BadMacUse/BadMacOrderDecryptToMac.expected
@@ -32,4 +32,3 @@ nodes
 subpaths
 testFailures
 | BadMacUse.java:92:16:92:36 | doFinal(...) : byte[] | Unexpected result: Source |
-| BadMacUse.java:124:42:124:51 | ciphertext | Unexpected result: Alert |

--- a/java/ql/test/experimental/query-tests/quantum/examples/BadMacUse/BadMacOrderDecryptToMac.expected
+++ b/java/ql/test/experimental/query-tests/quantum/examples/BadMacUse/BadMacOrderDecryptToMac.expected
@@ -30,5 +30,3 @@ nodes
 | BadMacUse.java:118:83:118:84 | iv : byte[] | semmle.label | iv : byte[] |
 | BadMacUse.java:124:42:124:51 | ciphertext | semmle.label | ciphertext |
 subpaths
-testFailures
-| BadMacUse.java:92:16:92:36 | doFinal(...) : byte[] | Unexpected result: Source |

--- a/java/ql/test/experimental/query-tests/quantum/examples/BadMacUse/BadMacOrderDecryptToMac.expected
+++ b/java/ql/test/experimental/query-tests/quantum/examples/BadMacUse/BadMacOrderDecryptToMac.expected
@@ -31,7 +31,5 @@ nodes
 | BadMacUse.java:124:42:124:51 | ciphertext | semmle.label | ciphertext |
 subpaths
 testFailures
-| BadMacUse.java:63:118:63:128 | // $ Source | Missing result: Source |
 | BadMacUse.java:92:16:92:36 | doFinal(...) : byte[] | Unexpected result: Source |
 | BadMacUse.java:124:42:124:51 | ciphertext | Unexpected result: Alert |
-| BadMacUse.java:146:95:146:105 | // $ Source | Missing result: Source |

--- a/java/ql/test/experimental/query-tests/quantum/examples/BadMacUse/BadMacOrderMacOnEncryptPlaintext.expected
+++ b/java/ql/test/experimental/query-tests/quantum/examples/BadMacUse/BadMacOrderMacOnEncryptPlaintext.expected
@@ -44,6 +44,3 @@ nodes
 | BadMacUse.java:146:48:146:57 | ciphertext : byte[] [[]] : Object | semmle.label | ciphertext : byte[] [[]] : Object |
 | BadMacUse.java:152:42:152:51 | ciphertext | semmle.label | ciphertext |
 subpaths
-testFailures
-| BadMacUse.java:139:79:139:90 | input : byte[] | Unexpected result: Source |
-| BadMacUse.java:152:42:152:51 | ciphertext | Unexpected result: Alert |

--- a/java/ql/test/experimental/query-tests/quantum/examples/BadMacUse/BadMacOrderMacOnEncryptPlaintext.expected
+++ b/java/ql/test/experimental/query-tests/quantum/examples/BadMacUse/BadMacOrderMacOnEncryptPlaintext.expected
@@ -45,7 +45,5 @@ nodes
 | BadMacUse.java:152:42:152:51 | ciphertext | semmle.label | ciphertext |
 subpaths
 testFailures
-| BadMacUse.java:50:56:50:66 | // $ Source | Missing result: Source |
 | BadMacUse.java:139:79:139:90 | input : byte[] | Unexpected result: Source |
-| BadMacUse.java:146:95:146:105 | // $ Source | Missing result: Source |
 | BadMacUse.java:152:42:152:51 | ciphertext | Unexpected result: Alert |

--- a/java/ql/test/experimental/query-tests/quantum/examples/BadMacUse/BadMacUse.java
+++ b/java/ql/test/experimental/query-tests/quantum/examples/BadMacUse/BadMacUse.java
@@ -121,7 +121,7 @@ class BadMacUse {
         SecretKey macKey = new SecretKeySpec(macKeyBytes, "HmacSHA256");
         Mac mac = Mac.getInstance("HmacSHA256");
         mac.init(macKey);
-        byte[] computedMac = mac.doFinal(ciphertext); // False Positive
+        byte[] computedMac = mac.doFinal(ciphertext); // $ SPURIOUS: Alert[java/quantum/examples/bad-mac-order-decrypt-to-mac]
 
         // Concatenate ciphertext and MAC
         byte[] output = new byte[ciphertext.length + computedMac.length];
@@ -136,7 +136,7 @@ class BadMacUse {
      * The function decrypts THEN computes the MAC on the plaintext.
      * It should have the MAC computed on the ciphertext first.
      */
-    public void decryptThenMac(byte[] encryptionKeyBytes, byte[] macKeyBytes, byte[] input) throws Exception {
+    public void decryptThenMac(byte[] encryptionKeyBytes, byte[] macKeyBytes, byte[] input) throws Exception { // $ SPURIOUS: Source[java/quantum/examples/bad-mac-order-encrypt-plaintext-also-in-mac]
         // Split input into ciphertext and MAC
         int macLength = 32; // HMAC-SHA256 output length
         byte[] ciphertext = Arrays.copyOfRange(input, 0, input.length - macLength);
@@ -149,7 +149,7 @@ class BadMacUse {
         SecretKey macKey = new SecretKeySpec(macKeyBytes, "HmacSHA256");
         Mac mac = Mac.getInstance("HmacSHA256");
         mac.init(macKey);
-        byte[] computedMac = mac.doFinal(ciphertext); // $ Alert[java/quantum/examples/bad-mac-order-decrypt-then-mac], False positive for Plaintext reuse
+        byte[] computedMac = mac.doFinal(ciphertext); // $ Alert[java/quantum/examples/bad-mac-order-decrypt-then-mac] SPURIOUS: Alert[java/quantum/examples/bad-mac-order-encrypt-plaintext-also-in-mac]
 
         if (!MessageDigest.isEqual(receivedMac, computedMac)) {
             throw new SecurityException("MAC verification failed");

--- a/java/ql/test/experimental/query-tests/quantum/examples/BadMacUse/BadMacUse.java
+++ b/java/ql/test/experimental/query-tests/quantum/examples/BadMacUse/BadMacUse.java
@@ -89,7 +89,7 @@ class BadMacUse {
 
         IvParameterSpec ivParameterSpec = new IvParameterSpec(iv);
         cipher.init(mode, secretKeySpec, ivParameterSpec);
-        return cipher.doFinal(bytes);
+        return cipher.doFinal(bytes); // $ Source[java/quantum/examples/bad-mac-order-decrypt-then-mac]
     }
 
     /**
@@ -143,7 +143,7 @@ class BadMacUse {
         byte[] receivedMac = Arrays.copyOfRange(input, input.length - macLength, input.length);
 
         // Decrypt first (unsafe)
-        byte[] plaintext = decryptUsingWrapper(ciphertext, encryptionKeyBytes, new byte[16]); // $ Source[java/quantum/examples/bad-mac-order-decrypt-then-mac]
+        byte[] plaintext = decryptUsingWrapper(ciphertext, encryptionKeyBytes, new byte[16]);
 
         // Now verify MAC (too late)
         SecretKey macKey = new SecretKeySpec(macKeyBytes, "HmacSHA256");

--- a/java/ql/test/experimental/query-tests/quantum/examples/BadMacUse/BadMacUse.java
+++ b/java/ql/test/experimental/query-tests/quantum/examples/BadMacUse/BadMacUse.java
@@ -89,7 +89,7 @@ class BadMacUse {
 
         IvParameterSpec ivParameterSpec = new IvParameterSpec(iv);
         cipher.init(mode, secretKeySpec, ivParameterSpec);
-        return cipher.doFinal(bytes); // $ Source[java/quantum/examples/bad-mac-order-decrypt-then-mac]
+        return cipher.doFinal(bytes); // $ Source[java/quantum/examples/bad-mac-order-decrypt-then-mac] Source[java/quantum/examples/bad-mac-order-decrypt-to-mac]
     }
 
     /**

--- a/java/ql/test/experimental/query-tests/quantum/examples/BadMacUse/BadMacUse.java
+++ b/java/ql/test/experimental/query-tests/quantum/examples/BadMacUse/BadMacUse.java
@@ -47,7 +47,7 @@ class BadMacUse {
         SecretKey encryptionKey = new SecretKeySpec(encryptionKeyBytes, "AES");
         Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
         cipher.init(Cipher.DECRYPT_MODE, encryptionKey, new SecureRandom());
-        byte[] plaintext = cipher.doFinal(ciphertext); // $ Source
+        byte[] plaintext = cipher.doFinal(ciphertext); // $ Source[java/quantum/examples/bad-mac-order-decrypt-to-mac]
 
         // Now verify MAC (too late)
         SecretKey macKey = new SecretKeySpec(macKeyBytes, "HmacSHA256");
@@ -60,7 +60,7 @@ class BadMacUse {
         }
     }
 
-    public void BadMacOnPlaintext(byte[] encryptionKeyBytes, byte[] macKeyBytes, byte[] plaintext) throws Exception {// $ Source
+    public void BadMacOnPlaintext(byte[] encryptionKeyBytes, byte[] macKeyBytes, byte[] plaintext) throws Exception {// $ Source[java/quantum/examples/bad-mac-order-encrypt-plaintext-also-in-mac]
         // Create keys directly from provided byte arrays
         SecretKey encryptionKey = new SecretKeySpec(encryptionKeyBytes, "AES");
         SecretKey macKey = new SecretKeySpec(macKeyBytes, "HmacSHA256");
@@ -143,7 +143,7 @@ class BadMacUse {
         byte[] receivedMac = Arrays.copyOfRange(input, input.length - macLength, input.length);
 
         // Decrypt first (unsafe)
-        byte[] plaintext = decryptUsingWrapper(ciphertext, encryptionKeyBytes, new byte[16]); // $ Source
+        byte[] plaintext = decryptUsingWrapper(ciphertext, encryptionKeyBytes, new byte[16]); // $ Source[java/quantum/examples/bad-mac-order-decrypt-then-mac]
 
         // Now verify MAC (too late)
         SecretKey macKey = new SecretKeySpec(macKeyBytes, "HmacSHA256");

--- a/java/ql/test/experimental/query-tests/quantum/examples/InsecureOrUnknownNonceSource/InsecureIVorNonceSource.expected
+++ b/java/ql/test/experimental/query-tests/quantum/examples/InsecureOrUnknownNonceSource/InsecureIVorNonceSource.expected
@@ -126,5 +126,3 @@ nodes
 | InsecureIVorNonceSource.java:202:54:202:55 | iv : byte[] | semmle.label | iv : byte[] |
 | InsecureIVorNonceSource.java:206:51:206:56 | ivSpec | semmle.label | ivSpec |
 subpaths
-testFailures
-| InsecureIVorNonceSource.java:42:21:42:21 | 1 : Number | Unexpected result: Source |

--- a/java/ql/test/experimental/query-tests/quantum/examples/InsecureOrUnknownNonceSource/InsecureIVorNonceSource.java
+++ b/java/ql/test/experimental/query-tests/quantum/examples/InsecureOrUnknownNonceSource/InsecureIVorNonceSource.java
@@ -39,7 +39,7 @@ public class InsecureIVorNonceSource {
     public byte[] encryptWithStaticIvByteArray(byte[] key, byte[] plaintext) throws Exception {
         byte[] iv = new byte[16];
         for (byte i = 0; i < iv.length; i++) {
-            iv[i] = 1;
+            iv[i] = 1; // $ Source[java/quantum/examples/insecure-iv-or-nonce]
         }
 
         IvParameterSpec ivSpec = new IvParameterSpec(iv);

--- a/java/ql/test/experimental/query-tests/quantum/examples/WeakOrUnknownKDFIterationCount/Test.java
+++ b/java/ql/test/experimental/query-tests/quantum/examples/WeakOrUnknownKDFIterationCount/Test.java
@@ -42,9 +42,9 @@ public class Test {
      */
     public void pbkdf2LowIteration(String password, int iterationCount) throws Exception { // $ Source[java/quantum/examples/unknown-kdf-iteration-count]
         byte[] salt = generateSalt(16);
-        PBEKeySpec spec = new PBEKeySpec(password.toCharArray(), salt, iterationCount, 256); // $ Alert[java/quantum/examples/unknown-kdf-iteration-count]
+        PBEKeySpec spec = new PBEKeySpec(password.toCharArray(), salt, iterationCount, 256);
         SecretKeyFactory factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256");
-        byte[] key = factory.generateSecret(spec).getEncoded();
+        byte[] key = factory.generateSecret(spec).getEncoded(); // $ Alert[java/quantum/examples/unknown-kdf-iteration-count]
     }
 
     /**

--- a/java/ql/test/experimental/query-tests/quantum/examples/WeakOrUnknownKDFIterationCount/Test.java
+++ b/java/ql/test/experimental/query-tests/quantum/examples/WeakOrUnknownKDFIterationCount/Test.java
@@ -40,7 +40,7 @@ public class Test {
      * SAST/CBOM: - Parent: PBKDF2. - Iteration count is only 10, which is far
      * below acceptable security standards. - Flagged as insecure.
      */
-    public void pbkdf2LowIteration(String password, int iterationCount) throws Exception { // $ Source
+    public void pbkdf2LowIteration(String password, int iterationCount) throws Exception { // $ Source[java/quantum/examples/unknown-kdf-iteration-count]
         byte[] salt = generateSalt(16);
         PBEKeySpec spec = new PBEKeySpec(password.toCharArray(), salt, iterationCount, 256); // $ Alert[java/quantum/examples/unknown-kdf-iteration-count]
         SecretKeyFactory factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256");

--- a/java/ql/test/experimental/query-tests/quantum/examples/WeakOrUnknownKDFIterationCount/UnknownKDFIterationCount.expected
+++ b/java/ql/test/experimental/query-tests/quantum/examples/WeakOrUnknownKDFIterationCount/UnknownKDFIterationCount.expected
@@ -1,5 +1,1 @@
-#select
 | Test.java:47:22:47:49 | KeyDerivation | Key derivation operation with unknown iteration: $@ | Test.java:43:53:43:70 | iterationCount | iterationCount |
-testFailures
-| Test.java:45:94:45:154 | // $ Alert[java/quantum/examples/unknown-kdf-iteration-count] | Missing result: Alert[java/quantum/examples/unknown-kdf-iteration-count] |
-| Test.java:47:22:47:49 | Key derivation operation with unknown iteration: $@ | Unexpected result: Alert |

--- a/java/ql/test/experimental/query-tests/quantum/examples/WeakOrUnknownKDFIterationCount/WeakKDFIterationCount.expected
+++ b/java/ql/test/experimental/query-tests/quantum/examples/WeakOrUnknownKDFIterationCount/WeakKDFIterationCount.expected
@@ -12,5 +12,3 @@ nodes
 | Test.java:58:30:58:38 | 1_000_000 : Number | semmle.label | 1_000_000 : Number |
 | Test.java:59:72:59:85 | iterationCount | semmle.label | iterationCount |
 subpaths
-testFailures
-| Test.java:43:92:43:102 | // $ Source | Missing result: Source |


### PR DESCRIPTION
Address testFailures in inline expectations tests.  Annotations should always be updated so that the `testFailures` section of the `.expected` file is empty.

These particular `testFailures` have been around for a while and have evolved a bit as changes were made.  My interpretation is that we just got into a bad habit of not updating the annotations, or perhaps didn't understand how to do so correctly where several queries are run on the same test source (which can be fiddly).  i.e. I don't think we've uncovered any surprising issues here.