### PR TITLE
JS: Update supported TypeScript language version

### DIFF
--- a/docs/codeql/reusables/supported-versions-compilers.rst
+++ b/docs/codeql/reusables/supported-versions-compilers.rst
@@ -27,7 +27,7 @@
    Ruby [10]_,"up to 3.3",Not applicable,"``.rb``, ``.erb``, ``.gemspec``, ``Gemfile``"
    Rust [11]_,"Rust editions 2021 and 2024","Rust compiler","``.rs``, ``Cargo.toml``"
    Swift [12]_ [13]_,"Swift 5.4-6.3","Swift compiler","``.swift``"
-   TypeScript [14]_,"2.6-5.9",Standard TypeScript compiler,"``.ts``, ``.tsx``, ``.mts``, ``.cts``"
+   TypeScript [14]_,"2.6-7.0",Standard TypeScript compiler,"``.ts``, ``.tsx``, ``.mts``, ``.cts``"
 
 .. container:: footnote-group
 


### PR DESCRIPTION
Even though we're not using the new Go-based TypeScript compiler under the hood, we can still handle TypeScript 7.0 codebases, so bumping to that version.