### PR TITLE
C++: Fix a crazy FP in `cpp/leap-year/unsafe-array-for-days-of-the-year`

### DIFF
--- a/cpp/ql/src/Likely Bugs/Leap Year/UnsafeArrayForDaysOfYear.ql
+++ b/cpp/ql/src/Likely Bugs/Leap Year/UnsafeArrayForDaysOfYear.ql
@@ -26,6 +26,7 @@ where
   or
   exists(Variable var |
     var = element and
+    not var.isCompilerGenerated() and
     var.getType() instanceof LeapYearUnsafeDaysOfTheYearArrayType and
     allocType = "an array allocation"
   )

--- a/cpp/ql/src/change-notes/2026-08-28-leap-year-unsafe-array-fp.md
+++ b/cpp/ql/src/change-notes/2026-08-28-leap-year-unsafe-array-fp.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The `cpp/leap-year/unsafe-array-for-days-of-the-year` query ("Unsafe array for days of the year") no longer reports an alert on the `__PRETTY_FUNCTION__` variable (and related variables) when the enclosing function has a signature that is exactly 364 characters.

--- a/cpp/ql/test/query-tests/Likely Bugs/Leap Year/UnsafeArrayForDaysOfYear/UnsafeArrayForDaysOfYear.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Leap Year/UnsafeArrayForDaysOfYear/UnsafeArrayForDaysOfYear.expected
@@ -1,4 +1,3 @@
 | test.cpp:17:6:17:10 | items | There is an array allocation with a hard-coded set of 365 elements, which may indicate the number of days in a year without considering leap year scenarios. |
 | test.cpp:25:15:25:26 | new[] | There is an array allocation with a hard-coded set of 365 elements, which may indicate the number of days in a year without considering leap year scenarios. |
 | test.cpp:52:20:52:23 | call to vector | There is a std::vector allocation with a hard-coded set of 365 elements, which may indicate the number of days in a year without considering leap year scenarios. |
-| test.cpp:78:11:78:29 | __PRETTY_FUNCTION__ | There is an array allocation with a hard-coded set of 365 elements, which may indicate the number of days in a year without considering leap year scenarios. |

--- a/cpp/ql/test/query-tests/Likely Bugs/Leap Year/UnsafeArrayForDaysOfYear/UnsafeArrayForDaysOfYear.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Leap Year/UnsafeArrayForDaysOfYear/UnsafeArrayForDaysOfYear.expected
@@ -1,3 +1,4 @@
 | test.cpp:17:6:17:10 | items | There is an array allocation with a hard-coded set of 365 elements, which may indicate the number of days in a year without considering leap year scenarios. |
 | test.cpp:25:15:25:26 | new[] | There is an array allocation with a hard-coded set of 365 elements, which may indicate the number of days in a year without considering leap year scenarios. |
 | test.cpp:52:20:52:23 | call to vector | There is a std::vector allocation with a hard-coded set of 365 elements, which may indicate the number of days in a year without considering leap year scenarios. |
+| test.cpp:78:11:78:29 | __PRETTY_FUNCTION__ | There is an array allocation with a hard-coded set of 365 elements, which may indicate the number of days in a year without considering leap year scenarios. |

--- a/cpp/ql/test/query-tests/Likely Bugs/Leap Year/UnsafeArrayForDaysOfYear/test.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Leap Year/UnsafeArrayForDaysOfYear/test.cpp
@@ -71,8 +71,8 @@ void VectorOfDays_FalsePositive(int dayOfYear, int x)
 
 void f_______________________________________________________this_name_must_be_exactly_357_chars__________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________() {
   // Using this magic compiler variable results in a `const char` array being
-  // initialized with the function name which (including `void`, a space,
-  // and `()`). in this case, this adds up to exactly 364 characters.
+  // initialized with the function signature. Including `void`, a space, and
+  // `()`, the signature adds up to exactly 364 characters in this case.
   // The initializer for `__PRETTY_FUNCTION__` thus initializes an array of
   // length 365 (because the null-terminator adds another character).
   auto x = __PRETTY_FUNCTION__; // clean

--- a/cpp/ql/test/query-tests/Likely Bugs/Leap Year/UnsafeArrayForDaysOfYear/test.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Leap Year/UnsafeArrayForDaysOfYear/test.cpp
@@ -68,3 +68,12 @@ void VectorOfDays_FalsePositive(int dayOfYear, int x)
 
 	items[dayOfYear - 1] = x;
 }
+
+void f_______________________________________________________this_name_must_be_exactly_357_chars__________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________() {
+  // Using this magic compiler variable results in a `const char` array being
+  // initialized with the function name which (including `void`, a space,
+  // and `()`). in this case, this adds up to exactly 364 characters.
+  // The initializer for `__PRETTY_FUNCTION__` thus initializes an array of
+  // length 365 (because the null-terminator adds another character).
+  auto x = __PRETTY_FUNCTION__; // $ SPURIOUS: Alert
+}

--- a/cpp/ql/test/query-tests/Likely Bugs/Leap Year/UnsafeArrayForDaysOfYear/test.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Leap Year/UnsafeArrayForDaysOfYear/test.cpp
@@ -75,5 +75,5 @@ void f_______________________________________________________this_name_must_be_e
   // and `()`). in this case, this adds up to exactly 364 characters.
   // The initializer for `__PRETTY_FUNCTION__` thus initializes an array of
   // length 365 (because the null-terminator adds another character).
-  auto x = __PRETTY_FUNCTION__; // $ SPURIOUS: Alert
+  auto x = __PRETTY_FUNCTION__; // clean
 }


### PR DESCRIPTION
This is from an internal FP report at Microsoft. It is _without a single level of doubt_ my favorite false positive in CodeQL ever. And I'm kinda excited that I get to share it with you all since it happened in a GitHub query 😂