### PR TITLE
Swift: Fix self-compare in frontend-invocations test

### DIFF
--- a/swift/ql/integration-tests/posix/frontend-invocations/test.py
+++ b/swift/ql/integration-tests/posix/frontend-invocations/test.py
@@ -21,4 +21,4 @@ def test(codeql, swift, expected_files):
         hashes.sort()
         for module, hash in hashes:
             print(module, hash, file=actual)
-    expected_files.add("hashes.expected")
+    expected_files.add("hashes.actual")


### PR DESCRIPTION
The changed line was a no-op in practice. The `expected_files` pytest fixture actually means "check this generated file against a committed expected file".