### PR TITLE
JS: Recognize @fastify/rate-limit as a rate limiter

### DIFF
--- a/javascript/ql/lib/semmle/javascript/security/dataflow/MissingRateLimiting.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/MissingRateLimiting.qll
@@ -189,7 +189,9 @@ class RouteHandlerLimitedByRateLimiterFlexible extends RateLimitingMiddleware in
 { }
 
 private class FastifyRateLimiter extends RateLimitingMiddleware {
-  FastifyRateLimiter() { this = DataFlow::moduleImport("fastify-rate-limit") }
+  FastifyRateLimiter() {
+    this = DataFlow::moduleImport(["fastify-rate-limit", "@fastify/rate-limit"])
+  }
 }
 
 /**

--- a/javascript/ql/src/change-notes/2026-07-22-fastify-rate-limit.md
+++ b/javascript/ql/src/change-notes/2026-07-22-fastify-rate-limit.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The `js/missing-rate-limiting` query now recognizes the `@fastify/rate-limit` package as a rate limiter.

--- a/javascript/ql/test/query-tests/Security/CWE-770/MissingRateLimit/MissingRateLimiting.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-770/MissingRateLimit/MissingRateLimiting.expected
@@ -9,4 +9,5 @@
 | tst.js:64:25:64:63 | functio ... req); } | This route handler performs $@, but is not rate-limited. | tst.js:64:46:64:60 | verifyUser(req) | authorization |
 | tst.js:76:25:76:53 | catchAs ... ndler1) | This route handler performs $@, but is not rate-limited. | tst.js:14:40:14:46 | login() | authorization |
 | tst.js:88:24:88:40 | expensiveHandler1 | This route handler performs $@, but is not rate-limited. | tst.js:14:40:14:46 | login() | authorization |
-| tst.js:112:28:112:44 | expensiveHandler1 | This route handler performs $@, but is not rate-limited. | tst.js:14:40:14:46 | login() | authorization |
+| tst.js:111:28:111:44 | expensiveHandler1 | This route handler performs $@, but is not rate-limited. | tst.js:14:40:14:46 | login() | authorization |
+| tst.js:116:39:116:55 | expensiveHandler1 | This route handler performs $@, but is not rate-limited. | tst.js:14:40:14:46 | login() | authorization |

--- a/javascript/ql/test/query-tests/Security/CWE-770/MissingRateLimit/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-770/MissingRateLimit/tst.js
@@ -91,7 +91,6 @@ fastifyApp.get('/bar', expensiveHandler1);
 
 // Fastify per-route rate limiting via config.rateLimit
 const fastifyApp2 = require('fastify')();
-fastifyApp2.register(require('@fastify/rate-limit'));
 
 fastifyApp2.post('/login', {
   config: {
@@ -110,3 +109,10 @@ fastifyApp2.post('/signup', {
 }, expensiveHandler1); // OK - has per-route rateLimit directly in options
 
 fastifyApp2.post('/other', expensiveHandler1); // $ Alert - no rate limiting
+
+// rate limiting using the scoped package name
+const fastifyApp3 = require('fastify')();
+
+fastifyApp3.get('/before-rate-limit', expensiveHandler1); // $ Alert
+fastifyApp3.register(require('@fastify/rate-limit'));
+fastifyApp3.get('/after-rate-limit', expensiveHandler1);


### PR DESCRIPTION
## Summary

The `js/missing-rate-limiting` query reports Fastify routes protected by `@fastify/rate-limit` as unprotected.

The Fastify rate-limiter model recognizes only the legacy `fastify-rate-limit` package name. This change adds the current scoped package name while retaining support for the legacy package.

## Test coverage

The regression test uses independent Fastify applications to verify that:

- `fastify-rate-limit` registration remains recognized.
- `@fastify/rate-limit` registration protects routes declared after registration.
- A route declared before scoped-package registration is still reported as unprotected.
- Existing per-route rate-limiting assertions remain independently exercised.

The red/green behavior was verified directly: before the model change, the focused test failed because the query reported the route following `@fastify/rate-limit` registration. After the change, the test passes and only the intentionally unprotected route is reported.

## Validation

- Focused `MissingRateLimit` query test: passed
- QL formatting check: passed
- JavaScript query-pack release validation: passed
- `git diff --check`: passed

Developed and validated with assistance from OpenAI Codex.
