### PR TITLE
Rust: Use `zstd` compression for TRAP files by default

### DIFF
--- a/rust/codeql-extractor.yml
+++ b/rust/codeql-extractor.yml
@@ -25,8 +25,8 @@ options:
         title: Controls compression for the TRAP files written by the extractor.
         description: >
           This option is only intended for use in debugging the extractor. Accepted
-          values are 'gzip' (to write gzip-compressed TRAP) 'zstd' (to write
-          Zstandard-compressed TRAP) and 'none' (the default, to write uncompressed
+          values are 'gzip' (to write gzip-compressed TRAP) 'zstd' (the default,
+          to write Zstandard-compressed TRAP) and 'none' (to write uncompressed
           TRAP).
         type: string
         pattern: "^(none|gzip|zstd)$"

--- a/rust/extractor/src/config.rs
+++ b/rust/extractor/src/config.rs
@@ -28,9 +28,9 @@ use std::path::{Path, PathBuf};
 #[serde(rename_all = "lowercase")]
 #[clap(rename_all = "lowercase")]
 pub enum Compression {
-    #[default] // TODO make gzip default
     None,
     Gzip,
+    #[default]
     Zstd,
 }
 


### PR DESCRIPTION
In a local experiment this reduces the `trap` folder from 1.69 GB to 293 MB.