### PR TITLE
C#: Remove the query `cs/useless-assignment-to-local` from the `code-quality` suite.

### DIFF
--- a/csharp/ql/integration-tests/posix/query-suite/csharp-code-quality.qls.expected
+++ b/csharp/ql/integration-tests/posix/query-suite/csharp-code-quality.qls.expected
@@ -22,7 +22,6 @@ ql/csharp/ql/src/Concurrency/FutileSyncOnField.ql
 ql/csharp/ql/src/Concurrency/LockOrder.ql
 ql/csharp/ql/src/Concurrency/LockThis.ql
 ql/csharp/ql/src/Concurrency/LockedWait.ql
-ql/csharp/ql/src/Dead Code/DeadStoreOfLocal.ql
 ql/csharp/ql/src/Language Abuse/CastThisToTypeParameter.ql
 ql/csharp/ql/src/Language Abuse/CatchOfGenericException.ql
 ql/csharp/ql/src/Language Abuse/DubiousDowncastOfThis.ql

--- a/csharp/ql/src/change-notes/2026-07-15-code-quality-useless-assignment.md
+++ b/csharp/ql/src/change-notes/2026-07-15-code-quality-useless-assignment.md
@@ -1,0 +1,4 @@
+---
+category: queryMetadata
+---
+* The query `cs/useless-assignment-to-local` has been removed from the `code-quality` suite, but it remains in the `code-quality-extended` suite.

--- a/csharp/ql/src/codeql-suites/csharp-code-quality.qls
+++ b/csharp/ql/src/codeql-suites/csharp-code-quality.qls
@@ -1,3 +1,6 @@
 - queries: .
 - apply: code-quality-selectors.yml
   from: codeql/suite-helpers
+- exclude:
+    id:
+      - cs/useless-assignment-to-local


### PR DESCRIPTION
In this PR we remove the query `cs/useless-assignment-to-local` from the `code-quality` suite.