### PR TITLE
C++: Update the CWE tag of `cpp/new-free-mismatch`

### DIFF
--- a/cpp/ql/src/Critical/NewFreeMismatch.ql
+++ b/cpp/ql/src/Critical/NewFreeMismatch.ql
@@ -8,7 +8,7 @@
  * @id cpp/new-free-mismatch
  * @tags reliability
  *       security
- *       external/cwe/cwe-401
+ *       external/cwe/cwe-762
  */
 
 import NewDelete

--- a/cpp/ql/src/change-notes/2026-07-13-new-free.md
+++ b/cpp/ql/src/change-notes/2026-07-13-new-free.md
@@ -1,0 +1,4 @@
+---
+category: queryMetadata
+---
+* Added the tag `external/cwe/cwe-762` to `cpp/new-free-mismatch`, and removed the tag `external/cwe/cwe-401`. This better matches the behavior of the query.


### PR DESCRIPTION
Fixes: https://github.com/github/codeql/issues/22162