### PR TITLE
C++: Remove support for global variables as sources and sinks in MaD

### DIFF
--- a/cpp/ql/lib/change-notes/2026-06-30-variables-as-mad-sources-and-sinks.md
+++ b/cpp/ql/lib/change-notes/2026-06-30-variables-as-mad-sources-and-sinks.md
@@ -1,0 +1,4 @@
+---
+category: breaking
+---
+* Removed support for using variables as sources and sinks in models-as-data. Users of this feature should convert such sources and sinks to models defined using the QL language.

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/ExternalFlow.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/ExternalFlow.qll
@@ -931,31 +931,6 @@ private Element interpretElement0(
     signature = "" and
     elementSpec(namespace, type, subtypes, name, signature, _)
   )
-  or
-  // Member variables
-  elementSpec(namespace, type, subtypes, name, signature, _) and
-  signature = "" and
-  exists(Class namedClass, Class classWithMember, MemberVariable member |
-    member.getName() = name and
-    member = classWithMember.getAMember() and
-    namedClass.hasQualifiedName(namespace, type) and
-    result = member
-  |
-    // field declared in the named type or a subtype of it (or an extension of any)
-    subtypes = true and
-    classWithMember = namedClass.getADerivedClass*()
-    or
-    // field declared directly in the named type (or an extension of it)
-    subtypes = false and
-    classWithMember = namedClass
-  )
-  or
-  // Global or namespace variables
-  elementSpec(namespace, type, subtypes, name, signature, _) and
-  signature = "" and
-  type = "" and
-  subtypes = false and
-  result = any(GlobalOrNamespaceVariable v | v.hasQualifiedName(namespace, name))
 }
 
 cached

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/FlowSummaryImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/FlowSummaryImpl.qll
@@ -218,40 +218,11 @@ module SourceSinkInterpretationInput implements
 
   /** Provides additional sink specification logic. */
   bindingset[c]
-  predicate interpretOutput(string c, InterpretNode mid, InterpretNode node) {
-    // Allow variables to be picked as output nodes.
-    exists(Node n, Element ast |
-      n = node.asNode() and
-      ast = mid.asElement()
-    |
-      c = "" and
-      n.asExpr().(VariableAccess).getTarget() = ast
-    )
-  }
+  predicate interpretOutput(string c, InterpretNode mid, InterpretNode node) { none() }
 
   /** Provides additional source specification logic. */
   bindingset[c]
-  predicate interpretInput(string c, InterpretNode mid, InterpretNode node) {
-    exists(Node n, Element ast, VariableAccess e |
-      n = node.asNode() and
-      ast = mid.asElement() and
-      e.getTarget() = ast
-    |
-      // Allow variables to be picked as input nodes.
-      // We could simply do this as `e = n.asExpr()`, but that would not allow
-      // us to pick `x` as a sink in an example such as `x = source()` (but
-      // only subsequent uses of `x`) since the variable access on `x` doesn't
-      // actually load the value of `x`. So instead, we pick the instruction
-      // node corresponding to the generated `StoreInstruction` and use the
-      // expression associated with the destination instruction. This means
-      // that the `x` in `x = source()` can be marked as an input.
-      c = "" and
-      exists(StoreInstruction store |
-        store.getDestinationAddress().getUnconvertedResultExpression() = e and
-        n.asInstruction() = store
-      )
-    )
-  }
+  predicate interpretInput(string c, InterpretNode mid, InterpretNode node) { none() }
 }
 
 module Private {

--- a/cpp/ql/test/library-tests/dataflow/models-as-data/testModels.expected
+++ b/cpp/ql/test/library-tests/dataflow/models-as-data/testModels.expected
@@ -28,26 +28,6 @@ multipleArgumentCall
 lambdaCallEnclosingCallableMismatch
 speculativeStepAlreadyHasModel
 testFailures
-| tests.cpp:20:25:20:45 | // $ interpretElement | Missing result: interpretElement |
-| tests.cpp:21:34:21:54 | // $ interpretElement | Missing result: interpretElement |
-| tests.cpp:25:34:25:54 | // $ interpretElement | Missing result: interpretElement |
-| tests.cpp:72:28:72:34 | // $ ir | Missing result: ir |
-| tests.cpp:79:49:79:55 | // $ ir | Missing result: ir |
-| tests.cpp:99:17:99:37 | // $ interpretElement | Missing result: interpretElement |
-| tests.cpp:100:26:100:46 | // $ interpretElement | Missing result: interpretElement |
-| tests.cpp:122:26:122:32 | // $ ir | Missing result: ir |
-| tests.cpp:128:35:128:41 | // $ ir | Missing result: ir |
-| tests.cpp:167:33:167:53 | // $ interpretElement | Missing result: interpretElement |
-| tests.cpp:168:41:168:61 | // $ interpretElement | Missing result: interpretElement |
-| tests.cpp:169:42:169:62 | // $ interpretElement | Missing result: interpretElement |
-| tests.cpp:272:32:272:52 | // $ interpretElement | Missing result: interpretElement |
-| tests.cpp:278:24:278:44 | // $ interpretElement | Missing result: interpretElement |
-| tests.cpp:309:34:309:54 | // $ interpretElement | Missing result: interpretElement |
-| tests.cpp:310:47:310:67 | // $ interpretElement | Missing result: interpretElement |
-| tests.cpp:334:37:334:43 | // $ ir | Missing result: ir |
-| tests.cpp:347:34:347:40 | // $ ir | Missing result: ir |
-| tests.cpp:351:44:351:50 | // $ ir | Missing result: ir |
-| tests.cpp:352:68:352:74 | // $ ir | Missing result: ir |
 summaryCalls
 | file://:0:0:0:0 | [summary] call to [summary param] 0 in madCallArg0ReturnToReturn in madCallArg0ReturnToReturn |
 | file://:0:0:0:0 | [summary] call to [summary param] 0 in madCallArg0ReturnToReturnFirst in madCallArg0ReturnToReturnFirst |
@@ -102,10 +82,6 @@ sourceCallables
 | tests.cpp:19:6:19:32 | remoteMadSourceIndirectArg1 |
 | tests.cpp:19:39:19:39 | x |
 | tests.cpp:19:47:19:47 | y |
-| tests.cpp:20:5:20:22 | remoteMadSourceVar |
-| tests.cpp:21:6:21:31 | remoteMadSourceVarIndirect |
-| tests.cpp:24:6:24:28 | namespaceLocalMadSource |
-| tests.cpp:25:6:25:31 | namespaceLocalMadSourceVar |
 | tests.cpp:28:7:28:30 | namespace2LocalMadSource |
 | tests.cpp:31:6:31:19 | localMadSource |
 | tests.cpp:33:5:33:27 | namespaceLocalMadSource |
@@ -139,8 +115,6 @@ sourceCallables
 | tests.cpp:97:31:97:31 | x |
 | tests.cpp:98:6:98:30 | madSinkDoubleIndirectArg0 |
 | tests.cpp:98:38:98:38 | x |
-| tests.cpp:99:5:99:14 | madSinkVar |
-| tests.cpp:100:6:100:23 | madSinkVarIndirect |
 | tests.cpp:102:6:102:15 | test_sinks |
 | tests.cpp:116:6:116:6 | a |
 | tests.cpp:117:7:117:11 | a_ptr |
@@ -196,9 +170,6 @@ sourceCallables
 | tests.cpp:164:47:164:47 | x |
 | tests.cpp:165:13:165:40 | madArg0ToReturnFieldIndirect |
 | tests.cpp:165:46:165:46 | x |
-| tests.cpp:167:13:167:30 | madFieldToFieldVar |
-| tests.cpp:168:13:168:38 | madFieldToIndirectFieldVar |
-| tests.cpp:169:14:169:39 | madIndirectFieldToFieldVar |
 | tests.cpp:171:6:171:19 | test_summaries |
 | tests.cpp:174:6:174:6 | a |
 | tests.cpp:174:9:174:9 | b |
@@ -217,12 +188,10 @@ sourceCallables
 | tests.cpp:270:6:270:26 | memberRemoteMadSource |
 | tests.cpp:271:7:271:39 | memberRemoteMadSourceIndirectArg0 |
 | tests.cpp:271:46:271:46 | x |
-| tests.cpp:272:6:272:29 | memberRemoteMadSourceVar |
 | tests.cpp:273:7:273:21 | qualifierSource |
 | tests.cpp:274:7:274:26 | qualifierFieldSource |
 | tests.cpp:277:7:277:23 | memberMadSinkArg0 |
 | tests.cpp:277:29:277:29 | x |
-| tests.cpp:278:6:278:21 | memberMadSinkVar |
 | tests.cpp:279:7:279:19 | qualifierSink |
 | tests.cpp:280:7:280:23 | qualifierArg0Sink |
 | tests.cpp:280:29:280:29 | x |
@@ -252,8 +221,6 @@ sourceCallables
 | tests.cpp:307:39:307:39 | x |
 | tests.cpp:308:15:308:46 | namespaceStaticMemberMadSinkArg0 |
 | tests.cpp:308:52:308:52 | x |
-| tests.cpp:309:7:309:31 | namespaceMemberMadSinkVar |
-| tests.cpp:310:14:310:44 | namespaceStaticMemberMadSinkVar |
 | tests.cpp:313:7:313:30 | namespaceMadSelfToReturn |
 | tests.cpp:317:22:317:28 | source3 |
 | tests.cpp:319:6:319:23 | test_class_members |

--- a/cpp/ql/test/library-tests/dataflow/models-as-data/testModels.expected
+++ b/cpp/ql/test/library-tests/dataflow/models-as-data/testModels.expected
@@ -28,6 +28,26 @@ multipleArgumentCall
 lambdaCallEnclosingCallableMismatch
 speculativeStepAlreadyHasModel
 testFailures
+| tests.cpp:20:25:20:45 | // $ interpretElement | Missing result: interpretElement |
+| tests.cpp:21:34:21:54 | // $ interpretElement | Missing result: interpretElement |
+| tests.cpp:25:34:25:54 | // $ interpretElement | Missing result: interpretElement |
+| tests.cpp:72:28:72:34 | // $ ir | Missing result: ir |
+| tests.cpp:79:49:79:55 | // $ ir | Missing result: ir |
+| tests.cpp:99:17:99:37 | // $ interpretElement | Missing result: interpretElement |
+| tests.cpp:100:26:100:46 | // $ interpretElement | Missing result: interpretElement |
+| tests.cpp:122:26:122:32 | // $ ir | Missing result: ir |
+| tests.cpp:128:35:128:41 | // $ ir | Missing result: ir |
+| tests.cpp:167:33:167:53 | // $ interpretElement | Missing result: interpretElement |
+| tests.cpp:168:41:168:61 | // $ interpretElement | Missing result: interpretElement |
+| tests.cpp:169:42:169:62 | // $ interpretElement | Missing result: interpretElement |
+| tests.cpp:272:32:272:52 | // $ interpretElement | Missing result: interpretElement |
+| tests.cpp:278:24:278:44 | // $ interpretElement | Missing result: interpretElement |
+| tests.cpp:309:34:309:54 | // $ interpretElement | Missing result: interpretElement |
+| tests.cpp:310:47:310:67 | // $ interpretElement | Missing result: interpretElement |
+| tests.cpp:334:37:334:43 | // $ ir | Missing result: ir |
+| tests.cpp:347:34:347:40 | // $ ir | Missing result: ir |
+| tests.cpp:351:44:351:50 | // $ ir | Missing result: ir |
+| tests.cpp:352:68:352:74 | // $ ir | Missing result: ir |
 summaryCalls
 | file://:0:0:0:0 | [summary] call to [summary param] 0 in madCallArg0ReturnToReturn in madCallArg0ReturnToReturn |
 | file://:0:0:0:0 | [summary] call to [summary param] 0 in madCallArg0ReturnToReturnFirst in madCallArg0ReturnToReturnFirst |

--- a/cpp/ql/test/library-tests/dataflow/models-as-data/testModels.expected
+++ b/cpp/ql/test/library-tests/dataflow/models-as-data/testModels.expected
@@ -33,34 +33,34 @@ summaryCalls
 | file://:0:0:0:0 | [summary] call to [summary param] 0 in madCallArg0ReturnToReturnFirst in madCallArg0ReturnToReturnFirst |
 | file://:0:0:0:0 | [summary] call to [summary param] 0 in madCallArg0WithValue in madCallArg0WithValue |
 summarizedCallables
-| tests.cpp:144:5:144:19 | madArg0ToReturn |
-| tests.cpp:145:6:145:28 | madArg0ToReturnIndirect |
-| tests.cpp:147:5:147:28 | madArg0ToReturnValueFlow |
-| tests.cpp:148:5:148:27 | madArg0IndirectToReturn |
-| tests.cpp:149:5:149:33 | madArg0DoubleIndirectToReturn |
-| tests.cpp:150:5:150:30 | madArg0NotIndirectToReturn |
-| tests.cpp:151:6:151:26 | madArg0ToArg1Indirect |
-| tests.cpp:152:6:152:34 | madArg0IndirectToArg1Indirect |
-| tests.cpp:153:5:153:18 | madArgsComplex |
-| tests.cpp:154:5:154:14 | madArgsAny |
-| tests.cpp:155:5:155:28 | madAndImplementedComplex |
-| tests.cpp:160:5:160:24 | madArg0FieldToReturn |
-| tests.cpp:161:5:161:32 | madArg0IndirectFieldToReturn |
-| tests.cpp:162:5:162:32 | madArg0FieldIndirectToReturn |
-| tests.cpp:163:13:163:32 | madArg0ToReturnField |
-| tests.cpp:164:14:164:41 | madArg0ToReturnIndirectField |
-| tests.cpp:165:13:165:40 | madArg0ToReturnFieldIndirect |
-| tests.cpp:284:7:284:19 | madArg0ToSelf |
-| tests.cpp:285:6:285:20 | madSelfToReturn |
-| tests.cpp:287:7:287:20 | madArg0ToField |
-| tests.cpp:288:6:288:21 | madFieldToReturn |
-| tests.cpp:313:7:313:30 | namespaceMadSelfToReturn |
-| tests.cpp:434:5:434:29 | madCallArg0ReturnToReturn |
-| tests.cpp:435:9:435:38 | madCallArg0ReturnToReturnFirst |
-| tests.cpp:436:6:436:25 | madCallArg0WithValue |
-| tests.cpp:437:5:437:36 | madCallReturnValueIgnoreFunction |
-| tests.cpp:459:5:459:31 | parameter_ref_to_return_ref |
-| tests.cpp:471:5:471:17 | receive_array |
+| tests.cpp:127:5:127:19 | madArg0ToReturn |
+| tests.cpp:128:6:128:28 | madArg0ToReturnIndirect |
+| tests.cpp:130:5:130:28 | madArg0ToReturnValueFlow |
+| tests.cpp:131:5:131:27 | madArg0IndirectToReturn |
+| tests.cpp:132:5:132:33 | madArg0DoubleIndirectToReturn |
+| tests.cpp:133:5:133:30 | madArg0NotIndirectToReturn |
+| tests.cpp:134:6:134:26 | madArg0ToArg1Indirect |
+| tests.cpp:135:6:135:34 | madArg0IndirectToArg1Indirect |
+| tests.cpp:136:5:136:18 | madArgsComplex |
+| tests.cpp:137:5:137:14 | madArgsAny |
+| tests.cpp:138:5:138:28 | madAndImplementedComplex |
+| tests.cpp:143:5:143:24 | madArg0FieldToReturn |
+| tests.cpp:144:5:144:32 | madArg0IndirectFieldToReturn |
+| tests.cpp:145:5:145:32 | madArg0FieldIndirectToReturn |
+| tests.cpp:146:13:146:32 | madArg0ToReturnField |
+| tests.cpp:147:14:147:41 | madArg0ToReturnIndirectField |
+| tests.cpp:148:13:148:40 | madArg0ToReturnFieldIndirect |
+| tests.cpp:250:7:250:19 | madArg0ToSelf |
+| tests.cpp:251:6:251:20 | madSelfToReturn |
+| tests.cpp:253:7:253:20 | madArg0ToField |
+| tests.cpp:254:6:254:21 | madFieldToReturn |
+| tests.cpp:277:7:277:30 | namespaceMadSelfToReturn |
+| tests.cpp:392:5:392:29 | madCallArg0ReturnToReturn |
+| tests.cpp:393:9:393:38 | madCallArg0ReturnToReturnFirst |
+| tests.cpp:394:6:394:25 | madCallArg0WithValue |
+| tests.cpp:395:5:395:36 | madCallReturnValueIgnoreFunction |
+| tests.cpp:417:5:417:31 | parameter_ref_to_return_ref |
+| tests.cpp:429:5:429:17 | receive_array |
 sourceCallables
 | tests.cpp:3:5:3:10 | source |
 | tests.cpp:4:6:4:14 | sourcePtr |
@@ -82,284 +82,284 @@ sourceCallables
 | tests.cpp:19:6:19:32 | remoteMadSourceIndirectArg1 |
 | tests.cpp:19:39:19:39 | x |
 | tests.cpp:19:47:19:47 | y |
-| tests.cpp:28:7:28:30 | namespace2LocalMadSource |
-| tests.cpp:31:6:31:19 | localMadSource |
-| tests.cpp:33:5:33:27 | namespaceLocalMadSource |
-| tests.cpp:35:6:35:17 | test_sources |
-| tests.cpp:50:6:50:6 | v |
-| tests.cpp:51:7:51:16 | v_indirect |
-| tests.cpp:52:6:52:13 | v_direct |
-| tests.cpp:63:6:63:6 | a |
-| tests.cpp:63:9:63:9 | b |
-| tests.cpp:63:12:63:12 | c |
-| tests.cpp:63:15:63:15 | d |
-| tests.cpp:75:6:75:6 | e |
-| tests.cpp:85:6:85:26 | remoteMadSourceParam0 |
-| tests.cpp:85:32:85:32 | x |
-| tests.cpp:92:6:92:16 | madSinkArg0 |
-| tests.cpp:92:22:92:22 | x |
-| tests.cpp:93:6:93:13 | notASink |
-| tests.cpp:93:19:93:19 | x |
-| tests.cpp:94:6:94:16 | madSinkArg1 |
-| tests.cpp:94:22:94:22 | x |
-| tests.cpp:94:29:94:29 | y |
-| tests.cpp:95:6:95:17 | madSinkArg01 |
-| tests.cpp:95:23:95:23 | x |
-| tests.cpp:95:30:95:30 | y |
-| tests.cpp:95:37:95:37 | z |
-| tests.cpp:96:6:96:17 | madSinkArg02 |
-| tests.cpp:96:23:96:23 | x |
-| tests.cpp:96:30:96:30 | y |
-| tests.cpp:96:37:96:37 | z |
-| tests.cpp:97:6:97:24 | madSinkIndirectArg0 |
-| tests.cpp:97:31:97:31 | x |
-| tests.cpp:98:6:98:30 | madSinkDoubleIndirectArg0 |
-| tests.cpp:98:38:98:38 | x |
-| tests.cpp:102:6:102:15 | test_sinks |
-| tests.cpp:116:6:116:6 | a |
-| tests.cpp:117:7:117:11 | a_ptr |
-| tests.cpp:132:6:132:18 | madSinkParam0 |
-| tests.cpp:132:24:132:24 | x |
-| tests.cpp:138:8:138:8 | operator= |
-| tests.cpp:138:8:138:8 | operator= |
-| tests.cpp:138:8:138:18 | MyContainer |
-| tests.cpp:139:6:139:10 | value |
-| tests.cpp:140:6:140:11 | value2 |
-| tests.cpp:141:7:141:9 | ptr |
-| tests.cpp:144:5:144:19 | madArg0ToReturn |
-| tests.cpp:144:25:144:25 | x |
-| tests.cpp:145:6:145:28 | madArg0ToReturnIndirect |
-| tests.cpp:145:34:145:34 | x |
-| tests.cpp:146:5:146:15 | notASummary |
-| tests.cpp:146:21:146:21 | x |
-| tests.cpp:147:5:147:28 | madArg0ToReturnValueFlow |
-| tests.cpp:147:34:147:34 | x |
-| tests.cpp:148:5:148:27 | madArg0IndirectToReturn |
-| tests.cpp:148:34:148:34 | x |
-| tests.cpp:149:5:149:33 | madArg0DoubleIndirectToReturn |
-| tests.cpp:149:41:149:41 | x |
-| tests.cpp:150:5:150:30 | madArg0NotIndirectToReturn |
-| tests.cpp:150:37:150:37 | x |
-| tests.cpp:151:6:151:26 | madArg0ToArg1Indirect |
-| tests.cpp:151:32:151:32 | x |
-| tests.cpp:151:40:151:40 | y |
-| tests.cpp:152:6:152:34 | madArg0IndirectToArg1Indirect |
-| tests.cpp:152:47:152:47 | x |
-| tests.cpp:152:55:152:55 | y |
-| tests.cpp:153:5:153:18 | madArgsComplex |
-| tests.cpp:153:25:153:25 | a |
-| tests.cpp:153:33:153:33 | b |
-| tests.cpp:153:40:153:40 | c |
-| tests.cpp:153:47:153:47 | d |
-| tests.cpp:154:5:154:14 | madArgsAny |
-| tests.cpp:154:20:154:20 | a |
-| tests.cpp:154:28:154:28 | b |
-| tests.cpp:155:5:155:28 | madAndImplementedComplex |
-| tests.cpp:155:34:155:34 | a |
-| tests.cpp:155:41:155:41 | b |
-| tests.cpp:155:48:155:48 | c |
-| tests.cpp:160:5:160:24 | madArg0FieldToReturn |
-| tests.cpp:160:38:160:39 | mc |
-| tests.cpp:161:5:161:32 | madArg0IndirectFieldToReturn |
-| tests.cpp:161:47:161:48 | mc |
-| tests.cpp:162:5:162:32 | madArg0FieldIndirectToReturn |
-| tests.cpp:162:46:162:47 | mc |
-| tests.cpp:163:13:163:32 | madArg0ToReturnField |
-| tests.cpp:163:38:163:38 | x |
-| tests.cpp:164:14:164:41 | madArg0ToReturnIndirectField |
-| tests.cpp:164:47:164:47 | x |
-| tests.cpp:165:13:165:40 | madArg0ToReturnFieldIndirect |
-| tests.cpp:165:46:165:46 | x |
-| tests.cpp:171:6:171:19 | test_summaries |
-| tests.cpp:174:6:174:6 | a |
-| tests.cpp:174:9:174:9 | b |
-| tests.cpp:174:12:174:12 | c |
-| tests.cpp:174:15:174:15 | d |
-| tests.cpp:174:18:174:18 | e |
-| tests.cpp:175:7:175:11 | a_ptr |
-| tests.cpp:218:14:218:16 | mc1 |
-| tests.cpp:218:19:218:21 | mc2 |
-| tests.cpp:237:15:237:18 | rtn1 |
-| tests.cpp:240:14:240:17 | rtn2 |
-| tests.cpp:241:7:241:14 | rtn2_ptr |
-| tests.cpp:267:7:267:7 | operator= |
-| tests.cpp:267:7:267:7 | operator= |
-| tests.cpp:267:7:267:13 | MyClass |
-| tests.cpp:270:6:270:26 | memberRemoteMadSource |
-| tests.cpp:271:7:271:39 | memberRemoteMadSourceIndirectArg0 |
-| tests.cpp:271:46:271:46 | x |
-| tests.cpp:273:7:273:21 | qualifierSource |
-| tests.cpp:274:7:274:26 | qualifierFieldSource |
-| tests.cpp:277:7:277:23 | memberMadSinkArg0 |
-| tests.cpp:277:29:277:29 | x |
-| tests.cpp:279:7:279:19 | qualifierSink |
-| tests.cpp:280:7:280:23 | qualifierArg0Sink |
-| tests.cpp:280:29:280:29 | x |
-| tests.cpp:281:7:281:24 | qualifierFieldSink |
-| tests.cpp:284:7:284:19 | madArg0ToSelf |
-| tests.cpp:284:25:284:25 | x |
-| tests.cpp:285:6:285:20 | madSelfToReturn |
-| tests.cpp:286:6:286:16 | notASummary |
-| tests.cpp:287:7:287:20 | madArg0ToField |
-| tests.cpp:287:26:287:26 | x |
-| tests.cpp:288:6:288:21 | madFieldToReturn |
-| tests.cpp:290:6:290:8 | val |
-| tests.cpp:293:7:293:7 | MyDerivedClass |
-| tests.cpp:293:7:293:7 | operator= |
-| tests.cpp:293:7:293:7 | operator= |
-| tests.cpp:293:7:293:20 | MyDerivedClass |
-| tests.cpp:295:6:295:28 | subtypeRemoteMadSource1 |
-| tests.cpp:296:6:296:21 | subtypeNonSource |
-| tests.cpp:297:6:297:28 | subtypeRemoteMadSource2 |
-| tests.cpp:300:9:300:15 | source2 |
-| tests.cpp:301:6:301:9 | sink |
-| tests.cpp:301:19:301:20 | mc |
-| tests.cpp:304:8:304:8 | operator= |
-| tests.cpp:304:8:304:8 | operator= |
-| tests.cpp:304:8:304:14 | MyClass |
-| tests.cpp:307:8:307:33 | namespaceMemberMadSinkArg0 |
-| tests.cpp:307:39:307:39 | x |
-| tests.cpp:308:15:308:46 | namespaceStaticMemberMadSinkArg0 |
-| tests.cpp:308:52:308:52 | x |
-| tests.cpp:313:7:313:30 | namespaceMadSelfToReturn |
-| tests.cpp:317:22:317:28 | source3 |
-| tests.cpp:319:6:319:23 | test_class_members |
-| tests.cpp:320:10:320:11 | mc |
-| tests.cpp:320:14:320:16 | mc2 |
-| tests.cpp:320:19:320:21 | mc3 |
-| tests.cpp:320:24:320:26 | mc4 |
-| tests.cpp:320:29:320:31 | mc5 |
-| tests.cpp:320:34:320:36 | mc6 |
-| tests.cpp:320:39:320:41 | mc7 |
-| tests.cpp:320:44:320:46 | mc8 |
-| tests.cpp:320:49:320:51 | mc9 |
-| tests.cpp:320:54:320:57 | mc10 |
-| tests.cpp:320:60:320:63 | mc11 |
-| tests.cpp:321:11:321:13 | ptr |
-| tests.cpp:321:17:321:23 | mc4_ptr |
-| tests.cpp:322:17:322:19 | mdc |
-| tests.cpp:323:23:323:25 | mnc |
-| tests.cpp:323:28:323:31 | mnc2 |
-| tests.cpp:324:24:324:31 | mnc2_ptr |
-| tests.cpp:330:6:330:6 | a |
-| tests.cpp:429:8:429:8 | operator= |
-| tests.cpp:429:8:429:8 | operator= |
-| tests.cpp:429:8:429:14 | intPair |
-| tests.cpp:430:6:430:10 | first |
-| tests.cpp:431:6:431:11 | second |
-| tests.cpp:434:5:434:29 | madCallArg0ReturnToReturn |
-| tests.cpp:434:37:434:43 | fun_ptr |
-| tests.cpp:435:9:435:38 | madCallArg0ReturnToReturnFirst |
-| tests.cpp:435:46:435:52 | fun_ptr |
-| tests.cpp:436:6:436:25 | madCallArg0WithValue |
-| tests.cpp:436:34:436:40 | fun_ptr |
-| tests.cpp:436:53:436:57 | value |
-| tests.cpp:437:5:437:36 | madCallReturnValueIgnoreFunction |
-| tests.cpp:437:45:437:51 | fun_ptr |
-| tests.cpp:437:64:437:68 | value |
-| tests.cpp:439:5:439:14 | getTainted |
-| tests.cpp:440:6:440:13 | useValue |
-| tests.cpp:440:19:440:19 | x |
-| tests.cpp:441:6:441:17 | dontUseValue |
-| tests.cpp:441:23:441:23 | x |
-| tests.cpp:443:6:443:27 | test_function_pointers |
-| tests.cpp:456:19:456:19 | X |
-| tests.cpp:457:8:457:35 | StructWithTypedefInParameter<X> |
-| tests.cpp:457:8:457:35 | StructWithTypedefInParameter<int> |
-| tests.cpp:458:12:458:15 | Type |
-| tests.cpp:459:5:459:31 | parameter_ref_to_return_ref |
-| tests.cpp:459:5:459:31 | parameter_ref_to_return_ref |
-| tests.cpp:459:45:459:45 | x |
-| tests.cpp:459:45:459:45 | x |
-| tests.cpp:462:6:462:37 | test_parameter_ref_to_return_ref |
-| tests.cpp:463:6:463:6 | x |
-| tests.cpp:464:36:464:36 | s |
-| tests.cpp:465:6:465:6 | y |
-| tests.cpp:469:7:469:9 | INT |
-| tests.cpp:471:5:471:17 | receive_array |
-| tests.cpp:471:23:471:23 | a |
-| tests.cpp:473:6:473:23 | test_receive_array |
-| tests.cpp:474:6:474:6 | x |
-| tests.cpp:475:6:475:10 | array |
-| tests.cpp:476:6:476:6 | y |
+| tests.cpp:23:7:23:30 | namespace2LocalMadSource |
+| tests.cpp:26:6:26:19 | localMadSource |
+| tests.cpp:28:5:28:27 | namespaceLocalMadSource |
+| tests.cpp:30:6:30:17 | test_sources |
+| tests.cpp:45:6:45:6 | v |
+| tests.cpp:46:7:46:16 | v_indirect |
+| tests.cpp:47:6:47:13 | v_direct |
+| tests.cpp:58:6:58:6 | a |
+| tests.cpp:58:9:58:9 | b |
+| tests.cpp:58:12:58:12 | c |
+| tests.cpp:58:15:58:15 | d |
+| tests.cpp:67:6:67:6 | e |
+| tests.cpp:75:6:75:26 | remoteMadSourceParam0 |
+| tests.cpp:75:32:75:32 | x |
+| tests.cpp:82:6:82:16 | madSinkArg0 |
+| tests.cpp:82:22:82:22 | x |
+| tests.cpp:83:6:83:13 | notASink |
+| tests.cpp:83:19:83:19 | x |
+| tests.cpp:84:6:84:16 | madSinkArg1 |
+| tests.cpp:84:22:84:22 | x |
+| tests.cpp:84:29:84:29 | y |
+| tests.cpp:85:6:85:17 | madSinkArg01 |
+| tests.cpp:85:23:85:23 | x |
+| tests.cpp:85:30:85:30 | y |
+| tests.cpp:85:37:85:37 | z |
+| tests.cpp:86:6:86:17 | madSinkArg02 |
+| tests.cpp:86:23:86:23 | x |
+| tests.cpp:86:30:86:30 | y |
+| tests.cpp:86:37:86:37 | z |
+| tests.cpp:87:6:87:24 | madSinkIndirectArg0 |
+| tests.cpp:87:31:87:31 | x |
+| tests.cpp:88:6:88:30 | madSinkDoubleIndirectArg0 |
+| tests.cpp:88:38:88:38 | x |
+| tests.cpp:92:6:92:15 | test_sinks |
+| tests.cpp:106:6:106:6 | a |
+| tests.cpp:107:7:107:11 | a_ptr |
+| tests.cpp:115:6:115:18 | madSinkParam0 |
+| tests.cpp:115:24:115:24 | x |
+| tests.cpp:121:8:121:8 | operator= |
+| tests.cpp:121:8:121:8 | operator= |
+| tests.cpp:121:8:121:18 | MyContainer |
+| tests.cpp:122:6:122:10 | value |
+| tests.cpp:123:6:123:11 | value2 |
+| tests.cpp:124:7:124:9 | ptr |
+| tests.cpp:127:5:127:19 | madArg0ToReturn |
+| tests.cpp:127:25:127:25 | x |
+| tests.cpp:128:6:128:28 | madArg0ToReturnIndirect |
+| tests.cpp:128:34:128:34 | x |
+| tests.cpp:129:5:129:15 | notASummary |
+| tests.cpp:129:21:129:21 | x |
+| tests.cpp:130:5:130:28 | madArg0ToReturnValueFlow |
+| tests.cpp:130:34:130:34 | x |
+| tests.cpp:131:5:131:27 | madArg0IndirectToReturn |
+| tests.cpp:131:34:131:34 | x |
+| tests.cpp:132:5:132:33 | madArg0DoubleIndirectToReturn |
+| tests.cpp:132:41:132:41 | x |
+| tests.cpp:133:5:133:30 | madArg0NotIndirectToReturn |
+| tests.cpp:133:37:133:37 | x |
+| tests.cpp:134:6:134:26 | madArg0ToArg1Indirect |
+| tests.cpp:134:32:134:32 | x |
+| tests.cpp:134:40:134:40 | y |
+| tests.cpp:135:6:135:34 | madArg0IndirectToArg1Indirect |
+| tests.cpp:135:47:135:47 | x |
+| tests.cpp:135:55:135:55 | y |
+| tests.cpp:136:5:136:18 | madArgsComplex |
+| tests.cpp:136:25:136:25 | a |
+| tests.cpp:136:33:136:33 | b |
+| tests.cpp:136:40:136:40 | c |
+| tests.cpp:136:47:136:47 | d |
+| tests.cpp:137:5:137:14 | madArgsAny |
+| tests.cpp:137:20:137:20 | a |
+| tests.cpp:137:28:137:28 | b |
+| tests.cpp:138:5:138:28 | madAndImplementedComplex |
+| tests.cpp:138:34:138:34 | a |
+| tests.cpp:138:41:138:41 | b |
+| tests.cpp:138:48:138:48 | c |
+| tests.cpp:143:5:143:24 | madArg0FieldToReturn |
+| tests.cpp:143:38:143:39 | mc |
+| tests.cpp:144:5:144:32 | madArg0IndirectFieldToReturn |
+| tests.cpp:144:47:144:48 | mc |
+| tests.cpp:145:5:145:32 | madArg0FieldIndirectToReturn |
+| tests.cpp:145:46:145:47 | mc |
+| tests.cpp:146:13:146:32 | madArg0ToReturnField |
+| tests.cpp:146:38:146:38 | x |
+| tests.cpp:147:14:147:41 | madArg0ToReturnIndirectField |
+| tests.cpp:147:47:147:47 | x |
+| tests.cpp:148:13:148:40 | madArg0ToReturnFieldIndirect |
+| tests.cpp:148:46:148:46 | x |
+| tests.cpp:150:6:150:19 | test_summaries |
+| tests.cpp:153:6:153:6 | a |
+| tests.cpp:153:9:153:9 | b |
+| tests.cpp:153:12:153:12 | c |
+| tests.cpp:153:15:153:15 | d |
+| tests.cpp:153:18:153:18 | e |
+| tests.cpp:154:7:154:11 | a_ptr |
+| tests.cpp:197:14:197:16 | mc1 |
+| tests.cpp:197:19:197:21 | mc2 |
+| tests.cpp:216:15:216:18 | rtn1 |
+| tests.cpp:219:14:219:17 | rtn2 |
+| tests.cpp:220:7:220:14 | rtn2_ptr |
+| tests.cpp:233:7:233:7 | operator= |
+| tests.cpp:233:7:233:7 | operator= |
+| tests.cpp:233:7:233:13 | MyClass |
+| tests.cpp:236:6:236:26 | memberRemoteMadSource |
+| tests.cpp:237:7:237:39 | memberRemoteMadSourceIndirectArg0 |
+| tests.cpp:237:46:237:46 | x |
+| tests.cpp:239:7:239:21 | qualifierSource |
+| tests.cpp:240:7:240:26 | qualifierFieldSource |
+| tests.cpp:243:7:243:23 | memberMadSinkArg0 |
+| tests.cpp:243:29:243:29 | x |
+| tests.cpp:245:7:245:19 | qualifierSink |
+| tests.cpp:246:7:246:23 | qualifierArg0Sink |
+| tests.cpp:246:29:246:29 | x |
+| tests.cpp:247:7:247:24 | qualifierFieldSink |
+| tests.cpp:250:7:250:19 | madArg0ToSelf |
+| tests.cpp:250:25:250:25 | x |
+| tests.cpp:251:6:251:20 | madSelfToReturn |
+| tests.cpp:252:6:252:16 | notASummary |
+| tests.cpp:253:7:253:20 | madArg0ToField |
+| tests.cpp:253:26:253:26 | x |
+| tests.cpp:254:6:254:21 | madFieldToReturn |
+| tests.cpp:256:6:256:8 | val |
+| tests.cpp:259:7:259:7 | MyDerivedClass |
+| tests.cpp:259:7:259:7 | operator= |
+| tests.cpp:259:7:259:7 | operator= |
+| tests.cpp:259:7:259:20 | MyDerivedClass |
+| tests.cpp:261:6:261:28 | subtypeRemoteMadSource1 |
+| tests.cpp:262:6:262:21 | subtypeNonSource |
+| tests.cpp:263:6:263:28 | subtypeRemoteMadSource2 |
+| tests.cpp:266:9:266:15 | source2 |
+| tests.cpp:267:6:267:9 | sink |
+| tests.cpp:267:19:267:20 | mc |
+| tests.cpp:270:8:270:8 | operator= |
+| tests.cpp:270:8:270:8 | operator= |
+| tests.cpp:270:8:270:14 | MyClass |
+| tests.cpp:273:8:273:33 | namespaceMemberMadSinkArg0 |
+| tests.cpp:273:39:273:39 | x |
+| tests.cpp:274:15:274:46 | namespaceStaticMemberMadSinkArg0 |
+| tests.cpp:274:52:274:52 | x |
+| tests.cpp:277:7:277:30 | namespaceMadSelfToReturn |
+| tests.cpp:281:22:281:28 | source3 |
+| tests.cpp:283:6:283:23 | test_class_members |
+| tests.cpp:284:10:284:11 | mc |
+| tests.cpp:284:14:284:16 | mc2 |
+| tests.cpp:284:19:284:21 | mc3 |
+| tests.cpp:284:24:284:26 | mc4 |
+| tests.cpp:284:29:284:31 | mc5 |
+| tests.cpp:284:34:284:36 | mc6 |
+| tests.cpp:284:39:284:41 | mc7 |
+| tests.cpp:284:44:284:46 | mc8 |
+| tests.cpp:284:49:284:51 | mc9 |
+| tests.cpp:284:54:284:57 | mc10 |
+| tests.cpp:284:60:284:63 | mc11 |
+| tests.cpp:285:11:285:13 | ptr |
+| tests.cpp:285:17:285:23 | mc4_ptr |
+| tests.cpp:286:17:286:19 | mdc |
+| tests.cpp:287:23:287:25 | mnc |
+| tests.cpp:287:28:287:31 | mnc2 |
+| tests.cpp:288:24:288:31 | mnc2_ptr |
+| tests.cpp:294:6:294:6 | a |
+| tests.cpp:387:8:387:8 | operator= |
+| tests.cpp:387:8:387:8 | operator= |
+| tests.cpp:387:8:387:14 | intPair |
+| tests.cpp:388:6:388:10 | first |
+| tests.cpp:389:6:389:11 | second |
+| tests.cpp:392:5:392:29 | madCallArg0ReturnToReturn |
+| tests.cpp:392:37:392:43 | fun_ptr |
+| tests.cpp:393:9:393:38 | madCallArg0ReturnToReturnFirst |
+| tests.cpp:393:46:393:52 | fun_ptr |
+| tests.cpp:394:6:394:25 | madCallArg0WithValue |
+| tests.cpp:394:34:394:40 | fun_ptr |
+| tests.cpp:394:53:394:57 | value |
+| tests.cpp:395:5:395:36 | madCallReturnValueIgnoreFunction |
+| tests.cpp:395:45:395:51 | fun_ptr |
+| tests.cpp:395:64:395:68 | value |
+| tests.cpp:397:5:397:14 | getTainted |
+| tests.cpp:398:6:398:13 | useValue |
+| tests.cpp:398:19:398:19 | x |
+| tests.cpp:399:6:399:17 | dontUseValue |
+| tests.cpp:399:23:399:23 | x |
+| tests.cpp:401:6:401:27 | test_function_pointers |
+| tests.cpp:414:19:414:19 | X |
+| tests.cpp:415:8:415:35 | StructWithTypedefInParameter<X> |
+| tests.cpp:415:8:415:35 | StructWithTypedefInParameter<int> |
+| tests.cpp:416:12:416:15 | Type |
+| tests.cpp:417:5:417:31 | parameter_ref_to_return_ref |
+| tests.cpp:417:5:417:31 | parameter_ref_to_return_ref |
+| tests.cpp:417:45:417:45 | x |
+| tests.cpp:417:45:417:45 | x |
+| tests.cpp:420:6:420:37 | test_parameter_ref_to_return_ref |
+| tests.cpp:421:6:421:6 | x |
+| tests.cpp:422:36:422:36 | s |
+| tests.cpp:423:6:423:6 | y |
+| tests.cpp:427:7:427:9 | INT |
+| tests.cpp:429:5:429:17 | receive_array |
+| tests.cpp:429:23:429:23 | a |
+| tests.cpp:431:6:431:23 | test_receive_array |
+| tests.cpp:432:6:432:6 | x |
+| tests.cpp:433:6:433:10 | array |
+| tests.cpp:434:6:434:6 | y |
 flowSummaryNode
-| tests.cpp:144:5:144:19 | [summary param] 0 in madArg0ToReturn | ParameterNode | madArg0ToReturn | madArg0ToReturn |
-| tests.cpp:144:5:144:19 | [summary] to write: ReturnValue in madArg0ToReturn | ReturnNode | madArg0ToReturn | madArg0ToReturn |
-| tests.cpp:145:6:145:28 | [summary param] 0 in madArg0ToReturnIndirect | ParameterNode | madArg0ToReturnIndirect | madArg0ToReturnIndirect |
-| tests.cpp:145:6:145:28 | [summary] to write: ReturnValue[*] in madArg0ToReturnIndirect | ReturnNode | madArg0ToReturnIndirect | madArg0ToReturnIndirect |
-| tests.cpp:147:5:147:28 | [summary param] 0 in madArg0ToReturnValueFlow | ParameterNode | madArg0ToReturnValueFlow | madArg0ToReturnValueFlow |
-| tests.cpp:147:5:147:28 | [summary] to write: ReturnValue in madArg0ToReturnValueFlow | ReturnNode | madArg0ToReturnValueFlow | madArg0ToReturnValueFlow |
-| tests.cpp:148:5:148:27 | [summary param] *0 in madArg0IndirectToReturn | ParameterNode | madArg0IndirectToReturn | madArg0IndirectToReturn |
-| tests.cpp:148:5:148:27 | [summary] to write: ReturnValue in madArg0IndirectToReturn | ReturnNode | madArg0IndirectToReturn | madArg0IndirectToReturn |
-| tests.cpp:149:5:149:33 | [summary param] **0 in madArg0DoubleIndirectToReturn | ParameterNode | madArg0DoubleIndirectToReturn | madArg0DoubleIndirectToReturn |
-| tests.cpp:149:5:149:33 | [summary] to write: ReturnValue in madArg0DoubleIndirectToReturn | ReturnNode | madArg0DoubleIndirectToReturn | madArg0DoubleIndirectToReturn |
-| tests.cpp:150:5:150:30 | [summary param] 0 in madArg0NotIndirectToReturn | ParameterNode | madArg0NotIndirectToReturn | madArg0NotIndirectToReturn |
-| tests.cpp:150:5:150:30 | [summary] to write: ReturnValue in madArg0NotIndirectToReturn | ReturnNode | madArg0NotIndirectToReturn | madArg0NotIndirectToReturn |
-| tests.cpp:151:6:151:26 | [summary param] 0 in madArg0ToArg1Indirect | ParameterNode | madArg0ToArg1Indirect | madArg0ToArg1Indirect |
-| tests.cpp:151:6:151:26 | [summary param] *1 in madArg0ToArg1Indirect | ParameterNode | madArg0ToArg1Indirect | madArg0ToArg1Indirect |
-| tests.cpp:151:6:151:26 | [summary] to write: Argument[*1] in madArg0ToArg1Indirect | PostUpdateNode | madArg0ToArg1Indirect | madArg0ToArg1Indirect |
-| tests.cpp:152:6:152:34 | [summary param] *0 in madArg0IndirectToArg1Indirect | ParameterNode | madArg0IndirectToArg1Indirect | madArg0IndirectToArg1Indirect |
-| tests.cpp:152:6:152:34 | [summary param] *1 in madArg0IndirectToArg1Indirect | ParameterNode | madArg0IndirectToArg1Indirect | madArg0IndirectToArg1Indirect |
-| tests.cpp:152:6:152:34 | [summary] to write: Argument[*1] in madArg0IndirectToArg1Indirect | PostUpdateNode | madArg0IndirectToArg1Indirect | madArg0IndirectToArg1Indirect |
-| tests.cpp:153:5:153:18 | [summary param] 2 in madArgsComplex | ParameterNode | madArgsComplex | madArgsComplex |
-| tests.cpp:153:5:153:18 | [summary param] *0 in madArgsComplex | ParameterNode | madArgsComplex | madArgsComplex |
-| tests.cpp:153:5:153:18 | [summary param] *1 in madArgsComplex | ParameterNode | madArgsComplex | madArgsComplex |
-| tests.cpp:153:5:153:18 | [summary] to write: ReturnValue in madArgsComplex | ReturnNode | madArgsComplex | madArgsComplex |
-| tests.cpp:155:5:155:28 | [summary param] 2 in madAndImplementedComplex | ParameterNode | madAndImplementedComplex | madAndImplementedComplex |
-| tests.cpp:155:5:155:28 | [summary] to write: ReturnValue in madAndImplementedComplex | ReturnNode | madAndImplementedComplex | madAndImplementedComplex |
-| tests.cpp:160:5:160:24 | [summary param] 0 in madArg0FieldToReturn | ParameterNode | madArg0FieldToReturn | madArg0FieldToReturn |
-| tests.cpp:160:5:160:24 | [summary] read: Argument[0].Field[value] in madArg0FieldToReturn |  | madArg0FieldToReturn | madArg0FieldToReturn |
-| tests.cpp:160:5:160:24 | [summary] to write: ReturnValue in madArg0FieldToReturn | ReturnNode | madArg0FieldToReturn | madArg0FieldToReturn |
-| tests.cpp:161:5:161:32 | [summary param] *0 in madArg0IndirectFieldToReturn | ParameterNode | madArg0IndirectFieldToReturn | madArg0IndirectFieldToReturn |
-| tests.cpp:161:5:161:32 | [summary] read: Argument[*0].Field[value] in madArg0IndirectFieldToReturn |  | madArg0IndirectFieldToReturn | madArg0IndirectFieldToReturn |
-| tests.cpp:161:5:161:32 | [summary] to write: ReturnValue in madArg0IndirectFieldToReturn | ReturnNode | madArg0IndirectFieldToReturn | madArg0IndirectFieldToReturn |
-| tests.cpp:162:5:162:32 | [summary param] 0 in madArg0FieldIndirectToReturn | ParameterNode | madArg0FieldIndirectToReturn | madArg0FieldIndirectToReturn |
-| tests.cpp:162:5:162:32 | [summary] read: Argument[0].Field[*ptr] in madArg0FieldIndirectToReturn |  | madArg0FieldIndirectToReturn | madArg0FieldIndirectToReturn |
-| tests.cpp:162:5:162:32 | [summary] to write: ReturnValue in madArg0FieldIndirectToReturn | ReturnNode | madArg0FieldIndirectToReturn | madArg0FieldIndirectToReturn |
-| tests.cpp:163:13:163:32 | [summary param] 0 in madArg0ToReturnField | ParameterNode | madArg0ToReturnField | madArg0ToReturnField |
-| tests.cpp:163:13:163:32 | [summary] to write: ReturnValue in madArg0ToReturnField | ReturnNode | madArg0ToReturnField | madArg0ToReturnField |
-| tests.cpp:163:13:163:32 | [summary] to write: ReturnValue.Field[value] in madArg0ToReturnField |  | madArg0ToReturnField | madArg0ToReturnField |
-| tests.cpp:164:14:164:41 | [summary param] 0 in madArg0ToReturnIndirectField | ParameterNode | madArg0ToReturnIndirectField | madArg0ToReturnIndirectField |
-| tests.cpp:164:14:164:41 | [summary] to write: ReturnValue[*] in madArg0ToReturnIndirectField | ReturnNode | madArg0ToReturnIndirectField | madArg0ToReturnIndirectField |
-| tests.cpp:164:14:164:41 | [summary] to write: ReturnValue[*].Field[value] in madArg0ToReturnIndirectField |  | madArg0ToReturnIndirectField | madArg0ToReturnIndirectField |
-| tests.cpp:165:13:165:40 | [summary param] 0 in madArg0ToReturnFieldIndirect | ParameterNode | madArg0ToReturnFieldIndirect | madArg0ToReturnFieldIndirect |
-| tests.cpp:165:13:165:40 | [summary] to write: ReturnValue in madArg0ToReturnFieldIndirect | ReturnNode | madArg0ToReturnFieldIndirect | madArg0ToReturnFieldIndirect |
-| tests.cpp:165:13:165:40 | [summary] to write: ReturnValue.Field[*ptr] in madArg0ToReturnFieldIndirect |  | madArg0ToReturnFieldIndirect | madArg0ToReturnFieldIndirect |
-| tests.cpp:284:7:284:19 | [summary param] 0 in madArg0ToSelf | ParameterNode | madArg0ToSelf | madArg0ToSelf |
-| tests.cpp:284:7:284:19 | [summary param] this in madArg0ToSelf | ParameterNode | madArg0ToSelf | madArg0ToSelf |
-| tests.cpp:284:7:284:19 | [summary] to write: Argument[this] in madArg0ToSelf | PostUpdateNode | madArg0ToSelf | madArg0ToSelf |
-| tests.cpp:285:6:285:20 | [summary param] this in madSelfToReturn | ParameterNode | madSelfToReturn | madSelfToReturn |
-| tests.cpp:285:6:285:20 | [summary] to write: ReturnValue in madSelfToReturn | ReturnNode | madSelfToReturn | madSelfToReturn |
-| tests.cpp:287:7:287:20 | [summary param] 0 in madArg0ToField | ParameterNode | madArg0ToField | madArg0ToField |
-| tests.cpp:287:7:287:20 | [summary param] this in madArg0ToField | ParameterNode | madArg0ToField | madArg0ToField |
-| tests.cpp:287:7:287:20 | [summary] to write: Argument[this] in madArg0ToField | PostUpdateNode | madArg0ToField | madArg0ToField |
-| tests.cpp:287:7:287:20 | [summary] to write: Argument[this].Field[val] in madArg0ToField |  | madArg0ToField | madArg0ToField |
-| tests.cpp:288:6:288:21 | [summary param] this in madFieldToReturn | ParameterNode | madFieldToReturn | madFieldToReturn |
-| tests.cpp:288:6:288:21 | [summary] read: Argument[this].Field[val] in madFieldToReturn |  | madFieldToReturn | madFieldToReturn |
-| tests.cpp:288:6:288:21 | [summary] to write: ReturnValue in madFieldToReturn | ReturnNode | madFieldToReturn | madFieldToReturn |
-| tests.cpp:313:7:313:30 | [summary param] this in namespaceMadSelfToReturn | ParameterNode | namespaceMadSelfToReturn | namespaceMadSelfToReturn |
-| tests.cpp:313:7:313:30 | [summary] to write: ReturnValue in namespaceMadSelfToReturn | ReturnNode | namespaceMadSelfToReturn | namespaceMadSelfToReturn |
-| tests.cpp:434:5:434:29 | [summary param] 0 in madCallArg0ReturnToReturn | ParameterNode | madCallArg0ReturnToReturn | madCallArg0ReturnToReturn |
-| tests.cpp:434:5:434:29 | [summary] read: Argument[0].Parameter[this pointer] in madCallArg0ReturnToReturn | PostUpdateNode | madCallArg0ReturnToReturn | madCallArg0ReturnToReturn |
-| tests.cpp:434:5:434:29 | [summary] read: Argument[0].ReturnValue in madCallArg0ReturnToReturn | OutNode | madCallArg0ReturnToReturn | madCallArg0ReturnToReturn |
-| tests.cpp:434:5:434:29 | [summary] to write: Argument[0].Parameter[this pointer] in madCallArg0ReturnToReturn | ArgumentNode | madCallArg0ReturnToReturn | madCallArg0ReturnToReturn |
-| tests.cpp:434:5:434:29 | [summary] to write: ReturnValue in madCallArg0ReturnToReturn | ReturnNode | madCallArg0ReturnToReturn | madCallArg0ReturnToReturn |
-| tests.cpp:435:9:435:38 | [summary param] 0 in madCallArg0ReturnToReturnFirst | ParameterNode | madCallArg0ReturnToReturnFirst | madCallArg0ReturnToReturnFirst |
-| tests.cpp:435:9:435:38 | [summary] read: Argument[0].Parameter[this pointer] in madCallArg0ReturnToReturnFirst | PostUpdateNode | madCallArg0ReturnToReturnFirst | madCallArg0ReturnToReturnFirst |
-| tests.cpp:435:9:435:38 | [summary] read: Argument[0].ReturnValue in madCallArg0ReturnToReturnFirst | OutNode | madCallArg0ReturnToReturnFirst | madCallArg0ReturnToReturnFirst |
-| tests.cpp:435:9:435:38 | [summary] to write: Argument[0].Parameter[this pointer] in madCallArg0ReturnToReturnFirst | ArgumentNode | madCallArg0ReturnToReturnFirst | madCallArg0ReturnToReturnFirst |
-| tests.cpp:435:9:435:38 | [summary] to write: ReturnValue in madCallArg0ReturnToReturnFirst | ReturnNode | madCallArg0ReturnToReturnFirst | madCallArg0ReturnToReturnFirst |
-| tests.cpp:435:9:435:38 | [summary] to write: ReturnValue.Field[first] in madCallArg0ReturnToReturnFirst |  | madCallArg0ReturnToReturnFirst | madCallArg0ReturnToReturnFirst |
-| tests.cpp:436:6:436:25 | [summary param] 0 in madCallArg0WithValue | ParameterNode | madCallArg0WithValue | madCallArg0WithValue |
-| tests.cpp:436:6:436:25 | [summary param] 1 in madCallArg0WithValue | ParameterNode | madCallArg0WithValue | madCallArg0WithValue |
-| tests.cpp:436:6:436:25 | [summary] read: Argument[0].Parameter[0] in madCallArg0WithValue | PostUpdateNode | madCallArg0WithValue | madCallArg0WithValue |
-| tests.cpp:436:6:436:25 | [summary] read: Argument[0].Parameter[this pointer] in madCallArg0WithValue | PostUpdateNode | madCallArg0WithValue | madCallArg0WithValue |
-| tests.cpp:436:6:436:25 | [summary] to write: Argument[0].Parameter[0] in madCallArg0WithValue | ArgumentNode | madCallArg0WithValue | madCallArg0WithValue |
-| tests.cpp:436:6:436:25 | [summary] to write: Argument[0].Parameter[this pointer] in madCallArg0WithValue | ArgumentNode | madCallArg0WithValue | madCallArg0WithValue |
-| tests.cpp:436:6:436:25 | [summary] to write: Argument[1] in madCallArg0WithValue | PostUpdateNode | madCallArg0WithValue | madCallArg0WithValue |
-| tests.cpp:437:5:437:36 | [summary param] 1 in madCallReturnValueIgnoreFunction | ParameterNode | madCallReturnValueIgnoreFunction | madCallReturnValueIgnoreFunction |
-| tests.cpp:437:5:437:36 | [summary] to write: ReturnValue in madCallReturnValueIgnoreFunction | ReturnNode | madCallReturnValueIgnoreFunction | madCallReturnValueIgnoreFunction |
-| tests.cpp:459:5:459:31 | [summary param] *0 in parameter_ref_to_return_ref | ParameterNode | parameter_ref_to_return_ref | parameter_ref_to_return_ref |
-| tests.cpp:459:5:459:31 | [summary] to write: ReturnValue[*] in parameter_ref_to_return_ref | ReturnNode | parameter_ref_to_return_ref | parameter_ref_to_return_ref |
-| tests.cpp:471:5:471:17 | [summary param] *0 in receive_array | ParameterNode | receive_array | receive_array |
-| tests.cpp:471:5:471:17 | [summary] to write: ReturnValue in receive_array | ReturnNode | receive_array | receive_array |
+| tests.cpp:127:5:127:19 | [summary param] 0 in madArg0ToReturn | ParameterNode | madArg0ToReturn | madArg0ToReturn |
+| tests.cpp:127:5:127:19 | [summary] to write: ReturnValue in madArg0ToReturn | ReturnNode | madArg0ToReturn | madArg0ToReturn |
+| tests.cpp:128:6:128:28 | [summary param] 0 in madArg0ToReturnIndirect | ParameterNode | madArg0ToReturnIndirect | madArg0ToReturnIndirect |
+| tests.cpp:128:6:128:28 | [summary] to write: ReturnValue[*] in madArg0ToReturnIndirect | ReturnNode | madArg0ToReturnIndirect | madArg0ToReturnIndirect |
+| tests.cpp:130:5:130:28 | [summary param] 0 in madArg0ToReturnValueFlow | ParameterNode | madArg0ToReturnValueFlow | madArg0ToReturnValueFlow |
+| tests.cpp:130:5:130:28 | [summary] to write: ReturnValue in madArg0ToReturnValueFlow | ReturnNode | madArg0ToReturnValueFlow | madArg0ToReturnValueFlow |
+| tests.cpp:131:5:131:27 | [summary param] *0 in madArg0IndirectToReturn | ParameterNode | madArg0IndirectToReturn | madArg0IndirectToReturn |
+| tests.cpp:131:5:131:27 | [summary] to write: ReturnValue in madArg0IndirectToReturn | ReturnNode | madArg0IndirectToReturn | madArg0IndirectToReturn |
+| tests.cpp:132:5:132:33 | [summary param] **0 in madArg0DoubleIndirectToReturn | ParameterNode | madArg0DoubleIndirectToReturn | madArg0DoubleIndirectToReturn |
+| tests.cpp:132:5:132:33 | [summary] to write: ReturnValue in madArg0DoubleIndirectToReturn | ReturnNode | madArg0DoubleIndirectToReturn | madArg0DoubleIndirectToReturn |
+| tests.cpp:133:5:133:30 | [summary param] 0 in madArg0NotIndirectToReturn | ParameterNode | madArg0NotIndirectToReturn | madArg0NotIndirectToReturn |
+| tests.cpp:133:5:133:30 | [summary] to write: ReturnValue in madArg0NotIndirectToReturn | ReturnNode | madArg0NotIndirectToReturn | madArg0NotIndirectToReturn |
+| tests.cpp:134:6:134:26 | [summary param] 0 in madArg0ToArg1Indirect | ParameterNode | madArg0ToArg1Indirect | madArg0ToArg1Indirect |
+| tests.cpp:134:6:134:26 | [summary param] *1 in madArg0ToArg1Indirect | ParameterNode | madArg0ToArg1Indirect | madArg0ToArg1Indirect |
+| tests.cpp:134:6:134:26 | [summary] to write: Argument[*1] in madArg0ToArg1Indirect | PostUpdateNode | madArg0ToArg1Indirect | madArg0ToArg1Indirect |
+| tests.cpp:135:6:135:34 | [summary param] *0 in madArg0IndirectToArg1Indirect | ParameterNode | madArg0IndirectToArg1Indirect | madArg0IndirectToArg1Indirect |
+| tests.cpp:135:6:135:34 | [summary param] *1 in madArg0IndirectToArg1Indirect | ParameterNode | madArg0IndirectToArg1Indirect | madArg0IndirectToArg1Indirect |
+| tests.cpp:135:6:135:34 | [summary] to write: Argument[*1] in madArg0IndirectToArg1Indirect | PostUpdateNode | madArg0IndirectToArg1Indirect | madArg0IndirectToArg1Indirect |
+| tests.cpp:136:5:136:18 | [summary param] 2 in madArgsComplex | ParameterNode | madArgsComplex | madArgsComplex |
+| tests.cpp:136:5:136:18 | [summary param] *0 in madArgsComplex | ParameterNode | madArgsComplex | madArgsComplex |
+| tests.cpp:136:5:136:18 | [summary param] *1 in madArgsComplex | ParameterNode | madArgsComplex | madArgsComplex |
+| tests.cpp:136:5:136:18 | [summary] to write: ReturnValue in madArgsComplex | ReturnNode | madArgsComplex | madArgsComplex |
+| tests.cpp:138:5:138:28 | [summary param] 2 in madAndImplementedComplex | ParameterNode | madAndImplementedComplex | madAndImplementedComplex |
+| tests.cpp:138:5:138:28 | [summary] to write: ReturnValue in madAndImplementedComplex | ReturnNode | madAndImplementedComplex | madAndImplementedComplex |
+| tests.cpp:143:5:143:24 | [summary param] 0 in madArg0FieldToReturn | ParameterNode | madArg0FieldToReturn | madArg0FieldToReturn |
+| tests.cpp:143:5:143:24 | [summary] read: Argument[0].Field[value] in madArg0FieldToReturn |  | madArg0FieldToReturn | madArg0FieldToReturn |
+| tests.cpp:143:5:143:24 | [summary] to write: ReturnValue in madArg0FieldToReturn | ReturnNode | madArg0FieldToReturn | madArg0FieldToReturn |
+| tests.cpp:144:5:144:32 | [summary param] *0 in madArg0IndirectFieldToReturn | ParameterNode | madArg0IndirectFieldToReturn | madArg0IndirectFieldToReturn |
+| tests.cpp:144:5:144:32 | [summary] read: Argument[*0].Field[value] in madArg0IndirectFieldToReturn |  | madArg0IndirectFieldToReturn | madArg0IndirectFieldToReturn |
+| tests.cpp:144:5:144:32 | [summary] to write: ReturnValue in madArg0IndirectFieldToReturn | ReturnNode | madArg0IndirectFieldToReturn | madArg0IndirectFieldToReturn |
+| tests.cpp:145:5:145:32 | [summary param] 0 in madArg0FieldIndirectToReturn | ParameterNode | madArg0FieldIndirectToReturn | madArg0FieldIndirectToReturn |
+| tests.cpp:145:5:145:32 | [summary] read: Argument[0].Field[*ptr] in madArg0FieldIndirectToReturn |  | madArg0FieldIndirectToReturn | madArg0FieldIndirectToReturn |
+| tests.cpp:145:5:145:32 | [summary] to write: ReturnValue in madArg0FieldIndirectToReturn | ReturnNode | madArg0FieldIndirectToReturn | madArg0FieldIndirectToReturn |
+| tests.cpp:146:13:146:32 | [summary param] 0 in madArg0ToReturnField | ParameterNode | madArg0ToReturnField | madArg0ToReturnField |
+| tests.cpp:146:13:146:32 | [summary] to write: ReturnValue in madArg0ToReturnField | ReturnNode | madArg0ToReturnField | madArg0ToReturnField |
+| tests.cpp:146:13:146:32 | [summary] to write: ReturnValue.Field[value] in madArg0ToReturnField |  | madArg0ToReturnField | madArg0ToReturnField |
+| tests.cpp:147:14:147:41 | [summary param] 0 in madArg0ToReturnIndirectField | ParameterNode | madArg0ToReturnIndirectField | madArg0ToReturnIndirectField |
+| tests.cpp:147:14:147:41 | [summary] to write: ReturnValue[*] in madArg0ToReturnIndirectField | ReturnNode | madArg0ToReturnIndirectField | madArg0ToReturnIndirectField |
+| tests.cpp:147:14:147:41 | [summary] to write: ReturnValue[*].Field[value] in madArg0ToReturnIndirectField |  | madArg0ToReturnIndirectField | madArg0ToReturnIndirectField |
+| tests.cpp:148:13:148:40 | [summary param] 0 in madArg0ToReturnFieldIndirect | ParameterNode | madArg0ToReturnFieldIndirect | madArg0ToReturnFieldIndirect |
+| tests.cpp:148:13:148:40 | [summary] to write: ReturnValue in madArg0ToReturnFieldIndirect | ReturnNode | madArg0ToReturnFieldIndirect | madArg0ToReturnFieldIndirect |
+| tests.cpp:148:13:148:40 | [summary] to write: ReturnValue.Field[*ptr] in madArg0ToReturnFieldIndirect |  | madArg0ToReturnFieldIndirect | madArg0ToReturnFieldIndirect |
+| tests.cpp:250:7:250:19 | [summary param] 0 in madArg0ToSelf | ParameterNode | madArg0ToSelf | madArg0ToSelf |
+| tests.cpp:250:7:250:19 | [summary param] this in madArg0ToSelf | ParameterNode | madArg0ToSelf | madArg0ToSelf |
+| tests.cpp:250:7:250:19 | [summary] to write: Argument[this] in madArg0ToSelf | PostUpdateNode | madArg0ToSelf | madArg0ToSelf |
+| tests.cpp:251:6:251:20 | [summary param] this in madSelfToReturn | ParameterNode | madSelfToReturn | madSelfToReturn |
+| tests.cpp:251:6:251:20 | [summary] to write: ReturnValue in madSelfToReturn | ReturnNode | madSelfToReturn | madSelfToReturn |
+| tests.cpp:253:7:253:20 | [summary param] 0 in madArg0ToField | ParameterNode | madArg0ToField | madArg0ToField |
+| tests.cpp:253:7:253:20 | [summary param] this in madArg0ToField | ParameterNode | madArg0ToField | madArg0ToField |
+| tests.cpp:253:7:253:20 | [summary] to write: Argument[this] in madArg0ToField | PostUpdateNode | madArg0ToField | madArg0ToField |
+| tests.cpp:253:7:253:20 | [summary] to write: Argument[this].Field[val] in madArg0ToField |  | madArg0ToField | madArg0ToField |
+| tests.cpp:254:6:254:21 | [summary param] this in madFieldToReturn | ParameterNode | madFieldToReturn | madFieldToReturn |
+| tests.cpp:254:6:254:21 | [summary] read: Argument[this].Field[val] in madFieldToReturn |  | madFieldToReturn | madFieldToReturn |
+| tests.cpp:254:6:254:21 | [summary] to write: ReturnValue in madFieldToReturn | ReturnNode | madFieldToReturn | madFieldToReturn |
+| tests.cpp:277:7:277:30 | [summary param] this in namespaceMadSelfToReturn | ParameterNode | namespaceMadSelfToReturn | namespaceMadSelfToReturn |
+| tests.cpp:277:7:277:30 | [summary] to write: ReturnValue in namespaceMadSelfToReturn | ReturnNode | namespaceMadSelfToReturn | namespaceMadSelfToReturn |
+| tests.cpp:392:5:392:29 | [summary param] 0 in madCallArg0ReturnToReturn | ParameterNode | madCallArg0ReturnToReturn | madCallArg0ReturnToReturn |
+| tests.cpp:392:5:392:29 | [summary] read: Argument[0].Parameter[this pointer] in madCallArg0ReturnToReturn | PostUpdateNode | madCallArg0ReturnToReturn | madCallArg0ReturnToReturn |
+| tests.cpp:392:5:392:29 | [summary] read: Argument[0].ReturnValue in madCallArg0ReturnToReturn | OutNode | madCallArg0ReturnToReturn | madCallArg0ReturnToReturn |
+| tests.cpp:392:5:392:29 | [summary] to write: Argument[0].Parameter[this pointer] in madCallArg0ReturnToReturn | ArgumentNode | madCallArg0ReturnToReturn | madCallArg0ReturnToReturn |
+| tests.cpp:392:5:392:29 | [summary] to write: ReturnValue in madCallArg0ReturnToReturn | ReturnNode | madCallArg0ReturnToReturn | madCallArg0ReturnToReturn |
+| tests.cpp:393:9:393:38 | [summary param] 0 in madCallArg0ReturnToReturnFirst | ParameterNode | madCallArg0ReturnToReturnFirst | madCallArg0ReturnToReturnFirst |
+| tests.cpp:393:9:393:38 | [summary] read: Argument[0].Parameter[this pointer] in madCallArg0ReturnToReturnFirst | PostUpdateNode | madCallArg0ReturnToReturnFirst | madCallArg0ReturnToReturnFirst |
+| tests.cpp:393:9:393:38 | [summary] read: Argument[0].ReturnValue in madCallArg0ReturnToReturnFirst | OutNode | madCallArg0ReturnToReturnFirst | madCallArg0ReturnToReturnFirst |
+| tests.cpp:393:9:393:38 | [summary] to write: Argument[0].Parameter[this pointer] in madCallArg0ReturnToReturnFirst | ArgumentNode | madCallArg0ReturnToReturnFirst | madCallArg0ReturnToReturnFirst |
+| tests.cpp:393:9:393:38 | [summary] to write: ReturnValue in madCallArg0ReturnToReturnFirst | ReturnNode | madCallArg0ReturnToReturnFirst | madCallArg0ReturnToReturnFirst |
+| tests.cpp:393:9:393:38 | [summary] to write: ReturnValue.Field[first] in madCallArg0ReturnToReturnFirst |  | madCallArg0ReturnToReturnFirst | madCallArg0ReturnToReturnFirst |
+| tests.cpp:394:6:394:25 | [summary param] 0 in madCallArg0WithValue | ParameterNode | madCallArg0WithValue | madCallArg0WithValue |
+| tests.cpp:394:6:394:25 | [summary param] 1 in madCallArg0WithValue | ParameterNode | madCallArg0WithValue | madCallArg0WithValue |
+| tests.cpp:394:6:394:25 | [summary] read: Argument[0].Parameter[0] in madCallArg0WithValue | PostUpdateNode | madCallArg0WithValue | madCallArg0WithValue |
+| tests.cpp:394:6:394:25 | [summary] read: Argument[0].Parameter[this pointer] in madCallArg0WithValue | PostUpdateNode | madCallArg0WithValue | madCallArg0WithValue |
+| tests.cpp:394:6:394:25 | [summary] to write: Argument[0].Parameter[0] in madCallArg0WithValue | ArgumentNode | madCallArg0WithValue | madCallArg0WithValue |
+| tests.cpp:394:6:394:25 | [summary] to write: Argument[0].Parameter[this pointer] in madCallArg0WithValue | ArgumentNode | madCallArg0WithValue | madCallArg0WithValue |
+| tests.cpp:394:6:394:25 | [summary] to write: Argument[1] in madCallArg0WithValue | PostUpdateNode | madCallArg0WithValue | madCallArg0WithValue |
+| tests.cpp:395:5:395:36 | [summary param] 1 in madCallReturnValueIgnoreFunction | ParameterNode | madCallReturnValueIgnoreFunction | madCallReturnValueIgnoreFunction |
+| tests.cpp:395:5:395:36 | [summary] to write: ReturnValue in madCallReturnValueIgnoreFunction | ReturnNode | madCallReturnValueIgnoreFunction | madCallReturnValueIgnoreFunction |
+| tests.cpp:417:5:417:31 | [summary param] *0 in parameter_ref_to_return_ref | ParameterNode | parameter_ref_to_return_ref | parameter_ref_to_return_ref |
+| tests.cpp:417:5:417:31 | [summary] to write: ReturnValue[*] in parameter_ref_to_return_ref | ReturnNode | parameter_ref_to_return_ref | parameter_ref_to_return_ref |
+| tests.cpp:429:5:429:17 | [summary param] *0 in receive_array | ParameterNode | receive_array | receive_array |
+| tests.cpp:429:5:429:17 | [summary] to write: ReturnValue in receive_array | ReturnNode | receive_array | receive_array |

--- a/cpp/ql/test/library-tests/dataflow/models-as-data/testModels.ext.yml
+++ b/cpp/ql/test/library-tests/dataflow/models-as-data/testModels.ext.yml
@@ -11,15 +11,12 @@ extensions:
       - ["", "", False, "remoteMadSourceDoubleIndirect", "", "", "ReturnValue[**]", "remote", "manual"]
       - ["", "", False, "remoteMadSourceIndirectArg0", "", "", "Argument[*0]", "remote", "manual"]
       - ["", "", False, "remoteMadSourceIndirectArg1", "", "", "Argument[*1]", "remote", "manual"]
-      - ["", "", False, "remoteMadSourceVar", "", "", "", "remote", "manual"]
-      - ["", "", False, "remoteMadSourceVarIndirect", "", "", "*", "remote", "manual"] # we can't express this source/sink correctly at present, "*" is not a valid access path
       - ["", "", False, "remoteMadSourceParam0", "", "", "Parameter[0]", "remote", "manual"]
       - ["MyNamespace", "", False, "namespaceLocalMadSource", "", "", "ReturnValue", "local", "manual"]
       - ["MyNamespace", "", False, "namespaceLocalMadSourceVar", "", "", "", "local", "manual"]
       - ["MyNamespace::MyNamespace2", "", False, "namespace2LocalMadSource", "", "", "ReturnValue", "local", "manual"]
       - ["", "MyClass", True, "memberRemoteMadSource", "", "", "ReturnValue", "remote", "manual"]
       - ["", "MyClass", True, "memberRemoteMadSourceIndirectArg0", "", "", "Argument[*0]", "remote", "manual"]
-      - ["", "MyClass", True, "memberRemoteMadSourceVar", "", "", "", "remote", "manual"]
       - ["", "MyClass", True, "subtypeRemoteMadSource1", "", "", "ReturnValue", "remote", "manual"]
       - ["", "MyClass", False, "subtypeNonSource", "", "", "ReturnValue", "remote", "manual"] # the tests define this in MyDerivedClass, so it should *not* be recongized as a source
       - ["", "MyClass", True, "qualifierSource", "", "", "Argument[-1]", "remote", "manual"]
@@ -35,18 +32,13 @@ extensions:
       - ["", "", False, "madSinkArg02", "", "", "Argument[0,2]", "test-sink", "manual"]
       - ["", "", False, "madSinkIndirectArg0", "", "", "Argument[*0]", "test-sink", "manual"]
       - ["", "", False, "madSinkDoubleIndirectArg0", "", "", "Argument[**0]", "test-sink", "manual"]
-      - ["", "", False, "madSinkVar", "", "", "", "test-sink", "manual"]
-      - ["", "", False, "madSinkVarIndirect", "", "", "*", "test-sink", "manual"] # we can't express this source/sink correctly at present, "*" is not a valid access path
       - ["", "", False, "madSinkParam0", "", "", "Parameter[0]", "test-sink", "manual"]
       - ["", "MyClass", True, "memberMadSinkArg0", "", "", "Argument[0]", "test-sink", "manual"]
-      - ["", "MyClass", True, "memberMadSinkVar", "", "", "", "test-sink", "manual"]
       - ["", "MyClass", True, "qualifierSink", "", "", "Argument[-1]", "test-sink", "manual"]
       - ["", "MyClass", True, "qualifierArg0Sink", "", "", "Argument[-1..0]", "test-sink", "manual"]
       - ["", "MyClass", True, "qualifierFieldSink", "", "", "Argument[-1].val", "test-sink", "manual"]
       - ["MyNamespace", "MyClass", True, "namespaceMemberMadSinkArg0", "", "", "Argument[0]", "test-sink", "manual"]
       - ["MyNamespace", "MyClass", True, "namespaceStaticMemberMadSinkArg0", "", "", "Argument[0]", "test-sink", "manual"]
-      - ["MyNamespace", "MyClass", True, "namespaceMemberMadSinkVar", "", "", "", "test-sink", "manual"]
-      - ["MyNamespace", "MyClass", True, "namespaceStaticMemberMadSinkVar", "", "", "", "test-sink", "manual"]
   - addsTo:
       pack: codeql/cpp-all
       extensible: summaryModel
@@ -68,9 +60,6 @@ extensions:
       - ["", "", False, "madArg0ToReturnField", "", "", "Argument[0]", "ReturnValue.Field[value]", "taint", "manual"]
       - ["", "", False, "madArg0ToReturnIndirectField", "", "", "Argument[0]", "ReturnValue[*].Field[value]", "taint", "manual"]
       - ["", "", False, "madArg0ToReturnFieldIndirect", "", "", "Argument[0]", "ReturnValue.Field[*ptr]", "taint", "manual"]
-      - ["", "", False, "madFieldToFieldVar", "", "", "Field[value]", "Field[value2]", "taint", "manual"] # we can't express this source/sink correctly at present, "Field[value]" is not a valid input and "Field[value2]" is not a valid output
-      - ["", "", False, "madFieldToIndirectFieldVar", "", "", "Field[value]", "Field[*ptr]", "taint", "manual"] # we can't express this source/sink correctly at present, "Field[value]" is not a valid input and "Field[*ptr]" is not a valid output
-      - ["", "", False, "madIndirectFieldToFieldVar", "", "", "Field[value]", "Field[value2]", "taint", "manual"] # we can't express this source/sink correctly at present, "Field[value]" is not a valid input and "Field[value2]" is not a valid output
       - ["", "MyClass", True, "madArg0ToSelf", "", "", "Argument[0]", "Argument[-1]", "taint", "manual"]
       - ["", "MyClass", True, "madSelfToReturn", "", "", "Argument[-1]", "ReturnValue", "taint", "manual"]
       - ["", "MyClass", True, "madArg0ToField", "", "", "Argument[0]", "Argument[-1].Field[val]", "taint", "manual"]

--- a/cpp/ql/test/library-tests/dataflow/models-as-data/tests.cpp
+++ b/cpp/ql/test/library-tests/dataflow/models-as-data/tests.cpp
@@ -17,12 +17,12 @@ int *remoteMadSourceIndirect(); // $ interpretElement
 int **remoteMadSourceDoubleIndirect(); // $ interpretElement
 void remoteMadSourceIndirectArg0(int *x, int *y); // $ interpretElement
 void remoteMadSourceIndirectArg1(int &x, int &y); // $ interpretElement
-int remoteMadSourceVar; // $ interpretElement
-int *remoteMadSourceVarIndirect; // $ interpretElement
+
+
 
 namespace MyNamespace {
-	int namespaceLocalMadSource(); // $ interpretElement
-	int namespaceLocalMadSourceVar; // $ interpretElement
+
+
 
 	namespace MyNamespace2 {
 		int namespace2LocalMadSource(); // $ interpretElement
@@ -69,14 +69,14 @@ void test_sources() {
 	sink(c);
 	sink(d); // $ ir
 
-	sink(remoteMadSourceVar); // $ ir
-	sink(*remoteMadSourceVarIndirect); // $ MISSING: ir
+
+
 
 	int e = localMadSource();
 	sink(e); // $ ir
 
-	sink(MyNamespace::namespaceLocalMadSource()); // $ ir
-	sink(MyNamespace::namespaceLocalMadSourceVar); // $ ir
+
+	
 	sink(MyNamespace::MyNamespace2::namespace2LocalMadSource()); // $ ir
 	sink(MyNamespace::localMadSource()); // $ (the MyNamespace version of this function is not a source)
 	sink(namespaceLocalMadSource()); // (the global namespace version of this function is not a source)
@@ -96,8 +96,8 @@ void madSinkArg01(int x, int y, int z); // $ interpretElement
 void madSinkArg02(int x, int y, int z); // $ interpretElement
 void madSinkIndirectArg0(int *x); // $ interpretElement
 void madSinkDoubleIndirectArg0(int **x); // $ interpretElement
-int madSinkVar; // $ interpretElement
-int *madSinkVarIndirect; // $ interpretElement
+
+
 
 void test_sinks() {
 	// test sinks
@@ -119,14 +119,14 @@ void test_sinks() {
 	madSinkIndirectArg0(a_ptr); // $ ir
 	madSinkDoubleIndirectArg0(&a_ptr); // $ ir
 
-	madSinkVar = source();  // $ ir
 
-	// test sources + sinks together
+
+
 
 	madSinkArg0(localMadSource()); // $ ir
 	madSinkIndirectArg0(remoteMadSourceIndirect()); // $ ir
-	madSinkVar = remoteMadSourceVar; // $ ir
-	*madSinkVarIndirect = remoteMadSourceVar; // $ MISSING: ir
+	
+
 }
 
 void madSinkParam0(int x) { // $ interpretElement
@@ -164,9 +164,9 @@ MyContainer madArg0ToReturnField(int x); // $ interpretElement
 MyContainer *madArg0ToReturnIndirectField(int x); // $ interpretElement
 MyContainer madArg0ToReturnFieldIndirect(int x); // $ interpretElement
 
-MyContainer madFieldToFieldVar; // $ interpretElement
-MyContainer madFieldToIndirectFieldVar; // $ interpretElement
-MyContainer *madIndirectFieldToFieldVar; // $ interpretElement
+
+
+
 
 void test_summaries() {
 	// test summaries
@@ -241,18 +241,18 @@ void test_summaries() {
 	int *rtn2_ptr = rtn2.ptr;
 	sink(*rtn2_ptr); // $ ir
 
-	// test global variable summaries
+	
 
-	madFieldToFieldVar.value = source();
-	sink(madFieldToFieldVar.value2); // $ MISSING: ir
 
-	madFieldToIndirectFieldVar.value = source();
-	sink(madFieldToIndirectFieldVar.ptr);
-	sink(*(madFieldToIndirectFieldVar.ptr)); // $ MISSING: ir
+	
 
-	madIndirectFieldToFieldVar->value = source();
-	sink((*madIndirectFieldToFieldVar).value2); // $ MISSING: ir
-	sink(madIndirectFieldToFieldVar->value2); // $ MISSING: ir
+
+
+	
+
+
+	
+	
 
 	// test source + sinks + summaries together
 
@@ -269,13 +269,13 @@ public:
 	// sources
 	int memberRemoteMadSource(); // $ interpretElement
 	void memberRemoteMadSourceIndirectArg0(int *x); // $ interpretElement
-	int memberRemoteMadSourceVar; // $ interpretElement
+	
 	void qualifierSource(); // $ interpretElement
 	void qualifierFieldSource(); // $ interpretElement
 
 	// sinks
 	void memberMadSinkArg0(int x); // $ interpretElement
-	int memberMadSinkVar; // $ interpretElement
+
 	void qualifierSink(); // $ interpretElement
 	void qualifierArg0Sink(int x); // $ interpretElement
 	void qualifierFieldSink(); // $ interpretElement
@@ -306,8 +306,8 @@ namespace MyNamespace {
 		// sinks
 		void namespaceMemberMadSinkArg0(int x); // $ interpretElement
 		static void namespaceStaticMemberMadSinkArg0(int x); // $ interpretElement
-		int namespaceMemberMadSinkVar; // $ interpretElement
-		static int namespaceStaticMemberMadSinkVar; // $ interpretElement
+
+
 
 		// summaries
 		int namespaceMadSelfToReturn(); // $ interpretElement
@@ -331,7 +331,7 @@ void test_class_members() {
 	mc.memberRemoteMadSourceIndirectArg0(&a);
 	sink(a); // $ ir
 
-	sink(mc.memberRemoteMadSourceVar); // $ ir
+
 
 	// test subtype sources
 
@@ -344,12 +344,12 @@ void test_class_members() {
 
 	mc.memberMadSinkArg0(source()); // $ ir
 
-	mc.memberMadSinkVar = source(); // $ ir
+
 
 	mnc.namespaceMemberMadSinkArg0(source()); // $ ir
 	MyNamespace::MyClass::namespaceStaticMemberMadSinkArg0(source()); // $ ir
-	mnc.namespaceMemberMadSinkVar = source(); // $ ir
-	MyNamespace::MyClass::namespaceStaticMemberMadSinkVar = source(); // $ ir
+
+
 
 	// test class member summaries
 

--- a/cpp/ql/test/library-tests/dataflow/models-as-data/tests.cpp
+++ b/cpp/ql/test/library-tests/dataflow/models-as-data/tests.cpp
@@ -18,12 +18,7 @@ int **remoteMadSourceDoubleIndirect(); // $ interpretElement
 void remoteMadSourceIndirectArg0(int *x, int *y); // $ interpretElement
 void remoteMadSourceIndirectArg1(int &x, int &y); // $ interpretElement
 
-
-
 namespace MyNamespace {
-
-
-
 	namespace MyNamespace2 {
 		int namespace2LocalMadSource(); // $ interpretElement
 	}
@@ -69,13 +64,8 @@ void test_sources() {
 	sink(c);
 	sink(d); // $ ir
 
-
-
-
 	int e = localMadSource();
 	sink(e); // $ ir
-
-
 	
 	sink(MyNamespace::MyNamespace2::namespace2LocalMadSource()); // $ ir
 	sink(MyNamespace::localMadSource()); // $ (the MyNamespace version of this function is not a source)
@@ -118,15 +108,8 @@ void test_sinks() {
 	madSinkIndirectArg0(&a); // $ ir
 	madSinkIndirectArg0(a_ptr); // $ ir
 	madSinkDoubleIndirectArg0(&a_ptr); // $ ir
-
-
-
-
-
 	madSinkArg0(localMadSource()); // $ ir
 	madSinkIndirectArg0(remoteMadSourceIndirect()); // $ ir
-	
-
 }
 
 void madSinkParam0(int x) { // $ interpretElement
@@ -163,10 +146,6 @@ int madArg0FieldIndirectToReturn(MyContainer mc); // $ interpretElement
 MyContainer madArg0ToReturnField(int x); // $ interpretElement
 MyContainer *madArg0ToReturnIndirectField(int x); // $ interpretElement
 MyContainer madArg0ToReturnFieldIndirect(int x); // $ interpretElement
-
-
-
-
 
 void test_summaries() {
 	// test summaries
@@ -241,19 +220,6 @@ void test_summaries() {
 	int *rtn2_ptr = rtn2.ptr;
 	sink(*rtn2_ptr); // $ ir
 
-	
-
-
-	
-
-
-
-	
-
-
-	
-	
-
 	// test source + sinks + summaries together
 
 	madSinkArg0(madArg0ToReturn(remoteMadSource())); // $ ir
@@ -307,8 +273,6 @@ namespace MyNamespace {
 		void namespaceMemberMadSinkArg0(int x); // $ interpretElement
 		static void namespaceStaticMemberMadSinkArg0(int x); // $ interpretElement
 
-
-
 		// summaries
 		int namespaceMadSelfToReturn(); // $ interpretElement
 	};
@@ -331,8 +295,6 @@ void test_class_members() {
 	mc.memberRemoteMadSourceIndirectArg0(&a);
 	sink(a); // $ ir
 
-
-
 	// test subtype sources
 
 	sink(mdc.memberRemoteMadSource()); // $ ir
@@ -344,12 +306,8 @@ void test_class_members() {
 
 	mc.memberMadSinkArg0(source()); // $ ir
 
-
-
 	mnc.namespaceMemberMadSinkArg0(source()); // $ ir
 	MyNamespace::MyClass::namespaceStaticMemberMadSinkArg0(source()); // $ ir
-
-
 
 	// test class member summaries
 


### PR DESCRIPTION
When we added MaD support for C/C++ we added (partial) support for picking variables as flow sources or flow sinks. I was never really a fan of adding this kind of support with no clear use-case for it (see my comments [here](https://github.com/github/codeql/pull/15371#discussion_r1463022976) and [here](https://github.com/github/codeql/pull/15371#discussion_r1463023539)) and in the 2 years we've had MaD support we've never had a need for this particular feature, and the only occurrence of this has been in the tests we added 2 years ago. We've also never publicly documented this feature (as it was only ever partially implemented).

I am now adding support for access paths for MaD sources and sinks (because I've got a use-case for it coming up), and this feature variables as sources and sinks are making it harder to support this.

In conclusion: I think we should just remove this feature.

DCA was uneventful (as expected).