### PR TITLE
C#: Use static constructor as enclosing callable for static member initializers.

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/ExprOrStmtParent.qll
+++ b/csharp/ql/lib/semmle/code/csharp/ExprOrStmtParent.qll
@@ -6,6 +6,7 @@
 
 import csharp
 private import internal.Location
+private import controlflow.internal.ControlFlowGraph
 
 /**
  * INTERNAL: Do not use.
@@ -145,6 +146,8 @@ private module Cached {
     parent*(cfe, c.(Constructor).getObjectInitializerCall())
     or
     parent*(cfe, any(AssignExpr init | c.(ObjectInitMethod).initializes(init)))
+    or
+    parent*(cfe, any(Expr init | Initializers::staticMemberInitializer(c, init)))
   }
 
   /** Holds if the enclosing statement of expression `e` is `s`. */

--- a/csharp/ql/src/change-notes/2026-07-15-static-member-enclosing-callable.md
+++ b/csharp/ql/src/change-notes/2026-07-15-static-member-enclosing-callable.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Static constructors are now used as the enclosing callable for static member initializer expressions. This improves the precision of a range of queries, including `cs/useless-assignment-to-local` and `cs/dereferenced-value-may-be-null`.

--- a/csharp/ql/test/query-tests/Dead Code/DeadStoreOfLocal/DeadStoreOfLocal.cs
+++ b/csharp/ql/test/query-tests/Dead Code/DeadStoreOfLocal/DeadStoreOfLocal.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 public class DeadStoreOfLocal
 {
@@ -483,4 +484,17 @@ class StringInterpolation
         const int align = 6; // GOOD
         Console.WriteLine($"Pi, {pi,align:F3}");
     }
+}
+
+class LinqFields
+{
+    private readonly IEnumerable<int> QueryBackedField =
+        from x1 in new[] { 1, 2, 3 }
+        where x1 > 1
+        select x1; // GOOD: The query range variable is used by the LINQ expression.
+
+    public static readonly IEnumerable<int> StaticQueryBackedField =
+        from x2 in new[] { 1, 2, 3 }
+        where x2 > 1
+        select x2; // GOOD: The query range variable is used by the LINQ expression.
 }

--- a/csharp/ql/test/query-tests/Dead Code/DeadStoreOfLocal/DeadStoreOfLocal.expected
+++ b/csharp/ql/test/query-tests/Dead Code/DeadStoreOfLocal/DeadStoreOfLocal.expected
@@ -1,21 +1,25 @@
-| DeadStoreOfLocal.cs:12:13:12:20 | Int32 x = ... | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:12:13:12:13 | x | x |
-| DeadStoreOfLocal.cs:19:21:19:25 | ... = ... | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:18:13:18:13 | x | x |
-| DeadStoreOfLocal.cs:44:13:44:20 | Int32 x = ... | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:44:13:44:13 | x | x |
-| DeadStoreOfLocal.cs:50:9:50:14 | ... += ... | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:49:13:49:13 | x | x |
-| DeadStoreOfLocal.cs:56:9:56:11 | ...++ | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:55:13:55:13 | x | x |
-| DeadStoreOfLocal.cs:82:22:82:24 | String val | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:82:22:82:24 | val | val |
-| DeadStoreOfLocal.cs:101:13:101:37 | ... = ... | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:94:40:94:44 | extra | extra |
-| DeadStoreOfLocal.cs:104:13:104:37 | ... = ... | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:94:16:94:20 | info1 | info1 |
-| DeadStoreOfLocal.cs:142:26:142:27 | Exception ex | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:142:26:142:27 | ex | ex |
-| DeadStoreOfLocal.cs:246:17:246:24 | Int32 y = ... | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:246:17:246:17 | y | y |
-| DeadStoreOfLocal.cs:261:17:261:21 | Int32 x = ... | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:261:17:261:17 | x | x |
-| DeadStoreOfLocal.cs:300:23:300:28 | Object v1 | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:300:27:300:28 | v1 | v1 |
-| DeadStoreOfLocal.cs:314:18:314:23 | Object v2 | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:314:22:314:23 | v2 | v2 |
-| DeadStoreOfLocal.cs:331:9:331:32 | ... = ... | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:327:23:327:23 | b | b |
-| DeadStoreOfLocal.cs:372:13:372:20 | String s = ... | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:372:13:372:13 | s | s |
-| DeadStoreOfLocal.cs:472:20:472:76 | FileStream y = ... | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:472:20:472:20 | y | y |
+#select
+| DeadStoreOfLocal.cs:13:13:13:20 | Int32 x = ... | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:13:13:13:13 | x | x |
+| DeadStoreOfLocal.cs:20:21:20:25 | ... = ... | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:19:13:19:13 | x | x |
+| DeadStoreOfLocal.cs:45:13:45:20 | Int32 x = ... | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:45:13:45:13 | x | x |
+| DeadStoreOfLocal.cs:51:9:51:14 | ... += ... | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:50:13:50:13 | x | x |
+| DeadStoreOfLocal.cs:57:9:57:11 | ...++ | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:56:13:56:13 | x | x |
+| DeadStoreOfLocal.cs:83:22:83:24 | String val | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:83:22:83:24 | val | val |
+| DeadStoreOfLocal.cs:102:13:102:37 | ... = ... | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:95:40:95:44 | extra | extra |
+| DeadStoreOfLocal.cs:105:13:105:37 | ... = ... | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:95:16:95:20 | info1 | info1 |
+| DeadStoreOfLocal.cs:143:26:143:27 | Exception ex | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:143:26:143:27 | ex | ex |
+| DeadStoreOfLocal.cs:247:17:247:24 | Int32 y = ... | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:247:17:247:17 | y | y |
+| DeadStoreOfLocal.cs:262:17:262:21 | Int32 x = ... | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:262:17:262:17 | x | x |
+| DeadStoreOfLocal.cs:301:23:301:28 | Object v1 | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:301:27:301:28 | v1 | v1 |
+| DeadStoreOfLocal.cs:315:18:315:23 | Object v2 | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:315:22:315:23 | v2 | v2 |
+| DeadStoreOfLocal.cs:332:9:332:32 | ... = ... | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:328:23:328:23 | b | b |
+| DeadStoreOfLocal.cs:373:13:373:20 | String s = ... | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:373:13:373:13 | s | s |
+| DeadStoreOfLocal.cs:473:20:473:76 | FileStream y = ... | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:473:20:473:20 | y | y |
+| DeadStoreOfLocal.cs:497:9:497:36 | Int32 x2 = ... | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:497:14:497:15 | x2 | x2 |
 | DeadStoreOfLocalBad.cs:7:13:7:48 | Boolean success = ... | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocalBad.cs:7:13:7:19 | success | success |
 | DeadStoreOfLocalBad.cs:23:32:23:32 | FormatException e | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocalBad.cs:23:32:23:32 | e | e |
 | DeadStoreOfLocalBad.cs:32:22:32:22 | String s | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocalBad.cs:32:22:32:22 | s | s |
 | DeadStoreOfLocalBad.cs:39:18:39:22 | Int32 i | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocalBad.cs:39:22:39:22 | i | i |
 | DeadStoreOfLocalBad.cs:49:18:49:25 | String s | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocalBad.cs:49:25:49:25 | s | s |
+testFailures
+| DeadStoreOfLocal.cs:497:9:497:36 | This assignment to $@ is useless, since its value is never read. | Unexpected result: Alert |

--- a/csharp/ql/test/query-tests/Dead Code/DeadStoreOfLocal/DeadStoreOfLocal.expected
+++ b/csharp/ql/test/query-tests/Dead Code/DeadStoreOfLocal/DeadStoreOfLocal.expected
@@ -1,4 +1,3 @@
-#select
 | DeadStoreOfLocal.cs:13:13:13:20 | Int32 x = ... | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:13:13:13:13 | x | x |
 | DeadStoreOfLocal.cs:20:21:20:25 | ... = ... | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:19:13:19:13 | x | x |
 | DeadStoreOfLocal.cs:45:13:45:20 | Int32 x = ... | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:45:13:45:13 | x | x |
@@ -15,11 +14,8 @@
 | DeadStoreOfLocal.cs:332:9:332:32 | ... = ... | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:328:23:328:23 | b | b |
 | DeadStoreOfLocal.cs:373:13:373:20 | String s = ... | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:373:13:373:13 | s | s |
 | DeadStoreOfLocal.cs:473:20:473:76 | FileStream y = ... | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:473:20:473:20 | y | y |
-| DeadStoreOfLocal.cs:497:9:497:36 | Int32 x2 = ... | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:497:14:497:15 | x2 | x2 |
 | DeadStoreOfLocalBad.cs:7:13:7:48 | Boolean success = ... | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocalBad.cs:7:13:7:19 | success | success |
 | DeadStoreOfLocalBad.cs:23:32:23:32 | FormatException e | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocalBad.cs:23:32:23:32 | e | e |
 | DeadStoreOfLocalBad.cs:32:22:32:22 | String s | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocalBad.cs:32:22:32:22 | s | s |
 | DeadStoreOfLocalBad.cs:39:18:39:22 | Int32 i | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocalBad.cs:39:22:39:22 | i | i |
 | DeadStoreOfLocalBad.cs:49:18:49:25 | String s | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocalBad.cs:49:25:49:25 | s | s |
-testFailures
-| DeadStoreOfLocal.cs:497:9:497:36 | This assignment to $@ is useless, since its value is never read. | Unexpected result: Alert |


### PR DESCRIPTION
The query `cs/useless-assignment-to-local` produces some false positives for static members.
That is, the query incorrectly reports `x` as being a useless assignment in
```csharp
public static readonly IEnumerable<int> StaticQueryBackedField =
        from x in new[] { 1, 2, 3 }
        where x > 1
        select x;
```

The root cause of the problem is that the static member initializers don't have an enclosing callable (which affects the SSA logic and this bubbles up into the results of `cs/useless-assignment-to-local` query). In this PR we fix the problem by using the static constructor as the enclosing callable for the control flow elements/expressions of static member inititializers. For instance fields, there is a dedicated synthetic "object initializer" method (as there can exist multiple instance constructors). However, there is exactly one static constructor, so we can use that as the enclosing callable (instead of also introducing a "type initializer" (a static version of the "object initializer")).

Notes on DCA.
- Performance appears unaffected.
- Notable changes for several queries. I spot-checked the results and they mostly appear to be good.
  - `cs/useless-assignment-to-local`. There appears to be two genuine alert removals. I only checked the alert removal in non-generated code and that appears to be a false positive removal (local variable declaration with subsequent use in a static member initialization - similar to the example provided above).
  - `cs/dereferenced-value-may-be-null`: New alerts, which look good (method calls without null-checks on static members that are assigned the result of a cast).
  - `cs/coupled-types`: New alerts. The query uses the enclosing callable for finding candidate types of variables accesses. I have no reason to doubt that these are not sound with respect to the query logic.
  - `cs/local-not-disposed`: New alerts. I checked one, which looks sound. An IDisposable appears to be used as a part of initializing a static field. The query also relies on enclosing callable as a part of its logic.
  - `cs/virtual-call-in-constructor`. New Alerts. These are false positives, but that is due to a query bug as we shouldn't consider `nameof(VirtualMethod)` a virtual call - this is perfectly safe in constructors as well. An issue has been opened [here](https://github.com/github/codeql-csharp-team/issues/489).