### PR TITLE
Add arm64 Linux support to prebuilt ripunzip

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -327,6 +327,7 @@ ripunzip_archive = use_repo_rule("//misc/ripunzip:ripunzip.bzl", "ripunzip_archi
 ripunzip_archive(
     name = "ripunzip",
     sha256_linux = "71482d7a7e4ea9176d5596161c49250c34b136b157c45f632b1111323fbfc0de",
+    sha256_linux_arm = "a282740ef376ff8dc0de3c589b7457598db15cc045b7daa688f15531612e0bbe",
     sha256_macos_arm = "604194ab13f0aba3972995d995f11002b8fc285c8170401fcd46655065df20c9",
     sha256_macos_intel = "65367b94fd579d93d46f2d2595cc4c9a60cfcf497e3c824f9d1a7b80fa8bd38a",
     sha256_windows = "ac3874075def2b9e5074a3b5945005ab082cc6e689e1de658da8965bc23e643e",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -326,11 +326,11 @@ ripunzip_archive = use_repo_rule("//misc/ripunzip:ripunzip.bzl", "ripunzip_archi
 # go to https://github.com/GoogleChrome/ripunzip/releases to find latest version and corresponding sha256s
 ripunzip_archive(
     name = "ripunzip",
-    sha256_linux = "71482d7a7e4ea9176d5596161c49250c34b136b157c45f632b1111323fbfc0de",
-    sha256_linux_arm = "a282740ef376ff8dc0de3c589b7457598db15cc045b7daa688f15531612e0bbe",
-    sha256_macos_arm = "604194ab13f0aba3972995d995f11002b8fc285c8170401fcd46655065df20c9",
-    sha256_macos_intel = "65367b94fd579d93d46f2d2595cc4c9a60cfcf497e3c824f9d1a7b80fa8bd38a",
-    sha256_windows = "ac3874075def2b9e5074a3b5945005ab082cc6e689e1de658da8965bc23e643e",
+    sha256_linux_arm64 = "a282740ef376ff8dc0de3c589b7457598db15cc045b7daa688f15531612e0bbe",
+    sha256_linux_x64 = "71482d7a7e4ea9176d5596161c49250c34b136b157c45f632b1111323fbfc0de",
+    sha256_macos_arm64 = "604194ab13f0aba3972995d995f11002b8fc285c8170401fcd46655065df20c9",
+    sha256_macos_x64 = "65367b94fd579d93d46f2d2595cc4c9a60cfcf497e3c824f9d1a7b80fa8bd38a",
+    sha256_windows_x64 = "ac3874075def2b9e5074a3b5945005ab082cc6e689e1de658da8965bc23e643e",
     version = "2.0.4",
 )
 

--- a/misc/ripunzip/ripunzip.bzl
+++ b/misc/ripunzip/ripunzip.bzl
@@ -4,7 +4,7 @@ def _ripunzip_archive_impl(repository_ctx):
     build_file = Label("//misc/ripunzip:BUILD.ripunzip.bazel")
     if "linux" in repository_ctx.os.name:
         arch = repository_ctx.os.arch
-        if arch in ("aarch64", "arm64"):
+        if arch == "aarch64":
             deb_arch = "arm64"
             sha256 = repository_ctx.attr.sha256_linux_arm
             canonical_id = "ripunzip-linux-arm"

--- a/misc/ripunzip/ripunzip.bzl
+++ b/misc/ripunzip/ripunzip.bzl
@@ -3,12 +3,22 @@ def _ripunzip_archive_impl(repository_ctx):
     url_prefix = "https://github.com/GoogleChrome/ripunzip/releases/download/v%s" % version
     build_file = Label("//misc/ripunzip:BUILD.ripunzip.bazel")
     if "linux" in repository_ctx.os.name:
+        arch = repository_ctx.os.arch
+        if arch in ("aarch64", "arm64"):
+            deb_arch = "arm64"
+            sha256 = repository_ctx.attr.sha256_linux_arm
+            canonical_id = "ripunzip-linux-arm"
+        else:
+            deb_arch = "amd64"
+            sha256 = repository_ctx.attr.sha256_linux
+            canonical_id = "ripunzip-linux"
+
         # ripunzip only provides a deb package for Linux: we fish the binary out of it
         # a deb archive contains a data.tar.xz one which contains the files to be installed under usr/bin
         repository_ctx.download_and_extract(
-            url = "%s/ripunzip_%s-1_amd64.deb" % (url_prefix, version),
-            sha256 = repository_ctx.attr.sha256_linux,
-            canonical_id = "ripunzip-linux",
+            url = "%s/ripunzip_%s-1_%s.deb" % (url_prefix, version, deb_arch),
+            sha256 = sha256,
+            canonical_id = canonical_id,
             output = "deb",
         )
         repository_ctx.extract(
@@ -52,6 +62,7 @@ ripunzip_archive = repository_rule(
     attrs = {
         "version": attr.string(mandatory = True),
         "sha256_linux": attr.string(mandatory = True),
+        "sha256_linux_arm": attr.string(mandatory = True),
         "sha256_windows": attr.string(mandatory = True),
         "sha256_macos_intel": attr.string(mandatory = True),
         "sha256_macos_arm": attr.string(mandatory = True),

--- a/misc/ripunzip/ripunzip.bzl
+++ b/misc/ripunzip/ripunzip.bzl
@@ -8,10 +8,12 @@ def _ripunzip_archive_impl(repository_ctx):
             deb_arch = "arm64"
             sha256 = repository_ctx.attr.sha256_linux_arm64
             canonical_id = "ripunzip-linux-arm64"
-        else:
+        elif arch in ("x86_64", "amd64"):
             deb_arch = "amd64"
             sha256 = repository_ctx.attr.sha256_linux_x64
             canonical_id = "ripunzip-linux-x64"
+        else:
+            fail("Unsupported Linux architecture: %s" % arch)
 
         # ripunzip only provides a deb package for Linux: we fish the binary out of it
         # a deb archive contains a data.tar.xz one which contains the files to be installed under usr/bin

--- a/misc/ripunzip/ripunzip.bzl
+++ b/misc/ripunzip/ripunzip.bzl
@@ -6,12 +6,12 @@ def _ripunzip_archive_impl(repository_ctx):
         arch = repository_ctx.os.arch
         if arch == "aarch64":
             deb_arch = "arm64"
-            sha256 = repository_ctx.attr.sha256_linux_arm
-            canonical_id = "ripunzip-linux-arm"
+            sha256 = repository_ctx.attr.sha256_linux_arm64
+            canonical_id = "ripunzip-linux-arm64"
         else:
             deb_arch = "amd64"
-            sha256 = repository_ctx.attr.sha256_linux
-            canonical_id = "ripunzip-linux"
+            sha256 = repository_ctx.attr.sha256_linux_x64
+            canonical_id = "ripunzip-linux-x64"
 
         # ripunzip only provides a deb package for Linux: we fish the binary out of it
         # a deb archive contains a data.tar.xz one which contains the files to be installed under usr/bin
@@ -29,20 +29,20 @@ def _ripunzip_archive_impl(repository_ctx):
     elif "windows" in repository_ctx.os.name:
         repository_ctx.download_and_extract(
             url = "%s/ripunzip_v%s_x86_64-pc-windows-msvc.zip" % (url_prefix, version),
-            canonical_id = "ripunzip-windows",
-            sha256 = repository_ctx.attr.sha256_windows,
+            canonical_id = "ripunzip-windows-x64",
+            sha256 = repository_ctx.attr.sha256_windows_x64,
             output = "bin",
         )
     elif "mac os" in repository_ctx.os.name:
         arch = repository_ctx.os.arch
         if arch == "x86_64":
             suffix = "x86_64-apple-darwin"
-            sha256 = repository_ctx.attr.sha256_macos_intel
-            canonical_id = "ripunzip-macos-intel"
+            sha256 = repository_ctx.attr.sha256_macos_x64
+            canonical_id = "ripunzip-macos-x64"
         elif arch == "aarch64":
             suffix = "aarch64-apple-darwin"
-            sha256 = repository_ctx.attr.sha256_macos_arm
-            canonical_id = "ripunzip-macos-arm"
+            sha256 = repository_ctx.attr.sha256_macos_arm64
+            canonical_id = "ripunzip-macos-arm64"
         else:
             fail("Unsupported macOS architecture: %s" % arch)
         repository_ctx.download_and_extract(
@@ -61,10 +61,10 @@ ripunzip_archive = repository_rule(
     doc = "Downloads a prebuilt ripunzip binary for the host platform from https://github.com/GoogleChrome/ripunzip/releases",
     attrs = {
         "version": attr.string(mandatory = True),
-        "sha256_linux": attr.string(mandatory = True),
-        "sha256_linux_arm": attr.string(mandatory = True),
-        "sha256_windows": attr.string(mandatory = True),
-        "sha256_macos_intel": attr.string(mandatory = True),
-        "sha256_macos_arm": attr.string(mandatory = True),
+        "sha256_linux_x64": attr.string(mandatory = True),
+        "sha256_linux_arm64": attr.string(mandatory = True),
+        "sha256_windows_x64": attr.string(mandatory = True),
+        "sha256_macos_x64": attr.string(mandatory = True),
+        "sha256_macos_arm64": attr.string(mandatory = True),
     },
 )


### PR DESCRIPTION
## Overview

The `ripunzip_archive` repository rule in `misc/ripunzip/ripunzip.bzl` downloads a prebuilt `ripunzip` for the **host** platform at repo-fetch time. The macOS branch already switches on `repository_ctx.os.arch`, but the Linux branch was hardcoded to the amd64 deb (`ripunzip_%s-1_amd64.deb`) — so on an arm64 Linux host it would fetch an x86 binary.

This adds a Linux arch switch mirroring the macOS branch. GoogleChrome/ripunzip publishes an arm64 deb for the pinned version (`ripunzip_2.0.4-1_arm64.deb`), so no version bump is needed.

Part of the Linux arm64 support work for CodeQL.

## Changes

- **`misc/ripunzip/ripunzip.bzl`**: in the Linux branch, map `os.arch` → deb arch (`aarch64` → `arm64`, else `amd64`), selecting the matching sha and canonical id. Add a mandatory `sha256_linux_arm64` attribute.
- **Consistent arch naming**: standardized all sha attributes (and their `canonical_id`s) to a single `<os>_x64` / `<os>_arm64` scheme:
  - `sha256_linux` → `sha256_linux_x64`
  - `sha256_linux_arm64` (new)
  - `sha256_macos_intel` → `sha256_macos_x64`
  - `sha256_macos_arm` → `sha256_macos_arm64`
  - `sha256_windows` → `sha256_windows_x64`
- **`MODULE.bazel`**: add the arm64 deb sha and rename the existing attributes to match. Version and sha values unchanged (only names).

## Validation (x86 host)

The arm64 download only triggers on an arm64 host, so this was validated structurally on x86:
- `bazel build @ripunzip//:ripunzip` still resolves and fetches the amd64 deb (else-branch intact, new mandatory attr wired).
- `bazel mod deps` loads cleanly (MODULE.bazel satisfies the renamed attrs).
- buildifier reports no formatting changes.

## Note on drift

The coupling point is the deb-arch naming (`amd64`/`arm64`) plus bazel's `os.arch` reporting (`amd64`/`aarch64` on Linux). If ripunzip changes its release asset naming, or bazel changes how it reports `os.arch`, this mapping needs revisiting.