### PR TITLE
Rust: Add a few more data flow test cases for format

### DIFF
--- a/rust/ql/test/library-tests/dataflow/strings/inline-taint-flow.expected
+++ b/rust/ql/test/library-tests/dataflow/strings/inline-taint-flow.expected
@@ -8,134 +8,134 @@ models
 | 7 | Summary: alloc::fmt::format; Argument[0]; ReturnValue; taint |
 | 8 | Summary: core::hint::must_use; Argument[0]; ReturnValue; value |
 edges
-| main.rs:26:9:26:9 | s | main.rs:27:19:27:19 | s | provenance |  |
-| main.rs:26:9:26:9 | s | main.rs:27:19:27:25 | s[...] | provenance |  |
-| main.rs:26:13:26:22 | source(...) | main.rs:26:9:26:9 | s | provenance |  |
-| main.rs:27:9:27:14 | sliced [&ref] | main.rs:28:16:28:21 | sliced | provenance |  |
-| main.rs:27:18:27:25 | &... [&ref] | main.rs:27:9:27:14 | sliced [&ref] | provenance |  |
-| main.rs:27:19:27:19 | s | main.rs:27:19:27:25 | s[...] | provenance | MaD:2 |
-| main.rs:27:19:27:25 | s[...] | main.rs:27:18:27:25 | &... [&ref] | provenance |  |
-| main.rs:32:9:32:10 | s1 | main.rs:35:14:35:15 | s1 | provenance |  |
-| main.rs:32:14:32:23 | source(...) | main.rs:32:9:32:10 | s1 | provenance |  |
-| main.rs:35:9:35:10 | s4 | main.rs:38:10:38:11 | s4 | provenance |  |
-| main.rs:35:14:35:15 | s1 | main.rs:35:14:35:20 | ... + ... | provenance | MaD:5 |
-| main.rs:35:14:35:20 | ... + ... | main.rs:35:9:35:10 | s4 | provenance |  |
-| main.rs:43:9:43:10 | s1 | main.rs:46:34:46:35 | s1 | provenance |  |
-| main.rs:43:14:43:23 | source(...) | main.rs:43:9:43:10 | s1 | provenance |  |
-| main.rs:46:33:46:35 | &s1 [&ref] | main.rs:46:10:46:35 | ... + ... | provenance | MaD:4 |
-| main.rs:46:34:46:35 | s1 | main.rs:46:33:46:35 | &s1 [&ref] | provenance |  |
-| main.rs:51:9:51:10 | s1 | main.rs:52:27:52:28 | s1 | provenance |  |
-| main.rs:51:14:51:29 | source_slice(...) | main.rs:51:9:51:10 | s1 | provenance |  |
-| main.rs:52:9:52:10 | s2 | main.rs:53:10:53:11 | s2 | provenance |  |
-| main.rs:52:14:52:29 | ...::from(...) | main.rs:52:9:52:10 | s2 | provenance |  |
-| main.rs:52:27:52:28 | s1 | main.rs:52:14:52:29 | ...::from(...) | provenance | MaD:3 |
-| main.rs:57:9:57:10 | s1 | main.rs:58:14:58:15 | s1 | provenance |  |
-| main.rs:57:14:57:29 | source_slice(...) | main.rs:57:9:57:10 | s1 | provenance |  |
-| main.rs:58:9:58:10 | s2 | main.rs:59:10:59:11 | s2 | provenance |  |
-| main.rs:58:14:58:15 | s1 | main.rs:58:14:58:27 | s1.to_string() | provenance | MaD:1 |
-| main.rs:58:14:58:27 | s1.to_string() | main.rs:58:9:58:10 | s2 | provenance |  |
-| main.rs:63:9:63:9 | s | main.rs:64:16:64:16 | s | provenance |  |
-| main.rs:63:13:63:22 | source(...) | main.rs:63:9:63:9 | s | provenance |  |
-| main.rs:64:16:64:16 | s | main.rs:64:16:64:25 | s.as_str() | provenance | MaD:6 |
-| main.rs:68:9:68:9 | s | main.rs:70:34:70:61 | MacroExpr | provenance |  |
-| main.rs:68:9:68:9 | s | main.rs:73:34:73:59 | MacroExpr | provenance |  |
-| main.rs:68:13:68:22 | source(...) | main.rs:68:9:68:9 | s | provenance |  |
-| main.rs:70:9:70:18 | formatted1 | main.rs:71:10:71:19 | formatted1 | provenance |  |
-| main.rs:70:22:70:62 | ...::format(...) | main.rs:70:9:70:18 | formatted1 | provenance |  |
-| main.rs:70:34:70:61 | MacroExpr | main.rs:70:22:70:62 | ...::format(...) | provenance | MaD:7 |
-| main.rs:73:9:73:18 | formatted2 | main.rs:74:10:74:19 | formatted2 | provenance |  |
-| main.rs:73:22:73:60 | ...::format(...) | main.rs:73:9:73:18 | formatted2 | provenance |  |
-| main.rs:73:34:73:59 | MacroExpr | main.rs:73:22:73:60 | ...::format(...) | provenance | MaD:7 |
-| main.rs:76:9:76:13 | width | main.rs:77:34:77:74 | MacroExpr | provenance |  |
-| main.rs:76:17:76:32 | source_usize(...) | main.rs:76:9:76:13 | width | provenance |  |
-| main.rs:77:9:77:18 | formatted3 | main.rs:78:10:78:19 | formatted3 | provenance |  |
-| main.rs:77:22:77:75 | ...::format(...) | main.rs:77:9:77:18 | formatted3 | provenance |  |
-| main.rs:77:34:77:74 | MacroExpr | main.rs:77:22:77:75 | ...::format(...) | provenance | MaD:7 |
-| main.rs:82:9:82:10 | s1 | main.rs:86:18:86:25 | MacroExpr | provenance |  |
-| main.rs:82:9:82:10 | s1 | main.rs:87:18:87:32 | MacroExpr | provenance |  |
-| main.rs:82:14:82:23 | source(...) | main.rs:82:9:82:10 | s1 | provenance |  |
-| main.rs:86:18:86:25 | ...::format(...) | main.rs:86:18:86:25 | { ... } | provenance |  |
-| main.rs:86:18:86:25 | ...::must_use(...) | main.rs:86:10:86:26 | MacroExpr | provenance |  |
-| main.rs:86:18:86:25 | MacroExpr | main.rs:86:18:86:25 | ...::format(...) | provenance | MaD:7 |
-| main.rs:86:18:86:25 | { ... } | main.rs:86:18:86:25 | ...::must_use(...) | provenance | MaD:8 |
-| main.rs:87:18:87:32 | ...::format(...) | main.rs:87:18:87:32 | { ... } | provenance |  |
-| main.rs:87:18:87:32 | ...::must_use(...) | main.rs:87:10:87:33 | MacroExpr | provenance |  |
-| main.rs:87:18:87:32 | MacroExpr | main.rs:87:18:87:32 | ...::format(...) | provenance | MaD:7 |
-| main.rs:87:18:87:32 | { ... } | main.rs:87:18:87:32 | ...::must_use(...) | provenance | MaD:8 |
+| main.rs:27:9:27:9 | s | main.rs:28:19:28:19 | s | provenance |  |
+| main.rs:27:9:27:9 | s | main.rs:28:19:28:25 | s[...] | provenance |  |
+| main.rs:27:13:27:22 | source(...) | main.rs:27:9:27:9 | s | provenance |  |
+| main.rs:28:9:28:14 | sliced [&ref] | main.rs:29:16:29:21 | sliced | provenance |  |
+| main.rs:28:18:28:25 | &... [&ref] | main.rs:28:9:28:14 | sliced [&ref] | provenance |  |
+| main.rs:28:19:28:19 | s | main.rs:28:19:28:25 | s[...] | provenance | MaD:2 |
+| main.rs:28:19:28:25 | s[...] | main.rs:28:18:28:25 | &... [&ref] | provenance |  |
+| main.rs:33:9:33:10 | s1 | main.rs:36:14:36:15 | s1 | provenance |  |
+| main.rs:33:14:33:23 | source(...) | main.rs:33:9:33:10 | s1 | provenance |  |
+| main.rs:36:9:36:10 | s4 | main.rs:39:10:39:11 | s4 | provenance |  |
+| main.rs:36:14:36:15 | s1 | main.rs:36:14:36:20 | ... + ... | provenance | MaD:5 |
+| main.rs:36:14:36:20 | ... + ... | main.rs:36:9:36:10 | s4 | provenance |  |
+| main.rs:44:9:44:10 | s1 | main.rs:47:34:47:35 | s1 | provenance |  |
+| main.rs:44:14:44:23 | source(...) | main.rs:44:9:44:10 | s1 | provenance |  |
+| main.rs:47:33:47:35 | &s1 [&ref] | main.rs:47:10:47:35 | ... + ... | provenance | MaD:4 |
+| main.rs:47:34:47:35 | s1 | main.rs:47:33:47:35 | &s1 [&ref] | provenance |  |
+| main.rs:52:9:52:10 | s1 | main.rs:53:27:53:28 | s1 | provenance |  |
+| main.rs:52:14:52:29 | source_slice(...) | main.rs:52:9:52:10 | s1 | provenance |  |
+| main.rs:53:9:53:10 | s2 | main.rs:54:10:54:11 | s2 | provenance |  |
+| main.rs:53:14:53:29 | ...::from(...) | main.rs:53:9:53:10 | s2 | provenance |  |
+| main.rs:53:27:53:28 | s1 | main.rs:53:14:53:29 | ...::from(...) | provenance | MaD:3 |
+| main.rs:58:9:58:10 | s1 | main.rs:59:14:59:15 | s1 | provenance |  |
+| main.rs:58:14:58:29 | source_slice(...) | main.rs:58:9:58:10 | s1 | provenance |  |
+| main.rs:59:9:59:10 | s2 | main.rs:60:10:60:11 | s2 | provenance |  |
+| main.rs:59:14:59:15 | s1 | main.rs:59:14:59:27 | s1.to_string() | provenance | MaD:1 |
+| main.rs:59:14:59:27 | s1.to_string() | main.rs:59:9:59:10 | s2 | provenance |  |
+| main.rs:64:9:64:9 | s | main.rs:65:16:65:16 | s | provenance |  |
+| main.rs:64:13:64:22 | source(...) | main.rs:64:9:64:9 | s | provenance |  |
+| main.rs:65:16:65:16 | s | main.rs:65:16:65:25 | s.as_str() | provenance | MaD:6 |
+| main.rs:69:9:69:9 | s | main.rs:71:34:71:61 | MacroExpr | provenance |  |
+| main.rs:69:9:69:9 | s | main.rs:74:34:74:59 | MacroExpr | provenance |  |
+| main.rs:69:13:69:22 | source(...) | main.rs:69:9:69:9 | s | provenance |  |
+| main.rs:71:9:71:18 | formatted1 | main.rs:72:10:72:19 | formatted1 | provenance |  |
+| main.rs:71:22:71:62 | ...::format(...) | main.rs:71:9:71:18 | formatted1 | provenance |  |
+| main.rs:71:34:71:61 | MacroExpr | main.rs:71:22:71:62 | ...::format(...) | provenance | MaD:7 |
+| main.rs:74:9:74:18 | formatted2 | main.rs:75:10:75:19 | formatted2 | provenance |  |
+| main.rs:74:22:74:60 | ...::format(...) | main.rs:74:9:74:18 | formatted2 | provenance |  |
+| main.rs:74:34:74:59 | MacroExpr | main.rs:74:22:74:60 | ...::format(...) | provenance | MaD:7 |
+| main.rs:77:9:77:13 | width | main.rs:78:34:78:74 | MacroExpr | provenance |  |
+| main.rs:77:17:77:32 | source_usize(...) | main.rs:77:9:77:13 | width | provenance |  |
+| main.rs:78:9:78:18 | formatted3 | main.rs:79:10:79:19 | formatted3 | provenance |  |
+| main.rs:78:22:78:75 | ...::format(...) | main.rs:78:9:78:18 | formatted3 | provenance |  |
+| main.rs:78:34:78:74 | MacroExpr | main.rs:78:22:78:75 | ...::format(...) | provenance | MaD:7 |
+| main.rs:89:9:89:10 | s1 | main.rs:93:18:93:25 | MacroExpr | provenance |  |
+| main.rs:89:9:89:10 | s1 | main.rs:94:18:94:32 | MacroExpr | provenance |  |
+| main.rs:89:14:89:23 | source(...) | main.rs:89:9:89:10 | s1 | provenance |  |
+| main.rs:93:18:93:25 | ...::format(...) | main.rs:93:18:93:25 | { ... } | provenance |  |
+| main.rs:93:18:93:25 | ...::must_use(...) | main.rs:93:10:93:26 | MacroExpr | provenance |  |
+| main.rs:93:18:93:25 | MacroExpr | main.rs:93:18:93:25 | ...::format(...) | provenance | MaD:7 |
+| main.rs:93:18:93:25 | { ... } | main.rs:93:18:93:25 | ...::must_use(...) | provenance | MaD:8 |
+| main.rs:94:18:94:32 | ...::format(...) | main.rs:94:18:94:32 | { ... } | provenance |  |
+| main.rs:94:18:94:32 | ...::must_use(...) | main.rs:94:10:94:33 | MacroExpr | provenance |  |
+| main.rs:94:18:94:32 | MacroExpr | main.rs:94:18:94:32 | ...::format(...) | provenance | MaD:7 |
+| main.rs:94:18:94:32 | { ... } | main.rs:94:18:94:32 | ...::must_use(...) | provenance | MaD:8 |
 nodes
-| main.rs:26:9:26:9 | s | semmle.label | s |
-| main.rs:26:13:26:22 | source(...) | semmle.label | source(...) |
-| main.rs:27:9:27:14 | sliced [&ref] | semmle.label | sliced [&ref] |
-| main.rs:27:18:27:25 | &... [&ref] | semmle.label | &... [&ref] |
-| main.rs:27:19:27:19 | s | semmle.label | s |
-| main.rs:27:19:27:25 | s[...] | semmle.label | s[...] |
-| main.rs:28:16:28:21 | sliced | semmle.label | sliced |
-| main.rs:32:9:32:10 | s1 | semmle.label | s1 |
-| main.rs:32:14:32:23 | source(...) | semmle.label | source(...) |
-| main.rs:35:9:35:10 | s4 | semmle.label | s4 |
-| main.rs:35:14:35:15 | s1 | semmle.label | s1 |
-| main.rs:35:14:35:20 | ... + ... | semmle.label | ... + ... |
-| main.rs:38:10:38:11 | s4 | semmle.label | s4 |
-| main.rs:43:9:43:10 | s1 | semmle.label | s1 |
-| main.rs:43:14:43:23 | source(...) | semmle.label | source(...) |
-| main.rs:46:10:46:35 | ... + ... | semmle.label | ... + ... |
-| main.rs:46:33:46:35 | &s1 [&ref] | semmle.label | &s1 [&ref] |
-| main.rs:46:34:46:35 | s1 | semmle.label | s1 |
-| main.rs:51:9:51:10 | s1 | semmle.label | s1 |
-| main.rs:51:14:51:29 | source_slice(...) | semmle.label | source_slice(...) |
-| main.rs:52:9:52:10 | s2 | semmle.label | s2 |
-| main.rs:52:14:52:29 | ...::from(...) | semmle.label | ...::from(...) |
-| main.rs:52:27:52:28 | s1 | semmle.label | s1 |
-| main.rs:53:10:53:11 | s2 | semmle.label | s2 |
-| main.rs:57:9:57:10 | s1 | semmle.label | s1 |
-| main.rs:57:14:57:29 | source_slice(...) | semmle.label | source_slice(...) |
-| main.rs:58:9:58:10 | s2 | semmle.label | s2 |
-| main.rs:58:14:58:15 | s1 | semmle.label | s1 |
-| main.rs:58:14:58:27 | s1.to_string() | semmle.label | s1.to_string() |
-| main.rs:59:10:59:11 | s2 | semmle.label | s2 |
-| main.rs:63:9:63:9 | s | semmle.label | s |
-| main.rs:63:13:63:22 | source(...) | semmle.label | source(...) |
-| main.rs:64:16:64:16 | s | semmle.label | s |
-| main.rs:64:16:64:25 | s.as_str() | semmle.label | s.as_str() |
-| main.rs:68:9:68:9 | s | semmle.label | s |
-| main.rs:68:13:68:22 | source(...) | semmle.label | source(...) |
-| main.rs:70:9:70:18 | formatted1 | semmle.label | formatted1 |
-| main.rs:70:22:70:62 | ...::format(...) | semmle.label | ...::format(...) |
-| main.rs:70:34:70:61 | MacroExpr | semmle.label | MacroExpr |
-| main.rs:71:10:71:19 | formatted1 | semmle.label | formatted1 |
-| main.rs:73:9:73:18 | formatted2 | semmle.label | formatted2 |
-| main.rs:73:22:73:60 | ...::format(...) | semmle.label | ...::format(...) |
-| main.rs:73:34:73:59 | MacroExpr | semmle.label | MacroExpr |
-| main.rs:74:10:74:19 | formatted2 | semmle.label | formatted2 |
-| main.rs:76:9:76:13 | width | semmle.label | width |
-| main.rs:76:17:76:32 | source_usize(...) | semmle.label | source_usize(...) |
-| main.rs:77:9:77:18 | formatted3 | semmle.label | formatted3 |
-| main.rs:77:22:77:75 | ...::format(...) | semmle.label | ...::format(...) |
-| main.rs:77:34:77:74 | MacroExpr | semmle.label | MacroExpr |
-| main.rs:78:10:78:19 | formatted3 | semmle.label | formatted3 |
-| main.rs:82:9:82:10 | s1 | semmle.label | s1 |
-| main.rs:82:14:82:23 | source(...) | semmle.label | source(...) |
-| main.rs:86:10:86:26 | MacroExpr | semmle.label | MacroExpr |
-| main.rs:86:18:86:25 | ...::format(...) | semmle.label | ...::format(...) |
-| main.rs:86:18:86:25 | ...::must_use(...) | semmle.label | ...::must_use(...) |
-| main.rs:86:18:86:25 | MacroExpr | semmle.label | MacroExpr |
-| main.rs:86:18:86:25 | { ... } | semmle.label | { ... } |
-| main.rs:87:10:87:33 | MacroExpr | semmle.label | MacroExpr |
-| main.rs:87:18:87:32 | ...::format(...) | semmle.label | ...::format(...) |
-| main.rs:87:18:87:32 | ...::must_use(...) | semmle.label | ...::must_use(...) |
-| main.rs:87:18:87:32 | MacroExpr | semmle.label | MacroExpr |
-| main.rs:87:18:87:32 | { ... } | semmle.label | { ... } |
+| main.rs:27:9:27:9 | s | semmle.label | s |
+| main.rs:27:13:27:22 | source(...) | semmle.label | source(...) |
+| main.rs:28:9:28:14 | sliced [&ref] | semmle.label | sliced [&ref] |
+| main.rs:28:18:28:25 | &... [&ref] | semmle.label | &... [&ref] |
+| main.rs:28:19:28:19 | s | semmle.label | s |
+| main.rs:28:19:28:25 | s[...] | semmle.label | s[...] |
+| main.rs:29:16:29:21 | sliced | semmle.label | sliced |
+| main.rs:33:9:33:10 | s1 | semmle.label | s1 |
+| main.rs:33:14:33:23 | source(...) | semmle.label | source(...) |
+| main.rs:36:9:36:10 | s4 | semmle.label | s4 |
+| main.rs:36:14:36:15 | s1 | semmle.label | s1 |
+| main.rs:36:14:36:20 | ... + ... | semmle.label | ... + ... |
+| main.rs:39:10:39:11 | s4 | semmle.label | s4 |
+| main.rs:44:9:44:10 | s1 | semmle.label | s1 |
+| main.rs:44:14:44:23 | source(...) | semmle.label | source(...) |
+| main.rs:47:10:47:35 | ... + ... | semmle.label | ... + ... |
+| main.rs:47:33:47:35 | &s1 [&ref] | semmle.label | &s1 [&ref] |
+| main.rs:47:34:47:35 | s1 | semmle.label | s1 |
+| main.rs:52:9:52:10 | s1 | semmle.label | s1 |
+| main.rs:52:14:52:29 | source_slice(...) | semmle.label | source_slice(...) |
+| main.rs:53:9:53:10 | s2 | semmle.label | s2 |
+| main.rs:53:14:53:29 | ...::from(...) | semmle.label | ...::from(...) |
+| main.rs:53:27:53:28 | s1 | semmle.label | s1 |
+| main.rs:54:10:54:11 | s2 | semmle.label | s2 |
+| main.rs:58:9:58:10 | s1 | semmle.label | s1 |
+| main.rs:58:14:58:29 | source_slice(...) | semmle.label | source_slice(...) |
+| main.rs:59:9:59:10 | s2 | semmle.label | s2 |
+| main.rs:59:14:59:15 | s1 | semmle.label | s1 |
+| main.rs:59:14:59:27 | s1.to_string() | semmle.label | s1.to_string() |
+| main.rs:60:10:60:11 | s2 | semmle.label | s2 |
+| main.rs:64:9:64:9 | s | semmle.label | s |
+| main.rs:64:13:64:22 | source(...) | semmle.label | source(...) |
+| main.rs:65:16:65:16 | s | semmle.label | s |
+| main.rs:65:16:65:25 | s.as_str() | semmle.label | s.as_str() |
+| main.rs:69:9:69:9 | s | semmle.label | s |
+| main.rs:69:13:69:22 | source(...) | semmle.label | source(...) |
+| main.rs:71:9:71:18 | formatted1 | semmle.label | formatted1 |
+| main.rs:71:22:71:62 | ...::format(...) | semmle.label | ...::format(...) |
+| main.rs:71:34:71:61 | MacroExpr | semmle.label | MacroExpr |
+| main.rs:72:10:72:19 | formatted1 | semmle.label | formatted1 |
+| main.rs:74:9:74:18 | formatted2 | semmle.label | formatted2 |
+| main.rs:74:22:74:60 | ...::format(...) | semmle.label | ...::format(...) |
+| main.rs:74:34:74:59 | MacroExpr | semmle.label | MacroExpr |
+| main.rs:75:10:75:19 | formatted2 | semmle.label | formatted2 |
+| main.rs:77:9:77:13 | width | semmle.label | width |
+| main.rs:77:17:77:32 | source_usize(...) | semmle.label | source_usize(...) |
+| main.rs:78:9:78:18 | formatted3 | semmle.label | formatted3 |
+| main.rs:78:22:78:75 | ...::format(...) | semmle.label | ...::format(...) |
+| main.rs:78:34:78:74 | MacroExpr | semmle.label | MacroExpr |
+| main.rs:79:10:79:19 | formatted3 | semmle.label | formatted3 |
+| main.rs:89:9:89:10 | s1 | semmle.label | s1 |
+| main.rs:89:14:89:23 | source(...) | semmle.label | source(...) |
+| main.rs:93:10:93:26 | MacroExpr | semmle.label | MacroExpr |
+| main.rs:93:18:93:25 | ...::format(...) | semmle.label | ...::format(...) |
+| main.rs:93:18:93:25 | ...::must_use(...) | semmle.label | ...::must_use(...) |
+| main.rs:93:18:93:25 | MacroExpr | semmle.label | MacroExpr |
+| main.rs:93:18:93:25 | { ... } | semmle.label | { ... } |
+| main.rs:94:10:94:33 | MacroExpr | semmle.label | MacroExpr |
+| main.rs:94:18:94:32 | ...::format(...) | semmle.label | ...::format(...) |
+| main.rs:94:18:94:32 | ...::must_use(...) | semmle.label | ...::must_use(...) |
+| main.rs:94:18:94:32 | MacroExpr | semmle.label | MacroExpr |
+| main.rs:94:18:94:32 | { ... } | semmle.label | { ... } |
 subpaths
 testFailures
 #select
-| main.rs:28:16:28:21 | sliced | main.rs:26:13:26:22 | source(...) | main.rs:28:16:28:21 | sliced | $@ | main.rs:26:13:26:22 | source(...) | source(...) |
-| main.rs:38:10:38:11 | s4 | main.rs:32:14:32:23 | source(...) | main.rs:38:10:38:11 | s4 | $@ | main.rs:32:14:32:23 | source(...) | source(...) |
-| main.rs:46:10:46:35 | ... + ... | main.rs:43:14:43:23 | source(...) | main.rs:46:10:46:35 | ... + ... | $@ | main.rs:43:14:43:23 | source(...) | source(...) |
-| main.rs:53:10:53:11 | s2 | main.rs:51:14:51:29 | source_slice(...) | main.rs:53:10:53:11 | s2 | $@ | main.rs:51:14:51:29 | source_slice(...) | source_slice(...) |
-| main.rs:59:10:59:11 | s2 | main.rs:57:14:57:29 | source_slice(...) | main.rs:59:10:59:11 | s2 | $@ | main.rs:57:14:57:29 | source_slice(...) | source_slice(...) |
-| main.rs:64:16:64:25 | s.as_str() | main.rs:63:13:63:22 | source(...) | main.rs:64:16:64:25 | s.as_str() | $@ | main.rs:63:13:63:22 | source(...) | source(...) |
-| main.rs:71:10:71:19 | formatted1 | main.rs:68:13:68:22 | source(...) | main.rs:71:10:71:19 | formatted1 | $@ | main.rs:68:13:68:22 | source(...) | source(...) |
-| main.rs:74:10:74:19 | formatted2 | main.rs:68:13:68:22 | source(...) | main.rs:74:10:74:19 | formatted2 | $@ | main.rs:68:13:68:22 | source(...) | source(...) |
-| main.rs:78:10:78:19 | formatted3 | main.rs:76:17:76:32 | source_usize(...) | main.rs:78:10:78:19 | formatted3 | $@ | main.rs:76:17:76:32 | source_usize(...) | source_usize(...) |
-| main.rs:86:10:86:26 | MacroExpr | main.rs:82:14:82:23 | source(...) | main.rs:86:10:86:26 | MacroExpr | $@ | main.rs:82:14:82:23 | source(...) | source(...) |
-| main.rs:87:10:87:33 | MacroExpr | main.rs:82:14:82:23 | source(...) | main.rs:87:10:87:33 | MacroExpr | $@ | main.rs:82:14:82:23 | source(...) | source(...) |
+| main.rs:29:16:29:21 | sliced | main.rs:27:13:27:22 | source(...) | main.rs:29:16:29:21 | sliced | $@ | main.rs:27:13:27:22 | source(...) | source(...) |
+| main.rs:39:10:39:11 | s4 | main.rs:33:14:33:23 | source(...) | main.rs:39:10:39:11 | s4 | $@ | main.rs:33:14:33:23 | source(...) | source(...) |
+| main.rs:47:10:47:35 | ... + ... | main.rs:44:14:44:23 | source(...) | main.rs:47:10:47:35 | ... + ... | $@ | main.rs:44:14:44:23 | source(...) | source(...) |
+| main.rs:54:10:54:11 | s2 | main.rs:52:14:52:29 | source_slice(...) | main.rs:54:10:54:11 | s2 | $@ | main.rs:52:14:52:29 | source_slice(...) | source_slice(...) |
+| main.rs:60:10:60:11 | s2 | main.rs:58:14:58:29 | source_slice(...) | main.rs:60:10:60:11 | s2 | $@ | main.rs:58:14:58:29 | source_slice(...) | source_slice(...) |
+| main.rs:65:16:65:25 | s.as_str() | main.rs:64:13:64:22 | source(...) | main.rs:65:16:65:25 | s.as_str() | $@ | main.rs:64:13:64:22 | source(...) | source(...) |
+| main.rs:72:10:72:19 | formatted1 | main.rs:69:13:69:22 | source(...) | main.rs:72:10:72:19 | formatted1 | $@ | main.rs:69:13:69:22 | source(...) | source(...) |
+| main.rs:75:10:75:19 | formatted2 | main.rs:69:13:69:22 | source(...) | main.rs:75:10:75:19 | formatted2 | $@ | main.rs:69:13:69:22 | source(...) | source(...) |
+| main.rs:79:10:79:19 | formatted3 | main.rs:77:17:77:32 | source_usize(...) | main.rs:79:10:79:19 | formatted3 | $@ | main.rs:77:17:77:32 | source_usize(...) | source_usize(...) |
+| main.rs:93:10:93:26 | MacroExpr | main.rs:89:14:89:23 | source(...) | main.rs:93:10:93:26 | MacroExpr | $@ | main.rs:89:14:89:23 | source(...) | source(...) |
+| main.rs:94:10:94:33 | MacroExpr | main.rs:89:14:89:23 | source(...) | main.rs:94:10:94:33 | MacroExpr | $@ | main.rs:89:14:89:23 | source(...) | source(...) |

--- a/rust/ql/test/library-tests/dataflow/strings/inline-taint-flow.expected
+++ b/rust/ql/test/library-tests/dataflow/strings/inline-taint-flow.expected
@@ -39,6 +39,8 @@ edges
 | main.rs:65:16:65:16 | s | main.rs:65:16:65:25 | s.as_str() | provenance | MaD:6 |
 | main.rs:69:9:69:9 | s | main.rs:71:34:71:61 | MacroExpr | provenance |  |
 | main.rs:69:9:69:9 | s | main.rs:74:34:74:59 | MacroExpr | provenance |  |
+| main.rs:69:9:69:9 | s | main.rs:81:39:81:64 | MacroExpr | provenance |  |
+| main.rs:69:9:69:9 | s | main.rs:84:41:84:66 | MacroExpr | provenance |  |
 | main.rs:69:13:69:22 | source(...) | main.rs:69:9:69:9 | s | provenance |  |
 | main.rs:71:9:71:18 | formatted1 | main.rs:72:10:72:19 | formatted1 | provenance |  |
 | main.rs:71:22:71:62 | ...::format(...) | main.rs:71:9:71:18 | formatted1 | provenance |  |
@@ -51,6 +53,12 @@ edges
 | main.rs:78:9:78:18 | formatted3 | main.rs:79:10:79:19 | formatted3 | provenance |  |
 | main.rs:78:22:78:75 | ...::format(...) | main.rs:78:9:78:18 | formatted3 | provenance |  |
 | main.rs:78:34:78:74 | MacroExpr | main.rs:78:22:78:75 | ...::format(...) | provenance | MaD:7 |
+| main.rs:81:9:81:18 | formatted4 | main.rs:82:10:82:19 | formatted4 | provenance |  |
+| main.rs:81:22:81:65 | ...::format(...) | main.rs:81:9:81:18 | formatted4 | provenance |  |
+| main.rs:81:39:81:64 | MacroExpr | main.rs:81:22:81:65 | ...::format(...) | provenance | MaD:7 |
+| main.rs:84:9:84:18 | formatted5 | main.rs:85:10:85:19 | formatted5 | provenance |  |
+| main.rs:84:22:84:67 | ...::format(...) | main.rs:84:9:84:18 | formatted5 | provenance |  |
+| main.rs:84:41:84:66 | MacroExpr | main.rs:84:22:84:67 | ...::format(...) | provenance | MaD:7 |
 | main.rs:89:9:89:10 | s1 | main.rs:93:18:93:25 | MacroExpr | provenance |  |
 | main.rs:89:9:89:10 | s1 | main.rs:94:18:94:32 | MacroExpr | provenance |  |
 | main.rs:89:14:89:23 | source(...) | main.rs:89:9:89:10 | s1 | provenance |  |
@@ -113,6 +121,14 @@ nodes
 | main.rs:78:22:78:75 | ...::format(...) | semmle.label | ...::format(...) |
 | main.rs:78:34:78:74 | MacroExpr | semmle.label | MacroExpr |
 | main.rs:79:10:79:19 | formatted3 | semmle.label | formatted3 |
+| main.rs:81:9:81:18 | formatted4 | semmle.label | formatted4 |
+| main.rs:81:22:81:65 | ...::format(...) | semmle.label | ...::format(...) |
+| main.rs:81:39:81:64 | MacroExpr | semmle.label | MacroExpr |
+| main.rs:82:10:82:19 | formatted4 | semmle.label | formatted4 |
+| main.rs:84:9:84:18 | formatted5 | semmle.label | formatted5 |
+| main.rs:84:22:84:67 | ...::format(...) | semmle.label | ...::format(...) |
+| main.rs:84:41:84:66 | MacroExpr | semmle.label | MacroExpr |
+| main.rs:85:10:85:19 | formatted5 | semmle.label | formatted5 |
 | main.rs:89:9:89:10 | s1 | semmle.label | s1 |
 | main.rs:89:14:89:23 | source(...) | semmle.label | source(...) |
 | main.rs:93:10:93:26 | MacroExpr | semmle.label | MacroExpr |
@@ -137,5 +153,7 @@ testFailures
 | main.rs:72:10:72:19 | formatted1 | main.rs:69:13:69:22 | source(...) | main.rs:72:10:72:19 | formatted1 | $@ | main.rs:69:13:69:22 | source(...) | source(...) |
 | main.rs:75:10:75:19 | formatted2 | main.rs:69:13:69:22 | source(...) | main.rs:75:10:75:19 | formatted2 | $@ | main.rs:69:13:69:22 | source(...) | source(...) |
 | main.rs:79:10:79:19 | formatted3 | main.rs:77:17:77:32 | source_usize(...) | main.rs:79:10:79:19 | formatted3 | $@ | main.rs:77:17:77:32 | source_usize(...) | source_usize(...) |
+| main.rs:82:10:82:19 | formatted4 | main.rs:69:13:69:22 | source(...) | main.rs:82:10:82:19 | formatted4 | $@ | main.rs:69:13:69:22 | source(...) | source(...) |
+| main.rs:85:10:85:19 | formatted5 | main.rs:69:13:69:22 | source(...) | main.rs:85:10:85:19 | formatted5 | $@ | main.rs:69:13:69:22 | source(...) | source(...) |
 | main.rs:93:10:93:26 | MacroExpr | main.rs:89:14:89:23 | source(...) | main.rs:93:10:93:26 | MacroExpr | $@ | main.rs:89:14:89:23 | source(...) | source(...) |
 | main.rs:94:10:94:33 | MacroExpr | main.rs:89:14:89:23 | source(...) | main.rs:94:10:94:33 | MacroExpr | $@ | main.rs:89:14:89:23 | source(...) | source(...) |

--- a/rust/ql/test/library-tests/dataflow/strings/main.rs
+++ b/rust/ql/test/library-tests/dataflow/strings/main.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+
 // Taint tests for strings
 
 fn source(i: i64) -> String {
@@ -76,6 +77,12 @@ fn format_args_built_in() {
     let width = source_usize(10);
     let formatted3 = fmt::format(format_args!("Hello {:width$}!", "World"));
     sink(formatted3); // $ hasTaintFlow=10
+
+
+
+
+
+
 }
 
 fn format_macro() {

--- a/rust/ql/test/library-tests/dataflow/strings/main.rs
+++ b/rust/ql/test/library-tests/dataflow/strings/main.rs
@@ -1,5 +1,5 @@
 use std::fmt;
-
+extern crate alloc;
 
 // Taint tests for strings
 
@@ -78,11 +78,11 @@ fn format_args_built_in() {
     let formatted3 = fmt::format(format_args!("Hello {:width$}!", "World"));
     sink(formatted3); // $ hasTaintFlow=10
 
+    let formatted4 = std::fmt::format(format_args!("Hello {s}!"));
+    sink(formatted4); // $ hasTaintFlow=88
 
-
-
-
-
+    let formatted5 = alloc::fmt::format(format_args!("Hello {s}!"));
+    sink(formatted5); // $ hasTaintFlow=88
 }
 
 fn format_macro() {


### PR DESCRIPTION
Add a few more data flow test cases for `std::fmt::format` and `alloc::fmt::format` (which is being discussed elsewhere).