### PR TITLE
Docs: use a self-hosted CodeQL logo instead of deprecated GHIcons

### DIFF
--- a/docs/codeql/index.html
+++ b/docs/codeql/index.html
@@ -66,7 +66,7 @@
     </div>
     <article class="pb-6" style="min-height: calc(100vh - 68px);">
         <div class="blankslate">
-            <img src="https://ghicons.github.com/assets/images/blue/svg/Code%20QL.svg" class="mb-3" />
+            <img src="../assets/img/svgs/codeql.svg" alt="" class="mb-3" />
             <h1>CodeQL documentation</h1>
             <p class="f2">CodeQL enables you to query code as though it were data. Write a query to find all variants of a
                 vulnerability, eradicating it forever. Then share your query to help others do the same.</p>


### PR DESCRIPTION
`docs/codeql/index.html` hot-linked the CodeQL logo from `ghicons.github.com`. GHIcons is deprecated and that URL will eventually 404, so the logo on https://codeql.github.com/docs/ would become broken.

This points the `<img>` at the same artwork hosted alongside the site's other assets in the publication repo that serves `codeql.github.com`, so the page no longer depends on a deprecated host. The logo itself is unchanged — this is a like-for-like move, not a redesign.