### PR TITLE
Ruby: Approximate FieldContent in data flow.

### DIFF
--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
@@ -676,26 +676,28 @@ private module Cached {
     )
   }
 
+  private predicate fieldName(string name) {
+    name = any(InstanceVariable v).getName()
+    or
+    name = "@" + any(SetterMethodCall c).getTargetName()
+    or
+    // The following equation unfortunately leads to a non-monotonic recursion error:
+    //    name = any(AccessPathToken a).getAnArgument("Field")
+    // Therefore, we use the following instead to extract the field names from the
+    // external model data. This, unfortunately, does not included any field names used
+    // in models defined in QL code.
+    exists(string input, string output |
+      ModelOutput::relevantSummaryModel(_, _, input, output, _, _)
+    |
+      name = [input, output].regexpFind("(?<=(^|\\.)Field\\[)[^\\]]+(?=\\])", _, _).trim()
+    )
+  }
+
   cached
   newtype TContent =
     TKnownElementContent(ConstantValue cv) { trackKnownValue(cv) } or
     TUnknownElementContent() or
-    TFieldContent(string name) {
-      name = any(InstanceVariable v).getName()
-      or
-      name = "@" + any(SetterMethodCall c).getTargetName()
-      or
-      // The following equation unfortunately leads to a non-monotonic recursion error:
-      //    name = any(AccessPathToken a).getAnArgument("Field")
-      // Therefore, we use the following instead to extract the field names from the
-      // external model data. This, unfortunately, does not included any field names used
-      // in models defined in QL code.
-      exists(string input, string output |
-        ModelOutput::relevantSummaryModel(_, _, input, output, _, _)
-      |
-        name = [input, output].regexpFind("(?<=(^|\\.)Field\\[)[^\\]]+(?=\\])", _, _).trim()
-      )
-    } or
+    TFieldContent(string name) { fieldName(name) } or
     deprecated TSplatContent(int i, Boolean shifted) { i in [0 .. 10] } or
     deprecated THashSplatContent(ConstantValue::ConstantSymbolValue cv) or
     TCapturedVariableContent(VariableCapture::CapturedVariable v) or
@@ -717,11 +719,19 @@ private module Cached {
   }
 
   cached
+  int fieldNameBucket(string name) {
+    exists(int r | name = rank[r](string n | fieldName(n)) and result = r % 30)
+  }
+
+  cached
   newtype TContentApprox =
     TUnknownElementContentApprox() or
     TKnownIntegerElementContentApprox() or
     TKnownElementContentApprox(string approx) { approx = approxKnownElementIndex(_) } or
-    TNonElementContentApprox(Content c) { not c instanceof Content::ElementContent } or
+    TFieldContentApprox(int bucket) { bucket = fieldNameBucket(_) } or
+    TNonElementContentApprox(Content c) {
+      not c instanceof Content::ElementContent and not c instanceof Content::FieldContent
+    } or
     TCapturedVariableContentApprox(VariableCapture::CapturedVariable v)
 
   cached
@@ -2268,6 +2278,10 @@ class ContentApprox extends TContentApprox {
       result = "approximated element " + approx
     )
     or
+    exists(int bucket |
+      this = TFieldContentApprox(bucket) and result = "field bucket " + bucket.toString()
+    )
+    or
     exists(Content c |
       this = TNonElementContentApprox(c) and
       result = c.toString()
@@ -2306,6 +2320,8 @@ ContentApprox getContentApprox(Content c) {
   or
   result =
     TKnownElementContentApprox(approxKnownElementIndex(c.(Content::KnownElementContent).getIndex()))
+  or
+  result = TFieldContentApprox(fieldNameBucket(c.(Content::FieldContent).getName()))
   or
   result = TNonElementContentApprox(c)
 }


### PR DESCRIPTION
Field content is usually the prime candidate for approximation in `ContentApprox` to ensure decent data flow performance (in stage 3). We've usually done something along the lines of using the first (interesting) letter of the field name, but I figured I might as well just bucket the names based on a ranking. I initially chose 30 buckets as a guess towards the same level of approximation as picking a letter. I then compared it to both 20 and 50 and indeed 30 seemed like a decent sweet spot.