### PR TITLE
Remove agent instructions to not edit QL

### DIFF
--- a/.github/instructions/ql-files.instructions.md
+++ b/.github/instructions/ql-files.instructions.md
@@ -1,6 +1,0 @@
----
-applyTo: "**/*.ql,**/*.qll"
----
-When reviewing these QL files, do not make any comment on the code itself. You don't understand the QL programming language well enough yet. You can only make comments about the following aspects:
-* comments (lines starting with `//` or block comments enclosed in `/* ... */`): you can suggest improvements to the clarity of comments, or point out spelling mistakes
-* typos in identifiers


### PR DESCRIPTION
This made sense when it was added, but my experience is that current LLM models do understand QL, so the only effect of this is that very aligned models (i.e. they follow orders closely) refuse to edit QL, which is not helpful when that is what we are asking them to do.