### PR TITLE
yeast: Add context scoping mechanism

### DIFF
--- a/shared/yeast/src/build.rs
+++ b/shared/yeast/src/build.rs
@@ -161,52 +161,74 @@ impl<'a, C> BuildCtx<'a, C> {
 }
 
 impl<C: Clone> BuildCtx<'_, C> {
-    /// Recursively translate a node via the framework's rule machinery.
-    /// In a OneShot phase, applies OneShot rules to the given node and
-    /// returns the resulting node ids. In a Repeating phase, errors
-    /// (translation is not meaningful when input and output share a
-    /// schema).
+    /// Recursively translate every id in the given iterable via the
+    /// framework's rule machinery. In a OneShot phase, applies OneShot
+    /// rules to each id and returns the accumulated resulting node ids
+    /// in order. In a Repeating phase, errors (translation is not
+    /// meaningful when input and output share a schema).
+    ///
+    /// The single-`Id` case works too, because `Id: IntoIterator<Item
+    /// = Id>` as a singleton iterator — so `ctx.translate(some_id)?`
+    /// returns a `Vec<Id>` containing whatever `some_id` translated to.
     ///
     /// Errors if this `BuildCtx` was constructed by hand (without a
     /// translator handle) — for example, in unit tests that don't go
     /// through the rule driver.
-    pub fn translate<I: Into<Id>>(&mut self, id: I) -> Result<Vec<Id>, String> {
-        let id = id.into();
-        match &self.translator {
-            Some(t) => t.translate(self.ast, self.user_ctx, id),
-            None => Err("translate() called on a BuildCtx without a translator handle".into()),
-        }
-    }
-
-    /// Translate every node in an iterator with a **fresh** user context
-    /// (reset to `C::default()`), restoring the previous context afterwards.
-    ///
-    /// Use when descending into a subtree — a body, expression, or statement
-    /// list — that must not inherit any of the surrounding translation
-    /// context (for example an enclosing binding modifier). Accepts optional
-    /// (`Option<Id>`) and repeated (`Vec<Id>`) captures (both `IntoIterator`);
-    /// for a single `Id`, wrap it in `std::iter::once(id)`.
-    pub fn translate_reset<I: Into<Id>>(
+    pub fn translate<I: Into<Id>>(
         &mut self,
         ids: impl IntoIterator<Item = I>,
-    ) -> Result<Vec<Id>, String>
-    where
-        C: Default,
-    {
-        let saved = std::mem::take(&mut *self.user_ctx);
+    ) -> Result<Vec<Id>, String> {
+        let translator = self
+            .translator
+            .as_ref()
+            .ok_or("translate() called on a BuildCtx without a translator handle")?;
         let mut out = Vec::new();
-        let mut result = Ok(());
         for id in ids {
-            match self.translate(id) {
-                Ok(v) => out.extend(v),
-                Err(e) => {
-                    result = Err(e);
-                    break;
-                }
-            }
+            let translated = translator.translate(self.ast, self.user_ctx, id.into())?;
+            out.extend(translated);
         }
-        *self.user_ctx = saved;
-        result.map(|()| out)
+        Ok(out)
+    }
+
+    /// Run `f` with a temporary child [`BuildCtx`] whose `user_ctx` is
+    /// a fresh clone of the current one, sharing everything else
+    /// (`ast`, `captures`, `fresh`, `source_range`, `translator`) by
+    /// re-borrow. Any mutations `f` makes to the child's `user_ctx`
+    /// are discarded when it returns — no restore needed, because the
+    /// mutations only ever happened on a local clone.
+    ///
+    /// Use for the rare rule that needs to translate a subtree under a
+    /// modified context *and then continue using its own (unmodified)
+    /// context afterwards*. For rules where the modified translation
+    /// is the last use of `ctx`, mutate `ctx` in place — the
+    /// framework's rule-boundary save/restore cleans up on rule exit.
+    ///
+    /// Example: an outer rule that translates one child subtree with a
+    /// reset context, then continues with the outer context intact:
+    ///
+    /// ```ignore
+    /// let val = ctx.scoped(|ctx| {
+    ///     ctx.reset();
+    ///     ctx.translate(val)
+    /// })?;
+    /// // `ctx` here is untouched by the reset inside the closure.
+    /// let other = ctx.translate(other_id)?;
+    /// ```
+    pub fn scoped<F, R>(&mut self, f: F) -> R
+    where
+        F: for<'b> FnOnce(&mut BuildCtx<'b, C>) -> R,
+    {
+        let mut child_user_ctx = self.user_ctx.clone();
+        let mut child = BuildCtx {
+            ast: &mut *self.ast,
+            captures: self.captures,
+            fresh: self.fresh,
+            source_range: self.source_range,
+            user_ctx: &mut child_user_ctx,
+            translator: self.translator,
+        };
+        f(&mut child)
+        // child_user_ctx dropped; the outer `self` is unaffected.
     }
 }
 

--- a/shared/yeast/src/build.rs
+++ b/shared/yeast/src/build.rs
@@ -200,8 +200,9 @@ impl<C: Clone> BuildCtx<'_, C> {
     /// Use for the rare rule that needs to translate a subtree under a
     /// modified context *and then continue using its own (unmodified)
     /// context afterwards*. For rules where the modified translation
-    /// is the last use of `ctx`, mutate `ctx` in place — the
-    /// framework's rule-boundary save/restore cleans up on rule exit.
+    /// is the last use of `ctx`, mutate `ctx` in place — the framework
+    /// invokes each rule with a private clone of the user context, so
+    /// mutations are discarded on rule exit anyway.
     ///
     /// Example: an outer rule that translates one child subtree with a
     /// reset context, then continues with the outer context intact:

--- a/shared/yeast/src/build.rs
+++ b/shared/yeast/src/build.rs
@@ -168,7 +168,7 @@ impl<C: Clone> BuildCtx<'_, C> {
     /// meaningful when input and output share a schema).
     ///
     /// The single-`Id` case works too, because `Id: IntoIterator<Item
-    /// = Id>` as a singleton iterator — so `ctx.translate(some_id)?`
+    /// = Id>` is a singleton iterator — so `ctx.translate(some_id)?`
     /// returns a `Vec<Id>` containing whatever `some_id` translated to.
     ///
     /// Errors if this `BuildCtx` was constructed by hand (without a

--- a/shared/yeast/src/lib.rs
+++ b/shared/yeast/src/lib.rs
@@ -26,6 +26,12 @@ use query::QueryNode;
 /// without colliding with the impls for plain integers.
 ///
 /// Use `id.0` (or `id.into()`) to obtain the raw arena index.
+///
+/// Implements [`IntoIterator`] as a singleton (`iter::once(self)`)
+/// so that a bare `Id` can be used interchangeably with `Option<Id>`
+/// / `Vec<Id>` in places that expect an iterable of ids (e.g.
+/// [`crate::build::BuildCtx::translate`] and the field-splice
+/// interpolation via [`IntoFieldIds`]).
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Hash, Serialize)]
 pub struct Id(pub usize);
@@ -42,6 +48,14 @@ impl From<Id> for usize {
     }
 }
 
+impl IntoIterator for Id {
+    type Item = Id;
+    type IntoIter = std::iter::Once<Id>;
+    fn into_iter(self) -> Self::IntoIter {
+        std::iter::once(self)
+    }
+}
+
 /// Field and Kind ids are provided by tree-sitter
 type FieldId = u16;
 type KindId = u16;
@@ -49,21 +63,16 @@ type KindId = u16;
 /// Trait for values that can be appended to a field's id list inside a
 /// `tree!`/`trees!`/`rule!` template (in `{expr}` placeholders).
 ///
-/// `Id` pushes a single id; the blanket impl for
-/// `IntoIterator<Item: Into<Id>>` handles `Vec<Id>`, `Option<Id>`,
-/// arbitrary iterators yielding `Id`, etc.
+/// The blanket impl for `IntoIterator<Item: Into<Id>>` handles all
+/// current shapes: `Vec<Id>`, `Option<Id>`, arbitrary iterators
+/// yielding `Id`, and a bare `Id` itself (which is `IntoIterator`
+/// via a singleton).
 ///
 /// This lets `{expr}` interpolate any of these shapes without a
 /// dedicated splice syntax — the macro emits the same trait-dispatched
 /// call regardless of the value's type.
 pub trait IntoFieldIds {
     fn extend_into(self, out: &mut Vec<Id>);
-}
-
-impl IntoFieldIds for Id {
-    fn extend_into(self, out: &mut Vec<Id>) {
-        out.push(self);
-    }
 }
 
 impl<I, T> IntoFieldIds for I

--- a/shared/yeast/src/lib.rs
+++ b/shared/yeast/src/lib.rs
@@ -999,10 +999,13 @@ fn apply_repeating_rules_inner<C: Clone>(
         if Some(rule_ptr) == skip_rule {
             continue;
         }
-        // Snapshot the user context before invoking the rule so that any
-        // mutations the rule makes are visible during recursive translation
-        // of its result, but not leaked to the parent's siblings.
-        let snapshot = user_ctx.clone();
+        // Give each rule attempt a private clone of the user context.
+        // Any mutations the rule makes are visible to its transform and
+        // to the recursive translation of its result, but never leak
+        // back to the parent — the clone is simply dropped when we
+        // return. This is also `?`-safe: an error return drops `local`
+        // without touching the caller's `user_ctx`.
+        let mut local = user_ctx.clone();
         // Repeating rules don't need a real translator: their captures
         // aren't auto-translated (Repeating preserves the input schema),
         // and `ctx.translate(id)` errors if invoked from a Repeating
@@ -1010,7 +1013,7 @@ fn apply_repeating_rules_inner<C: Clone>(
         let translator = TranslatorHandle {
             inner: TranslatorImpl::Repeating,
         };
-        let try_result = rule.try_rule(ast, id, fresh, user_ctx, translator)?;
+        let try_result = rule.try_rule(ast, id, fresh, &mut local, translator)?;
         if let Some(result_node) = try_result {
             // For non-repeated rules, suppress further application of *this*
             // rule on the result root, so a rule whose output matches its own
@@ -1022,19 +1025,17 @@ fn apply_repeating_rules_inner<C: Clone>(
                 results.extend(apply_repeating_rules_inner(
                     index,
                     ast,
-                    user_ctx,
+                    &mut local,
                     node,
                     fresh,
                     rewrite_depth + 1,
                     next_skip,
                 )?);
             }
-            *user_ctx = snapshot;
             return Ok(results);
         }
-        // Rule didn't match; restore any speculative changes (none expected
-        // since try_rule only mutates on match, but be defensive).
-        *user_ctx = snapshot;
+        // Rule didn't match; `local` is dropped as we loop to the next
+        // rule.
     }
 
     // Take the parent's fields by ownership: the recursion will rewrite
@@ -1116,11 +1117,13 @@ fn apply_one_shot_rules_inner<C: Clone>(
 
     for rule in index.rules_for_kind(node_kind) {
         if let Some(captures) = rule.try_match(ast, id)? {
-            // Snapshot the user context before invoking the rule so that any
-            // mutations the rule (or its transitively-translated captures)
-            // make are visible during this rule's transform, but not leaked
-            // to the parent's siblings.
-            let snapshot = user_ctx.clone();
+            // Give the rule a private clone of the user context. Any
+            // mutations the rule (or its transitively-translated
+            // captures) make are visible during this rule's transform,
+            // but never leak back — the clone is dropped when we
+            // return. `?`-safe: an error return drops `local` without
+            // touching the caller's `user_ctx`.
+            let mut local = user_ctx.clone();
             // Build the translator handle the transform will use to
             // recursively translate captures (or, for macro-generated
             // rules, the auto-translate prefix uses it to translate every
@@ -1133,8 +1136,7 @@ fn apply_one_shot_rules_inner<C: Clone>(
                     matched_root: id,
                 },
             };
-            let result = rule.run_transform(ast, captures, id, fresh, user_ctx, translator)?;
-            *user_ctx = snapshot;
+            let result = rule.run_transform(ast, captures, id, fresh, &mut local, translator)?;
             return Ok(result);
         }
     }

--- a/shared/yeast/src/lib.rs
+++ b/shared/yeast/src/lib.rs
@@ -741,6 +741,16 @@ pub struct TranslatorHandle<'a, C> {
     inner: TranslatorImpl<'a, C>,
 }
 
+// Manual `Copy` / `Clone` so `TranslatorHandle<'_, C>: Copy` holds
+// regardless of whether `C: Copy`. `TranslatorImpl` contains only
+// shared references, which are `Copy` unconditionally.
+impl<C> Copy for TranslatorHandle<'_, C> {}
+impl<C> Clone for TranslatorHandle<'_, C> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
 /// Internal phase-specific translation state. Kept private — callers
 /// interact with [`TranslatorHandle`] only.
 enum TranslatorImpl<'a, C> {
@@ -759,6 +769,16 @@ enum TranslatorImpl<'a, C> {
     /// [`auto_translate_captures`] is a no-op so the macro's auto-prefix
     /// works unchanged for Repeating rules.
     Repeating,
+}
+
+// Manual `Copy` / `Clone` so `TranslatorImpl<'_, C>: Copy` holds
+// regardless of whether `C: Copy`. All variants hold only shared
+// references and small `Copy` scalars.
+impl<C> Copy for TranslatorImpl<'_, C> {}
+impl<C> Clone for TranslatorImpl<'_, C> {
+    fn clone(&self) -> Self {
+        *self
+    }
 }
 
 impl<'a, C: Clone> TranslatorHandle<'a, C> {

--- a/unified/extractor/src/languages/swift/swift.rs
+++ b/unified/extractor/src/languages/swift/swift.rs
@@ -60,10 +60,11 @@ impl SwiftContext {
     /// clearing here per-field.
     ///
     /// Called before recursively translating a body / initializer
-    /// slot. Most rules mutate `ctx` in place — the framework's
-    /// rule-boundary snapshot/restore cleans up on exit. Rules that
-    /// need the outer context intact *after* the reset-and-translate
-    /// (see e.g. the `property_binding` willSet/didSet rule) wrap the
+    /// slot. Most rules mutate `ctx` in place — the framework invokes
+    /// each rule with a private clone of the user context, so
+    /// mutations are discarded on rule exit anyway. Rules that need
+    /// the outer context intact *after* the reset-and-translate (see
+    /// e.g. the `property_binding` willSet/didSet rule) wrap the
     /// mutation in `ctx.scoped(...)` instead.
     fn reset(&mut self) {
         *self = SwiftContext::default();

--- a/unified/extractor/src/languages/swift/swift.rs
+++ b/unified/extractor/src/languages/swift/swift.rs
@@ -45,11 +45,28 @@ impl SwiftContext {
     ///
     /// True exactly when an enclosing binding has published its modifier into
     /// `outer_modifiers`. This is reliable because non-binding subtrees
-    /// (bodies, initializer values, ...) are translated with a reset context
-    /// (see `BuildCtx::translate_reset`), so a bare identifier only sees a
+    /// (bodies, initializer values, ...) are translated after resetting the
+    /// context (see `reset`), so a bare identifier only sees a
     /// non-empty `outer_modifiers` when it really is a binding.
     fn in_binding_pattern(&self) -> bool {
         !self.outer_modifiers.is_empty()
+    }
+
+    /// Clear the context fields that must not propagate into an
+    /// expression / statement / body subtree.
+    ///
+    /// Mirrors `Default::default()` for `SwiftContext` today, but is a
+    /// named method so future context fields can opt in or out of
+    /// clearing here per-field.
+    ///
+    /// Called before recursively translating a body / initializer
+    /// slot. Most rules mutate `ctx` in place — the framework's
+    /// rule-boundary snapshot/restore cleans up on exit. Rules that
+    /// need the outer context intact *after* the reset-and-translate
+    /// (see e.g. the `property_binding` willSet/didSet rule) wrap the
+    /// mutation in `ctx.scoped(...)` instead.
+    fn reset(&mut self) {
+        *self = SwiftContext::default();
     }
 }
 
@@ -239,7 +256,7 @@ fn translation_rules() -> Vec<Rule<SwiftContext>> {
                 name: (identifier #{name})
                 type: {ty}
                 accessor_kind: (accessor_kind "get")
-                body: (block stmt: {ctx.translate_reset(body)?}))
+                body: (block stmt: {ctx.reset(); ctx.translate(body)?}))
         ),
         // Stored property with willSet/didSet observers (initializer
         // optional) → a `variable_declaration` followed by one
@@ -260,12 +277,20 @@ fn translation_rules() -> Vec<Rule<SwiftContext>> {
                 observers: (willset_didset_block willset: _? @@ws didset: _? @@ds))
             =>
             {{
-                // The initializer value must not inherit the binding context
-                // (it may contain patterns, e.g. a switch expression), so
-                // translate it with a reset context. The observers keep the
-                // context: each willSet/didSet accessor emits the binding
-                // modifier and resets its own body.
-                let val = ctx.translate_reset(val)?;
+                // The initializer value must not inherit the binding
+                // context (it may contain patterns, e.g. a switch
+                // expression), so translate it inside a `ctx.scoped`
+                // block — the block receives a temporary `ctx` whose
+                // `user_ctx` is a clone; mutations to it are discarded
+                // when the block returns, so the outer `ctx` is intact
+                // for the observer loop below. The observers keep the
+                // outer context: each willSet/didSet accessor emits
+                // the binding modifier and, in turn, resets the
+                // context for its own body.
+                let val = ctx.scoped(|ctx| {
+                    ctx.reset();
+                    ctx.translate(val)
+                })?;
 
                 let var_decl = tree!(
                     (variable_declaration
@@ -295,7 +320,7 @@ fn translation_rules() -> Vec<Rule<SwiftContext>> {
         // The enclosing `property_declaration` leads `ctx.outer_modifiers`
         // with the `let`/`var` binding modifier, so the auto-translated name
         // pattern (the LHS) becomes a binding, while the initializer value is
-        // translated with a reset context (see `translate_reset`).
+        // translated with a reset context (see `SwiftContext::reset`).
         rule!(
             (property_binding
                 name: @pattern
@@ -307,7 +332,7 @@ fn translation_rules() -> Vec<Rule<SwiftContext>> {
                 modifier: {chained_modifier(&mut ctx)}
                 pattern: {pattern}
                 type: {ty}
-                value: {ctx.translate_reset(val)?}) // reset context: the initializer must not see the binding
+                value: {ctx.reset(); ctx.translate(val)?})
         ),
         // property_declaration: flatten declarators (each may translate
         // to multiple nodes — variable_declaration and/or
@@ -1118,7 +1143,7 @@ fn translation_rules() -> Vec<Rule<SwiftContext>> {
                 name: {ctx.property_name.ok_or("computed_getter outside property_binding context")?}
                 type: {ctx.property_type}
                 accessor_kind: (accessor_kind "get")
-                body: (block stmt: {ctx.translate_reset(body)?}))
+                body: (block stmt: {ctx.reset(); ctx.translate(body)?}))
         ),
         // Computed setter with explicit parameter name.
         rule!(
@@ -1131,7 +1156,7 @@ fn translation_rules() -> Vec<Rule<SwiftContext>> {
                 type: {ctx.property_type}
                 accessor_kind: (accessor_kind "set")
                 parameter: (parameter pattern: (name_pattern identifier: (identifier #{param})))
-                body: (block stmt: {ctx.translate_reset(body)?}))
+                body: (block stmt: {ctx.reset(); ctx.translate(body)?}))
         ),
         // Computed setter without explicit parameter name; body optional.
         rule!(
@@ -1143,7 +1168,7 @@ fn translation_rules() -> Vec<Rule<SwiftContext>> {
                 name: {ctx.property_name.ok_or("computed_setter outside property_binding context")?}
                 type: {ctx.property_type}
                 accessor_kind: (accessor_kind "set")
-                body: (block stmt: {ctx.translate_reset(body)?}))
+                body: (block stmt: {ctx.reset(); ctx.translate(body)?}))
         ),
         // Computed modify → accessor_declaration
         rule!(
@@ -1155,7 +1180,7 @@ fn translation_rules() -> Vec<Rule<SwiftContext>> {
                 name: {ctx.property_name.ok_or("computed_modify outside property_binding context")?}
                 type: {ctx.property_type}
                 accessor_kind: (accessor_kind "modify")
-                body: (block stmt: {ctx.translate_reset(body)?}))
+                body: (block stmt: {ctx.reset(); ctx.translate(body)?}))
         ),
         // willset/didset block — spread to children (only reachable as a
         // fallback; the outer property_binding manual rule normally
@@ -1173,7 +1198,7 @@ fn translation_rules() -> Vec<Rule<SwiftContext>> {
                 modifier: {chained_modifier(&mut ctx)}
                 name: {ctx.property_name.ok_or("willset_clause outside property_binding context")?}
                 accessor_kind: (accessor_kind "willSet")
-                body: (block stmt: {ctx.translate_reset(body)?}))
+                body: (block stmt: {ctx.reset(); ctx.translate(body)?}))
         ),
         // didset clause → accessor_declaration (body optional).
         rule!(
@@ -1184,7 +1209,7 @@ fn translation_rules() -> Vec<Rule<SwiftContext>> {
                 modifier: {chained_modifier(&mut ctx)}
                 name: {ctx.property_name.ok_or("didset_clause outside property_binding context")?}
                 accessor_kind: (accessor_kind "didSet")
-                body: (block stmt: {ctx.translate_reset(body)?}))
+                body: (block stmt: {ctx.reset(); ctx.translate(body)?}))
         ),
         // Preprocessor conditionals — unsupported
         rule!((diagnostic) => (unsupported_node)),


### PR DESCRIPTION
An addendum to #22120. Removes `translate_reset` in favour of a mechanism that is a bit less "all or nothing".

The main addition is a new method `ctx.scoped` which takes a closure as an argument. Thus, where we previously wrote

```rust
let val = ctx.translate_reset(val)?;
```

with `translate_reset` taking care of nuking the entire `user_ctx`, we now instead write

```rust
let val = ctx.scoped(|ctx| {
    ctx.reset();
    ctx.translate(val)
})?;
```
Note that in particular, `reset` is now a method on `SwiftContext`, not something that the yeast framework provides. This means we can easily make it more fine-grained, e.g. replacing it with a method that just resets the current modifiers.

Also, for cases where we _don't_ need `ctx` after doing the translation, we can simply call `ctx.reset()` without the scope -- the changes to the context are prevented from bleeding through by means of the existing context isolation mechanism.

---
Should be reviewed commit-by-commit. The final commit changes the isolation mechanism from "save and then restore" to "clone and then drop", which saves some unnecessary work, and is otherwise just as good.