### PR TITLE
CFG: Rename ForeachStmt to ForEachStmt.

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/controlflow/internal/ControlFlowGraph.qll
+++ b/csharp/ql/lib/semmle/code/csharp/controlflow/internal/ControlFlowGraph.qll
@@ -190,7 +190,7 @@ module Ast implements AstSig<Location> {
 
   final private class FinalForeachStmt = CS::ForeachStmt;
 
-  class ForeachStmt extends FinalForeachStmt {
+  class ForEachStmt extends FinalForeachStmt {
     Expr getVariable() {
       result = this.getVariableDeclExpr() or result = this.getVariableDeclTuple()
     }

--- a/java/ql/lib/semmle/code/java/ControlFlowGraph.qll
+++ b/java/ql/lib/semmle/code/java/ControlFlowGraph.qll
@@ -100,7 +100,7 @@ private module Ast implements AstSig<Location> {
 
   final private class FinalEnhancedForStmt = J::EnhancedForStmt;
 
-  class ForeachStmt extends FinalEnhancedForStmt {
+  class ForEachStmt extends FinalEnhancedForStmt {
     Expr getVariable() { result = super.getVariable() }
 
     Expr getCollection() { result = super.getExpr() }

--- a/python/ql/lib/semmle/python/controlflow/internal/AstNodeImpl.qll
+++ b/python/ql/lib/semmle/python/controlflow/internal/AstNodeImpl.qll
@@ -657,10 +657,10 @@ module Ast implements AstSig<Py::Location> {
   }
 
   /** A for-each loop (`for x in iterable:`). */
-  class ForeachStmt extends LoopStmtImpl {
+  class ForEachStmt extends LoopStmtImpl {
     private Py::For forStmt;
 
-    ForeachStmt() { this = TPyStmt(forStmt) }
+    ForEachStmt() { this = TPyStmt(forStmt) }
 
     /** Gets the loop variable. */
     Expr getVariable() { result.asExpr() = forStmt.getTarget() }
@@ -898,7 +898,7 @@ module Ast implements AstSig<Py::Location> {
   AstNode getLoopElse(LoopStmt loop) {
     result = loop.(WhileStmt).getElse()
     or
-    result = loop.(ForeachStmt).getElse()
+    result = loop.(ForEachStmt).getElse()
   }
 
   /** An exception handler (`except` or `except*`). */

--- a/ruby/ql/lib/codeql/ruby/controlflow/ControlFlowGraph.qll
+++ b/ruby/ql/lib/codeql/ruby/controlflow/ControlFlowGraph.qll
@@ -295,9 +295,9 @@ private module Ast implements AstSig<Location> {
     AstNode getUpdate(int index) { none() }
   }
 
-  // `ForExpr` would be a match for `ForeachStmt`, but it is desugared.
-  class ForeachStmt extends LoopStmt {
-    ForeachStmt() { none() }
+  // `ForExpr` would be a match for `ForEachStmt`, but it is desugared.
+  class ForEachStmt extends LoopStmt {
+    ForEachStmt() { none() }
 
     Expr getVariable() { none() }
 

--- a/shared/controlflow/codeql/controlflow/ControlFlowGraph.qll
+++ b/shared/controlflow/codeql/controlflow/ControlFlowGraph.qll
@@ -147,7 +147,7 @@ signature module AstSig<LocationSig Location> {
   }
 
   /** A for-loop that iterates over the elements of a collection. */
-  class ForeachStmt extends LoopStmt {
+  class ForEachStmt extends LoopStmt {
     /** Gets the variable declaration of this `foreach` loop. */
     Expr getVariable();
 
@@ -650,7 +650,7 @@ module Make0<LocationSig Location, AstSig<Location> Ast> {
         any(Case case).getGuard() = n
       )
       or
-      any(ForeachStmt foreachstmt).getCollection() = n and kind.isEmptiness()
+      any(ForEachStmt foreachstmt).getCollection() = n and kind.isEmptiness()
       or
       kind.isMatching() and
       (
@@ -1656,7 +1656,7 @@ module Make0<LocationSig Location, AstSig<Location> Ast> {
           n2.isAfter(loopstmt)
         )
         or
-        exists(ForeachStmt foreachstmt |
+        exists(ForEachStmt foreachstmt |
           n1.isBefore(foreachstmt) and
           n2.isBefore(foreachstmt.getCollection())
           or
@@ -2401,7 +2401,7 @@ module Make0<LocationSig Location, AstSig<Location> Ast> {
             // allow for loop headers in foreach loops (they're checking emptiness on the iterator, not the collection)
             not (
               t instanceof DirectSuccessor and
-              node.isAdditional(any(ForeachStmt foreach), loopHeaderTag())
+              node.isAdditional(any(ForEachStmt foreach), loopHeaderTag())
             ) and
             // allow for functions with multiple bodies
             not exists(Callable c |

--- a/unified/ql/lib/codeql/unified/internal/ControlFlowGraph.qll
+++ b/unified/ql/lib/codeql/unified/internal/ControlFlowGraph.qll
@@ -123,7 +123,7 @@ private module Ast implements AstSig<Location> {
     AstNode getUpdate(int index) { none() }
   }
 
-  class ForeachStmt extends LoopStmt instanceof U::ForEachStmt {
+  class ForEachStmt extends LoopStmt instanceof U::ForEachStmt {
     override Stmt getBody() { result = U::ForEachStmt.super.getBody() }
 
     // TODO support foreach guard


### PR DESCRIPTION
This renames all the instances that are effectively private (everything except C#).