### PR TITLE
Java: gate AGP-7.x Android integration tests off linux-arm64

### DIFF
--- a/java/ql/integration-tests/java/android-sample-kotlin-build-script-no-wrapper/test.py
+++ b/java/ql/integration-tests/java/android-sample-kotlin-build-script-no-wrapper/test.py
@@ -1,2 +1,7 @@
+import runs_on
+
+
+# This Android Gradle Plugin version ships no linux-aarch64 aapt2, so the build fails on linux-arm64 (macOS arm64 works).
+@(runs_on.x86_64 or runs_on.macos)
 def test(codeql, use_java_17, java, android_sdk):
     codeql.database.create()

--- a/java/ql/integration-tests/java/android-sample-kotlin-build-script/test.py
+++ b/java/ql/integration-tests/java/android-sample-kotlin-build-script/test.py
@@ -1,2 +1,7 @@
+import runs_on
+
+
+# This Android Gradle Plugin version ships no linux-aarch64 aapt2, so the build fails on linux-arm64 (macOS arm64 works).
+@(runs_on.x86_64 or runs_on.macos)
 def test(codeql, use_java_11, java, gradle_7_4, android_sdk):
     codeql.database.create()

--- a/java/ql/integration-tests/java/android-sample-no-wrapper/test.py
+++ b/java/ql/integration-tests/java/android-sample-no-wrapper/test.py
@@ -1,2 +1,7 @@
+import runs_on
+
+
+# This Android Gradle Plugin version ships no linux-aarch64 aapt2, so the build fails on linux-arm64 (macOS arm64 works).
+@(runs_on.x86_64 or runs_on.macos)
 def test(codeql, use_java_17, java, android_sdk):
     codeql.database.create()

--- a/java/ql/integration-tests/java/android-sample-old-style-kotlin-build-script-no-wrapper/test.py
+++ b/java/ql/integration-tests/java/android-sample-old-style-kotlin-build-script-no-wrapper/test.py
@@ -1,2 +1,7 @@
+import runs_on
+
+
+# This Android Gradle Plugin version ships no linux-aarch64 aapt2, so the build fails on linux-arm64 (macOS arm64 works).
+@(runs_on.x86_64 or runs_on.macos)
 def test(codeql, use_java_17, java, android_sdk, actions_toolchains_file):
     codeql.database.create(_env={"LGTM_INDEX_MAVEN_TOOLCHAINS_FILE": str(actions_toolchains_file)})

--- a/java/ql/integration-tests/java/android-sample-old-style-kotlin-build-script/test.py
+++ b/java/ql/integration-tests/java/android-sample-old-style-kotlin-build-script/test.py
@@ -1,2 +1,7 @@
+import runs_on
+
+
+# This Android Gradle Plugin version ships no linux-aarch64 aapt2, so the build fails on linux-arm64 (macOS arm64 works).
+@(runs_on.x86_64 or runs_on.macos)
 def test(codeql, use_java_11, java, gradle_7_4, android_sdk):
     codeql.database.create()

--- a/java/ql/integration-tests/java/android-sample-old-style-no-wrapper/test.py
+++ b/java/ql/integration-tests/java/android-sample-old-style-no-wrapper/test.py
@@ -1,2 +1,7 @@
+import runs_on
+
+
+# This Android Gradle Plugin version ships no linux-aarch64 aapt2, so the build fails on linux-arm64 (macOS arm64 works).
+@(runs_on.x86_64 or runs_on.macos)
 def test(codeql, use_java_17, java, android_sdk, actions_toolchains_file):
     codeql.database.create(_env={"LGTM_INDEX_MAVEN_TOOLCHAINS_FILE": str(actions_toolchains_file)})

--- a/java/ql/integration-tests/java/android-sample-old-style/test.py
+++ b/java/ql/integration-tests/java/android-sample-old-style/test.py
@@ -1,2 +1,7 @@
+import runs_on
+
+
+# This Android Gradle Plugin version ships no linux-aarch64 aapt2, so the build fails on linux-arm64 (macOS arm64 works).
+@(runs_on.x86_64 or runs_on.macos)
 def test(codeql, use_java_11, java, gradle_7_4, android_sdk):
     codeql.database.create()

--- a/java/ql/integration-tests/java/android-sample/test.py
+++ b/java/ql/integration-tests/java/android-sample/test.py
@@ -1,2 +1,7 @@
+import runs_on
+
+
+# This Android Gradle Plugin version ships no linux-aarch64 aapt2, so the build fails on linux-arm64 (macOS arm64 works).
+@(runs_on.x86_64 or runs_on.macos)
 def test(codeql, use_java_11, java, gradle_7_4, android_sdk):
     codeql.database.create()


### PR DESCRIPTION
These integration tests build an Android app via the Android Gradle Plugin (AGP), which downloads Google's prebuilt `aapt2` from Maven. The pinned AGP `7.0.0` and `7.3.1` ship no linux-aarch64 `aapt2`, so on linux-arm64 the build fails at AAPT2 daemon startup and database creation aborts. macOS arm64 is unaffected, as it uses its own `aapt2`.

This is a third-party tool gap rather than anything specific to the extractor, and bumping AGP is out of scope here since each test's expected output is coupled to the exact AGP and Gradle versions.

Following the existing `java-version-too-old` precedent, this gates the affected tests with `@(runs_on.x86_64 or runs_on.macos)` so they deselect on linux-arm64 while continuing to run on x86_64 and macOS arm64. `android-8-sample` (AGP `8.0.0`) is intentionally left untouched.

No `.expected` changes are required, since arch gating only removes the tests from collection on linux-arm64.