### PR TITLE
Rust: Canonical paths for blanket implementations

### DIFF
--- a/rust/ql/lib/codeql/rust/internal/PathResolution.qll
+++ b/rust/ql/lib/codeql/rust/internal/PathResolution.qll
@@ -874,7 +874,12 @@ final class ImplItemNode extends ImplOrTraitItemNode instanceof Impl {
    */
   predicate isBlanketImplementation() { exists(this.getBlanketImplementationTypeParam()) }
 
-  override predicate hasCanonicalPath(Crate c) { this.resolveSelfTy().hasCanonicalPathPrefix(c) }
+  override predicate hasCanonicalPath(Crate c) {
+    this.resolveSelfTy().hasCanonicalPathPrefix(c)
+    or
+    this.isBlanketImplementation() and
+    c.getASourceFile().getFile() = this.getFile()
+  }
 
   /**
    * Holds if `(c1, c2)` forms a pair of crates for the type and trait
@@ -920,7 +925,12 @@ final class ImplItemNode extends ImplOrTraitItemNode instanceof Impl {
     result = "<"
     or
     i = 1 and
-    result = this.getSelfCanonicalPath(c)
+    (
+      result = this.getSelfCanonicalPath(c)
+      or
+      this.isBlanketImplementation() and
+      result = "_"
+    )
     or
     if exists(this.getTraitPath())
     then

--- a/rust/ql/test/extractor-tests/canonical_path/canonical_paths.expected
+++ b/rust/ql/test/extractor-tests/canonical_path/canonical_paths.expected
@@ -15,6 +15,8 @@
 | regular.rs:13:5:13:18 | fn g | <test::regular::Struct>::g |
 | regular.rs:16:1:18:1 | trait TraitWithBlanketImpl | test::regular::TraitWithBlanketImpl |
 | regular.rs:17:5:17:16 | fn h | test::regular::TraitWithBlanketImpl::h |
+| regular.rs:20:1:22:1 | impl TraitWithBlanketImpl for T { ... } | <_ as test::regular::TraitWithBlanketImpl> |
+| regular.rs:21:5:21:18 | fn h | <_ as test::regular::TraitWithBlanketImpl>::h |
 | regular.rs:24:1:24:12 | fn free | test::regular::free |
 | regular.rs:26:1:32:1 | fn usage | test::regular::usage |
 | regular.rs:34:1:38:1 | enum MyEnum | test::regular::MyEnum |

--- a/rust/ql/test/library-tests/dataflow/models/external_file.rs
+++ b/rust/ql/test/library-tests/dataflow/models/external_file.rs
@@ -1,4 +1,3 @@
-
 pub fn generated_source(i: i64) -> i64 {
     0
 }
@@ -27,4 +26,15 @@ pub fn neutral_generated_summary(i: i64) -> i64 {
 
 pub fn neutral_manual_summary(i: i64) -> i64 {
     0
+}
+
+pub trait MyTrait2 {
+    fn flow_through2(i: i64) -> i64;
+}
+
+impl<T> MyTrait2 for T {
+    // inherits model from the trait function
+    fn flow_through2(i: i64) -> i64 {
+        0
+    }
 }

--- a/rust/ql/test/library-tests/dataflow/models/main.rs
+++ b/rust/ql/test/library-tests/dataflow/models/main.rs
@@ -102,7 +102,7 @@ fn test_set_var_field() {
     match e1 {
         MyFieldEnum::C { field_c: i } => sink(i),
         MyFieldEnum::D { field_d: i } => sink(i), // $ hasValueFlow=5
-        MyFieldEnum::E { field_e: o } => ()
+        MyFieldEnum::E { field_e: o } => (),
     }
 }
 
@@ -258,18 +258,17 @@ fn test_enum_source() {
     match s {
         MyFieldEnum::C { field_c: i } => sink(i),
         MyFieldEnum::D { field_d: i } => sink(i), // $ hasValueFlow=12
-        MyFieldEnum::E { field_e: o } => ()
+        MyFieldEnum::E { field_e: o } => (),
     }
 
     let s = enum_source_nested(13);
     match s {
         MyFieldEnum::C { field_c: i } => sink(i),
         MyFieldEnum::D { field_d: i } => sink(i),
-        MyFieldEnum::E { field_e: o } => 
-        { 
+        MyFieldEnum::E { field_e: o } => {
             match o {
                 Some(i) => sink(i), // $ hasValueFlow=13
-                None => ()
+                None => (),
             }
         }
     }
@@ -281,13 +280,13 @@ fn test_enum_method_source() {
     match s {
         MyFieldEnum::C { field_c: i } => sink(i), // $ hasValueFlow=13
         MyFieldEnum::D { field_d: i } => sink(i),
-        MyFieldEnum::E { field_e: o } => ()
+        MyFieldEnum::E { field_e: o } => (),
     }
 }
 
 mod source_into_function {
-    use crate::MyFieldEnum;
     use super::sink;
+    use crate::MyFieldEnum;
 
     // has a source model
     fn pass_source<A>(_i: i64, f: impl FnOnce(i64) -> A) -> A {
@@ -320,11 +319,10 @@ mod source_into_function {
             match e {
                 MyFieldEnum::C { field_c: i } => sink(i),
                 MyFieldEnum::D { field_d: i } => sink(i),
-                MyFieldEnum::E { field_e: o } => 
-                { 
+                MyFieldEnum::E { field_e: o } => {
                     match o {
                         Some(i) => sink(i), // $ hasValueFlow=5
-                        None => ()
+                        None => (),
                     }
                 }
             }
@@ -333,14 +331,14 @@ mod source_into_function {
 }
 
 mod sink_out_of_function {
-    use crate::MyFieldEnum;
     use super::source;
+    use crate::MyFieldEnum;
 
     // has a sink model
-    fn pass_sink(f: impl FnOnce(()) -> i64) { }
+    fn pass_sink(f: impl FnOnce(()) -> i64) {}
 
     // has a sink model
-    fn pass_sink_nested(f: impl FnOnce(()) -> MyFieldEnum) { }
+    fn pass_sink_nested(f: impl FnOnce(()) -> MyFieldEnum) {}
 
     fn test_sink_out_of_function() {
         let a = |a| source(1);
@@ -348,7 +346,9 @@ mod sink_out_of_function {
 
         let b = |_a| {
             let s = source(2);
-            MyFieldEnum::E { field_e: Option::Some(s) }
+            MyFieldEnum::E {
+                field_e: Option::Some(s),
+            }
         };
         pass_sink_nested(b); // $ hasValueFlow=2
     }
@@ -460,6 +460,17 @@ impl Ord for MyStruct2 {
     }
 }
 
+trait MyTrait3 {
+    fn flow_through3(i: i64) -> i64;
+}
+
+impl<T> MyTrait3 for T {
+    // has an explicit model
+    fn flow_through3(i: i64) -> i64 {
+        0
+    }
+}
+
 fn test_trait_model<T: Ord>(x: T) {
     let x1 = source(20).max(0);
     sink(x1); // $ hasValueFlow=20
@@ -488,6 +499,12 @@ fn test_trait_model<T: Ord>(x: T) {
 
     let x7 = (source(28) as i32) < 1;
     sink(x7);
+
+    let x8 = <()>::flow_through2(source(29));
+    sink(x8); // $ hasValueFlow=29
+
+    let x9 = <()>::flow_through3(source(30));
+    sink(x9); // $ MISSING: hasValueFlow=30
 }
 
 mod external_file;

--- a/rust/ql/test/library-tests/dataflow/models/main.rs
+++ b/rust/ql/test/library-tests/dataflow/models/main.rs
@@ -504,7 +504,7 @@ fn test_trait_model<T: Ord>(x: T) {
     sink(x8); // $ hasValueFlow=29
 
     let x9 = <()>::flow_through3(source(30));
-    sink(x9); // $ MISSING: hasValueFlow=30
+    sink(x9); // $ hasValueFlow=30
 }
 
 mod external_file;

--- a/rust/ql/test/library-tests/dataflow/models/models.expected
+++ b/rust/ql/test/library-tests/dataflow/models/models.expected
@@ -17,27 +17,28 @@ models
 | 16 | Source: main::simple_source; ReturnValue; test-source |
 | 17 | Source: main::source_into_function::pass_source; Argument[1].Parameter[0]; test-source |
 | 18 | Source: main::source_into_function::pass_source_nested; Argument[1].Parameter[0].Field[main::MyFieldEnum::E::field_e].Field[core::option::Option::Some(0)]; test-source |
-| 19 | Summary: core::cmp::Ord::max; Argument[self,0]; ReturnValue; value |
-| 20 | Summary: core::cmp::PartialOrd::lt; Argument[self].Reference; ReturnValue; taint |
-| 21 | Summary: core::ops::index::Index::index; Argument[self].Reference.Element; ReturnValue.Reference; value |
-| 22 | Summary: main::apply; Argument[0]; Argument[1].Parameter[0]; value |
-| 23 | Summary: main::apply; Argument[1].ReturnValue; ReturnValue; value |
-| 24 | Summary: main::coerce; Argument[0]; ReturnValue; taint |
-| 25 | Summary: main::external_file::MyTrait2::flow_through2; Argument[0]; ReturnValue; value |
-| 26 | Summary: main::external_file::generated_summary; Argument[0]; ReturnValue; value |
-| 27 | Summary: main::external_file::neutral_manual_summary; Argument[0]; ReturnValue; value |
-| 28 | Summary: main::get_array_element; Argument[0].Element; ReturnValue; value |
-| 29 | Summary: main::get_async_number; Argument[0]; ReturnValue.Future; value |
-| 30 | Summary: main::get_struct_field; Argument[0].Field[main::MyStruct::field1]; ReturnValue; value |
-| 31 | Summary: main::get_tuple_element; Argument[0].Field[0]; ReturnValue; value |
-| 32 | Summary: main::get_var_field; Argument[0].Field[main::MyFieldEnum::C::field_c]; ReturnValue; value |
-| 33 | Summary: main::get_var_pos; Argument[0].Field[main::MyPosEnum::A(0)]; ReturnValue; value |
-| 34 | Summary: main::set_array_element; Argument[0]; ReturnValue.Element; value |
-| 35 | Summary: main::set_struct_field; Argument[0]; ReturnValue.Field[main::MyStruct::field2]; value |
-| 36 | Summary: main::set_tuple_element; Argument[0]; ReturnValue.Field[1]; value |
-| 37 | Summary: main::set_var_field; Argument[0]; ReturnValue.Field[main::MyFieldEnum::D::field_d]; value |
-| 38 | Summary: main::set_var_pos; Argument[0]; ReturnValue.Field[main::MyPosEnum::B(0)]; value |
-| 39 | Summary: main::snd; Argument[1]; ReturnValue; value |
+| 19 | Summary: <_ as main::MyTrait3>::flow_through3; Argument[0]; ReturnValue; value |
+| 20 | Summary: core::cmp::Ord::max; Argument[self,0]; ReturnValue; value |
+| 21 | Summary: core::cmp::PartialOrd::lt; Argument[self].Reference; ReturnValue; taint |
+| 22 | Summary: core::ops::index::Index::index; Argument[self].Reference.Element; ReturnValue.Reference; value |
+| 23 | Summary: main::apply; Argument[0]; Argument[1].Parameter[0]; value |
+| 24 | Summary: main::apply; Argument[1].ReturnValue; ReturnValue; value |
+| 25 | Summary: main::coerce; Argument[0]; ReturnValue; taint |
+| 26 | Summary: main::external_file::MyTrait2::flow_through2; Argument[0]; ReturnValue; value |
+| 27 | Summary: main::external_file::generated_summary; Argument[0]; ReturnValue; value |
+| 28 | Summary: main::external_file::neutral_manual_summary; Argument[0]; ReturnValue; value |
+| 29 | Summary: main::get_array_element; Argument[0].Element; ReturnValue; value |
+| 30 | Summary: main::get_async_number; Argument[0]; ReturnValue.Future; value |
+| 31 | Summary: main::get_struct_field; Argument[0].Field[main::MyStruct::field1]; ReturnValue; value |
+| 32 | Summary: main::get_tuple_element; Argument[0].Field[0]; ReturnValue; value |
+| 33 | Summary: main::get_var_field; Argument[0].Field[main::MyFieldEnum::C::field_c]; ReturnValue; value |
+| 34 | Summary: main::get_var_pos; Argument[0].Field[main::MyPosEnum::A(0)]; ReturnValue; value |
+| 35 | Summary: main::set_array_element; Argument[0]; ReturnValue.Element; value |
+| 36 | Summary: main::set_struct_field; Argument[0]; ReturnValue.Field[main::MyStruct::field2]; value |
+| 37 | Summary: main::set_tuple_element; Argument[0]; ReturnValue.Field[1]; value |
+| 38 | Summary: main::set_var_field; Argument[0]; ReturnValue.Field[main::MyFieldEnum::D::field_d]; value |
+| 39 | Summary: main::set_var_pos; Argument[0]; ReturnValue.Field[main::MyPosEnum::B(0)]; value |
+| 40 | Summary: main::snd; Argument[1]; ReturnValue; value |
 edges
 | main.rs:15:9:15:9 | s | main.rs:16:19:16:19 | s | provenance |  |
 | main.rs:15:9:15:9 | s | main.rs:16:19:16:19 | s | provenance |  |
@@ -47,13 +48,13 @@ edges
 | main.rs:16:19:16:19 | s | main.rs:16:10:16:20 | identity(...) | provenance | QL |
 | main.rs:25:9:25:9 | s | main.rs:26:17:26:17 | s | provenance |  |
 | main.rs:25:13:25:22 | source(...) | main.rs:25:9:25:9 | s | provenance |  |
-| main.rs:26:17:26:17 | s | main.rs:26:10:26:18 | coerce(...) | provenance | MaD:24 |
+| main.rs:26:17:26:17 | s | main.rs:26:10:26:18 | coerce(...) | provenance | MaD:25 |
 | main.rs:41:9:41:10 | s1 | main.rs:42:17:42:18 | s1 | provenance |  |
 | main.rs:41:9:41:10 | s1 | main.rs:42:17:42:18 | s1 | provenance |  |
 | main.rs:41:14:41:23 | source(...) | main.rs:41:9:41:10 | s1 | provenance |  |
 | main.rs:41:14:41:23 | source(...) | main.rs:41:9:41:10 | s1 | provenance |  |
-| main.rs:42:17:42:18 | s1 | main.rs:42:10:42:19 | snd(...) | provenance | MaD:39 |
-| main.rs:42:17:42:18 | s1 | main.rs:42:10:42:19 | snd(...) | provenance | MaD:39 |
+| main.rs:42:17:42:18 | s1 | main.rs:42:10:42:19 | snd(...) | provenance | MaD:40 |
+| main.rs:42:17:42:18 | s1 | main.rs:42:10:42:19 | snd(...) | provenance | MaD:40 |
 | main.rs:54:9:54:9 | s | main.rs:55:27:55:27 | s | provenance |  |
 | main.rs:54:9:54:9 | s | main.rs:55:27:55:27 | s | provenance |  |
 | main.rs:54:13:54:21 | source(...) | main.rs:54:9:54:9 | s | provenance |  |
@@ -64,8 +65,8 @@ edges
 | main.rs:55:14:55:28 | ...::A(...) [A] | main.rs:55:9:55:10 | e1 [A] | provenance |  |
 | main.rs:55:27:55:27 | s | main.rs:55:14:55:28 | ...::A(...) [A] | provenance |  |
 | main.rs:55:27:55:27 | s | main.rs:55:14:55:28 | ...::A(...) [A] | provenance |  |
-| main.rs:56:22:56:23 | e1 [A] | main.rs:56:10:56:24 | get_var_pos(...) | provenance | MaD:33 |
-| main.rs:56:22:56:23 | e1 [A] | main.rs:56:10:56:24 | get_var_pos(...) | provenance | MaD:33 |
+| main.rs:56:22:56:23 | e1 [A] | main.rs:56:10:56:24 | get_var_pos(...) | provenance | MaD:34 |
+| main.rs:56:22:56:23 | e1 [A] | main.rs:56:10:56:24 | get_var_pos(...) | provenance | MaD:34 |
 | main.rs:67:9:67:9 | s | main.rs:68:26:68:26 | s | provenance |  |
 | main.rs:67:9:67:9 | s | main.rs:68:26:68:26 | s | provenance |  |
 | main.rs:67:13:67:21 | source(...) | main.rs:67:9:67:9 | s | provenance |  |
@@ -74,8 +75,8 @@ edges
 | main.rs:68:9:68:10 | e1 [B] | main.rs:69:11:69:12 | e1 [B] | provenance |  |
 | main.rs:68:14:68:27 | set_var_pos(...) [B] | main.rs:68:9:68:10 | e1 [B] | provenance |  |
 | main.rs:68:14:68:27 | set_var_pos(...) [B] | main.rs:68:9:68:10 | e1 [B] | provenance |  |
-| main.rs:68:26:68:26 | s | main.rs:68:14:68:27 | set_var_pos(...) [B] | provenance | MaD:38 |
-| main.rs:68:26:68:26 | s | main.rs:68:14:68:27 | set_var_pos(...) [B] | provenance | MaD:38 |
+| main.rs:68:26:68:26 | s | main.rs:68:14:68:27 | set_var_pos(...) [B] | provenance | MaD:39 |
+| main.rs:68:26:68:26 | s | main.rs:68:14:68:27 | set_var_pos(...) [B] | provenance | MaD:39 |
 | main.rs:69:11:69:12 | e1 [B] | main.rs:71:9:71:23 | ...::B(...) [B] | provenance |  |
 | main.rs:69:11:69:12 | e1 [B] | main.rs:71:9:71:23 | ...::B(...) [B] | provenance |  |
 | main.rs:71:9:71:23 | ...::B(...) [B] | main.rs:71:22:71:22 | i | provenance |  |
@@ -92,8 +93,8 @@ edges
 | main.rs:88:14:88:42 | ...::C {...} [C] | main.rs:88:9:88:10 | e1 [C] | provenance |  |
 | main.rs:88:40:88:40 | s | main.rs:88:14:88:42 | ...::C {...} [C] | provenance |  |
 | main.rs:88:40:88:40 | s | main.rs:88:14:88:42 | ...::C {...} [C] | provenance |  |
-| main.rs:89:24:89:25 | e1 [C] | main.rs:89:10:89:26 | get_var_field(...) | provenance | MaD:32 |
-| main.rs:89:24:89:25 | e1 [C] | main.rs:89:10:89:26 | get_var_field(...) | provenance | MaD:32 |
+| main.rs:89:24:89:25 | e1 [C] | main.rs:89:10:89:26 | get_var_field(...) | provenance | MaD:33 |
+| main.rs:89:24:89:25 | e1 [C] | main.rs:89:10:89:26 | get_var_field(...) | provenance | MaD:33 |
 | main.rs:100:9:100:9 | s | main.rs:101:28:101:28 | s | provenance |  |
 | main.rs:100:9:100:9 | s | main.rs:101:28:101:28 | s | provenance |  |
 | main.rs:100:13:100:21 | source(...) | main.rs:100:9:100:9 | s | provenance |  |
@@ -102,8 +103,8 @@ edges
 | main.rs:101:9:101:10 | e1 [D] | main.rs:102:11:102:12 | e1 [D] | provenance |  |
 | main.rs:101:14:101:29 | set_var_field(...) [D] | main.rs:101:9:101:10 | e1 [D] | provenance |  |
 | main.rs:101:14:101:29 | set_var_field(...) [D] | main.rs:101:9:101:10 | e1 [D] | provenance |  |
-| main.rs:101:28:101:28 | s | main.rs:101:14:101:29 | set_var_field(...) [D] | provenance | MaD:37 |
-| main.rs:101:28:101:28 | s | main.rs:101:14:101:29 | set_var_field(...) [D] | provenance | MaD:37 |
+| main.rs:101:28:101:28 | s | main.rs:101:14:101:29 | set_var_field(...) [D] | provenance | MaD:38 |
+| main.rs:101:28:101:28 | s | main.rs:101:14:101:29 | set_var_field(...) [D] | provenance | MaD:38 |
 | main.rs:102:11:102:12 | e1 [D] | main.rs:104:9:104:37 | ...::D {...} [D] | provenance |  |
 | main.rs:102:11:102:12 | e1 [D] | main.rs:104:9:104:37 | ...::D {...} [D] | provenance |  |
 | main.rs:104:9:104:37 | ...::D {...} [D] | main.rs:104:35:104:35 | i | provenance |  |
@@ -120,8 +121,8 @@ edges
 | main.rs:121:21:124:5 | MyStruct {...} [MyStruct.field1] | main.rs:121:9:121:17 | my_struct [MyStruct.field1] | provenance |  |
 | main.rs:122:17:122:17 | s | main.rs:121:21:124:5 | MyStruct {...} [MyStruct.field1] | provenance |  |
 | main.rs:122:17:122:17 | s | main.rs:121:21:124:5 | MyStruct {...} [MyStruct.field1] | provenance |  |
-| main.rs:125:27:125:35 | my_struct [MyStruct.field1] | main.rs:125:10:125:36 | get_struct_field(...) | provenance | MaD:30 |
-| main.rs:125:27:125:35 | my_struct [MyStruct.field1] | main.rs:125:10:125:36 | get_struct_field(...) | provenance | MaD:30 |
+| main.rs:125:27:125:35 | my_struct [MyStruct.field1] | main.rs:125:10:125:36 | get_struct_field(...) | provenance | MaD:31 |
+| main.rs:125:27:125:35 | my_struct [MyStruct.field1] | main.rs:125:10:125:36 | get_struct_field(...) | provenance | MaD:31 |
 | main.rs:142:9:142:9 | s | main.rs:143:38:143:38 | s | provenance |  |
 | main.rs:142:9:142:9 | s | main.rs:143:38:143:38 | s | provenance |  |
 | main.rs:142:13:142:21 | source(...) | main.rs:142:9:142:9 | s | provenance |  |
@@ -130,16 +131,16 @@ edges
 | main.rs:143:9:143:17 | my_struct [MyStruct.field2] | main.rs:145:10:145:18 | my_struct [MyStruct.field2] | provenance |  |
 | main.rs:143:21:143:39 | set_struct_field(...) [MyStruct.field2] | main.rs:143:9:143:17 | my_struct [MyStruct.field2] | provenance |  |
 | main.rs:143:21:143:39 | set_struct_field(...) [MyStruct.field2] | main.rs:143:9:143:17 | my_struct [MyStruct.field2] | provenance |  |
-| main.rs:143:38:143:38 | s | main.rs:143:21:143:39 | set_struct_field(...) [MyStruct.field2] | provenance | MaD:35 |
-| main.rs:143:38:143:38 | s | main.rs:143:21:143:39 | set_struct_field(...) [MyStruct.field2] | provenance | MaD:35 |
+| main.rs:143:38:143:38 | s | main.rs:143:21:143:39 | set_struct_field(...) [MyStruct.field2] | provenance | MaD:36 |
+| main.rs:143:38:143:38 | s | main.rs:143:21:143:39 | set_struct_field(...) [MyStruct.field2] | provenance | MaD:36 |
 | main.rs:145:10:145:18 | my_struct [MyStruct.field2] | main.rs:145:10:145:25 | my_struct.field2 | provenance |  |
 | main.rs:145:10:145:18 | my_struct [MyStruct.field2] | main.rs:145:10:145:25 | my_struct.field2 | provenance |  |
 | main.rs:154:9:154:9 | s | main.rs:155:29:155:29 | s | provenance |  |
 | main.rs:154:9:154:9 | s | main.rs:155:29:155:29 | s | provenance |  |
 | main.rs:154:13:154:21 | source(...) | main.rs:154:9:154:9 | s | provenance |  |
 | main.rs:154:13:154:21 | source(...) | main.rs:154:9:154:9 | s | provenance |  |
-| main.rs:155:28:155:30 | [...] [element] | main.rs:155:10:155:31 | get_array_element(...) | provenance | MaD:28 |
-| main.rs:155:28:155:30 | [...] [element] | main.rs:155:10:155:31 | get_array_element(...) | provenance | MaD:28 |
+| main.rs:155:28:155:30 | [...] [element] | main.rs:155:10:155:31 | get_array_element(...) | provenance | MaD:29 |
+| main.rs:155:28:155:30 | [...] [element] | main.rs:155:10:155:31 | get_array_element(...) | provenance | MaD:29 |
 | main.rs:155:29:155:29 | s | main.rs:155:28:155:30 | [...] [element] | provenance |  |
 | main.rs:155:29:155:29 | s | main.rs:155:28:155:30 | [...] [element] | provenance |  |
 | main.rs:164:9:164:9 | s | main.rs:165:33:165:33 | s | provenance |  |
@@ -150,10 +151,10 @@ edges
 | main.rs:165:9:165:11 | arr [element] | main.rs:166:10:166:12 | arr [element] | provenance |  |
 | main.rs:165:15:165:34 | set_array_element(...) [element] | main.rs:165:9:165:11 | arr [element] | provenance |  |
 | main.rs:165:15:165:34 | set_array_element(...) [element] | main.rs:165:9:165:11 | arr [element] | provenance |  |
-| main.rs:165:33:165:33 | s | main.rs:165:15:165:34 | set_array_element(...) [element] | provenance | MaD:34 |
-| main.rs:165:33:165:33 | s | main.rs:165:15:165:34 | set_array_element(...) [element] | provenance | MaD:34 |
-| main.rs:166:10:166:12 | arr [element] | main.rs:166:10:166:15 | arr[0] | provenance | MaD:21 |
-| main.rs:166:10:166:12 | arr [element] | main.rs:166:10:166:15 | arr[0] | provenance | MaD:21 |
+| main.rs:165:33:165:33 | s | main.rs:165:15:165:34 | set_array_element(...) [element] | provenance | MaD:35 |
+| main.rs:165:33:165:33 | s | main.rs:165:15:165:34 | set_array_element(...) [element] | provenance | MaD:35 |
+| main.rs:166:10:166:12 | arr [element] | main.rs:166:10:166:15 | arr[0] | provenance | MaD:22 |
+| main.rs:166:10:166:12 | arr [element] | main.rs:166:10:166:15 | arr[0] | provenance | MaD:22 |
 | main.rs:175:9:175:9 | s | main.rs:176:14:176:14 | s | provenance |  |
 | main.rs:175:9:175:9 | s | main.rs:176:14:176:14 | s | provenance |  |
 | main.rs:175:13:175:22 | source(...) | main.rs:175:9:175:9 | s | provenance |  |
@@ -164,8 +165,8 @@ edges
 | main.rs:176:13:176:18 | TupleExpr [tuple.0] | main.rs:176:9:176:9 | t [tuple.0] | provenance |  |
 | main.rs:176:14:176:14 | s | main.rs:176:13:176:18 | TupleExpr [tuple.0] | provenance |  |
 | main.rs:176:14:176:14 | s | main.rs:176:13:176:18 | TupleExpr [tuple.0] | provenance |  |
-| main.rs:177:28:177:28 | t [tuple.0] | main.rs:177:10:177:29 | get_tuple_element(...) | provenance | MaD:31 |
-| main.rs:177:28:177:28 | t [tuple.0] | main.rs:177:10:177:29 | get_tuple_element(...) | provenance | MaD:31 |
+| main.rs:177:28:177:28 | t [tuple.0] | main.rs:177:10:177:29 | get_tuple_element(...) | provenance | MaD:32 |
+| main.rs:177:28:177:28 | t [tuple.0] | main.rs:177:10:177:29 | get_tuple_element(...) | provenance | MaD:32 |
 | main.rs:188:9:188:9 | s | main.rs:189:31:189:31 | s | provenance |  |
 | main.rs:188:9:188:9 | s | main.rs:189:31:189:31 | s | provenance |  |
 | main.rs:188:13:188:22 | source(...) | main.rs:188:9:188:9 | s | provenance |  |
@@ -174,8 +175,8 @@ edges
 | main.rs:189:9:189:9 | t [tuple.1] | main.rs:191:10:191:10 | t [tuple.1] | provenance |  |
 | main.rs:189:13:189:32 | set_tuple_element(...) [tuple.1] | main.rs:189:9:189:9 | t [tuple.1] | provenance |  |
 | main.rs:189:13:189:32 | set_tuple_element(...) [tuple.1] | main.rs:189:9:189:9 | t [tuple.1] | provenance |  |
-| main.rs:189:31:189:31 | s | main.rs:189:13:189:32 | set_tuple_element(...) [tuple.1] | provenance | MaD:36 |
-| main.rs:189:31:189:31 | s | main.rs:189:13:189:32 | set_tuple_element(...) [tuple.1] | provenance | MaD:36 |
+| main.rs:189:31:189:31 | s | main.rs:189:13:189:32 | set_tuple_element(...) [tuple.1] | provenance | MaD:37 |
+| main.rs:189:31:189:31 | s | main.rs:189:13:189:32 | set_tuple_element(...) [tuple.1] | provenance | MaD:37 |
 | main.rs:191:10:191:10 | t [tuple.1] | main.rs:191:10:191:12 | t.1 | provenance |  |
 | main.rs:191:10:191:10 | t [tuple.1] | main.rs:191:10:191:12 | t.1 | provenance |  |
 | main.rs:203:9:203:9 | s | main.rs:208:11:208:11 | s | provenance |  |
@@ -184,8 +185,8 @@ edges
 | main.rs:203:13:203:22 | source(...) | main.rs:203:9:203:9 | s | provenance |  |
 | main.rs:204:14:204:14 | ... | main.rs:205:14:205:14 | n | provenance |  |
 | main.rs:204:14:204:14 | ... | main.rs:205:14:205:14 | n | provenance |  |
-| main.rs:208:11:208:11 | s | main.rs:204:14:204:14 | ... | provenance | MaD:22 |
-| main.rs:208:11:208:11 | s | main.rs:204:14:204:14 | ... | provenance | MaD:22 |
+| main.rs:208:11:208:11 | s | main.rs:204:14:204:14 | ... | provenance | MaD:23 |
+| main.rs:208:11:208:11 | s | main.rs:204:14:204:14 | ... | provenance | MaD:23 |
 | main.rs:212:13:212:22 | source(...) | main.rs:214:23:214:23 | f [captured s] | provenance |  |
 | main.rs:212:13:212:22 | source(...) | main.rs:214:23:214:23 | f [captured s] | provenance |  |
 | main.rs:213:40:213:40 | s | main.rs:213:17:213:42 | if ... {...} else {...} | provenance |  |
@@ -194,14 +195,14 @@ edges
 | main.rs:214:9:214:9 | t | main.rs:215:10:215:10 | t | provenance |  |
 | main.rs:214:13:214:24 | apply(...) | main.rs:214:9:214:9 | t | provenance |  |
 | main.rs:214:13:214:24 | apply(...) | main.rs:214:9:214:9 | t | provenance |  |
-| main.rs:214:23:214:23 | f [captured s] | main.rs:213:40:213:40 | s | provenance | MaD:22 |
-| main.rs:214:23:214:23 | f [captured s] | main.rs:213:40:213:40 | s | provenance | MaD:22 |
 | main.rs:214:23:214:23 | f [captured s] | main.rs:213:40:213:40 | s | provenance | MaD:23 |
 | main.rs:214:23:214:23 | f [captured s] | main.rs:213:40:213:40 | s | provenance | MaD:23 |
-| main.rs:214:23:214:23 | f [captured s] | main.rs:214:13:214:24 | apply(...) | provenance | MaD:22 |
-| main.rs:214:23:214:23 | f [captured s] | main.rs:214:13:214:24 | apply(...) | provenance | MaD:22 |
+| main.rs:214:23:214:23 | f [captured s] | main.rs:213:40:213:40 | s | provenance | MaD:24 |
+| main.rs:214:23:214:23 | f [captured s] | main.rs:213:40:213:40 | s | provenance | MaD:24 |
 | main.rs:214:23:214:23 | f [captured s] | main.rs:214:13:214:24 | apply(...) | provenance | MaD:23 |
 | main.rs:214:23:214:23 | f [captured s] | main.rs:214:13:214:24 | apply(...) | provenance | MaD:23 |
+| main.rs:214:23:214:23 | f [captured s] | main.rs:214:13:214:24 | apply(...) | provenance | MaD:24 |
+| main.rs:214:23:214:23 | f [captured s] | main.rs:214:13:214:24 | apply(...) | provenance | MaD:24 |
 | main.rs:219:9:219:9 | s | main.rs:221:19:221:19 | s | provenance |  |
 | main.rs:219:9:219:9 | s | main.rs:221:19:221:19 | s | provenance |  |
 | main.rs:219:13:219:22 | source(...) | main.rs:219:9:219:9 | s | provenance |  |
@@ -212,10 +213,10 @@ edges
 | main.rs:221:9:221:9 | t | main.rs:222:10:222:10 | t | provenance |  |
 | main.rs:221:13:221:23 | apply(...) | main.rs:221:9:221:9 | t | provenance |  |
 | main.rs:221:13:221:23 | apply(...) | main.rs:221:9:221:9 | t | provenance |  |
-| main.rs:221:19:221:19 | s | main.rs:220:14:220:14 | ... | provenance | MaD:22 |
-| main.rs:221:19:221:19 | s | main.rs:220:14:220:14 | ... | provenance | MaD:22 |
-| main.rs:221:19:221:19 | s | main.rs:221:13:221:23 | apply(...) | provenance | MaD:22 |
-| main.rs:221:19:221:19 | s | main.rs:221:13:221:23 | apply(...) | provenance | MaD:22 |
+| main.rs:221:19:221:19 | s | main.rs:220:14:220:14 | ... | provenance | MaD:23 |
+| main.rs:221:19:221:19 | s | main.rs:220:14:220:14 | ... | provenance | MaD:23 |
+| main.rs:221:19:221:19 | s | main.rs:221:13:221:23 | apply(...) | provenance | MaD:23 |
+| main.rs:221:19:221:19 | s | main.rs:221:13:221:23 | apply(...) | provenance | MaD:23 |
 | main.rs:231:9:231:9 | s | main.rs:232:30:232:30 | s | provenance |  |
 | main.rs:231:9:231:9 | s | main.rs:232:30:232:30 | s | provenance |  |
 | main.rs:231:13:231:22 | source(...) | main.rs:231:9:231:9 | s | provenance |  |
@@ -226,8 +227,8 @@ edges
 | main.rs:232:13:232:31 | get_async_number(...) [future] | main.rs:232:13:232:37 | await ... | provenance |  |
 | main.rs:232:13:232:37 | await ... | main.rs:232:9:232:9 | t | provenance |  |
 | main.rs:232:13:232:37 | await ... | main.rs:232:9:232:9 | t | provenance |  |
-| main.rs:232:30:232:30 | s | main.rs:232:13:232:31 | get_async_number(...) [future] | provenance | MaD:29 |
-| main.rs:232:30:232:30 | s | main.rs:232:13:232:31 | get_async_number(...) [future] | provenance | MaD:29 |
+| main.rs:232:30:232:30 | s | main.rs:232:13:232:31 | get_async_number(...) [future] | provenance | MaD:30 |
+| main.rs:232:30:232:30 | s | main.rs:232:13:232:31 | get_async_number(...) [future] | provenance | MaD:30 |
 | main.rs:257:9:257:9 | s [D] | main.rs:258:11:258:11 | s [D] | provenance |  |
 | main.rs:257:9:257:9 | s [D] | main.rs:258:11:258:11 | s [D] | provenance |  |
 | main.rs:257:13:257:27 | enum_source(...) | main.rs:257:9:257:9 | s [D] | provenance | Src:MaD:12  |
@@ -342,38 +343,44 @@ edges
 | main.rs:410:26:410:31 | ...: i64 | main.rs:411:14:411:14 | i | provenance | Src:MaD:10  |
 | main.rs:475:9:475:10 | x1 | main.rs:476:10:476:11 | x1 | provenance |  |
 | main.rs:475:9:475:10 | x1 | main.rs:476:10:476:11 | x1 | provenance |  |
-| main.rs:475:14:475:23 | source(...) | main.rs:475:14:475:30 | ... .max(...) | provenance | MaD:19 |
-| main.rs:475:14:475:23 | source(...) | main.rs:475:14:475:30 | ... .max(...) | provenance | MaD:19 |
+| main.rs:475:14:475:23 | source(...) | main.rs:475:14:475:30 | ... .max(...) | provenance | MaD:20 |
+| main.rs:475:14:475:23 | source(...) | main.rs:475:14:475:30 | ... .max(...) | provenance | MaD:20 |
 | main.rs:475:14:475:30 | ... .max(...) | main.rs:475:9:475:10 | x1 | provenance |  |
 | main.rs:475:14:475:30 | ... .max(...) | main.rs:475:9:475:10 | x1 | provenance |  |
 | main.rs:478:9:478:10 | x2 [MyStruct.field1] | main.rs:486:10:486:11 | x2 [MyStruct.field1] | provenance |  |
 | main.rs:478:9:478:10 | x2 [MyStruct.field1] | main.rs:486:10:486:11 | x2 [MyStruct.field1] | provenance |  |
 | main.rs:478:14:485:6 | ... .max(...) [MyStruct.field1] | main.rs:478:9:478:10 | x2 [MyStruct.field1] | provenance |  |
 | main.rs:478:14:485:6 | ... .max(...) [MyStruct.field1] | main.rs:478:9:478:10 | x2 [MyStruct.field1] | provenance |  |
-| main.rs:478:15:481:5 | MyStruct {...} [MyStruct.field1] | main.rs:478:14:485:6 | ... .max(...) [MyStruct.field1] | provenance | MaD:19 |
-| main.rs:478:15:481:5 | MyStruct {...} [MyStruct.field1] | main.rs:478:14:485:6 | ... .max(...) [MyStruct.field1] | provenance | MaD:19 |
+| main.rs:478:15:481:5 | MyStruct {...} [MyStruct.field1] | main.rs:478:14:485:6 | ... .max(...) [MyStruct.field1] | provenance | MaD:20 |
+| main.rs:478:15:481:5 | MyStruct {...} [MyStruct.field1] | main.rs:478:14:485:6 | ... .max(...) [MyStruct.field1] | provenance | MaD:20 |
 | main.rs:479:17:479:26 | source(...) | main.rs:478:15:481:5 | MyStruct {...} [MyStruct.field1] | provenance |  |
 | main.rs:479:17:479:26 | source(...) | main.rs:478:15:481:5 | MyStruct {...} [MyStruct.field1] | provenance |  |
 | main.rs:486:10:486:11 | x2 [MyStruct.field1] | main.rs:486:10:486:18 | x2.field1 | provenance |  |
 | main.rs:486:10:486:11 | x2 [MyStruct.field1] | main.rs:486:10:486:18 | x2.field1 | provenance |  |
 | main.rs:491:9:491:10 | x4 | main.rs:492:10:492:11 | x4 | provenance |  |
 | main.rs:491:9:491:10 | x4 | main.rs:492:10:492:11 | x4 | provenance |  |
-| main.rs:491:14:491:23 | source(...) | main.rs:491:14:491:30 | ... .max(...) | provenance | MaD:19 |
-| main.rs:491:14:491:23 | source(...) | main.rs:491:14:491:30 | ... .max(...) | provenance | MaD:19 |
+| main.rs:491:14:491:23 | source(...) | main.rs:491:14:491:30 | ... .max(...) | provenance | MaD:20 |
+| main.rs:491:14:491:23 | source(...) | main.rs:491:14:491:30 | ... .max(...) | provenance | MaD:20 |
 | main.rs:491:14:491:30 | ... .max(...) | main.rs:491:9:491:10 | x4 | provenance |  |
 | main.rs:491:14:491:30 | ... .max(...) | main.rs:491:9:491:10 | x4 | provenance |  |
 | main.rs:494:9:494:10 | x5 | main.rs:495:10:495:11 | x5 | provenance |  |
-| main.rs:494:14:494:23 | source(...) | main.rs:494:14:494:30 | ... .lt(...) | provenance | MaD:20 |
+| main.rs:494:14:494:23 | source(...) | main.rs:494:14:494:30 | ... .lt(...) | provenance | MaD:21 |
 | main.rs:494:14:494:30 | ... .lt(...) | main.rs:494:9:494:10 | x5 | provenance |  |
 | main.rs:497:9:497:10 | x6 | main.rs:498:10:498:11 | x6 | provenance |  |
-| main.rs:497:14:497:23 | source(...) | main.rs:497:14:497:27 | ... < ... | provenance | MaD:20 |
+| main.rs:497:14:497:23 | source(...) | main.rs:497:14:497:27 | ... < ... | provenance | MaD:21 |
 | main.rs:497:14:497:27 | ... < ... | main.rs:497:9:497:10 | x6 | provenance |  |
 | main.rs:503:9:503:10 | x8 | main.rs:504:10:504:11 | x8 | provenance |  |
 | main.rs:503:9:503:10 | x8 | main.rs:504:10:504:11 | x8 | provenance |  |
 | main.rs:503:14:503:44 | ...::flow_through2(...) | main.rs:503:9:503:10 | x8 | provenance |  |
 | main.rs:503:14:503:44 | ...::flow_through2(...) | main.rs:503:9:503:10 | x8 | provenance |  |
-| main.rs:503:34:503:43 | source(...) | main.rs:503:14:503:44 | ...::flow_through2(...) | provenance | MaD:25 |
-| main.rs:503:34:503:43 | source(...) | main.rs:503:14:503:44 | ...::flow_through2(...) | provenance | MaD:25 |
+| main.rs:503:34:503:43 | source(...) | main.rs:503:14:503:44 | ...::flow_through2(...) | provenance | MaD:26 |
+| main.rs:503:34:503:43 | source(...) | main.rs:503:14:503:44 | ...::flow_through2(...) | provenance | MaD:26 |
+| main.rs:506:9:506:10 | x9 | main.rs:507:10:507:11 | x9 | provenance |  |
+| main.rs:506:9:506:10 | x9 | main.rs:507:10:507:11 | x9 | provenance |  |
+| main.rs:506:14:506:44 | ...::flow_through3(...) | main.rs:506:9:506:10 | x9 | provenance |  |
+| main.rs:506:14:506:44 | ...::flow_through3(...) | main.rs:506:9:506:10 | x9 | provenance |  |
+| main.rs:506:34:506:43 | source(...) | main.rs:506:14:506:44 | ...::flow_through3(...) | provenance | MaD:19 |
+| main.rs:506:34:506:43 | source(...) | main.rs:506:14:506:44 | ...::flow_through3(...) | provenance | MaD:19 |
 | main.rs:519:10:519:28 | generated_source(...) | main.rs:519:10:519:28 | generated_source(...) | provenance | Src:MaD:14  |
 | main.rs:519:10:519:28 | generated_source(...) | main.rs:519:10:519:28 | generated_source(...) | provenance | Src:MaD:14  |
 | main.rs:521:10:521:33 | neutral_manual_source(...) | main.rs:521:10:521:33 | neutral_manual_source(...) | provenance | Src:MaD:15  |
@@ -382,10 +389,10 @@ edges
 | main.rs:522:20:522:28 | source(...) | main.rs:522:20:522:28 | source(...) | provenance | Sink:MaD:4 |
 | main.rs:524:25:524:33 | source(...) | main.rs:524:25:524:33 | source(...) | provenance | Sink:MaD:5 |
 | main.rs:524:25:524:33 | source(...) | main.rs:524:25:524:33 | source(...) | provenance | Sink:MaD:5 |
-| main.rs:525:28:525:36 | source(...) | main.rs:525:10:525:37 | generated_summary(...) | provenance | MaD:26 |
-| main.rs:525:28:525:36 | source(...) | main.rs:525:10:525:37 | generated_summary(...) | provenance | MaD:26 |
-| main.rs:527:33:527:41 | source(...) | main.rs:527:10:527:42 | neutral_manual_summary(...) | provenance | MaD:27 |
-| main.rs:527:33:527:41 | source(...) | main.rs:527:10:527:42 | neutral_manual_summary(...) | provenance | MaD:27 |
+| main.rs:525:28:525:36 | source(...) | main.rs:525:10:525:37 | generated_summary(...) | provenance | MaD:27 |
+| main.rs:525:28:525:36 | source(...) | main.rs:525:10:525:37 | generated_summary(...) | provenance | MaD:27 |
+| main.rs:527:33:527:41 | source(...) | main.rs:527:10:527:42 | neutral_manual_summary(...) | provenance | MaD:28 |
+| main.rs:527:33:527:41 | source(...) | main.rs:527:10:527:42 | neutral_manual_summary(...) | provenance | MaD:28 |
 nodes
 | main.rs:15:9:15:9 | s | semmle.label | s |
 | main.rs:15:9:15:9 | s | semmle.label | s |
@@ -793,6 +800,14 @@ nodes
 | main.rs:503:34:503:43 | source(...) | semmle.label | source(...) |
 | main.rs:504:10:504:11 | x8 | semmle.label | x8 |
 | main.rs:504:10:504:11 | x8 | semmle.label | x8 |
+| main.rs:506:9:506:10 | x9 | semmle.label | x9 |
+| main.rs:506:9:506:10 | x9 | semmle.label | x9 |
+| main.rs:506:14:506:44 | ...::flow_through3(...) | semmle.label | ...::flow_through3(...) |
+| main.rs:506:14:506:44 | ...::flow_through3(...) | semmle.label | ...::flow_through3(...) |
+| main.rs:506:34:506:43 | source(...) | semmle.label | source(...) |
+| main.rs:506:34:506:43 | source(...) | semmle.label | source(...) |
+| main.rs:507:10:507:11 | x9 | semmle.label | x9 |
+| main.rs:507:10:507:11 | x9 | semmle.label | x9 |
 | main.rs:519:10:519:28 | generated_source(...) | semmle.label | generated_source(...) |
 | main.rs:519:10:519:28 | generated_source(...) | semmle.label | generated_source(...) |
 | main.rs:519:10:519:28 | generated_source(...) | semmle.label | generated_source(...) |
@@ -902,6 +917,8 @@ invalidSpecComponent
 | main.rs:498:10:498:11 | x6 | main.rs:497:14:497:23 | source(...) | main.rs:498:10:498:11 | x6 | $@ | main.rs:497:14:497:23 | source(...) | source(...) |
 | main.rs:504:10:504:11 | x8 | main.rs:503:34:503:43 | source(...) | main.rs:504:10:504:11 | x8 | $@ | main.rs:503:34:503:43 | source(...) | source(...) |
 | main.rs:504:10:504:11 | x8 | main.rs:503:34:503:43 | source(...) | main.rs:504:10:504:11 | x8 | $@ | main.rs:503:34:503:43 | source(...) | source(...) |
+| main.rs:507:10:507:11 | x9 | main.rs:506:34:506:43 | source(...) | main.rs:507:10:507:11 | x9 | $@ | main.rs:506:34:506:43 | source(...) | source(...) |
+| main.rs:507:10:507:11 | x9 | main.rs:506:34:506:43 | source(...) | main.rs:507:10:507:11 | x9 | $@ | main.rs:506:34:506:43 | source(...) | source(...) |
 | main.rs:519:10:519:28 | generated_source(...) | main.rs:519:10:519:28 | generated_source(...) | main.rs:519:10:519:28 | generated_source(...) | $@ | main.rs:519:10:519:28 | generated_source(...) | generated_source(...) |
 | main.rs:519:10:519:28 | generated_source(...) | main.rs:519:10:519:28 | generated_source(...) | main.rs:519:10:519:28 | generated_source(...) | $@ | main.rs:519:10:519:28 | generated_source(...) | generated_source(...) |
 | main.rs:521:10:521:33 | neutral_manual_source(...) | main.rs:521:10:521:33 | neutral_manual_source(...) | main.rs:521:10:521:33 | neutral_manual_source(...) | $@ | main.rs:521:10:521:33 | neutral_manual_source(...) | neutral_manual_source(...) |

--- a/rust/ql/test/library-tests/dataflow/models/models.expected
+++ b/rust/ql/test/library-tests/dataflow/models/models.expected
@@ -23,20 +23,21 @@ models
 | 22 | Summary: main::apply; Argument[0]; Argument[1].Parameter[0]; value |
 | 23 | Summary: main::apply; Argument[1].ReturnValue; ReturnValue; value |
 | 24 | Summary: main::coerce; Argument[0]; ReturnValue; taint |
-| 25 | Summary: main::external_file::generated_summary; Argument[0]; ReturnValue; value |
-| 26 | Summary: main::external_file::neutral_manual_summary; Argument[0]; ReturnValue; value |
-| 27 | Summary: main::get_array_element; Argument[0].Element; ReturnValue; value |
-| 28 | Summary: main::get_async_number; Argument[0]; ReturnValue.Future; value |
-| 29 | Summary: main::get_struct_field; Argument[0].Field[main::MyStruct::field1]; ReturnValue; value |
-| 30 | Summary: main::get_tuple_element; Argument[0].Field[0]; ReturnValue; value |
-| 31 | Summary: main::get_var_field; Argument[0].Field[main::MyFieldEnum::C::field_c]; ReturnValue; value |
-| 32 | Summary: main::get_var_pos; Argument[0].Field[main::MyPosEnum::A(0)]; ReturnValue; value |
-| 33 | Summary: main::set_array_element; Argument[0]; ReturnValue.Element; value |
-| 34 | Summary: main::set_struct_field; Argument[0]; ReturnValue.Field[main::MyStruct::field2]; value |
-| 35 | Summary: main::set_tuple_element; Argument[0]; ReturnValue.Field[1]; value |
-| 36 | Summary: main::set_var_field; Argument[0]; ReturnValue.Field[main::MyFieldEnum::D::field_d]; value |
-| 37 | Summary: main::set_var_pos; Argument[0]; ReturnValue.Field[main::MyPosEnum::B(0)]; value |
-| 38 | Summary: main::snd; Argument[1]; ReturnValue; value |
+| 25 | Summary: main::external_file::MyTrait2::flow_through2; Argument[0]; ReturnValue; value |
+| 26 | Summary: main::external_file::generated_summary; Argument[0]; ReturnValue; value |
+| 27 | Summary: main::external_file::neutral_manual_summary; Argument[0]; ReturnValue; value |
+| 28 | Summary: main::get_array_element; Argument[0].Element; ReturnValue; value |
+| 29 | Summary: main::get_async_number; Argument[0]; ReturnValue.Future; value |
+| 30 | Summary: main::get_struct_field; Argument[0].Field[main::MyStruct::field1]; ReturnValue; value |
+| 31 | Summary: main::get_tuple_element; Argument[0].Field[0]; ReturnValue; value |
+| 32 | Summary: main::get_var_field; Argument[0].Field[main::MyFieldEnum::C::field_c]; ReturnValue; value |
+| 33 | Summary: main::get_var_pos; Argument[0].Field[main::MyPosEnum::A(0)]; ReturnValue; value |
+| 34 | Summary: main::set_array_element; Argument[0]; ReturnValue.Element; value |
+| 35 | Summary: main::set_struct_field; Argument[0]; ReturnValue.Field[main::MyStruct::field2]; value |
+| 36 | Summary: main::set_tuple_element; Argument[0]; ReturnValue.Field[1]; value |
+| 37 | Summary: main::set_var_field; Argument[0]; ReturnValue.Field[main::MyFieldEnum::D::field_d]; value |
+| 38 | Summary: main::set_var_pos; Argument[0]; ReturnValue.Field[main::MyPosEnum::B(0)]; value |
+| 39 | Summary: main::snd; Argument[1]; ReturnValue; value |
 edges
 | main.rs:15:9:15:9 | s | main.rs:16:19:16:19 | s | provenance |  |
 | main.rs:15:9:15:9 | s | main.rs:16:19:16:19 | s | provenance |  |
@@ -51,8 +52,8 @@ edges
 | main.rs:41:9:41:10 | s1 | main.rs:42:17:42:18 | s1 | provenance |  |
 | main.rs:41:14:41:23 | source(...) | main.rs:41:9:41:10 | s1 | provenance |  |
 | main.rs:41:14:41:23 | source(...) | main.rs:41:9:41:10 | s1 | provenance |  |
-| main.rs:42:17:42:18 | s1 | main.rs:42:10:42:19 | snd(...) | provenance | MaD:38 |
-| main.rs:42:17:42:18 | s1 | main.rs:42:10:42:19 | snd(...) | provenance | MaD:38 |
+| main.rs:42:17:42:18 | s1 | main.rs:42:10:42:19 | snd(...) | provenance | MaD:39 |
+| main.rs:42:17:42:18 | s1 | main.rs:42:10:42:19 | snd(...) | provenance | MaD:39 |
 | main.rs:54:9:54:9 | s | main.rs:55:27:55:27 | s | provenance |  |
 | main.rs:54:9:54:9 | s | main.rs:55:27:55:27 | s | provenance |  |
 | main.rs:54:13:54:21 | source(...) | main.rs:54:9:54:9 | s | provenance |  |
@@ -63,8 +64,8 @@ edges
 | main.rs:55:14:55:28 | ...::A(...) [A] | main.rs:55:9:55:10 | e1 [A] | provenance |  |
 | main.rs:55:27:55:27 | s | main.rs:55:14:55:28 | ...::A(...) [A] | provenance |  |
 | main.rs:55:27:55:27 | s | main.rs:55:14:55:28 | ...::A(...) [A] | provenance |  |
-| main.rs:56:22:56:23 | e1 [A] | main.rs:56:10:56:24 | get_var_pos(...) | provenance | MaD:32 |
-| main.rs:56:22:56:23 | e1 [A] | main.rs:56:10:56:24 | get_var_pos(...) | provenance | MaD:32 |
+| main.rs:56:22:56:23 | e1 [A] | main.rs:56:10:56:24 | get_var_pos(...) | provenance | MaD:33 |
+| main.rs:56:22:56:23 | e1 [A] | main.rs:56:10:56:24 | get_var_pos(...) | provenance | MaD:33 |
 | main.rs:67:9:67:9 | s | main.rs:68:26:68:26 | s | provenance |  |
 | main.rs:67:9:67:9 | s | main.rs:68:26:68:26 | s | provenance |  |
 | main.rs:67:13:67:21 | source(...) | main.rs:67:9:67:9 | s | provenance |  |
@@ -73,8 +74,8 @@ edges
 | main.rs:68:9:68:10 | e1 [B] | main.rs:69:11:69:12 | e1 [B] | provenance |  |
 | main.rs:68:14:68:27 | set_var_pos(...) [B] | main.rs:68:9:68:10 | e1 [B] | provenance |  |
 | main.rs:68:14:68:27 | set_var_pos(...) [B] | main.rs:68:9:68:10 | e1 [B] | provenance |  |
-| main.rs:68:26:68:26 | s | main.rs:68:14:68:27 | set_var_pos(...) [B] | provenance | MaD:37 |
-| main.rs:68:26:68:26 | s | main.rs:68:14:68:27 | set_var_pos(...) [B] | provenance | MaD:37 |
+| main.rs:68:26:68:26 | s | main.rs:68:14:68:27 | set_var_pos(...) [B] | provenance | MaD:38 |
+| main.rs:68:26:68:26 | s | main.rs:68:14:68:27 | set_var_pos(...) [B] | provenance | MaD:38 |
 | main.rs:69:11:69:12 | e1 [B] | main.rs:71:9:71:23 | ...::B(...) [B] | provenance |  |
 | main.rs:69:11:69:12 | e1 [B] | main.rs:71:9:71:23 | ...::B(...) [B] | provenance |  |
 | main.rs:71:9:71:23 | ...::B(...) [B] | main.rs:71:22:71:22 | i | provenance |  |
@@ -91,8 +92,8 @@ edges
 | main.rs:88:14:88:42 | ...::C {...} [C] | main.rs:88:9:88:10 | e1 [C] | provenance |  |
 | main.rs:88:40:88:40 | s | main.rs:88:14:88:42 | ...::C {...} [C] | provenance |  |
 | main.rs:88:40:88:40 | s | main.rs:88:14:88:42 | ...::C {...} [C] | provenance |  |
-| main.rs:89:24:89:25 | e1 [C] | main.rs:89:10:89:26 | get_var_field(...) | provenance | MaD:31 |
-| main.rs:89:24:89:25 | e1 [C] | main.rs:89:10:89:26 | get_var_field(...) | provenance | MaD:31 |
+| main.rs:89:24:89:25 | e1 [C] | main.rs:89:10:89:26 | get_var_field(...) | provenance | MaD:32 |
+| main.rs:89:24:89:25 | e1 [C] | main.rs:89:10:89:26 | get_var_field(...) | provenance | MaD:32 |
 | main.rs:100:9:100:9 | s | main.rs:101:28:101:28 | s | provenance |  |
 | main.rs:100:9:100:9 | s | main.rs:101:28:101:28 | s | provenance |  |
 | main.rs:100:13:100:21 | source(...) | main.rs:100:9:100:9 | s | provenance |  |
@@ -101,8 +102,8 @@ edges
 | main.rs:101:9:101:10 | e1 [D] | main.rs:102:11:102:12 | e1 [D] | provenance |  |
 | main.rs:101:14:101:29 | set_var_field(...) [D] | main.rs:101:9:101:10 | e1 [D] | provenance |  |
 | main.rs:101:14:101:29 | set_var_field(...) [D] | main.rs:101:9:101:10 | e1 [D] | provenance |  |
-| main.rs:101:28:101:28 | s | main.rs:101:14:101:29 | set_var_field(...) [D] | provenance | MaD:36 |
-| main.rs:101:28:101:28 | s | main.rs:101:14:101:29 | set_var_field(...) [D] | provenance | MaD:36 |
+| main.rs:101:28:101:28 | s | main.rs:101:14:101:29 | set_var_field(...) [D] | provenance | MaD:37 |
+| main.rs:101:28:101:28 | s | main.rs:101:14:101:29 | set_var_field(...) [D] | provenance | MaD:37 |
 | main.rs:102:11:102:12 | e1 [D] | main.rs:104:9:104:37 | ...::D {...} [D] | provenance |  |
 | main.rs:102:11:102:12 | e1 [D] | main.rs:104:9:104:37 | ...::D {...} [D] | provenance |  |
 | main.rs:104:9:104:37 | ...::D {...} [D] | main.rs:104:35:104:35 | i | provenance |  |
@@ -119,8 +120,8 @@ edges
 | main.rs:121:21:124:5 | MyStruct {...} [MyStruct.field1] | main.rs:121:9:121:17 | my_struct [MyStruct.field1] | provenance |  |
 | main.rs:122:17:122:17 | s | main.rs:121:21:124:5 | MyStruct {...} [MyStruct.field1] | provenance |  |
 | main.rs:122:17:122:17 | s | main.rs:121:21:124:5 | MyStruct {...} [MyStruct.field1] | provenance |  |
-| main.rs:125:27:125:35 | my_struct [MyStruct.field1] | main.rs:125:10:125:36 | get_struct_field(...) | provenance | MaD:29 |
-| main.rs:125:27:125:35 | my_struct [MyStruct.field1] | main.rs:125:10:125:36 | get_struct_field(...) | provenance | MaD:29 |
+| main.rs:125:27:125:35 | my_struct [MyStruct.field1] | main.rs:125:10:125:36 | get_struct_field(...) | provenance | MaD:30 |
+| main.rs:125:27:125:35 | my_struct [MyStruct.field1] | main.rs:125:10:125:36 | get_struct_field(...) | provenance | MaD:30 |
 | main.rs:142:9:142:9 | s | main.rs:143:38:143:38 | s | provenance |  |
 | main.rs:142:9:142:9 | s | main.rs:143:38:143:38 | s | provenance |  |
 | main.rs:142:13:142:21 | source(...) | main.rs:142:9:142:9 | s | provenance |  |
@@ -129,16 +130,16 @@ edges
 | main.rs:143:9:143:17 | my_struct [MyStruct.field2] | main.rs:145:10:145:18 | my_struct [MyStruct.field2] | provenance |  |
 | main.rs:143:21:143:39 | set_struct_field(...) [MyStruct.field2] | main.rs:143:9:143:17 | my_struct [MyStruct.field2] | provenance |  |
 | main.rs:143:21:143:39 | set_struct_field(...) [MyStruct.field2] | main.rs:143:9:143:17 | my_struct [MyStruct.field2] | provenance |  |
-| main.rs:143:38:143:38 | s | main.rs:143:21:143:39 | set_struct_field(...) [MyStruct.field2] | provenance | MaD:34 |
-| main.rs:143:38:143:38 | s | main.rs:143:21:143:39 | set_struct_field(...) [MyStruct.field2] | provenance | MaD:34 |
+| main.rs:143:38:143:38 | s | main.rs:143:21:143:39 | set_struct_field(...) [MyStruct.field2] | provenance | MaD:35 |
+| main.rs:143:38:143:38 | s | main.rs:143:21:143:39 | set_struct_field(...) [MyStruct.field2] | provenance | MaD:35 |
 | main.rs:145:10:145:18 | my_struct [MyStruct.field2] | main.rs:145:10:145:25 | my_struct.field2 | provenance |  |
 | main.rs:145:10:145:18 | my_struct [MyStruct.field2] | main.rs:145:10:145:25 | my_struct.field2 | provenance |  |
 | main.rs:154:9:154:9 | s | main.rs:155:29:155:29 | s | provenance |  |
 | main.rs:154:9:154:9 | s | main.rs:155:29:155:29 | s | provenance |  |
 | main.rs:154:13:154:21 | source(...) | main.rs:154:9:154:9 | s | provenance |  |
 | main.rs:154:13:154:21 | source(...) | main.rs:154:9:154:9 | s | provenance |  |
-| main.rs:155:28:155:30 | [...] [element] | main.rs:155:10:155:31 | get_array_element(...) | provenance | MaD:27 |
-| main.rs:155:28:155:30 | [...] [element] | main.rs:155:10:155:31 | get_array_element(...) | provenance | MaD:27 |
+| main.rs:155:28:155:30 | [...] [element] | main.rs:155:10:155:31 | get_array_element(...) | provenance | MaD:28 |
+| main.rs:155:28:155:30 | [...] [element] | main.rs:155:10:155:31 | get_array_element(...) | provenance | MaD:28 |
 | main.rs:155:29:155:29 | s | main.rs:155:28:155:30 | [...] [element] | provenance |  |
 | main.rs:155:29:155:29 | s | main.rs:155:28:155:30 | [...] [element] | provenance |  |
 | main.rs:164:9:164:9 | s | main.rs:165:33:165:33 | s | provenance |  |
@@ -149,8 +150,8 @@ edges
 | main.rs:165:9:165:11 | arr [element] | main.rs:166:10:166:12 | arr [element] | provenance |  |
 | main.rs:165:15:165:34 | set_array_element(...) [element] | main.rs:165:9:165:11 | arr [element] | provenance |  |
 | main.rs:165:15:165:34 | set_array_element(...) [element] | main.rs:165:9:165:11 | arr [element] | provenance |  |
-| main.rs:165:33:165:33 | s | main.rs:165:15:165:34 | set_array_element(...) [element] | provenance | MaD:33 |
-| main.rs:165:33:165:33 | s | main.rs:165:15:165:34 | set_array_element(...) [element] | provenance | MaD:33 |
+| main.rs:165:33:165:33 | s | main.rs:165:15:165:34 | set_array_element(...) [element] | provenance | MaD:34 |
+| main.rs:165:33:165:33 | s | main.rs:165:15:165:34 | set_array_element(...) [element] | provenance | MaD:34 |
 | main.rs:166:10:166:12 | arr [element] | main.rs:166:10:166:15 | arr[0] | provenance | MaD:21 |
 | main.rs:166:10:166:12 | arr [element] | main.rs:166:10:166:15 | arr[0] | provenance | MaD:21 |
 | main.rs:175:9:175:9 | s | main.rs:176:14:176:14 | s | provenance |  |
@@ -163,8 +164,8 @@ edges
 | main.rs:176:13:176:18 | TupleExpr [tuple.0] | main.rs:176:9:176:9 | t [tuple.0] | provenance |  |
 | main.rs:176:14:176:14 | s | main.rs:176:13:176:18 | TupleExpr [tuple.0] | provenance |  |
 | main.rs:176:14:176:14 | s | main.rs:176:13:176:18 | TupleExpr [tuple.0] | provenance |  |
-| main.rs:177:28:177:28 | t [tuple.0] | main.rs:177:10:177:29 | get_tuple_element(...) | provenance | MaD:30 |
-| main.rs:177:28:177:28 | t [tuple.0] | main.rs:177:10:177:29 | get_tuple_element(...) | provenance | MaD:30 |
+| main.rs:177:28:177:28 | t [tuple.0] | main.rs:177:10:177:29 | get_tuple_element(...) | provenance | MaD:31 |
+| main.rs:177:28:177:28 | t [tuple.0] | main.rs:177:10:177:29 | get_tuple_element(...) | provenance | MaD:31 |
 | main.rs:188:9:188:9 | s | main.rs:189:31:189:31 | s | provenance |  |
 | main.rs:188:9:188:9 | s | main.rs:189:31:189:31 | s | provenance |  |
 | main.rs:188:13:188:22 | source(...) | main.rs:188:9:188:9 | s | provenance |  |
@@ -173,8 +174,8 @@ edges
 | main.rs:189:9:189:9 | t [tuple.1] | main.rs:191:10:191:10 | t [tuple.1] | provenance |  |
 | main.rs:189:13:189:32 | set_tuple_element(...) [tuple.1] | main.rs:189:9:189:9 | t [tuple.1] | provenance |  |
 | main.rs:189:13:189:32 | set_tuple_element(...) [tuple.1] | main.rs:189:9:189:9 | t [tuple.1] | provenance |  |
-| main.rs:189:31:189:31 | s | main.rs:189:13:189:32 | set_tuple_element(...) [tuple.1] | provenance | MaD:35 |
-| main.rs:189:31:189:31 | s | main.rs:189:13:189:32 | set_tuple_element(...) [tuple.1] | provenance | MaD:35 |
+| main.rs:189:31:189:31 | s | main.rs:189:13:189:32 | set_tuple_element(...) [tuple.1] | provenance | MaD:36 |
+| main.rs:189:31:189:31 | s | main.rs:189:13:189:32 | set_tuple_element(...) [tuple.1] | provenance | MaD:36 |
 | main.rs:191:10:191:10 | t [tuple.1] | main.rs:191:10:191:12 | t.1 | provenance |  |
 | main.rs:191:10:191:10 | t [tuple.1] | main.rs:191:10:191:12 | t.1 | provenance |  |
 | main.rs:203:9:203:9 | s | main.rs:208:11:208:11 | s | provenance |  |
@@ -225,8 +226,8 @@ edges
 | main.rs:232:13:232:31 | get_async_number(...) [future] | main.rs:232:13:232:37 | await ... | provenance |  |
 | main.rs:232:13:232:37 | await ... | main.rs:232:9:232:9 | t | provenance |  |
 | main.rs:232:13:232:37 | await ... | main.rs:232:9:232:9 | t | provenance |  |
-| main.rs:232:30:232:30 | s | main.rs:232:13:232:31 | get_async_number(...) [future] | provenance | MaD:28 |
-| main.rs:232:30:232:30 | s | main.rs:232:13:232:31 | get_async_number(...) [future] | provenance | MaD:28 |
+| main.rs:232:30:232:30 | s | main.rs:232:13:232:31 | get_async_number(...) [future] | provenance | MaD:29 |
+| main.rs:232:30:232:30 | s | main.rs:232:13:232:31 | get_async_number(...) [future] | provenance | MaD:29 |
 | main.rs:257:9:257:9 | s [D] | main.rs:258:11:258:11 | s [D] | provenance |  |
 | main.rs:257:9:257:9 | s [D] | main.rs:258:11:258:11 | s [D] | provenance |  |
 | main.rs:257:13:257:27 | enum_source(...) | main.rs:257:9:257:9 | s [D] | provenance | Src:MaD:12  |
@@ -245,60 +246,60 @@ edges
 | main.rs:265:11:265:11 | s [E, Some] | main.rs:268:9:268:37 | ...::E {...} [E, Some] | provenance |  |
 | main.rs:268:9:268:37 | ...::E {...} [E, Some] | main.rs:268:35:268:35 | o [Some] | provenance |  |
 | main.rs:268:9:268:37 | ...::E {...} [E, Some] | main.rs:268:35:268:35 | o [Some] | provenance |  |
-| main.rs:268:35:268:35 | o [Some] | main.rs:270:19:270:19 | o [Some] | provenance |  |
-| main.rs:268:35:268:35 | o [Some] | main.rs:270:19:270:19 | o [Some] | provenance |  |
-| main.rs:270:19:270:19 | o [Some] | main.rs:271:17:271:23 | Some(...) [Some] | provenance |  |
-| main.rs:270:19:270:19 | o [Some] | main.rs:271:17:271:23 | Some(...) [Some] | provenance |  |
-| main.rs:271:17:271:23 | Some(...) [Some] | main.rs:271:22:271:22 | i | provenance |  |
-| main.rs:271:17:271:23 | Some(...) [Some] | main.rs:271:22:271:22 | i | provenance |  |
-| main.rs:271:22:271:22 | i | main.rs:271:33:271:33 | i | provenance |  |
-| main.rs:271:22:271:22 | i | main.rs:271:33:271:33 | i | provenance |  |
-| main.rs:280:9:280:9 | s [C] | main.rs:281:11:281:11 | s [C] | provenance |  |
-| main.rs:280:9:280:9 | s [C] | main.rs:281:11:281:11 | s [C] | provenance |  |
-| main.rs:280:13:280:24 | e.source(...) | main.rs:280:9:280:9 | s [C] | provenance | Src:MaD:9  |
-| main.rs:280:13:280:24 | e.source(...) | main.rs:280:9:280:9 | s [C] | provenance | Src:MaD:9  |
-| main.rs:281:11:281:11 | s [C] | main.rs:282:9:282:37 | ...::C {...} [C] | provenance |  |
-| main.rs:281:11:281:11 | s [C] | main.rs:282:9:282:37 | ...::C {...} [C] | provenance |  |
-| main.rs:282:9:282:37 | ...::C {...} [C] | main.rs:282:35:282:35 | i | provenance |  |
-| main.rs:282:9:282:37 | ...::C {...} [C] | main.rs:282:35:282:35 | i | provenance |  |
-| main.rs:282:35:282:35 | i | main.rs:282:47:282:47 | i | provenance |  |
-| main.rs:282:35:282:35 | i | main.rs:282:47:282:47 | i | provenance |  |
-| main.rs:304:24:304:24 | a | main.rs:303:26:303:26 | a | provenance | Src:MaD:17  |
-| main.rs:304:24:304:24 | a | main.rs:303:26:303:26 | a | provenance | Src:MaD:17  |
-| main.rs:306:24:308:9 | \|...\| ... | main.rs:307:18:307:18 | a | provenance | Src:MaD:17  |
-| main.rs:306:24:308:9 | \|...\| ... | main.rs:307:18:307:18 | a | provenance | Src:MaD:17  |
-| main.rs:313:24:313:24 | f | main.rs:311:18:311:18 | a | provenance | Src:MaD:17  |
-| main.rs:313:24:313:24 | f | main.rs:311:18:311:18 | a | provenance | Src:MaD:17  |
-| main.rs:315:24:317:9 | \|...\| ... | main.rs:316:18:316:18 | a | provenance | Src:MaD:17  |
-| main.rs:315:24:317:9 | \|...\| ... | main.rs:316:18:316:18 | a | provenance | Src:MaD:17  |
-| main.rs:319:31:331:9 | \|...\| ... | main.rs:319:31:331:9 | \|...\| ... [E, Some] | provenance | Src:MaD:18  |
-| main.rs:319:31:331:9 | \|...\| ... | main.rs:319:31:331:9 | \|...\| ... [E, Some] | provenance | Src:MaD:18  |
-| main.rs:319:31:331:9 | \|...\| ... [E, Some] | main.rs:320:19:320:19 | e [E, Some] | provenance |  |
-| main.rs:319:31:331:9 | \|...\| ... [E, Some] | main.rs:320:19:320:19 | e [E, Some] | provenance |  |
-| main.rs:320:19:320:19 | e [E, Some] | main.rs:323:17:323:45 | ...::E {...} [E, Some] | provenance |  |
-| main.rs:320:19:320:19 | e [E, Some] | main.rs:323:17:323:45 | ...::E {...} [E, Some] | provenance |  |
-| main.rs:323:17:323:45 | ...::E {...} [E, Some] | main.rs:323:43:323:43 | o [Some] | provenance |  |
-| main.rs:323:17:323:45 | ...::E {...} [E, Some] | main.rs:323:43:323:43 | o [Some] | provenance |  |
-| main.rs:323:43:323:43 | o [Some] | main.rs:325:27:325:27 | o [Some] | provenance |  |
-| main.rs:323:43:323:43 | o [Some] | main.rs:325:27:325:27 | o [Some] | provenance |  |
-| main.rs:325:27:325:27 | o [Some] | main.rs:326:25:326:31 | Some(...) [Some] | provenance |  |
-| main.rs:325:27:325:27 | o [Some] | main.rs:326:25:326:31 | Some(...) [Some] | provenance |  |
-| main.rs:326:25:326:31 | Some(...) [Some] | main.rs:326:30:326:30 | i | provenance |  |
-| main.rs:326:25:326:31 | Some(...) [Some] | main.rs:326:30:326:30 | i | provenance |  |
-| main.rs:326:30:326:30 | i | main.rs:326:41:326:41 | i | provenance |  |
-| main.rs:326:30:326:30 | i | main.rs:326:41:326:41 | i | provenance |  |
-| main.rs:346:21:346:29 | source(...) | main.rs:347:19:347:19 | a | provenance | Sink:MaD:7 |
-| main.rs:346:21:346:29 | source(...) | main.rs:347:19:347:19 | a | provenance | Sink:MaD:7 |
-| main.rs:350:17:350:17 | s | main.rs:351:52:351:52 | s | provenance |  |
-| main.rs:350:17:350:17 | s | main.rs:351:52:351:52 | s | provenance |  |
-| main.rs:350:21:350:29 | source(...) | main.rs:350:17:350:17 | s | provenance |  |
-| main.rs:350:21:350:29 | source(...) | main.rs:350:17:350:17 | s | provenance |  |
-| main.rs:351:13:351:55 | ...::E {...} [E, Some] | main.rs:353:26:353:26 | b [E, Some] | provenance |  |
-| main.rs:351:13:351:55 | ...::E {...} [E, Some] | main.rs:353:26:353:26 | b [E, Some] | provenance |  |
-| main.rs:351:39:351:53 | ...::Some(...) [Some] | main.rs:351:13:351:55 | ...::E {...} [E, Some] | provenance |  |
-| main.rs:351:39:351:53 | ...::Some(...) [Some] | main.rs:351:13:351:55 | ...::E {...} [E, Some] | provenance |  |
-| main.rs:351:52:351:52 | s | main.rs:351:39:351:53 | ...::Some(...) [Some] | provenance |  |
-| main.rs:351:52:351:52 | s | main.rs:351:39:351:53 | ...::Some(...) [Some] | provenance |  |
+| main.rs:268:35:268:35 | o [Some] | main.rs:269:19:269:19 | o [Some] | provenance |  |
+| main.rs:268:35:268:35 | o [Some] | main.rs:269:19:269:19 | o [Some] | provenance |  |
+| main.rs:269:19:269:19 | o [Some] | main.rs:270:17:270:23 | Some(...) [Some] | provenance |  |
+| main.rs:269:19:269:19 | o [Some] | main.rs:270:17:270:23 | Some(...) [Some] | provenance |  |
+| main.rs:270:17:270:23 | Some(...) [Some] | main.rs:270:22:270:22 | i | provenance |  |
+| main.rs:270:17:270:23 | Some(...) [Some] | main.rs:270:22:270:22 | i | provenance |  |
+| main.rs:270:22:270:22 | i | main.rs:270:33:270:33 | i | provenance |  |
+| main.rs:270:22:270:22 | i | main.rs:270:33:270:33 | i | provenance |  |
+| main.rs:279:9:279:9 | s [C] | main.rs:280:11:280:11 | s [C] | provenance |  |
+| main.rs:279:9:279:9 | s [C] | main.rs:280:11:280:11 | s [C] | provenance |  |
+| main.rs:279:13:279:24 | e.source(...) | main.rs:279:9:279:9 | s [C] | provenance | Src:MaD:9  |
+| main.rs:279:13:279:24 | e.source(...) | main.rs:279:9:279:9 | s [C] | provenance | Src:MaD:9  |
+| main.rs:280:11:280:11 | s [C] | main.rs:281:9:281:37 | ...::C {...} [C] | provenance |  |
+| main.rs:280:11:280:11 | s [C] | main.rs:281:9:281:37 | ...::C {...} [C] | provenance |  |
+| main.rs:281:9:281:37 | ...::C {...} [C] | main.rs:281:35:281:35 | i | provenance |  |
+| main.rs:281:9:281:37 | ...::C {...} [C] | main.rs:281:35:281:35 | i | provenance |  |
+| main.rs:281:35:281:35 | i | main.rs:281:47:281:47 | i | provenance |  |
+| main.rs:281:35:281:35 | i | main.rs:281:47:281:47 | i | provenance |  |
+| main.rs:303:24:303:24 | a | main.rs:302:26:302:26 | a | provenance | Src:MaD:17  |
+| main.rs:303:24:303:24 | a | main.rs:302:26:302:26 | a | provenance | Src:MaD:17  |
+| main.rs:305:24:307:9 | \|...\| ... | main.rs:306:18:306:18 | a | provenance | Src:MaD:17  |
+| main.rs:305:24:307:9 | \|...\| ... | main.rs:306:18:306:18 | a | provenance | Src:MaD:17  |
+| main.rs:312:24:312:24 | f | main.rs:310:18:310:18 | a | provenance | Src:MaD:17  |
+| main.rs:312:24:312:24 | f | main.rs:310:18:310:18 | a | provenance | Src:MaD:17  |
+| main.rs:314:24:316:9 | \|...\| ... | main.rs:315:18:315:18 | a | provenance | Src:MaD:17  |
+| main.rs:314:24:316:9 | \|...\| ... | main.rs:315:18:315:18 | a | provenance | Src:MaD:17  |
+| main.rs:318:31:329:9 | \|...\| ... | main.rs:318:31:329:9 | \|...\| ... [E, Some] | provenance | Src:MaD:18  |
+| main.rs:318:31:329:9 | \|...\| ... | main.rs:318:31:329:9 | \|...\| ... [E, Some] | provenance | Src:MaD:18  |
+| main.rs:318:31:329:9 | \|...\| ... [E, Some] | main.rs:319:19:319:19 | e [E, Some] | provenance |  |
+| main.rs:318:31:329:9 | \|...\| ... [E, Some] | main.rs:319:19:319:19 | e [E, Some] | provenance |  |
+| main.rs:319:19:319:19 | e [E, Some] | main.rs:322:17:322:45 | ...::E {...} [E, Some] | provenance |  |
+| main.rs:319:19:319:19 | e [E, Some] | main.rs:322:17:322:45 | ...::E {...} [E, Some] | provenance |  |
+| main.rs:322:17:322:45 | ...::E {...} [E, Some] | main.rs:322:43:322:43 | o [Some] | provenance |  |
+| main.rs:322:17:322:45 | ...::E {...} [E, Some] | main.rs:322:43:322:43 | o [Some] | provenance |  |
+| main.rs:322:43:322:43 | o [Some] | main.rs:323:27:323:27 | o [Some] | provenance |  |
+| main.rs:322:43:322:43 | o [Some] | main.rs:323:27:323:27 | o [Some] | provenance |  |
+| main.rs:323:27:323:27 | o [Some] | main.rs:324:25:324:31 | Some(...) [Some] | provenance |  |
+| main.rs:323:27:323:27 | o [Some] | main.rs:324:25:324:31 | Some(...) [Some] | provenance |  |
+| main.rs:324:25:324:31 | Some(...) [Some] | main.rs:324:30:324:30 | i | provenance |  |
+| main.rs:324:25:324:31 | Some(...) [Some] | main.rs:324:30:324:30 | i | provenance |  |
+| main.rs:324:30:324:30 | i | main.rs:324:41:324:41 | i | provenance |  |
+| main.rs:324:30:324:30 | i | main.rs:324:41:324:41 | i | provenance |  |
+| main.rs:344:21:344:29 | source(...) | main.rs:345:19:345:19 | a | provenance | Sink:MaD:7 |
+| main.rs:344:21:344:29 | source(...) | main.rs:345:19:345:19 | a | provenance | Sink:MaD:7 |
+| main.rs:348:17:348:17 | s | main.rs:350:39:350:39 | s | provenance |  |
+| main.rs:348:17:348:17 | s | main.rs:350:39:350:39 | s | provenance |  |
+| main.rs:348:21:348:29 | source(...) | main.rs:348:17:348:17 | s | provenance |  |
+| main.rs:348:21:348:29 | source(...) | main.rs:348:17:348:17 | s | provenance |  |
+| main.rs:349:13:351:13 | ...::E {...} [E, Some] | main.rs:353:26:353:26 | b [E, Some] | provenance |  |
+| main.rs:349:13:351:13 | ...::E {...} [E, Some] | main.rs:353:26:353:26 | b [E, Some] | provenance |  |
+| main.rs:350:26:350:40 | ...::Some(...) [Some] | main.rs:349:13:351:13 | ...::E {...} [E, Some] | provenance |  |
+| main.rs:350:26:350:40 | ...::Some(...) [Some] | main.rs:349:13:351:13 | ...::E {...} [E, Some] | provenance |  |
+| main.rs:350:39:350:39 | s | main.rs:350:26:350:40 | ...::Some(...) [Some] | provenance |  |
+| main.rs:350:39:350:39 | s | main.rs:350:26:350:40 | ...::Some(...) [Some] | provenance |  |
 | main.rs:353:26:353:26 | b [E, Some] | main.rs:353:26:353:26 | b | provenance | Sink:MaD:8 |
 | main.rs:353:26:353:26 | b [E, Some] | main.rs:353:26:353:26 | b | provenance | Sink:MaD:8 |
 | main.rs:364:9:364:9 | s | main.rs:365:41:365:41 | s | provenance |  |
@@ -339,46 +340,52 @@ edges
 | main.rs:400:16:400:16 | i | main.rs:401:10:401:10 | i | provenance | Src:MaD:11  |
 | main.rs:410:26:410:31 | ...: i64 | main.rs:411:14:411:14 | i | provenance | Src:MaD:10  |
 | main.rs:410:26:410:31 | ...: i64 | main.rs:411:14:411:14 | i | provenance | Src:MaD:10  |
-| main.rs:464:9:464:10 | x1 | main.rs:465:10:465:11 | x1 | provenance |  |
-| main.rs:464:9:464:10 | x1 | main.rs:465:10:465:11 | x1 | provenance |  |
-| main.rs:464:14:464:23 | source(...) | main.rs:464:14:464:30 | ... .max(...) | provenance | MaD:19 |
-| main.rs:464:14:464:23 | source(...) | main.rs:464:14:464:30 | ... .max(...) | provenance | MaD:19 |
-| main.rs:464:14:464:30 | ... .max(...) | main.rs:464:9:464:10 | x1 | provenance |  |
-| main.rs:464:14:464:30 | ... .max(...) | main.rs:464:9:464:10 | x1 | provenance |  |
-| main.rs:467:9:467:10 | x2 [MyStruct.field1] | main.rs:475:10:475:11 | x2 [MyStruct.field1] | provenance |  |
-| main.rs:467:9:467:10 | x2 [MyStruct.field1] | main.rs:475:10:475:11 | x2 [MyStruct.field1] | provenance |  |
-| main.rs:467:14:474:6 | ... .max(...) [MyStruct.field1] | main.rs:467:9:467:10 | x2 [MyStruct.field1] | provenance |  |
-| main.rs:467:14:474:6 | ... .max(...) [MyStruct.field1] | main.rs:467:9:467:10 | x2 [MyStruct.field1] | provenance |  |
-| main.rs:467:15:470:5 | MyStruct {...} [MyStruct.field1] | main.rs:467:14:474:6 | ... .max(...) [MyStruct.field1] | provenance | MaD:19 |
-| main.rs:467:15:470:5 | MyStruct {...} [MyStruct.field1] | main.rs:467:14:474:6 | ... .max(...) [MyStruct.field1] | provenance | MaD:19 |
-| main.rs:468:17:468:26 | source(...) | main.rs:467:15:470:5 | MyStruct {...} [MyStruct.field1] | provenance |  |
-| main.rs:468:17:468:26 | source(...) | main.rs:467:15:470:5 | MyStruct {...} [MyStruct.field1] | provenance |  |
-| main.rs:475:10:475:11 | x2 [MyStruct.field1] | main.rs:475:10:475:18 | x2.field1 | provenance |  |
-| main.rs:475:10:475:11 | x2 [MyStruct.field1] | main.rs:475:10:475:18 | x2.field1 | provenance |  |
-| main.rs:480:9:480:10 | x4 | main.rs:481:10:481:11 | x4 | provenance |  |
-| main.rs:480:9:480:10 | x4 | main.rs:481:10:481:11 | x4 | provenance |  |
-| main.rs:480:14:480:23 | source(...) | main.rs:480:14:480:30 | ... .max(...) | provenance | MaD:19 |
-| main.rs:480:14:480:23 | source(...) | main.rs:480:14:480:30 | ... .max(...) | provenance | MaD:19 |
-| main.rs:480:14:480:30 | ... .max(...) | main.rs:480:9:480:10 | x4 | provenance |  |
-| main.rs:480:14:480:30 | ... .max(...) | main.rs:480:9:480:10 | x4 | provenance |  |
-| main.rs:483:9:483:10 | x5 | main.rs:484:10:484:11 | x5 | provenance |  |
-| main.rs:483:14:483:23 | source(...) | main.rs:483:14:483:30 | ... .lt(...) | provenance | MaD:20 |
-| main.rs:483:14:483:30 | ... .lt(...) | main.rs:483:9:483:10 | x5 | provenance |  |
-| main.rs:486:9:486:10 | x6 | main.rs:487:10:487:11 | x6 | provenance |  |
-| main.rs:486:14:486:23 | source(...) | main.rs:486:14:486:27 | ... < ... | provenance | MaD:20 |
-| main.rs:486:14:486:27 | ... < ... | main.rs:486:9:486:10 | x6 | provenance |  |
-| main.rs:502:10:502:28 | generated_source(...) | main.rs:502:10:502:28 | generated_source(...) | provenance | Src:MaD:14  |
-| main.rs:502:10:502:28 | generated_source(...) | main.rs:502:10:502:28 | generated_source(...) | provenance | Src:MaD:14  |
-| main.rs:504:10:504:33 | neutral_manual_source(...) | main.rs:504:10:504:33 | neutral_manual_source(...) | provenance | Src:MaD:15  |
-| main.rs:504:10:504:33 | neutral_manual_source(...) | main.rs:504:10:504:33 | neutral_manual_source(...) | provenance | Src:MaD:15  |
-| main.rs:505:20:505:28 | source(...) | main.rs:505:20:505:28 | source(...) | provenance | Sink:MaD:4 |
-| main.rs:505:20:505:28 | source(...) | main.rs:505:20:505:28 | source(...) | provenance | Sink:MaD:4 |
-| main.rs:507:25:507:33 | source(...) | main.rs:507:25:507:33 | source(...) | provenance | Sink:MaD:5 |
-| main.rs:507:25:507:33 | source(...) | main.rs:507:25:507:33 | source(...) | provenance | Sink:MaD:5 |
-| main.rs:508:28:508:36 | source(...) | main.rs:508:10:508:37 | generated_summary(...) | provenance | MaD:25 |
-| main.rs:508:28:508:36 | source(...) | main.rs:508:10:508:37 | generated_summary(...) | provenance | MaD:25 |
-| main.rs:510:33:510:41 | source(...) | main.rs:510:10:510:42 | neutral_manual_summary(...) | provenance | MaD:26 |
-| main.rs:510:33:510:41 | source(...) | main.rs:510:10:510:42 | neutral_manual_summary(...) | provenance | MaD:26 |
+| main.rs:475:9:475:10 | x1 | main.rs:476:10:476:11 | x1 | provenance |  |
+| main.rs:475:9:475:10 | x1 | main.rs:476:10:476:11 | x1 | provenance |  |
+| main.rs:475:14:475:23 | source(...) | main.rs:475:14:475:30 | ... .max(...) | provenance | MaD:19 |
+| main.rs:475:14:475:23 | source(...) | main.rs:475:14:475:30 | ... .max(...) | provenance | MaD:19 |
+| main.rs:475:14:475:30 | ... .max(...) | main.rs:475:9:475:10 | x1 | provenance |  |
+| main.rs:475:14:475:30 | ... .max(...) | main.rs:475:9:475:10 | x1 | provenance |  |
+| main.rs:478:9:478:10 | x2 [MyStruct.field1] | main.rs:486:10:486:11 | x2 [MyStruct.field1] | provenance |  |
+| main.rs:478:9:478:10 | x2 [MyStruct.field1] | main.rs:486:10:486:11 | x2 [MyStruct.field1] | provenance |  |
+| main.rs:478:14:485:6 | ... .max(...) [MyStruct.field1] | main.rs:478:9:478:10 | x2 [MyStruct.field1] | provenance |  |
+| main.rs:478:14:485:6 | ... .max(...) [MyStruct.field1] | main.rs:478:9:478:10 | x2 [MyStruct.field1] | provenance |  |
+| main.rs:478:15:481:5 | MyStruct {...} [MyStruct.field1] | main.rs:478:14:485:6 | ... .max(...) [MyStruct.field1] | provenance | MaD:19 |
+| main.rs:478:15:481:5 | MyStruct {...} [MyStruct.field1] | main.rs:478:14:485:6 | ... .max(...) [MyStruct.field1] | provenance | MaD:19 |
+| main.rs:479:17:479:26 | source(...) | main.rs:478:15:481:5 | MyStruct {...} [MyStruct.field1] | provenance |  |
+| main.rs:479:17:479:26 | source(...) | main.rs:478:15:481:5 | MyStruct {...} [MyStruct.field1] | provenance |  |
+| main.rs:486:10:486:11 | x2 [MyStruct.field1] | main.rs:486:10:486:18 | x2.field1 | provenance |  |
+| main.rs:486:10:486:11 | x2 [MyStruct.field1] | main.rs:486:10:486:18 | x2.field1 | provenance |  |
+| main.rs:491:9:491:10 | x4 | main.rs:492:10:492:11 | x4 | provenance |  |
+| main.rs:491:9:491:10 | x4 | main.rs:492:10:492:11 | x4 | provenance |  |
+| main.rs:491:14:491:23 | source(...) | main.rs:491:14:491:30 | ... .max(...) | provenance | MaD:19 |
+| main.rs:491:14:491:23 | source(...) | main.rs:491:14:491:30 | ... .max(...) | provenance | MaD:19 |
+| main.rs:491:14:491:30 | ... .max(...) | main.rs:491:9:491:10 | x4 | provenance |  |
+| main.rs:491:14:491:30 | ... .max(...) | main.rs:491:9:491:10 | x4 | provenance |  |
+| main.rs:494:9:494:10 | x5 | main.rs:495:10:495:11 | x5 | provenance |  |
+| main.rs:494:14:494:23 | source(...) | main.rs:494:14:494:30 | ... .lt(...) | provenance | MaD:20 |
+| main.rs:494:14:494:30 | ... .lt(...) | main.rs:494:9:494:10 | x5 | provenance |  |
+| main.rs:497:9:497:10 | x6 | main.rs:498:10:498:11 | x6 | provenance |  |
+| main.rs:497:14:497:23 | source(...) | main.rs:497:14:497:27 | ... < ... | provenance | MaD:20 |
+| main.rs:497:14:497:27 | ... < ... | main.rs:497:9:497:10 | x6 | provenance |  |
+| main.rs:503:9:503:10 | x8 | main.rs:504:10:504:11 | x8 | provenance |  |
+| main.rs:503:9:503:10 | x8 | main.rs:504:10:504:11 | x8 | provenance |  |
+| main.rs:503:14:503:44 | ...::flow_through2(...) | main.rs:503:9:503:10 | x8 | provenance |  |
+| main.rs:503:14:503:44 | ...::flow_through2(...) | main.rs:503:9:503:10 | x8 | provenance |  |
+| main.rs:503:34:503:43 | source(...) | main.rs:503:14:503:44 | ...::flow_through2(...) | provenance | MaD:25 |
+| main.rs:503:34:503:43 | source(...) | main.rs:503:14:503:44 | ...::flow_through2(...) | provenance | MaD:25 |
+| main.rs:519:10:519:28 | generated_source(...) | main.rs:519:10:519:28 | generated_source(...) | provenance | Src:MaD:14  |
+| main.rs:519:10:519:28 | generated_source(...) | main.rs:519:10:519:28 | generated_source(...) | provenance | Src:MaD:14  |
+| main.rs:521:10:521:33 | neutral_manual_source(...) | main.rs:521:10:521:33 | neutral_manual_source(...) | provenance | Src:MaD:15  |
+| main.rs:521:10:521:33 | neutral_manual_source(...) | main.rs:521:10:521:33 | neutral_manual_source(...) | provenance | Src:MaD:15  |
+| main.rs:522:20:522:28 | source(...) | main.rs:522:20:522:28 | source(...) | provenance | Sink:MaD:4 |
+| main.rs:522:20:522:28 | source(...) | main.rs:522:20:522:28 | source(...) | provenance | Sink:MaD:4 |
+| main.rs:524:25:524:33 | source(...) | main.rs:524:25:524:33 | source(...) | provenance | Sink:MaD:5 |
+| main.rs:524:25:524:33 | source(...) | main.rs:524:25:524:33 | source(...) | provenance | Sink:MaD:5 |
+| main.rs:525:28:525:36 | source(...) | main.rs:525:10:525:37 | generated_summary(...) | provenance | MaD:26 |
+| main.rs:525:28:525:36 | source(...) | main.rs:525:10:525:37 | generated_summary(...) | provenance | MaD:26 |
+| main.rs:527:33:527:41 | source(...) | main.rs:527:10:527:42 | neutral_manual_summary(...) | provenance | MaD:27 |
+| main.rs:527:33:527:41 | source(...) | main.rs:527:10:527:42 | neutral_manual_summary(...) | provenance | MaD:27 |
 nodes
 | main.rs:15:9:15:9 | s | semmle.label | s |
 | main.rs:15:9:15:9 | s | semmle.label | s |
@@ -620,74 +627,74 @@ nodes
 | main.rs:268:9:268:37 | ...::E {...} [E, Some] | semmle.label | ...::E {...} [E, Some] |
 | main.rs:268:35:268:35 | o [Some] | semmle.label | o [Some] |
 | main.rs:268:35:268:35 | o [Some] | semmle.label | o [Some] |
-| main.rs:270:19:270:19 | o [Some] | semmle.label | o [Some] |
-| main.rs:270:19:270:19 | o [Some] | semmle.label | o [Some] |
-| main.rs:271:17:271:23 | Some(...) [Some] | semmle.label | Some(...) [Some] |
-| main.rs:271:17:271:23 | Some(...) [Some] | semmle.label | Some(...) [Some] |
-| main.rs:271:22:271:22 | i | semmle.label | i |
-| main.rs:271:22:271:22 | i | semmle.label | i |
-| main.rs:271:33:271:33 | i | semmle.label | i |
-| main.rs:271:33:271:33 | i | semmle.label | i |
-| main.rs:280:9:280:9 | s [C] | semmle.label | s [C] |
-| main.rs:280:9:280:9 | s [C] | semmle.label | s [C] |
-| main.rs:280:13:280:24 | e.source(...) | semmle.label | e.source(...) |
-| main.rs:280:13:280:24 | e.source(...) | semmle.label | e.source(...) |
-| main.rs:281:11:281:11 | s [C] | semmle.label | s [C] |
-| main.rs:281:11:281:11 | s [C] | semmle.label | s [C] |
-| main.rs:282:9:282:37 | ...::C {...} [C] | semmle.label | ...::C {...} [C] |
-| main.rs:282:9:282:37 | ...::C {...} [C] | semmle.label | ...::C {...} [C] |
-| main.rs:282:35:282:35 | i | semmle.label | i |
-| main.rs:282:35:282:35 | i | semmle.label | i |
-| main.rs:282:47:282:47 | i | semmle.label | i |
-| main.rs:282:47:282:47 | i | semmle.label | i |
-| main.rs:303:26:303:26 | a | semmle.label | a |
-| main.rs:303:26:303:26 | a | semmle.label | a |
-| main.rs:304:24:304:24 | a | semmle.label | a |
-| main.rs:304:24:304:24 | a | semmle.label | a |
-| main.rs:306:24:308:9 | \|...\| ... | semmle.label | \|...\| ... |
-| main.rs:306:24:308:9 | \|...\| ... | semmle.label | \|...\| ... |
-| main.rs:307:18:307:18 | a | semmle.label | a |
-| main.rs:307:18:307:18 | a | semmle.label | a |
-| main.rs:311:18:311:18 | a | semmle.label | a |
-| main.rs:311:18:311:18 | a | semmle.label | a |
-| main.rs:313:24:313:24 | f | semmle.label | f |
-| main.rs:313:24:313:24 | f | semmle.label | f |
-| main.rs:315:24:317:9 | \|...\| ... | semmle.label | \|...\| ... |
-| main.rs:315:24:317:9 | \|...\| ... | semmle.label | \|...\| ... |
-| main.rs:316:18:316:18 | a | semmle.label | a |
-| main.rs:316:18:316:18 | a | semmle.label | a |
-| main.rs:319:31:331:9 | \|...\| ... | semmle.label | \|...\| ... |
-| main.rs:319:31:331:9 | \|...\| ... | semmle.label | \|...\| ... |
-| main.rs:319:31:331:9 | \|...\| ... [E, Some] | semmle.label | \|...\| ... [E, Some] |
-| main.rs:319:31:331:9 | \|...\| ... [E, Some] | semmle.label | \|...\| ... [E, Some] |
-| main.rs:320:19:320:19 | e [E, Some] | semmle.label | e [E, Some] |
-| main.rs:320:19:320:19 | e [E, Some] | semmle.label | e [E, Some] |
-| main.rs:323:17:323:45 | ...::E {...} [E, Some] | semmle.label | ...::E {...} [E, Some] |
-| main.rs:323:17:323:45 | ...::E {...} [E, Some] | semmle.label | ...::E {...} [E, Some] |
-| main.rs:323:43:323:43 | o [Some] | semmle.label | o [Some] |
-| main.rs:323:43:323:43 | o [Some] | semmle.label | o [Some] |
-| main.rs:325:27:325:27 | o [Some] | semmle.label | o [Some] |
-| main.rs:325:27:325:27 | o [Some] | semmle.label | o [Some] |
-| main.rs:326:25:326:31 | Some(...) [Some] | semmle.label | Some(...) [Some] |
-| main.rs:326:25:326:31 | Some(...) [Some] | semmle.label | Some(...) [Some] |
-| main.rs:326:30:326:30 | i | semmle.label | i |
-| main.rs:326:30:326:30 | i | semmle.label | i |
-| main.rs:326:41:326:41 | i | semmle.label | i |
-| main.rs:326:41:326:41 | i | semmle.label | i |
-| main.rs:346:21:346:29 | source(...) | semmle.label | source(...) |
-| main.rs:346:21:346:29 | source(...) | semmle.label | source(...) |
-| main.rs:347:19:347:19 | a | semmle.label | a |
-| main.rs:347:19:347:19 | a | semmle.label | a |
-| main.rs:350:17:350:17 | s | semmle.label | s |
-| main.rs:350:17:350:17 | s | semmle.label | s |
-| main.rs:350:21:350:29 | source(...) | semmle.label | source(...) |
-| main.rs:350:21:350:29 | source(...) | semmle.label | source(...) |
-| main.rs:351:13:351:55 | ...::E {...} [E, Some] | semmle.label | ...::E {...} [E, Some] |
-| main.rs:351:13:351:55 | ...::E {...} [E, Some] | semmle.label | ...::E {...} [E, Some] |
-| main.rs:351:39:351:53 | ...::Some(...) [Some] | semmle.label | ...::Some(...) [Some] |
-| main.rs:351:39:351:53 | ...::Some(...) [Some] | semmle.label | ...::Some(...) [Some] |
-| main.rs:351:52:351:52 | s | semmle.label | s |
-| main.rs:351:52:351:52 | s | semmle.label | s |
+| main.rs:269:19:269:19 | o [Some] | semmle.label | o [Some] |
+| main.rs:269:19:269:19 | o [Some] | semmle.label | o [Some] |
+| main.rs:270:17:270:23 | Some(...) [Some] | semmle.label | Some(...) [Some] |
+| main.rs:270:17:270:23 | Some(...) [Some] | semmle.label | Some(...) [Some] |
+| main.rs:270:22:270:22 | i | semmle.label | i |
+| main.rs:270:22:270:22 | i | semmle.label | i |
+| main.rs:270:33:270:33 | i | semmle.label | i |
+| main.rs:270:33:270:33 | i | semmle.label | i |
+| main.rs:279:9:279:9 | s [C] | semmle.label | s [C] |
+| main.rs:279:9:279:9 | s [C] | semmle.label | s [C] |
+| main.rs:279:13:279:24 | e.source(...) | semmle.label | e.source(...) |
+| main.rs:279:13:279:24 | e.source(...) | semmle.label | e.source(...) |
+| main.rs:280:11:280:11 | s [C] | semmle.label | s [C] |
+| main.rs:280:11:280:11 | s [C] | semmle.label | s [C] |
+| main.rs:281:9:281:37 | ...::C {...} [C] | semmle.label | ...::C {...} [C] |
+| main.rs:281:9:281:37 | ...::C {...} [C] | semmle.label | ...::C {...} [C] |
+| main.rs:281:35:281:35 | i | semmle.label | i |
+| main.rs:281:35:281:35 | i | semmle.label | i |
+| main.rs:281:47:281:47 | i | semmle.label | i |
+| main.rs:281:47:281:47 | i | semmle.label | i |
+| main.rs:302:26:302:26 | a | semmle.label | a |
+| main.rs:302:26:302:26 | a | semmle.label | a |
+| main.rs:303:24:303:24 | a | semmle.label | a |
+| main.rs:303:24:303:24 | a | semmle.label | a |
+| main.rs:305:24:307:9 | \|...\| ... | semmle.label | \|...\| ... |
+| main.rs:305:24:307:9 | \|...\| ... | semmle.label | \|...\| ... |
+| main.rs:306:18:306:18 | a | semmle.label | a |
+| main.rs:306:18:306:18 | a | semmle.label | a |
+| main.rs:310:18:310:18 | a | semmle.label | a |
+| main.rs:310:18:310:18 | a | semmle.label | a |
+| main.rs:312:24:312:24 | f | semmle.label | f |
+| main.rs:312:24:312:24 | f | semmle.label | f |
+| main.rs:314:24:316:9 | \|...\| ... | semmle.label | \|...\| ... |
+| main.rs:314:24:316:9 | \|...\| ... | semmle.label | \|...\| ... |
+| main.rs:315:18:315:18 | a | semmle.label | a |
+| main.rs:315:18:315:18 | a | semmle.label | a |
+| main.rs:318:31:329:9 | \|...\| ... | semmle.label | \|...\| ... |
+| main.rs:318:31:329:9 | \|...\| ... | semmle.label | \|...\| ... |
+| main.rs:318:31:329:9 | \|...\| ... [E, Some] | semmle.label | \|...\| ... [E, Some] |
+| main.rs:318:31:329:9 | \|...\| ... [E, Some] | semmle.label | \|...\| ... [E, Some] |
+| main.rs:319:19:319:19 | e [E, Some] | semmle.label | e [E, Some] |
+| main.rs:319:19:319:19 | e [E, Some] | semmle.label | e [E, Some] |
+| main.rs:322:17:322:45 | ...::E {...} [E, Some] | semmle.label | ...::E {...} [E, Some] |
+| main.rs:322:17:322:45 | ...::E {...} [E, Some] | semmle.label | ...::E {...} [E, Some] |
+| main.rs:322:43:322:43 | o [Some] | semmle.label | o [Some] |
+| main.rs:322:43:322:43 | o [Some] | semmle.label | o [Some] |
+| main.rs:323:27:323:27 | o [Some] | semmle.label | o [Some] |
+| main.rs:323:27:323:27 | o [Some] | semmle.label | o [Some] |
+| main.rs:324:25:324:31 | Some(...) [Some] | semmle.label | Some(...) [Some] |
+| main.rs:324:25:324:31 | Some(...) [Some] | semmle.label | Some(...) [Some] |
+| main.rs:324:30:324:30 | i | semmle.label | i |
+| main.rs:324:30:324:30 | i | semmle.label | i |
+| main.rs:324:41:324:41 | i | semmle.label | i |
+| main.rs:324:41:324:41 | i | semmle.label | i |
+| main.rs:344:21:344:29 | source(...) | semmle.label | source(...) |
+| main.rs:344:21:344:29 | source(...) | semmle.label | source(...) |
+| main.rs:345:19:345:19 | a | semmle.label | a |
+| main.rs:345:19:345:19 | a | semmle.label | a |
+| main.rs:348:17:348:17 | s | semmle.label | s |
+| main.rs:348:17:348:17 | s | semmle.label | s |
+| main.rs:348:21:348:29 | source(...) | semmle.label | source(...) |
+| main.rs:348:21:348:29 | source(...) | semmle.label | source(...) |
+| main.rs:349:13:351:13 | ...::E {...} [E, Some] | semmle.label | ...::E {...} [E, Some] |
+| main.rs:349:13:351:13 | ...::E {...} [E, Some] | semmle.label | ...::E {...} [E, Some] |
+| main.rs:350:26:350:40 | ...::Some(...) [Some] | semmle.label | ...::Some(...) [Some] |
+| main.rs:350:26:350:40 | ...::Some(...) [Some] | semmle.label | ...::Some(...) [Some] |
+| main.rs:350:39:350:39 | s | semmle.label | s |
+| main.rs:350:39:350:39 | s | semmle.label | s |
 | main.rs:353:26:353:26 | b | semmle.label | b |
 | main.rs:353:26:353:26 | b | semmle.label | b |
 | main.rs:353:26:353:26 | b [E, Some] | semmle.label | b [E, Some] |
@@ -742,66 +749,74 @@ nodes
 | main.rs:410:26:410:31 | ...: i64 | semmle.label | ...: i64 |
 | main.rs:411:14:411:14 | i | semmle.label | i |
 | main.rs:411:14:411:14 | i | semmle.label | i |
-| main.rs:464:9:464:10 | x1 | semmle.label | x1 |
-| main.rs:464:9:464:10 | x1 | semmle.label | x1 |
-| main.rs:464:14:464:23 | source(...) | semmle.label | source(...) |
-| main.rs:464:14:464:23 | source(...) | semmle.label | source(...) |
-| main.rs:464:14:464:30 | ... .max(...) | semmle.label | ... .max(...) |
-| main.rs:464:14:464:30 | ... .max(...) | semmle.label | ... .max(...) |
-| main.rs:465:10:465:11 | x1 | semmle.label | x1 |
-| main.rs:465:10:465:11 | x1 | semmle.label | x1 |
-| main.rs:467:9:467:10 | x2 [MyStruct.field1] | semmle.label | x2 [MyStruct.field1] |
-| main.rs:467:9:467:10 | x2 [MyStruct.field1] | semmle.label | x2 [MyStruct.field1] |
-| main.rs:467:14:474:6 | ... .max(...) [MyStruct.field1] | semmle.label | ... .max(...) [MyStruct.field1] |
-| main.rs:467:14:474:6 | ... .max(...) [MyStruct.field1] | semmle.label | ... .max(...) [MyStruct.field1] |
-| main.rs:467:15:470:5 | MyStruct {...} [MyStruct.field1] | semmle.label | MyStruct {...} [MyStruct.field1] |
-| main.rs:467:15:470:5 | MyStruct {...} [MyStruct.field1] | semmle.label | MyStruct {...} [MyStruct.field1] |
-| main.rs:468:17:468:26 | source(...) | semmle.label | source(...) |
-| main.rs:468:17:468:26 | source(...) | semmle.label | source(...) |
-| main.rs:475:10:475:11 | x2 [MyStruct.field1] | semmle.label | x2 [MyStruct.field1] |
-| main.rs:475:10:475:11 | x2 [MyStruct.field1] | semmle.label | x2 [MyStruct.field1] |
-| main.rs:475:10:475:18 | x2.field1 | semmle.label | x2.field1 |
-| main.rs:475:10:475:18 | x2.field1 | semmle.label | x2.field1 |
-| main.rs:480:9:480:10 | x4 | semmle.label | x4 |
-| main.rs:480:9:480:10 | x4 | semmle.label | x4 |
-| main.rs:480:14:480:23 | source(...) | semmle.label | source(...) |
-| main.rs:480:14:480:23 | source(...) | semmle.label | source(...) |
-| main.rs:480:14:480:30 | ... .max(...) | semmle.label | ... .max(...) |
-| main.rs:480:14:480:30 | ... .max(...) | semmle.label | ... .max(...) |
-| main.rs:481:10:481:11 | x4 | semmle.label | x4 |
-| main.rs:481:10:481:11 | x4 | semmle.label | x4 |
-| main.rs:483:9:483:10 | x5 | semmle.label | x5 |
-| main.rs:483:14:483:23 | source(...) | semmle.label | source(...) |
-| main.rs:483:14:483:30 | ... .lt(...) | semmle.label | ... .lt(...) |
-| main.rs:484:10:484:11 | x5 | semmle.label | x5 |
-| main.rs:486:9:486:10 | x6 | semmle.label | x6 |
-| main.rs:486:14:486:23 | source(...) | semmle.label | source(...) |
-| main.rs:486:14:486:27 | ... < ... | semmle.label | ... < ... |
-| main.rs:487:10:487:11 | x6 | semmle.label | x6 |
-| main.rs:502:10:502:28 | generated_source(...) | semmle.label | generated_source(...) |
-| main.rs:502:10:502:28 | generated_source(...) | semmle.label | generated_source(...) |
-| main.rs:502:10:502:28 | generated_source(...) | semmle.label | generated_source(...) |
-| main.rs:502:10:502:28 | generated_source(...) | semmle.label | generated_source(...) |
-| main.rs:504:10:504:33 | neutral_manual_source(...) | semmle.label | neutral_manual_source(...) |
-| main.rs:504:10:504:33 | neutral_manual_source(...) | semmle.label | neutral_manual_source(...) |
-| main.rs:504:10:504:33 | neutral_manual_source(...) | semmle.label | neutral_manual_source(...) |
-| main.rs:504:10:504:33 | neutral_manual_source(...) | semmle.label | neutral_manual_source(...) |
-| main.rs:505:20:505:28 | source(...) | semmle.label | source(...) |
-| main.rs:505:20:505:28 | source(...) | semmle.label | source(...) |
-| main.rs:505:20:505:28 | source(...) | semmle.label | source(...) |
-| main.rs:505:20:505:28 | source(...) | semmle.label | source(...) |
-| main.rs:507:25:507:33 | source(...) | semmle.label | source(...) |
-| main.rs:507:25:507:33 | source(...) | semmle.label | source(...) |
-| main.rs:507:25:507:33 | source(...) | semmle.label | source(...) |
-| main.rs:507:25:507:33 | source(...) | semmle.label | source(...) |
-| main.rs:508:10:508:37 | generated_summary(...) | semmle.label | generated_summary(...) |
-| main.rs:508:10:508:37 | generated_summary(...) | semmle.label | generated_summary(...) |
-| main.rs:508:28:508:36 | source(...) | semmle.label | source(...) |
-| main.rs:508:28:508:36 | source(...) | semmle.label | source(...) |
-| main.rs:510:10:510:42 | neutral_manual_summary(...) | semmle.label | neutral_manual_summary(...) |
-| main.rs:510:10:510:42 | neutral_manual_summary(...) | semmle.label | neutral_manual_summary(...) |
-| main.rs:510:33:510:41 | source(...) | semmle.label | source(...) |
-| main.rs:510:33:510:41 | source(...) | semmle.label | source(...) |
+| main.rs:475:9:475:10 | x1 | semmle.label | x1 |
+| main.rs:475:9:475:10 | x1 | semmle.label | x1 |
+| main.rs:475:14:475:23 | source(...) | semmle.label | source(...) |
+| main.rs:475:14:475:23 | source(...) | semmle.label | source(...) |
+| main.rs:475:14:475:30 | ... .max(...) | semmle.label | ... .max(...) |
+| main.rs:475:14:475:30 | ... .max(...) | semmle.label | ... .max(...) |
+| main.rs:476:10:476:11 | x1 | semmle.label | x1 |
+| main.rs:476:10:476:11 | x1 | semmle.label | x1 |
+| main.rs:478:9:478:10 | x2 [MyStruct.field1] | semmle.label | x2 [MyStruct.field1] |
+| main.rs:478:9:478:10 | x2 [MyStruct.field1] | semmle.label | x2 [MyStruct.field1] |
+| main.rs:478:14:485:6 | ... .max(...) [MyStruct.field1] | semmle.label | ... .max(...) [MyStruct.field1] |
+| main.rs:478:14:485:6 | ... .max(...) [MyStruct.field1] | semmle.label | ... .max(...) [MyStruct.field1] |
+| main.rs:478:15:481:5 | MyStruct {...} [MyStruct.field1] | semmle.label | MyStruct {...} [MyStruct.field1] |
+| main.rs:478:15:481:5 | MyStruct {...} [MyStruct.field1] | semmle.label | MyStruct {...} [MyStruct.field1] |
+| main.rs:479:17:479:26 | source(...) | semmle.label | source(...) |
+| main.rs:479:17:479:26 | source(...) | semmle.label | source(...) |
+| main.rs:486:10:486:11 | x2 [MyStruct.field1] | semmle.label | x2 [MyStruct.field1] |
+| main.rs:486:10:486:11 | x2 [MyStruct.field1] | semmle.label | x2 [MyStruct.field1] |
+| main.rs:486:10:486:18 | x2.field1 | semmle.label | x2.field1 |
+| main.rs:486:10:486:18 | x2.field1 | semmle.label | x2.field1 |
+| main.rs:491:9:491:10 | x4 | semmle.label | x4 |
+| main.rs:491:9:491:10 | x4 | semmle.label | x4 |
+| main.rs:491:14:491:23 | source(...) | semmle.label | source(...) |
+| main.rs:491:14:491:23 | source(...) | semmle.label | source(...) |
+| main.rs:491:14:491:30 | ... .max(...) | semmle.label | ... .max(...) |
+| main.rs:491:14:491:30 | ... .max(...) | semmle.label | ... .max(...) |
+| main.rs:492:10:492:11 | x4 | semmle.label | x4 |
+| main.rs:492:10:492:11 | x4 | semmle.label | x4 |
+| main.rs:494:9:494:10 | x5 | semmle.label | x5 |
+| main.rs:494:14:494:23 | source(...) | semmle.label | source(...) |
+| main.rs:494:14:494:30 | ... .lt(...) | semmle.label | ... .lt(...) |
+| main.rs:495:10:495:11 | x5 | semmle.label | x5 |
+| main.rs:497:9:497:10 | x6 | semmle.label | x6 |
+| main.rs:497:14:497:23 | source(...) | semmle.label | source(...) |
+| main.rs:497:14:497:27 | ... < ... | semmle.label | ... < ... |
+| main.rs:498:10:498:11 | x6 | semmle.label | x6 |
+| main.rs:503:9:503:10 | x8 | semmle.label | x8 |
+| main.rs:503:9:503:10 | x8 | semmle.label | x8 |
+| main.rs:503:14:503:44 | ...::flow_through2(...) | semmle.label | ...::flow_through2(...) |
+| main.rs:503:14:503:44 | ...::flow_through2(...) | semmle.label | ...::flow_through2(...) |
+| main.rs:503:34:503:43 | source(...) | semmle.label | source(...) |
+| main.rs:503:34:503:43 | source(...) | semmle.label | source(...) |
+| main.rs:504:10:504:11 | x8 | semmle.label | x8 |
+| main.rs:504:10:504:11 | x8 | semmle.label | x8 |
+| main.rs:519:10:519:28 | generated_source(...) | semmle.label | generated_source(...) |
+| main.rs:519:10:519:28 | generated_source(...) | semmle.label | generated_source(...) |
+| main.rs:519:10:519:28 | generated_source(...) | semmle.label | generated_source(...) |
+| main.rs:519:10:519:28 | generated_source(...) | semmle.label | generated_source(...) |
+| main.rs:521:10:521:33 | neutral_manual_source(...) | semmle.label | neutral_manual_source(...) |
+| main.rs:521:10:521:33 | neutral_manual_source(...) | semmle.label | neutral_manual_source(...) |
+| main.rs:521:10:521:33 | neutral_manual_source(...) | semmle.label | neutral_manual_source(...) |
+| main.rs:521:10:521:33 | neutral_manual_source(...) | semmle.label | neutral_manual_source(...) |
+| main.rs:522:20:522:28 | source(...) | semmle.label | source(...) |
+| main.rs:522:20:522:28 | source(...) | semmle.label | source(...) |
+| main.rs:522:20:522:28 | source(...) | semmle.label | source(...) |
+| main.rs:522:20:522:28 | source(...) | semmle.label | source(...) |
+| main.rs:524:25:524:33 | source(...) | semmle.label | source(...) |
+| main.rs:524:25:524:33 | source(...) | semmle.label | source(...) |
+| main.rs:524:25:524:33 | source(...) | semmle.label | source(...) |
+| main.rs:524:25:524:33 | source(...) | semmle.label | source(...) |
+| main.rs:525:10:525:37 | generated_summary(...) | semmle.label | generated_summary(...) |
+| main.rs:525:10:525:37 | generated_summary(...) | semmle.label | generated_summary(...) |
+| main.rs:525:28:525:36 | source(...) | semmle.label | source(...) |
+| main.rs:525:28:525:36 | source(...) | semmle.label | source(...) |
+| main.rs:527:10:527:42 | neutral_manual_summary(...) | semmle.label | neutral_manual_summary(...) |
+| main.rs:527:10:527:42 | neutral_manual_summary(...) | semmle.label | neutral_manual_summary(...) |
+| main.rs:527:33:527:41 | source(...) | semmle.label | source(...) |
+| main.rs:527:33:527:41 | source(...) | semmle.label | source(...) |
 subpaths
 | main.rs:214:23:214:23 | f [captured s] | main.rs:213:40:213:40 | s | main.rs:213:17:213:42 | if ... {...} else {...} | main.rs:214:13:214:24 | apply(...) |
 | main.rs:214:23:214:23 | f [captured s] | main.rs:213:40:213:40 | s | main.rs:213:17:213:42 | if ... {...} else {...} | main.rs:214:13:214:24 | apply(...) |
@@ -845,24 +860,24 @@ invalidSpecComponent
 | main.rs:233:10:233:10 | t | main.rs:231:13:231:22 | source(...) | main.rs:233:10:233:10 | t | $@ | main.rs:231:13:231:22 | source(...) | source(...) |
 | main.rs:260:47:260:47 | i | main.rs:257:13:257:27 | enum_source(...) | main.rs:260:47:260:47 | i | $@ | main.rs:257:13:257:27 | enum_source(...) | enum_source(...) |
 | main.rs:260:47:260:47 | i | main.rs:257:13:257:27 | enum_source(...) | main.rs:260:47:260:47 | i | $@ | main.rs:257:13:257:27 | enum_source(...) | enum_source(...) |
-| main.rs:271:33:271:33 | i | main.rs:264:13:264:34 | enum_source_nested(...) | main.rs:271:33:271:33 | i | $@ | main.rs:264:13:264:34 | enum_source_nested(...) | enum_source_nested(...) |
-| main.rs:271:33:271:33 | i | main.rs:264:13:264:34 | enum_source_nested(...) | main.rs:271:33:271:33 | i | $@ | main.rs:264:13:264:34 | enum_source_nested(...) | enum_source_nested(...) |
-| main.rs:282:47:282:47 | i | main.rs:280:13:280:24 | e.source(...) | main.rs:282:47:282:47 | i | $@ | main.rs:280:13:280:24 | e.source(...) | e.source(...) |
-| main.rs:282:47:282:47 | i | main.rs:280:13:280:24 | e.source(...) | main.rs:282:47:282:47 | i | $@ | main.rs:280:13:280:24 | e.source(...) | e.source(...) |
-| main.rs:303:26:303:26 | a | main.rs:304:24:304:24 | a | main.rs:303:26:303:26 | a | $@ | main.rs:304:24:304:24 | a | a |
-| main.rs:303:26:303:26 | a | main.rs:304:24:304:24 | a | main.rs:303:26:303:26 | a | $@ | main.rs:304:24:304:24 | a | a |
-| main.rs:307:18:307:18 | a | main.rs:306:24:308:9 | \|...\| ... | main.rs:307:18:307:18 | a | $@ | main.rs:306:24:308:9 | \|...\| ... | \|...\| ... |
-| main.rs:307:18:307:18 | a | main.rs:306:24:308:9 | \|...\| ... | main.rs:307:18:307:18 | a | $@ | main.rs:306:24:308:9 | \|...\| ... | \|...\| ... |
-| main.rs:311:18:311:18 | a | main.rs:313:24:313:24 | f | main.rs:311:18:311:18 | a | $@ | main.rs:313:24:313:24 | f | f |
-| main.rs:311:18:311:18 | a | main.rs:313:24:313:24 | f | main.rs:311:18:311:18 | a | $@ | main.rs:313:24:313:24 | f | f |
-| main.rs:316:18:316:18 | a | main.rs:315:24:317:9 | \|...\| ... | main.rs:316:18:316:18 | a | $@ | main.rs:315:24:317:9 | \|...\| ... | \|...\| ... |
-| main.rs:316:18:316:18 | a | main.rs:315:24:317:9 | \|...\| ... | main.rs:316:18:316:18 | a | $@ | main.rs:315:24:317:9 | \|...\| ... | \|...\| ... |
-| main.rs:326:41:326:41 | i | main.rs:319:31:331:9 | \|...\| ... | main.rs:326:41:326:41 | i | $@ | main.rs:319:31:331:9 | \|...\| ... | \|...\| ... |
-| main.rs:326:41:326:41 | i | main.rs:319:31:331:9 | \|...\| ... | main.rs:326:41:326:41 | i | $@ | main.rs:319:31:331:9 | \|...\| ... | \|...\| ... |
-| main.rs:347:19:347:19 | a | main.rs:346:21:346:29 | source(...) | main.rs:347:19:347:19 | a | $@ | main.rs:346:21:346:29 | source(...) | source(...) |
-| main.rs:347:19:347:19 | a | main.rs:346:21:346:29 | source(...) | main.rs:347:19:347:19 | a | $@ | main.rs:346:21:346:29 | source(...) | source(...) |
-| main.rs:353:26:353:26 | b | main.rs:350:21:350:29 | source(...) | main.rs:353:26:353:26 | b | $@ | main.rs:350:21:350:29 | source(...) | source(...) |
-| main.rs:353:26:353:26 | b | main.rs:350:21:350:29 | source(...) | main.rs:353:26:353:26 | b | $@ | main.rs:350:21:350:29 | source(...) | source(...) |
+| main.rs:270:33:270:33 | i | main.rs:264:13:264:34 | enum_source_nested(...) | main.rs:270:33:270:33 | i | $@ | main.rs:264:13:264:34 | enum_source_nested(...) | enum_source_nested(...) |
+| main.rs:270:33:270:33 | i | main.rs:264:13:264:34 | enum_source_nested(...) | main.rs:270:33:270:33 | i | $@ | main.rs:264:13:264:34 | enum_source_nested(...) | enum_source_nested(...) |
+| main.rs:281:47:281:47 | i | main.rs:279:13:279:24 | e.source(...) | main.rs:281:47:281:47 | i | $@ | main.rs:279:13:279:24 | e.source(...) | e.source(...) |
+| main.rs:281:47:281:47 | i | main.rs:279:13:279:24 | e.source(...) | main.rs:281:47:281:47 | i | $@ | main.rs:279:13:279:24 | e.source(...) | e.source(...) |
+| main.rs:302:26:302:26 | a | main.rs:303:24:303:24 | a | main.rs:302:26:302:26 | a | $@ | main.rs:303:24:303:24 | a | a |
+| main.rs:302:26:302:26 | a | main.rs:303:24:303:24 | a | main.rs:302:26:302:26 | a | $@ | main.rs:303:24:303:24 | a | a |
+| main.rs:306:18:306:18 | a | main.rs:305:24:307:9 | \|...\| ... | main.rs:306:18:306:18 | a | $@ | main.rs:305:24:307:9 | \|...\| ... | \|...\| ... |
+| main.rs:306:18:306:18 | a | main.rs:305:24:307:9 | \|...\| ... | main.rs:306:18:306:18 | a | $@ | main.rs:305:24:307:9 | \|...\| ... | \|...\| ... |
+| main.rs:310:18:310:18 | a | main.rs:312:24:312:24 | f | main.rs:310:18:310:18 | a | $@ | main.rs:312:24:312:24 | f | f |
+| main.rs:310:18:310:18 | a | main.rs:312:24:312:24 | f | main.rs:310:18:310:18 | a | $@ | main.rs:312:24:312:24 | f | f |
+| main.rs:315:18:315:18 | a | main.rs:314:24:316:9 | \|...\| ... | main.rs:315:18:315:18 | a | $@ | main.rs:314:24:316:9 | \|...\| ... | \|...\| ... |
+| main.rs:315:18:315:18 | a | main.rs:314:24:316:9 | \|...\| ... | main.rs:315:18:315:18 | a | $@ | main.rs:314:24:316:9 | \|...\| ... | \|...\| ... |
+| main.rs:324:41:324:41 | i | main.rs:318:31:329:9 | \|...\| ... | main.rs:324:41:324:41 | i | $@ | main.rs:318:31:329:9 | \|...\| ... | \|...\| ... |
+| main.rs:324:41:324:41 | i | main.rs:318:31:329:9 | \|...\| ... | main.rs:324:41:324:41 | i | $@ | main.rs:318:31:329:9 | \|...\| ... | \|...\| ... |
+| main.rs:345:19:345:19 | a | main.rs:344:21:344:29 | source(...) | main.rs:345:19:345:19 | a | $@ | main.rs:344:21:344:29 | source(...) | source(...) |
+| main.rs:345:19:345:19 | a | main.rs:344:21:344:29 | source(...) | main.rs:345:19:345:19 | a | $@ | main.rs:344:21:344:29 | source(...) | source(...) |
+| main.rs:353:26:353:26 | b | main.rs:348:21:348:29 | source(...) | main.rs:353:26:353:26 | b | $@ | main.rs:348:21:348:29 | source(...) | source(...) |
+| main.rs:353:26:353:26 | b | main.rs:348:21:348:29 | source(...) | main.rs:353:26:353:26 | b | $@ | main.rs:348:21:348:29 | source(...) | source(...) |
 | main.rs:365:15:365:43 | ...::C {...} | main.rs:364:13:364:22 | source(...) | main.rs:365:15:365:43 | ...::C {...} | $@ | main.rs:364:13:364:22 | source(...) | source(...) |
 | main.rs:365:15:365:43 | ...::C {...} | main.rs:364:13:364:22 | source(...) | main.rs:365:15:365:43 | ...::C {...} | $@ | main.rs:364:13:364:22 | source(...) | source(...) |
 | main.rs:368:22:368:56 | ...::E {...} | main.rs:364:13:364:22 | source(...) | main.rs:368:22:368:56 | ...::E {...} | $@ | main.rs:364:13:364:22 | source(...) | source(...) |
@@ -877,23 +892,25 @@ invalidSpecComponent
 | main.rs:401:10:401:10 | i | main.rs:400:16:400:16 | i | main.rs:401:10:401:10 | i | $@ | main.rs:400:16:400:16 | i | i |
 | main.rs:411:14:411:14 | i | main.rs:410:26:410:31 | ...: i64 | main.rs:411:14:411:14 | i | $@ | main.rs:410:26:410:31 | ...: i64 | ...: i64 |
 | main.rs:411:14:411:14 | i | main.rs:410:26:410:31 | ...: i64 | main.rs:411:14:411:14 | i | $@ | main.rs:410:26:410:31 | ...: i64 | ...: i64 |
-| main.rs:465:10:465:11 | x1 | main.rs:464:14:464:23 | source(...) | main.rs:465:10:465:11 | x1 | $@ | main.rs:464:14:464:23 | source(...) | source(...) |
-| main.rs:465:10:465:11 | x1 | main.rs:464:14:464:23 | source(...) | main.rs:465:10:465:11 | x1 | $@ | main.rs:464:14:464:23 | source(...) | source(...) |
-| main.rs:475:10:475:18 | x2.field1 | main.rs:468:17:468:26 | source(...) | main.rs:475:10:475:18 | x2.field1 | $@ | main.rs:468:17:468:26 | source(...) | source(...) |
-| main.rs:475:10:475:18 | x2.field1 | main.rs:468:17:468:26 | source(...) | main.rs:475:10:475:18 | x2.field1 | $@ | main.rs:468:17:468:26 | source(...) | source(...) |
-| main.rs:481:10:481:11 | x4 | main.rs:480:14:480:23 | source(...) | main.rs:481:10:481:11 | x4 | $@ | main.rs:480:14:480:23 | source(...) | source(...) |
-| main.rs:481:10:481:11 | x4 | main.rs:480:14:480:23 | source(...) | main.rs:481:10:481:11 | x4 | $@ | main.rs:480:14:480:23 | source(...) | source(...) |
-| main.rs:484:10:484:11 | x5 | main.rs:483:14:483:23 | source(...) | main.rs:484:10:484:11 | x5 | $@ | main.rs:483:14:483:23 | source(...) | source(...) |
-| main.rs:487:10:487:11 | x6 | main.rs:486:14:486:23 | source(...) | main.rs:487:10:487:11 | x6 | $@ | main.rs:486:14:486:23 | source(...) | source(...) |
-| main.rs:502:10:502:28 | generated_source(...) | main.rs:502:10:502:28 | generated_source(...) | main.rs:502:10:502:28 | generated_source(...) | $@ | main.rs:502:10:502:28 | generated_source(...) | generated_source(...) |
-| main.rs:502:10:502:28 | generated_source(...) | main.rs:502:10:502:28 | generated_source(...) | main.rs:502:10:502:28 | generated_source(...) | $@ | main.rs:502:10:502:28 | generated_source(...) | generated_source(...) |
-| main.rs:504:10:504:33 | neutral_manual_source(...) | main.rs:504:10:504:33 | neutral_manual_source(...) | main.rs:504:10:504:33 | neutral_manual_source(...) | $@ | main.rs:504:10:504:33 | neutral_manual_source(...) | neutral_manual_source(...) |
-| main.rs:504:10:504:33 | neutral_manual_source(...) | main.rs:504:10:504:33 | neutral_manual_source(...) | main.rs:504:10:504:33 | neutral_manual_source(...) | $@ | main.rs:504:10:504:33 | neutral_manual_source(...) | neutral_manual_source(...) |
-| main.rs:505:20:505:28 | source(...) | main.rs:505:20:505:28 | source(...) | main.rs:505:20:505:28 | source(...) | $@ | main.rs:505:20:505:28 | source(...) | source(...) |
-| main.rs:505:20:505:28 | source(...) | main.rs:505:20:505:28 | source(...) | main.rs:505:20:505:28 | source(...) | $@ | main.rs:505:20:505:28 | source(...) | source(...) |
-| main.rs:507:25:507:33 | source(...) | main.rs:507:25:507:33 | source(...) | main.rs:507:25:507:33 | source(...) | $@ | main.rs:507:25:507:33 | source(...) | source(...) |
-| main.rs:507:25:507:33 | source(...) | main.rs:507:25:507:33 | source(...) | main.rs:507:25:507:33 | source(...) | $@ | main.rs:507:25:507:33 | source(...) | source(...) |
-| main.rs:508:10:508:37 | generated_summary(...) | main.rs:508:28:508:36 | source(...) | main.rs:508:10:508:37 | generated_summary(...) | $@ | main.rs:508:28:508:36 | source(...) | source(...) |
-| main.rs:508:10:508:37 | generated_summary(...) | main.rs:508:28:508:36 | source(...) | main.rs:508:10:508:37 | generated_summary(...) | $@ | main.rs:508:28:508:36 | source(...) | source(...) |
-| main.rs:510:10:510:42 | neutral_manual_summary(...) | main.rs:510:33:510:41 | source(...) | main.rs:510:10:510:42 | neutral_manual_summary(...) | $@ | main.rs:510:33:510:41 | source(...) | source(...) |
-| main.rs:510:10:510:42 | neutral_manual_summary(...) | main.rs:510:33:510:41 | source(...) | main.rs:510:10:510:42 | neutral_manual_summary(...) | $@ | main.rs:510:33:510:41 | source(...) | source(...) |
+| main.rs:476:10:476:11 | x1 | main.rs:475:14:475:23 | source(...) | main.rs:476:10:476:11 | x1 | $@ | main.rs:475:14:475:23 | source(...) | source(...) |
+| main.rs:476:10:476:11 | x1 | main.rs:475:14:475:23 | source(...) | main.rs:476:10:476:11 | x1 | $@ | main.rs:475:14:475:23 | source(...) | source(...) |
+| main.rs:486:10:486:18 | x2.field1 | main.rs:479:17:479:26 | source(...) | main.rs:486:10:486:18 | x2.field1 | $@ | main.rs:479:17:479:26 | source(...) | source(...) |
+| main.rs:486:10:486:18 | x2.field1 | main.rs:479:17:479:26 | source(...) | main.rs:486:10:486:18 | x2.field1 | $@ | main.rs:479:17:479:26 | source(...) | source(...) |
+| main.rs:492:10:492:11 | x4 | main.rs:491:14:491:23 | source(...) | main.rs:492:10:492:11 | x4 | $@ | main.rs:491:14:491:23 | source(...) | source(...) |
+| main.rs:492:10:492:11 | x4 | main.rs:491:14:491:23 | source(...) | main.rs:492:10:492:11 | x4 | $@ | main.rs:491:14:491:23 | source(...) | source(...) |
+| main.rs:495:10:495:11 | x5 | main.rs:494:14:494:23 | source(...) | main.rs:495:10:495:11 | x5 | $@ | main.rs:494:14:494:23 | source(...) | source(...) |
+| main.rs:498:10:498:11 | x6 | main.rs:497:14:497:23 | source(...) | main.rs:498:10:498:11 | x6 | $@ | main.rs:497:14:497:23 | source(...) | source(...) |
+| main.rs:504:10:504:11 | x8 | main.rs:503:34:503:43 | source(...) | main.rs:504:10:504:11 | x8 | $@ | main.rs:503:34:503:43 | source(...) | source(...) |
+| main.rs:504:10:504:11 | x8 | main.rs:503:34:503:43 | source(...) | main.rs:504:10:504:11 | x8 | $@ | main.rs:503:34:503:43 | source(...) | source(...) |
+| main.rs:519:10:519:28 | generated_source(...) | main.rs:519:10:519:28 | generated_source(...) | main.rs:519:10:519:28 | generated_source(...) | $@ | main.rs:519:10:519:28 | generated_source(...) | generated_source(...) |
+| main.rs:519:10:519:28 | generated_source(...) | main.rs:519:10:519:28 | generated_source(...) | main.rs:519:10:519:28 | generated_source(...) | $@ | main.rs:519:10:519:28 | generated_source(...) | generated_source(...) |
+| main.rs:521:10:521:33 | neutral_manual_source(...) | main.rs:521:10:521:33 | neutral_manual_source(...) | main.rs:521:10:521:33 | neutral_manual_source(...) | $@ | main.rs:521:10:521:33 | neutral_manual_source(...) | neutral_manual_source(...) |
+| main.rs:521:10:521:33 | neutral_manual_source(...) | main.rs:521:10:521:33 | neutral_manual_source(...) | main.rs:521:10:521:33 | neutral_manual_source(...) | $@ | main.rs:521:10:521:33 | neutral_manual_source(...) | neutral_manual_source(...) |
+| main.rs:522:20:522:28 | source(...) | main.rs:522:20:522:28 | source(...) | main.rs:522:20:522:28 | source(...) | $@ | main.rs:522:20:522:28 | source(...) | source(...) |
+| main.rs:522:20:522:28 | source(...) | main.rs:522:20:522:28 | source(...) | main.rs:522:20:522:28 | source(...) | $@ | main.rs:522:20:522:28 | source(...) | source(...) |
+| main.rs:524:25:524:33 | source(...) | main.rs:524:25:524:33 | source(...) | main.rs:524:25:524:33 | source(...) | $@ | main.rs:524:25:524:33 | source(...) | source(...) |
+| main.rs:524:25:524:33 | source(...) | main.rs:524:25:524:33 | source(...) | main.rs:524:25:524:33 | source(...) | $@ | main.rs:524:25:524:33 | source(...) | source(...) |
+| main.rs:525:10:525:37 | generated_summary(...) | main.rs:525:28:525:36 | source(...) | main.rs:525:10:525:37 | generated_summary(...) | $@ | main.rs:525:28:525:36 | source(...) | source(...) |
+| main.rs:525:10:525:37 | generated_summary(...) | main.rs:525:28:525:36 | source(...) | main.rs:525:10:525:37 | generated_summary(...) | $@ | main.rs:525:28:525:36 | source(...) | source(...) |
+| main.rs:527:10:527:42 | neutral_manual_summary(...) | main.rs:527:33:527:41 | source(...) | main.rs:527:10:527:42 | neutral_manual_summary(...) | $@ | main.rs:527:33:527:41 | source(...) | source(...) |
+| main.rs:527:10:527:42 | neutral_manual_summary(...) | main.rs:527:33:527:41 | source(...) | main.rs:527:10:527:42 | neutral_manual_summary(...) | $@ | main.rs:527:33:527:41 | source(...) | source(...) |

--- a/rust/ql/test/library-tests/dataflow/models/models.ext.yml
+++ b/rust/ql/test/library-tests/dataflow/models/models.ext.yml
@@ -54,6 +54,8 @@ extensions:
       - ["main::external_file::generated_summary", "Argument[0]", "ReturnValue", "value", "dfc-generated"]
       - ["main::external_file::neutral_generated_summary", "Argument[0]", "ReturnValue", "value", "dfc-generated"]
       - ["main::external_file::neutral_manual_summary", "Argument[0]", "ReturnValue", "value", "manual"]
+      - ["main::external_file::MyTrait2::flow_through2", "Argument[0]", "ReturnValue", "value", "manual"]
+      - ["<_ as main::MyTrait3>::flow_through3", "Argument[0]", "ReturnValue", "value", "manual"]
   - addsTo:
       pack: codeql/rust-all
       extensible: neutralModel


### PR DESCRIPTION
Implements `getCanonicalPath` also for blanket implementations:

```rust
impl<T> Foo for T {
  // canonical path: `<_ as Foo>::bar`
  fn bar(...) { ... }
}
```