### PR TITLE
C#/Java: Modelgenerator. Lift models to unbound generic implementations.

### DIFF
--- a/csharp/ql/src/utils/modelgenerator/internal/CaptureModels.qll
+++ b/csharp/ql/src/utils/modelgenerator/internal/CaptureModels.qll
@@ -213,7 +213,8 @@ module SummaryModelGeneratorInput implements SummaryModelGeneratorInputSig {
   }
 
   private Callable getARelevantOverrideeOrImplementee(Overridable m) {
-    m.overridesOrImplements(result) and relevant(result)
+    exists(Callable c | m.overridesOrImplements(c) and result = c.getUnboundDeclaration()) and
+    relevant(result)
   }
 
   /**

--- a/csharp/ql/test/utils/modelgenerator/dataflow/Summaries.cs
+++ b/csharp/ql/test/utils/modelgenerator/dataflow/Summaries.cs
@@ -287,8 +287,6 @@ public class GenericWithVirtual1<T>
         return input;
     }
 
-    // Missing model. Should have been lifted.
-    // SPURIOUS-neutral=Models;GenericWithVirtual1<T>;StubImplementation;(T);summary;df-generated
     public virtual T StubImplementation(T input)
     {
         throw null;
@@ -297,15 +295,15 @@ public class GenericWithVirtual1<T>
 
 public class DerivedGenericWithVirtual : GenericWithVirtual1<string>
 {
-    // SPURIOUS-heuristic-summary=Models;DerivedGenericWithVirtual;true;ReturnParam;(System.String);;Argument[0];ReturnValue;value;df-generated
-    // SPURIOUS-contentbased-summary=Models;DerivedGenericWithVirtual;true;ReturnParam;(System.String);;Argument[0];ReturnValue;value;dfc-generated
+    // heuristic-summary=Models;GenericWithVirtual1<T>;true;ReturnParam;(T);;Argument[0];ReturnValue;value;df-generated
+    // contentbased-summary=Models;GenericWithVirtual1<T>;true;ReturnParam;(T);;Argument[0];ReturnValue;value;dfc-generated
     public override string ReturnParam(string input)
     {
         return input;
     }
 
-    // SPURIOUS-heuristic-summary=Models;DerivedGenericWithVirtual;true;StubImplementation;(System.String);;Argument[0];ReturnValue;value;df-generated
-    // SPURIOUS-contentbased-summary=Models;DerivedGenericWithVirtual;true;StubImplementation;(System.String);;Argument[0];ReturnValue;value;dfc-generated
+    // heuristic-summary=Models;GenericWithVirtual1<T>;true;StubImplementation;(T);;Argument[0];ReturnValue;value;df-generated
+    // contentbased-summary=Models;GenericWithVirtual1<T>;true;StubImplementation;(T);;Argument[0];ReturnValue;value;dfc-generated
     public override string StubImplementation(string input)
     {
         return input;
@@ -321,9 +319,6 @@ public class GenericWithVirtual2<T>
         return input;
     }
 
-    // Missing model. Should have been lifted.
-    // SPURIOUS-neutral=Models;GenericWithVirtual2<T>;StubImplementation;(T);summary;df-generated
-
     public virtual T StubImplementation(T input)
     {
         throw null;
@@ -334,15 +329,15 @@ public class NestedGenericWithVirtual<T> : GenericWithVirtual2<string> { }
 
 public class DerivedNestedGenericWithVirtual : NestedGenericWithVirtual<int>
 {
-    // SPURIOUS-heuristic-summary=Models;DerivedNestedGenericWithVirtual;true;ReturnParam;(System.String);;Argument[0];ReturnValue;value;df-generated
-    // SPURIOUS-contentbased-summary=Models;DerivedNestedGenericWithVirtual;true;ReturnParam;(System.String);;Argument[0];ReturnValue;value;dfc-generated
+    // heuristic-summary=Models;GenericWithVirtual2<T>;true;ReturnParam;(T);;Argument[0];ReturnValue;value;df-generated
+    // contentbased-summary=Models;GenericWithVirtual2<T>;true;ReturnParam;(T);;Argument[0];ReturnValue;value;dfc-generated
     public override string ReturnParam(string input)
     {
         return input;
     }
 
-    // SPURIOUS-heuristic-summary=Models;DerivedNestedGenericWithVirtual;true;StubImplementation;(System.String);;Argument[0];ReturnValue;value;df-generated
-    // SPURIOUS-contentbased-summary=Models;DerivedNestedGenericWithVirtual;true;StubImplementation;(System.String);;Argument[0];ReturnValue;value;dfc-generated
+    // heuristic-summary=Models;GenericWithVirtual2<T>;true;StubImplementation;(T);;Argument[0];ReturnValue;value;df-generated
+    // contentbased-summary=Models;GenericWithVirtual2<T>;true;StubImplementation;(T);;Argument[0];ReturnValue;value;dfc-generated
     public override string StubImplementation(string input)
     {
         return input;

--- a/csharp/ql/test/utils/modelgenerator/dataflow/Summaries.cs
+++ b/csharp/ql/test/utils/modelgenerator/dataflow/Summaries.cs
@@ -278,6 +278,77 @@ public class GenericFlow<T>
     }
 }
 
+public class GenericWithVirtual1<T>
+{
+    // heuristic-summary=Models;GenericWithVirtual1<T>;true;ReturnParam;(T);;Argument[0];ReturnValue;value;df-generated
+    // contentbased-summary=Models;GenericWithVirtual1<T>;true;ReturnParam;(T);;Argument[0];ReturnValue;value;dfc-generated
+    public virtual T ReturnParam(T input)
+    {
+        return input;
+    }
+
+    // Missing model. Should have been lifted.
+    // SPURIOUS-neutral=Models;GenericWithVirtual1<T>;StubImplementation;(T);summary;df-generated
+    public virtual T StubImplementation(T input)
+    {
+        throw null;
+    }
+}
+
+public class DerivedGenericWithVirtual : GenericWithVirtual1<string>
+{
+    // SPURIOUS-heuristic-summary=Models;DerivedGenericWithVirtual;true;ReturnParam;(System.String);;Argument[0];ReturnValue;value;df-generated
+    // SPURIOUS-contentbased-summary=Models;DerivedGenericWithVirtual;true;ReturnParam;(System.String);;Argument[0];ReturnValue;value;dfc-generated
+    public override string ReturnParam(string input)
+    {
+        return input;
+    }
+
+    // SPURIOUS-heuristic-summary=Models;DerivedGenericWithVirtual;true;StubImplementation;(System.String);;Argument[0];ReturnValue;value;df-generated
+    // SPURIOUS-contentbased-summary=Models;DerivedGenericWithVirtual;true;StubImplementation;(System.String);;Argument[0];ReturnValue;value;dfc-generated
+    public override string StubImplementation(string input)
+    {
+        return input;
+    }
+}
+
+public class GenericWithVirtual2<T>
+{
+    // heuristic-summary=Models;GenericWithVirtual2<T>;true;ReturnParam;(T);;Argument[0];ReturnValue;value;df-generated
+    // contentbased-summary=Models;GenericWithVirtual2<T>;true;ReturnParam;(T);;Argument[0];ReturnValue;value;dfc-generated
+    public virtual T ReturnParam(T input)
+    {
+        return input;
+    }
+
+    // Missing model. Should have been lifted.
+    // SPURIOUS-neutral=Models;GenericWithVirtual2<T>;StubImplementation;(T);summary;df-generated
+
+    public virtual T StubImplementation(T input)
+    {
+        throw null;
+    }
+}
+
+public class NestedGenericWithVirtual<T> : GenericWithVirtual2<string> { }
+
+public class DerivedNestedGenericWithVirtual : NestedGenericWithVirtual<int>
+{
+    // SPURIOUS-heuristic-summary=Models;DerivedNestedGenericWithVirtual;true;ReturnParam;(System.String);;Argument[0];ReturnValue;value;df-generated
+    // SPURIOUS-contentbased-summary=Models;DerivedNestedGenericWithVirtual;true;ReturnParam;(System.String);;Argument[0];ReturnValue;value;dfc-generated
+    public override string ReturnParam(string input)
+    {
+        return input;
+    }
+
+    // SPURIOUS-heuristic-summary=Models;DerivedNestedGenericWithVirtual;true;StubImplementation;(System.String);;Argument[0];ReturnValue;value;df-generated
+    // SPURIOUS-contentbased-summary=Models;DerivedNestedGenericWithVirtual;true;StubImplementation;(System.String);;Argument[0];ReturnValue;value;dfc-generated
+    public override string StubImplementation(string input)
+    {
+        return input;
+    }
+}
+
 public abstract class BaseClassFlow
 {
     // heuristic-summary=Models;BaseClassFlow;true;ReturnParam;(System.Object);;Argument[0];ReturnValue;value;df-generated

--- a/java/ql/src/utils/modelgenerator/internal/CaptureModels.qll
+++ b/java/ql/src/utils/modelgenerator/internal/CaptureModels.qll
@@ -167,7 +167,7 @@ module SummaryModelGeneratorInput implements SummaryModelGeneratorInputSig {
   Parameter asParameter(NodeExtended node) { result = node.asParameter() }
 
   private J::Method getARelevantOverride(J::Method m) {
-    result = m.getAnOverride() and
+    result = m.getAnOverride().getSourceDeclaration() and
     relevant(result) and
     // Other exclusions for overrides.
     not m instanceof J::ToStringMethod

--- a/java/ql/test/utils/modelgenerator/dataflow/p/Generics.java
+++ b/java/ql/test/utils/modelgenerator/dataflow/p/Generics.java
@@ -1,0 +1,62 @@
+package p;
+
+public class Generics {
+
+  public class Generic1<T> {
+    // heuristic-summary=p;Generics$Generic1;true;ReturnParam;(Object);;Argument[0];ReturnValue;value;df-generated
+    // contentbased-summary=p;Generics$Generic1;true;ReturnParam;(Object);;Argument[0];ReturnValue;value;dfc-generated
+    public T ReturnParam(T input) {
+      return input;
+    }
+
+    public T StubImplementation(T input) {
+      return null;
+    }
+  }
+
+  public class DerivedGeneric extends Generic1<String> {
+    // heuristic-summary=p;Generics$Generic1;true;ReturnParam;(Object);;Argument[0];ReturnValue;value;df-generated
+    // contentbased-summary=p;Generics$Generic1;true;ReturnParam;(Object);;Argument[0];ReturnValue;value;dfc-generated
+    @Override
+      public String ReturnParam(String input) {
+        return input;
+      }
+
+    // heuristic-summary=p;Generics$Generic1;true;StubImplementation;(Object);;Argument[0];ReturnValue;value;df-generated
+    // contentbased-summary=p;Generics$Generic1;true;StubImplementation;(Object);;Argument[0];ReturnValue;value;dfc-generated
+    @Override
+    public String StubImplementation(String input) {
+      return input;
+    }
+  }
+
+  public class Generic2<T> {
+    // heuristic-summary=p;Generics$Generic2;true;ReturnParam;(Object);;Argument[0];ReturnValue;value;df-generated
+    // contentbased-summary=p;Generics$Generic2;true;ReturnParam;(Object);;Argument[0];ReturnValue;value;dfc-generated
+    public T ReturnParam(T input) {
+      return input;
+    }
+
+    public T StubImplementation(T input) {
+      return null;
+    }
+  }
+
+  public class NestedGeneric<T> extends Generic2<String> { }
+
+  public class DerivedNestedGeneric extends NestedGeneric<Integer> {
+    // heuristic-summary=p;Generics$Generic2;true;ReturnParam;(Object);;Argument[0];ReturnValue;value;df-generated
+    // contentbased-summary=p;Generics$Generic2;true;ReturnParam;(Object);;Argument[0];ReturnValue;value;dfc-generated
+    @Override
+    public String ReturnParam(String input) {
+      return input;
+    }
+
+    // heuristic-summary=p;Generics$Generic2;true;StubImplementation;(Object);;Argument[0];ReturnValue;value;df-generated
+    // contentbased-summary=p;Generics$Generic2;true;StubImplementation;(Object);;Argument[0];ReturnValue;value;dfc-generated
+    @Override
+    public String StubImplementation(String input) {
+      return input;
+    }
+  }
+}


### PR DESCRIPTION
In this PR we update the model generator to cater for lifting models to unbound declarations.

If the PR is review'ed on a commit basis, the effect for C# is evident.