### PR TITLE
CPP: Disable dynamic reordering for AliasedSSA::isCoveredOffset

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/internal/AliasedSSA.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/internal/AliasedSSA.qll
@@ -815,6 +815,7 @@ private predicate isRelatableMemoryLocation(VariableMemoryLocation vml) {
   vml.getStartBitOffset() != Ints::unknown()
 }
 
+pragma[no_dynamic_join_order]
 private predicate isCoveredOffset(Allocation var, int offsetRank, VariableMemoryLocation vml) {
   exists(int startRank, int endRank, VirtualVariable vvar |
     vml.getStartBitOffset() = rank[startRank](IntValue offset_ | isRelevantOffset(vvar, offset_)) and


### PR DESCRIPTION
We are working on a new dynamic join orderer for CodeQL that join orders predicates at evaluation-time using run-time cardinality information instead of relying on a statically chosen join order decided at compilation-time. At the moment the `AliasedSSA::isCoveredOffset` predicate is join ordered badly by the dynamic join orderer, leading to a catastrophic join regression for `wireshark`. This PR disables dynamic join ordering for this particular predicate, while we work on improving the dynamic join orderer. 

Dynamic join ordering is still disabled by default during compilation and evaluation and the `no_dynamic_join_order` pragma has no effect on compilation when dynamic join ordering is not explicitly enabled during compilation.  