### PR TITLE
Go: support linux-arm64 in autobuild scripts

### DIFF
--- a/go/codeql-tools/autobuild.sh
+++ b/go/codeql-tools/autobuild.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-if [ "$CODEQL_PLATFORM" != "linux64" ] && [ "$CODEQL_PLATFORM" != "osx64" ] ; then
+if [ "$CODEQL_PLATFORM" != "linux64" ] && [ "$CODEQL_PLATFORM" != "linux-arm64" ] && [ "$CODEQL_PLATFORM" != "osx64" ] ; then
     echo "Automatic build detection for $CODEQL_PLATFORM is not implemented."
     exit 1
 fi

--- a/go/codeql-tools/identify-environment.sh
+++ b/go/codeql-tools/identify-environment.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-if [ "$CODEQL_PLATFORM" != "linux64" ] && [ "$CODEQL_PLATFORM" != "osx64" ] ; then
+if [ "$CODEQL_PLATFORM" != "linux64" ] && [ "$CODEQL_PLATFORM" != "linux-arm64" ] && [ "$CODEQL_PLATFORM" != "osx64" ] ; then
     echo "Automatic build detection for $CODEQL_PLATFORM is not implemented."
     exit 1
 fi

--- a/go/codeql-tools/index.sh
+++ b/go/codeql-tools/index.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-if [ "$CODEQL_PLATFORM" != "linux64" ] && [ "$CODEQL_PLATFORM" != "osx64" ] ; then
+if [ "$CODEQL_PLATFORM" != "linux64" ] && [ "$CODEQL_PLATFORM" != "linux-arm64" ] && [ "$CODEQL_PLATFORM" != "osx64" ] ; then
     echo "Automatic build detection for $CODEQL_PLATFORM is not implemented."
     exit 1
 fi


### PR DESCRIPTION
Part of the native Linux Arm64 support effort. Enables the Go extractor's automatic build detection on `linux-arm64`.

## Problem

The Go extractor's unix wrapper scripts in `go/codeql-tools/` (`autobuild.sh`, `index.sh`, `identify-environment.sh`) hard-gate on `CODEQL_PLATFORM` being `linux64` or `osx64`. On a native Linux Arm64 runner `CODEQL_PLATFORM=linux-arm64`, so every one of them bails out immediately with:

```
Automatic build detection for linux-arm64 is not implemented.
```

This causes `codeql database create` to fail for Go on arm64 even though the per-platform extractor binaries (`go-autobuilder`, `go-build-runner`, `go-extractor`, etc.) are already built natively for `linux-arm64` via `prefix = "tools/{CODEQL_PLATFORM}"`.

## Fix

Add `linux-arm64` to the platform allowlist in the three scripts. The Go autobuilder/extractor code is arch-agnostic (no hardcoded `amd64`/`GOARCH` assumptions), so no further change is needed. macOS remains a universal `osx64` build, so no `osx-arm64` entry is required.

## Validation

Surfaced by running the Go integration tests on a native `linux-arm64` runner, where the whole suite failed with the message above; this fix unblocks that slice. `bash -n` passes on all three modified scripts.