### PR TITLE
cpp: model Protocol Buffers parse/serialize taint flow

### DIFF
--- a/cpp/ql/lib/change-notes/2026-08-27-protobuf-models.md
+++ b/cpp/ql/lib/change-notes/2026-08-27-protobuf-models.md
@@ -1,4 +1,4 @@
 ---
 category: minorAnalysis
 ---
-* Added flow summaries for the Protocol Buffers C++ API (`google::protobuf::MessageLite`, covering `Message` and all generated messages). The `ParseFrom*`/`MergeFrom*` methods (string, array, Cord, istream, and zero-copy/coded-stream forms) propagate taint from the encoded input to the message, and the `SerializeTo*`/`SerializeAs*`/`AppendTo*` methods propagate taint from the message to the output buffer, stream, or return value.
+* Added flow summaries for the Protocol Buffers C++ API (`google::protobuf::MessageLite`, covering `Message` and all generated messages).

--- a/cpp/ql/lib/change-notes/2026-08-27-protobuf-models.md
+++ b/cpp/ql/lib/change-notes/2026-08-27-protobuf-models.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added flow summaries for the Protocol Buffers C++ API (`google::protobuf::MessageLite`, covering `Message` and all generated messages). The `ParseFrom*`/`MergeFrom*` methods (string, array, Cord, istream, and zero-copy/coded-stream forms) propagate taint from the encoded input to the message, and the `SerializeTo*`/`SerializeAs*`/`AppendTo*` methods propagate taint from the message to the output buffer, stream, or return value.

--- a/cpp/ql/lib/change-notes/2026-08-27-protobuf-models.md
+++ b/cpp/ql/lib/change-notes/2026-08-27-protobuf-models.md
@@ -1,4 +1,4 @@
 ---
 category: minorAnalysis
 ---
-* Added flow summaries for the Protocol Buffers C++ API (`google::protobuf::MessageLite`, covering `Message` and all generated messages).
+* Added flow summaries for the Protocol Buffers `google::protobuf::MessageLite` C++ API.

--- a/cpp/ql/lib/ext/Protobuf.model.yml
+++ b/cpp/ql/lib/ext/Protobuf.model.yml
@@ -9,11 +9,18 @@ extensions:
       # File-descriptor variants (`{Parse,Serialize}*FromFileDescriptor`) are intentionally omitted:
       # the descriptor is an `int`, not a data buffer, so there is no buffer argument to model.
 
-      # Deserialization: the encoded input (`Argument[*0]`) taints the message (`this`).
-      - ["google::protobuf", "MessageLite", True, "ParseFromString", "", "", "Argument[*0]", "Argument[-1]", "taint", "manual"]
-      - ["google::protobuf", "MessageLite", True, "ParsePartialFromString", "", "", "Argument[*0]", "Argument[-1]", "taint", "manual"]
-      - ["google::protobuf", "MessageLite", True, "MergeFromString", "", "", "Argument[*0]", "Argument[-1]", "taint", "manual"]
-      - ["google::protobuf", "MessageLite", True, "MergePartialFromString", "", "", "Argument[*0]", "Argument[-1]", "taint", "manual"]
+      # Deserialization: the encoded input taints the message (`this`). The `*FromString` methods each
+      # have a `string_view` overload (the buffer is the by-value argument, so `Argument[0]`) and a
+      # `const Cord &` overload (the buffer is behind a reference, so `Argument[*0]`). The remaining
+      # inputs below are pointers or references, so they take `Argument[*0]`.
+      - ["google::protobuf", "MessageLite", True, "ParseFromString", "(string_view)", "", "Argument[0]", "Argument[-1]", "taint", "manual"]
+      - ["google::protobuf", "MessageLite", True, "ParseFromString", "(const Cord &)", "", "Argument[*0]", "Argument[-1]", "taint", "manual"]
+      - ["google::protobuf", "MessageLite", True, "ParsePartialFromString", "(string_view)", "", "Argument[0]", "Argument[-1]", "taint", "manual"]
+      - ["google::protobuf", "MessageLite", True, "ParsePartialFromString", "(const Cord &)", "", "Argument[*0]", "Argument[-1]", "taint", "manual"]
+      - ["google::protobuf", "MessageLite", True, "MergeFromString", "(string_view)", "", "Argument[0]", "Argument[-1]", "taint", "manual"]
+      - ["google::protobuf", "MessageLite", True, "MergeFromString", "(const Cord &)", "", "Argument[*0]", "Argument[-1]", "taint", "manual"]
+      - ["google::protobuf", "MessageLite", True, "MergePartialFromString", "(string_view)", "", "Argument[0]", "Argument[-1]", "taint", "manual"]
+      - ["google::protobuf", "MessageLite", True, "MergePartialFromString", "(const Cord &)", "", "Argument[*0]", "Argument[-1]", "taint", "manual"]
       - ["google::protobuf", "MessageLite", True, "ParseFromArray", "", "", "Argument[*0]", "Argument[-1]", "taint", "manual"]
       - ["google::protobuf", "MessageLite", True, "ParsePartialFromArray", "", "", "Argument[*0]", "Argument[-1]", "taint", "manual"]
       - ["google::protobuf", "MessageLite", True, "ParseFromCord", "", "", "Argument[*0]", "Argument[-1]", "taint", "manual"]

--- a/cpp/ql/lib/ext/Protobuf.model.yml
+++ b/cpp/ql/lib/ext/Protobuf.model.yml
@@ -1,0 +1,58 @@
+extensions:
+  - addsTo:
+      pack: codeql/cpp-all
+      extensible: summaryModel
+    data: # namespace, type, subtypes, name, signature, ext, input, output, kind, provenance
+      # Flow summaries for the Protocol Buffers C++ API. All of these methods are declared on
+      # `google::protobuf::MessageLite`; `subtypes` covers `Message` and every generated message.
+      #
+      # File-descriptor variants (`{Parse,Serialize}*FromFileDescriptor`) are intentionally omitted:
+      # the descriptor is an `int`, not a data buffer, so there is no buffer argument to model.
+
+      # Deserialization: the encoded input (`Argument[*0]`) taints the message (`this`).
+      - ["google::protobuf", "MessageLite", True, "ParseFromString", "", "", "Argument[*0]", "Argument[-1]", "taint", "manual"]
+      - ["google::protobuf", "MessageLite", True, "ParsePartialFromString", "", "", "Argument[*0]", "Argument[-1]", "taint", "manual"]
+      - ["google::protobuf", "MessageLite", True, "MergeFromString", "", "", "Argument[*0]", "Argument[-1]", "taint", "manual"]
+      - ["google::protobuf", "MessageLite", True, "MergePartialFromString", "", "", "Argument[*0]", "Argument[-1]", "taint", "manual"]
+      - ["google::protobuf", "MessageLite", True, "ParseFromArray", "", "", "Argument[*0]", "Argument[-1]", "taint", "manual"]
+      - ["google::protobuf", "MessageLite", True, "ParsePartialFromArray", "", "", "Argument[*0]", "Argument[-1]", "taint", "manual"]
+      - ["google::protobuf", "MessageLite", True, "ParseFromCord", "", "", "Argument[*0]", "Argument[-1]", "taint", "manual"]
+      - ["google::protobuf", "MessageLite", True, "ParsePartialFromCord", "", "", "Argument[*0]", "Argument[-1]", "taint", "manual"]
+      - ["google::protobuf", "MessageLite", True, "MergeFromCord", "", "", "Argument[*0]", "Argument[-1]", "taint", "manual"]
+      - ["google::protobuf", "MessageLite", True, "MergePartialFromCord", "", "", "Argument[*0]", "Argument[-1]", "taint", "manual"]
+      - ["google::protobuf", "MessageLite", True, "ParseFromIstream", "", "", "Argument[*0]", "Argument[-1]", "taint", "manual"]
+      - ["google::protobuf", "MessageLite", True, "ParsePartialFromIstream", "", "", "Argument[*0]", "Argument[-1]", "taint", "manual"]
+      - ["google::protobuf", "MessageLite", True, "ParseFromZeroCopyStream", "", "", "Argument[*0]", "Argument[-1]", "taint", "manual"]
+      - ["google::protobuf", "MessageLite", True, "ParsePartialFromZeroCopyStream", "", "", "Argument[*0]", "Argument[-1]", "taint", "manual"]
+      - ["google::protobuf", "MessageLite", True, "ParseFromBoundedZeroCopyStream", "", "", "Argument[*0]", "Argument[-1]", "taint", "manual"]
+      - ["google::protobuf", "MessageLite", True, "ParsePartialFromBoundedZeroCopyStream", "", "", "Argument[*0]", "Argument[-1]", "taint", "manual"]
+      - ["google::protobuf", "MessageLite", True, "MergeFromBoundedZeroCopyStream", "", "", "Argument[*0]", "Argument[-1]", "taint", "manual"]
+      - ["google::protobuf", "MessageLite", True, "MergePartialFromBoundedZeroCopyStream", "", "", "Argument[*0]", "Argument[-1]", "taint", "manual"]
+      - ["google::protobuf", "MessageLite", True, "ParseFromCodedStream", "", "", "Argument[*0]", "Argument[-1]", "taint", "manual"]
+      - ["google::protobuf", "MessageLite", True, "ParsePartialFromCodedStream", "", "", "Argument[*0]", "Argument[-1]", "taint", "manual"]
+      - ["google::protobuf", "MessageLite", True, "MergeFromCodedStream", "", "", "Argument[*0]", "Argument[-1]", "taint", "manual"]
+      - ["google::protobuf", "MessageLite", True, "MergePartialFromCodedStream", "", "", "Argument[*0]", "Argument[-1]", "taint", "manual"]
+
+      # Serialization into an output buffer/stream: the message (`this`) taints `Argument[*0]`.
+      - ["google::protobuf", "MessageLite", True, "SerializeToString", "", "", "Argument[-1]", "Argument[*0]", "taint", "manual"]
+      - ["google::protobuf", "MessageLite", True, "SerializePartialToString", "", "", "Argument[-1]", "Argument[*0]", "taint", "manual"]
+      - ["google::protobuf", "MessageLite", True, "AppendToString", "", "", "Argument[-1]", "Argument[*0]", "taint", "manual"]
+      - ["google::protobuf", "MessageLite", True, "AppendPartialToString", "", "", "Argument[-1]", "Argument[*0]", "taint", "manual"]
+      - ["google::protobuf", "MessageLite", True, "SerializeToArray", "", "", "Argument[-1]", "Argument[*0]", "taint", "manual"]
+      - ["google::protobuf", "MessageLite", True, "SerializePartialToArray", "", "", "Argument[-1]", "Argument[*0]", "taint", "manual"]
+      - ["google::protobuf", "MessageLite", True, "SerializeToCord", "", "", "Argument[-1]", "Argument[*0]", "taint", "manual"]
+      - ["google::protobuf", "MessageLite", True, "SerializePartialToCord", "", "", "Argument[-1]", "Argument[*0]", "taint", "manual"]
+      - ["google::protobuf", "MessageLite", True, "AppendToCord", "", "", "Argument[-1]", "Argument[*0]", "taint", "manual"]
+      - ["google::protobuf", "MessageLite", True, "AppendPartialToCord", "", "", "Argument[-1]", "Argument[*0]", "taint", "manual"]
+      - ["google::protobuf", "MessageLite", True, "SerializeToOstream", "", "", "Argument[-1]", "Argument[*0]", "taint", "manual"]
+      - ["google::protobuf", "MessageLite", True, "SerializePartialToOstream", "", "", "Argument[-1]", "Argument[*0]", "taint", "manual"]
+      - ["google::protobuf", "MessageLite", True, "SerializeToZeroCopyStream", "", "", "Argument[-1]", "Argument[*0]", "taint", "manual"]
+      - ["google::protobuf", "MessageLite", True, "SerializePartialToZeroCopyStream", "", "", "Argument[-1]", "Argument[*0]", "taint", "manual"]
+      - ["google::protobuf", "MessageLite", True, "SerializeToCodedStream", "", "", "Argument[-1]", "Argument[*0]", "taint", "manual"]
+      - ["google::protobuf", "MessageLite", True, "SerializePartialToCodedStream", "", "", "Argument[-1]", "Argument[*0]", "taint", "manual"]
+
+      # Serialization returning the bytes: the message (`this`) taints the (by-value) return value.
+      - ["google::protobuf", "MessageLite", True, "SerializeAsString", "", "", "Argument[-1]", "ReturnValue", "taint", "manual"]
+      - ["google::protobuf", "MessageLite", True, "SerializePartialAsString", "", "", "Argument[-1]", "ReturnValue", "taint", "manual"]
+      - ["google::protobuf", "MessageLite", True, "SerializeAsCord", "", "", "Argument[-1]", "ReturnValue", "taint", "manual"]
+      - ["google::protobuf", "MessageLite", True, "SerializePartialAsCord", "", "", "Argument[-1]", "ReturnValue", "taint", "manual"]

--- a/cpp/ql/lib/ext/Protobuf.model.yml
+++ b/cpp/ql/lib/ext/Protobuf.model.yml
@@ -3,16 +3,10 @@ extensions:
       pack: codeql/cpp-all
       extensible: summaryModel
     data: # namespace, type, subtypes, name, signature, ext, input, output, kind, provenance
-      # Flow summaries for the Protocol Buffers C++ API. All of these methods are declared on
-      # `google::protobuf::MessageLite`; `subtypes` covers `Message` and every generated message.
-      #
       # File-descriptor variants (`{Parse,Serialize}*FromFileDescriptor`) are intentionally omitted:
       # the descriptor is an `int`, not a data buffer, so there is no buffer argument to model.
 
-      # Deserialization: the encoded input taints the message (`this`). The `*FromString` methods each
-      # have a `string_view` overload (the buffer is the by-value argument, so `Argument[0]`) and a
-      # `const Cord &` overload (the buffer is behind a reference, so `Argument[*0]`). The remaining
-      # inputs below are pointers or references, so they take `Argument[*0]`.
+      # Deserialization
       - ["google::protobuf", "MessageLite", True, "ParseFromString", "(string_view)", "", "Argument[0]", "Argument[-1]", "taint", "manual"]
       - ["google::protobuf", "MessageLite", True, "ParseFromString", "(const Cord &)", "", "Argument[*0]", "Argument[-1]", "taint", "manual"]
       - ["google::protobuf", "MessageLite", True, "ParsePartialFromString", "(string_view)", "", "Argument[0]", "Argument[-1]", "taint", "manual"]
@@ -40,7 +34,7 @@ extensions:
       - ["google::protobuf", "MessageLite", True, "MergeFromCodedStream", "", "", "Argument[*0]", "Argument[-1]", "taint", "manual"]
       - ["google::protobuf", "MessageLite", True, "MergePartialFromCodedStream", "", "", "Argument[*0]", "Argument[-1]", "taint", "manual"]
 
-      # Serialization into an output buffer/stream: the message (`this`) taints `Argument[*0]`.
+      # Serialization
       - ["google::protobuf", "MessageLite", True, "SerializeToString", "", "", "Argument[-1]", "Argument[*0]", "taint", "manual"]
       - ["google::protobuf", "MessageLite", True, "SerializePartialToString", "", "", "Argument[-1]", "Argument[*0]", "taint", "manual"]
       - ["google::protobuf", "MessageLite", True, "AppendToString", "", "", "Argument[-1]", "Argument[*0]", "taint", "manual"]
@@ -58,7 +52,7 @@ extensions:
       - ["google::protobuf", "MessageLite", True, "SerializeToCodedStream", "", "", "Argument[-1]", "Argument[*0]", "taint", "manual"]
       - ["google::protobuf", "MessageLite", True, "SerializePartialToCodedStream", "", "", "Argument[-1]", "Argument[*0]", "taint", "manual"]
 
-      # Serialization returning the bytes: the message (`this`) taints the (by-value) return value.
+      # Serialization returning bytes
       - ["google::protobuf", "MessageLite", True, "SerializeAsString", "", "", "Argument[-1]", "ReturnValue", "taint", "manual"]
       - ["google::protobuf", "MessageLite", True, "SerializePartialAsString", "", "", "Argument[-1]", "ReturnValue", "taint", "manual"]
       - ["google::protobuf", "MessageLite", True, "SerializeAsCord", "", "", "Argument[-1]", "ReturnValue", "taint", "manual"]

--- a/cpp/ql/test/library-tests/dataflow/external-models/asio_streams.cpp
+++ b/cpp/ql/test/library-tests/dataflow/external-models/asio_streams.cpp
@@ -1,24 +1,11 @@
 
 // --- stub library headers ---
 
+#include "std_string.h"
+
+#define SIZE_MAX 0xFFFFFFFF
+
 namespace std {
-	typedef unsigned long size_t;
-	#define SIZE_MAX 0xFFFFFFFF
-
-	template <class T> class allocator {
-	};
-
-	template<class charT> struct char_traits {
-	};
-
-	template<class charT, class traits = char_traits<charT>, class Allocator = allocator<charT> >
-	class basic_string {
-	public:
-		basic_string(const charT* s, const Allocator& a = Allocator());
-	};
-
-	typedef basic_string<char> string;
-
 	class string_view {
 	public:
 		string_view(const char* s);

--- a/cpp/ql/test/library-tests/dataflow/external-models/flow.expected
+++ b/cpp/ql/test/library-tests/dataflow/external-models/flow.expected
@@ -166,78 +166,78 @@ models
 | 165 | Summary: google::protobuf; MessageLite; true; SerializeToString; ; ; Argument[-1]; Argument[*0]; taint; manual |
 | 166 | Summary: google::protobuf; MessageLite; true; SerializeToZeroCopyStream; ; ; Argument[-1]; Argument[*0]; taint; manual |
 edges
-| asio_streams.cpp:129:34:129:44 | read_until output argument | asio_streams.cpp:133:7:133:17 | recv_buffer | provenance | Src:MaD:56  |
-| asio_streams.cpp:129:34:129:44 | read_until output argument | asio_streams.cpp:135:29:135:39 | recv_buffer | provenance | Src:MaD:56 Sink:MaD:4 |
-| asio_streams.cpp:139:37:139:44 | call to source | asio_streams.cpp:140:7:140:14 | send_str | provenance | TaintFunction |
-| asio_streams.cpp:139:37:139:44 | call to source | asio_streams.cpp:142:64:142:71 | *send_str | provenance | TaintFunction |
-| asio_streams.cpp:142:44:142:62 | call to buffer | asio_streams.cpp:142:44:142:62 | call to buffer | provenance |  |
-| asio_streams.cpp:142:44:142:62 | call to buffer | asio_streams.cpp:143:7:143:17 | send_buffer | provenance |  |
-| asio_streams.cpp:142:44:142:62 | call to buffer | asio_streams.cpp:145:29:145:39 | send_buffer | provenance | Sink:MaD:4 |
-| asio_streams.cpp:142:64:142:71 | *send_str | asio_streams.cpp:142:44:142:62 | call to buffer | provenance | MaD:120 |
-| asio_streams.cpp:156:19:156:26 | call to source | asio_streams.cpp:161:24:161:27 | *host | provenance | TaintFunction |
-| asio_streams.cpp:156:19:156:26 | call to source | asio_streams.cpp:162:24:162:27 | *host | provenance | TaintFunction |
-| asio_streams.cpp:156:19:156:26 | call to source | asio_streams.cpp:163:24:163:27 | *host | provenance | TaintFunction |
-| asio_streams.cpp:156:19:156:26 | call to source | asio_streams.cpp:164:24:164:27 | *host | provenance | TaintFunction |
-| asio_streams.cpp:156:19:156:26 | call to source | asio_streams.cpp:171:34:171:37 | *host | provenance | TaintFunction |
-| asio_streams.cpp:156:19:156:26 | call to source | asio_streams.cpp:172:34:172:37 | *host | provenance | TaintFunction |
-| asio_streams.cpp:156:19:156:26 | call to source | asio_streams.cpp:173:34:173:37 | *host | provenance | TaintFunction |
-| asio_streams.cpp:156:19:156:26 | call to source | asio_streams.cpp:174:34:174:37 | *host | provenance | TaintFunction |
-| asio_streams.cpp:158:29:158:36 | call to source | asio_streams.cpp:166:24:166:32 | host_view | provenance | TaintFunction |
-| asio_streams.cpp:158:29:158:36 | call to source | asio_streams.cpp:167:24:167:32 | host_view | provenance | TaintFunction |
-| asio_streams.cpp:158:29:158:36 | call to source | asio_streams.cpp:168:24:168:32 | host_view | provenance | TaintFunction |
-| asio_streams.cpp:158:29:158:36 | call to source | asio_streams.cpp:169:24:169:32 | host_view | provenance | TaintFunction |
-| asio_streams.cpp:158:29:158:36 | call to source | asio_streams.cpp:176:34:176:42 | host_view | provenance | TaintFunction |
-| asio_streams.cpp:158:29:158:36 | call to source | asio_streams.cpp:177:34:177:42 | host_view | provenance | TaintFunction |
-| asio_streams.cpp:158:29:158:36 | call to source | asio_streams.cpp:178:34:178:42 | host_view | provenance | TaintFunction |
-| asio_streams.cpp:158:29:158:36 | call to source | asio_streams.cpp:179:34:179:42 | host_view | provenance | TaintFunction |
-| asio_streams.cpp:161:24:161:27 | *host | asio_streams.cpp:161:16:161:22 | call to resolve | provenance | MaD:112 |
-| asio_streams.cpp:162:24:162:27 | *host | asio_streams.cpp:162:16:162:22 | call to resolve | provenance | MaD:113 |
-| asio_streams.cpp:163:24:163:27 | *host | asio_streams.cpp:163:16:163:22 | call to resolve | provenance | MaD:114 |
-| asio_streams.cpp:164:24:164:27 | *host | asio_streams.cpp:164:16:164:22 | call to resolve | provenance | MaD:115 |
-| asio_streams.cpp:166:24:166:32 | host_view | asio_streams.cpp:166:16:166:22 | call to resolve | provenance | MaD:116 |
-| asio_streams.cpp:167:24:167:32 | host_view | asio_streams.cpp:167:16:167:22 | call to resolve | provenance | MaD:117 |
-| asio_streams.cpp:168:24:168:32 | host_view | asio_streams.cpp:168:16:168:22 | call to resolve | provenance | MaD:118 |
-| asio_streams.cpp:169:24:169:32 | host_view | asio_streams.cpp:169:16:169:22 | call to resolve | provenance | MaD:119 |
-| asio_streams.cpp:171:34:171:37 | *host | asio_streams.cpp:171:16:171:22 | call to resolve | provenance | MaD:104 |
-| asio_streams.cpp:172:34:172:37 | *host | asio_streams.cpp:172:16:172:22 | call to resolve | provenance | MaD:105 |
-| asio_streams.cpp:173:34:173:37 | *host | asio_streams.cpp:173:16:173:22 | call to resolve | provenance | MaD:106 |
-| asio_streams.cpp:174:34:174:37 | *host | asio_streams.cpp:174:16:174:22 | call to resolve | provenance | MaD:107 |
-| asio_streams.cpp:176:34:176:42 | host_view | asio_streams.cpp:176:16:176:22 | call to resolve | provenance | MaD:108 |
-| asio_streams.cpp:177:34:177:42 | host_view | asio_streams.cpp:177:16:177:22 | call to resolve | provenance | MaD:109 |
-| asio_streams.cpp:178:34:178:42 | host_view | asio_streams.cpp:178:16:178:22 | call to resolve | provenance | MaD:110 |
-| asio_streams.cpp:179:34:179:42 | host_view | asio_streams.cpp:179:16:179:22 | call to resolve | provenance | MaD:111 |
-| asio_streams.cpp:188:22:188:29 | call to source | asio_streams.cpp:192:30:192:36 | *service | provenance | TaintFunction |
-| asio_streams.cpp:188:22:188:29 | call to source | asio_streams.cpp:193:30:193:36 | *service | provenance | TaintFunction |
-| asio_streams.cpp:188:22:188:29 | call to source | asio_streams.cpp:194:30:194:36 | *service | provenance | TaintFunction |
-| asio_streams.cpp:188:22:188:29 | call to source | asio_streams.cpp:195:30:195:36 | *service | provenance | TaintFunction |
-| asio_streams.cpp:188:22:188:29 | call to source | asio_streams.cpp:202:40:202:46 | *service | provenance | TaintFunction |
-| asio_streams.cpp:188:22:188:29 | call to source | asio_streams.cpp:203:40:203:46 | *service | provenance | TaintFunction |
-| asio_streams.cpp:188:22:188:29 | call to source | asio_streams.cpp:204:40:204:46 | *service | provenance | TaintFunction |
-| asio_streams.cpp:188:22:188:29 | call to source | asio_streams.cpp:205:40:205:46 | *service | provenance | TaintFunction |
-| asio_streams.cpp:190:32:190:39 | call to source | asio_streams.cpp:197:35:197:46 | service_view | provenance | TaintFunction |
-| asio_streams.cpp:190:32:190:39 | call to source | asio_streams.cpp:198:35:198:46 | service_view | provenance | TaintFunction |
-| asio_streams.cpp:190:32:190:39 | call to source | asio_streams.cpp:199:35:199:46 | service_view | provenance | TaintFunction |
-| asio_streams.cpp:190:32:190:39 | call to source | asio_streams.cpp:200:35:200:46 | service_view | provenance | TaintFunction |
-| asio_streams.cpp:190:32:190:39 | call to source | asio_streams.cpp:207:45:207:56 | service_view | provenance | TaintFunction |
-| asio_streams.cpp:190:32:190:39 | call to source | asio_streams.cpp:208:45:208:56 | service_view | provenance | TaintFunction |
-| asio_streams.cpp:190:32:190:39 | call to source | asio_streams.cpp:209:45:209:56 | service_view | provenance | TaintFunction |
-| asio_streams.cpp:190:32:190:39 | call to source | asio_streams.cpp:210:45:210:56 | service_view | provenance | TaintFunction |
-| asio_streams.cpp:192:30:192:36 | *service | asio_streams.cpp:192:16:192:22 | call to resolve | provenance | MaD:112 |
-| asio_streams.cpp:193:30:193:36 | *service | asio_streams.cpp:193:16:193:22 | call to resolve | provenance | MaD:113 |
-| asio_streams.cpp:194:30:194:36 | *service | asio_streams.cpp:194:16:194:22 | call to resolve | provenance | MaD:114 |
-| asio_streams.cpp:195:30:195:36 | *service | asio_streams.cpp:195:16:195:22 | call to resolve | provenance | MaD:115 |
-| asio_streams.cpp:197:35:197:46 | service_view | asio_streams.cpp:197:16:197:22 | call to resolve | provenance | MaD:116 |
-| asio_streams.cpp:198:35:198:46 | service_view | asio_streams.cpp:198:16:198:22 | call to resolve | provenance | MaD:117 |
-| asio_streams.cpp:199:35:199:46 | service_view | asio_streams.cpp:199:16:199:22 | call to resolve | provenance | MaD:118 |
-| asio_streams.cpp:200:35:200:46 | service_view | asio_streams.cpp:200:16:200:22 | call to resolve | provenance | MaD:119 |
-| asio_streams.cpp:202:40:202:46 | *service | asio_streams.cpp:202:16:202:22 | call to resolve | provenance | MaD:104 |
-| asio_streams.cpp:203:40:203:46 | *service | asio_streams.cpp:203:16:203:22 | call to resolve | provenance | MaD:105 |
-| asio_streams.cpp:204:40:204:46 | *service | asio_streams.cpp:204:16:204:22 | call to resolve | provenance | MaD:106 |
-| asio_streams.cpp:205:40:205:46 | *service | asio_streams.cpp:205:16:205:22 | call to resolve | provenance | MaD:107 |
-| asio_streams.cpp:207:45:207:56 | service_view | asio_streams.cpp:207:16:207:22 | call to resolve | provenance | MaD:108 |
-| asio_streams.cpp:208:45:208:56 | service_view | asio_streams.cpp:208:16:208:22 | call to resolve | provenance | MaD:109 |
-| asio_streams.cpp:209:45:209:56 | service_view | asio_streams.cpp:209:16:209:22 | call to resolve | provenance | MaD:110 |
-| asio_streams.cpp:210:45:210:56 | service_view | asio_streams.cpp:210:16:210:22 | call to resolve | provenance | MaD:111 |
+| asio_streams.cpp:116:34:116:44 | read_until output argument | asio_streams.cpp:120:7:120:17 | recv_buffer | provenance | Src:MaD:56  |
+| asio_streams.cpp:116:34:116:44 | read_until output argument | asio_streams.cpp:122:29:122:39 | recv_buffer | provenance | Src:MaD:56 Sink:MaD:4 |
+| asio_streams.cpp:126:37:126:44 | call to source | asio_streams.cpp:127:7:127:14 | send_str | provenance | TaintFunction |
+| asio_streams.cpp:126:37:126:44 | call to source | asio_streams.cpp:129:64:129:71 | *send_str | provenance | TaintFunction |
+| asio_streams.cpp:129:44:129:62 | call to buffer | asio_streams.cpp:129:44:129:62 | call to buffer | provenance |  |
+| asio_streams.cpp:129:44:129:62 | call to buffer | asio_streams.cpp:130:7:130:17 | send_buffer | provenance |  |
+| asio_streams.cpp:129:44:129:62 | call to buffer | asio_streams.cpp:132:29:132:39 | send_buffer | provenance | Sink:MaD:4 |
+| asio_streams.cpp:129:64:129:71 | *send_str | asio_streams.cpp:129:44:129:62 | call to buffer | provenance | MaD:120 |
+| asio_streams.cpp:143:19:143:26 | call to source | asio_streams.cpp:148:24:148:27 | *host | provenance | TaintFunction |
+| asio_streams.cpp:143:19:143:26 | call to source | asio_streams.cpp:149:24:149:27 | *host | provenance | TaintFunction |
+| asio_streams.cpp:143:19:143:26 | call to source | asio_streams.cpp:150:24:150:27 | *host | provenance | TaintFunction |
+| asio_streams.cpp:143:19:143:26 | call to source | asio_streams.cpp:151:24:151:27 | *host | provenance | TaintFunction |
+| asio_streams.cpp:143:19:143:26 | call to source | asio_streams.cpp:158:34:158:37 | *host | provenance | TaintFunction |
+| asio_streams.cpp:143:19:143:26 | call to source | asio_streams.cpp:159:34:159:37 | *host | provenance | TaintFunction |
+| asio_streams.cpp:143:19:143:26 | call to source | asio_streams.cpp:160:34:160:37 | *host | provenance | TaintFunction |
+| asio_streams.cpp:143:19:143:26 | call to source | asio_streams.cpp:161:34:161:37 | *host | provenance | TaintFunction |
+| asio_streams.cpp:145:29:145:36 | call to source | asio_streams.cpp:153:24:153:32 | host_view | provenance | TaintFunction |
+| asio_streams.cpp:145:29:145:36 | call to source | asio_streams.cpp:154:24:154:32 | host_view | provenance | TaintFunction |
+| asio_streams.cpp:145:29:145:36 | call to source | asio_streams.cpp:155:24:155:32 | host_view | provenance | TaintFunction |
+| asio_streams.cpp:145:29:145:36 | call to source | asio_streams.cpp:156:24:156:32 | host_view | provenance | TaintFunction |
+| asio_streams.cpp:145:29:145:36 | call to source | asio_streams.cpp:163:34:163:42 | host_view | provenance | TaintFunction |
+| asio_streams.cpp:145:29:145:36 | call to source | asio_streams.cpp:164:34:164:42 | host_view | provenance | TaintFunction |
+| asio_streams.cpp:145:29:145:36 | call to source | asio_streams.cpp:165:34:165:42 | host_view | provenance | TaintFunction |
+| asio_streams.cpp:145:29:145:36 | call to source | asio_streams.cpp:166:34:166:42 | host_view | provenance | TaintFunction |
+| asio_streams.cpp:148:24:148:27 | *host | asio_streams.cpp:148:16:148:22 | call to resolve | provenance | MaD:112 |
+| asio_streams.cpp:149:24:149:27 | *host | asio_streams.cpp:149:16:149:22 | call to resolve | provenance | MaD:113 |
+| asio_streams.cpp:150:24:150:27 | *host | asio_streams.cpp:150:16:150:22 | call to resolve | provenance | MaD:114 |
+| asio_streams.cpp:151:24:151:27 | *host | asio_streams.cpp:151:16:151:22 | call to resolve | provenance | MaD:115 |
+| asio_streams.cpp:153:24:153:32 | host_view | asio_streams.cpp:153:16:153:22 | call to resolve | provenance | MaD:116 |
+| asio_streams.cpp:154:24:154:32 | host_view | asio_streams.cpp:154:16:154:22 | call to resolve | provenance | MaD:117 |
+| asio_streams.cpp:155:24:155:32 | host_view | asio_streams.cpp:155:16:155:22 | call to resolve | provenance | MaD:118 |
+| asio_streams.cpp:156:24:156:32 | host_view | asio_streams.cpp:156:16:156:22 | call to resolve | provenance | MaD:119 |
+| asio_streams.cpp:158:34:158:37 | *host | asio_streams.cpp:158:16:158:22 | call to resolve | provenance | MaD:104 |
+| asio_streams.cpp:159:34:159:37 | *host | asio_streams.cpp:159:16:159:22 | call to resolve | provenance | MaD:105 |
+| asio_streams.cpp:160:34:160:37 | *host | asio_streams.cpp:160:16:160:22 | call to resolve | provenance | MaD:106 |
+| asio_streams.cpp:161:34:161:37 | *host | asio_streams.cpp:161:16:161:22 | call to resolve | provenance | MaD:107 |
+| asio_streams.cpp:163:34:163:42 | host_view | asio_streams.cpp:163:16:163:22 | call to resolve | provenance | MaD:108 |
+| asio_streams.cpp:164:34:164:42 | host_view | asio_streams.cpp:164:16:164:22 | call to resolve | provenance | MaD:109 |
+| asio_streams.cpp:165:34:165:42 | host_view | asio_streams.cpp:165:16:165:22 | call to resolve | provenance | MaD:110 |
+| asio_streams.cpp:166:34:166:42 | host_view | asio_streams.cpp:166:16:166:22 | call to resolve | provenance | MaD:111 |
+| asio_streams.cpp:175:22:175:29 | call to source | asio_streams.cpp:179:30:179:36 | *service | provenance | TaintFunction |
+| asio_streams.cpp:175:22:175:29 | call to source | asio_streams.cpp:180:30:180:36 | *service | provenance | TaintFunction |
+| asio_streams.cpp:175:22:175:29 | call to source | asio_streams.cpp:181:30:181:36 | *service | provenance | TaintFunction |
+| asio_streams.cpp:175:22:175:29 | call to source | asio_streams.cpp:182:30:182:36 | *service | provenance | TaintFunction |
+| asio_streams.cpp:175:22:175:29 | call to source | asio_streams.cpp:189:40:189:46 | *service | provenance | TaintFunction |
+| asio_streams.cpp:175:22:175:29 | call to source | asio_streams.cpp:190:40:190:46 | *service | provenance | TaintFunction |
+| asio_streams.cpp:175:22:175:29 | call to source | asio_streams.cpp:191:40:191:46 | *service | provenance | TaintFunction |
+| asio_streams.cpp:175:22:175:29 | call to source | asio_streams.cpp:192:40:192:46 | *service | provenance | TaintFunction |
+| asio_streams.cpp:177:32:177:39 | call to source | asio_streams.cpp:184:35:184:46 | service_view | provenance | TaintFunction |
+| asio_streams.cpp:177:32:177:39 | call to source | asio_streams.cpp:185:35:185:46 | service_view | provenance | TaintFunction |
+| asio_streams.cpp:177:32:177:39 | call to source | asio_streams.cpp:186:35:186:46 | service_view | provenance | TaintFunction |
+| asio_streams.cpp:177:32:177:39 | call to source | asio_streams.cpp:187:35:187:46 | service_view | provenance | TaintFunction |
+| asio_streams.cpp:177:32:177:39 | call to source | asio_streams.cpp:194:45:194:56 | service_view | provenance | TaintFunction |
+| asio_streams.cpp:177:32:177:39 | call to source | asio_streams.cpp:195:45:195:56 | service_view | provenance | TaintFunction |
+| asio_streams.cpp:177:32:177:39 | call to source | asio_streams.cpp:196:45:196:56 | service_view | provenance | TaintFunction |
+| asio_streams.cpp:177:32:177:39 | call to source | asio_streams.cpp:197:45:197:56 | service_view | provenance | TaintFunction |
+| asio_streams.cpp:179:30:179:36 | *service | asio_streams.cpp:179:16:179:22 | call to resolve | provenance | MaD:112 |
+| asio_streams.cpp:180:30:180:36 | *service | asio_streams.cpp:180:16:180:22 | call to resolve | provenance | MaD:113 |
+| asio_streams.cpp:181:30:181:36 | *service | asio_streams.cpp:181:16:181:22 | call to resolve | provenance | MaD:114 |
+| asio_streams.cpp:182:30:182:36 | *service | asio_streams.cpp:182:16:182:22 | call to resolve | provenance | MaD:115 |
+| asio_streams.cpp:184:35:184:46 | service_view | asio_streams.cpp:184:16:184:22 | call to resolve | provenance | MaD:116 |
+| asio_streams.cpp:185:35:185:46 | service_view | asio_streams.cpp:185:16:185:22 | call to resolve | provenance | MaD:117 |
+| asio_streams.cpp:186:35:186:46 | service_view | asio_streams.cpp:186:16:186:22 | call to resolve | provenance | MaD:118 |
+| asio_streams.cpp:187:35:187:46 | service_view | asio_streams.cpp:187:16:187:22 | call to resolve | provenance | MaD:119 |
+| asio_streams.cpp:189:40:189:46 | *service | asio_streams.cpp:189:16:189:22 | call to resolve | provenance | MaD:104 |
+| asio_streams.cpp:190:40:190:46 | *service | asio_streams.cpp:190:16:190:22 | call to resolve | provenance | MaD:105 |
+| asio_streams.cpp:191:40:191:46 | *service | asio_streams.cpp:191:16:191:22 | call to resolve | provenance | MaD:106 |
+| asio_streams.cpp:192:40:192:46 | *service | asio_streams.cpp:192:16:192:22 | call to resolve | provenance | MaD:107 |
+| asio_streams.cpp:194:45:194:56 | service_view | asio_streams.cpp:194:16:194:22 | call to resolve | provenance | MaD:108 |
+| asio_streams.cpp:195:45:195:56 | service_view | asio_streams.cpp:195:16:195:22 | call to resolve | provenance | MaD:109 |
+| asio_streams.cpp:196:45:196:56 | service_view | asio_streams.cpp:196:16:196:22 | call to resolve | provenance | MaD:110 |
+| asio_streams.cpp:197:45:197:56 | service_view | asio_streams.cpp:197:16:197:22 | call to resolve | provenance | MaD:111 |
 | azure.cpp:253:48:253:60 | *call to GetBodyStream | azure.cpp:257:5:257:8 | *resp | provenance |  |
 | azure.cpp:253:48:253:60 | *call to GetBodyStream | azure.cpp:262:5:262:8 | *resp | provenance |  |
 | azure.cpp:253:48:253:60 | *call to GetBodyStream | azure.cpp:266:38:266:41 | *resp | provenance |  |
@@ -309,200 +309,200 @@ edges
 | bdlbb.cpp:94:46:94:48 | *src | bdlbb.cpp:94:37:94:40 | copy output argument | provenance | MaD:100 |
 | bdlbb.cpp:96:37:96:39 | copy output argument | bdlbb.cpp:97:7:97:10 | * ... | provenance |  |
 | bdlbb.cpp:96:42:96:44 | *dst | bdlbb.cpp:96:37:96:39 | copy output argument | provenance | MaD:102 |
-| protobuf.cpp:134:27:134:51 | call to source | protobuf.cpp:134:27:134:51 | call to source | provenance |  |
-| protobuf.cpp:134:27:134:51 | call to source | protobuf.cpp:135:22:135:25 | data | provenance |  |
-| protobuf.cpp:135:2:135:4 | ParseFromString output argument | protobuf.cpp:136:7:136:9 | msg | provenance |  |
-| protobuf.cpp:135:22:135:25 | data | protobuf.cpp:135:2:135:4 | ParseFromString output argument | provenance | MaD:141 |
-| protobuf.cpp:141:20:141:37 | call to source | protobuf.cpp:141:20:141:37 | call to source | provenance |  |
-| protobuf.cpp:141:20:141:37 | call to source | protobuf.cpp:142:22:142:25 | *data | provenance |  |
-| protobuf.cpp:142:2:142:4 | ParseFromString output argument | protobuf.cpp:143:7:143:9 | msg | provenance |  |
-| protobuf.cpp:142:22:142:25 | *data | protobuf.cpp:142:2:142:4 | ParseFromString output argument | provenance | MaD:140 |
-| protobuf.cpp:148:27:148:51 | call to source | protobuf.cpp:148:27:148:51 | call to source | provenance |  |
-| protobuf.cpp:148:27:148:51 | call to source | protobuf.cpp:149:29:149:32 | data | provenance |  |
-| protobuf.cpp:149:2:149:4 | ParsePartialFromString output argument | protobuf.cpp:150:7:150:9 | msg | provenance |  |
-| protobuf.cpp:149:29:149:32 | data | protobuf.cpp:149:2:149:4 | ParsePartialFromString output argument | provenance | MaD:149 |
-| protobuf.cpp:155:20:155:37 | call to source | protobuf.cpp:155:20:155:37 | call to source | provenance |  |
-| protobuf.cpp:155:20:155:37 | call to source | protobuf.cpp:156:29:156:32 | *data | provenance |  |
-| protobuf.cpp:156:2:156:4 | ParsePartialFromString output argument | protobuf.cpp:157:7:157:9 | msg | provenance |  |
-| protobuf.cpp:156:29:156:32 | *data | protobuf.cpp:156:2:156:4 | ParsePartialFromString output argument | provenance | MaD:148 |
-| protobuf.cpp:162:27:162:51 | call to source | protobuf.cpp:162:27:162:51 | call to source | provenance |  |
-| protobuf.cpp:162:27:162:51 | call to source | protobuf.cpp:163:22:163:25 | data | provenance |  |
-| protobuf.cpp:163:2:163:4 | MergeFromString output argument | protobuf.cpp:164:7:164:9 | msg | provenance |  |
-| protobuf.cpp:163:22:163:25 | data | protobuf.cpp:163:2:163:4 | MergeFromString output argument | provenance | MaD:129 |
-| protobuf.cpp:169:20:169:37 | call to source | protobuf.cpp:169:20:169:37 | call to source | provenance |  |
-| protobuf.cpp:169:20:169:37 | call to source | protobuf.cpp:170:22:170:25 | *data | provenance |  |
-| protobuf.cpp:170:2:170:4 | MergeFromString output argument | protobuf.cpp:171:7:171:9 | msg | provenance |  |
-| protobuf.cpp:170:22:170:25 | *data | protobuf.cpp:170:2:170:4 | MergeFromString output argument | provenance | MaD:128 |
-| protobuf.cpp:176:27:176:51 | call to source | protobuf.cpp:176:27:176:51 | call to source | provenance |  |
-| protobuf.cpp:176:27:176:51 | call to source | protobuf.cpp:177:29:177:32 | data | provenance |  |
-| protobuf.cpp:177:2:177:4 | MergePartialFromString output argument | protobuf.cpp:178:7:178:9 | msg | provenance |  |
-| protobuf.cpp:177:29:177:32 | data | protobuf.cpp:177:2:177:4 | MergePartialFromString output argument | provenance | MaD:134 |
-| protobuf.cpp:183:20:183:37 | call to source | protobuf.cpp:183:20:183:37 | call to source | provenance |  |
-| protobuf.cpp:183:20:183:37 | call to source | protobuf.cpp:184:29:184:32 | *data | provenance |  |
-| protobuf.cpp:184:2:184:4 | MergePartialFromString output argument | protobuf.cpp:185:7:185:9 | msg | provenance |  |
-| protobuf.cpp:184:29:184:32 | *data | protobuf.cpp:184:2:184:4 | MergePartialFromString output argument | provenance | MaD:133 |
-| protobuf.cpp:190:19:190:38 | call to source | protobuf.cpp:191:21:191:31 | *call to data | provenance | TaintFunction |
-| protobuf.cpp:191:2:191:4 | ParseFromArray output argument | protobuf.cpp:192:7:192:9 | msg | provenance |  |
-| protobuf.cpp:191:21:191:31 | *call to data | protobuf.cpp:191:2:191:4 | ParseFromArray output argument | provenance | MaD:135 |
-| protobuf.cpp:197:19:197:38 | call to source | protobuf.cpp:198:28:198:38 | *call to data | provenance | TaintFunction |
-| protobuf.cpp:198:2:198:4 | ParsePartialFromArray output argument | protobuf.cpp:199:7:199:9 | msg | provenance |  |
-| protobuf.cpp:198:28:198:38 | *call to data | protobuf.cpp:198:2:198:4 | ParsePartialFromArray output argument | provenance | MaD:143 |
-| protobuf.cpp:204:20:204:37 | call to source | protobuf.cpp:204:20:204:37 | call to source | provenance |  |
-| protobuf.cpp:204:20:204:37 | call to source | protobuf.cpp:205:20:205:23 | *data | provenance |  |
-| protobuf.cpp:205:2:205:4 | ParseFromCord output argument | protobuf.cpp:206:7:206:9 | msg | provenance |  |
-| protobuf.cpp:205:20:205:23 | *data | protobuf.cpp:205:2:205:4 | ParseFromCord output argument | provenance | MaD:138 |
-| protobuf.cpp:211:20:211:37 | call to source | protobuf.cpp:211:20:211:37 | call to source | provenance |  |
-| protobuf.cpp:211:20:211:37 | call to source | protobuf.cpp:212:27:212:30 | *data | provenance |  |
-| protobuf.cpp:212:2:212:4 | ParsePartialFromCord output argument | protobuf.cpp:213:7:213:9 | msg | provenance |  |
-| protobuf.cpp:212:27:212:30 | *data | protobuf.cpp:212:2:212:4 | ParsePartialFromCord output argument | provenance | MaD:146 |
-| protobuf.cpp:218:20:218:37 | call to source | protobuf.cpp:218:20:218:37 | call to source | provenance |  |
-| protobuf.cpp:218:20:218:37 | call to source | protobuf.cpp:219:20:219:23 | *data | provenance |  |
-| protobuf.cpp:219:2:219:4 | MergeFromCord output argument | protobuf.cpp:220:7:220:9 | msg | provenance |  |
-| protobuf.cpp:219:20:219:23 | *data | protobuf.cpp:219:2:219:4 | MergeFromCord output argument | provenance | MaD:127 |
-| protobuf.cpp:225:20:225:37 | call to source | protobuf.cpp:225:20:225:37 | call to source | provenance |  |
-| protobuf.cpp:225:20:225:37 | call to source | protobuf.cpp:226:27:226:30 | *data | provenance |  |
-| protobuf.cpp:226:2:226:4 | MergePartialFromCord output argument | protobuf.cpp:227:7:227:9 | msg | provenance |  |
-| protobuf.cpp:226:27:226:30 | *data | protobuf.cpp:226:2:226:4 | MergePartialFromCord output argument | provenance | MaD:132 |
-| protobuf.cpp:232:20:232:39 | call to source | protobuf.cpp:232:20:232:39 | call to source | provenance |  |
-| protobuf.cpp:232:20:232:39 | call to source | protobuf.cpp:233:23:233:25 | *& ... | provenance |  |
-| protobuf.cpp:233:2:233:4 | ParseFromIstream output argument | protobuf.cpp:234:7:234:9 | msg | provenance |  |
-| protobuf.cpp:233:23:233:25 | *& ... | protobuf.cpp:233:2:233:4 | ParseFromIstream output argument | provenance | MaD:139 |
-| protobuf.cpp:239:20:239:39 | call to source | protobuf.cpp:239:20:239:39 | call to source | provenance |  |
-| protobuf.cpp:239:20:239:39 | call to source | protobuf.cpp:240:30:240:32 | *& ... | provenance |  |
-| protobuf.cpp:240:2:240:4 | ParsePartialFromIstream output argument | protobuf.cpp:241:7:241:9 | msg | provenance |  |
-| protobuf.cpp:240:30:240:32 | *& ... | protobuf.cpp:240:2:240:4 | ParsePartialFromIstream output argument | provenance | MaD:147 |
-| protobuf.cpp:246:27:246:53 | call to source | protobuf.cpp:246:27:246:53 | call to source | provenance |  |
-| protobuf.cpp:246:27:246:53 | call to source | protobuf.cpp:247:30:247:32 | *& ... | provenance |  |
-| protobuf.cpp:247:2:247:4 | ParseFromZeroCopyStream output argument | protobuf.cpp:248:7:248:9 | msg | provenance |  |
-| protobuf.cpp:247:30:247:32 | *& ... | protobuf.cpp:247:2:247:4 | ParseFromZeroCopyStream output argument | provenance | MaD:142 |
-| protobuf.cpp:253:27:253:53 | call to source | protobuf.cpp:253:27:253:53 | call to source | provenance |  |
-| protobuf.cpp:253:27:253:53 | call to source | protobuf.cpp:254:37:254:39 | *& ... | provenance |  |
-| protobuf.cpp:254:2:254:4 | ParsePartialFromZeroCopyStream output argument | protobuf.cpp:255:7:255:9 | msg | provenance |  |
-| protobuf.cpp:254:37:254:39 | *& ... | protobuf.cpp:254:2:254:4 | ParsePartialFromZeroCopyStream output argument | provenance | MaD:150 |
-| protobuf.cpp:260:27:260:53 | call to source | protobuf.cpp:260:27:260:53 | call to source | provenance |  |
-| protobuf.cpp:260:27:260:53 | call to source | protobuf.cpp:261:37:261:39 | *& ... | provenance |  |
-| protobuf.cpp:261:2:261:4 | ParseFromBoundedZeroCopyStream output argument | protobuf.cpp:262:7:262:9 | msg | provenance |  |
-| protobuf.cpp:261:37:261:39 | *& ... | protobuf.cpp:261:2:261:4 | ParseFromBoundedZeroCopyStream output argument | provenance | MaD:136 |
-| protobuf.cpp:267:27:267:53 | call to source | protobuf.cpp:267:27:267:53 | call to source | provenance |  |
-| protobuf.cpp:267:27:267:53 | call to source | protobuf.cpp:268:44:268:46 | *& ... | provenance |  |
-| protobuf.cpp:268:2:268:4 | ParsePartialFromBoundedZeroCopyStream output argument | protobuf.cpp:269:7:269:9 | msg | provenance |  |
-| protobuf.cpp:268:44:268:46 | *& ... | protobuf.cpp:268:2:268:4 | ParsePartialFromBoundedZeroCopyStream output argument | provenance | MaD:144 |
-| protobuf.cpp:274:27:274:53 | call to source | protobuf.cpp:274:27:274:53 | call to source | provenance |  |
-| protobuf.cpp:274:27:274:53 | call to source | protobuf.cpp:275:37:275:39 | *& ... | provenance |  |
-| protobuf.cpp:275:2:275:4 | MergeFromBoundedZeroCopyStream output argument | protobuf.cpp:276:7:276:9 | msg | provenance |  |
-| protobuf.cpp:275:37:275:39 | *& ... | protobuf.cpp:275:2:275:4 | MergeFromBoundedZeroCopyStream output argument | provenance | MaD:125 |
-| protobuf.cpp:281:27:281:53 | call to source | protobuf.cpp:281:27:281:53 | call to source | provenance |  |
-| protobuf.cpp:281:27:281:53 | call to source | protobuf.cpp:282:44:282:46 | *& ... | provenance |  |
-| protobuf.cpp:282:2:282:4 | MergePartialFromBoundedZeroCopyStream output argument | protobuf.cpp:283:7:283:9 | msg | provenance |  |
-| protobuf.cpp:282:44:282:46 | *& ... | protobuf.cpp:282:2:282:4 | MergePartialFromBoundedZeroCopyStream output argument | provenance | MaD:130 |
-| protobuf.cpp:288:24:288:47 | call to source | protobuf.cpp:288:24:288:47 | call to source | provenance |  |
-| protobuf.cpp:288:24:288:47 | call to source | protobuf.cpp:289:27:289:29 | *& ... | provenance |  |
-| protobuf.cpp:289:2:289:4 | ParseFromCodedStream output argument | protobuf.cpp:290:7:290:9 | msg | provenance |  |
-| protobuf.cpp:289:27:289:29 | *& ... | protobuf.cpp:289:2:289:4 | ParseFromCodedStream output argument | provenance | MaD:137 |
-| protobuf.cpp:295:24:295:47 | call to source | protobuf.cpp:295:24:295:47 | call to source | provenance |  |
-| protobuf.cpp:295:24:295:47 | call to source | protobuf.cpp:296:34:296:36 | *& ... | provenance |  |
-| protobuf.cpp:296:2:296:4 | ParsePartialFromCodedStream output argument | protobuf.cpp:297:7:297:9 | msg | provenance |  |
-| protobuf.cpp:296:34:296:36 | *& ... | protobuf.cpp:296:2:296:4 | ParsePartialFromCodedStream output argument | provenance | MaD:145 |
-| protobuf.cpp:302:24:302:47 | call to source | protobuf.cpp:302:24:302:47 | call to source | provenance |  |
-| protobuf.cpp:302:24:302:47 | call to source | protobuf.cpp:303:27:303:29 | *& ... | provenance |  |
-| protobuf.cpp:303:2:303:4 | MergeFromCodedStream output argument | protobuf.cpp:304:7:304:9 | msg | provenance |  |
-| protobuf.cpp:303:27:303:29 | *& ... | protobuf.cpp:303:2:303:4 | MergeFromCodedStream output argument | provenance | MaD:126 |
-| protobuf.cpp:309:24:309:47 | call to source | protobuf.cpp:309:24:309:47 | call to source | provenance |  |
-| protobuf.cpp:309:24:309:47 | call to source | protobuf.cpp:310:34:310:36 | *& ... | provenance |  |
-| protobuf.cpp:310:2:310:4 | MergePartialFromCodedStream output argument | protobuf.cpp:311:7:311:9 | msg | provenance |  |
-| protobuf.cpp:310:34:310:36 | *& ... | protobuf.cpp:310:2:310:4 | MergePartialFromCodedStream output argument | provenance | MaD:131 |
-| protobuf.cpp:324:15:324:28 | call to source | protobuf.cpp:324:15:324:28 | call to source | provenance |  |
-| protobuf.cpp:324:15:324:28 | call to source | protobuf.cpp:326:2:326:4 | *msg | provenance |  |
-| protobuf.cpp:326:2:326:4 | *msg | protobuf.cpp:326:24:326:27 | SerializeToString output argument | provenance | MaD:165 |
-| protobuf.cpp:326:24:326:27 | SerializeToString output argument | protobuf.cpp:327:7:327:9 | out | provenance |  |
-| protobuf.cpp:331:15:331:28 | call to source | protobuf.cpp:331:15:331:28 | call to source | provenance |  |
-| protobuf.cpp:331:15:331:28 | call to source | protobuf.cpp:333:2:333:4 | *msg | provenance |  |
-| protobuf.cpp:333:2:333:4 | *msg | protobuf.cpp:333:31:333:34 | SerializePartialToString output argument | provenance | MaD:159 |
-| protobuf.cpp:333:31:333:34 | SerializePartialToString output argument | protobuf.cpp:334:7:334:9 | out | provenance |  |
-| protobuf.cpp:338:15:338:28 | call to source | protobuf.cpp:338:15:338:28 | call to source | provenance |  |
-| protobuf.cpp:338:15:338:28 | call to source | protobuf.cpp:340:2:340:4 | *msg | provenance |  |
-| protobuf.cpp:340:2:340:4 | *msg | protobuf.cpp:340:21:340:24 | AppendToString output argument | provenance | MaD:124 |
-| protobuf.cpp:340:21:340:24 | AppendToString output argument | protobuf.cpp:341:7:341:9 | out | provenance |  |
-| protobuf.cpp:345:15:345:28 | call to source | protobuf.cpp:345:15:345:28 | call to source | provenance |  |
-| protobuf.cpp:345:15:345:28 | call to source | protobuf.cpp:347:2:347:4 | *msg | provenance |  |
-| protobuf.cpp:347:2:347:4 | *msg | protobuf.cpp:347:28:347:31 | AppendPartialToString output argument | provenance | MaD:122 |
-| protobuf.cpp:347:28:347:31 | AppendPartialToString output argument | protobuf.cpp:348:7:348:9 | out | provenance |  |
-| protobuf.cpp:352:15:352:28 | call to source | protobuf.cpp:352:15:352:28 | call to source | provenance |  |
-| protobuf.cpp:352:15:352:28 | call to source | protobuf.cpp:354:2:354:4 | *msg | provenance |  |
-| protobuf.cpp:354:2:354:4 | *msg | protobuf.cpp:354:24:354:27 | SerializeToString output argument | provenance | MaD:165 |
-| protobuf.cpp:354:24:354:27 | SerializeToString output argument | protobuf.cpp:355:7:355:9 | out | provenance |  |
-| protobuf.cpp:359:15:359:28 | call to source | protobuf.cpp:359:15:359:28 | call to source | provenance |  |
-| protobuf.cpp:359:15:359:28 | call to source | protobuf.cpp:361:2:361:4 | *msg | provenance |  |
-| protobuf.cpp:361:2:361:4 | *msg | protobuf.cpp:361:31:361:34 | SerializePartialToString output argument | provenance | MaD:159 |
-| protobuf.cpp:361:31:361:34 | SerializePartialToString output argument | protobuf.cpp:362:7:362:9 | out | provenance |  |
-| protobuf.cpp:366:15:366:28 | call to source | protobuf.cpp:366:15:366:28 | call to source | provenance |  |
-| protobuf.cpp:366:15:366:28 | call to source | protobuf.cpp:368:2:368:4 | *msg | provenance |  |
-| protobuf.cpp:368:2:368:4 | *msg | protobuf.cpp:368:21:368:24 | AppendToString output argument | provenance | MaD:124 |
-| protobuf.cpp:368:21:368:24 | AppendToString output argument | protobuf.cpp:369:7:369:9 | out | provenance |  |
-| protobuf.cpp:373:15:373:28 | call to source | protobuf.cpp:373:15:373:28 | call to source | provenance |  |
-| protobuf.cpp:373:15:373:28 | call to source | protobuf.cpp:375:2:375:4 | *msg | provenance |  |
-| protobuf.cpp:375:2:375:4 | *msg | protobuf.cpp:375:28:375:31 | AppendPartialToString output argument | provenance | MaD:122 |
-| protobuf.cpp:375:28:375:31 | AppendPartialToString output argument | protobuf.cpp:376:7:376:9 | out | provenance |  |
-| protobuf.cpp:380:15:380:28 | call to source | protobuf.cpp:380:15:380:28 | call to source | provenance |  |
-| protobuf.cpp:380:15:380:28 | call to source | protobuf.cpp:382:2:382:4 | *msg | provenance |  |
-| protobuf.cpp:382:2:382:4 | *msg | protobuf.cpp:382:23:382:25 | SerializeToArray output argument | provenance | MaD:161 |
-| protobuf.cpp:382:23:382:25 | SerializeToArray output argument | protobuf.cpp:383:7:383:10 | * ... | provenance |  |
-| protobuf.cpp:387:15:387:28 | call to source | protobuf.cpp:387:15:387:28 | call to source | provenance |  |
-| protobuf.cpp:387:15:387:28 | call to source | protobuf.cpp:389:2:389:4 | *msg | provenance |  |
-| protobuf.cpp:389:2:389:4 | *msg | protobuf.cpp:389:30:389:32 | SerializePartialToArray output argument | provenance | MaD:155 |
-| protobuf.cpp:389:30:389:32 | SerializePartialToArray output argument | protobuf.cpp:390:7:390:10 | * ... | provenance |  |
-| protobuf.cpp:394:15:394:28 | call to source | protobuf.cpp:394:15:394:28 | call to source | provenance |  |
-| protobuf.cpp:394:15:394:28 | call to source | protobuf.cpp:396:2:396:4 | *msg | provenance |  |
-| protobuf.cpp:396:2:396:4 | *msg | protobuf.cpp:396:22:396:25 | SerializeToCord output argument | provenance | MaD:163 |
-| protobuf.cpp:396:22:396:25 | SerializeToCord output argument | protobuf.cpp:397:7:397:9 | out | provenance |  |
-| protobuf.cpp:401:15:401:28 | call to source | protobuf.cpp:401:15:401:28 | call to source | provenance |  |
-| protobuf.cpp:401:15:401:28 | call to source | protobuf.cpp:403:2:403:4 | *msg | provenance |  |
-| protobuf.cpp:403:2:403:4 | *msg | protobuf.cpp:403:29:403:32 | SerializePartialToCord output argument | provenance | MaD:157 |
-| protobuf.cpp:403:29:403:32 | SerializePartialToCord output argument | protobuf.cpp:404:7:404:9 | out | provenance |  |
-| protobuf.cpp:408:15:408:28 | call to source | protobuf.cpp:408:15:408:28 | call to source | provenance |  |
-| protobuf.cpp:408:15:408:28 | call to source | protobuf.cpp:410:2:410:4 | *msg | provenance |  |
-| protobuf.cpp:410:2:410:4 | *msg | protobuf.cpp:410:19:410:22 | AppendToCord output argument | provenance | MaD:123 |
-| protobuf.cpp:410:19:410:22 | AppendToCord output argument | protobuf.cpp:411:7:411:9 | out | provenance |  |
-| protobuf.cpp:415:15:415:28 | call to source | protobuf.cpp:415:15:415:28 | call to source | provenance |  |
-| protobuf.cpp:415:15:415:28 | call to source | protobuf.cpp:417:2:417:4 | *msg | provenance |  |
-| protobuf.cpp:417:2:417:4 | *msg | protobuf.cpp:417:26:417:29 | AppendPartialToCord output argument | provenance | MaD:121 |
-| protobuf.cpp:417:26:417:29 | AppendPartialToCord output argument | protobuf.cpp:418:7:418:9 | out | provenance |  |
-| protobuf.cpp:422:15:422:28 | call to source | protobuf.cpp:422:15:422:28 | call to source | provenance |  |
-| protobuf.cpp:422:15:422:28 | call to source | protobuf.cpp:424:2:424:4 | *msg | provenance |  |
-| protobuf.cpp:424:2:424:4 | *msg | protobuf.cpp:424:25:424:28 | SerializeToOstream output argument | provenance | MaD:164 |
-| protobuf.cpp:424:25:424:28 | SerializeToOstream output argument | protobuf.cpp:425:7:425:9 | out | provenance |  |
-| protobuf.cpp:429:15:429:28 | call to source | protobuf.cpp:429:15:429:28 | call to source | provenance |  |
-| protobuf.cpp:429:15:429:28 | call to source | protobuf.cpp:431:2:431:4 | *msg | provenance |  |
-| protobuf.cpp:431:2:431:4 | *msg | protobuf.cpp:431:32:431:35 | SerializePartialToOstream output argument | provenance | MaD:158 |
-| protobuf.cpp:431:32:431:35 | SerializePartialToOstream output argument | protobuf.cpp:432:7:432:9 | out | provenance |  |
-| protobuf.cpp:436:15:436:28 | call to source | protobuf.cpp:436:15:436:28 | call to source | provenance |  |
-| protobuf.cpp:436:15:436:28 | call to source | protobuf.cpp:438:2:438:4 | *msg | provenance |  |
-| protobuf.cpp:438:2:438:4 | *msg | protobuf.cpp:438:32:438:35 | SerializeToZeroCopyStream output argument | provenance | MaD:166 |
-| protobuf.cpp:438:32:438:35 | SerializeToZeroCopyStream output argument | protobuf.cpp:439:7:439:9 | out | provenance |  |
-| protobuf.cpp:443:15:443:28 | call to source | protobuf.cpp:443:15:443:28 | call to source | provenance |  |
-| protobuf.cpp:443:15:443:28 | call to source | protobuf.cpp:445:2:445:4 | *msg | provenance |  |
-| protobuf.cpp:445:2:445:4 | *msg | protobuf.cpp:445:39:445:42 | SerializePartialToZeroCopyStream output argument | provenance | MaD:160 |
-| protobuf.cpp:445:39:445:42 | SerializePartialToZeroCopyStream output argument | protobuf.cpp:446:7:446:9 | out | provenance |  |
-| protobuf.cpp:450:15:450:28 | call to source | protobuf.cpp:450:15:450:28 | call to source | provenance |  |
-| protobuf.cpp:450:15:450:28 | call to source | protobuf.cpp:452:2:452:4 | *msg | provenance |  |
-| protobuf.cpp:452:2:452:4 | *msg | protobuf.cpp:452:29:452:32 | SerializeToCodedStream output argument | provenance | MaD:162 |
-| protobuf.cpp:452:29:452:32 | SerializeToCodedStream output argument | protobuf.cpp:453:7:453:9 | out | provenance |  |
-| protobuf.cpp:457:15:457:28 | call to source | protobuf.cpp:457:15:457:28 | call to source | provenance |  |
-| protobuf.cpp:457:15:457:28 | call to source | protobuf.cpp:459:2:459:4 | *msg | provenance |  |
-| protobuf.cpp:459:2:459:4 | *msg | protobuf.cpp:459:36:459:39 | SerializePartialToCodedStream output argument | provenance | MaD:156 |
-| protobuf.cpp:459:36:459:39 | SerializePartialToCodedStream output argument | protobuf.cpp:460:7:460:9 | out | provenance |  |
-| protobuf.cpp:466:15:466:28 | call to source | protobuf.cpp:466:15:466:28 | call to source | provenance |  |
-| protobuf.cpp:466:15:466:28 | call to source | protobuf.cpp:467:7:467:9 | *msg | provenance |  |
-| protobuf.cpp:467:7:467:9 | *msg | protobuf.cpp:467:11:467:27 | call to SerializeAsString | provenance | MaD:152 |
-| protobuf.cpp:471:15:471:28 | call to source | protobuf.cpp:471:15:471:28 | call to source | provenance |  |
-| protobuf.cpp:471:15:471:28 | call to source | protobuf.cpp:472:7:472:9 | *msg | provenance |  |
-| protobuf.cpp:472:7:472:9 | *msg | protobuf.cpp:472:11:472:34 | call to SerializePartialAsString | provenance | MaD:154 |
-| protobuf.cpp:476:15:476:28 | call to source | protobuf.cpp:476:15:476:28 | call to source | provenance |  |
-| protobuf.cpp:476:15:476:28 | call to source | protobuf.cpp:477:7:477:9 | *msg | provenance |  |
-| protobuf.cpp:477:7:477:9 | *msg | protobuf.cpp:477:11:477:25 | call to SerializeAsCord | provenance | MaD:151 |
-| protobuf.cpp:481:15:481:28 | call to source | protobuf.cpp:481:15:481:28 | call to source | provenance |  |
-| protobuf.cpp:481:15:481:28 | call to source | protobuf.cpp:482:7:482:9 | *msg | provenance |  |
-| protobuf.cpp:482:7:482:9 | *msg | protobuf.cpp:482:11:482:32 | call to SerializePartialAsCord | provenance | MaD:153 |
+| protobuf.cpp:117:27:117:51 | call to source | protobuf.cpp:117:27:117:51 | call to source | provenance |  |
+| protobuf.cpp:117:27:117:51 | call to source | protobuf.cpp:118:22:118:25 | data | provenance |  |
+| protobuf.cpp:118:2:118:4 | ParseFromString output argument | protobuf.cpp:119:7:119:9 | msg | provenance |  |
+| protobuf.cpp:118:22:118:25 | data | protobuf.cpp:118:2:118:4 | ParseFromString output argument | provenance | MaD:141 |
+| protobuf.cpp:124:20:124:37 | call to source | protobuf.cpp:124:20:124:37 | call to source | provenance |  |
+| protobuf.cpp:124:20:124:37 | call to source | protobuf.cpp:125:22:125:25 | *data | provenance |  |
+| protobuf.cpp:125:2:125:4 | ParseFromString output argument | protobuf.cpp:126:7:126:9 | msg | provenance |  |
+| protobuf.cpp:125:22:125:25 | *data | protobuf.cpp:125:2:125:4 | ParseFromString output argument | provenance | MaD:140 |
+| protobuf.cpp:131:27:131:51 | call to source | protobuf.cpp:131:27:131:51 | call to source | provenance |  |
+| protobuf.cpp:131:27:131:51 | call to source | protobuf.cpp:132:29:132:32 | data | provenance |  |
+| protobuf.cpp:132:2:132:4 | ParsePartialFromString output argument | protobuf.cpp:133:7:133:9 | msg | provenance |  |
+| protobuf.cpp:132:29:132:32 | data | protobuf.cpp:132:2:132:4 | ParsePartialFromString output argument | provenance | MaD:149 |
+| protobuf.cpp:138:20:138:37 | call to source | protobuf.cpp:138:20:138:37 | call to source | provenance |  |
+| protobuf.cpp:138:20:138:37 | call to source | protobuf.cpp:139:29:139:32 | *data | provenance |  |
+| protobuf.cpp:139:2:139:4 | ParsePartialFromString output argument | protobuf.cpp:140:7:140:9 | msg | provenance |  |
+| protobuf.cpp:139:29:139:32 | *data | protobuf.cpp:139:2:139:4 | ParsePartialFromString output argument | provenance | MaD:148 |
+| protobuf.cpp:145:27:145:51 | call to source | protobuf.cpp:145:27:145:51 | call to source | provenance |  |
+| protobuf.cpp:145:27:145:51 | call to source | protobuf.cpp:146:22:146:25 | data | provenance |  |
+| protobuf.cpp:146:2:146:4 | MergeFromString output argument | protobuf.cpp:147:7:147:9 | msg | provenance |  |
+| protobuf.cpp:146:22:146:25 | data | protobuf.cpp:146:2:146:4 | MergeFromString output argument | provenance | MaD:129 |
+| protobuf.cpp:152:20:152:37 | call to source | protobuf.cpp:152:20:152:37 | call to source | provenance |  |
+| protobuf.cpp:152:20:152:37 | call to source | protobuf.cpp:153:22:153:25 | *data | provenance |  |
+| protobuf.cpp:153:2:153:4 | MergeFromString output argument | protobuf.cpp:154:7:154:9 | msg | provenance |  |
+| protobuf.cpp:153:22:153:25 | *data | protobuf.cpp:153:2:153:4 | MergeFromString output argument | provenance | MaD:128 |
+| protobuf.cpp:159:27:159:51 | call to source | protobuf.cpp:159:27:159:51 | call to source | provenance |  |
+| protobuf.cpp:159:27:159:51 | call to source | protobuf.cpp:160:29:160:32 | data | provenance |  |
+| protobuf.cpp:160:2:160:4 | MergePartialFromString output argument | protobuf.cpp:161:7:161:9 | msg | provenance |  |
+| protobuf.cpp:160:29:160:32 | data | protobuf.cpp:160:2:160:4 | MergePartialFromString output argument | provenance | MaD:134 |
+| protobuf.cpp:166:20:166:37 | call to source | protobuf.cpp:166:20:166:37 | call to source | provenance |  |
+| protobuf.cpp:166:20:166:37 | call to source | protobuf.cpp:167:29:167:32 | *data | provenance |  |
+| protobuf.cpp:167:2:167:4 | MergePartialFromString output argument | protobuf.cpp:168:7:168:9 | msg | provenance |  |
+| protobuf.cpp:167:29:167:32 | *data | protobuf.cpp:167:2:167:4 | MergePartialFromString output argument | provenance | MaD:133 |
+| protobuf.cpp:173:19:173:38 | call to source | protobuf.cpp:174:21:174:31 | *call to data | provenance | TaintFunction |
+| protobuf.cpp:174:2:174:4 | ParseFromArray output argument | protobuf.cpp:175:7:175:9 | msg | provenance |  |
+| protobuf.cpp:174:21:174:31 | *call to data | protobuf.cpp:174:2:174:4 | ParseFromArray output argument | provenance | MaD:135 |
+| protobuf.cpp:180:19:180:38 | call to source | protobuf.cpp:181:28:181:38 | *call to data | provenance | TaintFunction |
+| protobuf.cpp:181:2:181:4 | ParsePartialFromArray output argument | protobuf.cpp:182:7:182:9 | msg | provenance |  |
+| protobuf.cpp:181:28:181:38 | *call to data | protobuf.cpp:181:2:181:4 | ParsePartialFromArray output argument | provenance | MaD:143 |
+| protobuf.cpp:187:20:187:37 | call to source | protobuf.cpp:187:20:187:37 | call to source | provenance |  |
+| protobuf.cpp:187:20:187:37 | call to source | protobuf.cpp:188:20:188:23 | *data | provenance |  |
+| protobuf.cpp:188:2:188:4 | ParseFromCord output argument | protobuf.cpp:189:7:189:9 | msg | provenance |  |
+| protobuf.cpp:188:20:188:23 | *data | protobuf.cpp:188:2:188:4 | ParseFromCord output argument | provenance | MaD:138 |
+| protobuf.cpp:194:20:194:37 | call to source | protobuf.cpp:194:20:194:37 | call to source | provenance |  |
+| protobuf.cpp:194:20:194:37 | call to source | protobuf.cpp:195:27:195:30 | *data | provenance |  |
+| protobuf.cpp:195:2:195:4 | ParsePartialFromCord output argument | protobuf.cpp:196:7:196:9 | msg | provenance |  |
+| protobuf.cpp:195:27:195:30 | *data | protobuf.cpp:195:2:195:4 | ParsePartialFromCord output argument | provenance | MaD:146 |
+| protobuf.cpp:201:20:201:37 | call to source | protobuf.cpp:201:20:201:37 | call to source | provenance |  |
+| protobuf.cpp:201:20:201:37 | call to source | protobuf.cpp:202:20:202:23 | *data | provenance |  |
+| protobuf.cpp:202:2:202:4 | MergeFromCord output argument | protobuf.cpp:203:7:203:9 | msg | provenance |  |
+| protobuf.cpp:202:20:202:23 | *data | protobuf.cpp:202:2:202:4 | MergeFromCord output argument | provenance | MaD:127 |
+| protobuf.cpp:208:20:208:37 | call to source | protobuf.cpp:208:20:208:37 | call to source | provenance |  |
+| protobuf.cpp:208:20:208:37 | call to source | protobuf.cpp:209:27:209:30 | *data | provenance |  |
+| protobuf.cpp:209:2:209:4 | MergePartialFromCord output argument | protobuf.cpp:210:7:210:9 | msg | provenance |  |
+| protobuf.cpp:209:27:209:30 | *data | protobuf.cpp:209:2:209:4 | MergePartialFromCord output argument | provenance | MaD:132 |
+| protobuf.cpp:215:20:215:39 | call to source | protobuf.cpp:215:20:215:39 | call to source | provenance |  |
+| protobuf.cpp:215:20:215:39 | call to source | protobuf.cpp:216:23:216:25 | *& ... | provenance |  |
+| protobuf.cpp:216:2:216:4 | ParseFromIstream output argument | protobuf.cpp:217:7:217:9 | msg | provenance |  |
+| protobuf.cpp:216:23:216:25 | *& ... | protobuf.cpp:216:2:216:4 | ParseFromIstream output argument | provenance | MaD:139 |
+| protobuf.cpp:222:20:222:39 | call to source | protobuf.cpp:222:20:222:39 | call to source | provenance |  |
+| protobuf.cpp:222:20:222:39 | call to source | protobuf.cpp:223:30:223:32 | *& ... | provenance |  |
+| protobuf.cpp:223:2:223:4 | ParsePartialFromIstream output argument | protobuf.cpp:224:7:224:9 | msg | provenance |  |
+| protobuf.cpp:223:30:223:32 | *& ... | protobuf.cpp:223:2:223:4 | ParsePartialFromIstream output argument | provenance | MaD:147 |
+| protobuf.cpp:229:27:229:53 | call to source | protobuf.cpp:229:27:229:53 | call to source | provenance |  |
+| protobuf.cpp:229:27:229:53 | call to source | protobuf.cpp:230:30:230:32 | *& ... | provenance |  |
+| protobuf.cpp:230:2:230:4 | ParseFromZeroCopyStream output argument | protobuf.cpp:231:7:231:9 | msg | provenance |  |
+| protobuf.cpp:230:30:230:32 | *& ... | protobuf.cpp:230:2:230:4 | ParseFromZeroCopyStream output argument | provenance | MaD:142 |
+| protobuf.cpp:236:27:236:53 | call to source | protobuf.cpp:236:27:236:53 | call to source | provenance |  |
+| protobuf.cpp:236:27:236:53 | call to source | protobuf.cpp:237:37:237:39 | *& ... | provenance |  |
+| protobuf.cpp:237:2:237:4 | ParsePartialFromZeroCopyStream output argument | protobuf.cpp:238:7:238:9 | msg | provenance |  |
+| protobuf.cpp:237:37:237:39 | *& ... | protobuf.cpp:237:2:237:4 | ParsePartialFromZeroCopyStream output argument | provenance | MaD:150 |
+| protobuf.cpp:243:27:243:53 | call to source | protobuf.cpp:243:27:243:53 | call to source | provenance |  |
+| protobuf.cpp:243:27:243:53 | call to source | protobuf.cpp:244:37:244:39 | *& ... | provenance |  |
+| protobuf.cpp:244:2:244:4 | ParseFromBoundedZeroCopyStream output argument | protobuf.cpp:245:7:245:9 | msg | provenance |  |
+| protobuf.cpp:244:37:244:39 | *& ... | protobuf.cpp:244:2:244:4 | ParseFromBoundedZeroCopyStream output argument | provenance | MaD:136 |
+| protobuf.cpp:250:27:250:53 | call to source | protobuf.cpp:250:27:250:53 | call to source | provenance |  |
+| protobuf.cpp:250:27:250:53 | call to source | protobuf.cpp:251:44:251:46 | *& ... | provenance |  |
+| protobuf.cpp:251:2:251:4 | ParsePartialFromBoundedZeroCopyStream output argument | protobuf.cpp:252:7:252:9 | msg | provenance |  |
+| protobuf.cpp:251:44:251:46 | *& ... | protobuf.cpp:251:2:251:4 | ParsePartialFromBoundedZeroCopyStream output argument | provenance | MaD:144 |
+| protobuf.cpp:257:27:257:53 | call to source | protobuf.cpp:257:27:257:53 | call to source | provenance |  |
+| protobuf.cpp:257:27:257:53 | call to source | protobuf.cpp:258:37:258:39 | *& ... | provenance |  |
+| protobuf.cpp:258:2:258:4 | MergeFromBoundedZeroCopyStream output argument | protobuf.cpp:259:7:259:9 | msg | provenance |  |
+| protobuf.cpp:258:37:258:39 | *& ... | protobuf.cpp:258:2:258:4 | MergeFromBoundedZeroCopyStream output argument | provenance | MaD:125 |
+| protobuf.cpp:264:27:264:53 | call to source | protobuf.cpp:264:27:264:53 | call to source | provenance |  |
+| protobuf.cpp:264:27:264:53 | call to source | protobuf.cpp:265:44:265:46 | *& ... | provenance |  |
+| protobuf.cpp:265:2:265:4 | MergePartialFromBoundedZeroCopyStream output argument | protobuf.cpp:266:7:266:9 | msg | provenance |  |
+| protobuf.cpp:265:44:265:46 | *& ... | protobuf.cpp:265:2:265:4 | MergePartialFromBoundedZeroCopyStream output argument | provenance | MaD:130 |
+| protobuf.cpp:271:24:271:47 | call to source | protobuf.cpp:271:24:271:47 | call to source | provenance |  |
+| protobuf.cpp:271:24:271:47 | call to source | protobuf.cpp:272:27:272:29 | *& ... | provenance |  |
+| protobuf.cpp:272:2:272:4 | ParseFromCodedStream output argument | protobuf.cpp:273:7:273:9 | msg | provenance |  |
+| protobuf.cpp:272:27:272:29 | *& ... | protobuf.cpp:272:2:272:4 | ParseFromCodedStream output argument | provenance | MaD:137 |
+| protobuf.cpp:278:24:278:47 | call to source | protobuf.cpp:278:24:278:47 | call to source | provenance |  |
+| protobuf.cpp:278:24:278:47 | call to source | protobuf.cpp:279:34:279:36 | *& ... | provenance |  |
+| protobuf.cpp:279:2:279:4 | ParsePartialFromCodedStream output argument | protobuf.cpp:280:7:280:9 | msg | provenance |  |
+| protobuf.cpp:279:34:279:36 | *& ... | protobuf.cpp:279:2:279:4 | ParsePartialFromCodedStream output argument | provenance | MaD:145 |
+| protobuf.cpp:285:24:285:47 | call to source | protobuf.cpp:285:24:285:47 | call to source | provenance |  |
+| protobuf.cpp:285:24:285:47 | call to source | protobuf.cpp:286:27:286:29 | *& ... | provenance |  |
+| protobuf.cpp:286:2:286:4 | MergeFromCodedStream output argument | protobuf.cpp:287:7:287:9 | msg | provenance |  |
+| protobuf.cpp:286:27:286:29 | *& ... | protobuf.cpp:286:2:286:4 | MergeFromCodedStream output argument | provenance | MaD:126 |
+| protobuf.cpp:292:24:292:47 | call to source | protobuf.cpp:292:24:292:47 | call to source | provenance |  |
+| protobuf.cpp:292:24:292:47 | call to source | protobuf.cpp:293:34:293:36 | *& ... | provenance |  |
+| protobuf.cpp:293:2:293:4 | MergePartialFromCodedStream output argument | protobuf.cpp:294:7:294:9 | msg | provenance |  |
+| protobuf.cpp:293:34:293:36 | *& ... | protobuf.cpp:293:2:293:4 | MergePartialFromCodedStream output argument | provenance | MaD:131 |
+| protobuf.cpp:307:15:307:28 | call to source | protobuf.cpp:307:15:307:28 | call to source | provenance |  |
+| protobuf.cpp:307:15:307:28 | call to source | protobuf.cpp:309:2:309:4 | *msg | provenance |  |
+| protobuf.cpp:309:2:309:4 | *msg | protobuf.cpp:309:24:309:27 | SerializeToString output argument | provenance | MaD:165 |
+| protobuf.cpp:309:24:309:27 | SerializeToString output argument | protobuf.cpp:310:7:310:9 | out | provenance |  |
+| protobuf.cpp:314:15:314:28 | call to source | protobuf.cpp:314:15:314:28 | call to source | provenance |  |
+| protobuf.cpp:314:15:314:28 | call to source | protobuf.cpp:316:2:316:4 | *msg | provenance |  |
+| protobuf.cpp:316:2:316:4 | *msg | protobuf.cpp:316:31:316:34 | SerializePartialToString output argument | provenance | MaD:159 |
+| protobuf.cpp:316:31:316:34 | SerializePartialToString output argument | protobuf.cpp:317:7:317:9 | out | provenance |  |
+| protobuf.cpp:321:15:321:28 | call to source | protobuf.cpp:321:15:321:28 | call to source | provenance |  |
+| protobuf.cpp:321:15:321:28 | call to source | protobuf.cpp:323:2:323:4 | *msg | provenance |  |
+| protobuf.cpp:323:2:323:4 | *msg | protobuf.cpp:323:21:323:24 | AppendToString output argument | provenance | MaD:124 |
+| protobuf.cpp:323:21:323:24 | AppendToString output argument | protobuf.cpp:324:7:324:9 | out | provenance |  |
+| protobuf.cpp:328:15:328:28 | call to source | protobuf.cpp:328:15:328:28 | call to source | provenance |  |
+| protobuf.cpp:328:15:328:28 | call to source | protobuf.cpp:330:2:330:4 | *msg | provenance |  |
+| protobuf.cpp:330:2:330:4 | *msg | protobuf.cpp:330:28:330:31 | AppendPartialToString output argument | provenance | MaD:122 |
+| protobuf.cpp:330:28:330:31 | AppendPartialToString output argument | protobuf.cpp:331:7:331:9 | out | provenance |  |
+| protobuf.cpp:335:15:335:28 | call to source | protobuf.cpp:335:15:335:28 | call to source | provenance |  |
+| protobuf.cpp:335:15:335:28 | call to source | protobuf.cpp:337:2:337:4 | *msg | provenance |  |
+| protobuf.cpp:337:2:337:4 | *msg | protobuf.cpp:337:24:337:27 | SerializeToString output argument | provenance | MaD:165 |
+| protobuf.cpp:337:24:337:27 | SerializeToString output argument | protobuf.cpp:338:7:338:9 | out | provenance |  |
+| protobuf.cpp:342:15:342:28 | call to source | protobuf.cpp:342:15:342:28 | call to source | provenance |  |
+| protobuf.cpp:342:15:342:28 | call to source | protobuf.cpp:344:2:344:4 | *msg | provenance |  |
+| protobuf.cpp:344:2:344:4 | *msg | protobuf.cpp:344:31:344:34 | SerializePartialToString output argument | provenance | MaD:159 |
+| protobuf.cpp:344:31:344:34 | SerializePartialToString output argument | protobuf.cpp:345:7:345:9 | out | provenance |  |
+| protobuf.cpp:349:15:349:28 | call to source | protobuf.cpp:349:15:349:28 | call to source | provenance |  |
+| protobuf.cpp:349:15:349:28 | call to source | protobuf.cpp:351:2:351:4 | *msg | provenance |  |
+| protobuf.cpp:351:2:351:4 | *msg | protobuf.cpp:351:21:351:24 | AppendToString output argument | provenance | MaD:124 |
+| protobuf.cpp:351:21:351:24 | AppendToString output argument | protobuf.cpp:352:7:352:9 | out | provenance |  |
+| protobuf.cpp:356:15:356:28 | call to source | protobuf.cpp:356:15:356:28 | call to source | provenance |  |
+| protobuf.cpp:356:15:356:28 | call to source | protobuf.cpp:358:2:358:4 | *msg | provenance |  |
+| protobuf.cpp:358:2:358:4 | *msg | protobuf.cpp:358:28:358:31 | AppendPartialToString output argument | provenance | MaD:122 |
+| protobuf.cpp:358:28:358:31 | AppendPartialToString output argument | protobuf.cpp:359:7:359:9 | out | provenance |  |
+| protobuf.cpp:363:15:363:28 | call to source | protobuf.cpp:363:15:363:28 | call to source | provenance |  |
+| protobuf.cpp:363:15:363:28 | call to source | protobuf.cpp:365:2:365:4 | *msg | provenance |  |
+| protobuf.cpp:365:2:365:4 | *msg | protobuf.cpp:365:23:365:25 | SerializeToArray output argument | provenance | MaD:161 |
+| protobuf.cpp:365:23:365:25 | SerializeToArray output argument | protobuf.cpp:366:7:366:10 | * ... | provenance |  |
+| protobuf.cpp:370:15:370:28 | call to source | protobuf.cpp:370:15:370:28 | call to source | provenance |  |
+| protobuf.cpp:370:15:370:28 | call to source | protobuf.cpp:372:2:372:4 | *msg | provenance |  |
+| protobuf.cpp:372:2:372:4 | *msg | protobuf.cpp:372:30:372:32 | SerializePartialToArray output argument | provenance | MaD:155 |
+| protobuf.cpp:372:30:372:32 | SerializePartialToArray output argument | protobuf.cpp:373:7:373:10 | * ... | provenance |  |
+| protobuf.cpp:377:15:377:28 | call to source | protobuf.cpp:377:15:377:28 | call to source | provenance |  |
+| protobuf.cpp:377:15:377:28 | call to source | protobuf.cpp:379:2:379:4 | *msg | provenance |  |
+| protobuf.cpp:379:2:379:4 | *msg | protobuf.cpp:379:22:379:25 | SerializeToCord output argument | provenance | MaD:163 |
+| protobuf.cpp:379:22:379:25 | SerializeToCord output argument | protobuf.cpp:380:7:380:9 | out | provenance |  |
+| protobuf.cpp:384:15:384:28 | call to source | protobuf.cpp:384:15:384:28 | call to source | provenance |  |
+| protobuf.cpp:384:15:384:28 | call to source | protobuf.cpp:386:2:386:4 | *msg | provenance |  |
+| protobuf.cpp:386:2:386:4 | *msg | protobuf.cpp:386:29:386:32 | SerializePartialToCord output argument | provenance | MaD:157 |
+| protobuf.cpp:386:29:386:32 | SerializePartialToCord output argument | protobuf.cpp:387:7:387:9 | out | provenance |  |
+| protobuf.cpp:391:15:391:28 | call to source | protobuf.cpp:391:15:391:28 | call to source | provenance |  |
+| protobuf.cpp:391:15:391:28 | call to source | protobuf.cpp:393:2:393:4 | *msg | provenance |  |
+| protobuf.cpp:393:2:393:4 | *msg | protobuf.cpp:393:19:393:22 | AppendToCord output argument | provenance | MaD:123 |
+| protobuf.cpp:393:19:393:22 | AppendToCord output argument | protobuf.cpp:394:7:394:9 | out | provenance |  |
+| protobuf.cpp:398:15:398:28 | call to source | protobuf.cpp:398:15:398:28 | call to source | provenance |  |
+| protobuf.cpp:398:15:398:28 | call to source | protobuf.cpp:400:2:400:4 | *msg | provenance |  |
+| protobuf.cpp:400:2:400:4 | *msg | protobuf.cpp:400:26:400:29 | AppendPartialToCord output argument | provenance | MaD:121 |
+| protobuf.cpp:400:26:400:29 | AppendPartialToCord output argument | protobuf.cpp:401:7:401:9 | out | provenance |  |
+| protobuf.cpp:405:15:405:28 | call to source | protobuf.cpp:405:15:405:28 | call to source | provenance |  |
+| protobuf.cpp:405:15:405:28 | call to source | protobuf.cpp:407:2:407:4 | *msg | provenance |  |
+| protobuf.cpp:407:2:407:4 | *msg | protobuf.cpp:407:25:407:28 | SerializeToOstream output argument | provenance | MaD:164 |
+| protobuf.cpp:407:25:407:28 | SerializeToOstream output argument | protobuf.cpp:408:7:408:9 | out | provenance |  |
+| protobuf.cpp:412:15:412:28 | call to source | protobuf.cpp:412:15:412:28 | call to source | provenance |  |
+| protobuf.cpp:412:15:412:28 | call to source | protobuf.cpp:414:2:414:4 | *msg | provenance |  |
+| protobuf.cpp:414:2:414:4 | *msg | protobuf.cpp:414:32:414:35 | SerializePartialToOstream output argument | provenance | MaD:158 |
+| protobuf.cpp:414:32:414:35 | SerializePartialToOstream output argument | protobuf.cpp:415:7:415:9 | out | provenance |  |
+| protobuf.cpp:419:15:419:28 | call to source | protobuf.cpp:419:15:419:28 | call to source | provenance |  |
+| protobuf.cpp:419:15:419:28 | call to source | protobuf.cpp:421:2:421:4 | *msg | provenance |  |
+| protobuf.cpp:421:2:421:4 | *msg | protobuf.cpp:421:32:421:35 | SerializeToZeroCopyStream output argument | provenance | MaD:166 |
+| protobuf.cpp:421:32:421:35 | SerializeToZeroCopyStream output argument | protobuf.cpp:422:7:422:9 | out | provenance |  |
+| protobuf.cpp:426:15:426:28 | call to source | protobuf.cpp:426:15:426:28 | call to source | provenance |  |
+| protobuf.cpp:426:15:426:28 | call to source | protobuf.cpp:428:2:428:4 | *msg | provenance |  |
+| protobuf.cpp:428:2:428:4 | *msg | protobuf.cpp:428:39:428:42 | SerializePartialToZeroCopyStream output argument | provenance | MaD:160 |
+| protobuf.cpp:428:39:428:42 | SerializePartialToZeroCopyStream output argument | protobuf.cpp:429:7:429:9 | out | provenance |  |
+| protobuf.cpp:433:15:433:28 | call to source | protobuf.cpp:433:15:433:28 | call to source | provenance |  |
+| protobuf.cpp:433:15:433:28 | call to source | protobuf.cpp:435:2:435:4 | *msg | provenance |  |
+| protobuf.cpp:435:2:435:4 | *msg | protobuf.cpp:435:29:435:32 | SerializeToCodedStream output argument | provenance | MaD:162 |
+| protobuf.cpp:435:29:435:32 | SerializeToCodedStream output argument | protobuf.cpp:436:7:436:9 | out | provenance |  |
+| protobuf.cpp:440:15:440:28 | call to source | protobuf.cpp:440:15:440:28 | call to source | provenance |  |
+| protobuf.cpp:440:15:440:28 | call to source | protobuf.cpp:442:2:442:4 | *msg | provenance |  |
+| protobuf.cpp:442:2:442:4 | *msg | protobuf.cpp:442:36:442:39 | SerializePartialToCodedStream output argument | provenance | MaD:156 |
+| protobuf.cpp:442:36:442:39 | SerializePartialToCodedStream output argument | protobuf.cpp:443:7:443:9 | out | provenance |  |
+| protobuf.cpp:449:15:449:28 | call to source | protobuf.cpp:449:15:449:28 | call to source | provenance |  |
+| protobuf.cpp:449:15:449:28 | call to source | protobuf.cpp:450:7:450:9 | *msg | provenance |  |
+| protobuf.cpp:450:7:450:9 | *msg | protobuf.cpp:450:11:450:27 | call to SerializeAsString | provenance | MaD:152 |
+| protobuf.cpp:454:15:454:28 | call to source | protobuf.cpp:454:15:454:28 | call to source | provenance |  |
+| protobuf.cpp:454:15:454:28 | call to source | protobuf.cpp:455:7:455:9 | *msg | provenance |  |
+| protobuf.cpp:455:7:455:9 | *msg | protobuf.cpp:455:11:455:34 | call to SerializePartialAsString | provenance | MaD:154 |
+| protobuf.cpp:459:15:459:28 | call to source | protobuf.cpp:459:15:459:28 | call to source | provenance |  |
+| protobuf.cpp:459:15:459:28 | call to source | protobuf.cpp:460:7:460:9 | *msg | provenance |  |
+| protobuf.cpp:460:7:460:9 | *msg | protobuf.cpp:460:11:460:25 | call to SerializeAsCord | provenance | MaD:151 |
+| protobuf.cpp:464:15:464:28 | call to source | protobuf.cpp:464:15:464:28 | call to source | provenance |  |
+| protobuf.cpp:464:15:464:28 | call to source | protobuf.cpp:465:7:465:9 | *msg | provenance |  |
+| protobuf.cpp:465:7:465:9 | *msg | protobuf.cpp:465:11:465:32 | call to SerializePartialAsCord | provenance | MaD:153 |
 | test.cpp:7:47:7:52 | value2 | test.cpp:7:64:7:69 | value2 | provenance |  |
 | test.cpp:7:64:7:69 | value2 | test.cpp:7:5:7:30 | *ymlStepGenerated_with_body | provenance |  |
 | test.cpp:10:10:10:18 | call to ymlSource | test.cpp:10:10:10:18 | call to ymlSource | provenance | Src:MaD:48  |
@@ -846,84 +846,84 @@ edges
 | windows.cpp:1172:21:1172:24 | *guid | windows.cpp:1172:27:1172:29 | StringFromGUID2 output argument | provenance | MaD:76 |
 | windows.cpp:1172:27:1172:29 | StringFromGUID2 output argument | windows.cpp:1174:10:1174:13 | * ... | provenance |  |
 nodes
-| asio_streams.cpp:129:34:129:44 | read_until output argument | semmle.label | read_until output argument |
-| asio_streams.cpp:133:7:133:17 | recv_buffer | semmle.label | recv_buffer |
-| asio_streams.cpp:135:29:135:39 | recv_buffer | semmle.label | recv_buffer |
-| asio_streams.cpp:139:37:139:44 | call to source | semmle.label | call to source |
-| asio_streams.cpp:140:7:140:14 | send_str | semmle.label | send_str |
-| asio_streams.cpp:142:44:142:62 | call to buffer | semmle.label | call to buffer |
-| asio_streams.cpp:142:44:142:62 | call to buffer | semmle.label | call to buffer |
-| asio_streams.cpp:142:64:142:71 | *send_str | semmle.label | *send_str |
-| asio_streams.cpp:143:7:143:17 | send_buffer | semmle.label | send_buffer |
-| asio_streams.cpp:145:29:145:39 | send_buffer | semmle.label | send_buffer |
-| asio_streams.cpp:156:19:156:26 | call to source | semmle.label | call to source |
-| asio_streams.cpp:158:29:158:36 | call to source | semmle.label | call to source |
+| asio_streams.cpp:116:34:116:44 | read_until output argument | semmle.label | read_until output argument |
+| asio_streams.cpp:120:7:120:17 | recv_buffer | semmle.label | recv_buffer |
+| asio_streams.cpp:122:29:122:39 | recv_buffer | semmle.label | recv_buffer |
+| asio_streams.cpp:126:37:126:44 | call to source | semmle.label | call to source |
+| asio_streams.cpp:127:7:127:14 | send_str | semmle.label | send_str |
+| asio_streams.cpp:129:44:129:62 | call to buffer | semmle.label | call to buffer |
+| asio_streams.cpp:129:44:129:62 | call to buffer | semmle.label | call to buffer |
+| asio_streams.cpp:129:64:129:71 | *send_str | semmle.label | *send_str |
+| asio_streams.cpp:130:7:130:17 | send_buffer | semmle.label | send_buffer |
+| asio_streams.cpp:132:29:132:39 | send_buffer | semmle.label | send_buffer |
+| asio_streams.cpp:143:19:143:26 | call to source | semmle.label | call to source |
+| asio_streams.cpp:145:29:145:36 | call to source | semmle.label | call to source |
+| asio_streams.cpp:148:16:148:22 | call to resolve | semmle.label | call to resolve |
+| asio_streams.cpp:148:24:148:27 | *host | semmle.label | *host |
+| asio_streams.cpp:149:16:149:22 | call to resolve | semmle.label | call to resolve |
+| asio_streams.cpp:149:24:149:27 | *host | semmle.label | *host |
+| asio_streams.cpp:150:16:150:22 | call to resolve | semmle.label | call to resolve |
+| asio_streams.cpp:150:24:150:27 | *host | semmle.label | *host |
+| asio_streams.cpp:151:16:151:22 | call to resolve | semmle.label | call to resolve |
+| asio_streams.cpp:151:24:151:27 | *host | semmle.label | *host |
+| asio_streams.cpp:153:16:153:22 | call to resolve | semmle.label | call to resolve |
+| asio_streams.cpp:153:24:153:32 | host_view | semmle.label | host_view |
+| asio_streams.cpp:154:16:154:22 | call to resolve | semmle.label | call to resolve |
+| asio_streams.cpp:154:24:154:32 | host_view | semmle.label | host_view |
+| asio_streams.cpp:155:16:155:22 | call to resolve | semmle.label | call to resolve |
+| asio_streams.cpp:155:24:155:32 | host_view | semmle.label | host_view |
+| asio_streams.cpp:156:16:156:22 | call to resolve | semmle.label | call to resolve |
+| asio_streams.cpp:156:24:156:32 | host_view | semmle.label | host_view |
+| asio_streams.cpp:158:16:158:22 | call to resolve | semmle.label | call to resolve |
+| asio_streams.cpp:158:34:158:37 | *host | semmle.label | *host |
+| asio_streams.cpp:159:16:159:22 | call to resolve | semmle.label | call to resolve |
+| asio_streams.cpp:159:34:159:37 | *host | semmle.label | *host |
+| asio_streams.cpp:160:16:160:22 | call to resolve | semmle.label | call to resolve |
+| asio_streams.cpp:160:34:160:37 | *host | semmle.label | *host |
 | asio_streams.cpp:161:16:161:22 | call to resolve | semmle.label | call to resolve |
-| asio_streams.cpp:161:24:161:27 | *host | semmle.label | *host |
-| asio_streams.cpp:162:16:162:22 | call to resolve | semmle.label | call to resolve |
-| asio_streams.cpp:162:24:162:27 | *host | semmle.label | *host |
+| asio_streams.cpp:161:34:161:37 | *host | semmle.label | *host |
 | asio_streams.cpp:163:16:163:22 | call to resolve | semmle.label | call to resolve |
-| asio_streams.cpp:163:24:163:27 | *host | semmle.label | *host |
+| asio_streams.cpp:163:34:163:42 | host_view | semmle.label | host_view |
 | asio_streams.cpp:164:16:164:22 | call to resolve | semmle.label | call to resolve |
-| asio_streams.cpp:164:24:164:27 | *host | semmle.label | *host |
+| asio_streams.cpp:164:34:164:42 | host_view | semmle.label | host_view |
+| asio_streams.cpp:165:16:165:22 | call to resolve | semmle.label | call to resolve |
+| asio_streams.cpp:165:34:165:42 | host_view | semmle.label | host_view |
 | asio_streams.cpp:166:16:166:22 | call to resolve | semmle.label | call to resolve |
-| asio_streams.cpp:166:24:166:32 | host_view | semmle.label | host_view |
-| asio_streams.cpp:167:16:167:22 | call to resolve | semmle.label | call to resolve |
-| asio_streams.cpp:167:24:167:32 | host_view | semmle.label | host_view |
-| asio_streams.cpp:168:16:168:22 | call to resolve | semmle.label | call to resolve |
-| asio_streams.cpp:168:24:168:32 | host_view | semmle.label | host_view |
-| asio_streams.cpp:169:16:169:22 | call to resolve | semmle.label | call to resolve |
-| asio_streams.cpp:169:24:169:32 | host_view | semmle.label | host_view |
-| asio_streams.cpp:171:16:171:22 | call to resolve | semmle.label | call to resolve |
-| asio_streams.cpp:171:34:171:37 | *host | semmle.label | *host |
-| asio_streams.cpp:172:16:172:22 | call to resolve | semmle.label | call to resolve |
-| asio_streams.cpp:172:34:172:37 | *host | semmle.label | *host |
-| asio_streams.cpp:173:16:173:22 | call to resolve | semmle.label | call to resolve |
-| asio_streams.cpp:173:34:173:37 | *host | semmle.label | *host |
-| asio_streams.cpp:174:16:174:22 | call to resolve | semmle.label | call to resolve |
-| asio_streams.cpp:174:34:174:37 | *host | semmle.label | *host |
-| asio_streams.cpp:176:16:176:22 | call to resolve | semmle.label | call to resolve |
-| asio_streams.cpp:176:34:176:42 | host_view | semmle.label | host_view |
-| asio_streams.cpp:177:16:177:22 | call to resolve | semmle.label | call to resolve |
-| asio_streams.cpp:177:34:177:42 | host_view | semmle.label | host_view |
-| asio_streams.cpp:178:16:178:22 | call to resolve | semmle.label | call to resolve |
-| asio_streams.cpp:178:34:178:42 | host_view | semmle.label | host_view |
+| asio_streams.cpp:166:34:166:42 | host_view | semmle.label | host_view |
+| asio_streams.cpp:175:22:175:29 | call to source | semmle.label | call to source |
+| asio_streams.cpp:177:32:177:39 | call to source | semmle.label | call to source |
 | asio_streams.cpp:179:16:179:22 | call to resolve | semmle.label | call to resolve |
-| asio_streams.cpp:179:34:179:42 | host_view | semmle.label | host_view |
-| asio_streams.cpp:188:22:188:29 | call to source | semmle.label | call to source |
-| asio_streams.cpp:190:32:190:39 | call to source | semmle.label | call to source |
+| asio_streams.cpp:179:30:179:36 | *service | semmle.label | *service |
+| asio_streams.cpp:180:16:180:22 | call to resolve | semmle.label | call to resolve |
+| asio_streams.cpp:180:30:180:36 | *service | semmle.label | *service |
+| asio_streams.cpp:181:16:181:22 | call to resolve | semmle.label | call to resolve |
+| asio_streams.cpp:181:30:181:36 | *service | semmle.label | *service |
+| asio_streams.cpp:182:16:182:22 | call to resolve | semmle.label | call to resolve |
+| asio_streams.cpp:182:30:182:36 | *service | semmle.label | *service |
+| asio_streams.cpp:184:16:184:22 | call to resolve | semmle.label | call to resolve |
+| asio_streams.cpp:184:35:184:46 | service_view | semmle.label | service_view |
+| asio_streams.cpp:185:16:185:22 | call to resolve | semmle.label | call to resolve |
+| asio_streams.cpp:185:35:185:46 | service_view | semmle.label | service_view |
+| asio_streams.cpp:186:16:186:22 | call to resolve | semmle.label | call to resolve |
+| asio_streams.cpp:186:35:186:46 | service_view | semmle.label | service_view |
+| asio_streams.cpp:187:16:187:22 | call to resolve | semmle.label | call to resolve |
+| asio_streams.cpp:187:35:187:46 | service_view | semmle.label | service_view |
+| asio_streams.cpp:189:16:189:22 | call to resolve | semmle.label | call to resolve |
+| asio_streams.cpp:189:40:189:46 | *service | semmle.label | *service |
+| asio_streams.cpp:190:16:190:22 | call to resolve | semmle.label | call to resolve |
+| asio_streams.cpp:190:40:190:46 | *service | semmle.label | *service |
+| asio_streams.cpp:191:16:191:22 | call to resolve | semmle.label | call to resolve |
+| asio_streams.cpp:191:40:191:46 | *service | semmle.label | *service |
 | asio_streams.cpp:192:16:192:22 | call to resolve | semmle.label | call to resolve |
-| asio_streams.cpp:192:30:192:36 | *service | semmle.label | *service |
-| asio_streams.cpp:193:16:193:22 | call to resolve | semmle.label | call to resolve |
-| asio_streams.cpp:193:30:193:36 | *service | semmle.label | *service |
+| asio_streams.cpp:192:40:192:46 | *service | semmle.label | *service |
 | asio_streams.cpp:194:16:194:22 | call to resolve | semmle.label | call to resolve |
-| asio_streams.cpp:194:30:194:36 | *service | semmle.label | *service |
+| asio_streams.cpp:194:45:194:56 | service_view | semmle.label | service_view |
 | asio_streams.cpp:195:16:195:22 | call to resolve | semmle.label | call to resolve |
-| asio_streams.cpp:195:30:195:36 | *service | semmle.label | *service |
+| asio_streams.cpp:195:45:195:56 | service_view | semmle.label | service_view |
+| asio_streams.cpp:196:16:196:22 | call to resolve | semmle.label | call to resolve |
+| asio_streams.cpp:196:45:196:56 | service_view | semmle.label | service_view |
 | asio_streams.cpp:197:16:197:22 | call to resolve | semmle.label | call to resolve |
-| asio_streams.cpp:197:35:197:46 | service_view | semmle.label | service_view |
-| asio_streams.cpp:198:16:198:22 | call to resolve | semmle.label | call to resolve |
-| asio_streams.cpp:198:35:198:46 | service_view | semmle.label | service_view |
-| asio_streams.cpp:199:16:199:22 | call to resolve | semmle.label | call to resolve |
-| asio_streams.cpp:199:35:199:46 | service_view | semmle.label | service_view |
-| asio_streams.cpp:200:16:200:22 | call to resolve | semmle.label | call to resolve |
-| asio_streams.cpp:200:35:200:46 | service_view | semmle.label | service_view |
-| asio_streams.cpp:202:16:202:22 | call to resolve | semmle.label | call to resolve |
-| asio_streams.cpp:202:40:202:46 | *service | semmle.label | *service |
-| asio_streams.cpp:203:16:203:22 | call to resolve | semmle.label | call to resolve |
-| asio_streams.cpp:203:40:203:46 | *service | semmle.label | *service |
-| asio_streams.cpp:204:16:204:22 | call to resolve | semmle.label | call to resolve |
-| asio_streams.cpp:204:40:204:46 | *service | semmle.label | *service |
-| asio_streams.cpp:205:16:205:22 | call to resolve | semmle.label | call to resolve |
-| asio_streams.cpp:205:40:205:46 | *service | semmle.label | *service |
-| asio_streams.cpp:207:16:207:22 | call to resolve | semmle.label | call to resolve |
-| asio_streams.cpp:207:45:207:56 | service_view | semmle.label | service_view |
-| asio_streams.cpp:208:16:208:22 | call to resolve | semmle.label | call to resolve |
-| asio_streams.cpp:208:45:208:56 | service_view | semmle.label | service_view |
-| asio_streams.cpp:209:16:209:22 | call to resolve | semmle.label | call to resolve |
-| asio_streams.cpp:209:45:209:56 | service_view | semmle.label | service_view |
-| asio_streams.cpp:210:16:210:22 | call to resolve | semmle.label | call to resolve |
-| asio_streams.cpp:210:45:210:56 | service_view | semmle.label | service_view |
+| asio_streams.cpp:197:45:197:56 | service_view | semmle.label | service_view |
 | azure.cpp:253:48:253:60 | *call to GetBodyStream | semmle.label | *call to GetBodyStream |
 | azure.cpp:253:48:253:60 | call to GetBodyStream | semmle.label | call to GetBodyStream |
 | azure.cpp:257:5:257:8 | *resp | semmle.label | *resp |
@@ -1005,250 +1005,250 @@ nodes
 | bdlbb.cpp:96:37:96:39 | copy output argument | semmle.label | copy output argument |
 | bdlbb.cpp:96:42:96:44 | *dst | semmle.label | *dst |
 | bdlbb.cpp:97:7:97:10 | * ... | semmle.label | * ... |
-| protobuf.cpp:134:27:134:51 | call to source | semmle.label | call to source |
-| protobuf.cpp:134:27:134:51 | call to source | semmle.label | call to source |
-| protobuf.cpp:135:2:135:4 | ParseFromString output argument | semmle.label | ParseFromString output argument |
-| protobuf.cpp:135:22:135:25 | data | semmle.label | data |
-| protobuf.cpp:136:7:136:9 | msg | semmle.label | msg |
-| protobuf.cpp:141:20:141:37 | call to source | semmle.label | call to source |
-| protobuf.cpp:141:20:141:37 | call to source | semmle.label | call to source |
-| protobuf.cpp:142:2:142:4 | ParseFromString output argument | semmle.label | ParseFromString output argument |
-| protobuf.cpp:142:22:142:25 | *data | semmle.label | *data |
-| protobuf.cpp:143:7:143:9 | msg | semmle.label | msg |
-| protobuf.cpp:148:27:148:51 | call to source | semmle.label | call to source |
-| protobuf.cpp:148:27:148:51 | call to source | semmle.label | call to source |
-| protobuf.cpp:149:2:149:4 | ParsePartialFromString output argument | semmle.label | ParsePartialFromString output argument |
-| protobuf.cpp:149:29:149:32 | data | semmle.label | data |
-| protobuf.cpp:150:7:150:9 | msg | semmle.label | msg |
-| protobuf.cpp:155:20:155:37 | call to source | semmle.label | call to source |
-| protobuf.cpp:155:20:155:37 | call to source | semmle.label | call to source |
-| protobuf.cpp:156:2:156:4 | ParsePartialFromString output argument | semmle.label | ParsePartialFromString output argument |
-| protobuf.cpp:156:29:156:32 | *data | semmle.label | *data |
-| protobuf.cpp:157:7:157:9 | msg | semmle.label | msg |
-| protobuf.cpp:162:27:162:51 | call to source | semmle.label | call to source |
-| protobuf.cpp:162:27:162:51 | call to source | semmle.label | call to source |
-| protobuf.cpp:163:2:163:4 | MergeFromString output argument | semmle.label | MergeFromString output argument |
-| protobuf.cpp:163:22:163:25 | data | semmle.label | data |
-| protobuf.cpp:164:7:164:9 | msg | semmle.label | msg |
-| protobuf.cpp:169:20:169:37 | call to source | semmle.label | call to source |
-| protobuf.cpp:169:20:169:37 | call to source | semmle.label | call to source |
-| protobuf.cpp:170:2:170:4 | MergeFromString output argument | semmle.label | MergeFromString output argument |
-| protobuf.cpp:170:22:170:25 | *data | semmle.label | *data |
-| protobuf.cpp:171:7:171:9 | msg | semmle.label | msg |
-| protobuf.cpp:176:27:176:51 | call to source | semmle.label | call to source |
-| protobuf.cpp:176:27:176:51 | call to source | semmle.label | call to source |
-| protobuf.cpp:177:2:177:4 | MergePartialFromString output argument | semmle.label | MergePartialFromString output argument |
-| protobuf.cpp:177:29:177:32 | data | semmle.label | data |
-| protobuf.cpp:178:7:178:9 | msg | semmle.label | msg |
-| protobuf.cpp:183:20:183:37 | call to source | semmle.label | call to source |
-| protobuf.cpp:183:20:183:37 | call to source | semmle.label | call to source |
-| protobuf.cpp:184:2:184:4 | MergePartialFromString output argument | semmle.label | MergePartialFromString output argument |
-| protobuf.cpp:184:29:184:32 | *data | semmle.label | *data |
-| protobuf.cpp:185:7:185:9 | msg | semmle.label | msg |
-| protobuf.cpp:190:19:190:38 | call to source | semmle.label | call to source |
-| protobuf.cpp:191:2:191:4 | ParseFromArray output argument | semmle.label | ParseFromArray output argument |
-| protobuf.cpp:191:21:191:31 | *call to data | semmle.label | *call to data |
-| protobuf.cpp:192:7:192:9 | msg | semmle.label | msg |
-| protobuf.cpp:197:19:197:38 | call to source | semmle.label | call to source |
-| protobuf.cpp:198:2:198:4 | ParsePartialFromArray output argument | semmle.label | ParsePartialFromArray output argument |
-| protobuf.cpp:198:28:198:38 | *call to data | semmle.label | *call to data |
-| protobuf.cpp:199:7:199:9 | msg | semmle.label | msg |
-| protobuf.cpp:204:20:204:37 | call to source | semmle.label | call to source |
-| protobuf.cpp:204:20:204:37 | call to source | semmle.label | call to source |
-| protobuf.cpp:205:2:205:4 | ParseFromCord output argument | semmle.label | ParseFromCord output argument |
-| protobuf.cpp:205:20:205:23 | *data | semmle.label | *data |
-| protobuf.cpp:206:7:206:9 | msg | semmle.label | msg |
-| protobuf.cpp:211:20:211:37 | call to source | semmle.label | call to source |
-| protobuf.cpp:211:20:211:37 | call to source | semmle.label | call to source |
-| protobuf.cpp:212:2:212:4 | ParsePartialFromCord output argument | semmle.label | ParsePartialFromCord output argument |
-| protobuf.cpp:212:27:212:30 | *data | semmle.label | *data |
-| protobuf.cpp:213:7:213:9 | msg | semmle.label | msg |
-| protobuf.cpp:218:20:218:37 | call to source | semmle.label | call to source |
-| protobuf.cpp:218:20:218:37 | call to source | semmle.label | call to source |
-| protobuf.cpp:219:2:219:4 | MergeFromCord output argument | semmle.label | MergeFromCord output argument |
-| protobuf.cpp:219:20:219:23 | *data | semmle.label | *data |
-| protobuf.cpp:220:7:220:9 | msg | semmle.label | msg |
-| protobuf.cpp:225:20:225:37 | call to source | semmle.label | call to source |
-| protobuf.cpp:225:20:225:37 | call to source | semmle.label | call to source |
-| protobuf.cpp:226:2:226:4 | MergePartialFromCord output argument | semmle.label | MergePartialFromCord output argument |
-| protobuf.cpp:226:27:226:30 | *data | semmle.label | *data |
-| protobuf.cpp:227:7:227:9 | msg | semmle.label | msg |
-| protobuf.cpp:232:20:232:39 | call to source | semmle.label | call to source |
-| protobuf.cpp:232:20:232:39 | call to source | semmle.label | call to source |
-| protobuf.cpp:233:2:233:4 | ParseFromIstream output argument | semmle.label | ParseFromIstream output argument |
-| protobuf.cpp:233:23:233:25 | *& ... | semmle.label | *& ... |
-| protobuf.cpp:234:7:234:9 | msg | semmle.label | msg |
-| protobuf.cpp:239:20:239:39 | call to source | semmle.label | call to source |
-| protobuf.cpp:239:20:239:39 | call to source | semmle.label | call to source |
-| protobuf.cpp:240:2:240:4 | ParsePartialFromIstream output argument | semmle.label | ParsePartialFromIstream output argument |
-| protobuf.cpp:240:30:240:32 | *& ... | semmle.label | *& ... |
-| protobuf.cpp:241:7:241:9 | msg | semmle.label | msg |
-| protobuf.cpp:246:27:246:53 | call to source | semmle.label | call to source |
-| protobuf.cpp:246:27:246:53 | call to source | semmle.label | call to source |
-| protobuf.cpp:247:2:247:4 | ParseFromZeroCopyStream output argument | semmle.label | ParseFromZeroCopyStream output argument |
-| protobuf.cpp:247:30:247:32 | *& ... | semmle.label | *& ... |
-| protobuf.cpp:248:7:248:9 | msg | semmle.label | msg |
-| protobuf.cpp:253:27:253:53 | call to source | semmle.label | call to source |
-| protobuf.cpp:253:27:253:53 | call to source | semmle.label | call to source |
-| protobuf.cpp:254:2:254:4 | ParsePartialFromZeroCopyStream output argument | semmle.label | ParsePartialFromZeroCopyStream output argument |
-| protobuf.cpp:254:37:254:39 | *& ... | semmle.label | *& ... |
-| protobuf.cpp:255:7:255:9 | msg | semmle.label | msg |
-| protobuf.cpp:260:27:260:53 | call to source | semmle.label | call to source |
-| protobuf.cpp:260:27:260:53 | call to source | semmle.label | call to source |
-| protobuf.cpp:261:2:261:4 | ParseFromBoundedZeroCopyStream output argument | semmle.label | ParseFromBoundedZeroCopyStream output argument |
-| protobuf.cpp:261:37:261:39 | *& ... | semmle.label | *& ... |
-| protobuf.cpp:262:7:262:9 | msg | semmle.label | msg |
-| protobuf.cpp:267:27:267:53 | call to source | semmle.label | call to source |
-| protobuf.cpp:267:27:267:53 | call to source | semmle.label | call to source |
-| protobuf.cpp:268:2:268:4 | ParsePartialFromBoundedZeroCopyStream output argument | semmle.label | ParsePartialFromBoundedZeroCopyStream output argument |
-| protobuf.cpp:268:44:268:46 | *& ... | semmle.label | *& ... |
-| protobuf.cpp:269:7:269:9 | msg | semmle.label | msg |
-| protobuf.cpp:274:27:274:53 | call to source | semmle.label | call to source |
-| protobuf.cpp:274:27:274:53 | call to source | semmle.label | call to source |
-| protobuf.cpp:275:2:275:4 | MergeFromBoundedZeroCopyStream output argument | semmle.label | MergeFromBoundedZeroCopyStream output argument |
-| protobuf.cpp:275:37:275:39 | *& ... | semmle.label | *& ... |
-| protobuf.cpp:276:7:276:9 | msg | semmle.label | msg |
-| protobuf.cpp:281:27:281:53 | call to source | semmle.label | call to source |
-| protobuf.cpp:281:27:281:53 | call to source | semmle.label | call to source |
-| protobuf.cpp:282:2:282:4 | MergePartialFromBoundedZeroCopyStream output argument | semmle.label | MergePartialFromBoundedZeroCopyStream output argument |
-| protobuf.cpp:282:44:282:46 | *& ... | semmle.label | *& ... |
-| protobuf.cpp:283:7:283:9 | msg | semmle.label | msg |
-| protobuf.cpp:288:24:288:47 | call to source | semmle.label | call to source |
-| protobuf.cpp:288:24:288:47 | call to source | semmle.label | call to source |
-| protobuf.cpp:289:2:289:4 | ParseFromCodedStream output argument | semmle.label | ParseFromCodedStream output argument |
-| protobuf.cpp:289:27:289:29 | *& ... | semmle.label | *& ... |
-| protobuf.cpp:290:7:290:9 | msg | semmle.label | msg |
-| protobuf.cpp:295:24:295:47 | call to source | semmle.label | call to source |
-| protobuf.cpp:295:24:295:47 | call to source | semmle.label | call to source |
-| protobuf.cpp:296:2:296:4 | ParsePartialFromCodedStream output argument | semmle.label | ParsePartialFromCodedStream output argument |
-| protobuf.cpp:296:34:296:36 | *& ... | semmle.label | *& ... |
-| protobuf.cpp:297:7:297:9 | msg | semmle.label | msg |
-| protobuf.cpp:302:24:302:47 | call to source | semmle.label | call to source |
-| protobuf.cpp:302:24:302:47 | call to source | semmle.label | call to source |
-| protobuf.cpp:303:2:303:4 | MergeFromCodedStream output argument | semmle.label | MergeFromCodedStream output argument |
-| protobuf.cpp:303:27:303:29 | *& ... | semmle.label | *& ... |
-| protobuf.cpp:304:7:304:9 | msg | semmle.label | msg |
-| protobuf.cpp:309:24:309:47 | call to source | semmle.label | call to source |
-| protobuf.cpp:309:24:309:47 | call to source | semmle.label | call to source |
-| protobuf.cpp:310:2:310:4 | MergePartialFromCodedStream output argument | semmle.label | MergePartialFromCodedStream output argument |
-| protobuf.cpp:310:34:310:36 | *& ... | semmle.label | *& ... |
-| protobuf.cpp:311:7:311:9 | msg | semmle.label | msg |
-| protobuf.cpp:324:15:324:28 | call to source | semmle.label | call to source |
-| protobuf.cpp:324:15:324:28 | call to source | semmle.label | call to source |
-| protobuf.cpp:326:2:326:4 | *msg | semmle.label | *msg |
-| protobuf.cpp:326:24:326:27 | SerializeToString output argument | semmle.label | SerializeToString output argument |
-| protobuf.cpp:327:7:327:9 | out | semmle.label | out |
-| protobuf.cpp:331:15:331:28 | call to source | semmle.label | call to source |
-| protobuf.cpp:331:15:331:28 | call to source | semmle.label | call to source |
-| protobuf.cpp:333:2:333:4 | *msg | semmle.label | *msg |
-| protobuf.cpp:333:31:333:34 | SerializePartialToString output argument | semmle.label | SerializePartialToString output argument |
-| protobuf.cpp:334:7:334:9 | out | semmle.label | out |
-| protobuf.cpp:338:15:338:28 | call to source | semmle.label | call to source |
-| protobuf.cpp:338:15:338:28 | call to source | semmle.label | call to source |
-| protobuf.cpp:340:2:340:4 | *msg | semmle.label | *msg |
-| protobuf.cpp:340:21:340:24 | AppendToString output argument | semmle.label | AppendToString output argument |
-| protobuf.cpp:341:7:341:9 | out | semmle.label | out |
-| protobuf.cpp:345:15:345:28 | call to source | semmle.label | call to source |
-| protobuf.cpp:345:15:345:28 | call to source | semmle.label | call to source |
-| protobuf.cpp:347:2:347:4 | *msg | semmle.label | *msg |
-| protobuf.cpp:347:28:347:31 | AppendPartialToString output argument | semmle.label | AppendPartialToString output argument |
-| protobuf.cpp:348:7:348:9 | out | semmle.label | out |
-| protobuf.cpp:352:15:352:28 | call to source | semmle.label | call to source |
-| protobuf.cpp:352:15:352:28 | call to source | semmle.label | call to source |
-| protobuf.cpp:354:2:354:4 | *msg | semmle.label | *msg |
-| protobuf.cpp:354:24:354:27 | SerializeToString output argument | semmle.label | SerializeToString output argument |
-| protobuf.cpp:355:7:355:9 | out | semmle.label | out |
-| protobuf.cpp:359:15:359:28 | call to source | semmle.label | call to source |
-| protobuf.cpp:359:15:359:28 | call to source | semmle.label | call to source |
-| protobuf.cpp:361:2:361:4 | *msg | semmle.label | *msg |
-| protobuf.cpp:361:31:361:34 | SerializePartialToString output argument | semmle.label | SerializePartialToString output argument |
-| protobuf.cpp:362:7:362:9 | out | semmle.label | out |
-| protobuf.cpp:366:15:366:28 | call to source | semmle.label | call to source |
-| protobuf.cpp:366:15:366:28 | call to source | semmle.label | call to source |
-| protobuf.cpp:368:2:368:4 | *msg | semmle.label | *msg |
-| protobuf.cpp:368:21:368:24 | AppendToString output argument | semmle.label | AppendToString output argument |
-| protobuf.cpp:369:7:369:9 | out | semmle.label | out |
-| protobuf.cpp:373:15:373:28 | call to source | semmle.label | call to source |
-| protobuf.cpp:373:15:373:28 | call to source | semmle.label | call to source |
-| protobuf.cpp:375:2:375:4 | *msg | semmle.label | *msg |
-| protobuf.cpp:375:28:375:31 | AppendPartialToString output argument | semmle.label | AppendPartialToString output argument |
-| protobuf.cpp:376:7:376:9 | out | semmle.label | out |
-| protobuf.cpp:380:15:380:28 | call to source | semmle.label | call to source |
-| protobuf.cpp:380:15:380:28 | call to source | semmle.label | call to source |
-| protobuf.cpp:382:2:382:4 | *msg | semmle.label | *msg |
-| protobuf.cpp:382:23:382:25 | SerializeToArray output argument | semmle.label | SerializeToArray output argument |
-| protobuf.cpp:383:7:383:10 | * ... | semmle.label | * ... |
-| protobuf.cpp:387:15:387:28 | call to source | semmle.label | call to source |
-| protobuf.cpp:387:15:387:28 | call to source | semmle.label | call to source |
-| protobuf.cpp:389:2:389:4 | *msg | semmle.label | *msg |
-| protobuf.cpp:389:30:389:32 | SerializePartialToArray output argument | semmle.label | SerializePartialToArray output argument |
-| protobuf.cpp:390:7:390:10 | * ... | semmle.label | * ... |
-| protobuf.cpp:394:15:394:28 | call to source | semmle.label | call to source |
-| protobuf.cpp:394:15:394:28 | call to source | semmle.label | call to source |
-| protobuf.cpp:396:2:396:4 | *msg | semmle.label | *msg |
-| protobuf.cpp:396:22:396:25 | SerializeToCord output argument | semmle.label | SerializeToCord output argument |
-| protobuf.cpp:397:7:397:9 | out | semmle.label | out |
-| protobuf.cpp:401:15:401:28 | call to source | semmle.label | call to source |
-| protobuf.cpp:401:15:401:28 | call to source | semmle.label | call to source |
-| protobuf.cpp:403:2:403:4 | *msg | semmle.label | *msg |
-| protobuf.cpp:403:29:403:32 | SerializePartialToCord output argument | semmle.label | SerializePartialToCord output argument |
-| protobuf.cpp:404:7:404:9 | out | semmle.label | out |
-| protobuf.cpp:408:15:408:28 | call to source | semmle.label | call to source |
-| protobuf.cpp:408:15:408:28 | call to source | semmle.label | call to source |
-| protobuf.cpp:410:2:410:4 | *msg | semmle.label | *msg |
-| protobuf.cpp:410:19:410:22 | AppendToCord output argument | semmle.label | AppendToCord output argument |
-| protobuf.cpp:411:7:411:9 | out | semmle.label | out |
-| protobuf.cpp:415:15:415:28 | call to source | semmle.label | call to source |
-| protobuf.cpp:415:15:415:28 | call to source | semmle.label | call to source |
-| protobuf.cpp:417:2:417:4 | *msg | semmle.label | *msg |
-| protobuf.cpp:417:26:417:29 | AppendPartialToCord output argument | semmle.label | AppendPartialToCord output argument |
-| protobuf.cpp:418:7:418:9 | out | semmle.label | out |
-| protobuf.cpp:422:15:422:28 | call to source | semmle.label | call to source |
-| protobuf.cpp:422:15:422:28 | call to source | semmle.label | call to source |
-| protobuf.cpp:424:2:424:4 | *msg | semmle.label | *msg |
-| protobuf.cpp:424:25:424:28 | SerializeToOstream output argument | semmle.label | SerializeToOstream output argument |
-| protobuf.cpp:425:7:425:9 | out | semmle.label | out |
-| protobuf.cpp:429:15:429:28 | call to source | semmle.label | call to source |
-| protobuf.cpp:429:15:429:28 | call to source | semmle.label | call to source |
-| protobuf.cpp:431:2:431:4 | *msg | semmle.label | *msg |
-| protobuf.cpp:431:32:431:35 | SerializePartialToOstream output argument | semmle.label | SerializePartialToOstream output argument |
-| protobuf.cpp:432:7:432:9 | out | semmle.label | out |
-| protobuf.cpp:436:15:436:28 | call to source | semmle.label | call to source |
-| protobuf.cpp:436:15:436:28 | call to source | semmle.label | call to source |
-| protobuf.cpp:438:2:438:4 | *msg | semmle.label | *msg |
-| protobuf.cpp:438:32:438:35 | SerializeToZeroCopyStream output argument | semmle.label | SerializeToZeroCopyStream output argument |
-| protobuf.cpp:439:7:439:9 | out | semmle.label | out |
-| protobuf.cpp:443:15:443:28 | call to source | semmle.label | call to source |
-| protobuf.cpp:443:15:443:28 | call to source | semmle.label | call to source |
-| protobuf.cpp:445:2:445:4 | *msg | semmle.label | *msg |
-| protobuf.cpp:445:39:445:42 | SerializePartialToZeroCopyStream output argument | semmle.label | SerializePartialToZeroCopyStream output argument |
-| protobuf.cpp:446:7:446:9 | out | semmle.label | out |
-| protobuf.cpp:450:15:450:28 | call to source | semmle.label | call to source |
-| protobuf.cpp:450:15:450:28 | call to source | semmle.label | call to source |
-| protobuf.cpp:452:2:452:4 | *msg | semmle.label | *msg |
-| protobuf.cpp:452:29:452:32 | SerializeToCodedStream output argument | semmle.label | SerializeToCodedStream output argument |
-| protobuf.cpp:453:7:453:9 | out | semmle.label | out |
-| protobuf.cpp:457:15:457:28 | call to source | semmle.label | call to source |
-| protobuf.cpp:457:15:457:28 | call to source | semmle.label | call to source |
-| protobuf.cpp:459:2:459:4 | *msg | semmle.label | *msg |
-| protobuf.cpp:459:36:459:39 | SerializePartialToCodedStream output argument | semmle.label | SerializePartialToCodedStream output argument |
-| protobuf.cpp:460:7:460:9 | out | semmle.label | out |
-| protobuf.cpp:466:15:466:28 | call to source | semmle.label | call to source |
-| protobuf.cpp:466:15:466:28 | call to source | semmle.label | call to source |
-| protobuf.cpp:467:7:467:9 | *msg | semmle.label | *msg |
-| protobuf.cpp:467:11:467:27 | call to SerializeAsString | semmle.label | call to SerializeAsString |
-| protobuf.cpp:471:15:471:28 | call to source | semmle.label | call to source |
-| protobuf.cpp:471:15:471:28 | call to source | semmle.label | call to source |
-| protobuf.cpp:472:7:472:9 | *msg | semmle.label | *msg |
-| protobuf.cpp:472:11:472:34 | call to SerializePartialAsString | semmle.label | call to SerializePartialAsString |
-| protobuf.cpp:476:15:476:28 | call to source | semmle.label | call to source |
-| protobuf.cpp:476:15:476:28 | call to source | semmle.label | call to source |
-| protobuf.cpp:477:7:477:9 | *msg | semmle.label | *msg |
-| protobuf.cpp:477:11:477:25 | call to SerializeAsCord | semmle.label | call to SerializeAsCord |
-| protobuf.cpp:481:15:481:28 | call to source | semmle.label | call to source |
-| protobuf.cpp:481:15:481:28 | call to source | semmle.label | call to source |
-| protobuf.cpp:482:7:482:9 | *msg | semmle.label | *msg |
-| protobuf.cpp:482:11:482:32 | call to SerializePartialAsCord | semmle.label | call to SerializePartialAsCord |
+| protobuf.cpp:117:27:117:51 | call to source | semmle.label | call to source |
+| protobuf.cpp:117:27:117:51 | call to source | semmle.label | call to source |
+| protobuf.cpp:118:2:118:4 | ParseFromString output argument | semmle.label | ParseFromString output argument |
+| protobuf.cpp:118:22:118:25 | data | semmle.label | data |
+| protobuf.cpp:119:7:119:9 | msg | semmle.label | msg |
+| protobuf.cpp:124:20:124:37 | call to source | semmle.label | call to source |
+| protobuf.cpp:124:20:124:37 | call to source | semmle.label | call to source |
+| protobuf.cpp:125:2:125:4 | ParseFromString output argument | semmle.label | ParseFromString output argument |
+| protobuf.cpp:125:22:125:25 | *data | semmle.label | *data |
+| protobuf.cpp:126:7:126:9 | msg | semmle.label | msg |
+| protobuf.cpp:131:27:131:51 | call to source | semmle.label | call to source |
+| protobuf.cpp:131:27:131:51 | call to source | semmle.label | call to source |
+| protobuf.cpp:132:2:132:4 | ParsePartialFromString output argument | semmle.label | ParsePartialFromString output argument |
+| protobuf.cpp:132:29:132:32 | data | semmle.label | data |
+| protobuf.cpp:133:7:133:9 | msg | semmle.label | msg |
+| protobuf.cpp:138:20:138:37 | call to source | semmle.label | call to source |
+| protobuf.cpp:138:20:138:37 | call to source | semmle.label | call to source |
+| protobuf.cpp:139:2:139:4 | ParsePartialFromString output argument | semmle.label | ParsePartialFromString output argument |
+| protobuf.cpp:139:29:139:32 | *data | semmle.label | *data |
+| protobuf.cpp:140:7:140:9 | msg | semmle.label | msg |
+| protobuf.cpp:145:27:145:51 | call to source | semmle.label | call to source |
+| protobuf.cpp:145:27:145:51 | call to source | semmle.label | call to source |
+| protobuf.cpp:146:2:146:4 | MergeFromString output argument | semmle.label | MergeFromString output argument |
+| protobuf.cpp:146:22:146:25 | data | semmle.label | data |
+| protobuf.cpp:147:7:147:9 | msg | semmle.label | msg |
+| protobuf.cpp:152:20:152:37 | call to source | semmle.label | call to source |
+| protobuf.cpp:152:20:152:37 | call to source | semmle.label | call to source |
+| protobuf.cpp:153:2:153:4 | MergeFromString output argument | semmle.label | MergeFromString output argument |
+| protobuf.cpp:153:22:153:25 | *data | semmle.label | *data |
+| protobuf.cpp:154:7:154:9 | msg | semmle.label | msg |
+| protobuf.cpp:159:27:159:51 | call to source | semmle.label | call to source |
+| protobuf.cpp:159:27:159:51 | call to source | semmle.label | call to source |
+| protobuf.cpp:160:2:160:4 | MergePartialFromString output argument | semmle.label | MergePartialFromString output argument |
+| protobuf.cpp:160:29:160:32 | data | semmle.label | data |
+| protobuf.cpp:161:7:161:9 | msg | semmle.label | msg |
+| protobuf.cpp:166:20:166:37 | call to source | semmle.label | call to source |
+| protobuf.cpp:166:20:166:37 | call to source | semmle.label | call to source |
+| protobuf.cpp:167:2:167:4 | MergePartialFromString output argument | semmle.label | MergePartialFromString output argument |
+| protobuf.cpp:167:29:167:32 | *data | semmle.label | *data |
+| protobuf.cpp:168:7:168:9 | msg | semmle.label | msg |
+| protobuf.cpp:173:19:173:38 | call to source | semmle.label | call to source |
+| protobuf.cpp:174:2:174:4 | ParseFromArray output argument | semmle.label | ParseFromArray output argument |
+| protobuf.cpp:174:21:174:31 | *call to data | semmle.label | *call to data |
+| protobuf.cpp:175:7:175:9 | msg | semmle.label | msg |
+| protobuf.cpp:180:19:180:38 | call to source | semmle.label | call to source |
+| protobuf.cpp:181:2:181:4 | ParsePartialFromArray output argument | semmle.label | ParsePartialFromArray output argument |
+| protobuf.cpp:181:28:181:38 | *call to data | semmle.label | *call to data |
+| protobuf.cpp:182:7:182:9 | msg | semmle.label | msg |
+| protobuf.cpp:187:20:187:37 | call to source | semmle.label | call to source |
+| protobuf.cpp:187:20:187:37 | call to source | semmle.label | call to source |
+| protobuf.cpp:188:2:188:4 | ParseFromCord output argument | semmle.label | ParseFromCord output argument |
+| protobuf.cpp:188:20:188:23 | *data | semmle.label | *data |
+| protobuf.cpp:189:7:189:9 | msg | semmle.label | msg |
+| protobuf.cpp:194:20:194:37 | call to source | semmle.label | call to source |
+| protobuf.cpp:194:20:194:37 | call to source | semmle.label | call to source |
+| protobuf.cpp:195:2:195:4 | ParsePartialFromCord output argument | semmle.label | ParsePartialFromCord output argument |
+| protobuf.cpp:195:27:195:30 | *data | semmle.label | *data |
+| protobuf.cpp:196:7:196:9 | msg | semmle.label | msg |
+| protobuf.cpp:201:20:201:37 | call to source | semmle.label | call to source |
+| protobuf.cpp:201:20:201:37 | call to source | semmle.label | call to source |
+| protobuf.cpp:202:2:202:4 | MergeFromCord output argument | semmle.label | MergeFromCord output argument |
+| protobuf.cpp:202:20:202:23 | *data | semmle.label | *data |
+| protobuf.cpp:203:7:203:9 | msg | semmle.label | msg |
+| protobuf.cpp:208:20:208:37 | call to source | semmle.label | call to source |
+| protobuf.cpp:208:20:208:37 | call to source | semmle.label | call to source |
+| protobuf.cpp:209:2:209:4 | MergePartialFromCord output argument | semmle.label | MergePartialFromCord output argument |
+| protobuf.cpp:209:27:209:30 | *data | semmle.label | *data |
+| protobuf.cpp:210:7:210:9 | msg | semmle.label | msg |
+| protobuf.cpp:215:20:215:39 | call to source | semmle.label | call to source |
+| protobuf.cpp:215:20:215:39 | call to source | semmle.label | call to source |
+| protobuf.cpp:216:2:216:4 | ParseFromIstream output argument | semmle.label | ParseFromIstream output argument |
+| protobuf.cpp:216:23:216:25 | *& ... | semmle.label | *& ... |
+| protobuf.cpp:217:7:217:9 | msg | semmle.label | msg |
+| protobuf.cpp:222:20:222:39 | call to source | semmle.label | call to source |
+| protobuf.cpp:222:20:222:39 | call to source | semmle.label | call to source |
+| protobuf.cpp:223:2:223:4 | ParsePartialFromIstream output argument | semmle.label | ParsePartialFromIstream output argument |
+| protobuf.cpp:223:30:223:32 | *& ... | semmle.label | *& ... |
+| protobuf.cpp:224:7:224:9 | msg | semmle.label | msg |
+| protobuf.cpp:229:27:229:53 | call to source | semmle.label | call to source |
+| protobuf.cpp:229:27:229:53 | call to source | semmle.label | call to source |
+| protobuf.cpp:230:2:230:4 | ParseFromZeroCopyStream output argument | semmle.label | ParseFromZeroCopyStream output argument |
+| protobuf.cpp:230:30:230:32 | *& ... | semmle.label | *& ... |
+| protobuf.cpp:231:7:231:9 | msg | semmle.label | msg |
+| protobuf.cpp:236:27:236:53 | call to source | semmle.label | call to source |
+| protobuf.cpp:236:27:236:53 | call to source | semmle.label | call to source |
+| protobuf.cpp:237:2:237:4 | ParsePartialFromZeroCopyStream output argument | semmle.label | ParsePartialFromZeroCopyStream output argument |
+| protobuf.cpp:237:37:237:39 | *& ... | semmle.label | *& ... |
+| protobuf.cpp:238:7:238:9 | msg | semmle.label | msg |
+| protobuf.cpp:243:27:243:53 | call to source | semmle.label | call to source |
+| protobuf.cpp:243:27:243:53 | call to source | semmle.label | call to source |
+| protobuf.cpp:244:2:244:4 | ParseFromBoundedZeroCopyStream output argument | semmle.label | ParseFromBoundedZeroCopyStream output argument |
+| protobuf.cpp:244:37:244:39 | *& ... | semmle.label | *& ... |
+| protobuf.cpp:245:7:245:9 | msg | semmle.label | msg |
+| protobuf.cpp:250:27:250:53 | call to source | semmle.label | call to source |
+| protobuf.cpp:250:27:250:53 | call to source | semmle.label | call to source |
+| protobuf.cpp:251:2:251:4 | ParsePartialFromBoundedZeroCopyStream output argument | semmle.label | ParsePartialFromBoundedZeroCopyStream output argument |
+| protobuf.cpp:251:44:251:46 | *& ... | semmle.label | *& ... |
+| protobuf.cpp:252:7:252:9 | msg | semmle.label | msg |
+| protobuf.cpp:257:27:257:53 | call to source | semmle.label | call to source |
+| protobuf.cpp:257:27:257:53 | call to source | semmle.label | call to source |
+| protobuf.cpp:258:2:258:4 | MergeFromBoundedZeroCopyStream output argument | semmle.label | MergeFromBoundedZeroCopyStream output argument |
+| protobuf.cpp:258:37:258:39 | *& ... | semmle.label | *& ... |
+| protobuf.cpp:259:7:259:9 | msg | semmle.label | msg |
+| protobuf.cpp:264:27:264:53 | call to source | semmle.label | call to source |
+| protobuf.cpp:264:27:264:53 | call to source | semmle.label | call to source |
+| protobuf.cpp:265:2:265:4 | MergePartialFromBoundedZeroCopyStream output argument | semmle.label | MergePartialFromBoundedZeroCopyStream output argument |
+| protobuf.cpp:265:44:265:46 | *& ... | semmle.label | *& ... |
+| protobuf.cpp:266:7:266:9 | msg | semmle.label | msg |
+| protobuf.cpp:271:24:271:47 | call to source | semmle.label | call to source |
+| protobuf.cpp:271:24:271:47 | call to source | semmle.label | call to source |
+| protobuf.cpp:272:2:272:4 | ParseFromCodedStream output argument | semmle.label | ParseFromCodedStream output argument |
+| protobuf.cpp:272:27:272:29 | *& ... | semmle.label | *& ... |
+| protobuf.cpp:273:7:273:9 | msg | semmle.label | msg |
+| protobuf.cpp:278:24:278:47 | call to source | semmle.label | call to source |
+| protobuf.cpp:278:24:278:47 | call to source | semmle.label | call to source |
+| protobuf.cpp:279:2:279:4 | ParsePartialFromCodedStream output argument | semmle.label | ParsePartialFromCodedStream output argument |
+| protobuf.cpp:279:34:279:36 | *& ... | semmle.label | *& ... |
+| protobuf.cpp:280:7:280:9 | msg | semmle.label | msg |
+| protobuf.cpp:285:24:285:47 | call to source | semmle.label | call to source |
+| protobuf.cpp:285:24:285:47 | call to source | semmle.label | call to source |
+| protobuf.cpp:286:2:286:4 | MergeFromCodedStream output argument | semmle.label | MergeFromCodedStream output argument |
+| protobuf.cpp:286:27:286:29 | *& ... | semmle.label | *& ... |
+| protobuf.cpp:287:7:287:9 | msg | semmle.label | msg |
+| protobuf.cpp:292:24:292:47 | call to source | semmle.label | call to source |
+| protobuf.cpp:292:24:292:47 | call to source | semmle.label | call to source |
+| protobuf.cpp:293:2:293:4 | MergePartialFromCodedStream output argument | semmle.label | MergePartialFromCodedStream output argument |
+| protobuf.cpp:293:34:293:36 | *& ... | semmle.label | *& ... |
+| protobuf.cpp:294:7:294:9 | msg | semmle.label | msg |
+| protobuf.cpp:307:15:307:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:307:15:307:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:309:2:309:4 | *msg | semmle.label | *msg |
+| protobuf.cpp:309:24:309:27 | SerializeToString output argument | semmle.label | SerializeToString output argument |
+| protobuf.cpp:310:7:310:9 | out | semmle.label | out |
+| protobuf.cpp:314:15:314:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:314:15:314:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:316:2:316:4 | *msg | semmle.label | *msg |
+| protobuf.cpp:316:31:316:34 | SerializePartialToString output argument | semmle.label | SerializePartialToString output argument |
+| protobuf.cpp:317:7:317:9 | out | semmle.label | out |
+| protobuf.cpp:321:15:321:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:321:15:321:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:323:2:323:4 | *msg | semmle.label | *msg |
+| protobuf.cpp:323:21:323:24 | AppendToString output argument | semmle.label | AppendToString output argument |
+| protobuf.cpp:324:7:324:9 | out | semmle.label | out |
+| protobuf.cpp:328:15:328:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:328:15:328:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:330:2:330:4 | *msg | semmle.label | *msg |
+| protobuf.cpp:330:28:330:31 | AppendPartialToString output argument | semmle.label | AppendPartialToString output argument |
+| protobuf.cpp:331:7:331:9 | out | semmle.label | out |
+| protobuf.cpp:335:15:335:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:335:15:335:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:337:2:337:4 | *msg | semmle.label | *msg |
+| protobuf.cpp:337:24:337:27 | SerializeToString output argument | semmle.label | SerializeToString output argument |
+| protobuf.cpp:338:7:338:9 | out | semmle.label | out |
+| protobuf.cpp:342:15:342:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:342:15:342:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:344:2:344:4 | *msg | semmle.label | *msg |
+| protobuf.cpp:344:31:344:34 | SerializePartialToString output argument | semmle.label | SerializePartialToString output argument |
+| protobuf.cpp:345:7:345:9 | out | semmle.label | out |
+| protobuf.cpp:349:15:349:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:349:15:349:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:351:2:351:4 | *msg | semmle.label | *msg |
+| protobuf.cpp:351:21:351:24 | AppendToString output argument | semmle.label | AppendToString output argument |
+| protobuf.cpp:352:7:352:9 | out | semmle.label | out |
+| protobuf.cpp:356:15:356:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:356:15:356:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:358:2:358:4 | *msg | semmle.label | *msg |
+| protobuf.cpp:358:28:358:31 | AppendPartialToString output argument | semmle.label | AppendPartialToString output argument |
+| protobuf.cpp:359:7:359:9 | out | semmle.label | out |
+| protobuf.cpp:363:15:363:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:363:15:363:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:365:2:365:4 | *msg | semmle.label | *msg |
+| protobuf.cpp:365:23:365:25 | SerializeToArray output argument | semmle.label | SerializeToArray output argument |
+| protobuf.cpp:366:7:366:10 | * ... | semmle.label | * ... |
+| protobuf.cpp:370:15:370:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:370:15:370:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:372:2:372:4 | *msg | semmle.label | *msg |
+| protobuf.cpp:372:30:372:32 | SerializePartialToArray output argument | semmle.label | SerializePartialToArray output argument |
+| protobuf.cpp:373:7:373:10 | * ... | semmle.label | * ... |
+| protobuf.cpp:377:15:377:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:377:15:377:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:379:2:379:4 | *msg | semmle.label | *msg |
+| protobuf.cpp:379:22:379:25 | SerializeToCord output argument | semmle.label | SerializeToCord output argument |
+| protobuf.cpp:380:7:380:9 | out | semmle.label | out |
+| protobuf.cpp:384:15:384:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:384:15:384:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:386:2:386:4 | *msg | semmle.label | *msg |
+| protobuf.cpp:386:29:386:32 | SerializePartialToCord output argument | semmle.label | SerializePartialToCord output argument |
+| protobuf.cpp:387:7:387:9 | out | semmle.label | out |
+| protobuf.cpp:391:15:391:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:391:15:391:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:393:2:393:4 | *msg | semmle.label | *msg |
+| protobuf.cpp:393:19:393:22 | AppendToCord output argument | semmle.label | AppendToCord output argument |
+| protobuf.cpp:394:7:394:9 | out | semmle.label | out |
+| protobuf.cpp:398:15:398:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:398:15:398:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:400:2:400:4 | *msg | semmle.label | *msg |
+| protobuf.cpp:400:26:400:29 | AppendPartialToCord output argument | semmle.label | AppendPartialToCord output argument |
+| protobuf.cpp:401:7:401:9 | out | semmle.label | out |
+| protobuf.cpp:405:15:405:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:405:15:405:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:407:2:407:4 | *msg | semmle.label | *msg |
+| protobuf.cpp:407:25:407:28 | SerializeToOstream output argument | semmle.label | SerializeToOstream output argument |
+| protobuf.cpp:408:7:408:9 | out | semmle.label | out |
+| protobuf.cpp:412:15:412:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:412:15:412:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:414:2:414:4 | *msg | semmle.label | *msg |
+| protobuf.cpp:414:32:414:35 | SerializePartialToOstream output argument | semmle.label | SerializePartialToOstream output argument |
+| protobuf.cpp:415:7:415:9 | out | semmle.label | out |
+| protobuf.cpp:419:15:419:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:419:15:419:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:421:2:421:4 | *msg | semmle.label | *msg |
+| protobuf.cpp:421:32:421:35 | SerializeToZeroCopyStream output argument | semmle.label | SerializeToZeroCopyStream output argument |
+| protobuf.cpp:422:7:422:9 | out | semmle.label | out |
+| protobuf.cpp:426:15:426:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:426:15:426:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:428:2:428:4 | *msg | semmle.label | *msg |
+| protobuf.cpp:428:39:428:42 | SerializePartialToZeroCopyStream output argument | semmle.label | SerializePartialToZeroCopyStream output argument |
+| protobuf.cpp:429:7:429:9 | out | semmle.label | out |
+| protobuf.cpp:433:15:433:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:433:15:433:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:435:2:435:4 | *msg | semmle.label | *msg |
+| protobuf.cpp:435:29:435:32 | SerializeToCodedStream output argument | semmle.label | SerializeToCodedStream output argument |
+| protobuf.cpp:436:7:436:9 | out | semmle.label | out |
+| protobuf.cpp:440:15:440:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:440:15:440:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:442:2:442:4 | *msg | semmle.label | *msg |
+| protobuf.cpp:442:36:442:39 | SerializePartialToCodedStream output argument | semmle.label | SerializePartialToCodedStream output argument |
+| protobuf.cpp:443:7:443:9 | out | semmle.label | out |
+| protobuf.cpp:449:15:449:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:449:15:449:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:450:7:450:9 | *msg | semmle.label | *msg |
+| protobuf.cpp:450:11:450:27 | call to SerializeAsString | semmle.label | call to SerializeAsString |
+| protobuf.cpp:454:15:454:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:454:15:454:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:455:7:455:9 | *msg | semmle.label | *msg |
+| protobuf.cpp:455:11:455:34 | call to SerializePartialAsString | semmle.label | call to SerializePartialAsString |
+| protobuf.cpp:459:15:459:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:459:15:459:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:460:7:460:9 | *msg | semmle.label | *msg |
+| protobuf.cpp:460:11:460:25 | call to SerializeAsCord | semmle.label | call to SerializeAsCord |
+| protobuf.cpp:464:15:464:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:464:15:464:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:465:7:465:9 | *msg | semmle.label | *msg |
+| protobuf.cpp:465:11:465:32 | call to SerializePartialAsCord | semmle.label | call to SerializePartialAsCord |
 | test.cpp:7:5:7:30 | *ymlStepGenerated_with_body | semmle.label | *ymlStepGenerated_with_body |
 | test.cpp:7:47:7:52 | value2 | semmle.label | value2 |
 | test.cpp:7:64:7:69 | value2 | semmle.label | value2 |

--- a/cpp/ql/test/library-tests/dataflow/external-models/flow.expected
+++ b/cpp/ql/test/library-tests/dataflow/external-models/flow.expected
@@ -120,9 +120,8 @@ models
 | 119 | Summary: boost::asio::ip; basic_resolver<InternetProtocol>; false; resolve; (string_view,string_view,flags,error_code &); ; Argument[0..1]; ReturnValue; taint; manual |
 | 120 | Summary: boost::asio; ; false; buffer; ; ; Argument[*0]; ReturnValue; taint; manual |
 | 121 | Summary: google::protobuf; MessageLite; true; ParseFromArray; ; ; Argument[*0]; Argument[-1]; taint; manual |
-| 122 | Summary: google::protobuf; MessageLite; true; ParseFromString; ; ; Argument[*0]; Argument[-1]; taint; manual |
-| 123 | Summary: google::protobuf; MessageLite; true; SerializeAsString; ; ; Argument[-1]; ReturnValue; taint; manual |
-| 124 | Summary: google::protobuf; MessageLite; true; SerializeToArray; ; ; Argument[-1]; Argument[*0]; taint; manual |
+| 122 | Summary: google::protobuf; MessageLite; true; SerializeAsString; ; ; Argument[-1]; ReturnValue; taint; manual |
+| 123 | Summary: google::protobuf; MessageLite; true; SerializeToArray; ; ; Argument[-1]; Argument[*0]; taint; manual |
 edges
 | asio_streams.cpp:129:34:129:44 | read_until output argument | asio_streams.cpp:133:7:133:17 | recv_buffer | provenance | Src:MaD:56  |
 | asio_streams.cpp:129:34:129:44 | read_until output argument | asio_streams.cpp:135:29:135:39 | recv_buffer | provenance | Src:MaD:56 Sink:MaD:4 |
@@ -267,26 +266,21 @@ edges
 | bdlbb.cpp:94:46:94:48 | *src | bdlbb.cpp:94:37:94:40 | copy output argument | provenance | MaD:100 |
 | bdlbb.cpp:96:37:96:39 | copy output argument | bdlbb.cpp:97:7:97:10 | * ... | provenance |  |
 | bdlbb.cpp:96:42:96:44 | *dst | bdlbb.cpp:96:37:96:39 | copy output argument | provenance | MaD:102 |
-| protobuf.cpp:75:33:75:40 | call to source | protobuf.cpp:76:22:76:25 | *data | provenance | TaintFunction |
-| protobuf.cpp:76:2:76:4 | ParseFromString output argument | protobuf.cpp:78:2:78:4 | *msg | provenance |  |
-| protobuf.cpp:76:22:76:25 | *data | protobuf.cpp:76:2:76:4 | ParseFromString output argument | provenance | MaD:122 |
-| protobuf.cpp:78:2:78:4 | *msg | protobuf.cpp:78:23:78:25 | SerializeToArray output argument | provenance | MaD:124 |
-| protobuf.cpp:78:23:78:25 | SerializeToArray output argument | protobuf.cpp:79:7:79:10 | * ... | provenance |  |
-| protobuf.cpp:84:33:84:40 | call to source | protobuf.cpp:85:21:85:31 | *call to data | provenance | TaintFunction |
-| protobuf.cpp:85:2:85:4 | ParseFromArray output argument | protobuf.cpp:87:2:87:4 | *msg | provenance |  |
-| protobuf.cpp:85:21:85:31 | *call to data | protobuf.cpp:85:2:85:4 | ParseFromArray output argument | provenance | MaD:121 |
-| protobuf.cpp:87:2:87:4 | *msg | protobuf.cpp:87:23:87:25 | SerializeToArray output argument | provenance | MaD:124 |
-| protobuf.cpp:87:23:87:25 | SerializeToArray output argument | protobuf.cpp:88:7:88:10 | * ... | provenance |  |
-| protobuf.cpp:95:33:95:40 | call to source | protobuf.cpp:96:22:96:25 | *data | provenance | TaintFunction |
-| protobuf.cpp:96:2:96:4 | ParseFromString output argument | protobuf.cpp:98:23:98:25 | *msg | provenance |  |
-| protobuf.cpp:96:22:96:25 | *data | protobuf.cpp:96:2:96:4 | ParseFromString output argument | provenance | MaD:122 |
-| protobuf.cpp:98:2:98:5 | ParseFromString output argument | protobuf.cpp:100:2:100:5 | *msg2 | provenance |  |
-| protobuf.cpp:98:23:98:25 | *msg | protobuf.cpp:98:27:98:43 | call to SerializeAsString | provenance | MaD:123 |
-| protobuf.cpp:98:23:98:45 | call to SerializeAsString | protobuf.cpp:98:2:98:5 | ParseFromString output argument | provenance | MaD:122 |
-| protobuf.cpp:98:27:98:43 | call to SerializeAsString | protobuf.cpp:98:23:98:45 | call to SerializeAsString | provenance |  |
-| protobuf.cpp:98:27:98:43 | call to SerializeAsString | protobuf.cpp:98:27:98:43 | call to SerializeAsString | provenance |  |
-| protobuf.cpp:100:2:100:5 | *msg2 | protobuf.cpp:100:24:100:26 | SerializeToArray output argument | provenance | MaD:124 |
-| protobuf.cpp:100:24:100:26 | SerializeToArray output argument | protobuf.cpp:101:7:101:10 | * ... | provenance |  |
+| protobuf.cpp:140:33:140:40 | call to source | protobuf.cpp:141:21:141:31 | *call to data | provenance | TaintFunction |
+| protobuf.cpp:141:2:141:4 | ParseFromArray output argument | protobuf.cpp:143:2:143:4 | *msg | provenance |  |
+| protobuf.cpp:141:21:141:31 | *call to data | protobuf.cpp:141:2:141:4 | ParseFromArray output argument | provenance | MaD:121 |
+| protobuf.cpp:143:2:143:4 | *msg | protobuf.cpp:143:23:143:25 | SerializeToArray output argument | provenance | MaD:123 |
+| protobuf.cpp:143:23:143:25 | SerializeToArray output argument | protobuf.cpp:144:7:144:10 | * ... | provenance |  |
+| protobuf.cpp:151:33:151:40 | call to source | protobuf.cpp:152:21:152:31 | *call to data | provenance | TaintFunction |
+| protobuf.cpp:152:2:152:4 | ParseFromArray output argument | protobuf.cpp:153:18:153:20 | *msg | provenance |  |
+| protobuf.cpp:152:21:152:31 | *call to data | protobuf.cpp:152:2:152:4 | ParseFromArray output argument | provenance | MaD:121 |
+| protobuf.cpp:153:18:153:20 | *msg | protobuf.cpp:153:22:153:38 | call to SerializeAsString | provenance | MaD:122 |
+| protobuf.cpp:153:22:153:38 | call to SerializeAsString | protobuf.cpp:153:22:153:38 | call to SerializeAsString | provenance |  |
+| protobuf.cpp:153:22:153:38 | call to SerializeAsString | protobuf.cpp:155:22:155:29 | *call to data | provenance | TaintFunction |
+| protobuf.cpp:155:2:155:5 | ParseFromArray output argument | protobuf.cpp:157:2:157:5 | *msg2 | provenance |  |
+| protobuf.cpp:155:22:155:29 | *call to data | protobuf.cpp:155:2:155:5 | ParseFromArray output argument | provenance | MaD:121 |
+| protobuf.cpp:157:2:157:5 | *msg2 | protobuf.cpp:157:24:157:26 | SerializeToArray output argument | provenance | MaD:123 |
+| protobuf.cpp:157:24:157:26 | SerializeToArray output argument | protobuf.cpp:158:7:158:10 | * ... | provenance |  |
 | test.cpp:7:47:7:52 | value2 | test.cpp:7:64:7:69 | value2 | provenance |  |
 | test.cpp:7:64:7:69 | value2 | test.cpp:7:5:7:30 | *ymlStepGenerated_with_body | provenance |  |
 | test.cpp:10:10:10:18 | call to ymlSource | test.cpp:10:10:10:18 | call to ymlSource | provenance | Src:MaD:48  |
@@ -789,29 +783,23 @@ nodes
 | bdlbb.cpp:96:37:96:39 | copy output argument | semmle.label | copy output argument |
 | bdlbb.cpp:96:42:96:44 | *dst | semmle.label | *dst |
 | bdlbb.cpp:97:7:97:10 | * ... | semmle.label | * ... |
-| protobuf.cpp:75:33:75:40 | call to source | semmle.label | call to source |
-| protobuf.cpp:76:2:76:4 | ParseFromString output argument | semmle.label | ParseFromString output argument |
-| protobuf.cpp:76:22:76:25 | *data | semmle.label | *data |
-| protobuf.cpp:78:2:78:4 | *msg | semmle.label | *msg |
-| protobuf.cpp:78:23:78:25 | SerializeToArray output argument | semmle.label | SerializeToArray output argument |
-| protobuf.cpp:79:7:79:10 | * ... | semmle.label | * ... |
-| protobuf.cpp:84:33:84:40 | call to source | semmle.label | call to source |
-| protobuf.cpp:85:2:85:4 | ParseFromArray output argument | semmle.label | ParseFromArray output argument |
-| protobuf.cpp:85:21:85:31 | *call to data | semmle.label | *call to data |
-| protobuf.cpp:87:2:87:4 | *msg | semmle.label | *msg |
-| protobuf.cpp:87:23:87:25 | SerializeToArray output argument | semmle.label | SerializeToArray output argument |
-| protobuf.cpp:88:7:88:10 | * ... | semmle.label | * ... |
-| protobuf.cpp:95:33:95:40 | call to source | semmle.label | call to source |
-| protobuf.cpp:96:2:96:4 | ParseFromString output argument | semmle.label | ParseFromString output argument |
-| protobuf.cpp:96:22:96:25 | *data | semmle.label | *data |
-| protobuf.cpp:98:2:98:5 | ParseFromString output argument | semmle.label | ParseFromString output argument |
-| protobuf.cpp:98:23:98:25 | *msg | semmle.label | *msg |
-| protobuf.cpp:98:23:98:45 | call to SerializeAsString | semmle.label | call to SerializeAsString |
-| protobuf.cpp:98:27:98:43 | call to SerializeAsString | semmle.label | call to SerializeAsString |
-| protobuf.cpp:98:27:98:43 | call to SerializeAsString | semmle.label | call to SerializeAsString |
-| protobuf.cpp:100:2:100:5 | *msg2 | semmle.label | *msg2 |
-| protobuf.cpp:100:24:100:26 | SerializeToArray output argument | semmle.label | SerializeToArray output argument |
-| protobuf.cpp:101:7:101:10 | * ... | semmle.label | * ... |
+| protobuf.cpp:140:33:140:40 | call to source | semmle.label | call to source |
+| protobuf.cpp:141:2:141:4 | ParseFromArray output argument | semmle.label | ParseFromArray output argument |
+| protobuf.cpp:141:21:141:31 | *call to data | semmle.label | *call to data |
+| protobuf.cpp:143:2:143:4 | *msg | semmle.label | *msg |
+| protobuf.cpp:143:23:143:25 | SerializeToArray output argument | semmle.label | SerializeToArray output argument |
+| protobuf.cpp:144:7:144:10 | * ... | semmle.label | * ... |
+| protobuf.cpp:151:33:151:40 | call to source | semmle.label | call to source |
+| protobuf.cpp:152:2:152:4 | ParseFromArray output argument | semmle.label | ParseFromArray output argument |
+| protobuf.cpp:152:21:152:31 | *call to data | semmle.label | *call to data |
+| protobuf.cpp:153:18:153:20 | *msg | semmle.label | *msg |
+| protobuf.cpp:153:22:153:38 | call to SerializeAsString | semmle.label | call to SerializeAsString |
+| protobuf.cpp:153:22:153:38 | call to SerializeAsString | semmle.label | call to SerializeAsString |
+| protobuf.cpp:155:2:155:5 | ParseFromArray output argument | semmle.label | ParseFromArray output argument |
+| protobuf.cpp:155:22:155:29 | *call to data | semmle.label | *call to data |
+| protobuf.cpp:157:2:157:5 | *msg2 | semmle.label | *msg2 |
+| protobuf.cpp:157:24:157:26 | SerializeToArray output argument | semmle.label | SerializeToArray output argument |
+| protobuf.cpp:158:7:158:10 | * ... | semmle.label | * ... |
 | test.cpp:7:5:7:30 | *ymlStepGenerated_with_body | semmle.label | *ymlStepGenerated_with_body |
 | test.cpp:7:47:7:52 | value2 | semmle.label | value2 |
 | test.cpp:7:64:7:69 | value2 | semmle.label | value2 |

--- a/cpp/ql/test/library-tests/dataflow/external-models/flow.expected
+++ b/cpp/ql/test/library-tests/dataflow/external-models/flow.expected
@@ -119,9 +119,52 @@ models
 | 118 | Summary: boost::asio::ip; basic_resolver<InternetProtocol>; false; resolve; (string_view,string_view,flags); ; Argument[0..1]; ReturnValue; taint; manual |
 | 119 | Summary: boost::asio::ip; basic_resolver<InternetProtocol>; false; resolve; (string_view,string_view,flags,error_code &); ; Argument[0..1]; ReturnValue; taint; manual |
 | 120 | Summary: boost::asio; ; false; buffer; ; ; Argument[*0]; ReturnValue; taint; manual |
-| 121 | Summary: google::protobuf; MessageLite; true; ParseFromArray; ; ; Argument[*0]; Argument[-1]; taint; manual |
-| 122 | Summary: google::protobuf; MessageLite; true; SerializeAsString; ; ; Argument[-1]; ReturnValue; taint; manual |
-| 123 | Summary: google::protobuf; MessageLite; true; SerializeToArray; ; ; Argument[-1]; Argument[*0]; taint; manual |
+| 121 | Summary: google::protobuf; MessageLite; true; AppendPartialToCord; ; ; Argument[-1]; Argument[*0]; taint; manual |
+| 122 | Summary: google::protobuf; MessageLite; true; AppendPartialToString; ; ; Argument[-1]; Argument[*0]; taint; manual |
+| 123 | Summary: google::protobuf; MessageLite; true; AppendToCord; ; ; Argument[-1]; Argument[*0]; taint; manual |
+| 124 | Summary: google::protobuf; MessageLite; true; AppendToString; ; ; Argument[-1]; Argument[*0]; taint; manual |
+| 125 | Summary: google::protobuf; MessageLite; true; MergeFromBoundedZeroCopyStream; ; ; Argument[*0]; Argument[-1]; taint; manual |
+| 126 | Summary: google::protobuf; MessageLite; true; MergeFromCodedStream; ; ; Argument[*0]; Argument[-1]; taint; manual |
+| 127 | Summary: google::protobuf; MessageLite; true; MergeFromCord; ; ; Argument[*0]; Argument[-1]; taint; manual |
+| 128 | Summary: google::protobuf; MessageLite; true; MergeFromString; (const Cord &); ; Argument[*0]; Argument[-1]; taint; manual |
+| 129 | Summary: google::protobuf; MessageLite; true; MergeFromString; (string_view); ; Argument[0]; Argument[-1]; taint; manual |
+| 130 | Summary: google::protobuf; MessageLite; true; MergePartialFromBoundedZeroCopyStream; ; ; Argument[*0]; Argument[-1]; taint; manual |
+| 131 | Summary: google::protobuf; MessageLite; true; MergePartialFromCodedStream; ; ; Argument[*0]; Argument[-1]; taint; manual |
+| 132 | Summary: google::protobuf; MessageLite; true; MergePartialFromCord; ; ; Argument[*0]; Argument[-1]; taint; manual |
+| 133 | Summary: google::protobuf; MessageLite; true; MergePartialFromString; (const Cord &); ; Argument[*0]; Argument[-1]; taint; manual |
+| 134 | Summary: google::protobuf; MessageLite; true; MergePartialFromString; (string_view); ; Argument[0]; Argument[-1]; taint; manual |
+| 135 | Summary: google::protobuf; MessageLite; true; ParseFromArray; ; ; Argument[*0]; Argument[-1]; taint; manual |
+| 136 | Summary: google::protobuf; MessageLite; true; ParseFromBoundedZeroCopyStream; ; ; Argument[*0]; Argument[-1]; taint; manual |
+| 137 | Summary: google::protobuf; MessageLite; true; ParseFromCodedStream; ; ; Argument[*0]; Argument[-1]; taint; manual |
+| 138 | Summary: google::protobuf; MessageLite; true; ParseFromCord; ; ; Argument[*0]; Argument[-1]; taint; manual |
+| 139 | Summary: google::protobuf; MessageLite; true; ParseFromIstream; ; ; Argument[*0]; Argument[-1]; taint; manual |
+| 140 | Summary: google::protobuf; MessageLite; true; ParseFromString; (const Cord &); ; Argument[*0]; Argument[-1]; taint; manual |
+| 141 | Summary: google::protobuf; MessageLite; true; ParseFromString; (string_view); ; Argument[0]; Argument[-1]; taint; manual |
+| 142 | Summary: google::protobuf; MessageLite; true; ParseFromZeroCopyStream; ; ; Argument[*0]; Argument[-1]; taint; manual |
+| 143 | Summary: google::protobuf; MessageLite; true; ParsePartialFromArray; ; ; Argument[*0]; Argument[-1]; taint; manual |
+| 144 | Summary: google::protobuf; MessageLite; true; ParsePartialFromBoundedZeroCopyStream; ; ; Argument[*0]; Argument[-1]; taint; manual |
+| 145 | Summary: google::protobuf; MessageLite; true; ParsePartialFromCodedStream; ; ; Argument[*0]; Argument[-1]; taint; manual |
+| 146 | Summary: google::protobuf; MessageLite; true; ParsePartialFromCord; ; ; Argument[*0]; Argument[-1]; taint; manual |
+| 147 | Summary: google::protobuf; MessageLite; true; ParsePartialFromIstream; ; ; Argument[*0]; Argument[-1]; taint; manual |
+| 148 | Summary: google::protobuf; MessageLite; true; ParsePartialFromString; (const Cord &); ; Argument[*0]; Argument[-1]; taint; manual |
+| 149 | Summary: google::protobuf; MessageLite; true; ParsePartialFromString; (string_view); ; Argument[0]; Argument[-1]; taint; manual |
+| 150 | Summary: google::protobuf; MessageLite; true; ParsePartialFromZeroCopyStream; ; ; Argument[*0]; Argument[-1]; taint; manual |
+| 151 | Summary: google::protobuf; MessageLite; true; SerializeAsCord; ; ; Argument[-1]; ReturnValue; taint; manual |
+| 152 | Summary: google::protobuf; MessageLite; true; SerializeAsString; ; ; Argument[-1]; ReturnValue; taint; manual |
+| 153 | Summary: google::protobuf; MessageLite; true; SerializePartialAsCord; ; ; Argument[-1]; ReturnValue; taint; manual |
+| 154 | Summary: google::protobuf; MessageLite; true; SerializePartialAsString; ; ; Argument[-1]; ReturnValue; taint; manual |
+| 155 | Summary: google::protobuf; MessageLite; true; SerializePartialToArray; ; ; Argument[-1]; Argument[*0]; taint; manual |
+| 156 | Summary: google::protobuf; MessageLite; true; SerializePartialToCodedStream; ; ; Argument[-1]; Argument[*0]; taint; manual |
+| 157 | Summary: google::protobuf; MessageLite; true; SerializePartialToCord; ; ; Argument[-1]; Argument[*0]; taint; manual |
+| 158 | Summary: google::protobuf; MessageLite; true; SerializePartialToOstream; ; ; Argument[-1]; Argument[*0]; taint; manual |
+| 159 | Summary: google::protobuf; MessageLite; true; SerializePartialToString; ; ; Argument[-1]; Argument[*0]; taint; manual |
+| 160 | Summary: google::protobuf; MessageLite; true; SerializePartialToZeroCopyStream; ; ; Argument[-1]; Argument[*0]; taint; manual |
+| 161 | Summary: google::protobuf; MessageLite; true; SerializeToArray; ; ; Argument[-1]; Argument[*0]; taint; manual |
+| 162 | Summary: google::protobuf; MessageLite; true; SerializeToCodedStream; ; ; Argument[-1]; Argument[*0]; taint; manual |
+| 163 | Summary: google::protobuf; MessageLite; true; SerializeToCord; ; ; Argument[-1]; Argument[*0]; taint; manual |
+| 164 | Summary: google::protobuf; MessageLite; true; SerializeToOstream; ; ; Argument[-1]; Argument[*0]; taint; manual |
+| 165 | Summary: google::protobuf; MessageLite; true; SerializeToString; ; ; Argument[-1]; Argument[*0]; taint; manual |
+| 166 | Summary: google::protobuf; MessageLite; true; SerializeToZeroCopyStream; ; ; Argument[-1]; Argument[*0]; taint; manual |
 edges
 | asio_streams.cpp:129:34:129:44 | read_until output argument | asio_streams.cpp:133:7:133:17 | recv_buffer | provenance | Src:MaD:56  |
 | asio_streams.cpp:129:34:129:44 | read_until output argument | asio_streams.cpp:135:29:135:39 | recv_buffer | provenance | Src:MaD:56 Sink:MaD:4 |
@@ -266,21 +309,200 @@ edges
 | bdlbb.cpp:94:46:94:48 | *src | bdlbb.cpp:94:37:94:40 | copy output argument | provenance | MaD:100 |
 | bdlbb.cpp:96:37:96:39 | copy output argument | bdlbb.cpp:97:7:97:10 | * ... | provenance |  |
 | bdlbb.cpp:96:42:96:44 | *dst | bdlbb.cpp:96:37:96:39 | copy output argument | provenance | MaD:102 |
-| protobuf.cpp:140:33:140:40 | call to source | protobuf.cpp:141:21:141:31 | *call to data | provenance | TaintFunction |
-| protobuf.cpp:141:2:141:4 | ParseFromArray output argument | protobuf.cpp:143:2:143:4 | *msg | provenance |  |
-| protobuf.cpp:141:21:141:31 | *call to data | protobuf.cpp:141:2:141:4 | ParseFromArray output argument | provenance | MaD:121 |
-| protobuf.cpp:143:2:143:4 | *msg | protobuf.cpp:143:23:143:25 | SerializeToArray output argument | provenance | MaD:123 |
-| protobuf.cpp:143:23:143:25 | SerializeToArray output argument | protobuf.cpp:144:7:144:10 | * ... | provenance |  |
-| protobuf.cpp:151:33:151:40 | call to source | protobuf.cpp:152:21:152:31 | *call to data | provenance | TaintFunction |
-| protobuf.cpp:152:2:152:4 | ParseFromArray output argument | protobuf.cpp:153:18:153:20 | *msg | provenance |  |
-| protobuf.cpp:152:21:152:31 | *call to data | protobuf.cpp:152:2:152:4 | ParseFromArray output argument | provenance | MaD:121 |
-| protobuf.cpp:153:18:153:20 | *msg | protobuf.cpp:153:22:153:38 | call to SerializeAsString | provenance | MaD:122 |
-| protobuf.cpp:153:22:153:38 | call to SerializeAsString | protobuf.cpp:153:22:153:38 | call to SerializeAsString | provenance |  |
-| protobuf.cpp:153:22:153:38 | call to SerializeAsString | protobuf.cpp:155:22:155:29 | *call to data | provenance | TaintFunction |
-| protobuf.cpp:155:2:155:5 | ParseFromArray output argument | protobuf.cpp:157:2:157:5 | *msg2 | provenance |  |
-| protobuf.cpp:155:22:155:29 | *call to data | protobuf.cpp:155:2:155:5 | ParseFromArray output argument | provenance | MaD:121 |
-| protobuf.cpp:157:2:157:5 | *msg2 | protobuf.cpp:157:24:157:26 | SerializeToArray output argument | provenance | MaD:123 |
-| protobuf.cpp:157:24:157:26 | SerializeToArray output argument | protobuf.cpp:158:7:158:10 | * ... | provenance |  |
+| protobuf.cpp:134:27:134:51 | call to source | protobuf.cpp:134:27:134:51 | call to source | provenance |  |
+| protobuf.cpp:134:27:134:51 | call to source | protobuf.cpp:135:22:135:25 | data | provenance |  |
+| protobuf.cpp:135:2:135:4 | ParseFromString output argument | protobuf.cpp:136:7:136:9 | msg | provenance |  |
+| protobuf.cpp:135:22:135:25 | data | protobuf.cpp:135:2:135:4 | ParseFromString output argument | provenance | MaD:141 |
+| protobuf.cpp:141:20:141:37 | call to source | protobuf.cpp:141:20:141:37 | call to source | provenance |  |
+| protobuf.cpp:141:20:141:37 | call to source | protobuf.cpp:142:22:142:25 | *data | provenance |  |
+| protobuf.cpp:142:2:142:4 | ParseFromString output argument | protobuf.cpp:143:7:143:9 | msg | provenance |  |
+| protobuf.cpp:142:22:142:25 | *data | protobuf.cpp:142:2:142:4 | ParseFromString output argument | provenance | MaD:140 |
+| protobuf.cpp:148:27:148:51 | call to source | protobuf.cpp:148:27:148:51 | call to source | provenance |  |
+| protobuf.cpp:148:27:148:51 | call to source | protobuf.cpp:149:29:149:32 | data | provenance |  |
+| protobuf.cpp:149:2:149:4 | ParsePartialFromString output argument | protobuf.cpp:150:7:150:9 | msg | provenance |  |
+| protobuf.cpp:149:29:149:32 | data | protobuf.cpp:149:2:149:4 | ParsePartialFromString output argument | provenance | MaD:149 |
+| protobuf.cpp:155:20:155:37 | call to source | protobuf.cpp:155:20:155:37 | call to source | provenance |  |
+| protobuf.cpp:155:20:155:37 | call to source | protobuf.cpp:156:29:156:32 | *data | provenance |  |
+| protobuf.cpp:156:2:156:4 | ParsePartialFromString output argument | protobuf.cpp:157:7:157:9 | msg | provenance |  |
+| protobuf.cpp:156:29:156:32 | *data | protobuf.cpp:156:2:156:4 | ParsePartialFromString output argument | provenance | MaD:148 |
+| protobuf.cpp:162:27:162:51 | call to source | protobuf.cpp:162:27:162:51 | call to source | provenance |  |
+| protobuf.cpp:162:27:162:51 | call to source | protobuf.cpp:163:22:163:25 | data | provenance |  |
+| protobuf.cpp:163:2:163:4 | MergeFromString output argument | protobuf.cpp:164:7:164:9 | msg | provenance |  |
+| protobuf.cpp:163:22:163:25 | data | protobuf.cpp:163:2:163:4 | MergeFromString output argument | provenance | MaD:129 |
+| protobuf.cpp:169:20:169:37 | call to source | protobuf.cpp:169:20:169:37 | call to source | provenance |  |
+| protobuf.cpp:169:20:169:37 | call to source | protobuf.cpp:170:22:170:25 | *data | provenance |  |
+| protobuf.cpp:170:2:170:4 | MergeFromString output argument | protobuf.cpp:171:7:171:9 | msg | provenance |  |
+| protobuf.cpp:170:22:170:25 | *data | protobuf.cpp:170:2:170:4 | MergeFromString output argument | provenance | MaD:128 |
+| protobuf.cpp:176:27:176:51 | call to source | protobuf.cpp:176:27:176:51 | call to source | provenance |  |
+| protobuf.cpp:176:27:176:51 | call to source | protobuf.cpp:177:29:177:32 | data | provenance |  |
+| protobuf.cpp:177:2:177:4 | MergePartialFromString output argument | protobuf.cpp:178:7:178:9 | msg | provenance |  |
+| protobuf.cpp:177:29:177:32 | data | protobuf.cpp:177:2:177:4 | MergePartialFromString output argument | provenance | MaD:134 |
+| protobuf.cpp:183:20:183:37 | call to source | protobuf.cpp:183:20:183:37 | call to source | provenance |  |
+| protobuf.cpp:183:20:183:37 | call to source | protobuf.cpp:184:29:184:32 | *data | provenance |  |
+| protobuf.cpp:184:2:184:4 | MergePartialFromString output argument | protobuf.cpp:185:7:185:9 | msg | provenance |  |
+| protobuf.cpp:184:29:184:32 | *data | protobuf.cpp:184:2:184:4 | MergePartialFromString output argument | provenance | MaD:133 |
+| protobuf.cpp:190:19:190:38 | call to source | protobuf.cpp:191:21:191:31 | *call to data | provenance | TaintFunction |
+| protobuf.cpp:191:2:191:4 | ParseFromArray output argument | protobuf.cpp:192:7:192:9 | msg | provenance |  |
+| protobuf.cpp:191:21:191:31 | *call to data | protobuf.cpp:191:2:191:4 | ParseFromArray output argument | provenance | MaD:135 |
+| protobuf.cpp:197:19:197:38 | call to source | protobuf.cpp:198:28:198:38 | *call to data | provenance | TaintFunction |
+| protobuf.cpp:198:2:198:4 | ParsePartialFromArray output argument | protobuf.cpp:199:7:199:9 | msg | provenance |  |
+| protobuf.cpp:198:28:198:38 | *call to data | protobuf.cpp:198:2:198:4 | ParsePartialFromArray output argument | provenance | MaD:143 |
+| protobuf.cpp:204:20:204:37 | call to source | protobuf.cpp:204:20:204:37 | call to source | provenance |  |
+| protobuf.cpp:204:20:204:37 | call to source | protobuf.cpp:205:20:205:23 | *data | provenance |  |
+| protobuf.cpp:205:2:205:4 | ParseFromCord output argument | protobuf.cpp:206:7:206:9 | msg | provenance |  |
+| protobuf.cpp:205:20:205:23 | *data | protobuf.cpp:205:2:205:4 | ParseFromCord output argument | provenance | MaD:138 |
+| protobuf.cpp:211:20:211:37 | call to source | protobuf.cpp:211:20:211:37 | call to source | provenance |  |
+| protobuf.cpp:211:20:211:37 | call to source | protobuf.cpp:212:27:212:30 | *data | provenance |  |
+| protobuf.cpp:212:2:212:4 | ParsePartialFromCord output argument | protobuf.cpp:213:7:213:9 | msg | provenance |  |
+| protobuf.cpp:212:27:212:30 | *data | protobuf.cpp:212:2:212:4 | ParsePartialFromCord output argument | provenance | MaD:146 |
+| protobuf.cpp:218:20:218:37 | call to source | protobuf.cpp:218:20:218:37 | call to source | provenance |  |
+| protobuf.cpp:218:20:218:37 | call to source | protobuf.cpp:219:20:219:23 | *data | provenance |  |
+| protobuf.cpp:219:2:219:4 | MergeFromCord output argument | protobuf.cpp:220:7:220:9 | msg | provenance |  |
+| protobuf.cpp:219:20:219:23 | *data | protobuf.cpp:219:2:219:4 | MergeFromCord output argument | provenance | MaD:127 |
+| protobuf.cpp:225:20:225:37 | call to source | protobuf.cpp:225:20:225:37 | call to source | provenance |  |
+| protobuf.cpp:225:20:225:37 | call to source | protobuf.cpp:226:27:226:30 | *data | provenance |  |
+| protobuf.cpp:226:2:226:4 | MergePartialFromCord output argument | protobuf.cpp:227:7:227:9 | msg | provenance |  |
+| protobuf.cpp:226:27:226:30 | *data | protobuf.cpp:226:2:226:4 | MergePartialFromCord output argument | provenance | MaD:132 |
+| protobuf.cpp:232:20:232:39 | call to source | protobuf.cpp:232:20:232:39 | call to source | provenance |  |
+| protobuf.cpp:232:20:232:39 | call to source | protobuf.cpp:233:23:233:25 | *& ... | provenance |  |
+| protobuf.cpp:233:2:233:4 | ParseFromIstream output argument | protobuf.cpp:234:7:234:9 | msg | provenance |  |
+| protobuf.cpp:233:23:233:25 | *& ... | protobuf.cpp:233:2:233:4 | ParseFromIstream output argument | provenance | MaD:139 |
+| protobuf.cpp:239:20:239:39 | call to source | protobuf.cpp:239:20:239:39 | call to source | provenance |  |
+| protobuf.cpp:239:20:239:39 | call to source | protobuf.cpp:240:30:240:32 | *& ... | provenance |  |
+| protobuf.cpp:240:2:240:4 | ParsePartialFromIstream output argument | protobuf.cpp:241:7:241:9 | msg | provenance |  |
+| protobuf.cpp:240:30:240:32 | *& ... | protobuf.cpp:240:2:240:4 | ParsePartialFromIstream output argument | provenance | MaD:147 |
+| protobuf.cpp:246:27:246:53 | call to source | protobuf.cpp:246:27:246:53 | call to source | provenance |  |
+| protobuf.cpp:246:27:246:53 | call to source | protobuf.cpp:247:30:247:32 | *& ... | provenance |  |
+| protobuf.cpp:247:2:247:4 | ParseFromZeroCopyStream output argument | protobuf.cpp:248:7:248:9 | msg | provenance |  |
+| protobuf.cpp:247:30:247:32 | *& ... | protobuf.cpp:247:2:247:4 | ParseFromZeroCopyStream output argument | provenance | MaD:142 |
+| protobuf.cpp:253:27:253:53 | call to source | protobuf.cpp:253:27:253:53 | call to source | provenance |  |
+| protobuf.cpp:253:27:253:53 | call to source | protobuf.cpp:254:37:254:39 | *& ... | provenance |  |
+| protobuf.cpp:254:2:254:4 | ParsePartialFromZeroCopyStream output argument | protobuf.cpp:255:7:255:9 | msg | provenance |  |
+| protobuf.cpp:254:37:254:39 | *& ... | protobuf.cpp:254:2:254:4 | ParsePartialFromZeroCopyStream output argument | provenance | MaD:150 |
+| protobuf.cpp:260:27:260:53 | call to source | protobuf.cpp:260:27:260:53 | call to source | provenance |  |
+| protobuf.cpp:260:27:260:53 | call to source | protobuf.cpp:261:37:261:39 | *& ... | provenance |  |
+| protobuf.cpp:261:2:261:4 | ParseFromBoundedZeroCopyStream output argument | protobuf.cpp:262:7:262:9 | msg | provenance |  |
+| protobuf.cpp:261:37:261:39 | *& ... | protobuf.cpp:261:2:261:4 | ParseFromBoundedZeroCopyStream output argument | provenance | MaD:136 |
+| protobuf.cpp:267:27:267:53 | call to source | protobuf.cpp:267:27:267:53 | call to source | provenance |  |
+| protobuf.cpp:267:27:267:53 | call to source | protobuf.cpp:268:44:268:46 | *& ... | provenance |  |
+| protobuf.cpp:268:2:268:4 | ParsePartialFromBoundedZeroCopyStream output argument | protobuf.cpp:269:7:269:9 | msg | provenance |  |
+| protobuf.cpp:268:44:268:46 | *& ... | protobuf.cpp:268:2:268:4 | ParsePartialFromBoundedZeroCopyStream output argument | provenance | MaD:144 |
+| protobuf.cpp:274:27:274:53 | call to source | protobuf.cpp:274:27:274:53 | call to source | provenance |  |
+| protobuf.cpp:274:27:274:53 | call to source | protobuf.cpp:275:37:275:39 | *& ... | provenance |  |
+| protobuf.cpp:275:2:275:4 | MergeFromBoundedZeroCopyStream output argument | protobuf.cpp:276:7:276:9 | msg | provenance |  |
+| protobuf.cpp:275:37:275:39 | *& ... | protobuf.cpp:275:2:275:4 | MergeFromBoundedZeroCopyStream output argument | provenance | MaD:125 |
+| protobuf.cpp:281:27:281:53 | call to source | protobuf.cpp:281:27:281:53 | call to source | provenance |  |
+| protobuf.cpp:281:27:281:53 | call to source | protobuf.cpp:282:44:282:46 | *& ... | provenance |  |
+| protobuf.cpp:282:2:282:4 | MergePartialFromBoundedZeroCopyStream output argument | protobuf.cpp:283:7:283:9 | msg | provenance |  |
+| protobuf.cpp:282:44:282:46 | *& ... | protobuf.cpp:282:2:282:4 | MergePartialFromBoundedZeroCopyStream output argument | provenance | MaD:130 |
+| protobuf.cpp:288:24:288:47 | call to source | protobuf.cpp:288:24:288:47 | call to source | provenance |  |
+| protobuf.cpp:288:24:288:47 | call to source | protobuf.cpp:289:27:289:29 | *& ... | provenance |  |
+| protobuf.cpp:289:2:289:4 | ParseFromCodedStream output argument | protobuf.cpp:290:7:290:9 | msg | provenance |  |
+| protobuf.cpp:289:27:289:29 | *& ... | protobuf.cpp:289:2:289:4 | ParseFromCodedStream output argument | provenance | MaD:137 |
+| protobuf.cpp:295:24:295:47 | call to source | protobuf.cpp:295:24:295:47 | call to source | provenance |  |
+| protobuf.cpp:295:24:295:47 | call to source | protobuf.cpp:296:34:296:36 | *& ... | provenance |  |
+| protobuf.cpp:296:2:296:4 | ParsePartialFromCodedStream output argument | protobuf.cpp:297:7:297:9 | msg | provenance |  |
+| protobuf.cpp:296:34:296:36 | *& ... | protobuf.cpp:296:2:296:4 | ParsePartialFromCodedStream output argument | provenance | MaD:145 |
+| protobuf.cpp:302:24:302:47 | call to source | protobuf.cpp:302:24:302:47 | call to source | provenance |  |
+| protobuf.cpp:302:24:302:47 | call to source | protobuf.cpp:303:27:303:29 | *& ... | provenance |  |
+| protobuf.cpp:303:2:303:4 | MergeFromCodedStream output argument | protobuf.cpp:304:7:304:9 | msg | provenance |  |
+| protobuf.cpp:303:27:303:29 | *& ... | protobuf.cpp:303:2:303:4 | MergeFromCodedStream output argument | provenance | MaD:126 |
+| protobuf.cpp:309:24:309:47 | call to source | protobuf.cpp:309:24:309:47 | call to source | provenance |  |
+| protobuf.cpp:309:24:309:47 | call to source | protobuf.cpp:310:34:310:36 | *& ... | provenance |  |
+| protobuf.cpp:310:2:310:4 | MergePartialFromCodedStream output argument | protobuf.cpp:311:7:311:9 | msg | provenance |  |
+| protobuf.cpp:310:34:310:36 | *& ... | protobuf.cpp:310:2:310:4 | MergePartialFromCodedStream output argument | provenance | MaD:131 |
+| protobuf.cpp:324:15:324:28 | call to source | protobuf.cpp:324:15:324:28 | call to source | provenance |  |
+| protobuf.cpp:324:15:324:28 | call to source | protobuf.cpp:326:2:326:4 | *msg | provenance |  |
+| protobuf.cpp:326:2:326:4 | *msg | protobuf.cpp:326:24:326:27 | SerializeToString output argument | provenance | MaD:165 |
+| protobuf.cpp:326:24:326:27 | SerializeToString output argument | protobuf.cpp:327:7:327:9 | out | provenance |  |
+| protobuf.cpp:331:15:331:28 | call to source | protobuf.cpp:331:15:331:28 | call to source | provenance |  |
+| protobuf.cpp:331:15:331:28 | call to source | protobuf.cpp:333:2:333:4 | *msg | provenance |  |
+| protobuf.cpp:333:2:333:4 | *msg | protobuf.cpp:333:31:333:34 | SerializePartialToString output argument | provenance | MaD:159 |
+| protobuf.cpp:333:31:333:34 | SerializePartialToString output argument | protobuf.cpp:334:7:334:9 | out | provenance |  |
+| protobuf.cpp:338:15:338:28 | call to source | protobuf.cpp:338:15:338:28 | call to source | provenance |  |
+| protobuf.cpp:338:15:338:28 | call to source | protobuf.cpp:340:2:340:4 | *msg | provenance |  |
+| protobuf.cpp:340:2:340:4 | *msg | protobuf.cpp:340:21:340:24 | AppendToString output argument | provenance | MaD:124 |
+| protobuf.cpp:340:21:340:24 | AppendToString output argument | protobuf.cpp:341:7:341:9 | out | provenance |  |
+| protobuf.cpp:345:15:345:28 | call to source | protobuf.cpp:345:15:345:28 | call to source | provenance |  |
+| protobuf.cpp:345:15:345:28 | call to source | protobuf.cpp:347:2:347:4 | *msg | provenance |  |
+| protobuf.cpp:347:2:347:4 | *msg | protobuf.cpp:347:28:347:31 | AppendPartialToString output argument | provenance | MaD:122 |
+| protobuf.cpp:347:28:347:31 | AppendPartialToString output argument | protobuf.cpp:348:7:348:9 | out | provenance |  |
+| protobuf.cpp:352:15:352:28 | call to source | protobuf.cpp:352:15:352:28 | call to source | provenance |  |
+| protobuf.cpp:352:15:352:28 | call to source | protobuf.cpp:354:2:354:4 | *msg | provenance |  |
+| protobuf.cpp:354:2:354:4 | *msg | protobuf.cpp:354:24:354:27 | SerializeToString output argument | provenance | MaD:165 |
+| protobuf.cpp:354:24:354:27 | SerializeToString output argument | protobuf.cpp:355:7:355:9 | out | provenance |  |
+| protobuf.cpp:359:15:359:28 | call to source | protobuf.cpp:359:15:359:28 | call to source | provenance |  |
+| protobuf.cpp:359:15:359:28 | call to source | protobuf.cpp:361:2:361:4 | *msg | provenance |  |
+| protobuf.cpp:361:2:361:4 | *msg | protobuf.cpp:361:31:361:34 | SerializePartialToString output argument | provenance | MaD:159 |
+| protobuf.cpp:361:31:361:34 | SerializePartialToString output argument | protobuf.cpp:362:7:362:9 | out | provenance |  |
+| protobuf.cpp:366:15:366:28 | call to source | protobuf.cpp:366:15:366:28 | call to source | provenance |  |
+| protobuf.cpp:366:15:366:28 | call to source | protobuf.cpp:368:2:368:4 | *msg | provenance |  |
+| protobuf.cpp:368:2:368:4 | *msg | protobuf.cpp:368:21:368:24 | AppendToString output argument | provenance | MaD:124 |
+| protobuf.cpp:368:21:368:24 | AppendToString output argument | protobuf.cpp:369:7:369:9 | out | provenance |  |
+| protobuf.cpp:373:15:373:28 | call to source | protobuf.cpp:373:15:373:28 | call to source | provenance |  |
+| protobuf.cpp:373:15:373:28 | call to source | protobuf.cpp:375:2:375:4 | *msg | provenance |  |
+| protobuf.cpp:375:2:375:4 | *msg | protobuf.cpp:375:28:375:31 | AppendPartialToString output argument | provenance | MaD:122 |
+| protobuf.cpp:375:28:375:31 | AppendPartialToString output argument | protobuf.cpp:376:7:376:9 | out | provenance |  |
+| protobuf.cpp:380:15:380:28 | call to source | protobuf.cpp:380:15:380:28 | call to source | provenance |  |
+| protobuf.cpp:380:15:380:28 | call to source | protobuf.cpp:382:2:382:4 | *msg | provenance |  |
+| protobuf.cpp:382:2:382:4 | *msg | protobuf.cpp:382:23:382:25 | SerializeToArray output argument | provenance | MaD:161 |
+| protobuf.cpp:382:23:382:25 | SerializeToArray output argument | protobuf.cpp:383:7:383:10 | * ... | provenance |  |
+| protobuf.cpp:387:15:387:28 | call to source | protobuf.cpp:387:15:387:28 | call to source | provenance |  |
+| protobuf.cpp:387:15:387:28 | call to source | protobuf.cpp:389:2:389:4 | *msg | provenance |  |
+| protobuf.cpp:389:2:389:4 | *msg | protobuf.cpp:389:30:389:32 | SerializePartialToArray output argument | provenance | MaD:155 |
+| protobuf.cpp:389:30:389:32 | SerializePartialToArray output argument | protobuf.cpp:390:7:390:10 | * ... | provenance |  |
+| protobuf.cpp:394:15:394:28 | call to source | protobuf.cpp:394:15:394:28 | call to source | provenance |  |
+| protobuf.cpp:394:15:394:28 | call to source | protobuf.cpp:396:2:396:4 | *msg | provenance |  |
+| protobuf.cpp:396:2:396:4 | *msg | protobuf.cpp:396:22:396:25 | SerializeToCord output argument | provenance | MaD:163 |
+| protobuf.cpp:396:22:396:25 | SerializeToCord output argument | protobuf.cpp:397:7:397:9 | out | provenance |  |
+| protobuf.cpp:401:15:401:28 | call to source | protobuf.cpp:401:15:401:28 | call to source | provenance |  |
+| protobuf.cpp:401:15:401:28 | call to source | protobuf.cpp:403:2:403:4 | *msg | provenance |  |
+| protobuf.cpp:403:2:403:4 | *msg | protobuf.cpp:403:29:403:32 | SerializePartialToCord output argument | provenance | MaD:157 |
+| protobuf.cpp:403:29:403:32 | SerializePartialToCord output argument | protobuf.cpp:404:7:404:9 | out | provenance |  |
+| protobuf.cpp:408:15:408:28 | call to source | protobuf.cpp:408:15:408:28 | call to source | provenance |  |
+| protobuf.cpp:408:15:408:28 | call to source | protobuf.cpp:410:2:410:4 | *msg | provenance |  |
+| protobuf.cpp:410:2:410:4 | *msg | protobuf.cpp:410:19:410:22 | AppendToCord output argument | provenance | MaD:123 |
+| protobuf.cpp:410:19:410:22 | AppendToCord output argument | protobuf.cpp:411:7:411:9 | out | provenance |  |
+| protobuf.cpp:415:15:415:28 | call to source | protobuf.cpp:415:15:415:28 | call to source | provenance |  |
+| protobuf.cpp:415:15:415:28 | call to source | protobuf.cpp:417:2:417:4 | *msg | provenance |  |
+| protobuf.cpp:417:2:417:4 | *msg | protobuf.cpp:417:26:417:29 | AppendPartialToCord output argument | provenance | MaD:121 |
+| protobuf.cpp:417:26:417:29 | AppendPartialToCord output argument | protobuf.cpp:418:7:418:9 | out | provenance |  |
+| protobuf.cpp:422:15:422:28 | call to source | protobuf.cpp:422:15:422:28 | call to source | provenance |  |
+| protobuf.cpp:422:15:422:28 | call to source | protobuf.cpp:424:2:424:4 | *msg | provenance |  |
+| protobuf.cpp:424:2:424:4 | *msg | protobuf.cpp:424:25:424:28 | SerializeToOstream output argument | provenance | MaD:164 |
+| protobuf.cpp:424:25:424:28 | SerializeToOstream output argument | protobuf.cpp:425:7:425:9 | out | provenance |  |
+| protobuf.cpp:429:15:429:28 | call to source | protobuf.cpp:429:15:429:28 | call to source | provenance |  |
+| protobuf.cpp:429:15:429:28 | call to source | protobuf.cpp:431:2:431:4 | *msg | provenance |  |
+| protobuf.cpp:431:2:431:4 | *msg | protobuf.cpp:431:32:431:35 | SerializePartialToOstream output argument | provenance | MaD:158 |
+| protobuf.cpp:431:32:431:35 | SerializePartialToOstream output argument | protobuf.cpp:432:7:432:9 | out | provenance |  |
+| protobuf.cpp:436:15:436:28 | call to source | protobuf.cpp:436:15:436:28 | call to source | provenance |  |
+| protobuf.cpp:436:15:436:28 | call to source | protobuf.cpp:438:2:438:4 | *msg | provenance |  |
+| protobuf.cpp:438:2:438:4 | *msg | protobuf.cpp:438:32:438:35 | SerializeToZeroCopyStream output argument | provenance | MaD:166 |
+| protobuf.cpp:438:32:438:35 | SerializeToZeroCopyStream output argument | protobuf.cpp:439:7:439:9 | out | provenance |  |
+| protobuf.cpp:443:15:443:28 | call to source | protobuf.cpp:443:15:443:28 | call to source | provenance |  |
+| protobuf.cpp:443:15:443:28 | call to source | protobuf.cpp:445:2:445:4 | *msg | provenance |  |
+| protobuf.cpp:445:2:445:4 | *msg | protobuf.cpp:445:39:445:42 | SerializePartialToZeroCopyStream output argument | provenance | MaD:160 |
+| protobuf.cpp:445:39:445:42 | SerializePartialToZeroCopyStream output argument | protobuf.cpp:446:7:446:9 | out | provenance |  |
+| protobuf.cpp:450:15:450:28 | call to source | protobuf.cpp:450:15:450:28 | call to source | provenance |  |
+| protobuf.cpp:450:15:450:28 | call to source | protobuf.cpp:452:2:452:4 | *msg | provenance |  |
+| protobuf.cpp:452:2:452:4 | *msg | protobuf.cpp:452:29:452:32 | SerializeToCodedStream output argument | provenance | MaD:162 |
+| protobuf.cpp:452:29:452:32 | SerializeToCodedStream output argument | protobuf.cpp:453:7:453:9 | out | provenance |  |
+| protobuf.cpp:457:15:457:28 | call to source | protobuf.cpp:457:15:457:28 | call to source | provenance |  |
+| protobuf.cpp:457:15:457:28 | call to source | protobuf.cpp:459:2:459:4 | *msg | provenance |  |
+| protobuf.cpp:459:2:459:4 | *msg | protobuf.cpp:459:36:459:39 | SerializePartialToCodedStream output argument | provenance | MaD:156 |
+| protobuf.cpp:459:36:459:39 | SerializePartialToCodedStream output argument | protobuf.cpp:460:7:460:9 | out | provenance |  |
+| protobuf.cpp:466:15:466:28 | call to source | protobuf.cpp:466:15:466:28 | call to source | provenance |  |
+| protobuf.cpp:466:15:466:28 | call to source | protobuf.cpp:467:7:467:9 | *msg | provenance |  |
+| protobuf.cpp:467:7:467:9 | *msg | protobuf.cpp:467:11:467:27 | call to SerializeAsString | provenance | MaD:152 |
+| protobuf.cpp:471:15:471:28 | call to source | protobuf.cpp:471:15:471:28 | call to source | provenance |  |
+| protobuf.cpp:471:15:471:28 | call to source | protobuf.cpp:472:7:472:9 | *msg | provenance |  |
+| protobuf.cpp:472:7:472:9 | *msg | protobuf.cpp:472:11:472:34 | call to SerializePartialAsString | provenance | MaD:154 |
+| protobuf.cpp:476:15:476:28 | call to source | protobuf.cpp:476:15:476:28 | call to source | provenance |  |
+| protobuf.cpp:476:15:476:28 | call to source | protobuf.cpp:477:7:477:9 | *msg | provenance |  |
+| protobuf.cpp:477:7:477:9 | *msg | protobuf.cpp:477:11:477:25 | call to SerializeAsCord | provenance | MaD:151 |
+| protobuf.cpp:481:15:481:28 | call to source | protobuf.cpp:481:15:481:28 | call to source | provenance |  |
+| protobuf.cpp:481:15:481:28 | call to source | protobuf.cpp:482:7:482:9 | *msg | provenance |  |
+| protobuf.cpp:482:7:482:9 | *msg | protobuf.cpp:482:11:482:32 | call to SerializePartialAsCord | provenance | MaD:153 |
 | test.cpp:7:47:7:52 | value2 | test.cpp:7:64:7:69 | value2 | provenance |  |
 | test.cpp:7:64:7:69 | value2 | test.cpp:7:5:7:30 | *ymlStepGenerated_with_body | provenance |  |
 | test.cpp:10:10:10:18 | call to ymlSource | test.cpp:10:10:10:18 | call to ymlSource | provenance | Src:MaD:48  |
@@ -783,23 +1005,250 @@ nodes
 | bdlbb.cpp:96:37:96:39 | copy output argument | semmle.label | copy output argument |
 | bdlbb.cpp:96:42:96:44 | *dst | semmle.label | *dst |
 | bdlbb.cpp:97:7:97:10 | * ... | semmle.label | * ... |
-| protobuf.cpp:140:33:140:40 | call to source | semmle.label | call to source |
-| protobuf.cpp:141:2:141:4 | ParseFromArray output argument | semmle.label | ParseFromArray output argument |
-| protobuf.cpp:141:21:141:31 | *call to data | semmle.label | *call to data |
-| protobuf.cpp:143:2:143:4 | *msg | semmle.label | *msg |
-| protobuf.cpp:143:23:143:25 | SerializeToArray output argument | semmle.label | SerializeToArray output argument |
-| protobuf.cpp:144:7:144:10 | * ... | semmle.label | * ... |
-| protobuf.cpp:151:33:151:40 | call to source | semmle.label | call to source |
-| protobuf.cpp:152:2:152:4 | ParseFromArray output argument | semmle.label | ParseFromArray output argument |
-| protobuf.cpp:152:21:152:31 | *call to data | semmle.label | *call to data |
-| protobuf.cpp:153:18:153:20 | *msg | semmle.label | *msg |
-| protobuf.cpp:153:22:153:38 | call to SerializeAsString | semmle.label | call to SerializeAsString |
-| protobuf.cpp:153:22:153:38 | call to SerializeAsString | semmle.label | call to SerializeAsString |
-| protobuf.cpp:155:2:155:5 | ParseFromArray output argument | semmle.label | ParseFromArray output argument |
-| protobuf.cpp:155:22:155:29 | *call to data | semmle.label | *call to data |
-| protobuf.cpp:157:2:157:5 | *msg2 | semmle.label | *msg2 |
-| protobuf.cpp:157:24:157:26 | SerializeToArray output argument | semmle.label | SerializeToArray output argument |
-| protobuf.cpp:158:7:158:10 | * ... | semmle.label | * ... |
+| protobuf.cpp:134:27:134:51 | call to source | semmle.label | call to source |
+| protobuf.cpp:134:27:134:51 | call to source | semmle.label | call to source |
+| protobuf.cpp:135:2:135:4 | ParseFromString output argument | semmle.label | ParseFromString output argument |
+| protobuf.cpp:135:22:135:25 | data | semmle.label | data |
+| protobuf.cpp:136:7:136:9 | msg | semmle.label | msg |
+| protobuf.cpp:141:20:141:37 | call to source | semmle.label | call to source |
+| protobuf.cpp:141:20:141:37 | call to source | semmle.label | call to source |
+| protobuf.cpp:142:2:142:4 | ParseFromString output argument | semmle.label | ParseFromString output argument |
+| protobuf.cpp:142:22:142:25 | *data | semmle.label | *data |
+| protobuf.cpp:143:7:143:9 | msg | semmle.label | msg |
+| protobuf.cpp:148:27:148:51 | call to source | semmle.label | call to source |
+| protobuf.cpp:148:27:148:51 | call to source | semmle.label | call to source |
+| protobuf.cpp:149:2:149:4 | ParsePartialFromString output argument | semmle.label | ParsePartialFromString output argument |
+| protobuf.cpp:149:29:149:32 | data | semmle.label | data |
+| protobuf.cpp:150:7:150:9 | msg | semmle.label | msg |
+| protobuf.cpp:155:20:155:37 | call to source | semmle.label | call to source |
+| protobuf.cpp:155:20:155:37 | call to source | semmle.label | call to source |
+| protobuf.cpp:156:2:156:4 | ParsePartialFromString output argument | semmle.label | ParsePartialFromString output argument |
+| protobuf.cpp:156:29:156:32 | *data | semmle.label | *data |
+| protobuf.cpp:157:7:157:9 | msg | semmle.label | msg |
+| protobuf.cpp:162:27:162:51 | call to source | semmle.label | call to source |
+| protobuf.cpp:162:27:162:51 | call to source | semmle.label | call to source |
+| protobuf.cpp:163:2:163:4 | MergeFromString output argument | semmle.label | MergeFromString output argument |
+| protobuf.cpp:163:22:163:25 | data | semmle.label | data |
+| protobuf.cpp:164:7:164:9 | msg | semmle.label | msg |
+| protobuf.cpp:169:20:169:37 | call to source | semmle.label | call to source |
+| protobuf.cpp:169:20:169:37 | call to source | semmle.label | call to source |
+| protobuf.cpp:170:2:170:4 | MergeFromString output argument | semmle.label | MergeFromString output argument |
+| protobuf.cpp:170:22:170:25 | *data | semmle.label | *data |
+| protobuf.cpp:171:7:171:9 | msg | semmle.label | msg |
+| protobuf.cpp:176:27:176:51 | call to source | semmle.label | call to source |
+| protobuf.cpp:176:27:176:51 | call to source | semmle.label | call to source |
+| protobuf.cpp:177:2:177:4 | MergePartialFromString output argument | semmle.label | MergePartialFromString output argument |
+| protobuf.cpp:177:29:177:32 | data | semmle.label | data |
+| protobuf.cpp:178:7:178:9 | msg | semmle.label | msg |
+| protobuf.cpp:183:20:183:37 | call to source | semmle.label | call to source |
+| protobuf.cpp:183:20:183:37 | call to source | semmle.label | call to source |
+| protobuf.cpp:184:2:184:4 | MergePartialFromString output argument | semmle.label | MergePartialFromString output argument |
+| protobuf.cpp:184:29:184:32 | *data | semmle.label | *data |
+| protobuf.cpp:185:7:185:9 | msg | semmle.label | msg |
+| protobuf.cpp:190:19:190:38 | call to source | semmle.label | call to source |
+| protobuf.cpp:191:2:191:4 | ParseFromArray output argument | semmle.label | ParseFromArray output argument |
+| protobuf.cpp:191:21:191:31 | *call to data | semmle.label | *call to data |
+| protobuf.cpp:192:7:192:9 | msg | semmle.label | msg |
+| protobuf.cpp:197:19:197:38 | call to source | semmle.label | call to source |
+| protobuf.cpp:198:2:198:4 | ParsePartialFromArray output argument | semmle.label | ParsePartialFromArray output argument |
+| protobuf.cpp:198:28:198:38 | *call to data | semmle.label | *call to data |
+| protobuf.cpp:199:7:199:9 | msg | semmle.label | msg |
+| protobuf.cpp:204:20:204:37 | call to source | semmle.label | call to source |
+| protobuf.cpp:204:20:204:37 | call to source | semmle.label | call to source |
+| protobuf.cpp:205:2:205:4 | ParseFromCord output argument | semmle.label | ParseFromCord output argument |
+| protobuf.cpp:205:20:205:23 | *data | semmle.label | *data |
+| protobuf.cpp:206:7:206:9 | msg | semmle.label | msg |
+| protobuf.cpp:211:20:211:37 | call to source | semmle.label | call to source |
+| protobuf.cpp:211:20:211:37 | call to source | semmle.label | call to source |
+| protobuf.cpp:212:2:212:4 | ParsePartialFromCord output argument | semmle.label | ParsePartialFromCord output argument |
+| protobuf.cpp:212:27:212:30 | *data | semmle.label | *data |
+| protobuf.cpp:213:7:213:9 | msg | semmle.label | msg |
+| protobuf.cpp:218:20:218:37 | call to source | semmle.label | call to source |
+| protobuf.cpp:218:20:218:37 | call to source | semmle.label | call to source |
+| protobuf.cpp:219:2:219:4 | MergeFromCord output argument | semmle.label | MergeFromCord output argument |
+| protobuf.cpp:219:20:219:23 | *data | semmle.label | *data |
+| protobuf.cpp:220:7:220:9 | msg | semmle.label | msg |
+| protobuf.cpp:225:20:225:37 | call to source | semmle.label | call to source |
+| protobuf.cpp:225:20:225:37 | call to source | semmle.label | call to source |
+| protobuf.cpp:226:2:226:4 | MergePartialFromCord output argument | semmle.label | MergePartialFromCord output argument |
+| protobuf.cpp:226:27:226:30 | *data | semmle.label | *data |
+| protobuf.cpp:227:7:227:9 | msg | semmle.label | msg |
+| protobuf.cpp:232:20:232:39 | call to source | semmle.label | call to source |
+| protobuf.cpp:232:20:232:39 | call to source | semmle.label | call to source |
+| protobuf.cpp:233:2:233:4 | ParseFromIstream output argument | semmle.label | ParseFromIstream output argument |
+| protobuf.cpp:233:23:233:25 | *& ... | semmle.label | *& ... |
+| protobuf.cpp:234:7:234:9 | msg | semmle.label | msg |
+| protobuf.cpp:239:20:239:39 | call to source | semmle.label | call to source |
+| protobuf.cpp:239:20:239:39 | call to source | semmle.label | call to source |
+| protobuf.cpp:240:2:240:4 | ParsePartialFromIstream output argument | semmle.label | ParsePartialFromIstream output argument |
+| protobuf.cpp:240:30:240:32 | *& ... | semmle.label | *& ... |
+| protobuf.cpp:241:7:241:9 | msg | semmle.label | msg |
+| protobuf.cpp:246:27:246:53 | call to source | semmle.label | call to source |
+| protobuf.cpp:246:27:246:53 | call to source | semmle.label | call to source |
+| protobuf.cpp:247:2:247:4 | ParseFromZeroCopyStream output argument | semmle.label | ParseFromZeroCopyStream output argument |
+| protobuf.cpp:247:30:247:32 | *& ... | semmle.label | *& ... |
+| protobuf.cpp:248:7:248:9 | msg | semmle.label | msg |
+| protobuf.cpp:253:27:253:53 | call to source | semmle.label | call to source |
+| protobuf.cpp:253:27:253:53 | call to source | semmle.label | call to source |
+| protobuf.cpp:254:2:254:4 | ParsePartialFromZeroCopyStream output argument | semmle.label | ParsePartialFromZeroCopyStream output argument |
+| protobuf.cpp:254:37:254:39 | *& ... | semmle.label | *& ... |
+| protobuf.cpp:255:7:255:9 | msg | semmle.label | msg |
+| protobuf.cpp:260:27:260:53 | call to source | semmle.label | call to source |
+| protobuf.cpp:260:27:260:53 | call to source | semmle.label | call to source |
+| protobuf.cpp:261:2:261:4 | ParseFromBoundedZeroCopyStream output argument | semmle.label | ParseFromBoundedZeroCopyStream output argument |
+| protobuf.cpp:261:37:261:39 | *& ... | semmle.label | *& ... |
+| protobuf.cpp:262:7:262:9 | msg | semmle.label | msg |
+| protobuf.cpp:267:27:267:53 | call to source | semmle.label | call to source |
+| protobuf.cpp:267:27:267:53 | call to source | semmle.label | call to source |
+| protobuf.cpp:268:2:268:4 | ParsePartialFromBoundedZeroCopyStream output argument | semmle.label | ParsePartialFromBoundedZeroCopyStream output argument |
+| protobuf.cpp:268:44:268:46 | *& ... | semmle.label | *& ... |
+| protobuf.cpp:269:7:269:9 | msg | semmle.label | msg |
+| protobuf.cpp:274:27:274:53 | call to source | semmle.label | call to source |
+| protobuf.cpp:274:27:274:53 | call to source | semmle.label | call to source |
+| protobuf.cpp:275:2:275:4 | MergeFromBoundedZeroCopyStream output argument | semmle.label | MergeFromBoundedZeroCopyStream output argument |
+| protobuf.cpp:275:37:275:39 | *& ... | semmle.label | *& ... |
+| protobuf.cpp:276:7:276:9 | msg | semmle.label | msg |
+| protobuf.cpp:281:27:281:53 | call to source | semmle.label | call to source |
+| protobuf.cpp:281:27:281:53 | call to source | semmle.label | call to source |
+| protobuf.cpp:282:2:282:4 | MergePartialFromBoundedZeroCopyStream output argument | semmle.label | MergePartialFromBoundedZeroCopyStream output argument |
+| protobuf.cpp:282:44:282:46 | *& ... | semmle.label | *& ... |
+| protobuf.cpp:283:7:283:9 | msg | semmle.label | msg |
+| protobuf.cpp:288:24:288:47 | call to source | semmle.label | call to source |
+| protobuf.cpp:288:24:288:47 | call to source | semmle.label | call to source |
+| protobuf.cpp:289:2:289:4 | ParseFromCodedStream output argument | semmle.label | ParseFromCodedStream output argument |
+| protobuf.cpp:289:27:289:29 | *& ... | semmle.label | *& ... |
+| protobuf.cpp:290:7:290:9 | msg | semmle.label | msg |
+| protobuf.cpp:295:24:295:47 | call to source | semmle.label | call to source |
+| protobuf.cpp:295:24:295:47 | call to source | semmle.label | call to source |
+| protobuf.cpp:296:2:296:4 | ParsePartialFromCodedStream output argument | semmle.label | ParsePartialFromCodedStream output argument |
+| protobuf.cpp:296:34:296:36 | *& ... | semmle.label | *& ... |
+| protobuf.cpp:297:7:297:9 | msg | semmle.label | msg |
+| protobuf.cpp:302:24:302:47 | call to source | semmle.label | call to source |
+| protobuf.cpp:302:24:302:47 | call to source | semmle.label | call to source |
+| protobuf.cpp:303:2:303:4 | MergeFromCodedStream output argument | semmle.label | MergeFromCodedStream output argument |
+| protobuf.cpp:303:27:303:29 | *& ... | semmle.label | *& ... |
+| protobuf.cpp:304:7:304:9 | msg | semmle.label | msg |
+| protobuf.cpp:309:24:309:47 | call to source | semmle.label | call to source |
+| protobuf.cpp:309:24:309:47 | call to source | semmle.label | call to source |
+| protobuf.cpp:310:2:310:4 | MergePartialFromCodedStream output argument | semmle.label | MergePartialFromCodedStream output argument |
+| protobuf.cpp:310:34:310:36 | *& ... | semmle.label | *& ... |
+| protobuf.cpp:311:7:311:9 | msg | semmle.label | msg |
+| protobuf.cpp:324:15:324:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:324:15:324:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:326:2:326:4 | *msg | semmle.label | *msg |
+| protobuf.cpp:326:24:326:27 | SerializeToString output argument | semmle.label | SerializeToString output argument |
+| protobuf.cpp:327:7:327:9 | out | semmle.label | out |
+| protobuf.cpp:331:15:331:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:331:15:331:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:333:2:333:4 | *msg | semmle.label | *msg |
+| protobuf.cpp:333:31:333:34 | SerializePartialToString output argument | semmle.label | SerializePartialToString output argument |
+| protobuf.cpp:334:7:334:9 | out | semmle.label | out |
+| protobuf.cpp:338:15:338:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:338:15:338:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:340:2:340:4 | *msg | semmle.label | *msg |
+| protobuf.cpp:340:21:340:24 | AppendToString output argument | semmle.label | AppendToString output argument |
+| protobuf.cpp:341:7:341:9 | out | semmle.label | out |
+| protobuf.cpp:345:15:345:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:345:15:345:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:347:2:347:4 | *msg | semmle.label | *msg |
+| protobuf.cpp:347:28:347:31 | AppendPartialToString output argument | semmle.label | AppendPartialToString output argument |
+| protobuf.cpp:348:7:348:9 | out | semmle.label | out |
+| protobuf.cpp:352:15:352:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:352:15:352:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:354:2:354:4 | *msg | semmle.label | *msg |
+| protobuf.cpp:354:24:354:27 | SerializeToString output argument | semmle.label | SerializeToString output argument |
+| protobuf.cpp:355:7:355:9 | out | semmle.label | out |
+| protobuf.cpp:359:15:359:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:359:15:359:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:361:2:361:4 | *msg | semmle.label | *msg |
+| protobuf.cpp:361:31:361:34 | SerializePartialToString output argument | semmle.label | SerializePartialToString output argument |
+| protobuf.cpp:362:7:362:9 | out | semmle.label | out |
+| protobuf.cpp:366:15:366:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:366:15:366:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:368:2:368:4 | *msg | semmle.label | *msg |
+| protobuf.cpp:368:21:368:24 | AppendToString output argument | semmle.label | AppendToString output argument |
+| protobuf.cpp:369:7:369:9 | out | semmle.label | out |
+| protobuf.cpp:373:15:373:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:373:15:373:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:375:2:375:4 | *msg | semmle.label | *msg |
+| protobuf.cpp:375:28:375:31 | AppendPartialToString output argument | semmle.label | AppendPartialToString output argument |
+| protobuf.cpp:376:7:376:9 | out | semmle.label | out |
+| protobuf.cpp:380:15:380:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:380:15:380:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:382:2:382:4 | *msg | semmle.label | *msg |
+| protobuf.cpp:382:23:382:25 | SerializeToArray output argument | semmle.label | SerializeToArray output argument |
+| protobuf.cpp:383:7:383:10 | * ... | semmle.label | * ... |
+| protobuf.cpp:387:15:387:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:387:15:387:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:389:2:389:4 | *msg | semmle.label | *msg |
+| protobuf.cpp:389:30:389:32 | SerializePartialToArray output argument | semmle.label | SerializePartialToArray output argument |
+| protobuf.cpp:390:7:390:10 | * ... | semmle.label | * ... |
+| protobuf.cpp:394:15:394:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:394:15:394:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:396:2:396:4 | *msg | semmle.label | *msg |
+| protobuf.cpp:396:22:396:25 | SerializeToCord output argument | semmle.label | SerializeToCord output argument |
+| protobuf.cpp:397:7:397:9 | out | semmle.label | out |
+| protobuf.cpp:401:15:401:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:401:15:401:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:403:2:403:4 | *msg | semmle.label | *msg |
+| protobuf.cpp:403:29:403:32 | SerializePartialToCord output argument | semmle.label | SerializePartialToCord output argument |
+| protobuf.cpp:404:7:404:9 | out | semmle.label | out |
+| protobuf.cpp:408:15:408:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:408:15:408:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:410:2:410:4 | *msg | semmle.label | *msg |
+| protobuf.cpp:410:19:410:22 | AppendToCord output argument | semmle.label | AppendToCord output argument |
+| protobuf.cpp:411:7:411:9 | out | semmle.label | out |
+| protobuf.cpp:415:15:415:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:415:15:415:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:417:2:417:4 | *msg | semmle.label | *msg |
+| protobuf.cpp:417:26:417:29 | AppendPartialToCord output argument | semmle.label | AppendPartialToCord output argument |
+| protobuf.cpp:418:7:418:9 | out | semmle.label | out |
+| protobuf.cpp:422:15:422:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:422:15:422:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:424:2:424:4 | *msg | semmle.label | *msg |
+| protobuf.cpp:424:25:424:28 | SerializeToOstream output argument | semmle.label | SerializeToOstream output argument |
+| protobuf.cpp:425:7:425:9 | out | semmle.label | out |
+| protobuf.cpp:429:15:429:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:429:15:429:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:431:2:431:4 | *msg | semmle.label | *msg |
+| protobuf.cpp:431:32:431:35 | SerializePartialToOstream output argument | semmle.label | SerializePartialToOstream output argument |
+| protobuf.cpp:432:7:432:9 | out | semmle.label | out |
+| protobuf.cpp:436:15:436:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:436:15:436:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:438:2:438:4 | *msg | semmle.label | *msg |
+| protobuf.cpp:438:32:438:35 | SerializeToZeroCopyStream output argument | semmle.label | SerializeToZeroCopyStream output argument |
+| protobuf.cpp:439:7:439:9 | out | semmle.label | out |
+| protobuf.cpp:443:15:443:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:443:15:443:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:445:2:445:4 | *msg | semmle.label | *msg |
+| protobuf.cpp:445:39:445:42 | SerializePartialToZeroCopyStream output argument | semmle.label | SerializePartialToZeroCopyStream output argument |
+| protobuf.cpp:446:7:446:9 | out | semmle.label | out |
+| protobuf.cpp:450:15:450:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:450:15:450:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:452:2:452:4 | *msg | semmle.label | *msg |
+| protobuf.cpp:452:29:452:32 | SerializeToCodedStream output argument | semmle.label | SerializeToCodedStream output argument |
+| protobuf.cpp:453:7:453:9 | out | semmle.label | out |
+| protobuf.cpp:457:15:457:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:457:15:457:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:459:2:459:4 | *msg | semmle.label | *msg |
+| protobuf.cpp:459:36:459:39 | SerializePartialToCodedStream output argument | semmle.label | SerializePartialToCodedStream output argument |
+| protobuf.cpp:460:7:460:9 | out | semmle.label | out |
+| protobuf.cpp:466:15:466:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:466:15:466:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:467:7:467:9 | *msg | semmle.label | *msg |
+| protobuf.cpp:467:11:467:27 | call to SerializeAsString | semmle.label | call to SerializeAsString |
+| protobuf.cpp:471:15:471:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:471:15:471:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:472:7:472:9 | *msg | semmle.label | *msg |
+| protobuf.cpp:472:11:472:34 | call to SerializePartialAsString | semmle.label | call to SerializePartialAsString |
+| protobuf.cpp:476:15:476:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:476:15:476:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:477:7:477:9 | *msg | semmle.label | *msg |
+| protobuf.cpp:477:11:477:25 | call to SerializeAsCord | semmle.label | call to SerializeAsCord |
+| protobuf.cpp:481:15:481:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:481:15:481:28 | call to source | semmle.label | call to source |
+| protobuf.cpp:482:7:482:9 | *msg | semmle.label | *msg |
+| protobuf.cpp:482:11:482:32 | call to SerializePartialAsCord | semmle.label | call to SerializePartialAsCord |
 | test.cpp:7:5:7:30 | *ymlStepGenerated_with_body | semmle.label | *ymlStepGenerated_with_body |
 | test.cpp:7:47:7:52 | value2 | semmle.label | value2 |
 | test.cpp:7:64:7:69 | value2 | semmle.label | value2 |

--- a/cpp/ql/test/library-tests/dataflow/external-models/flow.expected
+++ b/cpp/ql/test/library-tests/dataflow/external-models/flow.expected
@@ -119,6 +119,10 @@ models
 | 118 | Summary: boost::asio::ip; basic_resolver<InternetProtocol>; false; resolve; (string_view,string_view,flags); ; Argument[0..1]; ReturnValue; taint; manual |
 | 119 | Summary: boost::asio::ip; basic_resolver<InternetProtocol>; false; resolve; (string_view,string_view,flags,error_code &); ; Argument[0..1]; ReturnValue; taint; manual |
 | 120 | Summary: boost::asio; ; false; buffer; ; ; Argument[*0]; ReturnValue; taint; manual |
+| 121 | Summary: google::protobuf; MessageLite; true; ParseFromArray; ; ; Argument[*0]; Argument[-1]; taint; manual |
+| 122 | Summary: google::protobuf; MessageLite; true; ParseFromString; ; ; Argument[*0]; Argument[-1]; taint; manual |
+| 123 | Summary: google::protobuf; MessageLite; true; SerializeAsString; ; ; Argument[-1]; ReturnValue; taint; manual |
+| 124 | Summary: google::protobuf; MessageLite; true; SerializeToArray; ; ; Argument[-1]; Argument[*0]; taint; manual |
 edges
 | asio_streams.cpp:129:34:129:44 | read_until output argument | asio_streams.cpp:133:7:133:17 | recv_buffer | provenance | Src:MaD:56  |
 | asio_streams.cpp:129:34:129:44 | read_until output argument | asio_streams.cpp:135:29:135:39 | recv_buffer | provenance | Src:MaD:56 Sink:MaD:4 |
@@ -263,6 +267,26 @@ edges
 | bdlbb.cpp:94:46:94:48 | *src | bdlbb.cpp:94:37:94:40 | copy output argument | provenance | MaD:100 |
 | bdlbb.cpp:96:37:96:39 | copy output argument | bdlbb.cpp:97:7:97:10 | * ... | provenance |  |
 | bdlbb.cpp:96:42:96:44 | *dst | bdlbb.cpp:96:37:96:39 | copy output argument | provenance | MaD:102 |
+| protobuf.cpp:75:33:75:40 | call to source | protobuf.cpp:76:22:76:25 | *data | provenance | TaintFunction |
+| protobuf.cpp:76:2:76:4 | ParseFromString output argument | protobuf.cpp:78:2:78:4 | *msg | provenance |  |
+| protobuf.cpp:76:22:76:25 | *data | protobuf.cpp:76:2:76:4 | ParseFromString output argument | provenance | MaD:122 |
+| protobuf.cpp:78:2:78:4 | *msg | protobuf.cpp:78:23:78:25 | SerializeToArray output argument | provenance | MaD:124 |
+| protobuf.cpp:78:23:78:25 | SerializeToArray output argument | protobuf.cpp:79:7:79:10 | * ... | provenance |  |
+| protobuf.cpp:84:33:84:40 | call to source | protobuf.cpp:85:21:85:31 | *call to data | provenance | TaintFunction |
+| protobuf.cpp:85:2:85:4 | ParseFromArray output argument | protobuf.cpp:87:2:87:4 | *msg | provenance |  |
+| protobuf.cpp:85:21:85:31 | *call to data | protobuf.cpp:85:2:85:4 | ParseFromArray output argument | provenance | MaD:121 |
+| protobuf.cpp:87:2:87:4 | *msg | protobuf.cpp:87:23:87:25 | SerializeToArray output argument | provenance | MaD:124 |
+| protobuf.cpp:87:23:87:25 | SerializeToArray output argument | protobuf.cpp:88:7:88:10 | * ... | provenance |  |
+| protobuf.cpp:95:33:95:40 | call to source | protobuf.cpp:96:22:96:25 | *data | provenance | TaintFunction |
+| protobuf.cpp:96:2:96:4 | ParseFromString output argument | protobuf.cpp:98:23:98:25 | *msg | provenance |  |
+| protobuf.cpp:96:22:96:25 | *data | protobuf.cpp:96:2:96:4 | ParseFromString output argument | provenance | MaD:122 |
+| protobuf.cpp:98:2:98:5 | ParseFromString output argument | protobuf.cpp:100:2:100:5 | *msg2 | provenance |  |
+| protobuf.cpp:98:23:98:25 | *msg | protobuf.cpp:98:27:98:43 | call to SerializeAsString | provenance | MaD:123 |
+| protobuf.cpp:98:23:98:45 | call to SerializeAsString | protobuf.cpp:98:2:98:5 | ParseFromString output argument | provenance | MaD:122 |
+| protobuf.cpp:98:27:98:43 | call to SerializeAsString | protobuf.cpp:98:23:98:45 | call to SerializeAsString | provenance |  |
+| protobuf.cpp:98:27:98:43 | call to SerializeAsString | protobuf.cpp:98:27:98:43 | call to SerializeAsString | provenance |  |
+| protobuf.cpp:100:2:100:5 | *msg2 | protobuf.cpp:100:24:100:26 | SerializeToArray output argument | provenance | MaD:124 |
+| protobuf.cpp:100:24:100:26 | SerializeToArray output argument | protobuf.cpp:101:7:101:10 | * ... | provenance |  |
 | test.cpp:7:47:7:52 | value2 | test.cpp:7:64:7:69 | value2 | provenance |  |
 | test.cpp:7:64:7:69 | value2 | test.cpp:7:5:7:30 | *ymlStepGenerated_with_body | provenance |  |
 | test.cpp:10:10:10:18 | call to ymlSource | test.cpp:10:10:10:18 | call to ymlSource | provenance | Src:MaD:48  |
@@ -765,6 +789,29 @@ nodes
 | bdlbb.cpp:96:37:96:39 | copy output argument | semmle.label | copy output argument |
 | bdlbb.cpp:96:42:96:44 | *dst | semmle.label | *dst |
 | bdlbb.cpp:97:7:97:10 | * ... | semmle.label | * ... |
+| protobuf.cpp:75:33:75:40 | call to source | semmle.label | call to source |
+| protobuf.cpp:76:2:76:4 | ParseFromString output argument | semmle.label | ParseFromString output argument |
+| protobuf.cpp:76:22:76:25 | *data | semmle.label | *data |
+| protobuf.cpp:78:2:78:4 | *msg | semmle.label | *msg |
+| protobuf.cpp:78:23:78:25 | SerializeToArray output argument | semmle.label | SerializeToArray output argument |
+| protobuf.cpp:79:7:79:10 | * ... | semmle.label | * ... |
+| protobuf.cpp:84:33:84:40 | call to source | semmle.label | call to source |
+| protobuf.cpp:85:2:85:4 | ParseFromArray output argument | semmle.label | ParseFromArray output argument |
+| protobuf.cpp:85:21:85:31 | *call to data | semmle.label | *call to data |
+| protobuf.cpp:87:2:87:4 | *msg | semmle.label | *msg |
+| protobuf.cpp:87:23:87:25 | SerializeToArray output argument | semmle.label | SerializeToArray output argument |
+| protobuf.cpp:88:7:88:10 | * ... | semmle.label | * ... |
+| protobuf.cpp:95:33:95:40 | call to source | semmle.label | call to source |
+| protobuf.cpp:96:2:96:4 | ParseFromString output argument | semmle.label | ParseFromString output argument |
+| protobuf.cpp:96:22:96:25 | *data | semmle.label | *data |
+| protobuf.cpp:98:2:98:5 | ParseFromString output argument | semmle.label | ParseFromString output argument |
+| protobuf.cpp:98:23:98:25 | *msg | semmle.label | *msg |
+| protobuf.cpp:98:23:98:45 | call to SerializeAsString | semmle.label | call to SerializeAsString |
+| protobuf.cpp:98:27:98:43 | call to SerializeAsString | semmle.label | call to SerializeAsString |
+| protobuf.cpp:98:27:98:43 | call to SerializeAsString | semmle.label | call to SerializeAsString |
+| protobuf.cpp:100:2:100:5 | *msg2 | semmle.label | *msg2 |
+| protobuf.cpp:100:24:100:26 | SerializeToArray output argument | semmle.label | SerializeToArray output argument |
+| protobuf.cpp:101:7:101:10 | * ... | semmle.label | * ... |
 | test.cpp:7:5:7:30 | *ymlStepGenerated_with_body | semmle.label | *ymlStepGenerated_with_body |
 | test.cpp:7:47:7:52 | value2 | semmle.label | value2 |
 | test.cpp:7:64:7:69 | value2 | semmle.label | value2 |

--- a/cpp/ql/test/library-tests/dataflow/external-models/protobuf.cpp
+++ b/cpp/ql/test/library-tests/dataflow/external-models/protobuf.cpp
@@ -33,7 +33,6 @@ namespace std {
 }
 
 namespace absl {
-	// `absl::string_view` is passed by value; `absl::Cord` is passed by const reference.
 	class string_view {
 	public:
 		string_view();
@@ -56,12 +55,8 @@ namespace protobuf {
 		class CodedOutputStream {};
 	}
 
-	// A faithful subset of `MessageLite`. The string/Cord/stream signatures mirror the real
-	// `message_lite.h`; the iostream-based methods are declared on `Message` in the real headers
-	// but are modeled here on `MessageLite` (with `subtypes` covering `Message`).
 	class MessageLite {
 	public:
-		// Deserialization: input taints the message.
 		bool ParseFromString(absl::string_view data);
 		bool ParseFromString(const absl::Cord &data);
 		bool ParsePartialFromString(absl::string_view data);
@@ -89,11 +84,14 @@ namespace protobuf {
 		bool MergeFromCodedStream(io::CodedInputStream *input);
 		bool MergePartialFromCodedStream(io::CodedInputStream *input);
 
-		// Serialization into an output buffer/stream: the message taints the output argument.
 		bool SerializeToString(std::string *output) const;
 		bool SerializePartialToString(std::string *output) const;
 		bool AppendToString(std::string *output) const;
 		bool AppendPartialToString(std::string *output) const;
+		bool SerializeToString(absl::Cord *output) const;
+		bool SerializePartialToString(absl::Cord *output) const;
+		bool AppendToString(absl::Cord *output) const;
+		bool AppendPartialToString(absl::Cord *output) const;
 		bool SerializeToArray(void *data, int size) const;
 		bool SerializePartialToArray(void *data, int size) const;
 		bool SerializeToCord(absl::Cord *output) const;
@@ -107,7 +105,6 @@ namespace protobuf {
 		bool SerializeToCodedStream(io::CodedOutputStream *output) const;
 		bool SerializePartialToCodedStream(io::CodedOutputStream *output) const;
 
-		// Serialization returning the bytes.
 		std::string SerializeAsString() const;
 		std::string SerializePartialAsString() const;
 		absl::Cord SerializeAsCord() const;
@@ -125,110 +122,367 @@ class Person : public google::protobuf::Message {
 
 // --- test code ---
 
-char *source();
-void sink(char);
+template<typename T> T source();
+void sink(...);
 
-// End-to-end flow is demonstrated through the pointer-to-buffer methods, where content taint
-// flows naturally: `ParseFromArray` reads a tainted buffer into the message, and `SerializeToArray`
-// writes the message back out to a scalar buffer that reaches the sink. The `string_view`, `Cord`,
-// and stream overloads do not carry content taint through their argument conversions without further
-// library models, so they are exercised for summary-step coverage (`steps.ql`) rather than flow.
+using namespace google::protobuf::io;
 
-// Deserialization: the encoded input taints the message (`this`).
+// Deserialization: the input taints the message.
+
+void test_ParseFromString_string_view() {
+	Person msg;
+	absl::string_view data = source<absl::string_view>();
+	msg.ParseFromString(data);
+	sink(msg); // $ ir
+}
+
+void test_ParseFromString_Cord() {
+	Person msg;
+	absl::Cord data = source<absl::Cord>();
+	msg.ParseFromString(data);
+	sink(msg); // $ ir
+}
+
+void test_ParsePartialFromString_string_view() {
+	Person msg;
+	absl::string_view data = source<absl::string_view>();
+	msg.ParsePartialFromString(data);
+	sink(msg); // $ ir
+}
+
+void test_ParsePartialFromString_Cord() {
+	Person msg;
+	absl::Cord data = source<absl::Cord>();
+	msg.ParsePartialFromString(data);
+	sink(msg); // $ ir
+}
+
+void test_MergeFromString_string_view() {
+	Person msg;
+	absl::string_view data = source<absl::string_view>();
+	msg.MergeFromString(data);
+	sink(msg); // $ ir
+}
+
+void test_MergeFromString_Cord() {
+	Person msg;
+	absl::Cord data = source<absl::Cord>();
+	msg.MergeFromString(data);
+	sink(msg); // $ ir
+}
+
+void test_MergePartialFromString_string_view() {
+	Person msg;
+	absl::string_view data = source<absl::string_view>();
+	msg.MergePartialFromString(data);
+	sink(msg); // $ ir
+}
+
+void test_MergePartialFromString_Cord() {
+	Person msg;
+	absl::Cord data = source<absl::Cord>();
+	msg.MergePartialFromString(data);
+	sink(msg); // $ ir
+}
+
 void test_ParseFromArray() {
 	Person msg;
-	std::string data = std::string(source());
+	std::string data(source<const char *>());
 	msg.ParseFromArray(data.data(), data.size());
+	sink(msg); // $ ir
+}
+
+void test_ParsePartialFromArray() {
+	Person msg;
+	std::string data(source<const char *>());
+	msg.ParsePartialFromArray(data.data(), data.size());
+	sink(msg); // $ ir
+}
+
+void test_ParseFromCord() {
+	Person msg;
+	absl::Cord data = source<absl::Cord>();
+	msg.ParseFromCord(data);
+	sink(msg); // $ ir
+}
+
+void test_ParsePartialFromCord() {
+	Person msg;
+	absl::Cord data = source<absl::Cord>();
+	msg.ParsePartialFromCord(data);
+	sink(msg); // $ ir
+}
+
+void test_MergeFromCord() {
+	Person msg;
+	absl::Cord data = source<absl::Cord>();
+	msg.MergeFromCord(data);
+	sink(msg); // $ ir
+}
+
+void test_MergePartialFromCord() {
+	Person msg;
+	absl::Cord data = source<absl::Cord>();
+	msg.MergePartialFromCord(data);
+	sink(msg); // $ ir
+}
+
+void test_ParseFromIstream() {
+	Person msg;
+	std::istream in = source<std::istream>();
+	msg.ParseFromIstream(&in);
+	sink(msg); // $ ir
+}
+
+void test_ParsePartialFromIstream() {
+	Person msg;
+	std::istream in = source<std::istream>();
+	msg.ParsePartialFromIstream(&in);
+	sink(msg); // $ ir
+}
+
+void test_ParseFromZeroCopyStream() {
+	Person msg;
+	ZeroCopyInputStream in = source<ZeroCopyInputStream>();
+	msg.ParseFromZeroCopyStream(&in);
+	sink(msg); // $ ir
+}
+
+void test_ParsePartialFromZeroCopyStream() {
+	Person msg;
+	ZeroCopyInputStream in = source<ZeroCopyInputStream>();
+	msg.ParsePartialFromZeroCopyStream(&in);
+	sink(msg); // $ ir
+}
+
+void test_ParseFromBoundedZeroCopyStream() {
+	Person msg;
+	ZeroCopyInputStream in = source<ZeroCopyInputStream>();
+	msg.ParseFromBoundedZeroCopyStream(&in, 1);
+	sink(msg); // $ ir
+}
+
+void test_ParsePartialFromBoundedZeroCopyStream() {
+	Person msg;
+	ZeroCopyInputStream in = source<ZeroCopyInputStream>();
+	msg.ParsePartialFromBoundedZeroCopyStream(&in, 1);
+	sink(msg); // $ ir
+}
+
+void test_MergeFromBoundedZeroCopyStream() {
+	Person msg;
+	ZeroCopyInputStream in = source<ZeroCopyInputStream>();
+	msg.MergeFromBoundedZeroCopyStream(&in, 1);
+	sink(msg); // $ ir
+}
+
+void test_MergePartialFromBoundedZeroCopyStream() {
+	Person msg;
+	ZeroCopyInputStream in = source<ZeroCopyInputStream>();
+	msg.MergePartialFromBoundedZeroCopyStream(&in, 1);
+	sink(msg); // $ ir
+}
+
+void test_ParseFromCodedStream() {
+	Person msg;
+	CodedInputStream in = source<CodedInputStream>();
+	msg.ParseFromCodedStream(&in);
+	sink(msg); // $ ir
+}
+
+void test_ParsePartialFromCodedStream() {
+	Person msg;
+	CodedInputStream in = source<CodedInputStream>();
+	msg.ParsePartialFromCodedStream(&in);
+	sink(msg); // $ ir
+}
+
+void test_MergeFromCodedStream() {
+	Person msg;
+	CodedInputStream in = source<CodedInputStream>();
+	msg.MergeFromCodedStream(&in);
+	sink(msg); // $ ir
+}
+
+void test_MergePartialFromCodedStream() {
+	Person msg;
+	CodedInputStream in = source<CodedInputStream>();
+	msg.MergePartialFromCodedStream(&in);
+	sink(msg); // $ ir
+}
+
+void test_untainted_input() {
+	Person msg;
+	absl::Cord data;
+	msg.ParseFromString(data);
+	sink(msg); // clean
+}
+
+// Serialization: the message taints the output argument.
+
+void test_SerializeToString() {
+	Person msg = source<Person>();
+	std::string out;
+	msg.SerializeToString(&out);
+	sink(out); // $ ir
+}
+
+void test_SerializePartialToString() {
+	Person msg = source<Person>();
+	std::string out;
+	msg.SerializePartialToString(&out);
+	sink(out); // $ ir
+}
+
+void test_AppendToString() {
+	Person msg = source<Person>();
+	std::string out;
+	msg.AppendToString(&out);
+	sink(out); // $ ir
+}
+
+void test_AppendPartialToString() {
+	Person msg = source<Person>();
+	std::string out;
+	msg.AppendPartialToString(&out);
+	sink(out); // $ ir
+}
+
+void test_SerializeToString_Cord() {
+	Person msg = source<Person>();
+	absl::Cord out;
+	msg.SerializeToString(&out);
+	sink(out); // $ ir
+}
+
+void test_SerializePartialToString_Cord() {
+	Person msg = source<Person>();
+	absl::Cord out;
+	msg.SerializePartialToString(&out);
+	sink(out); // $ ir
+}
+
+void test_AppendToString_Cord() {
+	Person msg = source<Person>();
+	absl::Cord out;
+	msg.AppendToString(&out);
+	sink(out); // $ ir
+}
+
+void test_AppendPartialToString_Cord() {
+	Person msg = source<Person>();
+	absl::Cord out;
+	msg.AppendPartialToString(&out);
+	sink(out); // $ ir
+}
+
+void test_SerializeToArray() {
+	Person msg = source<Person>();
 	char buf[64];
 	msg.SerializeToArray(buf, sizeof(buf));
 	sink(*buf); // $ ir
 }
 
-// Serialization returning the bytes: the message taints the returned string, observed by parsing it
-// into a second message and serializing that back out.
-void test_SerializeAsString() {
-	Person msg;
-	std::string data = std::string(source());
-	msg.ParseFromArray(data.data(), data.size());
-	std::string s = msg.SerializeAsString();
-	Person msg2;
-	msg2.ParseFromArray(s.data(), s.size());
+void test_SerializePartialToArray() {
+	Person msg = source<Person>();
 	char buf[64];
-	msg2.SerializeToArray(buf, sizeof(buf));
+	msg.SerializePartialToArray(buf, sizeof(buf));
 	sink(*buf); // $ ir
 }
 
-// Every modeled method is called below so its summary step is covered by `steps.ql`. Endpoint
-// mistakes and rows that fail to bind show up as missing lines in `steps.expected`.
-void test_step_coverage() {
+void test_SerializeToCord() {
+	Person msg = source<Person>();
+	absl::Cord out;
+	msg.SerializeToCord(&out);
+	sink(out); // $ ir
+}
+
+void test_SerializePartialToCord() {
+	Person msg = source<Person>();
+	absl::Cord out;
+	msg.SerializePartialToCord(&out);
+	sink(out); // $ ir
+}
+
+void test_AppendToCord() {
+	Person msg = source<Person>();
+	absl::Cord out;
+	msg.AppendToCord(&out);
+	sink(out); // $ ir
+}
+
+void test_AppendPartialToCord() {
+	Person msg = source<Person>();
+	absl::Cord out;
+	msg.AppendPartialToCord(&out);
+	sink(out); // $ ir
+}
+
+void test_SerializeToOstream() {
+	Person msg = source<Person>();
+	std::ostream out;
+	msg.SerializeToOstream(&out);
+	sink(out); // $ ir
+}
+
+void test_SerializePartialToOstream() {
+	Person msg = source<Person>();
+	std::ostream out;
+	msg.SerializePartialToOstream(&out);
+	sink(out); // $ ir
+}
+
+void test_SerializeToZeroCopyStream() {
+	Person msg = source<Person>();
+	ZeroCopyOutputStream out;
+	msg.SerializeToZeroCopyStream(&out);
+	sink(out); // $ ir
+}
+
+void test_SerializePartialToZeroCopyStream() {
+	Person msg = source<Person>();
+	ZeroCopyOutputStream out;
+	msg.SerializePartialToZeroCopyStream(&out);
+	sink(out); // $ ir
+}
+
+void test_SerializeToCodedStream() {
+	Person msg = source<Person>();
+	CodedOutputStream out;
+	msg.SerializeToCodedStream(&out);
+	sink(out); // $ ir
+}
+
+void test_SerializePartialToCodedStream() {
+	Person msg = source<Person>();
+	CodedOutputStream out;
+	msg.SerializePartialToCodedStream(&out);
+	sink(out); // $ ir
+}
+
+// Serialization: the message taints the returned bytes.
+
+void test_SerializeAsString() {
+	Person msg = source<Person>();
+	sink(msg.SerializeAsString()); // $ ir
+}
+
+void test_SerializePartialAsString() {
+	Person msg = source<Person>();
+	sink(msg.SerializePartialAsString()); // $ ir
+}
+
+void test_SerializeAsCord() {
+	Person msg = source<Person>();
+	sink(msg.SerializeAsCord()); // $ ir
+}
+
+void test_SerializePartialAsCord() {
+	Person msg = source<Person>();
+	sink(msg.SerializePartialAsCord()); // $ ir
+}
+
+void test_untainted_message() {
 	Person msg;
-	std::string data = std::string(source());
-	absl::string_view sv = data;
-	absl::Cord cord;
-
-	msg.ParseFromString(sv);
-	msg.ParseFromString(cord);
-	msg.ParsePartialFromString(sv);
-	msg.ParsePartialFromString(cord);
-	msg.MergeFromString(sv);
-	msg.MergeFromString(cord);
-	msg.MergePartialFromString(sv);
-	msg.MergePartialFromString(cord);
-
-	msg.ParsePartialFromArray(data.data(), data.size());
-
-	msg.ParseFromCord(cord);
-	msg.ParsePartialFromCord(cord);
-	msg.MergeFromCord(cord);
-	msg.MergePartialFromCord(cord);
-
-	std::istream in;
-	msg.ParseFromIstream(&in);
-	msg.ParsePartialFromIstream(&in);
-
-	google::protobuf::io::ZeroCopyInputStream zin;
-	msg.ParseFromZeroCopyStream(&zin);
-	msg.ParsePartialFromZeroCopyStream(&zin);
-	msg.ParseFromBoundedZeroCopyStream(&zin, 1);
-	msg.ParsePartialFromBoundedZeroCopyStream(&zin, 1);
-	msg.MergeFromBoundedZeroCopyStream(&zin, 1);
-	msg.MergePartialFromBoundedZeroCopyStream(&zin, 1);
-
-	google::protobuf::io::CodedInputStream cin;
-	msg.ParseFromCodedStream(&cin);
-	msg.ParsePartialFromCodedStream(&cin);
-	msg.MergeFromCodedStream(&cin);
-	msg.MergePartialFromCodedStream(&cin);
-
-	std::string out;
-	msg.SerializeToString(&out);
-	msg.SerializePartialToString(&out);
-	msg.AppendToString(&out);
-	msg.AppendPartialToString(&out);
-
-	char buf[64];
-	msg.SerializePartialToArray(buf, sizeof(buf));
-
-	absl::Cord cordout;
-	msg.SerializeToCord(&cordout);
-	msg.SerializePartialToCord(&cordout);
-	msg.AppendToCord(&cordout);
-	msg.AppendPartialToCord(&cordout);
-
-	std::ostream os;
-	msg.SerializeToOstream(&os);
-	msg.SerializePartialToOstream(&os);
-
-	google::protobuf::io::ZeroCopyOutputStream zout;
-	msg.SerializeToZeroCopyStream(&zout);
-	msg.SerializePartialToZeroCopyStream(&zout);
-
-	google::protobuf::io::CodedOutputStream cout;
-	msg.SerializeToCodedStream(&cout);
-	msg.SerializePartialToCodedStream(&cout);
-
-	msg.SerializeAsString();
-	msg.SerializePartialAsString();
-	msg.SerializeAsCord();
-	msg.SerializePartialAsCord();
+	sink(msg.SerializeAsString()); // clean
 }

--- a/cpp/ql/test/library-tests/dataflow/external-models/protobuf.cpp
+++ b/cpp/ql/test/library-tests/dataflow/external-models/protobuf.cpp
@@ -32,23 +32,86 @@ namespace std {
 	};
 }
 
+namespace absl {
+	// `absl::string_view` is passed by value; `absl::Cord` is passed by const reference.
+	class string_view {
+	public:
+		string_view();
+		string_view(const char *s);
+		string_view(const std::string &s);
+	};
+
+	class Cord {
+	public:
+		Cord();
+	};
+}
+
 namespace google {
 namespace protobuf {
-	// A faithful subset of `MessageLite`; every method below is declared on `MessageLite`
-	// in the real headers (message_lite.h), including the iostream-based ones.
+	namespace io {
+		class ZeroCopyInputStream {};
+		class ZeroCopyOutputStream {};
+		class CodedInputStream {};
+		class CodedOutputStream {};
+	}
+
+	// A faithful subset of `MessageLite`. The string/Cord/stream signatures mirror the real
+	// `message_lite.h`; the iostream-based methods are declared on `Message` in the real headers
+	// but are modeled here on `MessageLite` (with `subtypes` covering `Message`).
 	class MessageLite {
 	public:
-		bool ParseFromString(const std::string &data);
-		bool MergeFromString(const std::string &data);
-		bool ParsePartialFromString(const std::string &data);
+		// Deserialization: input taints the message.
+		bool ParseFromString(absl::string_view data);
+		bool ParseFromString(const absl::Cord &data);
+		bool ParsePartialFromString(absl::string_view data);
+		bool ParsePartialFromString(const absl::Cord &data);
+		bool MergeFromString(absl::string_view data);
+		bool MergeFromString(const absl::Cord &data);
+		bool MergePartialFromString(absl::string_view data);
+		bool MergePartialFromString(const absl::Cord &data);
 		bool ParseFromArray(const void *data, int size);
+		bool ParsePartialFromArray(const void *data, int size);
+		bool ParseFromCord(const absl::Cord &data);
+		bool ParsePartialFromCord(const absl::Cord &data);
+		bool MergeFromCord(const absl::Cord &data);
+		bool MergePartialFromCord(const absl::Cord &data);
 		bool ParseFromIstream(std::istream *input);
+		bool ParsePartialFromIstream(std::istream *input);
+		bool ParseFromZeroCopyStream(io::ZeroCopyInputStream *input);
+		bool ParsePartialFromZeroCopyStream(io::ZeroCopyInputStream *input);
+		bool ParseFromBoundedZeroCopyStream(io::ZeroCopyInputStream *input, int size);
+		bool ParsePartialFromBoundedZeroCopyStream(io::ZeroCopyInputStream *input, int size);
+		bool MergeFromBoundedZeroCopyStream(io::ZeroCopyInputStream *input, int size);
+		bool MergePartialFromBoundedZeroCopyStream(io::ZeroCopyInputStream *input, int size);
+		bool ParseFromCodedStream(io::CodedInputStream *input);
+		bool ParsePartialFromCodedStream(io::CodedInputStream *input);
+		bool MergeFromCodedStream(io::CodedInputStream *input);
+		bool MergePartialFromCodedStream(io::CodedInputStream *input);
+
+		// Serialization into an output buffer/stream: the message taints the output argument.
 		bool SerializeToString(std::string *output) const;
 		bool SerializePartialToString(std::string *output) const;
 		bool AppendToString(std::string *output) const;
+		bool AppendPartialToString(std::string *output) const;
 		bool SerializeToArray(void *data, int size) const;
+		bool SerializePartialToArray(void *data, int size) const;
+		bool SerializeToCord(absl::Cord *output) const;
+		bool SerializePartialToCord(absl::Cord *output) const;
+		bool AppendToCord(absl::Cord *output) const;
+		bool AppendPartialToCord(absl::Cord *output) const;
 		bool SerializeToOstream(std::ostream *output) const;
+		bool SerializePartialToOstream(std::ostream *output) const;
+		bool SerializeToZeroCopyStream(io::ZeroCopyOutputStream *output) const;
+		bool SerializePartialToZeroCopyStream(io::ZeroCopyOutputStream *output) const;
+		bool SerializeToCodedStream(io::CodedOutputStream *output) const;
+		bool SerializePartialToCodedStream(io::CodedOutputStream *output) const;
+
+		// Serialization returning the bytes.
 		std::string SerializeAsString() const;
+		std::string SerializePartialAsString() const;
+		absl::Cord SerializeAsCord() const;
+		absl::Cord SerializePartialAsCord() const;
 	};
 
 	class Message : public MessageLite {
@@ -65,20 +128,13 @@ class Person : public google::protobuf::Message {
 char *source();
 void sink(char);
 
-// Message taint is observed through `SerializeToArray`, whose scalar output flows cleanly
-// to a sink. The object-typed serialize outputs (String/Ostream/...) and the input-stream
-// parse methods are checked directly by `steps.ql`, which asserts each summary step exists.
+// End-to-end flow is demonstrated through the pointer-to-buffer methods, where content taint
+// flows naturally: `ParseFromArray` reads a tainted buffer into the message, and `SerializeToArray`
+// writes the message back out to a scalar buffer that reaches the sink. The `string_view`, `Cord`,
+// and stream overloads do not carry content taint through their argument conversions without further
+// library models, so they are exercised for summary-step coverage (`steps.ql`) rather than flow.
 
 // Deserialization: the encoded input taints the message (`this`).
-void test_ParseFromString() {
-	Person msg;
-	std::string data = std::string(source());
-	msg.ParseFromString(data);
-	char buf[64];
-	msg.SerializeToArray(buf, sizeof(buf));
-	sink(*buf); // $ ir
-}
-
 void test_ParseFromArray() {
 	Person msg;
 	std::string data = std::string(source());
@@ -88,35 +144,91 @@ void test_ParseFromArray() {
 	sink(*buf); // $ ir
 }
 
-// Serialization returning the bytes: the message taints the returned string, observed by
-// parsing it into a second message and serializing that back out.
+// Serialization returning the bytes: the message taints the returned string, observed by parsing it
+// into a second message and serializing that back out.
 void test_SerializeAsString() {
 	Person msg;
 	std::string data = std::string(source());
-	msg.ParseFromString(data);
+	msg.ParseFromArray(data.data(), data.size());
+	std::string s = msg.SerializeAsString();
 	Person msg2;
-	msg2.ParseFromString(msg.SerializeAsString());
+	msg2.ParseFromArray(s.data(), s.size());
 	char buf[64];
 	msg2.SerializeToArray(buf, sizeof(buf));
 	sink(*buf); // $ ir
 }
 
-// Additional modeled methods, exercised so their summary steps are covered by `steps.ql`.
+// Every modeled method is called below so its summary step is covered by `steps.ql`. Endpoint
+// mistakes and rows that fail to bind show up as missing lines in `steps.expected`.
 void test_step_coverage() {
 	Person msg;
 	std::string data = std::string(source());
+	absl::string_view sv = data;
+	absl::Cord cord;
 
-	msg.MergeFromString(data);
-	msg.ParsePartialFromString(data);
+	msg.ParseFromString(sv);
+	msg.ParseFromString(cord);
+	msg.ParsePartialFromString(sv);
+	msg.ParsePartialFromString(cord);
+	msg.MergeFromString(sv);
+	msg.MergeFromString(cord);
+	msg.MergePartialFromString(sv);
+	msg.MergePartialFromString(cord);
+
+	msg.ParsePartialFromArray(data.data(), data.size());
+
+	msg.ParseFromCord(cord);
+	msg.ParsePartialFromCord(cord);
+	msg.MergeFromCord(cord);
+	msg.MergePartialFromCord(cord);
 
 	std::istream in;
 	msg.ParseFromIstream(&in);
+	msg.ParsePartialFromIstream(&in);
+
+	google::protobuf::io::ZeroCopyInputStream zin;
+	msg.ParseFromZeroCopyStream(&zin);
+	msg.ParsePartialFromZeroCopyStream(&zin);
+	msg.ParseFromBoundedZeroCopyStream(&zin, 1);
+	msg.ParsePartialFromBoundedZeroCopyStream(&zin, 1);
+	msg.MergeFromBoundedZeroCopyStream(&zin, 1);
+	msg.MergePartialFromBoundedZeroCopyStream(&zin, 1);
+
+	google::protobuf::io::CodedInputStream cin;
+	msg.ParseFromCodedStream(&cin);
+	msg.ParsePartialFromCodedStream(&cin);
+	msg.MergeFromCodedStream(&cin);
+	msg.MergePartialFromCodedStream(&cin);
 
 	std::string out;
 	msg.SerializeToString(&out);
 	msg.SerializePartialToString(&out);
 	msg.AppendToString(&out);
+	msg.AppendPartialToString(&out);
+
+	char buf[64];
+	msg.SerializePartialToArray(buf, sizeof(buf));
+
+	absl::Cord cordout;
+	msg.SerializeToCord(&cordout);
+	msg.SerializePartialToCord(&cordout);
+	msg.AppendToCord(&cordout);
+	msg.AppendPartialToCord(&cordout);
 
 	std::ostream os;
 	msg.SerializeToOstream(&os);
+	msg.SerializePartialToOstream(&os);
+
+	google::protobuf::io::ZeroCopyOutputStream zout;
+	msg.SerializeToZeroCopyStream(&zout);
+	msg.SerializePartialToZeroCopyStream(&zout);
+
+	google::protobuf::io::CodedOutputStream cout;
+	msg.SerializeToCodedStream(&cout);
+	msg.SerializePartialToCodedStream(&cout);
+
+	msg.SerializeAsString();
+	msg.SerializePartialAsString();
+	msg.SerializeAsCord();
+	msg.SerializePartialAsCord();
 }

--- a/cpp/ql/test/library-tests/dataflow/external-models/protobuf.cpp
+++ b/cpp/ql/test/library-tests/dataflow/external-models/protobuf.cpp
@@ -1,0 +1,122 @@
+
+// --- stub library headers ---
+
+namespace std {
+	typedef unsigned long size_t;
+
+	template <class T> class allocator {
+	};
+
+	template<class charT> struct char_traits {
+	};
+
+	template<class charT, class traits = char_traits<charT>, class Allocator = allocator<charT> >
+	class basic_string {
+	public:
+		basic_string();
+		basic_string(const charT* s, const Allocator& a = Allocator());
+		const charT* data() const;
+		size_t size() const;
+	};
+
+	typedef basic_string<char> string;
+
+	class istream {
+	public:
+		istream();
+	};
+
+	class ostream {
+	public:
+		ostream();
+	};
+}
+
+namespace google {
+namespace protobuf {
+	// A faithful subset of `MessageLite`; every method below is declared on `MessageLite`
+	// in the real headers (message_lite.h), including the iostream-based ones.
+	class MessageLite {
+	public:
+		bool ParseFromString(const std::string &data);
+		bool MergeFromString(const std::string &data);
+		bool ParsePartialFromString(const std::string &data);
+		bool ParseFromArray(const void *data, int size);
+		bool ParseFromIstream(std::istream *input);
+		bool SerializeToString(std::string *output) const;
+		bool SerializePartialToString(std::string *output) const;
+		bool AppendToString(std::string *output) const;
+		bool SerializeToArray(void *data, int size) const;
+		bool SerializeToOstream(std::ostream *output) const;
+		std::string SerializeAsString() const;
+	};
+
+	class Message : public MessageLite {
+	};
+}
+}
+
+// A generated message type derives from `Message`.
+class Person : public google::protobuf::Message {
+};
+
+// --- test code ---
+
+char *source();
+void sink(char);
+
+// Message taint is observed through `SerializeToArray`, whose scalar output flows cleanly
+// to a sink. The object-typed serialize outputs (String/Ostream/...) and the input-stream
+// parse methods are checked directly by `steps.ql`, which asserts each summary step exists.
+
+// Deserialization: the encoded input taints the message (`this`).
+void test_ParseFromString() {
+	Person msg;
+	std::string data = std::string(source());
+	msg.ParseFromString(data);
+	char buf[64];
+	msg.SerializeToArray(buf, sizeof(buf));
+	sink(*buf); // $ ir
+}
+
+void test_ParseFromArray() {
+	Person msg;
+	std::string data = std::string(source());
+	msg.ParseFromArray(data.data(), data.size());
+	char buf[64];
+	msg.SerializeToArray(buf, sizeof(buf));
+	sink(*buf); // $ ir
+}
+
+// Serialization returning the bytes: the message taints the returned string, observed by
+// parsing it into a second message and serializing that back out.
+void test_SerializeAsString() {
+	Person msg;
+	std::string data = std::string(source());
+	msg.ParseFromString(data);
+	Person msg2;
+	msg2.ParseFromString(msg.SerializeAsString());
+	char buf[64];
+	msg2.SerializeToArray(buf, sizeof(buf));
+	sink(*buf); // $ ir
+}
+
+// Additional modeled methods, exercised so their summary steps are covered by `steps.ql`.
+void test_step_coverage() {
+	Person msg;
+	std::string data = std::string(source());
+
+	msg.MergeFromString(data);
+	msg.ParsePartialFromString(data);
+
+	std::istream in;
+	msg.ParseFromIstream(&in);
+
+	std::string out;
+	msg.SerializeToString(&out);
+	msg.SerializePartialToString(&out);
+	msg.AppendToString(&out);
+
+	std::ostream os;
+	msg.SerializeToOstream(&os);
+}

--- a/cpp/ql/test/library-tests/dataflow/external-models/protobuf.cpp
+++ b/cpp/ql/test/library-tests/dataflow/external-models/protobuf.cpp
@@ -1,26 +1,9 @@
 
 // --- stub library headers ---
 
+#include "std_string.h"
+
 namespace std {
-	typedef unsigned long size_t;
-
-	template <class T> class allocator {
-	};
-
-	template<class charT> struct char_traits {
-	};
-
-	template<class charT, class traits = char_traits<charT>, class Allocator = allocator<charT> >
-	class basic_string {
-	public:
-		basic_string();
-		basic_string(const charT* s, const Allocator& a = Allocator());
-		const charT* data() const;
-		size_t size() const;
-	};
-
-	typedef basic_string<char> string;
-
 	class istream {
 	public:
 		istream();

--- a/cpp/ql/test/library-tests/dataflow/external-models/sinks.expected
+++ b/cpp/ql/test/library-tests/dataflow/external-models/sinks.expected
@@ -1,5 +1,5 @@
-| asio_streams.cpp:135:29:135:39 | recv_buffer | remote-sink |
-| asio_streams.cpp:145:29:145:39 | send_buffer | remote-sink |
+| asio_streams.cpp:122:29:122:39 | recv_buffer | remote-sink |
+| asio_streams.cpp:132:29:132:39 | send_buffer | remote-sink |
 | test.cpp:12:10:12:10 | 0 | test-sink |
 | test.cpp:14:10:14:10 | x | test-sink |
 | test.cpp:18:10:18:10 | y | test-sink |

--- a/cpp/ql/test/library-tests/dataflow/external-models/sources.expected
+++ b/cpp/ql/test/library-tests/dataflow/external-models/sources.expected
@@ -1,4 +1,4 @@
-| asio_streams.cpp:129:34:129:44 | read_until output argument | remote |
+| asio_streams.cpp:116:34:116:44 | read_until output argument | remote |
 | azure.cpp:253:48:253:60 | call to GetBodyStream | remote |
 | azure.cpp:273:52:273:61 | call to GetHeaders | remote |
 | azure.cpp:277:38:277:44 | call to GetBody | remote |

--- a/cpp/ql/test/library-tests/dataflow/external-models/std_string.h
+++ b/cpp/ql/test/library-tests/dataflow/external-models/std_string.h
@@ -1,0 +1,25 @@
+#ifndef CODEQL_TEST_STD_STRING_H
+#define CODEQL_TEST_STD_STRING_H
+
+namespace std {
+	typedef unsigned long size_t;
+
+	template <class T> class allocator {
+	};
+
+	template<class charT> struct char_traits {
+	};
+
+	template<class charT, class traits = char_traits<charT>, class Allocator = allocator<charT> >
+	class basic_string {
+	public:
+		basic_string();
+		basic_string(const charT* s, const Allocator& a = Allocator());
+		const charT* data() const;
+		size_t size() const;
+	};
+
+	typedef basic_string<char> string;
+}
+
+#endif

--- a/cpp/ql/test/library-tests/dataflow/external-models/steps.expected
+++ b/cpp/ql/test/library-tests/dataflow/external-models/steps.expected
@@ -1,68 +1,68 @@
-| asio_streams.cpp:142:64:142:71 | *send_str | asio_streams.cpp:142:44:142:62 | call to buffer |
-| asio_streams.cpp:161:24:161:27 | *host | asio_streams.cpp:161:16:161:22 | call to resolve |
-| asio_streams.cpp:161:30:161:36 | *service | asio_streams.cpp:161:16:161:22 | call to resolve |
-| asio_streams.cpp:162:24:162:27 | *host | asio_streams.cpp:162:16:162:22 | call to resolve |
-| asio_streams.cpp:162:30:162:36 | *service | asio_streams.cpp:162:16:162:22 | call to resolve |
-| asio_streams.cpp:163:24:163:27 | *host | asio_streams.cpp:163:16:163:22 | call to resolve |
-| asio_streams.cpp:163:30:163:36 | *service | asio_streams.cpp:163:16:163:22 | call to resolve |
-| asio_streams.cpp:164:24:164:27 | *host | asio_streams.cpp:164:16:164:22 | call to resolve |
-| asio_streams.cpp:164:30:164:36 | *service | asio_streams.cpp:164:16:164:22 | call to resolve |
-| asio_streams.cpp:166:24:166:32 | host_view | asio_streams.cpp:166:16:166:22 | call to resolve |
-| asio_streams.cpp:166:35:166:46 | service_view | asio_streams.cpp:166:16:166:22 | call to resolve |
-| asio_streams.cpp:167:24:167:32 | host_view | asio_streams.cpp:167:16:167:22 | call to resolve |
-| asio_streams.cpp:167:35:167:46 | service_view | asio_streams.cpp:167:16:167:22 | call to resolve |
-| asio_streams.cpp:168:24:168:32 | host_view | asio_streams.cpp:168:16:168:22 | call to resolve |
-| asio_streams.cpp:168:35:168:46 | service_view | asio_streams.cpp:168:16:168:22 | call to resolve |
-| asio_streams.cpp:169:24:169:32 | host_view | asio_streams.cpp:169:16:169:22 | call to resolve |
-| asio_streams.cpp:169:35:169:46 | service_view | asio_streams.cpp:169:16:169:22 | call to resolve |
-| asio_streams.cpp:171:34:171:37 | *host | asio_streams.cpp:171:16:171:22 | call to resolve |
-| asio_streams.cpp:171:40:171:46 | *service | asio_streams.cpp:171:16:171:22 | call to resolve |
-| asio_streams.cpp:172:34:172:37 | *host | asio_streams.cpp:172:16:172:22 | call to resolve |
-| asio_streams.cpp:172:40:172:46 | *service | asio_streams.cpp:172:16:172:22 | call to resolve |
-| asio_streams.cpp:173:34:173:37 | *host | asio_streams.cpp:173:16:173:22 | call to resolve |
-| asio_streams.cpp:173:40:173:46 | *service | asio_streams.cpp:173:16:173:22 | call to resolve |
-| asio_streams.cpp:174:34:174:37 | *host | asio_streams.cpp:174:16:174:22 | call to resolve |
-| asio_streams.cpp:174:40:174:46 | *service | asio_streams.cpp:174:16:174:22 | call to resolve |
-| asio_streams.cpp:176:34:176:42 | host_view | asio_streams.cpp:176:16:176:22 | call to resolve |
-| asio_streams.cpp:176:45:176:56 | service_view | asio_streams.cpp:176:16:176:22 | call to resolve |
-| asio_streams.cpp:177:34:177:42 | host_view | asio_streams.cpp:177:16:177:22 | call to resolve |
-| asio_streams.cpp:177:45:177:56 | service_view | asio_streams.cpp:177:16:177:22 | call to resolve |
-| asio_streams.cpp:178:34:178:42 | host_view | asio_streams.cpp:178:16:178:22 | call to resolve |
-| asio_streams.cpp:178:45:178:56 | service_view | asio_streams.cpp:178:16:178:22 | call to resolve |
-| asio_streams.cpp:179:34:179:42 | host_view | asio_streams.cpp:179:16:179:22 | call to resolve |
-| asio_streams.cpp:179:45:179:56 | service_view | asio_streams.cpp:179:16:179:22 | call to resolve |
-| asio_streams.cpp:192:24:192:27 | *host | asio_streams.cpp:192:16:192:22 | call to resolve |
-| asio_streams.cpp:192:30:192:36 | *service | asio_streams.cpp:192:16:192:22 | call to resolve |
-| asio_streams.cpp:193:24:193:27 | *host | asio_streams.cpp:193:16:193:22 | call to resolve |
-| asio_streams.cpp:193:30:193:36 | *service | asio_streams.cpp:193:16:193:22 | call to resolve |
-| asio_streams.cpp:194:24:194:27 | *host | asio_streams.cpp:194:16:194:22 | call to resolve |
-| asio_streams.cpp:194:30:194:36 | *service | asio_streams.cpp:194:16:194:22 | call to resolve |
-| asio_streams.cpp:195:24:195:27 | *host | asio_streams.cpp:195:16:195:22 | call to resolve |
-| asio_streams.cpp:195:30:195:36 | *service | asio_streams.cpp:195:16:195:22 | call to resolve |
-| asio_streams.cpp:197:24:197:32 | host_view | asio_streams.cpp:197:16:197:22 | call to resolve |
-| asio_streams.cpp:197:35:197:46 | service_view | asio_streams.cpp:197:16:197:22 | call to resolve |
-| asio_streams.cpp:198:24:198:32 | host_view | asio_streams.cpp:198:16:198:22 | call to resolve |
-| asio_streams.cpp:198:35:198:46 | service_view | asio_streams.cpp:198:16:198:22 | call to resolve |
-| asio_streams.cpp:199:24:199:32 | host_view | asio_streams.cpp:199:16:199:22 | call to resolve |
-| asio_streams.cpp:199:35:199:46 | service_view | asio_streams.cpp:199:16:199:22 | call to resolve |
-| asio_streams.cpp:200:24:200:32 | host_view | asio_streams.cpp:200:16:200:22 | call to resolve |
-| asio_streams.cpp:200:35:200:46 | service_view | asio_streams.cpp:200:16:200:22 | call to resolve |
-| asio_streams.cpp:202:34:202:37 | *host | asio_streams.cpp:202:16:202:22 | call to resolve |
-| asio_streams.cpp:202:40:202:46 | *service | asio_streams.cpp:202:16:202:22 | call to resolve |
-| asio_streams.cpp:203:34:203:37 | *host | asio_streams.cpp:203:16:203:22 | call to resolve |
-| asio_streams.cpp:203:40:203:46 | *service | asio_streams.cpp:203:16:203:22 | call to resolve |
-| asio_streams.cpp:204:34:204:37 | *host | asio_streams.cpp:204:16:204:22 | call to resolve |
-| asio_streams.cpp:204:40:204:46 | *service | asio_streams.cpp:204:16:204:22 | call to resolve |
-| asio_streams.cpp:205:34:205:37 | *host | asio_streams.cpp:205:16:205:22 | call to resolve |
-| asio_streams.cpp:205:40:205:46 | *service | asio_streams.cpp:205:16:205:22 | call to resolve |
-| asio_streams.cpp:207:34:207:42 | host_view | asio_streams.cpp:207:16:207:22 | call to resolve |
-| asio_streams.cpp:207:45:207:56 | service_view | asio_streams.cpp:207:16:207:22 | call to resolve |
-| asio_streams.cpp:208:34:208:42 | host_view | asio_streams.cpp:208:16:208:22 | call to resolve |
-| asio_streams.cpp:208:45:208:56 | service_view | asio_streams.cpp:208:16:208:22 | call to resolve |
-| asio_streams.cpp:209:34:209:42 | host_view | asio_streams.cpp:209:16:209:22 | call to resolve |
-| asio_streams.cpp:209:45:209:56 | service_view | asio_streams.cpp:209:16:209:22 | call to resolve |
-| asio_streams.cpp:210:34:210:42 | host_view | asio_streams.cpp:210:16:210:22 | call to resolve |
-| asio_streams.cpp:210:45:210:56 | service_view | asio_streams.cpp:210:16:210:22 | call to resolve |
+| asio_streams.cpp:129:64:129:71 | *send_str | asio_streams.cpp:129:44:129:62 | call to buffer |
+| asio_streams.cpp:148:24:148:27 | *host | asio_streams.cpp:148:16:148:22 | call to resolve |
+| asio_streams.cpp:148:30:148:36 | *service | asio_streams.cpp:148:16:148:22 | call to resolve |
+| asio_streams.cpp:149:24:149:27 | *host | asio_streams.cpp:149:16:149:22 | call to resolve |
+| asio_streams.cpp:149:30:149:36 | *service | asio_streams.cpp:149:16:149:22 | call to resolve |
+| asio_streams.cpp:150:24:150:27 | *host | asio_streams.cpp:150:16:150:22 | call to resolve |
+| asio_streams.cpp:150:30:150:36 | *service | asio_streams.cpp:150:16:150:22 | call to resolve |
+| asio_streams.cpp:151:24:151:27 | *host | asio_streams.cpp:151:16:151:22 | call to resolve |
+| asio_streams.cpp:151:30:151:36 | *service | asio_streams.cpp:151:16:151:22 | call to resolve |
+| asio_streams.cpp:153:24:153:32 | host_view | asio_streams.cpp:153:16:153:22 | call to resolve |
+| asio_streams.cpp:153:35:153:46 | service_view | asio_streams.cpp:153:16:153:22 | call to resolve |
+| asio_streams.cpp:154:24:154:32 | host_view | asio_streams.cpp:154:16:154:22 | call to resolve |
+| asio_streams.cpp:154:35:154:46 | service_view | asio_streams.cpp:154:16:154:22 | call to resolve |
+| asio_streams.cpp:155:24:155:32 | host_view | asio_streams.cpp:155:16:155:22 | call to resolve |
+| asio_streams.cpp:155:35:155:46 | service_view | asio_streams.cpp:155:16:155:22 | call to resolve |
+| asio_streams.cpp:156:24:156:32 | host_view | asio_streams.cpp:156:16:156:22 | call to resolve |
+| asio_streams.cpp:156:35:156:46 | service_view | asio_streams.cpp:156:16:156:22 | call to resolve |
+| asio_streams.cpp:158:34:158:37 | *host | asio_streams.cpp:158:16:158:22 | call to resolve |
+| asio_streams.cpp:158:40:158:46 | *service | asio_streams.cpp:158:16:158:22 | call to resolve |
+| asio_streams.cpp:159:34:159:37 | *host | asio_streams.cpp:159:16:159:22 | call to resolve |
+| asio_streams.cpp:159:40:159:46 | *service | asio_streams.cpp:159:16:159:22 | call to resolve |
+| asio_streams.cpp:160:34:160:37 | *host | asio_streams.cpp:160:16:160:22 | call to resolve |
+| asio_streams.cpp:160:40:160:46 | *service | asio_streams.cpp:160:16:160:22 | call to resolve |
+| asio_streams.cpp:161:34:161:37 | *host | asio_streams.cpp:161:16:161:22 | call to resolve |
+| asio_streams.cpp:161:40:161:46 | *service | asio_streams.cpp:161:16:161:22 | call to resolve |
+| asio_streams.cpp:163:34:163:42 | host_view | asio_streams.cpp:163:16:163:22 | call to resolve |
+| asio_streams.cpp:163:45:163:56 | service_view | asio_streams.cpp:163:16:163:22 | call to resolve |
+| asio_streams.cpp:164:34:164:42 | host_view | asio_streams.cpp:164:16:164:22 | call to resolve |
+| asio_streams.cpp:164:45:164:56 | service_view | asio_streams.cpp:164:16:164:22 | call to resolve |
+| asio_streams.cpp:165:34:165:42 | host_view | asio_streams.cpp:165:16:165:22 | call to resolve |
+| asio_streams.cpp:165:45:165:56 | service_view | asio_streams.cpp:165:16:165:22 | call to resolve |
+| asio_streams.cpp:166:34:166:42 | host_view | asio_streams.cpp:166:16:166:22 | call to resolve |
+| asio_streams.cpp:166:45:166:56 | service_view | asio_streams.cpp:166:16:166:22 | call to resolve |
+| asio_streams.cpp:179:24:179:27 | *host | asio_streams.cpp:179:16:179:22 | call to resolve |
+| asio_streams.cpp:179:30:179:36 | *service | asio_streams.cpp:179:16:179:22 | call to resolve |
+| asio_streams.cpp:180:24:180:27 | *host | asio_streams.cpp:180:16:180:22 | call to resolve |
+| asio_streams.cpp:180:30:180:36 | *service | asio_streams.cpp:180:16:180:22 | call to resolve |
+| asio_streams.cpp:181:24:181:27 | *host | asio_streams.cpp:181:16:181:22 | call to resolve |
+| asio_streams.cpp:181:30:181:36 | *service | asio_streams.cpp:181:16:181:22 | call to resolve |
+| asio_streams.cpp:182:24:182:27 | *host | asio_streams.cpp:182:16:182:22 | call to resolve |
+| asio_streams.cpp:182:30:182:36 | *service | asio_streams.cpp:182:16:182:22 | call to resolve |
+| asio_streams.cpp:184:24:184:32 | host_view | asio_streams.cpp:184:16:184:22 | call to resolve |
+| asio_streams.cpp:184:35:184:46 | service_view | asio_streams.cpp:184:16:184:22 | call to resolve |
+| asio_streams.cpp:185:24:185:32 | host_view | asio_streams.cpp:185:16:185:22 | call to resolve |
+| asio_streams.cpp:185:35:185:46 | service_view | asio_streams.cpp:185:16:185:22 | call to resolve |
+| asio_streams.cpp:186:24:186:32 | host_view | asio_streams.cpp:186:16:186:22 | call to resolve |
+| asio_streams.cpp:186:35:186:46 | service_view | asio_streams.cpp:186:16:186:22 | call to resolve |
+| asio_streams.cpp:187:24:187:32 | host_view | asio_streams.cpp:187:16:187:22 | call to resolve |
+| asio_streams.cpp:187:35:187:46 | service_view | asio_streams.cpp:187:16:187:22 | call to resolve |
+| asio_streams.cpp:189:34:189:37 | *host | asio_streams.cpp:189:16:189:22 | call to resolve |
+| asio_streams.cpp:189:40:189:46 | *service | asio_streams.cpp:189:16:189:22 | call to resolve |
+| asio_streams.cpp:190:34:190:37 | *host | asio_streams.cpp:190:16:190:22 | call to resolve |
+| asio_streams.cpp:190:40:190:46 | *service | asio_streams.cpp:190:16:190:22 | call to resolve |
+| asio_streams.cpp:191:34:191:37 | *host | asio_streams.cpp:191:16:191:22 | call to resolve |
+| asio_streams.cpp:191:40:191:46 | *service | asio_streams.cpp:191:16:191:22 | call to resolve |
+| asio_streams.cpp:192:34:192:37 | *host | asio_streams.cpp:192:16:192:22 | call to resolve |
+| asio_streams.cpp:192:40:192:46 | *service | asio_streams.cpp:192:16:192:22 | call to resolve |
+| asio_streams.cpp:194:34:194:42 | host_view | asio_streams.cpp:194:16:194:22 | call to resolve |
+| asio_streams.cpp:194:45:194:56 | service_view | asio_streams.cpp:194:16:194:22 | call to resolve |
+| asio_streams.cpp:195:34:195:42 | host_view | asio_streams.cpp:195:16:195:22 | call to resolve |
+| asio_streams.cpp:195:45:195:56 | service_view | asio_streams.cpp:195:16:195:22 | call to resolve |
+| asio_streams.cpp:196:34:196:42 | host_view | asio_streams.cpp:196:16:196:22 | call to resolve |
+| asio_streams.cpp:196:45:196:56 | service_view | asio_streams.cpp:196:16:196:22 | call to resolve |
+| asio_streams.cpp:197:34:197:42 | host_view | asio_streams.cpp:197:16:197:22 | call to resolve |
+| asio_streams.cpp:197:45:197:56 | service_view | asio_streams.cpp:197:16:197:22 | call to resolve |
 | azure.cpp:252:79:252:98 | call to string | azure.cpp:252:62:252:99 | call to Url |
 | azure.cpp:257:5:257:8 | *resp | azure.cpp:257:16:257:21 | Read output argument |
 | azure.cpp:262:5:262:8 | *resp | azure.cpp:262:23:262:28 | ReadToCount output argument |
@@ -82,58 +82,58 @@
 | bdlbb.cpp:92:48:92:51 | *call to data | bdlbb.cpp:92:37:92:40 | copy output argument |
 | bdlbb.cpp:94:46:94:48 | *src | bdlbb.cpp:94:37:94:40 | copy output argument |
 | bdlbb.cpp:96:42:96:44 | *dst | bdlbb.cpp:96:37:96:39 | copy output argument |
-| protobuf.cpp:135:22:135:25 | data | protobuf.cpp:135:2:135:4 | ParseFromString output argument |
-| protobuf.cpp:142:22:142:25 | *data | protobuf.cpp:142:2:142:4 | ParseFromString output argument |
-| protobuf.cpp:149:29:149:32 | data | protobuf.cpp:149:2:149:4 | ParsePartialFromString output argument |
-| protobuf.cpp:156:29:156:32 | *data | protobuf.cpp:156:2:156:4 | ParsePartialFromString output argument |
-| protobuf.cpp:163:22:163:25 | data | protobuf.cpp:163:2:163:4 | MergeFromString output argument |
-| protobuf.cpp:170:22:170:25 | *data | protobuf.cpp:170:2:170:4 | MergeFromString output argument |
-| protobuf.cpp:177:29:177:32 | data | protobuf.cpp:177:2:177:4 | MergePartialFromString output argument |
-| protobuf.cpp:184:29:184:32 | *data | protobuf.cpp:184:2:184:4 | MergePartialFromString output argument |
-| protobuf.cpp:191:21:191:31 | *call to data | protobuf.cpp:191:2:191:4 | ParseFromArray output argument |
-| protobuf.cpp:198:28:198:38 | *call to data | protobuf.cpp:198:2:198:4 | ParsePartialFromArray output argument |
-| protobuf.cpp:205:20:205:23 | *data | protobuf.cpp:205:2:205:4 | ParseFromCord output argument |
-| protobuf.cpp:212:27:212:30 | *data | protobuf.cpp:212:2:212:4 | ParsePartialFromCord output argument |
-| protobuf.cpp:219:20:219:23 | *data | protobuf.cpp:219:2:219:4 | MergeFromCord output argument |
-| protobuf.cpp:226:27:226:30 | *data | protobuf.cpp:226:2:226:4 | MergePartialFromCord output argument |
-| protobuf.cpp:233:23:233:25 | *& ... | protobuf.cpp:233:2:233:4 | ParseFromIstream output argument |
-| protobuf.cpp:240:30:240:32 | *& ... | protobuf.cpp:240:2:240:4 | ParsePartialFromIstream output argument |
-| protobuf.cpp:247:30:247:32 | *& ... | protobuf.cpp:247:2:247:4 | ParseFromZeroCopyStream output argument |
-| protobuf.cpp:254:37:254:39 | *& ... | protobuf.cpp:254:2:254:4 | ParsePartialFromZeroCopyStream output argument |
-| protobuf.cpp:261:37:261:39 | *& ... | protobuf.cpp:261:2:261:4 | ParseFromBoundedZeroCopyStream output argument |
-| protobuf.cpp:268:44:268:46 | *& ... | protobuf.cpp:268:2:268:4 | ParsePartialFromBoundedZeroCopyStream output argument |
-| protobuf.cpp:275:37:275:39 | *& ... | protobuf.cpp:275:2:275:4 | MergeFromBoundedZeroCopyStream output argument |
-| protobuf.cpp:282:44:282:46 | *& ... | protobuf.cpp:282:2:282:4 | MergePartialFromBoundedZeroCopyStream output argument |
-| protobuf.cpp:289:27:289:29 | *& ... | protobuf.cpp:289:2:289:4 | ParseFromCodedStream output argument |
-| protobuf.cpp:296:34:296:36 | *& ... | protobuf.cpp:296:2:296:4 | ParsePartialFromCodedStream output argument |
-| protobuf.cpp:303:27:303:29 | *& ... | protobuf.cpp:303:2:303:4 | MergeFromCodedStream output argument |
-| protobuf.cpp:310:34:310:36 | *& ... | protobuf.cpp:310:2:310:4 | MergePartialFromCodedStream output argument |
-| protobuf.cpp:317:22:317:25 | *data | protobuf.cpp:317:2:317:4 | ParseFromString output argument |
-| protobuf.cpp:326:2:326:4 | *msg | protobuf.cpp:326:24:326:27 | SerializeToString output argument |
-| protobuf.cpp:333:2:333:4 | *msg | protobuf.cpp:333:31:333:34 | SerializePartialToString output argument |
-| protobuf.cpp:340:2:340:4 | *msg | protobuf.cpp:340:21:340:24 | AppendToString output argument |
-| protobuf.cpp:347:2:347:4 | *msg | protobuf.cpp:347:28:347:31 | AppendPartialToString output argument |
-| protobuf.cpp:354:2:354:4 | *msg | protobuf.cpp:354:24:354:27 | SerializeToString output argument |
-| protobuf.cpp:361:2:361:4 | *msg | protobuf.cpp:361:31:361:34 | SerializePartialToString output argument |
-| protobuf.cpp:368:2:368:4 | *msg | protobuf.cpp:368:21:368:24 | AppendToString output argument |
-| protobuf.cpp:375:2:375:4 | *msg | protobuf.cpp:375:28:375:31 | AppendPartialToString output argument |
-| protobuf.cpp:382:2:382:4 | *msg | protobuf.cpp:382:23:382:25 | SerializeToArray output argument |
-| protobuf.cpp:389:2:389:4 | *msg | protobuf.cpp:389:30:389:32 | SerializePartialToArray output argument |
-| protobuf.cpp:396:2:396:4 | *msg | protobuf.cpp:396:22:396:25 | SerializeToCord output argument |
-| protobuf.cpp:403:2:403:4 | *msg | protobuf.cpp:403:29:403:32 | SerializePartialToCord output argument |
-| protobuf.cpp:410:2:410:4 | *msg | protobuf.cpp:410:19:410:22 | AppendToCord output argument |
-| protobuf.cpp:417:2:417:4 | *msg | protobuf.cpp:417:26:417:29 | AppendPartialToCord output argument |
-| protobuf.cpp:424:2:424:4 | *msg | protobuf.cpp:424:25:424:28 | SerializeToOstream output argument |
-| protobuf.cpp:431:2:431:4 | *msg | protobuf.cpp:431:32:431:35 | SerializePartialToOstream output argument |
-| protobuf.cpp:438:2:438:4 | *msg | protobuf.cpp:438:32:438:35 | SerializeToZeroCopyStream output argument |
-| protobuf.cpp:445:2:445:4 | *msg | protobuf.cpp:445:39:445:42 | SerializePartialToZeroCopyStream output argument |
-| protobuf.cpp:452:2:452:4 | *msg | protobuf.cpp:452:29:452:32 | SerializeToCodedStream output argument |
-| protobuf.cpp:459:2:459:4 | *msg | protobuf.cpp:459:36:459:39 | SerializePartialToCodedStream output argument |
-| protobuf.cpp:467:7:467:9 | *msg | protobuf.cpp:467:11:467:27 | call to SerializeAsString |
-| protobuf.cpp:472:7:472:9 | *msg | protobuf.cpp:472:11:472:34 | call to SerializePartialAsString |
-| protobuf.cpp:477:7:477:9 | *msg | protobuf.cpp:477:11:477:25 | call to SerializeAsCord |
-| protobuf.cpp:482:7:482:9 | *msg | protobuf.cpp:482:11:482:32 | call to SerializePartialAsCord |
-| protobuf.cpp:487:7:487:9 | *msg | protobuf.cpp:487:11:487:27 | call to SerializeAsString |
+| protobuf.cpp:118:22:118:25 | data | protobuf.cpp:118:2:118:4 | ParseFromString output argument |
+| protobuf.cpp:125:22:125:25 | *data | protobuf.cpp:125:2:125:4 | ParseFromString output argument |
+| protobuf.cpp:132:29:132:32 | data | protobuf.cpp:132:2:132:4 | ParsePartialFromString output argument |
+| protobuf.cpp:139:29:139:32 | *data | protobuf.cpp:139:2:139:4 | ParsePartialFromString output argument |
+| protobuf.cpp:146:22:146:25 | data | protobuf.cpp:146:2:146:4 | MergeFromString output argument |
+| protobuf.cpp:153:22:153:25 | *data | protobuf.cpp:153:2:153:4 | MergeFromString output argument |
+| protobuf.cpp:160:29:160:32 | data | protobuf.cpp:160:2:160:4 | MergePartialFromString output argument |
+| protobuf.cpp:167:29:167:32 | *data | protobuf.cpp:167:2:167:4 | MergePartialFromString output argument |
+| protobuf.cpp:174:21:174:31 | *call to data | protobuf.cpp:174:2:174:4 | ParseFromArray output argument |
+| protobuf.cpp:181:28:181:38 | *call to data | protobuf.cpp:181:2:181:4 | ParsePartialFromArray output argument |
+| protobuf.cpp:188:20:188:23 | *data | protobuf.cpp:188:2:188:4 | ParseFromCord output argument |
+| protobuf.cpp:195:27:195:30 | *data | protobuf.cpp:195:2:195:4 | ParsePartialFromCord output argument |
+| protobuf.cpp:202:20:202:23 | *data | protobuf.cpp:202:2:202:4 | MergeFromCord output argument |
+| protobuf.cpp:209:27:209:30 | *data | protobuf.cpp:209:2:209:4 | MergePartialFromCord output argument |
+| protobuf.cpp:216:23:216:25 | *& ... | protobuf.cpp:216:2:216:4 | ParseFromIstream output argument |
+| protobuf.cpp:223:30:223:32 | *& ... | protobuf.cpp:223:2:223:4 | ParsePartialFromIstream output argument |
+| protobuf.cpp:230:30:230:32 | *& ... | protobuf.cpp:230:2:230:4 | ParseFromZeroCopyStream output argument |
+| protobuf.cpp:237:37:237:39 | *& ... | protobuf.cpp:237:2:237:4 | ParsePartialFromZeroCopyStream output argument |
+| protobuf.cpp:244:37:244:39 | *& ... | protobuf.cpp:244:2:244:4 | ParseFromBoundedZeroCopyStream output argument |
+| protobuf.cpp:251:44:251:46 | *& ... | protobuf.cpp:251:2:251:4 | ParsePartialFromBoundedZeroCopyStream output argument |
+| protobuf.cpp:258:37:258:39 | *& ... | protobuf.cpp:258:2:258:4 | MergeFromBoundedZeroCopyStream output argument |
+| protobuf.cpp:265:44:265:46 | *& ... | protobuf.cpp:265:2:265:4 | MergePartialFromBoundedZeroCopyStream output argument |
+| protobuf.cpp:272:27:272:29 | *& ... | protobuf.cpp:272:2:272:4 | ParseFromCodedStream output argument |
+| protobuf.cpp:279:34:279:36 | *& ... | protobuf.cpp:279:2:279:4 | ParsePartialFromCodedStream output argument |
+| protobuf.cpp:286:27:286:29 | *& ... | protobuf.cpp:286:2:286:4 | MergeFromCodedStream output argument |
+| protobuf.cpp:293:34:293:36 | *& ... | protobuf.cpp:293:2:293:4 | MergePartialFromCodedStream output argument |
+| protobuf.cpp:300:22:300:25 | *data | protobuf.cpp:300:2:300:4 | ParseFromString output argument |
+| protobuf.cpp:309:2:309:4 | *msg | protobuf.cpp:309:24:309:27 | SerializeToString output argument |
+| protobuf.cpp:316:2:316:4 | *msg | protobuf.cpp:316:31:316:34 | SerializePartialToString output argument |
+| protobuf.cpp:323:2:323:4 | *msg | protobuf.cpp:323:21:323:24 | AppendToString output argument |
+| protobuf.cpp:330:2:330:4 | *msg | protobuf.cpp:330:28:330:31 | AppendPartialToString output argument |
+| protobuf.cpp:337:2:337:4 | *msg | protobuf.cpp:337:24:337:27 | SerializeToString output argument |
+| protobuf.cpp:344:2:344:4 | *msg | protobuf.cpp:344:31:344:34 | SerializePartialToString output argument |
+| protobuf.cpp:351:2:351:4 | *msg | protobuf.cpp:351:21:351:24 | AppendToString output argument |
+| protobuf.cpp:358:2:358:4 | *msg | protobuf.cpp:358:28:358:31 | AppendPartialToString output argument |
+| protobuf.cpp:365:2:365:4 | *msg | protobuf.cpp:365:23:365:25 | SerializeToArray output argument |
+| protobuf.cpp:372:2:372:4 | *msg | protobuf.cpp:372:30:372:32 | SerializePartialToArray output argument |
+| protobuf.cpp:379:2:379:4 | *msg | protobuf.cpp:379:22:379:25 | SerializeToCord output argument |
+| protobuf.cpp:386:2:386:4 | *msg | protobuf.cpp:386:29:386:32 | SerializePartialToCord output argument |
+| protobuf.cpp:393:2:393:4 | *msg | protobuf.cpp:393:19:393:22 | AppendToCord output argument |
+| protobuf.cpp:400:2:400:4 | *msg | protobuf.cpp:400:26:400:29 | AppendPartialToCord output argument |
+| protobuf.cpp:407:2:407:4 | *msg | protobuf.cpp:407:25:407:28 | SerializeToOstream output argument |
+| protobuf.cpp:414:2:414:4 | *msg | protobuf.cpp:414:32:414:35 | SerializePartialToOstream output argument |
+| protobuf.cpp:421:2:421:4 | *msg | protobuf.cpp:421:32:421:35 | SerializeToZeroCopyStream output argument |
+| protobuf.cpp:428:2:428:4 | *msg | protobuf.cpp:428:39:428:42 | SerializePartialToZeroCopyStream output argument |
+| protobuf.cpp:435:2:435:4 | *msg | protobuf.cpp:435:29:435:32 | SerializeToCodedStream output argument |
+| protobuf.cpp:442:2:442:4 | *msg | protobuf.cpp:442:36:442:39 | SerializePartialToCodedStream output argument |
+| protobuf.cpp:450:7:450:9 | *msg | protobuf.cpp:450:11:450:27 | call to SerializeAsString |
+| protobuf.cpp:455:7:455:9 | *msg | protobuf.cpp:455:11:455:34 | call to SerializePartialAsString |
+| protobuf.cpp:460:7:460:9 | *msg | protobuf.cpp:460:11:460:25 | call to SerializeAsCord |
+| protobuf.cpp:465:7:465:9 | *msg | protobuf.cpp:465:11:465:32 | call to SerializePartialAsCord |
+| protobuf.cpp:470:7:470:9 | *msg | protobuf.cpp:470:11:470:27 | call to SerializeAsString |
 | test.cpp:17:24:17:24 | x | test.cpp:17:10:17:22 | call to ymlStepManual |
 | test.cpp:21:27:21:27 | x | test.cpp:21:10:21:25 | call to ymlStepGenerated |
 | test.cpp:25:35:25:35 | x | test.cpp:25:11:25:33 | call to ymlStepManual_with_body |

--- a/cpp/ql/test/library-tests/dataflow/external-models/steps.expected
+++ b/cpp/ql/test/library-tests/dataflow/external-models/steps.expected
@@ -82,56 +82,58 @@
 | bdlbb.cpp:92:48:92:51 | *call to data | bdlbb.cpp:92:37:92:40 | copy output argument |
 | bdlbb.cpp:94:46:94:48 | *src | bdlbb.cpp:94:37:94:40 | copy output argument |
 | bdlbb.cpp:96:42:96:44 | *dst | bdlbb.cpp:96:37:96:39 | copy output argument |
-| protobuf.cpp:141:21:141:31 | *call to data | protobuf.cpp:141:2:141:4 | ParseFromArray output argument |
-| protobuf.cpp:143:2:143:4 | *msg | protobuf.cpp:143:23:143:25 | SerializeToArray output argument |
-| protobuf.cpp:152:21:152:31 | *call to data | protobuf.cpp:152:2:152:4 | ParseFromArray output argument |
-| protobuf.cpp:153:18:153:20 | *msg | protobuf.cpp:153:22:153:38 | call to SerializeAsString |
-| protobuf.cpp:155:22:155:29 | *call to data | protobuf.cpp:155:2:155:5 | ParseFromArray output argument |
-| protobuf.cpp:157:2:157:5 | *msg2 | protobuf.cpp:157:24:157:26 | SerializeToArray output argument |
-| protobuf.cpp:169:22:169:23 | sv | protobuf.cpp:169:2:169:4 | ParseFromString output argument |
-| protobuf.cpp:170:22:170:25 | *cord | protobuf.cpp:170:2:170:4 | ParseFromString output argument |
-| protobuf.cpp:171:29:171:30 | sv | protobuf.cpp:171:2:171:4 | ParsePartialFromString output argument |
-| protobuf.cpp:172:29:172:32 | *cord | protobuf.cpp:172:2:172:4 | ParsePartialFromString output argument |
-| protobuf.cpp:173:22:173:23 | sv | protobuf.cpp:173:2:173:4 | MergeFromString output argument |
-| protobuf.cpp:174:22:174:25 | *cord | protobuf.cpp:174:2:174:4 | MergeFromString output argument |
-| protobuf.cpp:175:29:175:30 | sv | protobuf.cpp:175:2:175:4 | MergePartialFromString output argument |
-| protobuf.cpp:176:29:176:32 | *cord | protobuf.cpp:176:2:176:4 | MergePartialFromString output argument |
-| protobuf.cpp:178:28:178:38 | *call to data | protobuf.cpp:178:2:178:4 | ParsePartialFromArray output argument |
-| protobuf.cpp:180:20:180:23 | *cord | protobuf.cpp:180:2:180:4 | ParseFromCord output argument |
-| protobuf.cpp:181:27:181:30 | *cord | protobuf.cpp:181:2:181:4 | ParsePartialFromCord output argument |
-| protobuf.cpp:182:20:182:23 | *cord | protobuf.cpp:182:2:182:4 | MergeFromCord output argument |
-| protobuf.cpp:183:27:183:30 | *cord | protobuf.cpp:183:2:183:4 | MergePartialFromCord output argument |
-| protobuf.cpp:186:23:186:25 | *& ... | protobuf.cpp:186:2:186:4 | ParseFromIstream output argument |
-| protobuf.cpp:187:30:187:32 | *& ... | protobuf.cpp:187:2:187:4 | ParsePartialFromIstream output argument |
-| protobuf.cpp:190:30:190:33 | *& ... | protobuf.cpp:190:2:190:4 | ParseFromZeroCopyStream output argument |
-| protobuf.cpp:191:37:191:40 | *& ... | protobuf.cpp:191:2:191:4 | ParsePartialFromZeroCopyStream output argument |
-| protobuf.cpp:192:37:192:40 | *& ... | protobuf.cpp:192:2:192:4 | ParseFromBoundedZeroCopyStream output argument |
-| protobuf.cpp:193:44:193:47 | *& ... | protobuf.cpp:193:2:193:4 | ParsePartialFromBoundedZeroCopyStream output argument |
-| protobuf.cpp:194:37:194:40 | *& ... | protobuf.cpp:194:2:194:4 | MergeFromBoundedZeroCopyStream output argument |
-| protobuf.cpp:195:44:195:47 | *& ... | protobuf.cpp:195:2:195:4 | MergePartialFromBoundedZeroCopyStream output argument |
-| protobuf.cpp:198:27:198:30 | *& ... | protobuf.cpp:198:2:198:4 | ParseFromCodedStream output argument |
-| protobuf.cpp:199:34:199:37 | *& ... | protobuf.cpp:199:2:199:4 | ParsePartialFromCodedStream output argument |
-| protobuf.cpp:200:27:200:30 | *& ... | protobuf.cpp:200:2:200:4 | MergeFromCodedStream output argument |
-| protobuf.cpp:201:34:201:37 | *& ... | protobuf.cpp:201:2:201:4 | MergePartialFromCodedStream output argument |
-| protobuf.cpp:204:2:204:4 | *msg | protobuf.cpp:204:24:204:27 | SerializeToString output argument |
-| protobuf.cpp:205:2:205:4 | *msg | protobuf.cpp:205:31:205:34 | SerializePartialToString output argument |
-| protobuf.cpp:206:2:206:4 | *msg | protobuf.cpp:206:21:206:24 | AppendToString output argument |
-| protobuf.cpp:207:2:207:4 | *msg | protobuf.cpp:207:28:207:31 | AppendPartialToString output argument |
-| protobuf.cpp:210:2:210:4 | *msg | protobuf.cpp:210:30:210:32 | SerializePartialToArray output argument |
-| protobuf.cpp:213:2:213:4 | *msg | protobuf.cpp:213:22:213:29 | SerializeToCord output argument |
-| protobuf.cpp:214:2:214:4 | *msg | protobuf.cpp:214:29:214:36 | SerializePartialToCord output argument |
-| protobuf.cpp:215:2:215:4 | *msg | protobuf.cpp:215:19:215:26 | AppendToCord output argument |
-| protobuf.cpp:216:2:216:4 | *msg | protobuf.cpp:216:26:216:33 | AppendPartialToCord output argument |
-| protobuf.cpp:219:2:219:4 | *msg | protobuf.cpp:219:25:219:27 | SerializeToOstream output argument |
-| protobuf.cpp:220:2:220:4 | *msg | protobuf.cpp:220:32:220:34 | SerializePartialToOstream output argument |
-| protobuf.cpp:223:2:223:4 | *msg | protobuf.cpp:223:32:223:36 | SerializeToZeroCopyStream output argument |
-| protobuf.cpp:224:2:224:4 | *msg | protobuf.cpp:224:39:224:43 | SerializePartialToZeroCopyStream output argument |
-| protobuf.cpp:227:2:227:4 | *msg | protobuf.cpp:227:29:227:33 | SerializeToCodedStream output argument |
-| protobuf.cpp:228:2:228:4 | *msg | protobuf.cpp:228:36:228:40 | SerializePartialToCodedStream output argument |
-| protobuf.cpp:230:2:230:4 | *msg | protobuf.cpp:230:6:230:22 | call to SerializeAsString |
-| protobuf.cpp:231:2:231:4 | *msg | protobuf.cpp:231:6:231:29 | call to SerializePartialAsString |
-| protobuf.cpp:232:2:232:4 | *msg | protobuf.cpp:232:6:232:20 | call to SerializeAsCord |
-| protobuf.cpp:233:2:233:4 | *msg | protobuf.cpp:233:6:233:27 | call to SerializePartialAsCord |
+| protobuf.cpp:135:22:135:25 | data | protobuf.cpp:135:2:135:4 | ParseFromString output argument |
+| protobuf.cpp:142:22:142:25 | *data | protobuf.cpp:142:2:142:4 | ParseFromString output argument |
+| protobuf.cpp:149:29:149:32 | data | protobuf.cpp:149:2:149:4 | ParsePartialFromString output argument |
+| protobuf.cpp:156:29:156:32 | *data | protobuf.cpp:156:2:156:4 | ParsePartialFromString output argument |
+| protobuf.cpp:163:22:163:25 | data | protobuf.cpp:163:2:163:4 | MergeFromString output argument |
+| protobuf.cpp:170:22:170:25 | *data | protobuf.cpp:170:2:170:4 | MergeFromString output argument |
+| protobuf.cpp:177:29:177:32 | data | protobuf.cpp:177:2:177:4 | MergePartialFromString output argument |
+| protobuf.cpp:184:29:184:32 | *data | protobuf.cpp:184:2:184:4 | MergePartialFromString output argument |
+| protobuf.cpp:191:21:191:31 | *call to data | protobuf.cpp:191:2:191:4 | ParseFromArray output argument |
+| protobuf.cpp:198:28:198:38 | *call to data | protobuf.cpp:198:2:198:4 | ParsePartialFromArray output argument |
+| protobuf.cpp:205:20:205:23 | *data | protobuf.cpp:205:2:205:4 | ParseFromCord output argument |
+| protobuf.cpp:212:27:212:30 | *data | protobuf.cpp:212:2:212:4 | ParsePartialFromCord output argument |
+| protobuf.cpp:219:20:219:23 | *data | protobuf.cpp:219:2:219:4 | MergeFromCord output argument |
+| protobuf.cpp:226:27:226:30 | *data | protobuf.cpp:226:2:226:4 | MergePartialFromCord output argument |
+| protobuf.cpp:233:23:233:25 | *& ... | protobuf.cpp:233:2:233:4 | ParseFromIstream output argument |
+| protobuf.cpp:240:30:240:32 | *& ... | protobuf.cpp:240:2:240:4 | ParsePartialFromIstream output argument |
+| protobuf.cpp:247:30:247:32 | *& ... | protobuf.cpp:247:2:247:4 | ParseFromZeroCopyStream output argument |
+| protobuf.cpp:254:37:254:39 | *& ... | protobuf.cpp:254:2:254:4 | ParsePartialFromZeroCopyStream output argument |
+| protobuf.cpp:261:37:261:39 | *& ... | protobuf.cpp:261:2:261:4 | ParseFromBoundedZeroCopyStream output argument |
+| protobuf.cpp:268:44:268:46 | *& ... | protobuf.cpp:268:2:268:4 | ParsePartialFromBoundedZeroCopyStream output argument |
+| protobuf.cpp:275:37:275:39 | *& ... | protobuf.cpp:275:2:275:4 | MergeFromBoundedZeroCopyStream output argument |
+| protobuf.cpp:282:44:282:46 | *& ... | protobuf.cpp:282:2:282:4 | MergePartialFromBoundedZeroCopyStream output argument |
+| protobuf.cpp:289:27:289:29 | *& ... | protobuf.cpp:289:2:289:4 | ParseFromCodedStream output argument |
+| protobuf.cpp:296:34:296:36 | *& ... | protobuf.cpp:296:2:296:4 | ParsePartialFromCodedStream output argument |
+| protobuf.cpp:303:27:303:29 | *& ... | protobuf.cpp:303:2:303:4 | MergeFromCodedStream output argument |
+| protobuf.cpp:310:34:310:36 | *& ... | protobuf.cpp:310:2:310:4 | MergePartialFromCodedStream output argument |
+| protobuf.cpp:317:22:317:25 | *data | protobuf.cpp:317:2:317:4 | ParseFromString output argument |
+| protobuf.cpp:326:2:326:4 | *msg | protobuf.cpp:326:24:326:27 | SerializeToString output argument |
+| protobuf.cpp:333:2:333:4 | *msg | protobuf.cpp:333:31:333:34 | SerializePartialToString output argument |
+| protobuf.cpp:340:2:340:4 | *msg | protobuf.cpp:340:21:340:24 | AppendToString output argument |
+| protobuf.cpp:347:2:347:4 | *msg | protobuf.cpp:347:28:347:31 | AppendPartialToString output argument |
+| protobuf.cpp:354:2:354:4 | *msg | protobuf.cpp:354:24:354:27 | SerializeToString output argument |
+| protobuf.cpp:361:2:361:4 | *msg | protobuf.cpp:361:31:361:34 | SerializePartialToString output argument |
+| protobuf.cpp:368:2:368:4 | *msg | protobuf.cpp:368:21:368:24 | AppendToString output argument |
+| protobuf.cpp:375:2:375:4 | *msg | protobuf.cpp:375:28:375:31 | AppendPartialToString output argument |
+| protobuf.cpp:382:2:382:4 | *msg | protobuf.cpp:382:23:382:25 | SerializeToArray output argument |
+| protobuf.cpp:389:2:389:4 | *msg | protobuf.cpp:389:30:389:32 | SerializePartialToArray output argument |
+| protobuf.cpp:396:2:396:4 | *msg | protobuf.cpp:396:22:396:25 | SerializeToCord output argument |
+| protobuf.cpp:403:2:403:4 | *msg | protobuf.cpp:403:29:403:32 | SerializePartialToCord output argument |
+| protobuf.cpp:410:2:410:4 | *msg | protobuf.cpp:410:19:410:22 | AppendToCord output argument |
+| protobuf.cpp:417:2:417:4 | *msg | protobuf.cpp:417:26:417:29 | AppendPartialToCord output argument |
+| protobuf.cpp:424:2:424:4 | *msg | protobuf.cpp:424:25:424:28 | SerializeToOstream output argument |
+| protobuf.cpp:431:2:431:4 | *msg | protobuf.cpp:431:32:431:35 | SerializePartialToOstream output argument |
+| protobuf.cpp:438:2:438:4 | *msg | protobuf.cpp:438:32:438:35 | SerializeToZeroCopyStream output argument |
+| protobuf.cpp:445:2:445:4 | *msg | protobuf.cpp:445:39:445:42 | SerializePartialToZeroCopyStream output argument |
+| protobuf.cpp:452:2:452:4 | *msg | protobuf.cpp:452:29:452:32 | SerializeToCodedStream output argument |
+| protobuf.cpp:459:2:459:4 | *msg | protobuf.cpp:459:36:459:39 | SerializePartialToCodedStream output argument |
+| protobuf.cpp:467:7:467:9 | *msg | protobuf.cpp:467:11:467:27 | call to SerializeAsString |
+| protobuf.cpp:472:7:472:9 | *msg | protobuf.cpp:472:11:472:34 | call to SerializePartialAsString |
+| protobuf.cpp:477:7:477:9 | *msg | protobuf.cpp:477:11:477:25 | call to SerializeAsCord |
+| protobuf.cpp:482:7:482:9 | *msg | protobuf.cpp:482:11:482:32 | call to SerializePartialAsCord |
+| protobuf.cpp:487:7:487:9 | *msg | protobuf.cpp:487:11:487:27 | call to SerializeAsString |
 | test.cpp:17:24:17:24 | x | test.cpp:17:10:17:22 | call to ymlStepManual |
 | test.cpp:21:27:21:27 | x | test.cpp:21:10:21:25 | call to ymlStepGenerated |
 | test.cpp:25:35:25:35 | x | test.cpp:25:11:25:33 | call to ymlStepManual_with_body |

--- a/cpp/ql/test/library-tests/dataflow/external-models/steps.expected
+++ b/cpp/ql/test/library-tests/dataflow/external-models/steps.expected
@@ -82,21 +82,56 @@
 | bdlbb.cpp:92:48:92:51 | *call to data | bdlbb.cpp:92:37:92:40 | copy output argument |
 | bdlbb.cpp:94:46:94:48 | *src | bdlbb.cpp:94:37:94:40 | copy output argument |
 | bdlbb.cpp:96:42:96:44 | *dst | bdlbb.cpp:96:37:96:39 | copy output argument |
-| protobuf.cpp:76:22:76:25 | *data | protobuf.cpp:76:2:76:4 | ParseFromString output argument |
-| protobuf.cpp:78:2:78:4 | *msg | protobuf.cpp:78:23:78:25 | SerializeToArray output argument |
-| protobuf.cpp:85:21:85:31 | *call to data | protobuf.cpp:85:2:85:4 | ParseFromArray output argument |
-| protobuf.cpp:87:2:87:4 | *msg | protobuf.cpp:87:23:87:25 | SerializeToArray output argument |
-| protobuf.cpp:96:22:96:25 | *data | protobuf.cpp:96:2:96:4 | ParseFromString output argument |
-| protobuf.cpp:98:23:98:25 | *msg | protobuf.cpp:98:27:98:43 | call to SerializeAsString |
-| protobuf.cpp:98:23:98:45 | call to SerializeAsString | protobuf.cpp:98:2:98:5 | ParseFromString output argument |
-| protobuf.cpp:100:2:100:5 | *msg2 | protobuf.cpp:100:24:100:26 | SerializeToArray output argument |
-| protobuf.cpp:109:22:109:25 | *data | protobuf.cpp:109:2:109:4 | MergeFromString output argument |
-| protobuf.cpp:110:29:110:32 | *data | protobuf.cpp:110:2:110:4 | ParsePartialFromString output argument |
-| protobuf.cpp:113:23:113:25 | *& ... | protobuf.cpp:113:2:113:4 | ParseFromIstream output argument |
-| protobuf.cpp:116:2:116:4 | *msg | protobuf.cpp:116:24:116:27 | SerializeToString output argument |
-| protobuf.cpp:117:2:117:4 | *msg | protobuf.cpp:117:31:117:34 | SerializePartialToString output argument |
-| protobuf.cpp:118:2:118:4 | *msg | protobuf.cpp:118:21:118:24 | AppendToString output argument |
-| protobuf.cpp:121:2:121:4 | *msg | protobuf.cpp:121:25:121:27 | SerializeToOstream output argument |
+| protobuf.cpp:141:21:141:31 | *call to data | protobuf.cpp:141:2:141:4 | ParseFromArray output argument |
+| protobuf.cpp:143:2:143:4 | *msg | protobuf.cpp:143:23:143:25 | SerializeToArray output argument |
+| protobuf.cpp:152:21:152:31 | *call to data | protobuf.cpp:152:2:152:4 | ParseFromArray output argument |
+| protobuf.cpp:153:18:153:20 | *msg | protobuf.cpp:153:22:153:38 | call to SerializeAsString |
+| protobuf.cpp:155:22:155:29 | *call to data | protobuf.cpp:155:2:155:5 | ParseFromArray output argument |
+| protobuf.cpp:157:2:157:5 | *msg2 | protobuf.cpp:157:24:157:26 | SerializeToArray output argument |
+| protobuf.cpp:169:22:169:23 | sv | protobuf.cpp:169:2:169:4 | ParseFromString output argument |
+| protobuf.cpp:170:22:170:25 | *cord | protobuf.cpp:170:2:170:4 | ParseFromString output argument |
+| protobuf.cpp:171:29:171:30 | sv | protobuf.cpp:171:2:171:4 | ParsePartialFromString output argument |
+| protobuf.cpp:172:29:172:32 | *cord | protobuf.cpp:172:2:172:4 | ParsePartialFromString output argument |
+| protobuf.cpp:173:22:173:23 | sv | protobuf.cpp:173:2:173:4 | MergeFromString output argument |
+| protobuf.cpp:174:22:174:25 | *cord | protobuf.cpp:174:2:174:4 | MergeFromString output argument |
+| protobuf.cpp:175:29:175:30 | sv | protobuf.cpp:175:2:175:4 | MergePartialFromString output argument |
+| protobuf.cpp:176:29:176:32 | *cord | protobuf.cpp:176:2:176:4 | MergePartialFromString output argument |
+| protobuf.cpp:178:28:178:38 | *call to data | protobuf.cpp:178:2:178:4 | ParsePartialFromArray output argument |
+| protobuf.cpp:180:20:180:23 | *cord | protobuf.cpp:180:2:180:4 | ParseFromCord output argument |
+| protobuf.cpp:181:27:181:30 | *cord | protobuf.cpp:181:2:181:4 | ParsePartialFromCord output argument |
+| protobuf.cpp:182:20:182:23 | *cord | protobuf.cpp:182:2:182:4 | MergeFromCord output argument |
+| protobuf.cpp:183:27:183:30 | *cord | protobuf.cpp:183:2:183:4 | MergePartialFromCord output argument |
+| protobuf.cpp:186:23:186:25 | *& ... | protobuf.cpp:186:2:186:4 | ParseFromIstream output argument |
+| protobuf.cpp:187:30:187:32 | *& ... | protobuf.cpp:187:2:187:4 | ParsePartialFromIstream output argument |
+| protobuf.cpp:190:30:190:33 | *& ... | protobuf.cpp:190:2:190:4 | ParseFromZeroCopyStream output argument |
+| protobuf.cpp:191:37:191:40 | *& ... | protobuf.cpp:191:2:191:4 | ParsePartialFromZeroCopyStream output argument |
+| protobuf.cpp:192:37:192:40 | *& ... | protobuf.cpp:192:2:192:4 | ParseFromBoundedZeroCopyStream output argument |
+| protobuf.cpp:193:44:193:47 | *& ... | protobuf.cpp:193:2:193:4 | ParsePartialFromBoundedZeroCopyStream output argument |
+| protobuf.cpp:194:37:194:40 | *& ... | protobuf.cpp:194:2:194:4 | MergeFromBoundedZeroCopyStream output argument |
+| protobuf.cpp:195:44:195:47 | *& ... | protobuf.cpp:195:2:195:4 | MergePartialFromBoundedZeroCopyStream output argument |
+| protobuf.cpp:198:27:198:30 | *& ... | protobuf.cpp:198:2:198:4 | ParseFromCodedStream output argument |
+| protobuf.cpp:199:34:199:37 | *& ... | protobuf.cpp:199:2:199:4 | ParsePartialFromCodedStream output argument |
+| protobuf.cpp:200:27:200:30 | *& ... | protobuf.cpp:200:2:200:4 | MergeFromCodedStream output argument |
+| protobuf.cpp:201:34:201:37 | *& ... | protobuf.cpp:201:2:201:4 | MergePartialFromCodedStream output argument |
+| protobuf.cpp:204:2:204:4 | *msg | protobuf.cpp:204:24:204:27 | SerializeToString output argument |
+| protobuf.cpp:205:2:205:4 | *msg | protobuf.cpp:205:31:205:34 | SerializePartialToString output argument |
+| protobuf.cpp:206:2:206:4 | *msg | protobuf.cpp:206:21:206:24 | AppendToString output argument |
+| protobuf.cpp:207:2:207:4 | *msg | protobuf.cpp:207:28:207:31 | AppendPartialToString output argument |
+| protobuf.cpp:210:2:210:4 | *msg | protobuf.cpp:210:30:210:32 | SerializePartialToArray output argument |
+| protobuf.cpp:213:2:213:4 | *msg | protobuf.cpp:213:22:213:29 | SerializeToCord output argument |
+| protobuf.cpp:214:2:214:4 | *msg | protobuf.cpp:214:29:214:36 | SerializePartialToCord output argument |
+| protobuf.cpp:215:2:215:4 | *msg | protobuf.cpp:215:19:215:26 | AppendToCord output argument |
+| protobuf.cpp:216:2:216:4 | *msg | protobuf.cpp:216:26:216:33 | AppendPartialToCord output argument |
+| protobuf.cpp:219:2:219:4 | *msg | protobuf.cpp:219:25:219:27 | SerializeToOstream output argument |
+| protobuf.cpp:220:2:220:4 | *msg | protobuf.cpp:220:32:220:34 | SerializePartialToOstream output argument |
+| protobuf.cpp:223:2:223:4 | *msg | protobuf.cpp:223:32:223:36 | SerializeToZeroCopyStream output argument |
+| protobuf.cpp:224:2:224:4 | *msg | protobuf.cpp:224:39:224:43 | SerializePartialToZeroCopyStream output argument |
+| protobuf.cpp:227:2:227:4 | *msg | protobuf.cpp:227:29:227:33 | SerializeToCodedStream output argument |
+| protobuf.cpp:228:2:228:4 | *msg | protobuf.cpp:228:36:228:40 | SerializePartialToCodedStream output argument |
+| protobuf.cpp:230:2:230:4 | *msg | protobuf.cpp:230:6:230:22 | call to SerializeAsString |
+| protobuf.cpp:231:2:231:4 | *msg | protobuf.cpp:231:6:231:29 | call to SerializePartialAsString |
+| protobuf.cpp:232:2:232:4 | *msg | protobuf.cpp:232:6:232:20 | call to SerializeAsCord |
+| protobuf.cpp:233:2:233:4 | *msg | protobuf.cpp:233:6:233:27 | call to SerializePartialAsCord |
 | test.cpp:17:24:17:24 | x | test.cpp:17:10:17:22 | call to ymlStepManual |
 | test.cpp:21:27:21:27 | x | test.cpp:21:10:21:25 | call to ymlStepGenerated |
 | test.cpp:25:35:25:35 | x | test.cpp:25:11:25:33 | call to ymlStepManual_with_body |

--- a/cpp/ql/test/library-tests/dataflow/external-models/steps.expected
+++ b/cpp/ql/test/library-tests/dataflow/external-models/steps.expected
@@ -82,6 +82,21 @@
 | bdlbb.cpp:92:48:92:51 | *call to data | bdlbb.cpp:92:37:92:40 | copy output argument |
 | bdlbb.cpp:94:46:94:48 | *src | bdlbb.cpp:94:37:94:40 | copy output argument |
 | bdlbb.cpp:96:42:96:44 | *dst | bdlbb.cpp:96:37:96:39 | copy output argument |
+| protobuf.cpp:76:22:76:25 | *data | protobuf.cpp:76:2:76:4 | ParseFromString output argument |
+| protobuf.cpp:78:2:78:4 | *msg | protobuf.cpp:78:23:78:25 | SerializeToArray output argument |
+| protobuf.cpp:85:21:85:31 | *call to data | protobuf.cpp:85:2:85:4 | ParseFromArray output argument |
+| protobuf.cpp:87:2:87:4 | *msg | protobuf.cpp:87:23:87:25 | SerializeToArray output argument |
+| protobuf.cpp:96:22:96:25 | *data | protobuf.cpp:96:2:96:4 | ParseFromString output argument |
+| protobuf.cpp:98:23:98:25 | *msg | protobuf.cpp:98:27:98:43 | call to SerializeAsString |
+| protobuf.cpp:98:23:98:45 | call to SerializeAsString | protobuf.cpp:98:2:98:5 | ParseFromString output argument |
+| protobuf.cpp:100:2:100:5 | *msg2 | protobuf.cpp:100:24:100:26 | SerializeToArray output argument |
+| protobuf.cpp:109:22:109:25 | *data | protobuf.cpp:109:2:109:4 | MergeFromString output argument |
+| protobuf.cpp:110:29:110:32 | *data | protobuf.cpp:110:2:110:4 | ParsePartialFromString output argument |
+| protobuf.cpp:113:23:113:25 | *& ... | protobuf.cpp:113:2:113:4 | ParseFromIstream output argument |
+| protobuf.cpp:116:2:116:4 | *msg | protobuf.cpp:116:24:116:27 | SerializeToString output argument |
+| protobuf.cpp:117:2:117:4 | *msg | protobuf.cpp:117:31:117:34 | SerializePartialToString output argument |
+| protobuf.cpp:118:2:118:4 | *msg | protobuf.cpp:118:21:118:24 | AppendToString output argument |
+| protobuf.cpp:121:2:121:4 | *msg | protobuf.cpp:121:25:121:27 | SerializeToOstream output argument |
 | test.cpp:17:24:17:24 | x | test.cpp:17:10:17:22 | call to ymlStepManual |
 | test.cpp:21:27:21:27 | x | test.cpp:21:10:21:25 | call to ymlStepGenerated |
 | test.cpp:25:35:25:35 | x | test.cpp:25:11:25:33 | call to ymlStepManual_with_body |

--- a/cpp/ql/test/library-tests/dataflow/external-models/validatemodels.expected
+++ b/cpp/ql/test/library-tests/dataflow/external-models/validatemodels.expected
@@ -3167,6 +3167,7 @@
 | Dubious signature "(const CURLU *,CURLUPart,char **,unsigned int)" in summary model. |
 | Dubious signature "(const ComPtr &)" in summary model. |
 | Dubious signature "(const Command *,const size_t,const BlockSplit *,const BlockSplit *,const BlockSplit *,const uint8_t *,size_t,size_t,uint8_t,uint8_t,const ContextType *,HistogramLiteral *,HistogramCommand *,HistogramDistance *)" in summary model. |
+| Dubious signature "(const Cord &)" in summary model. |
 | Dubious signature "(const Curl_easy *,const connectdata *,int)" in summary model. |
 | Dubious signature "(const DH *)" in summary model. |
 | Dubious signature "(const DH *,const BIGNUM *)" in summary model. |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/test_mad-signatures.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/test_mad-signatures.expected
@@ -14064,6 +14064,10 @@ getSignatureParameterName
 | (const Command *,const size_t,const BlockSplit *,const BlockSplit *,const BlockSplit *,const uint8_t *,size_t,size_t,uint8_t,uint8_t,const ContextType *,HistogramLiteral *,HistogramCommand *,HistogramDistance *) |  | BrotliBuildHistogramsWithContext | 11 | HistogramLiteral * |
 | (const Command *,const size_t,const BlockSplit *,const BlockSplit *,const BlockSplit *,const uint8_t *,size_t,size_t,uint8_t,uint8_t,const ContextType *,HistogramLiteral *,HistogramCommand *,HistogramDistance *) |  | BrotliBuildHistogramsWithContext | 12 | HistogramCommand * |
 | (const Command *,const size_t,const BlockSplit *,const BlockSplit *,const BlockSplit *,const uint8_t *,size_t,size_t,uint8_t,uint8_t,const ContextType *,HistogramLiteral *,HistogramCommand *,HistogramDistance *) |  | BrotliBuildHistogramsWithContext | 13 | HistogramDistance * |
+| (const Cord &) | MessageLite | MergeFromString | 0 | const Cord & |
+| (const Cord &) | MessageLite | MergePartialFromString | 0 | const Cord & |
+| (const Cord &) | MessageLite | ParseFromString | 0 | const Cord & |
+| (const Cord &) | MessageLite | ParsePartialFromString | 0 | const Cord & |
 | (const Curl_easy *,const connectdata *,int) |  | Curl_conn_is_http2 | 0 | const Curl_easy * |
 | (const Curl_easy *,const connectdata *,int) |  | Curl_conn_is_http2 | 1 | const connectdata * |
 | (const Curl_easy *,const connectdata *,int) |  | Curl_conn_is_http2 | 2 | int |
@@ -24746,6 +24750,10 @@ getSignatureParameterName
 | (string_buf *,unsigned char **,size_t *) |  | _libssh2_get_string | 0 | string_buf * |
 | (string_buf *,unsigned char **,size_t *) |  | _libssh2_get_string | 1 | unsigned char ** |
 | (string_buf *,unsigned char **,size_t *) |  | _libssh2_get_string | 2 | size_t * |
+| (string_view) | MessageLite | MergeFromString | 0 | string_view |
+| (string_view) | MessageLite | MergePartialFromString | 0 | string_view |
+| (string_view) | MessageLite | ParseFromString | 0 | string_view |
+| (string_view) | MessageLite | ParsePartialFromString | 0 | string_view |
 | (string_view,string_view) | basic_resolver<InternetProtocol> | resolve | 0 | string_view |
 | (string_view,string_view) | basic_resolver<InternetProtocol> | resolve | 1 | string_view |
 | (string_view,string_view,error_code &) | basic_resolver<InternetProtocol> | resolve | 0 | string_view |


### PR DESCRIPTION
Add flow summaries for the protobuf C++ API on google::protobuf::MessageLite (subtypes=true, so Message and all generated messages are covered):

- ParseFrom*/MergeFrom* (string, array, Cord, istream, zero-copy and coded-stream forms) propagate taint from the encoded input to the message.
- SerializeTo*/AppendTo* propagate taint from the message to the output buffer or stream; SerializeAs*/AppendTo* to the return value.
- File-descriptor variants are omitted (the fd is an int, not a buffer).