### PR TITLE
C#: Harden `cs/useless-cast-to-self` with respect to unknown types.

### DIFF
--- a/csharp/ql/src/Language Abuse/UselessCastToSelf.ql
+++ b/csharp/ql/src/Language Abuse/UselessCastToSelf.ql
@@ -19,5 +19,6 @@ where
   type = cast.getTargetType() and
   type = e.getType() and
   not type instanceof NullType and
+  not type instanceof UnknownType and
   not e.(ImplicitDelegateCreation).getArgument() instanceof AnonymousFunctionExpr
 select cast, "This cast is redundant because the expression already has type " + type + "."

--- a/csharp/ql/src/change-notes/2026-08-20-harden-useless-cast-to-self.md
+++ b/csharp/ql/src/change-notes/2026-08-20-harden-useless-cast-to-self.md
@@ -1,0 +1,4 @@
+---
+category: fix
+---
+* The query `cs/useless-cast-to-self` no longer reports casts when both the expression type and the cast target type are unknown, which can occur in `build-mode: none` databases.


### PR DESCRIPTION
Especially for `build-mode: none` expressions can more easily be of *unknown* type (and the same goes for types used in casts). Such cases should not be reported by the query `cs/useless-cast-to-self`.

This change removes around 7k results across the repos in the DCA suite.