### PR TITLE
Rust: Update supported-frameworks.rst and add a few more native-tls models

### DIFF
--- a/docs/codeql/reusables/supported-frameworks.rst
+++ b/docs/codeql/reusables/supported-frameworks.rst
@@ -327,6 +327,7 @@ and the CodeQL library pack ``codeql/rust-all`` (`changelog <https://github.com/
    `actix-web <https://crates.io/crates/actix-web>`__, Web framework
    alloc, Standard library
    `async-std <https://crates.io/crates/async-std>`__, Asynchronous programming library
+   `axum <https://crates.io/crates/axum>`__, Web framework
    `biscotti <https://crates.io/crates/biscotti>`__, Cookie management
    `clap <http://crates.io/crates/clap>`__, Utility library
    `cookie <https://crates.io/crates/cookie>`__, Cookie management
@@ -341,6 +342,8 @@ and the CodeQL library pack ``codeql/rust-all`` (`changelog <https://github.com/
    `memchr <https://crates.io/crates/memchr>`__, Utility library
    `mysql <https://crates.io/crates/mysql>`__, Database
    `mysql_async <https://crates.io/crates/mysql_async>`__, Database
+   `native-tls <https://crates.io/crates/native-tls>`__, Network communicator
+   `async-native-tls <https://crates.io/crates/async-native-tls>`__, Network communicator
    `once_cell <https://crates.io/crates/once_cell>`__, Utility library
    `poem <https://crates.io/crates/poem>`__, Web framework
    `postgres <https://crates.io/crates/postgres>`__, Database

--- a/rust/ql/lib/change-notes/2026-08-19-native-tls-summary-models.md
+++ b/rust/ql/lib/change-notes/2026-08-19-native-tls-summary-models.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added new flow summary models for the `native-tls`, `async-native-tls`, and `tokio-native-tls` crates.

--- a/rust/ql/lib/codeql/rust/frameworks/native-tls.model.yml
+++ b/rust/ql/lib/codeql/rust/frameworks/native-tls.model.yml
@@ -7,3 +7,11 @@ extensions:
       - ["<native_tls::TlsConnectorBuilder>::danger_accept_invalid_hostnames", "Argument[0]", "disable-certificate", "manual"]
       - ["<async_native_tls::connect::TlsConnector>::danger_accept_invalid_certs", "Argument[0]", "disable-certificate", "manual"]
       - ["<async_native_tls::connect::TlsConnector>::danger_accept_invalid_hostnames", "Argument[0]", "disable-certificate", "manual"]
+  - addsTo:
+      pack: codeql/rust-all
+      extensible: summaryModel
+    data:
+      - ["<native_tls::TlsConnector>::connect", "Argument[1]", "ReturnValue.Field[core::result::Result::Ok(0)]", "taint", "manual"]
+      - ["<async_native_tls::connect::TlsConnector>::connect", "Argument[1]", "ReturnValue.Future.Field[core::result::Result::Ok(0)]", "taint", "manual"]
+      - ["async_native_tls::connect", "Argument[1]", "ReturnValue.Future.Field[core::result::Result::Ok(0)]", "taint", "manual"]
+      - ["<tokio_native_tls::TlsConnector>::connect", "Argument[1]", "ReturnValue.Future.Field[core::result::Result::Ok(0)]", "taint", "manual"]

--- a/rust/ql/test/library-tests/dataflow/sources/net/Cargo.lock
+++ b/rust/ql/test/library-tests/dataflow/sources/net/Cargo.lock
@@ -1558,6 +1558,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
+ "native-tls",
  "reqwest",
  "rustls",
  "tokio",

--- a/rust/ql/test/library-tests/dataflow/sources/net/InlineFlow.expected
+++ b/rust/ql/test/library-tests/dataflow/sources/net/InlineFlow.expected
@@ -32,47 +32,48 @@ models
 | 31 | Summary: <http::response::Response>::body; Argument[self].Reference.Field[http::response::Response::body]; ReturnValue.Reference; value |
 | 32 | Summary: <http::response::Response>::body_mut; Argument[self].Reference.Field[http::response::Response::body]; ReturnValue.Reference; value |
 | 33 | Summary: <http::response::Response>::into_body; Argument[self].Field[http::response::Response::body]; ReturnValue; value |
-| 34 | Summary: <reqwest::async_impl::response::Response>::bytes; Argument[self]; ReturnValue.Future.Field[core::result::Result::Ok(0)]; taint |
-| 35 | Summary: <reqwest::async_impl::response::Response>::chunk; Argument[self].Reference; ReturnValue.Future.Field[core::result::Result::Ok(0)].Field[core::option::Option::Some(0)]; taint |
-| 36 | Summary: <reqwest::async_impl::response::Response>::text; Argument[self]; ReturnValue.Future.Field[core::result::Result::Ok(0)]; taint |
-| 37 | Summary: <reqwest::blocking::response::Response>::bytes; Argument[self]; ReturnValue.Field[core::result::Result::Ok(0)]; taint |
-| 38 | Summary: <reqwest::blocking::response::Response>::text; Argument[self]; ReturnValue.Field[core::result::Result::Ok(0)]; taint |
-| 39 | Summary: <reqwest::blocking::response::Response>::text_with_charset; Argument[self]; ReturnValue.Field[core::result::Result::Ok(0)]; taint |
-| 40 | Summary: <std::io::buffered::bufreader::BufReader>::new; Argument[0]; ReturnValue; taint |
-| 41 | Summary: <std::net::tcp::TcpStream>::try_clone; Argument[self].Reference; ReturnValue.Field[core::result::Result::Ok(0)]; taint |
-| 42 | Summary: <tokio::net::tcp::stream::TcpStream>::peek; Argument[self].Reference; Argument[0].Reference; taint |
-| 43 | Summary: <tokio::net::tcp::stream::TcpStream>::try_read; Argument[self].Reference; Argument[0].Reference; taint |
-| 44 | Summary: <tokio::net::tcp::stream::TcpStream>::try_read_buf; Argument[self].Reference; Argument[0].Reference; taint |
+| 34 | Summary: <native_tls::TlsConnector>::connect; Argument[1]; ReturnValue.Field[core::result::Result::Ok(0)]; taint |
+| 35 | Summary: <reqwest::async_impl::response::Response>::bytes; Argument[self]; ReturnValue.Future.Field[core::result::Result::Ok(0)]; taint |
+| 36 | Summary: <reqwest::async_impl::response::Response>::chunk; Argument[self].Reference; ReturnValue.Future.Field[core::result::Result::Ok(0)].Field[core::option::Option::Some(0)]; taint |
+| 37 | Summary: <reqwest::async_impl::response::Response>::text; Argument[self]; ReturnValue.Future.Field[core::result::Result::Ok(0)]; taint |
+| 38 | Summary: <reqwest::blocking::response::Response>::bytes; Argument[self]; ReturnValue.Field[core::result::Result::Ok(0)]; taint |
+| 39 | Summary: <reqwest::blocking::response::Response>::text; Argument[self]; ReturnValue.Field[core::result::Result::Ok(0)]; taint |
+| 40 | Summary: <reqwest::blocking::response::Response>::text_with_charset; Argument[self]; ReturnValue.Field[core::result::Result::Ok(0)]; taint |
+| 41 | Summary: <std::io::buffered::bufreader::BufReader>::new; Argument[0]; ReturnValue; taint |
+| 42 | Summary: <std::net::tcp::TcpStream>::try_clone; Argument[self].Reference; ReturnValue.Field[core::result::Result::Ok(0)]; taint |
+| 43 | Summary: <tokio::net::tcp::stream::TcpStream>::peek; Argument[self].Reference; Argument[0].Reference; taint |
+| 44 | Summary: <tokio::net::tcp::stream::TcpStream>::try_read; Argument[self].Reference; Argument[0].Reference; taint |
+| 45 | Summary: <tokio::net::tcp::stream::TcpStream>::try_read_buf; Argument[self].Reference; Argument[0].Reference; taint |
 edges
 | test.rs:11:9:11:22 | remote_string1 | test.rs:12:10:12:23 | remote_string1 | provenance |  |
 | test.rs:11:26:11:62 | ...::get(...) | test.rs:11:26:11:62 | ...::get(...) [Ok] | provenance | Src:MaD:7  |
 | test.rs:11:26:11:62 | ...::get(...) [Ok] | test.rs:11:26:11:63 | TryExpr | provenance |  |
-| test.rs:11:26:11:63 | TryExpr | test.rs:11:26:11:70 | ... .text() [Ok] | provenance | MaD:38 |
+| test.rs:11:26:11:63 | TryExpr | test.rs:11:26:11:70 | ... .text() [Ok] | provenance | MaD:39 |
 | test.rs:11:26:11:70 | ... .text() [Ok] | test.rs:11:26:11:71 | TryExpr | provenance |  |
 | test.rs:11:26:11:71 | TryExpr | test.rs:11:9:11:22 | remote_string1 | provenance |  |
 | test.rs:14:9:14:22 | remote_string2 | test.rs:15:10:15:23 | remote_string2 | provenance |  |
 | test.rs:14:26:14:62 | ...::get(...) | test.rs:14:26:14:62 | ...::get(...) [Ok] | provenance | Src:MaD:7  |
 | test.rs:14:26:14:62 | ...::get(...) [Ok] | test.rs:14:26:14:71 | ... .unwrap() | provenance | MaD:28 |
-| test.rs:14:26:14:71 | ... .unwrap() | test.rs:14:26:14:78 | ... .text() [Ok] | provenance | MaD:38 |
+| test.rs:14:26:14:71 | ... .unwrap() | test.rs:14:26:14:78 | ... .text() [Ok] | provenance | MaD:39 |
 | test.rs:14:26:14:78 | ... .text() [Ok] | test.rs:14:26:14:87 | ... .unwrap() | provenance | MaD:28 |
 | test.rs:14:26:14:87 | ... .unwrap() | test.rs:14:9:14:22 | remote_string2 | provenance |  |
 | test.rs:17:9:17:22 | remote_string3 | test.rs:18:10:18:23 | remote_string3 | provenance |  |
 | test.rs:17:26:17:62 | ...::get(...) | test.rs:17:26:17:62 | ...::get(...) [Ok] | provenance | Src:MaD:7  |
 | test.rs:17:26:17:62 | ...::get(...) [Ok] | test.rs:17:26:17:71 | ... .unwrap() | provenance | MaD:28 |
-| test.rs:17:26:17:71 | ... .unwrap() | test.rs:17:26:17:98 | ... .text_with_charset(...) [Ok] | provenance | MaD:39 |
+| test.rs:17:26:17:71 | ... .unwrap() | test.rs:17:26:17:98 | ... .text_with_charset(...) [Ok] | provenance | MaD:40 |
 | test.rs:17:26:17:98 | ... .text_with_charset(...) [Ok] | test.rs:17:26:17:107 | ... .unwrap() | provenance | MaD:28 |
 | test.rs:17:26:17:107 | ... .unwrap() | test.rs:17:9:17:22 | remote_string3 | provenance |  |
 | test.rs:20:9:20:22 | remote_string4 | test.rs:21:10:21:23 | remote_string4 | provenance |  |
 | test.rs:20:26:20:62 | ...::get(...) | test.rs:20:26:20:62 | ...::get(...) [Ok] | provenance | Src:MaD:7  |
 | test.rs:20:26:20:62 | ...::get(...) [Ok] | test.rs:20:26:20:71 | ... .unwrap() | provenance | MaD:28 |
-| test.rs:20:26:20:71 | ... .unwrap() | test.rs:20:26:20:79 | ... .bytes() [Ok] | provenance | MaD:37 |
+| test.rs:20:26:20:71 | ... .unwrap() | test.rs:20:26:20:79 | ... .bytes() [Ok] | provenance | MaD:38 |
 | test.rs:20:26:20:79 | ... .bytes() [Ok] | test.rs:20:26:20:88 | ... .unwrap() | provenance | MaD:28 |
 | test.rs:20:26:20:88 | ... .unwrap() | test.rs:20:9:20:22 | remote_string4 | provenance |  |
 | test.rs:23:9:23:22 | remote_string5 | test.rs:24:10:24:23 | remote_string5 | provenance |  |
 | test.rs:23:26:23:52 | ...::get(...) | test.rs:23:26:23:52 | ...::get(...) [future, Ok] | provenance | Src:MaD:8  |
 | test.rs:23:26:23:52 | ...::get(...) [future, Ok] | test.rs:23:26:23:58 | await ... [Ok] | provenance |  |
 | test.rs:23:26:23:58 | await ... [Ok] | test.rs:23:26:23:59 | TryExpr | provenance |  |
-| test.rs:23:26:23:59 | TryExpr | test.rs:23:26:23:66 | ... .text() [future, Ok] | provenance | MaD:36 |
+| test.rs:23:26:23:59 | TryExpr | test.rs:23:26:23:66 | ... .text() [future, Ok] | provenance | MaD:37 |
 | test.rs:23:26:23:66 | ... .text() [future, Ok] | test.rs:23:26:23:72 | await ... [Ok] | provenance |  |
 | test.rs:23:26:23:72 | await ... [Ok] | test.rs:23:26:23:73 | TryExpr | provenance |  |
 | test.rs:23:26:23:73 | TryExpr | test.rs:23:9:23:22 | remote_string5 | provenance |  |
@@ -80,7 +81,7 @@ edges
 | test.rs:26:26:26:52 | ...::get(...) | test.rs:26:26:26:52 | ...::get(...) [future, Ok] | provenance | Src:MaD:8  |
 | test.rs:26:26:26:52 | ...::get(...) [future, Ok] | test.rs:26:26:26:58 | await ... [Ok] | provenance |  |
 | test.rs:26:26:26:58 | await ... [Ok] | test.rs:26:26:26:59 | TryExpr | provenance |  |
-| test.rs:26:26:26:59 | TryExpr | test.rs:26:26:26:67 | ... .bytes() [future, Ok] | provenance | MaD:34 |
+| test.rs:26:26:26:59 | TryExpr | test.rs:26:26:26:67 | ... .bytes() [future, Ok] | provenance | MaD:35 |
 | test.rs:26:26:26:67 | ... .bytes() [future, Ok] | test.rs:26:26:26:73 | await ... [Ok] | provenance |  |
 | test.rs:26:26:26:73 | await ... [Ok] | test.rs:26:26:26:74 | TryExpr | provenance |  |
 | test.rs:26:26:26:74 | TryExpr | test.rs:26:9:26:22 | remote_string6 | provenance |  |
@@ -90,13 +91,13 @@ edges
 | test.rs:29:24:29:50 | ...::get(...) [future, Ok] | test.rs:29:24:29:56 | await ... [Ok] | provenance |  |
 | test.rs:29:24:29:56 | await ... [Ok] | test.rs:29:24:29:57 | TryExpr | provenance |  |
 | test.rs:29:24:29:57 | TryExpr | test.rs:29:9:29:20 | mut request1 | provenance |  |
-| test.rs:30:10:30:17 | request1 | test.rs:30:10:30:25 | request1.chunk() [future, Ok, Some] | provenance | MaD:35 |
+| test.rs:30:10:30:17 | request1 | test.rs:30:10:30:25 | request1.chunk() [future, Ok, Some] | provenance | MaD:36 |
 | test.rs:30:10:30:25 | request1.chunk() [future, Ok, Some] | test.rs:30:10:30:31 | await ... [Ok, Some] | provenance |  |
 | test.rs:30:10:30:31 | await ... [Ok, Some] | test.rs:30:10:30:32 | TryExpr [Some] | provenance |  |
 | test.rs:30:10:30:32 | TryExpr [Some] | test.rs:30:10:30:41 | ... .unwrap() | provenance | MaD:25 |
 | test.rs:31:15:31:25 | Some(...) [Some] | test.rs:31:20:31:24 | chunk | provenance |  |
 | test.rs:31:20:31:24 | chunk | test.rs:32:14:32:18 | chunk | provenance |  |
-| test.rs:31:29:31:36 | request1 | test.rs:31:29:31:44 | request1.chunk() [future, Ok, Some] | provenance | MaD:35 |
+| test.rs:31:29:31:36 | request1 | test.rs:31:29:31:44 | request1.chunk() [future, Ok, Some] | provenance | MaD:36 |
 | test.rs:31:29:31:44 | request1.chunk() [future, Ok, Some] | test.rs:31:29:31:50 | await ... [Ok, Some] | provenance |  |
 | test.rs:31:29:31:50 | await ... [Ok, Some] | test.rs:31:29:31:51 | TryExpr [Some] | provenance |  |
 | test.rs:31:29:31:51 | TryExpr [Some] | test.rs:31:15:31:25 | Some(...) [Some] | provenance |  |
@@ -140,7 +141,7 @@ edges
 | test.rs:182:21:182:30 | mut reader | test.rs:185:27:185:32 | reader | provenance |  |
 | test.rs:182:34:182:64 | ...::new(...) | test.rs:182:34:182:74 | ... .take(...) | provenance | MaD:23 |
 | test.rs:182:34:182:74 | ... .take(...) | test.rs:182:21:182:30 | mut reader | provenance |  |
-| test.rs:182:58:182:63 | stream | test.rs:182:34:182:64 | ...::new(...) | provenance | MaD:40 |
+| test.rs:182:58:182:63 | stream | test.rs:182:34:182:64 | ...::new(...) | provenance | MaD:41 |
 | test.rs:185:27:185:32 | reader | test.rs:185:44:185:52 | [post] &mut line [&ref] | provenance | MaD:19 |
 | test.rs:185:44:185:52 | [post] &mut line [&ref] | test.rs:185:49:185:52 | [post] line | provenance |  |
 | test.rs:185:49:185:52 | [post] line | test.rs:192:35:192:38 | line | provenance |  |
@@ -148,9 +149,9 @@ edges
 | test.rs:203:21:203:26 | reader | test.rs:204:29:204:34 | reader | provenance |  |
 | test.rs:203:30:203:73 | ...::new(...) | test.rs:203:30:203:83 | ... .take(...) | provenance | MaD:23 |
 | test.rs:203:30:203:83 | ... .take(...) | test.rs:203:21:203:26 | reader | provenance |  |
-| test.rs:203:54:203:59 | stream | test.rs:203:54:203:71 | stream.try_clone() [Ok] | provenance | MaD:41 |
+| test.rs:203:54:203:59 | stream | test.rs:203:54:203:71 | stream.try_clone() [Ok] | provenance | MaD:42 |
 | test.rs:203:54:203:71 | stream.try_clone() [Ok] | test.rs:203:54:203:72 | TryExpr | provenance |  |
-| test.rs:203:54:203:72 | TryExpr | test.rs:203:30:203:73 | ...::new(...) | provenance | MaD:40 |
+| test.rs:203:54:203:72 | TryExpr | test.rs:203:30:203:73 | ...::new(...) | provenance | MaD:41 |
 | test.rs:204:29:204:34 | reader | test.rs:204:29:204:42 | reader.lines() | provenance | MaD:18 |
 | test.rs:204:29:204:42 | reader.lines() | test.rs:205:28:205:37 | Ok(...) | provenance |  |
 | test.rs:205:28:205:37 | Ok(...) | test.rs:207:30:207:35 | string | provenance |  |
@@ -162,7 +163,7 @@ edges
 | test.rs:224:28:224:66 | ...::connect(...) [future, Ok] | test.rs:224:28:224:72 | await ... [Ok] | provenance |  |
 | test.rs:224:28:224:72 | await ... [Ok] | test.rs:224:28:224:73 | TryExpr | provenance |  |
 | test.rs:224:28:224:73 | TryExpr | test.rs:224:9:224:24 | mut tokio_stream | provenance |  |
-| test.rs:232:17:232:28 | tokio_stream | test.rs:232:35:232:46 | [post] &mut buffer1 [&ref] | provenance | MaD:42 |
+| test.rs:232:17:232:28 | tokio_stream | test.rs:232:35:232:46 | [post] &mut buffer1 [&ref] | provenance | MaD:43 |
 | test.rs:232:35:232:46 | [post] &mut buffer1 [&ref] | test.rs:232:40:232:46 | [post] buffer1 | provenance |  |
 | test.rs:232:40:232:46 | [post] buffer1 | test.rs:239:15:239:21 | buffer1 | provenance |  |
 | test.rs:232:40:232:46 | [post] buffer1 | test.rs:240:14:240:20 | buffer1 | provenance |  |
@@ -174,11 +175,11 @@ edges
 | test.rs:240:14:240:20 | buffer1 | test.rs:240:14:240:23 | buffer1[0] | provenance | MaD:10 |
 | test.rs:243:15:243:21 | buffer2 | test.rs:243:14:243:21 | &buffer2 | provenance |  |
 | test.rs:244:14:244:20 | buffer2 | test.rs:244:14:244:23 | buffer2[0] | provenance | MaD:10 |
-| test.rs:252:19:252:30 | tokio_stream | test.rs:252:41:252:51 | [post] &mut buffer [&ref] | provenance | MaD:43 |
+| test.rs:252:19:252:30 | tokio_stream | test.rs:252:41:252:51 | [post] &mut buffer [&ref] | provenance | MaD:44 |
 | test.rs:252:41:252:51 | [post] &mut buffer [&ref] | test.rs:252:46:252:51 | [post] buffer | provenance |  |
 | test.rs:252:46:252:51 | [post] buffer | test.rs:259:27:259:32 | buffer | provenance |  |
 | test.rs:259:27:259:32 | buffer | test.rs:259:26:259:32 | &buffer | provenance |  |
-| test.rs:275:19:275:30 | tokio_stream | test.rs:275:45:275:55 | [post] &mut buffer [&ref] | provenance | MaD:44 |
+| test.rs:275:19:275:30 | tokio_stream | test.rs:275:45:275:55 | [post] &mut buffer [&ref] | provenance | MaD:45 |
 | test.rs:275:45:275:55 | [post] &mut buffer [&ref] | test.rs:275:50:275:55 | [post] buffer | provenance |  |
 | test.rs:275:50:275:55 | [post] buffer | test.rs:282:27:282:32 | buffer | provenance |  |
 | test.rs:282:27:282:32 | buffer | test.rs:282:26:282:32 | &buffer | provenance |  |
@@ -205,6 +206,26 @@ edges
 | test.rs:350:44:350:54 | [post] &mut buffer [&ref] | test.rs:350:49:350:54 | [post] buffer | provenance |  |
 | test.rs:350:49:350:54 | [post] buffer | test.rs:351:15:351:20 | buffer | provenance |  |
 | test.rs:351:15:351:20 | buffer | test.rs:351:14:351:20 | &buffer | provenance |  |
+| test.rs:359:9:359:14 | stream | test.rs:361:59:361:64 | stream | provenance |  |
+| test.rs:359:18:359:54 | ...::connect(...) | test.rs:359:18:359:54 | ...::connect(...) [Ok] | provenance | Src:MaD:4  |
+| test.rs:359:18:359:54 | ...::connect(...) [Ok] | test.rs:359:18:359:55 | TryExpr | provenance |  |
+| test.rs:359:18:359:55 | TryExpr | test.rs:359:9:359:14 | stream | provenance |  |
+| test.rs:361:9:361:18 | mut stream | test.rs:362:11:362:16 | stream | provenance |  |
+| test.rs:361:9:361:18 | mut stream | test.rs:367:22:367:27 | stream | provenance |  |
+| test.rs:361:9:361:18 | mut stream | test.rs:373:5:373:10 | stream | provenance |  |
+| test.rs:361:22:361:65 | connector.connect(...) [Ok] | test.rs:361:22:361:66 | TryExpr | provenance |  |
+| test.rs:361:22:361:66 | TryExpr | test.rs:361:9:361:18 | mut stream | provenance |  |
+| test.rs:361:59:361:64 | stream | test.rs:361:22:361:65 | connector.connect(...) [Ok] | provenance | MaD:34 |
+| test.rs:362:11:362:16 | stream | test.rs:362:10:362:16 | &stream | provenance |  |
+| test.rs:367:22:367:27 | stream | test.rs:367:34:367:44 | [post] &mut buffer [&ref] | provenance | MaD:20 |
+| test.rs:367:34:367:44 | [post] &mut buffer [&ref] | test.rs:367:39:367:44 | [post] buffer | provenance |  |
+| test.rs:367:39:367:44 | [post] buffer | test.rs:370:11:370:16 | buffer | provenance |  |
+| test.rs:367:39:367:44 | [post] buffer | test.rs:370:11:370:30 | buffer[...] | provenance |  |
+| test.rs:370:11:370:16 | buffer | test.rs:370:11:370:30 | buffer[...] | provenance | MaD:10 |
+| test.rs:370:11:370:30 | buffer[...] | test.rs:370:10:370:30 | &... | provenance |  |
+| test.rs:373:5:373:10 | stream | test.rs:373:27:373:39 | [post] &mut response [&ref] | provenance | MaD:22 |
+| test.rs:373:27:373:39 | [post] &mut response [&ref] | test.rs:373:32:373:39 | [post] response | provenance |  |
+| test.rs:373:32:373:39 | [post] response | test.rs:375:10:375:17 | response | provenance |  |
 | test.rs:396:13:396:15 | tcp | test.rs:397:15:397:17 | tcp | provenance |  |
 | test.rs:396:13:396:15 | tcp | test.rs:403:57:403:59 | tcp | provenance |  |
 | test.rs:396:19:396:41 | ...::connect(...) | test.rs:396:19:396:41 | ...::connect(...) [future, Ok] | provenance | Src:MaD:1  |
@@ -543,6 +564,26 @@ nodes
 | test.rs:350:49:350:54 | [post] buffer | semmle.label | [post] buffer |
 | test.rs:351:14:351:20 | &buffer | semmle.label | &buffer |
 | test.rs:351:15:351:20 | buffer | semmle.label | buffer |
+| test.rs:359:9:359:14 | stream | semmle.label | stream |
+| test.rs:359:18:359:54 | ...::connect(...) | semmle.label | ...::connect(...) |
+| test.rs:359:18:359:54 | ...::connect(...) [Ok] | semmle.label | ...::connect(...) [Ok] |
+| test.rs:359:18:359:55 | TryExpr | semmle.label | TryExpr |
+| test.rs:361:9:361:18 | mut stream | semmle.label | mut stream |
+| test.rs:361:22:361:65 | connector.connect(...) [Ok] | semmle.label | connector.connect(...) [Ok] |
+| test.rs:361:22:361:66 | TryExpr | semmle.label | TryExpr |
+| test.rs:361:59:361:64 | stream | semmle.label | stream |
+| test.rs:362:10:362:16 | &stream | semmle.label | &stream |
+| test.rs:362:11:362:16 | stream | semmle.label | stream |
+| test.rs:367:22:367:27 | stream | semmle.label | stream |
+| test.rs:367:34:367:44 | [post] &mut buffer [&ref] | semmle.label | [post] &mut buffer [&ref] |
+| test.rs:367:39:367:44 | [post] buffer | semmle.label | [post] buffer |
+| test.rs:370:10:370:30 | &... | semmle.label | &... |
+| test.rs:370:11:370:16 | buffer | semmle.label | buffer |
+| test.rs:370:11:370:30 | buffer[...] | semmle.label | buffer[...] |
+| test.rs:373:5:373:10 | stream | semmle.label | stream |
+| test.rs:373:27:373:39 | [post] &mut response [&ref] | semmle.label | [post] &mut response [&ref] |
+| test.rs:373:32:373:39 | [post] response | semmle.label | [post] response |
+| test.rs:375:10:375:17 | response | semmle.label | response |
 | test.rs:396:13:396:15 | tcp | semmle.label | tcp |
 | test.rs:396:19:396:41 | ...::connect(...) | semmle.label | ...::connect(...) |
 | test.rs:396:19:396:41 | ...::connect(...) [future, Ok] | semmle.label | ...::connect(...) [future, Ok] |
@@ -728,6 +769,9 @@ testFailures
 | test.rs:339:14:339:20 | &buffer | test.rs:332:22:332:75 | ...::new(...) | test.rs:339:14:339:20 | &buffer | $@ | test.rs:332:22:332:75 | ...::new(...) | ...::new(...) |
 | test.rs:345:14:345:20 | &buffer | test.rs:332:22:332:75 | ...::new(...) | test.rs:345:14:345:20 | &buffer | $@ | test.rs:332:22:332:75 | ...::new(...) | ...::new(...) |
 | test.rs:351:14:351:20 | &buffer | test.rs:332:22:332:75 | ...::new(...) | test.rs:351:14:351:20 | &buffer | $@ | test.rs:332:22:332:75 | ...::new(...) | ...::new(...) |
+| test.rs:362:10:362:16 | &stream | test.rs:359:18:359:54 | ...::connect(...) | test.rs:362:10:362:16 | &stream | $@ | test.rs:359:18:359:54 | ...::connect(...) | ...::connect(...) |
+| test.rs:370:10:370:30 | &... | test.rs:359:18:359:54 | ...::connect(...) | test.rs:370:10:370:30 | &... | $@ | test.rs:359:18:359:54 | ...::connect(...) | ...::connect(...) |
+| test.rs:375:10:375:17 | response | test.rs:359:18:359:54 | ...::connect(...) | test.rs:375:10:375:17 | response | $@ | test.rs:359:18:359:54 | ...::connect(...) | ...::connect(...) |
 | test.rs:397:14:397:17 | &tcp | test.rs:396:19:396:41 | ...::connect(...) | test.rs:397:14:397:17 | &tcp | $@ | test.rs:396:19:396:41 | ...::connect(...) | ...::connect(...) |
 | test.rs:404:14:404:20 | &reader | test.rs:396:19:396:41 | ...::connect(...) | test.rs:404:14:404:20 | &reader | $@ | test.rs:396:19:396:41 | ...::connect(...) | ...::connect(...) |
 | test.rs:410:18:410:24 | &pinned | test.rs:396:19:396:41 | ...::connect(...) | test.rs:410:18:410:24 | &pinned | $@ | test.rs:396:19:396:41 | ...::connect(...) | ...::connect(...) |

--- a/rust/ql/test/library-tests/dataflow/sources/net/InlineFlow.expected
+++ b/rust/ql/test/library-tests/dataflow/sources/net/InlineFlow.expected
@@ -205,136 +205,105 @@ edges
 | test.rs:350:44:350:54 | [post] &mut buffer [&ref] | test.rs:350:49:350:54 | [post] buffer | provenance |  |
 | test.rs:350:49:350:54 | [post] buffer | test.rs:351:15:351:20 | buffer | provenance |  |
 | test.rs:351:15:351:20 | buffer | test.rs:351:14:351:20 | &buffer | provenance |  |
-| test.rs:373:13:373:15 | tcp | test.rs:374:15:374:17 | tcp | provenance |  |
-| test.rs:373:13:373:15 | tcp | test.rs:380:57:380:59 | tcp | provenance |  |
-| test.rs:373:19:373:41 | ...::connect(...) | test.rs:373:19:373:41 | ...::connect(...) [future, Ok] | provenance | Src:MaD:1  |
-| test.rs:373:19:373:41 | ...::connect(...) [future, Ok] | test.rs:373:19:373:47 | await ... [Ok] | provenance |  |
-| test.rs:373:19:373:47 | await ... [Ok] | test.rs:373:19:373:48 | TryExpr | provenance |  |
-| test.rs:373:19:373:48 | TryExpr | test.rs:373:13:373:15 | tcp | provenance |  |
-| test.rs:374:15:374:17 | tcp | test.rs:374:14:374:17 | &tcp | provenance |  |
-| test.rs:380:13:380:22 | mut reader | test.rs:381:15:381:20 | reader | provenance |  |
-| test.rs:380:13:380:22 | mut reader | test.rs:386:44:386:49 | reader | provenance |  |
-| test.rs:380:13:380:22 | mut reader | test.rs:399:68:399:73 | reader | provenance |  |
-| test.rs:380:13:380:22 | mut reader | test.rs:403:31:403:36 | reader | provenance |  |
-| test.rs:380:13:380:22 | mut reader | test.rs:408:55:408:60 | reader | provenance |  |
-| test.rs:380:26:380:60 | connector.connect(...) [future, Ok] | test.rs:380:26:380:66 | await ... [Ok] | provenance |  |
-| test.rs:380:26:380:66 | await ... [Ok] | test.rs:380:26:380:67 | TryExpr | provenance |  |
-| test.rs:380:26:380:67 | TryExpr | test.rs:380:13:380:22 | mut reader | provenance |  |
-| test.rs:380:57:380:59 | tcp | test.rs:380:26:380:60 | connector.connect(...) [future, Ok] | provenance | MaD:29 |
-| test.rs:381:15:381:20 | reader | test.rs:381:14:381:20 | &reader | provenance |  |
-| test.rs:386:17:386:26 | mut pinned | test.rs:387:19:387:24 | pinned | provenance |  |
-| test.rs:386:17:386:26 | mut pinned | test.rs:389:30:389:35 | pinned | provenance |  |
-| test.rs:386:17:386:26 | mut pinned [Pin, &ref] | test.rs:387:19:387:24 | pinned [Pin, &ref] | provenance |  |
-| test.rs:386:30:386:50 | ...::new(...) | test.rs:386:17:386:26 | mut pinned | provenance |  |
-| test.rs:386:30:386:50 | ...::new(...) [Pin, &ref] | test.rs:386:17:386:26 | mut pinned [Pin, &ref] | provenance |  |
-| test.rs:386:39:386:49 | &mut reader [&ref] | test.rs:386:30:386:50 | ...::new(...) | provenance | MaD:26 |
-| test.rs:386:39:386:49 | &mut reader [&ref] | test.rs:386:30:386:50 | ...::new(...) [Pin, &ref] | provenance | MaD:27 |
-| test.rs:386:44:386:49 | reader | test.rs:386:39:386:49 | &mut reader [&ref] | provenance |  |
-| test.rs:387:19:387:24 | pinned | test.rs:387:18:387:24 | &pinned | provenance |  |
-| test.rs:387:19:387:24 | pinned [Pin, &ref] | test.rs:387:18:387:24 | &pinned | provenance |  |
-| test.rs:389:30:389:35 | pinned | test.rs:389:56:389:66 | [post] &mut buffer [&ref] | provenance | MaD:12 |
-| test.rs:389:56:389:66 | [post] &mut buffer [&ref] | test.rs:389:61:389:66 | [post] buffer | provenance |  |
-| test.rs:389:61:389:66 | [post] buffer | test.rs:391:23:391:28 | buffer | provenance |  |
-| test.rs:389:61:389:66 | [post] buffer | test.rs:392:23:392:28 | buffer | provenance |  |
-| test.rs:389:61:389:66 | [post] buffer | test.rs:392:23:392:33 | buffer[...] | provenance |  |
-| test.rs:391:23:391:28 | buffer | test.rs:391:22:391:28 | &buffer | provenance |  |
-| test.rs:392:23:392:28 | buffer | test.rs:392:23:392:33 | buffer[...] | provenance | MaD:10 |
-| test.rs:392:23:392:33 | buffer[...] | test.rs:392:22:392:33 | &... | provenance |  |
-| test.rs:399:63:399:73 | &mut reader [&ref] | test.rs:399:76:399:87 | [post] &mut buffer1 [&ref] | provenance | MaD:16 |
-| test.rs:399:68:399:73 | reader | test.rs:399:63:399:73 | &mut reader [&ref] | provenance |  |
-| test.rs:399:76:399:87 | [post] &mut buffer1 [&ref] | test.rs:399:81:399:87 | [post] buffer1 | provenance |  |
-| test.rs:399:81:399:87 | [post] buffer1 | test.rs:400:19:400:25 | buffer1 | provenance |  |
-| test.rs:399:81:399:87 | [post] buffer1 | test.rs:400:19:400:40 | buffer1[...] | provenance |  |
-| test.rs:400:19:400:25 | buffer1 | test.rs:400:19:400:40 | buffer1[...] | provenance | MaD:10 |
-| test.rs:400:19:400:40 | buffer1[...] | test.rs:400:18:400:40 | &... | provenance |  |
-| test.rs:403:31:403:36 | reader | test.rs:403:43:403:54 | [post] &mut buffer2 [&ref] | provenance | MaD:16 |
-| test.rs:403:43:403:54 | [post] &mut buffer2 [&ref] | test.rs:403:48:403:54 | [post] buffer2 | provenance |  |
-| test.rs:403:48:403:54 | [post] buffer2 | test.rs:405:19:405:25 | buffer2 | provenance |  |
-| test.rs:403:48:403:54 | [post] buffer2 | test.rs:405:19:405:40 | buffer2[...] | provenance |  |
-| test.rs:405:19:405:25 | buffer2 | test.rs:405:19:405:40 | buffer2[...] | provenance | MaD:10 |
-| test.rs:405:19:405:40 | buffer2[...] | test.rs:405:18:405:40 | &... | provenance |  |
-| test.rs:408:13:408:23 | mut reader2 | test.rs:409:15:409:21 | reader2 | provenance |  |
-| test.rs:408:13:408:23 | mut reader2 | test.rs:413:44:413:50 | reader2 | provenance |  |
-| test.rs:408:13:408:23 | mut reader2 | test.rs:423:41:423:47 | reader2 | provenance |  |
-| test.rs:408:13:408:23 | mut reader2 | test.rs:437:26:437:32 | reader2 | provenance |  |
-| test.rs:408:13:408:23 | mut reader2 | test.rs:444:44:444:50 | reader2 | provenance |  |
-| test.rs:408:13:408:23 | mut reader2 | test.rs:457:68:457:74 | reader2 | provenance |  |
-| test.rs:408:13:408:23 | mut reader2 | test.rs:461:31:461:37 | reader2 | provenance |  |
-| test.rs:408:13:408:23 | mut reader2 | test.rs:467:44:467:50 | reader2 | provenance |  |
-| test.rs:408:13:408:23 | mut reader2 | test.rs:479:26:479:32 | reader2 | provenance |  |
-| test.rs:408:13:408:23 | mut reader2 | test.rs:486:31:486:37 | reader2 | provenance |  |
-| test.rs:408:13:408:23 | mut reader2 | test.rs:493:31:493:37 | reader2 | provenance |  |
-| test.rs:408:13:408:23 | mut reader2 | test.rs:500:31:500:37 | reader2 | provenance |  |
-| test.rs:408:27:408:61 | ...::new(...) | test.rs:408:13:408:23 | mut reader2 | provenance |  |
-| test.rs:408:55:408:60 | reader | test.rs:408:27:408:61 | ...::new(...) | provenance | MaD:30 |
-| test.rs:409:15:409:21 | reader2 | test.rs:409:14:409:21 | &reader2 | provenance |  |
-| test.rs:413:17:413:26 | mut pinned | test.rs:414:19:414:24 | pinned | provenance |  |
-| test.rs:413:17:413:26 | mut pinned | test.rs:416:26:416:31 | pinned | provenance |  |
-| test.rs:413:17:413:26 | mut pinned [Pin, &ref] | test.rs:414:19:414:24 | pinned [Pin, &ref] | provenance |  |
-| test.rs:413:30:413:51 | ...::new(...) | test.rs:413:17:413:26 | mut pinned | provenance |  |
-| test.rs:413:30:413:51 | ...::new(...) [Pin, &ref] | test.rs:413:17:413:26 | mut pinned [Pin, &ref] | provenance |  |
-| test.rs:413:39:413:50 | &mut reader2 [&ref] | test.rs:413:30:413:51 | ...::new(...) | provenance | MaD:26 |
-| test.rs:413:39:413:50 | &mut reader2 [&ref] | test.rs:413:30:413:51 | ...::new(...) [Pin, &ref] | provenance | MaD:27 |
-| test.rs:413:44:413:50 | reader2 | test.rs:413:39:413:50 | &mut reader2 [&ref] | provenance |  |
-| test.rs:414:19:414:24 | pinned | test.rs:414:18:414:24 | &pinned | provenance |  |
-| test.rs:414:19:414:24 | pinned [Pin, &ref] | test.rs:414:18:414:24 | &pinned | provenance |  |
-| test.rs:416:17:416:22 | buffer [Ready, Ok] | test.rs:417:20:417:39 | ...::Ready(...) [Ready, Ok] | provenance |  |
-| test.rs:416:17:416:22 | buffer [Ready, Ok] | test.rs:418:23:418:28 | buffer [Ready, Ok] | provenance |  |
-| test.rs:416:26:416:31 | pinned | test.rs:416:26:416:54 | pinned.poll_fill_buf(...) [Ready, Ok] | provenance | MaD:11 |
-| test.rs:416:26:416:54 | pinned.poll_fill_buf(...) [Ready, Ok] | test.rs:416:17:416:22 | buffer [Ready, Ok] | provenance |  |
-| test.rs:417:20:417:39 | ...::Ready(...) [Ready, Ok] | test.rs:417:32:417:38 | Ok(...) [Ok] | provenance |  |
-| test.rs:417:32:417:38 | Ok(...) [Ok] | test.rs:417:35:417:37 | buf | provenance |  |
-| test.rs:417:35:417:37 | buf | test.rs:419:22:419:24 | buf | provenance |  |
-| test.rs:418:23:418:28 | buffer [Ready, Ok] | test.rs:418:22:418:28 | &buffer | provenance |  |
-| test.rs:423:17:423:23 | buffer2 [Ready, Ok] | test.rs:424:20:424:26 | buffer2 [Ready, Ok] | provenance |  |
-| test.rs:423:27:423:48 | ...::new(...) | test.rs:423:27:423:71 | ... .poll_fill_buf(...) [Ready, Ok] | provenance | MaD:11 |
-| test.rs:423:27:423:71 | ... .poll_fill_buf(...) [Ready, Ok] | test.rs:423:17:423:23 | buffer2 [Ready, Ok] | provenance |  |
-| test.rs:423:36:423:47 | &mut reader2 [&ref] | test.rs:423:27:423:48 | ...::new(...) | provenance | MaD:26 |
-| test.rs:423:41:423:47 | reader2 | test.rs:423:36:423:47 | &mut reader2 [&ref] | provenance |  |
-| test.rs:424:20:424:26 | buffer2 [Ready, Ok] | test.rs:425:17:425:36 | ...::Ready(...) [Ready, Ok] | provenance |  |
-| test.rs:424:20:424:26 | buffer2 [Ready, Ok] | test.rs:426:27:426:33 | buffer2 [Ready, Ok] | provenance |  |
-| test.rs:425:17:425:36 | ...::Ready(...) [Ready, Ok] | test.rs:425:29:425:35 | Ok(...) [Ok] | provenance |  |
-| test.rs:425:29:425:35 | Ok(...) [Ok] | test.rs:425:32:425:34 | buf | provenance |  |
-| test.rs:425:32:425:34 | buf | test.rs:427:26:427:28 | buf | provenance |  |
-| test.rs:426:27:426:33 | buffer2 [Ready, Ok] | test.rs:426:26:426:33 | &buffer2 | provenance |  |
-| test.rs:437:17:437:22 | buffer | test.rs:438:18:438:23 | buffer | provenance |  |
-| test.rs:437:26:437:32 | reader2 | test.rs:437:26:437:43 | reader2.fill_buf() [future, Ok] | provenance | MaD:13 |
-| test.rs:437:26:437:43 | reader2.fill_buf() [future, Ok] | test.rs:437:26:437:49 | await ... [Ok] | provenance |  |
-| test.rs:437:26:437:49 | await ... [Ok] | test.rs:437:26:437:50 | TryExpr | provenance |  |
-| test.rs:437:26:437:50 | TryExpr | test.rs:437:17:437:22 | buffer | provenance |  |
-| test.rs:444:17:444:26 | mut pinned | test.rs:445:19:445:24 | pinned | provenance |  |
-| test.rs:444:17:444:26 | mut pinned | test.rs:447:30:447:35 | pinned | provenance |  |
-| test.rs:444:17:444:26 | mut pinned [Pin, &ref] | test.rs:445:19:445:24 | pinned [Pin, &ref] | provenance |  |
-| test.rs:444:30:444:51 | ...::new(...) | test.rs:444:17:444:26 | mut pinned | provenance |  |
-| test.rs:444:30:444:51 | ...::new(...) [Pin, &ref] | test.rs:444:17:444:26 | mut pinned [Pin, &ref] | provenance |  |
-| test.rs:444:39:444:50 | &mut reader2 [&ref] | test.rs:444:30:444:51 | ...::new(...) | provenance | MaD:26 |
-| test.rs:444:39:444:50 | &mut reader2 [&ref] | test.rs:444:30:444:51 | ...::new(...) [Pin, &ref] | provenance | MaD:27 |
-| test.rs:444:44:444:50 | reader2 | test.rs:444:39:444:50 | &mut reader2 [&ref] | provenance |  |
-| test.rs:445:19:445:24 | pinned | test.rs:445:18:445:24 | &pinned | provenance |  |
-| test.rs:445:19:445:24 | pinned [Pin, &ref] | test.rs:445:18:445:24 | &pinned | provenance |  |
-| test.rs:447:30:447:35 | pinned | test.rs:447:56:447:66 | [post] &mut buffer [&ref] | provenance | MaD:12 |
-| test.rs:447:56:447:66 | [post] &mut buffer [&ref] | test.rs:447:61:447:66 | [post] buffer | provenance |  |
-| test.rs:447:61:447:66 | [post] buffer | test.rs:448:19:448:24 | buffer | provenance |  |
-| test.rs:447:61:447:66 | [post] buffer | test.rs:450:23:450:28 | buffer | provenance |  |
-| test.rs:447:61:447:66 | [post] buffer | test.rs:450:23:450:33 | buffer[...] | provenance |  |
-| test.rs:448:19:448:24 | buffer | test.rs:448:18:448:24 | &buffer | provenance |  |
-| test.rs:450:23:450:28 | buffer | test.rs:450:23:450:33 | buffer[...] | provenance | MaD:10 |
-| test.rs:450:23:450:33 | buffer[...] | test.rs:450:22:450:33 | &... | provenance |  |
-| test.rs:457:63:457:74 | &mut reader2 [&ref] | test.rs:457:77:457:88 | [post] &mut buffer1 [&ref] | provenance | MaD:16 |
-| test.rs:457:68:457:74 | reader2 | test.rs:457:63:457:74 | &mut reader2 [&ref] | provenance |  |
-| test.rs:457:77:457:88 | [post] &mut buffer1 [&ref] | test.rs:457:82:457:88 | [post] buffer1 | provenance |  |
-| test.rs:457:82:457:88 | [post] buffer1 | test.rs:458:19:458:25 | buffer1 | provenance |  |
-| test.rs:457:82:457:88 | [post] buffer1 | test.rs:458:19:458:40 | buffer1[...] | provenance |  |
-| test.rs:458:19:458:25 | buffer1 | test.rs:458:19:458:40 | buffer1[...] | provenance | MaD:10 |
-| test.rs:458:19:458:40 | buffer1[...] | test.rs:458:18:458:40 | &... | provenance |  |
-| test.rs:461:31:461:37 | reader2 | test.rs:461:44:461:55 | [post] &mut buffer2 [&ref] | provenance | MaD:16 |
-| test.rs:461:44:461:55 | [post] &mut buffer2 [&ref] | test.rs:461:49:461:55 | [post] buffer2 | provenance |  |
-| test.rs:461:49:461:55 | [post] buffer2 | test.rs:462:19:462:25 | buffer2 | provenance |  |
-| test.rs:461:49:461:55 | [post] buffer2 | test.rs:462:19:462:40 | buffer2[...] | provenance |  |
-| test.rs:462:19:462:25 | buffer2 | test.rs:462:19:462:40 | buffer2[...] | provenance | MaD:10 |
-| test.rs:462:19:462:40 | buffer2[...] | test.rs:462:18:462:40 | &... | provenance |  |
+| test.rs:396:13:396:15 | tcp | test.rs:397:15:397:17 | tcp | provenance |  |
+| test.rs:396:13:396:15 | tcp | test.rs:403:57:403:59 | tcp | provenance |  |
+| test.rs:396:19:396:41 | ...::connect(...) | test.rs:396:19:396:41 | ...::connect(...) [future, Ok] | provenance | Src:MaD:1  |
+| test.rs:396:19:396:41 | ...::connect(...) [future, Ok] | test.rs:396:19:396:47 | await ... [Ok] | provenance |  |
+| test.rs:396:19:396:47 | await ... [Ok] | test.rs:396:19:396:48 | TryExpr | provenance |  |
+| test.rs:396:19:396:48 | TryExpr | test.rs:396:13:396:15 | tcp | provenance |  |
+| test.rs:397:15:397:17 | tcp | test.rs:397:14:397:17 | &tcp | provenance |  |
+| test.rs:403:13:403:22 | mut reader | test.rs:404:15:404:20 | reader | provenance |  |
+| test.rs:403:13:403:22 | mut reader | test.rs:409:44:409:49 | reader | provenance |  |
+| test.rs:403:13:403:22 | mut reader | test.rs:422:68:422:73 | reader | provenance |  |
+| test.rs:403:13:403:22 | mut reader | test.rs:426:31:426:36 | reader | provenance |  |
+| test.rs:403:13:403:22 | mut reader | test.rs:431:55:431:60 | reader | provenance |  |
+| test.rs:403:26:403:60 | connector.connect(...) [future, Ok] | test.rs:403:26:403:66 | await ... [Ok] | provenance |  |
+| test.rs:403:26:403:66 | await ... [Ok] | test.rs:403:26:403:67 | TryExpr | provenance |  |
+| test.rs:403:26:403:67 | TryExpr | test.rs:403:13:403:22 | mut reader | provenance |  |
+| test.rs:403:57:403:59 | tcp | test.rs:403:26:403:60 | connector.connect(...) [future, Ok] | provenance | MaD:29 |
+| test.rs:404:15:404:20 | reader | test.rs:404:14:404:20 | &reader | provenance |  |
+| test.rs:409:17:409:26 | mut pinned | test.rs:410:19:410:24 | pinned | provenance |  |
+| test.rs:409:17:409:26 | mut pinned | test.rs:412:30:412:35 | pinned | provenance |  |
+| test.rs:409:17:409:26 | mut pinned [Pin, &ref] | test.rs:410:19:410:24 | pinned [Pin, &ref] | provenance |  |
+| test.rs:409:30:409:50 | ...::new(...) | test.rs:409:17:409:26 | mut pinned | provenance |  |
+| test.rs:409:30:409:50 | ...::new(...) [Pin, &ref] | test.rs:409:17:409:26 | mut pinned [Pin, &ref] | provenance |  |
+| test.rs:409:39:409:49 | &mut reader [&ref] | test.rs:409:30:409:50 | ...::new(...) | provenance | MaD:26 |
+| test.rs:409:39:409:49 | &mut reader [&ref] | test.rs:409:30:409:50 | ...::new(...) [Pin, &ref] | provenance | MaD:27 |
+| test.rs:409:44:409:49 | reader | test.rs:409:39:409:49 | &mut reader [&ref] | provenance |  |
+| test.rs:410:19:410:24 | pinned | test.rs:410:18:410:24 | &pinned | provenance |  |
+| test.rs:410:19:410:24 | pinned [Pin, &ref] | test.rs:410:18:410:24 | &pinned | provenance |  |
+| test.rs:412:30:412:35 | pinned | test.rs:412:56:412:66 | [post] &mut buffer [&ref] | provenance | MaD:12 |
+| test.rs:412:56:412:66 | [post] &mut buffer [&ref] | test.rs:412:61:412:66 | [post] buffer | provenance |  |
+| test.rs:412:61:412:66 | [post] buffer | test.rs:414:23:414:28 | buffer | provenance |  |
+| test.rs:412:61:412:66 | [post] buffer | test.rs:415:23:415:28 | buffer | provenance |  |
+| test.rs:412:61:412:66 | [post] buffer | test.rs:415:23:415:33 | buffer[...] | provenance |  |
+| test.rs:414:23:414:28 | buffer | test.rs:414:22:414:28 | &buffer | provenance |  |
+| test.rs:415:23:415:28 | buffer | test.rs:415:23:415:33 | buffer[...] | provenance | MaD:10 |
+| test.rs:415:23:415:33 | buffer[...] | test.rs:415:22:415:33 | &... | provenance |  |
+| test.rs:422:63:422:73 | &mut reader [&ref] | test.rs:422:76:422:87 | [post] &mut buffer1 [&ref] | provenance | MaD:16 |
+| test.rs:422:68:422:73 | reader | test.rs:422:63:422:73 | &mut reader [&ref] | provenance |  |
+| test.rs:422:76:422:87 | [post] &mut buffer1 [&ref] | test.rs:422:81:422:87 | [post] buffer1 | provenance |  |
+| test.rs:422:81:422:87 | [post] buffer1 | test.rs:423:19:423:25 | buffer1 | provenance |  |
+| test.rs:422:81:422:87 | [post] buffer1 | test.rs:423:19:423:40 | buffer1[...] | provenance |  |
+| test.rs:423:19:423:25 | buffer1 | test.rs:423:19:423:40 | buffer1[...] | provenance | MaD:10 |
+| test.rs:423:19:423:40 | buffer1[...] | test.rs:423:18:423:40 | &... | provenance |  |
+| test.rs:426:31:426:36 | reader | test.rs:426:43:426:54 | [post] &mut buffer2 [&ref] | provenance | MaD:16 |
+| test.rs:426:43:426:54 | [post] &mut buffer2 [&ref] | test.rs:426:48:426:54 | [post] buffer2 | provenance |  |
+| test.rs:426:48:426:54 | [post] buffer2 | test.rs:428:19:428:25 | buffer2 | provenance |  |
+| test.rs:426:48:426:54 | [post] buffer2 | test.rs:428:19:428:40 | buffer2[...] | provenance |  |
+| test.rs:428:19:428:25 | buffer2 | test.rs:428:19:428:40 | buffer2[...] | provenance | MaD:10 |
+| test.rs:428:19:428:40 | buffer2[...] | test.rs:428:18:428:40 | &... | provenance |  |
+| test.rs:431:13:431:23 | mut reader2 | test.rs:432:15:432:21 | reader2 | provenance |  |
+| test.rs:431:13:431:23 | mut reader2 | test.rs:436:44:436:50 | reader2 | provenance |  |
+| test.rs:431:13:431:23 | mut reader2 | test.rs:446:41:446:47 | reader2 | provenance |  |
+| test.rs:431:13:431:23 | mut reader2 | test.rs:460:26:460:32 | reader2 | provenance |  |
+| test.rs:431:13:431:23 | mut reader2 | test.rs:467:44:467:50 | reader2 | provenance |  |
+| test.rs:431:13:431:23 | mut reader2 | test.rs:480:68:480:74 | reader2 | provenance |  |
+| test.rs:431:13:431:23 | mut reader2 | test.rs:484:31:484:37 | reader2 | provenance |  |
+| test.rs:431:13:431:23 | mut reader2 | test.rs:490:44:490:50 | reader2 | provenance |  |
+| test.rs:431:13:431:23 | mut reader2 | test.rs:502:26:502:32 | reader2 | provenance |  |
+| test.rs:431:13:431:23 | mut reader2 | test.rs:509:31:509:37 | reader2 | provenance |  |
+| test.rs:431:13:431:23 | mut reader2 | test.rs:516:31:516:37 | reader2 | provenance |  |
+| test.rs:431:13:431:23 | mut reader2 | test.rs:523:31:523:37 | reader2 | provenance |  |
+| test.rs:431:27:431:61 | ...::new(...) | test.rs:431:13:431:23 | mut reader2 | provenance |  |
+| test.rs:431:55:431:60 | reader | test.rs:431:27:431:61 | ...::new(...) | provenance | MaD:30 |
+| test.rs:432:15:432:21 | reader2 | test.rs:432:14:432:21 | &reader2 | provenance |  |
+| test.rs:436:17:436:26 | mut pinned | test.rs:437:19:437:24 | pinned | provenance |  |
+| test.rs:436:17:436:26 | mut pinned | test.rs:439:26:439:31 | pinned | provenance |  |
+| test.rs:436:17:436:26 | mut pinned [Pin, &ref] | test.rs:437:19:437:24 | pinned [Pin, &ref] | provenance |  |
+| test.rs:436:30:436:51 | ...::new(...) | test.rs:436:17:436:26 | mut pinned | provenance |  |
+| test.rs:436:30:436:51 | ...::new(...) [Pin, &ref] | test.rs:436:17:436:26 | mut pinned [Pin, &ref] | provenance |  |
+| test.rs:436:39:436:50 | &mut reader2 [&ref] | test.rs:436:30:436:51 | ...::new(...) | provenance | MaD:26 |
+| test.rs:436:39:436:50 | &mut reader2 [&ref] | test.rs:436:30:436:51 | ...::new(...) [Pin, &ref] | provenance | MaD:27 |
+| test.rs:436:44:436:50 | reader2 | test.rs:436:39:436:50 | &mut reader2 [&ref] | provenance |  |
+| test.rs:437:19:437:24 | pinned | test.rs:437:18:437:24 | &pinned | provenance |  |
+| test.rs:437:19:437:24 | pinned [Pin, &ref] | test.rs:437:18:437:24 | &pinned | provenance |  |
+| test.rs:439:17:439:22 | buffer [Ready, Ok] | test.rs:440:20:440:39 | ...::Ready(...) [Ready, Ok] | provenance |  |
+| test.rs:439:17:439:22 | buffer [Ready, Ok] | test.rs:441:23:441:28 | buffer [Ready, Ok] | provenance |  |
+| test.rs:439:26:439:31 | pinned | test.rs:439:26:439:54 | pinned.poll_fill_buf(...) [Ready, Ok] | provenance | MaD:11 |
+| test.rs:439:26:439:54 | pinned.poll_fill_buf(...) [Ready, Ok] | test.rs:439:17:439:22 | buffer [Ready, Ok] | provenance |  |
+| test.rs:440:20:440:39 | ...::Ready(...) [Ready, Ok] | test.rs:440:32:440:38 | Ok(...) [Ok] | provenance |  |
+| test.rs:440:32:440:38 | Ok(...) [Ok] | test.rs:440:35:440:37 | buf | provenance |  |
+| test.rs:440:35:440:37 | buf | test.rs:442:22:442:24 | buf | provenance |  |
+| test.rs:441:23:441:28 | buffer [Ready, Ok] | test.rs:441:22:441:28 | &buffer | provenance |  |
+| test.rs:446:17:446:23 | buffer2 [Ready, Ok] | test.rs:447:20:447:26 | buffer2 [Ready, Ok] | provenance |  |
+| test.rs:446:27:446:48 | ...::new(...) | test.rs:446:27:446:71 | ... .poll_fill_buf(...) [Ready, Ok] | provenance | MaD:11 |
+| test.rs:446:27:446:71 | ... .poll_fill_buf(...) [Ready, Ok] | test.rs:446:17:446:23 | buffer2 [Ready, Ok] | provenance |  |
+| test.rs:446:36:446:47 | &mut reader2 [&ref] | test.rs:446:27:446:48 | ...::new(...) | provenance | MaD:26 |
+| test.rs:446:41:446:47 | reader2 | test.rs:446:36:446:47 | &mut reader2 [&ref] | provenance |  |
+| test.rs:447:20:447:26 | buffer2 [Ready, Ok] | test.rs:448:17:448:36 | ...::Ready(...) [Ready, Ok] | provenance |  |
+| test.rs:447:20:447:26 | buffer2 [Ready, Ok] | test.rs:449:27:449:33 | buffer2 [Ready, Ok] | provenance |  |
+| test.rs:448:17:448:36 | ...::Ready(...) [Ready, Ok] | test.rs:448:29:448:35 | Ok(...) [Ok] | provenance |  |
+| test.rs:448:29:448:35 | Ok(...) [Ok] | test.rs:448:32:448:34 | buf | provenance |  |
+| test.rs:448:32:448:34 | buf | test.rs:450:26:450:28 | buf | provenance |  |
+| test.rs:449:27:449:33 | buffer2 [Ready, Ok] | test.rs:449:26:449:33 | &buffer2 | provenance |  |
+| test.rs:460:17:460:22 | buffer | test.rs:461:18:461:23 | buffer | provenance |  |
+| test.rs:460:26:460:32 | reader2 | test.rs:460:26:460:43 | reader2.fill_buf() [future, Ok] | provenance | MaD:13 |
+| test.rs:460:26:460:43 | reader2.fill_buf() [future, Ok] | test.rs:460:26:460:49 | await ... [Ok] | provenance |  |
+| test.rs:460:26:460:49 | await ... [Ok] | test.rs:460:26:460:50 | TryExpr | provenance |  |
+| test.rs:460:26:460:50 | TryExpr | test.rs:460:17:460:22 | buffer | provenance |  |
 | test.rs:467:17:467:26 | mut pinned | test.rs:468:19:468:24 | pinned | provenance |  |
-| test.rs:467:17:467:26 | mut pinned | test.rs:470:26:470:31 | pinned | provenance |  |
+| test.rs:467:17:467:26 | mut pinned | test.rs:470:30:470:35 | pinned | provenance |  |
 | test.rs:467:17:467:26 | mut pinned [Pin, &ref] | test.rs:468:19:468:24 | pinned [Pin, &ref] | provenance |  |
 | test.rs:467:30:467:51 | ...::new(...) | test.rs:467:17:467:26 | mut pinned | provenance |  |
 | test.rs:467:30:467:51 | ...::new(...) [Pin, &ref] | test.rs:467:17:467:26 | mut pinned [Pin, &ref] | provenance |  |
@@ -343,31 +312,62 @@ edges
 | test.rs:467:44:467:50 | reader2 | test.rs:467:39:467:50 | &mut reader2 [&ref] | provenance |  |
 | test.rs:468:19:468:24 | pinned | test.rs:468:18:468:24 | &pinned | provenance |  |
 | test.rs:468:19:468:24 | pinned [Pin, &ref] | test.rs:468:18:468:24 | &pinned | provenance |  |
-| test.rs:470:17:470:22 | buffer [Ready, Ok] | test.rs:471:19:471:24 | buffer [Ready, Ok] | provenance |  |
-| test.rs:470:17:470:22 | buffer [Ready, Ok] | test.rs:472:20:472:39 | ...::Ready(...) [Ready, Ok] | provenance |  |
-| test.rs:470:26:470:31 | pinned | test.rs:470:26:470:54 | pinned.poll_fill_buf(...) [Ready, Ok] | provenance | MaD:11 |
-| test.rs:470:26:470:54 | pinned.poll_fill_buf(...) [Ready, Ok] | test.rs:470:17:470:22 | buffer [Ready, Ok] | provenance |  |
-| test.rs:471:19:471:24 | buffer [Ready, Ok] | test.rs:471:18:471:24 | &buffer | provenance |  |
-| test.rs:472:20:472:39 | ...::Ready(...) [Ready, Ok] | test.rs:472:32:472:38 | Ok(...) [Ok] | provenance |  |
-| test.rs:472:32:472:38 | Ok(...) [Ok] | test.rs:472:35:472:37 | buf | provenance |  |
-| test.rs:472:35:472:37 | buf | test.rs:473:22:473:24 | buf | provenance |  |
-| test.rs:479:17:479:22 | buffer | test.rs:480:18:480:23 | buffer | provenance |  |
-| test.rs:479:26:479:32 | reader2 | test.rs:479:26:479:43 | reader2.fill_buf() [future, Ok] | provenance | MaD:13 |
-| test.rs:479:26:479:43 | reader2.fill_buf() [future, Ok] | test.rs:479:26:479:49 | await ... [Ok] | provenance |  |
-| test.rs:479:26:479:49 | await ... [Ok] | test.rs:479:26:479:50 | TryExpr | provenance |  |
-| test.rs:479:26:479:50 | TryExpr | test.rs:479:17:479:22 | buffer | provenance |  |
-| test.rs:486:31:486:37 | reader2 | test.rs:486:57:486:65 | [post] &mut line [&ref] | provenance | MaD:15 |
-| test.rs:486:57:486:65 | [post] &mut line [&ref] | test.rs:486:62:486:65 | [post] line | provenance |  |
-| test.rs:486:62:486:65 | [post] line | test.rs:487:19:487:22 | line | provenance |  |
-| test.rs:487:19:487:22 | line | test.rs:487:18:487:22 | &line | provenance |  |
-| test.rs:493:31:493:37 | reader2 | test.rs:493:49:493:57 | [post] &mut line [&ref] | provenance | MaD:14 |
-| test.rs:493:49:493:57 | [post] &mut line [&ref] | test.rs:493:54:493:57 | [post] line | provenance |  |
-| test.rs:493:54:493:57 | [post] line | test.rs:494:19:494:22 | line | provenance |  |
-| test.rs:494:19:494:22 | line | test.rs:494:18:494:22 | &line | provenance |  |
-| test.rs:500:31:500:37 | reader2 | test.rs:500:51:500:61 | [post] &mut buffer [&ref] | provenance | MaD:17 |
-| test.rs:500:51:500:61 | [post] &mut buffer [&ref] | test.rs:500:56:500:61 | [post] buffer | provenance |  |
-| test.rs:500:56:500:61 | [post] buffer | test.rs:501:19:501:24 | buffer | provenance |  |
-| test.rs:501:19:501:24 | buffer | test.rs:501:18:501:24 | &buffer | provenance |  |
+| test.rs:470:30:470:35 | pinned | test.rs:470:56:470:66 | [post] &mut buffer [&ref] | provenance | MaD:12 |
+| test.rs:470:56:470:66 | [post] &mut buffer [&ref] | test.rs:470:61:470:66 | [post] buffer | provenance |  |
+| test.rs:470:61:470:66 | [post] buffer | test.rs:471:19:471:24 | buffer | provenance |  |
+| test.rs:470:61:470:66 | [post] buffer | test.rs:473:23:473:28 | buffer | provenance |  |
+| test.rs:470:61:470:66 | [post] buffer | test.rs:473:23:473:33 | buffer[...] | provenance |  |
+| test.rs:471:19:471:24 | buffer | test.rs:471:18:471:24 | &buffer | provenance |  |
+| test.rs:473:23:473:28 | buffer | test.rs:473:23:473:33 | buffer[...] | provenance | MaD:10 |
+| test.rs:473:23:473:33 | buffer[...] | test.rs:473:22:473:33 | &... | provenance |  |
+| test.rs:480:63:480:74 | &mut reader2 [&ref] | test.rs:480:77:480:88 | [post] &mut buffer1 [&ref] | provenance | MaD:16 |
+| test.rs:480:68:480:74 | reader2 | test.rs:480:63:480:74 | &mut reader2 [&ref] | provenance |  |
+| test.rs:480:77:480:88 | [post] &mut buffer1 [&ref] | test.rs:480:82:480:88 | [post] buffer1 | provenance |  |
+| test.rs:480:82:480:88 | [post] buffer1 | test.rs:481:19:481:25 | buffer1 | provenance |  |
+| test.rs:480:82:480:88 | [post] buffer1 | test.rs:481:19:481:40 | buffer1[...] | provenance |  |
+| test.rs:481:19:481:25 | buffer1 | test.rs:481:19:481:40 | buffer1[...] | provenance | MaD:10 |
+| test.rs:481:19:481:40 | buffer1[...] | test.rs:481:18:481:40 | &... | provenance |  |
+| test.rs:484:31:484:37 | reader2 | test.rs:484:44:484:55 | [post] &mut buffer2 [&ref] | provenance | MaD:16 |
+| test.rs:484:44:484:55 | [post] &mut buffer2 [&ref] | test.rs:484:49:484:55 | [post] buffer2 | provenance |  |
+| test.rs:484:49:484:55 | [post] buffer2 | test.rs:485:19:485:25 | buffer2 | provenance |  |
+| test.rs:484:49:484:55 | [post] buffer2 | test.rs:485:19:485:40 | buffer2[...] | provenance |  |
+| test.rs:485:19:485:25 | buffer2 | test.rs:485:19:485:40 | buffer2[...] | provenance | MaD:10 |
+| test.rs:485:19:485:40 | buffer2[...] | test.rs:485:18:485:40 | &... | provenance |  |
+| test.rs:490:17:490:26 | mut pinned | test.rs:491:19:491:24 | pinned | provenance |  |
+| test.rs:490:17:490:26 | mut pinned | test.rs:493:26:493:31 | pinned | provenance |  |
+| test.rs:490:17:490:26 | mut pinned [Pin, &ref] | test.rs:491:19:491:24 | pinned [Pin, &ref] | provenance |  |
+| test.rs:490:30:490:51 | ...::new(...) | test.rs:490:17:490:26 | mut pinned | provenance |  |
+| test.rs:490:30:490:51 | ...::new(...) [Pin, &ref] | test.rs:490:17:490:26 | mut pinned [Pin, &ref] | provenance |  |
+| test.rs:490:39:490:50 | &mut reader2 [&ref] | test.rs:490:30:490:51 | ...::new(...) | provenance | MaD:26 |
+| test.rs:490:39:490:50 | &mut reader2 [&ref] | test.rs:490:30:490:51 | ...::new(...) [Pin, &ref] | provenance | MaD:27 |
+| test.rs:490:44:490:50 | reader2 | test.rs:490:39:490:50 | &mut reader2 [&ref] | provenance |  |
+| test.rs:491:19:491:24 | pinned | test.rs:491:18:491:24 | &pinned | provenance |  |
+| test.rs:491:19:491:24 | pinned [Pin, &ref] | test.rs:491:18:491:24 | &pinned | provenance |  |
+| test.rs:493:17:493:22 | buffer [Ready, Ok] | test.rs:494:19:494:24 | buffer [Ready, Ok] | provenance |  |
+| test.rs:493:17:493:22 | buffer [Ready, Ok] | test.rs:495:20:495:39 | ...::Ready(...) [Ready, Ok] | provenance |  |
+| test.rs:493:26:493:31 | pinned | test.rs:493:26:493:54 | pinned.poll_fill_buf(...) [Ready, Ok] | provenance | MaD:11 |
+| test.rs:493:26:493:54 | pinned.poll_fill_buf(...) [Ready, Ok] | test.rs:493:17:493:22 | buffer [Ready, Ok] | provenance |  |
+| test.rs:494:19:494:24 | buffer [Ready, Ok] | test.rs:494:18:494:24 | &buffer | provenance |  |
+| test.rs:495:20:495:39 | ...::Ready(...) [Ready, Ok] | test.rs:495:32:495:38 | Ok(...) [Ok] | provenance |  |
+| test.rs:495:32:495:38 | Ok(...) [Ok] | test.rs:495:35:495:37 | buf | provenance |  |
+| test.rs:495:35:495:37 | buf | test.rs:496:22:496:24 | buf | provenance |  |
+| test.rs:502:17:502:22 | buffer | test.rs:503:18:503:23 | buffer | provenance |  |
+| test.rs:502:26:502:32 | reader2 | test.rs:502:26:502:43 | reader2.fill_buf() [future, Ok] | provenance | MaD:13 |
+| test.rs:502:26:502:43 | reader2.fill_buf() [future, Ok] | test.rs:502:26:502:49 | await ... [Ok] | provenance |  |
+| test.rs:502:26:502:49 | await ... [Ok] | test.rs:502:26:502:50 | TryExpr | provenance |  |
+| test.rs:502:26:502:50 | TryExpr | test.rs:502:17:502:22 | buffer | provenance |  |
+| test.rs:509:31:509:37 | reader2 | test.rs:509:57:509:65 | [post] &mut line [&ref] | provenance | MaD:15 |
+| test.rs:509:57:509:65 | [post] &mut line [&ref] | test.rs:509:62:509:65 | [post] line | provenance |  |
+| test.rs:509:62:509:65 | [post] line | test.rs:510:19:510:22 | line | provenance |  |
+| test.rs:510:19:510:22 | line | test.rs:510:18:510:22 | &line | provenance |  |
+| test.rs:516:31:516:37 | reader2 | test.rs:516:49:516:57 | [post] &mut line [&ref] | provenance | MaD:14 |
+| test.rs:516:49:516:57 | [post] &mut line [&ref] | test.rs:516:54:516:57 | [post] line | provenance |  |
+| test.rs:516:54:516:57 | [post] line | test.rs:517:19:517:22 | line | provenance |  |
+| test.rs:517:19:517:22 | line | test.rs:517:18:517:22 | &line | provenance |  |
+| test.rs:523:31:523:37 | reader2 | test.rs:523:51:523:61 | [post] &mut buffer [&ref] | provenance | MaD:17 |
+| test.rs:523:51:523:61 | [post] &mut buffer [&ref] | test.rs:523:56:523:61 | [post] buffer | provenance |  |
+| test.rs:523:56:523:61 | [post] buffer | test.rs:524:19:524:24 | buffer | provenance |  |
+| test.rs:524:19:524:24 | buffer | test.rs:524:18:524:24 | &buffer | provenance |  |
 nodes
 | test.rs:11:9:11:22 | remote_string1 | semmle.label | remote_string1 |
 | test.rs:11:26:11:62 | ...::get(...) | semmle.label | ...::get(...) |
@@ -543,121 +543,91 @@ nodes
 | test.rs:350:49:350:54 | [post] buffer | semmle.label | [post] buffer |
 | test.rs:351:14:351:20 | &buffer | semmle.label | &buffer |
 | test.rs:351:15:351:20 | buffer | semmle.label | buffer |
-| test.rs:373:13:373:15 | tcp | semmle.label | tcp |
-| test.rs:373:19:373:41 | ...::connect(...) | semmle.label | ...::connect(...) |
-| test.rs:373:19:373:41 | ...::connect(...) [future, Ok] | semmle.label | ...::connect(...) [future, Ok] |
-| test.rs:373:19:373:47 | await ... [Ok] | semmle.label | await ... [Ok] |
-| test.rs:373:19:373:48 | TryExpr | semmle.label | TryExpr |
-| test.rs:374:14:374:17 | &tcp | semmle.label | &tcp |
-| test.rs:374:15:374:17 | tcp | semmle.label | tcp |
-| test.rs:380:13:380:22 | mut reader | semmle.label | mut reader |
-| test.rs:380:26:380:60 | connector.connect(...) [future, Ok] | semmle.label | connector.connect(...) [future, Ok] |
-| test.rs:380:26:380:66 | await ... [Ok] | semmle.label | await ... [Ok] |
-| test.rs:380:26:380:67 | TryExpr | semmle.label | TryExpr |
-| test.rs:380:57:380:59 | tcp | semmle.label | tcp |
-| test.rs:381:14:381:20 | &reader | semmle.label | &reader |
-| test.rs:381:15:381:20 | reader | semmle.label | reader |
-| test.rs:386:17:386:26 | mut pinned | semmle.label | mut pinned |
-| test.rs:386:17:386:26 | mut pinned [Pin, &ref] | semmle.label | mut pinned [Pin, &ref] |
-| test.rs:386:30:386:50 | ...::new(...) | semmle.label | ...::new(...) |
-| test.rs:386:30:386:50 | ...::new(...) [Pin, &ref] | semmle.label | ...::new(...) [Pin, &ref] |
-| test.rs:386:39:386:49 | &mut reader [&ref] | semmle.label | &mut reader [&ref] |
-| test.rs:386:44:386:49 | reader | semmle.label | reader |
-| test.rs:387:18:387:24 | &pinned | semmle.label | &pinned |
-| test.rs:387:19:387:24 | pinned | semmle.label | pinned |
-| test.rs:387:19:387:24 | pinned [Pin, &ref] | semmle.label | pinned [Pin, &ref] |
-| test.rs:389:30:389:35 | pinned | semmle.label | pinned |
-| test.rs:389:56:389:66 | [post] &mut buffer [&ref] | semmle.label | [post] &mut buffer [&ref] |
-| test.rs:389:61:389:66 | [post] buffer | semmle.label | [post] buffer |
-| test.rs:391:22:391:28 | &buffer | semmle.label | &buffer |
-| test.rs:391:23:391:28 | buffer | semmle.label | buffer |
-| test.rs:392:22:392:33 | &... | semmle.label | &... |
-| test.rs:392:23:392:28 | buffer | semmle.label | buffer |
-| test.rs:392:23:392:33 | buffer[...] | semmle.label | buffer[...] |
-| test.rs:399:63:399:73 | &mut reader [&ref] | semmle.label | &mut reader [&ref] |
-| test.rs:399:68:399:73 | reader | semmle.label | reader |
-| test.rs:399:76:399:87 | [post] &mut buffer1 [&ref] | semmle.label | [post] &mut buffer1 [&ref] |
-| test.rs:399:81:399:87 | [post] buffer1 | semmle.label | [post] buffer1 |
-| test.rs:400:18:400:40 | &... | semmle.label | &... |
-| test.rs:400:19:400:25 | buffer1 | semmle.label | buffer1 |
-| test.rs:400:19:400:40 | buffer1[...] | semmle.label | buffer1[...] |
-| test.rs:403:31:403:36 | reader | semmle.label | reader |
-| test.rs:403:43:403:54 | [post] &mut buffer2 [&ref] | semmle.label | [post] &mut buffer2 [&ref] |
-| test.rs:403:48:403:54 | [post] buffer2 | semmle.label | [post] buffer2 |
-| test.rs:405:18:405:40 | &... | semmle.label | &... |
-| test.rs:405:19:405:25 | buffer2 | semmle.label | buffer2 |
-| test.rs:405:19:405:40 | buffer2[...] | semmle.label | buffer2[...] |
-| test.rs:408:13:408:23 | mut reader2 | semmle.label | mut reader2 |
-| test.rs:408:27:408:61 | ...::new(...) | semmle.label | ...::new(...) |
-| test.rs:408:55:408:60 | reader | semmle.label | reader |
-| test.rs:409:14:409:21 | &reader2 | semmle.label | &reader2 |
-| test.rs:409:15:409:21 | reader2 | semmle.label | reader2 |
-| test.rs:413:17:413:26 | mut pinned | semmle.label | mut pinned |
-| test.rs:413:17:413:26 | mut pinned [Pin, &ref] | semmle.label | mut pinned [Pin, &ref] |
-| test.rs:413:30:413:51 | ...::new(...) | semmle.label | ...::new(...) |
-| test.rs:413:30:413:51 | ...::new(...) [Pin, &ref] | semmle.label | ...::new(...) [Pin, &ref] |
-| test.rs:413:39:413:50 | &mut reader2 [&ref] | semmle.label | &mut reader2 [&ref] |
-| test.rs:413:44:413:50 | reader2 | semmle.label | reader2 |
-| test.rs:414:18:414:24 | &pinned | semmle.label | &pinned |
-| test.rs:414:19:414:24 | pinned | semmle.label | pinned |
-| test.rs:414:19:414:24 | pinned [Pin, &ref] | semmle.label | pinned [Pin, &ref] |
-| test.rs:416:17:416:22 | buffer [Ready, Ok] | semmle.label | buffer [Ready, Ok] |
-| test.rs:416:26:416:31 | pinned | semmle.label | pinned |
-| test.rs:416:26:416:54 | pinned.poll_fill_buf(...) [Ready, Ok] | semmle.label | pinned.poll_fill_buf(...) [Ready, Ok] |
-| test.rs:417:20:417:39 | ...::Ready(...) [Ready, Ok] | semmle.label | ...::Ready(...) [Ready, Ok] |
-| test.rs:417:32:417:38 | Ok(...) [Ok] | semmle.label | Ok(...) [Ok] |
-| test.rs:417:35:417:37 | buf | semmle.label | buf |
-| test.rs:418:22:418:28 | &buffer | semmle.label | &buffer |
-| test.rs:418:23:418:28 | buffer [Ready, Ok] | semmle.label | buffer [Ready, Ok] |
-| test.rs:419:22:419:24 | buf | semmle.label | buf |
-| test.rs:423:17:423:23 | buffer2 [Ready, Ok] | semmle.label | buffer2 [Ready, Ok] |
-| test.rs:423:27:423:48 | ...::new(...) | semmle.label | ...::new(...) |
-| test.rs:423:27:423:71 | ... .poll_fill_buf(...) [Ready, Ok] | semmle.label | ... .poll_fill_buf(...) [Ready, Ok] |
-| test.rs:423:36:423:47 | &mut reader2 [&ref] | semmle.label | &mut reader2 [&ref] |
-| test.rs:423:41:423:47 | reader2 | semmle.label | reader2 |
-| test.rs:424:20:424:26 | buffer2 [Ready, Ok] | semmle.label | buffer2 [Ready, Ok] |
-| test.rs:425:17:425:36 | ...::Ready(...) [Ready, Ok] | semmle.label | ...::Ready(...) [Ready, Ok] |
-| test.rs:425:29:425:35 | Ok(...) [Ok] | semmle.label | Ok(...) [Ok] |
-| test.rs:425:32:425:34 | buf | semmle.label | buf |
-| test.rs:426:26:426:33 | &buffer2 | semmle.label | &buffer2 |
-| test.rs:426:27:426:33 | buffer2 [Ready, Ok] | semmle.label | buffer2 [Ready, Ok] |
-| test.rs:427:26:427:28 | buf | semmle.label | buf |
-| test.rs:437:17:437:22 | buffer | semmle.label | buffer |
-| test.rs:437:26:437:32 | reader2 | semmle.label | reader2 |
-| test.rs:437:26:437:43 | reader2.fill_buf() [future, Ok] | semmle.label | reader2.fill_buf() [future, Ok] |
-| test.rs:437:26:437:49 | await ... [Ok] | semmle.label | await ... [Ok] |
-| test.rs:437:26:437:50 | TryExpr | semmle.label | TryExpr |
-| test.rs:438:18:438:23 | buffer | semmle.label | buffer |
-| test.rs:444:17:444:26 | mut pinned | semmle.label | mut pinned |
-| test.rs:444:17:444:26 | mut pinned [Pin, &ref] | semmle.label | mut pinned [Pin, &ref] |
-| test.rs:444:30:444:51 | ...::new(...) | semmle.label | ...::new(...) |
-| test.rs:444:30:444:51 | ...::new(...) [Pin, &ref] | semmle.label | ...::new(...) [Pin, &ref] |
-| test.rs:444:39:444:50 | &mut reader2 [&ref] | semmle.label | &mut reader2 [&ref] |
-| test.rs:444:44:444:50 | reader2 | semmle.label | reader2 |
-| test.rs:445:18:445:24 | &pinned | semmle.label | &pinned |
-| test.rs:445:19:445:24 | pinned | semmle.label | pinned |
-| test.rs:445:19:445:24 | pinned [Pin, &ref] | semmle.label | pinned [Pin, &ref] |
-| test.rs:447:30:447:35 | pinned | semmle.label | pinned |
-| test.rs:447:56:447:66 | [post] &mut buffer [&ref] | semmle.label | [post] &mut buffer [&ref] |
-| test.rs:447:61:447:66 | [post] buffer | semmle.label | [post] buffer |
-| test.rs:448:18:448:24 | &buffer | semmle.label | &buffer |
-| test.rs:448:19:448:24 | buffer | semmle.label | buffer |
-| test.rs:450:22:450:33 | &... | semmle.label | &... |
-| test.rs:450:23:450:28 | buffer | semmle.label | buffer |
-| test.rs:450:23:450:33 | buffer[...] | semmle.label | buffer[...] |
-| test.rs:457:63:457:74 | &mut reader2 [&ref] | semmle.label | &mut reader2 [&ref] |
-| test.rs:457:68:457:74 | reader2 | semmle.label | reader2 |
-| test.rs:457:77:457:88 | [post] &mut buffer1 [&ref] | semmle.label | [post] &mut buffer1 [&ref] |
-| test.rs:457:82:457:88 | [post] buffer1 | semmle.label | [post] buffer1 |
-| test.rs:458:18:458:40 | &... | semmle.label | &... |
-| test.rs:458:19:458:25 | buffer1 | semmle.label | buffer1 |
-| test.rs:458:19:458:40 | buffer1[...] | semmle.label | buffer1[...] |
-| test.rs:461:31:461:37 | reader2 | semmle.label | reader2 |
-| test.rs:461:44:461:55 | [post] &mut buffer2 [&ref] | semmle.label | [post] &mut buffer2 [&ref] |
-| test.rs:461:49:461:55 | [post] buffer2 | semmle.label | [post] buffer2 |
-| test.rs:462:18:462:40 | &... | semmle.label | &... |
-| test.rs:462:19:462:25 | buffer2 | semmle.label | buffer2 |
-| test.rs:462:19:462:40 | buffer2[...] | semmle.label | buffer2[...] |
+| test.rs:396:13:396:15 | tcp | semmle.label | tcp |
+| test.rs:396:19:396:41 | ...::connect(...) | semmle.label | ...::connect(...) |
+| test.rs:396:19:396:41 | ...::connect(...) [future, Ok] | semmle.label | ...::connect(...) [future, Ok] |
+| test.rs:396:19:396:47 | await ... [Ok] | semmle.label | await ... [Ok] |
+| test.rs:396:19:396:48 | TryExpr | semmle.label | TryExpr |
+| test.rs:397:14:397:17 | &tcp | semmle.label | &tcp |
+| test.rs:397:15:397:17 | tcp | semmle.label | tcp |
+| test.rs:403:13:403:22 | mut reader | semmle.label | mut reader |
+| test.rs:403:26:403:60 | connector.connect(...) [future, Ok] | semmle.label | connector.connect(...) [future, Ok] |
+| test.rs:403:26:403:66 | await ... [Ok] | semmle.label | await ... [Ok] |
+| test.rs:403:26:403:67 | TryExpr | semmle.label | TryExpr |
+| test.rs:403:57:403:59 | tcp | semmle.label | tcp |
+| test.rs:404:14:404:20 | &reader | semmle.label | &reader |
+| test.rs:404:15:404:20 | reader | semmle.label | reader |
+| test.rs:409:17:409:26 | mut pinned | semmle.label | mut pinned |
+| test.rs:409:17:409:26 | mut pinned [Pin, &ref] | semmle.label | mut pinned [Pin, &ref] |
+| test.rs:409:30:409:50 | ...::new(...) | semmle.label | ...::new(...) |
+| test.rs:409:30:409:50 | ...::new(...) [Pin, &ref] | semmle.label | ...::new(...) [Pin, &ref] |
+| test.rs:409:39:409:49 | &mut reader [&ref] | semmle.label | &mut reader [&ref] |
+| test.rs:409:44:409:49 | reader | semmle.label | reader |
+| test.rs:410:18:410:24 | &pinned | semmle.label | &pinned |
+| test.rs:410:19:410:24 | pinned | semmle.label | pinned |
+| test.rs:410:19:410:24 | pinned [Pin, &ref] | semmle.label | pinned [Pin, &ref] |
+| test.rs:412:30:412:35 | pinned | semmle.label | pinned |
+| test.rs:412:56:412:66 | [post] &mut buffer [&ref] | semmle.label | [post] &mut buffer [&ref] |
+| test.rs:412:61:412:66 | [post] buffer | semmle.label | [post] buffer |
+| test.rs:414:22:414:28 | &buffer | semmle.label | &buffer |
+| test.rs:414:23:414:28 | buffer | semmle.label | buffer |
+| test.rs:415:22:415:33 | &... | semmle.label | &... |
+| test.rs:415:23:415:28 | buffer | semmle.label | buffer |
+| test.rs:415:23:415:33 | buffer[...] | semmle.label | buffer[...] |
+| test.rs:422:63:422:73 | &mut reader [&ref] | semmle.label | &mut reader [&ref] |
+| test.rs:422:68:422:73 | reader | semmle.label | reader |
+| test.rs:422:76:422:87 | [post] &mut buffer1 [&ref] | semmle.label | [post] &mut buffer1 [&ref] |
+| test.rs:422:81:422:87 | [post] buffer1 | semmle.label | [post] buffer1 |
+| test.rs:423:18:423:40 | &... | semmle.label | &... |
+| test.rs:423:19:423:25 | buffer1 | semmle.label | buffer1 |
+| test.rs:423:19:423:40 | buffer1[...] | semmle.label | buffer1[...] |
+| test.rs:426:31:426:36 | reader | semmle.label | reader |
+| test.rs:426:43:426:54 | [post] &mut buffer2 [&ref] | semmle.label | [post] &mut buffer2 [&ref] |
+| test.rs:426:48:426:54 | [post] buffer2 | semmle.label | [post] buffer2 |
+| test.rs:428:18:428:40 | &... | semmle.label | &... |
+| test.rs:428:19:428:25 | buffer2 | semmle.label | buffer2 |
+| test.rs:428:19:428:40 | buffer2[...] | semmle.label | buffer2[...] |
+| test.rs:431:13:431:23 | mut reader2 | semmle.label | mut reader2 |
+| test.rs:431:27:431:61 | ...::new(...) | semmle.label | ...::new(...) |
+| test.rs:431:55:431:60 | reader | semmle.label | reader |
+| test.rs:432:14:432:21 | &reader2 | semmle.label | &reader2 |
+| test.rs:432:15:432:21 | reader2 | semmle.label | reader2 |
+| test.rs:436:17:436:26 | mut pinned | semmle.label | mut pinned |
+| test.rs:436:17:436:26 | mut pinned [Pin, &ref] | semmle.label | mut pinned [Pin, &ref] |
+| test.rs:436:30:436:51 | ...::new(...) | semmle.label | ...::new(...) |
+| test.rs:436:30:436:51 | ...::new(...) [Pin, &ref] | semmle.label | ...::new(...) [Pin, &ref] |
+| test.rs:436:39:436:50 | &mut reader2 [&ref] | semmle.label | &mut reader2 [&ref] |
+| test.rs:436:44:436:50 | reader2 | semmle.label | reader2 |
+| test.rs:437:18:437:24 | &pinned | semmle.label | &pinned |
+| test.rs:437:19:437:24 | pinned | semmle.label | pinned |
+| test.rs:437:19:437:24 | pinned [Pin, &ref] | semmle.label | pinned [Pin, &ref] |
+| test.rs:439:17:439:22 | buffer [Ready, Ok] | semmle.label | buffer [Ready, Ok] |
+| test.rs:439:26:439:31 | pinned | semmle.label | pinned |
+| test.rs:439:26:439:54 | pinned.poll_fill_buf(...) [Ready, Ok] | semmle.label | pinned.poll_fill_buf(...) [Ready, Ok] |
+| test.rs:440:20:440:39 | ...::Ready(...) [Ready, Ok] | semmle.label | ...::Ready(...) [Ready, Ok] |
+| test.rs:440:32:440:38 | Ok(...) [Ok] | semmle.label | Ok(...) [Ok] |
+| test.rs:440:35:440:37 | buf | semmle.label | buf |
+| test.rs:441:22:441:28 | &buffer | semmle.label | &buffer |
+| test.rs:441:23:441:28 | buffer [Ready, Ok] | semmle.label | buffer [Ready, Ok] |
+| test.rs:442:22:442:24 | buf | semmle.label | buf |
+| test.rs:446:17:446:23 | buffer2 [Ready, Ok] | semmle.label | buffer2 [Ready, Ok] |
+| test.rs:446:27:446:48 | ...::new(...) | semmle.label | ...::new(...) |
+| test.rs:446:27:446:71 | ... .poll_fill_buf(...) [Ready, Ok] | semmle.label | ... .poll_fill_buf(...) [Ready, Ok] |
+| test.rs:446:36:446:47 | &mut reader2 [&ref] | semmle.label | &mut reader2 [&ref] |
+| test.rs:446:41:446:47 | reader2 | semmle.label | reader2 |
+| test.rs:447:20:447:26 | buffer2 [Ready, Ok] | semmle.label | buffer2 [Ready, Ok] |
+| test.rs:448:17:448:36 | ...::Ready(...) [Ready, Ok] | semmle.label | ...::Ready(...) [Ready, Ok] |
+| test.rs:448:29:448:35 | Ok(...) [Ok] | semmle.label | Ok(...) [Ok] |
+| test.rs:448:32:448:34 | buf | semmle.label | buf |
+| test.rs:449:26:449:33 | &buffer2 | semmle.label | &buffer2 |
+| test.rs:449:27:449:33 | buffer2 [Ready, Ok] | semmle.label | buffer2 [Ready, Ok] |
+| test.rs:450:26:450:28 | buf | semmle.label | buf |
+| test.rs:460:17:460:22 | buffer | semmle.label | buffer |
+| test.rs:460:26:460:32 | reader2 | semmle.label | reader2 |
+| test.rs:460:26:460:43 | reader2.fill_buf() [future, Ok] | semmle.label | reader2.fill_buf() [future, Ok] |
+| test.rs:460:26:460:49 | await ... [Ok] | semmle.label | await ... [Ok] |
+| test.rs:460:26:460:50 | TryExpr | semmle.label | TryExpr |
+| test.rs:461:18:461:23 | buffer | semmle.label | buffer |
 | test.rs:467:17:467:26 | mut pinned | semmle.label | mut pinned |
 | test.rs:467:17:467:26 | mut pinned [Pin, &ref] | semmle.label | mut pinned [Pin, &ref] |
 | test.rs:467:30:467:51 | ...::new(...) | semmle.label | ...::new(...) |
@@ -667,36 +637,66 @@ nodes
 | test.rs:468:18:468:24 | &pinned | semmle.label | &pinned |
 | test.rs:468:19:468:24 | pinned | semmle.label | pinned |
 | test.rs:468:19:468:24 | pinned [Pin, &ref] | semmle.label | pinned [Pin, &ref] |
-| test.rs:470:17:470:22 | buffer [Ready, Ok] | semmle.label | buffer [Ready, Ok] |
-| test.rs:470:26:470:31 | pinned | semmle.label | pinned |
-| test.rs:470:26:470:54 | pinned.poll_fill_buf(...) [Ready, Ok] | semmle.label | pinned.poll_fill_buf(...) [Ready, Ok] |
+| test.rs:470:30:470:35 | pinned | semmle.label | pinned |
+| test.rs:470:56:470:66 | [post] &mut buffer [&ref] | semmle.label | [post] &mut buffer [&ref] |
+| test.rs:470:61:470:66 | [post] buffer | semmle.label | [post] buffer |
 | test.rs:471:18:471:24 | &buffer | semmle.label | &buffer |
-| test.rs:471:19:471:24 | buffer [Ready, Ok] | semmle.label | buffer [Ready, Ok] |
-| test.rs:472:20:472:39 | ...::Ready(...) [Ready, Ok] | semmle.label | ...::Ready(...) [Ready, Ok] |
-| test.rs:472:32:472:38 | Ok(...) [Ok] | semmle.label | Ok(...) [Ok] |
-| test.rs:472:35:472:37 | buf | semmle.label | buf |
-| test.rs:473:22:473:24 | buf | semmle.label | buf |
-| test.rs:479:17:479:22 | buffer | semmle.label | buffer |
-| test.rs:479:26:479:32 | reader2 | semmle.label | reader2 |
-| test.rs:479:26:479:43 | reader2.fill_buf() [future, Ok] | semmle.label | reader2.fill_buf() [future, Ok] |
-| test.rs:479:26:479:49 | await ... [Ok] | semmle.label | await ... [Ok] |
-| test.rs:479:26:479:50 | TryExpr | semmle.label | TryExpr |
-| test.rs:480:18:480:23 | buffer | semmle.label | buffer |
-| test.rs:486:31:486:37 | reader2 | semmle.label | reader2 |
-| test.rs:486:57:486:65 | [post] &mut line [&ref] | semmle.label | [post] &mut line [&ref] |
-| test.rs:486:62:486:65 | [post] line | semmle.label | [post] line |
-| test.rs:487:18:487:22 | &line | semmle.label | &line |
-| test.rs:487:19:487:22 | line | semmle.label | line |
-| test.rs:493:31:493:37 | reader2 | semmle.label | reader2 |
-| test.rs:493:49:493:57 | [post] &mut line [&ref] | semmle.label | [post] &mut line [&ref] |
-| test.rs:493:54:493:57 | [post] line | semmle.label | [post] line |
-| test.rs:494:18:494:22 | &line | semmle.label | &line |
-| test.rs:494:19:494:22 | line | semmle.label | line |
-| test.rs:500:31:500:37 | reader2 | semmle.label | reader2 |
-| test.rs:500:51:500:61 | [post] &mut buffer [&ref] | semmle.label | [post] &mut buffer [&ref] |
-| test.rs:500:56:500:61 | [post] buffer | semmle.label | [post] buffer |
-| test.rs:501:18:501:24 | &buffer | semmle.label | &buffer |
-| test.rs:501:19:501:24 | buffer | semmle.label | buffer |
+| test.rs:471:19:471:24 | buffer | semmle.label | buffer |
+| test.rs:473:22:473:33 | &... | semmle.label | &... |
+| test.rs:473:23:473:28 | buffer | semmle.label | buffer |
+| test.rs:473:23:473:33 | buffer[...] | semmle.label | buffer[...] |
+| test.rs:480:63:480:74 | &mut reader2 [&ref] | semmle.label | &mut reader2 [&ref] |
+| test.rs:480:68:480:74 | reader2 | semmle.label | reader2 |
+| test.rs:480:77:480:88 | [post] &mut buffer1 [&ref] | semmle.label | [post] &mut buffer1 [&ref] |
+| test.rs:480:82:480:88 | [post] buffer1 | semmle.label | [post] buffer1 |
+| test.rs:481:18:481:40 | &... | semmle.label | &... |
+| test.rs:481:19:481:25 | buffer1 | semmle.label | buffer1 |
+| test.rs:481:19:481:40 | buffer1[...] | semmle.label | buffer1[...] |
+| test.rs:484:31:484:37 | reader2 | semmle.label | reader2 |
+| test.rs:484:44:484:55 | [post] &mut buffer2 [&ref] | semmle.label | [post] &mut buffer2 [&ref] |
+| test.rs:484:49:484:55 | [post] buffer2 | semmle.label | [post] buffer2 |
+| test.rs:485:18:485:40 | &... | semmle.label | &... |
+| test.rs:485:19:485:25 | buffer2 | semmle.label | buffer2 |
+| test.rs:485:19:485:40 | buffer2[...] | semmle.label | buffer2[...] |
+| test.rs:490:17:490:26 | mut pinned | semmle.label | mut pinned |
+| test.rs:490:17:490:26 | mut pinned [Pin, &ref] | semmle.label | mut pinned [Pin, &ref] |
+| test.rs:490:30:490:51 | ...::new(...) | semmle.label | ...::new(...) |
+| test.rs:490:30:490:51 | ...::new(...) [Pin, &ref] | semmle.label | ...::new(...) [Pin, &ref] |
+| test.rs:490:39:490:50 | &mut reader2 [&ref] | semmle.label | &mut reader2 [&ref] |
+| test.rs:490:44:490:50 | reader2 | semmle.label | reader2 |
+| test.rs:491:18:491:24 | &pinned | semmle.label | &pinned |
+| test.rs:491:19:491:24 | pinned | semmle.label | pinned |
+| test.rs:491:19:491:24 | pinned [Pin, &ref] | semmle.label | pinned [Pin, &ref] |
+| test.rs:493:17:493:22 | buffer [Ready, Ok] | semmle.label | buffer [Ready, Ok] |
+| test.rs:493:26:493:31 | pinned | semmle.label | pinned |
+| test.rs:493:26:493:54 | pinned.poll_fill_buf(...) [Ready, Ok] | semmle.label | pinned.poll_fill_buf(...) [Ready, Ok] |
+| test.rs:494:18:494:24 | &buffer | semmle.label | &buffer |
+| test.rs:494:19:494:24 | buffer [Ready, Ok] | semmle.label | buffer [Ready, Ok] |
+| test.rs:495:20:495:39 | ...::Ready(...) [Ready, Ok] | semmle.label | ...::Ready(...) [Ready, Ok] |
+| test.rs:495:32:495:38 | Ok(...) [Ok] | semmle.label | Ok(...) [Ok] |
+| test.rs:495:35:495:37 | buf | semmle.label | buf |
+| test.rs:496:22:496:24 | buf | semmle.label | buf |
+| test.rs:502:17:502:22 | buffer | semmle.label | buffer |
+| test.rs:502:26:502:32 | reader2 | semmle.label | reader2 |
+| test.rs:502:26:502:43 | reader2.fill_buf() [future, Ok] | semmle.label | reader2.fill_buf() [future, Ok] |
+| test.rs:502:26:502:49 | await ... [Ok] | semmle.label | await ... [Ok] |
+| test.rs:502:26:502:50 | TryExpr | semmle.label | TryExpr |
+| test.rs:503:18:503:23 | buffer | semmle.label | buffer |
+| test.rs:509:31:509:37 | reader2 | semmle.label | reader2 |
+| test.rs:509:57:509:65 | [post] &mut line [&ref] | semmle.label | [post] &mut line [&ref] |
+| test.rs:509:62:509:65 | [post] line | semmle.label | [post] line |
+| test.rs:510:18:510:22 | &line | semmle.label | &line |
+| test.rs:510:19:510:22 | line | semmle.label | line |
+| test.rs:516:31:516:37 | reader2 | semmle.label | reader2 |
+| test.rs:516:49:516:57 | [post] &mut line [&ref] | semmle.label | [post] &mut line [&ref] |
+| test.rs:516:54:516:57 | [post] line | semmle.label | [post] line |
+| test.rs:517:18:517:22 | &line | semmle.label | &line |
+| test.rs:517:19:517:22 | line | semmle.label | line |
+| test.rs:523:31:523:37 | reader2 | semmle.label | reader2 |
+| test.rs:523:51:523:61 | [post] &mut buffer [&ref] | semmle.label | [post] &mut buffer [&ref] |
+| test.rs:523:56:523:61 | [post] buffer | semmle.label | [post] buffer |
+| test.rs:524:18:524:24 | &buffer | semmle.label | &buffer |
+| test.rs:524:19:524:24 | buffer | semmle.label | buffer |
 subpaths
 testFailures
 #select
@@ -728,29 +728,29 @@ testFailures
 | test.rs:339:14:339:20 | &buffer | test.rs:332:22:332:75 | ...::new(...) | test.rs:339:14:339:20 | &buffer | $@ | test.rs:332:22:332:75 | ...::new(...) | ...::new(...) |
 | test.rs:345:14:345:20 | &buffer | test.rs:332:22:332:75 | ...::new(...) | test.rs:345:14:345:20 | &buffer | $@ | test.rs:332:22:332:75 | ...::new(...) | ...::new(...) |
 | test.rs:351:14:351:20 | &buffer | test.rs:332:22:332:75 | ...::new(...) | test.rs:351:14:351:20 | &buffer | $@ | test.rs:332:22:332:75 | ...::new(...) | ...::new(...) |
-| test.rs:374:14:374:17 | &tcp | test.rs:373:19:373:41 | ...::connect(...) | test.rs:374:14:374:17 | &tcp | $@ | test.rs:373:19:373:41 | ...::connect(...) | ...::connect(...) |
-| test.rs:381:14:381:20 | &reader | test.rs:373:19:373:41 | ...::connect(...) | test.rs:381:14:381:20 | &reader | $@ | test.rs:373:19:373:41 | ...::connect(...) | ...::connect(...) |
-| test.rs:387:18:387:24 | &pinned | test.rs:373:19:373:41 | ...::connect(...) | test.rs:387:18:387:24 | &pinned | $@ | test.rs:373:19:373:41 | ...::connect(...) | ...::connect(...) |
-| test.rs:391:22:391:28 | &buffer | test.rs:373:19:373:41 | ...::connect(...) | test.rs:391:22:391:28 | &buffer | $@ | test.rs:373:19:373:41 | ...::connect(...) | ...::connect(...) |
-| test.rs:392:22:392:33 | &... | test.rs:373:19:373:41 | ...::connect(...) | test.rs:392:22:392:33 | &... | $@ | test.rs:373:19:373:41 | ...::connect(...) | ...::connect(...) |
-| test.rs:400:18:400:40 | &... | test.rs:373:19:373:41 | ...::connect(...) | test.rs:400:18:400:40 | &... | $@ | test.rs:373:19:373:41 | ...::connect(...) | ...::connect(...) |
-| test.rs:405:18:405:40 | &... | test.rs:373:19:373:41 | ...::connect(...) | test.rs:405:18:405:40 | &... | $@ | test.rs:373:19:373:41 | ...::connect(...) | ...::connect(...) |
-| test.rs:409:14:409:21 | &reader2 | test.rs:373:19:373:41 | ...::connect(...) | test.rs:409:14:409:21 | &reader2 | $@ | test.rs:373:19:373:41 | ...::connect(...) | ...::connect(...) |
-| test.rs:414:18:414:24 | &pinned | test.rs:373:19:373:41 | ...::connect(...) | test.rs:414:18:414:24 | &pinned | $@ | test.rs:373:19:373:41 | ...::connect(...) | ...::connect(...) |
-| test.rs:418:22:418:28 | &buffer | test.rs:373:19:373:41 | ...::connect(...) | test.rs:418:22:418:28 | &buffer | $@ | test.rs:373:19:373:41 | ...::connect(...) | ...::connect(...) |
-| test.rs:419:22:419:24 | buf | test.rs:373:19:373:41 | ...::connect(...) | test.rs:419:22:419:24 | buf | $@ | test.rs:373:19:373:41 | ...::connect(...) | ...::connect(...) |
-| test.rs:426:26:426:33 | &buffer2 | test.rs:373:19:373:41 | ...::connect(...) | test.rs:426:26:426:33 | &buffer2 | $@ | test.rs:373:19:373:41 | ...::connect(...) | ...::connect(...) |
-| test.rs:427:26:427:28 | buf | test.rs:373:19:373:41 | ...::connect(...) | test.rs:427:26:427:28 | buf | $@ | test.rs:373:19:373:41 | ...::connect(...) | ...::connect(...) |
-| test.rs:438:18:438:23 | buffer | test.rs:373:19:373:41 | ...::connect(...) | test.rs:438:18:438:23 | buffer | $@ | test.rs:373:19:373:41 | ...::connect(...) | ...::connect(...) |
-| test.rs:445:18:445:24 | &pinned | test.rs:373:19:373:41 | ...::connect(...) | test.rs:445:18:445:24 | &pinned | $@ | test.rs:373:19:373:41 | ...::connect(...) | ...::connect(...) |
-| test.rs:448:18:448:24 | &buffer | test.rs:373:19:373:41 | ...::connect(...) | test.rs:448:18:448:24 | &buffer | $@ | test.rs:373:19:373:41 | ...::connect(...) | ...::connect(...) |
-| test.rs:450:22:450:33 | &... | test.rs:373:19:373:41 | ...::connect(...) | test.rs:450:22:450:33 | &... | $@ | test.rs:373:19:373:41 | ...::connect(...) | ...::connect(...) |
-| test.rs:458:18:458:40 | &... | test.rs:373:19:373:41 | ...::connect(...) | test.rs:458:18:458:40 | &... | $@ | test.rs:373:19:373:41 | ...::connect(...) | ...::connect(...) |
-| test.rs:462:18:462:40 | &... | test.rs:373:19:373:41 | ...::connect(...) | test.rs:462:18:462:40 | &... | $@ | test.rs:373:19:373:41 | ...::connect(...) | ...::connect(...) |
-| test.rs:468:18:468:24 | &pinned | test.rs:373:19:373:41 | ...::connect(...) | test.rs:468:18:468:24 | &pinned | $@ | test.rs:373:19:373:41 | ...::connect(...) | ...::connect(...) |
-| test.rs:471:18:471:24 | &buffer | test.rs:373:19:373:41 | ...::connect(...) | test.rs:471:18:471:24 | &buffer | $@ | test.rs:373:19:373:41 | ...::connect(...) | ...::connect(...) |
-| test.rs:473:22:473:24 | buf | test.rs:373:19:373:41 | ...::connect(...) | test.rs:473:22:473:24 | buf | $@ | test.rs:373:19:373:41 | ...::connect(...) | ...::connect(...) |
-| test.rs:480:18:480:23 | buffer | test.rs:373:19:373:41 | ...::connect(...) | test.rs:480:18:480:23 | buffer | $@ | test.rs:373:19:373:41 | ...::connect(...) | ...::connect(...) |
-| test.rs:487:18:487:22 | &line | test.rs:373:19:373:41 | ...::connect(...) | test.rs:487:18:487:22 | &line | $@ | test.rs:373:19:373:41 | ...::connect(...) | ...::connect(...) |
-| test.rs:494:18:494:22 | &line | test.rs:373:19:373:41 | ...::connect(...) | test.rs:494:18:494:22 | &line | $@ | test.rs:373:19:373:41 | ...::connect(...) | ...::connect(...) |
-| test.rs:501:18:501:24 | &buffer | test.rs:373:19:373:41 | ...::connect(...) | test.rs:501:18:501:24 | &buffer | $@ | test.rs:373:19:373:41 | ...::connect(...) | ...::connect(...) |
+| test.rs:397:14:397:17 | &tcp | test.rs:396:19:396:41 | ...::connect(...) | test.rs:397:14:397:17 | &tcp | $@ | test.rs:396:19:396:41 | ...::connect(...) | ...::connect(...) |
+| test.rs:404:14:404:20 | &reader | test.rs:396:19:396:41 | ...::connect(...) | test.rs:404:14:404:20 | &reader | $@ | test.rs:396:19:396:41 | ...::connect(...) | ...::connect(...) |
+| test.rs:410:18:410:24 | &pinned | test.rs:396:19:396:41 | ...::connect(...) | test.rs:410:18:410:24 | &pinned | $@ | test.rs:396:19:396:41 | ...::connect(...) | ...::connect(...) |
+| test.rs:414:22:414:28 | &buffer | test.rs:396:19:396:41 | ...::connect(...) | test.rs:414:22:414:28 | &buffer | $@ | test.rs:396:19:396:41 | ...::connect(...) | ...::connect(...) |
+| test.rs:415:22:415:33 | &... | test.rs:396:19:396:41 | ...::connect(...) | test.rs:415:22:415:33 | &... | $@ | test.rs:396:19:396:41 | ...::connect(...) | ...::connect(...) |
+| test.rs:423:18:423:40 | &... | test.rs:396:19:396:41 | ...::connect(...) | test.rs:423:18:423:40 | &... | $@ | test.rs:396:19:396:41 | ...::connect(...) | ...::connect(...) |
+| test.rs:428:18:428:40 | &... | test.rs:396:19:396:41 | ...::connect(...) | test.rs:428:18:428:40 | &... | $@ | test.rs:396:19:396:41 | ...::connect(...) | ...::connect(...) |
+| test.rs:432:14:432:21 | &reader2 | test.rs:396:19:396:41 | ...::connect(...) | test.rs:432:14:432:21 | &reader2 | $@ | test.rs:396:19:396:41 | ...::connect(...) | ...::connect(...) |
+| test.rs:437:18:437:24 | &pinned | test.rs:396:19:396:41 | ...::connect(...) | test.rs:437:18:437:24 | &pinned | $@ | test.rs:396:19:396:41 | ...::connect(...) | ...::connect(...) |
+| test.rs:441:22:441:28 | &buffer | test.rs:396:19:396:41 | ...::connect(...) | test.rs:441:22:441:28 | &buffer | $@ | test.rs:396:19:396:41 | ...::connect(...) | ...::connect(...) |
+| test.rs:442:22:442:24 | buf | test.rs:396:19:396:41 | ...::connect(...) | test.rs:442:22:442:24 | buf | $@ | test.rs:396:19:396:41 | ...::connect(...) | ...::connect(...) |
+| test.rs:449:26:449:33 | &buffer2 | test.rs:396:19:396:41 | ...::connect(...) | test.rs:449:26:449:33 | &buffer2 | $@ | test.rs:396:19:396:41 | ...::connect(...) | ...::connect(...) |
+| test.rs:450:26:450:28 | buf | test.rs:396:19:396:41 | ...::connect(...) | test.rs:450:26:450:28 | buf | $@ | test.rs:396:19:396:41 | ...::connect(...) | ...::connect(...) |
+| test.rs:461:18:461:23 | buffer | test.rs:396:19:396:41 | ...::connect(...) | test.rs:461:18:461:23 | buffer | $@ | test.rs:396:19:396:41 | ...::connect(...) | ...::connect(...) |
+| test.rs:468:18:468:24 | &pinned | test.rs:396:19:396:41 | ...::connect(...) | test.rs:468:18:468:24 | &pinned | $@ | test.rs:396:19:396:41 | ...::connect(...) | ...::connect(...) |
+| test.rs:471:18:471:24 | &buffer | test.rs:396:19:396:41 | ...::connect(...) | test.rs:471:18:471:24 | &buffer | $@ | test.rs:396:19:396:41 | ...::connect(...) | ...::connect(...) |
+| test.rs:473:22:473:33 | &... | test.rs:396:19:396:41 | ...::connect(...) | test.rs:473:22:473:33 | &... | $@ | test.rs:396:19:396:41 | ...::connect(...) | ...::connect(...) |
+| test.rs:481:18:481:40 | &... | test.rs:396:19:396:41 | ...::connect(...) | test.rs:481:18:481:40 | &... | $@ | test.rs:396:19:396:41 | ...::connect(...) | ...::connect(...) |
+| test.rs:485:18:485:40 | &... | test.rs:396:19:396:41 | ...::connect(...) | test.rs:485:18:485:40 | &... | $@ | test.rs:396:19:396:41 | ...::connect(...) | ...::connect(...) |
+| test.rs:491:18:491:24 | &pinned | test.rs:396:19:396:41 | ...::connect(...) | test.rs:491:18:491:24 | &pinned | $@ | test.rs:396:19:396:41 | ...::connect(...) | ...::connect(...) |
+| test.rs:494:18:494:24 | &buffer | test.rs:396:19:396:41 | ...::connect(...) | test.rs:494:18:494:24 | &buffer | $@ | test.rs:396:19:396:41 | ...::connect(...) | ...::connect(...) |
+| test.rs:496:22:496:24 | buf | test.rs:396:19:396:41 | ...::connect(...) | test.rs:496:22:496:24 | buf | $@ | test.rs:396:19:396:41 | ...::connect(...) | ...::connect(...) |
+| test.rs:503:18:503:23 | buffer | test.rs:396:19:396:41 | ...::connect(...) | test.rs:503:18:503:23 | buffer | $@ | test.rs:396:19:396:41 | ...::connect(...) | ...::connect(...) |
+| test.rs:510:18:510:22 | &line | test.rs:396:19:396:41 | ...::connect(...) | test.rs:510:18:510:22 | &line | $@ | test.rs:396:19:396:41 | ...::connect(...) | ...::connect(...) |
+| test.rs:517:18:517:22 | &line | test.rs:396:19:396:41 | ...::connect(...) | test.rs:517:18:517:22 | &line | $@ | test.rs:396:19:396:41 | ...::connect(...) | ...::connect(...) |
+| test.rs:524:18:524:24 | &buffer | test.rs:396:19:396:41 | ...::connect(...) | test.rs:524:18:524:24 | &buffer | $@ | test.rs:396:19:396:41 | ...::connect(...) | ...::connect(...) |

--- a/rust/ql/test/library-tests/dataflow/sources/net/TaintSources.expected
+++ b/rust/ql/test/library-tests/dataflow/sources/net/TaintSources.expected
@@ -13,5 +13,6 @@
 | test.rs:224:28:224:66 | ...::connect(...) | Flow source 'RemoteSource' of type remote (DEFAULT). |
 | test.rs:306:22:306:58 | ...::connect(...) | Flow source 'RemoteSource' of type remote (DEFAULT). |
 | test.rs:332:22:332:75 | ...::new(...) | Flow source 'RemoteSource' of type remote (DEFAULT). |
-| test.rs:373:19:373:41 | ...::connect(...) | Flow source 'RemoteSource' of type remote (DEFAULT). |
-| test.rs:519:16:519:31 | ...::args(...) | Flow source 'CommandLineArgs' of type commandargs (DEFAULT). |
+| test.rs:359:18:359:54 | ...::connect(...) | Flow source 'RemoteSource' of type remote (DEFAULT). |
+| test.rs:396:19:396:41 | ...::connect(...) | Flow source 'RemoteSource' of type remote (DEFAULT). |
+| test.rs:542:16:542:31 | ...::args(...) | Flow source 'CommandLineArgs' of type commandargs (DEFAULT). |

--- a/rust/ql/test/library-tests/dataflow/sources/net/options.yml
+++ b/rust/ql/test/library-tests/dataflow/sources/net/options.yml
@@ -10,3 +10,4 @@ qltest_dependencies:
     - rustls = { version = "0.23.27" }
     - futures-rustls = { version = "0.26.0" }
     - async-std = { version = "1.13.1" }
+    - native-tls = { version = "0.2.14" }

--- a/rust/ql/test/library-tests/dataflow/sources/net/test.rs
+++ b/rust/ql/test/library-tests/dataflow/sources/net/test.rs
@@ -359,7 +359,7 @@ fn test_native_tls() -> Result<(), Box<dyn std::error::Error>> {
     let stream = std::net::TcpStream::connect(address)?; // $ Alert[rust/summary/taint-sources]
     let connector = native_tls::TlsConnector::new()?;
     let mut stream = connector.connect("www.example.com", stream)?;
-    sink(&stream); // $ MISSING: hasTaintFlow=address
+    sink(&stream); // $ hasTaintFlow=address
 
     stream.write_all(b"GET / HTTP/1.1\r\nHost: www.example.com\r\nConnection: close\r\n\r\n")?;
 
@@ -367,12 +367,12 @@ fn test_native_tls() -> Result<(), Box<dyn std::error::Error>> {
     let bytes_read = stream.read(&mut buffer)?;
     println!("bytes_read = {}", bytes_read);
     println!("buffer = {:?}", &buffer[..bytes_read]);
-    sink(&buffer[..bytes_read]); // $ MISSING: hasTaintFlow=address
+    sink(&buffer[..bytes_read]); // $ hasTaintFlow=address
 
     let mut response = String::new();
     stream.read_to_string(&mut response)?;
     println!("rest of response = '{}'", response);
-    sink(response); // $ MISSING: hasTaintFlow=address
+    sink(response); // $ hasTaintFlow=address
 
     Ok(())
 }

--- a/rust/ql/test/library-tests/dataflow/sources/net/test.rs
+++ b/rust/ql/test/library-tests/dataflow/sources/net/test.rs
@@ -354,6 +354,29 @@ fn test_rustls() -> std::io::Result<()> {
     Ok(())
 }
 
+fn test_native_tls() -> Result<(), Box<dyn std::error::Error>> {
+    let address = "www.example.com:443";
+    let stream = std::net::TcpStream::connect(address)?; // $ Alert[rust/summary/taint-sources]
+    let connector = native_tls::TlsConnector::new()?;
+    let mut stream = connector.connect("www.example.com", stream)?;
+    sink(&stream); // $ MISSING: hasTaintFlow=address
+
+    stream.write_all(b"GET / HTTP/1.1\r\nHost: www.example.com\r\nConnection: close\r\n\r\n")?;
+
+    let mut buffer = [0u8; 100];
+    let bytes_read = stream.read(&mut buffer)?;
+    println!("bytes_read = {}", bytes_read);
+    println!("buffer = {:?}", &buffer[..bytes_read]);
+    sink(&buffer[..bytes_read]); // $ MISSING: hasTaintFlow=address
+
+    let mut response = String::new();
+    stream.read_to_string(&mut response)?;
+    println!("rest of response = '{}'", response);
+    sink(response); // $ MISSING: hasTaintFlow=address
+
+    Ok(())
+}
+
 mod futures_rustls {
     use async_std::net::TcpStream;
     use async_std::sync::Arc;
@@ -544,6 +567,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("test_std_to_tokio_tcpstream...");
     match futures::executor::block_on(test_std_to_tokio_tcpstream()) {
+        Ok(_) => println!("complete"),
+        Err(e) => println!("error: {}", e),
+    }
+
+    println!("test_native_tls...");
+    match test_native_tls() {
         Ok(_) => println!("complete"),
         Err(e) => println!("error: {}", e),
     }


### PR DESCRIPTION
I spotted some gaps in `supported-frameworks.rst`, which motivated (via a Copilot suggestion) a few model improvements as well:
- `axum` is supported ([sources](https://github.com/github/codeql/blob/8eb1ae9c27e37c5d6bd93ee731208bcff179596d/rust/ql/lib/codeql/rust/frameworks/axum.model.yml#L7) + [sinks](https://github.com/github/codeql/blob/8eb1ae9c27e37c5d6bd93ee731208bcff179596d/rust/ql/lib/codeql/rust/security/XssExtensions.qll#L71)).
- `native-tls` and `async-native-tls` are supported ([sinks](https://github.com/github/codeql/blob/8eb1ae9c27e37c5d6bd93ee731208bcff179596d/rust/ql/lib/codeql/rust/frameworks/native-tls.model.yml#L4)).
- in the latter case I added a couple of new models for better coverage.