### PR TITLE
Shared: Add missing QLdoc

### DIFF
--- a/shared/util/codeql/util/Strings.qll
+++ b/shared/util/codeql/util/Strings.qll
@@ -1,3 +1,4 @@
+/** Provides predicates for working with strings. */
 overlay[local?]
 module;
 


### PR DESCRIPTION
The missing QLdoc is blocking the internal tests from running on one of my PRs.