### PR TITLE
Documentation Actions EnvironmentCheck

### DIFF
--- a/actions/ql/lib/codeql/actions/security/ControlChecks.qll
+++ b/actions/ql/lib/codeql/actions/security/ControlChecks.qll
@@ -284,7 +284,7 @@ abstract class LabelCheck extends ControlCheck {
  * of this model is for any environment to be considered a sanitizer.
  * If values are (currently manually/externally) provided in `actions/ql/lib/ext/config/deployment_environment.yml`
  * then those names will be used to define the valid sanitizer set.
- * To create a default of "no default saniziter environment" one can add an
+ * To create a default of "no default sanitizer environment" one can add an
  * empty string to the data array in `deployment_environment.yml`.
  */
 class EnvironmentCheck extends ControlCheck instanceof Environment {

--- a/actions/ql/lib/codeql/actions/security/ControlChecks.qll
+++ b/actions/ql/lib/codeql/actions/security/ControlChecks.qll
@@ -282,10 +282,10 @@ abstract class LabelCheck extends ControlCheck {
  *
  * It is possible to customize which deployment environments apply. The default behavior
  * of this model is for any environment to be considered a sanitizer.
- * If values are (currently manually/externally) provided in `actions/ql/lib/ext/config/deployment_environment.yml`
- * then those names will be used to define the valid sanitizer set.
- * To create a default of "no default sanitizer environment" one can add an
- * empty string to the data array in `deployment_environment.yml`.
+ * If values are provided then those names
+ * will be used to define the valid sanitizer set.
+ * To describe the situation where there is no acceptable sanitizer environment
+ * populate the predicate `enabledDeploymentEnvironmentDataModel` to contain a single empty string.
  */
 class EnvironmentCheck extends ControlCheck instanceof Environment {
   EnvironmentCheck() {

--- a/actions/ql/lib/codeql/actions/security/ControlChecks.qll
+++ b/actions/ql/lib/codeql/actions/security/ControlChecks.qll
@@ -278,7 +278,7 @@ abstract class LabelCheck extends ControlCheck {
 
 /**
  * This type represents deployment environments that may serve as sanitizers for
- * various vunlerabilities.
+ * various vulnerabilities.
  *
  * It is possible to customize which deployment environments apply. The default behavior
  * of this model is for any environment to be considered a sanitizer.

--- a/actions/ql/lib/codeql/actions/security/ControlChecks.qll
+++ b/actions/ql/lib/codeql/actions/security/ControlChecks.qll
@@ -276,9 +276,19 @@ abstract class LabelCheck extends ControlCheck {
   }
 }
 
+/**
+ * This type represents deployment environments that may serve as sanitizers for
+ * various vunlerabilities.
+ *
+ * It is possible to customize which deployment environments apply. The default behavior
+ * of this model is for any environment to be considered a sanitizer.
+ * If values are (currently manually/externally) provided in `actions/ql/lib/ext/config/deployment_environment.yml`
+ * then those names will be used to define the valid sanitizer set.
+ * To create a default of "no default saniziter environment" one can add an
+ * empty string to the data array in `deployment_environment.yml`.
+ */
 class EnvironmentCheck extends ControlCheck instanceof Environment {
   EnvironmentCheck() {
-    // if there are any custom tuples use those
     if enabledDeploymentEnvironmentDataModel(_)
     then enabledDeploymentEnvironmentDataModel(this.(Environment).getName())
     else this instanceof Environment

--- a/actions/ql/lib/codeql/actions/security/ControlChecks.qll
+++ b/actions/ql/lib/codeql/actions/security/ControlChecks.qll
@@ -277,7 +277,7 @@ abstract class LabelCheck extends ControlCheck {
 }
 
 /**
- * This type represents deployment environments that may serve as sanitizers for
+ * A deployment environment that may serve as a sanitizer for
  * various vulnerabilities.
  *
  * It is possible to customize which deployment environments apply. The default behavior


### PR DESCRIPTION
Improve documentation on actions/security/ControlChecks.qll EnvironmentCheck

currently was undocumented and as such its intended ways to use it could stand to be clarified

I dont think this needs a change note... but let me know if that is an incorrect assumption