### PR TITLE
unified: Don't try to build an extractor binary on windows

### DIFF
--- a/unified/BUILD.bazel
+++ b/unified/BUILD.bazel
@@ -41,9 +41,10 @@ codeql_pkg_files(
 
 codeql_pkg_files(
     name = "extractor-arch",
-    exes = [
-        "//unified/extractor",
-    ] + select_os(
+    exes = select_os(
+        posix = ["//unified/extractor"],
+        windows = ["//unified/extractor-unsupported-os:extractor"],
+    ) + select_os(
         linux = ["//unified/swift-syntax-rs:swift_runtime_libs"],
         otherwise = [],
     ),

--- a/unified/extractor-unsupported-os/BUILD.bazel
+++ b/unified/extractor-unsupported-os/BUILD.bazel
@@ -1,0 +1,8 @@
+load("//misc/bazel:rust.bzl", "codeql_rust_binary")
+
+codeql_rust_binary(
+    name = "extractor",
+    srcs = ["src/main.rs"],
+    crate_root = "src/main.rs",
+    visibility = ["//visibility:public"],
+)

--- a/unified/extractor-unsupported-os/Cargo.toml
+++ b/unified/extractor-unsupported-os/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "codeql-extractor-unified-unsupported-os"
+description = "Fallback executable for unsupported CodeQL Unified extractor platforms"
+version = "0.1.0"
+authors = ["GitHub"]
+edition = "2024"

--- a/unified/extractor-unsupported-os/src/main.rs
+++ b/unified/extractor-unsupported-os/src/main.rs
@@ -1,4 +1,4 @@
 fn main() {
-    println!("Unsupported OS. Extraction is not currently supported on Windows.");
+    eprintln!("Unsupported OS. Extraction is not currently supported on Windows.");
     std::process::exit(1);
 }

--- a/unified/extractor-unsupported-os/src/main.rs
+++ b/unified/extractor-unsupported-os/src/main.rs
@@ -1,0 +1,4 @@
+fn main() {
+    println!("Unsupported OS. Extraction is not currently supported on Windows.");
+    std::process::exit(1);
+}


### PR DESCRIPTION
Needed to unblock DCA support while we don't have build support on Windows yet.