### PR TITLE
Add unified jump-to-definition query

### DIFF
--- a/unified/ql/lib/codeql/Definitions.qll
+++ b/unified/ql/lib/codeql/Definitions.qll
@@ -1,0 +1,16 @@
+/**
+ * Provides predicates related to jump-to-definition links in the code viewer.
+ */
+
+private import unified
+private import codeql.unified.internal.StaticNameBinding
+
+/**
+ * Holds if `reference` refers to `definition`.
+ */
+cached
+predicate definitionOf(Identifier reference, NameDeclaration definition, string kind) {
+  reference = trackNameDeclaration(definition).asIdentifier() and
+  not reference instanceof NameDeclaration and
+  kind = "name"
+}

--- a/unified/ql/lib/ide-contextual-queries/definitions.ql
+++ b/unified/ql/lib/ide-contextual-queries/definitions.ql
@@ -1,0 +1,20 @@
+/**
+ * @name Jump-to-definition links
+ * @description Generates use-definition pairs that provide the data
+ *              for jump-to-definition in the code viewer.
+ * @kind definitions
+ * @id unified/ide-jump-to-definition
+ * @tags ide-contextual-queries/local-definitions
+ */
+
+import codeql.Definitions
+import codeql.IDEContextual
+import unified
+
+external string selectedSourceFile();
+
+from Identifier reference, NameDeclaration definition, string kind
+where
+  definitionOf(reference, definition, kind) and
+  reference.getLocation().getFile() = getFileBySourceArchiveName(selectedSourceFile())
+select reference, definition, kind

--- a/unified/ql/lib/utils/test/TestUtils.qll
+++ b/unified/ql/lib/utils/test/TestUtils.qll
@@ -1,0 +1,33 @@
+private import unified
+private import CommentUtil
+private import codeql.unified.internal.StaticNameBinding
+
+private string deriveClassName(ClassLikeDeclaration cls) {
+  not exists(cls.getParent().getEnclosingClass()) and
+  result = cls.getName().getValue()
+  or
+  result = deriveClassName(cls.getParent().getEnclosingClass()) + "." + cls.getName().getValue()
+}
+
+private string defaultName(NameDeclaration decl) {
+  exists(ClassLikeDeclaration cls |
+    decl.getDeclaration() = cls.getAMember() and
+    result = deriveClassName(cls) + "." + decl.getName()
+  )
+  or
+  not decl.getDeclaration() = any(ClassLikeDeclaration cls).getAMember() and
+  result = decl.getName()
+}
+
+private predicate declAt(NameDeclaration v, string filepath, int line) {
+  v.getLocation().hasLocationInfo(filepath, line, _, _, _)
+}
+
+predicate nameDeclaration(NameDeclaration v, string alias) {
+  exists(string filepath, int line | declAt(v, filepath, line) |
+    keyValueCommentAt(filepath, line, "name", alias)
+    or
+    not keyValueCommentAt(filepath, line, "name", _) and
+    alias = defaultName(v)
+  )
+}

--- a/unified/ql/test/library-tests/definitions/test.ql
+++ b/unified/ql/test/library-tests/definitions/test.ql
@@ -1,0 +1,20 @@
+import unified
+import utils.test.InlineExpectationsTest
+import utils.test.TestUtils
+import codeql.Definitions
+
+module DefinitionsTest implements TestSig {
+  string getARelevantTag() { result = "definition" }
+
+  predicate hasActualResult(Location location, string element, string tag, string value) {
+    exists(Identifier reference, NameDeclaration definition |
+      definitionOf(reference, definition, "name") and
+      location = reference.getLocation() and
+      element = reference.toString() and
+      nameDeclaration(definition, value) and
+      tag = "definition"
+    )
+  }
+}
+
+import MakeTest<DefinitionsTest>

--- a/unified/ql/test/library-tests/definitions/test.swift
+++ b/unified/ql/test/library-tests/definitions/test.swift
@@ -1,0 +1,18 @@
+class Base {
+    class Nested {}
+    static let member = 1
+}
+
+class Derived : Base {} // $ definition=Base
+
+func test() {
+    let local = 1 // name=local1
+    local // $ definition=local1
+    let local = 2 // name=local2
+    local // $ definition=local2
+    Derived.member // $ definition=Derived definition=Base.member
+    let _: Derived.Nested? // $ definition=Derived definition=Base.Nested
+}
+
+typealias Alias = Derived // $ definition=Derived
+let _: Alias.Nested? // $ definition=Alias definition=Base.Nested

--- a/unified/ql/test/library-tests/static-name-binding/test.ql
+++ b/unified/ql/test/library-tests/static-name-binding/test.ql
@@ -1,40 +1,10 @@
 import unified
 import utils.test.InlineExpectationsTest
-import utils.test.CommentUtil
+import utils.test.TestUtils
 import codeql.unified.internal.StaticNameBinding
 
 module StaticDeclAccess implements TestSig {
   string getARelevantTag() { result = "access" }
-
-  private string deriveClassName(ClassLikeDeclaration cls) {
-    not exists(cls.getParent().getEnclosingClass()) and
-    result = cls.getName().getValue()
-    or
-    result = deriveClassName(cls.getParent().getEnclosingClass()) + "." + cls.getName().getValue()
-  }
-
-  private string defaultName(NameDeclaration decl) {
-    exists(ClassLikeDeclaration cls |
-      decl.getDeclaration() = cls.getAMember() and
-      result = deriveClassName(cls) + "." + decl.getName()
-    )
-    or
-    not decl.getDeclaration() = any(ClassLikeDeclaration cls).getAMember() and
-    result = decl.getName()
-  }
-
-  additional predicate declAt(NameDeclaration v, string filepath, int line) {
-    v.getLocation().hasLocationInfo(filepath, line, _, _, _)
-  }
-
-  private predicate decl(NameDeclaration v, string alias) {
-    exists(string filepath, int line | declAt(v, filepath, line) |
-      keyValueCommentAt(filepath, line, "name", alias)
-      or
-      not keyValueCommentAt(filepath, line, "name", _) and
-      alias = defaultName(v)
-    )
-  }
 
   predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(NameDeclaration decl, Identifier access |
@@ -42,7 +12,7 @@ module StaticDeclAccess implements TestSig {
       not access instanceof NameDeclaration and
       location = access.getLocation() and
       element = access.toString() and
-      decl(decl, value) and
+      nameDeclaration(decl, value) and
       tag = "access"
     )
   }


### PR DESCRIPTION
Unified currently lacks jump-to-definition support in contextual code navigation. This adds a definitions query backed by the existing static name-binding graph so identifier references resolve to their declarations.

The query follows the contextual-query structure used by other languages and limits results to the selected source file. Inline-expectation tests cover local names, inheritance, static members, nested types, and type aliases. Shared declaration naming logic is extracted into a unified test utility and reused by the existing static name-binding test.