### PR TITLE
unified: Add inline expectation test library

### DIFF
--- a/unified/ql/lib/utils/test/InlineExpectationsTest.qll
+++ b/unified/ql/lib/utils/test/InlineExpectationsTest.qll
@@ -1,0 +1,8 @@
+/**
+ * Inline expectation tests for unified.
+ * See `shared/util/codeql/util/test/InlineExpectationsTest.qll`
+ */
+
+private import codeql.util.test.InlineExpectationsTest
+private import internal.InlineExpectationsTestImpl
+import Make<Impl>

--- a/unified/ql/lib/utils/test/InlineExpectationsTestQuery.ql
+++ b/unified/ql/lib/utils/test/InlineExpectationsTestQuery.ql
@@ -1,0 +1,21 @@
+/**
+ * @kind test-postprocess
+ */
+
+private import unified
+private import codeql.util.test.InlineExpectationsTest as T
+private import internal.InlineExpectationsTestImpl
+import T::TestPostProcessing
+import T::TestPostProcessing::Make<Impl, Input>
+
+private module Input implements T::TestPostProcessing::InputSig<Impl> {
+  string getRelativeUrl(Location location) {
+    exists(File f, int startline, int startcolumn, int endline, int endcolumn |
+      location.hasLocationInfo(_, startline, startcolumn, endline, endcolumn) and
+      f = location.getFile()
+    |
+      result =
+        f.getRelativePath() + ":" + startline + ":" + startcolumn + ":" + endline + ":" + endcolumn
+    )
+  }
+}

--- a/unified/ql/lib/utils/test/internal/InlineExpectationsTestImpl.qll
+++ b/unified/ql/lib/utils/test/internal/InlineExpectationsTestImpl.qll
@@ -1,0 +1,12 @@
+private import unified as U
+private import U
+private import codeql.util.test.InlineExpectationsTest
+
+module Impl implements InlineExpectationsTestSig {
+  class ExpectationComment extends U::Comment {
+    /** Gets the contents of the given comment, _without_ the preceding comment marker (`//`). */
+    string getContents() { result = this.getCommentText() }
+  }
+
+  class Location = U::Location;
+}

--- a/unified/ql/lib/utils/test/internal/InlineExpectationsTestImpl.qll
+++ b/unified/ql/lib/utils/test/internal/InlineExpectationsTestImpl.qll
@@ -4,7 +4,7 @@ private import codeql.util.test.InlineExpectationsTest
 
 module Impl implements InlineExpectationsTestSig {
   class ExpectationComment extends U::Comment {
-    /** Gets the contents of the given comment, _without_ the preceding comment marker (`//`). */
+    /** Gets the text inside this comment, without the surrounding comment delimiters. */
     string getContents() { result = this.getCommentText() }
   }
 


### PR DESCRIPTION
I was going to add this alongside local scoping, but it's looking like it might be needed for other work first, so I thought we might as well get this in here.