### PR TITLE
Python: fix shared CFG exception-handler reachability

### DIFF
--- a/python/ql/lib/semmle/python/controlflow/internal/AstNodeImpl.qll
+++ b/python/ql/lib/semmle/python/controlflow/internal/AstNodeImpl.qll
@@ -1635,12 +1635,15 @@ private module Input implements InputSig1, InputSig2 {
    * its normal evaluation (not via an explicit `raise`/`assert`, which are
    * modeled separately).
    *
-   * The set mirrors what the legacy CFG used to flag implicitly: function
+   * `TypeError` is intentionally excluded along with exceptions thrown by dunder
+   * implementations to avoid cluttering the CFG; we expect user code to catch
+   * these only rarely.
+   *
+   * Otherwise, the set mirrors what the legacy CFG used to flag implicitly: function
    * calls (anything can raise), attribute access (`AttributeError`),
-   * subscript access (`IndexError`/`KeyError`/`TypeError`), arithmetic and
-   * comparison operators (`TypeError`/`ZeroDivisionError`), imports
+   * subscript access (`IndexError`/`KeyError`), division (`ZeroDivisionError`), imports
    * (`ImportError`/`ModuleNotFoundError`), and generator/coroutine
-   * suspension points (`await`/`yield`/`yield from`).
+   * suspension points (`await`/`yield`/`yield from` throwing `CancelledError` or `GeneratorExit`).
    *
    * Bare `Name` reads are intentionally excluded — modeling every name
    * read as `mayThrow` would explode CFG edge count for negligible
@@ -1654,11 +1657,7 @@ private module Input implements InputSig1, InputSig2 {
     or
     e instanceof Py::Subscript
     or
-    e instanceof Py::BinaryExpr
-    or
-    e instanceof Py::UnaryExpr
-    or
-    e instanceof Py::Compare
+    e instanceof Py::BinaryExpr and e.(Py::BinaryExpr).getOp() instanceof Py::Div
     or
     e instanceof Py::ImportExpr
     or

--- a/python/ql/lib/semmle/python/controlflow/internal/AstNodeImpl.qll
+++ b/python/ql/lib/semmle/python/controlflow/internal/AstNodeImpl.qll
@@ -1724,7 +1724,7 @@ private module Input implements InputSig1, InputSig2 {
     always = true
     or
     mayThrow(ast) and
-    n.isIn(ast) and
+    n.injects(ast) and
     c.asSimpleAbruptCompletion() instanceof ExceptionSuccessor and
     always = false
   }

--- a/python/ql/lib/semmle/python/controlflow/internal/AstNodeImpl.qll
+++ b/python/ql/lib/semmle/python/controlflow/internal/AstNodeImpl.qll
@@ -1657,7 +1657,7 @@ private module Input implements InputSig1, InputSig2 {
     or
     e instanceof Py::Subscript
     or
-    e instanceof Py::BinaryExpr and e.(Py::BinaryExpr).getOp() instanceof Py::Div
+    e.(Py::BinaryExpr).getOp() instanceof Py::Div
     or
     e instanceof Py::ImportExpr
     or

--- a/python/ql/lib/semmle/python/controlflow/internal/AstNodeImpl.qll
+++ b/python/ql/lib/semmle/python/controlflow/internal/AstNodeImpl.qll
@@ -1626,6 +1626,8 @@ private module Input implements InputSig1, InputSig2 {
     n = any(Ast::AssertStmt a).getTest()
   }
 
+  predicate postOrInOrder(Ast::AstNode n) { mayThrow(n) }
+
   private string assertThrowTag() { result = "[assert-throw]" }
 
   /**
@@ -1724,7 +1726,7 @@ private module Input implements InputSig1, InputSig2 {
     always = true
     or
     mayThrow(ast) and
-    n.injects(ast) and
+    n.isIn(ast) and
     c.asSimpleAbruptCompletion() instanceof ExceptionSuccessor and
     always = false
   }

--- a/python/ql/test/library-tests/ControlFlow/shared-cfg-exceptions/ExceptionReachabilityTest.ql
+++ b/python/ql/test/library-tests/ControlFlow/shared-cfg-exceptions/ExceptionReachabilityTest.ql
@@ -1,0 +1,29 @@
+/**
+ * Inline-expectations test for exception-handler reachability in the shared CFG.
+ */
+
+import python
+import semmle.python.controlflow.internal.AstNodeImpl as CfgImpl
+import semmle.python.controlflow.internal.Cfg as Cfg
+import utils.test.InlineExpectationsTest
+
+module ExceptionReachabilityTest implements TestSig {
+  string getARelevantTag() { result = "exception-handler" }
+
+  predicate hasActualResult(Location location, string element, string tag, string value) {
+    exists(
+      Expr source, ExceptStmt handler, Cfg::ControlFlowNode sourceCfg,
+      Cfg::ControlFlowNode handlerEntry
+    |
+      sourceCfg.getNode() = source and
+      handlerEntry = sourceCfg.getAnExceptionalSuccessor() and
+      CfgImpl::astNodeToPyNode(handlerEntry.getAstNode()) = handler and
+      location = source.getLocation() and
+      element = source.toString() and
+      tag = "exception-handler" and
+      value = handler.getType().toString()
+    )
+  }
+}
+
+import MakeTest<ExceptionReachabilityTest>

--- a/python/ql/test/library-tests/ControlFlow/shared-cfg-exceptions/test.py
+++ b/python/ql/test/library-tests/ControlFlow/shared-cfg-exceptions/test.py
@@ -1,12 +1,12 @@
 def generator():
     try:
-        yield  # $ MISSING: exception-handler=GeneratorExit
+        yield  # $ exception-handler=GeneratorExit
     except GeneratorExit:
         return
 
 
 def load_module():
     try:
-        import unavailable_module  # $ MISSING: exception-handler=ImportError
+        import unavailable_module  # $ exception-handler=ImportError
     except ImportError:
         return None

--- a/python/ql/test/library-tests/ControlFlow/shared-cfg-exceptions/test.py
+++ b/python/ql/test/library-tests/ControlFlow/shared-cfg-exceptions/test.py
@@ -1,0 +1,12 @@
+def generator():
+    try:
+        yield  # $ MISSING: exception-handler=GeneratorExit
+    except GeneratorExit:
+        return
+
+
+def load_module():
+    try:
+        import unavailable_module  # $ MISSING: exception-handler=ImportError
+    except ImportError:
+        return None


### PR DESCRIPTION
## Summary

Fixes exception-handler reachability in the shared Python CFG introduced by #21921 and now present on `main`. Testing the dataflow switch-over in #21925 surfaced the bug.

Leaf expressions that may throw, including bare `yield` and plain imports, were not always connected to typed exception-handler entries. The fix uses the canonical shared-CFG `injects` mapping when starting exceptional completion, so these expressions reach the appropriate catch entry.

## Tests

Adds focused inline coverage for:

- bare `yield` reaching a `GeneratorExit` handler;
- a plain import reaching an `ImportError` handler.

## DCA impact

The switch-over DCA in [#38556](https://github.com/github/codeql-dca-main/issues/38556) exposed effects of the missing exception edges in mypy, CPython, and youtube-dl. Restoring these edges recovers the affected catch reachability and downstream flow.

## Validation

- `codeql test run python/ql/test/library-tests/ControlFlow/shared-cfg-exceptions`
- `codeql query format --check-only python/ql/test/library-tests/ControlFlow/shared-cfg-exceptions/ExceptionReachabilityTest.ql`
