### PR TITLE
C++/C#: Specify additional CWE tags for queries that specify CWE 114

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-114/UncontrolledProcessOperation.ql
+++ b/cpp/ql/src/Security/CWE/CWE-114/UncontrolledProcessOperation.ql
@@ -9,6 +9,8 @@
  * @precision medium
  * @id cpp/uncontrolled-process-operation
  * @tags security
+ *       external/cwe/cwe-073
+ *       external/cwe/cwe-078
  *       external/cwe/cwe-114
  */
 

--- a/cpp/ql/src/change-notes/2026-07-09-CWE-114.md
+++ b/cpp/ql/src/change-notes/2026-07-09-CWE-114.md
@@ -1,0 +1,4 @@
+---
+category: queryMetadata
+---
+* Added the tags `external/cwe/cwe-073` and `external/cwe/cwe-078` to `cpp/uncontrolled-process-operation`.

--- a/csharp/ql/src/Security Features/CWE-114/AssemblyPathInjection.ql
+++ b/csharp/ql/src/Security Features/CWE-114/AssemblyPathInjection.ql
@@ -9,6 +9,7 @@
  * @security-severity 8.2
  * @precision high
  * @tags security
+ *       external/cwe/cwe-073
  *       external/cwe/cwe-114
  */
 

--- a/csharp/ql/src/change-notes/2026-07-09-CWE-114.md
+++ b/csharp/ql/src/change-notes/2026-07-09-CWE-114.md
@@ -1,0 +1,4 @@
+---
+category: queryMetadata
+---
+* Added the tag `external/cwe/cwe-073` to `cs/assembly-path-injection`.

--- a/csharp/ql/src/change-notes/released/2022-11-07-constant-expression.md
+++ b/csharp/ql/src/change-notes/released/2022-11-07-constant-expression.md
@@ -1,4 +1,0 @@
----
-category: minorAnalysis
----
-* The `Constant Condition` query was extended to catch cases when `String.IsNullOrEmpty` returns a constant value. 


### PR DESCRIPTION
This addresses https://github.com/github/codeql/issues/22131 for all queries that specify CWE 114. I kept the CWE 114 tag, as customers might depend on this.

See individual commit messages for further motivation.

Note that the changelog CI failure is incorrect (it errors on the removed change note).