### PR TITLE
Rust: Always force high access path precision

### DIFF
--- a/rust/ql/lib/codeql/rust/dataflow/internal/DataFlowImpl.qll
+++ b/rust/ql/lib/codeql/rust/dataflow/internal/DataFlowImpl.qll
@@ -583,7 +583,7 @@ module RustDataFlowGen<RustDataFlowInputSig Input> implements InputSig<Location>
 
   class LambdaCallKind = LambdaCallKindAlias;
 
-  predicate forceHighPrecision(Content c) { none() }
+  predicate forceHighPrecision(Content c) { any() }
 
   class ContentApprox = ContentApproxAlias;
 


### PR DESCRIPTION
Stages stats for `AccessAfterLifetime.ql` on `rust` before and after:

\# | n | stage | nodes | fields | conscand | states | tuples | calledges | tfnodes | tftuples
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
1 | 10 | 1 Fwd | 3,778,294 | 38,306 | -1 | 1 | 4,503,242 | -1 | -1 | -1
2 | 15 | 1 Rev | 1,425,221 | 16,549 | -1 | 1 | 1,667,531 | 1,470,786 | -1 | -1
3 | 20 | 2 Fwd | 720,349 | 4,111 | 5,796 | 1 | 1,719,512 | 374,218 | 0 | 0
4 | 25 | 2 Rev | 415,990 | 1,525 | 2,160 | 1 | 598,321 | 229,086 | 0 | 0
5 | 30 | 3 Fwd | 158,978 | 1,008 | 17,292 | 1 | 3,800,765 | 208,204 | 19 | 167
6 | 35 | 3 Rev | 141,824 | 843 | 9,830 | 1 | 937,772 | 203,758 | 9 | 20
7 | 40 | 4 Fwd | 138,816 | 717 | 93,422 | 1 | 118,836,935 | 202,876 | 9 | 26
8 | 45 | 4 Rev | 135,363 | 705 | 80,252 | 1 | 38,270,989 | 202,123 | 9 | 20
9 | 50 | 5 Fwd | 127,950 | 566 | 22,131 | 1 | 27,011,587 | 200,142 | 9 | 26
10 | 55 | 5 Rev | 109,938 | 458 | 7,423 | 1 | 1,584,901 | 192,141 | 9 | 17
11 | 60 | 6 Fwd | 107,568 | 440 | 4,875 | 1 | 10,699,981 | 191,784 | 7 | 9
12 | 65 | 6 Rev | 107,409 | 439 | 4,786 | 1 | 1,186,926 | 191,714 | 5 | 5


\# | n | stage | nodes | fields | conscand | states | tuples | calledges | tfnodes | tftuples
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
1 | 10 | 1 Fwd | 3,778,294 | 38,306 | -1 | 1 | 4,503,242 | -1 | -1 | -1
2 | 15 | 1 Rev | 1,425,221 | 16,549 | -1 | 1 | 1,667,531 | 1,470,786 | -1 | -1
3 | 20 | 2 Fwd | 720,349 | 4,111 | 5,796 | 1 | 1,719,512 | 374,218 | 0 | 0
4 | 25 | 2 Rev | 415,990 | 1,525 | 2,160 | 1 | 598,321 | 229,086 | 0 | 0
5 | 30 | 3 Fwd | 158,978 | 1,008 | 17,292 | 1 | 3,800,765 | 208,204 | 19 | 167
6 | 35 | 3 Rev | 141,824 | 843 | 9,830 | 1 | 937,772 | 203,758 | 9 | 20
7 | 40 | 4 Fwd | 138,816 | 717 | 93,422 | 1 | 118,836,935 | 202,876 | 9 | 26
8 | 45 | 4 Rev | 135,363 | 705 | 80,252 | 1 | 38,270,989 | 202,123 | 9 | 20
9 | 50 | 5 Fwd | 114,126 | 513 | 3,200 | 1 | 681,843 | 192,053 | 7 | 24
10 | 55 | 5 Rev | 91,447 | 392 | 1,076 | 1 | 122,901 | 182,333 | 7 | 7
11 | 60 | 6 Fwd | 91,192 | 385 | 898 | 1 | 133,660 | 182,259 | 5 | 5
12 | 65 | 6 Rev | 91,085 | 385 | 895 | 1 | 107,885 | 182,238 | 5 | 5


DCA confirms the speedup on `rust`.