### PR TITLE
Rust: Remove experimental flag to `codeql_pack` rule

### DIFF
--- a/rust/BUILD.bazel
+++ b/rust/BUILD.bazel
@@ -58,5 +58,4 @@ codeql_pack(
         ":tools",
         "//rust/downgrades",
     ],
-    experimental = True,
 )


### PR DESCRIPTION
I'm guessing we no longer need this. @redsun82 should probably confirm :)