### PR TITLE
Java: Model Spring reactive `WebClient.uri` as a request forgery sink

### DIFF
--- a/java/ql/lib/change-notes/2026-06-30-spring-webclient-uri-ssrf.md
+++ b/java/ql/lib/change-notes/2026-06-30-spring-webclient-uri-ssrf.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The `uri` method of Spring's reactive `WebClient` is now considered a request forgery sink. Previously only the `create` and `baseUrl` methods were considered. This may lead to more alerts for the query `java/ssrf` (Server-side request forgery).

--- a/java/ql/lib/change-notes/2026-06-30-spring-webclient-uri-ssrf.md
+++ b/java/ql/lib/change-notes/2026-06-30-spring-webclient-uri-ssrf.md
@@ -1,4 +1,4 @@
 ---
 category: minorAnalysis
 ---
-* The `uri` method of Spring's reactive `WebClient` is now considered a request forgery sink. Previously only the `create` and `baseUrl` methods were considered. This may lead to more alerts for the query `java/ssrf` (Server-side request forgery).
+* The first argument of the `uri` method of `WebClient$UriSpec` in `org.springframework.web.reactive.function.client` is now considered a request forgery sink. Previously only the first arguments of the `WebClient.create` and `WebClient$Builder.baseUrl` methods were considered. This may lead to more alerts for the query `java/ssrf` (Server-side request forgery).

--- a/java/ql/lib/ext/org.springframework.web.reactive.function.client.model.yml
+++ b/java/ql/lib/ext/org.springframework.web.reactive.function.client.model.yml
@@ -1,4 +1,3 @@
-# Copyright © 2026 Apple Inc.
 extensions:
   - addsTo:
       pack: codeql/java-all

--- a/java/ql/lib/ext/org.springframework.web.reactive.function.client.model.yml
+++ b/java/ql/lib/ext/org.springframework.web.reactive.function.client.model.yml
@@ -1,3 +1,4 @@
+# Copyright © 2026 Apple Inc.
 extensions:
   - addsTo:
       pack: codeql/java-all
@@ -5,3 +6,4 @@ extensions:
     data:
       - ["org.springframework.web.reactive.function.client", "WebClient", False, "create", "", "", "Argument[0]", "request-forgery", "manual"]
       - ["org.springframework.web.reactive.function.client", "WebClient$Builder", False, "baseUrl", "", "", "Argument[0]", "request-forgery", "manual"]
+      - ["org.springframework.web.reactive.function.client", "WebClient$UriSpec", True, "uri", "", "", "Argument[0]", "request-forgery", "manual"]

--- a/java/ql/test/query-tests/security/CWE-918/ReactiveWebClientSSRF.java
+++ b/java/ql/test/query-tests/security/CWE-918/ReactiveWebClientSSRF.java
@@ -46,4 +46,27 @@ public class ReactiveWebClientSSRF extends HttpServlet {
             // Ignore
         }
     }
+
+    protected void doPut(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        try {
+            WebClient webClient = WebClient.create("https://example.com");
+
+            String p = request.getParameter("uri"); // $ Source
+            webClient.get()
+                    .uri(p) // $ Alert
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .block();
+
+            String p2 = request.getParameter("uri"); // $ Source
+            webClient.get()
+                    .uri(java.net.URI.create("https://example.com" + p2)) // $ Alert
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .block();
+        } catch (Exception e) {
+            // Ignore
+        }
+    }
 }

--- a/java/ql/test/query-tests/security/CWE-918/RequestForgery.expected
+++ b/java/ql/test/query-tests/security/CWE-918/RequestForgery.expected
@@ -237,6 +237,8 @@
 | JdbcUrlSSRF.java:88:19:88:25 | jdbcUrl | JdbcUrlSSRF.java:80:26:80:56 | getParameter(...) : String | JdbcUrlSSRF.java:88:19:88:25 | jdbcUrl | Potential server-side request forgery due to a $@. | JdbcUrlSSRF.java:80:26:80:56 | getParameter(...) | user-provided value |
 | ReactiveWebClientSSRF.java:16:52:16:54 | url | ReactiveWebClientSSRF.java:15:26:15:52 | getParameter(...) : String | ReactiveWebClientSSRF.java:16:52:16:54 | url | Potential server-side request forgery due to a $@. | ReactiveWebClientSSRF.java:15:26:15:52 | getParameter(...) | user-provided value |
 | ReactiveWebClientSSRF.java:35:30:35:32 | url | ReactiveWebClientSSRF.java:32:26:32:52 | getParameter(...) : String | ReactiveWebClientSSRF.java:35:30:35:32 | url | Potential server-side request forgery due to a $@. | ReactiveWebClientSSRF.java:32:26:32:52 | getParameter(...) | user-provided value |
+| ReactiveWebClientSSRF.java:57:26:57:26 | p | ReactiveWebClientSSRF.java:55:24:55:50 | getParameter(...) : String | ReactiveWebClientSSRF.java:57:26:57:26 | p | Potential server-side request forgery due to a $@. | ReactiveWebClientSSRF.java:55:24:55:50 | getParameter(...) | user-provided value |
+| ReactiveWebClientSSRF.java:64:26:64:72 | create(...) | ReactiveWebClientSSRF.java:62:25:62:51 | getParameter(...) : String | ReactiveWebClientSSRF.java:64:26:64:72 | create(...) | Potential server-side request forgery due to a $@. | ReactiveWebClientSSRF.java:62:25:62:51 | getParameter(...) | user-provided value |
 | SanitizationTests.java:25:52:25:54 | uri | SanitizationTests.java:22:31:22:57 | getParameter(...) : String | SanitizationTests.java:25:52:25:54 | uri | Potential server-side request forgery due to a $@. | SanitizationTests.java:22:31:22:57 | getParameter(...) | user-provided value |
 | SanitizationTests.java:26:25:26:25 | r | SanitizationTests.java:22:31:22:57 | getParameter(...) : String | SanitizationTests.java:26:25:26:25 | r | Potential server-side request forgery due to a $@. | SanitizationTests.java:22:31:22:57 | getParameter(...) | user-provided value |
 | SanitizationTests.java:79:59:79:77 | new URI(...) | SanitizationTests.java:78:33:78:63 | getParameter(...) : String | SanitizationTests.java:79:59:79:77 | new URI(...) | Potential server-side request forgery due to a $@. | SanitizationTests.java:78:33:78:63 | getParameter(...) | user-provided value |
@@ -386,21 +388,21 @@
 | mad/Test.java:107:15:107:31 | (...)... | mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:107:15:107:31 | (...)... | Potential server-side request forgery due to a $@. | mad/Test.java:26:16:26:41 | getParameter(...) | user-provided value |
 | mad/Test.java:112:15:112:31 | (...)... | mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:112:15:112:31 | (...)... | Potential server-side request forgery due to a $@. | mad/Test.java:26:16:26:41 | getParameter(...) | user-provided value |
 edges
-| ApacheHttpClientExecuteSSRF.java:23:29:23:56 | getParameter(...) : String | ApacheHttpClientExecuteSSRF.java:25:42:25:47 | source : String | provenance | Src:MaD:285  |
-| ApacheHttpClientExecuteSSRF.java:23:29:23:56 | getParameter(...) : String | ApacheHttpClientExecuteSSRF.java:27:56:27:61 | source | provenance | Src:MaD:285 Sink:MaD:220 |
-| ApacheHttpClientExecuteSSRF.java:23:29:23:56 | getParameter(...) : String | ApacheHttpClientExecuteSSRF.java:27:56:27:61 | source : String | provenance | Src:MaD:285  |
+| ApacheHttpClientExecuteSSRF.java:23:29:23:56 | getParameter(...) : String | ApacheHttpClientExecuteSSRF.java:25:42:25:47 | source : String | provenance | Src:MaD:286  |
+| ApacheHttpClientExecuteSSRF.java:23:29:23:56 | getParameter(...) : String | ApacheHttpClientExecuteSSRF.java:27:56:27:61 | source | provenance | Src:MaD:286 Sink:MaD:220 |
+| ApacheHttpClientExecuteSSRF.java:23:29:23:56 | getParameter(...) : String | ApacheHttpClientExecuteSSRF.java:27:56:27:61 | source : String | provenance | Src:MaD:286  |
 | ApacheHttpClientExecuteSSRF.java:25:29:25:48 | new HttpHost(...) : HttpHost | ApacheHttpClientExecuteSSRF.java:32:28:32:31 | host | provenance | Sink:MaD:228 |
 | ApacheHttpClientExecuteSSRF.java:25:29:25:48 | new HttpHost(...) : HttpHost | ApacheHttpClientExecuteSSRF.java:33:28:33:31 | host | provenance | Sink:MaD:229 |
 | ApacheHttpClientExecuteSSRF.java:25:29:25:48 | new HttpHost(...) : HttpHost | ApacheHttpClientExecuteSSRF.java:34:28:34:31 | host | provenance | Sink:MaD:230 |
 | ApacheHttpClientExecuteSSRF.java:25:29:25:48 | new HttpHost(...) : HttpHost | ApacheHttpClientExecuteSSRF.java:35:28:35:31 | host | provenance | Sink:MaD:231 |
-| ApacheHttpClientExecuteSSRF.java:25:42:25:47 | source : String | ApacheHttpClientExecuteSSRF.java:25:29:25:48 | new HttpHost(...) : HttpHost | provenance | MaD:307 |
-| ApacheHttpClientExecuteSSRF.java:27:37:27:62 | get(...) : RequestBuilder | ApacheHttpClientExecuteSSRF.java:27:37:27:70 | build(...) : HttpUriRequest | provenance | MaD:304 |
+| ApacheHttpClientExecuteSSRF.java:25:42:25:47 | source : String | ApacheHttpClientExecuteSSRF.java:25:29:25:48 | new HttpHost(...) : HttpHost | provenance | MaD:309 |
+| ApacheHttpClientExecuteSSRF.java:27:37:27:62 | get(...) : RequestBuilder | ApacheHttpClientExecuteSSRF.java:27:37:27:70 | build(...) : HttpUriRequest | provenance | MaD:306 |
 | ApacheHttpClientExecuteSSRF.java:27:37:27:70 | build(...) : HttpUriRequest | ApacheHttpClientExecuteSSRF.java:36:28:36:33 | uriReq | provenance | Sink:MaD:232 |
 | ApacheHttpClientExecuteSSRF.java:27:37:27:70 | build(...) : HttpUriRequest | ApacheHttpClientExecuteSSRF.java:37:28:37:33 | uriReq | provenance | Sink:MaD:233 |
 | ApacheHttpClientExecuteSSRF.java:27:37:27:70 | build(...) : HttpUriRequest | ApacheHttpClientExecuteSSRF.java:38:28:38:33 | uriReq | provenance | Sink:MaD:234 |
 | ApacheHttpClientExecuteSSRF.java:27:37:27:70 | build(...) : HttpUriRequest | ApacheHttpClientExecuteSSRF.java:39:28:39:33 | uriReq | provenance | Sink:MaD:235 |
-| ApacheHttpClientExecuteSSRF.java:27:56:27:61 | source : String | ApacheHttpClientExecuteSSRF.java:27:37:27:62 | get(...) : RequestBuilder | provenance | MaD:305 |
-| ApacheHttpSSRF.java:27:27:27:53 | getParameter(...) : String | ApacheHttpSSRF.java:28:31:28:34 | sink : String | provenance | Src:MaD:285  |
+| ApacheHttpClientExecuteSSRF.java:27:56:27:61 | source : String | ApacheHttpClientExecuteSSRF.java:27:37:27:62 | get(...) : RequestBuilder | provenance | MaD:307 |
+| ApacheHttpSSRF.java:27:27:27:53 | getParameter(...) : String | ApacheHttpSSRF.java:28:31:28:34 | sink : String | provenance | Src:MaD:286  |
 | ApacheHttpSSRF.java:28:23:28:35 | new URI(...) : URI | ApacheHttpSSRF.java:30:43:30:45 | uri | provenance | Sink:MaD:211 |
 | ApacheHttpSSRF.java:28:23:28:35 | new URI(...) : URI | ApacheHttpSSRF.java:32:29:32:31 | uri | provenance | Sink:MaD:217 |
 | ApacheHttpSSRF.java:28:23:28:35 | new URI(...) : URI | ApacheHttpSSRF.java:34:26:34:28 | uri | provenance | Sink:MaD:212 |
@@ -426,16 +428,16 @@ edges
 | ApacheHttpSSRF.java:28:23:28:35 | new URI(...) : URI | ApacheHttpSSRF.java:57:34:57:36 | uri | provenance | Sink:MaD:223 |
 | ApacheHttpSSRF.java:28:23:28:35 | new URI(...) : URI | ApacheHttpSSRF.java:58:43:58:45 | uri | provenance | Sink:MaD:226 |
 | ApacheHttpSSRF.java:28:31:28:34 | sink : String | ApacheHttpSSRF.java:28:23:28:35 | new URI(...) : URI | provenance | Config |
-| ApacheHttpSSRF.java:28:31:28:34 | sink : String | ApacheHttpSSRF.java:28:23:28:35 | new URI(...) : URI | provenance | MaD:293 |
-| ApacheHttpSSRF.java:42:62:42:64 | uri : URI | ApacheHttpSSRF.java:42:62:42:75 | toString(...) : String | provenance | MaD:295 |
-| ApacheHttpSSRF.java:42:62:42:75 | toString(...) : String | ApacheHttpSSRF.java:42:34:42:82 | new BasicRequestLine(...) | provenance | MaD:306 Sink:MaD:239 |
-| ApacheHttpSSRF.java:43:41:43:43 | uri : URI | ApacheHttpSSRF.java:43:41:43:54 | toString(...) | provenance | MaD:295 Sink:MaD:240 |
-| ApacheHttpSSRF.java:44:41:44:43 | uri : URI | ApacheHttpSSRF.java:44:41:44:54 | toString(...) | provenance | MaD:295 Sink:MaD:241 |
-| ApacheHttpSSRF.java:46:77:46:79 | uri : URI | ApacheHttpSSRF.java:46:77:46:90 | toString(...) : String | provenance | MaD:295 |
-| ApacheHttpSSRF.java:46:77:46:90 | toString(...) : String | ApacheHttpSSRF.java:46:49:46:97 | new BasicRequestLine(...) | provenance | MaD:306 Sink:MaD:236 |
-| ApacheHttpSSRF.java:47:56:47:58 | uri : URI | ApacheHttpSSRF.java:47:56:47:69 | toString(...) | provenance | MaD:295 Sink:MaD:237 |
-| ApacheHttpSSRF.java:48:56:48:58 | uri : URI | ApacheHttpSSRF.java:48:56:48:69 | toString(...) | provenance | MaD:295 Sink:MaD:238 |
-| ApacheHttpSSRFVersion5.java:41:30:41:56 | getParameter(...) : String | ApacheHttpSSRFVersion5.java:42:31:42:37 | uriSink : String | provenance | Src:MaD:285  |
+| ApacheHttpSSRF.java:28:31:28:34 | sink : String | ApacheHttpSSRF.java:28:23:28:35 | new URI(...) : URI | provenance | MaD:294 |
+| ApacheHttpSSRF.java:42:62:42:64 | uri : URI | ApacheHttpSSRF.java:42:62:42:75 | toString(...) : String | provenance | MaD:297 |
+| ApacheHttpSSRF.java:42:62:42:75 | toString(...) : String | ApacheHttpSSRF.java:42:34:42:82 | new BasicRequestLine(...) | provenance | MaD:308 Sink:MaD:239 |
+| ApacheHttpSSRF.java:43:41:43:43 | uri : URI | ApacheHttpSSRF.java:43:41:43:54 | toString(...) | provenance | MaD:297 Sink:MaD:240 |
+| ApacheHttpSSRF.java:44:41:44:43 | uri : URI | ApacheHttpSSRF.java:44:41:44:54 | toString(...) | provenance | MaD:297 Sink:MaD:241 |
+| ApacheHttpSSRF.java:46:77:46:79 | uri : URI | ApacheHttpSSRF.java:46:77:46:90 | toString(...) : String | provenance | MaD:297 |
+| ApacheHttpSSRF.java:46:77:46:90 | toString(...) : String | ApacheHttpSSRF.java:46:49:46:97 | new BasicRequestLine(...) | provenance | MaD:308 Sink:MaD:236 |
+| ApacheHttpSSRF.java:47:56:47:58 | uri : URI | ApacheHttpSSRF.java:47:56:47:69 | toString(...) | provenance | MaD:297 Sink:MaD:237 |
+| ApacheHttpSSRF.java:48:56:48:58 | uri : URI | ApacheHttpSSRF.java:48:56:48:69 | toString(...) | provenance | MaD:297 Sink:MaD:238 |
+| ApacheHttpSSRFVersion5.java:41:30:41:56 | getParameter(...) : String | ApacheHttpSSRFVersion5.java:42:31:42:37 | uriSink : String | provenance | Src:MaD:286  |
 | ApacheHttpSSRFVersion5.java:42:23:42:38 | new URI(...) : URI | ApacheHttpSSRFVersion5.java:49:54:49:56 | uri : URI | provenance |  |
 | ApacheHttpSSRFVersion5.java:42:23:42:38 | new URI(...) : URI | ApacheHttpSSRFVersion5.java:50:54:50:56 | uri | provenance | Sink:MaD:40 |
 | ApacheHttpSSRFVersion5.java:42:23:42:38 | new URI(...) : URI | ApacheHttpSSRFVersion5.java:51:48:51:50 | uri : URI | provenance |  |
@@ -501,8 +503,8 @@ edges
 | ApacheHttpSSRFVersion5.java:42:23:42:38 | new URI(...) : URI | ApacheHttpSSRFVersion5.java:167:40:167:42 | uri : URI | provenance |  |
 | ApacheHttpSSRFVersion5.java:42:23:42:38 | new URI(...) : URI | ApacheHttpSSRFVersion5.java:168:40:168:42 | uri | provenance | Sink:MaD:121 |
 | ApacheHttpSSRFVersion5.java:42:31:42:37 | uriSink : String | ApacheHttpSSRFVersion5.java:42:23:42:38 | new URI(...) : URI | provenance | Config |
-| ApacheHttpSSRFVersion5.java:42:31:42:37 | uriSink : String | ApacheHttpSSRFVersion5.java:42:23:42:38 | new URI(...) : URI | provenance | MaD:293 |
-| ApacheHttpSSRFVersion5.java:44:31:44:58 | getParameter(...) : String | ApacheHttpSSRFVersion5.java:45:42:45:49 | hostSink : String | provenance | Src:MaD:285  |
+| ApacheHttpSSRFVersion5.java:42:31:42:37 | uriSink : String | ApacheHttpSSRFVersion5.java:42:23:42:38 | new URI(...) : URI | provenance | MaD:294 |
+| ApacheHttpSSRFVersion5.java:44:31:44:58 | getParameter(...) : String | ApacheHttpSSRFVersion5.java:45:42:45:49 | hostSink : String | provenance | Src:MaD:286  |
 | ApacheHttpSSRFVersion5.java:45:29:45:50 | new HttpHost(...) : HttpHost | ApacheHttpSSRFVersion5.java:48:54:48:57 | host | provenance | Sink:MaD:38 |
 | ApacheHttpSSRFVersion5.java:45:29:45:50 | new HttpHost(...) : HttpHost | ApacheHttpSSRFVersion5.java:54:38:54:41 | host | provenance | Sink:MaD:43 |
 | ApacheHttpSSRFVersion5.java:45:29:45:50 | new HttpHost(...) : HttpHost | ApacheHttpSSRFVersion5.java:58:35:58:38 | host | provenance | Sink:MaD:46 |
@@ -526,38 +528,38 @@ edges
 | ApacheHttpSSRFVersion5.java:45:29:45:50 | new HttpHost(...) : HttpHost | ApacheHttpSSRFVersion5.java:132:36:132:39 | host | provenance | Sink:MaD:100 |
 | ApacheHttpSSRFVersion5.java:45:29:45:50 | new HttpHost(...) : HttpHost | ApacheHttpSSRFVersion5.java:136:38:136:41 | host | provenance | Sink:MaD:103 |
 | ApacheHttpSSRFVersion5.java:45:29:45:50 | new HttpHost(...) : HttpHost | ApacheHttpSSRFVersion5.java:162:52:162:55 | host | provenance | Sink:MaD:204 |
-| ApacheHttpSSRFVersion5.java:45:42:45:49 | hostSink : String | ApacheHttpSSRFVersion5.java:45:29:45:50 | new HttpHost(...) : HttpHost | provenance | MaD:303 |
-| ApacheHttpSSRFVersion5.java:49:54:49:56 | uri : URI | ApacheHttpSSRFVersion5.java:49:54:49:67 | toString(...) | provenance | MaD:295 Sink:MaD:39 |
-| ApacheHttpSSRFVersion5.java:51:48:51:50 | uri : URI | ApacheHttpSSRFVersion5.java:51:48:51:61 | toString(...) | provenance | MaD:295 Sink:MaD:41 |
-| ApacheHttpSSRFVersion5.java:55:38:55:40 | uri : URI | ApacheHttpSSRFVersion5.java:55:38:55:51 | toString(...) | provenance | MaD:295 Sink:MaD:44 |
-| ApacheHttpSSRFVersion5.java:59:35:59:37 | uri : URI | ApacheHttpSSRFVersion5.java:59:35:59:48 | toString(...) | provenance | MaD:295 Sink:MaD:47 |
-| ApacheHttpSSRFVersion5.java:63:36:63:38 | uri : URI | ApacheHttpSSRFVersion5.java:63:36:63:49 | toString(...) | provenance | MaD:295 Sink:MaD:50 |
-| ApacheHttpSSRFVersion5.java:67:39:67:41 | uri : URI | ApacheHttpSSRFVersion5.java:67:39:67:52 | toString(...) | provenance | MaD:295 Sink:MaD:53 |
-| ApacheHttpSSRFVersion5.java:71:37:71:39 | uri : URI | ApacheHttpSSRFVersion5.java:71:37:71:50 | toString(...) | provenance | MaD:295 Sink:MaD:56 |
-| ApacheHttpSSRFVersion5.java:75:36:75:38 | uri : URI | ApacheHttpSSRFVersion5.java:75:36:75:49 | toString(...) | provenance | MaD:295 Sink:MaD:59 |
-| ApacheHttpSSRFVersion5.java:79:35:79:37 | uri : URI | ApacheHttpSSRFVersion5.java:79:35:79:48 | toString(...) | provenance | MaD:295 Sink:MaD:62 |
-| ApacheHttpSSRFVersion5.java:83:37:83:39 | uri : URI | ApacheHttpSSRFVersion5.java:83:37:83:50 | toString(...) | provenance | MaD:295 Sink:MaD:65 |
-| ApacheHttpSSRFVersion5.java:98:48:98:50 | uri : URI | ApacheHttpSSRFVersion5.java:98:48:98:61 | toString(...) | provenance | MaD:295 Sink:MaD:75 |
-| ApacheHttpSSRFVersion5.java:103:55:103:57 | uri : URI | ApacheHttpSSRFVersion5.java:103:55:103:68 | toString(...) | provenance | MaD:295 Sink:MaD:78 |
-| ApacheHttpSSRFVersion5.java:105:49:105:51 | uri : URI | ApacheHttpSSRFVersion5.java:105:49:105:62 | toString(...) | provenance | MaD:295 Sink:MaD:80 |
-| ApacheHttpSSRFVersion5.java:109:39:109:41 | uri : URI | ApacheHttpSSRFVersion5.java:109:39:109:52 | toString(...) | provenance | MaD:295 Sink:MaD:83 |
-| ApacheHttpSSRFVersion5.java:113:36:113:38 | uri : URI | ApacheHttpSSRFVersion5.java:113:36:113:49 | toString(...) | provenance | MaD:295 Sink:MaD:86 |
-| ApacheHttpSSRFVersion5.java:117:37:117:39 | uri : URI | ApacheHttpSSRFVersion5.java:117:37:117:50 | toString(...) | provenance | MaD:295 Sink:MaD:89 |
-| ApacheHttpSSRFVersion5.java:121:40:121:42 | uri : URI | ApacheHttpSSRFVersion5.java:121:40:121:53 | toString(...) | provenance | MaD:295 Sink:MaD:92 |
-| ApacheHttpSSRFVersion5.java:125:38:125:40 | uri : URI | ApacheHttpSSRFVersion5.java:125:38:125:51 | toString(...) | provenance | MaD:295 Sink:MaD:95 |
-| ApacheHttpSSRFVersion5.java:129:37:129:39 | uri : URI | ApacheHttpSSRFVersion5.java:129:37:129:50 | toString(...) | provenance | MaD:295 Sink:MaD:98 |
-| ApacheHttpSSRFVersion5.java:133:36:133:38 | uri : URI | ApacheHttpSSRFVersion5.java:133:36:133:49 | toString(...) | provenance | MaD:295 Sink:MaD:101 |
-| ApacheHttpSSRFVersion5.java:137:38:137:40 | uri : URI | ApacheHttpSSRFVersion5.java:137:38:137:51 | toString(...) | provenance | MaD:295 Sink:MaD:104 |
-| ApacheHttpSSRFVersion5.java:141:41:141:43 | uri : URI | ApacheHttpSSRFVersion5.java:141:41:141:54 | toString(...) | provenance | MaD:295 Sink:MaD:106 |
-| ApacheHttpSSRFVersion5.java:144:38:144:40 | uri : URI | ApacheHttpSSRFVersion5.java:144:38:144:51 | toString(...) | provenance | MaD:295 Sink:MaD:108 |
-| ApacheHttpSSRFVersion5.java:147:39:147:41 | uri : URI | ApacheHttpSSRFVersion5.java:147:39:147:52 | toString(...) | provenance | MaD:295 Sink:MaD:110 |
-| ApacheHttpSSRFVersion5.java:150:42:150:44 | uri : URI | ApacheHttpSSRFVersion5.java:150:42:150:55 | toString(...) | provenance | MaD:295 Sink:MaD:112 |
-| ApacheHttpSSRFVersion5.java:153:40:153:42 | uri : URI | ApacheHttpSSRFVersion5.java:153:40:153:53 | toString(...) | provenance | MaD:295 Sink:MaD:114 |
-| ApacheHttpSSRFVersion5.java:156:39:156:41 | uri : URI | ApacheHttpSSRFVersion5.java:156:39:156:52 | toString(...) | provenance | MaD:295 Sink:MaD:116 |
-| ApacheHttpSSRFVersion5.java:159:38:159:40 | uri : URI | ApacheHttpSSRFVersion5.java:159:38:159:51 | toString(...) | provenance | MaD:295 Sink:MaD:118 |
-| ApacheHttpSSRFVersion5.java:164:47:164:49 | uri : URI | ApacheHttpSSRFVersion5.java:164:47:164:60 | toString(...) | provenance | MaD:295 Sink:MaD:205 |
-| ApacheHttpSSRFVersion5.java:167:40:167:42 | uri : URI | ApacheHttpSSRFVersion5.java:167:40:167:53 | toString(...) | provenance | MaD:295 Sink:MaD:120 |
-| ApacheHttpSSRFVersion5.java:180:30:180:56 | getParameter(...) : String | ApacheHttpSSRFVersion5.java:181:31:181:37 | uriSink : String | provenance | Src:MaD:285  |
+| ApacheHttpSSRFVersion5.java:45:42:45:49 | hostSink : String | ApacheHttpSSRFVersion5.java:45:29:45:50 | new HttpHost(...) : HttpHost | provenance | MaD:305 |
+| ApacheHttpSSRFVersion5.java:49:54:49:56 | uri : URI | ApacheHttpSSRFVersion5.java:49:54:49:67 | toString(...) | provenance | MaD:297 Sink:MaD:39 |
+| ApacheHttpSSRFVersion5.java:51:48:51:50 | uri : URI | ApacheHttpSSRFVersion5.java:51:48:51:61 | toString(...) | provenance | MaD:297 Sink:MaD:41 |
+| ApacheHttpSSRFVersion5.java:55:38:55:40 | uri : URI | ApacheHttpSSRFVersion5.java:55:38:55:51 | toString(...) | provenance | MaD:297 Sink:MaD:44 |
+| ApacheHttpSSRFVersion5.java:59:35:59:37 | uri : URI | ApacheHttpSSRFVersion5.java:59:35:59:48 | toString(...) | provenance | MaD:297 Sink:MaD:47 |
+| ApacheHttpSSRFVersion5.java:63:36:63:38 | uri : URI | ApacheHttpSSRFVersion5.java:63:36:63:49 | toString(...) | provenance | MaD:297 Sink:MaD:50 |
+| ApacheHttpSSRFVersion5.java:67:39:67:41 | uri : URI | ApacheHttpSSRFVersion5.java:67:39:67:52 | toString(...) | provenance | MaD:297 Sink:MaD:53 |
+| ApacheHttpSSRFVersion5.java:71:37:71:39 | uri : URI | ApacheHttpSSRFVersion5.java:71:37:71:50 | toString(...) | provenance | MaD:297 Sink:MaD:56 |
+| ApacheHttpSSRFVersion5.java:75:36:75:38 | uri : URI | ApacheHttpSSRFVersion5.java:75:36:75:49 | toString(...) | provenance | MaD:297 Sink:MaD:59 |
+| ApacheHttpSSRFVersion5.java:79:35:79:37 | uri : URI | ApacheHttpSSRFVersion5.java:79:35:79:48 | toString(...) | provenance | MaD:297 Sink:MaD:62 |
+| ApacheHttpSSRFVersion5.java:83:37:83:39 | uri : URI | ApacheHttpSSRFVersion5.java:83:37:83:50 | toString(...) | provenance | MaD:297 Sink:MaD:65 |
+| ApacheHttpSSRFVersion5.java:98:48:98:50 | uri : URI | ApacheHttpSSRFVersion5.java:98:48:98:61 | toString(...) | provenance | MaD:297 Sink:MaD:75 |
+| ApacheHttpSSRFVersion5.java:103:55:103:57 | uri : URI | ApacheHttpSSRFVersion5.java:103:55:103:68 | toString(...) | provenance | MaD:297 Sink:MaD:78 |
+| ApacheHttpSSRFVersion5.java:105:49:105:51 | uri : URI | ApacheHttpSSRFVersion5.java:105:49:105:62 | toString(...) | provenance | MaD:297 Sink:MaD:80 |
+| ApacheHttpSSRFVersion5.java:109:39:109:41 | uri : URI | ApacheHttpSSRFVersion5.java:109:39:109:52 | toString(...) | provenance | MaD:297 Sink:MaD:83 |
+| ApacheHttpSSRFVersion5.java:113:36:113:38 | uri : URI | ApacheHttpSSRFVersion5.java:113:36:113:49 | toString(...) | provenance | MaD:297 Sink:MaD:86 |
+| ApacheHttpSSRFVersion5.java:117:37:117:39 | uri : URI | ApacheHttpSSRFVersion5.java:117:37:117:50 | toString(...) | provenance | MaD:297 Sink:MaD:89 |
+| ApacheHttpSSRFVersion5.java:121:40:121:42 | uri : URI | ApacheHttpSSRFVersion5.java:121:40:121:53 | toString(...) | provenance | MaD:297 Sink:MaD:92 |
+| ApacheHttpSSRFVersion5.java:125:38:125:40 | uri : URI | ApacheHttpSSRFVersion5.java:125:38:125:51 | toString(...) | provenance | MaD:297 Sink:MaD:95 |
+| ApacheHttpSSRFVersion5.java:129:37:129:39 | uri : URI | ApacheHttpSSRFVersion5.java:129:37:129:50 | toString(...) | provenance | MaD:297 Sink:MaD:98 |
+| ApacheHttpSSRFVersion5.java:133:36:133:38 | uri : URI | ApacheHttpSSRFVersion5.java:133:36:133:49 | toString(...) | provenance | MaD:297 Sink:MaD:101 |
+| ApacheHttpSSRFVersion5.java:137:38:137:40 | uri : URI | ApacheHttpSSRFVersion5.java:137:38:137:51 | toString(...) | provenance | MaD:297 Sink:MaD:104 |
+| ApacheHttpSSRFVersion5.java:141:41:141:43 | uri : URI | ApacheHttpSSRFVersion5.java:141:41:141:54 | toString(...) | provenance | MaD:297 Sink:MaD:106 |
+| ApacheHttpSSRFVersion5.java:144:38:144:40 | uri : URI | ApacheHttpSSRFVersion5.java:144:38:144:51 | toString(...) | provenance | MaD:297 Sink:MaD:108 |
+| ApacheHttpSSRFVersion5.java:147:39:147:41 | uri : URI | ApacheHttpSSRFVersion5.java:147:39:147:52 | toString(...) | provenance | MaD:297 Sink:MaD:110 |
+| ApacheHttpSSRFVersion5.java:150:42:150:44 | uri : URI | ApacheHttpSSRFVersion5.java:150:42:150:55 | toString(...) | provenance | MaD:297 Sink:MaD:112 |
+| ApacheHttpSSRFVersion5.java:153:40:153:42 | uri : URI | ApacheHttpSSRFVersion5.java:153:40:153:53 | toString(...) | provenance | MaD:297 Sink:MaD:114 |
+| ApacheHttpSSRFVersion5.java:156:39:156:41 | uri : URI | ApacheHttpSSRFVersion5.java:156:39:156:52 | toString(...) | provenance | MaD:297 Sink:MaD:116 |
+| ApacheHttpSSRFVersion5.java:159:38:159:40 | uri : URI | ApacheHttpSSRFVersion5.java:159:38:159:51 | toString(...) | provenance | MaD:297 Sink:MaD:118 |
+| ApacheHttpSSRFVersion5.java:164:47:164:49 | uri : URI | ApacheHttpSSRFVersion5.java:164:47:164:60 | toString(...) | provenance | MaD:297 Sink:MaD:205 |
+| ApacheHttpSSRFVersion5.java:167:40:167:42 | uri : URI | ApacheHttpSSRFVersion5.java:167:40:167:53 | toString(...) | provenance | MaD:297 Sink:MaD:120 |
+| ApacheHttpSSRFVersion5.java:180:30:180:56 | getParameter(...) : String | ApacheHttpSSRFVersion5.java:181:31:181:37 | uriSink : String | provenance | Src:MaD:286  |
 | ApacheHttpSSRFVersion5.java:181:23:181:38 | new URI(...) : URI | ApacheHttpSSRFVersion5.java:184:56:184:58 | uri : URI | provenance |  |
 | ApacheHttpSSRFVersion5.java:181:23:181:38 | new URI(...) : URI | ApacheHttpSSRFVersion5.java:185:56:185:58 | uri | provenance | Sink:MaD:123 |
 | ApacheHttpSSRFVersion5.java:181:23:181:38 | new URI(...) : URI | ApacheHttpSSRFVersion5.java:186:50:186:52 | uri : URI | provenance |  |
@@ -596,26 +598,26 @@ edges
 | ApacheHttpSSRFVersion5.java:181:23:181:38 | new URI(...) : URI | ApacheHttpSSRFVersion5.java:236:27:236:29 | uri | provenance | Sink:MaD:157 |
 | ApacheHttpSSRFVersion5.java:181:23:181:38 | new URI(...) : URI | ApacheHttpSSRFVersion5.java:239:46:239:48 | uri | provenance | Sink:MaD:158 |
 | ApacheHttpSSRFVersion5.java:181:31:181:37 | uriSink : String | ApacheHttpSSRFVersion5.java:181:23:181:38 | new URI(...) : URI | provenance | Config |
-| ApacheHttpSSRFVersion5.java:181:31:181:37 | uriSink : String | ApacheHttpSSRFVersion5.java:181:23:181:38 | new URI(...) : URI | provenance | MaD:293 |
-| ApacheHttpSSRFVersion5.java:184:56:184:58 | uri : URI | ApacheHttpSSRFVersion5.java:184:56:184:69 | toString(...) | provenance | MaD:295 Sink:MaD:122 |
-| ApacheHttpSSRFVersion5.java:186:50:186:52 | uri : URI | ApacheHttpSSRFVersion5.java:186:50:186:63 | toString(...) | provenance | MaD:295 Sink:MaD:124 |
-| ApacheHttpSSRFVersion5.java:189:40:189:42 | uri : URI | ApacheHttpSSRFVersion5.java:189:40:189:53 | toString(...) | provenance | MaD:295 Sink:MaD:126 |
-| ApacheHttpSSRFVersion5.java:192:37:192:39 | uri : URI | ApacheHttpSSRFVersion5.java:192:37:192:50 | toString(...) | provenance | MaD:295 Sink:MaD:128 |
-| ApacheHttpSSRFVersion5.java:195:38:195:40 | uri : URI | ApacheHttpSSRFVersion5.java:195:38:195:51 | toString(...) | provenance | MaD:295 Sink:MaD:130 |
-| ApacheHttpSSRFVersion5.java:198:41:198:43 | uri : URI | ApacheHttpSSRFVersion5.java:198:41:198:54 | toString(...) | provenance | MaD:295 Sink:MaD:132 |
-| ApacheHttpSSRFVersion5.java:201:39:201:41 | uri : URI | ApacheHttpSSRFVersion5.java:201:39:201:52 | toString(...) | provenance | MaD:295 Sink:MaD:134 |
-| ApacheHttpSSRFVersion5.java:204:38:204:40 | uri : URI | ApacheHttpSSRFVersion5.java:204:38:204:51 | toString(...) | provenance | MaD:295 Sink:MaD:136 |
-| ApacheHttpSSRFVersion5.java:207:37:207:39 | uri : URI | ApacheHttpSSRFVersion5.java:207:37:207:50 | toString(...) | provenance | MaD:295 Sink:MaD:138 |
-| ApacheHttpSSRFVersion5.java:210:39:210:41 | uri : URI | ApacheHttpSSRFVersion5.java:210:39:210:52 | toString(...) | provenance | MaD:295 Sink:MaD:140 |
-| ApacheHttpSSRFVersion5.java:214:28:214:30 | uri : URI | ApacheHttpSSRFVersion5.java:214:28:214:41 | toString(...) | provenance | MaD:295 Sink:MaD:142 |
-| ApacheHttpSSRFVersion5.java:217:25:217:27 | uri : URI | ApacheHttpSSRFVersion5.java:217:25:217:38 | toString(...) | provenance | MaD:295 Sink:MaD:144 |
-| ApacheHttpSSRFVersion5.java:220:26:220:28 | uri : URI | ApacheHttpSSRFVersion5.java:220:26:220:39 | toString(...) | provenance | MaD:295 Sink:MaD:146 |
-| ApacheHttpSSRFVersion5.java:223:29:223:31 | uri : URI | ApacheHttpSSRFVersion5.java:223:29:223:42 | toString(...) | provenance | MaD:295 Sink:MaD:148 |
-| ApacheHttpSSRFVersion5.java:226:27:226:29 | uri : URI | ApacheHttpSSRFVersion5.java:226:27:226:40 | toString(...) | provenance | MaD:295 Sink:MaD:150 |
-| ApacheHttpSSRFVersion5.java:229:26:229:28 | uri : URI | ApacheHttpSSRFVersion5.java:229:26:229:39 | toString(...) | provenance | MaD:295 Sink:MaD:152 |
-| ApacheHttpSSRFVersion5.java:232:25:232:27 | uri : URI | ApacheHttpSSRFVersion5.java:232:25:232:38 | toString(...) | provenance | MaD:295 Sink:MaD:154 |
-| ApacheHttpSSRFVersion5.java:235:27:235:29 | uri : URI | ApacheHttpSSRFVersion5.java:235:27:235:40 | toString(...) | provenance | MaD:295 Sink:MaD:156 |
-| ApacheHttpSSRFVersion5.java:251:30:251:56 | getParameter(...) : String | ApacheHttpSSRFVersion5.java:252:31:252:37 | uriSink : String | provenance | Src:MaD:285  |
+| ApacheHttpSSRFVersion5.java:181:31:181:37 | uriSink : String | ApacheHttpSSRFVersion5.java:181:23:181:38 | new URI(...) : URI | provenance | MaD:294 |
+| ApacheHttpSSRFVersion5.java:184:56:184:58 | uri : URI | ApacheHttpSSRFVersion5.java:184:56:184:69 | toString(...) | provenance | MaD:297 Sink:MaD:122 |
+| ApacheHttpSSRFVersion5.java:186:50:186:52 | uri : URI | ApacheHttpSSRFVersion5.java:186:50:186:63 | toString(...) | provenance | MaD:297 Sink:MaD:124 |
+| ApacheHttpSSRFVersion5.java:189:40:189:42 | uri : URI | ApacheHttpSSRFVersion5.java:189:40:189:53 | toString(...) | provenance | MaD:297 Sink:MaD:126 |
+| ApacheHttpSSRFVersion5.java:192:37:192:39 | uri : URI | ApacheHttpSSRFVersion5.java:192:37:192:50 | toString(...) | provenance | MaD:297 Sink:MaD:128 |
+| ApacheHttpSSRFVersion5.java:195:38:195:40 | uri : URI | ApacheHttpSSRFVersion5.java:195:38:195:51 | toString(...) | provenance | MaD:297 Sink:MaD:130 |
+| ApacheHttpSSRFVersion5.java:198:41:198:43 | uri : URI | ApacheHttpSSRFVersion5.java:198:41:198:54 | toString(...) | provenance | MaD:297 Sink:MaD:132 |
+| ApacheHttpSSRFVersion5.java:201:39:201:41 | uri : URI | ApacheHttpSSRFVersion5.java:201:39:201:52 | toString(...) | provenance | MaD:297 Sink:MaD:134 |
+| ApacheHttpSSRFVersion5.java:204:38:204:40 | uri : URI | ApacheHttpSSRFVersion5.java:204:38:204:51 | toString(...) | provenance | MaD:297 Sink:MaD:136 |
+| ApacheHttpSSRFVersion5.java:207:37:207:39 | uri : URI | ApacheHttpSSRFVersion5.java:207:37:207:50 | toString(...) | provenance | MaD:297 Sink:MaD:138 |
+| ApacheHttpSSRFVersion5.java:210:39:210:41 | uri : URI | ApacheHttpSSRFVersion5.java:210:39:210:52 | toString(...) | provenance | MaD:297 Sink:MaD:140 |
+| ApacheHttpSSRFVersion5.java:214:28:214:30 | uri : URI | ApacheHttpSSRFVersion5.java:214:28:214:41 | toString(...) | provenance | MaD:297 Sink:MaD:142 |
+| ApacheHttpSSRFVersion5.java:217:25:217:27 | uri : URI | ApacheHttpSSRFVersion5.java:217:25:217:38 | toString(...) | provenance | MaD:297 Sink:MaD:144 |
+| ApacheHttpSSRFVersion5.java:220:26:220:28 | uri : URI | ApacheHttpSSRFVersion5.java:220:26:220:39 | toString(...) | provenance | MaD:297 Sink:MaD:146 |
+| ApacheHttpSSRFVersion5.java:223:29:223:31 | uri : URI | ApacheHttpSSRFVersion5.java:223:29:223:42 | toString(...) | provenance | MaD:297 Sink:MaD:148 |
+| ApacheHttpSSRFVersion5.java:226:27:226:29 | uri : URI | ApacheHttpSSRFVersion5.java:226:27:226:40 | toString(...) | provenance | MaD:297 Sink:MaD:150 |
+| ApacheHttpSSRFVersion5.java:229:26:229:28 | uri : URI | ApacheHttpSSRFVersion5.java:229:26:229:39 | toString(...) | provenance | MaD:297 Sink:MaD:152 |
+| ApacheHttpSSRFVersion5.java:232:25:232:27 | uri : URI | ApacheHttpSSRFVersion5.java:232:25:232:38 | toString(...) | provenance | MaD:297 Sink:MaD:154 |
+| ApacheHttpSSRFVersion5.java:235:27:235:29 | uri : URI | ApacheHttpSSRFVersion5.java:235:27:235:40 | toString(...) | provenance | MaD:297 Sink:MaD:156 |
+| ApacheHttpSSRFVersion5.java:251:30:251:56 | getParameter(...) : String | ApacheHttpSSRFVersion5.java:252:31:252:37 | uriSink : String | provenance | Src:MaD:286  |
 | ApacheHttpSSRFVersion5.java:252:23:252:38 | new URI(...) : URI | ApacheHttpSSRFVersion5.java:255:44:255:46 | uri | provenance | Sink:MaD:159 |
 | ApacheHttpSSRFVersion5.java:252:23:252:38 | new URI(...) : URI | ApacheHttpSSRFVersion5.java:256:38:256:40 | uri : URI | provenance |  |
 | ApacheHttpSSRFVersion5.java:252:23:252:38 | new URI(...) : URI | ApacheHttpSSRFVersion5.java:257:38:257:40 | uri | provenance | Sink:MaD:161 |
@@ -636,30 +638,30 @@ edges
 | ApacheHttpSSRFVersion5.java:252:23:252:38 | new URI(...) : URI | ApacheHttpSSRFVersion5.java:280:27:280:29 | uri : URI | provenance |  |
 | ApacheHttpSSRFVersion5.java:252:23:252:38 | new URI(...) : URI | ApacheHttpSSRFVersion5.java:281:27:281:29 | uri | provenance | Sink:MaD:177 |
 | ApacheHttpSSRFVersion5.java:252:31:252:37 | uriSink : String | ApacheHttpSSRFVersion5.java:252:23:252:38 | new URI(...) : URI | provenance | Config |
-| ApacheHttpSSRFVersion5.java:252:31:252:37 | uriSink : String | ApacheHttpSSRFVersion5.java:252:23:252:38 | new URI(...) : URI | provenance | MaD:293 |
-| ApacheHttpSSRFVersion5.java:256:38:256:40 | uri : URI | ApacheHttpSSRFVersion5.java:256:38:256:51 | toString(...) | provenance | MaD:295 Sink:MaD:160 |
-| ApacheHttpSSRFVersion5.java:259:28:259:30 | uri : URI | ApacheHttpSSRFVersion5.java:259:28:259:41 | toString(...) | provenance | MaD:295 Sink:MaD:162 |
-| ApacheHttpSSRFVersion5.java:262:25:262:27 | uri : URI | ApacheHttpSSRFVersion5.java:262:25:262:38 | toString(...) | provenance | MaD:295 Sink:MaD:164 |
-| ApacheHttpSSRFVersion5.java:265:26:265:28 | uri : URI | ApacheHttpSSRFVersion5.java:265:26:265:39 | toString(...) | provenance | MaD:295 Sink:MaD:166 |
-| ApacheHttpSSRFVersion5.java:268:29:268:31 | uri : URI | ApacheHttpSSRFVersion5.java:268:29:268:42 | toString(...) | provenance | MaD:295 Sink:MaD:168 |
-| ApacheHttpSSRFVersion5.java:271:27:271:29 | uri : URI | ApacheHttpSSRFVersion5.java:271:27:271:40 | toString(...) | provenance | MaD:295 Sink:MaD:170 |
-| ApacheHttpSSRFVersion5.java:274:26:274:28 | uri : URI | ApacheHttpSSRFVersion5.java:274:26:274:39 | toString(...) | provenance | MaD:295 Sink:MaD:172 |
-| ApacheHttpSSRFVersion5.java:277:25:277:27 | uri : URI | ApacheHttpSSRFVersion5.java:277:25:277:38 | toString(...) | provenance | MaD:295 Sink:MaD:174 |
-| ApacheHttpSSRFVersion5.java:280:27:280:29 | uri : URI | ApacheHttpSSRFVersion5.java:280:27:280:40 | toString(...) | provenance | MaD:295 Sink:MaD:176 |
-| ApacheHttpSSRFVersion5.java:295:30:295:56 | getParameter(...) : String | ApacheHttpSSRFVersion5.java:296:31:296:37 | uriSink : String | provenance | Src:MaD:285  |
+| ApacheHttpSSRFVersion5.java:252:31:252:37 | uriSink : String | ApacheHttpSSRFVersion5.java:252:23:252:38 | new URI(...) : URI | provenance | MaD:294 |
+| ApacheHttpSSRFVersion5.java:256:38:256:40 | uri : URI | ApacheHttpSSRFVersion5.java:256:38:256:51 | toString(...) | provenance | MaD:297 Sink:MaD:160 |
+| ApacheHttpSSRFVersion5.java:259:28:259:30 | uri : URI | ApacheHttpSSRFVersion5.java:259:28:259:41 | toString(...) | provenance | MaD:297 Sink:MaD:162 |
+| ApacheHttpSSRFVersion5.java:262:25:262:27 | uri : URI | ApacheHttpSSRFVersion5.java:262:25:262:38 | toString(...) | provenance | MaD:297 Sink:MaD:164 |
+| ApacheHttpSSRFVersion5.java:265:26:265:28 | uri : URI | ApacheHttpSSRFVersion5.java:265:26:265:39 | toString(...) | provenance | MaD:297 Sink:MaD:166 |
+| ApacheHttpSSRFVersion5.java:268:29:268:31 | uri : URI | ApacheHttpSSRFVersion5.java:268:29:268:42 | toString(...) | provenance | MaD:297 Sink:MaD:168 |
+| ApacheHttpSSRFVersion5.java:271:27:271:29 | uri : URI | ApacheHttpSSRFVersion5.java:271:27:271:40 | toString(...) | provenance | MaD:297 Sink:MaD:170 |
+| ApacheHttpSSRFVersion5.java:274:26:274:28 | uri : URI | ApacheHttpSSRFVersion5.java:274:26:274:39 | toString(...) | provenance | MaD:297 Sink:MaD:172 |
+| ApacheHttpSSRFVersion5.java:277:25:277:27 | uri : URI | ApacheHttpSSRFVersion5.java:277:25:277:38 | toString(...) | provenance | MaD:297 Sink:MaD:174 |
+| ApacheHttpSSRFVersion5.java:280:27:280:29 | uri : URI | ApacheHttpSSRFVersion5.java:280:27:280:40 | toString(...) | provenance | MaD:297 Sink:MaD:176 |
+| ApacheHttpSSRFVersion5.java:295:30:295:56 | getParameter(...) : String | ApacheHttpSSRFVersion5.java:296:31:296:37 | uriSink : String | provenance | Src:MaD:286  |
 | ApacheHttpSSRFVersion5.java:296:23:296:38 | new URI(...) : URI | ApacheHttpSSRFVersion5.java:308:60:308:62 | uri : URI | provenance |  |
 | ApacheHttpSSRFVersion5.java:296:23:296:38 | new URI(...) : URI | ApacheHttpSSRFVersion5.java:309:60:309:62 | uri | provenance | Sink:MaD:209 |
 | ApacheHttpSSRFVersion5.java:296:23:296:38 | new URI(...) : URI | ApacheHttpSSRFVersion5.java:313:53:313:55 | uri : URI | provenance |  |
 | ApacheHttpSSRFVersion5.java:296:23:296:38 | new URI(...) : URI | ApacheHttpSSRFVersion5.java:314:53:314:55 | uri | provenance | Sink:MaD:209 |
 | ApacheHttpSSRFVersion5.java:296:31:296:37 | uriSink : String | ApacheHttpSSRFVersion5.java:296:23:296:38 | new URI(...) : URI | provenance | Config |
-| ApacheHttpSSRFVersion5.java:296:31:296:37 | uriSink : String | ApacheHttpSSRFVersion5.java:296:23:296:38 | new URI(...) : URI | provenance | MaD:293 |
-| ApacheHttpSSRFVersion5.java:298:31:298:58 | getParameter(...) : String | ApacheHttpSSRFVersion5.java:299:42:299:49 | hostSink : String | provenance | Src:MaD:285  |
+| ApacheHttpSSRFVersion5.java:296:31:296:37 | uriSink : String | ApacheHttpSSRFVersion5.java:296:23:296:38 | new URI(...) : URI | provenance | MaD:294 |
+| ApacheHttpSSRFVersion5.java:298:31:298:58 | getParameter(...) : String | ApacheHttpSSRFVersion5.java:299:42:299:49 | hostSink : String | provenance | Src:MaD:286  |
 | ApacheHttpSSRFVersion5.java:299:29:299:50 | new HttpHost(...) : HttpHost | ApacheHttpSSRFVersion5.java:303:34:303:37 | host | provenance | Sink:MaD:178 |
 | ApacheHttpSSRFVersion5.java:299:29:299:50 | new HttpHost(...) : HttpHost | ApacheHttpSSRFVersion5.java:304:34:304:37 | host | provenance | Sink:MaD:179 |
-| ApacheHttpSSRFVersion5.java:299:42:299:49 | hostSink : String | ApacheHttpSSRFVersion5.java:299:29:299:50 | new HttpHost(...) : HttpHost | provenance | MaD:303 |
-| ApacheHttpSSRFVersion5.java:308:60:308:62 | uri : URI | ApacheHttpSSRFVersion5.java:308:60:308:73 | toString(...) | provenance | MaD:295 Sink:MaD:208 |
-| ApacheHttpSSRFVersion5.java:313:53:313:55 | uri : URI | ApacheHttpSSRFVersion5.java:313:53:313:66 | toString(...) | provenance | MaD:295 Sink:MaD:208 |
-| ApacheHttpSSRFVersion5.java:326:30:326:56 | getParameter(...) : String | ApacheHttpSSRFVersion5.java:327:31:327:37 | uriSink : String | provenance | Src:MaD:285  |
+| ApacheHttpSSRFVersion5.java:299:42:299:49 | hostSink : String | ApacheHttpSSRFVersion5.java:299:29:299:50 | new HttpHost(...) : HttpHost | provenance | MaD:305 |
+| ApacheHttpSSRFVersion5.java:308:60:308:62 | uri : URI | ApacheHttpSSRFVersion5.java:308:60:308:73 | toString(...) | provenance | MaD:297 Sink:MaD:208 |
+| ApacheHttpSSRFVersion5.java:313:53:313:55 | uri : URI | ApacheHttpSSRFVersion5.java:313:53:313:66 | toString(...) | provenance | MaD:297 Sink:MaD:208 |
+| ApacheHttpSSRFVersion5.java:326:30:326:56 | getParameter(...) : String | ApacheHttpSSRFVersion5.java:327:31:327:37 | uriSink : String | provenance | Src:MaD:286  |
 | ApacheHttpSSRFVersion5.java:327:23:327:38 | new URI(...) : URI | ApacheHttpSSRFVersion5.java:333:42:333:44 | uri : URI | provenance |  |
 | ApacheHttpSSRFVersion5.java:327:23:327:38 | new URI(...) : URI | ApacheHttpSSRFVersion5.java:334:42:334:44 | uri | provenance | Sink:MaD:181 |
 | ApacheHttpSSRFVersion5.java:327:23:327:38 | new URI(...) : URI | ApacheHttpSSRFVersion5.java:336:39:336:41 | uri : URI | provenance |  |
@@ -679,20 +681,20 @@ edges
 | ApacheHttpSSRFVersion5.java:327:23:327:38 | new URI(...) : URI | ApacheHttpSSRFVersion5.java:359:41:359:43 | uri : URI | provenance |  |
 | ApacheHttpSSRFVersion5.java:327:23:327:38 | new URI(...) : URI | ApacheHttpSSRFVersion5.java:360:41:360:43 | uri | provenance | Sink:MaD:195 |
 | ApacheHttpSSRFVersion5.java:327:31:327:37 | uriSink : String | ApacheHttpSSRFVersion5.java:327:23:327:38 | new URI(...) : URI | provenance | Config |
-| ApacheHttpSSRFVersion5.java:327:31:327:37 | uriSink : String | ApacheHttpSSRFVersion5.java:327:23:327:38 | new URI(...) : URI | provenance | MaD:293 |
-| ApacheHttpSSRFVersion5.java:329:31:329:58 | getParameter(...) : String | ApacheHttpSSRFVersion5.java:330:42:330:49 | hostSink : String | provenance | Src:MaD:285  |
+| ApacheHttpSSRFVersion5.java:327:31:327:37 | uriSink : String | ApacheHttpSSRFVersion5.java:327:23:327:38 | new URI(...) : URI | provenance | MaD:294 |
+| ApacheHttpSSRFVersion5.java:329:31:329:58 | getParameter(...) : String | ApacheHttpSSRFVersion5.java:330:42:330:49 | hostSink : String | provenance | Src:MaD:286  |
 | ApacheHttpSSRFVersion5.java:330:29:330:50 | new HttpHost(...) : HttpHost | ApacheHttpSSRFVersion5.java:354:53:354:56 | host | provenance | Sink:MaD:204 |
-| ApacheHttpSSRFVersion5.java:330:42:330:49 | hostSink : String | ApacheHttpSSRFVersion5.java:330:29:330:50 | new HttpHost(...) : HttpHost | provenance | MaD:303 |
-| ApacheHttpSSRFVersion5.java:333:42:333:44 | uri : URI | ApacheHttpSSRFVersion5.java:333:42:333:55 | toString(...) | provenance | MaD:295 Sink:MaD:180 |
-| ApacheHttpSSRFVersion5.java:336:39:336:41 | uri : URI | ApacheHttpSSRFVersion5.java:336:39:336:52 | toString(...) | provenance | MaD:295 Sink:MaD:182 |
-| ApacheHttpSSRFVersion5.java:339:40:339:42 | uri : URI | ApacheHttpSSRFVersion5.java:339:40:339:53 | toString(...) | provenance | MaD:295 Sink:MaD:184 |
-| ApacheHttpSSRFVersion5.java:342:43:342:45 | uri : URI | ApacheHttpSSRFVersion5.java:342:43:342:56 | toString(...) | provenance | MaD:295 Sink:MaD:186 |
-| ApacheHttpSSRFVersion5.java:345:41:345:43 | uri : URI | ApacheHttpSSRFVersion5.java:345:41:345:54 | toString(...) | provenance | MaD:295 Sink:MaD:188 |
-| ApacheHttpSSRFVersion5.java:348:40:348:42 | uri : URI | ApacheHttpSSRFVersion5.java:348:40:348:53 | toString(...) | provenance | MaD:295 Sink:MaD:190 |
-| ApacheHttpSSRFVersion5.java:351:39:351:41 | uri : URI | ApacheHttpSSRFVersion5.java:351:39:351:52 | toString(...) | provenance | MaD:295 Sink:MaD:192 |
-| ApacheHttpSSRFVersion5.java:356:48:356:50 | uri : URI | ApacheHttpSSRFVersion5.java:356:48:356:61 | toString(...) | provenance | MaD:295 Sink:MaD:205 |
-| ApacheHttpSSRFVersion5.java:359:41:359:43 | uri : URI | ApacheHttpSSRFVersion5.java:359:41:359:54 | toString(...) | provenance | MaD:295 Sink:MaD:194 |
-| ApacheHttpSSRFVersion5.java:372:30:372:56 | getParameter(...) : String | ApacheHttpSSRFVersion5.java:373:31:373:37 | uriSink : String | provenance | Src:MaD:285  |
+| ApacheHttpSSRFVersion5.java:330:42:330:49 | hostSink : String | ApacheHttpSSRFVersion5.java:330:29:330:50 | new HttpHost(...) : HttpHost | provenance | MaD:305 |
+| ApacheHttpSSRFVersion5.java:333:42:333:44 | uri : URI | ApacheHttpSSRFVersion5.java:333:42:333:55 | toString(...) | provenance | MaD:297 Sink:MaD:180 |
+| ApacheHttpSSRFVersion5.java:336:39:336:41 | uri : URI | ApacheHttpSSRFVersion5.java:336:39:336:52 | toString(...) | provenance | MaD:297 Sink:MaD:182 |
+| ApacheHttpSSRFVersion5.java:339:40:339:42 | uri : URI | ApacheHttpSSRFVersion5.java:339:40:339:53 | toString(...) | provenance | MaD:297 Sink:MaD:184 |
+| ApacheHttpSSRFVersion5.java:342:43:342:45 | uri : URI | ApacheHttpSSRFVersion5.java:342:43:342:56 | toString(...) | provenance | MaD:297 Sink:MaD:186 |
+| ApacheHttpSSRFVersion5.java:345:41:345:43 | uri : URI | ApacheHttpSSRFVersion5.java:345:41:345:54 | toString(...) | provenance | MaD:297 Sink:MaD:188 |
+| ApacheHttpSSRFVersion5.java:348:40:348:42 | uri : URI | ApacheHttpSSRFVersion5.java:348:40:348:53 | toString(...) | provenance | MaD:297 Sink:MaD:190 |
+| ApacheHttpSSRFVersion5.java:351:39:351:41 | uri : URI | ApacheHttpSSRFVersion5.java:351:39:351:52 | toString(...) | provenance | MaD:297 Sink:MaD:192 |
+| ApacheHttpSSRFVersion5.java:356:48:356:50 | uri : URI | ApacheHttpSSRFVersion5.java:356:48:356:61 | toString(...) | provenance | MaD:297 Sink:MaD:205 |
+| ApacheHttpSSRFVersion5.java:359:41:359:43 | uri : URI | ApacheHttpSSRFVersion5.java:359:41:359:54 | toString(...) | provenance | MaD:297 Sink:MaD:194 |
+| ApacheHttpSSRFVersion5.java:372:30:372:56 | getParameter(...) : String | ApacheHttpSSRFVersion5.java:373:31:373:37 | uriSink : String | provenance | Src:MaD:286  |
 | ApacheHttpSSRFVersion5.java:373:23:373:38 | new URI(...) : URI | ApacheHttpSSRFVersion5.java:380:57:380:59 | uri | provenance | Sink:MaD:197 |
 | ApacheHttpSSRFVersion5.java:373:23:373:38 | new URI(...) : URI | ApacheHttpSSRFVersion5.java:382:51:382:53 | uri | provenance | Sink:MaD:199 |
 | ApacheHttpSSRFVersion5.java:373:23:373:38 | new URI(...) : URI | ApacheHttpSSRFVersion5.java:386:50:386:52 | uri | provenance | Sink:MaD:201 |
@@ -700,220 +702,224 @@ edges
 | ApacheHttpSSRFVersion5.java:373:23:373:38 | new URI(...) : URI | ApacheHttpSSRFVersion5.java:390:24:390:26 | uri | provenance | Sink:MaD:207 |
 | ApacheHttpSSRFVersion5.java:373:23:373:38 | new URI(...) : URI | ApacheHttpSSRFVersion5.java:394:24:394:26 | uri | provenance | Sink:MaD:207 |
 | ApacheHttpSSRFVersion5.java:373:31:373:37 | uriSink : String | ApacheHttpSSRFVersion5.java:373:23:373:38 | new URI(...) : URI | provenance | Config |
-| ApacheHttpSSRFVersion5.java:373:31:373:37 | uriSink : String | ApacheHttpSSRFVersion5.java:373:23:373:38 | new URI(...) : URI | provenance | MaD:293 |
-| ApacheHttpSSRFVersion5.java:375:31:375:58 | getParameter(...) : String | ApacheHttpSSRFVersion5.java:376:42:376:49 | hostSink : String | provenance | Src:MaD:285  |
+| ApacheHttpSSRFVersion5.java:373:31:373:37 | uriSink : String | ApacheHttpSSRFVersion5.java:373:23:373:38 | new URI(...) : URI | provenance | MaD:294 |
+| ApacheHttpSSRFVersion5.java:375:31:375:58 | getParameter(...) : String | ApacheHttpSSRFVersion5.java:376:42:376:49 | hostSink : String | provenance | Src:MaD:286  |
 | ApacheHttpSSRFVersion5.java:376:29:376:50 | new HttpHost(...) : HttpHost | ApacheHttpSSRFVersion5.java:379:57:379:60 | host | provenance | Sink:MaD:196 |
 | ApacheHttpSSRFVersion5.java:376:29:376:50 | new HttpHost(...) : HttpHost | ApacheHttpSSRFVersion5.java:381:51:381:54 | host | provenance | Sink:MaD:198 |
 | ApacheHttpSSRFVersion5.java:376:29:376:50 | new HttpHost(...) : HttpHost | ApacheHttpSSRFVersion5.java:385:50:385:53 | host | provenance | Sink:MaD:200 |
 | ApacheHttpSSRFVersion5.java:376:29:376:50 | new HttpHost(...) : HttpHost | ApacheHttpSSRFVersion5.java:387:44:387:47 | host | provenance | Sink:MaD:202 |
-| ApacheHttpSSRFVersion5.java:376:42:376:49 | hostSink : String | ApacheHttpSSRFVersion5.java:376:29:376:50 | new HttpHost(...) : HttpHost | provenance | MaD:303 |
-| JakartaWsSSRF.java:14:22:14:48 | getParameter(...) : String | JakartaWsSSRF.java:15:23:15:25 | url | provenance | Src:MaD:285 Sink:MaD:3 |
-| JavaNetHttpSSRF.java:25:27:25:53 | getParameter(...) : String | JavaNetHttpSSRF.java:26:31:26:34 | sink : String | provenance | Src:MaD:285  |
+| ApacheHttpSSRFVersion5.java:376:42:376:49 | hostSink : String | ApacheHttpSSRFVersion5.java:376:29:376:50 | new HttpHost(...) : HttpHost | provenance | MaD:305 |
+| JakartaWsSSRF.java:14:22:14:48 | getParameter(...) : String | JakartaWsSSRF.java:15:23:15:25 | url | provenance | Src:MaD:286 Sink:MaD:3 |
+| JavaNetHttpSSRF.java:25:27:25:53 | getParameter(...) : String | JavaNetHttpSSRF.java:26:31:26:34 | sink : String | provenance | Src:MaD:286  |
 | JavaNetHttpSSRF.java:26:23:26:35 | new URI(...) : URI | JavaNetHttpSSRF.java:39:59:39:61 | uri | provenance | Sink:MaD:6 |
 | JavaNetHttpSSRF.java:26:31:26:34 | sink : String | JavaNetHttpSSRF.java:26:23:26:35 | new URI(...) : URI | provenance | Config |
-| JavaNetHttpSSRF.java:26:31:26:34 | sink : String | JavaNetHttpSSRF.java:26:23:26:35 | new URI(...) : URI | provenance | MaD:293 |
+| JavaNetHttpSSRF.java:26:31:26:34 | sink : String | JavaNetHttpSSRF.java:26:23:26:35 | new URI(...) : URI | provenance | MaD:294 |
 | JavaNetHttpSSRF.java:26:31:26:34 | sink : String | JavaNetHttpSSRF.java:27:40:27:43 | sink : String | provenance |  |
 | JavaNetHttpSSRF.java:27:24:27:57 | new URI(...) : URI | JavaNetHttpSSRF.java:38:65:38:68 | uri2 | provenance | Sink:MaD:5 |
 | JavaNetHttpSSRF.java:27:40:27:43 | sink : String | JavaNetHttpSSRF.java:27:24:27:57 | new URI(...) : URI | provenance | Config |
-| JavaNetHttpSSRF.java:27:40:27:43 | sink : String | JavaNetHttpSSRF.java:27:24:27:57 | new URI(...) : URI | provenance | MaD:294 |
+| JavaNetHttpSSRF.java:27:40:27:43 | sink : String | JavaNetHttpSSRF.java:27:24:27:57 | new URI(...) : URI | provenance | MaD:295 |
 | JavaNetHttpSSRF.java:27:40:27:43 | sink : String | JavaNetHttpSSRF.java:28:32:28:35 | sink : String | provenance |  |
 | JavaNetHttpSSRF.java:28:24:28:36 | new URL(...) : URL | JavaNetHttpSSRF.java:30:32:30:35 | url1 | provenance | Sink:MaD:9 |
 | JavaNetHttpSSRF.java:28:24:28:36 | new URL(...) : URL | JavaNetHttpSSRF.java:33:32:33:35 | url1 | provenance | Sink:MaD:9 |
 | JavaNetHttpSSRF.java:28:24:28:36 | new URL(...) : URL | JavaNetHttpSSRF.java:34:30:34:33 | url1 | provenance | Sink:MaD:10 |
 | JavaNetHttpSSRF.java:28:32:28:35 | sink : String | JavaNetHttpSSRF.java:28:24:28:36 | new URL(...) : URL | provenance | Config |
-| JavaNetHttpSSRF.java:28:32:28:35 | sink : String | JavaNetHttpSSRF.java:28:24:28:36 | new URL(...) : URL | provenance | MaD:297 |
-| JaxWsSSRF.java:14:22:14:48 | getParameter(...) : String | JaxWsSSRF.java:15:23:15:25 | url | provenance | Src:MaD:285 Sink:MaD:23 |
-| JdbcUrlSSRF.java:21:26:21:56 | getParameter(...) : String | JdbcUrlSSRF.java:26:28:26:34 | jdbcUrl | provenance | Src:MaD:285 Sink:MaD:17 |
-| JdbcUrlSSRF.java:21:26:21:56 | getParameter(...) : String | JdbcUrlSSRF.java:28:41:28:47 | jdbcUrl | provenance | Src:MaD:285 Sink:MaD:18 |
-| JdbcUrlSSRF.java:21:26:21:56 | getParameter(...) : String | JdbcUrlSSRF.java:29:41:29:47 | jdbcUrl | provenance | Src:MaD:285 Sink:MaD:20 |
-| JdbcUrlSSRF.java:21:26:21:56 | getParameter(...) : String | JdbcUrlSSRF.java:30:41:30:47 | jdbcUrl | provenance | Src:MaD:285 Sink:MaD:19 |
-| JdbcUrlSSRF.java:21:26:21:56 | getParameter(...) : String | JdbcUrlSSRF.java:32:27:32:33 | jdbcUrl | provenance | Src:MaD:285 Sink:MaD:250 |
-| JdbcUrlSSRF.java:40:26:40:56 | getParameter(...) : String | JdbcUrlSSRF.java:43:27:43:33 | jdbcUrl | provenance | Src:MaD:285 Sink:MaD:2 |
-| JdbcUrlSSRF.java:40:26:40:56 | getParameter(...) : String | JdbcUrlSSRF.java:48:23:48:29 | jdbcUrl | provenance | Src:MaD:285 Sink:MaD:2 |
-| JdbcUrlSSRF.java:40:26:40:56 | getParameter(...) : String | JdbcUrlSSRF.java:52:38:52:44 | jdbcUrl : String | provenance | Src:MaD:285  |
+| JavaNetHttpSSRF.java:28:32:28:35 | sink : String | JavaNetHttpSSRF.java:28:24:28:36 | new URL(...) : URL | provenance | MaD:299 |
+| JaxWsSSRF.java:14:22:14:48 | getParameter(...) : String | JaxWsSSRF.java:15:23:15:25 | url | provenance | Src:MaD:286 Sink:MaD:23 |
+| JdbcUrlSSRF.java:21:26:21:56 | getParameter(...) : String | JdbcUrlSSRF.java:26:28:26:34 | jdbcUrl | provenance | Src:MaD:286 Sink:MaD:17 |
+| JdbcUrlSSRF.java:21:26:21:56 | getParameter(...) : String | JdbcUrlSSRF.java:28:41:28:47 | jdbcUrl | provenance | Src:MaD:286 Sink:MaD:18 |
+| JdbcUrlSSRF.java:21:26:21:56 | getParameter(...) : String | JdbcUrlSSRF.java:29:41:29:47 | jdbcUrl | provenance | Src:MaD:286 Sink:MaD:20 |
+| JdbcUrlSSRF.java:21:26:21:56 | getParameter(...) : String | JdbcUrlSSRF.java:30:41:30:47 | jdbcUrl | provenance | Src:MaD:286 Sink:MaD:19 |
+| JdbcUrlSSRF.java:21:26:21:56 | getParameter(...) : String | JdbcUrlSSRF.java:32:27:32:33 | jdbcUrl | provenance | Src:MaD:286 Sink:MaD:250 |
+| JdbcUrlSSRF.java:40:26:40:56 | getParameter(...) : String | JdbcUrlSSRF.java:43:27:43:33 | jdbcUrl | provenance | Src:MaD:286 Sink:MaD:2 |
+| JdbcUrlSSRF.java:40:26:40:56 | getParameter(...) : String | JdbcUrlSSRF.java:48:23:48:29 | jdbcUrl | provenance | Src:MaD:286 Sink:MaD:2 |
+| JdbcUrlSSRF.java:40:26:40:56 | getParameter(...) : String | JdbcUrlSSRF.java:52:38:52:44 | jdbcUrl : String | provenance | Src:MaD:286  |
 | JdbcUrlSSRF.java:52:9:52:13 | props : Properties | JdbcUrlSSRF.java:54:49:54:53 | props | provenance | Sink:MaD:1 |
 | JdbcUrlSSRF.java:52:9:52:13 | props [post update] : Properties [<map.value>] : String | JdbcUrlSSRF.java:54:49:54:53 | props | provenance | Sink:MaD:1 |
 | JdbcUrlSSRF.java:52:38:52:44 | jdbcUrl : String | JdbcUrlSSRF.java:52:9:52:13 | props : Properties | provenance | Config |
-| JdbcUrlSSRF.java:52:38:52:44 | jdbcUrl : String | JdbcUrlSSRF.java:52:9:52:13 | props [post update] : Properties [<map.value>] : String | provenance | MaD:302 |
-| JdbcUrlSSRF.java:60:26:60:56 | getParameter(...) : String | JdbcUrlSSRF.java:65:27:65:33 | jdbcUrl | provenance | Src:MaD:285 Sink:MaD:265 |
-| JdbcUrlSSRF.java:60:26:60:56 | getParameter(...) : String | JdbcUrlSSRF.java:67:75:67:81 | jdbcUrl | provenance | Src:MaD:285 Sink:MaD:266 |
-| JdbcUrlSSRF.java:60:26:60:56 | getParameter(...) : String | JdbcUrlSSRF.java:70:75:70:81 | jdbcUrl | provenance | Src:MaD:285 Sink:MaD:268 |
-| JdbcUrlSSRF.java:60:26:60:56 | getParameter(...) : String | JdbcUrlSSRF.java:73:75:73:81 | jdbcUrl | provenance | Src:MaD:285 Sink:MaD:267 |
-| JdbcUrlSSRF.java:80:26:80:56 | getParameter(...) : String | JdbcUrlSSRF.java:82:21:82:27 | jdbcUrl | provenance | Src:MaD:285 Sink:MaD:243 |
-| JdbcUrlSSRF.java:80:26:80:56 | getParameter(...) : String | JdbcUrlSSRF.java:83:21:83:27 | jdbcUrl | provenance | Src:MaD:285 Sink:MaD:244 |
-| JdbcUrlSSRF.java:80:26:80:56 | getParameter(...) : String | JdbcUrlSSRF.java:84:21:84:27 | jdbcUrl | provenance | Src:MaD:285 Sink:MaD:245 |
-| JdbcUrlSSRF.java:80:26:80:56 | getParameter(...) : String | JdbcUrlSSRF.java:86:19:86:25 | jdbcUrl | provenance | Src:MaD:285 Sink:MaD:246 |
-| JdbcUrlSSRF.java:80:26:80:56 | getParameter(...) : String | JdbcUrlSSRF.java:87:19:87:25 | jdbcUrl | provenance | Src:MaD:285 Sink:MaD:247 |
-| JdbcUrlSSRF.java:80:26:80:56 | getParameter(...) : String | JdbcUrlSSRF.java:88:19:88:25 | jdbcUrl | provenance | Src:MaD:285 Sink:MaD:248 |
-| ReactiveWebClientSSRF.java:15:26:15:52 | getParameter(...) : String | ReactiveWebClientSSRF.java:16:52:16:54 | url | provenance | Src:MaD:285 Sink:MaD:282 |
-| ReactiveWebClientSSRF.java:32:26:32:52 | getParameter(...) : String | ReactiveWebClientSSRF.java:35:30:35:32 | url | provenance | Src:MaD:285 Sink:MaD:281 |
+| JdbcUrlSSRF.java:52:38:52:44 | jdbcUrl : String | JdbcUrlSSRF.java:52:9:52:13 | props [post update] : Properties [<map.value>] : String | provenance | MaD:304 |
+| JdbcUrlSSRF.java:60:26:60:56 | getParameter(...) : String | JdbcUrlSSRF.java:65:27:65:33 | jdbcUrl | provenance | Src:MaD:286 Sink:MaD:265 |
+| JdbcUrlSSRF.java:60:26:60:56 | getParameter(...) : String | JdbcUrlSSRF.java:67:75:67:81 | jdbcUrl | provenance | Src:MaD:286 Sink:MaD:266 |
+| JdbcUrlSSRF.java:60:26:60:56 | getParameter(...) : String | JdbcUrlSSRF.java:70:75:70:81 | jdbcUrl | provenance | Src:MaD:286 Sink:MaD:268 |
+| JdbcUrlSSRF.java:60:26:60:56 | getParameter(...) : String | JdbcUrlSSRF.java:73:75:73:81 | jdbcUrl | provenance | Src:MaD:286 Sink:MaD:267 |
+| JdbcUrlSSRF.java:80:26:80:56 | getParameter(...) : String | JdbcUrlSSRF.java:82:21:82:27 | jdbcUrl | provenance | Src:MaD:286 Sink:MaD:243 |
+| JdbcUrlSSRF.java:80:26:80:56 | getParameter(...) : String | JdbcUrlSSRF.java:83:21:83:27 | jdbcUrl | provenance | Src:MaD:286 Sink:MaD:244 |
+| JdbcUrlSSRF.java:80:26:80:56 | getParameter(...) : String | JdbcUrlSSRF.java:84:21:84:27 | jdbcUrl | provenance | Src:MaD:286 Sink:MaD:245 |
+| JdbcUrlSSRF.java:80:26:80:56 | getParameter(...) : String | JdbcUrlSSRF.java:86:19:86:25 | jdbcUrl | provenance | Src:MaD:286 Sink:MaD:246 |
+| JdbcUrlSSRF.java:80:26:80:56 | getParameter(...) : String | JdbcUrlSSRF.java:87:19:87:25 | jdbcUrl | provenance | Src:MaD:286 Sink:MaD:247 |
+| JdbcUrlSSRF.java:80:26:80:56 | getParameter(...) : String | JdbcUrlSSRF.java:88:19:88:25 | jdbcUrl | provenance | Src:MaD:286 Sink:MaD:248 |
+| ReactiveWebClientSSRF.java:15:26:15:52 | getParameter(...) : String | ReactiveWebClientSSRF.java:16:52:16:54 | url | provenance | Src:MaD:286 Sink:MaD:283 |
+| ReactiveWebClientSSRF.java:32:26:32:52 | getParameter(...) : String | ReactiveWebClientSSRF.java:35:30:35:32 | url | provenance | Src:MaD:286 Sink:MaD:281 |
+| ReactiveWebClientSSRF.java:55:24:55:50 | getParameter(...) : String | ReactiveWebClientSSRF.java:57:26:57:26 | p | provenance | Src:MaD:286 Sink:MaD:282 |
+| ReactiveWebClientSSRF.java:62:25:62:51 | getParameter(...) : String | ReactiveWebClientSSRF.java:64:46:64:71 | ... + ... : String | provenance | Src:MaD:286  |
+| ReactiveWebClientSSRF.java:64:46:64:71 | ... + ... : String | ReactiveWebClientSSRF.java:64:26:64:72 | create(...) | provenance | Config Sink:MaD:282 |
+| ReactiveWebClientSSRF.java:64:46:64:71 | ... + ... : String | ReactiveWebClientSSRF.java:64:26:64:72 | create(...) | provenance | MaD:296 Sink:MaD:282 |
 | SanitizationTests.java:22:23:22:58 | new URI(...) : URI | SanitizationTests.java:25:52:25:54 | uri | provenance | Sink:MaD:6 |
 | SanitizationTests.java:22:23:22:58 | new URI(...) : URI | SanitizationTests.java:25:52:25:54 | uri : URI | provenance |  |
-| SanitizationTests.java:22:31:22:57 | getParameter(...) : String | SanitizationTests.java:22:23:22:58 | new URI(...) : URI | provenance | Src:MaD:285 Config |
-| SanitizationTests.java:22:31:22:57 | getParameter(...) : String | SanitizationTests.java:22:23:22:58 | new URI(...) : URI | provenance | Src:MaD:285 MaD:293 |
-| SanitizationTests.java:25:29:25:55 | newBuilder(...) : Builder | SanitizationTests.java:25:29:25:63 | build(...) : HttpRequest | provenance | MaD:291 |
+| SanitizationTests.java:22:31:22:57 | getParameter(...) : String | SanitizationTests.java:22:23:22:58 | new URI(...) : URI | provenance | Src:MaD:286 Config |
+| SanitizationTests.java:22:31:22:57 | getParameter(...) : String | SanitizationTests.java:22:23:22:58 | new URI(...) : URI | provenance | Src:MaD:286 MaD:294 |
+| SanitizationTests.java:25:29:25:55 | newBuilder(...) : Builder | SanitizationTests.java:25:29:25:63 | build(...) : HttpRequest | provenance | MaD:292 |
 | SanitizationTests.java:25:29:25:63 | build(...) : HttpRequest | SanitizationTests.java:26:25:26:25 | r | provenance | Sink:MaD:4 |
-| SanitizationTests.java:25:52:25:54 | uri : URI | SanitizationTests.java:25:29:25:55 | newBuilder(...) : Builder | provenance | MaD:292 |
-| SanitizationTests.java:78:33:78:63 | getParameter(...) : String | SanitizationTests.java:79:67:79:76 | unsafeUri3 : String | provenance | Src:MaD:285  |
-| SanitizationTests.java:79:36:79:78 | newBuilder(...) : Builder | SanitizationTests.java:79:36:79:86 | build(...) : HttpRequest | provenance | MaD:291 |
+| SanitizationTests.java:25:52:25:54 | uri : URI | SanitizationTests.java:25:29:25:55 | newBuilder(...) : Builder | provenance | MaD:293 |
+| SanitizationTests.java:78:33:78:63 | getParameter(...) : String | SanitizationTests.java:79:67:79:76 | unsafeUri3 : String | provenance | Src:MaD:286  |
+| SanitizationTests.java:79:36:79:78 | newBuilder(...) : Builder | SanitizationTests.java:79:36:79:86 | build(...) : HttpRequest | provenance | MaD:292 |
 | SanitizationTests.java:79:36:79:86 | build(...) : HttpRequest | SanitizationTests.java:80:25:80:32 | unsafer3 | provenance | Sink:MaD:4 |
-| SanitizationTests.java:79:59:79:77 | new URI(...) : URI | SanitizationTests.java:79:36:79:78 | newBuilder(...) : Builder | provenance | MaD:292 |
+| SanitizationTests.java:79:59:79:77 | new URI(...) : URI | SanitizationTests.java:79:36:79:78 | newBuilder(...) : Builder | provenance | MaD:293 |
 | SanitizationTests.java:79:67:79:76 | unsafeUri3 : String | SanitizationTests.java:79:59:79:77 | new URI(...) | provenance | Config Sink:MaD:6 |
-| SanitizationTests.java:79:67:79:76 | unsafeUri3 : String | SanitizationTests.java:79:59:79:77 | new URI(...) | provenance | MaD:293 Sink:MaD:6 |
+| SanitizationTests.java:79:67:79:76 | unsafeUri3 : String | SanitizationTests.java:79:59:79:77 | new URI(...) | provenance | MaD:294 Sink:MaD:6 |
 | SanitizationTests.java:79:67:79:76 | unsafeUri3 : String | SanitizationTests.java:79:59:79:77 | new URI(...) : URI | provenance | Config |
-| SanitizationTests.java:79:67:79:76 | unsafeUri3 : String | SanitizationTests.java:79:59:79:77 | new URI(...) : URI | provenance | MaD:293 |
-| SanitizationTests.java:82:49:82:79 | getParameter(...) : String | SanitizationTests.java:83:67:83:76 | unsafeUri4 : String | provenance | Src:MaD:285  |
-| SanitizationTests.java:83:36:83:78 | newBuilder(...) : Builder | SanitizationTests.java:83:36:83:86 | build(...) : HttpRequest | provenance | MaD:291 |
+| SanitizationTests.java:79:67:79:76 | unsafeUri3 : String | SanitizationTests.java:79:59:79:77 | new URI(...) : URI | provenance | MaD:294 |
+| SanitizationTests.java:82:49:82:79 | getParameter(...) : String | SanitizationTests.java:83:67:83:76 | unsafeUri4 : String | provenance | Src:MaD:286  |
+| SanitizationTests.java:83:36:83:78 | newBuilder(...) : Builder | SanitizationTests.java:83:36:83:86 | build(...) : HttpRequest | provenance | MaD:292 |
 | SanitizationTests.java:83:36:83:86 | build(...) : HttpRequest | SanitizationTests.java:84:25:84:32 | unsafer4 | provenance | Sink:MaD:4 |
-| SanitizationTests.java:83:59:83:77 | new URI(...) : URI | SanitizationTests.java:83:36:83:78 | newBuilder(...) : Builder | provenance | MaD:292 |
+| SanitizationTests.java:83:59:83:77 | new URI(...) : URI | SanitizationTests.java:83:36:83:78 | newBuilder(...) : Builder | provenance | MaD:293 |
 | SanitizationTests.java:83:67:83:76 | unsafeUri4 : String | SanitizationTests.java:83:59:83:77 | new URI(...) | provenance | Config Sink:MaD:6 |
-| SanitizationTests.java:83:67:83:76 | unsafeUri4 : String | SanitizationTests.java:83:59:83:77 | new URI(...) | provenance | MaD:293 Sink:MaD:6 |
+| SanitizationTests.java:83:67:83:76 | unsafeUri4 : String | SanitizationTests.java:83:59:83:77 | new URI(...) | provenance | MaD:294 Sink:MaD:6 |
 | SanitizationTests.java:83:67:83:76 | unsafeUri4 : String | SanitizationTests.java:83:59:83:77 | new URI(...) : URI | provenance | Config |
-| SanitizationTests.java:83:67:83:76 | unsafeUri4 : String | SanitizationTests.java:83:59:83:77 | new URI(...) : URI | provenance | MaD:293 |
+| SanitizationTests.java:83:67:83:76 | unsafeUri4 : String | SanitizationTests.java:83:59:83:77 | new URI(...) : URI | provenance | MaD:294 |
 | SanitizationTests.java:87:13:87:22 | unsafeUri5 [post update] : StringBuilder | SanitizationTests.java:88:67:88:76 | unsafeUri5 : StringBuilder | provenance |  |
-| SanitizationTests.java:87:31:87:61 | getParameter(...) : String | SanitizationTests.java:87:13:87:22 | unsafeUri5 [post update] : StringBuilder | provenance | Src:MaD:285 MaD:286 |
-| SanitizationTests.java:88:36:88:89 | newBuilder(...) : Builder | SanitizationTests.java:88:36:88:97 | build(...) : HttpRequest | provenance | MaD:291 |
+| SanitizationTests.java:87:31:87:61 | getParameter(...) : String | SanitizationTests.java:87:13:87:22 | unsafeUri5 [post update] : StringBuilder | provenance | Src:MaD:286 MaD:287 |
+| SanitizationTests.java:88:36:88:89 | newBuilder(...) : Builder | SanitizationTests.java:88:36:88:97 | build(...) : HttpRequest | provenance | MaD:292 |
 | SanitizationTests.java:88:36:88:97 | build(...) : HttpRequest | SanitizationTests.java:89:25:89:32 | unsafer5 | provenance | Sink:MaD:4 |
-| SanitizationTests.java:88:59:88:88 | new URI(...) : URI | SanitizationTests.java:88:36:88:89 | newBuilder(...) : Builder | provenance | MaD:292 |
-| SanitizationTests.java:88:67:88:76 | unsafeUri5 : StringBuilder | SanitizationTests.java:88:67:88:87 | toString(...) : String | provenance | MaD:288 |
+| SanitizationTests.java:88:59:88:88 | new URI(...) : URI | SanitizationTests.java:88:36:88:89 | newBuilder(...) : Builder | provenance | MaD:293 |
+| SanitizationTests.java:88:67:88:76 | unsafeUri5 : StringBuilder | SanitizationTests.java:88:67:88:87 | toString(...) : String | provenance | MaD:289 |
 | SanitizationTests.java:88:67:88:87 | toString(...) : String | SanitizationTests.java:88:59:88:88 | new URI(...) | provenance | Config Sink:MaD:6 |
-| SanitizationTests.java:88:67:88:87 | toString(...) : String | SanitizationTests.java:88:59:88:88 | new URI(...) | provenance | MaD:293 Sink:MaD:6 |
+| SanitizationTests.java:88:67:88:87 | toString(...) : String | SanitizationTests.java:88:59:88:88 | new URI(...) | provenance | MaD:294 Sink:MaD:6 |
 | SanitizationTests.java:88:67:88:87 | toString(...) : String | SanitizationTests.java:88:59:88:88 | new URI(...) : URI | provenance | Config |
-| SanitizationTests.java:88:67:88:87 | toString(...) : String | SanitizationTests.java:88:59:88:88 | new URI(...) : URI | provenance | MaD:293 |
+| SanitizationTests.java:88:67:88:87 | toString(...) : String | SanitizationTests.java:88:59:88:88 | new URI(...) : URI | provenance | MaD:294 |
 | SanitizationTests.java:91:40:91:87 | new StringBuilder(...) : StringBuilder | SanitizationTests.java:93:68:93:77 | unafeUri5a : StringBuilder | provenance |  |
-| SanitizationTests.java:91:58:91:86 | getParameter(...) : String | SanitizationTests.java:91:40:91:87 | new StringBuilder(...) : StringBuilder | provenance | Src:MaD:285 MaD:290 |
-| SanitizationTests.java:93:37:93:90 | newBuilder(...) : Builder | SanitizationTests.java:93:37:93:98 | build(...) : HttpRequest | provenance | MaD:291 |
+| SanitizationTests.java:91:58:91:86 | getParameter(...) : String | SanitizationTests.java:91:40:91:87 | new StringBuilder(...) : StringBuilder | provenance | Src:MaD:286 MaD:291 |
+| SanitizationTests.java:93:37:93:90 | newBuilder(...) : Builder | SanitizationTests.java:93:37:93:98 | build(...) : HttpRequest | provenance | MaD:292 |
 | SanitizationTests.java:93:37:93:98 | build(...) : HttpRequest | SanitizationTests.java:94:25:94:33 | unsafer5a | provenance | Sink:MaD:4 |
-| SanitizationTests.java:93:60:93:89 | new URI(...) : URI | SanitizationTests.java:93:37:93:90 | newBuilder(...) : Builder | provenance | MaD:292 |
-| SanitizationTests.java:93:68:93:77 | unafeUri5a : StringBuilder | SanitizationTests.java:93:68:93:88 | toString(...) : String | provenance | MaD:288 |
+| SanitizationTests.java:93:60:93:89 | new URI(...) : URI | SanitizationTests.java:93:37:93:90 | newBuilder(...) : Builder | provenance | MaD:293 |
+| SanitizationTests.java:93:68:93:77 | unafeUri5a : StringBuilder | SanitizationTests.java:93:68:93:88 | toString(...) : String | provenance | MaD:289 |
 | SanitizationTests.java:93:68:93:88 | toString(...) : String | SanitizationTests.java:93:60:93:89 | new URI(...) | provenance | Config Sink:MaD:6 |
-| SanitizationTests.java:93:68:93:88 | toString(...) : String | SanitizationTests.java:93:60:93:89 | new URI(...) | provenance | MaD:293 Sink:MaD:6 |
+| SanitizationTests.java:93:68:93:88 | toString(...) : String | SanitizationTests.java:93:60:93:89 | new URI(...) | provenance | MaD:294 Sink:MaD:6 |
 | SanitizationTests.java:93:68:93:88 | toString(...) : String | SanitizationTests.java:93:60:93:89 | new URI(...) : URI | provenance | Config |
-| SanitizationTests.java:93:68:93:88 | toString(...) : String | SanitizationTests.java:93:60:93:89 | new URI(...) : URI | provenance | MaD:293 |
+| SanitizationTests.java:93:68:93:88 | toString(...) : String | SanitizationTests.java:93:60:93:89 | new URI(...) : URI | provenance | MaD:294 |
 | SanitizationTests.java:96:41:96:105 | append(...) : StringBuilder | SanitizationTests.java:98:68:98:78 | unsafeUri5b : StringBuilder | provenance |  |
-| SanitizationTests.java:96:42:96:89 | new StringBuilder(...) : StringBuilder | SanitizationTests.java:96:41:96:105 | append(...) : StringBuilder | provenance | MaD:287 |
-| SanitizationTests.java:96:60:96:88 | getParameter(...) : String | SanitizationTests.java:96:42:96:89 | new StringBuilder(...) : StringBuilder | provenance | Src:MaD:285 MaD:290 |
-| SanitizationTests.java:98:37:98:91 | newBuilder(...) : Builder | SanitizationTests.java:98:37:98:99 | build(...) : HttpRequest | provenance | MaD:291 |
+| SanitizationTests.java:96:42:96:89 | new StringBuilder(...) : StringBuilder | SanitizationTests.java:96:41:96:105 | append(...) : StringBuilder | provenance | MaD:288 |
+| SanitizationTests.java:96:60:96:88 | getParameter(...) : String | SanitizationTests.java:96:42:96:89 | new StringBuilder(...) : StringBuilder | provenance | Src:MaD:286 MaD:291 |
+| SanitizationTests.java:98:37:98:91 | newBuilder(...) : Builder | SanitizationTests.java:98:37:98:99 | build(...) : HttpRequest | provenance | MaD:292 |
 | SanitizationTests.java:98:37:98:99 | build(...) : HttpRequest | SanitizationTests.java:99:25:99:33 | unsafer5b | provenance | Sink:MaD:4 |
-| SanitizationTests.java:98:60:98:90 | new URI(...) : URI | SanitizationTests.java:98:37:98:91 | newBuilder(...) : Builder | provenance | MaD:292 |
-| SanitizationTests.java:98:68:98:78 | unsafeUri5b : StringBuilder | SanitizationTests.java:98:68:98:89 | toString(...) : String | provenance | MaD:288 |
+| SanitizationTests.java:98:60:98:90 | new URI(...) : URI | SanitizationTests.java:98:37:98:91 | newBuilder(...) : Builder | provenance | MaD:293 |
+| SanitizationTests.java:98:68:98:78 | unsafeUri5b : StringBuilder | SanitizationTests.java:98:68:98:89 | toString(...) : String | provenance | MaD:289 |
 | SanitizationTests.java:98:68:98:89 | toString(...) : String | SanitizationTests.java:98:60:98:90 | new URI(...) | provenance | Config Sink:MaD:6 |
-| SanitizationTests.java:98:68:98:89 | toString(...) : String | SanitizationTests.java:98:60:98:90 | new URI(...) | provenance | MaD:293 Sink:MaD:6 |
+| SanitizationTests.java:98:68:98:89 | toString(...) : String | SanitizationTests.java:98:60:98:90 | new URI(...) | provenance | MaD:294 Sink:MaD:6 |
 | SanitizationTests.java:98:68:98:89 | toString(...) : String | SanitizationTests.java:98:60:98:90 | new URI(...) : URI | provenance | Config |
-| SanitizationTests.java:98:68:98:89 | toString(...) : String | SanitizationTests.java:98:60:98:90 | new URI(...) : URI | provenance | MaD:293 |
+| SanitizationTests.java:98:68:98:89 | toString(...) : String | SanitizationTests.java:98:60:98:90 | new URI(...) : URI | provenance | MaD:294 |
 | SanitizationTests.java:101:41:101:106 | append(...) : StringBuilder | SanitizationTests.java:103:68:103:78 | unsafeUri5c : StringBuilder | provenance |  |
-| SanitizationTests.java:101:77:101:105 | getParameter(...) : String | SanitizationTests.java:101:41:101:106 | append(...) : StringBuilder | provenance | Src:MaD:285 MaD:286+MaD:287 |
-| SanitizationTests.java:103:37:103:91 | newBuilder(...) : Builder | SanitizationTests.java:103:37:103:99 | build(...) : HttpRequest | provenance | MaD:291 |
+| SanitizationTests.java:101:77:101:105 | getParameter(...) : String | SanitizationTests.java:101:41:101:106 | append(...) : StringBuilder | provenance | Src:MaD:286 MaD:287+MaD:288 |
+| SanitizationTests.java:103:37:103:91 | newBuilder(...) : Builder | SanitizationTests.java:103:37:103:99 | build(...) : HttpRequest | provenance | MaD:292 |
 | SanitizationTests.java:103:37:103:99 | build(...) : HttpRequest | SanitizationTests.java:104:25:104:33 | unsafer5c | provenance | Sink:MaD:4 |
-| SanitizationTests.java:103:60:103:90 | new URI(...) : URI | SanitizationTests.java:103:37:103:91 | newBuilder(...) : Builder | provenance | MaD:292 |
-| SanitizationTests.java:103:68:103:78 | unsafeUri5c : StringBuilder | SanitizationTests.java:103:68:103:89 | toString(...) : String | provenance | MaD:288 |
+| SanitizationTests.java:103:60:103:90 | new URI(...) : URI | SanitizationTests.java:103:37:103:91 | newBuilder(...) : Builder | provenance | MaD:293 |
+| SanitizationTests.java:103:68:103:78 | unsafeUri5c : StringBuilder | SanitizationTests.java:103:68:103:89 | toString(...) : String | provenance | MaD:289 |
 | SanitizationTests.java:103:68:103:89 | toString(...) : String | SanitizationTests.java:103:60:103:90 | new URI(...) | provenance | Config Sink:MaD:6 |
-| SanitizationTests.java:103:68:103:89 | toString(...) : String | SanitizationTests.java:103:60:103:90 | new URI(...) | provenance | MaD:293 Sink:MaD:6 |
+| SanitizationTests.java:103:68:103:89 | toString(...) : String | SanitizationTests.java:103:60:103:90 | new URI(...) | provenance | MaD:294 Sink:MaD:6 |
 | SanitizationTests.java:103:68:103:89 | toString(...) : String | SanitizationTests.java:103:60:103:90 | new URI(...) : URI | provenance | Config |
-| SanitizationTests.java:103:68:103:89 | toString(...) : String | SanitizationTests.java:103:60:103:90 | new URI(...) : URI | provenance | MaD:293 |
+| SanitizationTests.java:103:68:103:89 | toString(...) : String | SanitizationTests.java:103:60:103:90 | new URI(...) : URI | provenance | MaD:294 |
 | SanitizationTests.java:106:33:106:104 | format(...) : String | SanitizationTests.java:107:67:107:76 | unsafeUri6 : String | provenance |  |
-| SanitizationTests.java:106:33:106:104 | new ..[] { .. } : Object[] [[]] : String | SanitizationTests.java:106:33:106:104 | format(...) : String | provenance | MaD:289 |
-| SanitizationTests.java:106:73:106:103 | getParameter(...) : String | SanitizationTests.java:106:33:106:104 | new ..[] { .. } : Object[] [[]] : String | provenance | Src:MaD:285  |
-| SanitizationTests.java:107:36:107:78 | newBuilder(...) : Builder | SanitizationTests.java:107:36:107:86 | build(...) : HttpRequest | provenance | MaD:291 |
+| SanitizationTests.java:106:33:106:104 | new ..[] { .. } : Object[] [[]] : String | SanitizationTests.java:106:33:106:104 | format(...) : String | provenance | MaD:290 |
+| SanitizationTests.java:106:73:106:103 | getParameter(...) : String | SanitizationTests.java:106:33:106:104 | new ..[] { .. } : Object[] [[]] : String | provenance | Src:MaD:286  |
+| SanitizationTests.java:107:36:107:78 | newBuilder(...) : Builder | SanitizationTests.java:107:36:107:86 | build(...) : HttpRequest | provenance | MaD:292 |
 | SanitizationTests.java:107:36:107:86 | build(...) : HttpRequest | SanitizationTests.java:108:25:108:32 | unsafer6 | provenance | Sink:MaD:4 |
-| SanitizationTests.java:107:59:107:77 | new URI(...) : URI | SanitizationTests.java:107:36:107:78 | newBuilder(...) : Builder | provenance | MaD:292 |
+| SanitizationTests.java:107:59:107:77 | new URI(...) : URI | SanitizationTests.java:107:36:107:78 | newBuilder(...) : Builder | provenance | MaD:293 |
 | SanitizationTests.java:107:67:107:76 | unsafeUri6 : String | SanitizationTests.java:107:59:107:77 | new URI(...) | provenance | Config Sink:MaD:6 |
-| SanitizationTests.java:107:67:107:76 | unsafeUri6 : String | SanitizationTests.java:107:59:107:77 | new URI(...) | provenance | MaD:293 Sink:MaD:6 |
+| SanitizationTests.java:107:67:107:76 | unsafeUri6 : String | SanitizationTests.java:107:59:107:77 | new URI(...) | provenance | MaD:294 Sink:MaD:6 |
 | SanitizationTests.java:107:67:107:76 | unsafeUri6 : String | SanitizationTests.java:107:59:107:77 | new URI(...) : URI | provenance | Config |
-| SanitizationTests.java:107:67:107:76 | unsafeUri6 : String | SanitizationTests.java:107:59:107:77 | new URI(...) : URI | provenance | MaD:293 |
+| SanitizationTests.java:107:67:107:76 | unsafeUri6 : String | SanitizationTests.java:107:59:107:77 | new URI(...) : URI | provenance | MaD:294 |
 | SanitizationTests.java:110:33:110:110 | format(...) : String | SanitizationTests.java:111:67:111:76 | unsafeUri7 : String | provenance |  |
-| SanitizationTests.java:110:33:110:110 | new ..[] { .. } : Object[] [[]] : String | SanitizationTests.java:110:33:110:110 | format(...) : String | provenance | MaD:289 |
-| SanitizationTests.java:110:56:110:86 | getParameter(...) : String | SanitizationTests.java:110:33:110:110 | new ..[] { .. } : Object[] [[]] : String | provenance | Src:MaD:285  |
-| SanitizationTests.java:111:36:111:78 | newBuilder(...) : Builder | SanitizationTests.java:111:36:111:86 | build(...) : HttpRequest | provenance | MaD:291 |
+| SanitizationTests.java:110:33:110:110 | new ..[] { .. } : Object[] [[]] : String | SanitizationTests.java:110:33:110:110 | format(...) : String | provenance | MaD:290 |
+| SanitizationTests.java:110:56:110:86 | getParameter(...) : String | SanitizationTests.java:110:33:110:110 | new ..[] { .. } : Object[] [[]] : String | provenance | Src:MaD:286  |
+| SanitizationTests.java:111:36:111:78 | newBuilder(...) : Builder | SanitizationTests.java:111:36:111:86 | build(...) : HttpRequest | provenance | MaD:292 |
 | SanitizationTests.java:111:36:111:86 | build(...) : HttpRequest | SanitizationTests.java:112:25:112:32 | unsafer7 | provenance | Sink:MaD:4 |
-| SanitizationTests.java:111:59:111:77 | new URI(...) : URI | SanitizationTests.java:111:36:111:78 | newBuilder(...) : Builder | provenance | MaD:292 |
+| SanitizationTests.java:111:59:111:77 | new URI(...) : URI | SanitizationTests.java:111:36:111:78 | newBuilder(...) : Builder | provenance | MaD:293 |
 | SanitizationTests.java:111:67:111:76 | unsafeUri7 : String | SanitizationTests.java:111:59:111:77 | new URI(...) | provenance | Config Sink:MaD:6 |
-| SanitizationTests.java:111:67:111:76 | unsafeUri7 : String | SanitizationTests.java:111:59:111:77 | new URI(...) | provenance | MaD:293 Sink:MaD:6 |
+| SanitizationTests.java:111:67:111:76 | unsafeUri7 : String | SanitizationTests.java:111:59:111:77 | new URI(...) | provenance | MaD:294 Sink:MaD:6 |
 | SanitizationTests.java:111:67:111:76 | unsafeUri7 : String | SanitizationTests.java:111:59:111:77 | new URI(...) : URI | provenance | Config |
-| SanitizationTests.java:111:67:111:76 | unsafeUri7 : String | SanitizationTests.java:111:59:111:77 | new URI(...) : URI | provenance | MaD:293 |
+| SanitizationTests.java:111:67:111:76 | unsafeUri7 : String | SanitizationTests.java:111:59:111:77 | new URI(...) : URI | provenance | MaD:294 |
 | SanitizationTests.java:114:33:114:110 | format(...) : String | SanitizationTests.java:115:67:115:76 | unsafeUri8 : String | provenance |  |
-| SanitizationTests.java:114:33:114:110 | new ..[] { .. } : Object[] [[]] : String | SanitizationTests.java:114:33:114:110 | format(...) : String | provenance | MaD:289 |
-| SanitizationTests.java:114:55:114:85 | getParameter(...) : String | SanitizationTests.java:114:33:114:110 | new ..[] { .. } : Object[] [[]] : String | provenance | Src:MaD:285  |
-| SanitizationTests.java:115:36:115:78 | newBuilder(...) : Builder | SanitizationTests.java:115:36:115:86 | build(...) : HttpRequest | provenance | MaD:291 |
+| SanitizationTests.java:114:33:114:110 | new ..[] { .. } : Object[] [[]] : String | SanitizationTests.java:114:33:114:110 | format(...) : String | provenance | MaD:290 |
+| SanitizationTests.java:114:55:114:85 | getParameter(...) : String | SanitizationTests.java:114:33:114:110 | new ..[] { .. } : Object[] [[]] : String | provenance | Src:MaD:286  |
+| SanitizationTests.java:115:36:115:78 | newBuilder(...) : Builder | SanitizationTests.java:115:36:115:86 | build(...) : HttpRequest | provenance | MaD:292 |
 | SanitizationTests.java:115:36:115:86 | build(...) : HttpRequest | SanitizationTests.java:116:25:116:32 | unsafer8 | provenance | Sink:MaD:4 |
-| SanitizationTests.java:115:59:115:77 | new URI(...) : URI | SanitizationTests.java:115:36:115:78 | newBuilder(...) : Builder | provenance | MaD:292 |
+| SanitizationTests.java:115:59:115:77 | new URI(...) : URI | SanitizationTests.java:115:36:115:78 | newBuilder(...) : Builder | provenance | MaD:293 |
 | SanitizationTests.java:115:67:115:76 | unsafeUri8 : String | SanitizationTests.java:115:59:115:77 | new URI(...) | provenance | Config Sink:MaD:6 |
-| SanitizationTests.java:115:67:115:76 | unsafeUri8 : String | SanitizationTests.java:115:59:115:77 | new URI(...) | provenance | MaD:293 Sink:MaD:6 |
+| SanitizationTests.java:115:67:115:76 | unsafeUri8 : String | SanitizationTests.java:115:59:115:77 | new URI(...) | provenance | MaD:294 Sink:MaD:6 |
 | SanitizationTests.java:115:67:115:76 | unsafeUri8 : String | SanitizationTests.java:115:59:115:77 | new URI(...) : URI | provenance | Config |
-| SanitizationTests.java:115:67:115:76 | unsafeUri8 : String | SanitizationTests.java:115:59:115:77 | new URI(...) : URI | provenance | MaD:293 |
-| SanitizationTests.java:118:33:118:63 | getParameter(...) : String | SanitizationTests.java:119:67:119:76 | unsafeUri9 : String | provenance | Src:MaD:285  |
-| SanitizationTests.java:119:36:119:78 | newBuilder(...) : Builder | SanitizationTests.java:119:36:119:86 | build(...) : HttpRequest | provenance | MaD:291 |
+| SanitizationTests.java:115:67:115:76 | unsafeUri8 : String | SanitizationTests.java:115:59:115:77 | new URI(...) : URI | provenance | MaD:294 |
+| SanitizationTests.java:118:33:118:63 | getParameter(...) : String | SanitizationTests.java:119:67:119:76 | unsafeUri9 : String | provenance | Src:MaD:286  |
+| SanitizationTests.java:119:36:119:78 | newBuilder(...) : Builder | SanitizationTests.java:119:36:119:86 | build(...) : HttpRequest | provenance | MaD:292 |
 | SanitizationTests.java:119:36:119:86 | build(...) : HttpRequest | SanitizationTests.java:120:25:120:32 | unsafer9 | provenance | Sink:MaD:4 |
-| SanitizationTests.java:119:59:119:77 | new URI(...) : URI | SanitizationTests.java:119:36:119:78 | newBuilder(...) : Builder | provenance | MaD:292 |
+| SanitizationTests.java:119:59:119:77 | new URI(...) : URI | SanitizationTests.java:119:36:119:78 | newBuilder(...) : Builder | provenance | MaD:293 |
 | SanitizationTests.java:119:67:119:76 | unsafeUri9 : String | SanitizationTests.java:119:59:119:77 | new URI(...) | provenance | Config Sink:MaD:6 |
-| SanitizationTests.java:119:67:119:76 | unsafeUri9 : String | SanitizationTests.java:119:59:119:77 | new URI(...) | provenance | MaD:293 Sink:MaD:6 |
+| SanitizationTests.java:119:67:119:76 | unsafeUri9 : String | SanitizationTests.java:119:59:119:77 | new URI(...) | provenance | MaD:294 Sink:MaD:6 |
 | SanitizationTests.java:119:67:119:76 | unsafeUri9 : String | SanitizationTests.java:119:59:119:77 | new URI(...) : URI | provenance | Config |
-| SanitizationTests.java:119:67:119:76 | unsafeUri9 : String | SanitizationTests.java:119:59:119:77 | new URI(...) : URI | provenance | MaD:293 |
+| SanitizationTests.java:119:67:119:76 | unsafeUri9 : String | SanitizationTests.java:119:59:119:77 | new URI(...) : URI | provenance | MaD:294 |
 | SanitizationTests.java:122:34:122:126 | format(...) : String | SanitizationTests.java:123:68:123:78 | unsafeUri10 : String | provenance |  |
-| SanitizationTests.java:122:34:122:126 | new ..[] { .. } : Object[] [[]] : String | SanitizationTests.java:122:34:122:126 | format(...) : String | provenance | MaD:289 |
-| SanitizationTests.java:122:94:122:125 | getParameter(...) : String | SanitizationTests.java:122:34:122:126 | new ..[] { .. } : Object[] [[]] : String | provenance | Src:MaD:285  |
-| SanitizationTests.java:123:37:123:80 | newBuilder(...) : Builder | SanitizationTests.java:123:37:123:88 | build(...) : HttpRequest | provenance | MaD:291 |
+| SanitizationTests.java:122:34:122:126 | new ..[] { .. } : Object[] [[]] : String | SanitizationTests.java:122:34:122:126 | format(...) : String | provenance | MaD:290 |
+| SanitizationTests.java:122:94:122:125 | getParameter(...) : String | SanitizationTests.java:122:34:122:126 | new ..[] { .. } : Object[] [[]] : String | provenance | Src:MaD:286  |
+| SanitizationTests.java:123:37:123:80 | newBuilder(...) : Builder | SanitizationTests.java:123:37:123:88 | build(...) : HttpRequest | provenance | MaD:292 |
 | SanitizationTests.java:123:37:123:88 | build(...) : HttpRequest | SanitizationTests.java:124:25:124:33 | unsafer10 | provenance | Sink:MaD:4 |
-| SanitizationTests.java:123:60:123:79 | new URI(...) : URI | SanitizationTests.java:123:37:123:80 | newBuilder(...) : Builder | provenance | MaD:292 |
+| SanitizationTests.java:123:60:123:79 | new URI(...) : URI | SanitizationTests.java:123:37:123:80 | newBuilder(...) : Builder | provenance | MaD:293 |
 | SanitizationTests.java:123:68:123:78 | unsafeUri10 : String | SanitizationTests.java:123:60:123:79 | new URI(...) | provenance | Config Sink:MaD:6 |
-| SanitizationTests.java:123:68:123:78 | unsafeUri10 : String | SanitizationTests.java:123:60:123:79 | new URI(...) | provenance | MaD:293 Sink:MaD:6 |
+| SanitizationTests.java:123:68:123:78 | unsafeUri10 : String | SanitizationTests.java:123:60:123:79 | new URI(...) | provenance | MaD:294 Sink:MaD:6 |
 | SanitizationTests.java:123:68:123:78 | unsafeUri10 : String | SanitizationTests.java:123:60:123:79 | new URI(...) : URI | provenance | Config |
-| SanitizationTests.java:123:68:123:78 | unsafeUri10 : String | SanitizationTests.java:123:60:123:79 | new URI(...) : URI | provenance | MaD:293 |
-| SanitizationTests.java:177:31:177:114 | newBuilder(...) : Builder | SanitizationTests.java:177:31:177:122 | build(...) : HttpRequest | provenance | MaD:291 |
+| SanitizationTests.java:123:68:123:78 | unsafeUri10 : String | SanitizationTests.java:123:60:123:79 | new URI(...) : URI | provenance | MaD:294 |
+| SanitizationTests.java:177:31:177:114 | newBuilder(...) : Builder | SanitizationTests.java:177:31:177:122 | build(...) : HttpRequest | provenance | MaD:292 |
 | SanitizationTests.java:177:31:177:122 | build(...) : HttpRequest | SanitizationTests.java:178:25:178:27 | r18 | provenance | Sink:MaD:4 |
-| SanitizationTests.java:177:54:177:113 | new URI(...) : URI | SanitizationTests.java:177:31:177:114 | newBuilder(...) : Builder | provenance | MaD:292 |
+| SanitizationTests.java:177:54:177:113 | new URI(...) : URI | SanitizationTests.java:177:31:177:114 | newBuilder(...) : Builder | provenance | MaD:293 |
 | SanitizationTests.java:177:62:177:112 | getFromList(...) : String | SanitizationTests.java:177:54:177:113 | new URI(...) | provenance | Config Sink:MaD:6 |
-| SanitizationTests.java:177:62:177:112 | getFromList(...) : String | SanitizationTests.java:177:54:177:113 | new URI(...) | provenance | MaD:293 Sink:MaD:6 |
+| SanitizationTests.java:177:62:177:112 | getFromList(...) : String | SanitizationTests.java:177:54:177:113 | new URI(...) | provenance | MaD:294 Sink:MaD:6 |
 | SanitizationTests.java:177:62:177:112 | getFromList(...) : String | SanitizationTests.java:177:54:177:113 | new URI(...) : URI | provenance | Config |
-| SanitizationTests.java:177:62:177:112 | getFromList(...) : String | SanitizationTests.java:177:54:177:113 | new URI(...) : URI | provenance | MaD:293 |
-| SanitizationTests.java:177:74:177:111 | of(...) : List [<element>] : String | SanitizationTests.java:177:62:177:112 | getFromList(...) : String | provenance | MaD:299 |
+| SanitizationTests.java:177:62:177:112 | getFromList(...) : String | SanitizationTests.java:177:54:177:113 | new URI(...) : URI | provenance | MaD:294 |
+| SanitizationTests.java:177:74:177:111 | of(...) : List [<element>] : String | SanitizationTests.java:177:62:177:112 | getFromList(...) : String | provenance | MaD:301 |
 | SanitizationTests.java:177:74:177:111 | of(...) : List [<element>] : String | SanitizationTests.java:199:31:199:112 | list : List [<element>] : String | provenance |  |
-| SanitizationTests.java:177:82:177:110 | getParameter(...) : String | SanitizationTests.java:177:74:177:111 | of(...) : List [<element>] : String | provenance | Src:MaD:285 MaD:298 |
+| SanitizationTests.java:177:82:177:110 | getParameter(...) : String | SanitizationTests.java:177:74:177:111 | of(...) : List [<element>] : String | provenance | Src:MaD:286 MaD:300 |
 | SanitizationTests.java:199:31:199:112 | list : List [<element>] : String | SanitizationTests.java:200:16:200:19 | list : List [<element>] : String | provenance |  |
-| SanitizationTests.java:200:16:200:19 | list : List [<element>] : String | SanitizationTests.java:200:16:200:26 | get(...) : String | provenance | MaD:299 |
-| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:32:39:32:59 | ... + ... | provenance | Src:MaD:285 Sink:MaD:272 |
-| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:33:69:33:82 | fooResourceUrl | provenance | Src:MaD:285  |
-| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:34:73:34:86 | fooResourceUrl | provenance | Src:MaD:285  |
-| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:35:87:35:100 | fooResourceUrl | provenance | Src:MaD:285  |
-| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:38:83:38:96 | fooResourceUrl : String | provenance | Src:MaD:285  |
-| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:40:105:40:118 | fooResourceUrl : String | provenance | Src:MaD:285  |
-| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:43:35:43:48 | fooResourceUrl | provenance | Src:MaD:285 Sink:MaD:270 |
-| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:44:91:44:104 | fooResourceUrl | provenance | Src:MaD:285  |
-| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:45:95:45:108 | fooResourceUrl | provenance | Src:MaD:285  |
-| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:46:109:46:122 | fooResourceUrl | provenance | Src:MaD:285  |
-| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:49:105:49:118 | fooResourceUrl : String | provenance | Src:MaD:285  |
-| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:51:127:51:140 | fooResourceUrl : String | provenance | Src:MaD:285  |
-| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:54:34:54:47 | fooResourceUrl | provenance | Src:MaD:285 Sink:MaD:271 |
-| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:55:79:55:92 | fooResourceUrl | provenance | Src:MaD:285  |
-| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:56:83:56:96 | fooResourceUrl | provenance | Src:MaD:285  |
-| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:57:97:57:110 | fooResourceUrl | provenance | Src:MaD:285  |
-| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:60:93:60:106 | fooResourceUrl : String | provenance | Src:MaD:285  |
-| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:62:115:62:128 | fooResourceUrl : String | provenance | Src:MaD:285  |
-| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:65:39:65:52 | fooResourceUrl | provenance | Src:MaD:285 Sink:MaD:273 |
-| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:66:69:66:82 | fooResourceUrl | provenance | Src:MaD:285  |
-| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:67:73:67:86 | fooResourceUrl | provenance | Src:MaD:285  |
-| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:68:87:68:100 | fooResourceUrl | provenance | Src:MaD:285  |
-| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:71:83:71:96 | fooResourceUrl : String | provenance | Src:MaD:285  |
-| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:73:105:73:118 | fooResourceUrl : String | provenance | Src:MaD:285  |
-| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:76:41:76:54 | fooResourceUrl | provenance | Src:MaD:285 Sink:MaD:276 |
-| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:77:93:77:106 | fooResourceUrl | provenance | Src:MaD:285  |
-| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:78:97:78:110 | fooResourceUrl | provenance | Src:MaD:285  |
-| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:79:111:79:124 | fooResourceUrl | provenance | Src:MaD:285  |
-| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:82:107:82:120 | fooResourceUrl : String | provenance | Src:MaD:285  |
-| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:84:129:84:142 | fooResourceUrl : String | provenance | Src:MaD:285  |
-| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:87:48:87:61 | fooResourceUrl : String | provenance | Src:MaD:285  |
-| SpringSSRF.java:38:83:38:96 | fooResourceUrl : String | SpringSSRF.java:38:69:38:97 | of(...) | provenance | MaD:300 |
-| SpringSSRF.java:40:105:40:118 | fooResourceUrl : String | SpringSSRF.java:40:69:40:119 | of(...) | provenance | MaD:301 |
-| SpringSSRF.java:49:105:49:118 | fooResourceUrl : String | SpringSSRF.java:49:91:49:119 | of(...) | provenance | MaD:300 |
-| SpringSSRF.java:51:127:51:140 | fooResourceUrl : String | SpringSSRF.java:51:91:51:141 | of(...) | provenance | MaD:301 |
-| SpringSSRF.java:60:93:60:106 | fooResourceUrl : String | SpringSSRF.java:60:79:60:107 | of(...) | provenance | MaD:300 |
-| SpringSSRF.java:62:115:62:128 | fooResourceUrl : String | SpringSSRF.java:62:79:62:129 | of(...) | provenance | MaD:301 |
-| SpringSSRF.java:71:83:71:96 | fooResourceUrl : String | SpringSSRF.java:71:69:71:97 | of(...) | provenance | MaD:300 |
-| SpringSSRF.java:73:105:73:118 | fooResourceUrl : String | SpringSSRF.java:73:69:73:119 | of(...) | provenance | MaD:301 |
-| SpringSSRF.java:82:107:82:120 | fooResourceUrl : String | SpringSSRF.java:82:93:82:121 | of(...) | provenance | MaD:300 |
-| SpringSSRF.java:84:129:84:142 | fooResourceUrl : String | SpringSSRF.java:84:93:84:143 | of(...) | provenance | MaD:301 |
+| SanitizationTests.java:200:16:200:19 | list : List [<element>] : String | SanitizationTests.java:200:16:200:26 | get(...) : String | provenance | MaD:301 |
+| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:32:39:32:59 | ... + ... | provenance | Src:MaD:286 Sink:MaD:272 |
+| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:33:69:33:82 | fooResourceUrl | provenance | Src:MaD:286  |
+| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:34:73:34:86 | fooResourceUrl | provenance | Src:MaD:286  |
+| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:35:87:35:100 | fooResourceUrl | provenance | Src:MaD:286  |
+| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:38:83:38:96 | fooResourceUrl : String | provenance | Src:MaD:286  |
+| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:40:105:40:118 | fooResourceUrl : String | provenance | Src:MaD:286  |
+| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:43:35:43:48 | fooResourceUrl | provenance | Src:MaD:286 Sink:MaD:270 |
+| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:44:91:44:104 | fooResourceUrl | provenance | Src:MaD:286  |
+| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:45:95:45:108 | fooResourceUrl | provenance | Src:MaD:286  |
+| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:46:109:46:122 | fooResourceUrl | provenance | Src:MaD:286  |
+| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:49:105:49:118 | fooResourceUrl : String | provenance | Src:MaD:286  |
+| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:51:127:51:140 | fooResourceUrl : String | provenance | Src:MaD:286  |
+| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:54:34:54:47 | fooResourceUrl | provenance | Src:MaD:286 Sink:MaD:271 |
+| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:55:79:55:92 | fooResourceUrl | provenance | Src:MaD:286  |
+| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:56:83:56:96 | fooResourceUrl | provenance | Src:MaD:286  |
+| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:57:97:57:110 | fooResourceUrl | provenance | Src:MaD:286  |
+| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:60:93:60:106 | fooResourceUrl : String | provenance | Src:MaD:286  |
+| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:62:115:62:128 | fooResourceUrl : String | provenance | Src:MaD:286  |
+| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:65:39:65:52 | fooResourceUrl | provenance | Src:MaD:286 Sink:MaD:273 |
+| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:66:69:66:82 | fooResourceUrl | provenance | Src:MaD:286  |
+| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:67:73:67:86 | fooResourceUrl | provenance | Src:MaD:286  |
+| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:68:87:68:100 | fooResourceUrl | provenance | Src:MaD:286  |
+| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:71:83:71:96 | fooResourceUrl : String | provenance | Src:MaD:286  |
+| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:73:105:73:118 | fooResourceUrl : String | provenance | Src:MaD:286  |
+| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:76:41:76:54 | fooResourceUrl | provenance | Src:MaD:286 Sink:MaD:276 |
+| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:77:93:77:106 | fooResourceUrl | provenance | Src:MaD:286  |
+| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:78:97:78:110 | fooResourceUrl | provenance | Src:MaD:286  |
+| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:79:111:79:124 | fooResourceUrl | provenance | Src:MaD:286  |
+| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:82:107:82:120 | fooResourceUrl : String | provenance | Src:MaD:286  |
+| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:84:129:84:142 | fooResourceUrl : String | provenance | Src:MaD:286  |
+| SpringSSRF.java:28:33:28:60 | getParameter(...) : String | SpringSSRF.java:87:48:87:61 | fooResourceUrl : String | provenance | Src:MaD:286  |
+| SpringSSRF.java:38:83:38:96 | fooResourceUrl : String | SpringSSRF.java:38:69:38:97 | of(...) | provenance | MaD:302 |
+| SpringSSRF.java:40:105:40:118 | fooResourceUrl : String | SpringSSRF.java:40:69:40:119 | of(...) | provenance | MaD:303 |
+| SpringSSRF.java:49:105:49:118 | fooResourceUrl : String | SpringSSRF.java:49:91:49:119 | of(...) | provenance | MaD:302 |
+| SpringSSRF.java:51:127:51:140 | fooResourceUrl : String | SpringSSRF.java:51:91:51:141 | of(...) | provenance | MaD:303 |
+| SpringSSRF.java:60:93:60:106 | fooResourceUrl : String | SpringSSRF.java:60:79:60:107 | of(...) | provenance | MaD:302 |
+| SpringSSRF.java:62:115:62:128 | fooResourceUrl : String | SpringSSRF.java:62:79:62:129 | of(...) | provenance | MaD:303 |
+| SpringSSRF.java:71:83:71:96 | fooResourceUrl : String | SpringSSRF.java:71:69:71:97 | of(...) | provenance | MaD:302 |
+| SpringSSRF.java:73:105:73:118 | fooResourceUrl : String | SpringSSRF.java:73:69:73:119 | of(...) | provenance | MaD:303 |
+| SpringSSRF.java:82:107:82:120 | fooResourceUrl : String | SpringSSRF.java:82:93:82:121 | of(...) | provenance | MaD:302 |
+| SpringSSRF.java:84:129:84:142 | fooResourceUrl : String | SpringSSRF.java:84:93:84:143 | of(...) | provenance | MaD:303 |
 | SpringSSRF.java:87:48:87:61 | fooResourceUrl : String | SpringSSRF.java:87:40:87:62 | new URI(...) | provenance | Config Sink:MaD:277 |
-| SpringSSRF.java:87:48:87:61 | fooResourceUrl : String | SpringSSRF.java:87:40:87:62 | new URI(...) | provenance | MaD:293 Sink:MaD:277 |
+| SpringSSRF.java:87:48:87:61 | fooResourceUrl : String | SpringSSRF.java:87:40:87:62 | new URI(...) | provenance | MaD:294 Sink:MaD:277 |
 | SpringSSRF.java:87:48:87:61 | fooResourceUrl : String | SpringSSRF.java:88:92:88:105 | fooResourceUrl | provenance |  |
 | SpringSSRF.java:87:48:87:61 | fooResourceUrl : String | SpringSSRF.java:89:96:89:109 | fooResourceUrl | provenance |  |
 | SpringSSRF.java:87:48:87:61 | fooResourceUrl : String | SpringSSRF.java:90:110:90:123 | fooResourceUrl | provenance |  |
@@ -956,20 +962,20 @@ edges
 | SpringSSRF.java:87:48:87:61 | fooResourceUrl : String | SpringSSRF.java:159:72:159:85 | fooResourceUrl : String | provenance |  |
 | SpringSSRF.java:87:48:87:61 | fooResourceUrl : String | SpringSSRF.java:161:94:161:107 | fooResourceUrl : String | provenance |  |
 | SpringSSRF.java:87:48:87:61 | fooResourceUrl : String | SpringSSRF.java:166:35:166:48 | fooResourceUrl : String | provenance |  |
-| SpringSSRF.java:93:106:93:119 | fooResourceUrl : String | SpringSSRF.java:93:92:93:120 | of(...) | provenance | MaD:300 |
-| SpringSSRF.java:95:128:95:141 | fooResourceUrl : String | SpringSSRF.java:95:92:95:142 | of(...) | provenance | MaD:301 |
-| SpringSSRF.java:104:94:104:107 | fooResourceUrl : String | SpringSSRF.java:104:80:104:108 | of(...) | provenance | MaD:300 |
-| SpringSSRF.java:106:116:106:129 | fooResourceUrl : String | SpringSSRF.java:106:80:106:130 | of(...) | provenance | MaD:301 |
-| SpringSSRF.java:115:106:115:119 | fooResourceUrl : String | SpringSSRF.java:115:92:115:120 | of(...) | provenance | MaD:300 |
-| SpringSSRF.java:117:128:117:141 | fooResourceUrl : String | SpringSSRF.java:117:92:117:142 | of(...) | provenance | MaD:301 |
-| SpringSSRF.java:126:82:126:95 | fooResourceUrl : String | SpringSSRF.java:126:68:126:96 | of(...) | provenance | MaD:300 |
-| SpringSSRF.java:128:104:128:117 | fooResourceUrl : String | SpringSSRF.java:128:68:128:118 | of(...) | provenance | MaD:301 |
-| SpringSSRF.java:137:63:137:76 | fooResourceUrl : String | SpringSSRF.java:137:49:137:77 | of(...) | provenance | MaD:300 |
-| SpringSSRF.java:139:85:139:98 | fooResourceUrl : String | SpringSSRF.java:139:49:139:99 | of(...) | provenance | MaD:301 |
-| SpringSSRF.java:148:71:148:84 | fooResourceUrl : String | SpringSSRF.java:148:57:148:85 | of(...) | provenance | MaD:300 |
-| SpringSSRF.java:150:93:150:106 | fooResourceUrl : String | SpringSSRF.java:150:57:150:107 | of(...) | provenance | MaD:301 |
-| SpringSSRF.java:159:72:159:85 | fooResourceUrl : String | SpringSSRF.java:159:58:159:86 | of(...) | provenance | MaD:300 |
-| SpringSSRF.java:161:94:161:107 | fooResourceUrl : String | SpringSSRF.java:161:58:161:108 | of(...) | provenance | MaD:301 |
+| SpringSSRF.java:93:106:93:119 | fooResourceUrl : String | SpringSSRF.java:93:92:93:120 | of(...) | provenance | MaD:302 |
+| SpringSSRF.java:95:128:95:141 | fooResourceUrl : String | SpringSSRF.java:95:92:95:142 | of(...) | provenance | MaD:303 |
+| SpringSSRF.java:104:94:104:107 | fooResourceUrl : String | SpringSSRF.java:104:80:104:108 | of(...) | provenance | MaD:302 |
+| SpringSSRF.java:106:116:106:129 | fooResourceUrl : String | SpringSSRF.java:106:80:106:130 | of(...) | provenance | MaD:303 |
+| SpringSSRF.java:115:106:115:119 | fooResourceUrl : String | SpringSSRF.java:115:92:115:120 | of(...) | provenance | MaD:302 |
+| SpringSSRF.java:117:128:117:141 | fooResourceUrl : String | SpringSSRF.java:117:92:117:142 | of(...) | provenance | MaD:303 |
+| SpringSSRF.java:126:82:126:95 | fooResourceUrl : String | SpringSSRF.java:126:68:126:96 | of(...) | provenance | MaD:302 |
+| SpringSSRF.java:128:104:128:117 | fooResourceUrl : String | SpringSSRF.java:128:68:128:118 | of(...) | provenance | MaD:303 |
+| SpringSSRF.java:137:63:137:76 | fooResourceUrl : String | SpringSSRF.java:137:49:137:77 | of(...) | provenance | MaD:302 |
+| SpringSSRF.java:139:85:139:98 | fooResourceUrl : String | SpringSSRF.java:139:49:139:99 | of(...) | provenance | MaD:303 |
+| SpringSSRF.java:148:71:148:84 | fooResourceUrl : String | SpringSSRF.java:148:57:148:85 | of(...) | provenance | MaD:302 |
+| SpringSSRF.java:150:93:150:106 | fooResourceUrl : String | SpringSSRF.java:150:57:150:107 | of(...) | provenance | MaD:303 |
+| SpringSSRF.java:159:72:159:85 | fooResourceUrl : String | SpringSSRF.java:159:58:159:86 | of(...) | provenance | MaD:302 |
+| SpringSSRF.java:161:94:161:107 | fooResourceUrl : String | SpringSSRF.java:161:58:161:108 | of(...) | provenance | MaD:303 |
 | SpringSSRF.java:166:27:166:49 | new URI(...) : URI | SpringSSRF.java:168:44:168:46 | uri | provenance | Sink:MaD:263 |
 | SpringSSRF.java:166:27:166:49 | new URI(...) : URI | SpringSSRF.java:170:35:170:37 | uri | provenance | Sink:MaD:258 |
 | SpringSSRF.java:166:27:166:49 | new URI(...) : URI | SpringSSRF.java:171:35:171:37 | uri | provenance | Sink:MaD:264 |
@@ -979,7 +985,7 @@ edges
 | SpringSSRF.java:166:27:166:49 | new URI(...) : URI | SpringSSRF.java:175:36:175:38 | uri | provenance | Sink:MaD:259 |
 | SpringSSRF.java:166:27:166:49 | new URI(...) : URI | SpringSSRF.java:176:44:176:46 | uri | provenance | Sink:MaD:260 |
 | SpringSSRF.java:166:35:166:48 | fooResourceUrl : String | SpringSSRF.java:166:27:166:49 | new URI(...) : URI | provenance | Config |
-| SpringSSRF.java:166:35:166:48 | fooResourceUrl : String | SpringSSRF.java:166:27:166:49 | new URI(...) : URI | provenance | MaD:293 |
+| SpringSSRF.java:166:35:166:48 | fooResourceUrl : String | SpringSSRF.java:166:27:166:49 | new URI(...) : URI | provenance | MaD:294 |
 | SpringSSRF.java:166:35:166:48 | fooResourceUrl : String | SpringSSRF.java:179:35:179:48 | fooResourceUrl : String | provenance |  |
 | SpringSSRF.java:179:27:179:49 | new URI(...) : URI | SpringSSRF.java:182:49:182:51 | uri | provenance | Sink:MaD:251 |
 | SpringSSRF.java:179:27:179:49 | new URI(...) : URI | SpringSSRF.java:183:58:183:60 | uri | provenance | Sink:MaD:252 |
@@ -988,84 +994,84 @@ edges
 | SpringSSRF.java:179:27:179:49 | new URI(...) : URI | SpringSSRF.java:186:57:186:59 | uri | provenance | Sink:MaD:254 |
 | SpringSSRF.java:179:27:179:49 | new URI(...) : URI | SpringSSRF.java:187:66:187:68 | uri | provenance | Sink:MaD:256 |
 | SpringSSRF.java:179:35:179:48 | fooResourceUrl : String | SpringSSRF.java:179:27:179:49 | new URI(...) : URI | provenance | Config |
-| SpringSSRF.java:179:35:179:48 | fooResourceUrl : String | SpringSSRF.java:179:27:179:49 | new URI(...) : URI | provenance | MaD:293 |
-| URLClassLoaderSSRF.java:16:26:16:52 | getParameter(...) : String | URLClassLoaderSSRF.java:17:31:17:33 | url : String | provenance | Src:MaD:285  |
+| SpringSSRF.java:179:35:179:48 | fooResourceUrl : String | SpringSSRF.java:179:27:179:49 | new URI(...) : URI | provenance | MaD:294 |
+| URLClassLoaderSSRF.java:16:26:16:52 | getParameter(...) : String | URLClassLoaderSSRF.java:17:31:17:33 | url : String | provenance | Src:MaD:286  |
 | URLClassLoaderSSRF.java:17:23:17:34 | new URI(...) : URI | URLClassLoaderSSRF.java:18:74:18:76 | uri : URI | provenance |  |
 | URLClassLoaderSSRF.java:17:31:17:33 | url : String | URLClassLoaderSSRF.java:17:23:17:34 | new URI(...) : URI | provenance | Config |
-| URLClassLoaderSSRF.java:17:31:17:33 | url : String | URLClassLoaderSSRF.java:17:23:17:34 | new URI(...) : URI | provenance | MaD:293 |
+| URLClassLoaderSSRF.java:17:31:17:33 | url : String | URLClassLoaderSSRF.java:17:23:17:34 | new URI(...) : URI | provenance | MaD:294 |
 | URLClassLoaderSSRF.java:18:64:18:85 | {...} : URL[] [[]] : URL | URLClassLoaderSSRF.java:18:64:18:85 | new URL[] | provenance | Sink:MaD:13 |
 | URLClassLoaderSSRF.java:18:64:18:85 | {...} : URL[] [[]] : URL | URLClassLoaderSSRF.java:18:64:18:85 | new URL[] | provenance | Sink:MaD:13 |
-| URLClassLoaderSSRF.java:18:74:18:76 | uri : URI | URLClassLoaderSSRF.java:18:74:18:84 | toURL(...) : URL | provenance | MaD:296 |
+| URLClassLoaderSSRF.java:18:74:18:76 | uri : URI | URLClassLoaderSSRF.java:18:74:18:84 | toURL(...) : URL | provenance | MaD:298 |
 | URLClassLoaderSSRF.java:18:74:18:84 | toURL(...) : URL | URLClassLoaderSSRF.java:18:64:18:85 | {...} : URL[] [[]] : URL | provenance |  |
-| URLClassLoaderSSRF.java:28:26:28:52 | getParameter(...) : String | URLClassLoaderSSRF.java:29:31:29:33 | url : String | provenance | Src:MaD:285  |
+| URLClassLoaderSSRF.java:28:26:28:52 | getParameter(...) : String | URLClassLoaderSSRF.java:29:31:29:33 | url : String | provenance | Src:MaD:286  |
 | URLClassLoaderSSRF.java:29:23:29:34 | new URI(...) : URI | URLClassLoaderSSRF.java:30:74:30:76 | uri : URI | provenance |  |
 | URLClassLoaderSSRF.java:29:31:29:33 | url : String | URLClassLoaderSSRF.java:29:23:29:34 | new URI(...) : URI | provenance | Config |
-| URLClassLoaderSSRF.java:29:31:29:33 | url : String | URLClassLoaderSSRF.java:29:23:29:34 | new URI(...) : URI | provenance | MaD:293 |
+| URLClassLoaderSSRF.java:29:31:29:33 | url : String | URLClassLoaderSSRF.java:29:23:29:34 | new URI(...) : URI | provenance | MaD:294 |
 | URLClassLoaderSSRF.java:30:64:30:85 | {...} : URL[] [[]] : URL | URLClassLoaderSSRF.java:30:64:30:85 | new URL[] | provenance | Sink:MaD:14 |
 | URLClassLoaderSSRF.java:30:64:30:85 | {...} : URL[] [[]] : URL | URLClassLoaderSSRF.java:30:64:30:85 | new URL[] | provenance | Sink:MaD:14 |
-| URLClassLoaderSSRF.java:30:74:30:76 | uri : URI | URLClassLoaderSSRF.java:30:74:30:84 | toURL(...) : URL | provenance | MaD:296 |
+| URLClassLoaderSSRF.java:30:74:30:76 | uri : URI | URLClassLoaderSSRF.java:30:74:30:84 | toURL(...) : URL | provenance | MaD:298 |
 | URLClassLoaderSSRF.java:30:74:30:84 | toURL(...) : URL | URLClassLoaderSSRF.java:30:64:30:85 | {...} : URL[] [[]] : URL | provenance |  |
-| URLClassLoaderSSRF.java:40:26:40:52 | getParameter(...) : String | URLClassLoaderSSRF.java:41:31:41:33 | url : String | provenance | Src:MaD:285  |
+| URLClassLoaderSSRF.java:40:26:40:52 | getParameter(...) : String | URLClassLoaderSSRF.java:41:31:41:33 | url : String | provenance | Src:MaD:286  |
 | URLClassLoaderSSRF.java:41:23:41:34 | new URI(...) : URI | URLClassLoaderSSRF.java:44:74:44:76 | uri : URI | provenance |  |
 | URLClassLoaderSSRF.java:41:31:41:33 | url : String | URLClassLoaderSSRF.java:41:23:41:34 | new URI(...) : URI | provenance | Config |
-| URLClassLoaderSSRF.java:41:31:41:33 | url : String | URLClassLoaderSSRF.java:41:23:41:34 | new URI(...) : URI | provenance | MaD:293 |
+| URLClassLoaderSSRF.java:41:31:41:33 | url : String | URLClassLoaderSSRF.java:41:23:41:34 | new URI(...) : URI | provenance | MaD:294 |
 | URLClassLoaderSSRF.java:44:64:44:85 | {...} : URL[] [[]] : URL | URLClassLoaderSSRF.java:44:64:44:85 | new URL[] | provenance | Sink:MaD:15 |
 | URLClassLoaderSSRF.java:44:64:44:85 | {...} : URL[] [[]] : URL | URLClassLoaderSSRF.java:44:64:44:85 | new URL[] | provenance | Sink:MaD:15 |
-| URLClassLoaderSSRF.java:44:74:44:76 | uri : URI | URLClassLoaderSSRF.java:44:74:44:84 | toURL(...) : URL | provenance | MaD:296 |
+| URLClassLoaderSSRF.java:44:74:44:76 | uri : URI | URLClassLoaderSSRF.java:44:74:44:84 | toURL(...) : URL | provenance | MaD:298 |
 | URLClassLoaderSSRF.java:44:74:44:84 | toURL(...) : URL | URLClassLoaderSSRF.java:44:64:44:85 | {...} : URL[] [[]] : URL | provenance |  |
-| URLClassLoaderSSRF.java:54:26:54:52 | getParameter(...) : String | URLClassLoaderSSRF.java:55:31:55:33 | url : String | provenance | Src:MaD:285  |
+| URLClassLoaderSSRF.java:54:26:54:52 | getParameter(...) : String | URLClassLoaderSSRF.java:55:31:55:33 | url : String | provenance | Src:MaD:286  |
 | URLClassLoaderSSRF.java:55:23:55:34 | new URI(...) : URI | URLClassLoaderSSRF.java:56:82:56:84 | uri : URI | provenance |  |
 | URLClassLoaderSSRF.java:55:31:55:33 | url : String | URLClassLoaderSSRF.java:55:23:55:34 | new URI(...) : URI | provenance | Config |
-| URLClassLoaderSSRF.java:55:31:55:33 | url : String | URLClassLoaderSSRF.java:55:23:55:34 | new URI(...) : URI | provenance | MaD:293 |
+| URLClassLoaderSSRF.java:55:31:55:33 | url : String | URLClassLoaderSSRF.java:55:23:55:34 | new URI(...) : URI | provenance | MaD:294 |
 | URLClassLoaderSSRF.java:56:72:56:93 | {...} : URL[] [[]] : URL | URLClassLoaderSSRF.java:56:72:56:93 | new URL[] | provenance | Sink:MaD:16 |
-| URLClassLoaderSSRF.java:56:82:56:84 | uri : URI | URLClassLoaderSSRF.java:56:82:56:92 | toURL(...) : URL | provenance | MaD:296 |
+| URLClassLoaderSSRF.java:56:82:56:84 | uri : URI | URLClassLoaderSSRF.java:56:82:56:92 | toURL(...) : URL | provenance | MaD:298 |
 | URLClassLoaderSSRF.java:56:82:56:92 | toURL(...) : URL | URLClassLoaderSSRF.java:56:72:56:93 | {...} : URL[] [[]] : URL | provenance |  |
-| URLClassLoaderSSRF.java:66:26:66:52 | getParameter(...) : String | URLClassLoaderSSRF.java:67:31:67:33 | url : String | provenance | Src:MaD:285  |
+| URLClassLoaderSSRF.java:66:26:66:52 | getParameter(...) : String | URLClassLoaderSSRF.java:67:31:67:33 | url : String | provenance | Src:MaD:286  |
 | URLClassLoaderSSRF.java:67:23:67:34 | new URI(...) : URI | URLClassLoaderSSRF.java:70:31:70:33 | uri : URI | provenance |  |
 | URLClassLoaderSSRF.java:67:31:67:33 | url : String | URLClassLoaderSSRF.java:67:23:67:34 | new URI(...) : URI | provenance | Config |
-| URLClassLoaderSSRF.java:67:31:67:33 | url : String | URLClassLoaderSSRF.java:67:23:67:34 | new URI(...) : URI | provenance | MaD:293 |
+| URLClassLoaderSSRF.java:67:31:67:33 | url : String | URLClassLoaderSSRF.java:67:23:67:34 | new URI(...) : URI | provenance | MaD:294 |
 | URLClassLoaderSSRF.java:70:21:70:42 | {...} : URL[] [[]] : URL | URLClassLoaderSSRF.java:70:21:70:42 | new URL[] | provenance | Sink:MaD:11 |
 | URLClassLoaderSSRF.java:70:21:70:42 | {...} : URL[] [[]] : URL | URLClassLoaderSSRF.java:70:21:70:42 | new URL[] | provenance | Sink:MaD:11 |
-| URLClassLoaderSSRF.java:70:31:70:33 | uri : URI | URLClassLoaderSSRF.java:70:31:70:41 | toURL(...) : URL | provenance | MaD:296 |
+| URLClassLoaderSSRF.java:70:31:70:33 | uri : URI | URLClassLoaderSSRF.java:70:31:70:41 | toURL(...) : URL | provenance | MaD:298 |
 | URLClassLoaderSSRF.java:70:31:70:41 | toURL(...) : URL | URLClassLoaderSSRF.java:70:21:70:42 | {...} : URL[] [[]] : URL | provenance |  |
-| URLClassLoaderSSRF.java:83:26:83:52 | getParameter(...) : String | URLClassLoaderSSRF.java:84:31:84:33 | url : String | provenance | Src:MaD:285  |
+| URLClassLoaderSSRF.java:83:26:83:52 | getParameter(...) : String | URLClassLoaderSSRF.java:84:31:84:33 | url : String | provenance | Src:MaD:286  |
 | URLClassLoaderSSRF.java:84:23:84:34 | new URI(...) : URI | URLClassLoaderSSRF.java:89:31:89:33 | uri : URI | provenance |  |
 | URLClassLoaderSSRF.java:84:31:84:33 | url : String | URLClassLoaderSSRF.java:84:23:84:34 | new URI(...) : URI | provenance | Config |
-| URLClassLoaderSSRF.java:84:31:84:33 | url : String | URLClassLoaderSSRF.java:84:23:84:34 | new URI(...) : URI | provenance | MaD:293 |
+| URLClassLoaderSSRF.java:84:31:84:33 | url : String | URLClassLoaderSSRF.java:84:23:84:34 | new URI(...) : URI | provenance | MaD:294 |
 | URLClassLoaderSSRF.java:89:21:89:42 | {...} : URL[] [[]] : URL | URLClassLoaderSSRF.java:89:21:89:42 | new URL[] | provenance | Sink:MaD:12 |
 | URLClassLoaderSSRF.java:89:21:89:42 | {...} : URL[] [[]] : URL | URLClassLoaderSSRF.java:89:21:89:42 | new URL[] | provenance | Sink:MaD:12 |
-| URLClassLoaderSSRF.java:89:31:89:33 | uri : URI | URLClassLoaderSSRF.java:89:31:89:41 | toURL(...) : URL | provenance | MaD:296 |
+| URLClassLoaderSSRF.java:89:31:89:33 | uri : URI | URLClassLoaderSSRF.java:89:31:89:41 | toURL(...) : URL | provenance | MaD:298 |
 | URLClassLoaderSSRF.java:89:31:89:41 | toURL(...) : URL | URLClassLoaderSSRF.java:89:21:89:42 | {...} : URL[] [[]] : URL | provenance |  |
-| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:31:40:31:47 | source(...) : String | provenance | Src:MaD:285  |
-| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:36:16:36:23 | source(...) : String | provenance | Src:MaD:285  |
-| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:38:36:38:43 | source(...) : String | provenance | Src:MaD:285  |
-| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:40:16:40:23 | source(...) : String | provenance | Src:MaD:285  |
-| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:45:40:45:47 | source(...) : String | provenance | Src:MaD:285  |
-| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:47:40:47:47 | source(...) : String | provenance | Src:MaD:285  |
-| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:49:36:49:43 | source(...) : String | provenance | Src:MaD:285  |
-| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:51:36:51:43 | source(...) : String | provenance | Src:MaD:285  |
-| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:53:36:53:43 | source(...) : String | provenance | Src:MaD:285  |
-| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:55:44:55:51 | source(...) : String | provenance | Src:MaD:285  |
-| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:57:38:57:45 | source(...) : String | provenance | Src:MaD:285  |
-| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:59:44:59:51 | source(...) : String | provenance | Src:MaD:285  |
-| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:61:53:61:60 | source(...) : String | provenance | Src:MaD:285  |
-| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:63:32:63:39 | source(...) : String | provenance | Src:MaD:285  |
-| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:65:44:65:51 | source(...) : String | provenance | Src:MaD:285  |
-| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:67:32:67:39 | source(...) : String | provenance | Src:MaD:285  |
-| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:69:33:69:40 | source(...) : String | provenance | Src:MaD:285  |
-| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:71:53:71:60 | source(...) : String | provenance | Src:MaD:285  |
-| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:74:58:74:65 | source(...) : String | provenance | Src:MaD:285  |
-| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:76:62:76:69 | source(...) : String | provenance | Src:MaD:285  |
-| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:78:52:78:59 | source(...) : String | provenance | Src:MaD:285  |
-| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:80:34:80:41 | source(...) : String | provenance | Src:MaD:285  |
-| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:82:40:82:47 | source(...) : String | provenance | Src:MaD:285  |
-| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:84:40:84:47 | source(...) : String | provenance | Src:MaD:285  |
-| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:86:50:86:57 | source(...) : String | provenance | Src:MaD:285  |
-| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:92:33:92:40 | source(...) : String | provenance | Src:MaD:285  |
-| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:97:35:97:42 | source(...) : String | provenance | Src:MaD:285  |
-| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:102:32:102:39 | source(...) : String | provenance | Src:MaD:285  |
-| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:107:24:107:31 | source(...) : String | provenance | Src:MaD:285  |
-| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:112:24:112:31 | source(...) : String | provenance | Src:MaD:285  |
+| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:31:40:31:47 | source(...) : String | provenance | Src:MaD:286  |
+| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:36:16:36:23 | source(...) : String | provenance | Src:MaD:286  |
+| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:38:36:38:43 | source(...) : String | provenance | Src:MaD:286  |
+| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:40:16:40:23 | source(...) : String | provenance | Src:MaD:286  |
+| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:45:40:45:47 | source(...) : String | provenance | Src:MaD:286  |
+| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:47:40:47:47 | source(...) : String | provenance | Src:MaD:286  |
+| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:49:36:49:43 | source(...) : String | provenance | Src:MaD:286  |
+| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:51:36:51:43 | source(...) : String | provenance | Src:MaD:286  |
+| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:53:36:53:43 | source(...) : String | provenance | Src:MaD:286  |
+| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:55:44:55:51 | source(...) : String | provenance | Src:MaD:286  |
+| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:57:38:57:45 | source(...) : String | provenance | Src:MaD:286  |
+| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:59:44:59:51 | source(...) : String | provenance | Src:MaD:286  |
+| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:61:53:61:60 | source(...) : String | provenance | Src:MaD:286  |
+| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:63:32:63:39 | source(...) : String | provenance | Src:MaD:286  |
+| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:65:44:65:51 | source(...) : String | provenance | Src:MaD:286  |
+| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:67:32:67:39 | source(...) : String | provenance | Src:MaD:286  |
+| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:69:33:69:40 | source(...) : String | provenance | Src:MaD:286  |
+| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:71:53:71:60 | source(...) : String | provenance | Src:MaD:286  |
+| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:74:58:74:65 | source(...) : String | provenance | Src:MaD:286  |
+| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:76:62:76:69 | source(...) : String | provenance | Src:MaD:286  |
+| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:78:52:78:59 | source(...) : String | provenance | Src:MaD:286  |
+| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:80:34:80:41 | source(...) : String | provenance | Src:MaD:286  |
+| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:82:40:82:47 | source(...) : String | provenance | Src:MaD:286  |
+| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:84:40:84:47 | source(...) : String | provenance | Src:MaD:286  |
+| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:86:50:86:57 | source(...) : String | provenance | Src:MaD:286  |
+| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:92:33:92:40 | source(...) : String | provenance | Src:MaD:286  |
+| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:97:35:97:42 | source(...) : String | provenance | Src:MaD:286  |
+| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:102:32:102:39 | source(...) : String | provenance | Src:MaD:286  |
+| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:107:24:107:31 | source(...) : String | provenance | Src:MaD:286  |
+| mad/Test.java:26:16:26:41 | getParameter(...) : String | mad/Test.java:112:24:112:31 | source(...) : String | provenance | Src:MaD:286  |
 | mad/Test.java:31:40:31:47 | source(...) : String | mad/Test.java:31:24:31:47 | (...)... | provenance | Sink:MaD:7 |
 | mad/Test.java:36:16:36:23 | source(...) : String | mad/Test.java:36:10:36:23 | (...)... | provenance | Sink:MaD:9 |
 | mad/Test.java:38:36:38:43 | source(...) : String | mad/Test.java:38:28:38:43 | (...)... | provenance | Sink:MaD:8 |
@@ -1099,8 +1105,8 @@ edges
 | mad/Test.java:92:33:92:40 | source(...) : String | mad/Test.java:92:24:92:40 | (...)... | provenance | Sink:MaD:21 |
 | mad/Test.java:97:35:97:42 | source(...) : String | mad/Test.java:97:29:97:42 | (...)... | provenance | Sink:MaD:242 |
 | mad/Test.java:102:32:102:39 | source(...) : String | mad/Test.java:102:26:102:39 | (...)... | provenance | Sink:MaD:249 |
-| mad/Test.java:107:24:107:31 | source(...) : String | mad/Test.java:107:15:107:31 | (...)... | provenance | Sink:MaD:284 |
-| mad/Test.java:112:24:112:31 | source(...) : String | mad/Test.java:112:15:112:31 | (...)... | provenance | Sink:MaD:283 |
+| mad/Test.java:107:24:107:31 | source(...) : String | mad/Test.java:107:15:107:31 | (...)... | provenance | Sink:MaD:285 |
+| mad/Test.java:112:24:112:31 | source(...) : String | mad/Test.java:112:15:112:31 | (...)... | provenance | Sink:MaD:284 |
 models
 | 1 | Sink: com.zaxxer.hikari; HikariConfig; false; HikariConfig; (Properties); ; Argument[0]; request-forgery; manual |
 | 2 | Sink: com.zaxxer.hikari; HikariConfig; false; setJdbcUrl; (String); ; Argument[0]; request-forgery; manual |
@@ -1383,32 +1389,34 @@ models
 | 279 | Sink: org.springframework.web.client; RestTemplate; false; postForObject; ; ; Argument[0]; request-forgery; manual |
 | 280 | Sink: org.springframework.web.client; RestTemplate; false; put; ; ; Argument[0]; request-forgery; manual |
 | 281 | Sink: org.springframework.web.reactive.function.client; WebClient$Builder; false; baseUrl; ; ; Argument[0]; request-forgery; manual |
-| 282 | Sink: org.springframework.web.reactive.function.client; WebClient; false; create; ; ; Argument[0]; request-forgery; manual |
-| 283 | Sink: play.libs.ws; StandaloneWSClient; true; url; ; ; Argument[0]; request-forgery; manual |
-| 284 | Sink: play.libs.ws; WSClient; true; url; ; ; Argument[0]; request-forgery; manual |
-| 285 | Source: javax.servlet; ServletRequest; false; getParameter; (String); ; ReturnValue; remote; manual |
-| 286 | Summary: java.lang; AbstractStringBuilder; true; append; ; ; Argument[0]; Argument[this]; taint; manual |
-| 287 | Summary: java.lang; AbstractStringBuilder; true; append; ; ; Argument[this]; ReturnValue; value; manual |
-| 288 | Summary: java.lang; CharSequence; true; toString; ; ; Argument[this]; ReturnValue; taint; manual |
-| 289 | Summary: java.lang; String; false; format; (String,Object[]); ; Argument[1].ArrayElement; ReturnValue; taint; manual |
-| 290 | Summary: java.lang; StringBuilder; true; StringBuilder; ; ; Argument[0]; Argument[this]; taint; manual |
-| 291 | Summary: java.net.http; HttpRequest$Builder; true; build; (); ; Argument[this]; ReturnValue; taint; df-generated |
-| 292 | Summary: java.net.http; HttpRequest; true; newBuilder; (URI); ; Argument[0]; ReturnValue; taint; df-generated |
-| 293 | Summary: java.net; URI; false; URI; (String); ; Argument[0]; Argument[this]; taint; manual |
-| 294 | Summary: java.net; URI; false; URI; (String,String,String); ; Argument[1]; Argument[this]; taint; ai-manual |
-| 295 | Summary: java.net; URI; false; toString; ; ; Argument[this]; ReturnValue; taint; manual |
-| 296 | Summary: java.net; URI; false; toURL; ; ; Argument[this]; ReturnValue; taint; manual |
-| 297 | Summary: java.net; URL; false; URL; (String); ; Argument[0]; Argument[this]; taint; manual |
-| 298 | Summary: java.util; List; false; of; (Object); ; Argument[0]; ReturnValue.Element; value; manual |
-| 299 | Summary: java.util; List; true; get; (int); ; Argument[this].Element; ReturnValue; value; manual |
-| 300 | Summary: java.util; Map; false; of; ; ; Argument[1]; ReturnValue.MapValue; value; manual |
-| 301 | Summary: java.util; Map; false; of; ; ; Argument[3]; ReturnValue.MapValue; value; manual |
-| 302 | Summary: java.util; Properties; true; setProperty; (String,String); ; Argument[1]; Argument[this].MapValue; value; manual |
-| 303 | Summary: org.apache.hc.core5.http; HttpHost; true; HttpHost; (String); ; Argument[0]; Argument[this]; taint; hq-manual |
-| 304 | Summary: org.apache.http.client.methods; RequestBuilder; true; build; (); ; Argument[this]; ReturnValue; taint; ai-manual |
-| 305 | Summary: org.apache.http.client.methods; RequestBuilder; true; get; (String); ; Argument[0]; ReturnValue; taint; ai-manual |
-| 306 | Summary: org.apache.http.message; BasicRequestLine; false; BasicRequestLine; ; ; Argument[1]; Argument[this]; taint; manual |
-| 307 | Summary: org.apache.http; HttpHost; true; HttpHost; (String); ; Argument[0]; Argument[this]; taint; hq-manual |
+| 282 | Sink: org.springframework.web.reactive.function.client; WebClient$UriSpec; true; uri; ; ; Argument[0]; request-forgery; manual |
+| 283 | Sink: org.springframework.web.reactive.function.client; WebClient; false; create; ; ; Argument[0]; request-forgery; manual |
+| 284 | Sink: play.libs.ws; StandaloneWSClient; true; url; ; ; Argument[0]; request-forgery; manual |
+| 285 | Sink: play.libs.ws; WSClient; true; url; ; ; Argument[0]; request-forgery; manual |
+| 286 | Source: javax.servlet; ServletRequest; false; getParameter; (String); ; ReturnValue; remote; manual |
+| 287 | Summary: java.lang; AbstractStringBuilder; true; append; ; ; Argument[0]; Argument[this]; taint; manual |
+| 288 | Summary: java.lang; AbstractStringBuilder; true; append; ; ; Argument[this]; ReturnValue; value; manual |
+| 289 | Summary: java.lang; CharSequence; true; toString; ; ; Argument[this]; ReturnValue; taint; manual |
+| 290 | Summary: java.lang; String; false; format; (String,Object[]); ; Argument[1].ArrayElement; ReturnValue; taint; manual |
+| 291 | Summary: java.lang; StringBuilder; true; StringBuilder; ; ; Argument[0]; Argument[this]; taint; manual |
+| 292 | Summary: java.net.http; HttpRequest$Builder; true; build; (); ; Argument[this]; ReturnValue; taint; df-generated |
+| 293 | Summary: java.net.http; HttpRequest; true; newBuilder; (URI); ; Argument[0]; ReturnValue; taint; df-generated |
+| 294 | Summary: java.net; URI; false; URI; (String); ; Argument[0]; Argument[this]; taint; manual |
+| 295 | Summary: java.net; URI; false; URI; (String,String,String); ; Argument[1]; Argument[this]; taint; ai-manual |
+| 296 | Summary: java.net; URI; false; create; ; ; Argument[0]; ReturnValue; taint; manual |
+| 297 | Summary: java.net; URI; false; toString; ; ; Argument[this]; ReturnValue; taint; manual |
+| 298 | Summary: java.net; URI; false; toURL; ; ; Argument[this]; ReturnValue; taint; manual |
+| 299 | Summary: java.net; URL; false; URL; (String); ; Argument[0]; Argument[this]; taint; manual |
+| 300 | Summary: java.util; List; false; of; (Object); ; Argument[0]; ReturnValue.Element; value; manual |
+| 301 | Summary: java.util; List; true; get; (int); ; Argument[this].Element; ReturnValue; value; manual |
+| 302 | Summary: java.util; Map; false; of; ; ; Argument[1]; ReturnValue.MapValue; value; manual |
+| 303 | Summary: java.util; Map; false; of; ; ; Argument[3]; ReturnValue.MapValue; value; manual |
+| 304 | Summary: java.util; Properties; true; setProperty; (String,String); ; Argument[1]; Argument[this].MapValue; value; manual |
+| 305 | Summary: org.apache.hc.core5.http; HttpHost; true; HttpHost; (String); ; Argument[0]; Argument[this]; taint; hq-manual |
+| 306 | Summary: org.apache.http.client.methods; RequestBuilder; true; build; (); ; Argument[this]; ReturnValue; taint; ai-manual |
+| 307 | Summary: org.apache.http.client.methods; RequestBuilder; true; get; (String); ; Argument[0]; ReturnValue; taint; ai-manual |
+| 308 | Summary: org.apache.http.message; BasicRequestLine; false; BasicRequestLine; ; ; Argument[1]; Argument[this]; taint; manual |
+| 309 | Summary: org.apache.http; HttpHost; true; HttpHost; (String); ; Argument[0]; Argument[this]; taint; hq-manual |
 nodes
 | ApacheHttpClientExecuteSSRF.java:23:29:23:56 | getParameter(...) : String | semmle.label | getParameter(...) : String |
 | ApacheHttpClientExecuteSSRF.java:25:29:25:48 | new HttpHost(...) : HttpHost | semmle.label | new HttpHost(...) : HttpHost |
@@ -1781,6 +1789,11 @@ nodes
 | ReactiveWebClientSSRF.java:16:52:16:54 | url | semmle.label | url |
 | ReactiveWebClientSSRF.java:32:26:32:52 | getParameter(...) : String | semmle.label | getParameter(...) : String |
 | ReactiveWebClientSSRF.java:35:30:35:32 | url | semmle.label | url |
+| ReactiveWebClientSSRF.java:55:24:55:50 | getParameter(...) : String | semmle.label | getParameter(...) : String |
+| ReactiveWebClientSSRF.java:57:26:57:26 | p | semmle.label | p |
+| ReactiveWebClientSSRF.java:62:25:62:51 | getParameter(...) : String | semmle.label | getParameter(...) : String |
+| ReactiveWebClientSSRF.java:64:26:64:72 | create(...) | semmle.label | create(...) |
+| ReactiveWebClientSSRF.java:64:46:64:71 | ... + ... : String | semmle.label | ... + ... : String |
 | SanitizationTests.java:22:23:22:58 | new URI(...) : URI | semmle.label | new URI(...) : URI |
 | SanitizationTests.java:22:31:22:57 | getParameter(...) : String | semmle.label | getParameter(...) : String |
 | SanitizationTests.java:25:29:25:55 | newBuilder(...) : Builder | semmle.label | newBuilder(...) : Builder |

--- a/java/ql/test/stubs/springframework-5.8.x/org/springframework/web/reactive/function/client/WebClient.java
+++ b/java/ql/test/stubs/springframework-5.8.x/org/springframework/web/reactive/function/client/WebClient.java
@@ -51,6 +51,7 @@ public interface WebClient {
 
 	interface UriSpec<S extends RequestHeadersSpec<?>> {
 		S uri(String uri, Object... uriVariables);
+		S uri(java.net.URI uri);
 	}
 
 	interface RequestBodySpec extends RequestHeadersSpec<RequestBodySpec> {


### PR DESCRIPTION
Spring WebFlux's reactive `WebClient` sends a request to the URL passed to the per-request `uri(...)` method (for example `webClient.get().uri(url)`), declared on `WebClient.UriSpec`. The `request-forgery` model covers `WebClient.create(url)` and `WebClient.builder().baseUrl(url)`. It does not yet cover the per-request `uri(...)` method, which is the usual way to set a request URL, so a URL built from untrusted input and sent through `uri(...)` is a `java/ssrf` sink that is currently unmodeled.

### Change

Adds `WebClient$UriSpec.uri` as a `request-forgery` sink:

```yaml
- ["org.springframework.web.reactive.function.client", "WebClient$UriSpec", True, "uri", "", "", "Argument[0]", "request-forgery", "manual"]
```

- `subtypes` is `True` so the row also applies to `RequestHeadersUriSpec` and `RequestBodyUriSpec`, the receiver types returned by `get()`, `post()` and similar methods.
- The signature is left blank to cover all URL-bearing overloads: `uri(URI)`, `uri(String, Object...)` and `uri(String, Map)`.

### Testing

Validated at three levels.

**Query tests.** `ReactiveWebClientSSRF.java` adds tainted flows into `uri(String)` and `uri(URI)`, and `RequestForgery.expected` is regenerated. The CWE-918 tests pass.

**True positives (full-build database).** Compiled against the Spring WebFlux library, the sink reports untrusted input reaching the request URL:
- directly, via `uri(String)`;
- as a URI template, via `uri(String, Object...)`;
- via a `UriComponentsBuilder` whose host is attacker-controlled (`fromUriString`, `host`).

**Multi-repository variant analysis.**
- **Dataset:** 34 popular public Java projects (Spring and WebFlux based), using the CodeQL databases GitHub publishes for them, fetched through the [code scanning API](https://docs.github.com/rest/code-scanning/code-scanning#get-a-codeql-database-for-a-repository). The full list is below:
<details>
  <summary>Repositories analyzed (34)</summary>

  - [alibaba/arthas](https://github.com/alibaba/arthas)
  - [alibaba/canal](https://github.com/alibaba/canal)
  - [alibaba/nacos](https://github.com/alibaba/nacos)
  - [alibaba/spring-cloud-alibaba](https://github.com/alibaba/spring-cloud-alibaba)
  - [apache/dolphinscheduler](https://github.com/apache/dolphinscheduler)
  - [apache/dubbo](https://github.com/apache/dubbo)
  - [apache/rocketmq](https://github.com/apache/rocketmq)
  - [apache/shenyu](https://github.com/apache/shenyu)
  - [apache/skywalking](https://github.com/apache/skywalking)
  - [apolloconfig/apollo](https://github.com/apolloconfig/apollo)
  - [elunez/eladmin](https://github.com/elunez/eladmin)
  - [google/guava](https://github.com/google/guava)
  - [graphhopper/graphhopper](https://github.com/graphhopper/graphhopper)
  - [halo-dev/halo](https://github.com/halo-dev/halo)
  - [jeecgboot/jeecg-boot](https://github.com/jeecgboot/jeecg-boot)
  - [macrozheng/mall](https://github.com/macrozheng/mall)
  - [macrozheng/mall-swarm](https://github.com/macrozheng/mall-swarm)
  - [Netflix/zuul](https://github.com/Netflix/zuul)
  - [openzipkin/zipkin](https://github.com/openzipkin/zipkin)
  - [resilience4j/resilience4j](https://github.com/resilience4j/resilience4j)
  - [sofastack/sofa-boot](https://github.com/sofastack/sofa-boot)
  - [spring-cloud/spring-cloud-commons](https://github.com/spring-cloud/spring-cloud-commons)
  - [spring-cloud/spring-cloud-config](https://github.com/spring-cloud/spring-cloud-config)
  - [spring-cloud/spring-cloud-gateway](https://github.com/spring-cloud/spring-cloud-gateway)
  - [spring-cloud/spring-cloud-netflix](https://github.com/spring-cloud/spring-cloud-netflix)
  - [spring-cloud/spring-cloud-openfeign](https://github.com/spring-cloud/spring-cloud-openfeign)
  - [spring-projects/spring-boot](https://github.com/spring-projects/spring-boot)
  - [spring-projects/spring-framework](https://github.com/spring-projects/spring-framework)
  - [spring-projects/spring-security](https://github.com/spring-projects/spring-security)
  - [square/okhttp](https://github.com/square/okhttp)
  - [thingsboard/thingsboard](https://github.com/thingsboard/thingsboard)
  - [YunaiV/ruoyi-vue-pro](https://github.com/YunaiV/ruoyi-vue-pro)
  - [zalando/logbook](https://github.com/zalando/logbook)
  - [zhoutaoo/SpringCloud](https://github.com/zhoutaoo/SpringCloud)

  </details>
  
- **Coverage check:** the sink resolves and matches `WebClient.uri` call sites across the dataset, confirming the run exercises the new model.
- **Result:** no alerts, confirming no false positives on the dataset.

### Overload coverage

The blank signature also matches the `uri(Function<UriBuilder, URI>)` overload, whose `Argument[0]` is a builder callback. This matches how other fluent URL setters are modeled. The row can be restricted to the `String` and `URI` overloads if preferred.
