### PR TITLE
Shared: Shadow isAfterValue on ControlFlowNode.

### DIFF
--- a/shared/controlflow/codeql/controlflow/ControlFlowGraph.qll
+++ b/shared/controlflow/codeql/controlflow/ControlFlowGraph.qll
@@ -2053,6 +2053,33 @@ module Make0<LocationSig Location, AstSig<Location> Ast> {
             result = this.getASuccessor(any(ExceptionSuccessor t))
           }
 
+          /*
+           * Note that the following 3 predicates, `isAfterValue`,
+           * `isAfterTrue`, and `isAfterFalse`, shadow their counterparts in
+           * `PreControlFlowNode`, and that their semantics are slightly
+           * different.
+           *
+           * This is because, in `PreControlFlowNode`, during CFG construction,
+           * we need to identify the control flow node that results from the
+           * evaluation of an AST node to a certain value, but that control
+           * flow node may or may not encode that fact. In contrast, in
+           * `ControlFlowNode`, we instead want to know what the node actually
+           * encodes.
+           */
+
+          /** Holds if this node indicates that `n` evaluates to the value `t`. */
+          predicate isAfterValue(AstNode n, ConditionalSuccessor t) { this = TAfterValueNode(n, t) }
+
+          /** Holds if this node indicates that `n` evaluates to the value `true`. */
+          predicate isAfterTrue(AstNode n) {
+            this = TAfterValueNode(n, any(BooleanSuccessor b | b.getValue() = true))
+          }
+
+          /** Holds if this node indicates that `n` evaluates to the value `false`. */
+          predicate isAfterFalse(AstNode n) {
+            this = TAfterValueNode(n, any(BooleanSuccessor b | b.getValue() = false))
+          }
+
           /**
            * Holds if this node dominates `that` node.
            *


### PR DESCRIPTION
It can actually be nice to to use `isAfterValue` on `ControlFlowNode` post CFG construction. But in those use-cases the semantics you want (and expect) is actually different from what's on `PreControlFlowNode`. And using `PreControlFlowNode::isAfterValue` after the CFG is constructed is almost guaranteed to be wrong. Fortunately we can simply shadow the predicates to get a more useful and safer API since `PreControlFlowNode` is `final`.

The 3 added predicates are not used anywhere yet.