### PR TITLE
C#: Re-factor FeedManager to allow better unit testing.

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependabotProxy.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependabotProxy.cs
@@ -9,7 +9,7 @@ using System.Linq;
 
 namespace Semmle.Extraction.CSharp.DependencyFetching
 {
-    public class DependabotProxy : IDisposable
+    public class DependabotProxy : IDependabotProxy
     {
         /// <summary>
         /// Represents configurations for package registries.
@@ -21,24 +21,15 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         private readonly string host;
         private readonly string port;
 
-        /// <summary>
-        /// The full address of the Dependabot proxy, if available.
-        /// </summary>
-        internal string Address { get; }
-        /// <summary>
-        /// The URLs of package registries that are configured for the proxy.
-        /// </summary>
-        internal HashSet<string> RegistryURLs { get; }
-        /// <summary>
-        /// The path to the temporary file where the certificate is stored.
-        /// </summary>
-        internal string? CertificatePath { get; private set; }
-        /// <summary>
-        /// The certificate used for the Dependabot proxy.
-        /// </summary>
-        internal X509Certificate2? Certificate { get; private set; }
+        public string Address { get; }
 
-        internal static DependabotProxy? GetDependabotProxy(
+        public HashSet<string> RegistryURLs { get; }
+
+        public string? CertificatePath { get; private set; }
+
+        public X509Certificate2? Certificate { get; private set; }
+
+        internal static IDependabotProxy? GetDependabotProxy(
             ILogger logger, IDiagnosticsWriter diagnosticsWriter, TemporaryDirectory tempWorkingDirectory)
         {
             // Setting HTTP(S)_PROXY and SSL_CERT_FILE have no effect on Windows or macOS,

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependencyManager.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependencyManager.cs
@@ -27,7 +27,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         private readonly ILogger logger;
         private readonly IDiagnosticsWriter diagnosticsWriter;
         private readonly NugetPackageRestorer nugetPackageRestorer;
-        private readonly DependabotProxy? dependabotProxy;
+        private readonly IDependabotProxy? dependabotProxy;
         private readonly IDotNet dotnet;
         private readonly FileContent fileContent;
         private readonly IFileProvider fileProvider;

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependencyManager.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependencyManager.cs
@@ -30,7 +30,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         private readonly DependabotProxy? dependabotProxy;
         private readonly IDotNet dotnet;
         private readonly FileContent fileContent;
-        private readonly FileProvider fileProvider;
+        private readonly IFileProvider fileProvider;
 
         // Only used as a set, but ConcurrentDictionary is the only concurrent set in .NET.
         private readonly IDictionary<string, bool> usedReferences = new ConcurrentDictionary<string, bool>();

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DotNet.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DotNet.cs
@@ -90,7 +90,8 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                 args.Add("/p:EnableWindowsTargeting=true");
             }
 
-            args.AddRange(restoreSettings.NugetSources);
+            var nugetSources = restoreSettings.NugetSources.SelectMany<string, string>(source => ["-s", source]).ToList();
+            args.AddRange(nugetSources);
 
             return args;
         }

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DotNet.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DotNet.cs
@@ -31,11 +31,11 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             }
         }
 
-        private DotNet(ILogger logger, string? dotNetPath, TemporaryDirectory tempWorkingDirectory, DependabotProxy? dependabotProxy) : this(new DotNetCliInvoker(logger, Path.Join(dotNetPath ?? string.Empty, "dotnet"), dependabotProxy), logger, dotNetPath is null, tempWorkingDirectory) { }
+        private DotNet(ILogger logger, string? dotNetPath, TemporaryDirectory tempWorkingDirectory, IDependabotProxy? dependabotProxy) : this(new DotNetCliInvoker(logger, Path.Join(dotNetPath ?? string.Empty, "dotnet"), dependabotProxy), logger, dotNetPath is null, tempWorkingDirectory) { }
 
         internal static IDotNet Make(IDotNetCliInvoker dotnetCliInvoker, ILogger logger, bool runDotnetInfo) => new DotNet(dotnetCliInvoker, logger, runDotnetInfo);
 
-        public static IDotNet Make(ILogger logger, string? dotNetPath, TemporaryDirectory tempWorkingDirectory, DependabotProxy? dependabotProxy) => new DotNet(logger, dotNetPath, tempWorkingDirectory, dependabotProxy);
+        public static IDotNet Make(ILogger logger, string? dotNetPath, TemporaryDirectory tempWorkingDirectory, IDependabotProxy? dependabotProxy) => new DotNet(logger, dotNetPath, tempWorkingDirectory, dependabotProxy);
 
         private static void HandleRetryExitCode143(string dotnet, int attempt, ILogger logger)
         {

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DotNetCliInvoker.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DotNetCliInvoker.cs
@@ -12,11 +12,11 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
     internal sealed class DotNetCliInvoker : IDotNetCliInvoker
     {
         private readonly ILogger logger;
-        private readonly DependabotProxy? proxy;
+        private readonly IDependabotProxy? proxy;
 
         public string Exec { get; }
 
-        public DotNetCliInvoker(ILogger logger, string exec, DependabotProxy? dependabotProxy)
+        public DotNetCliInvoker(ILogger logger, string exec, IDependabotProxy? dependabotProxy)
         {
             this.logger = logger;
             this.proxy = dependabotProxy;

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/FeedManager.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/FeedManager.cs
@@ -21,7 +21,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
 
         private readonly ILogger logger;
         private readonly IDotNet dotnet;
-        private readonly FileProvider fileProvider;
+        private readonly IFileProvider fileProvider;
         private readonly DependabotProxy? dependabotProxy;
         private readonly DependencyDirectory emptyPackageDirectory;
         private readonly ImmutableHashSet<string> privateRegistryFeeds;
@@ -79,7 +79,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         /// </summary>
         public ImmutableHashSet<string> ReachableFallbackFeeds => lazyReachableFallbackFeeds.Value;
 
-        public FeedManager(ILogger logger, IDotNet dotnet, DependabotProxy? dependabotProxy, FileProvider fileProvider)
+        public FeedManager(ILogger logger, IDotNet dotnet, DependabotProxy? dependabotProxy, IFileProvider fileProvider)
         {
             this.logger = logger;
             this.dotnet = dotnet;

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/FeedManager.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/FeedManager.cs
@@ -22,7 +22,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         private readonly ILogger logger;
         private readonly IDotNet dotnet;
         private readonly IFileProvider fileProvider;
-        private readonly DependabotProxy? dependabotProxy;
+        private readonly IDependabotProxy? dependabotProxy;
         private readonly DependencyDirectory emptyPackageDirectory;
         private readonly ImmutableHashSet<string> privateRegistryFeeds;
 
@@ -79,7 +79,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         /// </summary>
         public ImmutableHashSet<string> ReachableFallbackFeeds => lazyReachableFallbackFeeds.Value;
 
-        public FeedManager(ILogger logger, IDotNet dotnet, DependabotProxy? dependabotProxy, IFileProvider fileProvider)
+        public FeedManager(ILogger logger, IDotNet dotnet, IDependabotProxy? dependabotProxy, IFileProvider fileProvider)
         {
             this.logger = logger;
             this.dotnet = dotnet;

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/FeedManager.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/FeedManager.cs
@@ -1,15 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.IO;
 using System.Linq;
-using System.Net;
-using System.Net.Http;
-using System.Security.Cryptography.X509Certificates;
-using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading;
-using System.Threading.Tasks;
 using Semmle.Util;
 using Semmle.Util.Logging;
 
@@ -22,9 +15,9 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         private readonly ILogger logger;
         private readonly IDotNet dotnet;
         private readonly IFileProvider fileProvider;
-        private readonly IDependabotProxy? dependabotProxy;
         private readonly DependencyDirectory emptyPackageDirectory;
         private readonly ImmutableHashSet<string> privateRegistryFeeds;
+        private readonly IFeedManagerIO feedManagerIo;
 
         /// <summary>
         /// Gets whether there are private package registries configured for C#.
@@ -79,12 +72,12 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         /// </summary>
         public ImmutableHashSet<string> ReachableFallbackFeeds => lazyReachableFallbackFeeds.Value;
 
-        public FeedManager(ILogger logger, IDotNet dotnet, IDependabotProxy? dependabotProxy, IFileProvider fileProvider)
+        public FeedManager(ILogger logger, IDotNet dotnet, IDependabotProxy? dependabotProxy, IFileProvider fileProvider, IFeedManagerIO feedManagerIo)
         {
             this.logger = logger;
             this.dotnet = dotnet;
-            this.dependabotProxy = dependabotProxy;
             this.fileProvider = fileProvider;
+            this.feedManagerIo = feedManagerIo;
             privateRegistryFeeds = dependabotProxy?.RegistryURLs.ToImmutableHashSet() ?? [];
             HasPrivateRegistryFeeds = privateRegistryFeeds.Count > 0;
             emptyPackageDirectory = new DependencyDirectory("empty", "empty package", logger);
@@ -105,17 +98,9 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             });
         }
 
-        private string? GetDirectoryName(string path)
+        public FeedManager(ILogger logger, IDotNet dotnet, IDependabotProxy? dependabotProxy, IFileProvider fileProvider)
+            : this(logger, dotnet, dependabotProxy, fileProvider, new FeedManagerIO(logger, dependabotProxy))
         {
-            try
-            {
-                return new FileInfo(path).Directory?.FullName;
-            }
-            catch (Exception exc)
-            {
-                logger.LogWarning($"Failed to get directory of '{path}': {exc}");
-            }
-            return null;
         }
 
         private IEnumerable<string> GetFeeds(Func<IList<string>> getNugetFeeds)
@@ -193,7 +178,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         public IEnumerable<string> FeedsToUse(string path)
         {
             // Find the path specific feeds.
-            var folder = GetDirectoryName(path);
+            var folder = feedManagerIo.GetDirectoryName(path);
             var feedsToConsider = folder is not null ? GetFeedsFromFolder(folder).ToHashSet() : new HashSet<string>();
 
             return FeedsToUseAux(feedsToConsider);
@@ -236,76 +221,6 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             logger.LogDebug($"Number of tries for NuGet feed reachability check is {tryCount}.");
 
             return (timeoutMilliSeconds, tryCount);
-        }
-
-        private static async Task<HttpResponseMessage> ExecuteGetRequest(string address, HttpClient httpClient, CancellationToken cancellationToken)
-        {
-            return await httpClient.GetAsync(address, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
-        }
-
-        private bool IsFeedReachable(string feed, int timeoutMilliSeconds, int tryCount)
-        {
-            logger.LogInfo($"Checking if NuGet feed '{feed}' is reachable...");
-
-            // Configure the HttpClient to be aware of the Dependabot Proxy, if used.
-            HttpClientHandler httpClientHandler = new();
-            if (dependabotProxy != null)
-            {
-                httpClientHandler.Proxy = new WebProxy(dependabotProxy.Address);
-
-                if (dependabotProxy.Certificate != null)
-                {
-                    httpClientHandler.ServerCertificateCustomValidationCallback = (message, cert, chain, _) =>
-                    {
-                        if (chain is null || cert is null)
-                        {
-                            var msg = cert is null && chain is null
-                                ? "certificate and chain"
-                                : chain is null
-                                    ? "chain"
-                                    : "certificate";
-                            logger.LogWarning($"Dependabot proxy certificate validation failed due to missing {msg}");
-                            return false;
-                        }
-                        chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
-                        chain.ChainPolicy.CustomTrustStore.Add(dependabotProxy.Certificate);
-                        return chain.Build(cert);
-                    };
-                }
-            }
-
-            using HttpClient client = new(httpClientHandler);
-
-            for (var i = 0; i < tryCount; i++)
-            {
-                using var cts = new CancellationTokenSource();
-                cts.CancelAfter(timeoutMilliSeconds);
-                try
-                {
-                    logger.LogInfo($"Attempt {i + 1}/{tryCount} to reach NuGet feed '{feed}'.");
-                    using var response = ExecuteGetRequest(feed, client, cts.Token).GetAwaiter().GetResult();
-                    response.EnsureSuccessStatusCode();
-                    logger.LogInfo($"Querying NuGet feed '{feed}' succeeded.");
-                    return true;
-                }
-                catch (Exception exc)
-                {
-                    if (exc is TaskCanceledException tce &&
-                        tce.CancellationToken == cts.Token &&
-                        cts.Token.IsCancellationRequested)
-                    {
-                        logger.LogInfo($"Didn't receive answer from NuGet feed '{feed}' in {timeoutMilliSeconds}ms.");
-                        timeoutMilliSeconds *= 2;
-                        continue;
-                    }
-
-                    logger.LogInfo($"Querying NuGet feed '{feed}' failed. The reason for the failure: {exc.Message}");
-                    return false;
-                }
-            }
-
-            logger.LogWarning($"Didn't receive answer from NuGet feed '{feed}'. Tried it {tryCount} times.");
-            return false;
         }
 
         /// <summary>
@@ -361,7 +276,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             if (CheckNugetFeedResponsiveness)
             {
                 var (initialTimeout, tryCount) = GetFeedRequestSettings(isFallback: false);
-                return IsFeedReachable(PublicNugetOrgFeed, initialTimeout, tryCount);
+                return feedManagerIo.IsFeedReachable(PublicNugetOrgFeed, initialTimeout, tryCount);
             }
 
             return true;
@@ -380,7 +295,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
 
             var (initialTimeout, tryCount) = GetFeedRequestSettings(isFallback);
             var reachableFeeds = feedsToCheck
-                .Where(feed => IsFeedReachable(feed, initialTimeout, tryCount))
+                .Where(feed => feedManagerIo.IsFeedReachable(feed, initialTimeout, tryCount))
                 .ToList();
 
             if (reachableFeeds.Count == 0)
@@ -464,7 +379,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             if (nugetConfigs.Count > 0)
             {
                 var nugetConfigFeeds = nugetConfigs
-                    .Select(GetDirectoryName)
+                    .Select(feedManagerIo.GetDirectoryName)
                     .Where(folder => folder != null)
                     .SelectMany(folder => GetFeedsFromFolder(folder!))
                     .ToHashSet();

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/FeedManager.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/FeedManager.cs
@@ -157,19 +157,16 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         /// If there are no feeds, a dummy source argument is added to override any default feeds that `restore` would use.
         /// </summary>
         /// <param name="feeds">The list of feeds to use for the restore command.</param>
-        /// <param name="sourceArgumentPrefix">The prefix to use for each source argument (e.g., "-s").</param>
         /// <returns>The list of NuGet sources arguments for the restore command.</returns>
-        public List<string> FeedsToRestoreArgument(IEnumerable<string> feeds, string sourceArgumentPrefix)
+        public List<string> RestoreFeeds(IEnumerable<string> feeds)
         {
             // If there are no feeds, we want to override any default feeds that `restore` would use by passing a dummy source argument.
             if (!feeds.Any())
             {
-                return [sourceArgumentPrefix, emptyPackageDirectory.DirInfo.FullName];
+                return [emptyPackageDirectory.DirInfo.FullName];
             }
 
-            // Add package sources. If any are present, they override all sources specified in
-            // the configuration file(s).
-            return feeds.SelectMany<string, string>(feed => [sourceArgumentPrefix, feed]).ToList();
+            return feeds.ToList();
         }
 
         private IEnumerable<string> FeedsToUseAux(HashSet<string> feedsToConsider)
@@ -203,23 +200,13 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         }
 
         /// <summary>
-        /// Constructs the NuGet sources argument for the `dotnet restore` command based on the given feeds.
-        /// </summary>
-        /// <param name="feeds">The list of NuGet feeds to use for the restore command.</param>
-        /// <returns>A list representing the NuGet sources arguments for the `dotnet restore` command.</returns>
-        public List<string> FeedsToDotnetRestoreArgument(IEnumerable<string> feeds)
-        {
-            return FeedsToRestoreArgument(feeds, "-s");
-        }
-
-        /// <summary>
         /// Constructs the list of NuGet sources to use for dotnet restore.
         /// (1) Use the feeds we get from `dotnet nuget list source`
         /// (2) Use private registries, if they are configured
         /// </summary>
         /// <param name="path">Path to project/solution</param>
         /// <returns>A list representing the NuGet sources arguments for the `dotnet restore` command.</returns>
-        public List<string> MakeDotnetRestoreSourcesArguments(string path)
+        public List<string> MakeRestoreFeeds(string path)
         {
             // Do not construct a set of explicit NuGet sources to use for restore.
             if (!CheckNugetFeedResponsiveness && !HasPrivateRegistryFeeds)
@@ -229,7 +216,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
 
             var feedsToUse = FeedsToUse(path);
 
-            return FeedsToDotnetRestoreArgument(feedsToUse);
+            return RestoreFeeds(feedsToUse);
         }
 
         private (int initialTimeout, int tryCount) GetFeedRequestSettings(bool isFallback)

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/FeedManagerIO.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/FeedManagerIO.cs
@@ -1,0 +1,109 @@
+
+using System;
+using System.IO;
+using Semmle.Util.Logging;
+using System.Net.Http;
+using System.Net;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Semmle.Extraction.CSharp.DependencyFetching
+{
+    public class FeedManagerIO : IFeedManagerIO
+    {
+        private readonly ILogger logger;
+        private readonly IDependabotProxy? dependabotProxy;
+
+        public FeedManagerIO(ILogger logger, IDependabotProxy? dependabotProxy)
+        {
+            this.logger = logger;
+            this.dependabotProxy = dependabotProxy;
+        }
+
+        public string? GetDirectoryName(string path)
+        {
+            try
+            {
+                return new FileInfo(path).Directory?.FullName;
+            }
+            catch (Exception exc)
+            {
+                logger.LogWarning($"Failed to get directory of '{path}': {exc}");
+            }
+            return null;
+        }
+
+        private static async Task<HttpResponseMessage> ExecuteGetRequest(string address, HttpClient httpClient, CancellationToken cancellationToken)
+        {
+            return await httpClient.GetAsync(address, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+        }
+
+        public bool IsFeedReachable(string feed, int timeoutMilliSeconds, int tryCount)
+        {
+            logger.LogInfo($"Checking if NuGet feed '{feed}' is reachable...");
+
+            // Configure the HttpClient to be aware of the Dependabot Proxy, if used.
+            HttpClientHandler httpClientHandler = new();
+            if (dependabotProxy != null)
+            {
+                httpClientHandler.Proxy = new WebProxy(dependabotProxy.Address);
+
+                if (dependabotProxy.Certificate != null)
+                {
+                    httpClientHandler.ServerCertificateCustomValidationCallback = (message, cert, chain, _) =>
+                    {
+                        if (chain is null || cert is null)
+                        {
+                            var msg = cert is null && chain is null
+                                ? "certificate and chain"
+                                : chain is null
+                                    ? "chain"
+                                    : "certificate";
+                            logger.LogWarning($"Dependabot proxy certificate validation failed due to missing {msg}");
+                            return false;
+                        }
+                        chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
+                        chain.ChainPolicy.CustomTrustStore.Add(dependabotProxy.Certificate);
+                        return chain.Build(cert);
+                    };
+                }
+            }
+
+            using HttpClient client = new(httpClientHandler);
+
+            for (var i = 0; i < tryCount; i++)
+            {
+                using var cts = new CancellationTokenSource();
+                cts.CancelAfter(timeoutMilliSeconds);
+                try
+                {
+                    logger.LogInfo($"Attempt {i + 1}/{tryCount} to reach NuGet feed '{feed}'.");
+                    using var response = ExecuteGetRequest(feed, client, cts.Token).GetAwaiter().GetResult();
+                    response.EnsureSuccessStatusCode();
+                    logger.LogInfo($"Querying NuGet feed '{feed}' succeeded.");
+                    return true;
+                }
+                catch (Exception exc)
+                {
+                    if (exc is TaskCanceledException tce &&
+                        tce.CancellationToken == cts.Token &&
+                        cts.Token.IsCancellationRequested)
+                    {
+                        logger.LogInfo($"Didn't receive answer from NuGet feed '{feed}' in {timeoutMilliSeconds}ms.");
+                        timeoutMilliSeconds *= 2;
+                        continue;
+                    }
+
+                    logger.LogInfo($"Querying NuGet feed '{feed}' failed. The reason for the failure: {exc.Message}");
+                    return false;
+                }
+            }
+
+            logger.LogWarning($"Didn't receive answer from NuGet feed '{feed}'. Tried it {tryCount} times.");
+            return false;
+        }
+
+
+    }
+}

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/FileProvider.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/FileProvider.cs
@@ -2,12 +2,11 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Security.Policy;
 using Semmle.Util.Logging;
 
 namespace Semmle.Extraction.CSharp.DependencyFetching
 {
-    public class FileProvider
+    public class FileProvider : IFileProvider
     {
         private static readonly HashSet<string> binaryFileExtensions = [".dll", ".exe"]; // TODO: add more binary file extensions.
 

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/IDependabotProxy.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/IDependabotProxy.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Semmle.Extraction.CSharp.DependencyFetching
+{
+    public interface IDependabotProxy : IDisposable
+    {
+        /// <summary>
+        /// The full address of the Dependabot proxy, if available.
+        /// </summary>
+        string Address { get; }
+
+        /// <summary>
+        /// The URLs of package registries that are configured for the proxy.
+        /// </summary>
+        HashSet<string> RegistryURLs { get; }
+
+        /// <summary>
+        /// The path to the temporary file where the certificate is stored.
+        /// </summary>
+        string? CertificatePath { get; }
+
+        /// <summary>
+        /// The certificate used for the Dependabot proxy.
+        /// </summary>
+        X509Certificate2? Certificate { get; }
+    }
+}

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/IFeedManagerIO.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/IFeedManagerIO.cs
@@ -1,0 +1,16 @@
+
+namespace Semmle.Extraction.CSharp.DependencyFetching
+{
+    public interface IFeedManagerIO
+    {
+        /// <summary>
+        /// Gets the directory name of the specified path.
+        /// </summary>
+        string? GetDirectoryName(string path);
+
+        /// <summary>
+        /// Returns true if the feed is reachable within the specified timeout and try count.
+        /// </summary>
+        bool IsFeedReachable(string feed, int timeoutMilliSeconds, int tryCount);
+    }
+}

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/IFileProvider.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/IFileProvider.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using System.IO;
+
+namespace Semmle.Extraction.CSharp.DependencyFetching
+{
+    public interface IFileProvider
+    {
+        DirectoryInfo SourceDir { get; }
+        IEnumerable<string> SmallNonBinary { get; }
+        IEnumerable<string> Sources { get; }
+        ICollection<string> Projects { get; }
+        ICollection<string> Solutions { get; }
+        IEnumerable<string> Dlls { get; }
+        ICollection<string> NugetConfigs { get; }
+        ICollection<string> NugetExes { get; }
+        string? RootNugetConfig { get; }
+        IEnumerable<string> GlobalJsons { get; }
+        ICollection<string> PackagesConfigs { get; }
+        ICollection<string> RazorViews { get; }
+        ICollection<string> Resources { get; }
+    }
+}

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/NugetPackageRestorer.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/NugetPackageRestorer.cs
@@ -15,7 +15,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
 {
     internal sealed partial class NugetPackageRestorer : IDisposable
     {
-        private readonly FileProvider fileProvider;
+        private readonly IFileProvider fileProvider;
         private readonly FileContent fileContent;
         private readonly IDotNet dotnet;
         private readonly IDiagnosticsWriter diagnosticsWriter;
@@ -29,7 +29,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
 
 
         public NugetPackageRestorer(
-            FileProvider fileProvider,
+            IFileProvider fileProvider,
             FileContent fileContent,
             IDotNet dotnet,
             DependabotProxy? dependabotProxy,

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/NugetPackageRestorer.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/NugetPackageRestorer.cs
@@ -53,7 +53,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         public string? TryRestore(string package)
         {
             var feeds = feedManager.CheckNugetFeedResponsiveness ? feedManager.ReachableFeeds : feedManager.AllFeeds;
-            var nugetSources = feedManager.FeedsToDotnetRestoreArgument(feeds);
+            var nugetSources = feedManager.RestoreFeeds(feeds);
             if (TryRestorePackageManually(package, nugetSources))
             {
                 var packageDir = DependencyManager.GetPackageDirectory(package, missingPackageDirectory.DirInfo);
@@ -216,7 +216,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             var projects = fileProvider.Solutions.SelectMany(solution =>
                 {
                     logger.LogInfo($"Restoring solution {solution}...");
-                    var nugetSources = feedManager.MakeDotnetRestoreSourcesArguments(solution);
+                    var nugetSources = feedManager.MakeRestoreFeeds(solution);
                     var res = dotnet.Restore(new(solution, PackageDirectory.DirInfo.FullName, ForceDotnetRefAssemblyFetching: true, NugetSources: nugetSources, TargetWindows: isWindows));
                     if (res.Success)
                     {
@@ -264,7 +264,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                 foreach (var project in projectGroup)
                 {
                     logger.LogInfo($"Restoring project {project}...");
-                    var nugetSources = feedManager.MakeDotnetRestoreSourcesArguments(project);
+                    var nugetSources = feedManager.MakeRestoreFeeds(project);
                     var res = dotnet.Restore(new(project, PackageDirectory.DirInfo.FullName, ForceDotnetRefAssemblyFetching: true, NugetSources: nugetSources, TargetWindows: isWindows));
                     assets.AddDependenciesRange(res.AssetsFilePaths);
                     lock (sync)
@@ -312,7 +312,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                 feeds = feedManager.AllFeeds;
             }
 
-            var nugetSources = feedManager.FeedsToDotnetRestoreArgument(feeds);
+            var nugetSources = feedManager.RestoreFeeds(feeds);
             var alreadyDownloadedPackages = usedPackageNames.Select(p => p.ToLowerInvariant());
             var alreadyDownloadedLegacyPackages = GetRestoredLegacyPackageNames();
 

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/NugetPackageRestorer.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/NugetPackageRestorer.cs
@@ -32,7 +32,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             IFileProvider fileProvider,
             FileContent fileContent,
             IDotNet dotnet,
-            DependabotProxy? dependabotProxy,
+            IDependabotProxy? dependabotProxy,
             IDiagnosticsWriter diagnosticsWriter,
             ILogger logger,
             ICompilationInfoContainer compilationInfoContainer)

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/PackagesConfigRestorer.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/PackagesConfigRestorer.cs
@@ -33,7 +33,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
     /// </summary>
     internal class PackagesConfigRestoreFactory
     {
-        public static IPackagesConfigRestore Create(FileProvider fileProvider, DependencyDirectory packageDirectory, Semmle.Util.Logging.ILogger logger, FeedManager feedManager)
+        public static IPackagesConfigRestore Create(IFileProvider fileProvider, DependencyDirectory packageDirectory, Semmle.Util.Logging.ILogger logger, FeedManager feedManager)
         {
             if (SystemBuildActions.Instance.IsWindows() || SystemBuildActions.Instance.IsMonoInstalled())
             {
@@ -55,7 +55,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
 
             public int PackageCount => fileProvider.PackagesConfigs.Count;
 
-            private readonly FileProvider fileProvider;
+            private readonly IFileProvider fileProvider;
 
             /// <summary>
             /// The packages directory.
@@ -74,7 +74,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             /// <summary>
             /// Create the package manager for a specified source tree.
             /// </summary>
-            public NugetExeWrapper(FileProvider fileProvider, DependencyDirectory packageDirectory, Semmle.Util.Logging.ILogger logger, FeedManager feedManager)
+            public NugetExeWrapper(IFileProvider fileProvider, DependencyDirectory packageDirectory, Semmle.Util.Logging.ILogger logger, FeedManager feedManager)
             {
                 this.fileProvider = fileProvider;
                 this.packageDirectory = packageDirectory;

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/PackagesConfigRestorer.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/PackagesConfigRestorer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -180,7 +179,8 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                     {
                         feedsToUse.Add(FeedManager.PublicNugetOrgFeed);
                     }
-                    sourcesArgument = feedManager.FeedsToRestoreArgument(feedsToUse, "-Source");
+                    var restoreFeeds = feedManager.RestoreFeeds(feedsToUse);
+                    sourcesArgument = restoreFeeds.SelectMany<string, string>(feed => ["-Source", feed]).ToList();
                 }
 
                 /* Use nuget.exe to install a package.

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/SourceGenerators/DotnetSourceGeneratorBase.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/SourceGenerators/DotnetSourceGeneratorBase.cs
@@ -9,14 +9,14 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
 {
     internal abstract class DotnetSourceGeneratorBase<T> : SourceGeneratorBase where T : DotnetSourceGeneratorWrapper
     {
-        protected readonly FileProvider fileProvider;
+        protected readonly IFileProvider fileProvider;
         protected readonly FileContent fileContent;
         protected readonly IDotNet dotnet;
         protected readonly ICompilationInfoContainer compilationInfoContainer;
         protected readonly IEnumerable<string> references;
 
         public DotnetSourceGeneratorBase(
-            FileProvider fileProvider,
+            IFileProvider fileProvider,
             FileContent fileContent,
             IDotNet dotnet,
             ICompilationInfoContainer compilationInfoContainer,

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/SourceGenerators/RazorGenerator.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/SourceGenerators/RazorGenerator.cs
@@ -8,7 +8,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
     internal class RazorGenerator : DotnetSourceGeneratorBase<Razor>
     {
         public RazorGenerator(
-            FileProvider fileProvider,
+            IFileProvider fileProvider,
             FileContent fileContent,
             IDotNet dotnet,
             ICompilationInfoContainer compilationInfoContainer,

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/SourceGenerators/ResxGenerator.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/SourceGenerators/ResxGenerator.cs
@@ -10,7 +10,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         private readonly string? sourceGeneratorFolder = null;
 
         public ResxGenerator(
-            FileProvider fileProvider,
+            IFileProvider fileProvider,
             FileContent fileContent,
             IDotNet dotnet,
             ICompilationInfoContainer compilationInfoContainer,

--- a/csharp/extractor/Semmle.Extraction.Tests/DotNet.cs
+++ b/csharp/extractor/Semmle.Extraction.Tests/DotNet.cs
@@ -148,7 +148,7 @@ namespace Semmle.Extraction.Tests
             var dotnet = MakeDotnet(dotnetCliInvoker);
 
             // Execute
-            var res = dotnet.Restore(new("myproject.csproj", "mypackages", false, ["-s", "https://my.nuget.source1"], true));
+            var res = dotnet.Restore(new("myproject.csproj", "mypackages", false, ["https://my.nuget.source1"], true));
 
             // Verify
             var lastArgs = dotnetCliInvoker.GetLastArgs();
@@ -166,7 +166,7 @@ namespace Semmle.Extraction.Tests
             var dotnet = MakeDotnet(dotnetCliInvoker);
 
             // Execute
-            var res = dotnet.Restore(new("mysolution.sln", "mypackages", false, ["-s", "https://my.nuget.source1", "-s", "https://my.nuget.source2"]));
+            var res = dotnet.Restore(new("mysolution.sln", "mypackages", false, ["https://my.nuget.source1", "https://my.nuget.source2"]));
 
             // Verify
             var lastArgs = dotnetCliInvoker.GetLastArgs();

--- a/csharp/extractor/Semmle.Extraction.Tests/DotNet.cs
+++ b/csharp/extractor/Semmle.Extraction.Tests/DotNet.cs
@@ -148,11 +148,11 @@ namespace Semmle.Extraction.Tests
             var dotnet = MakeDotnet(dotnetCliInvoker);
 
             // Execute
-            var res = dotnet.Restore(new("myproject.csproj", "mypackages", false, [], true));
+            var res = dotnet.Restore(new("myproject.csproj", "mypackages", false, ["-s", "https://my.nuget.source1"], true));
 
             // Verify
             var lastArgs = dotnetCliInvoker.GetLastArgs();
-            Assert.Equal(["restore", "--no-dependencies", "myproject.csproj", "--packages", "mypackages", "/p:DisableImplicitNuGetFallbackFolder=true", "--verbosity", "normal", "--force"], lastArgs);
+            Assert.Equal(["restore", "--no-dependencies", "myproject.csproj", "--packages", "mypackages", "/p:DisableImplicitNuGetFallbackFolder=true", "--verbosity", "normal", "--force", "-s", "https://my.nuget.source1"], lastArgs);
             Assert.Equal(2, res.AssetsFilePaths.Count());
             Assert.Contains("/path/to/project.assets.json", res.AssetsFilePaths);
             Assert.Contains("/path/to/project2.assets.json", res.AssetsFilePaths);
@@ -166,11 +166,11 @@ namespace Semmle.Extraction.Tests
             var dotnet = MakeDotnet(dotnetCliInvoker);
 
             // Execute
-            var res = dotnet.Restore(new("mysolution.sln", "mypackages", false, []));
+            var res = dotnet.Restore(new("mysolution.sln", "mypackages", false, ["-s", "https://my.nuget.source1", "-s", "https://my.nuget.source2"]));
 
             // Verify
             var lastArgs = dotnetCliInvoker.GetLastArgs();
-            Assert.Equal(["restore", "--no-dependencies", "mysolution.sln", "--packages", "mypackages", "/p:DisableImplicitNuGetFallbackFolder=true", "--verbosity", "normal"], lastArgs);
+            Assert.Equal(["restore", "--no-dependencies", "mysolution.sln", "--packages", "mypackages", "/p:DisableImplicitNuGetFallbackFolder=true", "--verbosity", "normal", "-s", "https://my.nuget.source1", "-s", "https://my.nuget.source2"], lastArgs);
             Assert.Equal(2, res.RestoredProjects.Count());
             Assert.Contains("/path/to/project.csproj", res.RestoredProjects);
             Assert.Contains("/path/to/project2.csproj", res.RestoredProjects);

--- a/csharp/extractor/Semmle.Extraction.Tests/DotNetStub.cs
+++ b/csharp/extractor/Semmle.Extraction.Tests/DotNetStub.cs
@@ -8,11 +8,15 @@ namespace Semmle.Extraction.Tests
     {
         private readonly IList<string> runtimes;
         private readonly IList<string> sdks;
+        private readonly IList<string> nugetFeedsFromConfig;
+        private readonly IList<string> nugetFeedsFromFolder;
 
-        public DotNetStub(IList<string> runtimes, IList<string> sdks)
+        public DotNetStub(IList<string> runtimes, IList<string> sdks, IList<string> nugetFeedsFromConfig, IList<string> nugetFeedsFromFolder)
         {
             this.runtimes = runtimes;
             this.sdks = sdks;
+            this.nugetFeedsFromConfig = nugetFeedsFromConfig;
+            this.nugetFeedsFromFolder = nugetFeedsFromFolder;
         }
         public bool AddPackage(string folder, string package) => true;
 
@@ -26,8 +30,8 @@ namespace Semmle.Extraction.Tests
 
         public bool Exec(List<string> execArgs) => true;
 
-        public IList<string> GetNugetFeeds(string nugetConfig) => [];
+        public IList<string> GetNugetFeeds(string nugetConfig) => nugetFeedsFromConfig;
 
-        public IList<string> GetNugetFeedsFromFolder(string folderPath) => [];
+        public IList<string> GetNugetFeedsFromFolder(string folderPath) => nugetFeedsFromFolder;
     }
 }

--- a/csharp/extractor/Semmle.Extraction.Tests/DotNetStub.cs
+++ b/csharp/extractor/Semmle.Extraction.Tests/DotNetStub.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using Semmle.Extraction.CSharp.DependencyFetching;
+
+namespace Semmle.Extraction.Tests
+{
+    internal class DotNetStub : IDotNet
+    {
+        private readonly IList<string> runtimes;
+        private readonly IList<string> sdks;
+
+        public DotNetStub(IList<string> runtimes, IList<string> sdks)
+        {
+            this.runtimes = runtimes;
+            this.sdks = sdks;
+        }
+        public bool AddPackage(string folder, string package) => true;
+
+        public bool New(string folder) => true;
+
+        public RestoreResult Restore(RestoreSettings restoreSettings) => new(true, Array.Empty<string>());
+
+        public IList<string> GetListedRuntimes() => runtimes;
+
+        public IList<string> GetListedSdks() => sdks;
+
+        public bool Exec(List<string> execArgs) => true;
+
+        public IList<string> GetNugetFeeds(string nugetConfig) => [];
+
+        public IList<string> GetNugetFeedsFromFolder(string folderPath) => [];
+    }
+}

--- a/csharp/extractor/Semmle.Extraction.Tests/FeedManager.cs
+++ b/csharp/extractor/Semmle.Extraction.Tests/FeedManager.cs
@@ -1,0 +1,187 @@
+using Xunit;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Semmle.Extraction.CSharp.DependencyFetching;
+
+namespace Semmle.Extraction.Tests
+{
+    public class DependabotProxyStub : IDependabotProxy
+    {
+        public string Address { get; } = "";
+        public HashSet<string> RegistryURLs { get; } = ["https://example.com/registry1", "https://example.com/registry2"];
+        public string? CertificatePath { get; } = null;
+        public System.Security.Cryptography.X509Certificates.X509Certificate2? Certificate { get; } = null;
+
+        public void Dispose() { }
+    }
+
+    public class FeedManagerIOStub : IFeedManagerIO
+    {
+        private readonly List<string> unreachableFeeds;
+
+        public FeedManagerIOStub(List<string> unreachableFeeds)
+        {
+            this.unreachableFeeds = unreachableFeeds;
+        }
+
+        public string? GetDirectoryName(string path)
+        {
+            return "/path/to/folder";
+        }
+
+        public bool IsFeedReachable(string feed, int timeoutMilliSeconds, int tryCount)
+        {
+            return !unreachableFeeds.Contains(feed);
+        }
+    }
+
+    public class FileProviderStub : IFileProvider
+    {
+        public DirectoryInfo SourceDir { get; } = new DirectoryInfo("/path/to/source");
+        public IEnumerable<string> SmallNonBinary { get; } = Enumerable.Empty<string>();
+        public IEnumerable<string> Sources { get; } = Enumerable.Empty<string>();
+        public ICollection<string> Projects { get; } = new List<string>();
+        public ICollection<string> Solutions { get; } = new List<string>();
+        public IEnumerable<string> Dlls { get; } = Enumerable.Empty<string>();
+        public ICollection<string> NugetConfigs { get; } = ["/path/to/nuget.config"];
+        public ICollection<string> NugetExes { get; } = new List<string>();
+        public string? RootNugetConfig { get; } = null;
+        public IEnumerable<string> GlobalJsons { get; } = Enumerable.Empty<string>();
+        public ICollection<string> PackagesConfigs { get; } = new List<string>();
+        public ICollection<string> RazorViews { get; } = new List<string>();
+        public ICollection<string> Resources { get; } = new List<string>();
+    }
+
+    public class FeedManagerTests
+    {
+        private static FeedManager MakeFeedManager()
+        {
+            var logger = new LoggerStub();
+            var dotnet = new DotNetStub([], [], ["E https://feed.from/config"], ["E https://feed.from/folder1", "E https://feed.from/folder2", "D https://feed.from/folder3"]);
+            var dependabotProxy = new DependabotProxyStub();
+            var fileProvider = new FileProviderStub();
+            var feedManagerIo = new FeedManagerIOStub(["https://example.com/registry1", "https://feed.from/folder2"]);
+            return new FeedManager(logger, dotnet, dependabotProxy, fileProvider, feedManagerIo);
+        }
+
+        [Fact]
+        public void TestExplicitFeeds()
+        {
+            // Setup
+            var feedManager = MakeFeedManager();
+
+            // Execute
+            var actualFeeds = feedManager.ExplicitFeeds;
+
+            // Verify
+            Assert.Equal([
+                "https://example.com/registry1",
+                "https://example.com/registry2",
+                "https://feed.from/config"
+            ], actualFeeds);
+        }
+
+        [Fact]
+        public void TestInheritedFeeds()
+        {
+            // Setup
+            var feedManager = MakeFeedManager();
+
+            // Execute
+            var inherited = feedManager.InheritedFeeds;
+
+            // Verify
+            Assert.Equal([
+                "https://feed.from/folder1",
+                "https://feed.from/folder2"
+            ], inherited);
+        }
+
+        [Fact]
+        public void TestAllFeeds()
+        {
+            // Setup
+            var feedManager = MakeFeedManager();
+
+            // Execute
+            var all = feedManager.AllFeeds;
+
+            // Verify
+            Assert.Equal([
+                "https://example.com/registry1",
+                "https://example.com/registry2",
+                "https://feed.from/config",
+                "https://feed.from/folder1",
+                "https://feed.from/folder2"
+            ], all);
+        }
+
+        [Fact]
+        public void TestReachableFeeds()
+        {
+            // Setup
+            var feedManager = MakeFeedManager();
+
+            // Execute
+            var reachableFeeds = feedManager.ReachableFeeds;
+
+            // Verify
+            Assert.Equal([
+                "https://example.com/registry2",
+                "https://feed.from/config",
+                "https://feed.from/folder1"
+            ], reachableFeeds);
+        }
+
+        [Fact]
+        public void TestReachableExplicitFeeds()
+        {
+            // Setup
+            var feedManager = MakeFeedManager();
+
+            // Execute
+            var reachableFeeds = feedManager.ReachableExplicitFeeds;
+
+            // Verify
+            Assert.Equal([
+                "https://example.com/registry2",
+                "https://feed.from/config"
+            ], reachableFeeds);
+        }
+
+        [Fact]
+        public void TestReachableFallbackFeeds()
+        {
+            // Setup
+            var feedManager = MakeFeedManager();
+
+            // Execute
+            var reachableFallback = feedManager.ReachableFallbackFeeds;
+
+            // Verify
+            Assert.Equal([
+                "https://example.com/registry2",
+                "https://feed.from/config",
+                "https://api.nuget.org/v3/index.json"
+            ], reachableFallback);
+        }
+
+        [Fact]
+        public void TestFeedsToUse()
+        {
+            // Setup
+            var feedManager = MakeFeedManager();
+
+            // Execute
+            var feedsToUse = feedManager.FeedsToUse("/path/to/packages.config").ToHashSet();
+
+            // Verify
+            Assert.Equal([
+                "https://example.com/registry2",
+                "https://feed.from/folder1"
+            ], feedsToUse);
+        }
+    }
+}

--- a/csharp/extractor/Semmle.Extraction.Tests/Runtime.cs
+++ b/csharp/extractor/Semmle.Extraction.Tests/Runtime.cs
@@ -5,33 +5,6 @@ using Semmle.Extraction.CSharp.DependencyFetching;
 
 namespace Semmle.Extraction.Tests
 {
-    internal class DotNetStub : IDotNet
-    {
-        private readonly IList<string> runtimes;
-        private readonly IList<string> sdks;
-
-        public DotNetStub(IList<string> runtimes, IList<string> sdks)
-        {
-            this.runtimes = runtimes;
-            this.sdks = sdks;
-        }
-        public bool AddPackage(string folder, string package) => true;
-
-        public bool New(string folder) => true;
-
-        public RestoreResult Restore(RestoreSettings restoreSettings) => new(true, Array.Empty<string>());
-
-        public IList<string> GetListedRuntimes() => runtimes;
-
-        public IList<string> GetListedSdks() => sdks;
-
-        public bool Exec(List<string> execArgs) => true;
-
-        public IList<string> GetNugetFeeds(string nugetConfig) => [];
-
-        public IList<string> GetNugetFeedsFromFolder(string folderPath) => [];
-    }
-
     public class RuntimeTests
     {
         private static string FixExpectedPathOnWindows(string path) => path.Replace('\\', '/');

--- a/csharp/extractor/Semmle.Extraction.Tests/Runtime.cs
+++ b/csharp/extractor/Semmle.Extraction.Tests/Runtime.cs
@@ -9,6 +9,8 @@ namespace Semmle.Extraction.Tests
     {
         private static string FixExpectedPathOnWindows(string path) => path.Replace('\\', '/');
 
+        private static DotNetStub MakeDotNetStub(IList<string> listedRuntimes) => new DotNetStub(listedRuntimes, null!, [], []);
+
         [Fact]
         public void TestRuntime1()
         {
@@ -23,7 +25,7 @@ namespace Semmle.Extraction.Tests
                 "Microsoft.NETCore.App 7.0.0 [/path/dotnet/shared/Microsoft.NETCore.App]",
                 "Microsoft.NETCore.App 7.0.2 [/path/dotnet/shared/Microsoft.NETCore.App]"
                 };
-            var dotnet = new DotNetStub(listedRuntimes, null!);
+            var dotnet = MakeDotNetStub(listedRuntimes);
             var runtime = new Runtime(dotnet);
 
             // Execute
@@ -49,7 +51,7 @@ namespace Semmle.Extraction.Tests
                 "Microsoft.NETCore.App 8.0.0-preview.5.43280.8 [/path/dotnet/shared/Microsoft.NETCore.App]",
                 "Microsoft.NETCore.App 8.0.0-preview.5.23280.8 [/path/dotnet/shared/Microsoft.NETCore.App]"
             };
-            var dotnet = new DotNetStub(listedRuntimes, null!);
+            var dotnet = new DotNetStub(listedRuntimes, null!, [], []);
             var runtime = new Runtime(dotnet);
 
             // Execute
@@ -72,7 +74,7 @@ namespace Semmle.Extraction.Tests
                 "Microsoft.NETCore.App 8.0.0-rc.4.43280.8 [/path/dotnet/shared/Microsoft.NETCore.App]",
                 "Microsoft.NETCore.App 8.0.0-preview.5.23280.8 [/path/dotnet/shared/Microsoft.NETCore.App]"
             };
-            var dotnet = new DotNetStub(listedRuntimes, null!);
+            var dotnet = MakeDotNetStub(listedRuntimes);
             var runtime = new Runtime(dotnet);
 
             // Execute
@@ -101,7 +103,7 @@ namespace Semmle.Extraction.Tests
                 @"Microsoft.WindowsDesktop.App 6.0.20 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]",
                 @"Microsoft.WindowsDesktop.App 7.0.4 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]"
             };
-            var dotnet = new DotNetStub(listedRuntimes, null!);
+            var dotnet = MakeDotNetStub(listedRuntimes);
             var runtime = new Runtime(dotnet);
 
             // Execute
@@ -122,6 +124,7 @@ namespace Semmle.Extraction.Tests
     {
         private static string FixExpectedPathOnWindows(string path) => path.Replace('\\', '/');
 
+        private static DotNetStub MakeDotNetStub(IList<string> listedSdks) => new DotNetStub(null!, listedSdks, [], []);
         [Fact]
         public void TestSdk1()
         {
@@ -136,7 +139,7 @@ namespace Semmle.Extraction.Tests
                 "6.0.102 [/usr/local/share/dotnet/sdk6]",
                 "6.0.301 [/usr/local/share/dotnet/sdk7]",
             };
-            var dotnet = new DotNetStub(null!, listedSdks);
+            var dotnet = MakeDotNetStub(listedSdks);
             var sdk = new Sdk(dotnet, new LoggerStub());
 
             // Execute
@@ -158,7 +161,7 @@ namespace Semmle.Extraction.Tests
                 "8.0.100-preview.7.23376.3 [/usr/local/share/dotnet/sdk3]",
                 "7.0.400 [/usr/local/share/dotnet/sdk4]",
             };
-            var dotnet = new DotNetStub(null!, listedSdks);
+            var dotnet = MakeDotNetStub(listedSdks);
             var sdk = new Sdk(dotnet, new LoggerStub());
 
             // Execute


### PR DESCRIPTION
In this PR we
- Re-factor the FeedManager to enable unit testing.
- Add some unit tests.

This is in preparation for using feeds configured via the dependabot proxy as "base" feed(s) (instead of the current hardcoded public `nuget.org` feed).

DCA looks good.