### PR TITLE
Yeast: silence warning

### DIFF
--- a/shared/yeast/src/lib.rs
+++ b/shared/yeast/src/lib.rs
@@ -492,7 +492,7 @@ impl Ast {
         }
     }
 
-    pub fn walk(&self) -> AstCursor {
+    pub fn walk(&self) -> AstCursor<'_> {
         AstCursor::new(self)
     }
 


### PR DESCRIPTION
```
warning: hiding a lifetime that's elided elsewhere is confusing
   --> external/ql+/shared/yeast/src/lib.rs:495:17
    |
495 |     pub fn walk(&self) -> AstCursor {
    |                 ^^^^^     ^^^^^^^^^ the same lifetime is hidden here
    |                 |
    |                 the lifetime is elided here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
    = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: use `'_` for type paths
    |
495 |     pub fn walk(&self) -> AstCursor<'_> {
    |                                    ++++
warning: 1 warning emitted
```