### PR TITLE
Unified: Resolve `Self` in static name binding

### DIFF
--- a/unified/ql/lib/codeql/unified/internal/LocalNameBinding.qll
+++ b/unified/ql/lib/codeql/unified/internal/LocalNameBinding.qll
@@ -333,6 +333,12 @@ private module LocalNameBindingInput implements LocalNameBindingInputSig<Locatio
       name = any(NameBindingPlugin p).getImplicitReceiverParameterName(callable) and
       scope = callable
     )
+    or
+    exists(ClassLikeDeclaration cls |
+      isLocalVariable = false and
+      name = any(NameBindingPlugin p).getStaticSelfName(cls) and
+      scope = cls
+    )
   }
 
   predicate implicitDeclInScope(string name, AstNode scope) { implicitDeclInScope(name, scope, _) }

--- a/unified/ql/lib/codeql/unified/internal/NameBindingPlugin.qll
+++ b/unified/ql/lib/codeql/unified/internal/NameBindingPlugin.qll
@@ -44,10 +44,11 @@ class NameBindingPlugin extends Unit {
   string getImplicitReceiverParameterName(Callable callable) { none() }
 
   /**
-   * Gets the name through which static members of the enclosing class can be
+   * Gets the name through which static members of the enclosing class `cls` can be
    * accessed, for example `Self` in Swift.
    */
-  string getStaticSelfName() { none() }
+  bindingset[cls]
+  string getStaticSelfName(ClassLikeDeclaration cls) { none() }
 }
 
 /** Holds if `member` is an instance member. */

--- a/unified/ql/lib/codeql/unified/internal/NameBindingPlugin.qll
+++ b/unified/ql/lib/codeql/unified/internal/NameBindingPlugin.qll
@@ -42,6 +42,12 @@ class NameBindingPlugin extends Unit {
 
   /** Gets the name of the implicit receiver parameter in `callable`, if it has one. */
   string getImplicitReceiverParameterName(Callable callable) { none() }
+
+  /**
+   * Gets the name through which static members of the enclosing class can be
+   * accessed, for example `Self` in Swift.
+   */
+  string getStaticSelfName() { none() }
 }
 
 /** Holds if `member` is an instance member. */

--- a/unified/ql/lib/codeql/unified/internal/NameBindingPluginSwift.qll
+++ b/unified/ql/lib/codeql/unified/internal/NameBindingPluginSwift.qll
@@ -44,6 +44,8 @@ class NameBindingPluginSwift extends NameBindingPlugin {
     callable = any(ClassLikeDeclaration cls).getAMember() and
     result = "self"
   }
+
+  override string getStaticSelfName() { result = "Self" }
 }
 
 /** Holds if `node` is in a context where a bare name node should be seen as a reference rather than a declaration. */

--- a/unified/ql/lib/codeql/unified/internal/NameBindingPluginSwift.qll
+++ b/unified/ql/lib/codeql/unified/internal/NameBindingPluginSwift.qll
@@ -45,7 +45,8 @@ class NameBindingPluginSwift extends NameBindingPlugin {
     result = "self"
   }
 
-  override string getStaticSelfName() { result = "Self" }
+  bindingset[cls]
+  override string getStaticSelfName(ClassLikeDeclaration cls) { exists(cls) and result = "Self" }
 }
 
 /** Holds if `node` is in a context where a bare name node should be seen as a reference rather than a declaration. */

--- a/unified/ql/lib/codeql/unified/internal/StaticNameBinding.qll
+++ b/unified/ql/lib/codeql/unified/internal/StaticNameBinding.qll
@@ -210,6 +210,12 @@ predicate storeStep(NameBindingNode node1, string name, NameBindingNode node2) {
   )
   or
   FolderHeuristic::storeStep(node1, name, node2)
+  or
+  exists(ClassLikeDeclaration cls |
+    name = any(NameBindingPlugin p).getStaticSelfName() and
+    node1.isIdentifier(cls.getNameNode()) and
+    node2.isStaticMemberNamespace(cls)
+  )
 }
 
 predicate valueStep(NameBindingNode node1, NameBindingNode node2) {

--- a/unified/ql/lib/codeql/unified/internal/StaticNameBinding.qll
+++ b/unified/ql/lib/codeql/unified/internal/StaticNameBinding.qll
@@ -210,12 +210,6 @@ predicate storeStep(NameBindingNode node1, string name, NameBindingNode node2) {
   )
   or
   FolderHeuristic::storeStep(node1, name, node2)
-  or
-  exists(ClassLikeDeclaration cls |
-    name = any(NameBindingPlugin p).getStaticSelfName() and
-    node1.isIdentifier(cls.getNameNode()) and
-    node2.isStaticMemberNamespace(cls)
-  )
 }
 
 predicate valueStep(NameBindingNode node1, NameBindingNode node2) {
@@ -269,6 +263,12 @@ predicate valueStep(NameBindingNode node1, NameBindingNode node2) {
   )
   or
   FolderHeuristic::valueStep(node1, node2)
+  or
+  exists(ClassLikeDeclaration cls, LocalNameBindingOutput::ImplicitLocal self |
+    node1.isIdentifier(cls.getNameNode()) and
+    node2.isLocalName(self) and
+    self.hasNameAndScope(any(NameBindingPlugin p).getStaticSelfName(cls), cls)
+  )
 }
 
 private predicate isImportPrefix(Expr e) {

--- a/unified/ql/test/library-tests/static-name-binding/explicit-instance-field-access.swift
+++ b/unified/ql/test/library-tests/static-name-binding/explicit-instance-field-access.swift
@@ -8,7 +8,7 @@ private class A {
     static let y = 456 // name=A.type.y
 
     func getY1() {
-        return Self.y // $ MISSING: access=A access=A.type.y
+        return Self.y // $ access=A access=A.type.y
     }
 
     static func getY2() {
@@ -30,7 +30,7 @@ private class B : A { // $ access=A
     }
 
     func getY3() {
-        return Self.y // $ MISSING: access=B access=A.type.y
+        return Self.y // $ access=B access=A.type.y
     }
 
     static func getY4() {

--- a/unified/ql/test/library-tests/static-name-binding/explicit-instance-field-access.swift
+++ b/unified/ql/test/library-tests/static-name-binding/explicit-instance-field-access.swift
@@ -50,6 +50,6 @@ private class C {
     static let x = 1
     class D {
         static let x = 2
-        static let foo = Self.x // $ access=C.D access=C.D.x $ SPURIOUS: access=C.x
+        static let foo = Self.x // $ access=C.D access=C.D.x
     }
 }

--- a/unified/ql/test/library-tests/static-name-binding/explicit-instance-field-access.swift
+++ b/unified/ql/test/library-tests/static-name-binding/explicit-instance-field-access.swift
@@ -1,0 +1,47 @@
+private class A {
+    let x = 123 // name=A.instance.x
+
+    func getX() {
+        return self.x // not handled by static name binding
+    }
+
+    static let y = 456 // name=A.type.y
+
+    func getY1() {
+        return Self.y // $ MISSING: access=A access=A.type.y
+    }
+
+    static func getY2() {
+        return self.y // $ not handled by static name binding
+    }
+
+    class func z() -> Int { // name=A.type.z
+        return 789
+    }
+
+    class func getZ() {
+        return self.z // $ not handled by static name binding
+    }
+}
+
+private class B : A { // $ access=A
+    func getX2() {
+        return self.x // not handled by static name binding
+    }
+
+    func getY3() {
+        return Self.y // $ MISSING: access=B access=A.type.y
+    }
+
+    static func getY4() {
+        return self.y // $ not handled by static name binding
+    }
+
+    class func z() -> Int { // name=B.type.z
+        return 789
+    }
+
+    class func getZ2() {
+        return self.z // $ not handled by static name binding
+    }
+}

--- a/unified/ql/test/library-tests/static-name-binding/explicit-instance-field-access.swift
+++ b/unified/ql/test/library-tests/static-name-binding/explicit-instance-field-access.swift
@@ -45,3 +45,11 @@ private class B : A { // $ access=A
         return self.z // $ not handled by static name binding
     }
 }
+
+private class C {
+    static let x = 1
+    class D {
+        static let x = 2
+        static let foo = Self.x // $ access=C.D access=C.D.x $ SPURIOUS: access=C.x
+    }
+}


### PR DESCRIPTION
[DCA](https://github.com/github/codeql-dca-main/issues/39160) confirms a small improvement in number of resolved names.