### PR TITLE
C++: Fix bad join in virtual dispatch

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowDispatch.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowDispatch.qll
@@ -131,6 +131,15 @@ private predicate qualifierSourceImpl(RelevantNode n, Class c) {
   )
 }
 
+pragma[nomagic]
+private predicate hasKindAndEnclosingCallable(
+  DataFlowPrivate::DataFlowCallable callable, DataFlowPrivate::ReturnKind kind,
+  DataFlowPrivate::ReturnNode return
+) {
+  return.getEnclosingCallable() = callable and
+  return.getKind() = kind
+}
+
 private module TrackVirtualDispatch<methodDispatchSig/1 virtualDispatch0> {
   /**
    * Gets a possible runtime target of `c` using both static call-target
@@ -197,11 +206,21 @@ private module TrackVirtualDispatch<methodDispatchSig/1 virtualDispatch0> {
       )
     }
 
+    pragma[nomagic]
+    private predicate hasDispatchWithKind(
+      DataFlowPrivate::DataFlowCallable callable, DataFlowPrivate::ReturnKind kind,
+      LocalSourceNode n2
+    ) {
+      exists(DataFlowPrivate::DataFlowCall call |
+        n2 = DataFlowPrivate::getAnOutNode(call, kind) and
+        callable = dispatch(call)
+      )
+    }
+
     predicate returnStep(Node n1, LocalSourceNode n2) {
-      exists(DataFlowPrivate::DataFlowCallable callable, DataFlowPrivate::DataFlowCall call |
-        n1.(DataFlowPrivate::ReturnNode).getEnclosingCallable() = callable and
-        callable = dispatch(call) and
-        n2 = DataFlowPrivate::getAnOutNode(call, n1.(DataFlowPrivate::ReturnNode).getKind())
+      exists(DataFlowPrivate::DataFlowCallable callable, DataFlowPrivate::ReturnKind kind |
+        hasKindAndEnclosingCallable(callable, kind, n1) and
+        hasDispatchWithKind(callable, kind, n2)
       )
     }
 


### PR DESCRIPTION
Before:
```
[2026-09-04 12:36:47] Evaluated non-recursive predicate DataFlowDispatch::TrackVirtualDispatch<noDisp>::TtInput::returnStep/2#64397117@7819e22o in 216ms (size: 1415417).
Evaluated relational algebra for predicate DataFlowDispatch::TrackVirtualDispatch<noDisp>::TtInput::returnStep/2#64397117@7819e22o with tuple counts:
        73694211  ~2%    {2} r1 = JOIN `_DataFlowDispatch::RelevantNode#d8b83544_DataFlowUtil::Node.getEnclosingCallable/0#dispred#74002437#shared` WITH `DataFlowDispatch::nonVirtualDispatch/1#f749a2ef_10#join_rhs` ON FIRST 1 OUTPUT Lhs.1, Rhs.1
         1425123  ~0%    {3}    | JOIN WITH `DataFlowPrivate::ReturnNode.getKind/0#dispred#c7586c0b` ON FIRST 1 OUTPUT Lhs.1, Rhs.1, Lhs.0
         1422517  ~0%    {2}    | JOIN WITH `DataFlowPrivate::getAnOutNode/2#fa64ae7d` ON FIRST 2 OUTPUT Rhs.2, Lhs.2
         1415417  ~2%    {2}    | JOIN WITH `DataFlowDispatch::TrackVirtualDispatch<d1>::TtInput::LocalSourceNode#9cbbba61` ON FIRST 1 OUTPUT Lhs.1, Lhs.0
                         return r1
```
After:

```
[2026-09-04 13:23:46] Evaluated non-recursive predicate DataFlowDispatch::hasKindAndEnclosingCallable/3#f9907305@df466fdu in 102ms (size: 614924).
Evaluated relational algebra for predicate DataFlowDispatch::hasKindAndEnclosingCallable/3#f9907305@df466fdu with tuple counts:
        614924  ~0%    {3} r1 = JOIN `DataFlowUtil::Node.getEnclosingCallable/0#dispred#74002437` WITH `DataFlowPrivate::ReturnNode.getKind/0#dispred#c7586c0b` ON FIRST 1 OUTPUT Lhs.1, Rhs.1, Lhs.0
                       return r1

[2026-09-04 13:23:47] Evaluated non-recursive predicate _DataFlowDispatch::RelevantNode#d8b83544_DataFlowDispatch::hasKindAndEnclosingCallable/3#f9907305#shared@13f314hb in 37ms (size: 470063).
Evaluated relational algebra for predicate _DataFlowDispatch::RelevantNode#d8b83544_DataFlowDispatch::hasKindAndEnclosingCallable/3#f9907305#shared@13f314hb with tuple counts:
        614924  ~0%    {3} r1 = SCAN `DataFlowDispatch::hasKindAndEnclosingCallable/3#f9907305` OUTPUT In.2, In.0, In.1
        470063  ~0%    {3}    | JOIN WITH DataFlowDispatch::RelevantNode#d8b83544 ON FIRST 1 OUTPUT Lhs.1, Lhs.2, Lhs.0
                       return r1

[2026-09-04 13:23:47] Evaluated non-recursive predicate DataFlowDispatch::TrackVirtualDispatch<noDisp>::TtInput::hasDispatchWithKind/3#0e8dc366@4d20b7ij in 235ms (size: 2025567).
Evaluated relational algebra for predicate DataFlowDispatch::TrackVirtualDispatch<noDisp>::TtInput::hasDispatchWithKind/3#0e8dc366@4d20b7ij with tuple counts:
        2025573  ~0%    {3} r1 = JOIN `_DataFlowDispatch::TrackVirtualDispatch<d1>::TtInput::LocalSourceNode#9cbbba61_DataFlowPrivate::getA__#shared` WITH `DataFlowDispatch::nonVirtualDispatch/1#f749a2ef` ON FIRST 1 OUTPUT Rhs.1, Lhs.2, Lhs.1
                        return r1

[2026-09-04 13:23:47] Evaluated non-recursive predicate DataFlowDispatch::TrackVirtualDispatch<noDisp>::TtInput::returnStep/2#64397117@4eb6ac89 in 77ms (size: 1415417).
Evaluated relational algebra for predicate DataFlowDispatch::TrackVirtualDispatch<noDisp>::TtInput::returnStep/2#64397117@4eb6ac89 with tuple counts:
        1415417  ~5%    {2} r1 = JOIN `_DataFlowDispatch::RelevantNode#d8b83544_DataFlowDispatch::hasKindAndEnclosingCallable/3#f9907305#shared` WITH `DataFlowDispatch::TrackVirtualDispatch<noDisp>::TtInput::hasDispatchWithKind/3#0e8dc366` ON FIRST 2 OUTPUT Lhs.2, Rhs.2
                        return r1
```