### PR TITLE
Rust: Source/sink/barrier MaD trait models apply to implementations

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/FlowSummaryImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/FlowSummaryImpl.qll
@@ -17,10 +17,6 @@ module Input implements InputSig<Location, DataFlowImplSpecific::CppDataFlow> {
 
   class SummarizedCallableBase = Function;
 
-  class SourceBase = Function;
-
-  class SinkBase = Function;
-
   class FlowSummaryCallBase = CallInstruction;
 
   predicate callableFromSource(SummarizedCallableBase c) { exists(c.getBlock()) }
@@ -232,7 +228,7 @@ private module Input2 implements Impl::Private::InputSig2 {
 
   bindingset[source, sc]
   SourceSinkReportingElement getASourceReportingElement(
-    Input::SourceBase source, Impl::Private::SummaryComponent sc
+    Input::SummarizedCallableBase source, Impl::Private::SummaryComponent sc
   ) {
     exists(Call call | call.getTarget() = source |
       sc = Impl::Private::SummaryComponent::return(_) and
@@ -312,7 +308,7 @@ private module Input2 implements Impl::Private::InputSig2 {
 
   bindingset[sink, sc]
   SourceSinkReportingElement getASinkReportingElement(
-    Input::SinkBase sink, Impl::Private::SummaryComponent sc
+    Input::SummarizedCallableBase sink, Impl::Private::SummaryComponent sc
   ) {
     exists(Call call, ArgumentPosition pos |
       call.getTarget() = sink and
@@ -525,9 +521,10 @@ private class SourceModelFunction extends Public::SourceElement instanceof Funct
   }
 
   override predicate isSource(
-    string output, string kind, Public::Provenance provenance, string model
+    string output, string kind, Public::Provenance provenance, boolean isExact, string model
   ) {
-    sourceModel(namespace, type, subtypes, name, signature, ext, output, kind, provenance, model)
+    sourceModel(namespace, type, subtypes, name, signature, ext, output, kind, provenance, model) and
+    isExact = true
   }
 }
 
@@ -544,7 +541,10 @@ private class SinkModelFunction extends Public::SinkElement instanceof Function 
     this = interpretElement(namespace, type, subtypes, name, signature, ext)
   }
 
-  override predicate isSink(string input, string kind, Public::Provenance provenance, string model) {
-    sinkModel(namespace, type, subtypes, name, signature, ext, input, kind, provenance, model)
+  override predicate isSink(
+    string input, string kind, Public::Provenance provenance, boolean isExact, string model
+  ) {
+    sinkModel(namespace, type, subtypes, name, signature, ext, input, kind, provenance, model) and
+    isExact = true
   }
 }

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImpl.qll
@@ -30,13 +30,9 @@ module Input implements InputSig<Location, DataFlowImplSpecific::CsharpDataFlow>
     )
   }
 
-  class SourceBase extends Void {
+  class FlowSummaryCallBase extends Void {
     Location getLocation() { none() }
   }
-
-  class SinkBase = SourceBase;
-
-  class FlowSummaryCallBase = SourceBase;
 
   DataFlowCallable getSummarizedCallableAsDataFlowCallable(SummarizedCallableBase c) {
     result.asSummarizedCallable() = c

--- a/go/ql/lib/semmle/go/dataflow/internal/FlowSummaryImpl.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/FlowSummaryImpl.qll
@@ -27,13 +27,9 @@ module Input implements InputSig<Location, DataFlowImplSpecific::GoDataFlow> {
 
   class SummarizedCallableBase = Callable;
 
-  class SourceBase extends Void {
+  class FlowSummaryCallBase extends Void {
     Location getLocation() { none() }
   }
-
-  class SinkBase = SourceBase;
-
-  class FlowSummaryCallBase = SourceBase;
 
   predicate callableFromSource(SummarizedCallableBase c) { exists(c.getFuncDef()) }
 

--- a/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImpl.qll
@@ -37,13 +37,9 @@ module Input implements InputSig<Location, DataFlowImplSpecific::JavaDataFlow> {
     sc.asCallable() = any(Callable c | c.fromSource() and not c.isStub())
   }
 
-  class SourceBase extends Void {
+  class FlowSummaryCallBase extends Void {
     Location getLocation() { none() }
   }
-
-  class SinkBase = SourceBase;
-
-  class FlowSummaryCallBase = SourceBase;
 
   DataFlowCallable getSummarizedCallableAsDataFlowCallable(SummarizedCallableBase c) {
     result.asSummarizedCallable() = c

--- a/javascript/ql/lib/semmle/javascript/dataflow/internal/FlowSummaryPrivate.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/internal/FlowSummaryPrivate.qll
@@ -24,13 +24,9 @@ class SummarizedCallableBase extends string {
   Location getLocation() { none() }
 }
 
-class SourceBase extends Void {
+class FlowSummaryCallBase extends Void {
   Location getLocation() { none() }
 }
-
-class SinkBase = SourceBase;
-
-class FlowSummaryCallBase = SourceBase;
 
 DataFlowCallable getSummarizedCallableAsDataFlowCallable(SummarizedCallableBase c) {
   result.asLibraryCallable() = c

--- a/python/ql/lib/semmle/python/dataflow/new/internal/FlowSummaryImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/FlowSummaryImpl.qll
@@ -21,13 +21,9 @@ module Input implements InputSig<Location, DataFlowImplSpecific::PythonDataFlow>
     Location getLocation() { none() }
   }
 
-  class SourceBase extends Void {
+  class FlowSummaryCallBase extends Void {
     Location getLocation() { none() }
   }
-
-  class SinkBase = SourceBase;
-
-  class FlowSummaryCallBase = SourceBase;
 
   predicate callableFromSource(SummarizedCallableBase c) { none() }
 

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImpl.qll
@@ -20,13 +20,9 @@ module Input implements InputSig<Location, DataFlowImplSpecific::RubyDataFlow> {
     Location getLocation() { result instanceof EmptyLocation }
   }
 
-  class SourceBase extends Void {
+  class FlowSummaryCallBase extends Void {
     Location getLocation() { none() }
   }
-
-  class SinkBase = SourceBase;
-
-  class FlowSummaryCallBase = SourceBase;
 
   predicate callableFromSource(SummarizedCallableBase c) { none() }
 

--- a/rust/ql/lib/codeql/rust/dataflow/FlowBarrier.qll
+++ b/rust/ql/lib/codeql/rust/dataflow/FlowBarrier.qll
@@ -44,9 +44,9 @@ module FlowBarrier {
     Range() { any() }
 
     override predicate isBarrier(
-      string output, string kind, Impl::Public::Provenance provenance, string model
+      string output, string kind, Impl::Public::Provenance provenance, boolean isExact, string model
     ) {
-      this.isBarrier(output, kind) and provenance = "manual" and model = ""
+      this.isBarrier(output, kind) and provenance = "manual" and isExact = true and model = ""
     }
 
     /**
@@ -67,9 +67,13 @@ module FlowBarrierGuard {
     Range() { any() }
 
     override predicate isBarrierGuard(
-      string input, string branch, string kind, Impl::Public::Provenance provenance, string model
+      string input, string branch, string kind, Impl::Public::Provenance provenance,
+      boolean isExact, string model
     ) {
-      this.isBarrierGuard(input, branch, kind) and provenance = "manual" and model = ""
+      this.isBarrierGuard(input, branch, kind) and
+      provenance = "manual" and
+      isExact = true and
+      model = ""
     }
 
     /**

--- a/rust/ql/lib/codeql/rust/dataflow/FlowSink.qll
+++ b/rust/ql/lib/codeql/rust/dataflow/FlowSink.qll
@@ -36,9 +36,9 @@ module FlowSink {
     Range() { any() }
 
     override predicate isSink(
-      string input, string kind, Impl::Public::Provenance provenance, string model
+      string input, string kind, Impl::Public::Provenance provenance, boolean isExact, string model
     ) {
-      this.isSink(input, kind) and provenance = "manual" and model = ""
+      this.isSink(input, kind) and provenance = "manual" and isExact = true and model = ""
     }
 
     /**

--- a/rust/ql/lib/codeql/rust/dataflow/FlowSource.qll
+++ b/rust/ql/lib/codeql/rust/dataflow/FlowSource.qll
@@ -42,9 +42,9 @@ module FlowSource {
     Range() { any() }
 
     override predicate isSource(
-      string output, string kind, Impl::Public::Provenance provenance, string model
+      string output, string kind, Impl::Public::Provenance provenance, boolean isExact, string model
     ) {
-      this.isSource(output, kind) and provenance = "manual" and model = ""
+      this.isSource(output, kind) and provenance = "manual" and isExact = true and model = ""
     }
 
     /**

--- a/rust/ql/lib/codeql/rust/dataflow/internal/FlowSummaryImpl.qll
+++ b/rust/ql/lib/codeql/rust/dataflow/internal/FlowSummaryImpl.qll
@@ -43,17 +43,12 @@ module Input implements InputSig<Location, RustDataFlow> {
     result.asSummarizedCallable() = c
   }
 
-  class SourceBase = Function;
-
-  class SinkBase = Function;
-
   predicate neutralElement(
     Input::SummarizedCallableBase c, string kind, string provenance, boolean isExact
   ) {
-    exists(string path |
-      neutralModel(path, kind, provenance, _) and
-      c.getCanonicalPath() = path and
-      isExact = true
+    exists(string path, Provenance orig |
+      neutralModel(path, kind, orig, _) and
+      interpretPath(path, c, orig, provenance, isExact)
     )
   }
 
@@ -170,7 +165,7 @@ module Input2 implements Impl::Private::InputSig2 {
   }
 
   SourceSinkReportingElement getASourceReportingElement(
-    Input::SourceBase source, Impl::Private::SummaryComponent sc
+    Input::SummarizedCallableBase source, Impl::Private::SummaryComponent sc
   ) {
     exists(Call call | call.getResolvedTarget() = source |
       sc = Impl::Private::SummaryComponent::return(_) and
@@ -200,7 +195,7 @@ module Input2 implements Impl::Private::InputSig2 {
   }
 
   SourceSinkReportingElement getASinkReportingElement(
-    Input::SinkBase sink, Impl::Private::SummaryComponent sc
+    Input::SummarizedCallableBase sink, Impl::Private::SummaryComponent sc
   ) {
     exists(Call call |
       call.getResolvedTarget() = sink and

--- a/rust/ql/lib/codeql/rust/dataflow/internal/ModelsAsData.qll
+++ b/rust/ql/lib/codeql/rust/dataflow/internal/ModelsAsData.qll
@@ -174,6 +174,26 @@ predicate interpretModelForTest(QlBuiltins::ExtensionId madId, string model) {
   )
 }
 
+bindingset[path]
+pragma[inline_late]
+private Function interpretPath0(string path) { path = result.getCanonicalPath() }
+
+bindingset[path, orig]
+pragma[inline_late]
+predicate interpretPath(string path, Function f, Provenance orig, Provenance p, boolean isExact) {
+  exists(Function f0 | f0 = interpretPath0(path) |
+    f = f0 and
+    isExact = true and
+    p = orig
+    or
+    f.implements(f0) and
+    isExact = false and
+    // making inherited models generated means that source code definitions and
+    // exact generated models take precedence
+    p = "hq-generated"
+  )
+}
+
 private class SummarizedCallableFromModel extends SummarizedCallable::Range {
   string input_;
   string output_;
@@ -183,19 +203,9 @@ private class SummarizedCallableFromModel extends SummarizedCallable::Range {
   QlBuiltins::ExtensionId madId;
 
   SummarizedCallableFromModel() {
-    exists(string path, Function f, Provenance p |
+    exists(string path, Provenance p |
       summaryModel(path, input_, output_, kind, p, madId) and
-      f.getCanonicalPath() = path
-    |
-      this = f and
-      isExact_ = true and
-      p_ = p
-      or
-      this.implements(f) and
-      isExact_ = false and
-      // making inherited models generated means that source code definitions and
-      // exact generated models take precedence
-      p_ = "hq-generated"
+      interpretPath(path, this, p, p_, isExact_)
     )
   }
 
@@ -246,78 +256,97 @@ private class SummarizedCallableWithCallback extends SummarizedCallable::Range {
 
 private class FlowSourceFromModel extends FlowSource::Range {
   private string path;
+  private string kind_;
+  private Provenance orig;
+  private Provenance p_;
+  private boolean isExact_;
 
   FlowSourceFromModel() {
-    sourceModel(path, _, _, _, _) and
-    this.getCanonicalPath() = path
+    sourceModel(path, _, kind_, orig, _) and
+    interpretPath(path, this, orig, p_, isExact_)
   }
 
-  override predicate isSource(string output, string kind, Provenance provenance, string model) {
+  override predicate isSource(
+    string output, string kind, Provenance provenance, boolean isExact, string model
+  ) {
     exists(QlBuiltins::ExtensionId madId |
-      sourceModel(path, output, kind, provenance, madId) and
-      model = "MaD:" + madId.toString()
-    ) and
-    // Only apply generated models when no neutral model exists
-    // (the shared code only applies neutral models to summaries at present)
-    not (
-      provenance.isGenerated() and
-      neutralModel(path, "source", _, _)
+      sourceModel(path, output, kind, orig, madId) and
+      model = "MaD:" + madId.toString() and
+      kind = kind_ and
+      provenance = p_ and
+      isExact = isExact_
     )
   }
 }
 
 private class FlowSinkFromModel extends FlowSink::Range {
   private string path;
+  private string kind_;
+  private Provenance orig;
+  private Provenance p_;
+  private boolean isExact_;
 
   FlowSinkFromModel() {
-    sinkModel(path, _, _, _, _) and
-    this.getCanonicalPath() = path
+    sinkModel(path, _, kind_, orig, _) and
+    interpretPath(path, this, orig, p_, isExact_)
   }
 
-  override predicate isSink(string input, string kind, Provenance provenance, string model) {
+  override predicate isSink(
+    string input, string kind, Provenance provenance, boolean isExact, string model
+  ) {
     exists(QlBuiltins::ExtensionId madId |
-      sinkModel(path, input, kind, provenance, madId) and
-      model = "MaD:" + madId.toString()
-    ) and
-    // Only apply generated models when no neutral model exists
-    // (the shared code only applies neutral models to summaries at present)
-    not (
-      provenance.isGenerated() and
-      neutralModel(path, "sink", _, _)
+      sinkModel(path, input, kind, orig, madId) and
+      model = "MaD:" + madId.toString() and
+      kind = kind_ and
+      provenance = p_ and
+      isExact = isExact_
     )
   }
 }
 
 private class FlowBarrierFromModel extends FlowBarrier::Range {
   private string path;
+  private Provenance orig;
+  private Provenance p_;
+  private boolean isExact_;
 
   FlowBarrierFromModel() {
-    barrierModel(path, _, _, _, _) and
-    this.getCanonicalPath() = path
+    barrierModel(path, _, _, orig, _) and
+    interpretPath(path, this, orig, p_, isExact_)
   }
 
-  override predicate isBarrier(string output, string kind, Provenance provenance, string model) {
+  override predicate isBarrier(
+    string output, string kind, Provenance provenance, boolean isExact, string model
+  ) {
     exists(QlBuiltins::ExtensionId madId |
-      barrierModel(path, output, kind, provenance, madId) and
-      model = "MaD:" + madId.toString()
+      barrierModel(path, output, kind, orig, madId) and
+      model = "MaD:" + madId.toString() and
+      provenance = p_ and
+      isExact = isExact_
     )
   }
 }
 
 private class FlowBarrierGuardFromModel extends FlowBarrierGuard::Range {
   private string path;
+  private Provenance orig;
+  private Provenance p_;
+  private boolean isExact_;
 
   FlowBarrierGuardFromModel() {
-    barrierGuardModel(path, _, _, _, _, _) and
-    this.getCanonicalPath() = path
+    barrierGuardModel(path, _, _, _, orig, _) and
+    interpretPath(path, this, orig, p_, isExact_)
   }
 
   override predicate isBarrierGuard(
-    string input, string acceptingValue, string kind, Provenance provenance, string model
+    string input, string acceptingValue, string kind, Provenance provenance, boolean isExact,
+    string model
   ) {
     exists(QlBuiltins::ExtensionId madId |
-      barrierGuardModel(path, input, acceptingValue, kind, provenance, madId) and
-      model = "MaD:" + madId.toString()
+      barrierGuardModel(path, input, acceptingValue, kind, orig, madId) and
+      model = "MaD:" + madId.toString() and
+      provenance = p_ and
+      isExact = isExact_
     )
   }
 }

--- a/rust/ql/lib/codeql/rust/internal/PathResolution.qll
+++ b/rust/ql/lib/codeql/rust/internal/PathResolution.qll
@@ -2409,4 +2409,10 @@ private module Debug {
     result = i.getCanonicalPath(c) and
     i = getRelevantLocatable()
   }
+
+  predicate debugCallTargetCanonicalPath(Call call, Function f, string path) {
+    call = getRelevantLocatable() and
+    f = call.getStaticTarget() and
+    path = f.getCanonicalPath()
+  }
 }

--- a/rust/ql/test/library-tests/dataflow/barrier/external_file.rs
+++ b/rust/ql/test/library-tests/dataflow/barrier/external_file.rs
@@ -1,0 +1,8 @@
+pub trait MyBarrierTrait2 {
+    fn sanitize2(s: &str);
+}
+
+impl<T> MyBarrierTrait2 for T {
+    // inherits model from the trait function
+    fn sanitize2(s: &str) {}
+}

--- a/rust/ql/test/library-tests/dataflow/barrier/inline-flow.expected
+++ b/rust/ql/test/library-tests/dataflow/barrier/inline-flow.expected
@@ -4,6 +4,8 @@ edges
 | main.rs:21:13:21:21 | source(...) | main.rs:21:9:21:9 | s | provenance |  |
 | main.rs:32:9:32:9 | s | main.rs:33:10:33:10 | s | provenance |  |
 | main.rs:32:13:32:21 | source(...) | main.rs:32:9:32:9 | s | provenance |  |
+| main.rs:63:9:63:9 | s | main.rs:65:10:65:10 | s | provenance |  |
+| main.rs:63:13:63:21 | source(...) | main.rs:63:9:63:9 | s | provenance |  |
 nodes
 | main.rs:17:10:17:18 | source(...) | semmle.label | source(...) |
 | main.rs:21:9:21:9 | s | semmle.label | s |
@@ -12,9 +14,13 @@ nodes
 | main.rs:32:9:32:9 | s | semmle.label | s |
 | main.rs:32:13:32:21 | source(...) | semmle.label | source(...) |
 | main.rs:33:10:33:10 | s | semmle.label | s |
+| main.rs:63:9:63:9 | s | semmle.label | s |
+| main.rs:63:13:63:21 | source(...) | semmle.label | source(...) |
+| main.rs:65:10:65:10 | s | semmle.label | s |
 subpaths
 testFailures
 #select
 | main.rs:17:10:17:18 | source(...) | main.rs:17:10:17:18 | source(...) | main.rs:17:10:17:18 | source(...) | $@ | main.rs:17:10:17:18 | source(...) | source(...) |
 | main.rs:22:10:22:10 | s | main.rs:21:13:21:21 | source(...) | main.rs:22:10:22:10 | s | $@ | main.rs:21:13:21:21 | source(...) | source(...) |
 | main.rs:33:10:33:10 | s | main.rs:32:13:32:21 | source(...) | main.rs:33:10:33:10 | s | $@ | main.rs:32:13:32:21 | source(...) | source(...) |
+| main.rs:65:10:65:10 | s | main.rs:63:13:63:21 | source(...) | main.rs:65:10:65:10 | s | $@ | main.rs:63:13:63:21 | source(...) | source(...) |

--- a/rust/ql/test/library-tests/dataflow/barrier/inline-flow.expected
+++ b/rust/ql/test/library-tests/dataflow/barrier/inline-flow.expected
@@ -4,8 +4,6 @@ edges
 | main.rs:21:13:21:21 | source(...) | main.rs:21:9:21:9 | s | provenance |  |
 | main.rs:32:9:32:9 | s | main.rs:33:10:33:10 | s | provenance |  |
 | main.rs:32:13:32:21 | source(...) | main.rs:32:9:32:9 | s | provenance |  |
-| main.rs:63:9:63:9 | s | main.rs:65:10:65:10 | s | provenance |  |
-| main.rs:63:13:63:21 | source(...) | main.rs:63:9:63:9 | s | provenance |  |
 nodes
 | main.rs:17:10:17:18 | source(...) | semmle.label | source(...) |
 | main.rs:21:9:21:9 | s | semmle.label | s |
@@ -14,13 +12,9 @@ nodes
 | main.rs:32:9:32:9 | s | semmle.label | s |
 | main.rs:32:13:32:21 | source(...) | semmle.label | source(...) |
 | main.rs:33:10:33:10 | s | semmle.label | s |
-| main.rs:63:9:63:9 | s | semmle.label | s |
-| main.rs:63:13:63:21 | source(...) | semmle.label | source(...) |
-| main.rs:65:10:65:10 | s | semmle.label | s |
 subpaths
 testFailures
 #select
 | main.rs:17:10:17:18 | source(...) | main.rs:17:10:17:18 | source(...) | main.rs:17:10:17:18 | source(...) | $@ | main.rs:17:10:17:18 | source(...) | source(...) |
 | main.rs:22:10:22:10 | s | main.rs:21:13:21:21 | source(...) | main.rs:22:10:22:10 | s | $@ | main.rs:21:13:21:21 | source(...) | source(...) |
 | main.rs:33:10:33:10 | s | main.rs:32:13:32:21 | source(...) | main.rs:33:10:33:10 | s | $@ | main.rs:32:13:32:21 | source(...) | source(...) |
-| main.rs:65:10:65:10 | s | main.rs:63:13:63:21 | source(...) | main.rs:65:10:65:10 | s | $@ | main.rs:63:13:63:21 | source(...) | source(...) |

--- a/rust/ql/test/library-tests/dataflow/barrier/inline-flow.ext.yml
+++ b/rust/ql/test/library-tests/dataflow/barrier/inline-flow.ext.yml
@@ -4,8 +4,16 @@ extensions:
       extensible: barrierModel
     data:
       - ["main::sanitize", "ReturnValue", "test-barrier", "manual"]
+      - ["<main::external_file::MyBarrierTrait2>::sanitize2", "Argument[0]", "test-barrier", "manual"]
+      - ["<_ as main::MyBarrierTrait3>::sanitize3", "Argument[0]", "test-barrier", "manual"]
   - addsTo:
       pack: codeql/rust-all
       extensible: barrierGuardModel
     data:
       - ["main::verify_safe", "Argument[0]", "true", "test-barrier", "manual"]
+  - addsTo:
+      pack: codeql/rust-all
+      extensible: additionalExternalFile
+    data:
+      - ["external_file.rs"]
+

--- a/rust/ql/test/library-tests/dataflow/barrier/main.rs
+++ b/rust/ql/test/library-tests/dataflow/barrier/main.rs
@@ -46,3 +46,25 @@ fn with_barrier_guard() {
         sink(s);
     }
 }
+
+mod external_file;
+use external_file::*;
+
+trait MyBarrierTrait3 {
+    fn sanitize3(s: &str);
+}
+
+impl<T> MyBarrierTrait3 for T {
+    // has an explicit model
+    fn sanitize3(s: &str) {}
+}
+
+fn with_trait_barriers() {
+    let s = source(2);
+    <()>::sanitize2(s);
+    sink(s); // $ SPURIOUS: hasValueFlow=2
+
+    let s = source(3);
+    <()>::sanitize3(s);
+    sink(s);
+}

--- a/rust/ql/test/library-tests/dataflow/barrier/main.rs
+++ b/rust/ql/test/library-tests/dataflow/barrier/main.rs
@@ -62,7 +62,7 @@ impl<T> MyBarrierTrait3 for T {
 fn with_trait_barriers() {
     let s = source(2);
     <()>::sanitize2(s);
-    sink(s); // $ SPURIOUS: hasValueFlow=2
+    sink(s);
 
     let s = source(3);
     <()>::sanitize3(s);

--- a/rust/ql/test/library-tests/dataflow/models/external_file.rs
+++ b/rust/ql/test/library-tests/dataflow/models/external_file.rs
@@ -38,3 +38,23 @@ impl<T> MyTrait2 for T {
         0
     }
 }
+
+pub trait MySourceTrait2 {
+    fn produce2(i: i64) -> i64;
+}
+
+impl<T> MySourceTrait2 for T {
+    // inherits model from the trait function
+    fn produce2(i: i64) -> i64 {
+        0
+    }
+}
+
+pub trait MySinkTrait2 {
+    fn consume2(i: i64);
+}
+
+impl<T> MySinkTrait2 for T {
+    // inherits model from the trait function
+    fn consume2(i: i64) {}
+}

--- a/rust/ql/test/library-tests/dataflow/models/main.rs
+++ b/rust/ql/test/library-tests/dataflow/models/main.rs
@@ -527,12 +527,12 @@ fn test_trait_model<T: Ord>(x: T) {
     sink(x9); // $ hasValueFlow=30
 
     let x10 = <()>::produce2(31);
-    sink(x10); // $ MISSING: hasValueFlow=31
+    sink(x10); // $ hasValueFlow=31
 
     let x11 = <()>::produce3(32);
     sink(x11); // $ hasValueFlow=32
 
-    <()>::consume2(source(33)); // $ MISSING: hasValueFlow=33
+    <()>::consume2(source(33)); // $ hasValueFlow=33
 
     <()>::consume3(source(34)); // $ hasValueFlow=34
 }

--- a/rust/ql/test/library-tests/dataflow/models/main.rs
+++ b/rust/ql/test/library-tests/dataflow/models/main.rs
@@ -471,6 +471,26 @@ impl<T> MyTrait3 for T {
     }
 }
 
+trait MySourceTrait3 {
+    fn produce3(i: i64) -> i64;
+}
+
+impl<T> MySourceTrait3 for T {
+    // has an explicit model
+    fn produce3(i: i64) -> i64 {
+        0
+    }
+}
+
+trait MySinkTrait3 {
+    fn consume3(i: i64);
+}
+
+impl<T> MySinkTrait3 for T {
+    // has an explicit model
+    fn consume3(i: i64) {}
+}
+
 fn test_trait_model<T: Ord>(x: T) {
     let x1 = source(20).max(0);
     sink(x1); // $ hasValueFlow=20
@@ -505,6 +525,16 @@ fn test_trait_model<T: Ord>(x: T) {
 
     let x9 = <()>::flow_through3(source(30));
     sink(x9); // $ hasValueFlow=30
+
+    let x10 = <()>::produce2(31);
+    sink(x10); // $ MISSING: hasValueFlow=31
+
+    let x11 = <()>::produce3(32);
+    sink(x11); // $ hasValueFlow=32
+
+    <()>::consume2(source(33)); // $ MISSING: hasValueFlow=33
+
+    <()>::consume3(source(34)); // $ hasValueFlow=34
 }
 
 mod external_file;

--- a/rust/ql/test/library-tests/dataflow/models/models.expected
+++ b/rust/ql/test/library-tests/dataflow/models/models.expected
@@ -1,46 +1,48 @@
 models
 | 1 | Sink: <_ as main::MySinkTrait3>::consume3; Argument[0]; test-sink |
 | 2 | Sink: <main::MyFieldEnum>::sink; Argument[self].Field[main::MyFieldEnum::D::field_d]; test-sink |
-| 3 | Sink: main::enum_sink; Argument[0].Field[main::MyFieldEnum::C::field_c]; test-sink |
-| 4 | Sink: main::enum_sink_nested; Argument[0].Field[main::MyFieldEnum::E::field_e].Field[core::option::Option::Some(0)]; test-sink |
-| 5 | Sink: main::external_file::generated_sink; Argument[0]; test-sink |
-| 6 | Sink: main::external_file::neutral_manual_sink; Argument[0]; test-sink |
-| 7 | Sink: main::simple_sink; Argument[0]; test-sink |
-| 8 | Sink: main::sink_out_of_function::pass_sink; Argument[0].ReturnValue; test-sink |
-| 9 | Sink: main::sink_out_of_function::pass_sink_nested; Argument[0].ReturnValue.Field[main::MyFieldEnum::E::field_e].Field[core::option::Option::Some(0)]; test-sink |
-| 10 | Source: <_ as main::MySourceTrait3>::produce3; ReturnValue; test-source |
-| 11 | Source: <main::MyFieldEnum>::source; ReturnValue.Field[main::MyFieldEnum::C::field_c]; test-source |
-| 12 | Source: <main::MyTrait>::test_param_source; Parameter[0]; test-source |
-| 13 | Source: main::arg_source; Argument[0]; test-source |
-| 14 | Source: main::enum_source; ReturnValue.Field[main::MyFieldEnum::D::field_d]; test-source |
-| 15 | Source: main::enum_source_nested; ReturnValue.Field[main::MyFieldEnum::E::field_e].Field[core::option::Option::Some(0)]; test-source |
-| 16 | Source: main::external_file::generated_source; ReturnValue; test-source |
-| 17 | Source: main::external_file::neutral_manual_source; ReturnValue; test-source |
-| 18 | Source: main::simple_source; ReturnValue; test-source |
-| 19 | Source: main::source_into_function::pass_source; Argument[1].Parameter[0]; test-source |
-| 20 | Source: main::source_into_function::pass_source_nested; Argument[1].Parameter[0].Field[main::MyFieldEnum::E::field_e].Field[core::option::Option::Some(0)]; test-source |
-| 21 | Summary: <_ as main::MyTrait3>::flow_through3; Argument[0]; ReturnValue; value |
-| 22 | Summary: <core::cmp::Ord>::max; Argument[self,0]; ReturnValue; value |
-| 23 | Summary: <core::cmp::PartialOrd>::lt; Argument[self].Reference; ReturnValue; taint |
-| 24 | Summary: <core::ops::index::Index>::index; Argument[self].Reference.Element; ReturnValue.Reference; value |
-| 25 | Summary: <main::external_file::MyTrait2>::flow_through2; Argument[0]; ReturnValue; value |
-| 26 | Summary: main::apply; Argument[0]; Argument[1].Parameter[0]; value |
-| 27 | Summary: main::apply; Argument[1].ReturnValue; ReturnValue; value |
-| 28 | Summary: main::coerce; Argument[0]; ReturnValue; taint |
-| 29 | Summary: main::external_file::generated_summary; Argument[0]; ReturnValue; value |
-| 30 | Summary: main::external_file::neutral_manual_summary; Argument[0]; ReturnValue; value |
-| 31 | Summary: main::get_array_element; Argument[0].Element; ReturnValue; value |
-| 32 | Summary: main::get_async_number; Argument[0]; ReturnValue.Future; value |
-| 33 | Summary: main::get_struct_field; Argument[0].Field[main::MyStruct::field1]; ReturnValue; value |
-| 34 | Summary: main::get_tuple_element; Argument[0].Field[0]; ReturnValue; value |
-| 35 | Summary: main::get_var_field; Argument[0].Field[main::MyFieldEnum::C::field_c]; ReturnValue; value |
-| 36 | Summary: main::get_var_pos; Argument[0].Field[main::MyPosEnum::A(0)]; ReturnValue; value |
-| 37 | Summary: main::set_array_element; Argument[0]; ReturnValue.Element; value |
-| 38 | Summary: main::set_struct_field; Argument[0]; ReturnValue.Field[main::MyStruct::field2]; value |
-| 39 | Summary: main::set_tuple_element; Argument[0]; ReturnValue.Field[1]; value |
-| 40 | Summary: main::set_var_field; Argument[0]; ReturnValue.Field[main::MyFieldEnum::D::field_d]; value |
-| 41 | Summary: main::set_var_pos; Argument[0]; ReturnValue.Field[main::MyPosEnum::B(0)]; value |
-| 42 | Summary: main::snd; Argument[1]; ReturnValue; value |
+| 3 | Sink: <main::external_file::MySinkTrait2>::consume2; Argument[0]; test-sink |
+| 4 | Sink: main::enum_sink; Argument[0].Field[main::MyFieldEnum::C::field_c]; test-sink |
+| 5 | Sink: main::enum_sink_nested; Argument[0].Field[main::MyFieldEnum::E::field_e].Field[core::option::Option::Some(0)]; test-sink |
+| 6 | Sink: main::external_file::generated_sink; Argument[0]; test-sink |
+| 7 | Sink: main::external_file::neutral_manual_sink; Argument[0]; test-sink |
+| 8 | Sink: main::simple_sink; Argument[0]; test-sink |
+| 9 | Sink: main::sink_out_of_function::pass_sink; Argument[0].ReturnValue; test-sink |
+| 10 | Sink: main::sink_out_of_function::pass_sink_nested; Argument[0].ReturnValue.Field[main::MyFieldEnum::E::field_e].Field[core::option::Option::Some(0)]; test-sink |
+| 11 | Source: <_ as main::MySourceTrait3>::produce3; ReturnValue; test-source |
+| 12 | Source: <main::MyFieldEnum>::source; ReturnValue.Field[main::MyFieldEnum::C::field_c]; test-source |
+| 13 | Source: <main::MyTrait>::test_param_source; Parameter[0]; test-source |
+| 14 | Source: <main::external_file::MySourceTrait2>::produce2; ReturnValue; test-source |
+| 15 | Source: main::arg_source; Argument[0]; test-source |
+| 16 | Source: main::enum_source; ReturnValue.Field[main::MyFieldEnum::D::field_d]; test-source |
+| 17 | Source: main::enum_source_nested; ReturnValue.Field[main::MyFieldEnum::E::field_e].Field[core::option::Option::Some(0)]; test-source |
+| 18 | Source: main::external_file::generated_source; ReturnValue; test-source |
+| 19 | Source: main::external_file::neutral_manual_source; ReturnValue; test-source |
+| 20 | Source: main::simple_source; ReturnValue; test-source |
+| 21 | Source: main::source_into_function::pass_source; Argument[1].Parameter[0]; test-source |
+| 22 | Source: main::source_into_function::pass_source_nested; Argument[1].Parameter[0].Field[main::MyFieldEnum::E::field_e].Field[core::option::Option::Some(0)]; test-source |
+| 23 | Summary: <_ as main::MyTrait3>::flow_through3; Argument[0]; ReturnValue; value |
+| 24 | Summary: <core::cmp::Ord>::max; Argument[self,0]; ReturnValue; value |
+| 25 | Summary: <core::cmp::PartialOrd>::lt; Argument[self].Reference; ReturnValue; taint |
+| 26 | Summary: <core::ops::index::Index>::index; Argument[self].Reference.Element; ReturnValue.Reference; value |
+| 27 | Summary: <main::external_file::MyTrait2>::flow_through2; Argument[0]; ReturnValue; value |
+| 28 | Summary: main::apply; Argument[0]; Argument[1].Parameter[0]; value |
+| 29 | Summary: main::apply; Argument[1].ReturnValue; ReturnValue; value |
+| 30 | Summary: main::coerce; Argument[0]; ReturnValue; taint |
+| 31 | Summary: main::external_file::generated_summary; Argument[0]; ReturnValue; value |
+| 32 | Summary: main::external_file::neutral_manual_summary; Argument[0]; ReturnValue; value |
+| 33 | Summary: main::get_array_element; Argument[0].Element; ReturnValue; value |
+| 34 | Summary: main::get_async_number; Argument[0]; ReturnValue.Future; value |
+| 35 | Summary: main::get_struct_field; Argument[0].Field[main::MyStruct::field1]; ReturnValue; value |
+| 36 | Summary: main::get_tuple_element; Argument[0].Field[0]; ReturnValue; value |
+| 37 | Summary: main::get_var_field; Argument[0].Field[main::MyFieldEnum::C::field_c]; ReturnValue; value |
+| 38 | Summary: main::get_var_pos; Argument[0].Field[main::MyPosEnum::A(0)]; ReturnValue; value |
+| 39 | Summary: main::set_array_element; Argument[0]; ReturnValue.Element; value |
+| 40 | Summary: main::set_struct_field; Argument[0]; ReturnValue.Field[main::MyStruct::field2]; value |
+| 41 | Summary: main::set_tuple_element; Argument[0]; ReturnValue.Field[1]; value |
+| 42 | Summary: main::set_var_field; Argument[0]; ReturnValue.Field[main::MyFieldEnum::D::field_d]; value |
+| 43 | Summary: main::set_var_pos; Argument[0]; ReturnValue.Field[main::MyPosEnum::B(0)]; value |
+| 44 | Summary: main::snd; Argument[1]; ReturnValue; value |
 edges
 | main.rs:15:9:15:9 | s | main.rs:16:19:16:19 | s | provenance |  |
 | main.rs:15:9:15:9 | s | main.rs:16:19:16:19 | s | provenance |  |
@@ -50,13 +52,13 @@ edges
 | main.rs:16:19:16:19 | s | main.rs:16:10:16:20 | identity(...) | provenance | QL |
 | main.rs:25:9:25:9 | s | main.rs:26:17:26:17 | s | provenance |  |
 | main.rs:25:13:25:22 | source(...) | main.rs:25:9:25:9 | s | provenance |  |
-| main.rs:26:17:26:17 | s | main.rs:26:10:26:18 | coerce(...) | provenance | MaD:28 |
+| main.rs:26:17:26:17 | s | main.rs:26:10:26:18 | coerce(...) | provenance | MaD:30 |
 | main.rs:41:9:41:10 | s1 | main.rs:42:17:42:18 | s1 | provenance |  |
 | main.rs:41:9:41:10 | s1 | main.rs:42:17:42:18 | s1 | provenance |  |
 | main.rs:41:14:41:23 | source(...) | main.rs:41:9:41:10 | s1 | provenance |  |
 | main.rs:41:14:41:23 | source(...) | main.rs:41:9:41:10 | s1 | provenance |  |
-| main.rs:42:17:42:18 | s1 | main.rs:42:10:42:19 | snd(...) | provenance | MaD:42 |
-| main.rs:42:17:42:18 | s1 | main.rs:42:10:42:19 | snd(...) | provenance | MaD:42 |
+| main.rs:42:17:42:18 | s1 | main.rs:42:10:42:19 | snd(...) | provenance | MaD:44 |
+| main.rs:42:17:42:18 | s1 | main.rs:42:10:42:19 | snd(...) | provenance | MaD:44 |
 | main.rs:54:9:54:9 | s | main.rs:55:27:55:27 | s | provenance |  |
 | main.rs:54:9:54:9 | s | main.rs:55:27:55:27 | s | provenance |  |
 | main.rs:54:13:54:21 | source(...) | main.rs:54:9:54:9 | s | provenance |  |
@@ -67,8 +69,8 @@ edges
 | main.rs:55:14:55:28 | ...::A(...) [A] | main.rs:55:9:55:10 | e1 [A] | provenance |  |
 | main.rs:55:27:55:27 | s | main.rs:55:14:55:28 | ...::A(...) [A] | provenance |  |
 | main.rs:55:27:55:27 | s | main.rs:55:14:55:28 | ...::A(...) [A] | provenance |  |
-| main.rs:56:22:56:23 | e1 [A] | main.rs:56:10:56:24 | get_var_pos(...) | provenance | MaD:36 |
-| main.rs:56:22:56:23 | e1 [A] | main.rs:56:10:56:24 | get_var_pos(...) | provenance | MaD:36 |
+| main.rs:56:22:56:23 | e1 [A] | main.rs:56:10:56:24 | get_var_pos(...) | provenance | MaD:38 |
+| main.rs:56:22:56:23 | e1 [A] | main.rs:56:10:56:24 | get_var_pos(...) | provenance | MaD:38 |
 | main.rs:67:9:67:9 | s | main.rs:68:26:68:26 | s | provenance |  |
 | main.rs:67:9:67:9 | s | main.rs:68:26:68:26 | s | provenance |  |
 | main.rs:67:13:67:21 | source(...) | main.rs:67:9:67:9 | s | provenance |  |
@@ -77,8 +79,8 @@ edges
 | main.rs:68:9:68:10 | e1 [B] | main.rs:69:11:69:12 | e1 [B] | provenance |  |
 | main.rs:68:14:68:27 | set_var_pos(...) [B] | main.rs:68:9:68:10 | e1 [B] | provenance |  |
 | main.rs:68:14:68:27 | set_var_pos(...) [B] | main.rs:68:9:68:10 | e1 [B] | provenance |  |
-| main.rs:68:26:68:26 | s | main.rs:68:14:68:27 | set_var_pos(...) [B] | provenance | MaD:41 |
-| main.rs:68:26:68:26 | s | main.rs:68:14:68:27 | set_var_pos(...) [B] | provenance | MaD:41 |
+| main.rs:68:26:68:26 | s | main.rs:68:14:68:27 | set_var_pos(...) [B] | provenance | MaD:43 |
+| main.rs:68:26:68:26 | s | main.rs:68:14:68:27 | set_var_pos(...) [B] | provenance | MaD:43 |
 | main.rs:69:11:69:12 | e1 [B] | main.rs:71:9:71:23 | ...::B(...) [B] | provenance |  |
 | main.rs:69:11:69:12 | e1 [B] | main.rs:71:9:71:23 | ...::B(...) [B] | provenance |  |
 | main.rs:71:9:71:23 | ...::B(...) [B] | main.rs:71:22:71:22 | i | provenance |  |
@@ -95,8 +97,8 @@ edges
 | main.rs:88:14:88:42 | ...::C {...} [C] | main.rs:88:9:88:10 | e1 [C] | provenance |  |
 | main.rs:88:40:88:40 | s | main.rs:88:14:88:42 | ...::C {...} [C] | provenance |  |
 | main.rs:88:40:88:40 | s | main.rs:88:14:88:42 | ...::C {...} [C] | provenance |  |
-| main.rs:89:24:89:25 | e1 [C] | main.rs:89:10:89:26 | get_var_field(...) | provenance | MaD:35 |
-| main.rs:89:24:89:25 | e1 [C] | main.rs:89:10:89:26 | get_var_field(...) | provenance | MaD:35 |
+| main.rs:89:24:89:25 | e1 [C] | main.rs:89:10:89:26 | get_var_field(...) | provenance | MaD:37 |
+| main.rs:89:24:89:25 | e1 [C] | main.rs:89:10:89:26 | get_var_field(...) | provenance | MaD:37 |
 | main.rs:100:9:100:9 | s | main.rs:101:28:101:28 | s | provenance |  |
 | main.rs:100:9:100:9 | s | main.rs:101:28:101:28 | s | provenance |  |
 | main.rs:100:13:100:21 | source(...) | main.rs:100:9:100:9 | s | provenance |  |
@@ -105,8 +107,8 @@ edges
 | main.rs:101:9:101:10 | e1 [D] | main.rs:102:11:102:12 | e1 [D] | provenance |  |
 | main.rs:101:14:101:29 | set_var_field(...) [D] | main.rs:101:9:101:10 | e1 [D] | provenance |  |
 | main.rs:101:14:101:29 | set_var_field(...) [D] | main.rs:101:9:101:10 | e1 [D] | provenance |  |
-| main.rs:101:28:101:28 | s | main.rs:101:14:101:29 | set_var_field(...) [D] | provenance | MaD:40 |
-| main.rs:101:28:101:28 | s | main.rs:101:14:101:29 | set_var_field(...) [D] | provenance | MaD:40 |
+| main.rs:101:28:101:28 | s | main.rs:101:14:101:29 | set_var_field(...) [D] | provenance | MaD:42 |
+| main.rs:101:28:101:28 | s | main.rs:101:14:101:29 | set_var_field(...) [D] | provenance | MaD:42 |
 | main.rs:102:11:102:12 | e1 [D] | main.rs:104:9:104:37 | ...::D {...} [D] | provenance |  |
 | main.rs:102:11:102:12 | e1 [D] | main.rs:104:9:104:37 | ...::D {...} [D] | provenance |  |
 | main.rs:104:9:104:37 | ...::D {...} [D] | main.rs:104:35:104:35 | i | provenance |  |
@@ -123,8 +125,8 @@ edges
 | main.rs:121:21:124:5 | MyStruct {...} [MyStruct.field1] | main.rs:121:9:121:17 | my_struct [MyStruct.field1] | provenance |  |
 | main.rs:122:17:122:17 | s | main.rs:121:21:124:5 | MyStruct {...} [MyStruct.field1] | provenance |  |
 | main.rs:122:17:122:17 | s | main.rs:121:21:124:5 | MyStruct {...} [MyStruct.field1] | provenance |  |
-| main.rs:125:27:125:35 | my_struct [MyStruct.field1] | main.rs:125:10:125:36 | get_struct_field(...) | provenance | MaD:33 |
-| main.rs:125:27:125:35 | my_struct [MyStruct.field1] | main.rs:125:10:125:36 | get_struct_field(...) | provenance | MaD:33 |
+| main.rs:125:27:125:35 | my_struct [MyStruct.field1] | main.rs:125:10:125:36 | get_struct_field(...) | provenance | MaD:35 |
+| main.rs:125:27:125:35 | my_struct [MyStruct.field1] | main.rs:125:10:125:36 | get_struct_field(...) | provenance | MaD:35 |
 | main.rs:142:9:142:9 | s | main.rs:143:38:143:38 | s | provenance |  |
 | main.rs:142:9:142:9 | s | main.rs:143:38:143:38 | s | provenance |  |
 | main.rs:142:13:142:21 | source(...) | main.rs:142:9:142:9 | s | provenance |  |
@@ -133,16 +135,16 @@ edges
 | main.rs:143:9:143:17 | my_struct [MyStruct.field2] | main.rs:145:10:145:18 | my_struct [MyStruct.field2] | provenance |  |
 | main.rs:143:21:143:39 | set_struct_field(...) [MyStruct.field2] | main.rs:143:9:143:17 | my_struct [MyStruct.field2] | provenance |  |
 | main.rs:143:21:143:39 | set_struct_field(...) [MyStruct.field2] | main.rs:143:9:143:17 | my_struct [MyStruct.field2] | provenance |  |
-| main.rs:143:38:143:38 | s | main.rs:143:21:143:39 | set_struct_field(...) [MyStruct.field2] | provenance | MaD:38 |
-| main.rs:143:38:143:38 | s | main.rs:143:21:143:39 | set_struct_field(...) [MyStruct.field2] | provenance | MaD:38 |
+| main.rs:143:38:143:38 | s | main.rs:143:21:143:39 | set_struct_field(...) [MyStruct.field2] | provenance | MaD:40 |
+| main.rs:143:38:143:38 | s | main.rs:143:21:143:39 | set_struct_field(...) [MyStruct.field2] | provenance | MaD:40 |
 | main.rs:145:10:145:18 | my_struct [MyStruct.field2] | main.rs:145:10:145:25 | my_struct.field2 | provenance |  |
 | main.rs:145:10:145:18 | my_struct [MyStruct.field2] | main.rs:145:10:145:25 | my_struct.field2 | provenance |  |
 | main.rs:154:9:154:9 | s | main.rs:155:29:155:29 | s | provenance |  |
 | main.rs:154:9:154:9 | s | main.rs:155:29:155:29 | s | provenance |  |
 | main.rs:154:13:154:21 | source(...) | main.rs:154:9:154:9 | s | provenance |  |
 | main.rs:154:13:154:21 | source(...) | main.rs:154:9:154:9 | s | provenance |  |
-| main.rs:155:28:155:30 | [...] [element] | main.rs:155:10:155:31 | get_array_element(...) | provenance | MaD:31 |
-| main.rs:155:28:155:30 | [...] [element] | main.rs:155:10:155:31 | get_array_element(...) | provenance | MaD:31 |
+| main.rs:155:28:155:30 | [...] [element] | main.rs:155:10:155:31 | get_array_element(...) | provenance | MaD:33 |
+| main.rs:155:28:155:30 | [...] [element] | main.rs:155:10:155:31 | get_array_element(...) | provenance | MaD:33 |
 | main.rs:155:29:155:29 | s | main.rs:155:28:155:30 | [...] [element] | provenance |  |
 | main.rs:155:29:155:29 | s | main.rs:155:28:155:30 | [...] [element] | provenance |  |
 | main.rs:164:9:164:9 | s | main.rs:165:33:165:33 | s | provenance |  |
@@ -153,10 +155,10 @@ edges
 | main.rs:165:9:165:11 | arr [element] | main.rs:166:10:166:12 | arr [element] | provenance |  |
 | main.rs:165:15:165:34 | set_array_element(...) [element] | main.rs:165:9:165:11 | arr [element] | provenance |  |
 | main.rs:165:15:165:34 | set_array_element(...) [element] | main.rs:165:9:165:11 | arr [element] | provenance |  |
-| main.rs:165:33:165:33 | s | main.rs:165:15:165:34 | set_array_element(...) [element] | provenance | MaD:37 |
-| main.rs:165:33:165:33 | s | main.rs:165:15:165:34 | set_array_element(...) [element] | provenance | MaD:37 |
-| main.rs:166:10:166:12 | arr [element] | main.rs:166:10:166:15 | arr[0] | provenance | MaD:24 |
-| main.rs:166:10:166:12 | arr [element] | main.rs:166:10:166:15 | arr[0] | provenance | MaD:24 |
+| main.rs:165:33:165:33 | s | main.rs:165:15:165:34 | set_array_element(...) [element] | provenance | MaD:39 |
+| main.rs:165:33:165:33 | s | main.rs:165:15:165:34 | set_array_element(...) [element] | provenance | MaD:39 |
+| main.rs:166:10:166:12 | arr [element] | main.rs:166:10:166:15 | arr[0] | provenance | MaD:26 |
+| main.rs:166:10:166:12 | arr [element] | main.rs:166:10:166:15 | arr[0] | provenance | MaD:26 |
 | main.rs:175:9:175:9 | s | main.rs:176:14:176:14 | s | provenance |  |
 | main.rs:175:9:175:9 | s | main.rs:176:14:176:14 | s | provenance |  |
 | main.rs:175:13:175:22 | source(...) | main.rs:175:9:175:9 | s | provenance |  |
@@ -167,8 +169,8 @@ edges
 | main.rs:176:13:176:18 | TupleExpr [tuple.0] | main.rs:176:9:176:9 | t [tuple.0] | provenance |  |
 | main.rs:176:14:176:14 | s | main.rs:176:13:176:18 | TupleExpr [tuple.0] | provenance |  |
 | main.rs:176:14:176:14 | s | main.rs:176:13:176:18 | TupleExpr [tuple.0] | provenance |  |
-| main.rs:177:28:177:28 | t [tuple.0] | main.rs:177:10:177:29 | get_tuple_element(...) | provenance | MaD:34 |
-| main.rs:177:28:177:28 | t [tuple.0] | main.rs:177:10:177:29 | get_tuple_element(...) | provenance | MaD:34 |
+| main.rs:177:28:177:28 | t [tuple.0] | main.rs:177:10:177:29 | get_tuple_element(...) | provenance | MaD:36 |
+| main.rs:177:28:177:28 | t [tuple.0] | main.rs:177:10:177:29 | get_tuple_element(...) | provenance | MaD:36 |
 | main.rs:188:9:188:9 | s | main.rs:189:31:189:31 | s | provenance |  |
 | main.rs:188:9:188:9 | s | main.rs:189:31:189:31 | s | provenance |  |
 | main.rs:188:13:188:22 | source(...) | main.rs:188:9:188:9 | s | provenance |  |
@@ -177,8 +179,8 @@ edges
 | main.rs:189:9:189:9 | t [tuple.1] | main.rs:191:10:191:10 | t [tuple.1] | provenance |  |
 | main.rs:189:13:189:32 | set_tuple_element(...) [tuple.1] | main.rs:189:9:189:9 | t [tuple.1] | provenance |  |
 | main.rs:189:13:189:32 | set_tuple_element(...) [tuple.1] | main.rs:189:9:189:9 | t [tuple.1] | provenance |  |
-| main.rs:189:31:189:31 | s | main.rs:189:13:189:32 | set_tuple_element(...) [tuple.1] | provenance | MaD:39 |
-| main.rs:189:31:189:31 | s | main.rs:189:13:189:32 | set_tuple_element(...) [tuple.1] | provenance | MaD:39 |
+| main.rs:189:31:189:31 | s | main.rs:189:13:189:32 | set_tuple_element(...) [tuple.1] | provenance | MaD:41 |
+| main.rs:189:31:189:31 | s | main.rs:189:13:189:32 | set_tuple_element(...) [tuple.1] | provenance | MaD:41 |
 | main.rs:191:10:191:10 | t [tuple.1] | main.rs:191:10:191:12 | t.1 | provenance |  |
 | main.rs:191:10:191:10 | t [tuple.1] | main.rs:191:10:191:12 | t.1 | provenance |  |
 | main.rs:203:9:203:9 | s | main.rs:208:11:208:11 | s | provenance |  |
@@ -187,8 +189,8 @@ edges
 | main.rs:203:13:203:22 | source(...) | main.rs:203:9:203:9 | s | provenance |  |
 | main.rs:204:14:204:14 | ... | main.rs:205:14:205:14 | n | provenance |  |
 | main.rs:204:14:204:14 | ... | main.rs:205:14:205:14 | n | provenance |  |
-| main.rs:208:11:208:11 | s | main.rs:204:14:204:14 | ... | provenance | MaD:26 |
-| main.rs:208:11:208:11 | s | main.rs:204:14:204:14 | ... | provenance | MaD:26 |
+| main.rs:208:11:208:11 | s | main.rs:204:14:204:14 | ... | provenance | MaD:28 |
+| main.rs:208:11:208:11 | s | main.rs:204:14:204:14 | ... | provenance | MaD:28 |
 | main.rs:212:13:212:22 | source(...) | main.rs:214:23:214:23 | f [captured s] | provenance |  |
 | main.rs:212:13:212:22 | source(...) | main.rs:214:23:214:23 | f [captured s] | provenance |  |
 | main.rs:213:40:213:40 | s | main.rs:213:17:213:42 | if ... {...} else {...} | provenance |  |
@@ -197,14 +199,14 @@ edges
 | main.rs:214:9:214:9 | t | main.rs:215:10:215:10 | t | provenance |  |
 | main.rs:214:13:214:24 | apply(...) | main.rs:214:9:214:9 | t | provenance |  |
 | main.rs:214:13:214:24 | apply(...) | main.rs:214:9:214:9 | t | provenance |  |
-| main.rs:214:23:214:23 | f [captured s] | main.rs:213:40:213:40 | s | provenance | MaD:26 |
-| main.rs:214:23:214:23 | f [captured s] | main.rs:213:40:213:40 | s | provenance | MaD:26 |
-| main.rs:214:23:214:23 | f [captured s] | main.rs:213:40:213:40 | s | provenance | MaD:27 |
-| main.rs:214:23:214:23 | f [captured s] | main.rs:213:40:213:40 | s | provenance | MaD:27 |
-| main.rs:214:23:214:23 | f [captured s] | main.rs:214:13:214:24 | apply(...) | provenance | MaD:26 |
-| main.rs:214:23:214:23 | f [captured s] | main.rs:214:13:214:24 | apply(...) | provenance | MaD:26 |
-| main.rs:214:23:214:23 | f [captured s] | main.rs:214:13:214:24 | apply(...) | provenance | MaD:27 |
-| main.rs:214:23:214:23 | f [captured s] | main.rs:214:13:214:24 | apply(...) | provenance | MaD:27 |
+| main.rs:214:23:214:23 | f [captured s] | main.rs:213:40:213:40 | s | provenance | MaD:28 |
+| main.rs:214:23:214:23 | f [captured s] | main.rs:213:40:213:40 | s | provenance | MaD:28 |
+| main.rs:214:23:214:23 | f [captured s] | main.rs:213:40:213:40 | s | provenance | MaD:29 |
+| main.rs:214:23:214:23 | f [captured s] | main.rs:213:40:213:40 | s | provenance | MaD:29 |
+| main.rs:214:23:214:23 | f [captured s] | main.rs:214:13:214:24 | apply(...) | provenance | MaD:28 |
+| main.rs:214:23:214:23 | f [captured s] | main.rs:214:13:214:24 | apply(...) | provenance | MaD:28 |
+| main.rs:214:23:214:23 | f [captured s] | main.rs:214:13:214:24 | apply(...) | provenance | MaD:29 |
+| main.rs:214:23:214:23 | f [captured s] | main.rs:214:13:214:24 | apply(...) | provenance | MaD:29 |
 | main.rs:219:9:219:9 | s | main.rs:221:19:221:19 | s | provenance |  |
 | main.rs:219:9:219:9 | s | main.rs:221:19:221:19 | s | provenance |  |
 | main.rs:219:13:219:22 | source(...) | main.rs:219:9:219:9 | s | provenance |  |
@@ -215,10 +217,10 @@ edges
 | main.rs:221:9:221:9 | t | main.rs:222:10:222:10 | t | provenance |  |
 | main.rs:221:13:221:23 | apply(...) | main.rs:221:9:221:9 | t | provenance |  |
 | main.rs:221:13:221:23 | apply(...) | main.rs:221:9:221:9 | t | provenance |  |
-| main.rs:221:19:221:19 | s | main.rs:220:14:220:14 | ... | provenance | MaD:26 |
-| main.rs:221:19:221:19 | s | main.rs:220:14:220:14 | ... | provenance | MaD:26 |
-| main.rs:221:19:221:19 | s | main.rs:221:13:221:23 | apply(...) | provenance | MaD:26 |
-| main.rs:221:19:221:19 | s | main.rs:221:13:221:23 | apply(...) | provenance | MaD:26 |
+| main.rs:221:19:221:19 | s | main.rs:220:14:220:14 | ... | provenance | MaD:28 |
+| main.rs:221:19:221:19 | s | main.rs:220:14:220:14 | ... | provenance | MaD:28 |
+| main.rs:221:19:221:19 | s | main.rs:221:13:221:23 | apply(...) | provenance | MaD:28 |
+| main.rs:221:19:221:19 | s | main.rs:221:13:221:23 | apply(...) | provenance | MaD:28 |
 | main.rs:231:9:231:9 | s | main.rs:232:30:232:30 | s | provenance |  |
 | main.rs:231:9:231:9 | s | main.rs:232:30:232:30 | s | provenance |  |
 | main.rs:231:13:231:22 | source(...) | main.rs:231:9:231:9 | s | provenance |  |
@@ -229,12 +231,12 @@ edges
 | main.rs:232:13:232:31 | get_async_number(...) [future] | main.rs:232:13:232:37 | await ... | provenance |  |
 | main.rs:232:13:232:37 | await ... | main.rs:232:9:232:9 | t | provenance |  |
 | main.rs:232:13:232:37 | await ... | main.rs:232:9:232:9 | t | provenance |  |
-| main.rs:232:30:232:30 | s | main.rs:232:13:232:31 | get_async_number(...) [future] | provenance | MaD:32 |
-| main.rs:232:30:232:30 | s | main.rs:232:13:232:31 | get_async_number(...) [future] | provenance | MaD:32 |
+| main.rs:232:30:232:30 | s | main.rs:232:13:232:31 | get_async_number(...) [future] | provenance | MaD:34 |
+| main.rs:232:30:232:30 | s | main.rs:232:13:232:31 | get_async_number(...) [future] | provenance | MaD:34 |
 | main.rs:257:9:257:9 | s [D] | main.rs:258:11:258:11 | s [D] | provenance |  |
 | main.rs:257:9:257:9 | s [D] | main.rs:258:11:258:11 | s [D] | provenance |  |
-| main.rs:257:13:257:27 | enum_source(...) | main.rs:257:9:257:9 | s [D] | provenance | Src:MaD:14  |
-| main.rs:257:13:257:27 | enum_source(...) | main.rs:257:9:257:9 | s [D] | provenance | Src:MaD:14  |
+| main.rs:257:13:257:27 | enum_source(...) | main.rs:257:9:257:9 | s [D] | provenance | Src:MaD:16  |
+| main.rs:257:13:257:27 | enum_source(...) | main.rs:257:9:257:9 | s [D] | provenance | Src:MaD:16  |
 | main.rs:258:11:258:11 | s [D] | main.rs:260:9:260:37 | ...::D {...} [D] | provenance |  |
 | main.rs:258:11:258:11 | s [D] | main.rs:260:9:260:37 | ...::D {...} [D] | provenance |  |
 | main.rs:260:9:260:37 | ...::D {...} [D] | main.rs:260:35:260:35 | i | provenance |  |
@@ -243,8 +245,8 @@ edges
 | main.rs:260:35:260:35 | i | main.rs:260:47:260:47 | i | provenance |  |
 | main.rs:264:9:264:9 | s [E, Some] | main.rs:265:11:265:11 | s [E, Some] | provenance |  |
 | main.rs:264:9:264:9 | s [E, Some] | main.rs:265:11:265:11 | s [E, Some] | provenance |  |
-| main.rs:264:13:264:34 | enum_source_nested(...) | main.rs:264:9:264:9 | s [E, Some] | provenance | Src:MaD:15  |
-| main.rs:264:13:264:34 | enum_source_nested(...) | main.rs:264:9:264:9 | s [E, Some] | provenance | Src:MaD:15  |
+| main.rs:264:13:264:34 | enum_source_nested(...) | main.rs:264:9:264:9 | s [E, Some] | provenance | Src:MaD:17  |
+| main.rs:264:13:264:34 | enum_source_nested(...) | main.rs:264:9:264:9 | s [E, Some] | provenance | Src:MaD:17  |
 | main.rs:265:11:265:11 | s [E, Some] | main.rs:268:9:268:37 | ...::E {...} [E, Some] | provenance |  |
 | main.rs:265:11:265:11 | s [E, Some] | main.rs:268:9:268:37 | ...::E {...} [E, Some] | provenance |  |
 | main.rs:268:9:268:37 | ...::E {...} [E, Some] | main.rs:268:35:268:35 | o [Some] | provenance |  |
@@ -259,24 +261,24 @@ edges
 | main.rs:270:22:270:22 | i | main.rs:270:33:270:33 | i | provenance |  |
 | main.rs:279:9:279:9 | s [C] | main.rs:280:11:280:11 | s [C] | provenance |  |
 | main.rs:279:9:279:9 | s [C] | main.rs:280:11:280:11 | s [C] | provenance |  |
-| main.rs:279:13:279:24 | e.source(...) | main.rs:279:9:279:9 | s [C] | provenance | Src:MaD:11  |
-| main.rs:279:13:279:24 | e.source(...) | main.rs:279:9:279:9 | s [C] | provenance | Src:MaD:11  |
+| main.rs:279:13:279:24 | e.source(...) | main.rs:279:9:279:9 | s [C] | provenance | Src:MaD:12  |
+| main.rs:279:13:279:24 | e.source(...) | main.rs:279:9:279:9 | s [C] | provenance | Src:MaD:12  |
 | main.rs:280:11:280:11 | s [C] | main.rs:281:9:281:37 | ...::C {...} [C] | provenance |  |
 | main.rs:280:11:280:11 | s [C] | main.rs:281:9:281:37 | ...::C {...} [C] | provenance |  |
 | main.rs:281:9:281:37 | ...::C {...} [C] | main.rs:281:35:281:35 | i | provenance |  |
 | main.rs:281:9:281:37 | ...::C {...} [C] | main.rs:281:35:281:35 | i | provenance |  |
 | main.rs:281:35:281:35 | i | main.rs:281:47:281:47 | i | provenance |  |
 | main.rs:281:35:281:35 | i | main.rs:281:47:281:47 | i | provenance |  |
-| main.rs:303:24:303:24 | a | main.rs:302:26:302:26 | a | provenance | Src:MaD:19  |
-| main.rs:303:24:303:24 | a | main.rs:302:26:302:26 | a | provenance | Src:MaD:19  |
-| main.rs:305:24:307:9 | \|...\| ... | main.rs:306:18:306:18 | a | provenance | Src:MaD:19  |
-| main.rs:305:24:307:9 | \|...\| ... | main.rs:306:18:306:18 | a | provenance | Src:MaD:19  |
-| main.rs:312:24:312:24 | f | main.rs:310:18:310:18 | a | provenance | Src:MaD:19  |
-| main.rs:312:24:312:24 | f | main.rs:310:18:310:18 | a | provenance | Src:MaD:19  |
-| main.rs:314:24:316:9 | \|...\| ... | main.rs:315:18:315:18 | a | provenance | Src:MaD:19  |
-| main.rs:314:24:316:9 | \|...\| ... | main.rs:315:18:315:18 | a | provenance | Src:MaD:19  |
-| main.rs:318:31:329:9 | \|...\| ... | main.rs:318:31:329:9 | \|...\| ... [E, Some] | provenance | Src:MaD:20  |
-| main.rs:318:31:329:9 | \|...\| ... | main.rs:318:31:329:9 | \|...\| ... [E, Some] | provenance | Src:MaD:20  |
+| main.rs:303:24:303:24 | a | main.rs:302:26:302:26 | a | provenance | Src:MaD:21  |
+| main.rs:303:24:303:24 | a | main.rs:302:26:302:26 | a | provenance | Src:MaD:21  |
+| main.rs:305:24:307:9 | \|...\| ... | main.rs:306:18:306:18 | a | provenance | Src:MaD:21  |
+| main.rs:305:24:307:9 | \|...\| ... | main.rs:306:18:306:18 | a | provenance | Src:MaD:21  |
+| main.rs:312:24:312:24 | f | main.rs:310:18:310:18 | a | provenance | Src:MaD:21  |
+| main.rs:312:24:312:24 | f | main.rs:310:18:310:18 | a | provenance | Src:MaD:21  |
+| main.rs:314:24:316:9 | \|...\| ... | main.rs:315:18:315:18 | a | provenance | Src:MaD:21  |
+| main.rs:314:24:316:9 | \|...\| ... | main.rs:315:18:315:18 | a | provenance | Src:MaD:21  |
+| main.rs:318:31:329:9 | \|...\| ... | main.rs:318:31:329:9 | \|...\| ... [E, Some] | provenance | Src:MaD:22  |
+| main.rs:318:31:329:9 | \|...\| ... | main.rs:318:31:329:9 | \|...\| ... [E, Some] | provenance | Src:MaD:22  |
 | main.rs:318:31:329:9 | \|...\| ... [E, Some] | main.rs:319:19:319:19 | e [E, Some] | provenance |  |
 | main.rs:318:31:329:9 | \|...\| ... [E, Some] | main.rs:319:19:319:19 | e [E, Some] | provenance |  |
 | main.rs:319:19:319:19 | e [E, Some] | main.rs:322:17:322:45 | ...::E {...} [E, Some] | provenance |  |
@@ -291,8 +293,8 @@ edges
 | main.rs:324:25:324:31 | Some(...) [Some] | main.rs:324:30:324:30 | i | provenance |  |
 | main.rs:324:30:324:30 | i | main.rs:324:41:324:41 | i | provenance |  |
 | main.rs:324:30:324:30 | i | main.rs:324:41:324:41 | i | provenance |  |
-| main.rs:344:21:344:29 | source(...) | main.rs:345:19:345:19 | a | provenance | Sink:MaD:8 |
-| main.rs:344:21:344:29 | source(...) | main.rs:345:19:345:19 | a | provenance | Sink:MaD:8 |
+| main.rs:344:21:344:29 | source(...) | main.rs:345:19:345:19 | a | provenance | Sink:MaD:9 |
+| main.rs:344:21:344:29 | source(...) | main.rs:345:19:345:19 | a | provenance | Sink:MaD:9 |
 | main.rs:348:17:348:17 | s | main.rs:350:39:350:39 | s | provenance |  |
 | main.rs:348:17:348:17 | s | main.rs:350:39:350:39 | s | provenance |  |
 | main.rs:348:21:348:29 | source(...) | main.rs:348:17:348:17 | s | provenance |  |
@@ -303,20 +305,20 @@ edges
 | main.rs:350:26:350:40 | ...::Some(...) [Some] | main.rs:349:13:351:13 | ...::E {...} [E, Some] | provenance |  |
 | main.rs:350:39:350:39 | s | main.rs:350:26:350:40 | ...::Some(...) [Some] | provenance |  |
 | main.rs:350:39:350:39 | s | main.rs:350:26:350:40 | ...::Some(...) [Some] | provenance |  |
-| main.rs:353:26:353:26 | b [E, Some] | main.rs:353:26:353:26 | b | provenance | Sink:MaD:9 |
-| main.rs:353:26:353:26 | b [E, Some] | main.rs:353:26:353:26 | b | provenance | Sink:MaD:9 |
+| main.rs:353:26:353:26 | b [E, Some] | main.rs:353:26:353:26 | b | provenance | Sink:MaD:10 |
+| main.rs:353:26:353:26 | b [E, Some] | main.rs:353:26:353:26 | b | provenance | Sink:MaD:10 |
 | main.rs:364:9:364:9 | s | main.rs:365:41:365:41 | s | provenance |  |
 | main.rs:364:9:364:9 | s | main.rs:365:41:365:41 | s | provenance |  |
 | main.rs:364:9:364:9 | s | main.rs:368:53:368:53 | s | provenance |  |
 | main.rs:364:9:364:9 | s | main.rs:368:53:368:53 | s | provenance |  |
 | main.rs:364:13:364:22 | source(...) | main.rs:364:9:364:9 | s | provenance |  |
 | main.rs:364:13:364:22 | source(...) | main.rs:364:9:364:9 | s | provenance |  |
-| main.rs:365:15:365:43 | ...::C {...} [C] | main.rs:365:15:365:43 | ...::C {...} | provenance | Sink:MaD:3 |
-| main.rs:365:15:365:43 | ...::C {...} [C] | main.rs:365:15:365:43 | ...::C {...} | provenance | Sink:MaD:3 |
+| main.rs:365:15:365:43 | ...::C {...} [C] | main.rs:365:15:365:43 | ...::C {...} | provenance | Sink:MaD:4 |
+| main.rs:365:15:365:43 | ...::C {...} [C] | main.rs:365:15:365:43 | ...::C {...} | provenance | Sink:MaD:4 |
 | main.rs:365:41:365:41 | s | main.rs:365:15:365:43 | ...::C {...} [C] | provenance |  |
 | main.rs:365:41:365:41 | s | main.rs:365:15:365:43 | ...::C {...} [C] | provenance |  |
-| main.rs:368:22:368:56 | ...::E {...} [E, Some] | main.rs:368:22:368:56 | ...::E {...} | provenance | Sink:MaD:4 |
-| main.rs:368:22:368:56 | ...::E {...} [E, Some] | main.rs:368:22:368:56 | ...::E {...} | provenance | Sink:MaD:4 |
+| main.rs:368:22:368:56 | ...::E {...} [E, Some] | main.rs:368:22:368:56 | ...::E {...} | provenance | Sink:MaD:5 |
+| main.rs:368:22:368:56 | ...::E {...} [E, Some] | main.rs:368:22:368:56 | ...::E {...} | provenance | Sink:MaD:5 |
 | main.rs:368:48:368:54 | Some(...) [Some] | main.rs:368:22:368:56 | ...::E {...} [E, Some] | provenance |  |
 | main.rs:368:48:368:54 | Some(...) [Some] | main.rs:368:22:368:56 | ...::E {...} [E, Some] | provenance |  |
 | main.rs:368:53:368:53 | s | main.rs:368:48:368:54 | Some(...) [Some] | provenance |  |
@@ -333,74 +335,80 @@ edges
 | main.rs:373:39:373:39 | s | main.rs:373:13:373:41 | ...::D {...} [D] | provenance |  |
 | main.rs:383:9:383:9 | s | main.rs:384:10:384:10 | s | provenance |  |
 | main.rs:383:9:383:9 | s | main.rs:384:10:384:10 | s | provenance |  |
-| main.rs:383:13:383:29 | simple_source(...) | main.rs:383:9:383:9 | s | provenance | Src:MaD:18  |
-| main.rs:383:13:383:29 | simple_source(...) | main.rs:383:9:383:9 | s | provenance | Src:MaD:18  |
-| main.rs:391:9:391:9 | s | main.rs:392:17:392:17 | s | provenance | Sink:MaD:7 |
-| main.rs:391:9:391:9 | s | main.rs:392:17:392:17 | s | provenance | Sink:MaD:7 |
+| main.rs:383:13:383:29 | simple_source(...) | main.rs:383:9:383:9 | s | provenance | Src:MaD:20  |
+| main.rs:383:13:383:29 | simple_source(...) | main.rs:383:9:383:9 | s | provenance | Src:MaD:20  |
+| main.rs:391:9:391:9 | s | main.rs:392:17:392:17 | s | provenance | Sink:MaD:8 |
+| main.rs:391:9:391:9 | s | main.rs:392:17:392:17 | s | provenance | Sink:MaD:8 |
 | main.rs:391:13:391:22 | source(...) | main.rs:391:9:391:9 | s | provenance |  |
 | main.rs:391:13:391:22 | source(...) | main.rs:391:9:391:9 | s | provenance |  |
-| main.rs:400:16:400:16 | i | main.rs:401:10:401:10 | i | provenance | Src:MaD:13  |
-| main.rs:400:16:400:16 | i | main.rs:401:10:401:10 | i | provenance | Src:MaD:13  |
-| main.rs:410:26:410:31 | ...: i64 | main.rs:411:14:411:14 | i | provenance | Src:MaD:12  |
-| main.rs:410:26:410:31 | ...: i64 | main.rs:411:14:411:14 | i | provenance | Src:MaD:12  |
+| main.rs:400:16:400:16 | i | main.rs:401:10:401:10 | i | provenance | Src:MaD:15  |
+| main.rs:400:16:400:16 | i | main.rs:401:10:401:10 | i | provenance | Src:MaD:15  |
+| main.rs:410:26:410:31 | ...: i64 | main.rs:411:14:411:14 | i | provenance | Src:MaD:13  |
+| main.rs:410:26:410:31 | ...: i64 | main.rs:411:14:411:14 | i | provenance | Src:MaD:13  |
 | main.rs:495:9:495:10 | x1 | main.rs:496:10:496:11 | x1 | provenance |  |
 | main.rs:495:9:495:10 | x1 | main.rs:496:10:496:11 | x1 | provenance |  |
-| main.rs:495:14:495:23 | source(...) | main.rs:495:14:495:30 | ... .max(...) | provenance | MaD:22 |
-| main.rs:495:14:495:23 | source(...) | main.rs:495:14:495:30 | ... .max(...) | provenance | MaD:22 |
+| main.rs:495:14:495:23 | source(...) | main.rs:495:14:495:30 | ... .max(...) | provenance | MaD:24 |
+| main.rs:495:14:495:23 | source(...) | main.rs:495:14:495:30 | ... .max(...) | provenance | MaD:24 |
 | main.rs:495:14:495:30 | ... .max(...) | main.rs:495:9:495:10 | x1 | provenance |  |
 | main.rs:495:14:495:30 | ... .max(...) | main.rs:495:9:495:10 | x1 | provenance |  |
 | main.rs:498:9:498:10 | x2 [MyStruct.field1] | main.rs:506:10:506:11 | x2 [MyStruct.field1] | provenance |  |
 | main.rs:498:9:498:10 | x2 [MyStruct.field1] | main.rs:506:10:506:11 | x2 [MyStruct.field1] | provenance |  |
 | main.rs:498:14:505:6 | ... .max(...) [MyStruct.field1] | main.rs:498:9:498:10 | x2 [MyStruct.field1] | provenance |  |
 | main.rs:498:14:505:6 | ... .max(...) [MyStruct.field1] | main.rs:498:9:498:10 | x2 [MyStruct.field1] | provenance |  |
-| main.rs:498:15:501:5 | MyStruct {...} [MyStruct.field1] | main.rs:498:14:505:6 | ... .max(...) [MyStruct.field1] | provenance | MaD:22 |
-| main.rs:498:15:501:5 | MyStruct {...} [MyStruct.field1] | main.rs:498:14:505:6 | ... .max(...) [MyStruct.field1] | provenance | MaD:22 |
+| main.rs:498:15:501:5 | MyStruct {...} [MyStruct.field1] | main.rs:498:14:505:6 | ... .max(...) [MyStruct.field1] | provenance | MaD:24 |
+| main.rs:498:15:501:5 | MyStruct {...} [MyStruct.field1] | main.rs:498:14:505:6 | ... .max(...) [MyStruct.field1] | provenance | MaD:24 |
 | main.rs:499:17:499:26 | source(...) | main.rs:498:15:501:5 | MyStruct {...} [MyStruct.field1] | provenance |  |
 | main.rs:499:17:499:26 | source(...) | main.rs:498:15:501:5 | MyStruct {...} [MyStruct.field1] | provenance |  |
 | main.rs:506:10:506:11 | x2 [MyStruct.field1] | main.rs:506:10:506:18 | x2.field1 | provenance |  |
 | main.rs:506:10:506:11 | x2 [MyStruct.field1] | main.rs:506:10:506:18 | x2.field1 | provenance |  |
 | main.rs:511:9:511:10 | x4 | main.rs:512:10:512:11 | x4 | provenance |  |
 | main.rs:511:9:511:10 | x4 | main.rs:512:10:512:11 | x4 | provenance |  |
-| main.rs:511:14:511:23 | source(...) | main.rs:511:14:511:30 | ... .max(...) | provenance | MaD:22 |
-| main.rs:511:14:511:23 | source(...) | main.rs:511:14:511:30 | ... .max(...) | provenance | MaD:22 |
+| main.rs:511:14:511:23 | source(...) | main.rs:511:14:511:30 | ... .max(...) | provenance | MaD:24 |
+| main.rs:511:14:511:23 | source(...) | main.rs:511:14:511:30 | ... .max(...) | provenance | MaD:24 |
 | main.rs:511:14:511:30 | ... .max(...) | main.rs:511:9:511:10 | x4 | provenance |  |
 | main.rs:511:14:511:30 | ... .max(...) | main.rs:511:9:511:10 | x4 | provenance |  |
 | main.rs:514:9:514:10 | x5 | main.rs:515:10:515:11 | x5 | provenance |  |
-| main.rs:514:14:514:23 | source(...) | main.rs:514:14:514:30 | ... .lt(...) | provenance | MaD:23 |
+| main.rs:514:14:514:23 | source(...) | main.rs:514:14:514:30 | ... .lt(...) | provenance | MaD:25 |
 | main.rs:514:14:514:30 | ... .lt(...) | main.rs:514:9:514:10 | x5 | provenance |  |
 | main.rs:517:9:517:10 | x6 | main.rs:518:10:518:11 | x6 | provenance |  |
-| main.rs:517:14:517:23 | source(...) | main.rs:517:14:517:27 | ... < ... | provenance | MaD:23 |
+| main.rs:517:14:517:23 | source(...) | main.rs:517:14:517:27 | ... < ... | provenance | MaD:25 |
 | main.rs:517:14:517:27 | ... < ... | main.rs:517:9:517:10 | x6 | provenance |  |
 | main.rs:523:9:523:10 | x8 | main.rs:524:10:524:11 | x8 | provenance |  |
 | main.rs:523:9:523:10 | x8 | main.rs:524:10:524:11 | x8 | provenance |  |
 | main.rs:523:14:523:44 | ...::flow_through2(...) | main.rs:523:9:523:10 | x8 | provenance |  |
 | main.rs:523:14:523:44 | ...::flow_through2(...) | main.rs:523:9:523:10 | x8 | provenance |  |
-| main.rs:523:34:523:43 | source(...) | main.rs:523:14:523:44 | ...::flow_through2(...) | provenance | MaD:25 |
-| main.rs:523:34:523:43 | source(...) | main.rs:523:14:523:44 | ...::flow_through2(...) | provenance | MaD:25 |
+| main.rs:523:34:523:43 | source(...) | main.rs:523:14:523:44 | ...::flow_through2(...) | provenance | MaD:27 |
+| main.rs:523:34:523:43 | source(...) | main.rs:523:14:523:44 | ...::flow_through2(...) | provenance | MaD:27 |
 | main.rs:526:9:526:10 | x9 | main.rs:527:10:527:11 | x9 | provenance |  |
 | main.rs:526:9:526:10 | x9 | main.rs:527:10:527:11 | x9 | provenance |  |
 | main.rs:526:14:526:44 | ...::flow_through3(...) | main.rs:526:9:526:10 | x9 | provenance |  |
 | main.rs:526:14:526:44 | ...::flow_through3(...) | main.rs:526:9:526:10 | x9 | provenance |  |
-| main.rs:526:34:526:43 | source(...) | main.rs:526:14:526:44 | ...::flow_through3(...) | provenance | MaD:21 |
-| main.rs:526:34:526:43 | source(...) | main.rs:526:14:526:44 | ...::flow_through3(...) | provenance | MaD:21 |
+| main.rs:526:34:526:43 | source(...) | main.rs:526:14:526:44 | ...::flow_through3(...) | provenance | MaD:23 |
+| main.rs:526:34:526:43 | source(...) | main.rs:526:14:526:44 | ...::flow_through3(...) | provenance | MaD:23 |
+| main.rs:529:9:529:11 | x10 | main.rs:530:10:530:12 | x10 | provenance |  |
+| main.rs:529:9:529:11 | x10 | main.rs:530:10:530:12 | x10 | provenance |  |
+| main.rs:529:15:529:32 | ...::produce2(...) | main.rs:529:9:529:11 | x10 | provenance | Src:MaD:14  |
+| main.rs:529:15:529:32 | ...::produce2(...) | main.rs:529:9:529:11 | x10 | provenance | Src:MaD:14  |
 | main.rs:532:9:532:11 | x11 | main.rs:533:10:533:12 | x11 | provenance |  |
 | main.rs:532:9:532:11 | x11 | main.rs:533:10:533:12 | x11 | provenance |  |
-| main.rs:532:15:532:32 | ...::produce3(...) | main.rs:532:9:532:11 | x11 | provenance | Src:MaD:10  |
-| main.rs:532:15:532:32 | ...::produce3(...) | main.rs:532:9:532:11 | x11 | provenance | Src:MaD:10  |
+| main.rs:532:15:532:32 | ...::produce3(...) | main.rs:532:9:532:11 | x11 | provenance | Src:MaD:11  |
+| main.rs:532:15:532:32 | ...::produce3(...) | main.rs:532:9:532:11 | x11 | provenance | Src:MaD:11  |
+| main.rs:535:20:535:29 | source(...) | main.rs:535:20:535:29 | source(...) | provenance | Sink:MaD:3 |
+| main.rs:535:20:535:29 | source(...) | main.rs:535:20:535:29 | source(...) | provenance | Sink:MaD:3 |
 | main.rs:537:20:537:29 | source(...) | main.rs:537:20:537:29 | source(...) | provenance | Sink:MaD:1 |
 | main.rs:537:20:537:29 | source(...) | main.rs:537:20:537:29 | source(...) | provenance | Sink:MaD:1 |
-| main.rs:549:10:549:28 | generated_source(...) | main.rs:549:10:549:28 | generated_source(...) | provenance | Src:MaD:16  |
-| main.rs:549:10:549:28 | generated_source(...) | main.rs:549:10:549:28 | generated_source(...) | provenance | Src:MaD:16  |
-| main.rs:551:10:551:33 | neutral_manual_source(...) | main.rs:551:10:551:33 | neutral_manual_source(...) | provenance | Src:MaD:17  |
-| main.rs:551:10:551:33 | neutral_manual_source(...) | main.rs:551:10:551:33 | neutral_manual_source(...) | provenance | Src:MaD:17  |
-| main.rs:552:20:552:28 | source(...) | main.rs:552:20:552:28 | source(...) | provenance | Sink:MaD:5 |
-| main.rs:552:20:552:28 | source(...) | main.rs:552:20:552:28 | source(...) | provenance | Sink:MaD:5 |
-| main.rs:554:25:554:33 | source(...) | main.rs:554:25:554:33 | source(...) | provenance | Sink:MaD:6 |
-| main.rs:554:25:554:33 | source(...) | main.rs:554:25:554:33 | source(...) | provenance | Sink:MaD:6 |
-| main.rs:555:28:555:36 | source(...) | main.rs:555:10:555:37 | generated_summary(...) | provenance | MaD:29 |
-| main.rs:555:28:555:36 | source(...) | main.rs:555:10:555:37 | generated_summary(...) | provenance | MaD:29 |
-| main.rs:557:33:557:41 | source(...) | main.rs:557:10:557:42 | neutral_manual_summary(...) | provenance | MaD:30 |
-| main.rs:557:33:557:41 | source(...) | main.rs:557:10:557:42 | neutral_manual_summary(...) | provenance | MaD:30 |
+| main.rs:549:10:549:28 | generated_source(...) | main.rs:549:10:549:28 | generated_source(...) | provenance | Src:MaD:18  |
+| main.rs:549:10:549:28 | generated_source(...) | main.rs:549:10:549:28 | generated_source(...) | provenance | Src:MaD:18  |
+| main.rs:551:10:551:33 | neutral_manual_source(...) | main.rs:551:10:551:33 | neutral_manual_source(...) | provenance | Src:MaD:19  |
+| main.rs:551:10:551:33 | neutral_manual_source(...) | main.rs:551:10:551:33 | neutral_manual_source(...) | provenance | Src:MaD:19  |
+| main.rs:552:20:552:28 | source(...) | main.rs:552:20:552:28 | source(...) | provenance | Sink:MaD:6 |
+| main.rs:552:20:552:28 | source(...) | main.rs:552:20:552:28 | source(...) | provenance | Sink:MaD:6 |
+| main.rs:554:25:554:33 | source(...) | main.rs:554:25:554:33 | source(...) | provenance | Sink:MaD:7 |
+| main.rs:554:25:554:33 | source(...) | main.rs:554:25:554:33 | source(...) | provenance | Sink:MaD:7 |
+| main.rs:555:28:555:36 | source(...) | main.rs:555:10:555:37 | generated_summary(...) | provenance | MaD:31 |
+| main.rs:555:28:555:36 | source(...) | main.rs:555:10:555:37 | generated_summary(...) | provenance | MaD:31 |
+| main.rs:557:33:557:41 | source(...) | main.rs:557:10:557:42 | neutral_manual_summary(...) | provenance | MaD:32 |
+| main.rs:557:33:557:41 | source(...) | main.rs:557:10:557:42 | neutral_manual_summary(...) | provenance | MaD:32 |
 nodes
 | main.rs:15:9:15:9 | s | semmle.label | s |
 | main.rs:15:9:15:9 | s | semmle.label | s |
@@ -816,12 +824,22 @@ nodes
 | main.rs:526:34:526:43 | source(...) | semmle.label | source(...) |
 | main.rs:527:10:527:11 | x9 | semmle.label | x9 |
 | main.rs:527:10:527:11 | x9 | semmle.label | x9 |
+| main.rs:529:9:529:11 | x10 | semmle.label | x10 |
+| main.rs:529:9:529:11 | x10 | semmle.label | x10 |
+| main.rs:529:15:529:32 | ...::produce2(...) | semmle.label | ...::produce2(...) |
+| main.rs:529:15:529:32 | ...::produce2(...) | semmle.label | ...::produce2(...) |
+| main.rs:530:10:530:12 | x10 | semmle.label | x10 |
+| main.rs:530:10:530:12 | x10 | semmle.label | x10 |
 | main.rs:532:9:532:11 | x11 | semmle.label | x11 |
 | main.rs:532:9:532:11 | x11 | semmle.label | x11 |
 | main.rs:532:15:532:32 | ...::produce3(...) | semmle.label | ...::produce3(...) |
 | main.rs:532:15:532:32 | ...::produce3(...) | semmle.label | ...::produce3(...) |
 | main.rs:533:10:533:12 | x11 | semmle.label | x11 |
 | main.rs:533:10:533:12 | x11 | semmle.label | x11 |
+| main.rs:535:20:535:29 | source(...) | semmle.label | source(...) |
+| main.rs:535:20:535:29 | source(...) | semmle.label | source(...) |
+| main.rs:535:20:535:29 | source(...) | semmle.label | source(...) |
+| main.rs:535:20:535:29 | source(...) | semmle.label | source(...) |
 | main.rs:537:20:537:29 | source(...) | semmle.label | source(...) |
 | main.rs:537:20:537:29 | source(...) | semmle.label | source(...) |
 | main.rs:537:20:537:29 | source(...) | semmle.label | source(...) |
@@ -937,8 +955,12 @@ invalidSpecComponent
 | main.rs:524:10:524:11 | x8 | main.rs:523:34:523:43 | source(...) | main.rs:524:10:524:11 | x8 | $@ | main.rs:523:34:523:43 | source(...) | source(...) |
 | main.rs:527:10:527:11 | x9 | main.rs:526:34:526:43 | source(...) | main.rs:527:10:527:11 | x9 | $@ | main.rs:526:34:526:43 | source(...) | source(...) |
 | main.rs:527:10:527:11 | x9 | main.rs:526:34:526:43 | source(...) | main.rs:527:10:527:11 | x9 | $@ | main.rs:526:34:526:43 | source(...) | source(...) |
+| main.rs:530:10:530:12 | x10 | main.rs:529:15:529:32 | ...::produce2(...) | main.rs:530:10:530:12 | x10 | $@ | main.rs:529:15:529:32 | ...::produce2(...) | ...::produce2(...) |
+| main.rs:530:10:530:12 | x10 | main.rs:529:15:529:32 | ...::produce2(...) | main.rs:530:10:530:12 | x10 | $@ | main.rs:529:15:529:32 | ...::produce2(...) | ...::produce2(...) |
 | main.rs:533:10:533:12 | x11 | main.rs:532:15:532:32 | ...::produce3(...) | main.rs:533:10:533:12 | x11 | $@ | main.rs:532:15:532:32 | ...::produce3(...) | ...::produce3(...) |
 | main.rs:533:10:533:12 | x11 | main.rs:532:15:532:32 | ...::produce3(...) | main.rs:533:10:533:12 | x11 | $@ | main.rs:532:15:532:32 | ...::produce3(...) | ...::produce3(...) |
+| main.rs:535:20:535:29 | source(...) | main.rs:535:20:535:29 | source(...) | main.rs:535:20:535:29 | source(...) | $@ | main.rs:535:20:535:29 | source(...) | source(...) |
+| main.rs:535:20:535:29 | source(...) | main.rs:535:20:535:29 | source(...) | main.rs:535:20:535:29 | source(...) | $@ | main.rs:535:20:535:29 | source(...) | source(...) |
 | main.rs:537:20:537:29 | source(...) | main.rs:537:20:537:29 | source(...) | main.rs:537:20:537:29 | source(...) | $@ | main.rs:537:20:537:29 | source(...) | source(...) |
 | main.rs:537:20:537:29 | source(...) | main.rs:537:20:537:29 | source(...) | main.rs:537:20:537:29 | source(...) | $@ | main.rs:537:20:537:29 | source(...) | source(...) |
 | main.rs:549:10:549:28 | generated_source(...) | main.rs:549:10:549:28 | generated_source(...) | main.rs:549:10:549:28 | generated_source(...) | $@ | main.rs:549:10:549:28 | generated_source(...) | generated_source(...) |

--- a/rust/ql/test/library-tests/dataflow/models/models.expected
+++ b/rust/ql/test/library-tests/dataflow/models/models.expected
@@ -1,44 +1,46 @@
 models
-| 1 | Sink: <main::MyFieldEnum>::sink; Argument[self].Field[main::MyFieldEnum::D::field_d]; test-sink |
-| 2 | Sink: main::enum_sink; Argument[0].Field[main::MyFieldEnum::C::field_c]; test-sink |
-| 3 | Sink: main::enum_sink_nested; Argument[0].Field[main::MyFieldEnum::E::field_e].Field[core::option::Option::Some(0)]; test-sink |
-| 4 | Sink: main::external_file::generated_sink; Argument[0]; test-sink |
-| 5 | Sink: main::external_file::neutral_manual_sink; Argument[0]; test-sink |
-| 6 | Sink: main::simple_sink; Argument[0]; test-sink |
-| 7 | Sink: main::sink_out_of_function::pass_sink; Argument[0].ReturnValue; test-sink |
-| 8 | Sink: main::sink_out_of_function::pass_sink_nested; Argument[0].ReturnValue.Field[main::MyFieldEnum::E::field_e].Field[core::option::Option::Some(0)]; test-sink |
-| 9 | Source: <main::MyFieldEnum>::source; ReturnValue.Field[main::MyFieldEnum::C::field_c]; test-source |
-| 10 | Source: <main::MyTrait>::test_param_source; Parameter[0]; test-source |
-| 11 | Source: main::arg_source; Argument[0]; test-source |
-| 12 | Source: main::enum_source; ReturnValue.Field[main::MyFieldEnum::D::field_d]; test-source |
-| 13 | Source: main::enum_source_nested; ReturnValue.Field[main::MyFieldEnum::E::field_e].Field[core::option::Option::Some(0)]; test-source |
-| 14 | Source: main::external_file::generated_source; ReturnValue; test-source |
-| 15 | Source: main::external_file::neutral_manual_source; ReturnValue; test-source |
-| 16 | Source: main::simple_source; ReturnValue; test-source |
-| 17 | Source: main::source_into_function::pass_source; Argument[1].Parameter[0]; test-source |
-| 18 | Source: main::source_into_function::pass_source_nested; Argument[1].Parameter[0].Field[main::MyFieldEnum::E::field_e].Field[core::option::Option::Some(0)]; test-source |
-| 19 | Summary: <_ as main::MyTrait3>::flow_through3; Argument[0]; ReturnValue; value |
-| 20 | Summary: <core::cmp::Ord>::max; Argument[self,0]; ReturnValue; value |
-| 21 | Summary: <core::cmp::PartialOrd>::lt; Argument[self].Reference; ReturnValue; taint |
-| 22 | Summary: <core::ops::index::Index>::index; Argument[self].Reference.Element; ReturnValue.Reference; value |
-| 23 | Summary: <main::external_file::MyTrait2>::flow_through2; Argument[0]; ReturnValue; value |
-| 24 | Summary: main::apply; Argument[0]; Argument[1].Parameter[0]; value |
-| 25 | Summary: main::apply; Argument[1].ReturnValue; ReturnValue; value |
-| 26 | Summary: main::coerce; Argument[0]; ReturnValue; taint |
-| 27 | Summary: main::external_file::generated_summary; Argument[0]; ReturnValue; value |
-| 28 | Summary: main::external_file::neutral_manual_summary; Argument[0]; ReturnValue; value |
-| 29 | Summary: main::get_array_element; Argument[0].Element; ReturnValue; value |
-| 30 | Summary: main::get_async_number; Argument[0]; ReturnValue.Future; value |
-| 31 | Summary: main::get_struct_field; Argument[0].Field[main::MyStruct::field1]; ReturnValue; value |
-| 32 | Summary: main::get_tuple_element; Argument[0].Field[0]; ReturnValue; value |
-| 33 | Summary: main::get_var_field; Argument[0].Field[main::MyFieldEnum::C::field_c]; ReturnValue; value |
-| 34 | Summary: main::get_var_pos; Argument[0].Field[main::MyPosEnum::A(0)]; ReturnValue; value |
-| 35 | Summary: main::set_array_element; Argument[0]; ReturnValue.Element; value |
-| 36 | Summary: main::set_struct_field; Argument[0]; ReturnValue.Field[main::MyStruct::field2]; value |
-| 37 | Summary: main::set_tuple_element; Argument[0]; ReturnValue.Field[1]; value |
-| 38 | Summary: main::set_var_field; Argument[0]; ReturnValue.Field[main::MyFieldEnum::D::field_d]; value |
-| 39 | Summary: main::set_var_pos; Argument[0]; ReturnValue.Field[main::MyPosEnum::B(0)]; value |
-| 40 | Summary: main::snd; Argument[1]; ReturnValue; value |
+| 1 | Sink: <_ as main::MySinkTrait3>::consume3; Argument[0]; test-sink |
+| 2 | Sink: <main::MyFieldEnum>::sink; Argument[self].Field[main::MyFieldEnum::D::field_d]; test-sink |
+| 3 | Sink: main::enum_sink; Argument[0].Field[main::MyFieldEnum::C::field_c]; test-sink |
+| 4 | Sink: main::enum_sink_nested; Argument[0].Field[main::MyFieldEnum::E::field_e].Field[core::option::Option::Some(0)]; test-sink |
+| 5 | Sink: main::external_file::generated_sink; Argument[0]; test-sink |
+| 6 | Sink: main::external_file::neutral_manual_sink; Argument[0]; test-sink |
+| 7 | Sink: main::simple_sink; Argument[0]; test-sink |
+| 8 | Sink: main::sink_out_of_function::pass_sink; Argument[0].ReturnValue; test-sink |
+| 9 | Sink: main::sink_out_of_function::pass_sink_nested; Argument[0].ReturnValue.Field[main::MyFieldEnum::E::field_e].Field[core::option::Option::Some(0)]; test-sink |
+| 10 | Source: <_ as main::MySourceTrait3>::produce3; ReturnValue; test-source |
+| 11 | Source: <main::MyFieldEnum>::source; ReturnValue.Field[main::MyFieldEnum::C::field_c]; test-source |
+| 12 | Source: <main::MyTrait>::test_param_source; Parameter[0]; test-source |
+| 13 | Source: main::arg_source; Argument[0]; test-source |
+| 14 | Source: main::enum_source; ReturnValue.Field[main::MyFieldEnum::D::field_d]; test-source |
+| 15 | Source: main::enum_source_nested; ReturnValue.Field[main::MyFieldEnum::E::field_e].Field[core::option::Option::Some(0)]; test-source |
+| 16 | Source: main::external_file::generated_source; ReturnValue; test-source |
+| 17 | Source: main::external_file::neutral_manual_source; ReturnValue; test-source |
+| 18 | Source: main::simple_source; ReturnValue; test-source |
+| 19 | Source: main::source_into_function::pass_source; Argument[1].Parameter[0]; test-source |
+| 20 | Source: main::source_into_function::pass_source_nested; Argument[1].Parameter[0].Field[main::MyFieldEnum::E::field_e].Field[core::option::Option::Some(0)]; test-source |
+| 21 | Summary: <_ as main::MyTrait3>::flow_through3; Argument[0]; ReturnValue; value |
+| 22 | Summary: <core::cmp::Ord>::max; Argument[self,0]; ReturnValue; value |
+| 23 | Summary: <core::cmp::PartialOrd>::lt; Argument[self].Reference; ReturnValue; taint |
+| 24 | Summary: <core::ops::index::Index>::index; Argument[self].Reference.Element; ReturnValue.Reference; value |
+| 25 | Summary: <main::external_file::MyTrait2>::flow_through2; Argument[0]; ReturnValue; value |
+| 26 | Summary: main::apply; Argument[0]; Argument[1].Parameter[0]; value |
+| 27 | Summary: main::apply; Argument[1].ReturnValue; ReturnValue; value |
+| 28 | Summary: main::coerce; Argument[0]; ReturnValue; taint |
+| 29 | Summary: main::external_file::generated_summary; Argument[0]; ReturnValue; value |
+| 30 | Summary: main::external_file::neutral_manual_summary; Argument[0]; ReturnValue; value |
+| 31 | Summary: main::get_array_element; Argument[0].Element; ReturnValue; value |
+| 32 | Summary: main::get_async_number; Argument[0]; ReturnValue.Future; value |
+| 33 | Summary: main::get_struct_field; Argument[0].Field[main::MyStruct::field1]; ReturnValue; value |
+| 34 | Summary: main::get_tuple_element; Argument[0].Field[0]; ReturnValue; value |
+| 35 | Summary: main::get_var_field; Argument[0].Field[main::MyFieldEnum::C::field_c]; ReturnValue; value |
+| 36 | Summary: main::get_var_pos; Argument[0].Field[main::MyPosEnum::A(0)]; ReturnValue; value |
+| 37 | Summary: main::set_array_element; Argument[0]; ReturnValue.Element; value |
+| 38 | Summary: main::set_struct_field; Argument[0]; ReturnValue.Field[main::MyStruct::field2]; value |
+| 39 | Summary: main::set_tuple_element; Argument[0]; ReturnValue.Field[1]; value |
+| 40 | Summary: main::set_var_field; Argument[0]; ReturnValue.Field[main::MyFieldEnum::D::field_d]; value |
+| 41 | Summary: main::set_var_pos; Argument[0]; ReturnValue.Field[main::MyPosEnum::B(0)]; value |
+| 42 | Summary: main::snd; Argument[1]; ReturnValue; value |
 edges
 | main.rs:15:9:15:9 | s | main.rs:16:19:16:19 | s | provenance |  |
 | main.rs:15:9:15:9 | s | main.rs:16:19:16:19 | s | provenance |  |
@@ -48,13 +50,13 @@ edges
 | main.rs:16:19:16:19 | s | main.rs:16:10:16:20 | identity(...) | provenance | QL |
 | main.rs:25:9:25:9 | s | main.rs:26:17:26:17 | s | provenance |  |
 | main.rs:25:13:25:22 | source(...) | main.rs:25:9:25:9 | s | provenance |  |
-| main.rs:26:17:26:17 | s | main.rs:26:10:26:18 | coerce(...) | provenance | MaD:26 |
+| main.rs:26:17:26:17 | s | main.rs:26:10:26:18 | coerce(...) | provenance | MaD:28 |
 | main.rs:41:9:41:10 | s1 | main.rs:42:17:42:18 | s1 | provenance |  |
 | main.rs:41:9:41:10 | s1 | main.rs:42:17:42:18 | s1 | provenance |  |
 | main.rs:41:14:41:23 | source(...) | main.rs:41:9:41:10 | s1 | provenance |  |
 | main.rs:41:14:41:23 | source(...) | main.rs:41:9:41:10 | s1 | provenance |  |
-| main.rs:42:17:42:18 | s1 | main.rs:42:10:42:19 | snd(...) | provenance | MaD:40 |
-| main.rs:42:17:42:18 | s1 | main.rs:42:10:42:19 | snd(...) | provenance | MaD:40 |
+| main.rs:42:17:42:18 | s1 | main.rs:42:10:42:19 | snd(...) | provenance | MaD:42 |
+| main.rs:42:17:42:18 | s1 | main.rs:42:10:42:19 | snd(...) | provenance | MaD:42 |
 | main.rs:54:9:54:9 | s | main.rs:55:27:55:27 | s | provenance |  |
 | main.rs:54:9:54:9 | s | main.rs:55:27:55:27 | s | provenance |  |
 | main.rs:54:13:54:21 | source(...) | main.rs:54:9:54:9 | s | provenance |  |
@@ -65,8 +67,8 @@ edges
 | main.rs:55:14:55:28 | ...::A(...) [A] | main.rs:55:9:55:10 | e1 [A] | provenance |  |
 | main.rs:55:27:55:27 | s | main.rs:55:14:55:28 | ...::A(...) [A] | provenance |  |
 | main.rs:55:27:55:27 | s | main.rs:55:14:55:28 | ...::A(...) [A] | provenance |  |
-| main.rs:56:22:56:23 | e1 [A] | main.rs:56:10:56:24 | get_var_pos(...) | provenance | MaD:34 |
-| main.rs:56:22:56:23 | e1 [A] | main.rs:56:10:56:24 | get_var_pos(...) | provenance | MaD:34 |
+| main.rs:56:22:56:23 | e1 [A] | main.rs:56:10:56:24 | get_var_pos(...) | provenance | MaD:36 |
+| main.rs:56:22:56:23 | e1 [A] | main.rs:56:10:56:24 | get_var_pos(...) | provenance | MaD:36 |
 | main.rs:67:9:67:9 | s | main.rs:68:26:68:26 | s | provenance |  |
 | main.rs:67:9:67:9 | s | main.rs:68:26:68:26 | s | provenance |  |
 | main.rs:67:13:67:21 | source(...) | main.rs:67:9:67:9 | s | provenance |  |
@@ -75,8 +77,8 @@ edges
 | main.rs:68:9:68:10 | e1 [B] | main.rs:69:11:69:12 | e1 [B] | provenance |  |
 | main.rs:68:14:68:27 | set_var_pos(...) [B] | main.rs:68:9:68:10 | e1 [B] | provenance |  |
 | main.rs:68:14:68:27 | set_var_pos(...) [B] | main.rs:68:9:68:10 | e1 [B] | provenance |  |
-| main.rs:68:26:68:26 | s | main.rs:68:14:68:27 | set_var_pos(...) [B] | provenance | MaD:39 |
-| main.rs:68:26:68:26 | s | main.rs:68:14:68:27 | set_var_pos(...) [B] | provenance | MaD:39 |
+| main.rs:68:26:68:26 | s | main.rs:68:14:68:27 | set_var_pos(...) [B] | provenance | MaD:41 |
+| main.rs:68:26:68:26 | s | main.rs:68:14:68:27 | set_var_pos(...) [B] | provenance | MaD:41 |
 | main.rs:69:11:69:12 | e1 [B] | main.rs:71:9:71:23 | ...::B(...) [B] | provenance |  |
 | main.rs:69:11:69:12 | e1 [B] | main.rs:71:9:71:23 | ...::B(...) [B] | provenance |  |
 | main.rs:71:9:71:23 | ...::B(...) [B] | main.rs:71:22:71:22 | i | provenance |  |
@@ -93,8 +95,8 @@ edges
 | main.rs:88:14:88:42 | ...::C {...} [C] | main.rs:88:9:88:10 | e1 [C] | provenance |  |
 | main.rs:88:40:88:40 | s | main.rs:88:14:88:42 | ...::C {...} [C] | provenance |  |
 | main.rs:88:40:88:40 | s | main.rs:88:14:88:42 | ...::C {...} [C] | provenance |  |
-| main.rs:89:24:89:25 | e1 [C] | main.rs:89:10:89:26 | get_var_field(...) | provenance | MaD:33 |
-| main.rs:89:24:89:25 | e1 [C] | main.rs:89:10:89:26 | get_var_field(...) | provenance | MaD:33 |
+| main.rs:89:24:89:25 | e1 [C] | main.rs:89:10:89:26 | get_var_field(...) | provenance | MaD:35 |
+| main.rs:89:24:89:25 | e1 [C] | main.rs:89:10:89:26 | get_var_field(...) | provenance | MaD:35 |
 | main.rs:100:9:100:9 | s | main.rs:101:28:101:28 | s | provenance |  |
 | main.rs:100:9:100:9 | s | main.rs:101:28:101:28 | s | provenance |  |
 | main.rs:100:13:100:21 | source(...) | main.rs:100:9:100:9 | s | provenance |  |
@@ -103,8 +105,8 @@ edges
 | main.rs:101:9:101:10 | e1 [D] | main.rs:102:11:102:12 | e1 [D] | provenance |  |
 | main.rs:101:14:101:29 | set_var_field(...) [D] | main.rs:101:9:101:10 | e1 [D] | provenance |  |
 | main.rs:101:14:101:29 | set_var_field(...) [D] | main.rs:101:9:101:10 | e1 [D] | provenance |  |
-| main.rs:101:28:101:28 | s | main.rs:101:14:101:29 | set_var_field(...) [D] | provenance | MaD:38 |
-| main.rs:101:28:101:28 | s | main.rs:101:14:101:29 | set_var_field(...) [D] | provenance | MaD:38 |
+| main.rs:101:28:101:28 | s | main.rs:101:14:101:29 | set_var_field(...) [D] | provenance | MaD:40 |
+| main.rs:101:28:101:28 | s | main.rs:101:14:101:29 | set_var_field(...) [D] | provenance | MaD:40 |
 | main.rs:102:11:102:12 | e1 [D] | main.rs:104:9:104:37 | ...::D {...} [D] | provenance |  |
 | main.rs:102:11:102:12 | e1 [D] | main.rs:104:9:104:37 | ...::D {...} [D] | provenance |  |
 | main.rs:104:9:104:37 | ...::D {...} [D] | main.rs:104:35:104:35 | i | provenance |  |
@@ -121,8 +123,8 @@ edges
 | main.rs:121:21:124:5 | MyStruct {...} [MyStruct.field1] | main.rs:121:9:121:17 | my_struct [MyStruct.field1] | provenance |  |
 | main.rs:122:17:122:17 | s | main.rs:121:21:124:5 | MyStruct {...} [MyStruct.field1] | provenance |  |
 | main.rs:122:17:122:17 | s | main.rs:121:21:124:5 | MyStruct {...} [MyStruct.field1] | provenance |  |
-| main.rs:125:27:125:35 | my_struct [MyStruct.field1] | main.rs:125:10:125:36 | get_struct_field(...) | provenance | MaD:31 |
-| main.rs:125:27:125:35 | my_struct [MyStruct.field1] | main.rs:125:10:125:36 | get_struct_field(...) | provenance | MaD:31 |
+| main.rs:125:27:125:35 | my_struct [MyStruct.field1] | main.rs:125:10:125:36 | get_struct_field(...) | provenance | MaD:33 |
+| main.rs:125:27:125:35 | my_struct [MyStruct.field1] | main.rs:125:10:125:36 | get_struct_field(...) | provenance | MaD:33 |
 | main.rs:142:9:142:9 | s | main.rs:143:38:143:38 | s | provenance |  |
 | main.rs:142:9:142:9 | s | main.rs:143:38:143:38 | s | provenance |  |
 | main.rs:142:13:142:21 | source(...) | main.rs:142:9:142:9 | s | provenance |  |
@@ -131,16 +133,16 @@ edges
 | main.rs:143:9:143:17 | my_struct [MyStruct.field2] | main.rs:145:10:145:18 | my_struct [MyStruct.field2] | provenance |  |
 | main.rs:143:21:143:39 | set_struct_field(...) [MyStruct.field2] | main.rs:143:9:143:17 | my_struct [MyStruct.field2] | provenance |  |
 | main.rs:143:21:143:39 | set_struct_field(...) [MyStruct.field2] | main.rs:143:9:143:17 | my_struct [MyStruct.field2] | provenance |  |
-| main.rs:143:38:143:38 | s | main.rs:143:21:143:39 | set_struct_field(...) [MyStruct.field2] | provenance | MaD:36 |
-| main.rs:143:38:143:38 | s | main.rs:143:21:143:39 | set_struct_field(...) [MyStruct.field2] | provenance | MaD:36 |
+| main.rs:143:38:143:38 | s | main.rs:143:21:143:39 | set_struct_field(...) [MyStruct.field2] | provenance | MaD:38 |
+| main.rs:143:38:143:38 | s | main.rs:143:21:143:39 | set_struct_field(...) [MyStruct.field2] | provenance | MaD:38 |
 | main.rs:145:10:145:18 | my_struct [MyStruct.field2] | main.rs:145:10:145:25 | my_struct.field2 | provenance |  |
 | main.rs:145:10:145:18 | my_struct [MyStruct.field2] | main.rs:145:10:145:25 | my_struct.field2 | provenance |  |
 | main.rs:154:9:154:9 | s | main.rs:155:29:155:29 | s | provenance |  |
 | main.rs:154:9:154:9 | s | main.rs:155:29:155:29 | s | provenance |  |
 | main.rs:154:13:154:21 | source(...) | main.rs:154:9:154:9 | s | provenance |  |
 | main.rs:154:13:154:21 | source(...) | main.rs:154:9:154:9 | s | provenance |  |
-| main.rs:155:28:155:30 | [...] [element] | main.rs:155:10:155:31 | get_array_element(...) | provenance | MaD:29 |
-| main.rs:155:28:155:30 | [...] [element] | main.rs:155:10:155:31 | get_array_element(...) | provenance | MaD:29 |
+| main.rs:155:28:155:30 | [...] [element] | main.rs:155:10:155:31 | get_array_element(...) | provenance | MaD:31 |
+| main.rs:155:28:155:30 | [...] [element] | main.rs:155:10:155:31 | get_array_element(...) | provenance | MaD:31 |
 | main.rs:155:29:155:29 | s | main.rs:155:28:155:30 | [...] [element] | provenance |  |
 | main.rs:155:29:155:29 | s | main.rs:155:28:155:30 | [...] [element] | provenance |  |
 | main.rs:164:9:164:9 | s | main.rs:165:33:165:33 | s | provenance |  |
@@ -151,10 +153,10 @@ edges
 | main.rs:165:9:165:11 | arr [element] | main.rs:166:10:166:12 | arr [element] | provenance |  |
 | main.rs:165:15:165:34 | set_array_element(...) [element] | main.rs:165:9:165:11 | arr [element] | provenance |  |
 | main.rs:165:15:165:34 | set_array_element(...) [element] | main.rs:165:9:165:11 | arr [element] | provenance |  |
-| main.rs:165:33:165:33 | s | main.rs:165:15:165:34 | set_array_element(...) [element] | provenance | MaD:35 |
-| main.rs:165:33:165:33 | s | main.rs:165:15:165:34 | set_array_element(...) [element] | provenance | MaD:35 |
-| main.rs:166:10:166:12 | arr [element] | main.rs:166:10:166:15 | arr[0] | provenance | MaD:22 |
-| main.rs:166:10:166:12 | arr [element] | main.rs:166:10:166:15 | arr[0] | provenance | MaD:22 |
+| main.rs:165:33:165:33 | s | main.rs:165:15:165:34 | set_array_element(...) [element] | provenance | MaD:37 |
+| main.rs:165:33:165:33 | s | main.rs:165:15:165:34 | set_array_element(...) [element] | provenance | MaD:37 |
+| main.rs:166:10:166:12 | arr [element] | main.rs:166:10:166:15 | arr[0] | provenance | MaD:24 |
+| main.rs:166:10:166:12 | arr [element] | main.rs:166:10:166:15 | arr[0] | provenance | MaD:24 |
 | main.rs:175:9:175:9 | s | main.rs:176:14:176:14 | s | provenance |  |
 | main.rs:175:9:175:9 | s | main.rs:176:14:176:14 | s | provenance |  |
 | main.rs:175:13:175:22 | source(...) | main.rs:175:9:175:9 | s | provenance |  |
@@ -165,8 +167,8 @@ edges
 | main.rs:176:13:176:18 | TupleExpr [tuple.0] | main.rs:176:9:176:9 | t [tuple.0] | provenance |  |
 | main.rs:176:14:176:14 | s | main.rs:176:13:176:18 | TupleExpr [tuple.0] | provenance |  |
 | main.rs:176:14:176:14 | s | main.rs:176:13:176:18 | TupleExpr [tuple.0] | provenance |  |
-| main.rs:177:28:177:28 | t [tuple.0] | main.rs:177:10:177:29 | get_tuple_element(...) | provenance | MaD:32 |
-| main.rs:177:28:177:28 | t [tuple.0] | main.rs:177:10:177:29 | get_tuple_element(...) | provenance | MaD:32 |
+| main.rs:177:28:177:28 | t [tuple.0] | main.rs:177:10:177:29 | get_tuple_element(...) | provenance | MaD:34 |
+| main.rs:177:28:177:28 | t [tuple.0] | main.rs:177:10:177:29 | get_tuple_element(...) | provenance | MaD:34 |
 | main.rs:188:9:188:9 | s | main.rs:189:31:189:31 | s | provenance |  |
 | main.rs:188:9:188:9 | s | main.rs:189:31:189:31 | s | provenance |  |
 | main.rs:188:13:188:22 | source(...) | main.rs:188:9:188:9 | s | provenance |  |
@@ -175,8 +177,8 @@ edges
 | main.rs:189:9:189:9 | t [tuple.1] | main.rs:191:10:191:10 | t [tuple.1] | provenance |  |
 | main.rs:189:13:189:32 | set_tuple_element(...) [tuple.1] | main.rs:189:9:189:9 | t [tuple.1] | provenance |  |
 | main.rs:189:13:189:32 | set_tuple_element(...) [tuple.1] | main.rs:189:9:189:9 | t [tuple.1] | provenance |  |
-| main.rs:189:31:189:31 | s | main.rs:189:13:189:32 | set_tuple_element(...) [tuple.1] | provenance | MaD:37 |
-| main.rs:189:31:189:31 | s | main.rs:189:13:189:32 | set_tuple_element(...) [tuple.1] | provenance | MaD:37 |
+| main.rs:189:31:189:31 | s | main.rs:189:13:189:32 | set_tuple_element(...) [tuple.1] | provenance | MaD:39 |
+| main.rs:189:31:189:31 | s | main.rs:189:13:189:32 | set_tuple_element(...) [tuple.1] | provenance | MaD:39 |
 | main.rs:191:10:191:10 | t [tuple.1] | main.rs:191:10:191:12 | t.1 | provenance |  |
 | main.rs:191:10:191:10 | t [tuple.1] | main.rs:191:10:191:12 | t.1 | provenance |  |
 | main.rs:203:9:203:9 | s | main.rs:208:11:208:11 | s | provenance |  |
@@ -185,8 +187,8 @@ edges
 | main.rs:203:13:203:22 | source(...) | main.rs:203:9:203:9 | s | provenance |  |
 | main.rs:204:14:204:14 | ... | main.rs:205:14:205:14 | n | provenance |  |
 | main.rs:204:14:204:14 | ... | main.rs:205:14:205:14 | n | provenance |  |
-| main.rs:208:11:208:11 | s | main.rs:204:14:204:14 | ... | provenance | MaD:24 |
-| main.rs:208:11:208:11 | s | main.rs:204:14:204:14 | ... | provenance | MaD:24 |
+| main.rs:208:11:208:11 | s | main.rs:204:14:204:14 | ... | provenance | MaD:26 |
+| main.rs:208:11:208:11 | s | main.rs:204:14:204:14 | ... | provenance | MaD:26 |
 | main.rs:212:13:212:22 | source(...) | main.rs:214:23:214:23 | f [captured s] | provenance |  |
 | main.rs:212:13:212:22 | source(...) | main.rs:214:23:214:23 | f [captured s] | provenance |  |
 | main.rs:213:40:213:40 | s | main.rs:213:17:213:42 | if ... {...} else {...} | provenance |  |
@@ -195,14 +197,14 @@ edges
 | main.rs:214:9:214:9 | t | main.rs:215:10:215:10 | t | provenance |  |
 | main.rs:214:13:214:24 | apply(...) | main.rs:214:9:214:9 | t | provenance |  |
 | main.rs:214:13:214:24 | apply(...) | main.rs:214:9:214:9 | t | provenance |  |
-| main.rs:214:23:214:23 | f [captured s] | main.rs:213:40:213:40 | s | provenance | MaD:24 |
-| main.rs:214:23:214:23 | f [captured s] | main.rs:213:40:213:40 | s | provenance | MaD:24 |
-| main.rs:214:23:214:23 | f [captured s] | main.rs:213:40:213:40 | s | provenance | MaD:25 |
-| main.rs:214:23:214:23 | f [captured s] | main.rs:213:40:213:40 | s | provenance | MaD:25 |
-| main.rs:214:23:214:23 | f [captured s] | main.rs:214:13:214:24 | apply(...) | provenance | MaD:24 |
-| main.rs:214:23:214:23 | f [captured s] | main.rs:214:13:214:24 | apply(...) | provenance | MaD:24 |
-| main.rs:214:23:214:23 | f [captured s] | main.rs:214:13:214:24 | apply(...) | provenance | MaD:25 |
-| main.rs:214:23:214:23 | f [captured s] | main.rs:214:13:214:24 | apply(...) | provenance | MaD:25 |
+| main.rs:214:23:214:23 | f [captured s] | main.rs:213:40:213:40 | s | provenance | MaD:26 |
+| main.rs:214:23:214:23 | f [captured s] | main.rs:213:40:213:40 | s | provenance | MaD:26 |
+| main.rs:214:23:214:23 | f [captured s] | main.rs:213:40:213:40 | s | provenance | MaD:27 |
+| main.rs:214:23:214:23 | f [captured s] | main.rs:213:40:213:40 | s | provenance | MaD:27 |
+| main.rs:214:23:214:23 | f [captured s] | main.rs:214:13:214:24 | apply(...) | provenance | MaD:26 |
+| main.rs:214:23:214:23 | f [captured s] | main.rs:214:13:214:24 | apply(...) | provenance | MaD:26 |
+| main.rs:214:23:214:23 | f [captured s] | main.rs:214:13:214:24 | apply(...) | provenance | MaD:27 |
+| main.rs:214:23:214:23 | f [captured s] | main.rs:214:13:214:24 | apply(...) | provenance | MaD:27 |
 | main.rs:219:9:219:9 | s | main.rs:221:19:221:19 | s | provenance |  |
 | main.rs:219:9:219:9 | s | main.rs:221:19:221:19 | s | provenance |  |
 | main.rs:219:13:219:22 | source(...) | main.rs:219:9:219:9 | s | provenance |  |
@@ -213,10 +215,10 @@ edges
 | main.rs:221:9:221:9 | t | main.rs:222:10:222:10 | t | provenance |  |
 | main.rs:221:13:221:23 | apply(...) | main.rs:221:9:221:9 | t | provenance |  |
 | main.rs:221:13:221:23 | apply(...) | main.rs:221:9:221:9 | t | provenance |  |
-| main.rs:221:19:221:19 | s | main.rs:220:14:220:14 | ... | provenance | MaD:24 |
-| main.rs:221:19:221:19 | s | main.rs:220:14:220:14 | ... | provenance | MaD:24 |
-| main.rs:221:19:221:19 | s | main.rs:221:13:221:23 | apply(...) | provenance | MaD:24 |
-| main.rs:221:19:221:19 | s | main.rs:221:13:221:23 | apply(...) | provenance | MaD:24 |
+| main.rs:221:19:221:19 | s | main.rs:220:14:220:14 | ... | provenance | MaD:26 |
+| main.rs:221:19:221:19 | s | main.rs:220:14:220:14 | ... | provenance | MaD:26 |
+| main.rs:221:19:221:19 | s | main.rs:221:13:221:23 | apply(...) | provenance | MaD:26 |
+| main.rs:221:19:221:19 | s | main.rs:221:13:221:23 | apply(...) | provenance | MaD:26 |
 | main.rs:231:9:231:9 | s | main.rs:232:30:232:30 | s | provenance |  |
 | main.rs:231:9:231:9 | s | main.rs:232:30:232:30 | s | provenance |  |
 | main.rs:231:13:231:22 | source(...) | main.rs:231:9:231:9 | s | provenance |  |
@@ -227,12 +229,12 @@ edges
 | main.rs:232:13:232:31 | get_async_number(...) [future] | main.rs:232:13:232:37 | await ... | provenance |  |
 | main.rs:232:13:232:37 | await ... | main.rs:232:9:232:9 | t | provenance |  |
 | main.rs:232:13:232:37 | await ... | main.rs:232:9:232:9 | t | provenance |  |
-| main.rs:232:30:232:30 | s | main.rs:232:13:232:31 | get_async_number(...) [future] | provenance | MaD:30 |
-| main.rs:232:30:232:30 | s | main.rs:232:13:232:31 | get_async_number(...) [future] | provenance | MaD:30 |
+| main.rs:232:30:232:30 | s | main.rs:232:13:232:31 | get_async_number(...) [future] | provenance | MaD:32 |
+| main.rs:232:30:232:30 | s | main.rs:232:13:232:31 | get_async_number(...) [future] | provenance | MaD:32 |
 | main.rs:257:9:257:9 | s [D] | main.rs:258:11:258:11 | s [D] | provenance |  |
 | main.rs:257:9:257:9 | s [D] | main.rs:258:11:258:11 | s [D] | provenance |  |
-| main.rs:257:13:257:27 | enum_source(...) | main.rs:257:9:257:9 | s [D] | provenance | Src:MaD:12  |
-| main.rs:257:13:257:27 | enum_source(...) | main.rs:257:9:257:9 | s [D] | provenance | Src:MaD:12  |
+| main.rs:257:13:257:27 | enum_source(...) | main.rs:257:9:257:9 | s [D] | provenance | Src:MaD:14  |
+| main.rs:257:13:257:27 | enum_source(...) | main.rs:257:9:257:9 | s [D] | provenance | Src:MaD:14  |
 | main.rs:258:11:258:11 | s [D] | main.rs:260:9:260:37 | ...::D {...} [D] | provenance |  |
 | main.rs:258:11:258:11 | s [D] | main.rs:260:9:260:37 | ...::D {...} [D] | provenance |  |
 | main.rs:260:9:260:37 | ...::D {...} [D] | main.rs:260:35:260:35 | i | provenance |  |
@@ -241,8 +243,8 @@ edges
 | main.rs:260:35:260:35 | i | main.rs:260:47:260:47 | i | provenance |  |
 | main.rs:264:9:264:9 | s [E, Some] | main.rs:265:11:265:11 | s [E, Some] | provenance |  |
 | main.rs:264:9:264:9 | s [E, Some] | main.rs:265:11:265:11 | s [E, Some] | provenance |  |
-| main.rs:264:13:264:34 | enum_source_nested(...) | main.rs:264:9:264:9 | s [E, Some] | provenance | Src:MaD:13  |
-| main.rs:264:13:264:34 | enum_source_nested(...) | main.rs:264:9:264:9 | s [E, Some] | provenance | Src:MaD:13  |
+| main.rs:264:13:264:34 | enum_source_nested(...) | main.rs:264:9:264:9 | s [E, Some] | provenance | Src:MaD:15  |
+| main.rs:264:13:264:34 | enum_source_nested(...) | main.rs:264:9:264:9 | s [E, Some] | provenance | Src:MaD:15  |
 | main.rs:265:11:265:11 | s [E, Some] | main.rs:268:9:268:37 | ...::E {...} [E, Some] | provenance |  |
 | main.rs:265:11:265:11 | s [E, Some] | main.rs:268:9:268:37 | ...::E {...} [E, Some] | provenance |  |
 | main.rs:268:9:268:37 | ...::E {...} [E, Some] | main.rs:268:35:268:35 | o [Some] | provenance |  |
@@ -257,24 +259,24 @@ edges
 | main.rs:270:22:270:22 | i | main.rs:270:33:270:33 | i | provenance |  |
 | main.rs:279:9:279:9 | s [C] | main.rs:280:11:280:11 | s [C] | provenance |  |
 | main.rs:279:9:279:9 | s [C] | main.rs:280:11:280:11 | s [C] | provenance |  |
-| main.rs:279:13:279:24 | e.source(...) | main.rs:279:9:279:9 | s [C] | provenance | Src:MaD:9  |
-| main.rs:279:13:279:24 | e.source(...) | main.rs:279:9:279:9 | s [C] | provenance | Src:MaD:9  |
+| main.rs:279:13:279:24 | e.source(...) | main.rs:279:9:279:9 | s [C] | provenance | Src:MaD:11  |
+| main.rs:279:13:279:24 | e.source(...) | main.rs:279:9:279:9 | s [C] | provenance | Src:MaD:11  |
 | main.rs:280:11:280:11 | s [C] | main.rs:281:9:281:37 | ...::C {...} [C] | provenance |  |
 | main.rs:280:11:280:11 | s [C] | main.rs:281:9:281:37 | ...::C {...} [C] | provenance |  |
 | main.rs:281:9:281:37 | ...::C {...} [C] | main.rs:281:35:281:35 | i | provenance |  |
 | main.rs:281:9:281:37 | ...::C {...} [C] | main.rs:281:35:281:35 | i | provenance |  |
 | main.rs:281:35:281:35 | i | main.rs:281:47:281:47 | i | provenance |  |
 | main.rs:281:35:281:35 | i | main.rs:281:47:281:47 | i | provenance |  |
-| main.rs:303:24:303:24 | a | main.rs:302:26:302:26 | a | provenance | Src:MaD:17  |
-| main.rs:303:24:303:24 | a | main.rs:302:26:302:26 | a | provenance | Src:MaD:17  |
-| main.rs:305:24:307:9 | \|...\| ... | main.rs:306:18:306:18 | a | provenance | Src:MaD:17  |
-| main.rs:305:24:307:9 | \|...\| ... | main.rs:306:18:306:18 | a | provenance | Src:MaD:17  |
-| main.rs:312:24:312:24 | f | main.rs:310:18:310:18 | a | provenance | Src:MaD:17  |
-| main.rs:312:24:312:24 | f | main.rs:310:18:310:18 | a | provenance | Src:MaD:17  |
-| main.rs:314:24:316:9 | \|...\| ... | main.rs:315:18:315:18 | a | provenance | Src:MaD:17  |
-| main.rs:314:24:316:9 | \|...\| ... | main.rs:315:18:315:18 | a | provenance | Src:MaD:17  |
-| main.rs:318:31:329:9 | \|...\| ... | main.rs:318:31:329:9 | \|...\| ... [E, Some] | provenance | Src:MaD:18  |
-| main.rs:318:31:329:9 | \|...\| ... | main.rs:318:31:329:9 | \|...\| ... [E, Some] | provenance | Src:MaD:18  |
+| main.rs:303:24:303:24 | a | main.rs:302:26:302:26 | a | provenance | Src:MaD:19  |
+| main.rs:303:24:303:24 | a | main.rs:302:26:302:26 | a | provenance | Src:MaD:19  |
+| main.rs:305:24:307:9 | \|...\| ... | main.rs:306:18:306:18 | a | provenance | Src:MaD:19  |
+| main.rs:305:24:307:9 | \|...\| ... | main.rs:306:18:306:18 | a | provenance | Src:MaD:19  |
+| main.rs:312:24:312:24 | f | main.rs:310:18:310:18 | a | provenance | Src:MaD:19  |
+| main.rs:312:24:312:24 | f | main.rs:310:18:310:18 | a | provenance | Src:MaD:19  |
+| main.rs:314:24:316:9 | \|...\| ... | main.rs:315:18:315:18 | a | provenance | Src:MaD:19  |
+| main.rs:314:24:316:9 | \|...\| ... | main.rs:315:18:315:18 | a | provenance | Src:MaD:19  |
+| main.rs:318:31:329:9 | \|...\| ... | main.rs:318:31:329:9 | \|...\| ... [E, Some] | provenance | Src:MaD:20  |
+| main.rs:318:31:329:9 | \|...\| ... | main.rs:318:31:329:9 | \|...\| ... [E, Some] | provenance | Src:MaD:20  |
 | main.rs:318:31:329:9 | \|...\| ... [E, Some] | main.rs:319:19:319:19 | e [E, Some] | provenance |  |
 | main.rs:318:31:329:9 | \|...\| ... [E, Some] | main.rs:319:19:319:19 | e [E, Some] | provenance |  |
 | main.rs:319:19:319:19 | e [E, Some] | main.rs:322:17:322:45 | ...::E {...} [E, Some] | provenance |  |
@@ -289,8 +291,8 @@ edges
 | main.rs:324:25:324:31 | Some(...) [Some] | main.rs:324:30:324:30 | i | provenance |  |
 | main.rs:324:30:324:30 | i | main.rs:324:41:324:41 | i | provenance |  |
 | main.rs:324:30:324:30 | i | main.rs:324:41:324:41 | i | provenance |  |
-| main.rs:344:21:344:29 | source(...) | main.rs:345:19:345:19 | a | provenance | Sink:MaD:7 |
-| main.rs:344:21:344:29 | source(...) | main.rs:345:19:345:19 | a | provenance | Sink:MaD:7 |
+| main.rs:344:21:344:29 | source(...) | main.rs:345:19:345:19 | a | provenance | Sink:MaD:8 |
+| main.rs:344:21:344:29 | source(...) | main.rs:345:19:345:19 | a | provenance | Sink:MaD:8 |
 | main.rs:348:17:348:17 | s | main.rs:350:39:350:39 | s | provenance |  |
 | main.rs:348:17:348:17 | s | main.rs:350:39:350:39 | s | provenance |  |
 | main.rs:348:21:348:29 | source(...) | main.rs:348:17:348:17 | s | provenance |  |
@@ -301,20 +303,20 @@ edges
 | main.rs:350:26:350:40 | ...::Some(...) [Some] | main.rs:349:13:351:13 | ...::E {...} [E, Some] | provenance |  |
 | main.rs:350:39:350:39 | s | main.rs:350:26:350:40 | ...::Some(...) [Some] | provenance |  |
 | main.rs:350:39:350:39 | s | main.rs:350:26:350:40 | ...::Some(...) [Some] | provenance |  |
-| main.rs:353:26:353:26 | b [E, Some] | main.rs:353:26:353:26 | b | provenance | Sink:MaD:8 |
-| main.rs:353:26:353:26 | b [E, Some] | main.rs:353:26:353:26 | b | provenance | Sink:MaD:8 |
+| main.rs:353:26:353:26 | b [E, Some] | main.rs:353:26:353:26 | b | provenance | Sink:MaD:9 |
+| main.rs:353:26:353:26 | b [E, Some] | main.rs:353:26:353:26 | b | provenance | Sink:MaD:9 |
 | main.rs:364:9:364:9 | s | main.rs:365:41:365:41 | s | provenance |  |
 | main.rs:364:9:364:9 | s | main.rs:365:41:365:41 | s | provenance |  |
 | main.rs:364:9:364:9 | s | main.rs:368:53:368:53 | s | provenance |  |
 | main.rs:364:9:364:9 | s | main.rs:368:53:368:53 | s | provenance |  |
 | main.rs:364:13:364:22 | source(...) | main.rs:364:9:364:9 | s | provenance |  |
 | main.rs:364:13:364:22 | source(...) | main.rs:364:9:364:9 | s | provenance |  |
-| main.rs:365:15:365:43 | ...::C {...} [C] | main.rs:365:15:365:43 | ...::C {...} | provenance | Sink:MaD:2 |
-| main.rs:365:15:365:43 | ...::C {...} [C] | main.rs:365:15:365:43 | ...::C {...} | provenance | Sink:MaD:2 |
+| main.rs:365:15:365:43 | ...::C {...} [C] | main.rs:365:15:365:43 | ...::C {...} | provenance | Sink:MaD:3 |
+| main.rs:365:15:365:43 | ...::C {...} [C] | main.rs:365:15:365:43 | ...::C {...} | provenance | Sink:MaD:3 |
 | main.rs:365:41:365:41 | s | main.rs:365:15:365:43 | ...::C {...} [C] | provenance |  |
 | main.rs:365:41:365:41 | s | main.rs:365:15:365:43 | ...::C {...} [C] | provenance |  |
-| main.rs:368:22:368:56 | ...::E {...} [E, Some] | main.rs:368:22:368:56 | ...::E {...} | provenance | Sink:MaD:3 |
-| main.rs:368:22:368:56 | ...::E {...} [E, Some] | main.rs:368:22:368:56 | ...::E {...} | provenance | Sink:MaD:3 |
+| main.rs:368:22:368:56 | ...::E {...} [E, Some] | main.rs:368:22:368:56 | ...::E {...} | provenance | Sink:MaD:4 |
+| main.rs:368:22:368:56 | ...::E {...} [E, Some] | main.rs:368:22:368:56 | ...::E {...} | provenance | Sink:MaD:4 |
 | main.rs:368:48:368:54 | Some(...) [Some] | main.rs:368:22:368:56 | ...::E {...} [E, Some] | provenance |  |
 | main.rs:368:48:368:54 | Some(...) [Some] | main.rs:368:22:368:56 | ...::E {...} [E, Some] | provenance |  |
 | main.rs:368:53:368:53 | s | main.rs:368:48:368:54 | Some(...) [Some] | provenance |  |
@@ -323,76 +325,82 @@ edges
 | main.rs:372:9:372:9 | s | main.rs:373:39:373:39 | s | provenance |  |
 | main.rs:372:13:372:22 | source(...) | main.rs:372:9:372:9 | s | provenance |  |
 | main.rs:372:13:372:22 | source(...) | main.rs:372:9:372:9 | s | provenance |  |
-| main.rs:373:9:373:9 | e [D] | main.rs:374:5:374:5 | e | provenance | Sink:MaD:1 |
-| main.rs:373:9:373:9 | e [D] | main.rs:374:5:374:5 | e | provenance | Sink:MaD:1 |
+| main.rs:373:9:373:9 | e [D] | main.rs:374:5:374:5 | e | provenance | Sink:MaD:2 |
+| main.rs:373:9:373:9 | e [D] | main.rs:374:5:374:5 | e | provenance | Sink:MaD:2 |
 | main.rs:373:13:373:41 | ...::D {...} [D] | main.rs:373:9:373:9 | e [D] | provenance |  |
 | main.rs:373:13:373:41 | ...::D {...} [D] | main.rs:373:9:373:9 | e [D] | provenance |  |
 | main.rs:373:39:373:39 | s | main.rs:373:13:373:41 | ...::D {...} [D] | provenance |  |
 | main.rs:373:39:373:39 | s | main.rs:373:13:373:41 | ...::D {...} [D] | provenance |  |
 | main.rs:383:9:383:9 | s | main.rs:384:10:384:10 | s | provenance |  |
 | main.rs:383:9:383:9 | s | main.rs:384:10:384:10 | s | provenance |  |
-| main.rs:383:13:383:29 | simple_source(...) | main.rs:383:9:383:9 | s | provenance | Src:MaD:16  |
-| main.rs:383:13:383:29 | simple_source(...) | main.rs:383:9:383:9 | s | provenance | Src:MaD:16  |
-| main.rs:391:9:391:9 | s | main.rs:392:17:392:17 | s | provenance | Sink:MaD:6 |
-| main.rs:391:9:391:9 | s | main.rs:392:17:392:17 | s | provenance | Sink:MaD:6 |
+| main.rs:383:13:383:29 | simple_source(...) | main.rs:383:9:383:9 | s | provenance | Src:MaD:18  |
+| main.rs:383:13:383:29 | simple_source(...) | main.rs:383:9:383:9 | s | provenance | Src:MaD:18  |
+| main.rs:391:9:391:9 | s | main.rs:392:17:392:17 | s | provenance | Sink:MaD:7 |
+| main.rs:391:9:391:9 | s | main.rs:392:17:392:17 | s | provenance | Sink:MaD:7 |
 | main.rs:391:13:391:22 | source(...) | main.rs:391:9:391:9 | s | provenance |  |
 | main.rs:391:13:391:22 | source(...) | main.rs:391:9:391:9 | s | provenance |  |
-| main.rs:400:16:400:16 | i | main.rs:401:10:401:10 | i | provenance | Src:MaD:11  |
-| main.rs:400:16:400:16 | i | main.rs:401:10:401:10 | i | provenance | Src:MaD:11  |
-| main.rs:410:26:410:31 | ...: i64 | main.rs:411:14:411:14 | i | provenance | Src:MaD:10  |
-| main.rs:410:26:410:31 | ...: i64 | main.rs:411:14:411:14 | i | provenance | Src:MaD:10  |
-| main.rs:475:9:475:10 | x1 | main.rs:476:10:476:11 | x1 | provenance |  |
-| main.rs:475:9:475:10 | x1 | main.rs:476:10:476:11 | x1 | provenance |  |
-| main.rs:475:14:475:23 | source(...) | main.rs:475:14:475:30 | ... .max(...) | provenance | MaD:20 |
-| main.rs:475:14:475:23 | source(...) | main.rs:475:14:475:30 | ... .max(...) | provenance | MaD:20 |
-| main.rs:475:14:475:30 | ... .max(...) | main.rs:475:9:475:10 | x1 | provenance |  |
-| main.rs:475:14:475:30 | ... .max(...) | main.rs:475:9:475:10 | x1 | provenance |  |
-| main.rs:478:9:478:10 | x2 [MyStruct.field1] | main.rs:486:10:486:11 | x2 [MyStruct.field1] | provenance |  |
-| main.rs:478:9:478:10 | x2 [MyStruct.field1] | main.rs:486:10:486:11 | x2 [MyStruct.field1] | provenance |  |
-| main.rs:478:14:485:6 | ... .max(...) [MyStruct.field1] | main.rs:478:9:478:10 | x2 [MyStruct.field1] | provenance |  |
-| main.rs:478:14:485:6 | ... .max(...) [MyStruct.field1] | main.rs:478:9:478:10 | x2 [MyStruct.field1] | provenance |  |
-| main.rs:478:15:481:5 | MyStruct {...} [MyStruct.field1] | main.rs:478:14:485:6 | ... .max(...) [MyStruct.field1] | provenance | MaD:20 |
-| main.rs:478:15:481:5 | MyStruct {...} [MyStruct.field1] | main.rs:478:14:485:6 | ... .max(...) [MyStruct.field1] | provenance | MaD:20 |
-| main.rs:479:17:479:26 | source(...) | main.rs:478:15:481:5 | MyStruct {...} [MyStruct.field1] | provenance |  |
-| main.rs:479:17:479:26 | source(...) | main.rs:478:15:481:5 | MyStruct {...} [MyStruct.field1] | provenance |  |
-| main.rs:486:10:486:11 | x2 [MyStruct.field1] | main.rs:486:10:486:18 | x2.field1 | provenance |  |
-| main.rs:486:10:486:11 | x2 [MyStruct.field1] | main.rs:486:10:486:18 | x2.field1 | provenance |  |
-| main.rs:491:9:491:10 | x4 | main.rs:492:10:492:11 | x4 | provenance |  |
-| main.rs:491:9:491:10 | x4 | main.rs:492:10:492:11 | x4 | provenance |  |
-| main.rs:491:14:491:23 | source(...) | main.rs:491:14:491:30 | ... .max(...) | provenance | MaD:20 |
-| main.rs:491:14:491:23 | source(...) | main.rs:491:14:491:30 | ... .max(...) | provenance | MaD:20 |
-| main.rs:491:14:491:30 | ... .max(...) | main.rs:491:9:491:10 | x4 | provenance |  |
-| main.rs:491:14:491:30 | ... .max(...) | main.rs:491:9:491:10 | x4 | provenance |  |
-| main.rs:494:9:494:10 | x5 | main.rs:495:10:495:11 | x5 | provenance |  |
-| main.rs:494:14:494:23 | source(...) | main.rs:494:14:494:30 | ... .lt(...) | provenance | MaD:21 |
-| main.rs:494:14:494:30 | ... .lt(...) | main.rs:494:9:494:10 | x5 | provenance |  |
-| main.rs:497:9:497:10 | x6 | main.rs:498:10:498:11 | x6 | provenance |  |
-| main.rs:497:14:497:23 | source(...) | main.rs:497:14:497:27 | ... < ... | provenance | MaD:21 |
-| main.rs:497:14:497:27 | ... < ... | main.rs:497:9:497:10 | x6 | provenance |  |
-| main.rs:503:9:503:10 | x8 | main.rs:504:10:504:11 | x8 | provenance |  |
-| main.rs:503:9:503:10 | x8 | main.rs:504:10:504:11 | x8 | provenance |  |
-| main.rs:503:14:503:44 | ...::flow_through2(...) | main.rs:503:9:503:10 | x8 | provenance |  |
-| main.rs:503:14:503:44 | ...::flow_through2(...) | main.rs:503:9:503:10 | x8 | provenance |  |
-| main.rs:503:34:503:43 | source(...) | main.rs:503:14:503:44 | ...::flow_through2(...) | provenance | MaD:23 |
-| main.rs:503:34:503:43 | source(...) | main.rs:503:14:503:44 | ...::flow_through2(...) | provenance | MaD:23 |
-| main.rs:506:9:506:10 | x9 | main.rs:507:10:507:11 | x9 | provenance |  |
-| main.rs:506:9:506:10 | x9 | main.rs:507:10:507:11 | x9 | provenance |  |
-| main.rs:506:14:506:44 | ...::flow_through3(...) | main.rs:506:9:506:10 | x9 | provenance |  |
-| main.rs:506:14:506:44 | ...::flow_through3(...) | main.rs:506:9:506:10 | x9 | provenance |  |
-| main.rs:506:34:506:43 | source(...) | main.rs:506:14:506:44 | ...::flow_through3(...) | provenance | MaD:19 |
-| main.rs:506:34:506:43 | source(...) | main.rs:506:14:506:44 | ...::flow_through3(...) | provenance | MaD:19 |
-| main.rs:519:10:519:28 | generated_source(...) | main.rs:519:10:519:28 | generated_source(...) | provenance | Src:MaD:14  |
-| main.rs:519:10:519:28 | generated_source(...) | main.rs:519:10:519:28 | generated_source(...) | provenance | Src:MaD:14  |
-| main.rs:521:10:521:33 | neutral_manual_source(...) | main.rs:521:10:521:33 | neutral_manual_source(...) | provenance | Src:MaD:15  |
-| main.rs:521:10:521:33 | neutral_manual_source(...) | main.rs:521:10:521:33 | neutral_manual_source(...) | provenance | Src:MaD:15  |
-| main.rs:522:20:522:28 | source(...) | main.rs:522:20:522:28 | source(...) | provenance | Sink:MaD:4 |
-| main.rs:522:20:522:28 | source(...) | main.rs:522:20:522:28 | source(...) | provenance | Sink:MaD:4 |
-| main.rs:524:25:524:33 | source(...) | main.rs:524:25:524:33 | source(...) | provenance | Sink:MaD:5 |
-| main.rs:524:25:524:33 | source(...) | main.rs:524:25:524:33 | source(...) | provenance | Sink:MaD:5 |
-| main.rs:525:28:525:36 | source(...) | main.rs:525:10:525:37 | generated_summary(...) | provenance | MaD:27 |
-| main.rs:525:28:525:36 | source(...) | main.rs:525:10:525:37 | generated_summary(...) | provenance | MaD:27 |
-| main.rs:527:33:527:41 | source(...) | main.rs:527:10:527:42 | neutral_manual_summary(...) | provenance | MaD:28 |
-| main.rs:527:33:527:41 | source(...) | main.rs:527:10:527:42 | neutral_manual_summary(...) | provenance | MaD:28 |
+| main.rs:400:16:400:16 | i | main.rs:401:10:401:10 | i | provenance | Src:MaD:13  |
+| main.rs:400:16:400:16 | i | main.rs:401:10:401:10 | i | provenance | Src:MaD:13  |
+| main.rs:410:26:410:31 | ...: i64 | main.rs:411:14:411:14 | i | provenance | Src:MaD:12  |
+| main.rs:410:26:410:31 | ...: i64 | main.rs:411:14:411:14 | i | provenance | Src:MaD:12  |
+| main.rs:495:9:495:10 | x1 | main.rs:496:10:496:11 | x1 | provenance |  |
+| main.rs:495:9:495:10 | x1 | main.rs:496:10:496:11 | x1 | provenance |  |
+| main.rs:495:14:495:23 | source(...) | main.rs:495:14:495:30 | ... .max(...) | provenance | MaD:22 |
+| main.rs:495:14:495:23 | source(...) | main.rs:495:14:495:30 | ... .max(...) | provenance | MaD:22 |
+| main.rs:495:14:495:30 | ... .max(...) | main.rs:495:9:495:10 | x1 | provenance |  |
+| main.rs:495:14:495:30 | ... .max(...) | main.rs:495:9:495:10 | x1 | provenance |  |
+| main.rs:498:9:498:10 | x2 [MyStruct.field1] | main.rs:506:10:506:11 | x2 [MyStruct.field1] | provenance |  |
+| main.rs:498:9:498:10 | x2 [MyStruct.field1] | main.rs:506:10:506:11 | x2 [MyStruct.field1] | provenance |  |
+| main.rs:498:14:505:6 | ... .max(...) [MyStruct.field1] | main.rs:498:9:498:10 | x2 [MyStruct.field1] | provenance |  |
+| main.rs:498:14:505:6 | ... .max(...) [MyStruct.field1] | main.rs:498:9:498:10 | x2 [MyStruct.field1] | provenance |  |
+| main.rs:498:15:501:5 | MyStruct {...} [MyStruct.field1] | main.rs:498:14:505:6 | ... .max(...) [MyStruct.field1] | provenance | MaD:22 |
+| main.rs:498:15:501:5 | MyStruct {...} [MyStruct.field1] | main.rs:498:14:505:6 | ... .max(...) [MyStruct.field1] | provenance | MaD:22 |
+| main.rs:499:17:499:26 | source(...) | main.rs:498:15:501:5 | MyStruct {...} [MyStruct.field1] | provenance |  |
+| main.rs:499:17:499:26 | source(...) | main.rs:498:15:501:5 | MyStruct {...} [MyStruct.field1] | provenance |  |
+| main.rs:506:10:506:11 | x2 [MyStruct.field1] | main.rs:506:10:506:18 | x2.field1 | provenance |  |
+| main.rs:506:10:506:11 | x2 [MyStruct.field1] | main.rs:506:10:506:18 | x2.field1 | provenance |  |
+| main.rs:511:9:511:10 | x4 | main.rs:512:10:512:11 | x4 | provenance |  |
+| main.rs:511:9:511:10 | x4 | main.rs:512:10:512:11 | x4 | provenance |  |
+| main.rs:511:14:511:23 | source(...) | main.rs:511:14:511:30 | ... .max(...) | provenance | MaD:22 |
+| main.rs:511:14:511:23 | source(...) | main.rs:511:14:511:30 | ... .max(...) | provenance | MaD:22 |
+| main.rs:511:14:511:30 | ... .max(...) | main.rs:511:9:511:10 | x4 | provenance |  |
+| main.rs:511:14:511:30 | ... .max(...) | main.rs:511:9:511:10 | x4 | provenance |  |
+| main.rs:514:9:514:10 | x5 | main.rs:515:10:515:11 | x5 | provenance |  |
+| main.rs:514:14:514:23 | source(...) | main.rs:514:14:514:30 | ... .lt(...) | provenance | MaD:23 |
+| main.rs:514:14:514:30 | ... .lt(...) | main.rs:514:9:514:10 | x5 | provenance |  |
+| main.rs:517:9:517:10 | x6 | main.rs:518:10:518:11 | x6 | provenance |  |
+| main.rs:517:14:517:23 | source(...) | main.rs:517:14:517:27 | ... < ... | provenance | MaD:23 |
+| main.rs:517:14:517:27 | ... < ... | main.rs:517:9:517:10 | x6 | provenance |  |
+| main.rs:523:9:523:10 | x8 | main.rs:524:10:524:11 | x8 | provenance |  |
+| main.rs:523:9:523:10 | x8 | main.rs:524:10:524:11 | x8 | provenance |  |
+| main.rs:523:14:523:44 | ...::flow_through2(...) | main.rs:523:9:523:10 | x8 | provenance |  |
+| main.rs:523:14:523:44 | ...::flow_through2(...) | main.rs:523:9:523:10 | x8 | provenance |  |
+| main.rs:523:34:523:43 | source(...) | main.rs:523:14:523:44 | ...::flow_through2(...) | provenance | MaD:25 |
+| main.rs:523:34:523:43 | source(...) | main.rs:523:14:523:44 | ...::flow_through2(...) | provenance | MaD:25 |
+| main.rs:526:9:526:10 | x9 | main.rs:527:10:527:11 | x9 | provenance |  |
+| main.rs:526:9:526:10 | x9 | main.rs:527:10:527:11 | x9 | provenance |  |
+| main.rs:526:14:526:44 | ...::flow_through3(...) | main.rs:526:9:526:10 | x9 | provenance |  |
+| main.rs:526:14:526:44 | ...::flow_through3(...) | main.rs:526:9:526:10 | x9 | provenance |  |
+| main.rs:526:34:526:43 | source(...) | main.rs:526:14:526:44 | ...::flow_through3(...) | provenance | MaD:21 |
+| main.rs:526:34:526:43 | source(...) | main.rs:526:14:526:44 | ...::flow_through3(...) | provenance | MaD:21 |
+| main.rs:532:9:532:11 | x11 | main.rs:533:10:533:12 | x11 | provenance |  |
+| main.rs:532:9:532:11 | x11 | main.rs:533:10:533:12 | x11 | provenance |  |
+| main.rs:532:15:532:32 | ...::produce3(...) | main.rs:532:9:532:11 | x11 | provenance | Src:MaD:10  |
+| main.rs:532:15:532:32 | ...::produce3(...) | main.rs:532:9:532:11 | x11 | provenance | Src:MaD:10  |
+| main.rs:537:20:537:29 | source(...) | main.rs:537:20:537:29 | source(...) | provenance | Sink:MaD:1 |
+| main.rs:537:20:537:29 | source(...) | main.rs:537:20:537:29 | source(...) | provenance | Sink:MaD:1 |
+| main.rs:549:10:549:28 | generated_source(...) | main.rs:549:10:549:28 | generated_source(...) | provenance | Src:MaD:16  |
+| main.rs:549:10:549:28 | generated_source(...) | main.rs:549:10:549:28 | generated_source(...) | provenance | Src:MaD:16  |
+| main.rs:551:10:551:33 | neutral_manual_source(...) | main.rs:551:10:551:33 | neutral_manual_source(...) | provenance | Src:MaD:17  |
+| main.rs:551:10:551:33 | neutral_manual_source(...) | main.rs:551:10:551:33 | neutral_manual_source(...) | provenance | Src:MaD:17  |
+| main.rs:552:20:552:28 | source(...) | main.rs:552:20:552:28 | source(...) | provenance | Sink:MaD:5 |
+| main.rs:552:20:552:28 | source(...) | main.rs:552:20:552:28 | source(...) | provenance | Sink:MaD:5 |
+| main.rs:554:25:554:33 | source(...) | main.rs:554:25:554:33 | source(...) | provenance | Sink:MaD:6 |
+| main.rs:554:25:554:33 | source(...) | main.rs:554:25:554:33 | source(...) | provenance | Sink:MaD:6 |
+| main.rs:555:28:555:36 | source(...) | main.rs:555:10:555:37 | generated_summary(...) | provenance | MaD:29 |
+| main.rs:555:28:555:36 | source(...) | main.rs:555:10:555:37 | generated_summary(...) | provenance | MaD:29 |
+| main.rs:557:33:557:41 | source(...) | main.rs:557:10:557:42 | neutral_manual_summary(...) | provenance | MaD:30 |
+| main.rs:557:33:557:41 | source(...) | main.rs:557:10:557:42 | neutral_manual_summary(...) | provenance | MaD:30 |
 nodes
 | main.rs:15:9:15:9 | s | semmle.label | s |
 | main.rs:15:9:15:9 | s | semmle.label | s |
@@ -756,82 +764,92 @@ nodes
 | main.rs:410:26:410:31 | ...: i64 | semmle.label | ...: i64 |
 | main.rs:411:14:411:14 | i | semmle.label | i |
 | main.rs:411:14:411:14 | i | semmle.label | i |
-| main.rs:475:9:475:10 | x1 | semmle.label | x1 |
-| main.rs:475:9:475:10 | x1 | semmle.label | x1 |
-| main.rs:475:14:475:23 | source(...) | semmle.label | source(...) |
-| main.rs:475:14:475:23 | source(...) | semmle.label | source(...) |
-| main.rs:475:14:475:30 | ... .max(...) | semmle.label | ... .max(...) |
-| main.rs:475:14:475:30 | ... .max(...) | semmle.label | ... .max(...) |
-| main.rs:476:10:476:11 | x1 | semmle.label | x1 |
-| main.rs:476:10:476:11 | x1 | semmle.label | x1 |
-| main.rs:478:9:478:10 | x2 [MyStruct.field1] | semmle.label | x2 [MyStruct.field1] |
-| main.rs:478:9:478:10 | x2 [MyStruct.field1] | semmle.label | x2 [MyStruct.field1] |
-| main.rs:478:14:485:6 | ... .max(...) [MyStruct.field1] | semmle.label | ... .max(...) [MyStruct.field1] |
-| main.rs:478:14:485:6 | ... .max(...) [MyStruct.field1] | semmle.label | ... .max(...) [MyStruct.field1] |
-| main.rs:478:15:481:5 | MyStruct {...} [MyStruct.field1] | semmle.label | MyStruct {...} [MyStruct.field1] |
-| main.rs:478:15:481:5 | MyStruct {...} [MyStruct.field1] | semmle.label | MyStruct {...} [MyStruct.field1] |
-| main.rs:479:17:479:26 | source(...) | semmle.label | source(...) |
-| main.rs:479:17:479:26 | source(...) | semmle.label | source(...) |
-| main.rs:486:10:486:11 | x2 [MyStruct.field1] | semmle.label | x2 [MyStruct.field1] |
-| main.rs:486:10:486:11 | x2 [MyStruct.field1] | semmle.label | x2 [MyStruct.field1] |
-| main.rs:486:10:486:18 | x2.field1 | semmle.label | x2.field1 |
-| main.rs:486:10:486:18 | x2.field1 | semmle.label | x2.field1 |
-| main.rs:491:9:491:10 | x4 | semmle.label | x4 |
-| main.rs:491:9:491:10 | x4 | semmle.label | x4 |
-| main.rs:491:14:491:23 | source(...) | semmle.label | source(...) |
-| main.rs:491:14:491:23 | source(...) | semmle.label | source(...) |
-| main.rs:491:14:491:30 | ... .max(...) | semmle.label | ... .max(...) |
-| main.rs:491:14:491:30 | ... .max(...) | semmle.label | ... .max(...) |
-| main.rs:492:10:492:11 | x4 | semmle.label | x4 |
-| main.rs:492:10:492:11 | x4 | semmle.label | x4 |
-| main.rs:494:9:494:10 | x5 | semmle.label | x5 |
-| main.rs:494:14:494:23 | source(...) | semmle.label | source(...) |
-| main.rs:494:14:494:30 | ... .lt(...) | semmle.label | ... .lt(...) |
-| main.rs:495:10:495:11 | x5 | semmle.label | x5 |
-| main.rs:497:9:497:10 | x6 | semmle.label | x6 |
-| main.rs:497:14:497:23 | source(...) | semmle.label | source(...) |
-| main.rs:497:14:497:27 | ... < ... | semmle.label | ... < ... |
-| main.rs:498:10:498:11 | x6 | semmle.label | x6 |
-| main.rs:503:9:503:10 | x8 | semmle.label | x8 |
-| main.rs:503:9:503:10 | x8 | semmle.label | x8 |
-| main.rs:503:14:503:44 | ...::flow_through2(...) | semmle.label | ...::flow_through2(...) |
-| main.rs:503:14:503:44 | ...::flow_through2(...) | semmle.label | ...::flow_through2(...) |
-| main.rs:503:34:503:43 | source(...) | semmle.label | source(...) |
-| main.rs:503:34:503:43 | source(...) | semmle.label | source(...) |
-| main.rs:504:10:504:11 | x8 | semmle.label | x8 |
-| main.rs:504:10:504:11 | x8 | semmle.label | x8 |
-| main.rs:506:9:506:10 | x9 | semmle.label | x9 |
-| main.rs:506:9:506:10 | x9 | semmle.label | x9 |
-| main.rs:506:14:506:44 | ...::flow_through3(...) | semmle.label | ...::flow_through3(...) |
-| main.rs:506:14:506:44 | ...::flow_through3(...) | semmle.label | ...::flow_through3(...) |
-| main.rs:506:34:506:43 | source(...) | semmle.label | source(...) |
-| main.rs:506:34:506:43 | source(...) | semmle.label | source(...) |
-| main.rs:507:10:507:11 | x9 | semmle.label | x9 |
-| main.rs:507:10:507:11 | x9 | semmle.label | x9 |
-| main.rs:519:10:519:28 | generated_source(...) | semmle.label | generated_source(...) |
-| main.rs:519:10:519:28 | generated_source(...) | semmle.label | generated_source(...) |
-| main.rs:519:10:519:28 | generated_source(...) | semmle.label | generated_source(...) |
-| main.rs:519:10:519:28 | generated_source(...) | semmle.label | generated_source(...) |
-| main.rs:521:10:521:33 | neutral_manual_source(...) | semmle.label | neutral_manual_source(...) |
-| main.rs:521:10:521:33 | neutral_manual_source(...) | semmle.label | neutral_manual_source(...) |
-| main.rs:521:10:521:33 | neutral_manual_source(...) | semmle.label | neutral_manual_source(...) |
-| main.rs:521:10:521:33 | neutral_manual_source(...) | semmle.label | neutral_manual_source(...) |
-| main.rs:522:20:522:28 | source(...) | semmle.label | source(...) |
-| main.rs:522:20:522:28 | source(...) | semmle.label | source(...) |
-| main.rs:522:20:522:28 | source(...) | semmle.label | source(...) |
-| main.rs:522:20:522:28 | source(...) | semmle.label | source(...) |
-| main.rs:524:25:524:33 | source(...) | semmle.label | source(...) |
-| main.rs:524:25:524:33 | source(...) | semmle.label | source(...) |
-| main.rs:524:25:524:33 | source(...) | semmle.label | source(...) |
-| main.rs:524:25:524:33 | source(...) | semmle.label | source(...) |
-| main.rs:525:10:525:37 | generated_summary(...) | semmle.label | generated_summary(...) |
-| main.rs:525:10:525:37 | generated_summary(...) | semmle.label | generated_summary(...) |
-| main.rs:525:28:525:36 | source(...) | semmle.label | source(...) |
-| main.rs:525:28:525:36 | source(...) | semmle.label | source(...) |
-| main.rs:527:10:527:42 | neutral_manual_summary(...) | semmle.label | neutral_manual_summary(...) |
-| main.rs:527:10:527:42 | neutral_manual_summary(...) | semmle.label | neutral_manual_summary(...) |
-| main.rs:527:33:527:41 | source(...) | semmle.label | source(...) |
-| main.rs:527:33:527:41 | source(...) | semmle.label | source(...) |
+| main.rs:495:9:495:10 | x1 | semmle.label | x1 |
+| main.rs:495:9:495:10 | x1 | semmle.label | x1 |
+| main.rs:495:14:495:23 | source(...) | semmle.label | source(...) |
+| main.rs:495:14:495:23 | source(...) | semmle.label | source(...) |
+| main.rs:495:14:495:30 | ... .max(...) | semmle.label | ... .max(...) |
+| main.rs:495:14:495:30 | ... .max(...) | semmle.label | ... .max(...) |
+| main.rs:496:10:496:11 | x1 | semmle.label | x1 |
+| main.rs:496:10:496:11 | x1 | semmle.label | x1 |
+| main.rs:498:9:498:10 | x2 [MyStruct.field1] | semmle.label | x2 [MyStruct.field1] |
+| main.rs:498:9:498:10 | x2 [MyStruct.field1] | semmle.label | x2 [MyStruct.field1] |
+| main.rs:498:14:505:6 | ... .max(...) [MyStruct.field1] | semmle.label | ... .max(...) [MyStruct.field1] |
+| main.rs:498:14:505:6 | ... .max(...) [MyStruct.field1] | semmle.label | ... .max(...) [MyStruct.field1] |
+| main.rs:498:15:501:5 | MyStruct {...} [MyStruct.field1] | semmle.label | MyStruct {...} [MyStruct.field1] |
+| main.rs:498:15:501:5 | MyStruct {...} [MyStruct.field1] | semmle.label | MyStruct {...} [MyStruct.field1] |
+| main.rs:499:17:499:26 | source(...) | semmle.label | source(...) |
+| main.rs:499:17:499:26 | source(...) | semmle.label | source(...) |
+| main.rs:506:10:506:11 | x2 [MyStruct.field1] | semmle.label | x2 [MyStruct.field1] |
+| main.rs:506:10:506:11 | x2 [MyStruct.field1] | semmle.label | x2 [MyStruct.field1] |
+| main.rs:506:10:506:18 | x2.field1 | semmle.label | x2.field1 |
+| main.rs:506:10:506:18 | x2.field1 | semmle.label | x2.field1 |
+| main.rs:511:9:511:10 | x4 | semmle.label | x4 |
+| main.rs:511:9:511:10 | x4 | semmle.label | x4 |
+| main.rs:511:14:511:23 | source(...) | semmle.label | source(...) |
+| main.rs:511:14:511:23 | source(...) | semmle.label | source(...) |
+| main.rs:511:14:511:30 | ... .max(...) | semmle.label | ... .max(...) |
+| main.rs:511:14:511:30 | ... .max(...) | semmle.label | ... .max(...) |
+| main.rs:512:10:512:11 | x4 | semmle.label | x4 |
+| main.rs:512:10:512:11 | x4 | semmle.label | x4 |
+| main.rs:514:9:514:10 | x5 | semmle.label | x5 |
+| main.rs:514:14:514:23 | source(...) | semmle.label | source(...) |
+| main.rs:514:14:514:30 | ... .lt(...) | semmle.label | ... .lt(...) |
+| main.rs:515:10:515:11 | x5 | semmle.label | x5 |
+| main.rs:517:9:517:10 | x6 | semmle.label | x6 |
+| main.rs:517:14:517:23 | source(...) | semmle.label | source(...) |
+| main.rs:517:14:517:27 | ... < ... | semmle.label | ... < ... |
+| main.rs:518:10:518:11 | x6 | semmle.label | x6 |
+| main.rs:523:9:523:10 | x8 | semmle.label | x8 |
+| main.rs:523:9:523:10 | x8 | semmle.label | x8 |
+| main.rs:523:14:523:44 | ...::flow_through2(...) | semmle.label | ...::flow_through2(...) |
+| main.rs:523:14:523:44 | ...::flow_through2(...) | semmle.label | ...::flow_through2(...) |
+| main.rs:523:34:523:43 | source(...) | semmle.label | source(...) |
+| main.rs:523:34:523:43 | source(...) | semmle.label | source(...) |
+| main.rs:524:10:524:11 | x8 | semmle.label | x8 |
+| main.rs:524:10:524:11 | x8 | semmle.label | x8 |
+| main.rs:526:9:526:10 | x9 | semmle.label | x9 |
+| main.rs:526:9:526:10 | x9 | semmle.label | x9 |
+| main.rs:526:14:526:44 | ...::flow_through3(...) | semmle.label | ...::flow_through3(...) |
+| main.rs:526:14:526:44 | ...::flow_through3(...) | semmle.label | ...::flow_through3(...) |
+| main.rs:526:34:526:43 | source(...) | semmle.label | source(...) |
+| main.rs:526:34:526:43 | source(...) | semmle.label | source(...) |
+| main.rs:527:10:527:11 | x9 | semmle.label | x9 |
+| main.rs:527:10:527:11 | x9 | semmle.label | x9 |
+| main.rs:532:9:532:11 | x11 | semmle.label | x11 |
+| main.rs:532:9:532:11 | x11 | semmle.label | x11 |
+| main.rs:532:15:532:32 | ...::produce3(...) | semmle.label | ...::produce3(...) |
+| main.rs:532:15:532:32 | ...::produce3(...) | semmle.label | ...::produce3(...) |
+| main.rs:533:10:533:12 | x11 | semmle.label | x11 |
+| main.rs:533:10:533:12 | x11 | semmle.label | x11 |
+| main.rs:537:20:537:29 | source(...) | semmle.label | source(...) |
+| main.rs:537:20:537:29 | source(...) | semmle.label | source(...) |
+| main.rs:537:20:537:29 | source(...) | semmle.label | source(...) |
+| main.rs:537:20:537:29 | source(...) | semmle.label | source(...) |
+| main.rs:549:10:549:28 | generated_source(...) | semmle.label | generated_source(...) |
+| main.rs:549:10:549:28 | generated_source(...) | semmle.label | generated_source(...) |
+| main.rs:549:10:549:28 | generated_source(...) | semmle.label | generated_source(...) |
+| main.rs:549:10:549:28 | generated_source(...) | semmle.label | generated_source(...) |
+| main.rs:551:10:551:33 | neutral_manual_source(...) | semmle.label | neutral_manual_source(...) |
+| main.rs:551:10:551:33 | neutral_manual_source(...) | semmle.label | neutral_manual_source(...) |
+| main.rs:551:10:551:33 | neutral_manual_source(...) | semmle.label | neutral_manual_source(...) |
+| main.rs:551:10:551:33 | neutral_manual_source(...) | semmle.label | neutral_manual_source(...) |
+| main.rs:552:20:552:28 | source(...) | semmle.label | source(...) |
+| main.rs:552:20:552:28 | source(...) | semmle.label | source(...) |
+| main.rs:552:20:552:28 | source(...) | semmle.label | source(...) |
+| main.rs:552:20:552:28 | source(...) | semmle.label | source(...) |
+| main.rs:554:25:554:33 | source(...) | semmle.label | source(...) |
+| main.rs:554:25:554:33 | source(...) | semmle.label | source(...) |
+| main.rs:554:25:554:33 | source(...) | semmle.label | source(...) |
+| main.rs:554:25:554:33 | source(...) | semmle.label | source(...) |
+| main.rs:555:10:555:37 | generated_summary(...) | semmle.label | generated_summary(...) |
+| main.rs:555:10:555:37 | generated_summary(...) | semmle.label | generated_summary(...) |
+| main.rs:555:28:555:36 | source(...) | semmle.label | source(...) |
+| main.rs:555:28:555:36 | source(...) | semmle.label | source(...) |
+| main.rs:557:10:557:42 | neutral_manual_summary(...) | semmle.label | neutral_manual_summary(...) |
+| main.rs:557:10:557:42 | neutral_manual_summary(...) | semmle.label | neutral_manual_summary(...) |
+| main.rs:557:33:557:41 | source(...) | semmle.label | source(...) |
+| main.rs:557:33:557:41 | source(...) | semmle.label | source(...) |
 subpaths
 | main.rs:214:23:214:23 | f [captured s] | main.rs:213:40:213:40 | s | main.rs:213:17:213:42 | if ... {...} else {...} | main.rs:214:13:214:24 | apply(...) |
 | main.rs:214:23:214:23 | f [captured s] | main.rs:213:40:213:40 | s | main.rs:213:17:213:42 | if ... {...} else {...} | main.rs:214:13:214:24 | apply(...) |
@@ -907,27 +925,31 @@ invalidSpecComponent
 | main.rs:401:10:401:10 | i | main.rs:400:16:400:16 | i | main.rs:401:10:401:10 | i | $@ | main.rs:400:16:400:16 | i | i |
 | main.rs:411:14:411:14 | i | main.rs:410:26:410:31 | ...: i64 | main.rs:411:14:411:14 | i | $@ | main.rs:410:26:410:31 | ...: i64 | ...: i64 |
 | main.rs:411:14:411:14 | i | main.rs:410:26:410:31 | ...: i64 | main.rs:411:14:411:14 | i | $@ | main.rs:410:26:410:31 | ...: i64 | ...: i64 |
-| main.rs:476:10:476:11 | x1 | main.rs:475:14:475:23 | source(...) | main.rs:476:10:476:11 | x1 | $@ | main.rs:475:14:475:23 | source(...) | source(...) |
-| main.rs:476:10:476:11 | x1 | main.rs:475:14:475:23 | source(...) | main.rs:476:10:476:11 | x1 | $@ | main.rs:475:14:475:23 | source(...) | source(...) |
-| main.rs:486:10:486:18 | x2.field1 | main.rs:479:17:479:26 | source(...) | main.rs:486:10:486:18 | x2.field1 | $@ | main.rs:479:17:479:26 | source(...) | source(...) |
-| main.rs:486:10:486:18 | x2.field1 | main.rs:479:17:479:26 | source(...) | main.rs:486:10:486:18 | x2.field1 | $@ | main.rs:479:17:479:26 | source(...) | source(...) |
-| main.rs:492:10:492:11 | x4 | main.rs:491:14:491:23 | source(...) | main.rs:492:10:492:11 | x4 | $@ | main.rs:491:14:491:23 | source(...) | source(...) |
-| main.rs:492:10:492:11 | x4 | main.rs:491:14:491:23 | source(...) | main.rs:492:10:492:11 | x4 | $@ | main.rs:491:14:491:23 | source(...) | source(...) |
-| main.rs:495:10:495:11 | x5 | main.rs:494:14:494:23 | source(...) | main.rs:495:10:495:11 | x5 | $@ | main.rs:494:14:494:23 | source(...) | source(...) |
-| main.rs:498:10:498:11 | x6 | main.rs:497:14:497:23 | source(...) | main.rs:498:10:498:11 | x6 | $@ | main.rs:497:14:497:23 | source(...) | source(...) |
-| main.rs:504:10:504:11 | x8 | main.rs:503:34:503:43 | source(...) | main.rs:504:10:504:11 | x8 | $@ | main.rs:503:34:503:43 | source(...) | source(...) |
-| main.rs:504:10:504:11 | x8 | main.rs:503:34:503:43 | source(...) | main.rs:504:10:504:11 | x8 | $@ | main.rs:503:34:503:43 | source(...) | source(...) |
-| main.rs:507:10:507:11 | x9 | main.rs:506:34:506:43 | source(...) | main.rs:507:10:507:11 | x9 | $@ | main.rs:506:34:506:43 | source(...) | source(...) |
-| main.rs:507:10:507:11 | x9 | main.rs:506:34:506:43 | source(...) | main.rs:507:10:507:11 | x9 | $@ | main.rs:506:34:506:43 | source(...) | source(...) |
-| main.rs:519:10:519:28 | generated_source(...) | main.rs:519:10:519:28 | generated_source(...) | main.rs:519:10:519:28 | generated_source(...) | $@ | main.rs:519:10:519:28 | generated_source(...) | generated_source(...) |
-| main.rs:519:10:519:28 | generated_source(...) | main.rs:519:10:519:28 | generated_source(...) | main.rs:519:10:519:28 | generated_source(...) | $@ | main.rs:519:10:519:28 | generated_source(...) | generated_source(...) |
-| main.rs:521:10:521:33 | neutral_manual_source(...) | main.rs:521:10:521:33 | neutral_manual_source(...) | main.rs:521:10:521:33 | neutral_manual_source(...) | $@ | main.rs:521:10:521:33 | neutral_manual_source(...) | neutral_manual_source(...) |
-| main.rs:521:10:521:33 | neutral_manual_source(...) | main.rs:521:10:521:33 | neutral_manual_source(...) | main.rs:521:10:521:33 | neutral_manual_source(...) | $@ | main.rs:521:10:521:33 | neutral_manual_source(...) | neutral_manual_source(...) |
-| main.rs:522:20:522:28 | source(...) | main.rs:522:20:522:28 | source(...) | main.rs:522:20:522:28 | source(...) | $@ | main.rs:522:20:522:28 | source(...) | source(...) |
-| main.rs:522:20:522:28 | source(...) | main.rs:522:20:522:28 | source(...) | main.rs:522:20:522:28 | source(...) | $@ | main.rs:522:20:522:28 | source(...) | source(...) |
-| main.rs:524:25:524:33 | source(...) | main.rs:524:25:524:33 | source(...) | main.rs:524:25:524:33 | source(...) | $@ | main.rs:524:25:524:33 | source(...) | source(...) |
-| main.rs:524:25:524:33 | source(...) | main.rs:524:25:524:33 | source(...) | main.rs:524:25:524:33 | source(...) | $@ | main.rs:524:25:524:33 | source(...) | source(...) |
-| main.rs:525:10:525:37 | generated_summary(...) | main.rs:525:28:525:36 | source(...) | main.rs:525:10:525:37 | generated_summary(...) | $@ | main.rs:525:28:525:36 | source(...) | source(...) |
-| main.rs:525:10:525:37 | generated_summary(...) | main.rs:525:28:525:36 | source(...) | main.rs:525:10:525:37 | generated_summary(...) | $@ | main.rs:525:28:525:36 | source(...) | source(...) |
-| main.rs:527:10:527:42 | neutral_manual_summary(...) | main.rs:527:33:527:41 | source(...) | main.rs:527:10:527:42 | neutral_manual_summary(...) | $@ | main.rs:527:33:527:41 | source(...) | source(...) |
-| main.rs:527:10:527:42 | neutral_manual_summary(...) | main.rs:527:33:527:41 | source(...) | main.rs:527:10:527:42 | neutral_manual_summary(...) | $@ | main.rs:527:33:527:41 | source(...) | source(...) |
+| main.rs:496:10:496:11 | x1 | main.rs:495:14:495:23 | source(...) | main.rs:496:10:496:11 | x1 | $@ | main.rs:495:14:495:23 | source(...) | source(...) |
+| main.rs:496:10:496:11 | x1 | main.rs:495:14:495:23 | source(...) | main.rs:496:10:496:11 | x1 | $@ | main.rs:495:14:495:23 | source(...) | source(...) |
+| main.rs:506:10:506:18 | x2.field1 | main.rs:499:17:499:26 | source(...) | main.rs:506:10:506:18 | x2.field1 | $@ | main.rs:499:17:499:26 | source(...) | source(...) |
+| main.rs:506:10:506:18 | x2.field1 | main.rs:499:17:499:26 | source(...) | main.rs:506:10:506:18 | x2.field1 | $@ | main.rs:499:17:499:26 | source(...) | source(...) |
+| main.rs:512:10:512:11 | x4 | main.rs:511:14:511:23 | source(...) | main.rs:512:10:512:11 | x4 | $@ | main.rs:511:14:511:23 | source(...) | source(...) |
+| main.rs:512:10:512:11 | x4 | main.rs:511:14:511:23 | source(...) | main.rs:512:10:512:11 | x4 | $@ | main.rs:511:14:511:23 | source(...) | source(...) |
+| main.rs:515:10:515:11 | x5 | main.rs:514:14:514:23 | source(...) | main.rs:515:10:515:11 | x5 | $@ | main.rs:514:14:514:23 | source(...) | source(...) |
+| main.rs:518:10:518:11 | x6 | main.rs:517:14:517:23 | source(...) | main.rs:518:10:518:11 | x6 | $@ | main.rs:517:14:517:23 | source(...) | source(...) |
+| main.rs:524:10:524:11 | x8 | main.rs:523:34:523:43 | source(...) | main.rs:524:10:524:11 | x8 | $@ | main.rs:523:34:523:43 | source(...) | source(...) |
+| main.rs:524:10:524:11 | x8 | main.rs:523:34:523:43 | source(...) | main.rs:524:10:524:11 | x8 | $@ | main.rs:523:34:523:43 | source(...) | source(...) |
+| main.rs:527:10:527:11 | x9 | main.rs:526:34:526:43 | source(...) | main.rs:527:10:527:11 | x9 | $@ | main.rs:526:34:526:43 | source(...) | source(...) |
+| main.rs:527:10:527:11 | x9 | main.rs:526:34:526:43 | source(...) | main.rs:527:10:527:11 | x9 | $@ | main.rs:526:34:526:43 | source(...) | source(...) |
+| main.rs:533:10:533:12 | x11 | main.rs:532:15:532:32 | ...::produce3(...) | main.rs:533:10:533:12 | x11 | $@ | main.rs:532:15:532:32 | ...::produce3(...) | ...::produce3(...) |
+| main.rs:533:10:533:12 | x11 | main.rs:532:15:532:32 | ...::produce3(...) | main.rs:533:10:533:12 | x11 | $@ | main.rs:532:15:532:32 | ...::produce3(...) | ...::produce3(...) |
+| main.rs:537:20:537:29 | source(...) | main.rs:537:20:537:29 | source(...) | main.rs:537:20:537:29 | source(...) | $@ | main.rs:537:20:537:29 | source(...) | source(...) |
+| main.rs:537:20:537:29 | source(...) | main.rs:537:20:537:29 | source(...) | main.rs:537:20:537:29 | source(...) | $@ | main.rs:537:20:537:29 | source(...) | source(...) |
+| main.rs:549:10:549:28 | generated_source(...) | main.rs:549:10:549:28 | generated_source(...) | main.rs:549:10:549:28 | generated_source(...) | $@ | main.rs:549:10:549:28 | generated_source(...) | generated_source(...) |
+| main.rs:549:10:549:28 | generated_source(...) | main.rs:549:10:549:28 | generated_source(...) | main.rs:549:10:549:28 | generated_source(...) | $@ | main.rs:549:10:549:28 | generated_source(...) | generated_source(...) |
+| main.rs:551:10:551:33 | neutral_manual_source(...) | main.rs:551:10:551:33 | neutral_manual_source(...) | main.rs:551:10:551:33 | neutral_manual_source(...) | $@ | main.rs:551:10:551:33 | neutral_manual_source(...) | neutral_manual_source(...) |
+| main.rs:551:10:551:33 | neutral_manual_source(...) | main.rs:551:10:551:33 | neutral_manual_source(...) | main.rs:551:10:551:33 | neutral_manual_source(...) | $@ | main.rs:551:10:551:33 | neutral_manual_source(...) | neutral_manual_source(...) |
+| main.rs:552:20:552:28 | source(...) | main.rs:552:20:552:28 | source(...) | main.rs:552:20:552:28 | source(...) | $@ | main.rs:552:20:552:28 | source(...) | source(...) |
+| main.rs:552:20:552:28 | source(...) | main.rs:552:20:552:28 | source(...) | main.rs:552:20:552:28 | source(...) | $@ | main.rs:552:20:552:28 | source(...) | source(...) |
+| main.rs:554:25:554:33 | source(...) | main.rs:554:25:554:33 | source(...) | main.rs:554:25:554:33 | source(...) | $@ | main.rs:554:25:554:33 | source(...) | source(...) |
+| main.rs:554:25:554:33 | source(...) | main.rs:554:25:554:33 | source(...) | main.rs:554:25:554:33 | source(...) | $@ | main.rs:554:25:554:33 | source(...) | source(...) |
+| main.rs:555:10:555:37 | generated_summary(...) | main.rs:555:28:555:36 | source(...) | main.rs:555:10:555:37 | generated_summary(...) | $@ | main.rs:555:28:555:36 | source(...) | source(...) |
+| main.rs:555:10:555:37 | generated_summary(...) | main.rs:555:28:555:36 | source(...) | main.rs:555:10:555:37 | generated_summary(...) | $@ | main.rs:555:28:555:36 | source(...) | source(...) |
+| main.rs:557:10:557:42 | neutral_manual_summary(...) | main.rs:557:33:557:41 | source(...) | main.rs:557:10:557:42 | neutral_manual_summary(...) | $@ | main.rs:557:33:557:41 | source(...) | source(...) |
+| main.rs:557:10:557:42 | neutral_manual_summary(...) | main.rs:557:33:557:41 | source(...) | main.rs:557:10:557:42 | neutral_manual_summary(...) | $@ | main.rs:557:33:557:41 | source(...) | source(...) |

--- a/rust/ql/test/library-tests/dataflow/models/models.ext.yml
+++ b/rust/ql/test/library-tests/dataflow/models/models.ext.yml
@@ -14,6 +14,8 @@ extensions:
       - ["main::external_file::generated_source", "ReturnValue", "test-source", "dfc-generated"] # not actually generated, but we want to test behaviour of generated models here.
       - ["main::external_file::neutral_generated_source", "ReturnValue", "test-source", "dfc-generated"]
       - ["main::external_file::neutral_manual_source", "ReturnValue", "test-source", "manual"]
+      - ["<main::external_file::MySourceTrait2>::produce2", "ReturnValue", "test-source", "manual"]
+      - ["<_ as main::MySourceTrait3>::produce3", "ReturnValue", "test-source", "manual"]
   - addsTo:
       pack: codeql/rust-all
       extensible: sinkModel
@@ -27,6 +29,8 @@ extensions:
       - ["main::external_file::generated_sink", "Argument[0]", "test-sink", "dfc-generated"]
       - ["main::external_file::neutral_generated_sink", "Argument[0]", "test-sink", "dfc-generated"]
       - ["main::external_file::neutral_manual_sink", "Argument[0]", "test-sink", "manual"]
+      - ["<main::external_file::MySinkTrait2>::consume2", "Argument[0]", "test-sink", "manual"]
+      - ["<_ as main::MySinkTrait3>::consume3", "Argument[0]", "test-sink", "manual"]
   - addsTo:
       pack: codeql/rust-all
       extensible: summaryModel

--- a/rust/ql/test/query-tests/security/CWE-327/WeakSensitiveDataHashing/CryptographicOperations.expected
+++ b/rust/ql/test/query-tests/security/CWE-327/WeakSensitiveDataHashing/CryptographicOperations.expected
@@ -1,10 +1,40 @@
+| test.rs:13:26:13:33 | harmless | HashingAlgorithm MD5 WEAK inputs:1 |
+| test.rs:14:26:14:39 | credit_card_no | HashingAlgorithm MD5 WEAK inputs:1 |
+| test.rs:15:26:15:33 | password | HashingAlgorithm MD5 WEAK inputs:1 |
+| test.rs:16:26:16:43 | encrypted_password | HashingAlgorithm MD5 WEAK inputs:1 |
 | test.rs:19:26:19:33 | harmless | HashingAlgorithm MD5 WEAK inputs:1 |
 | test.rs:20:26:20:39 | credit_card_no | HashingAlgorithm MD5 WEAK inputs:1 |
 | test.rs:21:26:21:33 | password | HashingAlgorithm MD5 WEAK inputs:1 |
 | test.rs:22:26:22:43 | encrypted_password | HashingAlgorithm MD5 WEAK inputs:1 |
+| test.rs:25:28:25:35 | harmless | HashingAlgorithm SHA1 WEAK inputs:1 |
+| test.rs:26:28:26:41 | credit_card_no | HashingAlgorithm SHA1 WEAK inputs:1 |
+| test.rs:27:28:27:35 | password | HashingAlgorithm SHA1 WEAK inputs:1 |
+| test.rs:28:28:28:45 | encrypted_password | HashingAlgorithm SHA1 WEAK inputs:1 |
+| test.rs:31:36:31:43 | harmless | HashingAlgorithm SHA1 WEAK inputs:1 |
+| test.rs:32:36:32:49 | credit_card_no | HashingAlgorithm SHA1 WEAK inputs:1 |
+| test.rs:33:36:33:43 | password | HashingAlgorithm SHA1 WEAK inputs:1 |
+| test.rs:34:36:34:53 | encrypted_password | HashingAlgorithm SHA1 WEAK inputs:1 |
+| test.rs:37:32:37:39 | harmless | HashingAlgorithm SHA3256  inputs:1 |
+| test.rs:38:32:38:45 | credit_card_no | HashingAlgorithm SHA3256  inputs:1 |
+| test.rs:39:32:39:39 | password | HashingAlgorithm SHA3256  inputs:1 |
+| test.rs:40:32:40:49 | encrypted_password | HashingAlgorithm SHA3256  inputs:1 |
+| test.rs:59:26:59:37 | harmless_str | HashingAlgorithm MD5 WEAK inputs:1 |
+| test.rs:60:26:60:37 | password_str | HashingAlgorithm MD5 WEAK inputs:1 |
+| test.rs:61:26:61:37 | harmless_arr | HashingAlgorithm MD5 WEAK inputs:1 |
+| test.rs:62:26:62:37 | password_arr | HashingAlgorithm MD5 WEAK inputs:1 |
+| test.rs:63:26:63:37 | harmless_vec | HashingAlgorithm MD5 WEAK inputs:1 |
+| test.rs:64:26:64:37 | password_vec | HashingAlgorithm MD5 WEAK inputs:1 |
 | test.rs:67:26:67:40 | ...::new(...) | HashingAlgorithm MD5 WEAK  |
 | test.rs:73:9:73:23 | ...::new(...) | HashingAlgorithm MD5 WEAK  |
 | test.rs:74:9:74:23 | ...::new(...) | HashingAlgorithm MD5 WEAK  |
+| test.rs:76:35:76:42 | harmless | HashingAlgorithm MD5 WEAK inputs:1 |
+| test.rs:77:35:77:42 | password | HashingAlgorithm MD5 WEAK inputs:1 |
+| test.rs:80:26:80:40 | harmless.trim() | HashingAlgorithm MD5 WEAK inputs:1 |
+| test.rs:81:26:81:40 | password.trim() | HashingAlgorithm MD5 WEAK inputs:1 |
+| test.rs:82:26:82:44 | harmless.as_bytes() | HashingAlgorithm MD5 WEAK inputs:1 |
+| test.rs:83:26:83:44 | password.as_bytes() | HashingAlgorithm MD5 WEAK inputs:1 |
+| test.rs:84:26:84:67 | ... .unwrap() | HashingAlgorithm MD5 WEAK inputs:1 |
+| test.rs:85:26:85:67 | ... .unwrap() | HashingAlgorithm MD5 WEAK inputs:1 |
 | test.rs:133:26:133:40 | ...::new(...) | HashingAlgorithm MD5 WEAK  |
 | test.rs:156:26:156:40 | ...::new(...) | HashingAlgorithm MD5 WEAK  |
 | test.rs:176:13:176:24 | ...::new(...) | EncryptionAlgorithm SEED   |

--- a/rust/ql/test/query-tests/security/CWE-327/WeakSensitiveDataHashing/WeakSensitiveDataHashing.expected
+++ b/rust/ql/test/query-tests/security/CWE-327/WeakSensitiveDataHashing/WeakSensitiveDataHashing.expected
@@ -1,19 +1,79 @@
 #select
+| test.rs:14:26:14:39 | credit_card_no | test.rs:14:26:14:39 | credit_card_no | test.rs:14:26:14:39 | credit_card_no | $@ is used in a hashing algorithm (MD5) that is insecure. | test.rs:14:26:14:39 | credit_card_no | Sensitive data (private) |
+| test.rs:15:26:15:33 | password | test.rs:15:26:15:33 | password | test.rs:15:26:15:33 | password | $@ is used in a hashing algorithm (MD5) that is insecure for password hashing, since it is not a computationally expensive hash function. | test.rs:15:26:15:33 | password | Sensitive data (password) |
 | test.rs:20:26:20:39 | credit_card_no | test.rs:20:26:20:39 | credit_card_no | test.rs:20:26:20:39 | credit_card_no | $@ is used in a hashing algorithm (MD5) that is insecure. | test.rs:20:26:20:39 | credit_card_no | Sensitive data (private) |
 | test.rs:21:26:21:33 | password | test.rs:21:26:21:33 | password | test.rs:21:26:21:33 | password | $@ is used in a hashing algorithm (MD5) that is insecure for password hashing, since it is not a computationally expensive hash function. | test.rs:21:26:21:33 | password | Sensitive data (password) |
+| test.rs:26:28:26:41 | credit_card_no | test.rs:26:28:26:41 | credit_card_no | test.rs:26:28:26:41 | credit_card_no | $@ is used in a hashing algorithm (SHA1) that is insecure. | test.rs:26:28:26:41 | credit_card_no | Sensitive data (private) |
+| test.rs:27:28:27:35 | password | test.rs:27:28:27:35 | password | test.rs:27:28:27:35 | password | $@ is used in a hashing algorithm (SHA1) that is insecure for password hashing, since it is not a computationally expensive hash function. | test.rs:27:28:27:35 | password | Sensitive data (password) |
+| test.rs:32:36:32:49 | credit_card_no | test.rs:32:36:32:49 | credit_card_no | test.rs:32:36:32:49 | credit_card_no | $@ is used in a hashing algorithm (SHA1) that is insecure. | test.rs:32:36:32:49 | credit_card_no | Sensitive data (private) |
+| test.rs:33:36:33:43 | password | test.rs:33:36:33:43 | password | test.rs:33:36:33:43 | password | $@ is used in a hashing algorithm (SHA1) that is insecure for password hashing, since it is not a computationally expensive hash function. | test.rs:33:36:33:43 | password | Sensitive data (password) |
+| test.rs:39:32:39:39 | password | test.rs:39:32:39:39 | password | test.rs:39:32:39:39 | password | $@ is used in a hashing algorithm (SHA3256) that is insecure for password hashing, since it is not a computationally expensive hash function. | test.rs:39:32:39:39 | password | Sensitive data (password) |
+| test.rs:60:26:60:37 | password_str | test.rs:60:26:60:37 | password_str | test.rs:60:26:60:37 | password_str | $@ is used in a hashing algorithm (MD5) that is insecure for password hashing, since it is not a computationally expensive hash function. | test.rs:60:26:60:37 | password_str | Sensitive data (password) |
+| test.rs:62:26:62:37 | password_arr | test.rs:62:26:62:37 | password_arr | test.rs:62:26:62:37 | password_arr | $@ is used in a hashing algorithm (MD5) that is insecure for password hashing, since it is not a computationally expensive hash function. | test.rs:62:26:62:37 | password_arr | Sensitive data (password) |
+| test.rs:64:26:64:37 | password_vec | test.rs:64:26:64:37 | password_vec | test.rs:64:26:64:37 | password_vec | $@ is used in a hashing algorithm (MD5) that is insecure for password hashing, since it is not a computationally expensive hash function. | test.rs:64:26:64:37 | password_vec | Sensitive data (password) |
+| test.rs:77:35:77:42 | password | test.rs:77:35:77:42 | password | test.rs:77:35:77:42 | password | $@ is used in a hashing algorithm (MD5) that is insecure for password hashing, since it is not a computationally expensive hash function. | test.rs:77:35:77:42 | password | Sensitive data (password) |
+| test.rs:81:26:81:40 | password.trim() | test.rs:81:26:81:33 | password | test.rs:81:26:81:40 | password.trim() | $@ is used in a hashing algorithm (MD5) that is insecure for password hashing, since it is not a computationally expensive hash function. | test.rs:81:26:81:33 | password | Sensitive data (password) |
+| test.rs:83:26:83:44 | password.as_bytes() | test.rs:83:26:83:33 | password | test.rs:83:26:83:44 | password.as_bytes() | $@ is used in a hashing algorithm (MD5) that is insecure for password hashing, since it is not a computationally expensive hash function. | test.rs:83:26:83:33 | password | Sensitive data (password) |
 | test.rs:211:30:211:34 | value | test.rs:226:29:226:36 | password | test.rs:211:30:211:34 | value | $@ is used in a hashing algorithm (MD5) that is insecure for password hashing, since it is not a computationally expensive hash function. | test.rs:226:29:226:36 | password | Sensitive data (password) |
 edges
-| test.rs:20:26:20:39 | credit_card_no | test.rs:20:26:20:39 | credit_card_no | provenance | Sink:MaD:1 |
-| test.rs:21:26:21:33 | password | test.rs:21:26:21:33 | password | provenance | Sink:MaD:1 |
-| test.rs:210:20:210:30 | ...: ... | test.rs:211:30:211:34 | value | provenance | Sink:MaD:1 |
+| test.rs:14:26:14:39 | credit_card_no | test.rs:14:26:14:39 | credit_card_no | provenance | Sink:MaD:1 |
+| test.rs:15:26:15:33 | password | test.rs:15:26:15:33 | password | provenance | Sink:MaD:1 |
+| test.rs:20:26:20:39 | credit_card_no | test.rs:20:26:20:39 | credit_card_no | provenance | Sink:MaD:3 |
+| test.rs:21:26:21:33 | password | test.rs:21:26:21:33 | password | provenance | Sink:MaD:3 |
+| test.rs:26:28:26:41 | credit_card_no | test.rs:26:28:26:41 | credit_card_no | provenance | Sink:MaD:1 |
+| test.rs:27:28:27:35 | password | test.rs:27:28:27:35 | password | provenance | Sink:MaD:1 |
+| test.rs:32:36:32:49 | credit_card_no | test.rs:32:36:32:49 | credit_card_no | provenance | Sink:MaD:1 |
+| test.rs:33:36:33:43 | password | test.rs:33:36:33:43 | password | provenance | Sink:MaD:1 |
+| test.rs:39:32:39:39 | password | test.rs:39:32:39:39 | password | provenance | Sink:MaD:1 |
+| test.rs:60:26:60:37 | password_str | test.rs:60:26:60:37 | password_str | provenance | Sink:MaD:1 |
+| test.rs:62:26:62:37 | password_arr | test.rs:62:26:62:37 | password_arr | provenance | Sink:MaD:1 |
+| test.rs:64:26:64:37 | password_vec | test.rs:64:26:64:37 | password_vec | provenance | Sink:MaD:1 |
+| test.rs:77:35:77:42 | password | test.rs:77:35:77:42 | password | provenance | Sink:MaD:2 |
+| test.rs:81:26:81:33 | password | test.rs:81:26:81:40 | password.trim() [&ref] | provenance | MaD:5 |
+| test.rs:81:26:81:40 | password.trim() [&ref] | test.rs:81:26:81:40 | password.trim() | provenance | Sink:MaD:1 |
+| test.rs:83:26:83:33 | password | test.rs:83:26:83:44 | password.as_bytes() [&ref] | provenance | MaD:4 |
+| test.rs:83:26:83:44 | password.as_bytes() [&ref] | test.rs:83:26:83:44 | password.as_bytes() | provenance | Sink:MaD:1 |
+| test.rs:210:20:210:30 | ...: ... | test.rs:211:30:211:34 | value | provenance | Sink:MaD:3 |
 | test.rs:226:29:226:36 | password | test.rs:210:20:210:30 | ...: ... | provenance |  |
 models
-| 1 | Sink: md5::compute; Argument[0]; hasher-input |
+| 1 | Sink: <digest::digest::Digest>::digest; Argument[0]; hasher-input |
+| 2 | Sink: <digest::digest::Digest>::new_with_prefix; Argument[0]; hasher-input |
+| 3 | Sink: md5::compute; Argument[0]; hasher-input |
+| 4 | Summary: <core::str>::as_bytes; Argument[self].Reference; ReturnValue.Reference; taint |
+| 5 | Summary: <core::str>::trim; Argument[self].Reference; ReturnValue.Reference; taint |
 nodes
+| test.rs:14:26:14:39 | credit_card_no | semmle.label | credit_card_no |
+| test.rs:14:26:14:39 | credit_card_no | semmle.label | credit_card_no |
+| test.rs:15:26:15:33 | password | semmle.label | password |
+| test.rs:15:26:15:33 | password | semmle.label | password |
 | test.rs:20:26:20:39 | credit_card_no | semmle.label | credit_card_no |
 | test.rs:20:26:20:39 | credit_card_no | semmle.label | credit_card_no |
 | test.rs:21:26:21:33 | password | semmle.label | password |
 | test.rs:21:26:21:33 | password | semmle.label | password |
+| test.rs:26:28:26:41 | credit_card_no | semmle.label | credit_card_no |
+| test.rs:26:28:26:41 | credit_card_no | semmle.label | credit_card_no |
+| test.rs:27:28:27:35 | password | semmle.label | password |
+| test.rs:27:28:27:35 | password | semmle.label | password |
+| test.rs:32:36:32:49 | credit_card_no | semmle.label | credit_card_no |
+| test.rs:32:36:32:49 | credit_card_no | semmle.label | credit_card_no |
+| test.rs:33:36:33:43 | password | semmle.label | password |
+| test.rs:33:36:33:43 | password | semmle.label | password |
+| test.rs:39:32:39:39 | password | semmle.label | password |
+| test.rs:39:32:39:39 | password | semmle.label | password |
+| test.rs:60:26:60:37 | password_str | semmle.label | password_str |
+| test.rs:60:26:60:37 | password_str | semmle.label | password_str |
+| test.rs:62:26:62:37 | password_arr | semmle.label | password_arr |
+| test.rs:62:26:62:37 | password_arr | semmle.label | password_arr |
+| test.rs:64:26:64:37 | password_vec | semmle.label | password_vec |
+| test.rs:64:26:64:37 | password_vec | semmle.label | password_vec |
+| test.rs:77:35:77:42 | password | semmle.label | password |
+| test.rs:77:35:77:42 | password | semmle.label | password |
+| test.rs:81:26:81:33 | password | semmle.label | password |
+| test.rs:81:26:81:40 | password.trim() | semmle.label | password.trim() |
+| test.rs:81:26:81:40 | password.trim() [&ref] | semmle.label | password.trim() [&ref] |
+| test.rs:83:26:83:33 | password | semmle.label | password |
+| test.rs:83:26:83:44 | password.as_bytes() | semmle.label | password.as_bytes() |
+| test.rs:83:26:83:44 | password.as_bytes() [&ref] | semmle.label | password.as_bytes() [&ref] |
 | test.rs:210:20:210:30 | ...: ... | semmle.label | ...: ... |
 | test.rs:211:30:211:34 | value | semmle.label | value |
 | test.rs:226:29:226:36 | password | semmle.label | password |

--- a/rust/ql/test/query-tests/security/CWE-327/WeakSensitiveDataHashing/test.rs
+++ b/rust/ql/test/query-tests/security/CWE-327/WeakSensitiveDataHashing/test.rs
@@ -10,10 +10,10 @@ fn test_hash_algorithms(
     // test hashing with different algorithms and data
 
     // MD5
-    _ = md5::Md5::digest(harmless);
-    _ = md5::Md5::digest(credit_card_no); // $ MISSING: Alert[rust/weak-sensitive-data-hashing]
-    _ = md5::Md5::digest(password); // $ MISSING: Alert[rust/weak-sensitive-data-hashing]
-    _ = md5::Md5::digest(encrypted_password);
+    _ = md5::Md5::digest(harmless); // $ Alert[rust/summary/cryptographic-operations]
+    _ = md5::Md5::digest(credit_card_no); // $ Alert[rust/weak-sensitive-data-hashing] Alert[rust/summary/cryptographic-operations]
+    _ = md5::Md5::digest(password); // $ Alert[rust/weak-sensitive-data-hashing] Alert[rust/summary/cryptographic-operations]
+    _ = md5::Md5::digest(encrypted_password); // $ Alert[rust/summary/cryptographic-operations]
 
     // MD5 (alternative / older library)
     _ = md5_alt::compute(harmless); // $ Alert[rust/summary/cryptographic-operations]
@@ -22,22 +22,22 @@ fn test_hash_algorithms(
     _ = md5_alt::compute(encrypted_password); // $ Alert[rust/summary/cryptographic-operations]
 
     // SHA-1
-    _ = sha1::Sha1::digest(harmless);
-    _ = sha1::Sha1::digest(credit_card_no); // $ MISSING: Alert[rust/weak-sensitive-data-hashing]
-    _ = sha1::Sha1::digest(password); // $ MISSING: Alert[rust/weak-sensitive-data-hashing]
-    _ = sha1::Sha1::digest(encrypted_password);
+    _ = sha1::Sha1::digest(harmless); // $ Alert[rust/summary/cryptographic-operations]
+    _ = sha1::Sha1::digest(credit_card_no); // $ Alert[rust/weak-sensitive-data-hashing] Alert[rust/summary/cryptographic-operations]
+    _ = sha1::Sha1::digest(password); // $ Alert[rust/weak-sensitive-data-hashing] Alert[rust/summary/cryptographic-operations]
+    _ = sha1::Sha1::digest(encrypted_password); // $ Alert[rust/summary/cryptographic-operations]
 
     // SHA-1 checked
-    _ = sha1_checked::Sha1::digest(harmless);
-    _ = sha1_checked::Sha1::digest(credit_card_no); // $ MISSING: Alert[rust/weak-sensitive-data-hashing]
-    _ = sha1_checked::Sha1::digest(password); // $ MISSING: Alert[rust/weak-sensitive-data-hashing]
-    _ = sha1_checked::Sha1::digest(encrypted_password);
+    _ = sha1_checked::Sha1::digest(harmless); // $ Alert[rust/summary/cryptographic-operations]
+    _ = sha1_checked::Sha1::digest(credit_card_no); // $ Alert[rust/weak-sensitive-data-hashing] Alert[rust/summary/cryptographic-operations]
+    _ = sha1_checked::Sha1::digest(password); // $ Alert[rust/weak-sensitive-data-hashing] Alert[rust/summary/cryptographic-operations]
+    _ = sha1_checked::Sha1::digest(encrypted_password); // $ Alert[rust/summary/cryptographic-operations]
 
     // SHA-256 (appropriate for sensitive data hashing)
-    _ = sha3::Sha3_256::digest(harmless);
-    _ = sha3::Sha3_256::digest(credit_card_no);
-    _ = sha3::Sha3_256::digest(password); // $ MISSING: Alert[rust/weak-sensitive-data-hashing]
-    _ = sha3::Sha3_256::digest(encrypted_password);
+    _ = sha3::Sha3_256::digest(harmless); // $ Alert[rust/summary/cryptographic-operations]
+    _ = sha3::Sha3_256::digest(credit_card_no); // $  Alert[rust/summary/cryptographic-operations]
+    _ = sha3::Sha3_256::digest(password); // $ Alert[rust/weak-sensitive-data-hashing] Alert[rust/summary/cryptographic-operations]
+    _ = sha3::Sha3_256::digest(encrypted_password); // $ Alert[rust/summary/cryptographic-operations]
 
     // Argon2 (appropriate for password hashing)
     let argon2_salt = argon2::password_hash::Salt::from_b64(salt).unwrap();
@@ -56,12 +56,12 @@ fn test_hash_code_patterns(
     // test hashing with different code patterns
 
     // hash different types of data
-    _ = md5::Md5::digest(harmless_str);
-    _ = md5::Md5::digest(password_str); // $ MISSING: Alert[rust/weak-sensitive-data-hashing]
-    _ = md5::Md5::digest(harmless_arr);
-    _ = md5::Md5::digest(password_arr); // $ MISSING: Alert[rust/weak-sensitive-data-hashing]
-    _ = md5::Md5::digest(harmless_vec);
-    _ = md5::Md5::digest(password_vec); // $ MISSING: Alert[rust/weak-sensitive-data-hashing]
+    _ = md5::Md5::digest(harmless_str); // $ Alert[rust/summary/cryptographic-operations]
+    _ = md5::Md5::digest(password_str); // $ Alert[rust/weak-sensitive-data-hashing] Alert[rust/summary/cryptographic-operations]
+    _ = md5::Md5::digest(harmless_arr); // $ Alert[rust/summary/cryptographic-operations]
+    _ = md5::Md5::digest(password_arr); // $ Alert[rust/weak-sensitive-data-hashing] Alert[rust/summary/cryptographic-operations]
+    _ = md5::Md5::digest(harmless_vec); // $ Alert[rust/summary/cryptographic-operations]
+    _ = md5::Md5::digest(password_vec); // $ Alert[rust/weak-sensitive-data-hashing] Alert[rust/summary/cryptographic-operations]
 
     // hash through a hasher object
     let mut md5_hasher = md5::Md5::new(); // $ Alert[rust/summary/cryptographic-operations]
@@ -73,16 +73,16 @@ fn test_hash_code_patterns(
     _ = md5::Md5::new().chain_update(harmless).chain_update(harmless).chain_update(harmless).finalize(); // $ Alert[rust/summary/cryptographic-operations]
     _ = md5::Md5::new().chain_update(harmless).chain_update(password).chain_update(harmless).finalize(); // $ Alert[rust/summary/cryptographic-operations] MISSING: Alert[rust/weak-sensitive-data-hashing]
 
-    _ = md5::Md5::new_with_prefix(harmless).finalize();
-    _ = md5::Md5::new_with_prefix(password).finalize(); // $ MISSING: Alert[rust/weak-sensitive-data-hashing]
+    _ = md5::Md5::new_with_prefix(harmless).finalize(); // $ Alert[rust/summary/cryptographic-operations]
+    _ = md5::Md5::new_with_prefix(password).finalize(); // $ Alert[rust/weak-sensitive-data-hashing] Alert[rust/summary/cryptographic-operations]
 
     // hash transformed data
-    _ = md5::Md5::digest(harmless.trim());
-    _ = md5::Md5::digest(password.trim()); // $ MISSING: Alert[rust/weak-sensitive-data-hashing]
-    _ = md5::Md5::digest(harmless.as_bytes());
-    _ = md5::Md5::digest(password.as_bytes()); // $ MISSING: Alert[rust/weak-sensitive-data-hashing]
-    _ = md5::Md5::digest(std::str::from_utf8(harmless_arr).unwrap());
-    _ = md5::Md5::digest(std::str::from_utf8(password_arr).unwrap()); // $ MISSING: Alert[rust/weak-sensitive-data-hashing]
+    _ = md5::Md5::digest(harmless.trim()); // $ Alert[rust/summary/cryptographic-operations]
+    _ = md5::Md5::digest(password.trim()); // $ Alert[rust/weak-sensitive-data-hashing] Alert[rust/summary/cryptographic-operations]
+    _ = md5::Md5::digest(harmless.as_bytes()); // $ Alert[rust/summary/cryptographic-operations]
+    _ = md5::Md5::digest(password.as_bytes()); // $ Alert[rust/weak-sensitive-data-hashing] Alert[rust/summary/cryptographic-operations]
+    _ = md5::Md5::digest(std::str::from_utf8(harmless_arr).unwrap()); // $ Alert[rust/summary/cryptographic-operations]
+    _ = md5::Md5::digest(std::str::from_utf8(password_arr).unwrap()); // $ Alert[rust/summary/cryptographic-operations] $ MISSING: Alert[rust/weak-sensitive-data-hashing]
 }
 
 #[derive(Serialize)]

--- a/rust/ql/test/query-tests/security/CWE-798/HardcodedCryptographicValue.expected
+++ b/rust/ql/test/query-tests/security/CWE-798/HardcodedCryptographicValue.expected
@@ -5,7 +5,15 @@
 | test_cipher.rs:37:27:37:74 | [...] | test_cipher.rs:37:27:37:74 | [...] | test_cipher.rs:38:49:38:80 | ...::from_slice(...) | This hard-coded value is used as $@. | test_cipher.rs:38:49:38:80 | ...::from_slice(...) | a key |
 | test_cipher.rs:41:29:41:76 | [...] | test_cipher.rs:41:29:41:76 | [...] | test_cipher.rs:42:49:42:79 | ...::from_slice(...) | This hard-coded value is used as $@. | test_cipher.rs:42:49:42:79 | ...::from_slice(...) | a key |
 | test_cipher.rs:50:37:50:54 | ...::zeroed(...) | test_cipher.rs:50:37:50:54 | ...::zeroed(...) | test_cipher.rs:51:50:51:82 | ...::from_slice(...) | This hard-coded value is used as $@. | test_cipher.rs:51:50:51:82 | ...::from_slice(...) | a key |
+| test_cipher.rs:66:19:66:26 | [0u8; 32] | test_cipher.rs:66:19:66:26 | [0u8; 32] | test_cipher.rs:67:35:67:47 | const2.into() | This hard-coded value is used as $@. | test_cipher.rs:67:35:67:47 | const2.into() | a key |
 | test_cipher.rs:73:19:73:26 | [0u8; 32] | test_cipher.rs:73:19:73:26 | [0u8; 32] | test_cipher.rs:74:46:74:51 | const2 | This hard-coded value is used as $@. | test_cipher.rs:74:46:74:51 | const2 | a key |
+| test_cipher.rs:80:19:80:26 | [0u8; 32] | test_cipher.rs:80:19:80:26 | [0u8; 32] | test_cipher.rs:81:63:81:75 | const6.into() | This hard-coded value is used as $@. | test_cipher.rs:81:63:81:75 | const6.into() | a key |
+| test_cipher.rs:84:19:84:27 | [0u8; 16] | test_cipher.rs:84:19:84:27 | [0u8; 16] | test_cipher.rs:85:75:85:87 | const7.into() | This hard-coded value is used as $@. | test_cipher.rs:85:75:85:87 | const7.into() | an initialization vector |
+| test_cipher.rs:94:23:94:40 | "1234567890123456" | test_cipher.rs:94:23:94:40 | "1234567890123456" | test_cipher.rs:95:63:95:73 | key9.into() | This hard-coded value is used as $@. | test_cipher.rs:95:63:95:73 | key9.into() | a key |
+| test_cipher.rs:124:25:124:30 | [0; 32] | test_cipher.rs:124:25:124:30 | [0; 32] | test_cipher.rs:126:34:126:45 | &... | This hard-coded value is used as $@. | test_cipher.rs:126:34:126:45 | &... | a key |
+| test_cipher.rs:125:18:125:23 | [0; 12] | test_cipher.rs:125:18:125:23 | [0; 12] | test_cipher.rs:127:29:127:42 | &... | This hard-coded value is used as $@. | test_cipher.rs:127:29:127:42 | &... | a nonce |
+| test_cipher.rs:129:33:129:41 | [0xff; 32] | test_cipher.rs:129:33:129:41 | [0xff; 32] | test_cipher.rs:132:34:132:38 | &key3 | This hard-coded value is used as $@. | test_cipher.rs:132:34:132:38 | &key3 | a key |
+| test_cipher.rs:131:27:131:35 | [0xff; 12] | test_cipher.rs:131:27:131:35 | [0xff; 12] | test_cipher.rs:133:29:133:42 | &... | This hard-coded value is used as $@. | test_cipher.rs:133:29:133:42 | &... | a nonce |
 | test_cookie.rs:17:28:17:34 | [0; 64] | test_cookie.rs:17:28:17:34 | [0; 64] | test_cookie.rs:18:26:18:32 | &array1 | This hard-coded value is used as $@. | test_cookie.rs:18:26:18:32 | &array1 | a key |
 | test_cookie.rs:21:28:21:34 | [0; 64] | test_cookie.rs:21:28:21:34 | [0; 64] | test_cookie.rs:22:26:22:32 | &array2 | This hard-coded value is used as $@. | test_cookie.rs:22:26:22:32 | &array2 | a key |
 | test_cookie.rs:25:16:29:5 | match ... { ... } | test_cookie.rs:25:16:29:5 | match ... { ... } | test_cookie.rs:30:26:30:40 | str3.as_bytes() | This hard-coded value is used as $@. | test_cookie.rs:30:26:30:40 | str3.as_bytes() | a key |
@@ -29,61 +37,107 @@ edges
 | test_cipher.rs:18:9:18:14 | const1 [&ref] | test_cipher.rs:19:73:19:78 | const1 [&ref] | provenance |  |
 | test_cipher.rs:18:28:18:36 | &... [&ref] | test_cipher.rs:18:9:18:14 | const1 [&ref] | provenance |  |
 | test_cipher.rs:18:29:18:36 | [0u8; 16] | test_cipher.rs:18:28:18:36 | &... [&ref] | provenance |  |
-| test_cipher.rs:19:49:19:79 | ...::from_slice(...) [&ref] | test_cipher.rs:19:49:19:79 | ...::from_slice(...) | provenance | Sink:MaD:2 |
-| test_cipher.rs:19:73:19:78 | const1 [&ref] | test_cipher.rs:19:49:19:79 | ...::from_slice(...) [&ref] | provenance | MaD:14 |
+| test_cipher.rs:19:49:19:79 | ...::from_slice(...) [&ref] | test_cipher.rs:19:49:19:79 | ...::from_slice(...) | provenance | Sink:MaD:3 |
+| test_cipher.rs:19:73:19:78 | const1 [&ref] | test_cipher.rs:19:49:19:79 | ...::from_slice(...) [&ref] | provenance | MaD:20 |
 | test_cipher.rs:25:9:25:14 | const4 [&ref] | test_cipher.rs:26:66:26:71 | const4 [&ref] | provenance |  |
 | test_cipher.rs:25:28:25:36 | &... [&ref] | test_cipher.rs:25:9:25:14 | const4 [&ref] | provenance |  |
 | test_cipher.rs:25:29:25:36 | [0u8; 16] | test_cipher.rs:25:28:25:36 | &... [&ref] | provenance |  |
-| test_cipher.rs:26:42:26:72 | ...::from_slice(...) [&ref] | test_cipher.rs:26:42:26:72 | ...::from_slice(...) | provenance | Sink:MaD:3 |
-| test_cipher.rs:26:66:26:71 | const4 [&ref] | test_cipher.rs:26:42:26:72 | ...::from_slice(...) [&ref] | provenance | MaD:14 |
+| test_cipher.rs:26:42:26:72 | ...::from_slice(...) [&ref] | test_cipher.rs:26:42:26:72 | ...::from_slice(...) | provenance | Sink:MaD:4 |
+| test_cipher.rs:26:66:26:71 | const4 [&ref] | test_cipher.rs:26:42:26:72 | ...::from_slice(...) [&ref] | provenance | MaD:20 |
 | test_cipher.rs:29:9:29:14 | const5 [&ref] | test_cipher.rs:30:95:30:100 | const5 [&ref] | provenance |  |
 | test_cipher.rs:29:28:29:36 | &... [&ref] | test_cipher.rs:29:9:29:14 | const5 [&ref] | provenance |  |
 | test_cipher.rs:29:29:29:36 | [0u8; 16] | test_cipher.rs:29:28:29:36 | &... [&ref] | provenance |  |
-| test_cipher.rs:30:72:30:101 | ...::from_slice(...) [&ref] | test_cipher.rs:30:72:30:101 | ...::from_slice(...) | provenance | Sink:MaD:4 |
-| test_cipher.rs:30:95:30:100 | const5 [&ref] | test_cipher.rs:30:72:30:101 | ...::from_slice(...) [&ref] | provenance | MaD:14 |
+| test_cipher.rs:30:72:30:101 | ...::from_slice(...) [&ref] | test_cipher.rs:30:72:30:101 | ...::from_slice(...) | provenance | Sink:MaD:5 |
+| test_cipher.rs:30:95:30:100 | const5 [&ref] | test_cipher.rs:30:72:30:101 | ...::from_slice(...) [&ref] | provenance | MaD:20 |
 | test_cipher.rs:37:9:37:14 | const7 | test_cipher.rs:38:74:38:79 | const7 | provenance |  |
 | test_cipher.rs:37:27:37:74 | [...] | test_cipher.rs:37:9:37:14 | const7 | provenance |  |
-| test_cipher.rs:38:49:38:80 | ...::from_slice(...) [&ref] | test_cipher.rs:38:49:38:80 | ...::from_slice(...) | provenance | Sink:MaD:2 |
-| test_cipher.rs:38:73:38:79 | &const7 [&ref] | test_cipher.rs:38:49:38:80 | ...::from_slice(...) [&ref] | provenance | MaD:14 |
+| test_cipher.rs:38:49:38:80 | ...::from_slice(...) [&ref] | test_cipher.rs:38:49:38:80 | ...::from_slice(...) | provenance | Sink:MaD:3 |
+| test_cipher.rs:38:73:38:79 | &const7 [&ref] | test_cipher.rs:38:49:38:80 | ...::from_slice(...) [&ref] | provenance | MaD:20 |
 | test_cipher.rs:38:74:38:79 | const7 | test_cipher.rs:38:73:38:79 | &const7 [&ref] | provenance |  |
 | test_cipher.rs:41:9:41:14 | const8 [&ref] | test_cipher.rs:42:73:42:78 | const8 [&ref] | provenance |  |
 | test_cipher.rs:41:28:41:76 | &... [&ref] | test_cipher.rs:41:9:41:14 | const8 [&ref] | provenance |  |
 | test_cipher.rs:41:29:41:76 | [...] | test_cipher.rs:41:28:41:76 | &... [&ref] | provenance |  |
-| test_cipher.rs:42:49:42:79 | ...::from_slice(...) [&ref] | test_cipher.rs:42:49:42:79 | ...::from_slice(...) | provenance | Sink:MaD:2 |
-| test_cipher.rs:42:73:42:78 | const8 [&ref] | test_cipher.rs:42:49:42:79 | ...::from_slice(...) [&ref] | provenance | MaD:14 |
+| test_cipher.rs:42:49:42:79 | ...::from_slice(...) [&ref] | test_cipher.rs:42:49:42:79 | ...::from_slice(...) | provenance | Sink:MaD:3 |
+| test_cipher.rs:42:73:42:78 | const8 [&ref] | test_cipher.rs:42:49:42:79 | ...::from_slice(...) [&ref] | provenance | MaD:20 |
 | test_cipher.rs:50:9:50:15 | const10 [element] | test_cipher.rs:51:75:51:81 | const10 [element] | provenance |  |
-| test_cipher.rs:50:37:50:54 | ...::zeroed(...) | test_cipher.rs:50:9:50:15 | const10 [element] | provenance | Src:MaD:7  |
-| test_cipher.rs:51:50:51:82 | ...::from_slice(...) [&ref, element] | test_cipher.rs:51:50:51:82 | ...::from_slice(...) | provenance | Sink:MaD:2 Sink:MaD:2 |
-| test_cipher.rs:51:74:51:81 | &const10 [&ref, element] | test_cipher.rs:51:50:51:82 | ...::from_slice(...) [&ref, element] | provenance | MaD:14 |
+| test_cipher.rs:50:37:50:54 | ...::zeroed(...) | test_cipher.rs:50:9:50:15 | const10 [element] | provenance | Src:MaD:11  |
+| test_cipher.rs:51:50:51:82 | ...::from_slice(...) [&ref, element] | test_cipher.rs:51:50:51:82 | ...::from_slice(...) | provenance | Sink:MaD:3 Sink:MaD:3 |
+| test_cipher.rs:51:74:51:81 | &const10 [&ref, element] | test_cipher.rs:51:50:51:82 | ...::from_slice(...) [&ref, element] | provenance | MaD:20 |
 | test_cipher.rs:51:75:51:81 | const10 [element] | test_cipher.rs:51:74:51:81 | &const10 [&ref, element] | provenance |  |
-| test_cipher.rs:73:9:73:14 | const2 [&ref] | test_cipher.rs:74:46:74:51 | const2 | provenance | Sink:MaD:6 |
+| test_cipher.rs:66:9:66:14 | const2 [&ref] | test_cipher.rs:67:35:67:40 | const2 [&ref] | provenance |  |
+| test_cipher.rs:66:18:66:26 | &... [&ref] | test_cipher.rs:66:9:66:14 | const2 [&ref] | provenance |  |
+| test_cipher.rs:66:19:66:26 | [0u8; 32] | test_cipher.rs:66:18:66:26 | &... [&ref] | provenance |  |
+| test_cipher.rs:67:35:67:40 | const2 [&ref] | test_cipher.rs:67:35:67:47 | const2.into() [element] | provenance | MaD:18 |
+| test_cipher.rs:67:35:67:47 | const2.into() [element] | test_cipher.rs:67:35:67:47 | const2.into() | provenance | Sink:MaD:7 |
+| test_cipher.rs:73:9:73:14 | const2 [&ref] | test_cipher.rs:74:46:74:51 | const2 | provenance | Sink:MaD:8 |
 | test_cipher.rs:73:18:73:26 | &... [&ref] | test_cipher.rs:73:9:73:14 | const2 [&ref] | provenance |  |
 | test_cipher.rs:73:19:73:26 | [0u8; 32] | test_cipher.rs:73:18:73:26 | &... [&ref] | provenance |  |
+| test_cipher.rs:80:9:80:14 | const6 [&ref] | test_cipher.rs:81:63:81:68 | const6 [&ref] | provenance |  |
+| test_cipher.rs:80:18:80:26 | &... [&ref] | test_cipher.rs:80:9:80:14 | const6 [&ref] | provenance |  |
+| test_cipher.rs:80:19:80:26 | [0u8; 32] | test_cipher.rs:80:18:80:26 | &... [&ref] | provenance |  |
+| test_cipher.rs:81:63:81:68 | const6 [&ref] | test_cipher.rs:81:63:81:75 | const6.into() [element] | provenance | MaD:18 |
+| test_cipher.rs:81:63:81:75 | const6.into() [element] | test_cipher.rs:81:63:81:75 | const6.into() | provenance | Sink:MaD:9 |
+| test_cipher.rs:84:9:84:14 | const7 [&ref] | test_cipher.rs:85:75:85:80 | const7 [&ref] | provenance |  |
+| test_cipher.rs:84:18:84:27 | &... [&ref] | test_cipher.rs:84:9:84:14 | const7 [&ref] | provenance |  |
+| test_cipher.rs:84:19:84:27 | [0u8; 16] | test_cipher.rs:84:18:84:27 | &... [&ref] | provenance |  |
+| test_cipher.rs:85:75:85:80 | const7 [&ref] | test_cipher.rs:85:75:85:87 | const7.into() [element] | provenance | MaD:18 |
+| test_cipher.rs:85:75:85:87 | const7.into() [element] | test_cipher.rs:85:75:85:87 | const7.into() | provenance | Sink:MaD:10 |
+| test_cipher.rs:94:9:94:12 | key9 [&ref] | test_cipher.rs:95:63:95:66 | key9 [&ref] | provenance |  |
+| test_cipher.rs:94:23:94:40 | "1234567890123456" | test_cipher.rs:94:23:94:51 | "1234567890123456".as_bytes() [&ref] | provenance | MaD:19 |
+| test_cipher.rs:94:23:94:51 | "1234567890123456".as_bytes() [&ref] | test_cipher.rs:94:9:94:12 | key9 [&ref] | provenance |  |
+| test_cipher.rs:95:63:95:66 | key9 [&ref] | test_cipher.rs:95:63:95:73 | key9.into() [element] | provenance | MaD:18 |
+| test_cipher.rs:95:63:95:73 | key9.into() [element] | test_cipher.rs:95:63:95:73 | key9.into() | provenance | Sink:MaD:9 |
+| test_cipher.rs:124:9:124:12 | key2 | test_cipher.rs:126:35:126:38 | key2 | provenance |  |
+| test_cipher.rs:124:25:124:30 | [0; 32] | test_cipher.rs:124:9:124:12 | key2 | provenance |  |
+| test_cipher.rs:125:9:125:14 | nonce2 | test_cipher.rs:127:30:127:35 | nonce2 | provenance |  |
+| test_cipher.rs:125:18:125:23 | [0; 12] | test_cipher.rs:125:9:125:14 | nonce2 | provenance |  |
+| test_cipher.rs:126:34:126:45 | &... [&ref, element] | test_cipher.rs:126:34:126:45 | &... | provenance | Sink:MaD:7 Sink:MaD:7 |
+| test_cipher.rs:126:35:126:38 | key2 | test_cipher.rs:126:35:126:45 | key2.into() [element] | provenance | MaD:17 |
+| test_cipher.rs:126:35:126:38 | key2 | test_cipher.rs:126:35:126:45 | key2.into() [element] | provenance | MaD:18 |
+| test_cipher.rs:126:35:126:45 | key2.into() [element] | test_cipher.rs:126:34:126:45 | &... [&ref, element] | provenance |  |
+| test_cipher.rs:127:29:127:42 | &... [&ref, element] | test_cipher.rs:127:29:127:42 | &... | provenance | Sink:MaD:1 Sink:MaD:1 |
+| test_cipher.rs:127:30:127:35 | nonce2 | test_cipher.rs:127:30:127:42 | nonce2.into() [element] | provenance | MaD:17 |
+| test_cipher.rs:127:30:127:35 | nonce2 | test_cipher.rs:127:30:127:42 | nonce2.into() [element] | provenance | MaD:18 |
+| test_cipher.rs:127:30:127:42 | nonce2.into() [element] | test_cipher.rs:127:29:127:42 | &... [&ref, element] | provenance |  |
+| test_cipher.rs:129:9:129:18 | key3_array [&ref] | test_cipher.rs:130:45:130:54 | key3_array [&ref] | provenance |  |
+| test_cipher.rs:129:32:129:41 | &... [&ref] | test_cipher.rs:129:9:129:18 | key3_array [&ref] | provenance |  |
+| test_cipher.rs:129:33:129:41 | [0xff; 32] | test_cipher.rs:129:32:129:41 | &... [&ref] | provenance |  |
+| test_cipher.rs:130:9:130:12 | key3 [&ref] | test_cipher.rs:132:35:132:38 | key3 [&ref] | provenance |  |
+| test_cipher.rs:130:16:130:55 | ...::from_slice(...) [&ref] | test_cipher.rs:130:9:130:12 | key3 [&ref] | provenance |  |
+| test_cipher.rs:130:45:130:54 | key3_array [&ref] | test_cipher.rs:130:16:130:55 | ...::from_slice(...) [&ref] | provenance | MaD:20 |
+| test_cipher.rs:131:9:131:14 | nonce3 | test_cipher.rs:133:30:133:35 | nonce3 | provenance |  |
+| test_cipher.rs:131:27:131:35 | [0xff; 12] | test_cipher.rs:131:9:131:14 | nonce3 | provenance |  |
+| test_cipher.rs:132:34:132:38 | &key3 [&ref, &ref] | test_cipher.rs:132:34:132:38 | &key3 | provenance | Sink:MaD:7 Sink:MaD:7 |
+| test_cipher.rs:132:35:132:38 | key3 [&ref] | test_cipher.rs:132:34:132:38 | &key3 [&ref, &ref] | provenance |  |
+| test_cipher.rs:133:29:133:42 | &... [&ref, element] | test_cipher.rs:133:29:133:42 | &... | provenance | Sink:MaD:1 Sink:MaD:1 |
+| test_cipher.rs:133:30:133:35 | nonce3 | test_cipher.rs:133:30:133:42 | nonce3.into() [element] | provenance | MaD:17 |
+| test_cipher.rs:133:30:133:35 | nonce3 | test_cipher.rs:133:30:133:42 | nonce3.into() [element] | provenance | MaD:18 |
+| test_cipher.rs:133:30:133:42 | nonce3.into() [element] | test_cipher.rs:133:29:133:42 | &... [&ref, element] | provenance |  |
 | test_cookie.rs:17:9:17:14 | array1 | test_cookie.rs:18:27:18:32 | array1 | provenance |  |
 | test_cookie.rs:17:28:17:34 | [0; 64] | test_cookie.rs:17:9:17:14 | array1 | provenance |  |
-| test_cookie.rs:18:26:18:32 | &array1 [&ref] | test_cookie.rs:18:26:18:32 | &array1 | provenance | Sink:MaD:5 |
+| test_cookie.rs:18:26:18:32 | &array1 [&ref] | test_cookie.rs:18:26:18:32 | &array1 | provenance | Sink:MaD:6 |
 | test_cookie.rs:18:27:18:32 | array1 | test_cookie.rs:18:26:18:32 | &array1 [&ref] | provenance |  |
 | test_cookie.rs:21:9:21:14 | array2 | test_cookie.rs:22:27:22:32 | array2 | provenance |  |
 | test_cookie.rs:21:28:21:34 | [0; 64] | test_cookie.rs:21:9:21:14 | array2 | provenance |  |
-| test_cookie.rs:22:26:22:32 | &array2 [&ref] | test_cookie.rs:22:26:22:32 | &array2 | provenance | Sink:MaD:5 |
+| test_cookie.rs:22:26:22:32 | &array2 [&ref] | test_cookie.rs:22:26:22:32 | &array2 | provenance | Sink:MaD:6 |
 | test_cookie.rs:22:27:22:32 | array2 | test_cookie.rs:22:26:22:32 | &array2 [&ref] | provenance |  |
 | test_cookie.rs:25:9:25:12 | str3 | test_cookie.rs:30:26:30:29 | str3 | provenance |  |
 | test_cookie.rs:25:16:29:5 | match ... { ... } | test_cookie.rs:25:9:25:12 | str3 | provenance |  |
-| test_cookie.rs:30:26:30:29 | str3 | test_cookie.rs:30:26:30:40 | str3.as_bytes() [&ref] | provenance | MaD:13 |
-| test_cookie.rs:30:26:30:40 | str3.as_bytes() [&ref] | test_cookie.rs:30:26:30:40 | str3.as_bytes() | provenance | Sink:MaD:5 |
+| test_cookie.rs:30:26:30:29 | str3 | test_cookie.rs:30:26:30:40 | str3.as_bytes() [&ref] | provenance | MaD:19 |
+| test_cookie.rs:30:26:30:40 | str3.as_bytes() [&ref] | test_cookie.rs:30:26:30:40 | str3.as_bytes() | provenance | Sink:MaD:6 |
 | test_cookie.rs:33:9:33:14 | array4 | test_cookie.rs:38:27:38:32 | array4 | provenance |  |
 | test_cookie.rs:33:27:37:5 | [...] | test_cookie.rs:33:9:33:14 | array4 | provenance |  |
-| test_cookie.rs:38:26:38:32 | &array4 [&ref] | test_cookie.rs:38:26:38:32 | &array4 | provenance | Sink:MaD:5 |
+| test_cookie.rs:38:26:38:32 | &array4 [&ref] | test_cookie.rs:38:26:38:32 | &array4 | provenance | Sink:MaD:6 |
 | test_cookie.rs:38:27:38:32 | array4 | test_cookie.rs:38:26:38:32 | &array4 [&ref] | provenance |  |
-| test_cookie.rs:54:9:54:14 | array2 | test_cookie.rs:58:34:58:39 | array2 | provenance | Sink:MaD:1 |
+| test_cookie.rs:54:9:54:14 | array2 | test_cookie.rs:58:34:58:39 | array2 | provenance | Sink:MaD:2 |
 | test_cookie.rs:54:18:54:37 | ...::from(...) | test_cookie.rs:54:9:54:14 | array2 | provenance |  |
-| test_cookie.rs:54:28:54:36 | [0u8; 64] | test_cookie.rs:54:18:54:37 | ...::from(...) | provenance | MaD:8 |
-| test_cookie.rs:54:28:54:36 | [0u8; 64] | test_cookie.rs:54:18:54:37 | ...::from(...) | provenance | MaD:9 |
-| test_cookie.rs:54:28:54:36 | [0u8; 64] | test_cookie.rs:54:18:54:37 | ...::from(...) | provenance | MaD:10 |
-| test_cookie.rs:54:28:54:36 | [0u8; 64] | test_cookie.rs:54:18:54:37 | ...::from(...) | provenance | MaD:11 |
 | test_cookie.rs:54:28:54:36 | [0u8; 64] | test_cookie.rs:54:18:54:37 | ...::from(...) | provenance | MaD:12 |
-| test_cookie.rs:65:9:65:14 | array3 [element] | test_cookie.rs:69:34:69:39 | array3 | provenance | Sink:MaD:1 |
-| test_cookie.rs:65:23:65:25 | 0u8 | test_cookie.rs:65:23:65:29 | ...::from_elem(...) [element] | provenance | MaD:15 |
+| test_cookie.rs:54:28:54:36 | [0u8; 64] | test_cookie.rs:54:18:54:37 | ...::from(...) | provenance | MaD:13 |
+| test_cookie.rs:54:28:54:36 | [0u8; 64] | test_cookie.rs:54:18:54:37 | ...::from(...) | provenance | MaD:14 |
+| test_cookie.rs:54:28:54:36 | [0u8; 64] | test_cookie.rs:54:18:54:37 | ...::from(...) | provenance | MaD:15 |
+| test_cookie.rs:54:28:54:36 | [0u8; 64] | test_cookie.rs:54:18:54:37 | ...::from(...) | provenance | MaD:16 |
+| test_cookie.rs:65:9:65:14 | array3 [element] | test_cookie.rs:69:34:69:39 | array3 | provenance | Sink:MaD:2 |
+| test_cookie.rs:65:23:65:25 | 0u8 | test_cookie.rs:65:23:65:29 | ...::from_elem(...) [element] | provenance | MaD:21 |
 | test_cookie.rs:65:23:65:29 | ...::from_elem(...) [element] | test_cookie.rs:65:9:65:14 | array3 [element] | provenance |  |
 | test_heuristic.rs:38:25:38:30 | 0xFFFF | test_heuristic.rs:81:22:81:31 | MY_CONST_1 | provenance |  |
 | test_heuristic.rs:39:25:39:59 | ... as u64 | test_heuristic.rs:82:22:82:31 | MY_CONST_2 | provenance |  |
@@ -97,21 +151,27 @@ edges
 | test_heuristic.rs:86:29:86:32 | 1u64 | test_heuristic.rs:87:22:87:31 | MY_CONST_5 | provenance |  |
 | test_heuristic.rs:88:29:88:33 | ... + ... | test_heuristic.rs:89:22:89:31 | MY_CONST_6 | provenance |  |
 models
-| 1 | Sink: <biscotti::crypto::master::Key>::from; Argument[0]; credentials-key |
-| 2 | Sink: <cipher::stream_wrapper::StreamCipherCoreWrapper as crypto_common::KeyInit>::new; Argument[0]; credentials-key |
-| 3 | Sink: <cipher::stream_wrapper::StreamCipherCoreWrapper as crypto_common::KeyIvInit>::new; Argument[0]; credentials-key |
-| 4 | Sink: <cipher::stream_wrapper::StreamCipherCoreWrapper as crypto_common::KeyIvInit>::new; Argument[1]; credentials-iv |
-| 5 | Sink: <cookie::secure::key::Key>::from; Argument[0].Reference; credentials-key |
-| 6 | Sink: <crypto_common::KeyInit>::new_from_slice; Argument[0]; credentials-key |
-| 7 | Source: core::mem::zeroed; ReturnValue.Element; constant-source |
-| 8 | Summary: <alloc::vec::Vec as core::convert::From>::from; Argument[0].Field[alloc::borrow::Cow::Owned(0)]; ReturnValue; value |
-| 9 | Summary: <alloc::vec::Vec as core::convert::From>::from; Argument[0].Field[alloc::bstr::ByteString(0)]; ReturnValue; value |
-| 10 | Summary: <alloc::vec::Vec as core::convert::From>::from; Argument[0].Field[alloc::collections::binary_heap::BinaryHeap::data]; ReturnValue; value |
-| 11 | Summary: <alloc::vec::Vec as core::convert::From>::from; Argument[0].Field[alloc::string::String::vec]; ReturnValue; value |
-| 12 | Summary: <alloc::vec::Vec as core::convert::From>::from; Argument[0]; ReturnValue; taint |
-| 13 | Summary: <core::str>::as_bytes; Argument[self].Reference; ReturnValue.Reference; taint |
-| 14 | Summary: <generic_array::GenericArray>::from_slice; Argument[0].Reference; ReturnValue.Reference; value |
-| 15 | Summary: alloc::vec::from_elem; Argument[0]; ReturnValue.Element; value |
+| 1 | Sink: <aead::Aead>::encrypt; Argument[0]; credentials-nonce |
+| 2 | Sink: <biscotti::crypto::master::Key>::from; Argument[0]; credentials-key |
+| 3 | Sink: <cipher::stream_wrapper::StreamCipherCoreWrapper as crypto_common::KeyInit>::new; Argument[0]; credentials-key |
+| 4 | Sink: <cipher::stream_wrapper::StreamCipherCoreWrapper as crypto_common::KeyIvInit>::new; Argument[0]; credentials-key |
+| 5 | Sink: <cipher::stream_wrapper::StreamCipherCoreWrapper as crypto_common::KeyIvInit>::new; Argument[1]; credentials-iv |
+| 6 | Sink: <cookie::secure::key::Key>::from; Argument[0].Reference; credentials-key |
+| 7 | Sink: <crypto_common::KeyInit>::new; Argument[0]; credentials-key |
+| 8 | Sink: <crypto_common::KeyInit>::new_from_slice; Argument[0]; credentials-key |
+| 9 | Sink: <crypto_common::KeyIvInit>::new; Argument[0]; credentials-key |
+| 10 | Sink: <crypto_common::KeyIvInit>::new; Argument[1]; credentials-iv |
+| 11 | Source: core::mem::zeroed; ReturnValue.Element; constant-source |
+| 12 | Summary: <alloc::vec::Vec as core::convert::From>::from; Argument[0].Field[alloc::borrow::Cow::Owned(0)]; ReturnValue; value |
+| 13 | Summary: <alloc::vec::Vec as core::convert::From>::from; Argument[0].Field[alloc::bstr::ByteString(0)]; ReturnValue; value |
+| 14 | Summary: <alloc::vec::Vec as core::convert::From>::from; Argument[0].Field[alloc::collections::binary_heap::BinaryHeap::data]; ReturnValue; value |
+| 15 | Summary: <alloc::vec::Vec as core::convert::From>::from; Argument[0].Field[alloc::string::String::vec]; ReturnValue; value |
+| 16 | Summary: <alloc::vec::Vec as core::convert::From>::from; Argument[0]; ReturnValue; taint |
+| 17 | Summary: <core::convert::Into>::into; Argument[self].Element; ReturnValue.Element; taint |
+| 18 | Summary: <core::convert::Into>::into; Argument[self].Reference.Element; ReturnValue.Element; taint |
+| 19 | Summary: <core::str>::as_bytes; Argument[self].Reference; ReturnValue.Reference; taint |
+| 20 | Summary: <generic_array::GenericArray>::from_slice; Argument[0].Reference; ReturnValue.Reference; value |
+| 21 | Summary: alloc::vec::from_elem; Argument[0]; ReturnValue.Element; value |
 nodes
 | test_cipher.rs:18:9:18:14 | const1 [&ref] | semmle.label | const1 [&ref] |
 | test_cipher.rs:18:28:18:36 | &... [&ref] | semmle.label | &... [&ref] |
@@ -149,10 +209,61 @@ nodes
 | test_cipher.rs:51:50:51:82 | ...::from_slice(...) [&ref, element] | semmle.label | ...::from_slice(...) [&ref, element] |
 | test_cipher.rs:51:74:51:81 | &const10 [&ref, element] | semmle.label | &const10 [&ref, element] |
 | test_cipher.rs:51:75:51:81 | const10 [element] | semmle.label | const10 [element] |
+| test_cipher.rs:66:9:66:14 | const2 [&ref] | semmle.label | const2 [&ref] |
+| test_cipher.rs:66:18:66:26 | &... [&ref] | semmle.label | &... [&ref] |
+| test_cipher.rs:66:19:66:26 | [0u8; 32] | semmle.label | [0u8; 32] |
+| test_cipher.rs:67:35:67:40 | const2 [&ref] | semmle.label | const2 [&ref] |
+| test_cipher.rs:67:35:67:47 | const2.into() | semmle.label | const2.into() |
+| test_cipher.rs:67:35:67:47 | const2.into() [element] | semmle.label | const2.into() [element] |
 | test_cipher.rs:73:9:73:14 | const2 [&ref] | semmle.label | const2 [&ref] |
 | test_cipher.rs:73:18:73:26 | &... [&ref] | semmle.label | &... [&ref] |
 | test_cipher.rs:73:19:73:26 | [0u8; 32] | semmle.label | [0u8; 32] |
 | test_cipher.rs:74:46:74:51 | const2 | semmle.label | const2 |
+| test_cipher.rs:80:9:80:14 | const6 [&ref] | semmle.label | const6 [&ref] |
+| test_cipher.rs:80:18:80:26 | &... [&ref] | semmle.label | &... [&ref] |
+| test_cipher.rs:80:19:80:26 | [0u8; 32] | semmle.label | [0u8; 32] |
+| test_cipher.rs:81:63:81:68 | const6 [&ref] | semmle.label | const6 [&ref] |
+| test_cipher.rs:81:63:81:75 | const6.into() | semmle.label | const6.into() |
+| test_cipher.rs:81:63:81:75 | const6.into() [element] | semmle.label | const6.into() [element] |
+| test_cipher.rs:84:9:84:14 | const7 [&ref] | semmle.label | const7 [&ref] |
+| test_cipher.rs:84:18:84:27 | &... [&ref] | semmle.label | &... [&ref] |
+| test_cipher.rs:84:19:84:27 | [0u8; 16] | semmle.label | [0u8; 16] |
+| test_cipher.rs:85:75:85:80 | const7 [&ref] | semmle.label | const7 [&ref] |
+| test_cipher.rs:85:75:85:87 | const7.into() | semmle.label | const7.into() |
+| test_cipher.rs:85:75:85:87 | const7.into() [element] | semmle.label | const7.into() [element] |
+| test_cipher.rs:94:9:94:12 | key9 [&ref] | semmle.label | key9 [&ref] |
+| test_cipher.rs:94:23:94:40 | "1234567890123456" | semmle.label | "1234567890123456" |
+| test_cipher.rs:94:23:94:51 | "1234567890123456".as_bytes() [&ref] | semmle.label | "1234567890123456".as_bytes() [&ref] |
+| test_cipher.rs:95:63:95:66 | key9 [&ref] | semmle.label | key9 [&ref] |
+| test_cipher.rs:95:63:95:73 | key9.into() | semmle.label | key9.into() |
+| test_cipher.rs:95:63:95:73 | key9.into() [element] | semmle.label | key9.into() [element] |
+| test_cipher.rs:124:9:124:12 | key2 | semmle.label | key2 |
+| test_cipher.rs:124:25:124:30 | [0; 32] | semmle.label | [0; 32] |
+| test_cipher.rs:125:9:125:14 | nonce2 | semmle.label | nonce2 |
+| test_cipher.rs:125:18:125:23 | [0; 12] | semmle.label | [0; 12] |
+| test_cipher.rs:126:34:126:45 | &... | semmle.label | &... |
+| test_cipher.rs:126:34:126:45 | &... [&ref, element] | semmle.label | &... [&ref, element] |
+| test_cipher.rs:126:35:126:38 | key2 | semmle.label | key2 |
+| test_cipher.rs:126:35:126:45 | key2.into() [element] | semmle.label | key2.into() [element] |
+| test_cipher.rs:127:29:127:42 | &... | semmle.label | &... |
+| test_cipher.rs:127:29:127:42 | &... [&ref, element] | semmle.label | &... [&ref, element] |
+| test_cipher.rs:127:30:127:35 | nonce2 | semmle.label | nonce2 |
+| test_cipher.rs:127:30:127:42 | nonce2.into() [element] | semmle.label | nonce2.into() [element] |
+| test_cipher.rs:129:9:129:18 | key3_array [&ref] | semmle.label | key3_array [&ref] |
+| test_cipher.rs:129:32:129:41 | &... [&ref] | semmle.label | &... [&ref] |
+| test_cipher.rs:129:33:129:41 | [0xff; 32] | semmle.label | [0xff; 32] |
+| test_cipher.rs:130:9:130:12 | key3 [&ref] | semmle.label | key3 [&ref] |
+| test_cipher.rs:130:16:130:55 | ...::from_slice(...) [&ref] | semmle.label | ...::from_slice(...) [&ref] |
+| test_cipher.rs:130:45:130:54 | key3_array [&ref] | semmle.label | key3_array [&ref] |
+| test_cipher.rs:131:9:131:14 | nonce3 | semmle.label | nonce3 |
+| test_cipher.rs:131:27:131:35 | [0xff; 12] | semmle.label | [0xff; 12] |
+| test_cipher.rs:132:34:132:38 | &key3 | semmle.label | &key3 |
+| test_cipher.rs:132:34:132:38 | &key3 [&ref, &ref] | semmle.label | &key3 [&ref, &ref] |
+| test_cipher.rs:132:35:132:38 | key3 [&ref] | semmle.label | key3 [&ref] |
+| test_cipher.rs:133:29:133:42 | &... | semmle.label | &... |
+| test_cipher.rs:133:29:133:42 | &... [&ref, element] | semmle.label | &... [&ref, element] |
+| test_cipher.rs:133:30:133:35 | nonce3 | semmle.label | nonce3 |
+| test_cipher.rs:133:30:133:42 | nonce3.into() [element] | semmle.label | nonce3.into() [element] |
 | test_cookie.rs:17:9:17:14 | array1 | semmle.label | array1 |
 | test_cookie.rs:17:28:17:34 | [0; 64] | semmle.label | [0; 64] |
 | test_cookie.rs:18:26:18:32 | &array1 | semmle.label | &array1 |

--- a/rust/ql/test/query-tests/security/CWE-798/test_cipher.rs
+++ b/rust/ql/test/query-tests/security/CWE-798/test_cipher.rs
@@ -63,8 +63,8 @@ fn test_block_cipher_aes(
     let aes_cipher1 = Aes256::new(key256.into());
     aes_cipher1.encrypt_block(block128.into());
 
-    let const2 = &[0u8;32]; // $ MISSING: Alert[rust/hard-coded-cryptographic-value]
-    let aes_cipher2 = Aes256::new(const2.into()); // $ MISSING: Sink
+    let const2 = &[0u8;32]; // $ Alert[rust/hard-coded-cryptographic-value]
+    let aes_cipher2 = Aes256::new(const2.into()); // $ Sink
     aes_cipher2.encrypt_block(block128.into());
 
     let aes_cipher3 = Aes256::new_from_slice(key256).unwrap();
@@ -77,12 +77,12 @@ fn test_block_cipher_aes(
     let aes_cipher5 = cfb_mode::Encryptor::<aes::Aes256>::new(key.into(), iv.into());
     _ = aes_cipher5.encrypt_b2b(input, output).unwrap();
 
-    let const6 = &[0u8;32]; // $ MISSING: Alert[rust/hard-coded-cryptographic-value]
-    let aes_cipher6 = cfb_mode::Encryptor::<aes::Aes256>::new(const6.into(), iv.into()); // $ MISSING: Sink
+    let const6 = &[0u8;32]; // $ Alert[rust/hard-coded-cryptographic-value]
+    let aes_cipher6 = cfb_mode::Encryptor::<aes::Aes256>::new(const6.into(), iv.into()); // $ Sink
     _ = aes_cipher6.encrypt_b2b(input, output).unwrap();
 
-    let const7 = &[0u8; 16]; // $ MISSING: Alert[rust/hard-coded-cryptographic-value]
-    let aes_cipher7 = cfb_mode::Encryptor::<aes::Aes256>::new(key.into(), const7.into()); // $ MISSING: Sink
+    let const7 = &[0u8; 16]; // $ Alert[rust/hard-coded-cryptographic-value]
+    let aes_cipher7 = cfb_mode::Encryptor::<aes::Aes256>::new(key.into(), const7.into()); // $ Sink
     _ = aes_cipher7.encrypt_b2b(input, output).unwrap();
 
     // various string conversions
@@ -91,8 +91,8 @@ fn test_block_cipher_aes(
     let aes_cipher8 = cfb_mode::Encryptor::<aes::Aes256>::new(key8.into(), iv.into());
     _ = aes_cipher8.encrypt_b2b(input, output).unwrap();
 
-    let key9: &[u8] = "1234567890123456".as_bytes(); // $ MISSING: Alert[rust/hard-coded-cryptographic-value]
-    let aes_cipher9 = cfb_mode::Encryptor::<aes::Aes256>::new(key9.into(), iv.into());
+    let key9: &[u8] = "1234567890123456".as_bytes(); // $ Alert[rust/hard-coded-cryptographic-value]
+    let aes_cipher9 = cfb_mode::Encryptor::<aes::Aes256>::new(key9.into(), iv.into()); // $ Sink
     _ = aes_cipher9.encrypt_b2b(input, output).unwrap();
 
     let key10: [u8; 32] = match base64::engine::general_purpose::STANDARD.decode(key_str) {
@@ -121,16 +121,16 @@ fn test_aes_gcm(
     let cipher1 = Aes256Gcm::new(&key1);
     let _ = cipher1.encrypt(&nonce1, b"plaintext".as_ref()).unwrap();
 
-    let key2: [u8;32] = [0;32]; // $ MISSING: Alert[rust/hard-coded-cryptographic-value]
-    let nonce2 = [0;12]; // $ MISSING: Alert[rust/hard-coded-cryptographic-value]
-    let cipher2 = Aes256Gcm::new(&key2.into()); // $ MISSING: Sink
-    let _ = cipher2.encrypt(&nonce2.into(), b"plaintext".as_ref()).unwrap(); // $ MISSING: Sink
+    let key2: [u8;32] = [0;32]; // $ Alert[rust/hard-coded-cryptographic-value]
+    let nonce2 = [0;12]; // $ Alert[rust/hard-coded-cryptographic-value]
+    let cipher2 = Aes256Gcm::new(&key2.into()); // $ Sink
+    let _ = cipher2.encrypt(&nonce2.into(), b"plaintext".as_ref()).unwrap(); // $ Sink
 
-    let key3_array: &[u8;32] = &[0xff;32]; // $ MISSING: Alert[rust/hard-coded-cryptographic-value]
+    let key3_array: &[u8;32] = &[0xff;32]; // $ Alert[rust/hard-coded-cryptographic-value]
     let key3 = Key::<Aes256Gcm>::from_slice(key3_array);
-    let nonce3: [u8;12] = [0xff;12]; // $ MISSING: Alert[rust/hard-coded-cryptographic-value]
-    let cipher3 = Aes256Gcm::new(&key3); // $ MISSING: Sink
-    let _ = cipher3.encrypt(&nonce3.into(), b"plaintext".as_ref()).unwrap(); // $ MISSING: Sink
+    let nonce3: [u8;12] = [0xff;12]; // $ Alert[rust/hard-coded-cryptographic-value]
+    let cipher3 = Aes256Gcm::new(&key3); // $ Sink
+    let _ = cipher3.encrypt(&nonce3.into(), b"plaintext".as_ref()).unwrap(); // $ Sink
 
     // with barrier
 

--- a/shared/dataflow/codeql/dataflow/internal/FlowSummaryImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/FlowSummaryImpl.qll
@@ -29,28 +29,6 @@ signature module InputSig<LocationSig Location, DF::InputSig<Location> Lang> {
   predicate callableFromSource(SummarizedCallableBase c);
 
   /**
-   * A base class of elements that are candidates for flow source modeling.
-   */
-  bindingset[this]
-  class SourceBase {
-    bindingset[this]
-    string toString();
-
-    Location getLocation();
-  }
-
-  /**
-   * A base class of elements that are candidates for flow sink modeling.
-   */
-  bindingset[this]
-  class SinkBase {
-    bindingset[this]
-    string toString();
-
-    Location getLocation();
-  }
-
-  /**
    * Holds if a neutral (MaD) model exists for `c` of kind `kind`
    * with provenance `provenance` and `isExact` is true if the model
    * signature matches `c` exactly - otherwise false.
@@ -225,10 +203,6 @@ module Make<
 
   final private class SummarizedCallableBaseFinal = SummarizedCallableBase;
 
-  final private class SourceBaseFinal = SourceBase;
-
-  final private class SinkBaseFinal = SinkBase;
-
   /** Provides classes and predicates for defining flow summaries. */
   module Public {
     private import Private
@@ -371,7 +345,7 @@ module Make<
     }
 
     /** A source element. */
-    abstract class SourceElement extends SourceBaseFinal {
+    abstract class SourceElement extends SummarizedCallableBaseFinal {
       bindingset[this]
       SourceElement() { any() }
 
@@ -380,11 +354,13 @@ module Make<
        * flows out as described by `output`.
        */
       pragma[nomagic]
-      abstract predicate isSource(string output, string kind, Provenance provenance, string model);
+      abstract predicate isSource(
+        string output, string kind, Provenance provenance, boolean isExact, string model
+      );
     }
 
     /** A sink element. */
-    abstract class SinkElement extends SinkBaseFinal {
+    abstract class SinkElement extends SummarizedCallableBaseFinal {
       bindingset[this]
       SinkElement() { any() }
 
@@ -393,11 +369,13 @@ module Make<
        * flows in as described by `input`.
        */
       pragma[nomagic]
-      abstract predicate isSink(string input, string kind, Provenance provenance, string model);
+      abstract predicate isSink(
+        string input, string kind, Provenance provenance, boolean isExact, string model
+      );
     }
 
     /** A barrier element. */
-    abstract class BarrierElement extends SourceBaseFinal {
+    abstract class BarrierElement extends SummarizedCallableBaseFinal {
       bindingset[this]
       BarrierElement() { any() }
 
@@ -406,11 +384,13 @@ module Make<
        * flows out as described by `output`.
        */
       pragma[nomagic]
-      abstract predicate isBarrier(string output, string kind, Provenance provenance, string model);
+      abstract predicate isBarrier(
+        string output, string kind, Provenance provenance, boolean isExact, string model
+      );
     }
 
     /** A barrier guard element. */
-    abstract class BarrierGuardElement extends SinkBaseFinal {
+    abstract class BarrierGuardElement extends SummarizedCallableBaseFinal {
       bindingset[this]
       BarrierGuardElement() { any() }
 
@@ -420,7 +400,8 @@ module Make<
        */
       pragma[nomagic]
       abstract predicate isBarrierGuard(
-        string input, string acceptingValue, string kind, Provenance provenance, string model
+        string input, string acceptingValue, string kind, Provenance provenance, boolean isExact,
+        string model
       );
     }
 
@@ -534,6 +515,51 @@ module Make<
   module Private {
     private import Public
 
+    private signature predicate modelSig(
+      SummarizedCallableBase c, string kind, Provenance provenance, string model, boolean isExact,
+      string modelKind
+    );
+
+    private module RelevantModel<modelSig/6 model> {
+      /**
+       * Holds if the model described by the parameters is relevant. A model may be
+       * irrelevant if a more specific model exists.
+       */
+      predicate isRelevantModel(
+        SummarizedCallableBase c, string kind, Provenance provenance, string model, boolean isExact
+      ) {
+        exists(string modelKind |
+          model(c, kind, provenance, model, isExact, modelKind) and
+          if provenance.isGenerated() or isExact = false
+          then
+            // Only apply generated models to functions in library code
+            not (provenance.isGenerated() and callableFromSource(c)) and
+            // Only apply generated or inexact models when no strictly better model exists
+            not exists(Provenance other, boolean isExactOther |
+              model(c, _, other, _, isExactOther, modelKind)
+              or
+              neutralElement(c, modelKind, other, isExactOther)
+            |
+              provenance.isGenerated() and other.isManual()
+              or
+              provenance.getVerification() = other.getVerification() and
+              isExact = false and
+              isExactOther = true
+            )
+          else any()
+        )
+      }
+    }
+
+    private predicate summaryModel(
+      SummarizedCallableBase c, string kind, Provenance p, string model, boolean isExact,
+      string modelKind
+    ) {
+      c.(SummarizedCallable).propagatesFlow(_, _, _, p, isExact, model) and
+      kind = "(unused)" and
+      modelKind = "summary"
+    }
+
     /**
      * Holds if `c` has a relevant flow summary.
      *
@@ -550,23 +576,7 @@ module Make<
       boolean isExact, string model
     ) {
       c.propagatesFlow(input, output, preservesValue, p, isExact, model) and
-      if p.isGenerated() or isExact = false
-      then
-        // Only apply generated models to functions in library code
-        not (p.isGenerated() and callableFromSource(c)) and
-        // Only apply generated or inexact models when no strictly better model exists
-        not exists(Provenance other, boolean isExactOther |
-          c.propagatesFlow(_, _, _, other, isExactOther, _)
-          or
-          neutralElement(c, "summary", other, isExactOther)
-        |
-          p.isGenerated() and other.isManual()
-          or
-          p.getVerification() = other.getVerification() and
-          isExact = false and
-          isExactOther = true
-        )
-      else any()
+      RelevantModel<summaryModel/6>::isRelevantModel(c, _, p, model, isExact)
     }
 
     /**
@@ -759,52 +769,72 @@ module Make<
       unsupportedCallable(callable, _, _, _)
     }
 
+    private predicate sourceModel(
+      SummarizedCallableBase c, string kind, Provenance p, string model, boolean isExact,
+      string modelKind
+    ) {
+      c.(SourceElement).isSource(_, kind, p, isExact, model) and
+      modelKind = "source"
+    }
+
     private predicate isRelevantSource(
       SourceElement e, string output, string kind, Provenance provenance, string model
     ) {
-      e.isSource(output, kind, provenance, model) and
-      (
-        provenance.isManual()
-        or
-        provenance.isGenerated() and
-        not exists(Provenance p | p.isManual() and e.isSource(_, kind, p, _))
+      exists(boolean isExact |
+        e.isSource(output, kind, provenance, isExact, model) and
+        RelevantModel<sourceModel/6>::isRelevantModel(e, kind, provenance, model, isExact)
       )
+    }
+
+    private predicate sinkModel(
+      SummarizedCallableBase c, string kind, Provenance p, string model, boolean isExact,
+      string modelKind
+    ) {
+      c.(SinkElement).isSink(_, kind, p, isExact, model) and
+      modelKind = "sink"
     }
 
     private predicate isRelevantSink(
       SinkElement e, string input, string kind, Provenance provenance, string model
     ) {
-      e.isSink(input, kind, provenance, model) and
-      (
-        provenance.isManual()
-        or
-        provenance.isGenerated() and
-        not exists(Provenance p | p.isManual() and e.isSink(_, kind, p, _))
+      exists(boolean isExact |
+        e.isSink(input, kind, provenance, isExact, model) and
+        RelevantModel<sinkModel/6>::isRelevantModel(e, kind, provenance, model, isExact)
       )
+    }
+
+    private predicate barrierModel(
+      SummarizedCallableBase c, string kind, Provenance p, string model, boolean isExact,
+      string modelKind
+    ) {
+      c.(BarrierElement).isBarrier(_, kind, p, isExact, model) and
+      modelKind = "barrier"
     }
 
     private predicate isRelevantBarrier(
       BarrierElement e, string output, string kind, Provenance provenance, string model
     ) {
-      e.isBarrier(output, kind, provenance, model) and
-      (
-        provenance.isManual()
-        or
-        provenance.isGenerated() and
-        not exists(Provenance p | p.isManual() and e.isBarrier(_, kind, p, _))
+      exists(boolean isExact |
+        e.isBarrier(output, kind, provenance, isExact, model) and
+        RelevantModel<barrierModel/6>::isRelevantModel(e, kind, provenance, model, isExact)
       )
+    }
+
+    private predicate barrierGuardModel(
+      SummarizedCallableBase c, string kind, Provenance p, string model, boolean isExact,
+      string modelKind
+    ) {
+      c.(BarrierGuardElement).isBarrierGuard(_, _, kind, p, isExact, model) and
+      modelKind = "barrier-guard"
     }
 
     private predicate isRelevantBarrierGuard(
       BarrierGuardElement e, string input, string acceptingValue, string kind,
       Provenance provenance, string model
     ) {
-      e.isBarrierGuard(input, acceptingValue, kind, provenance, model) and
-      (
-        provenance.isManual()
-        or
-        provenance.isGenerated() and
-        not exists(Provenance p | p.isManual() and e.isBarrierGuard(_, _, kind, p, _))
+      exists(boolean isExact |
+        e.isBarrierGuard(input, acceptingValue, kind, provenance, isExact, model) and
+        RelevantModel<barrierGuardModel/6>::isRelevantModel(e, kind, provenance, model, isExact)
       )
     }
 
@@ -1464,7 +1494,7 @@ module Make<
        */
       bindingset[source, sc]
       default SourceSinkReportingElement getASourceReportingElement(
-        SourceBase source, SummaryComponent sc
+        SummarizedCallableBase source, SummaryComponent sc
       ) {
         none()
       }
@@ -1489,7 +1519,9 @@ module Make<
        * at position 0 in a call to `sink`.
        */
       bindingset[sink, sc]
-      default SourceSinkReportingElement getASinkReportingElement(SinkBase sink, SummaryComponent sc) {
+      default SourceSinkReportingElement getASinkReportingElement(
+        SummarizedCallableBase sink, SummaryComponent sc
+      ) {
         none()
       }
 

--- a/swift/ql/lib/codeql/swift/dataflow/internal/FlowSummaryImpl.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/FlowSummaryImpl.qll
@@ -16,13 +16,9 @@ module Input implements InputSig<Location, DataFlowImplSpecific::SwiftDataFlow> 
 
   class SummarizedCallableBase = Function;
 
-  class SourceBase extends Void {
+  class FlowSummaryCallBase extends Void {
     Location getLocation() { none() }
   }
-
-  class SinkBase = SourceBase;
-
-  class FlowSummaryCallBase = SourceBase;
 
   predicate callableFromSource(SummarizedCallableBase c) { c.hasBody() }
 


### PR DESCRIPTION
This PR applies the same inheritance logic to source/sink/barrier MaD models for trait functions as for summary models, that is, a model for `<Foo>::bar` applies to any function implementing the trait function `foo`, _unless_ an explicit model exists for that particular implementation.

In order to ensure that the same prioritization rules apply as for summary models, this logic is defined in the shared library, but currently only Rust and C++ make use of it.

The updated test output shows that we fix some existing FNs, and [DCA](https://github.com/github/codeql-dca-main/tree/data/hvitved/PR-22445-1-rust__1/reports) shows that we both remove some alerts (presumably because we now have more barriers) and we gain some alerts (presumably because we now have more sources and sinks).