### PR TITLE
Ruby: Exclude vendored library parameters from taint sources.

### DIFF
--- a/ruby/ql/lib/change-notes/2026-08-05-vendored-lib-taint.md
+++ b/ruby/ql/lib/change-notes/2026-08-05-vendored-lib-taint.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Removed library input to vendored gems from the set of taint sources. This should reduce false positives for `rb/polynomial-redos`, `rb/regex/badly-anchored-regexp`, `rb/unsafe-code-construction`, `rb/html-constructed-from-input`, and `rb/shell-command-constructed-from-input` whenever vendoring is used.

--- a/ruby/ql/lib/codeql/ruby/frameworks/core/Gem.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/core/Gem.qll
@@ -90,6 +90,9 @@ module Gem {
       result = this.getAPublicModule().getStmt(_).(SingletonClass)
     }
 
+    /** Holds if this gem is vendored in this codebase. */
+    predicate isVendored() { File.super.getParentContainer+().getBaseName() = "vendor" }
+
     /** Gets a parameter from an exported method, which is an input to this gem. */
     DataFlow::ParameterNode getAnInputParameter() {
       exists(MethodBase method |
@@ -107,6 +110,7 @@ module Gem {
   DataFlow::ParameterNode getALibraryInput() {
     exists(GemSpec spec |
       exists(spec.getName()) and // we only consider `.gemspec` files that have a name
+      not spec.isVendored() and // if the gem is vendored its parameters are not external inputs
       result = spec.getAnInputParameter()
     )
   }


### PR DESCRIPTION
5 queries (`PolynomialReDoS.ql`, `MissingFullAnchor.ql`, `UnsafeCodeConstruction.ql`, `UnsafeHtmlConstruction.ql`, and `UnsafeShellCommandConstruction.ql`) use `Gem::getALibraryInput()` as a taint source, but when the gem is vendored this leads to FPs, since then those parameters aren't external input, but instead just ordinary call targets from a fixed set of call sites.