### PR TITLE
Make CODEQL_PLATFORM architecture-aware for linux-arm64

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -1,5 +1,8 @@
-codeql_platform = select({
-    "@platforms//os:linux": "linux64",
-    "@platforms//os:macos": "osx64",
-    "@platforms//os:windows": "win64",
-})
+load("//misc/bazel:os.bzl", "codeql_platform_select")
+
+codeql_platform = codeql_platform_select(
+    linux64 = "linux64",
+    linux_arm64 = "linux-arm64",
+    osx64 = "osx64",
+    win64 = "win64",
+)

--- a/misc/bazel/BUILD.bazel
+++ b/misc/bazel/BUILD.bazel
@@ -1,5 +1,16 @@
 load("@rules_shell//shell:sh_library.bzl", "sh_library")
 
+# Matches the Linux arm64 target, used to give it a distinct `CODEQL_PLATFORM` string
+# (`linux-arm64`). Every other configuration keeps its OS-only string.
+config_setting(
+    name = "linux_arm64",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:arm64",
+    ],
+    visibility = ["//visibility:public"],
+)
+
 sh_library(
     name = "sh_runfiles",
     srcs = ["runfiles.sh"],

--- a/misc/bazel/os.bzl
+++ b/misc/bazel/os.bzl
@@ -19,11 +19,15 @@ def codeql_platform_select(
     This works both in a macro context (`ctx = None`, returning a `select`) and in a rule context
     (passing `ctx`, which then needs `OS_DETECTION_ATTRS` on the rule attributes).
     """
+
+    def _or_otherwise(value):
+        return value if value != None else otherwise
+
     choices = {
-        "//misc/bazel:linux_arm64": linux_arm64 or otherwise,
-        "@platforms//os:linux": linux64 or otherwise,
-        "@platforms//os:macos": osx64 or otherwise,
-        "@platforms//os:windows": win64 or otherwise,
+        "//misc/bazel:linux_arm64": _or_otherwise(linux_arm64),
+        "@platforms//os:linux": _or_otherwise(linux64),
+        "@platforms//os:macos": _or_otherwise(osx64),
+        "@platforms//os:windows": _or_otherwise(win64),
     }
     if not ctx:
         return select({

--- a/misc/bazel/os.bzl
+++ b/misc/bazel/os.bzl
@@ -23,8 +23,9 @@ def codeql_platform_select(
     def _or_otherwise(value):
         return value if value != None else otherwise
 
+    linux_arm64_setting = Label("//misc/bazel:linux_arm64")
     choices = {
-        "//misc/bazel:linux_arm64": _or_otherwise(linux_arm64),
+        linux_arm64_setting: _or_otherwise(linux_arm64),
         "@platforms//os:linux": _or_otherwise(linux64),
         "@platforms//os:macos": _or_otherwise(osx64),
         "@platforms//os:windows": _or_otherwise(win64),
@@ -40,7 +41,7 @@ def codeql_platform_select(
         return ctx.target_platform_has_constraint(getattr(ctx.attr, "_%s_constraint" % constraint)[platform_common.ConstraintValueInfo])
 
     if has("linux"):
-        result = choices["//misc/bazel:linux_arm64"] if has("arm64") else choices["@platforms//os:linux"]
+        result = choices[linux_arm64_setting] if has("arm64") else choices["@platforms//os:linux"]
     elif has("macos"):
         result = choices["@platforms//os:macos"]
     elif has("windows"):

--- a/misc/bazel/os.bzl
+++ b/misc/bazel/os.bzl
@@ -1,5 +1,52 @@
 """ Os detection facilities. """
 
+def codeql_platform_select(
+        ctx = None,
+        *,
+        linux64 = None,
+        linux_arm64 = None,
+        osx64 = None,
+        win64 = None,
+        otherwise = None):
+    """
+    Choose a value based on the target CodeQL platform, discriminating the four platforms CodeQL
+    knows about: `linux64` (Linux on x86_64), `linux_arm64` (Linux on arm64), `osx64` (macOS, any
+    architecture) and `win64` (Windows on x86_64). Any platform left unspecified uses `otherwise`.
+
+    There is deliberately no fallback between `linux64` and `linux_arm64`: if you want the same value
+    for both (i.e. you only care about the OS, not the architecture), use `os_select` instead.
+
+    This works both in a macro context (`ctx = None`, returning a `select`) and in a rule context
+    (passing `ctx`, which then needs `OS_DETECTION_ATTRS` on the rule attributes).
+    """
+    choices = {
+        "//misc/bazel:linux_arm64": linux_arm64 or otherwise,
+        "@platforms//os:linux": linux64 or otherwise,
+        "@platforms//os:macos": osx64 or otherwise,
+        "@platforms//os:windows": win64 or otherwise,
+    }
+    if not ctx:
+        return select({
+            setting: v
+            for setting, v in choices.items()
+            if v != None
+        })
+
+    def has(constraint):
+        return ctx.target_platform_has_constraint(getattr(ctx.attr, "_%s_constraint" % constraint)[platform_common.ConstraintValueInfo])
+
+    if has("linux"):
+        result = choices["//misc/bazel:linux_arm64"] if has("arm64") else choices["@platforms//os:linux"]
+    elif has("macos"):
+        result = choices["@platforms//os:macos"]
+    elif has("windows"):
+        result = choices["@platforms//os:windows"]
+    else:
+        fail("Unknown OS detected")
+    if result == None:
+        fail("platform not supported by %s" % ctx.label)
+    return result
+
 def os_select(
         ctx = None,
         *,
@@ -8,31 +55,22 @@ def os_select(
         macos = None,
         default = None):
     """
-    This can work both in a macro and a rule context to choose something based on the current OS.
-    If used in a rule implementation, you need to pass `ctx` and add `OS_DETECTION_ATTRS` to the
-    rule attributes.
+    Choose a value based on the target OS, ignoring the architecture. This is a thin, OS-only wrapper
+    around `codeql_platform_select` (Linux gets the same value on both x86_64 and arm64).
+    See `codeql_platform_select` for macro vs rule usage.
     """
-    choices = {
-        "linux": linux or default,
-        "windows": windows or default,
-        "macos": macos or default,
-    }
-    if not ctx:
-        return select({
-            "@platforms//os:%s" % os: v
-            for os, v in choices.items()
-            if v != None
-        })
-
-    for os, v in choices.items():
-        if ctx.target_platform_has_constraint(getattr(ctx.attr, "_%s_constraint" % os)[platform_common.ConstraintValueInfo]):
-            if v == None:
-                fail("%s not supported by %s" % (os, ctx.label))
-            return v
-    fail("Unknown OS detected")
+    return codeql_platform_select(
+        ctx,
+        linux64 = linux,
+        linux_arm64 = linux,
+        osx64 = macos,
+        win64 = windows,
+        otherwise = default,
+    )
 
 OS_DETECTION_ATTRS = {
     "_windows_constraint": attr.label(default = "@platforms//os:windows"),
     "_macos_constraint": attr.label(default = "@platforms//os:macos"),
     "_linux_constraint": attr.label(default = "@platforms//os:linux"),
+    "_arm64_constraint": attr.label(default = "@platforms//cpu:arm64"),
 }

--- a/misc/bazel/os.bzl
+++ b/misc/bazel/os.bzl
@@ -57,12 +57,19 @@ def os_select(
         linux = None,
         windows = None,
         macos = None,
+        posix = None,
         default = None):
     """
     Choose a value based on the target OS, ignoring the architecture. This is a thin, OS-only wrapper
     around `codeql_platform_select` (Linux gets the same value on both x86_64 and arm64).
-    See `codeql_platform_select` for macro vs rule usage.
+    `posix` is a convenience for the value shared by `linux` and `macos`; it is mutually exclusive
+    with both. See `codeql_platform_select` for macro vs rule usage.
     """
+    if posix != None:
+        if linux != None or macos != None:
+            fail("`posix` is mutually exclusive with `linux` and `macos`")
+        linux = posix
+        macos = posix
     return codeql_platform_select(
         ctx,
         linux64 = linux,

--- a/misc/bazel/pkg.bzl
+++ b/misc/bazel/pkg.bzl
@@ -8,7 +8,7 @@ load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_filegroup", "pkg_fil
 load("@rules_pkg//pkg:pkg.bzl", "pkg_zip")
 load("@rules_pkg//pkg:providers.bzl", "PackageFilegroupInfo", "PackageFilesInfo")
 load("@rules_python//python:defs.bzl", "py_binary", "py_test")
-load("//misc/bazel:os.bzl", "OS_DETECTION_ATTRS", "os_select")
+load("//misc/bazel:os.bzl", "OS_DETECTION_ATTRS", "codeql_platform_select")
 
 def _make_internal(name):
     def internal(suffix = "internal", *args):
@@ -26,7 +26,13 @@ def _expand_path(path, platform):
     return ("common", path)
 
 def _detect_platform(ctx = None):
-    return os_select(ctx, linux = "linux64", macos = "osx64", windows = "win64")
+    return codeql_platform_select(
+        ctx,
+        linux64 = "linux64",
+        linux_arm64 = "linux-arm64",
+        osx64 = "osx64",
+        win64 = "win64",
+    )
 
 def codeql_pkg_files(
         *,

--- a/misc/bazel/pkg.bzl
+++ b/misc/bazel/pkg.bzl
@@ -464,12 +464,12 @@ def codeql_pack(
     `zips` is a map from `.zip` files to prefixes to import.
     The distinction between arch-specific and common contents is made based on whether the paths (including possible
     prefixes added by rules) contain the special `{CODEQL_PLATFORM}` placeholder, which in case it is present will also
-    be replaced by the appropriate platform (`linux64`, `win64` or `osx64`).
+    be replaced by the appropriate platform (`linux64`, `linux-arm64`, `win64` or `osx64`).
     Specific file paths can be placed in the arch-specific package by adding them to `arch_overrides`, even if their
     path doesn't contain the `CODEQL_PLATFORM` placeholder.
 
     The codeql pack rules will expand the `{CODEQL_PLATFORM}` marker in paths, and use that to split the files into a common and an arch-specific part.
-    This placeholder will be replaced by the appropriate platform (`linux64`, `win64` or `osx64`).
+    This placeholder will be replaced by the appropriate platform (`linux64`, `linux-arm64`, `win64` or `osx64`).
     `arch_overrides` is a list of files that should be included in the arch-specific bits of the pack, even if their path doesn't
     contain the `{CODEQL_PLATFORM}` marker.
     All files in the pack will be prefixed with `name`, unless `pack_prefix` is set, then is used instead.


### PR DESCRIPTION
## Why

Today `CODEQL_PLATFORM` is OS-only: `linux` -> `linux64`, `macos` -> `osx64`, `windows` -> `win64`. There is no architecture dimension. macOS ships a single universal (lipo) binary that serves both arches, so it can keep `osx64`, but ELF has no fat-binary equivalent, so Linux arm64 needs its own distinct platform string.

## What

Introduces a single source of truth, `codeql_platform_select`, and derives the platform string from `os:linux AND cpu:arm64` -> `linux-arm64`, with every other configuration resolving byte-identically to its existing string.

- `misc/bazel/os.bzl`: adds `codeql_platform_select(linux64, linux_arm64, osx64, win64, otherwise)` which works in both macro (`select`) and rule (`ctx`) contexts. `os_select` is kept as a thin OS-only wrapper implemented on top of it (Linux gets the same value on both arches), so all existing callers are unchanged. A `_arm64_constraint` attr is added to `OS_DETECTION_ATTRS` for the rule path.
- `misc/bazel/BUILD.bazel`: adds a `linux_arm64` `config_setting` (`os:linux` + `cpu:arm64`), a strict specialization of `@platforms//os:linux` so Bazel picks it unambiguously.
- `defs.bzl` and `misc/bazel/pkg.bzl` (`_detect_platform`, the load-bearing resolver for the `{CODEQL_PLATFORM}` placeholder): switched to `codeql_platform_select` and map the Linux arm64 slot to `linux-arm64`.

The `linux-arm64` token is deliberate: the legacy `linux64`/`osx64`/`win64` are CodeQL's own public release-asset identifiers and cannot be renamed, only added to. `${os}-arm64` matches the wider ecosystem (Node/.NET/Go) and codeql-action already uses the `arm64` token.

There is intentionally no fallback between `linux64` and `linux_arm64` in `codeql_platform_select`: callers that only care about the OS should use `os_select`.

## Additive and inert

Every configuration CI builds today resolves to the identical string, producing byte-identical outputs. Critically, the macOS universal build runs an `@platforms//cpu:arm64` transition slice, but its OS is macos, so the OS discriminator dominates and it still resolves to `osx64`. The new `linux-arm64` branch stays dormant because no current job builds Linux-on-arm64.

## Validation (x86_64 host)

- Confirmed via `bazel cquery` that existing configs still resolve exactly: linux x86_64 -> `linux64`, macos -> `osx64`, windows -> `win64` (zero diff vs `main`).
- Forced `--platforms` to an `os:linux` + `cpu:arm64` platform and confirmed it resolves to `linux-arm64` (analysis), with the `linux_arm64` config_setting selected unambiguously over `@platforms//os:linux`.
- Empirically confirmed the macOS + arm64 slice still resolves to `osx64` using a real macOS analysis platform.
- `os_select` consumers (e.g. Swift) re-checked and clean; buildifier/format clean.