### PR TITLE
C#: Disable dynamic reordering for Unification::Gvn::unifiableTypeArguments

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/Unification.qll
+++ b/csharp/ql/lib/semmle/code/csharp/Unification.qll
@@ -348,6 +348,7 @@ module Gvn {
    *
    * `subsumes` indicates whether `arg1` in fact subsumes `arg2`.
    */
+  pragma[no_dynamic_join_order]
   pragma[nomagic]
   private predicate unifiableTypeArguments(
     CompoundTypeKind k, GvnTypeArgument arg1, GvnTypeArgument arg2, int i, boolean subsumes


### PR DESCRIPTION
We are working on a new dynamic join orderer for CodeQL that join orders predicates at evaluation-time using run-time cardinality information instead of relying on a statically chosen join order decided at compilation-time. At the moment the `Unification::Gvn::unifiableTypeArguments` predicate is join ordered badly by the dynamic join orderer, leading to a catastrophic join regression for `efcore`. This PR disables dynamic join ordering for this particular predicate, while we work on improving the dynamic join orderer. 

Dynamic join ordering is still disabled by default during compilation and evaluation and the `no_dynamic_join_order` pragma has no effect on compilation when dynamic join ordering is not explicitly enabled during compilation.  