### PR TITLE
QL: Autoformat test files

### DIFF
--- a/ql/ql/test/queries/performance/MissingNoInline/Test.qll
+++ b/ql/ql/test/queries/performance/MissingNoInline/Test.qll
@@ -5,7 +5,8 @@ import ql
  *
  * This predicate exists to fix a join order.
  */
-predicate missingNoInline(AddExpr add, Expr e1, Expr e2) { // $ Alert
+predicate missingNoInline(AddExpr add, Expr e1, Expr e2) {
+  // $ Alert
   // BAD
   add.getLeftOperand() = e1 and
   add.getRightOperand() = e2

--- a/ql/ql/test/queries/style/AcronymsShouldBeCamelCase/Test.qll
+++ b/ql/ql/test/queries/style/AcronymsShouldBeCamelCase/Test.qll
@@ -5,7 +5,8 @@ predicate isXML() { any() } // $ Alert
 predicate isAES() { any() }
 
 // BAD
-newtype TXMLElements = // $ Alert
+newtype TXMLElements =
+  // $ Alert
   TXmlElement() or // GOOD
   TXMLElement() // $ Alert // BAD
 

--- a/ql/ql/test/queries/style/DataFlowConfigModuleNaming/Test.qll
+++ b/ql/ql/test/queries/style/DataFlowConfigModuleNaming/Test.qll
@@ -8,14 +8,16 @@ module EmptyConfig implements DataFlow::ConfigSig {
 }
 
 // BAD - does not end with "Config"
-module EmptyConfiguration implements DataFlow::ConfigSig { // $ Alert
+module EmptyConfiguration implements DataFlow::ConfigSig {
+  // $ Alert
   predicate isSource(DataFlow::Node src) { none() }
 
   predicate isSink(DataFlow::Node sink) { none() }
 }
 
 // BAD - does not end with "Config"
-module EmptyFlow implements DataFlow::ConfigSig { // $ Alert
+module EmptyFlow implements DataFlow::ConfigSig {
+  // $ Alert
   predicate isSource(DataFlow::Node src) { none() }
 
   predicate isSink(DataFlow::Node sink) { none() }

--- a/ql/ql/test/queries/style/DeadCode/Foo.qll
+++ b/ql/ql/test/queries/style/DeadCode/Foo.qll
@@ -43,7 +43,8 @@ private module Input1 implements InputSig {
   predicate foo() { any() }
 }
 
-private module Input2 implements InputSig { // $ Alert
+private module Input2 implements InputSig {
+  // $ Alert
   predicate foo() { any() }
 }
 

--- a/ql/ql/test/queries/style/Misspelling/Test.qll
+++ b/ql/ql/test/queries/style/Misspelling/Test.qll
@@ -1,7 +1,8 @@
 /**
  * A string that's deliberately mispelled (and so is that last word).
  */ // $ Alert
-class PublicallyAccessible extends string { // $ Alert
+class PublicallyAccessible extends string {
+  // $ Alert
   int numOccurences; // $ Alert // should be 'occurrences'
 
   PublicallyAccessible() { this = "publically" and numOccurences = 123 }
@@ -16,7 +17,8 @@ class PublicallyAccessible extends string { // $ Alert
  * A class whose name contains a British-English spelling.
  * And here's the word 'colour'.
  */ // $ Alert
-class AnalysedInt extends int { // $ Alert
+class AnalysedInt extends int {
+  // $ Alert
   AnalysedInt() { this = 7 }
 
   // 'analyses' should not be flagged

--- a/ql/ql/test/queries/style/NonDocBlock/Foo.qll
+++ b/ql/ql/test/queries/style/NonDocBlock/Foo.qll
@@ -1,13 +1,15 @@
 /*
  * This should be QLDoc.
- */ // $ Alert
+ */
 
+// $ Alert
 /**
  * this is fine
  */
 predicate foo() { any() }
 
-/* Note: this is bad. */ // $ Alert
+/* Note: this is bad. */
+// $ Alert
 class Foo extends string {
   Foo() { this = "FOo" }
 }

--- a/ql/ql/test/queries/style/UseInstanceofExtension/Foo.qll
+++ b/ql/ql/test/queries/style/UseInstanceofExtension/Foo.qll
@@ -4,7 +4,8 @@ class Range extends string {
   string getAChild() { result = "test" }
 }
 
-class Inst extends string { // $ Alert
+class Inst extends string {
+  // $ Alert
   Range range;
 
   Inst() { this = range }
@@ -12,13 +13,15 @@ class Inst extends string { // $ Alert
   string getAChild() { result = range.getAChild() }
 }
 
-class Inst2 extends string { // $ Alert
+class Inst2 extends string {
+  // $ Alert
   Inst2() { this instanceof Range }
 
   string getAChild() { result = this.(Range).getAChild() }
 }
 
-class Inst3 extends string { // $ Alert
+class Inst3 extends string {
+  // $ Alert
   Range range;
 
   Inst3() { this = range }
@@ -26,6 +29,7 @@ class Inst3 extends string { // $ Alert
   Range getRange() { result = range }
 }
 
-class Inst4 extends string { // $ Alert
+class Inst4 extends string {
+  // $ Alert
   Inst4() { this instanceof Range }
 }


### PR DESCRIPTION
This autoformats seven QL test files that were left unformatted by commit 4ad3a44aab30 ("QL: Convert qlref tests to inline expectations").

The inline expectation comments introduced there were not run through formatter output, which causes the Check Autoformatting CI job in semmle-code to fail.