### PR TITLE
Experiment: restore captured-jump selectivity with shared SSA

### DIFF
--- a/python/ql/lib/semmle/python/dataflow/new/internal/TypeTrackingImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/TypeTrackingImpl.qll
@@ -324,10 +324,12 @@ module TypeTrackingInput implements Shared::TypeTrackingInput<Location> {
     // nodeFrom is `expr`
     // nodeTo is entry node for `f`
     exists(
-      SsaImpl::ScopeEntryDefinition e, SsaImpl::SsaSourceVariable var, Cfg::DefinitionNode def
+      SsaImpl::ScopeEntryDefinition e, SsaImpl::SsaSourceVariable var,
+      SsaImpl::EssaNodeDefinition write, Cfg::DefinitionNode def
     |
       e.getSourceVariable() = var and
-      def.getNode() = var.getVariable().getAStore()
+      write.getSourceVariable() = var and
+      write.getDefiningNode() = def
     |
       nodeTo.(DataFlowPublic::ScopeEntryDefinitionNode).getDefinition() = e and
       nodeFrom.asCfgNode() = def and

--- a/python/ql/test/library-tests/dataflow/typetracking/test.py
+++ b/python/ql/test/library-tests/dataflow/typetracking/test.py
@@ -86,14 +86,14 @@ def captured_reassignment_tradeoff():
     value = tracked # $ tracked
 
     def read_value():
-        return value # $ tracked
+        return value # $ MISSING: tracked
 
-    before_reassignment = read_value() # $ tracked
+    before_reassignment = read_value() # $ MISSING: tracked
     value = "safe"
-    safe_sibling = read_value() # $ SPURIOUS: tracked
+    safe_sibling = read_value()
 
-    before_reassignment # $ tracked
-    safe_sibling # $ SPURIOUS: tracked
+    before_reassignment # $ MISSING: tracked
+    safe_sibling
 
 
 # ------------------------------------------------------------------------------

--- a/python/ql/test/library-tests/dataflow/typetracking/test.py
+++ b/python/ql/test/library-tests/dataflow/typetracking/test.py
@@ -79,6 +79,24 @@ def from_parameter_default():
 
 
 # ------------------------------------------------------------------------------
+# Captured variable reassignment
+# ------------------------------------------------------------------------------
+
+def captured_reassignment_tradeoff():
+    value = tracked # $ tracked
+
+    def read_value():
+        return value # $ tracked
+
+    before_reassignment = read_value() # $ tracked
+    value = "safe"
+    safe_sibling = read_value() # $ SPURIOUS: tracked
+
+    before_reassignment # $ tracked
+    safe_sibling # $ SPURIOUS: tracked
+
+
+# ------------------------------------------------------------------------------
 # Function decorator
 # ------------------------------------------------------------------------------
 


### PR DESCRIPTION
## Experiment

Dependent on #21925. This draft does **not** claim semantic equivalence with legacy ESSA; it measures the closest general shared-SSA gate for `TypeTrackingInput::capturedJumpStep`.

The gate now requires an actual non-phi `SsaImpl::EssaNodeDefinition` whose `getSourceVariable()` is the captured `SsaSourceVariable` and whose `getDefiningNode()` is the candidate `Cfg::DefinitionNode`, instead of admitting every syntactic `Variable.getAStore()`.

## Exact two-commit structure

1. `439edf66b1fcc4b6c73827f1bad0e9d2716db4e8` — red-state inline regression test; broad behavior passes with the safe read marked `SPURIOUS`.
2. `33133d6cc5e8cd179d7787454140da64c46220e3` — selective shared-SSA implementation; expected lost captures become `MISSING` and the safe-read spurious results disappear.

## Tuple measurements

| Database | Broad | SSA-gated | Broad-only | SSA-only |
| --- | ---: | ---: | ---: | ---: |
| Focused typetracking test DB | 49 | 48 | 1 | 0 |
| `zauberzeug/nicegui@26756ccf` local corpus DB | 6,958 | 6,929 | 29 | 0 |
| `openai/codex@cd2d84d4` local corpus DB | 154 | 150 | 4 | 0 |
| `qlustered/deepdiff@6f3d5eeb` local corpus DB | 2,146 | 2,140 | 6 | 0 |

No reusable exact Airflow `a9da0f7fb48dc7526b2745be3e8fe64e1c775da2` database was present in the current worktree, session artifacts, or known local CodeQL database/cache locations, so this experiment does not fabricate an Airflow measurement.

## Precision trade-off

The focused test assigns `tracked`, reads it through a closure, reassigns the variable to a safe value, then reads through the closure again. The broad gate reports both reads. The SSA gate removes the one broad-only write tuple: three true-positive annotation sites before reassignment are intentionally recorded as `MISSING`, while two `SPURIOUS` annotation sites for the safe sibling read disappear. This is evidence of restored legacy-style selectivity, not proof of semantic equivalence.

## Validation

- `codeql test run python/ql/test/library-tests/dataflow/typetracking --threads=2` — 2/2 passed in both red and green states.
- `codeql test run python/ql/test/library-tests/dataflow/typetracking python/ql/test/library-tests/dataflow/global-or-captured-vars python/ql/test/library-tests/dataflow/variable-capture python/ql/test/library-tests/dataflow/regression --threads=2` — 7/7 passed.
- `codeql query format --check-only python/ql/lib/semmle/python/dataflow/new/internal/TypeTrackingImpl.qll` — passed.
- Temporary tuple instrumentation compiled and produced the exact counts above; it is not part of the branch.

The branch is ready for a DCA comparison against #21925 (including baseline #38534 / data branch `data/yoff/PR-21925-0-python__1`).
