### PR TITLE
Skip mono/nuget C# integration tests on Ubuntu 26.04

### DIFF
--- a/csharp/ql/integration-tests/posix/conftest.py
+++ b/csharp/ql/integration-tests/posix/conftest.py
@@ -5,15 +5,10 @@ def _supports_mono_nuget():
     """
     Helper function to determine if the current platform supports Mono and nuget.
     
-    Returns True if running on Linux or on macOS x86_64 (excluding macos-15 and macos-26).
-    macOS ARM runners (macos-15 and macos-26) are excluded due to issues with Mono and nuget.
+    Returns True on Ubuntu before 26.04 and on macOS x86_64 before macOS 15. Linux other than
+    Ubuntu is not selected, as we do not test on it.
+    Ubuntu dropped the `mono-complete` package in 26.04, and mono is end-of-life, its own apt
+    repository publishing nothing newer than Ubuntu 20.04, so there is nothing to fall back on.
+    macOS 15 and later are ARM runners, which have issues with Mono and nuget.
     """
-    return (
-        runs_on.linux
-        or (
-            runs_on.macos
-            and runs_on.x86_64
-            and not runs_on.macos_15
-            and not runs_on.macos_26
-        )
-    )
+    return runs_on.ubuntu < 2604 or (runs_on.macos < 15 and runs_on.x86_64)


### PR DESCRIPTION
Mono is end-of-life and its apt repository only publishes packages up to Ubuntu 18.04 (`vs-bionic`). On Ubuntu 26.04 those packages are uninstallable, since their gtk2-era dependency chain (`libgtk2.0-0`, `gnome-icon-theme`, `fsharp`, ...) no longer resolves:

```
mono-complete : Depends: mono-runtime (= 6.12.0.200-0xamarin2+ubuntu1804b1) but it is not going to be installed
                Depends: referenceassemblies-pcl but it is not going to be installed
                ...
```

Four C# integration tests need mono, and without it they fail quietly rather than obviously:

- the legacy `packages.config` restore needs `nuget.exe` under mono, so it produces **no assemblies at all** and `Assemblies.ql` returns an empty result
- `standalone_dependencies_no_framework` no longer finds mono's framework assemblies, so the buildless extractor falls back to downloading `microsoft.netframework.referenceassemblies.net481`, turning 1 expected row into 242

## What

`_supports_mono_nuget()` already exists precisely to exclude platforms where mono and nuget do not work, and already excludes `macos-15`/`macos-26` for the same class of reason. This adds Ubuntu 26.04 to it, so the four tests are deselected instead of failing.

Verified by collection on both platforms (26.04 simulated by faking `freedesktop_os_release`):

| platform | collected |
| --- | --- |
| Ubuntu 24.04 | 28/28, unchanged |
| Ubuntu 26.04 | 24/28, the 4 mono tests deselected |