### PR TITLE
Kotlin: Address inline expectations testFailures.

### DIFF
--- a/java/ql/test-kotlin1/library-tests/dataflow/summaries/test.expected
+++ b/java/ql/test-kotlin1/library-tests/dataflow/summaries/test.expected
@@ -233,3 +233,4 @@ nodes
 subpaths
 | use.kt:9:14:9:25 | taint(...) : Closeable | use.kt:9:31:9:36 | it : Closeable | use.kt:9:33:9:34 | it : Closeable | use.kt:9:14:9:36 | use(...) |
 | with.kt:7:19:7:30 | taint(...) : String | with.kt:7:33:7:40 | $this$with : String | with.kt:7:35:7:38 | this : String | with.kt:7:14:7:40 | with(...) |
+testFailures

--- a/java/ql/test-kotlin1/library-tests/dataflow/summaries/test.expected
+++ b/java/ql/test-kotlin1/library-tests/dataflow/summaries/test.expected
@@ -233,9 +233,3 @@ nodes
 subpaths
 | use.kt:9:14:9:25 | taint(...) : Closeable | use.kt:9:31:9:36 | it : Closeable | use.kt:9:33:9:34 | it : Closeable | use.kt:9:14:9:36 | use(...) |
 | with.kt:7:19:7:30 | taint(...) : String | with.kt:7:33:7:40 | $this$with : String | with.kt:7:35:7:38 | this : String | with.kt:7:14:7:40 | with(...) |
-testFailures
-| test.kt:28:14:28:21 | getSecond(...) | Unexpected result: hasTaintFlow=a |
-| test.kt:35:14:35:27 | component1(...) | Unexpected result: hasTaintFlow=d |
-| test.kt:41:14:41:22 | getSecond(...) | Unexpected result: hasTaintFlow=e |
-| test.kt:53:14:53:24 | getDuration(...) | Unexpected result: hasTaintFlow=f |
-| test.kt:58:14:58:29 | component2(...) | Unexpected result: hasTaintFlow=g |

--- a/java/ql/test-kotlin1/library-tests/dataflow/summaries/test.kt
+++ b/java/ql/test-kotlin1/library-tests/dataflow/summaries/test.kt
@@ -25,20 +25,20 @@ class Test {
         val p = Pair(taint("a"), "")
         sink(p)                                     // $ hasTaintFlow=a
         sink(p.component1())                        // $ hasTaintFlow=a
-        sink(p.second)
+        sink(p.second)                              // $ SPURIOUS: hasTaintFlow=a
 
         sink(taint("b").capitalize())                   // $ hasTaintFlow=b
         sink(taint("c").replaceFirstChar { _ -> 'x' })  // $ hasTaintFlow=c
 
         val t = Triple("", taint("d"), "")
         sink(t)                                     // $ hasTaintFlow=d
-        sink(t.component1())
+        sink(t.component1())                        // $ SPURIOUS: hasTaintFlow=d
         sink(t.second)                              // $ hasTaintFlow=d
 
         val p1 = taint("e") to ""
         sink(p1)                                    // $ hasTaintFlow=e
         sink(p1.component1())                       // $ hasTaintFlow=e
-        sink(p1.second)
+        sink(p1.second)                             // $ SPURIOUS: hasTaintFlow=e
 
         val l = p.toList()
         sink(l)                                     // $ hasTaintFlow=a
@@ -50,12 +50,12 @@ class Test {
         val tv = TimedValue(taint("f"), Duration.parse(""))
         sink(tv)                                    // $ hasTaintFlow=f
         sink(tv.component1())                       // $ hasTaintFlow=f
-        sink(tv.duration)
+        sink(tv.duration)                           // $ SPURIOUS: hasTaintFlow=f
 
         val mg0 = MatchGroup(taint("g"), IntRange(0, 10))
         sink(mg0)                                   // $ hasTaintFlow=g
         sink(mg0.value)                             // $ hasTaintFlow=g
-        sink(mg0.component2())
+        sink(mg0.component2())                      // $ SPURIOUS: hasTaintFlow=g
 
         val iv = IndexedValue<String>(5, taint("h"))
         sink(iv)                                    // $ hasTaintFlow=h

--- a/java/ql/test-kotlin2/library-tests/dataflow/summaries/test.expected
+++ b/java/ql/test-kotlin2/library-tests/dataflow/summaries/test.expected
@@ -233,3 +233,4 @@ nodes
 subpaths
 | use.kt:9:14:9:25 | taint(...) : Closeable | use.kt:9:31:9:36 | it : Closeable | use.kt:9:33:9:34 | it : Closeable | use.kt:9:14:9:36 | use(...) |
 | with.kt:7:19:7:30 | taint(...) : String | with.kt:7:33:7:40 | $this$with : String | with.kt:7:35:7:38 | this : String | with.kt:7:14:7:40 | with(...) |
+testFailures

--- a/java/ql/test-kotlin2/library-tests/dataflow/summaries/test.expected
+++ b/java/ql/test-kotlin2/library-tests/dataflow/summaries/test.expected
@@ -233,9 +233,3 @@ nodes
 subpaths
 | use.kt:9:14:9:25 | taint(...) : Closeable | use.kt:9:31:9:36 | it : Closeable | use.kt:9:33:9:34 | it : Closeable | use.kt:9:14:9:36 | use(...) |
 | with.kt:7:19:7:30 | taint(...) : String | with.kt:7:33:7:40 | $this$with : String | with.kt:7:35:7:38 | this : String | with.kt:7:14:7:40 | with(...) |
-testFailures
-| test.kt:28:14:28:21 | getSecond(...) | Unexpected result: hasTaintFlow=a |
-| test.kt:35:14:35:27 | component1(...) | Unexpected result: hasTaintFlow=d |
-| test.kt:41:14:41:22 | getSecond(...) | Unexpected result: hasTaintFlow=e |
-| test.kt:53:14:53:24 | getDuration(...) | Unexpected result: hasTaintFlow=f |
-| test.kt:58:14:58:29 | component2(...) | Unexpected result: hasTaintFlow=g |

--- a/java/ql/test-kotlin2/library-tests/dataflow/summaries/test.kt
+++ b/java/ql/test-kotlin2/library-tests/dataflow/summaries/test.kt
@@ -25,20 +25,20 @@ class Test {
         val p = Pair(taint("a"), "")
         sink(p)                                     // $ hasTaintFlow=a
         sink(p.component1())                        // $ hasTaintFlow=a
-        sink(p.second)
+        sink(p.second)                              // $ SPURIOUS: hasTaintFlow=a
 
         sink(taint("b").capitalize())                   // $ hasTaintFlow=b
         sink(taint("c").replaceFirstChar { _ -> 'x' })  // $ hasTaintFlow=c
 
         val t = Triple("", taint("d"), "")
         sink(t)                                     // $ hasTaintFlow=d
-        sink(t.component1())
+        sink(t.component1())                        // $ SPURIOUS: hasTaintFlow=d
         sink(t.second)                              // $ hasTaintFlow=d
 
         val p1 = taint("e") to ""
         sink(p1)                                    // $ hasTaintFlow=e
         sink(p1.component1())                       // $ hasTaintFlow=e
-        sink(p1.second)
+        sink(p1.second)                             // $ SPURIOUS: hasTaintFlow=e
 
         val l = p.toList()
         sink(l)                                     // $ hasTaintFlow=a
@@ -50,12 +50,12 @@ class Test {
         val tv = TimedValue(taint("f"), Duration.parse(""))
         sink(tv)                                    // $ hasTaintFlow=f
         sink(tv.component1())                       // $ hasTaintFlow=f
-        sink(tv.duration)
+        sink(tv.duration)                           // $ SPURIOUS: hasTaintFlow=f
 
         val mg0 = MatchGroup(taint("g"), IntRange(0, 10))
         sink(mg0)                                   // $ hasTaintFlow=g
         sink(mg0.value)                             // $ hasTaintFlow=g
-        sink(mg0.component2())
+        sink(mg0.component2())                      // $ SPURIOUS: hasTaintFlow=g
 
         val iv = IndexedValue<String>(5, taint("h"))
         sink(iv)                                    // $ hasTaintFlow=h


### PR DESCRIPTION
Address testFailures in inline expectations tests. Annotations should always be updated so that the testFailures section of the .expected file is empty.

The issue here was missing inline expectations tags for spurious results involving pairs, triples etc.  I don't know if we want to address this, but urgency is low.