### PR TITLE
Rust: Add a couple of new metrics to rust/summary/summary-statistics.

### DIFF
--- a/rust/ql/integration-tests/hello-project/summary.expected
+++ b/rust/ql/integration-tests/hello-project/summary.expected
@@ -1,6 +1,6 @@
 | Extraction errors | 0 |
 | Extraction warnings | 0 |
-| Files extracted - total | 5 |
+| Files extracted - total user | 5 |
 | Files extracted - with errors | 0 |
 | Files extracted - without errors | 5 |
 | Files extracted - without errors % | 100 |

--- a/rust/ql/integration-tests/hello-workspace/summary.cargo.expected
+++ b/rust/ql/integration-tests/hello-workspace/summary.cargo.expected
@@ -1,6 +1,6 @@
 | Extraction errors | 0 |
 | Extraction warnings | 0 |
-| Files extracted - total | 4 |
+| Files extracted - total user | 4 |
 | Files extracted - with errors | 0 |
 | Files extracted - without errors | 4 |
 | Files extracted - without errors % | 100 |

--- a/rust/ql/integration-tests/hello-workspace/summary.rust-project.expected
+++ b/rust/ql/integration-tests/hello-workspace/summary.rust-project.expected
@@ -1,6 +1,6 @@
 | Extraction errors | 0 |
 | Extraction warnings | 0 |
-| Files extracted - total | 4 |
+| Files extracted - total user | 4 |
 | Files extracted - with errors | 0 |
 | Files extracted - without errors | 4 |
 | Files extracted - without errors % | 100 |

--- a/rust/ql/src/queries/summary/Stats.qll
+++ b/rust/ql/src/queries/summary/Stats.qll
@@ -142,7 +142,8 @@ predicate extractionStats(string key, int value) {
   key = "Extraction warnings" and
   value = count(ExtractionWarning w | not exists(w.getLocation()) or w.getLocation().fromSource())
   or
-  key = "Files extracted - total user" and value = count(ExtractedFile f | exists(f.getRelativePath()))
+  key = "Files extracted - total user" and
+  value = count(ExtractedFile f | exists(f.getRelativePath()))
   or
   key = "Files extracted - with errors" and
   value =
@@ -219,7 +220,8 @@ predicate taintStats(string key, int value) {
   or
   key = "Taint reach - per million nodes" and value = getTaintReach().floor()
   or
-  key = "Taint nodes - highly colocated nodes" and value = count(DataFlow::Node n | isColocated10(n))
+  key = "Taint nodes - highly colocated nodes" and
+  value = count(DataFlow::Node n | isColocated10(n))
   or
   key = "Taint sinks - query sinks" and value = getQuerySinksCount()
   or

--- a/rust/ql/src/queries/summary/Stats.qll
+++ b/rust/ql/src/queries/summary/Stats.qll
@@ -104,6 +104,17 @@ int getTaintEdgesCount() {
  */
 int getQuerySinksCount() { result = count(QuerySink s) }
 
+/**
+ * Holds if there are at least 10 data flow nodes in the same location
+ * as `n`.
+ */
+private predicate isColocated10(DataFlow::Node n) {
+  exists(Location l |
+    l = n.getLocation() and
+    strictcount(DataFlow::Node other | other.getLocation() = l) >= 10
+  )
+}
+
 class CrateElement extends Element {
   CrateElement() {
     this instanceof Crate or
@@ -131,7 +142,9 @@ predicate extractionStats(string key, int value) {
   key = "Extraction warnings" and
   value = count(ExtractionWarning w | not exists(w.getLocation()) or w.getLocation().fromSource())
   or
-  key = "Files extracted - total" and value = count(ExtractedFile f | exists(f.getRelativePath()))
+  key = "Files extracted - total" and value = count(File f)
+  or
+  key = "Files extracted - total user" and value = count(ExtractedFile f | exists(f.getRelativePath()))
   or
   key = "Files extracted - with errors" and
   value =
@@ -200,6 +213,8 @@ predicate taintStats(string key, int value) {
   key = "Taint reach - total non-summary nodes" and value = getTotalNodesCount()
   or
   key = "Taint reach - per million nodes" and value = getTaintReach().floor()
+  or
+  key = "Taint nodes - highly colocated nodes" and value = count(DataFlow::Node n | isColocated10(n))
   or
   key = "Taint sinks - query sinks" and value = getQuerySinksCount()
   or

--- a/rust/ql/src/queries/summary/Stats.qll
+++ b/rust/ql/src/queries/summary/Stats.qll
@@ -142,8 +142,6 @@ predicate extractionStats(string key, int value) {
   key = "Extraction warnings" and
   value = count(ExtractionWarning w | not exists(w.getLocation()) or w.getLocation().fromSource())
   or
-  key = "Files extracted - total" and value = count(File f)
-  or
   key = "Files extracted - total user" and value = count(ExtractedFile f | exists(f.getRelativePath()))
   or
   key = "Files extracted - with errors" and
@@ -171,6 +169,13 @@ predicate extractionStats(string key, int value) {
   or
   key = "Macro calls - unresolved" and
   value = count(MacroCall mc | mc.fromSource() and not mc.hasMacroCallExpansion())
+}
+
+/**
+ * Gets further summary statistics about extraction.
+ */
+predicate extractionStatsExtra(string key, int value) {
+  key = "Files extracted - total" and value = count(File f)
 }
 
 /**

--- a/rust/ql/src/queries/summary/Stats.qll
+++ b/rust/ql/src/queries/summary/Stats.qll
@@ -104,17 +104,6 @@ int getTaintEdgesCount() {
  */
 int getQuerySinksCount() { result = count(QuerySink s) }
 
-/**
- * Holds if there are at least 10 data flow nodes in the same location
- * as `n`.
- */
-private predicate isColocated10(DataFlow::Node n) {
-  exists(Location l |
-    l = n.getLocation() and
-    strictcount(DataFlow::Node other | other.getLocation() = l) >= 10
-  )
-}
-
 class CrateElement extends Element {
   CrateElement() {
     this instanceof Crate or
@@ -219,9 +208,6 @@ predicate taintStats(string key, int value) {
   key = "Taint reach - total non-summary nodes" and value = getTotalNodesCount()
   or
   key = "Taint reach - per million nodes" and value = getTaintReach().floor()
-  or
-  key = "Taint nodes - highly colocated nodes" and
-  value = count(DataFlow::Node n | isColocated10(n))
   or
   key = "Taint sinks - query sinks" and value = getQuerySinksCount()
   or

--- a/rust/ql/src/queries/summary/SummaryStats.ql
+++ b/rust/ql/src/queries/summary/SummaryStats.ql
@@ -15,6 +15,8 @@ where
   or
   extractionStats(key, value)
   or
+  extractionStatsExtra(key, value)
+  or
   inconsistencyStats(key, value)
   or
   typeInferenceInconsistencyStats(key, value)

--- a/rust/ql/test/query-tests/diagnostics/SummaryStatsReduced.expected
+++ b/rust/ql/test/query-tests/diagnostics/SummaryStatsReduced.expected
@@ -1,6 +1,6 @@
 | Extraction errors | 0 |
 | Extraction warnings | 7 |
-| Files extracted - total | 7 |
+| Files extracted - total user | 7 |
 | Files extracted - with errors | 3 |
 | Files extracted - without errors | 4 |
 | Files extracted - without errors % | 57 |


### PR DESCRIPTION
Add a couple of new metrics to `rust/summary/summary-statistics`:
- "Files extracted - total" (including non-source files and files outside of the source location, that were previously invisible in from query).
- "Taint nodes - highly colocated nodes" (can potentially help expose when something unusual is going on in the data flow graph).

(I'm going to do a small DCA run because there's some integration between this query and the reports there, to be sure I haven't broken anything)