### PR TITLE
Python: test closure instance cross-talk

### DIFF
--- a/python/ql/test/library-tests/dataflow/typetracking/test.py
+++ b/python/ql/test/library-tests/dataflow/typetracking/test.py
@@ -107,6 +107,28 @@ def use_funcs_with_decorators():
     x = get_tracked2() # $ tracked
     y = unrelated_func() # $ SPURIOUS: tracked
 
+# A decorator factory creates a distinct closure each time it is called. The captured
+# callable and data therefore belong to that closure instance, even though every
+# instance comes from the same wrapper AST.
+def make_capturing_wrapper(func, captured): # $ tracked
+    def wrapper():
+        print(captured) # $ tracked
+        return func() # $ tracked
+    return wrapper
+
+def closure_sensitive_func():
+    return tracked # $ tracked
+
+def closure_safe_func():
+    return "safe"
+
+closure_sensitive = make_capturing_wrapper(closure_sensitive_func, tracked) # $ tracked
+closure_safe = make_capturing_wrapper(closure_safe_func, "safe")
+
+def use_capturing_wrappers():
+    sensitive = closure_sensitive() # $ tracked
+    safe = closure_safe() # $ SPURIOUS: tracked
+
 # ------------------------------------------------------------------------------
 
 def expects_int(x): # $ int


### PR DESCRIPTION
## Summary

- add an inline type-tracking regression for two closures created from one wrapper AST with different captured callables
- keep positive controls for the sensitive callable and ordinary captured data
- mark the safe closure result as `SPURIOUS` so this tests-only draft remains green

## Motivation

This is an experimental dependent follow-up to #21925. The improved shared-CFG/SSA routing exposes cross-talk in generic decorator factories such as Django `keep_lazy` and Airflow `provide_session` / `action_cli`: separate wrapper instances can capture different callables, but callable type tracking currently merges their returns.

## Current finding

`TypeTrackingImpl::capturedJumpStep` transfers the merged outer value into the wrapper scope through a shared type-tracking `JumpStep`, which intentionally discards call context. Removing that jump eliminates the false positive but also drops legitimate captured callable and data flow. A sound implementation therefore appears to require call-site-specific closure/function-object identity in shared type tracking or dataflow; this draft intentionally does not include a workaround or framework-specific suppression.

## Testing

```text
codeql test run python/ql/test/library-tests/dataflow/variable-capture python/ql/test/library-tests/dataflow/typetracking
```

All four targeted tests pass with the inline `SPURIOUS` expectations.
