### PR TITLE
JS: Report file-coverage for (X)HTML files

### DIFF
--- a/javascript/ql/src/change-notes/2026-09-02-html-coverage.md
+++ b/javascript/ql/src/change-notes/2026-09-02-html-coverage.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* HTML files are now included in file-coverage stats, and will start showing up on the status page for CodeQL under "Scanned Files".

--- a/javascript/resources/codeql-extractor.yml
+++ b/javascript/resources/codeql-extractor.yml
@@ -25,15 +25,23 @@ file_coverage_languages:
     display_name: Vue.js component
     scc_languages:
       - Vue
+  - name: html
+    display_name: HTML
+    scc_languages:
+      - HTML
+      - XHTML
 github_api_languages:
   - JavaScript
   - TypeScript
   - Vue
+  - HTML
 scc_languages:
   - JavaScript
   - TypeScript
   - TypeScript Typings
   - Vue
+  - HTML
+  - XHTML
 file_types:
   - name: javascript
     display_name: JavaScript


### PR DESCRIPTION
Adds HTML and XHTML as files to be included in file-coverage stats, so they will start showing up on the status page for CodeQL under "Scanned Files".