### PR TITLE
C#: add linux-arm64 to standalone_dependencies assembly path normalization

### DIFF
--- a/csharp/ql/integration-tests/posix/standalone_dependencies_executing_runtime/Assemblies.ql
+++ b/csharp/ql/integration-tests/posix/standalone_dependencies_executing_runtime/Assemblies.ql
@@ -3,7 +3,7 @@ import csharp
 private string getPath(Assembly a) {
   not a.getCompilation().getOutputAssembly() = a and
   exists(string s | s = a.getFile().getAbsolutePath() |
-    exists(string sub | sub = "csharp/tools/" + ["osx64", "linux64"] |
+    exists(string sub | sub = "csharp/tools/" + ["osx64", "linux64", "linux-arm64"] |
       result = "[...]/csharp/tools/[...]" + s.substring(s.indexOf(sub) + sub.length(), s.length())
     )
     or


### PR DESCRIPTION
The `Assemblies.ql` integration-test query normalizes absolute paths of extractor tool assemblies so the expected output is platform independent. It did this only for `osx64` and `linux64`, so on `linux-arm64` (where the C# extractor tools live under `csharp/tools/linux-arm64/`) those tool assembly paths were not normalized and got dropped from the results.

This adds `linux-arm64` to the architecture list used for path normalization. The managed assembly set is architecture independent, so the expected output is unchanged and `Assemblies.expected` needs no update.