### PR TITLE
C++: Fix two more joins

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/FlowSummaryImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/FlowSummaryImpl.qll
@@ -256,7 +256,7 @@ private module Input2 implements Impl::Private::InputSig2 {
   pragma[nomagic]
   private predicate hasKindAndEnclosingFunction(Function f, ReturnKind rk, ReturnNode r) {
     r.getEnclosingCallable().asSourceCallable() = f and
-    r.getKind() = rk
+    pragma[only_bind_into](r).getKind() = rk
   }
 
   pragma[nomagic]

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -122,6 +122,47 @@ private module Cached {
     FlowSummaryImpl::Private::Steps::summaryJumpStep(n1, n2)
   }
 
+  bindingset[store]
+  pragma[inline_late]
+  private predicate nodeHasInstructionLate(Node node, StoreInstruction store, int indirectionIndex) {
+    nodeHasInstruction(node, store, indirectionIndex)
+  }
+
+  pragma[nomagic]
+  private predicate storeStepSource(
+    Operand fieldAddress, int contentIndirectionIndex, Node node, boolean certain
+  ) {
+    exists(int indirectionIndex, int numberOfLoads, StoreInstruction store |
+      nodeHasInstructionLate(node, store, indirectionIndex) and
+      numberOfLoadsFromOperand(fieldAddress, store.getDestinationAddressOperand(), numberOfLoads,
+        certain) and
+      contentIndirectionIndex = 1 + indirectionIndex + numberOfLoads
+    )
+  }
+
+  pragma[nomagic]
+  private predicate hasFieldAddressAndField(Field f, PostFieldUpdateNode pfu, Operand fieldAddress) {
+    pfu.getIndirectionIndex() = 1 and
+    pfu.getUpdatedField() = f and
+    pfu.getFieldAddress() = fieldAddress
+  }
+
+  pragma[nomagic]
+  private predicate hasFieldAndIndirectionIndex(Field f, int indirectionIndex, FieldContent fc) {
+    fc.getAField() = f and
+    fc.getIndirectionIndex() = indirectionIndex
+  }
+
+  pragma[nomagic]
+  private predicate storeStepTarget(
+    Operand address, int indirectionIndex, PostFieldUpdateNode pfu, FieldContent fc
+  ) {
+    exists(Field f |
+      hasFieldAddressAndField(f, pfu, address) and
+      hasFieldAndIndirectionIndex(f, indirectionIndex, fc)
+    )
+  }
+
   /**
    * Holds if data can flow from `node1` to `node2` via an assignment to `f`.
    * Thus, `node2` references an object with a field `f` that contains the
@@ -132,19 +173,9 @@ private module Cached {
    */
   cached
   predicate storeStepImpl(Node node1, Content c, Node node2, boolean certain) {
-    exists(
-      PostFieldUpdateNode postFieldUpdate, int indirectionIndex1, int numberOfLoads,
-      StoreInstruction store, FieldContent fc
-    |
-      postFieldUpdate = node2 and
-      fc = c and
-      nodeHasInstruction(node1, pragma[only_bind_into](store),
-        pragma[only_bind_into](indirectionIndex1)) and
-      postFieldUpdate.getIndirectionIndex() = 1 and
-      numberOfLoadsFromOperand(postFieldUpdate.getFieldAddress(),
-        store.getDestinationAddressOperand(), numberOfLoads, certain) and
-      fc.getAField() = postFieldUpdate.getUpdatedField() and
-      getIndirectionIndexLate(fc) = 1 + indirectionIndex1 + numberOfLoads
+    exists(Operand fieldAddress, int indirectionIndex |
+      storeStepSource(fieldAddress, indirectionIndex, node1, certain) and
+      storeStepTarget(fieldAddress, indirectionIndex, node2, c)
     )
     or
     // models-as-data summarized flow


### PR DESCRIPTION
This PR fixes two more bad joins.

The first one is pretty obvious: we should start by reducing the set of tuples to `ReturnNode`s before joining to grab all the enclosing callable.

The next one is a minor performance improvement. It doesn't fix a tuple count explosion from a bad join, but rather reduces the tuple duplication throughout pipeline. This may not look very bad, but I was seeing way larger numbers on an internal Microsoft repo which suggests that the rewrite is worth it:
```
[2026-09-03 16:51:21] Evaluated non-recursive predicate DataFlowPrivate::storeStepImpl/4#5a9e2fd2@d68f5cme in 220359ms (size: 752669).
Evaluated relational algebra for predicate DataFlowPrivate::storeStepImpl/4#5a9e2fd2@d68f5cme with tuple counts:
              8817       ~0%    {3} r1 = JOIN `FlowSummaryImpl::Private::Steps::summaryStoreStep/3#a7d89e4d` WITH DataFlowNodes::TFlowSummaryNode#d5706fd6 ON FIRST 1 OUTPUT Lhs.2, Lhs.1, Rhs.1
              8817       ~0%    {4}    | JOIN WITH DataFlowNodes::TFlowSummaryNode#d5706fd6 ON FIRST 1 OUTPUT Lhs.2, Lhs.1, Rhs.1, _
              8817       ~0%    {4}    | REWRITE WITH Out.3 := true

         202895630       ~0%    {3} r2 = SCAN `DataFlowPrivate::nodeHasInstruction/3#f469bb06` OUTPUT In.1, In.0, In.2
           8657916       ~3%    {3}    | JOIN WITH `Instruction::StoreInstruction.getDestinationAddressOperand/0#dispred#596a4aba` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
          12715059       ~7%    {6}    | JOIN WITH `DataFlowPrivate::numberOfLoadsFromOperand/4#7e555666_1023#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Rhs.3, _, Lhs.2, Rhs.2
          12715059       ~0%    {4}    | REWRITE WITH Tmp.3 := 1, Out.3 := (Tmp.3 + In.4 + In.5) KEEPING 4
           1472551       ~4%    {6}    | JOIN WITH DataFlowNodes::PostFieldUpdateNode#ba49e082_1023#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Rhs.2, Rhs.3
           1472551       ~0%    {8}    | JOIN WITH DataFlowNodes::TPostUpdateNodeImpl#15a1088b_21#join_rhs ON FIRST 1 OUTPUT Lhs.1, Lhs.2, Lhs.3, Lhs.0, Lhs.4, Lhs.5, Rhs.1, _
                                {7}    | REWRITE WITH Tmp.7 := 1, TEST InOut.6 = Tmp.7 KEEPING 7
            734797       ~6%    {6}    | SCAN OUTPUT In.3, In.4, In.5, In.0, In.1, In.2
        1621127648       ~0%    {5}    | JOIN WITH DataFlowNodes::PostFieldUpdateNode#ba49e082_0231#join_rhs ON FIRST 3 OUTPUT Rhs.3, Lhs.3, Lhs.4, Lhs.5, Lhs.0
        1621127650  ~223033%    {5}    | JOIN WITH `DataFlowNodes::FieldAddress.getField/0#dispred#fea3b845` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.4
        4183728692  ~244195%    {5}    | JOIN WITH `DataFlowUtil::FieldContent.getAField/0#dispred#ba1c91e5_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.3, Lhs.1, Lhs.2, Lhs.4
        1387996922  ~202996%    {4}    | JOIN WITH `DataFlowUtil::Content.getIndirectionIndex/0#dispred#c14b335b` ON FIRST 2 OUTPUT Lhs.2, Lhs.0, Lhs.4, Lhs.3

        1388005739  ~199712%    {4} r3 = r1 UNION r2
                                return r3
```
Notice that the true number of tuples is ~750K, but we end up operating on a pipeline with ~4B tuples.