### PR TITLE
Docs: add linux-arm64 to supported platforms

### DIFF
--- a/docs/codeql/reusables/supported-platforms.rst
+++ b/docs/codeql/reusables/supported-platforms.rst
@@ -19,4 +19,4 @@
 .. container:: footnote-group
 
     .. [1] Support for Linux on arm64 is currently in beta.
-    .. [2] On Apple Silicon, building your code during analysis requires Rosetta 2; analyzing an interpreted language or using build mode ``none`` runs natively.
+    .. [2] Support for Apple Silicon is currently in beta. Building your code during analysis requires Rosetta 2; analyzing an interpreted language or using build mode ``none`` runs natively.

--- a/docs/codeql/reusables/supported-platforms.rst
+++ b/docs/codeql/reusables/supported-platforms.rst
@@ -20,4 +20,4 @@
 
     .. [1] Support for Linux on arm64 is currently in beta.
 
-    .. [2] Support for Apple Silicon is currently in beta.
+    .. [2] On Apple Silicon, building your code during analysis requires Rosetta 2; analyzing an interpreted language or using build mode ``none`` runs natively.

--- a/docs/codeql/reusables/supported-platforms.rst
+++ b/docs/codeql/reusables/supported-platforms.rst
@@ -19,5 +19,4 @@
 .. container:: footnote-group
 
     .. [1] Support for Linux on arm64 is currently in beta.
-
     .. [2] On Apple Silicon, building your code during analysis requires Rosetta 2; analyzing an interpreted language or using build mode ``none`` runs natively.

--- a/docs/codeql/reusables/supported-platforms.rst
+++ b/docs/codeql/reusables/supported-platforms.rst
@@ -6,7 +6,7 @@
    Operating system,Supported versions,Supported CPU architectures
    Linux,"Ubuntu 22.04
 
-   Ubuntu 24.04","x86-64"
+   Ubuntu 24.04","x86-64, arm64 [1]_"
    Windows,"Windows 10 / Windows Server 2019
 
    Windows 11 / Windows Server 2022/2025","x86-64"
@@ -14,8 +14,10 @@
 
    macOS 15 Sequoia
 
-   macOS 26 Tahoe","x86-64, arm64 (Apple Silicon) [1]_"
+   macOS 26 Tahoe","x86-64, arm64 (Apple Silicon) [2]_"
 
 .. container:: footnote-group
 
-    .. [1] Support for Apple Silicon is currently in beta.
+    .. [1] Support for Linux on arm64 is currently in beta.
+
+    .. [2] Support for Apple Silicon is currently in beta.


### PR DESCRIPTION
## Why

Linux on arm64 is becoming a supported CodeQL platform, so the customer-facing supported-platforms matrix (published to codeql.github.com) needs to list it. While here, the existing Apple Silicon footnote is clarified with practical guidance.

## What changed

Single file: `docs/codeql/reusables/supported-platforms.rst` (a reusable `.. include::`-d by `system-requirements.rst`).

- **Linux row:** add `arm64` alongside `x86-64`, marked beta via a new `[1]` footnote. Footnotes are numbered by their order of appearance in the table (Linux `[1]`, macOS `[2]`).
- **Apple Silicon footnote (`[2]`):** keep the "currently in beta" marker and add practical guidance on when Rosetta 2 is needed. Building your code during analysis requires Rosetta 2; analyzing an interpreted language or using build mode `none` runs natively.

## Release timing

These docs publish with the next CodeQL release, which lines up with the public Linux arm64 rollout, so there is no risk of documenting the platform ahead of availability.

## Open decision

The Linux arm64 entry is drafted as **beta**. Flipping it to GA is a one-line change: drop the `[1]` footnote reference from the Linux cell and remove the `[1]` definition.

## Validation

The csv-table parses cleanly under `docutils --strict`; both footnote references resolve. Docs-only change, no build/test impact.
