### PR TITLE
Shared/Unified: Hoist members in generated Ast.qll

### DIFF
--- a/shared/tree-sitter-extractor/src/generator/ql.rs
+++ b/shared/tree-sitter-extractor/src/generator/ql.rs
@@ -109,7 +109,7 @@ impl fmt::Display for Class<'_> {
                     is_final: false,
                     return_type: None,
                     formal_parameters: vec![],
-                    body: charpred.clone(),
+                    body: Some(charpred.clone()),
                     overlay: None,
                 }
             )?;
@@ -307,7 +307,9 @@ pub struct Predicate<'a> {
     pub is_final: bool,
     pub return_type: Option<Type<'a>>,
     pub formal_parameters: Vec<FormalParameter<'a>>,
-    pub body: Expression<'a>,
+    /// The body of the predicate, or `None` if this is an `abstract`
+    /// predicate declaration with no body.
+    pub body: Option<Expression<'a>>,
     pub overlay: Option<OverlayAnnotation>,
 }
 
@@ -330,6 +332,9 @@ impl fmt::Display for Predicate<'_> {
         if self.is_final {
             write!(f, "final ")?;
         }
+        if self.body.is_none() {
+            write!(f, "abstract ")?;
+        }
         if self.overridden {
             write!(f, "override ")?;
         }
@@ -344,7 +349,10 @@ impl fmt::Display for Predicate<'_> {
             }
             write!(f, "{param}")?;
         }
-        write!(f, ") {{ {} }}", self.body)?;
+        match &self.body {
+            Some(body) => write!(f, ") {{ {body} }}")?,
+            None => write!(f, ");")?,
+        }
 
         Ok(())
     }

--- a/shared/tree-sitter-extractor/src/generator/ql_gen.rs
+++ b/shared/tree-sitter-extractor/src/generator/ql_gen.rs
@@ -862,6 +862,9 @@ fn compute_exposed_predicates<'a, 'b>(
     let node = nodes.get(type_name);
     let class_name = node.map_or(type_name.kind.as_str(), |node| node.ql_class_name.as_str());
     if !cache.contains_key(class_name) {
+        // Supertype declarations that recursively refer to themselves are a mistake, but we don't
+        // want to cause infinite recursion, so we insert a temporary sentinel.
+        cache.insert(class_name, Vec::new());
         let exposed = match node.map(|node| &node.kind) {
             Some(node_types::EntryKind::Table { .. }) => {
                 field_predicates.get(type_name).cloned().unwrap_or_default()

--- a/shared/tree-sitter-extractor/src/generator/ql_gen.rs
+++ b/shared/tree-sitter-extractor/src/generator/ql_gen.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 
 use crate::{generator::ql, node_types};
@@ -20,14 +21,14 @@ pub fn create_ast_node_class<'a>(
         is_final: false,
         return_type: Some(ql::Type::String),
         formal_parameters: vec![],
-        body: ql::Expression::Equals(
+        body: Some(ql::Expression::Equals(
             Box::new(ql::Expression::Var("result")),
             Box::new(ql::Expression::Dot(
                 Box::new(ql::Expression::Var("this")),
                 "getAPrimaryQlClass",
                 vec![],
             )),
-        ),
+        )),
         overlay: None,
     };
     let get_location = ql::Predicate {
@@ -38,10 +39,10 @@ pub fn create_ast_node_class<'a>(
         is_final: true,
         return_type: Some(ql::Type::Normal("L::Location")),
         formal_parameters: vec![],
-        body: ql::Expression::Pred(
+        body: Some(ql::Expression::Pred(
             node_location_table,
             vec![ql::Expression::Var("this"), ql::Expression::Var("result")],
-        ),
+        )),
         overlay: None,
     };
     let get_a_field_or_child = create_none_predicate(
@@ -58,14 +59,14 @@ pub fn create_ast_node_class<'a>(
         is_final: true,
         return_type: Some(ql::Type::Facade("AstNode")),
         formal_parameters: vec![],
-        body: ql::Expression::Pred(
+        body: Some(ql::Expression::Pred(
             node_parent_table,
             vec![
                 ql::Expression::Var("this"),
                 ql::Expression::Var("result"),
                 ql::Expression::Var("_"),
             ],
-        ),
+        )),
         overlay: None,
     };
     let get_parent_index = ql::Predicate {
@@ -78,14 +79,14 @@ pub fn create_ast_node_class<'a>(
         is_final: true,
         return_type: Some(ql::Type::Int),
         formal_parameters: vec![],
-        body: ql::Expression::Pred(
+        body: Some(ql::Expression::Pred(
             node_parent_table,
             vec![
                 ql::Expression::Var("this"),
                 ql::Expression::Var("_"),
                 ql::Expression::Var("result"),
             ],
-        ),
+        )),
         overlay: None,
     };
     let get_a_primary_ql_class = ql::Predicate {
@@ -98,10 +99,10 @@ pub fn create_ast_node_class<'a>(
         is_final: false,
         return_type: Some(ql::Type::String),
         formal_parameters: vec![],
-        body: ql::Expression::Equals(
+        body: Some(ql::Expression::Equals(
             Box::new(ql::Expression::Var("result")),
             Box::new(ql::Expression::String("???")),
-        ),
+        )),
         overlay: None,
     };
     let get_primary_ql_classes = ql::Predicate {
@@ -116,7 +117,7 @@ pub fn create_ast_node_class<'a>(
         is_final: false,
         return_type: Some(ql::Type::String),
         formal_parameters: vec![],
-        body: ql::Expression::Equals(
+        body: Some(ql::Expression::Equals(
             Box::new(ql::Expression::Var("result")),
             Box::new(ql::Expression::Aggregate {
                 name: "concat",
@@ -129,7 +130,7 @@ pub fn create_ast_node_class<'a>(
                 )),
                 second_expr: Some(Box::new(ql::Expression::String(","))),
             }),
-        ),
+        )),
         overlay: None,
     };
     ql::Class {
@@ -163,7 +164,12 @@ pub fn create_token_class<'a>(token_type: &'a str, tokeninfo: &'a str) -> ql::Cl
         is_final: true,
         return_type: Some(ql::Type::String),
         formal_parameters: vec![],
-        body: create_get_field_expr_for_column_storage("result", tokeninfo, 1, tokeninfo_arity),
+        body: Some(create_get_field_expr_for_column_storage(
+            "result",
+            tokeninfo,
+            1,
+            tokeninfo_arity,
+        )),
         overlay: None,
     };
     let to_string = ql::Predicate {
@@ -176,14 +182,14 @@ pub fn create_token_class<'a>(token_type: &'a str, tokeninfo: &'a str) -> ql::Cl
         is_final: true,
         return_type: Some(ql::Type::String),
         formal_parameters: vec![],
-        body: ql::Expression::Equals(
+        body: Some(ql::Expression::Equals(
             Box::new(ql::Expression::Var("result")),
             Box::new(ql::Expression::Dot(
                 Box::new(ql::Expression::Var("this")),
                 "getValue",
                 vec![],
             )),
-        ),
+        )),
         overlay: None,
     };
     ql::Class {
@@ -223,12 +229,12 @@ pub fn create_trivia_token_class<'a>(
         is_final: true,
         return_type: Some(ql::Type::String),
         formal_parameters: vec![],
-        body: create_get_field_expr_for_column_storage(
+        body: Some(create_get_field_expr_for_column_storage(
             "result",
             trivia_tokeninfo,
             1,
             trivia_tokeninfo_arity,
-        ),
+        )),
         overlay: None,
     };
     let to_string = ql::Predicate {
@@ -241,14 +247,14 @@ pub fn create_trivia_token_class<'a>(
         is_final: true,
         return_type: Some(ql::Type::String),
         formal_parameters: vec![],
-        body: ql::Expression::Equals(
+        body: Some(ql::Expression::Equals(
             Box::new(ql::Expression::Var("result")),
             Box::new(ql::Expression::Dot(
                 Box::new(ql::Expression::Var("this")),
                 "getValue",
                 vec![],
             )),
-        ),
+        )),
         overlay: None,
     };
     ql::Class {
@@ -306,7 +312,7 @@ fn create_none_predicate<'a>(
         is_final: false,
         return_type,
         formal_parameters: Vec::new(),
-        body: ql::Expression::Pred("none", vec![]),
+        body: Some(ql::Expression::Pred("none", vec![])),
         overlay: None,
     }
 }
@@ -324,10 +330,10 @@ fn create_get_a_primary_ql_class(class_name: &str, is_final: bool) -> ql::Predic
         is_final,
         return_type: Some(ql::Type::String),
         formal_parameters: vec![],
-        body: ql::Expression::Equals(
+        body: Some(ql::Expression::Equals(
             Box::new(ql::Expression::Var("result")),
             Box::new(ql::Expression::String(class_name)),
-        ),
+        )),
         overlay: None,
     }
 }
@@ -342,13 +348,13 @@ pub fn create_is_overlay_predicate() -> ql::Predicate<'static> {
         return_type: None,
         overlay: Some(ql::OverlayAnnotation::Local),
         formal_parameters: vec![],
-        body: ql::Expression::Pred(
+        body: Some(ql::Expression::Pred(
             "databaseMetadata",
             vec![
                 ql::Expression::String("isOverlay"),
                 ql::Expression::String("true"),
             ],
-        ),
+        )),
     }
 }
 
@@ -368,7 +374,7 @@ pub fn create_get_node_file_predicate<'a>(
             name: "node",
             param_type: ql::Type::At(ast_node_name),
         }],
-        body: ql::Expression::Aggregate {
+        body: Some(ql::Expression::Aggregate {
             name: "exists",
             vars: vec![ql::FormalParameter {
                 name: "loc",
@@ -390,7 +396,7 @@ pub fn create_get_node_file_predicate<'a>(
                 ],
             )),
             second_expr: None,
-        },
+        }),
     }
 }
 
@@ -415,7 +421,7 @@ pub fn create_discardable_ast_node_predicate(ast_node_name: &str) -> ql::Predica
                 param_type: ql::Type::At(ast_node_name),
             },
         ],
-        body: ql::Expression::And(vec![
+        body: Some(ql::Expression::And(vec![
             ql::Expression::Negation(Box::new(ql::Expression::Pred("isOverlay", vec![]))),
             ql::Expression::Equals(
                 Box::new(ql::Expression::Var("file")),
@@ -424,7 +430,7 @@ pub fn create_discardable_ast_node_predicate(ast_node_name: &str) -> ql::Predica
                     vec![ql::Expression::Var("node")],
                 )),
             ),
-        ]),
+        ])),
     }
 }
 
@@ -444,7 +450,7 @@ pub fn create_discard_ast_node_predicate(ast_node_name: &str) -> ql::Predicate<'
             name: "node",
             param_type: ql::Type::At(ast_node_name),
         }],
-        body: ql::Expression::Aggregate {
+        body: Some(ql::Expression::Aggregate {
             name: "exists",
             vars: vec![
                 ql::FormalParameter {
@@ -468,7 +474,7 @@ pub fn create_discard_ast_node_predicate(ast_node_name: &str) -> ql::Predicate<'
                 ql::Expression::Pred("overlayChangedFiles", vec![ql::Expression::Var("path")]),
             ])),
             second_expr: None,
-        },
+        }),
     }
 }
 
@@ -493,7 +499,7 @@ pub fn create_discardable_location_predicate() -> ql::Predicate<'static> {
                 param_type: ql::Type::At("location_default"),
             },
         ],
-        body: ql::Expression::And(vec![
+        body: Some(ql::Expression::And(vec![
             ql::Expression::Negation(Box::new(ql::Expression::Pred("isOverlay", vec![]))),
             ql::Expression::Pred(
                 "locations_default",
@@ -506,7 +512,7 @@ pub fn create_discardable_location_predicate() -> ql::Predicate<'static> {
                     ql::Expression::Var("_"),
                 ],
             ),
-        ]),
+        ])),
     }
 }
 
@@ -529,7 +535,7 @@ pub fn create_discard_location_predicate() -> ql::Predicate<'static> {
             name: "loc",
             param_type: ql::Type::At("location_default"),
         }],
-        body: ql::Expression::Aggregate {
+        body: Some(ql::Expression::Aggregate {
             name: "exists",
             vars: vec![
                 ql::FormalParameter {
@@ -553,7 +559,7 @@ pub fn create_discard_location_predicate() -> ql::Predicate<'static> {
                 ql::Expression::Pred("overlayChangedFiles", vec![ql::Expression::Var("path")]),
             ])),
             second_expr: None,
-        },
+        }),
     }
 }
 
@@ -760,7 +766,7 @@ fn create_field_getters<'a>(
         is_final: true,
         return_type: return_type.clone(),
         formal_parameters,
-        body,
+        body: Some(body),
         overlay: None,
     }];
 
@@ -773,14 +779,14 @@ fn create_field_getters<'a>(
             is_final: true,
             return_type,
             formal_parameters: vec![],
-            body: ql::Expression::Equals(
+            body: Some(ql::Expression::Equals(
                 Box::new(ql::Expression::Var("result")),
                 Box::new(ql::Expression::Dot(
                     Box::new(ql::Expression::Var("this")),
                     &field.getter_name,
                     vec![ql::Expression::Var("_")],
                 )),
-            ),
+            )),
             overlay: None,
         });
     }
@@ -828,6 +834,86 @@ fn class_supertypes<'a>(
     supertypes
 }
 
+/// Returns whether `a` and `b` have the same signature, i.e. the same name,
+/// return type, and formal parameters. Predicates with the same signature can
+/// override one another.
+fn same_predicate_signature(a: &ql::Predicate, b: &ql::Predicate) -> bool {
+    a.name == b.name && a.return_type == b.return_type && a.formal_parameters == b.formal_parameters
+}
+
+/// Computes, for each tree-sitter supertype (union) node, the list of
+/// predicates that are guaranteed to be defined identically (in terms of
+/// name, return type, and formal parameters, though not necessarily body) by
+/// every one of its members. These are the predicates that can be hoisted to
+/// an `abstract` predicate on the union's class, with the corresponding
+/// predicates on its members becoming `override`s.
+///
+/// The result for a given node is memoized in `cache` (keyed by its QL class
+/// name), and also used to answer the query for any other node that
+/// (directly, or transitively through further supertypes) has that node as a
+/// member. The same cache also serves as the answer to "what does the class
+/// named X expose?", used by `is_predicate_inherited`.
+fn compute_exposed_predicates<'a, 'b>(
+    type_name: &'a node_types::TypeName,
+    nodes: &'a node_types::NodeTypeMap,
+    field_predicates: &BTreeMap<&node_types::TypeName, Vec<ql::Predicate<'a>>>,
+    cache: &'b mut BTreeMap<&'a str, Vec<ql::Predicate<'a>>>,
+) -> &'b Vec<ql::Predicate<'a>> {
+    let node = nodes.get(type_name);
+    let class_name = node.map_or(type_name.kind.as_str(), |node| node.ql_class_name.as_str());
+    if !cache.contains_key(class_name) {
+        let exposed = match node.map(|node| &node.kind) {
+            Some(node_types::EntryKind::Table { .. }) => {
+                field_predicates.get(type_name).cloned().unwrap_or_default()
+            }
+            Some(node_types::EntryKind::Union { members }) => {
+                let mut members = members.iter();
+                let mut common = match members.next() {
+                    Some(first) => {
+                        compute_exposed_predicates(first, nodes, field_predicates, cache).clone()
+                    }
+                    None => Vec::new(),
+                };
+                for member in members {
+                    let member_predicates =
+                        compute_exposed_predicates(member, nodes, field_predicates, cache);
+                    common.retain(|predicate| {
+                        member_predicates
+                            .iter()
+                            .any(|other| same_predicate_signature(predicate, other))
+                    });
+                }
+                common
+            }
+            Some(node_types::EntryKind::Token { .. }) | None => Vec::new(),
+        };
+        cache.insert(class_name, exposed);
+    }
+    cache.get(class_name).unwrap()
+}
+
+/// Returns whether `predicate` (declared, or about to be declared, on the
+/// class for `type_name`) is already exposed by one of `type_name`'s direct
+/// supertypes, and therefore must be marked as an `override` (for a concrete
+/// predicate) or can be omitted entirely (for an `abstract` one, since it's
+/// already inherited).
+fn is_predicate_inherited(
+    predicate: &ql::Predicate,
+    type_name: &node_types::TypeName,
+    direct_supertypes: &BTreeMap<node_types::TypeName, BTreeSet<&str>>,
+    exposed_predicates: &BTreeMap<&str, Vec<ql::Predicate>>,
+) -> bool {
+    direct_supertypes.get(type_name).is_some_and(|supertypes| {
+        supertypes.iter().any(|supertype| {
+            exposed_predicates.get(supertype).is_some_and(|predicates| {
+                predicates
+                    .iter()
+                    .any(|other| same_predicate_signature(predicate, other))
+            })
+        })
+    })
+}
+
 /// Converts the given node types into CodeQL classes wrapping the dbscheme.
 pub fn convert_nodes(nodes: &node_types::NodeTypeMap) -> Vec<ql::TopLevel<'_>> {
     let mut classes = Vec::new();
@@ -838,6 +924,71 @@ pub fn convert_nodes(nodes: &node_types::NodeTypeMap) -> Vec<ql::TopLevel<'_>> {
             && type_name.named
         {
             token_kinds.insert(&type_name.kind);
+        }
+    }
+
+    // First, compute the field-getter predicates (and the expressions used by
+    // `getAFieldOrChild`) for every table node, without yet knowing whether
+    // any of them will need to be marked `override`. These are needed both
+    // to build the final classes below, and to figure out which fields are
+    // shared identically by all the members of a supertype.
+    let mut field_predicates: BTreeMap<&node_types::TypeName, Vec<ql::Predicate<'_>>> =
+        BTreeMap::new();
+    let mut get_child_exprs: BTreeMap<&node_types::TypeName, Vec<ql::Expression<'_>>> =
+        BTreeMap::new();
+    for (type_name, node) in nodes {
+        if let node_types::EntryKind::Table {
+            name: main_table_name,
+            fields,
+        } = &node.kind
+        {
+            if fields.is_empty() {
+                panic!("Encountered node '{}' with no fields", type_name.kind);
+            }
+
+            // Count how many columns there will be in the main table. There
+            // will be one for the id, plus one for each field that's stored
+            // as a column.
+            let main_table_arity = 1 + fields
+                .iter()
+                .filter(|&f| matches!(f.storage, node_types::Storage::Column { .. }))
+                .count();
+
+            let mut main_table_column_index: usize = 0;
+            let mut predicates = Vec::new();
+            let mut exprs = Vec::new();
+            for field in fields {
+                let (get_preds, get_child_expr) = create_field_getters(
+                    main_table_name,
+                    main_table_arity,
+                    &mut main_table_column_index,
+                    field,
+                    nodes,
+                );
+                predicates.extend(get_preds);
+                if let Some(get_child_expr) = get_child_expr {
+                    exprs.push(get_child_expr)
+                }
+            }
+            field_predicates.insert(type_name, predicates);
+            get_child_exprs.insert(type_name, exprs);
+        }
+    }
+
+    // Next, for every supertype (union) node, compute the predicates that are
+    // guaranteed to be defined identically (in name, return type, and formal
+    // parameters) by every one of its members. Such predicates can be hoisted
+    // to an `abstract` predicate on the supertype's class, with the
+    // corresponding predicates on its members becoming `override`s.
+    let mut exposed_predicates: BTreeMap<&str, Vec<ql::Predicate<'_>>> = BTreeMap::new();
+    for (type_name, node) in nodes {
+        if let node_types::EntryKind::Union { .. } = &node.kind {
+            compute_exposed_predicates(
+                type_name,
+                nodes,
+                &field_predicates,
+                &mut exposed_predicates,
+            );
         }
     }
 
@@ -865,7 +1016,26 @@ pub fn convert_nodes(nodes: &node_types::NodeTypeMap) -> Vec<ql::TopLevel<'_>> {
             }
             node_types::EntryKind::Union { members: _ } => {
                 // It's a tree-sitter supertype node, so we're wrapping a dbscheme
-                // union type.
+                // union type. Any predicate that's identically defined by every
+                // member becomes an `abstract` predicate here.
+                let predicates = exposed_predicates
+                    .get(node.ql_class_name.as_str())
+                    .cloned()
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|predicate| ql::Predicate {
+                        overridden: is_predicate_inherited(
+                            &predicate,
+                            type_name,
+                            &direct_supertypes,
+                            &exposed_predicates,
+                        ),
+                        is_private: false,
+                        is_final: false,
+                        body: None,
+                        ..predicate
+                    })
+                    .collect();
                 classes.push(ql::TopLevel::Class(ql::Class {
                     qldoc: None,
                     name: &node.ql_class_name,
@@ -879,25 +1049,10 @@ pub fn convert_nodes(nodes: &node_types::NodeTypeMap) -> Vec<ql::TopLevel<'_>> {
                         &direct_supertypes,
                     ),
                     characteristic_predicate: None,
-                    predicates: vec![],
+                    predicates,
                 }));
             }
-            node_types::EntryKind::Table {
-                name: main_table_name,
-                fields,
-            } => {
-                if fields.is_empty() {
-                    panic!("Encountered node '{}' with no fields", type_name.kind);
-                }
-
-                // Count how many columns there will be in the main table. There
-                // will be one for the id, plus one for each field that's stored
-                // as a column.
-                let main_table_arity = 1 + fields
-                    .iter()
-                    .filter(|&f| matches!(f.storage, node_types::Storage::Column { .. }))
-                    .count();
-
+            node_types::EntryKind::Table { .. } => {
                 let main_class_name = &node.ql_class_name;
                 let mut main_class = ql::Class {
                     qldoc: Some(format!("A class representing `{}` nodes.", type_name.kind)),
@@ -915,26 +1070,30 @@ pub fn convert_nodes(nodes: &node_types::NodeTypeMap) -> Vec<ql::TopLevel<'_>> {
                     predicates: vec![create_get_a_primary_ql_class(main_class_name, true)],
                 };
 
-                let mut main_table_column_index: usize = 0;
-                let mut get_child_exprs: Vec<ql::Expression> = Vec::new();
-
-                // Iterate through the fields, creating:
-                // - classes to wrap union types if fields need them,
-                // - predicates to access the fields,
-                // - the QL expressions to access the fields that will be part of getAFieldOrChild.
-                for field in fields {
-                    let (get_preds, get_child_expr) = create_field_getters(
-                        main_table_name,
-                        main_table_arity,
-                        &mut main_table_column_index,
-                        field,
-                        nodes,
-                    );
-                    main_class.predicates.extend(get_preds);
-                    if let Some(get_child_expr) = get_child_expr {
-                        get_child_exprs.push(get_child_expr)
-                    }
-                }
+                // A field getter that's identically defined (in signature) by
+                // every member of one of this node's direct supertypes is an
+                // override of the corresponding `abstract` predicate declared
+                // there.
+                main_class.predicates.extend(
+                    field_predicates
+                        .get(type_name)
+                        .cloned()
+                        .unwrap_or_default()
+                        .into_iter()
+                        .map(|predicate| {
+                            let overridden = predicate.overridden
+                                || is_predicate_inherited(
+                                    &predicate,
+                                    type_name,
+                                    &direct_supertypes,
+                                    &exposed_predicates,
+                                );
+                            ql::Predicate {
+                                overridden,
+                                ..predicate
+                            }
+                        }),
+                );
 
                 main_class.predicates.push(ql::Predicate {
                     qldoc: Some(String::from("Gets a field or child node of this node.")),
@@ -944,7 +1103,9 @@ pub fn convert_nodes(nodes: &node_types::NodeTypeMap) -> Vec<ql::TopLevel<'_>> {
                     is_final: true,
                     return_type: Some(ql::Type::Facade("AstNode")),
                     formal_parameters: vec![],
-                    body: ql::Expression::Or(get_child_exprs),
+                    body: Some(ql::Expression::Or(
+                        get_child_exprs.get(type_name).cloned().unwrap_or_default(),
+                    )),
                     overlay: None,
                 });
 
@@ -1038,7 +1199,7 @@ pub fn create_print_ast_module(nodes: &node_types::NodeTypeMap) -> ql::TopLevel<
                 param_type: ql::Type::Int,
             },
         ],
-        body: ql::Expression::Or(disjuncts),
+        body: Some(ql::Expression::Or(disjuncts)),
         overlay: None,
     };
 

--- a/unified/ql/lib/codeql/unified/internal/Ast.qll
+++ b/unified/ql/lib/codeql/unified/internal/Ast.qll
@@ -104,7 +104,7 @@ module Unified {
     final F::AccessorKind getAccessorKind() { unified_accessor_declaration_def(this, result, _) }
 
     /** Gets the node corresponding to the field `body`. */
-    final F::Block getBody() { unified_accessor_declaration_body(this, result) }
+    final override F::Block getBody() { unified_accessor_declaration_body(this, result) }
 
     /** Gets the node corresponding to the field `modifier`. */
     final F::Modifier getModifier(int i) { unified_accessor_declaration_modifier(this, i, result) }
@@ -373,7 +373,10 @@ module Unified {
     }
   }
 
-  class Callable extends @unified_callable, F::AstNode { }
+  class Callable extends @unified_callable, F::AstNode {
+    /** Gets the node corresponding to the field `body`. */
+    abstract F::Block getBody();
+  }
 
   /** A class representing `catch_clause` nodes. */
   class CatchClause extends @unified_catch_clause, F::AstNode {
@@ -512,7 +515,7 @@ module Unified {
     final override string getAPrimaryQlClass() { result = "ConstructorDeclaration" }
 
     /** Gets the node corresponding to the field `body`. */
-    final F::Block getBody() { unified_constructor_declaration_def(this, result) }
+    final override F::Block getBody() { unified_constructor_declaration_def(this, result) }
 
     /** Gets the node corresponding to the field `modifier`. */
     final F::Modifier getModifier(int i) {
@@ -592,7 +595,7 @@ module Unified {
     final override string getAPrimaryQlClass() { result = "DestructorDeclaration" }
 
     /** Gets the node corresponding to the field `body`. */
-    final F::Block getBody() { unified_destructor_declaration_def(this, result) }
+    final override F::Block getBody() { unified_destructor_declaration_def(this, result) }
 
     /** Gets the node corresponding to the field `modifier`. */
     final F::Modifier getModifier(int i) {
@@ -727,7 +730,7 @@ module Unified {
     final override string getAPrimaryQlClass() { result = "FunctionDeclaration" }
 
     /** Gets the node corresponding to the field `body`. */
-    final F::Block getBody() { unified_function_declaration_body(this, result) }
+    final override F::Block getBody() { unified_function_declaration_body(this, result) }
 
     /** Gets the node corresponding to the field `modifier`. */
     final F::Modifier getModifier(int i) { unified_function_declaration_modifier(this, i, result) }
@@ -783,7 +786,7 @@ module Unified {
     final override string getAPrimaryQlClass() { result = "FunctionExpr" }
 
     /** Gets the node corresponding to the field `body`. */
-    final F::Block getBody() { unified_function_expr_def(this, result) }
+    final override F::Block getBody() { unified_function_expr_def(this, result) }
 
     /** Gets the node corresponding to the field `capture_declaration`. */
     final F::VariableDeclaration getCaptureDeclaration(int i) {
@@ -958,7 +961,7 @@ module Unified {
     final override string getAPrimaryQlClass() { result = "InitializerDeclaration" }
 
     /** Gets the node corresponding to the field `body`. */
-    final F::Block getBody() { unified_initializer_declaration_def(this, result) }
+    final override F::Block getBody() { unified_initializer_declaration_def(this, result) }
 
     /** Gets the node corresponding to the field `modifier`. */
     final F::Modifier getModifier(int i) {
@@ -1359,7 +1362,7 @@ module Unified {
     final override string getAPrimaryQlClass() { result = "TopLevel" }
 
     /** Gets the node corresponding to the field `body`. */
-    final F::Block getBody() { unified_top_level_def(this, result) }
+    final override F::Block getBody() { unified_top_level_def(this, result) }
 
     /** Gets a field or child node of this node. */
     final override F::AstNode getAFieldOrChild() { unified_top_level_def(this, result) }

--- a/unified/ql/lib/codeql/unified/internal/ControlFlowGraph.qll
+++ b/unified/ql/lib/codeql/unified/internal/ControlFlowGraph.qll
@@ -46,15 +46,7 @@ private module Ast implements AstSig<Location> {
 
   class Callable = U::Callable;
 
-  AstNode callableGetBody(Callable c) {
-    result = c.(AccessorDeclaration).getBody() or
-    result = c.(ConstructorDeclaration).getBody() or
-    result = c.(DestructorDeclaration).getBody() or
-    result = c.(FunctionDeclaration).getBody() or
-    result = c.(FunctionExpr).getBody() or
-    result = c.(InitializerDeclaration).getBody() or
-    result = c.(TopLevel).getBody()
-  }
+  AstNode callableGetBody(Callable c) { result = c.getBody() }
 
   class Parameter extends U::Parameter {
     Expr getDefaultValue() { result = super.getDefault() }


### PR DESCRIPTION
This hoists identical predicates shared by all subclasses to a root-def on their superclass. The second commit shows the effect.
Copilot wrote most of the Rust code, but I've tweaked it a bit and I've read through it all and convinced myself that it does the right thing.