### PR TITLE
FlowSummaryImpl: Model more source/sink steps as jump steps

### DIFF
--- a/cpp/ql/test/library-tests/dataflow/external-models/flow.expected
+++ b/cpp/ql/test/library-tests/dataflow/external-models/flow.expected
@@ -240,6 +240,7 @@ edges
 | test.cpp:223:12:223:12 | *s | test.cpp:223:13:223:15 | call to operator[] | provenance | MaD:87 |
 | test.cpp:223:13:223:15 | call to operator[] | test.cpp:223:13:223:15 | call to operator[] | provenance |  |
 | test.cpp:223:13:223:15 | call to operator[] | test.cpp:224:11:224:11 | c | provenance | Sink:MaD:3 |
+| test.cpp:242:29:242:29 | *s [value] | test.cpp:243:10:243:10 | *s [value] | provenance |  |
 | test.cpp:243:10:243:10 | *s [value] | test.cpp:243:13:243:17 | value | provenance |  |
 | test.cpp:243:13:243:17 | value | test.cpp:243:13:243:17 | value | provenance | Sink:MaD:3 |
 | test.cpp:247:26:247:39 | call to ymlFieldSource | test.cpp:247:26:247:39 | call to ymlFieldSource [value] | provenance | Src:MaD:47  |
@@ -247,35 +248,41 @@ edges
 | test.cpp:248:10:248:16 | *wrapper [value] | test.cpp:248:18:248:22 | value | provenance |  |
 | test.cpp:248:18:248:22 | value | test.cpp:248:18:248:22 | value | provenance | Sink:MaD:3 |
 | test.cpp:250:32:250:32 | source_from_callback_template output argument | test.cpp:250:32:250:32 | source_from_callback_template output argument [value] | provenance | Src:MaD:40  |
-| test.cpp:250:32:250:32 | source_from_callback_template output argument [value] | test.cpp:243:10:243:10 | *s [value] | provenance |  |
+| test.cpp:250:32:250:32 | source_from_callback_template output argument [value] | test.cpp:242:29:242:29 | *s [value] | provenance |  |
 | test.cpp:251:27:251:27 | source_from_callback_ptr output argument | test.cpp:251:27:251:27 | source_from_callback_ptr output argument [value] | provenance | Src:MaD:37  |
-| test.cpp:251:27:251:27 | source_from_callback_ptr output argument [value] | test.cpp:243:10:243:10 | *s [value] | provenance |  |
+| test.cpp:251:27:251:27 | source_from_callback_ptr output argument [value] | test.cpp:242:29:242:29 | *s [value] | provenance |  |
+| test.cpp:257:35:257:35 | *s [value] | test.cpp:258:12:258:12 | *s [value] | provenance |  |
 | test.cpp:258:12:258:12 | *s [value] | test.cpp:258:15:258:19 | value | provenance |  |
 | test.cpp:258:15:258:19 | value | test.cpp:258:15:258:19 | value | provenance | Sink:MaD:3 |
 | test.cpp:262:27:262:31 | source_from_callback_ptr output argument | test.cpp:262:27:262:31 | source_from_callback_ptr output argument [value] | provenance | Src:MaD:37  |
-| test.cpp:262:27:262:31 | source_from_callback_ptr output argument [value] | test.cpp:243:10:243:10 | *s [value] | provenance |  |
-| test.cpp:262:27:262:31 | source_from_callback_ptr output argument [value] | test.cpp:258:12:258:12 | *s [value] | provenance |  |
+| test.cpp:262:27:262:31 | source_from_callback_ptr output argument [value] | test.cpp:242:29:242:29 | *s [value] | provenance |  |
+| test.cpp:262:27:262:31 | source_from_callback_ptr output argument [value] | test.cpp:257:35:257:35 | *s [value] | provenance |  |
 | test.cpp:264:32:266:2 | source_from_callback_template output argument | test.cpp:264:32:266:2 | source_from_callback_template output argument [value] | provenance | Src:MaD:40  |
-| test.cpp:264:32:266:2 | source_from_callback_template output argument [value] | test.cpp:265:11:265:11 | *s [value] | provenance |  |
+| test.cpp:264:32:266:2 | source_from_callback_template output argument [value] | test.cpp:264:56:264:56 | *s [value] | provenance |  |
+| test.cpp:264:56:264:56 | *s [value] | test.cpp:265:11:265:11 | *s [value] | provenance |  |
 | test.cpp:265:11:265:11 | *s [value] | test.cpp:265:14:265:18 | value | provenance |  |
 | test.cpp:265:14:265:18 | value | test.cpp:265:14:265:18 | value | provenance | Sink:MaD:3 |
 | test.cpp:268:27:268:27 | source_from_callback_ptr output argument | test.cpp:268:27:268:27 | source_from_callback_ptr output argument [value] | provenance | Src:MaD:37  |
-| test.cpp:268:27:268:27 | source_from_callback_ptr output argument [value] | test.cpp:269:11:269:11 | *s [value] | provenance |  |
+| test.cpp:268:27:268:27 | source_from_callback_ptr output argument [value] | test.cpp:268:51:268:51 | *s [value] | provenance |  |
+| test.cpp:268:51:268:51 | *s [value] | test.cpp:269:11:269:11 | *s [value] | provenance |  |
 | test.cpp:269:11:269:11 | *s [value] | test.cpp:269:14:269:18 | value | provenance |  |
 | test.cpp:269:14:269:18 | value | test.cpp:269:14:269:18 | value | provenance | Sink:MaD:3 |
+| test.cpp:273:40:273:40 | *s [value] | test.cpp:274:12:274:12 | *s [value] | provenance |  |
 | test.cpp:274:12:274:12 | *s [value] | test.cpp:274:15:274:19 | value | provenance |  |
 | test.cpp:274:15:274:19 | value | test.cpp:274:15:274:19 | value | provenance | Sink:MaD:3 |
 | test.cpp:278:32:278:34 | source_from_callback_template output argument | test.cpp:278:32:278:34 | source_from_callback_template output argument [value] | provenance | Src:MaD:40  |
-| test.cpp:278:32:278:34 | source_from_callback_template output argument [value] | test.cpp:274:12:274:12 | *s [value] | provenance |  |
+| test.cpp:278:32:278:34 | source_from_callback_template output argument [value] | test.cpp:273:40:273:40 | *s [value] | provenance |  |
 | test.cpp:293:5:293:26 | *callback_returning_int | test.cpp:307:10:307:31 | call to callback_returning_int | provenance |  |
 | test.cpp:294:5:294:28 | *callback_returning_int_2 | test.cpp:310:10:310:33 | call to callback_returning_int_2 | provenance |  |
 | test.cpp:295:6:295:31 | **callback_returning_ptr_int | test.cpp:313:13:313:38 | *call to callback_returning_ptr_int | provenance |  |
+| test.cpp:297:5:297:20 | *return_ymlSource | test.cpp:318:37:318:52 | return_ymlSource | provenance | Sink:MaD:1 |
+| test.cpp:297:33:297:41 | call to ymlSource | test.cpp:297:5:297:20 | *return_ymlSource | provenance |  |
+| test.cpp:297:33:297:41 | call to ymlSource | test.cpp:297:5:297:20 | *return_ymlSource | provenance | Src:MaD:48  |
 | test.cpp:297:33:297:41 | call to ymlSource | test.cpp:297:33:297:41 | call to ymlSource | provenance | Src:MaD:48  |
-| test.cpp:297:33:297:41 | call to ymlSource | test.cpp:318:37:318:52 | return_ymlSource | provenance | Sink:MaD:1 |
-| test.cpp:297:33:297:41 | call to ymlSource | test.cpp:318:37:318:52 | return_ymlSource | provenance | Src:MaD:48  Sink:MaD:1 |
-| test.cpp:299:41:299:52 | *call to ymlSourcePtr | test.cpp:321:36:321:58 | return_ptr_to_ymlSource | provenance | Sink:MaD:2 |
+| test.cpp:299:6:299:28 | **return_ptr_to_ymlSource | test.cpp:321:36:321:58 | return_ptr_to_ymlSource | provenance | Sink:MaD:2 |
+| test.cpp:299:41:299:52 | *call to ymlSourcePtr | test.cpp:299:6:299:28 | **return_ptr_to_ymlSource | provenance |  |
+| test.cpp:299:41:299:52 | call to ymlSourcePtr | test.cpp:299:6:299:28 | **return_ptr_to_ymlSource | provenance | Src:MaD:49  |
 | test.cpp:299:41:299:52 | call to ymlSourcePtr | test.cpp:299:41:299:52 | *call to ymlSourcePtr | provenance | Src:MaD:49  |
-| test.cpp:299:41:299:52 | call to ymlSourcePtr | test.cpp:321:36:321:58 | return_ptr_to_ymlSource | provenance | Src:MaD:49  Sink:MaD:2 |
 | test.cpp:304:11:304:22 | call to ymlSourcePtr | test.cpp:304:10:304:24 | * ... | provenance | Src:MaD:49 Sink:MaD:3 |
 | test.cpp:306:39:306:60 | source_from_callback_return_template output argument | test.cpp:293:5:293:26 | *callback_returning_int | provenance | Src:MaD:39  |
 | test.cpp:307:10:307:31 | call to callback_returning_int | test.cpp:307:10:307:31 | call to callback_returning_int | provenance | Sink:MaD:3 |
@@ -284,11 +291,13 @@ edges
 | test.cpp:312:38:312:63 | source_ptr_from_callback_return_ptr output argument | test.cpp:295:6:295:31 | **callback_returning_ptr_int | provenance | Src:MaD:41  |
 | test.cpp:313:13:313:38 | *call to callback_returning_ptr_int | test.cpp:313:13:313:38 | *call to callback_returning_ptr_int | provenance |  |
 | test.cpp:313:13:313:38 | *call to callback_returning_ptr_int | test.cpp:315:10:315:13 | * ... | provenance | Sink:MaD:3 |
-| test.cpp:317:51:317:59 | call to ymlSource | test.cpp:317:37:317:64 | [...](...){...} | provenance | Sink:MaD:1 |
-| test.cpp:317:51:317:59 | call to ymlSource | test.cpp:317:37:317:64 | [...](...){...} | provenance | Src:MaD:48  Sink:MaD:1 |
+| test.cpp:317:39:317:39 | *operator() | test.cpp:317:37:317:64 | [...](...){...} | provenance | Sink:MaD:1 |
+| test.cpp:317:51:317:59 | call to ymlSource | test.cpp:317:39:317:39 | *operator() | provenance |  |
+| test.cpp:317:51:317:59 | call to ymlSource | test.cpp:317:39:317:39 | *operator() | provenance | Src:MaD:48  |
 | test.cpp:317:51:317:59 | call to ymlSource | test.cpp:317:51:317:59 | call to ymlSource | provenance | Src:MaD:48  |
-| test.cpp:320:50:320:61 | *call to ymlSourcePtr | test.cpp:320:36:320:36 | call to operator int *(*)() | provenance | Sink:MaD:2 |
-| test.cpp:320:50:320:61 | call to ymlSourcePtr | test.cpp:320:36:320:36 | call to operator int *(*)() | provenance | Src:MaD:49  Sink:MaD:2 |
+| test.cpp:320:38:320:38 | **operator() | test.cpp:320:36:320:36 | call to operator int *(*)() | provenance | Sink:MaD:2 |
+| test.cpp:320:50:320:61 | *call to ymlSourcePtr | test.cpp:320:38:320:38 | **operator() | provenance |  |
+| test.cpp:320:50:320:61 | call to ymlSourcePtr | test.cpp:320:38:320:38 | **operator() | provenance | Src:MaD:49  |
 | test.cpp:320:50:320:61 | call to ymlSourcePtr | test.cpp:320:50:320:61 | *call to ymlSourcePtr | provenance | Src:MaD:49  |
 | test.cpp:324:36:324:36 | p | test.cpp:325:10:325:10 | *p [value] | provenance | Src:MaD:43  |
 | test.cpp:324:36:324:36 | p | test.cpp:327:11:327:11 | *p [*pointer] | provenance | Src:MaD:42  |
@@ -640,6 +649,7 @@ nodes
 | test.cpp:223:13:223:15 | call to operator[] | semmle.label | call to operator[] |
 | test.cpp:223:13:223:15 | call to operator[] | semmle.label | call to operator[] |
 | test.cpp:224:11:224:11 | c | semmle.label | c |
+| test.cpp:242:29:242:29 | *s [value] | semmle.label | *s [value] |
 | test.cpp:243:10:243:10 | *s [value] | semmle.label | *s [value] |
 | test.cpp:243:13:243:17 | value | semmle.label | value |
 | test.cpp:243:13:243:17 | value | semmle.label | value |
@@ -652,6 +662,7 @@ nodes
 | test.cpp:250:32:250:32 | source_from_callback_template output argument [value] | semmle.label | source_from_callback_template output argument [value] |
 | test.cpp:251:27:251:27 | source_from_callback_ptr output argument | semmle.label | source_from_callback_ptr output argument |
 | test.cpp:251:27:251:27 | source_from_callback_ptr output argument [value] | semmle.label | source_from_callback_ptr output argument [value] |
+| test.cpp:257:35:257:35 | *s [value] | semmle.label | *s [value] |
 | test.cpp:258:12:258:12 | *s [value] | semmle.label | *s [value] |
 | test.cpp:258:15:258:19 | value | semmle.label | value |
 | test.cpp:258:15:258:19 | value | semmle.label | value |
@@ -659,14 +670,17 @@ nodes
 | test.cpp:262:27:262:31 | source_from_callback_ptr output argument [value] | semmle.label | source_from_callback_ptr output argument [value] |
 | test.cpp:264:32:266:2 | source_from_callback_template output argument | semmle.label | source_from_callback_template output argument |
 | test.cpp:264:32:266:2 | source_from_callback_template output argument [value] | semmle.label | source_from_callback_template output argument [value] |
+| test.cpp:264:56:264:56 | *s [value] | semmle.label | *s [value] |
 | test.cpp:265:11:265:11 | *s [value] | semmle.label | *s [value] |
 | test.cpp:265:14:265:18 | value | semmle.label | value |
 | test.cpp:265:14:265:18 | value | semmle.label | value |
 | test.cpp:268:27:268:27 | source_from_callback_ptr output argument | semmle.label | source_from_callback_ptr output argument |
 | test.cpp:268:27:268:27 | source_from_callback_ptr output argument [value] | semmle.label | source_from_callback_ptr output argument [value] |
+| test.cpp:268:51:268:51 | *s [value] | semmle.label | *s [value] |
 | test.cpp:269:11:269:11 | *s [value] | semmle.label | *s [value] |
 | test.cpp:269:14:269:18 | value | semmle.label | value |
 | test.cpp:269:14:269:18 | value | semmle.label | value |
+| test.cpp:273:40:273:40 | *s [value] | semmle.label | *s [value] |
 | test.cpp:274:12:274:12 | *s [value] | semmle.label | *s [value] |
 | test.cpp:274:15:274:19 | value | semmle.label | value |
 | test.cpp:274:15:274:19 | value | semmle.label | value |
@@ -675,8 +689,10 @@ nodes
 | test.cpp:293:5:293:26 | *callback_returning_int | semmle.label | *callback_returning_int |
 | test.cpp:294:5:294:28 | *callback_returning_int_2 | semmle.label | *callback_returning_int_2 |
 | test.cpp:295:6:295:31 | **callback_returning_ptr_int | semmle.label | **callback_returning_ptr_int |
+| test.cpp:297:5:297:20 | *return_ymlSource | semmle.label | *return_ymlSource |
 | test.cpp:297:33:297:41 | call to ymlSource | semmle.label | call to ymlSource |
 | test.cpp:297:33:297:41 | call to ymlSource | semmle.label | call to ymlSource |
+| test.cpp:299:6:299:28 | **return_ptr_to_ymlSource | semmle.label | **return_ptr_to_ymlSource |
 | test.cpp:299:41:299:52 | *call to ymlSourcePtr | semmle.label | *call to ymlSourcePtr |
 | test.cpp:299:41:299:52 | call to ymlSourcePtr | semmle.label | call to ymlSourcePtr |
 | test.cpp:304:10:304:24 | * ... | semmle.label | * ... |
@@ -692,10 +708,12 @@ nodes
 | test.cpp:313:13:313:38 | *call to callback_returning_ptr_int | semmle.label | *call to callback_returning_ptr_int |
 | test.cpp:315:10:315:13 | * ... | semmle.label | * ... |
 | test.cpp:317:37:317:64 | [...](...){...} | semmle.label | [...](...){...} |
+| test.cpp:317:39:317:39 | *operator() | semmle.label | *operator() |
 | test.cpp:317:51:317:59 | call to ymlSource | semmle.label | call to ymlSource |
 | test.cpp:317:51:317:59 | call to ymlSource | semmle.label | call to ymlSource |
 | test.cpp:318:37:318:52 | return_ymlSource | semmle.label | return_ymlSource |
 | test.cpp:320:36:320:36 | call to operator int *(*)() | semmle.label | call to operator int *(*)() |
+| test.cpp:320:38:320:38 | **operator() | semmle.label | **operator() |
 | test.cpp:320:50:320:61 | *call to ymlSourcePtr | semmle.label | *call to ymlSourcePtr |
 | test.cpp:320:50:320:61 | call to ymlSourcePtr | semmle.label | call to ymlSourcePtr |
 | test.cpp:321:36:321:58 | return_ptr_to_ymlSource | semmle.label | return_ptr_to_ymlSource |

--- a/misc/scripts/accept-expected-changes-from-ci.py
+++ b/misc/scripts/accept-expected-changes-from-ci.py
@@ -208,7 +208,7 @@ def get_log_content(status: GithubStatus) -> str:
     LOGGER.debug(f"'{status.context}': Getting logs")
     if status.job_ids:
         contents = [subprocess.check_output(
-            ["gh", "api", f"/repos/{status.nwo}/actions/jobs/{job_id}/logs"],
+            ["gh", "api", f"/repos/{status.nwo}/actions/jobs/{job_id}/logs", "--allow-escape-sequences"],
         ).decode("utf-8") for job_id in status.job_ids]
         content = "\n".join(contents)
     else:
@@ -275,7 +275,7 @@ def main(pr_number: Optional[int], sha_override: Optional[str] = None, force=Fal
 
     lang_test_failures: List[GithubStatus] = list()
     for status in newest_status.values():
-        if " Language Tests" in status.context or status.context in supported_internal_status_language_test_names:
+        if " Language Tests" in status.context and not " Language Tests Windows" in status.context or status.context in supported_internal_status_language_test_names:
             if status.state == "failure":
                 lang_test_failures.append(status)
             elif status.state == "pending":

--- a/rust/ql/test/library-tests/dataflow/models/models.expected
+++ b/rust/ql/test/library-tests/dataflow/models/models.expected
@@ -269,18 +269,28 @@ edges
 | main.rs:281:9:281:37 | ...::C {...} [C] | main.rs:281:35:281:35 | i | provenance |  |
 | main.rs:281:35:281:35 | i | main.rs:281:47:281:47 | i | provenance |  |
 | main.rs:281:35:281:35 | i | main.rs:281:47:281:47 | i | provenance |  |
-| main.rs:303:24:303:24 | a | main.rs:302:26:302:26 | a | provenance | Src:MaD:21  |
-| main.rs:303:24:303:24 | a | main.rs:302:26:302:26 | a | provenance | Src:MaD:21  |
-| main.rs:305:24:307:9 | \|...\| ... | main.rs:306:18:306:18 | a | provenance | Src:MaD:21  |
-| main.rs:305:24:307:9 | \|...\| ... | main.rs:306:18:306:18 | a | provenance | Src:MaD:21  |
-| main.rs:312:24:312:24 | f | main.rs:310:18:310:18 | a | provenance | Src:MaD:21  |
-| main.rs:312:24:312:24 | f | main.rs:310:18:310:18 | a | provenance | Src:MaD:21  |
-| main.rs:314:24:316:9 | \|...\| ... | main.rs:315:18:315:18 | a | provenance | Src:MaD:21  |
-| main.rs:314:24:316:9 | \|...\| ... | main.rs:315:18:315:18 | a | provenance | Src:MaD:21  |
+| main.rs:302:18:302:18 | ... | main.rs:302:26:302:26 | a | provenance |  |
+| main.rs:302:18:302:18 | ... | main.rs:302:26:302:26 | a | provenance |  |
+| main.rs:303:24:303:24 | a | main.rs:302:18:302:18 | ... | provenance | Src:MaD:21  |
+| main.rs:303:24:303:24 | a | main.rs:302:18:302:18 | ... | provenance | Src:MaD:21  |
+| main.rs:305:24:307:9 | \|...\| ... | main.rs:305:25:305:25 | ... | provenance | Src:MaD:21  |
+| main.rs:305:24:307:9 | \|...\| ... | main.rs:305:25:305:25 | ... | provenance | Src:MaD:21  |
+| main.rs:305:25:305:25 | ... | main.rs:306:18:306:18 | a | provenance |  |
+| main.rs:305:25:305:25 | ... | main.rs:306:18:306:18 | a | provenance |  |
+| main.rs:309:14:309:19 | ...: i64 | main.rs:310:18:310:18 | a | provenance |  |
+| main.rs:309:14:309:19 | ...: i64 | main.rs:310:18:310:18 | a | provenance |  |
+| main.rs:312:24:312:24 | f | main.rs:309:14:309:19 | ...: i64 | provenance | Src:MaD:21  |
+| main.rs:312:24:312:24 | f | main.rs:309:14:309:19 | ...: i64 | provenance | Src:MaD:21  |
+| main.rs:314:24:316:9 | \|...\| ... | main.rs:314:36:314:36 | ... | provenance | Src:MaD:21  |
+| main.rs:314:24:316:9 | \|...\| ... | main.rs:314:36:314:36 | ... | provenance | Src:MaD:21  |
+| main.rs:314:36:314:36 | ... | main.rs:315:18:315:18 | a | provenance |  |
+| main.rs:314:36:314:36 | ... | main.rs:315:18:315:18 | a | provenance |  |
 | main.rs:318:31:329:9 | \|...\| ... | main.rs:318:31:329:9 | \|...\| ... [E, Some] | provenance | Src:MaD:22  |
 | main.rs:318:31:329:9 | \|...\| ... | main.rs:318:31:329:9 | \|...\| ... [E, Some] | provenance | Src:MaD:22  |
-| main.rs:318:31:329:9 | \|...\| ... [E, Some] | main.rs:319:19:319:19 | e [E, Some] | provenance |  |
-| main.rs:318:31:329:9 | \|...\| ... [E, Some] | main.rs:319:19:319:19 | e [E, Some] | provenance |  |
+| main.rs:318:31:329:9 | \|...\| ... [E, Some] | main.rs:318:32:318:32 | ... [E, Some] | provenance |  |
+| main.rs:318:31:329:9 | \|...\| ... [E, Some] | main.rs:318:32:318:32 | ... [E, Some] | provenance |  |
+| main.rs:318:32:318:32 | ... [E, Some] | main.rs:319:19:319:19 | e [E, Some] | provenance |  |
+| main.rs:318:32:318:32 | ... [E, Some] | main.rs:319:19:319:19 | e [E, Some] | provenance |  |
 | main.rs:319:19:319:19 | e [E, Some] | main.rs:322:17:322:45 | ...::E {...} [E, Some] | provenance |  |
 | main.rs:319:19:319:19 | e [E, Some] | main.rs:322:17:322:45 | ...::E {...} [E, Some] | provenance |  |
 | main.rs:322:17:322:45 | ...::E {...} [E, Some] | main.rs:322:43:322:43 | o [Some] | provenance |  |
@@ -295,12 +305,14 @@ edges
 | main.rs:324:30:324:30 | i | main.rs:324:41:324:41 | i | provenance |  |
 | main.rs:344:21:344:29 | source(...) | main.rs:345:19:345:19 | a | provenance | Sink:MaD:9 |
 | main.rs:344:21:344:29 | source(...) | main.rs:345:19:345:19 | a | provenance | Sink:MaD:9 |
+| main.rs:347:22:352:9 | { ... } [E, Some] | main.rs:353:26:353:26 | b [E, Some] | provenance |  |
+| main.rs:347:22:352:9 | { ... } [E, Some] | main.rs:353:26:353:26 | b [E, Some] | provenance |  |
 | main.rs:348:17:348:17 | s | main.rs:350:39:350:39 | s | provenance |  |
 | main.rs:348:17:348:17 | s | main.rs:350:39:350:39 | s | provenance |  |
 | main.rs:348:21:348:29 | source(...) | main.rs:348:17:348:17 | s | provenance |  |
 | main.rs:348:21:348:29 | source(...) | main.rs:348:17:348:17 | s | provenance |  |
-| main.rs:349:13:351:13 | ...::E {...} [E, Some] | main.rs:353:26:353:26 | b [E, Some] | provenance |  |
-| main.rs:349:13:351:13 | ...::E {...} [E, Some] | main.rs:353:26:353:26 | b [E, Some] | provenance |  |
+| main.rs:349:13:351:13 | ...::E {...} [E, Some] | main.rs:347:22:352:9 | { ... } [E, Some] | provenance |  |
+| main.rs:349:13:351:13 | ...::E {...} [E, Some] | main.rs:347:22:352:9 | { ... } [E, Some] | provenance |  |
 | main.rs:350:26:350:40 | ...::Some(...) [Some] | main.rs:349:13:351:13 | ...::E {...} [E, Some] | provenance |  |
 | main.rs:350:26:350:40 | ...::Some(...) [Some] | main.rs:349:13:351:13 | ...::E {...} [E, Some] | provenance |  |
 | main.rs:350:39:350:39 | s | main.rs:350:26:350:40 | ...::Some(...) [Some] | provenance |  |
@@ -670,26 +682,36 @@ nodes
 | main.rs:281:35:281:35 | i | semmle.label | i |
 | main.rs:281:47:281:47 | i | semmle.label | i |
 | main.rs:281:47:281:47 | i | semmle.label | i |
+| main.rs:302:18:302:18 | ... | semmle.label | ... |
+| main.rs:302:18:302:18 | ... | semmle.label | ... |
 | main.rs:302:26:302:26 | a | semmle.label | a |
 | main.rs:302:26:302:26 | a | semmle.label | a |
 | main.rs:303:24:303:24 | a | semmle.label | a |
 | main.rs:303:24:303:24 | a | semmle.label | a |
 | main.rs:305:24:307:9 | \|...\| ... | semmle.label | \|...\| ... |
 | main.rs:305:24:307:9 | \|...\| ... | semmle.label | \|...\| ... |
+| main.rs:305:25:305:25 | ... | semmle.label | ... |
+| main.rs:305:25:305:25 | ... | semmle.label | ... |
 | main.rs:306:18:306:18 | a | semmle.label | a |
 | main.rs:306:18:306:18 | a | semmle.label | a |
+| main.rs:309:14:309:19 | ...: i64 | semmle.label | ...: i64 |
+| main.rs:309:14:309:19 | ...: i64 | semmle.label | ...: i64 |
 | main.rs:310:18:310:18 | a | semmle.label | a |
 | main.rs:310:18:310:18 | a | semmle.label | a |
 | main.rs:312:24:312:24 | f | semmle.label | f |
 | main.rs:312:24:312:24 | f | semmle.label | f |
 | main.rs:314:24:316:9 | \|...\| ... | semmle.label | \|...\| ... |
 | main.rs:314:24:316:9 | \|...\| ... | semmle.label | \|...\| ... |
+| main.rs:314:36:314:36 | ... | semmle.label | ... |
+| main.rs:314:36:314:36 | ... | semmle.label | ... |
 | main.rs:315:18:315:18 | a | semmle.label | a |
 | main.rs:315:18:315:18 | a | semmle.label | a |
 | main.rs:318:31:329:9 | \|...\| ... | semmle.label | \|...\| ... |
 | main.rs:318:31:329:9 | \|...\| ... | semmle.label | \|...\| ... |
 | main.rs:318:31:329:9 | \|...\| ... [E, Some] | semmle.label | \|...\| ... [E, Some] |
 | main.rs:318:31:329:9 | \|...\| ... [E, Some] | semmle.label | \|...\| ... [E, Some] |
+| main.rs:318:32:318:32 | ... [E, Some] | semmle.label | ... [E, Some] |
+| main.rs:318:32:318:32 | ... [E, Some] | semmle.label | ... [E, Some] |
 | main.rs:319:19:319:19 | e [E, Some] | semmle.label | e [E, Some] |
 | main.rs:319:19:319:19 | e [E, Some] | semmle.label | e [E, Some] |
 | main.rs:322:17:322:45 | ...::E {...} [E, Some] | semmle.label | ...::E {...} [E, Some] |
@@ -708,6 +730,8 @@ nodes
 | main.rs:344:21:344:29 | source(...) | semmle.label | source(...) |
 | main.rs:345:19:345:19 | a | semmle.label | a |
 | main.rs:345:19:345:19 | a | semmle.label | a |
+| main.rs:347:22:352:9 | { ... } [E, Some] | semmle.label | { ... } [E, Some] |
+| main.rs:347:22:352:9 | { ... } [E, Some] | semmle.label | { ... } [E, Some] |
 | main.rs:348:17:348:17 | s | semmle.label | s |
 | main.rs:348:17:348:17 | s | semmle.label | s |
 | main.rs:348:21:348:29 | source(...) | semmle.label | source(...) |

--- a/rust/ql/test/library-tests/dataflow/sources/database/InlineFlow.expected
+++ b/rust/ql/test/library-tests/dataflow/sources/database/InlineFlow.expected
@@ -47,27 +47,31 @@ edges
 | test.rs:41:14:41:61 | ... .get(...) [Some] | test.rs:41:14:41:70 | ... .unwrap() | provenance | MaD:13 |
 | test.rs:42:13:42:15 | row | test.rs:44:22:44:22 | v | provenance |  |
 | test.rs:42:20:42:21 | t1 [element] | test.rs:42:13:42:15 | row | provenance |  |
-| test.rs:50:13:52:13 | \|...\| ... | test.rs:51:22:51:27 | values | provenance | Src:MaD:4  |
-| test.rs:57:13:61:13 | \|...\| ... | test.rs:58:22:58:29 | values.0 | provenance | Src:MaD:4  |
-| test.rs:57:13:61:13 | \|...\| ... | test.rs:59:22:59:29 | values.1 | provenance | Src:MaD:4  |
-| test.rs:57:13:61:13 | \|...\| ... | test.rs:60:22:60:29 | values.2 | provenance | Src:MaD:4  |
+| test.rs:50:13:52:13 | \|...\| ... | test.rs:50:14:50:24 | ...: i64 | provenance | Src:MaD:4  |
+| test.rs:50:14:50:24 | ...: i64 | test.rs:51:22:51:27 | values | provenance |  |
+| test.rs:57:13:61:13 | \|...\| ... | test.rs:57:14:57:39 | ...: ... | provenance | Src:MaD:4  |
+| test.rs:57:14:57:39 | ...: ... | test.rs:58:22:58:29 | values.0 | provenance |  |
+| test.rs:57:14:57:39 | ...: ... | test.rs:59:22:59:29 | values.1 | provenance |  |
+| test.rs:57:14:57:39 | ...: ... | test.rs:60:22:60:29 | values.2 | provenance |  |
 | test.rs:64:13:64:17 | total | test.rs:68:14:68:18 | total | provenance |  |
 | test.rs:64:13:64:17 | total [Wrapping] | test.rs:68:14:68:18 | total | provenance |  |
 | test.rs:64:21:67:10 | conn.query_fold(...) [Ok, Wrapping] | test.rs:64:21:67:11 | TryExpr [Wrapping] | provenance |  |
 | test.rs:64:21:67:10 | conn.query_fold(...) [Ok] | test.rs:64:21:67:11 | TryExpr | provenance |  |
 | test.rs:64:21:67:11 | TryExpr | test.rs:64:13:64:17 | total | provenance |  |
 | test.rs:64:21:67:11 | TryExpr [Wrapping] | test.rs:64:13:64:17 | total [Wrapping] | provenance |  |
-| test.rs:64:65:67:9 | \|...\| ... | test.rs:65:18:65:20 | row | provenance | Src:MaD:3  |
-| test.rs:64:65:67:9 | \|...\| ... | test.rs:66:19:66:21 | row | provenance | Src:MaD:3  |
+| test.rs:64:65:67:9 | \|...\| ... | test.rs:64:76:64:83 | ...: i64 | provenance | Src:MaD:3  |
+| test.rs:64:76:64:83 | ...: i64 | test.rs:65:18:65:20 | row | provenance |  |
+| test.rs:64:76:64:83 | ...: i64 | test.rs:66:19:66:21 | row | provenance |  |
 | test.rs:64:86:67:9 | { ... } | test.rs:64:21:67:10 | conn.query_fold(...) [Ok] | provenance | MaD:15 |
 | test.rs:64:86:67:9 | { ... } [Wrapping] | test.rs:64:21:67:10 | conn.query_fold(...) [Ok, Wrapping] | provenance | MaD:15 |
 | test.rs:66:13:66:21 | ... + ... | test.rs:64:86:67:9 | { ... } | provenance |  |
 | test.rs:66:13:66:21 | ... + ... [Wrapping] | test.rs:64:86:67:9 | { ... } [Wrapping] | provenance |  |
 | test.rs:66:19:66:21 | row | test.rs:66:13:66:21 | ... + ... | provenance | MaD:12 |
 | test.rs:66:19:66:21 | row | test.rs:66:13:66:21 | ... + ... [Wrapping] | provenance | MaD:11 |
-| test.rs:70:72:78:9 | \|...\| ... | test.rs:71:17:71:18 | id | provenance | Src:MaD:3  |
-| test.rs:70:72:78:9 | \|...\| ... | test.rs:72:17:72:20 | name | provenance | Src:MaD:3  |
-| test.rs:70:72:78:9 | \|...\| ... | test.rs:73:17:73:19 | age | provenance | Src:MaD:3  |
+| test.rs:70:72:78:9 | \|...\| ... | test.rs:70:83:70:105 | ...: ... | provenance | Src:MaD:3  |
+| test.rs:70:83:70:105 | ...: ... | test.rs:71:17:71:18 | id | provenance |  |
+| test.rs:70:83:70:105 | ...: ... | test.rs:72:17:72:20 | name | provenance |  |
+| test.rs:70:83:70:105 | ...: ... | test.rs:73:17:73:19 | age | provenance |  |
 | test.rs:71:17:71:18 | id | test.rs:74:18:74:19 | id | provenance |  |
 | test.rs:72:17:72:20 | name | test.rs:75:18:75:21 | name | provenance |  |
 | test.rs:73:17:73:19 | age | test.rs:76:18:76:20 | age | provenance |  |
@@ -89,10 +93,12 @@ edges
 | test.rs:114:24:114:38 | row.take_opt(...) [Some, Ok] | test.rs:114:24:114:47 | ... .unwrap() [Ok] | provenance | MaD:13 |
 | test.rs:114:24:114:47 | ... .unwrap() [Ok] | test.rs:114:24:114:56 | ... .unwrap() | provenance | MaD:14 |
 | test.rs:114:24:114:56 | ... .unwrap() | test.rs:114:13:114:14 | v4 | provenance |  |
-| test.rs:137:13:139:13 | \|...\| ... | test.rs:138:22:138:27 | values | provenance | Src:MaD:6  |
-| test.rs:144:13:148:13 | \|...\| ... | test.rs:145:22:145:29 | values.0 | provenance | Src:MaD:6  |
-| test.rs:144:13:148:13 | \|...\| ... | test.rs:146:22:146:29 | values.1 | provenance | Src:MaD:6  |
-| test.rs:144:13:148:13 | \|...\| ... | test.rs:147:22:147:29 | values.2 | provenance | Src:MaD:6  |
+| test.rs:137:13:139:13 | \|...\| ... | test.rs:137:14:137:24 | ...: i64 | provenance | Src:MaD:6  |
+| test.rs:137:14:137:24 | ...: i64 | test.rs:138:22:138:27 | values | provenance |  |
+| test.rs:144:13:148:13 | \|...\| ... | test.rs:144:14:144:39 | ...: ... | provenance | Src:MaD:6  |
+| test.rs:144:14:144:39 | ...: ... | test.rs:145:22:145:29 | values.0 | provenance |  |
+| test.rs:144:14:144:39 | ...: ... | test.rs:146:22:146:29 | values.1 | provenance |  |
+| test.rs:144:14:144:39 | ...: ... | test.rs:147:22:147:29 | values.2 | provenance |  |
 | test.rs:151:13:151:17 | total | test.rs:155:14:155:18 | total | provenance |  |
 | test.rs:151:13:151:17 | total [Wrapping] | test.rs:155:14:155:18 | total | provenance |  |
 | test.rs:151:21:154:10 | conn.query_fold(...) [future, Ok, Wrapping] | test.rs:151:21:154:16 | await ... [Ok, Wrapping] | provenance |  |
@@ -101,17 +107,19 @@ edges
 | test.rs:151:21:154:16 | await ... [Ok] | test.rs:151:21:154:17 | TryExpr | provenance |  |
 | test.rs:151:21:154:17 | TryExpr | test.rs:151:13:151:17 | total | provenance |  |
 | test.rs:151:21:154:17 | TryExpr [Wrapping] | test.rs:151:13:151:17 | total [Wrapping] | provenance |  |
-| test.rs:151:65:154:9 | \|...\| ... | test.rs:152:18:152:20 | row | provenance | Src:MaD:5  |
-| test.rs:151:65:154:9 | \|...\| ... | test.rs:153:19:153:21 | row | provenance | Src:MaD:5  |
+| test.rs:151:65:154:9 | \|...\| ... | test.rs:151:76:151:83 | ...: i64 | provenance | Src:MaD:5  |
+| test.rs:151:76:151:83 | ...: i64 | test.rs:152:18:152:20 | row | provenance |  |
+| test.rs:151:76:151:83 | ...: i64 | test.rs:153:19:153:21 | row | provenance |  |
 | test.rs:151:86:154:9 | { ... } | test.rs:151:21:154:10 | conn.query_fold(...) [future, Ok] | provenance | MaD:16 |
 | test.rs:151:86:154:9 | { ... } [Wrapping] | test.rs:151:21:154:10 | conn.query_fold(...) [future, Ok, Wrapping] | provenance | MaD:16 |
 | test.rs:153:13:153:21 | ... + ... | test.rs:151:86:154:9 | { ... } | provenance |  |
 | test.rs:153:13:153:21 | ... + ... [Wrapping] | test.rs:151:86:154:9 | { ... } [Wrapping] | provenance |  |
 | test.rs:153:19:153:21 | row | test.rs:153:13:153:21 | ... + ... | provenance | MaD:12 |
 | test.rs:153:19:153:21 | row | test.rs:153:13:153:21 | ... + ... [Wrapping] | provenance | MaD:11 |
-| test.rs:157:72:165:9 | \|...\| ... | test.rs:158:17:158:18 | id | provenance | Src:MaD:5  |
-| test.rs:157:72:165:9 | \|...\| ... | test.rs:159:17:159:20 | name | provenance | Src:MaD:5  |
-| test.rs:157:72:165:9 | \|...\| ... | test.rs:160:17:160:19 | age | provenance | Src:MaD:5  |
+| test.rs:157:72:165:9 | \|...\| ... | test.rs:157:83:157:105 | ...: ... | provenance | Src:MaD:5  |
+| test.rs:157:83:157:105 | ...: ... | test.rs:158:17:158:18 | id | provenance |  |
+| test.rs:157:83:157:105 | ...: ... | test.rs:159:17:159:20 | name | provenance |  |
+| test.rs:157:83:157:105 | ...: ... | test.rs:160:17:160:19 | age | provenance |  |
 | test.rs:158:17:158:18 | id | test.rs:161:18:161:19 | id | provenance |  |
 | test.rs:159:17:159:20 | name | test.rs:162:18:162:21 | name | provenance |  |
 | test.rs:160:17:160:19 | age | test.rs:163:18:163:20 | age | provenance |  |
@@ -155,8 +163,10 @@ nodes
 | test.rs:42:20:42:21 | t1 [element] | semmle.label | t1 [element] |
 | test.rs:44:22:44:22 | v | semmle.label | v |
 | test.rs:50:13:52:13 | \|...\| ... | semmle.label | \|...\| ... |
+| test.rs:50:14:50:24 | ...: i64 | semmle.label | ...: i64 |
 | test.rs:51:22:51:27 | values | semmle.label | values |
 | test.rs:57:13:61:13 | \|...\| ... | semmle.label | \|...\| ... |
+| test.rs:57:14:57:39 | ...: ... | semmle.label | ...: ... |
 | test.rs:58:22:58:29 | values.0 | semmle.label | values.0 |
 | test.rs:59:22:59:29 | values.1 | semmle.label | values.1 |
 | test.rs:60:22:60:29 | values.2 | semmle.label | values.2 |
@@ -167,6 +177,7 @@ nodes
 | test.rs:64:21:67:11 | TryExpr | semmle.label | TryExpr |
 | test.rs:64:21:67:11 | TryExpr [Wrapping] | semmle.label | TryExpr [Wrapping] |
 | test.rs:64:65:67:9 | \|...\| ... | semmle.label | \|...\| ... |
+| test.rs:64:76:64:83 | ...: i64 | semmle.label | ...: i64 |
 | test.rs:64:86:67:9 | { ... } | semmle.label | { ... } |
 | test.rs:64:86:67:9 | { ... } [Wrapping] | semmle.label | { ... } [Wrapping] |
 | test.rs:65:18:65:20 | row | semmle.label | row |
@@ -175,6 +186,7 @@ nodes
 | test.rs:66:19:66:21 | row | semmle.label | row |
 | test.rs:68:14:68:18 | total | semmle.label | total |
 | test.rs:70:72:78:9 | \|...\| ... | semmle.label | \|...\| ... |
+| test.rs:70:83:70:105 | ...: ... | semmle.label | ...: ... |
 | test.rs:71:17:71:18 | id | semmle.label | id |
 | test.rs:72:17:72:20 | name | semmle.label | name |
 | test.rs:73:17:73:19 | age | semmle.label | age |
@@ -204,8 +216,10 @@ nodes
 | test.rs:114:24:114:56 | ... .unwrap() | semmle.label | ... .unwrap() |
 | test.rs:115:14:115:15 | v4 | semmle.label | v4 |
 | test.rs:137:13:139:13 | \|...\| ... | semmle.label | \|...\| ... |
+| test.rs:137:14:137:24 | ...: i64 | semmle.label | ...: i64 |
 | test.rs:138:22:138:27 | values | semmle.label | values |
 | test.rs:144:13:148:13 | \|...\| ... | semmle.label | \|...\| ... |
+| test.rs:144:14:144:39 | ...: ... | semmle.label | ...: ... |
 | test.rs:145:22:145:29 | values.0 | semmle.label | values.0 |
 | test.rs:146:22:146:29 | values.1 | semmle.label | values.1 |
 | test.rs:147:22:147:29 | values.2 | semmle.label | values.2 |
@@ -218,6 +232,7 @@ nodes
 | test.rs:151:21:154:17 | TryExpr | semmle.label | TryExpr |
 | test.rs:151:21:154:17 | TryExpr [Wrapping] | semmle.label | TryExpr [Wrapping] |
 | test.rs:151:65:154:9 | \|...\| ... | semmle.label | \|...\| ... |
+| test.rs:151:76:151:83 | ...: i64 | semmle.label | ...: i64 |
 | test.rs:151:86:154:9 | { ... } | semmle.label | { ... } |
 | test.rs:151:86:154:9 | { ... } [Wrapping] | semmle.label | { ... } [Wrapping] |
 | test.rs:152:18:152:20 | row | semmle.label | row |
@@ -226,6 +241,7 @@ nodes
 | test.rs:153:19:153:21 | row | semmle.label | row |
 | test.rs:155:14:155:18 | total | semmle.label | total |
 | test.rs:157:72:165:9 | \|...\| ... | semmle.label | \|...\| ... |
+| test.rs:157:83:157:105 | ...: ... | semmle.label | ...: ... |
 | test.rs:158:17:158:18 | id | semmle.label | id |
 | test.rs:159:17:159:20 | name | semmle.label | name |
 | test.rs:160:17:160:19 | age | semmle.label | age |

--- a/rust/ql/test/library-tests/dataflow/sources/web_frameworks/InlineFlow.expected
+++ b/rust/ql/test/library-tests/dataflow/sources/web_frameworks/InlineFlow.expected
@@ -25,6 +25,7 @@ edges
 | test.rs:58:14:58:15 | ms | test.rs:60:14:60:17 | ms.a | provenance |  |
 | test.rs:58:14:58:15 | ms | test.rs:61:14:61:17 | ms.b | provenance |  |
 | test.rs:68:15:68:15 | a | test.rs:70:14:70:14 | a | provenance |  |
+| test.rs:97:33:97:55 | ...: ...::Path::<...> | test.rs:98:17:98:20 | path | provenance |  |
 | test.rs:98:13:98:13 | a | test.rs:99:14:99:14 | a | provenance |  |
 | test.rs:98:13:98:13 | a | test.rs:100:14:100:14 | a | provenance |  |
 | test.rs:98:13:98:13 | a | test.rs:101:14:101:14 | a | provenance |  |
@@ -32,33 +33,46 @@ edges
 | test.rs:98:17:98:33 | path.into_inner() | test.rs:98:13:98:13 | a | provenance |  |
 | test.rs:99:14:99:14 | a | test.rs:99:14:99:23 | a.as_str() | provenance | MaD:13 |
 | test.rs:100:14:100:14 | a | test.rs:100:14:100:25 | a.as_bytes() | provenance | MaD:12 |
+| test.rs:106:33:106:65 | ...: ...::Path::<...> | test.rs:107:22:107:25 | path | provenance |  |
 | test.rs:107:13:107:18 | TuplePat | test.rs:109:14:109:14 | a | provenance |  |
 | test.rs:107:13:107:18 | TuplePat | test.rs:110:14:110:14 | b | provenance |  |
 | test.rs:107:22:107:25 | path | test.rs:107:22:107:38 | path.into_inner() | provenance | MaD:11 |
 | test.rs:107:22:107:38 | path.into_inner() | test.rs:107:13:107:18 | TuplePat | provenance |  |
-| test.rs:122:14:122:31 | my_actix_handler_4 | test.rs:123:17:123:20 | path | provenance | Src:MaD:1  |
+| test.rs:115:33:115:65 | ...: ...::Query::<...> | test.rs:116:14:116:14 | a | provenance |  |
+| test.rs:122:14:122:31 | my_actix_handler_4 | test.rs:122:33:122:55 | ...: ...::Path::<...> | provenance | Src:MaD:1  |
+| test.rs:122:33:122:55 | ...: ...::Path::<...> | test.rs:123:17:123:20 | path | provenance |  |
 | test.rs:123:13:123:13 | a | test.rs:124:14:124:14 | a | provenance |  |
 | test.rs:123:17:123:20 | path | test.rs:123:17:123:33 | path.into_inner() | provenance | MaD:11 |
 | test.rs:123:17:123:33 | path.into_inner() | test.rs:123:13:123:13 | a | provenance |  |
-| test.rs:131:44:131:61 | my_actix_handler_1 | test.rs:98:17:98:20 | path | provenance | Src:MaD:2  |
-| test.rs:132:48:132:65 | my_actix_handler_2 | test.rs:107:22:107:25 | path | provenance | Src:MaD:2  |
-| test.rs:133:44:133:61 | my_actix_handler_3 | test.rs:116:14:116:14 | a | provenance | Src:MaD:2  |
+| test.rs:131:44:131:61 | my_actix_handler_1 | test.rs:97:33:97:55 | ...: ...::Path::<...> | provenance | Src:MaD:2  |
+| test.rs:132:48:132:65 | my_actix_handler_2 | test.rs:106:33:106:65 | ...: ...::Path::<...> | provenance | Src:MaD:2  |
+| test.rs:133:44:133:61 | my_actix_handler_3 | test.rs:115:33:115:65 | ...: ...::Query::<...> | provenance | Src:MaD:2  |
+| test.rs:147:32:147:52 | ...: Path::<...> | test.rs:148:14:148:14 | a | provenance |  |
+| test.rs:147:32:147:52 | ...: Path::<...> | test.rs:149:14:149:14 | a | provenance |  |
+| test.rs:147:32:147:52 | ...: Path::<...> | test.rs:150:14:150:14 | a | provenance |  |
 | test.rs:148:14:148:14 | a | test.rs:148:14:148:23 | a.as_str() | provenance | MaD:13 |
 | test.rs:149:14:149:14 | a | test.rs:149:14:149:25 | a.as_bytes() | provenance | MaD:12 |
-| test.rs:200:34:200:50 | my_axum_handler_1 | test.rs:148:14:148:14 | a | provenance | Src:MaD:8  |
-| test.rs:200:34:200:50 | my_axum_handler_1 | test.rs:149:14:149:14 | a | provenance | Src:MaD:8  |
-| test.rs:200:34:200:50 | my_axum_handler_1 | test.rs:150:14:150:14 | a | provenance | Src:MaD:8  |
-| test.rs:201:39:201:55 | my_axum_handler_2 | test.rs:156:14:156:14 | a | provenance | Src:MaD:9  |
-| test.rs:201:39:201:55 | my_axum_handler_2 | test.rs:157:14:157:14 | b | provenance | Src:MaD:9  |
-| test.rs:202:33:202:49 | my_axum_handler_3 | test.rs:164:18:164:20 | key | provenance | Src:MaD:10  |
-| test.rs:202:33:202:49 | my_axum_handler_3 | test.rs:165:18:165:22 | value | provenance | Src:MaD:10  |
-| test.rs:205:65:205:81 | my_axum_handler_5 | test.rs:181:14:181:20 | payload | provenance | Src:MaD:4  |
-| test.rs:207:33:207:49 | my_axum_handler_6 | test.rs:187:14:187:17 | body | provenance | Src:MaD:8  |
-| test.rs:207:56:207:72 | my_axum_handler_7 | test.rs:193:14:193:17 | body | provenance | Src:MaD:3  |
-| test.rs:222:37:227:9 | \|...\| ... | test.rs:224:18:224:18 | a | provenance | Src:MaD:6  |
-| test.rs:231:13:235:13 | \|...\| ... | test.rs:232:22:232:22 | a | provenance | Src:MaD:7  |
-| test.rs:240:13:248:9 | \|...\| ... | test.rs:243:22:243:23 | id | provenance | Src:MaD:5  |
-| test.rs:253:13:258:14 | \|...\| ... | test.rs:255:22:255:22 | a | provenance | Src:MaD:6  |
+| test.rs:155:32:155:67 | ...: Path::<...> | test.rs:156:14:156:14 | a | provenance |  |
+| test.rs:155:32:155:67 | ...: Path::<...> | test.rs:157:14:157:14 | b | provenance |  |
+| test.rs:162:32:162:76 | ...: Query::<...> | test.rs:164:18:164:20 | key | provenance |  |
+| test.rs:162:32:162:76 | ...: Query::<...> | test.rs:165:18:165:22 | value | provenance |  |
+| test.rs:179:32:179:69 | ...: Json::<...> | test.rs:181:14:181:20 | payload | provenance |  |
+| test.rs:186:32:186:43 | ...: String | test.rs:187:14:187:17 | body | provenance |  |
+| test.rs:192:32:192:43 | ...: String | test.rs:193:14:193:17 | body | provenance |  |
+| test.rs:200:34:200:50 | my_axum_handler_1 | test.rs:147:32:147:52 | ...: Path::<...> | provenance | Src:MaD:8  |
+| test.rs:201:39:201:55 | my_axum_handler_2 | test.rs:155:32:155:67 | ...: Path::<...> | provenance | Src:MaD:9  |
+| test.rs:202:33:202:49 | my_axum_handler_3 | test.rs:162:32:162:76 | ...: Query::<...> | provenance | Src:MaD:10  |
+| test.rs:205:65:205:81 | my_axum_handler_5 | test.rs:179:32:179:69 | ...: Json::<...> | provenance | Src:MaD:4  |
+| test.rs:207:33:207:49 | my_axum_handler_6 | test.rs:186:32:186:43 | ...: String | provenance | Src:MaD:8  |
+| test.rs:207:56:207:72 | my_axum_handler_7 | test.rs:192:32:192:43 | ...: String | provenance | Src:MaD:3  |
+| test.rs:222:37:227:9 | \|...\| ... | test.rs:222:38:222:46 | ...: String | provenance | Src:MaD:6  |
+| test.rs:222:38:222:46 | ...: String | test.rs:224:18:224:18 | a | provenance |  |
+| test.rs:231:13:235:13 | \|...\| ... | test.rs:231:25:231:33 | ...: String | provenance | Src:MaD:7  |
+| test.rs:231:25:231:33 | ...: String | test.rs:232:22:232:22 | a | provenance |  |
+| test.rs:240:13:248:9 | \|...\| ... | test.rs:240:26:240:32 | ...: u64 | provenance | Src:MaD:5  |
+| test.rs:240:26:240:32 | ...: u64 | test.rs:243:22:243:23 | id | provenance |  |
+| test.rs:253:13:258:14 | \|...\| ... | test.rs:253:15:253:23 | ...: String | provenance | Src:MaD:6  |
+| test.rs:253:15:253:23 | ...: String | test.rs:255:22:255:22 | a | provenance |  |
 nodes
 | test.rs:11:31:11:31 | a | semmle.label | a |
 | test.rs:13:14:13:14 | a | semmle.label | a |
@@ -77,6 +91,7 @@ nodes
 | test.rs:61:14:61:17 | ms.b | semmle.label | ms.b |
 | test.rs:68:15:68:15 | a | semmle.label | a |
 | test.rs:70:14:70:14 | a | semmle.label | a |
+| test.rs:97:33:97:55 | ...: ...::Path::<...> | semmle.label | ...: ...::Path::<...> |
 | test.rs:98:13:98:13 | a | semmle.label | a |
 | test.rs:98:17:98:20 | path | semmle.label | path |
 | test.rs:98:17:98:33 | path.into_inner() | semmle.label | path.into_inner() |
@@ -85,13 +100,16 @@ nodes
 | test.rs:100:14:100:14 | a | semmle.label | a |
 | test.rs:100:14:100:25 | a.as_bytes() | semmle.label | a.as_bytes() |
 | test.rs:101:14:101:14 | a | semmle.label | a |
+| test.rs:106:33:106:65 | ...: ...::Path::<...> | semmle.label | ...: ...::Path::<...> |
 | test.rs:107:13:107:18 | TuplePat | semmle.label | TuplePat |
 | test.rs:107:22:107:25 | path | semmle.label | path |
 | test.rs:107:22:107:38 | path.into_inner() | semmle.label | path.into_inner() |
 | test.rs:109:14:109:14 | a | semmle.label | a |
 | test.rs:110:14:110:14 | b | semmle.label | b |
+| test.rs:115:33:115:65 | ...: ...::Query::<...> | semmle.label | ...: ...::Query::<...> |
 | test.rs:116:14:116:14 | a | semmle.label | a |
 | test.rs:122:14:122:31 | my_actix_handler_4 | semmle.label | my_actix_handler_4 |
+| test.rs:122:33:122:55 | ...: ...::Path::<...> | semmle.label | ...: ...::Path::<...> |
 | test.rs:123:13:123:13 | a | semmle.label | a |
 | test.rs:123:17:123:20 | path | semmle.label | path |
 | test.rs:123:17:123:33 | path.into_inner() | semmle.label | path.into_inner() |
@@ -99,17 +117,23 @@ nodes
 | test.rs:131:44:131:61 | my_actix_handler_1 | semmle.label | my_actix_handler_1 |
 | test.rs:132:48:132:65 | my_actix_handler_2 | semmle.label | my_actix_handler_2 |
 | test.rs:133:44:133:61 | my_actix_handler_3 | semmle.label | my_actix_handler_3 |
+| test.rs:147:32:147:52 | ...: Path::<...> | semmle.label | ...: Path::<...> |
 | test.rs:148:14:148:14 | a | semmle.label | a |
 | test.rs:148:14:148:23 | a.as_str() | semmle.label | a.as_str() |
 | test.rs:149:14:149:14 | a | semmle.label | a |
 | test.rs:149:14:149:25 | a.as_bytes() | semmle.label | a.as_bytes() |
 | test.rs:150:14:150:14 | a | semmle.label | a |
+| test.rs:155:32:155:67 | ...: Path::<...> | semmle.label | ...: Path::<...> |
 | test.rs:156:14:156:14 | a | semmle.label | a |
 | test.rs:157:14:157:14 | b | semmle.label | b |
+| test.rs:162:32:162:76 | ...: Query::<...> | semmle.label | ...: Query::<...> |
 | test.rs:164:18:164:20 | key | semmle.label | key |
 | test.rs:165:18:165:22 | value | semmle.label | value |
+| test.rs:179:32:179:69 | ...: Json::<...> | semmle.label | ...: Json::<...> |
 | test.rs:181:14:181:20 | payload | semmle.label | payload |
+| test.rs:186:32:186:43 | ...: String | semmle.label | ...: String |
 | test.rs:187:14:187:17 | body | semmle.label | body |
+| test.rs:192:32:192:43 | ...: String | semmle.label | ...: String |
 | test.rs:193:14:193:17 | body | semmle.label | body |
 | test.rs:200:34:200:50 | my_axum_handler_1 | semmle.label | my_axum_handler_1 |
 | test.rs:201:39:201:55 | my_axum_handler_2 | semmle.label | my_axum_handler_2 |
@@ -118,12 +142,16 @@ nodes
 | test.rs:207:33:207:49 | my_axum_handler_6 | semmle.label | my_axum_handler_6 |
 | test.rs:207:56:207:72 | my_axum_handler_7 | semmle.label | my_axum_handler_7 |
 | test.rs:222:37:227:9 | \|...\| ... | semmle.label | \|...\| ... |
+| test.rs:222:38:222:46 | ...: String | semmle.label | ...: String |
 | test.rs:224:18:224:18 | a | semmle.label | a |
 | test.rs:231:13:235:13 | \|...\| ... | semmle.label | \|...\| ... |
+| test.rs:231:25:231:33 | ...: String | semmle.label | ...: String |
 | test.rs:232:22:232:22 | a | semmle.label | a |
 | test.rs:240:13:248:9 | \|...\| ... | semmle.label | \|...\| ... |
+| test.rs:240:26:240:32 | ...: u64 | semmle.label | ...: u64 |
 | test.rs:243:22:243:23 | id | semmle.label | id |
 | test.rs:253:13:258:14 | \|...\| ... | semmle.label | \|...\| ... |
+| test.rs:253:15:253:23 | ...: String | semmle.label | ...: String |
 | test.rs:255:22:255:22 | a | semmle.label | a |
 subpaths
 testFailures

--- a/rust/ql/test/query-tests/security/CWE-079/actix/XSS.expected
+++ b/rust/ql/test/query-tests/security/CWE-079/actix/XSS.expected
@@ -1,7 +1,8 @@
 #select
 | main.rs:25:15:25:18 | html | main.rs:9:10:9:27 | vulnerable_handler | main.rs:25:15:25:18 | html | Cross-site scripting vulnerability due to a $@. | main.rs:9:10:9:27 | vulnerable_handler | user-provided value |
 edges
-| main.rs:9:10:9:27 | vulnerable_handler | main.rs:10:22:10:25 | path | provenance | Src:MaD:2  |
+| main.rs:9:10:9:27 | vulnerable_handler | main.rs:9:29:9:51 | ...: ...::Path::<...> | provenance | Src:MaD:2  |
+| main.rs:9:29:9:51 | ...: ...::Path::<...> | main.rs:10:22:10:25 | path | provenance |  |
 | main.rs:10:9:10:18 | user_input | main.rs:13:9:22:18 | MacroExpr | provenance |  |
 | main.rs:10:22:10:25 | path | main.rs:10:22:10:38 | path.into_inner() | provenance | MaD:3 |
 | main.rs:10:22:10:38 | path.into_inner() | main.rs:10:9:10:18 | user_input | provenance |  |
@@ -18,6 +19,7 @@ models
 | 5 | Summary: core::hint::must_use; Argument[0]; ReturnValue; value |
 nodes
 | main.rs:9:10:9:27 | vulnerable_handler | semmle.label | vulnerable_handler |
+| main.rs:9:29:9:51 | ...: ...::Path::<...> | semmle.label | ...: ...::Path::<...> |
 | main.rs:10:9:10:18 | user_input | semmle.label | user_input |
 | main.rs:10:22:10:25 | path | semmle.label | path |
 | main.rs:10:22:10:38 | path.into_inner() | semmle.label | path.into_inner() |

--- a/rust/ql/test/query-tests/security/CWE-079/axum/XSS.expected
+++ b/rust/ql/test/query-tests/security/CWE-079/axum/XSS.expected
@@ -1,17 +1,19 @@
 #select
 | main.rs:10:10:10:21 | html_content | main.rs:15:55:15:67 | greet_handler | main.rs:10:10:10:21 | html_content | Cross-site scripting vulnerability due to a $@. | main.rs:15:55:15:67 | greet_handler | user-provided value |
 edges
+| main.rs:8:24:8:59 | ...: Query::<...> | main.rs:9:32:9:63 | MacroExpr | provenance |  |
 | main.rs:9:9:9:20 | html_content | main.rs:10:10:10:21 | html_content | provenance |  |
 | main.rs:9:32:9:63 | ...::format(...) | main.rs:9:32:9:63 | { ... } | provenance |  |
 | main.rs:9:32:9:63 | ...::must_use(...) | main.rs:9:9:9:20 | html_content | provenance |  |
 | main.rs:9:32:9:63 | MacroExpr | main.rs:9:32:9:63 | ...::format(...) | provenance | MaD:2 |
 | main.rs:9:32:9:63 | { ... } | main.rs:9:32:9:63 | ...::must_use(...) | provenance | MaD:3 |
-| main.rs:15:55:15:67 | greet_handler | main.rs:9:32:9:63 | MacroExpr | provenance | Src:MaD:1  |
+| main.rs:15:55:15:67 | greet_handler | main.rs:8:24:8:59 | ...: Query::<...> | provenance | Src:MaD:1  |
 models
 | 1 | Source: axum::routing::method_routing::get; Argument[0].Parameter[0..7]; remote |
 | 2 | Summary: alloc::fmt::format; Argument[0]; ReturnValue; taint |
 | 3 | Summary: core::hint::must_use; Argument[0]; ReturnValue; value |
 nodes
+| main.rs:8:24:8:59 | ...: Query::<...> | semmle.label | ...: Query::<...> |
 | main.rs:9:9:9:20 | html_content | semmle.label | html_content |
 | main.rs:9:32:9:63 | ...::format(...) | semmle.label | ...::format(...) |
 | main.rs:9:32:9:63 | ...::must_use(...) | semmle.label | ...::must_use(...) |

--- a/rust/ql/test/query-tests/security/CWE-079/warp/XSS.expected
+++ b/rust/ql/test/query-tests/security/CWE-079/warp/XSS.expected
@@ -1,7 +1,8 @@
 #select
 | main.rs:10:31:10:34 | body | main.rs:7:14:11:9 | \|...\| ... | main.rs:10:31:10:34 | body | Cross-site scripting vulnerability due to a $@. | main.rs:7:14:11:9 | \|...\| ... | user-provided value |
 edges
-| main.rs:7:14:11:9 | \|...\| ... | main.rs:9:32:9:56 | MacroExpr | provenance | Src:MaD:2  |
+| main.rs:7:14:11:9 | \|...\| ... | main.rs:7:15:7:26 | ...: String | provenance | Src:MaD:2  |
+| main.rs:7:15:7:26 | ...: String | main.rs:9:32:9:56 | MacroExpr | provenance |  |
 | main.rs:9:17:9:20 | body | main.rs:10:31:10:34 | body | provenance | Sink:MaD:1 |
 | main.rs:9:32:9:56 | ...::format(...) | main.rs:9:32:9:56 | { ... } | provenance |  |
 | main.rs:9:32:9:56 | ...::must_use(...) | main.rs:9:17:9:20 | body | provenance |  |
@@ -14,6 +15,7 @@ models
 | 4 | Summary: core::hint::must_use; Argument[0]; ReturnValue; value |
 nodes
 | main.rs:7:14:11:9 | \|...\| ... | semmle.label | \|...\| ... |
+| main.rs:7:15:7:26 | ...: String | semmle.label | ...: String |
 | main.rs:9:17:9:20 | body | semmle.label | body |
 | main.rs:9:32:9:56 | ...::format(...) | semmle.label | ...::format(...) |
 | main.rs:9:32:9:56 | ...::must_use(...) | semmle.label | ...::must_use(...) |

--- a/rust/ql/test/query-tests/security/CWE-117/LogInjection.expected
+++ b/rust/ql/test/query-tests/security/CWE-117/LogInjection.expected
@@ -78,6 +78,7 @@ edges
 | main.rs:127:25:127:45 | ...::var(...) | main.rs:127:25:127:45 | ...::var(...) [Ok] | provenance | Src:MaD:7  |
 | main.rs:127:25:127:45 | ...::var(...) [Ok] | main.rs:127:25:127:65 | ... .unwrap_or_default() | provenance | MaD:20 |
 | main.rs:127:25:127:65 | ... .unwrap_or_default() | main.rs:127:13:127:21 | user_data | provenance |  |
+| main.rs:140:32:140:59 | ...: Option::<...> | main.rs:141:22:141:27 | o_path | provenance |  |
 | main.rs:141:13:141:18 | m_path [Some] | main.rs:143:26:143:31 | m_path [Some] | provenance |  |
 | main.rs:141:22:141:27 | o_path | main.rs:141:22:141:38 | o_path.map(...) [Some] | provenance | MaD:14 |
 | main.rs:141:22:141:27 | o_path | main.rs:141:34:141:34 | ... | provenance | MaD:14 |
@@ -85,7 +86,7 @@ edges
 | main.rs:141:34:141:34 | ... | main.rs:141:37:141:37 | x | provenance |  |
 | main.rs:143:26:143:31 | m_path [Some] | main.rs:143:26:143:40 | m_path.unwrap() | provenance | MaD:15 |
 | main.rs:143:26:143:40 | m_path.unwrap() | main.rs:143:18:143:40 | MacroExpr | provenance | Sink:MaD:3 |
-| main.rs:150:32:150:48 | my_axum_handler_1 | main.rs:141:22:141:27 | o_path | provenance | Src:MaD:4  |
+| main.rs:150:32:150:48 | my_axum_handler_1 | main.rs:140:32:140:59 | ...: Option::<...> | provenance | Src:MaD:4  |
 models
 | 1 | Sink: log::__private_api::log; Argument[0]; log-injection |
 | 2 | Sink: std::io::stdio::_eprint; Argument[0]; log-injection |
@@ -174,6 +175,7 @@ nodes
 | main.rs:127:25:127:65 | ... .unwrap_or_default() | semmle.label | ... .unwrap_or_default() |
 | main.rs:130:18:130:38 | MacroExpr | semmle.label | MacroExpr |
 | main.rs:131:19:131:49 | MacroExpr | semmle.label | MacroExpr |
+| main.rs:140:32:140:59 | ...: Option::<...> | semmle.label | ...: Option::<...> |
 | main.rs:141:13:141:18 | m_path [Some] | semmle.label | m_path [Some] |
 | main.rs:141:22:141:27 | o_path | semmle.label | o_path |
 | main.rs:141:22:141:38 | o_path.map(...) [Some] | semmle.label | o_path.map(...) [Some] |

--- a/rust/ql/test/query-tests/security/CWE-918/RequestForgery.expected
+++ b/rust/ql/test/query-tests/security/CWE-918/RequestForgery.expected
@@ -40,7 +40,8 @@ edges
 | request_forgery_tests.rs:31:43:31:50 | user_url | request_forgery_tests.rs:31:42:31:50 | &user_url [&ref] | provenance |  |
 | request_forgery_tests.rs:37:50:37:58 | &user_url [&ref] | request_forgery_tests.rs:37:50:37:58 | &user_url | provenance | Sink:MaD:1 |
 | request_forgery_tests.rs:37:51:37:58 | user_url | request_forgery_tests.rs:37:50:37:58 | &user_url [&ref] | provenance |  |
-| request_forgery_tests.rs:65:42:73:9 | \|...\| ... | request_forgery_tests.rs:68:42:68:42 | a | provenance | Src:MaD:2  |
+| request_forgery_tests.rs:65:42:73:9 | \|...\| ... | request_forgery_tests.rs:65:49:65:57 | ...: String | provenance | Src:MaD:2  |
+| request_forgery_tests.rs:65:49:65:57 | ...: String | request_forgery_tests.rs:68:42:68:42 | a | provenance |  |
 | request_forgery_tests.rs:68:41:68:42 | &a [&ref] | request_forgery_tests.rs:68:41:68:42 | &a | provenance | Sink:MaD:1 |
 | request_forgery_tests.rs:68:42:68:42 | a | request_forgery_tests.rs:68:41:68:42 | &a [&ref] | provenance |  |
 models
@@ -84,6 +85,7 @@ nodes
 | request_forgery_tests.rs:37:50:37:58 | &user_url [&ref] | semmle.label | &user_url [&ref] |
 | request_forgery_tests.rs:37:51:37:58 | user_url | semmle.label | user_url |
 | request_forgery_tests.rs:65:42:73:9 | \|...\| ... | semmle.label | \|...\| ... |
+| request_forgery_tests.rs:65:49:65:57 | ...: String | semmle.label | ...: String |
 | request_forgery_tests.rs:68:41:68:42 | &a | semmle.label | &a |
 | request_forgery_tests.rs:68:41:68:42 | &a [&ref] | semmle.label | &a [&ref] |
 | request_forgery_tests.rs:68:42:68:42 | a | semmle.label | a |

--- a/shared/dataflow/codeql/dataflow/internal/FlowSummaryImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/FlowSummaryImpl.qll
@@ -2292,20 +2292,24 @@ module Make<
       /** Provides a compilation of flow summaries to atomic data-flow steps. */
       module Steps<StepsInputSig StepsInput> {
         private predicate sourceExitStep(SourceOutputNode nodeFrom, Node nodeTo, boolean local) {
-          exists(SummaryComponent sc, SourceSinkReportingElement e |
-            nodeFrom.isExit(_, sc, e, _) and
+          exists(SummaryComponent sc, SourceSinkReportingElement e, string model |
+            nodeFrom.isExit(_, sc, e, model) and
             nodeTo = getSourceDataFlowNode(e, sc) and
-            if e.getEnclosingCallable() = getNodeEnclosingCallable(nodeTo)
+            if
+              e.getEnclosingCallable() = getNodeEnclosingCallable(nodeTo) and
+              (nodeFrom.isEntry(_, model) or summaryStoreStep(_, _, nodeFrom))
             then local = true
             else local = false
           )
         }
 
         private predicate sinkEntryStep(Node nodeFrom, SinkInputNode nodeTo, boolean local) {
-          exists(SummaryComponent sc, SourceSinkReportingElement e |
-            nodeTo.isEntry(_, sc, e, _) and
+          exists(SummaryComponent sc, SourceSinkReportingElement e, string model |
+            nodeTo.isEntry(_, sc, e, model) and
             nodeFrom = getSinkDataFlowNode(e, sc) and
-            if e.getEnclosingCallable() = getNodeEnclosingCallable(nodeFrom)
+            if
+              e.getEnclosingCallable() = getNodeEnclosingCallable(nodeFrom) and
+              (nodeTo.isExit(_, model) or summaryReadStep(nodeTo, _, _))
             then local = true
             else local = false
           )


### PR DESCRIPTION
Modeling more source/sink steps as jump steps instead of local steps means that we avoid skipping over nodes that we would like to see in the path graph. For example, in
```rust
let callback = |x| sink(x);
//              ^ A
//                      ^ B
pass_source_into_callback(callback)
//                        ^^^^^^^^ C
```
we would previously get a direct edge `C -> B`, but now we instead get two edges `C -> A` and `A -> B`.