### PR TITLE
C#: Use ProcessStartInfo built-in for correct escaping/quoting in the Dependency manager.

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DotNet.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DotNet.cs
@@ -49,7 +49,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             // Allow up to four attempts (with up to three retries) to run `dotnet --info`, to mitigate transient issues
             for (int attempt = 0; attempt < 4; attempt++)
             {
-                var exitCode = dotnetCliInvoker.RunCommandExitCode("--info", silent: false);
+                var exitCode = dotnetCliInvoker.RunCommandExitCode(["--info"], silent: false);
                 switch (exitCode)
                 {
                     case 0:
@@ -63,9 +63,9 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             }
         }
 
-        private string GetRestoreArgs(RestoreSettings restoreSettings)
+        private List<string> GetRestoreArgs(RestoreSettings restoreSettings)
         {
-            var args = $"restore --no-dependencies \"{restoreSettings.File}\" --packages \"{restoreSettings.PackageDirectory}\" /p:DisableImplicitNuGetFallbackFolder=true --verbosity normal";
+            List<string> args = ["restore", "--no-dependencies", restoreSettings.File, "--packages", restoreSettings.PackageDirectory, "/p:DisableImplicitNuGetFallbackFolder=true", "--verbosity", "normal"];
 
             if (restoreSettings.ForceDotnetRefAssemblyFetching)
             {
@@ -77,23 +77,20 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                     Directory.CreateDirectory(path);
                 }
 
-                args += $" /p:TargetFrameworkRootPath=\"{path}\" /p:NetCoreTargetingPackRoot=\"{path}\" /p:AllowMissingPrunePackageData=true";
+                args.AddRange([$"/p:TargetFrameworkRootPath={path}", $"/p:NetCoreTargetingPackRoot={path}", "/p:AllowMissingPrunePackageData=true"]);
             }
 
             if (restoreSettings.ForceReevaluation)
             {
-                args += " --force";
+                args.Add("--force");
             }
 
             if (restoreSettings.TargetWindows)
             {
-                args += " /p:EnableWindowsTargeting=true";
+                args.Add("/p:EnableWindowsTargeting=true");
             }
 
-            if (restoreSettings.NugetSources is not null)
-            {
-                args += $" {restoreSettings.NugetSources}";
-            }
+            args.AddRange(restoreSettings.NugetSources);
 
             return args;
         }
@@ -107,48 +104,48 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
 
         public bool New(string folder)
         {
-            var args = $"new console --no-restore --output \"{folder}\"";
+            List<string> args = ["new", "console", "--no-restore", "--output", folder];
             return dotnetCliInvoker.RunCommand(args);
         }
 
         public bool AddPackage(string folder, string package)
         {
-            var args = $"add \"{folder}\" package \"{package}\" --no-restore";
+            List<string> args = ["add", folder, "package", package, "--no-restore"];
             return dotnetCliInvoker.RunCommand(args);
         }
 
-        public IList<string> GetListedRuntimes() => GetResultList("--list-runtimes");
+        public IList<string> GetListedRuntimes() => GetResultList(["--list-runtimes"]);
 
-        public IList<string> GetListedSdks() => GetResultList("--list-sdks");
+        public IList<string> GetListedSdks() => GetResultList(["--list-sdks"]);
 
-        private IList<string> GetResultList(string args, string? workingDirectory = null, bool silent = true)
+        private IList<string> GetResultList(List<string> args, string? workingDirectory = null, bool silent = true)
         {
             if (dotnetCliInvoker.RunCommand(args, workingDirectory, out var results, silent))
             {
                 return results;
             }
-            logger.LogWarning($"Running 'dotnet {args}' failed.");
+            logger.LogWarning($"Running 'dotnet {string.Join(" ", args)}' failed.");
             return [];
         }
 
-        public bool Exec(string execArgs)
+        public bool Exec(List<string> execArgs)
         {
-            var args = $"exec {execArgs}";
+            List<string> args = ["exec", .. execArgs];
             return dotnetCliInvoker.RunCommand(args);
         }
 
-        private const string nugetListSourceCommand = "nuget list source --format Short";
+        private static readonly IReadOnlyList<string> nugetListSourceCommandArgs = ["nuget", "list", "source", "--format", "Short"];
 
         public IList<string> GetNugetFeeds(string nugetConfig)
         {
             logger.LogInfo($"Getting NuGet feeds from '{nugetConfig}'...");
-            return GetResultList($"{nugetListSourceCommand} --configfile \"{nugetConfig}\"");
+            return GetResultList([.. nugetListSourceCommandArgs, "--configfile", nugetConfig]);
         }
 
         public IList<string> GetNugetFeedsFromFolder(string folderPath)
         {
             logger.LogInfo($"Getting NuGet feeds in folder '{folderPath}'...");
-            return GetResultList(nugetListSourceCommand, folderPath);
+            return GetResultList(nugetListSourceCommandArgs.ToList(), folderPath);
         }
 
         // The version number should be kept in sync with the version .NET version used for building the application.

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DotNetCliInvoker.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DotNetCliInvoker.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Diagnostics;
 using Semmle.Util;
 using Semmle.Util.Logging;
@@ -25,7 +24,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             logger.LogInfo($"Using .NET CLI executable: '{Exec}'");
         }
 
-        private ProcessStartInfo MakeDotnetStartInfo(string args, string? workingDirectory)
+        private ProcessStartInfo MakeDotnetStartInfo(List<string> args, string? workingDirectory)
         {
             var startInfo = new ProcessStartInfo(Exec, args)
             {
@@ -57,39 +56,39 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             return startInfo;
         }
 
-        private int RunCommandExitCodeAux(string args, string? workingDirectory, out IList<string> output, out string dirLog, bool silent)
+        private int RunCommandExitCodeAux(List<string> args, string? workingDirectory, out IList<string> output, out string dirLog, bool silent)
         {
             dirLog = string.IsNullOrWhiteSpace(workingDirectory) ? "" : $" in {workingDirectory}";
             var pi = MakeDotnetStartInfo(args, workingDirectory);
             var threadId = Environment.CurrentManagedThreadId;
             void onOut(string s) => logger.Log(silent ? Severity.Debug : Severity.Info, s, threadId);
             void onError(string s) => logger.LogError(s, threadId);
-            logger.LogInfo($"Running '{Exec} {args}'{dirLog}");
+            logger.LogInfo($"Running '{Exec} {string.Join(" ", args)}'{dirLog}");
             var exitCode = pi.ReadOutput(out output, onOut, onError);
             return exitCode;
         }
 
-        private bool RunCommandAux(string args, string? workingDirectory, out IList<string> output, bool silent)
+        private bool RunCommandAux(List<string> args, string? workingDirectory, out IList<string> output, bool silent)
         {
             var exitCode = RunCommandExitCodeAux(args, workingDirectory, out output, out var dirLog, silent);
             if (exitCode != 0)
             {
-                logger.LogError($"Command '{Exec} {args}'{dirLog} failed with exit code {exitCode}");
+                logger.LogError($"Command '{Exec} {string.Join(" ", args)}'{dirLog} failed with exit code {exitCode}");
                 return false;
             }
             return true;
         }
 
-        public bool RunCommand(string args, bool silent = true) =>
+        public bool RunCommand(List<string> args, bool silent = true) =>
             RunCommandAux(args, null, out _, silent);
 
-        public int RunCommandExitCode(string args, bool silent = true) =>
+        public int RunCommandExitCode(List<string> args, bool silent = true) =>
             RunCommandExitCodeAux(args, null, out _, out _, silent);
 
-        public bool RunCommand(string args, out IList<string> output, bool silent = true) =>
+        public bool RunCommand(List<string> args, out IList<string> output, bool silent = true) =>
             RunCommandAux(args, null, out output, silent);
 
-        public bool RunCommand(string args, string? workingDirectory, out IList<string> output, bool silent = true) =>
+        public bool RunCommand(List<string> args, string? workingDirectory, out IList<string> output, bool silent = true) =>
             RunCommandAux(args, workingDirectory, out output, silent);
     }
 }

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/FeedManager.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/FeedManager.cs
@@ -158,24 +158,18 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         /// </summary>
         /// <param name="feeds">The list of feeds to use for the restore command.</param>
         /// <param name="sourceArgumentPrefix">The prefix to use for each source argument (e.g., "-s").</param>
-        /// <returns>The constructed NuGet sources argument for the restore command.</returns>
-        public string FeedsToRestoreArgument(IEnumerable<string> feeds, string sourceArgumentPrefix)
+        /// <returns>The list of NuGet sources arguments for the restore command.</returns>
+        public List<string> FeedsToRestoreArgument(IEnumerable<string> feeds, string sourceArgumentPrefix)
         {
             // If there are no feeds, we want to override any default feeds that `restore` would use by passing a dummy source argument.
             if (!feeds.Any())
             {
-                return $" {sourceArgumentPrefix} \"{emptyPackageDirectory.DirInfo.FullName}\"";
+                return [sourceArgumentPrefix, emptyPackageDirectory.DirInfo.FullName];
             }
 
             // Add package sources. If any are present, they override all sources specified in
             // the configuration file(s).
-            var feedArgs = new StringBuilder();
-            foreach (var feed in feeds)
-            {
-                feedArgs.Append($" {sourceArgumentPrefix} \"{feed}\"");
-            }
-
-            return feedArgs.ToString();
+            return feeds.SelectMany<string, string>(feed => [sourceArgumentPrefix, feed]).ToList();
         }
 
         private IEnumerable<string> FeedsToUseAux(HashSet<string> feedsToConsider)
@@ -212,8 +206,8 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         /// Constructs the NuGet sources argument for the `dotnet restore` command based on the given feeds.
         /// </summary>
         /// <param name="feeds">The list of NuGet feeds to use for the restore command.</param>
-        /// <returns>A string representing the NuGet sources argument for the `dotnet restore` command.</returns>
-        public string FeedsToDotnetRestoreArgument(IEnumerable<string> feeds)
+        /// <returns>A list representing the NuGet sources arguments for the `dotnet restore` command.</returns>
+        public List<string> FeedsToDotnetRestoreArgument(IEnumerable<string> feeds)
         {
             return FeedsToRestoreArgument(feeds, "-s");
         }
@@ -224,13 +218,13 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         /// (2) Use private registries, if they are configured
         /// </summary>
         /// <param name="path">Path to project/solution</param>
-        /// <returns>A string representing the NuGet sources argument for the `dotnet restore` command.</returns>
-        public string? MakeDotnetRestoreSourcesArgument(string path)
+        /// <returns>A list representing the NuGet sources arguments for the `dotnet restore` command.</returns>
+        public List<string> MakeDotnetRestoreSourcesArguments(string path)
         {
             // Do not construct a set of explicit NuGet sources to use for restore.
             if (!CheckNugetFeedResponsiveness && !HasPrivateRegistryFeeds)
             {
-                return null;
+                return [];
             }
 
             var feedsToUse = FeedsToUse(path);

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/IDotNet.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/IDotNet.cs
@@ -12,12 +12,12 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         bool AddPackage(string folder, string package);
         IList<string> GetListedRuntimes();
         IList<string> GetListedSdks();
-        bool Exec(string execArgs);
+        bool Exec(List<string> execArgs);
         IList<string> GetNugetFeeds(string nugetConfig);
         IList<string> GetNugetFeedsFromFolder(string folderPath);
     }
 
-    public record class RestoreSettings(string File, string PackageDirectory, bool ForceDotnetRefAssemblyFetching, string? NugetSources = null, bool ForceReevaluation = false, bool TargetWindows = false);
+    public record class RestoreSettings(string File, string PackageDirectory, bool ForceDotnetRefAssemblyFetching, List<string> NugetSources, bool ForceReevaluation = false, bool TargetWindows = false);
 
     public partial record class RestoreResult(bool Success, IList<string> Output)
     {

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/IDotNetCliInvoker.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/IDotNetCliInvoker.cs
@@ -30,26 +30,26 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         /// Execute `dotnet <paramref name="args"/>` and return true if the command succeeded, otherwise false.
         /// If `silent` is true the output of the command is logged as `debug` otherwise as `info`.
         /// </summary>
-        bool RunCommand(string args, bool silent = true);
+        bool RunCommand(List<string> args, bool silent = true);
 
         /// <summary>
         /// Execute `dotnet <paramref name="args"/>` and return the exit code.
         /// If `silent` is true the output of the command is logged as `debug` otherwise as `info`.
         /// </summary>
-        int RunCommandExitCode(string args, bool silent = true);
+        int RunCommandExitCode(List<string> args, bool silent = true);
 
         /// <summary>
         /// Execute `dotnet <paramref name="args"/>` and return true if the command succeeded, otherwise false.
         /// The output of the command is returned in `output`.
         /// If `silent` is true the output of the command is logged as `debug` otherwise as `info`.
         /// </summary>
-        bool RunCommand(string args, out IList<string> output, bool silent = true);
+        bool RunCommand(List<string> args, out IList<string> output, bool silent = true);
 
         /// <summary>
         /// Execute `dotnet <paramref name="args"/>` in `<paramref name="workingDirectory"/>` and return true if the command succeeded, otherwise false.
         /// The output of the command is returned in `output`.
         /// If `silent` is true the output of the command is logged as `debug` otherwise as `info`.
         /// </summary>
-        bool RunCommand(string args, string? workingDirectory, out IList<string> output, bool silent = true);
+        bool RunCommand(List<string> args, string? workingDirectory, out IList<string> output, bool silent = true);
     }
 }

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/NugetPackageRestorer.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/NugetPackageRestorer.cs
@@ -216,7 +216,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             var projects = fileProvider.Solutions.SelectMany(solution =>
                 {
                     logger.LogInfo($"Restoring solution {solution}...");
-                    var nugetSources = feedManager.MakeDotnetRestoreSourcesArgument(solution);
+                    var nugetSources = feedManager.MakeDotnetRestoreSourcesArguments(solution);
                     var res = dotnet.Restore(new(solution, PackageDirectory.DirInfo.FullName, ForceDotnetRefAssemblyFetching: true, NugetSources: nugetSources, TargetWindows: isWindows));
                     if (res.Success)
                     {
@@ -264,7 +264,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                 foreach (var project in projectGroup)
                 {
                     logger.LogInfo($"Restoring project {project}...");
-                    var nugetSources = feedManager.MakeDotnetRestoreSourcesArgument(project);
+                    var nugetSources = feedManager.MakeDotnetRestoreSourcesArguments(project);
                     var res = dotnet.Restore(new(project, PackageDirectory.DirInfo.FullName, ForceDotnetRefAssemblyFetching: true, NugetSources: nugetSources, TargetWindows: isWindows));
                     assets.AddDependenciesRange(res.AssetsFilePaths);
                     lock (sync)
@@ -432,7 +432,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                 .Select(d => Path.GetFileName(d).ToLowerInvariant());
         }
 
-        private bool TryRestorePackageManually(string package, string? nugetSources, PackageReferenceSource packageReferenceSource = PackageReferenceSource.SdkCsProj, bool tryPrereleaseVersion = true)
+        private bool TryRestorePackageManually(string package, List<string> nugetSources, PackageReferenceSource packageReferenceSource = PackageReferenceSource.SdkCsProj, bool tryPrereleaseVersion = true)
         {
             logger.LogInfo($"Restoring package {package}...");
             using var tempDir = new TemporaryDirectory(
@@ -460,11 +460,11 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                 return true;
             }
 
-            if (!feedManager.CheckNugetFeedResponsiveness && res.HasNugetPackageSourceError && nugetSources is not null)
+            if (!feedManager.CheckNugetFeedResponsiveness && res.HasNugetPackageSourceError && nugetSources.Count > 0)
             {
                 logger.LogDebug($"Trying to restore '{package}' without explicitly providing NuGet sources.");
                 // Restore could not be completed because the listed source is unavailable. Try without an explicit restore source argument.
-                res = TryRestorePackageManually(package, nugetSources: null, tempDir, tryPrereleaseVersion);
+                res = TryRestorePackageManually(package, [], tempDir, tryPrereleaseVersion);
                 if (res.Success)
                 {
                     return true;
@@ -475,16 +475,16 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             return false;
         }
 
-        private RestoreResult TryRestorePackageManually(string package, string? nugetSources, TemporaryDirectory tempDir, bool tryPrereleaseVersion)
+        private RestoreResult TryRestorePackageManually(string package, List<string> nugetSources, TemporaryDirectory tempDir, bool tryPrereleaseVersion)
         {
-            var res = dotnet.Restore(new(tempDir.DirInfo.FullName, missingPackageDirectory.DirInfo.FullName, ForceDotnetRefAssemblyFetching: false, NugetSources: nugetSources, ForceReevaluation: true));
+            var res = dotnet.Restore(new(tempDir.DirInfo.FullName, missingPackageDirectory.DirInfo.FullName, ForceDotnetRefAssemblyFetching: false, nugetSources, ForceReevaluation: true));
 
             if (!res.Success && tryPrereleaseVersion && res.HasNugetNoStablePackageVersionError)
             {
                 logger.LogDebug($"Failed to restore nuget package {package} because no stable version was found.");
                 TryChangePackageVersion(tempDir.DirInfo, "*-*");
 
-                res = dotnet.Restore(new(tempDir.DirInfo.FullName, missingPackageDirectory.DirInfo.FullName, ForceDotnetRefAssemblyFetching: false, NugetSources: nugetSources, ForceReevaluation: true));
+                res = dotnet.Restore(new(tempDir.DirInfo.FullName, missingPackageDirectory.DirInfo.FullName, ForceDotnetRefAssemblyFetching: false, nugetSources, ForceReevaluation: true));
                 if (!res.Success)
                 {
                     TryChangePackageVersion(tempDir.DirInfo, "*");

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/PackagesConfigRestorer.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/PackagesConfigRestorer.cs
@@ -168,7 +168,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             {
                 logger.LogInfo($"Restoring file \"{packagesConfig}\"...");
 
-                var sourcesArgument = "";
+                List<string> sourcesArgument = [];
                 var feedsToUse = feedManager.FeedsToUse(packagesConfig).ToList();
                 var useDefaultFeed = feedsToUse.Count == 0 && IsDefaultFeedReachable;
 
@@ -189,16 +189,18 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                  * really unwieldy and this solution works for now.
                  */
 
-                string exe, args;
+                string exe;
+                List<string> args;
+
                 if (RunWithMono)
                 {
                     exe = "mono";
-                    args = $"\"{nugetExe}\" install -OutputDirectory \"{packageDirectory}\" {sourcesArgument} \"{packagesConfig}\"";
+                    args = [nugetExe!, "install", "-OutputDirectory", packageDirectory.ToString(), .. sourcesArgument, packagesConfig];
                 }
                 else
                 {
                     exe = nugetExe!;
-                    args = $"install -OutputDirectory \"{packageDirectory}\" {sourcesArgument} \"{packagesConfig}\"";
+                    args = ["install", "-OutputDirectory", packageDirectory.ToString(), .. sourcesArgument, packagesConfig];
                 }
 
                 var pi = new ProcessStartInfo(exe, args)
@@ -214,7 +216,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                 var exitCode = pi.ReadOutput(out _, onOut, onError);
                 if (exitCode != 0)
                 {
-                    logger.LogError($"Command {pi.FileName} {pi.Arguments} failed with exit code {exitCode}");
+                    logger.LogError($"Command {pi.FileName} {string.Join(" ", pi.ArgumentList)} failed with exit code {exitCode}");
                     return false;
                 }
                 else

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/SourceGenerators/DotnetSourceGeneratorWrapper/DotnetSourceGeneratorWrapper.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/SourceGenerators/DotnetSourceGeneratorWrapper/DotnetSourceGeneratorWrapper.cs
@@ -79,7 +79,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                     sw.Write(argsString);
                 }
 
-                dotnet.Exec($"\"{cscPath}\" /noconfig @\"{cscArgsPath}\"");
+                dotnet.Exec([cscPath, "/noconfig", $"@{cscArgsPath}"]);
 
                 var files = Directory.GetFiles(outputFolder, "*.*", new EnumerationOptions { RecurseSubdirectories = true });
 

--- a/csharp/extractor/Semmle.Extraction.Tests/DotNet.cs
+++ b/csharp/extractor/Semmle.Extraction.Tests/DotNet.cs
@@ -8,45 +8,45 @@ namespace Semmle.Extraction.Tests
 {
     internal class DotNetCliInvokerStub : IDotNetCliInvoker
     {
-        private readonly IList<string> output;
-        private string lastArgs = "";
+        private readonly IList<string> returnOutput;
+        private List<string> lastArgs = [];
         public string WorkingDirectory { get; private set; } = "";
         public bool Success { get; set; } = true;
         public int ExitCode { get; set; } = 0;
 
-        public DotNetCliInvokerStub(IList<string> output)
+        public DotNetCliInvokerStub(IList<string> returnOutput)
         {
-            this.output = output;
+            this.returnOutput = returnOutput;
         }
 
         public string Exec => "dotnet";
 
-        public bool RunCommand(string args, bool silent)
+        public bool RunCommand(List<string> args, bool silent)
         {
             lastArgs = args;
             return Success;
         }
 
-        public int RunCommandExitCode(string args, bool silent)
+        public int RunCommandExitCode(List<string> args, bool silent)
         {
             lastArgs = args;
             return ExitCode;
         }
 
-        public bool RunCommand(string args, out IList<string> output, bool silent)
+        public bool RunCommand(List<string> args, out IList<string> output, bool silent)
         {
             lastArgs = args;
-            output = this.output;
+            output = this.returnOutput;
             return Success;
         }
 
-        public bool RunCommand(string args, string? workingDirectory, out IList<string> output, bool silent)
+        public bool RunCommand(List<string> args, string? workingDirectory, out IList<string> output, bool silent)
         {
             WorkingDirectory = workingDirectory ?? "";
             return RunCommand(args, out output, silent);
         }
 
-        public string GetLastArgs() => lastArgs;
+        public List<string> GetLastArgs() => lastArgs;
     }
 
     public class DotNetTests
@@ -83,7 +83,7 @@ namespace Semmle.Extraction.Tests
 
             // Verify
             var lastArgs = dotnetCliInvoker.GetLastArgs();
-            Assert.Equal("--info", lastArgs);
+            Assert.Equal(["--info"], lastArgs);
         }
 
         [Fact]
@@ -115,11 +115,11 @@ namespace Semmle.Extraction.Tests
             var dotnet = MakeDotnet(dotnetCliInvoker);
 
             // Execute
-            dotnet.Restore(new("myproject.csproj", "mypackages", false));
+            dotnet.Restore(new("myproject.csproj", "mypackages", false, []));
 
             // Verify
             var lastArgs = dotnetCliInvoker.GetLastArgs();
-            Assert.Equal("restore --no-dependencies \"myproject.csproj\" --packages \"mypackages\" /p:DisableImplicitNuGetFallbackFolder=true --verbosity normal", lastArgs);
+            Assert.Equal(["restore", "--no-dependencies", "myproject.csproj", "--packages", "mypackages", "/p:DisableImplicitNuGetFallbackFolder=true", "--verbosity", "normal"], lastArgs);
         }
 
         [Fact]
@@ -130,11 +130,11 @@ namespace Semmle.Extraction.Tests
             var dotnet = MakeDotnet(dotnetCliInvoker);
 
             // Execute
-            var res = dotnet.Restore(new("myproject.csproj", "mypackages", false, null));
+            var res = dotnet.Restore(new("myproject.csproj", "mypackages", false, []));
 
             // Verify
             var lastArgs = dotnetCliInvoker.GetLastArgs();
-            Assert.Equal("restore --no-dependencies \"myproject.csproj\" --packages \"mypackages\" /p:DisableImplicitNuGetFallbackFolder=true --verbosity normal", lastArgs);
+            Assert.Equal(["restore", "--no-dependencies", "myproject.csproj", "--packages", "mypackages", "/p:DisableImplicitNuGetFallbackFolder=true", "--verbosity", "normal"], lastArgs);
             Assert.Equal(2, res.AssetsFilePaths.Count());
             Assert.Contains("/path/to/project.assets.json", res.AssetsFilePaths);
             Assert.Contains("/path/to/project2.assets.json", res.AssetsFilePaths);
@@ -148,11 +148,11 @@ namespace Semmle.Extraction.Tests
             var dotnet = MakeDotnet(dotnetCliInvoker);
 
             // Execute
-            var res = dotnet.Restore(new("myproject.csproj", "mypackages", false, null, true));
+            var res = dotnet.Restore(new("myproject.csproj", "mypackages", false, [], true));
 
             // Verify
             var lastArgs = dotnetCliInvoker.GetLastArgs();
-            Assert.Equal("restore --no-dependencies \"myproject.csproj\" --packages \"mypackages\" /p:DisableImplicitNuGetFallbackFolder=true --verbosity normal --force", lastArgs);
+            Assert.Equal(["restore", "--no-dependencies", "myproject.csproj", "--packages", "mypackages", "/p:DisableImplicitNuGetFallbackFolder=true", "--verbosity", "normal", "--force"], lastArgs);
             Assert.Equal(2, res.AssetsFilePaths.Count());
             Assert.Contains("/path/to/project.assets.json", res.AssetsFilePaths);
             Assert.Contains("/path/to/project2.assets.json", res.AssetsFilePaths);
@@ -166,11 +166,11 @@ namespace Semmle.Extraction.Tests
             var dotnet = MakeDotnet(dotnetCliInvoker);
 
             // Execute
-            var res = dotnet.Restore(new("mysolution.sln", "mypackages", false));
+            var res = dotnet.Restore(new("mysolution.sln", "mypackages", false, []));
 
             // Verify
             var lastArgs = dotnetCliInvoker.GetLastArgs();
-            Assert.Equal("restore --no-dependencies \"mysolution.sln\" --packages \"mypackages\" /p:DisableImplicitNuGetFallbackFolder=true --verbosity normal", lastArgs);
+            Assert.Equal(["restore", "--no-dependencies", "mysolution.sln", "--packages", "mypackages", "/p:DisableImplicitNuGetFallbackFolder=true", "--verbosity", "normal"], lastArgs);
             Assert.Equal(2, res.RestoredProjects.Count());
             Assert.Contains("/path/to/project.csproj", res.RestoredProjects);
             Assert.Contains("/path/to/project2.csproj", res.RestoredProjects);
@@ -188,11 +188,11 @@ namespace Semmle.Extraction.Tests
             dotnetCliInvoker.Success = false;
 
             // Execute
-            var res = dotnet.Restore(new("mysolution.sln", "mypackages", false));
+            var res = dotnet.Restore(new("mysolution.sln", "mypackages", false, []));
 
             // Verify
             var lastArgs = dotnetCliInvoker.GetLastArgs();
-            Assert.Equal("restore --no-dependencies \"mysolution.sln\" --packages \"mypackages\" /p:DisableImplicitNuGetFallbackFolder=true --verbosity normal", lastArgs);
+            Assert.Equal(["restore", "--no-dependencies", "mysolution.sln", "--packages", "mypackages", "/p:DisableImplicitNuGetFallbackFolder=true", "--verbosity", "normal"], lastArgs);
             Assert.Empty(res.RestoredProjects);
             Assert.Empty(res.AssetsFilePaths);
         }
@@ -209,7 +209,7 @@ namespace Semmle.Extraction.Tests
 
             // Verify
             var lastArgs = dotnetCliInvoker.GetLastArgs();
-            Assert.Equal("new console --no-restore --output \"myfolder\"", lastArgs);
+            Assert.Equal(["new", "console", "--no-restore", "--output", "myfolder"], lastArgs);
         }
 
         [Fact]
@@ -224,7 +224,7 @@ namespace Semmle.Extraction.Tests
 
             // Verify
             var lastArgs = dotnetCliInvoker.GetLastArgs();
-            Assert.Equal("add \"myfolder\" package \"mypackage\" --no-restore", lastArgs);
+            Assert.Equal(["add", "myfolder", "package", "mypackage", "--no-restore"], lastArgs);
         }
 
         [Fact]
@@ -239,7 +239,7 @@ namespace Semmle.Extraction.Tests
 
             // Verify
             var lastArgs = dotnetCliInvoker.GetLastArgs();
-            Assert.Equal("--list-runtimes", lastArgs);
+            Assert.Equal(["--list-runtimes"], lastArgs);
             Assert.Equal(2, runtimes.Count);
             Assert.Contains("Microsoft.AspNetCore.App 7.0.2 [/path/dotnet/shared/Microsoft.AspNetCore.App]", runtimes);
             Assert.Contains("Microsoft.NETCore.App 7.0.2 [/path/dotnet/shared/Microsoft.NETCore.App]", runtimes);
@@ -258,7 +258,7 @@ namespace Semmle.Extraction.Tests
 
             // Verify
             var lastArgs = dotnetCliInvoker.GetLastArgs();
-            Assert.Equal("--list-runtimes", lastArgs);
+            Assert.Equal(["--list-runtimes"], lastArgs);
             Assert.Empty(runtimes);
         }
 
@@ -270,11 +270,11 @@ namespace Semmle.Extraction.Tests
             var dotnet = MakeDotnet(dotnetCliInvoker);
 
             // Execute
-            dotnet.Exec("myarg1 myarg2");
+            dotnet.Exec(["myarg1", "myarg2"]);
 
             // Verify
             var lastArgs = dotnetCliInvoker.GetLastArgs();
-            Assert.Equal("exec myarg1 myarg2", lastArgs);
+            Assert.Equal(["exec", "myarg1", "myarg2"], lastArgs);
         }
 
         [Fact]
@@ -289,7 +289,7 @@ namespace Semmle.Extraction.Tests
 
             // Verify
             var lastArgs = dotnetCliInvoker.GetLastArgs();
-            Assert.Equal("nuget list source --format Short --configfile \"abc\"", lastArgs);
+            Assert.Equal(["nuget", "list", "source", "--format", "Short", "--configfile", "abc"], lastArgs);
         }
 
         [Fact]
@@ -304,7 +304,7 @@ namespace Semmle.Extraction.Tests
 
             // Verify
             var lastArgs = dotnetCliInvoker.GetLastArgs();
-            Assert.Equal("nuget list source --format Short", lastArgs);
+            Assert.Equal(["nuget", "list", "source", "--format", "Short"], lastArgs);
             Assert.Equal("abc", dotnetCliInvoker.WorkingDirectory);
         }
     }

--- a/csharp/extractor/Semmle.Extraction.Tests/Runtime.cs
+++ b/csharp/extractor/Semmle.Extraction.Tests/Runtime.cs
@@ -25,7 +25,7 @@ namespace Semmle.Extraction.Tests
 
         public IList<string> GetListedSdks() => sdks;
 
-        public bool Exec(string execArgs) => true;
+        public bool Exec(List<string> execArgs) => true;
 
         public IList<string> GetNugetFeeds(string nugetConfig) => [];
 


### PR DESCRIPTION
Instead of escaping/quoting of arguments when we invoke `dotnet` in the dependency manager, we should rely on the built-in support in `ProcessStartInfo`. That is, we should supply the arguments to the call via `ArgumentList` instead of `Arguments` (documentation can be seen [here](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.processstartinfo.argumentlist?view=net-10.0)).

DCA looks good.

Also ran QA (note - this is only internally visible for GitHub), which showed significant extraction regressions for some repos (among others the `dotnet/project-system`). However, Iattempted to do the extraction locally and didn't observe a similar regression. Will run QA again just to make sure.
- Issue with link to dashboard that shows regressions can be seen [here](https://github.com/github/codeql-qa-ops/issues/432).
- Issue with link to dashboard that doesn't show any regressions can be seen [here](https://github.com/github/codeql-qa-ops/issues/433). It is worth noting that baseline variant failed to execute in several thousand repositories. However, from the "Run list" we can see that `vsvim/vsvim`, `dotnet/project-system`, `microsoft/nodejstools` and `microsoft/ptvs` succeeded in both variants and the execution times are similar (these were the outliers in the first QA run).