### PR TITLE
Python: bind captured type-tracking jumps from source

### DIFF
--- a/python/ql/lib/semmle/python/dataflow/new/internal/TypeTrackingImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/TypeTrackingImpl.qll
@@ -323,14 +323,10 @@ module TypeTrackingInput implements Shared::TypeTrackingInput<Location> {
     //
     // nodeFrom is `expr`
     // nodeTo is entry node for `f`
-    exists(
-      SsaImpl::ScopeEntryDefinition e, SsaImpl::SsaSourceVariable var, Cfg::DefinitionNode def
-    |
-      e.getSourceVariable() = var and
-      def.getNode() = var.getVariable().getAStore()
-    |
+    exists(SsaImpl::ScopeEntryDefinition e, SsaImpl::SsaSourceVariable var |
       nodeTo.(DataFlowPublic::ScopeEntryDefinitionNode).getDefinition() = e and
-      nodeFrom.asCfgNode() = def and
+      e.getSourceVariable() = var and
+      nodeFrom.asCfgNode().(Cfg::DefinitionNode).getNode() = var.getVariable().getAStore() and
       var.getVariable().getScope().getScope*() = nodeFrom.getScope()
     )
   }

--- a/python/ql/test/library-tests/dataflow/captured-call-targets/CallTargets.expected
+++ b/python/ql/test/library-tests/dataflow/captured-call-targets/CallTargets.expected
@@ -1,0 +1,4 @@
+| test.py:14:13:14:38 | Attribute() | test.py:3:5:3:25 | Function compile | CallTypeStaticMethod |
+| test.py:14:13:14:38 | Attribute() | test.py:9:5:9:25 | Function compile | CallTypeStaticMethod |
+| test.py:23:16:23:21 | func() | test.py:29:1:29:12 | Function first | CallTypePlainFunction |
+| test.py:23:16:23:21 | func() | test.py:34:1:34:13 | Function second | CallTypePlainFunction |

--- a/python/ql/test/library-tests/dataflow/captured-call-targets/CallTargets.ql
+++ b/python/ql/test/library-tests/dataflow/captured-call-targets/CallTargets.ql
@@ -1,0 +1,18 @@
+import python
+private import semmle.python.controlflow.internal.Cfg as Cfg
+private import semmle.python.dataflow.new.internal.DataFlowDispatch as Dispatch
+
+from Call call, Function target, Dispatch::CallType callType
+where
+  exists(Cfg::CallNode cfgCall |
+    cfgCall.getNode() = call and
+    Dispatch::resolveCall(cfgCall, target, callType)
+  ) and
+  call.getLocation().getFile().getRelativePath() = "test.py" and
+  target.getLocation().getFile().getRelativePath() = "test.py" and
+  (
+    call.getFunc().(Name).getId() = "func"
+    or
+    call.getFunc().(Attribute).getName() = "compile"
+  )
+select call, target, callType.toString()

--- a/python/ql/test/library-tests/dataflow/captured-call-targets/test.py
+++ b/python/ql/test/library-tests/dataflow/captured-call-targets/test.py
@@ -1,0 +1,39 @@
+class RegexRule:
+    @staticmethod
+    def compile(pattern):
+        return pattern
+
+
+class GlobRule:
+    @staticmethod
+    def compile(pattern):
+        return pattern
+
+
+def compile_rules(rule_type, patterns):
+    return [rule_type.compile(pattern) for pattern in patterns]
+
+
+compile_rules(RegexRule, ["x"])
+compile_rules(GlobRule, ["*"])
+
+
+def decorate(func):
+    def wrapper():
+        return func()
+
+    return wrapper
+
+
+@decorate
+def first():
+    return 1
+
+
+@decorate
+def second():
+    return 2
+
+
+first()
+second()


### PR DESCRIPTION
Depends on #21925.

## Summary

This rewrites the captured-scope type-tracking jump so the scope-entry definition binds the source variable before the source CFG node is matched. The relation is unchanged, but the evaluator no longer materializes the high-duplication store/variable cross product induced by the previous join shape.

The old constraints introduced an independent `Cfg::DefinitionNode def`, related `def` to `var.getVariable().getAStore()`, and only then constrained `nodeFrom = def`. The new form binds `e` from `nodeTo`, derives `var` from `e`, and directly applies the same `DefinitionNode.getNode() = store` constraint to `nodeFrom`. This is existential elimination with the same type and scope restrictions, not a semantic change.

## Diagnostic commit

Commit 1 is intentionally a semantic call-target invariant diagnostic, not an inline `MISSING`/`SPURIOUS` red-state. It records the valid captured-callable targets produced for decorator wrappers and captured type parameters in comprehensions, including the mechanism behind Airflow's legitimate `_RegexpIgnoreRule.compile` and `_GlobIgnoreRule.compile` targets. It passes before and after the optimization so that commit 2 must preserve the relation exactly. An annotation that failed before the fix would assert an artificial semantic delta and would not test this behavior-preserving plan optimization.

## Exact Airflow measurement

Measured with CodeQL 2.26.2 on Airflow `a9da0f7fb48dc7526b2745be3e8fe64e1c775da2`, comparing exact #21925 head `1a8e317b4a328bea1059453a2ab3ba6eada09e3f` to this branch:

- Call-target diagnostic: identical 59,732-edge sets; tuples joined 1,032,403,207 -> 66,969,953 (-93.5%); maximum duplication 1,473,981 -> 4,053; evaluator wall time 59.9s -> 6.2s.
- `py/clear-text-logging-sensitive-data`: every result tuple is preserved (130 alerts, 256,708 path edges, 102,385 path nodes, 116,976 subpaths); tuples joined 1,329,594,809 -> 242,111,554 (-81.8%); evaluator wall time 94s -> 14.4s.

No valid call target is suppressed.

## Limitations

These measurements cover one exact substantial Airflow database and two query shapes. The fix does not reduce legitimate semantic call-graph or path growth, and fleet-wide performance remains to be confirmed. No DCA was launched.

## Tests

- `captured-call-targets/CallTargets.ql`
- `typetracking/tracked.ql`
- QL formatting check for the changed library and diagnostic query
