### PR TITLE
python: wildcard case is not default case

### DIFF
--- a/python/ql/lib/semmle/python/controlflow/internal/AstNodeImpl.qll
+++ b/python/ql/lib/semmle/python/controlflow/internal/AstNodeImpl.qll
@@ -993,9 +993,8 @@ module Ast implements AstSig<Py::Location> {
     }
   }
 
-  /** A wildcard case (`case _:`). */
   class DefaultCase extends Case {
-    DefaultCase() { this.isWildcard() }
+    DefaultCase() { none() }
   }
 
   /** A conditional expression (`x if cond else y`). */
@@ -1753,6 +1752,11 @@ private module Input implements InputSig1, InputSig2 {
       n1.isAfter(assertStmt.getMsg()) and
       n2.isAdditional(assertStmt, assertThrowTag())
     )
+  }
+
+  predicate matchAll(Ast::Case c) {
+    // A wildcard case (`case _:`) will match all values.
+    c.isWildcard()
   }
 }
 


### PR DESCRIPTION
A wildcard case (`case _:`) should not be considered default as the CFG library will then order it last.
Instead it is a `matchAll`. Revealed by https://github.com/github/codeql/pull/22510.