### PR TITLE
Docs: list psycopg (v3) in supported frameworks

### DIFF
--- a/docs/codeql/reusables/supported-frameworks.rst
+++ b/docs/codeql/reusables/supported-frameworks.rst
@@ -263,6 +263,7 @@ and the CodeQL library pack ``codeql/python-all`` (`changelog <https://github.co
    mysqlclient, Database
    oracledb, Database
    phoenixdb, Database
+   psycopg, Database
    psycopg2, Database
    pymssql, Database
    PyMySQL, Database


### PR DESCRIPTION
## What does this PR do?

Adds `psycopg` (v3) to the Python supported-frameworks table. Psycopg 3 already has models in this repo (`python/ql/lib/semmle/python/frameworks/Psycopg.qll`, imported by `Frameworks.qll`) but was missing from the docs table — only `psycopg2` was listed.

Companion docs follow-up to #22352 (duckdb models).