### PR TITLE
Python: cache exposed shared SSA adjacency relations

### DIFF
--- a/python/ql/lib/semmle/python/dataflow/new/internal/SsaImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/SsaImpl.qll
@@ -564,8 +564,10 @@ class EssaVariable extends Ssa::SsaDefinition {
  * library. Provides the same interface as legacy
  * `semmle.python.essa.SsaCompute::AdjacentUses`.
  */
+cached
 module AdjacentUses {
   /** Holds if `nodeFrom` and `nodeTo` are adjacent uses of the same SSA variable. */
+  cached
   predicate adjacentUseUse(Cfg::NameNode nodeFrom, Cfg::NameNode nodeTo) {
     exists(CfgImpl::BasicBlock bb1, int i1, CfgImpl::BasicBlock bb2, int i2 |
       Impl::adjacentUseUse(bb1, i1, bb2, i2, _, _) and
@@ -575,6 +577,7 @@ module AdjacentUses {
   }
 
   /** Holds if `use` is a first use of definition `def`. */
+  cached
   predicate firstUse(Ssa::SsaDefinition def, Cfg::NameNode use) {
     exists(CfgImpl::BasicBlock bb, int i |
       Impl::firstUse(def, bb, i, _) and
@@ -586,6 +589,7 @@ module AdjacentUses {
    * Holds if `use` is any reachable use of definition `def`. Combines
    * `firstUse` with transitive use-use adjacency.
    */
+  cached
   predicate useOfDef(Ssa::SsaDefinition def, Cfg::NameNode use) {
     firstUse(def, use)
     or

--- a/python/ql/test/library-tests/dataflow-new-ssa/AdjacentUsesContract.expected
+++ b/python/ql/test/library-tests/dataflow-new-ssa/AdjacentUsesContract.expected
@@ -1,0 +1,12 @@
+exposed_first_use_count
+| 9 |
+exposed_adjacent_use_count
+| 1 |
+exposed_use_of_def_count
+| 10 |
+first_use_projection_mismatch_count
+| 0 |
+adjacent_use_projection_mismatch_count
+| 0 |
+use_of_def_expansion_mismatch_count
+| 0 |

--- a/python/ql/test/library-tests/dataflow-new-ssa/AdjacentUsesContract.ql
+++ b/python/ql/test/library-tests/dataflow-new-ssa/AdjacentUsesContract.ql
@@ -1,0 +1,72 @@
+import python
+private import semmle.python.controlflow.internal.AstNodeImpl as CfgImpl
+private import semmle.python.controlflow.internal.Cfg as Cfg
+private import semmle.python.dataflow.new.internal.SsaImpl as SsaImpl
+
+private predicate projectedFirstUse(SsaImpl::Definition def, Cfg::NameNode use) {
+  exists(CfgImpl::BasicBlock bb, int i |
+    SsaImpl::Impl::firstUse(def, bb, i, _) and
+    use = bb.getNode(i)
+  )
+}
+
+private predicate projectedAdjacentUse(Cfg::NameNode nodeFrom, Cfg::NameNode nodeTo) {
+  exists(CfgImpl::BasicBlock bb1, int i1, CfgImpl::BasicBlock bb2, int i2 |
+    SsaImpl::Impl::adjacentUseUse(bb1, i1, bb2, i2, _, _) and
+    nodeFrom = bb1.getNode(i1) and
+    nodeTo = bb2.getNode(i2)
+  )
+}
+
+private predicate expandedUseOfDef(SsaImpl::Definition def, Cfg::NameNode use) {
+  exists(Cfg::NameNode first |
+    SsaImpl::AdjacentUses::firstUse(def, first) and
+    SsaImpl::AdjacentUses::adjacentUseUse*(first, use)
+  )
+}
+
+query int exposed_first_use_count() {
+  result =
+    count(SsaImpl::Definition def, Cfg::NameNode use | SsaImpl::AdjacentUses::firstUse(def, use))
+}
+
+query int exposed_adjacent_use_count() {
+  result =
+    count(Cfg::NameNode nodeFrom, Cfg::NameNode nodeTo |
+      SsaImpl::AdjacentUses::adjacentUseUse(nodeFrom, nodeTo)
+    )
+}
+
+query int exposed_use_of_def_count() {
+  result =
+    count(SsaImpl::Definition def, Cfg::NameNode use | SsaImpl::AdjacentUses::useOfDef(def, use))
+}
+
+query int first_use_projection_mismatch_count() {
+  result =
+    count(SsaImpl::Definition def, Cfg::NameNode use |
+      SsaImpl::AdjacentUses::firstUse(def, use) and not projectedFirstUse(def, use)
+      or
+      projectedFirstUse(def, use) and not SsaImpl::AdjacentUses::firstUse(def, use)
+    )
+}
+
+query int adjacent_use_projection_mismatch_count() {
+  result =
+    count(Cfg::NameNode nodeFrom, Cfg::NameNode nodeTo |
+      SsaImpl::AdjacentUses::adjacentUseUse(nodeFrom, nodeTo) and
+      not projectedAdjacentUse(nodeFrom, nodeTo)
+      or
+      projectedAdjacentUse(nodeFrom, nodeTo) and
+      not SsaImpl::AdjacentUses::adjacentUseUse(nodeFrom, nodeTo)
+    )
+}
+
+query int use_of_def_expansion_mismatch_count() {
+  result =
+    count(SsaImpl::Definition def, Cfg::NameNode use |
+      SsaImpl::AdjacentUses::useOfDef(def, use) and not expandedUseOfDef(def, use)
+      or
+      expandedUseOfDef(def, use) and not SsaImpl::AdjacentUses::useOfDef(def, use)
+    )
+}

--- a/python/ql/test/library-tests/dataflow-new-ssa/test.py
+++ b/python/ql/test/library-tests/dataflow-new-ssa/test.py
@@ -31,6 +31,11 @@ def basic_assign():  # $ def=basic_assign
     return y  # $ use=y
 
 
+def repeated_use(x):  # $ def=repeated_use def=x
+    first = x  # $ def=first use=x
+    return x + first  # $ use=x use=first
+
+
 def reassignment():  # $ def=reassignment
     x = 1
     x = 2  # $ def=x


### PR DESCRIPTION
## Summary

The shared SSA implementation documents that language adapters must cache predicates they expose. Python's shared-SSA adapter exposed `AdjacentUses::firstUse`, `adjacentUseUse`, and `useOfDef` without restoring that cache boundary, unlike the legacy ESSA implementation.

This two-commit dependent draft:

1. adds a passing semantic contract diagnostic for all three exposed relations, including exact projection/expansion mismatch counts;
2. adds `cached` to the Python `AdjacentUses` module and its three public predicates.

The diagnostic intentionally has no `MISSING`/`SPURIOUS` annotation and no wall-time assertion. The defect is duplicate evaluator specialization with identical semantic output, so relation equality is the stable red-state equivalent and timing would be machine-dependent.

## Why the adapter cache

On exact historical Salt, the same 6,313,793-row `liveAtExit` fixed point was evaluated twice per endpoint query. Equivalent recursive plans received distinct RA hashes because one inherited an unrelated cached-empty sentinel while the other used a literal empty base.

Caching at the Python adapter boundary restores the documented shared-SSA contract and is narrower than caching the 6.31M-row generic liveness relation for every language instantiation.

## Current-head measurement

Base: exact #21925 head `1a8e317b4a328bea1059453a2ab3ba6eada09e3f`.
Database: exact `saltstack/salt@d036b1177efeec175164571e9cc07b52cddf7844`.
Mode: three matched, prewarmed, serial `-j1` repeats.

| Endpoint query | Baseline evaluator median | Fixed evaluator median | Paired median reduction | Joined tuples | Recursive runs |
|---|---:|---:|---:|---:|---:|
| unsafe deserialization | 51.294s | 45.103s | 6.428s | 821,363,441 -> 763,107,771 | 12,955 -> 10,956 |
| modification of default value | 42.377s | 34.238s | 8.247s | 617,442,427 -> 531,778,114 | 11,692 -> 8,677 |

Every repeat retained zero endpoint rows and BQRS hash `2a514e093aae140a14f6bf77beebe1ad`. Peak dependent relation size was unchanged at 15,216,060 tuples.

Historical exact relation controls retained 483,922 definitions, 169,921 phi inputs, 390,548 first uses, 475,226 adjacent uses, and 123,231 semantic call edges, with zero left-only or right-only rows. Historical Salt recovery was 16.5% and 19.9%. Cold prewarm evaluator time was neutral (106.609s -> 106.620s), so this is a warm-query optimization rather than a claimed cold-cache speedup.

## Tests

- `codeql query format --check-only` for the changed QL files
- `python/ql/test/library-tests/dataflow-new-ssa/AdjacentUsesContract.ql`
- `python/ql/test/library-tests/dataflow-new-ssa/SsaTest.ql`

The broader requested Airflow and Python test matrix was not started after the coordinator requested the final current-head result without additional experiments; this remains a draft for that reason.

## Stack

This PR is based directly on `yoff/python-shared-cfg-dataflow-flip` (#21925 head). It neither includes nor depends on sibling drafts #22116 (legacy CFG/ESSA unpin) or #22407 (`capturedJumpStep` binding rewrite).

No DCA was launched.
