### PR TITLE
C#: Support `replaces-base` via the DependabotProxy.

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependabotProxy.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependabotProxy.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Immutable;
 using System.Collections.Generic;
 using System.IO;
 using System.Security.Cryptography.X509Certificates;
@@ -14,13 +15,39 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         /// <summary>
         /// Represents configurations for package registries.
         /// </summary>
-        /// <param name="Type">The type of package registry.</param>
-        /// <param name="URL">The URL of the package registry.</param>
-        public record class RegistryConfig(string Type, string URL);
+        public class RegistryConfig
+        {
+            /// <summary>
+            /// The type of the package registry.
+            /// </summary>
+            public string Type { get; init; } = "";
+
+            /// <summary>
+            /// The URL of the package registry.
+            /// </summary>
+            public string URL { get; init; } = "";
+
+            /// <summary>
+            /// A boolean indicating whether this registry replaces the base registry.
+            /// </summary>
+            [JsonProperty("replaces-base")]
+            public bool ReplacesBase { get; init; } = false;
+        };
 
         public string Address { get; }
 
-        public HashSet<string> RegistryURLs { get; } = [];
+        /// <summary>
+        /// A dictionary mapping registry URLs to a boolean indicating whether they replace the base registry.
+        /// </summary>
+        private readonly Dictionary<string, bool> registryMapping = [];
+
+        private ImmutableHashSet<string>? registryURLs;
+        public ImmutableHashSet<string> RegistryURLs =>
+            registryURLs ??= registryMapping.Keys.ToImmutableHashSet();
+
+        private ImmutableHashSet<string>? registryBaseURLs;
+        public ImmutableHashSet<string> RegistryBaseURLs =>
+            registryBaseURLs ??= registryMapping.Where(kvp => kvp.Value).Select(kvp => kvp.Key).ToImmutableHashSet();
 
         public string? CertificatePath { get; private set; }
 
@@ -65,7 +92,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                             }
 
                             logger.LogInfo($"Found private registry at '{registry.URL}'");
-                            RegistryURLs.Add(registry.URL);
+                            registryMapping.AddOrUpdateToLatest(registry.URL, registry.ReplacesBase);
                         }
                     }
                 }

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependabotProxy.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependabotProxy.cs
@@ -20,12 +20,12 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             /// <summary>
             /// The type of the package registry.
             /// </summary>
-            public string Type { get; init; } = "";
+            public string? Type { get; init; }
 
             /// <summary>
             /// The URL of the package registry.
             /// </summary>
-            public string URL { get; init; } = "";
+            public string? Url { get; init; }
 
             /// <summary>
             /// A boolean indicating whether this registry replaces the base registry.
@@ -42,10 +42,22 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         private readonly Dictionary<string, bool> registryMapping = [];
 
         private ImmutableHashSet<string>? registryURLs;
+        /// <summary>
+        /// Gets the set of registry URLs that have been configured as part of the organization-level
+        /// private registry configuration. This includes all registries, regardless of whether they replace
+        /// the default feeds.
+        /// </summary>
         public ImmutableHashSet<string> RegistryURLs =>
             registryURLs ??= registryMapping.Keys.ToImmutableHashSet();
 
         private ImmutableHashSet<string>? registryBaseURLs;
+        /// <summary>
+        /// Gets the set of registry URLs that have been configured as part of the organization-level
+        /// private registry configuration and that replace the default registry. This is a subset of
+        /// <see cref="RegistryURLs"/>.
+        /// If non-empty, the set should be used as a replacement for the default registry during
+        /// package resolution.
+        /// </summary>
         public ImmutableHashSet<string> RegistryBaseURLs =>
             registryBaseURLs ??= registryMapping.Where(kvp => kvp.Value).Select(kvp => kvp.Key).ToImmutableHashSet();
 
@@ -83,16 +95,22 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                     {
                         foreach (RegistryConfig registry in array)
                         {
-                            // The array contains all configured private registries, not just ones for C#.
-                            // We ignore the non-C# ones here.
-                            if (!registry.Type.Equals("nuget_feed"))
+                            if (string.IsNullOrWhiteSpace(registry.Url))
                             {
-                                logger.LogDebug($"Ignoring registry at '{registry.URL}' since it is not of type 'nuget_feed'.");
+                                logger.LogDebug("Ignoring registry with empty URL.");
                                 continue;
                             }
 
-                            logger.LogInfo($"Found private registry at '{registry.URL}'");
-                            registryMapping.AddOrUpdateToLatest(registry.URL, registry.ReplacesBase);
+                            // The array contains all configured private registries, not just ones for C#.
+                            // We ignore the non-C# ones here.
+                            if (registry.Type is null || !registry.Type.Equals("nuget_feed"))
+                            {
+                                logger.LogDebug($"Ignoring registry at '{registry.Url}' since it is not of type 'nuget_feed'.");
+                                continue;
+                            }
+
+                            logger.LogInfo($"Found private registry at '{registry.Url}'");
+                            registryMapping.AddOrUpdateToLatest(registry.Url, registry.ReplacesBase);
                         }
                     }
                 }

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependabotProxy.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependabotProxy.cs
@@ -97,13 +97,19 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                         {
                             if (string.IsNullOrWhiteSpace(registry.Url))
                             {
-                                logger.LogDebug("Ignoring registry with empty URL.");
+                                logger.LogError("Ignoring registry with empty URL.");
+                                continue;
+                            }
+
+                            if (string.IsNullOrWhiteSpace(registry.Type))
+                            {
+                                logger.LogError($"Ignoring registry at '{registry.Url}' since it has no type.");
                                 continue;
                             }
 
                             // The array contains all configured private registries, not just ones for C#.
                             // We ignore the non-C# ones here.
-                            if (registry.Type is null || !registry.Type.Equals("nuget_feed"))
+                            if (!registry.Type.Equals("nuget_feed"))
                             {
                                 logger.LogDebug($"Ignoring registry at '{registry.Url}' since it is not of type 'nuget_feed'.");
                                 continue;

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DotNet.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DotNet.cs
@@ -137,7 +137,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
 
         private static readonly IReadOnlyList<string> nugetListSourceCommandArgs = ["nuget", "list", "source", "--format", "Short"];
 
-        public IList<string> GetNugetFeeds(string nugetConfig)
+        public IList<string> GetNugetFeedsFromConfig(string nugetConfig)
         {
             logger.LogInfo($"Getting NuGet feeds from '{nugetConfig}'...");
             return GetResultList([.. nugetListSourceCommandArgs, "--configfile", nugetConfig]);

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/EnvironmentVariableNames.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/EnvironmentVariableNames.cs
@@ -56,7 +56,6 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
 
         /// <summary>
         /// Specifies the NuGet feeds to use for fallback NuGet dependency fetching. The value is a space-separated list of feed URLs.
-        /// The default value is `https://api.nuget.org/v3/index.json`.
         /// </summary>
         public const string FallbackNugetFeeds = "CODEQL_EXTRACTOR_CSHARP_BUILDLESS_NUGET_FEEDS_FALLBACK";
 

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/FeedManager.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/FeedManager.cs
@@ -17,7 +17,6 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         private readonly IFileProvider fileProvider;
         private readonly DependencyDirectory emptyPackageDirectory;
         private readonly ImmutableHashSet<string> privateRegistryFeeds;
-        private readonly ImmutableHashSet<string> defaultFeeds;
         private readonly IFeedManagerIO feedManagerIo;
 
         /// <summary>
@@ -76,6 +75,12 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         private readonly Lazy<ImmutableHashSet<string>> lazyReachableDefaultFeeds;
 
         /// <summary>
+        /// Gets the list of default NuGet feeds that are configured in the environment.
+        /// This is either the public NuGet feed or a set of feeds specified by the environment.
+        /// </summary>
+        public ImmutableHashSet<string> DefaultFeeds { get; init; }
+
+        /// <summary>
         /// Gets the list of reachable default NuGet feeds.
         /// </summary>
         public ImmutableHashSet<string> ReachableDefaultFeeds => lazyReachableDefaultFeeds.Value;
@@ -88,7 +93,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             this.feedManagerIo = feedManagerIo;
             privateRegistryFeeds = dependabotProxy?.RegistryURLs ?? [];
             HasPrivateRegistryFeeds = privateRegistryFeeds.Count > 0;
-            defaultFeeds = dependabotProxy?.RegistryBaseURLs.Any() == true
+            DefaultFeeds = dependabotProxy?.RegistryBaseURLs.Any() == true
                 ? dependabotProxy.RegistryBaseURLs
                 : [PublicNugetOrgFeed];
             emptyPackageDirectory = new DependencyDirectory("empty", "empty package", logger);
@@ -107,7 +112,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                 var reachableFallbackFeeds = GetReachableFallbackNugetFeeds();
                 return reachableFallbackFeeds.ToImmutableHashSet();
             });
-            lazyReachableDefaultFeeds = new Lazy<ImmutableHashSet<string>>(() => CheckSpecifiedFeeds(defaultFeeds));
+            lazyReachableDefaultFeeds = new Lazy<ImmutableHashSet<string>>(() => CheckSpecifiedFeeds(DefaultFeeds));
         }
 
         public FeedManager(ILogger logger, IDotNet dotnet, IDependabotProxy? dependabotProxy, IFileProvider fileProvider)
@@ -311,8 +316,8 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             var fallbackFeeds = EnvironmentVariables.GetURLs(EnvironmentVariableNames.FallbackNugetFeeds).ToHashSet();
             if (fallbackFeeds.Count == 0)
             {
-                fallbackFeeds.UnionWith(defaultFeeds);
-                logger.LogInfo($"No fallback NuGet feeds specified. Adding default feeds: {string.Join(", ", defaultFeeds.OrderBy(f => f))}");
+                fallbackFeeds.UnionWith(DefaultFeeds);
+                logger.LogInfo($"No fallback NuGet feeds specified. Adding default feeds: {string.Join(", ", DefaultFeeds.OrderBy(f => f))}");
 
                 var shouldAddNugetConfigFeeds = EnvironmentVariables.GetBooleanOptOut(EnvironmentVariableNames.AddNugetConfigFeedsToFallback);
                 logger.LogInfo($"Adding feeds from nuget.config to fallback restore: {shouldAddNugetConfigFeeds}");

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/FeedManager.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/FeedManager.cs
@@ -10,13 +10,17 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
 {
     internal sealed partial class FeedManager : IDisposable
     {
-        internal const string PublicNugetOrgFeed = "https://api.nuget.org/v3/index.json";
+        private const string PublicNugetOrg = "nuget.org";
+        private const string PublicDotNugetOrg = $".{PublicNugetOrg}";
+        internal const string PublicApiNugetOrgFeed = $"https://api{PublicDotNugetOrg}/v3/index.json";
 
         private readonly ILogger logger;
         private readonly IDotNet dotnet;
         private readonly IFileProvider fileProvider;
         private readonly DependencyDirectory emptyPackageDirectory;
         private readonly ImmutableHashSet<string> privateRegistryFeeds;
+        private readonly bool hasPrivateRegistryBaseFeeds;
+        private readonly ImmutableHashSet<string> privateRegistryBaseFeeds;
         private readonly IFeedManagerIO feedManagerIo;
 
         /// <summary>
@@ -93,9 +97,12 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             this.feedManagerIo = feedManagerIo;
             privateRegistryFeeds = dependabotProxy?.RegistryURLs ?? [];
             HasPrivateRegistryFeeds = privateRegistryFeeds.Count > 0;
-            DefaultFeeds = dependabotProxy?.RegistryBaseURLs.Any() == true
-                ? dependabotProxy.RegistryBaseURLs
-                : [PublicNugetOrgFeed];
+            privateRegistryBaseFeeds = dependabotProxy?.RegistryBaseURLs ?? [];
+            hasPrivateRegistryBaseFeeds = privateRegistryBaseFeeds.Count > 0;
+
+            DefaultFeeds = hasPrivateRegistryBaseFeeds
+                ? privateRegistryBaseFeeds
+                : [PublicApiNugetOrgFeed];
             emptyPackageDirectory = new DependencyDirectory("empty", "empty package", logger);
 
             lazyExplicitFeeds = new Lazy<ImmutableHashSet<string>>(GetExplicitFeeds);
@@ -120,6 +127,20 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         {
         }
 
+        private bool IsNugetOrgFeed(string url)
+        {
+            try
+            {
+                var uri = new Uri(url);
+                return uri.Host.EndsWith(PublicDotNugetOrg, StringComparison.InvariantCultureIgnoreCase) ||
+                    string.Equals(uri.Host, PublicNugetOrg, StringComparison.InvariantCultureIgnoreCase);
+            }
+            catch (UriFormatException)
+            {
+                return false;
+            }
+        }
+
         private IEnumerable<string> GetFeeds(Func<IList<string>> getNugetFeeds)
         {
             var results = getNugetFeeds();
@@ -138,6 +159,17 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                     !url.StartsWith("http://", StringComparison.InvariantCultureIgnoreCase))
                 {
                     logger.LogInfo($"Skipping feed '{url}' as it is not a valid URL.");
+                    continue;
+                }
+
+                if (hasPrivateRegistryBaseFeeds && IsNugetOrgFeed(url))
+                {
+                    // Use private registry base feeds.
+                    foreach (var feed in privateRegistryBaseFeeds)
+                    {
+                        logger.LogDebug($"Using private registry base feed '{feed}'.");
+                        yield return feed;
+                    }
                     continue;
                 }
 

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/FeedManager.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/FeedManager.cs
@@ -141,10 +141,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                     continue;
                 }
 
-                if (!string.IsNullOrWhiteSpace(url))
-                {
-                    yield return url;
-                }
+                yield return url;
             }
         }
 

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/FeedManager.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/FeedManager.cs
@@ -78,7 +78,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             this.dotnet = dotnet;
             this.fileProvider = fileProvider;
             this.feedManagerIo = feedManagerIo;
-            privateRegistryFeeds = dependabotProxy?.RegistryURLs.ToImmutableHashSet() ?? [];
+            privateRegistryFeeds = dependabotProxy?.RegistryURLs ?? [];
             HasPrivateRegistryFeeds = privateRegistryFeeds.Count > 0;
             emptyPackageDirectory = new DependencyDirectory("empty", "empty package", logger);
 

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/FeedManager.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/FeedManager.cs
@@ -17,6 +17,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         private readonly IFileProvider fileProvider;
         private readonly DependencyDirectory emptyPackageDirectory;
         private readonly ImmutableHashSet<string> privateRegistryFeeds;
+        private readonly ImmutableHashSet<string> defaultFeeds;
         private readonly IFeedManagerIO feedManagerIo;
 
         /// <summary>
@@ -72,6 +73,13 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         /// </summary>
         public ImmutableHashSet<string> ReachableFallbackFeeds => lazyReachableFallbackFeeds.Value;
 
+        private readonly Lazy<ImmutableHashSet<string>> lazyReachableDefaultFeeds;
+
+        /// <summary>
+        /// Gets the list of reachable default NuGet feeds.
+        /// </summary>
+        public ImmutableHashSet<string> ReachableDefaultFeeds => lazyReachableDefaultFeeds.Value;
+
         public FeedManager(ILogger logger, IDotNet dotnet, IDependabotProxy? dependabotProxy, IFileProvider fileProvider, IFeedManagerIO feedManagerIo)
         {
             this.logger = logger;
@@ -80,6 +88,9 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             this.feedManagerIo = feedManagerIo;
             privateRegistryFeeds = dependabotProxy?.RegistryURLs ?? [];
             HasPrivateRegistryFeeds = privateRegistryFeeds.Count > 0;
+            defaultFeeds = dependabotProxy?.RegistryBaseURLs.Any() == true
+                ? dependabotProxy.RegistryBaseURLs
+                : [PublicNugetOrgFeed];
             emptyPackageDirectory = new DependencyDirectory("empty", "empty package", logger);
 
             lazyExplicitFeeds = new Lazy<ImmutableHashSet<string>>(GetExplicitFeeds);
@@ -96,6 +107,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                 var reachableFallbackFeeds = GetReachableFallbackNugetFeeds();
                 return reachableFallbackFeeds.ToImmutableHashSet();
             });
+            lazyReachableDefaultFeeds = new Lazy<ImmutableHashSet<string>>(() => CheckSpecifiedFeeds(defaultFeeds));
         }
 
         public FeedManager(ILogger logger, IDotNet dotnet, IDependabotProxy? dependabotProxy, IFileProvider fileProvider)
@@ -267,22 +279,6 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         }
 
         /// <summary>
-        /// Return true if the default NuGet feed is reachable, false otherwise.
-        /// If the reachability check is disabled, this method will always return true.
-        /// </summary>
-        /// <returns>True if the default NuGet feed is reachable, false otherwise.</returns>
-        public bool IsDefaultFeedReachable()
-        {
-            if (CheckNugetFeedResponsiveness)
-            {
-                var (initialTimeout, tryCount) = GetFeedRequestSettings(isFallback: false);
-                return feedManagerIo.IsFeedReachable(PublicNugetOrgFeed, initialTimeout, tryCount);
-            }
-
-            return true;
-        }
-
-        /// <summary>
         /// Tests which of the feeds given by <paramref name="feedsToCheck"/> are reachable.
         /// </summary>
         /// <param name="feedsToCheck">The feeds to check.</param>
@@ -315,8 +311,8 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             var fallbackFeeds = EnvironmentVariables.GetURLs(EnvironmentVariableNames.FallbackNugetFeeds).ToHashSet();
             if (fallbackFeeds.Count == 0)
             {
-                fallbackFeeds.Add(PublicNugetOrgFeed);
-                logger.LogInfo($"No fallback NuGet feeds specified. Adding default feed: {PublicNugetOrgFeed}");
+                fallbackFeeds.UnionWith(defaultFeeds);
+                logger.LogInfo($"No fallback NuGet feeds specified. Adding default feeds: {string.Join(", ", defaultFeeds.OrderBy(f => f))}");
 
                 var shouldAddNugetConfigFeeds = EnvironmentVariables.GetBooleanOptOut(EnvironmentVariableNames.AddNugetConfigFeedsToFallback);
                 logger.LogInfo($"Adding feeds from nuget.config to fallback restore: {shouldAddNugetConfigFeeds}");

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/FeedManager.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/FeedManager.cs
@@ -181,7 +181,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             GetFeeds(() => dotnet.GetNugetFeedsFromFolder(folderPath));
 
         private IEnumerable<string> GetFeedsFromNugetConfig(string nugetConfigPath) =>
-            GetFeeds(() => dotnet.GetNugetFeeds(nugetConfigPath));
+            GetFeeds(() => dotnet.GetNugetFeedsFromConfig(nugetConfigPath));
 
         /// <summary>
         /// Constructs the NuGet sources argument for the restore command based on the given feeds.

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/FeedManager.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/FeedManager.cs
@@ -359,6 +359,10 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                     logger.LogInfo($"Using NuGet feeds from nuget.config files as fallback feeds: {string.Join(", ", ExplicitFeeds.OrderBy(f => f))}");
                 }
             }
+            else
+            {
+                logger.LogInfo($"Using fallback NuGet feeds from environment variable '{EnvironmentVariableNames.FallbackNugetFeeds}'.");
+            }
 
             return GetReachableNuGetFeeds(fallbackFeeds, isFallback: true);
         }

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/IDependabotProxy.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/IDependabotProxy.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Security.Cryptography.X509Certificates;
 
 namespace Semmle.Extraction.CSharp.DependencyFetching
@@ -14,7 +14,12 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         /// <summary>
         /// The URLs of package registries that are configured for the proxy.
         /// </summary>
-        HashSet<string> RegistryURLs { get; }
+        ImmutableHashSet<string> RegistryURLs { get; }
+
+        /// <summary>
+        /// The URLs of package registries that replace the base registry.
+        /// </summary>
+        ImmutableHashSet<string> RegistryBaseURLs { get; }
 
         /// <summary>
         /// The path to the temporary file where the certificate is stored.

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/IDotNet.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/IDotNet.cs
@@ -13,7 +13,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         IList<string> GetListedRuntimes();
         IList<string> GetListedSdks();
         bool Exec(List<string> execArgs);
-        IList<string> GetNugetFeeds(string nugetConfig);
+        IList<string> GetNugetFeedsFromConfig(string nugetConfig);
         IList<string> GetNugetFeedsFromFolder(string folderPath);
     }
 

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/NugetPackageRestorer.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/NugetPackageRestorer.cs
@@ -460,7 +460,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                 return true;
             }
 
-            if (!feedManager.CheckNugetFeedResponsiveness && res.HasNugetPackageSourceError && nugetSources.Count > 0)
+            if (!feedManager.CheckNugetFeedResponsiveness && !feedManager.HasPrivateRegistryFeeds && res.HasNugetPackageSourceError && nugetSources.Count > 0)
             {
                 logger.LogDebug($"Trying to restore '{package}' without explicitly providing NuGet sources.");
                 // Restore could not be completed because the listed source is unavailable. Try without an explicit restore source argument.

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/PackagesConfigRestorer.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/PackagesConfigRestorer.cs
@@ -165,7 +165,10 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
 
                 List<string> sourcesArgument = [];
                 var feedsToUse = feedManager.FeedsToUse(packagesConfig).ToList();
-                var useDefaultFeeds = feedsToUse.Count == 0 && feedManager.ReachableDefaultFeeds.Count > 0;
+                var defaultFeeds = feedManager.CheckNugetFeedResponsiveness
+                    ? feedManager.ReachableDefaultFeeds
+                    : feedManager.DefaultFeeds;
+                var useDefaultFeeds = feedsToUse.Count == 0 && defaultFeeds.Count > 0;
 
                 // Explicitly construct the sources to be used for the restore command when checking feed
                 // responsiveness, using private registries, or falling back to default feeds.
@@ -173,7 +176,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                 {
                     if (useDefaultFeeds)
                     {
-                        feedsToUse.AddRange(feedManager.ReachableDefaultFeeds);
+                        feedsToUse.AddRange(defaultFeeds);
                     }
                     var restoreFeeds = feedManager.RestoreFeeds(feedsToUse);
                     sourcesArgument = restoreFeeds.SelectMany<string, string>(feed => ["-Source", feed]).ToList();

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/PackagesConfigRestorer.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/PackagesConfigRestorer.cs
@@ -67,10 +67,6 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
 
             private bool IsWindows => SystemBuildActions.Instance.IsWindows();
 
-            private bool? isDefaultFeedReachable;
-            private bool IsDefaultFeedReachable =>
-                isDefaultFeedReachable ??= feedManager.IsDefaultFeedReachable();
-
             /// <summary>
             /// Create the package manager for a specified source tree.
             /// </summary>
@@ -169,15 +165,15 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
 
                 List<string> sourcesArgument = [];
                 var feedsToUse = feedManager.FeedsToUse(packagesConfig).ToList();
-                var useDefaultFeed = feedsToUse.Count == 0 && IsDefaultFeedReachable;
+                var useDefaultFeeds = feedsToUse.Count == 0 && feedManager.ReachableDefaultFeeds.Count > 0;
 
                 // Explicitly construct the sources to be used for the restore command when checking feed
-                // responsiveness, using private registries, or falling back to nuget.org.
-                if (feedManager.CheckNugetFeedResponsiveness || feedManager.HasPrivateRegistryFeeds || useDefaultFeed)
+                // responsiveness, using private registries, or falling back to default feeds.
+                if (feedManager.CheckNugetFeedResponsiveness || feedManager.HasPrivateRegistryFeeds || useDefaultFeeds)
                 {
-                    if (useDefaultFeed)
+                    if (useDefaultFeeds)
                     {
-                        feedsToUse.Add(FeedManager.PublicNugetOrgFeed);
+                        feedsToUse.AddRange(feedManager.ReachableDefaultFeeds);
                     }
                     var restoreFeeds = feedManager.RestoreFeeds(feedsToUse);
                     sourcesArgument = restoreFeeds.SelectMany<string, string>(feed => ["-Source", feed]).ToList();

--- a/csharp/extractor/Semmle.Extraction.Tests/DependabotProxy.cs
+++ b/csharp/extractor/Semmle.Extraction.Tests/DependabotProxy.cs
@@ -135,7 +135,8 @@ namespace Semmle.Extraction.Tests
 
             // Verify
             Assert.NotNull(proxy);
-            Assert.Equal([], proxy.RegistryURLs);
+            Assert.Empty(proxy.RegistryURLs);
+            Assert.Empty(proxy.RegistryBaseURLs);
         }
 
         [Fact]
@@ -158,6 +159,7 @@ namespace Semmle.Extraction.Tests
             Assert.Equal([
                 "https://nuget.pkg.github.com/org/index.json"
             ], proxy.RegistryURLs);
+            Assert.Empty(proxy.RegistryBaseURLs);
         }
 
         [Fact]
@@ -180,6 +182,33 @@ namespace Semmle.Extraction.Tests
             Assert.Equal([
                 "https://example.com/org/index.json"
             ], proxy.RegistryURLs);
+            Assert.Empty(proxy.RegistryBaseURLs);
+        }
+
+        [Fact]
+        public void TestDependabotReplacesBase1()
+        {
+            // Setup
+            var config = new DependabotConfigurationStub
+            {
+                Port = "8080",
+                Host = "localhost",
+                RegistryURLs = "[ { \"type\": \"nuget_feed\", \"url\": \"https://example.com/org/index.json\", \"replaces-base\": true }, { \"type\": \"nuget_feed\", \"url\": \"https://example2.com/org/index.json\", \"replaces-base\": false } ]"
+            };
+
+            // Execute
+            using var tempWorkingDirectory = MakeTemporaryDirectory();
+            using var proxy = DependabotProxy.Make(config, new LoggerStub(), new DiagnosticsWriterStub(), tempWorkingDirectory);
+
+            // Verify
+            Assert.NotNull(proxy);
+            Assert.Equal([
+                "https://example.com/org/index.json",
+                "https://example2.com/org/index.json"
+            ], proxy.RegistryURLs);
+            Assert.Equal([
+                "https://example.com/org/index.json",
+            ], proxy.RegistryBaseURLs);
         }
     }
 }

--- a/csharp/extractor/Semmle.Extraction.Tests/DependabotProxy.cs
+++ b/csharp/extractor/Semmle.Extraction.Tests/DependabotProxy.cs
@@ -28,8 +28,12 @@ namespace Semmle.Extraction.Tests
             return new TemporaryDirectory(tmp, "testing", new LoggerStub());
         }
 
+        /// <summary>
+        /// The purpose of this test is to verify that the registry proxy correctly handles the case where the port is not specified.
+        /// In this case, the registry proxy should not be created.
+        /// </summary>
         [Fact]
-        public void TestDependabotProxyCreation1()
+        public void TestDependabotProxyNoPort()
         {
             // Setup
             var config = new DependabotConfigurationStub
@@ -46,8 +50,12 @@ namespace Semmle.Extraction.Tests
             Assert.Null(proxy);
         }
 
+        /// <summary>
+        /// The purpose of this test is to verify that the registry proxy correctly handles the case where the host is not specified.
+        /// In this case, the registry proxy should not be created.
+        /// </summary>
         [Fact]
-        public void TestDependabotProxyCreation2()
+        public void TestDependabotProxyNoHost()
         {
             // Setup
             var config = new DependabotConfigurationStub
@@ -96,6 +104,10 @@ namespace Semmle.Extraction.Tests
         -----END CERTIFICATE-----
         """;
 
+        /// <summary>
+        /// The purpose of this test is to verify that the registry proxy correctly handles the case
+        /// where the port, host, and certificate are specified.
+        /// </summary>
         [Fact]
         public void TestDependabotProxyCertificate()
         {
@@ -118,8 +130,13 @@ namespace Semmle.Extraction.Tests
             Assert.NotNull(proxy.CertificatePath);
         }
 
+        /// <summary>
+        /// The purpose of this test is to verify that the registry proxy correctly handles the case
+        /// where the RegistryURLs environment variable is not a valid JSON list.
+        /// In this case, the registry proxy should be created, but the list of private registries should be empty.
+        /// </summary>
         [Fact]
-        public void TestDependabotRegistryUrls1()
+        public void TestDependabotRegistryUrlsParseError()
         {
             // Setup
             var config = new DependabotConfigurationStub
@@ -139,8 +156,13 @@ namespace Semmle.Extraction.Tests
             Assert.Empty(proxy.RegistryBaseURLs);
         }
 
+        /// <summary>
+        /// The purpose of this test is to verify that the registry proxy correctly handles the case
+        /// where the RegistryURLs environment variable is a valid JSON list with a single entry.
+        /// In this case, the registry proxy should be created, and the list of private registries should contain the single entry.
+        /// </summary>
         [Fact]
-        public void TestDependabotRegistryUrls2()
+        public void TestDependabotRegistryUrlsSingle()
         {
             // Setup
             var config = new DependabotConfigurationStub
@@ -162,6 +184,13 @@ namespace Semmle.Extraction.Tests
             Assert.Empty(proxy.RegistryBaseURLs);
         }
 
+        /// <summary>
+        /// The purpose of this test is to verify that the registry proxy correctly handles the case
+        /// where the RegistryURLs environment variable is a valid JSON list with multiple entries, but only one of them
+        /// is of type "nuget_feed", which is relevant for C#.
+        /// In this case, the registry proxy should be created, and the list of private registries should
+        /// contain only the entry of type "nuget_feed".
+        /// </summary>
         [Fact]
         public void TestDependabotRegistryUrls3()
         {
@@ -185,8 +214,15 @@ namespace Semmle.Extraction.Tests
             Assert.Empty(proxy.RegistryBaseURLs);
         }
 
+        /// <summary>
+        /// The purpose of this test is to verify that the registry proxy correctly handles the case
+        /// where the RegistryURLs environment variable is a valid JSON list with multiple entries and one of them
+        /// is configured to replace the base feeds.
+        /// In this case, the registry proxy should be created, and the list of private registries should contain all
+        /// entries, while the list of base registries should contain only the entry that replaces the base feeds.
+        /// </summary>
         [Fact]
-        public void TestDependabotReplacesBase1()
+        public void TestDependabotRegistryUrlsReplacesBase()
         {
             // Setup
             var config = new DependabotConfigurationStub

--- a/csharp/extractor/Semmle.Extraction.Tests/DotNet.cs
+++ b/csharp/extractor/Semmle.Extraction.Tests/DotNet.cs
@@ -285,7 +285,7 @@ namespace Semmle.Extraction.Tests
             var dotnet = MakeDotnet(dotnetCliInvoker);
 
             // Execute
-            dotnet.GetNugetFeeds("abc");
+            dotnet.GetNugetFeedsFromConfig("abc");
 
             // Verify
             var lastArgs = dotnetCliInvoker.GetLastArgs();

--- a/csharp/extractor/Semmle.Extraction.Tests/DotNetStub.cs
+++ b/csharp/extractor/Semmle.Extraction.Tests/DotNetStub.cs
@@ -30,7 +30,7 @@ namespace Semmle.Extraction.Tests
 
         public bool Exec(List<string> execArgs) => true;
 
-        public IList<string> GetNugetFeeds(string nugetConfig) => nugetFeedsFromConfig;
+        public IList<string> GetNugetFeedsFromConfig(string nugetConfig) => nugetFeedsFromConfig;
 
         public IList<string> GetNugetFeedsFromFolder(string folderPath) => nugetFeedsFromFolder;
     }

--- a/csharp/extractor/Semmle.Extraction.Tests/FeedManager.cs
+++ b/csharp/extractor/Semmle.Extraction.Tests/FeedManager.cs
@@ -205,9 +205,13 @@ namespace Semmle.Extraction.Tests
             var feedManager = MakeFeedManager();
 
             // Execute
+            var defaultFeeds = feedManager.DefaultFeeds;
             var reachableDefault = feedManager.ReachableDefaultFeeds;
 
             // Verify
+            Assert.Equal([
+                "https://api.nuget.org/v3/index.json"
+            ], defaultFeeds);
             Assert.Equal([
                 "https://api.nuget.org/v3/index.json"
             ], reachableDefault);
@@ -225,10 +229,15 @@ namespace Semmle.Extraction.Tests
             var feedManager = new FeedManager(logger, dotnet, dependabotProxy, fileProvider, feedManagerIo);
 
             // Execute
+            var defaultFeeds = feedManager.DefaultFeeds;
             var reachableDefault = feedManager.ReachableDefaultFeeds;
             var reachableFallback = feedManager.ReachableFallbackFeeds;
 
             // Verify
+            Assert.Equal([
+                "https://example.com/base1",
+                "https://example.com/base2"
+            ], defaultFeeds);
             Assert.Equal([
                 "https://example.com/base2"
             ], reachableDefault);

--- a/csharp/extractor/Semmle.Extraction.Tests/FeedManager.cs
+++ b/csharp/extractor/Semmle.Extraction.Tests/FeedManager.cs
@@ -246,5 +246,62 @@ namespace Semmle.Extraction.Tests
                 "https://example.com/base2"
             ], reachableFallback);
         }
+
+        [Fact]
+        public void TestNugetOrg()
+        {
+            // Setup
+            var logger = new LoggerStub();
+            var dotnet = new DotNetStub([], [], [], ["E https://api.nuget.org/v3/index.json"]);
+            var dependabotProxy = new DependabotProxyStub();
+            var fileProvider = new FileProviderStub();
+            var feedManagerIo = new FeedManagerIOStub(["https://example.com/registry2", "https://example.com/base1"]);
+            var feedManager = new FeedManager(logger, dotnet, dependabotProxy, fileProvider, feedManagerIo);
+
+            // Execute
+            var explicitFeeds = feedManager.ExplicitFeeds;
+            var allFeeds = feedManager.AllFeeds;
+
+            // Verify
+            Assert.Equal([
+                "https://example.com/registry1",
+                "https://example.com/registry2",
+            ], explicitFeeds);
+            Assert.Equal([
+                "https://example.com/registry1",
+                "https://example.com/registry2",
+                "https://api.nuget.org/v3/index.json"
+            ], allFeeds);
+
+        }
+        [Fact]
+        public void TestNugetOrgReplacement()
+        {
+            // Setup
+            var logger = new LoggerStub();
+            var dotnet = new DotNetStub([], [], ["E https://api.nuget.org/v3/index.json"], ["E https://api.nuget.org/v3/index.json"]);
+            var dependabotProxy = new DependabotProxyStubWithBaseUrls();
+            var fileProvider = new FileProviderStub();
+            var feedManagerIo = new FeedManagerIOStub(["https://example.com/registry2", "https://example.com/base1"]);
+            var feedManager = new FeedManager(logger, dotnet, dependabotProxy, fileProvider, feedManagerIo);
+
+            // Execute
+            var explicitFeeds = feedManager.ExplicitFeeds;
+            var allFeeds = feedManager.AllFeeds;
+
+            // Verify
+            Assert.Equal([
+                "https://example.com/base1",
+                "https://example.com/base2",
+                "https://example.com/registry1",
+                "https://example.com/registry2"
+            ], explicitFeeds);
+            Assert.Equal([
+                "https://example.com/base1",
+                "https://example.com/base2",
+                "https://example.com/registry1",
+                "https://example.com/registry2",
+            ], allFeeds);
+        }
     }
 }

--- a/csharp/extractor/Semmle.Extraction.Tests/FeedManager.cs
+++ b/csharp/extractor/Semmle.Extraction.Tests/FeedManager.cs
@@ -4,13 +4,15 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Semmle.Extraction.CSharp.DependencyFetching;
+using System.Collections.Immutable;
 
 namespace Semmle.Extraction.Tests
 {
     public class DependabotProxyStub : IDependabotProxy
     {
         public string Address { get; } = "";
-        public HashSet<string> RegistryURLs { get; } = ["https://example.com/registry1", "https://example.com/registry2"];
+        public ImmutableHashSet<string> RegistryURLs { get; } = ["https://example.com/registry1", "https://example.com/registry2"];
+        public ImmutableHashSet<string> RegistryBaseURLs { get; } = [];
         public string? CertificatePath { get; } = null;
         public System.Security.Cryptography.X509Certificates.X509Certificate2? Certificate { get; } = null;
 

--- a/csharp/extractor/Semmle.Extraction.Tests/FeedManager.cs
+++ b/csharp/extractor/Semmle.Extraction.Tests/FeedManager.cs
@@ -279,7 +279,7 @@ namespace Semmle.Extraction.Tests
         {
             // Setup
             var logger = new LoggerStub();
-            var dotnet = new DotNetStub([], [], ["E https://api.nuget.org/v3/index.json"], ["E https://api.nuget.org/v3/index.json"]);
+            var dotnet = new DotNetStub([], [], ["E https://www.nuget.org/api/v2/"], ["E https://api.nuget.org/v3/index.json"]);
             var dependabotProxy = new DependabotProxyStubWithBaseUrls();
             var fileProvider = new FileProviderStub();
             var feedManagerIo = new FeedManagerIOStub(["https://example.com/registry2", "https://example.com/base1"]);

--- a/csharp/extractor/Semmle.Extraction.Tests/FeedManager.cs
+++ b/csharp/extractor/Semmle.Extraction.Tests/FeedManager.cs
@@ -1,10 +1,11 @@
 using Xunit;
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
+using System.Security.Cryptography.X509Certificates;
 using Semmle.Extraction.CSharp.DependencyFetching;
-using System.Collections.Immutable;
 
 namespace Semmle.Extraction.Tests
 {
@@ -14,7 +15,18 @@ namespace Semmle.Extraction.Tests
         public ImmutableHashSet<string> RegistryURLs { get; } = ["https://example.com/registry1", "https://example.com/registry2"];
         public ImmutableHashSet<string> RegistryBaseURLs { get; } = [];
         public string? CertificatePath { get; } = null;
-        public System.Security.Cryptography.X509Certificates.X509Certificate2? Certificate { get; } = null;
+        public X509Certificate2? Certificate { get; } = null;
+
+        public void Dispose() { }
+    }
+
+    public class DependabotProxyStubWithBaseUrls : IDependabotProxy
+    {
+        public string Address { get; } = "";
+        public ImmutableHashSet<string> RegistryURLs { get; } = ["https://example.com/registry1", "https://example.com/registry2", "https://example.com/base1", "https://example.com/base2"];
+        public ImmutableHashSet<string> RegistryBaseURLs { get; } = ["https://example.com/base1", "https://example.com/base2"];
+        public string? CertificatePath { get; } = null;
+        public X509Certificate2? Certificate { get; } = null;
 
         public void Dispose() { }
     }
@@ -184,6 +196,46 @@ namespace Semmle.Extraction.Tests
                 "https://example.com/registry2",
                 "https://feed.from/folder1"
             ], feedsToUse);
+        }
+
+        [Fact]
+        public void TestDefaultFeeds1()
+        {
+            // Setup
+            var feedManager = MakeFeedManager();
+
+            // Execute
+            var reachableDefault = feedManager.ReachableDefaultFeeds;
+
+            // Verify
+            Assert.Equal([
+                "https://api.nuget.org/v3/index.json"
+            ], reachableDefault);
+        }
+
+        [Fact]
+        public void TestDefaultFeeds2()
+        {
+            // Setup
+            var logger = new LoggerStub();
+            var dotnet = new DotNetStub([], [], [], []);
+            var dependabotProxy = new DependabotProxyStubWithBaseUrls();
+            var fileProvider = new FileProviderStub();
+            var feedManagerIo = new FeedManagerIOStub(["https://example.com/registry2", "https://example.com/base1"]);
+            var feedManager = new FeedManager(logger, dotnet, dependabotProxy, fileProvider, feedManagerIo);
+
+            // Execute
+            var reachableDefault = feedManager.ReachableDefaultFeeds;
+            var reachableFallback = feedManager.ReachableFallbackFeeds;
+
+            // Verify
+            Assert.Equal([
+                "https://example.com/base2"
+            ], reachableDefault);
+            Assert.Equal([
+                "https://example.com/registry1",
+                "https://example.com/base2"
+            ], reachableFallback);
         }
     }
 }

--- a/csharp/extractor/Semmle.Extraction.Tests/FeedManager.cs
+++ b/csharp/extractor/Semmle.Extraction.Tests/FeedManager.cs
@@ -86,8 +86,10 @@ namespace Semmle.Extraction.Tests
         }
 
         /// <summary>
-        /// The purpose of this test is to verify that the FeedManager correctly computes the set of
-        /// explicit feeds.
+        /// Verify that `FeedManager` correctly computes the explicit feeds using feeds discovered in nuget.config files and
+        /// private registries.
+        /// See the initialization of `DotNetStub` and `DependabotProxyStub` in `MakeFeedManager` for the feeds configured
+        /// to be returned and classified as explicit feeds.
         /// </summary>
         [Fact]
         public void TestExplicitFeeds()
@@ -107,8 +109,9 @@ namespace Semmle.Extraction.Tests
         }
 
         /// <summary>
-        /// The purpose of this test is to verify that the FeedManager correctly computes the set of
-        /// inherited feeds.
+        /// Verify that `FeedManager` correctly computes the inherited feeds using feeds discovered from the environment.
+        /// See the initialization of `DotNetStub` in `MakeFeedManager` for the feeds configured
+        /// to be returned and classified as inherited feeds.
         /// </summary>
         [Fact]
         public void TestInheritedFeeds()
@@ -127,8 +130,10 @@ namespace Semmle.Extraction.Tests
         }
 
         /// <summary>
-        /// The purpose of this test is to verify that the FeedManager correctly computes the set of
-        /// all feeds.
+        /// Verify that `FeedManager` correctly computes all feeds using feeds discovered in nuget.config files, private registries,
+        /// and the environment.
+        /// See the initialization of `DotNetStub` and `DependabotProxyStub` in `MakeFeedManager` for the feeds configured
+        /// to be returned and included in all feeds.
         /// </summary>
         [Fact]
         public void TestAllFeeds()
@@ -150,8 +155,10 @@ namespace Semmle.Extraction.Tests
         }
 
         /// <summary>
-        /// The purpose of this test is to verify that the FeedManager correctly computes the set of
-        /// reachable feeds.
+        /// Verify that `FeedManager` correctly computes the reachable feeds using feeds discovered in
+        /// nuget.config files, private registries, and the environment.
+        /// See the initialization of `FeedManagerIOStub` in `MakeFeedManager` for the feeds configured as unreachable
+        /// and therefore filtered out of the reachable feeds.
         /// </summary>
         [Fact]
         public void TestReachableFeeds()
@@ -171,8 +178,10 @@ namespace Semmle.Extraction.Tests
         }
 
         /// <summary>
-        /// The purpose of this test is to verify that the FeedManager correctly computes the set of
-        /// reachable explicit feeds.
+        /// Verify that `FeedManager` correctly computes the reachable explicit feeds using feeds discovered in
+        /// nuget.config files and private registries.
+        /// See the initialization of `FeedManagerIOStub` in `MakeFeedManager` for the feeds configured as unreachable
+        /// and therefore filtered out of the reachable explicit feeds.
         /// </summary>
         [Fact]
         public void TestReachableExplicitFeeds()
@@ -191,8 +200,10 @@ namespace Semmle.Extraction.Tests
         }
 
         /// <summary>
-        /// The purpose of this test is to verify that the FeedManager correctly computes the set of
-        /// reachable fallback feeds.
+        /// Verify that `FeedManager` correctly computes the reachable fallback feeds using feeds discovered in
+        /// nuget.config files and the default NuGet.org feed.
+        /// See the initialization of `FeedManagerIOStub` in `MakeFeedManager` for the feeds configured as unreachable
+        /// and therefore filtered out of the reachable fallback feeds.
         /// </summary>
         [Fact]
         public void TestReachableFallbackFeeds()
@@ -212,8 +223,10 @@ namespace Semmle.Extraction.Tests
         }
 
         /// <summary>
-        /// The purpose of this test is to verify that the FeedManager correctly computes the set of
-        /// feeds to use for a given file.
+        /// Verify that `FeedManager` correctly computes the feeds to use for a given packages.config file from feeds discovered
+        /// in private registries and the environment.
+        /// See the initialization of `DotNetStub` in `MakeFeedManager` for the feeds configured
+        /// to be returned and selected for use.
         /// </summary>
         [Fact]
         public void TestFeedsToUse()
@@ -232,8 +245,8 @@ namespace Semmle.Extraction.Tests
         }
 
         /// <summary>
-        /// The purpose of this test is to verify that the FeedManager correctly computes the set of
-        /// default feeds and reachable default feeds when no private registries are configured.
+        /// Verify that `FeedManager` correctly computes the default feeds and reachable default feeds
+        /// when no private registries are configured.
         /// </summary>
         [Fact]
         public void TestDefaultFeedsNugetOrg()
@@ -255,9 +268,9 @@ namespace Semmle.Extraction.Tests
         }
 
         /// <summary>
-        /// The purpose of this test is to verify that the FeedManager correctly computes the set of
-        /// default feeds, reachable default feeds, and fallback feeds when private registries
-        /// are configured and some of them replace the default feeds.
+        /// Verify that `FeedManager` correctly computes the default feeds and reachable default feeds
+        /// when private registries are configured to replace the default feeds.
+        /// See the initialization of `DependabotProxyStubWithBaseUrls` for the feeds configured to replace the default feeds.
         /// </summary>
         [Fact]
         public void TestDefaultFeedsPrivateRegistries()
@@ -290,9 +303,8 @@ namespace Semmle.Extraction.Tests
         }
 
         /// <summary>
-        /// The purpose of this test is to verify that the FeedManager correctly computes the set of
-        /// all feeds when https://api.nuget.org/v3/index.json is not replaced by any private registries because
-        /// none of them are configured to replace the base feeds.
+        /// Verify that `FeedManager` correctly computes all feeds when https://api.nuget.org/v3/index.json is not replaced
+        /// by a private registry because no private registry is configured to replace the base feed.
         /// </summary>
         [Fact]
         public void TestNugetOrgNotReplaced()
@@ -323,9 +335,9 @@ namespace Semmle.Extraction.Tests
         }
 
         /// <summary>
-        /// The purpose of this test is to verify that the FeedManager correctly computes the set of
-        /// all feeds when https://api.nuget.org/v3/index.json and related NuGet.org URLs are replaced by private
-        /// registries configured to replace the base feeds.
+        /// Verify that `FeedManager` correctly computes the explicit and all feeds when https://api.nuget.org/v3/index.json and
+        /// related NuGet.org URLs are replaced by private registries configured to replace the base feeds.
+        /// See the initialization of `DependabotProxyStubWithBaseUrls` for the feeds configured as default replacements.
         /// </summary>
         [Fact]
         public void TestNugetOrgReplacement()

--- a/csharp/extractor/Semmle.Extraction.Tests/FeedManager.cs
+++ b/csharp/extractor/Semmle.Extraction.Tests/FeedManager.cs
@@ -68,6 +68,11 @@ namespace Semmle.Extraction.Tests
         public ICollection<string> Resources { get; } = new List<string>();
     }
 
+    /// <summary>
+    /// The purpose of this test class is to verify the behavior of the FeedManager class.
+    /// The tests use stub implementations of the FeedManager's dependencies to control the behavior of the FeedManager
+    /// and verify its behavior.
+    /// </summary>
     public class FeedManagerTests
     {
         private static FeedManager MakeFeedManager()
@@ -80,6 +85,10 @@ namespace Semmle.Extraction.Tests
             return new FeedManager(logger, dotnet, dependabotProxy, fileProvider, feedManagerIo);
         }
 
+        /// <summary>
+        /// The purpose of this test is to verify that the FeedManager correctly computes the set of
+        /// explicit feeds.
+        /// </summary>
         [Fact]
         public void TestExplicitFeeds()
         {
@@ -97,6 +106,10 @@ namespace Semmle.Extraction.Tests
             ], actualFeeds);
         }
 
+        /// <summary>
+        /// The purpose of this test is to verify that the FeedManager correctly computes the set of
+        /// inherited feeds.
+        /// </summary>
         [Fact]
         public void TestInheritedFeeds()
         {
@@ -113,6 +126,10 @@ namespace Semmle.Extraction.Tests
             ], inherited);
         }
 
+        /// <summary>
+        /// The purpose of this test is to verify that the FeedManager correctly computes the set of
+        /// all feeds.
+        /// </summary>
         [Fact]
         public void TestAllFeeds()
         {
@@ -132,6 +149,10 @@ namespace Semmle.Extraction.Tests
             ], all);
         }
 
+        /// <summary>
+        /// The purpose of this test is to verify that the FeedManager correctly computes the set of
+        /// reachable feeds.
+        /// </summary>
         [Fact]
         public void TestReachableFeeds()
         {
@@ -149,6 +170,10 @@ namespace Semmle.Extraction.Tests
             ], reachableFeeds);
         }
 
+        /// <summary>
+        /// The purpose of this test is to verify that the FeedManager correctly computes the set of
+        /// reachable explicit feeds.
+        /// </summary>
         [Fact]
         public void TestReachableExplicitFeeds()
         {
@@ -165,6 +190,10 @@ namespace Semmle.Extraction.Tests
             ], reachableFeeds);
         }
 
+        /// <summary>
+        /// The purpose of this test is to verify that the FeedManager correctly computes the set of
+        /// reachable fallback feeds.
+        /// </summary>
         [Fact]
         public void TestReachableFallbackFeeds()
         {
@@ -182,6 +211,10 @@ namespace Semmle.Extraction.Tests
             ], reachableFallback);
         }
 
+        /// <summary>
+        /// The purpose of this test is to verify that the FeedManager correctly computes the set of
+        /// feeds to use for a given file.
+        /// </summary>
         [Fact]
         public void TestFeedsToUse()
         {
@@ -198,8 +231,12 @@ namespace Semmle.Extraction.Tests
             ], feedsToUse);
         }
 
+        /// <summary>
+        /// The purpose of this test is to verify that the FeedManager correctly computes the set of
+        /// default feeds and reachable default feeds when no private registries are configured.
+        /// </summary>
         [Fact]
-        public void TestDefaultFeeds1()
+        public void TestDefaultFeedsNugetOrg()
         {
             // Setup
             var feedManager = MakeFeedManager();
@@ -217,8 +254,13 @@ namespace Semmle.Extraction.Tests
             ], reachableDefault);
         }
 
+        /// <summary>
+        /// The purpose of this test is to verify that the FeedManager correctly computes the set of
+        /// default feeds, reachable default feeds, and fallback feeds when private registries
+        /// are configured and some of them replace the default feeds.
+        /// </summary>
         [Fact]
-        public void TestDefaultFeeds2()
+        public void TestDefaultFeedsPrivateRegistries()
         {
             // Setup
             var logger = new LoggerStub();
@@ -247,8 +289,13 @@ namespace Semmle.Extraction.Tests
             ], reachableFallback);
         }
 
+        /// <summary>
+        /// The purpose of this test is to verify that the FeedManager correctly computes the set of
+        /// all feeds when https://api.nuget.org/v3/index.json is not replaced by any private registries because
+        /// none of them are configured to replace the base feeds.
+        /// </summary>
         [Fact]
-        public void TestNugetOrg()
+        public void TestNugetOrgNotReplaced()
         {
             // Setup
             var logger = new LoggerStub();
@@ -274,6 +321,12 @@ namespace Semmle.Extraction.Tests
             ], allFeeds);
 
         }
+
+        /// <summary>
+        /// The purpose of this test is to verify that the FeedManager correctly computes the set of
+        /// all feeds when https://api.nuget.org/v3/index.json and related NuGet.org URLs are replaced by private
+        /// registries configured to replace the base feeds.
+        /// </summary>
         [Fact]
         public void TestNugetOrgReplacement()
         {

--- a/csharp/ql/lib/change-notes/2026-09-03-replaces-base.md
+++ b/csharp/ql/lib/change-notes/2026-09-03-replaces-base.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* In `build-mode: none`, private NuGet registries configured with `replaces-base: true` in the organization-level private registry configuration now replace `nuget.org` sources whenever dependencies are downloaded, including sources discovered from NuGet configuration.

--- a/csharp/ql/lib/change-notes/2026-09-03-replaces-base.md
+++ b/csharp/ql/lib/change-notes/2026-09-03-replaces-base.md
@@ -1,4 +1,4 @@
 ---
 category: minorAnalysis
 ---
-* In `build-mode: none`, private NuGet registries configured with `replaces-base: true` in the organization-level private registry configuration now replace `nuget.org` sources whenever dependencies are downloaded, including sources discovered from NuGet configuration.
+* Private NuGet registries for which the "Replaces base" option is enabled in the organization-level private registry configuration now replace `nuget.org` sources whenever dependencies are downloaded, including sources discovered from NuGet configuration.

--- a/csharp/ql/lib/change-notes/2026-09-03-replaces-base.md
+++ b/csharp/ql/lib/change-notes/2026-09-03-replaces-base.md
@@ -1,4 +1,4 @@
 ---
 category: minorAnalysis
 ---
-* Private NuGet registries for which the "Replaces base" option is enabled in the organization-level private registry configuration now replace `nuget.org` sources whenever dependencies are downloaded, including sources discovered from NuGet configuration.
+* Private NuGet registries for which the "Replaces base" option is enabled in the organization-level private registry configuration now replace default NuGet feeds whenever dependencies are downloaded, including when default NuGet feeds are configured explicitly for a project.


### PR DESCRIPTION
In this PR we add support using the `replace-base` flag for *private* *registries*. If any private registries are configured to *replace* *base*, then we use these registries as NuGet feed sources instead of the *default* public `nuget.org` in ~~fallback scenarios~~ all scenarios - even if the public NuGet feed is mentioned in `nuget.config` files (unless it is explicitly configured as a fallback feed as well).

As an add on for this PR, we also prevent the fallback that doesn't provide feeds via the command line when restoring packages manually, if private registries are configured (to make the logic consistent with other similar paths).

DCA looks good.

Also ran QA, which doesn't show any regressions. The issue can be seen [here](https://github.com/github/codeql-qa-ops/issues/442) (note that this is only GitHub internal).