### PR TITLE
Gate remaining Android integration tests off linux-arm64

### DIFF
--- a/java/ql/integration-tests/java/android-8-sample/test.py
+++ b/java/ql/integration-tests/java/android-8-sample/test.py
@@ -1,4 +1,9 @@
+import runs_on
+
+
 # Put Java 11 on the path so as to challenge our version selection logic: Java 11 is unsuitable for Android Gradle Plugin 8+,
 # so it will be necessary to notice Java 17 available in the environment and actively select it.
+# This Android Gradle Plugin version ships no linux-aarch64 aapt2, so the build fails on linux-arm64 (macOS arm64 works).
+@(runs_on.x86_64 or runs_on.macos)
 def test(codeql, use_java_11, java, gradle_8_0, android_sdk):
     codeql.database.create()

--- a/java/ql/integration-tests/java/diagnostics/android-gradle-incompatibility/test.py
+++ b/java/ql/integration-tests/java/diagnostics/android-gradle-incompatibility/test.py
@@ -1,2 +1,7 @@
+import runs_on
+
+
+# Deselected on linux-arm64: the build also fails there due to the x86_64-only aapt2 gap, which would conflate with the AGP/Gradle-incompatibility failure this test asserts.
+@(runs_on.x86_64 or runs_on.macos)
 def test(codeql, java, gradle_7_3, android_sdk):
     codeql.database.create(_assert_failure=True)

--- a/java/ql/integration-tests/java/diagnostics/android-gradle-incompatibility/test.py
+++ b/java/ql/integration-tests/java/diagnostics/android-gradle-incompatibility/test.py
@@ -1,7 +1,7 @@
 import runs_on
 
 
-# Deselected on linux-arm64: the build also fails there due to the x86_64-only aapt2 gap, which would conflate with the AGP/Gradle-incompatibility failure this test asserts.
+# Deselected on linux-arm64: there the AGP build fails because no linux-aarch64 aapt2 exists, which is unrelated to the AGP/Gradle version incompatibility this test asserts and would otherwise let it pass for the wrong reason.
 @(runs_on.x86_64 or runs_on.macos)
 def test(codeql, java, gradle_7_3, android_sdk):
     codeql.database.create(_assert_failure=True)


### PR DESCRIPTION
Finishes the native Linux Arm64 gating begun in #22327 for the last two Android-driving Java integration tests. Those tests build with the Android Gradle Plugin, which invokes `aapt2`, and Google only publishes `aapt2` for linux/osx/windows (x86-64) plus macOS arm64 — there is no linux-aarch64 build at any version. So on linux-arm64 the build fails when an x86-64 `aapt2` is exec'd on aarch64. macOS arm64 and x86_64 stay green.

With this change, all 10 Android sample/diagnostic integration tests are deselected on linux-arm64 (8 already merged via #22327 plus these 2), which is what semmle-code #56095 needs to green the Java arm64 leg.

## Changes

Both files gain `import runs_on` and the `@(runs_on.x86_64 or runs_on.macos)` decorator, byte-identical to the 8 merged siblings.

- `android-8-sample/test.py` — AGP 8.0.0 hits the same x86-64-only `aapt2` gap; deselect linux-arm64 while keeping macOS arm64. Signature and body are unchanged.
- `diagnostics/android-gradle-incompatibility/test.py` — this test asserts a *build failure* for AGP/Gradle version incompatibility. On linux-arm64 the build also fails for the unrelated `aapt2` arch gap, so the test would pass for the wrong reason and mask a real regression in the incompatibility diagnostic. Gating restricts the assertion to platforms where the failure cause is unambiguous. `_assert_failure=True` is preserved, and the comment is deliberately distinct from the aapt2 wording to keep the two reasons separate.

## Notes for reviewers

The two files intentionally carry different comments because they are gated for different reasons (arch-only aapt2 gap vs. avoiding a false pass). No `.expected` changes are needed — gating only deselects on arm; x86_64 behavior is unchanged. `python3 -m py_compile` passes on both files.