### PR TITLE
Ruby: Include EndBlocks in Scope.

### DIFF
--- a/ruby/ql/lib/codeql/ruby/ast/internal/Scope.qll
+++ b/ruby/ql/lib/codeql/ruby/ast/internal/Scope.qll
@@ -19,7 +19,8 @@ private class TBlockLike = TDoBlock or TLambda or TBlock or TEndBlock;
 
 private class TModuleLike = TToplevel or TModuleDeclaration or TClassDeclaration or TSingletonClass;
 
-private class TScopeReal = TMethodBase or TModuleLike or TDoBlock or TLambda or TBraceBlock;
+private class TScopeReal =
+  TMethodBase or TModuleLike or TDoBlock or TLambda or TBraceBlock or TEndBlock;
 
 module Scope {
   class TypeRange = Callable::TypeRange or ModuleBase::TypeRange or @ruby_end_block;


### PR DESCRIPTION
A somewhat minor bugfix: `EndBlock`s are their own scope, but was accidentally left out of the `Scope` type.