### PR TITLE
Swift: Recurse clang submodules when computing extension indexes

### DIFF
--- a/swift/extractor/mangler/SwiftMangler.cpp
+++ b/swift/extractor/mangler/SwiftMangler.cpp
@@ -1,6 +1,5 @@
 #include "swift/extractor/mangler/SwiftMangler.h"
 #include "swift/extractor/infra/SwiftDispatcher.h"
-#include "swift/extractor/trap/generated/decl/TrapClasses.h"
 #include "swift/logging/SwiftLogging.h"
 
 #include <swift/AST/Module.h>
@@ -170,15 +169,12 @@ void SwiftMangler::indexExtensionsAndFilePrivateValues(llvm::ArrayRef<swift::Dec
   }
 }
 
-void SwiftMangler::indexClangExtensionsAndFilePrivateValues(
+uint32_t SwiftMangler::indexClangSubmoduleExtensionsAndFilePrivateValues(
     const clang::Module* clangModule,
-    swift::ClangModuleLoader* moduleLoader) {
-  if (!moduleLoader) {
-    return;
-  }
-
-  auto index = 0u;
+    swift::ClangModuleLoader* moduleLoader,
+    uint32_t index) {
   for (const auto& submodule : clangModule->submodules()) {
+    index = indexClangSubmoduleExtensionsAndFilePrivateValues(submodule, moduleLoader, index);
     if (auto* swiftSubmodule = moduleLoader->getWrapperForModule(submodule)) {
       llvm::SmallVector<swift::Decl*> children;
       swiftSubmodule->getTopLevelDecls(children);
@@ -191,6 +187,17 @@ void SwiftMangler::indexClangExtensionsAndFilePrivateValues(
       }
     }
   }
+  return index;
+}
+
+void SwiftMangler::indexClangExtensionsAndFilePrivateValues(
+    const clang::Module* clangModule,
+    swift::ClangModuleLoader* moduleLoader) {
+  if (!moduleLoader) {
+    return;
+  }
+
+  indexClangSubmoduleExtensionsAndFilePrivateValues(clangModule, moduleLoader, 0u);
 }
 
 SwiftMangledName SwiftMangler::visitGenericTypeParamDecl(const swift::GenericTypeParamDecl* decl) {

--- a/swift/extractor/mangler/SwiftMangler.h
+++ b/swift/extractor/mangler/SwiftMangler.h
@@ -126,6 +126,9 @@ class SwiftMangler : private swift::TypeVisitor<SwiftMangler, SwiftMangledName>,
 
   bool isExtensionOrFilePrivateValue(const swift::Decl* decl);
   void indexExtensionsAndFilePrivateValues(llvm::ArrayRef<swift::Decl*> siblings);
+  uint32_t indexClangSubmoduleExtensionsAndFilePrivateValues(const clang::Module* clangModule,
+                                                             swift::ClangModuleLoader* moduleLoader,
+                                                             uint32_t index);
   void indexClangExtensionsAndFilePrivateValues(const clang::Module* clangModule,
                                                 swift::ClangModuleLoader* moduleLoader);
   ExtensionOrFilePrivateValueIndex getExtensionOrFilePrivateValueIndex(const swift::Decl* decl,


### PR DESCRIPTION
I had originally excluded this, as this didn't seem possible. Looks like I was mistaken. The crash on the linked issue is on an extension, not something private.

~I just hope this doesn't make things even slower 😅~ DCA looks ok.

Fixes: https://github.com/github/codeql/issues/22224