### PR TITLE
Java: Normalize java_version in integration test

### DIFF
--- a/java/ql/integration-tests/java/gradle-sample-without-wrapper-or-gradle-buildless/diagnostics.expected
+++ b/java/ql/integration-tests/java/gradle-sample-without-wrapper-or-gradle-buildless/diagnostics.expected
@@ -1,7 +1,7 @@
 {
   "attributes": {
     "java_vendor": "__REDACTED__",
-    "java_version": "11.0.31"
+    "java_version": "__REDACTED__"
   },
   "markdownMessage": "Internal telemetry for the Java extractor.\n\nNo action needed.",
   "severity": "note",

--- a/java/ql/integration-tests/java/gradle-sample-without-wrapper-or-gradle-buildless/diagnostics.expected
+++ b/java/ql/integration-tests/java/gradle-sample-without-wrapper-or-gradle-buildless/diagnostics.expected
@@ -1,7 +1,7 @@
 {
   "attributes": {
     "java_vendor": "__REDACTED__",
-    "java_version": "__REDACTED__"
+    "java_version": "11"
   },
   "markdownMessage": "Internal telemetry for the Java extractor.\n\nNo action needed.",
   "severity": "note",

--- a/java/ql/integration-tests/java/gradle-sample-without-wrapper-or-gradle-buildless/test.py
+++ b/java/ql/integration-tests/java/gradle-sample-without-wrapper-or-gradle-buildless/test.py
@@ -5,7 +5,7 @@ import pathlib
 
 # The version of gradle used doesn't work on java 17
 def test(codeql, use_java_11, java, environment, check_diagnostics):
-    check_diagnostics.redact += ["attributes.java_vendor"]
+    check_diagnostics.redact += ["attributes.java_vendor", "attributes.java_version"]
     gradle_override_dir = pathlib.Path(tempfile.mkdtemp())
     if runs_on.windows:
         (gradle_override_dir / "gradle.bat").write_text("@echo off\nexit /b 2\n")

--- a/java/ql/integration-tests/java/gradle-sample-without-wrapper-or-gradle-buildless/test.py
+++ b/java/ql/integration-tests/java/gradle-sample-without-wrapper-or-gradle-buildless/test.py
@@ -5,7 +5,8 @@ import pathlib
 
 # The version of gradle used doesn't work on java 17
 def test(codeql, use_java_11, java, environment, check_diagnostics):
-    check_diagnostics.redact += ["attributes.java_vendor", "attributes.java_version"]
+    check_diagnostics.redact += ["attributes.java_vendor"]
+    check_diagnostics.replacements = [("11\\.[0-9]+\\.[0-9]+", "11")]
     gradle_override_dir = pathlib.Path(tempfile.mkdtemp())
     if runs_on.windows:
         (gradle_override_dir / "gradle.bat").write_text("@echo off\nexit /b 2\n")


### PR DESCRIPTION
The `gradle-sample-without-wrapper-or-gradle-buildless` integration test hardcodes `java_version: "11.0.31"` in `diagnostics.expected`. This breaks when the CI runner updates JDK (now 11.0.32).

The field was introduced in fefe01ecbf7 (June 2026) which batch-added the new `java/extractor/summary` diagnostic to ~22 tests.

~~Fix: redact `java_version` the same way `java_vendor` already is.~~

Update: normalizing `java_version` instead, see review.
