### PR TITLE
C#: support linux-arm64 in autobuild script

### DIFF
--- a/csharp/tools/autobuild.sh
+++ b/csharp/tools/autobuild.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-if [ "$CODEQL_PLATFORM" != "linux64" ] && [ "$CODEQL_PLATFORM" != "osx64" ] ; then
+if [ "$CODEQL_PLATFORM" != "linux64" ] && [ "$CODEQL_PLATFORM" != "linux-arm64" ] && [ "$CODEQL_PLATFORM" != "osx64" ] ; then
     echo "Automatic build detection for $CODEQL_PLATFORM is not implemented."
     exit 1
 fi


### PR DESCRIPTION
Enables the C# extractor's automatic build detection on `linux-arm64`. This is the C# analog of #22338 (Go).

## Problem

The C# extractor's unix wrapper script `csharp/tools/autobuild.sh` hard-gates on `CODEQL_PLATFORM` being `linux64` or `osx64`. On a native Linux Arm64 runner `CODEQL_PLATFORM=linux-arm64`, so it bails out immediately with:

```
Automatic build detection for linux-arm64 is not implemented.
```

This causes automatic build detection for C# to fail on arm64. Unlike Go (which had three gated scripts), C# has only this single gated script — there is no `identify-environment.sh`/`index.sh` gate to touch.

## Fix

Add `linux-arm64` to the platform allowlist. The C# autobuilder (`Semmle.Autobuild.CSharp`) is a portable .NET program invoked from `tools/$CODEQL_PLATFORM/`, so once a `linux-arm64` extractor pack is produced it runs unmodified.

## Build & packaging

The C# extractor binaries are produced per-`CODEQL_PLATFORM` by the Bazel build: `publish_binary` in `misc/bazel/csharp.bzl` builds `Semmle.Autobuild.CSharp` self-contained and packages it under `tools/{CODEQL_PLATFORM}/`. The runtime identifier is `osx-x64` on macOS (intel-pinned for now) and the toolchain/target-resolved default on Linux/Windows — i.e. Linux is not pinned to x64. The Bazel platform machinery (`misc/bazel/os.bzl`, `misc/bazel/pkg.bzl`) already understands `linux_arm64` and emits `tools/linux-arm64/...` on an arm64 build, exactly as the shipping `linux64`/`win64` packs do today. This change lifts the last runtime gate; CI on the arm64 leg is the final confirmation.

## Validation

`bash -n csharp/tools/autobuild.sh` passes.