### PR TITLE
JavaScript: Fix TransformStream constructor arity

### DIFF
--- a/javascript/externs/web/streamsapi.js
+++ b/javascript/externs/web/streamsapi.js
@@ -38,9 +38,27 @@ var QueuingStrategy;
 
 
 /**
+ * A transform stream (https://streams.spec.whatwg.org/#transform-stream).
  * @record
  */
-function TransformStream() {};
+function ITransformStream() {};
+
+/** @type {!WritableStream} */
+ITransformStream.prototype.writable;
+
+/** @type {!ReadableStream} */
+ITransformStream.prototype.readable;
+
+
+/**
+ * @constructor
+ * @implements {ITransformStream}
+ * @param {Object=} transformer
+ * @param {!QueuingStrategy=} writableStrategy
+ * @param {!QueuingStrategy=} readableStrategy
+ * @see https://streams.spec.whatwg.org/#ts-class
+ */
+function TransformStream(transformer, writableStrategy, readableStrategy) {};
 
 /** @type {!WritableStream} */
 TransformStream.prototype.writable;
@@ -120,7 +138,7 @@ ReadableStream.prototype.cancel = function(reason) {};
 ReadableStream.prototype.getReader = function(opt_options) {};
 
 /**
- * @param {!TransformStream} transform
+ * @param {!ITransformStream} transform
  * @param {!PipeOptions=} opt_options
  * @return {!ReadableStream}
  * @see https://streams.spec.whatwg.org/#rs-pipe-through

--- a/javascript/ql/src/change-notes/2026-08-14-transformstream-constructor-arity.md
+++ b/javascript/ql/src/change-notes/2026-08-14-transformstream-constructor-arity.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The `js/superfluous-trailing-arguments` query no longer reports valid arguments passed to the `TransformStream` constructor.

--- a/javascript/ql/test/query-tests/LanguageFeatures/SpuriousArguments/SpuriousArguments.expected
+++ b/javascript/ql/test/query-tests/LanguageFeatures/SpuriousArguments/SpuriousArguments.expected
@@ -8,6 +8,7 @@
 | reflection.js:7:15:7:18 | 1 | Superfluous arguments passed to $@. | reflection.js:1:1:1:23 | functio ... eturn;} | function f0 |
 | reflection.js:12:18:12:18 | 2 | Superfluous argument passed to $@. | reflection.js:2:1:2:24 | functio ... eturn;} | function f1 |
 | thisparameter.ts:4:11:4:12 | 45 | Superfluous argument passed to $@. | thisparameter.ts:1:1:1:45 | functio ... eturn;} | function foo |
+| transformstream.ts:15:33:15:34 | {} | Superfluous argument passed to $@. | externs.js:48:1:48:76 | functio ... egy) {} | function TransformStream |
 | tst.js:10:3:10:5 | g() | Superfluous argument passed to $@. | tst.js:1:1:4:1 | functio ... x+19;\\n} | function f |
 | tst.js:31:15:31:18 | 2 | Superfluous arguments passed to $@. | externs.js:34:1:34:27 | functio ... str) {} | function String |
 | tst.js:34:4:34:5 | 42 | Superfluous argument passed to $@. | tst.js:35:4:35:23 | function() {return;} | anonymous function |

--- a/javascript/ql/test/query-tests/LanguageFeatures/SpuriousArguments/externs.js
+++ b/javascript/ql/test/query-tests/LanguageFeatures/SpuriousArguments/externs.js
@@ -39,4 +39,12 @@ function Number() {}
 
 Number.parseFloat = function(num) {};
 
+/**
+ * @param {*=} transformer
+ * @param {*=} writableStrategy
+ * @param {*=} readableStrategy
+ * @constructor
+ */
+function TransformStream(transformer, writableStrategy, readableStrategy) {}
+
 /** @externs */

--- a/javascript/ql/test/query-tests/LanguageFeatures/SpuriousArguments/transformstream.ts
+++ b/javascript/ql/test/query-tests/LanguageFeatures/SpuriousArguments/transformstream.ts
@@ -1,0 +1,15 @@
+class CustomTransformStream extends TransformStream<Uint8Array, number | string> {
+  constructor() {
+    super({
+      transform(chunk, controller) {
+        controller.enqueue(chunk);
+      }
+    });
+  }
+}
+
+new TransformStream();
+new TransformStream({});
+new TransformStream({}, {});
+new TransformStream({}, {}, {});
+new TransformStream({}, {}, {}, {}); // $ Alert


### PR DESCRIPTION
Fixes #18249.

This updates the Web Streams extern to model `TransformStream` as a three-argument constructor while preserving the structural `ITransformStream` type used by `pipeThrough`.

The regression test covers the reported TypeScript `super(...)` call and verifies that zero to three arguments are accepted while a fourth is reported.

### Testing

- Focused `SpuriousArguments` tests: 2/2 passed
- JavaScript `LanguageFeatures` tests: 54/54 passed
