### PR TITLE
Go: When `go.mod` version is above `maxGoVersion` request `go.mod` version

### DIFF
--- a/go/extractor/autobuilder/build-environment.go
+++ b/go/extractor/autobuilder/build-environment.go
@@ -83,55 +83,58 @@ func getVersionWhenGoModVersionNotFound(v versionInfo) (msg string, version util
 func getVersionWhenGoModVersionTooHigh(v versionInfo) (msg string, version util.SemVer) {
 	if v.goEnvVersion == nil {
 		// The version in the `go.mod` file is above the supported range. There is no Go version
-		// installed. We install the maximum supported version as a best effort.
+		// installed. We install the version from the `go.mod` file as a best effort.
 		msg = "The version of Go found in the `go.mod` file (" + v.goModVersion.String() +
 			") is above the supported range (" + minGoVersion.String() + "-" + maxGoVersion.String() +
-			"). No version of Go installed. Requesting the maximum supported version of Go (" +
-			maxGoVersion.String() + ")."
-		version = maxGoVersion
+			"). No version of Go installed. Requesting the version of Go from the `go.mod` file (" +
+			v.goModVersion.String() + ")."
+		version = v.goModVersion
 		diagnostics.EmitGoModVersionTooHighAndNoGoEnv(msg)
-	} else if aboveSupportedRange(v.goEnvVersion) {
+	} else if !outsideSupportedRange(v.goEnvVersion) {
 		// The version in the `go.mod` file is above the supported range. The version of Go that
-		// is installed is above the supported range. We do not install a version of Go.
+		// is installed is in the supported range. We install the version from the `go.mod`
+		// file as a best effort.
 		msg = "The version of Go found in the `go.mod` file (" + v.goModVersion.String() +
 			") is above the supported range (" + minGoVersion.String() + "-" + maxGoVersion.String() +
 			"). The version of Go installed in the environment (" + v.goEnvVersion.String() +
-			") is above the supported range (" + minGoVersion.String() + "-" + maxGoVersion.String() +
-			"). Not requesting any version of Go."
-		version = nil
-		diagnostics.EmitGoModVersionTooHighAndEnvVersionTooHigh(msg)
+			") is inside the supported range (" + minGoVersion.String() + "-" + maxGoVersion.String() +
+			"). Requesting the version of Go from the `go.mod` file (" + v.goModVersion.String() + ")."
+		version = v.goModVersion
+		diagnostics.EmitGoModVersionTooHighAndEnvVersionSupported(msg)
 	} else if belowSupportedRange(v.goEnvVersion) {
 		// The version in the `go.mod` file is above the supported range. The version of Go that
-		// is installed is below the supported range. We install the maximum supported version as
-		// a best effort.
+		// is installed is below the supported range. We install the version from the `go.mod`
+		// file as a best effort.
 		msg = "The version of Go found in the `go.mod` file (" + v.goModVersion.String() +
 			") is above the supported range (" + minGoVersion.String() + "-" + maxGoVersion.String() +
 			"). The version of Go installed in the environment (" + v.goEnvVersion.String() +
 			") is below the supported range (" + minGoVersion.String() + "-" + maxGoVersion.String() +
-			"). Requesting the maximum supported version of Go (" + maxGoVersion.String() + ")."
-		version = maxGoVersion
+			"). Requesting the version of Go from the `go.mod` file (" + v.goModVersion.String() + ")."
+		version = v.goModVersion
 		diagnostics.EmitGoModVersionTooHighAndEnvVersionTooLow(msg)
-	} else if maxGoVersion.IsNewerThan(v.goEnvVersion) {
+	} else if v.goModVersion.IsNewerThan(v.goEnvVersion) {
 		// The version in the `go.mod` file is above the supported range. The version of Go that
-		// is installed is supported and below the maximum supported version. We install the
-		// maximum supported version as a best effort.
+		// is installed is also above the supported range, but older. We install the version
+		// from the `go.mod` file as a best effort.
 		msg = "The version of Go found in the `go.mod` file (" + v.goModVersion.String() +
 			") is above the supported range (" + minGoVersion.String() + "-" + maxGoVersion.String() +
 			"). The version of Go installed in the environment (" + v.goEnvVersion.String() +
-			") is below the maximum supported version (" + maxGoVersion.String() +
-			"). Requesting the maximum supported version of Go (" + maxGoVersion.String() + ")."
-		version = maxGoVersion
-		diagnostics.EmitGoModVersionTooHighAndEnvVersionBelowMax(msg)
+			") is also above the supported range (" + minGoVersion.String() + "-" + maxGoVersion.String() +
+			") but older. Requesting the version of Go from the `go.mod` file (" + v.goModVersion.String() +
+			")."
+		version = v.goModVersion
+		diagnostics.EmitGoModVersionTooHighAndEnvVersionTooHighButOlder(msg)
 	} else {
 		// The version in the `go.mod` file is above the supported range. The version of Go that
-		// is installed is the maximum supported version. We do not install a version of Go.
+		// is installed is also above the supported range, but newer or equal. We do not install
+		// a version of Go.
 		msg = "The version of Go found in the `go.mod` file (" + v.goModVersion.String() +
 			") is above the supported range (" + minGoVersion.String() + "-" + maxGoVersion.String() +
 			"). The version of Go installed in the environment (" + v.goEnvVersion.String() +
-			") is the maximum supported version (" + maxGoVersion.String() +
+			") is also above the supported range (" + minGoVersion.String() + "-" + maxGoVersion.String() +
 			"). Not requesting any version of Go."
 		version = nil
-		diagnostics.EmitGoModVersionTooHighAndEnvVersionMax(msg)
+		diagnostics.EmitGoModVersionTooHighAndEnvTooHigh(msg)
 	}
 
 	return msg, version
@@ -218,17 +221,16 @@ func getVersionWhenGoModVersionSupported(v versionInfo) (msg string, version uti
 
 // Check the versions of Go found in the environment and in the `go.mod` file, and return a
 // version to install. If the version is the empty string then no installation is required.
-// We never return a version of Go that is outside of the supported range.
 //
-// +-----------------------+-----------------------+-----------------------+-----------------------------------------------------+------------------------------------------------+
-// | Found in go.mod >     | *None*                | *Below min supported* | *In supported range*                                | *Above max supported                           |
-// | Installed \/          |                       |                       |                                                     |                                                |
-// |-----------------------|-----------------------|-----------------------|-----------------------------------------------------|------------------------------------------------|
-// | *None*                | Install max supported | Install min supported | Install version from go.mod                         | Install max supported                          |
-// | *Below min supported* | Install max supported | Install min supported | Install version from go.mod                         | Install max supported                          |
-// | *In supported range*  | No action             | No action             | Install version from go.mod if newer than installed | Install max supported if newer than installed  |
-// | *Above max supported* | Install max supported | Install min supported | Install version from go.mod                         | No action                                      |
-// +-----------------------+-----------------------+-----------------------+-----------------------------------------------------+------------------------------------------------+
+// +-----------------------+-----------------------+-----------------------+-----------------------------------------------------+-----------------------------------------------------+
+// | Found in go.mod >     | *None*                | *Below min supported* | *In supported range*                                | *Above max supported                                |
+// | Installed \/          |                       |                       |                                                     |                                                     |
+// |-----------------------|-----------------------|-----------------------|-----------------------------------------------------|-----------------------------------------------------|
+// | *None*                | Install max supported | Install min supported | Install version from go.mod                         | Install version from go.mod                         |
+// | *Below min supported* | Install max supported | Install min supported | Install version from go.mod                         | Install version from go.mod                         |
+// | *In supported range*  | No action             | No action             | Install version from go.mod if newer than installed | Install version from go.mod                         |
+// | *Above max supported* | Install max supported | Install min supported | Install version from go.mod                         | Install version from go.mod if newer than installed |
+// +-----------------------+-----------------------+-----------------------+-----------------------------------------------------+-----------------------------------------------------+
 func getVersionToInstall(v versionInfo) (msg string, version util.SemVer) {
 	if v.goModVersion == nil {
 		return getVersionWhenGoModVersionNotFound(v)

--- a/go/extractor/autobuilder/build-environment_test.go
+++ b/go/extractor/autobuilder/build-environment_test.go
@@ -20,11 +20,15 @@ func TestGetVersionToInstall(t *testing.T) {
 		{"", "1.20.3"}:   "",
 
 		// getVersionWhenGoModVersionTooHigh()
-		{"9999.0", ""}:                    maxGoVersion.String(),
+		{"9999.0", ""}:                    "9999.0",
 		{"9999.0", "9999.0.1"}:            "",
-		{"9999.0", "1.1"}:                 maxGoVersion.String(),
-		{"9999.0", minGoVersion.String()}: maxGoVersion.String(),
-		{"9999.0", maxGoVersion.String()}: "",
+		{"9999.0", "1.1"}:                 "9999.0",
+		{"9999.0", minGoVersion.String()}: "9999.0",
+		{"9999.0", maxGoVersion.String()}: "9999.0",
+		{"9999.1", "9999.0"}:              "9999.1",
+		{"9999.0", "9999.1"}:              "",
+		{"9999.0", "9999.0"}:              "",
+		{"9999.0rc2", ""}:                 "v9999.0.0-rc2",
 
 		// getVersionWhenGoModVersionTooLow()
 		{"0.0", ""}:       minGoVersion.String(),

--- a/go/extractor/diagnostics/diagnostics.go
+++ b/go/extractor/diagnostics/diagnostics.go
@@ -422,10 +422,10 @@ func EmitGoModVersionTooHighAndNoGoEnv(msg string) {
 	)
 }
 
-func EmitGoModVersionTooHighAndEnvVersionTooHigh(msg string) {
+func EmitGoModVersionTooHighAndEnvVersionSupported(msg string) {
 	emitDiagnostic(
-		"go/autobuilder/env-go-mod-version-too-high-go-env-too-high",
-		"Go version in `go.mod` file above supported range and Go version in environment above supported range",
+		"go/autobuilder/env-go-mod-version-too-high-go-env-supported",
+		"Go version in `go.mod` file above supported range and Go version in environment is supported",
 		msg,
 		severityNote,
 		telemetryOnly,
@@ -444,10 +444,10 @@ func EmitGoModVersionTooHighAndEnvVersionTooLow(msg string) {
 	)
 }
 
-func EmitGoModVersionTooHighAndEnvVersionBelowMax(msg string) {
+func EmitGoModVersionTooHighAndEnvVersionTooHighButOlder(msg string) {
 	emitDiagnostic(
-		"go/autobuilder/env-go-mod-version-too-high-go-env-below-max",
-		"Go version in `go.mod` file above supported range and Go version in environment is supported and below the maximum supported version",
+		"go/autobuilder/env-go-mod-version-too-high-go-env-too-high-but-older",
+		"Go version in `go.mod` file above supported range and Go version in environment is above supported range but older",
 		msg,
 		severityNote,
 		telemetryOnly,
@@ -455,10 +455,10 @@ func EmitGoModVersionTooHighAndEnvVersionBelowMax(msg string) {
 	)
 }
 
-func EmitGoModVersionTooHighAndEnvVersionMax(msg string) {
+func EmitGoModVersionTooHighAndEnvTooHigh(msg string) {
 	emitDiagnostic(
-		"go/autobuilder/env-go-mod-version-too-high-go-env-max",
-		"Go version in `go.mod` file above supported range and Go version in environment is the maximum supported version",
+		"go/autobuilder/env-go-mod-version-too-high-go-env-too-high",
+		"Go version in `go.mod` file above supported range and Go version in environment is above supported range",
 		msg,
 		severityNote,
 		telemetryOnly,

--- a/go/ql/integration-tests/diagnostics/newer-go-version-needed/build_environment.expected
+++ b/go/ql/integration-tests/diagnostics/newer-go-version-needed/build_environment.expected
@@ -1,5 +1,7 @@
 {
   "configuration" : {
-    "go" : { }
+    "go" : {
+      "version" : "1.999.0"
+    }
   }
 }


### PR DESCRIPTION
We currently block analysis of projects that target a Go version that is too new. If we do not do this, we get an error like the following when the user has not selected the correct Go toolchain in their workflow:
```
Error running go tooling: err: exit status 1: stderr: go: go.mod requires go >= 1.27 (running go 1.26.6; GOTOOLCHAIN=local)
```
See, e.g., [here](https://github.com/github/codeql/issues/22394). This seems quite strict, as we could just as well download the newer version through the existing mechanisms that we have for this. This PR together with the related internal changes does just that.

Because of the version mismatch we might see some additional parse errors on projects that are too new. Given the number of syntax changes between recent Go versions this seems acceptable. Database quality might be slightly lower, but at least the won't block users until we have updated the extractor.