### PR TITLE
C++: Speed up `Ssa::getAnUltimateDefinition`

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/FlowSummaryImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/FlowSummaryImpl.qll
@@ -171,6 +171,23 @@ private module Input2 implements Impl::Private::InputSig2 {
     result = e.(ConversionCall).getQualifier().(LambdaExpression).getLambdaFunction()
   }
 
+  private module GetAnUltimateDefinitionInput implements Ssa::GetAnUltimateDefinitionSig {
+    predicate isRelevantUltimateDefinition(Ssa::Definition def) {
+      exists(
+        getFunctionFromExpr(def.(Ssa::DirectExplicitDefinition)
+              .getAssignedInstruction()
+              .(StoreInstruction)
+              .getSourceValue()
+              .getUnconvertedResultExpression())
+      )
+    }
+  }
+
+  private Ssa::Definition getAnUltimateDefinition(Ssa::Definition def) {
+    result =
+      Ssa::GetAnUltimateDefinition<GetAnUltimateDefinitionInput>::getAnUltimateDefinition(def)
+  }
+
   class SourceSinkReportingElement extends Element {
     SourceSinkReportingElement() { this instanceof Expr or this instanceof Parameter }
 
@@ -191,7 +208,7 @@ private module Input2 implements Impl::Private::InputSig2 {
       exists(Ssa::Definition def |
         def.getAUse().getDef().getUnconvertedResultExpression() = this and
         result =
-          getFunctionFromExpr(def.getAnUltimateDefinition()
+          getFunctionFromExpr(getAnUltimateDefinition(def)
                 .(Ssa::DirectExplicitDefinition)
                 .getAssignedInstruction()
                 .(StoreInstruction)

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/FlowSummaryImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/FlowSummaryImpl.qll
@@ -171,21 +171,26 @@ private module Input2 implements Impl::Private::InputSig2 {
     result = e.(ConversionCall).getQualifier().(LambdaExpression).getLambdaFunction()
   }
 
+  private predicate isRelevantUltimateDefinition(Ssa::DirectExplicitDefinition def, Function f) {
+    f =
+      getFunctionFromExpr(def.getAssignedInstruction()
+            .(StoreInstruction)
+            .getSourceValue()
+            .getUnconvertedResultExpression())
+  }
+
   private module GetAnUltimateDefinitionInput implements Ssa::GetAnUltimateDefinitionSig {
     predicate isRelevantUltimateDefinition(Ssa::Definition def) {
-      exists(
-        getFunctionFromExpr(def.(Ssa::DirectExplicitDefinition)
-              .getAssignedInstruction()
-              .(StoreInstruction)
-              .getSourceValue()
-              .getUnconvertedResultExpression())
-      )
+      isRelevantUltimateDefinition(def, _)
     }
   }
 
-  private Ssa::Definition getAnUltimateDefinition(Ssa::Definition def) {
-    result =
-      Ssa::GetAnUltimateDefinition<GetAnUltimateDefinitionInput>::getAnUltimateDefinition(def)
+  private predicate hasAnUltimateFunctionAccessDefinition(Ssa::Definition def, Function f) {
+    exists(Ssa::Definition ultimate |
+      ultimate =
+        Ssa::GetAnUltimateDefinition<GetAnUltimateDefinitionInput>::getAnUltimateDefinition(def) and
+      isRelevantUltimateDefinition(ultimate, f)
+    )
   }
 
   class SourceSinkReportingElement extends Element {
@@ -207,13 +212,7 @@ private module Input2 implements Impl::Private::InputSig2 {
       // The expression is an SSA read of an assignment of a callable
       exists(Ssa::Definition def |
         def.getAUse().getDef().getUnconvertedResultExpression() = this and
-        result =
-          getFunctionFromExpr(getAnUltimateDefinition(def)
-                .(Ssa::DirectExplicitDefinition)
-                .getAssignedInstruction()
-                .(StoreInstruction)
-                .getSourceValue()
-                .getUnconvertedResultExpression())
+        hasAnUltimateFunctionAccessDefinition(def, result)
       )
     }
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -1977,13 +1977,23 @@ module IteratorFlow {
     }
 
     /**
-     * Gets an ultimate definition of `def`.
-     *
-     * Note: Unlike `def.getAnUltimateDefinition()` this predicate also
-     * traverses back through iterator increment and decrement operations.
+     * Holds if `write` is an instruction that writes to address `address`
      */
-    private Ssa::Definition getAnUltimateDefinition(Ssa::Definition def) {
-      result = def.getAnUltimateDefinition()
+    private predicate isIteratorWrite(Instruction write, Operand address) {
+      exists(Ssa::DefImpl writeDef, IRBlock bb, int i |
+        writeDef.hasIndexInBlock(_, bb, i) and
+        bb.getInstruction(i) = write and
+        address = writeDef.getAddressOperand()
+      )
+    }
+
+    private module GetAnUltimateDefinitionInput implements Ssa::GetAnUltimateDefinitionSig {
+      predicate isRelevantUltimateDefinition(Ssa::Definition def) { fwd(_, def) }
+    }
+
+    private Ssa::Definition getAnUltimateDefinitionStep(Ssa::Definition def) {
+      result =
+        Ssa::GetAnUltimateDefinition<GetAnUltimateDefinitionInput>::getAnUltimateDefinition(def)
       or
       exists(IRBlock bb, int i, IteratorCrementCall crementCall, Ssa::SourceVariable sv |
         crementCall = def.getValue().asInstruction().(StoreInstruction).getSourceValue() and
@@ -1993,14 +2003,28 @@ module IteratorFlow {
       )
     }
 
-    /**
-     * Holds if `write` is an instruction that writes to address `address`
-     */
-    private predicate isIteratorWrite(Instruction write, Operand address) {
-      exists(Ssa::DefImpl writeDef, IRBlock bb, int i |
-        writeDef.hasIndexInBlock(_, bb, i) and
-        bb.getInstruction(i) = write and
-        address = writeDef.getAddressOperand()
+    private predicate isSource(GetsIteratorCall beginCall, Ssa::Definition def) {
+      exists(StoreInstruction beginStore |
+        beginStore = def.getValue().asInstruction() and
+        operandForFullyConvertedCall(beginStore.getSourceValueOperand(), beginCall)
+      )
+    }
+
+    private predicate isSink(Instruction writeToDeref, Ssa::Definition def) {
+      exists(IteratorPointerDereferenceCall starCall, Operand address, IRBlock bbStar, int iStar |
+        isIteratorWrite(writeToDeref, address) and
+        operandForFullyConvertedCall(address, starCall) and
+        bbStar.getInstruction(iStar) = starCall and
+        Ssa::ssaDefReachesRead(_, def, bbStar, iStar)
+      )
+    }
+
+    private predicate fwd(GetsIteratorCall beginCall, Ssa::Definition def) {
+      isSource(beginCall, def)
+      or
+      exists(Ssa::Definition def0 |
+        fwd(beginCall, def0) and
+        def0 = getAnUltimateDefinitionStep(def)
       )
     }
 
@@ -2016,17 +2040,9 @@ module IteratorFlow {
     private predicate isIteratorStoreInstruction(
       GetsIteratorCall beginCall, Instruction writeToDeref
     ) {
-      exists(
-        StoreInstruction beginStore, IRBlock bbStar, int iStar, Ssa::Definition def,
-        IteratorPointerDereferenceCall starCall, Ssa::Definition ultimate, Operand address
-      |
-        isIteratorWrite(writeToDeref, address) and
-        operandForFullyConvertedCall(address, starCall) and
-        bbStar.getInstruction(iStar) = starCall and
-        Ssa::ssaDefReachesRead(_, def, bbStar, iStar) and
-        ultimate = getAnUltimateDefinition*(def) and
-        beginStore = ultimate.getValue().asInstruction() and
-        operandForFullyConvertedCall(beginStore.getSourceValueOperand(), beginCall)
+      exists(Ssa::Definition def |
+        fwd(beginCall, def) and
+        isSink(writeToDeref, def)
       )
     }
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -1018,4 +1018,6 @@ module Ssa {
   class IndirectExplicitDefinition = SsaImpl::IndirectExplicitDefinition;
 
   class PhiNode = SsaImpl::PhiNode;
+
+  import SsaImpl::Public
 }

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaImpl.qll
@@ -1405,14 +1405,80 @@ private class PhiCycle extends PhiCycleEquivalence::EquivalenceClass {
   }
 }
 
-/** An static single assignment (SSA) definition. */
-class Definition extends SsaImpl::Definition {
-  private Definition getAPhiInputOrPriorDefinition() {
-    result = this.(PhiNode).getAnInput()
-    or
-    uncertainWriteDefinitionInput(this, result)
+private Definition getAPhiInputOrPriorDefinition(Definition def) {
+  result = def.(PhiNode).getAnInput()
+  or
+  uncertainWriteDefinitionInput(def, result)
+}
+
+module Public {
+  /**
+   * A module signature to define relevant ultimate definitions for an
+   * optimized version of `Definition.getAnUltimateDefinition`.
+   */
+  signature module GetAnUltimateDefinitionSig {
+    /**
+     * Holds if `def` is a relevant definition. This defines the set
+     * of `Definition`s which may be returned by
+     * `GetAnUltimateDefinition::getAnUltimateDefinition`.
+     */
+    predicate isRelevantUltimateDefinition(Definition def);
   }
 
+  /**
+   * A module which constructs an optimized version of
+   * ```
+   * Definition.getAnUltimateDefinition
+   * ```
+   * by restricting the set of possible ultimate definitions.
+   *
+   * Use this module by defining a module `M` which implements
+   * `GetAnUltimateDefinitionSig` and then call:
+   * ```
+   * GetAnUltimateDefinition<M>::getAnUltimateDefinition
+   * ```
+   */
+  module GetAnUltimateDefinition<GetAnUltimateDefinitionSig Sig> {
+    private import Sig
+
+    private predicate relevantUltimateDefinition(Definition def) {
+      isRelevantUltimateDefinition(def) and
+      not def instanceof PhiNode
+    }
+
+    private predicate fwd(Definition def) {
+      relevantUltimateDefinition(def)
+      or
+      exists(Definition def0 |
+        fwd(def0) and
+        def0 = getAPhiInputOrPriorDefinition(def)
+      )
+    }
+
+    private predicate step(Definition def1, Definition def2) {
+      fwd(def1) and
+      fwd(def2) and
+      def1 = getAPhiInputOrPriorDefinition(def2)
+    }
+
+    /**
+     * Gets a definition that ultimately defines this SSA definition and is
+     * not itself a phi node.
+     *
+     * This predicate is restricted to ultimate definitions which
+     * satisfy `isRelevantUltimateDefinition`.
+     */
+    Definition getAnUltimateDefinition(Definition def) {
+      step*(result, def) and
+      relevantUltimateDefinition(result)
+    }
+  }
+}
+
+import Public
+
+/** An static single assignment (SSA) definition. */
+class Definition extends SsaImpl::Definition {
   /**
    * Holds if this SSA definition is live at the end of basic block `bb`.
    * That is, this definition reaches the end of basic block `bb`, at which
@@ -1424,9 +1490,13 @@ class Definition extends SsaImpl::Definition {
   /**
    * Gets a definition that ultimately defines this SSA definition and is
    * not itself a phi node.
+   *
+   * Note: A more efficient implementation of this predicate exists. See the
+   * `GetAnUltimateDefinition` module for a description of how to access
+   * the more efficient implementation.
    */
   final Definition getAnUltimateDefinition() {
-    result = this.getAPhiInputOrPriorDefinition*() and
+    result = getAPhiInputOrPriorDefinition*(this) and
     not result instanceof PhiNode
   }
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaImpl.qll
@@ -1446,15 +1446,31 @@ module Public {
       not def instanceof PhiNode
     }
 
+    /**
+     * The `getAnUltimateDefinition` predicate uses an optimized step relation
+     * which is pruned to only those uncertain steps which lead back to a
+     * definition which satisfies `relevantUltimateDefinition`. This predicate
+     * computes the subset of `Definition`s which can lead back to definitions
+     * which satisfy `relevantUltimateDefinition`.
+     */
     private predicate fwd(Definition def) {
+      // Base case: This definition is a relevant definition
       relevantUltimateDefinition(def)
       or
       exists(Definition def0 |
+        // Recursive case: `def0` is a relevant definition, and
+        // `def` is an uncertain step which takes us back to `def0`.
         fwd(def0) and
         def0 = getAPhiInputOrPriorDefinition(def)
       )
     }
 
+    /**
+     * Holds if `def1 = getAPhiInputOrPriorDefinition(def2)`, and
+     * both `def1` and `def2` are part of a sequence of uncertain
+     * steps which lead back to a `Definition` which
+     * satisfies `relevantUltimateDefinition`.
+     */
     private predicate step(Definition def1, Definition def2) {
       fwd(def1) and
       fwd(def2) and

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaImpl.qll
@@ -1477,7 +1477,7 @@ module Public {
 
 import Public
 
-/** An static single assignment (SSA) definition. */
+/** A static single assignment (SSA) definition. */
 class Definition extends SsaImpl::Definition {
   /**
    * Holds if this SSA definition is live at the end of basic block `bb`.


### PR DESCRIPTION
For a long time we've had an implementation of `Ssa::getAnUltimateDefinition` which is pretty much just a total copy/paste from the other languages, and the only use we've have for it has been when implementing iterator flow in SSA.

However, in https://github.com/github/codeql/pull/22374/changes/150d0a78ca7e802f7f5826d500b58d72c2f607bf we started using it in `FlowSummaryImpl.qll` as well. And it turns out this predicate now performs poorly on a single DCA project (I guess maybe the predicate was magic'd prior to this change? I didn't actually check).

I don't expect that there's anything wrong with the predicate, and it's probably more likely that this project just has some crazy pattern somewhere.

With that said, it's quite simple to speed up the uses we have by doing an initial pruning phase.

1. `FlowSummaryImpl.qll` is the simplest case since we have some ready bounds for one of th end-points (i.e., the ultimate definition).
2. The iterator flow one is slightly more complicated since the "step" we're taking a transitive closure over consists of (among other things) a call to `getAnUltimateDefinition`. So for each iteration we have to provide a bound for the end-point, and that bound depends on the pruning we've done so far. This all leads to some fun recursion 🙈. I think it's all working well, though!

Before:
```ql
[2026-08-25 14:32:13] Evaluated non-recursive predicate SsaImpl::Definition.getAnUltimateDefinition/0#dispred#64b05bcd@4257f8rj in 36749ms (size: 947368939).
Evaluated relational algebra for predicate SsaImpl::Definition.getAnUltimateDefinition/0#dispred#64b05bcd@4257f8rj with tuple counts:
           429707   ~1%    {2} r1 = SCAN SsaImpl::SsaImpl::Definition#7e130722 OUTPUT In.0, In.0
                       
        947393511   ~1%    {2} r2 = `#SsaImpl::Definition.getAPhiInputOrPriorDefinition/0#dispred#e5e7cf53Plus#swapped` UNION r1
                           {2}    | AND NOT SsaImpl::SsaImpl::TPhiNode#58476d59_2#antijoin_rhs(FIRST 1)
        947369105   ~2%    {2}    | SCAN OUTPUT In.1, In.0
                           return r2

[2026-08-25 14:32:18] Evaluated non-recursive predicate FlowSummaryImpl::Input2::SourceSinkReportingElement.getCallable/0#dispred#14338d9c@166b76aa in 37ms (size: 8221).
Evaluated relational algebra for predicate FlowSummaryImpl::Input2::SourceSinkReportingElement.getCallable/0#dispred#14338d9c@166b76aa with tuple counts:
          7204   ~0%    {2} r1 = JOIN FlowSummaryImpl::Input2::SourceSinkReportingElement#5f9b62cc WITH `FlowSummaryImpl::Input2::getFunctionFromType/1#69f77c8e` ON FIRST 1 OUTPUT Lhs.0, Rhs.1
                    
          1016   ~0%    {2} r2 = JOIN FlowSummaryImpl::Input2::SourceSinkReportingElement#5f9b62cc WITH `FlowSummaryImpl::Input2::getFunctionFromExpr/1#f5cd0a4f` ON FIRST 1 OUTPUT Lhs.0, Rhs.1
                    
        441675   ~5%    {2} r3 = JOIN `Instruction::Instruction.getUnconvertedResultExpression/0#dispred#d46d1df3_10#join_rhs` WITH FlowSummaryImpl::Input2::SourceSinkReportingElement#5f9b62cc ON FIRST 1 OUTPUT Lhs.1, Lhs.0
        511564   ~0%    {2}    | JOIN WITH `Operand::Operand.getDef/0#dispred#a70e8079_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1
        139726   ~4%    {2}    | JOIN WITH `SsaImpl::Definition.getAUse/0#dispred#97e30a5e_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1
        152420   ~2%    {2}    | JOIN WITH `SsaImpl::Definition.getAnUltimateDefinition/0#dispred#64b05bcd` ON FIRST 1 OUTPUT Rhs.1, Lhs.1
        146731   ~4%    {2}    | JOIN WITH project#SsaImpl::DirectExplicitDefinition#6c37db61 ON FIRST 1 OUTPUT Lhs.0, Lhs.1
        106091   ~0%    {2}    | JOIN WITH `SsaImpl::ExplicitDefinition.getAssignedInstruction/0#dispred#2b7f8f44` ON FIRST 1 OUTPUT Rhs.1, Lhs.1
         43326   ~0%    {2}    | JOIN WITH Instruction::StoreInstruction#ae96f30c ON FIRST 1 OUTPUT Lhs.0, Lhs.1
         43326   ~0%    {2}    | JOIN WITH `Instruction::CopyInstruction.getSourceValue/0#dispred#991471be` ON FIRST 1 OUTPUT Rhs.1, Lhs.1
         33256   ~7%    {2}    | JOIN WITH `Instruction::Instruction.getUnconvertedResultExpression/0#dispred#d46d1df3` ON FIRST 1 OUTPUT Rhs.1, Lhs.1
             1   ~0%    {2}    | JOIN WITH `FlowSummaryImpl::Input2::getFunctionFromExpr/1#f5cd0a4f` ON FIRST 1 OUTPUT Lhs.1, Rhs.1
                    
          8221   ~1%    {2} r4 = r1 UNION r2 UNION r3
                        return r4
```

After:
```ql
Pipeline base for SsaImpl::GetAnUltimateDefinition<FlowSummaryImpl::Input2::GetAnUltimateDefinitionInput>::fwd/1#194007e7@f4033wso was evaluated in 1 iterations totaling 0ms (delta sizes total: 45).
                return `project#FlowSummaryImpl::Input2::isRelevantUltimateDefinition/2#056df527`

Pipeline standard for SsaImpl::GetAnUltimateDefinition<FlowSummaryImpl::Input2::GetAnUltimateDefinitionInput>::fwd/1#194007e7@f4033wso was evaluated in 1 iterations totaling 0ms (delta sizes total: 1).
        12  ~0%    {1} r1 = JOIN `SsaImpl::GetAnUltimateDefinition<FlowSummaryImpl::Input2::GetAnUltimateDefinitionInput>::fwd/1#194007e7#prev_delta` WITH `SsaImpl::getAPhiInputOrPriorDefinition/1#b4a967ca_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1
         1  ~0%    {1}    | AND NOT `SsaImpl::GetAnUltimateDefinition<FlowSummaryImpl::Input2::GetAnUltimateDefinitionInput>::fwd/1#194007e7#prev`(FIRST 1)
                   return r1

[2026-08-25 14:34:44] Evaluated non-recursive predicate SsaImpl::GetAnUltimateDefinition<FlowSummaryImpl::Input2::GetAnUltimateDefinitionInput>::step/2#882d6515@28fe1bti in 0ms (size: 12).
Evaluated relational algebra for predicate SsaImpl::GetAnUltimateDefinition<FlowSummaryImpl::Input2::GetAnUltimateDefinitionInput>::step/2#882d6515@28fe1bti with tuple counts:
        13  ~0%    {2} r1 = JOIN `SsaImpl::GetAnUltimateDefinition<FlowSummaryImpl::Input2::GetAnUltimateDefinitionInput>::fwd/1#194007e7` WITH `SsaImpl::getAPhiInputOrPriorDefinition/1#b4a967ca` ON FIRST 1 OUTPUT Rhs.1, Lhs.0
        12  ~0%    {2}    | JOIN WITH `SsaImpl::GetAnUltimateDefinition<FlowSummaryImpl::Input2::GetAnUltimateDefinitionInput>::fwd/1#194007e7` ON FIRST 1 OUTPUT Lhs.0, Lhs.1
                   return r1

[2026-08-25 14:34:44] Evaluated non-recursive predicate boundedFastTC:SsaImpl::GetAnUltimateDefinition<FlowSummaryImpl::Input2::GetAnUltimateDefinitionInput>::step/2#882d6515:project#FlowSummaryImpl::Input2::isRelevantUltimateDefinition/2#056df527@c1ac78fm in 0ms (size: 67).
[2026-08-25 14:34:44] Evaluated non-recursive predicate SsaImpl::GetAnUltimateDefinition<FlowSummaryImpl::Input2::GetAnUltimateDefinitionInput>::getAnUltimateDefinition/1#c3385f4f@174c4fok in 0ms (size: 112).
Evaluated relational algebra for predicate SsaImpl::GetAnUltimateDefinition<FlowSummaryImpl::Input2::GetAnUltimateDefinitionInput>::getAnUltimateDefinition/1#c3385f4f@174c4fok with tuple counts:
         45   ~0%    {2} r1 = SCAN `project#FlowSummaryImpl::Input2::isRelevantUltimateDefinition/2#056df527` OUTPUT In.0, In.0
                 
         67   ~1%    {2} r2 = JOIN `boundedFastTC:SsaImpl::GetAnUltimateDefinition<FlowSummaryImpl::Input2::GetAnUltimateDefinitionInput>::step/2#882d6515:project#FlowSummaryImpl::Input2::isRelevantUltimateDefinition/2#056df527` WITH `project#FlowSummaryImpl::Input2::isRelevantUltimateDefinition/2#056df527` ON FIRST 1 OUTPUT Lhs.1, Lhs.0
                 
        112   ~3%    {2} r3 = r1 UNION r2
                     return r3


[2026-08-25 14:34:44] Evaluated non-recursive predicate FlowSummaryImpl::Input2::SourceSinkReportingElement.getCallable/0#dispred#14338d9c@2bd0296f in 12ms (size: 8221).
Evaluated relational algebra for predicate FlowSummaryImpl::Input2::SourceSinkReportingElement.getCallable/0#dispred#14338d9c@2bd0296f with tuple counts:
          7204   ~0%    {2} r1 = JOIN FlowSummaryImpl::Input2::SourceSinkReportingElement#5f9b62cc WITH `FlowSummaryImpl::Input2::getFunctionFromType/1#69f77c8e` ON FIRST 1 OUTPUT Lhs.0, Rhs.1
                    
          1016   ~0%    {2} r2 = JOIN FlowSummaryImpl::Input2::SourceSinkReportingElement#5f9b62cc WITH `FlowSummaryImpl::Input2::getFunctionFromExpr/1#f5cd0a4f` ON FIRST 1 OUTPUT Lhs.0, Rhs.1
                    
        441675   ~0%    {2} r3 = JOIN `Instruction::Instruction.getUnconvertedResultExpression/0#dispred#d46d1df3_10#join_rhs` WITH FlowSummaryImpl::Input2::SourceSinkReportingElement#5f9b62cc ON FIRST 1 OUTPUT Lhs.1, Lhs.0
        511564   ~6%    {2}    | JOIN WITH `Operand::Operand.getDef/0#dispred#a70e8079_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1
        139726   ~5%    {2}    | JOIN WITH `SsaImpl::Definition.getAUse/0#dispred#97e30a5e_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1
             1   ~0%    {2}    | JOIN WITH `SsaImpl::GetAnUltimateDefinition<FlowSummaryImpl::Input2::GetAnUltimateDefinitionInput>::getAnUltimateDefinition/1#c3385f4f` ON FIRST 1 OUTPUT Rhs.1, Lhs.1
             1   ~0%    {2}    | JOIN WITH `FlowSummaryImpl::Input2::isRelevantUltimateDefinition/2#056df527` ON FIRST 1 OUTPUT Lhs.1, Rhs.1
                    
          8221   ~1%    {2} r4 = r1 UNION r2 UNION r3
                        return r4
```