### PR TITLE
Python: add SQL injection models for the duckdb package

### DIFF
--- a/docs/codeql/reusables/supported-frameworks.rst
+++ b/docs/codeql/reusables/supported-frameworks.rst
@@ -256,6 +256,7 @@ and the CodeQL library pack ``codeql/python-all`` (`changelog <https://github.co
    cassandra-driver, Database
    clickhouse-driver, Database
    cx_Oracle, Database
+duckdb, Database
    hdbcli, Database
    mysql-connector, Database
    mysql-connector-python, Database

--- a/python/ql/lib/semmle/python/Frameworks.qll
+++ b/python/ql/lib/semmle/python/Frameworks.qll
@@ -28,6 +28,7 @@ private import semmle.python.frameworks.Cx_Oracle
 private import semmle.python.frameworks.data.ModelsAsData
 private import semmle.python.frameworks.Dill
 private import semmle.python.frameworks.Django
+private import semmle.python.frameworks.Duckdb
 private import semmle.python.frameworks.Fabric
 private import semmle.python.frameworks.FastApi
 private import semmle.python.frameworks.Flask

--- a/python/ql/lib/semmle/python/frameworks/Duckdb.qll
+++ b/python/ql/lib/semmle/python/frameworks/Duckdb.qll
@@ -1,0 +1,44 @@
+/**
+ * Provides classes modeling security-relevant aspects of the `duckdb` PyPI package.
+ * See
+ * - https://duckdb.org/docs/stable/clients/python/overview
+ * - https://pypi.org/project/duckdb/
+ */
+
+private import python
+private import semmle.python.dataflow.new.DataFlow
+private import semmle.python.dataflow.new.RemoteFlowSources
+private import semmle.python.Concepts
+private import semmle.python.ApiGraphs
+private import semmle.python.frameworks.PEP249
+
+/**
+ * Provides models for the `duckdb` PyPI package.
+ * See
+ * - https://duckdb.org/docs/stable/clients/python/overview
+ * - https://pypi.org/project/duckdb/
+ */
+private module Duckdb {
+  /**
+   * A model of `duckdb` as a module that implements PEP 249, providing ways to execute SQL statements
+   * against a database.
+   */
+  class DuckdbPEP249 extends PEP249::PEP249ModuleApiNode {
+    DuckdbPEP249() { this = API::moduleImport("duckdb") }
+  }
+
+  /**
+   * A call to one of the module level functions `duckdb.sql`, `duckdb.execute` or
+   * `duckdb.executemany`, all of which immediately execute a SQL statement on the
+   * default connection.
+   *
+   * See https://duckdb.org/docs/stable/clients/python/overview
+   */
+  class ModuleLevelExecuteCall extends SqlExecution::Range, API::CallNode {
+    ModuleLevelExecuteCall() {
+      this = API::moduleImport("duckdb").getMember(["sql", "execute", "executemany"]).getACall()
+    }
+
+    override DataFlow::Node getSql() { result in [this.getArg(0), this.getArgByName("query")] }
+  }
+}

--- a/python/ql/src/change-notes/2026-08-15-duckdb-models.md
+++ b/python/ql/src/change-notes/2026-08-15-duckdb-models.md
@@ -1,0 +1,8 @@
+## Change notes
+
+Add SQL injection models for the `duckdb` PyPI package. `duckdb` implements the
+Python DB-API 2.0 (PEP 249): `duckdb.connect()`, `connection.cursor()`,
+`cursor.execute()`, `cursor.executemany()` are now modeled as SQL execution
+sinks, and the module-level convenience wrappers `duckdb.sql()`,
+`duckdb.execute()` and `duckdb.executemany()` are additionally modeled as
+`SqlExecution` calls.


### PR DESCRIPTION
## What does this PR do?

Adds CodeQL data-flow models for the [`duckdb`](https://pypi.org/project/duckdb/) Python package (~10M downloads/month). `duckdb` implements the Python DB-API 2.0 (PEP 249), but had no models in this repo, so string-built SQL passed to `duckdb` execution APIs was not flagged by the `SqlInjection` query suite.

Specifically:

- **`DuckdbPEP249`** models `duckdb` as a PEP 249 module, giving `duckdb.connect()`, `connection.cursor()`, `cursor.execute()` and `cursor.executemany()` the standard SQL-execution sink models via the existing PEP 249 machinery (plus the fetch\* threat-model sources).
- **`ModuleLevelExecuteCall`** additionally models the module-level convenience wrappers `duckdb.sql()`, `duckdb.execute()` and `duckdb.executemany()` as `SqlExecution` calls, with `getSql()` bound to positional argument 0 or the `query` keyword.
- Registers the framework in `Frameworks.qll` and adds `duckdb, Database` to the supported frameworks docs.

The modeling pattern follows the merged `hdbcli` models from #19444.

## Testing

- [x] QL syntax follows existing reviewed models (PEP249 extension + module-level ApiGraph call, same as hdbcli)

**Checklist:**

- [x] `.qll` changes are in `semmle/python/frameworks/`
- [x] Change note added
- [x] Supported frameworks docs updated