### PR TITLE
Go: de-bazel checks in test action

### DIFF
--- a/go/actions/test/action.yml
+++ b/go/actions/test/action.yml
@@ -1,12 +1,12 @@
 name: Test Go extractor
-description: Run build, QL tests, and optionally basic code sanity checks (formatting and generated code) for the Go extractor
+description: Run build, QL tests, and optionally qhelp generation for the Go extractor
 inputs:
   go-test-version:
     description: Which Go version to use for running the tests
     required: false
     default: "~1.26.6"
   run-code-checks:
-    description: Whether to run formatting, code and qhelp generation checks
+    description: Whether to run qhelp generation checks
     required: false
     default: false
 runs:
@@ -26,28 +26,11 @@ runs:
       shell: bash
       run: 'find .github/problem-matchers -name \*.json -exec echo "::add-matcher::{}" \;'
 
-    - name: Check checked-in generated code
-      if: inputs.run-code-checks == 'true'
-      shell: bash
-      run: |
-        bazel run go:gen
-        git add .
-        git diff --exit-code HEAD || (
-          echo "please run bazel run //go:gen"
-          exit 1
-        )
-
     - name: Build
       shell: bash
       run: |
-        bazel run go:go-installer
-
-    - name: Check that all Go code is autoformatted
-      if: inputs.run-code-checks == 'true' && !cancelled()
-      shell: bash
-      run: |
-          cd go
-          make check-formatting
+        cd go/extractor
+        go build ./...
 
     - name: Compile qhelp files to markdown
       if: inputs.run-code-checks == 'true' && !cancelled()


### PR DESCRIPTION
## Why

The generated-code drift check and the gofmt formatting check are moving to a companion CI job that can piggyback on that pipeline's bazel cache. To avoid running them in two places, we drop those two checks here and keep a lightweight, non-bazel `go build` sanity check so this repo still verifies the Go extractor compiles with the standard toolchain.

## Changes to `go/actions/test/action.yml`

- Remove the generated-code drift check (`bazel run go:gen` + `git diff`).
- Remove the gofmt check (`cd go && make check-formatting`).
- Replace the bazel build (`bazel run go:go-installer`) with a plain `cd go/extractor && go build ./...`.
- Keep the qhelp-to-markdown compile + upload steps unchanged.

## Note

This depends on the companion change landing first. Merging this before that lands would leave a short window where neither side runs the codegen + gofmt checks.