### PR TITLE
Python: Ignore await and typing ellipsis as non-effectful statements

### DIFF
--- a/python/ql/src/Statements/StatementNoEffect.ql
+++ b/python/ql/src/Statements/StatementNoEffect.ql
@@ -128,6 +128,18 @@ private ClassDef getAProtocolDef() {
   )
 }
 
+predicate is_typing_ellipsis(ExprStmt s) {
+  s.getValue() instanceof Ellipsis and
+  s.getScope() instanceof Function and
+  is_only_scope_statement(s) and
+  (
+    s.getScope() = getAnOverload()
+    or
+    s.getScope().getScope() instanceof Class and
+    s.getScope().getScope() = getAProtocolDef().getDefinedClass()
+  )
+}
+
 predicate is_notebook(File f) {
   exists(Comment c | c.getLocation().getFile() = f |
     c.getText().regexpMatch("#\\s*<nbformat>.+</nbformat>\\s*")
@@ -173,5 +185,5 @@ predicate no_effect(Expr e) {
 }
 
 from ExprStmt stmt
-where no_effect(stmt.getValue())
+where no_effect(stmt.getValue()) and not is_typing_ellipsis(stmt)
 select stmt, "This statement has no effect."

--- a/python/ql/src/Statements/StatementNoEffect.ql
+++ b/python/ql/src/Statements/StatementNoEffect.ql
@@ -126,6 +126,8 @@ predicate python2_print(Expr e) {
 predicate no_effect(Expr e) {
   // strings can be used as comments
   not e instanceof StringLiteral and
+  // await triggers actions and switches coroutines
+  not e instanceof Await and
   not e.hasSideEffects() and
   forall(Expr sub | sub = e.getASubExpression*() |
     not side_effecting_binary(sub) and

--- a/python/ql/src/Statements/StatementNoEffect.ql
+++ b/python/ql/src/Statements/StatementNoEffect.ql
@@ -14,6 +14,7 @@
 
 import python
 private import LegacyPointsTo
+import semmle.python.ApiGraphs
 
 predicate understood_attribute(Attribute attr, ClassValue cls, ClassValue attr_cls) {
   exists(string name | attr.getName() = name |
@@ -92,6 +93,20 @@ private string special_method() {
   result = any(Cmpop c).getSpecialMethodName()
   or
   result = any(BinaryExpr b).getOp().getSpecialMethodName()
+}
+
+ClassDef getAProtocolDef() {
+  exists(Expr e |
+    e =
+      API::moduleImport("typing")
+          .getMember("Protocol")
+          .getASubclass*()
+          .getAValueReachableFromSource()
+          .asExpr()
+  |
+    e instanceof ClassExpr and
+    e = result.getValue()
+  )
 }
 
 predicate is_notebook(File f) {

--- a/python/ql/src/Statements/StatementNoEffect.ql
+++ b/python/ql/src/Statements/StatementNoEffect.ql
@@ -114,7 +114,7 @@ private Function getAnOverload() {
   )
 }
 
-ClassDef getAProtocolDef() {
+private ClassDef getAProtocolDef() {
   exists(Expr e |
     e =
       API::moduleImport("typing")

--- a/python/ql/src/Statements/StatementNoEffect.ql
+++ b/python/ql/src/Statements/StatementNoEffect.ql
@@ -106,6 +106,14 @@ private predicate is_only_scope_statement(Stmt s) {
   forex(Stmt scope_stmt | scope_stmt = s.getScope().getAStmt() | scope_stmt = s)
 }
 
+private Function getAnOverload() {
+  exists(Expr e |
+    e = API::moduleImport("typing").getMember("overload").getAValueReachableFromSource().asExpr()
+  |
+    e = result.getADecorator()
+  )
+}
+
 ClassDef getAProtocolDef() {
   exists(Expr e |
     e =

--- a/python/ql/src/Statements/StatementNoEffect.ql
+++ b/python/ql/src/Statements/StatementNoEffect.ql
@@ -95,6 +95,10 @@ private string special_method() {
   result = any(BinaryExpr b).getOp().getSpecialMethodName()
 }
 
+private predicate is_only_scope_statement(Stmt s) {
+  forex(Stmt scope_stmt | scope_stmt = s.getScope().getAStmt() | scope_stmt = s)
+}
+
 ClassDef getAProtocolDef() {
   exists(Expr e |
     e =

--- a/python/ql/src/Statements/StatementNoEffect.ql
+++ b/python/ql/src/Statements/StatementNoEffect.ql
@@ -114,12 +114,18 @@ private Function getAnOverload() {
   )
 }
 
+private API::Node getATypedSubclass(API::Node base) {
+  // class Result(base, ...)
+  result = base.getASubclass()
+  or
+  // Result = base[...]
+  result = base.getASubscript()
+}
+
 private ClassDef getAProtocolDef() {
   exists(Expr e |
     e =
-      API::moduleImport("typing")
-          .getMember("Protocol")
-          .getASubclass*()
+      getATypedSubclass*(API::moduleImport("typing").getMember("Protocol"))
           .getAValueReachableFromSource()
           .asExpr()
   |

--- a/python/ql/src/Statements/StatementNoEffect.ql
+++ b/python/ql/src/Statements/StatementNoEffect.ql
@@ -95,6 +95,13 @@ private string special_method() {
   result = any(BinaryExpr b).getOp().getSpecialMethodName()
 }
 
+/*
+ * utilities for detection `...` typing ellipsis expression statements
+ *
+ * Various Python typing constructs merely define class/function signatures.
+ * In this case, the body is commonly a single `...` expression statement.
+ */
+
 private predicate is_only_scope_statement(Stmt s) {
   forex(Stmt scope_stmt | scope_stmt = s.getScope().getAStmt() | scope_stmt = s)
 }

--- a/python/ql/src/change-notes/2026-08-07-stmt-effects.md
+++ b/python/ql/src/change-notes/2026-08-07-stmt-effects.md
@@ -1,0 +1,5 @@
+---
+category: majorAnalysis
+---
+* Ignore `await` expression statements for `StatementNoEffect` check.
+* Ignore `...` expression statements for `StatementNoEffect` check in various typing contexts.


### PR DESCRIPTION
This PR extends the Python `StatementNoEffect` query to ignore `await` and many typing ellipses expression statements.

- [x] ignore `await` expression statements (closes #11235)
  - `await` is used to switch between coroutines and execute long-running effects. While strictly speaking an `await` can have no side-effect, these are so rare that a purely syntactical analysis seems appropriate.
- [x] ignore `...` as the sole expression statement of a typing stub body (closes #11351)
  - `@typing.overload` indicates a function definition purely for its signature, not implementation. [An `...` expression statement is commonly used for the body](https://docs.python.org/3/library/typing.html#typing.overload) to denote that the body is insignificant.
  - Similar to `@typing.overload`, a `Protocol` is only defined for its methods. [An `...` expression is commonly used for statement bodies.](https://docs.python.org/3/library/typing.html#typing.Protocol)

The `Protocol` check currently misses generic `Protocol`s (e.g. `class Foo(Protocol[T])` and `class Bar(Foo[int])`). This seems to be a parser bug, see #22298. In principle, the code checks for subscriptions and should be able to pick up such cases once the parser is fixed. To avoid going out of scope here, the parser fixes are in #22301.