### PR TITLE
Go: Reduce package processing log messages to `debug` level

### DIFF
--- a/go/extractor/extractor.go
+++ b/go/extractor/extractor.go
@@ -232,13 +232,13 @@ func ExtractWithFlags(buildFlags []string, patterns []string, extractTests bool,
 		// This should only cause some wasted time and not inconsistency because the names for
 		// objects seen in this process should be the same each time.
 
-		log.Printf("Processing package %s.", pkg.PkgPath)
+		slog.Debug("Processing package", "package", pkg.PkgPath)
 
 		if _, ok := pkgInfos[pkg.PkgPath]; !ok {
 			pkgInfos[pkg.PkgPath] = toolchain.GetPkgInfo(pkg.PkgPath, modFlags...)
 		}
 
-		log.Printf("Extracting types for package %s.", pkg.PkgPath)
+		slog.Debug("Extracting types for package", "package", pkg.PkgPath)
 
 		tw, err := trap.NewWriter(pkg.PkgPath, pkg)
 		if err != nil {


### PR DESCRIPTION
Currently, the Go extractor logs three lines for every package that is extracted successfully:

```
Processing package name.
Extracting types for package name.
Done extracting types for package name.
```

In large codebases, this leads to a lot of noise in the output. 

This PR moves the first two log messages over to `slog.debug` so that they are only output when debug-level logging is enabled. `slog` is already configured appropriately for the extractor by the existing call to `SetLogLevel`.