### PR TITLE
JS: Add React Native Worklets "worklet" directive as a KnownDirective

### DIFF
--- a/javascript/ql/lib/change-notes/2026-08-10-worklet-directive.md
+++ b/javascript/ql/lib/change-notes/2026-08-10-worklet-directive.md
@@ -1,0 +1,5 @@
+---
+category: feature
+---
+
+- Added support for recognizing the React Native Worklets `"worklet"` directive as a known directive.

--- a/javascript/ql/lib/semmle/javascript/Stmt.qll
+++ b/javascript/ql/lib/semmle/javascript/Stmt.qll
@@ -475,6 +475,21 @@ module Directive {
   class UseCacheDirective extends KnownDirective {
     UseCacheDirective() { this.getDirectiveText().regexpMatch("use cache(:.*)?") }
   }
+
+  /**
+   * A React Native Reanimated worklet directive.
+   *
+   * Example:
+   *
+   * ```
+   * function myWorklet() {
+   *   "worklet";
+   * }
+   * ```
+   */
+  class WorkletDirective extends KnownDirective {
+    WorkletDirective() { this.getDirectiveText() = "worklet" }
+  }
 }
 
 /**

--- a/javascript/ql/lib/semmle/javascript/Stmt.qll
+++ b/javascript/ql/lib/semmle/javascript/Stmt.qll
@@ -477,7 +477,7 @@ module Directive {
   }
 
   /**
-   * A React Native Reanimated worklet directive.
+   * A React Native Worklets worklet directive.
    *
    * Example:
    *

--- a/javascript/ql/test/library-tests/Directives/KnownDirective.expected
+++ b/javascript/ql/test/library-tests/Directives/KnownDirective.expected
@@ -1,20 +1,22 @@
 | tst.js:1:1:1:13 | 'use strict'; | use strict |
 | tst.js:2:1:2:10 | 'use asm'; | use asm |
 | tst.js:3:1:3:9 | 'bundle'; | bundle |
-| tst.js:4:1:4:13 | 'use server'; | use server |
-| tst.js:5:1:5:13 | 'use client'; | use client |
-| tst.js:6:1:6:11 | 'use memo'; | use memo |
-| tst.js:7:1:7:14 | 'use no memo'; | use no memo |
-| tst.js:8:1:8:12 | 'use cache'; | use cache |
-| tst.js:9:1:9:20 | 'use cache: remote'; | use cache: remote |
-| tst.js:10:1:10:21 | 'use ca ... ivate'; | use cache: private |
-| tst.js:19:3:19:12 | 'use asm'; | use asm |
-| tst.js:20:3:20:11 | 'bundle'; | bundle |
-| tst.js:21:3:21:15 | 'use server'; | use server |
-| tst.js:22:3:22:15 | 'use client'; | use client |
-| tst.js:23:3:23:13 | 'use memo'; | use memo |
-| tst.js:24:3:24:16 | 'use no memo'; | use no memo |
-| tst.js:25:3:25:14 | 'use cache'; | use cache |
-| tst.js:26:3:26:22 | 'use cache: remote'; | use cache: remote |
-| tst.js:27:3:27:23 | 'use ca ... ivate'; | use cache: private |
-| tst.js:34:5:34:17 | 'use strict'; | use strict |
+| tst.js:4:1:4:10 | 'worklet'; | worklet |
+| tst.js:5:1:5:13 | 'use server'; | use server |
+| tst.js:6:1:6:13 | 'use client'; | use client |
+| tst.js:7:1:7:11 | 'use memo'; | use memo |
+| tst.js:8:1:8:14 | 'use no memo'; | use no memo |
+| tst.js:9:1:9:12 | 'use cache'; | use cache |
+| tst.js:10:1:10:20 | 'use cache: remote'; | use cache: remote |
+| tst.js:11:1:11:21 | 'use ca ... ivate'; | use cache: private |
+| tst.js:20:3:20:12 | 'use asm'; | use asm |
+| tst.js:21:3:21:11 | 'bundle'; | bundle |
+| tst.js:22:3:22:12 | 'worklet'; | worklet |
+| tst.js:23:3:23:15 | 'use server'; | use server |
+| tst.js:24:3:24:15 | 'use client'; | use client |
+| tst.js:25:3:25:13 | 'use memo'; | use memo |
+| tst.js:26:3:26:16 | 'use no memo'; | use no memo |
+| tst.js:27:3:27:14 | 'use cache'; | use cache |
+| tst.js:28:3:28:22 | 'use cache: remote'; | use cache: remote |
+| tst.js:29:3:29:23 | 'use ca ... ivate'; | use cache: private |
+| tst.js:36:5:36:17 | 'use strict'; | use strict |

--- a/javascript/ql/test/library-tests/Directives/tst.js
+++ b/javascript/ql/test/library-tests/Directives/tst.js
@@ -1,6 +1,7 @@
 'use strict'; // this is a directive
 'use asm'; // and so is this
 'bundle';// and this
+'worklet';
 'use server';
 'use client';
 'use memo';
@@ -18,6 +19,7 @@ function f() {
   'use\x20strict'; // this is a directive, though not a strict mode directive
   'use asm'; // and so is this
   'bundle';
+  'worklet';
   'use server';
   'use client';
   'use memo';


### PR DESCRIPTION
Worklet is a short-running JavaScript function that can be moved and executed across different Javascript Runtimes. Reanimated uses React Native Worklets `"worklet"` to calculate view styles and react to events on the UI thread.

https://docs.swmansion.com/react-native-reanimated/docs/guides/worklets/

https://docs.swmansion.com/react-native-worklets/

cc: @tjzel from Software Mansion
