### PR TITLE
Ruby: Address testFailures in inline expectations tests (part 2)

### DIFF
--- a/ruby/ql/lib/utils/test/internal/InlineExpectationsTestImpl.qll
+++ b/ruby/ql/lib/utils/test/internal/InlineExpectationsTestImpl.qll
@@ -4,11 +4,51 @@ private import codeql.util.test.InlineExpectationsTest
 module Impl implements InlineExpectationsTestSig {
   private import codeql.ruby.ast.internal.TreeSitter
 
+  private newtype TAnyComment =
+    RubyComment(Ruby::Comment comment) or
+    ErbComment(R::ErbComment comment)
+
+  private class AnyComment extends TAnyComment {
+    string toString() {
+      exists(Ruby::Comment c |
+        this = RubyComment(c) and
+        result = c.toString()
+      )
+      or
+      exists(R::ErbComment c |
+        this = ErbComment(c) and
+        result = c.toString()
+      )
+    }
+
+    Location getLocation() {
+      exists(Ruby::Comment c |
+        this = RubyComment(c) and
+        result = c.getLocation()
+      )
+      or
+      exists(R::ErbComment c |
+        this = ErbComment(c) and
+        result = c.getLocation()
+      )
+    }
+  }
+
   /**
    * A class representing line comments in Ruby.
    */
-  class ExpectationComment extends Ruby::Comment {
-    string getContents() { result = this.getValue().suffix(1) }
+  class ExpectationComment extends AnyComment {
+    string getContents() {
+      exists(Ruby::Comment c |
+        this = RubyComment(c) and
+        result = c.getValue().suffix(1)
+      )
+      or
+      exists(R::ErbComment c |
+        this = ErbComment(c) and
+        result = c.getValue().suffix(1)
+      )
+    }
   }
 
   class Location = R::Location;

--- a/ruby/ql/lib/utils/test/internal/InlineExpectationsTestImpl.qll
+++ b/ruby/ql/lib/utils/test/internal/InlineExpectationsTestImpl.qll
@@ -13,39 +13,21 @@ module Impl implements InlineExpectationsTestSig {
    */
   class ExpectationComment extends TAnyComment {
     string toString() {
-      exists(Ruby::Comment c |
-        this = RubyComment(c) and
-        result = c.toString()
-      )
+      result = any(Ruby::Comment c | this = RubyComment(c)).toString()
       or
-      exists(R::ErbComment c |
-        this = ErbComment(c) and
-        result = c.toString()
-      )
+      result = any(R::ErbComment c | this = ErbComment(c)).toString()
     }
 
     Location getLocation() {
-      exists(Ruby::Comment c |
-        this = RubyComment(c) and
-        result = c.getLocation()
-      )
+      result = any(Ruby::Comment c | this = RubyComment(c)).getLocation()
       or
-      exists(R::ErbComment c |
-        this = ErbComment(c) and
-        result = c.getLocation()
-      )
+      result = any(R::ErbComment c | this = ErbComment(c)).getLocation()
     }
 
     string getContents() {
-      exists(Ruby::Comment c |
-        this = RubyComment(c) and
-        result = c.getValue().suffix(1)
-      )
+      result = any(Ruby::Comment c | this = RubyComment(c)).getValue().suffix(1)
       or
-      exists(R::ErbComment c |
-        this = ErbComment(c) and
-        result = c.getValue().suffix(1)
-      )
+      result = any(R::ErbComment c | this = ErbComment(c)).getValue().suffix(1)
     }
   }
 

--- a/ruby/ql/lib/utils/test/internal/InlineExpectationsTestImpl.qll
+++ b/ruby/ql/lib/utils/test/internal/InlineExpectationsTestImpl.qll
@@ -35,7 +35,7 @@ module Impl implements InlineExpectationsTestSig {
   }
 
   /**
-   * A class representing line comments in Ruby.
+   * A class representing comments that may contain inline expectations (Ruby line comments and ERB comments).
    */
   class ExpectationComment extends AnyComment {
     string getContents() {

--- a/ruby/ql/lib/utils/test/internal/InlineExpectationsTestImpl.qll
+++ b/ruby/ql/lib/utils/test/internal/InlineExpectationsTestImpl.qll
@@ -12,22 +12,26 @@ module Impl implements InlineExpectationsTestSig {
    * A class representing comments that may contain inline expectations (Ruby line comments and ERB comments).
    */
   class ExpectationComment extends TAnyComment {
+    Ruby::Comment asRubyComment() { this = RubyComment(result) }
+
+    R::ErbComment asErbComment() { this = ErbComment(result) }
+
     string toString() {
-      result = any(Ruby::Comment c | this = RubyComment(c)).toString()
+      result = this.asRubyComment().toString()
       or
-      result = any(R::ErbComment c | this = ErbComment(c)).toString()
+      result = this.asErbComment().toString()
     }
 
     Location getLocation() {
-      result = any(Ruby::Comment c | this = RubyComment(c)).getLocation()
+      result = this.asRubyComment().getLocation()
       or
-      result = any(R::ErbComment c | this = ErbComment(c)).getLocation()
+      result = this.asErbComment().getLocation()
     }
 
     string getContents() {
-      result = any(Ruby::Comment c | this = RubyComment(c)).getValue().suffix(1)
+      result = this.asRubyComment().getValue().suffix(1)
       or
-      result = any(R::ErbComment c | this = ErbComment(c)).getValue().suffix(1)
+      result = this.asErbComment().getValue().suffix(1)
     }
   }
 

--- a/ruby/ql/lib/utils/test/internal/InlineExpectationsTestImpl.qll
+++ b/ruby/ql/lib/utils/test/internal/InlineExpectationsTestImpl.qll
@@ -8,7 +8,10 @@ module Impl implements InlineExpectationsTestSig {
     RubyComment(Ruby::Comment comment) or
     ErbComment(R::ErbComment comment)
 
-  private class AnyComment extends TAnyComment {
+  /**
+   * A class representing comments that may contain inline expectations (Ruby line comments and ERB comments).
+   */
+  class ExpectationComment extends TAnyComment {
     string toString() {
       exists(Ruby::Comment c |
         this = RubyComment(c) and
@@ -32,12 +35,7 @@ module Impl implements InlineExpectationsTestSig {
         result = c.getLocation()
       )
     }
-  }
 
-  /**
-   * A class representing comments that may contain inline expectations (Ruby line comments and ERB comments).
-   */
-  class ExpectationComment extends AnyComment {
     string getContents() {
       exists(Ruby::Comment c |
         this = RubyComment(c) and

--- a/ruby/ql/test/library-tests/frameworks/sinatra/Flow.expected
+++ b/ruby/ql/test/library-tests/frameworks/sinatra/Flow.expected
@@ -23,7 +23,6 @@ nodes
 | views/index.erb:2:10:2:12 | call to foo | semmle.label | call to foo |
 subpaths
 testFailures
-| views/index.erb:2:10:2:12 | call to foo | Unexpected result: hasTaintFlow |
 #select
 | app.rb:95:10:95:14 | @user | app.rb:103:13:103:22 | call to source | app.rb:95:10:95:14 | @user | $@ | app.rb:103:13:103:22 | call to source | call to source |
 | views/index.erb:2:10:2:12 | call to foo | app.rb:75:12:75:17 | call to params | views/index.erb:2:10:2:12 | call to foo | $@ | app.rb:75:12:75:17 | call to params | call to params |

--- a/ruby/ql/test/library-tests/frameworks/sinatra/views/index.erb
+++ b/ruby/ql/test/library-tests/frameworks/sinatra/views/index.erb
@@ -1,2 +1,2 @@
 <%= @foo %>
-<%= sink foo %>
+<%= sink foo %> <%# $ hasTaintFlow %>

--- a/ruby/ql/test/query-tests/experimental/improper-memoization/ImproperMemoization.expected
+++ b/ruby/ql/test/query-tests/experimental/improper-memoization/ImproperMemoization.expected
@@ -1,5 +1,4 @@
 testFailures
-| improper_memoization.rb:100:1:104:3 | m14 | Unexpected result: result=BAD |
 #select
 | improper_memoization.rb:50:1:55:3 | m7 | improper_memoization.rb:50:8:50:10 | arg | improper_memoization.rb:51:3:53:5 | ... \|\|= ... |
 | improper_memoization.rb:58:1:63:3 | m8 | improper_memoization.rb:58:8:58:10 | arg | improper_memoization.rb:59:3:61:5 | ... \|\|= ... |

--- a/ruby/ql/test/query-tests/experimental/improper-memoization/improper_memoization.rb
+++ b/ruby/ql/test/query-tests/experimental/improper-memoization/improper_memoization.rb
@@ -101,4 +101,4 @@ def m14(arg)
   @m14 ||= {}
   key = "foo/#{arg}"
   @m14[key] ||= long_running_method(arg)
-end
+end # $ SPURIOUS: result=BAD


### PR DESCRIPTION
Address further testFailures in inline expectations tests. Annotations should always be updated so that the `testFailures` section of the `.expected` file is empty.

The `improper_memoization.rb` change is trivial.  The other one is in a `.erb` file, so I had to add support for inline expectations comments in `.erb` files in order to make the `testFailures` result go away.  I'm fairly happy with that aspect of the PR.

I'd appreciate confirmation that the taint flow result in the `.erb` is a valid result, and shouldn't be marked as `SPURIOUS:`.  It looks like that's the intent, but I wasn't 100% confident what was going on.