### PR TITLE
Unified: Introduce local variables and 'self' bindings

### DIFF
--- a/shared/namebinding/codeql/namebinding/LocalNameBinding.qll
+++ b/shared/namebinding/codeql/namebinding/LocalNameBinding.qll
@@ -337,53 +337,88 @@ module LocalNameBinding<LocationSig Location, LocalNameBindingInputSig<Location>
     )
   }
 
-  private predicate accessCandInLookupScope(AstNode n, string name, Scope lookup) {
-    accessCand(n, name) and
-    (
-      lookupStartsAt(n, lookup)
-      or
-      not lookupStartsAt(n, _) and
-      lookup = getEnclosingScope(n)
-    )
-  }
-
-  pragma[nomagic]
-  private predicate lookupInScope(string name, Scope lookup, Scope scope) {
-    accessCandInLookupScope(_, name, lookup) and
-    scope = lookup
-    or
-    exists(Scope mid |
-      lookupInScope(name, lookup, mid) and
-      not declInScope(name, mid) and
-      not isTopScope(mid) and
-      scope = getEnclosingScope(mid)
-    )
-  }
-
   private predicate declInScope(string name, AstNode scope) {
     declInScope(_, name, scope) or
     implicitDeclInScope(name, scope)
   }
 
-  /**
-   * Holds if `name`, when resolved from `lookup`, may resolve to one of the uncertain members of `scope`.
-   */
-  pragma[nomagic]
-  private predicate lookupInUncertainScope(string name, Scope lookup, Scope scope) {
-    lookupInScope(name, lookup, scope) and
-    uncertainScope(scope) and
-    not declInScope(name, scope)
-  }
+  signature predicate accessCandSig(AstNode n, string name);
 
   /**
-   * Gets an uncertain scope in which the `accessCand` pair may resolve.
+   * Allows resolution of access candidates.
+   *
+   * This is instantiated once by the local name binding library itself in order to populate `LocalAccces`.
+   * It can be instantiated further by the client, to resolve additional lookups at a later evaluation stage.
    */
-  AstNode getAnUncertainScope(AstNode access, string name) {
-    exists(Scope lookup |
-      accessCandInLookupScope(access, name, lookup) and
-      lookupInUncertainScope(name, lookup, result)
-    )
+  module ResolveAccesses<accessCandSig/2 accessCandInput> {
+    private predicate accessCandInLookupScope(AstNode n, string name, Scope lookup) {
+      accessCandInput(n, name) and
+      (
+        lookupStartsAt(n, lookup)
+        or
+        not lookupStartsAt(n, _) and
+        lookup = getEnclosingScope(n)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate lookupInScope(string name, Scope lookup, Scope scope) {
+      accessCandInLookupScope(_, name, lookup) and
+      scope = lookup
+      or
+      exists(Scope mid |
+        lookupInScope(name, lookup, mid) and
+        not declInScope(name, mid) and
+        not isTopScope(mid) and
+        scope = getEnclosingScope(mid)
+      )
+    }
+
+    pragma[nomagic]
+    private predicate resolveInScope(string name, Scope lookup, Local l) {
+      exists(Scope scope | lookupInScope(name, lookup, scope) |
+        l = TExplicitLocal(_, name, scope) or
+        l = TImplicitLocal(name, scope)
+      )
+    }
+
+    predicate access(AstNode access, Local l) {
+      exists(Scope lookup, string name |
+        accessCandInLookupScope(access, name, lookup) and
+        resolveInScope(name, lookup, l)
+      )
+    }
+
+    /**
+     * Holds if `name`, when resolved from `lookup`, may resolve to one of the uncertain members of `scope`.
+     */
+    pragma[nomagic]
+    private predicate lookupInUncertainScope(string name, Scope lookup, Scope scope) {
+      lookupInScope(name, lookup, scope) and
+      uncertainScope(scope) and
+      not declInScope(name, scope)
+    }
+
+    /**
+     * Gets an uncertain scope in which the `accessCand` pair may resolve.
+     */
+    AstNode getAnUncertainScope(AstNode access, string name) {
+      exists(Scope lookup |
+        accessCandInLookupScope(access, name, lookup) and
+        lookupInUncertainScope(name, lookup, result)
+      )
+    }
   }
+
+  private module DefaultAccesses = ResolveAccesses<accessCand/2>;
+
+  cached
+  predicate access(AstNode access, Local l) {
+    CachedStage::ref() and
+    DefaultAccesses::access(access, l)
+  }
+
+  predicate getAnUncertainScope = DefaultAccesses::getAnUncertainScope/2;
 
   cached
   private newtype TLocal =
@@ -447,23 +482,6 @@ module LocalNameBinding<LocationSig Location, LocalNameBindingInputSig<Location>
     override string getName() { result = name }
 
     override Location getLocation() { result = scope.getLocation() }
-  }
-
-  pragma[nomagic]
-  private predicate resolveInScope(string name, Scope lookup, Local l) {
-    exists(Scope scope | lookupInScope(name, lookup, scope) |
-      l = TExplicitLocal(_, name, scope) or
-      l = TImplicitLocal(name, scope)
-    )
-  }
-
-  cached
-  private predicate access(AstNode access, Local l) {
-    CachedStage::ref() and
-    exists(Scope lookup, string name |
-      accessCandInLookupScope(access, name, lookup) and
-      resolveInScope(name, lookup, l)
-    )
   }
 
   /** A local access. */

--- a/shared/namebinding/codeql/namebinding/LocalNameBinding.qll
+++ b/shared/namebinding/codeql/namebinding/LocalNameBinding.qll
@@ -415,7 +415,7 @@ module LocalNameBinding<LocationSig Location, LocalNameBindingInputSig<Location>
 
   /** Holds if `access` resolves to `l`. */
   cached
-  predicate access(AstNode access, Local l) {
+  private predicate access(AstNode access, Local l) {
     CachedStage::ref() and
     DefaultAccesses::access(access, l)
   }

--- a/shared/namebinding/codeql/namebinding/LocalNameBinding.qll
+++ b/shared/namebinding/codeql/namebinding/LocalNameBinding.qll
@@ -347,7 +347,7 @@ module LocalNameBinding<LocationSig Location, LocalNameBindingInputSig<Location>
   /**
    * Allows resolution of access candidates.
    *
-   * This is instantiated once by the local name binding library itself in order to populate `LocalAccces`.
+   * This is instantiated once by the local name binding library itself in order to populate `LocalAccess`.
    * It can be instantiated further by the client, to resolve additional lookups at a later evaluation stage.
    */
   module ResolveAccesses<accessCandSig/2 accessCandInput> {

--- a/shared/namebinding/codeql/namebinding/LocalNameBinding.qll
+++ b/shared/namebinding/codeql/namebinding/LocalNameBinding.qll
@@ -484,6 +484,10 @@ module LocalNameBinding<LocationSig Location, LocalNameBindingInputSig<Location>
     override string getName() { result = name }
 
     override Location getLocation() { result = scope.getLocation() }
+
+    /** Holds if this variable has the given name and scope. */
+    pragma[nomagic]
+    predicate hasNameAndScope(string name_, AstNode scope_) { name = name_ and scope = scope_ }
   }
 
   /** A local access. */

--- a/shared/namebinding/codeql/namebinding/LocalNameBinding.qll
+++ b/shared/namebinding/codeql/namebinding/LocalNameBinding.qll
@@ -382,6 +382,7 @@ module LocalNameBinding<LocationSig Location, LocalNameBindingInputSig<Location>
       )
     }
 
+    /** Holds if `access` resolves to `l`. */
     predicate access(AstNode access, Local l) {
       exists(Scope lookup, string name |
         accessCandInLookupScope(access, name, lookup) and
@@ -412,6 +413,7 @@ module LocalNameBinding<LocationSig Location, LocalNameBindingInputSig<Location>
 
   private module DefaultAccesses = ResolveAccesses<accessCand/2>;
 
+  /** Holds if `access` resolves to `l`. */
   cached
   predicate access(AstNode access, Local l) {
     CachedStage::ref() and

--- a/unified/ql/lib/codeql/Definitions.qll
+++ b/unified/ql/lib/codeql/Definitions.qll
@@ -3,7 +3,7 @@
  */
 
 private import unified
-private import codeql.unified.internal.StaticNameBinding
+private import codeql.unified.internal.NameBinding
 
 /**
  * Holds if `reference` refers to `definition`.

--- a/unified/ql/lib/codeql/Definitions.qll
+++ b/unified/ql/lib/codeql/Definitions.qll
@@ -9,8 +9,8 @@ private import codeql.unified.internal.StaticNameBinding
  * Holds if `reference` refers to `definition`.
  */
 cached
-predicate definitionOf(Identifier reference, NameDeclaration definition, string kind) {
+predicate definitionOf(Identifier reference, NameBinding definition, string kind) {
   definition = getStaticBindingTarget(reference) and
-  not reference instanceof NameDeclaration and
+  not reference instanceof NameBinding and
   kind = "name"
 }

--- a/unified/ql/lib/codeql/unified/internal/AnalysisQuality.qll
+++ b/unified/ql/lib/codeql/unified/internal/AnalysisQuality.qll
@@ -1,8 +1,6 @@
 private import unified
 private import codeql.util.ReportStats
-private import codeql.unified.internal.StaticNameBinding
-private import codeql.unified.internal.LocalNameBinding
-private import codeql.unified.internal.NameBindingPlugin
+private import codeql.unified.internal.NameBinding
 
 /** Stats about name nodes that static name binding could resolve. */
 module StaticNameResolutionStats implements EntityStatsSig {

--- a/unified/ql/lib/codeql/unified/internal/AnalysisQuality.qll
+++ b/unified/ql/lib/codeql/unified/internal/AnalysisQuality.qll
@@ -46,19 +46,17 @@ module StaticNameResolutionStats implements EntityStatsSig {
     }
 
     NameBindingNode getTarget() {
-      (
-        result.asIdentifier() = getStaticBindingTarget(this)
-        or
-        result.isModuleScopeNode(_) and
-        result.(NamespaceNode).ref().isIdentifier(this)
-        or
-        // Resolving to an implicitly-declared local such as "self" should count as
-        // as a successfully resolved name
-        exists(LocalName implicitLocal |
-          implicitLocal = this.(LocalNameAccess).getLocalName() and
-          not exists(implicitLocal.getABinding()) and
-          result.isLocalName(implicitLocal)
-        )
+      result.asIdentifier() = getStaticBindingTarget(this)
+      or
+      result.isModuleScopeNode(_) and
+      result.(NamespaceNode).ref().isIdentifier(this)
+      or
+      // Resolving to an implicitly-declared local such as "self" should count as
+      // as a successfully resolved name
+      exists(LocalName implicitLocal |
+        implicitLocal = this.(LocalNameAccess).getLocalName() and
+        not exists(implicitLocal.getABinding()) and
+        result.isLocalName(implicitLocal)
       )
     }
 

--- a/unified/ql/lib/codeql/unified/internal/AnalysisQuality.qll
+++ b/unified/ql/lib/codeql/unified/internal/AnalysisQuality.qll
@@ -51,6 +51,14 @@ module StaticNameResolutionStats implements EntityStatsSig {
         or
         result.isModuleScopeNode(_) and
         result.(NamespaceNode).ref().isIdentifier(this)
+        or
+        // Resolving to an implicitly-declared local such as "self" should count as
+        // as a successfully resolved name
+        exists(LocalName implicitLocal |
+          implicitLocal = this.(LocalNameAccess).getLocalName() and
+          not exists(implicitLocal.getABinding()) and
+          result.isLocalName(implicitLocal)
+        )
       )
     }
 

--- a/unified/ql/lib/codeql/unified/internal/AnalysisQuality.qll
+++ b/unified/ql/lib/codeql/unified/internal/AnalysisQuality.qll
@@ -44,7 +44,7 @@ module StaticNameResolutionStats implements EntityStatsSig {
         this = getIdentifierFromRef(ref) and
         not memberAccessDependsOnTypeInference(ref)
       ) and
-      not this instanceof NameDeclaration
+      not this instanceof NameBinding
     }
 
     NameBindingNode getTarget() {

--- a/unified/ql/lib/codeql/unified/internal/AstExtra.qll
+++ b/unified/ql/lib/codeql/unified/internal/AstExtra.qll
@@ -3,6 +3,7 @@
  */
 
 private import unified
+private import codeql.unified.internal.NameBindingPlugin
 
 module Public {
   /** A short-circuiting logical AND expression. */
@@ -29,24 +30,14 @@ module Public {
    * Declaration of a local or top-level variable.
    */
   class LocalVariableDeclaration extends VariableDeclaration {
-    private Block block;
-
-    LocalVariableDeclaration() { this = block.getStmt(_) }
-
-    /** Gets the block in which this variable is declared. */
-    Block getDeclaringBlock() { result = block }
+    LocalVariableDeclaration() { not isStaticMember(this) and not isInstanceMember(this) }
   }
 
   /**
    * Declaration of a local or top-level function.
    */
   class LocalFunctionDeclaration extends FunctionDeclaration {
-    private Block block;
-
-    LocalFunctionDeclaration() { this = block.getStmt(_) }
-
-    /** Gets the block in which this function is declared. */
-    Block getDeclaringBlock() { result = block }
+    LocalFunctionDeclaration() { not isStaticMember(this) and not isInstanceMember(this) }
   }
 
   /**

--- a/unified/ql/lib/codeql/unified/internal/ControlFlowGraph.qll
+++ b/unified/ql/lib/codeql/unified/internal/ControlFlowGraph.qll
@@ -39,14 +39,7 @@ private module Ast implements AstSig<Location> {
     not skipControlFlow(result)
   }
 
-  Callable getEnclosingCallable(AstNode node) {
-    exists(AstNode parent | parent = node.getParent() |
-      result = parent
-      or
-      not parent instanceof Callable and
-      result = getEnclosingCallable(parent)
-    )
-  }
+  Callable getEnclosingCallable(AstNode node) { result = node.getEnclosingCallable() }
 
   class Callable = U::Callable;
 

--- a/unified/ql/lib/codeql/unified/internal/FacadeAst.qll
+++ b/unified/ql/lib/codeql/unified/internal/FacadeAst.qll
@@ -23,7 +23,7 @@ module Unified {
       )
     }
 
-    /** Gets the nearest enclosing class declaration. */
+    /** Gets the nearest enclosing class declaration, if any. */
     ClassLikeDeclaration getEnclosingClass() {
       exists(AstNode parent | parent = this.getParent() |
         result = parent

--- a/unified/ql/lib/codeql/unified/internal/FacadeAst.qll
+++ b/unified/ql/lib/codeql/unified/internal/FacadeAst.qll
@@ -23,12 +23,14 @@ module Unified {
       )
     }
 
-    /** Gets the nearest enclosing class declaration, possibly this node itself. */
+    /** Gets the nearest enclosing class declaration. */
     ClassLikeDeclaration getEnclosingClass() {
-      result = this
-      or
-      not this instanceof ClassLikeDeclaration and
-      result = this.getParent().getEnclosingClass()
+      exists(AstNode parent | parent = this.getParent() |
+        result = parent
+        or
+        not parent instanceof ClassLikeDeclaration and
+        result = parent.getEnclosingClass()
+      )
     }
 
     /** Gets the nearest callable containing this AST node. */

--- a/unified/ql/lib/codeql/unified/internal/FacadeAst.qll
+++ b/unified/ql/lib/codeql/unified/internal/FacadeAst.qll
@@ -42,7 +42,16 @@ module Unified {
       )
     }
 
-    /** Gets the nearest callable containing this AST node. */
+    /**
+     * Gets the nearest callable containing this AST node.
+     *
+     * If this node is itself a callable, this gets the outer callable, not the node itself.
+     *
+     * Note that the `TopLevel` is callable, so all nodes other than the `TopLevel` itself has an enclosing callable.
+     *
+     * In some cases this predicate skips overs the syntactically-enclosing callable in order to get the callable in which
+     * the AST is actually evaluated (such as for capture declarations in a function expression).
+     */
     Callable getEnclosingCallable() {
       exists(AstNode parent |
         parent = this.overrideEnclosingCallableParent()

--- a/unified/ql/lib/codeql/unified/internal/FacadeAst.qll
+++ b/unified/ql/lib/codeql/unified/internal/FacadeAst.qll
@@ -33,9 +33,23 @@ module Unified {
       )
     }
 
+    private AstNode overrideEnclosingCallableParent() {
+      exists(FunctionExpr func |
+        // Capture declarations are evaluated as part of the outer context, and
+        // considered to be captured by the function expression.
+        this = func.getACaptureDeclaration() and
+        result = func.getParent()
+      )
+    }
+
     /** Gets the nearest callable containing this AST node. */
     Callable getEnclosingCallable() {
-      exists(AstNode parent | parent = this.getParent() |
+      exists(AstNode parent |
+        parent = this.overrideEnclosingCallableParent()
+        or
+        not exists(this.overrideEnclosingCallableParent()) and
+        parent = this.getParent()
+      |
         result = parent
         or
         not parent instanceof Callable and

--- a/unified/ql/lib/codeql/unified/internal/FacadeAst.qll
+++ b/unified/ql/lib/codeql/unified/internal/FacadeAst.qll
@@ -31,6 +31,16 @@ module Unified {
       result = this.getParent().getEnclosingClass()
     }
 
+    /** Gets the nearest callable containing this AST node. */
+    Callable getEnclosingCallable() {
+      exists(AstNode parent | parent = this.getParent() |
+        result = parent
+        or
+        not parent instanceof Callable and
+        result = parent.getEnclosingCallable()
+      )
+    }
+
     /** Gets the depth of this node in the AST. The root node has a depth of 0. */
     int getDepth() {
       not exists(this.getParent()) and result = 0

--- a/unified/ql/lib/codeql/unified/internal/LocalNameBinding.qll
+++ b/unified/ql/lib/codeql/unified/internal/LocalNameBinding.qll
@@ -360,13 +360,13 @@ module Public {
 
     LocalNameAccess getAnAccess() { result.getLocalName() = this }
 
-    /** Gets an identiier that declares this local name. */
-    NameDeclaration getADeclaration() { result.getLocalName() = this }
+    /** Gets a name binding that declares this local name. */
+    NameBinding getABinding() { result.getLocalName() = this }
   }
 
-  /** A name node that appears as the declaration site of a name, such as the `x` in `let x = 123`. */
-  class NameDeclaration extends Identifier {
-    NameDeclaration() { LocalNameBindingInput::bindingContext(this, _, _) }
+  /** An identifier appearing in a name-binding position, such as the `x` in `let x = 123`. */
+  class NameBinding extends Identifier {
+    NameBinding() { LocalNameBindingInput::bindingContext(this, _, _) }
 
     /** Gets the statement-like node declaring this name, such as a `VariableDeclaration` or `CatchClause`. */
     AstNode getDeclaration() { LocalNameBindingInput::bindingContext(this, _, result) }
@@ -382,7 +382,7 @@ module Public {
   class LocalVariable extends LocalName {
     LocalVariable() {
       exists(AstNode decl |
-        decl = this.getADeclaration().getDeclaration() and
+        decl = this.getABinding().getDeclaration() and
         not isInstanceMember(decl) and
         not isStaticMember(decl)
       |
@@ -429,6 +429,6 @@ class PotentialLocalNameAccess extends IdentifierExpr {
 
   string getName() { result = this.getValue() }
 
-  /** Holds if this is one of the declaration sites for a name, such as the `x` in `let x = 123`. */
-  predicate isDeclarationSite() { this instanceof NameDeclaration }
+  /** Holds if this is one of the binding sites for a name, such as the `x` in `let x = 123`. */
+  predicate isBindingSite() { this instanceof NameBinding }
 }

--- a/unified/ql/lib/codeql/unified/internal/LocalNameBinding.qll
+++ b/unified/ql/lib/codeql/unified/internal/LocalNameBinding.qll
@@ -168,6 +168,11 @@ private module LocalNameBindingInput implements LocalNameBindingInputSig<Locatio
 
   private class LocalVariableDeclarationSiblingShadowingDecl extends SiblingShadowingDecl instanceof LocalVariableDeclaration
   {
+    LocalVariableDeclarationSiblingShadowingDecl() {
+      // Capture-declarations act as local variables, but are not sibling-shadowing
+      not this = any(FunctionExpr e).getACaptureDeclaration()
+    }
+
     override Expr getPattern() { result = LocalVariableDeclaration.super.getPattern() }
 
     override AstNode getRhs() { result = LocalVariableDeclaration.super.getValue() }

--- a/unified/ql/lib/codeql/unified/internal/LocalNameBinding.qll
+++ b/unified/ql/lib/codeql/unified/internal/LocalNameBinding.qll
@@ -367,6 +367,7 @@ module Public {
     /** Gets the name of this local, as a string. */
     string getName() { result = super.getName() }
 
+    /** Gets an access to this entity, through its lexically scoped name. */
     LocalNameAccess getAnAccess() { result.getLocalName() = this }
 
     /** Gets a name binding that declares this local name. */
@@ -458,8 +459,10 @@ module Public {
  * ```
  */
 class PotentialLocalNameAccess extends IdentifierExpr {
+  /** Gets the representative for the local name being accessed. */
   LocalName getLocalName() { result = this.(LocalNameBindingOutput::LocalAccess).getLocal() }
 
+  /** Gets the name being accessed. */
   string getName() { result = this.getValue() }
 
   /** Holds if this is one of the binding sites for a name, such as the `x` in `let x = 123`. */

--- a/unified/ql/lib/codeql/unified/internal/LocalNameBinding.qll
+++ b/unified/ql/lib/codeql/unified/internal/LocalNameBinding.qll
@@ -395,6 +395,14 @@ module Public {
         decl instanceof SwitchCase
       )
     }
+
+    /** Gets the callable containing the declaration of this local variable. */
+    Callable getDeclaringCallable() { result = this.getABinding().getEnclosingCallable() }
+
+    /** Holds if this local variable is captured, that is, it is accessed from another callable than the one declaring it. */
+    predicate isCaptured() {
+      this.getAnAccess().getEnclosingCallable() != this.getDeclaringCallable()
+    }
   }
 
   /** An access to a locally-declared name. */

--- a/unified/ql/lib/codeql/unified/internal/LocalNameBinding.qll
+++ b/unified/ql/lib/codeql/unified/internal/LocalNameBinding.qll
@@ -326,6 +326,7 @@ private module LocalNameBindingInput implements LocalNameBindingInputSig<Locatio
     )
   }
 
+  pragma[nomagic]
   additional predicate implicitDeclInScope(string name, AstNode scope, boolean isLocalVariable) {
     exists(Callable callable |
       isLocalVariable = true and
@@ -407,8 +408,7 @@ module Public {
       or
       // For implicitly-declared locals we can't expect to find a binding. Check 'implicitDeclInScope' directly.
       exists(AstNode scope, string name |
-        this.getName() = name and
-        this.(LocalNameBindingOutput::ImplicitLocal).getScope() = scope and
+        this.(LocalNameBindingOutput::ImplicitLocal).hasNameAndScope(name, scope) and
         LocalNameBindingInput::implicitDeclInScope(name, scope, true)
       )
     }

--- a/unified/ql/lib/codeql/unified/internal/LocalNameBinding.qll
+++ b/unified/ql/lib/codeql/unified/internal/LocalNameBinding.qll
@@ -6,6 +6,7 @@ private import unified
 private import unified as U
 private import codeql.namebinding.LocalNameBinding
 private import codeql.unified.internal.NameBindingPlugin
+private import codeql.unified.internal.StaticNameBinding
 
 private module LocalNameBindingInput implements LocalNameBindingInputSig<Location> {
   class AstNode = U::AstNode;
@@ -325,6 +326,7 @@ private module LocalNameBindingInput implements LocalNameBindingInputSig<Locatio
   predicate implicitDeclInScope(string name, AstNode scope) {
     none()
     // TODO: self
+    // TODO: When populating this predicate, make sure LocalVariable knows which implicit locals are variables
   }
 
   predicate accessCand(AstNode n, string name) { n.(PotentialLocalNameAccess).getName() = name }
@@ -357,6 +359,11 @@ module Public {
 
     /** Gets the name of this local, as a string. */
     string getName() { result = super.getName() }
+
+    LocalNameAccess getAnAccess() { result.getLocalName() = this }
+
+    /** Gets an identiier that declares this local name. */
+    NameDeclaration getADeclaration() { result.getLocalName() = this }
   }
 
   /** A name node that appears as the declaration site of a name, such as the `x` in `let x = 123`. */
@@ -371,6 +378,38 @@ module Public {
 
     /** Gets the representative for the local name introduced by this declaration. */
     LocalName getLocalName() { result = this.(LocalNameBindingOutput::LocalAccess).getLocal() }
+  }
+
+  /** A representative for a lexically scoped local variable. */
+  class LocalVariable extends LocalName {
+    LocalVariable() {
+      exists(AstNode decl |
+        decl = this.getADeclaration().getDeclaration() and
+        not isInstanceMember(decl) and
+        not isStaticMember(decl)
+      |
+        decl instanceof VariableDeclaration or
+        decl instanceof FunctionDeclaration or // treat functions as values
+        decl instanceof Parameter or
+        decl instanceof ForEachStmt or
+        decl instanceof PatternGuardExpr or
+        decl instanceof CatchClause or
+        decl instanceof SwitchCase
+      )
+    }
+  }
+
+  /** An access to a locally-declared name. */
+  class LocalNameAccess extends PotentialLocalNameAccess {
+    LocalNameAccess() { not this instanceof UnqualifiedMemberAccess }
+  }
+
+  /** An access to a local variable. */
+  class LocalVariableAccess extends LocalNameAccess {
+    LocalVariableAccess() { this.getLocalName() instanceof LocalVariable }
+
+    /** Gets the local variable being accessed. Alias for `getLocalName()`. */
+    LocalVariable getLocalVariable() { result = this.getLocalName() }
   }
 }
 

--- a/unified/ql/lib/codeql/unified/internal/LocalNameBinding.qll
+++ b/unified/ql/lib/codeql/unified/internal/LocalNameBinding.qll
@@ -321,11 +321,15 @@ private module LocalNameBindingInput implements LocalNameBindingInputSig<Locatio
     )
   }
 
-  predicate implicitDeclInScope(string name, AstNode scope) {
-    none()
-    // TODO: self
-    // TODO: When populating this predicate, make sure LocalVariable knows which implicit locals are variables
+  additional predicate implicitDeclInScope(string name, AstNode scope, boolean isLocalVariable) {
+    exists(Callable callable |
+      isLocalVariable = true and
+      name = any(NameBindingPlugin p).getImplicitReceiverParameterName(callable) and
+      scope = callable
+    )
   }
+
+  predicate implicitDeclInScope(string name, AstNode scope) { implicitDeclInScope(name, scope, _) }
 
   predicate accessCand(AstNode n, string name) { n.(PotentialLocalNameAccess).getName() = name }
 
@@ -394,10 +398,26 @@ module Public {
         decl instanceof CatchClause or
         decl instanceof SwitchCase
       )
+      or
+      // For implicitly-declared locals we can't expect to find a binding. Check 'implicitDeclInScope' directly.
+      exists(AstNode scope, string name |
+        this.getName() = name and
+        this.(LocalNameBindingOutput::ImplicitLocal).getScope() = scope and
+        LocalNameBindingInput::implicitDeclInScope(name, scope, true)
+      )
     }
 
     /** Gets the callable containing the declaration of this local variable. */
-    Callable getDeclaringCallable() { result = this.getABinding().getEnclosingCallable() }
+    Callable getDeclaringCallable() {
+      result = this.getABinding().getEnclosingCallable()
+      or
+      exists(AstNode scope | scope = this.(LocalNameBindingOutput::ImplicitLocal).getScope() |
+        result = scope
+        or
+        not scope instanceof Callable and
+        result = scope.getEnclosingCallable()
+      )
+    }
 
     /** Holds if this local variable is captured, that is, it is accessed from another callable than the one declaring it. */
     predicate isCaptured() {

--- a/unified/ql/lib/codeql/unified/internal/LocalNameBinding.qll
+++ b/unified/ql/lib/codeql/unified/internal/LocalNameBinding.qll
@@ -168,8 +168,6 @@ private module LocalNameBindingInput implements LocalNameBindingInputSig<Locatio
 
   private class LocalVariableDeclarationSiblingShadowingDecl extends SiblingShadowingDecl instanceof LocalVariableDeclaration
   {
-    LocalVariableDeclarationSiblingShadowingDecl() { not this instanceof TopLevelStmt }
-
     override Expr getPattern() { result = LocalVariableDeclaration.super.getPattern() }
 
     override AstNode getRhs() { result = LocalVariableDeclaration.super.getValue() }

--- a/unified/ql/lib/codeql/unified/internal/NameBinding.qll
+++ b/unified/ql/lib/codeql/unified/internal/NameBinding.qll
@@ -1,0 +1,15 @@
+/**
+ * Re-exports everything from the name-binding passes, while avoiding conflicts on 'Public'.
+ *
+ * TODO: move name binding passes into a subfolder.
+ */
+
+import StaticNameBinding
+import LocalNameBinding
+import NameBindingPlugin
+
+module Public {
+  // re-declare here to avoid conflicting import
+  import StaticNameBinding::Public
+  import LocalNameBinding::Public
+}

--- a/unified/ql/lib/codeql/unified/internal/NameBindingPlugin.qll
+++ b/unified/ql/lib/codeql/unified/internal/NameBindingPlugin.qll
@@ -39,6 +39,9 @@ class NameBindingPlugin extends Unit {
    */
   bindingset[cls, member]
   predicate isInheritableMember(ClassLikeDeclaration cls, Member member) { none() }
+
+  /** Gets the name of the implicit receiver parameter in `callable`, if it has one. */
+  string getImplicitReceiverParameterName(Callable callable) { none() }
 }
 
 /** Holds if `member` is an instance member. */

--- a/unified/ql/lib/codeql/unified/internal/NameBindingPluginSwift.qll
+++ b/unified/ql/lib/codeql/unified/internal/NameBindingPluginSwift.qll
@@ -38,6 +38,12 @@ class NameBindingPluginSwift extends NameBindingPlugin {
     exists(cls) and
     not member.hasModifier("private")
   }
+
+  override string getImplicitReceiverParameterName(Callable callable) {
+    // TODO: field initializers can also reference 'self' but are not currently wrapped in a Callable
+    callable = any(ClassLikeDeclaration cls).getAMember() and
+    result = "self"
+  }
 }
 
 /** Holds if `node` is in a context where a bare name node should be seen as a reference rather than a declaration. */

--- a/unified/ql/lib/codeql/unified/internal/StaticNameBinding.qll
+++ b/unified/ql/lib/codeql/unified/internal/StaticNameBinding.qll
@@ -656,6 +656,11 @@ module Public {
 
     /** Holds if this is an instance access on the accessing class. */
     predicate isInstanceAccess() { instanceAccess = true }
+
+    /** Gets the local variable implicitly referenced as the base of this access. */
+    LocalVariable getImplicitQualifierVariable() {
+      ResolveImplicitReceiverAccess::access(this, result)
+    }
   }
 }
 
@@ -668,3 +673,24 @@ NameBinding getStaticBindingTarget(Identifier access) {
   not access instanceof UnqualifiedMemberAccess and
   trackNameBinding(result).asIdentifier() = access
 }
+
+/**
+ * Gets the name of the implicit receiver parameter in scope at `callable` (possibly declared by an outer callable).
+ *
+ * Note that we only propagate the name, not the LocalVariable, since capture-declarations and Swift's `guard let self` statements
+ * may re-introduce a new binding for `self`, which becomes the one referenced by subsequent unqualified member accesses.
+ */
+private string getEnclosingReceiverParameterName(Callable callable) {
+  result = any(NameBindingPlugin p).getImplicitReceiverParameterName(callable)
+  or
+  not exists(any(NameBindingPlugin p).getImplicitReceiverParameterName(callable)) and
+  result = getEnclosingReceiverParameterName(callable.getEnclosingCallable())
+}
+
+/** Holds if `access` contains a reference to the implicit receiver parameter `name`. */
+private predicate implicitReceiverAccess(AstNode access, string name) {
+  name = getEnclosingReceiverParameterName(access.(UnqualifiedMemberAccess).getEnclosingCallable())
+}
+
+private module ResolveImplicitReceiverAccess =
+  LocalNameBindingOutput::ResolveAccesses<implicitReceiverAccess/2>;

--- a/unified/ql/lib/codeql/unified/internal/StaticNameBinding.qll
+++ b/unified/ql/lib/codeql/unified/internal/StaticNameBinding.qll
@@ -139,7 +139,7 @@ private predicate isPrivateToLocalScope(AstNode binding) {
       member = any(ClassLikeDeclaration cls).getAMember() or
       member = any(TopLevel t).getBody().getAStmt()
     ) and
-    (binding instanceof NameDeclaration or binding instanceof BulkImportingPattern) and
+    (binding instanceof NameBinding or binding instanceof BulkImportingPattern) and
     any(NameBindingPlugin p).isPrivateToLocalScope(member, binding)
   )
 }
@@ -168,7 +168,7 @@ predicate readStep(NameBindingNode node1, string name, NameBindingNode node2) {
   )
   or
   exists(PotentialLocalNameAccess access |
-    not access.isDeclarationSite() and
+    not access.isBindingSite() and
     name = access.getName() and
     node1 = getNodeFromUncertainScope(LocalNameBindingOutput::getAnUncertainScope(access, name)) and
     node2.isIdentifier(access)
@@ -183,7 +183,7 @@ predicate readStep(NameBindingNode node1, string name, NameBindingNode node2) {
 }
 
 predicate storeStep(NameBindingNode node1, string name, NameBindingNode node2) {
-  exists(ClassLikeDeclaration cls, Member member, NameDeclaration nameDecl |
+  exists(ClassLikeDeclaration cls, Member member, NameBinding nameDecl |
     member = cls.getAMember() and
     not isPrivateToLocalScope(nameDecl) and
     nameDecl.getDeclaration() = member and
@@ -194,7 +194,7 @@ predicate storeStep(NameBindingNode node1, string name, NameBindingNode node2) {
     else node2.isStaticMemberNamespace(cls)
   )
   or
-  exists(TopLevel top, Stmt stmt, NameDeclaration nameDecl |
+  exists(TopLevel top, Stmt stmt, NameBinding nameDecl |
     stmt = top.getBody().getAStmt() and
     not isPrivateToLocalScope(nameDecl) and
     nameDecl.getDeclaration() = stmt and
@@ -214,11 +214,11 @@ predicate storeStep(NameBindingNode node1, string name, NameBindingNode node2) {
 
 predicate valueStep(NameBindingNode node1, NameBindingNode node2) {
   exists(PotentialLocalNameAccess access |
-    access.isDeclarationSite() and
+    access.isBindingSite() and
     node1.isIdentifier(access) and
     node2.isLocalName(access.getLocalName())
     or
-    not access.isDeclarationSite() and
+    not access.isBindingSite() and
     node1.isLocalName(access.getLocalName()) and
     node2.isIdentifier(access)
   )
@@ -327,7 +327,7 @@ private predicate derivedStoreReadStep(NameBindingNode node1, NameBindingNode no
 /** Holds if the member represented by `node` can be inherited. */
 pragma[nomagic]
 private predicate isInheritableMemberNode(NameBindingNode node) {
-  exists(NameDeclaration decl |
+  exists(NameBinding decl |
     node.isIdentifier(decl) and
     isInheritableMember(decl.getDeclaration())
   )
@@ -414,29 +414,29 @@ private predicate sameName(Identifier node1, Identifier node2) {
  * will be passed through.
  */
 pragma[nomagic]
-predicate isTrivialNameAlias(NameDeclaration decl) {
+predicate isTrivialNameAlias(NameBinding decl) {
   exists(ImportDeclaration imprt |
     decl = getImportBindingIdentifier(imprt) and
     sameName(decl, getIdentifierFromRef(imprt.getImportedExpr()))
   )
 }
 
-private module TrackNameDeclarationInput implements TrackInputSig {
+private module TrackNameBindingInput implements TrackInputSig {
   predicate shouldTrack(NameBindingNode node) {
-    exists(NameDeclaration decl |
+    exists(NameBinding decl |
       node.isIdentifier(decl) and
       not isTrivialNameAlias(decl)
     )
   }
 }
 
-private module TrackNameDeclaration = Track<TrackNameDeclarationInput>;
+private module TrackNameBinding = Track<TrackNameBindingInput>;
 
 /** Gets a name-binding node that may refer to the given declaration. */
-NameBindingNode trackNameDeclaration(NameDeclaration decl) {
+NameBindingNode trackNameBinding(NameBinding decl) {
   exists(NameBindingNode start |
     start.isIdentifier(decl) and
-    result = TrackNameDeclaration::track(start)
+    result = TrackNameBinding::track(start)
   )
 }
 
@@ -490,7 +490,7 @@ module DebugGraph<relevantNodeSig/1 relevantNode> {
  */
 private module FolderHeuristic {
   private predicate topLevelNameDef(File file, string name, NameBindingNode node) {
-    exists(TopLevel top, Stmt stmt, NameDeclaration nameDecl |
+    exists(TopLevel top, Stmt stmt, NameBinding nameDecl |
       top.getFile() = file and
       stmt = top.getBody().getAStmt() and
       not isPrivateToLocalScope(nameDecl) and
@@ -583,10 +583,10 @@ private module FolderHeuristic {
  * or as a static member.
  */
 private predicate unqualifiedMemberAccessCand(
-  PotentialLocalNameAccess access, boolean instanceAccess, NameDeclaration target,
+  PotentialLocalNameAccess access, boolean instanceAccess, NameBinding target,
   ClassLikeDeclaration accessingClass
 ) {
-  not access instanceof NameDeclaration and
+  not access instanceof NameBinding and
   (
     // Resolved by local scoping
     exists(LocalName local |
@@ -628,7 +628,7 @@ private int unqualifiedMemberAccessDepth(PotentialLocalNameAccess access) {
  * `instanceAccess` indicates if it is an instance member or static member.
  */
 predicate unqualifiedMemberAccess(
-  PotentialLocalNameAccess access, boolean instanceAccess, NameDeclaration target,
+  PotentialLocalNameAccess access, boolean instanceAccess, NameBinding target,
   ClassLikeDeclaration accessingClass
 ) {
   unqualifiedMemberAccessCand(access, instanceAccess, target, accessingClass) and
@@ -640,7 +640,7 @@ predicate unqualifiedMemberAccess(
  */
 class UnqualifiedMemberAccess extends Identifier {
   private boolean instanceAccess;
-  private NameDeclaration target;
+  private NameBinding target;
   private ClassLikeDeclaration accessingClass;
 
   UnqualifiedMemberAccess() {
@@ -648,7 +648,7 @@ class UnqualifiedMemberAccess extends Identifier {
   }
 
   /** Gets the name declaration of the member being accessed. */
-  NameDeclaration getTarget() { result = target }
+  NameBinding getTarget() { result = target }
 
   /** Gets the enclosing class whose (possibly inherited) member is being accessed. */
   ClassLikeDeclaration getAccessingClass() { result = accessingClass }
@@ -658,11 +658,11 @@ class UnqualifiedMemberAccess extends Identifier {
 }
 
 /** Gets the declaration being accessed by `access`, as determined by static name binding. */
-NameDeclaration getStaticBindingTarget(Identifier access) {
+NameBinding getStaticBindingTarget(Identifier access) {
   // For unqualified accesses, use the shadowing-aware lookup
   result = access.(UnqualifiedMemberAccess).getTarget()
   or
   // For others, just follow the name binding graph
   not access instanceof UnqualifiedMemberAccess and
-  trackNameDeclaration(result).asIdentifier() = access
+  trackNameBinding(result).asIdentifier() = access
 }

--- a/unified/ql/lib/codeql/unified/internal/StaticNameBinding.qll
+++ b/unified/ql/lib/codeql/unified/internal/StaticNameBinding.qll
@@ -648,7 +648,7 @@ module Public {
       unqualifiedMemberAccess(this, instanceAccess, target, accessingClass)
     }
 
-    /** Gets the name declaration of the member being accessed. */
+    /** Gets the name binding of the member being accessed. */
     NameBinding getTarget() { result = target }
 
     /** Gets the enclosing class whose (possibly inherited) member is being accessed. */

--- a/unified/ql/lib/codeql/unified/internal/StaticNameBinding.qll
+++ b/unified/ql/lib/codeql/unified/internal/StaticNameBinding.qll
@@ -635,26 +635,28 @@ predicate unqualifiedMemberAccess(
   accessingClass.getDepth() = unqualifiedMemberAccessDepth(access)
 }
 
-/**
- * A name node appearing in an unqualified position, referring to a member of an enclosing class.
- */
-class UnqualifiedMemberAccess extends Identifier {
-  private boolean instanceAccess;
-  private NameBinding target;
-  private ClassLikeDeclaration accessingClass;
+module Public {
+  /**
+   * A name node appearing in an unqualified position, referring to a member of an enclosing class.
+   */
+  class UnqualifiedMemberAccess extends Identifier {
+    private boolean instanceAccess;
+    private NameBinding target;
+    private ClassLikeDeclaration accessingClass;
 
-  UnqualifiedMemberAccess() {
-    unqualifiedMemberAccess(this, instanceAccess, target, accessingClass)
+    UnqualifiedMemberAccess() {
+      unqualifiedMemberAccess(this, instanceAccess, target, accessingClass)
+    }
+
+    /** Gets the name declaration of the member being accessed. */
+    NameBinding getTarget() { result = target }
+
+    /** Gets the enclosing class whose (possibly inherited) member is being accessed. */
+    ClassLikeDeclaration getAccessingClass() { result = accessingClass }
+
+    /** Holds if this is an instance access on the accessing class. */
+    predicate isInstanceAccess() { instanceAccess = true }
   }
-
-  /** Gets the name declaration of the member being accessed. */
-  NameBinding getTarget() { result = target }
-
-  /** Gets the enclosing class whose (possibly inherited) member is being accessed. */
-  ClassLikeDeclaration getAccessingClass() { result = accessingClass }
-
-  /** Holds if this is an instance access on the accessing class. */
-  predicate isInstanceAccess() { instanceAccess = true }
 }
 
 /** Gets the declaration being accessed by `access`, as determined by static name binding. */

--- a/unified/ql/lib/codeql/unified/internal/dev/debugLocalNameBindingGraph.ql
+++ b/unified/ql/lib/codeql/unified/internal/dev/debugLocalNameBindingGraph.ql
@@ -6,7 +6,7 @@
  */
 
 private import unified
-private import codeql.unified.internal.LocalNameBinding
+private import codeql.unified.internal.NameBinding
 
 /**
  * Holds if `node` should be shown in the graph.

--- a/unified/ql/lib/codeql/unified/internal/dev/debugStaticNameBindingGraph.ql
+++ b/unified/ql/lib/codeql/unified/internal/dev/debugStaticNameBindingGraph.ql
@@ -6,7 +6,7 @@
  */
 
 private import unified
-private import codeql.unified.internal.StaticNameBinding
+private import codeql.unified.internal.NameBinding
 
 /**
  * Holds if `node` should be shown in the graph.

--- a/unified/ql/lib/ide-contextual-queries/definitions.ql
+++ b/unified/ql/lib/ide-contextual-queries/definitions.ql
@@ -13,7 +13,7 @@ import unified
 
 external string selectedSourceFile();
 
-from Identifier reference, NameDeclaration definition, string kind
+from Identifier reference, NameBinding definition, string kind
 where
   definitionOf(reference, definition, kind) and
   reference.getLocation().getFile() = getFileBySourceArchiveName(selectedSourceFile())

--- a/unified/ql/lib/unified.qll
+++ b/unified/ql/lib/unified.qll
@@ -7,5 +7,4 @@ import codeql.files.FileSystem
 import codeql.unified.internal.Ast::UnifiedFinal
 import codeql.unified.internal.AstExtra::Public
 import codeql.unified.internal.ControlFlowGraph
-import codeql.unified.internal.LocalNameBinding::Public
-import codeql.unified.internal.StaticNameBinding::Public
+import codeql.unified.internal.NameBinding::Public

--- a/unified/ql/lib/unified.qll
+++ b/unified/ql/lib/unified.qll
@@ -8,3 +8,4 @@ import codeql.unified.internal.Ast::UnifiedFinal
 import codeql.unified.internal.AstExtra::Public
 import codeql.unified.internal.ControlFlowGraph
 import codeql.unified.internal.LocalNameBinding::Public
+import codeql.unified.internal.StaticNameBinding::Public

--- a/unified/ql/lib/utils/test/CommentUtil.qll
+++ b/unified/ql/lib/utils/test/CommentUtil.qll
@@ -12,7 +12,7 @@ predicate plainCommentAt(string filepath, int line, string text) {
 predicate keyValueCommentAt(string filepath, int line, string key, string value) {
   exists(string text, string regexp, string match |
     plainCommentAt(filepath, line, text) and
-    regexp = "(\\w+)=([\\w.0-9]+)" and
+    regexp = "([\\w.-]+)=([\\w.0-9]+)" and
     match = text.regexpFind(regexp, _, _) and
     key = match.regexpCapture(regexp, 1) and
     value = match.regexpCapture(regexp, 2)

--- a/unified/ql/lib/utils/test/TestUtils.qll
+++ b/unified/ql/lib/utils/test/TestUtils.qll
@@ -23,6 +23,7 @@ private predicate declAt(NameBinding v, string filepath, int line) {
   v.getLocation().hasLocationInfo(filepath, line, _, _, _)
 }
 
+/** Holds if the name-binding `v` has been assigned the given `alias` by a comment in the test code. */
 predicate nameBinding(NameBinding v, string alias) {
   exists(string filepath, int line | declAt(v, filepath, line) |
     keyValueCommentAt(filepath, line, "name", alias)

--- a/unified/ql/lib/utils/test/TestUtils.qll
+++ b/unified/ql/lib/utils/test/TestUtils.qll
@@ -3,10 +3,10 @@ private import CommentUtil
 private import codeql.unified.internal.StaticNameBinding
 
 private string deriveClassName(ClassLikeDeclaration cls) {
-  not exists(cls.getParent().getEnclosingClass()) and
+  not exists(cls.getEnclosingClass()) and
   result = cls.getName()
   or
-  result = deriveClassName(cls.getParent().getEnclosingClass()) + "." + cls.getName()
+  result = deriveClassName(cls.getEnclosingClass()) + "." + cls.getName()
 }
 
 private string defaultName(NameDeclaration decl) {

--- a/unified/ql/lib/utils/test/TestUtils.qll
+++ b/unified/ql/lib/utils/test/TestUtils.qll
@@ -1,6 +1,6 @@
 private import unified
 private import CommentUtil
-private import codeql.unified.internal.StaticNameBinding
+private import codeql.unified.internal.NameBinding
 
 private string deriveClassName(ClassLikeDeclaration cls) {
   not exists(cls.getEnclosingClass()) and

--- a/unified/ql/lib/utils/test/TestUtils.qll
+++ b/unified/ql/lib/utils/test/TestUtils.qll
@@ -9,7 +9,7 @@ private string deriveClassName(ClassLikeDeclaration cls) {
   result = deriveClassName(cls.getEnclosingClass()) + "." + cls.getName()
 }
 
-private string defaultName(NameDeclaration decl) {
+private string defaultName(NameBinding decl) {
   exists(ClassLikeDeclaration cls |
     decl.getDeclaration() = cls.getAMember() and
     result = deriveClassName(cls) + "." + decl.getName()
@@ -19,11 +19,11 @@ private string defaultName(NameDeclaration decl) {
   result = decl.getName()
 }
 
-private predicate declAt(NameDeclaration v, string filepath, int line) {
+private predicate declAt(NameBinding v, string filepath, int line) {
   v.getLocation().hasLocationInfo(filepath, line, _, _, _)
 }
 
-predicate nameDeclaration(NameDeclaration v, string alias) {
+predicate nameBinding(NameBinding v, string alias) {
   exists(string filepath, int line | declAt(v, filepath, line) |
     keyValueCommentAt(filepath, line, "name", alias)
     or

--- a/unified/ql/src/diagnostic/FilesCoveredByModuleManifest.ql
+++ b/unified/ql/src/diagnostic/FilesCoveredByModuleManifest.ql
@@ -9,7 +9,7 @@
  */
 
 import unified
-import codeql.unified.internal.StaticNameBinding
+import codeql.unified.internal.NameBinding
 import codeql.unified.internal.NameBindingPlugin
 import codeql.unified.internal.AnalysisQuality
 

--- a/unified/ql/src/diagnostic/StaticNameResolution.ql
+++ b/unified/ql/src/diagnostic/StaticNameResolution.ql
@@ -9,7 +9,7 @@
  */
 
 import unified
-import codeql.unified.internal.StaticNameBinding
+import codeql.unified.internal.NameBinding
 import codeql.unified.internal.AnalysisQuality
 
 from StaticNameResolutionStats::Candidate c, NameBindingNode target

--- a/unified/ql/test/library-tests/definitions/test.ql
+++ b/unified/ql/test/library-tests/definitions/test.ql
@@ -7,11 +7,11 @@ module DefinitionsTest implements TestSig {
   string getARelevantTag() { result = "definition" }
 
   predicate hasActualResult(Location location, string element, string tag, string value) {
-    exists(Identifier reference, NameDeclaration definition |
+    exists(Identifier reference, NameBinding definition |
       definitionOf(reference, definition, "name") and
       location = reference.getLocation() and
       element = reference.toString() and
-      nameDeclaration(definition, value) and
+      nameBinding(definition, value) and
       tag = "definition"
     )
   }

--- a/unified/ql/test/library-tests/local-name-binding/class_scope.swift
+++ b/unified/ql/test/library-tests/local-name-binding/class_scope.swift
@@ -5,8 +5,8 @@ class A {
         let b: B = nil // $ access=A.B
         let c: C = nil // $ access=A.C
     }
-    func instance_before() {
-        print(instanceVar) // $ access=instanceVar
+    func instance_before() { // implicit-self=instance_before.self
+        print(instanceVar) // $ access=instanceVar implicit-qualifier=instance_before.self
         B(); // $ access=A.B
         let b: B = nil // $ access=A.B
         let c: C = nil // $ access=A.C
@@ -25,8 +25,8 @@ class A {
         let c: C = nil // $ access=A.C
 
     }
-    func instance_after() {
-        print(instanceVar) // $ access=instanceVar
+    func instance_after() { // implicit-self=instance_after.self
+        print(instanceVar) // $ access=instanceVar implicit-qualifier=instance_after.self
         B(); // $ access=A.B
         let b: B = nil // $ access=A.B
         let c: C = nil // $ access=A.C

--- a/unified/ql/test/library-tests/local-name-binding/self_access.swift
+++ b/unified/ql/test/library-tests/local-name-binding/self_access.swift
@@ -1,0 +1,33 @@
+class C {
+    func t1() { // implicit-self=t1.self
+        print(self) // $ access=t1.self
+    }
+
+    var instanceField = 123;
+
+    func t2() { // implicit-self=t2.self
+        print(instanceField) // $ access=instanceField implicit-qualifier=t2.self
+    }
+
+    func t3() { // implicit-self=t3.self
+        foo(123) { [self] in // name=closure.self
+            print(self) // $ access=closure.self
+            print(instanceField) // $ access=instanceField implicit-qualifier=closure.self
+        }
+    }
+
+    func t4() { // implicit-self=t4.self
+        foo(123) { [weak self] in // name=weak.self
+            // Here, 'self' is an Option<C> referring to .some(<outer self>) if it
+            // has not been GC'ed yet. Swift does not allow unqualified self access here.
+
+            print(self) // $ access=weak.self
+
+            // Unwrap the 'self' optional to get a strong reference.
+            guard let self else { return } // $ access=weak.self // name=guarded.self
+
+            print(self) // $ access=guarded.self
+            print(instanceField) // $ access=instanceField implicit-qualifier=guarded.self
+        }
+    }
+}

--- a/unified/ql/test/library-tests/local-name-binding/self_access.swift
+++ b/unified/ql/test/library-tests/local-name-binding/self_access.swift
@@ -10,14 +10,14 @@ class C {
     }
 
     func t3() { // implicit-self=t3.self
-        foo(123) { [self] in // name=closure.self
+        foo(123) { [self] in // $ captured=closure.self // name=closure.self
             print(self) // $ access=closure.self
             print(instanceField) // $ access=instanceField implicit-qualifier=closure.self
         }
     }
 
     func t4() { // implicit-self=t4.self
-        foo(123) { [weak self] in // name=weak.self
+        foo(123) { [weak self] in // $ captured=weak.self // name=weak.self
             // Here, 'self' is an Option<C> referring to .some(<outer self>) if it
             // has not been GC'ed yet. Swift does not allow unqualified self access here.
 

--- a/unified/ql/test/library-tests/local-name-binding/test.ql
+++ b/unified/ql/test/library-tests/local-name-binding/test.ql
@@ -1,7 +1,7 @@
 import unified
 import utils.test.InlineExpectationsTest
 import utils.test.CommentUtil
-import codeql.unified.internal.LocalNameBinding
+import codeql.unified.internal.NameBinding
 
 module VariableAccessTest implements TestSig {
   string getARelevantTag() { result = ["access", "implicit-qualifier", "captured"] }

--- a/unified/ql/test/library-tests/local-name-binding/test.ql
+++ b/unified/ql/test/library-tests/local-name-binding/test.ql
@@ -4,7 +4,7 @@ import utils.test.CommentUtil
 import codeql.unified.internal.LocalNameBinding
 
 module VariableAccessTest implements TestSig {
-  string getARelevantTag() { result = ["access", "implicit-qualifier"] }
+  string getARelevantTag() { result = ["access", "implicit-qualifier", "captured"] }
 
   additional predicate declAt(LocalName v, string filepath, int line) {
     v.getLocation().hasLocationInfo(filepath, line, _, _, _)
@@ -50,6 +50,14 @@ module VariableAccessTest implements TestSig {
       decl(v, value) and
       access.isInstanceAccess() and // For now, don't annotate receiver access in static methods. It technically exists, it's just not important yet.
       tag = "implicit-qualifier"
+    )
+    or
+    exists(LocalVariable v |
+      v.isCaptured() and
+      location = v.getLocation() and
+      element = v.toString() and
+      decl(v, value) and
+      tag = "captured"
     )
   }
 }

--- a/unified/ql/test/library-tests/local-name-binding/test.ql
+++ b/unified/ql/test/library-tests/local-name-binding/test.ql
@@ -20,8 +20,7 @@ module VariableAccessTest implements TestSig {
   }
 
   private PotentialLocalNameAccess getUniqueDeclarationSite(LocalName name) {
-    result =
-      unique(PotentialLocalNameAccess ac | ac.isDeclarationSite() and ac.getLocalName() = name)
+    result = unique(PotentialLocalNameAccess ac | ac.isBindingSite() and ac.getLocalName() = name)
   }
 
   predicate hasActualResult(Location location, string element, string tag, string value) {

--- a/unified/ql/test/library-tests/local-name-binding/test.ql
+++ b/unified/ql/test/library-tests/local-name-binding/test.ql
@@ -4,17 +4,27 @@ import utils.test.CommentUtil
 import codeql.unified.internal.LocalNameBinding
 
 module VariableAccessTest implements TestSig {
-  string getARelevantTag() { result = "access" }
+  string getARelevantTag() { result = ["access", "implicit-qualifier"] }
 
   additional predicate declAt(LocalName v, string filepath, int line) {
     v.getLocation().hasLocationInfo(filepath, line, _, _, _)
   }
 
   private predicate decl(LocalName v, string alias) {
-    exists(string filepath, int line | declAt(v, filepath, line) |
-      keyValueCommentAt(filepath, line, "name", alias)
+    exists(string filepath, int line, string tag |
+      declAt(v, filepath, line) and
+      if exists(v.getABinding())
+      then
+        // explicit declarations must be annotated with 'name'
+        tag = "name"
+      else (
+        // implicit declarations have their own tags
+        v.getName() = "self" and tag = "implicit-self"
+      )
+    |
+      keyValueCommentAt(filepath, line, tag, alias)
       or
-      not keyValueCommentAt(filepath, line, "name", _) and
+      not keyValueCommentAt(filepath, line, tag, _) and
       alias = v.getName()
     )
   }
@@ -31,6 +41,15 @@ module VariableAccessTest implements TestSig {
       element = va.toString() and
       decl(v, value) and
       tag = "access"
+    )
+    or
+    exists(UnqualifiedMemberAccess access, LocalName v |
+      v = access.getImplicitQualifierVariable() and
+      location = access.getLocation() and
+      element = access.toString() and
+      decl(v, value) and
+      access.isInstanceAccess() and // For now, don't annotate receiver access in static methods. It technically exists, it's just not important yet.
+      tag = "implicit-qualifier"
     )
   }
 }

--- a/unified/ql/test/library-tests/local-name-binding/test.swift
+++ b/unified/ql/test/library-tests/local-name-binding/test.swift
@@ -135,7 +135,7 @@ func t16() throws {
 
 // Closure captures
 func t17() {
-    let x = 1 // name=x1
+    let x = 1 // $ captured=x1 // name=x1
     let closure = { // name=closure1
         print(x) // $ access=x1
     }
@@ -181,7 +181,7 @@ func t21() {
 // Nested functions
 func t22() {
     let x = 1 // name=x1
-    func inner() { // name=inner1
+    func inner() { // $ captured=inner1 // name=inner1
         let x = 2 // name=x2
         print(x) // $ access=x2
     }

--- a/unified/ql/test/library-tests/static-name-binding/test.ql
+++ b/unified/ql/test/library-tests/static-name-binding/test.ql
@@ -1,7 +1,7 @@
 import unified
 import utils.test.InlineExpectationsTest
 import utils.test.TestUtils
-import codeql.unified.internal.StaticNameBinding
+import codeql.unified.internal.NameBinding
 
 module StaticDeclAccess implements TestSig {
   string getARelevantTag() { result = "access" }

--- a/unified/ql/test/library-tests/static-name-binding/test.ql
+++ b/unified/ql/test/library-tests/static-name-binding/test.ql
@@ -7,12 +7,12 @@ module StaticDeclAccess implements TestSig {
   string getARelevantTag() { result = "access" }
 
   predicate hasActualResult(Location location, string element, string tag, string value) {
-    exists(NameDeclaration decl, Identifier access |
+    exists(NameBinding decl, Identifier access |
       decl = getStaticBindingTarget(access) and
-      not access instanceof NameDeclaration and
+      not access instanceof NameBinding and
       location = access.getLocation() and
       element = access.toString() and
-      nameDeclaration(decl, value) and
+      nameBinding(decl, value) and
       tag = "access"
     )
   }


### PR DESCRIPTION
Expands name binding with:
- `LocalVariable` with many of the usual predicates like `getDeclaringCallable()` and `isCaptured()`.
- `LocalVariableAccess`
- `UnqualifiedMemberAccess.getImplicitQualifierVariable` for getting the `LocalVariable` corresponding to the implicit `self` access.
- Some utilities like `AstNode.getEnclosingCallable()` (moved out from CFG)

### Re-declarations of 'self' in Swift
There is a unique complication for Swift due to `[weak self]` and `guard let self` statements, which re-introduce new variables called `self`. I've decided to just treat `self` as "just another variable" so this doesn't become a weird corner case, but something that "just works" because the extractor inserts the correct variable-declarations:
```swift
let closure = { [weak self] in
  // Here, 'self' is an Option<C> referring to .some(<outer self>) if it
  // has not been GC'ed yet. Swift does not allow unqualified self access here.

  print(self) // Prints "Optional(<stringified self>)"

  // Unwrap the 'self' optional to get a strong reference.
  guard let self else { return }

  print(self) // Prints stringified self
}
```