### PR TITLE
JS: Do not warn about browser-specific source kinds in MaD

### DIFF
--- a/shared/mad/codeql/mad/ModelValidation.qll
+++ b/shared/mad/codeql/mad/ModelValidation.qll
@@ -132,7 +132,9 @@ module KindValidation<KindValidationConfigSig Config> {
           // C#
           "file-write", "windows-registry",
           // JavaScript
-          "database-access-result", "response", "request"
+          "database-access-result", "response", "request", "browser", "browser-url-query",
+          "browser-url-fragment", "browser-url-path", "browser-url", "browser-window-name",
+          "browser-message-event"
         ]
       or
       this.matches([


### PR DESCRIPTION
The browser-specific source kinds are already supported, but our tests currently warn about them because they weren't listed in `ModelValidation.qll`