### PR TITLE
Ruby: Address testFailures in inline expectations tests (part 1)

### DIFF
--- a/ruby/ql/test/library-tests/dataflow/string-flow/string-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/string-flow/string-flow.expected
@@ -28,8 +28,6 @@ nodes
 | string_flow.rb:227:10:227:10 | a | semmle.label | a |
 subpaths
 testFailures
-| string_flow.rb:85:10:85:10 | a | Unexpected result: hasValueFlow=a |
-| string_flow.rb:227:10:227:10 | a | Unexpected result: hasValueFlow=a |
 #select
 | string_flow.rb:3:10:3:22 | call to new | string_flow.rb:2:9:2:18 | call to source | string_flow.rb:3:10:3:22 | call to new | $@ | string_flow.rb:2:9:2:18 | call to source | call to source |
 | string_flow.rb:85:10:85:10 | a | string_flow.rb:83:9:83:18 | call to source | string_flow.rb:85:10:85:10 | a | $@ | string_flow.rb:83:9:83:18 | call to source | call to source |

--- a/ruby/ql/test/library-tests/dataflow/string-flow/string_flow.rb
+++ b/ruby/ql/test/library-tests/dataflow/string-flow/string_flow.rb
@@ -82,7 +82,7 @@ end
 def m_clear
     a = source "a"
     a.clear
-    sink a
+    sink a # $ SPURIOUS: hasValueFlow=a
 end
 
 # concat and prepend omitted because they clash with the summaries for
@@ -224,7 +224,7 @@ def m_replace
     b = source "b"
     sink a.replace(b) # $ hasTaintFlow=b
     # TODO: currently we get value flow for a, because we don't clear content
-    sink a # $ hasTaintFlow=b
+    sink a # $ hasTaintFlow=b SPURIOUS: hasValueFlow=a
 end
 
 def m_reverse

--- a/ruby/ql/test/library-tests/frameworks/action_controller/filter_flow.rb
+++ b/ruby/ql/test/library-tests/frameworks/action_controller/filter_flow.rb
@@ -9,7 +9,7 @@ end
 class OneController < ActionController::Base
   before_action :a
   after_action :c
-  
+
   def a
     @foo = params[:foo]
   end
@@ -18,14 +18,14 @@ class OneController < ActionController::Base
   end
 
   def c
-    sink @foo
+    sink @foo # $ hasTaintFlow
   end
 end
 
 class TwoController < ActionController::Base
   before_action :a
   after_action :c
-  
+
   def a
     @foo = params[:foo]
   end
@@ -35,14 +35,14 @@ class TwoController < ActionController::Base
   end
 
   def c
-    sink @foo
+    sink @foo # $ SPURIOUS: hasTaintFlow
   end
 end
 
 class ThreeController < ActionController::Base
   before_action :a
   after_action :c
-  
+
   def a
     @foo = params[:foo]
     @foo = "safe"
@@ -52,14 +52,14 @@ class ThreeController < ActionController::Base
   end
 
   def c
-    sink @foo
+    sink @foo # $ SPURIOUS: hasTaintFlow
   end
 end
 
 class FourController < ActionController::Base
   before_action :a
   after_action :c
-  
+
   def a
     @foo.bar = params[:foo]
   end
@@ -68,14 +68,14 @@ class FourController < ActionController::Base
   end
 
   def c
-    sink(@foo.bar)
+    sink(@foo.bar) # $ hasTaintFlow
   end
 end
 
 class FiveController < ActionController::Base
   before_action :a
   after_action :c
-  
+
   def a
     self.taint_foo
   end
@@ -84,9 +84,9 @@ class FiveController < ActionController::Base
   end
 
   def c
-    sink  @foo
+    sink  @foo # $ hasTaintFlow
   end
-  
+
   def taint_foo
     @foo = params[:foo]
   end

--- a/ruby/ql/test/library-tests/frameworks/action_controller/params-flow.expected
+++ b/ruby/ql/test/library-tests/frameworks/action_controller/params-flow.expected
@@ -270,11 +270,6 @@ nodes
 | params_flow.rb:205:10:205:10 | a | semmle.label | a |
 subpaths
 testFailures
-| filter_flow.rb:21:10:21:13 | @foo | Unexpected result: hasTaintFlow |
-| filter_flow.rb:38:10:38:13 | @foo | Unexpected result: hasTaintFlow |
-| filter_flow.rb:55:10:55:13 | @foo | Unexpected result: hasTaintFlow |
-| filter_flow.rb:71:10:71:17 | call to bar | Unexpected result: hasTaintFlow |
-| filter_flow.rb:87:11:87:14 | @foo | Unexpected result: hasTaintFlow |
 #select
 | filter_flow.rb:21:10:21:13 | @foo | filter_flow.rb:14:12:14:17 | call to params | filter_flow.rb:21:10:21:13 | @foo | $@ | filter_flow.rb:14:12:14:17 | call to params | call to params |
 | filter_flow.rb:38:10:38:13 | @foo | filter_flow.rb:30:12:30:17 | call to params | filter_flow.rb:38:10:38:13 | @foo | $@ | filter_flow.rb:30:12:30:17 | call to params | call to params |


### PR DESCRIPTION
Address testFailures in inline expectations tests.  Annotations should always be updated so that the `testFailures` section of the `.expected` file is empty.

I don't think there are any surprises here, just some missing inline expectations tags.