### PR TITLE
Java: Improve join order.

### DIFF
--- a/java/ql/lib/semmle/code/java/ControlFlowGraph.qll
+++ b/java/ql/lib/semmle/code/java/ControlFlowGraph.qll
@@ -406,7 +406,9 @@ private module NonReturningCalls {
     }
 
     /** Gets a `MethodCall` that calls this method. */
-    MethodCall getAnAccess() { result.getMethod().getAPossibleImplementation() = this }
+    MethodCall getAnAccess() {
+      result.getMethod().getAPossibleImplementation() = pragma[only_bind_out](this)
+    }
   }
 
   /** Holds if a call to `m` indicates that `m` is expected to return. */


### PR DESCRIPTION
Before:
```
[2026-07-10 15:15:58] Evaluated non-recursive predicate ControlFlowGraph::NonReturningCalls::EffectivelyNonVirtualMethod.getAnAccess/0#dispred#efac59ed@090459qt in 4303ms (size: 186002).
Evaluated relational algebra for predicate ControlFlowGraph::NonReturningCalls::EffectivelyNonVirtualMethod.getAnAccess/0#dispred#efac59ed@090459qt with tuple counts:
           790592  ~0%    {2} r1 = JOIN `Expr::MethodCall.getMethod/0#dispred#41989dc9_10#join_rhs` WITH `Member::Method.getSourceDeclaration/0#dispred#93e6cdf8` ON FIRST 1 OUTPUT Rhs.1, Lhs.1
        539755681  ~2%    {2}    | JOIN WITH `Member::SrcMethod.getAPossibleImplementationOfSrcMethod/0#dispred#4f4317e6#bf` ON FIRST 1 OUTPUT Rhs.1, Lhs.1
           186002  ~2%    {2}    | JOIN WITH ControlFlowGraph::NonReturningCalls::EffectivelyNonVirtualMethod#86c19e07 ON FIRST 1 OUTPUT Lhs.0, Lhs.1
                          return r1
```
After:
```
[2026-07-10 15:29:39] Evaluated non-recursive predicate ControlFlowGraph::NonReturningCalls::EffectivelyNonVirtualMethod.getAnAccess/0#dispred#efac59ed@32fb2e61 in 10ms (size: 186002).
Evaluated relational algebra for predicate ControlFlowGraph::NonReturningCalls::EffectivelyNonVirtualMethod.getAnAccess/0#dispred#efac59ed@32fb2e61 with tuple counts:
        122765  ~0%    {2} r1 = SCAN ControlFlowGraph::NonReturningCalls::EffectivelyNonVirtualMethod#86c19e07 OUTPUT In.0, In.0
        122766  ~0%    {2}    | JOIN WITH `Member::SrcMethod.getAPossibleImplementationOfSrcMethod/0#dispred#4f4317e6_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1
        126911  ~0%    {2}    | JOIN WITH `Member::Method.getSourceDeclaration/0#dispred#93e6cdf8_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1
        186002  ~2%    {2}    | JOIN WITH `Expr::MethodCall.getMethod/0#dispred#41989dc9_10#join_rhs` ON FIRST 1 OUTPUT Lhs.1, Rhs.1
                       return r1
```