### PR TITLE
Python: Use fastTC explicitly in `localFlow`

### DIFF
--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowUtil.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowUtil.qll
@@ -20,9 +20,11 @@ predicate localFlowStep(Node nodeFrom, Node nodeTo) {
   FlowSummaryImpl::Private::Steps::summaryThroughStepValue(nodeFrom, nodeTo, _)
 }
 
+private predicate localFlowStepPlus(Node node1, Node node2) = fastTC(localFlowStep/2)(node1, node2)
+
 /**
  * Holds if data flows from `source` to `sink` in zero or more local
  * (intra-procedural) steps.
  */
 pragma[inline]
-predicate localFlow(Node source, Node sink) { localFlowStep*(source, sink) }
+predicate localFlow(Node source, Node sink) { source = sink or localFlowStepPlus(source, sink) }


### PR DESCRIPTION
Microsoft hit a performance problem on an internal query. The root-cause was that the compiler suddenly decided not to compile a `localFlowStep*` to a `fastTC`, but instead to good old QL recursion (with a suboptimal bound on the sink as a cherry on top). This resulted in:
```ql
Pipeline standard for #DataFlowUtil::localFlowStep/2#5174ed45Plus#fb#flipped@38867we6 was evaluated in 15275 iterations totaling 774484ms (delta sizes total: 1576975703).
        1577556584  ~1%    {2} r1 = SCAN `#DataFlowUtil::localFlowStep/2#5174ed45Plus#fb#flipped#prev_delta` OUTPUT In.1, In.0
        1578595232  ~1%    {2}    | JOIN WITH `DataFlowUtil::localFlowStep/2#5174ed45#flipped` ON FIRST 1 OUTPUT Lhs.1, Rhs.1
        1576984587  ~1%    {2}    | AND NOT `#DataFlowUtil::localFlowStep/2#5174ed45Plus#fb#flipped#prev`(FIRST 2)
                           return r1
```
This PR explicitly uses `fastTC` to prevent this surprise from biting us all going forward.

We could of course fine-tune the calls to `localFlow` and ensure that the end-points are optimally bound, but we might as well follow what other languages have done in similar situations (see [C#](https://github.com/github/codeql/blob/46e738df8fb6ec1cab2d199467530c305f5bc715/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPublic.qll#L143), [C++](https://github.com/github/codeql/blob/46e738df8fb6ec1cab2d199467530c305f5bc715/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll#L369), and [Java](https://github.com/github/codeql/blob/46e738df8fb6ec1cab2d199467530c305f5bc715/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowUtil.qll#L84)).

DCA looks fantastic 🎉