### PR TITLE
Data flow: Earlier pruning based on `accessPathLimit`

### DIFF
--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -567,8 +567,8 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
           ap instanceof ApNil and
           result = 0
           or
-          exists(Content c, Ap tail |
-            fwdFlowConsCand(_, ap, c, _, tail) and
+          exists(Ap tail |
+            fwdFlowConsCand(_, ap, _, _, tail) and
             ap != tail and // no need to report a longer length
             result = 1 + getAnApLengthLowerBound(tail) and
             result <= accessPathLimit()

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -562,6 +562,21 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
         }
 
         pragma[nomagic]
+        private int getAnApLengthLowerBound(Ap ap) {
+          accessPathLimit() > 1 and // `accessPathLimit() <= 1` is already checked in stages 1 and 2
+          ap instanceof ApNil and
+          result = 0
+          or
+          exists(Content c, Ap tail |
+            ap = apCons(c, tail) and
+            fwdFlowConsCand(_, ap, c, _, tail) and
+            ap != tail and // no need to report a longer length
+            result = 1 + getAnApLengthLowerBound(tail) and
+            result <= accessPathLimit()
+          )
+        }
+
+        pragma[nomagic]
         private predicate fwdFlow0(
           Nd node, Cc cc, SummaryCtx summaryCtx, Typ t, Ap ap, ApApprox apa, TypOption stored
         ) {
@@ -594,7 +609,10 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
           exists(Content c, Ap ap0 |
             fwdFlowStore(_, _, ap0, _, c, t, stored, node, cc, summaryCtx) and
             ap = apCons(c, ap0) and
-            apa = getApprox(ap)
+            apa = getApprox(ap) and
+            if accessPathLimit() > 1
+            then getAnApLengthLowerBound(ap0) < accessPathLimit()
+            else any()
           )
           or
           // read
@@ -1321,6 +1339,20 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
         }
 
         pragma[nomagic]
+        private int getAnApLengthLowerBoundRev(Ap ap) {
+          accessPathLimit() > 1 and // `accessPathLimit() <= 1` is already checked in stages 1 and 2
+          ap instanceof ApNil and
+          result = 0
+          or
+          exists(Ap tail |
+            revFlowConsCand(ap, _, tail) and
+            ap != tail and // no need to report a longer length
+            result = 1 + getAnApLengthLowerBoundRev(tail) and
+            result <= accessPathLimit()
+          )
+        }
+
+        pragma[nomagic]
         private predicate revFlow0(Nd node, ReturnCtx returnCtx, ApOption returnAp, Ap ap) {
           fwdFlow(node, _, any(SummaryCtx sinkCtx | sinkCtx.isASinkCtx()), _, ap, _) and
           sinkNode(node) and
@@ -1356,7 +1388,10 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
           // read
           exists(Nd mid, Ap ap0 |
             revFlow(mid, returnCtx, returnAp, ap0) and
-            readStepFwd(node, ap, _, mid, ap0)
+            readStepFwd(node, ap, _, mid, ap0) and
+            if accessPathLimit() > 1
+            then getAnApLengthLowerBoundRev(ap0) < accessPathLimit()
+            else any()
           )
           or
           // flow into a callable

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -568,7 +568,6 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
           result = 0
           or
           exists(Content c, Ap tail |
-            ap = apCons(c, tail) and
             fwdFlowConsCand(_, ap, c, _, tail) and
             ap != tail and // no need to report a longer length
             result = 1 + getAnApLengthLowerBound(tail) and


### PR DESCRIPTION
`accessPathLimit = 0` is checked [in stage 1](https://github.com/github/codeql/blob/08547cbce75ab9c8d542ba1ca3266d6bec9a514b/shared/dataflow/codeql/dataflow/internal/DataFlowImplStage1.qll#L495) and `accessPathLimit = 1` is checked [in stage 2](https://github.com/github/codeql/blob/08547cbce75ab9c8d542ba1ca3266d6bec9a514b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll#L2754), however all other access path limits are not checked until [stage 5](https://github.com/github/codeql/blob/08547cbce75ab9c8d542ba1ca3266d6bec9a514b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll#L3047).

While we cannot in general know the lengths of access paths in stages 4 and below, we can provide lower bounds, and then check those bounds against `accessPathLimit`. This generalizes the check from stage 2, but unlike that check, it requires non-linear recursion, so I decided to keep the original check as-is and only apply the new check when `accessPathLimit() > 1`.

DCA shows a massive 60 % reduction in total analysis time for `microsoft__vscode` (down `966 s` from `2,510 s`).