### PR TITLE
Unified: Extract modifiers for function declarations

### DIFF
--- a/unified/extractor/src/languages/swift/swift.rs
+++ b/unified/extractor/src/languages/swift/swift.rs
@@ -558,6 +558,7 @@ fn translation_rules() -> Vec<Rule<SwiftContext>> {
         // an empty `block`.
         rule!(
             (functionDecl
+                modifiers: _* @mods
                 name: @name
                 genericParameterClause: (genericParameterClause parameters: _* @type_params)?
                 signature: (functionSignature
@@ -566,6 +567,7 @@ fn translation_rules() -> Vec<Rule<SwiftContext>> {
                 body: (codeBlock statements: _* @body))
             =>
             (function_declaration
+                modifier: {mods}
                 name_node: (identifier #{name})
                 type_parameter: {type_params}
                 parameter: {params}
@@ -574,6 +576,7 @@ fn translation_rules() -> Vec<Rule<SwiftContext>> {
         ),
         rule!(
             (functionDecl
+                modifiers: _* @mods
                 name: @name
                 genericParameterClause: (genericParameterClause parameters: _* @type_params)?
                 signature: (functionSignature
@@ -581,6 +584,7 @@ fn translation_rules() -> Vec<Rule<SwiftContext>> {
                     returnClause: (returnClause type: @ret)?))
             =>
             (function_declaration
+                modifier: {mods}
                 name_node: (identifier #{name})
                 type_parameter: {type_params}
                 parameter: {params}

--- a/unified/extractor/tests/corpus/swift/control-flow/discard-statement.output
+++ b/unified/extractor/tests/corpus/swift/control-flow/discard-statement.output
@@ -75,6 +75,7 @@ top_level
               type: unsupported_node "~Copyable"
           member:
             function_declaration
+              modifier: modifier "consuming"
               name_node: identifier "close"
               body:
                 block

--- a/unified/extractor/tests/corpus/swift/types/class-function.output
+++ b/unified/extractor/tests/corpus/swift/types/class-function.output
@@ -1,0 +1,57 @@
+class Factory {
+  class func make() {}
+}
+
+---
+
+sourceFile
+  endOfFileToken: endOfFile
+  statements:
+    codeBlockItem
+      item:
+        classDecl
+          attributes:
+          name: identifier "Factory"
+          memberBlock:
+            memberBlock
+              leftBrace: {
+              rightBrace: }
+              members:
+                memberBlockItem
+                  decl:
+                    functionDecl
+                      attributes:
+                      body:
+                        codeBlock
+                          leftBrace: {
+                          rightBrace: }
+                          statements:
+                      name: identifier "make"
+                      modifiers:
+                        declModifier
+                          name: class
+                      signature:
+                        functionSignature
+                          parameterClause:
+                            functionParameterClause
+                              leftParen: (
+                              rightParen: )
+                              parameters:
+                      funcKeyword: func
+          modifiers:
+          classKeyword: class
+
+---
+
+top_level
+  body:
+    block
+      stmt:
+        class_like_declaration
+          modifier: modifier "class"
+          name_node: identifier "Factory"
+          member:
+            function_declaration
+              modifier: modifier "class"
+              name_node: identifier "make"
+              body: block "class func make() {}"

--- a/unified/extractor/tests/corpus/swift/types/class-function.swift
+++ b/unified/extractor/tests/corpus/swift/types/class-function.swift
@@ -1,0 +1,3 @@
+class Factory {
+  class func make() {}
+}

--- a/unified/extractor/tests/corpus/swift/types/protocol-declaration.output
+++ b/unified/extractor/tests/corpus/swift/types/protocol-declaration.output
@@ -66,5 +66,5 @@ top_level
               body: block "func draw()"
             function_declaration
               modifier: modifier "static"
-              name: identifier "make"
+              name_node: identifier "make"
               body: block "static func make()"

--- a/unified/extractor/tests/corpus/swift/types/protocol-declaration.output
+++ b/unified/extractor/tests/corpus/swift/types/protocol-declaration.output
@@ -1,5 +1,6 @@
 protocol Drawable {
   func draw()
+  static func make()
 }
 
 ---
@@ -31,6 +32,22 @@ sourceFile
                               rightParen: )
                               parameters:
                       funcKeyword: func
+                memberBlockItem
+                  decl:
+                    functionDecl
+                      attributes:
+                      name: identifier "make"
+                      modifiers:
+                        declModifier
+                          name: static
+                      signature:
+                        functionSignature
+                          parameterClause:
+                            functionParameterClause
+                              leftParen: (
+                              rightParen: )
+                              parameters:
+                      funcKeyword: func
           modifiers:
           protocolKeyword: protocol
 
@@ -47,3 +64,7 @@ top_level
             function_declaration
               name_node: identifier "draw"
               body: block "func draw()"
+            function_declaration
+              modifier: modifier "static"
+              name: identifier "make"
+              body: block "static func make()"

--- a/unified/extractor/tests/corpus/swift/types/protocol-declaration.swift
+++ b/unified/extractor/tests/corpus/swift/types/protocol-declaration.swift
@@ -1,3 +1,4 @@
 protocol Drawable {
   func draw()
+  static func make()
 }

--- a/unified/extractor/tests/corpus/swift/types/static-function.output
+++ b/unified/extractor/tests/corpus/swift/types/static-function.output
@@ -1,0 +1,57 @@
+class Factory {
+  static func make() {}
+}
+
+---
+
+sourceFile
+  endOfFileToken: endOfFile
+  statements:
+    codeBlockItem
+      item:
+        classDecl
+          attributes:
+          name: identifier "Factory"
+          memberBlock:
+            memberBlock
+              leftBrace: {
+              rightBrace: }
+              members:
+                memberBlockItem
+                  decl:
+                    functionDecl
+                      attributes:
+                      body:
+                        codeBlock
+                          leftBrace: {
+                          rightBrace: }
+                          statements:
+                      name: identifier "make"
+                      modifiers:
+                        declModifier
+                          name: static
+                      signature:
+                        functionSignature
+                          parameterClause:
+                            functionParameterClause
+                              leftParen: (
+                              rightParen: )
+                              parameters:
+                      funcKeyword: func
+          modifiers:
+          classKeyword: class
+
+---
+
+top_level
+  body:
+    block
+      stmt:
+        class_like_declaration
+          modifier: modifier "class"
+          name_node: identifier "Factory"
+          member:
+            function_declaration
+              modifier: modifier "static"
+              name_node: identifier "make"
+              body: block "static func make() {}"

--- a/unified/extractor/tests/corpus/swift/types/static-function.swift
+++ b/unified/extractor/tests/corpus/swift/types/static-function.swift
@@ -1,0 +1,3 @@
+class Factory {
+  static func make() {}
+}


### PR DESCRIPTION
Swift function declaration modifiers were omitted from the unified AST, preventing consumers from distinguishing declarations such as `consuming`, `static`, and `class` functions.

Capture the `functionDecl.modifiers` field for functions both with and without bodies, and emit the translated modifiers on `function_declaration`. Add focused corpus coverage for `static` and `class` functions, while updating the existing `consuming` function corpus output.