### PR TITLE
Shared: Disable dynamic reordering for select predicate

### DIFF
--- a/shared/concepts/codeql/concepts/ConceptsShared.qll
+++ b/shared/concepts/codeql/concepts/ConceptsShared.qll
@@ -128,6 +128,7 @@ module ConceptsMake<LocationSig Location, DF::InputSig<Location> DataFlowLang> {
            * Gets a data flow node that contributes to the URL of the request.
            * Depending on the framework, a request may have multiple nodes which contribute to the URL.
            */
+          pragma[no_dynamic_join_order]
           abstract DataFlowNode getAUrlPart();
 
           /** Gets a string that identifies the framework used for this request. */


### PR DESCRIPTION
We are working on a new dynamic join orderer for CodeQL that join orders predicates at evaluation-time using run-time cardinality information instead of relying on a statically chosen join order decided at compilation-time. At the moment the dispatch predicate for the `...Request::Range.getAUrlPart` method is join ordered badly by the dynamic join orderer, leading to a catastrophic join regression for `ruby-opal`. This PR disables dynamic join ordering for the affected predicate, while we work on improving the dynamic join orderer. 

Dynamic join ordering is still disabled by default during compilation and evaluation and the `no_dynamic_join_order` pragma has no effect on compilation when dynamic join ordering is not explicitly enabled during compilation.  