### PR TITLE
Python: preserve sensitive configuration key precision

### DIFF
--- a/python/ql/lib/change-notes/2026-08-20-sensitive-configuration-keys.md
+++ b/python/ql/lib/change-notes/2026-08-20-sensitive-configuration-keys.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The `py/clear-text-logging-sensitive-data`, `py/clear-text-storage-sensitive-data`, and `py/weak-sensitive-data-hashing` queries no longer propagate sensitive data through resolved configuration lookups whose only value selectors are concrete, non-sensitive `section` and `key` arguments. Calls with sensitive or dynamic names, or with additional value arguments, remain unchanged.

--- a/python/ql/lib/semmle/python/dataflow/new/SensitiveDataSources.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/SensitiveDataSources.qll
@@ -6,6 +6,7 @@
 private import python
 private import semmle.python.controlflow.internal.Cfg as Cfg
 private import semmle.python.dataflow.new.DataFlow
+private import semmle.python.dataflow.new.internal.DataFlowDispatch as DataFlowDispatch
 // Need to import `semmle.python.Frameworks` since frameworks can extend `SensitiveDataSource::Range`
 private import semmle.python.Frameworks
 private import codeql.concepts.internal.SensitiveDataHeuristics as SensitiveDataHeuristics
@@ -82,6 +83,87 @@ private module SensitiveDataModeling {
    */
   DataFlow::Node sensitiveFunction(SensitiveDataClassification classification) {
     sensitiveFunction(DataFlow::TypeTracker::end(), classification).flowsTo(result)
+  }
+
+  /** Gets the unique string literal passed to `parameterName`, if all local sources agree. */
+  private string constantArgument(DataFlowDispatch::NormalCall call, string parameterName) {
+    exists(
+      DataFlowDispatch::ArgumentPosition argumentPosition,
+      DataFlowDispatch::ParameterPosition parameterPosition, DataFlow::ArgumentNode argument,
+      DataFlow::LocalSourceNode representative
+    |
+      DataFlowDispatch::parameterMatch(parameterPosition, argumentPosition) and
+      call.getCallable().getParameter(parameterPosition).getParameter().getName() = parameterName and
+      argument = call.getArgument(argumentPosition) and
+      representative = argument.getALocalSource() and
+      result = representative.asExpr().(StringLiteral).getText() and
+      forall(DataFlow::LocalSourceNode source | source = argument.getALocalSource() |
+        source.asExpr().(StringLiteral).getText() = result
+      )
+    )
+  }
+
+  private predicate resolvedConfigurationCall(
+    DataFlowDispatch::NormalCall call, string section, string key
+  ) {
+    section = constantArgument(call, "section") and
+    key = constantArgument(call, "key") and
+    not callNameIndicatesSensitiveData(call) and
+    onlyConfigurationSelectorArguments(call)
+  }
+
+  private predicate onlyConfigurationSelectorArguments(DataFlowDispatch::NormalCall call) {
+    forall(DataFlowDispatch::ArgumentPosition argumentPosition |
+      exists(call.getArgument(argumentPosition))
+    |
+      exists(DataFlowDispatch::ParameterPosition parameterPosition |
+        DataFlowDispatch::parameterMatch(parameterPosition, argumentPosition) and
+        (
+          parameterPosition.isSelf()
+          or
+          call.getCallable().getParameter(parameterPosition).getParameter().getName() in [
+              "section", "key"
+            ]
+        )
+      )
+    )
+  }
+
+  private predicate callNameIndicatesSensitiveData(DataFlowDispatch::NormalCall call) {
+    nameIndicatesSensitiveData(call.getCallable().getScope().(Function).getName())
+    or
+    nameIndicatesSensitiveData(call.getNode().(Cfg::CallNode).getFunction().(Cfg::NameNode).getId())
+    or
+    nameIndicatesSensitiveData(call.getNode()
+          .(Cfg::CallNode)
+          .getFunction()
+          .(Cfg::AttrNode)
+          .getName())
+  }
+
+  bindingset[name]
+  private predicate configurationSelectorIndicatesSensitiveData(string name) {
+    // File, path, and URL suffixes do not make configuration selectors safe: they
+    // commonly identify an indirect secret or a value that embeds credentials.
+    name.regexpMatch(maybeSensitiveRegexp(_))
+    or
+    name.regexpMatch("(?is).*(^|[_-])(secret|auth|salt|bearer|key(tab)?|token|cred(ential)?|conn(ect(ion)?)?|"
+        + "backend|dsn|url|uri|args|kwargs)([_-]|$).*")
+  }
+
+  /**
+   * Holds if every resolved target for `node` has concrete `section` and `key`
+   * arguments whose names do not indicate sensitive data.
+   */
+  predicate knownNonSensitiveConfigurationValue(DataFlow::Node node) {
+    exists(DataFlowDispatch::NormalCall call | call.getNode() = node.asCfgNode()) and
+    forall(DataFlowDispatch::NormalCall call | call.getNode() = node.asCfgNode() |
+      exists(string section, string key |
+        resolvedConfigurationCall(call, section, key) and
+        not configurationSelectorIndicatesSensitiveData(section) and
+        not configurationSelectorIndicatesSensitiveData(key)
+      )
+    )
   }
 
   /**
@@ -335,5 +417,17 @@ private module SensitiveDataModeling {
 }
 
 predicate sensitiveDataExtraStepForCalls = SensitiveDataModeling::extraStepForCalls/2;
+
+/**
+ * Holds if `node` is a resolved configuration lookup whose only inputs are its
+ * receiver and concrete, non-sensitive section and key names.
+ *
+ * This predicate is intended for use as a sensitive-data barrier. It blocks all
+ * flow through the lookup result, so calls with additional value arguments are
+ * deliberately excluded.
+ */
+predicate isKnownNonSensitiveConfigurationLookup(DataFlow::Node node) {
+  SensitiveDataModeling::knownNonSensitiveConfigurationValue(node)
+}
 
 predicate sensitiveLookupStringConst = SensitiveDataModeling::sensitiveLookupStringConst/1;

--- a/python/ql/lib/semmle/python/security/dataflow/CleartextLoggingCustomizations.qll
+++ b/python/ql/lib/semmle/python/security/dataflow/CleartextLoggingCustomizations.qll
@@ -36,6 +36,10 @@ module CleartextLogging {
    */
   abstract class Sanitizer extends DataFlow::Node { }
 
+  private class KnownNonSensitiveConfigurationLookupSanitizer extends Sanitizer {
+    KnownNonSensitiveConfigurationLookupSanitizer() { isKnownNonSensitiveConfigurationLookup(this) }
+  }
+
   /**
    * A source of sensitive data, considered as a flow source.
    */

--- a/python/ql/lib/semmle/python/security/dataflow/CleartextStorageCustomizations.qll
+++ b/python/ql/lib/semmle/python/security/dataflow/CleartextStorageCustomizations.qll
@@ -35,6 +35,10 @@ module CleartextStorage {
    */
   abstract class Sanitizer extends DataFlow::Node { }
 
+  private class KnownNonSensitiveConfigurationLookupSanitizer extends Sanitizer {
+    KnownNonSensitiveConfigurationLookupSanitizer() { isKnownNonSensitiveConfigurationLookup(this) }
+  }
+
   /**
    * A source of sensitive data, considered as a flow source.
    */

--- a/python/ql/lib/semmle/python/security/dataflow/WeakSensitiveDataHashingCustomizations.qll
+++ b/python/ql/lib/semmle/python/security/dataflow/WeakSensitiveDataHashingCustomizations.qll
@@ -48,6 +48,10 @@ module NormalHashFunction {
    */
   abstract class Sanitizer extends DataFlow::Node { }
 
+  private class KnownNonSensitiveConfigurationLookupSanitizer extends Sanitizer {
+    KnownNonSensitiveConfigurationLookupSanitizer() { isKnownNonSensitiveConfigurationLookup(this) }
+  }
+
   /**
    * A source of sensitive data, considered as a flow source.
    */
@@ -116,6 +120,10 @@ module ComputationallyExpensiveHashFunction {
    * algorithm on sensitive data" vulnerabilities.
    */
   abstract class Sanitizer extends DataFlow::Node { }
+
+  private class KnownNonSensitiveConfigurationLookupSanitizer extends Sanitizer {
+    KnownNonSensitiveConfigurationLookupSanitizer() { isKnownNonSensitiveConfigurationLookup(this) }
+  }
 
   /**
    * A source of passwords, considered as a flow source.

--- a/python/ql/test/library-tests/dataflow/sensitive-data/TestSensitiveDataSources.ql
+++ b/python/ql/test/library-tests/dataflow/sensitive-data/TestSensitiveDataSources.ql
@@ -40,6 +40,8 @@ module SensitiveUseConfig implements DataFlow::ConfigSig {
   predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
     sensitiveDataExtraStepForCalls(node1, node2)
   }
+
+  predicate isBarrier(DataFlow::Node node) { isKnownNonSensitiveConfigurationLookup(node) }
 }
 
 module SensitiveUseFlow = TaintTracking::Global<SensitiveUseConfig>;

--- a/python/ql/test/library-tests/dataflow/sensitive-data/test.py
+++ b/python/ql/test/library-tests/dataflow/sensitive-data/test.py
@@ -133,3 +133,39 @@ _config = {"sleep_timer": 5, "mysql_password": password}
 
 # since we have precise dictionary content, other items of the config are not tainted
 print(_config["sleep_timer"])
+
+
+# ------------------------------------------------------------------------------
+# cross-talk through configuration getters.
+# ------------------------------------------------------------------------------
+
+class Configuration:
+    def _get_secret_option(self, section, key):
+        if self.is_sensitive(section, key):
+            return load_secret_value() # $ SensitiveDataSource=secret
+        return None
+
+    def get(self, section, key):
+        value = self._get_secret_option(section, key) # $ SensitiveDataSource=secret
+        if value is not None:
+            return value
+        return "default"
+
+    def getlist(self, section, key):
+        return self.get(section, key).split(",")
+
+    def get_mandatory_list_value(self, section, key):
+        return self.getlist(section, key)
+
+
+configuration = Configuration()
+
+executor_name = configuration.get_mandatory_list_value("core", "EXECUTOR")[0]
+print(executor_name) # $ SPURIOUS: SensitiveUse=secret
+
+value2 = configuration.get_mandatory_list_value("database", "PASSWORD")[0]
+print(value2) # $ SensitiveUse=secret
+
+dynamic_key = get_key()
+dynamic_value = configuration.get_mandatory_list_value("core", dynamic_key)[0]
+print(dynamic_value) # $ SensitiveUse=secret

--- a/python/ql/test/library-tests/dataflow/sensitive-data/test.py
+++ b/python/ql/test/library-tests/dataflow/sensitive-data/test.py
@@ -145,11 +145,11 @@ class Configuration:
             return load_secret_value() # $ SensitiveDataSource=secret
         return None
 
-    def get(self, section, key):
+    def get(self, section, key, fallback="default"):
         value = self._get_secret_option(section, key) # $ SensitiveDataSource=secret
         if value is not None:
             return value
-        return "default"
+        return fallback
 
     def getlist(self, section, key):
         return self.get(section, key).split(",")
@@ -161,11 +161,38 @@ class Configuration:
 configuration = Configuration()
 
 executor_name = configuration.get_mandatory_list_value("core", "EXECUTOR")[0]
-print(executor_name) # $ SPURIOUS: SensitiveUse=secret
+print(executor_name)
 
+# A second Airflow-shaped path carries a non-sensitive directory through a helper.
+dags_folder = configuration.get_mandatory_list_value("core", "DAGS_FOLDER")[0]
+
+
+def find_path_from_directory(base_dir_path):
+    print(base_dir_path)
+
+
+find_path_from_directory(dags_folder)
+
+# Concrete sensitive keys remain conservative.
 value2 = configuration.get_mandatory_list_value("database", "PASSWORD")[0]
 print(value2) # $ SensitiveUse=secret
 
+# Configuration key names that can hold or locate secrets remain conservative.
+value_with_key_suffix = configuration.get_mandatory_list_value("crypto", "FERNET_KEY")[0]
+print(value_with_key_suffix) # $ SensitiveUse=secret
+
+value_with_path_suffix = configuration.get_mandatory_list_value("smtp", "PASSWORD_FILE")[0]
+print(value_with_path_suffix) # $ SensitiveUse=secret
+
+# Dynamic keys remain conservative.
 dynamic_key = get_key()
 dynamic_value = configuration.get_mandatory_list_value("core", dynamic_key)[0]
 print(dynamic_value) # $ SensitiveUse=secret
+
+# A sensitive callee name remains a source even with non-sensitive selector names.
+value3 = configuration._get_secret_option("core", "EXECUTOR") # $ SensitiveDataSource=secret
+print(value3) # $ SensitiveUse=secret
+
+# Additional value arguments prevent the call result from becoming a barrier.
+value4 = configuration.get("core", "EXECUTOR", get_password()) # $ SensitiveDataSource=password
+print(value4) # $ SensitiveUse=password SensitiveUse=secret


### PR DESCRIPTION
> [!IMPORTANT]
> Experimental draft stacked on #21925. This must not merge independently of its parent.

The base was revalidated immediately before creation at `github/codeql:yoff/python-shared-cfg-dataflow-flip` = `1a8e317b4a328bea1059453a2ab3ba6eada09e3f`.

## Causal evidence

This is not an Airflow model correction. Python's generic `SensitiveFunctionCall` heuristic marks `_get_config_value_from_secret_backend(...)` as a `secret` source because the resolved function name matches the sensitive-name regular expression. Global summaries then preserve the topological return path through Airflow's `_get_env_var_option` / `_get_secret_option`, `Configuration.get`, `getlist`, and `get_mandatory_list_value`, but they do not retain the control correlation between `(section, key) in self.sensitive_config_values` and each caller's concrete arguments.

Consequently, `core.EXECUTOR` and `core.DAGS_FOLDER` can inherit the secret source even though those pairs are not members of Airflow's runtime sensitive-key registry and cannot take the secret-backend branches. A secret-backend getter being reachable for some registered keys does not imply that every concrete key handled by the shared getter is sensitive.

The first commit reproduces this with an Airflow-shaped local flow and a passing `SPURIOUS` expectation. The second commit removes that annotation after the precision fix.

## Scope

The change deliberately leaves core dataflow and summary routing unchanged: those paths are topologically valid and useful to other analyses. Instead, `SensitiveDataSources` identifies a known non-sensitive configuration lookup only when:

- every resolved target maps conventional `section` and `key` parameters;
- all local sources agree on unique string literals;
- the receiver, section, and key are the only actual inputs;
- neither resolved nor syntactic callee names indicate sensitive data; and
- section/key names do not match sensitive or conservative configuration-secret indicators.

The clear-text logging, clear-text storage, and weak sensitive-data hashing customizations expose those nodes through their existing sanitizer extension points. There are no Airflow names or key values in the implementation.

## Exact Airflow evidence

On a locally extracted CodeQL database for `apache/airflow@a9da0f7fb48dc7526b2745be3e8fe64e1c775da2`:

- the parent query produced 81 result rows; this branch produces 41;
- the `core.EXECUTOR` family at `executor_loader.py:225/234` is removed;
- the `core.DAGS_FOLDER` family at `utils/file.py:68/96` is removed;
- the final barrier matches 354 call sites / 212 unique concrete pairs; none overlap Airflow's 9 metadata-declared sensitive `(section, key)` pairs; and
- evaluation was 11.4s on the parent versus 4.9s on the final query in this local run.

The DCA report's `cli_parser.py:64` row is the motivating `core.EXECUTOR` route. The local extraction did not reproduce that exact sink location, so its evidence remains the DCA comparison plus the independently reproduced shared configuration route; the exact local database did reproduce and remove the related executor and file-path families above.

## Conservative controls

Tests retain flow for:

- concrete `PASSWORD`, `FERNET_KEY`, and `PASSWORD_FILE` selectors;
- dynamic keys;
- direct secret-named getter calls; and
- calls with an additional sensitive fallback argument.

Ambiguous or unresolved calls also remain conservative because every resolved target must satisfy the refinement.

## Limitations

This is still a name-based heuristic refinement. It intentionally recognizes only configuration APIs using conventional `section` / `key` formal names and does not attempt arbitrary application registry reasoning. Calls with additional value inputs are excluded because the sanitizer blocks the complete lookup result, not one incoming edge. The broad Airflow result delta is why this remains an experimental draft despite the zero-overlap registry audit.

## Validation

- `python/ql/test/library-tests/dataflow/sensitive-data`
- `python/ql/test/query-tests/Security/CWE-312-CleartextLogging`
- `python/ql/test/query-tests/Security/CWE-312-CleartextStorage`
- `python/ql/test/query-tests/Security/CWE-312-CleartextStorage-py3`
- `python/ql/test/query-tests/Security/CWE-327-WeakSensitiveDataHashing`
- QL formatting checks for all modified QL files
